### PR TITLE
fix(desktop): 将 Beta 渠道标识改为版本号后的普通文字

### DIFF
--- a/apps/desktop/src/renderer/__tests__/userInfoSectionHover.test.ts
+++ b/apps/desktop/src/renderer/__tests__/userInfoSectionHover.test.ts
@@ -86,14 +86,13 @@ describe('UserInfoSection — version label', () => {
     expect(source).toContain('title={appVersionLabelDetail}');
   });
 
-  it('shows the Beta badge only after the persisted channel state has loaded', () => {
+  it('shows the Beta label only after the persisted channel state has loaded', () => {
     expect(source).toContain("import { useBetaChannelSettings } from '@/hooks/useBetaChannelSettings';");
     expect(source).toContain(
-      'const showBetaBadge = !betaChannelState.loading && betaChannelState.enableBeta;',
+      'const showBetaLabel = !betaChannelState.loading && betaChannelState.enableBeta;',
     );
-    expect(source).toContain('data-testid="sidebar-beta-channel-badge"');
-    expect(source).toContain('bg-[var(--beta-channel-badge-bg)]');
-    expect(source).toContain('text-[var(--beta-channel-badge-fg)]');
+    expect(source).toContain('data-testid="sidebar-beta-channel-label"');
+    expect(source).not.toContain('beta-channel-badge');
     expect(source).toContain("t('settings.betaChannel.badge')");
   });
 });

