### PR TITLE
fix(desktop): 统一选择器 classic rail 超高时内部滚动,不再叠压 footer (#3516)

### DIFF
--- a/apps/desktop/src/renderer/__tests__/unifiedModelPanelRendering.test.tsx
+++ b/apps/desktop/src/renderer/__tests__/unifiedModelPanelRendering.test.tsx
@@ -195,6 +195,7 @@ vi.mock('@/state/deviceLinkModelMirror', () => ({
 }));
 
 import { ModelSelectorContent } from '@/components/new-chat/ModelSelector';
+import type { UnifiedRailItem } from '@/components/new-chat/unifiedModelSelection';
 import {
   __resetForTest as resetEnginePrefs,
   getModelEngineOverride,
@@ -3241,5 +3242,64 @@ describe('列表样式试用开关(badge · v7 引擎徽标行)', () => {
     ) as HTMLElement;
     expect(header.className).not.toContain('sticky');
     expect(header.getAttribute('data-group-label')).toBe('Cindy AI');
+  });
+});
+
+// ── classic 左侧 rail 的高度约束(#3516)────────────────────────────────────
+// 自定义来源一多,rail 的 34px 格位累计高度会超过面板可用高度:根节点若无
+// min-h-0 / overflow-y-auto,子项按 visible 溢出向下绘制,直接叠到底部「添加模型」
+// footer 上。这里锁两件事:骨架类保留 + 溢出时格子一个不少、顺序不变。
+describe('classic 左侧 rail:超高时内部滚动,不叠压 footer(#3516)', () => {
+  function railItems(count: number): UnifiedRailItem[] {
+    return [
+      { kind: 'favorites' },
+      { kind: 'all' },
+      ...Array.from({ length: count }, (_, index) => ({
+        kind: 'provider' as const,
+        providerId: `src-${String(index).padStart(2, '0')}`,
+      })),
+    ];
+  }
+
+  async function mountRail(items: readonly UnifiedRailItem[]): Promise<HTMLElement> {
+    const { UnifiedModelRail } = await import('@/components/new-chat/UnifiedModelRail');
+    render(
+      React.createElement(UnifiedModelRail, {
+        items,
+        active: { kind: 'all' },
+        onSelect: vi.fn(),
+        providers: [],
+        providerLabel: (providerId: string) => providerId,
+      }),
+    );
+    return document.querySelector('[data-unified-model-rail]') as HTMLElement;
+  }
+
+  it('根节点保留 w-12 / shrink-0 骨架,并带 min-h-0 + overflow-y-auto 收缩滚动链', async () => {
+    const root = await mountRail(railItems(1));
+    expect(root).not.toBeNull();
+    for (const token of ['w-12', 'shrink-0', 'min-h-0', 'overflow-y-auto', 'overscroll-contain']) {
+      expect(root.className).toContain(token);
+    }
+  });
+
+  it('格位铺满超出可用高度时全部渲染、顺序不变(不靠裁剪或删项规避)', async () => {
+    const root = await mountRail(railItems(24));
+    // ★收藏 → 全部(带唯一的段间分隔线)→ 各来源,定位走 data-rail-item 稳定标记。
+    const keys = Array.from(root.querySelectorAll('button[data-rail-item]')).map((button) =>
+      button.getAttribute('data-rail-item'),
+    );
+    expect(keys).toHaveLength(26);
+    expect(keys[0]).toBe('favorites');
+    expect(keys[1]).toBe('all');
+    expect(root.querySelectorAll('[aria-hidden="true"]')).toHaveLength(1);
+    const providerIds = keys.slice(2).map((key) => key?.replace(/^provider:/, ''));
+    expect(providerIds[0]).toBe('src-00');
+    expect(providerIds[23]).toBe('src-23');
+    expect(new Set(providerIds).size).toBe(24);
+    // 可达性:title/aria-label 跟着 providerLabel 走,不能因为溢出就丢格子文案。
+    const lastButton = root.querySelector('button[data-rail-item="provider:src-23"]');
+    expect(lastButton?.getAttribute('title')).toBe('src-23');
+    expect(lastButton?.getAttribute('aria-label')).toBe('src-23');
   });
 });

