### PR TITLE
fix(desktop): 让 Scheduler 跟随 Session 自动恢复

### DIFF
--- a/apps/desktop/src/main/scheduler-host/__tests__/runnerQueuedDispatch.test.ts
+++ b/apps/desktop/src/main/scheduler-host/__tests__/runnerQueuedDispatch.test.ts
@@ -746,6 +746,46 @@ describe('MakerScheduleRunner queued dispatch (busy bound session)', () => {
     expect(harness.listenerCount()).toBe(0);
   });
 
+  it('cancels recovery and aborts the replacement after an idle coordinator dispatch', async () => {
+    const original = createSessionHarness(async () => ({ accepted: true }));
+    const replacement = createSessionHarness(async () => ({ accepted: true }));
+    const queue = createQueueHarness({
+      busy: false,
+      acceptBeforeEnqueueResolves: true,
+      autoResumePending: () => true,
+    });
+    const { runner, replaceLiveSession } = createRunnerHarness(original.session, queue.deps);
+    const ctx = createFireContext();
+
+    const firePromise = runner.fire(heartbeatSchedule(), ctx);
+    await vi.waitFor(() => expect(original.listenerCount()).toBe(1));
+    expect(queue.enqueueCalls).toHaveLength(1);
+    expect(original.send).not.toHaveBeenCalled();
+    original.emit({
+      type: 'error',
+      data: { message: 'backend unreachable', isTerminal: true },
+      source: 'claude-code',
+    });
+    await Promise.resolve();
+    original.emitStatus('closed');
+    replaceLiveSession(replacement.session);
+    expect(replacement.listenerCount()).toBe(1);
+
+    ctx.abortController.abort();
+
+    await expect(firePromise).rejects.toThrow(/aborted/i);
+    expect(queue.cancelAutoResumeCalls).toEqual([
+      { sessionId: SESSION_ID, runId: 'run-q1' },
+    ]);
+    expect(
+      (replacement.session as unknown as { abort: ReturnType<typeof vi.fn> }).abort,
+    ).toHaveBeenCalledTimes(1);
+    expect(
+      (original.session as unknown as { abort: ReturnType<typeof vi.fn> }).abort,
+    ).not.toHaveBeenCalled();
+    expect(replacement.listenerCount()).toBe(0);
+  });
+
   it('does not let the previous auto-resume claim hide a deterministic error from the resumed turn', async () => {
     let autoResumePending = true;
     const harness = createSessionHarness(async () => ({ accepted: true }));

--- a/apps/desktop/src/main/scheduler-host/__tests__/runnerQueuedDispatch.test.ts
+++ b/apps/desktop/src/main/scheduler-host/__tests__/runnerQueuedDispatch.test.ts
@@ -84,6 +84,8 @@ import {
 import { isHeadlessGhostSetupTurn } from '../../mcp-integrations/ghostSetupInteractionSurface';
 
 type SessionSendOptions = Parameters<Session['send']>[1];
+type SessionStatus = Parameters<Parameters<Session['onStatusChange']>[0]>[0];
+type MakerEventListener = Parameters<Maker['on']>[0];
 type SendImpl = (
   message: Parameters<Session['send']>[0],
   opts?: SessionSendOptions,
@@ -105,11 +107,14 @@ interface FakeSessionHarness {
   setVendorOptions: ReturnType<typeof vi.fn>;
   vendorOptions: Record<string, unknown>;
   emit(event: AgentEvent): void;
+  emitStatus(status: SessionStatus): void;
   listenerCount(): number;
+  statusListenerCount(): number;
 }
 
 function createSessionHarness(sendImpl: SendImpl): FakeSessionHarness {
   const listeners: Array<(event: AgentEvent) => void> = [];
+  const statusListeners: Array<(status: SessionStatus) => void> = [];
   const send = vi.fn<SendImpl>(sendImpl);
   const setModel = vi.fn(
     async (_model: string, _opts?: { providerId?: string | null }) => undefined,
@@ -136,6 +141,13 @@ function createSessionHarness(sendImpl: SendImpl): FakeSessionHarness {
         if (idx >= 0) listeners.splice(idx, 1);
       };
     },
+    onStatusChange(listener: (status: SessionStatus) => void) {
+      statusListeners.push(listener);
+      return () => {
+        const idx = statusListeners.indexOf(listener);
+        if (idx >= 0) statusListeners.splice(idx, 1);
+      };
+    },
     abort: vi.fn(async () => undefined),
     close: vi.fn(async () => undefined),
   } as unknown as Session;
@@ -153,8 +165,14 @@ function createSessionHarness(sendImpl: SendImpl): FakeSessionHarness {
       const emitted = { turnOrigin: SCHEDULER_TURN_ORIGIN, ...event };
       for (const listener of [...listeners]) listener(emitted);
     },
+    emitStatus(status: SessionStatus) {
+      for (const listener of [...statusListeners]) listener(status);
+    },
     listenerCount() {
       return listeners.length;
+    },
+    statusListenerCount() {
+      return statusListeners.length;
     },
   };
 }
@@ -318,9 +336,11 @@ function createRunnerHarness(
   const notifier: Notifier & { notify: ReturnType<typeof vi.fn> } = {
     notify: vi.fn(async () => undefined),
   };
+  let liveSession = session;
+  const makerListeners = new Set<MakerEventListener>();
   const maker = {
-    createSession: vi.fn(async () => session),
-    getSession: vi.fn(() => session),
+    createSession: vi.fn(async () => liveSession),
+    getSession: vi.fn(() => liveSession),
     getSessionMeta: vi.fn(async () => ({
       id: SESSION_ID,
       agentKind: 'claude-code',
@@ -332,6 +352,10 @@ function createRunnerHarness(
     })),
     isSessionAlive: vi.fn(() => true),
     closeSession: vi.fn(async () => undefined),
+    on: vi.fn((listener: MakerEventListener) => {
+      makerListeners.add(listener);
+      return () => makerListeners.delete(listener);
+    }),
     // issue #456:排队派发路径也按所选模型 efforts reconcile effort;测试经 availableModels 注入能力。
     getCapabilities: vi.fn((_agent: string) => ({ availableModels: opts.availableModels ?? [] })),
   } as unknown as Maker;
@@ -343,7 +367,21 @@ function createRunnerHarness(
     schedulerQueue,
     checkModelRoute: opts.checkModelRoute,
   });
-  return { runner, logger, notifier, maker };
+  return {
+    runner,
+    logger,
+    notifier,
+    maker,
+    replaceLiveSession(nextSession: Session) {
+      liveSession = nextSession;
+      for (const listener of [...makerListeners]) {
+        listener({ type: 'session:created', session: nextSession });
+      }
+    },
+    makerListenerCount() {
+      return makerListeners.size;
+    },
+  };
 }
 
 function latestNotifiedRun(notifier: Notifier & { notify: ReturnType<typeof vi.fn> }): ScheduleRun {
@@ -505,6 +543,110 @@ describe('MakerScheduleRunner queued dispatch (busy bound session)', () => {
       resultText: 'continued result',
     });
     expect(harness.vendorOptions[SCHEDULER_RUN_ID_VENDOR_OPTION]).toBeUndefined();
+  });
+
+  it("rebinds the same run to Maker's replacement Session while auto-resume still owns it", async () => {
+    vi.useFakeTimers();
+    try {
+      let autoResumePending = true;
+      const original = createSessionHarness(async () => ({ accepted: true }));
+      const replacement = createSessionHarness(async () => ({ accepted: true }));
+      const queue = createQueueHarness({ busy: true, autoResumePending: () => autoResumePending });
+      const { runner, notifier, replaceLiveSession, makerListenerCount } = createRunnerHarness(
+        original.session,
+        queue.deps,
+      );
+
+      const firePromise = runner.fire(heartbeatSchedule(), createFireContext());
+      const settled = vi.fn();
+      void firePromise.then(
+        () => settled('resolved'),
+        () => settled('rejected'),
+      );
+      await vi.waitFor(() => expect(queue.enqueueCalls.length).toBe(1));
+      await queue.accept();
+
+      original.emit({
+        type: 'error',
+        data: { message: 'backend unreachable', isTerminal: true },
+        source: 'claude-code',
+      });
+      await Promise.resolve();
+      original.emitStatus('closed');
+      await Promise.resolve();
+
+      expect(settled).not.toHaveBeenCalled();
+      expect(original.listenerCount()).toBe(0);
+      expect(original.statusListenerCount()).toBe(0);
+      expect(makerListenerCount()).toBe(1);
+
+      // 真实 auto-resume 的最短退避远大于配对 done 窗口；替代 Session 由 Maker
+      // 用同一业务 id lazy rebuild，runner 只跟随既有生命周期。
+      await vi.advanceTimersByTimeAsync(251);
+      replaceLiveSession(replacement.session);
+      expect(replacement.listenerCount()).toBe(1);
+      expect(replacement.statusListenerCount()).toBe(1);
+
+      autoResumePending = false;
+      replacement.emit({
+        type: 'text',
+        data: { text: 'recovered result', isFinal: true },
+        source: 'claude-code',
+      });
+      replacement.emit({ type: 'done', data: {}, source: 'claude-code' });
+
+      await expect(firePromise).resolves.toMatchObject({
+        sessionId: SESSION_ID,
+        resultText: 'recovered result',
+      });
+      expect(latestNotifiedRun(notifier).status).toBe('success');
+      expect(replacement.listenerCount()).toBe(0);
+      expect(replacement.statusListenerCount()).toBe(0);
+      expect(makerListenerCount()).toBe(0);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it('still fails when the Session closes without an auto-resume claim', async () => {
+    const harness = createSessionHarness(async () => ({ accepted: true }));
+    const queue = createQueueHarness({ busy: true, autoResumePending: () => false });
+    const { runner, makerListenerCount } = createRunnerHarness(harness.session, queue.deps);
+
+    const firePromise = runner.fire(heartbeatSchedule(), createFireContext());
+    await vi.waitFor(() => expect(queue.enqueueCalls.length).toBe(1));
+    await queue.accept();
+    harness.emitStatus('closed');
+
+    await expect(firePromise).rejects.toThrow(
+      'scheduler session ended without a terminal event (closed)',
+    );
+    expect(harness.listenerCount()).toBe(0);
+    expect(harness.statusListenerCount()).toBe(0);
+    expect(makerListenerCount()).toBe(0);
+  });
+
+  it('lets the existing auto-resume failure signal settle a run after its Session closed', async () => {
+    const harness = createSessionHarness(async () => ({ accepted: true }));
+    const queue = createQueueHarness({ busy: true, autoResumePending: () => true });
+    const { runner, makerListenerCount } = createRunnerHarness(harness.session, queue.deps);
+
+    const firePromise = runner.fire(heartbeatSchedule(), createFireContext());
+    await vi.waitFor(() => expect(queue.enqueueCalls.length).toBe(1));
+    await queue.accept();
+    harness.emit({
+      type: 'error',
+      data: { message: 'backend unreachable', isTerminal: true },
+      source: 'claude-code',
+    });
+    await Promise.resolve();
+    harness.emitStatus('closed');
+    queue.failAutoResume();
+
+    await expect(firePromise).rejects.toThrow('scheduled task auto-resume failed');
+    expect(harness.listenerCount()).toBe(0);
+    expect(harness.statusListenerCount()).toBe(0);
+    expect(makerListenerCount()).toBe(0);
   });
 
   it('ignores a delayed done while the same run still owns the auto-resume claim', async () => {

--- a/apps/desktop/src/main/scheduler-host/runner.ts
+++ b/apps/desktop/src/main/scheduler-host/runner.ts
@@ -15,8 +15,8 @@
  *   3. workingDir：useWorktree=true 走 workdir-resolver 建 ephemeral worktree
  *      （绝不手动注册清理，maker-host:116-122 onClose 会自动清）
  *   4. maker.createSession（heartbeat 模式不传 title，让现有 row 标题保留）
- *   5. 一次性 listener：onEvent 收 done/error 任一立刻 unsubscribe
- *      （硬规则：listener 加 session 不加 maker；done/error 后立刻 unsub 防泄漏）
+ *   5. 一次性 turn listener：监听当前 Session 实例；自动恢复重建同一业务 Session 时，
+ *      经 Maker 生命周期事件把 listener 重绑到新实例，done/error 后统一 unsubscribe。
  *   6. session.send（硬规则：send 后**不要**立刻 closeSession，会切断后续事件）
  *   7. 收到 done/error 后组装 ScheduleRun，主动调 notifier.notify
  *      （Phase 1 changelog L1141 方案 A：runner 内部主动 notify，
@@ -2372,17 +2372,10 @@ export class MakerScheduleRunner implements ScheduleRunner {
    * 不再按静默时长猜完成。
    */
   private createTurnCompletionWaiter(
-    session: Pick<Awaited<ReturnType<Maker['createSession']>>, 'id' | 'onEvent'> & {
-      beginTurnContinuationWait?: (continuationId?: number) => TurnContinuationState | null;
-      onTurnContinuationChange?: (
-        listener: (continuationId: number, state: TurnContinuationState) => void,
-      ) => () => void;
-      onStatusChange?: (
-        listener: (status: 'active' | 'aborting' | 'closed' | 'error') => void,
-      ) => () => void;
-    },
+    initialSession: Session,
     options: TurnCompletionWaiterOptions,
   ): TurnCompletionWaiter {
+    const sessionId = initialSession.id;
     let assistantText = '';
     let stopped = false;
     let stopListeningTurn: (() => void) | undefined;
@@ -2392,8 +2385,10 @@ export class MakerScheduleRunner implements ScheduleRunner {
       let pendingSettleUnsub: (() => void) | undefined;
       let pendingContinuationUnsub: (() => void) | undefined;
       let autoResumeFailureUnsub: (() => void) | undefined;
+      let makerLifecycleUnsub: (() => void) | undefined;
       let off: () => void = () => undefined;
       let offStatus: () => void = () => undefined;
+      let currentSession: Session | null = null;
       let settled = false;
       const clearInterruptedDoneTimer = (): void => {
         if (interruptedDoneTimer) {
@@ -2403,19 +2398,27 @@ export class MakerScheduleRunner implements ScheduleRunner {
       };
       const isCurrentAutoResumePending = (): boolean =>
         this.deps.schedulerQueue?.isAutoResumePending?.(
-          session.id,
+          sessionId,
           options.origin.runId,
         ) === true;
+      const clearSessionListeners = (): void => {
+        pendingContinuationUnsub?.();
+        pendingContinuationUnsub = undefined;
+        off();
+        off = () => undefined;
+        offStatus();
+        offStatus = () => undefined;
+        currentSession = null;
+      };
       const cleanup = (): void => {
         clearInterruptedDoneTimer();
         pendingSettleUnsub?.();
         pendingSettleUnsub = undefined;
-        pendingContinuationUnsub?.();
-        pendingContinuationUnsub = undefined;
         autoResumeFailureUnsub?.();
         autoResumeFailureUnsub = undefined;
-        off();
-        offStatus();
+        makerLifecycleUnsub?.();
+        makerLifecycleUnsub = undefined;
+        clearSessionListeners();
         stopListeningTurn = undefined;
       };
       const finish = (): void => {
@@ -2430,11 +2433,29 @@ export class MakerScheduleRunner implements ScheduleRunner {
         cleanup();
         reject(err);
       };
-      offStatus = session.onStatusChange?.((status) => {
+
+      const onSessionStatus = (
+        owner: Session,
+        status: 'active' | 'aborting' | 'closed' | 'error',
+      ): void => {
+        if (owner !== currentSession) return;
         if (status !== 'closed' && status !== 'error') return;
+        if (isCurrentAutoResumePending()) {
+          // AutoResumeBookkeeping owns the retry decision. A dead provider instance is
+          // therefore not the logical run terminal: detach from it and wait for Maker's
+          // existing same-id lazy rebuild. No second recovery state or timer lives here.
+          clearSessionListeners();
+          this.deps.logger.info?.(
+            '[runner] scheduler session instance ended during auto-resume; waiting for replacement',
+            { sessionId, runId: options.origin.runId, status },
+          );
+          return;
+        }
         fail(new Error(`scheduler session ended without a terminal event (${status})`));
-      }) ?? (() => undefined);
-      off = session.onEvent((ev: AgentEvent) => {
+      };
+
+      const onSessionEvent = (owner: Session, ev: AgentEvent): void => {
+        if (owner !== currentSession) return;
         // 一个绑定会话可能在自动续跑退避期间被用户接管。waiter 只消费本 run
         // 的 scheduler turn（初始派发与 autoResume 都保留同一 origin）；其它 run、
         // 手动消息与 /compact 的事件既不能刷新本 run 的存活时间，也不能改写结果。
@@ -2484,7 +2505,7 @@ export class MakerScheduleRunner implements ScheduleRunner {
           const continuationId = ev.turnContinuationId;
           const continuationState = continuationId === undefined
             ? null
-            : session.beginTurnContinuationWait?.(continuationId) ?? null;
+            : owner.beginTurnContinuationWait?.(continuationId) ?? null;
           if (continuationState === 'cancelled') {
             // Provider already observed an explicit stop/teardown. Session
             // gets a separate ordered boundary; this run can settle now.
@@ -2495,7 +2516,7 @@ export class MakerScheduleRunner implements ScheduleRunner {
             // 当前 SDK turn 已结束，但 provider 确认 wake 任务会自动续开下一
             // turn —— 不定格，等待续 turn 自己的 done。
             pendingContinuationUnsub?.();
-            pendingContinuationUnsub = session.onTurnContinuationChange?.(
+            pendingContinuationUnsub = owner.onTurnContinuationChange?.(
               (changedContinuationId, state) => {
                 if (
                   state !== 'cancelled' ||
@@ -2510,17 +2531,17 @@ export class MakerScheduleRunner implements ScheduleRunner {
             );
             this.deps.logger.info?.(
               '[runner] turn done with pending provider continuation; deferring run finalization',
-              { sessionId: session.id },
+              { sessionId },
             );
             return;
           }
           if (isSilentStopDone) {
             this.deps.logger.info?.(
               '[runner] silent-stop done deferred; waiting for auto-resume or settled',
-              { sessionId: session.id },
+              { sessionId },
             );
             pendingSettleUnsub?.();
-            pendingSettleUnsub = onSilentStopSettled(session.id, (_sid, reason) => {
+            pendingSettleUnsub = onSilentStopSettled(sessionId, (_sid, reason) => {
               pendingSettleUnsub?.();
               pendingSettleUnsub = undefined;
               if (reason === 'exhausted') {
@@ -2549,9 +2570,34 @@ export class MakerScheduleRunner implements ScheduleRunner {
             if (!claimed) fail(new Error(error));
           });
         }
-      });
+      };
+
+      const bindSession = (nextSession: Session): void => {
+        if (settled || nextSession.id !== sessionId || currentSession === nextSession) return;
+        clearSessionListeners();
+        currentSession = nextSession;
+        offStatus =
+          nextSession.onStatusChange?.((status) => onSessionStatus(nextSession, status)) ??
+          (() => undefined);
+        off = nextSession.onEvent((event) => onSessionEvent(nextSession, event));
+      };
+
+      // Maker is already the source of truth for same-business-id Session replacement.
+      // Subscribe before the turn can fail so a fast lazy rebuild cannot be missed.
+      makerLifecycleUnsub =
+        this.deps.maker.on?.((event) => {
+          if (
+            event.type !== 'session:created' ||
+            event.session.id !== sessionId ||
+            !isCurrentAutoResumePending()
+          ) {
+            return;
+          }
+          bindSession(event.session);
+        }) ?? (() => undefined);
+      bindSession(initialSession);
       autoResumeFailureUnsub = this.deps.schedulerQueue?.onAutoResumeFailed?.(
-        session.id,
+        sessionId,
         options.origin.runId,
         () => fail(new Error('scheduled task auto-resume failed')),
       );


### PR DESCRIPTION
## 这次改了什么

### 摘要

让 Scheduler run 跟随现有 Session 自动恢复生命周期：当 auto-resume 已接管中断时，旧 Session 实例关闭不再提前把 run 判失败；Maker 以同一业务 Session ID 重建实例后，runner 会重绑监听并继续等待真实终态。

本次没有新增“恢复中”状态、重试器或持久化机制，恢复是否继续仍完全由现有 auto-resume claim 与失败信号决定。

### 变更类型

- [ ] `feat` 新功能
- [x] `fix` 缺陷修复
- [ ] `refactor` / `perf` 重构或性能优化
- [ ] `docs` / `test` / `chore` 文档、测试或工程维护
- [ ] 其他：

### 范围

- 关联 Issue / 需求：Scheduler 与 Session 自动恢复生命周期一致性
- 本 PR 包含：同 ID Session 重建时的 waiter 重绑；无恢复声明和恢复最终失败的收口回归测试
- 明确不包含：新增恢复状态机、修改 auto-resume 策略、修改 Mobile 或远端协议
- 用户可见变化：自动重连期间，定时任务不会因旧 Session 实例关闭而被提前显示为失败
- 是否存在 breaking change：无

### UI 变化

- 引用的设计规范：不涉及

## 怎么验证的

### 自动验证

```text
pnpm test:unit:related
结果：通过（apps/desktop related tests）

pnpm --filter desktop run --if-present typecheck
结果：通过

pnpm --filter desktop exec vitest run src/main/scheduler-host/__tests__
结果：358 passed，1 skipped

pnpm --filter desktop exec vitest run src/main/scheduler-host/__tests__/runnerQueuedDispatch.test.ts
结果：49 passed

bash /Users/dash/Code/XD/dash/Skills/git/scripts/run-unit-gate.sh <worktree>
结果：PR 无关的主干 Mobile 基线测试 startupSplashOverlay.test.ts 连续两次在 5 秒处超时；其余 3970 tests passed。本 PR 相对 origin/main 没有 apps/mobile 改动，交由 CI 在干净环境复核。
```

### 手工验证

不涉及；生命周期乱序由回归测试模拟。

### 未执行的验证

未连接真实 provider 制造断网；现有 Session close、Maker replacement、auto-resume success/failure 信号均已在单测覆盖。

## 风险

### 风险分类

- [ ] 无已知风险
- [ ] SQLite / migration
- [ ] system prompt
- [ ] 协议兼容
- [ ] 权限 / 安全 / 用户数据
- [ ] 存量插件兼容（批准状态 / 指纹 / manifest 校验 / 安装布局 / 包格式）
- [ ] 原生层 / fingerprint / OTA
- [ ] 跨平台差异
- [x] 其他：异步 Session 生命周期收口

### 影响与回滚

- 影响范围：Desktop Scheduler 绑定 Session 的 run 完成监听；只在同一 schedule run 的既有 auto-resume claim 有效时跨 Session 实例继续等待
- 回滚 / 降级方式：回退本提交即可恢复旧的“Session 实例关闭即失败”行为；不涉及数据迁移或持久状态

### 提交前检查

- [x] 已 review 完整 diff
- [x] 每个 commit 都带 DCO 签名（`git commit -s`，见 [DCO](../DCO)）
- [x] UI 改动已在「UI 变化」注明引用的设计规范（不涉及 UI 则跳过）
- [x] 未提交凭证、令牌或授权文件
- [x] 已补充必要文档
- [x] 已确认测试结果或说明未执行原因
