### PR TITLE
fix(desktop): 缓存目录缺失时创建后打开 #3519

### DIFF
--- a/apps/desktop/src/main/bootstrap-electron.ts
+++ b/apps/desktop/src/main/bootstrap-electron.ts
@@ -271,6 +271,7 @@ import {
 } from './cindy-media/cindyMediaProtocol';
 import * as cindyMediaBlobStore from './cindy-media/blobStore';
 import * as cindyChatAttachments from './cindy-media/chatAttachments';
+import { openOrCreateFixedDirectory } from './cindy-media/fixedDirectory';
 import { createStorageIpcHandlers } from './cindy-media/storageIpc';
 import {
   getAllRegisteredDraftUrls,
@@ -7245,22 +7246,14 @@ const registerIpcHandlers = () => {
         throwIpcError('INTERNAL', 'fixed cache directory action failed');
       }
     };
-    const openExistingFixedDirectory = async (
+    const openFixedDirectory = (
       rootDir: string,
       canOpen: () => boolean = () => true,
-    ): Promise<boolean> => {
-      try {
-        const stat = await fs.promises.lstat(rootDir);
-        if (!stat.isDirectory()) return false;
-      } catch (err) {
-        if ((err as NodeJS.ErrnoException)?.code === 'ENOENT') return false;
-        throw err;
-      }
-      if (!canOpen()) throw new Error('fixed directory owner changed before open');
-      const error = await shell.openPath(rootDir);
-      if (error) throw new Error(error);
-      return true;
-    };
+    ): Promise<boolean> =>
+      openOrCreateFixedDirectory(rootDir, {
+        canOpen,
+        openPath: (filePath) => shell.openPath(filePath),
+      });
     // These actions intentionally accept no renderer path. The frozen xdt-image
     // cache has no owner metadata, so its confirmed cleanup applies to the whole
     // profile-level legacy root. Chat attachments remain scoped to the active
