### PR TITLE
fix(desktop): 计划进行中步骤改用对齐空心圆的圆弧 spinner

### DIFF
--- a/apps/desktop/src/renderer/__tests__/agentActionRowRendering.test.ts
+++ b/apps/desktop/src/renderer/__tests__/agentActionRowRendering.test.ts
@@ -448,7 +448,7 @@ describe('AgentActionsBlock — 状态判定与块头', () => {
         isSessionStreaming: true,
       }),
     );
-    expect(container.querySelector('.animate-spin')).toBeTruthy();
+    expect(container.querySelector('.animate-spinner')).toBeTruthy();
     expandBlock();
     expect(screen.getAllByLabelText('chat.agentActionRow.status.done')).toHaveLength(1);
     expect(screen.getAllByLabelText('chat.agentActionRow.status.running')).toHaveLength(1);
@@ -463,7 +463,7 @@ describe('AgentActionsBlock — 状态判定与块头', () => {
         isSessionStreaming: true,
       }),
     );
-    expect(container.querySelector('.animate-spin')).toBeNull();
+    expect(container.querySelector('.animate-spinner')).toBeNull();
     expandBlock();
     expect(screen.getByLabelText('chat.agentActionRow.status.done')).toBeTruthy();
   });
@@ -475,7 +475,7 @@ describe('AgentActionsBlock — 状态判定与块头', () => {
         resultMap: new Map(),
       }),
     );
-    expect(container.querySelector('.animate-spin')).toBeNull();
+    expect(container.querySelector('.animate-spinner')).toBeNull();
     expandBlock();
     expect(screen.getByLabelText('chat.agentActionRow.status.done')).toBeTruthy();
   });

--- a/apps/desktop/src/renderer/components/chat/TodoListCard.tsx
+++ b/apps/desktop/src/renderer/components/chat/TodoListCard.tsx
@@ -8,10 +8,9 @@
  *   - 鼠标悬停时临时展开,移开即收起;点击/Enter 后固定展开,再次触发立即收起。
  *     浮层绝对定位(bottom-full),不改变 composer overlay 的实测高度,
  *     消息流不会因 hover 抖动。
- *   - 浮层行:completed 灰(check 圆圈),in_progress 高亮(实心圆点呼吸,
- *     复用侧栏运行态同款 session-status-breathing;按 DESIGN.md §SVG 常驻
- *     动画红线,呼吸挂 HTML wrapper,SVG 本体静态;reduced-motion 静止),
- *     pending 正常前景色(空心圆圈)。
+ *   - 浮层行:completed 灰(check 圆圈),in_progress 高亮(「正在工作…」同款圆弧
+ *     spinner,半径对齐空心圆 r=10;旋转挂 HTML wrapper、SVG 本体静态;
+ *     reduced-motion 与会话空闲时静止),pending 正常前景色(空心圆圈)。
  *   - 胶囊图标使用静态灰度进度圆环表达当前步骤位置(它表达"第几步",不是
  *     loading 语义,不旋转);进度变化只通过圆环长度的短过渡反馈。
  *
