### PR TITLE
fix(maker-shared): 丢掉整段泄漏的模型停止符

### DIFF
--- a/apps/desktop/src/main/__tests__/messagePersistBroadcaster.test.ts
+++ b/apps/desktop/src/main/__tests__/messagePersistBroadcaster.test.ts
@@ -2238,8 +2238,10 @@ describe('consumeLastAssistantPersistId(per-turn 费用挂载的目标消息追�
   it('does not persist a leaked Grok stop token as the last assistant', async () => {
     const first = onAssistantTextEvent(SESSION, { text: '现有 reviewer 空闲。', isFinal: true }, null);
     const leaked = onAssistantTextEvent(SESSION, { text: '<|eos|>', isFinal: true }, null);
+    const repeated = onAssistantTextEvent(SESSION, { text: '<|eos|><|eos|>', isFinal: true }, null);
     await flushWrites();
     expect(leaked).toBeUndefined();
+    expect(repeated).toBeUndefined();
     expect(createMessage).toHaveBeenCalledTimes(1);
     expect(consumeLastAssistantPersistId(SESSION)).toBe(first);
   });

--- a/apps/desktop/src/main/localDb/__tests__/mapperCitation.test.ts
+++ b/apps/desktop/src/main/localDb/__tests__/mapperCitation.test.ts
@@ -44,7 +44,15 @@ describe('message mapper internal citation compatibility', () => {
     } as Parameters<typeof messageToCamel>[0];
 
     expect(messageToCamel(row).content).toBe('');
+    expect(
+      messageToCamel({
+        ...row,
+        id: 'message-eos-repeat',
+        content: JSON.stringify('<|eos|><|eos|>'),
+      }).content,
+    ).toBe('');
     expect(extractMessagePreview(JSON.stringify('<|eos|>'), 'assistant')).toBeNull();
+    expect(extractMessagePreview(JSON.stringify('<|eos|><|eos|>'), 'assistant')).toBeNull();
     expect(extractMessagePreview(JSON.stringify('The token is <|eos|>'), 'assistant')).toBe(
       'The token is <|eos|>',
     );

--- a/packages/maker-core/src/agents/claude-code/__tests__/translator-subagent-model.test.ts
+++ b/packages/maker-core/src/agents/claude-code/__tests__/translator-subagent-model.test.ts
@@ -484,7 +484,7 @@ describe('Claude Code assistant text streaming contract', () => {
     ]);
     expect(ctx.turn.uiEmittedText).toBe('answer');
     expect(ctx.rt.streamStopTokenByKey.get('toolu-a:0')).toEqual({
-      pending: '',
+      pending: '<|eos|>',
       emitted: false,
     });
   });
@@ -525,7 +525,7 @@ describe('Claude Code assistant text streaming contract', () => {
     ]);
     expect(ctx.turn.uiEmittedText).toBe('先看一眼。');
     expect(ctx.rt.streamStopTokenByKey.get('__main__:0')).toEqual({
-      pending: '',
+      pending: '<|eos|>',
       emitted: false,
     });
   });
@@ -573,7 +573,7 @@ describe('Claude Code assistant text streaming contract', () => {
       { text: '先看一眼。', isFinal: false },
     ]);
     expect(ctx.rt.streamStopTokenByKey.get('__main__:1')).toEqual({
-      pending: '',
+      pending: '<|eos|>',
       emitted: false,
     });
   });

--- a/packages/maker-core/src/agents/claude-code/__tests__/translator-subagent-model.test.ts
+++ b/packages/maker-core/src/agents/claude-code/__tests__/translator-subagent-model.test.ts
@@ -222,6 +222,32 @@ describe('Claude Code assistant text streaming contract', () => {
     expect(ctx.turn.lastAssistantMsgHadSubstance).toBe(true);
   });
 
+  it('does not emit a repeated Grok stop token as assistant text', async () => {
+    const queue = createAsyncQueue<AgentEvent>();
+    const ctx = createCtx();
+
+    translateSdkMessage(
+      {
+        type: 'assistant',
+        uuid: 'assistant-eos-repeat',
+        session_id: 'sdk-session',
+        parent_tool_use_id: null,
+        message: {
+          model: 'grok-4.6',
+          content: [{ type: 'text', text: '<|eos|><|eos|>' }],
+        },
+      },
+      queue,
+      ctx,
+    );
+
+    const textEvents = (await collect(queue)).filter((event) => event.type === 'text');
+    expect(textEvents).toEqual([]);
+    expect(ctx.turn.hasEmittedText).toBe(false);
+    expect(ctx.turn.uiEmittedText).toBe('');
+    expect(ctx.turn.lastAssistantMsgHadSubstance).toBe(true);
+  });
+
   it('does not emit a stop token split across streaming deltas', async () => {
     const queue = createAsyncQueue<AgentEvent>();
     const ctx = createCtx();
@@ -458,7 +484,7 @@ describe('Claude Code assistant text streaming contract', () => {
     ]);
     expect(ctx.turn.uiEmittedText).toBe('answer');
     expect(ctx.rt.streamStopTokenByKey.get('toolu-a:0')).toEqual({
-      pending: '<|eos|>',
+      pending: '',
       emitted: false,
     });
   });
