### PR TITLE
feat(codex): enable remote compaction for Cindy Provider

### DIFF
--- a/apps/desktop/src/main/maker-host/__tests__/codexCredentialSwitch.test.ts
+++ b/apps/desktop/src/main/maker-host/__tests__/codexCredentialSwitch.test.ts
@@ -63,6 +63,21 @@ describe('shouldCloseSessionForCredentialSwitch codex mode', () => {
     expect(shouldCloseSessionForCredentialSwitch(input)).toBe(false);
   });
 
+  it('keeps a local-compaction Cindy Codex thread when its independent subagent is incompatible', () => {
+    const input = {
+      agentKind: 'codex',
+      currentProviderId: 'xd',
+      nextProviderId: 'xd',
+      currentModel: 'codex/gpt-5.5',
+      nextModel: 'codex/gpt-5.6-sol',
+      currentCodexProxyActive: true,
+      currentCodexThreadModelProviderId: 'cindy_gateway',
+      currentCodexCindyRemoteCompactionCompatible: false,
+    } as const;
+    expect(isCodexThreadModelProviderIdentityMismatch(input)).toBe(false);
+    expect(shouldCloseSessionForCredentialSwitch(input)).toBe(false);
+  });
+
   it('keeps a proxy-active OAuth Codex session for oauth-family model changes', () => {
     expect(shouldCloseSessionForCredentialSwitch({
       agentKind: 'codex',

--- a/apps/desktop/src/main/maker-host/__tests__/codexCredentialSwitch.test.ts
+++ b/apps/desktop/src/main/maker-host/__tests__/codexCredentialSwitch.test.ts
@@ -49,6 +49,20 @@ describe('shouldCloseSessionForCredentialSwitch codex mode', () => {
     })).toBe(false);
   });
 
+  it('keeps a matching Cindy Codex remote-compaction thread for Cindy codex model changes', () => {
+    const input = {
+      agentKind: 'codex',
+      currentProviderId: 'xd',
+      nextProviderId: 'xd',
+      currentModel: 'codex/gpt-5.5',
+      nextModel: 'codex/gpt-5.6-sol',
+      currentCodexProxyActive: true,
+      currentCodexThreadModelProviderId: 'cindy_codex',
+    } as const;
+    expect(isCodexThreadModelProviderIdentityMismatch(input)).toBe(false);
+    expect(shouldCloseSessionForCredentialSwitch(input)).toBe(false);
+  });
+
   it('keeps a proxy-active OAuth Codex session for oauth-family model changes', () => {
     expect(shouldCloseSessionForCredentialSwitch({
       agentKind: 'codex',

--- a/apps/desktop/src/main/maker-host/__tests__/codexProxyHost.test.ts
+++ b/apps/desktop/src/main/maker-host/__tests__/codexProxyHost.test.ts
@@ -352,17 +352,23 @@ describe('codex gateway config', () => {
     expect(args).toContain('model_providers.cindy_openai.wire_api="responses"');
     expect(args).toContain('model_providers.cindy_openai.requires_openai_auth=true');
     expect(args).toContain('model_providers.cindy_openai.supports_websockets=true');
+    expect(args).toContain('model_providers.cindy_codex.name="OpenAI"');
+    expect(args).toContain('model_providers.cindy_codex.requires_openai_auth=true');
+    expect(args).toContain('model_providers.cindy_codex.supports_websockets=false');
     // is_openai + OAuth 命中时 codex 默认 zstd 压缩请求体,loopback proxy 无法解析,必须关。
     expect(args).toContain('features.enable_request_compression=false');
   });
 
-  it('env-key / provider-oauth 模式: 不定义 OpenAI 身份 provider', async () => {
+  it('env-key / provider-oauth 只定义 Cindy Codex 远程压缩 identity', async () => {
     const { buildCodexProxySpawnArgs } = await import('../codex-gateway-config.js');
 
     for (const mode of ['env-key', 'provider-oauth'] as const) {
       const args = buildCodexProxySpawnArgs('http://127.0.0.1:12345', mode);
       expect(args.some((arg) => arg.includes('cindy_openai'))).toBe(false);
-      expect(args).not.toContain('features.enable_request_compression=false');
+      expect(args).toContain('model_providers.cindy_codex.name="OpenAI"');
+      expect(args).toContain('model_providers.cindy_codex.env_key="XDT_CODEX_API_KEY"');
+      expect(args).toContain('model_providers.cindy_codex.supports_websockets=false');
+      expect(args).toContain('features.enable_request_compression=false');
     }
   });
 
@@ -470,6 +476,27 @@ describe('createCrossProviderCompactionCompatTransform', () => {
       { model: 'gpt-5.5', input: [compactionItem, agentMessage, reasoningItem, userMessage] },
       { ...CTX_BASE, upstreamBase: 'https://chatgpt.com/backend-api/codex' },
     )).toBeNull();
+  });
+
+  it('Cindy Provider codex/* 原样透传 compaction，同时清理 agent 消息密文', async () => {
+    const { createCrossProviderCompactionCompatTransform } = await import('../codex-proxy-host.js');
+    const transform = createCrossProviderCompactionCompatTransform();
+
+    const out = transform(
+      { model: 'codex/gpt-5.6-sol', input: [compactionItem, agentMessage, userMessage] },
+      { ...CTX_BASE, upstreamBase: 'https://gateway.example.com/v1' },
+    ) as { input: Array<Record<string, unknown>> };
+
+    expect(out.input).toEqual([
+      compactionItem,
+      {
+        type: 'agent_message',
+        author: 'researcher',
+        recipient: 'parent',
+        content: [{ type: 'input_text', text: 'readable agent result' }],
+      },
+      userMessage,
+    ]);
   });
 
   it('upstreamBase 缺失时不改写(保守方向:宁可维持现状,不误伤 ChatGPT 请求)', async () => {

--- a/apps/desktop/src/main/maker-host/codex-credential-switch.ts
+++ b/apps/desktop/src/main/maker-host/codex-credential-switch.ts
@@ -33,6 +33,8 @@ export interface ShouldCloseSessionForCredentialSwitchInput {
    * 它是 thread 级冻结身份，不能用可能已被 UI 提前覆盖的 provider store 代替。
    */
   currentCodexThreadModelProviderId?: string | null;
+  /** 当前 host 的独立 Subagent 路由是否兼容 Cindy Codex 远程压缩。 */
+  currentCodexCindyRemoteCompactionCompatible?: boolean | null;
   /**
    * 当前本地 Codex app-server spawn 的鉴权注入形态(getCodexProxyAuthInjectionState())。
    * 用于把隐式来源(resolveAgentCredentialMode 解析出 undefined)落到实际凭证家族,
@@ -167,7 +169,9 @@ export function isCodexThreadModelProviderIdentityMismatch(
       providerId: nextProviderId,
       model: input.nextModel,
     })
-      ? CODEX_CINDY_COMPACT_PROVIDER_ID
+      ? input.currentCodexCindyRemoteCompactionCompatible === false
+        ? CODEX_GATEWAY_PROVIDER_ID
+        : CODEX_CINDY_COMPACT_PROVIDER_ID
       : effectiveNextMode === 'oauth-bearer'
       ? CODEX_OPENAI_COMPACT_PROVIDER_ID
       : effectiveNextMode !== undefined

--- a/apps/desktop/src/main/maker-host/codex-credential-switch.ts
+++ b/apps/desktop/src/main/maker-host/codex-credential-switch.ts
@@ -1,6 +1,7 @@
 import {
   canReuseCodexHostForCredentialMode,
   canReuseHostForCredentialMode,
+  isCindyProviderCodexRemoteCompactionRoute,
   resolveAgentCredentialMode,
   type AgentCredentialMode,
   type AgentKind,
@@ -8,6 +9,7 @@ import {
 
 import { claudeToolSearchMode } from './claude-behavior-flags.js';
 import {
+  CODEX_CINDY_COMPACT_PROVIDER_ID,
   CODEX_GATEWAY_PROVIDER_ID,
   CODEX_OPENAI_COMPACT_PROVIDER_ID,
 } from './codex-gateway-config.js';
@@ -161,7 +163,12 @@ export function isCodexThreadModelProviderIdentityMismatch(
   });
   const effectiveNextMode = nextMode ?? credentialFamilyFromAuthInjection(input.codexAuthInjection);
   const expectedThreadModelProviderId =
-    effectiveNextMode === 'oauth-bearer'
+    isCindyProviderCodexRemoteCompactionRoute({
+      providerId: nextProviderId,
+      model: input.nextModel,
+    })
+      ? CODEX_CINDY_COMPACT_PROVIDER_ID
+      : effectiveNextMode === 'oauth-bearer'
       ? CODEX_OPENAI_COMPACT_PROVIDER_ID
       : effectiveNextMode !== undefined
         ? CODEX_GATEWAY_PROVIDER_ID
@@ -171,6 +178,7 @@ export function isCodexThreadModelProviderIdentityMismatch(
   );
   const actualThreadIdentityKnown =
     actualThreadModelProviderId === CODEX_OPENAI_COMPACT_PROVIDER_ID ||
+    actualThreadModelProviderId === CODEX_CINDY_COMPACT_PROVIDER_ID ||
     actualThreadModelProviderId === CODEX_GATEWAY_PROVIDER_ID;
 
   return (

--- a/apps/desktop/src/main/maker-host/codex-gateway-config.ts
+++ b/apps/desktop/src/main/maker-host/codex-gateway-config.ts
@@ -38,6 +38,12 @@ export const CODEX_GATEWAY_PROVIDER_ID = 'cindy_gateway';
 export const CODEX_OPENAI_COMPACT_PROVIDER_ID = 'cindy_openai';
 
 /**
+ * Cindy Provider codex/* 的内部 transport identity。产品 Provider 和上游不变；
+ * name="OpenAI" 只用于让 Codex 启用远程压缩，HTTP 与订阅 WS identity 分开冻结。
+ */
+export const CODEX_CINDY_COMPACT_PROVIDER_ID = 'cindy_codex';
+
+/**
  * 注入 codex 子进程的环境变量名 —— codex 通过 config 的 `env_key` 来这里读 API key。
  * 用专名避免撞用户机器上已有的同名变量。
  */
@@ -97,6 +103,17 @@ export function buildCodexProxySpawnArgs(
     // 只有不依赖请求体改写的订阅直连 provider(下面的 cindy_openai)才放开 WS。
     '-c', `model_providers.${p}.supports_websockets=false`,
   ];
+  const c = CODEX_CINDY_COMPACT_PROVIDER_ID;
+  const cindyCompactAuthArg = authMode === 'oauth-bearer'
+    ? `model_providers.${c}.requires_openai_auth=true`
+    : `model_providers.${c}.env_key="${CODEX_GATEWAY_ENV_KEY}"`;
+  args.push(
+    '-c', `model_providers.${c}.name="OpenAI"`,
+    '-c', `model_providers.${c}.base_url="${baseUrl}"`,
+    '-c', `model_providers.${c}.wire_api="responses"`,
+    '-c', cindyCompactAuthArg,
+    '-c', `model_providers.${c}.supports_websockets=false`,
+  );
   if (authMode === 'oauth-bearer') {
     // OpenAI 身份 provider(见 CODEX_OPENAI_COMPACT_PROVIDER_ID):默认 model_provider
     // 仍是 cindy_gateway(本地压缩,安全缺省),订阅直连 thread 由 maker-core 在
@@ -137,8 +154,9 @@ export function buildCodexProxySpawnArgs(
       // is_openai + codex-backend OAuth 命中时 codex 默认对 /responses 请求体做 zstd
       // 压缩(enable_request_compression 默认开);loopback proxy 要整段 JSON.parse
       // 改写请求体,无法解 zstd,必须显式关掉(仅少传输优化,无功能损失)。
-      '-c', 'features.enable_request_compression=false',
     );
   }
+  // OpenAI identity 可能启用 zstd；loopback proxy 需要解析 JSON 做路由和 prompt 注入。
+  args.push('-c', 'features.enable_request_compression=false');
   return args;
 }

--- a/apps/desktop/src/main/maker-host/codex-proxy-host.ts
+++ b/apps/desktop/src/main/maker-host/codex-proxy-host.ts
@@ -35,6 +35,7 @@ import {
   type RoutingDecision,
   type RoutingTransform,
 } from '@cindy/anthropic-compat-proxy';
+import { isCindyProviderCodexRemoteCompactionRoute } from '@cindy/maker-core';
 import { buildVisionBridgeProxyTransform } from '../vision-bridge/vision-bridge-controller.js';
 import {
   createResponsesCustomToolFunctionAdapter,
@@ -47,7 +48,10 @@ import fs from 'node:fs';
 import path from 'node:path';
 
 import { isCuratedQwen38Tag } from '../../shared/localModelRuntime.js';
-import { buildCodexGatewayBaseUrl, CODEX_OAUTH_UPSTREAM } from './codex-gateway-config.js';
+import {
+  buildCodexGatewayBaseUrl,
+  CODEX_OAUTH_UPSTREAM,
+} from './codex-gateway-config.js';
 import { claudeUpstreamEndpoint } from './runtime-configs.js';
 import {
   getActiveCatalog,
@@ -2121,17 +2125,13 @@ function createGatewayGrokResponsesCompatTransform(
 /**
  * 跨来源恢复的加密压缩历史兼容(Greptile P1, PR #265):
  *
- * OpenAI 远端压缩会把早期历史替换成加密 compaction 块(只有 ChatGPT 后端能解)。
- * 该会话切到 XD / xAI / 自定义供应商后按原 thread id resume,持久化历史里的加密块
- * 会被逐请求重放给读不懂它的上游 → 请求被拒、会话卡死。客户端无法解密转换,
- * 唯一可行的降级是:发往**非 ChatGPT 上游**时把加密块替换成明文占位 user message,
- * 明确告知模型「压缩点之前的上下文不可用」,保留压缩点之后仍在历史里的对话继续跑。
+ * 远端压缩会把早期历史替换成加密 compaction 块。ChatGPT 和 Cindy Provider
+ * codex/* 都需要原样回放；切到 xAI / 自定义供应商后仍按既有明文占位降级。
  * 判断去向用 ctx.upstreamBase(引擎按最终路由注入),不复刻路由逻辑。
- * ChatGPT 路由(chatgpt.com)原样透传,远端压缩语义不受影响。
  */
 const COMPACTION_UNAVAILABLE_NOTE =
   '[context note] Earlier conversation history was compacted into an encrypted snapshot by the ' +
-  'OpenAI subscription backend and is not readable on the current model provider. Treat the ' +
+  'previous Codex backend and is not readable on the current model provider. Treat the ' +
   'conversation from this point on as the available context; ask the user if earlier details are needed.';
 
 function isChatGptUpstreamBase(upstreamBase: string | undefined): boolean {
@@ -2154,12 +2154,16 @@ function isChatGptUpstreamBase(upstreamBase: string | undefined): boolean {
  * - reasoning.encrypted_content 不属于本故障；继续交给后续供应商兼容层判断，
  *   不在这里扩大删除面。
  */
-function rewriteCrossProviderHistoryItems(body: unknown): Record<string, unknown> | null {
+function rewriteCrossProviderHistoryItems(
+  body: unknown,
+  opts: { preserveCompaction?: boolean } = {},
+): Record<string, unknown> | null {
   if (!isPlainObject(body) || !Array.isArray(body.input)) return null;
   let changed = false;
   const input: unknown[] = [];
   for (const item of body.input) {
     if (
+      opts.preserveCompaction !== true &&
       isPlainObject(item) &&
       (item.type === 'compaction' || item.type === 'context_compaction') &&
       typeof item.encrypted_content === 'string' &&
@@ -2190,10 +2194,18 @@ function rewriteCrossProviderHistoryItems(body: unknown): Record<string, unknown
 
 export function createCrossProviderCompactionCompatTransform(): RequestTransform {
   return (body, ctx) => {
-    // upstreamBase 未注入(理论不发生)按非 ChatGPT 保守处理?否——保守方向是不改写:
-    // 改写会丢加密块,误伤真 ChatGPT 请求的代价(远端压缩语义被破坏)高于维持现状。
-    if (!ctx.upstreamBase || isChatGptUpstreamBase(ctx.upstreamBase)) return null;
-    const replaced = rewriteCrossProviderHistoryItems(body);
+    // upstreamBase 未注入(理论不发生)时不猜目标后端，避免误删合法加密快照。
+    if (!ctx.upstreamBase) return null;
+    const requestModel = isPlainObject(body) && typeof body.model === 'string' ? body.model : '';
+    const providerContext = providerContextForRequest(ctx.headers, requestModel);
+    const isCindyCodexRoute = isCindyProviderCodexRemoteCompactionRoute({
+      providerId: providerContext.providerId,
+      model: providerContext.catalogModel,
+    });
+    if (isChatGptUpstreamBase(ctx.upstreamBase)) return null;
+    const replaced = rewriteCrossProviderHistoryItems(body, {
+      preserveCompaction: isCindyCodexRoute,
+    });
     if (!replaced) return null;
     log.info('rewrote incompatible Codex history for non-ChatGPT upstream', {
       reqId: ctx.reqId,

--- a/apps/desktop/src/main/maker-host/index.ts
+++ b/apps/desktop/src/main/maker-host/index.ts
@@ -220,6 +220,7 @@ import {
 } from '../mcp-integrations/codexBuiltinToolPolicy.js';
 import {
   buildCodexProxySpawnArgs,
+  CODEX_CINDY_COMPACT_PROVIDER_ID,
   CODEX_OPENAI_COMPACT_PROVIDER_ID,
 } from './codex-gateway-config.js';
 import {
@@ -1569,8 +1570,10 @@ export function getMaker(): Maker {
                 codexBrowserUseStartupTimeoutMs: browserCompanion.startupTimeoutMs,
               }
             : {}),
-          // oauth spawn 才定义 OpenAI 身份 provider(spawn args 同源);maker-core 只对
-          // 「订阅直连路由」的 thread 用它开 OpenAI 远端压缩,其余 thread 保持本地压缩。
+          ...(ready
+            ? { codexCindyRemoteCompactionProviderId: CODEX_CINDY_COMPACT_PROVIDER_ID }
+            : {}),
+          // oauth spawn 额外定义订阅直连 identity；Cindy codex/* 使用上面的 HTTP identity。
           ...(useOAuthBearer && ready
             ? { codexRemoteCompactionProviderId: CODEX_OPENAI_COMPACT_PROVIDER_ID }
             : {}),
@@ -1615,7 +1618,9 @@ export function getMaker(): Maker {
         text,
         subagentRoute,
       }) =>
-        registerCodexProxyComposed(sessionId, threadId, text, { subagentRoute }),
+        registerCodexProxyComposed(sessionId, threadId, text, {
+          ...(subagentRoute ? { subagentRoute } : {}),
+        }),
       armCodexHttpRecovery,
       registerCodexChildThreadForParent: ({ parentThreadId, childThreadId }) => {
         registerCodexProxyChildThread(parentThreadId, childThreadId);

--- a/apps/desktop/src/main/maker-ipc/__tests__/runtimeSetModel.test.ts
+++ b/apps/desktop/src/main/maker-ipc/__tests__/runtimeSetModel.test.ts
@@ -242,6 +242,43 @@ describe('applyRuntimeSetModelChange', () => {
     expect(getSessionProvider(sessionId)).toBe('xd');
   });
 
+  it('keeps an idle Cindy Codex thread local when its independent subagent is incompatible', async () => {
+    const sessionId = rememberSession('runtime-set-model-cindy-local-compaction');
+    setSessionProvider(sessionId, 'xd');
+    const setModel = vi.fn(async () => {});
+    const closeSession = vi.fn(async () => {});
+    const maker: RuntimeSetModelMaker = {
+      getSession: () => ({
+        agentKind: 'codex',
+        remoteHostId: null,
+        codexProxyActive: true,
+        codexThreadModelProviderId: 'cindy_gateway',
+        codexCindyRemoteCompactionCompatible: false,
+        model: 'codex/gpt-5.5',
+        setModel,
+      }),
+      listActiveSessions: () => [{
+        id: sessionId,
+        agentKind: 'codex',
+        remoteHostId: null,
+        isTurnRunning: () => false,
+      }],
+      closeSession,
+    };
+
+    const result = await applyRuntimeSetModelChange({
+      maker,
+      sessionId,
+      model: 'codex/gpt-5.6-sol',
+      providerId: 'xd',
+    });
+
+    expect(result).toEqual({ status: 'applied' });
+    expect(closeSession).not.toHaveBeenCalled();
+    expect(setModel).toHaveBeenCalledWith('codex/gpt-5.6-sol', { providerId: 'xd' });
+    expect(getSessionProvider(sessionId)).toBe('xd');
+  });
+
   it('soft-closes a local Codex session before switching into xAI provider OAuth routing', async () => {
     const sessionId = rememberSession('runtime-set-model-close-codex-xai');
     setSessionProvider(sessionId, 'xd');

--- a/apps/desktop/src/main/maker-ipc/runtimeSetModel.ts
+++ b/apps/desktop/src/main/maker-ipc/runtimeSetModel.ts
@@ -21,6 +21,7 @@ interface RuntimeSetModelSession {
   remoteHostId?: string | null;
   codexProxyActive?: boolean | null;
   codexThreadModelProviderId?: string | null;
+  codexCindyRemoteCompactionCompatible?: boolean | null;
   model: string;
   setModel: (model: string, opts?: { providerId?: string | null; effort?: Effort }) => Promise<void>;
 }
@@ -153,6 +154,8 @@ export async function applyRuntimeSetModelChange(
         nextModel: model,
         currentCodexProxyActive: sess.codexProxyActive,
         currentCodexThreadModelProviderId: sess.codexThreadModelProviderId,
+        currentCodexCindyRemoteCompactionCompatible:
+          sess.codexCindyRemoteCompactionCompatible,
         codexAuthInjection: input.codexAuthInjection,
       })
     : false;

--- a/apps/desktop/src/main/scheduler-host/__tests__/runnerQueuedDispatch.test.ts
+++ b/apps/desktop/src/main/scheduler-host/__tests__/runnerQueuedDispatch.test.ts
@@ -745,6 +745,42 @@ describe('MakerScheduleRunner queued dispatch (busy bound session)', () => {
     expect(mocks.setSessionProvider).not.toHaveBeenCalled();
   });
 
+  it('排队 Cindy Codex 在独立 Subagent 不兼容时接受正确的本地压缩身份', async () => {
+    mocks.getSessionRowSnapshot.mockResolvedValue({
+      status: 'active',
+      userSendAt: null,
+      providerId: 'xd',
+    });
+    mocks.getSessionProvider.mockReturnValue('xd');
+    const harness = createSessionHarness(async () => ({ accepted: true }));
+    Object.defineProperties(harness.session, {
+      agentKind: { value: 'codex' },
+      model: { value: 'codex/gpt-5.6-sol', writable: true },
+      codexProxyActive: { value: true },
+      codexThreadModelProviderId: { value: 'cindy_gateway' },
+      codexCindyRemoteCompactionCompatible: { value: false },
+    });
+    const queue = createQueueHarness({ busy: true });
+    const { runner } = createRunnerHarness(harness.session, queue.deps, {
+      metaModel: 'codex/gpt-5.6-sol',
+    });
+
+    const firePromise = runner.fire(
+      heartbeatSchedule({
+        agentKind: 'codex',
+        model: 'codex/gpt-5.6-sol',
+        providerId: 'xd',
+      }),
+      createFireContext(),
+    );
+    await vi.waitFor(() => expect(queue.enqueueCalls.length).toBe(1));
+    await queue.accept();
+    await vi.waitFor(() => expect(harness.listenerCount()).toBe(1));
+    harness.emit({ type: 'done', data: {}, source: 'codex' });
+
+    await expect(firePromise).resolves.toMatchObject({ sessionId: SESSION_ID });
+  });
+
   it('排队 Pi 每次派发都写 Fast=false，清掉复用会话的旧 bridge 状态', async () => {
     const harness = createSessionHarness(async () => ({ accepted: true }));
     (harness.session as { agentKind: string }).agentKind = 'pi';

--- a/apps/desktop/src/main/scheduler-host/runner.ts
+++ b/apps/desktop/src/main/scheduler-host/runner.ts
@@ -925,6 +925,8 @@ export class MakerScheduleRunner implements ScheduleRunner {
             nextModel: model,
             currentCodexProxyActive: liveSession.codexProxyActive,
             currentCodexThreadModelProviderId: liveSession.codexThreadModelProviderId,
+            currentCodexCindyRemoteCompactionCompatible:
+              liveSession.codexCindyRemoteCompactionCompatible,
           }
         : null;
       if (
@@ -1344,6 +1346,8 @@ export class MakerScheduleRunner implements ScheduleRunner {
               nextModel: runtimeModel,
               currentCodexProxyActive: session.codexProxyActive,
               currentCodexThreadModelProviderId: session.codexThreadModelProviderId,
+              currentCodexCindyRemoteCompactionCompatible:
+                session.codexCindyRemoteCompactionCompatible,
             })
           ) {
             throw new Error(
@@ -2124,6 +2128,8 @@ export class MakerScheduleRunner implements ScheduleRunner {
         nextModel: live.model,
         currentCodexProxyActive: live.codexProxyActive,
         currentCodexThreadModelProviderId: live.codexThreadModelProviderId,
+        currentCodexCindyRemoteCompactionCompatible:
+          live.codexCindyRemoteCompactionCompatible,
       })
     ) {
       throw new QueuedCodexThreadIdentityMismatchError(
@@ -2140,6 +2146,8 @@ export class MakerScheduleRunner implements ScheduleRunner {
         nextModel: targetModel,
         currentCodexProxyActive: live.codexProxyActive,
         currentCodexThreadModelProviderId: live.codexThreadModelProviderId,
+        currentCodexCindyRemoteCompactionCompatible:
+          live.codexCindyRemoteCompactionCompatible,
       })
     ) {
       // 早退 = 本轮沿用 live 当前路由派发:这条保留路由自己也要过停用裁决 ——

--- a/packages/maker-core/src/agents/base-agent.ts
+++ b/packages/maker-core/src/agents/base-agent.ts
@@ -1673,6 +1673,8 @@ export interface AgentSessionHandle {
    * 这是 thread 级冻结身份，不随 thread/settings/update 的模型切换改变。
    */
   readonly codexThreadModelProviderId?: string;
+  /** Codex-only: 当前 host 的独立 Subagent 路由是否兼容 Cindy Codex 远程压缩。 */
+  readonly codexCindyRemoteCompactionCompatible?: boolean;
   /**
    * Codex-only: start/resume 成功后,产品 prompt 这一次到底有没有进入
    * codex thread history。Maker 用这个事实更新 host 持久化 bit,避免再从

--- a/packages/maker-core/src/agents/base-agent.ts
+++ b/packages/maker-core/src/agents/base-agent.ts
@@ -363,13 +363,11 @@ export interface CodexExtraSpawnConfig {
   buildSessionMcpConfig?: (sessionInstanceId: string) => Record<string, unknown>;
   codexProxyActive?: boolean;
   /**
-   * spawn args 中定义的「OpenAI 身份」provider id(name 逐字为 "OpenAI",
-   * codex 据 name 判定 supports_remote_compaction)。仅 oauth-bearer spawn 下发。
-   * CodexAgent 只对 ChatGPT 订阅直连路由的 thread 在 thread/start|resume 传
-   * modelProvider=该 id,启用 OpenAI 远端压缩;其余 thread 保持默认 provider
-   * (本地压缩)—— 网关 / xAI / 自定义供应商上游不实现远端压缩,错配是硬失败。
+   * ChatGPT 订阅直连的内部 OpenAI transport identity，仅 oauth-bearer spawn 下发。
    */
   codexRemoteCompactionProviderId?: string;
+  /** Cindy Provider codex/* 的内部 OpenAI transport identity；固定走 HTTP。 */
+  codexCindyRemoteCompactionProviderId?: string;
 }
 
 export type CodexAppServerProcessRole = 'task-host' | 'control-plane-service';

--- a/packages/maker-core/src/agents/codex/app-server/host.ts
+++ b/packages/maker-core/src/agents/codex/app-server/host.ts
@@ -268,10 +268,11 @@ export interface AppServerHostOptions {
   /** Maximum wait for the provisioned Browser companion to publish its MCP tools. */
   codexBrowserUseStartupTimeoutMs?: number;
   /**
-   * Host 创建时冻结的事实:spawn args 里定义的 OpenAI 身份 provider id(仅
-   * oauth-bearer spawn 存在)。thread/start|resume 据此对订阅直连会话开远端压缩。
+   * Host 创建时冻结的 ChatGPT OpenAI transport identity，仅 oauth-bearer spawn 存在。
    */
   remoteCompactionProviderId?: string;
+  /** Cindy Provider codex/* 的内部 OpenAI transport identity。 */
+  cindyRemoteCompactionProviderId?: string;
   /** Per-thread host-owned MCP URL overrides keyed by the Session instance. */
   buildSessionMcpConfig?: (sessionInstanceId: string) => Record<string, unknown>;
   /** Cindy-side fallback used only when a subagent's actual model is not reported. */
@@ -429,6 +430,10 @@ export class AppServerHost {
   /** oauth spawn 定义的 OpenAI 身份 provider id;非 oauth spawn / 未下发 → null。 */
   getRemoteCompactionProviderId(): string | null {
     return this.opts.remoteCompactionProviderId ?? null;
+  }
+
+  getCindyRemoteCompactionProviderId(): string | null {
+    return this.opts.cindyRemoteCompactionProviderId ?? null;
   }
 
   /**

--- a/packages/maker-core/src/agents/codex/app-server/protocol.ts
+++ b/packages/maker-core/src/agents/codex/app-server/protocol.ts
@@ -215,8 +215,8 @@ export interface ThreadStartParams {
   model?: string;
   /**
    * 覆盖本 thread 的 model provider(config `model_providers` 里的 key)。
-   * 缺省走 config 顶层 model_provider。用于订阅直连 thread 选 OpenAI 身份
-   * provider(开远端压缩);provider 身份是 thread 级冻结,settings/update 改不了。
+   * 缺省走 config 顶层 model_provider。用于支持远端压缩的 thread 选择内部 OpenAI
+   * transport identity；产品 Provider 不随之改变。provider 身份是 thread 级冻结。
    */
   modelProvider?: string;
   cwd?: string;

--- a/packages/maker-core/src/agents/codex/index.test.ts
+++ b/packages/maker-core/src/agents/codex/index.test.ts
@@ -433,6 +433,7 @@ function installFakeHost(
     codexBrowserUseVersion?: string;
     codexBrowserMcpToolAvailable?: boolean;
     remoteCompactionProviderId?: string;
+    cindyRemoteCompactionProviderId?: string;
     subagentModelFallback?: string;
     subagentRoute?: {
       providerId: string;
@@ -507,6 +508,9 @@ function installFakeHost(
     opts.codexBrowserMcpToolAvailable ?? opts.codexBrowserUseAvailable === true
   ));
   const getRemoteCompactionProviderId = vi.fn(() => opts.remoteCompactionProviderId ?? null);
+  const getCindyRemoteCompactionProviderId = vi.fn(
+    () => opts.cindyRemoteCompactionProviderId ?? null,
+  );
   const getSessionMcpConfig = vi.fn((sessionInstanceId?: string) =>
     opts.buildSessionMcpConfig?.(sessionInstanceId) ?? {},
   );
@@ -526,6 +530,7 @@ function installFakeHost(
     getCodexBrowserUseVersion,
     waitForMcpTool,
     getRemoteCompactionProviderId,
+    getCindyRemoteCompactionProviderId,
     getSessionMcpConfig,
     getSubagentModelFallback,
     getSubagentRoute,
@@ -3700,11 +3705,12 @@ describe('CodexAgent.startSession developerInstructions', () => {
     await handle.close();
   });
 
-  it('passes the OpenAI compaction provider to thread/start only for oauth-family sessions', async () => {
+  it('selects remote compaction identities only for ChatGPT and Cindy codex routes', async () => {
     const agent = new CodexAgent(createDeps());
     const host = installFakeHost(agent, undefined, {
       codexProxyActive: true,
       remoteCompactionProviderId: 'cindy_openai',
+      cindyRemoteCompactionProviderId: 'cindy_codex',
     });
 
     // 显式 openai 来源(ChatGPT 订阅直连)→ thread 选 OpenAI 身份 provider(远端压缩)。
@@ -3720,7 +3726,7 @@ describe('CodexAgent.startSession developerInstructions', () => {
     expect(oauthParams.modelProvider).toBe('cindy_openai');
     await oauthHandle.close();
 
-    // 折扣 codex/(gateway-key 家族)→ 保持默认 provider(本地压缩)。
+    // Cindy Provider codex/* → 同一 app-server 内选择固定 HTTP 的远程压缩 identity。
     host.request.mock.calls.length = 0;
     const gatewayHandle = await agent.startSession({
       sessionId: 'session-gateway',
@@ -3731,8 +3737,35 @@ describe('CodexAgent.startSession developerInstructions', () => {
     const gatewayParams = host.request.mock.calls.find(([method]) => method === Method.ThreadStart)?.[1] as {
       modelProvider?: string;
     };
-    expect(gatewayParams.modelProvider).toBeUndefined();
+    expect(gatewayParams.modelProvider).toBe('cindy_codex');
     await gatewayHandle.close();
+
+    // 旧会话未写 providerId 时，codex/* 仍属于 Cindy Provider。
+    host.request.mock.calls.length = 0;
+    const implicitGatewayHandle = await agent.startSession({
+      sessionId: 'session-gateway-implicit',
+      model: 'codex/gpt-5.6-sol',
+      workingDir: '/repo',
+    });
+    const implicitGatewayParams = host.request.mock.calls.find(
+      ([method]) => method === Method.ThreadStart,
+    )?.[1] as { modelProvider?: string };
+    expect(implicitGatewayParams.modelProvider).toBe('cindy_codex');
+    await implicitGatewayHandle.close();
+
+    // Cindy Provider 的非 codex/* 模型不误开远程压缩。
+    host.request.mock.calls.length = 0;
+    const plainGatewayHandle = await agent.startSession({
+      sessionId: 'session-gateway-plain',
+      model: 'deepseek/deepseek-v4-pro',
+      providerId: 'xd',
+      workingDir: '/repo',
+    });
+    const plainGatewayParams = host.request.mock.calls.find(
+      ([method]) => method === Method.ThreadStart,
+    )?.[1] as { modelProvider?: string };
+    expect(plainGatewayParams.modelProvider).toBeUndefined();
+    await plainGatewayHandle.close();
 
     // xAI(provider-oauth 家族)→ 保持默认 provider。
     host.request.mock.calls.length = 0;
@@ -3747,6 +3780,32 @@ describe('CodexAgent.startSession developerInstructions', () => {
     };
     expect(xaiParams.modelProvider).toBeUndefined();
     await xaiHandle.close();
+  });
+
+  it('keeps Cindy codex root compaction local when an independent subagent uses another backend', async () => {
+    const agent = new CodexAgent(createDeps());
+    const host = installFakeHost(agent, undefined, {
+      codexProxyActive: true,
+      cindyRemoteCompactionProviderId: 'cindy_codex',
+      subagentRoute: {
+        providerId: 'xai',
+        catalogModel: 'xai/grok-4.3',
+        reasoningEffort: 'high',
+      },
+    });
+
+    const handle = await agent.startSession({
+      sessionId: 'session-cindy-codex-with-xai-subagent',
+      model: 'codex/gpt-5.6-sol',
+      providerId: 'xd',
+      workingDir: '/repo',
+    });
+    const params = host.request.mock.calls.find(
+      ([method]) => method === Method.ThreadStart,
+    )?.[1] as { modelProvider?: string };
+
+    expect(params.modelProvider).toBeUndefined();
+    await handle.close();
   });
 
   it('passes the OpenAI compaction provider for implicit-source sessions on an oauth-effective host', async () => {

--- a/packages/maker-core/src/agents/codex/index.test.ts
+++ b/packages/maker-core/src/agents/codex/index.test.ts
@@ -3805,6 +3805,7 @@ describe('CodexAgent.startSession developerInstructions', () => {
     )?.[1] as { modelProvider?: string };
 
     expect(params.modelProvider).toBeUndefined();
+    expect(handle.codexCindyRemoteCompactionCompatible).toBe(false);
     await handle.close();
   });
 

--- a/packages/maker-core/src/agents/codex/index.ts
+++ b/packages/maker-core/src/agents/codex/index.ts
@@ -191,6 +191,7 @@ import { buildMemoryScopeKey } from '../../memory/storage.js';
 import { CODEX_AGENT_COMMANDS } from './commands.js';
 import {
   canReuseCodexHostForCredentialMode,
+  isCindyProviderCodexRemoteCompactionRoute,
   resolveAgentCredentialMode,
   resolveEffectiveCredentialModeFromAuthSource,
 } from '../credential-mode.js';
@@ -2572,6 +2573,7 @@ export class CodexAgent extends BaseAgent {
     let codexBrowserUseVersion: string | undefined;
     let codexBrowserUseStartupTimeoutMs: number | undefined;
     let remoteCompactionProviderId: string | undefined;
+    let cindyRemoteCompactionProviderId: string | undefined;
     let buildSessionMcpConfig: CodexExtraSpawnConfig['buildSessionMcpConfig'];
     let subagentModelFallback: string | undefined;
     let subagentRoute: CodexExtraSpawnConfig['subagentRoute'];
@@ -2600,6 +2602,7 @@ export class CodexAgent extends BaseAgent {
       codexBrowserUseVersion = undefined;
       codexBrowserUseStartupTimeoutMs = undefined;
       remoteCompactionProviderId = undefined;
+      cindyRemoteCompactionProviderId = undefined;
       buildSessionMcpConfig = undefined;
       subagentModelFallback = undefined;
       subagentRoute = undefined;
@@ -2650,6 +2653,9 @@ export class CodexAgent extends BaseAgent {
           // (退化直连网关)时不得下发,否则远端压缩请求会打到不支持它的上游。
           if (codexProxyActive && cfg.codexRemoteCompactionProviderId) {
             remoteCompactionProviderId = cfg.codexRemoteCompactionProviderId;
+          }
+          if (codexProxyActive && cfg.codexCindyRemoteCompactionProviderId) {
+            cindyRemoteCompactionProviderId = cfg.codexCindyRemoteCompactionProviderId;
           }
           this.deps.logger.info('codex MCP bridge ready', {
             providers: this.deps.mcpProviders?.length ?? 0,
@@ -2737,6 +2743,7 @@ export class CodexAgent extends BaseAgent {
       codexBrowserUseVersion,
       codexBrowserUseStartupTimeoutMs,
       remoteCompactionProviderId,
+      cindyRemoteCompactionProviderId,
       buildSessionMcpConfig,
       subagentModelFallback,
       subagentRoute,
@@ -5267,21 +5274,31 @@ export class CodexAgent extends BaseAgent {
 
     const hostUsesCodexProxy = host.isCodexProxyActive();
 
-    // ── OpenAI 远端压缩身份(thread 级,start/resume 冻结)────────────────────
-    // 仅当 ① host 是 oauth spawn 且下发了 OpenAI 身份 provider(见
-    // CodexExtraSpawnConfig.codexRemoteCompactionProviderId),② 本会话的凭证家族
-    // 解析为 oauth-bearer(显式 openai 来源,或隐式来源 + host 归一化形态为订阅)
-    // 时,才让 thread 选 OpenAI 身份 provider → codex 走 OpenAI 远端压缩。
-    // codex/ 折扣(gateway-key)、xai/、chatgpt/ 与显式第三方来源(provider-oauth)
-    // 都被 resolveAgentCredentialMode 排除 —— 它们的上游不支持远端压缩,且 codex
-    // 远端压缩失败无本地回退,错配会打断长会话。
-    const threadModelProvider = (() => {
-      if (opts.remoteHostId) return undefined;
-      const providerIdFromHost = host.getRemoteCompactionProviderId?.();
-      if (!providerIdFromHost) return undefined;
-      const family = credentialMode ?? this.hostEffectiveCredentialModes.get(currentHostKey);
-      return family === 'oauth-bearer' ? providerIdFromHost : undefined;
-    })();
+    // Codex 只按 model provider 的 name="OpenAI" 判断远程压缩能力。Cindy 先按
+    // 产品来源 + codex/* 模型做语义路由，再选择同一 app-server 内固定 HTTP 的 identity。
+    const cindyProviderRemoteCompactionRequested = isCindyProviderCodexRemoteCompactionRoute({
+      providerId: mutableProviderId,
+      model: mutableModel,
+    });
+    const independentSubagentRoute = host.getSubagentRoute?.();
+    // 独立 Subagent 只在 proxy 层改写 Provider/model，Codex child thread 仍继承 root
+    // 的 model provider identity。若 child 不是同一 Cindy Codex 后端，给 root 打开
+    // remote compaction 会让 child 也错误调用不兼容上游；该组合保持本地压缩。
+    const cindyProviderRemoteCompaction = cindyProviderRemoteCompactionRequested && (
+      !independentSubagentRoute || isCindyProviderCodexRemoteCompactionRoute({
+        providerId: independentSubagentRoute.providerId,
+        model: independentSubagentRoute.catalogModel,
+      })
+    );
+    const threadCredentialFamily =
+      credentialMode ?? this.hostEffectiveCredentialModes.get(currentHostKey);
+    const threadModelProvider = opts.remoteHostId
+      ? undefined
+      : cindyProviderRemoteCompaction
+        ? host.getCindyRemoteCompactionProviderId?.() ?? undefined
+        : threadCredentialFamily === 'oauth-bearer'
+          ? host.getRemoteCompactionProviderId?.() ?? undefined
+          : undefined;
 
     /**
      * 本 thread 的 Responses 请求是否走 WebSocket。
@@ -5293,7 +5310,8 @@ export class CodexAgent extends BaseAgent {
      * 单独起名是为了把「选没选 provider」和「实际走不走 WS」分开，避免 prompt 注入
      * 通道错误地只看 provider 身份。
      */
-    const threadUsesWebSocket = !!threadModelProvider
+    const threadUsesWebSocket = !cindyProviderRemoteCompaction
+      && !!threadModelProvider
       && (host.getOpenAiWebSocketsEnabled?.() ?? true);
 
     /**

--- a/packages/maker-core/src/agents/codex/index.ts
+++ b/packages/maker-core/src/agents/codex/index.ts
@@ -5284,12 +5284,14 @@ export class CodexAgent extends BaseAgent {
     // 独立 Subagent 只在 proxy 层改写 Provider/model，Codex child thread 仍继承 root
     // 的 model provider identity。若 child 不是同一 Cindy Codex 后端，给 root 打开
     // remote compaction 会让 child 也错误调用不兼容上游；该组合保持本地压缩。
-    const cindyProviderRemoteCompaction = cindyProviderRemoteCompactionRequested && (
+    const cindyProviderRemoteCompactionCompatible = (
       !independentSubagentRoute || isCindyProviderCodexRemoteCompactionRoute({
         providerId: independentSubagentRoute.providerId,
         model: independentSubagentRoute.catalogModel,
       })
     );
+    const cindyProviderRemoteCompaction =
+      cindyProviderRemoteCompactionRequested && cindyProviderRemoteCompactionCompatible;
     const threadCredentialFamily =
       credentialMode ?? this.hostEffectiveCredentialModes.get(currentHostKey);
     const threadModelProvider = opts.remoteHostId
@@ -11082,6 +11084,9 @@ export class CodexAgent extends BaseAgent {
       get model() { return mutableModel; },
       get codexProxyActive() { return hostUsesCodexProxy; },
       get codexThreadModelProviderId() { return codexThreadModelProviderId; },
+      get codexCindyRemoteCompactionCompatible() {
+        return cindyProviderRemoteCompactionCompatible;
+      },
       get codexProductPromptDelivery() { return codexProductPromptDelivery; },
 
       validateSendOptions(sendOpts: SendOptions) {

--- a/packages/maker-core/src/agents/credential-mode.test.ts
+++ b/packages/maker-core/src/agents/credential-mode.test.ts
@@ -3,9 +3,28 @@ import { describe, expect, it } from 'vitest';
 import {
   canReuseCodexHostForCredentialMode,
   canReuseHostForCredentialMode,
+  isCindyProviderCodexRemoteCompactionRoute,
   resolveAgentCredentialMode,
   resolveEffectiveCredentialModeFromAuthSource,
 } from './credential-mode.js';
+
+describe('isCindyProviderCodexRemoteCompactionRoute', () => {
+  it.each([null, undefined, 'xd'])('accepts Cindy codex models for provider %s', (providerId) => {
+    expect(isCindyProviderCodexRemoteCompactionRoute({
+      providerId,
+      model: 'codex/gpt-5.6-sol',
+    })).toBe(true);
+  });
+
+  it.each([
+    { providerId: 'xd', model: 'gpt-5.6-sol' },
+    { providerId: 'openai', model: 'codex/gpt-5.6-sol' },
+    { providerId: 'xai', model: 'codex/gpt-5.6-sol' },
+    { providerId: 'xd', model: 'codex/' },
+  ])('rejects non-Cindy-Codex route $providerId/$model', (input) => {
+    expect(isCindyProviderCodexRemoteCompactionRoute(input)).toBe(false);
+  });
+});
 
 describe('resolveAgentCredentialMode', () => {
   it('uses built-in provider ids as the authoritative credential source', () => {

--- a/packages/maker-core/src/agents/credential-mode.ts
+++ b/packages/maker-core/src/agents/credential-mode.ts
@@ -7,6 +7,20 @@ export interface ResolveAgentCredentialModeOptions {
   model?: string | null;
 }
 
+/** Cindy Provider 中由 Codex Responses 上游实现远程压缩的模型路由。 */
+export function isCindyProviderCodexRemoteCompactionRoute(input: {
+  providerId: string | null | undefined;
+  model: string | null | undefined;
+}): boolean {
+  const providerId = input.providerId?.trim() || null;
+  const model = input.model?.trim() ?? '';
+  return (
+    (providerId === null || providerId === 'xd') &&
+    model.startsWith('codex/') &&
+    model.length > 'codex/'.length
+  );
+}
+
 /**
  * 根据本次会话的显式来源推导子进程凭证形态。
  *

--- a/packages/maker-core/src/agents/index.ts
+++ b/packages/maker-core/src/agents/index.ts
@@ -21,6 +21,7 @@ export { PiAgent } from './pi/index.js';
 export {
   canReuseCodexHostForCredentialMode,
   canReuseHostForCredentialMode,
+  isCindyProviderCodexRemoteCompactionRoute,
   resolveAgentCredentialMode,
 } from './credential-mode.js';
 // host 在 boot 阶段需要的 env 守卫(详见 claude-code/env-builder.ts 注释)

--- a/packages/maker-core/src/session.ts
+++ b/packages/maker-core/src/session.ts
@@ -1426,6 +1426,11 @@ export class Session {
     return this.handle.codexThreadModelProviderId;
   }
 
+  /** Codex-only: 当前 host 的独立 Subagent 路由是否兼容 Cindy Codex 远程压缩。 */
+  get codexCindyRemoteCompactionCompatible(): boolean | undefined {
+    return this.handle.codexCindyRemoteCompactionCompatible;
+  }
+
   /** Snapshot used by temporary host overrides to avoid undoing a newer user change. */
   get permissionModeState(): PermissionModeState {
     return { ...this.permissionModeStateValue };


### PR DESCRIPTION
## 这次改了什么

### 摘要

让 Cindy Provider 的 `codex/*` 模型启用 Codex 原生远程压缩。实现只增加一个内部 `name="OpenAI"`、HTTP-only 的 model provider identity；产品 Provider、Cindy Gateway、鉴权、模型路由和 Codex 进程复用方式均保持不变。

### 变更类型

- [x] `feat` 新功能
- [ ] `fix` 缺陷修复
- [ ] `refactor` / `perf` 重构或性能优化
- [ ] `docs` / `test` / `chore` 文档、测试或工程维护
- [ ] 其他：

### 范围

- 关联 Issue / 需求：Cindy Provider Codex 远程压缩适配
- 本 PR 包含：为 Cindy Provider `codex/*` 选择 HTTP-only `cindy_codex` identity；复用现有 Gateway 路由并保留远程 compaction；避免异后端独立 Subagent 继承错误 identity
- 明确不包含：新增产品 Provider；修改 ChatGPT 订阅 WS 链路；SSH 远程 Codex 配置；跨 Provider 历史迁移；其他模型行为
- 用户可见变化：Cindy Provider 的 Codex 长会话使用服务端远程压缩，不再走本地摘要压缩
- 是否存在 breaking change：无

### UI 变化

不涉及。

- 引用的设计规范：不涉及

## 怎么验证的

### 自动验证

```text
pnpm --filter desktop run --if-present typecheck
结果：通过

pnpm exec vitest run src/main/maker-host/__tests__/codexProxyHost.test.ts src/main/maker-host/__tests__/codexCredentialSwitch.test.ts --pool=forks --maxWorkers=1
结果：210 passed

pnpm exec vitest run src/agents/codex/index.test.ts src/agents/credential-mode.test.ts --pool=forks --maxWorkers=1
结果：580 passed

pnpm check:dco
结果：通过
```

`pnpm test:unit:related` 中本 PR 相关的 Codex/Desktop 测试通过；全命令仍有一条无关的 Pi xAI integration 用例固定在 60 秒超时。隔离复跑该 xAI 用例仍超时，隔离复跑其连带失败的 BYOM 用例通过。

### 手工验证

- macOS 本地开发实例，企业 Cindy Provider 账号
- 普通 turn：`/responses` 200，rollout 的 `model_provider` 为 `cindy_codex`
- 构造 254,664 token 上下文后继续发送：`/responses/compact` 200，随后 continuation 200
- rollout 生成 `type: "compacted"`，replacement history 包含带 `encrypted_content` 的 compaction；压缩后继续回复成功

### 未执行的验证

- 未做 Windows 实机验证；本次没有平台专属实现
- 未验证 SSH 远程 Codex；该链路明确不在本 PR 范围

## 风险

### 风险分类

- [ ] 无已知风险
- [ ] SQLite / migration
- [ ] system prompt
- [x] 协议兼容
- [ ] 权限 / 安全 / 用户数据
- [ ] 存量插件兼容（批准状态 / 指纹 / manifest 校验 / 安装布局 / 包格式）
- [ ] 原生层 / fingerprint / OTA
- [ ] 跨平台差异
- [ ] 其他：

### 影响与回滚

- 影响范围：仅本地 Cindy Provider `codex/*` thread 的 model provider identity 和 compaction 行为；普通请求仍走原 Cindy Gateway HTTP 路由
- 回滚 / 降级方式：移除 `cindy_codex` identity 选择后即恢复默认 `cindy_gateway` 和本地压缩

### 提交前检查

- [x] 已 review 完整 diff
- [x] 每个 commit 都带 DCO 签名（`git commit -s`，见 [DCO](../DCO)）
- [x] UI 改动已在「UI 变化」注明引用的设计规范（不涉及 UI 则跳过）
- [x] 未提交凭证、令牌或授权文件
- [x] 已补充必要文档（本次无需新增用户文档）
- [x] 已确认测试结果或说明未执行原因
