### PR TITLE
fix(desktop): safely rebuild Codex thread across credential providers

### DIFF
--- a/apps/desktop/src/main/__tests__/sessionRuntimeControlWiring.test.ts
+++ b/apps/desktop/src/main/__tests__/sessionRuntimeControlWiring.test.ts
@@ -271,6 +271,22 @@ describe('session runtime control wiring', () => {
     expect(setModel).toContain('return withSendToSessionLock(sessionId, applyLocked);');
   });
 
+  it('maps Codex relink CAS conflicts to the structured IPC error protocol', () => {
+    const setModel = handlerBody(
+      registerSource,
+      'const handleSetModel = async (',
+      'const recoverRemoteRuntimeAxisPersistence',
+    );
+    const conflictMapping = setModel.indexOf(
+      "err.message.startsWith('Codex provider thread relink was superseded')",
+    );
+    expect(conflictMapping).toBeGreaterThan(-1);
+    expect(
+      setModel.indexOf("throwIpcError(\n            'PRECONDITION_FAILED'", conflictMapping),
+    ).toBeGreaterThan(conflictMapping);
+    expect(setModel.indexOf('throw err;', conflictMapping)).toBeGreaterThan(conflictMapping);
+  });
+
   it('rejects terminal tasks before effort or Fast mutations recreate runtime state', () => {
     const effort = handlerBody(
       registerSource,

--- a/apps/desktop/src/main/__tests__/sessionRuntimeControlWiring.test.ts
+++ b/apps/desktop/src/main/__tests__/sessionRuntimeControlWiring.test.ts
@@ -302,7 +302,8 @@ describe('session runtime control wiring', () => {
       setModel.indexOf('const targetCodexRoute:'),
       setModel.indexOf('const relinkCodexThread ='),
     );
-    expect(targetRoute).toContain('requiresCodexThreadRelink\n          ? {');
+    expect(targetRoute).toContain('requiresCodexThreadRelink');
+    expect(targetRoute).toContain('? {');
     expect(targetRoute).toContain(
       'effort: atomicSelection?.effort ?? runtimeStatus.effort',
     );
@@ -310,6 +311,26 @@ describe('session runtime control wiring', () => {
       'fastMode: atomicSelection?.fastMode ?? runtimeStatus.fastMode',
     );
     expect(targetRoute).not.toContain('requiresCodexThreadRelink && atomicSelection');
+  });
+
+  it('derives the Codex relink boundary from effective credential identities', () => {
+    const setModel = handlerBody(
+      registerSource,
+      'const handleSetModel = async (',
+      'const recoverRemoteRuntimeAxisPersistence',
+    );
+    const relinkGate = setModel.slice(
+      setModel.indexOf('const hasPersistedLocalCodexThread ='),
+      setModel.indexOf('const targetCodexRoute:'),
+    );
+    expect(relinkGate).toContain('decideCodexProviderThreadRelink(');
+    expect(relinkGate).toContain(
+      '{ model: runtimeStatus.model, providerId: runtimeStatus.providerId }',
+    );
+    expect(relinkGate).toContain('{ model, providerId: targetProviderId }');
+    expect(relinkGate).toContain("relinkDecision === 'unresolved'");
+    expect(relinkGate).toContain("relinkDecision === 'relink'");
+    expect(relinkGate).toContain("throwIpcError(\n          'PRECONDITION_FAILED'");
   });
 
   it('rejects terminal tasks before effort or Fast mutations recreate runtime state', () => {

--- a/apps/desktop/src/main/__tests__/sessionRuntimeControlWiring.test.ts
+++ b/apps/desktop/src/main/__tests__/sessionRuntimeControlWiring.test.ts
@@ -292,6 +292,26 @@ describe('session runtime control wiring', () => {
     expect(relinkBoundary).not.toContain('throw new Error');
   });
 
+  it('relinks legacy provider selections with the persisted effort and Fast axes', () => {
+    const setModel = handlerBody(
+      registerSource,
+      'const handleSetModel = async (',
+      'const recoverRemoteRuntimeAxisPersistence',
+    );
+    const targetRoute = setModel.slice(
+      setModel.indexOf('const targetCodexRoute:'),
+      setModel.indexOf('const relinkCodexThread ='),
+    );
+    expect(targetRoute).toContain('requiresCodexThreadRelink\n          ? {');
+    expect(targetRoute).toContain(
+      'effort: atomicSelection?.effort ?? runtimeStatus.effort',
+    );
+    expect(targetRoute).toContain(
+      'fastMode: atomicSelection?.fastMode ?? runtimeStatus.fastMode',
+    );
+    expect(targetRoute).not.toContain('requiresCodexThreadRelink && atomicSelection');
+  });
+
   it('rejects terminal tasks before effort or Fast mutations recreate runtime state', () => {
     const effort = handlerBody(
       registerSource,

--- a/apps/desktop/src/main/__tests__/sessionRuntimeControlWiring.test.ts
+++ b/apps/desktop/src/main/__tests__/sessionRuntimeControlWiring.test.ts
@@ -271,20 +271,25 @@ describe('session runtime control wiring', () => {
     expect(setModel).toContain('return withSendToSessionLock(sessionId, applyLocked);');
   });
 
-  it('maps Codex relink CAS conflicts to the structured IPC error protocol', () => {
+  it('maps every Codex relink failure to the structured IPC error protocol', () => {
     const setModel = handlerBody(
       registerSource,
       'const handleSetModel = async (',
       'const recoverRemoteRuntimeAxisPersistence',
     );
-    const conflictMapping = setModel.indexOf(
-      "err.message.startsWith('Codex provider thread relink was superseded')",
+    const relinkBoundary = setModel.slice(
+      setModel.indexOf('const relinkCodexThread ='),
+      setModel.indexOf('const rebuildLiveOrcaWorker'),
     );
-    expect(conflictMapping).toBeGreaterThan(-1);
-    expect(
-      setModel.indexOf("throwIpcError(\n            'PRECONDITION_FAILED'", conflictMapping),
-    ).toBeGreaterThan(conflictMapping);
-    expect(setModel.indexOf('throw err;', conflictMapping)).toBeGreaterThan(conflictMapping);
+    expect(relinkBoundary).toContain(
+      "throwIpcError(\n                'PRECONDITION_FAILED'",
+    );
+    expect(relinkBoundary).toContain('.catch((error) => {');
+    expect(relinkBoundary).toContain('if (isIpcError(error)) throw error;');
+    expect(relinkBoundary).toContain(
+      "throwIpcError('INTERNAL', 'Failed to rebuild Codex provider thread')",
+    );
+    expect(relinkBoundary).not.toContain('throw new Error');
   });
 
   it('rejects terminal tasks before effort or Fast mutations recreate runtime state', () => {

--- a/apps/desktop/src/main/__tests__/sessionRuntimeControlWiring.test.ts
+++ b/apps/desktop/src/main/__tests__/sessionRuntimeControlWiring.test.ts
@@ -305,10 +305,10 @@ describe('session runtime control wiring', () => {
     expect(targetRoute).toContain('requiresCodexThreadRelink');
     expect(targetRoute).toContain('? {');
     expect(targetRoute).toContain(
-      'effort: atomicSelection?.effort ?? runtimeStatus.effort',
+      'effort: atomicSelection ? atomicSelection.effort : runtimeStatus.effort',
     );
     expect(targetRoute).toContain(
-      'fastMode: atomicSelection?.fastMode ?? runtimeStatus.fastMode',
+      'fastMode: atomicSelection ? atomicSelection.fastMode : runtimeStatus.fastMode',
     );
     expect(targetRoute).not.toContain('requiresCodexThreadRelink && atomicSelection');
   });

--- a/apps/desktop/src/main/__tests__/sessionRuntimeControlWiring.test.ts
+++ b/apps/desktop/src/main/__tests__/sessionRuntimeControlWiring.test.ts
@@ -285,6 +285,8 @@ describe('session runtime control wiring', () => {
       "throwIpcError(\n                'PRECONDITION_FAILED'",
     );
     expect(relinkBoundary).toContain('.catch((error) => {');
+    expect(relinkBoundary).toContain('reserveCodexForkCleanup(');
+    expect(relinkBoundary).toContain('...(cleanup ? { cleanup } : {})');
     expect(relinkBoundary).toContain('if (isIpcError(error)) throw error;');
     expect(relinkBoundary).toContain(
       "throwIpcError('INTERNAL', 'Failed to rebuild Codex provider thread')",

--- a/apps/desktop/src/main/maker-host/__tests__/importSharedCodexThread.test.ts
+++ b/apps/desktop/src/main/maker-host/__tests__/importSharedCodexThread.test.ts
@@ -21,6 +21,7 @@ vi.mock('../../logger.js', () => ({
 import {
   importSharedCodexThread,
   removeSharedCodexThread,
+  reserveCodexForkCleanup,
 } from '../codex-local-sessions';
 
 const THREAD_ID = '019dcd5a-6e54-7960-95e0-aa68117a28f1';
@@ -253,5 +254,32 @@ describe('importSharedCodexThread', () => {
     const db = new Database(stateDbPath, { readonly: true });
     expect(db.prepare('SELECT COUNT(*) AS n FROM thread_dynamic_tools').get()).toEqual({ n: 0 });
     db.close();
+  });
+
+  it('removes only the exact reserved fork rollout and state rows', async () => {
+    const sourceThreadId = '019dcd5a-6e54-7960-95e0-aa68117a28f2';
+    const rolloutPath = path.join(
+      codexHome,
+      'sessions',
+      '2026',
+      '08',
+      '29',
+      `rollout-2026-08-29T00-00-00-${THREAD_ID}.jsonl`,
+    );
+    fs.mkdirSync(path.dirname(rolloutPath), { recursive: true });
+    fs.writeFileSync(rolloutPath, '{"type":"session_meta"}\n');
+    const db = new Database(stateDbPath);
+    db.prepare('INSERT INTO threads (id, rollout_path) VALUES (?, ?)').run(THREAD_ID, rolloutPath);
+    db.prepare('INSERT INTO thread_dynamic_tools (thread_id, tool_name) VALUES (?, ?)')
+      .run(THREAD_ID, 'browser');
+    db.close();
+
+    const reservation = reserveCodexForkCleanup(THREAD_ID, sourceThreadId);
+    expect(reservation).not.toBeNull();
+    await reservation!();
+
+    expect(fs.existsSync(rolloutPath)).toBe(false);
+    expect(desktopThreadExists(THREAD_ID)).toBe(false);
+    expect(reserveCodexForkCleanup(sourceThreadId, sourceThreadId)).toBeNull();
   });
 });

--- a/apps/desktop/src/main/maker-host/codex-local-sessions.ts
+++ b/apps/desktop/src/main/maker-host/codex-local-sessions.ts
@@ -1564,6 +1564,68 @@ export async function dumpCodexThreadStateRows(threadId: string): Promise<CodexT
   return dump;
 }
 
+/** Capture only a newly forked thread's exact private DB row and rollout identity. */
+export function reserveCodexForkCleanup(
+  threadId: string,
+  sourceThreadId: string,
+): (() => Promise<void>) | null {
+  if (!isLikelyThreadId(threadId) || threadId === sourceThreadId) return null;
+  const home = getDesktopCodexHome();
+  const stateDbPath = findLatestStateDb(home);
+  if (!stateDbPath || !isPathInside(home, stateDbPath)) return null;
+  const row = readRawThreadRow(stateDbPath, threadId);
+  const rolloutPath = stringValue(row?.rollout_path);
+  if (
+    !rolloutPath ||
+    !isPathInside(home, rolloutPath) ||
+    threadIdFromRolloutPath(rolloutPath) !== threadId
+  ) return null;
+  try {
+    const stateDb = fs.lstatSync(stateDbPath);
+    const rollout = fs.lstatSync(rolloutPath);
+    if (!stateDb.isFile() || !rollout.isFile()) return null;
+    return async () => {
+      let db: Database.Database | null = null;
+      try {
+        const currentDb = fs.lstatSync(stateDbPath);
+        const currentRollout = fs.lstatSync(rolloutPath);
+        if (
+          !currentDb.isFile() || currentDb.dev !== stateDb.dev || currentDb.ino !== stateDb.ino ||
+          !currentRollout.isFile() || currentRollout.dev !== rollout.dev || currentRollout.ino !== rollout.ino
+        ) return;
+        db = createBetterSqliteDatabase(stateDbPath);
+        db.pragma(`busy_timeout = ${SQLITE_BUSY_TIMEOUT_MS}`);
+        const targetDb = db;
+        let stateRemoved = false;
+        targetDb.transaction(() => {
+          const current = targetDb.prepare('SELECT rollout_path FROM threads WHERE id = ? LIMIT 1')
+            .get(threadId) as { rollout_path?: string } | undefined;
+          if (current?.rollout_path !== rolloutPath) return;
+          if (tableExists(targetDb, 'thread_dynamic_tools')) {
+            targetDb.prepare('DELETE FROM thread_dynamic_tools WHERE thread_id = ?').run(threadId);
+          }
+          if (tableExists(targetDb, 'thread_spawn_edges')) {
+            targetDb.prepare('DELETE FROM thread_spawn_edges WHERE parent_thread_id = ?').run(threadId);
+          }
+          stateRemoved = targetDb.prepare('DELETE FROM threads WHERE id = ? AND rollout_path = ?')
+            .run(threadId, rolloutPath).changes > 0;
+        })();
+        if (stateRemoved) await fsp.rm(rolloutPath, { force: true });
+      } catch (error) {
+        log.warn('forked Codex thread cleanup failed', {
+          threadId,
+          error: error instanceof Error ? error.message : String(error),
+        });
+        throw error;
+      } finally {
+        closeDbQuietly(db);
+      }
+    };
+  } catch {
+    return null;
+  }
+}
+
 /** 只读取一个 state DB 里该 thread 的三表行并转成 JSON 可序列化形态。 */
 function readThreadStateRows(
   dbPath: string,

--- a/apps/desktop/src/main/maker-ipc/__tests__/codexProviderThreadRelink.test.ts
+++ b/apps/desktop/src/main/maker-ipc/__tests__/codexProviderThreadRelink.test.ts
@@ -1,0 +1,88 @@
+import { describe, expect, it, vi } from 'vitest';
+
+import {
+  isXdOpenAiCodexProviderTransition,
+  relinkCodexProviderThread,
+} from '../codexProviderThreadRelink.js';
+
+const source = {
+  sdkSessionId: 'thread-xd',
+  workingDir: '/work',
+  model: 'codex/gpt-5.6-sol',
+  providerId: 'xd',
+  effort: 'xhigh',
+  fastMode: true,
+};
+
+const target = {
+  model: 'gpt-5.6-sol',
+  providerId: 'openai',
+  effort: 'high',
+  fastMode: false,
+};
+
+describe('isXdOpenAiCodexProviderTransition', () => {
+  it('accepts only the two intended credential-family directions', () => {
+    expect(isXdOpenAiCodexProviderTransition('xd', 'openai')).toBe(true);
+    expect(isXdOpenAiCodexProviderTransition('openai', 'xd')).toBe(true);
+    expect(isXdOpenAiCodexProviderTransition('xd', 'xai')).toBe(false);
+    expect(isXdOpenAiCodexProviderTransition(null, 'openai')).toBe(false);
+    expect(isXdOpenAiCodexProviderTransition('openai', 'openai')).toBe(false);
+  });
+});
+
+describe('relinkCodexProviderThread', () => {
+  it('forks with source credentials and CAS-commits the full target route', async () => {
+    const fork = vi.fn(async () => ({ newSdkSessionId: 'thread-openai' }));
+    const commit = vi.fn(async () => true);
+
+    await expect(
+      relinkCodexProviderThread(
+        { readSource: vi.fn(async () => source), fork, commit },
+        { sessionId: 'session-1', target },
+      ),
+    ).resolves.toEqual({
+      previousSdkSessionId: 'thread-xd',
+      newSdkSessionId: 'thread-openai',
+    });
+
+    expect(fork).toHaveBeenCalledWith({
+      sourceSdkSessionId: 'thread-xd',
+      sourceModel: 'codex/gpt-5.6-sol',
+      sourceProviderId: 'xd',
+      workingDir: '/work',
+    });
+    expect(commit).toHaveBeenCalledWith({
+      sessionId: 'session-1',
+      source,
+      newSdkSessionId: 'thread-openai',
+      target,
+    });
+  });
+
+  it('does not fork when the task has no persisted native thread', async () => {
+    const fork = vi.fn();
+    const commit = vi.fn();
+    await expect(
+      relinkCodexProviderThread(
+        { readSource: vi.fn(async () => ({ ...source, sdkSessionId: null })), fork, commit },
+        { sessionId: 'session-1', target },
+      ),
+    ).resolves.toBeNull();
+    expect(fork).not.toHaveBeenCalled();
+    expect(commit).not.toHaveBeenCalled();
+  });
+
+  it('fails closed when the source tuple is superseded before CAS commit', async () => {
+    await expect(
+      relinkCodexProviderThread(
+        {
+          readSource: vi.fn(async () => source),
+          fork: vi.fn(async () => ({ newSdkSessionId: 'thread-openai' })),
+          commit: vi.fn(async () => false),
+        },
+        { sessionId: 'session-1', target },
+      ),
+    ).rejects.toThrow(/superseded/);
+  });
+});

--- a/apps/desktop/src/main/maker-ipc/__tests__/codexProviderThreadRelink.test.ts
+++ b/apps/desktop/src/main/maker-ipc/__tests__/codexProviderThreadRelink.test.ts
@@ -51,7 +51,7 @@ describe('relinkCodexProviderThread', () => {
       target,
     },
     {
-      name: 'OpenAI to implicit XD',
+      name: 'OpenAI to implicit XD fixed-effort model',
       source: {
         ...source,
         sdkSessionId: 'thread-openai',
@@ -61,7 +61,7 @@ describe('relinkCodexProviderThread', () => {
       target: {
         model: 'codex/gpt-5.6-sol',
         providerId: null,
-        effort: 'xhigh',
+        effort: null,
         fastMode: true,
       },
     },

--- a/apps/desktop/src/main/maker-ipc/__tests__/codexProviderThreadRelink.test.ts
+++ b/apps/desktop/src/main/maker-ipc/__tests__/codexProviderThreadRelink.test.ts
@@ -66,7 +66,8 @@ describe('relinkCodexProviderThread', () => {
       },
     },
   ])('forks and CAS-commits the complete route for $name', async ({ source, target }) => {
-    const fork = vi.fn(async () => ({ newSdkSessionId: 'thread-replacement' }));
+    const cleanup = vi.fn(async () => {});
+    const fork = vi.fn(async () => ({ newSdkSessionId: 'thread-replacement', cleanup }));
     const commit = vi.fn(async () => true);
 
     expect(decideCodexProviderThreadRelink(source, target)).toBe('relink');
@@ -92,6 +93,7 @@ describe('relinkCodexProviderThread', () => {
       newSdkSessionId: 'thread-replacement',
       target,
     });
+    expect(cleanup).not.toHaveBeenCalled();
   });
 
   it('forks with source credentials and CAS-commits the full target route', async () => {
@@ -136,15 +138,37 @@ describe('relinkCodexProviderThread', () => {
   });
 
   it('fails closed when the source tuple is superseded before CAS commit', async () => {
+    const cleanup = vi.fn(async () => {});
     await expect(
       relinkCodexProviderThread(
         {
           readSource: vi.fn(async () => source),
-          fork: vi.fn(async () => ({ newSdkSessionId: 'thread-openai' })),
+          fork: vi.fn(async () => ({ newSdkSessionId: 'thread-openai', cleanup })),
           commit: vi.fn(async () => false),
         },
         { sessionId: 'session-1', target },
       ),
     ).rejects.toThrow(/superseded/);
+    expect(cleanup).toHaveBeenCalledOnce();
+  });
+
+  it('preserves the database error when replacement cleanup also fails', async () => {
+    const databaseError = new Error('route CAS failed');
+    const cleanup = vi.fn(async () => {
+      throw new Error('replacement cleanup failed');
+    });
+    await expect(
+      relinkCodexProviderThread(
+        {
+          readSource: vi.fn(async () => source),
+          fork: vi.fn(async () => ({ newSdkSessionId: 'thread-openai', cleanup })),
+          commit: vi.fn(async () => {
+            throw databaseError;
+          }),
+        },
+        { sessionId: 'session-1', target },
+      ),
+    ).rejects.toBe(databaseError);
+    expect(cleanup).toHaveBeenCalledOnce();
   });
 });

--- a/apps/desktop/src/main/maker-ipc/__tests__/codexProviderThreadRelink.test.ts
+++ b/apps/desktop/src/main/maker-ipc/__tests__/codexProviderThreadRelink.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it, vi } from 'vitest';
 
 import {
+  decideCodexProviderThreadRelink,
   isXdOpenAiCodexProviderTransition,
   relinkCodexProviderThread,
 } from '../codexProviderThreadRelink.js';
@@ -29,9 +30,70 @@ describe('isXdOpenAiCodexProviderTransition', () => {
     expect(isXdOpenAiCodexProviderTransition(null, 'openai')).toBe(false);
     expect(isXdOpenAiCodexProviderTransition('openai', 'openai')).toBe(false);
   });
+
+  it('recognizes implicit XD Codex routes after credential identity resolution', () => {
+    const implicitXd = { providerId: null, model: 'codex/gpt-5.6-sol' };
+    const subscription = { providerId: 'openai', model: 'gpt-5.6-sol' };
+
+    expect(decideCodexProviderThreadRelink(implicitXd, subscription)).toBe('relink');
+    expect(decideCodexProviderThreadRelink(subscription, implicitXd)).toBe('relink');
+    expect(
+      decideCodexProviderThreadRelink({ providerId: null, model: 'ambiguous-model' }, subscription),
+    ).toBe('unresolved');
+  });
 });
 
 describe('relinkCodexProviderThread', () => {
+  it.each([
+    {
+      name: 'implicit XD to OpenAI',
+      source: { ...source, providerId: null, model: 'codex/gpt-5.6-sol' },
+      target,
+    },
+    {
+      name: 'OpenAI to implicit XD',
+      source: {
+        ...source,
+        sdkSessionId: 'thread-openai',
+        providerId: 'openai',
+        model: 'gpt-5.6-sol',
+      },
+      target: {
+        model: 'codex/gpt-5.6-sol',
+        providerId: null,
+        effort: 'xhigh',
+        fastMode: true,
+      },
+    },
+  ])('forks and CAS-commits the complete route for $name', async ({ source, target }) => {
+    const fork = vi.fn(async () => ({ newSdkSessionId: 'thread-replacement' }));
+    const commit = vi.fn(async () => true);
+
+    expect(decideCodexProviderThreadRelink(source, target)).toBe('relink');
+    await expect(
+      relinkCodexProviderThread(
+        { readSource: vi.fn(async () => source), fork, commit },
+        { sessionId: 'session-implicit-provider', target },
+      ),
+    ).resolves.toEqual({
+      previousSdkSessionId: source.sdkSessionId,
+      newSdkSessionId: 'thread-replacement',
+    });
+
+    expect(fork).toHaveBeenCalledWith({
+      sourceSdkSessionId: source.sdkSessionId,
+      sourceModel: source.model,
+      sourceProviderId: source.providerId,
+      workingDir: source.workingDir,
+    });
+    expect(commit).toHaveBeenCalledWith({
+      sessionId: 'session-implicit-provider',
+      source,
+      newSdkSessionId: 'thread-replacement',
+      target,
+    });
+  });
+
   it('forks with source credentials and CAS-commits the full target route', async () => {
     const fork = vi.fn(async () => ({ newSdkSessionId: 'thread-openai' }));
     const commit = vi.fn(async () => true);

--- a/apps/desktop/src/main/maker-ipc/__tests__/runtimeSetModelCodexRelink.test.ts
+++ b/apps/desktop/src/main/maker-ipc/__tests__/runtimeSetModelCodexRelink.test.ts
@@ -1,0 +1,194 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+import {
+  clearSessionProvider,
+  getSessionProvider,
+  setSessionProvider,
+} from '../../maker-host/session-provider-store.js';
+import { applyRuntimeSetModelChange, type RuntimeSetModelMaker } from '../runtimeSetModel.js';
+
+const sessionProviderWriteObserver = vi.hoisted(() => ({
+  current: null as ((sessionId: string, providerId: string | null) => void) | null,
+}));
+
+vi.mock('../../maker-host/session-provider-store.js', async (importOriginal) => {
+  const actual =
+    await importOriginal<typeof import('../../maker-host/session-provider-store.js')>();
+  return {
+    ...actual,
+    setSessionProvider: (sessionId: string, providerId: string | null) => {
+      actual.setSessionProvider(sessionId, providerId);
+      sessionProviderWriteObserver.current?.(sessionId, providerId);
+    },
+  };
+});
+
+const touchedSessions = new Set<string>();
+
+afterEach(() => {
+  sessionProviderWriteObserver.current = null;
+  for (const sessionId of touchedSessions) clearSessionProvider(sessionId);
+  touchedSessions.clear();
+});
+
+function rememberSession(sessionId: string): string {
+  touchedSessions.add(sessionId);
+  return sessionId;
+}
+
+describe('applyRuntimeSetModelChange Codex provider thread relink', () => {
+  it('closes, relinks, then publishes an idle XD-to-subscription route', async () => {
+    const sessionId = rememberSession('runtime-set-model-atomic-relink');
+    setSessionProvider(sessionId, 'xd');
+    const order: string[] = [];
+    const closeSession = vi.fn(async () => {
+      order.push('close');
+    });
+    const relinkCodexThread = vi.fn(async () => {
+      order.push('relink');
+    });
+    const wakeSessionInputQueue = vi.fn(() => {
+      order.push('wake');
+    });
+    sessionProviderWriteObserver.current = (writtenSessionId, providerId) => {
+      if (writtenSessionId === sessionId && providerId === 'openai') order.push('route');
+    };
+    const maker: RuntimeSetModelMaker = {
+      getSession: () => ({
+        agentKind: 'codex',
+        remoteHostId: null,
+        model: 'codex/gpt-5.6-sol',
+        setModel: vi.fn(async () => {}),
+      }),
+      listActiveSessions: () => [
+        { id: sessionId, agentKind: 'codex', remoteHostId: null, isTurnRunning: () => false },
+      ],
+      closeSession,
+    };
+
+    await expect(
+      applyRuntimeSetModelChange({
+        maker,
+        sessionId,
+        model: 'gpt-5.6-sol',
+        providerId: 'openai',
+        requiresCodexThreadRelink: true,
+        relinkCodexThread,
+        clearPendingCredentialSwitch: vi.fn(),
+        wakeSessionInputQueue,
+      }),
+    ).resolves.toEqual({ status: 'applied', persistedRoute: true });
+
+    expect(order).toEqual(['close', 'relink', 'route', 'wake']);
+    expect(getSessionProvider(sessionId)).toBe('openai');
+  });
+
+  it('fails closed instead of registering pending work while the task is busy', async () => {
+    const sessionId = rememberSession('runtime-set-model-busy-relink');
+    setSessionProvider(sessionId, 'xd');
+    const registerPendingCredentialSwitch = vi.fn();
+    const relinkCodexThread = vi.fn(async () => {});
+    const closeSession = vi.fn(async () => {});
+    const maker: RuntimeSetModelMaker = {
+      getSession: () => ({
+        agentKind: 'codex',
+        remoteHostId: null,
+        model: 'codex/gpt-5.6-sol',
+        setModel: vi.fn(async () => {}),
+      }),
+      listActiveSessions: () => [
+        { id: sessionId, agentKind: 'codex', remoteHostId: null, isTurnRunning: () => true },
+      ],
+      closeSession,
+    };
+
+    await expect(
+      applyRuntimeSetModelChange({
+        maker,
+        sessionId,
+        model: 'gpt-5.6-sol',
+        providerId: 'openai',
+        requiresCodexThreadRelink: true,
+        relinkCodexThread,
+        registerPendingCredentialSwitch,
+      }),
+    ).rejects.toThrow(/busy/);
+
+    expect(registerPendingCredentialSwitch).not.toHaveBeenCalled();
+    expect(relinkCodexThread).not.toHaveBeenCalled();
+    expect(closeSession).not.toHaveBeenCalled();
+    expect(getSessionProvider(sessionId)).toBe('xd');
+  });
+
+  it('still fails closed when the task becomes busy during the close preflight', async () => {
+    const sessionId = rememberSession('runtime-set-model-busy-race-relink');
+    setSessionProvider(sessionId, 'xd');
+    let busyCheck = 0;
+    const registerPendingCredentialSwitch = vi.fn();
+    const relinkCodexThread = vi.fn(async () => {});
+    const closeSession = vi.fn(async () => {});
+    const maker: RuntimeSetModelMaker = {
+      getSession: () => ({
+        agentKind: 'codex',
+        remoteHostId: null,
+        model: 'codex/gpt-5.6-sol',
+        setModel: vi.fn(async () => {}),
+      }),
+      listActiveSessions: () => [
+        {
+          id: sessionId,
+          agentKind: 'codex',
+          remoteHostId: null,
+          isTurnRunning: () => ++busyCheck > 1,
+        },
+      ],
+      closeSession,
+    };
+
+    await expect(
+      applyRuntimeSetModelChange({
+        maker,
+        sessionId,
+        model: 'gpt-5.6-sol',
+        providerId: 'openai',
+        requiresCodexThreadRelink: true,
+        relinkCodexThread,
+        registerPendingCredentialSwitch,
+        clearPendingCredentialSwitch: vi.fn(),
+      }),
+    ).rejects.toThrow(/busy/);
+
+    expect(registerPendingCredentialSwitch).not.toHaveBeenCalled();
+    expect(relinkCodexThread).not.toHaveBeenCalled();
+    expect(closeSession).not.toHaveBeenCalled();
+    expect(getSessionProvider(sessionId)).toBe('xd');
+  });
+
+  it('relinks a persisted thread even without a live Session handle', async () => {
+    const sessionId = rememberSession('runtime-set-model-cold-relink');
+    setSessionProvider(sessionId, 'xd');
+    const relinkCodexThread = vi.fn(async () => {});
+    const wakeSessionInputQueue = vi.fn();
+    const maker: RuntimeSetModelMaker = {
+      getSession: () => undefined,
+      listActiveSessions: () => [],
+      closeSession: vi.fn(async () => {}),
+    };
+
+    await expect(
+      applyRuntimeSetModelChange({
+        maker,
+        sessionId,
+        model: 'gpt-5.6-sol',
+        providerId: 'openai',
+        requiresCodexThreadRelink: true,
+        relinkCodexThread,
+        wakeSessionInputQueue,
+      }),
+    ).resolves.toEqual({ status: 'applied', persistedRoute: true });
+
+    expect(relinkCodexThread).toHaveBeenCalledOnce();
+    expect(wakeSessionInputQueue).toHaveBeenCalledWith(sessionId);
+    expect(getSessionProvider(sessionId)).toBe('openai');
+  });
+});

--- a/apps/desktop/src/main/maker-ipc/codexProviderThreadRelink.ts
+++ b/apps/desktop/src/main/maker-ipc/codexProviderThreadRelink.ts
@@ -1,0 +1,72 @@
+/**
+ * Rebuild a local Codex native thread before crossing the XD/OpenAI credential boundary.
+ *
+ * Fork authentication belongs to the source thread. The replacement thread id and the
+ * complete target runtime route are then committed by one caller-provided CAS.
+ */
+
+export interface CodexProviderThreadRoute {
+  model: string;
+  providerId: string | null;
+  effort: string | null;
+  fastMode: boolean;
+}
+
+export interface CodexProviderThreadRelinkSource extends CodexProviderThreadRoute {
+  sdkSessionId: string | null;
+  workingDir: string | null;
+}
+
+export interface CodexProviderThreadRelinkDeps {
+  readSource(sessionId: string): Promise<CodexProviderThreadRelinkSource | null>;
+  fork(input: {
+    sourceSdkSessionId: string;
+    sourceModel: string;
+    sourceProviderId: string | null;
+    workingDir?: string;
+  }): Promise<{ newSdkSessionId: string }>;
+  commit(input: {
+    sessionId: string;
+    source: CodexProviderThreadRelinkSource & { sdkSessionId: string };
+    newSdkSessionId: string;
+    target: CodexProviderThreadRoute;
+  }): Promise<boolean>;
+}
+
+export function isXdOpenAiCodexProviderTransition(
+  sourceProviderId: string | null | undefined,
+  targetProviderId: string | null | undefined,
+): boolean {
+  const source = sourceProviderId?.trim() || null;
+  const target = targetProviderId?.trim() || null;
+  return (source === 'xd' && target === 'openai') || (source === 'openai' && target === 'xd');
+}
+
+export async function relinkCodexProviderThread(
+  deps: CodexProviderThreadRelinkDeps,
+  input: { sessionId: string; target: CodexProviderThreadRoute },
+): Promise<{ previousSdkSessionId: string; newSdkSessionId: string } | null> {
+  const source = await deps.readSource(input.sessionId);
+  if (!source?.sdkSessionId) return null;
+
+  const sourceWithThread = { ...source, sdkSessionId: source.sdkSessionId };
+  const forked = await deps.fork({
+    sourceSdkSessionId: sourceWithThread.sdkSessionId,
+    sourceModel: sourceWithThread.model,
+    sourceProviderId: sourceWithThread.providerId,
+    ...(sourceWithThread.workingDir ? { workingDir: sourceWithThread.workingDir } : {}),
+  });
+  const committed = await deps.commit({
+    sessionId: input.sessionId,
+    source: sourceWithThread,
+    newSdkSessionId: forked.newSdkSessionId,
+    target: input.target,
+  });
+  if (!committed) {
+    throw new Error(`Codex provider thread relink was superseded for session ${input.sessionId}`);
+  }
+  return {
+    previousSdkSessionId: sourceWithThread.sdkSessionId,
+    newSdkSessionId: forked.newSdkSessionId,
+  };
+}

--- a/apps/desktop/src/main/maker-ipc/codexProviderThreadRelink.ts
+++ b/apps/desktop/src/main/maker-ipc/codexProviderThreadRelink.ts
@@ -26,7 +26,7 @@ export interface CodexProviderThreadRelinkDeps {
     sourceModel: string;
     sourceProviderId: string | null;
     workingDir?: string;
-  }): Promise<{ newSdkSessionId: string }>;
+  }): Promise<{ newSdkSessionId: string; cleanup?: () => Promise<void> }>;
   commit(input: {
     sessionId: string;
     source: CodexProviderThreadRelinkSource & { sdkSessionId: string };
@@ -85,14 +85,19 @@ export async function relinkCodexProviderThread(
     sourceProviderId: sourceWithThread.providerId,
     ...(sourceWithThread.workingDir ? { workingDir: sourceWithThread.workingDir } : {}),
   });
-  const committed = await deps.commit({
-    sessionId: input.sessionId,
-    source: sourceWithThread,
-    newSdkSessionId: forked.newSdkSessionId,
-    target: input.target,
-  });
-  if (!committed) {
-    throw new Error(`Codex provider thread relink was superseded for session ${input.sessionId}`);
+  try {
+    const committed = await deps.commit({
+      sessionId: input.sessionId,
+      source: sourceWithThread,
+      newSdkSessionId: forked.newSdkSessionId,
+      target: input.target,
+    });
+    if (!committed) {
+      throw new Error(`Codex provider thread relink was superseded for session ${input.sessionId}`);
+    }
+  } catch (error) {
+    await forked.cleanup?.().catch(() => undefined);
+    throw error;
   }
   return {
     previousSdkSessionId: sourceWithThread.sdkSessionId,

--- a/apps/desktop/src/main/maker-ipc/codexProviderThreadRelink.ts
+++ b/apps/desktop/src/main/maker-ipc/codexProviderThreadRelink.ts
@@ -5,6 +5,8 @@
  * complete target runtime route are then committed by one caller-provided CAS.
  */
 
+import { resolveAgentCredentialMode } from '@cindy/maker-core';
+
 export interface CodexProviderThreadRoute {
   model: string;
   providerId: string | null;
@@ -40,6 +42,33 @@ export function isXdOpenAiCodexProviderTransition(
   const source = sourceProviderId?.trim() || null;
   const target = targetProviderId?.trim() || null;
   return (source === 'xd' && target === 'openai') || (source === 'openai' && target === 'xd');
+}
+
+export type CodexProviderThreadRelinkDecision = 'relink' | 'not-applicable' | 'unresolved';
+
+export function decideCodexProviderThreadRelink(
+  source: Pick<CodexProviderThreadRoute, 'model' | 'providerId'>,
+  target: Pick<CodexProviderThreadRoute, 'model' | 'providerId'>,
+): CodexProviderThreadRelinkDecision {
+  const sourceMode = resolveAgentCredentialMode({ agentKind: 'codex', ...source });
+  const targetMode = resolveAgentCredentialMode({ agentKind: 'codex', ...target });
+  const toProviderIdentity = (mode: typeof sourceMode): 'xd' | 'openai' | null => {
+    if (mode === 'gateway-key') return 'xd';
+    if (mode === 'oauth-bearer') return 'openai';
+    return null;
+  };
+  const involvesXdOpenAiBoundary = [sourceMode, targetMode].some(
+    (mode) => mode === 'gateway-key' || mode === 'oauth-bearer',
+  );
+  if (involvesXdOpenAiBoundary && (sourceMode === undefined || targetMode === undefined)) {
+    return 'unresolved';
+  }
+  return isXdOpenAiCodexProviderTransition(
+    toProviderIdentity(sourceMode),
+    toProviderIdentity(targetMode),
+  )
+    ? 'relink'
+    : 'not-applicable';
 }
 
 export async function relinkCodexProviderThread(

--- a/apps/desktop/src/main/maker-ipc/register.ts
+++ b/apps/desktop/src/main/maker-ipc/register.ts
@@ -15168,8 +15168,8 @@ export function registerMakerIpc(maker: Maker, options: RegisterMakerIpcOptions)
         ? {
             model,
             providerId: targetProviderId,
-            effort: atomicSelection?.effort ?? runtimeStatus.effort,
-            fastMode: atomicSelection?.fastMode ?? runtimeStatus.fastMode,
+            effort: atomicSelection ? atomicSelection.effort : runtimeStatus.effort,
+            fastMode: atomicSelection ? atomicSelection.fastMode : runtimeStatus.fastMode,
           }
         : undefined;
       const relinkCodexThread = targetCodexRoute

--- a/apps/desktop/src/main/maker-ipc/register.ts
+++ b/apps/desktop/src/main/maker-ipc/register.ts
@@ -15153,12 +15153,12 @@ export function registerMakerIpc(maker: Maker, options: RegisterMakerIpcOptions)
         !!runtimeStatus.sdkSessionId &&
         isXdOpenAiCodexProviderTransition(runtimeStatus.providerId, targetProviderId);
       const targetCodexRoute: CodexProviderThreadRoute | undefined =
-        requiresCodexThreadRelink && atomicSelection
+        requiresCodexThreadRelink
           ? {
               model,
               providerId: targetProviderId,
-              effort: atomicSelection.effort,
-              fastMode: atomicSelection.fastMode,
+              effort: atomicSelection?.effort ?? runtimeStatus.effort,
+              fastMode: atomicSelection?.fastMode ?? runtimeStatus.fastMode,
             }
           : undefined;
       const relinkCodexThread = targetCodexRoute

--- a/apps/desktop/src/main/maker-ipc/register.ts
+++ b/apps/desktop/src/main/maker-ipc/register.ts
@@ -15166,7 +15166,10 @@ export function registerMakerIpc(maker: Maker, options: RegisterMakerIpcOptions)
             const ownerScope = captureDataOwnerBroadcastScope();
             const dbSnapshot = getCurrentDbClientSnapshot();
             if (!dbSnapshot) {
-              throw new Error('Codex provider thread relink requires an active Profile database');
+              throwIpcError(
+                'PRECONDITION_FAILED',
+                'Codex provider thread relink requires an active Profile database',
+              );
             }
             const relinked = await relinkCodexProviderThread(
               {
@@ -15249,10 +15252,23 @@ export function registerMakerIpc(maker: Maker, options: RegisterMakerIpcOptions)
                 },
               },
               { sessionId, target: targetCodexRoute },
-            );
+            ).catch((error) => {
+              if (isIpcError(error)) throw error;
+              if (
+                error instanceof Error &&
+                error.message.startsWith('Codex provider thread relink was superseded')
+              ) {
+                throwIpcError(
+                  'PRECONDITION_FAILED',
+                  'Codex provider thread changed during model switch; retry the selection',
+                );
+              }
+              throwIpcError('INTERNAL', 'Failed to rebuild Codex provider thread');
+            });
             if (!relinked) {
-              throw new Error(
-                `Codex provider thread relink was superseded for session ${sessionId}`,
+              throwIpcError(
+                'PRECONDITION_FAILED',
+                'Codex provider thread changed during model switch; retry the selection',
               );
             }
             log.info('Codex provider thread and route committed atomically', {
@@ -15628,16 +15644,6 @@ export function registerMakerIpc(maker: Maker, options: RegisterMakerIpcOptions)
           // 兜底(正常路径 busy 已转 deferred):切模型撞上凭证切换忙,独立 code,
           // renderer toast 走 ipcError.CREDENTIAL_SWITCH_BUSY 专属文案。
           throwIpcError('CREDENTIAL_SWITCH_BUSY', err.message);
-        }
-        if (
-          requiresCodexThreadRelink &&
-          err instanceof Error &&
-          err.message.startsWith('Codex provider thread relink was superseded')
-        ) {
-          throwIpcError(
-            'PRECONDITION_FAILED',
-            'Codex provider thread changed during model switch; retry the selection',
-          );
         }
         throw err;
       }

--- a/apps/desktop/src/main/maker-ipc/register.ts
+++ b/apps/desktop/src/main/maker-ipc/register.ts
@@ -15629,6 +15629,16 @@ export function registerMakerIpc(maker: Maker, options: RegisterMakerIpcOptions)
           // renderer toast 走 ipcError.CREDENTIAL_SWITCH_BUSY 专属文案。
           throwIpcError('CREDENTIAL_SWITCH_BUSY', err.message);
         }
+        if (
+          requiresCodexThreadRelink &&
+          err instanceof Error &&
+          err.message.startsWith('Codex provider thread relink was superseded')
+        ) {
+          throwIpcError(
+            'PRECONDITION_FAILED',
+            'Codex provider thread changed during model switch; retry the selection',
+          );
+        }
         throw err;
       }
     };

--- a/apps/desktop/src/main/maker-ipc/register.ts
+++ b/apps/desktop/src/main/maker-ipc/register.ts
@@ -882,7 +882,7 @@ import {
   isRemoteModelSwitchRouteChangeError,
 } from './runtimeSetModel.js';
 import {
-  isXdOpenAiCodexProviderTransition,
+  decideCodexProviderThreadRelink,
   relinkCodexProviderThread,
   type CodexProviderThreadRoute,
 } from './codexProviderThreadRelink.js';
@@ -15145,22 +15145,33 @@ export function registerMakerIpc(maker: Maker, options: RegisterMakerIpcOptions)
         effectiveProviderId === undefined
           ? currentProviderId
           : (normalizeSessionProviderId(effectiveProviderId) ?? null);
-      const requiresCodexThreadRelink =
+      const hasPersistedLocalCodexThread =
         internalOptions.source === 'user' &&
         !isDeviceLinkInvoke() &&
         runtimeStatus.agentKind === 'codex' &&
         !runtimeStatus.remoteHostId &&
-        !!runtimeStatus.sdkSessionId &&
-        isXdOpenAiCodexProviderTransition(runtimeStatus.providerId, targetProviderId);
-      const targetCodexRoute: CodexProviderThreadRoute | undefined =
-        requiresCodexThreadRelink
-          ? {
-              model,
-              providerId: targetProviderId,
-              effort: atomicSelection?.effort ?? runtimeStatus.effort,
-              fastMode: atomicSelection?.fastMode ?? runtimeStatus.fastMode,
-            }
-          : undefined;
+        !!runtimeStatus.sdkSessionId;
+      const relinkDecision = hasPersistedLocalCodexThread
+        ? decideCodexProviderThreadRelink(
+            { model: runtimeStatus.model, providerId: runtimeStatus.providerId },
+            { model, providerId: targetProviderId },
+          )
+        : 'not-applicable';
+      if (relinkDecision === 'unresolved') {
+        throwIpcError(
+          'PRECONDITION_FAILED',
+          'Codex provider credential identity could not be resolved; retry with an explicit provider',
+        );
+      }
+      const requiresCodexThreadRelink = relinkDecision === 'relink';
+      const targetCodexRoute: CodexProviderThreadRoute | undefined = requiresCodexThreadRelink
+        ? {
+            model,
+            providerId: targetProviderId,
+            effort: atomicSelection?.effort ?? runtimeStatus.effort,
+            fastMode: atomicSelection?.fastMode ?? runtimeStatus.fastMode,
+          }
+        : undefined;
       const relinkCodexThread = targetCodexRoute
         ? async (): Promise<void> => {
             const ownerScope = captureDataOwnerBroadcastScope();

--- a/apps/desktop/src/main/maker-ipc/register.ts
+++ b/apps/desktop/src/main/maker-ipc/register.ts
@@ -882,6 +882,11 @@ import {
   isRemoteModelSwitchRouteChangeError,
 } from './runtimeSetModel.js';
 import {
+  isXdOpenAiCodexProviderTransition,
+  relinkCodexProviderThread,
+  type CodexProviderThreadRoute,
+} from './codexProviderThreadRelink.js';
+import {
   applyRuntimeSelectionAxesWithRecovery,
   commitRuntimeAxisAfterPersistence,
   isSupportedRuntimeEffort,
@@ -14916,7 +14921,18 @@ export function registerMakerIpc(maker: Maker, options: RegisterMakerIpcOptions)
       // 状态可封住两种次序：本请求先拿锁时终态写等待并在之后清理 override；终态
       // 先拿锁时旧请求看到非 active，不能在 cleanup 后重新建立 pending/override。
       const [runtimeStatus] = await getDbClient()
-        .drizzle.select({ status: sessions.status, orcaRole: sessions.orcaRole })
+        .drizzle.select({
+          status: sessions.status,
+          orcaRole: sessions.orcaRole,
+          agentKind: sessions.agentKind,
+          remoteHostId: sessions.remoteHostId,
+          sdkSessionId: sessions.sdkSessionId,
+          model: sessions.model,
+          providerId: sessions.providerId,
+          effort: sessions.effort,
+          fastMode: sessions.fastMode,
+          workingDir: sessions.workingDir,
+        })
         .from(sessions)
         .where(eq(sessions.id, sessionId))
         .limit(1);
@@ -15129,6 +15145,125 @@ export function registerMakerIpc(maker: Maker, options: RegisterMakerIpcOptions)
         effectiveProviderId === undefined
           ? currentProviderId
           : (normalizeSessionProviderId(effectiveProviderId) ?? null);
+      const requiresCodexThreadRelink =
+        internalOptions.source === 'user' &&
+        !isDeviceLinkInvoke() &&
+        runtimeStatus.agentKind === 'codex' &&
+        !runtimeStatus.remoteHostId &&
+        !!runtimeStatus.sdkSessionId &&
+        isXdOpenAiCodexProviderTransition(runtimeStatus.providerId, targetProviderId);
+      const targetCodexRoute: CodexProviderThreadRoute | undefined =
+        requiresCodexThreadRelink && atomicSelection
+          ? {
+              model,
+              providerId: targetProviderId,
+              effort: atomicSelection.effort,
+              fastMode: atomicSelection.fastMode,
+            }
+          : undefined;
+      const relinkCodexThread = targetCodexRoute
+        ? async (): Promise<void> => {
+            const ownerScope = captureDataOwnerBroadcastScope();
+            const dbSnapshot = getCurrentDbClientSnapshot();
+            if (!dbSnapshot) {
+              throw new Error('Codex provider thread relink requires an active Profile database');
+            }
+            const relinked = await relinkCodexProviderThread(
+              {
+                readSource: async (targetSessionId) => {
+                  const [row] = await dbSnapshot.client.drizzle
+                    .select({
+                      sdkSessionId: sessions.sdkSessionId,
+                      workingDir: sessions.workingDir,
+                      model: sessions.model,
+                      providerId: sessions.providerId,
+                      effort: sessions.effort,
+                      fastMode: sessions.fastMode,
+                    })
+                    .from(sessions)
+                    .where(eq(sessions.id, targetSessionId))
+                    .limit(1);
+                  return row ?? null;
+                },
+                fork: async ({ sourceSdkSessionId, sourceModel, sourceProviderId, workingDir }) => {
+                  const forked = await maker.forkSdkSession('codex', {
+                    sourceSdkSessionId,
+                    model: sourceModel,
+                    providerId: sourceProviderId,
+                    upToMessageId: undefined,
+                    ...(workingDir ? { workingDir } : {}),
+                    stripEncryptedReasoning: true,
+                    remoteHostId: null,
+                  });
+                  return { newSdkSessionId: forked.newSdkSessionId };
+                },
+                commit: async ({ sessionId: targetSessionId, source, newSdkSessionId, target }) => {
+                  if (
+                    !isDataOwnerBroadcastScopeCurrent(ownerScope) ||
+                    getCurrentDbClientSnapshot()?.clientEpoch !== dbSnapshot.clientEpoch
+                  ) {
+                    return false;
+                  }
+                  const now = Date.now();
+                  const sourceRouteConditions = [
+                    eq(sessions.id, targetSessionId),
+                    eq(sessions.sdkSessionId, source.sdkSessionId),
+                    eq(sessions.model, source.model),
+                    source.providerId === null
+                      ? isNull(sessions.providerId)
+                      : eq(sessions.providerId, source.providerId),
+                    source.effort === null
+                      ? isNull(sessions.effort)
+                      : eq(
+                          sessions.effort,
+                          source.effort as (typeof sessions.$inferSelect)['effort'],
+                        ),
+                    eq(sessions.fastMode, source.fastMode),
+                  ];
+                  const write = await dbSnapshot.client.drizzle
+                    .update(sessions)
+                    .set({
+                      sdkSessionId: newSdkSessionId,
+                      model: target.model,
+                      providerId: target.providerId,
+                      effort: target.effort as (typeof sessions.$inferInsert)['effort'],
+                      fastMode: target.fastMode,
+                      updatedAt: now,
+                    })
+                    .where(and(...sourceRouteConditions))
+                    .run();
+                  if (write.changes === 0) return false;
+                  broadcastSessionPatched(
+                    targetSessionId,
+                    {
+                      sdkSessionId: newSdkSessionId,
+                      model: target.model,
+                      providerId: target.providerId,
+                      effort: target.effort,
+                      fastMode: target.fastMode,
+                      updatedAt: new Date(now).toISOString(),
+                    },
+                    ownerScope,
+                  );
+                  return true;
+                },
+              },
+              { sessionId, target: targetCodexRoute },
+            );
+            if (!relinked) {
+              throw new Error(
+                `Codex provider thread relink was superseded for session ${sessionId}`,
+              );
+            }
+            log.info('Codex provider thread and route committed atomically', {
+              sessionId,
+              fromThreadId: relinked.previousSdkSessionId,
+              toThreadId: relinked.newSdkSessionId,
+              providerId: targetCodexRoute.providerId,
+              model: targetCodexRoute.model,
+            });
+          }
+        : undefined;
       const rebuildLiveOrcaWorker =
         routeExplicit &&
         runtimeStatus.orcaRole === 'worker' &&
@@ -15256,6 +15391,8 @@ export function registerMakerIpc(maker: Maker, options: RegisterMakerIpcOptions)
               // 解析隐式来源的凭证家族,精确判定是否跨远端压缩身份边界(见
               // shouldCloseSessionForCredentialSwitch.codexAuthInjection)。
               codexAuthInjection: getCodexProxyAuthInjectionState(),
+              requiresCodexThreadRelink,
+              ...(relinkCodexThread ? { relinkCodexThread } : {}),
               logger: log,
             })
           : { status: 'applied' as const };
@@ -15301,7 +15438,11 @@ export function registerMakerIpc(maker: Maker, options: RegisterMakerIpcOptions)
             commitControlStores();
           }
         }
-        if (internalOptions.source === 'user' && (isDeviceLinkInvoke() || atomicSelection)) {
+        if (
+          internalOptions.source === 'user' &&
+          (isDeviceLinkInvoke() || atomicSelection) &&
+          result.persistedRoute !== true
+        ) {
           // device-link 的通用持久化原本发生在 handler 返回、session 锁释放之后；
           // 本地 renderer 的 sessionService.update 也有同一窗口。凡携带 selection 的
           // 新调用都由 host 在解锁前一次落定全部字段。

--- a/apps/desktop/src/main/maker-ipc/register.ts
+++ b/apps/desktop/src/main/maker-ipc/register.ts
@@ -747,7 +747,10 @@ import {
   persistedUserContentToWireMessage,
   shouldRebuildPiNativeSession,
 } from './contextOverflowRollover.js';
-import { classifyCodexHistoryOversized } from '../maker-host/codex-local-sessions.js';
+import {
+  classifyCodexHistoryOversized,
+  reserveCodexForkCleanup,
+} from '../maker-host/codex-local-sessions.js';
 import { hydrateQueuedAgentReferences } from './agentInputReferences.js';
 import { agentHandoffPending } from './agentHandoffPendingSingleton.js';
 import { clearSealedCodexPlanState, readCodexPlanState } from '../localDb/codexPlanState.js';
@@ -15209,7 +15212,17 @@ export function registerMakerIpc(maker: Maker, options: RegisterMakerIpcOptions)
                     stripEncryptedReasoning: true,
                     remoteHostId: null,
                   });
-                  return { newSdkSessionId: forked.newSdkSessionId };
+                  if (forked.newSdkSessionId === sourceSdkSessionId) {
+                    throwIpcError('INTERNAL', 'Codex fork returned an invalid replacement thread');
+                  }
+                  const cleanup = reserveCodexForkCleanup(
+                    forked.newSdkSessionId,
+                    sourceSdkSessionId,
+                  );
+                  return {
+                    newSdkSessionId: forked.newSdkSessionId,
+                    ...(cleanup ? { cleanup } : {}),
+                  };
                 },
                 commit: async ({ sessionId: targetSessionId, source, newSdkSessionId, target }) => {
                   if (

--- a/apps/desktop/src/main/maker-ipc/runtimeSetModel.ts
+++ b/apps/desktop/src/main/maker-ipc/runtimeSetModel.ts
@@ -92,14 +92,21 @@ export interface ApplyRuntimeSetModelChangeInput {
    * 是否跨「远端压缩身份」边界;不传时该判定按未知保守处理(倾向关会话重建)。
    */
   codexAuthInjection?: CodexProxyAuthInjection | null;
+  /**
+   * The host has proved that this local Codex selection crosses the explicit XD/OpenAI
+   * credential boundary and has a persisted native thread to rebuild.
+   */
+  requiresCodexThreadRelink?: boolean;
+  /** Closes over the captured Profile DB and atomically commits thread + full target route. */
+  relinkCodexThread?: () => Promise<void>;
   logger?: RuntimeSetModelLogger;
 }
 
 export type ApplyRuntimeSetModelChangeResult =
   /** 直接生效(热切 route / 或已关会话待下次发送重建)。 */
-  | { status: 'applied' }
+  | { status: 'applied'; persistedRoute?: true }
   /** 凭证形态要换但会话自己在跑:已登记 pending,turn 结束后自动生效。 */
-  | { status: 'deferred' };
+  | { status: 'deferred'; persistedRoute?: never };
 
 export function isRemoteModelSwitchRouteChangeError(error: unknown): boolean {
   return (
@@ -159,6 +166,10 @@ export async function applyRuntimeSetModelChange(
         codexAuthInjection: input.codexAuthInjection,
       })
     : false;
+  const requiresCodexThreadRelink = input.requiresCodexThreadRelink === true;
+  if (requiresCodexThreadRelink && !input.relinkCodexThread) {
+    throw new Error(`Codex provider thread relink is required for session ${sessionId}`);
+  }
   let selfBusyMemo: boolean | undefined;
   const isSelfBusy = (): boolean => {
     if (selfBusyMemo !== undefined) return selfBusyMemo;
@@ -170,6 +181,20 @@ export async function applyRuntimeSetModelChange(
       : isSessionInTurn?.(sessionId) === true;
     return selfBusyMemo;
   };
+
+  if (requiresCodexThreadRelink && isSelfBusy()) {
+    throw new CredentialModeSwitchBusyError(
+      [sessionId],
+      `Cannot rebuild Codex provider thread while the session is busy: ${sessionId}`,
+    );
+  }
+
+  if (!sess && requiresCodexThreadRelink) {
+    await input.relinkCodexThread?.();
+    if (providerId !== undefined) setSessionProvider(sessionId, nextProviderId);
+    input.wakeSessionInputQueue?.(sessionId);
+    return { status: 'applied', persistedRoute: true };
+  }
 
   if (
     sess?.agentKind === 'codex' &&
@@ -203,7 +228,7 @@ export async function applyRuntimeSetModelChange(
     );
   }
 
-  if (sess && shouldCloseSession) {
+  if (sess && (shouldCloseSession || requiresCodexThreadRelink)) {
     if (isSelfBusy() && input.registerPendingCredentialSwitch) {
       await input.registerPendingCredentialSwitch(sessionId, {
         model,
@@ -237,7 +262,11 @@ export async function applyRuntimeSetModelChange(
     } catch (err) {
       // 空闲判定与 close 之间的竞态(恰好起了新 turn):有 pending 通道就转延迟,
       // 没有(老调用方)保持抛 busy 的旧语义。
-      if (isCredentialModeSwitchBusyError(err) && input.registerPendingCredentialSwitch) {
+      if (
+        !requiresCodexThreadRelink &&
+        isCredentialModeSwitchBusyError(err) &&
+        input.registerPendingCredentialSwitch
+      ) {
         input.registerPendingCredentialSwitch(sessionId, {
           model,
           providerId: nextProviderId,
@@ -254,6 +283,9 @@ export async function applyRuntimeSetModelChange(
       }
       throw err;
     }
+    if (requiresCodexThreadRelink) {
+      await input.relinkCodexThread?.();
+    }
     if (providerId !== undefined) setSessionProvider(sessionId, nextProviderId);
     // close + route 都落定后再唤醒队列:排队消息按新凭证形态 lazy-create 派发。
     input.wakeSessionInputQueue?.(sessionId);
@@ -265,7 +297,9 @@ export async function applyRuntimeSetModelChange(
       fromModel: sess.model,
       toModel: model,
     });
-    return { status: 'applied' };
+    return requiresCodexThreadRelink
+      ? { status: 'applied', persistedRoute: true }
+      : { status: 'applied' };
   }
 
   if (providerId !== undefined) {


### PR DESCRIPTION
## 这次改了什么

### 摘要

重新实现本地 Codex 任务在 XD 与 OpenAI 包月之间切换时的 thread 安全重建，替代已关闭且范围失控的 #3543。fork 始终使用源 thread 的凭证身份；新 `sdk_session_id` 与目标 model/provider/effort/fast 在同一条 SQLite CAS 中提交。任务忙碌或提交条件变化时直接失败，不建立 deferred/pending 状态机。

### 变更类型

- [ ] `feat` 新功能
- [x] `fix` 缺陷修复
- [ ] `refactor` / `perf` 重构或性能优化
- [ ] `docs` / `test` / `chore` 文档、测试或工程维护
- [ ] 其他：

### 范围

- 关联 Issue / 需求：替代已关闭的 #3543
- 本 PR 包含：本地 Codex、用户主动选择、已有持久 thread、仅 XD ↔ OpenAI 包月两个方向；源身份 fork、完整路由原子 CAS、忙碌/竞态 fail-closed。
- 明确不包含：Device Link、IM `model:pick`、agent/fallback/scheduler、远程 host、其它 provider/agent、授权与模型目录、Windows 启动屏障、通用 pending 恢复状态机。
- 用户可见变化：空闲本地 Codex 任务跨上述两类凭证切换时会创建兼容的新 thread；忙碌时明确失败并要求稍后重试，不会后台延迟切换。
- 是否存在 breaking change：无。

### UI 变化

- 引用的设计规范：不涉及；纯 main-process 逻辑与单测，无视觉、交互或文案变化。

## 怎么验证的

### 自动验证

```text
pnpm --filter desktop exec vitest run src/main/maker-ipc/__tests__/codexProviderThreadRelink.test.ts src/main/maker-ipc/__tests__/runtimeSetModelCodexRelink.test.ts src/main/maker-ipc/__tests__/runtimeSetModel.test.ts
结果：3 files / 36 tests passed

pnpm --filter desktop run --if-present typecheck
结果：通过

pnpm check:dco
结果：1 commit signed off

pnpm test:unit:related
结果：Desktop、Mobile 及其余已执行 workspace 通过；总命令被未改动的 packages/maker-core 两条 Pi 集成测试拦截（xAI baseline 60s 超时；BYOM 临时配置目录期望 1 个但发现 2 个）。精确重跑同一未改动测试文件仍复现，本 PR 未修改 maker-core。
```

### 手工验证

不涉及；未启动 Desktop DEV。

### 未执行的验证

未做实机切换；遵守本仓禁止未经明确授权启动 Desktop DEV 的约束。完整 CI 交由 PR 门禁执行。

## 风险

### 风险分类

- [ ] 无已知风险
- [x] SQLite / migration
- [ ] system prompt
- [ ] 协议兼容
- [ ] 权限 / 安全 / 用户数据
- [ ] 存量插件兼容（批准状态 / 指纹 / manifest 校验 / 安装布局 / 包格式）
- [ ] 原生层 / fingerprint / OTA
- [ ] 跨平台差异
- [ ] 其他：

### 影响与回滚

- 影响范围：仅本地 Codex 的 XD ↔ OpenAI 包月显式切换；复用现有 sessions 表，不新增 schema 或 migration。
- 回滚 / 降级方式：回退本提交即可恢复原有行为；CAS 失败时不会提交目标路由。

### 提交前检查

- [x] 已 review 完整 diff
- [x] 每个 commit 都带 DCO 签名（`git commit -s`，见 [DCO](../DCO)）
- [x] UI 改动已在「UI 变化」注明引用的设计规范章节（不涉及 UI 则跳过）
- [x] 未提交凭证、令牌或授权文件
- [x] 已补充必要文档
- [x] 已确认测试结果或说明未执行原因