@@ -499,7 +525,7 @@ describe('Claude Code assistant text streaming contract', () => {
     ]);
     expect(ctx.turn.uiEmittedText).toBe('先看一眼。');
     expect(ctx.rt.streamStopTokenByKey.get('__main__:0')).toEqual({
-      pending: '<|eos|>',
+      pending: '',
       emitted: false,
     });
   });
@@ -547,7 +573,7 @@ describe('Claude Code assistant text streaming contract', () => {
       { text: '先看一眼。', isFinal: false },
     ]);
     expect(ctx.rt.streamStopTokenByKey.get('__main__:1')).toEqual({
-      pending: '<|eos|>',
+      pending: '',
       emitted: false,
     });
   });

--- a/packages/maker-core/src/agents/codex/translator.test.ts
+++ b/packages/maker-core/src/agents/codex/translator.test.ts
@@ -2048,6 +2048,7 @@ describe('codex internal citation 归一化 (#785)', () => {
     expect(stableCitationBoundary('<|eo')).toBe(0);
     expect(stableCitationBoundary('<')).toBe(0);
     expect(stableCitationBoundary('  <|eos|>')).toBe(0);
+    expect(stableCitationBoundary('<|eos|><|eos|>')).toBe(0);
     expect(stableCitationBoundary('The token is <|eos|>')).toBe('The token is <|eos|>'.length);
   });
 