@@ -7327,11 +7320,11 @@ const registerIpcHandlers = () => {
       getQueueScanTexts: collectAgentInputQueueScanTexts,
       loadSnapshotPayloads: loadAllQueueSnapshotPayloads,
       getRegisteredDraftUrls: getAllRegisteredDraftUrls,
-      openLegacyImagesDir: () => openExistingFixedDirectory(imageCacheStore.getCacheRoot()),
+      openLegacyImagesDir: () => openFixedDirectory(imageCacheStore.getCacheRoot()),
       clearLegacyImagesDir: () => clearFixedDirectory(imageCacheStore.getCacheRoot()),
       openChatAttachmentsDir: () =>
         withActiveChatAttachmentRoot((rootDir, isCurrentOwner) =>
-          openExistingFixedDirectory(rootDir, isCurrentOwner),
+          openFixedDirectory(rootDir, isCurrentOwner),
         ),
       clearChatAttachmentsDir: () =>
         withActiveChatAttachmentRoot((rootDir, isCurrentOwner) =>

--- a/apps/desktop/src/main/cindy-media/__tests__/fixedDirectory.test.ts
+++ b/apps/desktop/src/main/cindy-media/__tests__/fixedDirectory.test.ts
@@ -1,0 +1,133 @@
+import { describe, expect, it, vi } from 'vitest';
+import type fs from 'node:fs';
+
+import { openOrCreateFixedDirectory } from '../fixedDirectory';
+
+function directoryStat(isDirectory: boolean): fs.Stats {
+  return { isDirectory: () => isDirectory } as fs.Stats;
+}
+
+function missingPathError(): NodeJS.ErrnoException {
+  return Object.assign(new Error('missing'), { code: 'ENOENT' });
+}
+
+describe('openOrCreateFixedDirectory', () => {
+  it('creates a missing fixed directory before opening it', async () => {
+    const lstat = vi.fn().mockRejectedValueOnce(missingPathError()).mockResolvedValueOnce(
+      directoryStat(true),
+    );
+    const mkdir = vi.fn().mockResolvedValue(undefined);
+    const openPath = vi.fn().mockResolvedValue('');
+    const canOpen = vi.fn().mockReturnValue(true);
+
+    await expect(
+      openOrCreateFixedDirectory('C:\\cache\\images', {
+        canOpen,
+        fileSystem: { lstat, mkdir },
+        openPath,
+      }),
+    ).resolves.toBe(true);
+
+    expect(mkdir).toHaveBeenCalledWith('C:\\cache\\images', { recursive: true });
+    expect(lstat).toHaveBeenCalledTimes(2);
+    expect(canOpen).toHaveBeenCalledTimes(2);
+    expect(openPath).toHaveBeenCalledWith('C:\\cache\\images');
+  });
+
+  it('opens an existing fixed directory without creating it again', async () => {
+    const lstat = vi.fn().mockResolvedValue(directoryStat(true));
+    const mkdir = vi.fn();
+    const openPath = vi.fn().mockResolvedValue('');
+
+    await expect(
+      openOrCreateFixedDirectory('/cache/images', {
+        fileSystem: { lstat, mkdir },
+        openPath,
+      }),
+    ).resolves.toBe(true);
+
+    expect(mkdir).not.toHaveBeenCalled();
+    expect(openPath).toHaveBeenCalledWith('/cache/images');
+  });
+
+  it('does not open or replace a fixed path that is not a directory', async () => {
+    const mkdir = vi.fn();
+    const openPath = vi.fn();
+
+    await expect(
+      openOrCreateFixedDirectory('/cache/images', {
+        fileSystem: {
+          lstat: vi.fn().mockResolvedValue(directoryStat(false)),
+          mkdir,
+        },
+        openPath,
+      }),
+    ).resolves.toBe(false);
+
+    expect(mkdir).not.toHaveBeenCalled();
+    expect(openPath).not.toHaveBeenCalled();
+  });
+
+  it('does not create a missing owner-scoped directory after the owner changes', async () => {
+    const mkdir = vi.fn();
+    const openPath = vi.fn();
+
+    await expect(
+      openOrCreateFixedDirectory('/cache/owner-a', {
+        canOpen: () => false,
+        fileSystem: {
+          lstat: vi.fn().mockRejectedValue(missingPathError()),
+          mkdir,
+        },
+        openPath,
+      }),
+    ).rejects.toThrow('fixed directory owner changed before open');
+
+    expect(mkdir).not.toHaveBeenCalled();
+    expect(openPath).not.toHaveBeenCalled();
+  });
+
+  it('rechecks the owner after creating the directory and before opening it', async () => {
+    const canOpen = vi.fn().mockReturnValueOnce(true).mockReturnValueOnce(false);
+    const openPath = vi.fn();
+
+    await expect(
+      openOrCreateFixedDirectory('/cache/owner-a', {
+        canOpen,
+        fileSystem: {
+          lstat: vi
+            .fn()
+            .mockRejectedValueOnce(missingPathError())
+            .mockResolvedValueOnce(directoryStat(true)),
+          mkdir: vi.fn().mockResolvedValue(undefined),
+        },
+        openPath,
+      }),
+    ).rejects.toThrow('fixed directory owner changed before open');
+
+    expect(openPath).not.toHaveBeenCalled();
+  });
+
+  it('propagates directory creation and shell opening failures', async () => {
+    const createError = new Error('access denied');
+    await expect(
+      openOrCreateFixedDirectory('/cache/images', {
+        fileSystem: {
+          lstat: vi.fn().mockRejectedValue(missingPathError()),
+          mkdir: vi.fn().mockRejectedValue(createError),
+        },
+        openPath: vi.fn(),
+      }),
+    ).rejects.toBe(createError);
+
+    await expect(
+      openOrCreateFixedDirectory('/cache/images', {
+        fileSystem: {
+          lstat: vi.fn().mockResolvedValue(directoryStat(true)),
+          mkdir: vi.fn(),
+        },
+        openPath: vi.fn().mockResolvedValue('shell failed'),
+      }),
+    ).rejects.toThrow('shell failed');
+  });
+});

--- a/apps/desktop/src/main/cindy-media/__tests__/fixedDirectory.test.ts
+++ b/apps/desktop/src/main/cindy-media/__tests__/fixedDirectory.test.ts
@@ -34,6 +34,44 @@ describe('openOrCreateFixedDirectory', () => {
     expect(openPath).toHaveBeenCalledWith('C:\\cache\\images');
   });
 
+  it('recreates a directory removed by concurrent cleanup before opening it', async () => {
+    const lstat = vi
+      .fn()
+      .mockRejectedValueOnce(missingPathError())
+      .mockRejectedValueOnce(missingPathError())
+      .mockResolvedValueOnce(directoryStat(true));
+    const mkdir = vi.fn().mockResolvedValue(undefined);
+    const openPath = vi.fn().mockResolvedValue('');
+
+    await expect(
+      openOrCreateFixedDirectory('/cache/images', {
+        fileSystem: { lstat, mkdir },
+        openPath,
+      }),
+    ).resolves.toBe(true);
+
+    expect(mkdir).toHaveBeenCalledTimes(2);
+    expect(openPath).toHaveBeenCalledWith('/cache/images');
+  });
+
+  it('keeps repeated concurrent deletion as a recoverable not-opened result', async () => {
+    const mkdir = vi.fn().mockResolvedValue(undefined);
+    const openPath = vi.fn();
+
+    await expect(
+      openOrCreateFixedDirectory('/cache/images', {
+        fileSystem: {
+          lstat: vi.fn().mockRejectedValue(missingPathError()),
+          mkdir,
+        },
+        openPath,
+      }),
+    ).resolves.toBe(false);
+
+    expect(mkdir).toHaveBeenCalledTimes(2);
+    expect(openPath).not.toHaveBeenCalled();
+  });
+
   it('opens an existing fixed directory without creating it again', async () => {
     const lstat = vi.fn().mockResolvedValue(directoryStat(true));
     const mkdir = vi.fn();
@@ -129,5 +167,24 @@ describe('openOrCreateFixedDirectory', () => {
         openPath: vi.fn().mockResolvedValue('shell failed'),
       }),
     ).rejects.toThrow('shell failed');
+  });
+
+  it('keeps deletion during shell opening as a recoverable not-opened result', async () => {
+    const openPath = vi.fn().mockResolvedValue('path disappeared');
+
+    await expect(
+      openOrCreateFixedDirectory('/cache/images', {
+        fileSystem: {
+          lstat: vi
+            .fn()
+            .mockResolvedValueOnce(directoryStat(true))
+            .mockRejectedValueOnce(missingPathError()),
+          mkdir: vi.fn(),
+        },
+        openPath,
+      }),
+    ).resolves.toBe(false);
+
+    expect(openPath).toHaveBeenCalledWith('/cache/images');
   });
 });

