### PR TITLE
test(desktop): make Codex exec cleanup deterministic

### DIFF
--- a/apps/desktop/src/main/maker-host/__tests__/codexExecFunctionAdapter.e2e.test.ts
+++ b/apps/desktop/src/main/maker-host/__tests__/codexExecFunctionAdapter.e2e.test.ts
@@ -11,7 +11,10 @@ import { createResponsesCustomToolFunctionAdapter } from '@cindy/responses-chat-
 import { afterEach, describe, expect, it } from 'vitest';
 
 import type { Logger } from '../../../../../../packages/maker-core/src/interfaces/logger.js';
-import { AppServerHost } from '../../../../../../packages/maker-core/src/agents/codex/app-server/host.js';
+import {
+  AppServerHost,
+  type ThreadSubscription,
+} from '../../../../../../packages/maker-core/src/agents/codex/app-server/host.js';
 import {
   Method,
   type ItemEnvelope,
@@ -201,7 +204,12 @@ describe.skipIf(!codexBoundaryAvailable)('Codex custom exec function adapter E2E
       res.end(responseBody);
     });
     const providerUrl = await listen(provider);
-    cleanups.push(() => new Promise<void>((resolve) => provider.close(() => resolve())));
+    cleanups.push(() =>
+      new Promise<void>((resolve) => {
+        provider.closeAllConnections();
+        provider.close(() => resolve());
+      }),
+    );
 
     const adapter = createResponsesCustomToolFunctionAdapter(['exec']);
     const proxy: ProxyHandle = await createAnthropicCompatProxy({
@@ -263,7 +271,13 @@ stream_max_retries = 0
       logger,
       clientInfo: { name: 'cindy-issue-3168-e2e', version: '0.0.0' },
     });
-    cleanups.push(() => host.shutdown());
+    let subscription: ThreadSubscription | undefined;
+    cleanups.push(async () => {
+      // This test owns the host. Shut it down before releasing the thread so a
+      // slow thread/unsubscribe cannot consume most of Vitest's hook budget.
+      await host.shutdown();
+      await subscription?.release();
+    });
 
     const thread = await withTimeout(
       host.request<ThreadStartResponse>(
@@ -287,12 +301,11 @@ stream_max_retries = 0
     });
     const startedItems: ItemEnvelope[] = [];
     const completedItems: ItemEnvelope[] = [];
-    const subscription = host.subscribeThread(thread.thread.id, {
+    subscription = host.subscribeThread(thread.thread.id, {
       turnCompleted: () => resolveTurnCompleted(),
       itemStarted: ({ item }) => startedItems.push(item),
       itemCompleted: ({ item }) => completedItems.push(item),
     });
-    cleanups.push(() => subscription.release());
 
     await withTimeout(
       host.request(


### PR DESCRIPTION
## 这次改了什么

### 摘要

修复 Codex custom exec E2E 在 Windows 本地门禁中稳定撞上 Vitest 10 秒 hook 超时的问题。

测试现在先关闭自己独占的 app-server host，再释放 thread subscription，避免 `thread/unsubscribe` 占用大部分 teardown 预算；同时在关闭 fake provider 前主动断开残留 HTTP 连接，不再让 `server.close()` 等待连接自然回收。

### 变更类型

- [ ] `feat` 新功能
- [ ] `fix` 缺陷修复
- [ ] `refactor` / `perf` 重构或性能优化
- [x] `docs` / `test` / `chore` 文档、测试或工程维护
- [ ] 其他：

### 范围

- 关联 Issue / 需求：解除本地 `pnpm test:unit:related` 的既有 teardown 阻塞
- 本 PR 包含：单个 Codex custom exec E2E 的确定性资源回收
- 明确不包含：生产代码；`/issue` Harness / Model ID 功能
- 用户可见变化：无
- 是否存在 breaking change：无

### UI 变化

不涉及。

- 引用的设计规范：不涉及

## 怎么验证的

### 自动验证

```text
Remove-Item Env:XDT_ISOLATED -ErrorAction SilentlyContinue; pnpm test:unit:related
结果：通过；在最终修改后连续执行两次均通过

pnpm --filter desktop run --if-present typecheck
结果：通过

pnpm check:dco
结果：通过，1 个 commit 已签署 DCO

git diff --check
结果：通过
```

### 手工验证

Windows 本地环境复现修改前的 `afterEach` 10 秒超时；修改后同一真实 Codex commandExecution E2E 连续通过。

### 未执行的验证

未跑全量 `pnpm test:unit`；本 PR 只修改单个测试文件，仓库相关门禁精确运行该测试，完整门禁由 CI 执行。

## 风险

### 风险分类

- [x] 无已知风险
- [ ] SQLite / migration
- [ ] system prompt
- [ ] 协议兼容
- [ ] 权限 / 安全 / 用户数据
- [ ] 存量插件兼容（批准状态 / 指纹 / manifest 校验 / 安装布局 / 包格式）
- [ ] 原生层 / fingerprint / OTA
- [ ] 跨平台差异
- [ ] 其他：

### 影响与回滚

- 影响范围：仅测试 teardown
- 回滚 / 降级方式：可整体回滚本提交；不影响生产运行时

### 提交前检查

- [x] 已 review 完整 diff
- [x] 每个 commit 都带 DCO 签名（`git commit -s`，见 [DCO](../DCO)）
- [x] UI 改动已在「UI 变化」注明引用的设计规范章节（不涉及 UI 则跳过）
- [x] 未提交凭证、令牌或授权文件
- [x] 已补充必要文档
- [x] 已确认测试结果或说明未执行原因
