### PR TITLE
fix(settings): 用量历史「按模型 / 按 agent」表首列不再横向撑开

### DIFF
--- a/apps/desktop/src/renderer/components/settings/usage/UsageBreakdownTables.tsx
+++ b/apps/desktop/src/renderer/components/settings/usage/UsageBreakdownTables.tsx
@@ -31,9 +31,17 @@ const AGENT_RANK: Record<UsageAgentKind, number> = {
 };
 
 const TH_CLASS =
-  'whitespace-nowrap border-b border-[var(--border-default)] pb-2 text-right text-11 font-medium text-[var(--text-tertiary)]';
+  'whitespace-nowrap border-b border-[var(--border-default)] pb-2 pl-3 text-right text-11 font-medium text-[var(--text-tertiary)]';
 const TD_CLASS =
-  'whitespace-nowrap border-b border-[var(--border-default)] py-2 text-right text-12 tabular-nums';
+  'whitespace-nowrap border-b border-[var(--border-default)] py-2 pl-3 text-right text-12 tabular-nums';
+
+/**
+ * 首列 (agent / model) 是唯一可收缩的列, 实现与 UsageTaskTable 的任务列相同:
+ * `w-full + max-w-0` 让它先塌到 0 (打破"按最长内容取列宽"的默认行为) 再领走
+ * 其余列分完后剩下的空间, 内层的 truncate 由此生效 (见 #3393 的同一段分析)。
+ * pl-3 是列间距, 否则相邻两列的数字会贴到一起; 首列自身取 pl-0。
+ */
+const FIRST_COL_CLASS = 'w-full max-w-0 pl-0';
 
 function Swatch({ rank }: { rank: number }): React.JSX.Element {
   return (
@@ -87,7 +95,9 @@ export function UsageAgentTable({ rows }: { rows: AgentTokenRow[] }): React.JSX.
       <table className="w-full border-collapse">
         <thead>
           <tr>
-            <th className={cn(TH_CLASS, 'text-left')}>{t('usageHistory.byAgent.col.agent')}</th>
+            <th className={cn(TH_CLASS, FIRST_COL_CLASS, 'text-left')}>
+              {t('usageHistory.byAgent.col.agent')}
+            </th>
             <th className={TH_CLASS}>{t('usageHistory.byAgent.col.total')}</th>
             <th className={TH_CLASS}>{t('usageHistory.byAgent.col.share')}</th>
             <th className={TH_CLASS}>{t('usageHistory.byAgent.col.today')}</th>
@@ -102,10 +112,12 @@ export function UsageAgentTable({ rows }: { rows: AgentTokenRow[] }): React.JSX.
             const rank = AGENT_RANK[row.agentKind] ?? 3;
             return (
               <tr key={row.agentKind}>
-                <td className={cn(TD_CLASS, 'text-left')}>
+                <td className={cn(TD_CLASS, FIRST_COL_CLASS, 'text-left')}>
                   <span className="flex min-w-0 items-center gap-2">
                     <Swatch rank={rank} />
-                    <span className="truncate">{row.agentKind}</span>
+                    <span className="truncate" title={row.agentKind}>
+                      {row.agentKind}
+                    </span>
                   </span>
                 </td>
                 <td className={TD_CLASS}>{formatCompactTokens(row.tokens)}</td>
@@ -131,7 +143,9 @@ export function UsageModelTable({ rows }: { rows: ModelTokenRow[] }): React.JSX.
     <table className="w-full border-collapse">
       <thead>
         <tr>
-          <th className={cn(TH_CLASS, 'text-left')}>{t('usageHistory.byModel.col.model')}</th>
+          <th className={cn(TH_CLASS, FIRST_COL_CLASS, 'text-left')}>
+            {t('usageHistory.byModel.col.model')}
+          </th>
           <th className={TH_CLASS}>{t('usageHistory.byModel.col.total')}</th>
           <th className={TH_CLASS}>{t('usageHistory.byModel.col.share')}</th>
           <th className={TH_CLASS}>{t('usageHistory.byModel.col.input')}</th>
@@ -146,10 +160,12 @@ export function UsageModelTable({ rows }: { rows: ModelTokenRow[] }): React.JSX.
       <tbody>
         {rows.map((row, index) => (
           <tr key={row.key}>
-            <td className={cn(TD_CLASS, 'text-left')}>
+            <td className={cn(TD_CLASS, FIRST_COL_CLASS, 'text-left')}>
               <span className="flex min-w-0 items-center gap-2">
                 <Swatch rank={index} />
-                <span className="truncate">{formatModelShort(row.model)}</span>
+                <span className="truncate" title={row.model}>
+                  {formatModelShort(row.model)}
+                </span>
                 {/* 同一模型 id 可能跨 agent 撞名, 标签让两行区分得开 */}
                 <span className="shrink-0 rounded border border-[var(--border-default)] px-1 py-px text-10 leading-none text-[var(--text-tertiary)]">
                   {row.agentKind}

--- a/apps/desktop/src/renderer/components/settings/usage/UsageHistorySection.tsx
+++ b/apps/desktop/src/renderer/components/settings/usage/UsageHistorySection.tsx
@@ -138,7 +138,9 @@ export function UsageHistorySection(): React.JSX.Element {
               title={t('usageHistory.byAgent.title')}
               subtitle={t('usageHistory.byAgent.subtitle')}
             >
-              <UsageAgentTable rows={agentRows} />
+              <div className="overflow-x-auto">
+                <UsageAgentTable rows={agentRows} />
+              </div>
             </Card>
           )}
 
@@ -147,7 +149,9 @@ export function UsageHistorySection(): React.JSX.Element {
               title={t('usageHistory.byModel.title')}
               subtitle={t('usageHistory.byModel.subtitle')}
             >
-              <UsageModelTable rows={modelRows} />
+              <div className="overflow-x-auto">
+                <UsageModelTable rows={modelRows} />
+              </div>
             </Card>
           )}
 
@@ -156,7 +160,9 @@ export function UsageHistorySection(): React.JSX.Element {
               title={t('usageHistory.tasks.title')}
               subtitle={t('usageHistory.tasks.subtitle')}
             >
-              <UsageTaskTable rows={taskRows} />
+              <div className="overflow-x-auto">
+                <UsageTaskTable rows={taskRows} />
+              </div>
             </Card>
           )}
         </>


### PR DESCRIPTION
## 这次改了什么

### 摘要

设置 → 用量历史里「按模型」「按 agent」两张明细表的首列（模型名 / agent 名）一长，会把整张卡片横向撑出内容区：右侧占比 / 输入 / 输出 / 缓存读 / 缓存写 / 命中率列被挤出卡片右缘并裁掉，相邻数字贴到一起。

这是 #3393 里「最耗 token 的任务」同类病的另一个落点（#3393 修的是 `UsageTaskTable`；其描述已注明"「按模型」表首列的同类问题——同一个病但另一张表，单独提"）。自定义 provider 的超长 model id 必然触发。本 PR 把 #3393 的既定修法套用到这两张表：首列加 `w-full max-w-0 pl-0` 让 `truncate` 生效（自动布局表格默认按最长 nowrap 内容算列宽，没有可收缩宽度时 truncate 失效）；模型 / agent 名补 `title` 悬停全名；其余列补 `pl-3` 列间距，避免截断生效后相邻数字贴到一起。

### 变更类型

- [ ] `feat` 新功能
- [x] `fix` 缺陷修复
- [ ] `refactor` / `perf` 重构或性能优化
- [ ] `docs` / `test` / `chore` 文档、测试或工程维护
- [ ] 其他：

### 范围

- 关联 Issue / 需求：#3445
- 本 PR 包含：`UsageBreakdownTables` 两张表首列的宽度约束与截断（与 `UsageTaskTable` 同款）、模型 / agent 名 `title` 悬停提示、其余列列间距
- 明确不包含：
  - 数据逻辑 / 聚合口径改动（`usageHistoryStats`），本表行与列语义不变；
  - `UsageTaskTable`（#3393 已修——但注意 v0.1.61 发布早于该修复，下一版才带上）；
  - 供应商列空值语义（`—` 兼表「未指定」与「无数据」）——与 #3393 同，单独提。
- 用户可见变化：超长模型 / agent 名不再撑破卡片，改为省略号截断 + 悬停显示完整模型 id / agent 名；两表各列间距与「最耗 token 的任务」对齐（0 → 12px）
- 是否存在 breaking change：无

### UI 变化

- 引用的设计规范：
  - **DESIGN.md §14.6 Icon-only Controls and Tooltips**——「Native `title` remains acceptable for truncated persistent text」。本表模型 / agent 名列是被截断的常驻文本，用 native `title` 而非 Radix `Tip` 正落在这条许可里（与 #3393 同口径）。
  - **DESIGN.md §5 Layout Principles / Spacing System**——列间距取 12px，落在 `4/6/8/10/12/14/16/20/24/32/40/48` 刻度上；同样为了把窄窗口下不可收缩的 nowrap 宽度压到最小（与 #3393 的第二笔修正同因）。
  - **DESIGN.md §8 Window & Adaptive Behavior**——主窗下限 800×600，布局随窗口收缩而重排；首列成为唯一可收缩列，其余数字列在任何窗口宽度下保持完整可读。
  - 截断口径：表头与格式化数值（`占比` / `输入` / `输出` / `缓存读` / `缓存写` / `命中率`）属产品可控文案，不参与截断；只有用户输入的模型 / agent 名会出现省略号。
  - 悬停跑马灯不引入：与 #3393 一致，DESIGN.md §14.4 例外仅登记在 `SessionItem.tsx`，不外溢。


补充说明（回应 review-pr:ui-evidence-notice & P2 thread）:「按模型 / 按 agent」表与「最耗 token 的任务」表所在 Card 内容已包 `overflow-x-auto`（commit 9ed992e7）——正常宽度 ≥430px 无滚动条、视觉与之前一致;侧栏拉满 + 主窗最小的极端 ~230px 容器下出现横向滚动条,数字列不再被裁切。下面是改动后界面的等价 HTML 演示（改后结构 + 真实超长 model id + 英文长表头,可保存为 .html 直接预览,实测 430px fit / 230px 滚动）:

```html
<!DOCTYPE html><meta charset="utf-8"><style>
.tbl{width:100%;border-collapse:collapse;white-space:nowrap;font:12px/1.4 -apple-system,"PingFang SC",sans-serif}
.tbl th{border-bottom:1px solid #eee;padding:0 0 8px 12px;text-align:right;font-size:11px;font-weight:500;color:#999}
.tbl td{border-bottom:1px solid #eee;padding:8px 0;padding-left:12px;text-align:right;font-variant-numeric:tabular-nums}
.tbl .task-col{width:100%;max-width:0;padding-left:0}
.tbl .trunc{max-width:100%;display:inline-block;vertical-align:middle;overflow:hidden;text-overflow:ellipsis;white-space:nowrap}
.tag{border:1px solid #ddd;border-radius:4px;padding:1px 4px;font-size:10px;color:#999}
.host{overflow-x:auto} /* 对应组件的 overflow-x-auto 兜底 */
</style><div style="width:460px" class="host">
<table class="tbl"><thead><tr><th class="task-col" style="text-align:left">Model</th><th>Total</th><th>Share</th><th>Input</th><th>Output</th><th>Cache Read</th><th>Cache Create</th><th>Hit Rate</th></tr></thead>
<tbody><tr><td class="task-col" style="text-align:left"><span class="trunc" title="zai-qwen3-500b-a22b-mix-232k-highreason-extended-openai-compatible-cn-shared-pool-latest">zai-qwen3-500b-a22b-mix-232k-highreason-extended-openai-compatible-cn-shared-pool-latest</span> <span class="tag">codex</span></td>
<td>123.4M</td><td>51.2%</td><td>90.1M</td><td>33.2M</td><td>12.1M</td><td>0.443M</td><td>55%</td></tr></tbody></table></div>
```
---

## 怎么验证的

### 自动验证

未执行 repo 级 test / lint（clone 后未安装 node_modules；改动仅涉及 `UsageBreakdownTables.tsx` 的 className 字符串与 `title` 属性，无逻辑路径，仓库 CI - tests 会覆盖）。改用等价类浏览器（Chrome）复现与验证，见下。

### 手工验证

用与该组件完全等价的 Tailwind 类自建 6 组对照页（修复前 / #3393 修复后 / 本 PR 修复后 × 800px / 460px），同一份真实超长 model id，Playwright 截图 + 测量表格实际宽度：

| 场景 | 卡片宽 | 表格实际宽 | 溢出 |
|---|---|---|---|
| 任务表（v0.1.61 旧结构） | 800px | 1024px | +241px（用户报告的现象即此） |
| 任务表（#3393 修复后） | 800px | 766px | 无 |
| 按模型表（修复前，main 现状） | 800px | 871px | +88px |
| 按模型表（修复前，窄窗） | 460px | 847px | +404px |
| 按模型表（本 PR 修复后） | 800px / 460px | 766px / 426px | 无 |

视觉确认：修复后首列省略号截断、agent 徽标保留、右侧数字列完整且读数清晰；修复前数字列被挤出卡片右缘裁掉。

### 未执行的验证

- 未跑 `pnpm test` / `pnpm lint` / `pnpm check:dco`（本机未装 repo 依赖与 pnpm store；DCO 已通过 `git commit -s` 满足）。请 CI 在校验时补齐。


## 风险

### 风险分类

- [x] 无已知风险
- [ ] SQLite / migration
- [ ] system prompt
- [ ] 协议兼容
- [ ] 权限 / 安全 / 用户数据
- [ ] 存量插件兼容（批准状态 / 指纹 / manifest 校验 / 安装布局 / 包格式）
- [ ] 原生层 / fingerprint / OTA
- [ ] 跨平台差异
- [ ] 其他：

### 影响与回滚

- 影响范围：仅设置 → 用量历史页三张表（按 agent / 按模型 / 最耗 token 的任务）的**布局容器**——每个 Card 内容包一层 `overflow-x-auto`；无数据、聚合、i18n 变更。
  - 已有用量历史表：正常宽度（≥430px）下无滚动条、视觉与之前一致（字体、间距、配色、行高均未动）；本 PR 原修复（首列收缩 + 截断 + title）只影响超长名称的行。
  - 窄窗口截断：窗口/侧栏组合把容器压到极窄（约 230px）时出现横向滚动条，数字列仍完整可读，不再被卡片右缘裁掉——这一点是本次 P2 评审后新增的行为，此前是裁切。
  - title 提示：仅新增 native title（模型列为原始 model id、agent 列为 agentKind），悬停可读全名；不改变默认选中态、键盘与触屏操作（title 不出现在触摸序列）。
  - 无迁移、无协议、无插件、无原生层影响；Mac/Windows/Linux 三平台 CI 单测已全绿，CSS 行为跨平台一致。
- 回滚 / 降级方式：revert 本 PR 即可（两个 commit 均为独立可逆的类名/单个包装层改动），或删除 `UsageHistorySection.tsx` 的三个 `<div className="overflow-x-auto">` 包装层；无 DB、配置或发行资产跟随。

### 提交前检查

- [x] 已 review 完整 diff
- [x] 每个 commit 都带 DCO 签名（`git commit -s`，见 DCO）
- [x] UI 改动已在「UI 变化」注明引用的设计规范章节（不涉及 UI 则跳过）
- [x] 未提交凭证、令牌或授权文件
- [x] 已补充必要文档（无新增文档需求；本改动与 #3393 同口径，其 PR 描述即行为规范记录，无独立文档可补）
- [x] 已确认测试结果或说明未执行原因
