### PR TITLE
fix(codex): 远端 compact 密文失败走同一任务换窗

### DIFF
--- a/apps/desktop/src/main/maker-ipc/__tests__/contextOverflowRollover.test.ts
+++ b/apps/desktop/src/main/maker-ipc/__tests__/contextOverflowRollover.test.ts
@@ -46,6 +46,21 @@ describe('isContextOverflowErrorData', () => {
       isContextOverflowErrorData({ message: 'Rate limit exceeded: too many tokens per minute' }),
     ).toBe(false);
   });
+
+  it('treats Codex remote compact encrypted-content 400 as rebuildable', () => {
+    expect(
+      isContextOverflowErrorData({
+        message:
+          'Error running remote compact task: { "type": "error", "error": { "code": "invalid_encrypted_content" } }',
+      }),
+    ).toBe(true);
+    expect(
+      isContextOverflowErrorData({
+        message:
+          'Encrypted content could not be decrypted or parsed. code=invalid_encrypted_content',
+      }),
+    ).toBe(false);
+  });
 });
 
 describe('shouldRebuildPiNativeSession', () => {
@@ -720,6 +735,43 @@ describe('createContextOverflowRollover', () => {
     expect(remoteDeps.closeSession).not.toHaveBeenCalled();
   });
 
+  it('rebuilds Codex remote compact encrypted-content failures without a context-overflow reason key', async () => {
+    const deps = makeDeps([
+      msg('user', '先做 A', 'u1', 1),
+      msg('assistant', '做完 A', 'a1', 2),
+      msg('user', '再做 B', 'u2', 3),
+    ]);
+    deps.getSessionRow.mockResolvedValue({
+      status: 'active',
+      agentKind: 'codex',
+      remoteHostId: null,
+      clearedAt: null,
+      sdkSessionId: 'thread-1',
+      contextTokens: 12_000,
+      contextWindow: 200_000,
+      model: 'gpt-5.6-sol',
+      providerId: 'openai',
+    });
+    const rollover = createContextOverflowRollover(deps);
+    rollover.claim('s1');
+    await expect(
+      rollover.tryRecover('s1', {
+        message:
+          'Error running remote compact task: { "type": "error", "error": { "code": "invalid_encrypted_content" } }',
+      }),
+    ).resolves.toBe(true);
+    expect(deps.commitRebuild).toHaveBeenCalledWith(
+      's1',
+      expect.any(String),
+      expect.objectContaining({
+        reason: 'context-overflow',
+        sourceUserClientId: 'u2',
+        sourceAgentKind: 'codex',
+      }),
+    );
+    expect(deps.replayUserMessage).toHaveBeenCalledWith('s1', '再做 B');
+  });
+
   it('rebuilds once, injects handoff, and wire-replays the same user content', async () => {
     const deps = makeDeps([
       msg('user', '先做 A', 'u1', 1),
@@ -837,6 +889,27 @@ describe('createContextOverflowRollover', () => {
       rollover.tryRecover('s1', { reason: 'context-overflow', message: 'prompt too long' }),
     ).resolves.toBe(false);
     expect(deps.commitRebuild).not.toHaveBeenCalled();
+    expect(deps.replayUserMessage).not.toHaveBeenCalled();
+  });
+
+  it('rebuilds before send when the trailing error is a Codex remote compact encrypted-content 400', async () => {
+    const compactError =
+      'Error running remote compact task: { "type": "error", "error": { "code": "invalid_encrypted_content" } }';
+    const deps = makeDeps([msg('user', '继续', 'u1'), msg('error', compactError, 'e1')]);
+    deps.getSessionRow.mockResolvedValue({
+      status: 'active',
+      agentKind: 'codex',
+      remoteHostId: null,
+      clearedAt: null,
+      sdkSessionId: 'thread-1',
+      contextTokens: 12_000,
+      contextWindow: 200_000,
+      model: 'gpt-5.6-sol',
+      providerId: 'openai',
+    });
+    const rollover = createContextOverflowRollover(deps);
+    await expect(rollover.prepareUnhealthySession('s1')).resolves.toBe(true);
+    expect(deps.commitRebuild).toHaveBeenCalled();
     expect(deps.replayUserMessage).not.toHaveBeenCalled();
   });
 

--- a/apps/desktop/src/main/maker-ipc/contextOverflowRollover.ts
+++ b/apps/desktop/src/main/maker-ipc/contextOverflowRollover.ts
@@ -9,6 +9,7 @@ import {
   CODEX_HISTORY_OVERSIZED_REASON,
   CONTEXT_OVERFLOW_REASON,
   isContextOverflowErrorMessage,
+  isRemoteCompactEncryptedContentError,
 } from '@cindy/maker-core';
 import {
   projectAgentFacingText,
@@ -48,7 +49,9 @@ export function isContextOverflowErrorData(data: unknown): boolean {
   const rec = data as { reason?: unknown; message?: unknown; sdkError?: unknown };
   if (rec.reason === CONTEXT_OVERFLOW_REASON) return true;
   return [rec.message, rec.sdkError].some(
-    (value) => typeof value === 'string' && isContextOverflowErrorMessage(value),
+    (value) =>
+      typeof value === 'string' &&
+      (isContextOverflowErrorMessage(value) || isRemoteCompactEncryptedContentError(value)),
   );
 }
 

--- a/docs/dev-rules/maker-core-and-agent-behavior.md
+++ b/docs/dev-rules/maker-core-and-agent-behavior.md
@@ -37,7 +37,10 @@ controller／进程内；重启后没有 live handle 时不凭估算换窗。Orc
 fail closed。compact 失败触发的换窗同样 fail closed，不得自动 replay 已有副作用的用户消息。
 PI 的 `pi-prompt-timeout` 是唯一保留的 timeout 交接入口；Claude Code／Codex 的普通
 timeout 不得触发自动换窗或 replay。Codex 当前没有与 Claude `AutoCompactController` 对等的 host
-自动 `/compact` 注入路径；未来若增加，仍须遵守同一评估和交接边界。手动压缩入口不受此规则影响，
+自动 `/compact` 注入路径；未来若增加，仍须遵守同一评估和交接边界。Codex 订阅远端压缩若因
+`invalid_encrypted_content` 硬失败（`Error running remote compact task`），视为官方 compact
+确定性失败，走同一套 host-controlled rollover；单独的 `invalid_encrypted_content`（HTTP 静默剥
+推理密文范围）不得当成换窗。手动压缩入口不受此规则影响，
 手动 compact 失败不得锁存换窗。
 
 Cindy 保底压缩是**一套**流程，不是剥图 / 换窗两套功能。装得进当前约束就不动；

--- a/packages/maker-core/src/agents/codex/index.test.ts
+++ b/packages/maker-core/src/agents/codex/index.test.ts
@@ -8280,6 +8280,62 @@ describe('CodexAgent MCP thread context hooks', () => {
       await handle.close();
     });
 
+    it('does not arm HTTP fallback for remote compact encrypted-content 400', async () => {
+      const compactEncrypted =
+        'Error running remote compact task: { "type": "error", "error": { "code": "invalid_encrypted_content" } }';
+      const armCodexHttpRecovery = vi.fn(() => 'encrypted_content');
+      const agent = new CodexAgent(createDeps({}, { armCodexHttpRecovery }));
+      const host = installRecoveryHost(agent);
+      const handle = await agent.startSession({
+        sessionId: 'session-ws-remote-compact-encrypted',
+        model: 'gpt-5.4',
+        workingDir: '/repo',
+      });
+      const events: AgentEvent[] = [];
+      void (async () => {
+        for await (const event of handle.events()) events.push(event);
+      })();
+
+      await handle.send({ type: 'user', content: 'hello' });
+      const handlers = host.getThreadHandlers();
+      if (!handlers?.error || !handlers.turnCompleted) throw new Error('expected handlers');
+
+      handlers.error({
+        threadId: 'start-thread-id',
+        turnId: 'turn-1',
+        willRetry: false,
+        error: {
+          message: compactEncrypted,
+          additionalDetails: compactEncrypted,
+          codexErrorInfo: 'badRequest',
+        },
+      });
+      handlers.turnCompleted({
+        threadId: 'start-thread-id',
+        turn: {
+          id: 'turn-1',
+          status: 'failed',
+          error: { message: compactEncrypted },
+        },
+      });
+
+      await waitForExpectation(() => {
+        expect(
+          events.some(
+            (event) =>
+              event.type === 'error' &&
+              (event.data as { isTerminal?: boolean; reason?: string }).isTerminal === true &&
+              (event.data as { reason?: string }).reason === 'context-overflow',
+          ),
+        ).toBe(true);
+      });
+      expect(
+        host.request.mock.calls.filter(([method]) => method === Method.TurnStart),
+      ).toHaveLength(1);
+      expect(armCodexHttpRecovery).not.toHaveBeenCalled();
+      await handle.close();
+    });
+
     it.each([false, true])(
       'defers HTTP fallback until an early recovery error gets turn/start ownership (started=%s)',
       async (startedBeforeError) => {

--- a/packages/maker-core/src/agents/codex/index.ts
+++ b/packages/maker-core/src/agents/codex/index.ts
@@ -109,6 +109,7 @@ import {
   overloadRetryDelayMs,
   parseOverloadError,
 } from '../shared/overload-error.js';
+import { isRemoteCompactEncryptedContentError } from '../shared/remote-compact-encrypted-error.js';
 import { buildCodexEnv } from './env-builder.js';
 import {
   buildCodexCapabilityConfigOverrides,
@@ -8770,6 +8771,10 @@ export class CodexAgent extends BaseAgent {
       const additionalDetails =
         typeof error?.additionalDetails === 'string' ? error.additionalDetails : null;
       if (!message && !additionalDetails) return null;
+      const classifyText = additionalDetails ? `${message}\n${additionalDetails}` : message;
+      // 远端 compact 密文 400 是 Codex 内部硬失败，HTTP 剥密文跳过 compaction blob，
+      // 重投必再 400。不得当推理密文 400 去 arm WS→HTTP recovery。
+      if (isRemoteCompactEncryptedContentError(classifyText)) return null;
       try {
         return this.deps.armCodexHttpRecovery({
           sessionId: sid,

--- a/packages/maker-core/src/agents/codex/translator.test.ts
+++ b/packages/maker-core/src/agents/codex/translator.test.ts
@@ -808,6 +808,41 @@ describe('translateErrorNotification', () => {
     expect(events[0]!.data).not.toHaveProperty('reason');
   });
 
+  it('Codex 远端 compact 密文 400 走 context-overflow，交给 host 换窗而不是原样重试', async () => {
+    const rt = newCodexRuntimeState();
+    const q = createAsyncQueue<AgentEvent>();
+    translateErrorNotification(
+      makeParams({
+        willRetry: false,
+        message:
+          'Error running remote compact task: { "type": "error", "error": { "code": "invalid_encrypted_content", "message": "The encrypted content cind...9ln0 could not be verified." } }',
+      }),
+      q,
+      makeCtx(rt),
+    );
+    const events = await collect(q);
+    expect(events[0]!.data).toMatchObject({
+      reason: 'context-overflow',
+      isTerminal: true,
+    });
+  });
+
+  it('单独的 invalid_encrypted_content 不冒充超限换窗', async () => {
+    const rt = newCodexRuntimeState();
+    const q = createAsyncQueue<AgentEvent>();
+    translateErrorNotification(
+      makeParams({
+        willRetry: false,
+        message:
+          'Encrypted content could not be decrypted or parsed. code=invalid_encrypted_content',
+      }),
+      q,
+      makeCtx(rt),
+    );
+    const events = await collect(q);
+    expect(events[0]!.data).not.toHaveProperty('reason');
+  });
+
   it('上下文超限终止错误带 context-overflow reason(#1429): 原样重试必败, renderer 靠它换恢复动作', async () => {
     const rt = newCodexRuntimeState();
     const q = createAsyncQueue<AgentEvent>();
@@ -843,6 +878,23 @@ describe('translateErrorNotification', () => {
       message: 'stream dropped',
       codexErrorInfo: { responseStreamDisconnected: { httpStatusCode: 502 } },
     }).errorInfoTag).toBe('responseStreamDisconnected');
+    expect(
+      classifyCodexError({
+        message:
+          'Error running remote compact task: { "type": "error", "error": { "code": "invalid_encrypted_content" } }',
+      }).reason,
+    ).toBe('context-overflow');
+    expect(
+      classifyCodexError({
+        message: 'Error running remote compact task',
+        additionalDetails: 'code=invalid_encrypted_content',
+      }).reason,
+    ).toBe('context-overflow');
+    expect(
+      classifyCodexError({
+        message: 'Encrypted content could not be decrypted or parsed. code=invalid_encrypted_content',
+      }).reason,
+    ).toBeUndefined();
   });
 
   it('Codex 结构化 contextWindowExceeded tag 不依赖错误文案措辞', async () => {

--- a/packages/maker-core/src/agents/codex/translator.ts
+++ b/packages/maker-core/src/agents/codex/translator.ts
@@ -46,6 +46,7 @@ import {
   CONTEXT_OVERFLOW_REASON,
   isContextOverflowErrorMessage,
 } from '../shared/context-overflow-error.js';
+import { isRemoteCompactEncryptedContentError } from '../shared/remote-compact-encrypted-error.js';
 import { commandExecutionDisplayInput, type CommandExecutionDisplayInput } from './command-display.js';
 import { annotateSandboxInitFailure } from './sandbox-init-failure.js';
 import { codexErrorInfoTag } from './app-server/protocol.js';
@@ -491,10 +492,13 @@ export interface ClassifiedCodexError {
 
 /**
  * ErrorNotification 与 turn/completed.turn.error 共用的结构化分类。
- * 只消费 Codex wire schema 的 codexErrorInfo；additionalDetails / stderr 不参与判定。
+ * 默认只消费 Codex wire schema 的 message + codexErrorInfo；stderr 不参与判定。
+ * 唯一例外：远端 compact 密文 400 会把 `additionalDetails` 拼进 classify 文本，
+ * 因为用户形态经常是 message=`Error running remote compact task`、code 在 details 里。
  */
 export function classifyCodexError(error: {
   message?: string;
+  additionalDetails?: unknown;
   codexErrorInfo?: import('./app-server/protocol.js').CodexErrorInfo | null;
 } | null | undefined): ClassifiedCodexError {
   const rawMessage = error?.message ?? 'codex error';
@@ -510,9 +514,14 @@ export function classifyCodexError(error: {
   const errorInfoTag = codexErrorInfoTag(error?.codexErrorInfo);
   const isCapacityError =
     parseOverloadError(message, signals.errorStatus, errorInfoTag)?.kind === 'capacity';
+  const additionalDetails =
+    typeof error?.additionalDetails === 'string' ? error.additionalDetails : '';
+  const compactClassifyText = additionalDetails ? `${message}\n${additionalDetails}` : message;
   const reason = isCapacityError
     ? UPSTREAM_OVERLOAD_REASON
-    : errorInfoTag === 'contextWindowExceeded' || isContextOverflowErrorMessage(message)
+    : errorInfoTag === 'contextWindowExceeded' ||
+        isContextOverflowErrorMessage(message) ||
+        isRemoteCompactEncryptedContentError(compactClassifyText)
       ? CONTEXT_OVERFLOW_REASON
       : undefined;
   return {

--- a/packages/maker-core/src/agents/index.ts
+++ b/packages/maker-core/src/agents/index.ts
@@ -72,6 +72,7 @@ export {
   CONTEXT_OVERFLOW_REASON,
   isContextOverflowErrorMessage,
 } from './shared/context-overflow-error.js';
+export { isRemoteCompactEncryptedContentError } from './shared/remote-compact-encrypted-error.js';
 export { isDeterministicHostCompactFailure } from './shared/auto-compact-controller.js';
 // ErrorBanner 用人话替换 LiteLLM / Responses 空壳流中断,不驱动自动续跑。
 export {

--- a/packages/maker-core/src/agents/shared/remote-compact-encrypted-error.test.ts
+++ b/packages/maker-core/src/agents/shared/remote-compact-encrypted-error.test.ts
@@ -1,0 +1,28 @@
+import { describe, expect, it } from "vitest";
+
+import { isRemoteCompactEncryptedContentError } from "./remote-compact-encrypted-error.js";
+
+const COMPACT_ENCRYPTED =
+  'Error running remote compact task: { "type": "error", "error": { "type": "invalid_request_error", "code": "invalid_encrypted_content", "message": "The encrypted content cind...9ln0 could not be verified. Reason: Encrypted content could not be decrypted or parsed." } }';
+
+describe("isRemoteCompactEncryptedContentError", () => {
+  it("matches Codex remote compact 400 with invalid_encrypted_content", () => {
+    expect(isRemoteCompactEncryptedContentError(COMPACT_ENCRYPTED)).toBe(true);
+  });
+
+  it("does not treat standalone encrypted-content failures as compact rollover", () => {
+    expect(
+      isRemoteCompactEncryptedContentError(
+        "Encrypted content could not be decrypted or parsed. code=invalid_encrypted_content",
+      ),
+    ).toBe(false);
+  });
+
+  it("does not match other compact failures", () => {
+    expect(
+      isRemoteCompactEncryptedContentError(
+        "Error running remote compact task: timeout",
+      ),
+    ).toBe(false);
+  });
+});

--- a/packages/maker-core/src/agents/shared/remote-compact-encrypted-error.ts
+++ b/packages/maker-core/src/agents/shared/remote-compact-encrypted-error.ts
@@ -1,0 +1,17 @@
+/**
+ * Codex 订阅远端压缩（remote compact）把解不开的 `encrypted_content` 送给上游后的硬失败。
+ *
+ * 与 HTTP 静默剥推理密文的分工：单独的 `invalid_encrypted_content` 仍由 proxy 剥
+ * `reasoning.encrypted_content` 透明重试。远端 compact 是 Codex 内部硬失败、无本地回退，
+ * 且压缩块密文不能剥；原样重试必再撞同一个 400。恢复动作与满窗 / host compact 确定性
+ * 失败相同：host-controlled rollover（换窗），不要求用户开新任务或 Fork。
+ *
+ * 必须同时命中 compact 入口文案和密文错误码，避免把供应商切换时的推理密文 400 误当成换窗。
+ */
+export function isRemoteCompactEncryptedContentError(message: string): boolean {
+  if (!message) return false;
+  return (
+    /invalid_encrypted_content/i.test(message) &&
+    /remote compact/i.test(message)
+  );
+}


### PR DESCRIPTION
## 这次改了什么

### 摘要

Codex 订阅会话做远端压缩时，如果历史里有解不开的 `encrypted_content`，上游直接 400：`Error running remote compact task` + `invalid_encrypted_content`。这条失败原样重试必败；HTTP 静默剥推理密文也够不到 compact / WebSocket。用户只能开新任务或手动 Fork。

本 PR 把它当成官方 compact 的确定性失败，接到现有同一任务换窗（host-controlled rollover）：关掉旧 native thread、写交接、重放刚才那句用户消息。新任务不用用户去开，也不走 Fork 并剥离。单独的 `invalid_encrypted_content`（供应商切换时 HTTP 还能剥推理密文）不会被误判成换窗。

已 rebase 到含 #3510 的 `main`：密文判定并进 `classifyCodexError`；远端 compact 密文 400 不再 arm HTTP recovery。

### 变更类型

- [x] `fix` 缺陷修复
- [ ] `feat` 新功能
- [ ] `refactor` / `perf` 重构或性能优化
- [ ] `docs` / `test` / `chore` 文档与工程维护
- [ ] 其他：

### 范围

- 关联 Issue / 需求：无独立 issue；用户报告更新后旧 Codex 任务（GPT-5.6 Sol）每条消息都报 remote compact `invalid_encrypted_content`，新任务正常。
- 本 PR 包含：
  - `isRemoteCompactEncryptedContentError`：必须同时命中 `remote compact` 与 `invalid_encrypted_content`
  - `classifyCodexError`（及 turn.completed）给稳定 `context-overflow` reason；仅此路径吃 `additionalDetails`
  - 远端 compact 密文 400 不 arm HTTP recovery
  - 现有 `contextOverflowRollover` 把这类错误当成可重建
  - 已卡住的任务下次发送也会 `prepareUnhealthySession`
- 明确不包含：
  - 不在同一 thread 里剥密文再 compact
  - 不把单独的推理密文 400 拿去换窗
- 用户可见变化：这类 compact 密文失败时，同一条任务自动出现既有「已整理上下文并继续」，不再停在红条上让用户重试或 Fork。本轮已有工具副作用时仍 fail closed，不自动重放。
- 是否存在 breaking change：无

### UI 变化

- 引用的设计规范：不涉及新增视觉。换窗边界卡复用既有 `contextRebuild` 分隔样式与 `chat.errorBanner.contextOverflow` 文案。

## 怎么验证的

### 自动验证

```text
pnpm --filter @cindy/maker-core exec vitest run \
  src/agents/shared/remote-compact-encrypted-error.test.ts \
  src/agents/codex/translator.test.ts \
  src/agents/codex/index.test.ts
结果：3 files / 682 passed（含 websocket body recovery 的 remote-compact 400 fixture）

pnpm --filter desktop exec vitest run \
  src/main/maker-ipc/__tests__/contextOverflowRollover.test.ts
结果：77 passed

pnpm --filter desktop run --if-present typecheck
结果：通过
```

CI 全量 `pnpm test:unit` 为准。

### maker-core 核心指标（translator / 错误分类）

按 `docs/dev-rules/maker-core-and-agent-behavior.md` §3：

- **可能影响**：3.1 缓存率；3.2 热路径；3.3 准确性。不改 system prompt、不改 tool/MCP 注册顺序。
- **实测方法**：
  - 3.1：对照 diff，无 prompt 拼接 / MEMORY 快照 / tool 暴露改动；缓存前缀字节级不变，不做改动前后 cache 对比（没有可对比的前缀变化）。
  - 3.2：`classifyCodexError` 只在 error notification 与 `turn/completed` 上跑，不是每 token。本 PR 只在该函数上多两次正则（`remote compact` + `invalid_encrypted_content`），热路径无新增同步 IO / 深拷贝。
  - 3.3：抽查错误事件映射——compact 密文 400 必须带 `reason: context-overflow` 且不得第二次 `TurnStart`；单独推理密文 400 不得带 overflow reason。由 `translator.test.ts` 与 `index.test.ts` websocket recovery fixture 锁死。
- **结论**：缓存率与流式速度不受影响；错误 reason 从「未分类的 400」细分为 overflow 换窗，属有意行为。

### 手工验证

未在安装版 Cindy 上用真实 GPT-5.6 Sol 旧任务复现换窗。分类与 rollover 由单测覆盖用户截图中的文案形态。

### 未执行的验证

真机：打开已报 `Error running remote compact task` 的旧 Codex 任务，发下一条，确认同一任务交接并继续。

### 远程与手机适配

1. **SSH 远程工作区**：不换窗。沿用现有 `contextOverflowRollover` 对 `remoteHostId` 的 fail-closed：native Codex thread / rollout 在远端，本 PR 不新增远程文件或远端 compact 恢复通道。SSH 上这条 400 仍会落到错误横幅，与满窗 overflow 一致。
2. **设备互联（device-link）**：不新增 IPC / push，不改 allowlist。`tryRecover` / `prepareUnhealthySession` 跑在拥有会话的被控桌面；手机只是控制端，发送仍走既有 maker send。故障半径是**单条任务**，不碰 relay 重连或 peer teardown。
3. **手机版**：无新入口或独立 UI。用户看到的是既有换窗边界卡（经现有事件流镜像）。不另开跟踪 issue。

## 风险

### 风险分类

- [ ] 无已知风险
- [ ] SQLite / migration
- [ ] system prompt
- [x] 协议兼容
- [ ] 权限 / 安全 / 用户数据
- [ ] 存量插件兼容（批准状态 / 指纹 / manifest 校验 / 安装布局 / 包格式）
- [ ] 原生层 / fingerprint / OTA
- [ ] 跨平台差异
- [x] 其他：把 compact 密文失败映射到既有 `context-overflow` 换窗；交接会丢掉 native 历史细节，只保留摘要。本轮已有工具副作用时不自动 replay。

### 影响与回滚

- 影响范围：本地与 device-link 被控桌面上的 Codex 订阅会话。SSH Codex 不换窗。
- 回滚 / 降级方式：revert 本 PR。已换窗的任务继续用新 native thread；旧 rollout 仍在磁盘。

### 提交前检查

- [x] 已 review 完整 diff
- [x] 每个 commit 都带 DCO 签名（`git commit -s`，见 [DCO](../DCO)）
- [x] UI 改动已在「UI 变化」注明引用的设计规范章节（不涉及 UI 则跳过）
- [x] 未提交凭证、令牌或授权文件
- [x] 已补充必要文档
- [x] 已确认测试结果或说明未执行原因
