### PR TITLE
docs(contributing): 建议开启维护者编辑权限

### DIFF
--- a/CONTRIBUTING.en.md
+++ b/CONTRIBUTING.en.md
@@ -66,7 +66,12 @@ explain why any highly relevant check was not run.
    including scope, verification, risks, and rollback information.
 5. When submitting a pull request from a personal fork, we recommend keeping
    `Allow edits from maintainers` enabled so maintainers and QA can collaborate
-   on fixes directly in the original pull request branch.
+   on fixes directly in the original pull request branch. If the fork contains
+   GitHub Actions workflows, GitHub labels the option
+   `Allow edits and access to secrets by maintainers`; enabling it also lets
+   upstream maintainers edit workflows in the fork, which can potentially
+   reveal Actions secrets or grant access to other branches. Only enable it if
+   you accept that permission scope.
 6. Wait for CI and review; do not push directly to `main`.
 
 Small documentation fixes are welcome as pull requests. For larger changes to

--- a/CONTRIBUTING.en.md
+++ b/CONTRIBUTING.en.md
@@ -64,7 +64,10 @@ explain why any highly relevant check was not run.
    unrelated generated files, or unintended submodule pointer changes.
 4. Complete the [pull request template](.github/PULL_REQUEST_TEMPLATE.md),
    including scope, verification, risks, and rollback information.
-5. Wait for CI and review; do not push directly to `main`.
+5. When submitting a pull request from a personal fork, we recommend keeping
+   `Allow edits from maintainers` enabled so maintainers and QA can collaborate
+   on fixes directly in the original pull request branch.
+6. Wait for CI and review; do not push directly to `main`.
 
 Small documentation fixes are welcome as pull requests. For larger changes to
 architecture, protocols, database migrations, permissions, or user data,

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -52,7 +52,10 @@ Git LFS 和依赖安装。该文档是安装命令的唯一权威说明；本指
 3. Review 完整 diff，确认没有凭证、无关生成文件或意外的 submodule 指针变化。
 4. 按 [PR 模板](.github/PULL_REQUEST_TEMPLATE.md) 填写变更范围、验证、风险和回滚方式。
 5. 从个人 Fork 提交 PR 时，建议保持 `Allow edits from maintainers` 开启，方便维护者和 QA
-   直接在原 PR 分支协作修复。
+   直接在原 PR 分支协作修复。若 Fork 包含 GitHub Actions workflow，该选项会显示为
+   `Allow edits and access to secrets by maintainers`；开启后，拥有上游仓库 push 权限的维护者
+   也能编辑 Fork 中的 workflow，可能暴露 Actions secrets 或取得其他分支的访问权限。
+   请仅在接受这一权限范围时开启。
 6. 等待 CI 和 review；不要直接向 `main` 推送。
 
 小型文档修正也欢迎直接提交 PR。较大的架构、协议、数据库 migration、权限或用户数据

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -51,7 +51,9 @@ Git LFS 和依赖安装。该文档是安装命令的唯一权威说明；本指
    [PR 模板](.github/PULL_REQUEST_TEMPLATE.md)。
 3. Review 完整 diff，确认没有凭证、无关生成文件或意外的 submodule 指针变化。
 4. 按 [PR 模板](.github/PULL_REQUEST_TEMPLATE.md) 填写变更范围、验证、风险和回滚方式。
-5. 等待 CI 和 review；不要直接向 `main` 推送。
+5. 从个人 Fork 提交 PR 时，建议保持 `Allow edits from maintainers` 开启，方便维护者和 QA
+   直接在原 PR 分支协作修复。
+6. 等待 CI 和 review；不要直接向 `main` 推送。
 
 小型文档修正也欢迎直接提交 PR。较大的架构、协议、数据库 migration、权限或用户数据
 变更，建议先开 issue 讨论范围和兼容性。


### PR DESCRIPTION
## 这次改了什么

### 摘要

在中英文贡献指南的 PR 提交流程中补充协作建议：从个人 Fork 提交 PR 时，建议保持 `Allow edits from maintainers` 开启，方便维护者和 QA 直接在原 PR 分支协作修复；同时提醒含 GitHub Actions workflow 的 Fork 会向维护者开放 workflow 编辑与 secrets 访问，仅应在接受该权限范围时开启。

### 变更类型

- [ ] `feat` 新功能
- [ ] `fix` 缺陷修复
- [ ] `refactor` / `perf` 重构或性能优化
- [x] `docs` / `test` / `chore` 文档、测试或工程维护
- [ ] 其他：

### 范围

- 关联 Issue / 需求：无
- 本 PR 包含：同步修改 `CONTRIBUTING.md` 与 `CONTRIBUTING.en.md` 的 PR 提交流程说明，并补充 Actions secrets 权限警示
- 明确不包含：PR 模板检查、机器人提醒或合并门禁
- 用户可见变化：贡献者会看到开启维护者编辑权限的建议，以及 Actions workflow 场景下的权限风险
- 是否存在 breaking change：无

### UI 变化

不涉及。

- 引用的设计规范：不涉及

## 怎么验证的

### 自动验证

```text
corepack pnpm test:unit:related
结果：通过；436 项测试中 435 通过、1 跳过、0 失败。

git diff --check origin/main...HEAD
结果：通过。

corepack pnpm check:dco
结果：通过；3 个 commit 均已签署 DCO。
```

### 手工验证

Review 完整 diff，确认仅修改 `CONTRIBUTING.md` 与 `CONTRIBUTING.en.md` 中的 PR 提交流程说明，并核对中英文权限警示语义一致。

### 未执行的验证

统一全量单测门禁已执行，但当前基线存在 6 个失败：

- `src/main/__tests__/claudeOrphanReaper.test.ts`：5 个断言失败
- `src/main/usage/__tests__/usageHistory.test.ts`：1 个断言失败

在干净的 `main` 基线（`1848e796`）上执行同一门禁可复现完全相同的失败，确认与本 PR 的文档改动无关，交由 CI 复核。

本次未涉及任何 package，因此无适用的 package typecheck。

## 风险

### 风险分类

- [x] 无已知风险
- [ ] SQLite / migration
- [ ] system prompt
- [ ] 协议兼容
- [ ] 权限 / 安全 / 用户数据
- [ ] 存量插件兼容（批准状态 / 指纹 / manifest 校验 / 安装布局 / 包格式）
- [ ] 原生层 / fingerprint / OTA
- [ ] 跨平台差异
- [ ] 其他：

### 影响与回滚

- 影响范围：中英文贡献指南中的 PR 协作与 Actions secrets 权限说明；不改变任何运行时权限
- 回滚 / 降级方式：回退该文档句子即可

### 提交前检查

- [x] 已 review 完整 diff
- [x] 每个 commit 都带 DCO 签名（`git commit -s`，见 [DCO](../DCO)）
- [ ] UI 改动已在「UI 变化」注明引用的设计规范章节（不涉及 UI 则跳过）
- [x] 未提交凭证、令牌或授权文件
- [x] 已补充必要文档
- [x] 已确认测试结果或说明未执行原因
