### PR TITLE
fix(desktop): lock skill preview host scrolling

### DIFF
--- a/apps/desktop/src/renderer/features/skillhub/SkillhubHomeView.tsx
+++ b/apps/desktop/src/renderer/features/skillhub/SkillhubHomeView.tsx
@@ -9,7 +9,7 @@
  * 三块都是整页内容卡片/列表;首页是栈底,自身无返回。
  */
 
-import { useCallback, useEffect, useMemo, useState } from 'react';
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { useNavigate } from 'react-router-dom';
 import { useTranslation } from 'react-i18next';
 import {
@@ -141,6 +141,8 @@ export function SkillhubHomeView({
   );
   const hasSearchResults = (marketAllowed && recommended.length > 0) || visibleLocalCount > 0;
 
+  const skillhubScrollRef = useRef<HTMLElement | null>(null);
+
   // 推荐技能的预览浮层 + 安装选择器(复用 Market 那套):点推荐卡 = 下一步直接
   // 进入该技能的预览;关闭 = 回退到首页。
   const [previewSkill, setPreviewSkill] = useState<MarketSkill | null>(null);
@@ -210,6 +212,7 @@ export function SkillhubHomeView({
       onSelectTab={onSelectCatalogTab}
     >
       <main
+        ref={skillhubScrollRef}
         className={cn(
           'relative h-full w-full overflow-x-hidden overflow-y-auto [scrollbar-gutter:stable_both-edges]',
           embedded ? 'bg-transparent' : 'bg-[var(--surface)]',
@@ -395,6 +398,7 @@ export function SkillhubHomeView({
         <SkillhubMarketPreviewPanel
           open={previewSkill !== null}
           skill={previewSkill}
+          scrollLockRef={skillhubScrollRef}
           onClose={() => setPreviewSkill(null)}
           primaryAction={
             previewSkill

--- a/apps/desktop/src/renderer/features/skillhub/SkillhubMarketListView.tsx
+++ b/apps/desktop/src/renderer/features/skillhub/SkillhubMarketListView.tsx
@@ -561,6 +561,7 @@ function SkillhubMarketListViewInner() {
       <SkillhubMarketPreviewPanel
         open={previewSkill !== null}
         skill={previewSkill}
+        scrollLockRef={marketScrollRef}
         onClose={handlePreviewClose}
         primaryAction={previewSkill
           ? marketCardPrimaryAction({

--- a/apps/desktop/src/renderer/features/skillhub/SkillhubMarketPreviewPanel.tsx
+++ b/apps/desktop/src/renderer/features/skillhub/SkillhubMarketPreviewPanel.tsx
@@ -1,4 +1,11 @@
-import { useEffect, useMemo, useState, type ReactNode } from 'react';
+import {
+  useEffect,
+  useLayoutEffect,
+  useMemo,
+  useState,
+  type ReactNode,
+  type RefObject,
+} from 'react';
 import { useTranslation } from 'react-i18next';
 import { Download, FileText, GraduationCap, X } from 'lucide-react';
 
@@ -35,6 +42,8 @@ import type { ScanResultPayload } from './PublishDialog';
 interface SkillhubMarketPreviewPanelProps {
   skill: MarketSkill | null;
   open: boolean;
+  /** The host list that must stop scrolling while the preview is open. */
+  scrollLockRef: RefObject<HTMLElement | null>;
   onClose: () => void;
   /** 与卡片同口径的主操作:clone / manage / none。头部据此渲染操作按钮 */
   primaryAction?: MarketCardPrimaryAction;
@@ -53,6 +62,7 @@ interface SkillhubMarketPreviewPanelProps {
 export function SkillhubMarketPreviewPanel({
   skill,
   open,
+  scrollLockRef,
   onClose,
   primaryAction = 'none',
   onClone,
@@ -153,6 +163,21 @@ export function SkillhubMarketPreviewPanel({
   }, [panelOpen, selectedPath, skillName, skillVersion, t]);
 
   const tree = useMemo(() => buildPreviewTree(files), [files]);
+
+  // The preview is an in-place drawer rather than a Radix Dialog, so it does
+  // not provide scroll locking for its host automatically. Preserve the host's
+  // inline value so closing the preview cannot clobber another scroll policy.
+  useLayoutEffect(() => {
+    if (!panelOpen) return undefined;
+    const container = scrollLockRef.current;
+    if (!container) return undefined;
+
+    const previousOverflowY = container.style.overflowY;
+    container.style.overflowY = 'hidden';
+    return () => {
+      container.style.overflowY = previousOverflowY;
+    };
+  }, [panelOpen, scrollLockRef]);
 
   return (
     <>

--- a/apps/desktop/src/renderer/features/skillhub/SkillhubMarketPreviewPanel.tsx
+++ b/apps/desktop/src/renderer/features/skillhub/SkillhubMarketPreviewPanel.tsx
@@ -1,6 +1,5 @@
 import {
   useEffect,
-  useLayoutEffect,
   useMemo,
   useState,
   type ReactNode,
@@ -38,6 +37,7 @@ import { MarketPreviewTree } from './components/MarketPreviewTree';
 import { ManageMenu, type MarketCardManageAction } from './components/MarketCard';
 import { ScanResultDialog } from './ScanResultDialog';
 import type { ScanResultPayload } from './PublishDialog';
+import { useSkillhubPreviewScrollLock } from './lib/useSkillhubPreviewScrollLock';
 
 interface SkillhubMarketPreviewPanelProps {
   skill: MarketSkill | null;
@@ -164,20 +164,7 @@ export function SkillhubMarketPreviewPanel({
 
   const tree = useMemo(() => buildPreviewTree(files), [files]);
 
-  // The preview is an in-place drawer rather than a Radix Dialog, so it does
-  // not provide scroll locking for its host automatically. Preserve the host's
-  // inline value so closing the preview cannot clobber another scroll policy.
-  useLayoutEffect(() => {
-    if (!panelOpen) return undefined;
-    const container = scrollLockRef.current;
-    if (!container) return undefined;
-
-    const previousOverflowY = container.style.overflowY;
-    container.style.overflowY = 'hidden';
-    return () => {
-      container.style.overflowY = previousOverflowY;
-    };
-  }, [panelOpen, scrollLockRef]);
+  useSkillhubPreviewScrollLock(panelOpen, scrollLockRef);
 
   return (
     <>

--- a/apps/desktop/src/renderer/features/skillhub/lib/__tests__/marketPreviewScrollLock.test.tsx
+++ b/apps/desktop/src/renderer/features/skillhub/lib/__tests__/marketPreviewScrollLock.test.tsx
@@ -1,0 +1,48 @@
+// @vitest-environment jsdom
+
+import { cleanup, renderHook } from '@testing-library/react';
+import type { RefObject } from 'react';
+import { afterEach, describe, expect, it } from 'vitest';
+
+import { useSkillhubPreviewScrollLock } from '../useSkillhubPreviewScrollLock';
+
+afterEach(() => {
+  cleanup();
+});
+
+function renderScrollLock(
+  locked: boolean,
+  scrollLockRef: RefObject<HTMLElement | null>,
+): ReturnType<typeof renderHook<void, { locked: boolean }>> {
+  return renderHook(
+    ({ locked: isLocked }) => useSkillhubPreviewScrollLock(isLocked, scrollLockRef),
+    { initialProps: { locked } },
+  );
+}
+
+describe('useSkillhubPreviewScrollLock', () => {
+  it('locks on open and restores the host overflow on close', () => {
+    const host = document.createElement('main');
+    host.style.overflowY = 'auto';
+    const scrollLockRef = { current: host };
+    const view = renderScrollLock(true, scrollLockRef);
+
+    expect(host.style.overflowY).toBe('hidden');
+
+    view.rerender({ locked: false });
+    expect(host.style.overflowY).toBe('auto');
+    host.remove();
+  });
+
+  it('restores the host overflow when the preview unmounts', () => {
+    const host = document.createElement('main');
+    host.style.overflowY = 'scroll';
+    const scrollLockRef = { current: host };
+    const view = renderScrollLock(true, scrollLockRef);
+
+    expect(host.style.overflowY).toBe('hidden');
+    view.unmount();
+    expect(host.style.overflowY).toBe('scroll');
+    host.remove();
+  });
+});

--- a/apps/desktop/src/renderer/features/skillhub/lib/__tests__/marketRoutes.test.ts
+++ b/apps/desktop/src/renderer/features/skillhub/lib/__tests__/marketRoutes.test.ts
@@ -53,6 +53,20 @@ describe('market route scope', () => {
     expect(previewSource).not.toContain('previewMarket');
   });
 
+  it('locks the host catalog scroll surface while the preview is open', () => {
+    const homeSource = readFileSync(resolve(skillhubDir, 'SkillhubHomeView.tsx'), 'utf8');
+    const listSource = readFileSync(resolve(skillhubDir, 'SkillhubMarketListView.tsx'), 'utf8');
+    const previewSource = readFileSync(resolve(skillhubDir, 'SkillhubMarketPreviewPanel.tsx'), 'utf8');
+
+    expect(previewSource).toContain('scrollLockRef');
+    expect(previewSource).toContain("container.style.overflowY = 'hidden'");
+    expect(previewSource).toContain('previousOverflowY');
+    expect(previewSource).toContain('container.style.overflowY = previousOverflowY');
+    expect(homeSource).toContain('ref={skillhubScrollRef}');
+    expect(homeSource).toContain('scrollLockRef={skillhubScrollRef}');
+    expect(listSource).toContain('scrollLockRef={marketScrollRef}');
+  });
+
   it('gates cloud management to the My Published entry point', () => {
     const listSource = readFileSync(resolve(skillhubDir, 'SkillhubMarketListView.tsx'), 'utf8');
     const viewModelSource = readFileSync(resolve(skillhubDir, 'lib/marketDetailViewModel.ts'), 'utf8');

--- a/apps/desktop/src/renderer/features/skillhub/lib/__tests__/marketRoutes.test.ts
+++ b/apps/desktop/src/renderer/features/skillhub/lib/__tests__/marketRoutes.test.ts
@@ -53,15 +53,13 @@ describe('market route scope', () => {
     expect(previewSource).not.toContain('previewMarket');
   });
 
-  it('locks the host catalog scroll surface while the preview is open', () => {
+  it('wires the host catalog scroll surface into the preview panel', () => {
     const homeSource = readFileSync(resolve(skillhubDir, 'SkillhubHomeView.tsx'), 'utf8');
     const listSource = readFileSync(resolve(skillhubDir, 'SkillhubMarketListView.tsx'), 'utf8');
     const previewSource = readFileSync(resolve(skillhubDir, 'SkillhubMarketPreviewPanel.tsx'), 'utf8');
 
     expect(previewSource).toContain('scrollLockRef');
-    expect(previewSource).toContain("container.style.overflowY = 'hidden'");
-    expect(previewSource).toContain('previousOverflowY');
-    expect(previewSource).toContain('container.style.overflowY = previousOverflowY');
+    expect(previewSource).toContain('useSkillhubPreviewScrollLock');
     expect(homeSource).toContain('ref={skillhubScrollRef}');
     expect(homeSource).toContain('scrollLockRef={skillhubScrollRef}');
     expect(listSource).toContain('scrollLockRef={marketScrollRef}');

--- a/apps/desktop/src/renderer/features/skillhub/lib/useSkillhubPreviewScrollLock.ts
+++ b/apps/desktop/src/renderer/features/skillhub/lib/useSkillhubPreviewScrollLock.ts
@@ -1,0 +1,25 @@
+import { useLayoutEffect, type RefObject } from 'react';
+
+/**
+ * Locks the catalog scroll surface while the in-place skill preview is open.
+ *
+ * The preview is not a Radix Dialog, so its host container needs an explicit
+ * lock. The previous inline value is restored on close or unmount so this hook
+ * does not overwrite another scroll policy owned by the host.
+ */
+export function useSkillhubPreviewScrollLock(
+  locked: boolean,
+  scrollLockRef: RefObject<HTMLElement | null>,
+): void {
+  useLayoutEffect(() => {
+    if (!locked) return undefined;
+    const container = scrollLockRef.current;
+    if (!container) return undefined;
+
+    const previousOverflowY = container.style.overflowY;
+    container.style.overflowY = 'hidden';
+    return () => {
+      container.style.overflowY = previousOverflowY;
+    };
+  }, [locked, scrollLockRef]);
+}


### PR DESCRIPTION
## 这次改了什么

### 摘要

技能管理页打开技能预览时，遮罩未锁定首页/市场列表的宿主滚动容器，导致鼠标滚轮事件穿透并滚动父容器。本 PR 为两个入口接入真实滚动容器，并在预览打开期间锁定 `overflow-y`，关闭时恢复原值。

### 变更类型

- [x] `fix` 缺陷修复
- [ ] `feat` 新功能
- [ ] `refactor` / `perf` 重构或性能优化
- [ ] `docs` / `test` / `chore` 文档、测试或工程维护

### 范围

- 关联 Issue / 需求：无
- 本 PR 包含：技能首页和市场列表的预览滚动锁定，以及静态契约测试
- 明确不包含：其他弹窗、全局页面或父级窗口滚动策略调整
- 用户可见变化：预览打开后，父容器不再随鼠标滚轮滚动
- 是否存在 breaking change：无

### UI 变化

- 引用的设计规范：`docs/design-rules/DESIGN.md` §4 Dialog & Modal（遮罩使用现有 `--overlay-modal`，浮层保持现有层级）；§10 Light / Dark 双模式交付门槛（本次不新增颜色或主题分支，现有双模式样式保持不变）
- 交互变化：预览浮层打开期间锁定其宿主滚动容器，关闭后恢复原滚动策略

## 怎么验证的

### 自动验证

```text
- [x] pnpm test:unit:related -- --workspace-concurrency=1
      结果：apps/desktop related unit 通过（19 个相关测试）
- [x] SkillhubPreviewScrollLock 生命周期回归测试
      结果：预览打开时锁定宿主 overflow-y，关闭和卸载时恢复原值
- [x] pnpm --filter desktop run --if-present typecheck
      结果：通过
- [x] pnpm exec vite build --config vite.renderer.config.ts
      结果：生产 renderer bundle 构建通过（6229 个模块）
- [x] git diff --check
      结果：通过
- [x] pnpm check:dco
      结果：1 个新增 commit 均已签名
```

### 手工验证

- [x] 在开发版技能管理页打开技能预览，滚动鼠标滚轮，确认首页/市场列表父容器不再滚动
- 平台：macOS 开发版，隔离 worktree 沙箱

### 未执行的验证

- [ ] 完整 Electron 安装包构建：当前机器缺少 `SimulatorKit.framework`，iOS Simulator sidecar 构建失败；与本次 renderer 改动无关。renderer 生产构建已单独通过。

## 风险

### 风险分类

- [x] 无已知风险
- [ ] SQLite / migration
- [ ] system prompt
- [ ] 协议兼容
- [ ] 权限 / 安全 / 用户数据
- [ ] 原生层 / fingerprint / OTA
- [ ] 跨平台差异

### 影响与回滚

- 影响范围：仅技能预览浮层打开期间的技能管理页滚动行为；不涉及数据、协议、原生层或插件存储格式
- 回滚 / 降级方式：回滚本 PR 提交 `d27ff9943`

### 提交前检查

- [x] 已 review 完整 diff
- [x] 每个 commit 都带 DCO 签名
- [x] UI 改动已注明设计规范
- [x] 未提交凭证、令牌或授权文件
- [x] 已确认测试结果或说明未执行原因