--- a/apps/desktop/src/renderer/__tests__/userInfoSectionMobileDownload.test.tsx
+++ b/apps/desktop/src/renderer/__tests__/userInfoSectionMobileDownload.test.tsx
@@ -82,11 +82,11 @@ beforeEach(() => {
 afterEach(cleanup);
 
 describe('UserInfoSection mobile download entry', () => {
-  it('shows the Beta badge beside the expanded app version when the channel is enabled', () => {
+  it('shows the Beta label beside the expanded app version when the channel is enabled', () => {
     betaChannelState.enableBeta = true;
     render(<UserInfoSection isCollapsed={false} />);
 
-    expect(screen.getByTestId('sidebar-beta-channel-badge').textContent).toBe(
+    expect(screen.getByTestId('sidebar-beta-channel-label').textContent).toBe(
       'settings.betaChannel.badge',
     );
     expect(

--- a/apps/desktop/src/renderer/components/sidebar/UserInfoSection.tsx
+++ b/apps/desktop/src/renderer/components/sidebar/UserInfoSection.tsx
@@ -36,14 +36,14 @@ export function UserInfoSection({ isCollapsed, onOpenUpdateNotice }: UserInfoSec
   const { state: betaChannelState } = useBetaChannelSettings();
   const hasPendingUpdate = status === 'ready' || status === 'superseding';
   const isFlameReopen = hasPendingUpdate && dismissed;
-  const showBetaBadge = !betaChannelState.loading && betaChannelState.enableBeta;
+  const showBetaLabel = !betaChannelState.loading && betaChannelState.enableBeta;
 
   // 头像地址变化(设置页改头像 / 服务端资料更新)时重置加载失败标记,
   // 让新地址有机会渲染,而不是永远停在首字母兜底。
   const isLocal = mode === 'local';
   const displayName = user?.name ?? (isLocal ? t('settings.userProfile.local.name') : '');
   const settingsLinkLabel = t('sidebar.user.settingsLink', { name: displayName });
-  const settingsLinkAriaLabel = showBetaBadge
+  const settingsLinkAriaLabel = showBetaLabel
     ? t('sidebar.user.settingsLinkBeta', { name: displayName })
     : settingsLinkLabel;
   const avatarUrl = user?.avatar ?? null;
@@ -256,10 +256,10 @@ export function UserInfoSection({ isCollapsed, onOpenUpdateNotice }: UserInfoSec
               title={appVersionLabelDetail}
             >
               <span className="truncate opacity-80">{appVersionLabel}</span>
-              {showBetaBadge ? (
+              {showBetaLabel ? (
                 <span
-                  className="shrink-0 select-none rounded-full bg-[var(--beta-channel-badge-bg)] px-1 font-medium text-[var(--beta-channel-badge-fg)]"
-                  data-testid="sidebar-beta-channel-badge"
+                  className="shrink-0 select-none opacity-80"
+                  data-testid="sidebar-beta-channel-label"
                 >
                   {t('settings.betaChannel.badge')}
                 </span>

--- a/apps/desktop/src/renderer/themes/__tests__/cindyDecisionData.ts
+++ b/apps/desktop/src/renderer/themes/__tests__/cindyDecisionData.ts
@@ -400,7 +400,6 @@ export const RED_EXCEPTION_ALLOWED_IDS = [
   'brand-login-bg',
   'brand-login-error-border',
   'brand-login-error-text',
-  'beta-channel-badge-bg', // 用户指定 Beta 状态徽标红底,2026-08-25
   // hover/soft token(中性,但 token 名保留在 allowed 防误报)
   'accent-soft',
   'accent-hover',

--- a/apps/desktop/src/renderer/themes/__tests__/tokenRegistry.test.ts
+++ b/apps/desktop/src/renderer/themes/__tests__/tokenRegistry.test.ts
@@ -64,16 +64,6 @@ describe('主题注册表 · 资源用量进程图标', () => {
   });
 });
 
-describe('主题注册表 · Beta 渠道状态徽标', () => {
-  it.each([
-    ['beta-channel-badge-bg', '#DF0C27'],
-    ['beta-channel-badge-fg', '#FFFFFF'],
-  ] as const)('"%s" 使用 light / dark 同值的专用语义色', (id, hex) => {
-    expect(colorRegistry.resolveDefault(id, 'light')).toBe(hex);
-    expect(colorRegistry.resolveDefault(id, 'dark')).toBe(hex);
-  });
-});
-
 describe('主题注册表 · Plan 操作卡文字语义', () => {
   it.each(['plan-action-approve-text', 'plan-action-fb-text'])(
     '"%s" 使用卡片强调正文而非反相按钮文字',

--- a/apps/desktop/src/renderer/themes/colors.ts
+++ b/apps/desktop/src/renderer/themes/colors.ts
@@ -380,14 +380,6 @@ registerColor('destructive', {
   light: '0 84% 60%',
   dark: '0 72% 63%',
 }, 'Titlebar — Ollama layer system (Light)');
-registerColor('beta-channel-badge-bg', {
-  light: '#DF0C27',
-  dark: '#DF0C27',
-}, 'Beta 测试渠道已开启徽标底色(用户指定红底,2026-08-25;跨主题固定品牌红)');
-registerColor('beta-channel-badge-fg', {
-  light: '#FFFFFF',
-  dark: '#FFFFFF',
-}, 'Beta 测试渠道已开启徽标文字(× #DF0C27 = 4.98:1)');
 
 // confirm-dialog
 registerColor('confirm-bg', {

--- a/docs/design-rules/DESIGN.md
+++ b/docs/design-rules/DESIGN.md
@@ -474,11 +474,11 @@ Theme switching: `useTheme.ts` provides `theme` (System / Light / Dark mode) plu
 | `--file-badge-pdf/-doc/-sheet/-slide/-code` + `--file-badge-fg`                                                                                               | `#B23A26` / `#2C5CA8` / `#2E7D4F` / `#A25A12` / `#5B49A8`, fg `#FFFFFF` | same                                                                  | File-type badges on the self-drawn attachment icon (2026-07-27). Bound to _what the file is_, not to the theme, so both modes share one value. Each accent is picked for ≥4.5:1 against `--file-badge-fg` (5.96 / 6.56 / 5.05 / 5.24 / 7.09) — the badge label renders at 10px (Micro Label floor, §3), so AA small-text applies. `--file-badge-fg` is a standalone white: `--accent-pure-cta-fg` flips to black in Dark and cannot be borrowed. |
 | `--process-agent-task-icon`, `--process-agent-service-icon`, `--process-main-icon`, `--process-renderer-icon`, `--process-gpu-icon`, `--process-utility-icon` | `#2563EB` / `#7C3AED` / `#DB2777` / `#0891B2` / `#D97706` / `#059669`   | `#60A5FA` / `#A78BFA` / `#F472B6` / `#22D3EE` / `#F59E0B` / `#34D399` | Resource Usage 14px process-category glyphs only (2026-08-06). Category cue, not status; all surrounding UI stays neutral. Protected from automatic external-theme import so category identity does not drift.                                                                                                                                                                                                                                   |
 
-`--beta-channel-badge-bg/-fg` (mobile `betaChannelBadgeBackground/Foreground`) are the
-cross-theme fixed pair `#DF0C27` / `#FFFFFF`. They are limited to the enabled Beta-channel
-badge beside the installed app version (desktop sidebar + mobile Settings), explicitly requested
-2026-08-25. This is a persistent channel-state cue, not an error or CTA; white text contrast is
-4.98:1.
+Mobile's `betaChannelBadgeBackground/Foreground` remain the cross-theme fixed pair `#DF0C27` /
+`#FFFFFF`. They are limited to the enabled Beta-channel badge beside the installed app version
+in mobile Settings, explicitly requested 2026-08-25. The Desktop sidebar uses ordinary text after
+the version number and does not consume a red Beta badge token. This is a persistent channel-state
+cue, not an error or CTA; the mobile white text contrast is 4.98:1.
 
 Never freestyle these semantic colors as hardcoded hex — always go through the corresponding token.
 
@@ -1148,7 +1148,7 @@ The splash wordmark is a separate asset pair (`assets/splash/wordmark.png`, whit
 ### 15.10 Red-System Boundary & Neutral CTAs — current state(E1D 红色边界)
 
 - Ordinary primary actions never use brand red — they are neutral-inverse. **Neutral button four states**: light bg `#3C3F43` / text `#FCFCFC`, hover `#2E3237`, pressed `#25282C`; dark bg `#EEEEEE` / text `#151515` (2026-08: inverse dark text shifted with the darker ramp, was `#252222`), hover `#E2E2E2`, pressed `#D4D4D4` (WCAG 10.32/15.74:1).
-- Red is confined to semantic exceptions: `destructive`/delete, `error-*`, warning, diff red, status dots, and the explicit Beta-channel state badge (`--beta-channel-badge-bg/-fg`, user decision 2026-08-25) — plus the login brand accent via `--login-brand-accent` (§16). The older `brand-login-*` tokens were retired with the wave4 white-canvas login and survive only as whitelist strings in `cindyDecisionData.ts` (harmless — the whitelist permits, it does not require).
+- Red is confined to semantic exceptions: `destructive`/delete, `error-*`, warning, diff red, status dots, and the explicit Mobile Beta-channel state badge (`betaChannelBadgeBackground/Foreground`, user decision 2026-08-25) — plus the login brand accent via `--login-brand-accent` (§16). The Desktop sidebar's Beta label is ordinary version text. The older `brand-login-*` tokens were retired with the wave4 white-canvas login and survive only as whitelist strings in `cindyDecisionData.ts` (harmless — the whitelist permits, it does not require).
 - **send-btn family**: `send-btn-bg/-icon/-hover-bg/-pressed-bg/-disabled-bg/-disabled-icon` — CINDY overrides the whole family to the neutral four states + disabled grays (light `#444242`/`#585555` unchanged; dark shifted 2026-08 to `#323232`/`#464646`); defaults keep `--accent-cta-bg` with the opacity-85 hover. Whole family sits in `cindyDecisionData` REQUIRED_IDS + CINDY_EXPECTED, guarded by assertion ③.
 - **Sidebar color hierarchy** (same set for light/dark):
   - Body (session titles) = `text-foreground` (= `text-primary`: light `#3C3F43` / dark `#D4D4D4`).
@@ -1280,7 +1280,7 @@ The execution rulebook for subsequent desktop / mobile UI updates. Sources: the 
 登录页是**黑白反色**体系（亮色 = 白底墨字 / 深色 = 深底米字），与编辑器主界面解耦，亮 / 深两模式镜像同构：
 
 - **面板 / 控件走墨黑–米白反色，深色镜像反相**：亮色白面板 `#FBFBFB` + 米白控件 `#EEEEEE` + 墨黑主按钮 `#2A2828`；深色反相为深面板 `#312F2F` + 深控件 `#2C2A2A` + 白主按钮 `#EEEEEE`。**两模式的面板 / 控件底色与文字都不出现纯黑 `#000` 或纯白 `#fff`**（`figma-component-spec §1.1`）；细描边例外——暗色主按钮 / 圆钮的 `#FFFFFF` 白边为 figma `white_button` 实测值，不受此限。
-- **品牌红 `#DF0C27` 在登录画布内只用于区域徽标（旧称 Global pill，见 §16.3）与字标红元素等品牌 accent，跨模式不变**；画布外仅有 §15.10 登记的 Beta 渠道状态徽标例外。**禁止作页面背景**（wave4 改判，见 `token-decision-table §3` 对 `#df0c27` 的语义判定），不渗入面板内部（呼应 §15.10 红色边界）。画布底走 `--login-bg-base`（亮 `#EDEDED` / 深 `#1F1F1E`），红只经 `--login-brand-accent` 消费。错误红 `#D91F37` 同样跨模式不变（语义豁免，呼应 §10 豁免族）。
+- **品牌红 `#DF0C27` 在登录画布内只用于区域徽标（旧称 Global pill，见 §16.3）与字标红元素等品牌 accent，跨模式不变**；画布外仅有 §15.10 登记的 Mobile Beta 渠道状态徽标例外。**禁止作页面背景**（wave4 改判，见 `token-decision-table §3` 对 `#df0c27` 的语义判定），不渗入面板内部（呼应 §15.10 红色边界）。画布底走 `--login-bg-base`（亮 `#EDEDED` / 深 `#1F1F1E`），红只经 `--login-brand-accent` 消费。错误红 `#D91F37` 同样跨模式不变（语义豁免，呼应 §10 豁免族）。
 - **`--login-*` 调色板双态目标值** —— token 已注册于 `apps/desktop/src/renderer/themes/colors.ts`（dark 槽位当前为 light 占位值）。下表为深色实现的目标规格，经 Figma 组件库 Dark symbol 逐个核验；实现 PR 须将 dark 槽位更新为本表 dark 列的值：
 
 | token                                                            | light                   | dark                     | 核验源                                                                                                                                                              |


### PR DESCRIPTION
## 这次改了什么

### 摘要

将 Desktop 侧栏账户卡片中的 Beta 渠道标识从红色徽标改为跟在应用版本号后的普通文字，解决标签视觉突兀和对齐不自然的问题；同时退休 Desktop 侧已不再使用的红色 Beta token 契约，避免实现与设计规范分叉。

### 变更类型

- [x] `fix` 缺陷修复
- [ ] `feat` 新功能
- [ ] `refactor` / `perf` 重构或性能优化
- [ ] `docs` / `test` / `chore` 文档、测试或工程维护
- [ ] 其他：

### 范围

- 关联 Issue / 需求：Telegram 反馈 #56710
- 本 PR 包含：Desktop 侧栏版本行的 Beta 展示、Desktop Beta 红色 token 契约清理、设计规范与回归测试更新。
- 明确不包含：Beta 渠道开关、更新检查逻辑及 Mobile 设置页行为；Mobile 继续保留独立的红色 Beta 徽标契约。
- 用户可见变化：Beta 不再显示红色胶囊标签，改为与版本号同一行的普通文字。
- 是否存在 breaking change：无

### UI 变化

- 引用的设计规范：`docs/design-rules/DESIGN.md` §2「Color Palette & Roles」、§15.10「Red-System Boundary & Neutral CTAs」和 §16.1「视觉风格」；Desktop Beta 使用版本行普通文字，红色 Beta 状态徽标仅保留给 Mobile Settings。

## 怎么验证的

### 自动验证

```text
corepack pnpm --filter desktop exec vitest run src/renderer/themes/__tests__/tokenRegistry.test.ts src/renderer/themes/__tests__/cindyThemes.test.ts src/renderer/__tests__/userInfoSectionHover.test.ts src/renderer/__tests__/userInfoSectionMobileDownload.test.tsx
结果：4 个测试文件、79 个测试通过

corepack pnpm --filter desktop typecheck
结果：通过

corepack pnpm test:unit:related
结果：apps/desktop unit 与 test:runner 通过
```

### 手工验证

未执行：本 worktree 未启动 Desktop 实机预览；本次改动由 Desktop Renderer 定向渲染测试覆盖。

### 未执行的验证

未执行 Desktop Light / Dark 实机目检，原因是当前会话未启动预览实例。

## 风险

### 风险分类

- [x] 无已知风险
- [ ] SQLite / migration
- [ ] system prompt
- [ ] 协议兼容
- [ ] 权限 / 安全 / 用户数据
- [ ] 存量插件兼容（批准状态 / 指纹 / manifest 校验 / 安装布局 / 包格式）
- [ ] 原生层 / fingerprint / OTA
- [ ] 跨平台差异
- [ ] 其他：

### 影响与回滚

- 影响范围：Desktop 侧栏账户卡片版本行的 Beta 文本呈现，以及 Desktop 主题 token 的静态契约；Mobile 设置页不变。
- 回滚 / 降级方式：回滚本 PR commit 即可恢复原有 Desktop 红色徽标及对应契约。

### 提交前检查

- [x] 已 review 完整 diff
- [x] 每个 commit 都带 DCO 签名（`git commit -s`，见 [DCO](../DCO)）
- [x] UI 改动已在「UI 变化」注明引用的设计规范章节（不涉及 UI 则跳过）
- [x] 未提交凭证、令牌或授权文件
- [x] 已补充必要文档
- [x] 已确认测试结果或说明未执行原因
