### PR TITLE
fix(desktop): 修复 Review 成果授权窗操作无响应

### DIFF
--- a/apps/desktop/src/main/reviewer/__tests__/reviewArtifactConfirmWindow.test.ts
+++ b/apps/desktop/src/main/reviewer/__tests__/reviewArtifactConfirmWindow.test.ts
@@ -28,9 +28,15 @@ class FakeWebContents extends EventEmitter {
   readonly id = nextWebContentsId++;
   loadedUrl = '';
   openHandler: (() => { action: 'deny' }) | null = null;
+  executedScripts: string[] = [];
 
   setWindowOpenHandler(handler: () => { action: 'deny' }): void {
     this.openHandler = handler;
+  }
+
+  executeJavaScript(script: string): Promise<unknown> {
+    this.executedScripts.push(script);
+    return Promise.resolve(undefined);
   }
 }
 
@@ -68,25 +74,19 @@ function createHarness(timeoutMs = 60_000) {
   const parent = new FakeWindow();
   const dialog = new FakeWindow();
   let windowOptions: BrowserWindowConstructorOptions | null = null;
-  const result = showReviewArtifactConfirmWindow(
-    parent as unknown as BrowserWindow,
-    MODEL,
-    {
-      timeoutMs,
-      isDark: false,
-      createWindow: (options) => {
-        windowOptions = options;
-        return dialog as unknown as BrowserWindow;
-      },
+  const result = showReviewArtifactConfirmWindow(parent as unknown as BrowserWindow, MODEL, {
+    timeoutMs,
+    isDark: false,
+    createWindow: (options) => {
+      windowOptions = options;
+      return dialog as unknown as BrowserWindow;
     },
-  );
+  });
   return { parent, dialog, result, getWindowOptions: () => windowOptions };
 }
 
 function readEmbeddedStylesheet(document: string): string {
-  const match = document.match(
-    /<link rel="stylesheet" href="data:text\/css;base64,([^"]+)">/,
-  );
+  const match = document.match(/<link rel="stylesheet" href="data:text\/css;base64,([^"]+)">/);
   expect(match).not.toBeNull();
   return Buffer.from(match?.[1] ?? '', 'base64').toString('utf8');
 }
