### PR TITLE
fix(maker-core): 把 upstream stream error 纳入自动续跑白名单

### DIFF
--- a/apps/desktop/src/main/maker-ipc/__tests__/interruptedTurnAutoResume.test.ts
+++ b/apps/desktop/src/main/maker-ipc/__tests__/interruptedTurnAutoResume.test.ts
@@ -146,6 +146,8 @@ describe('isInterruptedTurnError', () => {
       'upstream unreachable',
       '502 Bad Gateway',
       'Service Unavailable',
+      'API Error: upstream stream error: terminated',
+      'upstream stream error: socket reset',
     ]) {
       expect(isInterruptedTurnError({ message }), `${message} 应自动重连`).toBe(true);
     }
@@ -176,6 +178,7 @@ describe('isInterruptedTurnError', () => {
       ['codex thread', { message: 'thread not found' }],
       ['加密内容失效', { message: 'invalid encrypted content' }],
       ['Pi auto-retry 耗尽后交给用户点重试', { reason: 'pi-gateway-drop', message: 'The operation timed out.' }],
+      ['Codex 鉴权会话结束', { message: 'app_session_terminated' }],
     ] as Array<[string, Parameters<typeof isInterruptedTurnError>[0]]>) {
       expect(isInterruptedTurnError(signals), `${label} 不该自动重连`).toBe(false);
     }

--- a/apps/desktop/src/renderer/__tests__/networkError.test.ts
+++ b/apps/desktop/src/renderer/__tests__/networkError.test.ts
@@ -26,6 +26,10 @@ describe('isNetworkishErrorMessage', () => {
     'Reconnecting… 3/5 (stream disconnected before completion)',
     'The operation timed out.',
     'OpenAI Responses stream ended before a terminal response event',
+    // Cindy Responses bridge / compat-proxy 中途断流；Claude Code 再包 API Error:
+    'API Error: upstream stream error: terminated',
+    'upstream stream error: socket reset',
+    'upstream stream error: Error: terminated',
   ])('matches networkish message: %s', (msg) => {
     expect(isNetworkishErrorMessage(msg)).toBe(true);
   });
@@ -38,6 +42,9 @@ describe('isNetworkishErrorMessage', () => {
     'Wrapped error: API Error: The operation timed out.',
     // 长数字不因包含 502 片段误伤(\b 词边界)
     'order id 15024 rejected',
+    // 裸 terminated 是鉴权终态,不能当传输抖动
+    'app_session_terminated',
+    'Your session has ended. Please log in again. (app_session_terminated)',
   ])('does not match non-network message: %s', (msg) => {
     expect(isNetworkishErrorMessage(msg)).toBe(false);
   });

--- a/apps/desktop/src/renderer/utils/networkError.ts
+++ b/apps/desktop/src/renderer/utils/networkError.ts
@@ -14,6 +14,9 @@
  * `API Error: The operation timed out` / `Connection error` 是 Anthropic SDK 的
  * APIConnectionTimeoutError / APIConnectionError 原文(SDK 重试耗尽后透传成
  * 终止型 turn error),同属重试可自愈的网络类(2026-07-13 超时横幅裸英文实锤)。
