### PR TITLE
fix(desktop): 终态错误横幅只弹一次，首次即可重试

### DIFF
--- a/apps/desktop/src/main/__tests__/makerEventHotPathOrdering.test.ts
+++ b/apps/desktop/src/main/__tests__/makerEventHotPathOrdering.test.ts
@@ -487,6 +487,28 @@ describe('maker:event hot path ordering', () => {
     );
   });
 
+  it('reserves terminal error persistId before EVENT broadcast and writes after', () => {
+    const wireSessionSource = extractWireSessionSource();
+    expectOrder(
+      wireSessionSource,
+      'persistId = reserveTurnErrorPersistId(',
+      'broadcastToAllWindows(MAKER_PUSH.EVENT',
+    );
+    expectOrder(
+      wireSessionSource,
+      'broadcastToAllWindows(MAKER_PUSH.EVENT',
+      'onTurnErrorEvent(',
+    );
+    expect(wireSessionSource).toContain('const autoResumeWouldSuppressPersist');
+    const persistBoundaryStart = wireSessionSource.indexOf(
+      'let turnAssistantPersistId: string | undefined;',
+    );
+    expect(persistBoundaryStart).toBeGreaterThanOrEqual(0);
+    expect(
+      wireSessionSource.indexOf('const autoResumeSuppressesPersist', persistBoundaryStart),
+    ).toBeGreaterThan(persistBoundaryStart);
+  });
+
   it('rejects stale Agent Island interactions before renderer delivery', () => {
     const interactionListenerSource = extractInstallDesktopInteractionListenerSource();
     const epochCaptureIndex = interactionListenerSource.indexOf(

--- a/apps/desktop/src/main/__tests__/makerEventHotPathOrdering.test.ts
+++ b/apps/desktop/src/main/__tests__/makerEventHotPathOrdering.test.ts
@@ -311,10 +311,16 @@ describe('maker:event hot path ordering', () => {
     expect(wireSessionSource).toContain('isRemoteAuthRetry = isRemoteAuthRetryErrorEvent(session, event);');
     expect(deferredHandler).toBeTruthy();
     expect(deferredHandler).toContain('getAgentIslandService()?.resolveDeferredRemoteAuthRetryError(sid);');
+    expect(deferredHandler).toContain('return persistId;');
     expectOrder(
       deferredHandler ?? '',
       'onTurnErrorEvent(sid, errData, agentMeta);',
       'getAgentIslandService()?.resolveDeferredRemoteAuthRetryError(sid);',
+    );
+    expectOrder(
+      deferredHandler ?? '',
+      'getAgentIslandService()?.resolveDeferredRemoteAuthRetryError(sid);',
+      'return persistId;',
     );
   });
 

--- a/apps/desktop/src/main/__tests__/messagePersistBroadcaster.test.ts
+++ b/apps/desktop/src/main/__tests__/messagePersistBroadcaster.test.ts
@@ -90,6 +90,9 @@ import {
   flushOrphanToolResults,
   isSuccessfulCodexDoneEventData,
   onTurnErrorEvent,
+  reserveTurnErrorPersistId,
+  releaseReservedTurnErrorPersistId,
+  whenTurnErrorPersisted,
   resetTurnPersistState,
   clearCodexPlanRowsForSession,
   clearSessionPersistState,
@@ -2397,7 +2400,7 @@ describe('onTurnErrorEvent — terminal error 持久化', () => {
     // 脏信号必须发:让已加载历史的后台会话下次打开时从 DB 重拉,error 卡正常浮现。
     expect(mockSend).toHaveBeenCalledWith(
       'local-db:session:error-persisted',
-      { sessionId: SESSION },
+      { sessionId: SESSION, persistId },
       undefined,
     );
   });
@@ -2736,6 +2739,77 @@ describe('onTurnErrorEvent — terminal error 持久化', () => {
     // turnStartedAt (1000) <= clearBoundary (2000) → cap 生效
     // createdAt 必须 <= clearBoundaryTs，error 卡不出现在清空后的新会话
     expect(createdAt).toBeLessThanOrEqual(clearBoundaryTs);
+  });
+});
+
+describe('reserveTurnErrorPersistId — 广播前预留与 waiter', () => {
+  it('预留 id 不写库,onTurnErrorEvent 复用同一 id', async () => {
+    const reserved = reserveTurnErrorPersistId(SESSION, { message: 'boom' });
+    expect(reserved).toBeTruthy();
+    expect(createMessage).not.toHaveBeenCalled();
+
+    const persistId = onTurnErrorEvent(SESSION, { message: 'boom' }, null, reserved);
+    expect(persistId).toBe(reserved);
+
+    await flushWrites();
+    expect(createMessage).toHaveBeenCalledTimes(1);
+    expect(vi.mocked(createMessage).mock.calls[0][1]).toMatchObject({ clientId: reserved });
+    expect(mockSend).toHaveBeenCalledWith(
+      'local-db:session:error-persisted',
+      { sessionId: SESSION, persistId: reserved },
+      undefined,
+    );
+  });
+
+  it('whenTurnErrorPersisted 等到写库完成才返回', async () => {
+    const reserved = reserveTurnErrorPersistId(SESSION, { message: 'wait-me' });
+    expect(reserved).toBeTruthy();
+    let done = false;
+    const waiting = whenTurnErrorPersisted(SESSION, reserved!).then(() => {
+      done = true;
+    });
+    expect(done).toBe(false);
+
+    onTurnErrorEvent(SESSION, { message: 'wait-me' }, null, reserved);
+    expect(done).toBe(false);
+
+    await flushWrites();
+    await waiting;
+    expect(done).toBe(true);
+  });
+
+  it('未知 persistId 的 whenTurnErrorPersisted 立即返回', async () => {
+    await expect(whenTurnErrorPersisted(SESSION, 'never-reserved')).resolves.toBeUndefined();
+  });
+
+  it('release 解开 waiter 且同一 id 不再写库', async () => {
+    const reserved = reserveTurnErrorPersistId(SESSION, { message: 'skip' });
+    expect(reserved).toBeTruthy();
+    const waiting = whenTurnErrorPersisted(SESSION, reserved!);
+    releaseReservedTurnErrorPersistId(SESSION, reserved!);
+    await waiting;
+    expect(createMessage).not.toHaveBeenCalled();
+
+    expect(onTurnErrorEvent(SESSION, { message: 'skip' }, null, reserved)).toBe(reserved);
+    await flushWrites();
+    expect(createMessage).not.toHaveBeenCalled();
+  });
+
+  it('同一预留 id 二次 onTurnErrorEvent 不双写', async () => {
+    const reserved = reserveTurnErrorPersistId(SESSION, { message: 'once' });
+    onTurnErrorEvent(SESSION, { message: 'once' }, null, reserved);
+    onTurnErrorEvent(SESSION, { message: 'once' }, null, reserved);
+    await flushWrites();
+    expect(createMessage).toHaveBeenCalledTimes(1);
+  });
+
+  it('owner-scope 跳过写入时仍解开 waiter', async () => {
+    const reserved = reserveTurnErrorPersistId(SESSION, { message: 'skip-owner' });
+    expect(reserved).toBeTruthy();
+    ownerScopeState.current = false;
+    onTurnErrorEvent(SESSION, { message: 'skip-owner' }, null, reserved);
+    await whenTurnErrorPersisted(SESSION, reserved!);
+    expect(createMessage).not.toHaveBeenCalled();
   });
 });
 

--- a/apps/desktop/src/main/__tests__/messagePersistBroadcaster.test.ts
+++ b/apps/desktop/src/main/__tests__/messagePersistBroadcaster.test.ts
@@ -2831,6 +2831,48 @@ describe('reserveTurnErrorPersistId — 广播前预留与 waiter', () => {
     await whenTurnErrorPersisted(SESSION, reserved!);
     expect(createMessage).not.toHaveBeenCalled();
   });
+
+  it('会话清理不提前兑现已入队的 waiter，写完才 done', async () => {
+    const persistId = onTurnErrorEvent(SESSION, { message: 'queued-then-clear' });
+    expect(persistId).toBeTruthy();
+    let done = false;
+    const waiting = whenTurnErrorPersisted(SESSION, persistId!).then(() => {
+      done = true;
+    });
+    expect(done).toBe(false);
+
+    clearSessionPersistState(SESSION);
+    await Promise.resolve();
+    expect(done).toBe(false);
+    expect(createMessage).not.toHaveBeenCalled();
+
+    await flushWrites();
+    await waiting;
+    expect(done).toBe(true);
+    expect(createMessage).toHaveBeenCalledTimes(1);
+    expect(vi.mocked(createMessage).mock.calls[0][1]).toMatchObject({ clientId: persistId });
+  });
+
+  it('尚未入队的预留在会话清理后解开且不再写', async () => {
+    const reserved = reserveTurnErrorPersistId(SESSION, { message: 'reserved-then-clear' });
+    expect(reserved).toBeTruthy();
+    let done = false;
+    const waiting = whenTurnErrorPersisted(SESSION, reserved!).then(() => {
+      done = true;
+    });
+    expect(done).toBe(false);
+
+    clearSessionPersistState(SESSION);
+    await waiting;
+    expect(done).toBe(true);
+    expect(createMessage).not.toHaveBeenCalled();
+
+    expect(onTurnErrorEvent(SESSION, { message: 'reserved-then-clear' }, null, reserved)).toBe(
+      reserved,
+    );
+    await flushWrites();
+    expect(createMessage).not.toHaveBeenCalled();
+  });
 });
 
 describe('媒体 echo 兜底:flushOrphanToolResults 从 fallback 池认领', () => {

--- a/apps/desktop/src/main/__tests__/messagePersistBroadcaster.test.ts
+++ b/apps/desktop/src/main/__tests__/messagePersistBroadcaster.test.ts
@@ -2782,6 +2782,26 @@ describe('reserveTurnErrorPersistId — 广播前预留与 waiter', () => {
     await expect(whenTurnErrorPersisted(SESSION, 'never-reserved')).resolves.toBeUndefined();
   });
 
+  it('whenTurnErrorPersisted 在预留写入完成前不会因墙钟超时提前返回', async () => {
+    vi.useFakeTimers();
+    try {
+      const reserved = reserveTurnErrorPersistId(SESSION, { message: 'slow-write' });
+      expect(reserved).toBeTruthy();
+      let done = false;
+      const waiting = whenTurnErrorPersisted(SESSION, reserved!).then(() => {
+        done = true;
+      });
+      await vi.advanceTimersByTimeAsync(10_000);
+      expect(done).toBe(false);
+
+      releaseReservedTurnErrorPersistId(SESSION, reserved!);
+      await waiting;
+      expect(done).toBe(true);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
   it('release 解开 waiter 且同一 id 不再写库', async () => {
     const reserved = reserveTurnErrorPersistId(SESSION, { message: 'skip' });
     expect(reserved).toBeTruthy();

--- a/apps/desktop/src/main/__tests__/messagePersistBroadcaster.test.ts
+++ b/apps/desktop/src/main/__tests__/messagePersistBroadcaster.test.ts
@@ -2497,8 +2497,8 @@ describe('onTurnErrorEvent — terminal error 持久化', () => {
     const id3 = onTurnErrorEvent(SESSION, { message: msg });
 
     expect(id1).toBeTruthy();
-    expect(id2).toBeUndefined(); // dedup 命中（同步调用 < 300ms）
-    expect(id3).toBeUndefined(); // dedup 命中（同步调用 < 300ms）
+    expect(id2).toBe(id1); // 输家也要拿到同一 persistId,关闭/重试才能 dismiss
+    expect(id3).toBe(id1);
 
     await flushWrites();
     expect(createMessage).toHaveBeenCalledTimes(1); // 只落一条
@@ -2547,7 +2547,7 @@ describe('onTurnErrorEvent — terminal error 持久化', () => {
     const id2 = onTurnErrorEvent(SESSION, { message: msg }, meta);
 
     expect(id1).toBeTruthy();
-    expect(id2).toBeUndefined(); // 同 requestId → dedup 命中
+    expect(id2).toBe(id1); // 同 requestId → dedup 命中,输家复用赢家 persistId
 
     await flushWrites();
     expect(createMessage).toHaveBeenCalledTimes(1);
@@ -2567,7 +2567,7 @@ describe('onTurnErrorEvent — terminal error 持久化', () => {
     secondSpy.mockRestore();
 
     expect(id1).toBeTruthy();
-    expect(id2).toBeUndefined();
+    expect(id2).toBe(id1);
 
     await flushWrites();
     expect(createMessage).toHaveBeenCalledTimes(1);
@@ -2830,6 +2830,26 @@ describe('reserveTurnErrorPersistId — 广播前预留与 waiter', () => {
     onTurnErrorEvent(SESSION, { message: 'skip-owner' }, null, reserved);
     await whenTurnErrorPersisted(SESSION, reserved!);
     expect(createMessage).not.toHaveBeenCalled();
+  });
+
+  it('多窗 dedup 输家返回同一 persistId，dismiss 等到同一写入', async () => {
+    const id1 = onTurnErrorEvent(SESSION, { message: 'dup-window-auth' });
+    const id2 = onTurnErrorEvent(SESSION, { message: 'dup-window-auth' });
+    expect(id1).toBeTruthy();
+    expect(id2).toBe(id1);
+
+    let done = false;
+    const waiting = whenTurnErrorPersisted(SESSION, id2!).then(() => {
+      done = true;
+    });
+    expect(done).toBe(false);
+    expect(createMessage).not.toHaveBeenCalled();
+
+    await flushWrites();
+    await waiting;
+    expect(done).toBe(true);
+    expect(createMessage).toHaveBeenCalledTimes(1);
+    expect(vi.mocked(createMessage).mock.calls[0][1]).toMatchObject({ clientId: id1 });
   });
 
   it('会话清理不提前兑现已入队的 waiter，写完才 done', async () => {

--- a/apps/desktop/src/main/localDb/ipc/messages.ts
+++ b/apps/desktop/src/main/localDb/ipc/messages.ts
@@ -621,6 +621,10 @@ export function registerMessageIpc(): void {
     async (_e, sessionId: unknown, clientId: unknown) => {
       const sid = requireString(sessionId, 'sessionId');
       const cid = requireString(clientId, 'clientId');
+      // 动态 import:messagePersistBroadcaster 已静态依赖本模块 createMessage,
+      // 静态反向 import 会成环。落库前点关闭/重试时先等同一 persistId 写完。
+      const { whenTurnErrorPersisted } = await import('../../messagePersistBroadcaster.js');
+      await whenTurnErrorPersisted(sid, cid);
       const msg = await dismissErrorMessage(sid, cid);
       if (!msg) throwIpcError('NOT_FOUND', 'Error message 不存在');
       return msg;

--- a/apps/desktop/src/main/maker-ipc/register.ts
+++ b/apps/desktop/src/main/maker-ipc/register.ts
@@ -458,6 +458,8 @@ import {
   sealAssistantBlockForLateFinal,
   markAutoResumeOutcome,
   onTurnErrorEvent,
+  releaseReservedTurnErrorPersistId,
+  reserveTurnErrorPersistId,
   prepareSyntheticToolEventForBroadcast,
   resetTurnPersistState,
   saveTurnStartedAtForDeferred,
@@ -4317,8 +4319,8 @@ export function wireSessionToIpc(session: ReturnType<Maker['getSession']>): void
       // F1-a Phase 2: assistant 文本持久化收口 main 单点(根除多窗各落一份的重复)。
       // 在 onEvent 同步路径只做 O(1):为在飞 assistant 分配 / 复用 persistId、累积全文,
       // 把 persistId 盖进广播 payload 让 renderer 在途气泡用同一 id;真正落库走模块内
-      // 异步队列、不在此同步执行(规则19 热路径)。其它消息类型的 persistId 暂为
-      // undefined,renderer 继续走原逻辑(后续 Phase 收口 tool_use / tool_result 等)。
+      // 异步队列、不在此同步执行(规则19 热路径)。终止型 error 同样在广播前预留 persistId
+      // (O(1) createId,不 flush、不写库),让 live 横幅与事后 error 行绑定同一 id。
       const eventAgentMeta = (event as { agentMeta?: AgentMeta | null }).agentMeta ?? null;
       // 跟踪会话最近一次非空 agentMeta(镜像 renderer state.lastAgentMeta),给 interaction
       // 边界 flush 当兜底锚点,保 agent_meta 不丢(rewind/fork)。
@@ -4451,12 +4453,38 @@ export function wireSessionToIpc(session: ReturnType<Maker['getSession']>): void
         !isContinuationBoundary && (event.type === 'done' || isTerminalTurnErrorEvent(event))
           ? orcaTeamServiceForEvents?.captureWorkerTerminalTurn(session.id)
           : undefined;
+      // 与下方 autoResumeSuppressesPersist 同判据,但必须在广播前就算出来:
+      // 热路径测试以 `const autoResumeSuppressesPersist` 为 flush 边界,不能把那条
+      // const 提前。预留 persistId 只看这份,真正写库仍走广播后的那份。
+      const autoResumeWouldSuppressPersist =
+        event.type === 'error' &&
+        (agentInputCoordinatorHolder?.isAutoResumePending(session.id) === true ||
+          agentInputCoordinatorHolder?.isAutoResumeDeferred(session.id) === true);
       const suppressOverflowBroadcast =
         !session.remoteHostId &&
         event.type === 'error' &&
         isTerminalTurnErrorEvent(event) &&
         (isContextOverflowErrorData(event.data) ||
           isOversizedHistoryErrorData(event.data));
+      if (
+        event.type === 'error' &&
+        isTerminalTurnErrorEvent(event) &&
+        !isPlannedUpgradeClose &&
+        !isRemoteAuthRetry &&
+        !isGatewayProxyTokenRecovery &&
+        !autoResumeWouldSuppressPersist &&
+        !suppressOverflowBroadcast
+      ) {
+        persistId = reserveTurnErrorPersistId(
+          session.id,
+          attributedEvent.data as {
+            message?: unknown;
+            reason?: unknown;
+            sdkError?: unknown;
+          } | null,
+          eventAgentMeta,
+        );
+      }
       if (suppressOverflowBroadcast) {
         overflowSuppressedBroadcasts.set(session.id, {
           sessionId: session.id,
@@ -4595,20 +4623,30 @@ export function wireSessionToIpc(session: ReturnType<Maker['getSession']>): void
         if (overflowClaim === 'claimed') {
           const overflowErrorData = attributedEvent.data;
           const surfaceOverflowFailure = (): void => {
+            const overflowErrorPayload = overflowErrorData as {
+              message?: unknown;
+              reason?: unknown;
+              sdkError?: unknown;
+            } | null;
+            const overflowPersistId = reserveTurnErrorPersistId(
+              session.id,
+              overflowErrorPayload,
+              eventAgentMeta,
+            );
             const stashed = overflowSuppressedBroadcasts.get(session.id);
             overflowSuppressedBroadcasts.delete(session.id);
             if (stashed) {
-              broadcastToAllWindows(MAKER_PUSH.EVENT, stashed);
+              broadcastToAllWindows(MAKER_PUSH.EVENT, {
+                ...stashed,
+                persistId: overflowPersistId ?? stashed.persistId,
+              });
               handleAgentIslandEventAfterBroadcast(session, stashed.event);
             }
             onTurnErrorEvent(
               session.id,
-              overflowErrorData as {
-                message?: unknown;
-                reason?: unknown;
-                sdkError?: unknown;
-              } | null,
+              overflowErrorPayload,
               eventAgentMeta,
+              overflowPersistId,
             );
           };
           void contextOverflowRolloverHolder
@@ -4629,6 +4667,7 @@ export function wireSessionToIpc(session: ReturnType<Maker['getSession']>): void
             });
         } else if (overflowClaim === 'in-flight') {
           // 同一 turn 的重复终态 error：继续压住，避免污染历史。
+          if (persistId) releaseReservedTurnErrorPersistId(session.id, persistId);
         } else if (
           event.type === 'error' &&
           !isPlannedUpgradeClose &&
@@ -4644,7 +4683,10 @@ export function wireSessionToIpc(session: ReturnType<Maker['getSession']>): void
               sdkError?: unknown;
             } | null,
             eventAgentMeta,
+            persistId,
           );
+        } else if (persistId) {
+          releaseReservedTurnErrorPersistId(session.id, persistId);
         }
         // 压住的错误详情必须在这里存一份:决策推迟场景下 onResumableTurnError 还没被调用过
         // (它自己那份 set 发生在接管成立时),不存就无从补落。同 clientId 内容,覆盖无害。

--- a/apps/desktop/src/main/maker-ipc/register.ts
+++ b/apps/desktop/src/main/maker-ipc/register.ts
@@ -14468,8 +14468,9 @@ export function registerMakerIpc(maker: Maker, options: RegisterMakerIpcOptions)
         agentMetaRaw != null && typeof agentMetaRaw === 'object'
           ? (agentMetaRaw as AgentMeta)
           : null;
-      onTurnErrorEvent(sid, errData, agentMeta);
+      const persistId = onTurnErrorEvent(sid, errData, agentMeta);
       getAgentIslandService()?.resolveDeferredRemoteAuthRetryError(sid);
+      return persistId;
     },
   );
 

--- a/apps/desktop/src/main/messagePersistBroadcaster.ts
+++ b/apps/desktop/src/main/messagePersistBroadcaster.ts
@@ -1949,7 +1949,12 @@ async function latestMessageCreatedAt(sessionId: string): Promise<number | undef
  *
  * clearSessionPersistState 时一并清理。
  */
-const _recentErrorPersistKeys = new Map<string, number>();
+interface RecentTurnErrorPersistClaim {
+  capturedAt: number;
+  persistId?: string;
+}
+
+const _recentErrorPersistKeys = new Map<string, RecentTurnErrorPersistClaim>();
 /** message-only fallback 窗口:完全无 turn identity 时仅防多窗近乎同时(<100ms)并发。 */
 const DEDUP_WINDOW_MS_MESSAGE = 300;
 
@@ -2060,12 +2065,39 @@ function claimTurnErrorDedup(
   capturedAt: number,
 ): boolean {
   const { dedupKey, hasTurnIdentity } = turnErrorDedupKey(sessionId, message, agentMeta);
-  const lastT = _recentErrorPersistKeys.get(dedupKey);
-  if (lastT !== undefined && (hasTurnIdentity || capturedAt - lastT < DEDUP_WINDOW_MS_MESSAGE)) {
+  const last = _recentErrorPersistKeys.get(dedupKey);
+  if (
+    last !== undefined &&
+    (hasTurnIdentity || capturedAt - last.capturedAt < DEDUP_WINDOW_MS_MESSAGE)
+  ) {
     return false;
   }
-  _recentErrorPersistKeys.set(dedupKey, capturedAt);
+  _recentErrorPersistKeys.set(dedupKey, { capturedAt });
   return true;
+}
+
+function rememberTurnErrorPersistId(
+  sessionId: string,
+  message: string,
+  agentMeta: AgentMeta | null,
+  persistId: string,
+): void {
+  const { dedupKey } = turnErrorDedupKey(sessionId, message, agentMeta);
+  const last = _recentErrorPersistKeys.get(dedupKey);
+  if (last) {
+    last.persistId = persistId;
+    return;
+  }
+  _recentErrorPersistKeys.set(dedupKey, { capturedAt: Date.now(), persistId });
+}
+
+function lookupTurnErrorPersistId(
+  sessionId: string,
+  message: string,
+  agentMeta: AgentMeta | null,
+): string | undefined {
+  const { dedupKey } = turnErrorDedupKey(sessionId, message, agentMeta);
+  return _recentErrorPersistKeys.get(dedupKey)?.persistId;
 }
 
 /**
@@ -2081,6 +2113,7 @@ export function reserveTurnErrorPersistId(
   if (!message) return undefined;
   if (!claimTurnErrorDedup(sessionId, message, agentMeta, Date.now())) return undefined;
   const persistId = createId();
+  rememberTurnErrorPersistId(sessionId, message, agentMeta, persistId);
   _reservedTurnErrorPersistIds.add(turnErrorPersistKey(sessionId, persistId));
   createTurnErrorWaiter(sessionId, persistId);
   return persistId;
@@ -2134,8 +2167,13 @@ export function onTurnErrorEvent(
     // 多窗 dedup:防止多个 BrowserWindow 各自触发 persistTurnErrorDeferred 导致重复 error 行。
     // 优先用 agentMeta.requestId/uuid 作 turn 级 key(唯一,不同 turn 不误 dedup);
     // 无 agentMeta 时优先使用 register 记录的 turnDedupId,最后才回退 message 短窗口。
-    if (!claimTurnErrorDedup(sessionId, message, agentMeta, capturedAt)) return undefined;
+    // Electron main 单线程:claim + createId + remember 在同一次调用里完成,输家
+    // 再进来时 lookup 一定能拿到赢家的 persistId,不必另造 pending-dismiss。
+    if (!claimTurnErrorDedup(sessionId, message, agentMeta, capturedAt)) {
+      return lookupTurnErrorPersistId(sessionId, message, agentMeta);
+    }
     persistId = createId();
+    rememberTurnErrorPersistId(sessionId, message, agentMeta, persistId);
     _consumedTurnErrorPersistIds.add(turnErrorPersistKey(sessionId, persistId));
     createTurnErrorWaiter(sessionId, persistId);
   }

--- a/apps/desktop/src/main/messagePersistBroadcaster.ts
+++ b/apps/desktop/src/main/messagePersistBroadcaster.ts
@@ -446,7 +446,7 @@ function enqueueWrite(label: string, fn: (ownerScope: OwnerScope) => Promise<unk
 
 /**
  * error 行写入专用队列：owner-scope 跳过或写入失败时也必须解开预留 waiter，
- * 否则 dismiss-error 会空等满超时窗口。
+ * 否则 dismiss-error 会一直等这条预留 id 落库。
  */
 function enqueueTurnErrorWrite(
   sessionId: string,
@@ -1952,7 +1952,6 @@ async function latestMessageCreatedAt(sessionId: string): Promise<number | undef
 const _recentErrorPersistKeys = new Map<string, number>();
 /** message-only fallback 窗口:完全无 turn identity 时仅防多窗近乎同时(<100ms)并发。 */
 const DEDUP_WINDOW_MS_MESSAGE = 300;
-const TURN_ERROR_PERSIST_WAIT_MS = 5000;
 
 interface TurnErrorPersistWaiter {
   promise: Promise<void>;
@@ -2029,7 +2028,8 @@ function dropSessionTurnErrorReservations(sessionId: string): void {
  *
  * persistId 可在广播前经 reserveTurnErrorPersistId 预留(O(1),不 flush、不写库);
  * 真正写库仍必须保持在广播后。用户若在落库前点关闭/重试,dismiss-error 会先等
- * whenTurnErrorPersisted 再按同一 id 标记 ignored。
+ * whenTurnErrorPersisted(等到写入、跳过或释放,不以墙钟超时当作已落库)再按同一
+ * id 标记 ignored。
  *
  * content 存结构化 { message, reason?, sdkError? }:reason 是 maker-core 的稳定
  * key('empty-response' / 'turn-failed' 等),renderer 渲染时按它走 i18n(规则 18),
@@ -2095,17 +2095,14 @@ export function releaseReservedTurnErrorPersistId(sessionId: string, persistId: 
 
 /**
  * dismiss-error 在写库完成前点关闭时,先等这条预留 id 落库(或被释放)。
- * 没有 waiter(已写完/从未预留)立即返回;超时 5s 后也返回,避免 IPC 挂死。
+ * 没有 waiter(已写完/从未预留)立即返回。有 waiter 就必须等到写入、owner-scope
+ * 跳过或 release —— 不能墙钟超时后按「已落库」去查询,否则会 NOT_FOUND,迟到的
+ * 写入留下未忽略行,重启又弹出同一张卡。会话清理会解开仍在等的 waiter。
  */
 export function whenTurnErrorPersisted(sessionId: string, persistId: string): Promise<void> {
   const waiter = _turnErrorPersistWaiters.get(turnErrorPersistKey(sessionId, persistId));
   if (!waiter) return Promise.resolve();
-  return Promise.race([
-    waiter.promise,
-    new Promise<void>((resolve) => {
-      setTimeout(resolve, TURN_ERROR_PERSIST_WAIT_MS);
-    }),
-  ]);
+  return waiter.promise;
 }
 
 export function onTurnErrorEvent(

--- a/apps/desktop/src/main/messagePersistBroadcaster.ts
+++ b/apps/desktop/src/main/messagePersistBroadcaster.ts
@@ -444,6 +444,37 @@ function enqueueWrite(label: string, fn: (ownerScope: OwnerScope) => Promise<unk
     });
 }
 
+/**
+ * error 行写入专用队列：owner-scope 跳过或写入失败时也必须解开预留 waiter，
+ * 否则 dismiss-error 会空等满超时窗口。
+ */
+function enqueueTurnErrorWrite(
+  sessionId: string,
+  persistId: string,
+  fn: (ownerScope: OwnerScope) => Promise<unknown>,
+): void {
+  const ownerScope = captureOwnerScope();
+  const label = `turn_error:${sessionId}:${persistId}`;
+  writeChain = writeChain
+    .then(async () => {
+      try {
+        if (!isOwnerScopeCurrent(ownerScope)) {
+          log.debug('message persist skipped after app-session boundary', { label });
+          return;
+        }
+        await fn(ownerScope);
+      } finally {
+        resolveTurnErrorWaiter(sessionId, persistId);
+      }
+    })
+    .catch((err) => {
+      log.warn('message persist failed', {
+        label,
+        error: err instanceof Error ? err.message : String(err),
+      });
+    });
+}
+
 /** 在事件入队时冻结 agent_kind，避免 writeChain 延迟执行时读到切换后的可变 Map。 */
 function enqueueVisibleDbMessage(
   label: string,
@@ -1921,6 +1952,56 @@ async function latestMessageCreatedAt(sessionId: string): Promise<number | undef
 const _recentErrorPersistKeys = new Map<string, number>();
 /** message-only fallback 窗口:完全无 turn identity 时仅防多窗近乎同时(<100ms)并发。 */
 const DEDUP_WINDOW_MS_MESSAGE = 300;
+const TURN_ERROR_PERSIST_WAIT_MS = 5000;
+
+interface TurnErrorPersistWaiter {
+  promise: Promise<void>;
+  resolve: () => void;
+}
+
+/** 预留后、写库前即可 await；key = `${sessionId}:${persistId}`。 */
+const _turnErrorPersistWaiters = new Map<string, TurnErrorPersistWaiter>();
+/** 预留后尚未 enqueue 写库的 id，供 onTurnErrorEvent 复用。 */
+const _reservedTurnErrorPersistIds = new Set<string>();
+/** 已消费（写库或 release）的预留 id，防止同一 persistId 双写。 */
+const _consumedTurnErrorPersistIds = new Set<string>();
+
+function turnErrorPersistKey(sessionId: string, persistId: string): string {
+  return `${sessionId}:${persistId}`;
+}
+
+function createTurnErrorWaiter(sessionId: string, persistId: string): void {
+  const key = turnErrorPersistKey(sessionId, persistId);
+  if (_turnErrorPersistWaiters.has(key)) return;
+  let resolve!: () => void;
+  const promise = new Promise<void>((r) => {
+    resolve = r;
+  });
+  _turnErrorPersistWaiters.set(key, { promise, resolve });
+}
+
+function resolveTurnErrorWaiter(sessionId: string, persistId: string): void {
+  const key = turnErrorPersistKey(sessionId, persistId);
+  const waiter = _turnErrorPersistWaiters.get(key);
+  if (!waiter) return;
+  waiter.resolve();
+  _turnErrorPersistWaiters.delete(key);
+}
+
+function dropSessionTurnErrorReservations(sessionId: string): void {
+  const prefix = `${sessionId}:`;
+  for (const key of _turnErrorPersistWaiters.keys()) {
+    if (!key.startsWith(prefix)) continue;
+    _turnErrorPersistWaiters.get(key)?.resolve();
+    _turnErrorPersistWaiters.delete(key);
+  }
+  for (const key of _reservedTurnErrorPersistIds) {
+    if (key.startsWith(prefix)) _reservedTurnErrorPersistIds.delete(key);
+  }
+  for (const key of _consumedTurnErrorPersistIds) {
+    if (key.startsWith(prefix)) _consumedTurnErrorPersistIds.delete(key);
+  }
+}
 
 /**
  * terminal error(turn 失败终态)持久化 —— 让失败在会话历史里留下可追溯的痕迹。
@@ -1938,6 +2019,7 @@ const DEDUP_WINDOW_MS_MESSAGE = 300;
  * **发送 local-db:session:error-persisted 脏信号**:对于已加载历史(historyLoaded=true)
  * 但当前不在流式中的后台会话,renderer 收到信号后将 historyLoaded 置 false,
  * 下次用户打开该会话时 ensureInitialMessages 从 DB 重拉,error 行正常浮现。
+ * payload 含 persistId,让 live 横幅与持久化行绑定同一 id。
  *
  * 先 flushAssistantBlock:error 是 turn 终结边界,在飞 assistant 文本必须先落库,
  * 否则 error 行会排在它产出的正文之前(时序错乱),与 tool_use / interaction 边界
@@ -1945,39 +2027,120 @@ const DEDUP_WINDOW_MS_MESSAGE = 300;
  * 之后调用(保证 orphan tool_result 排在 error 行之前);agentMeta 显式透传,
  * 兜底"失败轮只有 error 边界携带 SDK uuid"场景的 rewind/fork 锚点(greptile P1)。
  *
+ * persistId 可在广播前经 reserveTurnErrorPersistId 预留(O(1),不 flush、不写库);
+ * 真正写库仍必须保持在广播后。用户若在落库前点关闭/重试,dismiss-error 会先等
+ * whenTurnErrorPersisted 再按同一 id 标记 ignored。
+ *
  * content 存结构化 { message, reason?, sdkError? }:reason 是 maker-core 的稳定
  * key('empty-response' / 'turn-failed' 等),renderer 渲染时按它走 i18n(规则 18),
  * message 是给非 renderer 消费方(IM / orca / 旧版本客户端)的兜底文案。
  */
-export function onTurnErrorEvent(
+function turnErrorDedupKey(
+  sessionId: string,
+  message: string,
+  agentMeta: AgentMeta | null,
+): { dedupKey: string; hasTurnIdentity: boolean } {
+  const turnDedupId =
+    _turnDedupIdBySession.get(sessionId) ??
+    _savedTurnDedupIdForDeferred.get(sessionId) ??
+    null;
+  const turnId = agentMeta?.requestId ?? agentMeta?.uuid ?? null;
+  const messageKey = message.slice(0, 100);
+  return {
+    dedupKey: `${sessionId}:${turnId ?? (turnDedupId ? `turn:${turnDedupId}:${messageKey}` : `message:${messageKey}`)}`,
+    hasTurnIdentity: turnId !== null || turnDedupId !== null,
+  };
+}
+
+function claimTurnErrorDedup(
+  sessionId: string,
+  message: string,
+  agentMeta: AgentMeta | null,
+  capturedAt: number,
+): boolean {
+  const { dedupKey, hasTurnIdentity } = turnErrorDedupKey(sessionId, message, agentMeta);
+  const lastT = _recentErrorPersistKeys.get(dedupKey);
+  if (lastT !== undefined && (hasTurnIdentity || capturedAt - lastT < DEDUP_WINDOW_MS_MESSAGE)) {
+    return false;
+  }
+  _recentErrorPersistKeys.set(dedupKey, capturedAt);
+  return true;
+}
+
+/**
+ * 广播前预留 error 行 clientId。只做 dedup + createId + 登记 waiter,不 flush、不写库。
+ * 随后必须调用 onTurnErrorEvent(..., persistId) 或 releaseReservedTurnErrorPersistId。
+ */
+export function reserveTurnErrorPersistId(
   sessionId: string,
   data: { message?: unknown; reason?: unknown; sdkError?: unknown } | null | undefined,
   agentMeta: AgentMeta | null = null,
 ): string | undefined {
   const message = typeof data?.message === 'string' ? redactSensitiveText(data.message) : '';
   if (!message) return undefined;
-  const ownerScope = captureOwnerScope();
+  if (!claimTurnErrorDedup(sessionId, message, agentMeta, Date.now())) return undefined;
+  const persistId = createId();
+  _reservedTurnErrorPersistIds.add(turnErrorPersistKey(sessionId, persistId));
+  createTurnErrorWaiter(sessionId, persistId);
+  return persistId;
+}
+
+/** 预留后决定不写库时解开 waiter,并标记已消费以免同一 id 再写一次。 */
+export function releaseReservedTurnErrorPersistId(sessionId: string, persistId: string): void {
+  const key = turnErrorPersistKey(sessionId, persistId);
+  _reservedTurnErrorPersistIds.delete(key);
+  _consumedTurnErrorPersistIds.add(key);
+  resolveTurnErrorWaiter(sessionId, persistId);
+}
+
+/**
+ * dismiss-error 在写库完成前点关闭时,先等这条预留 id 落库(或被释放)。
+ * 没有 waiter(已写完/从未预留)立即返回;超时 5s 后也返回,避免 IPC 挂死。
+ */
+export function whenTurnErrorPersisted(sessionId: string, persistId: string): Promise<void> {
+  const waiter = _turnErrorPersistWaiters.get(turnErrorPersistKey(sessionId, persistId));
+  if (!waiter) return Promise.resolve();
+  return Promise.race([
+    waiter.promise,
+    new Promise<void>((resolve) => {
+      setTimeout(resolve, TURN_ERROR_PERSIST_WAIT_MS);
+    }),
+  ]);
+}
+
+export function onTurnErrorEvent(
+  sessionId: string,
+  data: { message?: unknown; reason?: unknown; sdkError?: unknown } | null | undefined,
+  agentMeta: AgentMeta | null = null,
+  reservedPersistId?: string,
+): string | undefined {
+  const message = typeof data?.message === 'string' ? redactSensitiveText(data.message) : '';
+  if (!message) return undefined;
   const capturedAt = Date.now();
   const recordedTurnStartedAt =
     _turnStartedAtBySession.get(sessionId) ??
     _savedTurnStartedAtForDeferred.get(sessionId);
   const turnStartedAtSnapshot = recordedTurnStartedAt ?? capturedAt;
-  const turnDedupId =
-    _turnDedupIdBySession.get(sessionId) ??
-    _savedTurnDedupIdForDeferred.get(sessionId) ??
-    null;
-  // 多窗 dedup:防止多个 BrowserWindow 各自触发 persistTurnErrorDeferred 导致重复 error 行。
-  // 优先用 agentMeta.requestId/uuid 作 turn 级 key(唯一,不同 turn 不误 dedup);
-  // 无 agentMeta 时优先使用 register 记录的 turnDedupId,最后才回退 message 短窗口。
-  const turnId = agentMeta?.requestId ?? agentMeta?.uuid ?? null;
-  const messageKey = message.slice(0, 100);
-  const dedupKey = `${sessionId}:${turnId ?? (turnDedupId ? `turn:${turnDedupId}:${messageKey}` : `message:${messageKey}`)}`;
-  const hasTurnIdentity = turnId !== null || turnDedupId !== null;
-  const lastT = _recentErrorPersistKeys.get(dedupKey);
-  if (lastT !== undefined && (hasTurnIdentity || capturedAt - lastT < DEDUP_WINDOW_MS_MESSAGE)) {
-    return undefined;
+
+  let persistId: string;
+  if (reservedPersistId) {
+    const key = turnErrorPersistKey(sessionId, reservedPersistId);
+    if (_consumedTurnErrorPersistIds.has(key) || !_reservedTurnErrorPersistIds.has(key)) {
+      return reservedPersistId;
+    }
+    _reservedTurnErrorPersistIds.delete(key);
+    _consumedTurnErrorPersistIds.add(key);
+    persistId = reservedPersistId;
+  } else {
+    // 多窗 dedup:防止多个 BrowserWindow 各自触发 persistTurnErrorDeferred 导致重复 error 行。
+    // 优先用 agentMeta.requestId/uuid 作 turn 级 key(唯一,不同 turn 不误 dedup);
+    // 无 agentMeta 时优先使用 register 记录的 turnDedupId,最后才回退 message 短窗口。
+    if (!claimTurnErrorDedup(sessionId, message, agentMeta, capturedAt)) return undefined;
+    persistId = createId();
+    _consumedTurnErrorPersistIds.add(turnErrorPersistKey(sessionId, persistId));
+    createTurnErrorWaiter(sessionId, persistId);
   }
-  _recentErrorPersistKeys.set(dedupKey, capturedAt);
+
   // 同步捕获当前时刻作为上界，防止异步写入延迟时 latestMessageCreatedAt
   // 取到 /clear 之后的新消息时间戳，导致 error 行出现在清空后的会话里。
   // 同步捕获 turn 开始时刻，防止 enqueueWrite 异步回调执行时 register.ts 已调
@@ -1995,7 +2158,6 @@ export function onTurnErrorEvent(
   //   避免 Date.now() 落在 /clear 之后导致 error 行在清空后的历史中浮现。
   const blockCreatedAt = assistantBlocks.get(sessionId)?.createdAt;
   flushAssistantBlock(sessionId, agentMeta);
-  const persistId = createId();
   const content: Record<string, unknown> = { message };
   if (typeof data?.reason === 'string' && data.reason) content.reason = data.reason;
   if (typeof data?.sdkError === 'string' && data.sdkError) {
@@ -2011,7 +2173,7 @@ export function onTurnErrorEvent(
   if (providerIdAtError) content.providerId = providerIdAtError;
   const meta = agentMeta ?? lastAgentMetaBySession.get(sessionId) ?? null;
   const dbAgentKindSnapshot = getSessionDbAgentKind(sessionId) ?? undefined;
-  enqueueWrite(`turn_error:${sessionId}:${persistId}`, async () => {
+  enqueueTurnErrorWrite(sessionId, persistId, async (ownerScope) => {
     // 两个分支统一 +1：保证 error.createdAt 严格晚于本轮所有已入库行。
     // 注意：register.ts 在 flushAssistantBlock 之后调本函数，blockCreatedAt
     // 在生产路径恒为 undefined（block 已 delete）；latestMessageCreatedAt
@@ -2055,13 +2217,14 @@ export function onTurnErrorEvent(
     );
     if (!isOwnerScopeCurrent(ownerScope)) return;
     const ownerStamp = ownerScope ? ownerScope.ownerStamp : broadcastTap.getSafeDataOwnerPushStamp?.();
+    const payload = { sessionId, persistId };
     for (const win of BrowserWindow.getAllWindows()) {
       if (win.isDestroyed()) continue;
       try {
         if (ownerScope === null) {
-          win.webContents.send('local-db:session:error-persisted', { sessionId });
+          win.webContents.send('local-db:session:error-persisted', payload);
         } else {
-          win.webContents.send('local-db:session:error-persisted', { sessionId }, ownerStamp);
+          win.webContents.send('local-db:session:error-persisted', payload, ownerStamp);
         }
       } catch {
         /* swallow per-window broadcast failures */
@@ -2069,9 +2232,9 @@ export function onTurnErrorEvent(
     }
     // device-link:把脏信号也转发给远控端,让已加载该会话历史的控制端窗口同样失效。
     if (ownerScope === null) {
-      broadcastTap.tapWindowBroadcast('local-db:session:error-persisted', { sessionId });
+      broadcastTap.tapWindowBroadcast('local-db:session:error-persisted', payload);
     } else {
-      broadcastTap.tapWindowBroadcast('local-db:session:error-persisted', { sessionId }, ownerStamp);
+      broadcastTap.tapWindowBroadcast('local-db:session:error-persisted', payload, ownerStamp);
     }
   });
   notePersistedMessage(sessionId, 'error', persistId);
@@ -2116,4 +2279,5 @@ export function clearSessionPersistState(sessionId: string): void {
   for (const key of _recentErrorPersistKeys.keys()) {
     if (key.startsWith(`${sessionId}:`)) _recentErrorPersistKeys.delete(key);
   }
+  dropSessionTurnErrorReservations(sessionId);
 }

--- a/apps/desktop/src/main/messagePersistBroadcaster.ts
+++ b/apps/desktop/src/main/messagePersistBroadcaster.ts
@@ -1989,16 +1989,17 @@ function resolveTurnErrorWaiter(sessionId: string, persistId: string): void {
 
 function dropSessionTurnErrorReservations(sessionId: string): void {
   const prefix = `${sessionId}:`;
-  for (const key of _turnErrorPersistWaiters.keys()) {
+  // 只解开尚未 enqueue 的预留。已入队的 waiter 必须等到 writeChain finally,
+  // 否则 dismiss 会在 createMessage 前得到 NOT_FOUND,迟到写入留下未忽略行。
+  for (const key of [..._reservedTurnErrorPersistIds]) {
     if (!key.startsWith(prefix)) continue;
-    _turnErrorPersistWaiters.get(key)?.resolve();
-    _turnErrorPersistWaiters.delete(key);
+    _reservedTurnErrorPersistIds.delete(key);
+    resolveTurnErrorWaiter(sessionId, key.slice(prefix.length));
   }
-  for (const key of _reservedTurnErrorPersistIds) {
-    if (key.startsWith(prefix)) _reservedTurnErrorPersistIds.delete(key);
-  }
-  for (const key of _consumedTurnErrorPersistIds) {
-    if (key.startsWith(prefix)) _consumedTurnErrorPersistIds.delete(key);
+  for (const key of [..._consumedTurnErrorPersistIds]) {
+    if (!_turnErrorPersistWaiters.has(key) && key.startsWith(prefix)) {
+      _consumedTurnErrorPersistIds.delete(key);
+    }
   }
 }
 
@@ -2097,7 +2098,8 @@ export function releaseReservedTurnErrorPersistId(sessionId: string, persistId: 
  * dismiss-error 在写库完成前点关闭时,先等这条预留 id 落库(或被释放)。
  * 没有 waiter(已写完/从未预留)立即返回。有 waiter 就必须等到写入、owner-scope
  * 跳过或 release —— 不能墙钟超时后按「已落库」去查询,否则会 NOT_FOUND,迟到的
- * 写入留下未忽略行,重启又弹出同一张卡。会话清理会解开仍在等的 waiter。
+ * 写入留下未忽略行,重启又弹出同一张卡。会话清理只解开尚未入队的预留 waiter;
+ * 已入队的等到 writeChain finally。
  */
 export function whenTurnErrorPersisted(sessionId: string, persistId: string): Promise<void> {
   const waiter = _turnErrorPersistWaiters.get(turnErrorPersistKey(sessionId, persistId));

--- a/apps/desktop/src/preload/preload.ts
+++ b/apps/desktop/src/preload/preload.ts
@@ -6541,7 +6541,7 @@ contextBridge.exposeInMainWorld('electronAPI', {
         sessionId: string,
         errData: Record<string, unknown> | null,
         agentMeta?: import('../renderer/lib/ccAgent.types').AgentMeta | null,
-      ): Promise<void> =>
+      ): Promise<string | undefined> =>
         ipcRenderer.invoke(
           'maker:persist-turn-error-deferred',
           sessionId,

--- a/apps/desktop/src/renderer/__tests__/errorRetryTokenPreserved.test.ts
+++ b/apps/desktop/src/renderer/__tests__/errorRetryTokenPreserved.test.ts
@@ -100,6 +100,7 @@ describe('handleStreamEvent — terminal error keeps the projection retry token'
     const before = {
       ...EMPTY_SESSION_STATE,
       errorRetryText: PROJECTION_TOKEN,
+      errorPersistId: 'old-persist',
       isStreaming: true,
     };
 
@@ -110,6 +111,29 @@ describe('handleStreamEvent — terminal error keeps the projection retry token'
     } as Parameters<typeof handleStreamEvent>[1]);
 
     expect(next.errorRetryText).toBeNull();
+    expect(next.errorPersistId).toBeNull();
     expect(next.recoverableError).toBe('transient');
+  });
+
+  it('copies persistId from the terminal error event', () => {
+    const next = handleStreamEvent(
+      { ...EMPTY_SESSION_STATE, isStreaming: true },
+      { ...terminalError(), persistId: 'err_persist_1' },
+    );
+
+    expect(next.error).toBe('Request timed out');
+    expect(next.errorPersistId).toBe('err_persist_1');
+  });
+
+  it('does not keep a previous persistId when the terminal event has none', () => {
+    const before = {
+      ...EMPTY_SESSION_STATE,
+      errorPersistId: 'old-id',
+      isStreaming: true,
+    };
+
+    const next = handleStreamEvent(before, terminalError());
+
+    expect(next.errorPersistId).toBeNull();
   });
 });

--- a/apps/desktop/src/renderer/__tests__/errorRetryTokenPreserved.test.ts
+++ b/apps/desktop/src/renderer/__tests__/errorRetryTokenPreserved.test.ts
@@ -123,6 +123,8 @@ describe('handleStreamEvent — terminal error keeps the projection retry token'
 
     expect(next.error).toBe('Request timed out');
     expect(next.errorPersistId).toBe('err_persist_1');
+    // persistId 只绑定即将落库的 error 行，不是 Retry 依据。
+    expect(next.errorRetryText).toBeNull();
   });
 
   it('does not keep a previous persistId when the terminal event has none', () => {

--- a/apps/desktop/src/renderer/__tests__/errorRetryTokenPreserved.test.ts
+++ b/apps/desktop/src/renderer/__tests__/errorRetryTokenPreserved.test.ts
@@ -127,15 +127,32 @@ describe('handleStreamEvent — terminal error keeps the projection retry token'
     expect(next.errorRetryText).toBeNull();
   });
 
-  it('does not keep a previous persistId when the terminal event has none', () => {
+  it('keeps an existing persistId when a duplicate terminal event omits it', () => {
     const before = {
       ...EMPTY_SESSION_STATE,
-      errorPersistId: 'old-id',
+      error: 'Request timed out',
+      errorPersistId: 'err_persist_1',
       isStreaming: true,
     };
 
     const next = handleStreamEvent(before, terminalError());
 
-    expect(next.errorPersistId).toBeNull();
+    expect(next.errorPersistId).toBe('err_persist_1');
+  });
+
+  it('replaces the binding when a later terminal event carries a new persistId', () => {
+    const before = {
+      ...EMPTY_SESSION_STATE,
+      error: 'old error',
+      errorPersistId: 'old-id',
+      isStreaming: true,
+    };
+
+    const next = handleStreamEvent(before, {
+      ...terminalError(),
+      persistId: 'err_persist_2',
+    });
+
+    expect(next.errorPersistId).toBe('err_persist_2');
   });
 });

--- a/apps/desktop/src/renderer/__tests__/makerChatStoreTextDeltaBatching.test.ts
+++ b/apps/desktop/src/renderer/__tests__/makerChatStoreTextDeltaBatching.test.ts
@@ -137,6 +137,7 @@ let onDeviceLinkStatusChanged: ((data: unknown) => void) | undefined;
 let onPresenceChanged: ((data: unknown) => void) | undefined;
 let onRemotePush: ((data: unknown, ownerStamp?: unknown) => void) | undefined;
 let onDbMessageCreated: ((data: unknown) => void) | undefined;
+let onErrorPersisted: ((data: unknown, ownerStamp?: unknown) => void) | undefined;
 let onInputProjection: ((data: unknown) => void) | undefined;
 let onInteractionRequest: ((data: unknown) => void) | undefined;
 let onInteractionDismissed: ((data: unknown) => void) | undefined;
@@ -179,7 +180,7 @@ const input = {
     void clearedAt;
     return projection(sessionId);
   }),
-  persistTurnErrorDeferred: vi.fn(async () => {}),
+  persistTurnErrorDeferred: vi.fn(async (): Promise<string | undefined> => undefined),
 };
 
 function projection(
@@ -254,6 +255,7 @@ function installElectronBridge(): void {
   onPresenceChanged = undefined;
   onRemotePush = undefined;
   onDbMessageCreated = undefined;
+  onErrorPersisted = undefined;
   onInputProjection = undefined;
   onInteractionRequest = undefined;
   onInteractionDismissed = undefined;
@@ -322,6 +324,10 @@ function installElectronBridge(): void {
         messages: {
           onCreated: (cb: (data: unknown) => void) => {
             onDbMessageCreated = cb;
+            return vi.fn();
+          },
+          onErrorPersisted: (cb: (data: unknown, ownerStamp?: unknown) => void) => {
+            onErrorPersisted = cb;
             return vi.fn();
           },
         },
@@ -2359,6 +2365,78 @@ describe('makerChatStore text delta batching', () => {
     expect(input.retryLastError).not.toHaveBeenCalled();
     expect(input.persistTurnErrorDeferred).toHaveBeenCalledOnce();
     expect(makerChatStore.getSnapshot(SESSION_ID).error).toContain('LiteLLM_VerificationTokenTable');
+  });
+
+  it('deferred persist IPC 回执只绑定 persistId，写失败时离开视图也不清 live error', async () => {
+    vi.mocked(window.electronAPI.modelAccess.retry).mockResolvedValueOnce({
+      state: 'failed',
+      source: null,
+      endpoint: null,
+      errorCode: 'NETWORK_ERROR',
+      accountTier: null,
+    });
+    input.persistTurnErrorDeferred.mockResolvedValueOnce('err-persist-deferred');
+    makerChatStore.enterView(SESSION_ID);
+    onInputProjection?.(
+      projection(SESSION_ID, {
+        error: LITELLM_INVALID_PROXY_TOKEN,
+        recovery: { kind: 'active-turn', item: activeTurnRecoveryItem() },
+        errorRetryText: 'retry:user-client',
+      }),
+    );
+
+    emitGatewayProxyTokenFailure({
+      isTerminal: true,
+      reason: 'gateway-proxy-token-invalid',
+      message: LITELLM_INVALID_PROXY_TOKEN,
+    });
+    await flushPromises();
+    await flushPromises();
+
+    expect(input.persistTurnErrorDeferred).toHaveBeenCalledOnce();
+    expect(makerChatStore.getSnapshot(SESSION_ID).error).toContain('LiteLLM_VerificationTokenTable');
+    expect(makerChatStore.getSnapshot(SESSION_ID).errorPersistId).toBe('err-persist-deferred');
+
+    makerChatStore.leaveView(SESSION_ID);
+    expect(makerChatStore.getSnapshot(SESSION_ID).error).toContain('LiteLLM_VerificationTokenTable');
+    expect(makerChatStore.getSnapshot(SESSION_ID).errorPersistId).toBe('err-persist-deferred');
+
+    onErrorPersisted?.({ sessionId: SESSION_ID, persistId: 'err-persist-deferred' });
+    expect(makerChatStore.getSnapshot(SESSION_ID).error).toBeNull();
+    expect(makerChatStore.getSnapshot(SESSION_ID).errorPersistId).toBeNull();
+  });
+
+  it('deferred persist IPC 回执不清后台 live error，要等真实脏信号', async () => {
+    vi.mocked(window.electronAPI.modelAccess.retry).mockResolvedValueOnce({
+      state: 'failed',
+      source: null,
+      endpoint: null,
+      errorCode: 'NETWORK_ERROR',
+      accountTier: null,
+    });
+    input.persistTurnErrorDeferred.mockResolvedValueOnce('err-persist-bg');
+    onInputProjection?.(
+      projection(SESSION_ID, {
+        error: LITELLM_INVALID_PROXY_TOKEN,
+        recovery: { kind: 'active-turn', item: activeTurnRecoveryItem() },
+        errorRetryText: 'retry:user-client',
+      }),
+    );
+
+    emitGatewayProxyTokenFailure({
+      isTerminal: true,
+      reason: 'gateway-proxy-token-invalid',
+      message: LITELLM_INVALID_PROXY_TOKEN,
+    });
+    await flushPromises();
+    await flushPromises();
+
+    expect(makerChatStore.getSnapshot(SESSION_ID).error).toContain('LiteLLM_VerificationTokenTable');
+    expect(makerChatStore.getSnapshot(SESSION_ID).errorPersistId).toBe('err-persist-bg');
+
+    onErrorPersisted?.({ sessionId: SESSION_ID, persistId: 'err-persist-bg' });
+    expect(makerChatStore.getSnapshot(SESSION_ID).error).toBeNull();
+    expect(makerChatStore.getSnapshot(SESSION_ID).errorPersistId).toBeNull();
   });
 
   it('does not treat a custom LiteLLM provider token error as Cindy credentials', async () => {

--- a/apps/desktop/src/renderer/__tests__/makerChatStoreTextDeltaBatching.test.ts
+++ b/apps/desktop/src/renderer/__tests__/makerChatStoreTextDeltaBatching.test.ts
@@ -2406,6 +2406,114 @@ describe('makerChatStore text delta batching', () => {
     expect(makerChatStore.getSnapshot(SESSION_ID).errorPersistId).toBeNull();
   });
 
+  it('迟到的 deferred persist IPC 不得把 A 的 persistId 绑到下一轮 live error B', async () => {
+    vi.mocked(window.electronAPI.modelAccess.retry).mockResolvedValueOnce({
+      state: 'failed',
+      source: null,
+      endpoint: null,
+      errorCode: 'NETWORK_ERROR',
+      accountTier: null,
+    });
+    let resolvePersist: ((id: string | undefined) => void) | undefined;
+    input.persistTurnErrorDeferred.mockImplementationOnce(
+      () =>
+        new Promise<string | undefined>((resolve) => {
+          resolvePersist = resolve;
+        }),
+    );
+    onInputProjection?.(
+      projection(SESSION_ID, {
+        error: LITELLM_INVALID_PROXY_TOKEN,
+        recovery: { kind: 'active-turn', item: activeTurnRecoveryItem() },
+        errorRetryText: 'retry:user-client',
+      }),
+    );
+
+    emitGatewayProxyTokenFailure({
+      isTerminal: true,
+      reason: 'gateway-proxy-token-invalid',
+      message: LITELLM_INVALID_PROXY_TOKEN,
+    });
+    await flushPromises();
+    await flushPromises();
+
+    expect(input.persistTurnErrorDeferred).toHaveBeenCalledOnce();
+    expect(makerChatStore.getSnapshot(SESSION_ID).error).toContain('LiteLLM_VerificationTokenTable');
+    expect(makerChatStore.getSnapshot(SESSION_ID).errorPersistId).toBeNull();
+
+    emitStatus({ status: 'Thinking…', isRunning: true });
+    expect(makerChatStore.getSnapshot(SESSION_ID).error).toBeNull();
+
+    onEvent?.({
+      sessionId: SESSION_ID,
+      event: {
+        type: 'error',
+        source: 'claude-code',
+        data: { isTerminal: true, message: 'later error B' },
+      },
+    });
+    expect(makerChatStore.getSnapshot(SESSION_ID).error).toBe('later error B');
+    expect(makerChatStore.getSnapshot(SESSION_ID).errorPersistId).toBeNull();
+
+    resolvePersist?.('err-persist-A');
+    await flushPromises();
+    await flushPromises();
+
+    expect(makerChatStore.getSnapshot(SESSION_ID).error).toBe('later error B');
+    expect(makerChatStore.getSnapshot(SESSION_ID).errorPersistId).toBeNull();
+  });
+
+  it('迟到的落库脏信号不得清掉下一轮 live error B', async () => {
+    vi.mocked(window.electronAPI.modelAccess.retry).mockResolvedValueOnce({
+      state: 'failed',
+      source: null,
+      endpoint: null,
+      errorCode: 'NETWORK_ERROR',
+      accountTier: null,
+    });
+    let resolvePersist: ((id: string | undefined) => void) | undefined;
+    input.persistTurnErrorDeferred.mockImplementationOnce(
+      () =>
+        new Promise<string | undefined>((resolve) => {
+          resolvePersist = resolve;
+        }),
+    );
+    onInputProjection?.(
+      projection(SESSION_ID, {
+        error: LITELLM_INVALID_PROXY_TOKEN,
+        recovery: { kind: 'active-turn', item: activeTurnRecoveryItem() },
+        errorRetryText: 'retry:user-client',
+      }),
+    );
+
+    emitGatewayProxyTokenFailure({
+      isTerminal: true,
+      reason: 'gateway-proxy-token-invalid',
+      message: LITELLM_INVALID_PROXY_TOKEN,
+    });
+    await flushPromises();
+    await flushPromises();
+
+    emitStatus({ status: 'Thinking…', isRunning: true });
+    onEvent?.({
+      sessionId: SESSION_ID,
+      event: {
+        type: 'error',
+        source: 'claude-code',
+        data: { isTerminal: true, message: 'later error B' },
+      },
+    });
+    expect(makerChatStore.getSnapshot(SESSION_ID).error).toBe('later error B');
+
+    resolvePersist?.('err-persist-A');
+    await flushPromises();
+    await flushPromises();
+
+    onErrorPersisted?.({ sessionId: SESSION_ID, persistId: 'err-persist-A' });
+    expect(makerChatStore.getSnapshot(SESSION_ID).error).toBe('later error B');
+    expect(makerChatStore.getSnapshot(SESSION_ID).errorPersistId).toBeNull();
+  });
+
   it('deferred persist IPC 回执不清后台 live error，要等真实脏信号', async () => {
     vi.mocked(window.electronAPI.modelAccess.retry).mockResolvedValueOnce({
       state: 'failed',

--- a/apps/desktop/src/renderer/__tests__/makerQueueState.test.ts
+++ b/apps/desktop/src/renderer/__tests__/makerQueueState.test.ts
@@ -76,6 +76,8 @@ const state = (overrides: Partial<SessionChatState> = {}): SessionChatState => (
   inputRecovery: null,
   activeTurnRetryText: null,
   errorRetryText: null,
+  errorPersistId: null,
+  disposedErrorPersistId: null,
   credentialSwitchWait: null,
   continuationInFlightClientId: null,
   continuationTurnClientId: null,

--- a/apps/desktop/src/renderer/components/chat/InterruptedTurnBanner.tsx
+++ b/apps/desktop/src/renderer/components/chat/InterruptedTurnBanner.tsx
@@ -151,7 +151,7 @@ export function UnreadFailedScheduleBanner({
 }
 
 /** ErrorBanner 的 retryText 只是显示 Retry 的非空 typed token,onRetry 忽略它。 */
-const ERROR_TAIL_RETRY_TOKEN = '__xdt_error_tail_continue__';
+export const ERROR_TAIL_RETRY_TOKEN = '__xdt_error_tail_continue__';
 
 export function ErrorTailErrorBanner({
   errorText,

--- a/apps/desktop/src/renderer/features/cc-agent/CCAgentSessionView.tsx
+++ b/apps/desktop/src/renderer/features/cc-agent/CCAgentSessionView.tsx
@@ -88,7 +88,6 @@ import {
 } from '@/components/chat/shareSelectionStore';
 import { ErrorBanner } from '@/components/chat/ErrorBanner';
 import {
-  ERROR_TAIL_RETRY_TOKEN,
   ErrorTailErrorBanner,
   InterruptedTurnBanner,
   UnreadFailedScheduleBanner,
@@ -1558,7 +1557,6 @@ export function CCAgentSessionView({
     usageLimitRecovery,
     errorIsRecoverable,
     errorRetryText,
-    errorPersistId,
     disposedErrorPersistId,
     credentialSwitchWait,
     continuationInFlightClientId,
@@ -3569,31 +3567,11 @@ export function CCAgentSessionView({
   // 失败路径则天然保留红点,与仍在展示的横幅一致。
   const handleRetry = useCallback(() => {
     void rebuildClaudeSubscriptionSessionBeforeRetry(errorReason)
-      .then(async () => {
-        if (errorRetryText) {
-          await retryLastError();
-          return;
-        }
-        if (errorPersistId && sessionId) {
-          makerChatStore.disposeLiveErrorPersist(sessionId);
-          await makerChatStore.sendUiTrigger(sessionId, CONTINUE_AFTER_ERROR_PROMPT);
-          clearError();
-          return;
-        }
-        await retryLastError();
-      })
+      .then(() => retryLastError())
       .catch((error) => {
         log.warn('retryLastError failed', error);
       });
-  }, [
-    clearError,
-    errorPersistId,
-    errorReason,
-    errorRetryText,
-    rebuildClaudeSubscriptionSessionBeforeRetry,
-    retryLastError,
-    sessionId,
-  ]);
+  }, [errorReason, rebuildClaudeSubscriptionSessionBeforeRetry, retryLastError]);
 
   const handleSwitchToClaudeSubscription = useCallback(async (): Promise<void> => {
     if (!sessionId || !session || !canSwitchToClaudeSubscription) return;
@@ -4611,7 +4589,7 @@ export function CCAgentSessionView({
                 error={error}
                 errorReason={errorReason}
                 isRecoverable={errorIsRecoverable}
-                retryText={errorRetryText ?? (errorPersistId ? ERROR_TAIL_RETRY_TOKEN : null)}
+                retryText={errorRetryText}
                 onRetry={handleRetry}
                 onSilentStopContinue={handleSilentStopContinue}
                 onContinueAfterUsageReset={

--- a/apps/desktop/src/renderer/features/cc-agent/CCAgentSessionView.tsx
+++ b/apps/desktop/src/renderer/features/cc-agent/CCAgentSessionView.tsx
@@ -88,6 +88,7 @@ import {
 } from '@/components/chat/shareSelectionStore';
 import { ErrorBanner } from '@/components/chat/ErrorBanner';
 import {
+  ERROR_TAIL_RETRY_TOKEN,
   ErrorTailErrorBanner,
   InterruptedTurnBanner,
   UnreadFailedScheduleBanner,
@@ -1557,6 +1558,8 @@ export function CCAgentSessionView({
     usageLimitRecovery,
     errorIsRecoverable,
     errorRetryText,
+    errorPersistId,
+    disposedErrorPersistId,
     credentialSwitchWait,
     continuationInFlightClientId,
     continuationTurnClientId,
@@ -1832,8 +1835,13 @@ export function CCAgentSessionView({
   }, [markCurrentUnreadFailedScheduleRun]);
   const errorTailMsg = useMemo(() => {
     const last = messages.length > 0 ? messages[messages.length - 1] : undefined;
-    return last && last.role === 'error' && !last.errorDismissed ? last : null;
-  }, [messages]);
+    return last &&
+      last.role === 'error' &&
+      !last.errorDismissed &&
+      last.clientId !== disposedErrorPersistId
+      ? last
+      : null;
+  }, [disposedErrorPersistId, messages]);
   // 队列里已有合成续跑项 = 用户已点过继续/重试、只是尚未被接受落库(排队被挡 /
   // 凭证切换等待):视为已推进,banner 抑制(review P2)—— 本地 hidden 态在重挂/
   // 重载后丢失,只看 messages 尾部时旧 error 行仍在,banner 会重现并允许对同一
@@ -3561,11 +3569,31 @@ export function CCAgentSessionView({
   // 失败路径则天然保留红点,与仍在展示的横幅一致。
   const handleRetry = useCallback(() => {
     void rebuildClaudeSubscriptionSessionBeforeRetry(errorReason)
-      .then(() => retryLastError())
+      .then(async () => {
+        if (errorRetryText) {
+          await retryLastError();
+          return;
+        }
+        if (errorPersistId && sessionId) {
+          makerChatStore.disposeLiveErrorPersist(sessionId);
+          await makerChatStore.sendUiTrigger(sessionId, CONTINUE_AFTER_ERROR_PROMPT);
+          clearError();
+          return;
+        }
+        await retryLastError();
+      })
       .catch((error) => {
         log.warn('retryLastError failed', error);
       });
-  }, [errorReason, rebuildClaudeSubscriptionSessionBeforeRetry, retryLastError]);
+  }, [
+    clearError,
+    errorPersistId,
+    errorReason,
+    errorRetryText,
+    rebuildClaudeSubscriptionSessionBeforeRetry,
+    retryLastError,
+    sessionId,
+  ]);
 
   const handleSwitchToClaudeSubscription = useCallback(async (): Promise<void> => {
     if (!sessionId || !session || !canSwitchToClaudeSubscription) return;
@@ -4583,7 +4611,7 @@ export function CCAgentSessionView({
                 error={error}
                 errorReason={errorReason}
                 isRecoverable={errorIsRecoverable}
-                retryText={errorRetryText}
+                retryText={errorRetryText ?? (errorPersistId ? ERROR_TAIL_RETRY_TOKEN : null)}
                 onRetry={handleRetry}
                 onSilentStopContinue={handleSilentStopContinue}
                 onContinueAfterUsageReset={

--- a/apps/desktop/src/renderer/hooks/useCCAgentChat.ts
+++ b/apps/desktop/src/renderer/hooks/useCCAgentChat.ts
@@ -188,6 +188,10 @@ interface UseCCAgentChatReturn {
   errorIsRecoverable: boolean;
   /** Explicit retry target for ErrorBanner; null means retry is unsafe or unavailable. */
   errorRetryText: string | null;
+  /** live 终态错误绑定的持久化 error 行 clientId;无则没有 persist 续跑依据。 */
+  errorPersistId: string | null;
+  /** 本视图已处置的 persistId;尾部横幅跳过,避免同一错误再弹。 */
+  disposedErrorPersistId: string | null;
   /** 凭证切换等待态(main 透传):挡路会话结束后自动重发,渲染等待横幅。 */
   credentialSwitchWait: { clientId?: string; blockedBySessionIds: string[] } | null;
   /** 已离队、正在 coordinator dispatch/turn 边界内的 Continue clientId。 */
@@ -859,6 +863,8 @@ export function useCCAgentChat(
     // ErrorBanner 网络分支据此显示「正在自动重试…」而非「可点击重试」。
     errorIsRecoverable: !lightState.error && lightState.recoverableError != null,
     errorRetryText: lightState.errorRetryText,
+    errorPersistId: lightState.errorPersistId,
+    disposedErrorPersistId: lightState.disposedErrorPersistId,
     credentialSwitchWait: lightState.credentialSwitchWait,
     continuationInFlightClientId: lightState.continuationInFlightClientId,
     continuationTurnClientId: lightState.continuationTurnClientId,

--- a/apps/desktop/src/renderer/lib/errorAlertAck.ts
+++ b/apps/desktop/src/renderer/lib/errorAlertAck.ts
@@ -12,11 +12,10 @@
  * 查询的结果,由 usePendingAlertAttention 的差分收敛清点。本函数服务的是
  * makerChatStore 内存态 live error 那条腿 —— 它没有持久真源可派生,必须显式清。
  *
- * 一个有意的取舍:live ErrorBanner 的「关闭」(handleDismissError → clearError)只清
- * 内存态,**不**把错误行标 dismissed,所以切走再回来会以 ErrorTailErrorBanner 的形式
- * 再次出现。这里仍然清红点 —— 关闭横幅表达的是「我知道了,先不管」,让红点跟着灭
- * 更符合直觉;真要彻底消掉提示,用尾行横幅上的「忽略」(落库)。反之若此时又产生
- * 新的终止错误,useSessionRunningStatus 会重新打点,提醒不会丢。
+ * live ErrorBanner 的「关闭 / 重试」会 dispose 同一 persistId(清内存态并尽快把
+ * 即将/已经落库的 error 行标 dismissed),所以同一视图不会再补弹尾部错误。未点
+ * 就离开再回来,仍可看到持久化卡 —— 点过才算处置。红点仍在关闭时 explicit 清;
+ * 新的终止错误会由 useSessionRunningStatus 重新打点。
  */
 
 import { clearSessionAttention } from './sessionAttentionStore';

--- a/apps/desktop/src/renderer/lib/makerChatStore.ts
+++ b/apps/desktop/src/renderer/lib/makerChatStore.ts
@@ -59,7 +59,7 @@ import {
   isTurnContinuationBoundaryEvent,
 } from '@cindy/maker-shared/turn-continuation';
 import { normalizeAutoTitle } from '@cindy/maker-shared/session-title';
-import type { MessageRole, Message, MessageAutomationOrigin } from '@/lib/ccAgent.types';
+import type { AgentMeta, MessageRole, Message, MessageAutomationOrigin } from '@/lib/ccAgent.types';
 import type { AttachedFile, MentionedResource, SerializedAttachedFile } from '@/lib/fileTypes';
 import type {
   AgentInputCreateOpts,
@@ -3570,6 +3570,8 @@ const _activeViewSessions = new Map<string, number>();
 // On leave, history is invalidated and live error banner is cleared so the
 // reloaded history shows only the persisted ErrorMessageCard.
 const _pendingErrorClearOnLeave = new Set<string>();
+/** Deferred persist IPC in flight: live 横幅点关闭/重试时还没有 persistId,等它回来再 dismiss。 */
+const _deferredTurnErrorPersist = new Map<string, Promise<string | undefined>>();
 
 /** Terminal error 后、配对 done 到达前，凭据刷新必须等 host 空闲。 */
 const GATEWAY_PROXY_TOKEN_TURN_SETTLE_MS = 5_000;
@@ -3625,6 +3627,33 @@ function enterView(sessionId: string): () => void {
   _ensureDemoteTimer();
   scheduleIdlePlanDiscoveryIfNeeded(sessionId);
   return () => leaveView(sessionId);
+}
+
+function persistTurnErrorDeferredTracked(
+  sessionId: string,
+  errData: Record<string, unknown> | null,
+  agentMeta: AgentMeta | null = null,
+): void {
+  let pending: Promise<string | undefined>;
+  pending = makerApiFor(sessionId)
+    .input.persistTurnErrorDeferred(sessionId, errData, agentMeta)
+    .then((persistId) => {
+      if (_deferredTurnErrorPersist.get(sessionId) === pending) {
+        _deferredTurnErrorPersist.delete(sessionId);
+      }
+      if (typeof persistId === 'string' && persistId) {
+        applyErrorPersistedDirtySignal(sessionId, persistId);
+      }
+      return typeof persistId === 'string' && persistId ? persistId : undefined;
+    })
+    .catch((err: unknown) => {
+      if (_deferredTurnErrorPersist.get(sessionId) === pending) {
+        _deferredTurnErrorPersist.delete(sessionId);
+      }
+      log.warn('deferred turn error persist failed', err);
+      return undefined;
+    });
+  _deferredTurnErrorPersist.set(sessionId, pending);
 }
 
 function applyErrorPersistedDirtySignal(sessionId: string, persistId?: string): void {
@@ -4061,10 +4090,10 @@ function applyInputProjection(
         ? s._authRetryPersistOnProjectionError
         : null;
     if (authRetryProjectionError) {
-      void makerApiFor(projection.sessionId).input.persistTurnErrorDeferred(
+      persistTurnErrorDeferredTracked(
         projection.sessionId,
         authRetryProjectionError.data,
-        authRetryProjectionError.agentMeta,
+        (authRetryProjectionError.agentMeta as AgentMeta | null) ?? null,
       );
     }
     // 视觉连续性兜底: sendMessage 在"agent 空闲假设"下会乐观把 user 气泡
@@ -7191,7 +7220,7 @@ function initGlobalListeners(options: GlobalListenerOptions = {}): void {
                 isCindyGatewayProxyTokenInvalid ||
                 (preSnap.remoteHostId && preSnap.agentKind === 'claude-code')
               ) {
-                void makerApiFor(sessionId).input.persistTurnErrorDeferred(
+                persistTurnErrorDeferredTracked(
                   sessionId,
                   event.data as Record<string, unknown> | null,
                   event.agentMeta ?? null,
@@ -7230,7 +7259,7 @@ function initGlobalListeners(options: GlobalListenerOptions = {}): void {
           (isAuthError && preSnap.remoteHostId && preSnap.agentKind === 'claude-code')) &&
         !preSnap._authRetryInFlight
       ) {
-        void makerApiFor(sessionId).input.persistTurnErrorDeferred(
+        persistTurnErrorDeferredTracked(
           sessionId,
           event.data as Record<string, unknown> | null,
           event.agentMeta ?? null,
@@ -8533,6 +8562,7 @@ function __teardownGlobalListeners(): void {
   pendingDeferredStateNotifications.clear();
   pendingMessageCreatedPatches.clear();
   _pendingErrorClearOnLeave.clear();
+  _deferredTurnErrorPersist.clear();
   remotePresenceOnlineByDevice.clear();
   resetRemoteDataOwnerPushFence();
   const remoteOptimisticSessionIds = new Set([
@@ -13402,11 +13432,22 @@ function popQueueTail(sessionId: string): boolean {
  */
 function disposeLiveErrorPersist(sessionId: string): void {
   const persistId = sessions.get(sessionId)?.errorPersistId;
-  if (!persistId) return;
-  setState(sessionId, (s) =>
-    s.disposedErrorPersistId === persistId ? s : { ...s, disposedErrorPersistId: persistId },
-  );
-  void dismissErrorTailMessage(sessionId, persistId);
+  if (persistId) {
+    setState(sessionId, (s) =>
+      s.disposedErrorPersistId === persistId ? s : { ...s, disposedErrorPersistId: persistId },
+    );
+    void dismissErrorTailMessage(sessionId, persistId);
+    return;
+  }
+  const pending = _deferredTurnErrorPersist.get(sessionId);
+  if (!pending) return;
+  void pending.then((id) => {
+    if (!id) return;
+    setState(sessionId, (s) =>
+      s.disposedErrorPersistId === id ? s : { ...s, disposedErrorPersistId: id },
+    );
+    void dismissErrorTailMessage(sessionId, id);
+  });
 }
 
 /**

--- a/apps/desktop/src/renderer/lib/makerChatStore.ts
+++ b/apps/desktop/src/renderer/lib/makerChatStore.ts
@@ -2402,7 +2402,9 @@ export interface SessionChatState {
   errorRetryText: string | null;
   /**
    * 当前 live 终态错误预留的持久化 error 行 clientId。广播 payload.persistId
-   * 写入;无可靠恢复依据(计划内升级关闭 / 自愈压住)时为 null。
+   * 写入;无可靠恢复依据(计划内升级关闭 / 自愈压住)时为 null。同一 turn 的重复
+   * 终态 error 往往因 main dedup 不再带 persistId,缺失时必须保留已有绑定,
+   * 否则点关闭/重试无法 dismiss 即将落库的那一行。
    */
   errorPersistId: string | null;
   /**
@@ -5623,10 +5625,15 @@ export function handleStreamEvent(
           isPlannedUpgradeClose || suppressAutoResumeBroadcastError ? null : (reason ?? null),
         recoverableError: null,
         errorRetryText: derivedRetryText ?? preservedRetryText,
+        // persistId 只绑定即将落库的 error 行,不是重试依据。新事件带来非空 id
+        // 时更新绑定;同一 turn 重复终态 error 常因 main dedup 不再带 persistId,
+        // 缺失时保留已有绑定,避免关掉/重试后无法 dismiss 已预留的那一行。
         errorPersistId:
           isPlannedUpgradeClose || suppressAutoResumeBroadcastError
             ? null
-            : (event.persistId ?? null),
+            : (typeof event.persistId === 'string' && event.persistId
+                ? event.persistId
+                : state.errorPersistId),
         isStreaming: false,
         activeTurnRetryText: null,
         continuationTurnClientId: null,

--- a/apps/desktop/src/renderer/lib/makerChatStore.ts
+++ b/apps/desktop/src/renderer/lib/makerChatStore.ts
@@ -3389,6 +3389,10 @@ function _purgeSession(sessionId: string): void {
   _cacheHydrateSuppressed.delete(sessionId);
   _lastViewedAt.delete(sessionId);
   _lastInboundEventAt.delete(sessionId);
+  _pendingErrorClearOnLeave.delete(sessionId);
+  _deferredTurnErrorPersist.delete(sessionId);
+  _liveErrorEpoch.delete(sessionId);
+  _staleDeferredErrorPersistIds.delete(sessionId);
   const i = _accessOrder.indexOf(sessionId);
   if (i !== -1) _accessOrder.splice(i, 1);
 }
@@ -3572,6 +3576,16 @@ const _activeViewSessions = new Map<string, number>();
 const _pendingErrorClearOnLeave = new Set<string>();
 /** Deferred persist IPC in flight: live 横幅点关闭/重试时还没有 persistId,等它回来再 dismiss。 */
 const _deferredTurnErrorPersist = new Map<string, Promise<string | undefined>>();
+/**
+ * 当前 live 终态错误的代次。error 从有到无、从无到有、或换成另一条文案时 +1。
+ * 迟到的 deferred IPC / 脏信号必须对上这一代,才能绑 persistId 或清 live 横幅。
+ */
+const _liveErrorEpoch = new Map<string, number>();
+/**
+ * 本窗口 deferred IPC 带回、但已对不上当前代次的 persistId。
+ * 脏信号不带 renderer epoch(跨窗口对不上),用这份名单拒绝把 A 绑到 B。
+ */
+const _staleDeferredErrorPersistIds = new Map<string, Set<string>>();
 
 /** Terminal error 后、配对 done 到达前，凭据刷新必须等 host 空闲。 */
 const GATEWAY_PROXY_TOKEN_TURN_SETTLE_MS = 5_000;
@@ -3634,6 +3648,8 @@ function persistTurnErrorDeferredTracked(
   errData: Record<string, unknown> | null,
   agentMeta: AgentMeta | null = null,
 ): void {
+  // 必须在 live error 已经 setState 之后调用,这样抓到的是这一代横幅的 epoch。
+  const epoch = _liveErrorEpoch.get(sessionId) ?? 0;
   let pending: Promise<string | undefined>;
   pending = makerApiFor(sessionId)
     .input.persistTurnErrorDeferred(sessionId, errData, agentMeta)
@@ -3642,7 +3658,15 @@ function persistTurnErrorDeferredTracked(
       // IPC 回执只表示已入队并登记了 persistId,不是 createMessage 成功。
       // 先绑定身份再摘掉 pending,点关闭/重试才能 dismiss 同一行;
       // 历史失效与后台清 live 仍等 local-db:session:error-persisted。
-      if (id) bindLiveErrorPersistId(sessionId, id);
+      // 代次已变(用户已进入下一轮横幅)则丢弃,避免把 A 的 id 绑到 B。
+      if (id) {
+        if ((_liveErrorEpoch.get(sessionId) ?? 0) !== epoch) {
+          const stale = _staleDeferredErrorPersistIds.get(sessionId) ?? new Set();
+          stale.add(id);
+          _staleDeferredErrorPersistIds.set(sessionId, stale);
+        }
+        bindLiveErrorPersistId(sessionId, id, epoch);
+      }
       if (_deferredTurnErrorPersist.get(sessionId) === pending) {
         _deferredTurnErrorPersist.delete(sessionId);
       }
@@ -3658,9 +3682,10 @@ function persistTurnErrorDeferredTracked(
   _deferredTurnErrorPersist.set(sessionId, pending);
 }
 
-function bindLiveErrorPersistId(sessionId: string, persistId: string): void {
+function bindLiveErrorPersistId(sessionId: string, persistId: string, epoch?: number): void {
   const state = sessions.get(sessionId);
   if (!state?.error || state.errorPersistId) return;
+  if (epoch !== undefined && (_liveErrorEpoch.get(sessionId) ?? 0) !== epoch) return;
   setState(sessionId, (s) => ({
     ...s,
     errorPersistId: s.error && !s.errorPersistId ? persistId : s.errorPersistId,
@@ -3670,12 +3695,30 @@ function bindLiveErrorPersistId(sessionId: string, persistId: string): void {
 function applyErrorPersistedDirtySignal(sessionId: string, persistId?: string): void {
   const state = sessions.get(sessionId);
   if (!state) return;
+  if (
+    persistId &&
+    !state.errorPersistId &&
+    state.error &&
+    !_deferredTurnErrorPersist.has(sessionId) &&
+    !_staleDeferredErrorPersistIds.get(sessionId)?.has(persistId)
+  ) {
+    // 本窗口没有 in-flight deferred(设备互联控制端只收到脏信号):绑到当前未绑定横幅。
+    // 本窗口刚拒绝过的迟到 persistId 不算控制端信号,不能绑到下一轮错误。
+    bindLiveErrorPersistId(sessionId, persistId);
+  }
+  const latest = sessions.get(sessionId) ?? state;
+  if (persistId && latest.errorPersistId !== persistId) {
+    // 上一轮错误的写成功:不能绑到或清掉当前横幅。历史仍可能因那一行落库而脏。
+    if (!_activeViewSessions.has(sessionId) && latest.historyLoaded) {
+      setState(sessionId, (s) => (s.historyLoaded ? { ...s, historyLoaded: false } : s));
+    }
+    return;
+  }
   if (_activeViewSessions.has(sessionId)) {
     // Keep live banner during active view; invalidate + clear on leave so the
     // persisted card can appear the next time the user enters without having
     // clicked. Click (retry/close) is what disposes — leave does not.
     _pendingErrorClearOnLeave.add(sessionId);
-    if (persistId) bindLiveErrorPersistId(sessionId, persistId);
     return;
   }
   setState(sessionId, (s) => ({
@@ -3777,6 +3820,9 @@ function setState(
   const prev = getOrCreateState(sessionId);
   const next = updater(prev);
   if (next === prev) return;
+  if (prev.error !== next.error) {
+    _liveErrorEpoch.set(sessionId, (_liveErrorEpoch.get(sessionId) ?? 0) + 1);
+  }
   const previousIssueRequestId = prev.pendingIssueConfirm?.requestId;
   if (previousIssueRequestId && next.pendingIssueConfirm?.requestId !== previousIssueRequestId) {
     clearIssueConfirmDraft(sessionId, previousIssueRequestId);
@@ -4038,6 +4084,12 @@ function applyInputProjection(
     }
   }
   let settlingClientIds: string[] = [];
+  const deferredPersistFromProjection: {
+    payload: {
+      data: Record<string, unknown> | null;
+      agentMeta: Record<string, unknown> | null;
+    } | null;
+  } = { payload: null };
   setState(projection.sessionId, (s) => {
     // DB created 可能先于 projection 回来；正式消息已经占据 transcript 的同一
     // clientId 位置时，不要让稍晚的旧 pendingQueue 再造一行重复队列项。
@@ -4096,11 +4148,11 @@ function applyInputProjection(
         ? s._authRetryPersistOnProjectionError
         : null;
     if (authRetryProjectionError) {
-      persistTurnErrorDeferredTracked(
-        projection.sessionId,
-        authRetryProjectionError.data,
-        (authRetryProjectionError.agentMeta as AgentMeta | null) ?? null,
-      );
+      // 等这次 setState 把 live error 装上并 bump epoch 后再 persist,否则抓到的是上一代。
+      deferredPersistFromProjection.payload = {
+        data: authRetryProjectionError.data,
+        agentMeta: authRetryProjectionError.agentMeta,
+      };
     }
     // 视觉连续性兜底: sendMessage 在"agent 空闲假设"下会乐观把 user 气泡
     // (isPendingPersist) 提前 push 进 messages。如果某条乐观气泡的 clientId 仍停在
@@ -4205,6 +4257,13 @@ function applyInputProjection(
       ...(authRetryProjectionError ? { _authRetryPersistOnProjectionError: undefined } : {}),
     };
   });
+  if (deferredPersistFromProjection.payload) {
+    persistTurnErrorDeferredTracked(
+      projection.sessionId,
+      deferredPersistFromProjection.payload.data,
+      (deferredPersistFromProjection.payload.agentMeta as AgentMeta | null) ?? null,
+    );
+  }
   for (const clientId of settlingClientIds) {
     scheduleRemoteOptimisticSettlingRetirement(projection.sessionId, clientId);
   }
@@ -7054,6 +7113,7 @@ function initGlobalListeners(options: GlobalListenerOptions = {}): void {
     // CCAgentStreamEvent.agentMeta 让 handleStreamEvent 落库 messages.agent_meta 行,
     // fork / rewind 反向找 prior assistant 锚点要靠这个字段。
     // Legacy CC/XD remote auth-retry: 在 reducer 写 error 之前拦截,避免 error banner 闪烁。
+    let persistDeferredAfterDispatch = false;
     if (event.type === 'error') {
       const errData =
         (event.data as {
@@ -7222,6 +7282,13 @@ function initGlobalListeners(options: GlobalListenerOptions = {}): void {
               }
             } catch {
               if (!isDataOwnerGenerationCurrent(dataOwnerAtIngress)) return;
+              const terminalErrorEvent = {
+                sessionId,
+                type: 'error',
+                data: event.data,
+              } as CCAgentStreamEvent;
+              supersedeInputProjectionOnTerminalEvent(sessionId, terminalErrorEvent);
+              setState(sessionId, (s) => handleStreamEvent(s, terminalErrorEvent));
               if (
                 isCindyGatewayProxyTokenInvalid ||
                 (preSnap.remoteHostId && preSnap.agentKind === 'claude-code')
@@ -7232,13 +7299,6 @@ function initGlobalListeners(options: GlobalListenerOptions = {}): void {
                   event.agentMeta ?? null,
                 );
               }
-              const terminalErrorEvent = {
-                sessionId,
-                type: 'error',
-                data: event.data,
-              } as CCAgentStreamEvent;
-              supersedeInputProjectionOnTerminalEvent(sessionId, terminalErrorEvent);
-              setState(sessionId, (s) => handleStreamEvent(s, terminalErrorEvent));
             } finally {
               if (isDataOwnerGenerationCurrent(dataOwnerAtIngress)) {
                 setState(sessionId, (s) => ({ ...s, _authRetryInFlight: false }));
@@ -7265,15 +7325,18 @@ function initGlobalListeners(options: GlobalListenerOptions = {}): void {
           (isAuthError && preSnap.remoteHostId && preSnap.agentKind === 'claude-code')) &&
         !preSnap._authRetryInFlight
       ) {
-        persistTurnErrorDeferredTracked(
-          sessionId,
-          event.data as Record<string, unknown> | null,
-          event.agentMeta ?? null,
-        );
+        persistDeferredAfterDispatch = true;
       }
     }
 
     dispatchStreamEventPayload(sessionId, event, persistId, resolvedContent, deferNotification);
+    if (persistDeferredAfterDispatch) {
+      persistTurnErrorDeferredTracked(
+        sessionId,
+        event.data as Record<string, unknown> | null,
+        event.agentMeta ?? null,
+      );
+    }
 
     // done / error 副作用 (从老 stream listener 搬过来)
     if (isProductTurnDoneEvent(event)) {
@@ -8569,6 +8632,8 @@ function __teardownGlobalListeners(): void {
   pendingMessageCreatedPatches.clear();
   _pendingErrorClearOnLeave.clear();
   _deferredTurnErrorPersist.clear();
+  _liveErrorEpoch.clear();
+  _staleDeferredErrorPersistIds.clear();
   remotePresenceOnlineByDevice.clear();
   resetRemoteDataOwnerPushFence();
   const remoteOptimisticSessionIds = new Set([

--- a/apps/desktop/src/renderer/lib/makerChatStore.ts
+++ b/apps/desktop/src/renderer/lib/makerChatStore.ts
@@ -2401,6 +2401,16 @@ export interface SessionChatState {
    */
   errorRetryText: string | null;
   /**
+   * 当前 live 终态错误预留的持久化 error 行 clientId。广播 payload.persistId
+   * 写入;无可靠恢复依据(计划内升级关闭 / 自愈压住)时为 null。
+   */
+  errorPersistId: string | null;
+  /**
+   * 本视图已对这次 live 错误点过重试或关闭。尾部横幅跳过该 id,避免同一错误再弹。
+   * 离开视图不清这个字段——点过才算处置;未点就离开,回来仍应看到持久化卡。
+   */
+  disposedErrorPersistId: string | null;
+  /**
    * 凭证切换等待态(main projection 透传):发送需重启共享 codex 进程,被列出的
    * 会话挡住;队首保留、结束后 main 自动重发。渲染为等待横幅(非错误)。
    */
@@ -2677,6 +2687,8 @@ export type SessionChatLightState = Pick<
   | 'errorReason'
   | 'recoverableError'
   | 'errorRetryText'
+  | 'errorPersistId'
+  | 'disposedErrorPersistId'
   | 'credentialSwitchWait'
   | 'continuationInFlightClientId'
   | 'continuationTurnClientId'
@@ -2737,6 +2749,8 @@ function createInitialState(): SessionChatState {
     inputRecovery: null,
     activeTurnRetryText: null,
     errorRetryText: null,
+    errorPersistId: null,
+    disposedErrorPersistId: null,
     credentialSwitchWait: null,
     continuationInFlightClientId: null,
     continuationTurnClientId: null,
@@ -2812,6 +2826,8 @@ export const EMPTY_SESSION_STATE: SessionChatState = Object.freeze({
   inputRecovery: null,
   activeTurnRetryText: null,
   errorRetryText: null,
+  errorPersistId: null,
+  disposedErrorPersistId: null,
   credentialSwitchWait: null,
   continuationInFlightClientId: null,
   continuationTurnClientId: null,
@@ -3609,6 +3625,31 @@ function enterView(sessionId: string): () => void {
   return () => leaveView(sessionId);
 }
 
+function applyErrorPersistedDirtySignal(sessionId: string, persistId?: string): void {
+  const state = sessions.get(sessionId);
+  if (!state) return;
+  if (_activeViewSessions.has(sessionId)) {
+    // Keep live banner during active view; invalidate + clear on leave so the
+    // persisted card can appear the next time the user enters without having
+    // clicked. Click (retry/close) is what disposes — leave does not.
+    _pendingErrorClearOnLeave.add(sessionId);
+    if (persistId && state.error && !state.errorPersistId) {
+      setState(sessionId, (s) => ({
+        ...s,
+        errorPersistId: s.error && !s.errorPersistId ? persistId : s.errorPersistId,
+      }));
+    }
+    return;
+  }
+  setState(sessionId, (s) => ({
+    ...s,
+    ...(s.historyLoaded ? { historyLoaded: false } : {}),
+    ...(s.error
+      ? { error: null, usageLimitRecovery: null, errorRetryText: null, errorPersistId: null }
+      : {}),
+  }));
+}
+
 function leaveView(sessionId: string): void {
   const count = _activeViewSessions.get(sessionId);
   if (!count) return;
@@ -3625,7 +3666,9 @@ function leaveView(sessionId: string): void {
     setState(sessionId, (s) => ({
       ...s,
       ...(s.historyLoaded ? { historyLoaded: false } : {}),
-      ...(s.error ? { error: null, usageLimitRecovery: null, errorRetryText: null } : {}),
+      ...(s.error
+        ? { error: null, usageLimitRecovery: null, errorRetryText: null, errorPersistId: null }
+        : {}),
     }));
   }
   _trimMessagesIfNeeded(sessionId);
@@ -4114,6 +4157,7 @@ function applyInputProjection(
       recoverableError:
         projection.error || projection.credentialSwitchWait ? null : s.recoverableError,
       errorRetryText: projection.errorRetryText,
+      errorPersistId: projection.error ? s.errorPersistId : null,
       credentialSwitchWait: projection.credentialSwitchWait ?? null,
       continuationInFlightClientId: projection.continuationInFlightClientId ?? null,
       continuationTurnClientId: projectedContinuationTurnClientId,
@@ -5497,6 +5541,7 @@ export function handleStreamEvent(
             errorReason: null,
             recoverableError: null,
             errorRetryText: null,
+            errorPersistId: null,
             isStreaming: hasAutoResumePendingCard ? state.isStreaming : true,
             agentStatus: {
               ...(hasAutoResumePendingCard
@@ -5520,6 +5565,7 @@ export function handleStreamEvent(
           errorReason: reason ?? null,
           recoverableError: errMsg,
           errorRetryText: null,
+          errorPersistId: null,
           isStreaming: true,
           agentStatus: {
             ...state.agentStatus,
@@ -5577,6 +5623,10 @@ export function handleStreamEvent(
           isPlannedUpgradeClose || suppressAutoResumeBroadcastError ? null : (reason ?? null),
         recoverableError: null,
         errorRetryText: derivedRetryText ?? preservedRetryText,
+        errorPersistId:
+          isPlannedUpgradeClose || suppressAutoResumeBroadcastError
+            ? null
+            : (event.persistId ?? null),
         isStreaming: false,
         activeTurnRetryText: null,
         continuationTurnClientId: null,
@@ -6042,6 +6092,7 @@ function forceFinalizeOnSessionClosed(state: SessionChatState): SessionChatState
     recoverableError: null,
     activeTurnRetryText: null,
     errorRetryText: null,
+    errorPersistId: null,
     pendingPermission: null,
     pendingAskUser: null,
     pendingPluginSetup: null,
@@ -6292,6 +6343,7 @@ function handleStatusUpdate(
     usageLimitRecovery: isTurnStart ? null : state.usageLimitRecovery,
     errorReason: isTurnStart ? null : state.errorReason,
     errorRetryText: isTurnStart || (isTurnComplete && !state.error) ? null : state.errorRetryText,
+    errorPersistId: isTurnStart ? null : state.errorPersistId,
     recoverableError: isTurnComplete ? null : state.recoverableError,
     isStreaming: update.isRunning
       ? true
@@ -8009,24 +8061,12 @@ function initGlobalListeners(options: GlobalListenerOptions = {}): void {
           // 被控端 terminal error 落库脏信号 → 让控制端已加载历史的远程会话同样失效,
           // 下次用户打开该会话时从被控端重拉,error 卡得以正常出现。
           // 当前正在被查看的会话:保留 live ErrorBanner 不干扰,但登记 pending,离开时再清。
-          const ep = push.payload as { sessionId?: string } | null;
+          const ep = push.payload as { sessionId?: string; persistId?: string } | null;
           if (ep?.sessionId) {
-            const epState = sessions.get(ep.sessionId);
-            if (epState) {
-              if (_activeViewSessions.has(ep.sessionId)) {
-                // Keep live banner; register pending so the error card appears on leave.
-                // Mirrors the local onErrorPersisted path including the streaming case.
-                _pendingErrorClearOnLeave.add(ep.sessionId);
-              } else {
-                setState(ep.sessionId, (s) => ({
-                  ...s,
-                  ...(s.historyLoaded ? { historyLoaded: false } : {}),
-                  ...(s.error
-                    ? { error: null, usageLimitRecovery: null, errorRetryText: null }
-                    : {}),
-                }));
-              }
-            }
+            applyErrorPersistedDirtySignal(
+              ep.sessionId,
+              typeof ep.persistId === 'string' ? ep.persistId : undefined,
+            );
           }
           break;
         }
@@ -8196,26 +8236,12 @@ function initGlobalListeners(options: GlobalListenerOptions = {}): void {
       ) {
         return;
       }
-      const p = raw as { sessionId?: string } | null;
+      const p = raw as { sessionId?: string; persistId?: string } | null;
       if (!p?.sessionId) return;
-      const state = sessions.get(p.sessionId);
-      if (!state) return;
-      if (_activeViewSessions.has(p.sessionId)) {
-        // Keep live banner during active view (or when a follow-up turn is streaming
-        // in the active view); invalidate + clear on leave so the ErrorMessageCard
-        // appears the next time the user enters the session.
-        _pendingErrorClearOnLeave.add(p.sessionId);
-        return;
-      }
-      // Background session (not in active view), possibly streaming a follow-up turn.
-      // ensureInitialMessages guards against mid-stream reload, so marking
-      // historyLoaded=false here is safe; the error card will surface when the user
-      // opens the session after the current turn finishes.
-      setState(p.sessionId, (s) => ({
-        ...s,
-        ...(s.historyLoaded ? { historyLoaded: false } : {}),
-        ...(s.error ? { error: null, usageLimitRecovery: null, errorRetryText: null } : {}),
-      }));
+      applyErrorPersistedDirtySignal(
+        p.sessionId,
+        typeof p.persistId === 'string' ? p.persistId : undefined,
+      );
     },
     'local-db-session-error-persisted',
   );
@@ -8561,6 +8587,8 @@ function selectLightState(state: SessionChatState): SessionChatLightState {
     errorReason: state.errorReason,
     recoverableError: state.recoverableError,
     errorRetryText: state.errorRetryText,
+    errorPersistId: state.errorPersistId,
+    disposedErrorPersistId: state.disposedErrorPersistId,
     credentialSwitchWait: state.credentialSwitchWait,
     continuationInFlightClientId: state.continuationInFlightClientId,
     continuationTurnClientId: state.continuationTurnClientId,
@@ -8606,6 +8634,8 @@ function lightStateEquals(a: SessionChatLightState, b: SessionChatLightState): b
     a.errorReason === b.errorReason &&
     a.recoverableError === b.recoverableError &&
     a.errorRetryText === b.errorRetryText &&
+    a.errorPersistId === b.errorPersistId &&
+    a.disposedErrorPersistId === b.disposedErrorPersistId &&
     a.credentialSwitchWait === b.credentialSwitchWait &&
     a.continuationInFlightClientId === b.continuationInFlightClientId &&
     a.continuationTurnClientId === b.continuationTurnClientId &&
@@ -13360,10 +13390,25 @@ function popQueueTail(sessionId: string): boolean {
 }
 
 /**
- * Dismiss the error banner without retrying. Pure UI state — no persistence.
+ * 用户点了 live 横幅的重试或关闭:这次错误算已处置。尾部横幅跳过同一 persistId,
+ * 并尽快把即将/已经落库的 error 行标 dismissed。离开视图不会走这里。
+ */
+function disposeLiveErrorPersist(sessionId: string): void {
+  const persistId = sessions.get(sessionId)?.errorPersistId;
+  if (!persistId) return;
+  setState(sessionId, (s) =>
+    s.disposedErrorPersistId === persistId ? s : { ...s, disposedErrorPersistId: persistId },
+  );
+  void dismissErrorTailMessage(sessionId, persistId);
+}
+
+/**
+ * Dismiss the error banner without retrying. Also disposes the bound persist row
+ * so the same error does not reappear as a tail banner in this view.
  */
 function clearError(sessionId: string): void {
   if (!sessionId) return;
+  disposeLiveErrorPersist(sessionId);
   const boundaryOpts = getRemoteInputClearBoundaryOpts(sessionId);
   runInputProjectionOperation(sessionId, (input) =>
     boundaryOpts ? input.clearError(sessionId, boundaryOpts) : input.clearError(sessionId),
@@ -13373,7 +13418,8 @@ function clearError(sessionId: string): void {
       s.error == null &&
       s.usageLimitRecovery == null &&
       s.recoverableError == null &&
-      s.errorRetryText == null
+      s.errorRetryText == null &&
+      s.errorPersistId == null
     ) {
       return s;
     }
@@ -13384,12 +13430,14 @@ function clearError(sessionId: string): void {
       errorReason: null,
       recoverableError: null,
       errorRetryText: null,
+      errorPersistId: null,
     };
   });
 }
 
 function retryLastError(sessionId: string): Promise<void> {
   if (!sessionId) return Promise.resolve();
+  disposeLiveErrorPersist(sessionId);
   // 续跑语义在 main:coordinator 判定失败 turn 已有 assistant 产出时,用共享英文
   // 常量 CONTINUE_AFTER_ERROR_PROMPT 替代重发原文(shared/interruptedTurn.ts),
   // renderer 不传文案、不做判定。
@@ -13507,6 +13555,7 @@ function retryLastError(sessionId: string): Promise<void> {
  */
 function continueAfterSilentStop(sessionId: string): void {
   if (!sessionId) return;
+  disposeLiveErrorPersist(sessionId);
   void sendUiTrigger(sessionId, CONTINUE_AFTER_ERROR_PROMPT).then(
     () => {
       setState(sessionId, (s) => ({
@@ -13515,6 +13564,7 @@ function continueAfterSilentStop(sessionId: string): void {
         usageLimitRecovery: null,
         errorReason: null,
         errorRetryText: null,
+        errorPersistId: null,
       }));
     },
     (err) => {
@@ -15116,6 +15166,8 @@ export const makerChatStore = {
   clearSession,
   /** Dismiss the error banner without retrying. */
   clearError,
+  /** Bind live error to persist row as already handled (retry/close). */
+  disposeLiveErrorPersist,
   /** Retry the typed recovery target owned by main coordinator. */
   retryLastError,
   /** silent-stop 耗尽横幅「继续」:清横幅 + 隐藏续跑指令(见函数注释)。 */

--- a/apps/desktop/src/renderer/lib/makerChatStore.ts
+++ b/apps/desktop/src/renderer/lib/makerChatStore.ts
@@ -3638,13 +3638,15 @@ function persistTurnErrorDeferredTracked(
   pending = makerApiFor(sessionId)
     .input.persistTurnErrorDeferred(sessionId, errData, agentMeta)
     .then((persistId) => {
+      const id = typeof persistId === 'string' && persistId ? persistId : undefined;
+      // IPC 回执只表示已入队并登记了 persistId,不是 createMessage 成功。
+      // 先绑定身份再摘掉 pending,点关闭/重试才能 dismiss 同一行;
+      // 历史失效与后台清 live 仍等 local-db:session:error-persisted。
+      if (id) bindLiveErrorPersistId(sessionId, id);
       if (_deferredTurnErrorPersist.get(sessionId) === pending) {
         _deferredTurnErrorPersist.delete(sessionId);
       }
-      if (typeof persistId === 'string' && persistId) {
-        applyErrorPersistedDirtySignal(sessionId, persistId);
-      }
-      return typeof persistId === 'string' && persistId ? persistId : undefined;
+      return id;
     })
     .catch((err: unknown) => {
       if (_deferredTurnErrorPersist.get(sessionId) === pending) {
@@ -3656,6 +3658,15 @@ function persistTurnErrorDeferredTracked(
   _deferredTurnErrorPersist.set(sessionId, pending);
 }
 
+function bindLiveErrorPersistId(sessionId: string, persistId: string): void {
+  const state = sessions.get(sessionId);
+  if (!state?.error || state.errorPersistId) return;
+  setState(sessionId, (s) => ({
+    ...s,
+    errorPersistId: s.error && !s.errorPersistId ? persistId : s.errorPersistId,
+  }));
+}
+
 function applyErrorPersistedDirtySignal(sessionId: string, persistId?: string): void {
   const state = sessions.get(sessionId);
   if (!state) return;
@@ -3664,12 +3675,7 @@ function applyErrorPersistedDirtySignal(sessionId: string, persistId?: string): 
     // persisted card can appear the next time the user enters without having
     // clicked. Click (retry/close) is what disposes — leave does not.
     _pendingErrorClearOnLeave.add(sessionId);
-    if (persistId && state.error && !state.errorPersistId) {
-      setState(sessionId, (s) => ({
-        ...s,
-        errorPersistId: s.error && !s.errorPersistId ? persistId : s.errorPersistId,
-      }));
-    }
+    if (persistId) bindLiveErrorPersistId(sessionId, persistId);
     return;
   }
   setState(sessionId, (s) => ({

--- a/apps/desktop/src/renderer/vite-env.d.ts
+++ b/apps/desktop/src/renderer/vite-env.d.ts
@@ -715,7 +715,8 @@ interface CCAgentStreamEvent {
    * F1-a: 由 main 端 messagePersistBroadcaster 为这条消息分配的稳定 persistId,
    * 经 maker:event payload 透传。renderer 用它当在途气泡 clientId(不再自造随机),
    * 让 main 落库后的 onCreated(同 id)命中 dedup,把在途气泡替换为权威行而非新增。
-   * Phase 2 仅对 assistant 'text' 事件下发;其它类型暂为 undefined。
+   * assistant 'text' 与终止型 error 都会下发(error 为广播前预留的 persistId);
+   * 其它类型暂为 undefined。
    */
   persistId?: string;
   /**

--- a/apps/desktop/src/renderer/vite-env.d.ts
+++ b/apps/desktop/src/renderer/vite-env.d.ts
@@ -5413,7 +5413,7 @@ interface ElectronAPI {
         sessionId: string,
         errData: Record<string, unknown> | null,
         agentMeta?: import('@/lib/ccAgent.types').AgentMeta | null,
-      ) => Promise<void>;
+      ) => Promise<string | undefined>;
       remove: (
         sessionId: string,
         clientId: string,


### PR DESCRIPTION
## 这次改了什么

### 摘要

同一次终态错误以前会先弹内存里的红框，关掉后再弹一次持久化尾部错误，等于关一次再点一次。这次按 2026-08-18 口径把 live 横幅和持久化 error 行用同一个 `persistId` 绑在一起：第一个横幅在有可靠恢复依据时直接提供「重试」；点重试或关闭后不再补弹尾部；没有可靠恢复依据时不显示 Retry。持久化横幅只用于重启后恢复，以及未点就离开、回来后仍能看到的那张卡。

### 变更类型

- [ ] `feat` 新功能
- [x] `fix` 缺陷修复
- [ ] `refactor` / `perf` 重构或性能优化
- [ ] `docs` / `test` / `chore` 文档、测试或工程维护
- [ ] 其他：

### 范围

- 关联 Issue / 需求：2026-08-18 飞书产品口径（同一次终态错误只弹一次；第一个横幅可安全重试）
- 本 PR 包含：Desktop live ErrorBanner 与持久化 error 行的 persistId 绑定；广播前预留 id（不破坏 maker 热路径时序）；落库前点关闭/重试先等写队列；点过重试即视为已处置。live Retry 只走 `retryLastError`（`persistId` 不是恢复依据，不直接发 CONTINUE）
- 明确不包含：Mobile；不改 `projectionRetryText`；不另造重发。有产出续跑与尾部横幅仍复用 `CONTINUE_AFTER_ERROR_PROMPT` / `sendUiTrigger`
- 用户可见变化：Desktop 终态错误只弹一次；第一个横幅在可恢复时显示「重试」；点过关闭/重试后同一视图不再补弹尾部错误
- 是否存在 breaking change：无
- 远程 / 手机版（三选一）：本 PR desktop-first，未在同一 PR 内一并适配手机版。
  1. SSH 远程工作区：不改 workdir / agent 执行位置，错误横幅仍在本机 Desktop 会话视图。
  2. 设备互联：`local-db:session:error-persisted` 已在 device-link allowlist；payload 只 additive 增加 `persistId`，旧控制端忽略该字段仍可按 `sessionId` 失效历史。
  3. 手机版：独立 `sessionTailBannerModel`，本 PR 不改。

### UI 变化

复用既有 `ErrorBanner` / `ErrorTailErrorBanner`，不新造横幅、不改配色/间距/文案。交互变化：同一次终态错误只弹一次；有可靠恢复依据时第一个横幅提供「重试」；点过不再补弹尾部。

- 引用的设计规范：`docs/design-rules/DESIGN.md` 双模式交付门槛（颜色走语义 token，不硬编码单模式）。本次只复用既有错误横幅组件与既有「重试 / 关闭」操作，不新增视觉样式。

## 怎么验证的

### 自动验证

```text
cd /Users/dash/Code/Cindy/cindy-fix-first-error-retry
pnpm test:unit:related
结果：PASS apps/desktop unit（首提 41.6s；42cb46d45 后 39.7s）

pnpm --filter desktop run --if-present typecheck
结果：tsc --noEmit 通过

/Users/dash/Code/XD/dash/Skills/git/scripts/run-unit-gate.sh <worktree>
结果：FAIL apps/mobile unit — `startupSplashOverlay.test.ts` 在 5000ms 超时（生成 Android splash icon）。
该失败与本 PR diff 无关：同一用例在干净 origin/main（a488c999e，无本改动）上同样 5000ms 超时。不混入修复，交 CI 给权威结论。
```

### 手工验证

未在运行中的 Desktop 实例目检。Worktree 改动不会热更新到宿主 app；提交后请在 Desktop 上复现：触发一次终态错误 → 第一个红框应能直接重试 → 点重试或关闭后同一视图不应再弹尾部错误 → 未点就切走再回来仍应看到持久化卡。

### 未执行的验证

- Mobile 本地验证：本 PR 不改 mobile。
- Desktop 实机双模式目检：未跑。

## 风险

### 风险分类

- [ ] 无已知风险
- [ ] SQLite / migration
- [ ] system prompt
- [x] 协议兼容
- [ ] 权限 / 安全 / 用户数据
- [ ] 存量插件兼容（批准状态 / 指纹 / manifest 校验 / 安装布局 / 包格式）
- [ ] 原生层 / fingerprint / OTA
- [ ] 跨平台差异
- [ ] 其他：

### 影响与回滚

- 影响范围：Desktop 终态错误横幅与 error 行持久化绑定；`local-db:session:error-persisted` payload 增加可选 `persistId`（additive）。无 schema / migration。maker 热路径仍先广播 EVENT，sqlite 写仍在广播后。
- 回滚 / 降级方式：回退本 PR。旧客户端忽略未知 `persistId` 字段。
- 存量插件影响：无

### 提交前检查

- [x] 已 review 完整 diff
- [x] 每个 commit 都带 DCO 签名（`git commit -s`，见 [DCO](../DCO)）
- [x] UI 改动已在「UI 变化」注明引用的设计规范章节（不涉及 UI 则跳过）
- [x] 未提交凭证、令牌或授权文件
- [x] 已补充必要文档
- [x] 已确认测试结果或说明未执行原因
