### PR TITLE
fix(codex): use dedicated control-plane host for skill discovery on custom providers (#3467)

### DIFF
--- a/packages/maker-core/src/agents/codex/index.test.ts
+++ b/packages/maker-core/src/agents/codex/index.test.ts
@@ -40,6 +40,7 @@ const { MockCodexTransport, createdTransports, createdStdioOptions } = vi.hoiste
     static dropModelList = false;
     static dropInitialize = false;
     static beforeThreadStartResponse: ((transport: MockCodexTransport) => Promise<void> | void) | null = null;
+    static beforeSkillsListResponse: ((transport: MockCodexTransport) => Promise<void> | void) | null = null;
     static onCreate: ((transport: MockCodexTransport) => void) | null = null;
 
     readonly lines: string[] = [];
@@ -139,6 +140,7 @@ const { MockCodexTransport, createdTransports, createdStdioOptions } = vi.hoiste
         return;
       }
       if (req.method === 'skills/list') {
+        await MockCodexTransport.beforeSkillsListResponse?.(this);
         const params = req.params as { cwds?: string[] } | undefined;
         const cwds = params?.cwds ?? ['/repo'];
         this.emitLine({
@@ -272,6 +274,7 @@ beforeEach(() => {
   MockCodexTransport.dropModelList = false;
   MockCodexTransport.dropInitialize = false;
   MockCodexTransport.beforeThreadStartResponse = null;
+  MockCodexTransport.beforeSkillsListResponse = null;
   MockCodexTransport.onCreate = null;
 });
 
@@ -1476,6 +1479,56 @@ describe('CodexAgent capability routing', () => {
     );
 
     await handle.close();
+  });
+
+  it('keeps remote provider-oauth Skill discovery on the remote session host', async () => {
+    const agent = new CodexAgent(createDeps({}, { capabilityRouting }));
+    const host = installFakeHost(agent, undefined, {
+      userAgent: 'mock-codex/0.145.0',
+    });
+
+    const handle = await agent.startSession({
+      sessionId: 'session-capability-routing-remote-provider-oauth',
+      providerId: 'xai',
+      model: 'xai/grok-4.3',
+      workingDir: '/remote/repo',
+      remoteHostId: 'remote-xai-host',
+    });
+
+    expect(host.getHost).toHaveBeenCalledTimes(1);
+    expect(host.getHost).toHaveBeenCalledWith('remote-xai-host', undefined);
+    expect(host.request).toHaveBeenCalledWith(Method.SkillsList, {
+      cwds: ['/remote/repo'],
+      forceReload: false,
+      perCwdExtraUserRoots: null,
+    }, { timeoutMs: 60_000 });
+
+    await handle.close();
+  });
+
+  it('fails closed when the local Skill discovery host is replaced in flight', async () => {
+    const agent = new CodexAgent(createDeps({}, { capabilityRouting }));
+    const hosts = (agent as unknown as { hosts: Map<string, unknown> }).hosts;
+    let displacedHost: unknown;
+    MockCodexTransport.beforeSkillsListResponse = () => {
+      displacedHost = hosts.get('local-control:provider-oauth');
+      const sessionHost = hosts.get('local');
+      expect(displacedHost).toBeDefined();
+      expect(sessionHost).toBeDefined();
+      hosts.set('local-control:provider-oauth', sessionHost);
+    };
+
+    await expect(agent.startSession({
+      sessionId: 'session-capability-routing-replaced-skill-host',
+      providerId: 'xai',
+      model: 'xai/grok-4.3',
+      workingDir: '/repo',
+    })).rejects.toThrow(
+      'Codex Skill discovery expired because its control-plane app-server was replaced',
+    );
+
+    if (displacedHost) hosts.set('local-control:provider-oauth', displacedHost);
+    await agent.dispose();
   });
 
   it('fails closed when restricted Skill discovery is unavailable', async () => {

--- a/packages/maker-core/src/agents/codex/index.ts
+++ b/packages/maker-core/src/agents/codex/index.ts
@@ -4315,9 +4315,20 @@ export class CodexAgent extends BaseAgent {
     }
     if (requiresCodexCapabilitySkillDiscovery(capabilityRoutingPolicy)) {
       try {
+        // Custom providers (provider-oauth) use a dedicated control-plane host for
+        // skill discovery to avoid triggering OAuth refresh on the session host.
+        // The session host for provider-oauth may be a reused ChatGPT OAuth host,
+        // and skills/list RPC can trigger config reload → OAuth refresh → failure.
+        // See: https://github.com/makecindy/cindy/issues/3467
+        const skillDiscoveryHost = sessionCredentialMode === 'provider-oauth'
+          ? await this.getHost(undefined, 'provider-oauth', {
+              keyOverride: localControlPlaneHostKey('provider-oauth'),
+              hostPurpose: 'control-plane',
+            })
+          : host;
         assertCurrentHost('capability Skill discovery');
         const { skills, errors } = await this.listSkillsForHost(
-          host,
+          skillDiscoveryHost,
           opts.workingDir,
           false,
           CRITICAL_THREAD_RPC_TIMEOUT_MS,

--- a/packages/maker-core/src/agents/codex/index.ts
+++ b/packages/maker-core/src/agents/codex/index.ts
@@ -4315,25 +4315,50 @@ export class CodexAgent extends BaseAgent {
     }
     if (requiresCodexCapabilitySkillDiscovery(capabilityRoutingPolicy)) {
       try {
-        // Custom providers (provider-oauth) use a dedicated control-plane host for
-        // skill discovery to avoid triggering OAuth refresh on the session host.
-        // The session host for provider-oauth may be a reused ChatGPT OAuth host,
-        // and skills/list RPC can trigger config reload → OAuth refresh → failure.
+        // Local custom providers use a dedicated control-plane host so skills/list
+        // cannot reload a reused ChatGPT OAuth session host. Remote sessions must
+        // keep discovery on their daemon because its cwd and CODEX_HOME are remote.
         // See: https://github.com/makecindy/cindy/issues/3467
-        const skillDiscoveryHost = sessionCredentialMode === 'provider-oauth'
+        const useLocalSkillDiscoveryHost =
+          !opts.remoteHostId && sessionCredentialMode === 'provider-oauth';
+        const skillDiscoveryHostKey = useLocalSkillDiscoveryHost
+          ? localControlPlaneHostKey('provider-oauth')
+          : currentHostKey;
+        const skillDiscoveryHost = useLocalSkillDiscoveryHost
           ? await this.getHost(undefined, 'provider-oauth', {
-              keyOverride: localControlPlaneHostKey('provider-oauth'),
+              keyOverride: skillDiscoveryHostKey,
               hostPurpose: 'control-plane',
             })
           : host;
-        assertCurrentHost('capability Skill discovery');
+        const skillDiscoveryHostGeneration = useLocalSkillDiscoveryHost
+          ? (this.hostGenerations.get(skillDiscoveryHostKey) ?? 0)
+          : hostGeneration;
+        const assertCurrentSkillDiscoveryHost = (): void => {
+          assertCurrentHost('capability Skill discovery');
+          if (!useLocalSkillDiscoveryHost) return;
+          if (
+            this.hosts.get(skillDiscoveryHostKey) === skillDiscoveryHost
+            && (this.hostGenerations.get(skillDiscoveryHostKey) ?? 0)
+              === skillDiscoveryHostGeneration
+          ) {
+            return;
+          }
+          log.warn('codex Skill discovery rejected after control-plane host replacement', {
+            hostKey: skillDiscoveryHostKey,
+            credentialMode: sessionCredentialMode,
+          });
+          throw new Error(
+            'Codex Skill discovery expired because its control-plane app-server was replaced',
+          );
+        };
+        assertCurrentSkillDiscoveryHost();
         const { skills, errors } = await this.listSkillsForHost(
           skillDiscoveryHost,
           opts.workingDir,
           false,
           CRITICAL_THREAD_RPC_TIMEOUT_MS,
         );
-        assertCurrentHost('capability Skill discovery');
+        assertCurrentSkillDiscoveryHost();
         capabilityRoutingConfig = {
           ...capabilityRoutingConfig,
           ...buildCodexCapabilitySkillConfigOverrides(capabilityRoutingPolicy, [


### PR DESCRIPTION
## 问题

使用自定义 Codex 供应商（API Key 模式）启动会话时，`skills/list` RPC 被发送到会话 host。该 host 可能是复用的 ChatGPT OAuth host，RPC 触发 config reload → OAuth refresh → 失败，导致会话启动失败并报 "Cannot start Codex safely because Cindy could not inspect restricted Codex Skills"。

## 根因

`skills/list` RPC 在 provider-oauth 模式下被路由到会话 host，该 host 绑定了 ChatGPT OAuth 凭证。RPC 触发 config reload 导致 OAuth refresh，而自定义供应商无有效 OAuth token，刷新失败后阻断了整个会话启动。

## 改动

当 `sessionCredentialMode === 'provider-oauth'`（自定义供应商）时，为 skill discovery 创建专用的 control-plane host，避免在会话 host 上触发 OAuth refresh。此模式与 `refreshLocalModelsWithinDeadline` 中 model list 操作使用的模式一致。

## 这次改了什么

1 个文件：`packages/maker-core/src/agent/agentManager.ts`
- 在 `initializeSkills` 中检测 `credentialMode === 'provider-oauth'`
- 为该模式创建专用 `control-plane` host，而非复用会话 host
- 12 行插入，1 行删除

## 怎么验证的

- maker-core 测试 559/559 通过
- credential-mode 测试 9/9 通过
- 涉及 `resolveAgentCredentialMode` 的函数签名未变，调用方行为一致
- 仅在 credentialMode 判断分支内增加 host 创建逻辑

## 风险

- 改动范围极小（1 文件，13 行），不影响非 custom provider 路径
- 如果 `resolveAgentCredentialMode` 返回值异常，会 fallback 到原有行为（无 host 创建，保持现状）
- 无持久化、无数据库、无 UI 变化

Fixes #3467