### PR TITLE
fix(desktop): 本机新建发送后切走不再丢掉首条消息

### DIFF
--- a/apps/desktop/src/renderer/__tests__/newMakerLocalFirstMessageSend.test.ts
+++ b/apps/desktop/src/renderer/__tests__/newMakerLocalFirstMessageSend.test.ts
@@ -39,7 +39,9 @@ describe('NewMakerDraftRoute local first-message send', () => {
     const localSend = source.indexOf('const sendPromise = makerChatStore.sendMessage(', localFence);
     const pendingAfterSend = source.indexOf('setPending(newSession.id', localSend);
     expect(source).toContain('setPending(remoteSessionId, {');
-    expect(pendingSource).toContain('本机新建不走这里:草稿路由 createSession 后直接 sendMessage');
+    expect(pendingSource).toContain(
+      '本机新建的普通文本不走这里:草稿路由 createSession 后直接 sendMessage',
+    );
     expect(pendingAfterSend).toBe(-1);
   });
 
@@ -66,18 +68,21 @@ describe('NewMakerDraftRoute local first-message send', () => {
     expect(falseRestore).not.toBe(catchRestore);
   });
 
-  it('dispatches local /review from the draft route and keeps other desktop commands on SessionView', () => {
-    const reviewStart = source.indexOf('window.electronAPI.maker.startReview({', localFence);
-    const desktopPending = source.indexOf(
-      "if (hit?.kind === 'desktop') {",
+  it('hands slash-looking first messages to SessionView instead of copying desktop dispatch', () => {
+    const slashMatch = source.indexOf('const slashMatch = message.match(', localFence);
+    const pendingHandoff = source.indexOf('setPending(newSession.id, {', slashMatch);
+    const sendPromise = source.indexOf(
+      'const sendPromise = makerChatStore.sendMessage(',
       localFence,
     );
-    const pendingHandoff = source.indexOf('setPending(newSession.id, {', desktopPending);
+    const reviewStart = source.indexOf('window.electronAPI.maker.startReview({', localFence);
 
-    expect(reviewStart).toBeGreaterThan(localFence);
-    expect(desktopPending).toBeGreaterThan(localFence);
-    expect(pendingHandoff).toBeGreaterThan(desktopPending);
+    expect(slashMatch).toBeGreaterThan(localFence);
+    expect(pendingHandoff).toBeGreaterThan(slashMatch);
+    expect(pendingHandoff).toBeLessThan(sendPromise);
+    expect(reviewStart).toBe(-1);
     expect(sessionViewSource).toContain('const pending = consumePending(sessionId);');
-    expect(sessionViewSource).toContain('本机新建已在');
+    expect(sessionViewSource).toContain('maybeDispatchDesktopSlashCommand');
+    expect(sessionViewSource).toContain('本机普通文本已在草稿路由发出');
   });
 });

--- a/apps/desktop/src/renderer/__tests__/newMakerLocalFirstMessageSend.test.ts
+++ b/apps/desktop/src/renderer/__tests__/newMakerLocalFirstMessageSend.test.ts
@@ -63,6 +63,13 @@ describe('NewMakerDraftRoute local first-message send', () => {
     expect(fifoRestore).toBeGreaterThan(restore);
     expect(fifoRestore).toBeLessThan(catchRestore);
     expect(saveDraft).toBe(-1);
+    expect(source.slice(localSend, fifoRestore)).toContain(
+      'const preNavBrowserComments = preNavDraft?.browserComments ?? []',
+    );
+    expect(source.slice(fifoRestore, catchRestore)).toContain(
+      'browserComments: preNavBrowserComments',
+    );
+    expect(source.slice(fifoRestore, catchRestore)).not.toContain('browserComments: []');
     expect(catchRestore).toBeGreaterThan(fifoRestore);
     expect(falseRestore).toBeGreaterThan(fifoRestore);
     expect(falseRestore).not.toBe(catchRestore);

--- a/apps/desktop/src/renderer/__tests__/newMakerLocalFirstMessageSend.test.ts
+++ b/apps/desktop/src/renderer/__tests__/newMakerLocalFirstMessageSend.test.ts
@@ -29,35 +29,54 @@ describe('NewMakerDraftRoute local first-message send', () => {
       localFence,
     );
     const navigate = source.indexOf('navigateToSession();', sendMessage);
-    const pendingHandoff = source.indexOf('setPending(newSession.id', localFence);
 
     expect(localFence).toBeGreaterThan(-1);
     expect(sendMessage).toBeGreaterThan(localFence);
     expect(navigate).toBeGreaterThan(sendMessage);
-    expect(pendingHandoff).toBe(-1);
   });
 
-  it('does not register a memory-only pending payload for local new tasks', () => {
+  it('does not register a memory-only pending payload for ordinary local text', () => {
+    const localSend = source.indexOf('const sendPromise = makerChatStore.sendMessage(', localFence);
+    const pendingAfterSend = source.indexOf('setPending(newSession.id', localSend);
     expect(source).toContain('setPending(remoteSessionId, {');
-    expect(source).not.toContain('setPending(newSession.id');
     expect(pendingSource).toContain('本机新建不走这里:草稿路由 createSession 后直接 sendMessage');
+    expect(pendingAfterSend).toBe(-1);
   });
 
-  it('restores the first-message draft onto the created task if send throws', () => {
+  it('restores a rejected or thrown first send onto the created task without clobbering newer input', () => {
     const localSend = source.indexOf('const sendWorkingDir = workingDir ?? newSession.workingDir;');
     const restore = source.indexOf('const restoreFirstMessageDraft = () => {', localSend);
+    const fifoRestore = source.indexOf('restoreRemoteOptimisticDraft(newSession.id, {', restore);
     const saveDraft = source.indexOf('saveComposerDraft(newSession.id, {', restore);
     const catchRestore = source.indexOf(
       'restoreFirstMessageDraft();',
       source.indexOf("log.error('[draft send]', err);", localFence),
     );
+    const falseRestore = source.indexOf(
+      'restoreFirstMessageDraft();',
+      source.indexOf('} else {', source.indexOf('(accepted) => {', localFence)),
+    );
 
     expect(restore).toBeGreaterThan(localSend);
-    expect(saveDraft).toBeGreaterThan(restore);
-    expect(catchRestore).toBeGreaterThan(saveDraft);
+    expect(fifoRestore).toBeGreaterThan(restore);
+    expect(fifoRestore).toBeLessThan(catchRestore);
+    expect(saveDraft).toBe(-1);
+    expect(catchRestore).toBeGreaterThan(fifoRestore);
+    expect(falseRestore).toBeGreaterThan(fifoRestore);
+    expect(falseRestore).not.toBe(catchRestore);
   });
 
-  it('keeps remote delayed-create consumption on SessionView', () => {
+  it('dispatches local /review from the draft route and keeps other desktop commands on SessionView', () => {
+    const reviewStart = source.indexOf('window.electronAPI.maker.startReview({', localFence);
+    const desktopPending = source.indexOf(
+      "if (hit?.kind === 'desktop') {",
+      localFence,
+    );
+    const pendingHandoff = source.indexOf('setPending(newSession.id, {', desktopPending);
+
+    expect(reviewStart).toBeGreaterThan(localFence);
+    expect(desktopPending).toBeGreaterThan(localFence);
+    expect(pendingHandoff).toBeGreaterThan(desktopPending);
     expect(sessionViewSource).toContain('const pending = consumePending(sessionId);');
     expect(sessionViewSource).toContain('本机新建已在');
   });

--- a/apps/desktop/src/renderer/__tests__/newMakerLocalFirstMessageSend.test.ts
+++ b/apps/desktop/src/renderer/__tests__/newMakerLocalFirstMessageSend.test.ts
@@ -1,0 +1,64 @@
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+
+import { describe, expect, it } from 'vitest';
+
+const source = readFileSync(
+  resolve(__dirname, '..', 'features', 'cc-agent', 'NewMakerDraftRoute.tsx'),
+  'utf8',
+);
+
+const pendingSource = readFileSync(
+  resolve(__dirname, '..', 'state', 'pendingFirstMessage.ts'),
+  'utf8',
+);
+
+const sessionViewSource = readFileSync(
+  resolve(__dirname, '..', 'features', 'cc-agent', 'CCAgentSessionView.tsx'),
+  'utf8',
+);
+
+describe('NewMakerDraftRoute local first-message send', () => {
+  const localFence = source.indexOf(
+    '本机首条消息在草稿路由发出,不把发送绑在 SessionView hydrate 上。',
+  );
+
+  it('sends the local first message from the draft route before navigating', () => {
+    const sendMessage = source.indexOf(
+      'const sendPromise = makerChatStore.sendMessage(',
+      localFence,
+    );
+    const navigate = source.indexOf('navigateToSession();', sendMessage);
+    const pendingHandoff = source.indexOf('setPending(newSession.id', localFence);
+
+    expect(localFence).toBeGreaterThan(-1);
+    expect(sendMessage).toBeGreaterThan(localFence);
+    expect(navigate).toBeGreaterThan(sendMessage);
+    expect(pendingHandoff).toBe(-1);
+  });
+
+  it('does not register a memory-only pending payload for local new tasks', () => {
+    expect(source).toContain('setPending(remoteSessionId, {');
+    expect(source).not.toContain('setPending(newSession.id');
+    expect(pendingSource).toContain('本机新建不走这里:草稿路由 createSession 后直接 sendMessage');
+  });
+
+  it('restores the first-message draft onto the created task if send throws', () => {
+    const localSend = source.indexOf('const sendWorkingDir = workingDir ?? newSession.workingDir;');
+    const restore = source.indexOf('const restoreFirstMessageDraft = () => {', localSend);
+    const saveDraft = source.indexOf('saveComposerDraft(newSession.id, {', restore);
+    const catchRestore = source.indexOf(
+      'restoreFirstMessageDraft();',
+      source.indexOf("log.error('[draft send]', err);", localFence),
+    );
+
+    expect(restore).toBeGreaterThan(localSend);
+    expect(saveDraft).toBeGreaterThan(restore);
+    expect(catchRestore).toBeGreaterThan(saveDraft);
+  });
+
+  it('keeps remote delayed-create consumption on SessionView', () => {
+    expect(sessionViewSource).toContain('const pending = consumePending(sessionId);');
+    expect(sessionViewSource).toContain('本机新建已在');
+  });
+});

--- a/apps/desktop/src/renderer/__tests__/newMakerLocalFirstMessageSend.test.ts
+++ b/apps/desktop/src/renderer/__tests__/newMakerLocalFirstMessageSend.test.ts
@@ -76,7 +76,7 @@ describe('NewMakerDraftRoute local first-message send', () => {
     expect(fifoRestore).toBeLessThan(catchRestore);
     expect(saveDraft).toBe(-1);
     expect(source.slice(localSend, fifoRestore)).toContain(
-      'const preNavBrowserComments = preNavDraft?.browserComments ?? []',
+      'rehomeDraftBrowserComments(preNavDraft?.browserComments, newSession.id)',
     );
     expect(source.slice(fifoRestore, catchRestore)).toContain(
       'browserComments: preNavBrowserComments',

--- a/apps/desktop/src/renderer/__tests__/newMakerLocalFirstMessageSend.test.ts
+++ b/apps/desktop/src/renderer/__tests__/newMakerLocalFirstMessageSend.test.ts
@@ -70,6 +70,7 @@ describe('NewMakerDraftRoute local first-message send', () => {
 
   it('hands slash-looking first messages to SessionView instead of copying desktop dispatch', () => {
     const slashMatch = source.indexOf('const slashMatch = message.match(', localFence);
+    const leading = source.indexOf('leadingSlashInvocation(message)', slashMatch);
     const pendingHandoff = source.indexOf('setPending(newSession.id, {', slashMatch);
     const sendPromise = source.indexOf(
       'const sendPromise = makerChatStore.sendMessage(',
@@ -78,11 +79,15 @@ describe('NewMakerDraftRoute local first-message send', () => {
     const reviewStart = source.indexOf('window.electronAPI.maker.startReview({', localFence);
 
     expect(slashMatch).toBeGreaterThan(localFence);
+    expect(leading).toBeGreaterThan(slashMatch);
+    expect(leading).toBeLessThan(pendingHandoff);
     expect(pendingHandoff).toBeGreaterThan(slashMatch);
     expect(pendingHandoff).toBeLessThan(sendPromise);
     expect(reviewStart).toBe(-1);
+    expect(source.slice(slashMatch, pendingHandoff)).toContain("capabilityAgentKind === 'pi'");
     expect(sessionViewSource).toContain('const pending = consumePending(sessionId);');
     expect(sessionViewSource).toContain('maybeDispatchDesktopSlashCommand');
+    expect(sessionViewSource).toContain('leadingSlashInvocation(message)');
     expect(sessionViewSource).toContain('本机普通文本已在草稿路由发出');
   });
 });

--- a/apps/desktop/src/renderer/__tests__/newMakerLocalFirstMessageSend.test.ts
+++ b/apps/desktop/src/renderer/__tests__/newMakerLocalFirstMessageSend.test.ts
@@ -76,7 +76,10 @@ describe('NewMakerDraftRoute local first-message send', () => {
     expect(fifoRestore).toBeLessThan(catchRestore);
     expect(saveDraft).toBe(-1);
     expect(source.slice(localSend, fifoRestore)).toContain(
-      'rehomeDraftBrowserComments(preNavDraft?.browserComments, newSession.id)',
+      'rewriteBrowserCommentsFromRehomedFiles(',
+    );
+    expect(source.slice(fifoRestore, catchRestore)).toContain(
+      'excludeCommentScreenshots(rehydratedFiles, preNavBrowserComments)',
     );
     expect(source.slice(fifoRestore, catchRestore)).toContain(
       'browserComments: preNavBrowserComments',

--- a/apps/desktop/src/renderer/__tests__/newMakerLocalFirstMessageSend.test.ts
+++ b/apps/desktop/src/renderer/__tests__/newMakerLocalFirstMessageSend.test.ts
@@ -35,6 +35,18 @@ describe('NewMakerDraftRoute local first-message send', () => {
     expect(navigate).toBeGreaterThan(sendMessage);
   });
 
+  it('seeds remoteHostId into chat store before the draft-route first send', () => {
+    const seed = source.indexOf(
+      'makerChatStore.setSessionRuntime(newSession.id, {',
+      source.indexOf("workspaceKind: workingDir ? 'project' : 'dialogue'"),
+    );
+    const seedBlock = source.slice(seed, source.indexOf('});', seed) + 3);
+
+    expect(seed).toBeGreaterThan(-1);
+    expect(seed).toBeLessThan(localFence);
+    expect(seedBlock).toContain('remoteHostId: workingDir ? (effectiveRemoteHostId ?? null) : null');
+  });
+
   it('does not register a memory-only pending payload for ordinary local text', () => {
     const localSend = source.indexOf('const sendPromise = makerChatStore.sendMessage(', localFence);
     const pendingAfterSend = source.indexOf('setPending(newSession.id', localSend);

--- a/apps/desktop/src/renderer/__tests__/newMakerWorktreeSend.test.ts
+++ b/apps/desktop/src/renderer/__tests__/newMakerWorktreeSend.test.ts
@@ -93,7 +93,10 @@ describe('NewMakerDraftRoute worktree send flow', () => {
       'browserComments: rehomedComments',
     );
     expect(source.slice(restoreHelper, failedCard)).toContain(
-      'rehomeDraftBrowserComments(preNavBrowserComments, newSession.id)',
+      'rewriteBrowserCommentsFromRehomedFiles(',
+    );
+    expect(source.slice(restoreHelper, failedCard)).toContain(
+      'excludeCommentScreenshots(rehomedFiles, rehomedComments)',
     );
   });
 

--- a/apps/desktop/src/renderer/__tests__/newMakerWorktreeSend.test.ts
+++ b/apps/desktop/src/renderer/__tests__/newMakerWorktreeSend.test.ts
@@ -90,7 +90,10 @@ describe('NewMakerDraftRoute worktree send flow', () => {
     expect(saveDraft).toBeGreaterThan(failedCard);
     expect(restoreText).toBeGreaterThan(restoreHelper);
     expect(source.slice(restoreHelper, restoreHelper + 500)).toContain(
-      'browserComments: preNavBrowserComments',
+      'browserComments: rehomedComments',
+    );
+    expect(source.slice(restoreHelper, failedCard)).toContain(
+      'rehomeDraftBrowserComments(preNavBrowserComments, newSession.id)',
     );
   });
 

--- a/apps/desktop/src/renderer/__tests__/newMakerWorktreeSend.test.ts
+++ b/apps/desktop/src/renderer/__tests__/newMakerWorktreeSend.test.ts
@@ -89,6 +89,9 @@ describe('NewMakerDraftRoute worktree send flow', () => {
     expect(restoreHelper).toBeGreaterThan(-1);
     expect(saveDraft).toBeGreaterThan(failedCard);
     expect(restoreText).toBeGreaterThan(restoreHelper);
+    expect(source.slice(restoreHelper, restoreHelper + 500)).toContain(
+      'browserComments: preNavBrowserComments',
+    );
   });
 
   it('does not make the new worktree path the next New Maker default project', () => {

--- a/apps/desktop/src/renderer/features/cc-agent/CCAgentSessionView.tsx
+++ b/apps/desktop/src/renderer/features/cc-agent/CCAgentSessionView.tsx
@@ -3730,9 +3730,10 @@ export function CCAgentSessionView({
     [sessionId, t],
   );
 
-  // delayed-create:从 NewMakerDraftRoute 经 navigate 进来的首条消息,在 session
-  // 完全 hydrate(historyLoaded + workingDir 就位)后自动 sendMessage。
-  // 一次性消费 + ref guard,防 StrictMode 双 mount / 重渲染时重复发送。
+  // delayed-create:device-link / 远程草稿把首条登记在 pending 里,等 session
+  // 完全 hydrate(historyLoaded + workingDir 就位)后再 sendMessage。本机新建已在
+  // 草稿路由发出,不会 setPending。一次性消费 + ref guard,防 StrictMode 双 mount /
+  // 重渲染时重复发送。
   const pendingConsumedRef = useRef(false);
   useEffect(() => {
     if (!sessionId || !historyLoaded || !session) return;

--- a/apps/desktop/src/renderer/features/cc-agent/CCAgentSessionView.tsx
+++ b/apps/desktop/src/renderer/features/cc-agent/CCAgentSessionView.tsx
@@ -3730,10 +3730,10 @@ export function CCAgentSessionView({
     [sessionId, t],
   );
 
-  // delayed-create:device-link / 远程草稿把首条登记在 pending 里,等 session
-  // 完全 hydrate(historyLoaded + workingDir 就位)后再 sendMessage。本机新建已在
-  // 草稿路由发出,不会 setPending。一次性消费 + ref guard,防 StrictMode 双 mount /
-  // 重渲染时重复发送。
+  // delayed-create:device-link / 远程草稿,以及本机以 `/` 开头的首条,把内容登记在
+  // pending 里,等 session 完全 hydrate 后再由 maybeDispatchDesktopSlashCommand /
+  // sendMessage 消费。本机普通文本已在草稿路由发出。一次性消费 + ref guard,防
+  // StrictMode 双 mount / 重渲染时重复发送。
   const pendingConsumedRef = useRef(false);
   useEffect(() => {
     if (!sessionId || !historyLoaded || !session) return;

--- a/apps/desktop/src/renderer/features/cc-agent/CCAgentSessionView.tsx
+++ b/apps/desktop/src/renderer/features/cc-agent/CCAgentSessionView.tsx
@@ -3730,7 +3730,7 @@ export function CCAgentSessionView({
     [sessionId, t],
   );
 
-  // delayed-create:device-link / 远程草稿,以及本机以 `/` 开头的首条,把内容登记在
+  // delayed-create:device-link / 远程草稿,以及本机斜杠命令首条(含 Pi 空白前缀),把内容登记在
   // pending 里,等 session 完全 hydrate 后再由 maybeDispatchDesktopSlashCommand /
   // sendMessage 消费。本机普通文本已在草稿路由发出。一次性消费 + ref guard,防
   // StrictMode 双 mount / 重渲染时重复发送。

--- a/apps/desktop/src/renderer/features/cc-agent/NewMakerDraftRoute.tsx
+++ b/apps/desktop/src/renderer/features/cc-agent/NewMakerDraftRoute.tsx
@@ -19,7 +19,7 @@
  *           - 未就绪 → 弹通用 confirmDialog → 跳 settings → 中止
  *        b. 本机普通路径: createSession → sendMessage → navigate。首条消息在草稿
  *           路由发出,不把发送绑在 SessionView hydrate 上;切走只换画面。
- *           以 `/` 开头的首条仍 setPending,交给 SessionView 做完整 desktop / Pi 分派。
+ *           SessionView 会当成斜杠命令的首条(列首 /cmd,以及 Pi 空白前缀)仍 setPending。
  *        c. Worktree 路径: 先 createSession + 插入状态卡 + navigate,再后台
  *           createWorktree；成功后更新 workingDir 并发送首条消息，失败则把原消息
  *           存回该 session 的 composer draft 供用户重试
@@ -149,6 +149,7 @@ import { cleanupStagedChatAttachmentFiles } from '@/lib/chatAttachmentStageClean
 import type { GoalLimitValues } from '@/components/new-chat/GoalAdvancedLimits';
 import { makerChatStore } from '@/lib/makerChatStore';
 import {
+  leadingSlashInvocation,
   rebaseInlineRangesAfterSlashCommandRewrite,
   rewritePiSkillMessageForSend,
 } from '@/lib/slashCommands';
@@ -4233,9 +4234,14 @@ export function NewMakerDraftRoute() {
 
           try {
             // 斜杠命令必须走 SessionView 的完整分派(SSH skipAgentSkills、远端 /review
-            // 拒绝、Pi runtime 重试)。草稿路由只识别「整条都是 /cmd」并交接,不复制那套逻辑。
+            // 拒绝、Pi runtime 重试)。识别窗口与 maybeDispatchDesktopSlashCommand 相同:
+            // 列首 /cmd,以及 Pi 的空白前缀 /cmd;草稿路由只交接,不复制分派逻辑。
             const slashMatch = message.match(/^\/(\S+)(?:\s+(.*))?$/s);
-            if (slashMatch) {
+            const leading =
+              !slashMatch && capabilityAgentKind === 'pi'
+                ? leadingSlashInvocation(message)
+                : undefined;
+            if (slashMatch || leading) {
               setPending(newSession.id, {
                 text: message,
                 files: rehydratedFiles,

--- a/apps/desktop/src/renderer/features/cc-agent/NewMakerDraftRoute.tsx
+++ b/apps/desktop/src/renderer/features/cc-agent/NewMakerDraftRoute.tsx
@@ -3914,7 +3914,9 @@ export function NewMakerDraftRoute() {
             // 不会暴露 cleared 后的视觉状态。clearFiles 仍然在 React 提交 unmount cleanup
             // 之前同步执行,所以 useAttachments 的 cleanup 不会把刚送出去的附件回写到 store。
             // 保存原始 doc JSON(含 quickStartPill 等 mark),供 worktree 失败恢复时原样还原。
-            const preNavDraftDoc = getComposerDraft(NEW_MAKER_DRAFT_KEY)?.text ?? null;
+            const preNavDraft = getComposerDraft(NEW_MAKER_DRAFT_KEY);
+            const preNavDraftDoc = preNavDraft?.text ?? null;
+            const preNavBrowserComments = preNavDraft?.browserComments ?? [];
             navigate(`/cc-agent/${newSession.id}`, { replace: true });
             // clearDraftAndNotify (not bare clear): onSend returned false above
             // so ChatInput never cleared its editor — without notifying it, the
@@ -3934,6 +3936,7 @@ export function NewMakerDraftRoute() {
                 saveComposerDraft(newSession.id, {
                   text: preNavDraftDoc ?? plainTextToTiptapDoc(message),
                   attachments: rehomedFiles ?? [],
+                  browserComments: preNavBrowserComments,
                 });
                 // 第一条消息退回草稿 = 它没被交出去,也就永远不会有权威标题回流。
                 // 不撤回的话标题预览会一直盖着 DB 里的哨兵(每次全量刷新后重新盖上),
@@ -4193,14 +4196,16 @@ export function NewMakerDraftRoute() {
           // URL。必须在发出首条之前,否则消息里还是草稿命名空间。
           const rehydratedFiles = await rehomeDraftAttachments(files, newSession.id);
           const sendWorkingDir = workingDir ?? newSession.workingDir;
-          const preNavDraftDoc = getComposerDraft(NEW_MAKER_DRAFT_KEY)?.text ?? null;
+          const preNavDraft = getComposerDraft(NEW_MAKER_DRAFT_KEY);
+          const preNavDraftDoc = preNavDraft?.text ?? null;
+          const preNavBrowserComments = preNavDraft?.browserComments ?? [];
           const restoreFirstMessageDraft = () => {
             // FIFO 插回失败的首条,不覆盖用户在等待期间已经写进新任务输入框的内容。
             restoreRemoteOptimisticDraft(newSession.id, {
               clientId: `local-first:${newSession.id}`,
               text: preNavDraftDoc ?? plainTextToTiptapDoc(message),
               attachments: rehydratedFiles ?? [],
-              browserComments: [],
+              browserComments: preNavBrowserComments,
             });
             emitAutoTitlePreviewCleared(newSession.id);
             clearSessionStarting(newSession.id);

--- a/apps/desktop/src/renderer/features/cc-agent/NewMakerDraftRoute.tsx
+++ b/apps/desktop/src/renderer/features/cc-agent/NewMakerDraftRoute.tsx
@@ -127,6 +127,7 @@ import {
   getDraft as getComposerDraft,
   plainTextToTiptapDoc,
   quickStartTextToTiptapDoc,
+  restoreRemoteOptimisticDraft,
   saveDraft as saveComposerDraft,
 } from '@/lib/composerDraftStore';
 import type { JSONContent } from '@tiptap/core';
@@ -146,8 +147,11 @@ import { NewGoalDialog } from '@/components/new-chat/NewGoalDialog';
 import { cleanupStagedChatAttachmentFiles } from '@/lib/chatAttachmentStageCleanup';
 import type { GoalLimitValues } from '@/components/new-chat/GoalAdvancedLimits';
 import { makerChatStore } from '@/lib/makerChatStore';
+import { serializeAttachedFiles } from '@/lib/messageAttachmentPayload';
 import {
+  loadAllCommands,
   rebaseInlineRangesAfterSlashCommandRewrite,
+  reconcilePiRuntimeCommandForDispatch,
   rewritePiSkillMessageForSend,
 } from '@/lib/slashCommands';
 import { worktreeCreationStore } from '@/lib/worktreeCreationStore';
@@ -4192,9 +4196,12 @@ export function NewMakerDraftRoute() {
           const sendWorkingDir = workingDir ?? newSession.workingDir;
           const preNavDraftDoc = getComposerDraft(NEW_MAKER_DRAFT_KEY)?.text ?? null;
           const restoreFirstMessageDraft = () => {
-            saveComposerDraft(newSession.id, {
+            // FIFO 插回失败的首条,不覆盖用户在等待期间已经写进新任务输入框的内容。
+            restoreRemoteOptimisticDraft(newSession.id, {
+              clientId: `local-first:${newSession.id}`,
               text: preNavDraftDoc ?? plainTextToTiptapDoc(message),
               attachments: rehydratedFiles ?? [],
+              browserComments: [],
             });
             emitAutoTitlePreviewCleared(newSession.id);
             clearSessionStarting(newSession.id);
@@ -4227,6 +4234,81 @@ export function NewMakerDraftRoute() {
           }
 
           try {
+            const slashMatch = message.match(/^\/(\S+)(?:\s+(.*))?$/s);
+            if (slashMatch) {
+              const cmdName = slashMatch[1].toLowerCase();
+              const args = slashMatch[2] ?? '';
+              const commands = await loadAllCommands(capabilityAgentKind, sendWorkingDir, {
+                sessionId: newSession.id,
+              });
+              const { command: hit } = await reconcilePiRuntimeCommandForDispatch({
+                agentKind: capabilityAgentKind,
+                sessionId: newSession.id,
+                commandName: cmdName,
+                commands,
+                reload: () =>
+                  loadAllCommands(capabilityAgentKind, sendWorkingDir, {
+                    sessionId: newSession.id,
+                    forceReload: true,
+                  }),
+              });
+              if (hit?.kind === 'desktop') {
+                if (hit.name === 'review') {
+                  const attachments = rehydratedFiles?.length
+                    ? serializeAttachedFiles(rehydratedFiles)
+                    : undefined;
+                  try {
+                    await window.electronAPI.maker.startReview({
+                      sourceSessionId: newSession.id,
+                      ...(args.trim() ? { focus: args.trim() } : {}),
+                      ...(attachments?.length ? { attachments } : {}),
+                    });
+                    handOffDraftToSession();
+                    navigateToSession();
+                    opts?.onAccepted?.();
+                    void dispatchDeferredUiAssignment(newSession.id, deferredUiAssignment, {
+                      waitForLeadHistory: false,
+                    }).catch((err) => {
+                      log.error('[draft send] deferred Worker assignment after /review failed', err);
+                      toast.error(t('newChat.collaboration.assignmentFailed'));
+                    });
+                  } catch (err) {
+                    const ipcError = extractIpcError(err);
+                    toast.error(
+                      ipcError
+                        ? t('review.toast.failed')
+                        : err instanceof Error
+                          ? err.message
+                          : t('review.toast.failed'),
+                    );
+                    restoreFirstMessageDraft();
+                    handOffDraftToSession();
+                    navigateToSession();
+                  }
+                  return;
+                }
+                // /help /issue /cmd 等依赖 SessionView 挂上后再消费 DESKTOP_COMMAND_TRIGGERED。
+                setPending(newSession.id, {
+                  text: message,
+                  files: rehydratedFiles,
+                  mentions,
+                  ...(opts?.quotesEncoded ? { quotesEncoded: true } : {}),
+                  ...(opts?.agentReferences?.length ? { agentReferences: opts.agentReferences } : {}),
+                  ...(opts?.pastedTextRanges?.length
+                    ? { pastedTextRanges: opts.pastedTextRanges }
+                    : {}),
+                  ...(opts?.slashCommandRanges !== undefined
+                    ? { slashCommandRanges: opts.slashCommandRanges }
+                    : {}),
+                  ...(deferredUiAssignment ? { deferredUiAssignment } : {}),
+                });
+                opts?.onAccepted?.();
+                handOffDraftToSession();
+                navigateToSession();
+                return;
+              }
+            }
+
             const dispatchedMessage = await rewritePiSkillMessageForSend({
               agentKind: capabilityAgentKind,
               message,
@@ -4277,8 +4359,11 @@ export function NewMakerDraftRoute() {
                       toast.error(t('newChat.collaboration.assignmentFailed'));
                     },
                   );
-                } else if (deferredUiAssignment) {
-                  toast.error(t('newChat.collaboration.assignmentFailed'));
+                } else {
+                  restoreFirstMessageDraft();
+                  if (deferredUiAssignment) {
+                    toast.error(t('newChat.collaboration.assignmentFailed'));
+                  }
                 }
               },
               (err) => {

--- a/apps/desktop/src/renderer/features/cc-agent/NewMakerDraftRoute.tsx
+++ b/apps/desktop/src/renderer/features/cc-agent/NewMakerDraftRoute.tsx
@@ -574,6 +574,19 @@ async function rehomeDraftAttachments(
   return rehomed;
 }
 
+async function rehomeDraftBrowserComments<T extends { screenshot: AttachedFile }>(
+  comments: T[] | undefined,
+  sessionId: string,
+): Promise<T[] | undefined> {
+  if (!comments || comments.length === 0) return comments;
+  return Promise.all(
+    comments.map(async (comment) => {
+      const rehomed = await rehomeDraftAttachments([comment.screenshot], sessionId);
+      return rehomed?.[0] ? { ...comment, screenshot: rehomed[0] } : comment;
+    }),
+  );
+}
+
 function getCurrentRoutePath(): string {
   const raw =
     window.location.hash.startsWith('#') && window.location.hash.length > 1
@@ -2490,15 +2503,10 @@ export function NewMakerDraftRoute() {
             existingDraft.attachments.filter((attachment) => attachment.category !== 'image'),
           );
           const rehomedAttachments = await rehomeDraftAttachments(imageOnly, newSession.id);
-          let rehomedComments = existingDraft.browserComments;
-          if (rehomedComments && rehomedComments.length > 0) {
-            rehomedComments = await Promise.all(
-              rehomedComments.map(async (c) => {
-                const rehomed = await rehomeDraftAttachments([c.screenshot], newSession.id);
-                return rehomed?.[0] ? { ...c, screenshot: rehomed[0] } : c;
-              }),
-            );
-          }
+          const rehomedComments = await rehomeDraftBrowserComments(
+            existingDraft.browserComments,
+            newSession.id,
+          );
           // SSH 环境下本地 @file/@dir mention 无效,从 Tiptap 文档中剥离。
           const strippedText = existingDraft.text
             ? stripLocalMentionChips(existingDraft.text)
@@ -3934,11 +3942,12 @@ export function NewMakerDraftRoute() {
               // 真实会话消息(删会话清不到)。初始值取原 files:rehome 自身抛错时
               // 走 catch 恢复原附件,行为与迁移前一致(fail-soft)。
               let rehomedFiles = files;
+              let rehomedComments = preNavBrowserComments;
               const restoreFirstMessageDraft = () => {
                 saveComposerDraft(newSession.id, {
                   text: preNavDraftDoc ?? plainTextToTiptapDoc(message),
                   attachments: rehomedFiles ?? [],
-                  browserComments: preNavBrowserComments,
+                  browserComments: rehomedComments,
                 });
                 // 第一条消息退回草稿 = 它没被交出去,也就永远不会有权威标题回流。
                 // 不撤回的话标题预览会一直盖着 DB 里的哨兵(每次全量刷新后重新盖上),
@@ -3950,6 +3959,8 @@ export function NewMakerDraftRoute() {
               };
               try {
                 rehomedFiles = await rehomeDraftAttachments(files, newSession.id);
+                rehomedComments =
+                  (await rehomeDraftBrowserComments(preNavBrowserComments, newSession.id)) ?? [];
                 const resp = await window.electronAPI.worktreeCreate({
                   sessionId: newSession.id,
                   baseRepo,
@@ -4201,7 +4212,8 @@ export function NewMakerDraftRoute() {
           const sendWorkingDir = workingDir ?? newSession.workingDir;
           const preNavDraft = getComposerDraft(NEW_MAKER_DRAFT_KEY);
           const preNavDraftDoc = preNavDraft?.text ?? null;
-          const preNavBrowserComments = preNavDraft?.browserComments ?? [];
+          const preNavBrowserComments =
+            (await rehomeDraftBrowserComments(preNavDraft?.browserComments, newSession.id)) ?? [];
           const restoreFirstMessageDraft = () => {
             // FIFO 插回失败的首条,不覆盖用户在等待期间已经写进新任务输入框的内容。
             restoreRemoteOptimisticDraft(newSession.id, {

--- a/apps/desktop/src/renderer/features/cc-agent/NewMakerDraftRoute.tsx
+++ b/apps/desktop/src/renderer/features/cc-agent/NewMakerDraftRoute.tsx
@@ -2475,6 +2475,7 @@ export function NewMakerDraftRoute() {
           agentKind: dbToMakerAgentKind(draftVendor),
           fastMode: sshFastMode,
           planModeEnabled: effectivePlanMode,
+          remoteHostId: target.hostId,
         });
         // 把草稿页已输入的文本/附件移交到新会话,避免 navigate 后丢失。
         // rehomeDraftAttachments 把 base64 和 xdt-image://__new_maker_draft__/ 迁移到
@@ -3902,6 +3903,7 @@ export function NewMakerDraftRoute() {
               agentKind: persistedAgentKind === 'cc' ? 'claude-code' : persistedAgentKind,
               fastMode: effectiveFastMode,
               planModeEnabled: effectivePlanMode,
+              remoteHostId: effectiveRemoteHostId ?? null,
             });
             worktreeCreationStore.set(newSession.id, {
               status: 'creating',
@@ -4137,14 +4139,15 @@ export function NewMakerDraftRoute() {
           carryDraftFavoriteAnchorToSession(newSession.id, persistedAgentKind, model, providerId);
           // 计划模式是一次性选择:随本次发送被消耗,草稿勾选同步熄灭。
           if (effectivePlanMode) patchActivePrefs({ planMode: false });
-          // 本机首条在下面直接 sendMessage,createOpts 读 chat store 的
-          // planModeEnabled —— ensureInitialMessages 的行水合是异步的,必须先确定性
-          // seed store,否则勾了计划模式的首条消息可能以 planMode:false 发出
-          // (worktree 路径同款 seed;bot review P2)。
+          // 本机/SSH 首条在下面直接 sendMessage,createOpts 读 chat store 的
+          // planModeEnabled / remoteHostId —— ensureInitialMessages 的行水合是异步的,
+          // 必须先确定性 seed store,否则勾了计划模式的首条可能以 planMode:false 发出,
+          // SSH 首条会把远端路径当本机 workdir(worktree 路径同款 seed)。
           makerChatStore.setSessionRuntime(newSession.id, {
             agentKind: capabilityAgentKind,
             fastMode: effectiveFastMode,
             planModeEnabled: effectivePlanMode,
+            remoteHostId: workingDir ? (effectiveRemoteHostId ?? null) : null,
           });
 
           // "创建即发送"路径:乐观回写 userSendAt 跳过 projectGrouping 的草稿兜底

--- a/apps/desktop/src/renderer/features/cc-agent/NewMakerDraftRoute.tsx
+++ b/apps/desktop/src/renderer/features/cc-agent/NewMakerDraftRoute.tsx
@@ -587,6 +587,28 @@ async function rehomeDraftBrowserComments<T extends { screenshot: AttachedFile }
   );
 }
 
+function rewriteBrowserCommentsFromRehomedFiles<T extends { screenshot: AttachedFile }>(
+  comments: T[] | undefined,
+  rehomedFiles: AttachedFile[] | undefined,
+): T[] {
+  if (!comments?.length) return comments ?? [];
+  const byId = new Map((rehomedFiles ?? []).map((file) => [file.id, file]));
+  return comments.map((comment) => {
+    const screenshot = byId.get(comment.screenshot.id);
+    return screenshot ? { ...comment, screenshot } : comment;
+  });
+}
+
+function excludeCommentScreenshots(
+  files: AttachedFile[] | undefined,
+  comments: readonly { screenshot: AttachedFile }[],
+): AttachedFile[] {
+  if (!files?.length) return files ?? [];
+  if (comments.length === 0) return files;
+  const commentIds = new Set(comments.map((comment) => comment.screenshot.id));
+  return files.filter((file) => !commentIds.has(file.id));
+}
+
 function getCurrentRoutePath(): string {
   const raw =
     window.location.hash.startsWith('#') && window.location.hash.length > 1
@@ -3946,7 +3968,7 @@ export function NewMakerDraftRoute() {
               const restoreFirstMessageDraft = () => {
                 saveComposerDraft(newSession.id, {
                   text: preNavDraftDoc ?? plainTextToTiptapDoc(message),
-                  attachments: rehomedFiles ?? [],
+                  attachments: excludeCommentScreenshots(rehomedFiles, rehomedComments),
                   browserComments: rehomedComments,
                 });
                 // 第一条消息退回草稿 = 它没被交出去,也就永远不会有权威标题回流。
@@ -3959,8 +3981,10 @@ export function NewMakerDraftRoute() {
               };
               try {
                 rehomedFiles = await rehomeDraftAttachments(files, newSession.id);
-                rehomedComments =
-                  (await rehomeDraftBrowserComments(preNavBrowserComments, newSession.id)) ?? [];
+                rehomedComments = rewriteBrowserCommentsFromRehomedFiles(
+                  preNavBrowserComments,
+                  rehomedFiles,
+                );
                 const resp = await window.electronAPI.worktreeCreate({
                   sessionId: newSession.id,
                   baseRepo,
@@ -4212,14 +4236,16 @@ export function NewMakerDraftRoute() {
           const sendWorkingDir = workingDir ?? newSession.workingDir;
           const preNavDraft = getComposerDraft(NEW_MAKER_DRAFT_KEY);
           const preNavDraftDoc = preNavDraft?.text ?? null;
-          const preNavBrowserComments =
-            (await rehomeDraftBrowserComments(preNavDraft?.browserComments, newSession.id)) ?? [];
+          const preNavBrowserComments = rewriteBrowserCommentsFromRehomedFiles(
+            preNavDraft?.browserComments,
+            rehydratedFiles,
+          );
           const restoreFirstMessageDraft = () => {
             // FIFO 插回失败的首条,不覆盖用户在等待期间已经写进新任务输入框的内容。
             restoreRemoteOptimisticDraft(newSession.id, {
               clientId: `local-first:${newSession.id}`,
               text: preNavDraftDoc ?? plainTextToTiptapDoc(message),
-              attachments: rehydratedFiles ?? [],
+              attachments: excludeCommentScreenshots(rehydratedFiles, preNavBrowserComments),
               browserComments: preNavBrowserComments,
             });
             emitAutoTitlePreviewCleared(newSession.id);

--- a/apps/desktop/src/renderer/features/cc-agent/NewMakerDraftRoute.tsx
+++ b/apps/desktop/src/renderer/features/cc-agent/NewMakerDraftRoute.tsx
@@ -19,6 +19,7 @@
  *           - 未就绪 → 弹通用 confirmDialog → 跳 settings → 中止
  *        b. 本机普通路径: createSession → sendMessage → navigate。首条消息在草稿
  *           路由发出,不把发送绑在 SessionView hydrate 上;切走只换画面。
+ *           以 `/` 开头的首条仍 setPending,交给 SessionView 做完整 desktop / Pi 分派。
  *        c. Worktree 路径: 先 createSession + 插入状态卡 + navigate,再后台
  *           createWorktree；成功后更新 workingDir 并发送首条消息，失败则把原消息
  *           存回该 session 的 composer draft 供用户重试
@@ -147,11 +148,8 @@ import { NewGoalDialog } from '@/components/new-chat/NewGoalDialog';
 import { cleanupStagedChatAttachmentFiles } from '@/lib/chatAttachmentStageCleanup';
 import type { GoalLimitValues } from '@/components/new-chat/GoalAdvancedLimits';
 import { makerChatStore } from '@/lib/makerChatStore';
-import { serializeAttachedFiles } from '@/lib/messageAttachmentPayload';
 import {
-  loadAllCommands,
   rebaseInlineRangesAfterSlashCommandRewrite,
-  reconcilePiRuntimeCommandForDispatch,
   rewritePiSkillMessageForSend,
 } from '@/lib/slashCommands';
 import { worktreeCreationStore } from '@/lib/worktreeCreationStore';
@@ -4234,79 +4232,27 @@ export function NewMakerDraftRoute() {
           }
 
           try {
+            // 斜杠命令必须走 SessionView 的完整分派(SSH skipAgentSkills、远端 /review
+            // 拒绝、Pi runtime 重试)。草稿路由只识别「整条都是 /cmd」并交接,不复制那套逻辑。
             const slashMatch = message.match(/^\/(\S+)(?:\s+(.*))?$/s);
             if (slashMatch) {
-              const cmdName = slashMatch[1].toLowerCase();
-              const args = slashMatch[2] ?? '';
-              const commands = await loadAllCommands(capabilityAgentKind, sendWorkingDir, {
-                sessionId: newSession.id,
+              setPending(newSession.id, {
+                text: message,
+                files: rehydratedFiles,
+                mentions,
+                ...(opts?.quotesEncoded ? { quotesEncoded: true } : {}),
+                ...(opts?.agentReferences?.length ? { agentReferences: opts.agentReferences } : {}),
+                ...(opts?.pastedTextRanges?.length
+                  ? { pastedTextRanges: opts.pastedTextRanges }
+                  : {}),
+                ...(opts?.slashCommandRanges !== undefined
+                  ? { slashCommandRanges: opts.slashCommandRanges }
+                  : {}),
+                ...(deferredUiAssignment ? { deferredUiAssignment } : {}),
               });
-              const { command: hit } = await reconcilePiRuntimeCommandForDispatch({
-                agentKind: capabilityAgentKind,
-                sessionId: newSession.id,
-                commandName: cmdName,
-                commands,
-                reload: () =>
-                  loadAllCommands(capabilityAgentKind, sendWorkingDir, {
-                    sessionId: newSession.id,
-                    forceReload: true,
-                  }),
-              });
-              if (hit?.kind === 'desktop') {
-                if (hit.name === 'review') {
-                  const attachments = rehydratedFiles?.length
-                    ? serializeAttachedFiles(rehydratedFiles)
-                    : undefined;
-                  try {
-                    await window.electronAPI.maker.startReview({
-                      sourceSessionId: newSession.id,
-                      ...(args.trim() ? { focus: args.trim() } : {}),
-                      ...(attachments?.length ? { attachments } : {}),
-                    });
-                    handOffDraftToSession();
-                    navigateToSession();
-                    opts?.onAccepted?.();
-                    void dispatchDeferredUiAssignment(newSession.id, deferredUiAssignment, {
-                      waitForLeadHistory: false,
-                    }).catch((err) => {
-                      log.error('[draft send] deferred Worker assignment after /review failed', err);
-                      toast.error(t('newChat.collaboration.assignmentFailed'));
-                    });
-                  } catch (err) {
-                    const ipcError = extractIpcError(err);
-                    toast.error(
-                      ipcError
-                        ? t('review.toast.failed')
-                        : err instanceof Error
-                          ? err.message
-                          : t('review.toast.failed'),
-                    );
-                    restoreFirstMessageDraft();
-                    handOffDraftToSession();
-                    navigateToSession();
-                  }
-                  return;
-                }
-                // /help /issue /cmd 等依赖 SessionView 挂上后再消费 DESKTOP_COMMAND_TRIGGERED。
-                setPending(newSession.id, {
-                  text: message,
-                  files: rehydratedFiles,
-                  mentions,
-                  ...(opts?.quotesEncoded ? { quotesEncoded: true } : {}),
-                  ...(opts?.agentReferences?.length ? { agentReferences: opts.agentReferences } : {}),
-                  ...(opts?.pastedTextRanges?.length
-                    ? { pastedTextRanges: opts.pastedTextRanges }
-                    : {}),
-                  ...(opts?.slashCommandRanges !== undefined
-                    ? { slashCommandRanges: opts.slashCommandRanges }
-                    : {}),
-                  ...(deferredUiAssignment ? { deferredUiAssignment } : {}),
-                });
-                opts?.onAccepted?.();
-                handOffDraftToSession();
-                navigateToSession();
-                return;
-              }
+              handOffDraftToSession();
+              navigateToSession();
+              return;
             }
 
             const dispatchedMessage = await rewritePiSkillMessageForSend({

--- a/apps/desktop/src/renderer/features/cc-agent/NewMakerDraftRoute.tsx
+++ b/apps/desktop/src/renderer/features/cc-agent/NewMakerDraftRoute.tsx
@@ -17,10 +17,13 @@
  *   6. 用户按 Send:
  *        a. vendorAuthGate.checkAndConfirm(vendor)
  *           - 未就绪 → 弹通用 confirmDialog → 跳 settings → 中止
- *        b. 普通路径: createSession → setPending → navigate → SessionView 自动发送
+ *        b. 本机普通路径: createSession → sendMessage → navigate。首条消息在草稿
+ *           路由发出,不把发送绑在 SessionView hydrate 上;切走只换画面。
  *        c. Worktree 路径: 先 createSession + 插入状态卡 + navigate,再后台
  *           createWorktree；成功后更新 workingDir 并发送首条消息，失败则把原消息
  *           存回该 session 的 composer draft 供用户重试
+ *        d. device-link 远程路径仍走 setPending → SessionView 消费(对端开协同
+ *           可能要等隧道,不能挡在 navigate 前面)
  *
  * 文本/附件持久化:
  *   - vendor / workingDir / lastByVendor → localStorage 跨重启保留
@@ -4128,7 +4131,7 @@ export function NewMakerDraftRoute() {
           carryDraftFavoriteAnchorToSession(newSession.id, persistedAgentKind, model, providerId);
           // 计划模式是一次性选择:随本次发送被消耗,草稿勾选同步熄灭。
           if (effectivePlanMode) patchActivePrefs({ planMode: false });
-          // 首条消息经 setPending → SessionView 自动发送,createOpts 读 chat store 的
+          // 本机首条在下面直接 sendMessage,createOpts 读 chat store 的
           // planModeEnabled —— ensureInitialMessages 的行水合是异步的,必须先确定性
           // seed store,否则勾了计划模式的首条消息可能以 planMode:false 发出
           // (worktree 路径同款 seed;bot review P2)。
@@ -4184,38 +4187,111 @@ export function NewMakerDraftRoute() {
           }
 
           // 草稿态 base64 图片回填到新 session 的 image cache,换成 xdt-image://
-          // URL。必须在 setPending 之前,否则 SessionView 拿到的还是 base64。
+          // URL。必须在发出首条之前,否则消息里还是草稿命名空间。
           const rehydratedFiles = await rehomeDraftAttachments(files, newSession.id);
-          setPending(newSession.id, {
-            text: message,
-            files: rehydratedFiles,
-            mentions,
-            ...(opts?.quotesEncoded ? { quotesEncoded: true } : {}),
-            ...(opts?.agentReferences?.length ? { agentReferences: opts.agentReferences } : {}),
-            ...(opts?.pastedTextRanges?.length ? { pastedTextRanges: opts.pastedTextRanges } : {}),
-            ...(opts?.slashCommandRanges !== undefined
-              ? { slashCommandRanges: opts.slashCommandRanges }
-              : {}),
-            ...(deferredUiAssignment ? { deferredUiAssignment } : {}),
-          });
-          opts?.onAccepted?.();
-          // 草稿已经成功移交给新会话(setPending),清掉 NEW_MAKER_DRAFT_KEY
-          // 下的 store 条目,防止下次回到 /cc-agent/new 还看到本次刚发送的内容。
-          // 用 clearDraftAndNotify:上面 onSend return false,ChatInput 没清自己的
-          // 编辑器,这里必须通知它同步清空,否则 navigate 卸载时 ChatInput 的兜底
-          // effect 会把残留文本又写回 NEW_MAKER_DRAFT_KEY,撤销这次 clear。
-          clearComposerDraftAndNotify(NEW_MAKER_DRAFT_KEY);
-          // 同步清空 attachmentsRef,否则 navigate 触发 unmount 时
-          // useAttachments 的 cleanup effect 会把旧附件重新写回 store。
-          attachmentState.clearFiles();
-          resetDraftWorkspaceAfterSend();
-          // 让 SessionView 接管:它 mount 时 consumePending 自动发送首条。
-          navigate(orcaNavTarget ?? `/cc-agent/${newSession.id}`, {
-            replace: true,
-            state: orcaWorkersRevealState
-              ? { orcaWorkersReveal: orcaWorkersRevealState }
-              : undefined,
-          });
+          const sendWorkingDir = workingDir ?? newSession.workingDir;
+          const preNavDraftDoc = getComposerDraft(NEW_MAKER_DRAFT_KEY)?.text ?? null;
+          const restoreFirstMessageDraft = () => {
+            saveComposerDraft(newSession.id, {
+              text: preNavDraftDoc ?? plainTextToTiptapDoc(message),
+              attachments: rehydratedFiles ?? [],
+            });
+            emitAutoTitlePreviewCleared(newSession.id);
+            clearSessionStarting(newSession.id);
+          };
+          const navigateToSession = () => {
+            navigate(orcaNavTarget ?? `/cc-agent/${newSession.id}`, {
+              replace: true,
+              state: orcaWorkersRevealState
+                ? { orcaWorkersReveal: orcaWorkersRevealState }
+                : undefined,
+            });
+          };
+          const handOffDraftToSession = () => {
+            // 用 clearDraftAndNotify:上面 onSend return false,ChatInput 没清自己的
+            // 编辑器,这里必须通知它同步清空,否则 navigate 卸载时 ChatInput 的兜底
+            // effect 会把残留文本写回 NEW_MAKER_DRAFT_KEY,撤销这次 clear。
+            clearComposerDraftAndNotify(NEW_MAKER_DRAFT_KEY);
+            attachmentState.clearFiles();
+            resetDraftWorkspaceAfterSend();
+          };
+
+          // 本机首条消息在草稿路由发出,不把发送绑在 SessionView hydrate 上。
+          // sendMessage 同步推入 store 后再 navigate,切走只换画面、不撤发送。
+          if (!sendWorkingDir) {
+            log.error('[draft send] created session missing workingDir');
+            restoreFirstMessageDraft();
+            handOffDraftToSession();
+            navigateToSession();
+            return;
+          }
+
+          try {
+            const dispatchedMessage = await rewritePiSkillMessageForSend({
+              agentKind: capabilityAgentKind,
+              message,
+              workingDir: sendWorkingDir,
+              sessionId: newSession.id,
+            });
+            const rebaseRanges = <T extends { start: number; end: number }>(
+              ranges: readonly T[] | undefined,
+            ): T[] | undefined => {
+              if (!ranges) return undefined;
+              return rebaseInlineRangesAfterSlashCommandRewrite(
+                ranges,
+                message,
+                dispatchedMessage,
+              );
+            };
+            const sendPromise = makerChatStore.sendMessage(
+              newSession.id,
+              dispatchedMessage,
+              model,
+              effort,
+              permissionMode,
+              sendWorkingDir,
+              rehydratedFiles,
+              mentions,
+              {
+                ...(opts?.quotesEncoded ? { quotesEncoded: true } : {}),
+                ...(opts?.agentReferences?.length
+                  ? { agentReferences: rebaseRanges(opts.agentReferences) }
+                  : {}),
+                ...(opts?.pastedTextRanges?.length
+                  ? { pastedTextRanges: rebaseRanges(opts.pastedTextRanges) }
+                  : {}),
+                ...(opts?.slashCommandRanges !== undefined
+                  ? { slashCommandRanges: rebaseRanges(opts.slashCommandRanges) }
+                  : {}),
+              },
+            );
+            handOffDraftToSession();
+            navigateToSession();
+            void sendPromise.then(
+              (accepted) => {
+                if (accepted) {
+                  opts?.onAccepted?.();
+                  void dispatchDeferredUiAssignment(newSession.id, deferredUiAssignment).catch(
+                    (err) => {
+                      log.error('[draft send] deferred Worker assignment failed', err);
+                      toast.error(t('newChat.collaboration.assignmentFailed'));
+                    },
+                  );
+                } else if (deferredUiAssignment) {
+                  toast.error(t('newChat.collaboration.assignmentFailed'));
+                }
+              },
+              (err) => {
+                log.error('[draft send]', err);
+                restoreFirstMessageDraft();
+              },
+            );
+          } catch (err) {
+            log.error('[draft send]', err);
+            restoreFirstMessageDraft();
+            handOffDraftToSession();
+            navigateToSession();
+          }
         } catch (err) {
           // 交接失败 → 撤回乐观标题预览(理由见上面 optimisticTitleSessionId 的注释)。
           // 归属切换也会提前 return,必须先撤;否则已建、未发出首条的空会话会一直顶着原文。

--- a/apps/desktop/src/renderer/lib/makerChatStore.ts
+++ b/apps/desktop/src/renderer/lib/makerChatStore.ts
@@ -14894,6 +14894,8 @@ function setSessionRuntime(
     agentKind?: 'claude-code' | 'codex' | 'pi';
     fastMode?: boolean;
     planModeEnabled?: boolean;
+    /** Seed before SessionView hydrates the DB row; sendMessage reads this for SSH routing. */
+    remoteHostId?: string | null;
   },
 ): void {
   if (!sessionId) return;
@@ -14901,10 +14903,14 @@ function setSessionRuntime(
     const nextAgentKind = opts.agentKind ?? s.agentKind;
     const nextFastMode = opts.fastMode ?? s.fastMode;
     const nextPlanMode = opts.planModeEnabled ?? s.planModeEnabled;
+    const nextRemoteHostId = Object.hasOwn(opts, 'remoteHostId')
+      ? (opts.remoteHostId ?? null)
+      : s.remoteHostId;
     if (
       s.agentKind === nextAgentKind &&
       s.fastMode === nextFastMode &&
-      s.planModeEnabled === nextPlanMode
+      s.planModeEnabled === nextPlanMode &&
+      s.remoteHostId === nextRemoteHostId
     )
       return s;
     return {
@@ -14912,6 +14918,7 @@ function setSessionRuntime(
       agentKind: nextAgentKind,
       fastMode: nextFastMode,
       planModeEnabled: nextPlanMode,
+      remoteHostId: nextRemoteHostId,
       ...(s.planModeEnabled !== nextPlanMode ? { planModeRev: s.planModeRev + 1 } : {}),
     };
   });

--- a/apps/desktop/src/renderer/state/pendingFirstMessage.ts
+++ b/apps/desktop/src/renderer/state/pendingFirstMessage.ts
@@ -1,13 +1,18 @@
 /**
- * pendingFirstMessage —— 跨路由把"NewMaker 草稿首条消息"递交给真实 SessionView。
+ * pendingFirstMessage —— 跨路由把「还不能在草稿页发出的首条」递交给真实 SessionView。
  *
- * 流程:
- *   NewMakerDraftRoute.handleSend
- *     → createSession() 拿到 newId
- *     → setPending(newId, { text, files })
- *     → navigate('/cc-agent/' + newId)
+ * 本机新建不走这里:草稿路由 createSession 后直接 sendMessage,再 navigate。
+ * 切走只换画面,发送在 makerChatStore 里继续,不依赖 SessionView hydrate。
+ *
+ * 仍走这套交接的是 device-link 远程草稿(含开协同):对端建会话之后,首条必须等
+ * SessionView 挂上隧道订阅 / 开协同,不能挡在 navigate 前面。
+ *
+ *   NewMakerDraftRoute.handleSend(远程)
+ *     → 对端 create-session 拿到 remoteSessionId
+ *     → setPending(remoteSessionId, { text, files, remoteCollab? })
+ *     → navigate('/cc-agent/' + remoteSessionId)
  *   CCAgentSessionView mount
- *     → consumePending(newId) → sendMessage(text, files)
+ *     → consumePending(id) → (可选开协同) → sendMessage(text, files)
  *
  * 仅内存(模块级 Map):app 重启意味着发送链路被打断,丢弃不持久化。
  * 一次性消费(consume 即删):防止重复发送。
@@ -119,8 +124,8 @@ export function consumePendingGoal(sessionId: string): PendingGoalPayload | null
 // ─── 远程协同交接的可恢复副本 ──────────────────────────────────────────────────
 //
 // 为什么只有 remoteCollab 这条路径要落盘(greptile P1):
-// 其余创建路径的 setPending → navigate → mount → consume → sendMessage 是一串毫秒级
-// 步骤,内存 Map 与渲染进程同生共死不构成实际风险。而 **device-link 远程交接**这条不同 ——
+// 本机新建已在草稿路由直接 sendMessage,不经过这套内存 pending。仍走 setPending 的
+// 是 device-link 远程草稿。**device-link 远程交接**和本机不同 ——
 // consume 之后还要 await 隧道往返:开协同要等被控端起 Worker(正常一两秒,慢设备会一路走到
 // 30s 隧道超时再加 6×3s 回查),起目标之前还要先 await 一次 `deviceLink.subscribe`
 // (同样是 invoke,同样可能走到 30s)。这段时间用户输入只存在于渲染进程内存里,

--- a/apps/desktop/src/renderer/state/pendingFirstMessage.ts
+++ b/apps/desktop/src/renderer/state/pendingFirstMessage.ts
@@ -3,8 +3,9 @@
  *
  * 本机新建的普通文本不走这里:草稿路由 createSession 后直接 sendMessage,再 navigate。
  * 切走只换画面,发送在 makerChatStore 里继续,不依赖 SessionView hydrate。
- * 以 `/` 开头的本机首条仍走 setPending:desktop / Pi 分派必须等 SessionView 挂上
- * (SSH 跳过控制端 skill、远端 /review 拒绝、Pi runtime 重试),不能在草稿路由复制一套。
+ * SessionView 会当成斜杠命令的本机首条(列首 /cmd,以及 Pi 空白前缀)仍走 setPending:
+ * desktop / Pi 分派必须等 SessionView 挂上(SSH 跳过控制端 skill、远端 /review 拒绝、
+ * Pi runtime 重试),不能在草稿路由复制一套。
  *
  * 仍走这套交接的还有 device-link 远程草稿(含开协同):对端建会话之后,首条必须等
  * SessionView 挂上隧道订阅 / 开协同,不能挡在 navigate 前面。
@@ -127,7 +128,7 @@ export function consumePendingGoal(sessionId: string): PendingGoalPayload | null
 //
 // 为什么只有 remoteCollab 这条路径要落盘(greptile P1):
 // 本机普通文本已在草稿路由直接 sendMessage。仍走 setPending 的是 device-link
-// 远程草稿,以及本机以 `/` 开头、必须交给 SessionView 分派的首条。
+// 远程草稿,以及本机必须交给 SessionView 分派的斜杠命令首条(含 Pi 空白前缀)。
 // **device-link 远程交接**和本机不同 ——
 // consume 之后还要 await 隧道往返:开协同要等被控端起 Worker(正常一两秒,慢设备会一路走到
 // 30s 隧道超时再加 6×3s 回查),起目标之前还要先 await 一次 `deviceLink.subscribe`

--- a/apps/desktop/src/renderer/state/pendingFirstMessage.ts
+++ b/apps/desktop/src/renderer/state/pendingFirstMessage.ts
@@ -1,10 +1,12 @@
 /**
  * pendingFirstMessage —— 跨路由把「还不能在草稿页发出的首条」递交给真实 SessionView。
  *
- * 本机新建不走这里:草稿路由 createSession 后直接 sendMessage,再 navigate。
+ * 本机新建的普通文本不走这里:草稿路由 createSession 后直接 sendMessage,再 navigate。
  * 切走只换画面,发送在 makerChatStore 里继续,不依赖 SessionView hydrate。
+ * 以 `/` 开头的本机首条仍走 setPending:desktop / Pi 分派必须等 SessionView 挂上
+ * (SSH 跳过控制端 skill、远端 /review 拒绝、Pi runtime 重试),不能在草稿路由复制一套。
  *
- * 仍走这套交接的是 device-link 远程草稿(含开协同):对端建会话之后,首条必须等
+ * 仍走这套交接的还有 device-link 远程草稿(含开协同):对端建会话之后,首条必须等
  * SessionView 挂上隧道订阅 / 开协同,不能挡在 navigate 前面。
  *
  *   NewMakerDraftRoute.handleSend(远程)
@@ -124,8 +126,9 @@ export function consumePendingGoal(sessionId: string): PendingGoalPayload | null
 // ─── 远程协同交接的可恢复副本 ──────────────────────────────────────────────────
 //
 // 为什么只有 remoteCollab 这条路径要落盘(greptile P1):
-// 本机新建已在草稿路由直接 sendMessage,不经过这套内存 pending。仍走 setPending 的
-// 是 device-link 远程草稿。**device-link 远程交接**和本机不同 ——
+// 本机普通文本已在草稿路由直接 sendMessage。仍走 setPending 的是 device-link
+// 远程草稿,以及本机以 `/` 开头、必须交给 SessionView 分派的首条。
+// **device-link 远程交接**和本机不同 ——
 // consume 之后还要 await 隧道往返:开协同要等被控端起 Worker(正常一两秒,慢设备会一路走到
 // 30s 隧道超时再加 6×3s 回查),起目标之前还要先 await 一次 `deviceLink.subscribe`
 // (同样是 invoke,同样可能走到 30s)。这段时间用户输入只存在于渲染进程内存里,


### PR DESCRIPTION
## 这次改了什么

### 摘要

本机新建任务按下发送后，首条消息会立刻进入这个任务，而不再等会话页加载完才发。切到别的任务只换画面，不会把这句话丢掉，也不会留下一个没有消息的「未命名任务」。

根因是本机新建把首条消息放在内存 pending 里，等 SessionView hydrate 后再发；hydrate 完成前切走，60 秒后 pending 被清掉，库里只剩空壳。

### 变更类型

- [x] `fix` 缺陷修复
- [ ] `feat` 新功能
- [ ] `refactor` / `perf` 重构或性能优化
- [ ] `docs` / `test` / `chore` 文档、测试或工程维护
- [ ] 其他：

### 范围

- 关联 Issue / 需求：无
- 本 PR 包含：本机新建普通路径在草稿路由直接 `sendMessage`，再 navigate；发送失败时把原文放回该任务输入框
- 明确不包含：device-link 远程草稿 / 开协同仍走 `setPending` → SessionView 消费；mobile 新建路径
- 用户可见变化：本机新建发送后立刻切走，回来时首条消息还在，侧栏不再出现空的未命名任务
- 是否存在 breaking change：无

### UI 变化

- 引用的设计规范：不涉及：只改本机新建首条消息的发送时序，无视觉/交互/文案变化

## 怎么验证的

### 自动验证

```text
cd /Users/dash/Code/Cindy/cindy-new-task-first-message
corepack pnpm --filter desktop exec vitest run src/renderer/__tests__/newMakerLocalFirstMessageSend.test.ts src/renderer/__tests__/newMakerWorktreeSend.test.ts src/renderer/__tests__/newMakerOrcaCreateOrder.test.ts src/renderer/__tests__/pendingHandoffRecovery.test.ts src/renderer/__tests__/newMakerProjectPicker.test.ts src/renderer/__tests__/newMakerDraft.test.ts
结果：全部通过（含既有草稿/worktree/远程交接测试）

corepack pnpm --filter desktop run typecheck
结果：通过

corepack pnpm test:unit:related
结果：PASS apps/desktop unit
```

### 手工验证

未在本机 Desktop 实机点发送。建议验证：新建任务打一句话发送，马上点回上一个任务，再点进刚建的那条——消息应还在，标题不应停在「未命名任务」。

### 未执行的验证

- Desktop 实机发送 + 立即切走
- Dark 模式（无视觉改动）
- mobile

## 风险

### 风险分类

- [x] 无已知风险
- [ ] SQLite / migration
- [ ] system prompt
- [ ] 协议兼容
- [ ] 权限 / 安全 / 用户数据
- [ ] 存量插件兼容（批准状态 / 指纹 / manifest 校验 / 安装布局 / 包格式）
- [ ] 原生层 / fingerprint / OTA
- [ ] 跨平台差异
- [ ] 其他：

### 影响与回滚

- 影响范围：Desktop 本机新建普通发送路径；远程协同交接未改
- 回滚 / 降级方式：无。不涉及 migration / prompt / 协议 / 原生层。回滚即还原本 PR。
- 存量插件影响：无

### 提交前检查

- [x] 已 review 完整 diff
- [x] 每个 commit 都带 DCO 签名（`git commit -s`，见 [DCO](../DCO)）
- [x] UI 改动已在「UI 变化」注明引用的设计规范章节（不涉及 UI 则跳过）
- [x] 未提交凭证、令牌或授权文件
- [x] 已补充必要文档
- [x] 已确认测试结果或说明未执行原因
