### PR TITLE
fix(chat): 发送时立即跟随最新消息

### DIFF
--- a/apps/desktop/src/renderer/__tests__/autoFollowIntent.test.ts
+++ b/apps/desktop/src/renderer/__tests__/autoFollowIntent.test.ts
@@ -594,7 +594,7 @@ describe('send follow cancel generation', () => {
     expect(readSendFollowCancelGeneration('session-b')).toBe(bStart + 1);
   });
 
-  it('bumps on scrollbar unpin and continued user up-scroll, not on content growth while following', () => {
+  it('bumps only when leaving the tail, not on leftover up-scroll while already away', () => {
     expect(
       shouldBumpSendFollowCancelOnScroll({
         wasNearBottom: true,
@@ -610,7 +610,7 @@ describe('send follow cancel generation', () => {
         scrollDelta: -40,
         directionDeadZonePx: 2,
       }),
-    ).toBe(true);
+    ).toBe(false);
     expect(
       shouldBumpSendFollowCancelOnScroll({
         wasNearBottom: true,
@@ -787,7 +787,9 @@ describe('MessageStream send-window handoff wiring', () => {
     expect(source).toContain('subscribeFollowLatestRequests');
     expect(source).toContain('readFollowLatestRequestKey(sessionId)');
     expect(source).toContain('pinToBottom();');
-    expect(source).toContain('bumpSendFollowCancelGeneration(sessionId)');
+    expect(source).toMatch(
+      /const unpinAutoFollowForUserUpIntent = useCallback\(\(\) => \{\s*if \(!isNearBottomRef\.current\) return;\s*bumpSendFollowCancelGeneration\(sessionId\);/,
+    );
     expect(source).toContain('shouldBumpSendFollowCancelOnScroll({');
     expect(source).toContain('knownUserMessageIds: knownUserMessageIdsRef.current');
     expect(source).toContain('collectKnownUserMessageIds(messages,');
@@ -799,19 +801,28 @@ describe('MessageStream send-window handoff wiring', () => {
     expect(source).toContain('cancelFocusJump({ consumeDeferredDelete: true });');
   });
 
-  it('session view commits follow-latest only after accept and unchanged scroll generation', () => {
+  it('session view requests follow-latest at send dispatch, not after accept', () => {
     const source = readFileSync(
       resolve(__dirname, '../features/cc-agent/CCAgentSessionView.tsx'),
       'utf8',
     );
     expect(source).toContain('tryRequestFollowLatest({');
-    expect(source).toContain('requestFollowLatest(sessionId, followStartGeneration)');
     expect(source).toContain(
       'const followStartGeneration = readSendFollowCancelGeneration(sessionId);',
     );
+    expect(source).toContain('if (sessionId) requestFollowLatest(sessionId, followStartGeneration);');
+    expect(source).toMatch(
+      /if \(sessionId\) requestFollowLatest\(sessionId, followStartGeneration\);\s*const accepted = await sendMessage\(/,
+    );
+    expect(source).toMatch(
+      /if \(sessionId\) requestFollowLatest\(sessionId, followStartGeneration\);\s*const accepted = await steerMessage\(/,
+    );
+    expect(source).not.toMatch(
+      /const accepted = await sendMessage\([\s\S]{0,400}requestFollowLatest\(sessionId, followStartGeneration\)/,
+    );
   });
 
-  it('edit-resend and blocked resend request follow-latest through the same owner', () => {
+  it('edit-resend and blocked resend request follow-latest at dispatch', () => {
     const source = readFileSync(
       resolve(__dirname, '../components/chat/UserMessageEditBox.tsx'),
       'utf8',
@@ -820,6 +831,8 @@ describe('MessageStream send-window handoff wiring', () => {
     expect(source).toContain(
       'const followStartGeneration = readSendFollowCancelGeneration(sessionId);',
     );
-    expect(source).toContain('if (accepted)');
+    expect(source).toMatch(
+      /tryRequestFollowLatest\(\{[\s\S]*?\}\);\s*if \(onCommitOverride\)/,
+    );
   });
 });

--- a/apps/desktop/src/renderer/__tests__/userMessageEditBox.test.ts
+++ b/apps/desktop/src/renderer/__tests__/userMessageEditBox.test.ts
@@ -101,7 +101,7 @@ describe('UserMessageEditBox — idle 发送', () => {
     expect(props.onRequestStop).not.toHaveBeenCalled();
   });
 
-  it('编辑重发受理后请求跟底;入队失败或等待期间上翻则不跟底', async () => {
+  it('编辑重发在派发时就请求跟底，不等受理，等待期间上翻也不撤票', async () => {
     const acceptedId = `edit-follow-ok-${Date.now()}`;
     commitMock.mockResolvedValueOnce(true);
     const accepted = renderBox({ sessionId: acceptedId });
@@ -116,22 +116,23 @@ describe('UserMessageEditBox — idle 发送', () => {
     const failed = renderBox({ sessionId: failedId });
     fireEvent.click(failed.sendBtn);
     await waitFor(() => expect(failed.props.onSent).toHaveBeenCalledTimes(1));
-    expect(readFollowLatestRequestKey(failedId)).toBe(0);
+    expect(readFollowLatestRequestKey(failedId)).toBe(1);
     failed.unmount();
     vi.clearAllMocks();
 
-    const cancelledId = `edit-follow-cancel-${Date.now()}`;
+    const dispatchedId = `edit-follow-dispatch-${Date.now()}`;
     let release: (value: boolean) => void = () => {};
     commitMock.mockImplementationOnce(
       () => new Promise<boolean>((resolve) => { release = resolve; }),
     );
-    const cancelled = renderBox({ sessionId: cancelledId });
-    fireEvent.click(cancelled.sendBtn);
+    const dispatched = renderBox({ sessionId: dispatchedId });
+    fireEvent.click(dispatched.sendBtn);
     await waitFor(() => expect(commitMock).toHaveBeenCalledTimes(1));
-    bumpSendFollowCancelGeneration(cancelledId);
+    expect(readFollowLatestRequestKey(dispatchedId)).toBe(1);
+    bumpSendFollowCancelGeneration(dispatchedId);
     await act(async () => { release(true); });
-    await waitFor(() => expect(cancelled.props.onSent).toHaveBeenCalledTimes(1));
-    expect(readFollowLatestRequestKey(cancelledId)).toBe(0);
+    await waitFor(() => expect(dispatched.props.onSent).toHaveBeenCalledTimes(1));
+    expect(readFollowLatestRequestKey(dispatchedId)).toBe(1);
   });
 
   it('被拦消息重发成功后请求跟底', async () => {

--- a/apps/desktop/src/renderer/components/chat/MessageStream.tsx
+++ b/apps/desktop/src/renderer/components/chat/MessageStream.tsx
@@ -4194,8 +4194,8 @@ export function MessageStream({
   // shouldUnpinOnUpIntent),本回调只负责翻转:ref 与 state 同步更新(F2 不
   // 变量);unreadCount 不动 — 它只在回底时清零。
   const unpinAutoFollowForUserUpIntent = useCallback(() => {
-    bumpSendFollowCancelGeneration(sessionId);
     if (!isNearBottomRef.current) return;
+    bumpSendFollowCancelGeneration(sessionId);
     isNearBottomRef.current = false;
     setIsNearBottom(false);
   }, [sessionId]);

--- a/apps/desktop/src/renderer/components/chat/UserMessageEditBox.tsx
+++ b/apps/desktop/src/renderer/components/chat/UserMessageEditBox.tsx
@@ -209,7 +209,12 @@ export function UserMessageEditBox({
           ? [rebuiltSlashRange]
           : undefined;
       const followStartGeneration = readSendFollowCancelGeneration(sessionId);
-      let accepted = true;
+      // 点发送就跟底。等受理会让阅读历史时的残留上翻把票作废。
+      tryRequestFollowLatest({
+        sourceSessionId: sessionId,
+        currentSessionId: sessionId,
+        startGeneration: followStartGeneration,
+      });
       if (onCommitOverride) {
         // 被拦消息:普通重发(不 rewind)。失败抛错落入下方 catch 保留编辑态。
         await onCommitOverride({
@@ -220,7 +225,7 @@ export function UserMessageEditBox({
           ...(preservedSlashCommandRanges !== undefined ? { slashCommandRanges: preservedSlashCommandRanges } : {}),
         });
       } else {
-        accepted = await commitEditAndResendWithRunningRetry({
+        await commitEditAndResendWithRunningRetry({
           sessionId,
           clientId: messageClientId,
           text: submitText,
@@ -231,18 +236,6 @@ export function UserMessageEditBox({
           ...(preservedAgentReferences ? { agentReferences: preservedAgentReferences } : {}),
           ...(preservedPastedTextRanges ? { pastedTextRanges: preservedPastedTextRanges } : {}),
           ...(preservedSlashCommandRanges !== undefined ? { slashCommandRanges: preservedSlashCommandRanges } : {}),
-        });
-      }
-      // 先归零守卫再 onSent:onSent 让父组件立刻卸载本组件,晚于它的 setState
-      // 在已卸载组件上是无效 no-op(bot review 指出的死代码顺序问题)。
-      // 编辑框挂在 MessageStream(key=sessionId) 里,切走即卸载;跟底 store 按
-      // session 隔离,这里 bump 不会钉到别的会话。CCAgentSessionView 会在
-      // `/cc-agent/:id` 切换后存活,所以那边才比对 sessionIdRef.current。
-      if (accepted) {
-        tryRequestFollowLatest({
-          sourceSessionId: sessionId,
-          currentSessionId: sessionId,
-          startGeneration: followStartGeneration,
         });
       }
       submittingRef.current = false;

--- a/apps/desktop/src/renderer/components/chat/autoFollowIntent.ts
+++ b/apps/desktop/src/renderer/components/chat/autoFollowIntent.ts
@@ -486,16 +486,15 @@ export function bumpSendFollowCancelGeneration(sessionId: string | null | undefi
 export function shouldBumpSendFollowCancelOnScroll({
   wasNearBottom,
   effectiveNearBottom,
-  scrollDelta,
-  directionDeadZonePx,
 }: {
   wasNearBottom: boolean;
   effectiveNearBottom: boolean;
   scrollDelta: number;
   directionDeadZonePx: number;
 }): boolean {
-  if (wasNearBottom && !effectiveNearBottom) return true;
-  return !effectiveNearBottom && scrollDelta < -directionDeadZonePx;
+  // Only leaving the tail cancels a pending follow. Continued up-scroll while
+  // already away is leftover reading inertia and must not void the next send.
+  return wasNearBottom && !effectiveNearBottom;
 }
 
 export function shouldCommitFollowLatestRequest({

--- a/apps/desktop/src/renderer/features/cc-agent/CCAgentSessionView.tsx
+++ b/apps/desktop/src/renderer/features/cc-agent/CCAgentSessionView.tsx
@@ -2956,6 +2956,10 @@ export function CCAgentSessionView({
               pending.onDeferredAccepted?.();
               const resumedSessionId = sessionId;
               if (resumedSessionId) {
+                requestFollowLatest(
+                  resumedSessionId,
+                  readSendFollowCancelGeneration(resumedSessionId),
+                );
                 void dispatchDeferredUiAssignment(resumedSessionId, undefined, {
                   waitForLeadHistory: false,
                 }).catch((err) => {
@@ -2991,6 +2995,7 @@ export function CCAgentSessionView({
               : undefined;
           const dispatch = pending.deliveryMode === 'steer' ? steerMessage : sendMessage;
           const followStartGeneration = readSendFollowCancelGeneration(sessionId);
+          requestFollowLatest(sessionId, followStartGeneration);
           const accepted = await dispatch(
             slashDispatch.message,
             pending.model,
@@ -3029,7 +3034,6 @@ export function CCAgentSessionView({
           );
           if (accepted) {
             pending.onDeferredAccepted?.();
-            requestFollowLatest(sessionId, followStartGeneration);
             const resumedSessionId = sessionId;
             if (resumedSessionId) {
               void dispatchDeferredUiAssignment(resumedSessionId, undefined).catch((err) => {
@@ -3175,6 +3179,7 @@ export function CCAgentSessionView({
             });
       if (slashDispatch.handled) {
         if (slashDispatch.accepted && sessionId) {
+          requestFollowLatest(sessionId, readSendFollowCancelGeneration(sessionId));
           void dispatchDeferredUiAssignment(sessionId, undefined, {
             waitForLeadHistory: false,
           }).catch((err) => {
@@ -3308,6 +3313,7 @@ export function CCAgentSessionView({
       };
       if (deliveryMode === 'steer') {
         const followStartGeneration = readSendFollowCancelGeneration(sessionId);
+        if (sessionId) requestFollowLatest(sessionId, followStartGeneration);
         const accepted = await steerMessage(
           message,
           model,
@@ -3319,7 +3325,6 @@ export function CCAgentSessionView({
           sendOptions,
         );
         if (accepted && sessionId) {
-          requestFollowLatest(sessionId, followStartGeneration);
           void dispatchDeferredUiAssignment(sessionId, undefined).catch((err) => {
             log.error('recover deferred Worker assignment after user message failed', err);
             toast.error(t('newChat.collaboration.assignmentFailed'));
@@ -3328,6 +3333,7 @@ export function CCAgentSessionView({
         return accepted;
       }
       const followStartGeneration = readSendFollowCancelGeneration(sessionId);
+      if (sessionId) requestFollowLatest(sessionId, followStartGeneration);
       const accepted = await sendMessage(
         message,
         model,
@@ -3339,7 +3345,6 @@ export function CCAgentSessionView({
         sendOptions,
       );
       if (accepted && sessionId) {
-        requestFollowLatest(sessionId, followStartGeneration);
         void dispatchDeferredUiAssignment(sessionId, undefined).catch((err) => {
           log.error('recover deferred Worker assignment after user message failed', err);
           toast.error(t('newChat.collaboration.assignmentFailed'));
@@ -3832,6 +3837,7 @@ export function CCAgentSessionView({
         // 必须 await:sendMessage 在设备离线 / 访问被撤销 / 远端 enqueue 拒绝时不抛错,
         // 而是 resolve false —— 不等它就丢副本,正文会从界面和磁盘上一起消失(codex P1)。
         const followStartGeneration = readSendFollowCancelGeneration(sessionId);
+        requestFollowLatest(sessionId, followStartGeneration);
         const delivered = await deliverRecoverableHandoff(sessionId, () =>
           sendMessage(
             pendingText,
@@ -3863,7 +3869,6 @@ export function CCAgentSessionView({
           ),
         );
         if (delivered) {
-          requestFollowLatest(sessionId, followStartGeneration);
           void dispatchDeferredUiAssignment(sessionId, deferredUiAssignment).catch((err) => {
             log.error('deferred Worker assignment after first message failed', err);
             toast.error(t('newChat.collaboration.assignmentFailed'));


### PR DESCRIPTION
## 这次改了什么

### 摘要

本端发送后聊天窗口有时不会跳到最新。#3057 把跟底放在 enqueue 受理之后，阅读历史时的触控板残留上翻会把这张票作废，而渲染层又不再从「尾部多了一条自己发的消息」推断跟底。

这次改成点发送就立刻跟底，已经不在底部时的继续上翻不再撤票。发送失败时窗口可能已经在底部；发出去之后如果又往上翻，仍然立刻停跟。

### 变更类型

- [ ] `feat` 新功能
- [x] `fix` 缺陷修复
- [ ] `refactor` / `perf` 重构或性能优化
- [ ] `docs` / `test` / `chore` 文档、测试或工程维护
- [ ] 其他：

### 范围

- 关联 Issue / 需求：无编号；#3057 / #2844 之后个人客户端上「发了新消息不跳到最新」复发
- 本 PR 包含：发送 / 插话 / 编辑重发 / 补选目录补发 / slash 在派发时请求 `followLatestRequestKey`；已离底的上翻不再 `bumpSendFollowCancelGeneration`
- 明确不包含：手机端对称改动、跳底按钮视觉、浏览位置快照语义
- 用户可见变化：在历史中间点发送会立刻回到最新；之后手动上翻仍会停跟
- 是否存在 breaking change：无

### UI 变化

- 引用的设计规范：不涉及：无控件、布局、色板或文案改动；只修正发送后自动贴底跟随的时序。

## 怎么验证的

### 自动验证

```text
cd /Users/dash/Code/Cindy/cindy-fix-send-follow-on-dispatch
pnpm test:unit:related
结果：PASS apps/desktop unit（related 6 files）

pnpm --filter desktop run --if-present typecheck
结果：通过

pnpm --filter desktop exec vitest run src/renderer/__tests__/autoFollowIntent.test.ts src/renderer/__tests__/userMessageEditBox.test.ts src/renderer/__tests__/editLastUserMessage.test.ts
结果：3 files / 104 tests passed

bash /Users/dash/Code/XD/dash/Skills/git/scripts/run-unit-gate.sh <worktree>
结果：desktop 全量 29109 passed，6 failed。失败项为
src/main/__tests__/claudeOrphanReaper.test.ts（5）
src/main/usage/__tests__/usageHistory.test.ts（1，Pi SuperGrok 估价）
与本 diff 无关。已在干净 origin/main（f4f52bc77）用同一命令复现相同 6 条失败。
```

### 手工验证

未在实机点发送回归。改动是发送跟底时序，建议在桌面长任务里：先上翻阅读历史再发送，确认立刻跳到最新；再上滚一行确认仍能立刻停跟。

### 未执行的验证

- 实机桌面发送后跟底目检：当前会话无法热更宿主 app。
- 全量本机单测见上，与本 diff 无关的 6 条基线失败交给 CI。

## 风险

### 风险分类

- [x] 其他：发送后贴底跟随时序
- [ ] 无已知风险
- [ ] SQLite / migration
- [ ] system prompt
- [ ] 协议兼容
- [ ] 权限 / 安全 / 用户数据
- [ ] 存量插件兼容（批准状态 / 指纹 / manifest 校验 / 安装布局 / 包格式）
- [ ] 原生层 / fingerprint / OTA
- [ ] 跨平台差异

### 影响与回滚

- 影响范围：仅 Desktop 消息流本端发送后的贴底跟随；不改 schema、协议、插件或原生指纹。发送失败时视口可能已经在底部。
- 回滚 / 降级方式：revert 本 PR。
- 存量插件影响：无

### 提交前检查

- [x] 已 review 完整 diff
- [x] 每个 commit 都带 DCO 签名（`git commit -s`，见 [DCO](../DCO)）
- [x] UI 改动已在「UI 变化」注明引用的设计规范章节（不涉及 UI 则跳过）
- [x] 未提交凭证、令牌或授权文件
- [x] 已补充必要文档
- [x] 已确认测试结果或说明未执行原因