--- a/apps/desktop/src/main/cindy-media/fixedDirectory.ts
+++ b/apps/desktop/src/main/cindy-media/fixedDirectory.ts
@@ -1,0 +1,34 @@
+import fs from 'node:fs';
+
+type FixedDirectoryFileSystem = Pick<typeof fs.promises, 'lstat' | 'mkdir'>;
+
+export interface OpenFixedDirectoryOptions {
+  canOpen?: () => boolean;
+  fileSystem?: FixedDirectoryFileSystem;
+  openPath: (filePath: string) => Promise<string>;
+}
+
+export async function openOrCreateFixedDirectory(
+  rootDir: string,
+  options: OpenFixedDirectoryOptions,
+): Promise<boolean> {
+  const canOpen = options.canOpen ?? (() => true);
+  const fileSystem = options.fileSystem ?? fs.promises;
+  let stat: Awaited<ReturnType<FixedDirectoryFileSystem['lstat']>>;
+
+  try {
+    stat = await fileSystem.lstat(rootDir);
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException)?.code !== 'ENOENT') throw error;
+    if (!canOpen()) throw new Error('fixed directory owner changed before open');
+    await fileSystem.mkdir(rootDir, { recursive: true });
+    stat = await fileSystem.lstat(rootDir);
+  }
+
+  if (!stat.isDirectory()) return false;
+  if (!canOpen()) throw new Error('fixed directory owner changed before open');
+
+  const error = await options.openPath(rootDir);
+  if (error) throw new Error(error);
+  return true;
+}

