### PR TITLE
fix(desktop): 修复 IM 工作区偏好同步

### DIFF
--- a/apps/desktop/src/main/hook-control/__tests__/workspacePrefsMirror.test.ts
+++ b/apps/desktop/src/main/hook-control/__tests__/workspacePrefsMirror.test.ts
@@ -4,6 +4,8 @@ import path from 'node:path';
 
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
+import type { HookWorkspacePrefs } from '../../../shared/hookControlIpc.js';
+
 const tmp = vi.hoisted(() => ({ dir: '' }));
 
 vi.mock('../../im/ownerScopedStorage.js', () => ({
@@ -223,6 +225,106 @@ describe('workspacePrefsMirror', () => {
       permissionMode: 'ask',
     });
     expect(setRemotePrefs).not.toHaveBeenCalled();
+  });
+
+  it('逐行写回期间收到主动快照时重新拉取并发送最新候选', async () => {
+    reconcileWorkspacePrefsForMirror('slack', []);
+    setWorkspacePref('slack', null, 'chat', { model: 'local-chat' });
+    setWorkspacePref('slack', null, 'repo', { model: 'local-repo' });
+
+    let generation = 0;
+    let releaseFirstWrite!: () => void;
+    const firstWritePending = new Promise<void>((resolve) => {
+      releaseFirstWrite = resolve;
+    });
+    const latestSnapshot = {
+      bound: true,
+      prefs: [
+        {
+          workspace: 'chat',
+          model: 'remote-chat',
+          effort: 'high',
+          agentKind: 'claude-code',
+          permissionMode: 'ask',
+          teamId: null,
+        },
+        {
+          workspace: 'repo',
+          model: 'remote-repo',
+          effort: 'medium',
+          agentKind: 'codex',
+          permissionMode: 'full',
+          teamId: null,
+        },
+      ],
+    };
+    let remotePrefs: HookWorkspacePrefs[] = [];
+    const getRemotePrefs = vi.fn(async () => ({ bound: true, prefs: remotePrefs }));
+    const setRemotePrefs = vi.fn<WorkspacePrefsMirrorDeps['setRemotePrefs']>(async (
+      _channel,
+      workspace,
+      patch,
+      teamId,
+    ) => {
+      if (setRemotePrefs.mock.calls.length === 1) await firstWritePending;
+      const current = remotePrefs.find(
+        (row) => row.workspace === workspace && (row.teamId ?? null) === teamId,
+      );
+      const next = {
+        workspace,
+        model: patch.model ?? null,
+        effort: patch.effort ?? null,
+        agentKind: patch.agentKind ?? null,
+        permissionMode: patch.permissionMode ?? null,
+        teamId,
+      };
+      remotePrefs = [...remotePrefs.filter((row) => row !== current), next];
+    });
+    const mirror = createWorkspacePrefsMirror({
+      getLiveBindingKey: () => 'slack:T1',
+      isMirrorTargetCurrent: () => true,
+      getRemoteSnapshotGeneration: () => generation,
+      getRemotePrefs,
+      setRemotePrefs,
+      onLocalPrefsChanged: vi.fn(),
+      onError: vi.fn(),
+    });
+
+    const flight = mirror('slack');
+    await vi.waitFor(() => expect(setRemotePrefs).toHaveBeenCalledTimes(1));
+
+    applyIncomingServerWorkspacePrefs('slack', latestSnapshot.prefs);
+    remotePrefs = latestSnapshot.prefs;
+    generation += 1;
+    releaseFirstWrite();
+    await flight;
+
+    expect(getRemotePrefs).toHaveBeenCalledTimes(2);
+    expect(setRemotePrefs).toHaveBeenCalledTimes(3);
+    expect(setRemotePrefs).toHaveBeenNthCalledWith(
+      2,
+      'slack',
+      'chat',
+      {
+        model: 'local-chat',
+        effort: 'high',
+        agentKind: 'claude-code',
+        permissionMode: 'ask',
+      },
+      null,
+    );
+    expect(setRemotePrefs).toHaveBeenNthCalledWith(
+      3,
+      'slack',
+      'repo',
+      {
+        model: 'local-repo',
+        effort: 'medium',
+        agentKind: 'codex',
+        permissionMode: 'full',
+      },
+      null,
+    );
   });
 
   it('首次快照到达前的 partial patch 会先补齐远端未改字段再镜像', async () => {

--- a/apps/desktop/src/main/hook-control/__tests__/workspacePrefsMirror.test.ts
+++ b/apps/desktop/src/main/hook-control/__tests__/workspacePrefsMirror.test.ts
@@ -1,0 +1,223 @@
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+const tmp = vi.hoisted(() => ({ dir: '' }));
+
+vi.mock('../../im/ownerScopedStorage.js', () => ({
+  ownerScopedImUserDataPath: (...parts: string[]) => path.join(tmp.dir, ...parts),
+}));
+
+import {
+  applyIncomingServerWorkspacePrefs,
+  getWorkspacePref,
+  reconcileWorkspacePrefsForMirror,
+  setWorkspacePref,
+} from '../workspacePrefsStore.js';
+import {
+  createWorkspacePrefsMirror,
+  type WorkspacePrefsMirrorDeps,
+} from '../workspacePrefsMirror.js';
+
+describe('workspacePrefsMirror', () => {
+  beforeEach(() => {
+    tmp.dir = fs.mkdtempSync(path.join(os.tmpdir(), 'wprefs-mirror-'));
+  });
+
+  afterEach(() => {
+    fs.rmSync(tmp.dir, { recursive: true, force: true });
+  });
+
+  it('不把 prefs.get 刚导入的 clean server 行回写', async () => {
+    reconcileWorkspacePrefsForMirror('slack', []);
+    const setRemotePrefs = vi.fn();
+    const mirror = createWorkspacePrefsMirror({
+      isLiveBound: () => true,
+      getRemoteSnapshotGeneration: () => 0,
+      getRemotePrefs: async () => ({
+        bound: true,
+        prefs: [
+          {
+            workspace: 'repo',
+            model: 'from-model-command',
+            effort: 'high',
+            agentKind: 'claude-code',
+            permissionMode: 'ask',
+            teamId: 'T1',
+          },
+        ],
+      }),
+      setRemotePrefs,
+      onLocalPrefsChanged: vi.fn(),
+      onError: vi.fn(),
+    });
+
+    await mirror('slack');
+
+    expect(getWorkspacePref('slack', 'T1', 'repo').model).toBe('from-model-command');
+    expect(setRemotePrefs).not.toHaveBeenCalled();
+  });
+
+  it('逐行镜像期间本地更新了后续候选时跳过旧候选', async () => {
+    reconcileWorkspacePrefsForMirror('slack', []);
+    setWorkspacePref('slack', null, 'chat', {
+      model: 'local-chat',
+      agentKind: 'claude-code',
+    });
+    setWorkspacePref('slack', 'T1', 'repo', {
+      model: 'old-local-repo',
+      agentKind: 'claude-code',
+    });
+
+    let releaseFirstWrite!: () => void;
+    const firstWrite = new Promise<void>((resolve) => {
+      releaseFirstWrite = resolve;
+    });
+    const setRemotePrefs = vi.fn<WorkspacePrefsMirrorDeps['setRemotePrefs']>(async () => {
+      if (setRemotePrefs.mock.calls.length === 1) await firstWrite;
+    });
+    const onError = vi.fn();
+    const mirror = createWorkspacePrefsMirror({
+      isLiveBound: () => true,
+      getRemoteSnapshotGeneration: () => 0,
+      getRemotePrefs: async () => ({ bound: true, prefs: [] }),
+      setRemotePrefs,
+      onLocalPrefsChanged: vi.fn(),
+      onError,
+    });
+
+    const flight = mirror('slack');
+    await vi.waitFor(() => expect(setRemotePrefs).toHaveBeenCalledTimes(1));
+    expect(setRemotePrefs.mock.calls[0]?.[1]).toBe('chat');
+
+    setWorkspacePref('slack', 'T1', 'repo', {
+      model: 'newer-local-repo',
+      effort: 'high',
+      agentKind: 'codex',
+      permissionMode: 'ask',
+    });
+    releaseFirstWrite();
+    await flight;
+
+    expect(setRemotePrefs).toHaveBeenCalledTimes(1);
+    expect(setRemotePrefs).toHaveBeenCalledWith(
+      'slack',
+      'chat',
+      {
+        model: 'local-chat',
+        effort: null,
+        agentKind: 'claude-code',
+        permissionMode: null,
+      },
+      null,
+    );
+    expect(getWorkspacePref('slack', 'T1', 'repo')).toMatchObject({
+      model: 'newer-local-repo',
+      effort: 'high',
+      agentKind: 'codex',
+      permissionMode: 'ask',
+    });
+    expect(onError).not.toHaveBeenCalled();
+  });
+
+  it('同一渠道的并发触发复用 single-flight，并补跑最新触发', async () => {
+    let releaseGet!: () => void;
+    const getPending = new Promise<void>((resolve) => {
+      releaseGet = resolve;
+    });
+    const getRemotePrefs = vi.fn(async () => {
+      await getPending;
+      return { bound: true, prefs: [] };
+    });
+    const onLocalPrefsChanged = vi.fn();
+    const mirror = createWorkspacePrefsMirror({
+      isLiveBound: () => true,
+      getRemoteSnapshotGeneration: () => 0,
+      getRemotePrefs,
+      setRemotePrefs: vi.fn(),
+      onLocalPrefsChanged,
+      onError: vi.fn(),
+    });
+
+    const first = mirror('slack');
+    const second = mirror('slack');
+    expect(second).toBe(first);
+    expect(getRemotePrefs).toHaveBeenCalledTimes(1);
+
+    releaseGet();
+    await Promise.all([first, second]);
+    expect(getRemotePrefs).toHaveBeenCalledTimes(2);
+    expect(onLocalPrefsChanged).toHaveBeenCalledTimes(1);
+  });
+
+  it('prefs.get 在途期间收到主动快照时丢弃旧响应并重新拉取', async () => {
+    reconcileWorkspacePrefsForMirror('slack', []);
+
+    let generation = 0;
+    let releaseFirstGet!: () => void;
+    const firstGetPending = new Promise<void>((resolve) => {
+      releaseFirstGet = resolve;
+    });
+    const oldSnapshot = {
+      bound: true,
+      prefs: [
+        {
+          workspace: 'repo',
+          model: 'old-model',
+          effort: null,
+          agentKind: 'claude-code',
+          permissionMode: null,
+          teamId: 'T1',
+        },
+      ],
+    };
+    const newSnapshot = {
+      bound: true,
+      prefs: [
+        {
+          workspace: 'repo',
+          model: 'new-model',
+          effort: 'high',
+          agentKind: 'codex',
+          permissionMode: 'ask',
+          teamId: 'T1',
+        },
+      ],
+    };
+    const getRemotePrefs = vi.fn(async () => {
+      if (getRemotePrefs.mock.calls.length === 1) {
+        await firstGetPending;
+        return oldSnapshot;
+      }
+      return newSnapshot;
+    });
+    const setRemotePrefs = vi.fn();
+    const mirror = createWorkspacePrefsMirror({
+      isLiveBound: () => true,
+      getRemoteSnapshotGeneration: () => generation,
+      getRemotePrefs,
+      setRemotePrefs,
+      onLocalPrefsChanged: vi.fn(),
+      onError: vi.fn(),
+    });
+
+    const flight = mirror('slack');
+    await vi.waitFor(() => expect(getRemotePrefs).toHaveBeenCalledTimes(1));
+
+    applyIncomingServerWorkspacePrefs('slack', newSnapshot.prefs);
+    generation += 1;
+    releaseFirstGet();
+    await flight;
+
+    expect(getRemotePrefs).toHaveBeenCalledTimes(2);
+    expect(getWorkspacePref('slack', 'T1', 'repo')).toMatchObject({
+      model: 'new-model',
+      effort: 'high',
+      agentKind: 'codex',
+      permissionMode: 'ask',
+    });
+    expect(setRemotePrefs).not.toHaveBeenCalled();
+  });
+});

--- a/apps/desktop/src/main/hook-control/__tests__/workspacePrefsMirror.test.ts
+++ b/apps/desktop/src/main/hook-control/__tests__/workspacePrefsMirror.test.ts
@@ -157,6 +157,60 @@ describe('workspacePrefsMirror', () => {
     expect(onLocalPrefsChanged).toHaveBeenCalledTimes(1);
   });
 
+  it('账号边界切换会失效旧 flight，并允许相同 binding key 的新 owner 立即镜像', async () => {
+    reconcileWorkspacePrefsForMirror('slack', []);
+
+    let owner: 'old' | 'new' = 'old';
+    let releaseOldGet!: () => void;
+    const oldGetPending = new Promise<void>((resolve) => {
+      releaseOldGet = resolve;
+    });
+    const getRemotePrefs = vi.fn(async () => {
+      const requestedOwner = owner;
+      if (requestedOwner === 'old') await oldGetPending;
+      return {
+        bound: true,
+        prefs: [
+          {
+            workspace: 'repo',
+            model: `${requestedOwner}-owner-model`,
+            effort: null,
+            agentKind: 'claude-code',
+            permissionMode: null,
+            teamId: 'T1',
+          },
+        ],
+      };
+    });
+    const onLocalPrefsChanged = vi.fn();
+    const mirror = createWorkspacePrefsMirror({
+      getLiveBindingKey: () => 'slack:T1',
+      isMirrorTargetCurrent: () => true,
+      getRemoteSnapshotGeneration: () => 0,
+      getRemotePrefs,
+      setRemotePrefs: vi.fn(),
+      onLocalPrefsChanged,
+      onError: vi.fn(),
+    });
+
+    const oldFlight = mirror('slack');
+    await vi.waitFor(() => expect(getRemotePrefs).toHaveBeenCalledTimes(1));
+
+    mirror.invalidateOwnerBoundary();
+    owner = 'new';
+    const newFlight = mirror('slack');
+    await vi.waitFor(() => expect(getRemotePrefs).toHaveBeenCalledTimes(2));
+    await newFlight;
+    expect(getWorkspacePref('slack', 'T1', 'repo').model).toBe('new-owner-model');
+
+    releaseOldGet();
+    await oldFlight;
+
+    expect(getRemotePrefs).toHaveBeenCalledTimes(2);
+    expect(getWorkspacePref('slack', 'T1', 'repo').model).toBe('new-owner-model');
+    expect(onLocalPrefsChanged).toHaveBeenCalledTimes(1);
+  });
+
   it('prefs.get 在途期间收到主动快照时丢弃旧响应并重新拉取', async () => {
     reconcileWorkspacePrefsForMirror('slack', []);
 

--- a/apps/desktop/src/main/hook-control/__tests__/workspacePrefsMirror.test.ts
+++ b/apps/desktop/src/main/hook-control/__tests__/workspacePrefsMirror.test.ts
@@ -34,7 +34,8 @@ describe('workspacePrefsMirror', () => {
     reconcileWorkspacePrefsForMirror('slack', []);
     const setRemotePrefs = vi.fn();
     const mirror = createWorkspacePrefsMirror({
-      isLiveBound: () => true,
+      getLiveBindingKey: () => 'slack:T1',
+      isMirrorTargetCurrent: () => true,
       getRemoteSnapshotGeneration: () => 0,
       getRemotePrefs: async () => ({
         bound: true,
@@ -80,7 +81,8 @@ describe('workspacePrefsMirror', () => {
     });
     const onError = vi.fn();
     const mirror = createWorkspacePrefsMirror({
-      isLiveBound: () => true,
+      getLiveBindingKey: () => 'slack:T1',
+      isMirrorTargetCurrent: () => true,
       getRemoteSnapshotGeneration: () => 0,
       getRemotePrefs: async () => ({ bound: true, prefs: [] }),
       setRemotePrefs,
@@ -133,7 +135,8 @@ describe('workspacePrefsMirror', () => {
     });
     const onLocalPrefsChanged = vi.fn();
     const mirror = createWorkspacePrefsMirror({
-      isLiveBound: () => true,
+      getLiveBindingKey: () => 'slack:T1',
+      isMirrorTargetCurrent: () => true,
       getRemoteSnapshotGeneration: () => 0,
       getRemotePrefs,
       setRemotePrefs: vi.fn(),
@@ -195,7 +198,8 @@ describe('workspacePrefsMirror', () => {
     });
     const setRemotePrefs = vi.fn();
     const mirror = createWorkspacePrefsMirror({
-      isLiveBound: () => true,
+      getLiveBindingKey: () => 'slack:T1',
+      isMirrorTargetCurrent: () => true,
       getRemoteSnapshotGeneration: () => generation,
       getRemotePrefs,
       setRemotePrefs,
@@ -219,5 +223,112 @@ describe('workspacePrefsMirror', () => {
       permissionMode: 'ask',
     });
     expect(setRemotePrefs).not.toHaveBeenCalled();
+  });
+
+  it('首次快照到达前的 partial patch 会先补齐远端未改字段再镜像', async () => {
+    setWorkspacePref('slack', 'T1', 'repo', { model: 'new-local-model' });
+    const setRemotePrefs = vi.fn();
+    const mirror = createWorkspacePrefsMirror({
+      getLiveBindingKey: () => 'slack:T1',
+      isMirrorTargetCurrent: () => true,
+      getRemoteSnapshotGeneration: () => 0,
+      getRemotePrefs: async () => ({
+        bound: true,
+        prefs: [
+          {
+            workspace: 'repo',
+            model: 'old-remote-model',
+            effort: 'high',
+            agentKind: 'claude-code',
+            permissionMode: 'ask',
+            teamId: 'T1',
+          },
+        ],
+      }),
+      setRemotePrefs,
+      onLocalPrefsChanged: vi.fn(),
+      onError: vi.fn(),
+    });
+
+    await mirror('slack');
+
+    expect(setRemotePrefs).toHaveBeenCalledWith(
+      'slack',
+      'repo',
+      {
+        model: 'new-local-model',
+        effort: 'high',
+        agentKind: 'claude-code',
+        permissionMode: 'ask',
+      },
+      'T1',
+    );
+    expect(getWorkspacePref('slack', 'T1', 'repo')).toMatchObject({
+      model: 'new-local-model',
+      effort: 'high',
+      agentKind: 'claude-code',
+      permissionMode: 'ask',
+    });
+  });
+
+  it('prefs.get 在途时绑定集合变化会丢弃旧快照，且不再写已解绑 team', async () => {
+    setWorkspacePref('slack', 'T1', 'repo', { model: 'local-team-one' });
+    let bindingKey = 'slack:T1,T2';
+    let releaseFirstGet!: () => void;
+    const firstGetPending = new Promise<void>((resolve) => {
+      releaseFirstGet = resolve;
+    });
+    const getRemotePrefs = vi.fn(async () => {
+      if (getRemotePrefs.mock.calls.length === 1) {
+        await firstGetPending;
+        return {
+          bound: true,
+          prefs: [
+            {
+              workspace: 'repo',
+              model: 'stale-team-one',
+              effort: 'high',
+              agentKind: 'codex',
+              permissionMode: 'ask',
+              teamId: 'T1',
+            },
+          ],
+        };
+      }
+      return {
+        bound: true,
+        prefs: [
+          {
+            workspace: 'chat',
+            model: 'stale-team-one-only',
+            effort: null,
+            agentKind: 'claude-code',
+            permissionMode: null,
+            teamId: 'T1',
+          },
+        ],
+      };
+    });
+    const setRemotePrefs = vi.fn();
+    const mirror = createWorkspacePrefsMirror({
+      getLiveBindingKey: () => bindingKey,
+      isMirrorTargetCurrent: (_channel, teamId) => teamId === null || teamId === 'T2',
+      getRemoteSnapshotGeneration: () => 0,
+      getRemotePrefs,
+      setRemotePrefs,
+      onLocalPrefsChanged: vi.fn(),
+      onError: vi.fn(),
+    });
+
+    const flight = mirror('slack');
+    await vi.waitFor(() => expect(getRemotePrefs).toHaveBeenCalledTimes(1));
+    bindingKey = 'slack:T2';
+    releaseFirstGet();
+    await flight;
+
+    expect(getRemotePrefs).toHaveBeenCalledTimes(2);
+    expect(setRemotePrefs).not.toHaveBeenCalled();
+    expect(getWorkspacePref('slack', 'T1', 'repo').model).toBe('local-team-one');
+    expect(getWorkspacePref('slack', 'T1', 'chat').model).toBeNull();
   });
 });

--- a/apps/desktop/src/main/hook-control/__tests__/workspacePrefsMirror.test.ts
+++ b/apps/desktop/src/main/hook-control/__tests__/workspacePrefsMirror.test.ts
@@ -373,6 +373,51 @@ describe('workspacePrefsMirror', () => {
     });
   });
 
+  it('multi-team 镜像保留完整快照中的非当前 team 偏好，但不向它写回', async () => {
+    reconcileWorkspacePrefsForMirror('slack', [
+      {
+        workspace: 'repo',
+        model: 'team-one-model',
+        effort: 'high',
+        agentKind: 'claude-code',
+        permissionMode: 'ask',
+        teamId: 'T1',
+      },
+    ]);
+    const setRemotePrefs = vi.fn();
+    const mirror = createWorkspacePrefsMirror({
+      getLiveBindingKey: () => 'slack:T2',
+      isMirrorTargetCurrent: (_channel, teamId) => teamId === null || teamId === 'T2',
+      getRemoteSnapshotGeneration: () => 0,
+      getRemotePrefs: async () => ({
+        bound: true,
+        prefs: [
+          {
+            workspace: 'repo',
+            model: 'stale-team-one-model',
+            effort: 'low',
+            agentKind: 'codex',
+            permissionMode: 'full',
+            teamId: 'T1',
+          },
+        ],
+      }),
+      setRemotePrefs,
+      onLocalPrefsChanged: vi.fn(),
+      onError: vi.fn(),
+    });
+
+    await mirror('slack');
+
+    expect(getWorkspacePref('slack', 'T1', 'repo')).toMatchObject({
+      model: 'team-one-model',
+      effort: 'high',
+      agentKind: 'claude-code',
+      permissionMode: 'ask',
+    });
+    expect(setRemotePrefs).not.toHaveBeenCalled();
+  });
+
   it('prefs.get 在途时绑定集合变化会丢弃旧快照，且不再写已解绑 team', async () => {
     setWorkspacePref('slack', 'T1', 'repo', { model: 'local-team-one' });
     let bindingKey = 'slack:T1,T2';

--- a/apps/desktop/src/main/hook-control/__tests__/workspacePrefsStore.test.ts
+++ b/apps/desktop/src/main/hook-control/__tests__/workspacePrefsStore.test.ts
@@ -80,6 +80,42 @@ describe('workspacePrefsStore', () => {
     });
   });
 
+  it('新建 team 行继承 dirty null 兜底尚未镜像的本地字段', () => {
+    reconcileWorkspacePrefsForMirror('slack', []);
+    setWorkspacePref('slack', null, 'repo', { effort: 'high' });
+    setWorkspacePref('slack', 'T1', 'repo', { model: 'team-model' });
+
+    const candidates = reconcileWorkspacePrefsForMirror('slack', [
+      {
+        workspace: 'repo',
+        model: 'fallback-model',
+        effort: 'low',
+        agentKind: 'claude-code',
+        permissionMode: 'ask',
+        teamId: null,
+      },
+      {
+        workspace: 'repo',
+        model: 'old-team-model',
+        effort: 'low',
+        agentKind: 'codex',
+        permissionMode: 'full',
+        teamId: 'T1',
+      },
+    ]);
+
+    expect(candidates.find((candidate) => candidate.prefs.teamId === 'T1')).toMatchObject({
+      prefs: {
+        workspace: 'repo',
+        model: 'team-model',
+        effort: 'high',
+        agentKind: 'codex',
+        permissionMode: 'full',
+        teamId: 'T1',
+      },
+    });
+  });
+
   it('四个字段都清空则保留墓碑，不丢键', () => {
     setWorkspacePref('x', null, 'chat', { model: 'grok-4', agentKind: 'pi' });
     setWorkspacePref('x', null, 'chat', {

--- a/apps/desktop/src/main/hook-control/__tests__/workspacePrefsStore.test.ts
+++ b/apps/desktop/src/main/hook-control/__tests__/workspacePrefsStore.test.ts
@@ -17,9 +17,11 @@ import {
   applyIncomingServerWorkspacePrefs,
   getWorkspacePref,
   importWorkspacePrefsIfNeeded,
+  isWorkspacePrefsMirrorCandidateCurrent,
   isWorkspacePrefsMigrated,
   listWorkspacePrefs,
   markWorkspacePrefMirrored,
+  reconcileWorkspacePrefsForMirror,
   replaceChannelWorkspacePrefs,
   resolveWorkspacePrefOverrides,
   setWorkspacePref,
@@ -49,15 +51,32 @@ describe('workspacePrefsStore', () => {
   });
 
   it('新建 team 专属行时从 null 兜底继承未改字段', () => {
-    setWorkspacePref('slack', null, 'repo', { model: 'sonnet', agentKind: 'claude-code' });
-    setWorkspacePref('slack', 'T1', 'repo', { model: 'opus' });
+    setWorkspacePref('slack', null, 'repo', {
+      model: 'sonnet',
+      effort: 'high',
+      agentKind: 'claude-code',
+      permissionMode: 'ask',
+    });
+    const written = setWorkspacePref('slack', 'T1', 'repo', { model: 'opus' });
     expect(getWorkspacePref('slack', 'T1', 'repo')).toMatchObject({
       model: 'opus',
+      effort: 'high',
       agentKind: 'claude-code',
+      permissionMode: 'ask',
     });
     expect(getWorkspacePref('slack', null, 'repo')).toMatchObject({
       model: 'sonnet',
+      effort: 'high',
       agentKind: 'claude-code',
+      permissionMode: 'ask',
+    });
+    expect(written.row).toEqual({
+      workspace: 'repo',
+      model: 'opus',
+      effort: 'high',
+      agentKind: 'claude-code',
+      permissionMode: 'ask',
+      teamId: 'T1',
     });
   });
 
@@ -114,6 +133,111 @@ describe('workspacePrefsStore', () => {
     expect(getWorkspacePref('telegram', null, 'chat').model).toBe('local-first');
     expect(getWorkspacePref('telegram', null, 'repo').model).toBe('server-repo');
     expect(isWorkspacePrefsMigrated('telegram')).toBe(true);
+  });
+
+  it('迁移完成后重连仍导入 /model 在远端新增的目录偏好，供 /new 使用', () => {
+    reconcileWorkspacePrefsForMirror('slack', []);
+    expect(isWorkspacePrefsMigrated('slack')).toBe(true);
+
+    const candidates = reconcileWorkspacePrefsForMirror('slack', [
+      {
+        workspace: 'repo',
+        model: 'from-model-command',
+        effort: 'high',
+        agentKind: 'claude-code',
+        permissionMode: 'ask',
+        teamId: 'T1',
+      },
+    ]);
+
+    const local = getWorkspacePref('slack', 'T1', 'repo');
+    expect(local.model).toBe('from-model-command');
+    expect(
+      resolveWorkspacePrefOverrides(
+        local,
+        {
+          agentKind: null,
+          model: null,
+          effort: null,
+          permissionMode: null,
+        },
+        true,
+      ),
+    ).toEqual({
+      agentKind: 'claude-code',
+      model: 'from-model-command',
+      effort: 'high',
+      permissionMode: 'ask',
+    });
+    expect(candidates).toEqual([]);
+  });
+
+  it('首次迁移只回写既有本地正本，不回写刚导入的 server clean 行', () => {
+    const localWrite = setWorkspacePref('slack', null, 'chat', {
+      model: 'local-model',
+      agentKind: 'claude-code',
+    });
+
+    const candidates = reconcileWorkspacePrefsForMirror('slack', [
+      {
+        workspace: 'chat',
+        model: 'stale-server-model',
+        effort: null,
+        agentKind: 'codex',
+        permissionMode: null,
+      },
+      {
+        workspace: 'repo',
+        model: 'server-only-model',
+        effort: 'high',
+        agentKind: 'codex',
+        permissionMode: 'ask',
+      },
+    ]);
+
+    expect(candidates).toEqual([
+      {
+        prefs: {
+          workspace: 'chat',
+          model: 'local-model',
+          effort: null,
+          agentKind: 'claude-code',
+          permissionMode: null,
+          teamId: null,
+        },
+        rev: localWrite.rev,
+      },
+    ]);
+    expect(getWorkspacePref('slack', null, 'repo').model).toBe('server-only-model');
+    expect(isWorkspacePrefsMirrorCandidateCurrent('slack', candidates[0]!)).toBe(true);
+
+    markWorkspacePrefMirrored('slack', null, 'chat', localWrite.rev);
+    expect(isWorkspacePrefsMirrorCandidateCurrent('slack', candidates[0]!)).toBe(false);
+  });
+
+  it('首次迁移导入 server 的 team 清空行，继续遮住 null-team 兜底', () => {
+    const candidates = reconcileWorkspacePrefsForMirror('slack', [
+      {
+        workspace: 'repo',
+        model: 'fallback-model',
+        effort: 'high',
+        agentKind: 'claude-code',
+        permissionMode: 'ask',
+        teamId: null,
+      },
+      {
+        workspace: 'repo',
+        model: null,
+        effort: null,
+        agentKind: null,
+        permissionMode: null,
+        teamId: 'T1',
+      },
+    ]);
+
+    expect(getWorkspacePref('slack', 'T1', 'repo').model).toBeNull();
+    expect(getWorkspacePref('slack', 'T2', 'repo').model).toBe('fallback-model');
+    expect(candidates).toEqual([]);
   });
 
   it('server 全量快照不复活本机墓碑，也不丢掉未镜像的本机实值', () => {
@@ -191,8 +315,83 @@ describe('workspacePrefsStore', () => {
     expect(getWorkspacePref('slack', null, 'repo').model).toBe('from-card');
   });
 
-  it('快照已无该键时也丢掉墓碑（删除已在 server 落地）', () => {
+  it('team 清空镜像成功后仍保留墓碑，避免重新继承 null 兜底', () => {
     setWorkspacePref('slack', null, 'repo', {
+      model: 'sonnet',
+      effort: 'high',
+      agentKind: 'claude-code',
+      permissionMode: 'ask',
+    });
+    const cleared = setWorkspacePref('slack', 'T1', 'repo', {
+      model: null,
+      effort: null,
+      agentKind: null,
+      permissionMode: null,
+    });
+
+    markWorkspacePrefMirrored('slack', 'T1', 'repo', cleared.rev);
+
+    expect(getWorkspacePref('slack', 'T1', 'repo')).toMatchObject({
+      model: null,
+      effort: null,
+      agentKind: null,
+      permissionMode: null,
+    });
+    expect(getWorkspacePref('slack', 'T2', 'repo')).toMatchObject({
+      model: 'sonnet',
+      effort: 'high',
+      agentKind: 'claude-code',
+      permissionMode: 'ask',
+    });
+  });
+
+  it('server 快照省略已清空的 team 键时仍保留墓碑，直到 null 兜底消失', () => {
+    reconcileWorkspacePrefsForMirror('slack', []);
+    const fallback = setWorkspacePref('slack', null, 'repo', {
+      model: 'sonnet',
+      agentKind: 'claude-code',
+    });
+    markWorkspacePrefMirrored('slack', null, 'repo', fallback.rev);
+    const cleared = setWorkspacePref('slack', 'T1', 'repo', {
+      model: null,
+      effort: null,
+      agentKind: null,
+      permissionMode: null,
+    });
+    markWorkspacePrefMirrored('slack', 'T1', 'repo', cleared.rev);
+
+    applyIncomingServerWorkspacePrefs('slack', [
+      {
+        workspace: 'repo',
+        model: 'sonnet',
+        effort: null,
+        agentKind: 'claude-code',
+        permissionMode: null,
+        teamId: null,
+      },
+    ]);
+
+    expect(getWorkspacePref('slack', 'T1', 'repo').model).toBeNull();
+    expect(getWorkspacePref('slack', 'T2', 'repo').model).toBe('sonnet');
+    expect(
+      reconcileWorkspacePrefsForMirror('slack', [
+        {
+          workspace: 'repo',
+          model: 'sonnet',
+          effort: null,
+          agentKind: 'claude-code',
+          permissionMode: null,
+          teamId: null,
+        },
+      ]),
+    ).toEqual([]);
+
+    applyIncomingServerWorkspacePrefs('slack', []);
+    expect(listWorkspacePrefs('slack')).toEqual([]);
+  });
+
+  it('dirty 墓碑不因快照省略而丢失，直到镜像回执确认', () => {
+    const cleared = setWorkspacePref('slack', null, 'repo', {
       model: null,
       effort: null,
       agentKind: null,
@@ -208,7 +407,16 @@ describe('workspacePrefsStore', () => {
         permissionMode: null,
       },
     ]);
+    expect(
+      listWorkspacePrefs('slack')
+        .map((e) => e.workspace)
+        .sort(),
+    ).toEqual(['chat', 'repo']);
+    expect(getWorkspacePref('slack', null, 'repo').model).toBeNull();
+
+    markWorkspacePrefMirrored('slack', null, 'repo', cleared.rev);
     expect(listWorkspacePrefs('slack').map((e) => e.workspace)).toEqual(['chat']);
+
     applyIncomingServerWorkspacePrefs('slack', [
       {
         workspace: 'repo',

--- a/apps/desktop/src/main/hook-control/__tests__/workspacePrefsStore.test.ts
+++ b/apps/desktop/src/main/hook-control/__tests__/workspacePrefsStore.test.ts
@@ -476,6 +476,74 @@ describe('workspacePrefsStore', () => {
     expect(getWorkspacePref('slack', null, 'chat').model).toBe('dirty-local');
   });
 
+  it('远端删除行后 partial patch 只复写本地实际修改的字段', () => {
+    reconcileWorkspacePrefsForMirror('slack', [
+      {
+        workspace: 'repo',
+        model: 'old-model',
+        effort: 'high',
+        agentKind: 'claude-code',
+        permissionMode: 'ask',
+      },
+    ]);
+    setWorkspacePref('slack', null, 'repo', { model: 'new-local-model' });
+
+    const candidates = reconcileWorkspacePrefsForMirror('slack', []);
+
+    expect(candidates).toEqual([
+      {
+        prefs: {
+          workspace: 'repo',
+          model: 'new-local-model',
+          effort: null,
+          agentKind: null,
+          permissionMode: null,
+          teamId: null,
+        },
+        rev: 1,
+      },
+    ]);
+  });
+
+  it('远端省略 team 行但仍有 null-team 兜底时保留兜底的未改字段', () => {
+    reconcileWorkspacePrefsForMirror('slack', [
+      {
+        workspace: 'repo',
+        model: 'old-team-model',
+        effort: 'low',
+        agentKind: 'codex',
+        permissionMode: 'ask',
+        teamId: 'T1',
+      },
+    ]);
+    setWorkspacePref('slack', 'T1', 'repo', { model: 'new-team-model' });
+
+    const candidates = reconcileWorkspacePrefsForMirror('slack', [
+      {
+        workspace: 'repo',
+        model: 'fallback-model',
+        effort: 'high',
+        agentKind: 'claude-code',
+        permissionMode: 'full',
+        teamId: null,
+      },
+    ]);
+
+    expect(candidates).toEqual([
+      {
+        prefs: {
+          workspace: 'repo',
+          model: 'new-team-model',
+          effort: 'high',
+          agentKind: 'claude-code',
+          permissionMode: 'full',
+          teamId: 'T1',
+        },
+        rev: 1,
+      },
+    ]);
+  });
+
   it('replaceChannel 只替换该渠道，并丢掉空白/非法别名', () => {
     setWorkspacePref('slack', null, 'keep-me', { model: 'slack-old' });
     setWorkspacePref('x', null, 'chat', { model: 'x-keep' });

--- a/apps/desktop/src/main/hook-control/ipc.ts
+++ b/apps/desktop/src/main/hook-control/ipc.ts
@@ -1195,6 +1195,7 @@ export async function stopHookControlAccount(): Promise<void> {
 
 /** Stop and discard all state tied to the current data owner; IPC stays registered. */
 export function resetHookControlOwnerBoundary(options?: { clearPersisted?: boolean }): void {
+  mirrorWorkspacePrefs.invalidateOwnerBoundary();
   unregisterSlackToolBridge();
   resetGroupContextCursorsSafely(options);
   resetTelegramSpeakerRegistrationCache();

--- a/apps/desktop/src/main/hook-control/ipc.ts
+++ b/apps/desktop/src/main/hook-control/ipc.ts
@@ -46,7 +46,6 @@ import {
 import {
   applyIncomingServerWorkspacePrefs,
   listWorkspacePrefs,
-  markWorkspacePrefMirrored,
   markWorkspacePrefsMigrated,
   setWorkspacePref,
   type HookPrefsChannel,
@@ -320,16 +319,38 @@ function persistUnsolicitedServerPrefs(channel: HookPrefsChannel, prefs: HookWor
   }
 }
 
-function channelLiveBound(channel: HookPrefsChannel): boolean {
+function channelLiveBindingKey(channel: HookPrefsChannel): string | null {
   const snap = ensureInstances().manager.snapshot();
   if (channel === 'slack') {
-    return snap.binding?.state === 'confirmed' || snap.bindings.some((b) => !b.displaced);
+    if (snap.serverMultiTeam) {
+      const teamIds = snap.bindings
+        .filter((binding) => !binding.displaced)
+        .map((binding) => binding.teamId)
+        .sort();
+      return teamIds.length > 0 ? `slack:multi:${teamIds.join(',')}` : null;
+    }
+    const binding = snap.binding;
+    return binding?.state === 'confirmed'
+      ? `slack:single:${binding.slackUserId ?? ''}:${binding.teamName ?? ''}`
+      : null;
   }
-  return snap[channel].binding?.state === 'confirmed';
+  const binding = snap[channel].binding;
+  return binding?.state === 'confirmed'
+    ? `${channel}:${binding.bindingId}:${binding.scopeId ?? ''}`
+    : null;
+}
+
+function channelMirrorTargetCurrent(channel: HookPrefsChannel, teamId: string | null): boolean {
+  if (channelLiveBindingKey(channel) === null) return false;
+  if (channel !== 'slack' || teamId === null) return true;
+  const snap = ensureInstances().manager.snapshot();
+  if (!snap.serverMultiTeam) return true;
+  return snap.bindings.some((binding) => binding.teamId === teamId && !binding.displaced);
 }
 
 const mirrorWorkspacePrefs = createWorkspacePrefsMirror({
-  isLiveBound: channelLiveBound,
+  getLiveBindingKey: channelLiveBindingKey,
+  isMirrorTargetCurrent: channelMirrorTargetCurrent,
   getRemoteSnapshotGeneration: (channel) => remotePrefsSnapshotGenerations.get(channel) ?? 0,
   getRemotePrefs: async (channel) => {
     const manager = ensureInstances().manager;
@@ -922,11 +943,10 @@ export function registerHookControlIpc(): void {
 
   registerTrustedHookControlHandler(HOOK_CONTROL_INVOKE.PREFS_SET, async (_e, payload) => {
     requireHookControl();
-    const { manager: m } = ensureInstances();
+    ensureInstances();
     const parsed = parseWorkspacePrefsWrite(payload);
-    let write: ReturnType<typeof setWorkspacePref>;
     try {
-      write = setWorkspacePref('slack', parsed.teamId, parsed.workspace, parsed.patch);
+      setWorkspacePref('slack', parsed.teamId, parsed.workspace, parsed.patch);
     } catch (err) {
       log.warn(
         `local slack workspace prefs write failed: ${err instanceof Error ? err.message : String(err)}`,
@@ -935,20 +955,7 @@ export function registerHookControlIpc(): void {
     }
     const view = slackLocalPrefsView();
     broadcastPrefs(view);
-    const mirrorPatch = {
-      model: write.row.model,
-      effort: write.row.effort,
-      agentKind: write.row.agentKind,
-      permissionMode: write.row.permissionMode,
-    };
-    void m
-      .setWorkspacePrefs(parsed.workspace, mirrorPatch, parsed.teamId)
-      .then(() => markWorkspacePrefMirrored('slack', parsed.teamId, parsed.workspace, write.rev))
-      .catch((err: unknown) => {
-        log.warn(
-          `slack workspace prefs mirror failed: ${err instanceof Error ? err.message : String(err)}`,
-        );
-      });
+    void mirrorWorkspacePrefs('slack');
     return { prefs: view };
   });
 
@@ -961,12 +968,11 @@ export function registerHookControlIpc(): void {
 
   registerTrustedHookControlHandler(HOOK_CONTROL_INVOKE.PROVIDER_PREFS_SET, async (_e, payload) => {
     requireHookControl();
-    const { manager: m } = ensureInstances();
+    ensureInstances();
     const provider = requireNeutralProvider(payload);
     const parsed = parseWorkspacePrefsWrite(payload);
-    let write: ReturnType<typeof setWorkspacePref>;
     try {
-      write = setWorkspacePref(provider, parsed.teamId, parsed.workspace, parsed.patch);
+      setWorkspacePref(provider, parsed.teamId, parsed.workspace, parsed.patch);
     } catch (err) {
       log.warn(
         `local ${provider} workspace prefs write failed: ${err instanceof Error ? err.message : String(err)}`,
@@ -975,20 +981,7 @@ export function registerHookControlIpc(): void {
     }
     const view = providerLocalPrefsView(provider);
     broadcastProviderPrefs(view);
-    const mirrorPatch = {
-      model: write.row.model,
-      effort: write.row.effort,
-      agentKind: write.row.agentKind,
-      permissionMode: write.row.permissionMode,
-    };
-    void m
-      .setProviderWorkspacePrefs(provider, parsed.workspace, mirrorPatch)
-      .then(() => markWorkspacePrefMirrored(provider, parsed.teamId, parsed.workspace, write.rev))
-      .catch((err: unknown) => {
-        log.warn(
-          `${provider} workspace prefs mirror failed: ${err instanceof Error ? err.message : String(err)}`,
-        );
-      });
+    void mirrorWorkspacePrefs(provider);
     return { prefs: view };
   });
 

--- a/apps/desktop/src/main/hook-control/ipc.ts
+++ b/apps/desktop/src/main/hook-control/ipc.ts
@@ -45,15 +45,13 @@ import {
 } from './workspaceProviderSourceStore.js';
 import {
   applyIncomingServerWorkspacePrefs,
-  importWorkspacePrefsIfNeeded,
-  isWorkspacePrefsMigrated,
   listWorkspacePrefs,
   markWorkspacePrefMirrored,
   markWorkspacePrefsMigrated,
-  peekWorkspacePrefRev,
   setWorkspacePref,
   type HookPrefsChannel,
 } from './workspacePrefsStore.js';
+import { createWorkspacePrefsMirror } from './workspacePrefsMirror.js';
 import { patchSessionMetaInDb } from '../localDb/ipc/sessions.js';
 import {
   dialogueWorkspaceRootDir,
@@ -305,9 +303,15 @@ function parseWorkspacePrefsWrite(payload: unknown): {
   return { workspace, teamId, patch };
 }
 
+const remotePrefsSnapshotGenerations = new Map<HookPrefsChannel, number>();
+
 function persistUnsolicitedServerPrefs(channel: HookPrefsChannel, prefs: HookWorkspacePrefs[]): void {
   try {
     applyIncomingServerWorkspacePrefs(channel, prefs);
+    remotePrefsSnapshotGenerations.set(
+      channel,
+      (remotePrefsSnapshotGenerations.get(channel) ?? 0) + 1,
+    );
     markWorkspacePrefsMigrated(channel);
   } catch (err) {
     log.warn(
@@ -324,39 +328,30 @@ function channelLiveBound(channel: HookPrefsChannel): boolean {
   return snap[channel].binding?.state === 'confirmed';
 }
 
-async function mirrorWorkspacePrefs(channel: HookPrefsChannel): Promise<void> {
-  const { manager: m } = ensureInstances();
-  if (!channelLiveBound(channel)) return;
-  try {
-    if (!isWorkspacePrefsMigrated(channel)) {
-      const remote =
-        channel === 'slack' ? await m.getWorkspacePrefs() : await m.getProviderWorkspacePrefs(channel);
-      importWorkspacePrefsIfNeeded(channel, remote.prefs);
-    }
-    for (const row of listWorkspacePrefs(channel)) {
-      const teamId = row.teamId ?? null;
-      const rev = peekWorkspacePrefRev(channel, teamId, row.workspace);
-      const patch = {
-        model: row.model,
-        effort: row.effort,
-        agentKind: row.agentKind,
-        permissionMode: row.permissionMode,
-      };
-      if (channel === 'slack') {
-        await m.setWorkspacePrefs(row.workspace, patch, teamId);
-      } else {
-        await m.setProviderWorkspacePrefs(channel, row.workspace, patch);
-      }
-      if (rev !== null) markWorkspacePrefMirrored(channel, teamId, row.workspace, rev);
-    }
+const mirrorWorkspacePrefs = createWorkspacePrefsMirror({
+  isLiveBound: channelLiveBound,
+  getRemoteSnapshotGeneration: (channel) => remotePrefsSnapshotGenerations.get(channel) ?? 0,
+  getRemotePrefs: async (channel) => {
+    const manager = ensureInstances().manager;
+    return channel === 'slack'
+      ? manager.getWorkspacePrefs()
+      : manager.getProviderWorkspacePrefs(channel);
+  },
+  setRemotePrefs: async (channel, workspace, patch, teamId) => {
+    const manager = ensureInstances().manager;
+    if (channel === 'slack') await manager.setWorkspacePrefs(workspace, patch, teamId);
+    else await manager.setProviderWorkspacePrefs(channel, workspace, patch);
+  },
+  onLocalPrefsChanged: (channel) => {
     if (channel === 'slack') broadcastPrefs(slackLocalPrefsView());
     else broadcastProviderPrefs(providerLocalPrefsView(channel));
-  } catch (err) {
+  },
+  onError: (channel, err) => {
     log.warn(
       `workspace prefs mirror (${channel}) failed: ${err instanceof Error ? err.message : String(err)}`,
     );
-  }
-}
+  },
+});
 
 function broadcastTelegramBehavior(view: TelegramHookBehaviorState): void {
   for (const w of BrowserWindow.getAllWindows()) {
@@ -929,9 +924,9 @@ export function registerHookControlIpc(): void {
     requireHookControl();
     const { manager: m } = ensureInstances();
     const parsed = parseWorkspacePrefsWrite(payload);
-    let writeRev: number;
+    let write: ReturnType<typeof setWorkspacePref>;
     try {
-      writeRev = setWorkspacePref('slack', parsed.teamId, parsed.workspace, parsed.patch).rev;
+      write = setWorkspacePref('slack', parsed.teamId, parsed.workspace, parsed.patch);
     } catch (err) {
       log.warn(
         `local slack workspace prefs write failed: ${err instanceof Error ? err.message : String(err)}`,
@@ -940,9 +935,15 @@ export function registerHookControlIpc(): void {
     }
     const view = slackLocalPrefsView();
     broadcastPrefs(view);
+    const mirrorPatch = {
+      model: write.row.model,
+      effort: write.row.effort,
+      agentKind: write.row.agentKind,
+      permissionMode: write.row.permissionMode,
+    };
     void m
-      .setWorkspacePrefs(parsed.workspace, parsed.patch, parsed.teamId)
-      .then(() => markWorkspacePrefMirrored('slack', parsed.teamId, parsed.workspace, writeRev))
+      .setWorkspacePrefs(parsed.workspace, mirrorPatch, parsed.teamId)
+      .then(() => markWorkspacePrefMirrored('slack', parsed.teamId, parsed.workspace, write.rev))
       .catch((err: unknown) => {
         log.warn(
           `slack workspace prefs mirror failed: ${err instanceof Error ? err.message : String(err)}`,
@@ -963,9 +964,9 @@ export function registerHookControlIpc(): void {
     const { manager: m } = ensureInstances();
     const provider = requireNeutralProvider(payload);
     const parsed = parseWorkspacePrefsWrite(payload);
-    let writeRev: number;
+    let write: ReturnType<typeof setWorkspacePref>;
     try {
-      writeRev = setWorkspacePref(provider, parsed.teamId, parsed.workspace, parsed.patch).rev;
+      write = setWorkspacePref(provider, parsed.teamId, parsed.workspace, parsed.patch);
     } catch (err) {
       log.warn(
         `local ${provider} workspace prefs write failed: ${err instanceof Error ? err.message : String(err)}`,
@@ -974,9 +975,15 @@ export function registerHookControlIpc(): void {
     }
     const view = providerLocalPrefsView(provider);
     broadcastProviderPrefs(view);
+    const mirrorPatch = {
+      model: write.row.model,
+      effort: write.row.effort,
+      agentKind: write.row.agentKind,
+      permissionMode: write.row.permissionMode,
+    };
     void m
-      .setProviderWorkspacePrefs(provider, parsed.workspace, parsed.patch)
-      .then(() => markWorkspacePrefMirrored(provider, parsed.teamId, parsed.workspace, writeRev))
+      .setProviderWorkspacePrefs(provider, parsed.workspace, mirrorPatch)
+      .then(() => markWorkspacePrefMirrored(provider, parsed.teamId, parsed.workspace, write.rev))
       .catch((err: unknown) => {
         log.warn(
           `${provider} workspace prefs mirror failed: ${err instanceof Error ? err.message : String(err)}`,

--- a/apps/desktop/src/main/hook-control/workspacePrefsMirror.ts
+++ b/apps/desktop/src/main/hook-control/workspacePrefsMirror.ts
@@ -1,0 +1,99 @@
+import type {
+  HookPrefsPatch,
+  HookPrefsView,
+  HookWorkspacePrefs,
+} from '../../shared/hookControlIpc.js';
+import {
+  isWorkspacePrefsMirrorCandidateCurrent,
+  markWorkspacePrefMirrored,
+  reconcileWorkspacePrefsForMirror,
+  type HookPrefsChannel,
+} from './workspacePrefsStore.js';
+
+export interface WorkspacePrefsMirrorDeps {
+  isLiveBound(channel: HookPrefsChannel): boolean;
+  getRemoteSnapshotGeneration(channel: HookPrefsChannel): number;
+  getRemotePrefs(channel: HookPrefsChannel): Promise<HookPrefsView>;
+  setRemotePrefs(
+    channel: HookPrefsChannel,
+    workspace: string,
+    patch: HookPrefsPatch,
+    teamId: string | null,
+  ): Promise<unknown>;
+  onLocalPrefsChanged(channel: HookPrefsChannel): void;
+  onError(channel: HookPrefsChannel, error: unknown): void;
+}
+
+function completePatch(row: HookWorkspacePrefs): HookPrefsPatch {
+  return {
+    model: row.model,
+    effort: row.effort,
+    agentKind: row.agentKind,
+    permissionMode: row.permissionMode,
+  };
+}
+
+/**
+ * 每个渠道只允许一轮重连镜像在途。server clean 行只落本机；只有仍为当前正本的
+ * dirty 行会写回，避免旧 prefs.get 快照覆盖稍后到达的 /model 更新。
+ */
+export function createWorkspacePrefsMirror(
+  deps: WorkspacePrefsMirrorDeps,
+): (channel: HookPrefsChannel) => Promise<void> {
+  const flights = new Map<HookPrefsChannel, Promise<void>>();
+  const triggerGenerations = new Map<HookPrefsChannel, number>();
+  const triggerGeneration = (channel: HookPrefsChannel): number =>
+    triggerGenerations.get(channel) ?? 0;
+
+  const run = async (channel: HookPrefsChannel): Promise<void> => {
+    while (true) {
+      const requestedGeneration = triggerGeneration(channel);
+      try {
+        if (!deps.isLiveBound(channel)) return;
+        const snapshotGeneration = deps.getRemoteSnapshotGeneration(channel);
+        const remote: HookPrefsView = await deps.getRemotePrefs(channel);
+        if (
+          requestedGeneration !== triggerGeneration(channel) ||
+          snapshotGeneration !== deps.getRemoteSnapshotGeneration(channel)
+        ) {
+          continue;
+        }
+        if (!remote.bound) return;
+
+        let restart = false;
+        for (const candidate of reconcileWorkspacePrefsForMirror(channel, remote.prefs)) {
+          if (requestedGeneration !== triggerGeneration(channel)) {
+            restart = true;
+            break;
+          }
+          if (!isWorkspacePrefsMirrorCandidateCurrent(channel, candidate)) continue;
+          const row = candidate.prefs;
+          await deps.setRemotePrefs(channel, row.workspace, completePatch(row), row.teamId ?? null);
+          if (requestedGeneration !== triggerGeneration(channel)) {
+            restart = true;
+            break;
+          }
+          markWorkspacePrefMirrored(channel, row.teamId ?? null, row.workspace, candidate.rev);
+        }
+        if (restart || requestedGeneration !== triggerGeneration(channel)) continue;
+        deps.onLocalPrefsChanged(channel);
+        return;
+      } catch (error) {
+        if (requestedGeneration !== triggerGeneration(channel)) continue;
+        deps.onError(channel, error);
+        return;
+      }
+    }
+  };
+
+  return (channel) => {
+    triggerGenerations.set(channel, triggerGeneration(channel) + 1);
+    const current = flights.get(channel);
+    if (current) return current;
+    const flight = run(channel).finally(() => {
+      if (flights.get(channel) === flight) flights.delete(channel);
+    });
+    flights.set(channel, flight);
+    return flight;
+  };
+}

--- a/apps/desktop/src/main/hook-control/workspacePrefsMirror.ts
+++ b/apps/desktop/src/main/hook-control/workspacePrefsMirror.ts
@@ -29,6 +29,12 @@ export interface WorkspacePrefsMirrorDeps {
   onError(channel: HookPrefsChannel, error: unknown): void;
 }
 
+export interface WorkspacePrefsMirror {
+  (channel: HookPrefsChannel): Promise<void>;
+  /** 账号 owner 切换时失效旧回调，并允许新 owner 立即启动独立 flight。 */
+  invalidateOwnerBoundary(): void;
+}
+
 function completePatch(row: HookWorkspacePrefs): HookPrefsPatch {
   return {
     model: row.model,
@@ -44,14 +50,18 @@ function completePatch(row: HookWorkspacePrefs): HookPrefsPatch {
  */
 export function createWorkspacePrefsMirror(
   deps: WorkspacePrefsMirrorDeps,
-): (channel: HookPrefsChannel) => Promise<void> {
+): WorkspacePrefsMirror {
   const flights = new Map<HookPrefsChannel, Promise<void>>();
   const triggerGenerations = new Map<HookPrefsChannel, number>();
+  let ownerBoundaryGeneration = 0;
   const triggerGeneration = (channel: HookPrefsChannel): number =>
     triggerGenerations.get(channel) ?? 0;
+  const ownerBoundaryCurrent = (generation: number): boolean =>
+    generation === ownerBoundaryGeneration;
 
-  const run = async (channel: HookPrefsChannel): Promise<void> => {
+  const run = async (channel: HookPrefsChannel, ownerGeneration: number): Promise<void> => {
     while (true) {
+      if (!ownerBoundaryCurrent(ownerGeneration)) return;
       const requestedGeneration = triggerGeneration(channel);
       const bindingKey = deps.getLiveBindingKey(channel);
       let snapshotGeneration: number | null = null;
@@ -59,6 +69,7 @@ export function createWorkspacePrefsMirror(
         if (bindingKey === null) return;
         snapshotGeneration = deps.getRemoteSnapshotGeneration(channel);
         const remote: HookPrefsView = await deps.getRemotePrefs(channel);
+        if (!ownerBoundaryCurrent(ownerGeneration)) return;
         if (
           requestedGeneration !== triggerGeneration(channel) ||
           snapshotGeneration !== deps.getRemoteSnapshotGeneration(channel) ||
@@ -92,6 +103,7 @@ export function createWorkspacePrefsMirror(
           if (!isWorkspacePrefsMirrorCandidateCurrent(channel, candidate)) continue;
           const row = candidate.prefs;
           await deps.setRemotePrefs(channel, row.workspace, completePatch(row), teamId);
+          if (!ownerBoundaryCurrent(ownerGeneration)) return;
           const snapshotChanged =
             snapshotGeneration !== deps.getRemoteSnapshotGeneration(channel);
           if (snapshotChanged) {
@@ -117,6 +129,7 @@ export function createWorkspacePrefsMirror(
         deps.onLocalPrefsChanged(channel);
         return;
       } catch (error) {
+        if (!ownerBoundaryCurrent(ownerGeneration)) return;
         if (
           requestedGeneration !== triggerGeneration(channel) ||
           (snapshotGeneration !== null &&
@@ -131,14 +144,23 @@ export function createWorkspacePrefsMirror(
     }
   };
 
-  return (channel) => {
-    triggerGenerations.set(channel, triggerGeneration(channel) + 1);
-    const current = flights.get(channel);
-    if (current) return current;
-    const flight = run(channel).finally(() => {
-      if (flights.get(channel) === flight) flights.delete(channel);
-    });
-    flights.set(channel, flight);
-    return flight;
-  };
+  return Object.assign(
+    (channel: HookPrefsChannel): Promise<void> => {
+      triggerGenerations.set(channel, triggerGeneration(channel) + 1);
+      const current = flights.get(channel);
+      if (current) return current;
+      const flight = run(channel, ownerBoundaryGeneration).finally(() => {
+        if (flights.get(channel) === flight) flights.delete(channel);
+      });
+      flights.set(channel, flight);
+      return flight;
+    },
+    {
+      invalidateOwnerBoundary(): void {
+        ownerBoundaryGeneration += 1;
+        triggerGenerations.clear();
+        flights.clear();
+      },
+    },
+  );
 }

--- a/apps/desktop/src/main/hook-control/workspacePrefsMirror.ts
+++ b/apps/desktop/src/main/hook-control/workspacePrefsMirror.ts
@@ -11,7 +11,10 @@ import {
 } from './workspacePrefsStore.js';
 
 export interface WorkspacePrefsMirrorDeps {
-  isLiveBound(channel: HookPrefsChannel): boolean;
+  /** 当前可镜像的绑定集合身份；null 表示没有 live binding。 */
+  getLiveBindingKey(channel: HookPrefsChannel): string | null;
+  /** multi-team 下只允许向仍处于当前绑定集合的 team 写回。 */
+  isMirrorTargetCurrent(channel: HookPrefsChannel, teamId: string | null): boolean;
   getRemoteSnapshotGeneration(channel: HookPrefsChannel): number;
   getRemotePrefs(channel: HookPrefsChannel): Promise<HookPrefsView>;
   setRemotePrefs(
@@ -48,38 +51,56 @@ export function createWorkspacePrefsMirror(
   const run = async (channel: HookPrefsChannel): Promise<void> => {
     while (true) {
       const requestedGeneration = triggerGeneration(channel);
+      const bindingKey = deps.getLiveBindingKey(channel);
       try {
-        if (!deps.isLiveBound(channel)) return;
+        if (bindingKey === null) return;
         const snapshotGeneration = deps.getRemoteSnapshotGeneration(channel);
         const remote: HookPrefsView = await deps.getRemotePrefs(channel);
         if (
           requestedGeneration !== triggerGeneration(channel) ||
-          snapshotGeneration !== deps.getRemoteSnapshotGeneration(channel)
+          snapshotGeneration !== deps.getRemoteSnapshotGeneration(channel) ||
+          bindingKey !== deps.getLiveBindingKey(channel)
         ) {
           continue;
         }
         if (!remote.bound) return;
 
         let restart = false;
-        for (const candidate of reconcileWorkspacePrefsForMirror(channel, remote.prefs)) {
-          if (requestedGeneration !== triggerGeneration(channel)) {
+        const currentPrefs = remote.prefs.filter((row) =>
+          deps.isMirrorTargetCurrent(channel, row.teamId ?? null),
+        );
+        for (const candidate of reconcileWorkspacePrefsForMirror(channel, currentPrefs)) {
+          const teamId = candidate.prefs.teamId ?? null;
+          if (
+            requestedGeneration !== triggerGeneration(channel) ||
+            bindingKey !== deps.getLiveBindingKey(channel)
+          ) {
             restart = true;
             break;
           }
+          if (!deps.isMirrorTargetCurrent(channel, teamId)) continue;
           if (!isWorkspacePrefsMirrorCandidateCurrent(channel, candidate)) continue;
           const row = candidate.prefs;
-          await deps.setRemotePrefs(channel, row.workspace, completePatch(row), row.teamId ?? null);
-          if (requestedGeneration !== triggerGeneration(channel)) {
+          await deps.setRemotePrefs(channel, row.workspace, completePatch(row), teamId);
+          if (
+            requestedGeneration !== triggerGeneration(channel) ||
+            bindingKey !== deps.getLiveBindingKey(channel)
+          ) {
             restart = true;
             break;
           }
-          markWorkspacePrefMirrored(channel, row.teamId ?? null, row.workspace, candidate.rev);
+          markWorkspacePrefMirrored(channel, teamId, row.workspace, candidate.rev);
         }
         if (restart || requestedGeneration !== triggerGeneration(channel)) continue;
         deps.onLocalPrefsChanged(channel);
         return;
       } catch (error) {
-        if (requestedGeneration !== triggerGeneration(channel)) continue;
+        if (
+          requestedGeneration !== triggerGeneration(channel) ||
+          bindingKey !== deps.getLiveBindingKey(channel)
+        ) {
+          continue;
+        }
         deps.onError(channel, error);
         return;
       }

--- a/apps/desktop/src/main/hook-control/workspacePrefsMirror.ts
+++ b/apps/desktop/src/main/hook-control/workspacePrefsMirror.ts
@@ -6,6 +6,7 @@ import type {
 import {
   isWorkspacePrefsMirrorCandidateCurrent,
   markWorkspacePrefMirrored,
+  pinWorkspacePrefForMirrorRetry,
   reconcileWorkspacePrefsForMirror,
   type HookPrefsChannel,
 } from './workspacePrefsStore.js';
@@ -52,9 +53,10 @@ export function createWorkspacePrefsMirror(
     while (true) {
       const requestedGeneration = triggerGeneration(channel);
       const bindingKey = deps.getLiveBindingKey(channel);
+      let snapshotGeneration: number | null = null;
       try {
         if (bindingKey === null) return;
-        const snapshotGeneration = deps.getRemoteSnapshotGeneration(channel);
+        snapshotGeneration = deps.getRemoteSnapshotGeneration(channel);
         const remote: HookPrefsView = await deps.getRemotePrefs(channel);
         if (
           requestedGeneration !== triggerGeneration(channel) ||
@@ -73,6 +75,7 @@ export function createWorkspacePrefsMirror(
           const teamId = candidate.prefs.teamId ?? null;
           if (
             requestedGeneration !== triggerGeneration(channel) ||
+            snapshotGeneration !== deps.getRemoteSnapshotGeneration(channel) ||
             bindingKey !== deps.getLiveBindingKey(channel)
           ) {
             restart = true;
@@ -82,8 +85,14 @@ export function createWorkspacePrefsMirror(
           if (!isWorkspacePrefsMirrorCandidateCurrent(channel, candidate)) continue;
           const row = candidate.prefs;
           await deps.setRemotePrefs(channel, row.workspace, completePatch(row), teamId);
+          const snapshotChanged =
+            snapshotGeneration !== deps.getRemoteSnapshotGeneration(channel);
+          if (snapshotChanged) {
+            pinWorkspacePrefForMirrorRetry(channel, teamId, row.workspace);
+          }
           if (
             requestedGeneration !== triggerGeneration(channel) ||
+            snapshotChanged ||
             bindingKey !== deps.getLiveBindingKey(channel)
           ) {
             restart = true;
@@ -91,12 +100,20 @@ export function createWorkspacePrefsMirror(
           }
           markWorkspacePrefMirrored(channel, teamId, row.workspace, candidate.rev);
         }
-        if (restart || requestedGeneration !== triggerGeneration(channel)) continue;
+        if (
+          restart ||
+          requestedGeneration !== triggerGeneration(channel) ||
+          snapshotGeneration !== deps.getRemoteSnapshotGeneration(channel)
+        ) {
+          continue;
+        }
         deps.onLocalPrefsChanged(channel);
         return;
       } catch (error) {
         if (
           requestedGeneration !== triggerGeneration(channel) ||
+          (snapshotGeneration !== null &&
+            snapshotGeneration !== deps.getRemoteSnapshotGeneration(channel)) ||
           bindingKey !== deps.getLiveBindingKey(channel)
         ) {
           continue;

--- a/apps/desktop/src/main/hook-control/workspacePrefsMirror.ts
+++ b/apps/desktop/src/main/hook-control/workspacePrefsMirror.ts
@@ -5,6 +5,7 @@ import type {
 } from '../../shared/hookControlIpc.js';
 import {
   isWorkspacePrefsMirrorCandidateCurrent,
+  listWorkspacePrefs,
   markWorkspacePrefMirrored,
   pinWorkspacePrefForMirrorRetry,
   reconcileWorkspacePrefsForMirror,
@@ -71,7 +72,13 @@ export function createWorkspacePrefsMirror(
         const currentPrefs = remote.prefs.filter((row) =>
           deps.isMirrorTargetCurrent(channel, row.teamId ?? null),
         );
-        for (const candidate of reconcileWorkspacePrefsForMirror(channel, currentPrefs)) {
+        const preservedPrefs = listWorkspacePrefs(channel).filter(
+          (row) => !deps.isMirrorTargetCurrent(channel, row.teamId ?? null),
+        );
+        for (const candidate of reconcileWorkspacePrefsForMirror(channel, [
+          ...currentPrefs,
+          ...preservedPrefs,
+        ])) {
           const teamId = candidate.prefs.teamId ?? null;
           if (
             requestedGeneration !== triggerGeneration(channel) ||

--- a/apps/desktop/src/main/hook-control/workspacePrefsStore.ts
+++ b/apps/desktop/src/main/hook-control/workspacePrefsStore.ts
@@ -174,12 +174,15 @@ function mergeDirtyRowWithServer(
   localRow: WorkspacePrefsEntry,
   serverRow: WorkspacePrefsEntry | undefined,
 ): WorkspacePrefsEntry {
-  if (localRow.dirtyPatch === undefined || serverRow === undefined) return localRow;
+  if (localRow.dirtyPatch === undefined) return localRow;
   const merged: WorkspacePrefsEntry = {
-    ...serverRow,
     channel: localRow.channel,
     teamId: localRow.teamId,
     workspace: localRow.workspace,
+    model: serverRow?.model ?? null,
+    effort: serverRow?.effort ?? null,
+    agentKind: serverRow?.agentKind ?? null,
+    permissionMode: serverRow?.permissionMode ?? null,
     rev: rowRev(localRow),
     dirty: true,
     dirtyPatch: localRow.dirtyPatch,
@@ -521,6 +524,29 @@ export function applyIncomingServerWorkspacePrefs(
 export interface WorkspacePrefsMirrorCandidate {
   prefs: HookWorkspacePrefs;
   rev: number;
+}
+
+/**
+ * 完整行写回期间若撞上更新的 server 快照，本机 dirty 行已经合并了该快照。
+ * 固定当前完整行，避免重试拉到刚被旧写回覆盖的 server 行后再次丢掉新字段。
+ */
+export function pinWorkspacePrefForMirrorRetry(
+  channel: HookPrefsChannel,
+  teamId: string | null,
+  workspace: string,
+): void {
+  const fp = filePath();
+  const store = readStore(fp);
+  const current = store.entries.find((row) => sameKey(row, channel, teamId, workspace));
+  if (!current || !isDirtyRow(current) || current.dirtyPatch === undefined) return;
+  const pinned = { ...current };
+  delete pinned.dirtyPatch;
+  writeStore(fp, {
+    ...store,
+    entries: store.entries.map((row) =>
+      sameKey(row, channel, teamId, workspace) ? pinned : row,
+    ),
+  });
 }
 
 /**

--- a/apps/desktop/src/main/hook-control/workspacePrefsStore.ts
+++ b/apps/desktop/src/main/hook-control/workspacePrefsStore.ts
@@ -260,13 +260,14 @@ export function setWorkspacePref(
           permissionMode: null,
         } satisfies WorkspacePrefsEntry));
   const rev = rowRev(current) + 1;
+  const localBase = exact ?? inherited;
   const fullLocalAuthority =
-    exact !== undefined &&
-    ((isDirtyRow(exact) && exact.dirtyPatch === undefined) ||
-      (store.migrated[channel] !== true && !isDirtyRow(exact)));
+    localBase !== undefined &&
+    ((isDirtyRow(localBase) && localBase.dirtyPatch === undefined) ||
+      (store.migrated[channel] !== true && !isDirtyRow(localBase)));
   const dirtyPatch = fullLocalAuthority
     ? undefined
-    : mergePatch(exact && isDirtyRow(exact) ? exact.dirtyPatch : undefined, patch);
+    : mergePatch(localBase && isDirtyRow(localBase) ? localBase.dirtyPatch : undefined, patch);
   const nextRow: WorkspacePrefsEntry = {
     ...current,
     ...(patch.model !== undefined ? { model: patch.model } : {}),

--- a/apps/desktop/src/main/hook-control/workspacePrefsStore.ts
+++ b/apps/desktop/src/main/hook-control/workspacePrefsStore.ts
@@ -36,6 +36,11 @@ export interface WorkspacePrefsEntry {
   rev?: number;
   /** 尚未成功镜像的本地写入。缺省：墓碑视为 dirty，旧实值行视为已同步。 */
   dirty?: boolean;
+  /**
+   * dirty 行里由本机实际修改的字段。缺省表示整行都是旧客户端留下的本机正本；
+   * 有值时可先用 server 快照补齐未改字段，再安全地生成完整镜像行。
+   */
+  dirtyPatch?: HookPrefsPatch;
 }
 
 interface StoreFile {
@@ -63,6 +68,18 @@ function isNullablePrefField(value: unknown): value is string | null {
   );
 }
 
+const PREF_FIELDS = ['model', 'effort', 'agentKind', 'permissionMode'] as const;
+type PrefField = (typeof PREF_FIELDS)[number];
+
+function isDirtyPatch(value: unknown): value is HookPrefsPatch {
+  if (!value || typeof value !== 'object' || Array.isArray(value)) return false;
+  const patch = value as Record<string, unknown>;
+  if (Object.keys(patch).some((key) => !PREF_FIELDS.includes(key as PrefField))) return false;
+  return PREF_FIELDS.every(
+    (field) => patch[field] === undefined || isNullablePrefField(patch[field]),
+  );
+}
+
 function isEntry(raw: unknown): raw is WorkspacePrefsEntry {
   if (!raw || typeof raw !== 'object') return false;
   const r = raw as Record<string, unknown>;
@@ -78,7 +95,8 @@ function isEntry(raw: unknown): raw is WorkspacePrefsEntry {
     isNullablePrefField(r.permissionMode) &&
     (r.rev === undefined ||
       (typeof r.rev === 'number' && Number.isInteger(r.rev) && r.rev >= 0 && r.rev <= 1_000_000_000)) &&
-    (r.dirty === undefined || typeof r.dirty === 'boolean')
+    (r.dirty === undefined || typeof r.dirty === 'boolean') &&
+    (r.dirtyPatch === undefined || isDirtyPatch(r.dirtyPatch))
   );
 }
 
@@ -144,6 +162,41 @@ function isDirtyRow(row: WorkspacePrefsEntry): boolean {
   return isBlankRow(row);
 }
 
+function mergePatch(base: HookPrefsPatch | undefined, patch: HookPrefsPatch): HookPrefsPatch {
+  const merged: HookPrefsPatch = { ...base };
+  for (const field of PREF_FIELDS) {
+    if (patch[field] !== undefined) merged[field] = patch[field];
+  }
+  return merged;
+}
+
+function mergeDirtyRowWithServer(
+  localRow: WorkspacePrefsEntry,
+  serverRow: WorkspacePrefsEntry | undefined,
+): WorkspacePrefsEntry {
+  if (localRow.dirtyPatch === undefined || serverRow === undefined) return localRow;
+  const merged: WorkspacePrefsEntry = {
+    ...serverRow,
+    channel: localRow.channel,
+    teamId: localRow.teamId,
+    workspace: localRow.workspace,
+    rev: rowRev(localRow),
+    dirty: true,
+    dirtyPatch: localRow.dirtyPatch,
+  };
+  for (const field of PREF_FIELDS) {
+    const value = localRow.dirtyPatch[field];
+    if (value !== undefined) merged[field] = value;
+  }
+  return merged;
+}
+
+function cleanRow(row: WorkspacePrefsEntry): WorkspacePrefsEntry {
+  const rest = { ...row };
+  delete rest.dirtyPatch;
+  return { ...rest, dirty: false };
+}
+
 export function isWorkspacePrefsMigrated(channel: HookPrefsChannel): boolean {
   return readStore(filePath()).migrated[channel] === true;
 }
@@ -204,6 +257,13 @@ export function setWorkspacePref(
           permissionMode: null,
         } satisfies WorkspacePrefsEntry));
   const rev = rowRev(current) + 1;
+  const fullLocalAuthority =
+    exact !== undefined &&
+    ((isDirtyRow(exact) && exact.dirtyPatch === undefined) ||
+      (store.migrated[channel] !== true && !isDirtyRow(exact)));
+  const dirtyPatch = fullLocalAuthority
+    ? undefined
+    : mergePatch(exact && isDirtyRow(exact) ? exact.dirtyPatch : undefined, patch);
   const nextRow: WorkspacePrefsEntry = {
     ...current,
     ...(patch.model !== undefined ? { model: patch.model } : {}),
@@ -212,6 +272,7 @@ export function setWorkspacePref(
     ...(patch.permissionMode !== undefined ? { permissionMode: patch.permissionMode } : {}),
     rev,
     dirty: true,
+    dirtyPatch,
   };
   const rest = store.entries.filter((e) => !sameKey(e, channel, teamId, workspace));
   // 全空行是未同步的删除墓碑：派发视为跟随默认，重连时向 server 发 all-null。
@@ -277,7 +338,7 @@ export function markWorkspacePrefMirrored(
       writeStore(fp, {
         ...store,
         entries: store.entries.map((e) =>
-          sameKey(e, channel, teamId, workspace) ? { ...e, dirty: false } : e,
+          sameKey(e, channel, teamId, workspace) ? cleanRow(e) : e,
         ),
       });
       return;
@@ -295,7 +356,7 @@ export function markWorkspacePrefMirrored(
   writeStore(fp, {
     ...store,
     entries: store.entries.map((e) =>
-      sameKey(e, channel, teamId, workspace) ? { ...e, dirty: false } : e,
+      sameKey(e, channel, teamId, workspace) ? cleanRow(e) : e,
     ),
   });
 }
@@ -339,6 +400,16 @@ function prefKey(teamId: string | null | undefined, workspace: string): string {
   return `${teamId ?? ''}::${workspace}`;
 }
 
+function serverRowForLocal(
+  serverByKey: Map<string, WorkspacePrefsEntry>,
+  row: Pick<WorkspacePrefsEntry, 'teamId' | 'workspace'>,
+): WorkspacePrefsEntry | undefined {
+  return (
+    serverByKey.get(prefKey(row.teamId, row.workspace)) ??
+    (row.teamId !== null ? serverByKey.get(prefKey(null, row.workspace)) : undefined)
+  );
+}
+
 function asStoreRow(channel: HookPrefsChannel, pref: HookWorkspacePrefs): WorkspacePrefsEntry | null {
   if (!HOOK_WORKSPACE_ALIAS_RE.test(pref.workspace)) return null;
   const teamId = pref.teamId === undefined || pref.teamId === null ? null : pref.teamId;
@@ -370,17 +441,23 @@ export function importWorkspacePrefsIfNeeded(
   const localKeys = new Set(
     store.entries.filter((e) => e.channel === channel).map((e) => prefKey(e.teamId, e.workspace)),
   );
+  const serverByKey = new Map<string, WorkspacePrefsEntry>();
   const incoming: WorkspacePrefsEntry[] = [];
   for (const pref of serverPrefs) {
     const row = asStoreRow(channel, pref);
     if (row === null) continue;
+    serverByKey.set(prefKey(row.teamId, row.workspace), row);
     if (localKeys.has(prefKey(row.teamId, row.workspace))) continue;
     incoming.push(row);
   }
   // 首次迁移前的既有本地行是正本，必须作为 dirty 行镜像；本次刚导入的 server 行
   // 保持 clean，避免把 prefs.get 的旧快照无条件回写。
   const combined = [
-    ...store.entries.map((row) => (row.channel === channel ? { ...row, dirty: true } : row)),
+    ...store.entries.map((row) => {
+      if (row.channel !== channel) return row;
+      const dirtyRow = { ...row, dirty: true };
+      return mergeDirtyRowWithServer(dirtyRow, serverRowForLocal(serverByKey, row));
+    }),
     ...incoming,
   ];
   const channelRows = combined.filter((row) => row.channel === channel);
@@ -418,7 +495,7 @@ export function applyIncomingServerWorkspacePrefs(
     const key = prefKey(localRow.teamId, localRow.workspace);
     seen.add(key);
     if (isDirtyRow(localRow)) {
-      nextChannel.push(localRow);
+      nextChannel.push(mergeDirtyRowWithServer(localRow, serverRowForLocal(serverByKey, localRow)));
       continue;
     }
     const serverRow = serverByKey.get(key);

--- a/apps/desktop/src/main/hook-control/workspacePrefsStore.ts
+++ b/apps/desktop/src/main/hook-control/workspacePrefsStore.ts
@@ -182,7 +182,7 @@ export function setWorkspacePref(
   teamId: string | null,
   workspace: string,
   patch: HookPrefsPatch,
-): { prefs: HookWorkspacePrefs[]; rev: number } {
+): { prefs: HookWorkspacePrefs[]; row: HookWorkspacePrefs; rev: number } {
   const fp = filePath();
   const store = readStore(fp);
   const exact = store.entries.find((e) => sameKey(e, channel, teamId, workspace));
@@ -221,21 +221,46 @@ export function setWorkspacePref(
     throw new Error('too many workspace prefs entries');
   }
   writeStore(fp, { ...store, entries });
-  return { prefs: entries.filter((e) => e.channel === channel).map(toHookPrefs), rev };
+  return {
+    prefs: entries.filter((e) => e.channel === channel).map(toHookPrefs),
+    row: toHookPrefs(nextRow),
+    rev,
+  };
 }
 
-export function peekWorkspacePrefRev(
-  channel: HookPrefsChannel,
-  teamId: string | null,
-  workspace: string,
-): number | null {
-  const current = readStore(filePath()).entries.find((e) => sameKey(e, channel, teamId, workspace));
-  return current ? rowRev(current) : null;
+function needsTeamTombstone(entries: WorkspacePrefsEntry[], row: WorkspacePrefsEntry): boolean {
+  return (
+    row.teamId !== null &&
+    entries.some(
+      (candidate) => sameKey(candidate, row.channel, null, row.workspace) && !isBlankRow(candidate),
+    )
+  );
+}
+
+function pruneRedundantBlankRows(entries: WorkspacePrefsEntry[]): WorkspacePrefsEntry[] {
+  return entries.filter(
+    (row) => !isBlankRow(row) || isDirtyRow(row) || needsTeamTombstone(entries, row),
+  );
+}
+
+function shouldMirrorRow(row: WorkspacePrefsEntry): boolean {
+  return isDirtyRow(row);
+}
+
+function samePrefs(row: WorkspacePrefsEntry, prefs: HookWorkspacePrefs): boolean {
+  return (
+    row.teamId === (prefs.teamId ?? null) &&
+    row.workspace === prefs.workspace &&
+    row.model === prefs.model &&
+    row.effort === prefs.effort &&
+    row.agentKind === prefs.agentKind &&
+    row.permissionMode === prefs.permissionMode
+  );
 }
 
 /**
  * 确认某次本地写入已镜像到 server：代次必须仍是 expectedRev。
- * 墓碑对上就丢掉；实值对上就清 dirty，之后卡片删除才能落地。
+ * team 空行若仍需遮住 null-team 兜底就转为 clean 墓碑；其余墓碑丢掉。
  */
 export function markWorkspacePrefMirrored(
   channel: HookPrefsChannel,
@@ -248,9 +273,21 @@ export function markWorkspacePrefMirrored(
   const current = store.entries.find((e) => sameKey(e, channel, teamId, workspace));
   if (!current || rowRev(current) !== expectedRev) return;
   if (isBlankRow(current)) {
+    if (needsTeamTombstone(store.entries, current)) {
+      writeStore(fp, {
+        ...store,
+        entries: store.entries.map((e) =>
+          sameKey(e, channel, teamId, workspace) ? { ...e, dirty: false } : e,
+        ),
+      });
+      return;
+    }
+    const remaining = store.entries.filter((e) => !sameKey(e, channel, teamId, workspace));
+    const otherChannels = remaining.filter((e) => e.channel !== channel);
+    const currentChannel = remaining.filter((e) => e.channel === channel);
     writeStore(fp, {
       ...store,
-      entries: store.entries.filter((e) => !sameKey(e, channel, teamId, workspace)),
+      entries: [...otherChannels, ...pruneRedundantBlankRows(currentChannel)],
     });
     return;
   }
@@ -336,11 +373,21 @@ export function importWorkspacePrefsIfNeeded(
   const incoming: WorkspacePrefsEntry[] = [];
   for (const pref of serverPrefs) {
     const row = asStoreRow(channel, pref);
-    if (row === null || isBlankRow(row)) continue;
+    if (row === null) continue;
     if (localKeys.has(prefKey(row.teamId, row.workspace))) continue;
     incoming.push(row);
   }
-  const entries = [...store.entries, ...incoming];
+  // 首次迁移前的既有本地行是正本，必须作为 dirty 行镜像；本次刚导入的 server 行
+  // 保持 clean，避免把 prefs.get 的旧快照无条件回写。
+  const combined = [
+    ...store.entries.map((row) => (row.channel === channel ? { ...row, dirty: true } : row)),
+    ...incoming,
+  ];
+  const channelRows = combined.filter((row) => row.channel === channel);
+  const retainedChannelRows = new Set(pruneRedundantBlankRows(channelRows));
+  const entries = combined.filter(
+    (row) => row.channel !== channel || retainedChannelRows.has(row),
+  );
   if (entries.length > HOOK_WORKSPACE_PREFS_MAX_ENTRIES) {
     throw new Error('too many workspace prefs entries');
   }
@@ -348,9 +395,8 @@ export function importWorkspacePrefsIfNeeded(
 }
 
 /**
- * /model 卡主动推送的全量快照：尚未镜像的本机墓碑优先（未同步的清空不能被救活），
- * 快照里已经没有该键时丢掉墓碑；已同步的本机实值若快照省略该键，视为卡片删除；
- * 尚未镜像的本机实值无论快照有没有同键都保留。快照里的实值只覆盖已同步行。
+ * /model 卡主动推送的全量快照：所有尚未镜像的本机写入优先；已同步行以 server 为准。
+ * team 空行在仍有 null-team 兜底时必须保留，避免该 team 的显式清空被兜底重新救活。
  */
 export function applyIncomingServerWorkspacePrefs(
   channel: HookPrefsChannel,
@@ -363,7 +409,7 @@ export function applyIncomingServerWorkspacePrefs(
   const serverByKey = new Map<string, WorkspacePrefsEntry>();
   for (const pref of serverPrefs) {
     const row = asStoreRow(channel, pref);
-    if (row === null || isBlankRow(row)) continue;
+    if (row === null) continue;
     serverByKey.set(prefKey(row.teamId, row.workspace), row);
   }
   const nextChannel: WorkspacePrefsEntry[] = [];
@@ -371,29 +417,69 @@ export function applyIncomingServerWorkspacePrefs(
   for (const localRow of local) {
     const key = prefKey(localRow.teamId, localRow.workspace);
     seen.add(key);
-    if (isBlankRow(localRow)) {
-      if (serverByKey.has(key)) nextChannel.push(localRow);
+    if (isDirtyRow(localRow)) {
+      nextChannel.push(localRow);
       continue;
     }
     const serverRow = serverByKey.get(key);
     if (serverRow) {
-      // 未镜像的本机实值不能被「别的目录」触发的全量快照盖掉。
-      if (isDirtyRow(localRow)) nextChannel.push(localRow);
-      else nextChannel.push({ ...serverRow, rev: rowRev(localRow), dirty: false });
+      nextChannel.push({ ...serverRow, rev: rowRev(localRow), dirty: false });
       continue;
     }
-    if (isDirtyRow(localRow)) nextChannel.push(localRow);
+    if (isBlankRow(localRow)) nextChannel.push(localRow);
   }
   for (const [key, serverRow] of serverByKey) {
     if (seen.has(key)) continue;
     nextChannel.push(serverRow);
   }
-  const entries = [...other, ...nextChannel];
+  const prunedChannel = pruneRedundantBlankRows(nextChannel);
+  const entries = [...other, ...prunedChannel];
   if (entries.length > HOOK_WORKSPACE_PREFS_MAX_ENTRIES) {
     throw new Error('too many workspace prefs entries');
   }
   writeStore(fp, { ...store, entries });
-  return nextChannel.map(toHookPrefs);
+  return prunedChannel.map(toHookPrefs);
+}
+
+export interface WorkspacePrefsMirrorCandidate {
+  prefs: HookWorkspacePrefs;
+  rev: number;
+}
+
+/**
+ * 渠道重连时先合并完整 server 快照，再返回需要镜像的本机完整行及其代次。
+ * 首次连接保留升级迁移语义；之后每次连接都吸收 /model 在离线期间的改动。
+ */
+export function reconcileWorkspacePrefsForMirror(
+  channel: HookPrefsChannel,
+  serverPrefs: HookWorkspacePrefs[],
+): WorkspacePrefsMirrorCandidate[] {
+  if (isWorkspacePrefsMigrated(channel)) {
+    applyIncomingServerWorkspacePrefs(channel, serverPrefs);
+  } else {
+    importWorkspacePrefsIfNeeded(channel, serverPrefs);
+  }
+  const channelRows = readStore(filePath()).entries.filter((row) => row.channel === channel);
+  return channelRows
+    .filter(shouldMirrorRow)
+    .map((row) => ({ prefs: toHookPrefs(row), rev: rowRev(row) }));
+}
+
+/** 发送镜像帧前再次确认候选仍是当前本地正本，关闭快照与逐行发送之间的竞态窗口。 */
+export function isWorkspacePrefsMirrorCandidateCurrent(
+  channel: HookPrefsChannel,
+  candidate: WorkspacePrefsMirrorCandidate,
+): boolean {
+  const channelRows = readStore(filePath()).entries.filter((row) => row.channel === channel);
+  const row = channelRows.find((entry) =>
+    sameKey(entry, channel, candidate.prefs.teamId ?? null, candidate.prefs.workspace),
+  );
+  return (
+    row !== undefined &&
+    rowRev(row) === candidate.rev &&
+    samePrefs(row, candidate.prefs) &&
+    shouldMirrorRow(row)
+  );
 }
 
 /**


### PR DESCRIPTION
<!--
PR Title 不是下面的正文标题，而是 GitHub PR 页面最上方的标题。
格式：<type>(<scope>): <简短描述>（scope 可省略）

type：feat / fix / refactor / perf / chore / docs / test / revert / build / ci
示例：docs(readme): 补充本地模式与远程开发说明；fix: 修复登录跳转
-->

## 这次改了什么

### 摘要

修复 PR #3475 合并后 IM 工作区偏好在 `/model` 与 `/new` 之间可能不同步的问题。客户端现在会在渠道重连时合并服务端完整快照，只镜像仍为本地最新版本的 dirty 行，并正确处理换绑、并发快照与 Slack team 级清空墓碑，避免旧快照覆盖新选择或让已清空配置重新继承默认值。

### 变更类型

- [ ] `feat` 新功能
- [x] `fix` 缺陷修复
- [ ] `refactor` / `perf` 重构或性能优化
- [ ] `docs` / `test` / `chore` 文档、测试或工程维护
- [ ] 其他：

### 范围

- 关联 Issue / 需求：PR #3475 合并后的客户端回归
- 本 PR 包含：Desktop 客户端 IM 工作区偏好的重连 reconciliation、dirty-only mirror、快照 generation 与 single-flight/换绑保护；Slack team 清空墓碑及首次迁移 all-null 行处理；对应单元测试
- 明确不包含：服务端修改、真实 Slack/Telegram/飞书环境配置、UI 改动、wire protocol shape 变化
- 用户可见变化：在 `/model` 修改目录模型后，后续 `/new` 能稳定读取同一偏好；重连或换绑不会被旧快照覆盖
- 是否存在 breaking change：无

### UI 变化

不涉及。

- 引用的设计规范：不涉及

## 怎么验证的

### 自动验证

```text
pnpm test:unit:related
结果：通过（apps/desktop related unit tests）

pnpm --filter desktop exec eslint src/main/hook-control/workspacePrefsStore.ts src/main/hook-control/workspacePrefsMirror.ts src/main/hook-control/ipc.ts src/main/hook-control/__tests__/workspacePrefsStore.test.ts src/main/hook-control/__tests__/workspacePrefsMirror.test.ts
结果：通过

pnpm --filter desktop run --if-present typecheck
结果：通过

git diff --check
结果：通过

pnpm check:dco
结果：通过（1 commit signed off）
```

### 手工验证

不涉及 UI；未连接真实 IM 渠道做端到端操作验证。

### 未执行的验证

未执行真实 Slack/Telegram/飞书绑定环境中的 `/model` → `/new` 端到端验证；本次通过覆盖重连、旧快照、换绑、并发写入、team 墓碑和首次迁移的单元测试验证客户端时序。

## 风险

### 风险分类

- [ ] 无已知风险
- [ ] SQLite / migration
- [ ] system prompt
- [ ] 协议兼容
- [ ] 权限 / 安全 / 用户数据
- [ ] 存量插件兼容（批准状态 / 指纹 / manifest 校验 / 安装布局 / 包格式）
- [ ] 原生层 / fingerprint / OTA
- [ ] 跨平台差异
- [x] 其他：IM 工作区偏好同步时序

### 影响与回滚

- 影响范围：Desktop 客户端 Slack、Telegram、飞书渠道的工作区偏好本地缓存与服务端镜像；不改变服务端接口或协议字段
- 回滚 / 降级方式：回退本 PR 的提交，恢复原有客户端镜像流程；无数据 schema 或 migration 需要回滚

### 提交前检查

- [x] 已 review 完整 diff
- [x] 每个 commit 都带 DCO 签名（`git commit -s`，见 [DCO](../DCO)）
- [ ] UI 改动已在「UI 变化」注明引用的设计规范章节（不涉及 UI 则跳过）
- [x] 未提交凭证、令牌或授权文件
- [x] 已补充必要文档
- [x] 已确认测试结果或说明未执行原因