### PR TITLE
feat(desktop): 按用户授权落准新任务默认模型组合

### DIFF
--- a/apps/desktop/src/renderer/__tests__/authContextRace.test.ts
+++ b/apps/desktop/src/renderer/__tests__/authContextRace.test.ts
@@ -30,7 +30,7 @@ describe('AuthContext auth-state races', () => {
   });
 
   it('repartitions every owner-scoped renderer store at the same boundary', () => {
-    // 统一模型选择器新增的两根轴(引擎 override / 收藏副本)与 newMakerDraft 同待遇:
+    // 模型选择器持久轴(模型预设 / 引擎 override / 收藏副本)与 newMakerDraft 同待遇:
     // 同一处、同一个 state.dataOwnerId(登出快照里就是 null)。漏接任一个 = 多账号串号 ——
     // 这正是 providerModelMemory 不分账号踩过的坑,不能在新 store 上重演。
     const applyStart = source.indexOf('const applyIncomingState = useCallback');
@@ -38,6 +38,7 @@ describe('AuthContext auth-state races', () => {
     const applyBlock = source.slice(applyStart, source.indexOf('[applyIncomingUser]', applyStart));
     for (const call of [
       'setNewMakerDraftOwner(state.dataOwnerId);',
+      'setProviderModelMemoryOwner(state.dataOwnerId);',
       'setModelEnginePrefsOwner(state.dataOwnerId);',
       'setModelFavoritesOwner(state.dataOwnerId);',
     ]) {

--- a/apps/desktop/src/renderer/__tests__/chatInputModelSelectorRouting.test.ts
+++ b/apps/desktop/src/renderer/__tests__/chatInputModelSelectorRouting.test.ts
@@ -237,6 +237,11 @@ describe('ChatInput model source switching wiring', () => {
     ]) {
       expect(draftBlock).toContain(write);
     }
+    // 「恢复推荐」已先删除记忆键；直通草稿时不得把推荐档位重新写成 override。
+    expect(draftBlock).toContain('!selection.resetToRecommended');
+    expect(draftBlock).toContain(
+      '...(selection.resetToRecommended ? { resetToRecommended: true as const } : {})',
+    );
   });
 
   it('feeds the selector the session/draft wire id as the selected model', () => {

--- a/apps/desktop/src/renderer/__tests__/modelEnginePrefs.test.ts
+++ b/apps/desktop/src/renderer/__tests__/modelEnginePrefs.test.ts
@@ -110,6 +110,7 @@ describe('modelEnginePrefs store', () => {
     const m = await loadModule();
     expect(m.getModelEngineOverride('anthropic', 'claude-opus-4-8')).toBeUndefined();
     expect(m.hasModelEngineOverride('anthropic', 'claude-opus-4-8')).toBe(false);
+    expect(m.hasAnyModelEngineOverride()).toBe(false);
     expect(memStorage.getItem(m.__STORAGE_KEY)).toBeNull();
   });
 
@@ -118,6 +119,7 @@ describe('modelEnginePrefs store', () => {
     m1.setModelEngineOverride('xd', 'gpt-5.5', 'cc');
     expect(m1.getModelEngineOverride('xd', 'gpt-5.5')).toBe('cc');
     expect(m1.hasModelEngineOverride('xd', 'gpt-5.5')).toBe(true);
+    expect(m1.hasAnyModelEngineOverride()).toBe(true);
     // 同步写:调用返回时已经落盘(不能靠 debounce / 微任务)。
     expect(JSON.parse(memStorage.getItem(m1.__STORAGE_KEY) ?? '{}')).toEqual({
       'xd:gpt-5.5': { agent: 'cc' },

--- a/apps/desktop/src/renderer/__tests__/modelPickerLayout.test.ts
+++ b/apps/desktop/src/renderer/__tests__/modelPickerLayout.test.ts
@@ -1,0 +1,35 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+class MemLocalStorage {
+  private store = new Map<string, string>();
+  getItem(key: string): string | null {
+    return this.store.get(key) ?? null;
+  }
+  setItem(key: string, value: string): void {
+    this.store.set(key, value);
+  }
+  removeItem(key: string): void {
+    this.store.delete(key);
+  }
+}
+
+let storage: MemLocalStorage;
+
+beforeEach(() => {
+  storage = new MemLocalStorage();
+  vi.stubGlobal('window', { localStorage: storage });
+  vi.resetModules();
+});
+
+describe('modelPickerLayout', () => {
+  it('未保存偏好时默认使用样式 A', async () => {
+    const { getModelPickerLayout } = await import('@/state/modelPickerLayout');
+    expect(getModelPickerLayout()).toBe('classic');
+  });
+
+  it.each(['original', 'classic', 'badge'] as const)('保留用户明确选择的 %s', async (layout) => {
+    storage.setItem('xdt:modelPickerLayout:v1', layout);
+    const { getModelPickerLayout } = await import('@/state/modelPickerLayout');
+    expect(getModelPickerLayout()).toBe(layout);
+  });
+});

--- a/apps/desktop/src/renderer/__tests__/newMakerDraft.test.ts
+++ b/apps/desktop/src/renderer/__tests__/newMakerDraft.test.ts
@@ -118,10 +118,10 @@ describe('newMakerDraft store', () => {
     expect(getDraft().defaultTupleCustomized).toBe(false);
   });
 
-  it('旧草稿的 Harness、模型、来源、思考深度或 Fast 选择会迁移成已自定义', async () => {
+  it('旧草稿的模型、来源、思考深度或 Fast 选择会迁移成已自定义', async () => {
     for (const saved of [
-      { vendor: 'codex' },
       { vendor: 'cc', modelChosenByVendor: { cc: true } },
+      { vendor: 'cc', lastByVendor: { cc: { model: 'claude-opus-4-8' } } },
       { vendor: 'cc', lastByVendor: { cc: { providerId: 'anthropic' } } },
       { vendor: 'cc', effortByModel: { 'claude-opus-5': 'high' } },
       { vendor: 'cc', fastModeByModel: { 'claude-opus-5': true } },
@@ -131,6 +131,73 @@ describe('newMakerDraft store', () => {
       const { getDraft } = await loadModule();
       expect(getDraft().defaultTupleCustomized).toBe(true);
     }
+  });
+
+  it('旧 preserving 路径仅留下 cc.model 时仍保护旧模型', async () => {
+    memStorage.setItem(
+      'xdt:newMakerDraft:v1',
+      JSON.stringify({ vendor: 'cc', lastByVendor: { cc: { model: 'claude-opus-4-8' } } }),
+    );
+    vi.resetModules();
+    const { applySuggestedDefaultTuple, getDraft } = await loadModule();
+    expect(getDraft().defaultTupleCustomized).toBe(true);
+    expect(
+      applySuggestedDefaultTuple({
+        vendor: 'pi',
+        providerId: 'xai',
+        model: 'grok-4.6',
+        effort: 'high',
+      }),
+    ).toBe(false);
+    expect(getDraft().vendor).toBe('cc');
+    expect(getDraft().lastByVendor.cc.model).toBe('claude-opus-4-8');
+  });
+
+  it('旧版系统可用性 fallback 不迁移成用户自定义', async () => {
+    for (const vendor of ['codex', 'pi'] as const) {
+      memStorage.setItem('xdt:newMakerDraft:v1', JSON.stringify({ vendor }));
+      vi.resetModules();
+      const { applySuggestedDefaultTuple, getDraft } = await loadModule();
+      expect(getDraft().defaultTupleCustomized).toBe(false);
+      expect(
+        applySuggestedDefaultTuple({
+          vendor: 'pi',
+          providerId: 'xai',
+          model: 'grok-4.6',
+          effort: 'high',
+        }),
+      ).toBe(true);
+      expect(getDraft()).toMatchObject({
+        vendor: 'pi',
+        defaultTupleCustomized: false,
+        lastByVendor: { pi: { providerId: 'xai', model: 'grok-4.6', effort: 'high' } },
+      });
+    }
+  });
+
+  it('默认组合先落 Pi 后，可用性回退读取实时草稿且不被旧 cc 闭包覆盖', async () => {
+    const { applySuggestedDefaultTuple, fallbackUnavailableVendor, getDraft } = await loadModule();
+    expect(
+      applySuggestedDefaultTuple({
+        vendor: 'pi',
+        providerId: 'xai',
+        model: 'grok-4.6',
+        effort: 'high',
+      }),
+    ).toBe(true);
+    expect(fallbackUnavailableVendor(new Set(['codex', 'pi']))).toBe(false);
+    expect(getDraft()).toMatchObject({
+      vendor: 'pi',
+      defaultTupleCustomized: false,
+      lastByVendor: { pi: { providerId: 'xai', model: 'grok-4.6', effort: 'high' } },
+    });
+  });
+
+  it('系统可用性回退本身不标记用户自定义', async () => {
+    const { fallbackUnavailableVendor, getDraft } = await loadModule();
+    expect(fallbackUnavailableVendor(new Set(['codex', 'pi']))).toBe(true);
+    expect(getDraft().vendor).toBe('codex');
+    expect(getDraft().defaultTupleCustomized).toBe(false);
   });
 
   it('persists an explicit Pi model choice across reload', async () => {

--- a/apps/desktop/src/renderer/__tests__/newMakerDraft.test.ts
+++ b/apps/desktop/src/renderer/__tests__/newMakerDraft.test.ts
@@ -647,21 +647,20 @@ describe('newMakerDraft store', () => {
     expect(getDraft().workingDir).toBe('E:/projects/foo/.claude/worktrees/auto-abc/src');
   });
 
-  it('switchVendor:落地当前 vendor 的最新 prefs 后再切到目标 vendor', async () => {
-    const { getDraft, switchVendor } = await loadModule();
-    // 当前 vendor='cc',传入"模拟用户改过的 cc prefs"
-    switchVendor('codex', {
-      ...getDraft().lastByVendor.cc,
+  it('switchVendor:保留已同步的当前 vendor prefs 后再切到目标 vendor', async () => {
+    const { getDraft, patchCurrentVendorPrefs, switchVendor } = await loadModule();
+    patchCurrentVendorPrefs({
       model: 'claude-opus-4-7',
       effort: 'high',
-      permissionMode: 'plan',
+      permissionMode: 'bypassPermissions',
     });
+    switchVendor('codex');
     const d = getDraft();
     expect(d.vendor).toBe('codex');
     // 旧 vendor(cc)的 prefs 被落地为传入的值
     expect(d.lastByVendor.cc.model).toBe('claude-opus-4-7');
     expect(d.lastByVendor.cc.effort).toBe('high');
-    expect(d.lastByVendor.cc.permissionMode).toBe('plan');
+    expect(d.lastByVendor.cc.permissionMode).toBe('bypassPermissions');
     // 新 vendor(codex)的 prefs 不变(等待用户在 codex 下继续操作)
     expect(d.lastByVendor.codex.permissionMode).toBe('auto');
   });
@@ -669,7 +668,7 @@ describe('newMakerDraft store', () => {
   it('switchVendor:选中的引擎跨重启保留(模拟 app 重启后仍是上次选的)', async () => {
     const m1 = await loadModule();
     expect(m1.getDraft().vendor).toBe('cc');
-    m1.switchVendor('codex', m1.getDraft().lastByVendor.cc);
+    m1.switchVendor('codex');
     expect(m1.getDraft().vendor).toBe('codex');
 
     vi.resetModules();
@@ -700,7 +699,7 @@ describe('newMakerDraft store', () => {
   it('switchVendor:相同 vendor 不变(no-op,避免误覆盖)', async () => {
     const { getDraft, switchVendor } = await loadModule();
     const before = getDraft().lastByVendor.cc;
-    switchVendor('cc', { ...before, model: 'XX', effort: 'low', permissionMode: 'auto' });
+    switchVendor('cc');
     expect(getDraft().lastByVendor.cc).toEqual(before);
   });
 
@@ -1069,7 +1068,7 @@ describe('newMakerDraft store', () => {
     const activeWindow = await loadModule();
 
     activeWindow.markDefaultTupleCustomized();
-    activeWindow.switchVendor('pi', activeWindow.getCurrentVendorPrefs());
+    activeWindow.switchVendor('pi');
     activeWindow.patchVendorPrefs('pi', {
       model: 'grok-4.6',
       providerId: 'xai',
@@ -1105,6 +1104,299 @@ describe('newMakerDraft store', () => {
     ).toMatchObject(expectedTuple);
   });
 
+  it('旧窗口的无关写入不会复活另一窗口已恢复推荐的 tuple', async () => {
+    const activeWindow = await loadModule();
+    activeWindow.setEffortForModel('legacy-model', 'high');
+    activeWindow.markDefaultTupleCustomized(false);
+    vi.resetModules();
+    const staleWindow = await loadModule();
+    expect(staleWindow.getDraft().defaultTupleCustomized).toBe(true);
+
+    activeWindow.clearDefaultTupleTuningCustomization({
+      modelId: 'legacy-model',
+      hasExternalOverrides: false,
+    });
+    const restoredTuple = {
+      vendor: activeWindow.getDraft().vendor,
+      defaultTupleCustomized: false,
+      defaultTupleSelectionCustomized: false,
+      modelChosenByVendor: {},
+      effortByModel: {},
+      fastModeByModel: {},
+      lastByVendor: activeWindow.getDraft().lastByVendor,
+    };
+
+    // storage event 尚未到达 B；仅改工作目录时必须采用 A 已写入的完整恢复结果。
+    staleWindow.patchDraft({ workingDir: '/projects/after-restore' });
+    expect(staleWindow.getDraft()).toMatchObject(restoredTuple);
+    expect(staleWindow.getDraft().workingDir).toBe('/projects/after-restore');
+    expect(JSON.parse(memStorage.getItem(staleWindow.__STORAGE_KEY) ?? '{}')).toMatchObject(
+      restoredTuple,
+    );
+  });
+
+  it('旧窗口在恢复推荐后明确选模时，只写入这次新的 tuple 意图', async () => {
+    const activeWindow = await loadModule();
+    activeWindow.setEffortForModel('legacy-model', 'high');
+    activeWindow.markDefaultTupleCustomized(false);
+    vi.resetModules();
+    const staleWindow = await loadModule();
+
+    activeWindow.clearDefaultTupleTuningCustomization({
+      modelId: 'legacy-model',
+      hasExternalOverrides: false,
+    });
+    staleWindow.patchVendorPrefs('cc', {
+      model: 'claude-new-choice',
+      providerId: 'anthropic',
+      effort: 'xhigh',
+    });
+
+    expect(staleWindow.getDraft()).toMatchObject({
+      defaultTupleCustomized: true,
+      defaultTupleSelectionCustomized: true,
+      modelChosenByVendor: { cc: true },
+      effortByModel: {},
+      fastModeByModel: {},
+      lastByVendor: {
+        cc: expect.objectContaining({
+          model: 'claude-new-choice',
+          providerId: 'anthropic',
+          effort: 'xhigh',
+        }),
+      },
+    });
+  });
+
+  it('旧窗口在恢复推荐后切 Harness 时，不用旧闭包污染最新来源槽', async () => {
+    const activeWindow = await loadModule();
+    activeWindow.setEffortForModel('legacy-model', 'high');
+    activeWindow.markDefaultTupleCustomized(false);
+    vi.resetModules();
+    const staleWindow = await loadModule();
+
+    activeWindow.clearDefaultTupleTuningCustomization({
+      modelId: 'legacy-model',
+      hasExternalOverrides: false,
+    });
+    activeWindow.applySuggestedDefaultTuple({
+      vendor: 'pi',
+      model: 'z-ai/glm-5.3-flash',
+      providerId: 'xd',
+      effort: 'medium',
+    });
+
+    // B 仍渲染着旧 cc tuple，但这次明确意图只有“切到 Codex”。切换前必须采用 A 的
+    // 最新 Pi tuple，不能把旧 cc prefs 填进 Pi 槽。
+    staleWindow.markDefaultTupleCustomized();
+    staleWindow.switchVendor('codex');
+
+    const expected = {
+      vendor: 'codex',
+      defaultTupleCustomized: true,
+      lastByVendor: {
+        pi: expect.objectContaining({
+          model: 'z-ai/glm-5.3-flash',
+          providerId: 'xd',
+          effort: 'medium',
+        }),
+      },
+    };
+    expect(staleWindow.getDraft()).toMatchObject(expected);
+    expect(JSON.parse(memStorage.getItem(staleWindow.__STORAGE_KEY) ?? '{}')).toMatchObject(
+      expected,
+    );
+  });
+
+  it('旧窗口选择界面所示 Harness 时，仍按最新持久状态执行切换', async () => {
+    const activeWindow = await loadModule();
+    activeWindow.setEffortForModel('legacy-model', 'high');
+    activeWindow.markDefaultTupleCustomized(false);
+    vi.resetModules();
+    const staleWindow = await loadModule();
+    expect(staleWindow.getDraft().vendor).toBe('cc');
+
+    activeWindow.clearDefaultTupleTuningCustomization({
+      modelId: 'legacy-model',
+      hasExternalOverrides: false,
+    });
+    activeWindow.applySuggestedDefaultTuple({
+      vendor: 'pi',
+      model: 'z-ai/glm-5.3-flash',
+      providerId: 'xd',
+      effort: 'medium',
+    });
+
+    // B 仍显示 cc，用户明确点 cc。调用方必须始终进入 switchVendor，让它先看到真实 Pi
+    // 再切回 cc；若用旧 draft.vendor 预判，这次明确意图会被错误跳过。
+    staleWindow.switchVendor('cc');
+    staleWindow.patchVendorPrefs('cc', {
+      model: 'claude-new-choice',
+      providerId: 'anthropic',
+      effort: 'high',
+    });
+
+    expect(staleWindow.getDraft()).toMatchObject({
+      vendor: 'cc',
+      defaultTupleCustomized: true,
+      modelChosenByVendor: { cc: true },
+      lastByVendor: {
+        cc: expect.objectContaining({
+          model: 'claude-new-choice',
+          providerId: 'anthropic',
+        }),
+        pi: expect.objectContaining({
+          model: 'z-ai/glm-5.3-flash',
+          providerId: 'xd',
+        }),
+      },
+    });
+  });
+
+  it('旧窗口的内联控件按界面 Harness 写入，不串到最新持久 Harness', async () => {
+    const activeWindow = await loadModule();
+    activeWindow.setEffortForModel('legacy-model', 'high');
+    activeWindow.markDefaultTupleCustomized(false);
+    vi.resetModules();
+    const staleWindow = await loadModule();
+    const renderedVendor = staleWindow.getDraft().vendor;
+    expect(renderedVendor).toBe('cc');
+
+    activeWindow.clearDefaultTupleTuningCustomization({
+      modelId: 'legacy-model',
+      hasExternalOverrides: false,
+    });
+    activeWindow.applySuggestedDefaultTuple({
+      vendor: 'pi',
+      model: 'z-ai/glm-5.3-flash',
+      providerId: 'xd',
+      effort: 'medium',
+    });
+
+    // 模拟 classic/inline 回调：marker 会先 rebase 到 Pi，但后续必须按渲染时捕获的 cc
+    // 执行切换并写 cc 槽，不能用 rebase 后的 currentDraft.vendor 把值串进 Pi。
+    staleWindow.markDefaultTupleCustomized();
+    staleWindow.switchVendor(renderedVendor);
+    staleWindow.patchVendorPrefs(renderedVendor, {
+      model: 'claude-inline-choice',
+      providerId: 'anthropic',
+      effort: 'xhigh',
+    });
+
+    expect(staleWindow.getDraft()).toMatchObject({
+      vendor: 'cc',
+      defaultTupleCustomized: true,
+      modelChosenByVendor: { cc: true },
+      lastByVendor: {
+        cc: expect.objectContaining({
+          model: 'claude-inline-choice',
+          providerId: 'anthropic',
+          effort: 'xhigh',
+        }),
+        pi: expect.objectContaining({
+          model: 'z-ai/glm-5.3-flash',
+          providerId: 'xd',
+          effort: 'medium',
+        }),
+      },
+    });
+  });
+
+  it('旧窗口切 Fast 时回到界面 Harness，并保留最新 Pi 默认', async () => {
+    const activeWindow = await loadModule();
+    activeWindow.setEffortForModel('legacy-model', 'high');
+    activeWindow.markDefaultTupleCustomized(false);
+    vi.resetModules();
+    const staleWindow = await loadModule();
+    const renderedVendor = staleWindow.getDraft().vendor;
+
+    activeWindow.clearDefaultTupleTuningCustomization({
+      modelId: 'legacy-model',
+      hasExternalOverrides: false,
+    });
+    activeWindow.applySuggestedDefaultTuple({
+      vendor: 'pi',
+      model: 'z-ai/glm-5.3-flash',
+      providerId: 'xd',
+      effort: 'medium',
+    });
+
+    // 模拟 Fast handler：先标记调档，再确保当前 Harness 是用户仍看见的 cc，最后写模型记忆。
+    staleWindow.markDefaultTupleCustomized(false);
+    staleWindow.switchVendor(renderedVendor);
+    staleWindow.setFastModeForModel('claude-visible-model', true);
+
+    expect(staleWindow.getDraft()).toMatchObject({
+      vendor: 'cc',
+      defaultTupleCustomized: true,
+      fastModeByModel: { 'claude-visible-model': true },
+      lastByVendor: {
+        pi: expect.objectContaining({
+          model: 'z-ai/glm-5.3-flash',
+          providerId: 'xd',
+        }),
+      },
+    });
+  });
+
+  it('旧窗口改权限等非 tuple 字段时，只更新界面 Harness 槽', async () => {
+    const activeWindow = await loadModule();
+    activeWindow.setEffortForModel('legacy-model', 'high');
+    activeWindow.markDefaultTupleCustomized(false);
+    vi.resetModules();
+    const staleWindow = await loadModule();
+
+    activeWindow.clearDefaultTupleTuningCustomization({
+      modelId: 'legacy-model',
+      hasExternalOverrides: false,
+    });
+    activeWindow.applySuggestedDefaultTuple({
+      vendor: 'pi',
+      model: 'z-ai/glm-5.3-flash',
+      providerId: 'xd',
+      effort: 'medium',
+    });
+
+    staleWindow.patchVendorPrefs('cc', { permissionMode: 'bypassPermissions' });
+
+    expect(staleWindow.getDraft()).toMatchObject({
+      vendor: 'pi',
+      defaultTupleCustomized: false,
+      lastByVendor: {
+        cc: expect.objectContaining({ permissionMode: 'bypassPermissions' }),
+        pi: expect.objectContaining({
+          model: 'z-ai/glm-5.3-flash',
+          providerId: 'xd',
+        }),
+      },
+    });
+  });
+
+  it('preserving 活动同步基于恢复后的 tuple，不带回旧 marker 和调档', async () => {
+    const activeWindow = await loadModule();
+    activeWindow.setEffortForModel('legacy-model', 'high');
+    activeWindow.markDefaultTupleCustomized(false);
+    vi.resetModules();
+    const staleWindow = await loadModule();
+
+    activeWindow.clearDefaultTupleTuningCustomization({
+      modelId: 'legacy-model',
+      hasExternalOverrides: false,
+    });
+    staleWindow.patchVendorPrefsPreservingModelChoice('cc', { effort: 'medium' });
+
+    expect(staleWindow.getDraft()).toMatchObject({
+      defaultTupleCustomized: false,
+      defaultTupleSelectionCustomized: false,
+      modelChosenByVendor: {},
+      effortByModel: {},
+      fastModeByModel: {},
+      lastByVendor: {
+        cc: expect.objectContaining({ effort: 'medium' }),
+      },
+    });
+  });
+
   it('旧窗口只清调档但未解锁时仍保住另一窗口的新默认组合', async () => {
     const staleWindow = await loadModule();
     staleWindow.setEffortForModel('legacy-model', 'high');
@@ -1112,7 +1404,7 @@ describe('newMakerDraft store', () => {
     const activeWindow = await loadModule();
 
     activeWindow.markDefaultTupleCustomized();
-    activeWindow.switchVendor('pi', activeWindow.getCurrentVendorPrefs());
+    activeWindow.switchVendor('pi');
     activeWindow.patchVendorPrefs('pi', {
       model: 'grok-4.6',
       providerId: 'xai',
@@ -1329,18 +1621,18 @@ describe('newMakerDraft store', () => {
 
     it('显式带设备 + 具体 workingDir(选该设备上的项目)→ 两者都保留', async () => {
       const { getDraft, patchDraft } = await loadModule();
-      patchDraft({
-        deviceLinkDeviceId: 'dev-a',
-        deviceLinkDeviceName: 'Studio Mac',
-        workingDir: '/host/proj',
-      });
+      patchDraft({ deviceLinkDeviceId: 'dev-a', deviceLinkDeviceName: 'Studio Mac', workingDir: '/host/proj' });
       expect(getDraft().deviceLinkDeviceId).toBe('dev-a');
       expect(getDraft().workingDir).toBe('/host/proj');
     });
 
     it('改 workingDir 但不带设备字段 → 仍按老规则清设备(防本地项目被误当远程)', async () => {
       const { getDraft, patchDraft } = await loadModule();
-      patchDraft({ deviceLinkDeviceId: 'dev-a', deviceLinkDeviceName: 'Studio Mac', workingDir: '/host/proj' });
+      patchDraft({
+        deviceLinkDeviceId: 'dev-a',
+        deviceLinkDeviceName: 'Studio Mac',
+        workingDir: '/host/proj',
+      });
       patchDraft({ workingDir: '/local/proj' });
       expect(getDraft().deviceLinkDeviceId).toBeNull();
       expect(getDraft().deviceLinkDeviceName).toBeNull();

--- a/apps/desktop/src/renderer/__tests__/newMakerDraft.test.ts
+++ b/apps/desktop/src/renderer/__tests__/newMakerDraft.test.ts
@@ -121,15 +121,86 @@ describe('newMakerDraft store', () => {
       defaultTupleCustomized: true,
       defaultTupleSelectionCustomized: false,
     });
-    tuningOnly.clearDefaultTupleTuningCustomization();
+    tuningOnly.clearDefaultTupleTuningCustomization({
+      modelId: 'claude-sonnet-4-6',
+      hasExternalOverrides: false,
+    });
     expect(tuningOnly.getDraft().defaultTupleCustomized).toBe(false);
 
     tuningOnly.markDefaultTupleCustomized();
     tuningOnly.markDefaultTupleCustomized(false);
-    tuningOnly.clearDefaultTupleTuningCustomization();
+    tuningOnly.clearDefaultTupleTuningCustomization({
+      modelId: 'claude-sonnet-4-6',
+      hasExternalOverrides: false,
+    });
     expect(tuningOnly.getDraft()).toMatchObject({
       defaultTupleCustomized: true,
       defaultTupleSelectionCustomized: true,
+    });
+  });
+
+  it.each(['effort', 'fast'] as const)(
+    '当前默认模型只改 %s 时，恢复推荐清空旧记忆并允许后续默认变化',
+    async (kind) => {
+      const modelId = 'claude-sonnet-4-6';
+      const draft = await loadModule();
+      draft.markDefaultTupleCustomized(false);
+      if (kind === 'effort') draft.setEffortForModel(modelId, 'high');
+      else draft.setFastModeForModel(modelId, true);
+
+      draft.clearDefaultTupleTuningCustomization({
+        modelId,
+        hasExternalOverrides: false,
+      });
+      expect(draft.getDraft()).toMatchObject({
+        defaultTupleCustomized: false,
+        defaultTupleSelectionCustomized: false,
+        effortByModel: {},
+        fastModeByModel: {},
+      });
+      expect(
+        draft.applySuggestedDefaultTuple({
+          vendor: 'pi',
+          providerId: 'xai',
+          model: 'grok-4.6',
+          effort: 'high',
+        }),
+      ).toBe(true);
+
+      vi.resetModules();
+      const reloaded = await loadModule();
+      expect(reloaded.getDraft()).toMatchObject({
+        defaultTupleCustomized: false,
+        effortByModel: {},
+        fastModeByModel: {},
+      });
+    },
+  );
+
+  it('恢复当前项后仍有其它草稿或外部 override 时继续保护默认组合', async () => {
+    const draft = await loadModule();
+    draft.markDefaultTupleCustomized(false);
+    draft.setEffortForModel('claude-sonnet-4-6', 'high');
+    draft.setFastModeForModel('gpt-5.5', true);
+
+    draft.clearDefaultTupleTuningCustomization({
+      modelId: 'claude-sonnet-4-6',
+      hasExternalOverrides: false,
+    });
+    expect(draft.getDraft()).toMatchObject({
+      defaultTupleCustomized: true,
+      effortByModel: {},
+      fastModeByModel: { 'gpt-5.5': true },
+    });
+
+    draft.clearDefaultTupleTuningCustomization({
+      modelId: 'gpt-5.5',
+      hasExternalOverrides: true,
+    });
+    expect(draft.getDraft()).toMatchObject({
+      defaultTupleCustomized: true,
+      effortByModel: {},
+      fastModeByModel: {},
     });
   });
 
@@ -305,7 +376,10 @@ describe('newMakerDraft store', () => {
       defaultTupleCustomized: true,
       defaultTupleSelectionCustomized: false,
     });
-    clearDefaultTupleTuningCustomization();
+    clearDefaultTupleTuningCustomization({
+      modelId: 'grok-4.6',
+      hasExternalOverrides: false,
+    });
     expect(getDraft().defaultTupleCustomized).toBe(false);
   });
 
@@ -329,7 +403,10 @@ describe('newMakerDraft store', () => {
       defaultTupleCustomized: true,
       defaultTupleSelectionCustomized: true,
     });
-    clearDefaultTupleTuningCustomization();
+    clearDefaultTupleTuningCustomization({
+      modelId: 'grok-4.6',
+      hasExternalOverrides: false,
+    });
     expect(getDraft().defaultTupleCustomized).toBe(true);
   });
 

--- a/apps/desktop/src/renderer/__tests__/newMakerDraft.test.ts
+++ b/apps/desktop/src/renderer/__tests__/newMakerDraft.test.ts
@@ -153,6 +153,37 @@ describe('newMakerDraft store', () => {
     expect(getDraft().lastByVendor.cc.model).toBe('claude-opus-4-8');
   });
 
+  it('旧完整快照里的 cc 种子模型不误判成用户自定义', async () => {
+    memStorage.setItem(
+      'xdt:newMakerDraft:v1',
+      JSON.stringify({
+        vendor: 'cc',
+        workingDir: '/tmp/project',
+        lastByVendor: {
+          cc: { model: 'claude-sonnet-4-6' },
+          codex: { model: 'gpt-5.5' },
+          pi: { model: 'claude-sonnet-5' },
+          orca: { model: 'claude-sonnet-4-6' },
+        },
+      }),
+    );
+    vi.resetModules();
+    const { applySuggestedDefaultTuple, getDraft } = await loadModule();
+    expect(getDraft().defaultTupleCustomized).toBe(false);
+    expect(
+      applySuggestedDefaultTuple({
+        vendor: 'pi',
+        providerId: 'xai',
+        model: 'grok-4.6',
+        effort: 'high',
+      }),
+    ).toBe(true);
+    expect(getDraft()).toMatchObject({
+      vendor: 'pi',
+      lastByVendor: { pi: { providerId: 'xai', model: 'grok-4.6', effort: 'high' } },
+    });
+  });
+
   it('旧版系统可用性 fallback 不迁移成用户自定义', async () => {
     for (const vendor of ['codex', 'pi'] as const) {
       memStorage.setItem('xdt:newMakerDraft:v1', JSON.stringify({ vendor }));

--- a/apps/desktop/src/renderer/__tests__/newMakerDraft.test.ts
+++ b/apps/desktop/src/renderer/__tests__/newMakerDraft.test.ts
@@ -66,6 +66,71 @@ describe('newMakerDraft store', () => {
     expect(d.effortByModel).toEqual({});
     expect(d.worktreeEnabled).toBe(false);
     expect(d.worktreePreferenceCustomized).toBe(false);
+    expect(d.defaultTupleCustomized).toBe(false);
+  });
+
+  it('产品默认原子写入完整组合，但不伪装成用户显式选模', async () => {
+    const { applySuggestedDefaultTuple, getDraft } = await loadModule();
+    expect(
+      applySuggestedDefaultTuple({
+        vendor: 'codex',
+        providerId: 'openai',
+        model: 'chatgpt/gpt-5.6-sol',
+        effort: 'high',
+      }),
+    ).toBe(true);
+    expect(getDraft()).toMatchObject({
+      vendor: 'codex',
+      defaultTupleCustomized: false,
+      lastByVendor: {
+        codex: {
+          providerId: 'openai',
+          model: 'chatgpt/gpt-5.6-sol',
+          effort: 'high',
+        },
+      },
+    });
+    expect(getDraft().modelChosenByVendor.codex).toBeUndefined();
+
+    vi.resetModules();
+    const reloaded = await loadModule();
+    expect(reloaded.getDraft().defaultTupleCustomized).toBe(false);
+  });
+
+  it('用户明确改过组合后，登录态变化不再覆盖', async () => {
+    const { applySuggestedDefaultTuple, getDraft, markDefaultTupleCustomized } = await loadModule();
+    markDefaultTupleCustomized();
+    expect(
+      applySuggestedDefaultTuple({
+        vendor: 'pi',
+        providerId: 'xai',
+        model: 'grok-4.6',
+        effort: 'high',
+      }),
+    ).toBe(false);
+    expect(getDraft().vendor).toBe('cc');
+    expect(getDraft().defaultTupleCustomized).toBe(true);
+  });
+
+  it('只改权限不把模型组合误标成用户自定义', async () => {
+    const { getDraft, patchCurrentVendorPrefs } = await loadModule();
+    patchCurrentVendorPrefs({ permissionMode: 'bypassPermissions' });
+    expect(getDraft().defaultTupleCustomized).toBe(false);
+  });
+
+  it('旧草稿的 Harness、模型、来源、思考深度或 Fast 选择会迁移成已自定义', async () => {
+    for (const saved of [
+      { vendor: 'codex' },
+      { vendor: 'cc', modelChosenByVendor: { cc: true } },
+      { vendor: 'cc', lastByVendor: { cc: { providerId: 'anthropic' } } },
+      { vendor: 'cc', effortByModel: { 'claude-opus-5': 'high' } },
+      { vendor: 'cc', fastModeByModel: { 'claude-opus-5': true } },
+    ]) {
+      memStorage.setItem('xdt:newMakerDraft:v1', JSON.stringify(saved));
+      vi.resetModules();
+      const { getDraft } = await loadModule();
+      expect(getDraft().defaultTupleCustomized).toBe(true);
+    }
   });
 
   it('persists an explicit Pi model choice across reload', async () => {

--- a/apps/desktop/src/renderer/__tests__/newMakerDraft.test.ts
+++ b/apps/desktop/src/renderer/__tests__/newMakerDraft.test.ts
@@ -67,6 +67,7 @@ describe('newMakerDraft store', () => {
     expect(d.worktreeEnabled).toBe(false);
     expect(d.worktreePreferenceCustomized).toBe(false);
     expect(d.defaultTupleCustomized).toBe(false);
+    expect(d.defaultTupleSelectionCustomized).toBe(false);
   });
 
   it('产品默认原子写入完整组合，但不伪装成用户显式选模', async () => {
@@ -110,6 +111,26 @@ describe('newMakerDraft store', () => {
     ).toBe(false);
     expect(getDraft().vendor).toBe('cc');
     expect(getDraft().defaultTupleCustomized).toBe(true);
+    expect(getDraft().defaultTupleSelectionCustomized).toBe(true);
+  });
+
+  it('恢复推荐只撤销 effort/Fast 调档，不清除模型/来源/Harness 选择', async () => {
+    const tuningOnly = await loadModule();
+    tuningOnly.markDefaultTupleCustomized(false);
+    expect(tuningOnly.getDraft()).toMatchObject({
+      defaultTupleCustomized: true,
+      defaultTupleSelectionCustomized: false,
+    });
+    tuningOnly.clearDefaultTupleTuningCustomization();
+    expect(tuningOnly.getDraft().defaultTupleCustomized).toBe(false);
+
+    tuningOnly.markDefaultTupleCustomized();
+    tuningOnly.markDefaultTupleCustomized(false);
+    tuningOnly.clearDefaultTupleTuningCustomization();
+    expect(tuningOnly.getDraft()).toMatchObject({
+      defaultTupleCustomized: true,
+      defaultTupleSelectionCustomized: true,
+    });
   });
 
   it('只改权限不把模型组合误标成用户自定义', async () => {
@@ -153,6 +174,45 @@ describe('newMakerDraft store', () => {
     expect(getDraft().lastByVendor.cc.model).toBe('claude-opus-4-8');
   });
 
+  it('旧 device-link preserving 完整快照与空 marker 仍保护 cc 旧模型', async () => {
+    memStorage.setItem(
+      'xdt:newMakerDraft:v1',
+      JSON.stringify({
+        vendor: 'cc',
+        modelChosenByVendor: {},
+        lastByVendor: {
+          cc: {
+            model: 'claude-opus-4-8',
+            providerId: null,
+            effort: 'medium',
+            permissionMode: 'auto',
+            planMode: false,
+          },
+          codex: { model: 'gpt-5.5', providerId: null, effort: 'high' },
+          pi: { model: 'claude-sonnet-5', providerId: null, effort: 'high' },
+          orca: { model: 'claude-sonnet-4-6', providerId: null, effort: 'medium' },
+        },
+      }),
+    );
+    vi.resetModules();
+    const { applySuggestedDefaultTuple, getDraft } = await loadModule();
+    expect(getDraft()).toMatchObject({
+      vendor: 'cc',
+      defaultTupleCustomized: true,
+      defaultTupleSelectionCustomized: true,
+      lastByVendor: { cc: { model: 'claude-opus-4-8', providerId: null, effort: 'medium' } },
+    });
+    expect(
+      applySuggestedDefaultTuple({
+        vendor: 'pi',
+        providerId: 'xai',
+        model: 'grok-4.6',
+        effort: 'high',
+      }),
+    ).toBe(false);
+    expect(getDraft().lastByVendor.cc.model).toBe('claude-opus-4-8');
+  });
+
   it('旧完整快照里的 cc 种子模型不误判成用户自定义', async () => {
     memStorage.setItem(
       'xdt:newMakerDraft:v1',
@@ -182,6 +242,95 @@ describe('newMakerDraft store', () => {
       vendor: 'pi',
       lastByVendor: { pi: { providerId: 'xai', model: 'grok-4.6', effort: 'high' } },
     });
+  });
+
+  it('旧 head 已标明系统默认时，不因 Gateway 来源反推成用户选择', async () => {
+    memStorage.setItem(
+      'xdt:newMakerDraft:v1',
+      JSON.stringify({
+        vendor: 'pi',
+        defaultTupleCustomized: false,
+        modelChosenByVendor: {},
+        lastByVendor: {
+          cc: { model: 'claude-sonnet-4-6' },
+          codex: { model: 'gpt-5.5' },
+          pi: { model: 'grok-4.6', providerId: 'xai', effort: 'high' },
+        },
+      }),
+    );
+    vi.resetModules();
+    const { getDraft } = await loadModule();
+    expect(getDraft()).toMatchObject({
+      defaultTupleCustomized: false,
+      defaultTupleSelectionCustomized: false,
+    });
+  });
+
+  it('旧 head 已标明自定义时，从显式模型证据补出 selection marker', async () => {
+    memStorage.setItem(
+      'xdt:newMakerDraft:v1',
+      JSON.stringify({
+        vendor: 'cc',
+        defaultTupleCustomized: true,
+        modelChosenByVendor: { cc: true },
+        lastByVendor: { cc: { model: 'claude-opus-4-8' } },
+      }),
+    );
+    vi.resetModules();
+    const { getDraft } = await loadModule();
+    expect(getDraft()).toMatchObject({
+      defaultTupleCustomized: true,
+      defaultTupleSelectionCustomized: true,
+    });
+  });
+
+  it('旧 head 的 Gateway 默认来源加调档，不误补成 selection marker', async () => {
+    memStorage.setItem(
+      'xdt:newMakerDraft:v1',
+      JSON.stringify({
+        vendor: 'pi',
+        defaultTupleCustomized: true,
+        modelChosenByVendor: {},
+        effortByModel: { 'grok-4.6': 'medium' },
+        lastByVendor: {
+          cc: { model: 'claude-sonnet-4-6' },
+          codex: { model: 'gpt-5.5' },
+          pi: { model: 'grok-4.6', providerId: 'xai', effort: 'medium' },
+        },
+      }),
+    );
+    vi.resetModules();
+    const { clearDefaultTupleTuningCustomization, getDraft } = await loadModule();
+    expect(getDraft()).toMatchObject({
+      defaultTupleCustomized: true,
+      defaultTupleSelectionCustomized: false,
+    });
+    clearDefaultTupleTuningCustomization();
+    expect(getDraft().defaultTupleCustomized).toBe(false);
+  });
+
+  it('旧 head 只换来源时，即使没有 modelChosen marker 也保护真实来源选择', async () => {
+    memStorage.setItem(
+      'xdt:newMakerDraft:v1',
+      JSON.stringify({
+        vendor: 'pi',
+        defaultTupleCustomized: true,
+        modelChosenByVendor: {},
+        lastByVendor: {
+          cc: { model: 'claude-sonnet-4-6' },
+          codex: { model: 'gpt-5.5' },
+          pi: { model: 'grok-4.6', providerId: 'openrouter', effort: 'high' },
+        },
+      }),
+    );
+    vi.resetModules();
+    const { clearDefaultTupleTuningCustomization, getDraft } = await loadModule();
+    expect(getDraft()).toMatchObject({
+      defaultTupleCustomized: true,
+      defaultTupleSelectionCustomized: true,
+    });
+    clearDefaultTupleTuningCustomization();
+    expect(getDraft().defaultTupleCustomized).toBe(true);
   });
 
   it('旧版系统可用性 fallback 不迁移成用户自定义', async () => {

--- a/apps/desktop/src/renderer/__tests__/newMakerDraft.test.ts
+++ b/apps/desktop/src/renderer/__tests__/newMakerDraft.test.ts
@@ -1062,6 +1062,80 @@ describe('newMakerDraft store', () => {
     });
   });
 
+  it('旧窗口的完整草稿写入不会覆盖另一窗口刚保存的默认模型组合', async () => {
+    // 两个 renderer 的模块内存独立；旧窗口仍停在未自定义的 cc 草稿。
+    const staleWindow = await loadModule();
+    vi.resetModules();
+    const activeWindow = await loadModule();
+
+    activeWindow.markDefaultTupleCustomized();
+    activeWindow.switchVendor('pi', activeWindow.getCurrentVendorPrefs());
+    activeWindow.patchVendorPrefs('pi', {
+      model: 'grok-4.6',
+      providerId: 'xai',
+      effort: 'high',
+    });
+    activeWindow.setEffortForModel('grok-4.6', 'high');
+    activeWindow.setFastModeForModel('grok-4.6', true);
+    expect(staleWindow.getDraft().defaultTupleCustomized).toBe(false);
+
+    // storage event 尚未送达时，旧窗口只改无关的工作目录。完整写入前必须把用户组合
+    // 整体 rebase，不能只保住 marker 而丢 Harness / 来源 / 模型 / 深度 / Fast。
+    staleWindow.patchDraft({ workingDir: '/projects/stale-window' });
+
+    const expectedTuple = {
+      vendor: 'pi',
+      defaultTupleCustomized: true,
+      defaultTupleSelectionCustomized: true,
+      modelChosenByVendor: { pi: true },
+      effortByModel: { 'grok-4.6': 'high' },
+      fastModeByModel: { 'grok-4.6': true },
+      lastByVendor: {
+        pi: expect.objectContaining({
+          model: 'grok-4.6',
+          providerId: 'xai',
+          effort: 'high',
+        }),
+      },
+    };
+    expect(staleWindow.getDraft()).toMatchObject(expectedTuple);
+    expect(staleWindow.getDraft().workingDir).toBe('/projects/stale-window');
+    expect(
+      JSON.parse(memStorage.getItem(staleWindow.__STORAGE_KEY) ?? '{}'),
+    ).toMatchObject(expectedTuple);
+  });
+
+  it('旧窗口只清调档但未解锁时仍保住另一窗口的新默认组合', async () => {
+    const staleWindow = await loadModule();
+    staleWindow.setEffortForModel('legacy-model', 'high');
+    vi.resetModules();
+    const activeWindow = await loadModule();
+
+    activeWindow.markDefaultTupleCustomized();
+    activeWindow.switchVendor('pi', activeWindow.getCurrentVendorPrefs());
+    activeWindow.patchVendorPrefs('pi', {
+      model: 'grok-4.6',
+      providerId: 'xai',
+      effort: 'high',
+    });
+
+    // staleWindow 自己仍是 false，所以这不是合法的 true → false 解锁；清理写入也必须 rebase。
+    staleWindow.clearDefaultTupleTuningCustomization({
+      modelId: 'legacy-model',
+      hasExternalOverrides: true,
+    });
+
+    expect(staleWindow.getDraft()).toMatchObject({
+      vendor: 'pi',
+      defaultTupleCustomized: true,
+      defaultTupleSelectionCustomized: true,
+      modelChosenByVendor: { pi: true },
+      lastByVendor: {
+        pi: expect.objectContaining({ model: 'grok-4.6', providerId: 'xai' }),
+      },
+    });
+  });
+
   it('远程 worktree 广播不会让旧窗口回滚持久草稿或 main 偏好镜像', async () => {
     // 先让附属窗口持有旧的模型/目录，再由活跃窗口保存新值；两个模块实例模拟两个 renderer。
     const staleWindow = await loadModule();
@@ -1152,6 +1226,21 @@ describe('newMakerDraft store', () => {
       ...draftStore.getDraft(),
       worktreeEnabled: true,
       worktreePreferenceCustomized: true,
+      vendor: 'pi',
+      defaultTupleCustomized: true,
+      defaultTupleSelectionCustomized: true,
+      modelChosenByVendor: { pi: true },
+      effortByModel: { 'grok-4.6': 'high' },
+      fastModeByModel: { 'grok-4.6': true },
+      lastByVendor: {
+        ...draftStore.getDraft().lastByVendor,
+        pi: {
+          ...draftStore.getDraft().lastByVendor.pi,
+          model: 'grok-4.6',
+          providerId: 'xai',
+          effort: 'high',
+        },
+      },
     });
     memStorage.setItem(draftStore.__STORAGE_KEY, serialized);
 
@@ -1162,6 +1251,21 @@ describe('newMakerDraft store', () => {
 
     expect(draftStore.getDraft().worktreeEnabled).toBe(true);
     expect(draftStore.getDraft().worktreePreferenceCustomized).toBe(true);
+    expect(draftStore.getDraft()).toMatchObject({
+      vendor: 'pi',
+      defaultTupleCustomized: true,
+      defaultTupleSelectionCustomized: true,
+      modelChosenByVendor: { pi: true },
+      effortByModel: { 'grok-4.6': 'high' },
+      fastModeByModel: { 'grok-4.6': true },
+      lastByVendor: {
+        pi: expect.objectContaining({
+          model: 'grok-4.6',
+          providerId: 'xai',
+          effort: 'high',
+        }),
+      },
+    });
     expect(subscriber).toHaveBeenCalledTimes(1);
 
     // 旧 false 事件若迟到,当前 localStorage 的 true 仍是权威值,不得回滚内存或 main 镜像。

--- a/apps/desktop/src/renderer/__tests__/newMakerProjectPicker.test.ts
+++ b/apps/desktop/src/renderer/__tests__/newMakerProjectPicker.test.ts
@@ -560,11 +560,14 @@ describe('Shared create project picker', () => {
       /opt\.vendor === value \|\| !hiddenVendors\.includes\(opt\.vendor\)/,
     );
 
-    // 路由:以被控端(deviceId)为准计算 hidden;选中值被隐藏时 coerce 到首个可用。
+    // 路由以被控端(deviceId)为准计算 hidden。不可用性变化只收窄可选入口；不得由
+    // 监听旧 draft 的 effect 再写回选中值，否则会覆盖同轮刚应用的新默认组合。
     expect(newMakerDraftRouteSource).toMatch(
       /useAvailableAgents\(\s*effectiveDeviceLinkDeviceId,?\s*\)/,
     );
-    expect(newMakerDraftRouteSource).toMatch(/hiddenSwitcherVendors\.includes\(draft\.vendor\)/);
+    expect(newMakerDraftRouteSource).not.toMatch(
+      /hiddenSwitcherVendors\.includes\(draft\.vendor\)/,
+    );
 
     // 2026-08-12 统一模型选择器(M5):新会话工具条上的引擎下拉常态已撤除(只在
     // device-link 老被控端的降级分支里保留),上面那条 hiddenVendors 断言因此不再是

--- a/apps/desktop/src/renderer/__tests__/providerModelMemory.test.ts
+++ b/apps/desktop/src/renderer/__tests__/providerModelMemory.test.ts
@@ -61,6 +61,33 @@ describe('providerModelMemory store', () => {
     expect(effortMemory.hasAnyProviderModelOverride()).toBe(true);
   });
 
+  it('按 dataOwnerId 隔离 override，旧全局快照只由首个 owner 认领', async () => {
+    memStorage.setItem(
+      'xdt:providerModelMemory:v2',
+      JSON.stringify({
+        'claude-code:anthropic': {
+          lastModel: '',
+          effortByModel: { 'claude-opus-4-8': 'high' },
+          fastByModel: {},
+          thinkingByModel: {},
+        },
+      }),
+    );
+    const m = await loadModule();
+    m.setProviderModelMemoryOwner('owner-a');
+    expect(m.hasAnyProviderModelOverride()).toBe(true);
+    expect(memStorage.getItem('xdt:providerModelMemory:v2')).toBeNull();
+
+    m.setProviderModelMemoryOwner('owner-b');
+    expect(m.hasAnyProviderModelOverride()).toBe(false);
+    m.setProviderModelFast('codex', 'openai', 'gpt-5.6-sol', false);
+    expect(m.hasAnyProviderModelOverride()).toBe(true);
+
+    m.setProviderModelMemoryOwner('owner-a');
+    expect(m.getProviderModelEffort('claude-code', 'anthropic', 'claude-opus-4-8')).toBe('high');
+    expect(m.getProviderModelFast('codex', 'openai', 'gpt-5.6-sol')).toBeUndefined();
+  });
+
   it('set/get 往返 + 跨重启持久化', async () => {
     const m1 = await loadModule();
     m1.setProviderModelChoice('claude-code', 'anthropic', 'claude-opus-4-8', 'high');

--- a/apps/desktop/src/renderer/__tests__/providerModelMemory.test.ts
+++ b/apps/desktop/src/renderer/__tests__/providerModelMemory.test.ts
@@ -16,10 +16,12 @@ import { describe, it, expect, beforeEach, vi } from 'vitest';
 
 class MemLocalStorage {
   private store = new Map<string, string>();
+  private writesFail = false;
   getItem(k: string): string | null {
     return this.store.has(k) ? (this.store.get(k) as string) : null;
   }
   setItem(k: string, v: string): void {
+    if (this.writesFail) throw new Error('simulated localStorage write failure');
     this.store.set(k, v);
   }
   removeItem(k: string): void {
@@ -27,6 +29,9 @@ class MemLocalStorage {
   }
   clear(): void {
     this.store.clear();
+  }
+  setWritesFail(writesFail: boolean): void {
+    this.writesFail = writesFail;
   }
 }
 
@@ -88,6 +93,292 @@ describe('providerModelMemory store', () => {
     expect(m.getProviderModelFast('codex', 'openai', 'gpt-5.6-sol')).toBeUndefined();
   });
 
+  it('同 owner 的外部写入刷新空缓存并通知订阅者，其他 owner 事件不串入', async () => {
+    let onStorage: ((event: StorageEvent) => void) | undefined;
+    vi.stubGlobal('window', {
+      localStorage: memStorage,
+      addEventListener: (type: string, listener: EventListener) => {
+        if (type === 'storage') onStorage = listener as (event: StorageEvent) => void;
+      },
+      removeEventListener: vi.fn(),
+    });
+    vi.resetModules();
+
+    const m = await loadModule();
+    m.setProviderModelMemoryOwner('owner-a');
+    expect(m.hasAnyProviderModelOverride()).toBe(false); // 窗口 B 先以空缓存启动。
+    const seen = vi.fn();
+    m.subscribeProviderModelMemory(seen);
+
+    const ownerAKey = `${m.__STORAGE_KEY}:owner-a`;
+    memStorage.setItem(
+      ownerAKey,
+      JSON.stringify({
+        'codex:openai': {
+          lastModel: '',
+          effortByModel: { 'gpt-5.6-sol': 'xhigh' },
+          fastByModel: { 'gpt-5.6-sol': true },
+          thinkingByModel: {},
+        },
+      }),
+    );
+    onStorage?.({ key: ownerAKey, newValue: '{ stale event payload }' } as StorageEvent);
+
+    expect(seen).toHaveBeenCalledTimes(1);
+    expect(m.hasAnyProviderModelOverride()).toBe(true);
+    expect(m.getProviderModelEffort('codex', 'openai', 'gpt-5.6-sol')).toBe('xhigh');
+    expect(m.getProviderModelFast('codex', 'openai', 'gpt-5.6-sol')).toBe(true);
+
+    // 相同持久化真相的迟到事件不应重复 bump modelPresetVersion。
+    onStorage?.({ key: ownerAKey, newValue: '{ older payload }' } as StorageEvent);
+    onStorage?.({
+      key: ownerAKey,
+      storageArea: {} as Storage,
+    } as StorageEvent);
+    expect(seen).toHaveBeenCalledTimes(1);
+
+    memStorage.setItem(
+      `${m.__STORAGE_KEY}:owner-b`,
+      JSON.stringify({
+        'claude-code:anthropic': {
+          lastModel: '',
+          effortByModel: { 'claude-opus-4-8': 'low' },
+          fastByModel: {},
+          thinkingByModel: {},
+        },
+      }),
+    );
+    onStorage?.({ key: `${m.__STORAGE_KEY}:owner-b` } as StorageEvent);
+    expect(seen).toHaveBeenCalledTimes(1);
+    expect(m.getProviderModelEffort('claude-code', 'anthropic', 'claude-opus-4-8')).toBeUndefined();
+
+    // owner 已切换后，旧 owner 的迟到事件不能刷新新 owner 缓存。
+    m.setProviderModelMemoryOwner('owner-c');
+    seen.mockClear();
+    onStorage?.({ key: ownerAKey } as StorageEvent);
+    expect(seen).not.toHaveBeenCalled();
+    expect(m.hasAnyProviderModelOverride()).toBe(false);
+  });
+
+  it('写入前重读 owner 分区，不用空缓存覆盖外部 effort/Fast', async () => {
+    const m = await loadModule();
+    m.setProviderModelMemoryOwner('owner-a');
+    expect(m.hasAnyProviderModelOverride()).toBe(false); // 窗口 B 的旧缓存。
+
+    const ownerAKey = `${m.__STORAGE_KEY}:owner-a`;
+    memStorage.setItem(
+      ownerAKey,
+      JSON.stringify({
+        'claude-code:anthropic': {
+          lastModel: '',
+          effortByModel: { 'claude-opus-4-8': 'high' },
+          fastByModel: { 'claude-opus-4-8': true },
+          thinkingByModel: {},
+        },
+      }),
+    );
+
+    // storage 事件尚未送达时，窗口 B 又写另一条；整表写回仍须保留窗口 A 的两项 override。
+    m.setProviderModelThinking('pi', 'xd', 'glm-5.3-flash', true);
+    const persisted = JSON.parse(memStorage.getItem(ownerAKey) ?? '{}') as Record<
+      string,
+      {
+        effortByModel: Record<string, string>;
+        fastByModel: Record<string, boolean>;
+        thinkingByModel: Record<string, boolean>;
+      }
+    >;
+    expect(persisted['claude-code:anthropic']?.effortByModel['claude-opus-4-8']).toBe('high');
+    expect(persisted['claude-code:anthropic']?.fastByModel['claude-opus-4-8']).toBe(true);
+    expect(persisted['pi:xd']?.thinkingByModel['glm-5.3-flash']).toBe(true);
+  });
+
+  it('写前读到外部同值时也刷新本窗口缓存和订阅者', async () => {
+    const m = await loadModule();
+    m.setProviderModelMemoryOwner('owner-a');
+    expect(m.hasAnyProviderModelOverride()).toBe(false);
+    const seen = vi.fn();
+    m.subscribeProviderModelMemory(seen);
+
+    const ownerAKey = `${m.__STORAGE_KEY}:owner-a`;
+    memStorage.setItem(
+      ownerAKey,
+      JSON.stringify({
+        'codex:openai': {
+          lastModel: '',
+          effortByModel: { 'gpt-5.6-sol': 'xhigh' },
+          fastByModel: {},
+          thinkingByModel: {},
+        },
+      }),
+    );
+
+    // storage 事件尚未到达；同值写虽无需再落盘，但 freshMap 已看到的真相必须立即被采纳。
+    m.setProviderModelEffort('codex', 'openai', 'gpt-5.6-sol', 'xhigh');
+    expect(m.getProviderModelEffort('codex', 'openai', 'gpt-5.6-sol')).toBe('xhigh');
+    expect(seen).toHaveBeenCalledTimes(1);
+  });
+
+  it('写盘失败后继续保留当前 owner 的新 override，可写时完整补落盘', async () => {
+    const m = await loadModule();
+    m.setProviderModelMemoryOwner('owner-a');
+    const ownerAKey = `${m.__STORAGE_KEY}:owner-a`;
+    memStorage.setItem(
+      ownerAKey,
+      JSON.stringify({
+        'claude-code:anthropic': {
+          lastModel: '',
+          effortByModel: { 'claude-opus-4-8': 'medium' },
+          fastByModel: {},
+          thinkingByModel: {},
+        },
+      }),
+    );
+
+    memStorage.setWritesFail(true);
+    m.setProviderModelFast('claude-code', 'anthropic', 'claude-opus-4-8', true);
+    m.setProviderModelEffort('codex', 'openai', 'gpt-5.6-sol', 'xhigh');
+    expect(m.getProviderModelFast('claude-code', 'anthropic', 'claude-opus-4-8')).toBe(true);
+    expect(m.getProviderModelEffort('codex', 'openai', 'gpt-5.6-sol')).toBe('xhigh');
+
+    memStorage.setWritesFail(false);
+    // 窗口 A 在 B 写盘失败期间成功写入另一项；B 恢复后必须在这份新盘面上重放自己的 op。
+    memStorage.setItem(
+      ownerAKey,
+      JSON.stringify({
+        'claude-code:anthropic': {
+          lastModel: '',
+          effortByModel: { 'claude-opus-4-8': 'medium' },
+          fastByModel: {},
+          thinkingByModel: {},
+        },
+        'claude-code:xd': {
+          lastModel: '',
+          effortByModel: { 'claude-haiku-4-5': 'low' },
+          fastByModel: {},
+          thinkingByModel: {},
+        },
+        'codex:openai': {
+          lastModel: 'gpt-5.5',
+          effortByModel: { 'gpt-5.5': 'medium' },
+          fastByModel: {},
+          thinkingByModel: {},
+        },
+        'codex:*': {
+          lastModel: '',
+          effortByModel: {},
+          fastByModel: { 'gpt-5.6-sol': false },
+          thinkingByModel: {},
+        },
+      }),
+    );
+    m.setProviderModelThinking('pi', 'xd', 'glm-5.3-flash', true);
+    const persisted = JSON.parse(memStorage.getItem(ownerAKey) ?? '{}') as Record<
+      string,
+      {
+        effortByModel: Record<string, string>;
+        fastByModel: Record<string, boolean>;
+        thinkingByModel: Record<string, boolean>;
+      }
+    >;
+    expect(persisted['claude-code:anthropic']?.effortByModel['claude-opus-4-8']).toBe('medium');
+    expect(persisted['claude-code:anthropic']?.fastByModel['claude-opus-4-8']).toBe(true);
+    expect(persisted['claude-code:xd']?.effortByModel['claude-haiku-4-5']).toBe('low');
+    expect(persisted['codex:openai']?.effortByModel['gpt-5.6-sol']).toBe('xhigh');
+    expect(persisted['codex:openai']?.effortByModel['gpt-5.5']).toBe('medium');
+    expect((persisted['codex:openai'] as { lastModel?: string })?.lastModel).toBe('gpt-5.5');
+    expect(persisted['codex:*']?.fastByModel['gpt-5.6-sol']).toBe(false);
+    expect(persisted['pi:xd']?.thinkingByModel['glm-5.3-flash']).toBe(true);
+  });
+
+  it('写盘失败的旧操作不覆盖另一窗口后来写入的同字段', async () => {
+    const m = await loadModule();
+    m.setProviderModelMemoryOwner('owner-a');
+    const ownerAKey = `${m.__STORAGE_KEY}:owner-a`;
+
+    memStorage.setWritesFail(true);
+    m.setProviderModelFast('codex', 'openai', 'gpt-5.6-sol', true);
+
+    memStorage.setWritesFail(false);
+    // 窗口 A 后来明确把同一字段设为 false；B 的旧 pending=true 恢复时必须退休。
+    memStorage.setItem(
+      ownerAKey,
+      JSON.stringify({
+        'codex:openai': {
+          lastModel: '',
+          effortByModel: {},
+          fastByModel: { 'gpt-5.6-sol': false },
+          thinkingByModel: {},
+        },
+      }),
+    );
+    m.setProviderModelThinking('pi', 'xd', 'glm-5.3-flash', true);
+
+    const persisted = JSON.parse(memStorage.getItem(ownerAKey) ?? '{}') as Record<
+      string,
+      { fastByModel: Record<string, boolean> }
+    >;
+    expect(persisted['codex:openai']?.fastByModel['gpt-5.6-sol']).toBe(false);
+  });
+
+  it('选模写盘失败后再调 effort，不会丢失独立的 lastModel 意图', async () => {
+    const m = await loadModule();
+    m.setProviderModelMemoryOwner('owner-a');
+
+    memStorage.setWritesFail(true);
+    m.setProviderModelChoice('codex', 'openai', 'gpt-5.6-sol', 'high');
+    m.setProviderModelEffort('codex', 'openai', 'gpt-5.6-sol', 'xhigh');
+
+    memStorage.setWritesFail(false);
+    m.setProviderModelThinking('pi', 'xd', 'glm-5.3-flash', true);
+    expect(m.getProviderModelChoice('codex', 'openai')).toEqual({
+      model: 'gpt-5.6-sol',
+      effort: 'xhigh',
+    });
+  });
+
+  it('冲突退休的旧 lastModel 基线不阻断后来更新的本地选模', async () => {
+    const m = await loadModule();
+    m.setProviderModelMemoryOwner('owner-a');
+    const ownerAKey = `${m.__STORAGE_KEY}:owner-a`;
+    memStorage.setItem(
+      ownerAKey,
+      JSON.stringify({
+        'codex:openai': {
+          lastModel: 'model-x',
+          effortByModel: { 'model-x': 'medium' },
+          fastByModel: {},
+          thinkingByModel: {},
+        },
+      }),
+    );
+
+    memStorage.setWritesFail(true);
+    m.setProviderModelChoice('codex', 'openai', 'model-a', 'high');
+
+    memStorage.setWritesFail(false);
+    memStorage.setItem(
+      ownerAKey,
+      JSON.stringify({
+        'codex:openai': {
+          lastModel: 'model-c',
+          effortByModel: { 'model-c': 'low' },
+          fastByModel: {},
+          thinkingByModel: {},
+        },
+      }),
+    );
+    memStorage.setWritesFail(true);
+    m.setProviderModelChoice('codex', 'openai', 'model-b', 'xhigh');
+
+    memStorage.setWritesFail(false);
+    m.setProviderModelThinking('pi', 'xd', 'glm-5.3-flash', true);
+    expect(m.getProviderModelChoice('codex', 'openai')).toEqual({
+      model: 'model-b',
+      effort: 'xhigh',
+    });
+  });
+
   it('set/get 往返 + 跨重启持久化', async () => {
     const m1 = await loadModule();
     m1.setProviderModelChoice('claude-code', 'anthropic', 'claude-opus-4-8', 'high');
@@ -133,7 +424,10 @@ describe('providerModelMemory store', () => {
     const m = await loadModule();
     m.setProviderModelChoice('codex', 'openai', 'gpt-5.4', 'high');
     expect(() => m.setProviderModelChoice('codex', 'openai', 'gpt-5.4', 'high')).not.toThrow();
-    expect(m.getProviderModelChoice('codex', 'openai')).toEqual({ model: 'gpt-5.4', effort: 'high' });
+    expect(m.getProviderModelChoice('codex', 'openai')).toEqual({
+      model: 'gpt-5.4',
+      effort: 'high',
+    });
   });
 
   it('空 providerId / model / effort 入参被忽略', async () => {
@@ -360,7 +654,9 @@ describe('providerModelMemory —— clear:恢复推荐删键(不写默认快照
     // 重启后仍是「无记录 ⇒ 跟随目录默认」。
     vi.resetModules();
     const m2 = await loadModule();
-    expect(m2.getProviderModelEffort('claude-code', 'anthropic', 'claude-opus-4-8')).toBeUndefined();
+    expect(
+      m2.getProviderModelEffort('claude-code', 'anthropic', 'claude-opus-4-8'),
+    ).toBeUndefined();
   });
 
   it('clearFast 同理;删的是键而不是写一份显式 false', async () => {

--- a/apps/desktop/src/renderer/__tests__/providerModelMemory.test.ts
+++ b/apps/desktop/src/renderer/__tests__/providerModelMemory.test.ts
@@ -45,9 +45,20 @@ async function loadModule() {
 
 describe('providerModelMemory store', () => {
   it('默认无记录:getProviderModelChoice 返回 undefined', async () => {
-    const { getProviderModelChoice } = await loadModule();
+    const { getProviderModelChoice, hasAnyProviderModelOverride } = await loadModule();
     expect(getProviderModelChoice('claude-code', 'xd')).toBeUndefined();
     expect(getProviderModelChoice('codex', 'openai')).toBeUndefined();
+    expect(hasAnyProviderModelOverride()).toBe(false);
+  });
+
+  it('仅有 effort 或 Fast 记忆也视为既有模型自定义', async () => {
+    const effortMemory = await loadModule();
+    effortMemory.setProviderModelEffort('claude-code', 'anthropic', 'claude-opus-4-8', 'high');
+    expect(effortMemory.hasAnyProviderModelOverride()).toBe(true);
+
+    effortMemory.__resetForTest();
+    effortMemory.setProviderModelFast('codex', 'openai', 'gpt-5.6-sol', false);
+    expect(effortMemory.hasAnyProviderModelOverride()).toBe(true);
   });
 
   it('set/get 往返 + 跨重启持久化', async () => {

--- a/apps/desktop/src/renderer/__tests__/unifiedModelPanelRendering.test.tsx
+++ b/apps/desktop/src/renderer/__tests__/unifiedModelPanelRendering.test.tsx
@@ -783,11 +783,12 @@ describe('统一面板 · 恢复推荐应用到 live 配置', () => {
     return await screen.findByTestId('unified-model-config-flyout');
   }
 
-  it('草稿 live 选中行:清 override 之外,深度 / Fast 走实时回调真的落下去', async () => {
+  it('草稿同引擎恢复推荐:走整行直通且不把推荐档重新写成 override', async () => {
     // 行落在 codex(= 草稿当前引擎,推荐引擎也是 codex),live 深度 low、Fast 开着。
     setModelEngineOverride('xd', 'gpt-5.5', 'cc');
     const onEffortChange = vi.fn();
     const onFastModeChange = vi.fn();
+    const onUnifiedSelect = vi.fn();
     renderPanel({
       vendorKey: 'codex',
       currentProviderId: 'xd',
@@ -796,15 +797,49 @@ describe('统一面板 · 恢复推荐应用到 live 配置', () => {
       fastMode: true,
       onEffortChange,
       onFastModeChange,
+      onUnifiedSelect,
     });
     const flyout = await openFlyoutFor('GPT-5.5');
     await act(async () => {
       fireEvent.click(within(flyout).getByText('恢复推荐'));
     });
     expect(getModelEngineOverride('xd', 'gpt-5.5')).toBeUndefined();
-    // codex 那条目录条目的默认档是 high;推荐态恒无 Fast。
-    expect(onEffortChange).toHaveBeenCalledWith('high');
-    expect(onFastModeChange).toHaveBeenCalledWith(false);
+    expect(onEffortChange).not.toHaveBeenCalled();
+    expect(onFastModeChange).not.toHaveBeenCalled();
+    expect(onUnifiedSelect).toHaveBeenCalledWith({
+      providerId: 'xd',
+      modelId: 'gpt-5.5',
+      effort: 'high',
+      engine: 'codex',
+      fast: false,
+      favoriteUid: null,
+      resetToRecommended: true,
+    });
+  });
+
+  it('草稿跨引擎恢复推荐:把删除 override 的语义完整传到草稿层', async () => {
+    setModelEngineOverride('xd', 'gpt-5.5', 'cc');
+    const onUnifiedSelect = vi.fn();
+    renderPanel({
+      vendorKey: 'cc',
+      currentProviderId: 'xd',
+      modelId: 'gpt-5.5',
+      effort: 'low',
+      onUnifiedSelect,
+    });
+    const flyout = await openFlyoutFor('GPT-5.5');
+    await act(async () => {
+      fireEvent.click(within(flyout).getByText('恢复推荐'));
+    });
+    expect(onUnifiedSelect).toHaveBeenCalledWith({
+      providerId: 'xd',
+      modelId: 'gpt-5.5',
+      effort: 'high',
+      engine: 'codex',
+      fast: false,
+      favoriteUid: null,
+      resetToRecommended: true,
+    });
   });
 
   it('会话内同引擎:同样走实时回调,不走跨引擎事务', async () => {
@@ -982,6 +1017,7 @@ describe('统一面板 · 删除选中的收藏回落到模型默认', () => {
       effort: 'high',
       fast: false,
       favoriteUid: null,
+      resetToRecommended: true,
     });
     expect(listModelFavorites()).toHaveLength(0);
   });
@@ -1266,6 +1302,12 @@ describe('统一面板 · 删除选中的收藏回落到模型默认', () => {
  * 任务还在旧配置上跑。跨引擎那条早就是「事务真成功才收尾」,这一组把同引擎路径拉齐。
  */
 describe('统一面板 · 同引擎实时写入成功才清存储', () => {
+  const sameEngineSession = () => ({
+    currentAgent: 'codex' as const,
+    runtimeAgent: 'codex' as const,
+    onCrossEngineSelect: vi.fn(),
+  });
+
   async function openFlyoutFor(name: string): Promise<HTMLElement> {
     await act(async () => {
       fireEvent.pointerEnter(rowFor(name));
@@ -1281,6 +1323,7 @@ describe('统一面板 · 同引擎实时写入成功才清存储', () => {
     const onEffortChange = vi.fn(() => false);
     const onFastModeChange = vi.fn();
     renderPanel({
+      sessionEngineFilter: sameEngineSession(),
       vendorKey: 'codex',
       currentProviderId: 'xd',
       modelId: 'gpt-5.5',
@@ -1303,6 +1346,7 @@ describe('统一面板 · 同引擎实时写入成功才清存储', () => {
     setModelEngineOverride('xd', 'gpt-5.5', 'cc');
     const onFastModeChange = vi.fn(async () => false);
     renderPanel({
+      sessionEngineFilter: sameEngineSession(),
       vendorKey: 'codex',
       currentProviderId: 'xd',
       modelId: 'gpt-5.5',
@@ -1322,6 +1366,7 @@ describe('统一面板 · 同引擎实时写入成功才清存储', () => {
   it('恢复推荐:两笔都成功才清 override(成功路径回归)', async () => {
     setModelEngineOverride('xd', 'gpt-5.5', 'cc');
     renderPanel({
+      sessionEngineFilter: sameEngineSession(),
       vendorKey: 'codex',
       currentProviderId: 'xd',
       modelId: 'gpt-5.5',
@@ -1379,6 +1424,12 @@ describe('统一面板 · 同引擎实时写入成功才清存储', () => {
  * override / 收藏再度分离。现在第二笔失败要把第一笔按进入前的实时值写回去。
  */
 describe('统一面板 · 两笔实时写入要么都落要么回滚', () => {
+  const sameEngineSession = () => ({
+    currentAgent: 'codex' as const,
+    runtimeAgent: 'codex' as const,
+    onCrossEngineSelect: vi.fn(),
+  });
+
   async function openFlyoutFor(name: string): Promise<HTMLElement> {
     await act(async () => {
       fireEvent.pointerEnter(rowFor(name));
@@ -1391,6 +1442,7 @@ describe('统一面板 · 两笔实时写入要么都落要么回滚', () => {
     const onEffortChange = vi.fn();
     const onFastModeChange = vi.fn(async () => false);
     renderPanel({
+      sessionEngineFilter: sameEngineSession(),
       vendorKey: 'codex',
       currentProviderId: 'xd',
       modelId: 'gpt-5.5',
@@ -1418,6 +1470,7 @@ describe('统一面板 · 两笔实时写入要么都落要么回滚', () => {
       return effortCalls === 1 ? undefined : false;
     });
     renderPanel({
+      sessionEngineFilter: sameEngineSession(),
       vendorKey: 'codex',
       currentProviderId: 'xd',
       modelId: 'gpt-5.5',
@@ -1439,6 +1492,7 @@ describe('统一面板 · 两笔实时写入要么都落要么回滚', () => {
     setModelEngineOverride('xd', 'gpt-5.5', 'cc');
     const onEffortChange = vi.fn(async () => true);
     renderPanel({
+      sessionEngineFilter: sameEngineSession(),
       vendorKey: 'codex',
       currentProviderId: 'xd',
       modelId: 'gpt-5.5',

--- a/apps/desktop/src/renderer/__tests__/unifiedModelPanelRendering.test.tsx
+++ b/apps/desktop/src/renderer/__tests__/unifiedModelPanelRendering.test.tsx
@@ -2203,28 +2203,43 @@ describe('统一面板 · 恢复推荐删记忆键', () => {
   }
 
   it('恢复推荐后记忆槽里没有该键(不是写了一份「等于当前默认」的快照)', async () => {
-    setModelEngineOverride('xd', 'gpt-5.5', 'cc');
+    setModelEngineOverride('openai', 'gpt-5.6', 'cc');
     const memory = makeMemory({
-      effort: { 'codex|xd|gpt-5.5': 'low' },
-      fast: { 'codex|xd|gpt-5.5': true },
+      effort: {
+        'claude-code|openai|chatgpt/gpt-5.6': 'low',
+        'codex|openai|gpt-5.6': 'low',
+        'pi|openrouter|other-model': 'medium',
+      },
+      fast: {
+        'claude-code|openai|chatgpt/gpt-5.6': true,
+        'codex|openai|gpt-5.6': true,
+        'pi|openrouter|other-model': true,
+      },
     });
-    // 选中的是 Opus 5 → GPT-5.5 那一行不是 live 行,只走持久化那一半。
+    // 选中的是 Opus 5 → GPT-5.6 那一行不是 live 行,只走持久化那一半。
     renderPanel({
       modelMemory: memory.accessors,
       currentProviderId: 'anthropic',
       modelId: 'claude-opus-5',
     });
     await act(async () => {
-      fireEvent.pointerEnter(rowFor('GPT-5.5'));
+      fireEvent.pointerEnter(rowFor('GPT-5.6'));
     });
     const flyout = await screen.findByTestId('unified-model-config-flyout');
     await act(async () => {
       fireEvent.click(within(flyout).getByText('恢复推荐'));
     });
-    expect(getModelEngineOverride('xd', 'gpt-5.5')).toBeUndefined();
-    // 键被**删掉**:留一份 'high' / false 的快照就是把这一版的默认固化成用户配置。
-    expect(memory.effort.has('codex|xd|gpt-5.5')).toBe(false);
-    expect(memory.fast.has('codex|xd|gpt-5.5')).toBe(false);
+    expect(getModelEngineOverride('openai', 'gpt-5.6')).toBeUndefined();
+    // 当前 Claude Code bridge 与推荐 Codex root 的 wire ID 不同，两格都必须删除。
+    for (const key of [
+      'claude-code|openai|chatgpt/gpt-5.6',
+      'codex|openai|gpt-5.6',
+    ]) {
+      expect(memory.effort.has(key)).toBe(false);
+      expect(memory.fast.has(key)).toBe(false);
+    }
+    expect(memory.effort.get('pi|openrouter|other-model')).toBe('medium');
+    expect(memory.fast.get('pi|openrouter|other-model')).toBe(true);
   });
 
   it('恢复推荐之后目录默认档变了 → 行展示跟随新默认(不被旧值钉死)', async () => {
@@ -2293,7 +2308,9 @@ describe('统一面板 · 恢复推荐删记忆键', () => {
     await act(async () => {
       fireEvent.click(within(flyout).getByText('恢复推荐'));
     });
+    expect(setEffort).toHaveBeenCalledWith('claude-code', 'xd', 'gpt-5.5', 'medium');
     expect(setEffort).toHaveBeenCalledWith('codex', 'xd', 'gpt-5.5', 'high');
+    expect(setFast).toHaveBeenCalledWith('claude-code', 'xd', 'gpt-5.5', false);
     expect(setFast).toHaveBeenCalledWith('codex', 'xd', 'gpt-5.5', false);
   });
 });

--- a/apps/desktop/src/renderer/components/new-chat/ChatInput.tsx
+++ b/apps/desktop/src/renderer/components/new-chat/ChatInput.tsx
@@ -773,6 +773,8 @@ interface ChatInputProps {
     effort?: Effort;
     fast: boolean;
     favoriteUid: string | null;
+    /** 来自配置浮层「恢复推荐」，不得把推荐档重新写成用户 override。 */
+    resetToRecommended?: true;
   }) => void;
   /**
    * 统一面板里被选中的收藏锚点 uid(与 onUnifiedDraftSelect 成对,由草稿层持有)。
@@ -6621,10 +6623,11 @@ export function ChatInput({
       favoriteUid: string | null;
       /** 行的归一化 id(面板行身份)。草稿层不消费,更不作为发送 id。 */
       rowModelId?: string;
+      resetToRecommended?: true;
     }) => {
       if (sessionId || settingsLocked) return;
       const targetKind = vendorKeyToAgentKind(selection.engine);
-      if (targetKind && selection.providerId) {
+      if (targetKind && selection.providerId && !selection.resetToRecommended) {
         if (selection.effort) {
           modelMemory?.setEffort(
             targetKind,
@@ -6644,6 +6647,7 @@ export function ChatInput({
         ...(selection.effort ? { effort: selection.effort } : {}),
         fast: selection.fast,
         favoriteUid: selection.favoriteUid,
+        ...(selection.resetToRecommended ? { resetToRecommended: true as const } : {}),
       });
     },
     [sessionId, settingsLocked, modelMemory, onUnifiedDraftSelect],

--- a/apps/desktop/src/renderer/components/new-chat/ModelSelector.tsx
+++ b/apps/desktop/src/renderer/components/new-chat/ModelSelector.tsx
@@ -913,6 +913,8 @@ interface ModelSelectorContentProps {
     engine: 'cc' | 'codex' | 'pi';
     fast: boolean;
     favoriteUid: string | null;
+    /** 配置浮层「恢复推荐」的应用动作；调用方应删除 override，不得重新记忆推荐值。 */
+    resetToRecommended?: true;
   }) => void;
   /** 语义同 ModelSelectorProps.reselectEmitsChange(点当前行照常回调)。 */
   reselectEmitsChange?: boolean;
@@ -2852,6 +2854,9 @@ function ModelSelectorContentView({
                   engine: rowConfig.engine,
                   fast: rowConfig.fast,
                   favoriteUid: rowConfig.favoriteUid,
+                  ...(rowConfig.resetToRecommended
+                    ? { resetToRecommended: true as const }
+                    : {}),
                 });
                 closeOptionsPanel();
                 onDismiss?.();

--- a/apps/desktop/src/renderer/components/new-chat/UnifiedModelPanel.tsx
+++ b/apps/desktop/src/renderer/components/new-chat/UnifiedModelPanel.tsx
@@ -103,6 +103,8 @@ export interface UnifiedSelectedRow {
    * 不同的 wire id,用 wire id 当身份会让「换个引擎再打开」认不出是同一行。
    */
   rowModelId: string;
+  /** 该次选中由配置浮层的「恢复推荐」触发；草稿层据此删除 override 而不是重新记忆。 */
+  resetToRecommended?: true;
 }
 
 export interface UnifiedModelPanelProps {

--- a/apps/desktop/src/renderer/components/new-chat/useUnifiedRowActions.ts
+++ b/apps/desktop/src/renderer/components/new-chat/useUnifiedRowActions.ts
@@ -670,11 +670,30 @@ export function useUnifiedRowActions(options: UnifiedRowActionsOptions): Unified
     // 推荐档一律取 M1 已解析的那一份(`UnifiedAgentCapability.defaultEffort`,缺省回落
     // 已经在那边应用过),不在这里另推一遍 —— 两处各推必然漂移。
     const defaultEffort = entry.capabilities[recommendedAgent]?.defaultEffort ?? null;
-    // 恢复推荐是把**推荐引擎**那一格收回默认,故按推荐引擎的 wire id 写(与该行当前
-    // 生效引擎的 wire id 可能不是同一个 id)。
+    // 推荐格与当前生效格的 wire id 可能不同；恢复时两格都要删，避免跨引擎残留继续
+    // 被 hasAnyProviderModelOverride 识别成用户配置。
     const recommendedWireId = wireModelIdOf(entry, recommendedAgent);
 
-    /** 「跟随推荐」的持久化部分:删 override + **删掉**推荐引擎那一格的深度 / Fast 记忆。 */
+    const memorySlots = [
+      {
+        agent: config.agent,
+        wireModelId: config.wireModelId ?? anchor.modelId,
+        defaultEffort: entry.capabilities[config.agent]?.defaultEffort ?? null,
+      },
+      {
+        agent: recommendedAgent,
+        wireModelId: recommendedWireId,
+        defaultEffort,
+      },
+    ].filter(
+      (slot, index, slots) =>
+        slots.findIndex(
+          (candidate) =>
+            candidate.agent === slot.agent && candidate.wireModelId === slot.wireModelId,
+        ) === index,
+    );
+
+    /** 「跟随推荐」的持久化部分:删 override + 删掉当前与推荐引擎两格的深度 / Fast 记忆。 */
     const resetStoredConfig = (): void => {
       clearModelEngineOverride(anchor.providerId, anchor.modelId);
       // ★ 删,不是写快照(2026-08-17 review H3)。记忆表是 override 表:表里没有该键
@@ -683,24 +702,28 @@ export function useUnifiedRowActions(options: UnifiedRowActionsOptions): Unified
       // clearModelEngineOverride 的语义(configuration-and-overrides §4)自相矛盾。
       // 没有删除入口的注入方(device-link 被控端镜像:隧道协议没有「删除」那一笔)退回
       // 既有的快照写法,行为与改动前一致。
-      if (modelMemory?.clearEffort) {
-        modelMemory.clearEffort(recommendedAgent, anchor.providerId, recommendedWireId);
-      } else if (defaultEffort) {
-        modelMemory?.setEffort(
-          recommendedAgent,
-          anchor.providerId,
-          recommendedWireId,
-          defaultEffort,
-        );
+      for (const slot of memorySlots) {
+        if (modelMemory?.clearEffort) {
+          modelMemory.clearEffort(slot.agent, anchor.providerId, slot.wireModelId);
+        } else if (slot.defaultEffort) {
+          modelMemory?.setEffort(
+            slot.agent,
+            anchor.providerId,
+            slot.wireModelId,
+            slot.defaultEffort,
+          );
+        }
       }
       // Fast 无条件收回:`config.fast` 是**当前生效引擎**那一格的值,拿它当门会漏掉「行现在
       // 落在 codex(Fast 关),推荐引擎槽里还留着上次开的 Fast」这一路 —— 恢复推荐后行会
-      // 当场翻回带 ⚡ 的样子。清的槽与上面的深度一样按推荐引擎 + 推荐引擎 wire id 走。
+      // 当场翻回带 ⚡ 的样子。当前格与推荐格都按各自 wire id 收回。
       // 记忆表缺省即「关」,所以删除与写 false 的显示等价,但删除不会把「关」固化成用户配置。
-      if (modelMemory?.clearFast) {
-        modelMemory.clearFast(recommendedAgent, anchor.providerId, recommendedWireId);
-      } else {
-        modelMemory?.setFast(recommendedAgent, anchor.providerId, recommendedWireId, false);
+      for (const slot of memorySlots) {
+        if (modelMemory?.clearFast) {
+          modelMemory.clearFast(slot.agent, anchor.providerId, slot.wireModelId);
+        } else {
+          modelMemory?.setFast(slot.agent, anchor.providerId, slot.wireModelId, false);
+        }
       }
     };
 

--- a/apps/desktop/src/renderer/components/new-chat/useUnifiedRowActions.ts
+++ b/apps/desktop/src/renderer/components/new-chat/useUnifiedRowActions.ts
@@ -388,6 +388,7 @@ export function useUnifiedRowActions(options: UnifiedRowActionsOptions): Unified
       fast: false,
       favoriteUid: null,
       rowModelId: args.anchor.modelId,
+      resetToRecommended: true,
     });
   };
 
@@ -709,6 +710,20 @@ export function useUnifiedRowActions(options: UnifiedRowActionsOptions): Unified
       return;
     }
 
+    // 本地/被控端草稿没有会话运行态；即使推荐引擎没变，也必须走草稿整行直通。
+    // 走 effort/Fast live 回调会先把推荐档重新写进记忆并再次打上 tuning custom，随后
+    // resetStoredConfig 虽删掉记忆键，却没有入口撤销草稿层的 custom lock。
+    if (!inSession) {
+      resetStoredConfig();
+      applyDefaultsToDraft({
+        anchor,
+        engine: recommendedEngine,
+        wireModelId: recommendedWireId,
+        effort: defaultEffort,
+      });
+      return;
+    }
+
     // ★ live 选中行还得把推荐配置**真的应用到正在跑的那一份**(2026-08-17 review):
     // 会话的实时深度 / Fast、草稿的 vendor+model 配置都**不读记忆表**(选中行读的是 live 值,
     // 见 UnifiedModelPanel.configOf)。只清记忆的话,用户点完「恢复推荐」当前任务照旧用着
@@ -746,14 +761,6 @@ export function useUnifiedRowActions(options: UnifiedRowActionsOptions): Unified
       });
       return;
     }
-    // 草稿换引擎无损:先落 override / 记忆,再把推荐引擎的整份配置按既有选中链路写回草稿。
-    resetStoredConfig();
-    applyDefaultsToDraft({
-      anchor,
-      engine: recommendedEngine,
-      wireModelId: recommendedWireId,
-      effort: defaultEffort,
-    });
   };
 
   const addFavorite: UnifiedRowActions['addFavorite'] = (anchor, config) => {

--- a/apps/desktop/src/renderer/contexts/AuthContext.tsx
+++ b/apps/desktop/src/renderer/contexts/AuthContext.tsx
@@ -42,6 +42,7 @@ import { isSidebarWindow } from '@/lib/sidebarWindow';
 import { isGhostPanelWindow } from '@/lib/ghostPanelWindow';
 import { setModelEnginePrefsOwner } from '@/state/modelEnginePrefs';
 import { setModelFavoritesOwner } from '@/state/modelFavorites';
+import { setProviderModelMemoryOwner } from '@/state/providerModelMemory';
 import { setFavoriteAnchorMemoryOwner } from '@/state/favoriteAnchorMemory';
 import { setNewMakerDraftOwner } from '@/state/newMakerDraft';
 import { setModelVisibilityOwner } from '@/state/modelVisibilityPrefs';
@@ -191,7 +192,8 @@ export function AuthProvider({
       activeDataOwnerIdRef.current = state.dataOwnerId;
       activeDataOwnerGenerationRef.current = state.ownerGeneration;
       setNewMakerDraftOwner(state.dataOwnerId);
-      // 统一模型选择器的两根新轴与 newMakerDraft 同待遇:同一处、同一个 dataOwnerId、
+      setProviderModelMemoryOwner(state.dataOwnerId);
+      // 模型选择器的持久记忆与 newMakerDraft 同待遇:同一处、同一个 dataOwnerId、
       // 登出时同样传 null(state.dataOwnerId 在 signed-out 快照里就是 null,分区键退回
       // 无后缀的默认槽)。漏接 = 多账号串号(providerModelMemory 的旧教训)。
       setModelEnginePrefsOwner(state.dataOwnerId);

--- a/apps/desktop/src/renderer/features/cc-agent/NewMakerDraftRoute.tsx
+++ b/apps/desktop/src/renderer/features/cc-agent/NewMakerDraftRoute.tsx
@@ -4,10 +4,10 @@
  * 职责:
  *   1. 从 newMakerDraft store 读取 vendor / workingDir / lastByVendor
  *   2. 渲染 CREATE AGENT 主区:lockup + ChatInput(sessionId=undefined) + 快速开始
- *   3. 用户切 vendor → switchVendor() 把当前 prefs 落地 lastByVendor[oldVendor]
- *      + 切到新 vendor 后 ChatInput 的 initialModel/Effort/PermissionMode 自动
+ *   3. 用户切 vendor → switchVendor() 保留已同步的当前 prefs 并切到新 vendor，
+ *      ChatInput 的 initialModel/Effort/PermissionMode 自动
  *      由 lastByVendor[newVendor] 提供
- *   4. 用户改 model/effort/permissionMode → patchCurrentVendorPrefs(局部更新)
+ *   4. 用户改 model/effort/permissionMode → patchVendorPrefs(按界面 Harness 局部更新)
  *   5. 用户改 workingDir → patchDraft({ workingDir })
  *
  * workspace 选择:
@@ -82,7 +82,6 @@ import {
   getDraft,
   patchDraft,
   patchCollab,
-  patchCurrentVendorPrefs,
   patchVendorPrefs,
   patchVendorPrefsPreservingModelChoice,
   applySuggestedDefaultTuple,
@@ -2465,7 +2464,7 @@ export function NewMakerDraftRoute() {
         }
         // 草稿里选中的那条收藏跟着会话走(见 carryDraftFavoriteAnchorToSession)。
         carryDraftFavoriteAnchorToSession(newSession.id, draftVendor, sshModel, sshProviderId);
-        if (effectivePlanMode) patchCurrentVendorPrefs({ planMode: false });
+        if (effectivePlanMode) patchVendorPrefs(draftVendor, { planMode: false });
         makerChatStore.setSessionRuntime(newSession.id, {
           agentKind: dbToMakerAgentKind(draftVendor),
           fastMode: sshFastMode,
@@ -2558,16 +2557,13 @@ export function NewMakerDraftRoute() {
   );
 
   // ─── 切 vendor ──────────────────────────────────────────────────────
-  // 把"当前 vendor 的最新 prefs"落进 lastByVendor[oldVendor],然后切到新 vendor。
+  // 当前 vendor 的 prefs 已由 patchActivePrefs 同步进草稿；这里只切到新 vendor。
   // ChatInput 的 initial* 由父级传入,vendor 切换后 ChatInput 重新 mount(key 变化)
   // 自动 pickup 新 vendor 的 lastByVendor 值。
-  const handleVendorChange = useCallback(
-    (next: MakerVendor) => {
-      markDefaultTupleCustomized();
-      switchVendor(next, currentPrefs);
-    },
-    [currentPrefs],
-  );
+  const handleVendorChange = useCallback((next: MakerVendor) => {
+    markDefaultTupleCustomized();
+    switchVendor(next);
+  }, []);
 
   // 当前草稿选中的 vendor 变为不可用(如 Pi 未注册 / 被控端无 Pi)时,coerce 到首个可用来源
   // (优先 cc),避免 tablist 卡在被隐藏段、且防止创建出注定 requireAgent 报错的会话。
@@ -2578,9 +2574,24 @@ export function NewMakerDraftRoute() {
   }, [availableAgentsLoaded, availableVendors]);
 
   // ─── 用户在 ChatInput 改 model/effort/permission 后,落进当前 vendor 的 prefs ──
-  const patchActivePrefs = useCallback((patch: Partial<VendorPrefs>) => {
-    patchCurrentVendorPrefs(patch);
-  }, []);
+  // 权限 / 计划模式不是默认模型 tuple：按界面 Harness 的槽写，但不改变 storage 中最新
+  // Harness。这样旧窗口的无关字段写入只 rebase，不会反向改掉另一窗口刚恢复的推荐。
+  const patchActivePrefs = useCallback(
+    (patch: Partial<VendorPrefs>) => {
+      patchVendorPrefs(draft.vendor, patch);
+    },
+    [draft.vendor],
+  );
+  const patchActiveTuplePrefs = useCallback(
+    (patch: Partial<VendorPrefs>) => {
+      // draft.vendor 是用户触发控件时眼前的 Harness，必须作为这次操作的明确意图带进
+      // store。另一个 renderer 可能已切换持久 tuple；先 rebase 并切回意图 Harness，
+      // 再按显式槽写入，避免把 cc 控件的值静默落进 Pi。
+      switchVendor(draft.vendor);
+      patchVendorPrefs(draft.vendor, patch);
+    },
+    [draft.vendor],
+  );
 
   const handleModelDidChange = useCallback(
     (newModelId: string) => {
@@ -2608,11 +2619,17 @@ export function NewMakerDraftRoute() {
         return;
       }
       markDefaultTupleCustomized();
-      patchActivePrefs({ model: newModelId });
+      patchActiveTuplePrefs({ model: newModelId });
       // 本地草稿的 Fast 直接由「新 model + 全局预设 + 来源能力」派生,patch 后同步收敛,
       // 不再维护一份可能与其它对话更新脱节的本地 state。
     },
-    [isDeviceLinkDraft, capabilities, remoteDraftState, patchActivePrefs, capabilityAgentKind],
+    [
+      isDeviceLinkDraft,
+      capabilities,
+      remoteDraftState,
+      patchActiveTuplePrefs,
+      capabilityAgentKind,
+    ],
   );
   const handleFastModeChange = useCallback(
     (enabled: boolean) => {
@@ -2626,6 +2643,9 @@ export function NewMakerDraftRoute() {
         return;
       }
       markDefaultTupleCustomized(false);
+      // Fast 也是当前可见模型组合的显式意图；旧窗口必须先从持久化的新 Harness
+      // 切回用户眼前的 Harness，再写该界面的 provider/model 记忆。
+      switchVendor(draft.vendor);
       // 权威库:per-(agent, 来源, 模型),与 resolveDraftFast 的读源对齐(ModelSelector 的 Edit 面板
       // 对选中模型也会写这一份;此处显式写一遍,使 onFastModeChange 走任何路径都自洽、不依赖选择器侧写)。
       // 写入键必须与 effectiveFastMode 的读取键同源:两者都用**校准后**的模型。若这里仍写
@@ -2639,6 +2659,7 @@ export function NewMakerDraftRoute() {
     },
     [
       isDeviceLinkDraft,
+      draft.vendor,
       calibratedDraftModel,
       supportsFastMode,
       effectiveSourceId,
@@ -2655,9 +2676,9 @@ export function NewMakerDraftRoute() {
         return;
       }
       markDefaultTupleCustomized(false);
-      patchActivePrefs({ effort: newEffort });
+      patchActiveTuplePrefs({ effort: newEffort });
     },
-    [isDeviceLinkDraft, patchActivePrefs, pushActiveDraftPref],
+    [isDeviceLinkDraft, patchActiveTuplePrefs, pushActiveDraftPref],
   );
   // ChatInput 内部决策完 newEffort 时回写这里, 让"每个 modelId 上次的 effort"
   // 跨 ChatInput 实例 / 跨重启保留 (修复: New Maker 先选 Haiku 发完, 再 New Maker
@@ -2700,9 +2721,9 @@ export function NewMakerDraftRoute() {
         return;
       }
       markDefaultTupleCustomized();
-      patchActivePrefs({ providerId: newProviderId });
+      patchActiveTuplePrefs({ providerId: newProviderId });
     },
-    [isDeviceLinkDraft, patchActivePrefs],
+    [isDeviceLinkDraft, patchActiveTuplePrefs],
   );
 
   // ─── 统一模型选择器:一次选中 = 一次完整写入 ─────────────────────────────
@@ -2746,7 +2767,9 @@ export function NewMakerDraftRoute() {
             }
           : null,
       );
-      if (selection.vendor !== draft.vendor) switchVendor(selection.vendor, currentPrefs);
+      // 必须无条件进入 store 的 rebase：当前 renderer 的 draft.vendor 可能还停在 storage
+      // event 到达前的旧 Harness。switchVendor 自身同值早返，不会制造额外写入。
+      switchVendor(selection.vendor);
       if (isDeviceLinkDraft) {
         dlRuntimeTouchedRef.current = true;
         // ★ 跨引擎选择必须**前置**把 seed key 推到目标引擎(2026-08-17 review 第三轮 G1)。
@@ -2846,7 +2869,6 @@ export function NewMakerDraftRoute() {
     },
     [
       draft.vendor,
-      currentPrefs,
       isDeviceLinkDraft,
       effectiveDeviceLinkDeviceId,
       deviceLinkInitial,

--- a/apps/desktop/src/renderer/features/cc-agent/NewMakerDraftRoute.tsx
+++ b/apps/desktop/src/renderer/features/cc-agent/NewMakerDraftRoute.tsx
@@ -2830,7 +2830,13 @@ export function NewMakerDraftRoute() {
         // 只调过 effort / Fast 的用户在记忆键被删后重新跟随产品默认；已有模型 / 来源 /
         // Harness 选择仍由 selection marker 保护。
         patchVendorPrefsPreservingModelChoice(selection.vendor, nextPrefs);
-        clearDefaultTupleTuningCustomization();
+        clearDefaultTupleTuningCustomization({
+          modelId: selection.modelId,
+          // resetStoredConfig 已同步删除当前行三类 override；这里重读完整 store，只有其它行也
+          // 没有留下用户配置时才允许后续授权 / 推荐变化重新应用产品默认。
+          hasExternalOverrides:
+            hasAnyModelEngineOverride() || hasAnyProviderModelOverride(),
+        });
       } else {
         markDefaultTupleCustomized();
         // 本地草稿:一次写进目标 vendor 的槽。走 patchVendorPrefs(不是 Preserving 版)——

--- a/apps/desktop/src/renderer/features/cc-agent/NewMakerDraftRoute.tsx
+++ b/apps/desktop/src/renderer/features/cc-agent/NewMakerDraftRoute.tsx
@@ -84,9 +84,11 @@ import {
   patchCollab,
   patchCurrentVendorPrefs,
   patchVendorPrefs,
+  patchVendorPrefsPreservingModelChoice,
   applySuggestedDefaultTuple,
   fallbackUnavailableVendor,
   markDefaultTupleCustomized,
+  clearDefaultTupleTuningCustomization,
   resetDraftWorkspaceTargets,
   getFastModeForModel,
   setFastModeForModel,
@@ -2623,7 +2625,7 @@ export function NewMakerDraftRoute() {
       if (!supportsFastMode) {
         return;
       }
-      markDefaultTupleCustomized();
+      markDefaultTupleCustomized(false);
       // 权威库:per-(agent, 来源, 模型),与 resolveDraftFast 的读源对齐(ModelSelector 的 Edit 面板
       // 对选中模型也会写这一份;此处显式写一遍,使 onFastModeChange 走任何路径都自洽、不依赖选择器侧写)。
       // 写入键必须与 effectiveFastMode 的读取键同源:两者都用**校准后**的模型。若这里仍写
@@ -2652,7 +2654,7 @@ export function NewMakerDraftRoute() {
         pushActiveDraftPref({ effort: newEffort }); // 选中模型 effort 写穿被控端
         return;
       }
-      markDefaultTupleCustomized();
+      markDefaultTupleCustomized(false);
       patchActivePrefs({ effort: newEffort });
     },
     [isDeviceLinkDraft, patchActivePrefs, pushActiveDraftPref],
@@ -2726,6 +2728,7 @@ export function NewMakerDraftRoute() {
       effort?: Effort;
       fast: boolean;
       favoriteUid: string | null;
+      resetToRecommended?: true;
     }) => {
       // 收藏锚点写进**目标引擎的槽**(Chris 2026-08-19 起持久化,见 draftFavoriteAnchor 的
       // 说明):记的是 uid + **本次写进草稿的 wire id**,失效判定才有可比的同类值。
@@ -2817,15 +2820,23 @@ export function NewMakerDraftRoute() {
         );
         return;
       }
-      markDefaultTupleCustomized();
-      // 本地草稿:一次写进目标 vendor 的槽。走 patchVendorPrefs(不是 Preserving 版)——
-      // 这是用户在 New Maker picker 里的**显式**模型选择,modelChosenByVendor 必须打标
-      // (scheduler 的成本兜底默认模型依赖它)。
-      patchVendorPrefs(selection.vendor, {
+      const nextPrefs = {
         model: selection.modelId,
         providerId: selection.providerId,
         ...(selection.effort ? { effort: selection.effort } : {}),
-      });
+      };
+      if (selection.resetToRecommended) {
+        // 恢复推荐沿既有选择链把推荐配置真正应用到草稿，但不能把它重新记成显式选择。
+        // 只调过 effort / Fast 的用户在记忆键被删后重新跟随产品默认；已有模型 / 来源 /
+        // Harness 选择仍由 selection marker 保护。
+        patchVendorPrefsPreservingModelChoice(selection.vendor, nextPrefs);
+        clearDefaultTupleTuningCustomization();
+      } else {
+        markDefaultTupleCustomized();
+        // 本地草稿:一次写进目标 vendor 的槽。走 patchVendorPrefs(不是 Preserving 版)——
+        // 这是用户在 New Maker picker 里的**显式**模型选择,modelChosenByVendor 必须打标。
+        patchVendorPrefs(selection.vendor, nextPrefs);
+      }
     },
     [
       draft.vendor,

--- a/apps/desktop/src/renderer/features/cc-agent/NewMakerDraftRoute.tsx
+++ b/apps/desktop/src/renderer/features/cc-agent/NewMakerDraftRoute.tsx
@@ -85,6 +85,7 @@ import {
   patchCurrentVendorPrefs,
   patchVendorPrefs,
   applySuggestedDefaultTuple,
+  fallbackUnavailableVendor,
   markDefaultTupleCustomized,
   resetDraftWorkspaceTargets,
   getFastModeForModel,
@@ -107,6 +108,7 @@ import {
 import {
   getProviderModelEffort,
   getProviderModelFast,
+  hasAnyProviderModelOverride,
   setProviderModelFast,
   useProviderModelMemoryVersion,
 } from '@/state/providerModelMemory';
@@ -1206,9 +1208,10 @@ export function NewMakerDraftRoute() {
   // 本地草稿用本机 providers。fast 判定统一交给 resolveFastSupported(不在控制端另写远程逻辑)。
   const { providers: localProviders, loading: localProvidersLoading } = useProviders();
   const modelEnginePrefsVersion = useModelEnginePrefsVersion();
-  const hasLegacyHarnessChoice = useMemo(
-    () => hasAnyModelEngineOverride(),
-    [modelEnginePrefsVersion],
+  const modelPresetVersion = useProviderModelMemoryVersion();
+  const hasLegacyDefaultChoice = useMemo(
+    () => hasAnyModelEngineOverride() || hasAnyProviderModelOverride(),
+    [modelEnginePrefsVersion, modelPresetVersion],
   );
   const suggestedDefaultTuple = useMemo(
     () =>
@@ -1226,7 +1229,7 @@ export function NewMakerDraftRoute() {
       !suggestedDefaultTuple ||
       effectiveDeviceLinkDeviceId ||
       draft.remoteHostId ||
-      hasLegacyHarnessChoice
+      hasLegacyDefaultChoice
     )
       return;
     applySuggestedDefaultTuple(suggestedDefaultTuple);
@@ -1234,7 +1237,7 @@ export function NewMakerDraftRoute() {
     suggestedDefaultTuple,
     effectiveDeviceLinkDeviceId,
     draft.remoteHostId,
-    hasLegacyHarnessChoice,
+    hasLegacyDefaultChoice,
   ]);
   const {
     providers: deviceProviders,
@@ -1379,7 +1382,6 @@ export function NewMakerDraftRoute() {
   // 首页是“下一次创建会话”的配置草稿,没有正在运行的当前模型需要保护。其它对话更新同一模型
   // 的全局预设后,即使该模型正显示在首页 trigger 上,也应立即采用新 effort / fast。真实会话仍
   // 由 CCAgentSessionView 的 live DB/runtime props 保护,不会走这里。
-  const modelPresetVersion = useProviderModelMemoryVersion();
   const localDraftEffort = useMemo<Effort>(() => {
     if (isDeviceLinkDraft || !effectiveSourceId) return chatPrefs.effort;
     const provider = providers.find((item) => item.id === effectiveSourceId);
@@ -2570,18 +2572,8 @@ export function NewMakerDraftRoute() {
   // 只在已加载可用性后收敛;fallback 一定可见,收敛一次即稳定(switchVendor 同值早返,不成环)。
   useEffect(() => {
     if (!availableAgentsLoaded) return;
-    if (!hiddenSwitcherVendors.includes(draft.vendor)) return;
-    const fallback = (['cc', 'codex', 'pi'] as const).find((vendor) =>
-      availableVendors.has(vendor),
-    );
-    if (fallback && fallback !== draft.vendor) switchVendor(fallback, currentPrefs);
-  }, [
-    availableAgentsLoaded,
-    hiddenSwitcherVendors,
-    availableVendors,
-    draft.vendor,
-    currentPrefs,
-  ]);
+    fallbackUnavailableVendor(availableVendors);
+  }, [availableAgentsLoaded, availableVendors]);
 
   // ─── 用户在 ChatInput 改 model/effort/permission 后,落进当前 vendor 的 prefs ──
   const patchActivePrefs = useCallback((patch: Partial<VendorPrefs>) => {

--- a/apps/desktop/src/renderer/features/cc-agent/NewMakerDraftRoute.tsx
+++ b/apps/desktop/src/renderer/features/cc-agent/NewMakerDraftRoute.tsx
@@ -84,6 +84,8 @@ import {
   patchCollab,
   patchCurrentVendorPrefs,
   patchVendorPrefs,
+  applySuggestedDefaultTuple,
+  markDefaultTupleCustomized,
   resetDraftWorkspaceTargets,
   getFastModeForModel,
   setFastModeForModel,
@@ -92,6 +94,10 @@ import {
   type VendorPrefs,
   type CollabDraft,
 } from '@/state/newMakerDraft';
+import {
+  hasAnyModelEngineOverride,
+  useModelEnginePrefsVersion,
+} from '@/state/modelEnginePrefs';
 import {
   setDraftFavoriteAnchor,
   setSessionFavoriteAnchor,
@@ -124,6 +130,7 @@ import {
   resolveDraftSessionProviderId,
   type DraftModelCalibrationResult,
 } from '@/lib/draftModelCalibration';
+import { resolveNewMakerDefaultTuple } from '@/lib/newMakerDefaultTuple';
 import { showWorktreeError } from '@/lib/worktreeToast';
 import * as sessionService from '@/lib/sessionService';
 import { sessionsStore } from '@/lib/sessionsStore';
@@ -1198,6 +1205,37 @@ export function NewMakerDraftRoute() {
   // device-link「以被控端为准」:远程草稿用被控端经隧道带来的 providers(per-provider,含 fast 能力);
   // 本地草稿用本机 providers。fast 判定统一交给 resolveFastSupported(不在控制端另写远程逻辑)。
   const { providers: localProviders, loading: localProvidersLoading } = useProviders();
+  const modelEnginePrefsVersion = useModelEnginePrefsVersion();
+  const hasLegacyHarnessChoice = useMemo(
+    () => hasAnyModelEngineOverride(),
+    [modelEnginePrefsVersion],
+  );
+  const suggestedDefaultTuple = useMemo(
+    () =>
+      resolveNewMakerDefaultTuple({
+        providers: localProviders,
+        providersLoading: localProvidersLoading,
+        availableAgents: availableVendors,
+        availableAgentsLoaded,
+      }),
+    [localProviders, localProvidersLoading, availableVendors, availableAgentsLoaded],
+  );
+  useEffect(() => {
+    // 远程主机 / device-link 的可用 Harness 与来源属于执行端，不能拿控制端本机登录态替它选。
+    if (
+      !suggestedDefaultTuple ||
+      effectiveDeviceLinkDeviceId ||
+      draft.remoteHostId ||
+      hasLegacyHarnessChoice
+    )
+      return;
+    applySuggestedDefaultTuple(suggestedDefaultTuple);
+  }, [
+    suggestedDefaultTuple,
+    effectiveDeviceLinkDeviceId,
+    draft.remoteHostId,
+    hasLegacyHarnessChoice,
+  ]);
   const {
     providers: deviceProviders,
     loading: deviceProvidersLoading,
@@ -1209,7 +1247,7 @@ export function NewMakerDraftRoute() {
   // 一一对应,工具条的引擎下拉必须按后者(active)决定去留:
   //   · capable(本变量)—— 联合列表只认供应商目录,老被控端(不支持 provider:list)只有
   //     一份拍平 capabilities → 开了就是空列表,composer 那边会降级回旧面板;
-  //   · active —— 再叠上形态偏好(modelPickerLayout,默认 'original' = 最原始选择器)。
+  //   · active —— 再叠上形态偏好(modelPickerLayout,默认 'classic' = A 版统一选择器)。
   // 旧面板是「先选引擎再选模型」,所以只要没真正启用统一面板,就必须把工具条上的引擎下拉
   // 还回来 —— 否则那条链路上根本换不了引擎(只按 capable 撤掉时,默认形态下的新建草稿
   // 就彻底没有换引擎入口)。统一面板真启用时不注入(引擎跟着模型走)。
@@ -2521,6 +2559,7 @@ export function NewMakerDraftRoute() {
   // 自动 pickup 新 vendor 的 lastByVendor 值。
   const handleVendorChange = useCallback(
     (next: MakerVendor) => {
+      markDefaultTupleCustomized();
       switchVendor(next, currentPrefs);
     },
     [currentPrefs],
@@ -2535,13 +2574,13 @@ export function NewMakerDraftRoute() {
     const fallback = (['cc', 'codex', 'pi'] as const).find((vendor) =>
       availableVendors.has(vendor),
     );
-    if (fallback && fallback !== draft.vendor) handleVendorChange(fallback);
+    if (fallback && fallback !== draft.vendor) switchVendor(fallback, currentPrefs);
   }, [
     availableAgentsLoaded,
     hiddenSwitcherVendors,
     availableVendors,
     draft.vendor,
-    handleVendorChange,
+    currentPrefs,
   ]);
 
   // ─── 用户在 ChatInput 改 model/effort/permission 后,落进当前 vendor 的 prefs ──
@@ -2574,6 +2613,7 @@ export function NewMakerDraftRoute() {
         }));
         return;
       }
+      markDefaultTupleCustomized();
       patchActivePrefs({ model: newModelId });
       // 本地草稿的 Fast 直接由「新 model + 全局预设 + 来源能力」派生,patch 后同步收敛,
       // 不再维护一份可能与其它对话更新脱节的本地 state。
@@ -2591,6 +2631,7 @@ export function NewMakerDraftRoute() {
       if (!supportsFastMode) {
         return;
       }
+      markDefaultTupleCustomized();
       // 权威库:per-(agent, 来源, 模型),与 resolveDraftFast 的读源对齐(ModelSelector 的 Edit 面板
       // 对选中模型也会写这一份;此处显式写一遍,使 onFastModeChange 走任何路径都自洽、不依赖选择器侧写)。
       // 写入键必须与 effectiveFastMode 的读取键同源:两者都用**校准后**的模型。若这里仍写
@@ -2619,6 +2660,7 @@ export function NewMakerDraftRoute() {
         pushActiveDraftPref({ effort: newEffort }); // 选中模型 effort 写穿被控端
         return;
       }
+      markDefaultTupleCustomized();
       patchActivePrefs({ effort: newEffort });
     },
     [isDeviceLinkDraft, patchActivePrefs, pushActiveDraftPref],
@@ -2663,6 +2705,7 @@ export function NewMakerDraftRoute() {
         setDlSel((prev) => (prev ? { ...prev, providerId: newProviderId } : prev));
         return;
       }
+      markDefaultTupleCustomized();
       patchActivePrefs({ providerId: newProviderId });
     },
     [isDeviceLinkDraft, patchActivePrefs],
@@ -2782,6 +2825,7 @@ export function NewMakerDraftRoute() {
         );
         return;
       }
+      markDefaultTupleCustomized();
       // 本地草稿:一次写进目标 vendor 的槽。走 patchVendorPrefs(不是 Preserving 版)——
       // 这是用户在 New Maker picker 里的**显式**模型选择,modelChosenByVendor 必须打标
       // (scheduler 的成本兜底默认模型依赖它)。

--- a/apps/desktop/src/renderer/lib/__tests__/newMakerDefaultTuple.test.ts
+++ b/apps/desktop/src/renderer/lib/__tests__/newMakerDefaultTuple.test.ts
@@ -109,7 +109,7 @@ describe('resolveNewMakerDefaultTuple', () => {
       expected: { vendor: 'pi', providerId: 'xai', model: 'grok-4.6', effort: 'high' },
     },
     {
-      name: '中国区 Gateway',
+      name: 'Cindy Gateway（CN / Global）',
       source: provider({
         id: 'xd',
         access: 'managed',
@@ -183,7 +183,7 @@ describe('resolveNewMakerDefaultTuple', () => {
     });
   });
 
-  it('Gateway 没有服务端区域默认标记时保持空态', () => {
+  it('Gateway 没有服务端默认标记时保持空态', () => {
     const gateway = provider({
       id: 'xd',
       access: 'managed',

--- a/apps/desktop/src/renderer/lib/__tests__/newMakerDefaultTuple.test.ts
+++ b/apps/desktop/src/renderer/lib/__tests__/newMakerDefaultTuple.test.ts
@@ -118,11 +118,11 @@ describe('resolveNewMakerDefaultTuple', () => {
         id: 'xd',
         access: 'managed',
         models: {
-          codex: [model('z-ai/glm-5.3-flash', 'high', ['codex'], ['text', 'image'])],
+          pi: [model('z-ai/glm-5.3-flash', 'high', ['pi'], ['text', 'image'])],
         },
       }),
       expected: {
-        vendor: 'codex',
+        vendor: 'pi',
         providerId: 'xd',
         model: 'z-ai/glm-5.3-flash',
         effort: 'high',
@@ -137,7 +137,7 @@ describe('resolveNewMakerDefaultTuple', () => {
       id: 'xd',
       access: 'managed',
       models: {
-        codex: [model('z-ai/glm-5.3-flash', 'high', ['codex'], ['text', 'image'])],
+        pi: [model('z-ai/glm-5.3-flash', 'high', ['pi'], ['text', 'image'])],
       },
     });
     const anthropic = provider({
@@ -153,6 +153,27 @@ describe('resolveNewMakerDefaultTuple', () => {
     expect(resolve([gateway, anthropic, openai])).toMatchObject({
       vendor: 'codex',
       providerId: 'openai',
+    });
+  });
+
+  it('本机 xAI 订阅优先于 Gateway，不会被 GLM 默认改写', () => {
+    const gateway = provider({
+      id: 'xd',
+      access: 'managed',
+      models: {
+        pi: [model('z-ai/glm-5.3-flash', 'high', ['pi'], ['text', 'image'])],
+      },
+    });
+    const xai = provider({
+      id: 'xai',
+      access: 'subscription',
+      models: { pi: [model('grok-4.6')] },
+    });
+    expect(resolve([gateway, xai])).toEqual({
+      vendor: 'pi',
+      providerId: 'xai',
+      model: 'grok-4.6',
+      effort: 'high',
     });
   });
 
@@ -184,12 +205,12 @@ describe('resolveNewMakerDefaultTuple', () => {
       id: 'xd',
       access: 'managed',
       models: {
-        codex: [model('z-ai/glm-5.3-flash', 'high', ['codex'], ['text', 'image'])],
+        pi: [model('z-ai/glm-5.3-flash', 'high', ['pi'], ['text', 'image'])],
       },
     });
     expect(resolve([failedOpenai, gateway])).toMatchObject({
       providerId: 'xd',
-      vendor: 'codex',
+      vendor: 'pi',
     });
   });
 
@@ -198,7 +219,18 @@ describe('resolveNewMakerDefaultTuple', () => {
       id: 'xd',
       access: 'managed',
       models: {
-        codex: [model('z-ai/glm-5.3-flash', 'high', undefined, ['text', 'image'])],
+        pi: [model('z-ai/glm-5.3-flash', 'high', undefined, ['text', 'image'])],
+      },
+    });
+    expect(resolve([gateway])).toBeNull();
+  });
+
+  it('Gateway 只有旧 Codex 标记时不把 GLM 默认塞进其它 Harness', () => {
+    const gateway = provider({
+      id: 'xd',
+      access: 'managed',
+      models: {
+        codex: [model('z-ai/glm-5.3-flash', 'high', ['codex'], ['text', 'image'])],
       },
     });
     expect(resolve([gateway])).toBeNull();
@@ -208,8 +240,17 @@ describe('resolveNewMakerDefaultTuple', () => {
     const gateway = provider({
       id: 'xd',
       access: 'managed',
-      models: { codex: [model('z-ai/glm-5.3-flash', 'high', ['codex'], ['text'])] },
+      models: { pi: [model('z-ai/glm-5.3-flash', 'high', ['pi'], ['text'])] },
     });
     expect(resolve([gateway])).toBeNull();
+  });
+
+  it('推荐模型不支持 high 时不静默降档为默认组合', () => {
+    const openai = provider({
+      id: 'openai',
+      access: 'subscription',
+      models: { codex: [model('chatgpt/gpt-5.6-sol', 'medium')] },
+    });
+    expect(resolve([openai])).toBeNull();
   });
 });

--- a/apps/desktop/src/renderer/lib/__tests__/newMakerDefaultTuple.test.ts
+++ b/apps/desktop/src/renderer/lib/__tests__/newMakerDefaultTuple.test.ts
@@ -8,6 +8,7 @@ function model(
   id: string,
   effort: CatalogModel['defaultEffort'] = 'high',
   newSessionDefault?: CatalogModel['newSessionDefault'],
+  inputModalities?: string[],
 ): CatalogModel {
   return {
     id,
@@ -16,6 +17,9 @@ function model(
     efforts: effort ? [effort] : [],
     defaultEffort: effort,
     newSessionDefault,
+    ...(inputModalities
+      ? { modalities: { input: inputModalities, output: ['text'] } }
+      : {}),
   };
 }
 
@@ -113,12 +117,14 @@ describe('resolveNewMakerDefaultTuple', () => {
       source: provider({
         id: 'xd',
         access: 'managed',
-        models: { codex: [model('deepseek/deepseek-v4-pro', 'high', ['codex'])] },
+        models: {
+          codex: [model('z-ai/glm-5.3-flash', 'high', ['codex'], ['text', 'image'])],
+        },
       }),
       expected: {
         vendor: 'codex',
         providerId: 'xd',
-        model: 'deepseek/deepseek-v4-pro',
+        model: 'z-ai/glm-5.3-flash',
         effort: 'high',
       },
     },
@@ -130,7 +136,9 @@ describe('resolveNewMakerDefaultTuple', () => {
     const gateway = provider({
       id: 'xd',
       access: 'managed',
-      models: { codex: [model('deepseek/deepseek-v4-pro', 'high', ['codex'])] },
+      models: {
+        codex: [model('z-ai/glm-5.3-flash', 'high', ['codex'], ['text', 'image'])],
+      },
     });
     const anthropic = provider({
       id: 'anthropic',
@@ -175,7 +183,9 @@ describe('resolveNewMakerDefaultTuple', () => {
     const gateway = provider({
       id: 'xd',
       access: 'managed',
-      models: { codex: [model('deepseek/deepseek-v4-pro', 'high', ['codex'])] },
+      models: {
+        codex: [model('z-ai/glm-5.3-flash', 'high', ['codex'], ['text', 'image'])],
+      },
     });
     expect(resolve([failedOpenai, gateway])).toMatchObject({
       providerId: 'xd',
@@ -187,7 +197,18 @@ describe('resolveNewMakerDefaultTuple', () => {
     const gateway = provider({
       id: 'xd',
       access: 'managed',
-      models: { codex: [model('deepseek/deepseek-v4-pro')] },
+      models: {
+        codex: [model('z-ai/glm-5.3-flash', 'high', undefined, ['text', 'image'])],
+      },
+    });
+    expect(resolve([gateway])).toBeNull();
+  });
+
+  it('Gateway 默认标记误落到纯文本模型时保持空态', () => {
+    const gateway = provider({
+      id: 'xd',
+      access: 'managed',
+      models: { codex: [model('z-ai/glm-5.3-flash', 'high', ['codex'], ['text'])] },
     });
     expect(resolve([gateway])).toBeNull();
   });

--- a/apps/desktop/src/renderer/lib/__tests__/newMakerDefaultTuple.test.ts
+++ b/apps/desktop/src/renderer/lib/__tests__/newMakerDefaultTuple.test.ts
@@ -1,0 +1,194 @@
+import { describe, expect, it } from 'vitest';
+
+import type { AgentKind, CatalogModel, ProviderView } from '@cindy/model-providers';
+
+import { resolveNewMakerDefaultTuple } from '@/lib/newMakerDefaultTuple';
+
+function model(
+  id: string,
+  effort: CatalogModel['defaultEffort'] = 'high',
+  newSessionDefault?: CatalogModel['newSessionDefault'],
+): CatalogModel {
+  return {
+    id,
+    name: id,
+    contextWindow: 200_000,
+    efforts: effort ? [effort] : [],
+    defaultEffort: effort,
+    newSessionDefault,
+  };
+}
+
+function provider(args: {
+  id: string;
+  access: 'subscription' | 'managed';
+  models: Partial<Record<AgentKind, CatalogModel[]>>;
+  connected?: boolean;
+  failed?: boolean;
+}): ProviderView {
+  const agents = Object.keys(args.models) as AgentKind[];
+  return {
+    id: args.id,
+    name: args.id,
+    source: 'builtin',
+    agents,
+    auth: { method: args.access === 'managed' ? 'managed' : 'oauth' },
+    access:
+      args.access === 'managed' ? { kind: 'managed' } : { kind: 'subscription', product: args.id },
+    routing: {},
+    models: args.models,
+    connected: args.connected ?? true,
+    ...(args.failed
+      ? { modelDiscoveryFailure: { kind: 'upstream' as const, at: '2026-08-27T00:00:00Z' } }
+      : {}),
+  };
+}
+
+const allAgents = new Set(['cc', 'codex', 'pi'] as const);
+
+function resolve(providers: ProviderView[], availableAgents = allAgents) {
+  return resolveNewMakerDefaultTuple({
+    providers,
+    providersLoading: false,
+    availableAgents,
+    availableAgentsLoaded: true,
+  });
+}
+
+describe('resolveNewMakerDefaultTuple', () => {
+  it('没有来源或清单仍在加载时不编造默认组合', () => {
+    expect(resolve([])).toBeNull();
+    expect(
+      resolveNewMakerDefaultTuple({
+        providers: [],
+        providersLoading: true,
+        availableAgents: allAgents,
+        availableAgentsLoaded: true,
+      }),
+    ).toBeNull();
+  });
+
+  it.each([
+    {
+      name: 'OpenAI 订阅',
+      source: provider({
+        id: 'openai',
+        access: 'subscription',
+        models: {
+          codex: [{ ...model('chatgpt/gpt-5.6-sol', 'medium'), efforts: ['medium', 'high'] }],
+        },
+      }),
+      expected: {
+        vendor: 'codex',
+        providerId: 'openai',
+        model: 'chatgpt/gpt-5.6-sol',
+        effort: 'high',
+      },
+    },
+    {
+      name: 'Anthropic 订阅',
+      source: provider({
+        id: 'anthropic',
+        access: 'subscription',
+        models: { 'claude-code': [model('claude-opus-5')] },
+      }),
+      expected: {
+        vendor: 'cc',
+        providerId: 'anthropic',
+        model: 'claude-opus-5',
+        effort: 'high',
+      },
+    },
+    {
+      name: 'xAI 订阅',
+      source: provider({
+        id: 'xai',
+        access: 'subscription',
+        models: { pi: [model('grok-4.6')] },
+      }),
+      expected: { vendor: 'pi', providerId: 'xai', model: 'grok-4.6', effort: 'high' },
+    },
+    {
+      name: '中国区 Gateway',
+      source: provider({
+        id: 'xd',
+        access: 'managed',
+        models: { codex: [model('deepseek/deepseek-v4-pro', 'high', ['codex'])] },
+      }),
+      expected: {
+        vendor: 'codex',
+        providerId: 'xd',
+        model: 'deepseek/deepseek-v4-pro',
+        effort: 'high',
+      },
+    },
+  ])('$name 得到完整推荐组合', ({ source, expected }) => {
+    expect(resolve([source])).toEqual(expected);
+  });
+
+  it('订阅优先于 Gateway，多订阅无时间信息时按 OpenAI 稳定优先', () => {
+    const gateway = provider({
+      id: 'xd',
+      access: 'managed',
+      models: { codex: [model('deepseek/deepseek-v4-pro', 'high', ['codex'])] },
+    });
+    const anthropic = provider({
+      id: 'anthropic',
+      access: 'subscription',
+      models: { 'claude-code': [model('claude-opus-5')] },
+    });
+    const openai = provider({
+      id: 'openai',
+      access: 'subscription',
+      models: { codex: [model('chatgpt/gpt-5.6-sol')] },
+    });
+    expect(resolve([gateway, anthropic, openai])).toMatchObject({
+      vendor: 'codex',
+      providerId: 'openai',
+    });
+  });
+
+  it('首选 Harness 未安装时留在同一订阅来源并降级 Harness', () => {
+    const xai = provider({
+      id: 'xai',
+      access: 'subscription',
+      models: {
+        pi: [model('grok-4.6')],
+        codex: [model('xai/grok-4.6')],
+      },
+    });
+    expect(resolve([xai], new Set(['cc', 'codex']))).toEqual({
+      vendor: 'codex',
+      providerId: 'xai',
+      model: 'xai/grok-4.6',
+      effort: 'high',
+    });
+  });
+
+  it('发现失败的订阅不压过健康 Gateway', () => {
+    const failedOpenai = provider({
+      id: 'openai',
+      access: 'subscription',
+      models: { codex: [model('chatgpt/gpt-5.6-sol')] },
+      failed: true,
+    });
+    const gateway = provider({
+      id: 'xd',
+      access: 'managed',
+      models: { codex: [model('deepseek/deepseek-v4-pro', 'high', ['codex'])] },
+    });
+    expect(resolve([failedOpenai, gateway])).toMatchObject({
+      providerId: 'xd',
+      vendor: 'codex',
+    });
+  });
+
+  it('Gateway 没有服务端区域默认标记时保持空态', () => {
+    const gateway = provider({
+      id: 'xd',
+      access: 'managed',
+      models: { codex: [model('deepseek/deepseek-v4-pro')] },
+    });
+    expect(resolve([gateway])).toBeNull();
+  });
+});

--- a/apps/desktop/src/renderer/lib/newMakerDefaultTuple.ts
+++ b/apps/desktop/src/renderer/lib/newMakerDefaultTuple.ts
@@ -20,6 +20,7 @@ interface ProviderDefaultPolicy {
   agents: readonly AgentKind[];
   modelIds: readonly string[];
   requireNewSessionDefault?: boolean;
+  requireImageInput?: boolean;
 }
 
 /**
@@ -52,8 +53,9 @@ const DEFAULT_POLICIES: readonly ProviderDefaultPolicy[] = [
     providerId: 'xd',
     accessKind: 'managed',
     agents: ['codex', 'claude-code', 'pi'],
-    modelIds: ['deepseek/deepseek-v4-pro', 'deepseek-v4-pro'],
+    modelIds: ['z-ai/glm-5.3-flash', 'glm-5.3-flash'],
     requireNewSessionDefault: true,
+    requireImageInput: true,
   },
 ];
 
@@ -61,11 +63,18 @@ function vendorForAgent(agent: AgentKind): NewMakerDefaultTuple['vendor'] {
   return agent === 'claude-code' ? 'cc' : agent;
 }
 
+function supportsImageInput(model: NonNullable<ProviderView['models'][AgentKind]>[number]): boolean {
+  return (
+    model.supportsImageInput === true || model.modalities?.input.includes('image') === true
+  );
+}
+
 function matchingModel(
   provider: ProviderView,
   agent: AgentKind,
   modelIds: readonly string[],
   requireNewSessionDefault = false,
+  requireImageInput = false,
 ) {
   const models = provider.models[agent] ?? [];
   return modelIds
@@ -75,6 +84,7 @@ function matchingModel(
         model !== undefined &&
         model.defaultEnabled !== false &&
         (!requireNewSessionDefault || model.newSessionDefault?.includes(agent) === true) &&
+        (!requireImageInput || supportsImageInput(model)) &&
         isModelSelectableForNewRoute(model, { userProvider: provider.source === 'user' }),
     );
 }
@@ -113,6 +123,7 @@ export function resolveNewMakerDefaultTuple(args: {
         agent,
         policy.modelIds,
         policy.requireNewSessionDefault,
+        policy.requireImageInput,
       );
       if (!model) continue;
       return {

--- a/apps/desktop/src/renderer/lib/newMakerDefaultTuple.ts
+++ b/apps/desktop/src/renderer/lib/newMakerDefaultTuple.ts
@@ -52,7 +52,7 @@ const DEFAULT_POLICIES: readonly ProviderDefaultPolicy[] = [
   {
     providerId: 'xd',
     accessKind: 'managed',
-    agents: ['codex', 'claude-code', 'pi'],
+    agents: ['pi'],
     modelIds: ['z-ai/glm-5.3-flash', 'glm-5.3-flash'],
     requireNewSessionDefault: true,
     requireImageInput: true,
@@ -83,6 +83,7 @@ function matchingModel(
       (model) =>
         model !== undefined &&
         model.defaultEnabled !== false &&
+        model.efforts.includes('high') &&
         (!requireNewSessionDefault || model.newSessionDefault?.includes(agent) === true) &&
         (!requireImageInput || supportsImageInput(model)) &&
         isModelSelectableForNewRoute(model, { userProvider: provider.source === 'user' }),
@@ -130,7 +131,7 @@ export function resolveNewMakerDefaultTuple(args: {
         vendor,
         providerId: provider.id,
         model: model.id,
-        effort: model.efforts.includes('high') ? 'high' : model.defaultEffort,
+        effort: 'high',
       };
     }
   }

--- a/apps/desktop/src/renderer/lib/newMakerDefaultTuple.ts
+++ b/apps/desktop/src/renderer/lib/newMakerDefaultTuple.ts
@@ -63,6 +63,23 @@ function vendorForAgent(agent: AgentKind): NewMakerDefaultTuple['vendor'] {
   return agent === 'claude-code' ? 'cc' : agent;
 }
 
+/**
+ * 仅供旧草稿迁移辨认“产品曾自动写入的 tuple 身份”。这里不判断账号实时可用性，
+ * 也不产生默认值；真正下放仍只能走 resolveNewMakerDefaultTuple 的实时能力门控。
+ */
+export function isKnownProductDefaultTupleIdentity(args: {
+  vendor: MakerVendor;
+  providerId: string;
+  model: string;
+}): boolean {
+  return DEFAULT_POLICIES.some(
+    (policy) =>
+      policy.providerId === args.providerId &&
+      policy.modelIds.includes(args.model) &&
+      policy.agents.some((agent) => vendorForAgent(agent) === args.vendor),
+  );
+}
+
 function supportsImageInput(model: NonNullable<ProviderView['models'][AgentKind]>[number]): boolean {
   return (
     model.supportsImageInput === true || model.modalities?.input.includes('image') === true

--- a/apps/desktop/src/renderer/lib/newMakerDefaultTuple.ts
+++ b/apps/desktop/src/renderer/lib/newMakerDefaultTuple.ts
@@ -1,0 +1,127 @@
+import {
+  isModelSelectableForNewRoute,
+  type AgentKind,
+  type Effort,
+  type ProviderView,
+} from '@cindy/model-providers';
+
+import type { MakerVendor } from '@/lib/ccAgent.types';
+
+export interface NewMakerDefaultTuple {
+  vendor: Extract<MakerVendor, 'cc' | 'codex' | 'pi'>;
+  providerId: string;
+  model: string;
+  effort: Effort | null;
+}
+
+interface ProviderDefaultPolicy {
+  providerId: 'openai' | 'anthropic' | 'xai' | 'xd';
+  accessKind: 'subscription' | 'managed';
+  agents: readonly AgentKind[];
+  modelIds: readonly string[];
+  requireNewSessionDefault?: boolean;
+}
+
+/**
+ * 新用户的产品默认顺序。
+ *
+ * 订阅永远先于 Gateway；多订阅又没有“最近连接时间”可用时，固定按
+ * OpenAI → Anthropic → xAI，避免依赖目录下发顺序造成升级后随机换默认。
+ * 每个来源的首个 agent 是推荐 Harness，其余只在本机没有安装首选 Harness 时降级。
+ */
+const DEFAULT_POLICIES: readonly ProviderDefaultPolicy[] = [
+  {
+    providerId: 'openai',
+    accessKind: 'subscription',
+    agents: ['codex', 'claude-code', 'pi'],
+    modelIds: ['chatgpt/gpt-5.6-sol', 'gpt-5.6-sol'],
+  },
+  {
+    providerId: 'anthropic',
+    accessKind: 'subscription',
+    agents: ['claude-code', 'codex', 'pi'],
+    modelIds: ['claude-opus-5', 'anthropic/claude-opus-5'],
+  },
+  {
+    providerId: 'xai',
+    accessKind: 'subscription',
+    agents: ['pi', 'codex', 'claude-code'],
+    modelIds: ['grok-4.6', 'xai/grok-4.6'],
+  },
+  {
+    providerId: 'xd',
+    accessKind: 'managed',
+    agents: ['codex', 'claude-code', 'pi'],
+    modelIds: ['deepseek/deepseek-v4-pro', 'deepseek-v4-pro'],
+    requireNewSessionDefault: true,
+  },
+];
+
+function vendorForAgent(agent: AgentKind): NewMakerDefaultTuple['vendor'] {
+  return agent === 'claude-code' ? 'cc' : agent;
+}
+
+function matchingModel(
+  provider: ProviderView,
+  agent: AgentKind,
+  modelIds: readonly string[],
+  requireNewSessionDefault = false,
+) {
+  const models = provider.models[agent] ?? [];
+  return modelIds
+    .map((id) => models.find((model) => model.id === id))
+    .find(
+      (model) =>
+        model !== undefined &&
+        model.defaultEnabled !== false &&
+        (!requireNewSessionDefault || model.newSessionDefault?.includes(agent) === true) &&
+        isModelSelectableForNewRoute(model, { userProvider: provider.source === 'user' }),
+    );
+}
+
+/**
+ * 为“尚未自定义”的本地新任务挑一份完整默认组合。
+ *
+ * 返回 null 表示没有足够证据给默认值：供应商仍在加载、没有可用来源，或推荐模型不在
+ * 当前账号目录里。调用方此时保留连接引导/既有空态，绝不编造一个看似可发送的组合。
+ */
+export function resolveNewMakerDefaultTuple(args: {
+  providers: readonly ProviderView[];
+  providersLoading: boolean;
+  availableAgents: ReadonlySet<MakerVendor>;
+  availableAgentsLoaded: boolean;
+}): NewMakerDefaultTuple | null {
+  const { providers, providersLoading, availableAgents, availableAgentsLoaded } = args;
+  if (providersLoading || !availableAgentsLoaded) return null;
+
+  for (const policy of DEFAULT_POLICIES) {
+    const provider = providers.find(
+      (candidate) =>
+        candidate.id === policy.providerId &&
+        candidate.connected &&
+        !candidate.suspended &&
+        !candidate.modelDiscoveryFailure &&
+        candidate.access?.kind === policy.accessKind,
+    );
+    if (!provider) continue;
+
+    for (const agent of policy.agents) {
+      const vendor = vendorForAgent(agent);
+      if (!availableAgents.has(vendor)) continue;
+      const model = matchingModel(
+        provider,
+        agent,
+        policy.modelIds,
+        policy.requireNewSessionDefault,
+      );
+      if (!model) continue;
+      return {
+        vendor,
+        providerId: provider.id,
+        model: model.id,
+        effort: model.efforts.includes('high') ? 'high' : model.defaultEffort,
+      };
+    }
+  }
+  return null;
+}

--- a/apps/desktop/src/renderer/state/modelEnginePrefs.ts
+++ b/apps/desktop/src/renderer/state/modelEnginePrefs.ts
@@ -376,6 +376,11 @@ export function hasModelEngineOverride(providerId: string, modelId: string): boo
   return getModelEngineOverride(providerId, modelId) !== undefined;
 }
 
+/** 当前账号是否存在任一显式 Harness 选择；用于旧草稿迁移时保护用户意图。 */
+export function hasAnyModelEngineOverride(): boolean {
+  return Object.keys(load()).length > 0;
+}
+
 /** 订阅引擎 override 变更(非 React 调用方)。 */
 export function subscribeModelEnginePrefs(listener: () => void): () => void {
   return subscribe(listener);

--- a/apps/desktop/src/renderer/state/modelPickerLayout.ts
+++ b/apps/desktop/src/renderer/state/modelPickerLayout.ts
@@ -1,16 +1,16 @@
 /**
  * modelPickerLayout —— 模型选择器的**形态**本机偏好(三档并存试用,Chris 2026-08-17
- * 裁决:保留最原始选择器,测试版默认用它,新选择器靠入口自选)。
+ * 裁决:保留最原始选择器供回退；2026-08-27 起新用户默认使用 A 版)。
  *
  *   - 'original':最原始的选择器(unifiedPanel 之前的浏览式面板,含旧 harness 分段
- *                切换)。**默认**。footer 右侧「尝试新选择器」切到 'classic'。
- *   - 'classic' :新选择器 A 版(统一面板现行样式:来源图标行首、引擎在行尾三元组)。
+ *                切换)。footer 右侧「尝试新选择器」切到 'classic'。
+ *   - 'classic' :新选择器 A 版(统一面板现行样式:来源图标行首、引擎在行尾三元组)。**默认**。
  *   - 'badge'   :新选择器 B 版(v7 设计稿:行首 22px 引擎徽标、右缘来源字签、
  *                滚动题头、价格按实付比例上色)。
  *   新选择器 footer 右侧两个文字按钮:A/B 互切 + 切回老版('original')。
  *
  * 纯呈现偏好,不进用户数据、不分账号、不跨端同步 —— 与 modelEnginePrefs 那类
- * 用户配置不同,这里丢了就丢了(回落 original),所以不做 owner 分区与迁移。
+ * 用户配置不同,这里丢了就丢了(回落 classic),所以不做 owner 分区与迁移。
  * 同步写 localStorage(与本目录其它 store 同取舍:热更 relaunch 走 app.exit(),
  * 异步写会丢最近一次切换)。
  */
@@ -28,9 +28,9 @@ function load(): ModelPickerLayout {
   if (cache !== null) return cache;
   try {
     const raw = window.localStorage.getItem(STORAGE_KEY);
-    cache = raw === 'badge' || raw === 'classic' ? raw : 'original';
+    cache = raw === 'badge' || raw === 'classic' || raw === 'original' ? raw : 'classic';
   } catch {
-    cache = 'original';
+    cache = 'classic';
   }
   return cache;
 }
@@ -82,7 +82,7 @@ if (import.meta.hot) {
 }
 
 export function useModelPickerLayout(): ModelPickerLayout {
-  return useSyncExternalStore(subscribe, load, () => 'original' as const);
+  return useSyncExternalStore(subscribe, load, () => 'classic' as const);
 }
 
 /** 测试用:重置缓存与存储。 */

--- a/apps/desktop/src/renderer/state/newMakerDraft.ts
+++ b/apps/desktop/src/renderer/state/newMakerDraft.ts
@@ -360,12 +360,16 @@ function sanitize(raw: unknown): NewMakerDraft {
   // 用户意图证据。preserving 写回还可能只留下当前 cc 槽的 model,没有 marker / providerId,
   // 这条旧模型同样必须保护。反过来,仅 vendor=codex/pi 不能算用户选择:旧版会在 cc
   // 不可用时由系统自动 fallback 并持久化该 vendor。
+  const legacyCcPrefs = lastByVendorRaw.cc;
   const legacyCcModel =
     vendor === 'cc' &&
-    lastByVendorRaw.cc &&
-    typeof lastByVendorRaw.cc === 'object' &&
-    typeof lastByVendorRaw.cc.model === 'string' &&
-    lastByVendorRaw.cc.model.length > 0;
+    r.modelChosenByVendor === undefined &&
+    Object.keys(lastByVendorRaw).length === 1 &&
+    legacyCcPrefs &&
+    typeof legacyCcPrefs === 'object' &&
+    Object.keys(legacyCcPrefs).every((key) => key === 'model') &&
+    typeof legacyCcPrefs.model === 'string' &&
+    legacyCcPrefs.model.length > 0;
   const legacyDefaultTupleCustomized =
     r.defaultTupleCustomized === undefined &&
     (Object.values(modelChosenByVendor).some(Boolean) ||

--- a/apps/desktop/src/renderer/state/newMakerDraft.ts
+++ b/apps/desktop/src/renderer/state/newMakerDraft.ts
@@ -582,6 +582,22 @@ type PreferenceSyncFallback = 'full-draft' | 'worktree-only' | null;
 let preferenceSyncFallback: PreferenceSyncFallback = null;
 
 /**
+ * 显式 tuple 操作先采用跨窗口持久真相，再只施加自己的字段变更。
+ * 这样既不会带着旧整表复活已恢复的 override，也不会吞掉本窗口刚发生的真实选模意图。
+ */
+function rebaseStoredDefaultTuplePreference(): void {
+  const stored = readStoredDefaultTuplePreference();
+  if (
+    stored !== undefined &&
+    !hasSameDefaultTuplePreference(stored, defaultTuplePreferenceOf(currentDraft))
+  ) {
+    currentDraft = { ...currentDraft, ...stored };
+    // 等价于 storage event 已到达：即使后续显式操作因同值短路，订阅者也必须看到这次收敛。
+    emit();
+  }
+}
+
+/**
  * Persist a complete draft snapshot without letting another renderer's stale in-memory copy
  * overwrite workstation-wide worktree or user-customized default-tuple preferences.
  *
@@ -593,7 +609,7 @@ let preferenceSyncFallback: PreferenceSyncFallback = null;
 function scheduleWrite(
   options: {
     preserveStoredWorktreePreference?: boolean;
-    preserveStoredDefaultTupleCustomization?: boolean;
+    preserveStoredDefaultTuplePreference?: boolean;
   } = {},
 ): void {
   if (typeof window === 'undefined') return;
@@ -611,16 +627,18 @@ function scheduleWrite(
     currentDraft = { ...currentDraft, ...storedWorktreePreference };
   }
   const storedDefaultTuplePreference =
-    options.preserveStoredDefaultTupleCustomization !== false
+    options.preserveStoredDefaultTuplePreference !== false
       ? readStoredDefaultTuplePreference()
       : undefined;
-  // 旧 renderer 还拿着未自定义草稿时，任意其它字段的完整快照写入都不能回滚另一个
-  // renderer 刚保存的用户组合。两个 marker 必须和 Harness / 来源 / 模型 / 深度 / Fast
-  // 整体 rebase；只 OR boolean 会留下“已自定义”却指向旧 tuple 的撕裂状态。
-  // 显式「恢复推荐」通过 option 跳过本保护，保留合法的 true → false 通道。
+  // 无关字段写入必须无条件采用最新完整 tuple，方向不能只保护 false → true：恢复推荐刚把
+  // true 清成 false 后，旧窗口的 workdir/collab 写入同样不能把旧 tuple/true 整体复活。
+  // 显式 tuple 操作已在变更前调用 rebaseStoredDefaultTuplePreference，再通过 option 跳过此处。
   if (
-    storedDefaultTuplePreference?.defaultTupleCustomized === true
-    && currentDraft.defaultTupleCustomized === false
+    storedDefaultTuplePreference !== undefined &&
+    !hasSameDefaultTuplePreference(
+      storedDefaultTuplePreference,
+      defaultTuplePreferenceOf(currentDraft),
+    )
   ) {
     currentDraft = { ...currentDraft, ...storedDefaultTuplePreference };
   }
@@ -860,22 +878,18 @@ export function patchCollab(patch: Partial<CollabDraft>): void {
 
 /**
  * 切 vendor 的便捷入口:
- *   1. 把当前 vendor 的 (model/effort/permissionMode) 落进 lastByVendor[currentVendor]
+ *   1. 保留当前 vendor 已同步进草稿的 (model/effort/permissionMode)
  *   2. 切到新 vendor
  * NewMakerDraftRoute 的 VendorSegmentedSwitcher 切换时调本函数;切回某 vendor 时 ChatInput 通过 lastByVendor[vendor] 取上次值。
  */
-export function switchVendor(next: MakerVendor, currentPrefs: VendorPrefs): void {
+export function switchVendor(next: MakerVendor): void {
+  rebaseStoredDefaultTuplePreference();
   if (currentDraft.vendor === next) return;
-  const prev = currentDraft.vendor;
   currentDraft = {
     ...currentDraft,
     vendor: next,
-    lastByVendor: {
-      ...currentDraft.lastByVendor,
-      [prev]: currentPrefs,
-    },
   };
-  scheduleWrite();
+  scheduleWrite({ preserveStoredDefaultTuplePreference: false });
   emit();
 }
 
@@ -887,13 +901,14 @@ export function switchVendor(next: MakerVendor, currentPrefs: VendorPrefs): void
  * defaultTupleCustomized,因为它不是用户选择。
  */
 export function fallbackUnavailableVendor(availableVendors: ReadonlySet<MakerVendor>): boolean {
+  rebaseStoredDefaultTuplePreference();
   const currentVendor = currentDraft.vendor;
   if (availableVendors.has(currentVendor)) return false;
   const fallback = (['cc', 'codex', 'pi'] as const).find((vendor) =>
     availableVendors.has(vendor),
   );
   if (!fallback) return false;
-  switchVendor(fallback, currentDraft.lastByVendor[currentVendor]);
+  switchVendor(fallback);
   return true;
 }
 
@@ -906,6 +921,7 @@ export interface SuggestedDefaultTuple {
 
 /** 原子应用产品默认；只改未自定义草稿，不把默认伪装成用户显式选模。 */
 export function applySuggestedDefaultTuple(tuple: SuggestedDefaultTuple): boolean {
+  rebaseStoredDefaultTuplePreference();
   if (currentDraft.defaultTupleCustomized) return false;
   const previous = currentDraft.lastByVendor[tuple.vendor];
   const nextPrefs: VendorPrefs = {
@@ -927,13 +943,14 @@ export function applySuggestedDefaultTuple(tuple: SuggestedDefaultTuple): boolea
     vendor: tuple.vendor,
     lastByVendor: { ...currentDraft.lastByVendor, [tuple.vendor]: nextPrefs },
   };
-  scheduleWrite();
+  scheduleWrite({ preserveStoredDefaultTuplePreference: false });
   emit();
   return true;
 }
 
 /** 用户开始调整默认组合后立刻封住后续自动下放。 */
 export function markDefaultTupleCustomized(selectionCustomized = true): void {
+  rebaseStoredDefaultTuplePreference();
   if (
     currentDraft.defaultTupleCustomized &&
     (!selectionCustomized || currentDraft.defaultTupleSelectionCustomized)
@@ -946,7 +963,7 @@ export function markDefaultTupleCustomized(selectionCustomized = true): void {
     defaultTupleSelectionCustomized:
       currentDraft.defaultTupleSelectionCustomized || selectionCustomized,
   };
-  scheduleWrite();
+  scheduleWrite({ preserveStoredDefaultTuplePreference: false });
   emit();
 }
 
@@ -962,6 +979,7 @@ export function clearDefaultTupleTuningCustomization(args: {
   modelId: string;
   hasExternalOverrides: boolean;
 }): void {
+  rebaseStoredDefaultTuplePreference();
   const nextEffortByModel = { ...currentDraft.effortByModel };
   const nextFastModeByModel = { ...currentDraft.fastModeByModel };
   const hadEffortOverride = args.modelId in nextEffortByModel;
@@ -987,7 +1005,7 @@ export function clearDefaultTupleTuningCustomization(args: {
     fastModeByModel: nextFastModeByModel,
     ...(shouldUnlock ? { defaultTupleCustomized: false } : {}),
   };
-  scheduleWrite({ preserveStoredDefaultTupleCustomization: !shouldUnlock });
+  scheduleWrite({ preserveStoredDefaultTuplePreference: false });
   emit();
 }
 
@@ -1002,6 +1020,7 @@ function patchVendorPrefsInternal(
   patch: Partial<VendorPrefs>,
   opts: { markModelChoice: boolean },
 ): void {
+  rebaseStoredDefaultTuplePreference();
   const marksSelection = opts.markModelChoice && ('model' in patch || 'providerId' in patch);
   const marksDefaultTuple = marksSelection || (opts.markModelChoice && 'effort' in patch);
   const modelChosen = { ...currentDraft.modelChosenByVendor };
@@ -1039,7 +1058,7 @@ function patchVendorPrefsInternal(
       [vendor]: { ...currentDraft.lastByVendor[vendor], ...nextPatch },
     },
   };
-  scheduleWrite();
+  scheduleWrite({ preserveStoredDefaultTuplePreference: false });
   emit();
 }
 
@@ -1073,6 +1092,7 @@ export function getEffortForModel(modelId: string | null | undefined): Effort | 
 
 export function setEffortForModel(modelId: string, effort: Effort): void {
   if (!modelId) return;
+  rebaseStoredDefaultTuplePreference();
   // 同值短路,避免无意义的 emit / write。
   if (currentDraft.effortByModel[modelId] === effort) return;
   currentDraft = {
@@ -1082,7 +1102,7 @@ export function setEffortForModel(modelId: string, effort: Effort): void {
       [modelId]: effort,
     },
   };
-  scheduleWrite();
+  scheduleWrite({ preserveStoredDefaultTuplePreference: false });
   emit();
 }
 
@@ -1093,6 +1113,7 @@ export function getFastModeForModel(modelId: string | null | undefined): boolean
 
 export function setFastModeForModel(modelId: string, enabled: boolean): void {
   if (!modelId) return;
+  rebaseStoredDefaultTuplePreference();
   currentDraft = {
     ...currentDraft,
     fastModeByModel: {
@@ -1100,7 +1121,7 @@ export function setFastModeForModel(modelId: string, enabled: boolean): void {
       [modelId]: enabled,
     },
   };
-  scheduleWrite();
+  scheduleWrite({ preserveStoredDefaultTuplePreference: false });
   emit();
 }
 
@@ -1108,7 +1129,7 @@ export function clearDraft(): void {
   currentDraft = makeDefault();
   scheduleWrite({
     preserveStoredWorktreePreference: false,
-    preserveStoredDefaultTupleCustomization: false,
+    preserveStoredDefaultTuplePreference: false,
   });
   emit();
 }

--- a/apps/desktop/src/renderer/state/newMakerDraft.ts
+++ b/apps/desktop/src/renderer/state/newMakerDraft.ts
@@ -870,12 +870,42 @@ export function markDefaultTupleCustomized(selectionCustomized = true): void {
 }
 
 /**
- * 「恢复推荐」只撤销 effort / Fast 造成的组合封锁。若用户还选过 Harness / 来源 / 模型，
- * selection marker 继续保留，后续登录或目录变化仍不得覆盖那次选择。
+ * 「恢复推荐」删除当前模型的旧草稿调档，并在所有 override 都已清空时撤销组合封锁。
+ *
+ * providerModelMemory / modelEnginePrefs 是独立 store，由调用方先删当前项、再把同步重读后的
+ * 汇总结果传进来。草稿内仍需在同一次写入里删除 legacy effort / Fast 键；否则 marker 虽清，
+ * 重启后残留记忆仍会把旧档顶回来。任一模型选择、其它模型调档或外部 override 仍存在时，
+ * defaultTupleCustomized 必须继续保护用户意图。
  */
-export function clearDefaultTupleTuningCustomization(): void {
-  if (!currentDraft.defaultTupleCustomized || currentDraft.defaultTupleSelectionCustomized) return;
-  currentDraft = { ...currentDraft, defaultTupleCustomized: false };
+export function clearDefaultTupleTuningCustomization(args: {
+  modelId: string;
+  hasExternalOverrides: boolean;
+}): void {
+  const nextEffortByModel = { ...currentDraft.effortByModel };
+  const nextFastModeByModel = { ...currentDraft.fastModeByModel };
+  const hadEffortOverride = args.modelId in nextEffortByModel;
+  const hadFastOverride = args.modelId in nextFastModeByModel;
+  delete nextEffortByModel[args.modelId];
+  delete nextFastModeByModel[args.modelId];
+
+  const hasSelectionOverride =
+    currentDraft.defaultTupleSelectionCustomized ||
+    Object.values(currentDraft.modelChosenByVendor).some(Boolean);
+  const hasRemainingDraftTuning =
+    Object.keys(nextEffortByModel).length > 0 || Object.keys(nextFastModeByModel).length > 0;
+  const shouldUnlock =
+    currentDraft.defaultTupleCustomized &&
+    !hasSelectionOverride &&
+    !hasRemainingDraftTuning &&
+    !args.hasExternalOverrides;
+  if (!hadEffortOverride && !hadFastOverride && !shouldUnlock) return;
+
+  currentDraft = {
+    ...currentDraft,
+    effortByModel: nextEffortByModel,
+    fastModeByModel: nextFastModeByModel,
+    ...(shouldUnlock ? { defaultTupleCustomized: false } : {}),
+  };
   scheduleWrite();
   emit();
 }

--- a/apps/desktop/src/renderer/state/newMakerDraft.ts
+++ b/apps/desktop/src/renderer/state/newMakerDraft.ts
@@ -24,6 +24,7 @@ import type { MakerVendor } from '@/lib/ccAgent.types';
 import { isSelectableVendor } from '@/lib/agentVendors';
 import type { Effort, PermissionMode } from '@/lib/userPreferences.types';
 import { getDefaultModelForVendor } from '@/lib/modelDefinitions';
+import { isKnownProductDefaultTupleIdentity } from '@/lib/newMakerDefaultTuple';
 import type { OrcaWorkerPermissionMode } from '../../shared/orca-worker-permission-mode';
 import { normalizeWorkingDirForStorage } from '../../shared/workingDir';
 import { getManagedWorktreeBasePath } from '../../shared/managedWorktreePaths';
@@ -159,6 +160,11 @@ export interface NewMakerDraft {
    * false 才允许连接态为新任务下放产品默认；目录热更与登录变化不得覆盖 true。
    */
   defaultTupleCustomized: boolean;
+  /**
+   * 自定义里是否包含 Harness / 来源 / 模型选择。与只调 effort / Fast 分开记，
+   * 这样「恢复推荐」只能撤销调档意图，不会顺手清掉真正的路由选择。
+   */
+  defaultTupleSelectionCustomized: boolean;
 }
 
 /**
@@ -226,6 +232,7 @@ function makeDefault(): NewMakerDraft {
     },
     modelChosenByVendor: {},
     defaultTupleCustomized: false,
+    defaultTupleSelectionCustomized: false,
   };
 }
 
@@ -357,33 +364,60 @@ function sanitize(raw: unknown): NewMakerDraft {
     if (modelChosenRaw[v] === true) modelChosenByVendor[v] = true;
   }
   // 老版本没有独立的组合标记：显式选过模型/来源/思考深度/Fast 都是足够强的
-  // 用户意图证据。preserving 写回还可能只留下当前 cc 槽的 model,没有 marker / providerId,
-  // 这条旧模型同样必须保护。反过来,仅 vendor=codex/pi 不能算用户选择:旧版会在 cc
-  // 不可用时由系统自动 fallback 并持久化该 vendor。
+  // 用户意图证据。preserving 写回会保留完整 vendor 快照与空 marker,所以不能再用
+  // 「只有 cc 单槽单字段」识别；cc 模型偏离当时同源的 seed 才是可保护的旧选择。
+  // 反过来,仅 vendor=codex/pi 不能算用户选择:旧版会在 cc 不可用时由系统自动 fallback。
   const legacyCcPrefs = lastByVendorRaw.cc;
-  const legacyCcModel =
+  // 已经随旧版完整草稿自然落盘过的 cc seed。它们不是用户选择，不能因为新版目录换了
+  // seed 就反过来把系统快照认成自定义；这里只服务一次性迁移，不参与新会话默认决策。
+  const legacyCcSeedModels = new Set([def.lastByVendor.cc.model, 'claude-sonnet-4-6']);
+  const isKnownProductTuple = (slotVendor: MakerVendor, prefs: Partial<VendorPrefs>): boolean =>
+    typeof prefs.providerId === 'string' &&
+    prefs.providerId.length > 0 &&
+    typeof prefs.model === 'string' &&
+    prefs.model.length > 0 &&
+    isKnownProductDefaultTupleIdentity({
+      vendor: slotVendor,
+      providerId: prefs.providerId,
+      model: prefs.model,
+    });
+  const legacyCcModelCandidate =
     vendor === 'cc' &&
-    r.modelChosenByVendor === undefined &&
-    Object.keys(lastByVendorRaw).length === 1 &&
     legacyCcPrefs &&
     typeof legacyCcPrefs === 'object' &&
-    Object.keys(legacyCcPrefs).every((key) => key === 'model') &&
     typeof legacyCcPrefs.model === 'string' &&
-    legacyCcPrefs.model.length > 0;
-  const legacyDefaultTupleCustomized =
-    r.defaultTupleCustomized === undefined &&
-    (Object.values(modelChosenByVendor).some(Boolean) ||
-      legacyCcModel ||
-      Object.keys(effortByModel).length > 0 ||
-      Object.keys(fastModeByModel).length > 0 ||
-      Object.values(lastByVendorRaw).some(
-        (prefs) =>
-          prefs &&
-          typeof prefs === 'object' &&
-          typeof prefs.providerId === 'string' &&
-          prefs.providerId.length > 0,
-      ));
-  const defaultTupleCustomized = r.defaultTupleCustomized === true || legacyDefaultTupleCustomized;
+    legacyCcPrefs.model.length > 0 &&
+    !legacyCcSeedModels.has(legacyCcPrefs.model);
+  const legacyCcModel =
+    legacyCcModelCandidate &&
+    (r.defaultTupleCustomized === undefined || !isKnownProductTuple('cc', legacyCcPrefs));
+  const legacySourceSelection = (['cc', 'orca', 'codex', 'pi'] as const).some((slotVendor) => {
+    const prefs = lastByVendorRaw[slotVendor];
+    if (
+      !prefs ||
+      typeof prefs !== 'object' ||
+      typeof prefs.providerId !== 'string' ||
+      prefs.providerId.length === 0
+    ) {
+      return false;
+    }
+    // 老版本完全没有组合标记时，来源是唯一可用的显式证据；已有单一 boolean 的过渡
+    // 版本则只排除产品策略能够自动写出的精确 tuple，保住“只换来源”的真实选择。
+    return r.defaultTupleCustomized === undefined || !isKnownProductTuple(slotVendor, prefs);
+  });
+  const legacySelectionCustomized =
+    Object.values(modelChosenByVendor).some(Boolean) || legacyCcModel || legacySourceSelection;
+  const legacyTuningCustomized =
+    Object.keys(effortByModel).length > 0 || Object.keys(fastModeByModel).length > 0;
+  const defaultTupleSelectionCustomized =
+    r.defaultTupleSelectionCustomized === true ||
+    (r.defaultTupleSelectionCustomized === undefined &&
+      r.defaultTupleCustomized !== false &&
+      legacySelectionCustomized);
+  const defaultTupleCustomized =
+    r.defaultTupleCustomized === true ||
+    defaultTupleSelectionCustomized ||
+    (r.defaultTupleCustomized === undefined && legacyTuningCustomized);
   // 2026-07 已落盘但尚无显式标记的 true，只可能来自用户把当时默认 false 切到 true，
   // 可安全迁移为 override；旧 false 无法区分“默认快照”与“明确关闭”，按未自定义处理。
   const worktreePreferenceCustomized =
@@ -422,6 +456,7 @@ function sanitize(raw: unknown): NewMakerDraft {
     },
     modelChosenByVendor,
     defaultTupleCustomized,
+    defaultTupleSelectionCustomized,
   };
 }
 
@@ -817,9 +852,30 @@ export function applySuggestedDefaultTuple(tuple: SuggestedDefaultTuple): boolea
 }
 
 /** 用户开始调整默认组合后立刻封住后续自动下放。 */
-export function markDefaultTupleCustomized(): void {
-  if (currentDraft.defaultTupleCustomized) return;
-  currentDraft = { ...currentDraft, defaultTupleCustomized: true };
+export function markDefaultTupleCustomized(selectionCustomized = true): void {
+  if (
+    currentDraft.defaultTupleCustomized &&
+    (!selectionCustomized || currentDraft.defaultTupleSelectionCustomized)
+  ) {
+    return;
+  }
+  currentDraft = {
+    ...currentDraft,
+    defaultTupleCustomized: true,
+    defaultTupleSelectionCustomized:
+      currentDraft.defaultTupleSelectionCustomized || selectionCustomized,
+  };
+  scheduleWrite();
+  emit();
+}
+
+/**
+ * 「恢复推荐」只撤销 effort / Fast 造成的组合封锁。若用户还选过 Harness / 来源 / 模型，
+ * selection marker 继续保留，后续登录或目录变化仍不得覆盖那次选择。
+ */
+export function clearDefaultTupleTuningCustomization(): void {
+  if (!currentDraft.defaultTupleCustomized || currentDraft.defaultTupleSelectionCustomized) return;
+  currentDraft = { ...currentDraft, defaultTupleCustomized: false };
   scheduleWrite();
   emit();
 }
@@ -835,9 +891,8 @@ function patchVendorPrefsInternal(
   patch: Partial<VendorPrefs>,
   opts: { markModelChoice: boolean },
 ): void {
-  const marksDefaultTuple =
-    opts.markModelChoice &&
-    ('model' in patch || 'providerId' in patch || 'effort' in patch);
+  const marksSelection = opts.markModelChoice && ('model' in patch || 'providerId' in patch);
+  const marksDefaultTuple = marksSelection || (opts.markModelChoice && 'effort' in patch);
   const modelChosen = { ...currentDraft.modelChosenByVendor };
   const nextPatch = { ...patch };
   if (typeof nextPatch.model === 'string' && nextPatch.model.length > 0) {
@@ -865,6 +920,8 @@ function patchVendorPrefsInternal(
   currentDraft = {
     ...currentDraft,
     defaultTupleCustomized: currentDraft.defaultTupleCustomized || marksDefaultTuple,
+    defaultTupleSelectionCustomized:
+      currentDraft.defaultTupleSelectionCustomized || marksSelection,
     modelChosenByVendor: modelChosen,
     lastByVendor: {
       ...currentDraft.lastByVendor,

--- a/apps/desktop/src/renderer/state/newMakerDraft.ts
+++ b/apps/desktop/src/renderer/state/newMakerDraft.ts
@@ -154,6 +154,11 @@ export interface NewMakerDraft {
    * 也不得在已打标后改写 lastByVendor.model / providerId / effort。
    */
   modelChosenByVendor: Partial<Record<MakerVendor, boolean>>;
+  /**
+   * 用户是否明确改过新任务的模型组合（Harness / 来源 / 模型 / 思考深度 / Fast）。
+   * false 才允许连接态为新任务下放产品默认；目录热更与登录变化不得覆盖 true。
+   */
+  defaultTupleCustomized: boolean;
 }
 
 /**
@@ -220,6 +225,7 @@ function makeDefault(): NewMakerDraft {
       codex: defaultVendorPrefs('codex'),
     },
     modelChosenByVendor: {},
+    defaultTupleCustomized: false,
   };
 }
 
@@ -350,6 +356,22 @@ function sanitize(raw: unknown): NewMakerDraft {
   for (const v of ['cc', 'orca', 'codex', 'pi'] as const) {
     if (modelChosenRaw[v] === true) modelChosenByVendor[v] = true;
   }
+  // 老版本没有独立的组合标记：显式选过模型/来源/思考深度/Fast，或当前 vendor 不是
+  // 历史硬默认 cc，都是足够强的用户意图证据。只有完全原始的 cc 种子接受新产品默认。
+  const legacyDefaultTupleCustomized =
+    r.defaultTupleCustomized === undefined &&
+    (Object.values(modelChosenByVendor).some(Boolean) ||
+      vendor !== 'cc' ||
+      Object.keys(effortByModel).length > 0 ||
+      Object.keys(fastModeByModel).length > 0 ||
+      Object.values(lastByVendorRaw).some(
+        (prefs) =>
+          prefs &&
+          typeof prefs === 'object' &&
+          typeof prefs.providerId === 'string' &&
+          prefs.providerId.length > 0,
+      ));
+  const defaultTupleCustomized = r.defaultTupleCustomized === true || legacyDefaultTupleCustomized;
   // 2026-07 已落盘但尚无显式标记的 true，只可能来自用户把当时默认 false 切到 true，
   // 可安全迁移为 override；旧 false 无法区分“默认快照”与“明确关闭”，按未自定义处理。
   const worktreePreferenceCustomized =
@@ -387,6 +409,7 @@ function sanitize(raw: unknown): NewMakerDraft {
       codex: sanitizeVendorPrefs(lastByVendorRaw.codex, 'codex'),
     },
     modelChosenByVendor,
+    defaultTupleCustomized,
   };
 }
 
@@ -728,6 +751,49 @@ export function switchVendor(next: MakerVendor, currentPrefs: VendorPrefs): void
   emit();
 }
 
+export interface SuggestedDefaultTuple {
+  vendor: Extract<MakerVendor, 'cc' | 'codex' | 'pi'>;
+  providerId: string;
+  model: string;
+  effort?: Effort | null;
+}
+
+/** 原子应用产品默认；只改未自定义草稿，不把默认伪装成用户显式选模。 */
+export function applySuggestedDefaultTuple(tuple: SuggestedDefaultTuple): boolean {
+  if (currentDraft.defaultTupleCustomized) return false;
+  const previous = currentDraft.lastByVendor[tuple.vendor];
+  const nextPrefs: VendorPrefs = {
+    ...previous,
+    model: tuple.model,
+    providerId: tuple.providerId,
+    ...(tuple.effort ? { effort: tuple.effort } : {}),
+  };
+  if (
+    currentDraft.vendor === tuple.vendor &&
+    previous.model === nextPrefs.model &&
+    previous.providerId === nextPrefs.providerId &&
+    previous.effort === nextPrefs.effort
+  ) {
+    return false;
+  }
+  currentDraft = {
+    ...currentDraft,
+    vendor: tuple.vendor,
+    lastByVendor: { ...currentDraft.lastByVendor, [tuple.vendor]: nextPrefs },
+  };
+  scheduleWrite();
+  emit();
+  return true;
+}
+
+/** 用户开始调整默认组合后立刻封住后续自动下放。 */
+export function markDefaultTupleCustomized(): void {
+  if (currentDraft.defaultTupleCustomized) return;
+  currentDraft = { ...currentDraft, defaultTupleCustomized: true };
+  scheduleWrite();
+  emit();
+}
+
 /**
  * 显式指定 vendor 的 pref 写入入口。读模块级 currentDraft (而非调用方 closure
  * 捕获的 draft), 避免连续调用之间相互覆盖 —— ChatInput 切 model 时会同步连发
@@ -739,6 +805,9 @@ function patchVendorPrefsInternal(
   patch: Partial<VendorPrefs>,
   opts: { markModelChoice: boolean },
 ): void {
+  const marksDefaultTuple =
+    opts.markModelChoice &&
+    ('model' in patch || 'providerId' in patch || 'effort' in patch);
   const modelChosen = { ...currentDraft.modelChosenByVendor };
   const nextPatch = { ...patch };
   if (typeof nextPatch.model === 'string' && nextPatch.model.length > 0) {
@@ -765,6 +834,7 @@ function patchVendorPrefsInternal(
   }
   currentDraft = {
     ...currentDraft,
+    defaultTupleCustomized: currentDraft.defaultTupleCustomized || marksDefaultTuple,
     modelChosenByVendor: modelChosen,
     lastByVendor: {
       ...currentDraft.lastByVendor,

--- a/apps/desktop/src/renderer/state/newMakerDraft.ts
+++ b/apps/desktop/src/renderer/state/newMakerDraft.ts
@@ -356,12 +356,20 @@ function sanitize(raw: unknown): NewMakerDraft {
   for (const v of ['cc', 'orca', 'codex', 'pi'] as const) {
     if (modelChosenRaw[v] === true) modelChosenByVendor[v] = true;
   }
-  // 老版本没有独立的组合标记：显式选过模型/来源/思考深度/Fast，或当前 vendor 不是
-  // 历史硬默认 cc，都是足够强的用户意图证据。只有完全原始的 cc 种子接受新产品默认。
+  // 老版本没有独立的组合标记：显式选过模型/来源/思考深度/Fast 都是足够强的
+  // 用户意图证据。preserving 写回还可能只留下当前 cc 槽的 model,没有 marker / providerId,
+  // 这条旧模型同样必须保护。反过来,仅 vendor=codex/pi 不能算用户选择:旧版会在 cc
+  // 不可用时由系统自动 fallback 并持久化该 vendor。
+  const legacyCcModel =
+    vendor === 'cc' &&
+    lastByVendorRaw.cc &&
+    typeof lastByVendorRaw.cc === 'object' &&
+    typeof lastByVendorRaw.cc.model === 'string' &&
+    lastByVendorRaw.cc.model.length > 0;
   const legacyDefaultTupleCustomized =
     r.defaultTupleCustomized === undefined &&
     (Object.values(modelChosenByVendor).some(Boolean) ||
-      vendor !== 'cc' ||
+      legacyCcModel ||
       Object.keys(effortByModel).length > 0 ||
       Object.keys(fastModeByModel).length > 0 ||
       Object.values(lastByVendorRaw).some(
@@ -749,6 +757,24 @@ export function switchVendor(next: MakerVendor, currentPrefs: VendorPrefs): void
   };
   scheduleWrite();
   emit();
+}
+
+/**
+ * 当前草稿 Harness 不可用时按系统顺序回退。
+ *
+ * 必须在调用瞬间读取模块级 currentDraft:产品默认 effect 可能刚把 cc 改成 Pi,若这里继续
+ * 使用 React 上一轮 closure 的 cc/currentPrefs,会把 xAI→Pi 又覆盖成 Codex。系统回退不标记
+ * defaultTupleCustomized,因为它不是用户选择。
+ */
+export function fallbackUnavailableVendor(availableVendors: ReadonlySet<MakerVendor>): boolean {
+  const currentVendor = currentDraft.vendor;
+  if (availableVendors.has(currentVendor)) return false;
+  const fallback = (['cc', 'codex', 'pi'] as const).find((vendor) =>
+    availableVendors.has(vendor),
+  );
+  if (!fallback) return false;
+  switchVendor(fallback, currentDraft.lastByVendor[currentVendor]);
+  return true;
 }
 
 export interface SuggestedDefaultTuple {

--- a/apps/desktop/src/renderer/state/newMakerDraft.ts
+++ b/apps/desktop/src/renderer/state/newMakerDraft.ts
@@ -493,6 +493,29 @@ interface StoredWorktreePreference {
   worktreePreferenceCustomized: boolean;
 }
 
+type StoredDefaultTuplePreference = Pick<
+  NewMakerDraft,
+  | 'vendor'
+  | 'fastModeByModel'
+  | 'effortByModel'
+  | 'lastByVendor'
+  | 'modelChosenByVendor'
+  | 'defaultTupleCustomized'
+  | 'defaultTupleSelectionCustomized'
+>;
+
+function defaultTuplePreferenceOf(draft: NewMakerDraft): StoredDefaultTuplePreference {
+  return {
+    vendor: draft.vendor,
+    fastModeByModel: draft.fastModeByModel,
+    effortByModel: draft.effortByModel,
+    lastByVendor: draft.lastByVendor,
+    modelChosenByVendor: draft.modelChosenByVendor,
+    defaultTupleCustomized: draft.defaultTupleCustomized,
+    defaultTupleSelectionCustomized: draft.defaultTupleSelectionCustomized,
+  };
+}
+
 function parseStoredWorktreePreference(
   raw: string | null,
 ): StoredWorktreePreference | undefined {
@@ -513,6 +536,14 @@ function parseStoredWorktreePreference(
   };
 }
 
+function parseStoredDefaultTuplePreference(
+  raw: string | null,
+): StoredDefaultTuplePreference | undefined {
+  const parsed = parseStoredDraftRecord(raw);
+  if (!parsed) return undefined;
+  return defaultTuplePreferenceOf(sanitize(parsed));
+}
+
 function readStoredDraftRecord(): StoredDraftRecord | undefined {
   if (typeof window === 'undefined') return undefined;
   try {
@@ -531,20 +562,39 @@ function readStoredWorktreePreference(): StoredWorktreePreference | undefined {
   }
 }
 
+function readStoredDefaultTuplePreference(): StoredDefaultTuplePreference | undefined {
+  if (typeof window === 'undefined') return undefined;
+  try {
+    return parseStoredDefaultTuplePreference(window.localStorage.getItem(storageKey()));
+  } catch {
+    return undefined;
+  }
+}
+
+function hasSameDefaultTuplePreference(
+  left: StoredDefaultTuplePreference,
+  right: StoredDefaultTuplePreference,
+): boolean {
+  return JSON.stringify(left) === JSON.stringify(right);
+}
+
 type PreferenceSyncFallback = 'full-draft' | 'worktree-only' | null;
 let preferenceSyncFallback: PreferenceSyncFallback = null;
 
 /**
  * Persist a complete draft snapshot without letting another renderer's stale in-memory copy
- * overwrite the workstation-wide worktree preference.
+ * overwrite workstation-wide worktree or user-customized default-tuple preferences.
  *
  * Electron windows do not share this module instance. A storage event normally refreshes the
- * other windows below, but that event is asynchronous; rebasing this one shared field at write
+ * other windows below, but that event is asynchronous; rebasing shared preferences at write
  * time also closes the race where a secondary/sidebar window mutates another draft field before
  * it has received the event.
  */
 function scheduleWrite(
-  options: { preserveStoredWorktreePreference?: boolean } = {},
+  options: {
+    preserveStoredWorktreePreference?: boolean;
+    preserveStoredDefaultTupleCustomization?: boolean;
+  } = {},
 ): void {
   if (typeof window === 'undefined') return;
   const storedWorktreePreference = options.preserveStoredWorktreePreference !== false
@@ -559,6 +609,20 @@ function scheduleWrite(
     )
   ) {
     currentDraft = { ...currentDraft, ...storedWorktreePreference };
+  }
+  const storedDefaultTuplePreference =
+    options.preserveStoredDefaultTupleCustomization !== false
+      ? readStoredDefaultTuplePreference()
+      : undefined;
+  // 旧 renderer 还拿着未自定义草稿时，任意其它字段的完整快照写入都不能回滚另一个
+  // renderer 刚保存的用户组合。两个 marker 必须和 Harness / 来源 / 模型 / 深度 / Fast
+  // 整体 rebase；只 OR boolean 会留下“已自定义”却指向旧 tuple 的撕裂状态。
+  // 显式「恢复推荐」通过 option 跳过本保护，保留合法的 true → false 通道。
+  if (
+    storedDefaultTuplePreference?.defaultTupleCustomized === true
+    && currentDraft.defaultTupleCustomized === false
+  ) {
+    currentDraft = { ...currentDraft, ...storedDefaultTuplePreference };
   }
   try {
     window.localStorage.setItem(storageKey(), JSON.stringify(currentDraft));
@@ -583,9 +647,9 @@ const removeStorageListener = (() => {
     if (event.storageArea && event.storageArea !== window.localStorage) return;
     // A queued storage event can arrive after this window has already written a newer value.
     // Re-read the shared storage truth first so the event payload itself cannot roll state back.
-    const livePreference = readStoredWorktreePreference();
-    const nextPreference =
-      livePreference ??
+    const liveWorktreePreference = readStoredWorktreePreference();
+    const nextWorktreePreference =
+      liveWorktreePreference ??
       (
         event.newValue == null
           ? {
@@ -594,17 +658,34 @@ const removeStorageListener = (() => {
             }
           : parseStoredWorktreePreference(event.newValue)
       );
-    if (
-      nextPreference === undefined
-      || (
-        nextPreference.worktreeEnabled === currentDraft.worktreeEnabled
-        && nextPreference.worktreePreferenceCustomized
-          === currentDraft.worktreePreferenceCustomized
-      )
-    ) return;
-    // Only this workstation-wide preference is cross-window shared. Keep transient per-window
-    // draft targets (deviceLinkDeviceId/extraDirs, etc.) untouched.
-    currentDraft = { ...currentDraft, ...nextPreference };
+    const liveDefaultTuplePreference = readStoredDefaultTuplePreference();
+    const nextDefaultTuplePreference =
+      liveDefaultTuplePreference ??
+      (
+        event.newValue == null
+          ? defaultTuplePreferenceOf(makeDefault())
+          : parseStoredDefaultTuplePreference(event.newValue)
+      );
+    const worktreeChanged =
+      nextWorktreePreference !== undefined
+      && (
+        nextWorktreePreference.worktreeEnabled !== currentDraft.worktreeEnabled
+        || nextWorktreePreference.worktreePreferenceCustomized
+          !== currentDraft.worktreePreferenceCustomized
+      );
+    const defaultTupleChanged =
+      nextDefaultTuplePreference !== undefined
+      && !hasSameDefaultTuplePreference(
+        nextDefaultTuplePreference,
+        defaultTuplePreferenceOf(currentDraft),
+      );
+    if (!worktreeChanged && !defaultTupleChanged) return;
+    // 只有工作端级偏好跨窗口同步；deviceLinkDeviceId / extraDirs 等单窗口临时目标保持不动。
+    currentDraft = {
+      ...currentDraft,
+      ...(worktreeChanged ? nextWorktreePreference : {}),
+      ...(defaultTupleChanged ? nextDefaultTuplePreference : {}),
+    };
     emit();
   };
   window.addEventListener('storage', onStorage);
@@ -906,7 +987,7 @@ export function clearDefaultTupleTuningCustomization(args: {
     fastModeByModel: nextFastModeByModel,
     ...(shouldUnlock ? { defaultTupleCustomized: false } : {}),
   };
-  scheduleWrite();
+  scheduleWrite({ preserveStoredDefaultTupleCustomization: !shouldUnlock });
   emit();
 }
 
@@ -1027,6 +1108,7 @@ export function clearDraft(): void {
   currentDraft = makeDefault();
   scheduleWrite({
     preserveStoredWorktreePreference: false,
+    preserveStoredDefaultTupleCustomization: false,
   });
   emit();
 }

--- a/apps/desktop/src/renderer/state/providerModelMemory.ts
+++ b/apps/desktop/src/renderer/state/providerModelMemory.ts
@@ -191,6 +191,21 @@ export function subscribeProviderModelMemory(listener: () => void): () => void {
   return subscribe(listener);
 }
 
+/**
+ * 是否已有任一模型级预设 override。
+ *
+ * 旧版本可能只在本表留下 effort / Fast（或 thinking）而没有 newMakerDraft 的模型标记；
+ * 这些仍是明确的用户设置，连接态默认组合不得把它们覆盖掉。
+ */
+export function hasAnyProviderModelOverride(): boolean {
+  return Object.values(load()).some(
+    (slot) =>
+      Object.keys(slot.effortByModel).length > 0 ||
+      Object.keys(slot.fastByModel).length > 0 ||
+      Object.keys(slot.thinkingByModel).length > 0,
+  );
+}
+
 function persist(map: Record<string, ProviderMemory>): void {
   cache = map;
   emit();

--- a/apps/desktop/src/renderer/state/providerModelMemory.ts
+++ b/apps/desktop/src/renderer/state/providerModelMemory.ts
@@ -101,7 +101,11 @@ function sanitize(raw: unknown): Record<string, ProviderMemory> {
       thinkingByModel?: unknown;
     };
     const effortByModel: Record<string, Effort> = {};
-    if (rec.effortByModel && typeof rec.effortByModel === 'object' && !Array.isArray(rec.effortByModel)) {
+    if (
+      rec.effortByModel &&
+      typeof rec.effortByModel === 'object' &&
+      !Array.isArray(rec.effortByModel)
+    ) {
       for (const [mid, eff] of Object.entries(rec.effortByModel as Record<string, unknown>)) {
         if (mid && typeof eff === 'string' && eff.length > 0) effortByModel[mid] = eff as Effort;
       }
@@ -113,7 +117,11 @@ function sanitize(raw: unknown): Record<string, ProviderMemory> {
       }
     }
     const thinkingByModel: Record<string, boolean> = {};
-    if (rec.thinkingByModel && typeof rec.thinkingByModel === 'object' && !Array.isArray(rec.thinkingByModel)) {
+    if (
+      rec.thinkingByModel &&
+      typeof rec.thinkingByModel === 'object' &&
+      !Array.isArray(rec.thinkingByModel)
+    ) {
       for (const [mid, tb] of Object.entries(rec.thinkingByModel as Record<string, unknown>)) {
         if (mid && typeof tb === 'boolean') thinkingByModel[mid] = tb;
       }
@@ -122,7 +130,8 @@ function sanitize(raw: unknown): Record<string, ProviderMemory> {
       Object.keys(effortByModel).length === 0 &&
       Object.keys(fastByModel).length === 0 &&
       Object.keys(thinkingByModel).length === 0
-    ) continue;
+    )
+      continue;
     out[k] = {
       lastModel: typeof rec.lastModel === 'string' ? rec.lastModel : '',
       effortByModel,
@@ -141,7 +150,12 @@ function migrateV1(raw: unknown): Record<string, ProviderMemory> {
     if (!k || !v || typeof v !== 'object') continue;
     const model = (v as { model?: unknown }).model;
     const effort = (v as { effort?: unknown }).effort;
-    if (typeof model === 'string' && model.length > 0 && typeof effort === 'string' && effort.length > 0) {
+    if (
+      typeof model === 'string' &&
+      model.length > 0 &&
+      typeof effort === 'string' &&
+      effort.length > 0
+    ) {
       out[k] = {
         lastModel: model,
         effortByModel: { [model]: effort as Effort },
@@ -184,8 +198,249 @@ function migrateLegacyToOwner(ownerId: string): void {
 // 进程内缓存(惰性加载)。读多写少,避免每次读都 parse localStorage。
 let cache: Record<string, ProviderMemory> | null = null;
 
+/** 一次用户写入的最小表达；写盘失败后重放到最新共享快照，不能保存并覆盖整张旧表。 */
+type ProviderMemoryOp =
+  | {
+      kind: 'set-effort';
+      agent: AgentKind;
+      providerId: string;
+      model: string;
+      effort: Effort;
+    }
+  | { kind: 'set-last-model'; agent: AgentKind; providerId: string; model: string }
+  | { kind: 'set-fast'; agent: AgentKind; providerId: string; model: string; enabled: boolean }
+  | { kind: 'set-thinking'; agent: AgentKind; providerId: string; model: string; enabled: boolean }
+  | { kind: 'clear-effort'; agent: AgentKind; providerId: string; model: string }
+  | { kind: 'clear-fast'; agent: AgentKind; providerId: string; model: string };
+
+interface PendingProviderMemoryOp {
+  op: ProviderMemoryOp;
+  /** 首次写失败前该字段的共享值；恢复时已变化说明别窗有更新，本旧操作必须退休。 */
+  baseline: {
+    providerValue: Effort | boolean | undefined;
+    lastModel: string;
+    presetValue: Effort | boolean | undefined;
+  };
+  conflictKey: string;
+}
+
+/** localStorage 临时不可写时只留本窗口未落盘的操作，按 owner 隔离。 */
+const pendingOpsByStorageKey = new Map<string, PendingProviderMemoryOp[]>();
+const MAX_PENDING_OPS_PER_KEY = 100;
+
+function sameRecord<T extends string | boolean>(
+  left: Record<string, T>,
+  right: Record<string, T>,
+): boolean {
+  const leftKeys = Object.keys(left);
+  const rightKeys = Object.keys(right);
+  return leftKeys.length === rightKeys.length && leftKeys.every((key) => left[key] === right[key]);
+}
+
+function sameMap(
+  left: Record<string, ProviderMemory>,
+  right: Record<string, ProviderMemory>,
+): boolean {
+  const leftKeys = Object.keys(left);
+  const rightKeys = Object.keys(right);
+  return (
+    leftKeys.length === rightKeys.length &&
+    leftKeys.every((key) => {
+      const a = left[key];
+      const b = right[key];
+      return Boolean(
+        a &&
+        b &&
+        a.lastModel === b.lastModel &&
+        sameRecord(a.effortByModel, b.effortByModel) &&
+        sameRecord(a.fastByModel, b.fastByModel) &&
+        sameRecord(a.thinkingByModel, b.thinkingByModel),
+      );
+    })
+  );
+}
+
+function applyProviderMemoryOp(
+  map: Record<string, ProviderMemory>,
+  op: ProviderMemoryOp,
+): Record<string, ProviderMemory> {
+  const providerKey = keyOf(op.agent, op.providerId);
+  const provider = map[providerKey];
+  if (op.kind === 'set-effort') {
+    if (provider?.effortByModel[op.model] === op.effort) return map;
+    return {
+      ...map,
+      [providerKey]: {
+        lastModel: provider?.lastModel ?? '',
+        effortByModel: { ...(provider?.effortByModel ?? {}), [op.model]: op.effort },
+        fastByModel: provider?.fastByModel ?? {},
+        thinkingByModel: provider?.thinkingByModel ?? {},
+      },
+    };
+  }
+  if (op.kind === 'set-last-model') {
+    if (provider?.lastModel === op.model) return map;
+    return {
+      ...map,
+      [providerKey]: {
+        lastModel: op.model,
+        effortByModel: provider?.effortByModel ?? {},
+        fastByModel: provider?.fastByModel ?? {},
+        thinkingByModel: provider?.thinkingByModel ?? {},
+      },
+    };
+  }
+  if (op.kind === 'set-fast') {
+    if (provider?.fastByModel?.[op.model] === op.enabled) return map;
+    return {
+      ...map,
+      [providerKey]: {
+        lastModel: provider?.lastModel ?? '',
+        effortByModel: provider?.effortByModel ?? {},
+        fastByModel: { ...(provider?.fastByModel ?? {}), [op.model]: op.enabled },
+        thinkingByModel: provider?.thinkingByModel ?? {},
+      },
+    };
+  }
+  if (op.kind === 'set-thinking') {
+    if (provider?.thinkingByModel?.[op.model] === op.enabled) return map;
+    return {
+      ...map,
+      [providerKey]: {
+        lastModel: provider?.lastModel ?? '',
+        effortByModel: provider?.effortByModel ?? {},
+        fastByModel: provider?.fastByModel ?? {},
+        thinkingByModel: { ...(provider?.thinkingByModel ?? {}), [op.model]: op.enabled },
+      },
+    };
+  }
+
+  const field = op.kind === 'clear-effort' ? 'effortByModel' : 'fastByModel';
+  const presetKey = presetKeyOf(op.agent);
+  const nextProvider = withoutModelKey(provider, field, op.model);
+  const nextPreset = withoutModelKey(map[presetKey], field, op.model);
+  if (!nextProvider && !nextPreset) return map;
+  return {
+    ...map,
+    ...(nextProvider ? { [providerKey]: nextProvider } : {}),
+    ...(nextPreset ? { [presetKey]: nextPreset } : {}),
+  };
+}
+
+function opDimension(op: ProviderMemoryOp): 'effort' | 'fast' | 'thinking' | 'last-model' {
+  if (op.kind === 'set-last-model') return 'last-model';
+  if (op.kind === 'set-thinking') return 'thinking';
+  if (op.kind === 'set-fast' || op.kind === 'clear-fast') return 'fast';
+  return 'effort';
+}
+
+function opConflictKey(op: ProviderMemoryOp): string {
+  if (op.kind === 'set-last-model') return `${keyOf(op.agent, op.providerId)}:last-model`;
+  return `${keyOf(op.agent, op.providerId)}:${op.model}:${opDimension(op)}`;
+}
+
+/** 捕获该维度的完整基线；匹配时再按最终 op 的实际写集选字段。 */
+function captureOpConflictBaseline(
+  map: Record<string, ProviderMemory>,
+  op: ProviderMemoryOp,
+): PendingProviderMemoryOp['baseline'] {
+  const provider = map[keyOf(op.agent, op.providerId)];
+  if (op.kind === 'set-last-model') {
+    return {
+      providerValue: undefined,
+      lastModel: provider?.lastModel ?? '',
+      presetValue: undefined,
+    };
+  }
+  if (opDimension(op) === 'thinking') {
+    return {
+      providerValue: provider?.thinkingByModel[op.model],
+      lastModel: provider?.lastModel ?? '',
+      presetValue: undefined,
+    };
+  }
+  const preset = map[presetKeyOf(op.agent)];
+  if (opDimension(op) === 'fast') {
+    return {
+      providerValue: provider?.fastByModel[op.model],
+      lastModel: provider?.lastModel ?? '',
+      presetValue: preset?.fastByModel[op.model],
+    };
+  }
+  return {
+    providerValue: provider?.effortByModel[op.model],
+    lastModel: provider?.lastModel ?? '',
+    presetValue: preset?.effortByModel[op.model],
+  };
+}
+
+/** 只比较最终 op 真正会写的字段；其它模型/维度变化可安全合并。 */
+function matchesOpConflictBaseline(
+  map: Record<string, ProviderMemory>,
+  pending: PendingProviderMemoryOp,
+): boolean {
+  const { op, baseline } = pending;
+  const current = captureOpConflictBaseline(map, op);
+  if (op.kind === 'set-last-model') return current.lastModel === baseline.lastModel;
+  if (current.providerValue !== baseline.providerValue) return false;
+  if (op.kind === 'clear-effort' || op.kind === 'clear-fast') {
+    return current.presetValue === baseline.presetValue;
+  }
+  return true;
+}
+
+function recordPendingOp(
+  key: string,
+  op: ProviderMemoryOp,
+  base: Record<string, ProviderMemory>,
+): void {
+  const conflictKey = opConflictKey(op);
+  const current = pendingOpsByStorageKey.get(key) ?? [];
+  const previous = current.find((entry) => entry.conflictKey === conflictKey);
+  const next = [
+    ...current.filter((entry) => entry.conflictKey !== conflictKey),
+    {
+      op,
+      conflictKey,
+      // 同字段多次失败只保留最终意图，但基线必须是第一次失败前的共享值。
+      baseline: previous?.baseline ?? captureOpConflictBaseline(base, op),
+    },
+  ];
+  pendingOpsByStorageKey.set(key, next.slice(-MAX_PENDING_OPS_PER_KEY));
+}
+
+function applyPendingOps(
+  key: string,
+  map: Record<string, ProviderMemory>,
+): Record<string, ProviderMemory> {
+  let next = map;
+  const pendingOps = pendingOpsByStorageKey.get(key) ?? [];
+  const survivors: PendingProviderMemoryOp[] = [];
+  for (const pending of pendingOps) {
+    if (!matchesOpConflictBaseline(next, pending)) continue;
+    survivors.push(pending);
+    next = applyProviderMemoryOp(next, pending.op);
+  }
+  if (survivors.length !== pendingOps.length) {
+    if (survivors.length > 0) pendingOpsByStorageKey.set(key, survivors);
+    else pendingOpsByStorageKey.delete(key);
+  }
+  return next;
+}
+
+function loadFromStorage(): Record<string, ProviderMemory> {
+  if (typeof window === 'undefined') return {};
+  try {
+    const raw = window.localStorage.getItem(storageKey());
+    return raw ? sanitize(JSON.parse(raw)) : {};
+  } catch {
+    return {};
+  }
+}
+
 function load(): Record<string, ProviderMemory> {
   if (cache) return cache;
+  const key = storageKey();
   if (typeof window === 'undefined') {
     cache = {};
     return cache;
@@ -193,23 +448,56 @@ function load(): Record<string, ProviderMemory> {
   try {
     const rawV2 = window.localStorage.getItem(storageKey());
     if (rawV2) {
-      cache = sanitize(JSON.parse(rawV2));
+      cache = applyPendingOps(key, sanitize(JSON.parse(rawV2)));
       return cache;
     }
     // 无 v2 → 尝试从历史 v1 迁移(只灌缓存,下次 set 再落盘 v2)。
-    const rawV1 = activeDataOwnerId
-      ? null
-      : window.localStorage.getItem(LEGACY_STORAGE_KEY_V1);
-    cache = rawV1 ? migrateV1(JSON.parse(rawV1)) : {};
+    const rawV1 = activeDataOwnerId ? null : window.localStorage.getItem(LEGACY_STORAGE_KEY_V1);
+    cache = applyPendingOps(key, rawV1 ? migrateV1(JSON.parse(rawV1)) : {});
   } catch {
     cache = {};
   }
   return cache;
 }
 
+/**
+ * 整表写回前重读当前 owner 分区，避免另一个 renderer 刚写入的 override 被本窗口旧缓存覆盖。
+ * localStorage 不可读时保留本窗口内存态，不能用空表抹掉尚未成功持久化的用户选择。
+ */
+function freshMap(): Record<string, ProviderMemory> {
+  if (typeof window === 'undefined') return load();
+  const key = storageKey();
+  let raw: string | null;
+  try {
+    raw = window.localStorage.getItem(storageKey());
+  } catch {
+    return load();
+  }
+  if (raw === null) return load();
+  try {
+    const stored = sanitize(JSON.parse(raw));
+    const next = applyPendingOps(key, stored);
+    if (pendingOpsByStorageKey.has(key)) {
+      try {
+        if (!sameMap(stored, next)) window.localStorage.setItem(key, JSON.stringify(next));
+        pendingOpsByStorageKey.delete(key);
+      } catch {
+        // 仍不可写：保留最小 op，下一次写入继续在最新共享快照上重放。
+      }
+    }
+    if (cache === null || !sameMap(cache, next)) {
+      cache = next;
+      emit();
+    }
+    return next;
+  } catch {
+    return load();
+  }
+}
+
 // 变更通知:device-link 被控端要把 providerModelMemory 镜像给 main(草稿列表行的真实读源),
-// 控制端的镜像 / ModelSelector 也据此重渲染。persist 是唯一写路径(set* 同值短路后才到这里),
-// 故在此统一 bump version + emit。
+// 控制端的镜像 / ModelSelector 也据此重渲染。本窗口 persist 与其它 renderer 的 storage 事件
+// 都在采纳最新缓存后 bump version + emit。
 const listeners = new Set<() => void>();
 let version = 0;
 function emit(): void {
@@ -232,6 +520,27 @@ export function subscribeProviderModelMemory(listener: () => void): () => void {
   return subscribe(listener);
 }
 
+const removeStorageListener = (() => {
+  if (typeof window === 'undefined' || typeof window.addEventListener !== 'function') return null;
+  const onStorage = (event: StorageEvent): void => {
+    if (event.storageArea && event.storageArea !== window.localStorage) return;
+    if (event.key !== null && event.key !== storageKey()) return;
+    // storage 事件可能迟到，event.newValue 不是当前真相；始终重读当前 owner 分区。
+    const next = applyPendingOps(storageKey(), loadFromStorage());
+    if (cache !== null && sameMap(cache, next)) return;
+    cache = next;
+    emit();
+  };
+  window.addEventListener('storage', onStorage);
+  return () => window.removeEventListener('storage', onStorage);
+})();
+
+if (import.meta.hot) {
+  import.meta.hot.dispose(() => {
+    removeStorageListener?.();
+  });
+}
+
 /**
  * 是否已有任一模型级预设 override。
  *
@@ -247,14 +556,21 @@ export function hasAnyProviderModelOverride(): boolean {
   );
 }
 
-function persist(map: Record<string, ProviderMemory>): void {
+function persist(
+  map: Record<string, ProviderMemory>,
+  ops: ProviderMemoryOp[],
+  base: Record<string, ProviderMemory>,
+): void {
+  const key = storageKey();
   cache = map;
   emit();
   if (typeof window === 'undefined') return;
   try {
-    window.localStorage.setItem(storageKey(), JSON.stringify(map));
+    window.localStorage.setItem(key, JSON.stringify(map));
+    pendingOpsByStorageKey.delete(key);
   } catch {
-    // localStorage 满 / 私密窗口禁写 —— 忽略,不影响内存缓存。
+    // 只记最小操作；恢复可写后重放到最新共享快照，不能用本窗口旧整表覆盖另一 renderer。
+    for (const op of ops) recordPendingOp(key, op, base);
   }
 }
 
@@ -269,7 +585,6 @@ export function getProviderModelChoice(
   if (!providerId) return undefined;
   const rec = load()[keyOf(agent, providerId)];
   if (!rec || !rec.lastModel) return undefined;
-  const map = load();
   const effort = rec.effortByModel[rec.lastModel];
   return effort ? { model: rec.lastModel, effort } : undefined;
 }
@@ -296,21 +611,16 @@ function setModelEffort(
   updateLastModel: boolean,
 ): void {
   if (!providerId || providerId === MODEL_PRESET_SLOT_ID || !model || !effort) return;
-  const map = load();
-  const providerKey = keyOf(agent, providerId);
-  const provider = map[providerKey];
-  const lastModel = updateLastModel ? model : (provider?.lastModel ?? '');
-  if (provider?.lastModel === lastModel && provider.effortByModel[model] === effort) return;
-
-  persist({
-    ...map,
-    [providerKey]: {
-      lastModel,
-      effortByModel: { ...(provider?.effortByModel ?? {}), [model]: effort },
-      fastByModel: provider?.fastByModel ?? {},
-      thinkingByModel: provider?.thinkingByModel ?? {},
-    },
-  });
+  const map = freshMap();
+  const ops: ProviderMemoryOp[] = [
+    { kind: 'set-effort', agent, providerId, model, effort },
+    ...(updateLastModel
+      ? [{ kind: 'set-last-model', agent, providerId, model } as ProviderMemoryOp]
+      : []),
+  ];
+  const next = ops.reduce(applyProviderMemoryOp, map);
+  if (next === map) return;
+  persist(next, ops, map);
 }
 
 /** 只更新模型级全局 effort,不把「编辑非选中模型」误记为该来源上次选中的模型。 */
@@ -359,19 +669,11 @@ export function setProviderModelFast(
   enabled: boolean,
 ): void {
   if (!providerId || providerId === MODEL_PRESET_SLOT_ID || !model) return;
-  const map = load();
-  const providerKey = keyOf(agent, providerId);
-  const provider = map[providerKey];
-  if (provider?.fastByModel?.[model] === enabled) return;
-  persist({
-    ...map,
-    [providerKey]: {
-      lastModel: provider?.lastModel ?? '',
-      effortByModel: provider?.effortByModel ?? {},
-      fastByModel: { ...(provider?.fastByModel ?? {}), [model]: enabled },
-      thinkingByModel: provider?.thinkingByModel ?? {},
-    },
-  });
+  const map = freshMap();
+  const op: ProviderMemoryOp = { kind: 'set-fast', agent, providerId, model, enabled };
+  const next = applyProviderMemoryOp(map, op);
+  if (next === map) return;
+  persist(next, [op], map);
 }
 
 export function getProviderModelThinking(
@@ -390,19 +692,11 @@ export function setProviderModelThinking(
   enabled: boolean,
 ): void {
   if (!providerId || providerId === MODEL_PRESET_SLOT_ID || !model) return;
-  const map = load();
-  const providerKey = keyOf(agent, providerId);
-  const provider = map[providerKey];
-  if (provider?.thinkingByModel?.[model] === enabled) return;
-  persist({
-    ...map,
-    [providerKey]: {
-      lastModel: provider?.lastModel ?? '',
-      effortByModel: provider?.effortByModel ?? {},
-      fastByModel: provider?.fastByModel ?? {},
-      thinkingByModel: { ...(provider?.thinkingByModel ?? {}), [model]: enabled },
-    },
-  });
+  const map = freshMap();
+  const op: ProviderMemoryOp = { kind: 'set-thinking', agent, providerId, model, enabled };
+  const next = applyProviderMemoryOp(map, op);
+  if (next === map) return;
+  persist(next, [op], map);
 }
 
 /**
@@ -435,17 +729,11 @@ export function clearProviderModelEffort(
   model: string,
 ): void {
   if (!providerId || providerId === MODEL_PRESET_SLOT_ID || !model) return;
-  const map = load();
-  const providerKey = keyOf(agent, providerId);
-  const presetKey = presetKeyOf(agent);
-  const nextProvider = withoutModelKey(map[providerKey], 'effortByModel', model);
-  const nextPreset = withoutModelKey(map[presetKey], 'effortByModel', model);
-  if (!nextProvider && !nextPreset) return;
-  persist({
-    ...map,
-    ...(nextProvider ? { [providerKey]: nextProvider } : {}),
-    ...(nextPreset ? { [presetKey]: nextPreset } : {}),
-  });
+  const map = freshMap();
+  const op: ProviderMemoryOp = { kind: 'clear-effort', agent, providerId, model };
+  const next = applyProviderMemoryOp(map, op);
+  if (next === map) return;
+  persist(next, [op], map);
 }
 
 /**
@@ -453,23 +741,13 @@ export function clearProviderModelEffort(
  * 表里没有该键 ⇒ 跟随默认(读侧 `getProviderModelFast` 返回 undefined,调用方按「关」解释),
  * 而不是落一份「显式 false」的快照 —— 后者同样是把当前默认固化成用户配置。
  */
-export function clearProviderModelFast(
-  agent: AgentKind,
-  providerId: string,
-  model: string,
-): void {
+export function clearProviderModelFast(agent: AgentKind, providerId: string, model: string): void {
   if (!providerId || providerId === MODEL_PRESET_SLOT_ID || !model) return;
-  const map = load();
-  const providerKey = keyOf(agent, providerId);
-  const presetKey = presetKeyOf(agent);
-  const nextProvider = withoutModelKey(map[providerKey], 'fastByModel', model);
-  const nextPreset = withoutModelKey(map[presetKey], 'fastByModel', model);
-  if (!nextProvider && !nextPreset) return;
-  persist({
-    ...map,
-    ...(nextProvider ? { [providerKey]: nextProvider } : {}),
-    ...(nextPreset ? { [presetKey]: nextPreset } : {}),
-  });
+  const map = freshMap();
+  const op: ProviderMemoryOp = { kind: 'clear-fast', agent, providerId, model };
+  const next = applyProviderMemoryOp(map, op);
+  if (next === map) return;
+  persist(next, [op], map);
 }
 
 /**
@@ -517,6 +795,7 @@ export function setProviderModelMemoryOwner(ownerId: string | null): void {
 export function __resetForTest(): void {
   const keyBeforeReset = storageKey();
   cache = null;
+  pendingOpsByStorageKey.clear();
   if (typeof window !== 'undefined') {
     try {
       window.localStorage.removeItem(keyBeforeReset);

--- a/apps/desktop/src/renderer/state/providerModelMemory.ts
+++ b/apps/desktop/src/renderer/state/providerModelMemory.ts
@@ -29,11 +29,12 @@
  *   xd 来源同时服务 cc / codex 两个 agent,若只按 providerId 分槽,cc 会话与 codex 会话会
  *   互相覆盖对方在 xd 下的选择。agent 维度始终保留;只有同 agent 的同 model 才跨来源共享预设。
  *
- * 持久化频率极低(仅用户点 dropdown 触发),同步写 localStorage,不做 batch / debounce
+ * 按 dataOwnerId 分区持久化；升级时首个稳定 owner 一次性认领旧设备全局快照，避免多账号
+ * 互相继承 effort / Fast。持久化频率极低(仅用户点 dropdown 触发),同步写 localStorage,不做 batch / debounce
  * —— 与 newMakerDraft 的取舍一致(避免热更新 relaunch 强退丢最近一次改动)。
  *
- * 版本:STORAGE_KEY 为 v2(多槽)。冷启动时若只有历史 v1(单槽 {model,effort})数据,惰性迁移
- * 进缓存(下次 set 落盘到 v2),不破坏老用户的「来源 lastModel」连续性。
+ * 版本:STORAGE_KEY 为 v2(多槽)。未建立 owner 分区前若只有历史 v1(单槽 {model,effort})
+ * 数据,仍可迁移为首个 owner 的 v2 快照,不破坏老用户的「来源 lastModel」连续性。
  */
 
 import { useSyncExternalStore } from 'react';
@@ -46,6 +47,16 @@ const STORAGE_KEY = 'xdt:providerModelMemory:v2';
 const LEGACY_STORAGE_KEY_V1 = 'xdt:providerModelMemory:v1';
 /** v2 schema 内的保留来源 id:同一 agent 下跨真实 provider 共享的模型级预设槽。 */
 export const MODEL_PRESET_SLOT_ID = '*';
+
+let activeDataOwnerId: string | null = null;
+
+function ownerStorageKey(ownerId: string): string {
+  return `${STORAGE_KEY}:${encodeURIComponent(ownerId)}`;
+}
+
+function storageKey(): string {
+  return activeDataOwnerId ? ownerStorageKey(activeDataOwnerId) : STORAGE_KEY;
+}
 
 /**
  * 单个来源槽:真实来源槽记「上次选中的模型」+ 兼容副本;`*` 槽记权威模型级 effort / fast。
@@ -142,6 +153,34 @@ function migrateV1(raw: unknown): Record<string, ProviderMemory> {
   return out;
 }
 
+/**
+ * 旧版只有一份设备全局快照。升级后的第一个稳定 owner 一次性认领它；随后删除旧 key，
+ * 其它账号只读各自命名空间，避免 A 的 effort / Fast 让 B 被误判为已自定义。
+ */
+function migrateLegacyToOwner(ownerId: string): void {
+  if (typeof window === 'undefined') return;
+  try {
+    const scopedKey = ownerStorageKey(ownerId);
+    if (window.localStorage.getItem(scopedKey) !== null) return;
+
+    const rawV2 = window.localStorage.getItem(STORAGE_KEY);
+    const rawV1 = window.localStorage.getItem(LEGACY_STORAGE_KEY_V1);
+    const migrated = rawV2
+      ? sanitize(JSON.parse(rawV2))
+      : rawV1
+        ? migrateV1(JSON.parse(rawV1))
+        : null;
+    if (!migrated) return;
+
+    window.localStorage.setItem(scopedKey, JSON.stringify(migrated));
+    if (window.localStorage.getItem(scopedKey) === null) return;
+    window.localStorage.removeItem(STORAGE_KEY);
+    window.localStorage.removeItem(LEGACY_STORAGE_KEY_V1);
+  } catch {
+    // 认领失败时保留旧 key；当前 owner 按空分区运行，绝不把未归属数据串给其它账号。
+  }
+}
+
 // 进程内缓存(惰性加载)。读多写少,避免每次读都 parse localStorage。
 let cache: Record<string, ProviderMemory> | null = null;
 
@@ -152,13 +191,15 @@ function load(): Record<string, ProviderMemory> {
     return cache;
   }
   try {
-    const rawV2 = window.localStorage.getItem(STORAGE_KEY);
+    const rawV2 = window.localStorage.getItem(storageKey());
     if (rawV2) {
       cache = sanitize(JSON.parse(rawV2));
       return cache;
     }
     // 无 v2 → 尝试从历史 v1 迁移(只灌缓存,下次 set 再落盘 v2)。
-    const rawV1 = window.localStorage.getItem(LEGACY_STORAGE_KEY_V1);
+    const rawV1 = activeDataOwnerId
+      ? null
+      : window.localStorage.getItem(LEGACY_STORAGE_KEY_V1);
     cache = rawV1 ? migrateV1(JSON.parse(rawV1)) : {};
   } catch {
     cache = {};
@@ -211,7 +252,7 @@ function persist(map: Record<string, ProviderMemory>): void {
   emit();
   if (typeof window === 'undefined') return;
   try {
-    window.localStorage.setItem(STORAGE_KEY, JSON.stringify(map));
+    window.localStorage.setItem(storageKey(), JSON.stringify(map));
   } catch {
     // localStorage 满 / 私密窗口禁写 —— 忽略,不影响内存缓存。
   }
@@ -462,17 +503,30 @@ export function snapshotForSeed(): Record<
   return out;
 }
 
+/** 随认证 dataOwnerId 切换模型预设命名空间，和 newMakerDraft / modelEnginePrefs 同步。 */
+export function setProviderModelMemoryOwner(ownerId: string | null): void {
+  const normalized = typeof ownerId === 'string' && ownerId.trim().length > 0 ? ownerId : null;
+  if (activeDataOwnerId === normalized) return;
+  if (normalized) migrateLegacyToOwner(normalized);
+  activeDataOwnerId = normalized;
+  cache = null;
+  emit();
+}
+
 /** 测试用 —— 重置缓存 + 清 localStorage(其它代码不应调用)。 */
 export function __resetForTest(): void {
+  const keyBeforeReset = storageKey();
   cache = null;
   if (typeof window !== 'undefined') {
     try {
+      window.localStorage.removeItem(keyBeforeReset);
       window.localStorage.removeItem(STORAGE_KEY);
       window.localStorage.removeItem(LEGACY_STORAGE_KEY_V1);
     } catch {
       // ignore
     }
   }
+  activeDataOwnerId = null;
 }
 
 export const __STORAGE_KEY = STORAGE_KEY;

--- a/docs/product-rules/model-selector-unified.md
+++ b/docs/product-rules/model-selector-unified.md
@@ -21,6 +21,7 @@
 
 ### 1.2 面板(向下展开)
 
+- 未保存过形态偏好的用户默认进入 **A 版**(`classic`)；原始版与 B 版继续保留为用户可选偏好，升级不改已保存选择。
 - 结构:搜索框贴顶 → 左侧 rail(★收藏 / [同引擎·仅会话内] / 全部 / 各供应商图标) → 右侧列表 → 底部「＋添加模型」。
 - 宽度自适应:`max-content`,min 460px / max min(600px, 100vw-48px)——长名先撑宽,到上限才截断,不硬砍。
 - 行(双行):
@@ -150,9 +151,11 @@
 
 | 情形 | 行为 |
 |---|---|
-| 新用户 | 无任何 override;推荐映射+目录默认(`newSessionDefault`→排序首个 defaultEnabled)生效;服务端改推荐,升级即跟随 |
-| 未自定义老用户 | 同新用户;旧 lastByVendor 种子值因 `modelChosenByVendor` 未置位而不视为自定义(现有语义) |
-| 已自定义老用户 | `modelChosenByVendor=true` 的 vendor 模型选择、providerModelMemory 深度/Fast、新引擎 override 全部保留;**零迁移**——新 store 为空即「全部跟随推荐」,旧数据不搬不猜 |
+| 新用户 | 本地新任务按完整组合落点：OpenAI 订阅→GPT-5.6-Sol / Codex / high；Anthropic 订阅→Claude Opus 5 / Claude Code / high；xAI 订阅→Grok 4.6 / Pi / high；中国区 Gateway→DeepSeek V4 Pro / Codex / high。首选 Harness 未安装时才在同一来源内降级 |
+| 多来源 | 可用订阅优先于 Gateway；客户端没有“最近连接时间”时，多订阅稳定按 OpenAI→Anthropic→xAI。来源仍在加载、账号目录没有目标模型、或零来源时不编造组合，保留连接引导 |
+| 未自定义老用户 | 同新用户；自动下放不设置 `modelChosenByVendor`。历史非 cc Harness、显式模型或显式来源迁移为已自定义，避免升级后换掉真实使用组合 |
+| 已自定义老用户 | 任一明确的 Harness / 来源 / 模型 / 思考深度 / Fast 选择会封住后续自动下放；`modelChosenByVendor`、providerModelMemory、引擎 override 与形态偏好全部保留 |
+| 远程任务 | SSH / device-link 不套用控制端本机登录态；继续由执行端能力与来源快照决定，避免把本机授权强塞给远端 |
 
 ---
 

--- a/docs/product-rules/model-selector-unified.md
+++ b/docs/product-rules/model-selector-unified.md
@@ -153,7 +153,7 @@
 |---|---|
 | 新用户 | 本地新任务按完整组合落点：OpenAI 订阅→GPT-5.6-Sol / Codex / high；Anthropic 订阅→Claude Opus 5 / Claude Code / high；xAI 订阅→Grok 4.6 / Pi / high；CN / Global Cindy Gateway→原生多模态 GLM-5.3-Flash / Codex / high。Gateway 默认还必须明确声明图片输入能力；首选 Harness 未安装时才在同一来源内降级 |
 | 多来源 | 可用订阅优先于 Gateway；客户端没有“最近连接时间”时，多订阅稳定按 OpenAI→Anthropic→xAI。来源仍在加载、账号目录没有目标模型、或零来源时不编造组合，保留连接引导 |
-| 未自定义老用户 | 同新用户；自动下放不设置 `modelChosenByVendor`。历史非 cc Harness、显式模型或显式来源迁移为已自定义，避免升级后换掉真实使用组合 |
+| 未自定义老用户 | 同新用户；自动下放不设置 `modelChosenByVendor`。仅由旧版 cc 不可用触发并持久化的非 cc Harness 仍属于系统回退，不算用户自定义 |
 | 已自定义老用户 | 任一明确的 Harness / 来源 / 模型 / 思考深度 / Fast 选择会封住后续自动下放；`modelChosenByVendor`、providerModelMemory、引擎 override 与形态偏好全部保留 |
 | 远程任务 | SSH / device-link 不套用控制端本机登录态；继续由执行端能力与来源快照决定，避免把本机授权强塞给远端 |
 

--- a/docs/product-rules/model-selector-unified.md
+++ b/docs/product-rules/model-selector-unified.md
@@ -151,7 +151,7 @@
 
 | 情形 | 行为 |
 |---|---|
-| 新用户 | 本地新任务按完整组合落点：OpenAI 订阅→GPT-5.6-Sol / Codex / high；Anthropic 订阅→Claude Opus 5 / Claude Code / high；xAI 订阅→Grok 4.6 / Pi / high；CN / Global Cindy Gateway→原生多模态 GLM-5.3-Flash / Codex / high。Gateway 默认还必须明确声明图片输入能力；首选 Harness 未安装时才在同一来源内降级 |
+| 新用户 | 本地新任务按完整组合落点：OpenAI 订阅→GPT-5.6-Sol / Codex / high；Anthropic 订阅→Claude Opus 5 / Claude Code / high；xAI 订阅→Grok 4.6 / Pi / high；CN / Global Cindy Gateway→原生多模态 GLM-5.3-Flash / Pi / high。Gateway 默认必须同时明确声明图片输入与 Pi 实时能力；Pi 不可用时不把该默认强塞进 Codex 或 Claude Code |
 | 多来源 | 可用订阅优先于 Gateway；客户端没有“最近连接时间”时，多订阅稳定按 OpenAI→Anthropic→xAI。来源仍在加载、账号目录没有目标模型、或零来源时不编造组合，保留连接引导 |
 | 未自定义老用户 | 同新用户；自动下放不设置 `modelChosenByVendor`。仅由旧版 cc 不可用触发并持久化的非 cc Harness 仍属于系统回退，不算用户自定义 |
 | 已自定义老用户 | 任一明确的 Harness / 来源 / 模型 / 思考深度 / Fast 选择会封住后续自动下放；`modelChosenByVendor`、providerModelMemory、引擎 override 与形态偏好全部保留 |

--- a/docs/product-rules/model-selector-unified.md
+++ b/docs/product-rules/model-selector-unified.md
@@ -151,7 +151,7 @@
 
 | 情形 | 行为 |
 |---|---|
-| 新用户 | 本地新任务按完整组合落点：OpenAI 订阅→GPT-5.6-Sol / Codex / high；Anthropic 订阅→Claude Opus 5 / Claude Code / high；xAI 订阅→Grok 4.6 / Pi / high；中国区 Gateway→DeepSeek V4 Pro / Codex / high。首选 Harness 未安装时才在同一来源内降级 |
+| 新用户 | 本地新任务按完整组合落点：OpenAI 订阅→GPT-5.6-Sol / Codex / high；Anthropic 订阅→Claude Opus 5 / Claude Code / high；xAI 订阅→Grok 4.6 / Pi / high；CN / Global Cindy Gateway→DeepSeek V4 Pro / Codex / high。首选 Harness 未安装时才在同一来源内降级 |
 | 多来源 | 可用订阅优先于 Gateway；客户端没有“最近连接时间”时，多订阅稳定按 OpenAI→Anthropic→xAI。来源仍在加载、账号目录没有目标模型、或零来源时不编造组合，保留连接引导 |
 | 未自定义老用户 | 同新用户；自动下放不设置 `modelChosenByVendor`。历史非 cc Harness、显式模型或显式来源迁移为已自定义，避免升级后换掉真实使用组合 |
 | 已自定义老用户 | 任一明确的 Harness / 来源 / 模型 / 思考深度 / Fast 选择会封住后续自动下放；`modelChosenByVendor`、providerModelMemory、引擎 override 与形态偏好全部保留 |

--- a/docs/product-rules/model-selector-unified.md
+++ b/docs/product-rules/model-selector-unified.md
@@ -151,7 +151,7 @@
 
 | 情形 | 行为 |
 |---|---|
-| 新用户 | 本地新任务按完整组合落点：OpenAI 订阅→GPT-5.6-Sol / Codex / high；Anthropic 订阅→Claude Opus 5 / Claude Code / high；xAI 订阅→Grok 4.6 / Pi / high；CN / Global Cindy Gateway→DeepSeek V4 Pro / Codex / high。首选 Harness 未安装时才在同一来源内降级 |
+| 新用户 | 本地新任务按完整组合落点：OpenAI 订阅→GPT-5.6-Sol / Codex / high；Anthropic 订阅→Claude Opus 5 / Claude Code / high；xAI 订阅→Grok 4.6 / Pi / high；CN / Global Cindy Gateway→原生多模态 GLM-5.3-Flash / Codex / high。Gateway 默认还必须明确声明图片输入能力；首选 Harness 未安装时才在同一来源内降级 |
 | 多来源 | 可用订阅优先于 Gateway；客户端没有“最近连接时间”时，多订阅稳定按 OpenAI→Anthropic→xAI。来源仍在加载、账号目录没有目标模型、或零来源时不编造组合，保留连接引导 |
 | 未自定义老用户 | 同新用户；自动下放不设置 `modelChosenByVendor`。历史非 cc Harness、显式模型或显式来源迁移为已自定义，避免升级后换掉真实使用组合 |
 | 已自定义老用户 | 任一明确的 Harness / 来源 / 模型 / 思考深度 / Fast 选择会封住后续自动下放；`modelChosenByVendor`、providerModelMemory、引擎 override 与形态偏好全部保留 |


### PR DESCRIPTION
## 这次改了什么

### 摘要

新任务会根据当前用户真正可用的订阅、Gateway 与本机 Harness，原子选择“来源 + 模型 + Harness + 思考深度”；模型选择器样式 A 同时成为未保存过样式偏好的默认界面。

默认矩阵：

- OpenAI 订阅：GPT-5.6-Sol + Codex + high
- Anthropic 订阅：Claude Opus 5 + Claude Code + high
- xAI 订阅：Grok 4.6 + Pi + high
- CN / Global Gateway：GLM-5.3-Flash + Pi + high

Gateway 组合只在服务端实时确认模型同时支持 text + image 输入、Responses / Pi 路由且本机 Pi 可用时采用；缺少任一条件就不伪造默认，也不会转塞 Claude Harness。订阅优先于 Gateway；多个订阅没有连接时间依据时稳定按 OpenAI → Anthropic → xAI。

### 变更类型

- [x] feat 新功能
- [x] fix 缺陷修复
- [ ] refactor / perf 重构或性能优化
- [ ] docs / test / chore 文档、测试或工程维护
- [ ] 其他：

### 范围

- 关联 Issue / 需求：新任务默认模型、Harness 与思考深度优化；模型选择器样式 A 转默认
- 本 PR 包含：
  - 本地新任务的来源感知默认组合 resolver 与接线
  - 用户显式 Harness / 来源 / 模型 / 思考深度 / Fast 选择保护
  - 稀疏 preserving 草稿、完整旧版 seeded snapshot 与系统 fallback 的迁移区分
  - providerModelMemory 按 dataOwnerId 分区，旧全局记忆仅由首个稳定账号一次性认领
  - 不可用性回退与推荐组合基于同一份最新状态计算，避免旧闭包覆盖 xAI → Pi
  - SSH / device-link 执行端边界
  - 模型选择器样式 A 缺省与既有偏好保留
  - 产品规则与单元测试
- 明确不包含：
  - 不改变手动可选模型或 Harness 范围
  - 不改变 wire protocol、远程草稿 schema 或会话数据库
  - 不启动或修改 Desktop DEV / 用户授权
- 用户可见变化：
  - 新用户与没有自定义过组合的老用户，打开本地新任务会直接落到匹配其可用授权的完整组合
  - 无来源、加载未完成、目录缺模型、缺图片能力或缺首选 Harness 时保持连接引导，不伪造可发送组合
  - 只保存了 effort / Fast 的用户也视为已有自定义，不被新默认覆盖
  - 已经改过任一模型组合轴的老用户不被覆盖；旧版系统 fallback 不会误算成用户自定义
  - 未保存过选择器形态的用户默认看到样式 A；已保存 original / classic / badge 的用户保持原值
- 是否存在 breaking change：无

### UI 变化

- 引用的设计规范：
  - docs/design-rules/DESIGN.md 双模式交付门槛：本 PR 仅切换现有样式 A 的默认启用状态，无新增颜色或样式；A 版继续复用既有语义 token 与 Light / Dark 实现。
  - docs/product-rules/model-selector-unified.md §1.2、§2.5：记录样式 A 默认及新用户 / 老用户 / 远程任务行为矩阵。
- 未附截图：没有改动样式 A 自身的视觉实现，只改变首次缺省落点；按安全约束未启动 Desktop DEV。

## 怎么验证的

### 自动验证

    pnpm test:unit:related
    PASS：test runner 435 passed / 1 skipped / 0 failed；Desktop、Mobile 与相关 package 均通过

    pnpm --filter desktop run typecheck
    PASS：0 errors

    默认组合定向回归
    PASS：204/204

    pnpm check:dco
    PASS：origin/main..049831f0 范围 6 个提交全部签署

    git diff --check
    PASS

定向矩阵覆盖零来源、加载中、三种订阅、CN / Global Gateway、订阅优先、Pi 不可用、目录发现失败、旧草稿迁移、系统 fallback、effort / Fast-only override、多账号切换与样式偏好保留。

### 手工验证

在本机现有正式授权上做了不启动 Desktop DEV 的真实 Pi + GLM-5.3-Flash 会话验证：

- 固定 Pi、z-ai/glm-5.3-flash、high，关闭 fallback
- 真实读取用户提供的图片，并正确识别图中 6 个模型名
- 成功调用本机工具并返回 PI_TOOL_OK
- 同一任务第二轮正确引用首轮图片中的 deepseek-v4-flash-vision-exp，确认连续上下文与缓存读取有效

### 未执行的验证

- 未启动 Desktop 做实机 UI 目检；原因是本 PR 不修改样式 A 的视觉代码，且安全约束禁止 Agent 启动 Desktop DEV。
- 未改动、重新登录或重置任何本机模型授权。

## 风险

### 风险分类

- [ ] 无已知风险
- [ ] SQLite / migration
- [ ] system prompt
- [ ] 协议兼容
- [x] 权限 / 安全 / 用户数据：仅涉及按 dataOwnerId 隔离本地模型偏好，不涉及凭证
- [ ] 存量插件兼容（批准状态 / 指纹 / manifest 校验 / 安装布局 / 包格式）
- [ ] 原生层 / fingerprint / OTA
- [ ] 跨平台差异
- [x] 其他：新任务默认选择行为变化

### 影响与回滚

- 影响范围：Desktop 本地新任务首次默认组合；不影响已有任务、远程执行端或用户已保存的模型组合。
- 回滚 / 降级方式：
  - 回滚本 PR 即可恢复旧默认逻辑。
  - 用户可继续手动切换模型、来源、Harness、思考深度与选择器样式。
  - Gateway 默认依赖配套服务端 PR 的实时能力标记；服务端不下发或本机 Pi 不可用时客户端保持空态。

### 提交前检查

- [x] 已 review 完整 diff
- [x] 每个 commit 都带 DCO 签名
- [x] UI 改动已在“UI 变化”注明引用的设计规范章节
- [x] 未提交凭证、令牌或授权文件
- [x] 已补充必要文档
- [x] 已确认测试结果或说明未执行原因

