### PR TITLE
fix(claude-code): 子代理不再毁掉父级 tok/s

### DIFF
--- a/packages/maker-core/src/agents/claude-code/generation-timing.test.ts
+++ b/packages/maker-core/src/agents/claude-code/generation-timing.test.ts
@@ -675,6 +675,10 @@ describe('claude generation pause boundaries', () => {
     const generating = events.filter(
       (event) => event.type === 'status' && (event.data as { status?: string }).status === 'Generating...',
     );
+    expect(generating[1]?.data).toMatchObject({
+      outputTokens: 0,
+      generationReliable: false,
+    });
     expect(generating.at(-1)?.data).toMatchObject({
       outputTokens: 80,
       generationReliable: true,
@@ -684,6 +688,188 @@ describe('claude generation pause boundaries', () => {
     );
     expect(doneStatus?.data).toMatchObject({
       outputTokens: 80,
+      generationReliable: true,
+      generationActive: false,
+    });
+    resetClaudeGenerationTiming(ctx.rt.generation);
+    vi.useRealTimers();
+  });
+
+  it('hides live tok/s until the current parent request streams output', async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(1_000);
+    const ctx = createTranslatorCtx();
+    const queue = createAsyncQueue<AgentEvent>();
+
+    translateSdkMessage(
+      {
+        type: 'stream_event',
+        event: {
+          type: 'message_start',
+          message: { model: 'claude-sonnet-4.5', usage: { input_tokens: 10 } },
+        },
+      },
+      queue,
+      ctx,
+    );
+    translateSdkMessage(
+      {
+        type: 'stream_event',
+        event: {
+          type: 'content_block_start',
+          index: 0,
+          content_block: { type: 'tool_use', id: 'toolu-agent-1', name: 'Agent', input: {} },
+        },
+      },
+      queue,
+      ctx,
+    );
+    vi.setSystemTime(1_800);
+    translateSdkMessage(
+      {
+        type: 'stream_event',
+        event: { type: 'message_delta', usage: { output_tokens: 80 } },
+      },
+      queue,
+      ctx,
+    );
+    translateSdkMessage(
+      {
+        type: 'stream_event',
+        parent_tool_use_id: 'toolu-agent-1',
+        event: {
+          type: 'message_start',
+          message: { model: 'claude-sonnet-4.5', usage: { input_tokens: 5 } },
+        },
+      },
+      queue,
+      ctx,
+    );
+    translateSdkMessage(
+      {
+        type: 'stream_event',
+        parent_tool_use_id: 'toolu-agent-1',
+        event: { type: 'message_delta', usage: { output_tokens: 500 } },
+      },
+      queue,
+      ctx,
+    );
+    translateSdkMessage(
+      {
+        type: 'user',
+        message: {
+          content: [{ type: 'tool_result', tool_use_id: 'toolu-agent-1', content: 'child 1 done' }],
+        },
+      },
+      queue,
+      ctx,
+    );
+
+    vi.setSystemTime(2_200);
+    translateSdkMessage(
+      {
+        type: 'stream_event',
+        event: {
+          type: 'message_start',
+          message: { model: 'claude-sonnet-4.5', usage: { input_tokens: 20 } },
+        },
+      },
+      queue,
+      ctx,
+    );
+    expect(ctx.rt.generation.reliable).toBe(true);
+
+    vi.setSystemTime(2_600);
+    translateSdkMessage(
+      {
+        type: 'stream_event',
+        parent_tool_use_id: 'toolu-agent-2',
+        event: {
+          type: 'message_start',
+          message: { model: 'claude-sonnet-4.5', usage: { input_tokens: 5 } },
+        },
+      },
+      queue,
+      ctx,
+    );
+    expect(ctx.rt.generation.reliable).toBe(true);
+    expect(ctx.rt.generation.startedAt).toBeNull();
+
+    translateSdkMessage(
+      {
+        type: 'stream_event',
+        event: {
+          type: 'content_block_start',
+          index: 0,
+          content_block: { type: 'tool_use', id: 'toolu-agent-2', name: 'Agent', input: {} },
+        },
+      },
+      queue,
+      ctx,
+    );
+    vi.setSystemTime(2_800);
+    translateSdkMessage(
+      {
+        type: 'stream_event',
+        event: { type: 'message_delta', usage: { output_tokens: 40 } },
+      },
+      queue,
+      ctx,
+    );
+    expect(ctx.rt.generation.reliable).toBe(true);
+
+    translateSdkMessage(
+      {
+        type: 'stream_event',
+        parent_tool_use_id: 'toolu-agent-2',
+        event: { type: 'message_delta', usage: { output_tokens: 200 } },
+      },
+      queue,
+      ctx,
+    );
+    translateSdkMessage(
+      {
+        type: 'user',
+        message: {
+          content: [{ type: 'tool_result', tool_use_id: 'toolu-agent-2', content: 'child 2 done' }],
+        },
+      },
+      queue,
+      ctx,
+    );
+    vi.setSystemTime(3_200);
+    translateSdkMessage(
+      {
+        type: 'result',
+        stop_reason: 'end_turn',
+        total_cost_usd: 0,
+        num_turns: 1,
+        usage: { input_tokens: 40, output_tokens: 820 },
+      },
+      queue,
+      ctx,
+    );
+    queue.end();
+    const events: AgentEvent[] = [];
+    for await (const event of queue) events.push(event);
+
+    const generating = events.filter(
+      (event) => event.type === 'status' && (event.data as { status?: string }).status === 'Generating...',
+    );
+    const pendingCurrentParent = generating.filter((event) => {
+      const data = event.data as { outputTokens?: number; generationReliable?: boolean };
+      return data.outputTokens === 80 && data.generationReliable === false;
+    });
+    expect(pendingCurrentParent.length).toBeGreaterThan(0);
+    expect(generating.at(-1)?.data).toMatchObject({
+      outputTokens: 120,
+      generationReliable: true,
+    });
+    const doneStatus = events.find(
+      (event) => event.type === 'status' && (event.data as { status?: string }).status === 'Done',
+    );
+    expect(doneStatus?.data).toMatchObject({
+      outputTokens: 120,
       generationReliable: true,
       generationActive: false,
     });

--- a/packages/maker-core/src/agents/claude-code/generation-timing.test.ts
+++ b/packages/maker-core/src/agents/claude-code/generation-timing.test.ts
@@ -534,7 +534,7 @@ describe('claude generation pause boundaries', () => {
     });
   });
 
-  it('marks timing unreliable for a complete subagent assistant without message_delta', () => {
+  it('keeps parent timing reliable for a complete subagent assistant without message_delta', () => {
     vi.useFakeTimers();
     vi.setSystemTime(1_000);
     const ctx = createTranslatorCtx();
@@ -560,9 +560,126 @@ describe('claude generation pause boundaries', () => {
       queue,
       ctx,
     );
-    expect(ctx.rt.generation.reliable).toBe(false);
+    expect(ctx.rt.generation.reliable).toBe(true);
+    expect(ctx.rt.generation.sawSubagent).toBe(true);
     resetClaudeGenerationTiming(ctx.rt.generation);
     queue.end();
+    vi.useRealTimers();
+  });
+
+  it('excludes subagent output from parent live tok/s', async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(1_000);
+    const ctx = createTranslatorCtx();
+    const queue = createAsyncQueue<AgentEvent>();
+
+    translateSdkMessage(
+      {
+        type: 'stream_event',
+        event: {
+          type: 'message_start',
+          message: { model: 'claude-sonnet-4.5', usage: { input_tokens: 10 } },
+        },
+      },
+      queue,
+      ctx,
+    );
+    translateSdkMessage(
+      {
+        type: 'stream_event',
+        event: {
+          type: 'content_block_start',
+          index: 0,
+          content_block: { type: 'tool_use', id: 'toolu-agent', name: 'Agent', input: {} },
+        },
+      },
+      queue,
+      ctx,
+    );
+    vi.setSystemTime(1_800);
+    translateSdkMessage(
+      {
+        type: 'stream_event',
+        event: {
+          type: 'message_delta',
+          usage: { output_tokens: 80 },
+        },
+      },
+      queue,
+      ctx,
+    );
+    expect(ctx.rt.generation.reliable).toBe(true);
+    expect(ctx.rt.generation.pendingToolIds.has('toolu-agent')).toBe(true);
+
+    translateSdkMessage(
+      {
+        type: 'stream_event',
+        parent_tool_use_id: 'toolu-agent',
+        event: {
+          type: 'message_start',
+          message: { model: 'claude-sonnet-4.5', usage: { input_tokens: 5 } },
+        },
+      },
+      queue,
+      ctx,
+    );
+    translateSdkMessage(
+      {
+        type: 'stream_event',
+        parent_tool_use_id: 'toolu-agent',
+        event: {
+          type: 'message_delta',
+          usage: { output_tokens: 500 },
+        },
+      },
+      queue,
+      ctx,
+    );
+    expect(ctx.rt.generation.reliable).toBe(true);
+    expect(ctx.rt.generation.sawSubagent).toBe(true);
+
+    translateSdkMessage(
+      {
+        type: 'user',
+        message: {
+          content: [{ type: 'tool_result', tool_use_id: 'toolu-agent', content: 'child done' }],
+        },
+      },
+      queue,
+      ctx,
+    );
+    vi.setSystemTime(2_200);
+    translateSdkMessage(
+      {
+        type: 'result',
+        stop_reason: 'end_turn',
+        total_cost_usd: 0,
+        num_turns: 1,
+        usage: { input_tokens: 15, output_tokens: 580 },
+      },
+      queue,
+      ctx,
+    );
+    queue.end();
+    const events: AgentEvent[] = [];
+    for await (const event of queue) events.push(event);
+
+    const generating = events.filter(
+      (event) => event.type === 'status' && (event.data as { status?: string }).status === 'Generating...',
+    );
+    expect(generating.at(-1)?.data).toMatchObject({
+      outputTokens: 80,
+      generationReliable: true,
+    });
+    const doneStatus = events.find(
+      (event) => event.type === 'status' && (event.data as { status?: string }).status === 'Done',
+    );
+    expect(doneStatus?.data).toMatchObject({
+      outputTokens: 80,
+      generationReliable: true,
+      generationActive: false,
+    });
+    resetClaudeGenerationTiming(ctx.rt.generation);
     vi.useRealTimers();
   });
 });

--- a/packages/maker-core/src/agents/claude-code/generation-timing.test.ts
+++ b/packages/maker-core/src/agents/claude-code/generation-timing.test.ts
@@ -562,9 +562,155 @@ describe('claude generation pause boundaries', () => {
     );
     expect(ctx.rt.generation.reliable).toBe(true);
     expect(ctx.rt.generation.sawSubagent).toBe(true);
+    expect(ctx.rt.generation.startedAt).toBeNull();
+    expect(ctx.rt.generation.pendingToolIds.has('toolu-agent')).toBe(true);
     resetClaudeGenerationTiming(ctx.rt.generation);
     queue.end();
     vi.useRealTimers();
+  });
+
+  it('closes parent generation when a child stream arrives before the parent tool pause', async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(1_000);
+    const ctx = createTranslatorCtx();
+    const queue = createAsyncQueue<AgentEvent>();
+
+    translateSdkMessage(
+      {
+        type: 'stream_event',
+        event: {
+          type: 'message_start',
+          message: { model: 'claude-sonnet-4.5', usage: { input_tokens: 10 } },
+        },
+      },
+      queue,
+      ctx,
+    );
+
+    vi.setSystemTime(1_500);
+    translateSdkMessage(
+      {
+        type: 'stream_event',
+        parent_tool_use_id: 'toolu-agent',
+        event: {
+          type: 'message_start',
+          message: { model: 'claude-sonnet-4.5', usage: { input_tokens: 5 } },
+        },
+      },
+      queue,
+      ctx,
+    );
+    expect(ctx.rt.generation.startedAt).toBeNull();
+    expect(ctx.rt.generation.pendingToolIds.has('toolu-agent')).toBe(true);
+    expect(ctx.rt.generation.durationMs).toBe(500);
+    expect(ctx.rt.generation.reliable).toBe(true);
+    expect(ctx.rt.generation.sawSubagent).toBe(true);
+
+    translateSdkMessage(
+      {
+        type: 'stream_event',
+        event: {
+          type: 'content_block_start',
+          index: 0,
+          content_block: { type: 'tool_use', id: 'toolu-agent', name: 'Agent', input: {} },
+        },
+      },
+      queue,
+      ctx,
+    );
+    vi.setSystemTime(5_000);
+    translateSdkMessage(
+      {
+        type: 'stream_event',
+        event: {
+          type: 'message_delta',
+          usage: { output_tokens: 80 },
+        },
+      },
+      queue,
+      ctx,
+    );
+    expect(ctx.rt.generation.startedAt).toBeNull();
+    expect(ctx.rt.generation.durationMs).toBe(500);
+    expect(ctx.rt.generation.reliable).toBe(true);
+
+    translateSdkMessage(
+      {
+        type: 'stream_event',
+        parent_tool_use_id: 'toolu-agent',
+        event: {
+          type: 'message_delta',
+          usage: { output_tokens: 500 },
+        },
+      },
+      queue,
+      ctx,
+    );
+    translateSdkMessage(
+      {
+        type: 'user',
+        message: {
+          content: [{ type: 'tool_result', tool_use_id: 'toolu-agent', content: 'child done' }],
+        },
+      },
+      queue,
+      ctx,
+    );
+    vi.setSystemTime(5_400);
+    translateSdkMessage(
+      {
+        type: 'result',
+        stop_reason: 'end_turn',
+        total_cost_usd: 0,
+        num_turns: 1,
+        usage: { input_tokens: 15, output_tokens: 580 },
+      },
+      queue,
+      ctx,
+    );
+    queue.end();
+    const events: AgentEvent[] = [];
+    for await (const event of queue) events.push(event);
+
+    const generating = events.filter(
+      (event) => event.type === 'status' && (event.data as { status?: string }).status === 'Generating...',
+    );
+    expect(generating.at(-1)?.data).toMatchObject({
+      outputTokens: 80,
+      generationReliable: true,
+    });
+    const doneStatus = events.find(
+      (event) => event.type === 'status' && (event.data as { status?: string }).status === 'Done',
+    );
+    expect(doneStatus?.data).toMatchObject({
+      outputTokens: 80,
+      generationReliable: true,
+      generationActive: false,
+    });
+    resetClaudeGenerationTiming(ctx.rt.generation);
+    vi.useRealTimers();
+  });
+
+  it('fails closed when a child stream arrives with no parent generation interval', () => {
+    const ctx = createTranslatorCtx();
+    const queue = createAsyncQueue<AgentEvent>();
+    translateSdkMessage(
+      {
+        type: 'stream_event',
+        parent_tool_use_id: 'toolu-agent',
+        event: {
+          type: 'message_start',
+          message: { model: 'claude-sonnet-4.5', usage: { input_tokens: 5 } },
+        },
+      },
+      queue,
+      ctx,
+    );
+    expect(ctx.rt.generation.sawSubagent).toBe(true);
+    expect(ctx.rt.generation.reliable).toBe(false);
+    expect(ctx.rt.generation.startedAt).toBeNull();
+    resetClaudeGenerationTiming(ctx.rt.generation);
+    queue.end();
   });
 
   it('excludes subagent output from parent live tok/s', async () => {

--- a/packages/maker-core/src/agents/claude-code/generation-timing.test.ts
+++ b/packages/maker-core/src/agents/claude-code/generation-timing.test.ts
@@ -877,7 +877,7 @@ describe('claude generation pause boundaries', () => {
     vi.useRealTimers();
   });
 
-  it('fails closed when a child stream arrives with no parent generation interval', () => {
+  it('does not pin a pause id when a child stream arrives with no parent generation interval', () => {
     const ctx = createTranslatorCtx();
     const queue = createAsyncQueue<AgentEvent>();
     translateSdkMessage(
@@ -893,10 +893,90 @@ describe('claude generation pause boundaries', () => {
       ctx,
     );
     expect(ctx.rt.generation.sawSubagent).toBe(true);
-    expect(ctx.rt.generation.reliable).toBe(false);
+    expect(ctx.rt.generation.reliable).toBe(true);
     expect(ctx.rt.generation.startedAt).toBeNull();
+    expect(ctx.rt.generation.pendingToolIds.size).toBe(0);
     resetClaudeGenerationTiming(ctx.rt.generation);
     queue.end();
+  });
+
+  it('does not let a settled-turn background child block the next parent generation', () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(1_000);
+    const ctx = createTranslatorCtx();
+    const queue = createAsyncQueue<AgentEvent>();
+
+    translateSdkMessage(
+      {
+        type: 'stream_event',
+        event: {
+          type: 'message_start',
+          message: { model: 'claude-sonnet-4.5', usage: { input_tokens: 10 } },
+        },
+      },
+      queue,
+      ctx,
+    );
+    vi.setSystemTime(1_800);
+    translateSdkMessage(
+      {
+        type: 'stream_event',
+        event: { type: 'message_delta', usage: { output_tokens: 80 } },
+      },
+      queue,
+      ctx,
+    );
+    vi.setSystemTime(2_200);
+    translateSdkMessage(
+      {
+        type: 'result',
+        stop_reason: 'end_turn',
+        total_cost_usd: 0,
+        num_turns: 1,
+        usage: { input_tokens: 10, output_tokens: 80 },
+      },
+      queue,
+      ctx,
+    );
+    expect(ctx.rt.generation.startedAt).toBeNull();
+    expect(ctx.rt.generation.pendingToolIds.size).toBe(0);
+    expect(ctx.rt.generation.reliable).toBe(true);
+
+    translateSdkMessage(
+      {
+        type: 'stream_event',
+        parent_tool_use_id: 'toolu-agent-bg',
+        event: {
+          type: 'message_start',
+          message: { model: 'claude-sonnet-4.5', usage: { input_tokens: 5 } },
+        },
+      },
+      queue,
+      ctx,
+    );
+    expect(ctx.rt.generation.sawSubagent).toBe(true);
+    expect(ctx.rt.generation.reliable).toBe(true);
+    expect(ctx.rt.generation.startedAt).toBeNull();
+    expect(ctx.rt.generation.pendingToolIds.size).toBe(0);
+
+    vi.setSystemTime(3_000);
+    translateSdkMessage(
+      {
+        type: 'stream_event',
+        event: {
+          type: 'message_start',
+          message: { model: 'claude-sonnet-4.5', usage: { input_tokens: 20 } },
+        },
+      },
+      queue,
+      ctx,
+    );
+    expect(ctx.rt.generation.startedAt).toBe(3_000);
+    expect(ctx.rt.generation.reliable).toBe(true);
+    expect(ctx.rt.generation.pendingToolIds.size).toBe(0);
+    resetClaudeGenerationTiming(ctx.rt.generation);
+    queue.end();
+    vi.useRealTimers();
   });
 
   it('excludes subagent output from parent live tok/s', async () => {

--- a/packages/maker-core/src/agents/claude-code/generation-timing.test.ts
+++ b/packages/maker-core/src/agents/claude-code/generation-timing.test.ts
@@ -51,6 +51,22 @@ describe('claude generation timing', () => {
     finalizeClaudeGeneration(state, 5_200);
     expect(state.reliable).toBe(false);
   });
+
+  it('does not re-pause a settled id while the current interval is open', () => {
+    const state = newClaudeGenerationState();
+    beginClaudeGeneration(state, 1_000);
+    pauseClaudeGeneration(state, 'tool-1', 1_400);
+    resumeClaudeGeneration(state, 'tool-1', 5_000);
+    expect(state.startedAt).toBe(5_000);
+    expect(state.pendingToolIds.size).toBe(0);
+    expect(state.settledPauseIds.has('tool-1')).toBe(true);
+
+    pauseClaudeGeneration(state, 'tool-1', 5_500);
+    expect(state.startedAt).toBe(5_000);
+    expect(state.pendingToolIds.size).toBe(0);
+    expect(state.reliable).toBe(true);
+    expect(state.durationMs).toBe(400);
+  });
 });
 
 function createTurnState(): TurnState {
@@ -974,6 +990,114 @@ describe('claude generation pause boundaries', () => {
     expect(ctx.rt.generation.startedAt).toBe(3_000);
     expect(ctx.rt.generation.reliable).toBe(true);
     expect(ctx.rt.generation.pendingToolIds.size).toBe(0);
+    resetClaudeGenerationTiming(ctx.rt.generation);
+    queue.end();
+    vi.useRealTimers();
+  });
+
+  it('does not re-pause a resumed background child during the next parent generation', () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(1_000);
+    const ctx = createTranslatorCtx();
+    const queue = createAsyncQueue<AgentEvent>();
+
+    translateSdkMessage(
+      {
+        type: 'stream_event',
+        event: {
+          type: 'message_start',
+          message: { model: 'claude-sonnet-4.5', usage: { input_tokens: 10 } },
+        },
+      },
+      queue,
+      ctx,
+    );
+    translateSdkMessage(
+      {
+        type: 'stream_event',
+        event: {
+          type: 'content_block_start',
+          index: 0,
+          content_block: { type: 'tool_use', id: 'toolu-agent-bg', name: 'Agent', input: {} },
+        },
+      },
+      queue,
+      ctx,
+    );
+    vi.setSystemTime(1_800);
+    translateSdkMessage(
+      {
+        type: 'stream_event',
+        event: { type: 'message_delta', usage: { output_tokens: 80 } },
+      },
+      queue,
+      ctx,
+    );
+    expect(ctx.rt.generation.pendingToolIds.has('toolu-agent-bg')).toBe(true);
+    expect(ctx.rt.generation.startedAt).toBeNull();
+
+    vi.setSystemTime(2_200);
+    translateSdkMessage(
+      {
+        type: 'user',
+        message: {
+          content: [{ type: 'tool_result', tool_use_id: 'toolu-agent-bg', content: 'async_launched' }],
+        },
+      },
+      queue,
+      ctx,
+    );
+    expect(ctx.rt.generation.pendingToolIds.size).toBe(0);
+    expect(ctx.rt.generation.startedAt).toBe(2_200);
+    expect(ctx.rt.generation.settledPauseIds.has('toolu-agent-bg')).toBe(true);
+    expect(ctx.rt.generation.reliable).toBe(true);
+
+    vi.setSystemTime(3_000);
+    translateSdkMessage(
+      {
+        type: 'stream_event',
+        event: {
+          type: 'message_start',
+          message: { model: 'claude-sonnet-4.5', usage: { input_tokens: 20 } },
+        },
+      },
+      queue,
+      ctx,
+    );
+    expect(ctx.rt.generation.startedAt).toBe(2_200);
+
+    translateSdkMessage(
+      {
+        type: 'stream_event',
+        parent_tool_use_id: 'toolu-agent-bg',
+        event: {
+          type: 'message_start',
+          message: { model: 'claude-sonnet-4.5', usage: { input_tokens: 5 } },
+        },
+      },
+      queue,
+      ctx,
+    );
+    expect(ctx.rt.generation.startedAt).toBe(2_200);
+    expect(ctx.rt.generation.pendingToolIds.size).toBe(0);
+    expect(ctx.rt.generation.reliable).toBe(true);
+
+    vi.setSystemTime(3_400);
+    translateSdkMessage(
+      {
+        type: 'stream_event',
+        parent_tool_use_id: 'toolu-agent-2',
+        event: {
+          type: 'message_start',
+          message: { model: 'claude-sonnet-4.5', usage: { input_tokens: 5 } },
+        },
+      },
+      queue,
+      ctx,
+    );
+    expect(ctx.rt.generation.startedAt).toBeNull();
+    expect(ctx.rt.generation.pendingToolIds.has('toolu-agent-2')).toBe(true);
+    expect(ctx.rt.generation.reliable).toBe(true);
     resetClaudeGenerationTiming(ctx.rt.generation);
     queue.end();
     vi.useRealTimers();

--- a/packages/maker-core/src/agents/claude-code/generation-timing.test.ts
+++ b/packages/maker-core/src/agents/claude-code/generation-timing.test.ts
@@ -682,4 +682,81 @@ describe('claude generation pause boundaries', () => {
     resetClaudeGenerationTiming(ctx.rt.generation);
     vi.useRealTimers();
   });
+
+  it('fails closed when a subagent is present but parent streamed output is incomplete', async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(1_000);
+    const ctx = createTranslatorCtx();
+    const queue = createAsyncQueue<AgentEvent>();
+
+    translateSdkMessage(
+      {
+        type: 'stream_event',
+        event: {
+          type: 'message_start',
+          message: { model: 'claude-sonnet-4.5', usage: { input_tokens: 10 } },
+        },
+      },
+      queue,
+      ctx,
+    );
+    translateSdkMessage(
+      {
+        type: 'assistant',
+        message: { content: [{ type: 'text', text: 'parent without delta' }] },
+      },
+      queue,
+      ctx,
+    );
+    translateSdkMessage(
+      {
+        type: 'stream_event',
+        parent_tool_use_id: 'toolu-agent',
+        event: {
+          type: 'message_start',
+          message: { model: 'claude-sonnet-4.5', usage: { input_tokens: 5 } },
+        },
+      },
+      queue,
+      ctx,
+    );
+    translateSdkMessage(
+      {
+        type: 'stream_event',
+        parent_tool_use_id: 'toolu-agent',
+        event: {
+          type: 'message_delta',
+          usage: { output_tokens: 500 },
+        },
+      },
+      queue,
+      ctx,
+    );
+    expect(ctx.rt.generation.sawSubagent).toBe(true);
+
+    vi.setSystemTime(1_800);
+    translateSdkMessage(
+      {
+        type: 'result',
+        stop_reason: 'end_turn',
+        total_cost_usd: 0,
+        num_turns: 1,
+        usage: { input_tokens: 15, output_tokens: 580 },
+      },
+      queue,
+      ctx,
+    );
+    queue.end();
+    const events: AgentEvent[] = [];
+    for await (const event of queue) events.push(event);
+    const doneStatus = events.find(
+      (event) => event.type === 'status' && (event.data as { status?: string }).status === 'Done',
+    );
+    expect(doneStatus?.data).toMatchObject({
+      generationReliable: false,
+      generationActive: false,
+    });
+    resetClaudeGenerationTiming(ctx.rt.generation);
+    vi.useRealTimers();
+  });
 });

--- a/packages/maker-core/src/agents/claude-code/generation-timing.test.ts
+++ b/packages/maker-core/src/agents/claude-code/generation-timing.test.ts
@@ -733,6 +733,8 @@ describe('claude generation pause boundaries', () => {
       ctx,
     );
     expect(ctx.rt.generation.sawSubagent).toBe(true);
+    expect(ctx.rt.generation.parentStreamedOutputIncomplete).toBe(true);
+    expect(ctx.rt.generation.reliable).toBe(false);
 
     vi.setSystemTime(1_800);
     translateSdkMessage(
@@ -749,10 +751,123 @@ describe('claude generation pause boundaries', () => {
     queue.end();
     const events: AgentEvent[] = [];
     for await (const event of queue) events.push(event);
+    const generating = events.filter(
+      (event) => event.type === 'status' && (event.data as { status?: string }).status === 'Generating...',
+    );
+    expect(generating.at(-1)?.data).toMatchObject({
+      generationReliable: false,
+    });
     const doneStatus = events.find(
       (event) => event.type === 'status' && (event.data as { status?: string }).status === 'Done',
     );
     expect(doneStatus?.data).toMatchObject({
+      generationReliable: false,
+      generationActive: false,
+    });
+    resetClaudeGenerationTiming(ctx.rt.generation);
+    vi.useRealTimers();
+  });
+
+  it('fails closed live when a later parent request closes without usage', async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(1_000);
+    const ctx = createTranslatorCtx();
+    const queue = createAsyncQueue<AgentEvent>();
+
+    translateSdkMessage(
+      {
+        type: 'stream_event',
+        event: {
+          type: 'message_start',
+          message: { model: 'claude-sonnet-4.5', usage: { input_tokens: 10 } },
+        },
+      },
+      queue,
+      ctx,
+    );
+    translateSdkMessage(
+      {
+        type: 'stream_event',
+        event: {
+          type: 'message_delta',
+          usage: { output_tokens: 80 },
+        },
+      },
+      queue,
+      ctx,
+    );
+    translateSdkMessage(
+      {
+        type: 'assistant',
+        message: { content: [{ type: 'text', text: 'first parent request' }] },
+      },
+      queue,
+      ctx,
+    );
+    expect(ctx.rt.generation.parentStreamedOutputIncomplete).toBe(false);
+
+    translateSdkMessage(
+      {
+        type: 'stream_event',
+        event: {
+          type: 'message_start',
+          message: { model: 'claude-sonnet-4.5', usage: { input_tokens: 8 } },
+        },
+      },
+      queue,
+      ctx,
+    );
+    translateSdkMessage(
+      {
+        type: 'assistant',
+        message: { content: [{ type: 'text', text: 'parent without delta' }] },
+      },
+      queue,
+      ctx,
+    );
+    expect(ctx.rt.generation.parentStreamedOutputIncomplete).toBe(true);
+
+    translateSdkMessage(
+      {
+        type: 'stream_event',
+        parent_tool_use_id: 'toolu-agent',
+        event: {
+          type: 'message_start',
+          message: { model: 'claude-sonnet-4.5', usage: { input_tokens: 5 } },
+        },
+      },
+      queue,
+      ctx,
+    );
+    expect(ctx.rt.generation.reliable).toBe(false);
+
+    vi.setSystemTime(1_800);
+    translateSdkMessage(
+      {
+        type: 'result',
+        stop_reason: 'end_turn',
+        total_cost_usd: 0,
+        num_turns: 1,
+        usage: { input_tokens: 23, output_tokens: 600 },
+      },
+      queue,
+      ctx,
+    );
+    queue.end();
+    const events: AgentEvent[] = [];
+    for await (const event of queue) events.push(event);
+    const generating = events.filter(
+      (event) => event.type === 'status' && (event.data as { status?: string }).status === 'Generating...',
+    );
+    expect(generating.at(-1)?.data).toMatchObject({
+      outputTokens: 80,
+      generationReliable: false,
+    });
+    const doneStatus = events.find(
+      (event) => event.type === 'status' && (event.data as { status?: string }).status === 'Done',
+    );
+    expect(doneStatus?.data).toMatchObject({
+      outputTokens: 80,
       generationReliable: false,
       generationActive: false,
     });

--- a/packages/maker-core/src/agents/claude-code/generation-timing.test.ts
+++ b/packages/maker-core/src/agents/claude-code/generation-timing.test.ts
@@ -979,6 +979,103 @@ describe('claude generation pause boundaries', () => {
     vi.useRealTimers();
   });
 
+  it('does not reuse the previous parent request output after that assistant closes', async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(1_000);
+    const ctx = createTranslatorCtx();
+    const queue = createAsyncQueue<AgentEvent>();
+
+    translateSdkMessage(
+      {
+        type: 'stream_event',
+        event: {
+          type: 'message_start',
+          message: { model: 'claude-sonnet-4.5', usage: { input_tokens: 10 } },
+        },
+      },
+      queue,
+      ctx,
+    );
+    translateSdkMessage(
+      {
+        type: 'stream_event',
+        event: {
+          type: 'content_block_start',
+          index: 0,
+          content_block: { type: 'tool_use', id: 'toolu-agent-1', name: 'Agent', input: {} },
+        },
+      },
+      queue,
+      ctx,
+    );
+    vi.setSystemTime(1_800);
+    translateSdkMessage(
+      {
+        type: 'stream_event',
+        event: { type: 'message_delta', usage: { output_tokens: 80 } },
+      },
+      queue,
+      ctx,
+    );
+    translateSdkMessage(
+      {
+        type: 'assistant',
+        message: {
+          content: [{ type: 'tool_use', id: 'toolu-agent-1', name: 'Agent', input: {} }],
+        },
+      },
+      queue,
+      ctx,
+    );
+    expect(ctx.rt.generation.parentStreamedOutputIncomplete).toBe(false);
+
+    translateSdkMessage(
+      {
+        type: 'user',
+        message: {
+          content: [{ type: 'tool_result', tool_use_id: 'toolu-agent-1', content: 'child 1 done' }],
+        },
+      },
+      queue,
+      ctx,
+    );
+
+    vi.setSystemTime(2_600);
+    translateSdkMessage(
+      {
+        type: 'assistant',
+        message: {
+          content: [{ type: 'tool_use', id: 'toolu-agent-2', name: 'Agent', input: {} }],
+        },
+      },
+      queue,
+      ctx,
+    );
+    expect(ctx.rt.generation.parentStreamedOutputIncomplete).toBe(true);
+
+    translateSdkMessage(
+      {
+        type: 'stream_event',
+        parent_tool_use_id: 'toolu-agent-2',
+        event: {
+          type: 'message_start',
+          message: { model: 'claude-sonnet-4.5', usage: { input_tokens: 5 } },
+        },
+      },
+      queue,
+      ctx,
+    );
+    queue.end();
+    const events: AgentEvent[] = [];
+    for await (const event of queue) events.push(event);
+    expect(events.at(-1)?.data).toMatchObject({
+      outputTokens: 80,
+      generationReliable: false,
+    });
+    resetClaudeGenerationTiming(ctx.rt.generation);
+    vi.useRealTimers();
+  });
+
   it('excludes subagent output from parent live tok/s', async () => {
     vi.useFakeTimers();
     vi.setSystemTime(1_000);

--- a/packages/maker-core/src/agents/claude-code/generation-timing.ts
+++ b/packages/maker-core/src/agents/claude-code/generation-timing.ts
@@ -5,6 +5,12 @@ export interface ClaudeGenerationState {
   startedAt: number | null;
   durationMs: number;
   pendingToolIds: Set<string>;
+  /**
+   * Pause ids that already resumed this generation. A later pause of the same
+   * id must not close the current open interval or re-enter pending — the
+   * matching tool_result will not arrive again.
+   */
+  settledPauseIds: Set<string>;
   reliable: boolean;
   /**
    * True after this turn observed a child assistant/stream (`parent_tool_use_id`).
@@ -26,6 +32,7 @@ export function newClaudeGenerationState(): ClaudeGenerationState {
     startedAt: null,
     durationMs: 0,
     pendingToolIds: new Set(),
+    settledPauseIds: new Set(),
     reliable: true,
     sawSubagent: false,
     parentStreamedOutputIncomplete: false,
@@ -76,6 +83,7 @@ export function resetClaudeGenerationTiming(state: ClaudeGenerationState): void 
   stopHeartbeat(state);
   state.startedAt = null;
   state.pendingToolIds.clear();
+  state.settledPauseIds.clear();
   state.durationMs = 0;
   state.reliable = true;
   state.sawSubagent = false;
@@ -99,6 +107,7 @@ export function pauseClaudeGeneration(
     return;
   }
   if (state.pendingToolIds.has(pauseId)) return;
+  if (state.settledPauseIds.has(pauseId)) return;
   if (state.pendingToolIds.size === 0) {
     // No open generation interval means we never saw message_start (or it was
     // already closed). Pausing here would resume the clock at tool_result and
@@ -118,6 +127,7 @@ export function resumeClaudeGeneration(
     state.reliable = false;
     return;
   }
+  state.settledPauseIds.add(pauseId);
   if (state.pendingToolIds.size === 0) {
     state.startedAt = resumedAt;
     startHeartbeat(state);

--- a/packages/maker-core/src/agents/claude-code/generation-timing.ts
+++ b/packages/maker-core/src/agents/claude-code/generation-timing.ts
@@ -12,6 +12,11 @@ export interface ClaudeGenerationState {
    * aggregate, which still includes subagent tokens.
    */
   sawSubagent: boolean;
+  /**
+   * True after a parent assistant closed without streamed output usage.
+   * Subagent live tok/s cannot use that incomplete parent numerator.
+   */
+  parentStreamedOutputIncomplete: boolean;
   heartbeatAt: number | null;
   heartbeatTimer: ReturnType<typeof setInterval> | null;
 }
@@ -23,6 +28,7 @@ export function newClaudeGenerationState(): ClaudeGenerationState {
     pendingToolIds: new Set(),
     reliable: true,
     sawSubagent: false,
+    parentStreamedOutputIncomplete: false,
     heartbeatAt: null,
     heartbeatTimer: null,
   };
@@ -73,6 +79,7 @@ export function resetClaudeGenerationTiming(state: ClaudeGenerationState): void 
   state.durationMs = 0;
   state.reliable = true;
   state.sawSubagent = false;
+  state.parentStreamedOutputIncomplete = false;
 }
 
 export function beginClaudeGeneration(state: ClaudeGenerationState, startedAt = Date.now()): void {
@@ -136,4 +143,8 @@ export function markClaudeGenerationUnreliable(state: ClaudeGenerationState): vo
 
 export function noteClaudeSubagent(state: ClaudeGenerationState): void {
   state.sawSubagent = true;
+}
+
+export function noteClaudeParentStreamedOutputIncomplete(state: ClaudeGenerationState): void {
+  state.parentStreamedOutputIncomplete = true;
 }

--- a/packages/maker-core/src/agents/claude-code/generation-timing.ts
+++ b/packages/maker-core/src/agents/claude-code/generation-timing.ts
@@ -6,6 +6,12 @@ export interface ClaudeGenerationState {
   durationMs: number;
   pendingToolIds: Set<string>;
   reliable: boolean;
+  /**
+   * True after this turn observed a child assistant/stream (`parent_tool_use_id`).
+   * Live tok/s then uses parent-only streamed output instead of the result
+   * aggregate, which still includes subagent tokens.
+   */
+  sawSubagent: boolean;
   heartbeatAt: number | null;
   heartbeatTimer: ReturnType<typeof setInterval> | null;
 }
@@ -16,6 +22,7 @@ export function newClaudeGenerationState(): ClaudeGenerationState {
     durationMs: 0,
     pendingToolIds: new Set(),
     reliable: true,
+    sawSubagent: false,
     heartbeatAt: null,
     heartbeatTimer: null,
   };
@@ -65,6 +72,7 @@ export function resetClaudeGenerationTiming(state: ClaudeGenerationState): void 
   state.pendingToolIds.clear();
   state.durationMs = 0;
   state.reliable = true;
+  state.sawSubagent = false;
 }
 
 export function beginClaudeGeneration(state: ClaudeGenerationState, startedAt = Date.now()): void {
@@ -124,4 +132,8 @@ export function finalizeClaudeGeneration(
 
 export function markClaudeGenerationUnreliable(state: ClaudeGenerationState): void {
   state.reliable = false;
+}
+
+export function noteClaudeSubagent(state: ClaudeGenerationState): void {
+  state.sawSubagent = true;
 }

--- a/packages/maker-core/src/agents/claude-code/translator.ts
+++ b/packages/maker-core/src/agents/claude-code/translator.ts
@@ -1540,7 +1540,8 @@ function pauseClaudeGenerationForKnownTools(ctx: TranslateContext): void {
  * pause 边界关掉父级开区间，避免分母吞进子代理时间、分子却只有父级 output。
  * 没有开区间且 pending 为空时不 pause：result/reset 后的后台 child、以及
  * 本 turn 尚未 begin 的 child，都不得钉死旧 parent_tool_use_id，否则下一轮
- * parent message_start 无法 begin。
+ * parent message_start 无法 begin。已 resume 的 pause id 由
+ * pauseClaudeGeneration 忽略，不会再次 close 当前开区间。
  */
 function observeClaudeSubagentStream(
   ctx: TranslateContext,

--- a/packages/maker-core/src/agents/claude-code/translator.ts
+++ b/packages/maker-core/src/agents/claude-code/translator.ts
@@ -42,6 +42,7 @@ import {
   finalizeClaudeGeneration,
   markClaudeGenerationUnreliable,
   newClaudeGenerationState,
+  noteClaudeParentStreamedOutputIncomplete,
   noteClaudeSubagent,
   pauseClaudeGeneration,
   resetClaudeGenerationTiming,
@@ -229,6 +230,28 @@ function mainTurnOutputTokens(tracker: UsageTracker): number {
   return output;
 }
 
+function mainActiveSegmentHasOutput(ctx: TranslateContext): boolean {
+  const segmentId = ctx.rt.activeUsageSegmentByParent.get(CLAUDE_MAIN_USAGE_PARENT);
+  if (!segmentId) return false;
+  for (const segment of ctx.tracker.getTurnUsageSegments()) {
+    if (segment.id === segmentId) return segment.outputTokens > 0;
+  }
+  return false;
+}
+
+function applySubagentLiveReliability(ctx: TranslateContext): void {
+  if (!ctx.rt.generation.sawSubagent) return;
+  // Live status cannot compare against result.usage yet. Parent tok/s stays
+  // reliable only while parent streamed output is present and no parent
+  // request closed without a usage frame.
+  if (
+    ctx.rt.generation.parentStreamedOutputIncomplete ||
+    mainTurnOutputTokens(ctx.tracker) <= 0
+  ) {
+    markClaudeGenerationUnreliable(ctx.rt.generation);
+  }
+}
+
 function liveParentOutputTokens(
   ctx: TranslateContext,
   resultOutput?: number,
@@ -255,6 +278,7 @@ function ccLiveStatus(
   status: string,
   isRunning: boolean,
 ): { status: string; isRunning: boolean } & ReturnType<UsageTracker['snapshot']> {
+  applySubagentLiveReliability(ctx);
   return {
     status,
     ...attachLiveGeneration(ctx.tracker.snapshot(), {
@@ -1343,6 +1367,9 @@ function handleAssistant(
   // 而父级 Agent 工具区间已从分母排除。记 sawSubagent，live tok/s 只用父级
   // streamed output，不再把整轮计时打成不可靠。
   if (parentToolUseId) noteClaudeSubagent(ctx.rt.generation);
+  else if (!mainActiveSegmentHasOutput(ctx)) {
+    noteClaudeParentStreamedOutputIncomplete(ctx.rt.generation);
+  }
   // 完整 child assistant 是实际执行模型的正式观测来源。SDK 不保证 child 的
   // partial message_start 一定向外暴露，所以不能只靠 handleStreamEvent 填模型；
   // 同时保持 main 新增的 loop guard 按 parent scope 读取同一张 stream model 表。

--- a/packages/maker-core/src/agents/claude-code/translator.ts
+++ b/packages/maker-core/src/agents/claude-code/translator.ts
@@ -250,6 +250,18 @@ function applySubagentLiveReliability(ctx: TranslateContext): void {
   }
 }
 
+/**
+ * Snapshot-only: the current parent request exists but has not streamed output.
+ * A later child `message_start` can win the race; hide this status without
+ * sticky-failing `generation.reliable`, so the parent `message_delta` can
+ * restore tok/s.
+ */
+function currentParentStreamedOutputPending(ctx: TranslateContext): boolean {
+  if (!ctx.rt.generation.sawSubagent) return false;
+  if (!ctx.rt.activeUsageSegmentByParent.get(CLAUDE_MAIN_USAGE_PARENT)) return false;
+  return !mainActiveSegmentHasOutput(ctx);
+}
+
 function liveParentOutputTokens(
   ctx: TranslateContext,
   resultOutput?: number,
@@ -283,7 +295,7 @@ function ccLiveStatus(
       outputTokens: mainTurnOutputTokens(ctx.tracker),
       closedDurationMs: ctx.rt.generation.durationMs,
       openStartedAt: ctx.rt.generation.startedAt,
-      reliable: ctx.rt.generation.reliable,
+      reliable: ctx.rt.generation.reliable && !currentParentStreamedOutputPending(ctx),
     }),
     isRunning,
   };

--- a/packages/maker-core/src/agents/claude-code/translator.ts
+++ b/packages/maker-core/src/agents/claude-code/translator.ts
@@ -40,8 +40,8 @@ import { attachLiveGeneration } from '../shared/live-generation-snapshot.js';
 import {
   beginClaudeGeneration,
   finalizeClaudeGeneration,
-  markClaudeGenerationUnreliable,
   newClaudeGenerationState,
+  noteClaudeSubagent,
   pauseClaudeGeneration,
   resetClaudeGenerationTiming,
   resumeClaudeGeneration,
@@ -213,6 +213,30 @@ export function newRuntimeState(): RuntimeState {
   };
 }
 
+const CLAUDE_MAIN_USAGE_PARENT = '__main__';
+
+function isMainUsageSegmentId(segmentId: string | undefined): boolean {
+  return typeof segmentId === 'string' && segmentId.endsWith(`:${CLAUDE_MAIN_USAGE_PARENT}`);
+}
+
+/** Parent-agent streamed output only. Subagent segments stay in cumulative usage. */
+function mainTurnOutputTokens(tracker: UsageTracker): number {
+  let output = 0;
+  for (const segment of tracker.getTurnUsageSegments()) {
+    if (isMainUsageSegmentId(segment.id)) output += segment.outputTokens;
+  }
+  return output;
+}
+
+function liveParentOutputTokens(ctx: TranslateContext, resultOutput?: number): number {
+  const mainOutput = mainTurnOutputTokens(ctx.tracker);
+  if (ctx.rt.generation.sawSubagent) return mainOutput;
+  if (typeof resultOutput === 'number' && Number.isFinite(resultOutput)) {
+    return Math.max(0, resultOutput);
+  }
+  return mainOutput;
+}
+
 function ccLiveStatus(
   ctx: TranslateContext,
   status: string,
@@ -221,7 +245,7 @@ function ccLiveStatus(
   return {
     status,
     ...attachLiveGeneration(ctx.tracker.snapshot(), {
-      outputTokens: ctx.tracker.getTurnUsage().output,
+      outputTokens: mainTurnOutputTokens(ctx.tracker),
       closedDurationMs: ctx.rt.generation.durationMs,
       openStartedAt: ctx.rt.generation.startedAt,
       reliable: ctx.rt.generation.reliable,
@@ -747,7 +771,7 @@ export function translateSdkMessage(
         // after tool execution has completed, rather than at the previous
         // message_delta (which can be much earlier than the next request).
         ctx.rt.pendingUsagePriceVariantByParent.set(
-          parentToolUseId ?? '__main__',
+          parentToolUseId ?? CLAUDE_MAIN_USAGE_PARENT,
           ctx.getFastMode?.() ? 'priority' : 'standard',
         );
       }
@@ -1292,7 +1316,7 @@ function handleAssistant(
   const parentToolUseId = typeof msg.parent_tool_use_id === 'string' && msg.parent_tool_use_id
     ? msg.parent_tool_use_id
     : undefined;
-  const parentStreamKey = parentToolUseId ?? '__main__';
+  const parentStreamKey = parentToolUseId ?? CLAUDE_MAIN_USAGE_PARENT;
   const assistantRequestId = typeof assistantMeta.requestId === 'string'
     ? assistantMeta.requestId
     : undefined;
@@ -1303,8 +1327,9 @@ function handleAssistant(
     ctx.rt.streamRequestIdByParent.delete(parentStreamKey);
   }
   // 子代理完整 assistant 没有 message_delta 时，result.usage 仍含其子输出，
-  // 而父级 Agent 工具区间已从分母排除。与 message_delta 路径同样 fail-closed。
-  if (parentToolUseId) markClaudeGenerationUnreliable(ctx.rt.generation);
+  // 而父级 Agent 工具区间已从分母排除。记 sawSubagent，live tok/s 只用父级
+  // streamed output，不再把整轮计时打成不可靠。
+  if (parentToolUseId) noteClaudeSubagent(ctx.rt.generation);
   // 完整 child assistant 是实际执行模型的正式观测来源。SDK 不保证 child 的
   // partial message_start 一定向外暴露，所以不能只靠 handleStreamEvent 填模型；
   // 同时保持 main 新增的 loop guard 按 parent scope 读取同一张 stream model 表。
@@ -1482,7 +1507,7 @@ function handleStreamEvent(
     const cb = event.content_block;
     if (cb && cb.type === 'text') {
       const blockIndex = typeof event.index === 'number' ? event.index : 0;
-      ctx.rt.streamStopTokenByKey.delete(`${parentToolUseId ?? '__main__'}:${blockIndex}`);
+      ctx.rt.streamStopTokenByKey.delete(`${parentToolUseId ?? CLAUDE_MAIN_USAGE_PARENT}:${blockIndex}`);
     }
     if (cb && cb.type === 'tool_use') {
       const toolUseId = rememberClaudeToolUseId(ctx, cb.id, cb.name);
@@ -1499,7 +1524,7 @@ function handleStreamEvent(
   // SDKPartialAssistantMessage 自带 parent_tool_use_id；并发 subagent 会在同一 Query
   // 事件流中交错，必须按 parent 隔离模型，不能使用会话级 lastAssistantMeta 串联。
   // 老 SDK / 单测若没有 wrapper 元数据，才保留旧兜底行为。
-  const parentStreamKey = parentToolUseId ?? '__main__';
+  const parentStreamKey = parentToolUseId ?? CLAUDE_MAIN_USAGE_PARENT;
   const blockIndex = typeof event.index === 'number' ? event.index : 0;
   const streamKey = `${parentStreamKey}:${blockIndex}`;
   const eventModel = event.message?.model;
@@ -1618,7 +1643,7 @@ function handleStreamEvent(
         cacheCreateTokens: dCacheCreate,
         complete: hasCompleteUsageSnapshot,
       });
-      if (parentToolUseId && dOut > 0) markClaudeGenerationUnreliable(ctx.rt.generation);
+      if (parentToolUseId) noteClaudeSubagent(ctx.rt.generation);
       // 每次 API 回合的 token 增量打一行 —— 一个 turn 可能多个 message_delta(工具循环),
       // 让人看日志能直观看到 token 是怎么涨上去的, 而不是只在 turn end 看到一个总数。
       ctx.log.debug('SDK ▷ token usage (message_delta)', {
@@ -1680,7 +1705,9 @@ function handleStreamEvent(
 
     // 不清 tracker —— message_start 在 turn 中可能出现多次(工具循环每次 API call 都会触发),
     // 老链路 agentManager.ts:2400-2407 这里也是带 currentTurn 累计, 不重置。
-    beginClaudeGeneration(ctx.rt.generation);
+    // 子代理 stream 不占用父级生成时钟；父级在 Agent 工具区间已经停表。
+    if (parentToolUseId) noteClaudeSubagent(ctx.rt.generation);
+    else beginClaudeGeneration(ctx.rt.generation);
     queue.push({
       type: 'status',
       data: ccLiveStatus(ctx, 'Generating...', true),
@@ -1946,7 +1973,7 @@ function handleResult(
   // turn end usage 锁定: Claude Code result.usage 是 session aggregate,
   // 这里先转成 turn delta; tracker.endTurn 内部覆盖 currentTurn 然后返回 snapshot 再 reset。
   finalizeClaudeGeneration(ctx.rt.generation);
-  const liveTurnOutput = resultUsage?.outputTokens ?? ctx.tracker.getTurnUsage().output;
+  const liveTurnOutput = liveParentOutputTokens(ctx, resultUsage?.outputTokens);
   const liveGeneration = ctx.rt.generation;
   const endSnapshot = ctx.tracker.endTurn(
     resultUsage

--- a/packages/maker-core/src/agents/claude-code/translator.ts
+++ b/packages/maker-core/src/agents/claude-code/translator.ts
@@ -40,6 +40,7 @@ import { attachLiveGeneration } from '../shared/live-generation-snapshot.js';
 import {
   beginClaudeGeneration,
   finalizeClaudeGeneration,
+  markClaudeGenerationUnreliable,
   newClaudeGenerationState,
   noteClaudeSubagent,
   pauseClaudeGeneration,
@@ -228,9 +229,21 @@ function mainTurnOutputTokens(tracker: UsageTracker): number {
   return output;
 }
 
-function liveParentOutputTokens(ctx: TranslateContext, resultOutput?: number): number {
+function liveParentOutputTokens(
+  ctx: TranslateContext,
+  resultOutput?: number,
+  streamedOutputMatchesResult = false,
+): number {
   const mainOutput = mainTurnOutputTokens(ctx.tracker);
-  if (ctx.rt.generation.sawSubagent) return mainOutput;
+  if (ctx.rt.generation.sawSubagent) {
+    // result.usage includes subagent output. Parent live tok/s is only
+    // commensurate with the parent generation denominator when streamed
+    // segments prove they cover every output token in the result aggregate.
+    if (!streamedOutputMatchesResult) {
+      markClaudeGenerationUnreliable(ctx.rt.generation);
+    }
+    return mainOutput;
+  }
   if (typeof resultOutput === 'number' && Number.isFinite(resultOutput)) {
     return Math.max(0, resultOutput);
   }
@@ -1973,7 +1986,11 @@ function handleResult(
   // turn end usage 锁定: Claude Code result.usage 是 session aggregate,
   // 这里先转成 turn delta; tracker.endTurn 内部覆盖 currentTurn 然后返回 snapshot 再 reset。
   finalizeClaudeGeneration(ctx.rt.generation);
-  const liveTurnOutput = liveParentOutputTokens(ctx, resultUsage?.outputTokens);
+  const liveTurnOutput = liveParentOutputTokens(
+    ctx,
+    resultUsage?.outputTokens,
+    resultUsage != null && segmentTotals.outputTokens === resultUsage.outputTokens,
+  );
   const liveGeneration = ctx.rt.generation;
   const endSnapshot = ctx.tracker.endTurn(
     resultUsage

--- a/packages/maker-core/src/agents/claude-code/translator.ts
+++ b/packages/maker-core/src/agents/claude-code/translator.ts
@@ -1531,8 +1531,10 @@ function pauseClaudeGenerationForKnownTools(ctx: TranslateContext): void {
 /**
  * 子代理事件到达时：父级生成时钟必须已经因对应 Agent 工具停表。
  * 若 child 先于父级 tool_use / message_delta，用 parent_tool_use_id 作为既有
- * pause 边界关掉父级区间，避免分母吞进子代理时间、分子却只有父级 output。
- * 父级从未开始生成时 pause 会 fail closed（与无 message_start 的 tool_use 同款）。
+ * pause 边界关掉父级开区间，避免分母吞进子代理时间、分子却只有父级 output。
+ * 没有开区间且 pending 为空时不 pause：result/reset 后的后台 child、以及
+ * 本 turn 尚未 begin 的 child，都不得钉死旧 parent_tool_use_id，否则下一轮
+ * parent message_start 无法 begin。
  */
 function observeClaudeSubagentStream(
   ctx: TranslateContext,
@@ -1540,6 +1542,12 @@ function observeClaudeSubagentStream(
 ): void {
   noteClaudeSubagent(ctx.rt.generation);
   if (ctx.rt.generation.pendingToolIds.has(parentToolUseId)) return;
+  if (
+    ctx.rt.generation.startedAt === null &&
+    ctx.rt.generation.pendingToolIds.size === 0
+  ) {
+    return;
+  }
   pauseClaudeGeneration(ctx.rt.generation, parentToolUseId);
 }
 

--- a/packages/maker-core/src/agents/claude-code/translator.ts
+++ b/packages/maker-core/src/agents/claude-code/translator.ts
@@ -251,15 +251,15 @@ function applySubagentLiveReliability(ctx: TranslateContext): void {
 }
 
 /**
- * Snapshot-only: the current parent request exists but has not streamed output.
- * A later child `message_start` can win the race; hide this status without
- * sticky-failing `generation.reliable`, so the parent `message_delta` can
- * restore tok/s.
+ * Snapshot-only: the current parent generation interval has no streamed output
+ * yet. Hide this status without sticky-failing `generation.reliable`, so a
+ * later parent `message_delta` can restore tok/s.
  */
 function currentParentStreamedOutputPending(ctx: TranslateContext): boolean {
   if (!ctx.rt.generation.sawSubagent) return false;
-  if (!ctx.rt.activeUsageSegmentByParent.get(CLAUDE_MAIN_USAGE_PARENT)) return false;
-  return !mainActiveSegmentHasOutput(ctx);
+  if (mainActiveSegmentHasOutput(ctx)) return false;
+  if (ctx.rt.generation.startedAt !== null) return true;
+  return Boolean(ctx.rt.activeUsageSegmentByParent.get(CLAUDE_MAIN_USAGE_PARENT));
 }
 
 function liveParentOutputTokens(
@@ -1377,8 +1377,14 @@ function handleAssistant(
   // 而父级 Agent 工具区间已从分母排除。记 sawSubagent，live tok/s 只用父级
   // streamed output，不再把整轮计时打成不可靠。
   if (parentToolUseId) observeClaudeSubagentStream(ctx, parentToolUseId);
-  else if (!mainActiveSegmentHasOutput(ctx)) {
-    noteClaudeParentStreamedOutputIncomplete(ctx.rt.generation);
+  else {
+    // Active __main__ segment is this request only. Keep it while checking
+    // completeness, then detach so the next open interval cannot inherit
+    // the previous request's streamed output.
+    if (!mainActiveSegmentHasOutput(ctx)) {
+      noteClaudeParentStreamedOutputIncomplete(ctx.rt.generation);
+    }
+    ctx.rt.activeUsageSegmentByParent.delete(CLAUDE_MAIN_USAGE_PARENT);
   }
   // 完整 child assistant 是实际执行模型的正式观测来源。SDK 不保证 child 的
   // partial message_start 一定向外暴露，所以不能只靠 handleStreamEvent 填模型；

--- a/packages/maker-core/src/agents/claude-code/translator.ts
+++ b/packages/maker-core/src/agents/claude-code/translator.ts
@@ -241,13 +241,11 @@ function mainActiveSegmentHasOutput(ctx: TranslateContext): boolean {
 
 function applySubagentLiveReliability(ctx: TranslateContext): void {
   if (!ctx.rt.generation.sawSubagent) return;
-  // Live status cannot compare against result.usage yet. Parent tok/s stays
-  // reliable only while parent streamed output is present and no parent
-  // request closed without a usage frame.
-  if (
-    ctx.rt.generation.parentStreamedOutputIncomplete ||
-    mainTurnOutputTokens(ctx.tracker) <= 0
-  ) {
+  // Live status cannot compare against result.usage yet. A parent request that
+  // already closed without usage is unrecoverable. Parent output may still be
+  // in flight when a child stream arrives first — do not fail closed on 0
+  // streamed output here, or the later parent message_delta cannot restore tok/s.
+  if (ctx.rt.generation.parentStreamedOutputIncomplete) {
     markClaudeGenerationUnreliable(ctx.rt.generation);
   }
 }
@@ -1366,7 +1364,7 @@ function handleAssistant(
   // 子代理完整 assistant 没有 message_delta 时，result.usage 仍含其子输出，
   // 而父级 Agent 工具区间已从分母排除。记 sawSubagent，live tok/s 只用父级
   // streamed output，不再把整轮计时打成不可靠。
-  if (parentToolUseId) noteClaudeSubagent(ctx.rt.generation);
+  if (parentToolUseId) observeClaudeSubagentStream(ctx, parentToolUseId);
   else if (!mainActiveSegmentHasOutput(ctx)) {
     noteClaudeParentStreamedOutputIncomplete(ctx.rt.generation);
   }
@@ -1516,6 +1514,21 @@ function pauseClaudeGenerationForKnownTools(ctx: TranslateContext): void {
   for (const toolUseId of ctx.rt.toolUseIdToName.keys()) {
     pauseClaudeGenerationForToolUse(ctx, toolUseId);
   }
+}
+
+/**
+ * 子代理事件到达时：父级生成时钟必须已经因对应 Agent 工具停表。
+ * 若 child 先于父级 tool_use / message_delta，用 parent_tool_use_id 作为既有
+ * pause 边界关掉父级区间，避免分母吞进子代理时间、分子却只有父级 output。
+ * 父级从未开始生成时 pause 会 fail closed（与无 message_start 的 tool_use 同款）。
+ */
+function observeClaudeSubagentStream(
+  ctx: TranslateContext,
+  parentToolUseId: string,
+): void {
+  noteClaudeSubagent(ctx.rt.generation);
+  if (ctx.rt.generation.pendingToolIds.has(parentToolUseId)) return;
+  pauseClaudeGeneration(ctx.rt.generation, parentToolUseId);
 }
 
 // ── stream_event 子分支(content_block_delta / message_delta / message_start) ──
@@ -1745,8 +1758,9 @@ function handleStreamEvent(
 
     // 不清 tracker —— message_start 在 turn 中可能出现多次(工具循环每次 API call 都会触发),
     // 老链路 agentManager.ts:2400-2407 这里也是带 currentTurn 累计, 不重置。
-    // 子代理 stream 不占用父级生成时钟；父级在 Agent 工具区间已经停表。
-    if (parentToolUseId) noteClaudeSubagent(ctx.rt.generation);
+    // 子代理 stream 不占用父级生成时钟。若对应 Agent 工具尚未停表，在此用
+    // parent_tool_use_id 补上既有 pause 边界，避免分母吞进子代理时间。
+    if (parentToolUseId) observeClaudeSubagentStream(ctx, parentToolUseId);
     else beginClaudeGeneration(ctx.rt.generation);
     queue.push({
       type: 'status',


### PR DESCRIPTION
## 这次改了什么

### 摘要

Claude Code 遇到 Explore / Agent 这类子代理时，以前会把整轮生成计时打成不可靠，右下角 `tok/s` 直接消失。原因是 `result.usage` 含子代理 output，而分母已经扣掉父级 Agent 工具等待。

现在状态栏速度只看父 agent：分子是父级 streamed output，分母仍是父级生成时长。子代理不再把 `generationReliable` 打成 false。累计 `↓ tok` 仍含子代理消耗。

### 变更类型

- [x] `fix` 缺陷修复
- [ ] `feat` 新功能
- [ ] `refactor` / `perf` 重构或性能优化
- [ ] `docs` / `test` / `chore` 文档、测试或工程维护
- [ ] 其他：

### 范围

- 关联 Issue / 需求：无编号；来自实际任务右下角无 tok/s 的排查
- 本 PR 包含：Claude Code translator / generation-timing 把父级 live tok/s 与子代理拆开，并补单测
- 明确不包含：Grok live `message_delta` usage 为 0 时运行中仍无速度；Codex / Pi harness；用字符数估临时 tok/s
- 用户可见变化：Claude Code 任务一旦走了子代理，运行中 / 收尾的 tok/s 不再整轮消失，数字只反映父 agent
- 是否存在 breaking change：无

### UI 变化

- 引用的设计规范：不涉及：未改 renderer、视觉、交互或文案；只改 Claude Code live usage 的分子与可靠标记。

## 怎么验证的

### 自动验证

```text
# 提交门禁（worktree，相对 origin/main）
corepack pnpm test:unit:related
结果：PASS
  apps/desktop unit (122.7s)
  packages/maker-core related（含 generation-timing.test.ts 12 例）(15.5s)
  packages/lizi-mcps unit (16.0s)
  packages/orca-workflow unit (1.9s)

corepack pnpm --filter @cindy/maker-core run --if-present typecheck
结果：包无 typecheck script，该步跳过（exit 0）

pnpm check:dco
结果：1 commit signed off（base origin/main）

# 全量单测（git skill run-unit-gate.sh）
bash /Users/dash/Code/XD/dash/Skills/git/scripts/run-unit-gate.sh <worktree>
结果：packages/maker-core unit FAIL（2 例），其余 workspace PASS
  FAIL src/agents/pi/__tests__/pi-agent.integration.test.ts
    - uses PI bundled xAI APIs…（60s timeout）
    - BYOM: a native provider model…（activeConfigHomes 期望 1 得到 2）
  本 PR 的 generation-timing.test.ts：12 passed

# 基线复现（主 checkout origin/main 2310a1333，与本 diff 无关）
corepack pnpm --dir packages/maker-core exec vitest run --pool=forks --maxWorkers=1 \
  src/agents/pi/__tests__/pi-agent.integration.test.ts \
  -t 'uses PI bundled xAI APIs|BYOM: a native provider model'
结果：同样 2 fail。结论：本机/基线问题，不混入本 PR。交 CI 给权威结论。
```

### maker-core 核心指标（docs/dev-rules/maker-core-and-agent-behavior.md §3）

- 缓存率：未改 prompt 拼接、tool / MCP 注册或 system 段。无影响。
- 热路径：`ccLiveStatus` 每次多扫一遍当前 turn 的 usage segment（数量级 = 本轮 API 次数），无同步 IO / 深拷贝 / 额外网络。
- 返回内容准确性：vendor 事件映射不变。变化仅限 live `outputTokens`（父级 streamed output）和 `generationReliable`（子代理不再 fail-closed）。累计 `tokenUsage` 仍走 `tracker.snapshot()`，含子代理。
- 实测：单测「父 message_delta 80 / 子 500 / result 580」→ Generating 与 Done 的 live `outputTokens=80` 且 `generationReliable=true`。无子代理时收尾仍可用 `result.usage.output`。

### 手工验证

不涉及。未启动 Desktop 实机跑带子代理的 Claude Code 任务。

### 未执行的验证

- Desktop 实机：带 Explore/Agent 的 Claude Code 任务，确认右下角 tok/s 在子代理期间冻结在父级数字、结束后仍显示。
- 全量 `pnpm test:unit` 在本机因上述 Pi 集成测试基线失败未绿；related 门禁已过。

## 风险

### 风险分类

- [ ] 无已知风险
- [ ] SQLite / migration
- [ ] system prompt
- [ ] 协议兼容
- [ ] 权限 / 安全 / 用户数据
- [ ] 存量插件兼容（批准状态 / 指纹 / manifest 校验 / 安装布局 / 包格式）
- [ ] 原生层 / fingerprint / OTA
- [ ] 跨平台差异
- [x] 其他：usage 计量展示口径。live tok/s 不再把子代理 output 算进分子；若有人把 status.`outputTokens` 当成整轮总 output 会看到偏小的数字。累计 `tokenUsage` / 记账不变。

### 影响与回滚

- 影响范围：Claude Code translator 的 live generation 字段；Desktop 状态栏 tok/s 显示。
- 回滚 / 降级方式：revert 本 PR。
- 存量插件影响：无。

### 提交前检查

- [x] 已 review 完整 diff
- [x] 每个 commit 都带 DCO 签名（`git commit -s`，见 [DCO](../DCO)）
- [x] UI 改动已在「UI 变化」注明引用的设计规范章节（不涉及 UI 则跳过）
- [x] 未提交凭证、令牌或授权文件
- [ ] 已补充必要文档（本次无需文档）
- [x] 已确认测试结果或说明未执行原因