@@ -2088,6 +2089,7 @@ describe('codex internal citation 归一化 (#785)', () => {
     expect(finalizeCodexCitationText('<')).toBe('<');
     expect(finalizeCodexCitationText('<|eo')).toBe('<|eo');
     expect(finalizeCodexCitationText('<|eos|>')).toBe('');
+    expect(finalizeCodexCitationText('<|eos|><|eos|>')).toBe('');
   });
 
   it('Web Search 引用标记被剥离,普通 cite 文本与相邻标点不变', async () => {

--- a/packages/maker-core/src/agents/pi/__tests__/pi-translator.test.ts
+++ b/packages/maker-core/src/agents/pi/__tests__/pi-translator.test.ts
@@ -355,6 +355,44 @@ describe('pi translator', () => {
     expect(events.filter((event) => event.type === 'text')).toEqual([]);
   });
 
+  it('does not emit a repeated Grok stop token as assistant text', () => {
+    const ctx = createPiTranslateContext(noopLogger);
+    const { queue, events } = makeQueue();
+
+    translatePiEvent(ev({ type: 'message_start' }), queue, ctx);
+    translatePiEvent(
+      ev({
+        type: 'message_update',
+        assistantMessageEvent: { type: 'text_delta', contentIndex: 0, delta: '<|eos|>' },
+      }),
+      queue,
+      ctx,
+    );
+    translatePiEvent(
+      ev({
+        type: 'message_update',
+        assistantMessageEvent: { type: 'text_delta', contentIndex: 0, delta: '<|eos|>' },
+      }),
+      queue,
+      ctx,
+    );
+    translatePiEvent(
+      ev({
+        type: 'message_end',
+        message: {
+          role: 'assistant',
+          content: [{ type: 'text', text: '<|eos|><|eos|>' }],
+          model: 'xai/grok-4.6',
+          stopReason: 'stop',
+        },
+      }),
+      queue,
+      ctx,
+    );
+
+    expect(events.filter((event) => event.type === 'text')).toEqual([]);
+  });
+
   it('surfaces a terminal provider error after Pi settles instead of staying in Working', () => {
     const ctx = createPiTranslateContext(noopLogger);
     const { queue, events } = makeQueue();

--- a/packages/maker-core/src/agents/pi/translator.ts
+++ b/packages/maker-core/src/agents/pi/translator.ts
@@ -119,7 +119,7 @@ export interface PiTranslateContext {
   /** contentIndex → 当前消息内的 thinking block 状态。 */
   thinkingBlocks: Map<number, PiThinkingBlock>;
   /**
-   * contentIndex → 独立停止符暂存。text_delta 可能把 `<|eos|>` 拆开，
+   * contentIndex → 停止符控制暂存。text_delta 可能把 `<|eos|>` 拆开或连写，
    * 必须按本块判定，不能和别的 text block 共用。
    */
   streamStopTokenByIndex: Map<number, StandaloneStopTokenHold>;

--- a/packages/maker-shared/src/internalCitation.test.ts
+++ b/packages/maker-shared/src/internalCitation.test.ts
@@ -108,8 +108,15 @@ describe('leaked model stop tokens', () => {
   it('holds whitespace-only deltas without releasing a later leftover token', () => {
     const buffer = { pending: '', emitted: false };
     expect(holdStandaloneStopTokenDelta(buffer, ' '.repeat(23))).toBeNull();
+    expect(buffer.pending).toBe(' '.repeat(23));
     expect(holdStandaloneStopTokenDelta(buffer, '<|eos|>')).toBeNull();
     expect(buffer).toEqual({ pending: '', emitted: false });
+  });
+
+  it('keeps ordinary leading whitespace when later prose arrives', () => {
+    const buffer = { pending: '', emitted: false };
+    expect(holdStandaloneStopTokenDelta(buffer, '    ')).toBeNull();
+    expect(holdStandaloneStopTokenDelta(buffer, 'code')).toBe('    code');
   });
 
   it('holds a one-character leftover prefix until the closer arrives', () => {

--- a/packages/maker-shared/src/internalCitation.test.ts
+++ b/packages/maker-shared/src/internalCitation.test.ts
@@ -44,6 +44,13 @@ describe('leaked model stop tokens', () => {
     expect(stripInternalWebCitations('  <|eos|>\n')).toBe('');
   });
 
+  it('strips a whole-message run of stop tokens, including mixed tokens and blank lines', () => {
+    expect(stripStandaloneModelStopToken('<|eos|><|eos|>')).toBe('');
+    expect(stripInternalWebCitations('<|eos|>\n\n<|eos|>')).toBe('');
+    expect(stripInternalWebCitations('  <|eos|> <|eot_id|>\n')).toBe('');
+    expect(stripInternalWebCitations('<|eos|>answer')).toBe('answer');
+  });
+
   it('leaves embedded stop-token prose intact', () => {
     expect(stripInternalWebCitations('The token is <|eos|>')).toBe('The token is <|eos|>');
     expect(stripInternalWebCitations('done<|eot_id|>')).toBe('done<|eot_id|>');
@@ -55,16 +62,20 @@ describe('leaked model stop tokens', () => {
     expect(stableStandaloneModelStopTokenBoundary('<|eo')).toBe(0);
     expect(stableStandaloneModelStopTokenBoundary('  <|eo')).toBe(0);
     expect(stableStandaloneModelStopTokenBoundary('<|eos|>')).toBe(0);
+    expect(stableStandaloneModelStopTokenBoundary('<|eos|><|eos|>')).toBe(0);
+    expect(stableStandaloneModelStopTokenBoundary('<|eos|><|eo')).toBe(0);
     expect(stableStandaloneModelStopTokenBoundary('The token is <|eo')).toBe('The token is <|eo'.length);
     expect(isPossibleStandaloneStopPrefix('  <|eo')).toBe(true);
     expect(isPossibleStandaloneStopPrefix('<')).toBe(true);
     expect(isPossibleStandaloneStopPrefix('<|')).toBe(true);
     expect(isPossibleStandaloneStopPrefix(`${' '.repeat(23)}<|eos|>`)).toBe(true);
+    expect(isPossibleStandaloneStopPrefix('<|eos|><|eos|>')).toBe(true);
     expect(isPossibleStandaloneStopPrefix('The token is <|eo')).toBe(false);
   });
 
   it('is idempotent', () => {
     expect(stripInternalWebCitations(stripInternalWebCitations('<|eos|>'))).toBe('');
+    expect(stripInternalWebCitations(stripInternalWebCitations('<|eos|><|eos|>'))).toBe('');
     expect(stripInternalWebCitations(stripInternalWebCitations('The token is <|eos|>'))).toBe(
       'The token is <|eos|>',
     );
@@ -76,7 +87,7 @@ describe('leaked model stop tokens', () => {
     expect(holdStandaloneStopTokenDelta(a, '<|eo')).toBeNull();
     expect(holdStandaloneStopTokenDelta(b, 'answer')).toBe('answer');
     expect(holdStandaloneStopTokenDelta(a, 's|>')).toBeNull();
-    expect(a).toEqual({ pending: '<|eos|>', emitted: false });
+    expect(a).toEqual({ pending: '', emitted: false });
     expect(b).toEqual({ pending: '', emitted: true });
   });
 
@@ -84,23 +95,29 @@ describe('leaked model stop tokens', () => {
     const buffer = { pending: '', emitted: false };
     const padded = `${' '.repeat(23)}<|eos|>`;
     expect(holdStandaloneStopTokenDelta(buffer, padded)).toBeNull();
-    expect(buffer.emitted).toBe(false);
-    expect(buffer.pending.endsWith('<|eos|>')).toBe(true);
+    expect(buffer).toEqual({ pending: '', emitted: false });
   });
 
   it('holds whitespace-only deltas without releasing a later leftover token', () => {
     const buffer = { pending: '', emitted: false };
     expect(holdStandaloneStopTokenDelta(buffer, ' '.repeat(23))).toBeNull();
     expect(holdStandaloneStopTokenDelta(buffer, '<|eos|>')).toBeNull();
-    expect(buffer.emitted).toBe(false);
-    expect(buffer.pending.trim()).toBe('<|eos|>');
+    expect(buffer).toEqual({ pending: '', emitted: false });
   });
 
   it('holds a one-character leftover prefix until the closer arrives', () => {
     const buffer = { pending: '', emitted: false };
     expect(holdStandaloneStopTokenDelta(buffer, '<')).toBeNull();
     expect(holdStandaloneStopTokenDelta(buffer, '|eos|>')).toBeNull();
-    expect(buffer).toEqual({ pending: '<|eos|>', emitted: false });
+    expect(buffer).toEqual({ pending: '', emitted: false });
+  });
+
+  it('drops a completed leftover so a second copy cannot flush it as prose', () => {
+    const buffer = { pending: '', emitted: false };
+    expect(holdStandaloneStopTokenDelta(buffer, '<|eos|>')).toBeNull();
+    expect(holdStandaloneStopTokenDelta(buffer, '<|eos|>')).toBeNull();
+    expect(buffer).toEqual({ pending: '', emitted: false });
+    expect(holdStandaloneStopTokenDelta(buffer, 'answer')).toBe('answer');
   });
 
   it('still strips a split web citation after ordinary prose has been emitted', () => {

--- a/packages/maker-shared/src/internalCitation.test.ts
+++ b/packages/maker-shared/src/internalCitation.test.ts
@@ -94,7 +94,7 @@ describe('leaked model stop tokens', () => {
     expect(holdStandaloneStopTokenDelta(a, '<|eo')).toBeNull();
     expect(holdStandaloneStopTokenDelta(b, 'answer')).toBe('answer');
     expect(holdStandaloneStopTokenDelta(a, 's|>')).toBeNull();
-    expect(a).toEqual({ pending: '', emitted: false });
+    expect(a).toEqual({ pending: '<|eos|>', emitted: false });
     expect(b).toEqual({ pending: '', emitted: true });
   });
 
@@ -102,7 +102,8 @@ describe('leaked model stop tokens', () => {
     const buffer = { pending: '', emitted: false };
     const padded = `${' '.repeat(23)}<|eos|>`;
     expect(holdStandaloneStopTokenDelta(buffer, padded)).toBeNull();
-    expect(buffer).toEqual({ pending: '', emitted: false });
+    expect(buffer.emitted).toBe(false);
+    expect(buffer.pending.endsWith('<|eos|>')).toBe(true);
   });
 
   it('holds whitespace-only deltas without releasing a later leftover token', () => {
@@ -110,7 +111,8 @@ describe('leaked model stop tokens', () => {
     expect(holdStandaloneStopTokenDelta(buffer, ' '.repeat(23))).toBeNull();
     expect(buffer.pending).toBe(' '.repeat(23));
     expect(holdStandaloneStopTokenDelta(buffer, '<|eos|>')).toBeNull();
-    expect(buffer).toEqual({ pending: '', emitted: false });
+    expect(buffer.emitted).toBe(false);
+    expect(buffer.pending.trim()).toBe('<|eos|>');
   });
 
   it('keeps ordinary leading whitespace when later prose arrives', () => {
@@ -123,21 +125,22 @@ describe('leaked model stop tokens', () => {
     const buffer = { pending: '', emitted: false };
     expect(holdStandaloneStopTokenDelta(buffer, '<')).toBeNull();
     expect(holdStandaloneStopTokenDelta(buffer, '|eos|>')).toBeNull();
-    expect(buffer).toEqual({ pending: '', emitted: false });
+    expect(buffer).toEqual({ pending: '<|eos|>', emitted: false });
+  });
+
+  it('keeps a split leftover so later prose reconstructs the original text', () => {
+    const buffer = { pending: '', emitted: false };
+    expect(holdStandaloneStopTokenDelta(buffer, '<|eos|>')).toBeNull();
+    expect(holdStandaloneStopTokenDelta(buffer, 'answer')).toBe('<|eos|>answer');
   });
 
   it('drops a completed leftover so a second copy cannot flush it as prose', () => {
     const buffer = { pending: '', emitted: false };
     expect(holdStandaloneStopTokenDelta(buffer, '<|eos|>')).toBeNull();
     expect(holdStandaloneStopTokenDelta(buffer, '<|eos|>')).toBeNull();
-    expect(buffer).toEqual({ pending: '', emitted: false });
-    expect(holdStandaloneStopTokenDelta(buffer, 'answer')).toBe('answer');
-  });
-
-  it('does not glue a completed leftover onto later prose in the same stream', () => {
-    const buffer = { pending: '', emitted: false };
-    expect(holdStandaloneStopTokenDelta(buffer, '<|eos|>')).toBeNull();
-    expect(holdStandaloneStopTokenDelta(buffer, 'answer')).toBe('answer');
+    expect(buffer.emitted).toBe(false);
+    expect(buffer.pending.trim()).toBe('<|eos|><|eos|>');
+    expect(holdStandaloneStopTokenDelta(buffer, 'answer')).toBe('<|eos|><|eos|>answer');
   });
 
   it('still strips a split web citation after ordinary prose has been emitted', () => {

--- a/packages/maker-shared/src/internalCitation.test.ts
+++ b/packages/maker-shared/src/internalCitation.test.ts
@@ -48,7 +48,14 @@ describe('leaked model stop tokens', () => {
     expect(stripStandaloneModelStopToken('<|eos|><|eos|>')).toBe('');
     expect(stripInternalWebCitations('<|eos|>\n\n<|eos|>')).toBe('');
     expect(stripInternalWebCitations('  <|eos|> <|eot_id|>\n')).toBe('');
-    expect(stripInternalWebCitations('<|eos|>answer')).toBe('answer');
+    expect(stripInternalWebCitations('<|eos|>answer')).toBe('<|eos|>answer');
+  });
+
+  it('leaves completed messages that start with a stop token but continue as prose', () => {
+    expect(stripStandaloneModelStopToken('<|eos|>answer')).toBe('<|eos|>answer');
+    expect(stripInternalWebCitations('<|endoftext|> The token is still here')).toBe(
+      '<|endoftext|> The token is still here',
+    );
   });
 
   it('leaves embedded stop-token prose intact', () => {
@@ -117,6 +124,12 @@ describe('leaked model stop tokens', () => {
     expect(holdStandaloneStopTokenDelta(buffer, '<|eos|>')).toBeNull();
     expect(holdStandaloneStopTokenDelta(buffer, '<|eos|>')).toBeNull();
     expect(buffer).toEqual({ pending: '', emitted: false });
+    expect(holdStandaloneStopTokenDelta(buffer, 'answer')).toBe('answer');
+  });
+
+  it('does not glue a completed leftover onto later prose in the same stream', () => {
+    const buffer = { pending: '', emitted: false };
+    expect(holdStandaloneStopTokenDelta(buffer, '<|eos|>')).toBeNull();
     expect(holdStandaloneStopTokenDelta(buffer, 'answer')).toBe('answer');
   });
 

--- a/packages/maker-shared/src/internalCitation.ts
+++ b/packages/maker-shared/src/internalCitation.ts
@@ -161,9 +161,9 @@ export function holdStandaloneStopTokenDelta(
 ): string | null {
   const combined = buffer.pending + delta;
   if (!buffer.emitted) {
-    const { remainder } = consumeLeadingStopControl(combined);
+    const { remainder, consumedToken } = consumeLeadingStopControl(combined);
     if (remainder.length === 0 || isIncompleteStopTokenPrefix(remainder)) {
-      buffer.pending = remainder;
+      buffer.pending = consumedToken ? remainder : combined;
       return null;
     }
   }

--- a/packages/maker-shared/src/internalCitation.ts
+++ b/packages/maker-shared/src/internalCitation.ts
@@ -92,8 +92,8 @@ function isIncompleteStopTokenPrefix(text: string): boolean {
 /**
  * Eat a leading run of known stop tokens and the whitespace around them.
  * Completed messages only disappear when nothing remains. The streaming
- * hold still drops recognized tokens from `pending` so a second copy
- * cannot flush the earlier leftover as prose.
+ * hold keeps a recognized run pending until later prose proves the block
+ * is not stop-control-only, then emits that original text.
  */
 function consumeLeadingStopControl(text: string): { remainder: string; consumedToken: boolean } {
   let index = 0;
@@ -149,11 +149,12 @@ export interface StandaloneStopTokenHold {
 
 /**
  * Hold leftover stop-token control until this stream has either completed
- * it or proven it is ordinary prose. Completed tokens are dropped from the
- * buffer so a later copy cannot flush the earlier leftover as visible text.
- * After visible prose starts, still hold an unfinished Web-citation tail
- * so split markers are not emitted raw. The buffer is per stream; callers
- * must not share it across concurrent text streams.
+ * it or proven it is ordinary prose. A recognized run stays pending so a
+ * later `answer` can still reconstruct `<|eos|>answer`; only a later copy
+ * of the same control run is dropped. After visible prose starts, still
+ * hold an unfinished Web-citation tail so split markers are not emitted
+ * raw. The buffer is per stream; callers must not share it across
+ * concurrent text streams.
  */
 export function holdStandaloneStopTokenDelta(
   buffer: StandaloneStopTokenHold,
@@ -161,9 +162,9 @@ export function holdStandaloneStopTokenDelta(
 ): string | null {
   const combined = buffer.pending + delta;
   if (!buffer.emitted) {
-    const { remainder, consumedToken } = consumeLeadingStopControl(combined);
+    const { remainder } = consumeLeadingStopControl(combined);
     if (remainder.length === 0 || isIncompleteStopTokenPrefix(remainder)) {
-      buffer.pending = consumedToken ? remainder : combined;
+      buffer.pending = combined;
       return null;
     }
   }

--- a/packages/maker-shared/src/internalCitation.ts
+++ b/packages/maker-shared/src/internalCitation.ts
@@ -5,16 +5,14 @@
  * expose only the flattened text and omit the structured URL annotations, so
  * client boundaries must remove the opaque marker deterministically.
  *
- * Grok / xAI may also leak the stop token `<|eos|>` as visible assistant
- * text, typically as a whole message after a tool-only wrap-up. That marker
- * is not user-facing prose either.
+ * Grok / xAI may also leak stop tokens such as `<|eos|>` as visible
+ * assistant text, typically as a wrap-up after a tool-only turn. One token,
+ * several in a row, or the same tokens split across stream deltas are still
+ * transport control, not user-facing prose. Mentions that follow real
+ * prose, such as `The token is <|eos|>`, stay intact.
  */
-const MODEL_STOP_TOKENS = new Set(['<|endoftext|>', '<|eot_id|>', '<|im_end|>', '<|eos|>']);
-const LONGEST_MODEL_STOP_TOKEN = Math.max(
-  ...[...MODEL_STOP_TOKENS].map((token) => token.length),
-);
-/** Leading whitespace plus the longest token. Anything longer cannot be standalone. */
-const MAX_STANDALONE_STOP_PREFIX = LONGEST_MODEL_STOP_TOKEN + 16;
+const MODEL_STOP_TOKEN_LIST = ['<|endoftext|>', '<|eot_id|>', '<|im_end|>', '<|eos|>'];
+const LONGEST_MODEL_STOP_TOKEN = MODEL_STOP_TOKEN_LIST[0]?.length ?? 0;
 const WEB_CITATION_OPEN = '\uE200cite\uE202';
 const WEB_CITATION_CLOSE = '\uE201';
 
@@ -76,34 +74,64 @@ function stripInternalWebCitationMarkers(text: string): string {
   }
 }
 
-/**
- * Drop a leaked model stop token only when it is the whole assistant
- * message (optional surrounding whitespace). Embedded mentions such as
- * `The token is <|eos|>` stay intact.
- */
-export function stripStandaloneModelStopToken(text: string): string {
-  return MODEL_STOP_TOKENS.has(text.trim()) ? '' : text;
+function matchStopTokenAt(text: string, index: number): string | null {
+  for (const token of MODEL_STOP_TOKEN_LIST) {
+    if (text.startsWith(token, index)) return token;
+  }
+  return null;
+}
+
+function isIncompleteStopTokenPrefix(text: string): boolean {
+  return text.length > 0
+    && text.length <= LONGEST_MODEL_STOP_TOKEN
+    && MODEL_STOP_TOKEN_LIST.some((token) => token.startsWith(text));
 }
 
 /**
- * True while `text` is still only a possible whole-message stop token:
- * surrounding whitespace, a known token, or any incomplete prefix of one
- * (`<`, `<|`, `<|eo`, …). Used to hold streaming deltas until the leftover
- * can be dropped or flushed.
+ * Eat a leading run of known stop tokens and the whitespace around them.
+ * Used by both the completed-message strip and the streaming hold so a
+ * second `<|eos|>` cannot turn an already-recognized leftover into prose.
+ */
+function consumeLeadingStopControl(text: string): string {
+  let index = 0;
+  while (index < text.length) {
+    if ((text[index] ?? '').trim() === '') {
+      index += 1;
+      continue;
+    }
+    const token = matchStopTokenAt(text, index);
+    if (!token) break;
+    index += token.length;
+  }
+  return text.slice(index);
+}
+
+/**
+ * Drop a leading run of leaked stop tokens. A whole message that is only
+ * those tokens (and whitespace) becomes empty; a leading run followed by
+ * prose keeps the prose. Embedded mentions such as `The token is <|eos|>`
+ * stay intact because they do not start with a known token.
+ */
+export function stripStandaloneModelStopToken(text: string): string {
+  const remainder = consumeLeadingStopControl(text);
+  return remainder === text.trimStart() ? text : remainder;
+}
+
+/**
+ * True while `text` is still only stop-token control: whitespace, one or
+ * more known tokens, and at most one incomplete prefix (`<`, `<|eo`, …).
+ * Used to hold streaming deltas until the leftover can be dropped or flushed.
  */
 export function isPossibleStandaloneStopPrefix(text: string): boolean {
-  const candidate = text.trim();
-  if (candidate.length === 0) return true;
-  if (MODEL_STOP_TOKENS.has(candidate)) return true;
-  if (candidate.length > MAX_STANDALONE_STOP_PREFIX) return false;
-  return [...MODEL_STOP_TOKENS].some((token) => token.startsWith(candidate));
+  const remainder = consumeLeadingStopControl(text);
+  return remainder.length === 0 || isIncompleteStopTokenPrefix(remainder);
 }
 
 /**
  * Return the append-only prefix of a streaming snapshot. A standalone
- * leftover — including its surrounding whitespace and an incomplete
- * `<|eos` prefix — is withheld until the closer arrives, because the
- * completed token will disappear.
+ * leftover — including repeated tokens and an incomplete `<|eos` prefix —
+ * is withheld until the closer arrives, because the completed control
+ * will disappear.
  */
 export function stableStandaloneModelStopTokenBoundary(text: string): number {
   return isPossibleStandaloneStopPrefix(text) ? 0 : text.length;
@@ -115,26 +143,24 @@ export interface StandaloneStopTokenHold {
 }
 
 /**
- * Hold a leftover stop token until this stream has either completed it or
- * proven it is ordinary prose. After visible prose starts, still hold an
- * unfinished Web-citation tail so split markers are not emitted raw.
- * The buffer is per stream; callers must not share it across concurrent
- * text streams.
+ * Hold leftover stop-token control until this stream has either completed
+ * it or proven it is ordinary prose. Completed tokens are dropped from the
+ * buffer so a later copy cannot flush the earlier leftover as visible text.
+ * After visible prose starts, still hold an unfinished Web-citation tail
+ * so split markers are not emitted raw. The buffer is per stream; callers
+ * must not share it across concurrent text streams.
  */
 export function holdStandaloneStopTokenDelta(
   buffer: StandaloneStopTokenHold,
   delta: string,
 ): string | null {
   const combined = buffer.pending + delta;
-  if (!buffer.emitted && isPossibleStandaloneStopPrefix(combined)) {
-    const candidate = combined.trim();
-    if (candidate.length === 0) {
-      buffer.pending = combined.slice(-MAX_STANDALONE_STOP_PREFIX);
-    } else {
-      const tokenStart = combined.lastIndexOf(candidate);
-      buffer.pending = `${combined.slice(0, tokenStart).slice(-MAX_STANDALONE_STOP_PREFIX)}${candidate}`;
+  if (!buffer.emitted) {
+    const remainder = consumeLeadingStopControl(combined);
+    if (remainder.length === 0 || isIncompleteStopTokenPrefix(remainder)) {
+      buffer.pending = remainder;
+      return null;
     }
-    return null;
   }
   const citationEnd = stableInternalWebCitationBoundary(combined);
   buffer.pending = combined.slice(citationEnd);

--- a/packages/maker-shared/src/internalCitation.ts
+++ b/packages/maker-shared/src/internalCitation.ts
@@ -12,7 +12,9 @@
  * prose, such as `The token is <|eos|>`, stay intact.
  */
 const MODEL_STOP_TOKEN_LIST = ['<|endoftext|>', '<|eot_id|>', '<|im_end|>', '<|eos|>'];
-const LONGEST_MODEL_STOP_TOKEN = MODEL_STOP_TOKEN_LIST[0]?.length ?? 0;
+const LONGEST_MODEL_STOP_TOKEN = Math.max(
+  ...MODEL_STOP_TOKEN_LIST.map((token) => token.length),
+);
 const WEB_CITATION_OPEN = '\uE200cite\uE202';
 const WEB_CITATION_CLOSE = '\uE201';
 
@@ -89,11 +91,13 @@ function isIncompleteStopTokenPrefix(text: string): boolean {
 
 /**
  * Eat a leading run of known stop tokens and the whitespace around them.
- * Used by both the completed-message strip and the streaming hold so a
- * second `<|eos|>` cannot turn an already-recognized leftover into prose.
+ * Completed messages only disappear when nothing remains. The streaming
+ * hold still drops recognized tokens from `pending` so a second copy
+ * cannot flush the earlier leftover as prose.
  */
-function consumeLeadingStopControl(text: string): string {
+function consumeLeadingStopControl(text: string): { remainder: string; consumedToken: boolean } {
   let index = 0;
+  let consumedToken = false;
   while (index < text.length) {
     if ((text[index] ?? '').trim() === '') {
       index += 1;
@@ -101,20 +105,21 @@ function consumeLeadingStopControl(text: string): string {
     }
     const token = matchStopTokenAt(text, index);
     if (!token) break;
+    consumedToken = true;
     index += token.length;
   }
-  return text.slice(index);
+  return { remainder: text.slice(index), consumedToken };
 }
 
 /**
- * Drop a leading run of leaked stop tokens. A whole message that is only
- * those tokens (and whitespace) becomes empty; a leading run followed by
- * prose keeps the prose. Embedded mentions such as `The token is <|eos|>`
- * stay intact because they do not start with a known token.
+ * Drop a leaked stop-token run only when it is the whole assistant
+ * message (optional surrounding whitespace). Repeated or mixed tokens
+ * still count. Mentions such as `The token is <|eos|>`, or a token
+ * glued to later prose (`<|eos|>answer`), stay intact.
  */
 export function stripStandaloneModelStopToken(text: string): string {
-  const remainder = consumeLeadingStopControl(text);
-  return remainder === text.trimStart() ? text : remainder;
+  const { remainder, consumedToken } = consumeLeadingStopControl(text);
+  return consumedToken && remainder.length === 0 ? '' : text;
 }
 
 /**
@@ -123,7 +128,7 @@ export function stripStandaloneModelStopToken(text: string): string {
  * Used to hold streaming deltas until the leftover can be dropped or flushed.
  */
 export function isPossibleStandaloneStopPrefix(text: string): boolean {
-  const remainder = consumeLeadingStopControl(text);
+  const { remainder } = consumeLeadingStopControl(text);
   return remainder.length === 0 || isIncompleteStopTokenPrefix(remainder);
 }
 
@@ -156,7 +161,7 @@ export function holdStandaloneStopTokenDelta(
 ): string | null {
   const combined = buffer.pending + delta;
   if (!buffer.emitted) {
-    const remainder = consumeLeadingStopControl(combined);
+    const { remainder } = consumeLeadingStopControl(combined);
     if (remainder.length === 0 || isIncompleteStopTokenPrefix(remainder)) {
       buffer.pending = remainder;
       return null;


### PR DESCRIPTION
## 这次改了什么

### 摘要

Grok 工具轮收尾仍会把停止符当成助手气泡吐出来。#2820 只丢掉「整条恰好一个停止符」，所以 `<|eos|><|eos|>`、中间夹空白、流式先来一个再来一个都会漏。

这次把共用清洗改成：还没发出去的助手文本如果只由已知停止符和空白组成，就当控制信息丢掉。完成的停止符不再留在 hold 里，第二个不会把第一个拼回正文。正文里提到停止符的句子照旧保留。

### 变更类型

- [x] `fix` 缺陷修复
- [ ] `feat` 新功能
- [ ] `refactor` / `perf` 重构或性能优化
- [ ] `docs` / `test` / `chore` 文档、测试或工程维护
- [ ] 其他：

### 范围

- 关联 Issue / 需求：#2820 合入后的同类泄漏；本机 8/13 之后 38 条真实泄漏都是单个或双个 `<|eos|>`
- 本 PR 包含：`stripStandaloneModelStopToken` / 流式 hold 按最长匹配吃掉前导停止符和空白；PI / Claude / Codex / 落库 / 历史回放沿用同一条清洗
- 明确不包含：不改请求 stop sequence、不改 xAI 代理、不改 silent-stop、不回写旧库、不改 system prompt
- 用户可见变化：新出现的单个/重复停止符不再进气泡、不落库；打开旧任务时已落库的 `<|eos|><|eos|>` 会被藏掉
- 是否存在 breaking change：无

### UI 变化

- 引用的设计规范：不涉及：没有改界面、布局、样式或文案，只改助手文本清洗

## 怎么验证的

### 自动验证

```text
pnpm --filter @cindy/maker-shared exec vitest run src/internalCitation.test.ts
结果：1 file / 16 tests 通过

pnpm --filter @cindy/maker-core exec vitest run \
  src/agents/pi/__tests__/pi-translator.test.ts \
  src/agents/claude-code/__tests__/translator-subagent-model.test.ts \
  src/agents/claude-code/__tests__/translator-silent-stop.test.ts \
  src/agents/codex/translator.test.ts
结果：4 files / 164 tests 通过（rebase 后复跑）

pnpm --filter desktop exec vitest run \
  src/main/localDb/__tests__/mapperCitation.test.ts \
  src/main/__tests__/messagePersistBroadcaster.test.ts
结果：2 files / 104 tests 通过

pnpm --filter desktop run typecheck
结果：通过

pnpm test:unit:related
结果：maker-shared / maker-core 通过；desktop 仅 ghostInstallReceipt 2 条失败（干净 origin/main 同样复现，与本 PR 无关）
```

### 手工验证

不涉及。本机账号库 8/13 之后的 38 条真实泄漏（单个或双个 `<|eos|>`）已对照新清洗，都会被吃空。

### 未执行的验证

全量 `pnpm test:unit` 在 rebase 后第一次跑因 worktree 缺 `exceljs` / `docx` 收集失败，并夹杂 `claudeOrphanReaper`、SuperGrok 估价等与本 diff 无关的断言。补装依赖后未整轮重跑，交给 CI。

## 风险

### 风险分类

- [x] 其他：展示层清洗可能把「整条只由停止符组成」的助手文本藏掉；正文里提到停止符的句子不洗
- [ ] 无已知风险
- [ ] SQLite / migration
- [ ] system prompt
- [ ] 协议兼容
- [ ] 权限 / 安全 / 用户数据
- [ ] 存量插件兼容（批准状态 / 指纹 / manifest 校验 / 安装布局 / 包格式）
- [ ] 原生层 / fingerprint / OTA
- [ ] 跨平台差异

### 影响与回滚

- 影响范围：PI / Claude Code / Codex 助手可见文本、落库、历史回放、侧栏预览。silent-stop 仍看上游原始 text block，不看清洗结果。
- 回滚 / 降级方式：revert 本 PR。

### 提交前检查

- [x] 已 review 完整 diff
- [x] 每个 commit 都带 DCO 签名（`git commit -s`，见 [DCO](../DCO)）
- [x] UI 改动已在「UI 变化」注明引用的设计规范章节（不涉及 UI 则跳过）
- [x] 未提交凭证、令牌或授权文件
- [x] 已补充必要文档
- [x] 已确认测试结果或说明未执行原因
