### PR TITLE
feat(mobile): 支持 CindyDev 运行时切换 Dev 与 Release 服务器

### DIFF
--- a/apps/mobile/.env.example
+++ b/apps/mobile/.env.example
@@ -30,6 +30,9 @@ EXPO_PUBLIC_XDT_MOBILE_VOICE_LITELLM_BASE_URL=
 #   EXPO_PUBLIC_APP_VARIANT             构建变体标识(beta/prod/自建)
 #   EXPO_PUBLIC_BETA_DEV                beta 开发模式门控
 #   EXPO_PUBLIC_XDT_OTA_SELFHOST        是否自建变体(=1)
+#   EXPO_PUBLIC_CINDY_DEV_RELEASE_ENDPOINT_MANIFEST_BASE_URL
+#                                        CindyDev 运行时切换用的 CN Release 清单基址；由构建 helper
+#                                        从 config/endpoint.json 派生，不要在本地 .env 手填
 #   EXPO_PUBLIC_DESKTOP_VERSION         自建线配对的桌面产品线版本号
 #   EXPO_PUBLIC_XDT_GIT_BRANCH          构建注入的 git 分支(调试展示)
 #   EXPO_PUBLIC_XDT_GIT_COMMIT          构建注入的 git commit(调试展示)

--- a/apps/mobile/app.config.js
+++ b/apps/mobile/app.config.js
@@ -221,6 +221,15 @@ module.exports = (context = {}) => {
   for (const [key, value] of Object.entries(mobileBundleEnv)) {
     if (!process.env[key]?.trim()) process.env[key] = value;
   }
+  // 该值只允许由 CindyDev 构建从仓内 CN 清单派生。Dev 构建覆盖 runner
+  // 残留值，CN / Global 构建主动清除，确保正式包不会误烘焙 Dev-only 配置。
+  if (region === 'dev') {
+    process.env.EXPO_PUBLIC_CINDY_DEV_RELEASE_ENDPOINT_MANIFEST_BASE_URL =
+      mobileBundleEnv.EXPO_PUBLIC_CINDY_DEV_RELEASE_ENDPOINT_MANIFEST_BASE_URL;
+  } else {
+    delete process.env
+      .EXPO_PUBLIC_CINDY_DEV_RELEASE_ENDPOINT_MANIFEST_BASE_URL;
+  }
   // xdtProductionEnv 是既有 Expo config / runtime fingerprint 的一部分。对端清单
   // 基址只需通过上面的 EXPO_PUBLIC_* 环境变量进入 Metro bundle；不要把它追加到
   // extra，否则本次纯 JS 登录路由会无意要求一次冷构建，并切断旧 runtime 的 OTA 链。

--- a/apps/mobile/app.config.js
+++ b/apps/mobile/app.config.js
@@ -113,11 +113,10 @@ function resolveMobileBuildEnv() {
   return loadMobileClientBuildEnv();
 }
 
-function resolvePeerManifestBaseUrl(region) {
+function resolveManifestBaseUrl(region) {
   const previousRegion = process.env.EXPO_PUBLIC_CINDY_AUTH_REGION;
   try {
-    process.env.EXPO_PUBLIC_CINDY_AUTH_REGION =
-      region === 'global' ? 'cn' : 'global';
+    process.env.EXPO_PUBLIC_CINDY_AUTH_REGION = region;
     const peerBuildEnv = loadMobileClientBuildEnv();
     return peerBuildEnv.EXPO_PUBLIC_ENDPOINT_MANIFEST_BASE_URL;
   } finally {
@@ -127,6 +126,10 @@ function resolvePeerManifestBaseUrl(region) {
       process.env.EXPO_PUBLIC_CINDY_AUTH_REGION = previousRegion;
     }
   }
+}
+
+function resolvePeerManifestBaseUrl(region) {
+  return resolveManifestBaseUrl(region === 'global' ? 'cn' : 'global');
 }
 
 const REGION_CONFIG = {
@@ -206,6 +209,14 @@ module.exports = (context = {}) => {
     ...mobileBuildEnv,
     EXPO_PUBLIC_ENDPOINT_MANIFEST_PEER_BASE_URL:
       resolvePeerManifestBaseUrl(region),
+    // CindyDev 的业务服务器切换只需把 CN Release 的可信清单基址内联进 JS。
+    // 不写入 extra / resolved ExpoConfig，避免让纯 JS 开发功能改变 runtime fingerprint。
+    ...(region === 'dev'
+      ? {
+          EXPO_PUBLIC_CINDY_DEV_RELEASE_ENDPOINT_MANIFEST_BASE_URL:
+            resolveManifestBaseUrl('cn'),
+        }
+      : {}),
   };
   for (const [key, value] of Object.entries(mobileBundleEnv)) {
     if (!process.env[key]?.trim()) process.env[key] = value;

--- a/apps/mobile/app/_layout.tsx
+++ b/apps/mobile/app/_layout.tsx
@@ -379,8 +379,14 @@ function RootLayout() {
             '{reason}',
             endpointGate.reason ?? 'unknown',
           )}
-          actionLabel={loginText('retry')}
-          onAction={endpointGate.retry}
+          actionLabel={loginText(
+            endpointGate.canResetToDev ? 'endpointGateResetToDev' : 'retry',
+          )}
+          onAction={
+            endpointGate.canResetToDev
+              ? endpointGate.resetToDev
+              : endpointGate.retry
+          }
         />
       </MobileLoginHandoffStage>
     );
@@ -429,7 +435,7 @@ function RootLayout() {
  * 品牌视觉由 MobileLoginHandoffStage 宿主拥有,本层背景透明、内容沉到下半屏
  * (避开品牌三要素),仅承载标题/说明/唯一动作。端点闸门与强更闸门共用本层
  * ——阻断语义一致:没有"跳过 / 稍后再说",只有一个出口。端点错误屏的文案 key 化
- * 契约不变(endpointGateTitle / endpointGateSubtitle{reason} / retry)。
+ * Release 覆盖失败时唯一动作改为返回 Dev；其它失败仍为 retry。
  */
 function StartupGateBlockedContent({
   title,

--- a/apps/mobile/app/settings.tsx
+++ b/apps/mobile/app/settings.tsx
@@ -563,34 +563,28 @@ export default function SettingsScreen() {
       ) {
         return;
       }
+      const reload = __DEV__
+        ? () => DevSettings.reload()
+        : Updates.isEnabled
+          ? () => Updates.reloadAsync()
+          : null;
+      if (!reload) {
+        Alert.alert(
+          t('settings.devServerEnvironment.title'),
+          t('settings.devServerEnvironment.switchFailed'),
+        );
+        return;
+      }
       setDevServerEnvironmentBusy(true);
       try {
         // 旧环境的 push 注销、token 与账号缓存必须先在旧端点仍生效时清理。
         await auth.logout();
-        if (__DEV__) {
-          await switchDevServerEnvironmentAndReload({
-            current: devServerEnvironment,
-            next,
-            reload: () => DevSettings.reload(),
-            setEnvironment: setDevServerEnvironment,
-          });
-          return;
-        }
-        if (Updates.isEnabled) {
-          await switchDevServerEnvironmentAndReload({
-            current: devServerEnvironment,
-            next,
-            reload: () => Updates.reloadAsync(),
-            setEnvironment: setDevServerEnvironment,
-          });
-          return;
-        }
-        await setDevServerEnvironment(next);
-        router.replace('/login');
-        Alert.alert(
-          t('settings.devServerEnvironment.title'),
-          t('settings.devServerEnvironment.restartRequired'),
-        );
+        await switchDevServerEnvironmentAndReload({
+          current: devServerEnvironment,
+          next,
+          reload,
+          setEnvironment: setDevServerEnvironment,
+        });
       } catch {
         Alert.alert(
           t('settings.devServerEnvironment.title'),
@@ -605,7 +599,6 @@ export default function SettingsScreen() {
       devServerEnvironment,
       devServerEnvironmentBusy,
       devServerEnvironmentReady,
-      router,
       setDevServerEnvironment,
       t,
     ],

--- a/apps/mobile/app/settings.tsx
+++ b/apps/mobile/app/settings.tsx
@@ -6,6 +6,7 @@ import { useRouter } from 'expo-router';
 import { Children, Fragment, isValidElement, useCallback, useEffect, useMemo, useRef, useState, type ReactNode } from 'react';
 import {
   Alert,
+  DevSettings,
   FlatList,
   Image,
   Linking,
@@ -53,6 +54,11 @@ import {
   IS_TESTFLIGHT_BUILD,
   REVIEW_MODE,
 } from '@/config/env';
+import {
+  DEV_SERVER_ENVIRONMENT_SWITCH_ENABLED,
+  type DevServerEnvironment,
+} from '@/config/devServerEnvironment';
+import { useDevServerEnvironment } from '@/config/useDevServerEnvironment';
 import { LEGAL_LINKS } from '@/config/legalLinks';
 import { useDeviceLink } from '@/device-link/DeviceLinkContext';
 import { buildMobileDeviceName } from '@/device-link/mobileDeviceIdentity';
@@ -148,6 +154,13 @@ export default function SettingsScreen() {
   const { enabled: betaEnabled, ready: betaReady, setEnabled: setBetaEnabled } = useBetaChannel();
   const [betaBusy, setBetaBusy] = useState(false);
   const showBetaBadge = betaReady && betaEnabled;
+  const {
+    environment: devServerEnvironment,
+    ready: devServerEnvironmentReady,
+    setEnvironment: setDevServerEnvironment,
+  } = useDevServerEnvironment();
+  const [devServerEnvironmentBusy, setDevServerEnvironmentBusy] =
+    useState(false);
   const updateCheckInFlightRef = useRef(false);
   // 语音词典:手机只读展示被控桌面的词典快照(正本在桌面,手机不参与合并)。
   const [dictionaryScreenOpen, setDictionaryScreenOpen] = useState(false);
@@ -538,6 +551,86 @@ export default function SettingsScreen() {
       setLoggingOut(false);
     }
   }, [auth, loggingOut, router]);
+
+  const switchDevServerEnvironment = useCallback(
+    async (next: DevServerEnvironment) => {
+      if (
+        !DEV_SERVER_ENVIRONMENT_SWITCH_ENABLED ||
+        devServerEnvironmentBusy ||
+        !devServerEnvironmentReady ||
+        next === devServerEnvironment
+      ) {
+        return;
+      }
+      setDevServerEnvironmentBusy(true);
+      try {
+        // 旧环境的 push 注销、token 与账号缓存必须先在旧端点仍生效时清理。
+        await auth.logout();
+        await setDevServerEnvironment(next);
+        if (__DEV__) {
+          DevSettings.reload();
+          return;
+        }
+        if (Updates.isEnabled) {
+          await Updates.reloadAsync();
+          return;
+        }
+        router.replace('/login');
+        Alert.alert(
+          t('settings.devServerEnvironment.title'),
+          t('settings.devServerEnvironment.restartRequired'),
+        );
+      } catch {
+        Alert.alert(
+          t('settings.devServerEnvironment.title'),
+          t('settings.devServerEnvironment.switchFailed'),
+        );
+      } finally {
+        setDevServerEnvironmentBusy(false);
+      }
+    },
+    [
+      auth,
+      devServerEnvironment,
+      devServerEnvironmentBusy,
+      devServerEnvironmentReady,
+      router,
+      setDevServerEnvironment,
+      t,
+    ],
+  );
+
+  const confirmDevServerEnvironmentSwitch = useCallback(() => {
+    if (
+      !DEV_SERVER_ENVIRONMENT_SWITCH_ENABLED ||
+      devServerEnvironmentBusy ||
+      !devServerEnvironmentReady
+    ) {
+      return;
+    }
+    const next: DevServerEnvironment =
+      devServerEnvironment === 'dev' ? 'release' : 'dev';
+    Alert.alert(
+      t('settings.devServerEnvironment.confirmTitle', {
+        environment: t(`settings.devServerEnvironment.options.${next}`),
+      }),
+      t('settings.devServerEnvironment.confirmBody'),
+      [
+        { text: t('settings.devServerEnvironment.cancel'), style: 'cancel' },
+        {
+          text: t('settings.devServerEnvironment.switchAction'),
+          style: 'destructive',
+          onPress: () => void switchDevServerEnvironment(next),
+        },
+      ],
+    );
+  }, [
+    devServerEnvironment,
+    devServerEnvironmentBusy,
+    devServerEnvironmentReady,
+    switchDevServerEnvironment,
+    t,
+  ]);
 
   const openAccountDeletion = useCallback(() => {
     router.push('/account-deletion');
@@ -1007,6 +1100,25 @@ export default function SettingsScreen() {
           >
             {debugExpanded
               ? [
+                ...(DEV_SERVER_ENVIRONMENT_SWITCH_ENABLED
+                  ? [
+                      <ActionInfoRow
+                        accessibilityLabel={t('settings.devServerEnvironment.accessibility')}
+                        detail={t('settings.devServerEnvironment.description')}
+                        key="dev-server-environment"
+                        label={t('settings.devServerEnvironment.title')}
+                        onPress={confirmDevServerEnvironmentSwitch}
+                        testID="settings.devServerEnvironment"
+                        value={
+                          devServerEnvironmentBusy
+                            ? t('settings.devServerEnvironment.switching')
+                            : t(
+                                `settings.devServerEnvironment.options.${devServerEnvironment}`,
+                              )
+                        }
+                      />,
+                    ]
+                  : []),
                 ...debugSection.rows.map((row) => (
                   row.copyValue ? (
                     <CopyRow copied={copiedRowId === row.id} key={row.id} onCopy={copyRow} row={row} />

--- a/apps/mobile/app/settings.tsx
+++ b/apps/mobile/app/settings.tsx
@@ -56,6 +56,7 @@ import {
 } from '@/config/env';
 import {
   DEV_SERVER_ENVIRONMENT_SWITCH_ENABLED,
+  switchDevServerEnvironmentAndReload,
   type DevServerEnvironment,
 } from '@/config/devServerEnvironment';
 import { useDevServerEnvironment } from '@/config/useDevServerEnvironment';
@@ -566,15 +567,25 @@ export default function SettingsScreen() {
       try {
         // 旧环境的 push 注销、token 与账号缓存必须先在旧端点仍生效时清理。
         await auth.logout();
-        await setDevServerEnvironment(next);
         if (__DEV__) {
-          DevSettings.reload();
+          await switchDevServerEnvironmentAndReload({
+            current: devServerEnvironment,
+            next,
+            reload: () => DevSettings.reload(),
+            setEnvironment: setDevServerEnvironment,
+          });
           return;
         }
         if (Updates.isEnabled) {
-          await Updates.reloadAsync();
+          await switchDevServerEnvironmentAndReload({
+            current: devServerEnvironment,
+            next,
+            reload: () => Updates.reloadAsync(),
+            setEnvironment: setDevServerEnvironment,
+          });
           return;
         }
+        await setDevServerEnvironment(next);
         router.replace('/login');
         Alert.alert(
           t('settings.devServerEnvironment.title'),

--- a/apps/mobile/scripts/build-android.mjs
+++ b/apps/mobile/scripts/build-android.mjs
@@ -90,6 +90,47 @@ const NPX = process.platform === 'win32' ? 'npx.cmd' : 'npx';
 
 function log(msg) { console.error(msg); }
 
+const ANDROID_BUILD_FAILURE_STAGE = Object.freeze({
+  arguments: 'arguments',
+  regionConfig: 'region-config',
+  buildPlan: 'build-plan',
+  preflight: 'preflight',
+  toolchain: 'toolchain',
+  artifactValidation: 'artifact-validation',
+  output: 'output',
+});
+
+let androidBuildFailureStage = ANDROID_BUILD_FAILURE_STAGE.arguments;
+
+// 只按脚本控制的阶段输出固定诊断，不打印异常消息或环境变量值。
+function reportAndroidBuildFailure() {
+  switch (androidBuildFailureStage) {
+    case ANDROID_BUILD_FAILURE_STAGE.arguments:
+      console.error('Android 构建失败（参数检查）：请确认已传 --region cn|global|dev，且 --artifacts、--version-code 等参数合法。');
+      break;
+    case ANDROID_BUILD_FAILURE_STAGE.regionConfig:
+      console.error('Android 构建失败（区域配置）：请检查 apps/mobile/scripts/self-host-regions.json 及对应 endpoint 配置是否存在且有效。');
+      break;
+    case ANDROID_BUILD_FAILURE_STAGE.buildPlan:
+      console.error('Android 构建失败（构建计划）：请检查 apps/mobile/app.json、android-version.json 与区域产物配置。');
+      break;
+    case ANDROID_BUILD_FAILURE_STAGE.preflight:
+      console.error('Android 构建失败（构建前检查）：请检查 Git 门禁、签名配置、JDK 17+ 与必需的 EXPO_PUBLIC_* 配置。');
+      break;
+    case ANDROID_BUILD_FAILURE_STAGE.toolchain:
+      console.error('Android 构建失败（工具链）：请查看上方 Expo/Gradle 输出；若无输出，请检查 npx、JDK 17+、Android SDK 与 Gradle wrapper。');
+      break;
+    case ANDROID_BUILD_FAILURE_STAGE.artifactValidation:
+      console.error('Android 构建失败（产物校验）：请检查 APK/AAB 路径、包名、versionCode、runtimeVersion 与签名证书配置。');
+      break;
+    case ANDROID_BUILD_FAILURE_STAGE.output:
+      console.error('Android 构建失败（复制产物）：请检查 --out 目录权限与磁盘空间。');
+      break;
+    default:
+      console.error('Android 构建失败；未能确定失败阶段。');
+  }
+}
+
 // self-host 变体的构建环境(与原发布线同源),注入 versionCode。
 function selfhostEnv(region, versionCode, desktopVersion) {
   const env = {
@@ -321,6 +362,7 @@ function validateAabSignature(aabPath, javaEnv, expectedCertificateSha256) {
 }
 
 async function main() {
+  androidBuildFailureStage = ANDROID_BUILD_FAILURE_STAGE.arguments;
   const args = parseArgs(process.argv.slice(2));
   // --region 必填(cn|global|dev):选出本次出包身份 + 签名配置(见 lib/self-host-region.mjs)。
   // 不走 resolveSelfHostRegion:它对 dev 强校验发布专用的 npkgExpectBundle,与纯构建
@@ -334,10 +376,12 @@ async function main() {
   if (!SELF_HOST_REGIONS.includes(rawRegion)) {
     throw new Error(`--region 只能是 ${SELF_HOST_REGIONS.join(' 或 ')},收到: ${rawRegion}`);
   }
+  androidBuildFailureStage = ANDROID_BUILD_FAILURE_STAGE.regionConfig;
   const region = loadSelfHostRegions({ mode: 'local' })[rawRegion];
   if (!region.androidPackage?.trim()) {
     throw new Error(`self-host-regions.json 的 ${region.authRegion}.androidPackage 未填(构建必需)`);
   }
+  androidBuildFailureStage = ANDROID_BUILD_FAILURE_STAGE.buildPlan;
   const artifactKinds = resolveAndroidArtifactKinds(region.authRegion, args.artifacts);
   const appJson = readAppJson();
   const version = appJson?.expo?.version ?? '';
@@ -359,6 +403,7 @@ async function main() {
   // git 闸门只管真构建:dry-run 纯本地(不做 origin/main 远端比对,分支/离线可跑)。
   let expectedUploadCertificateSha256 = null;
   if (args.execute) {
+    androidBuildFailureStage = ANDROID_BUILD_FAILURE_STAGE.preflight;
     if (!args.skipGitGate) assertProductionGitGate();
     else log('  warn: --skip-git-gate,跳过 main/clean/HEAD 校验(仅本地迭代用)');
     if (missingBake.length) {
@@ -409,12 +454,15 @@ async function main() {
     return;
   }
 
+  androidBuildFailureStage = ANDROID_BUILD_FAILURE_STAGE.preflight;
   // region / endpoint manifest 自举基址必须齐全(读仓内 config/endpoint*.json,离线可用)。
   assertPublicEnv(env, { variant: 'production', requiredKeys: SELF_HOST_PUBLIC_ENV_KEYS });
 
+  androidBuildFailureStage = ANDROID_BUILD_FAILURE_STAGE.toolchain;
   const built = buildAndroidArtifacts(env, region, artifactKinds);
   for (const kind of artifactKinds) log(`  ✓ ${kind}: ${built.artifacts[kind]}`);
 
+  androidBuildFailureStage = ANDROID_BUILD_FAILURE_STAGE.artifactValidation;
   // 权威 runtimeVersion 始终从真正烤进产物的 fingerprint 回读。双产物必须一致,
   // 否则同一个 versionCode 会出现两条不兼容 OTA runtime,直接中止。
   const runtimeVersions = {};
@@ -447,6 +495,7 @@ async function main() {
 
   const finalArtifacts = { ...built.artifacts };
   if (typeof args.out === 'string' && args.out) {
+    androidBuildFailureStage = ANDROID_BUILD_FAILURE_STAGE.output;
     const outDir = resolve(String(args.out));
     if (!existsSync(outDir)) mkdirSync(outDir, { recursive: true });
     for (const kind of artifactKinds) {
@@ -469,7 +518,6 @@ async function main() {
 }
 
 main().catch(() => {
-  // 子进程已继承 stdout/stderr；这里只输出固定提示，避免异常消息夹带签名口令等 env 值。
-  console.error('Android 构建失败；详细原因请查看上方构建工具输出。');
+  reportAndroidBuildFailure();
   process.exit(1);
 });

--- a/apps/mobile/scripts/build-android.mjs
+++ b/apps/mobile/scripts/build-android.mjs
@@ -79,7 +79,10 @@ import {
   readEmbeddedRuntimeVersionFromAab,
   readEmbeddedRuntimeVersionFromApk,
 } from './lib/embedded-runtime.mjs';
-import { mobileClientBundleEnv } from '../../../scripts/shared/client-endpoint-build-env.mjs';
+import {
+  mobileClientBundleEnv,
+  mobileClientBundleProcessEnv,
+} from '../../../scripts/shared/client-endpoint-build-env.mjs';
 import { SELF_HOST_REGIONS, loadSelfHostRegions, missingSelfHostBakeFields, stripSelfHostRegionEnv } from './lib/self-host-region.mjs';
 
 const MOBILE_DIR = resolve(dirname(fileURLToPath(import.meta.url)), '..');
@@ -90,8 +93,7 @@ function log(msg) { console.error(msg); }
 // self-host 变体的构建环境(与原发布线同源),注入 versionCode。
 function selfhostEnv(region, versionCode, desktopVersion) {
   const env = {
-    ...process.env,
-    ...mobileClientBundleEnv({ authRegion: region.authRegion }),
+    ...mobileClientBundleProcessEnv({ authRegion: region.authRegion }),
     EXPO_PUBLIC_XDT_OTA_SELFHOST: '1',
     XDT_ANDROID_VERSION_CODE: String(versionCode),
   };

--- a/apps/mobile/scripts/build-android.mjs
+++ b/apps/mobile/scripts/build-android.mjs
@@ -468,23 +468,8 @@ async function main() {
   console.log('==========================================================');
 }
 
-// 兜底脱敏:错误文案若意外携带签名口令等秘密类 env 值,输出前抹掉。
-// 用 IIFE 构建正则——RegExp 对象切断 CodeQL 对 env 值的 taint 追踪链。
-const _secretScrubRe = (() => {
-  const pats = [];
-  for (const [name, value] of Object.entries(process.env)) {
-    if (!value || value.length < 6 || value.length > 512 || value.includes("\n")) continue;
-    if (/(password|passwd|secret|token|api[_-]?key|credential|private)/i.test(name)) {
-      pats.push(value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&'));
-    }
-  }
-  pats.sort((a, b) => b.length - a.length);
-  return pats.length > 0 ? new RegExp(pats.join('|'), 'g') : null;
-})();
-
-function scrubSecretsFromText(text) {
-  const s = String(text ?? '');
-  return _secretScrubRe ? s.replace(_secretScrubRe, '***') : s;
-}
-
-main().catch((err) => { console.error(scrubSecretsFromText(err?.message)); process.exit(1); }); // lgtm[js/clear-text-logging]
+main().catch(() => {
+  // 子进程已继承 stdout/stderr；这里只输出固定提示，避免异常消息夹带签名口令等 env 值。
+  console.error('Android 构建失败；详细原因请查看上方构建工具输出。');
+  process.exit(1);
+});

--- a/apps/mobile/scripts/build-ios.mjs
+++ b/apps/mobile/scripts/build-ios.mjs
@@ -62,7 +62,10 @@ import {
 import { buildExportOptionsPlist, resolveIosSigningEnv } from './lib/ios-local.mjs';
 import { clearBundlerCache } from './lib/bundler-cache.mjs';
 import { readEmbeddedRuntimeVersionFromIpa } from './lib/embedded-runtime.mjs';
-import { mobileClientBundleEnv } from '../../../scripts/shared/client-endpoint-build-env.mjs';
+import {
+  mobileClientBundleEnv,
+  mobileClientBundleProcessEnv,
+} from '../../../scripts/shared/client-endpoint-build-env.mjs';
 import { SELF_HOST_REGIONS, loadSelfHostRegions, missingSelfHostBakeFields, stripSelfHostRegionEnv } from './lib/self-host-region.mjs';
 
 const MOBILE_DIR = resolve(dirname(fileURLToPath(import.meta.url)), '..');
@@ -73,8 +76,7 @@ function log(msg) { console.error(msg); }
 // self-host 变体的构建环境(与原发布线同源:prebuild/fingerprint 与安装包一致)。
 function selfhostEnv(region, desktopVersion) {
   const env = {
-    ...process.env,
-    ...mobileClientBundleEnv({ authRegion: region.authRegion }),
+    ...mobileClientBundleProcessEnv({ authRegion: region.authRegion }),
     EXPO_PUBLIC_XDT_OTA_SELFHOST: '1',
   };
   // 防止本机 shell / 旧 .env 残留变量混入构建;真实地址只认 config/endpoint*.json。

--- a/apps/mobile/scripts/build-ios.mjs
+++ b/apps/mobile/scripts/build-ios.mjs
@@ -268,23 +268,8 @@ async function main() {
   console.log('======================================================');
 }
 
-// 兜底脱敏:错误文案若意外携带签名/证书口令等秘密类 env 值,输出前抹掉。
-// 用 IIFE 构建正则——RegExp 对象切断 CodeQL 对 env 值的 taint 追踪链。
-const _secretScrubRe = (() => {
-  const pats = [];
-  for (const [name, value] of Object.entries(process.env)) {
-    if (!value || value.length < 6 || value.length > 512 || value.includes("\n")) continue;
-    if (/(password|passwd|secret|token|api[_-]?key|credential|private)/i.test(name)) {
-      pats.push(value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&'));
-    }
-  }
-  pats.sort((a, b) => b.length - a.length);
-  return pats.length > 0 ? new RegExp(pats.join('|'), 'g') : null;
-})();
-
-function scrubSecretsFromText(text) {
-  const s = String(text ?? '');
-  return _secretScrubRe ? s.replace(_secretScrubRe, '***') : s;
-}
-
-main().catch((err) => { console.error(scrubSecretsFromText(err?.message)); process.exit(1); }); // lgtm[js/clear-text-logging]
+main().catch(() => {
+  // 子进程已继承 stdout/stderr；这里只输出固定提示，避免异常消息夹带签名/证书 env 值。
+  console.error('iOS 构建失败；详细原因请查看上方构建工具输出。');
+  process.exit(1);
+});

--- a/apps/mobile/scripts/build-ios.mjs
+++ b/apps/mobile/scripts/build-ios.mjs
@@ -73,6 +73,47 @@ const NPX = process.platform === 'win32' ? 'npx.cmd' : 'npx';
 
 function log(msg) { console.error(msg); }
 
+const IOS_BUILD_FAILURE_STAGE = Object.freeze({
+  arguments: 'arguments',
+  regionConfig: 'region-config',
+  buildPlan: 'build-plan',
+  preflight: 'preflight',
+  toolchain: 'toolchain',
+  artifactValidation: 'artifact-validation',
+  output: 'output',
+});
+
+let iosBuildFailureStage = IOS_BUILD_FAILURE_STAGE.arguments;
+
+// 只按脚本控制的阶段输出固定诊断，不打印异常消息或环境变量值。
+function reportIosBuildFailure() {
+  switch (iosBuildFailureStage) {
+    case IOS_BUILD_FAILURE_STAGE.arguments:
+      console.error('iOS 构建失败（参数检查）：请确认已传 --region cn|global|dev，且其它参数合法。');
+      break;
+    case IOS_BUILD_FAILURE_STAGE.regionConfig:
+      console.error('iOS 构建失败（区域配置）：请检查 apps/mobile/scripts/self-host-regions.json 及对应 endpoint 配置是否存在且有效。');
+      break;
+    case IOS_BUILD_FAILURE_STAGE.buildPlan:
+      console.error('iOS 构建失败（构建计划）：请检查 apps/mobile/app.json 与区域产物配置。');
+      break;
+    case IOS_BUILD_FAILURE_STAGE.preflight:
+      console.error('iOS 构建失败（构建前检查）：请检查 Git 门禁、签名描述符、macOS/Xcode 与必需的 EXPO_PUBLIC_* 配置。');
+      break;
+    case IOS_BUILD_FAILURE_STAGE.toolchain:
+      console.error('iOS 构建失败（工具链）：请查看上方 Expo/CocoaPods/Xcode 输出；若无输出，请检查 npx、CocoaPods、Xcode 与本机签名材料。');
+      break;
+    case IOS_BUILD_FAILURE_STAGE.artifactValidation:
+      console.error('iOS 构建失败（产物校验）：请检查 IPA 路径与内嵌 runtimeVersion。');
+      break;
+    case IOS_BUILD_FAILURE_STAGE.output:
+      console.error('iOS 构建失败（复制产物）：请检查 --out 目录权限与磁盘空间。');
+      break;
+    default:
+      console.error('iOS 构建失败；未能确定失败阶段。');
+  }
+}
+
 // self-host 变体的构建环境(与原发布线同源:prebuild/fingerprint 与安装包一致)。
 function selfhostEnv(region, desktopVersion) {
   const env = {
@@ -175,6 +216,7 @@ function buildIpa(env, region) {
 }
 
 async function main() {
+  iosBuildFailureStage = IOS_BUILD_FAILURE_STAGE.arguments;
   const args = parseArgs(process.argv.slice(2));
   // --region 必填(cn|global|dev):选出本次出包身份 + 签名描述符(见 lib/self-host-region.mjs)。
   // 不走 resolveSelfHostRegion:它对 dev 强校验发布专用的 npkgExpectBundle,与纯构建
@@ -188,10 +230,12 @@ async function main() {
   if (!SELF_HOST_REGIONS.includes(rawRegion)) {
     throw new Error(`--region 只能是 ${SELF_HOST_REGIONS.join(' 或 ')},收到: ${rawRegion}`);
   }
+  iosBuildFailureStage = IOS_BUILD_FAILURE_STAGE.regionConfig;
   const region = loadSelfHostRegions({ mode: 'local' })[rawRegion];
   if (!region.iosBundleId?.trim()) {
     throw new Error(`self-host-regions.json 的 ${region.authRegion}.iosBundleId 未填(构建必需)`);
   }
+  iosBuildFailureStage = IOS_BUILD_FAILURE_STAGE.buildPlan;
   const desktopVersion = typeof args.desktopVersion === 'string' ? args.desktopVersion : '';
   const env = selfhostEnv(region, desktopVersion);
   const appJson = readAppJson();
@@ -204,6 +248,7 @@ async function main() {
 
   // git 闸门只管真构建:dry-run 纯本地(不做 origin/main 远端比对,分支/离线可跑)。
   if (args.execute) {
+    iosBuildFailureStage = IOS_BUILD_FAILURE_STAGE.preflight;
     if (!args.skipGitGate) assertProductionGitGate();
     else log('  warn: --skip-git-gate,跳过 main/clean/HEAD 校验(仅本地迭代用)');
     if (missingBake.length) {
@@ -239,20 +284,24 @@ async function main() {
     return;
   }
 
+  iosBuildFailureStage = IOS_BUILD_FAILURE_STAGE.preflight;
   if (process.platform !== 'darwin') throw new Error('--execute 需在 macOS 上运行(xcodebuild)');
 
   // region / endpoint manifest 自举基址必须齐全(读仓内 config/endpoint*.json,离线可用)。
   assertPublicEnv(env, { variant: 'production', requiredKeys: SELF_HOST_PUBLIC_ENV_KEYS });
 
+  iosBuildFailureStage = IOS_BUILD_FAILURE_STAGE.toolchain;
   const ipaPath = buildIpa(env, region);
   log(`  ✓ ipa: ${ipaPath}`);
 
+  iosBuildFailureStage = IOS_BUILD_FAILURE_STAGE.artifactValidation;
   // 权威 runtimeVersion = 真正烤进 .ipa 的 EXUpdates.bundle/fingerprint(仅报告,供发布侧比对)。
   const runtimeVersion = readEmbeddedRuntimeVersionFromIpa(ipaPath);
   log(`  ✓ runtimeVersion(读自 .ipa 内嵌 fingerprint): ${runtimeVersion}`);
 
   let finalPath = ipaPath;
   if (typeof args.out === 'string' && args.out) {
+    iosBuildFailureStage = IOS_BUILD_FAILURE_STAGE.output;
     const outDir = resolve(String(args.out));
     if (!existsSync(outDir)) mkdirSync(outDir, { recursive: true });
     finalPath = join(outDir, basename(ipaPath));
@@ -269,7 +318,6 @@ async function main() {
 }
 
 main().catch(() => {
-  // 子进程已继承 stdout/stderr；这里只输出固定提示，避免异常消息夹带签名/证书 env 值。
-  console.error('iOS 构建失败；详细原因请查看上方构建工具输出。');
+  reportIosBuildFailure();
   process.exit(1);
 });

--- a/apps/mobile/src/__tests__/clientEndpointStartup.test.ts
+++ b/apps/mobile/src/__tests__/clientEndpointStartup.test.ts
@@ -97,6 +97,95 @@ describe('runStartupEndpointResolve(CDN 解析)', () => {
     ).resolves.toEqual({ ok: true, source: 'cdn' });
   });
 
+  it('可从指定的第二个可信清单基址拉取端点', async () => {
+    const { startup } = await freshModules();
+    const fetchSpy = vi.spyOn(globalThis, 'fetch').mockResolvedValue({
+      ok: true,
+      text: async () => FULL_MANIFEST,
+    } as Response);
+    try {
+      await expect(
+        startup.runStartupEndpointResolve({
+          autoRetryDelaysMs: [],
+          manifestBaseUrl: 'https://release-manifest.example/app',
+        }),
+      ).resolves.toEqual({ ok: true, source: 'cdn' });
+      expect(fetchSpy).toHaveBeenCalledWith(
+        expect.stringMatching(
+          /^https:\/\/release-manifest\.example\/app\/endpoint\.json\?t=\d+$/,
+        ),
+        expect.objectContaining({ signal: expect.any(AbortSignal) }),
+      );
+    } finally {
+      fetchSpy.mockRestore();
+    }
+  });
+
+  it('第二份清单按显式目标区域校验，不受安装包默认区域限制', async () => {
+    const { startup } = await freshModules();
+    const apply = vi.fn();
+
+    await expect(
+      startup.runStartupEndpointResolve({
+        apply,
+        expectedRegion: 'global',
+        fetchManifest: okFetch(
+          JSON.stringify({ ...FULL_MANIFEST_OBJECT, region: 'global' }),
+        ),
+      }),
+    ).resolves.toEqual({ ok: true, source: 'cdn' });
+    expect(apply).toHaveBeenCalledTimes(1);
+  });
+
+  it('切换业务服务器时保留 CindyDev 的 OTA 与审核元数据', async () => {
+    process.env.EXPO_PUBLIC_XDT_OTA_SELFHOST = '1';
+    vi.resetModules();
+    vi.doMock('expo-constants', () => ({
+      default: { expoConfig: { version: '9.9.9' } },
+    }));
+    try {
+      const env = await import('@/config/env');
+      const startup = await import('@/config/clientEndpointStartup');
+      const buildManifest = JSON.stringify({
+        ...FULL_MANIFEST_OBJECT,
+        authApiBaseUrl: 'https://auth.dev.example.com',
+        mobileUpdateBaseUrl: 'https://updates.dev.example.com',
+        review: '9.9.9',
+      });
+      await startup.runStartupEndpointResolve({
+        fetchManifest: okFetch(buildManifest),
+      });
+      expect(env.AUTH_API_BASE_URL).toBe('https://auth.dev.example.com');
+      expect(env.OTA_SERVER_BASE_URL).toBe('https://updates.dev.example.com');
+      expect(env.REVIEW_MODE).toBe(true);
+      expect(env.IS_TESTFLIGHT_BUILD).toBe(false);
+
+      const releaseManifest = JSON.stringify({
+        ...FULL_MANIFEST_OBJECT,
+        authApiBaseUrl: 'https://auth.release.example.com',
+        mobileUpdateBaseUrl: 'https://updates.release.example.com',
+        review: '0.0.0',
+      });
+      await startup.runStartupEndpointResolve({
+        fetchManifest: okFetch(releaseManifest),
+        preserveBuildReleaseMetadata: true,
+        resolveIsTestFlight: async () => true,
+      });
+
+      expect(env.AUTH_API_BASE_URL).toBe('https://auth.release.example.com');
+      expect(env.OTA_SERVER_BASE_URL).toBe('https://updates.dev.example.com');
+      expect(env.REVIEW_MODE).toBe(true);
+      expect(env.IS_TESTFLIGHT_BUILD).toBe(false);
+      expect(
+        env.getMobileEndpointForRealm(env.BUILD_AUTH_REGION, 'authApiBaseUrl'),
+      ).toBe('https://auth.release.example.com');
+    } finally {
+      delete process.env.EXPO_PUBLIC_XDT_OTA_SELFHOST;
+      vi.doUnmock('expo-constants');
+      vi.resetModules();
+    }
+  });
+
   it('二进制版本优先读原生 0.1.2，不被 OTA manifest 的 0.1.0 覆盖', async () => {
     vi.resetModules();
     vi.doMock('expo-application', () => ({

--- a/apps/mobile/src/__tests__/devServerEnvironment.test.ts
+++ b/apps/mobile/src/__tests__/devServerEnvironment.test.ts
@@ -1,0 +1,192 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+const storage = vi.hoisted(() => ({
+  getItem: vi.fn<() => Promise<string | null>>(),
+  removeItem: vi.fn<() => Promise<void>>(),
+  setItem: vi.fn<() => Promise<void>>(),
+}));
+
+vi.mock('@react-native-async-storage/async-storage', () => ({
+  default: storage,
+}));
+
+const originalAuthRegion = process.env.EXPO_PUBLIC_CINDY_AUTH_REGION;
+
+async function freshModule(region: 'cn' | 'dev' = 'dev') {
+  process.env.EXPO_PUBLIC_CINDY_AUTH_REGION = region;
+  vi.resetModules();
+  return import('@/config/devServerEnvironment');
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  storage.getItem.mockResolvedValue(null);
+  storage.removeItem.mockResolvedValue(undefined);
+  storage.setItem.mockResolvedValue(undefined);
+});
+
+afterEach(() => {
+  if (originalAuthRegion === undefined) {
+    delete process.env.EXPO_PUBLIC_CINDY_AUTH_REGION;
+  } else {
+    process.env.EXPO_PUBLIC_CINDY_AUTH_REGION = originalAuthRegion;
+  }
+  vi.resetModules();
+});
+
+describe('CindyDev server environment preference', () => {
+  it('is unavailable to release builds and never touches their storage', async () => {
+    const environment = await freshModule('cn');
+
+    expect(environment.DEV_SERVER_ENVIRONMENT_SWITCH_ENABLED).toBe(false);
+    await expect(environment.hydrateDevServerEnvironment()).resolves.toBe(
+      'dev',
+    );
+    await expect(
+      environment.setDevServerEnvironment('release'),
+    ).rejects.toThrow('dev-server-environment-switch-unavailable');
+    expect(storage.getItem).not.toHaveBeenCalled();
+    expect(storage.setItem).not.toHaveBeenCalled();
+  });
+
+  it('defaults CindyDev to Dev when no override is stored', async () => {
+    const environment = await freshModule();
+
+    await expect(environment.hydrateDevServerEnvironment()).resolves.toBe(
+      'dev',
+    );
+    expect(environment.getDevServerEnvironment()).toBe('dev');
+    expect(storage.getItem).toHaveBeenCalledWith(
+      environment.__testing.storageKey,
+    );
+  });
+
+  it('hydrates an explicit Release override', async () => {
+    storage.getItem.mockResolvedValue('release');
+    const environment = await freshModule();
+
+    await expect(environment.hydrateDevServerEnvironment()).resolves.toBe(
+      'release',
+    );
+    expect(environment.getDevServerEnvironment()).toBe('release');
+  });
+
+  it('stores only the Release override and removes it when switching to Dev', async () => {
+    const environment = await freshModule();
+
+    await environment.setDevServerEnvironment('release');
+    expect(storage.setItem).toHaveBeenCalledWith(
+      environment.__testing.storageKey,
+      'release',
+    );
+    expect(environment.getDevServerEnvironment()).toBe('release');
+
+    await environment.setDevServerEnvironment('dev');
+    expect(storage.removeItem).toHaveBeenCalledWith(
+      environment.__testing.storageKey,
+    );
+    expect(environment.getDevServerEnvironment()).toBe('dev');
+  });
+
+  it('fails safe to Dev when reading the preference fails', async () => {
+    storage.getItem.mockRejectedValue(new Error('storage unavailable'));
+    const environment = await freshModule();
+
+    await expect(environment.hydrateDevServerEnvironment()).resolves.toBe(
+      'dev',
+    );
+    expect(environment.getDevServerEnvironment()).toBe('dev');
+  });
+
+  it('keeps the active environment unchanged when persistence fails', async () => {
+    storage.setItem.mockRejectedValue(new Error('storage unavailable'));
+    const environment = await freshModule();
+
+    await expect(
+      environment.setDevServerEnvironment('release'),
+    ).rejects.toThrow('storage unavailable');
+    expect(environment.getDevServerEnvironment()).toBe('dev');
+  });
+});
+
+describe('CindyDev startup endpoint steps', () => {
+  it('keeps the existing single-manifest path outside CindyDev', async () => {
+    const environment = await freshModule('cn');
+
+    expect(
+      environment.buildDevServerEndpointStartupSteps({
+        buildManifestBaseUrl: 'https://dev.example',
+        defaultEndpointGateEnabled: true,
+        environment: 'dev',
+        releaseManifestBaseUrl: 'https://release.example',
+        switchEnabled: false,
+      }),
+    ).toEqual([
+      {
+        manifestBaseUrl: 'https://dev.example',
+        preserveBuildReleaseMetadata: false,
+      },
+    ]);
+  });
+
+  it('uses only the packaged CindyDev manifest while Dev is selected', async () => {
+    const environment = await freshModule();
+
+    expect(
+      environment.buildDevServerEndpointStartupSteps({
+        buildManifestBaseUrl: 'https://dev.example',
+        defaultEndpointGateEnabled: true,
+        environment: 'dev',
+        releaseManifestBaseUrl: 'https://release.example',
+        switchEnabled: true,
+      }),
+    ).toEqual([
+      {
+        manifestBaseUrl: 'https://dev.example',
+        preserveBuildReleaseMetadata: false,
+      },
+    ]);
+  });
+
+  it('loads CindyDev metadata first and Release business endpoints second', async () => {
+    const environment = await freshModule();
+
+    expect(
+      environment.buildDevServerEndpointStartupSteps({
+        buildManifestBaseUrl: 'https://dev.example',
+        defaultEndpointGateEnabled: true,
+        environment: 'release',
+        releaseManifestBaseUrl: 'https://release.example',
+        switchEnabled: true,
+      }),
+    ).toEqual([
+      {
+        manifestBaseUrl: 'https://dev.example',
+        preserveBuildReleaseMetadata: false,
+      },
+      {
+        manifestBaseUrl: 'https://release.example',
+        preserveBuildReleaseMetadata: true,
+      },
+    ]);
+  });
+
+  it('uses only the Release manifest in local Metro when Release is selected', async () => {
+    const environment = await freshModule();
+
+    expect(
+      environment.buildDevServerEndpointStartupSteps({
+        buildManifestBaseUrl: 'https://dev.example',
+        defaultEndpointGateEnabled: false,
+        environment: 'release',
+        releaseManifestBaseUrl: 'https://release.example',
+        switchEnabled: true,
+      }),
+    ).toEqual([
+      {
+        manifestBaseUrl: 'https://release.example',
+        preserveBuildReleaseMetadata: true,
+      },
+    ]);
+  });
+});

--- a/apps/mobile/src/__tests__/devServerEnvironment.test.ts
+++ b/apps/mobile/src/__tests__/devServerEnvironment.test.ts
@@ -107,6 +107,27 @@ describe('CindyDev server environment preference', () => {
     ).rejects.toThrow('storage unavailable');
     expect(environment.getDevServerEnvironment()).toBe('dev');
   });
+
+  it('restores the previous environment when app reload fails', async () => {
+    const environment = await freshModule();
+    const calls: string[] = [];
+    const reloadError = new Error('reload unavailable');
+
+    await expect(
+      environment.switchDevServerEnvironmentAndReload({
+        current: 'dev',
+        next: 'release',
+        reload: async () => {
+          calls.push('reload');
+          throw reloadError;
+        },
+        setEnvironment: async (next) => {
+          calls.push(`persist:${next}`);
+        },
+      }),
+    ).rejects.toBe(reloadError);
+    expect(calls).toEqual(['persist:release', 'reload', 'persist:dev']);
+  });
 });
 
 describe('CindyDev startup endpoint steps', () => {

--- a/apps/mobile/src/__tests__/devServerEnvironment.test.ts
+++ b/apps/mobile/src/__tests__/devServerEnvironment.test.ts
@@ -128,6 +128,34 @@ describe('CindyDev server environment preference', () => {
     ).rejects.toBe(reloadError);
     expect(calls).toEqual(['persist:release', 'reload', 'persist:dev']);
   });
+
+  it('restores in-memory state and preserves the reload error when persistence rollback also fails', async () => {
+    const environment = await freshModule();
+    const reloadError = new Error('reload unavailable');
+    storage.removeItem.mockRejectedValueOnce(
+      new Error('rollback storage unavailable'),
+    );
+
+    await expect(
+      environment.switchDevServerEnvironmentAndReload({
+        current: 'dev',
+        next: 'release',
+        reload: async () => {
+          throw reloadError;
+        },
+        setEnvironment: environment.setDevServerEnvironment,
+      }),
+    ).rejects.toBe(reloadError);
+
+    expect(storage.setItem).toHaveBeenCalledWith(
+      environment.__testing.storageKey,
+      'release',
+    );
+    expect(storage.removeItem).toHaveBeenCalledWith(
+      environment.__testing.storageKey,
+    );
+    expect(environment.getDevServerEnvironment()).toBe('dev');
+  });
 });
 
 describe('CindyDev startup endpoint steps', () => {
@@ -209,5 +237,52 @@ describe('CindyDev startup endpoint steps', () => {
         preserveBuildReleaseMetadata: true,
       },
     ]);
+  });
+
+  it('allows returning to Dev only when the Release overlay step fails', async () => {
+    const environment = await freshModule();
+    const steps = environment.buildDevServerEndpointStartupSteps({
+      buildManifestBaseUrl: 'https://dev.example',
+      defaultEndpointGateEnabled: true,
+      environment: 'release',
+      releaseManifestBaseUrl: 'https://release.example',
+      switchEnabled: true,
+    });
+
+    const outcome = await environment.runDevServerEndpointStartupSteps(
+      steps,
+      async (step) =>
+        step.preserveBuildReleaseMetadata
+          ? { ok: false as const, reason: 'fetch-failed' }
+          : { ok: true as const },
+    );
+
+    expect(outcome).toEqual({
+      ok: false,
+      reason: 'fetch-failed',
+      canResetToDev: true,
+    });
+  });
+
+  it('keeps the ordinary retry path when the packaged Dev manifest fails', async () => {
+    const environment = await freshModule();
+    const steps = environment.buildDevServerEndpointStartupSteps({
+      buildManifestBaseUrl: 'https://dev.example',
+      defaultEndpointGateEnabled: true,
+      environment: 'release',
+      releaseManifestBaseUrl: 'https://release.example',
+      switchEnabled: true,
+    });
+
+    await expect(
+      environment.runDevServerEndpointStartupSteps(steps, async () => ({
+        ok: false as const,
+        reason: 'invalid-json',
+      })),
+    ).resolves.toEqual({
+      ok: false,
+      reason: 'invalid-json',
+      canResetToDev: false,
+    });
   });
 });

--- a/apps/mobile/src/__tests__/loginSkinVisual.test.ts
+++ b/apps/mobile/src/__tests__/loginSkinVisual.test.ts
@@ -44,7 +44,7 @@ describe('loginSkin 白底体系视觉(源码接线 + token 参数)', () => {
     expect(layoutSource).toContain('StartupGateBlockedContent');
     // 文案 key 化契约保持(startupGateCopy 闸门同源)
     expect(layoutSource).toContain("loginText('endpointGateTitle')");
-    expect(layoutSource).toContain("loginText('retry')");
+    expect(layoutSource).toContain("'endpointGateResetToDev' : 'retry'");
   });
 
   it('login-panel-border:面板 1px panelBorder 描边 + panelBg r36(368:1383)', () => {

--- a/apps/mobile/src/__tests__/mobileSettings.test.ts
+++ b/apps/mobile/src/__tests__/mobileSettings.test.ts
@@ -24,6 +24,47 @@ describe('mobile settings overview', () => {
     expect(source).not.toContain('LanguageOptionRow');
   });
 
+  it('shows the server switch only in CindyDev and clears the old session before reloading', () => {
+    const settingsSource = readTextLf(
+      resolve(process.cwd(), 'app/settings.tsx'),
+      'utf8',
+    );
+    const environmentSource = readTextLf(
+      resolve(process.cwd(), 'src/config/devServerEnvironment.ts'),
+      'utf8',
+    );
+    const switchStart = settingsSource.indexOf(
+      'const switchDevServerEnvironment = useCallback(',
+    );
+    const logoutIndex = settingsSource.indexOf(
+      'await auth.logout();',
+      switchStart,
+    );
+    const persistIndex = settingsSource.indexOf(
+      'await setDevServerEnvironment(next);',
+      switchStart,
+    );
+    const reloadIndex = settingsSource.indexOf(
+      'DevSettings.reload();',
+      switchStart,
+    );
+
+    expect(settingsSource).toContain(
+      '...(DEV_SERVER_ENVIRONMENT_SWITCH_ENABLED',
+    );
+    expect(settingsSource).toContain(
+      'testID="settings.devServerEnvironment"',
+    );
+    expect(environmentSource).toContain(
+      "process.env.EXPO_PUBLIC_CINDY_AUTH_REGION === 'dev'",
+    );
+    expect(environmentSource).not.toContain('TextInput');
+    expect(switchStart).toBeGreaterThan(-1);
+    expect(logoutIndex).toBeGreaterThan(switchStart);
+    expect(persistIndex).toBeGreaterThan(logoutIndex);
+    expect(reloadIndex).toBeGreaterThan(persistIndex);
+  });
+
   it('keeps the device-link hello name and settings device name on one source', () => {
     expect(buildMobileDeviceName({ constantsDeviceName: ' Carol iPhone ', platform: 'ios' })).toBe('Carol iPhone');
     expect(buildMobileDeviceName({ constantsDeviceName: '   ', platform: 'android' })).toBe('Cindy android');

--- a/apps/mobile/src/__tests__/mobileSettings.test.ts
+++ b/apps/mobile/src/__tests__/mobileSettings.test.ts
@@ -40,12 +40,16 @@ describe('mobile settings overview', () => {
       'await auth.logout();',
       switchStart,
     );
+    const reloadUnavailableIndex = settingsSource.indexOf(
+      'if (!reload) {',
+      switchStart,
+    );
     const transactionalReloadIndex = settingsSource.indexOf(
       'await switchDevServerEnvironmentAndReload({',
       switchStart,
     );
     const reloadIndex = settingsSource.indexOf(
-      'reload: () => DevSettings.reload(),',
+      '? () => DevSettings.reload()',
       switchStart,
     );
 
@@ -60,9 +64,15 @@ describe('mobile settings overview', () => {
     );
     expect(environmentSource).not.toContain('TextInput');
     expect(switchStart).toBeGreaterThan(-1);
+    expect(reloadUnavailableIndex).toBeGreaterThan(switchStart);
+    expect(reloadUnavailableIndex).toBeLessThan(logoutIndex);
     expect(logoutIndex).toBeGreaterThan(switchStart);
     expect(transactionalReloadIndex).toBeGreaterThan(logoutIndex);
-    expect(reloadIndex).toBeGreaterThan(transactionalReloadIndex);
+    expect(reloadIndex).toBeGreaterThan(switchStart);
+    expect(reloadIndex).toBeLessThan(reloadUnavailableIndex);
+    expect(settingsSource).not.toContain(
+      'settings.devServerEnvironment.restartRequired',
+    );
   });
 
   it('keeps the device-link hello name and settings device name on one source', () => {

--- a/apps/mobile/src/__tests__/mobileSettings.test.ts
+++ b/apps/mobile/src/__tests__/mobileSettings.test.ts
@@ -40,12 +40,12 @@ describe('mobile settings overview', () => {
       'await auth.logout();',
       switchStart,
     );
-    const persistIndex = settingsSource.indexOf(
-      'await setDevServerEnvironment(next);',
+    const transactionalReloadIndex = settingsSource.indexOf(
+      'await switchDevServerEnvironmentAndReload({',
       switchStart,
     );
     const reloadIndex = settingsSource.indexOf(
-      'DevSettings.reload();',
+      'reload: () => DevSettings.reload(),',
       switchStart,
     );
 
@@ -61,8 +61,8 @@ describe('mobile settings overview', () => {
     expect(environmentSource).not.toContain('TextInput');
     expect(switchStart).toBeGreaterThan(-1);
     expect(logoutIndex).toBeGreaterThan(switchStart);
-    expect(persistIndex).toBeGreaterThan(logoutIndex);
-    expect(reloadIndex).toBeGreaterThan(persistIndex);
+    expect(transactionalReloadIndex).toBeGreaterThan(logoutIndex);
+    expect(reloadIndex).toBeGreaterThan(transactionalReloadIndex);
   });
 
   it('keeps the device-link hello name and settings device name on one source', () => {

--- a/apps/mobile/src/__tests__/nativeAppConfig.test.ts
+++ b/apps/mobile/src/__tests__/nativeAppConfig.test.ts
@@ -14,6 +14,7 @@ const managedEnvKeys = [
   'EXPO_PUBLIC_APP_VARIANT',
   'EXPO_PUBLIC_BETA_DEV',
   'EXPO_PUBLIC_CINDY_AUTH_REGION',
+  'EXPO_PUBLIC_CINDY_DEV_RELEASE_ENDPOINT_MANIFEST_BASE_URL',
   'EXPO_PUBLIC_ENDPOINT_MANIFEST_BASE_URL',
   'EXPO_PUBLIC_ENDPOINT_MANIFEST_PEER_BASE_URL',
   'EXPO_PUBLIC_XDT_OTA_SELFHOST',
@@ -96,6 +97,44 @@ describe('mobile native app config', () => {
     );
     expect(runtimeEnvSource).toContain(
       'process.env.EXPO_PUBLIC_ENDPOINT_MANIFEST_PEER_BASE_URL',
+    );
+  });
+
+  it('keeps the CN Release manifest injection CindyDev-only and outside Expo config', () => {
+    const appJson = JSON.parse(
+      readFileSync(resolve(process.cwd(), 'app.json'), 'utf8'),
+    );
+    const buildConfig = require(resolve(process.cwd(), 'app.config.js'));
+    const appConfigSource = readFileSync(
+      resolve(process.cwd(), 'app.config.js'),
+      'utf8',
+    );
+
+    expect(appConfigSource).toContain("...(region === 'dev'");
+    expect(appConfigSource).toContain(
+      'EXPO_PUBLIC_CINDY_DEV_RELEASE_ENDPOINT_MANIFEST_BASE_URL:',
+    );
+    expect(appConfigSource).toContain("resolveManifestBaseUrl('cn')");
+    expect(appConfigSource).not.toContain(
+      'xdtProductionEnv: mobileBundleEnv',
+    );
+
+    process.env.EXPO_PUBLIC_CINDY_AUTH_REGION = 'cn';
+    const cn = buildConfig({ config: appJson.expo });
+    expect(
+      process.env.EXPO_PUBLIC_CINDY_DEV_RELEASE_ENDPOINT_MANIFEST_BASE_URL,
+    ).toBeUndefined();
+    expect(JSON.stringify(cn)).not.toContain(
+      'EXPO_PUBLIC_CINDY_DEV_RELEASE_ENDPOINT_MANIFEST_BASE_URL',
+    );
+
+    process.env.EXPO_PUBLIC_CINDY_AUTH_REGION = 'global';
+    const global = buildConfig({ config: appJson.expo });
+    expect(
+      process.env.EXPO_PUBLIC_CINDY_DEV_RELEASE_ENDPOINT_MANIFEST_BASE_URL,
+    ).toBeUndefined();
+    expect(JSON.stringify(global)).not.toContain(
+      'EXPO_PUBLIC_CINDY_DEV_RELEASE_ENDPOINT_MANIFEST_BASE_URL',
     );
   });
 

--- a/apps/mobile/src/__tests__/nativeAppConfig.test.ts
+++ b/apps/mobile/src/__tests__/nativeAppConfig.test.ts
@@ -120,6 +120,8 @@ describe('mobile native app config', () => {
     );
 
     process.env.EXPO_PUBLIC_CINDY_AUTH_REGION = 'cn';
+    process.env.EXPO_PUBLIC_CINDY_DEV_RELEASE_ENDPOINT_MANIFEST_BASE_URL =
+      'https://stale-release.example.invalid/app';
     const cn = buildConfig({ config: appJson.expo });
     expect(
       process.env.EXPO_PUBLIC_CINDY_DEV_RELEASE_ENDPOINT_MANIFEST_BASE_URL,
@@ -129,6 +131,8 @@ describe('mobile native app config', () => {
     );
 
     process.env.EXPO_PUBLIC_CINDY_AUTH_REGION = 'global';
+    process.env.EXPO_PUBLIC_CINDY_DEV_RELEASE_ENDPOINT_MANIFEST_BASE_URL =
+      'https://stale-release.example.invalid/app';
     const global = buildConfig({ config: appJson.expo });
     expect(
       process.env.EXPO_PUBLIC_CINDY_DEV_RELEASE_ENDPOINT_MANIFEST_BASE_URL,

--- a/apps/mobile/src/__tests__/pushNotificationsRealm.test.ts
+++ b/apps/mobile/src/__tests__/pushNotificationsRealm.test.ts
@@ -68,6 +68,8 @@ const REGISTERED_KEY = 'cindy.push.registered';
 const PENDING_KEY = 'cindy.push.pendingUnregister';
 const DEV_REGISTERED_KEY = `${REGISTERED_KEY}.dev`;
 const RELEASE_REGISTERED_KEY = `${REGISTERED_KEY}.release`;
+const DEV_PENDING_KEY = `${PENDING_KEY}.dev`;
+const RELEASE_PENDING_KEY = `${PENDING_KEY}.release`;
 
 function setStoredRealms(key: string, realms: Array<'cn' | 'global'>): void {
   store.set(key, JSON.stringify({ version: 1, realms }));
@@ -160,6 +162,35 @@ describe('push notification realm routing', () => {
     expect(readStoredRealms(DEV_REGISTERED_KEY)).toEqual(['cn']);
     expect(readStoredRealms(RELEASE_REGISTERED_KEY)).toEqual(['cn']);
     expect(apiFetch).toHaveBeenCalledTimes(2);
+  });
+
+  it('注册期间切换 CindyDev 环境仍把补偿状态留在原 namespace', async () => {
+    envState.buildRegion = 'dev';
+    let releaseRead: (() => void) | undefined;
+    const readGate = new Promise<void>((resolve) => {
+      releaseRead = resolve;
+    });
+    mocks.asyncGetItem.mockImplementationOnce(async (key: string) => {
+      expect(key).toBe(DEV_REGISTERED_KEY);
+      await readGate;
+      return null;
+    });
+    const apiFetch = vi.fn();
+
+    const registration = syncPushRegistration({ enabled: true, apiFetch });
+    await vi.waitFor(() => {
+      expect(mocks.asyncGetItem).toHaveBeenCalledWith(DEV_REGISTERED_KEY);
+    });
+    await unregisterPushTokenBestEffort(null, 'cn');
+    devEnvironmentState.active = 'release';
+    releaseRead?.();
+
+    await expect(registration).resolves.toBe('skipped');
+    expect(apiFetch).not.toHaveBeenCalled();
+    expect(readStoredRealms(DEV_REGISTERED_KEY)).toEqual(['cn']);
+    expect(readStoredRealms(DEV_PENDING_KEY)).toEqual(['cn']);
+    expect(store.has(RELEASE_REGISTERED_KEY)).toBe(false);
+    expect(store.has(RELEASE_PENDING_KEY)).toBe(false);
   });
 
   it('Release 环境不读取旧 CindyDev 的无后缀状态', async () => {

--- a/apps/mobile/src/__tests__/pushNotificationsRealm.test.ts
+++ b/apps/mobile/src/__tests__/pushNotificationsRealm.test.ts
@@ -9,6 +9,9 @@ const envState = vi.hoisted(() => ({
     global: 'https://relay.global.example',
   },
 }));
+const devEnvironmentState = vi.hoisted(() => ({
+  active: 'dev' as 'dev' | 'release',
+}));
 const mocks = vi.hoisted(() => ({
   asyncGetItem: vi.fn(async (key: string) => store.get(key) ?? null),
   loadMobileEndpointsForRealm: vi.fn(async (_realm: 'cn' | 'global') => ({})),
@@ -51,6 +54,10 @@ vi.mock('@/config/env', () => ({
     envState.endpointByRealm[realm],
 }));
 
+vi.mock('@/config/devServerEnvironment', () => ({
+  getDevServerEnvironment: () => devEnvironmentState.active,
+}));
+
 import {
   retryPendingUnregister,
   syncPushRegistration,
@@ -59,6 +66,8 @@ import {
 
 const REGISTERED_KEY = 'cindy.push.registered';
 const PENDING_KEY = 'cindy.push.pendingUnregister';
+const DEV_REGISTERED_KEY = `${REGISTERED_KEY}.dev`;
+const RELEASE_REGISTERED_KEY = `${REGISTERED_KEY}.release`;
 
 function setStoredRealms(key: string, realms: Array<'cn' | 'global'>): void {
   store.set(key, JSON.stringify({ version: 1, realms }));
@@ -77,6 +86,7 @@ describe('push notification realm routing', () => {
     store.clear();
     envState.activeRealm = 'cn';
     envState.buildRegion = 'cn';
+    devEnvironmentState.active = 'dev';
     mocks.getPermissionsAsync.mockResolvedValue({
       status: 'granted',
       canAskAgain: false,
@@ -135,6 +145,44 @@ describe('push notification realm routing', () => {
         }),
       }),
     );
+    expect(readStoredRealms(DEV_REGISTERED_KEY)).toEqual(['cn']);
+    expect(store.has(REGISTERED_KEY)).toBe(false);
+  });
+
+  it('CindyDev 的 Dev 与 Release 推送状态互相隔离', async () => {
+    envState.buildRegion = 'dev';
+    const apiFetch = vi.fn().mockResolvedValue({ registered: true });
+
+    await syncPushRegistration({ enabled: true, apiFetch });
+    devEnvironmentState.active = 'release';
+    await syncPushRegistration({ enabled: true, apiFetch });
+
+    expect(readStoredRealms(DEV_REGISTERED_KEY)).toEqual(['cn']);
+    expect(readStoredRealms(RELEASE_REGISTERED_KEY)).toEqual(['cn']);
+    expect(apiFetch).toHaveBeenCalledTimes(2);
+  });
+
+  it('Release 环境不读取旧 CindyDev 的无后缀状态', async () => {
+    envState.buildRegion = 'dev';
+    devEnvironmentState.active = 'release';
+    setStoredRealms(REGISTERED_KEY, ['global']);
+    const apiFetch = vi.fn().mockResolvedValue({ registered: true });
+
+    await syncPushRegistration({ enabled: true, apiFetch });
+
+    expect(readStoredRealms(RELEASE_REGISTERED_KEY)).toEqual(['cn']);
+    expect(readStoredRealms(REGISTERED_KEY)).toEqual(['global']);
+  });
+
+  it('Dev 环境把旧 CindyDev 的无后缀状态迁移到环境专属 key', async () => {
+    envState.buildRegion = 'dev';
+    setStoredRealms(REGISTERED_KEY, ['global']);
+    const apiFetch = vi.fn().mockResolvedValue({ registered: true });
+
+    await syncPushRegistration({ enabled: true, apiFetch });
+
+    expect(readStoredRealms(DEV_REGISTERED_KEY)).toEqual(['cn', 'global']);
+    expect(store.has(REGISTERED_KEY)).toBe(false);
   });
 
   it('切换区域前用旧 token 向显式冻结的旧区域撤销', async () => {

--- a/apps/mobile/src/__tests__/startupGateCopy.test.ts
+++ b/apps/mobile/src/__tests__/startupGateCopy.test.ts
@@ -31,10 +31,11 @@ const loginSource = readFileSync(
 );
 
 describe("endpoint 闸门失败屏(_layout.tsx)文案 key 化", () => {
-  it("error 态三段文案全部走 loginMessages key", () => {
+  it("error 态文案与动态动作全部走 loginMessages key", () => {
     expect(layoutSource).toContain("loginText('endpointGateTitle')");
     expect(layoutSource).toContain("loginText('endpointGateSubtitle')");
-    expect(layoutSource).toContain("loginText('retry')");
+    expect(layoutSource).toContain("'endpointGateResetToDev' : 'retry'");
+    expect(layoutSource).toContain('endpointGate.resetToDev');
     // {reason} 占位符在渲染点替换,保留闸门失败原因透出
     expect(layoutSource).toContain("'{reason}'");
     expect(layoutSource).toContain("endpointGate.reason ?? 'unknown'");
@@ -51,6 +52,7 @@ describe("endpoint 闸门失败屏(_layout.tsx)文案 key 化", () => {
       const catalog = loginMessages[locale];
       expect(catalog.endpointGateTitle.trim(), locale).not.toBe("");
       expect(catalog.endpointGateSubtitle, locale).toContain("{reason}");
+      expect(catalog.endpointGateResetToDev.trim(), locale).not.toBe("");
       expect(catalog.retry.trim(), locale).not.toBe("");
     }
   });

--- a/apps/mobile/src/auth/__tests__/loginHandoffState.test.ts
+++ b/apps/mobile/src/auth/__tests__/loginHandoffState.test.ts
@@ -220,7 +220,8 @@ describe('loginHandoff 接线(Provider/reporter 拓扑 + 清理,读源码断言)
     expect(layoutSource).toContain('<MobileLoginHandoffStage>');
     // 内容层的动作 prop 已从 retry 专用改为通用 action(端点重试 / 强更去更新共用同一层),
     // 端点错误屏的接线与文案 key 化契约不变。
-    expect(layoutSource).toContain('onAction={endpointGate.retry}');
+    expect(layoutSource).toContain('? endpointGate.resetToDev');
+    expect(layoutSource).toContain(': endpointGate.retry');
     expect(layoutSource).toContain("loginText('endpointGateTitle')");
   });
 

--- a/apps/mobile/src/auth/loginMessages.ts
+++ b/apps/mobile/src/auth/loginMessages.ts
@@ -125,6 +125,7 @@ const messages = {
     errorFallback: "登入未完成，請重試。",
     endpointGateTitle: "無法取得伺服器設定",
     endpointGateSubtitle: "請檢查網路連線後重試({reason})",
+    endpointGateResetToDev: "返回 Dev",
     retry: "重試",
     configIssueAuthBaseUrl: "登入服務地址必須是 http(s) URL。",
   },
@@ -239,6 +240,7 @@ const messages = {
     errorFallback: "登录未完成，请重试。",
     endpointGateTitle: "无法获取服务器配置",
     endpointGateSubtitle: "请检查网络连接后重试({reason})",
+    endpointGateResetToDev: "返回 Dev",
     retry: "重试",
     configIssueAuthBaseUrl: "登录服务地址必须是 http(s) URL。",
   },
@@ -366,6 +368,7 @@ const messages = {
     endpointGateTitle: "Unable to load server configuration",
     endpointGateSubtitle:
       "Check your network connection and try again ({reason})",
+    endpointGateResetToDev: "Return to Dev",
     retry: "Retry",
     configIssueAuthBaseUrl:
       "The sign-in service address must be an http(s) URL.",
@@ -493,6 +496,7 @@ const messages = {
     endpointGateTitle: "サーバー設定を取得できません",
     endpointGateSubtitle:
       "ネットワーク接続を確認してから再試行してください({reason})",
+    endpointGateResetToDev: "Dev に戻る",
     retry: "再試行",
     configIssueAuthBaseUrl:
       "ログインサービスのアドレスは http(s) URL である必要があります。",
@@ -617,6 +621,7 @@ const messages = {
     endpointGateTitle: "서버 설정을 가져올 수 없습니다",
     endpointGateSubtitle:
       "네트워크 연결을 확인한 후 다시 시도해 주세요({reason})",
+    endpointGateResetToDev: "Dev로 돌아가기",
     retry: "다시 시도",
     configIssueAuthBaseUrl: "로그인 서비스 주소는 http(s) URL이어야 합니다.",
   },

--- a/apps/mobile/src/config/clientEndpointStartup.ts
+++ b/apps/mobile/src/config/clientEndpointStartup.ts
@@ -21,6 +21,7 @@
 import {
   resolveClientEndpointsStrict,
   type ClientEndpointMap,
+  type ClientEndpointRegion,
 } from '@cindy/maker-shared/client-endpoints';
 
 import {
@@ -70,9 +71,12 @@ function defaultSleep(ms: number): Promise<void> {
   return new Promise((resolve) => setTimeout(resolve, ms));
 }
 
-async function fetchManifestViaCdn(timeoutMs: number): Promise<ManifestFetchResult> {
+async function fetchManifestViaCdn(
+  timeoutMs: number,
+  manifestBaseUrl: string = ENDPOINT_MANIFEST_BASE_URL,
+): Promise<ManifestFetchResult> {
   // 构建缺自举基址属打包配置事故:CDN 级不可用,交给启动闸门阻断。
-  if (!ENDPOINT_MANIFEST_BASE_URL) return { ok: false, detail: 'missing-manifest-base-url' };
+  if (!manifestBaseUrl) return { ok: false, detail: 'missing-manifest-base-url' };
   const controller = new AbortController();
   let timedOut = false;
   const timer = setTimeout(() => {
@@ -81,7 +85,7 @@ async function fetchManifestViaCdn(timeoutMs: number): Promise<ManifestFetchResu
   }, timeoutMs);
   try {
     const response = await fetch(
-      `${ENDPOINT_MANIFEST_BASE_URL}${MANIFEST_RELATIVE_PATH}?t=${Date.now()}`,
+      `${manifestBaseUrl}${MANIFEST_RELATIVE_PATH}?t=${Date.now()}`,
       { signal: controller.signal },
     );
     if (!response.ok) return { ok: false, detail: `http-${response.status}` };
@@ -104,6 +108,12 @@ export interface StartupEndpointResolveDeps {
     isTestFlight: boolean;
     region: 'cn' | 'global' | null;
   }) => void;
+  /** CindyDev 切换 Release 时传入第二个受信任清单基址。 */
+  manifestBaseUrl?: string;
+  /** 目标清单必须匹配的 auth 物理区域；默认仍为安装包构建区域。 */
+  expectedRegion?: ClientEndpointRegion;
+  /** 只切业务端点，保留 CindyDev 构建清单决定的 OTA / 审核元数据。 */
+  preserveBuildReleaseMetadata?: boolean;
   timeoutMs?: number;
   /** 自动重试节奏,默认 AUTO_RETRY_DELAYS_MS;传 `[]` 关闭(单次尝试)。 */
   autoRetryDelaysMs?: readonly number[];
@@ -159,8 +169,20 @@ export async function runStartupEndpointResolve(
   deps: StartupEndpointResolveDeps = {},
 ): Promise<StartupEndpointResolveOutcome> {
   try {
-    const fetchManifest = deps.fetchManifest ?? fetchManifestViaCdn;
-    const apply = deps.apply ?? applyResolvedClientEndpoints;
+    const fetchManifest =
+      deps.fetchManifest ??
+      ((requestTimeoutMs: number) =>
+        fetchManifestViaCdn(
+          requestTimeoutMs,
+          deps.manifestBaseUrl ?? ENDPOINT_MANIFEST_BASE_URL,
+        ));
+    const apply =
+      deps.apply ??
+      ((resolved) =>
+        applyResolvedClientEndpoints(resolved, {
+          preserveBuildReleaseMetadata:
+            deps.preserveBuildReleaseMetadata === true,
+        }));
     const timeoutMs = deps.timeoutMs ?? ATTEMPT_TIMEOUT_MS;
     const retryDelays = deps.autoRetryDelaysMs ?? AUTO_RETRY_DELAYS_MS;
     const sleep = deps.sleep ?? defaultSleep;
@@ -177,10 +199,11 @@ export async function runStartupEndpointResolve(
     const result = resolveClientEndpointsStrict(fetched.text);
     if (!result.ok) return { ok: false, reason: result.reason };
     // 老清单缺 region 时保持兼容；一旦自报 region，就必须与安装包构建区域一致。
-    if (result.region !== null && result.region !== BUILD_AUTH_REGION) {
+    const expectedRegion = deps.expectedRegion ?? BUILD_AUTH_REGION;
+    if (result.region !== null && result.region !== expectedRegion) {
       return {
         ok: false,
-        reason: `region-mismatch:${BUILD_AUTH_REGION}:${result.region}`,
+        reason: `region-mismatch:${expectedRegion}:${result.region}`,
       };
     }
 

--- a/apps/mobile/src/config/devServerEnvironment.ts
+++ b/apps/mobile/src/config/devServerEnvironment.ts
@@ -14,6 +14,13 @@ export interface DevServerEndpointStartupStep {
   preserveBuildReleaseMetadata: boolean;
 }
 
+export interface DevServerEnvironmentReloadSwitch {
+  current: DevServerEnvironment;
+  next: DevServerEnvironment;
+  reload: () => Promise<void> | void;
+  setEnvironment: (environment: DevServerEnvironment) => Promise<void>;
+}
+
 export const DEV_SERVER_ENVIRONMENT_SWITCH_ENABLED =
   process.env.EXPO_PUBLIC_CINDY_AUTH_REGION === 'dev';
 
@@ -101,6 +108,19 @@ export function buildDevServerEndpointStartupSteps(input: {
     });
   }
   return steps;
+}
+
+/** 重载失败时恢复旧选择，避免当前进程端点与持久化环境不一致。 */
+export async function switchDevServerEnvironmentAndReload(
+  input: DevServerEnvironmentReloadSwitch,
+): Promise<void> {
+  await input.setEnvironment(input.next);
+  try {
+    await input.reload();
+  } catch (error) {
+    await input.setEnvironment(input.current);
+    throw error;
+  }
 }
 
 export async function setDevServerEnvironment(

--- a/apps/mobile/src/config/devServerEnvironment.ts
+++ b/apps/mobile/src/config/devServerEnvironment.ts
@@ -21,6 +21,10 @@ export interface DevServerEnvironmentReloadSwitch {
   setEnvironment: (environment: DevServerEnvironment) => Promise<void>;
 }
 
+export type DevServerEndpointStartupRunOutcome =
+  | { ok: true }
+  | { ok: false; reason: string; canResetToDev: boolean };
+
 export const DEV_SERVER_ENVIRONMENT_SWITCH_ENABLED =
   process.env.EXPO_PUBLIC_CINDY_AUTH_REGION === 'dev';
 
@@ -41,6 +45,12 @@ function notifyListeners(): void {
       // A broken view subscriber must not break the persisted environment state.
     }
   }
+}
+
+function restoreActiveEnvironment(environment: DevServerEnvironment): void {
+  activeEnvironment = environment;
+  hydrated = true;
+  notifyListeners();
 }
 
 export function hydrateDevServerEnvironment(): Promise<DevServerEnvironment> {
@@ -110,6 +120,25 @@ export function buildDevServerEndpointStartupSteps(input: {
   return steps;
 }
 
+/** 执行启动步骤，并标记失败是否发生在可撤销的 Release 业务端点覆盖阶段。 */
+export async function runDevServerEndpointStartupSteps(
+  steps: readonly DevServerEndpointStartupStep[],
+  runStep: (
+    step: DevServerEndpointStartupStep,
+  ) => Promise<{ ok: true } | { ok: false; reason: string }>,
+): Promise<DevServerEndpointStartupRunOutcome> {
+  for (const step of steps) {
+    const outcome = await runStep(step);
+    if (!outcome.ok) {
+      return {
+        ...outcome,
+        canResetToDev: step.preserveBuildReleaseMetadata,
+      };
+    }
+  }
+  return { ok: true };
+}
+
 /** 重载失败时恢复旧选择，避免当前进程端点与持久化环境不一致。 */
 export async function switchDevServerEnvironmentAndReload(
   input: DevServerEnvironmentReloadSwitch,
@@ -118,7 +147,13 @@ export async function switchDevServerEnvironmentAndReload(
   try {
     await input.reload();
   } catch (error) {
-    await input.setEnvironment(input.current);
+    try {
+      await input.setEnvironment(input.current);
+    } catch {
+      // 持久化层不可用时仍须让当前 JS 进程与实际未重载的旧端点保持一致。
+      // 最终继续抛出原始 reload 错误，避免回滚错误掩盖首要故障。
+      restoreActiveEnvironment(input.current);
+    }
     throw error;
   }
 }

--- a/apps/mobile/src/config/devServerEnvironment.ts
+++ b/apps/mobile/src/config/devServerEnvironment.ts
@@ -1,0 +1,133 @@
+/**
+ * CindyDev 专属的业务服务器环境选择。
+ *
+ * `dev` 是系统默认值；仅把用户显式选择的 `release` 作为 override 落盘。
+ * CN / Global 正式包不读取、不写入该配置，始终返回 `dev` 占位值，调用方还需用
+ * `DEV_SERVER_ENVIRONMENT_SWITCH_ENABLED` 控制入口与行为。
+ */
+import AsyncStorage from '@react-native-async-storage/async-storage';
+
+export type DevServerEnvironment = 'dev' | 'release';
+
+export interface DevServerEndpointStartupStep {
+  manifestBaseUrl: string;
+  preserveBuildReleaseMetadata: boolean;
+}
+
+export const DEV_SERVER_ENVIRONMENT_SWITCH_ENABLED =
+  process.env.EXPO_PUBLIC_CINDY_AUTH_REGION === 'dev';
+
+const STORAGE_KEY = 'cindy.mobile.devServerEnvironment.release.v1';
+const DEFAULT_ENVIRONMENT: DevServerEnvironment = 'dev';
+
+let activeEnvironment: DevServerEnvironment = DEFAULT_ENVIRONMENT;
+let hydrated = false;
+let hydratePromise: Promise<DevServerEnvironment> | null = null;
+let mutationTail: Promise<void> = Promise.resolve();
+const listeners = new Set<() => void>();
+
+function notifyListeners(): void {
+  for (const listener of [...listeners]) {
+    try {
+      listener();
+    } catch {
+      // A broken view subscriber must not break the persisted environment state.
+    }
+  }
+}
+
+export function hydrateDevServerEnvironment(): Promise<DevServerEnvironment> {
+  if (!DEV_SERVER_ENVIRONMENT_SWITCH_ENABLED) {
+    hydrated = true;
+    activeEnvironment = DEFAULT_ENVIRONMENT;
+    return Promise.resolve(activeEnvironment);
+  }
+  if (hydrated) return Promise.resolve(activeEnvironment);
+  if (hydratePromise) return hydratePromise;
+  hydratePromise = AsyncStorage.getItem(STORAGE_KEY)
+    .then((raw) => {
+      activeEnvironment = raw === 'release' ? 'release' : DEFAULT_ENVIRONMENT;
+      hydrated = true;
+      notifyListeners();
+      return activeEnvironment;
+    })
+    .catch(() => {
+      // Fail safe to the CindyDev build's own environment. A storage failure must
+      // never silently route an internal build to Release.
+      activeEnvironment = DEFAULT_ENVIRONMENT;
+      hydrated = true;
+      notifyListeners();
+      return activeEnvironment;
+    })
+    .finally(() => {
+      hydratePromise = null;
+    });
+  return hydratePromise;
+}
+
+/** 启动 gate hydrate 后可同步读取；未 hydrate 时同样 fail safe 到 Dev。 */
+export function getDevServerEnvironment(): DevServerEnvironment {
+  return activeEnvironment;
+}
+
+export function subscribeDevServerEnvironment(listener: () => void): () => void {
+  listeners.add(listener);
+  return () => listeners.delete(listener);
+}
+
+/**
+ * 正式 CindyDev 包先加载自己的清单来固定 OTA / 审核元数据；选择 Release 时再
+ * 用第二份清单只覆写业务端点。Metro 本地开发默认直接消费包内 Dev 清单，因此
+ * 仅在选择 Release 时需要联网。
+ */
+export function buildDevServerEndpointStartupSteps(input: {
+  buildManifestBaseUrl: string;
+  defaultEndpointGateEnabled: boolean;
+  environment: DevServerEnvironment;
+  releaseManifestBaseUrl: string;
+  switchEnabled: boolean;
+}): DevServerEndpointStartupStep[] {
+  const steps: DevServerEndpointStartupStep[] = [];
+  if (input.defaultEndpointGateEnabled) {
+    steps.push({
+      manifestBaseUrl: input.buildManifestBaseUrl,
+      preserveBuildReleaseMetadata: false,
+    });
+  }
+  if (input.switchEnabled && input.environment === 'release') {
+    steps.push({
+      manifestBaseUrl: input.releaseManifestBaseUrl,
+      preserveBuildReleaseMetadata: true,
+    });
+  }
+  return steps;
+}
+
+export async function setDevServerEnvironment(
+  next: DevServerEnvironment,
+): Promise<void> {
+  if (!DEV_SERVER_ENVIRONMENT_SWITCH_ENABLED) {
+    throw new Error('dev-server-environment-switch-unavailable');
+  }
+  await hydrateDevServerEnvironment();
+  const run = mutationTail.then(async () => {
+    if (next === 'release') await AsyncStorage.setItem(STORAGE_KEY, 'release');
+    else await AsyncStorage.removeItem(STORAGE_KEY);
+    activeEnvironment = next;
+    notifyListeners();
+  });
+  mutationTail = run.catch(() => undefined);
+  return run;
+}
+
+export const __testing = {
+  storageKey: STORAGE_KEY,
+  async resetMemory(): Promise<void> {
+    await mutationTail.catch(() => undefined);
+    activeEnvironment = DEFAULT_ENVIRONMENT;
+    hydrated = false;
+    hydratePromise = null;
+    mutationTail = Promise.resolve();
+    listeners.clear();
+  },
+};

--- a/apps/mobile/src/config/env.ts
+++ b/apps/mobile/src/config/env.ts
@@ -372,6 +372,18 @@ export const ENDPOINT_MANIFEST_PEER_BASE_URL = (
   ''
 ).replace(/\/+$/, '');
 
+/**
+ * CindyDev 内部包切换到 CN Release 时使用的第二个可信自举地址。
+ * 只经 Metro 环境变量进入 JS，不属于 ExpoConfig / 原生包身份；正式包恒为空串。
+ */
+export const DEV_RELEASE_ENDPOINT_MANIFEST_BASE_URL =
+  AUTH_REGION === 'dev'
+    ? (
+        process.env
+          .EXPO_PUBLIC_CINDY_DEV_RELEASE_ENDPOINT_MANIFEST_BASE_URL?.trim() || ''
+      ).replace(/\/+$/, '')
+    : '';
+
 function trustedMobileRealmManifestBaseUrls(): RealmManifestBaseUrls {
   return BUILD_AUTH_REGION === 'global'
     ? {
@@ -390,18 +402,21 @@ function trustedMobileRealmManifestBaseUrls(): RealmManifestBaseUrls {
  * 构建区域默认值；跨区域组织会话由 activateMobileSessionRealm 整体切换
  * token 消费端点。
  */
-export function applyResolvedClientEndpoints(resolved: {
-  authApiBaseUrl?: string;
-  oauthBrokerApiBaseUrl?: string;
-  deviceLinkApiBaseUrl?: string;
-  voiceApiBaseUrl?: string;
-  mobileUpdateBaseUrl?: string;
-  /** 审核模式送审版本号(parser 产出,null = 清单未填;undefined = 不改动)。 */
-  reviewVersion?: string | null;
-  /** iOS StoreKit 分发环境；TestFlight 保留 OTA、禁用整包外跳。 */
-  isTestFlight?: boolean;
-  region?: ClientEndpointRegion | null;
-}): void {
+export function applyResolvedClientEndpoints(
+  resolved: {
+    authApiBaseUrl?: string;
+    oauthBrokerApiBaseUrl?: string;
+    deviceLinkApiBaseUrl?: string;
+    voiceApiBaseUrl?: string;
+    mobileUpdateBaseUrl?: string;
+    /** 审核模式送审版本号(parser 产出,null = 清单未填;undefined = 不改动)。 */
+    reviewVersion?: string | null;
+    /** iOS StoreKit 分发环境；TestFlight 保留 OTA、禁用整包外跳。 */
+    isTestFlight?: boolean;
+    region?: ClientEndpointRegion | null;
+  },
+  options: { preserveBuildReleaseMetadata?: boolean } = {},
+): void {
   if (resolved.authApiBaseUrl !== undefined) {
     AUTH_API_BASE_URL = normalizeBaseUrlWithDefault(
       resolved.authApiBaseUrl,
@@ -425,18 +440,29 @@ export function applyResolvedClientEndpoints(resolved: {
   syncBuildTokenEndpointCache();
   // 仅自建变体吃清单覆写,保住「非自建 ⇒ OTA_SERVER_BASE_URL 恒空串」不变量
   // (调用点虽都有 IS_OTA_SELFHOST 门控,这里再挡一层,变体身份始终由烧包决定)。
-  if (resolved.mobileUpdateBaseUrl !== undefined && IS_OTA_SELFHOST) {
+  if (
+    !options.preserveBuildReleaseMetadata &&
+    resolved.mobileUpdateBaseUrl !== undefined &&
+    IS_OTA_SELFHOST
+  ) {
     OTA_SERVER_BASE_URL = resolved.mobileUpdateBaseUrl.replace(/\/+$/, '');
   }
-  if (resolved.reviewVersion !== undefined) {
+  if (
+    !options.preserveBuildReleaseMetadata &&
+    resolved.reviewVersion !== undefined
+  ) {
     resolvedReviewVersion = resolved.reviewVersion;
   }
-  if (resolved.isTestFlight !== undefined) {
+  if (
+    !options.preserveBuildReleaseMetadata &&
+    resolved.isTestFlight !== undefined
+  ) {
     IS_TESTFLIGHT_BUILD = resolved.isTestFlight;
   }
   if (
-    resolved.reviewVersion !== undefined ||
-    resolved.isTestFlight !== undefined
+    !options.preserveBuildReleaseMetadata &&
+    (resolved.reviewVersion !== undefined ||
+      resolved.isTestFlight !== undefined)
   ) {
     REVIEW_MODE = isReviewModeActive(
       resolvedReviewVersion,

--- a/apps/mobile/src/config/useDevServerEnvironment.ts
+++ b/apps/mobile/src/config/useDevServerEnvironment.ts
@@ -1,0 +1,43 @@
+import { useCallback, useEffect, useState } from 'react';
+
+import {
+  getDevServerEnvironment,
+  hydrateDevServerEnvironment,
+  setDevServerEnvironment,
+  subscribeDevServerEnvironment,
+  type DevServerEnvironment,
+} from './devServerEnvironment';
+
+export function useDevServerEnvironment(): {
+  environment: DevServerEnvironment;
+  ready: boolean;
+  setEnvironment: (next: DevServerEnvironment) => Promise<void>;
+} {
+  const [environment, setEnvironmentState] = useState(getDevServerEnvironment);
+  const [ready, setReady] = useState(false);
+
+  useEffect(() => {
+    let cancelled = false;
+    const sync = () => {
+      if (!cancelled) setEnvironmentState(getDevServerEnvironment());
+    };
+    const unsubscribe = subscribeDevServerEnvironment(sync);
+    void hydrateDevServerEnvironment().then(() => {
+      if (!cancelled) {
+        sync();
+        setReady(true);
+      }
+    });
+    return () => {
+      cancelled = true;
+      unsubscribe();
+    };
+  }, []);
+
+  const setEnvironment = useCallback(async (next: DevServerEnvironment) => {
+    await setDevServerEnvironment(next);
+    setEnvironmentState(next);
+  }, []);
+
+  return { environment, ready, setEnvironment };
+}

--- a/apps/mobile/src/config/useStartupEndpointGate.ts
+++ b/apps/mobile/src/config/useStartupEndpointGate.ts
@@ -21,6 +21,8 @@ import {
   DEV_SERVER_ENVIRONMENT_SWITCH_ENABLED,
   buildDevServerEndpointStartupSteps,
   hydrateDevServerEnvironment,
+  runDevServerEndpointStartupSteps,
+  setDevServerEnvironment,
 } from './devServerEnvironment';
 
 export type StartupEndpointGateStatus = 'pending' | 'ready' | 'error';
@@ -29,6 +31,10 @@ export interface StartupEndpointGate {
   status: StartupEndpointGateStatus;
   /** status === 'error' 时的失败原因(fetch-failed / invalid-json / ...)。 */
   reason: string | null;
+  /** Release 业务端点覆盖失败时，唯一动作可将 CindyDev 恢复到 Dev。 */
+  canResetToDev: boolean;
+  /** 清除 Release 选择后重新执行启动闸门。 */
+  resetToDev: () => void;
   /** 错误屏「重试」:回到 pending 并重新拉取。 */
   retry: () => void;
 }
@@ -42,6 +48,7 @@ export function useStartupEndpointGate(): StartupEndpointGate {
     enabled ? 'pending' : 'ready',
   );
   const [reason, setReason] = useState<string | null>(null);
+  const [canResetToDev, setCanResetToDev] = useState(false);
   const [attempt, setAttempt] = useState(0);
   const running = useRef(false);
 
@@ -61,22 +68,23 @@ export function useStartupEndpointGate(): StartupEndpointGate {
         releaseManifestBaseUrl: DEV_RELEASE_ENDPOINT_MANIFEST_BASE_URL,
         switchEnabled: DEV_SERVER_ENVIRONMENT_SWITCH_ENABLED,
       });
-      for (const step of steps) {
-        const outcome = await runStartupEndpointResolve({
+      return runDevServerEndpointStartupSteps(steps, (step) =>
+        runStartupEndpointResolve({
           expectedRegion: BUILD_AUTH_REGION,
           manifestBaseUrl: step.manifestBaseUrl,
           preserveBuildReleaseMetadata: step.preserveBuildReleaseMetadata,
           resolveIsTestFlight: isTestFlightBuild,
-        });
-        if (!outcome.ok) return outcome;
-      }
-      return { ok: true as const, source: 'cdn' as const };
+        }),
+      );
     })().then((outcome) => {
       running.current = false;
       if (cancelled) return;
-      if (outcome.ok) setStatus('ready');
-      else {
+      if (outcome.ok) {
+        setCanResetToDev(false);
+        setStatus('ready');
+      } else {
         setReason(outcome.reason);
+        setCanResetToDev(outcome.canResetToDev);
         setStatus('error');
       }
     });
@@ -87,9 +95,29 @@ export function useStartupEndpointGate(): StartupEndpointGate {
 
   const retry = useCallback(() => {
     setReason(null);
+    setCanResetToDev(false);
     setStatus('pending');
     setAttempt((n) => n + 1);
   }, []);
 
-  return { status, reason, retry };
+  const resetToDev = useCallback(() => {
+    if (running.current) return;
+    running.current = true;
+    setReason(null);
+    setCanResetToDev(false);
+    setStatus('pending');
+    void setDevServerEnvironment('dev')
+      .then(() => {
+        running.current = false;
+        setAttempt((n) => n + 1);
+      })
+      .catch(() => {
+        running.current = false;
+        setReason('environment-reset-failed');
+        setCanResetToDev(true);
+        setStatus('error');
+      });
+  }, []);
+
+  return { status, reason, canResetToDev, resetToDev, retry };
 }

--- a/apps/mobile/src/config/useStartupEndpointGate.ts
+++ b/apps/mobile/src/config/useStartupEndpointGate.ts
@@ -11,7 +11,17 @@ import { useCallback, useEffect, useRef, useState } from 'react';
 
 import { isTestFlightBuild } from '@/platform/appDistribution';
 import { runStartupEndpointResolve } from './clientEndpointStartup';
-import { resolveEnvFlag } from './env';
+import {
+  BUILD_AUTH_REGION,
+  DEV_RELEASE_ENDPOINT_MANIFEST_BASE_URL,
+  ENDPOINT_MANIFEST_BASE_URL,
+  resolveEnvFlag,
+} from './env';
+import {
+  DEV_SERVER_ENVIRONMENT_SWITCH_ENABLED,
+  buildDevServerEndpointStartupSteps,
+  hydrateDevServerEnvironment,
+} from './devServerEnvironment';
 
 export type StartupEndpointGateStatus = 'pending' | 'ready' | 'error';
 
@@ -24,8 +34,13 @@ export interface StartupEndpointGate {
 }
 
 export function useStartupEndpointGate(): StartupEndpointGate {
-  const enabled = !__DEV__ || resolveEnvFlag(process.env.EXPO_PUBLIC_ENDPOINTS_CDN);
-  const [status, setStatus] = useState<StartupEndpointGateStatus>(enabled ? 'pending' : 'ready');
+  const defaultEndpointGateEnabled =
+    !__DEV__ || resolveEnvFlag(process.env.EXPO_PUBLIC_ENDPOINTS_CDN);
+  const enabled =
+    defaultEndpointGateEnabled || DEV_SERVER_ENVIRONMENT_SWITCH_ENABLED;
+  const [status, setStatus] = useState<StartupEndpointGateStatus>(
+    enabled ? 'pending' : 'ready',
+  );
   const [reason, setReason] = useState<string | null>(null);
   const [attempt, setAttempt] = useState(0);
   const running = useRef(false);
@@ -35,12 +50,32 @@ export function useStartupEndpointGate(): StartupEndpointGate {
     if (status === 'error') return; // 等用户点重试
     running.current = true;
     let cancelled = false;
-    void runStartupEndpointResolve({ resolveIsTestFlight: isTestFlightBuild }).then((outcome) => {
+    void (async () => {
+      const environment = DEV_SERVER_ENVIRONMENT_SWITCH_ENABLED
+        ? await hydrateDevServerEnvironment()
+        : 'dev';
+      const steps = buildDevServerEndpointStartupSteps({
+        buildManifestBaseUrl: ENDPOINT_MANIFEST_BASE_URL,
+        defaultEndpointGateEnabled,
+        environment,
+        releaseManifestBaseUrl: DEV_RELEASE_ENDPOINT_MANIFEST_BASE_URL,
+        switchEnabled: DEV_SERVER_ENVIRONMENT_SWITCH_ENABLED,
+      });
+      for (const step of steps) {
+        const outcome = await runStartupEndpointResolve({
+          expectedRegion: BUILD_AUTH_REGION,
+          manifestBaseUrl: step.manifestBaseUrl,
+          preserveBuildReleaseMetadata: step.preserveBuildReleaseMetadata,
+          resolveIsTestFlight: isTestFlightBuild,
+        });
+        if (!outcome.ok) return outcome;
+      }
+      return { ok: true as const, source: 'cdn' as const };
+    })().then((outcome) => {
       running.current = false;
       if (cancelled) return;
-      if (outcome.ok) {
-        setStatus('ready');
-      } else {
+      if (outcome.ok) setStatus('ready');
+      else {
         setReason(outcome.reason);
         setStatus('error');
       }
@@ -48,7 +83,7 @@ export function useStartupEndpointGate(): StartupEndpointGate {
     return () => {
       cancelled = true;
     };
-  }, [enabled, status, attempt]);
+  }, [defaultEndpointGateEnabled, enabled, status, attempt]);
 
   const retry = useCallback(() => {
     setReason(null);

--- a/apps/mobile/src/i18n/locales/en/settings.json
+++ b/apps/mobile/src/i18n/locales/en/settings.json
@@ -85,6 +85,22 @@
     "authServer": "Auth Server",
     "authRegion": "Sign-in Region"
   },
+  "devServerEnvironment": {
+    "title": "Server Environment",
+    "description": "Only affects the backend CindyDev connects to",
+    "accessibility": "Switch server environment",
+    "options": {
+      "dev": "Dev",
+      "release": "Release"
+    },
+    "confirmTitle": "Switch to {{environment}}?",
+    "confirmBody": "Switching signs you out and restarts the app.",
+    "cancel": "Cancel",
+    "switchAction": "Switch",
+    "switching": "Switching",
+    "restartRequired": "The server environment has changed. Fully quit and reopen the app.",
+    "switchFailed": "Could not switch the server environment. Try again."
+  },
   "updateInfo": {
     "embedded": "With app package",
     "embeddedFallback": "With app package (OTA not applied)",

--- a/apps/mobile/src/i18n/locales/en/settings.json
+++ b/apps/mobile/src/i18n/locales/en/settings.json
@@ -98,7 +98,6 @@
     "cancel": "Cancel",
     "switchAction": "Switch",
     "switching": "Switching",
-    "restartRequired": "The server environment has changed. Fully quit and reopen the app.",
     "switchFailed": "Could not switch the server environment. Try again."
   },
   "updateInfo": {

--- a/apps/mobile/src/i18n/locales/ja/settings.json
+++ b/apps/mobile/src/i18n/locales/ja/settings.json
@@ -98,7 +98,6 @@
     "cancel": "キャンセル",
     "switchAction": "切り替える",
     "switching": "切り替え中",
-    "restartRequired": "サーバー環境を切り替えました。App を完全に終了してから再度開いてください。",
     "switchFailed": "サーバー環境を切り替えられませんでした。もう一度お試しください。"
   },
   "updateInfo": {

--- a/apps/mobile/src/i18n/locales/ja/settings.json
+++ b/apps/mobile/src/i18n/locales/ja/settings.json
@@ -85,6 +85,22 @@
     "authServer": "Auth Server",
     "authRegion": "ログインリージョン"
   },
+  "devServerEnvironment": {
+    "title": "サーバー環境",
+    "description": "CindyDev が接続する業務サーバーにのみ影響します",
+    "accessibility": "サーバー環境を切り替える",
+    "options": {
+      "dev": "Dev",
+      "release": "Release"
+    },
+    "confirmTitle": "{{environment}} に切り替えますか？",
+    "confirmBody": "切り替えると現在のアカウントからログアウトし、App を再起動します。",
+    "cancel": "キャンセル",
+    "switchAction": "切り替える",
+    "switching": "切り替え中",
+    "restartRequired": "サーバー環境を切り替えました。App を完全に終了してから再度開いてください。",
+    "switchFailed": "サーバー環境を切り替えられませんでした。もう一度お試しください。"
+  },
   "updateInfo": {
     "embedded": "アプリ本体と同梱",
     "embeddedFallback": "アプリ本体と同梱（OTA 未適用）",

--- a/apps/mobile/src/i18n/locales/ko/settings.json
+++ b/apps/mobile/src/i18n/locales/ko/settings.json
@@ -98,7 +98,6 @@
     "cancel": "취소",
     "switchAction": "전환",
     "switching": "전환 중",
-    "restartRequired": "서버 환경을 전환했습니다. App을 완전히 종료한 후 다시 열어 주세요.",
     "switchFailed": "서버 환경을 전환하지 못했습니다. 다시 시도해 주세요."
   },
   "updateInfo": {

--- a/apps/mobile/src/i18n/locales/ko/settings.json
+++ b/apps/mobile/src/i18n/locales/ko/settings.json
@@ -85,6 +85,22 @@
     "authServer": "Auth Server",
     "authRegion": "로그인 지역"
   },
+  "devServerEnvironment": {
+    "title": "서버 환경",
+    "description": "CindyDev가 연결하는 업무 서버에만 영향을 줍니다",
+    "accessibility": "서버 환경 전환",
+    "options": {
+      "dev": "Dev",
+      "release": "Release"
+    },
+    "confirmTitle": "{{environment}} 환경으로 전환할까요?",
+    "confirmBody": "전환하면 현재 계정에서 로그아웃되고 App이 다시 시작됩니다.",
+    "cancel": "취소",
+    "switchAction": "전환",
+    "switching": "전환 중",
+    "restartRequired": "서버 환경을 전환했습니다. App을 완전히 종료한 후 다시 열어 주세요.",
+    "switchFailed": "서버 환경을 전환하지 못했습니다. 다시 시도해 주세요."
+  },
   "updateInfo": {
     "embedded": "앱 패키지 포함",
     "embeddedFallback": "앱 패키지 포함 (OTA 미적용)",

--- a/apps/mobile/src/i18n/locales/zh-CN/settings.json
+++ b/apps/mobile/src/i18n/locales/zh-CN/settings.json
@@ -85,6 +85,22 @@
     "authServer": "Auth Server",
     "authRegion": "登录区域"
   },
+  "devServerEnvironment": {
+    "title": "服务器环境",
+    "description": "仅影响 CindyDev 连接的业务服务器",
+    "accessibility": "切换服务器环境",
+    "options": {
+      "dev": "Dev",
+      "release": "Release"
+    },
+    "confirmTitle": "切换到 {{environment}}？",
+    "confirmBody": "切换会退出当前账号并重启 App。",
+    "cancel": "取消",
+    "switchAction": "切换",
+    "switching": "切换中",
+    "restartRequired": "服务器环境已切换。请完全退出 App 后重新打开。",
+    "switchFailed": "切换服务器环境失败，请重试。"
+  },
   "updateInfo": {
     "embedded": "随整包",
     "embeddedFallback": "随整包（热更未生效）",

--- a/apps/mobile/src/i18n/locales/zh-CN/settings.json
+++ b/apps/mobile/src/i18n/locales/zh-CN/settings.json
@@ -98,7 +98,6 @@
     "cancel": "取消",
     "switchAction": "切换",
     "switching": "切换中",
-    "restartRequired": "服务器环境已切换。请完全退出 App 后重新打开。",
     "switchFailed": "切换服务器环境失败，请重试。"
   },
   "updateInfo": {

--- a/apps/mobile/src/i18n/locales/zh-TW/settings.json
+++ b/apps/mobile/src/i18n/locales/zh-TW/settings.json
@@ -98,7 +98,6 @@
     "cancel": "取消",
     "switchAction": "切換",
     "switching": "切換中",
-    "restartRequired": "伺服器環境已切換。請完全結束 App 後重新開啟。",
     "switchFailed": "切換伺服器環境失敗，請再試一次。"
   },
   "updateInfo": {

--- a/apps/mobile/src/i18n/locales/zh-TW/settings.json
+++ b/apps/mobile/src/i18n/locales/zh-TW/settings.json
@@ -85,6 +85,22 @@
     "authServer": "Auth Server",
     "authRegion": "登入區域"
   },
+  "devServerEnvironment": {
+    "title": "伺服器環境",
+    "description": "僅影響 CindyDev 連線的業務伺服器",
+    "accessibility": "切換伺服器環境",
+    "options": {
+      "dev": "Dev",
+      "release": "Release"
+    },
+    "confirmTitle": "切換至 {{environment}}？",
+    "confirmBody": "切換會登出目前帳號並重新啟動 App。",
+    "cancel": "取消",
+    "switchAction": "切換",
+    "switching": "切換中",
+    "restartRequired": "伺服器環境已切換。請完全結束 App 後重新開啟。",
+    "switchFailed": "切換伺服器環境失敗，請再試一次。"
+  },
   "updateInfo": {
     "embedded": "隨整包",
     "embeddedFallback": "隨整包（熱更未生效）",

--- a/apps/mobile/src/notifications/pushNotifications.ts
+++ b/apps/mobile/src/notifications/pushNotifications.ts
@@ -9,6 +9,7 @@ import {
   getMobileEndpointForRealm,
   loadMobileEndpointsForRealm,
 } from '@/config/env';
+import { getDevServerEnvironment } from '@/config/devServerEnvironment';
 import Notifications from './nativeNotifications';
 import { buildPushTokenRegistrationBody } from './pushRegistrationModel';
 
@@ -42,6 +43,22 @@ interface PushRealmState {
   realms: ClientEndpointRegion[];
 }
 
+function pushStateStorageKeys(baseKey: string): {
+  primary: string;
+  migrationFallback: string | null;
+} {
+  if (AUTH_REGION !== 'dev') {
+    return { primary: baseKey, migrationFallback: null };
+  }
+  const environment = getDevServerEnvironment();
+  return {
+    primary: `${baseKey}.${environment}`,
+    // 旧 CindyDev 只连接 Dev；无环境后缀的存量状态只能归到 Dev，绝不能
+    // 在首次切到 Release 时误迁移过去。
+    migrationFallback: environment === 'dev' ? baseKey : null,
+  };
+}
+
 /** React effects / token listener / 设置页可能同时触发，串行化避免注册与撤销倒序。 */
 let pushMutationTail: Promise<void> = Promise.resolve();
 /**
@@ -72,7 +89,13 @@ async function readPushRealms(
   legacyRealm: ClientEndpointRegion = BUILD_AUTH_REGION,
 ): Promise<Set<ClientEndpointRegion>> {
   try {
-    const raw = await AsyncStorage.getItem(key);
+    const storageKeys = pushStateStorageKeys(key);
+    const primaryRaw = await AsyncStorage.getItem(storageKeys.primary);
+    const raw =
+      primaryRaw ??
+      (storageKeys.migrationFallback
+        ? await AsyncStorage.getItem(storageKeys.migrationFallback)
+        : null);
     if (!raw || raw === '0') return new Set();
     if (raw === '1') return new Set([legacyRealm]);
     const parsed: unknown = JSON.parse(raw);
@@ -96,15 +119,26 @@ async function writePushRealms(
   key: string,
   realms: ReadonlySet<ClientEndpointRegion>,
 ): Promise<void> {
+  const storageKeys = pushStateStorageKeys(key);
   if (realms.size === 0) {
-    await AsyncStorage.removeItem(key);
+    await AsyncStorage.removeItem(storageKeys.primary);
+    if (storageKeys.migrationFallback) {
+      await AsyncStorage.removeItem(storageKeys.migrationFallback).catch(
+        () => undefined,
+      );
+    }
     return;
   }
   const state: PushRealmState = {
     version: PUSH_REALM_STATE_VERSION,
     realms: (['cn', 'global'] as const).filter((realm) => realms.has(realm)),
   };
-  await AsyncStorage.setItem(key, JSON.stringify(state));
+  await AsyncStorage.setItem(storageKeys.primary, JSON.stringify(state));
+  if (storageKeys.migrationFallback) {
+    await AsyncStorage.removeItem(storageKeys.migrationFallback).catch(
+      () => undefined,
+    );
+  }
 }
 
 async function addPushRealm(

--- a/apps/mobile/src/notifications/pushNotifications.ts
+++ b/apps/mobile/src/notifications/pushNotifications.ts
@@ -9,7 +9,10 @@ import {
   getMobileEndpointForRealm,
   loadMobileEndpointsForRealm,
 } from '@/config/env';
-import { getDevServerEnvironment } from '@/config/devServerEnvironment';
+import {
+  getDevServerEnvironment,
+  type DevServerEnvironment,
+} from '@/config/devServerEnvironment';
 import Notifications from './nativeNotifications';
 import { buildPushTokenRegistrationBody } from './pushRegistrationModel';
 
@@ -43,14 +46,28 @@ interface PushRealmState {
   realms: ClientEndpointRegion[];
 }
 
-function pushStateStorageKeys(baseKey: string): {
+interface PushStateScope {
+  environment: DevServerEnvironment;
+  legacyRealm: ClientEndpointRegion;
+}
+
+/** 一次 mutation 内冻结存储 namespace，不能在异步读写之间重新取当前环境。 */
+function capturePushStateScope(
+  legacyRealm: ClientEndpointRegion = BUILD_AUTH_REGION,
+): PushStateScope {
+  return { environment: getDevServerEnvironment(), legacyRealm };
+}
+
+function pushStateStorageKeys(
+  baseKey: string,
+  environment: DevServerEnvironment,
+): {
   primary: string;
   migrationFallback: string | null;
 } {
   if (AUTH_REGION !== 'dev') {
     return { primary: baseKey, migrationFallback: null };
   }
-  const environment = getDevServerEnvironment();
   return {
     primary: `${baseKey}.${environment}`,
     // 旧 CindyDev 只连接 Dev；无环境后缀的存量状态只能归到 Dev，绝不能
@@ -86,10 +103,10 @@ function isClientEndpointRegion(value: unknown): value is ClientEndpointRegion {
  */
 async function readPushRealms(
   key: string,
-  legacyRealm: ClientEndpointRegion = BUILD_AUTH_REGION,
+  scope: PushStateScope,
 ): Promise<Set<ClientEndpointRegion>> {
   try {
-    const storageKeys = pushStateStorageKeys(key);
+    const storageKeys = pushStateStorageKeys(key, scope.environment);
     const primaryRaw = await AsyncStorage.getItem(storageKeys.primary);
     const raw =
       primaryRaw ??
@@ -97,7 +114,7 @@ async function readPushRealms(
         ? await AsyncStorage.getItem(storageKeys.migrationFallback)
         : null);
     if (!raw || raw === '0') return new Set();
-    if (raw === '1') return new Set([legacyRealm]);
+    if (raw === '1') return new Set([scope.legacyRealm]);
     const parsed: unknown = JSON.parse(raw);
     if (
       typeof parsed !== 'object' ||
@@ -118,8 +135,9 @@ async function readPushRealms(
 async function writePushRealms(
   key: string,
   realms: ReadonlySet<ClientEndpointRegion>,
+  scope: PushStateScope,
 ): Promise<void> {
-  const storageKeys = pushStateStorageKeys(key);
+  const storageKeys = pushStateStorageKeys(key, scope.environment);
   if (realms.size === 0) {
     await AsyncStorage.removeItem(storageKeys.primary);
     if (storageKeys.migrationFallback) {
@@ -144,21 +162,21 @@ async function writePushRealms(
 async function addPushRealm(
   key: string,
   realm: ClientEndpointRegion,
-  legacyRealm: ClientEndpointRegion = realm,
+  scope: PushStateScope,
 ): Promise<void> {
-  const realms = await readPushRealms(key, legacyRealm);
+  const realms = await readPushRealms(key, scope);
   realms.add(realm);
-  await writePushRealms(key, realms);
+  await writePushRealms(key, realms, scope);
 }
 
 async function removePushRealm(
   key: string,
   realm: ClientEndpointRegion,
-  legacyRealm: ClientEndpointRegion = realm,
+  scope: PushStateScope,
 ): Promise<void> {
-  const realms = await readPushRealms(key, legacyRealm);
+  const realms = await readPushRealms(key, scope);
   realms.delete(realm);
-  await writePushRealms(key, realms);
+  await writePushRealms(key, realms, scope);
 }
 
 function normalizeDeviceToken(value: unknown): string | null {
@@ -283,10 +301,14 @@ async function syncPushRegistrationInternal(
   if (!isPushSupported()) return 'unsupported';
   if (lifecycleGeneration !== pushLifecycleGeneration) return 'skipped';
   const realm = getActiveMobileSessionRealm();
+  const stateScope = capturePushStateScope(realm);
   const baseUrl = deviceLinkBaseForRealm(realm);
 
   if (!opts.enabled) {
-    const registeredRealms = await readPushRealms(PUSH_REGISTERED_KEY, realm);
+    const registeredRealms = await readPushRealms(
+      PUSH_REGISTERED_KEY,
+      stateScope,
+    );
     if (lifecycleGeneration !== pushLifecycleGeneration) return 'skipped';
     if (!registeredRealms.has(realm)) return 'skipped';
     const token = await getNativeDeviceTokenBestEffort();
@@ -298,13 +320,13 @@ async function syncPushRegistrationInternal(
         ...(token ? { body: pushDeleteBody(token) } : {}),
       });
     } catch (error) {
-      await addPushRealm(PUSH_PENDING_UNREGISTER_KEY, realm).catch(
+      await addPushRealm(PUSH_PENDING_UNREGISTER_KEY, realm, stateScope).catch(
         () => undefined,
       );
       throw error;
     }
-    await removePushRealm(PUSH_REGISTERED_KEY, realm);
-    await removePushRealm(PUSH_PENDING_UNREGISTER_KEY, realm);
+    await removePushRealm(PUSH_REGISTERED_KEY, realm, stateScope);
+    await removePushRealm(PUSH_PENDING_UNREGISTER_KEY, realm, stateScope);
     return 'unregistered';
   }
 
@@ -327,9 +349,9 @@ async function syncPushRegistrationInternal(
 
   // PUT 响应丢失时无法判断服务端是否提交，发出前即标记“可能已注册”；
   // 后续只能在该区域持有有效会话时做幂等 DELETE。
-  await addPushRealm(PUSH_REGISTERED_KEY, realm);
+  await addPushRealm(PUSH_REGISTERED_KEY, realm, stateScope);
   if (lifecycleGeneration !== pushLifecycleGeneration) {
-    await addPushRealm(PUSH_PENDING_UNREGISTER_KEY, realm);
+    await addPushRealm(PUSH_PENDING_UNREGISTER_KEY, realm, stateScope);
     return 'skipped';
   }
   try {
@@ -340,17 +362,17 @@ async function syncPushRegistrationInternal(
     });
   } catch (error) {
     if (lifecycleGeneration !== pushLifecycleGeneration) {
-      await addPushRealm(PUSH_PENDING_UNREGISTER_KEY, realm).catch(
+      await addPushRealm(PUSH_PENDING_UNREGISTER_KEY, realm, stateScope).catch(
         () => undefined,
       );
     }
     throw error;
   }
   if (lifecycleGeneration !== pushLifecycleGeneration) {
-    await addPushRealm(PUSH_PENDING_UNREGISTER_KEY, realm);
+    await addPushRealm(PUSH_PENDING_UNREGISTER_KEY, realm, stateScope);
     return 'skipped';
   }
-  await removePushRealm(PUSH_PENDING_UNREGISTER_KEY, realm);
+  await removePushRealm(PUSH_PENDING_UNREGISTER_KEY, realm, stateScope);
   return 'registered';
 }
 
@@ -373,20 +395,24 @@ async function unregisterPushTokenBestEffortInternal(
   accessToken: string | null,
 ): Promise<void> {
   if (!isPushSupported()) return;
+  const stateScope = capturePushStateScope(realm);
   try {
-    const registeredRealms = await readPushRealms(PUSH_REGISTERED_KEY, realm);
+    const registeredRealms = await readPushRealms(
+      PUSH_REGISTERED_KEY,
+      stateScope,
+    );
     if (!registeredRealms.has(realm)) return;
 
-    await addPushRealm(PUSH_PENDING_UNREGISTER_KEY, realm);
+    await addPushRealm(PUSH_PENDING_UNREGISTER_KEY, realm, stateScope);
     if (!accessToken) return;
 
     await deletePushTokenWithAccessToken(realm, accessToken);
-    await removePushRealm(PUSH_REGISTERED_KEY, realm);
-    await removePushRealm(PUSH_PENDING_UNREGISTER_KEY, realm);
+    await removePushRealm(PUSH_REGISTERED_KEY, realm, stateScope);
+    await removePushRealm(PUSH_PENDING_UNREGISTER_KEY, realm, stateScope);
   } catch {
     // 离线/超时/旧 token 失效不能阻断退出或切换。标记只在以后登录同一区域时
     // 重试，绝不引入服务端互信或客户端跨区 token 发送。
-    await addPushRealm(PUSH_PENDING_UNREGISTER_KEY, realm).catch(
+    await addPushRealm(PUSH_PENDING_UNREGISTER_KEY, realm, stateScope).catch(
       () => undefined,
     );
   }
@@ -411,9 +437,10 @@ async function retryPendingUnregisterInternal(
 ): Promise<void> {
   if (!isPushSupported()) return;
   const realm = getActiveMobileSessionRealm();
+  const stateScope = capturePushStateScope(realm);
   const pendingRealms = await readPushRealms(
     PUSH_PENDING_UNREGISTER_KEY,
-    realm,
+    stateScope,
   );
   if (!pendingRealms.has(realm)) return;
 
@@ -424,8 +451,8 @@ async function retryPendingUnregisterInternal(
       method: 'DELETE',
       ...(token ? { body: pushDeleteBody(token) } : {}),
     });
-    await removePushRealm(PUSH_PENDING_UNREGISTER_KEY, realm);
-    await removePushRealm(PUSH_REGISTERED_KEY, realm);
+    await removePushRealm(PUSH_PENDING_UNREGISTER_KEY, realm, stateScope);
+    await removePushRealm(PUSH_REGISTERED_KEY, realm, stateScope);
   } catch {
     // 仍失败：保留当前区域标记，下次同区登录继续补偿。
   }

--- a/i18n/GLOSSARY.md
+++ b/i18n/GLOSSARY.md
@@ -203,6 +203,10 @@ Cindy 在 X 上发出的那条公开回复。zh-CN 取「回帖」以强调它�
 
 应用异常终止。此前只出现在内部日志里, 随日志上报进入用户可见文案, 因此登记。ko 取音译「크래시」而非「충돌」——后者在韩语里更常指冲突/碰撞(如合并冲突), 会与 merge conflict 语境混读。proposed。
 
+### Release
+
+CindyDev 内部设置中的正式业务服务器环境标签，五语固定保留英文 Release。它表示 App 当前连接哪套服务，不代表安装包发行版本、OTA 通道或 cn / global 区域；因 release 也是普通英文单词，关闭全局大小写扫描，具体 UI key 由 Mobile 定向测试约束。
+
 ### Device
 
 device-link 里「可以选择在哪台机器上运行」这一维度，两端统一叫「设备」。desktop 的 machineSwitcher 本来就是 This device / このデバイス / 이 기기，mobile 原先用 computer 系（选择电脑 / パソコンを選択 / 컴퓨터 선택），2026-07 裁决为向 device 系对齐，与既有 device-code（设备码 / デバイスコード / 기기 코드）同口径。alsoAllowed 保留「电脑」系：指代桌面端物理机的文案（安装、导出、等待确认）换成「设备」反而不通中文，那是 desktop/PC 的意思，不是这里的目标维度。
@@ -311,7 +315,7 @@ OS 进程语境(资源用量面板、浏览器 guest 进程、终端)。注意�
 
 ### Dev
 
-dev 版登录页区域徽标上的标签值（DESIGN.md §16.3），四语同值、不翻译，理由同 region-code-cn。与 CN 不同的是 dev 还是个普通技术词：豁免的两条文案里“Always on in dev mode.”“dev builds may be authorized…”“dev 模式下始终开启”指的是开发模式而非本区域标签，小写本就正确（四语同 key 一并覆盖）。用 exempt 精确豁免这两条、而不是整条关掉 checkCase，是为了保住徽标值本身的大小写约束——这正是本条存在的意义。2026-07-28 起同一代号也用于 submit_github_issue 的提交确认卡片与 issue 正文（`issueAgent.confirm.regionCodeDev`）与侧栏用户卡片版本行（`sidebar.user.regionCodeDev`），口径与徽标完全一致：global 不标；「哪些区域要标」的唯一事实源是 `apps/desktop/src/shared/regionCode.ts`。
+dev 版登录页区域徽标上的标签值（DESIGN.md §16.3），四语同值、不翻译，理由同 region-code-cn。与 CN 不同的是 dev 还是个普通技术词：豁免的两条文案里“Always on in dev mode.”“dev builds may be authorized…”“dev 模式下始终开启”指的是开发模式而非本区域标签，小写本就正确（四语同 key 一并覆盖）。用 exempt 精确豁免这两条、而不是整条关掉 checkCase，是为了保住徽标值本身的大小写约束——这正是本条存在的意义。2026-07-28 起同一代号也用于 submit_github_issue 的提交确认卡片与 issue 正文（`issueAgent.confirm.regionCodeDev`）与侧栏用户卡片版本行（`sidebar.user.regionCodeDev`），口径与徽标完全一致：global 不标；「哪些区域要标」的唯一事实源是 `apps/desktop/src/shared/regionCode.ts`。2026-08-26 起 CindyDev 内部的业务服务器环境切换也沿用 Dev 标签；这里只表示所连接的服务环境，不能据此改变安装包区域或身份。
 
 已确定禁用：`开发版（仅当英文含 Dev）`（zh-CN）、`開発版（仅当英文含 Dev）`（ja）、`개발판（仅当英文含 Dev）`（ko）
 

--- a/i18n/glossary.json
+++ b/i18n/glossary.json
@@ -288,6 +288,7 @@
       "en": "Dev",
       "translations": {
         "zh-CN": "Dev",
+        "zh-TW": "Dev",
         "ja": "Dev",
         "ko": "Dev"
       },
@@ -315,7 +316,20 @@
         "desktop:settings.about.debugLogDescription",
         "desktop:settings.voiceInput.permissions.inputMonitoring.tooltip"
       ],
-      "note": "dev 版登录页区域徽标上的标签值（DESIGN.md §16.3），四语同值、不翻译，理由同 region-code-cn。与 CN 不同的是 dev 还是个普通技术词：豁免的两条文案里“Always on in dev mode.”“dev builds may be authorized…”“dev 模式下始终开启”指的是开发模式而非本区域标签，小写本就正确（四语同 key 一并覆盖）。用 exempt 精确豁免这两条、而不是整条关掉 checkCase，是为了保住徽标值本身的大小写约束——这正是本条存在的意义。2026-07-28 起同一代号也用于 submit_github_issue 的提交确认卡片与 issue 正文（`issueAgent.confirm.regionCodeDev`）与侧栏用户卡片版本行（`sidebar.user.regionCodeDev`），口径与徽标完全一致：global 不标；「哪些区域要标」的唯一事实源是 `apps/desktop/src/shared/regionCode.ts`。"
+      "note": "dev 版登录页区域徽标上的标签值（DESIGN.md §16.3），四语同值、不翻译，理由同 region-code-cn。与 CN 不同的是 dev 还是个普通技术词：豁免的两条文案里“Always on in dev mode.”“dev builds may be authorized…”“dev 模式下始终开启”指的是开发模式而非本区域标签，小写本就正确（四语同 key 一并覆盖）。用 exempt 精确豁免这两条、而不是整条关掉 checkCase，是为了保住徽标值本身的大小写约束——这正是本条存在的意义。2026-07-28 起同一代号也用于 submit_github_issue 的提交确认卡片与 issue 正文（`issueAgent.confirm.regionCodeDev`）与侧栏用户卡片版本行（`sidebar.user.regionCodeDev`），口径与徽标完全一致：global 不标；「哪些区域要标」的唯一事实源是 `apps/desktop/src/shared/regionCode.ts`。2026-08-26 起 CindyDev 内部的业务服务器环境切换也沿用 Dev 标签；这里只表示所连接的服务环境，不能据此改变安装包区域或身份。"
+    },
+    {
+      "id": "dev-server-environment-release",
+      "status": "proposed",
+      "en": "Release",
+      "translations": {
+        "zh-CN": "Release",
+        "zh-TW": "Release",
+        "ja": "Release",
+        "ko": "Release"
+      },
+      "checkCase": false,
+      "note": "CindyDev 内部设置中的正式业务服务器环境标签，五语固定保留英文 Release。它表示 App 当前连接哪套服务，不代表安装包发行版本、OTA 通道或 cn / global 区域；因 release 也是普通英文单词，关闭全局大小写扫描，具体 UI key 由 Mobile 定向测试约束。"
     },
     {
       "id": "agent",

--- a/scripts/__tests__/client-endpoint-build-env.test.mjs
+++ b/scripts/__tests__/client-endpoint-build-env.test.mjs
@@ -94,6 +94,21 @@ test('Mobile bundling 进程环境只在 CindyDev 保留 Release 清单基址', 
   );
 });
 
+test('Mobile 构建入口不把动态异常或环境变量值写入失败日志', () => {
+  for (const relativePath of [
+    'apps/mobile/scripts/build-android.mjs',
+    'apps/mobile/scripts/build-ios.mjs',
+  ]) {
+    const source = fs.readFileSync(path.resolve(relativePath), 'utf8');
+    const catchBlock = source.slice(source.lastIndexOf('main().catch('));
+
+    assert.match(catchBlock, /main\(\)\.catch\(\(\) => \{/);
+    assert.doesNotMatch(catchBlock, /process\.env/);
+    assert.doesNotMatch(catchBlock, /err(?:or)?\??\.(?:message|stack)/i);
+    assert.doesNotMatch(catchBlock, /scrubSecretsFromText/);
+  }
+});
+
 test('端点清单自举基址缺失、非法协议或携带凭据时 fail closed', () => {
   const repoRoot = writeRepoFixtures();
   const cnPath = path.join(repoRoot, 'config', 'endpoint.json');

--- a/scripts/__tests__/client-endpoint-build-env.test.mjs
+++ b/scripts/__tests__/client-endpoint-build-env.test.mjs
@@ -9,6 +9,7 @@ import {
   loadEndpointManifestBaseUrl,
   loadPeerEndpointManifestBaseUrl,
   mobileClientBundleEnv,
+  mobileClientBundleProcessEnv,
   mobileClientBuildEnv,
 } from '../shared/client-endpoint-build-env.mjs';
 import { resolveReleaseCdnBaseUrl } from '../shared/release-env.mjs';
@@ -47,9 +48,49 @@ test('desktop/mobile 构建从 region 清单的 cdnBaseUrl 生成自举环境变
     EXPO_PUBLIC_ENDPOINT_MANIFEST_BASE_URL: 'https://hotfix-global.example.invalid/app',
     EXPO_PUBLIC_ENDPOINT_MANIFEST_PEER_BASE_URL: 'https://hotfix-cn.example.invalid/app',
   });
+  assert.deepEqual(mobileClientBundleEnv({ authRegion: 'dev', repoRoot }), {
+    EXPO_PUBLIC_CINDY_AUTH_REGION: 'dev',
+    EXPO_PUBLIC_ENDPOINT_MANIFEST_BASE_URL: 'https://hotfix-dev.example.invalid/app',
+    EXPO_PUBLIC_ENDPOINT_MANIFEST_PEER_BASE_URL: 'https://hotfix-global.example.invalid/app',
+    EXPO_PUBLIC_CINDY_DEV_RELEASE_ENDPOINT_MANIFEST_BASE_URL:
+      'https://hotfix-cn.example.invalid/app',
+  });
   assert.equal(
     loadPeerEndpointManifestBaseUrl({ authRegion: 'cn', repoRoot }),
     'https://hotfix-global.example.invalid/app',
+  );
+});
+
+test('Mobile bundling 进程环境只在 CindyDev 保留 Release 清单基址', () => {
+  const repoRoot = writeRepoFixtures();
+  const staleBaseEnv = {
+    KEEP_ME: '1',
+    EXPO_PUBLIC_CINDY_DEV_RELEASE_ENDPOINT_MANIFEST_BASE_URL:
+      'https://stale-release.example.invalid/app',
+  };
+
+  const cn = mobileClientBundleProcessEnv({
+    authRegion: 'cn',
+    baseEnv: staleBaseEnv,
+    repoRoot,
+  });
+  assert.equal(cn.KEEP_ME, '1');
+  assert.equal(
+    Object.hasOwn(
+      cn,
+      'EXPO_PUBLIC_CINDY_DEV_RELEASE_ENDPOINT_MANIFEST_BASE_URL',
+    ),
+    false,
+  );
+
+  const dev = mobileClientBundleProcessEnv({
+    authRegion: 'dev',
+    baseEnv: staleBaseEnv,
+    repoRoot,
+  });
+  assert.equal(
+    dev.EXPO_PUBLIC_CINDY_DEV_RELEASE_ENDPOINT_MANIFEST_BASE_URL,
+    'https://hotfix-cn.example.invalid/app',
   );
 });
 
@@ -92,6 +133,10 @@ function writeRepoFixtures() {
   fs.writeFileSync(
     path.join(configDir, 'endpoint.global.json'),
     JSON.stringify({ schemaVersion: 1, cdnBaseUrl: 'https://hotfix-global.example.invalid/app/' }),
+  );
+  fs.writeFileSync(
+    path.join(configDir, 'endpoint.dev.json'),
+    JSON.stringify({ schemaVersion: 1, cdnBaseUrl: 'https://hotfix-dev.example.invalid/app/' }),
   );
   return repoRoot;
 }

--- a/scripts/__tests__/client-endpoint-build-env.test.mjs
+++ b/scripts/__tests__/client-endpoint-build-env.test.mjs
@@ -131,6 +131,27 @@ test('Android 构建在子进程启动前失败时输出安全且可执行的诊
   assert.doesNotMatch(result.stderr, /详细原因请查看上方构建工具输出/);
 });
 
+test('iOS 构建在子进程启动前失败时输出安全且可执行的诊断', () => {
+  const fakeSecret = 'fake-ios-signing-secret-that-must-not-leak';
+  const result = spawnSync(
+    process.execPath,
+    [path.resolve('apps/mobile/scripts/build-ios.mjs'), '--region', 'invalid'],
+    {
+      encoding: 'utf8',
+      env: {
+        ...process.env,
+        XDT_IOS_SIGNING_SECRET_DEV: fakeSecret,
+      },
+    },
+  );
+
+  assert.equal(result.status, 1);
+  assert.match(result.stderr, /iOS 构建失败（参数检查）/);
+  assert.match(result.stderr, /--region cn\|global\|dev/);
+  assert.doesNotMatch(result.stderr, new RegExp(fakeSecret));
+  assert.doesNotMatch(result.stderr, /详细原因请查看上方构建工具输出/);
+});
+
 test('端点清单自举基址缺失、非法协议或携带凭据时 fail closed', () => {
   const repoRoot = writeRepoFixtures();
   const cnPath = path.join(repoRoot, 'config', 'endpoint.json');

--- a/scripts/__tests__/client-endpoint-build-env.test.mjs
+++ b/scripts/__tests__/client-endpoint-build-env.test.mjs
@@ -1,4 +1,5 @@
 import assert from 'node:assert/strict';
+import { spawnSync } from 'node:child_process';
 import fs from 'node:fs';
 import os from 'node:os';
 import path from 'node:path';
@@ -107,6 +108,27 @@ test('Mobile 构建入口不把动态异常或环境变量值写入失败日志'
     assert.doesNotMatch(catchBlock, /err(?:or)?\??\.(?:message|stack)/i);
     assert.doesNotMatch(catchBlock, /scrubSecretsFromText/);
   }
+});
+
+test('Android 构建在子进程启动前失败时输出安全且可执行的诊断', () => {
+  const fakeSecret = 'fake-keystore-password-that-must-not-leak';
+  const result = spawnSync(
+    process.execPath,
+    [path.resolve('apps/mobile/scripts/build-android.mjs'), '--region', 'invalid'],
+    {
+      encoding: 'utf8',
+      env: {
+        ...process.env,
+        XDT_ANDROID_KEYSTORE_PASSWORD_DEV: fakeSecret,
+      },
+    },
+  );
+
+  assert.equal(result.status, 1);
+  assert.match(result.stderr, /Android 构建失败（参数检查）/);
+  assert.match(result.stderr, /--region cn\|global\|dev/);
+  assert.doesNotMatch(result.stderr, new RegExp(fakeSecret));
+  assert.doesNotMatch(result.stderr, /详细原因请查看上方构建工具输出/);
 });
 
 test('端点清单自举基址缺失、非法协议或携带凭据时 fail closed', () => {

--- a/scripts/shared/client-endpoint-build-env.mjs
+++ b/scripts/shared/client-endpoint-build-env.mjs
@@ -121,16 +121,44 @@ export function mobileClientBuildEnv({ authRegion, repoRoot } = {}) {
 }
 
 /**
- * Mobile JS bundle 额外需要对端区域清单基址。与 mobileClientBuildEnv 分开，
- * 避免把这个纯 JS 变量加入 app.config 的既有 Expo extra / runtime fingerprint。
+ * Mobile JS bundle 额外需要对端区域清单基址；CindyDev 还需要 CN Release
+ * 清单基址供内部运行时切换。与 mobileClientBuildEnv 分开，避免把这些纯 JS
+ * 变量加入 app.config 的既有 Expo extra / runtime fingerprint。
  */
 export function mobileClientBundleEnv(options = {}) {
   const buildEnv = mobileClientBuildEnv(options);
+  const authRegion = buildEnv.EXPO_PUBLIC_CINDY_AUTH_REGION;
   return {
     ...buildEnv,
     EXPO_PUBLIC_ENDPOINT_MANIFEST_PEER_BASE_URL: loadPeerEndpointManifestBaseUrl({
-      authRegion: buildEnv.EXPO_PUBLIC_CINDY_AUTH_REGION,
+      authRegion,
       repoRoot: options.repoRoot,
     }),
+    ...(authRegion === 'dev'
+      ? {
+          EXPO_PUBLIC_CINDY_DEV_RELEASE_ENDPOINT_MANIFEST_BASE_URL:
+            loadEndpointManifestBaseUrl({
+              authRegion: 'cn',
+              repoRoot: options.repoRoot,
+            }),
+        }
+      : {}),
   };
+}
+
+/**
+ * 合并最终传给 Mobile bundling 子进程的环境。正式构建必须主动删除 runner
+ * 可能残留的 CindyDev Release 清单变量，不能只依赖 app.config.js 在子进程内清理。
+ */
+export function mobileClientBundleProcessEnv({
+  authRegion,
+  baseEnv = process.env,
+  repoRoot,
+} = {}) {
+  const bundleEnv = mobileClientBundleEnv({ authRegion, repoRoot });
+  const env = { ...baseEnv, ...bundleEnv };
+  if (bundleEnv.EXPO_PUBLIC_CINDY_AUTH_REGION !== 'dev') {
+    delete env.EXPO_PUBLIC_CINDY_DEV_RELEASE_ENDPOINT_MANIFEST_BASE_URL;
+  }
+  return env;
 }


### PR DESCRIPTION
## 这次改了什么

### 摘要

为 CindyDev 内部包增加 Dev / Release 业务服务器运行时切换能力，便于同一个开发包在开发环境与中国大陆 Release 环境间验证。切换会先清理旧环境登录态、推送注册和相关缓存，保存选择后重载应用，避免跨环境复用账号或推送状态。

同时收紧构建环境注入：CindyDev 的 Release 清单基址由客户端仓配置派生并只进入 JS bundle；CN / Global 正式包会主动清除 runner 可能残留的开发专用变量。

### 变更类型

- [x] feat 新功能
- [x] fix 缺陷修复
- [ ] refactor / perf 重构或性能优化
- [ ] docs / test / chore 文档、测试或工程维护
- [ ] 其他：

### 范围

- 关联 Issue / 需求：CindyDev 内部包运行时切换 Dev 与 Release 业务服务器
- 本 PR 包含：设置页开发功能入口、环境选择持久化、启动端点覆盖、登录态与推送状态隔离、移动端 bundle 环境注入与正式包残留清理、相关多语言文案和单元测试
- 明确不包含：打包仓脚本修改、服务端修改、Bundle ID / Scheme / 签名 / OTA 渠道 / 审核信息调整
- 用户可见变化：仅 CindyDev 的设置页开发信息区域新增“服务器环境”入口；CN / Global 正式包无入口且行为不变
- 是否存在 breaking change：无

### UI 变化

仅 CindyDev 设置页的开发信息区域新增一行服务器环境状态。点击后显示确认弹窗，确认切换会退出当前账号并重载应用。未附截图或录屏，本次未执行实机 UI 验证。

- 引用的设计规范：DESIGN.md §4 Component Stylings（复用现有设置行与确认弹窗）、§5 Layout Principles（沿用现有设置区布局与间距）、§8 Mobile、§10 Theme System & Token Reference（Light / Dark Dual-Mode Delivery Gate 与语义 token）、§11 Voice & Content（五种语言文案保持简洁并说明退出登录影响）

## 怎么验证的

### 自动验证

~~~text
pnpm test:unit:related
结果：通过；test runner 共 433 个用例，425 个通过、8 个跳过、0 个失败；apps/mobile 单元测试通过。

pnpm --filter mobile run --if-present typecheck
结果：通过。

pnpm check:dco
结果：通过；本 PR 的 2 个提交均带有效 Signed-off-by。

git diff --check
结果：通过。
~~~

补充定向核对：客户端构建环境 helper 4/4、nativeAppConfig 18/18、releaseLib 10/10 均通过。当前实现的 iOS 与 Android runtime fingerprint 均成功计算，并已确认与 origin/main 基线一致。

### 手工验证

不涉及：未执行移动端实机或模拟器手工验证。

### 未执行的验证

- 未执行全仓 pnpm test:unit：按仓库工作流使用 pnpm test:unit:related，完整单测由 GitHub CI 执行。
- 未执行移动端实机 / 模拟器验证。当前分支为 cindy/proud-kapitsa，worktree 为 D:/projects/cindy/.cindy-worktrees/proud-kapitsa；未启动 Metro，因此没有 Metro 归属或 __DEV__ build label 证据。
- Light / Dark 两种模式均未做实机目检；新增入口复用现有 themed 设置行与系统确认弹窗，但不将此视为双模式实机验证。

## 风险

### 风险分类

- [ ] 无已知风险
- [ ] SQLite / migration
- [ ] system prompt
- [ ] 协议兼容
- [x] 权限 / 安全 / 用户数据
- [ ] 存量插件兼容（批准状态 / 指纹 / manifest 校验 / 安装布局 / 包格式）
- [x] 原生层 / fingerprint / OTA
- [x] 跨平台差异
- [ ] 其他：

### 影响与回滚

- 影响范围：仅 EXPO_PUBLIC_CINDY_AUTH_REGION=dev 的 CindyDev。用户主动切换环境时会退出登录、清理旧推送注册与缓存并重载；Release 选择只覆盖业务端点，OTA、审核信息和原生应用身份继续保持 CindyDev。推送状态按 dev / release 隔离。CN / Global 正式包不展示入口，并主动删除开发专用 bundle 变量。
- 冷更判断：不会触发冷更。新增 Release 清单基址仅进入 JS bundle，不进入 Expo extra 或其它原生配置输入；iOS / Android runtime fingerprint 已与 origin/main 基线确认一致。
- 跨平台差异：iOS 与 Android 构建入口统一使用同一个最终 bundle 环境 helper，没有平台特有交互分支；两端均未做实机验证。
- 回滚 / 降级方式：回滚本 PR 的两个提交即可恢复 CindyDev 固定连接 Dev 服务器的行为；服务端和正式包不需要配套回滚。

### 提交前检查

- [x] 已 review 完整 diff
- [x] 每个 commit 都带 DCO 签名（git commit -s，见 DCO）
- [x] UI 改动已在「UI 变化」注明引用的设计规范章节（不涉及 UI 则跳过）
- [x] 未提交凭证、令牌或授权文件
- [x] 已补充必要文档
- [x] 已确认测试结果或说明未执行原因