@@ -115,13 +115,18 @@ describe('Review artifact confirmation window', () => {
 
     expect(document).toContain('data-theme="dark"');
     expect(document).toContain("default-src 'none'; style-src data:");
+    expect(document).toContain('form-action cindy-review-artifact-confirm:');
     expect(document).not.toContain("'unsafe-inline'");
     expect(document).not.toContain('<script>');
     expect(document).not.toContain('<img');
     expect(document).not.toContain('<svg');
     expect(document).toContain('&lt;script&gt;bad&lt;/script&gt;');
-    expect(document).toContain('class="button primary" href="#allow" autofocus');
-    expect(document).not.toContain('href="#cancel" autofocus');
+    expect(document).toContain('action="cindy-review-artifact-confirm://allow" method="get"');
+    expect(document).toContain(
+      'id="review-confirm-allow" class="button primary" type="submit" autofocus',
+    );
+    expect(document).toContain('action="cindy-review-artifact-confirm://cancel" method="get"');
+    expect(document).not.toContain('href="#');
   });
 
   it('uses a hardened modal with no preload or renderer authorization bridge', async () => {
@@ -153,18 +158,30 @@ describe('Review artifact confirmation window', () => {
     harness.dialog.emit('ready-to-show');
     expect(harness.dialog.shown).toBe(true);
     expect(harness.dialog.focused).toBe(true);
+    expect(harness.dialog.webContents.executedScripts).toEqual([
+      "document.getElementById('review-confirm-allow')?.focus()",
+    ]);
 
     const preventDefault = vi.fn();
     harness.dialog.webContents.emit('will-navigate', { preventDefault }, 'https://example.com');
     expect(preventDefault).toHaveBeenCalledOnce();
 
+    const malformedDecisionPreventDefault = vi.fn();
     harness.dialog.webContents.emit(
-      'did-navigate-in-page',
-      {},
-      `${harness.dialog.webContents.loadedUrl}#allow`,
-      true,
+      'will-navigate',
+      { preventDefault: malformedDecisionPreventDefault },
+      'cindy-review-artifact-confirm://allow/forged',
+    );
+    expect(malformedDecisionPreventDefault).toHaveBeenCalledOnce();
+
+    const allowPreventDefault = vi.fn();
+    harness.dialog.webContents.emit(
+      'will-navigate',
+      { preventDefault: allowPreventDefault },
+      'cindy-review-artifact-confirm://allow?',
     );
     await expect(harness.result).resolves.toBe(true);
+    expect(allowPreventDefault).toHaveBeenCalledOnce();
     expect(harness.dialog.destroyed).toBe(true);
   });
 
@@ -192,13 +209,14 @@ describe('Review artifact confirmation window', () => {
 
   it('fails closed on cancel, timeout, parent close, and renderer failure', async () => {
     const cancelled = createHarness();
+    const cancelPreventDefault = vi.fn();
     cancelled.dialog.webContents.emit(
-      'did-navigate-in-page',
-      {},
-      `${cancelled.dialog.webContents.loadedUrl}#cancel`,
-      true,
+      'will-navigate',
+      { preventDefault: cancelPreventDefault },
+      'cindy-review-artifact-confirm://cancel?',
     );
     await expect(cancelled.result).resolves.toBe(false);
+    expect(cancelPreventDefault).toHaveBeenCalledOnce();
 
     vi.useFakeTimers();
     const timedOut = createHarness(10);

--- a/apps/desktop/src/main/reviewer/reviewArtifactConfirmWindow.ts
+++ b/apps/desktop/src/main/reviewer/reviewArtifactConfirmWindow.ts
@@ -1,8 +1,4 @@
-import {
-  BrowserWindow,
-  nativeTheme,
-  type BrowserWindowConstructorOptions,
-} from 'electron';
+import { BrowserWindow, nativeTheme, type BrowserWindowConstructorOptions } from 'electron';
 
 import { resolveAppThemeIsDark } from '../resolved-app-theme.js';
 import { readWindowThemeSnapshot } from '../window-theme-mode-store.js';
@@ -10,6 +6,10 @@ import type { ReviewArtifactConfirmDialogModel } from './reviewArtifactDialog.js
 import { markReviewArtifactConfirmWebContentsId } from './reviewArtifactConfirmWindowRegistry.js';
 
 const DEFAULT_TIMEOUT_MS = 90_000;
+const DECISION_PROTOCOL = 'cindy-review-artifact-confirm:';
+const ALLOW_DECISION_URL = `${DECISION_PROTOCOL}//allow`;
+const CANCEL_DECISION_URL = `${DECISION_PROTOCOL}//cancel`;
+const FOCUS_PRIMARY_ACTION_SCRIPT = "document.getElementById('review-confirm-allow')?.focus()";
 
 export interface ReviewArtifactConfirmWindowOptions {
   timeoutMs?: number;
@@ -68,13 +68,14 @@ li { margin-top: 8px; padding: 11px 12px; border: 1px solid var(--border); borde
 .label { overflow-wrap: anywhere; font-size: 13px; font-weight: 500; }
 .path { margin-top: 4px; overflow-wrap: anywhere; color: var(--muted); font-family: ui-monospace, SFMono-Regular, Consolas, monospace; font-size: 12px; }
 footer { display: flex; flex: none; justify-content: flex-end; gap: 10px; margin-top: auto; padding-top: 26px; }
-.button { display: inline-flex; min-width: 88px; height: 36px; align-items: center; justify-content: center; border: 1px solid var(--border); border-radius: 8px; color: var(--text); font-size: 13px; font-weight: 600; text-decoration: none; }
+form { margin: 0; }
+.button { appearance: none; display: inline-flex; min-width: 88px; height: 36px; padding: 0; align-items: center; justify-content: center; border: 1px solid var(--border); border-radius: 9999px; background: transparent; color: var(--text); cursor: pointer; font-family: inherit; font-size: 13px; font-weight: 600; }
 .button:hover, .button:focus-visible { background: var(--hover); outline: none; }
 .primary { border-color: var(--accent); background: var(--accent); color: var(--accent-text); }
 .primary:hover, .primary:focus-visible { background: var(--accent); opacity: .88; }
 `;
 
-/** Build a script-free document whose only decisions are same-document fragments. */
+/** Build a script-free document whose forms can only target the private decision protocol. */
 export function buildReviewArtifactConfirmDocument(
   model: ReviewArtifactConfirmDialogModel,
   isDark: boolean,
@@ -82,14 +83,9 @@ export function buildReviewArtifactConfirmDocument(
   const stylesheet = `data:text/css;base64,${Buffer.from(DIALOG_CSS).toString('base64')}`;
   const items = model.items
     .map((item) => {
-      const secondary =
-        item.kind === 'external-path'
-          ? item.path
-          : item.inlineLabel;
+      const secondary = item.kind === 'external-path' ? item.path : item.inlineLabel;
       return `<li><div class="label">${escapeHtml(item.label)}</div>${
-        secondary
-          ? `<div class="path" dir="ltr">${escapeHtml(secondary)}</div>`
-          : ''
+        secondary ? `<div class="path" dir="ltr">${escapeHtml(secondary)}</div>` : ''
       }</li>`;
     })
     .join('');
@@ -97,7 +93,7 @@ export function buildReviewArtifactConfirmDocument(
 <html lang="und" data-theme="${isDark ? 'dark' : 'light'}">
 <head>
   <meta charset="utf-8">
-  <meta http-equiv="Content-Security-Policy" content="default-src 'none'; style-src data:; base-uri 'none'; form-action 'none'; frame-ancestors 'none'">
+  <meta http-equiv="Content-Security-Policy" content="default-src 'none'; style-src data:; base-uri 'none'; form-action ${DECISION_PROTOCOL}; frame-ancestors 'none'">
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <link rel="stylesheet" href="${stylesheet}">
   <title>${escapeHtml(model.title)}</title>
@@ -110,8 +106,12 @@ export function buildReviewArtifactConfirmDocument(
     <p class="detail">${escapeHtml(model.detail)}</p>
     <ul>${items}</ul>
     <footer>
-      <a class="button" href="#cancel">${escapeHtml(model.cancelText)}</a>
-      <a class="button primary" href="#allow" autofocus>${escapeHtml(model.allowText)}</a>
+      <form action="${CANCEL_DECISION_URL}" method="get">
+        <button class="button" type="submit">${escapeHtml(model.cancelText)}</button>
+      </form>
+      <form action="${ALLOW_DECISION_URL}" method="get">
+        <button id="review-confirm-allow" class="button primary" type="submit" autofocus>${escapeHtml(model.allowText)}</button>
+      </form>
     </footer>
   </main>
 </body>
@@ -120,9 +120,20 @@ export function buildReviewArtifactConfirmDocument(
 
 function readDecision(url: string): boolean | null {
   try {
-    const hash = new URL(url).hash;
-    if (hash === '#allow') return true;
-    if (hash === '#cancel') return false;
+    const parsed = new URL(url);
+    if (
+      parsed.protocol !== DECISION_PROTOCOL ||
+      parsed.username !== '' ||
+      parsed.password !== '' ||
+      parsed.port !== '' ||
+      parsed.pathname !== '' ||
+      parsed.search !== '' ||
+      parsed.hash !== ''
+    ) {
+      return null;
+    }
+    if (parsed.hostname === 'allow') return true;
+    if (parsed.hostname === 'cancel') return false;
   } catch {
     // Invalid or non-URL navigation is denied below.
   }
@@ -133,8 +144,10 @@ function readDecision(url: string): boolean | null {
  * One authorization request owns one modal window. Reusing this security
  * prompt would risk carrying a stale parent, focus, or decision into another
  * grant, so it intentionally does not use the reusable auxiliary-tool window
- * lifecycle. The document has no preload, IPC, or script: an XSS in the main
- * app Renderer cannot observe or answer this prompt.
+ * lifecycle. The document has no preload, IPC, or embedded script: an XSS in
+ * the main app Renderer cannot observe or answer this prompt. Main only runs a
+ * fixed command that focuses the primary button; every decision still arrives
+ * as a denied navigation and is settled here.
  */
 export async function showReviewArtifactConfirmWindow(
   parent: BrowserWindow,
@@ -150,7 +163,8 @@ export async function showReviewArtifactConfirmWindow(
       persistedTheme?.mode,
       persistedTheme?.resolvedIsDark,
     );
-  const createWindow = options.createWindow ?? ((windowOptions) => new BrowserWindow(windowOptions));
+  const createWindow =
+    options.createWindow ?? ((windowOptions) => new BrowserWindow(windowOptions));
   let win: BrowserWindow;
   try {
     win = createWindow({
@@ -201,7 +215,6 @@ export async function showReviewArtifactConfirmWindow(
       win.removeListener('closed', onClosed);
       win.removeListener('ready-to-show', onReadyToShow);
       win.webContents.removeListener('will-navigate', onWillNavigate);
-      win.webContents.removeListener('did-navigate-in-page', onDidNavigateInPage);
       win.webContents.removeListener('before-input-event', onBeforeInput);
       win.webContents.removeListener('render-process-gone', onRendererGone);
       if (!win.isDestroyed()) win.destroy();
@@ -215,16 +228,21 @@ export async function showReviewArtifactConfirmWindow(
       // resources, so ready-to-show is also its business-content ready signal.
       win.show();
       win.focus();
+      try {
+        void win.webContents.executeJavaScript(FOCUS_PRIMARY_ACTION_SCRIPT, true).catch((error) => {
+          if (win.isDestroyed()) return;
+          options.log?.warn('failed to focus Review artifact confirmation action', {
+            error: error instanceof Error ? error.message : String(error),
+          });
+        });
+      } catch (error) {
+        options.log?.warn('failed to focus Review artifact confirmation action', {
+          error: error instanceof Error ? error.message : String(error),
+        });
+      }
     };
-    const onWillNavigate = (event: { preventDefault(): void }): void => {
+    const onWillNavigate = (event: { preventDefault(): void }, url: string): void => {
       event.preventDefault();
-    };
-    const onDidNavigateInPage = (
-      _event: unknown,
-      url: string,
-      isMainFrame: boolean,
-    ): void => {
-      if (!isMainFrame) return;
       const decision = readDecision(url);
       if (decision !== null) settle(decision);
     };
@@ -242,7 +260,6 @@ export async function showReviewArtifactConfirmWindow(
     win.once('closed', onClosed);
     win.once('ready-to-show', onReadyToShow);
     win.webContents.on('will-navigate', onWillNavigate);
-    win.webContents.on('did-navigate-in-page', onDidNavigateInPage);
     win.webContents.on('before-input-event', onBeforeInput);
     win.webContents.on('render-process-gone', onRendererGone);
     win.webContents.setWindowOpenHandler(() => ({ action: 'deny' }));
@@ -255,14 +272,14 @@ export async function showReviewArtifactConfirmWindow(
 
     const document = buildReviewArtifactConfirmDocument(model, isDark);
     try {
-      void win.loadURL(`data:text/html;charset=utf-8,${encodeURIComponent(document)}`).catch(
-        (error) => {
+      void win
+        .loadURL(`data:text/html;charset=utf-8,${encodeURIComponent(document)}`)
+        .catch((error) => {
           options.log?.warn('failed to load Review artifact confirmation; access denied', {
             error: error instanceof Error ? error.message : String(error),
           });
           settle(false);
-        },
-      );
+        });
     } catch (error) {
       options.log?.warn('failed to load Review artifact confirmation; access denied', {
         error: error instanceof Error ? error.message : String(error),


### PR DESCRIPTION
## 这次改了什么

### 摘要

修复 Review 工作区外成果授权窗中“取消”和“仅本次允许”点击无响应、Enter 无法确认的问题。原实现依赖 `data:` 页面内的 fragment 导航事件，但当前 Electron 中点击后不会产生可观察的导航；本次改为原生表单按钮，并由 Main 拦截和严格校验私有决策 URL。

### 变更类型

- [ ] `feat` 新功能
- [x] `fix` 缺陷修复
- [ ] `refactor` / `perf` 重构或性能优化
- [ ] `docs` / `test` / `chore` 文档、测试或工程维护
- [ ] 其他：

### 范围

- 关联 Issue / 需求：#3532
- 本 PR 包含：将 fragment 链接改为真正的提交按钮；使用受 CSP 限制的私有决策协议；Main 拦截全部导航并仅接受严格校验的允许/取消 URL；默认聚焦主操作；补充回归测试。
- 明确不包含：不回退 #3438 将系统弹窗替换为 Cindy 弹窗的产品决策；不修改 Review 的成果收集、任务生命周期或授权范围。
- 用户可见变化：鼠标点击“取消/仅本次允许”会立即生效；默认聚焦“仅本次允许”后可按 Enter 确认；Esc、关闭窗口和超时仍按拒绝授权处理。
- 是否存在 breaking change：无。

### UI 变化

- 确认窗布局和文案不变；操作控件改为语义正确的原生按钮，按钮使用 Cindy 的胶囊形态。
- 引用的设计规范：`docs/design-rules/DESIGN.md` §Buttons、§Dialog & Modal、§Light / Dark Dual-Mode Delivery Gate；保留成对操作布局和既有 Light/Dark 语义色变量。

## 怎么验证的

### 自动验证

```text
pnpm --filter desktop exec vitest run src/main/reviewer/__tests__/reviewArtifactConfirmWindow.test.ts
结果：通过，4 项测试通过。

pnpm test:unit:related
结果：通过，apps/desktop 相关单测通过。

pnpm --filter desktop run --if-present typecheck
结果：通过。

pnpm exec prettier --check apps/desktop/src/main/reviewer/reviewArtifactConfirmWindow.ts apps/desktop/src/main/reviewer/__tests__/reviewArtifactConfirmWindow.test.ts
结果：通过。

git diff --check
结果：通过。

pnpm check:dco
结果：通过，当前 PR 范围 1 个 commit 已签名。
```

### 手工验证

- Windows / Electron 41.10.3，CN 隔离 dev 沙盒 `curious-feynman-19f050`。
- 通过 `/review C:\Windows\win.ini` 触发真实的工作区外成果授权窗。
- 鼠标点击“取消”：确认窗立即关闭。
- 鼠标点击“仅本次允许”：确认窗关闭，来源任务进入审查并产出结果。
- 默认操作获得焦点后发送系统级 Enter：允许审查。
- 发送系统级 Esc：拒绝授权，不创建新审查，来源界面显示“无法开始审查”。
- 独立 subagent 完成安全与回归审查，未发现阻断问题。

### 未执行的验证

- 未做 macOS 实机验证。
- 未单独进行 Dark 模式实机目检；Light/Dark 继续使用同一组既有语义色变量。
- 未运行全量 `pnpm test:unit`；按仓库门禁运行了 `pnpm test:unit:related`，完整单测由 CI 覆盖。

## 风险

### 风险分类

- [ ] 无已知风险
- [ ] SQLite / migration
- [ ] system prompt
- [ ] 协议兼容
- [x] 权限 / 安全 / 用户数据
- [ ] 存量插件兼容（批准状态 / 指纹 / manifest 校验 / 安装布局 / 包格式）
- [ ] 原生层 / fingerprint / OTA
- [x] 跨平台差异
- [ ] 其他：

### 影响与回滚

- 影响范围：仅 Desktop Review 的工作区外/内存成果授权确认窗。Main 仍是授权权威，所有非精确决策 URL、Esc、关闭、超时和渲染进程异常均默认拒绝。
- 回滚 / 降级方式：回退本 PR commit 可恢复原实现；没有 schema、配置或持久数据迁移。回退后按钮无响应问题会重新出现，但授权仍默认拒绝。

### 提交前检查

- [x] 已 review 完整 diff
- [x] 每个 commit 都带 DCO 签名（`git commit -s`，见 [DCO](../DCO)）
- [x] UI 改动已在「UI 变化」注明引用的设计规范章节（不涉及 UI 则跳过）
- [x] 未提交凭证、令牌或授权文件
- [x] 已补充必要文档
- [x] 已确认测试结果或说明未执行原因