### PR TITLE
fix(pi): raise unknown model output token fallback

### DIFF
--- a/packages/maker-core/src/agents/pi/__tests__/pi-provider-routing.test.ts
+++ b/packages/maker-core/src/agents/pi/__tests__/pi-provider-routing.test.ts
@@ -253,6 +253,89 @@ describe('Pi provider-aware model routing', () => {
     await nativeHandle.close();
   });
 
+  it('uses explicit output caps and a context-bounded fallback for gateway and native models', async () => {
+    const availableModels: ModelDescriptor[] = [
+      {
+        id: 'gateway-fallback-model', displayName: 'Gateway fallback', contextWindow: 128_000,
+        efforts: [], defaultEffort: null,
+      },
+      {
+        id: 'gateway-explicit-model', displayName: 'Gateway explicit', contextWindow: 200_000,
+        maxOutputTokens: 90_000, efforts: [], defaultEffort: null,
+      },
+      {
+        id: 'gateway-small-context-model', displayName: 'Gateway small context', contextWindow: 32_000,
+        efforts: [], defaultEffort: null,
+      },
+      {
+        id: 'native-fallback-model', displayName: 'Native fallback', contextWindow: 200_000,
+        efforts: [], defaultEffort: null,
+      },
+      {
+        id: 'native-explicit-model', displayName: 'Native explicit', contextWindow: 200_000,
+        efforts: [], defaultEffort: null,
+      },
+      {
+        id: 'native-small-context-model', displayName: 'Native small context', contextWindow: 32_000,
+        efforts: [], defaultEffort: null,
+      },
+    ];
+    const descriptorResolver = (_providerId: string | null | undefined, modelId: string) =>
+      availableModels.find((candidate) => candidate.id === modelId)!;
+    const agent = new PiAgent({
+      auth: {
+        getState: async () => ({ authenticated: true, identity: 'test', authSource: 'api-key' as const }),
+        triggerLogin: async () => ({ authenticated: true }),
+        logout: async () => {},
+        getAuthEnv: async () => ({}),
+      },
+      runtimeConfig: { endpoint: 'http://127.0.0.1:9988' },
+      binaryPath: path.join(agentHome, 'pi'),
+      logger: noopLogger,
+      capabilityAdditions: { availableModels },
+      resolvePiAgentHome: () => agentHome,
+      resolvePiGatewayModelDescriptor: descriptorResolver,
+      resolvePiGatewayModelApi: () => 'anthropic-messages',
+      resolvePiNativeProviders: async () => ({
+        providers: [{
+          id: 'native', name: 'Native', baseUrl: 'http://native.test', api: 'openai-completions',
+          models: [
+            { id: 'native-fallback-model', contextWindow: 200_000 },
+            { id: 'native-explicit-model', contextWindow: 200_000, maxTokens: 90_000 },
+            { id: 'native-small-context-model', contextWindow: 32_000 },
+          ],
+        }],
+        env: {},
+      }),
+    });
+
+    const gatewayHandle = await agent.startSession({
+      sessionId: 'max-tokens-gateway', workingDir: cwd, model: 'gateway-fallback-model', providerId: 'openai',
+    });
+    const gatewayModels = JSON.parse(
+      readFileSync(path.join(captured.env.PI_CODING_AGENT_DIR as string, 'models.json'), 'utf8'),
+    ) as { providers: Record<string, { models?: Array<Record<string, unknown>> }> };
+    expect(gatewayModels.providers.cindy?.models).toEqual(expect.arrayContaining([
+      expect.objectContaining({ id: 'gateway-fallback-model', maxTokens: 65_536 }),
+      expect.objectContaining({ id: 'gateway-explicit-model', maxTokens: 90_000 }),
+      expect.objectContaining({ id: 'gateway-small-context-model', maxTokens: 32_000 }),
+    ]));
+    await gatewayHandle.close();
+
+    const nativeHandle = await agent.startSession({
+      sessionId: 'max-tokens-native', workingDir: cwd, model: 'native-fallback-model', providerId: 'native',
+    });
+    const nativeModels = JSON.parse(
+      readFileSync(path.join(captured.env.PI_CODING_AGENT_DIR as string, 'models.json'), 'utf8'),
+    ) as { providers: Record<string, { models?: Array<Record<string, unknown>> }> };
+    expect(nativeModels.providers.native?.models).toEqual(expect.arrayContaining([
+      expect.objectContaining({ id: 'native-fallback-model', maxTokens: 65_536 }),
+      expect.objectContaining({ id: 'native-explicit-model', maxTokens: 90_000 }),
+      expect.objectContaining({ id: 'native-small-context-model', maxTokens: 32_000 }),
+    ]));
+    await nativeHandle.close();
+  });
+
   it('routes host subscriptions through PI native providers and wire model ids', async () => {
     const authProviderIds: Array<string | null | undefined> = [];
     let resolveProxyProviderId: (() => string | null) | undefined;

--- a/packages/maker-core/src/agents/pi/index.ts
+++ b/packages/maker-core/src/agents/pi/index.ts
@@ -452,6 +452,21 @@ function effortToPiThinkingLevel(effort: Effort): string {
 
 const PI_NATIVE_THINKING_LEVELS = ['off', 'minimal', 'low', 'medium', 'high', 'xhigh', 'max'] as const;
 
+/**
+ * Last-resort maxTokens for models that provide no authoritative output limit.
+ * Explicit Model Access / native-provider metadata always wins. Pi separately clamps each
+ * request to the remaining context window, so keep this fallback context-bounded as well.
+ *
+ * This is deliberately a compatibility fallback rather than a claimed model capability:
+ * unknown upstreams may still have a lower output limit and should publish explicit metadata.
+ * Raising the legacy gateway/native defaults (32k/16k) to 64k prevents known long-thinking
+ * turns from being cut off solely by Cindy's synthetic value without making the fallback
+ * unbounded.
+ */
+function piMaxTokensFallback(contextWindow: number | undefined): number {
+  return contextWindow && contextWindow > 0 ? Math.min(contextWindow, 65_536) : 65_536;
+}
+
 /** 从本次启动写入 models.json 的 native model 快照提取可用 effort。 */
 function startupEffortsOfNativeModel(model: PiNativeModelSpec | undefined): readonly Effort[] | undefined {
   if (!model) return undefined;
@@ -1443,7 +1458,7 @@ export class PiAgent extends BaseAgent {
         input: supportsImageInput ? ['text', 'image'] : ['text'],
         // Model Access v3 requires this value; never replace the server limit with a client guess.
         contextWindow: m.contextWindow,
-        maxTokens: m.maxOutputTokens && m.maxOutputTokens > 0 ? m.maxOutputTokens : 32_000,
+        maxTokens: m.maxOutputTokens && m.maxOutputTokens > 0 ? m.maxOutputTokens : piMaxTokensFallback(m.contextWindow),
         // 计费单位与目录一致($/1M tokens);pi 按此自行计价,usage 事件的 cost 才有真值。
         cost: {
           input: m.cost?.input ?? 0,
@@ -1481,21 +1496,24 @@ export class PiAgent extends BaseAgent {
       }
       const nativeModels = (
         np.inheritModels ? np.models.filter((model) => model.api !== undefined || model.catalogAddition === true) : np.models
-      ).map((m) => ({
-        id: m.wireId ?? m.id,
-        name: m.name ?? m.id,
-        ...(m.baseUrl ? { baseUrl: m.baseUrl } : {}),
-        ...(m.headers && Object.keys(m.headers).length > 0 ? { headers: m.headers } : {}),
-        ...(m.api ? { api: m.api } : {}),
-        reasoning: m.reasoning ?? false,
-        ...(m.thinkingLevelMap ? { thinkingLevelMap: { ...m.thinkingLevelMap } } : {}),
-        input: m.input ?? ['text'],
-        contextWindow: m.contextWindow && m.contextWindow > 0 ? m.contextWindow : 128_000,
-        maxTokens: m.maxTokens && m.maxTokens > 0 ? m.maxTokens : 16_000,
-        ...(m.cost ? { cost: structuredClone(m.cost) } : {}),
-        ...(m.compat ? { compat: structuredClone(m.compat) } : {}),
-        ...(m.samplingParams ? { samplingParams: structuredClone(m.samplingParams) } : {}),
-      }));
+      ).map((m) => {
+        const contextWindow = m.contextWindow && m.contextWindow > 0 ? m.contextWindow : 128_000;
+        return {
+          id: m.wireId ?? m.id,
+          name: m.name ?? m.id,
+          ...(m.baseUrl ? { baseUrl: m.baseUrl } : {}),
+          ...(m.headers && Object.keys(m.headers).length > 0 ? { headers: m.headers } : {}),
+          ...(m.api ? { api: m.api } : {}),
+          reasoning: m.reasoning ?? false,
+          ...(m.thinkingLevelMap ? { thinkingLevelMap: { ...m.thinkingLevelMap } } : {}),
+          input: m.input ?? ['text'],
+          contextWindow,
+          maxTokens: m.maxTokens && m.maxTokens > 0 ? m.maxTokens : piMaxTokensFallback(contextWindow),
+          ...(m.cost ? { cost: structuredClone(m.cost) } : {}),
+          ...(m.compat ? { compat: structuredClone(m.compat) } : {}),
+          ...(m.samplingParams ? { samplingParams: structuredClone(m.samplingParams) } : {}),
+        };
+      });
       if (!np.inheritModels && !np.api) {
         throw new Error(`pi: native provider '${np.id}' has no default api`);
       }


### PR DESCRIPTION
## 这次改了什么

### 摘要

PI 写入 models.json 时，gateway 与 native model 缺少权威输出上限元数据会分别被 Cindy 固定为 32k / 16k，导致长推理可能被这个合成值提前截断。

本 PR 保留显式 maxOutputTokens / maxTokens 的最高优先级；仅在元数据缺失时使用 min(contextWindow, 65,536) 作为有界兼容 fallback。

### 变更类型

- [x] fix 缺陷修复
- [ ] feat 新功能
- [ ] refactor / perf 重构或性能优化
- [ ] docs / test / chore 文档、测试或工程维护
- [ ] 其他：

### 范围

- 关联 Issue / 需求：PI 长推理被缺省 maxTokens 提前截断
- 本 PR 包含：gateway/native models.json 输出上限 fallback 调整；显式值、64k fallback、32k context bound 回归测试
- 明确不包含：批量补齐 model catalog 元数据；上游 PI 或 provider 行为改动
- 用户可见变化：缺少输出上限元数据的 PI 模型更不容易在 16k / 32k 被 Cindy 人为截断
- 是否存在 breaking change：无

### UI 变化

不涉及。

- 引用的设计规范：不涉及

## 怎么验证的

### 自动验证

```text
PATH=/opt/homebrew/opt/node@22/bin:$PATH pnpm test:unit:related
结果：通过（Desktop、lizi-mcps、maker-core related、orca-workflow）

pnpm --filter @cindy/maker-core test -- src/agents/pi/__tests__/pi-provider-routing.test.ts --run
结果：通过，72/72

pnpm --filter @cindy/maker-core run --if-present typecheck
结果：命令通过；该 package 当前没有 typecheck script

pnpm check:dco
结果：通过，1 个 commit 已签名
```

### 手工验证

不涉及 UI；已检查生成的 gateway/native models.json 断言覆盖显式值与缺省值。

### 未执行的验证

未执行真实上游 PI/provider API smoke；该验证需要外部 provider 凭证与实际长输出调用。

## 风险

### 风险分类

- [ ] 无已知风险
- [ ] SQLite / migration
- [ ] system prompt
- [ ] 协议兼容
- [ ] 权限 / 安全 / 用户数据
- [ ] 存量插件兼容（批准状态 / 指纹 / manifest 校验 / 安装布局 / 包格式）
- [ ] 原生层 / fingerprint / OTA
- [ ] 跨平台差异
- [x] 其他：未知 provider 的实际输出上限兼容性

### 影响与回滚

- 影响范围：仅影响缺少显式输出上限元数据的 PI gateway/native model。若未知 provider 的真实上限低于 64k，它可能拒绝该 fallback；已有显式元数据的模型不受影响。
- 回滚 / 降级方式：回退本 PR commit，恢复原 32k / 16k fallback；也可通过补充权威 maxOutputTokens / maxTokens 元数据收窄单个模型。
- 性能与计量：不修改 system prompt、prompt cache 或逐 token 热路径；只改变 PI 启动时写入的模型配置。

### 提交前检查

- [x] 已 review 完整 diff
- [x] 每个 commit 都带 DCO 签名（git commit -s）
- [x] UI 改动已在「UI 变化」注明引用的设计规范章节（不涉及 UI）
- [x] 未提交凭证、令牌或授权文件
- [x] 已补充必要文档（本次无需新增文档）
- [x] 已确认测试结果或说明未执行原因