--- a/apps/desktop/src/main/cindy-media/fixedDirectory.ts
+++ b/apps/desktop/src/main/cindy-media/fixedDirectory.ts
@@ -2,6 +2,8 @@ import fs from 'node:fs';
 
 type FixedDirectoryFileSystem = Pick<typeof fs.promises, 'lstat' | 'mkdir'>;
 
+const MAX_CREATE_ATTEMPTS = 2;
+
 export interface OpenFixedDirectoryOptions {
   canOpen?: () => boolean;
   fileSystem?: FixedDirectoryFileSystem;
@@ -14,21 +16,30 @@ export async function openOrCreateFixedDirectory(
 ): Promise<boolean> {
   const canOpen = options.canOpen ?? (() => true);
   const fileSystem = options.fileSystem ?? fs.promises;
-  let stat: Awaited<ReturnType<FixedDirectoryFileSystem['lstat']>>;
+  const lstatIfExists = async () => {
+    try {
+      return await fileSystem.lstat(rootDir);
+    } catch (error) {
+      if ((error as NodeJS.ErrnoException)?.code === 'ENOENT') return null;
+      throw error;
+    }
+  };
 
-  try {
-    stat = await fileSystem.lstat(rootDir);
-  } catch (error) {
-    if ((error as NodeJS.ErrnoException)?.code !== 'ENOENT') throw error;
+  let stat = await lstatIfExists();
+  for (let attempt = 0; stat === null && attempt < MAX_CREATE_ATTEMPTS; attempt += 1) {
     if (!canOpen()) throw new Error('fixed directory owner changed before open');
     await fileSystem.mkdir(rootDir, { recursive: true });
-    stat = await fileSystem.lstat(rootDir);
+    stat = await lstatIfExists();
   }
 
+  if (stat === null) return false;
   if (!stat.isDirectory()) return false;
   if (!canOpen()) throw new Error('fixed directory owner changed before open');
 
   const error = await options.openPath(rootDir);
-  if (error) throw new Error(error);
+  if (error) {
+    if ((await lstatIfExists()) === null) return false;
+    throw new Error(error);
+  }
   return true;
 }

--- a/apps/desktop/src/main/cindy-media/storageIpc.ts
+++ b/apps/desktop/src/main/cindy-media/storageIpc.ts
@@ -43,7 +43,7 @@ export interface StorageIpcDeps {
   db?: ledger.LedgerDb;
   /** 测试注入死目录根;生产缺省 userData/cc-agent。 */
   legacyRootDir?: string;
-  /** Fixed-purpose directory opener. It returns false when the legacy directory is absent. */
+  /** Fixed-purpose directory opener. It returns false when the fixed path is not a directory. */
   openLegacyImagesDir?: () => Promise<boolean>;
   /** Delete only the fixed legacy image cache directory; no ledger or message lookup. */
   clearLegacyImagesDir?: () => Promise<void>;

--- a/apps/desktop/src/renderer/components/settings/__tests__/StorageManagementCard.test.tsx
+++ b/apps/desktop/src/renderer/components/settings/__tests__/StorageManagementCard.test.tsx
@@ -112,7 +112,7 @@ describe('StorageManagementCard fixed cache directories', () => {
     });
   });
 
-  it('reports a missing legacy directory without creating one', async () => {
+  it('reports when Main cannot open the fixed legacy directory', async () => {
     vi.mocked(window.electronAPI.cindyMediaStorage.openLegacyImagesDir).mockResolvedValue({
       opened: false,
     });


### PR DESCRIPTION
## 这次改了什么

### 摘要

修复设置页清理图片缓存或消息附件缓存后，立即点击“打开目录”会提示目录不存在的问题。Main 进程会在固定缓存目录缺失时先创建空目录，再交给系统文件管理器打开。

### 变更类型

- [ ] `feat` 新功能
- [x] `fix` 缺陷修复
- [ ] `refactor` / `perf` 重构或性能优化
- [ ] `docs` / `test` / `chore` 文档、测试或工程维护
- [ ] 其他：

### 范围

- 关联 Issue / 需求：#3519
- 本 PR 包含：固定缓存目录缺失时的创建与打开、当前附件 owner 在创建前后的复核，以及对应回归测试。
- 明确不包含：不改变清理时删除整个缓存根目录的既有语义；不修改 Renderer UI、文案或 IPC 契约。
- 用户可见变化：清理缓存后再次点击“打开目录”，会正常打开新建的空目录。
- 是否存在 breaking change：无。

### UI 变化

不涉及：未修改 UI 实现、布局、样式或文案；Renderer 测试仅更新测试名称以反映 Main 契约。

- 引用的设计规范：不涉及：本次仅调整 Desktop Main 文件系统行为。

## 怎么验证的

### 自动验证

```text
pnpm --filter desktop test -- src/main/cindy-media/__tests__/fixedDirectory.test.ts src/main/cindy-media/__tests__/storageIpc.test.ts src/renderer/components/settings/__tests__/StorageManagementCard.test.tsx
结果：通过，3 个测试文件、30 个测试用例通过。

pnpm --filter desktop run --if-present typecheck
结果：通过。

pnpm test:unit:related
结果：通过，apps/desktop unit 通过。

pnpm --filter desktop exec eslint src/main/cindy-media/fixedDirectory.ts src/main/cindy-media/__tests__/fixedDirectory.test.ts src/main/cindy-media/storageIpc.ts src/renderer/components/settings/__tests__/StorageManagementCard.test.tsx
结果：通过。

pnpm check:dco
结果：通过，1 个提交已签署 DCO。
```

### 手工验证

未执行：当前为 Cindy 内嵌 worktree，会话改动不会作用于正在运行的宿主 Desktop，无法在该实例中完成设置页实机点击。

### 未执行的验证

- 未执行 Desktop 实机清理后打开目录，原因同上。
- 未运行全仓 `pnpm test:unit`；按仓库规则执行了本次改动对应的 `pnpm test:unit:related`。
- 将 `bootstrap-electron.ts` 纳入单文件 ESLint 时会命中该文件当前基线已有的 5 个 `no-unused-vars`，本次未顺带修改无关基线问题；新增模块及其他改动文件的 ESLint 已通过。

## 风险

### 风险分类

- [ ] 无已知风险
- [ ] SQLite / migration
- [ ] system prompt
- [ ] 协议兼容
- [x] 权限 / 安全 / 用户数据
- [ ] 存量插件兼容（批准状态 / 指纹 / manifest 校验 / 安装布局 / 包格式）
- [ ] 原生层 / fingerprint / OTA
- [ ] 跨平台差异
- [ ] 其他：

### 影响与回滚

- 影响范围：仅 Desktop 设置页既有图片缓存与当前账号消息附件缓存的“打开目录”动作。目录创建仍在 Main 进程固定路径内完成，Renderer 不能传入路径；附件目录创建前后都会复核当前 owner。已存在但不是目录的路径仍拒绝打开。
- 回滚 / 降级方式：回滚本提交即可恢复为目录缺失时返回未打开并显示提示。
- 移动端冷更判断：不涉及 `apps/mobile`、原生配置、原生依赖或 runtime fingerprint，不会触发移动端冷更。

### 提交前检查

- [x] 已 review 完整 diff
- [x] 每个 commit 都带 DCO 签名（`git commit -s`，见 [DCO](../DCO)）
- [x] UI 改动已在“UI 变化”注明引用的设计规范章节（本次不涉及 UI）
- [x] 未提交凭证、令牌或授权文件
- [x] 已补充必要文档（本次无需用户文档，已更新代码契约注释）
- [x] 已确认测试结果或说明未执行原因