### PR TITLE
fix(desktop): IM 换新任务时渠道回复不再夹说明

### DIFF
--- a/apps/desktop/src/main/hook-control/__tests__/dispatcher.test.ts
+++ b/apps/desktop/src/main/hook-control/__tests__/dispatcher.test.ts
@@ -623,7 +623,7 @@ describe('dispatcher 核心语义', () => {
     fr.finish();
   });
 
-  it('会话被移出工作目录映射 -> 断开绑定、换新对话并说明, 不跟随到映射外', async () => {
+  it('会话被移出工作目录映射 -> 断开绑定、换新对话, 不跟随到映射外', async () => {
     const bindings = memoryBindings();
     const sessions: Record<string, { workingDir: string; usable: boolean }> = {};
     const fr = fakeRunner({ sessions });
@@ -651,10 +651,7 @@ describe('dispatcher 核心语义', () => {
 
     fr.finish({ finalText: '新对话的回答' });
     await tick();
-    const finalText = c.last('turn.end')!.payload.finalText;
-    expect(finalText).toContain('原任务已不在可用的工作目录里');
-    expect(finalText).toContain('把它所在的目录加进来');
-    expect(finalText).toContain('新对话的回答');
+    expect(c.last('turn.end')!.payload.finalText).toBe('新对话的回答');
   });
 
   it('旧任务还在跑时被移出映射: 新消息不排进旧会话(快路径也过边界)', async () => {
@@ -969,7 +966,7 @@ describe('dispatcher 核心语义', () => {
     fr.finish();
   });
 
-  it('工作目录映射被改(会话目录没变) -> 仍丢绑定重建, 并说明原因', async () => {
+  it('工作目录映射被改(会话目录没变) -> 仍丢绑定重建', async () => {
     const bindings = memoryBindings();
     const sessions: Record<string, { workingDir: string; usable: boolean }> = {};
     const fr = fakeRunner({ sessions });
@@ -998,9 +995,7 @@ describe('dispatcher 核心语义', () => {
 
     fr.finish({ finalText: '新会话的回答' });
     await tick();
-    const finalText = c.last('turn.end')!.payload.finalText;
-    expect(finalText).toContain('原任务已不在可用的工作目录里');
-    expect(finalText).toContain('新会话的回答');
+    expect(c.last('turn.end')!.payload.finalText).toBe('新会话的回答');
   });
 
   it('存量绑定(带早期版本残留字段)照常判定: 在映射内即复用, 越界即重建', async () => {
@@ -1034,7 +1029,7 @@ describe('dispatcher 核心语义', () => {
     fr2.finish();
   });
 
-  it('绑定的会话已归档/删除 -> 重建并说明是原对话没了', async () => {
+  it('绑定的会话已归档/删除 -> 重建, 渠道回复不夹说明', async () => {
     const bindings = memoryBindings();
     const fr = fakeRunner({ sessions: { 'gone-session': { workingDir: WS_DIR, usable: false } } });
     const { d } = makeDispatcher({ runner: fr.runner, bindings });
@@ -1047,8 +1042,7 @@ describe('dispatcher 核心语义', () => {
 
     fr.finish({ finalText: '新的回答' });
     await tick();
-    // 措辞留余地: inspect 的 null 也可能是读库瞬时失败, 不能一口咬定会话没了
-    expect(c.last('turn.end')!.payload.finalText).toContain('原任务现在读不到');
+    expect(c.last('turn.end')!.payload.finalText).toBe('新的回答');
   });
 
   it('切账号期间异步定位失败也不回写旧代 rejected ack', async () => {

--- a/apps/desktop/src/main/hook-control/dispatcher.ts
+++ b/apps/desktop/src/main/hook-control/dispatcher.ts
@@ -429,26 +429,6 @@ const TURN_DELIVERY_ACK_MAX_DELAY_MS = 60_000;
 const REOPEN_TTL_MS = 24 * 60 * 60_000;
 /** 续跑记账条数上限(FIFO 淘汰最老), 同 ackHistory 语义: 防长驻进程无界增长。 */
 const MAX_PENDING_REOPENS = 200;
-/**
- * 原对话不再落在工作目录映射内时(被移到映射外的项目, 或映射本身被改/删),
- * 回给渠道的一次性说明(Slack / Telegram 侧文案不进 locale, 与 interactions.ts
- * 的卡片按钮同规硬编码中文)。
- *
- * 必须如实: 旧绑定被丢弃后同一个 externalKey 立刻指向新对话, 光把目录加进映射
- * **不会**自动接回原对话(那条 thread 已经绑到新的了), 只有先让目录进映射、再用
- * 对话选择重新指定原对话才接得回来 —— 两步缺一不可。
- */
-const NOTICE_SESSION_RECREATED =
-  'ℹ️ 原任务已不在可用的工作目录里，这条消息起换用了新任务，原任务的上下文不会带过来。' +
-  '想接回原任务：先到 Cindy 的 设置 → 远程连接 → 工作目录映射 把它所在的目录加进来，' +
-  '再在这里选择任务重新指定它。';
-/**
- * 查不到原对话时的说明。措辞刻意留了余地: inspect 返回 null 是多义的 ——
- * 会话真的没了是 null, meta / DB 读取瞬时失败也被吞成 null(session-runner
- * 两路都 catch)。一口咬定"已被归档或删除"会在读库抖动时误导用户
- * (PR #733 review 指出)。
- */
-const NOTICE_SESSION_GONE = 'ℹ️ 原任务现在读不到（可能已被归档或删除），这条消息起换用了新任务。';
 
 /** 标题里消息摘要的最大长度(字符), 超出截断加省略号。 */
 const TITLE_SNIPPET_MAX = 24;
@@ -559,8 +539,6 @@ interface PendingTask {
   accountGeneration: number;
   /** 群上下文游标提交回调；仅在 provider 实际受理后调用。 */
   commitContextCursor?: ContextCursorCommit;
-  /** 会话定位阶段产生的一次性说明, 前置到本次 turn.end 的 finalText。 */
-  notice?: string;
   /**
    * 派活被接下那一刻, 这条连接宣告过 turn.reopen 吗。
    *
@@ -1585,13 +1563,7 @@ export function createHookDispatcher(deps: HookDispatcherDeps): HookDispatcher {
     const status: 'ok' | 'error' | 'cancelled' = wasCancelled ? 'cancelled' : outcome.status;
     // 协议约束: error 必须带非空 errorMessage, ok / cancelled 必须为 null
     const isError = status === 'error';
-    // 会话定位说明前置到正文: 协议没有系统消息通道, 而"为什么换了个会话 /
-    // 目录变了"必须让渠道里的人看见, 否则只能观察到会话莫名重开。
-    const finalText = task.notice
-      ? outcome.finalText
-        ? `${task.notice}\n\n${outcome.finalText}`
-        : task.notice
-      : outcome.finalText;
+    const finalText = outcome.finalText;
     const turnEnd: TurnEndPayload = {
       requestId: task.requestId,
       externalKey: task.externalKey,
@@ -1741,8 +1713,7 @@ export function createHookDispatcher(deps: HookDispatcherDeps): HookDispatcher {
 
   /**
    * 会话定位(接管 / 绑定复用 / 新建), 返回 run 参数或拒绝原因。
-   * notice: 需要随本次 turn.end 一并告知渠道用户的一次性说明(会话被移动 /
-   * 旧绑定失效换了新会话) —— 协议没有系统消息通道, 由 execute 前置到 finalText。
+   * 旧绑定失效时只换新任务, 不往渠道回复里塞说明 —— 渠道只回收正文。
    */
   async function resolveTarget(
     connectionId: string,
@@ -1750,7 +1721,7 @@ export function createHookDispatcher(deps: HookDispatcherDeps): HookDispatcher {
     payload: TaskDispatchPayload,
     generation: number,
   ): Promise<
-    | { run: HookRunRequest; notice?: string; cleanupWorktree?: () => Promise<void> }
+    | { run: HookRunRequest; cleanupWorktree?: () => Promise<void> }
     | { reject: TaskRejectReason }
   > {
     // options 四元组原样透传给 runner —— 空值由 runner 按桌面端草稿默认落值
@@ -1787,8 +1758,6 @@ export function createHookDispatcher(deps: HookDispatcherDeps): HookDispatcher {
     let forceNew = false;
     let replacementOfSessionId: string | null = null;
     let replacementPrompt: string | null = null;
-    /** 旧绑定作废、本次不得不新建会话时, 随 turn.end 回给渠道的说明。 */
-    let recreatedNotice: string | null = null;
 
     const laneKind = deriveLaneKind(payload.externalKey);
     const laneKey = bindingKey(connectionId, payload.externalKey);
@@ -2020,7 +1989,7 @@ export function createHookDispatcher(deps: HookDispatcherDeps): HookDispatcher {
        * 而例外必须跨「绑定文件」与「会话库」两次无事务的写保持一致, 中间还夹着
        * 随时可能到达的 IM 消息 —— PR #653 / #669 为此叠了在途标记、TTL、回滚、
        * CAS、补偿五层状态, 十轮 review 仍在出新的组合边界。现在的语义是: 移出
-       * 映射 = 断开绑定, 并向渠道说明怎么恢复(见 NOTICE_SESSION_RECREATED)。
+       * 映射 = 断开绑定, 在映射内另开新任务, 不向渠道解释。
        * 在映射**内**换目录仍然无感跟随, 因为那本就在边界内。
        */
       if (usable && inAllowedRoot) {
@@ -2045,16 +2014,12 @@ export function createHookDispatcher(deps: HookDispatcherDeps): HookDispatcher {
       }
       bindings.remove(connectionId, payload.externalKey);
       if (legacyNamespace) bindings.remove(legacyNamespace, payload.externalKey);
-      // 旧绑定作废后下面会新建会话 —— 渠道侧只会看到"换了个会话"却无从得知
-      // 原因, 因此带一条说明随本次 turn.end 回去(见 execute)。
-      if (!forceNew) {
-        recreatedNotice = info?.usable ? NOTICE_SESSION_RECREATED : NOTICE_SESSION_GONE;
-        // 当前 lane 自己的失效绑定可以作为交接来源。legacy namespace 可能来自
-        // 另一账号，只允许迁移可用且仍在映射内的任务，绝不从失效 legacy 读历史。
-        if (!info?.usable && bound === namespacedBound) {
-          replacementOfSessionId = bound;
-          replacementPrompt = latestPromptBySession.get(bound) ?? null;
-        }
+      // 旧绑定作废后下面会新建会话。渠道只回收正文, 不夹定位说明。
+      // 当前 lane 自己的失效绑定可以作为交接来源。legacy namespace 可能来自
+      // 另一账号，只允许迁移可用且仍在映射内的任务，绝不从失效 legacy 读历史。
+      if (!forceNew && !info?.usable && bound === namespacedBound) {
+        replacementOfSessionId = bound;
+        replacementPrompt = latestPromptBySession.get(bound) ?? null;
       }
       log.info(
         `hook binding for ${payload.externalKey} dropped: session ${bound} ${
@@ -2163,7 +2128,6 @@ export function createHookDispatcher(deps: HookDispatcherDeps): HookDispatcher {
         attachments: payload.attachments,
         origin,
       },
-      ...(recreatedNotice ? { notice: recreatedNotice } : {}),
       ...(cleanupWorktree ? { cleanupWorktree } : {}),
     };
   }
@@ -2308,7 +2272,6 @@ export function createHookDispatcher(deps: HookDispatcherDeps): HookDispatcher {
           commitContextCursor
             ? { commitContextCursor }
             : {}),
-          ...(resolved.notice ? { notice: resolved.notice } : {}),
           ...(resolved.cleanupWorktree ? { cleanupWorktree: resolved.cleanupWorktree } : {}),
         };
         const sessionId = resolved.run.sessionId;

--- a/apps/desktop/src/main/im/shared/turnRetryNotice.ts
+++ b/apps/desktop/src/main/im/shared/turnRetryNotice.ts
@@ -23,8 +23,8 @@
  * 推给用户(这也是 maker-core 侧 claude translator 只透过载类的同一条理由)。
  * 将来要放开某一类, 在这里按 kind 补一条文案即可, 不要直接外发原文。
  *
- * 文案硬编码中文, 与 hook-control/interactions.ts 的卡片按钮、dispatcher.ts 的
- * NOTICE_* 同规 —— 渠道侧文案不进 renderer 的 locale 文件
+ * 文案硬编码中文, 与 hook-control/interactions.ts 的卡片按钮同规 ——
+ * 渠道侧文案不进 renderer 的 locale 文件
  * (见 docs/dev-rules/engineering-conventions.md §5)。
  */
 


### PR DESCRIPTION
## 这次改了什么

### 摘要

Slack / Telegram 里如果原任务已经不在工作目录映射、或已经读不到，Cindy 仍会断开绑定并另开新任务，但渠道回复不再前置那段「换了新任务 / 去设置加映射」说明，只回收正文。

### 变更类型

- [x] `fix` 缺陷修复

### 范围

- 关联 Issue / 需求：无
- 本 PR 包含：去掉 hook dispatcher 往 `turn.end.finalText` 前置的会话重建说明
- 明确不包含：Cindy 桌面端打开新任务时的原因提示（先不做）
- 用户可见变化：官方 Slack / Telegram / X hook 在换新任务时，渠道消息不再夹 ℹ️ 说明
- 是否存在 breaking change：无

### UI 变化

- 引用的设计规范：不涉及：只改 IM 渠道回复正文，不改桌面 / 手机界面。

## 怎么验证的

### 自动验证

```text
pnpm --filter desktop run typecheck
结果：通过

pnpm test:unit:related
结果：PASS apps/desktop unit（含 dispatcher 155 条）

pnpm --filter desktop exec vitest run src/main/hook-control/__tests__/dispatcher.test.ts src/main/im/shared/__tests__/turnRetryNotice.test.ts
结果：179 passed
```

全量 `pnpm test:unit` 另有与本 diff 无关的失败（`claudeOrphanReaper`、`usageHistory` SuperGrok 估价、`codexProxyHost` 超时、`pi-agent.integration` 子 agent 标题），未纳入本 PR。

### 手工验证

不涉及。未在 Telegram / Slack 实机发消息。

### 未执行的验证

未做 IM 实机验证。mobile 不涉及。

## 风险

### 风险分类

- [x] 其他：官方 hook 渠道文案少了一段说明；用户只能在 Cindy 列表里看到新任务。

### 影响与回滚

- 影响范围：hook-control dispatcher 的 `turn.end` 正文；个人 Telegram bot 本来就没有这段说明。
- 回滚 / 降级方式：还原本 PR。
- 远程 / 手机：不改 workdir 文件访问、不改 IPC、不改手机入口。SSH 远程工作区不涉及；device-link allowlist 不涉及；手机版不涉及。

### 提交前检查

- [x] 已 review 完整 diff
- [x] 每个 commit 都带 DCO 签名（`git commit -s`，见 [DCO](../DCO)）
- [x] UI 改动已在「UI 变化」注明引用的设计规范章节（不涉及 UI 则跳过）
- [x] 未提交凭证、令牌或授权文件
- [x] 已补充必要文档
- [x] 已确认测试结果或说明未执行原因
