### PR TITLE
fix(desktop): 自动续跑后收掉过期的侧边栏错误红点

### DIFF
--- a/apps/desktop/src/renderer/__tests__/useSessionRunningStatusSilence.test.ts
+++ b/apps/desktop/src/renderer/__tests__/useSessionRunningStatusSilence.test.ts
@@ -13,6 +13,7 @@ import {
 } from '@/lib/silencedSessionDoneStore';
 import { markSessionStarting, resetSessionStartingStoreForTests } from '@/lib/sessionStartingStore';
 import { useSessionRunningStatus } from '@/hooks/useSessionRunningStatus';
+import { noteSessionTurnStartedForAlerts } from '@/hooks/usePendingAlertAttention';
 import {
   addSessionAttention,
   clearSessionAttention,
@@ -46,6 +47,10 @@ vi.mock('@/lib/sessionAttentionStore', () => ({
   getSessionAttentionKind: vi.fn(() => undefined),
   hasSessionAttention: vi.fn(() => false),
   useSessionAttentionSnapshot: () => new Set<string>(),
+}));
+
+vi.mock('@/hooks/usePendingAlertAttention', () => ({
+  noteSessionTurnStartedForAlerts: vi.fn(),
 }));
 
 function status(isRunning: boolean, hasError = false, sideTask?: boolean): SessionStatusInfo {
@@ -483,6 +488,7 @@ describe('useSessionRunningStatus silenced completion handling', () => {
     expect(vi.mocked(clearSessionAttention)).toHaveBeenCalledWith('s-orphan', {
       intent: 'explicit',
     });
+    expect(vi.mocked(noteSessionTurnStartedForAlerts)).toHaveBeenCalledWith('s-orphan');
     vi.mocked(getSessionAttentionKind).mockReturnValue(undefined);
   });
 
@@ -496,6 +502,7 @@ describe('useSessionRunningStatus silenced completion handling', () => {
     expect(vi.mocked(clearSessionAttention)).not.toHaveBeenCalledWith('s-real', {
       intent: 'explicit',
     });
+    expect(vi.mocked(noteSessionTurnStartedForAlerts)).toHaveBeenCalledWith('s-real');
     vi.mocked(getSessionAttentionKind).mockReturnValue(undefined);
     storeMock.terminalErrorSessions.delete('s-real');
   });

--- a/apps/desktop/src/renderer/hooks/__tests__/usePendingAlertAttention.test.ts
+++ b/apps/desktop/src/renderer/hooks/__tests__/usePendingAlertAttention.test.ts
@@ -8,6 +8,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 import {
   _resetPendingAlertAttentionForTests,
+  noteSessionTurnStartedForAlerts,
   refreshPendingAlerts,
   usePendingAlertAttention,
 } from '@/hooks/usePendingAlertAttention';
@@ -28,6 +29,9 @@ const clearMock = vi.mocked(clearSessionAttention);
 const kindMock = vi.mocked(getSessionAttentionKind);
 const errorTailPendingMock = vi.fn<() => Promise<string[]>>();
 const interruptedPendingMock = vi.fn<() => Promise<string[]>>();
+const createdListeners: Array<
+  (payload: { sessionId: string; message: { role?: string } }, ownerStamp?: unknown) => void
+> = [];
 
 /** 驱动一次错误尾行重算并等它收敛完成。 */
 async function reconcile(ids: string[]): Promise<void> {
@@ -38,11 +42,24 @@ async function reconcile(ids: string[]): Promise<void> {
 describe('usePendingAlertAttention (派生收敛)', () => {
   beforeEach(() => {
     _resetPendingAlertAttentionForTests();
+    createdListeners.length = 0;
     (window as unknown as { electronAPI: unknown }).electronAPI = {
       localDb: {
         sessions: {
           errorTailPending: errorTailPendingMock,
           interruptedPending: interruptedPendingMock,
+        },
+        sessionsPush: {
+          onPatched: () => () => {},
+        },
+        messages: {
+          onErrorPersisted: () => () => {},
+          onCreated: (
+            cb: (payload: { sessionId: string; message: { role?: string } }, ownerStamp?: unknown) => void,
+          ) => {
+            createdListeners.push(cb);
+            return () => {};
+          },
         },
       },
     };
@@ -200,5 +217,66 @@ describe('usePendingAlertAttention (派生收敛)', () => {
     await Promise.resolve();
 
     expect(addMock).toHaveBeenCalledWith('s-boot-tail', 'error');
+  });
+
+  it('认领了错误尾行时,该会话的 user 行触发重算;告警已消失则 explicit 清点', async () => {
+    await reconcile(['s1']);
+    interruptedPendingMock.mockResolvedValue([]);
+    renderHook(() => usePendingAlertAttention());
+    expect(createdListeners.length).toBeGreaterThan(0);
+
+    addMock.mockClear();
+    clearMock.mockClear();
+    errorTailPendingMock.mockClear();
+    errorTailPendingMock.mockResolvedValue([]);
+
+    createdListeners[0]!({ sessionId: 's1', message: { role: 'user' } });
+    await refreshPendingAlerts();
+    expect(clearMock).toHaveBeenCalledWith('s1', { intent: 'explicit' });
+  });
+
+  it('未认领错误尾行时,user 行不打 IPC', async () => {
+    interruptedPendingMock.mockResolvedValue([]);
+    errorTailPendingMock.mockResolvedValue([]);
+    renderHook(() => usePendingAlertAttention());
+    expect(createdListeners.length).toBeGreaterThan(0);
+
+    await refreshPendingAlerts();
+    errorTailPendingMock.mockClear();
+    createdListeners[0]!({ sessionId: 's1', message: { role: 'user' } });
+    await Promise.resolve();
+    await Promise.resolve();
+    expect(errorTailPendingMock).not.toHaveBeenCalled();
+  });
+
+  it('assistant 行不触发错误尾行重算', async () => {
+    await reconcile(['s1']);
+    interruptedPendingMock.mockResolvedValue([]);
+    renderHook(() => usePendingAlertAttention());
+    errorTailPendingMock.mockClear();
+
+    createdListeners[0]!({ sessionId: 's1', message: { role: 'assistant' } });
+    await Promise.resolve();
+    await Promise.resolve();
+    expect(errorTailPendingMock).not.toHaveBeenCalled();
+  });
+
+  it('新一轮启动时重算仍认领的错误尾行,告警消失则 explicit 清点', async () => {
+    await reconcile(['s1']);
+    clearMock.mockClear();
+    errorTailPendingMock.mockClear();
+    errorTailPendingMock.mockResolvedValue([]);
+
+    noteSessionTurnStartedForAlerts('s1');
+    await refreshPendingAlerts();
+    expect(clearMock).toHaveBeenCalledWith('s1', { intent: 'explicit' });
+  });
+
+  it('新一轮启动时未认领该会话则不打 IPC', async () => {
+    await reconcile(['s1']);
+    errorTailPendingMock.mockClear();
+    noteSessionTurnStartedForAlerts('other');
+    await Promise.resolve();
+    expect(errorTailPendingMock).not.toHaveBeenCalled();
   });
 });

--- a/apps/desktop/src/renderer/hooks/usePendingAlertAttention.ts
+++ b/apps/desktop/src/renderer/hooks/usePendingAlertAttention.ts
@@ -27,7 +27,12 @@
  * 重算触发点(全量重查 + 差分,不做增量推断):
  *  - 错误行落库脏信号(local-db:session:error-persisted)—— 正是 makerChatStore 清掉
  *    live error 的同一个信号,交接窗口红点不掉;
- *  - refreshPendingAlerts() 显式调用 —— 横幅处置(dismiss / 继续 / 批量已读)后触发。
+ *  - 已认领错误尾行的会话插入新 user 行(messages:created)—— 文件头不变量:
+ *    turn 一起就插 user 行,error 不再是尾行。自动续跑的 UI_ACTION_TRIGGER 也是
+ *    user 行;此前只订 error 行,续跑成功、横幅已灭时红点不掉。
+ *  - refreshPendingAlerts() 显式调用 —— 横幅处置(dismiss / 继续 / 批量已读)后触发;
+ *  - noteSessionTurnStartedForAlerts() —— 新一轮启动时补一次,覆盖 running 投影
+ *    早于 user 行落库的窗口。
  *
  * 打点范围限定:只清**本 hook 自己打过**且当前仍是 'error' 的点,不误伤 live error、
  * done、awaiting 等其它来源。
@@ -172,6 +177,18 @@ function noteInterruptedAck(sessionId: string): void {
   clearAlertIfStillError(sessionId);
 }
 
+/**
+ * 新一轮启动时收敛错误尾行红点。中断腿仍只认 lastTurnEndedAt(side-task 上升沿
+ * 也会把 isRunning 翻成 true,不能当成「继续 / 忽略」)。
+ *
+ * 只在本 hook 仍认领该会话的错误尾行时才打 IPC;查询结果若已不是尾行,差分会
+ * explicit 清点。生产调用点 fire-and-forget。
+ */
+export function noteSessionTurnStartedForAlerts(sessionId: string): void {
+  if (!_errorTailOwned.has(sessionId)) return;
+  void refreshPendingAlerts();
+}
+
 /** 启动首拉:中断腿 + 错误尾行腿各拉一次,分别记账。 */
 async function initialFetch(): Promise<void> {
   const gen = ++_queryGen;
@@ -246,14 +263,23 @@ export function usePendingAlertAttention(): void {
   // error 行的**更新**广播(peer 收敛):另一个窗口 / device-link 端点点「忽略」时,
   // dismissErrorMessage 会把 merge 后的行经 messages:created 广播出去,peer 的横幅
   // 据此即时熄灭 —— 但 error-persisted 只在错误**首次落库**时发,peer 的红点因此会
-  // 一直残留到某个无关的重算(PR #879 review P1)。这里按 role 过滤后重算,把
-  // dismiss / 新错误行两种情况都收敛掉;非 error 行不触发,避免每条消息都查一次库。
+  // 一直残留到某个无关的重算(PR #879 review P1)。
+  //
+  // user 行:只在本 hook 仍认领该会话的错误尾行时重算。文件头不变量是「新 turn
+  // 的 user 行会让 error 不再是尾行」;自动续跑的 UI_ACTION_TRIGGER 也是 user 行,
+  // 若不订这条,横幅已灭、任务已在跑,红点却一直亮。其它会话 / 非 user 行不打 IPC。
   useEffect(() => {
     const onCreated = window.electronAPI?.localDb?.messages?.onCreated;
     if (!onCreated) return;
-    return onCreated(({ message }, ownerStamp) => {
+    return onCreated(({ sessionId, message }, ownerStamp) => {
       if (!isDataOwnerPushCurrent(ownerStamp)) return;
-      if (message?.role === 'error') void refreshPendingAlerts();
+      if (message?.role === 'error') {
+        void refreshPendingAlerts();
+        return;
+      }
+      if (message?.role === 'user' && _errorTailOwned.has(sessionId)) {
+        void refreshPendingAlerts();
+      }
     });
   }, []);
 }

--- a/apps/desktop/src/renderer/hooks/useSessionRunningStatus.ts
+++ b/apps/desktop/src/renderer/hooks/useSessionRunningStatus.ts
@@ -53,6 +53,7 @@ import {
   isSessionTerminalNotificationOwnedByScheduler,
   isSessionDoneSilenced,
 } from '@/lib/silencedSessionDoneStore';
+import { noteSessionTurnStartedForAlerts } from '@/hooks/usePendingAlertAttention';
 
 // Codex maker 化后, codex session 也走 makerChatStore;
 // 不再需要双 store 合并 —— 直接订阅 makerChatStore 即可。
@@ -157,12 +158,16 @@ export function useSessionRunningStatus(
         // 重新挂角标,提醒不丢失。
         // 与派生红点(usePendingAlertAttention)一致:turn 启动会插入新的 user 行,
         // 原 error 行不再是尾行,pending-alerts 也不再命中 —— 两条路径同向收敛。
+        // hasSessionTerminalError 仍为 true 时不清(mivo 等 skipTurnReset 上升沿
+        // 不拆横幅);派生账本另走 noteSessionTurnStartedForAlerts,只在仍认领
+        // 错误尾行时重算,横幅已灭则差分熄灭红点。
         if (
           getSessionAttentionKind(sessionId) === 'error' &&
           !makerChatStore.hasSessionTerminalError(sessionId)
         ) {
           clearSessionAttention(sessionId, { intent: 'explicit' });
         }
+        noteSessionTurnStartedForAlerts(sessionId);
         // Queue auto-drain cancellation:如果此 session 有 pending done 定时器
         // (刚 turn done 还在 debounce 窗口内),说明 main 正在自动衔接下一条队列
         // 消息 —— 取消这次通知/角标 fire。用户视角这是一条完整任务的中间态。


### PR DESCRIPTION
## 这次改了什么

### 摘要

任务报错后如果自动续跑成功，输入框上方的红色横幅会消失，但侧边栏任务列表上的红色角标还可能一直亮着。用户点开任务也清不掉，因为错误红点按产品规则只能跟着「还有没处理的报错」走，不能靠点开会话消掉。

根因是红点靠「最后一条可见消息是不是未处理报错」来投影。自动续跑会插入一条隐藏的 user 行，报错不再是尾行、横幅也不再显示，但红点那条路径以前只在新的 error 行落库时才重算，所以投影过期。

这次让已亮红点的任务在插入新 user 行、以及新一轮启动时重新查询；查询结果里已经没有这条告警，就把红点收掉。真正还在的报错横幅不受影响。

### 变更类型

- [x] `fix` 缺陷修复
- [ ] `feat` 新功能
- [ ] `refactor` / `perf` 重构或性能优化
- [ ] `docs` / `test` / `chore` 文档、测试或工程维护
- [ ] 其他：

### 范围

- 关联 Issue / 需求：无独立 issue；由任务 `#3534 Grok malformed tool call 保护与 wire 诊断` 侧边栏红点消不掉触发。
- 本 PR 包含：错误红点在自动续跑 / 新一轮启动后按 DB 查询结果重新收敛；补单测。
- 明确不包含：不改红点产品语义（仍是未处理告警的投影，点开会话不清红点）；不改中断横幅的 ack 路径；不改 live error 的 orphan 清理守卫（`skipTurnReset` 旁路任务上升沿仍不能误清还在的横幅）。
- 用户可见变化：自动续跑成功且报错横幅已灭时，侧边栏错误红点应熄灭。
- 是否存在 breaking change：无

### UI 变化

- 不涉及：只修正错误红点收敛时机，无视觉/交互/文案改动
- 引用的设计规范：不涉及：只修正错误红点收敛时机，无视觉/交互/文案变化

## 怎么验证的

### 自动验证

```text
pnpm test:unit:related
结果：PASS  desktop  14.20s

pnpm --filter desktop run --if-present typecheck
结果：通过（exit 0）
```

相关单测：
- `apps/desktop/src/renderer/hooks/__tests__/usePendingAlertAttention.test.ts`（含 user 行 / turn 启动触发重算）
- `apps/desktop/src/renderer/__tests__/useSessionRunningStatusSilence.test.ts`（旁路任务仍真实的错误红点不清；orphan 清理时补一次重算）

### 手工验证

未在本 worktree 启动 Desktop。未实机复现「Codex 不可达 → 自动续跑成功 → 横幅已灭但红点仍亮」。

### 未执行的验证

- 未启动 Desktop 做手工回归。
- 未跑全量 `pnpm test:unit`（提交前按仓库规则跑了 `test:unit:related` 与 desktop typecheck）。

## 风险

### 风险分类

- [x] 无已知风险
- [ ] SQLite / migration
- [ ] system prompt
- [ ] 协议兼容
- [ ] 权限 / 安全 / 用户数据
- [ ] 存量插件兼容（批准状态 / 指纹 / manifest 校验 / 安装布局 / 包格式）
- [ ] 原生层 / fingerprint / OTA
- [ ] 跨平台差异
- [ ] 其他：

### 影响与回滚

- 影响范围：Desktop renderer 侧边栏错误红点收敛时机。不改 schema、IPC、协议或 mobile 原生层。device-link 对端已能收到 `messages:created`，本 PR 未新增 channel。
- 回滚 / 降级方式：回退本 PR。
- 远程工作区 / SSH：不涉及 workdir 文件或远端 agent 进程，红点数据来自本机会话 DB。
- 设备互联 / 手机版：未新增或修改 IPC；对端若走同一 `messages:created` 推送，会一起触发重算。手机版无独立侧边栏红点实现，不另开入口。
- 故障半径：不触及 device-link 重试 / 超时 / 断链恢复。

### 提交前检查

- [x] 已 review 完整 diff
- [x] 每个 commit 都带 DCO 签名（`git commit -s`，见 [DCO](../DCO)）
- [x] UI 改动已在「UI 变化」注明引用的设计规范章节（不涉及 UI 则跳过）
- [x] 未提交凭证、令牌或授权文件
- [x] 已补充必要文档
- [x] 已确认测试结果或说明未执行原因
