### PR TITLE
fix(mobile): use app language for session effort labels

### DIFF
--- a/apps/mobile/app/sessions/[sessionId].tsx
+++ b/apps/mobile/app/sessions/[sessionId].tsx
@@ -184,7 +184,7 @@ import { ModelPickerSheet } from '@/session/ModelPickerSheet';
 import { MobileModelIconMark } from '@/session/MobileProviderMark';
 import { getModel } from '@cindy/model-providers/registry';
 import { clearSessionMirror, makeSessionMirrorAccessors } from '@/session/sessionModelMirror';
-import { rowFastEditable } from '@/session/modelPickerRows';
+import { effortLabelFromRuntime, rowFastEditable } from '@/session/modelPickerRows';
 import {
   buildMobileModelSections,
   isSelectedSourceDisconnected,
@@ -647,7 +647,7 @@ function buildComposerRuntimeSummary(
   runtime: MobileSessionRuntimeOptions,
 ): ComposerRuntimeSummary {
   const modelLabel = runtime.currentModel?.label ?? session.model;
-  const effortLabel = choiceLabel(runtime.effortOptions, session.effort);
+  const effortLabel = effortLabelFromRuntime(runtime, session.effort);
   return {
     modelSummary: [modelLabel, effortLabel].filter(Boolean).join(' · '),
     permissionLabel: choiceLabel(runtime.permissionOptions, session.permissionMode),

--- a/apps/mobile/app/sessions/[sessionId].tsx
+++ b/apps/mobile/app/sessions/[sessionId].tsx
@@ -2256,7 +2256,8 @@ export default function SessionScreen() {
     () => composerDisplaySession && composerDisplayRuntimeOptions
       ? buildComposerRuntimeSummary(composerDisplaySession, composerDisplayRuntimeOptions)
       : null,
-    [composerDisplayRuntimeOptions, composerDisplaySession],
+    // effort / 权限标签按 app 语言解析,切换语言时必须重算,否则停留在上一语言。
+    [composerDisplayRuntimeOptions, composerDisplaySession, i18nInstance.language],
   );
   // 被控端供应商目录 → provider-aware 模型分段(与新建会话页同逻辑;0 供应商回退扁平 modelOptions)。
   const composerDeviceProviders = useDeviceProviders(deviceId || undefined);

--- a/apps/mobile/app/sessions/new.tsx
+++ b/apps/mobile/app/sessions/new.tsx
@@ -323,7 +323,7 @@ import {
 import { mobileAgentLabel, mobileAgentVendor } from '@/session/sessionAgentSwitch';
 import { MobileModelIconMark } from '@/session/MobileProviderMark';
 import { draftModelMemoryFor, hydrateDraftModelMemory } from '@/session/draftModelMemory';
-import { rowFastEditable } from '@/session/modelPickerRows';
+import { effortLabelFromRuntime, rowFastEditable } from '@/session/modelPickerRows';
 import { useTheme, useThemedStyles, type ThemeColors } from '@/theme';
 import { fontWeight, iconSize, iconStroke, lineHeight, radius, spacing, typeScale } from '@/theme/tokens';
 
@@ -6102,7 +6102,7 @@ function buildDraftRuntimeSummary(
   runtime: MobileSessionRuntimeOptions,
 ): { modelSummary: string; permissionLabel: string } {
   const modelLabel = runtime.currentModel?.label ?? draft.model;
-  const effortLabel = choiceLabel(runtime.effortOptions, draft.effort);
+  const effortLabel = effortLabelFromRuntime(runtime, draft.effort);
   return {
     modelSummary: [modelLabel, effortLabel].filter(Boolean).join(' · '),
     permissionLabel: choiceLabel(runtime.permissionOptions, draft.permissionMode),

--- a/apps/mobile/app/sessions/new.tsx
+++ b/apps/mobile/app/sessions/new.tsx
@@ -395,7 +395,7 @@ interface WorktreeCreateIntentSnapshot {
 export default function NewRemoteSessionScreen() {
   const styles = useThemedStyles(makeStyles);
   const { colors } = useTheme();
-  const { t } = useTranslation();
+  const { t, i18n: i18nInstance } = useTranslation();
   // Dev-only:把构建信息从全局浮层挪到这里的顶部展示(试 Fast Refresh)。
   const buildLabel = __DEV__
     ? formatMobileBuildLabel(normalizeBuildInfo({
@@ -1059,7 +1059,8 @@ export default function NewRemoteSessionScreen() {
   );
   const runtimeSummary = useMemo(
     () => buildDraftRuntimeSummary(draft, runtimeOptions),
-    [draft, runtimeOptions],
+    // effort / 权限标签按 app 语言解析,切换语言时必须重算,否则停留在上一语言。
+    [draft, runtimeOptions, i18nInstance.language],
   );
   // 权限按钮 / 权限下拉不体现 plan(对齐桌面 PR#494 / Cursor):计划模式激活时展示
   // 进入前的底层权限档(无记录时回退首个非 plan 档),激活态由 composer 的 PlanModeChip 表达。

--- a/apps/mobile/src/__tests__/composerSummaryLocaleRefresh.test.ts
+++ b/apps/mobile/src/__tests__/composerSummaryLocaleRefresh.test.ts
@@ -1,0 +1,26 @@
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+
+import { describe, expect, it } from 'vitest';
+
+/**
+ * composer / 新会话草稿摘要里的 effort 与权限标签按当前 app 语言解析,
+ * memo 依赖必须带上语言,否则切换语言后已挂载的路由会停在上一语言。
+ */
+describe('composer 摘要随 app 语言重算', () => {
+  it('会话页 composerRuntimeSummary memo 依赖包含 i18n 语言', () => {
+    const source = readFileSync(resolve(process.cwd(), 'app/sessions/[sessionId].tsx'), 'utf8');
+    const memo = source.slice(source.indexOf('const composerRuntimeSummary = useMemo('));
+    const deps = memo.slice(memo.indexOf('['), memo.indexOf(']') + 1);
+
+    expect(deps).toContain('i18nInstance.language');
+  });
+
+  it('新建会话页 runtimeSummary memo 依赖包含 i18n 语言', () => {
+    const source = readFileSync(resolve(process.cwd(), 'app/sessions/new.tsx'), 'utf8');
+    const memo = source.slice(source.indexOf('const runtimeSummary = useMemo('));
+    const deps = memo.slice(memo.indexOf('['), memo.indexOf(']') + 1);
+
+    expect(deps).toContain('i18nInstance.language');
+  });
+});

--- a/apps/mobile/src/__tests__/modelPickerRows.test.ts
+++ b/apps/mobile/src/__tests__/modelPickerRows.test.ts
@@ -14,6 +14,7 @@ import {
   buildRowMetaLine,
   compactEffortLabelFor,
   effortLabelFor,
+  effortLabelFromRuntime,
   formatContextWindow,
   formatPriceLine,
   modelRowAccessibilityLabel,
@@ -111,6 +112,27 @@ describe('effortLabelFor —— 五级优先(i18n → 模型覆盖 → capabilit
   });
   it('词表也没有 → 原 id', () => {
     expect(effortLabelFor({}, 'nonexistent', null)).toBe('nonexistent');
+  });
+});
+
+
+describe('effortLabelFromRuntime —— 会话摘要按 app 语言覆盖 snapshot 标签', () => {
+  it('effortOptions 为 zh-CN 快照时仍随界面语言切换', async () => {
+    const previousLanguage = i18n.language;
+    const runtime = {
+      currentModel: null,
+      effortOptions: [{ id: 'xhigh', label: '超高' }],
+    };
+    try {
+      await i18n.changeLanguage('en');
+      expect(effortLabelFromRuntime(runtime, 'xhigh')).toBe('Extra High');
+      await i18n.changeLanguage('zh-CN');
+      expect(effortLabelFromRuntime(runtime, 'xhigh')).toBe('超高');
+      expect(effortLabelFromRuntime(runtime, '')).toBe('');
+      expect(effortLabelFromRuntime(runtime, null)).toBe('');
+    } finally {
+      await i18n.changeLanguage(previousLanguage);
+    }
   });
 });
 

--- a/apps/mobile/src/session/modelPickerRows.ts
+++ b/apps/mobile/src/session/modelPickerRows.ts
@@ -17,7 +17,7 @@ import {
 
 import { i18n } from '@/i18n';
 
-import type { MobileAgentCapabilities } from './agentCapabilities';
+import type { MobileAgentCapabilities, MobileSessionRuntimeOptions } from './agentCapabilities';
 import type { MobileModelMemoryAccessors } from './draftModelMemory';
 import type { DeviceApiKeyStatus } from '@/device-link/deviceModelMetaCache';
 import type { MobileModelPricingMap } from '@/device-link/mobileMakerTransport';
@@ -111,6 +111,30 @@ export function effortLabelFor(
   if (override) return override;
   const level = capabilities?.effortLevels.find((l) => l.id === effort);
   return level?.label ?? MOBILE_EFFORT_LABELS[effort] ?? effort;
+}
+
+
+/**
+ * 会话页 composer / 新会话草稿摘要用的 effort 展示名。
+ * runtime.effortOptions 来自被控端 zh-CN 兼容快照，这里走 effortLabelFor
+ * 按当前 app 语言覆盖（英文 Extra High、简中 超高）。
+ */
+export function effortLabelFromRuntime(
+  runtime: Pick<MobileSessionRuntimeOptions, 'currentModel' | 'effortOptions'>,
+  effort: string | null | undefined,
+): string {
+  if (!effort) return '';
+  return effortLabelFor(
+    runtime.currentModel ?? { effortDisplayNames: {} },
+    effort,
+    {
+      availableModels: [],
+      effortLevels: runtime.effortOptions,
+      permissionModes: [],
+      hasFastMode: false,
+      planModeSupported: false,
+    },
+  );
 }
 
 /**


### PR DESCRIPTION
## 这次改了什么

### 摘要

iOS 英文界面里 reasoning effort 显示成中文「超高」。原因是会话页 / 新建会话页的 composer 摘要直接用 `runtime.effortOptions`(被控端下发的 zh-CN 兼容快照)的 label，而模型选择页早就走 `effortLabelFor` 按 app 语言覆盖了。本 PR 把摘要也接到同一条覆盖链上：新增 `effortLabelFromRuntime`，两处摘要改用它，英文显示 Extra High、简中仍是超高。

### 变更类型

- [x] `fix` 缺陷修复

### 范围

- 关联 Issue / 需求：无独立 issue；与 #3484(相对时间 i18n)同一批 iOS 英文界面混入中文的问题
- 本 PR 包含：`effortLabelFromRuntime`(modelPickerRows)；`app/sessions/[sessionId].tsx` 与 `app/sessions/new.tsx` 两处摘要改用它，并把 app 语言加进两个 `useMemo` 依赖；对应单测
- 明确不包含：工具行动词(「读取」/「正在工作」)的 messagePresentation 硬编码中文 → #3507；相对时间 → #3484；`models.json` 里各语言 effort 译名本身(ja/zh-TW 沿用「超高」是既有裁决，不在本 PR 改)
- 用户可见变化：英文界面 composer 药丸的 effort 从「超高」变成 Extra High；切换 app 语言时药丸立即跟着换语言
- 是否存在 breaking change：无

### UI 变化

改动只换 composer 药丸里 effort 这一段文字，药丸本身的容器、圆角、间距、字号一律没动。下面是改动后各语言的静态 HTML 复现，文案取自实测输出(见「自动验证」)：

```html
<!doctype html>
<meta charset="utf-8">
<style>
  body { margin: 0; padding: 24px; background: #fff; color: #1A1A1A;
         font: 14px/1.4 -apple-system, "SF Pro Text", "PingFang SC", sans-serif; }
  h2 { font-size: 13px; font-weight: 600; color: #8C8E94; margin: 20px 0 8px; }
  .toolbar { display: flex; align-items: center; gap: 8px; padding: 10px 12px;
             border: 1px solid #DCDFE3; border-radius: 12px; background: #fff; width: 360px; }
  /* composerRuntimePill: radius.pill / sheetActionSurface / sheetActionBorder / minHeight 34 / paddingHorizontal spacing.md */
  .pill { display: inline-flex; align-items: center; gap: 4px; min-height: 34px; padding: 0 12px;
          border: 0.5px solid #DCDFE3; border-radius: 9999px; background: #F6F6F6;
          color: #8C8E94; font-size: 13px; white-space: nowrap; }
  .bad { color: #C4462F; }
  .row { display: flex; gap: 16px; align-items: center; }
  .tag { font-size: 11px; color: #8C8E94; width: 92px; }
</style>

<h2>改动前 —— 英文界面 + effort xhigh(zh 快照标签漏出)</h2>
<div class="row"><span class="tag">en</span>
  <div class="toolbar"><span class="pill">Claude Sonnet 4.6 · <span class="bad">超高</span></span></div>
</div>

<h2>改动后 —— 药丸按 app 语言解析 effort</h2>
<div class="row"><span class="tag">en</span>
  <div class="toolbar"><span class="pill">Claude Sonnet 4.6 · Extra High</span></div>
</div>
<div class="row"><span class="tag">zh-CN</span>
  <div class="toolbar"><span class="pill">Claude Sonnet 4.6 · 超高</span></div>
</div>
<div class="row"><span class="tag">zh-TW</span>
  <div class="toolbar"><span class="pill">Claude Sonnet 4.6 · 超高</span></div>
</div>
<div class="row"><span class="tag">ja</span>
  <div class="toolbar"><span class="pill">Claude Sonnet 4.6 · 超高</span></div>
</div>
<div class="row"><span class="tag">ko</span>
  <div class="toolbar"><span class="pill">Claude Sonnet 4.6 · 초고</span></div>
</div>
```

- 引用的设计规范：DESIGN.md §11.2「Casing & Punctuation Per Language」——英文标签用 Title Case，所以英文档位是 `Extra High` 而不是 `extra high`；中文档位不套用 Title Case，保持「超高」。DESIGN.md §11.1「文案属于工具而非营销」——只换 effort 档位名，不加任何修饰词。药丸容器沿用既有 `composerRuntimePill`(radius.pill / spacing.md / sheetActionSurface)，本 PR 未改任何 token 或布局，故不触发 §4 / §5 的新约束。

## 怎么验证的

### 自动验证

```text
cd apps/mobile && vitest run src/__tests__/modelPickerRows.test.ts src/__tests__/composerSummaryLocaleRefresh.test.ts
结果：2 files / 26 tests passed

cd apps/mobile && vitest run          # 全量 mobile 单测
结果：322 files / 3900 tests passed

cd apps/mobile && tsc --noEmit
结果：0 error
```

`modelPickerRows.test.ts` 覆盖 `effortLabelFromRuntime` 在 en / zh-CN 下的输出；
`composerSummaryLocaleRefresh.test.ts` 是本轮新增的回归：断言两处摘要的 `useMemo`
依赖里带着 i18n 语言，防止再退回「切语言后停在上一语言」。

### 手工验证

未在真机 / 模拟器上跑。上面的 HTML 是按 `composerRuntimePill` 的样式常量复现的静态页面，文案是从实测输出里取的，不是手打的。

### 未执行的验证

- iOS 模拟器实机截图：本轮没有起 Metro / 模拟器；建议审阅者按「英文系统语言 → 选一个支持 xhigh 的模型 → 看 composer 药丸」这条路径确认，并在会话页开着时切一次 app 语言。
- desktop / e2e：本 PR 不碰 desktop 与 mobile e2e。

## 风险

### 风险分类

- [x] 无已知风险

### 影响与回滚

- 影响范围：仅 mobile 两处 composer 摘要的 effort 文案与其 memo 依赖。
- 回滚 / 降级方式：revert 本 PR 即回到直接用被控端快照 label 的行为。

### 提交前检查

- [x] 已 review 完整 diff
- [x] 每个 commit 都带 DCO 签名
- [x] UI 改动已在「UI 变化」注明引用的设计规范章节
- [x] 未提交凭证、令牌或授权文件
- [x] 已补充必要文档(本改动无需新增文档)
- [x] 已确认测试结果或说明未执行原因
