### PR TITLE
fix(plugin): stop treating market manifest as package cap

### DIFF
--- a/apps/desktop/src/main/cindy-brain/index.ts
+++ b/apps/desktop/src/main/cindy-brain/index.ts
@@ -5766,8 +5766,9 @@ async function installOrUpdateMarketGhostPackageLocked(
     releaseMutation = beginGhostMutation(mutationOwner);
     if (!installed) {
       // 市场首装一律装完即开(defaultInstall 与手动安装归一)，用户不必再手动
-      // 点一次开关。市场包走服务端校验 + sha256 下载校验，并受目录 manifest
-      // 能力上限约束；本地 .cindy 由明确的文件选择、拖入或双击动作直接装入。
+      // 点一次开关。市场包走服务端校验 + sha256 下载校验；自定义 Git/本地市场
+      // 额外受发现 Manifest 上限约束。本地 .cindy 由明确的文件选择、拖入或双击
+      // 动作直接装入。
       // expectedPackageSha256 把"检查过的字节"与"落位的字节"钉死为同一份:
       // inspect 与 install 各自重读磁盘,临时 .cindy 在两读之间被替换时,
       // 所有前置校验(保留前缀/能力上限/签名/解压上限)都会作用在旧字节上。

--- a/apps/desktop/src/main/cindy-brain/index.ts
+++ b/apps/desktop/src/main/cindy-brain/index.ts
@@ -5651,10 +5651,6 @@ export async function installOrUpdateMarketGhostPackage(
     /** receipt 模型并发护栏:更新分支比对 receipt 派生 token(与 main 硬化叠加,决策 A)。 */
     expectedInstalledApproval?: string;
     /**
-     * 市场发现层已经公开的 Manifest。真实包可以缩小能力，但不能携带发现层
-     * 没有声明的 Host 能力；超出时按包内容不一致拒绝，不转成用户授权弹窗。
-     */
-    /**
      * Organization server-market packages pass this Host-built fact because the
      * ledger row is written after install/update. Official-prefix ids never
      * consult it (they short-circuit). Not "first install only": the same
@@ -5662,6 +5658,7 @@ export async function installOrUpdateMarketGhostPackage(
      * defaultInstall, and source replacement.
      */
     pendingMarketRecord?: GhostFirstPartyPendingMarketRecord;
+    /** 自定义 Git/本地市场在打包前读取的 Manifest，用于防止打包窗口内能力扩张。 */
     manifestCap?: GhostManifest;
     beforeCommitInLock?: () => void;
     /** 新包已经原子换位；后续异常不能再按落位失败回滚来源路由。 */
@@ -5717,8 +5714,9 @@ async function installOrUpdateMarketGhostPackageLocked(
         ? 'cindy-official'
         : undefined;
     requireGhostAvailableForActiveSession(expected.ghostId);
-    // 市场投影只作为真实包的能力上限，避免分发内容与目录声明漂移；
-    // 安装动作本身不承担能力授权，也不会因此追加权限确认弹窗。
+    // 自定义 Git/本地市场的活目录可能在发现后、打包前变化；它们传入发现时的
+    // Manifest 作为 TOCTOU 上限。官方市场由服务端 Release SHA 绑定真实包，目录
+    // Manifest 只用于展示，不参与这里的安装准入。
     const installed = manager.list().find((ghost) => ghost.manifest.id === expected.ghostId);
     if (expected.manifestCap) {
       const undeclaredCapabilities = unreviewedGhostPermissionItems(
@@ -5739,7 +5737,7 @@ async function installOrUpdateMarketGhostPackageLocked(
         !ghostToolParametersWithinCap(expected.manifestCap, inspected.canonicalManifest) ||
         !ghostUnknownV3FieldsWithinCap(expected.manifestCap, inspected.canonicalManifest)
       ) {
-        log.warn('market package exceeds catalog manifest capabilities', {
+        log.warn('custom market package exceeds discovered manifest capabilities', {
           ghostId: expected.ghostId,
           keys: undeclaredCapabilities.map((item) => item.key),
         });
@@ -5762,7 +5760,7 @@ async function installOrUpdateMarketGhostPackageLocked(
     );
 
     // Manifest 能力只用于 Host 注册、校验和运行时守门。用户点击安装后不再
-    // 经过插件级权限确认；真实包仍必须通过上面的市场声明上限与 Host 校验。
+    // 经过插件级权限确认；自定义活目录还必须通过上面的打包窗口一致性校验。
     // Hold the owner-stability lease only for the actual Ghost filesystem
     // mutation.
     releaseMutation = beginGhostMutation(mutationOwner);

--- a/apps/desktop/src/main/plugin-market/__tests__/service-custom-sources.test.ts
+++ b/apps/desktop/src/main/plugin-market/__tests__/service-custom-sources.test.ts
@@ -2185,9 +2185,7 @@ describe('PluginMarketService 自定义市场 detail/install', () => {
         allowSourceReplacement: true,
       }),
     ).resolves.toMatchObject({ ghost: { manifest: { id: 'server-plugin' } } });
-    expect(runtime.install.mock.calls[0]?.[1]).toMatchObject({
-      manifestCap: ghostManifest('server-plugin'),
-    });
+    expect(runtime.install.mock.calls[0]?.[1]).not.toHaveProperty('manifestCap');
     expect(h.ledger.installationForGhost('server-plugin')).toMatchObject({
       pluginId: item.id,
       source: 'market',

--- a/apps/desktop/src/main/plugin-market/__tests__/service.test.ts
+++ b/apps/desktop/src/main/plugin-market/__tests__/service.test.ts
@@ -1016,7 +1016,6 @@ describe('PluginMarketService migration and defaultInstall', () => {
       expect.objectContaining({
         ghostId: 'cindy-test',
         version: '1.0.0',
-        manifestCap: manifest(),
         beforeCommitInLock: expect.any(Function),
       }),
     );
@@ -1031,7 +1030,7 @@ describe('PluginMarketService migration and defaultInstall', () => {
     });
   });
 
-  it('installs a default package whose manifest cap contains normalized setup requirements', async () => {
+  it('installs a default package whose detail manifest contains normalized setup requirements', async () => {
     const item = summary({ defaultInstall: true });
     const rawManifest = setupKvManifest();
     const approvedManifest = normalizedManifest(rawManifest);
@@ -1054,12 +1053,7 @@ describe('PluginMarketService migration and defaultInstall', () => {
     await expect(h.service.snapshot()).resolves.toMatchObject({
       items: [{ installState: 'installed', enabled: true }],
     });
-    expect(runtime.install).toHaveBeenCalledWith(
-      expect.stringMatching(/\.cindy$/),
-      expect.objectContaining({
-        manifestCap: approvedManifest,
-      }),
-    );
+    expect(runtime.install.mock.calls[0]?.[1]).not.toHaveProperty('manifestCap');
   });
 
   it('returns a Renderer snapshot before a default install download finishes', async () => {
@@ -1094,25 +1088,27 @@ describe('PluginMarketService migration and defaultInstall', () => {
     await vi.waitFor(() => expect(runtime.install).toHaveBeenCalledOnce());
   });
 
-  it('does not auto-install a package rejected for exceeding its catalog manifest', async () => {
+  it('auto-installs the verified package when its capabilities exceed stale catalog metadata', async () => {
     const item = summary({ defaultInstall: true });
-    runtime.install.mockRejectedValueOnce(
-      Object.assign(new Error('package capabilities exceed market manifest'), {
-        code: 'GHOST_FILE_INVALID',
-      }),
-    );
     const h = harness([item]);
+    const actualManifest = manifest(item.ghostId, item.currentRelease.version, ['notify', 'fs']);
+    runtime.inspectedManifest = actualManifest;
+    runtime.install.mockImplementationOnce(async () => {
+      const ghost = {
+        manifest: actualManifest,
+        dir: '/userData/cindy-brain/cindy-test',
+        enabled: true,
+      };
+      runtime.ghosts = [ghost];
+      return ghost;
+    });
 
     const snapshot = await h.service.snapshot();
 
-    expect(runtime.install).toHaveBeenCalledWith(
-      expect.stringMatching(/\.cindy$/),
-      expect.objectContaining({
-        manifestCap: manifest(),
-      }),
-    );
-    expect(snapshot.items[0]?.installState).toBe('not-installed');
-    expect(h.ledger.installationForGhost(item.ghostId)).toBeNull();
+    expect(runtime.install).toHaveBeenCalledOnce();
+    expect(runtime.install.mock.calls[0]?.[1]).not.toHaveProperty('manifestCap');
+    expect(snapshot.items[0]?.installState).toBe('installed');
+    expect(h.ledger.installationForGhost(item.ghostId)).toMatchObject({ installed: true });
   });
 
   it('does not infer historical provenance from the server manifest', async () => {
@@ -1182,7 +1178,6 @@ describe('PluginMarketService migration and defaultInstall', () => {
     expect(runtime.install).toHaveBeenCalledWith(expect.stringMatching(/\.cindy$/), {
       ghostId: 'cindy-test',
       version: '1.0.0',
-      manifestCap: incompatibleManifest,
       afterCommitInLock: expect.any(Function),
     });
   });
@@ -1214,7 +1209,7 @@ describe('PluginMarketService migration and defaultInstall', () => {
     expect(runtime.install).toHaveBeenCalledTimes(1);
   });
 
-  it('rejects downloaded tool parameter schemas that drift from the catalog manifest', async () => {
+  it('installs the verified package when tool schemas drift from stale catalog metadata', async () => {
     const item = summary();
     const reviewedManifest = normalizedManifest({
       ...manifest(),
@@ -1253,14 +1248,19 @@ describe('PluginMarketService migration and defaultInstall', () => {
       currentRelease: { ...item.currentRelease, manifest: reviewedManifest },
     } as unknown as VisiblePluginDetail);
     runtime.inspectedManifest = actualManifest;
+    runtime.install.mockResolvedValue({
+      manifest: actualManifest,
+      dir: '/userData/cindy-brain/cindy-test',
+      enabled: true,
+    });
 
     await expect(
       h.service.install(item.id, {
         expectedReleaseId: item.currentRelease.id,
         expectedManifest: reviewedManifest,
       }),
-    ).rejects.toMatchObject({ code: 'GHOST_FILE_INVALID' });
-    expect(runtime.install).not.toHaveBeenCalled();
+    ).resolves.toMatchObject({ ghost: { manifest: actualManifest } });
+    expect(runtime.install.mock.calls[0]?.[1]).not.toHaveProperty('manifestCap');
   });
 
   it('keeps a no-port broker release visible in detail but rejects market installation before download', async () => {
@@ -1304,7 +1304,6 @@ describe('PluginMarketService migration and defaultInstall', () => {
     expect(runtime.install).toHaveBeenCalledWith(expect.stringMatching(/\.cindy$/), {
       ghostId: 'cindy-test',
       version: '1.0.0',
-      manifestCap: manifest(),
       afterCommitInLock: expect.any(Function),
     });
     // 安装入口用目录 summary 做 detail 身份绑定(防止把 A 的确认导向 B 的内容),
@@ -1404,10 +1403,7 @@ describe('PluginMarketService migration and defaultInstall', () => {
         },
       },
     });
-    expect(runtime.install).toHaveBeenCalledWith(
-      expect.stringMatching(/\.cindy$/),
-      expect.objectContaining({ manifestCap: reviewedManifest }),
-    );
+    expect(runtime.install.mock.calls[0]?.[1]).not.toHaveProperty('manifestCap');
   });
 
   it('installs the explicitly selected official entry when another entry shares its ghostId', async () => {
@@ -1456,7 +1452,6 @@ describe('PluginMarketService migration and defaultInstall', () => {
     expect(runtime.install.mock.calls[0]?.[1]).toEqual({
       ghostId: 'cindy-test',
       version: '1.0.0',
-      manifestCap: manifest(),
       afterCommitInLock: expect.any(Function),
     });
   });
@@ -1798,7 +1793,7 @@ describe('PluginMarketService migration and defaultInstall', () => {
     });
   });
 
-  it('passes the selected server manifest as the downloaded package capability cap', async () => {
+  it('does not treat the server manifest as a downloaded package capability cap', async () => {
     const item = summary();
     runtime.install.mockResolvedValue({
       manifest: manifest(),
@@ -1809,12 +1804,10 @@ describe('PluginMarketService migration and defaultInstall', () => {
 
     await h.service.install(item.id, reviewedInstallOptions(item));
 
-    expect(runtime.install.mock.calls[0]?.[1]).toMatchObject({
-      manifestCap: manifest(),
-    });
+    expect(runtime.install.mock.calls[0]?.[1]).not.toHaveProperty('manifestCap');
   });
 
-  it('uses the selected release manifest as the update package capability cap', async () => {
+  it('does not treat the selected release manifest as an update package capability cap', async () => {
     const item = summary({
       currentRelease: { ...summary().currentRelease, id: 'release-2', version: '2.0.0' },
     });
@@ -1855,9 +1848,7 @@ describe('PluginMarketService migration and defaultInstall', () => {
       expectedInstalledApproval: APPROVED_INSTALL_TOKEN,
     });
 
-    expect(runtime.install.mock.calls[0]?.[1]).toMatchObject({
-      manifestCap: manifest(item.ghostId, '2.0.0'),
-    });
+    expect(runtime.install.mock.calls[0]?.[1]).not.toHaveProperty('manifestCap');
   });
 
   it('keeps a stale official record out of automatic updates but allows explicit replacement', async () => {
@@ -1922,9 +1913,7 @@ describe('PluginMarketService migration and defaultInstall', () => {
     ).resolves.toMatchObject({
       ghost: { manifest: { version: '2.0.0' } },
     });
-    expect(runtime.install.mock.calls[0]?.[1]).toMatchObject({
-      manifestCap: manifest(item.ghostId, '2.0.0'),
-    });
+    expect(runtime.install.mock.calls[0]?.[1]).not.toHaveProperty('manifestCap');
     expect(h.ledger.installationForGhost(item.ghostId)).toMatchObject({
       pluginId: item.id,
       source: 'market',
@@ -1933,7 +1922,7 @@ describe('PluginMarketService migration and defaultInstall', () => {
     });
   });
 
-  it('uses the selected release manifest as the cap for a legacy-record update', async () => {
+  it('updates a legacy record without treating server metadata as a package cap', async () => {
     const item = summary({
       currentRelease: { ...summary().currentRelease, id: 'release-2', version: '2.0.0' },
     });
@@ -1960,9 +1949,7 @@ describe('PluginMarketService migration and defaultInstall', () => {
       expectedInstalledApproval: APPROVED_INSTALL_TOKEN,
     });
 
-    expect(runtime.install.mock.calls[0]?.[1]).toMatchObject({
-      manifestCap: manifest(item.ghostId, '2.0.0'),
-    });
+    expect(runtime.install.mock.calls[0]?.[1]).not.toHaveProperty('manifestCap');
   });
 
   it('installs and enables a public defaultInstall package in local mode', async () => {
@@ -1990,7 +1977,6 @@ describe('PluginMarketService migration and defaultInstall', () => {
       expect.objectContaining({
         ghostId: item.ghostId,
         version: item.currentRelease.version,
-        manifestCap: manifest(),
         beforeCommitInLock: expect.any(Function),
       }),
     );
@@ -2078,13 +2064,12 @@ describe('PluginMarketService migration and defaultInstall', () => {
       expect.objectContaining({
         ghostId: item.ghostId,
         version: '2.0.0',
-        manifestCap: upgraded,
       }),
     );
     expect(snapshot.items[0]).toMatchObject({ installState: 'installed', enabled: false });
   });
 
-  it('silently upgrades a default package whose manifest cap contains normalized setup', async () => {
+  it('silently upgrades a default package whose detail manifest contains normalized setup', async () => {
     const item = summary({
       scope: 'organization',
       organizationId: 'org-1',
@@ -2123,12 +2108,7 @@ describe('PluginMarketService migration and defaultInstall', () => {
     await expect(h.service.snapshot()).resolves.toMatchObject({
       items: [{ installState: 'installed', version: '2.0.0' }],
     });
-    expect(runtime.install).toHaveBeenCalledWith(
-      expect.stringMatching(/\.cindy$/),
-      expect.objectContaining({
-        manifestCap: upgradedManifest,
-      }),
-    );
+    expect(runtime.install.mock.calls[0]?.[1]).not.toHaveProperty('manifestCap');
   });
 
   it('integration: snapshot upgrades an organization defaultInstall release', async () => {
@@ -3153,9 +3133,7 @@ describe('PluginMarketService migration and defaultInstall', () => {
     ).resolves.toMatchObject({
       ghost: { manifest: { id: item.ghostId } },
     });
-    expect(runtime.install.mock.calls[0]?.[1]).toMatchObject({
-      manifestCap: manifest(),
-    });
+    expect(runtime.install.mock.calls[0]?.[1]).not.toHaveProperty('manifestCap');
     expect(h.ledger.installationForGhost(item.ghostId)).toMatchObject({
       pluginId: item.id,
       source: 'market',
@@ -3189,7 +3167,7 @@ describe('PluginMarketService migration and defaultInstall', () => {
     expect(h.ledger.installationForGhost(item.ghostId)).toBeNull();
   });
 
-  it('keeps the selected release manifest as the cap when the installed snapshot changes', async () => {
+  it('keeps the selected release identity when the installed snapshot changes', async () => {
     const item = summary({
       currentRelease: { ...summary().currentRelease, id: 'release-2', version: '2.0.0' },
     });
@@ -3219,7 +3197,7 @@ describe('PluginMarketService migration and defaultInstall', () => {
       version: '1.0.0',
     });
     // 下载窗口期目标包相对“当前实际已装”多出 fs；安装事务仍以选中 release 的
-    // manifest 为能力上限，不再为能力变化增加另一层用户审批。
+    // id/version/SHA 为身份边界，不再把市场的展示 Manifest 当成包能力上限。
     await expect(
       h.service.install(item.id, {
         ...reviewedInstallOptions(item),
@@ -3228,9 +3206,7 @@ describe('PluginMarketService migration and defaultInstall', () => {
     ).resolves.toMatchObject({
       ghost: { manifest: { version: '2.0.0' } },
     });
-    expect(runtime.install.mock.calls[0]?.[1]).toMatchObject({
-      manifestCap: manifest('cindy-test', '2.0.0'),
-    });
+    expect(runtime.install.mock.calls[0]?.[1]).not.toHaveProperty('manifestCap');
   });
 
   it('rejects an update when the installed target disappears during download', async () => {

--- a/apps/desktop/src/main/plugin-market/service.ts
+++ b/apps/desktop/src/main/plugin-market/service.ts
@@ -13,19 +13,11 @@ import { app, dialog } from 'electron';
 
 import {
   GHOST_ICON_MAX_BYTES,
-  ghostNetworkAuthorizationWithinCap,
-  ghostNodeSecretAuthorizationWithinCap,
-  ghostSetupAuthorizationWithinCap,
-  ghostSettingsUiWithinCap,
-  ghostSubscribeAuthorizationWithinCap,
-  ghostToolParametersWithinCap,
-  ghostUnknownV3FieldsWithinCap,
   ghostInstallApprovalToken,
   ghostIconMimeType,
   isSafeGhostRelativePath,
   isOfficialGhostId,
   isValidGhostId,
-  unreviewedGhostPermissionItems,
   validateGhostManifest,
   type GhostManifest,
   type InstalledGhost,
@@ -1070,10 +1062,6 @@ export class PluginMarketService {
       if (plugin.currentRelease.id !== options.expectedReleaseId) {
         throwIpcError('PRECONDITION_FAILED', 'Plugin release changed after selection');
       }
-      const compatible = validateGhostManifest(plugin.currentRelease.manifest);
-      if (!compatible.ok) {
-        throwIpcError('GHOST_FILE_INVALID', 'This Plugin manifest is not supported');
-      }
       const existing = getGhostManager()
         .list()
         .find((ghost) => ghost.manifest.id === plugin.ghostId);
@@ -1084,7 +1072,6 @@ export class PluginMarketService {
           ...(options.expectedInstalledApproval !== undefined
             ? { expectedInstalledApproval: options.expectedInstalledApproval }
             : {}),
-          manifestCap: compatible.manifest,
           allowSourceReplacement: options.allowSourceReplacement === true,
         },
         owner,
@@ -1696,8 +1683,6 @@ export class PluginMarketService {
     options: {
       /** receipt 模型的并发护栏:比对 receipt 派生 token,状态变更即拒(与 main 硬化叠加)。 */
       expectedInstalledApproval?: string;
-      /** 市场目录公开 Manifest 是真实下载包允许的 Host 能力上限。 */
-      manifestCap?: GhostManifest;
       /** 用户明确点击安装时，允许所选市场包原地替换其它来源的同 id 插件。 */
       allowSourceReplacement?: boolean;
       beforeCommitInLock?: () => void;
@@ -1743,10 +1728,6 @@ export class PluginMarketService {
       }
     }
 
-    // manifestCap 只来自上游同一条安装链路已经通过 validateGhostManifest 的
-    // 规范化结果。v2 的内部模型会移除 slots，再把它当原始 ghost.json 二次校验
-    // 会误判为非法；这里直接把已验证的能力上限交给真实包一致性校验。
-    const manifestCap = options.manifestCap ?? null;
     const download = await this.api.download(plugin.id, plugin.currentRelease.id);
     requireSameMarketOwner(owner);
     if (
@@ -1775,28 +1756,6 @@ export class PluginMarketService {
         ) {
           throwIpcError('GHOST_FILE_INVALID', 'Downloaded Plugin package identity changed');
         }
-        if (manifestCap) {
-          const extraCapabilities = unreviewedGhostPermissionItems(
-            manifestCap,
-            undefined,
-            inspected.canonicalManifest,
-          );
-          if (
-            extraCapabilities.length > 0 ||
-            !ghostNetworkAuthorizationWithinCap(manifestCap, inspected.canonicalManifest) ||
-            !ghostNodeSecretAuthorizationWithinCap(manifestCap, inspected.canonicalManifest) ||
-            !ghostSetupAuthorizationWithinCap(manifestCap, inspected.canonicalManifest) ||
-            !ghostSettingsUiWithinCap(manifestCap, inspected.canonicalManifest) ||
-            !ghostSubscribeAuthorizationWithinCap(manifestCap, inspected.canonicalManifest) ||
-            !ghostToolParametersWithinCap(manifestCap, inspected.canonicalManifest) ||
-            !ghostUnknownV3FieldsWithinCap(manifestCap, inspected.canonicalManifest)
-          ) {
-            throwIpcError(
-              'GHOST_FILE_INVALID',
-              'Downloaded Plugin package capabilities exceed the market manifest',
-            );
-          }
-        }
       }
       const ghost = await this.commitDownloadedPackage(
         tempPath,
@@ -1806,7 +1765,6 @@ export class PluginMarketService {
           ...(options.expectedInstalledApproval !== undefined
             ? { expectedInstalledApproval: options.expectedInstalledApproval }
             : {}),
-          ...(manifestCap ? { manifestCap } : {}),
           allowSourceReplacement: options.allowSourceReplacement,
           beforeCommitInLock: options.beforeCommitInLock,
         },
@@ -1825,7 +1783,6 @@ export class PluginMarketService {
     plugin: VisiblePluginSummary | VisiblePluginDetail,
     options: {
       expectedInstalledApproval?: string;
-      manifestCap?: GhostManifest;
       allowSourceReplacement?: boolean;
       beforeCommitInLock?: () => void;
       expectedInstalled: boolean;
@@ -1908,7 +1865,6 @@ export class PluginMarketService {
         ...(options.expectedInstalledApproval !== undefined
           ? { expectedInstalledApproval: options.expectedInstalledApproval }
           : {}),
-        ...(options.manifestCap ? { manifestCap: options.manifestCap } : {}),
         ...(options.beforeCommitInLock || replacingSource
           ? { beforeCommitInLock: detachPreviousRoute }
           : {}),
@@ -2360,17 +2316,11 @@ export class PluginMarketService {
           const detail = await this.api.detail(summary.id);
           requireSameMarketOwner(owner);
           assertDetailMatchesSummary(summary, detail);
-          const manifestCap = validateGhostManifest(detail.currentRelease.manifest);
-          if (!manifestCap.ok) {
-            throwIpcError('GHOST_FILE_INVALID', 'This Plugin manifest is not supported');
-          }
           // 装完即开语义已收敛进市场安装入口本身,这里无需再显式声明。
           await this.installDetail(
             detail,
             {
               expectedInstalled: false,
-              // 目录 Manifest 是真实包允许的能力上限；超出时按包内容不一致拒绝。
-              manifestCap: manifestCap.manifest,
               // 下载期间用户可能从本地插件页完成显式卸载。最终落位前在
               // ghostId 锁内重读卸载意图，不能让旧 snapshot 把插件装回来。
               beforeCommitInLock: () => {
@@ -2464,16 +2414,11 @@ export class PluginMarketService {
           const detail = await this.api.detail(summary.id);
           requireSameMarketOwner(owner);
           assertDetailMatchesSummary(summary, detail);
-          const manifestCap = validateGhostManifest(detail.currentRelease.manifest);
-          if (!manifestCap.ok) {
-            throwIpcError('GHOST_FILE_INVALID', 'This Plugin manifest is not supported');
-          }
           await this.installDetail(
             detail,
             {
               expectedInstalled: true,
               expectedInstalledApproval: ghostInstallApprovalToken(freshInstalled.approval),
-              manifestCap: manifestCap.manifest,
               beforeCommitInLock: () => {
                 if (isGhostBusy(summary.ghostId)) {
                   throw new SilentUpgradeBusyError('Plugin is busy');


### PR DESCRIPTION
## 这次改了什么

### 摘要

修复 #3342 合并后，官方市场把目录 Manifest 当成实际 `.cindy` 包能力上限所造成的存量插件安装兼容问题。

官方市场的 Manifest 继续用于详情展示和现有准入检查，但不再限制经过 Release SHA、大小、插件 ID/版本和真实包 Manifest 校验的安装包。自定义 Git/本地市场仍保留发现 Manifest 上限，用于防止活目录在发现与打包之间扩张能力。

### 变更类型

- [ ] `feat` 新功能
- [x] `fix` 缺陷修复
- [ ] `refactor` / `perf` 重构或性能优化
- [ ] `docs` / `test` / `chore` 文档、测试或工程维护
- [ ] 其他：

### 范围

- 关联 Issue / 需求：#3342 合并后的存量市场插件安装回归
- 本 PR 包含：移除官方市场安装、默认安装、自动更新和显式来源替换路径中的目录 Manifest 能力上限；补充对应回归测试
- 明确不包含：服务端下发规则、Manifest v2/v3 协议、运行时授权模型、自定义市场 TOCTOU 校验及其他 #3342 改动的整体审视
- 用户可见变化：目录 Manifest 与真实包能力存在历史漂移时，官方市场插件可重新安装、更新或替换；安装过程仍不增加权限确认弹窗
- 是否存在 breaking change：无

### UI 变化

不涉及。

- 引用的设计规范：不涉及

## 怎么验证的

### 自动验证

```text
pnpm --filter desktop run --if-present typecheck
结果：通过

pnpm --filter desktop exec vitest run src/main/plugin-market/__tests__/service.test.ts src/main/plugin-market/__tests__/service-custom-sources.test.ts
结果：2 个测试文件、170 个测试全部通过

pnpm check:dco
结果：通过，1 个 commit 已签署 DCO
```

### 手工验证

不涉及：本 PR 先提供针对已定位回归的最小修复，实际 CN 市场插件安装验收交由合并前 beta 验证继续覆盖。

### 未执行的验证

`pnpm test:unit` 已执行但未全绿：本修复相关的唯一失败已修正并由上述 170 个定向测试验证；全量任务仍有与本 diff 无关的现有超时、文件监听和本机 sandbox 用例失败（desktop、maker-core、remote-file-service）。CI 将在干净环境重新执行完整门禁。

## 风险

### 风险分类

- [ ] 无已知风险
- [ ] SQLite / migration
- [ ] system prompt
- [ ] 协议兼容
- [x] 权限 / 安全 / 用户数据
- [x] 存量插件兼容（批准状态 / 指纹 / manifest 校验 / 安装布局 / 包格式）
- [ ] 原生层 / fingerprint / OTA
- [ ] 跨平台差异
- [ ] 其他：

### 影响与回滚

- 影响范围：仅官方服务端市场的安装包能力上限。包 SHA/大小、ID/版本、真实包 Manifest、Host 运行时授权、账本/来源/owner 并发护栏均保持不变；自定义 Git/本地市场能力上限保持不变。
- 存量插件影响：修复已卸载插件无法重装，以及目录 Manifest 漂移导致的安装/更新/替换失败；不迁移、不重写、也不要求重新确认已安装插件。
- 回滚 / 降级方式：revert 本 PR 可恢复旧行为，但会重新引入官方市场目录 Manifest 漂移造成的兼容问题。

### 提交前检查

- [x] 已 review 完整 diff
- [x] 每个 commit 都带 DCO 签名（`git commit -s`，见 [DCO](../DCO)）
- [x] UI 改动已在「UI 变化」注明引用的设计规范（不涉及 UI 则跳过）
- [x] 未提交凭证、令牌或授权文件
- [x] 已补充必要文档（本次未改变插件作者公开契约，无需同步开发文档）
- [x] 已确认测试结果或说明未执行原因