@@ -25,7 +24,6 @@ import {
   ChevronDown,
   ChevronRight,
   CircleCheck,
-  CircleDot,
   Circle,
   ListTodo,
   X,
@@ -33,6 +31,7 @@ import {
 import { useTranslation } from 'react-i18next';
 import type { MessageRenderTodoItem } from '@cindy/maker-shared/message-render';
 
+import { Spinner, type SpinnerIconComponent } from '@/components/ui/spinner';
 import { Tip } from '@/components/ui/tooltip';
 import { cn } from '@/lib/utils';
 
@@ -104,6 +103,61 @@ function ProgressRing({
 }
 
 /**
+ * lucide LoaderCircle 是 r=9 的开口弧;计划行 Circle / CircleDot 是 r=10。
+ * 不能 CSS scale(会连线宽一起放大)。保持同一 72° 缺口,把弧径收到 r=10。
+ */
+const PlanLoaderArc: SpinnerIconComponent = function PlanLoaderArc({
+  size = 18,
+  strokeWidth = 1.5,
+  className,
+  ...props
+}) {
+  return (
+    <svg
+      xmlns="http://www.w3.org/2000/svg"
+      width={size}
+      height={size}
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth={strokeWidth}
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      className={className}
+      data-plan-loader-arc="true"
+      {...props}
+    >
+      <path d="M22 12a10 10 0 1 1-6.91-9.51" />
+    </svg>
+  );
+}
+
+/**
+ * 进行中步骤:「正在工作…」同款圆弧,半径对齐旁边空心圆。
+ * 旋转挂 HTML wrapper,SVG 本体静态(DESIGN.md 常驻动画红线);
+ * 会话空闲或 reduced-motion 时停转,不谎报还在执行。
+ */
+function PlanInProgressIcon({
+  animated,
+  variant,
+}: {
+  animated: boolean;
+  variant: 'flyout' | 'inline';
+}) {
+  return (
+    <Spinner
+      icon={PlanLoaderArc}
+      size={18}
+      strokeWidth={1.5}
+      spinning={animated}
+      className="text-[var(--msg-tool-card-text)]"
+      data-plan-step-active={variant === 'flyout' ? 'true' : undefined}
+      data-inline-plan-step-active={variant === 'inline' ? 'true' : undefined}
+    />
+  );
+}
+
+/**
  * InlinePlanCard —— 计划在聊天时间线里的主呈现。
  *
  * 计划默认留在产生它的消息位置，用户滚回任务经过时能直接看到完整清单；
@@ -115,7 +169,7 @@ export function InlinePlanCard({
   animated = false,
 }: {
   todos: TodoItem[];
-  /** 只有会话确实在跑时，进行中行才呼吸；失败/中断后的历史卡保持静止。 */
+  /** 只有会话确实在跑时，进行中行才慢转；失败/中断后的历史卡保持静止。 */
   animated?: boolean;
 }) {
   const [expanded, setExpanded] = useState(true);
@@ -189,17 +243,7 @@ export function InlinePlanCard({
                     />
                   )}
                   {todo.status === 'in_progress' && (
-                    <span
-                      data-inline-plan-step-active="true"
-                      data-inline-plan-step-breathing={animated ? 'true' : 'false'}
-                      className={cn('inline-flex shrink-0', animated && 'session-status-breathing')}
-                    >
-                      <CircleDot
-                        size={18}
-                        strokeWidth={1.5}
-                        className="shrink-0 text-[var(--msg-tool-card-text)]"
-                      />
-                    </span>
+                    <PlanInProgressIcon animated={animated} variant="inline" />
                   )}
                   {todo.status === 'pending' && (
                     <Circle
@@ -242,9 +286,9 @@ export function TodoListCard({
 }: {
   todos: TodoItem[];
   /**
-   * 会话是否真的在跑(调用方传 isStreaming)。只有它为真时,in_progress 行才挂
-   * 呼吸动画——计划因停止/失败/中断留在屏幕上时会话已空闲,继续呼吸等于谎报
-   * "这步还在执行"。胶囊上的进度环与其它形态始终静态,不受此参数影响。
+   * 会话是否真的在跑(调用方传 isStreaming)。只有它为真时,in_progress 行才慢转
+   * ——计划因停止/失败/中断留在屏幕上时会话已空闲,继续转等于谎报"这步还在
+   * 执行"。胶囊上的进度环与其它形态始终静态,不受此参数影响。
    */
   animated?: boolean;
   /** Composer/chat column width. Keeps the flyout inside clipped compact panes. */
@@ -428,24 +472,7 @@ export function TodoListCard({
                       />
                     )}
                     {todo.status === 'in_progress' && (
-                      // 呼吸表达"正在干活":挂侧栏运行态同款动画。按 SVG 常驻
-                      // 动画红线,动画在 span wrapper 上,SVG 本体保持静态。
-                      // 会话空闲(停止/失败/中断后计划仍留屏)时静止:动画只在
-                      // 确有 running 语义时挂载,否则等于谎报该步骤仍在执行。
-                      <span
-                        data-plan-step-active="true"
-                        data-plan-step-breathing={animated ? 'true' : 'false'}
-                        className={cn(
-                          'inline-flex shrink-0',
-                          animated && 'session-status-breathing',
-                        )}
-                      >
-                        <CircleDot
-                          size={18}
-                          strokeWidth={1.5}
-                          className="shrink-0 text-[var(--msg-tool-card-text)]"
-                        />
-                      </span>
+                      <PlanInProgressIcon animated={animated} variant="flyout" />
                     )}
                     {todo.status === 'pending' && (
                       <Circle

--- a/apps/desktop/src/renderer/components/chat/__tests__/MessageActionBar.test.tsx
+++ b/apps/desktop/src/renderer/components/chat/__tests__/MessageActionBar.test.tsx
@@ -179,7 +179,7 @@ describe('MessageActionBar', () => {
     });
 
     fireEvent.click(forkButton);
-    await waitFor(() => expect(forkButton.querySelector('.animate-spin')).toBeTruthy());
+    await waitFor(() => expect(forkButton.querySelector('.animate-spinner')).toBeTruthy());
     expect(moreButton.querySelector('.lucide-ellipsis')).toBeTruthy();
     expect(moreButton.querySelector('.lucide-loader-circle')).toBeNull();
     expect((moreButton as HTMLButtonElement).disabled).toBe(false);
@@ -189,7 +189,7 @@ describe('MessageActionBar', () => {
 
     resolveFork();
     await waitFor(() => {
-      expect(forkButton.querySelector('.animate-spin')).toBeNull();
+      expect(forkButton.querySelector('.animate-spinner')).toBeNull();
       expect((editButton as HTMLButtonElement).disabled).toBe(false);
     });
   });

--- a/apps/desktop/src/renderer/components/chat/__tests__/TodoListCard.test.tsx
+++ b/apps/desktop/src/renderer/components/chat/__tests__/TodoListCard.test.tsx
@@ -51,7 +51,7 @@ describe('TodoListCard flyout interaction', () => {
   });
 
   it('keeps the active row static when the session is idle', () => {
-    // 计划因停止/失败/中断留在屏幕上时会话已空闲:继续呼吸等于谎报"这步还在跑"。
+    // 计划因停止/失败/中断留在屏幕上时会话已空闲:继续转等于谎报"这步还在跑"。
     const { container } = render(<TodoListCard todos={TODOS} animated={false} />);
 
     const trigger = screen.getByRole('button', { name: 'Step 1 / 2' });
@@ -59,27 +59,26 @@ describe('TodoListCard flyout interaction', () => {
 
     const wrapper = container.querySelector('span[data-plan-step-active="true"]');
     expect(wrapper).not.toBeNull();
-    expect(wrapper?.classList.contains('session-status-breathing')).toBe(false);
-    expect(wrapper?.getAttribute('data-plan-step-breathing')).toBe('false');
+    expect(wrapper?.classList.contains('animate-spin')).toBe(false);
     expect(wrapper?.querySelector('svg')).not.toBeNull();
   });
 
-  it('breathes the active row on an HTML wrapper when the flyout is open', () => {
+  it('spins the active LoaderCircle on an HTML wrapper when the flyout is open', () => {
     const { container } = render(<TodoListCard todos={TODOS} animated />);
 
     const trigger = screen.getByRole('button', { name: 'Step 1 / 2' });
     fireEvent.mouseEnter(trigger.parentElement as HTMLElement);
 
-    // 正在执行的步骤用侧栏运行态同款呼吸(session-status-breathing,已在
-    // reduced-motion 白名单)。按 SVG 常驻动画红线,动画必须挂 span wrapper,
-    // SVG 本体静态;不用旋转,不用 Tailwind 硬编码 pulse/spin。
-    const wrapper = container.querySelector('span[data-plan-step-active="true"]');
+    // 正在执行的步骤与「正在工作…」同款圆弧 spinner。按 SVG 常驻动画红线,
+    // 旋转必须挂 span wrapper,SVG 本体静态;不用 pulse,不用侧栏呼吸。
+    const wrapper = container.querySelector('span[data-plan-step-active="true"]') as HTMLElement;
     expect(wrapper?.tagName).toBe('SPAN');
-    expect(wrapper?.classList.contains('session-status-breathing')).toBe(true);
-    expect(wrapper?.querySelector('svg')).not.toBeNull();
-    expect(container.querySelector('svg.session-status-breathing')).toBeNull();
-    expect(container.querySelector('.animate-spin')).toBeNull();
-    expect(container.querySelector('.animate-spinner')).toBeNull();
+    expect(wrapper?.classList.contains('animate-spin')).toBe(true);
+    const arc = wrapper?.querySelector('svg[data-plan-loader-arc="true"]');
+    expect(arc).not.toBeNull();
+    expect(arc?.querySelector('path')?.getAttribute('d')).toContain('a10 10');
+    expect(container.querySelector('svg.animate-spin')).toBeNull();
+    expect(container.querySelector('.session-status-breathing')).toBeNull();
     expect(container.querySelector('.animate-pulse')).toBeNull();
   });
 
@@ -253,16 +252,22 @@ describe('InlinePlanCard', () => {
     expect(container.querySelector('[data-inline-plan-step-active="true"]')).toBeNull();
   });
 
-  it('breathes the active inline step only while the session is running', () => {
+  it('spins the active inline LoaderCircle only while the session is running', () => {
     const view = render(<InlinePlanCard todos={TODOS} animated />);
-    const active = view.container.querySelector('[data-inline-plan-step-active="true"]');
+    const active = view.container.querySelector(
+      '[data-inline-plan-step-active="true"]',
+    ) as HTMLElement;
 
-    expect(active?.getAttribute('data-inline-plan-step-breathing')).toBe('true');
-    expect(active?.classList.contains('session-status-breathing')).toBe(true);
+    expect(active?.classList.contains('animate-spin')).toBe(true);
+    const arc = active?.querySelector('svg[data-plan-loader-arc="true"]');
+    expect(arc).not.toBeNull();
+    expect(arc?.querySelector('path')?.getAttribute('d')).toContain('a10 10');
+    expect(active?.querySelector('svg.animate-spin')).toBeNull();
 
     view.rerender(<InlinePlanCard todos={TODOS} animated={false} />);
-    const idle = view.container.querySelector('[data-inline-plan-step-active="true"]');
-    expect(idle?.getAttribute('data-inline-plan-step-breathing')).toBe('false');
-    expect(idle?.classList.contains('session-status-breathing')).toBe(false);
+    const idle = view.container.querySelector(
+      '[data-inline-plan-step-active="true"]',
+    ) as HTMLElement;
+    expect(idle?.classList.contains('animate-spin')).toBe(false);
   });
 });

--- a/apps/desktop/src/renderer/components/chat/__tests__/TodoListCard.test.tsx
+++ b/apps/desktop/src/renderer/components/chat/__tests__/TodoListCard.test.tsx
@@ -46,7 +46,7 @@ describe('TodoListCard flyout interaction', () => {
     expect(container.firstElementChild?.classList.contains('pointer-events-none')).toBe(true);
     expect(trigger.parentElement?.classList.contains('pointer-events-auto')).toBe(true);
     expect(trigger.querySelector('svg[data-plan-progress-ring="true"]')).not.toBeNull();
-    expect(container.querySelector('.animate-spin')).toBeNull();
+    expect(container.querySelector('.animate-spinner')).toBeNull();
     expect(container.querySelector('.animate-pulse')).toBeNull();
   });
 
@@ -59,7 +59,7 @@ describe('TodoListCard flyout interaction', () => {
 
     const wrapper = container.querySelector('span[data-plan-step-active="true"]');
     expect(wrapper).not.toBeNull();
-    expect(wrapper?.classList.contains('animate-spin')).toBe(false);
+    expect(wrapper?.classList.contains('animate-spinner')).toBe(false);
     expect(wrapper?.querySelector('svg')).not.toBeNull();
   });
 
@@ -73,11 +73,12 @@ describe('TodoListCard flyout interaction', () => {
     // 旋转必须挂 span wrapper,SVG 本体静态;不用 pulse,不用侧栏呼吸。
     const wrapper = container.querySelector('span[data-plan-step-active="true"]') as HTMLElement;
     expect(wrapper?.tagName).toBe('SPAN');
-    expect(wrapper?.classList.contains('animate-spin')).toBe(true);
+    expect(wrapper?.classList.contains('animate-spinner')).toBe(true);
+    expect(wrapper?.classList.contains('animate-spin')).toBe(false);
     const arc = wrapper?.querySelector('svg[data-plan-loader-arc="true"]');
     expect(arc).not.toBeNull();
     expect(arc?.querySelector('path')?.getAttribute('d')).toContain('a10 10');
-    expect(container.querySelector('svg.animate-spin')).toBeNull();
+    expect(container.querySelector('svg.animate-spinner')).toBeNull();
     expect(container.querySelector('.session-status-breathing')).toBeNull();
     expect(container.querySelector('.animate-pulse')).toBeNull();
   });
@@ -258,16 +259,17 @@ describe('InlinePlanCard', () => {
       '[data-inline-plan-step-active="true"]',
     ) as HTMLElement;
 
-    expect(active?.classList.contains('animate-spin')).toBe(true);
+    expect(active?.classList.contains('animate-spinner')).toBe(true);
+    expect(active?.classList.contains('animate-spin')).toBe(false);
     const arc = active?.querySelector('svg[data-plan-loader-arc="true"]');
     expect(arc).not.toBeNull();
     expect(arc?.querySelector('path')?.getAttribute('d')).toContain('a10 10');
-    expect(active?.querySelector('svg.animate-spin')).toBeNull();
+    expect(active?.querySelector('svg.animate-spinner')).toBeNull();
 
     view.rerender(<InlinePlanCard todos={TODOS} animated={false} />);
     const idle = view.container.querySelector(
       '[data-inline-plan-step-active="true"]',
     ) as HTMLElement;
-    expect(idle?.classList.contains('animate-spin')).toBe(false);
+    expect(idle?.classList.contains('animate-spinner')).toBe(false);
   });
 });

--- a/apps/desktop/src/renderer/components/new-chat/PinnedPlanPanel.tsx
+++ b/apps/desktop/src/renderer/components/new-chat/PinnedPlanPanel.tsx
@@ -46,7 +46,7 @@ export function PinnedPlanPanel({
   messages: readonly ChatMessage[];
   /**
    * 会话是否真的在跑(调用方传 isStreaming)。胶囊上的进度环始终静态;该值只
-   * 透传给浮层里 in_progress 行的呼吸动画——空闲时静止,不谎报步骤仍在执行。
+   * 透传给浮层里 in_progress 行的慢转——空闲时静止,不谎报步骤仍在执行。
    */
   animated: boolean;
   /** 与 composer 同宽(inputWidth),胶囊在该宽度内居中,浮层不超出。 */

--- a/apps/desktop/src/renderer/components/ui/spinner.tsx
+++ b/apps/desktop/src/renderer/components/ui/spinner.tsx
@@ -32,7 +32,8 @@ export interface SpinnerProps extends Omit<React.HTMLAttributes<HTMLSpanElement>
  * DESIGN.md 设计实现规范(常驻动画必须 compositor-only,SVG 一律静止):
  * CSS animation on SVG roots or SVG children wakes the renderer main thread every
  * frame. Keep the icon SVG static, and animate only this inline-flex wrapper with
- * transform-based Tailwind `animate-spin`.
+ * `animate-spinner` (`--motion-spinner-cycle`, DESIGN.md §14.4)。不复用 Tailwind
+ * `animate-spin` 的硬编码 1s。
  *
  * Usage notes:
  * - The wrapper hugs the icon, so pass `size` only — don't add h/w classes that
@@ -40,7 +41,7 @@ export interface SpinnerProps extends Omit<React.HTMLAttributes<HTMLSpanElement>
  * - The svg sits one level deeper than a bare icon; parent `[&>svg]:` direct-child
  *   selectors won't match it — use `[&_svg]` or style the Spinner wrapper instead.
  * - Don't put translate utilities on the Spinner itself: while spinning, the
- *   `animate-spin` keyframe overwrites `transform` every frame. Nudge an outer
+ *   `animate-spinner` keyframe overwrites `transform` every frame. Nudge an outer
  *   static wrapper instead (never the svg inside — it would orbit off-center).
  */
 const Spinner = React.forwardRef<HTMLSpanElement, SpinnerProps>(function Spinner(
@@ -59,7 +60,7 @@ const Spinner = React.forwardRef<HTMLSpanElement, SpinnerProps>(function Spinner
       ref={ref}
       className={cn(
         'inline-flex shrink-0 items-center justify-center',
-        spinning && 'animate-spin motion-reduce:animate-none',
+        spinning && 'animate-spinner motion-reduce:animate-none',
         className,
       )}
       {...props}

--- a/apps/desktop/src/renderer/features/plugin/__tests__/GhostPluginCard.test.tsx
+++ b/apps/desktop/src/renderer/features/plugin/__tests__/GhostPluginCard.test.tsx
@@ -418,7 +418,7 @@ describe('GhostPluginCard', () => {
       name: 'settings.ghosts.page.updateAria',
     });
     expect(update.getAttribute('aria-busy')).toBe('true');
-    expect(update.querySelector('.animate-spin')).toBeTruthy();
+    expect(update.querySelector('.animate-spinner')).toBeTruthy();
     expect(update.textContent).toBe('');
   });
 
@@ -737,7 +737,7 @@ describe('MarketPluginCard', () => {
       name: 'settings.ghosts.page.installAria',
     });
     expect(install.getAttribute('aria-busy')).toBe('true');
-    expect(install.querySelector('.animate-spin')).toBeTruthy();
+    expect(install.querySelector('.animate-spinner')).toBeTruthy();
     expect(install.textContent).toBe('');
   });
 });

--- a/apps/desktop/src/renderer/features/plugin/__tests__/MarketPluginDetailView.test.tsx
+++ b/apps/desktop/src/renderer/features/plugin/__tests__/MarketPluginDetailView.test.tsx
@@ -121,7 +121,7 @@ describe('MarketPluginDetailView', () => {
       name: /settings\.ghosts\.market\.install/,
     });
     expect(action.getAttribute('aria-busy')).toBe('true');
-    expect(action.querySelector('.animate-spin')).toBeTruthy();
+    expect(action.querySelector('.animate-spinner')).toBeTruthy();
     expect(action.textContent).toBe('');
   });
 });

--- a/apps/desktop/src/renderer/features/right-sidebar/plugins/review/__tests__/ReviewTabBody.helpers.test.ts
+++ b/apps/desktop/src/renderer/features/right-sidebar/plugins/review/__tests__/ReviewTabBody.helpers.test.ts
@@ -456,7 +456,7 @@ describe('ReviewTabBody refresh control', () => {
     );
 
     const button = screen.getByRole('button', { name: 'rightSidebar.review.refreshGitData' });
-    expect(button.querySelector('.animate-spin')).toBeTruthy();
+    expect(button.querySelector('.animate-spinner')).toBeTruthy();
     button.click();
     expect(onRefresh).toHaveBeenCalledTimes(1);
   });
@@ -830,7 +830,7 @@ describe('ReviewTabBody hover-reveal action affordance', () => {
     expect(stageButton.querySelector('.sr-only')?.textContent).toBe(
       'rightSidebar.review.actions.stageAll',
     );
-    expect(stageButton.querySelector('.animate-spin')).toBeTruthy();
+    expect(stageButton.querySelector('.animate-spinner')).toBeTruthy();
   });
 });
 


### PR DESCRIPTION
## 这次改了什么

### 摘要

计划清单里「正在执行」那一步，从呼吸的实心圆点改成和聊天流「正在工作…」同一语言的开口圆弧 spinner。lucide 自带 `LoaderCircle` 半径是 9，旁边空心圆是 10，所以没有直接拿现成图标，而是画了一条同缺口、r=10 的弧，线宽和颜色仍跟空心圆一致。会话停了就停转。共享 `Spinner` 同时改走 `animate-spinner`（`--motion-spinner-cycle`）。

### 变更类型

- [ ] `feat` 新功能
- [x] `fix` 缺陷修复
- [ ] `refactor` / `perf` 重构或性能优化
- [ ] `docs` / `test` / `chore` 文档、测试或工程维护
- [ ] 其他：

### 范围

- 关联 Issue / 需求：计划卡进行中图标不再用呼吸圆点
- 本 PR 包含：Desktop 流内计划卡与胶囊浮层的 in_progress 图标、共用 `PlanInProgressIcon`、共享 `Spinner` 动效 token、对应单测
- 明确不包含：Mobile UI、胶囊收起态进度环、标题栏 ListTodo、侧栏呼吸动画
- 用户可见变化：进行中步骤显示开口圆弧并旋转；会话空闲时圆弧静止；半径与 pending 空心圆对齐
- 是否存在 breaking change：无

### UI 变化

- 引用的设计规范：`docs/design-rules/DESIGN.md` §14.4 Motion & Transitions（常驻动画只动 HTML wrapper 的 `transform`，SVG 本体静态；loading 用 `animate-spinner` / `--motion-spinner-cycle`，不复用 Tailwind `animate-spin` 硬编码 1s；`prefers-reduced-motion` 静止）、§2 / §10 语义色（`--msg-tool-card-text`，Light / Dark 走 token）。流内卡与胶囊浮层共用同一图标。

#### 界面效果证据（macOS Desktop Light / Dark）

按当前 `InlinePlanCard` 几何与 token 做的可复看预览：进行中是 r=10 开口弧（与 pending 空心圆同径、同 1.5 描边），旋转挂在 HTML wrapper 上。保存为 `.html` 后可直接打开。实机目检见下方「手工验证」。

<details>
<summary>展开自包含 HTML 预览</summary>

```html
<!doctype html>
<html lang="zh-CN">
<head>
  <meta charset="utf-8" />
  <meta name="viewport" content="width=device-width, initial-scale=1" />
  <title>计划进行中圆弧 spinner</title>
  <style>
    * { box-sizing: border-box; }
    body { margin: 0; padding: 28px; background: #111; font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif; }
    h1 { margin: 0 0 8px; color: #fff; font-size: 20px; font-weight: 600; }
    .note { margin: 0 0 22px; color: #aaa; font-size: 13px; }
    .grid { display: grid; grid-template-columns: repeat(2, minmax(320px, 1fr)); gap: 24px; max-width: 860px; }
    .theme { overflow: hidden; border-radius: 12px; }
    .theme.light { --card: #fff; --border: #d7d7d4; --text: #262626; --muted: #737373; --surface: #f8f8f6; }
    .theme.dark { --card: #2c2c2a; --border: #3c3c3a; --text: #d4d4d4; --muted: #a3a3a3; --surface: #1f1f1e; }
    .theme-title { padding: 14px 18px; border-bottom: 1px solid var(--border); background: var(--surface); color: var(--text); font-size: 13px; font-weight: 600; }
    .state { padding: 16px 18px 18px; background: var(--surface); }
    .card { max-width: 100%; overflow: hidden; border: 1px solid var(--border); border-radius: 12px; background: var(--card); color: var(--text); }
    .header { display: flex; align-items: center; gap: 8px; padding: 10px 14px; font-size: 13px; }
    .list { border-top: 1px solid var(--border); padding: 10px 14px 12px; display: flex; flex-direction: column; gap: 2px; }
    .row { display: flex; min-height: 30px; align-items: center; gap: 10px; font-size: 13px; }
    .row.active { font-weight: 500; }
    .row.pending { font-weight: 400; }
    .icon { width: 18px; height: 18px; flex: none; }
    .spin { display: inline-flex; animation: spin 1s linear infinite; }
    @keyframes spin { to { transform: rotate(360deg); } }
    @media (prefers-reduced-motion: reduce) { .spin { animation: none; } }
  </style>
</head>
<body>
  <h1>计划进行中步骤</h1>
  <p class="note">左 Light / 右 Dark。第一行开口弧与第二行空心圆同为 viewBox r=10、stroke 1.5、18px。</p>
  <div class="grid">
    <section class="theme light">
      <div class="theme-title">Default Light</div>
      <div class="state">
        <div class="card">
          <div class="header">
            <span style="color:var(--muted)">⌄</span>
            <span>0/2</span>
            <span style="color:var(--muted)">·</span>
            <span>Inspect renderer</span>
          </div>
          <div class="list">
            <div class="row active">
              <span class="spin">
                <svg class="icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round">
                  <path d="M22 12a10 10 0 1 1-6.91-9.51" />
                </svg>
              </span>
              <span>Inspect renderer</span>
            </div>
            <div class="row pending">
              <svg class="icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5">
                <circle cx="12" cy="12" r="10" />
              </svg>
              <span>Verify toggle behavior</span>
            </div>
          </div>
        </div>
      </div>
    </section>
    <section class="theme dark">
      <div class="theme-title">Default Dark</div>
      <div class="state">
        <div class="card">
          <div class="header">
            <span style="color:var(--muted)">⌄</span>
            <span>0/2</span>
            <span style="color:var(--muted)">·</span>
            <span>Inspect renderer</span>
          </div>
          <div class="list">
            <div class="row active">
              <span class="spin">
                <svg class="icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round">
                  <path d="M22 12a10 10 0 1 1-6.91-9.51" />
                </svg>
              </span>
              <span>Inspect renderer</span>
            </div>
            <div class="row pending">
              <svg class="icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5">
                <circle cx="12" cy="12" r="10" />
              </svg>
              <span>Verify toggle behavior</span>
            </div>
          </div>
        </div>
      </div>
    </section>
  </div>
</body>
</html>
```

</details>

## 怎么验证的

### 自动验证

```text
corepack pnpm test:unit:related
结果：PASS apps/desktop unit（含 TodoListCard / PinnedPlanPanel / Spinner 相关断言）

corepack pnpm --filter desktop run typecheck
结果：通过

GitHub client-ci（Linux / Windows unit、verify、design-basis、DCO）：全绿
```

### 手工验证

macOS Desktop，隔离开发版（`--isolated=@worktree`，region=cn）。新建任务让 agent 写出计划清单，进行中圆弧与 pending 空心圆半径/线宽对齐且在转；停止后停转。Dash 已目检通过。

### 未执行的验证

Mobile 未改，未跑手机。Dark 模式未单独实机目检（走同一套 token；上方 HTML 预览含 Dark）。

## 风险

### 风险分类

- [x] 无已知风险
- [ ] SQLite / migration
- [ ] system prompt
- [ ] 协议兼容
- [ ] 权限 / 安全 / 用户数据
- [ ] 存量插件兼容（批准状态 / 指纹 / manifest 校验 / 安装布局 / 包格式）
- [ ] 原生层 / fingerprint / OTA
- [ ] 跨平台差异
- [ ] 其他：

### 影响与回滚

- 影响范围：Desktop 计划卡进行中步骤图标；共享 `Spinner` 的旋转周期改为 `--motion-spinner-cycle`
- 回滚 / 降级方式：revert 本 PR

### 提交前检查

- [x] 已 review 完整 diff
- [x] 每个 commit 都带 DCO 签名（`git commit -s`，见 [DCO](../DCO)）
- [x] UI 改动已在「UI 变化」注明引用的设计规范章节（不涉及 UI 则跳过）
- [x] 未提交凭证、令牌或授权文件
- [x] 已补充必要文档
- [x] 已确认测试结果或说明未执行原因
