### PR TITLE
fix(desktop): 跨引擎点收藏时保留显式思考档

### DIFF
--- a/apps/desktop/src/renderer/__tests__/sessionAgentSwitchRemoteRouting.test.ts
+++ b/apps/desktop/src/renderer/__tests__/sessionAgentSwitchRemoteRouting.test.ts
@@ -1180,7 +1180,10 @@ describe('ChatInput 的入口门控与调用路由', () => {
     // 1d:意图期改选模型 / 来源必须 await 并把结果交回去,不能 fire-and-forget 返回
     // undefined 让上游读成「已应用」。
     expect(source).not.toContain('void performAgentSwitch(');
-    expect(source).toContain('return await performAgentSwitch(intent.target, newModelId, null);');
+    expect(source).toContain(
+      'return await performAgentSwitch(intent.target, newModelId, null, {',
+    );
+    expect(source).toContain('intent.effort ? { effort: intent.effort as Effort }');
   });
 
   /**

--- a/apps/desktop/src/renderer/__tests__/sessionAgentSwitchRemoteRouting.test.ts
+++ b/apps/desktop/src/renderer/__tests__/sessionAgentSwitchRemoteRouting.test.ts
@@ -1184,6 +1184,8 @@ describe('ChatInput 的入口门控与调用路由', () => {
       'return await performAgentSwitch(intent.target, newModelId, null, {',
     );
     expect(source).toContain('intent.effort ? { effort: intent.effort as Effort }');
+    // 意图期改选带来的 Fast override 必须过目标能力门,不能把旧 Fast 写进不支持的模型。
+    expect(source).toContain('overrides.fastMode && fastCapable');
   });
 
   /**

--- a/apps/desktop/src/renderer/components/new-chat/ChatInput.tsx
+++ b/apps/desktop/src/renderer/components/new-chat/ChatInput.tsx
@@ -145,6 +145,7 @@ import {
 import {
   isSelectedSourceDisconnected,
   resolveEffort,
+  resolveRequestedEffort,
   resolveProviderSwitchEffort,
 } from './sourceSwitch';
 import { useConfirmDialog } from '@/components/ui/confirm-dialog-provider';
@@ -6093,6 +6094,7 @@ export function ChatInput({
       providerId: string,
       modelId: string,
       expectedRevision?: number,
+      effort?: Effort,
     ) => void | boolean | Promise<void | boolean>;
     byModel: (
       modelId: string,
@@ -6167,16 +6169,14 @@ export function ChatInput({
           modelMemory && providerId
             ? modelMemory.getEffort(targetAgentKind, providerId, newModelId)
             : undefined;
-        const newEffort =
-          overrides?.effort && efforts.includes(overrides.effort)
-            ? overrides.effort
-            : resolveEffort({
-                efforts,
-                defaultEffort,
-                activeEffort,
-                providerEffort,
-                rememberedEffort: getRememberedEffort(newModelId),
-              });
+        const newEffort = resolveRequestedEffort({
+          requested: overrides?.effort,
+          efforts,
+          defaultEffort,
+          activeEffort,
+          providerEffort,
+          rememberedEffort: getRememberedEffort(newModelId),
+        });
         // Fast 目标值:目标 (来源,模型) 支持时按目标引擎全局预设,否则 false——
         // 旧引擎的 fastMode 不能原样带进新引擎。
         const targetFast =
@@ -6359,6 +6359,7 @@ export function ChatInput({
                 providerId,
                 newModelId,
                 result.sameEngineRevision,
+                newEffort,
               )
             : await sameEngineReselectRef.current.byModel(newModelId, result.sameEngineRevision);
           // 被更新的选择超车(byProvider / byModel 自带修订号守卫)→ 同样按「没切」上报。
@@ -6673,7 +6674,10 @@ export function ChatInput({
         // ★ await 并**透传真实结果**(Chris 2026-08-19):此前是 fire-and-forget + `return`,
         // 返回 undefined 被上游读成「已应用」——意图期内改选模型时,登记失败 / 被超车的
         // 那一路会被当成成功,后续持久化照跑,而会话上的意图其实一个字没变。
-        return await performAgentSwitch(intent.target, newModelId, null);
+        return await performAgentSwitch(intent.target, newModelId, null, {
+          ...(intent.effort ? { effort: intent.effort as Effort } : {}),
+          ...(typeof intent.fastMode === 'boolean' ? { fastMode: intent.fastMode } : {}),
+        });
       }
       let rollbackModelAfterPersistFailure: { model: string; seq: number } | null = null;
       const committedActiveEffort =
@@ -7192,6 +7196,14 @@ export function ChatInput({
           intent.target,
           reconciledModelId ?? intent.model,
           newProviderId,
+          {
+            ...(reconciledEffort
+              ? { effort: reconciledEffort }
+              : intent.effort
+                ? { effort: intent.effort as Effort }
+                : {}),
+            ...(typeof intent.fastMode === 'boolean' ? { fastMode: intent.fastMode } : {}),
+          },
         );
       }
       let rollbackProviderAfterPersistFailure: {
@@ -7477,8 +7489,8 @@ export function ChatInput({
 
   // performAgentSwitch 的"选回当前引擎"分支经 ref 调用(两 handler 声明在其后,TDZ)。
   sameEngineReselectRef.current = {
-    byProvider: (providerId, modelId, expectedRevision) =>
-      handleProviderChange(providerId, modelId, undefined, expectedRevision),
+    byProvider: (providerId, modelId, expectedRevision, effort) =>
+      handleProviderChange(providerId, modelId, effort, expectedRevision),
     byModel: (modelId, expectedRevision) => handleModelChange(modelId, expectedRevision),
   };
 

--- a/apps/desktop/src/renderer/components/new-chat/ChatInput.tsx
+++ b/apps/desktop/src/renderer/components/new-chat/ChatInput.tsx
@@ -6676,7 +6676,6 @@ export function ChatInput({
         // 那一路会被当成成功,后续持久化照跑,而会话上的意图其实一个字没变。
         return await performAgentSwitch(intent.target, newModelId, null, {
           ...(intent.effort ? { effort: intent.effort as Effort } : {}),
-          ...(typeof intent.fastMode === 'boolean' ? { fastMode: intent.fastMode } : {}),
         });
       }
       let rollbackModelAfterPersistFailure: { model: string; seq: number } | null = null;
@@ -7202,7 +7201,6 @@ export function ChatInput({
               : intent.effort
                 ? { effort: intent.effort as Effort }
                 : {}),
-            ...(typeof intent.fastMode === 'boolean' ? { fastMode: intent.fastMode } : {}),
           },
         );
       }

--- a/apps/desktop/src/renderer/components/new-chat/ChatInput.tsx
+++ b/apps/desktop/src/renderer/components/new-chat/ChatInput.tsx
@@ -6179,25 +6179,28 @@ export function ChatInput({
         });
         // Fast 目标值:目标 (来源,模型) 支持时按目标引擎全局预设,否则 false——
         // 旧引擎的 fastMode 不能原样带进新引擎。
+        // 显式 override 也必须过目标能力门:意图期改选到不支持 Fast 的模型/来源时,
+        // 旧 intent.fastMode=true 不能绕过 resolveFastSupported 写进新意图。
+        const fastCapable = resolveFastSupported({
+          deviceId: deviceLinkDeviceId ?? undefined,
+          deviceProviders: remoteProviders.providers,
+          localProviders: localProviders.providers,
+          capabilities:
+            targetAgentKind === 'codex'
+              ? codexCaps.capabilities
+              : targetAgentKind === 'pi'
+                ? piCaps.capabilities
+                : ccCaps.capabilities,
+          providerId,
+          modelId: newModelId,
+          agentKind: targetAgentKind,
+        });
         const targetFast =
           overrides?.fastMode !== undefined
-            ? overrides.fastMode
-            : !!providerId &&
+            ? overrides.fastMode && fastCapable
+            : fastCapable &&
+              !!providerId &&
               !!modelMemory &&
-              resolveFastSupported({
-                deviceId: deviceLinkDeviceId ?? undefined,
-                deviceProviders: remoteProviders.providers,
-                localProviders: localProviders.providers,
-                capabilities:
-                  targetAgentKind === 'codex'
-                    ? codexCaps.capabilities
-                    : targetAgentKind === 'pi'
-                      ? piCaps.capabilities
-                      : ccCaps.capabilities,
-                providerId,
-                modelId: newModelId,
-                agentKind: targetAgentKind,
-              }) &&
               (modelMemory.getFast(targetAgentKind, providerId, newModelId) ?? false);
 
         // 会话级操作按来源路由:device-link 远程会话隧道到被控端(意图注册表与引擎

--- a/apps/desktop/src/renderer/components/new-chat/ChatInput.tsx
+++ b/apps/desktop/src/renderer/components/new-chat/ChatInput.tsx
@@ -146,6 +146,7 @@ import {
   isSelectedSourceDisconnected,
   resolveEffort,
   resolveRequestedEffort,
+  resolveIntentReselectEffort,
   resolveProviderSwitchEffort,
 } from './sourceSwitch';
 import { useConfirmDialog } from '@/components/ui/confirm-dialog-provider';
@@ -7194,16 +7195,13 @@ export function ChatInput({
         const intent = makerChatStore.getAgentSwitchIntent(sessionId)!;
         // 同 performModelChange:await 并透传真实结果,别把「意图重登记失败」当成已应用
         // (Chris 2026-08-19)。
+        const nextEffort = resolveIntentReselectEffort(reconciledEffort, intent.effort);
         return await performAgentSwitch(
           intent.target,
           reconciledModelId ?? intent.model,
           newProviderId,
           {
-            ...(reconciledEffort
-              ? { effort: reconciledEffort }
-              : intent.effort
-                ? { effort: intent.effort as Effort }
-                : {}),
+            ...(nextEffort ? { effort: nextEffort as Effort } : {}),
           },
         );
       }

--- a/apps/desktop/src/renderer/components/new-chat/sourceSwitch.ts
+++ b/apps/desktop/src/renderer/components/new-chat/sourceSwitch.ts
@@ -167,7 +167,11 @@ export function resolveSourceSwitch(args: {
 // resolveEffort / resolveProviderSwitchEffort(切模型 / 同模型切来源的落档优先级)已下沉到共享包
 // `@cindy/model-providers`(手机版模型选择列表要用同一套口径)。这里 re-export 保持 renderer
 // 既有 import 路径不变,语义与历史版本逐字一致。
-export { resolveEffort, resolveProviderSwitchEffort } from '@cindy/model-providers';
+export {
+  resolveEffort,
+  resolveRequestedEffort,
+  resolveProviderSwitchEffort,
+} from '@cindy/model-providers';
 
 /**
  * 「显式选中的来源已断开」判定 —— 纯函数。会话把来源(providerId)持久化在 DB 里,

--- a/apps/desktop/src/renderer/components/new-chat/sourceSwitch.ts
+++ b/apps/desktop/src/renderer/components/new-chat/sourceSwitch.ts
@@ -170,6 +170,7 @@ export function resolveSourceSwitch(args: {
 export {
   resolveEffort,
   resolveRequestedEffort,
+  resolveIntentReselectEffort,
   resolveProviderSwitchEffort,
 } from '@cindy/model-providers';
 

--- a/apps/desktop/src/renderer/lib/__tests__/providerModelEfforts.test.ts
+++ b/apps/desktop/src/renderer/lib/__tests__/providerModelEfforts.test.ts
@@ -198,6 +198,9 @@ describe('resolveProviderModelEfforts', () => {
       'resolveModelEfforts(\n          newModelId,\n          providerId,\n          targetAgentKind,\n        )',
     );
     expect(source.slice(agentSwitchStart, agentSwitchEnd)).toContain('resolveRequestedEffort({');
+    expect(source.slice(agentSwitchStart, agentSwitchEnd)).toContain(
+      'overrides.fastMode && fastCapable',
+    );
     expect(source.slice(modelChangeStart, modelChangeEnd)).toContain(
       'intent.effort ? { effort: intent.effort as Effort }',
     );

--- a/apps/desktop/src/renderer/lib/__tests__/providerModelEfforts.test.ts
+++ b/apps/desktop/src/renderer/lib/__tests__/providerModelEfforts.test.ts
@@ -205,7 +205,7 @@ describe('resolveProviderModelEfforts', () => {
       'intent.effort ? { effort: intent.effort as Effort }',
     );
     expect(source.slice(providerChangeStart, providerChangeEnd)).toContain(
-      'reconciledEffort\n              ? { effort: reconciledEffort }',
+      'resolveIntentReselectEffort(reconciledEffort, intent.effort)',
     );
     expect(source.slice(modelChangeStart, modelChangeEnd)).toMatch(
       /resolveModelEfforts\(\s*newModelId,\s*effectiveSourceId,?\s*\)/,

--- a/apps/desktop/src/renderer/lib/__tests__/providerModelEfforts.test.ts
+++ b/apps/desktop/src/renderer/lib/__tests__/providerModelEfforts.test.ts
@@ -116,6 +116,58 @@ describe('resolveProviderModelEfforts', () => {
     ).toBe('low');
   });
 
+  it('xAI Grok Pi 裸 id 与订阅 xai/ wire id 都能查到同一条档位', () => {
+    const xai = {
+      id: 'xai',
+      name: 'xAI',
+      source: 'builtin' as const,
+      connected: true,
+      agents: ['pi', 'codex'],
+      auth: { method: 'apiKey' as const },
+      routing: {
+        pi: { upstream: 'https://api.x.ai/v1', authStrategy: 'api-key-header' as const },
+        codex: { upstream: 'https://api.x.ai/v1', authStrategy: 'api-key-header' as const },
+      },
+      models: {
+        pi: [
+          {
+            id: 'grok-4.6',
+            name: 'Grok 4.6',
+            contextWindow: 500_000,
+            efforts: ['low', 'medium', 'high', 'xhigh'] as Effort[],
+            defaultEffort: 'high' as Effort,
+          },
+        ],
+        codex: [
+          {
+            id: 'xai/grok-4.6',
+            name: 'Grok 4.6',
+            contextWindow: 500_000,
+            efforts: ['low', 'medium', 'high'] as Effort[],
+            defaultEffort: 'high' as Effort,
+          },
+        ],
+      },
+    } as ProviderView;
+
+    expect(
+      resolveProviderModelEfforts({
+        providers: [xai],
+        providerId: 'xai',
+        modelId: 'xai/grok-4.6',
+        agentKind: 'pi',
+      }),
+    ).toEqual({ efforts: ['low', 'medium', 'high', 'xhigh'], defaultEffort: 'high' });
+    expect(
+      resolveProviderModelEfforts({
+        providers: [xai],
+        providerId: 'xai',
+        modelId: 'grok-4.6',
+        agentKind: 'codex',
+      }),
+    ).toEqual({ efforts: ['low', 'medium', 'high'], defaultEffort: 'high' });
+  });
+
   it('ChatInput 把目标 provider 贯穿 model-only、换源与跨引擎 effort 解析后才组装 setModel 选择', () => {
     const source = readFileSync(
       resolve(__dirname, '../../components/new-chat/ChatInput.tsx'),
@@ -144,6 +196,13 @@ describe('resolveProviderModelEfforts', () => {
     );
     expect(source.slice(agentSwitchStart, agentSwitchEnd)).toContain(
       'resolveModelEfforts(\n          newModelId,\n          providerId,\n          targetAgentKind,\n        )',
+    );
+    expect(source.slice(agentSwitchStart, agentSwitchEnd)).toContain('resolveRequestedEffort({');
+    expect(source.slice(modelChangeStart, modelChangeEnd)).toContain(
+      'intent.effort ? { effort: intent.effort as Effort }',
+    );
+    expect(source.slice(providerChangeStart, providerChangeEnd)).toContain(
+      'reconciledEffort\n              ? { effort: reconciledEffort }',
     );
     expect(source.slice(modelChangeStart, modelChangeEnd)).toMatch(
       /resolveModelEfforts\(\s*newModelId,\s*effectiveSourceId,?\s*\)/,

--- a/apps/desktop/src/renderer/lib/providerModels.ts
+++ b/apps/desktop/src/renderer/lib/providerModels.ts
@@ -12,7 +12,7 @@
  */
 
 import {
-  getModel,
+  findCatalogModel,
   isModelSelectableForNewRoute,
   isModelVisible,
   providerOffersModel,
@@ -34,6 +34,11 @@ import { isSubscriptionDirectModel } from '../../shared/subscriptionModels';
  * 不能复用 `deriveModelsFromProviders`：后者是 picker 的跨来源 union，按目录顺序
  * first-wins；同一模型 id 在内置来源与 BYOM 上的显式 effort 子集可以不同。运行时切换
  * 若读拍平条目，会把另一来源支持的档位写给目标 provider。
+ *
+ * 查找走 `findCatalogModel`(精确 id 优先,失配再按 bridge 前缀 / 裸 id 归一)。
+ * 不能只用 `getModel` 精确匹配:同一逻辑模型在 Pi 目录是 `grok-4.6`、在
+ * Codex/订阅目录是 `xai/grok-4.6`。精确匹配失败会让调用方把 efforts 收成空数组,
+ * 面板已解析好的 high 被 `resolveEffort` 占位成 low。
  */
 export function resolveProviderModelEfforts(params: {
   providers: ProviderView[];
@@ -43,7 +48,7 @@ export function resolveProviderModelEfforts(params: {
 }): Pick<ModelDescriptor, 'efforts' | 'defaultEffort'> | null {
   const { providers, providerId, modelId, agentKind } = params;
   const provider = providersForAgent(providers, agentKind).find((entry) => entry.id === providerId);
-  const model = provider ? getModel(provider, modelId, agentKind) : undefined;
+  const model = findCatalogModel(provider, modelId, agentKind);
   if (!model) return null;
   return { efforts: model.efforts, defaultEffort: model.defaultEffort };
 }

--- a/packages/model-providers/src/__tests__/effortResolution.test.ts
+++ b/packages/model-providers/src/__tests__/effortResolution.test.ts
@@ -4,7 +4,12 @@
  */
 import { describe, it, expect } from 'vitest';
 
-import { resolveEffort, resolveProviderSwitchEffort, clampEffortToSupported } from '../effortResolution.js';
+import {
+  resolveEffort,
+  resolveRequestedEffort,
+  resolveProviderSwitchEffort,
+  clampEffortToSupported,
+} from '../effortResolution.js';
 import type { Effort } from '../types.js';
 
 describe('resolveEffort —— 选中模型后 effort 落档优先级', () => {
@@ -108,6 +113,55 @@ describe('resolveEffort —— defaultEffort 兜底校验(catalog 病态数据�
     expect(
       resolveEffort({ efforts: ['minimal', 'low'], defaultEffort: null, activeEffort: 'xhigh' }),
     ).toBe('minimal');
+  });
+});
+
+describe('resolveRequestedEffort —— 面板/收藏显式档 vs 本端再查目录', () => {
+  const EFFORTS: readonly Effort[] = ['low', 'medium', 'high', 'xhigh'];
+
+  it('目录查空时保留显式档,不落 resolveEffort 的占位 low', () => {
+    expect(
+      resolveRequestedEffort({
+        requested: 'high',
+        efforts: [],
+        defaultEffort: null,
+        activeEffort: 'low',
+        providerEffort: 'low',
+      }),
+    ).toBe('high');
+  });
+
+  it('目录支持该档 → 用显式档,压过记忆/当前档', () => {
+    expect(
+      resolveRequestedEffort({
+        requested: 'high',
+        efforts: EFFORTS,
+        defaultEffort: 'low',
+        activeEffort: 'low',
+        providerEffort: 'low',
+      }),
+    ).toBe('high');
+  });
+
+  it('目录非空但不含显式档 → 回落 resolveEffort,不硬塞', () => {
+    expect(
+      resolveRequestedEffort({
+        requested: 'xhigh',
+        efforts: ['low', 'medium', 'high'],
+        defaultEffort: 'medium',
+        activeEffort: 'low',
+      }),
+    ).toBe('low');
+  });
+
+  it('没有显式档 → 与 resolveEffort 同结果', () => {
+    expect(
+      resolveRequestedEffort({
+        efforts: EFFORTS,
+        defaultEffort: 'medium',
+        activeEffort: 'low',
+      }),
+    ).toBe('low');
   });
 });
 

--- a/packages/model-providers/src/__tests__/effortResolution.test.ts
+++ b/packages/model-providers/src/__tests__/effortResolution.test.ts
@@ -7,6 +7,7 @@ import { describe, it, expect } from 'vitest';
 import {
   resolveEffort,
   resolveRequestedEffort,
+  resolveIntentReselectEffort,
   resolveProviderSwitchEffort,
   clampEffortToSupported,
 } from '../effortResolution.js';
@@ -162,6 +163,25 @@ describe('resolveRequestedEffort —— 面板/收藏显式档 vs 本端再查�
         activeEffort: 'low',
       }),
     ).toBe('low');
