### PR TITLE
test: 解除 Agent 二进制测试的版本号绑定

### DIFF
--- a/apps/desktop/src/main/agent-binaries/__tests__/linuxRuntimeFallback.test.ts
+++ b/apps/desktop/src/main/agent-binaries/__tests__/linuxRuntimeFallback.test.ts
@@ -14,9 +14,17 @@ import {
   runtimeVersionMatchesPin,
   systemRuntimeVersionSupportsPin,
 } from '../linux-runtime-fallback';
+import {
+  newerStableVersion,
+  olderStableVersion,
+  PINNED_CLAUDE_VERSION,
+  PINNED_CODEX_VERSION,
+  prereleaseAtPinnedCore,
+} from './runtimeVersionFixtures';
 
 const tempDirs: string[] = [];
 const describeOnLinuxFileSystem = process.platform === 'win32' ? describe.skip : describe;
+const SAMPLE_ASSET_VERSION = '1.2.3';
 
 afterEach(() => {
   for (const dir of tempDirs.splice(0)) fs.rmSync(dir, { recursive: true, force: true });
@@ -39,10 +47,17 @@ function singleFileTar(name: string, content: Buffer): Buffer {
 
 describe('runtimeVersionMatchesPin', () => {
   it('requires Cindy-managed Claude and Codex binaries to match their pins exactly', () => {
-    expect(runtimeVersionMatchesPin('claude-code', '2.1.219 (Claude Code)')).toBe(true);
-    expect(runtimeVersionMatchesPin('claude-code', '2.1.218 (Claude Code)')).toBe(false);
-    expect(runtimeVersionMatchesPin('codex', 'codex-cli 0.145.0')).toBe(true);
-    expect(runtimeVersionMatchesPin('codex', 'codex-cli 0.144.6')).toBe(false);
+    expect(runtimeVersionMatchesPin('claude-code', `${PINNED_CLAUDE_VERSION} (Claude Code)`)).toBe(true);
+    expect(
+      runtimeVersionMatchesPin(
+        'claude-code',
+        `${olderStableVersion(PINNED_CLAUDE_VERSION)} (Claude Code)`,
+      ),
+    ).toBe(false);
+    expect(runtimeVersionMatchesPin('codex', `codex-cli ${PINNED_CODEX_VERSION}`)).toBe(true);
+    expect(
+      runtimeVersionMatchesPin('codex', `codex-cli ${olderStableVersion(PINNED_CODEX_VERSION)}`),
+    ).toBe(false);
   });
 
   it('rejects empty or unparsable version output', () => {
@@ -53,11 +68,21 @@ describe('runtimeVersionMatchesPin', () => {
 
 describe('systemRuntimeVersionSupportsPin', () => {
   it('accepts the pinned or newer Claude runtime and rejects older or prerelease-equivalent builds', () => {
-    expect(systemRuntimeVersionSupportsPin('claude-code', '2.1.219 (Claude Code)')).toBe(true);
-    expect(systemRuntimeVersionSupportsPin('claude-code', '2.2.0 (Claude Code)')).toBe(true);
-    expect(systemRuntimeVersionSupportsPin('claude-code', '2.1.218 (Claude Code)')).toBe(false);
-    expect(systemRuntimeVersionSupportsPin('claude-code', '2.1.219-beta.1')).toBe(false);
-    expect(systemRuntimeVersionSupportsPin('claude-code', '2.2.0-beta.1')).toBe(false);
+    const newerVersion = newerStableVersion(PINNED_CLAUDE_VERSION);
+    expect(
+      systemRuntimeVersionSupportsPin('claude-code', `${PINNED_CLAUDE_VERSION} (Claude Code)`),
+    ).toBe(true);
+    expect(systemRuntimeVersionSupportsPin('claude-code', `${newerVersion} (Claude Code)`)).toBe(true);
+    expect(
+      systemRuntimeVersionSupportsPin(
+        'claude-code',
+        `${olderStableVersion(PINNED_CLAUDE_VERSION)} (Claude Code)`,
+      ),
+    ).toBe(false);
+    expect(
+      systemRuntimeVersionSupportsPin('claude-code', prereleaseAtPinnedCore(PINNED_CLAUDE_VERSION)),
+    ).toBe(false);
+    expect(systemRuntimeVersionSupportsPin('claude-code', `${newerVersion}-beta.1`)).toBe(false);
   });
 });
 
@@ -77,10 +102,10 @@ describeOnLinuxFileSystem('install path helpers', () => {
 
   it('resolves the exact legacy CDN cache path for migration', () => {
     expect(legacyManagedBinaryPath('/userdata', 'claude-code')).toBe(
-      path.join('/userdata', 'claude-code', '2.1.219', 'claude'),
+      path.join('/userdata', 'claude-code', PINNED_CLAUDE_VERSION, 'claude'),
     );
     expect(legacyManagedBinaryPath('/userdata', 'codex')).toBe(
-      path.join('/userdata', 'codex', '0.145.0', 'codex'),
+      path.join('/userdata', 'codex', PINNED_CODEX_VERSION, 'codex'),
     );
   });
 
@@ -99,8 +124,8 @@ describe('official asset descriptors', () => {
     ['arm64', 'linux-arm64'],
   ])('uses the trusted Claude %s asset committed with the version pin', (arch, platformKey) => {
     const sha256 = 'a'.repeat(64);
-    const url = `https://downloads.claude.ai/claude-code-releases/2.1.219/${platformKey}/claude`;
-    expect(pinnedOfficialAssetDescriptor('claude-code', '2.1.219', {
+    const url = `https://downloads.claude.ai/claude-code-releases/${SAMPLE_ASSET_VERSION}/${platformKey}/claude`;
+    expect(pinnedOfficialAssetDescriptor('claude-code', SAMPLE_ASSET_VERSION, {
       runtimeAssets: { [platformKey]: { url, sha256, size: 123 } },
     }, arch)).toEqual({ url, sha256, size: 123 });
   });
@@ -110,11 +135,11 @@ describe('official asset descriptors', () => {
     ['arm64', 'linux-arm64', 'aarch64'],
   ])('uses the pinned Codex %s asset and rejects unexpected metadata', (arch, platformKey, rustArch) => {
     const sha256 = 'b'.repeat(64);
-    const url = `https://github.com/openai/codex/releases/download/rust-v0.144.6/codex-${rustArch}-unknown-linux-musl.tar.gz`;
-    expect(pinnedOfficialAssetDescriptor('codex', '0.144.6', {
+    const url = `https://github.com/openai/codex/releases/download/rust-v${SAMPLE_ASSET_VERSION}/codex-${rustArch}-unknown-linux-musl.tar.gz`;
+    expect(pinnedOfficialAssetDescriptor('codex', SAMPLE_ASSET_VERSION, {
       runtimeAssets: { [platformKey]: { url, sha256, size: 456 } },
     }, arch)).toEqual({ url, sha256, size: 456 });
-    expect(() => pinnedOfficialAssetDescriptor('codex', '0.144.6', {
+    expect(() => pinnedOfficialAssetDescriptor('codex', SAMPLE_ASSET_VERSION, {
       runtimeAssets: { [platformKey]: { url: 'https://example.test/codex.tar.gz', sha256 } },
     }, arch)).toThrow(
       new RegExp(`pin lacks a trusted ${platformKey} asset`),
@@ -129,12 +154,12 @@ describe('official asset descriptors', () => {
     const x64Pin = {
       runtimeAssets: {
         'linux-x64': {
-          url: 'https://downloads.claude.ai/claude-code-releases/2.1.219/linux-x64/claude',
+          url: `https://downloads.claude.ai/claude-code-releases/${SAMPLE_ASSET_VERSION}/linux-x64/claude`,
           sha256,
         },
       },
     };
-    expect(() => pinnedOfficialAssetDescriptor('claude-code', '2.1.219', x64Pin, 'arm64')).toThrow(
+    expect(() => pinnedOfficialAssetDescriptor('claude-code', SAMPLE_ASSET_VERSION, x64Pin, 'arm64')).toThrow(
       /pin lacks a trusted linux-arm64 asset/,
     );
   });
@@ -142,7 +167,7 @@ describe('official asset descriptors', () => {
   // 未知 arch 走 fail closed:URL 拼出来必然与 pin 不等,不做兜底猜测。
   it('rejects an unsupported architecture instead of guessing', () => {
     const sha256 = 'd'.repeat(64);
-    expect(() => pinnedOfficialAssetDescriptor('codex', '0.144.6', {
+    expect(() => pinnedOfficialAssetDescriptor('codex', SAMPLE_ASSET_VERSION, {
       runtimeAssets: { 'linux-armv7l': { url: 'https://example.test/codex.tar.gz', sha256 } },
     }, 'armv7l')).toThrow(
       /pin lacks a trusted linux-armv7l asset/,

--- a/apps/desktop/src/main/agent-binaries/__tests__/linuxRuntimeMigration.test.ts
+++ b/apps/desktop/src/main/agent-binaries/__tests__/linuxRuntimeMigration.test.ts
@@ -3,6 +3,8 @@ import os from 'node:os';
 import path from 'node:path';
 import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it, vi } from 'vitest';
 
+import { olderStableVersion, PINNED_CLAUDE_VERSION } from './runtimeVersionFixtures';
+
 const { appMock, downloadMock, execFileMock } = vi.hoisted(() => ({
   appMock: { isPackaged: true, getPath: vi.fn<(name: string) => string>() },
   downloadMock: vi.fn(),
@@ -19,6 +21,14 @@ vi.mock('../../downloader/index.js', () => ({ download: downloadMock }));
 const originalPlatform = process.platform;
 let fallback: typeof import('../linux-runtime-fallback');
 let tempDir = '';
+
+function claudeVersionOutput(version = PINNED_CLAUDE_VERSION): string {
+  return `${version} (Claude Code)\n`;
+}
+
+function claudeExecutable(version = PINNED_CLAUDE_VERSION): string {
+  return `#!/bin/sh\necho "${version} (Claude Code)"\n`;
+}
 
 beforeAll(async () => {
   Object.defineProperty(process, 'platform', { value: 'linux', configurable: true });
@@ -39,7 +49,7 @@ beforeEach(() => {
       callback(new Error('system lookup disabled in migration test'), '', '');
       return;
     }
-    callback(null, '2.1.219 (Claude Code)\n', '');
+    callback(null, claudeVersionOutput(), '');
   });
 });
 
@@ -55,14 +65,14 @@ describe('legacy managed binary migration', () => {
   it('reuses and atomically migrates the exact pinned Claude cache without network access', async () => {
     const legacyPath = fallback.legacyManagedBinaryPath(tempDir, 'claude-code');
     fs.mkdirSync(path.dirname(legacyPath), { recursive: true });
-    fs.writeFileSync(legacyPath, '#!/bin/sh\necho "2.1.219 (Claude Code)"\n', { mode: 0o755 });
+    fs.writeFileSync(legacyPath, claudeExecutable(), { mode: 0o755 });
     fs.writeFileSync(path.join(path.dirname(legacyPath), '.verified'), '');
 
     const result = await fallback.prepareLinuxRuntimeFallback('claude-code');
 
     expect(result).toMatchObject({ ready: true, installed: false, source: 'legacy' });
     expect(result.binaryPath).toBe(fallback.privateBinaryPath(tempDir, 'claude-code'));
-    expect(fs.readFileSync(result.binaryPath, 'utf8')).toContain('2.1.219');
+    expect(fs.readFileSync(result.binaryPath, 'utf8')).toContain(PINNED_CLAUDE_VERSION);
     expect(downloadMock).not.toHaveBeenCalled();
   });
 
@@ -81,14 +91,14 @@ describe('legacy managed binary migration', () => {
       callback(
         null,
         command === systemClaude
-          ? '2.1.218 (Claude Code)\n'
-          : '2.1.219 (Claude Code)\n',
+          ? claudeVersionOutput(olderStableVersion(PINNED_CLAUDE_VERSION))
+          : claudeVersionOutput(),
         '',
       );
     });
     downloadMock.mockImplementationOnce(async ({ targetPath }: { targetPath: string }) => {
       fs.mkdirSync(path.dirname(targetPath), { recursive: true });
-      fs.writeFileSync(targetPath, '#!/bin/sh\necho "2.1.219 (Claude Code)"\n', { mode: 0o755 });
+      fs.writeFileSync(targetPath, claudeExecutable(), { mode: 0o755 });
       return {
         path: targetPath,
         size: fs.statSync(targetPath).size,

--- a/apps/desktop/src/main/agent-binaries/__tests__/runtimeVersionFixtures.ts
+++ b/apps/desktop/src/main/agent-binaries/__tests__/runtimeVersionFixtures.ts
@@ -1,0 +1,29 @@
+import claudeLatest from '../../../../../../tools/claude/latest.json';
+import codexLatest from '../../../../../../tools/codex/latest.json';
+
+export const PINNED_CLAUDE_VERSION = claudeLatest.version;
+export const PINNED_CODEX_VERSION = codexLatest.version;
+
+function stableVersionParts(version: string): [number, number, number] {
+  const match = /^(\d+)\.(\d+)\.(\d+)(?:[-+].*)?$/.exec(version);
+  if (!match) throw new Error(`Expected a semantic runtime version, received: ${version}`);
+  return [Number(match[1]), Number(match[2]), Number(match[3])];
+}
+
+export function olderStableVersion(version: string): string {
+  const [major, minor, patch] = stableVersionParts(version);
+  if (patch > 0) return `${major}.${minor}.${patch - 1}`;
+  if (minor > 0) return `${major}.${minor - 1}.0`;
+  if (major > 0) return `${major - 1}.0.0`;
+  throw new Error(`Cannot derive an older stable version from: ${version}`);
+}
+
+export function newerStableVersion(version: string): string {
+  const [major, minor] = stableVersionParts(version);
+  return `${major}.${minor + 1}.0`;
+}
+
+export function prereleaseAtPinnedCore(version: string): string {
+  const [major, minor, patch] = stableVersionParts(version);
+  return `${major}.${minor}.${patch}-beta.1`;
+}

--- a/packages/maker-remote-ssh/src/__tests__/remote-agent-installer.test.ts
+++ b/packages/maker-remote-ssh/src/__tests__/remote-agent-installer.test.ts
@@ -85,7 +85,7 @@ describe('remote agent installer', () => {
           exitCode: 0,
           stdout: [
             'INSTALL_DIR /home/u/.xdt-server/v1',
-            'READY 0.83.0',
+            `READY ${PINNED_PI_VERSION}`,
           ].join('\n'),
           stderr: '',
         };
@@ -94,7 +94,7 @@ describe('remote agent installer', () => {
 
     const probe = await probeRemoteAgent(host, 'pi');
     expect(probe.installed).toBe(true);
-    expect(probe.installedVersion).toBe('0.83.0');
+    expect(probe.installedVersion).toBe(PINNED_PI_VERSION);
     expect(probe.binaryPath).toBe('/home/u/.xdt-server/v1/pi/pi');
     expect(calls[0].command).toContain(`'${PINNED_PI_VERSION}'`);
   });
@@ -111,7 +111,7 @@ describe('remote agent installer', () => {
             'INSTALL_START pi',
             'INSTALL_LOG sha256 ok',
             'INSTALL_DONE',
-            'READY 0.83.0',
+            `READY ${PINNED_PI_VERSION}`,
           ].join('\n'),
           stderr: '',
         };
@@ -120,7 +120,7 @@ describe('remote agent installer', () => {
 
     const result = await installRemoteAgent(host, 'pi');
     expect(result.ready).toBe(true);
-    expect(result.installedVersion).toBe('0.83.0');
+    expect(result.installedVersion).toBe(PINNED_PI_VERSION);
     expect(result.binaryPath).toBe('/home/u/.xdt-server/v1/pi/pi');
     // 4 个 POSIX 平台 SHA256(darwin-arm64 / darwin-x64 / linux-arm64 / linux-x64)。
     expect(calls[0].command).toContain(`'${PINNED_PI_VERSION}'`);


### PR DESCRIPTION
## 这次改了什么

### 摘要

让 Claude、Codex 和 PI 的版本相关测试从生产 pin 读取当前版本，并动态构造旧版、新版与预发布版样本，避免二进制升级后还要手工同步测试中的具体版本号。

### 变更类型

- [ ] `feat` 新功能
- [ ] `fix` 缺陷修复
- [ ] `refactor` / `perf` 重构或性能优化
- [x] `docs` / `test` / `chore` 文档、测试或工程维护
- [ ] 其他：

### 范围

- 关联 Issue / 需求：无
- 本 PR 包含：Desktop Linux runtime 的版本校验、旧缓存迁移与资产描述测试；远端 PI 安装测试
- 明确不包含：生产 runtime pin、下载/安装逻辑或二进制文件
- 用户可见变化：无
- 是否存在 breaking change：无

### UI 变化

- 引用的设计规范：不涉及

## 怎么验证的

### 自动验证

```text
pnpm test:unit:related
结果：通过；apps/desktop 与 packages/maker-remote-ssh 相关单测均通过

pnpm --filter desktop run --if-present typecheck
结果：通过

pnpm --filter @cindy/maker-remote-ssh run --if-present typecheck
结果：通过；该 package 当前没有 typecheck script，按 --if-present 跳过

pnpm check:dco
结果：通过；1 个 commit 已签名
```

### 手工验证

不涉及。

### 未执行的验证

无。

## 风险

### 风险分类

- [x] 无已知风险
- [ ] SQLite / migration
- [ ] system prompt
- [ ] 协议兼容
- [ ] 权限 / 安全 / 用户数据
- [ ] 存量插件兼容（批准状态 / 指纹 / manifest 校验 / 安装布局 / 包格式）
- [ ] 原生层 / fingerprint / OTA
- [ ] 跨平台差异
- [ ] 其他：

### 影响与回滚

- 影响范围：仅测试代码；后续升级 Claude、Codex 或 PI pin 时测试会自动读取新值
- 回滚 / 降级方式：回滚本 PR commit 即可；不影响生产运行时

### 提交前检查

- [x] 已 review 完整 diff
- [x] 每个 commit 都带 DCO 签名（`git commit -s`，见 [DCO](../DCO)）
- [x] UI 改动已在「UI 变化」注明引用的设计规范（不涉及 UI 则跳过）
- [x] 未提交凭证、令牌或授权文件
- [x] 已补充必要文档
- [x] 已确认测试结果或说明未执行原因