### PR TITLE
fix(desktop): use .run() for CAS clear of stale sdk_session_id (#3496)

### DIFF
--- a/apps/desktop/src/main/maker-host/__tests__/sessionStorageRemoteHostId.test.ts
+++ b/apps/desktop/src/main/maker-host/__tests__/sessionStorageRemoteHostId.test.ts
@@ -1,21 +1,81 @@
 /**
- * #1 回归:`maker.createSession()` 这条入库路径(maker:create-session IPC / scheduler /
- * Feishu / Orca 都经由 DesktopSessionStorage.create())也必须规范化 remoteHostId,
- * 不能让空串 / 空白原样落库 —— 否则 renderer 按 `remoteHostId ? remote : local` 分组时
- * 把它当本地,而 maker 侧又拿着一个"看似 remote"的空值,语义分裂。
+ * #3525 回归:DesktopSessionStorage 的 CAS 契约——
  *
- * 这里 mock 掉 db client,只断言传给 insert().values() 的 row.remoteHostId。
+ * INVARIANT: `compareAndClearSdkSessionId(id, expected)` 只能把「当前 sdkSessionId
+ * 仍等于 expected 的那一行」清空。若并发方已把新 ID 写回,旧恢复请求的 CAS 必须
+ * 自然未命中(changes=0 → false),绝不能清掉并发写入的新 ID。
+ *
+ * 与旧 mock 的差别(Greptile P2):旧 mock 的 where() 不评估条件表达式、靠手动
+ * 切换 runResult 决定结果 —— 即使实现漏掉 `sdkSessionId = expected` 谓词,测试
+ * 仍会通过。现在 mock 内部维护一个真实行存储:update 真正改行,where 条件对象
+ * 被逐节点解析成 (column, value) 谓词并按行求值,未命中自然返回 changes=0。
+ * 「实现漏掉谓词 → 测试变红」由此成立:漏掉谓词时两个 CAS 都会命中,第二个
+ * 断言(false)失败。
  */
 
 import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { and, eq, inArray } from 'drizzle-orm';
+import type { SQL } from 'drizzle-orm';
+import type { SQLiteColumn } from 'drizzle-orm/sqlite-core';
 
-// vi.mock 工厂会被 hoist 到 import 之上,引用模块级 let 会报未初始化;用 vi.hoisted 兜住。
-const h = vi.hoisted(() => ({
-  captured: null as Record<string, unknown> | null,
-  updateSet: null as Record<string, unknown> | null,
-  runResult: { changes: 0 } as { changes: number },
-  whereCalled: false,
-}));
+// 真实 schema:drizzle 列对象的 name 即 DB 列名(sdkSessionId → sdk_session_id)。
+// mock 的行存储以 DB 列名为键,update patch 必须先经过同一映射。
+import { sessions } from '../../localDb/schema.js';
+
+/** TS 属性名 patch → DB 列名 patch(与 where 条件用的列名同口径)。 */
+function toDbColumns(patch: Record<string, unknown>): Record<string, unknown> {
+  const out: Record<string, unknown> = {};
+  for (const [key, value] of Object.entries(patch)) {
+    const column = (sessions as unknown as Record<string, { name?: string }>)[key];
+    out[column?.name ?? key] = value;
+  }
+  return out;
+}
+
+/** 模拟数据库:sessions 表按 id 存行,update 真实改状态。 */
+const h = vi.hoisted(() => {
+  const rows = new Map<string, Record<string, unknown>>();
+  return {
+    rows,
+    captured: null as Record<string, unknown> | null,
+  };
+});
+
+/** drizzle 条件对象 → 谓词(逐节点下钻 queryChunks,拼出 (column, value) 对)。 */
+function compileCondition(condition: SQL): Array<{ column: string; value: unknown }> {
+  const predicates: Array<{ column: string; value: unknown }> = [];
+  const visit = (node: unknown): void => {
+    if (node == null) return;
+    const chunk = node as { queryChunks?: unknown[]; name?: unknown; value?: unknown; constructor?: { name?: string } };
+    const className = chunk.constructor?.name ?? '';
+    if (className === 'SQLiteText' || className === 'SQLiteInteger' || className === 'SQLiteBoolean') {
+      // 列节点本身没有独立谓词含义,等 EQ 节点把 column+value 拼在一起。
+      return;
+    }
+    if (Array.isArray(chunk.queryChunks)) {
+      const columnNode = chunk.queryChunks.find(
+        (c) => (c as { constructor?: { name?: string } })?.constructor?.name?.startsWith('SQLite'),
+      );
+      const paramNode = chunk.queryChunks.find(
+        (c) => (c as { constructor?: { name?: string } })?.constructor?.name === 'Param',
+      );
+      if (columnNode && paramNode) {
+        predicates.push({
+          column: String((columnNode as { name: string }).name),
+          value: (paramNode as { value: unknown }).value,
+        });
+        return;
+      }
+      for (const child of chunk.queryChunks) visit(child);
+    }
+  };
+  visit(condition);
+  return predicates;
+}
+
+function conditionMatches(row: Record<string, unknown>, condition: SQL): boolean {
+  return compileCondition(condition).every((p) => row[p.column] === p.value);
+}
 
 vi.mock('../../localDb/client/current.js', () => ({
   getDbClient: () => ({
@@ -23,29 +83,40 @@ vi.mock('../../localDb/client/current.js', () => ({
       insert: () => ({
         values: (row: Record<string, unknown>) => {
           h.captured = row;
+          if (typeof row.id === 'string') h.rows.set(row.id, { ...row });
           return Promise.resolve();
         },
       }),
       update: () => ({
-        set: (patch: Record<string, unknown>) => {
-          h.updateSet = patch;
-          return {
-            where: () => {
-              h.whereCalled = true;
-              return { run: async () => h.runResult };
+        set: (patch: Record<string, unknown>) => ({
+          where: (condition: SQL) => ({
+            run: async () => {
+              // patch 键是 TS 属性名,行键是 DB 列名,先对齐再合并。
+              const dbPatch = toDbColumns(patch);
+              let changes = 0;
+              for (const [id, row] of h.rows) {
+                if (conditionMatches(row, condition)) {
+                  h.rows.set(id, { ...row, ...dbPatch });
+                  changes += 1;
+                }
+              }
+              return { changes };
             },
-          };
-        },
+          }),
+        }),
       }),
     },
   }),
 }));
 
+// schema.js 同样需要指向 hoisted 行存储的列名映射;这里不 mock schema,
+// 直接用真实 schema(drizzle 列对象的 name 即 db 列名)。
 import { DesktopSessionStorage } from '../session-storage';
 
 describe('DesktopSessionStorage.create remoteHostId 规范化', () => {
   beforeEach(() => {
     h.captured = null;
+    h.rows.clear();
   });
 
   const base = {
@@ -88,6 +159,7 @@ describe('DesktopSessionStorage.create remoteHostId 规范化', () => {
 describe('DesktopSessionStorage.create workspaceKind', () => {
   beforeEach(() => {
     h.captured = null;
+    h.rows.clear();
   });
 
   const base = {
@@ -122,6 +194,7 @@ describe('DesktopSessionStorage.create workspaceKind', () => {
 describe('DesktopSessionStorage.create Review purpose', () => {
   beforeEach(() => {
     h.captured = null;
+    h.rows.clear();
   });
 
   it('persists Review source in the same insert that creates the session', async () => {
@@ -141,6 +214,7 @@ describe('DesktopSessionStorage.create Review purpose', () => {
 describe('DesktopSessionStorage.create workingDir 规范化', () => {
   beforeEach(() => {
     h.captured = null;
+    h.rows.clear();
   });
 
   it('Windows 反斜杠路径入库前归一为 storage spelling', async () => {
@@ -158,29 +232,80 @@ describe('DesktopSessionStorage.create workingDir 规范化', () => {
 });
 
 describe('DesktopSessionStorage.compareAndClearSdkSessionId', () => {
+  /**
+   * 建行:行存储按 **DB 列名**(snake_case)存值 —— 与 drizzle 条件对象里的
+   * SQLiteText.name 一致(谓词评估按列名匹配,不是 TS 属性名)。
+   */
+  function seedSession(id: string, sdkSessionId: string | null): void {
+    h.rows.set(id, {
+      id,
+      title: 't',
+      work_dir: '/repo',
+      working_dir: '/repo',
+      model: 'm',
+      agent_kind: 'codex',
+      effort: 'high',
+      permission_mode: 'ask',
+      status: 'active',
+      total_token_usage: 0,
+      total_cost_usd: 0,
+      total_cost_is_approximate: 0,
+      context_tokens: 0,
+      context_window: 0,
+      // DB 列名:sdk_session_id(schema: sdkSessionId: text('sdk_session_id'))。
+      sdk_session_id: sdkSessionId,
+    });
+  }
+
   beforeEach(() => {
-    h.updateSet = null;
-    h.runResult = { changes: 0 };
-    h.whereCalled = false;
+    h.captured = null;
+    h.rows.clear();
   });
-  it('CAS hit: .run() returns changes=1, method returns true', async () => {
+
+  it('CAS hit: 行内 sdk_session_id 与 expected 相等 → 清空 + changes=1 → true', async () => {
+    seedSession('session-1', 'sdk-old');
     const storage = new DesktopSessionStorage();
-    h.runResult = { changes: 1 };
     await expect(storage.compareAndClearSdkSessionId('session-1', 'sdk-old')).resolves.toBe(true);
-    expect(h.updateSet?.sdkSessionId).toBeNull();
-    expect(h.updateSet?.updatedAt).toEqual(expect.any(Number));
-    expect(h.whereCalled).toBe(true);
+    expect(h.rows.get('session-1')?.sdk_session_id).toBeNull();
   });
-  it('CAS miss: .run() returns changes=0, method returns false, preserves new ID', async () => {
+
+  it('CAS miss: 行内 sdk_session_id 已是并发新 ID → 未命中 changes=0 → false,新 ID 保留', async () => {
+    // 并发方已把 sdk-a 替换为 sdk-b;旧恢复请求仍期望 sdk-a。
+    seedSession('session-1', 'sdk-b');
     const storage = new DesktopSessionStorage();
-    h.runResult = { changes: 0 };
-    await expect(storage.compareAndClearSdkSessionId('session-1', 'sdk-stale')).resolves.toBe(false);
+    await expect(storage.compareAndClearSdkSessionId('session-1', 'sdk-a')).resolves.toBe(false);
+    expect(h.rows.get('session-1')?.sdk_session_id).toBe('sdk-b');
   });
-  it('concurrent path: hit then miss, each call correct', async () => {
+
+  it('未知 id → 未命中 → false', async () => {
     const storage = new DesktopSessionStorage();
-    h.runResult = { changes: 1 };
+    await expect(storage.compareAndClearSdkSessionId('missing', 'sdk-a')).resolves.toBe(false);
+  });
+
+  it('并发序列(CAS 契约核心):hit 后并发写回新 ID,旧 expected 的第二次 CAS 自然 miss', async () => {
+    seedSession('s1', 'sdk-a');
+    const storage = new DesktopSessionStorage();
+
+    // 1) 恢复请求 A:CAS(s1, sdk-a) 命中,行内 sdk_session_id 被清空。
     await expect(storage.compareAndClearSdkSessionId('s1', 'sdk-a')).resolves.toBe(true);
-    h.runResult = { changes: 0 };
+    expect(h.rows.get('s1')?.sdk_session_id).toBeNull();
+
+    // 2) 并发方立刻写回新 ID(真实状态迁移,不是手动改 runResult)。
+    //    注意 CAS patch 写的也是 DB 列名(null 清空),直接改行同口径。
+    h.rows.set('s1', { ...h.rows.get('s1'), sdk_session_id: 'sdk-b' });
+
+    // 3) 旧恢复请求 B 重放 CAS(s1, sdk-a):条件 sdk_session_id='sdk-a' 对当前
+    //    行(= sdk-b)自然未命中 → false。若实现漏掉 sdkSessionId 谓词,
+    //    这次 update 会清掉 sdk-b,本断言与下一行断言同时变红。
     await expect(storage.compareAndClearSdkSessionId('s1', 'sdk-a')).resolves.toBe(false);
+    expect(h.rows.get('s1')?.sdk_session_id).toBe('sdk-b');
+  });
+
+  it('谓词评估器 sanity:两个 eq 子条件都必须满足(and 语义)', async () => {
+    seedSession('s1', 'sdk-a');
+    const storage = new DesktopSessionStorage();
+    // id 对但 expected 不对 → miss。
+    await expect(storage.compareAndClearSdkSessionId('s1', 'sdk-nope')).resolves.toBe(false);
+    expect(h.rows.get('s1')?.sdk_session_id).toBe('sdk-a');
   });
 });

--- a/apps/desktop/src/main/maker-host/__tests__/sessionStorageRemoteHostId.test.ts
+++ b/apps/desktop/src/main/maker-host/__tests__/sessionStorageRemoteHostId.test.ts
@@ -13,7 +13,7 @@ import { describe, it, expect, vi, beforeEach } from 'vitest';
 const h = vi.hoisted(() => ({
   captured: null as Record<string, unknown> | null,
   updateSet: null as Record<string, unknown> | null,
-  updateReturning: [] as Array<{ id: string }>,
+  runResult: { changes: 0 } as { changes: number },
   whereCalled: false,
 }));
 
@@ -32,7 +32,7 @@ vi.mock('../../localDb/client/current.js', () => ({
           return {
             where: () => {
               h.whereCalled = true;
-              return { returning: async () => h.updateReturning };
+              return { run: async () => h.runResult };
             },
           };
         },
@@ -160,17 +160,27 @@ describe('DesktopSessionStorage.create workingDir 规范化', () => {
 describe('DesktopSessionStorage.compareAndClearSdkSessionId', () => {
   beforeEach(() => {
     h.updateSet = null;
-    h.updateReturning = [];
+    h.runResult = { changes: 0 };
     h.whereCalled = false;
   });
-  it('用单条条件 update 清空旧 id，并按 returning 报告 CAS 是否命中', async () => {
+  it('CAS hit: .run() returns changes=1, method returns true', async () => {
     const storage = new DesktopSessionStorage();
-    h.updateReturning = [{ id: 'session-1' }];
+    h.runResult = { changes: 1 };
     await expect(storage.compareAndClearSdkSessionId('session-1', 'sdk-old')).resolves.toBe(true);
     expect(h.updateSet?.sdkSessionId).toBeNull();
     expect(h.updateSet?.updatedAt).toEqual(expect.any(Number));
     expect(h.whereCalled).toBe(true);
-    h.updateReturning = [];
+  });
+  it('CAS miss: .run() returns changes=0, method returns false, preserves new ID', async () => {
+    const storage = new DesktopSessionStorage();
+    h.runResult = { changes: 0 };
     await expect(storage.compareAndClearSdkSessionId('session-1', 'sdk-stale')).resolves.toBe(false);
+  });
+  it('concurrent path: hit then miss, each call correct', async () => {
+    const storage = new DesktopSessionStorage();
+    h.runResult = { changes: 1 };
+    await expect(storage.compareAndClearSdkSessionId('s1', 'sdk-a')).resolves.toBe(true);
+    h.runResult = { changes: 0 };
+    await expect(storage.compareAndClearSdkSessionId('s1', 'sdk-a')).resolves.toBe(false);
   });
 });

--- a/apps/desktop/src/main/maker-host/session-storage.ts
+++ b/apps/desktop/src/main/maker-host/session-storage.ts
@@ -142,12 +142,12 @@ export class DesktopSessionStorage implements SessionStorage {
     expectedSdkSessionId: string,
   ): Promise<boolean> {
     const db = getDbClient().drizzle;
-    const changed = await db
+    const result = await db
       .update(sessions)
       .set({ sdkSessionId: null, updatedAt: Date.now() })
       .where(and(eq(sessions.id, id), eq(sessions.sdkSessionId, expectedSdkSessionId)))
-      .returning({ id: sessions.id });
-    return changed.length > 0;
+      .run();
+    return result.changes > 0;
   }
 
   async delete(id: string): Promise<void> {


### PR DESCRIPTION
## 问题

重开旧 Claude 会话时偶发 "No conversation found" 终态错误。根因是 `compareAndClearSdkSessionId()` 通过 drizzle IPC 代理使用 `.returning()`，但代理对 UPDATE 语句的 RETURNING 子句未实现，始终返回 `[]`，导致 CAS（compare-and-swap）即使 UPDATE 成功也报告失败，阻断了 invalid-resume 自愈路径。

## 改动

- `session-storage.ts`: 将 `.returning({ id })` 替换为 `.run()`，按 `result.changes > 0` 判断 CAS 命中
- `sessionStorageRemoteHostId.test.ts`: 更新 mock 从 `.returning()` 改为 `.run()`，拆分为3个回归测试（命中/未命中/并发）

此模式与 `sessions.ts:1323` 中已有的 `.run()` 用法一致。

## 这次改了什么

2 个文件：
- `apps/desktop/src/main/maker-host/session-storage.ts` — CAS 判定逻辑从 `.returning()` 改为 `.run()`（3 行变化）
- `apps/desktop/src/main/maker-host/__tests__/sessionStorageRemoteHostId.test.ts` — mock 更新 + 新增 3 个回归测试

## 怎么验证的

- Desktop 测试 12/12 通过
- maker-core 测试 77/77 通过
- 新增回归测试覆盖：CAS 命中（UPDATE 成功）、CAS 未命中（sdk_session_id 不匹配）、并发 CAS 竞争
- 仅改动 2 个文件，无 scope creep

## 风险

- 改动极小（3 行核心逻辑 + 测试更新），不影响其他 session 操作
- `.run()` 模式与现有 `sessions.ts:1323` 一致，非新模式
- 无持久化、无数据库 schema、无 UI 变化
- 如果 `result.changes` 在 IPC 层异常，行为与修复前相同（自愈失败），不会引入新问题

Fixes #3496