--- a/apps/desktop/src/renderer/__tests__/unifiedModelPanelRendering.test.tsx
+++ b/apps/desktop/src/renderer/__tests__/unifiedModelPanelRendering.test.tsx
@@ -3278,7 +3278,16 @@ describe('classic 左侧 rail:超高时内部滚动,不叠压 footer(#3516)', ()
   it('根节点保留 w-12 / shrink-0 骨架,并带 min-h-0 + overflow-y-auto 收缩滚动链', async () => {
     const root = await mountRail(railItems(1));
     expect(root).not.toBeNull();
-    for (const token of ['w-12', 'shrink-0', 'min-h-0', 'overflow-y-auto', 'overscroll-contain']) {
+    // scrollbar-hide:Windows 非 overlay 环境的全局 12px 滚动条槽会挤掉 34px 按钮
+    // (#3516 review P2),原生槽必须藏;滚轮 / 触控板照常滚。
+    for (const token of [
+      'w-12',
+      'shrink-0',
+      'min-h-0',
+      'overflow-y-auto',
+      'overscroll-contain',
+      'scrollbar-hide',
+    ]) {
       expect(root.className).toContain(token);
     }
   });

--- a/apps/desktop/src/renderer/components/new-chat/UnifiedModelRail.tsx
+++ b/apps/desktop/src/renderer/components/new-chat/UnifiedModelRail.tsx
@@ -1,10 +1,8 @@
 import { LayoutGrid, Star } from 'lucide-react';
-import { useEffect, useRef } from 'react';
 import { useTranslation } from 'react-i18next';
 
 import type { ProviderView } from '@cindy/model-providers';
 
-import { flashScrollbar } from '@/lib/scrollbarAutoHide';
 import { cn } from '@/lib/utils';
 
 import { agentOptionOf } from './agentOptions';
@@ -43,14 +41,6 @@ export function UnifiedModelRail({
   // rail 常驻,不做「项数少就整条隐藏」——设计稿的分类栏在单来源时也在(★/全部/来源),
   // 隐藏会让收藏与快速切换不可发现(Chris 2026-08-13 实测反馈)。
   const activeKey = railItemKey(active);
-  const railRef = useRef<HTMLDivElement>(null);
-  useEffect(() => {
-    const el = railRef.current;
-    if (!el) return;
-    // 格位铺得下时不闪滚动条;超出一屏才提示「下面还有来源」。与右侧列表同一套提示节奏。
-    const raf = requestAnimationFrame(() => flashScrollbar(el));
-    return () => cancelAnimationFrame(raf);
-  }, [items]);
   return (
     // 设计稿 .rail:宽 48(含 6px 侧距 + 1px 右分隔线)、纵向 8px、格间 2px。
     // min-h-0 + overflow-y-auto:自定义来源一多,34px 格位累计高度会超过面板可用高度 ——
@@ -58,10 +48,12 @@ export function UnifiedModelRail({
     // footer 上(#3516)。与右侧列表(UnifiedModelPanel 的 min-h-0 + overflow-y-auto)
     // 同一套收缩滚动链:父级高度受限时 rail 自己收缩并内部滚动,w-12 shrink-0 骨架不变,
     // 不引入折叠 / 截断等新的产品规则;不用 scrollbar-gutter:stable(48px 窄栏留给 34px 按钮)。
+    // scrollbar-hide:原生滚动条必须藏 —— Windows 等非 overlay 环境下全局 12px 槽位会把
+    // 内容区挤到 24px,34px 按钮放不下(#3516 review P2);折叠侧栏窄 rail 同一取舍
+    // (CCAgentSidebarUpper)。滚轮 / 触控板 / 键盘照常滚动。
     <div
-      ref={railRef}
       data-unified-model-rail="true"
-      className="flex w-12 min-h-0 shrink-0 flex-col items-center gap-0.5 overflow-y-auto overscroll-contain border-r border-[var(--model-dropdown-border)] px-1.5 py-2"
+      className="flex w-12 min-h-0 shrink-0 flex-col items-center gap-0.5 overflow-y-auto overscroll-contain border-r border-[var(--model-dropdown-border)] px-1.5 py-2 scrollbar-hide"
     >
       {items.map((item) => {
         const key = railItemKey(item);

--- a/apps/desktop/src/renderer/components/new-chat/UnifiedModelRail.tsx
+++ b/apps/desktop/src/renderer/components/new-chat/UnifiedModelRail.tsx
@@ -1,8 +1,10 @@
 import { LayoutGrid, Star } from 'lucide-react';
+import { useEffect, useRef } from 'react';
 import { useTranslation } from 'react-i18next';
 
 import type { ProviderView } from '@cindy/model-providers';
 
+import { flashScrollbar } from '@/lib/scrollbarAutoHide';
 import { cn } from '@/lib/utils';
 
 import { agentOptionOf } from './agentOptions';
@@ -41,9 +43,26 @@ export function UnifiedModelRail({
   // rail 常驻,不做「项数少就整条隐藏」——设计稿的分类栏在单来源时也在(★/全部/来源),
   // 隐藏会让收藏与快速切换不可发现(Chris 2026-08-13 实测反馈)。
   const activeKey = railItemKey(active);
+  const railRef = useRef<HTMLDivElement>(null);
+  useEffect(() => {
+    const el = railRef.current;
+    if (!el) return;
+    // 格位铺得下时不闪滚动条;超出一屏才提示「下面还有来源」。与右侧列表同一套提示节奏。
+    const raf = requestAnimationFrame(() => flashScrollbar(el));
+    return () => cancelAnimationFrame(raf);
+  }, [items]);
   return (
     // 设计稿 .rail:宽 48(含 6px 侧距 + 1px 右分隔线)、纵向 8px、格间 2px。
-    <div className="flex w-12 shrink-0 flex-col items-center gap-0.5 border-r border-[var(--model-dropdown-border)] px-1.5 py-2">
+    // min-h-0 + overflow-y-auto:自定义来源一多,34px 格位累计高度会超过面板可用高度 ——
+    // 根节点没有纵向约束时子项按 visible 溢出向下绘制,直接叠到面板底部「添加模型」
+    // footer 上(#3516)。与右侧列表(UnifiedModelPanel 的 min-h-0 + overflow-y-auto)
+    // 同一套收缩滚动链:父级高度受限时 rail 自己收缩并内部滚动,w-12 shrink-0 骨架不变,
+    // 不引入折叠 / 截断等新的产品规则;不用 scrollbar-gutter:stable(48px 窄栏留给 34px 按钮)。
+    <div
+      ref={railRef}
+      data-unified-model-rail="true"
+      className="flex w-12 min-h-0 shrink-0 flex-col items-center gap-0.5 overflow-y-auto overscroll-contain border-r border-[var(--model-dropdown-border)] px-1.5 py-2"
+    >
       {items.map((item) => {
         const key = railItemKey(item);
         const isActive = activeKey === key;
@@ -64,43 +83,46 @@ export function UnifiedModelRail({
         return (
           <div key={key} className="contents">
             {separatorBefore && (
-              <div aria-hidden className="my-[3px] w-[22px] border-t border-[var(--model-dropdown-border)]" />
+              <div
+                aria-hidden
+                className="my-[3px] w-[22px] border-t border-[var(--model-dropdown-border)]"
+              />
             )}
-          <button
-            type="button"
-            disabled={interactionDisabled}
-            onClick={() => onSelect(item)}
-            title={label}
-            aria-label={label}
-            aria-pressed={isActive}
-            data-rail-item={key}
-            className={cn(
-              // 设计稿 .rail-btn:34×34、圆角 9。
-              'flex h-[34px] w-[34px] shrink-0 items-center justify-center rounded-[9px] transition-colors',
-              // 选中态用**反色实心块**(与浮层里的选中分段同一套表达):
-              // 原先的 --surface-chip 在两种主题下都只比底色深一点点,用户看不出当前
-              // 停在哪个视图 —— 会话内「同引擎过滤开着没开着」正是靠这一格判断的
-              // (2026-08-13 实测反馈)。
-              isActive
-                ? 'bg-[var(--accent-cta-bg)] text-[var(--accent-pure-cta-fg)] shadow-[var(--shadow-menu)]'
-                : 'text-[var(--text-tertiary)] hover:bg-[var(--model-item-hover)] hover:text-[var(--text-secondary)]',
-              interactionDisabled && 'cursor-not-allowed opacity-50',
-            )}
-          >
-            {item.kind === 'favorites' ? (
-              // ☆ 未激活与其它格同灰(hover 提亮)—— 常亮金色会在没进收藏视图时也
-              // 抢视线(2026-08-14 实机自查);激活时整格反色 + 实心星跟随 currentColor。
-              <Star size={16} fill={isActive ? 'currentColor' : 'none'} />
-            ) : item.kind === 'engine' && engineOption ? (
-              // 同引擎格用**当前会话引擎自己的品牌 mark**(规格 §1.6),用户一眼知道
-              // 这个过滤器是按什么筛的。
-              <engineOption.Mark size={14} className="shrink-0" />
-            ) : item.kind === 'all' ? (
-              <LayoutGrid size={16} />
-            ) : item.kind === 'provider' ? (
-              <ProviderRailMark providerId={item.providerId} providers={providers} />
-            ) : null}
-          </button>
+            <button
+              type="button"
+              disabled={interactionDisabled}
+              onClick={() => onSelect(item)}
+              title={label}
+              aria-label={label}
+              aria-pressed={isActive}
+              data-rail-item={key}
+              className={cn(
+                // 设计稿 .rail-btn:34×34、圆角 9。
+                'flex h-[34px] w-[34px] shrink-0 items-center justify-center rounded-[9px] transition-colors',
+                // 选中态用**反色实心块**(与浮层里的选中分段同一套表达):
+                // 原先的 --surface-chip 在两种主题下都只比底色深一点点,用户看不出当前
+                // 停在哪个视图 —— 会话内「同引擎过滤开着没开着」正是靠这一格判断的
+                // (2026-08-13 实测反馈)。
+                isActive
+                  ? 'bg-[var(--accent-cta-bg)] text-[var(--accent-pure-cta-fg)] shadow-[var(--shadow-menu)]'
+                  : 'text-[var(--text-tertiary)] hover:bg-[var(--model-item-hover)] hover:text-[var(--text-secondary)]',
+                interactionDisabled && 'cursor-not-allowed opacity-50',
+              )}
+            >
+              {item.kind === 'favorites' ? (
+                // ☆ 未激活与其它格同灰(hover 提亮)—— 常亮金色会在没进收藏视图时也
+                // 抢视线(2026-08-14 实机自查);激活时整格反色 + 实心星跟随 currentColor。
+                <Star size={16} fill={isActive ? 'currentColor' : 'none'} />
+              ) : item.kind === 'engine' && engineOption ? (
+                // 同引擎格用**当前会话引擎自己的品牌 mark**(规格 §1.6),用户一眼知道
+                // 这个过滤器是按什么筛的。
+                <engineOption.Mark size={14} className="shrink-0" />
+              ) : item.kind === 'all' ? (
+                <LayoutGrid size={16} />
+              ) : item.kind === 'provider' ? (
+                <ProviderRailMark providerId={item.providerId} providers={providers} />
+              ) : null}
+            </button>
           </div>
         );
       })}


### PR DESCRIPTION
Closes #3516

## 这次改了什么

### 摘要

统一模型选择器 classic(样式 A)左侧 rail 原先没有纵向约束:自定义来源一多,34px 格位累计高度超过面板可用高度时,根节点既不收缩也不裁剪(默认 `overflow: visible`),溢出格位向下绘制,直接叠压底部「添加模型」footer 并越出弹层(#3516)。本 PR 给 rail 补上与右侧列表同一套收缩滚动链,超高时在自己内部滚动,footer 不再被遮挡。

### 变更类型

- [x] `fix` 缺陷修复

### 范围

- 关联 Issue / 需求:#3516(按该 issue 维护者分析的建议方案收口)
- 本 PR 包含:
  - `UnifiedModelRail` 根节点补 `min-h-0 overflow-y-auto overscroll-contain`;`w-12 shrink-0` 骨架不变;
  - `scrollbar-hide`(既有 `.scrollbar-hide` 工具类,globals.css F-FI-3):Windows 等非 overlay scrollbar 环境的全局 12px 槽位会把 48px 栏挤到放不下 34px 格位(review P2),原生槽必须藏、滚轮照常滚 —— 与折叠侧栏窄 rail(CCAgentSidebarUpper)同一取舍;
  - 按分析建议挂 `data-unified-model-rail` 定位标记,供测试定位;
  - 新增两条 rail 回归测试(见下)。
- 明确不包含:折叠 / 截断等新的产品规则;`scrollbar-gutter: stable`;滚动条视觉提示(`flashScrollbar` 在隐藏原生槽后无视觉载体,已从初版方案中摘除);badge(样式 B)与 original 选择器不受影响(badge 本就不渲染 rail)。
- 用户可见变化:来源较多时左栏内部可滚(无可见滚动条,跨平台一致),不再叠压「添加模型」。
- 是否存在 breaking change:无。

### UI 变化

平台:Desktop(macOS 实测,Electron renderer 层,CSS class 级改动跨三平台一致)。

界面效果证据([对比演示图](https://github.com/makecindy/cindy/pull/3520#issuecomment-5438293489),亦可从 [pr-assets 分支](https://github.com/FIERsity/cindy/tree/pr-assets/pr-3520) 取 png 与自包含 HTML;修复前叠压形态见 #3516 原 issue 配图):

- A 修复前:rail 格位溢出绘制、叠压「添加模型」footer;
- B 修复后(本 PR 提交态):栏内滚动,footer 干净;
- C 反例(review P2 已规避):不藏原生滚动条槽时 Windows 12px 槽对 34px 格位的挤压。

- 引用的设计规范:
  - **DESIGN.md §4 Select & Dropdown —— Composer 下拉菜单统一契约**:rail 格位的 34px 尺寸、反色选中态、1px Board 分隔线全部原样保留,本 PR 只补滚动约束,不触碰行高亮 token(`--model-item-hover`)、圆角与宽度契约;
  - **DESIGN.md §4 Dialog & Modal —— 多步向导的滚动区条款**(「滚动区收在两条 hairline 之间、常驻操作钉在下方始终可见」):同一结构原则在 rail 上的落地 —— 滚动发生在 rail 内部,「添加模型」footer 固定在其下方、不被覆盖;
  - **DESIGN.md §5 Layout Structure**(层间用 1px Board 分隔线):rail 右缘 1px 分隔线不变。

## 怎么验证的

### 自动验证

```text
pnpm vitest run src/renderer/__tests__/unifiedModelPanelRendering.test.tsx
结果:101 passed(含新增 2 条:rail 骨架类保留 w-12/shrink-0/min-h-0/overflow-y-auto/overscroll-contain/scrollbar-hide;24 来源共 26 格全部渲染、data-rail-item 顺序不变、段间分隔线唯一、title/aria-label 可达性文案不丢)

pnpm typecheck(desktop)
结果:通过

pnpm exec eslint <改动两文件>
pnpm exec prettier --check <改动两文件>
结果:均通过
```

### 手工验证

Linux/Windows 矮窗口 + 15+ 来源的实机矩阵(Light/Dark、滚轮/触控板在 rail 与列表间的滚动归属、Tab 焦点进入视口、badge/original 回归)随 CI 单测与本仓库实机 review 一并确认。

### 未执行的验证

未在本机逐一走查 Windows 形态(占宽问题经 review P2 指认后已按工具类先例消除,如 review 需要实机录屏再跟进)。


## 风险

### 风险分类

- [ ] 无已知风险
- [ ] SQLite / migration
- [ ] system prompt
- [ ] 协议兼容
- [ ] 权限 / 安全 / 用户数据
- [ ] 存量插件兼容（批准状态 / 指纹 / manifest 校验 / 安装布局 / 包格式）
- [ ] 原生层 / fingerprint / OTA
- [x] 跨平台差异
- [ ] 其他：

### 影响与回滚

- 影响范围：仅 classic(样式 A)统一模型选择器的左侧 rail。行为从「溢出可见」变为「栏内滚动」:rail 宽度 48px、34px 格位尺寸、顺序、选中态、1px 分隔线全部不变,「添加模型」footer 仍钉在面板底部、不再被覆盖。badge(样式 B)本就不渲染 rail、original 老版选择器不经过该组件,两者均不受影响。改动是单一组件根节点上的 className,无 props / 状态 / 持久化变更,localStorage 键 `xdt:modelPickerLayout:v1` 未触碰,不影响既有布局偏好。
- 跨平台差异(本 PR 唯一实质风险点):Windows / Linux 等非 overlay scrollbar 环境下,`globals.css` 的全局 `::-webkit-scrollbar { width: 12px }` 会占布局宽度,48px rail 扣掉 12px 槽 + 12px 横向 padding + 1px 边框后放不下 34px 格位。本 PR 用既有 `.scrollbar-hide` 工具类(globals.css F-FI-3)隐藏原生槽,滚动改为无可见滚动条 —— 滚轮 / 触控板 / 键盘照常滚动,与折叠侧栏窄 rail(`CCAgentSidebarUpper`)的既有取舍一致。已知取舍:该平台下 rail 滚动没有任何滚动条视觉提示;因原生槽不可用,初版方案里的 `flashScrollbar` 提示已摘除(无视觉载体)。
- 回滚 / 降级方式：纯 className 改动,`git revert 9500f4a 303e85c` 即整段回到原 `overflow: visible` 行为;不涉及数据、migration、协议或原生层,回滚无残留、无需清理用户侧状态。若仅需临时降级视觉表现,用户可在选择器 footer 切到「切回样式B」(badge 布局不渲染 rail)或「切回老版」,无需改代码。

### 提交前检查

- [x] 已 review 完整 diff
- [x] 每个 commit 都带 DCO 签名（`git commit -s`，见 [DCO](../DCO)）——DCO check 已通过
- [x] UI 改动已在「UI 变化」注明引用的设计规范章节（DESIGN.md §4 Select & Dropdown / §4 Dialog & Modal / §5 Layout Structure）
- [x] 未提交凭证、令牌或授权文件
- [x] 已补充必要文档——本次为 CSS 约束修复,不改变契约与用法,无文档需同步(源码内已就地注释说明取舍)
- [x] 已确认测试结果或说明未执行原因
