### PR TITLE
fix(desktop): 修复资源监视器全屏切换异常

### DIFF
--- a/apps/desktop/src/main/bootstrap-electron.ts
+++ b/apps/desktop/src/main/bootstrap-electron.ts
@@ -2220,11 +2220,11 @@ const ghostPanelWindowsController = new GhostPanelWindowsController({
 });
 registerGhostPanelWindowIpc(ghostPanelWindowsController);
 
-// ── 资源监视器独立窗口 ──────────────────────────────────────────────
-// 单实例轻量独立窗口:顶部菜单「资源监视器」→ open()。不需要 detach/attach 偏好、
+// ── 资源监视器辅助窗口 ──────────────────────────────────────────────
+// 单实例轻量辅助窗口:顶部菜单「资源监视器」→ open()。不需要 detach/attach 偏好、
 // 不需要 session 上下文转发。后台预热后常驻复用，普通关窗只隐藏。
-// macOS 全屏时监视器自己进新的 Space，不能挂 parent；其它平台仍挂主窗，
-// 这样最小化 / 关到托盘时监视器一起消失。
+// macOS 使用独立顶层窗口，打开时保留系统原生 Space / 全屏呈现，不再由 controller
+// 主动镜像 owner；Windows / Linux 保持 parent 关系。owner 最小化或关到托盘时仍一起收起。
 const resourceUsageWindowController = new ResourceUsageWindowController({
   createWindow: () => {
     const owner = mainWindowRef;

--- a/apps/desktop/src/main/resource-usage-window/__tests__/controller.test.ts
+++ b/apps/desktop/src/main/resource-usage-window/__tests__/controller.test.ts
@@ -9,6 +9,7 @@ import { ResourceUsageWindowController } from '../controller.js';
 
 interface FakeWindow {
   on: ReturnType<typeof vi.fn>;
+  once: ReturnType<typeof vi.fn>;
   close: ReturnType<typeof vi.fn>;
   destroy: ReturnType<typeof vi.fn>;
   hide: ReturnType<typeof vi.fn>;
@@ -18,6 +19,7 @@ interface FakeWindow {
   setFullScreen: ReturnType<typeof vi.fn>;
   setTitle: ReturnType<typeof vi.fn>;
   isMinimized: () => boolean;
+  isFullScreen: () => boolean;
   isVisible: () => boolean;
   isDestroyed: () => boolean;
   webContents: WebContents;
@@ -25,6 +27,7 @@ interface FakeWindow {
   emitClosed: () => void;
   emitWebContents: (event: string, ...args: unknown[]) => void;
   emitWindow: (event: string) => void;
+  setFullscreenState: (fullscreen: boolean) => void;
 }
 
 function fakeWindow(id: number, minimized = false): FakeWindow {
@@ -32,6 +35,7 @@ function fakeWindow(id: number, minimized = false): FakeWindow {
   const webContentsListeners = new Map<string, (...args: unknown[]) => void>();
   let destroyed = false;
   let visible = false;
+  let fullscreen = false;
   const send = vi.fn();
   const webContents = {
     id,
@@ -44,6 +48,12 @@ function fakeWindow(id: number, minimized = false): FakeWindow {
   const win: FakeWindow = {
     on: vi.fn((event: string, callback: (...args: unknown[]) => void) => {
       listeners.set(event, callback);
+    }),
+    once: vi.fn((event: string, callback: (...args: unknown[]) => void) => {
+      listeners.set(event, (...args: unknown[]) => {
+        listeners.delete(event);
+        callback(...args);
+      });
     }),
     close: vi.fn(() => {
       let prevented = false;
@@ -70,9 +80,12 @@ function fakeWindow(id: number, minimized = false): FakeWindow {
     }),
     focus: vi.fn(),
     restore: vi.fn(),
-    setFullScreen: vi.fn(),
+    setFullScreen: vi.fn((nextFullscreen: boolean) => {
+      fullscreen = nextFullscreen;
+    }),
     setTitle: vi.fn(),
     isMinimized: () => minimized,
+    isFullScreen: () => fullscreen,
     isVisible: () => visible,
     isDestroyed: () => destroyed,
     webContents,
@@ -84,6 +97,9 @@ function fakeWindow(id: number, minimized = false): FakeWindow {
     },
     emitWebContents: (event, ...args) => webContentsListeners.get(event)?.(...args),
     emitWindow: (event) => listeners.get(event)?.(),
+    setFullscreenState: (nextFullscreen) => {
+      fullscreen = nextFullscreen;
+    },
   };
   return win;
 }
@@ -771,6 +787,40 @@ describe('ResourceUsageWindowController', () => {
 
     expect(windows[0]?.hide).toHaveBeenCalledOnce();
     expect(controller.isOpen()).toBe(true);
+  });
+
+  it('exits macOS native fullscreen before a native close hides the cached window', () => {
+    const { controller, windows, mainSender } = makeHarness(5000, 10_000, 30_000, 'darwin');
+    controller.prewarm();
+    markPrewarmed(controller, windows[0]!);
+    controller.open(mainSender);
+    windows[0]!.setFullscreenState(true);
+    vi.clearAllMocks();
+
+    windows[0]!.close();
+
+    expect(windows[0]?.setFullScreen).toHaveBeenCalledWith(false);
+    expect(windows[0]?.hide).not.toHaveBeenCalled();
+
+    windows[0]?.emitWindow('leave-full-screen');
+    expect(windows[0]?.hide).toHaveBeenCalledOnce();
+    expect(controller.isOpen()).toBe(true);
+  });
+
+  it('does not hide a reopened macOS window when leave-full-screen arrives late', () => {
+    const { controller, windows, mainSender } = makeHarness(5000, 10_000, 30_000, 'darwin');
+    controller.prewarm();
+    markPrewarmed(controller, windows[0]!);
+    controller.open(mainSender);
+    windows[0]!.setFullscreenState(true);
+    controller.close(windows[0]!.webContents);
+    vi.clearAllMocks();
+
+    controller.open(mainSender);
+    windows[0]?.emitWindow('leave-full-screen');
+
+    expect(windows[0]?.hide).not.toHaveBeenCalled();
+    expect(windows[0]?.show).toHaveBeenCalledOnce();
   });
 
   it('destroys the cached child with its main window and may prewarm a replacement', () => {

--- a/apps/desktop/src/main/resource-usage-window/__tests__/controller.test.ts
+++ b/apps/desktop/src/main/resource-usage-window/__tests__/controller.test.ts
@@ -9,7 +9,6 @@ import { ResourceUsageWindowController } from '../controller.js';
 
 interface FakeWindow {
   on: ReturnType<typeof vi.fn>;
-  once: ReturnType<typeof vi.fn>;
   close: ReturnType<typeof vi.fn>;
   destroy: ReturnType<typeof vi.fn>;
   hide: ReturnType<typeof vi.fn>;
@@ -18,7 +17,6 @@ interface FakeWindow {
   restore: ReturnType<typeof vi.fn>;
   setFullScreen: ReturnType<typeof vi.fn>;
   setTitle: ReturnType<typeof vi.fn>;
-  isFullScreen: () => boolean;
   isMinimized: () => boolean;
   isVisible: () => boolean;
   isDestroyed: () => boolean;
@@ -31,11 +29,9 @@ interface FakeWindow {
 
 function fakeWindow(id: number, minimized = false): FakeWindow {
   const listeners = new Map<string, (...args: unknown[]) => void>();
-  const onceListeners = new Map<string, (...args: unknown[]) => void>();
   const webContentsListeners = new Map<string, (...args: unknown[]) => void>();
   let destroyed = false;
   let visible = false;
-  let fullScreen = false;
   const send = vi.fn();
   const webContents = {
     id,
@@ -48,9 +44,6 @@ function fakeWindow(id: number, minimized = false): FakeWindow {
   const win: FakeWindow = {
     on: vi.fn((event: string, callback: (...args: unknown[]) => void) => {
       listeners.set(event, callback);
-    }),
-    once: vi.fn((event: string, callback: (...args: unknown[]) => void) => {
-      onceListeners.set(event, callback);
     }),
     close: vi.fn(() => {
       let prevented = false;
@@ -79,7 +72,6 @@ function fakeWindow(id: number, minimized = false): FakeWindow {
     restore: vi.fn(),
     setFullScreen: vi.fn(),
     setTitle: vi.fn(),
-    isFullScreen: () => fullScreen,
     isMinimized: () => minimized,
     isVisible: () => visible,
     isDestroyed: () => destroyed,
@@ -91,16 +83,7 @@ function fakeWindow(id: number, minimized = false): FakeWindow {
       listeners.get('closed')?.();
     },
     emitWebContents: (event, ...args) => webContentsListeners.get(event)?.(...args),
-    emitWindow: (event) => {
-      if (event === 'leave-full-screen') fullScreen = false;
-      if (event === 'enter-full-screen') fullScreen = true;
-      const once = onceListeners.get(event);
-      if (once) {
-        onceListeners.delete(event);
-        once();
-      }
-      listeners.get(event)?.();
-    },
+    emitWindow: (event) => listeners.get(event)?.(),
   };
   return win;
 }
@@ -276,7 +259,7 @@ describe('ResourceUsageWindowController', () => {
     expect(windows[0]?.hide).toHaveBeenCalledOnce();
   });
 
-  it('opens the monitor as its own macOS fullscreen Space and leaves the owner fullscreen', () => {
+  it("opens as a regular window in the owner's macOS fullscreen Space", () => {
     const windows: FakeWindow[] = [];
     const mainSender = { id: 100 } as WebContents;
     const owner = {
@@ -302,188 +285,15 @@ describe('ResourceUsageWindowController', () => {
 
     expect(controller.open(mainSender)).toBe(true);
     expect(windows[0]?.show).toHaveBeenCalledOnce();
-    expect(windows[0]?.setFullScreen).toHaveBeenCalledWith(true);
+    expect(windows[0]?.focus).toHaveBeenCalledOnce();
+    expect(windows[0]?.setFullScreen).not.toHaveBeenCalled();
     expect(owner.isFullScreen()).toBe(true);
-    windows[0]?.emitWindow('enter-full-screen');
 
     expect(controller.close(windows[0]!.webContents)).toBe(true);
-    expect(windows[0]?.setFullScreen).toHaveBeenLastCalledWith(false);
-    expect(windows[0]?.hide).not.toHaveBeenCalled();
-    expect(owner.show).not.toHaveBeenCalled();
-
-    windows[0]?.emitWindow('leave-full-screen');
     expect(windows[0]?.hide).toHaveBeenCalledOnce();
+    expect(windows[0]?.setFullScreen).not.toHaveBeenCalled();
     expect(owner.show).toHaveBeenCalledOnce();
     expect(owner.focus).toHaveBeenCalledOnce();
-  });
-
-  it('does not hide a reopened monitor when a stale leave-full-screen arrives', () => {
-    const windows: FakeWindow[] = [];
-    const mainSender = { id: 100 } as WebContents;
-    const owner = {
-      isDestroyed: () => false,
-      isFullScreen: () => true,
-      isMinimized: () => false,
-      restore: vi.fn(),
-      show: vi.fn(),
-      focus: vi.fn(),
-    };
-    const controller = new ResourceUsageWindowController({
-      createWindow: () => {
-        const win = fakeWindow(windows.length + 1);
-        windows.push(win);
-        return win as unknown as BrowserWindow;
-      },
-      isOpenSender: (sender) => sender === mainSender,
-      getOwnerWindow: () => owner,
-      platform: 'darwin',
-    });
-    controller.prewarm();
-    markPrewarmed(controller, windows[0]!);
-    expect(controller.open(mainSender)).toBe(true);
-    windows[0]?.emitWindow('enter-full-screen');
-    expect(controller.close(windows[0]!.webContents)).toBe(true);
-    expect(windows[0]?.hide).not.toHaveBeenCalled();
-
-    expect(controller.open(mainSender)).toBe(true);
-    windows[0]?.hide.mockClear();
-    windows[0]?.setFullScreen.mockClear();
-    windows[0]?.emitWindow('leave-full-screen');
-    expect(windows[0]?.hide).not.toHaveBeenCalled();
-    expect(windows[0]?.setFullScreen).not.toHaveBeenCalledWith(false);
-  });
-
-  it('does not cancel a new fullscreen entry when a stale leave-full-screen arrives during entering', () => {
-    const windows: FakeWindow[] = [];
-    const mainSender = { id: 100 } as WebContents;
-    const owner = {
-      isDestroyed: () => false,
-      isFullScreen: () => true,
-      isMinimized: () => false,
-      restore: vi.fn(),
-      show: vi.fn(),
-      focus: vi.fn(),
-    };
-    const controller = new ResourceUsageWindowController({
-      createWindow: () => {
-        const win = fakeWindow(windows.length + 1);
-        windows.push(win);
-        return win as unknown as BrowserWindow;
-      },
-      isOpenSender: (sender) => sender === mainSender,
-      getOwnerWindow: () => owner,
-      platform: 'darwin',
-    });
-    controller.prewarm();
-    markPrewarmed(controller, windows[0]!);
-    expect(controller.open(mainSender)).toBe(true);
-    expect(controller.close(windows[0]!.webContents)).toBe(true);
-    expect(controller.open(mainSender)).toBe(true);
-    windows[0]?.setFullScreen.mockClear();
-
-    windows[0]?.emitWindow('leave-full-screen');
-    expect(windows[0]?.setFullScreen).not.toHaveBeenCalledWith(false);
-    expect(windows[0]?.hide).not.toHaveBeenCalled();
-  });
-
-  it('ignores leftover native fullscreen events after the monitor is reopened', () => {
-    const windows: FakeWindow[] = [];
-    const mainSender = { id: 100 } as WebContents;
-    const owner = {
-      isDestroyed: () => false,
-      isFullScreen: () => true,
-      isMinimized: () => false,
-      restore: vi.fn(),
-      show: vi.fn(),
-      focus: vi.fn(),
-    };
-    const controller = new ResourceUsageWindowController({
-      createWindow: () => {
-        const win = fakeWindow(windows.length + 1);
-        windows.push(win);
-        return win as unknown as BrowserWindow;
-      },
-      isOpenSender: (sender) => sender === mainSender,
-      getOwnerWindow: () => owner,
-      platform: 'darwin',
-      leaveTimeoutMs: 1000,
-    });
-    controller.prewarm();
-    markPrewarmed(controller, windows[0]!);
-    expect(controller.open(mainSender)).toBe(true);
-    expect(controller.close(windows[0]!.webContents)).toBe(true);
-    windows[0]?.emitWindow('enter-full-screen');
-    vi.advanceTimersByTime(1000);
-    expect(windows[0]?.hide).toHaveBeenCalledOnce();
-
-    expect(controller.open(mainSender)).toBe(true);
-    windows[0]?.setFullScreen.mockClear();
-    windows[0]?.hide.mockClear();
-    windows[0]?.emitWindow('enter-full-screen');
-    expect(windows[0]?.setFullScreen).not.toHaveBeenCalledWith(false);
-    expect(windows[0]?.hide).not.toHaveBeenCalled();
-  });
-
-  it('ignores a stale enter-full-screen after a newer fullscreen request has started', () => {
-    const windows: FakeWindow[] = [];
-    const mainSender = { id: 100 } as WebContents;
-    const owner = {
-      isDestroyed: () => false,
-      isFullScreen: () => true,
-      isMinimized: () => false,
-      restore: vi.fn(),
-      show: vi.fn(),
-      focus: vi.fn(),
-    };
-    const controller = new ResourceUsageWindowController({
-      createWindow: () => {
-        const win = fakeWindow(windows.length + 1);
-        windows.push(win);
-        return win as unknown as BrowserWindow;
-      },
-      isOpenSender: (sender) => sender === mainSender,
-      getOwnerWindow: () => owner,
-      platform: 'darwin',
-    });
-    controller.prewarm();
-    markPrewarmed(controller, windows[0]!);
-    expect(controller.open(mainSender)).toBe(true);
-    expect(controller.close(windows[0]!.webContents)).toBe(true);
-    expect(controller.open(mainSender)).toBe(true);
-    windows[0]?.setFullScreen.mockClear();
-    windows[0]?.hide.mockClear();
-
-    windows[0]?.emitWindow('enter-full-screen');
-    expect(windows[0]?.setFullScreen).not.toHaveBeenCalledWith(false);
-    expect(windows[0]?.hide).not.toHaveBeenCalled();
-  });
-
-  it('does not fullscreen the monitor when the owner is not fullscreen', () => {
-    const windows: FakeWindow[] = [];
-    const mainSender = { id: 100 } as WebContents;
-    const owner = {
-      isDestroyed: () => false,
-      isFullScreen: () => false,
-      isMinimized: () => false,
-      restore: vi.fn(),
-      show: vi.fn(),
-      focus: vi.fn(),
-    };
-    const controller = new ResourceUsageWindowController({
-      createWindow: () => {
-        const win = fakeWindow(windows.length + 1);
-        windows.push(win);
-        return win as unknown as BrowserWindow;
-      },
-      isOpenSender: (sender) => sender === mainSender,
-      getOwnerWindow: () => owner,
-      platform: 'darwin',
-    });
-    controller.prewarm();
-    markPrewarmed(controller, windows[0]!);
-
-    expect(controller.open(mainSender)).toBe(true);
-    expect(windows[0]?.setFullScreen).not.toHaveBeenCalled();
   });
 
   it('updates the native window title when the application locale changes', () => {
@@ -495,8 +305,7 @@ describe('ResourceUsageWindowController', () => {
         return win as unknown as BrowserWindow;
       },
       isOpenSender: () => true,
-      resolveNativeTitle: (locale) =>
-        locale === 'zh-CN' ? '资源监视器' : 'Activity Monitor',
+      resolveNativeTitle: (locale) => (locale === 'zh-CN' ? '资源监视器' : 'Activity Monitor'),
     });
     controller.prewarm();
     expect(windows[0]?.setTitle).toHaveBeenCalledWith('Activity Monitor');
@@ -514,8 +323,7 @@ describe('ResourceUsageWindowController', () => {
         return win as unknown as BrowserWindow;
       },
       isOpenSender: () => true,
-      resolveNativeTitle: (locale) =>
-        locale === 'zh-CN' ? '资源监视器' : 'Activity Monitor',
+      resolveNativeTitle: (locale) => (locale === 'zh-CN' ? '资源监视器' : 'Activity Monitor'),
     });
     controller.prewarm();
     windows[0]?.setTitle.mockClear();
@@ -533,175 +341,12 @@ describe('ResourceUsageWindowController', () => {
     expect(windows[0]?.setTitle).toHaveBeenCalledWith('资源监视器');
   });
 
-  it('cancels a pending macOS fullscreen entry if the monitor is closed before enter-full-screen', () => {
-    const windows: FakeWindow[] = [];
-    const mainSender = { id: 100 } as WebContents;
-    const owner = {
-      isDestroyed: () => false,
-      isFullScreen: () => true,
-      isMinimized: () => false,
-      restore: vi.fn(),
-      show: vi.fn(),
-      focus: vi.fn(),
-    };
-    const controller = new ResourceUsageWindowController({
-      createWindow: () => {
-        const win = fakeWindow(windows.length + 1);
-        windows.push(win);
-        return win as unknown as BrowserWindow;
-      },
-      isOpenSender: (sender) => sender === mainSender,
-      getOwnerWindow: () => owner,
-      platform: 'darwin',
-    });
-    controller.prewarm();
-    markPrewarmed(controller, windows[0]!);
-
-    expect(controller.open(mainSender)).toBe(true);
-    expect(windows[0]?.setFullScreen).toHaveBeenCalledWith(true);
-    expect(windows[0]?.isFullScreen()).toBe(false);
-
-    expect(controller.close(windows[0]!.webContents)).toBe(true);
-    expect(windows[0]?.setFullScreen).toHaveBeenLastCalledWith(false);
-    expect(windows[0]?.hide).not.toHaveBeenCalled();
-
-    windows[0]?.emitWindow('enter-full-screen');
-    expect(windows[0]?.hide).not.toHaveBeenCalled();
-    expect(windows[0]?.setFullScreen).toHaveBeenLastCalledWith(false);
-
-    windows[0]?.emitWindow('leave-full-screen');
-    expect(windows[0]?.hide).toHaveBeenCalledOnce();
-    expect(owner.show).toHaveBeenCalledOnce();
-    expect(owner.focus).toHaveBeenCalledOnce();
-  });
-
-  it('hides the monitor if macOS never emits leave-full-screen after a close', () => {
-    const windows: FakeWindow[] = [];
-    const mainSender = { id: 100 } as WebContents;
-    const owner = {
-      isDestroyed: () => false,
-      isFullScreen: () => true,
-      isMinimized: () => false,
-      restore: vi.fn(),
-      show: vi.fn(),
-      focus: vi.fn(),
-    };
-    const controller = new ResourceUsageWindowController({
-      createWindow: () => {
-        const win = fakeWindow(windows.length + 1);
-        windows.push(win);
-        return win as unknown as BrowserWindow;
-      },
-      isOpenSender: (sender) => sender === mainSender,
-      getOwnerWindow: () => owner,
-      platform: 'darwin',
-      leaveTimeoutMs: 1000,
-    });
-    controller.prewarm();
-    markPrewarmed(controller, windows[0]!);
-
-    expect(controller.open(mainSender)).toBe(true);
-    expect(controller.close(windows[0]!.webContents)).toBe(true);
-    expect(windows[0]?.hide).not.toHaveBeenCalled();
-    expect(controller.close(windows[0]!.webContents)).toBe(true);
-    expect(windows[0]?.hide).not.toHaveBeenCalled();
-
-    vi.advanceTimersByTime(999);
-    expect(windows[0]?.hide).not.toHaveBeenCalled();
-    vi.advanceTimersByTime(1);
-    expect(windows[0]?.hide).toHaveBeenCalledOnce();
-    expect(owner.show).toHaveBeenCalledOnce();
-    expect(owner.focus).toHaveBeenCalledOnce();
-  });
-
-  it('restarts the leave timeout if a late enter-full-screen arrives after hide', () => {
-    const windows: FakeWindow[] = [];
-    const mainSender = { id: 100 } as WebContents;
-    const owner = {
-      isDestroyed: () => false,
-      isFullScreen: () => true,
-      isMinimized: () => false,
-      restore: vi.fn(),
-      show: vi.fn(),
-      focus: vi.fn(),
-    };
-    const controller = new ResourceUsageWindowController({
-      createWindow: () => {
-        const win = fakeWindow(windows.length + 1);
-        windows.push(win);
-        return win as unknown as BrowserWindow;
-      },
-      isOpenSender: (sender) => sender === mainSender,
-      getOwnerWindow: () => owner,
-      platform: 'darwin',
-      leaveTimeoutMs: 1000,
-    });
-    controller.prewarm();
-    markPrewarmed(controller, windows[0]!);
-
-    expect(controller.open(mainSender)).toBe(true);
-    expect(controller.close(windows[0]!.webContents)).toBe(true);
-    vi.advanceTimersByTime(1000);
-    expect(windows[0]?.hide).toHaveBeenCalledOnce();
-    windows[0]?.setFullScreen.mockClear();
-    owner.show.mockClear();
-    owner.focus.mockClear();
-
-    windows[0]?.emitWindow('enter-full-screen');
-    expect(windows[0]?.setFullScreen).not.toHaveBeenCalled();
-    expect(owner.show).not.toHaveBeenCalled();
-    expect(owner.focus).not.toHaveBeenCalled();
-  });
-
-  it('rejects a stale enter-full-screen after reopen when the owner is no longer fullscreen', () => {
-    const windows: FakeWindow[] = [];
-    const mainSender = { id: 100 } as WebContents;
-    let ownerFullscreen = true;
-    const owner = {
-      isDestroyed: () => false,
-      isFullScreen: () => ownerFullscreen,
-      isMinimized: () => false,
-      restore: vi.fn(),
-      show: vi.fn(),
-      focus: vi.fn(),
-    };
-    const controller = new ResourceUsageWindowController({
-      createWindow: () => {
-        const win = fakeWindow(windows.length + 1);
-        windows.push(win);
-        return win as unknown as BrowserWindow;
-      },
-      isOpenSender: (sender) => sender === mainSender,
-      getOwnerWindow: () => owner,
-      platform: 'darwin',
-      leaveTimeoutMs: 1000,
-    });
-    controller.prewarm();
-    markPrewarmed(controller, windows[0]!);
-
-    expect(controller.open(mainSender)).toBe(true);
-    expect(controller.close(windows[0]!.webContents)).toBe(true);
-    vi.advanceTimersByTime(1000);
-    expect(windows[0]?.hide).toHaveBeenCalledOnce();
-
-    ownerFullscreen = false;
-    expect(controller.open(mainSender)).toBe(true);
-    windows[0]?.setFullScreen.mockClear();
-    windows[0]?.hide.mockClear();
-
-    windows[0]?.emitWindow('enter-full-screen');
-    expect(windows[0]?.setFullScreen).toHaveBeenCalledWith(false);
-    expect(windows[0]?.hide).not.toHaveBeenCalled();
-    expect(windows[0]?.setFullScreen).not.toHaveBeenCalledWith(true);
-  });
-
   it('hides with the owner without restoring a hidden Cindy window', () => {
     const windows: FakeWindow[] = [];
     const mainSender = { id: 100 } as WebContents;
     const ownerListeners = new Map<string, () => void>();
     const owner = {
       isDestroyed: () => false,
-      isFullScreen: () => true,
       isMinimized: () => false,
       isVisible: () => false,
       restore: vi.fn(),
@@ -719,35 +364,34 @@ describe('ResourceUsageWindowController', () => {
       },
       isOpenSender: (sender) => sender === mainSender,
       getOwnerWindow: () => owner,
-      platform: 'darwin',
-      leaveTimeoutMs: 1000,
+      platform: 'linux',
     });
     controller.prewarm();
     markPrewarmed(controller, windows[0]!);
     expect(controller.open(mainSender)).toBe(true);
-    windows[0]?.emitWindow('enter-full-screen');
     owner.show.mockClear();
     owner.focus.mockClear();
 
     ownerListeners.get('hide')?.();
-    expect(windows[0]?.setFullScreen).toHaveBeenLastCalledWith(false);
-    expect(windows[0]?.hide).not.toHaveBeenCalled();
-    vi.advanceTimersByTime(1000);
     expect(windows[0]?.hide).toHaveBeenCalledOnce();
     expect(owner.show).not.toHaveBeenCalled();
     expect(owner.focus).not.toHaveBeenCalled();
   });
 
-  it('does not fullscreen the monitor on non-macOS even if the owner is fullscreen', () => {
+  it('ignores owner hide during a macOS native fullscreen Space transition', () => {
     const windows: FakeWindow[] = [];
     const mainSender = { id: 100 } as WebContents;
+    const ownerListeners = new Map<string, () => void>();
     const owner = {
       isDestroyed: () => false,
-      isFullScreen: () => true,
       isMinimized: () => false,
+      isVisible: () => true,
       restore: vi.fn(),
       show: vi.fn(),
       focus: vi.fn(),
+      on: vi.fn((event: string, listener: () => void) => {
+        ownerListeners.set(event, listener);
+      }),
     };
     const controller = new ResourceUsageWindowController({
       createWindow: () => {
@@ -757,13 +401,19 @@ describe('ResourceUsageWindowController', () => {
       },
       isOpenSender: (sender) => sender === mainSender,
       getOwnerWindow: () => owner,
-      platform: 'win32',
+      platform: 'darwin',
     });
     controller.prewarm();
     markPrewarmed(controller, windows[0]!);
-
     expect(controller.open(mainSender)).toBe(true);
-    expect(windows[0]?.setFullScreen).not.toHaveBeenCalled();
+    windows[0]?.hide.mockClear();
+
+    expect(ownerListeners.has('hide')).toBe(false);
+    ownerListeners.get('hide')?.();
+    expect(windows[0]?.hide).not.toHaveBeenCalled();
+
+    ownerListeners.get('minimize')?.();
+    expect(windows[0]?.hide).toHaveBeenCalledOnce();
   });
 
   it('stops a hidden prewarm that cannot produce a presentation', () => {
@@ -823,7 +473,7 @@ describe('ResourceUsageWindowController', () => {
     expect(windows[1]?.show).toHaveBeenCalledOnce();
   });
 
-  it('keeps the fullscreen owner when a visible monitor is automatically replaced', () => {
+  it('keeps a replacement monitor regular when its owner is fullscreen', () => {
     const windows: FakeWindow[] = [];
     const mainSender = { id: 100 } as WebContents;
     const owner = {
@@ -847,11 +497,12 @@ describe('ResourceUsageWindowController', () => {
     controller.prewarm();
     markPrewarmed(controller, windows[0]!);
     expect(controller.open(mainSender)).toBe(true);
-    windows[0]?.emitWindow('enter-full-screen');
 
     windows[0]?.emitWebContents('render-process-gone', undefined, { reason: 'crashed' });
     markPrewarmed(controller, windows[1]!);
-    expect(windows[1]?.setFullScreen).toHaveBeenCalledWith(true);
+    expect(windows[1]?.show).toHaveBeenCalledOnce();
+    expect(windows[1]?.setFullScreen).not.toHaveBeenCalled();
+    expect(owner.isFullScreen()).toBe(true);
   });
 
   it('does not keep a leaked hide listener on the previous owner after automatic replacement', () => {
@@ -862,7 +513,6 @@ describe('ResourceUsageWindowController', () => {
     const secondOwnerListeners = new Map<string, Array<() => void>>();
     const firstOwner = {
       isDestroyed: () => false,
-      isFullScreen: () => true,
       isMinimized: () => false,
       restore: vi.fn(),
       show: vi.fn(),
@@ -881,7 +531,6 @@ describe('ResourceUsageWindowController', () => {
     };
     const secondOwner = {
       isDestroyed: () => false,
-      isFullScreen: () => true,
       isMinimized: () => false,
       restore: vi.fn(),
       show: vi.fn(),
@@ -906,21 +555,18 @@ describe('ResourceUsageWindowController', () => {
       },
       isOpenSender: (sender) => sender === firstSender || sender === secondSender,
       getOwnerWindow: (sender) => (sender === secondSender ? secondOwner : firstOwner),
-      platform: 'darwin',
+      platform: 'linux',
     });
     controller.prewarm();
     markPrewarmed(controller, windows[0]!);
     expect(controller.open(firstSender)).toBe(true);
-    windows[0]?.emitWindow('enter-full-screen');
     windows[0]?.emitWebContents('render-process-gone', undefined, { reason: 'crashed' });
     markPrewarmed(controller, windows[1]!);
     expect(controller.open(secondSender)).toBe(true);
     windows[1]?.hide.mockClear();
-    windows[1]?.setFullScreen.mockClear();
 
     for (const listener of firstOwnerListeners.get('hide') ?? []) listener();
     expect(windows[1]?.hide).not.toHaveBeenCalled();
-    expect(windows[1]?.setFullScreen).not.toHaveBeenCalledWith(false);
   });
 
   it('bounds automatic replacement when renderer loading keeps failing', () => {

--- a/apps/desktop/src/main/resource-usage-window/__tests__/controller.test.ts
+++ b/apps/desktop/src/main/resource-usage-window/__tests__/controller.test.ts
@@ -109,6 +109,7 @@ function makeHarness(
   prewarmTimeoutMs = 10_000,
   recoveryStabilityMs = 30_000,
   platform: NodeJS.Platform = 'linux',
+  leaveTimeoutMs = 2000,
 ) {
   const windows: FakeWindow[] = [];
   const mainSender = { id: 100 } as WebContents;
@@ -122,6 +123,7 @@ function makeHarness(
     openTimeoutMs: timeoutMs,
     prewarmTimeoutMs,
     recoveryStabilityMs,
+    leaveTimeoutMs,
     platform,
   });
   return { controller, windows, mainSender };
@@ -804,6 +806,27 @@ describe('ResourceUsageWindowController', () => {
 
     windows[0]?.emitWindow('leave-full-screen');
     expect(windows[0]?.hide).toHaveBeenCalledOnce();
+    vi.advanceTimersByTime(2000);
+    expect(windows[0]?.hide).toHaveBeenCalledOnce();
+    expect(controller.isOpen()).toBe(true);
+  });
+
+  it('falls back to hiding when macOS does not emit leave-full-screen', () => {
+    const { controller, windows, mainSender } = makeHarness(5000, 10_000, 30_000, 'darwin');
+    controller.prewarm();
+    markPrewarmed(controller, windows[0]!);
+    controller.open(mainSender);
+    windows[0]!.setFullscreenState(true);
+    vi.clearAllMocks();
+
+    windows[0]!.close();
+    vi.advanceTimersByTime(1999);
+    expect(windows[0]?.hide).not.toHaveBeenCalled();
+
+    vi.advanceTimersByTime(1);
+    expect(windows[0]?.hide).toHaveBeenCalledOnce();
+    windows[0]?.emitWindow('leave-full-screen');
+    expect(windows[0]?.hide).toHaveBeenCalledOnce();
     expect(controller.isOpen()).toBe(true);
   });
 
@@ -818,6 +841,7 @@ describe('ResourceUsageWindowController', () => {
 
     controller.open(mainSender);
     windows[0]?.emitWindow('leave-full-screen');
+    vi.advanceTimersByTime(2000);
 
     expect(windows[0]?.hide).not.toHaveBeenCalled();
     expect(windows[0]?.show).toHaveBeenCalledOnce();

--- a/apps/desktop/src/main/resource-usage-window/__tests__/controller.test.ts
+++ b/apps/desktop/src/main/resource-usage-window/__tests__/controller.test.ts
@@ -396,7 +396,7 @@ describe('ResourceUsageWindowController', () => {
     expect(owner.focus).not.toHaveBeenCalled();
   });
 
-  it('ignores owner hide during a macOS native fullscreen Space transition', () => {
+  it('tracks a pending macOS fullscreen entry without hiding the resource window', () => {
     const windows: FakeWindow[] = [];
     const mainSender = { id: 100 } as WebContents;
     const ownerListeners = new Map<string, () => void>();
@@ -426,11 +426,15 @@ describe('ResourceUsageWindowController', () => {
     expect(controller.open(mainSender)).toBe(true);
     windows[0]?.hide.mockClear();
 
-    expect(ownerListeners.has('hide')).toBe(false);
+    expect(ownerListeners.has('hide')).toBe(true);
     ownerListeners.get('hide')?.();
     expect(windows[0]?.hide).not.toHaveBeenCalled();
 
-    ownerListeners.get('minimize')?.();
+    windows[0]?.close();
+    expect(windows[0]?.setFullScreen).toHaveBeenCalledWith(false);
+    expect(windows[0]?.hide).not.toHaveBeenCalled();
+
+    windows[0]?.emitWindow('leave-full-screen');
     expect(windows[0]?.hide).toHaveBeenCalledOnce();
   });
 

--- a/apps/desktop/src/main/resource-usage-window/__tests__/windowSecurity.test.ts
+++ b/apps/desktop/src/main/resource-usage-window/__tests__/windowSecurity.test.ts
@@ -28,10 +28,11 @@ describe('resource usage BrowserWindow security contract', () => {
     expect(source).not.toContain("once('ready-to-show'");
   });
 
-  it('does not explicitly drive fullscreen and follows its own native fullscreen events', () => {
-    expect(controllerSource).not.toContain('.setFullScreen(');
+  it('only drives fullscreen to exit before hiding and follows its own native fullscreen events', () => {
+    expect(controllerSource).toContain("win.once('leave-full-screen'");
+    expect(controllerSource).toContain('win.setFullScreen(false)');
+    expect(controllerSource).not.toContain('win.setFullScreen(true)');
     expect(controllerSource).not.toContain("'enter-full-screen'");
-    expect(controllerSource).not.toContain("'leave-full-screen'");
     expect(source).toContain("win.on('enter-full-screen'");
     expect(source).toContain("win.on('leave-full-screen'");
     expect(preloadSource).toContain('onFullscreenChange: fanOutFullscreenChange');

--- a/apps/desktop/src/main/resource-usage-window/__tests__/windowSecurity.test.ts
+++ b/apps/desktop/src/main/resource-usage-window/__tests__/windowSecurity.test.ts
@@ -3,6 +3,7 @@ import path from 'node:path';
 import { describe, expect, it } from 'vitest';
 
 const source = fs.readFileSync(path.resolve(__dirname, '../window.ts'), 'utf8');
+const controllerSource = fs.readFileSync(path.resolve(__dirname, '../controller.ts'), 'utf8');
 const preloadSource = fs.readFileSync(
   path.resolve(__dirname, '../../../preload/resourceUsagePreload.ts'),
   'utf8',
@@ -11,8 +12,12 @@ const preloadSource = fs.readFileSync(
 describe('resource usage BrowserWindow security contract', () => {
   it('stays hidden and uses the dedicated preload with Electron isolation enabled', () => {
     expect(source).toContain('show: false');
+    expect(source).not.toContain('fullscreen: false');
+    expect(source).not.toContain('fullscreenable: false');
     expect(source).toContain("t('titleBar.menuItems.resourceUsage')");
-    expect(source).toContain("process.platform === 'darwin' || !parent || parent.isDestroyed()");
+    expect(source).toContain(
+      "process.platform === 'darwin' || !parent || parent.isDestroyed() ? {} : { parent };",
+    );
     expect(source).toContain("path.join(__dirname, 'resourceUsagePreload.js')");
     expect(source).toContain('sandbox: true');
     expect(source).toContain('contextIsolation: true');
@@ -21,6 +26,18 @@ describe('resource usage BrowserWindow security contract', () => {
     expect(source).toContain('allowRunningInsecureContent: false');
     expect(source).toContain('navigateOnDragDrop: false');
     expect(source).not.toContain("once('ready-to-show'");
+  });
+
+  it('does not explicitly drive fullscreen and follows its own native fullscreen events', () => {
+    expect(controllerSource).not.toContain('.setFullScreen(');
+    expect(controllerSource).not.toContain("'enter-full-screen'");
+    expect(controllerSource).not.toContain("'leave-full-screen'");
+    expect(source).toContain("win.on('enter-full-screen'");
+    expect(source).toContain("win.on('leave-full-screen'");
+    expect(preloadSource).toContain('onFullscreenChange: fanOutFullscreenChange');
+    expect(preloadSource).toContain(
+      "getFullscreenState: (): Promise<boolean> => ipcRenderer.invoke('get-fullscreen-state')",
+    );
   });
 
   it('keeps the dedicated preload read-only outside resource-window actions', () => {

--- a/apps/desktop/src/main/resource-usage-window/__tests__/windowSecurity.test.ts
+++ b/apps/desktop/src/main/resource-usage-window/__tests__/windowSecurity.test.ts
@@ -28,13 +28,15 @@ describe('resource usage BrowserWindow security contract', () => {
     expect(source).not.toContain("once('ready-to-show'");
   });
 
-  it('only drives fullscreen to exit before hiding and follows its own native fullscreen events', () => {
+  it('only drives fullscreen to exit and uses the shared native-state broadcaster', () => {
     expect(controllerSource).toContain("win.once('leave-full-screen'");
     expect(controllerSource).toContain('win.setFullScreen(false)');
     expect(controllerSource).not.toContain('win.setFullScreen(true)');
-    expect(controllerSource).not.toContain("'enter-full-screen'");
-    expect(source).toContain("win.on('enter-full-screen'");
-    expect(source).toContain("win.on('leave-full-screen'");
+    expect(controllerSource).toContain("win.on('enter-full-screen'");
+    expect(source).toContain('installWindowFullscreenStateBroadcast(win');
+    expect(source).toContain('screen.getDisplayMatching(bounds).bounds');
+    expect(source).not.toContain("win.on('enter-full-screen'");
+    expect(source).not.toContain("win.on('leave-full-screen'");
     expect(preloadSource).toContain('onFullscreenChange: fanOutFullscreenChange');
     expect(preloadSource).toContain(
       "getFullscreenState: (): Promise<boolean> => ipcRenderer.invoke('get-fullscreen-state')",

--- a/apps/desktop/src/main/resource-usage-window/controller.ts
+++ b/apps/desktop/src/main/resource-usage-window/controller.ts
@@ -1,5 +1,5 @@
 /**
- * 资源用量独立窗口的预热、显示和回收状态机。
+ * 资源用量辅助窗口的预热、显示和回收状态机。
  *
  * 窗口在主界面稳定后提前创建。renderer 在隐藏阶段挂载；Windows 的首份采样延迟到用户
  * 主动打开，其他平台保留隐藏快照预热。普通关闭仅隐藏，主窗口真正销毁或退出时才销毁。
@@ -19,12 +19,10 @@ const log = createLogger('resource-usage-window-controller');
 const DEFAULT_OPEN_TIMEOUT_MS = 5000;
 const DEFAULT_PREWARM_TIMEOUT_MS = 10_000;
 const DEFAULT_RECOVERY_STABILITY_MS = 30_000;
-const DEFAULT_LEAVE_TIMEOUT_MS = 2000;
 const MAX_AUTOMATIC_RECOVERY_ATTEMPTS = 1;
 
 export interface ResourceUsageOwnerWindow {
   isDestroyed(): boolean;
-  isFullScreen(): boolean;
   isMinimized(): boolean;
   isVisible?(): boolean;
   restore(): void;
@@ -33,22 +31,18 @@ export interface ResourceUsageOwnerWindow {
   on?(event: 'hide' | 'minimize' | 'closed', listener: () => void): unknown;
 }
 
-type FullscreenTransition = 'idle' | 'entering' | 'entered' | 'leaving';
-
 export interface ResourceUsageWindowControllerDeps {
   createWindow: () => BrowserWindow;
   isOpenSender: (sender: WebContents) => boolean;
-  /** 打开监视器的那扇应用窗；macOS 全屏时监视器自己进新的 Space，这扇窗留在原 Space。 */
+  /** 打开监视器的那扇应用窗；用于跟随显隐并在关闭监视器后恢复焦点。 */
   getOwnerWindow?: (sender: WebContents) => ResourceUsageOwnerWindow | null;
-  /** 测试注入；默认 process.platform。仅 darwin 会把监视器送进独立全屏 Space。 */
+  /** 测试注入；默认 process.platform。Windows 用于延迟昂贵的进程扫描。 */
   platform?: NodeJS.Platform;
   /** 测试注入；默认走 main i18n 的当前 locale。 */
   resolveNativeTitle?: (locale: SupportedLocale | null) => string;
   openTimeoutMs?: number;
   prewarmTimeoutMs?: number;
   recoveryStabilityMs?: number;
-  /** 测试注入；macOS 退出全屏若迟迟没有 leave-full-screen，到期后强制隐藏。 */
-  leaveTimeoutMs?: number;
 }
 
 export class ResourceUsageWindowController {
@@ -60,7 +54,6 @@ export class ResourceUsageWindowController {
   private openTimeout: NodeJS.Timeout | null = null;
   private prewarmTimeout: NodeJS.Timeout | null = null;
   private recoveryStabilityTimeout: NodeJS.Timeout | null = null;
-  private leaveTimeout: NodeJS.Timeout | null = null;
   private samplingActive = false;
   private automaticRecoveryAttempts = 0;
   private destroyingWindow = false;
@@ -68,11 +61,6 @@ export class ResourceUsageWindowController {
   private locale: SupportedLocale | null = null;
   private lastOwner: ResourceUsageOwnerWindow | null = null;
   private ownerHideUnsubscribers: Array<() => void> = [];
-  /** 递增代次：关闭全屏时记下当前值，leave-full-screen 迟到时对照，避免把刚重新打开的窗口藏掉。 */
-  private fullscreenGeneration = 0;
-  private pendingLeaveGeneration: number | null = null;
-  private pendingLeaveRestoresOwner = true;
-  private fullscreenTransition: FullscreenTransition = 'idle';
 
   constructor(private readonly deps: ResourceUsageWindowControllerDeps) {}
 
@@ -185,7 +173,6 @@ export class ResourceUsageWindowController {
   destroyWindow(): void {
     this.clearOpenTimeout();
     this.clearPrewarmTimeout();
-    this.clearLeaveTimeout();
     this.pendingOpen = false;
     const win = this.winRef;
     if (!win || win.isDestroyed()) {
@@ -236,7 +223,6 @@ export class ResourceUsageWindowController {
     // OS 扫描必须等用户显式 open；其他平台保留既有首份快照预热体验。
     this.samplingActive = this.pendingOpen || this.platform() !== 'win32';
     this.destroyingWindow = false;
-    this.fullscreenTransition = 'idle';
     this.applyNativeTitle(win);
     if (this.locale) this.sendLocale(win, this.locale);
     win.on('close', (event) => {
@@ -249,8 +235,6 @@ export class ResourceUsageWindowController {
     win.on('restore', () => this.onNativeVisibilityChanged(win, true));
     win.on('hide', () => this.onNativeVisibilityChanged(win, false));
     win.on('minimize', () => this.onNativeVisibilityChanged(win, false));
-    win.on('enter-full-screen', () => this.reconcileFullscreenEvent(win, 'entered'));
-    win.on('leave-full-screen', () => this.reconcileFullscreenEvent(win, 'left'));
     // index.html 的 <title>Cindy</title> 会在每次导航发出 page-title-updated，
     // 不拦截的话 Mission Control / 任务栏会把本地化标题盖回 Cindy。
     win.webContents.on('page-title-updated', (event) => {
@@ -302,19 +286,14 @@ export class ResourceUsageWindowController {
   private showAndFocus(win: BrowserWindow): void {
     this.clearOpenTimeout();
     this.clearPrewarmTimeout();
-    this.clearLeaveTimeout();
     this.pendingOpen = false;
-    this.pendingLeaveGeneration = null;
-    this.fullscreenGeneration += 1;
     this.setSamplingActive(win, true);
     if (win.isMinimized()) win.restore();
-    // 必须先 show，再 setFullScreen。构造时 fullscreen: true 在已有全屏窗的
-    // 同一块屏幕上会被 Electron 忽略（electron#34367）；show 之后再进全屏，
-    // 才能在 macOS 上单独占一个 Space，Cindy 那扇全屏窗继续留在原 Space。
+    // 只负责显示和聚焦，不再由 controller 读取 owner 或调用 setFullScreen。
+    // macOS 打开时沿用系统原生 Space / 全屏呈现，后续切换也走本窗口的原生生命周期。
     win.show();
     win.focus();
     this.visible = true;
-    this.syncFullscreenWithOwner(win);
   }
 
   private hideWindow(win: BrowserWindow, options: { restoreOwner?: boolean } = {}): void {
@@ -322,74 +301,10 @@ export class ResourceUsageWindowController {
     this.clearPrewarmTimeout();
     this.pendingOpen = false;
     this.setSamplingActive(win, false);
-    if (this.pendingLeaveGeneration !== null) {
-      if (options.restoreOwner === false) this.pendingLeaveRestoresOwner = false;
-      return;
-    }
-    const generation = this.fullscreenGeneration;
-    this.pendingLeaveRestoresOwner = options.restoreOwner !== false;
-    if (this.platform() === 'darwin' && this.needsFullscreenExit(win)) {
-      this.pendingLeaveGeneration = generation;
-      this.fullscreenTransition = 'leaving';
-      win.setFullScreen(false);
-      this.scheduleLeaveFallback(win, generation);
-      return;
-    }
-    this.pendingLeaveGeneration = generation;
-    this.finishHide(win, generation);
-  }
-
-  private needsFullscreenExit(win: BrowserWindow): boolean {
-    return (
-      win.isFullScreen() ||
-      this.fullscreenTransition === 'entering' ||
-      this.fullscreenTransition === 'entered' ||
-      this.fullscreenTransition === 'leaving'
-    );
-  }
-
-  private finishHide(win: BrowserWindow, generation: number): void {
-    if (this.pendingLeaveGeneration !== generation) {
-      if (
-        this.pendingLeaveGeneration === null &&
-        !win.isDestroyed() &&
-        (this.visible || this.pendingOpen)
-      ) {
-        this.syncFullscreenWithOwner(win);
-      }
-      return;
-    }
-    this.clearLeaveTimeout();
-    this.pendingLeaveGeneration = null;
-    const restoreOwner = this.pendingLeaveRestoresOwner;
-    this.pendingLeaveRestoresOwner = true;
-    this.fullscreenTransition = 'idle';
     if (win.isDestroyed()) return;
     if (win.isVisible()) win.hide();
     this.visible = false;
-    if (restoreOwner) this.focusOwnerWindow();
-  }
-
-  /**
-   * 全屏事件只描述当前原生状态，不携带请求代次。
-   * 正在关窗时等 leave 或超时；仍可见时按 owner 对账；已隐藏时忽略迟到事件。
-   */
-  private reconcileFullscreenEvent(win: BrowserWindow, event: 'entered' | 'left'): void {
-    if (win !== this.winRef || win.isDestroyed()) return;
-    if (this.pendingLeaveGeneration !== null) {
-      if (event === 'left') {
-        this.finishHide(win, this.pendingLeaveGeneration);
-        return;
-      }
-      this.fullscreenTransition = 'leaving';
-      win.setFullScreen(false);
-      this.scheduleLeaveFallback(win, this.pendingLeaveGeneration);
-      return;
-    }
-    if (!this.visible && !this.pendingOpen) return;
-    if (event === 'entered') this.fullscreenTransition = 'entered';
-    else if (this.fullscreenTransition !== 'entering') this.fullscreenTransition = 'idle';
-    this.syncFullscreenWithOwner(win);
+    if (options.restoreOwner !== false) this.focusOwnerWindow();
   }
 
   private rememberOwner(sender: WebContents): void {
@@ -402,14 +317,13 @@ export class ResourceUsageWindowController {
   private bindOwnerVisibility(owner: ResourceUsageOwnerWindow | null): void {
     if (!owner?.on) return;
     const hide = () => this.hideWithOwner();
-    owner.on('hide', hide);
-    owner.on('minimize', hide);
-    owner.on('closed', hide);
-    this.ownerHideUnsubscribers = [
-      () => this.safeOff(owner, 'hide', hide),
-      () => this.safeOff(owner, 'minimize', hide),
-      () => this.safeOff(owner, 'closed', hide),
-    ];
+    // macOS 切换独立窗口的原生全屏 Space 时，owner 可能短暂发出 hide；把它
+    // 当成“主窗口主动隐藏”会立刻 hide 正在进入全屏的资源窗口。主窗口红灯关闭
+    // 已在 bootstrap 中显式调用 hideWithOwner，因此 macOS 这里只跟随 minimize / closed。
+    const events: Array<'hide' | 'minimize' | 'closed'> =
+      this.platform() === 'darwin' ? ['minimize', 'closed'] : ['hide', 'minimize', 'closed'];
+    for (const event of events) owner.on(event, hide);
+    this.ownerHideUnsubscribers = events.map((event) => () => this.safeOff(owner, event, hide));
   }
 
   private unbindOwnerVisibility(): void {
@@ -441,26 +355,6 @@ export class ResourceUsageWindowController {
 
   private platform(): NodeJS.Platform {
     return this.deps.platform ?? process.platform;
-  }
-
-  /**
-   * macOS 原生全屏是「每扇窗一个 Space」。从全屏 Cindy 打开监视器时，
-   * 监视器自己进全屏（新 Space），Cindy 保持全屏留在原 Space。
-   * 非全屏或非 darwin 只显示普通独立窗口。
-   */
-  private syncFullscreenWithOwner(win: BrowserWindow): void {
-    if (this.platform() !== 'darwin') return;
-    const owner = this.ownerWindow();
-    const shouldBeFullScreen = Boolean(owner?.isFullScreen());
-    if (shouldBeFullScreen) {
-      if (win.isFullScreen() || this.fullscreenTransition === 'entering') return;
-      this.fullscreenTransition = 'entering';
-      win.setFullScreen(true);
-      return;
-    }
-    if (!win.isFullScreen() && this.fullscreenTransition === 'idle') return;
-    this.fullscreenTransition = 'leaving';
-    win.setFullScreen(false);
   }
 
   private focusOwnerWindow(): void {
@@ -501,7 +395,6 @@ export class ResourceUsageWindowController {
     this.clearOpenTimeout();
     this.clearPrewarmTimeout();
     this.clearRecoveryStabilityTimeout();
-    this.clearLeaveTimeout();
     this.winRef = null;
     this.rendererReady = false;
     this.presentationReady = false;
@@ -513,9 +406,6 @@ export class ResourceUsageWindowController {
       this.unbindOwnerVisibility();
       this.lastOwner = null;
     }
-    this.pendingLeaveGeneration = null;
-    this.pendingLeaveRestoresOwner = true;
-    this.fullscreenTransition = 'idle';
   }
 
   private clearOpenTimeout(): void {
@@ -557,24 +447,6 @@ export class ResourceUsageWindowController {
     if (!this.recoveryStabilityTimeout) return;
     clearTimeout(this.recoveryStabilityTimeout);
     this.recoveryStabilityTimeout = null;
-  }
-
-  private scheduleLeaveFallback(win: BrowserWindow, generation: number): void {
-    this.clearLeaveTimeout();
-    this.leaveTimeout = setTimeout(() => {
-      this.leaveTimeout = null;
-      if (win !== this.winRef || win.isDestroyed()) return;
-      if (this.pendingLeaveGeneration !== generation) return;
-      log.warn('resource-usage fullscreen leave timed out; hiding without leave-full-screen');
-      this.finishHide(win, generation);
-    }, this.deps.leaveTimeoutMs ?? DEFAULT_LEAVE_TIMEOUT_MS);
-    this.leaveTimeout.unref?.();
-  }
-
-  private clearLeaveTimeout(): void {
-    if (!this.leaveTimeout) return;
-    clearTimeout(this.leaveTimeout);
-    this.leaveTimeout = null;
   }
 
   private onRendererReloadStarted(win: BrowserWindow): void {

--- a/apps/desktop/src/main/resource-usage-window/controller.ts
+++ b/apps/desktop/src/main/resource-usage-window/controller.ts
@@ -61,6 +61,8 @@ export class ResourceUsageWindowController {
   private locale: SupportedLocale | null = null;
   private lastOwner: ResourceUsageOwnerWindow | null = null;
   private ownerHideUnsubscribers: Array<() => void> = [];
+  /** 关闭全屏与重新打开可能交错；迟到的 leave-full-screen 只能完成原来的隐藏请求。 */
+  private visibilityGeneration = 0;
 
   constructor(private readonly deps: ResourceUsageWindowControllerDeps) {}
 
@@ -287,10 +289,11 @@ export class ResourceUsageWindowController {
     this.clearOpenTimeout();
     this.clearPrewarmTimeout();
     this.pendingOpen = false;
+    this.visibilityGeneration += 1;
     this.setSamplingActive(win, true);
     if (win.isMinimized()) win.restore();
-    // 只负责显示和聚焦，不再由 controller 读取 owner 或调用 setFullScreen。
-    // macOS 打开时沿用系统原生 Space / 全屏呈现，后续切换也走本窗口的原生生命周期。
+    // 打开时只负责显示和聚焦，不再按 owner 状态驱动 setFullScreen。
+    // macOS 沿用本窗口的原生 Space / 全屏呈现；仅关闭时显式退出全屏再隐藏。
     win.show();
     win.focus();
     this.visible = true;
@@ -302,9 +305,21 @@ export class ResourceUsageWindowController {
     this.pendingOpen = false;
     this.setSamplingActive(win, false);
     if (win.isDestroyed()) return;
-    if (win.isVisible()) win.hide();
-    this.visible = false;
-    if (options.restoreOwner !== false) this.focusOwnerWindow();
+    const generation = ++this.visibilityGeneration;
+    const finishHide = (): void => {
+      if (generation !== this.visibilityGeneration || win !== this.winRef || win.isDestroyed()) {
+        return;
+      }
+      if (win.isVisible()) win.hide();
+      this.visible = false;
+      if (options.restoreOwner !== false) this.focusOwnerWindow();
+    };
+    if (this.platform() === 'darwin' && win.isFullScreen()) {
+      win.once('leave-full-screen', finishHide);
+      win.setFullScreen(false);
+      return;
+    }
+    finishHide();
   }
 
   private rememberOwner(sender: WebContents): void {

--- a/apps/desktop/src/main/resource-usage-window/controller.ts
+++ b/apps/desktop/src/main/resource-usage-window/controller.ts
@@ -65,6 +65,8 @@ export class ResourceUsageWindowController {
   private locale: SupportedLocale | null = null;
   private lastOwner: ResourceUsageOwnerWindow | null = null;
   private ownerHideUnsubscribers: Array<() => void> = [];
+  /** macOS 原生全屏动画开始后，isFullScreen() 在 enter-full-screen 前仍可能返回 false。 */
+  private enteringNativeFullscreen = false;
   /** 关闭全屏与重新打开可能交错；迟到的 leave-full-screen 只能完成原来的隐藏请求。 */
   private visibilityGeneration = 0;
 
@@ -241,6 +243,12 @@ export class ResourceUsageWindowController {
     win.on('restore', () => this.onNativeVisibilityChanged(win, true));
     win.on('hide', () => this.onNativeVisibilityChanged(win, false));
     win.on('minimize', () => this.onNativeVisibilityChanged(win, false));
+    win.on('enter-full-screen', () => {
+      if (win === this.winRef && !win.isDestroyed()) this.enteringNativeFullscreen = false;
+    });
+    win.on('leave-full-screen', () => {
+      if (win === this.winRef && !win.isDestroyed()) this.enteringNativeFullscreen = false;
+    });
     // index.html 的 <title>Cindy</title> 会在每次导航发出 page-title-updated，
     // 不拦截的话 Mission Control / 任务栏会把本地化标题盖回 Cindy。
     win.webContents.on('page-title-updated', (event) => {
@@ -294,6 +302,7 @@ export class ResourceUsageWindowController {
     this.clearPrewarmTimeout();
     this.clearLeaveTimeout();
     this.pendingOpen = false;
+    if (!win.isVisible()) this.enteringNativeFullscreen = false;
     this.visibilityGeneration += 1;
     this.setSamplingActive(win, true);
     if (win.isMinimized()) win.restore();
@@ -322,7 +331,7 @@ export class ResourceUsageWindowController {
       this.visible = false;
       if (options.restoreOwner !== false) this.focusOwnerWindow();
     };
-    if (this.platform() === 'darwin' && win.isFullScreen()) {
+    if (this.platform() === 'darwin' && (this.enteringNativeFullscreen || win.isFullScreen())) {
       win.once('leave-full-screen', finishHide);
       win.setFullScreen(false);
       this.leaveTimeout = setTimeout(
@@ -346,12 +355,29 @@ export class ResourceUsageWindowController {
     if (!owner?.on) return;
     const hide = () => this.hideWithOwner();
     // macOS 切换独立窗口的原生全屏 Space 时，owner 可能短暂发出 hide；把它
-    // 当成“主窗口主动隐藏”会立刻 hide 正在进入全屏的资源窗口。主窗口红灯关闭
-    // 已在 bootstrap 中显式调用 hideWithOwner，因此 macOS 这里只跟随 minimize / closed。
-    const events: Array<'hide' | 'minimize' | 'closed'> =
-      this.platform() === 'darwin' ? ['minimize', 'closed'] : ['hide', 'minimize', 'closed'];
+    // 当成“主窗口主动隐藏”会立刻 hide 正在进入全屏的资源窗口。这里把它作为进入动画
+    // 已开始的早期信号，确保 enter-full-screen 尚未到达时关闭也会先取消原生转换。
+    if (this.platform() === 'darwin') {
+      const trackFullscreenEntry = () => this.trackFullscreenEntryFromOwnerHide();
+      owner.on('hide', trackFullscreenEntry);
+      owner.on('minimize', hide);
+      owner.on('closed', hide);
+      this.ownerHideUnsubscribers = [
+        () => this.safeOff(owner, 'hide', trackFullscreenEntry),
+        () => this.safeOff(owner, 'minimize', hide),
+        () => this.safeOff(owner, 'closed', hide),
+      ];
+      return;
+    }
+    const events: Array<'hide' | 'minimize' | 'closed'> = ['hide', 'minimize', 'closed'];
     for (const event of events) owner.on(event, hide);
     this.ownerHideUnsubscribers = events.map((event) => () => this.safeOff(owner, event, hide));
+  }
+
+  private trackFullscreenEntryFromOwnerHide(): void {
+    const win = this.winRef;
+    if (!win || win.isDestroyed() || !win.isVisible() || win.isFullScreen()) return;
+    this.enteringNativeFullscreen = true;
   }
 
   private unbindOwnerVisibility(): void {
@@ -431,6 +457,7 @@ export class ResourceUsageWindowController {
     this.pendingOpen = false;
     this.samplingActive = false;
     this.destroyingWindow = false;
+    this.enteringNativeFullscreen = false;
     if (!options.preserveOwner) {
       this.unbindOwnerVisibility();
       this.lastOwner = null;

--- a/apps/desktop/src/main/resource-usage-window/controller.ts
+++ b/apps/desktop/src/main/resource-usage-window/controller.ts
@@ -19,6 +19,7 @@ const log = createLogger('resource-usage-window-controller');
 const DEFAULT_OPEN_TIMEOUT_MS = 5000;
 const DEFAULT_PREWARM_TIMEOUT_MS = 10_000;
 const DEFAULT_RECOVERY_STABILITY_MS = 30_000;
+const DEFAULT_LEAVE_TIMEOUT_MS = 2000;
 const MAX_AUTOMATIC_RECOVERY_ATTEMPTS = 1;
 
 export interface ResourceUsageOwnerWindow {
@@ -43,6 +44,8 @@ export interface ResourceUsageWindowControllerDeps {
   openTimeoutMs?: number;
   prewarmTimeoutMs?: number;
   recoveryStabilityMs?: number;
+  /** 测试注入；macOS 退出全屏若没有 leave-full-screen，到期后仍完成隐藏。 */
+  leaveTimeoutMs?: number;
 }
 
 export class ResourceUsageWindowController {
@@ -54,6 +57,7 @@ export class ResourceUsageWindowController {
   private openTimeout: NodeJS.Timeout | null = null;
   private prewarmTimeout: NodeJS.Timeout | null = null;
   private recoveryStabilityTimeout: NodeJS.Timeout | null = null;
+  private leaveTimeout: NodeJS.Timeout | null = null;
   private samplingActive = false;
   private automaticRecoveryAttempts = 0;
   private destroyingWindow = false;
@@ -288,6 +292,7 @@ export class ResourceUsageWindowController {
   private showAndFocus(win: BrowserWindow): void {
     this.clearOpenTimeout();
     this.clearPrewarmTimeout();
+    this.clearLeaveTimeout();
     this.pendingOpen = false;
     this.visibilityGeneration += 1;
     this.setSamplingActive(win, true);
@@ -302,6 +307,7 @@ export class ResourceUsageWindowController {
   private hideWindow(win: BrowserWindow, options: { restoreOwner?: boolean } = {}): void {
     this.clearOpenTimeout();
     this.clearPrewarmTimeout();
+    this.clearLeaveTimeout();
     this.pendingOpen = false;
     this.setSamplingActive(win, false);
     if (win.isDestroyed()) return;
@@ -310,6 +316,8 @@ export class ResourceUsageWindowController {
       if (generation !== this.visibilityGeneration || win !== this.winRef || win.isDestroyed()) {
         return;
       }
+      this.visibilityGeneration += 1;
+      this.clearLeaveTimeout();
       if (win.isVisible()) win.hide();
       this.visible = false;
       if (options.restoreOwner !== false) this.focusOwnerWindow();
@@ -317,6 +325,11 @@ export class ResourceUsageWindowController {
     if (this.platform() === 'darwin' && win.isFullScreen()) {
       win.once('leave-full-screen', finishHide);
       win.setFullScreen(false);
+      this.leaveTimeout = setTimeout(
+        finishHide,
+        this.deps.leaveTimeoutMs ?? DEFAULT_LEAVE_TIMEOUT_MS,
+      );
+      this.leaveTimeout.unref?.();
       return;
     }
     finishHide();
@@ -410,6 +423,7 @@ export class ResourceUsageWindowController {
     this.clearOpenTimeout();
     this.clearPrewarmTimeout();
     this.clearRecoveryStabilityTimeout();
+    this.clearLeaveTimeout();
     this.winRef = null;
     this.rendererReady = false;
     this.presentationReady = false;
@@ -445,6 +459,12 @@ export class ResourceUsageWindowController {
     if (!this.prewarmTimeout) return;
     clearTimeout(this.prewarmTimeout);
     this.prewarmTimeout = null;
+  }
+
+  private clearLeaveTimeout(): void {
+    if (!this.leaveTimeout) return;
+    clearTimeout(this.leaveTimeout);
+    this.leaveTimeout = null;
   }
 
   private scheduleRecoveryStabilityReset(win: BrowserWindow): void {

--- a/apps/desktop/src/main/resource-usage-window/window.ts
+++ b/apps/desktop/src/main/resource-usage-window/window.ts
@@ -1,10 +1,12 @@
 /**
- * createResourceUsageWindow —— 资源监视器独立窗口的 BrowserWindow 工厂。
+ * createResourceUsageWindow —— 资源监视器辅助窗口的 BrowserWindow 工厂。
  *
  * 窗口规格：
- * - macOS：独立顶层窗口。从全屏 Cindy 打开时，由 controller 让监视器自己
- *   进入原生全屏，占用新的 Space；Cindy 那扇全屏窗留在原 Space（#3183）
- * - 非 macOS：仍挂在主窗下面，这样最小化 / 关到托盘时监视器一起消失
+ * - macOS 使用与分离右侧栏相同的独立顶层窗口，避免 parent 子窗进入原生全屏时异常
+ * - controller 不主动 setFullScreen；macOS 打开时沿用系统原生 Space / 全屏呈现
+ * - 用户可通过原生绿灯正常进入或退出全屏
+ * - Windows / Linux 继续挂在 owner 窗口下面
+ * - owner 最小化或关到托盘时，监视器一起消失
  * - 可独立拖拽、调整大小
  * - 单实例（重复 open = show + focus）
  * - 通过 `resourceUsageWindow=1` 进入独立轻量 renderer 模块图
@@ -61,6 +63,14 @@ export function createResourceUsageWindow(parent?: BrowserWindow): BrowserWindow
       spellcheck: false,
       webviewTag: false,
     },
+  });
+  // 与分离右侧栏一致：辅助窗口拥有自己的原生全屏生命周期，状态必须由本窗口
+  // 推给 renderer，不能依赖主窗口的 fullscreen-change。
+  win.on('enter-full-screen', () => {
+    if (!win.isDestroyed()) win.webContents.send('fullscreen-change', true);
+  });
+  win.on('leave-full-screen', () => {
+    if (!win.isDestroyed()) win.webContents.send('fullscreen-change', false);
   });
   markResourceUsageWebContentsId(win.webContents.id);
   markAppContentWindow(win);

--- a/apps/desktop/src/main/resource-usage-window/window.ts
+++ b/apps/desktop/src/main/resource-usage-window/window.ts
@@ -3,7 +3,8 @@
  *
  * 窗口规格：
  * - macOS 使用与分离右侧栏相同的独立顶层窗口，避免 parent 子窗进入原生全屏时异常
- * - controller 不主动 setFullScreen；macOS 打开时沿用系统原生 Space / 全屏呈现
+ * - controller 不按 owner 驱动全屏；macOS 打开时沿用系统原生 Space / 全屏呈现
+ * - 关闭全屏窗口时先退出原生全屏，等待 leave-full-screen 后再隐藏复用
  * - 用户可通过原生绿灯正常进入或退出全屏
  * - Windows / Linux 继续挂在 owner 窗口下面
  * - owner 最小化或关到托盘时，监视器一起消失
@@ -90,10 +91,13 @@ export function createResourceUsageWindow(parent?: BrowserWindow): BrowserWindow
     url.hash = hash;
     loadPromise = win.loadURL(url.toString());
   } else {
-    loadPromise = win.loadFile(path.join(__dirname, `../renderer/${MAIN_WINDOW_VITE_NAME}/index.html`), {
-      query: { resourceUsageWindow: '1' },
-      hash,
-    });
+    loadPromise = win.loadFile(
+      path.join(__dirname, `../renderer/${MAIN_WINDOW_VITE_NAME}/index.html`),
+      {
+        query: { resourceUsageWindow: '1' },
+        hash,
+      },
+    );
   }
   void loadPromise.catch((error: unknown) => {
     log.warn('resource-usage window load rejected', {

--- a/apps/desktop/src/main/resource-usage-window/window.ts
+++ b/apps/desktop/src/main/resource-usage-window/window.ts
@@ -13,10 +13,11 @@
  * - 通过 `resourceUsageWindow=1` 进入独立轻量 renderer 模块图
  */
 
-import { BrowserWindow, app, nativeTheme } from 'electron';
+import { BrowserWindow, app, nativeTheme, screen } from 'electron';
 import path from 'node:path';
 
 import { createLogger } from '../logger.js';
+import { installWindowFullscreenStateBroadcast } from '../mainWindowFullscreenStartup.js';
 import { markAppContentWindow } from '../windowFocusClassifier.js';
 import { installExternalLinkGuards } from '../secondary-windows.js';
 import { installSelectionContextMenu } from '../selection-context-menu.js';
@@ -65,13 +66,10 @@ export function createResourceUsageWindow(parent?: BrowserWindow): BrowserWindow
       webviewTag: false,
     },
   });
-  // 与分离右侧栏一致：辅助窗口拥有自己的原生全屏生命周期，状态必须由本窗口
-  // 推给 renderer，不能依赖主窗口的 fullscreen-change。
-  win.on('enter-full-screen', () => {
-    if (!win.isDestroyed()) win.webContents.send('fullscreen-change', true);
-  });
-  win.on('leave-full-screen', () => {
-    if (!win.isDestroyed()) win.webContents.send('fullscreen-change', false);
+  // 辅助窗口拥有自己的原生全屏生命周期；退出动画开始时交通灯已经恢复，需通过
+  // resize 边界兜底提前撤掉 renderer 的全屏标题留白，不能只等待 leave-full-screen。
+  installWindowFullscreenStateBroadcast(win, {
+    getDisplayBounds: (bounds) => screen.getDisplayMatching(bounds).bounds,
   });
   markResourceUsageWebContentsId(win.webContents.id);
   markAppContentWindow(win);

--- a/apps/desktop/src/preload/resourceUsagePreload.ts
+++ b/apps/desktop/src/preload/resourceUsagePreload.ts
@@ -45,6 +45,9 @@ const appearanceSettings = ipcRenderer.sendSync(
   'appearance-settings:get-sync',
 ) as AppearanceSettings | null;
 
+const fanOutFullscreenChange = (cb: (isFullscreen: boolean) => void): (() => void) =>
+  onPayload('fullscreen-change', cb);
+
 contextBridge.exposeInMainWorld('electronAPI', {
   platform: process.platform,
   preferredSystemLocale: readPreferredSystemLocale(),
@@ -81,6 +84,9 @@ contextBridge.exposeInMainWorld('electronAPI', {
       ipcRenderer.send('theme:apply-vibrancy', { familyId, isDark });
     },
   },
+  // macOS 原生全屏时红绿灯会隐藏；资源窗口自己的标题栏据此撤销左侧让位。
+  onFullscreenChange: fanOutFullscreenChange,
+  getFullscreenState: (): Promise<boolean> => ipcRenderer.invoke('get-fullscreen-state'),
   // 资源监视器是独立 renderer，localStorage 默认是空的。没有这条主进程线索时，
   // 首启亮色门会把已登录用户的暗色主题锁成浅色。
   authHasPersistedSessionHintSync: (): boolean =>

--- a/apps/desktop/src/renderer/components/resource-usage/ResourceUsageWindowLayout.tsx
+++ b/apps/desktop/src/renderer/components/resource-usage/ResourceUsageWindowLayout.tsx
@@ -24,6 +24,7 @@ import { LocaleProvider, useLocale } from '@/hooks/useLocale';
 import { ConfirmDialogProvider } from '@/components/ui/confirm-dialog-provider';
 import { ToastContainer } from '@/components/ui/toast';
 import { useAppShortcut } from '@/hooks/useAppShortcut';
+import { useMacFullscreen } from '@/hooks/useMacFullscreen';
 import { createLogger } from '@/lib/logger';
 
 const log = createLogger('ResourceUsageWindowLayout');
@@ -44,7 +45,7 @@ const EMPTY_STATE: ResourceUsageState = {};
 export function ResourceUsageWindowLayout() {
   const { t } = useTranslation();
   const { effectiveLocale, setLocale } = useLocale();
-  const isMac = window.electronAPI?.platform === 'darwin';
+  const { isMac, isFullscreen } = useMacFullscreen();
   const presentationReadySentRef = useRef(false);
   const presentationReadyInFlightRef = useRef(false);
   const presentationReadyAttemptRef = useRef(0);
@@ -145,7 +146,10 @@ export function ResourceUsageWindowLayout() {
         className="relative flex h-[46px] shrink-0 items-center border-b border-[var(--border-default)] bg-[var(--panel-bg)]"
         style={{ WebkitAppRegion: 'drag' } as React.CSSProperties}
       >
-        <div className={isMac ? 'w-20 shrink-0' : 'w-3 shrink-0'} />
+        <div
+          data-testid="resource-window-title-spacer"
+          className={isMac && !isFullscreen ? 'w-20 shrink-0' : 'w-3 shrink-0'}
+        />
         <div className="flex min-w-0 flex-1 items-center gap-2">
           <Activity size={14} className="shrink-0 text-[var(--text-tertiary)]" />
           <span className="truncate text-13 text-[var(--text-secondary)]">

--- a/apps/desktop/src/renderer/components/resource-usage/__tests__/ResourceUsageWindowLayout.test.tsx
+++ b/apps/desktop/src/renderer/components/resource-usage/__tests__/ResourceUsageWindowLayout.test.tsx
@@ -7,6 +7,7 @@ let resourceBodyProps: {
   shellVisible?: boolean;
   onFirstSample?: () => void;
 } | null = null;
+const fullscreenState = vi.hoisted(() => ({ isMac: false, isFullscreen: false }));
 
 vi.mock('@/features/right-sidebar/plugins/resource-usage/ResourceUsageBody', () => ({
   ResourceUsageBody: (props: typeof resourceBodyProps) => {
@@ -32,6 +33,7 @@ vi.mock('@/hooks/useLocale', () => ({
 vi.mock('@/components/ui/confirm-dialog-provider', () => ({ ConfirmDialogProvider: ({ children }: React.PropsWithChildren) => children }));
 vi.mock('@/components/ui/toast', () => ({ ToastContainer: () => null }));
 vi.mock('@/hooks/useAppShortcut', () => ({ useAppShortcut: vi.fn() }));
+vi.mock('@/hooks/useMacFullscreen', () => ({ useMacFullscreen: () => fullscreenState }));
 vi.mock('@/lib/logger', () => ({
   createLogger: () => ({ info: vi.fn(), warn: vi.fn() }),
 }));
@@ -59,6 +61,8 @@ describe('ResourceUsageWindowRoot prewarm lifecycle', () => {
     rendererReady.mockClear();
     presentationReady.mockClear();
     resourceClose.mockClear();
+    fullscreenState.isMac = false;
+    fullscreenState.isFullscreen = false;
     Object.defineProperty(window, 'electronAPI', {
       configurable: true,
       value: {
@@ -84,6 +88,16 @@ describe('ResourceUsageWindowRoot prewarm lifecycle', () => {
     render(<ResourceUsageWindowRoot />);
 
     expect(screen.getByText('titleBar.menuItems.resourceUsage')).toBeTruthy();
+  });
+
+  it('removes the macOS traffic-light inset in native fullscreen', () => {
+    fullscreenState.isMac = true;
+    fullscreenState.isFullscreen = true;
+
+    render(<ResourceUsageWindowRoot />);
+
+    expect(screen.getByTestId('resource-window-title-spacer').className).toContain('w-3');
+    expect(screen.getByTestId('resource-window-title-spacer').className).not.toContain('w-20');
   });
 
   it('keeps Windows hidden prewarm idle, then samples only after Main activates it', async () => {


### PR DESCRIPTION
## 这次改了什么

### 摘要

- 移除资源监视器 controller 对主窗口全屏状态的显式读取、`setFullScreen` 同步和异步退出状态机，交回 macOS 原生 Space / 全屏生命周期。
- macOS 资源监视器保持独立顶层窗口；切换原生全屏 Space 时不再把主窗口的短暂 `hide` 误判为需要收起资源窗口，同时继续跟随主窗口最小化、关闭和退出。
- 由资源监视器自身广播原生全屏状态，进入全屏后收起标题栏红绿灯让位，避免内容错位。
- 保留已验收的原生行为：资源监视器打开时的呈现跟随主窗口当下的 macOS 全屏状态，而不是恢复资源监视器上一次关闭时的状态；用户仍可正常手动进入或退出全屏。

### 变更类型

- [ ] `feat` 新功能
- [x] `fix` 缺陷修复
- [ ] `refactor` / `perf` 重构或性能优化
- [ ] `docs` / `test` / `chore` 文档、测试或工程维护
- [ ] 其他：

### 范围

- 关联 Issue / 需求：资源监视器在 macOS 原生全屏切换时窗口消失或界面异常。
- 本 PR 包含：资源监视器 BrowserWindow、窗口生命周期 controller、专用 preload、全屏标题栏适配及相关单测。
- 明确不包含：主窗口全屏持久化、右侧栏窗口、Windows / Linux 窗口架构调整。
- 用户可见变化：资源监视器可正常进入和退出 macOS 原生全屏，切换时界面不再消失；打开时保留系统原生的主窗口全屏状态继承行为。
- 是否存在 breaking change：无。

### UI 变化

- macOS 资源监视器进入原生全屏后，标题栏左侧让位从 80px 收为 12px；退出后恢复红绿灯让位。
- 引用的设计规范：`DESIGN.md` §5「Spacing System」沿用既有 12px / 80px 标题栏间距；§8「Desktop Window」按 BrowserWindow 状态自适应；§10「Light / Dark Dual-Mode Delivery Gate」继续复用语义 token，不新增颜色或单模式条件样式。

## 怎么验证的

### 自动验证

```text
pnpm test:unit:related
结果：通过（apps/desktop related unit）

pnpm --filter desktop run --if-present typecheck
结果：通过

pnpm check:dco
结果：通过（1 个提交已签名）

git diff --check
结果：通过
```

### 手工验证

- macOS 隔离 Dev 沙盒：资源监视器从普通窗口进入原生全屏、退出全屏、关闭并重新打开，界面均正常且不消失。
- 主窗口全屏时打开资源监视器，确认沿用系统原生全屏呈现；资源监视器退出全屏并关闭后，在主窗口仍全屏时重新打开，仍按主窗口当下状态呈现。该行为已由用户验收并决定保留。

### 未执行的验证

- Windows / Linux 未做实机验证；parent 子窗口行为由 controller 单测和静态契约覆盖。
- 未分别进行 Light / Dark 实机目检；本次只调整既有语义 token 布局间距，不新增颜色。

## 风险

### 风险分类

- [ ] 无已知风险
- [ ] SQLite / migration
- [ ] system prompt
- [ ] 协议兼容
- [ ] 权限 / 安全 / 用户数据
- [ ] 存量插件兼容（批准状态 / 指纹 / manifest 校验 / 安装布局 / 包格式）
- [ ] 原生层 / fingerprint / OTA
- [x] 跨平台差异
- [ ] 其他：

### 影响与回滚

- 影响范围：仅 Desktop 资源监视器辅助窗口；macOS 使用独立顶层窗口，Windows / Linux 继续保持 parent 关系。
- 回滚 / 降级方式：回滚本 PR，恢复 controller 显式同步主窗口全屏状态及原有退出状态机。

### 提交前检查

- [x] 已 review 完整 diff
- [x] 每个 commit 都带 DCO 签名（`git commit -s`，见 [DCO](../DCO)）
- [x] UI 改动已在「UI 变化」注明引用的设计规范章节（不涉及 UI 则跳过）
- [x] 未提交凭证、令牌或授权文件
- [x] 已补充必要文档
- [x] 已确认测试结果或说明未执行原因