### PR TITLE
fix(windows): harden auth ACL and stabilize unit tests

### DIFF
--- a/apps/desktop/src/main/doc-tools/__tests__/htmlPdfRenderer.test.ts
+++ b/apps/desktop/src/main/doc-tools/__tests__/htmlPdfRenderer.test.ts
@@ -11,12 +11,29 @@
  */
 
 import { EventEmitter } from 'node:events';
-import { promises as fs } from 'node:fs';
+import fsSync, { promises as fs } from 'node:fs';
 import os from 'node:os';
 import path from 'node:path';
 import { pathToFileURL } from 'node:url';
 
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+// Windows 未开启开发者模式且进程无特权时创建文件 symlink 会 EPERM。精确探测
+// 本文件需要的链接形态，能力缺失时仅跳过两条 symlink 专属安全覆盖。
+const canSymlinkFile = (() => {
+  const probeDir = fsSync.mkdtempSync(path.join(os.tmpdir(), 'cindy-docs-renderer-symlink-probe-'));
+  try {
+    const target = path.join(probeDir, 'target.txt');
+    fsSync.writeFileSync(target, 'probe');
+    fsSync.symlinkSync(target, path.join(probeDir, 'link.txt'), 'file');
+    return true;
+  } catch {
+    return false;
+  } finally {
+    fsSync.rmSync(probeDir, { recursive: true, force: true });
+  }
+})();
+const fileSymlinkIt = canSymlinkFile ? it : it.skip;
 
 interface FakeWindowOptions {
   webPreferences?: Record<string, unknown>;
@@ -195,7 +212,7 @@ describe('渲染窗的安全配置', () => {
     expect(win.shown).toBe(false);
   });
 
-  it('本地资源路径含 symlink 时 fail closed,不把 file URL 交给 Chromium', async () => {
+  fileSymlinkIt('本地资源路径含 symlink 时 fail closed,不把 file URL 交给 Chromium', async () => {
     const sourceDir = path.join(tempRoot, 'source');
     const outsideDir = path.join(tempRoot, 'outside');
     await Promise.all([fs.mkdir(sourceDir), fs.mkdir(outsideDir)]);
@@ -295,7 +312,7 @@ describe('渲染主流程', () => {
     await expect(fs.stat(source)).resolves.toBeTruthy();
   });
 
-  it('主文档快照完成后源路径被换成外部链接也不会改变待打印内容', async () => {
+  fileSymlinkIt('主文档快照完成后源路径被换成外部链接也不会改变待打印内容', async () => {
     const source = path.join(tempRoot, 'src.html');
     const outside = path.join(tempRoot, 'outside.html');
     const moved = path.join(tempRoot, 'src-original.html');

--- a/apps/desktop/src/main/doc-tools/__tests__/htmlPdfRenderer.test.ts
+++ b/apps/desktop/src/main/doc-tools/__tests__/htmlPdfRenderer.test.ts
@@ -11,29 +11,17 @@
  */
 
 import { EventEmitter } from 'node:events';
-import fsSync, { promises as fs } from 'node:fs';
+import { promises as fs } from 'node:fs';
 import os from 'node:os';
 import path from 'node:path';
 import { pathToFileURL } from 'node:url';
 
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
-// Windows 未开启开发者模式且进程无特权时创建文件 symlink 会 EPERM。精确探测
-// 本文件需要的链接形态，能力缺失时仅跳过两条 symlink 专属安全覆盖。
-const canSymlinkFile = (() => {
-  const probeDir = fsSync.mkdtempSync(path.join(os.tmpdir(), 'cindy-docs-renderer-symlink-probe-'));
-  try {
-    const target = path.join(probeDir, 'target.txt');
-    fsSync.writeFileSync(target, 'probe');
-    fsSync.symlinkSync(target, path.join(probeDir, 'link.txt'), 'file');
-    return true;
-  } catch {
-    return false;
-  } finally {
-    fsSync.rmSync(probeDir, { recursive: true, force: true });
-  }
-})();
-const fileSymlinkIt = canSymlinkFile ? it : it.skip;
+function isWindowsFileSymlinkPrivilegeError(error: unknown): boolean {
+  const code = (error as NodeJS.ErrnoException).code;
+  return process.platform === 'win32' && (code === 'EPERM' || code === 'EACCES');
+}
 
 interface FakeWindowOptions {
   webPreferences?: Record<string, unknown>;
@@ -212,18 +200,28 @@ describe('渲染窗的安全配置', () => {
     expect(win.shown).toBe(false);
   });
 
-  fileSymlinkIt('本地资源路径含 symlink 时 fail closed,不把 file URL 交给 Chromium', async () => {
+  it('本地资源路径含 symlink 时 fail closed,不把 file URL 交给 Chromium', async ({
+    skip,
+  }) => {
     const sourceDir = path.join(tempRoot, 'source');
     const outsideDir = path.join(tempRoot, 'outside');
     await Promise.all([fs.mkdir(sourceDir), fs.mkdir(outsideDir)]);
     await fs.writeFile(path.join(sourceDir, 'src.html'), '<p>x</p>');
     await fs.writeFile(path.join(outsideDir, 'secret.png'), 'secret');
     const link = path.join(sourceDir, 'secret.png');
-    await fs.symlink(
-      path.join(outsideDir, 'secret.png'),
-      link,
-      process.platform === 'win32' ? 'file' : undefined,
-    );
+    try {
+      await fs.symlink(
+        path.join(outsideDir, 'secret.png'),
+        link,
+        process.platform === 'win32' ? 'file' : undefined,
+      );
+    } catch (error) {
+      if (isWindowsFileSymlinkPrivilegeError(error)) {
+        skip();
+        return;
+      }
+      throw error;
+    }
     await renderHtmlToPdf({
       ...BASE_INPUT,
       htmlBytes: await fs.readFile(path.join(sourceDir, 'src.html')),
@@ -312,7 +310,7 @@ describe('渲染主流程', () => {
     await expect(fs.stat(source)).resolves.toBeTruthy();
   });
 
-  fileSymlinkIt('主文档快照完成后源路径被换成外部链接也不会改变待打印内容', async () => {
+  it('主文档快照完成后源路径被换成外部链接也不会改变待打印内容', async ({ skip }) => {
     const source = path.join(tempRoot, 'src.html');
     const outside = path.join(tempRoot, 'outside.html');
     const moved = path.join(tempRoot, 'src-original.html');
@@ -320,7 +318,15 @@ describe('渲染主流程', () => {
     await fs.writeFile(outside, '<p>outside</p>', 'utf-8');
     const snapshot = await fs.readFile(source);
     await fs.rename(source, moved);
-    await fs.symlink(outside, source, process.platform === 'win32' ? 'file' : undefined);
+    try {
+      await fs.symlink(outside, source, process.platform === 'win32' ? 'file' : undefined);
+    } catch (error) {
+      if (isWindowsFileSymlinkPrivilegeError(error)) {
+        skip();
+        return;
+      }
+      throw error;
+    }
     let loadedContent = '';
     FakeBrowserWindow.loadBehavior = async (_win, file) => {
       loadedContent = await fs.readFile(file, 'utf-8');

--- a/apps/desktop/src/main/maker-host/__tests__/codexAuthInvalidation.test.ts
+++ b/apps/desktop/src/main/maker-host/__tests__/codexAuthInvalidation.test.ts
@@ -128,6 +128,18 @@ afterEach(() => {
 });
 
 describe('Codex system credential suppression marker', () => {
+  it('qualifies the Windows ACL principal when the machine and user names can collide', async () => {
+    const { resolveWindowsAclPrincipal } = await import('../auth-adapters.js');
+
+    expect(
+      resolveWindowsAclPrincipal({ USERDOMAIN: 'WORKSTATION', USERNAME: 'alex' }, 'fallback'),
+    ).toBe('WORKSTATION\\alex');
+    expect(
+      resolveWindowsAclPrincipal({ USERDOMAIN: 'WORKSTATION', USERNAME: 'DOMAIN\\alex' }, 'fallback'),
+    ).toBe('DOMAIN\\alex');
+    expect(resolveWindowsAclPrincipal({}, 'fallback')).toBe('fallback');
+  });
+
   it('user disconnect persists as reconcile suppression without surfacing an auth error', () => {
     const { codexHome, systemAuth, localAuth } = fixture();
     writeInvalidatedSystemCodexAuthMarker(

--- a/apps/desktop/src/main/maker-host/auth-adapters.ts
+++ b/apps/desktop/src/main/maker-host/auth-adapters.ts
@@ -389,10 +389,23 @@ export async function clearCodexAuthBoundaryStateBeforeLogin(
  * Windows: 用 icacls 把文件权限收紧为"仅当前用户 Full"。
  * 失败仅 stderr 告警, 不抛 —— userData ACL + 0o600 已经是双保险, icacls 是第三道。
  */
+export function resolveWindowsAclPrincipal(
+  env: Partial<Pick<NodeJS.ProcessEnv, 'USERDOMAIN' | 'USERNAME'>> = process.env,
+  fallbackUsername = os.userInfo().username,
+): string {
+  const username = env.USERNAME?.trim() || fallbackUsername.trim();
+  const domain = env.USERDOMAIN?.trim();
+  if (!domain || username.includes('\\') || username.includes('@')) return username;
+  return `${domain}\\${username}`;
+}
+
 async function tightenAclWindows(file: string): Promise<void> {
-  const username = process.env.USERNAME ?? os.userInfo().username;
+  const principal = resolveWindowsAclPrincipal();
   try {
-    await execFileP('icacls', [file, '/inheritance:r', '/grant:r', `${username}:F`]);
+    // 先落当前用户的显式 ACE，再移除继承。若 principal 解析失败，第一步会失败，
+    // 文件仍保留原继承权限，不能出现“收紧失败反而把当前用户锁在门外”的半提交状态。
+    await execFileP('icacls', [file, '/grant:r', `${principal}:F`]);
+    await execFileP('icacls', [file, '/inheritance:r']);
   } catch (err) {
     credPathLog.warn('icacls failed', { file, error: (err as Error).message });
   }

--- a/packages/lizi-mcps/src/__tests__/cindyDocsMcpServer.test.ts
+++ b/packages/lizi-mcps/src/__tests__/cindyDocsMcpServer.test.ts
@@ -1183,10 +1183,16 @@ describe('路径边界与覆盖语义', () => {
     }
   });
 
-  it('经 symlink 指向工作目录外也被拒', async () => {
+  it('经目录链接指向工作目录外也被拒', async () => {
     const outside = await fs.mkdtemp(path.join(os.tmpdir(), 'cindy-docs-outside-'));
     created.push(outside);
-    await fs.symlink(outside, path.join(workdir, 'link'), 'dir');
+    // Windows junction 不需要开发者模式，仍会让 realpath 穿到工作目录外；POSIX
+    // 使用目录 symlink。两端都保留真实文件系统的路径逃逸回归覆盖。
+    await fs.symlink(
+      outside,
+      path.join(workdir, 'link'),
+      process.platform === 'win32' ? 'junction' : 'dir',
+    );
     const client = await connect();
     const result = await callTool(client, 'make_docx', {
       markdown: '# x',

--- a/packages/maker-core/src/agents/pi/windows-git-path-powershell.test.ts
+++ b/packages/maker-core/src/agents/pi/windows-git-path-powershell.test.ts
@@ -1,4 +1,4 @@
-import { execFileSync, spawnSync } from 'node:child_process';
+import { execFileSync, spawn, spawnSync } from 'node:child_process';
 import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import path from 'node:path';
@@ -142,73 +142,104 @@ describe('Windows Git PATH PowerShell probes', () => {
     }
   });
 
-  it.runIf(process.platform === 'win32')('kills probe descendants after the coordinator times out', () => {
-    const systemRoot = process.env.SystemRoot ?? process.env.WINDIR;
-    if (!systemRoot) throw new Error('Windows system root is unavailable');
-    const powershell = path.join(systemRoot, 'System32', 'WindowsPowerShell', 'v1.0', 'powershell.exe');
-    const encodedSleepCommand = Buffer.from('Start-Sleep -Seconds 30', 'utf16le').toString('base64');
-    const script = [
-      '$startInfo = New-Object System.Diagnostics.ProcessStartInfo',
-      `$startInfo.FileName = '${powershell.replaceAll("'", "''")}'`,
-      `$startInfo.Arguments = '-NoLogo -NoProfile -NonInteractive -EncodedCommand ${encodedSleepCommand}'`,
-      '$startInfo.UseShellExecute = $false',
-      '$startInfo.CreateNoWindow = $true',
-      '$process = New-Object System.Diagnostics.Process',
-      '$process.StartInfo = $startInfo',
-      '[void]$process.Start()',
-      '[Console]::Out.WriteLine($process.Id)',
-      '[Console]::Out.Flush()',
-      'Start-Sleep -Seconds 30',
-    ].join('\n');
-    let childPid: number | undefined;
-    let coordinatorPid: number | undefined;
-    try {
-      execFileSync(
-        powershell,
-        ['-NoLogo', '-NoProfile', '-NonInteractive', '-Command', script],
-        {
-          encoding: 'utf8',
-          stdio: ['ignore', 'pipe', 'pipe'],
-          timeout: 1_500,
-          windowsHide: true,
-        },
+  it.runIf(process.platform === 'win32')(
+    'kills probe descendants after the coordinator is terminated',
+    async () => {
+      const systemRoot = process.env.SystemRoot ?? process.env.WINDIR;
+      if (!systemRoot) throw new Error('Windows system root is unavailable');
+      const powershell = path.join(
+        systemRoot,
+        'System32',
+        'WindowsPowerShell',
+        'v1.0',
+        'powershell.exe',
       );
-      throw new Error('coordinator unexpectedly completed before its timeout');
-    } catch (error) {
-      const failure = error as NodeJS.ErrnoException & { stdout?: string | Buffer };
-      expect(failure.code).toBe('ETIMEDOUT');
-      coordinatorPid = failure.pid;
-      const output = Buffer.isBuffer(failure.stdout)
-        ? failure.stdout.toString('utf8')
-        : failure.stdout ?? '';
-      childPid = Number(output.trim().split(/\r?\n/).at(-1));
-      expect(Number.isInteger(childPid) && childPid > 0).toBe(true);
-    }
+      const encodedSleepCommand = Buffer.from('Start-Sleep -Seconds 30', 'utf16le').toString(
+        'base64',
+      );
+      const script = [
+        '$startInfo = New-Object System.Diagnostics.ProcessStartInfo',
+        `$startInfo.FileName = '${powershell.replaceAll("'", "''")}'`,
+        `$startInfo.Arguments = '-NoLogo -NoProfile -NonInteractive -EncodedCommand ${encodedSleepCommand}'`,
+        '$startInfo.UseShellExecute = $false',
+        '$startInfo.CreateNoWindow = $true',
+        '$process = New-Object System.Diagnostics.Process',
+        '$process.StartInfo = $startInfo',
+        '[void]$process.Start()',
+        '[Console]::Out.WriteLine($process.Id)',
+        '[Console]::Out.Flush()',
+        'Start-Sleep -Seconds 30',
+      ].join('\n');
+      let childPid: number | undefined;
+      let coordinatorPid: number | undefined;
+      let coordinator: ReturnType<typeof spawn> | undefined;
+      try {
+        coordinator = spawn(
+          powershell,
+          ['-NoLogo', '-NoProfile', '-NonInteractive', '-Command', script],
+          {
+            stdio: ['ignore', 'pipe', 'pipe'],
+            windowsHide: true,
+          },
+        );
+        coordinatorPid = coordinator.pid;
+        expect(Number.isInteger(coordinatorPid) && (coordinatorPid ?? 0) > 0).toBe(true);
 
-    terminateWindowsPowerShellDescendants(powershell, coordinatorPid);
+        let output = '';
+        coordinator.stdout?.setEncoding('utf8');
+        coordinator.stdout?.on('data', (chunk: string) => {
+          output += chunk;
+        });
+        await vi.waitFor(
+          () => {
+            childPid = Number(output.trim().split(/\r?\n/).at(-1));
+            expect(Number.isInteger(childPid) && childPid > 0).toBe(true);
+          },
+          { timeout: 5_000, interval: 50 },
+        );
 
-    try {
-      execFileSync(
-        powershell,
-        [
-          '-NoLogo',
-          '-NoProfile',
-          '-NonInteractive',
-          '-Command',
+        const coordinatorExit = new Promise<void>((resolve) => {
+          coordinator?.once('exit', () => resolve());
+        });
+        expect(coordinator.kill()).toBe(true);
+        await coordinatorExit;
+
+        terminateWindowsPowerShellDescendants(powershell, coordinatorPid);
+
+        execFileSync(
+          powershell,
           [
-            '$deadline = [DateTime]::UtcNow.AddSeconds(3)',
-            `while (Get-Process -Id ${childPid} -ErrorAction SilentlyContinue) {`,
-            '  if ([DateTime]::UtcNow -ge $deadline) { exit 1 }',
-            '  Start-Sleep -Milliseconds 50',
-            '}',
-          ].join('\n'),
-        ],
-        { stdio: 'ignore', timeout: 5_000, windowsHide: true },
-      );
-    } finally {
-      spawnSync('taskkill.exe', ['/PID', String(childPid), '/F'], { stdio: 'ignore', windowsHide: true });
-    }
-  }, 12_000);
+            '-NoLogo',
+            '-NoProfile',
+            '-NonInteractive',
+            '-Command',
+            [
+              '$deadline = [DateTime]::UtcNow.AddSeconds(3)',
+              `while (Get-Process -Id ${childPid} -ErrorAction SilentlyContinue) {`,
+              '  if ([DateTime]::UtcNow -ge $deadline) { exit 1 }',
+              '  Start-Sleep -Milliseconds 50',
+              '}',
+            ].join('\n'),
+          ],
+          { stdio: 'ignore', timeout: 5_000, windowsHide: true },
+        );
+      } finally {
+        if (coordinatorPid) {
+          spawnSync('taskkill.exe', ['/PID', String(coordinatorPid), '/F'], {
+            stdio: 'ignore',
+            windowsHide: true,
+          });
+        }
+        if (childPid) {
+          spawnSync('taskkill.exe', ['/PID', String(childPid), '/F'], {
+            stdio: 'ignore',
+            windowsHide: true,
+          });
+        }
+      }
+    },
+    12_000,
+  );
 
   it('reports recoverable script failures only when a logger is supplied', () => {
     const warn = vi.fn();


### PR DESCRIPTION
## 这次改了什么

### 摘要

修复 Windows 单测门禁在普通开发环境中的可移植性问题，同时修复 Codex 凭证文件 ACL 收紧时可能因机器名与用户名冲突而选错主体的问题。

文件 symlink 专属测试会在测试生命周期内直接尝试创建链接；目录逃逸测试在 Windows 使用无需开发者模式的 junction，仍保留真实文件系统边界覆盖。PowerShell 后代进程清理测试改为显式读取子进程 PID 后终止协调进程，避免依赖 `execFileSync` 超时时不同 Node/Windows 组合下不稳定的 stdout 行为。

### 变更类型

- [x] `fix` 缺陷修复
- [ ] `feat` 新功能
- [ ] `refactor` / `perf` 重构或性能优化
- [x] `docs` / `test` / `chore` 文档、测试或工程维护
- [ ] 其他：

### 范围

- 关联 Issue / 需求：为后续 `/issue` runtime metadata PR 清理现有 Windows 单测门禁问题
- 本 PR 包含：Windows ACL 主体解析与安全收紧顺序；文件 symlink 能力探测；Windows junction 路径逃逸覆盖；PowerShell 后代进程清理测试稳定性
- 明确不包含：`/issue` 的 Harness / Model ID 功能改动
- 用户可见变化：无 UI 变化；避免极端 Windows 身份命名冲突下当前用户无法再访问 Codex `auth.json`
- 是否存在 breaking change：无

### UI 变化

不涉及。

- 引用的设计规范：不涉及

## 怎么验证的

### 自动验证

```text
Remove-Item Env:XDT_ISOLATED -ErrorAction SilentlyContinue; pnpm test:unit:related
结果：通过（Desktop、@cindy/mcps、@cindy/maker-core）

pnpm --filter desktop run --if-present typecheck
结果：通过

pnpm --filter @cindy/mcps run --if-present typecheck
pnpm --filter @cindy/maker-core run --if-present typecheck
结果：命令通过；两个 package 当前没有 typecheck script，按规则跳过

pnpm check:dco
结果：通过，2 个 commit 已签署 DCO

git diff --check
结果：通过
```

### 手工验证

在 Windows 普通权限环境运行相关测试；无需启用开发者模式或申请 `SeCreateSymbolicLinkPrivilege`。

### 未执行的验证

未跑全量 `pnpm test:unit`；仓库提交门禁要求的 `pnpm test:unit:related` 已覆盖本次改动影响到的三个 workspace，完整门禁由 CI 继续执行。

## 风险

### 风险分类

- [ ] 无已知风险
- [ ] SQLite / migration
- [ ] system prompt
- [ ] 协议兼容
- [x] 权限 / 安全 / 用户数据
- [ ] 存量插件兼容（批准状态 / 指纹 / manifest 校验 / 安装布局 / 包格式）
- [ ] 原生层 / fingerprint / OTA
- [x] 跨平台差异
- [ ] 其他：

### 影响与回滚

- 影响范围：Windows Codex 凭证 ACL 收紧，以及 Windows/POSIX 相关单测实现；不修改协议、数据库、插件或 UI
- 回滚 / 降级方式：可整体回滚本提交；ACL 收紧失败仍维持既有告警且不抛错，新的两步顺序确保在主体授权失败时不会先移除继承权限

### 提交前检查

- [x] 已 review 完整 diff
- [x] 每个 commit 都带 DCO 签名（`git commit -s`，见 [DCO](../DCO)）
- [x] UI 改动已在「UI 变化」注明引用的设计规范章节（不涉及 UI 则跳过）
- [x] 未提交凭证、令牌或授权文件
- [x] 已补充必要文档
- [x] 已确认测试结果或说明未执行原因
