### PR TITLE
fix(pi): 避免主动停止被误判为断流重试

### DIFF
--- a/packages/maker-core/src/agents/pi/__tests__/pi-startsession-cleanup.test.ts
+++ b/packages/maker-core/src/agents/pi/__tests__/pi-startsession-cleanup.test.ts
@@ -1781,7 +1781,7 @@ describe('PiAgent.startSession failure cleanup (mocked pi process)', () => {
     await handle.close();
   });
 
-  it('does not surface an aborted gateway error after the Host stops the Pi turn', async () => {
+  it('does not surface an aborted gateway error when Host stop beats agent_start', async () => {
     const handle = await new PiAgent(buildDeps()).startSession(opts());
     const events: Array<{ type: string; data?: unknown }> = [];
     void (async () => {
@@ -1789,8 +1789,9 @@ describe('PiAgent.startSession failure cleanup (mocked pi process)', () => {
     })();
     const rawError = 'OpenAI Responses stream ended before a terminal response event';
 
-    knobs.onEvent?.({ type: 'agent_start' });
+    await handle.send({ type: 'user', content: 'start a Pi turn' });
     await handle.abort();
+    knobs.onEvent?.({ type: 'agent_start' });
     knobs.onEvent?.({
       type: 'message_end',
       message: {
@@ -1817,8 +1818,9 @@ describe('PiAgent.startSession failure cleanup (mocked pi process)', () => {
     })();
     const rawError = 'OpenAI Responses stream ended before a terminal response event';
 
-    knobs.onEvent?.({ type: 'agent_start' });
+    await handle.send({ type: 'user', content: 'start a Pi turn' });
     await handle.abort();
+    knobs.onEvent?.({ type: 'agent_start' });
     knobs.onEvent?.({
       type: 'message_end',
       message: {

--- a/packages/maker-core/src/agents/pi/__tests__/pi-startsession-cleanup.test.ts
+++ b/packages/maker-core/src/agents/pi/__tests__/pi-startsession-cleanup.test.ts
@@ -21,6 +21,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 const knobs = vi.hoisted(() => ({
   ctorThrows: false,
   getStateRejects: false,
+  abortRejects: false,
   getStateGate: null as Promise<void> | null,
   closeRejects: false,
   closeFailuresRemaining: 0,
@@ -81,6 +82,9 @@ vi.mock('../rpc-client.js', () => ({
         if (knobs.getStateRejects) throw new Error('get_state rejected (mock)');
         return { success: true, data: { sessionFile: '/mock/session.jsonl', model: { contextWindow: 200000 } } };
       }
+      if (cmd.type === 'abort' && knobs.abortRejects) {
+        return { success: false, error: 'abort rejected (mock)' };
+      }
       // switch_session / set_thinking_level / set_auto_compaction / get_entries 等一律成功。
       return { success: true, data: { entries: [] } };
     }
@@ -127,6 +131,7 @@ describe('PiAgent.startSession failure cleanup (mocked pi process)', () => {
   beforeEach(() => {
     knobs.ctorThrows = false;
     knobs.getStateRejects = false;
+    knobs.abortRejects = false;
     knobs.getStateGate = null;
     knobs.closeRejects = false;
     knobs.closeFailuresRemaining = 0;
@@ -1772,6 +1777,65 @@ describe('PiAgent.startSession failure cleanup (mocked pi process)', () => {
     await expect(handle.requestGracefulStop?.()).resolves.toBeUndefined();
     expect(knobs.requests).toEqual(['abort']);
     expect(knobs.closeCount).toBe(0);
+
+    await handle.close();
+  });
+
+  it('does not surface an aborted gateway error after the Host stops the Pi turn', async () => {
+    const handle = await new PiAgent(buildDeps()).startSession(opts());
+    const events: Array<{ type: string; data?: unknown }> = [];
+    void (async () => {
+      for await (const event of handle.events()) events.push(event);
+    })();
+    const rawError = 'OpenAI Responses stream ended before a terminal response event';
+
+    knobs.onEvent?.({ type: 'agent_start' });
+    await handle.abort();
+    knobs.onEvent?.({
+      type: 'message_end',
+      message: {
+        role: 'assistant',
+        content: [],
+        stopReason: 'aborted',
+        errorMessage: rawError,
+      },
+    });
+    knobs.onEvent?.({ type: 'agent_settled' });
+
+    await vi.waitFor(() => expect(events.some((event) => event.type === 'done')).toBe(true));
+    expect(events.filter((event) => event.type === 'error')).toHaveLength(0);
+
+    await handle.close();
+  });
+
+  it('keeps a real gateway disconnect resumable when the Pi abort RPC is rejected', async () => {
+    knobs.abortRejects = true;
+    const handle = await new PiAgent(buildDeps()).startSession(opts());
+    const events: Array<{ type: string; data?: unknown }> = [];
+    void (async () => {
+      for await (const event of handle.events()) events.push(event);
+    })();
+    const rawError = 'OpenAI Responses stream ended before a terminal response event';
+
+    knobs.onEvent?.({ type: 'agent_start' });
+    await handle.abort();
+    knobs.onEvent?.({
+      type: 'message_end',
+      message: {
+        role: 'assistant',
+        content: [],
+        stopReason: 'aborted',
+        errorMessage: rawError,
+      },
+    });
+    knobs.onEvent?.({ type: 'agent_settled' });
+
+    await vi.waitFor(() => expect(events.some((event) => event.type === 'error')).toBe(true));
+    expect(events.filter((event) => event.type === 'error')).toEqual([
+      expect.objectContaining({
+        data: expect.objectContaining({ message: rawError, isTerminal: true }),
+      }),
+    ]);
 
     await handle.close();
   });

--- a/packages/maker-core/src/agents/pi/__tests__/pi-subagent-runs.test.ts
+++ b/packages/maker-core/src/agents/pi/__tests__/pi-subagent-runs.test.ts
@@ -732,6 +732,19 @@ describe('PI durable subagent run store', () => {
       expect(piSubagentOwnerIdentity('not-an-owner')).toBeNull();
     });
 
+    it('keeps the owner id stable when later start-time samples cross a rounding boundary', () => {
+      const nowSpy = vi.spyOn(Date, 'now')
+        .mockReturnValueOnce(1_700_000_100_499)
+        .mockReturnValueOnce(1_700_000_100_501);
+      const uptimeSpy = vi.spyOn(process, 'uptime').mockReturnValue(100);
+      restores.push(() => nowSpy.mockRestore(), () => uptimeSpy.mockRestore());
+
+      const first = piSubagentRuntimeOwnerId(process.pid, 'scope-stable');
+      const second = piSubagentRuntimeOwnerId(process.pid, 'scope-stable');
+
+      expect(second).toBe(first);
+    });
+
     it('treats a recycled pid as a dead owner, so the orphan stays reclaimable', async () => {
       const ownerPid = nextOwnerPid++;
       stubAliveOwner(ownerPid);

--- a/packages/maker-core/src/agents/pi/__tests__/pi-translator.test.ts
+++ b/packages/maker-core/src/agents/pi/__tests__/pi-translator.test.ts
@@ -11,6 +11,7 @@ import {
   disposePiTranslateContext,
   markPiHostAbortRequested,
   markPiHostTurnStartPending,
+  rollbackPiHostTurnStart,
   translatePiEvent,
   usageSnapshotOf,
 } from '../translator.js';
@@ -628,6 +629,43 @@ describe('pi translator', () => {
 
     expect(events.filter((event) => event.type === 'error')).toHaveLength(0);
     expect(events.filter((event) => event.type === 'done')).toHaveLength(1);
+  });
+
+  it('does not carry a stopped rejected prompt into the next Pi turn', () => {
+    const ctx = createPiTranslateContext(noopLogger);
+    const { queue, events } = makeQueue();
+    const rawError = 'OpenAI Responses stream ended before a terminal response event';
+
+    const rejectedPrompt = markPiHostTurnStartPending(ctx);
+    markPiHostAbortRequested(ctx);
+    rollbackPiHostTurnStart(ctx, rejectedPrompt);
+
+    markPiHostTurnStartPending(ctx);
+    translatePiEvent(ev({ type: 'agent_start' }), queue, ctx);
+    translatePiEvent(
+      ev({
+        type: 'message_end',
+        message: {
+          role: 'assistant',
+          content: [],
+          stopReason: 'aborted',
+          errorMessage: rawError,
+        },
+      }),
+      queue,
+      ctx,
+    );
+    translatePiEvent(ev({ type: 'agent_settled' }), queue, ctx);
+
+    expect(events.filter((event) => event.type === 'error')).toEqual([
+      expect.objectContaining({
+        source: 'pi',
+        data: expect.objectContaining({
+          message: rawError,
+          isTerminal: true,
+        }),
+      }),
+    ]);
   });
 
   it('does not carry a Host stop marker into the next Pi turn', () => {

--- a/packages/maker-core/src/agents/pi/__tests__/pi-translator.test.ts
+++ b/packages/maker-core/src/agents/pi/__tests__/pi-translator.test.ts
@@ -10,6 +10,7 @@ import {
   createPiTranslateContext,
   disposePiTranslateContext,
   markPiHostAbortRequested,
+  markPiHostTurnStartPending,
   translatePiEvent,
   usageSnapshotOf,
 } from '../translator.js';
@@ -592,6 +593,33 @@ describe('pi translator', () => {
         attempt: 1,
         maxAttempts: 3,
         errorMessage: rawError,
+      }),
+      queue,
+      ctx,
+    );
+    translatePiEvent(ev({ type: 'agent_settled' }), queue, ctx);
+
+    expect(events.filter((event) => event.type === 'error')).toHaveLength(0);
+    expect(events.filter((event) => event.type === 'done')).toHaveLength(1);
+  });
+
+  it('keeps a Host stop when it arrives before the pending turn agent_start', () => {
+    const ctx = createPiTranslateContext(noopLogger);
+    const { queue, events } = makeQueue();
+    const rawError = 'OpenAI Responses stream ended before a terminal response event';
+
+    markPiHostTurnStartPending(ctx);
+    markPiHostAbortRequested(ctx);
+    translatePiEvent(ev({ type: 'agent_start' }), queue, ctx);
+    translatePiEvent(
+      ev({
+        type: 'message_end',
+        message: {
+          role: 'assistant',
+          content: [],
+          stopReason: 'aborted',
+          errorMessage: rawError,
+        },
       }),
       queue,
       ctx,

--- a/packages/maker-core/src/agents/pi/__tests__/pi-translator.test.ts
+++ b/packages/maker-core/src/agents/pi/__tests__/pi-translator.test.ts
@@ -9,6 +9,7 @@ import { rewriteContextModeDoctorPath } from '../context-mode-doctor-path.js';
 import {
   createPiTranslateContext,
   disposePiTranslateContext,
+  markPiHostAbortRequested,
   translatePiEvent,
   usageSnapshotOf,
 } from '../translator.js';
@@ -530,7 +531,7 @@ describe('pi translator', () => {
     expect(events.filter((event) => event.type === 'error')).toHaveLength(0);
   });
 
-  it('treats aborted Responses stream failures as pending provider errors', () => {
+  it('keeps real aborted Responses stream failures resumable without a Host stop', () => {
     const ctx = createPiTranslateContext(noopLogger);
     const { queue, events } = makeQueue();
     const rawError = 'OpenAI Responses stream ended before a terminal response event';
@@ -563,6 +564,76 @@ describe('pi translator', () => {
     ]);
     expect((events.find((event) => event.type === 'error')?.data as { reason?: string }).reason)
       .toBeUndefined();
+  });
+
+  it('treats an aborted Responses stream failure as cancellation after a Host stop', () => {
+    const ctx = createPiTranslateContext(noopLogger);
+    const { queue, events } = makeQueue();
+    const rawError = 'OpenAI Responses stream ended before a terminal response event';
+
+    translatePiEvent(ev({ type: 'agent_start' }), queue, ctx);
+    markPiHostAbortRequested(ctx);
+    translatePiEvent(
+      ev({
+        type: 'message_end',
+        message: {
+          role: 'assistant',
+          content: [{ type: 'thinking', thinking: 'planning' }],
+          stopReason: 'aborted',
+          errorMessage: rawError,
+        },
+      }),
+      queue,
+      ctx,
+    );
+    translatePiEvent(
+      ev({
+        type: 'auto_retry_start',
+        attempt: 1,
+        maxAttempts: 3,
+        errorMessage: rawError,
+      }),
+      queue,
+      ctx,
+    );
+    translatePiEvent(ev({ type: 'agent_settled' }), queue, ctx);
+
+    expect(events.filter((event) => event.type === 'error')).toHaveLength(0);
+    expect(events.filter((event) => event.type === 'done')).toHaveLength(1);
+  });
+
+  it('does not carry a Host stop marker into the next Pi turn', () => {
+    const ctx = createPiTranslateContext(noopLogger);
+    const { queue, events } = makeQueue();
+    const rawError = 'OpenAI Responses stream ended before a terminal response event';
+
+    translatePiEvent(ev({ type: 'agent_start' }), queue, ctx);
+    markPiHostAbortRequested(ctx);
+    translatePiEvent(ev({ type: 'agent_start' }), queue, ctx);
+    translatePiEvent(
+      ev({
+        type: 'message_end',
+        message: {
+          role: 'assistant',
+          content: [],
+          stopReason: 'aborted',
+          errorMessage: rawError,
+        },
+      }),
+      queue,
+      ctx,
+    );
+    translatePiEvent(ev({ type: 'agent_settled' }), queue, ctx);
+
+    expect(events.filter((event) => event.type === 'error')).toEqual([
+      expect.objectContaining({
+        source: 'pi',
+        data: expect.objectContaining({
+          message: rawError,
+          isTerminal: true,
+        }),
+      }),
+    ]);
   });
 
   it('does not treat a bare abort as a provider failure', () => {

--- a/packages/maker-core/src/agents/pi/index.ts
+++ b/packages/maker-core/src/agents/pi/index.ts
@@ -178,6 +178,8 @@ import {
   createPiTranslateContext,
   disposePiTranslateContext,
   isFailedOrAbortedPiCompaction,
+  markPiHostAbortRequested,
+  rollbackPiHostAbortRequest,
   translatePiEvent,
   usageSnapshotOf,
   type PiTranslateContext,
@@ -5417,9 +5419,17 @@ export class PiAgent extends BaseAgent {
 
       async requestGracefulStop(): Promise<void> {
         if (proc.isClosed) throw new Error('No active Pi turn to stop');
+        const hostAbortToken = markPiHostAbortRequested(ctx);
         dismissAllPendingPrompts('turn_aborted', 'deny');
-        const resp = await proc.request({ type: 'abort' });
+        let resp: Awaited<ReturnType<typeof proc.request>>;
+        try {
+          resp = await proc.request({ type: 'abort' });
+        } catch (error) {
+          rollbackPiHostAbortRequest(ctx, hostAbortToken);
+          throw error;
+        }
         if (!resp.success) {
+          rollbackPiHostAbortRequest(ctx, hostAbortToken);
           throw new Error(`Pi graceful stop rejected: ${resp.error ?? 'unknown'}`);
         }
         clearActiveTurnPermissionPolicy('turn_aborted');
@@ -5427,6 +5437,7 @@ export class PiAgent extends BaseAgent {
 
       async abort(): Promise<void> {
         if (proc.isClosed) return;
+        const hostAbortToken = markPiHostAbortRequested(ctx);
         // 先把等待中的调用 fail-closed 唤醒；即使 abort RPC 失败，也不能让用户刚拒绝/
         // 停止的那次工具继续等一张已失效的卡。policy 仅在 Pi 确认接受 abort 后清空，
         // RPC 失败时继续保留，防止仍在运行的 turn 失去渠道安全边界。
@@ -5436,11 +5447,13 @@ export class PiAgent extends BaseAgent {
           if (resp.success) {
             clearActiveTurnPermissionPolicy('turn_aborted');
           } else {
+            rollbackPiHostAbortRequest(ctx, hostAbortToken);
             deps.logger.warn('pi abort request rejected', {
               message: resp.error ?? 'unknown',
             });
           }
         } catch (err) {
+          rollbackPiHostAbortRequest(ctx, hostAbortToken);
           deps.logger.warn('pi abort request failed', {
             message: err instanceof Error ? err.message : String(err),
           });

--- a/packages/maker-core/src/agents/pi/index.ts
+++ b/packages/maker-core/src/agents/pi/index.ts
@@ -179,7 +179,9 @@ import {
   disposePiTranslateContext,
   isFailedOrAbortedPiCompaction,
   markPiHostAbortRequested,
+  markPiHostTurnStartPending,
   rollbackPiHostAbortRequest,
+  rollbackPiHostTurnStart,
   translatePiEvent,
   usageSnapshotOf,
   type PiTranslateContext,
@@ -5140,6 +5142,7 @@ export class PiAgent extends BaseAgent {
             ? await readPiUserEntryIds()
             : null;
           if (!managedPackageRoute.accepted) rejectIfCancelled(sendOpts, 'send');
+          const pendingTurnStartToken = markPiHostTurnStartPending(ctx);
           promptRequestStarted = true;
           try {
             doctorCommandActivity.enter(isDoctorCommand);
@@ -5152,6 +5155,7 @@ export class PiAgent extends BaseAgent {
                 PI_PROMPT_ACCEPTANCE_PROGRESS_EVENTS.has(event.type),
             }));
             if (!resp.success) {
+              rollbackPiHostTurnStart(ctx, pendingTurnStartToken);
               if (managedPackageRoute.accepted) {
                 // The host-owned package mutation and its deterministic visible
                 // receipt already crossed the dispatch boundary. The follow-up
@@ -5221,6 +5225,7 @@ export class PiAgent extends BaseAgent {
                   data.isCompacting !== true &&
                   (typeof data.pendingMessageCount !== 'number' || data.pendingMessageCount === 0);
                 if (runtimeIdle && piAgentLifecycleSequence === lifecycleSequenceBeforePrompt) {
+                  rollbackPiHostTurnStart(ctx, pendingTurnStartToken);
                   const result = capturedExtensionNotifications?.join('\n\n') ?? '';
                   // prompt success is only the RPC acceptance boundary. Let
                   // handle.send() resolve before publishing a synthetic terminal;

--- a/packages/maker-core/src/agents/pi/pi-subagent-runs.ts
+++ b/packages/maker-core/src/agents/pi/pi-subagent-runs.ts
@@ -37,6 +37,8 @@ const KILL_CONFIRM_INTERVAL_MS = 200;
 const RENAME_RETRY_ATTEMPTS = 10;
 const RENAME_RETRY_STEP_MS = 25;
 const RENAME_RETRY_MAX_MS = 100;
+/** Stable wall-clock second for this process incarnation. */
+const OWN_PROCESS_START_TIME_SEC = Math.round(Date.now() / 1000 - process.uptime());
 let controlWriteSequence = 0;
 
 function containedParentSessionId(sessionId: string): string {
@@ -1022,7 +1024,7 @@ export function piSubagentRuntimeOwnerId(hostPid: number, scopeId: string): stri
 
 /** Wall-clock second this process started, in the form the owner id records. */
 function ownProcessStartTimeSec(): number {
-  return Math.round(Date.now() / 1000 - process.uptime());
+  return OWN_PROCESS_START_TIME_SEC;
 }
 
 export interface PiSubagentOwnerIdentity {

--- a/packages/maker-core/src/agents/pi/translator.ts
+++ b/packages/maker-core/src/agents/pi/translator.ts
@@ -237,7 +237,14 @@ export function rollbackPiHostTurnStart(
   ctx: PiTranslateContext,
   token: PiHostTurnStartToken,
 ): void {
-  if (ctx.pendingHostTurnStartToken === token) ctx.pendingHostTurnStartToken = null;
+  if (ctx.pendingHostTurnStartToken !== token) return;
+  ctx.pendingHostTurnStartToken = null;
+  // A stop requested before agent_start targets the pending generation. If the
+  // matching prompt is later rejected, that generation never exists, so its
+  // accepted stop must not be inherited by the next real turn.
+  if (ctx.hostAbortRequestGeneration === ctx.turnGeneration + 1) {
+    clearPiHostAbortRequests(ctx);
+  }
 }
 
 /**

--- a/packages/maker-core/src/agents/pi/translator.ts
+++ b/packages/maker-core/src/agents/pi/translator.ts
@@ -114,6 +114,11 @@ export interface PiTranslateContext {
   costUsd: number;
   /** agent run 是否进行中(send 的 streamingBehavior 判定也用它)。 */
   isStreaming: boolean;
+  /** agent_start 代际；主动停止只允许影响登记时所在的这一轮。 */
+  turnGeneration: number;
+  /** 当前 turn 内尚未被终态消费的 Host 主动停止请求。 */
+  hostAbortRequestGeneration: number | null;
+  hostAbortRequestTokens: Set<symbol>;
   /** thinking 块序号(blockId 生成)。 */
   thinkingSeq: number;
   /** contentIndex → 当前消息内的 thinking block 状态。 */
@@ -190,6 +195,9 @@ export function createPiTranslateContext(logger: Logger): PiTranslateContext {
     contextTokens: 0,
     costUsd: 0,
     isStreaming: false,
+    turnGeneration: 0,
+    hostAbortRequestGeneration: null,
+    hostAbortRequestTokens: new Set(),
     thinkingSeq: 0,
     thinkingBlocks: new Map(),
     streamStopTokenByIndex: new Map(),
@@ -211,6 +219,42 @@ export function createPiTranslateContext(logger: Logger): PiTranslateContext {
   };
 }
 
+export type PiHostAbortRequestToken = symbol;
+
+/**
+ * 在 abort RPC 发出前登记 Host 主动停止，避免 Pi 的 aborted 终态先于 RPC 回执到达。
+ * token 让并发或迟到的失败回滚只能撤销自己的请求，不能清掉更新的一次停止。
+ */
+export function markPiHostAbortRequested(ctx: PiTranslateContext): PiHostAbortRequestToken {
+  if (ctx.hostAbortRequestGeneration !== ctx.turnGeneration) {
+    ctx.hostAbortRequestTokens.clear();
+    ctx.hostAbortRequestGeneration = ctx.turnGeneration;
+  }
+  const token = Symbol('pi-host-abort-request');
+  ctx.hostAbortRequestTokens.add(token);
+  return token;
+}
+
+/** Abort RPC 未被接受时回滚对应请求，防止旧标记吞掉后续真实断流。 */
+export function rollbackPiHostAbortRequest(
+  ctx: PiTranslateContext,
+  token: PiHostAbortRequestToken,
+): void {
+  if (ctx.hostAbortRequestGeneration !== ctx.turnGeneration) return;
+  ctx.hostAbortRequestTokens.delete(token);
+  if (ctx.hostAbortRequestTokens.size === 0) ctx.hostAbortRequestGeneration = null;
+}
+
+function isCurrentTurnHostAbortRequested(ctx: PiTranslateContext): boolean {
+  return ctx.hostAbortRequestGeneration === ctx.turnGeneration
+    && ctx.hostAbortRequestTokens.size > 0;
+}
+
+function clearPiHostAbortRequests(ctx: PiTranslateContext): void {
+  ctx.hostAbortRequestTokens.clear();
+  ctx.hostAbortRequestGeneration = null;
+}
+
 const PI_GENERATION_HEARTBEAT_MS = 5_000;
 const PI_GENERATION_SUSPEND_GAP_MS = 30_000;
 
@@ -225,6 +269,7 @@ function stopPiGenerationHeartbeat(ctx: PiTranslateContext): void {
 export function disposePiTranslateContext(ctx: PiTranslateContext): void {
   stopPiGenerationHeartbeat(ctx);
   ctx.isStreaming = false;
+  clearPiHostAbortRequests(ctx);
   ctx.pendingAssistantError = null;
   ctx.compactTurnScope = null;
   ctx.subagentToolCalls.clear();
@@ -553,6 +598,8 @@ export function translatePiEvent(
 ): void {
   switch (event.type) {
     case 'agent_start': {
+      ctx.turnGeneration += 1;
+      clearPiHostAbortRequests(ctx);
       ctx.isStreaming = true;
       ctx.turnTokens = 0;
       ctx.turnInput = 0;
@@ -636,14 +683,18 @@ export function translatePiEvent(
         ctx.generationTimingReliable = false;
       }
       const fullText = assistantTextOf(message);
-      if (isPiTransientAssistantFailure(message)) {
+      const hostInitiatedAbort = message.stopReason === 'aborted'
+        && isCurrentTurnHostAbortRequested(ctx);
+      const transientAssistantFailure = !hostInitiatedAbort
+        && isPiTransientAssistantFailure(message);
+      if (transientAssistantFailure) {
         const rawError = message.errorMessage?.trim() || fullText.trim() || 'Pi agent request failed';
         ctx.pendingAssistantError = piAssistantErrorOf(rawError);
       } else {
         // A normal assistant message proves an earlier provider failure recovered.
         ctx.pendingAssistantError = null;
       }
-      if (!isPiTransientAssistantFailure(message) && fullText.length > 0) {
+      if (!transientAssistantFailure && fullText.length > 0) {
         // 覆盖为本 turn 最新一条有文本的 assistant 回复,agent_settled 作 done.result 上报。
         ctx.finalAssistantText = fullText;
         queue.push({
@@ -815,8 +866,11 @@ export function translatePiEvent(
       ctx.isStreaming = false;
       ctx.pendingPriceVariants = [];
       stopPiGenerationHeartbeat(ctx);
-      const pendingAssistantError = ctx.pendingAssistantError;
+      const pendingAssistantError = isCurrentTurnHostAbortRequested(ctx)
+        ? null
+        : ctx.pendingAssistantError;
       ctx.pendingAssistantError = null;
+      clearPiHostAbortRequests(ctx);
       if (pendingAssistantError) {
         queue.push({
           type: 'error',
@@ -868,6 +922,7 @@ export function translatePiEvent(
       // failed request. Drop any stale latch so the next request samples its
       // own tariff at message_start.
       ctx.pendingPriceVariants = [];
+      if (isCurrentTurnHostAbortRequested(ctx)) return;
       // `(auto-retry N/M)` 只给过载用：mobile / Telegram 把这个后缀当成「模型服务繁忙」。
       // 网络类改走 `Reconnecting... N/M`，未分类 5xx / LiteLLM in-stream 仍静默。
       const progress = parsePiAutoRetryProgress(event);
@@ -919,6 +974,10 @@ export function translatePiEvent(
     }
 
     case 'auto_retry_end': {
+      if (isCurrentTurnHostAbortRequested(ctx)) {
+        ctx.pendingAssistantError = null;
+        return;
+      }
       if (event.success === true) {
         ctx.pendingAssistantError = null;
         return;

--- a/packages/maker-core/src/agents/pi/translator.ts
+++ b/packages/maker-core/src/agents/pi/translator.ts
@@ -116,6 +116,8 @@ export interface PiTranslateContext {
   isStreaming: boolean;
   /** agent_start 代际；主动停止只允许影响登记时所在的这一轮。 */
   turnGeneration: number;
+  /** Host prompt 已发出、但对应 agent_start 尚未到达。 */
+  pendingHostTurnStartToken: symbol | null;
   /** 当前 turn 内尚未被终态消费的 Host 主动停止请求。 */
   hostAbortRequestGeneration: number | null;
   hostAbortRequestTokens: Set<symbol>;
@@ -196,6 +198,7 @@ export function createPiTranslateContext(logger: Logger): PiTranslateContext {
     costUsd: 0,
     isStreaming: false,
     turnGeneration: 0,
+    pendingHostTurnStartToken: null,
     hostAbortRequestGeneration: null,
     hostAbortRequestTokens: new Set(),
     thinkingSeq: 0,
@@ -220,15 +223,34 @@ export function createPiTranslateContext(logger: Logger): PiTranslateContext {
 }
 
 export type PiHostAbortRequestToken = symbol;
+export type PiHostTurnStartToken = symbol;
+
+/** 在 prompt RPC 发出前登记其尚未到达的 agent_start。 */
+export function markPiHostTurnStartPending(ctx: PiTranslateContext): PiHostTurnStartToken {
+  const token = Symbol('pi-host-turn-start');
+  ctx.pendingHostTurnStartToken = token;
+  return token;
+}
+
+/** 明确得知 prompt 未启动时，只撤销对应的待开始标记。 */
+export function rollbackPiHostTurnStart(
+  ctx: PiTranslateContext,
+  token: PiHostTurnStartToken,
+): void {
+  if (ctx.pendingHostTurnStartToken === token) ctx.pendingHostTurnStartToken = null;
+}
 
 /**
  * 在 abort RPC 发出前登记 Host 主动停止，避免 Pi 的 aborted 终态先于 RPC 回执到达。
  * token 让并发或迟到的失败回滚只能撤销自己的请求，不能清掉更新的一次停止。
  */
 export function markPiHostAbortRequested(ctx: PiTranslateContext): PiHostAbortRequestToken {
-  if (ctx.hostAbortRequestGeneration !== ctx.turnGeneration) {
+  const targetGeneration = !ctx.isStreaming && ctx.pendingHostTurnStartToken !== null
+    ? ctx.turnGeneration + 1
+    : ctx.turnGeneration;
+  if (ctx.hostAbortRequestGeneration !== targetGeneration) {
     ctx.hostAbortRequestTokens.clear();
-    ctx.hostAbortRequestGeneration = ctx.turnGeneration;
+    ctx.hostAbortRequestGeneration = targetGeneration;
   }
   const token = Symbol('pi-host-abort-request');
   ctx.hostAbortRequestTokens.add(token);
@@ -240,7 +262,6 @@ export function rollbackPiHostAbortRequest(
   ctx: PiTranslateContext,
   token: PiHostAbortRequestToken,
 ): void {
-  if (ctx.hostAbortRequestGeneration !== ctx.turnGeneration) return;
   ctx.hostAbortRequestTokens.delete(token);
   if (ctx.hostAbortRequestTokens.size === 0) ctx.hostAbortRequestGeneration = null;
 }
@@ -269,6 +290,7 @@ function stopPiGenerationHeartbeat(ctx: PiTranslateContext): void {
 export function disposePiTranslateContext(ctx: PiTranslateContext): void {
   stopPiGenerationHeartbeat(ctx);
   ctx.isStreaming = false;
+  ctx.pendingHostTurnStartToken = null;
   clearPiHostAbortRequests(ctx);
   ctx.pendingAssistantError = null;
   ctx.compactTurnScope = null;
@@ -599,7 +621,10 @@ export function translatePiEvent(
   switch (event.type) {
     case 'agent_start': {
       ctx.turnGeneration += 1;
-      clearPiHostAbortRequests(ctx);
+      ctx.pendingHostTurnStartToken = null;
+      if (ctx.hostAbortRequestGeneration !== ctx.turnGeneration) {
+        clearPiHostAbortRequests(ctx);
+      }
       ctx.isStreaming = true;
       ctx.turnTokens = 0;
       ctx.turnInput = 0;


### PR DESCRIPTION
## 这次改了什么

### 摘要

Pi 使用 Cindy AI 官方网关时，用户主动停止可能收到 `aborted` 加断流文案。此前这类事件会被误判为真实网关故障，并触发 Desktop 的自动续跑。本 PR 为 Host 主动停止增加按 Pi turn 绑定的标记，并覆盖停止早于 `agent_start` 到达的竞态；没有主动停止标记的真实断流仍保持可恢复行为。

### 变更类型

- [ ] `feat` 新功能
- [x] `fix` 缺陷修复
- [ ] `refactor` / `perf` 重构或性能优化
- [ ] `docs` / `test` / `chore` 文档、测试或工程维护
- [ ] 其他：

### 范围

- 关联 Issue / 需求：无
- 本 PR 包含：Pi 主动停止归因、停止 RPC 失败回滚、待到达 `agent_start` 的轮次绑定，以及对应回归测试
- 明确不包含：修改网关返回格式、Desktop 自动续跑额度、其他 agent harness
- 用户可见变化：用户主动停止 Pi 回复后不再显示错误重连进度，也不会自动续跑
- 是否存在 breaking change：无

### UI 变化

不涉及。本 PR 未修改 UI、视觉、交互组件或文案，只修正 Pi 终态事件的错误归因。

- 引用的设计规范：不涉及

## 怎么验证的

### 自动验证

```text
pnpm --filter @cindy/maker-core test -- src/agents/pi/__tests__/pi-translator.test.ts src/agents/pi/__tests__/pi-startsession-cleanup.test.ts
结果：通过，2 个测试文件，共 128 项测试

pnpm test:unit:related
结果：通过，apps/desktop、packages/lizi-mcps、packages/maker-core、packages/orca-workflow 均通过

pnpm --filter @cindy/maker-core exec eslint src/agents/pi/translator.ts src/agents/pi/__tests__/pi-translator.test.ts src/agents/pi/__tests__/pi-startsession-cleanup.test.ts
结果：通过

pnpm check:dco
结果：通过，2 个 commit 均带 DCO 签名
```

### 手工验证

不涉及：未连接真实 Cindy AI 网关，使用确定性的 Pi RPC 事件顺序测试覆盖官方网关返回形态与竞态。

### 未执行的验证

- 未执行真实 Cindy AI 网关实机验证；原因：回归测试已直接模拟 `aborted + OpenAI Responses stream ended before a terminal response event`，并分别覆盖主动停止与真实断流路径。
- 未执行 `pnpm test:unit`；按当前仓库工作流使用 `pnpm test:unit:related`，完整单测由 CI 运行。

## 风险

### 风险分类

- [ ] 无已知风险
- [ ] SQLite / migration
- [ ] system prompt
- [ ] 协议兼容
- [ ] 权限 / 安全 / 用户数据
- [ ] 存量插件兼容（批准状态 / 指纹 / manifest 校验 / 安装布局 / 包格式）
- [ ] 原生层 / fingerprint / OTA
- [ ] 跨平台差异
- [x] 其他：Pi turn 生命周期与中止事件顺序

### 影响与回滚

- 影响范围：仅 Pi session 的 Host 主动停止归因；未带主动停止标记的真实断流仍按原逻辑进入自动恢复
- 回滚 / 降级方式：回滚本 PR 的两个 commit，即恢复原有 Pi `aborted` 分类逻辑
- 移动端冷更判断：不会触发。未修改 `apps/mobile` 原生配置、原生依赖、config plugin、原生模块或其他 runtime fingerprint 输入

### 提交前检查

- [x] 已 review 完整 diff
- [x] 每个 commit 都带 DCO 签名（`git commit -s`，见 [DCO](../DCO)）
- [x] UI 改动已在「UI 变化」注明引用的设计规范章节（不涉及 UI）
- [x] 未提交凭证、令牌或授权文件
- [x] 已确认无需补充文档：内部错误归因修复已由测试固化
- [x] 已确认测试结果或说明未执行原因