+ * Cindy Responses bridge / compat-proxy 中途断流写成 `upstream stream error: …`
+ * （undici 的 `terminated`、socket reset 等），Claude Code 再包 `API Error:`；
+ * 只认这句短语，不裸匹配 `terminated`，避免误伤 `app_session_terminated`。
  */
 export interface ReconnectAttempt {
   attempt: number;
@@ -39,7 +42,7 @@ export function parseReconnectAttemptMessage(message: string): ReconnectAttempt 
 export function isNetworkishErrorMessage(message: string): boolean {
   return (
     parseReconnectAttemptMessage(message) !== null ||
-    /\b50[234]\b|Bad Gateway|Service Unavailable|Gateway Time-?out|upstream unreachable|ECONNREFUSED|ECONNRESET|ETIMEDOUT|ENOTFOUND|ENETUNREACH|EHOSTUNREACH|EPIPE|EAI_AGAIN|fetch failed|network error|socket hang up|AggregateError|Request timed out|^API Error:\s*The operation timed out|^The operation timed out|stream ended before a terminal|Connection error/i.test(
+    /\b50[234]\b|Bad Gateway|Service Unavailable|Gateway Time-?out|upstream unreachable|ECONNREFUSED|ECONNRESET|ETIMEDOUT|ENOTFOUND|ENETUNREACH|EHOSTUNREACH|EPIPE|EAI_AGAIN|fetch failed|network error|socket hang up|AggregateError|Request timed out|^API Error:\s*The operation timed out|^The operation timed out|stream ended before a terminal|Connection error|upstream stream error/i.test(
       message,
     )
   );

--- a/packages/maker-core/src/agents/shared/network-error.test.ts
+++ b/packages/maker-core/src/agents/shared/network-error.test.ts
@@ -29,6 +29,10 @@ describe('isNetworkishErrorMessage', () => {
     'Reconnecting… 3/5 (stream disconnected before completion)',
     'The operation timed out.',
     'OpenAI Responses stream ended before a terminal response event',
+    // Cindy Responses bridge / compat-proxy 中途断流；Claude Code 再包 API Error:
+    'API Error: upstream stream error: terminated',
+    'upstream stream error: socket reset',
+    'upstream stream error: Error: terminated',
   ])('matches networkish message: %s', (msg) => {
     expect(isNetworkishErrorMessage(msg)).toBe(true);
   });
@@ -41,6 +45,9 @@ describe('isNetworkishErrorMessage', () => {
     'Wrapped error: API Error: The operation timed out.',
     // 长数字不因包含 502 片段误伤(\b 词边界)
     'order id 15024 rejected',
+    // 裸 terminated 是鉴权终态,不能当传输抖动
+    'app_session_terminated',
+    'Your session has ended. Please log in again. (app_session_terminated)',
   ])('does not match non-network message: %s', (msg) => {
     expect(isNetworkishErrorMessage(msg)).toBe(false);
   });

--- a/packages/maker-core/src/agents/shared/network-error.ts
+++ b/packages/maker-core/src/agents/shared/network-error.ts
@@ -20,6 +20,9 @@
  * SDK 重试耗尽后透传成终止型 turn error)。Pi / OpenAI Responses 还会写出不带
  * `API Error:` 前缀的 `The operation timed out.`，以及
  * `OpenAI Responses stream ended before a terminal response event`。
+ * Cindy Responses bridge / compat-proxy 中途断流写成 `upstream stream error: …`
+ * （undici 的 `terminated`、socket reset 等），Claude Code 再包 `API Error:`；
+ * 只认这句短语，不裸匹配 `terminated`，避免误伤 `app_session_terminated`。
  */
 /** 仅在 Pi `auto_retry_end` 失败后使用：把「点一下重试」留给用户，Host 不再续跑。首次 aborted 不得打这个 reason。 */
 export const PI_GATEWAY_DROP_REASON = 'pi-gateway-drop';
@@ -53,7 +56,7 @@ export function parseReconnectAttemptMessage(message: string): ReconnectAttempt 
 export function isNetworkishErrorMessage(message: string): boolean {
   return (
     parseReconnectAttemptMessage(message) !== null ||
-    /\b50[234]\b|Bad Gateway|Service Unavailable|Gateway Time-?out|upstream unreachable|ECONNREFUSED|ECONNRESET|ETIMEDOUT|ENOTFOUND|ENETUNREACH|EHOSTUNREACH|EPIPE|EAI_AGAIN|fetch failed|network error|socket hang up|AggregateError|Request timed out|^API Error:\s*The operation timed out|^The operation timed out|stream ended before a terminal|Connection error/i.test(
+    /\b50[234]\b|Bad Gateway|Service Unavailable|Gateway Time-?out|upstream unreachable|ECONNREFUSED|ECONNRESET|ETIMEDOUT|ENOTFOUND|ENETUNREACH|EHOSTUNREACH|EPIPE|EAI_AGAIN|fetch failed|network error|socket hang up|AggregateError|Request timed out|^API Error:\s*The operation timed out|^The operation timed out|stream ended before a terminal|Connection error|upstream stream error/i.test(
       message,
     )
   );


### PR DESCRIPTION
## 这次改了什么

### 摘要

Claude Code 走 Cindy Responses bridge 时，上游 SSE 做到一半被掐，会报 `API Error: upstream stream error: terminated`。这是 undici 读 HTTP body 时连接被掐的传输抖动，和已经自动续跑的 `Connection closed mid-response` / `socket hang up` 同类，但 Host 白名单认不出，turn 直接死，只能手点重试。

这次把 `upstream stream error` 收进现有网络类判定（maker-core 与 renderer 同步）。命中后走既有 interrupted-turn 自动续跑，不新造重试状态机。不裸匹配 `terminated`，避免把 Codex `app_session_terminated` 鉴权终态当成网络抖动。

### 变更类型

- [x] `fix` 缺陷修复
- [ ] `feat` 新功能
- [ ] `refactor` / `perf` 重构或性能优化
- [ ] `docs` / `test` / `chore` 文档、测试或工程维护
- [ ] 其他：

### 范围

- 关联 Issue / 需求：无
- 本 PR 包含：
  - `isNetworkishErrorMessage` 增加 `upstream stream error`
  - 自动续跑白名单用例覆盖 Claude Code 包装后的原文
  - 锁住 `app_session_terminated` 不误伤
- 明确不包含：不在 bridge / 代理层重放半截 SSE；不改重试次数与退避
- 用户可见变化：这类断流会自动续跑；横幅沿用已有网络异常文案，不再只显示英文原文
- 是否存在 breaking change：无

### UI 变化

- 引用的设计规范：不涉及：只把已有网络类错误横幅套到新文案，无新视觉、交互或组件。

## 怎么验证的

### 自动验证

```text
corepack pnpm --filter @cindy/maker-core exec vitest run src/agents/shared/network-error.test.ts
结果：27 passed

corepack pnpm --filter desktop exec vitest run src/renderer/__tests__/networkError.test.ts src/main/maker-ipc/__tests__/interruptedTurnAutoResume.test.ts
结果：69 passed

corepack pnpm --filter desktop run --if-present typecheck
结果：通过（maker-core 无 typecheck script）

corepack pnpm test:unit:related
结果：maker-core / lizi-mcps / orca-workflow 通过。
desktop 全量单测 6 failed / 29279 passed，失败项为 claudeOrphanReaper（5）与 usageHistory SuperGrok 估价（1）。
同一 SHA 的干净 origin/main 复现同样 6 个失败，与本 diff 无关，不混入本 PR。
```

### 手工验证

不涉及。未实机跑一条 Grok 流中断会话。

### 未执行的验证

未跑全仓 `pnpm test:unit`（related 已覆盖本 diff；desktop 基线失败见上）。未实机制造上游 SSE 掐流。

## 风险

### 风险分类

- [x] 无已知风险
- [ ] SQLite / migration
- [ ] system prompt
- [ ] 协议兼容
- [ ] 权限 / 安全 / 用户数据
- [ ] 存量插件兼容（批准状态 / 指纹 / manifest 校验 / 安装布局 / 包格式）
- [ ] 原生层 / fingerprint / OTA
- [ ] 跨平台差异
- [ ] 其他：

### 影响与回滚

- 影响范围：Claude Code 经 Responses bridge / compat-proxy 的流中断错误会进入现有自动续跑（连续 5 次、周期 10 次）。ErrorBanner 对这句原文走网络类友好文案。
- 回滚 / 降级方式：revert 本 PR 即恢复为不自动续跑、只显示原文。
- 存量插件影响：无

### 提交前检查

- [x] 已 review 完整 diff
- [x] 每个 commit 都带 DCO 签名（`git commit -s`，见 [DCO](../DCO)）
- [x] UI 改动已在「UI 变化」注明引用的设计规范章节（不涉及 UI 则跳过）
- [x] 未提交凭证、令牌或授权文件
- [x] 已补充必要文档
- [x] 已确认测试结果或说明未执行原因
