### PR TITLE
fix(desktop): 避免消息全文索引维护全表扫描

### DIFF
--- a/apps/desktop/drizzle/0096_stabilize_messages_fts_rows.sql
+++ b/apps/desktop/drizzle/0096_stabilize_messages_fts_rows.sql
@@ -1,0 +1,6 @@
+CREATE TABLE IF NOT EXISTS `messages_fts_rows` (
+	`fts_rowid` integer PRIMARY KEY AUTOINCREMENT NOT NULL,
+	`message_id` text NOT NULL
+);
+--> statement-breakpoint
+CREATE UNIQUE INDEX IF NOT EXISTS `messages_fts_rows_message_id_idx` ON `messages_fts_rows` (`message_id`);

--- a/apps/desktop/drizzle/meta/0096_snapshot.json
+++ b/apps/desktop/drizzle/meta/0096_snapshot.json
@@ -1,0 +1,4417 @@
+{
+  "version": "6",
+  "dialect": "sqlite",
+  "id": "0301f553-95d2-4bd4-a120-d131780848c7",
+  "prevId": "90063e36-1470-45d3-84d6-4bb6139dd4a5",
+  "tables": {
+    "account_usage_snapshots": {
+      "name": "account_usage_snapshots",
+      "columns": {
+        "agent_kind": {
+          "name": "agent_kind",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "snapshot": {
+          "name": "snapshot",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "agent_input_queue_snapshots": {
+      "name": "agent_input_queue_snapshots",
+      "columns": {
+        "session_id": {
+          "name": "session_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "payload": {
+          "name": "payload",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "agent_input_queue_snapshots_session_id_sessions_id_fk": {
+          "name": "agent_input_queue_snapshots_session_id_sessions_id_fk",
+          "tableFrom": "agent_input_queue_snapshots",
+          "tableTo": "sessions",
+          "columnsFrom": [
+            "session_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "custom_mcp_servers": {
+      "name": "custom_mcp_servers",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "transport": {
+          "name": "transport",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "url": {
+          "name": "url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "headers": {
+          "name": "headers",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'{}'"
+        },
+        "sort_order": {
+          "name": "sort_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "idx_custom_mcp_servers_sort_order": {
+          "name": "idx_custom_mcp_servers_sort_order",
+          "columns": [
+            "sort_order"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "custom_providers": {
+      "name": "custom_providers",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "runtimes": {
+          "name": "runtimes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'{}'"
+        },
+        "auth": {
+          "name": "auth",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "sort_order": {
+          "name": "sort_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "idx_custom_providers_sort_order": {
+          "name": "idx_custom_providers_sort_order",
+          "columns": [
+            "sort_order"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "daily_model_usage": {
+      "name": "daily_model_usage",
+      "columns": {
+        "day": {
+          "name": "day",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "agent_kind": {
+          "name": "agent_kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "model": {
+          "name": "model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "cost_usd": {
+          "name": "cost_usd",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "cost_amount": {
+          "name": "cost_amount",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "cost_currency": {
+          "name": "cost_currency",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'USD'"
+        },
+        "cost_is_approximate": {
+          "name": "cost_is_approximate",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "input_tokens": {
+          "name": "input_tokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "output_tokens": {
+          "name": "output_tokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "cache_read_tokens": {
+          "name": "cache_read_tokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "cache_create_tokens": {
+          "name": "cache_create_tokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "daily_model_usage_day_agent_kind_model_cost_currency_pk": {
+          "columns": [
+            "day",
+            "agent_kind",
+            "model",
+            "cost_currency"
+          ],
+          "name": "daily_model_usage_day_agent_kind_model_cost_currency_pk"
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "daily_spend": {
+      "name": "daily_spend",
+      "columns": {
+        "day": {
+          "name": "day",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "cost_usd": {
+          "name": "cost_usd",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "cost_amount": {
+          "name": "cost_amount",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "cost_currency": {
+          "name": "cost_currency",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'USD'"
+        },
+        "cost_is_approximate": {
+          "name": "cost_is_approximate",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "daily_spend_day_cost_currency_pk": {
+          "columns": [
+            "day",
+            "cost_currency"
+          ],
+          "name": "daily_spend_day_cost_currency_pk"
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "device_link_ownership": {
+      "name": "device_link_ownership",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "owner_id": {
+          "name": "owner_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "owner_pid": {
+          "name": "owner_pid",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "owner_label": {
+          "name": "owner_label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "heartbeat_at": {
+          "name": "heartbeat_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "embedding_jobs": {
+      "name": "embedding_jobs",
+      "columns": {
+        "rowid": {
+          "name": "rowid",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "source": {
+          "name": "source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "source_id": {
+          "name": "source_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "chunk_index": {
+          "name": "chunk_index",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "model_id": {
+          "name": "model_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "vec_table": {
+          "name": "vec_table",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'pending'"
+        },
+        "attempts": {
+          "name": "attempts",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "last_error": {
+          "name": "last_error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "scheduled_at": {
+          "name": "scheduled_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "locked_at": {
+          "name": "locked_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "uniq_embedding_jobs_natural": {
+          "name": "uniq_embedding_jobs_natural",
+          "columns": [
+            "source",
+            "source_id",
+            "chunk_index",
+            "model_id"
+          ],
+          "isUnique": true
+        },
+        "idx_embedding_jobs_status_scheduled": {
+          "name": "idx_embedding_jobs_status_scheduled",
+          "columns": [
+            "status",
+            "scheduled_at"
+          ],
+          "isUnique": false
+        },
+        "idx_embedding_jobs_source_id": {
+          "name": "idx_embedding_jobs_source_id",
+          "columns": [
+            "source",
+            "source_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "embedding_meta": {
+      "name": "embedding_meta",
+      "columns": {
+        "key": {
+          "name": "key",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "ghost_cards": {
+      "name": "ghost_cards",
+      "columns": {
+        "call_id": {
+          "name": "call_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "ghost_id": {
+          "name": "ghost_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "session_id": {
+          "name": "session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "html": {
+          "name": "html",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "height": {
+          "name": "height",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "v": {
+          "name": "v",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 1
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "ghost_cards_updated_at_idx": {
+          "name": "ghost_cards_updated_at_idx",
+          "columns": [
+            "updated_at"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "hook_group_context_cursors": {
+      "name": "hook_group_context_cursors",
+      "columns": {
+        "provider": {
+          "name": "provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "cursor_key": {
+          "name": "cursor_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "cursor_id": {
+          "name": "cursor_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "hook_group_context_cursors_updated_at_idx": {
+          "name": "hook_group_context_cursors_updated_at_idx",
+          "columns": [
+            "updated_at"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "hook_group_context_cursors_provider_cursor_key_pk": {
+          "columns": [
+            "provider",
+            "cursor_key"
+          ],
+          "name": "hook_group_context_cursors_provider_cursor_key_pk"
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "hook_group_message_stats": {
+      "name": "hook_group_message_stats",
+      "columns": {
+        "provider": {
+          "name": "provider",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "row_count": {
+          "name": "row_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "text_bytes": {
+          "name": "text_bytes",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "hook_group_messages": {
+      "name": "hook_group_messages",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "provider": {
+          "name": "provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "chat_id": {
+          "name": "chat_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "thread_id": {
+          "name": "thread_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "message_id": {
+          "name": "message_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "chat_name": {
+          "name": "chat_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "author": {
+          "name": "author",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "is_bot": {
+          "name": "is_bot",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "text": {
+          "name": "text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "file_names": {
+          "name": "file_names",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "sent_at": {
+          "name": "sent_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "hook_group_messages_msg_idx": {
+          "name": "hook_group_messages_msg_idx",
+          "columns": [
+            "provider",
+            "chat_id",
+            "thread_id",
+            "message_id"
+          ],
+          "isUnique": true
+        },
+        "hook_group_messages_window_idx": {
+          "name": "hook_group_messages_window_idx",
+          "columns": [
+            "provider",
+            "chat_id",
+            "thread_id",
+            "id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "im_bindings": {
+      "name": "im_bindings",
+      "columns": {
+        "channel": {
+          "name": "channel",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "bot_context_id": {
+          "name": "bot_context_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "scope_key": {
+          "name": "scope_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "target_session_id": {
+          "name": "target_session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "attached_at": {
+          "name": "attached_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "attached_via_card_message_id": {
+          "name": "attached_via_card_message_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "idx_im_bindings_target": {
+          "name": "idx_im_bindings_target",
+          "columns": [
+            "target_session_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "im_bindings_target_session_id_sessions_id_fk": {
+          "name": "im_bindings_target_session_id_sessions_id_fk",
+          "tableFrom": "im_bindings",
+          "tableTo": "sessions",
+          "columnsFrom": [
+            "target_session_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "im_bindings_channel_bot_context_id_user_id_scope_key_pk": {
+          "columns": [
+            "channel",
+            "bot_context_id",
+            "user_id",
+            "scope_key"
+          ],
+          "name": "im_bindings_channel_bot_context_id_user_id_scope_key_pk"
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "media_blobs": {
+      "name": "media_blobs",
+      "columns": {
+        "hash": {
+          "name": "hash",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "ext": {
+          "name": "ext",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "mime_type": {
+          "name": "mime_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "bytes": {
+          "name": "bytes",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "is_cache": {
+          "name": "is_cache",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "last_access_at": {
+          "name": "last_access_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "media_invocations": {
+      "name": "media_invocations",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "owner": {
+          "name": "owner",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "model_id": {
+          "name": "model_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "capability": {
+          "name": "capability",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "guide_revision": {
+          "name": "guide_revision",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "guide_json": {
+          "name": "guide_json",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "state": {
+          "name": "state",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "task_id": {
+          "name": "task_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "response_json": {
+          "name": "response_json",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "media_invocations_owner_created_at_idx": {
+          "name": "media_invocations_owner_created_at_idx",
+          "columns": [
+            "owner",
+            "created_at"
+          ],
+          "isUnique": false
+        },
+        "media_invocations_owner_state_idx": {
+          "name": "media_invocations_owner_state_idx",
+          "columns": [
+            "owner",
+            "state"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "media_refs": {
+      "name": "media_refs",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "hash": {
+          "name": "hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "ref_kind": {
+          "name": "ref_kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "ref_id": {
+          "name": "ref_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "origin_session_id": {
+          "name": "origin_session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "origin_kind": {
+          "name": "origin_kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "origin_id": {
+          "name": "origin_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "label": {
+          "name": "label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "media_refs_hash_idx": {
+          "name": "media_refs_hash_idx",
+          "columns": [
+            "hash"
+          ],
+          "isUnique": false
+        },
+        "media_refs_ref_idx": {
+          "name": "media_refs_ref_idx",
+          "columns": [
+            "ref_kind",
+            "ref_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "media_refs_hash_media_blobs_hash_fk": {
+          "name": "media_refs_hash_media_blobs_hash_fk",
+          "tableFrom": "media_refs",
+          "tableTo": "media_blobs",
+          "columnsFrom": [
+            "hash"
+          ],
+          "columnsTo": [
+            "hash"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "messages": {
+      "name": "messages",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "client_id": {
+          "name": "client_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "session_id": {
+          "name": "session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "tool_use_id": {
+          "name": "tool_use_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "agent_meta": {
+          "name": "agent_meta",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "agent_kind": {
+          "name": "agent_kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "rewind_at": {
+          "name": "rewind_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "uniq_messages_session_client": {
+          "name": "uniq_messages_session_client",
+          "columns": [
+            "session_id",
+            "client_id"
+          ],
+          "isUnique": true
+        },
+        "idx_messages_session_created": {
+          "name": "idx_messages_session_created",
+          "columns": [
+            "session_id",
+            "created_at"
+          ],
+          "isUnique": false
+        },
+        "idx_messages_created_at": {
+          "name": "idx_messages_created_at",
+          "columns": [
+            "created_at",
+            "id"
+          ],
+          "isUnique": false
+        },
+        "idx_messages_rewind_at": {
+          "name": "idx_messages_rewind_at",
+          "columns": [
+            "rewind_at"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "messages_session_id_sessions_id_fk": {
+          "name": "messages_session_id_sessions_id_fk",
+          "tableFrom": "messages",
+          "tableTo": "sessions",
+          "columnsFrom": [
+            "session_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "messages_fts_rows": {
+      "name": "messages_fts_rows",
+      "columns": {
+        "fts_rowid": {
+          "name": "fts_rowid",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "message_id": {
+          "name": "message_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "messages_fts_rows_message_id_idx": {
+          "name": "messages_fts_rows_message_id_idx",
+          "columns": [
+            "message_id"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "migration_history": {
+      "name": "migration_history",
+      "columns": {
+        "seq": {
+          "name": "seq",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "file_name": {
+          "name": "file_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "content_hash": {
+          "name": "content_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "applied_at": {
+          "name": "applied_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "migration_meta": {
+      "name": "migration_meta",
+      "columns": {
+        "key": {
+          "name": "key",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "orca_teams": {
+      "name": "orca_teams",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "lead_session_id": {
+          "name": "lead_session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'active'"
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "uniq_active_team_per_lead": {
+          "name": "uniq_active_team_per_lead",
+          "columns": [
+            "lead_session_id"
+          ],
+          "isUnique": true,
+          "where": "\"orca_teams\".\"status\" = 'active'"
+        },
+        "idx_orca_teams_status": {
+          "name": "idx_orca_teams_status",
+          "columns": [
+            "status"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "orca_teams_lead_session_id_sessions_id_fk": {
+          "name": "orca_teams_lead_session_id_sessions_id_fk",
+          "tableFrom": "orca_teams",
+          "tableTo": "sessions",
+          "columnsFrom": [
+            "lead_session_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "orca_worker_creation_reservations": {
+      "name": "orca_worker_creation_reservations",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "team_id": {
+          "name": "team_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "label": {
+          "name": "label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "uniq_orca_worker_creation_reservations_team_label": {
+          "name": "uniq_orca_worker_creation_reservations_team_label",
+          "columns": [
+            "team_id",
+            "lower(\"label\")"
+          ],
+          "isUnique": true
+        },
+        "idx_orca_worker_creation_reservations_expires_at": {
+          "name": "idx_orca_worker_creation_reservations_expires_at",
+          "columns": [
+            "expires_at"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "orca_worker_creation_reservations_team_id_orca_teams_id_fk": {
+          "name": "orca_worker_creation_reservations_team_id_orca_teams_id_fk",
+          "tableFrom": "orca_worker_creation_reservations",
+          "tableTo": "orca_teams",
+          "columnsFrom": [
+            "team_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "orca_workers": {
+      "name": "orca_workers",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "team_id": {
+          "name": "team_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "session_id": {
+          "name": "session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'idle'"
+        },
+        "label": {
+          "name": "label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "worktree_branch": {
+          "name": "worktree_branch",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'developer'"
+        },
+        "focused": {
+          "name": "focused",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "idle_since": {
+          "name": "idle_since",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "uniq_orca_workers_session_id": {
+          "name": "uniq_orca_workers_session_id",
+          "columns": [
+            "session_id"
+          ],
+          "isUnique": true
+        },
+        "uniq_orca_workers_team_label": {
+          "name": "uniq_orca_workers_team_label",
+          "columns": [
+            "team_id",
+            "lower(\"label\")"
+          ],
+          "isUnique": true
+        },
+        "uniq_orca_workers_focused_per_team": {
+          "name": "uniq_orca_workers_focused_per_team",
+          "columns": [
+            "team_id"
+          ],
+          "isUnique": true,
+          "where": "\"orca_workers\".\"focused\" = true"
+        },
+        "idx_orca_workers_team_id": {
+          "name": "idx_orca_workers_team_id",
+          "columns": [
+            "team_id"
+          ],
+          "isUnique": false
+        },
+        "idx_orca_workers_status": {
+          "name": "idx_orca_workers_status",
+          "columns": [
+            "status"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "orca_workers_team_id_orca_teams_id_fk": {
+          "name": "orca_workers_team_id_orca_teams_id_fk",
+          "tableFrom": "orca_workers",
+          "tableTo": "orca_teams",
+          "columnsFrom": [
+            "team_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "orca_workers_session_id_sessions_id_fk": {
+          "name": "orca_workers_session_id_sessions_id_fk",
+          "tableFrom": "orca_workers",
+          "tableTo": "sessions",
+          "columnsFrom": [
+            "session_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "project_aliases": {
+      "name": "project_aliases",
+      "columns": {
+        "project_key": {
+          "name": "project_key",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "alias": {
+          "name": "alias",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "idx_project_aliases_updated_at": {
+          "name": "idx_project_aliases_updated_at",
+          "columns": [
+            "updated_at"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "project_automation_consents": {
+      "name": "project_automation_consents",
+      "columns": {
+        "working_dir": {
+          "name": "working_dir",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "consented_at": {
+          "name": "consented_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "config_hash": {
+          "name": "config_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "recent_workdirs": {
+      "name": "recent_workdirs",
+      "columns": {
+        "path": {
+          "name": "path",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "last_used_at": {
+          "name": "last_used_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "idx_recent_workdirs_last_used_at": {
+          "name": "idx_recent_workdirs_last_used_at",
+          "columns": [
+            "last_used_at"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "right_sidebar_tabs": {
+      "name": "right_sidebar_tabs",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "session_id": {
+          "name": "session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "kind": {
+          "name": "kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "position": {
+          "name": "position",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "is_active": {
+          "name": "is_active",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "state": {
+          "name": "state",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'{}'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "right_sidebar_tabs_session_idx": {
+          "name": "right_sidebar_tabs_session_idx",
+          "columns": [
+            "session_id",
+            "position"
+          ],
+          "isUnique": false
+        },
+        "right_sidebar_tabs_subagents_singleton_idx": {
+          "name": "right_sidebar_tabs_subagents_singleton_idx",
+          "columns": [
+            "session_id"
+          ],
+          "isUnique": true,
+          "where": "\"right_sidebar_tabs\".\"kind\" = 'subagents'"
+        }
+      },
+      "foreignKeys": {
+        "right_sidebar_tabs_session_id_sessions_id_fk": {
+          "name": "right_sidebar_tabs_session_id_sessions_id_fk",
+          "tableFrom": "right_sidebar_tabs",
+          "tableTo": "sessions",
+          "columnsFrom": [
+            "session_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "schedule_runs": {
+      "name": "schedule_runs",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "schedule_id": {
+          "name": "schedule_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "session_id": {
+          "name": "session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "fired_at": {
+          "name": "fired_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "finished_at": {
+          "name": "finished_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "error_msg": {
+          "name": "error_msg",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "cost_usd": {
+          "name": "cost_usd",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "estimated_value_usd": {
+          "name": "estimated_value_usd",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "cost_amount": {
+          "name": "cost_amount",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "estimated_value_amount": {
+          "name": "estimated_value_amount",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "cost_currency": {
+          "name": "cost_currency",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "cost_is_approximate": {
+          "name": "cost_is_approximate",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "cost_attribution": {
+          "name": "cost_attribution",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'legacy'"
+        },
+        "result_text": {
+          "name": "result_text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "pre_run_hook_result": {
+          "name": "pre_run_hook_result",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "read_at": {
+          "name": "read_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "heartbeat_at": {
+          "name": "heartbeat_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "idx_schedule_runs_schedule": {
+          "name": "idx_schedule_runs_schedule",
+          "columns": [
+            "schedule_id",
+            "fired_at"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "schedule_runs_schedule_id_schedules_id_fk": {
+          "name": "schedule_runs_schedule_id_schedules_id_fk",
+          "tableFrom": "schedule_runs",
+          "tableTo": "schedules",
+          "columnsFrom": [
+            "schedule_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "schedule_runs_session_id_sessions_id_fk": {
+          "name": "schedule_runs_session_id_sessions_id_fk",
+          "tableFrom": "schedule_runs",
+          "tableTo": "sessions",
+          "columnsFrom": [
+            "session_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "schedules": {
+      "name": "schedules",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "prompt": {
+          "name": "prompt",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "job_type": {
+          "name": "job_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'prompt'"
+        },
+        "job_config": {
+          "name": "job_config",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "execution_mode": {
+          "name": "execution_mode",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'agent'"
+        },
+        "script_config": {
+          "name": "script_config",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "source": {
+          "name": "source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "'user'"
+        },
+        "project_config_id": {
+          "name": "project_config_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "legacy_session_fallback": {
+          "name": "legacy_session_fallback",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "kind": {
+          "name": "kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'cron'"
+        },
+        "cron_expr": {
+          "name": "cron_expr",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "timezone": {
+          "name": "timezone",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "recurring": {
+          "name": "recurring",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": true
+        },
+        "manual": {
+          "name": "manual",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "interval_ms": {
+          "name": "interval_ms",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "agent_kind": {
+          "name": "agent_kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "model": {
+          "name": "model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "provider_id": {
+          "name": "provider_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "effort": {
+          "name": "effort",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "fast_mode": {
+          "name": "fast_mode",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "working_dir": {
+          "name": "working_dir",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "workspace_kind": {
+          "name": "workspace_kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'project'"
+        },
+        "use_worktree": {
+          "name": "use_worktree",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "target_session_id": {
+          "name": "target_session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "persistent_session": {
+          "name": "persistent_session",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "silent_when_idle": {
+          "name": "silent_when_idle",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "pre_run_hook_command": {
+          "name": "pre_run_hook_command",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "pre_run_hook_timeout_ms": {
+          "name": "pre_run_hook_timeout_ms",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "skip_log_session_id": {
+          "name": "skip_log_session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "notify_desktop": {
+          "name": "notify_desktop",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": true
+        },
+        "notify_feishu": {
+          "name": "notify_feishu",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "notify_wecom_group": {
+          "name": "notify_wecom_group",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'active'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "last_fired_at": {
+          "name": "last_fired_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "last_finished_at": {
+          "name": "last_finished_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "next_fire_at": {
+          "name": "next_fire_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "expire_at": {
+          "name": "expire_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "idx_schedules_active_next": {
+          "name": "idx_schedules_active_next",
+          "columns": [
+            "status",
+            "next_fire_at"
+          ],
+          "isUnique": false
+        },
+        "idx_schedules_target_session": {
+          "name": "idx_schedules_target_session",
+          "columns": [
+            "target_session_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "schedules_target_session_id_sessions_id_fk": {
+          "name": "schedules_target_session_id_sessions_id_fk",
+          "tableFrom": "schedules",
+          "tableTo": "sessions",
+          "columnsFrom": [
+            "target_session_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "schedules_skip_log_session_id_sessions_id_fk": {
+          "name": "schedules_skip_log_session_id_sessions_id_fk",
+          "tableFrom": "schedules",
+          "tableTo": "sessions",
+          "columnsFrom": [
+            "skip_log_session_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "session_goals": {
+      "name": "session_goals",
+      "columns": {
+        "session_id": {
+          "name": "session_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "objective": {
+          "name": "objective",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'active'"
+        },
+        "budget_tokens": {
+          "name": "budget_tokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "max_turns": {
+          "name": "max_turns",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "no_progress_limit": {
+          "name": "no_progress_limit",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "turns_used": {
+          "name": "turns_used",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "tokens_used": {
+          "name": "tokens_used",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "no_progress_streak": {
+          "name": "no_progress_streak",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "usage_reset_at": {
+          "name": "usage_reset_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "last_reason": {
+          "name": "last_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "agent_kind": {
+          "name": "agent_kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "idx_session_goals_status": {
+          "name": "idx_session_goals_status",
+          "columns": [
+            "status"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "session_goals_session_id_sessions_id_fk": {
+          "name": "session_goals_session_id_sessions_id_fk",
+          "tableFrom": "session_goals",
+          "tableTo": "sessions",
+          "columnsFrom": [
+            "session_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "session_pr_refs": {
+      "name": "session_pr_refs",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "session_id": {
+          "name": "session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "owner": {
+          "name": "owner",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "repo": {
+          "name": "repo",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "pr_number": {
+          "name": "pr_number",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "url": {
+          "name": "url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "first_seen_at": {
+          "name": "first_seen_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "last_seen_at": {
+          "name": "last_seen_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "uniq_session_pr_refs": {
+          "name": "uniq_session_pr_refs",
+          "columns": [
+            "session_id",
+            "owner",
+            "repo",
+            "pr_number"
+          ],
+          "isUnique": true
+        },
+        "idx_session_pr_refs_session_last_seen": {
+          "name": "idx_session_pr_refs_session_last_seen",
+          "columns": [
+            "session_id",
+            "last_seen_at"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "session_pr_refs_session_id_sessions_id_fk": {
+          "name": "session_pr_refs_session_id_sessions_id_fk",
+          "tableFrom": "session_pr_refs",
+          "tableTo": "sessions",
+          "columnsFrom": [
+            "session_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "sessions": {
+      "name": "sessions",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'New Maker'"
+        },
+        "working_dir": {
+          "name": "working_dir",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "workspace_kind": {
+          "name": "workspace_kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'project'"
+        },
+        "model": {
+          "name": "model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'claude-sonnet-4-6'"
+        },
+        "effort": {
+          "name": "effort",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'high'"
+        },
+        "permission_mode": {
+          "name": "permission_mode",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'ask'"
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'active'"
+        },
+        "sdk_session_id": {
+          "name": "sdk_session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "total_token_usage": {
+          "name": "total_token_usage",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "total_cost_usd": {
+          "name": "total_cost_usd",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "total_cost_amount": {
+          "name": "total_cost_amount",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "total_cost_currency": {
+          "name": "total_cost_currency",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "total_cost_is_approximate": {
+          "name": "total_cost_is_approximate",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "context_tokens": {
+          "name": "context_tokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "context_window": {
+          "name": "context_window",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "fast_mode": {
+          "name": "fast_mode",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "plan_mode_enabled": {
+          "name": "plan_mode_enabled",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "cleared_at": {
+          "name": "cleared_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "pinned_at": {
+          "name": "pinned_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "summary": {
+          "name": "summary",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "provider_id": {
+          "name": "provider_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "user_send_at": {
+          "name": "user_send_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "agent_kind": {
+          "name": "agent_kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'cc'"
+        },
+        "orca_role": {
+          "name": "orca_role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "parent_session_id": {
+          "name": "parent_session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "forked_at_message_id": {
+          "name": "forked_at_message_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "worktree_path": {
+          "name": "worktree_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "source": {
+          "name": "source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'desktop'"
+        },
+        "feishu_open_id": {
+          "name": "feishu_open_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "feishu_bot_app_id": {
+          "name": "feishu_bot_app_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "im_bot_context_id": {
+          "name": "im_bot_context_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "im_user_id": {
+          "name": "im_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "used_project_context": {
+          "name": "used_project_context",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "codex_history_has_product_prompt": {
+          "name": "codex_history_has_product_prompt",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "codex_plan_json": {
+          "name": "codex_plan_json",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "extra_dirs": {
+          "name": "extra_dirs",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'[]'"
+        },
+        "remote_host_id": {
+          "name": "remote_host_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "active_turn_started_at": {
+          "name": "active_turn_started_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "active_turn_pid": {
+          "name": "active_turn_pid",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "last_turn_ended_at": {
+          "name": "last_turn_ended_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "idx_sessions_updated_at": {
+          "name": "idx_sessions_updated_at",
+          "columns": [
+            "updated_at"
+          ],
+          "isUnique": false
+        },
+        "idx_sessions_user_send_at": {
+          "name": "idx_sessions_user_send_at",
+          "columns": [
+            "user_send_at"
+          ],
+          "isUnique": false
+        },
+        "idx_sessions_sdk_session_id": {
+          "name": "idx_sessions_sdk_session_id",
+          "columns": [
+            "sdk_session_id"
+          ],
+          "isUnique": false
+        },
+        "idx_sessions_workdir_created": {
+          "name": "idx_sessions_workdir_created",
+          "columns": [
+            "working_dir",
+            "created_at",
+            "id"
+          ],
+          "isUnique": false
+        },
+        "idx_sessions_created_at": {
+          "name": "idx_sessions_created_at",
+          "columns": [
+            "created_at",
+            "id"
+          ],
+          "isUnique": false
+        },
+        "idx_sessions_workspace_kind": {
+          "name": "idx_sessions_workspace_kind",
+          "columns": [
+            "workspace_kind"
+          ],
+          "isUnique": false
+        },
+        "idx_sessions_parent_session_id": {
+          "name": "idx_sessions_parent_session_id",
+          "columns": [
+            "parent_session_id"
+          ],
+          "isUnique": false
+        },
+        "idx_sessions_orca_role": {
+          "name": "idx_sessions_orca_role",
+          "columns": [
+            "orca_role"
+          ],
+          "isUnique": false
+        },
+        "idx_sessions_worktree_path": {
+          "name": "idx_sessions_worktree_path",
+          "columns": [
+            "worktree_path"
+          ],
+          "isUnique": false
+        },
+        "idx_sessions_feishu_lookup": {
+          "name": "idx_sessions_feishu_lookup",
+          "columns": [
+            "source",
+            "feishu_bot_app_id",
+            "feishu_open_id"
+          ],
+          "isUnique": false
+        },
+        "idx_sessions_im_lookup": {
+          "name": "idx_sessions_im_lookup",
+          "columns": [
+            "source",
+            "im_bot_context_id",
+            "im_user_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "sessions_parent_session_id_sessions_id_fk": {
+          "name": "sessions_parent_session_id_sessions_id_fk",
+          "tableFrom": "sessions",
+          "tableTo": "sessions",
+          "columnsFrom": [
+            "parent_session_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "skill_usage_exposures": {
+      "name": "skill_usage_exposures",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "analyzer_version": {
+          "name": "analyzer_version",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'6'"
+        },
+        "raw_file_path": {
+          "name": "raw_file_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "raw_line_no": {
+          "name": "raw_line_no",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "session_id": {
+          "name": "session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "sdk_session_id": {
+          "name": "sdk_session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "agent_kind": {
+          "name": "agent_kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "skill_name": {
+          "name": "skill_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "skill_path": {
+          "name": "skill_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "skill_document_hash": {
+          "name": "skill_document_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "exposure_content_hash": {
+          "name": "exposure_content_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "document_hash_source": {
+          "name": "document_hash_source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "source": {
+          "name": "source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "tool_use_id": {
+          "name": "tool_use_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "seen_at": {
+          "name": "seen_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "tool_call_count": {
+          "name": "tool_call_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "repeated_tool_call_count": {
+          "name": "repeated_tool_call_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "tool_error_count": {
+          "name": "tool_error_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "command_call_count": {
+          "name": "command_call_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "command_failure_count": {
+          "name": "command_failure_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        }
+      },
+      "indexes": {
+        "idx_skill_usage_exposures_skill_document_version": {
+          "name": "idx_skill_usage_exposures_skill_document_version",
+          "columns": [
+            "analyzer_version",
+            "skill_name",
+            "skill_document_hash"
+          ],
+          "isUnique": false
+        },
+        "idx_skill_usage_exposures_session": {
+          "name": "idx_skill_usage_exposures_session",
+          "columns": [
+            "session_id"
+          ],
+          "isUnique": false
+        },
+        "idx_skill_usage_exposures_raw_file": {
+          "name": "idx_skill_usage_exposures_raw_file",
+          "columns": [
+            "raw_file_path"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "skill_usage_exposures_raw_file_path_skill_usage_sources_raw_file_path_fk": {
+          "name": "skill_usage_exposures_raw_file_path_skill_usage_sources_raw_file_path_fk",
+          "tableFrom": "skill_usage_exposures",
+          "tableTo": "skill_usage_sources",
+          "columnsFrom": [
+            "raw_file_path"
+          ],
+          "columnsTo": [
+            "raw_file_path"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "skill_usage_sources": {
+      "name": "skill_usage_sources",
+      "columns": {
+        "raw_file_path": {
+          "name": "raw_file_path",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "analyzer_version": {
+          "name": "analyzer_version",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'6'"
+        },
+        "agent_kind": {
+          "name": "agent_kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "session_id": {
+          "name": "session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "sdk_session_id": {
+          "name": "sdk_session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "mtime_ms": {
+          "name": "mtime_ms",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "size_bytes": {
+          "name": "size_bytes",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "last_scanned_at": {
+          "name": "last_scanned_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'ok'"
+        },
+        "error": {
+          "name": "error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "idx_skill_usage_sources_session": {
+          "name": "idx_skill_usage_sources_session",
+          "columns": [
+            "session_id"
+          ],
+          "isUnique": false
+        },
+        "idx_skill_usage_sources_sdk_session": {
+          "name": "idx_skill_usage_sources_sdk_session",
+          "columns": [
+            "sdk_session_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "subagent_run_aliases": {
+      "name": "subagent_run_aliases",
+      "columns": {
+        "session_id": {
+          "name": "session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "provider": {
+          "name": "provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "alias": {
+          "name": "alias",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "run_id": {
+          "name": "run_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "subagent_run_aliases_lookup_idx": {
+          "name": "subagent_run_aliases_lookup_idx",
+          "columns": [
+            "session_id",
+            "provider",
+            "alias",
+            "created_at"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "subagent_run_aliases_session_id_sessions_id_fk": {
+          "name": "subagent_run_aliases_session_id_sessions_id_fk",
+          "tableFrom": "subagent_run_aliases",
+          "tableTo": "sessions",
+          "columnsFrom": [
+            "session_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "subagent_run_aliases_run_id_subagent_runs_id_fk": {
+          "name": "subagent_run_aliases_run_id_subagent_runs_id_fk",
+          "tableFrom": "subagent_run_aliases",
+          "tableTo": "subagent_runs",
+          "columnsFrom": [
+            "run_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "subagent_run_aliases_run_id_alias_pk": {
+          "columns": [
+            "run_id",
+            "alias"
+          ],
+          "name": "subagent_run_aliases_run_id_alias_pk"
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "subagent_runs": {
+      "name": "subagent_runs",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "session_id": {
+          "name": "session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "provider": {
+          "name": "provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "logical_agent_id": {
+          "name": "logical_agent_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "parent_tool_use_id": {
+          "name": "parent_tool_use_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "aliases": {
+          "name": "aliases",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'[]'"
+        },
+        "provider_run_ids": {
+          "name": "provider_run_ids",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'[]'"
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'running'"
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "summary": {
+          "name": "summary",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "returned_result": {
+          "name": "returned_result",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "returned_result_empty": {
+          "name": "returned_result_empty",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "returned_result_truncated": {
+          "name": "returned_result_truncated",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "model": {
+          "name": "model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "reasoning_effort": {
+          "name": "reasoning_effort",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "total_tokens": {
+          "name": "total_tokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "tool_uses": {
+          "name": "tool_uses",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "duration_ms": {
+          "name": "duration_ms",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "cost_usd": {
+          "name": "cost_usd",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "capabilities": {
+          "name": "capabilities",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'{}'"
+        },
+        "activity": {
+          "name": "activity",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'[]'"
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "ended_at": {
+          "name": "ended_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "rewind_at": {
+          "name": "rewind_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "subagent_runs_logical_idx": {
+          "name": "subagent_runs_logical_idx",
+          "columns": [
+            "session_id",
+            "provider",
+            "logical_agent_id"
+          ],
+          "isUnique": false
+        },
+        "subagent_runs_session_idx": {
+          "name": "subagent_runs_session_idx",
+          "columns": [
+            "session_id",
+            "rewind_at",
+            "deleted_at",
+            "started_at"
+          ],
+          "isUnique": false
+        },
+        "subagent_runs_parent_tool_use_idx": {
+          "name": "subagent_runs_parent_tool_use_idx",
+          "columns": [
+            "session_id",
+            "parent_tool_use_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "subagent_runs_session_id_sessions_id_fk": {
+          "name": "subagent_runs_session_id_sessions_id_fk",
+          "tableFrom": "subagent_runs",
+          "tableTo": "sessions",
+          "columnsFrom": [
+            "session_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "vec_table_meta": {
+      "name": "vec_table_meta",
+      "columns": {
+        "vec_table": {
+          "name": "vec_table",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "source": {
+          "name": "source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "model_id": {
+          "name": "model_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "dim": {
+          "name": "dim",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "registered_at": {
+          "name": "registered_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "wechat_file_attachments": {
+      "name": "wechat_file_attachments",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "binding_epoch": {
+          "name": "binding_epoch",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "task_id": {
+          "name": "task_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "session_id": {
+          "name": "session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "abs_path": {
+          "name": "abs_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "original_name": {
+          "name": "original_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "mime_type": {
+          "name": "mime_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "bytes": {
+          "name": "bytes",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'staged'"
+        },
+        "promoted_at": {
+          "name": "promoted_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "idx_wechat_file_attachments_task": {
+          "name": "idx_wechat_file_attachments_task",
+          "columns": [
+            "binding_epoch",
+            "task_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "wechat_file_attachments_binding_epoch_wechat_sync_state_binding_epoch_fk": {
+          "name": "wechat_file_attachments_binding_epoch_wechat_sync_state_binding_epoch_fk",
+          "tableFrom": "wechat_file_attachments",
+          "tableTo": "wechat_sync_state",
+          "columnsFrom": [
+            "binding_epoch"
+          ],
+          "columnsTo": [
+            "binding_epoch"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "wechat_file_attachments_task_id_wechat_inbox_id_fk": {
+          "name": "wechat_file_attachments_task_id_wechat_inbox_id_fk",
+          "tableFrom": "wechat_file_attachments",
+          "tableTo": "wechat_inbox",
+          "columnsFrom": [
+            "task_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "wechat_file_attachments_session_id_sessions_id_fk": {
+          "name": "wechat_file_attachments_session_id_sessions_id_fk",
+          "tableFrom": "wechat_file_attachments",
+          "tableTo": "sessions",
+          "columnsFrom": [
+            "session_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "wechat_inbox": {
+      "name": "wechat_inbox",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "binding_epoch": {
+          "name": "binding_epoch",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "platform_message_id": {
+          "name": "platform_message_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "platform_seq": {
+          "name": "platform_seq",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "peer_id": {
+          "name": "peer_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "received_at": {
+          "name": "received_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "platform_created_at": {
+          "name": "platform_created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'pending'"
+        },
+        "lease_until": {
+          "name": "lease_until",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "session_id": {
+          "name": "session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "conversation_epoch": {
+          "name": "conversation_epoch",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "payload_json": {
+          "name": "payload_json",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "context_nonce": {
+          "name": "context_nonce",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "context_ciphertext": {
+          "name": "context_ciphertext",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "context_tag": {
+          "name": "context_tag",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "attempts": {
+          "name": "attempts",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "last_error_code": {
+          "name": "last_error_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "uniq_wechat_inbox_platform_message": {
+          "name": "uniq_wechat_inbox_platform_message",
+          "columns": [
+            "binding_epoch",
+            "platform_message_id"
+          ],
+          "isUnique": true
+        },
+        "idx_wechat_inbox_queue": {
+          "name": "idx_wechat_inbox_queue",
+          "columns": [
+            "binding_epoch",
+            "status",
+            "received_at"
+          ],
+          "isUnique": false
+        },
+        "idx_wechat_inbox_lease": {
+          "name": "idx_wechat_inbox_lease",
+          "columns": [
+            "binding_epoch",
+            "lease_until"
+          ],
+          "isUnique": false
+        },
+        "idx_wechat_inbox_conversation": {
+          "name": "idx_wechat_inbox_conversation",
+          "columns": [
+            "binding_epoch",
+            "peer_id",
+            "conversation_epoch"
+          ],
+          "isUnique": false
+        },
+        "uniq_wechat_inbox_running_session": {
+          "name": "uniq_wechat_inbox_running_session",
+          "columns": [
+            "binding_epoch",
+            "session_id"
+          ],
+          "isUnique": true,
+          "where": "\"wechat_inbox\".\"session_id\" IS NOT NULL AND \"wechat_inbox\".\"status\" IN ('dispatching', 'accepted_running', 'waiting_desktop', 'delivery_pending')"
+        }
+      },
+      "foreignKeys": {
+        "wechat_inbox_binding_epoch_wechat_sync_state_binding_epoch_fk": {
+          "name": "wechat_inbox_binding_epoch_wechat_sync_state_binding_epoch_fk",
+          "tableFrom": "wechat_inbox",
+          "tableTo": "wechat_sync_state",
+          "columnsFrom": [
+            "binding_epoch"
+          ],
+          "columnsTo": [
+            "binding_epoch"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "wechat_inbox_session_id_sessions_id_fk": {
+          "name": "wechat_inbox_session_id_sessions_id_fk",
+          "tableFrom": "wechat_inbox",
+          "tableTo": "sessions",
+          "columnsFrom": [
+            "session_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "wechat_outbox": {
+      "name": "wechat_outbox",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "binding_epoch": {
+          "name": "binding_epoch",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "task_id": {
+          "name": "task_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "client_id": {
+          "name": "client_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "kind": {
+          "name": "kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "chunk_index": {
+          "name": "chunk_index",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "text": {
+          "name": "text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "media_json": {
+          "name": "media_json",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'[]'"
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'pending'"
+        },
+        "attempts": {
+          "name": "attempts",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "next_retry_at": {
+          "name": "next_retry_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "delivered_at": {
+          "name": "delivered_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "uniq_wechat_outbox_client_id": {
+          "name": "uniq_wechat_outbox_client_id",
+          "columns": [
+            "binding_epoch",
+            "client_id"
+          ],
+          "isUnique": true
+        },
+        "idx_wechat_outbox_delivery": {
+          "name": "idx_wechat_outbox_delivery",
+          "columns": [
+            "binding_epoch",
+            "status",
+            "next_retry_at"
+          ],
+          "isUnique": false
+        },
+        "idx_wechat_outbox_task": {
+          "name": "idx_wechat_outbox_task",
+          "columns": [
+            "binding_epoch",
+            "task_id",
+            "chunk_index"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "wechat_outbox_binding_epoch_wechat_sync_state_binding_epoch_fk": {
+          "name": "wechat_outbox_binding_epoch_wechat_sync_state_binding_epoch_fk",
+          "tableFrom": "wechat_outbox",
+          "tableTo": "wechat_sync_state",
+          "columnsFrom": [
+            "binding_epoch"
+          ],
+          "columnsTo": [
+            "binding_epoch"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "wechat_outbox_task_id_wechat_inbox_id_fk": {
+          "name": "wechat_outbox_task_id_wechat_inbox_id_fk",
+          "tableFrom": "wechat_outbox",
+          "tableTo": "wechat_inbox",
+          "columnsFrom": [
+            "task_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "wechat_sync_state": {
+      "name": "wechat_sync_state",
+      "columns": {
+        "binding_epoch": {
+          "name": "binding_epoch",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "is_active": {
+          "name": "is_active",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "sync_cursor": {
+          "name": "sync_cursor",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "last_poll_at": {
+          "name": "last_poll_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "last_error_code": {
+          "name": "last_error_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "uniq_wechat_sync_active": {
+          "name": "uniq_wechat_sync_active",
+          "columns": [
+            "is_active"
+          ],
+          "isUnique": true,
+          "where": "\"wechat_sync_state\".\"is_active\" = 1"
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    }
+  },
+  "views": {},
+  "enums": {},
+  "_meta": {
+    "schemas": {},
+    "tables": {},
+    "columns": {}
+  },
+  "internal": {
+    "indexes": {
+      "uniq_orca_worker_creation_reservations_team_label": {
+        "columns": {
+          "lower(\"label\")": {
+            "isExpression": true
+          }
+        }
+      },
+      "uniq_orca_workers_team_label": {
+        "columns": {
+          "lower(\"label\")": {
+            "isExpression": true
+          }
+        }
+      }
+    }
+  }
+}

--- a/apps/desktop/drizzle/meta/_journal.json
+++ b/apps/desktop/drizzle/meta/_journal.json
@@ -673,6 +673,13 @@
       "when": 1787644558248,
       "tag": "0095_scope_messages_fts_update_trigger",
       "breakpoints": true
+    },
+    {
+      "idx": 96,
+      "version": "6",
+      "when": 1787721235534,
+      "tag": "0096_stabilize_messages_fts_rows",
+      "breakpoints": true
     }
   ]
 }

--- a/apps/desktop/drizzle/scripts/0096_stabilize_messages_fts_rows.ts
+++ b/apps/desktop/drizzle/scripts/0096_stabilize_messages_fts_rows.ts
@@ -1,0 +1,165 @@
+import type Database from 'better-sqlite3';
+
+const FTS_ROLE_WHITELIST = "('user', 'assistant', 'ask_user', 'plan_review')";
+
+function tableExists(db: Database.Database, name: string): boolean {
+  return !!db.prepare(`SELECT 1 FROM sqlite_master WHERE type='table' AND name=?`).get(name);
+}
+
+function isConstraintError(error: unknown): boolean {
+  return (
+    error instanceof Error &&
+    typeof (error as Error & { code?: unknown }).code === 'string' &&
+    String((error as Error & { code: string }).code).startsWith('SQLITE_CONSTRAINT')
+  );
+}
+
+function rebuildFts(db: Database.Database): void {
+  db.exec('DROP TABLE IF EXISTS messages_fts;');
+  db.exec('DELETE FROM messages_fts_rows;');
+  db.exec(`
+    CREATE VIRTUAL TABLE messages_fts USING fts5(
+      message_id UNINDEXED,
+      session_id UNINDEXED,
+      role UNINDEXED,
+      content,
+      tokenize='porter unicode61'
+    );
+  `);
+  db.exec(`
+    INSERT INTO messages_fts_rows(message_id)
+      SELECT id
+      FROM messages
+      WHERE rewind_at IS NULL
+        AND role IN ${FTS_ROLE_WHITELIST}
+      ORDER BY rowid;
+  `);
+  db.exec(`
+    INSERT INTO messages_fts(rowid, message_id, session_id, role, content)
+      SELECT r.fts_rowid, m.id, m.session_id, m.role, m.content
+      FROM messages m
+      JOIN messages_fts_rows r ON r.message_id = m.id;
+  `);
+}
+
+function reuseExistingFtsRows(db: Database.Database): boolean {
+  db.exec('DELETE FROM messages_fts_rows;');
+  try {
+    db.exec(`
+      INSERT INTO messages_fts_rows(fts_rowid, message_id)
+        SELECT rowid, message_id
+        FROM messages_fts;
+    `);
+  } catch (error) {
+    if (isConstraintError(error)) return false;
+    throw error;
+  }
+
+  const invalidFtsRow = db
+    .prepare(
+      `SELECT 1
+       FROM messages_fts_rows r
+       LEFT JOIN messages m ON m.id = r.message_id
+       WHERE m.id IS NULL
+          OR m.rewind_at IS NOT NULL
+          OR m.role NOT IN ${FTS_ROLE_WHITELIST}
+       LIMIT 1`,
+    )
+    .get();
+  if (invalidFtsRow) return false;
+
+  const mismatchedFtsRow = db
+    .prepare(
+      `SELECT 1
+       FROM messages_fts f
+       JOIN messages_fts_rows r ON r.fts_rowid = f.rowid
+       JOIN messages m ON m.id = r.message_id
+       WHERE f.message_id IS NOT m.id
+          OR f.session_id IS NOT m.session_id
+          OR f.role IS NOT m.role
+          OR f.content IS NOT m.content
+       LIMIT 1`,
+    )
+    .get();
+  if (mismatchedFtsRow) return false;
+
+  const missingFtsRow = db
+    .prepare(
+      `SELECT 1
+       FROM messages m
+       LEFT JOIN messages_fts_rows r ON r.message_id = m.id
+       WHERE m.rewind_at IS NULL
+         AND m.role IN ${FTS_ROLE_WHITELIST}
+         AND r.message_id IS NULL
+       LIMIT 1`,
+    )
+    .get();
+  return !missingFtsRow;
+}
+
+function createTriggers(db: Database.Database): void {
+  db.exec(`
+    CREATE TRIGGER messages_fts_insert
+    AFTER INSERT ON messages
+    WHEN new.rewind_at IS NULL AND new.role IN ${FTS_ROLE_WHITELIST}
+    BEGIN
+      INSERT OR IGNORE INTO messages_fts_rows(message_id) VALUES (new.id);
+      INSERT OR REPLACE INTO messages_fts(rowid, message_id, session_id, role, content)
+        SELECT fts_rowid, new.id, new.session_id, new.role, new.content
+        FROM messages_fts_rows
+        WHERE message_id = new.id;
+    END;
+  `);
+
+  db.exec(`
+    CREATE TRIGGER messages_fts_delete
+    AFTER DELETE ON messages
+    BEGIN
+      DELETE FROM messages_fts
+        WHERE rowid = (
+          SELECT fts_rowid FROM messages_fts_rows WHERE message_id = old.id
+        );
+      DELETE FROM messages_fts_rows WHERE message_id = old.id;
+    END;
+  `);
+
+  db.exec(`
+    CREATE TRIGGER messages_fts_update
+    AFTER UPDATE OF id, session_id, role, content, rewind_at ON messages
+    WHEN old.id IS NOT new.id
+      OR old.session_id IS NOT new.session_id
+      OR old.role IS NOT new.role
+      OR old.content IS NOT new.content
+      OR old.rewind_at IS NOT new.rewind_at
+    BEGIN
+      DELETE FROM messages_fts
+        WHERE rowid = (
+          SELECT fts_rowid FROM messages_fts_rows WHERE message_id = old.id
+        );
+      UPDATE messages_fts_rows
+        SET message_id = new.id
+        WHERE message_id = old.id AND old.id IS NOT new.id;
+      INSERT OR IGNORE INTO messages_fts_rows(message_id)
+        SELECT new.id
+        WHERE new.rewind_at IS NULL AND new.role IN ${FTS_ROLE_WHITELIST};
+      INSERT OR REPLACE INTO messages_fts(rowid, message_id, session_id, role, content)
+        SELECT fts_rowid, new.id, new.session_id, new.role, new.content
+        FROM messages_fts_rows
+        WHERE message_id = new.id
+          AND new.rewind_at IS NULL
+          AND new.role IN ${FTS_ROLE_WHITELIST};
+    END;
+  `);
+}
+
+function run(db: Database.Database): void {
+  db.exec('DROP TRIGGER IF EXISTS messages_fts_insert;');
+  db.exec('DROP TRIGGER IF EXISTS messages_fts_delete;');
+  db.exec('DROP TRIGGER IF EXISTS messages_fts_update;');
+
+  if (!tableExists(db, 'messages')) return;
+  if (!tableExists(db, 'messages_fts') || !reuseExistingFtsRows(db)) rebuildFts(db);
+  createTriggers(db);
+}
+
+module.exports = { run };

--- a/apps/desktop/src/main/__tests__/schemaDriftRepair.test.ts
+++ b/apps/desktop/src/main/__tests__/schemaDriftRepair.test.ts
@@ -18,6 +18,31 @@ import {
   repairSchemaDriftWithBackup,
 } from '../localDb/schemaDriftRepair';
 
+interface FtsRow {
+  rowid: number;
+  message_id: string;
+  session_id: string;
+  role: string;
+  content: string;
+}
+
+function ftsRows(db: Database.Database): FtsRow[] {
+  return db
+    .prepare(
+      `SELECT rowid, message_id, session_id, role, content
+       FROM messages_fts
+       ORDER BY rowid`,
+    )
+    .all() as FtsRow[];
+}
+
+function insertSearchMessage(db: Database.Database, id: string, content: string): void {
+  db.prepare(
+    `INSERT INTO messages(id, client_id, session_id, role, content, created_at)
+     VALUES (?, ?, 's1', 'user', ?, 1)`,
+  ).run(id, `client-${id}`, content);
+}
+
 describe('repairSchemaDrift', () => {
   it('derives managed tables from every sqliteTable export in schema.ts', () => {
     const exportedTableNames = Object.values(localSchema)
@@ -215,6 +240,64 @@ describe('repairSchemaDrift', () => {
           AND name = 'uniq_active_team_per_lead'
       `).get();
       expect(partialIndex).toBeUndefined();
+    } finally {
+      db.close();
+    }
+  });
+
+  it('restores a missing FTS row map before later inserts, updates, and deletes', () => {
+    const db = new Database(':memory:');
+    try {
+      expect(repairSchemaDrift(db).residual).toEqual([]);
+      db.prepare("INSERT INTO sessions(id, created_at, updated_at) VALUES ('s1', 1, 1)").run();
+      insertSearchMessage(db, 'm1', 'first');
+      insertSearchMessage(db, 'm2', 'second');
+      const before = ftsRows(db);
+
+      db.exec('DROP TABLE messages_fts_rows;');
+      expect(repairSchemaDrift(db).residual).toEqual([]);
+
+      expect(
+        db.prepare('SELECT fts_rowid, message_id FROM messages_fts_rows ORDER BY fts_rowid').all(),
+      ).toEqual(before.map((row) => ({ fts_rowid: row.rowid, message_id: row.message_id })));
+
+      insertSearchMessage(db, 'm3', 'third');
+      db.prepare("UPDATE messages SET content = 'second updated' WHERE id = 'm2'").run();
+      db.prepare("DELETE FROM messages WHERE id = 'm1'").run();
+
+      expect(ftsRows(db).map(({ message_id, content }) => ({ message_id, content }))).toEqual([
+        { message_id: 'm2', content: 'second updated' },
+        { message_id: 'm3', content: 'third' },
+      ]);
+    } finally {
+      db.close();
+    }
+  });
+
+  it('rebuilds stale FTS content while restoring a missing row map', () => {
+    const db = new Database(':memory:');
+    try {
+      expect(repairSchemaDrift(db).residual).toEqual([]);
+      db.prepare("INSERT INTO sessions(id, created_at, updated_at) VALUES ('s1', 1, 1)").run();
+      insertSearchMessage(db, 'm1', 'canonical');
+      db.prepare("UPDATE messages_fts SET content = 'stale' WHERE message_id = 'm1'").run();
+      db.exec('DROP TABLE messages_fts_rows;');
+
+      expect(repairSchemaDrift(db).residual).toEqual([]);
+
+      const rows = ftsRows(db);
+      const mapping = db
+        .prepare("SELECT fts_rowid FROM messages_fts_rows WHERE message_id = 'm1'")
+        .get() as { fts_rowid: number };
+      expect(rows).toEqual([
+        {
+          rowid: mapping.fts_rowid,
+          message_id: 'm1',
+          session_id: 's1',
+          role: 'user',
+          content: 'canonical',
+        },
+      ]);
     } finally {
       db.close();
     }

--- a/apps/desktop/src/main/__tests__/stabilizeMessagesFtsRowsMigration.test.ts
+++ b/apps/desktop/src/main/__tests__/stabilizeMessagesFtsRowsMigration.test.ts
@@ -1,0 +1,286 @@
+import Database from 'better-sqlite3';
+import { describe, expect, it } from 'vitest';
+
+const { default: migration } =
+  (await import('../../../drizzle/scripts/0096_stabilize_messages_fts_rows')) as {
+    default: { run: (db: Database.Database) => void };
+  };
+
+const FTS_ROLE_WHITELIST = "('user', 'assistant', 'ask_user', 'plan_review')";
+
+interface FtsRow {
+  rowid: number;
+  message_id: string;
+  session_id: string;
+  role: string;
+  content: string;
+}
+
+function setupLegacyDb(): Database.Database {
+  const db = new Database(':memory:');
+  db.exec(`
+    CREATE TABLE messages (
+      id TEXT PRIMARY KEY,
+      session_id TEXT NOT NULL,
+      role TEXT NOT NULL,
+      content TEXT NOT NULL,
+      agent_meta TEXT,
+      rewind_at INTEGER
+    );
+    CREATE VIRTUAL TABLE messages_fts USING fts5(
+      message_id UNINDEXED,
+      session_id UNINDEXED,
+      role UNINDEXED,
+      content,
+      tokenize='porter unicode61'
+    );
+    CREATE TRIGGER messages_fts_insert
+    AFTER INSERT ON messages
+    WHEN new.rewind_at IS NULL AND new.role IN ${FTS_ROLE_WHITELIST}
+    BEGIN
+      INSERT INTO messages_fts(message_id, session_id, role, content)
+        VALUES (new.id, new.session_id, new.role, new.content);
+    END;
+    CREATE TRIGGER messages_fts_delete
+    AFTER DELETE ON messages
+    BEGIN
+      DELETE FROM messages_fts WHERE message_id = old.id;
+    END;
+    CREATE TRIGGER messages_fts_update
+    AFTER UPDATE ON messages
+    BEGIN
+      DELETE FROM messages_fts WHERE message_id = old.id;
+      INSERT INTO messages_fts(message_id, session_id, role, content)
+        SELECT new.id, new.session_id, new.role, new.content
+        WHERE new.rewind_at IS NULL AND new.role IN ${FTS_ROLE_WHITELIST};
+    END;
+    CREATE TABLE messages_fts_rows (
+      fts_rowid INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL,
+      message_id TEXT NOT NULL
+    );
+    CREATE UNIQUE INDEX messages_fts_rows_message_id_idx
+      ON messages_fts_rows(message_id);
+  `);
+  return db;
+}
+
+function insertMessage(
+  db: Database.Database,
+  id: string,
+  role: string,
+  content: string,
+  rewindAt: number | null = null,
+): void {
+  db.prepare(
+    `INSERT INTO messages(id, session_id, role, content, agent_meta, rewind_at)
+     VALUES (?, 's1', ?, ?, NULL, ?)`,
+  ).run(id, role, content, rewindAt);
+}
+
+function ftsRows(db: Database.Database): FtsRow[] {
+  return db
+    .prepare(
+      `SELECT rowid, message_id, session_id, role, content
+       FROM messages_fts
+       ORDER BY rowid`,
+    )
+    .all() as FtsRow[];
+}
+
+function mappedRowid(db: Database.Database, messageId: string): number | null {
+  const row = db
+    .prepare('SELECT fts_rowid FROM messages_fts_rows WHERE message_id = ?')
+    .get(messageId) as { fts_rowid: number } | undefined;
+  return row?.fts_rowid ?? null;
+}
+
+function totalChanges(db: Database.Database): number {
+  return (db.prepare('SELECT total_changes() AS changes').get() as { changes: number }).changes;
+}
+
+describe('0096 stabilize messages_fts rows migration', () => {
+  it('复用现有 FTS rowid，并让元数据更新完全绕过 FTS', () => {
+    const db = setupLegacyDb();
+    insertMessage(db, 'm1', 'user', 'first');
+    insertMessage(db, 'm2', 'assistant', 'second');
+    db.prepare('DELETE FROM messages WHERE id = ?').run('m1');
+    insertMessage(db, 'm3', 'user', 'third');
+    const beforeRows = ftsRows(db);
+
+    migration.run(db);
+
+    expect(
+      db.prepare('SELECT fts_rowid, message_id FROM messages_fts_rows ORDER BY fts_rowid').all(),
+    ).toEqual(beforeRows.map((row) => ({ fts_rowid: row.rowid, message_id: row.message_id })));
+
+    const changesBefore = totalChanges(db);
+    db.prepare('UPDATE messages SET agent_meta = ? WHERE id = ?').run('{"usage":1}', 'm2');
+    expect(totalChanges(db) - changesBefore).toBe(1);
+    expect(ftsRows(db)).toEqual(beforeRows);
+
+    const triggerSql = db
+      .prepare("SELECT sql FROM sqlite_master WHERE type='trigger' AND name='messages_fts_update'")
+      .get() as { sql: string };
+    expect(triggerSql.sql).toContain(
+      'AFTER UPDATE OF id, session_id, role, content, rewind_at ON messages',
+    );
+    expect(triggerSql.sql).not.toContain('agent_meta');
+
+    const plan = db
+      .prepare(
+        `EXPLAIN QUERY PLAN
+         DELETE FROM messages_fts
+         WHERE rowid = (
+           SELECT fts_rowid FROM messages_fts_rows WHERE message_id = ?
+         )`,
+      )
+      .all('m2') as Array<{ detail: string }>;
+    expect(plan.some((row) => row.detail.includes('messages_fts VIRTUAL TABLE INDEX 0:='))).toBe(
+      true,
+    );
+    expect(
+      plan.some(
+        (row) =>
+          row.detail.includes('SEARCH messages_fts_rows') &&
+          row.detail.includes('messages_fts_rows_message_id_idx'),
+      ),
+    ).toBe(true);
+    db.close();
+  });
+
+  it('定点维护插入、正文、角色、rewind、主键与物理删除', () => {
+    const db = setupLegacyDb();
+    migration.run(db);
+
+    insertMessage(db, 'm-user', 'user', 'original');
+    insertMessage(db, 'm-tool', 'tool_result', 'not indexed');
+    const stableRowid = mappedRowid(db, 'm-user');
+    expect(stableRowid).not.toBeNull();
+    expect(mappedRowid(db, 'm-tool')).toBeNull();
+
+    db.prepare('UPDATE messages SET content = ? WHERE id = ?').run('updated', 'm-user');
+    expect(ftsRows(db)).toEqual([
+      {
+        rowid: stableRowid,
+        message_id: 'm-user',
+        session_id: 's1',
+        role: 'user',
+        content: 'updated',
+      },
+    ]);
+
+    db.prepare('UPDATE messages SET role = ? WHERE id = ?').run('tool_result', 'm-user');
+    expect(ftsRows(db)).toEqual([]);
+    expect(mappedRowid(db, 'm-user')).toBe(stableRowid);
+
+    db.prepare('UPDATE messages SET role = ? WHERE id = ?').run('assistant', 'm-user');
+    expect(mappedRowid(db, 'm-user')).toBe(stableRowid);
+    expect(ftsRows(db)[0]?.rowid).toBe(stableRowid);
+
+    db.prepare('UPDATE messages SET rewind_at = 1 WHERE id = ?').run('m-user');
+    expect(ftsRows(db)).toEqual([]);
+    db.prepare('UPDATE messages SET rewind_at = NULL WHERE id = ?').run('m-user');
+    expect(ftsRows(db)[0]?.rowid).toBe(stableRowid);
+
+    db.prepare('UPDATE messages SET id = ?, session_id = ? WHERE id = ?').run(
+      'm-renamed',
+      's2',
+      'm-user',
+    );
+    expect(mappedRowid(db, 'm-user')).toBeNull();
+    expect(mappedRowid(db, 'm-renamed')).toBe(stableRowid);
+    expect(ftsRows(db)[0]).toMatchObject({
+      rowid: stableRowid,
+      message_id: 'm-renamed',
+      session_id: 's2',
+    });
+
+    db.prepare('DELETE FROM messages WHERE id = ?').run('m-renamed');
+    expect(ftsRows(db)).toEqual([]);
+    expect(mappedRowid(db, 'm-renamed')).toBeNull();
+    db.close();
+  });
+
+  it('现有 FTS 重复、孤儿、缺行或字段过期时从 messages 自动重建派生索引', () => {
+    const corruptions: Array<(db: Database.Database) => void> = [
+      (db) => {
+        db.prepare(
+          `INSERT INTO messages_fts(message_id, session_id, role, content)
+           VALUES ('m1', 's1', 'user', 'stale duplicate')`,
+        ).run();
+      },
+      (db) => {
+        db.prepare(
+          `INSERT INTO messages_fts(message_id, session_id, role, content)
+           VALUES ('orphan', 's1', 'user', 'stale orphan')`,
+        ).run();
+      },
+      (db) => {
+        db.prepare("DELETE FROM messages_fts WHERE message_id = 'm1'").run();
+      },
+      (db) => {
+        db.prepare("UPDATE messages_fts SET content = 'stale content' WHERE message_id = 'm1'").run();
+      },
+      (db) => {
+        db.prepare("UPDATE messages_fts SET session_id = 'stale-session' WHERE message_id = 'm1'").run();
+      },
+      (db) => {
+        db.prepare("UPDATE messages_fts SET role = 'assistant' WHERE message_id = 'm1'").run();
+      },
+    ];
+
+    for (const corrupt of corruptions) {
+      const db = setupLegacyDb();
+      insertMessage(db, 'm1', 'user', 'canonical');
+      corrupt(db);
+
+      migration.run(db);
+
+      expect(ftsRows(db)).toEqual([
+        {
+          rowid: mappedRowid(db, 'm1'),
+          message_id: 'm1',
+          session_id: 's1',
+          role: 'user',
+          content: 'canonical',
+        },
+      ]);
+      expect(() => migration.run(db)).not.toThrow();
+      expect(ftsRows(db)).toHaveLength(1);
+      db.close();
+    }
+  });
+
+  it('FTS 缺失时重建，messages 缺失的最小 fixture 安全跳过', () => {
+    const rebuildDb = setupLegacyDb();
+    insertMessage(rebuildDb, 'm1', 'assistant', 'restore me');
+    rebuildDb.exec('DROP TRIGGER messages_fts_insert;');
+    rebuildDb.exec('DROP TRIGGER messages_fts_delete;');
+    rebuildDb.exec('DROP TRIGGER messages_fts_update;');
+    rebuildDb.exec('DROP TABLE messages_fts;');
+    migration.run(rebuildDb);
+    expect(ftsRows(rebuildDb)).toEqual([
+      {
+        rowid: mappedRowid(rebuildDb, 'm1'),
+        message_id: 'm1',
+        session_id: 's1',
+        role: 'assistant',
+        content: 'restore me',
+      },
+    ]);
+    rebuildDb.close();
+
+    const fixtureDb = new Database(':memory:');
+    fixtureDb.exec(`
+      CREATE TABLE messages_fts_rows (
+        fts_rowid INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL,
+        message_id TEXT NOT NULL UNIQUE
+      );
+    `);
+    expect(() => migration.run(fixtureDb)).not.toThrow();
+    expect(
+      fixtureDb.prepare("SELECT 1 FROM sqlite_master WHERE name='messages_fts_insert'").get(),
+    ).toBeUndefined();
+    fixtureDb.close();
+  });
+});

--- a/apps/desktop/src/main/localDb/messagesFtsRowsRepair.ts
+++ b/apps/desktop/src/main/localDb/messagesFtsRowsRepair.ts
@@ -1,0 +1,180 @@
+import type Database from 'better-sqlite3';
+
+const FTS_ROLE_WHITELIST = "('user', 'assistant', 'ask_user', 'plan_review')";
+
+function tableExists(db: Database.Database, name: string): boolean {
+  return !!db.prepare(`SELECT 1 FROM sqlite_master WHERE type='table' AND name=?`).get(name);
+}
+
+function isConstraintError(error: unknown): boolean {
+  return (
+    error instanceof Error &&
+    typeof (error as Error & { code?: unknown }).code === 'string' &&
+    String((error as Error & { code: string }).code).startsWith('SQLITE_CONSTRAINT')
+  );
+}
+
+function createRowsTable(db: Database.Database): void {
+  db.exec(`
+    CREATE TABLE IF NOT EXISTS messages_fts_rows (
+      fts_rowid INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL,
+      message_id TEXT NOT NULL
+    );
+    CREATE UNIQUE INDEX IF NOT EXISTS messages_fts_rows_message_id_idx
+      ON messages_fts_rows(message_id);
+  `);
+}
+
+function rebuildFts(db: Database.Database): void {
+  db.exec('DROP TABLE IF EXISTS messages_fts;');
+  db.exec('DELETE FROM messages_fts_rows;');
+  db.exec(`
+    CREATE VIRTUAL TABLE messages_fts USING fts5(
+      message_id UNINDEXED,
+      session_id UNINDEXED,
+      role UNINDEXED,
+      content,
+      tokenize='porter unicode61'
+    );
+  `);
+  db.exec(`
+    INSERT INTO messages_fts_rows(message_id)
+      SELECT id
+      FROM messages
+      WHERE rewind_at IS NULL
+        AND role IN ${FTS_ROLE_WHITELIST}
+      ORDER BY rowid;
+  `);
+  db.exec(`
+    INSERT INTO messages_fts(rowid, message_id, session_id, role, content)
+      SELECT r.fts_rowid, m.id, m.session_id, m.role, m.content
+      FROM messages m
+      JOIN messages_fts_rows r ON r.message_id = m.id;
+  `);
+}
+
+function reuseExistingFtsRows(db: Database.Database): boolean {
+  db.exec('DELETE FROM messages_fts_rows;');
+  try {
+    db.exec(`
+      INSERT INTO messages_fts_rows(fts_rowid, message_id)
+        SELECT rowid, message_id
+        FROM messages_fts;
+    `);
+  } catch (error) {
+    if (isConstraintError(error)) return false;
+    throw error;
+  }
+
+  const invalidFtsRow = db
+    .prepare(
+      `SELECT 1
+       FROM messages_fts_rows r
+       LEFT JOIN messages m ON m.id = r.message_id
+       WHERE m.id IS NULL
+          OR m.rewind_at IS NOT NULL
+          OR m.role NOT IN ${FTS_ROLE_WHITELIST}
+       LIMIT 1`,
+    )
+    .get();
+  if (invalidFtsRow) return false;
+
+  const mismatchedFtsRow = db
+    .prepare(
+      `SELECT 1
+       FROM messages_fts f
+       JOIN messages_fts_rows r ON r.fts_rowid = f.rowid
+       JOIN messages m ON m.id = r.message_id
+       WHERE f.message_id IS NOT m.id
+          OR f.session_id IS NOT m.session_id
+          OR f.role IS NOT m.role
+          OR f.content IS NOT m.content
+       LIMIT 1`,
+    )
+    .get();
+  if (mismatchedFtsRow) return false;
+
+  const missingFtsRow = db
+    .prepare(
+      `SELECT 1
+       FROM messages m
+       LEFT JOIN messages_fts_rows r ON r.message_id = m.id
+       WHERE m.rewind_at IS NULL
+         AND m.role IN ${FTS_ROLE_WHITELIST}
+         AND r.message_id IS NULL
+       LIMIT 1`,
+    )
+    .get();
+  return !missingFtsRow;
+}
+
+function createTriggers(db: Database.Database): void {
+  db.exec(`
+    CREATE TRIGGER messages_fts_insert
+    AFTER INSERT ON messages
+    WHEN new.rewind_at IS NULL AND new.role IN ${FTS_ROLE_WHITELIST}
+    BEGIN
+      INSERT OR IGNORE INTO messages_fts_rows(message_id) VALUES (new.id);
+      INSERT OR REPLACE INTO messages_fts(rowid, message_id, session_id, role, content)
+        SELECT fts_rowid, new.id, new.session_id, new.role, new.content
+        FROM messages_fts_rows
+        WHERE message_id = new.id;
+    END;
+  `);
+
+  db.exec(`
+    CREATE TRIGGER messages_fts_delete
+    AFTER DELETE ON messages
+    BEGIN
+      DELETE FROM messages_fts
+        WHERE rowid = (
+          SELECT fts_rowid FROM messages_fts_rows WHERE message_id = old.id
+        );
+      DELETE FROM messages_fts_rows WHERE message_id = old.id;
+    END;
+  `);
+
+  db.exec(`
+    CREATE TRIGGER messages_fts_update
+    AFTER UPDATE OF id, session_id, role, content, rewind_at ON messages
+    WHEN old.id IS NOT new.id
+      OR old.session_id IS NOT new.session_id
+      OR old.role IS NOT new.role
+      OR old.content IS NOT new.content
+      OR old.rewind_at IS NOT new.rewind_at
+    BEGIN
+      DELETE FROM messages_fts
+        WHERE rowid = (
+          SELECT fts_rowid FROM messages_fts_rows WHERE message_id = old.id
+        );
+      UPDATE messages_fts_rows
+        SET message_id = new.id
+        WHERE message_id = old.id AND old.id IS NOT new.id;
+      INSERT OR IGNORE INTO messages_fts_rows(message_id)
+        SELECT new.id
+        WHERE new.rewind_at IS NULL AND new.role IN ${FTS_ROLE_WHITELIST};
+      INSERT OR REPLACE INTO messages_fts(rowid, message_id, session_id, role, content)
+        SELECT fts_rowid, new.id, new.session_id, new.role, new.content
+        FROM messages_fts_rows
+        WHERE message_id = new.id
+          AND new.rewind_at IS NULL
+          AND new.role IN ${FTS_ROLE_WHITELIST};
+    END;
+  `);
+}
+
+/** Restores the data-bearing rowid map together with the FTS state that depends on it. */
+export function repairMessagesFtsRows(db: Database.Database): void {
+  const run = db.transaction(() => {
+    db.exec('DROP TRIGGER IF EXISTS messages_fts_insert;');
+    db.exec('DROP TRIGGER IF EXISTS messages_fts_delete;');
+    db.exec('DROP TRIGGER IF EXISTS messages_fts_update;');
+
+    createRowsTable(db);
+    if (!tableExists(db, 'messages')) return;
+
+    if (!tableExists(db, 'messages_fts') || !reuseExistingFtsRows(db)) rebuildFts(db);
+    createTriggers(db);
+  });
+  run();
+}

--- a/apps/desktop/src/main/localDb/schema.ts
+++ b/apps/desktop/src/main/localDb/schema.ts
@@ -397,6 +397,24 @@ export const messages = sqliteTable(
 );
 
 /**
+ * messages_fts 的稳定整数行号映射。
+ *
+ * messages 使用 TEXT 主键，其隐藏 rowid 可能在 VACUUM 后变化，不能直接作为 FTS 的
+ * 持久关联键。这里为曾进入全文索引的消息分配独立整数键，让触发器可以通过普通 B-tree
+ * 按 message_id 找到 FTS rowid，再做定点更新或删除。
+ */
+export const messagesFtsRows = sqliteTable(
+  'messages_fts_rows',
+  {
+    ftsRowid: integer('fts_rowid').primaryKey({ autoIncrement: true }),
+    messageId: text('message_id').notNull(),
+  },
+  (t) => ({
+    byMessageId: uniqueIndex('messages_fts_rows_message_id_idx').on(t.messageId),
+  }),
+);
+
+/**
  * Cindy-owned durable Subagent records.
  *
  * This table is intentionally harness-neutral. `logical_agent_id` is the

--- a/apps/desktop/src/main/localDb/schemaDriftRepair.ts
+++ b/apps/desktop/src/main/localDb/schemaDriftRepair.ts
@@ -26,6 +26,7 @@ import type { SQLiteTableWithColumns, TableConfig } from 'drizzle-orm/sqlite-cor
 
 import * as schema from './schema';
 import { createLogger } from '../logger';
+import { repairMessagesFtsRows } from './messagesFtsRowsRepair';
 
 const log = createLogger('schema-drift-repair');
 
@@ -81,7 +82,7 @@ export interface RepairReport {
 /** 一条经只读反射确认需要执行的 schema 修复动作。 */
 export interface SchemaDriftRepairAction {
   table: string;
-  kind: 'add-column' | 'create-index' | 'create-table';
+  kind: 'add-column' | 'create-index' | 'create-table' | 'repair-messages-fts-rows';
   ddl: string;
   failureKind: ResidualMismatch['kind'];
   failureDetail: string;
@@ -368,6 +369,13 @@ export function planSchemaDriftRepair(db: Database.Database): SchemaDriftRepairP
       const tableName = getTableName(drizzleTable);
       try {
         if (!tableExists(db, tableName)) {
+          if (tableName === 'messages_fts_rows') {
+            actions.push({
+              ...planMissingTableRepair(tableName, drizzleTable),
+              kind: 'repair-messages-fts-rows',
+            });
+            continue;
+          }
           // CREATE TABLE 已包含全部列；只需额外计划 schema.ts 声明的索引。
           actions.push(planMissingTableRepair(tableName, drizzleTable));
           actions.push(...planIndexRepairs(db, tableName, drizzleTable, residual));
@@ -413,9 +421,16 @@ export function applySchemaDriftRepair(
 
   for (const action of plan.actions) {
     // CREATE TABLE 失败后，同表的索引动作没有执行意义，也不应制造一串重复 residual。
-    if (action.kind !== 'create-table' && !tableExists(db, action.table)) continue;
+    if (
+      action.kind !== 'create-table' &&
+      action.kind !== 'repair-messages-fts-rows' &&
+      !tableExists(db, action.table)
+    ) {
+      continue;
+    }
     try {
-      db.exec(action.ddl);
+      if (action.kind === 'repair-messages-fts-rows') repairMessagesFtsRows(db);
+      else db.exec(action.ddl);
       repaired.push(action.ddl);
     } catch (err) {
       log.error(


### PR DESCRIPTION
## 这次改了什么

### 摘要

修复消息全文索引在普通消息更新、删除及批量 rewind 时按未索引的 `message_id` 扫描整张 FTS 表的问题。迁移为既有 FTS 行建立稳定的 `rowid` 映射，运行期触发器改为通过映射表定位单行；同时补齐旧正文不一致和映射表丢失后的恢复逻辑，避免复用陈旧索引或留下错误关联。

### 变更类型

- [ ] `feat` 新功能
- [x] `fix` 缺陷修复
- [ ] `refactor` / `perf` 重构或性能优化
- [ ] `docs` / `test` / `chore` 文档、测试或工程维护
- [ ] 其他：

### 范围

- 关联 Issue / 需求：消息 FTS 维护性能问题及迁移审查反馈
- 本 PR 包含：0096 数据库迁移、FTS 行映射恢复、schema-drift 专用修复，以及迁移和增删改回归测试
- 明确不包含：搜索排序或分词语义调整、Review 查询优化、附件历史扫描优化
- 用户可见变化：消息量较大时，普通聊天完成回写、编辑、删除和 rewind 的数据库阻塞显著降低；搜索结果语义保持不变
- 是否存在 breaking change：无

### UI 变化

不涉及。

- 引用的设计规范：不涉及

## 怎么验证的

### 自动验证

```text
pnpm --filter desktop test:migration-replay
结果：通过，6/6

pnpm --filter desktop db:validate
结果：通过，0000–0096 migration 全部有效

pnpm --filter desktop run --if-present typecheck
结果：通过

pnpm test:unit:related
结果：通过，Desktop 相关单元测试通过

pnpm check:dco
结果：通过，当前 PR 范围 1 个 commit 已签名
```

### 手工验证

不涉及 UI。已通过迁移回放和数据库回归用例覆盖：旧正文不一致时重建、映射表丢失后恢复，以及恢复后的消息新增、更新和删除。

### 未执行的验证

未在本地执行全仓 `pnpm test:unit`；按仓库工作流使用 `pnpm test:unit:related` 作为提交前门禁，完整单元测试由 GitHub CI 执行。

## 风险

### 风险分类

- [ ] 无已知风险
- [x] SQLite / migration
- [ ] system prompt
- [ ] 协议兼容
- [ ] 权限 / 安全 / 用户数据
- [ ] 存量插件兼容（批准状态 / 指纹 / manifest 校验 / 安装布局 / 包格式）
- [ ] 原生层 / fingerprint / OTA
- [ ] 跨平台差异
- [ ] 其他：

### 影响与回滚

- 影响范围：升级时 0096 migration 会一次性线性校验已有 FTS 行；发现缺行、重复、孤儿、rewind 或字段不一致时会重建派生索引。该成本不进入普通聊天热路径。运行期仅在 schema-drift 检测到映射表缺失时执行专用事务恢复。迁移不修改 `messages` 正文等源数据。
- 回滚 / 降级方式：迁移与恢复均在事务中执行，失败时回滚并保留迁移前状态。降级到旧客户端时不主动删除已应用的映射表和触发器；如需代码回退，可保留这些兼容对象，不影响消息主表。
- Mobile 冷更判断：不涉及 `apps/mobile` 原生配置、依赖、config plugin 或原生模块，不改变 mobile runtime fingerprint，不触发冷更。

### 提交前检查

- [x] 已 review 完整 diff
- [x] 每个 commit 都带 DCO 签名（`git commit -s`，见 [DCO](../DCO)）
- [x] UI 改动已在「UI 变化」注明引用的设计规范章节（不涉及 UI 则跳过）
- [x] 未提交凭证、令牌或授权文件
- [x] 已补充必要文档
- [x] 已确认测试结果或说明未执行原因