### PR TITLE
test(device-link): 稳定旧连接超时断言

### DIFF
--- a/packages/device-link/src/__tests__/client.test.ts
+++ b/packages/device-link/src/__tests__/client.test.ts
@@ -5777,17 +5777,17 @@ describe('定时重发的单趟预算(TRANSPORT_RETRY_PASS_BUDGET)', () => {
     await relay.settleUntil(() => host.getStatus() === 'online' && controller.getStatus() === 'online');
 
     relay.dropNext((senderId, env) => senderId === 'desktop' && env.kind === 'link-accept');
-    const staleOpen = controller.openLink('desktop', {
+    const staleOpenError = controller.openLink('desktop', {
       controllerName: 'iPhone',
       protocolVersion: 1,
       appVersion: '1',
-    }, 50);
+    }, 50).catch((error: unknown) => error);
     await relay.settle();
     const staleRequestId = (relay.deliveredTo.get('desktop') ?? [])
       .filter((env) => env.kind === 'link-open')
       .at(-1)?.id;
     expect(staleRequestId).toBeTruthy();
-    await expect(staleOpen).rejects.toMatchObject({ code: 'INVOKE_TIMEOUT' });
+    expect(await staleOpenError).toMatchObject({ code: 'INVOKE_TIMEOUT' });
 
     const liveInvoke = host.invoke('ios', {
       channel: 'maker:cross-generation-request',


### PR DESCRIPTION
## 这次改了什么

### 摘要

device-link 的旧 request id 回归测试会在创建 50ms 超时 Promise 后，先等待 relay settle，再注册 rejection 断言。繁忙的 Windows CI 上 Promise 可能在断言注册前拒绝，被 Vitest 记录为未处理 rejection，即使全部测试断言都已通过。

本 PR 在创建 Promise 时立即接住预期错误，稍后仍断言 `INVOKE_TIMEOUT`，消除监听注册竞态；不延长超时，不修改生产逻辑。

### 变更类型

- [ ] `feat` 新功能
- [ ] `fix` 缺陷修复
- [ ] `refactor` / `perf` 重构或性能优化
- [ ] `docs` / `test` / `chore` 文档、测试或工程维护
- [x] 其他：测试稳定性修复

### 范围

- 关联 Issue / 需求：#3540 的 Windows CI 暴露的 device-link flaky test
- 本 PR 包含：立即注册预期超时 Promise 的 rejection 处理，并保留错误码断言
- 明确不包含：生产逻辑、超时时长、协议行为以及 #3540 的二进制版本测试改动
- 用户可见变化：无
- 是否存在 breaking change：无

### UI 变化

不涉及。

- 引用的设计规范：不涉及

## 怎么验证的

### 自动验证

```text
目标用例连续运行 25 次
结果：25/25 通过

pnpm test:unit:related
结果：PASS packages/device-link unit（183 tests）

pnpm --filter @cindy/device-link run --if-present typecheck
结果：package 无 typecheck script，按门禁规则跳过

pnpm check:dco
结果：1 commit signed off，检查通过
```

### 手工验证

不涉及。

### 未执行的验证

- 未本地执行全量 `pnpm test:unit`；本 PR 只改一份 device-link 测试，已运行相关单测，完整矩阵由 CI 执行。

## 风险

### 风险分类

- [x] 无已知风险
- [ ] SQLite / migration
- [ ] system prompt
- [ ] 协议兼容
- [ ] 权限 / 安全 / 用户数据
- [ ] 存量插件兼容（批准状态 / 指纹 / manifest 校验 / 安装布局 / 包格式）
- [ ] 原生层 / fingerprint / OTA
- [ ] 跨平台差异
- [ ] 其他：

### 影响与回滚

- 影响范围：仅 device-link 单元测试的预期错误处理时机
- 回滚 / 降级方式：回退本提交即可；不涉及生产行为或用户数据

### 提交前检查

- [x] 已 review 完整 diff
- [x] 每个 commit 都带 DCO 签名（`git commit -s`，见 [DCO](../DCO)）
- [x] UI 改动已在「UI 变化」注明引用的设计规范章节（不涉及 UI）
- [x] 未提交凭证、令牌或授权文件
- [x] 已补充必要文档（本次无需新增文档）
- [x] 已确认测试结果或说明未执行原因