+  });
+});
+
+describe('resolveIntentReselectEffort —— 意图期改选不把空串回落成旧 high', () => {
+  it('空串 = 目标明确无档,不继承旧意图 high', () => {
+    expect(resolveIntentReselectEffort('', 'high')).toBeUndefined();
+  });
+
+  it('非空新档压过旧意图', () => {
+    expect(resolveIntentReselectEffort('medium', 'high')).toBe('medium');
+  });
+
+  it('调用方没给新档 → 才继承旧意图', () => {
+    expect(resolveIntentReselectEffort(undefined, 'high')).toBe('high');
+  });
+
+  it('两边都空 → 不传 override', () => {
+    expect(resolveIntentReselectEffort(undefined, undefined)).toBeUndefined();
+    expect(resolveIntentReselectEffort('', '')).toBeUndefined();
   });
 });
 

--- a/packages/model-providers/src/effortResolution.ts
+++ b/packages/model-providers/src/effortResolution.ts
@@ -48,6 +48,36 @@ export function resolveEffort(args: {
 }
 
 /**
+ * 面板 / 收藏交出来的**显式档** vs 本端再查一遍目录。
+ *
+ * `resolveEffort` 在 efforts 为空时回落占位 `'low'`。那是「模型不可调档」的 UI 占位,
+ * 不能拿来消化一次查找失败:统一选择器已经按目标引擎解析过这一档(收藏副本、行上
+ * 显示的 high),本端若因 wire id 形态(Pi `grok-4.6` vs 订阅 `xai/grok-4.6`)查空,
+ * 再走 `resolveEffort` 就会把用户点的 high 写成 low。
+ *
+ * 面板只在 `config.effort` 非空时才把档交出来(不可调档行传空串,进不了 requested),
+ * 所以查空时信任 requested 不会给「真的没有档位的模型」塞一个假档。
+ *
+ * 目录非空且不含 requested → 不硬塞,回落 `resolveEffort`(目标引擎词表里没有这一档,
+ * 例如 xhigh 落到只有 high 的模型)。
+ */
+export function resolveRequestedEffort(args: {
+  requested?: Effort;
+  efforts: readonly Effort[];
+  defaultEffort: Effort | null;
+  activeEffort: Effort;
+  preferred?: Effort;
+  providerEffort?: Effort;
+  rememberedEffort?: Effort;
+}): Effort {
+  const { requested, efforts, ...rest } = args;
+  if (requested && (efforts.length === 0 || efforts.includes(requested))) {
+    return requested;
+  }
+  return resolveEffort({ efforts, ...rest });
+}
+
+/**
  * 「同模型只切来源」时落档。与 resolveEffort 的关键区别是没有 activeEffort 沿用档:
  * 有显式模型预设就按目标来源支持范围恢复;没有预设则回落模型默认,避免把当前会话 live 值
  * 意外写成全局默认。

--- a/packages/model-providers/src/effortResolution.ts
+++ b/packages/model-providers/src/effortResolution.ts
@@ -78,6 +78,23 @@ export function resolveRequestedEffort(args: {
 }
 
 /**
+ * 意图期内改选模型/来源时,面板交出来的档 vs 旧意图档。
+ *
+ * ModelSelector 对无思考档的行传空串(`rowEffortOf ?? ''`)。空串是「目标明确没有可调档」,
+ * 不能当成 falsy 再回落到旧意图的 high —— 否则会把目标不支持的档登记进意图、下次发送应用。
+ * 调用方没给新档(`undefined`)时才继承旧意图。
+ */
+export function resolveIntentReselectEffort(
+  selectedEffort: string | undefined,
+  intentEffort?: string,
+): string | undefined {
+  if (typeof selectedEffort === 'string') {
+    return selectedEffort || undefined;
+  }
+  return intentEffort || undefined;
+}
+
+/**
  * 「同模型只切来源」时落档。与 resolveEffort 的关键区别是没有 activeEffort 沿用档:
  * 有显式模型预设就按目标来源支持范围恢复;没有预设则回落模型默认,避免把当前会话 live 值
  * 意外写成全局默认。

--- a/packages/model-providers/src/index.ts
+++ b/packages/model-providers/src/index.ts
@@ -142,6 +142,7 @@ export type { SectionModel, ProviderSection, ModelIconKind } from './sections.js
 export {
   resolveEffort,
   resolveRequestedEffort,
+  resolveIntentReselectEffort,
   resolveProviderSwitchEffort,
   clampEffortToSupported,
   EFFORT_VALUES,

--- a/packages/model-providers/src/index.ts
+++ b/packages/model-providers/src/index.ts
@@ -141,6 +141,7 @@ export type { SectionModel, ProviderSection, ModelIconKind } from './sections.js
 
 export {
   resolveEffort,
+  resolveRequestedEffort,
   resolveProviderSwitchEffort,
   clampEffortToSupported,
   EFFORT_VALUES,


### PR DESCRIPTION
## 这次改了什么

### 摘要

Codex 会话里点收藏的 Pi + Grok + high 时，菜单行已经显示「高」，但切换意图会掉成 low。跨引擎落地用精确 model id 再查档位，Pi 裸 id 和订阅 `xai/` 对不上就查空，空目录被占位成 low。本 PR 让查找认两种 id，并在目录查空时保留面板交出来的显式档。

### 变更类型

- [x] `fix` 缺陷修复
- [ ] `feat` 新功能
- [ ] `refactor` / `perf` 重构或性能优化
- [ ] `docs` / `test` / `chore` 文档、测试或工程维护
- [ ] 其他：

### 范围

- 关联 Issue / 需求：用户实机：Codex+GPT 会话打开新模型菜单，选收藏的 Pi + Grok + high，composer 变成「低」
- 本 PR 包含：跨引擎切换保留面板/收藏显式思考档；Pi 裸 id 与 `xai/` wire id 都能查到档位；意图期内改模型/来源把 effort 带进切换事务
- 明确不包含：Grok 4.6 目录默认档 / xhigh / Fast ⚡ 上架；收藏存储形状；统一选择器交互与浮层；device-link 协议
- 用户可见变化：从 Codex 会话点 Pi+Grok+high 收藏后，composer 思考档应保持「高」
- 是否存在 breaking change：无

### UI 变化

- 引用的设计规范：不涉及：只改跨引擎思考档落地逻辑，无视觉/交互/文案变化

## 怎么验证的

### 自动验证

```text
pnpm test:unit:related
结果：PASS（desktop / mobile / @cindy/model-providers）

pnpm --filter desktop run typecheck
结果：PASS
```

### 手工验证

未实机：从 Codex+GPT 会话打开新模型菜单，点收藏「Pi + Grok + 高」，composer 应变为「π Grok 4.6 · 高」而不是「低」。

### 未执行的验证

实机点选收藏路径未跑（无本机 Cindy 实机操作）。

## 风险

### 风险分类

- [x] 无已知风险
- [ ] SQLite / migration
- [ ] system prompt
- [ ] 协议兼容
- [ ] 权限 / 安全 / 用户数据
- [ ] 存量插件兼容（批准状态 / 指纹 / manifest 校验 / 安装布局 / 包格式）
- [ ] 原生层 / fingerprint / OTA
- [ ] 跨平台差异
- [ ] 其他：

### 影响与回滚

- 影响范围：统一模型选择器跨引擎切换 / 收藏思考档落地
- 回滚 / 降级方式：revert 本 PR

### 提交前检查

- [x] 已 review 完整 diff
- [x] 每个 commit 都带 DCO 签名（`git commit -s`，见 [DCO](../DCO)）
- [x] UI 改动已在「UI 变化」注明引用的设计规范章节（不涉及 UI 则跳过）
- [x] 未提交凭证、令牌或授权文件
- [x] 已补充必要文档
- [x] 已确认测试结果或说明未执行原因
