### PR TITLE
fix(agents): 对齐 Pi 短答案请求与 Codex 终态正文

### DIFF
--- a/apps/desktop/src/main/cindy-brain/__tests__/assistantReplyHook.test.ts
+++ b/apps/desktop/src/main/cindy-brain/__tests__/assistantReplyHook.test.ts
@@ -6,7 +6,11 @@
 
 import { describe, expect, it, vi } from 'vitest';
 
-import { runAssistantReplyHook, type AssistantReplyHookDeps } from '../assistantReplyHook';
+import {
+  isSuccessfulAssistantReplyDoneData,
+  runAssistantReplyHook,
+  type AssistantReplyHookDeps,
+} from '../assistantReplyHook';
 import type { GhostAssistantScreenResult } from '../subscriptionGateway';
 
 function makeDeps(overrides: Partial<AssistantReplyHookDeps> = {}) {
@@ -28,6 +32,19 @@ function makeDeps(overrides: Partial<AssistantReplyHookDeps> = {}) {
   };
   return { deps, calls };
 }
+
+describe('isSuccessfulAssistantReplyDoneData', () => {
+  it.each([
+    [{ status: 'completed', result: 'answer' }, true],
+    [{ result: 'legacy answer' }, true],
+    [{ status: 'failed', result: 'partial' }, false],
+    [{ status: 'cancelled', result: 'partial' }, false],
+    [{ status: 'interrupted', result: 'partial' }, false],
+    [{ is_error: true, result: 'provider failure' }, false],
+  ])('classifies %j as %s', (data, expected) => {
+    expect(isSuccessfulAssistantReplyDoneData(data)).toBe(expected);
+  });
+});
 
 describe('runAssistantReplyHook', () => {
   it('no-hook 快路径:不查资格、不 screen、不动 pending', async () => {

--- a/apps/desktop/src/main/cindy-brain/assistantReplyHook.ts
+++ b/apps/desktop/src/main/cindy-brain/assistantReplyHook.ts
@@ -16,6 +16,16 @@
 
 import type { GhostAssistantScreenResult } from './subscriptionGateway.js';
 
+const NON_SUCCESS_DONE_STATUSES = new Set(['failed', 'cancelled', 'interrupted']);
+
+/** Only successful turn results are eligible for final-answer rewriting. */
+export function isSuccessfulAssistantReplyDoneData(data: unknown): boolean {
+  if (!data || typeof data !== 'object') return true;
+  const record = data as Record<string, unknown>;
+  if (record.is_error === true) return false;
+  return typeof record.status !== 'string' || !NON_SUCCESS_DONE_STATUSES.has(record.status);
+}
+
 /** render 裁决落地所需的净化后卡片(html 已净化、height 已 clamp)。 */
 export interface AssistantRenderCard {
   ghostId: string;

--- a/apps/desktop/src/main/maker-host/__tests__/piResponsesVerbosity.test.ts
+++ b/apps/desktop/src/main/maker-host/__tests__/piResponsesVerbosity.test.ts
@@ -1,0 +1,104 @@
+import { createServer } from 'node:http';
+import type { AddressInfo } from 'node:net';
+
+import { createAnthropicCompatProxy } from '@cindy/anthropic-compat-proxy';
+import { describe, expect, it, vi } from 'vitest';
+
+import { createPiResponsesVerbosityTransform } from '../pi-responses-verbosity.js';
+
+const CTX = {
+  reqId: 1,
+  method: 'POST',
+  url: '/v1/responses',
+  headers: { 'x-cindy-pi-session-id': 'session-1' },
+};
+
+describe('Pi Responses verbosity transform', () => {
+  it('adds low for a Cindy Codex GPT-5 gateway request', () => {
+    const resolveProvider = vi.fn(() => 'xd');
+    const transform = createPiResponsesVerbosityTransform(resolveProvider);
+
+    expect(transform({ model: 'codex/gpt-5.6-sol', input: [] }, CTX)).toEqual({
+      model: 'codex/gpt-5.6-sol',
+      input: [],
+      text: { verbosity: 'low' },
+    });
+    expect(resolveProvider).toHaveBeenCalledWith('session-1');
+  });
+
+  it('preserves an explicit verbosity and other text options', () => {
+    const transform = createPiResponsesVerbosityTransform(() => 'xd');
+    const body = {
+      model: 'codex/gpt-5.6-sol',
+      text: { verbosity: 'high', format: { type: 'text' } },
+    };
+
+    expect(transform(body, CTX)).toBeNull();
+  });
+
+  it.each([
+    ['non-Pi request', { ...CTX, headers: {} }, { model: 'codex/gpt-5.6-sol' }],
+    ['non-Responses path', { ...CTX, url: '/v1/messages' }, { model: 'codex/gpt-5.6-sol' }],
+    ['third-party provider', CTX, { model: 'codex/gpt-5.6-sol' }],
+    ['non-Codex model', CTX, { model: 'gpt-5.6-sol' }],
+    ['non-GPT-5 model', CTX, { model: 'codex/o4-mini' }],
+  ])('does not modify a %s', (_label, ctx, body) => {
+    const transform = createPiResponsesVerbosityTransform(() =>
+      _label === 'third-party provider' ? 'custom-provider' : 'xd',
+    );
+    expect(transform(body, ctx)).toBeNull();
+  });
+
+  it('keeps existing text options when adding the default', () => {
+    const transform = createPiResponsesVerbosityTransform(() => null);
+    expect(transform({
+      model: 'codex/gpt-5.6-terra',
+      text: { format: { type: 'text' } },
+    }, CTX)).toEqual({
+      model: 'codex/gpt-5.6-terra',
+      text: { format: { type: 'text' }, verbosity: 'low' },
+    });
+  });
+
+  it('serializes low onto the request that reaches the Gateway', async () => {
+    let resolveBody!: (body: Record<string, unknown>) => void;
+    const receivedBody = new Promise<Record<string, unknown>>((resolve) => {
+      resolveBody = resolve;
+    });
+    const upstream = createServer((req, res) => {
+      const chunks: Buffer[] = [];
+      req.on('data', (chunk) => chunks.push(Buffer.from(chunk)));
+      req.on('end', () => {
+        resolveBody(JSON.parse(Buffer.concat(chunks).toString('utf8')) as Record<string, unknown>);
+        res.writeHead(200, { 'content-type': 'text/event-stream' });
+        res.end('data: {"type":"response.completed","response":{"id":"r","output":[]}}\n\n');
+      });
+    });
+    await new Promise<void>((resolve) => upstream.listen(0, '127.0.0.1', resolve));
+    const port = (upstream.address() as AddressInfo).port;
+    const proxy = await createAnthropicCompatProxy({
+      upstream: `http://127.0.0.1:${port}`,
+      transformRequest: [createPiResponsesVerbosityTransform(() => 'xd')],
+    });
+
+    try {
+      const response = await fetch(`${proxy.url}/v1/responses`, {
+        method: 'POST',
+        headers: {
+          'content-type': 'application/json',
+          'x-cindy-pi-session-id': 'session-1',
+        },
+        body: JSON.stringify({ model: 'codex/gpt-5.6-sol', input: [], stream: true }),
+      });
+      await response.text();
+      expect(response.status).toBe(200);
+      await expect(receivedBody).resolves.toMatchObject({
+        model: 'codex/gpt-5.6-sol',
+        text: { verbosity: 'low' },
+      });
+    } finally {
+      await proxy.dispose();
+      await new Promise<void>((resolve) => upstream.close(() => resolve()));
+    }
+  });
+});

--- a/apps/desktop/src/main/maker-host/__tests__/piResponsesVerbosity.test.ts
+++ b/apps/desktop/src/main/maker-host/__tests__/piResponsesVerbosity.test.ts
@@ -2,16 +2,28 @@ import { createServer } from 'node:http';
 import type { AddressInfo } from 'node:net';
 
 import { createAnthropicCompatProxy } from '@cindy/anthropic-compat-proxy';
-import { describe, expect, it, vi } from 'vitest';
+import { afterEach, describe, expect, it, vi } from 'vitest';
 
+import {
+  getPiProxySessionProvider,
+  registerPiProxySession,
+  resetPiProxySessionsForTest,
+} from '../pi-proxy-session-auth.js';
 import { createPiResponsesVerbosityTransform } from '../pi-responses-verbosity.js';
 
 const CTX = {
   reqId: 1,
   method: 'POST',
   url: '/v1/responses',
-  headers: { 'x-cindy-pi-session-id': 'session-1' },
+  headers: {
+    'x-cindy-pi-session-id': 'session-1',
+    'x-cindy-pi-session-token': 'token-1',
+  },
 };
+
+afterEach(() => {
+  resetPiProxySessionsForTest();
+});
 
 describe('Pi Responses verbosity transform', () => {
   it('adds low for a Cindy Codex GPT-5 gateway request', () => {
@@ -23,7 +35,7 @@ describe('Pi Responses verbosity transform', () => {
       input: [],
       text: { verbosity: 'low' },
     });
-    expect(resolveProvider).toHaveBeenCalledWith('session-1');
+    expect(resolveProvider).toHaveBeenCalledWith('session-1', 'token-1');
   });
 
   it('preserves an explicit verbosity and other text options', () => {
@@ -47,6 +59,24 @@ describe('Pi Responses verbosity transform', () => {
       _label === 'third-party provider' ? 'custom-provider' : 'xd',
     );
     expect(transform(body, ctx)).toBeNull();
+  });
+
+  it('uses the provider frozen onto an authenticated subagent route', () => {
+    registerPiProxySession('session-1', 'subagent-token', () => 'xd', {
+      scope: 'subagent-route',
+    });
+    const transform = createPiResponsesVerbosityTransform(getPiProxySessionProvider);
+
+    expect(transform({ model: 'codex/gpt-5.6-sol' }, {
+      ...CTX,
+      headers: {
+        'x-cindy-pi-session-id': 'session-1',
+        'x-cindy-pi-session-token': 'subagent-token',
+      },
+    })).toEqual({
+      model: 'codex/gpt-5.6-sol',
+      text: { verbosity: 'low' },
+    });
   });
 
   it('keeps existing text options when adding the default', () => {
@@ -87,6 +117,7 @@ describe('Pi Responses verbosity transform', () => {
         headers: {
           'content-type': 'application/json',
           'x-cindy-pi-session-id': 'session-1',
+          'x-cindy-pi-session-token': 'token-1',
         },
         body: JSON.stringify({ model: 'codex/gpt-5.6-sol', input: [], stream: true }),
       });

--- a/apps/desktop/src/main/maker-host/anthropic-compat-proxy-host.ts
+++ b/apps/desktop/src/main/maker-host/anthropic-compat-proxy-host.ts
@@ -669,7 +669,7 @@ export async function ensureAnthropicCompatProxyReady(): Promise<void> {
       transformRequest: [
         // Pi 的通用 openai-responses adapter 不发送 text.verbosity；只对 Cindy
         // codex/gpt-5* 网关路由补 low。显式值优先，第三方兼容端点不碰。
-        createPiResponsesVerbosityTransform(getSessionProvider),
+        createPiResponsesVerbosityTransform(getPiProxySessionProvider),
         // 子代理 usage 在请求阶段预留 taskId，后续用同一 reqId 关联响应，避免响应乱序交换归因。
         createClaudeSubagentUsageRequestTransform(),
         // 开头:fast mode 请求侧核验(passthrough 不改写,放最前先记 cc 实际发出的 speed/beta)。

--- a/apps/desktop/src/main/maker-host/anthropic-compat-proxy-host.ts
+++ b/apps/desktop/src/main/maker-host/anthropic-compat-proxy-host.ts
@@ -110,6 +110,7 @@ import {
   isPiProxySubagentRoute,
 } from './pi-proxy-session-auth.js';
 import { createXdToolResultImageNoticeTransform } from './xd-tool-result-image-notice.js';
+import { createPiResponsesVerbosityTransform } from './pi-responses-verbosity.js';
 
 // scope = 'cc-proxy' → logger.ts 的 emit() 路由把这条流量并入统一 agent 流
 // (agent-*.ndjson, source=proxy)。child(sub) 会继续保持 'cc-proxy/sub' 前缀, routing 一致。
@@ -666,6 +667,9 @@ export async function ensureAnthropicCompatProxyReady(): Promise<void> {
         }),
       ),
       transformRequest: [
+        // Pi 的通用 openai-responses adapter 不发送 text.verbosity；只对 Cindy
+        // codex/gpt-5* 网关路由补 low。显式值优先，第三方兼容端点不碰。
+        createPiResponsesVerbosityTransform(getSessionProvider),
         // 子代理 usage 在请求阶段预留 taskId，后续用同一 reqId 关联响应，避免响应乱序交换归因。
         createClaudeSubagentUsageRequestTransform(),
         // 开头:fast mode 请求侧核验(passthrough 不改写,放最前先记 cc 实际发出的 speed/beta)。

--- a/apps/desktop/src/main/maker-host/pi-responses-verbosity.ts
+++ b/apps/desktop/src/main/maker-host/pi-responses-verbosity.ts
@@ -1,0 +1,56 @@
+import {
+  isCindyProviderCodexRemoteCompactionRoute,
+} from '@cindy/maker-core';
+import type {
+  RequestTransform,
+  RequestTransformCtx,
+} from '@cindy/anthropic-compat-proxy';
+
+const PI_SESSION_ID_HEADER = 'x-cindy-pi-session-id';
+const CODEX_GPT5_MODEL_RE = /^codex\/gpt-5(?:[.\-]|$)/;
+const RESPONSES_PATH_RE = /(?:^|\/)responses(?:\?|$)/;
+
+type TextVerbosity = 'low' | 'medium' | 'high';
+
+function isPlainObject(value: unknown): value is Record<string, unknown> {
+  return value !== null && typeof value === 'object' && !Array.isArray(value);
+}
+
+function hasExplicitVerbosity(value: unknown): boolean {
+  if (!isPlainObject(value)) return false;
+  return value.verbosity === 'low' || value.verbosity === 'medium' || value.verbosity === 'high';
+}
+
+/**
+ * Pi's generic `openai-responses` adapter does not currently serialize
+ * `text.verbosity`. Add the Cindy GPT-5 default at the local proxy boundary,
+ * while preserving any explicit value supplied by a newer Pi runtime.
+ *
+ * The model + provider checks keep this field away from third-party
+ * OpenAI-compatible endpoints that may reject the OpenAI-only option.
+ */
+export function createPiResponsesVerbosityTransform(
+  resolveProviderId: (sessionId: string) => string | null,
+  defaultVerbosity: TextVerbosity = 'low',
+): RequestTransform {
+  return (body: unknown, ctx: RequestTransformCtx): unknown | null => {
+    if (!RESPONSES_PATH_RE.test(ctx.url) || !isPlainObject(body)) return null;
+
+    const sessionId = ctx.headers[PI_SESSION_ID_HEADER]?.trim();
+    const model = typeof body.model === 'string' ? body.model.trim() : '';
+    if (!sessionId || !CODEX_GPT5_MODEL_RE.test(model)) return null;
+    if (!isCindyProviderCodexRemoteCompactionRoute({
+      providerId: resolveProviderId(sessionId),
+      model,
+    })) return null;
+    if (hasExplicitVerbosity(body.text)) return null;
+
+    return {
+      ...body,
+      text: {
+        ...(isPlainObject(body.text) ? body.text : {}),
+        verbosity: defaultVerbosity,
+      },
+    };
+  };
+}

--- a/apps/desktop/src/main/maker-host/pi-responses-verbosity.ts
+++ b/apps/desktop/src/main/maker-host/pi-responses-verbosity.ts
@@ -7,6 +7,7 @@ import type {
 } from '@cindy/anthropic-compat-proxy';
 
 const PI_SESSION_ID_HEADER = 'x-cindy-pi-session-id';
+const PI_SESSION_TOKEN_HEADER = 'x-cindy-pi-session-token';
 const CODEX_GPT5_MODEL_RE = /^codex\/gpt-5(?:[.\-]|$)/;
 const RESPONSES_PATH_RE = /(?:^|\/)responses(?:\?|$)/;
 
@@ -30,17 +31,21 @@ function hasExplicitVerbosity(value: unknown): boolean {
  * OpenAI-compatible endpoints that may reject the OpenAI-only option.
  */
 export function createPiResponsesVerbosityTransform(
-  resolveProviderId: (sessionId: string) => string | null,
+  resolveProviderId: (sessionId: string, sessionToken: string | null) => string | null,
   defaultVerbosity: TextVerbosity = 'low',
 ): RequestTransform {
   return (body: unknown, ctx: RequestTransformCtx): unknown | null => {
     if (!RESPONSES_PATH_RE.test(ctx.url) || !isPlainObject(body)) return null;
 
     const sessionId = ctx.headers[PI_SESSION_ID_HEADER]?.trim();
+    const sessionToken = ctx.headers[PI_SESSION_TOKEN_HEADER]?.trim() || null;
     const model = typeof body.model === 'string' ? body.model.trim() : '';
     if (!sessionId || !CODEX_GPT5_MODEL_RE.test(model)) return null;
+    // Resolve from the authenticated Pi process binding. A subagent-route
+    // token may intentionally freeze a provider that differs from its mutable
+    // parent session selection.
     if (!isCindyProviderCodexRemoteCompactionRoute({
-      providerId: resolveProviderId(sessionId),
+      providerId: resolveProviderId(sessionId, sessionToken),
       model,
     })) return null;
     if (hasExplicitVerbosity(body.text)) return null;

--- a/apps/desktop/src/main/maker-ipc/register.ts
+++ b/apps/desktop/src/main/maker-ipc/register.ts
@@ -1003,6 +1003,7 @@ import {
   type InterruptedTurnErrorSignals,
 } from './interruptedTurnAutoResume.js';
 import { readInterruptedTurnAutoResumeSettings } from '../maker-host/interrupted-turn-auto-resume-store.js';
+import { isSuccessfulAssistantReplyDoneData } from '../cindy-brain/assistantReplyHook.js';
 import {
   broadcastGhostMessageBlocked,
   broadcastGhostMessageRewritten,
@@ -4738,7 +4739,14 @@ export function wireSessionToIpc(session: ReturnType<Maker['getSession']>): void
         // 意识时,派一个独立异步续跑跑裁决并原地更新那条消息(rewrite 换文本 /
         // render 换自绘卡)。同步守卫 hasEnabledGhostAssistantHook 保证无此类意识时
         // 不 schedule —— 与今天行为逐字节一致,零额外开销(规则 10 不碰热路径)。
-        if (event.type === 'done' && !isContinuationBoundary && turnAssistantPersistId) {
+        if (
+          event.type === 'done'
+          && !isContinuationBoundary
+          && !isPairedFailedTurnDone
+          && !isTerminalTurnErrorEvent(event)
+          && isSuccessfulAssistantReplyDoneData(event.data)
+          && turnAssistantPersistId
+        ) {
           const doneResult = (event.data as { result?: unknown } | null)?.result;
           const replyText = typeof doneResult === 'string' ? doneResult : '';
           if (replyText.length > 0 && hasEnabledGhostAssistantHook()) {

--- a/packages/maker-core/src/agents/claude-code/__tests__/translator-workflow.test.ts
+++ b/packages/maker-core/src/agents/claude-code/__tests__/translator-workflow.test.ts
@@ -394,4 +394,20 @@ describe('Claude Code translator — workflow / task_updated', () => {
       workflowName: 'parallel-news-scan',
     });
   });
+
+  it('strips internal Web citations from the successful done result', async () => {
+    const citation = '\uE200cite\uE202turn17search1\uE201';
+    const events = await translateOne({
+      type: 'result',
+      is_error: false,
+      result: `Final answer.${citation}`,
+      stop_reason: 'end_turn',
+      total_cost_usd: 0,
+      usage: { input_tokens: 10, output_tokens: 2 },
+    });
+
+    expect(events.find((event) => event.type === 'done')?.data).toMatchObject({
+      result: 'Final answer.',
+    });
+  });
 });

--- a/packages/maker-core/src/agents/claude-code/translator.ts
+++ b/packages/maker-core/src/agents/claude-code/translator.ts
@@ -2321,8 +2321,13 @@ function handleResult(
   // surface 耗尽提示)。data 为 unknown 形状、既有消费方(记账 / IM / orca)均按需
   // typeof 读字段, 加字段零影响; 不命中时 done 与现状逐字节一致。
   const safeResult =
-    msg.is_error && typeof msg.result === 'string'
-      ? { ...msg, result: redactSensitiveText(msg.result) }
+    typeof msg.result === 'string'
+      ? {
+          ...msg,
+          result: msg.is_error
+            ? redactSensitiveText(msg.result)
+            : stripInternalWebCitations(msg.result),
+        }
       : msg;
   const resultWithUsageSegments = {
     ...safeResult,

--- a/packages/maker-core/src/agents/codex/index.test.ts
+++ b/packages/maker-core/src/agents/codex/index.test.ts
@@ -17582,6 +17582,75 @@ describe('CodexAgent MCP thread context hooks', () => {
   });
 });
 
+describe('CodexAgent final assistant result', () => {
+  it('uses final_answer for done.result and falls back to the last unphased message', async () => {
+    const agent = new CodexAgent(createDeps());
+    let turnSeq = 0;
+    const host = installFakeHost(agent, (method) => {
+      if (method === Method.TurnStart) {
+        turnSeq += 1;
+        return { turn: { id: `turn-final-${turnSeq}` } };
+      }
+      return undefined;
+    });
+    const handle = await agent.startSession({
+      sessionId: 'session-final-assistant-result',
+      model: 'gpt-5.6-sol',
+      workingDir: '/repo',
+    });
+    const handlers = host.getThreadHandlers();
+    if (!handlers?.itemCompleted || !handlers.turnCompleted) {
+      throw new Error('expected item and turn handlers');
+    }
+    const events: AgentEvent[] = [];
+    void (async () => {
+      for await (const event of handle.events()) events.push(event);
+    })();
+
+    await handle.send({ type: 'user', content: 'first' });
+    handlers.itemCompleted({
+      threadId: 'start-thread-id',
+      turnId: 'turn-final-1',
+      item: { id: 'commentary-1', type: 'agentMessage', text: 'Working…', phase: 'commentary' },
+    });
+    handlers.itemCompleted({
+      threadId: 'start-thread-id',
+      turnId: 'turn-final-1',
+      item: { id: 'answer-1', type: 'agentMessage', text: 'Concise answer.', phase: 'final_answer' },
+    });
+    handlers.itemCompleted({
+      threadId: 'start-thread-id',
+      turnId: 'turn-final-1',
+      item: { id: 'legacy-tail-1', type: 'agentMessage', text: 'unphased tail' },
+    });
+    handlers.turnCompleted({
+      threadId: 'start-thread-id',
+      turn: { id: 'turn-final-1', status: 'completed' },
+    });
+    await waitForExpectation(() => {
+      const done = events.find((event) => event.type === 'done');
+      expect((done?.data as { result?: string } | undefined)?.result).toBe('Concise answer.');
+    });
+
+    await handle.send({ type: 'user', content: 'second' });
+    handlers.itemCompleted({
+      threadId: 'start-thread-id',
+      turnId: 'turn-final-2',
+      item: { id: 'legacy-answer-2', type: 'agentMessage', text: 'Legacy concise answer.' },
+    });
+    handlers.turnCompleted({
+      threadId: 'start-thread-id',
+      turn: { id: 'turn-final-2', status: 'completed' },
+    });
+    await waitForExpectation(() => {
+      const done = events.filter((event) => event.type === 'done');
+      expect((done[1]?.data as { result?: string } | undefined)?.result).toBe('Legacy concise answer.');
+    });
+
+    await handle.close();
+  });
+});
+
 describe('CodexAgent yield continuation', () => {
   async function collectYieldEvents(handle: AgentSessionHandle): Promise<AgentEvent[]> {
     const events: AgentEvent[] = [];

--- a/packages/maker-core/src/agents/codex/index.ts
+++ b/packages/maker-core/src/agents/codex/index.ts
@@ -145,6 +145,7 @@ import {
   translateAccountRateLimitsUpdated,
   translatePlanUpdatedNotification,
   extractRolloutUpdatePlanFunctionCallEvent,
+  finalizeCodexCitationText,
   readCodexSubagentSpawnRegistration,
   type CodexRuntimeState,
 } from './translator.js';
@@ -3525,6 +3526,10 @@ export class CodexAgent extends BaseAgent {
     // replacement continuation. The snapshot is per-turn and is discarded
     // with the turn's denial state at terminal completion.
     const observedModelItemIdsByTurn = new Map<string, Set<string>>();
+    // turn → assistant 正文候选。app-server 对新模型提供 phase，final_answer
+    // 优先；旧模型/旧 provider 不带 phase 时回退本 turn 最后一条 agentMessage。
+    // turn/completed 把选中的正文放进 done.result，供出口 hook 与 worker 终态消费。
+    const assistantReplyByTurn = new Map<string, { lastText: string; finalText?: string }>();
     // daemon 后端 retry-loop 的终局升级 (issue #677): 远端摸不到 Codex 后端时
     // daemon 无限 willRetry, turn 永不收口。同 turn 重试超阈值 → 合成终态错误,
     // 走与终态 error 完全相同的收口路径 (terminalErroredTurnIds + Done status)。
@@ -8841,6 +8846,9 @@ export class CodexAgent extends BaseAgent {
       // including the paths that defer UI settlement or return early. Item
       // history is only needed while approval attribution is still mutable.
       observedModelItemIdsByTurn.delete(turn.id);
+      const assistantReply = assistantReplyByTurn.get(turn.id);
+      assistantReplyByTurn.delete(turn.id);
+      const finalAssistantText = assistantReply?.finalText ?? assistantReply?.lastText ?? '';
       const interruptOrigin = turnInterruptOrigins.get(turn.id);
       turnInterruptOrigins.delete(turn.id);
       if (
@@ -9239,6 +9247,7 @@ export class CodexAgent extends BaseAgent {
           type: 'done',
           data: {
             type: 'codex/event/task_complete',
+            result: finalAssistantText,
             usage: codexDoneUsage,
             raw: turn,
             plan: latestPlanByTurn.get(turn.id) ?? null,
@@ -9332,6 +9341,19 @@ export class CodexAgent extends BaseAgent {
     const itemRepresentsModelWork = (item: { type?: unknown } | null | undefined): boolean => {
       const type = typeof item?.type === 'string' ? item.type : null;
       return type === null || !ITEM_TYPES_WITHOUT_MODEL_WORK.has(type);
+    };
+
+    const noteAssistantReplyCandidate = (
+      turnId: string,
+      item: { type?: unknown; text?: unknown; phase?: unknown } | null | undefined,
+    ): void => {
+      if (item?.type !== 'agentMessage' || typeof item.text !== 'string') return;
+      const text = finalizeCodexCitationText(item.text);
+      if (text.length === 0) return;
+      const current = assistantReplyByTurn.get(turnId) ?? { lastText: '' };
+      current.lastText = text;
+      if (item.phase === 'final_answer') current.finalText = text;
+      assistantReplyByTurn.set(turnId, current);
     };
 
     const noteObservedModelItem = (
@@ -10588,6 +10610,7 @@ export class CodexAgent extends BaseAgent {
           clearApprovalPolicyDenialOnProgress(params.turnId, params.item.id);
           producedOutputTurnIds.add(params.turnId);
         }
+        noteAssistantReplyCandidate(params.turnId, params.item);
         completeActiveToolContext(params.item, params.turnId);
         rememberYieldedExecCells(params.turnId, params.item, 'completed');
         // This late item belongs to an already-terminal parent. The parent

--- a/packages/maker-core/src/agents/pi/__tests__/pi-translator.test.ts
+++ b/packages/maker-core/src/agents/pi/__tests__/pi-translator.test.ts
@@ -431,7 +431,11 @@ describe('pi translator', () => {
         }),
       }),
     ]);
-    expect(events).toContainEqual(expect.objectContaining({ type: 'done', source: 'pi' }));
+    expect(events).toContainEqual(expect.objectContaining({
+      type: 'done',
+      source: 'pi',
+      data: expect.objectContaining({ result: '', status: 'failed' }),
+    }));
     expect(events.at(-1)).toEqual(expect.objectContaining({
       type: 'status',
       data: expect.objectContaining({ status: 'Done', isRunning: false }),
@@ -760,8 +764,10 @@ describe('pi translator', () => {
     translatePiEvent(ev({ type: 'agent_settled' }), queue, ctx);
 
     expect(events.filter((event) => event.type === 'error')).toHaveLength(0);
-    expect((events.find((event) => event.type === 'done')?.data as { result?: string }).result)
-      .toBe('partial answer');
+    expect(events.find((event) => event.type === 'done')?.data).toMatchObject({
+      result: '',
+      status: 'cancelled',
+    });
   });
 
   it('notifies Pi network auto-retries with the shared Reconnecting progress line', () => {
@@ -1423,7 +1429,7 @@ describe('pi translator', () => {
     );
     translatePiEvent(ev({ type: 'agent_settled' }), queue, ctx);
     const done = events.find((e) => e.type === 'done');
-    expect((done!.data as { result?: unknown }).result).toBe('final answer');
+    expect(done!.data).toMatchObject({ result: 'final answer', status: 'completed' });
 
     // 新 turn:result 归零,不带上一 turn 的回复。
     translatePiEvent(ev({ type: 'agent_start' }), queue, ctx);

--- a/packages/maker-core/src/agents/pi/translator.ts
+++ b/packages/maker-core/src/agents/pi/translator.ts
@@ -137,6 +137,8 @@ export interface PiTranslateContext {
    * 不带上就会对 Pi 静默跳过这些钩子(codex review P1)。
    */
   finalAssistantText: string;
+  /** Latest assistant stop reason for classifying the settled turn outcome. */
+  finalAssistantStopReason: string | null;
   /**
    * Pi 会先用 message_end(stopReason=error) 报 provider 错误，之后仍可能自动重试。
    * 暂存到 agent_settled 再终态上报，避免一次可恢复错误提前收口整个 turn。
@@ -205,6 +207,7 @@ export function createPiTranslateContext(logger: Logger): PiTranslateContext {
     thinkingBlocks: new Map(),
     streamStopTokenByIndex: new Map(),
     finalAssistantText: '',
+    finalAssistantStopReason: null,
     turnWallClockStartedAt: 0,
     generationDurationMs: 0,
     generationOpenAt: 0,
@@ -644,6 +647,7 @@ export function translatePiEvent(
       ctx.pendingPriceVariants = [];
       ctx.turnSettled = false;
       ctx.finalAssistantText = '';
+      ctx.finalAssistantStopReason = null;
       ctx.pendingAssistantError = null;
       ctx.turnWallClockStartedAt = Date.now();
       ctx.generationDurationMs = 0;
@@ -715,6 +719,9 @@ export function translatePiEvent(
         ctx.generationTimingReliable = false;
       }
       const fullText = assistantTextOf(message);
+      ctx.finalAssistantStopReason = typeof message.stopReason === 'string'
+        ? message.stopReason
+        : null;
       const hostInitiatedAbort = message.stopReason === 'aborted'
         && isCurrentTurnHostAbortRequested(ctx);
       const transientAssistantFailure = !hostInitiatedAbort
@@ -898,9 +905,13 @@ export function translatePiEvent(
       ctx.isStreaming = false;
       ctx.pendingPriceVariants = [];
       stopPiGenerationHeartbeat(ctx);
-      const pendingAssistantError = isCurrentTurnHostAbortRequested(ctx)
-        ? null
-        : ctx.pendingAssistantError;
+      const hostAbortRequested = isCurrentTurnHostAbortRequested(ctx);
+      const pendingAssistantError = hostAbortRequested ? null : ctx.pendingAssistantError;
+      const outcome = pendingAssistantError
+        ? 'failed'
+        : hostAbortRequested || ctx.finalAssistantStopReason === 'aborted'
+          ? 'cancelled'
+          : 'completed';
       ctx.pendingAssistantError = null;
       clearPiHostAbortRequests(ctx);
       if (pendingAssistantError) {
@@ -920,7 +931,8 @@ export function translatePiEvent(
           // 本 turn 最终 assistant 回复文本。与 CC/Codex 的 done.data.result 对齐:
           // register.ts 的 will-assistant-message 出口钩子与 Orca worker 终态 finalText
           // 都读 done.data.result,不带上就会对 Pi 静默跳过这些钩子(codex review P1)。
-          result: ctx.finalAssistantText,
+          result: outcome === 'completed' ? ctx.finalAssistantText : '',
+          status: outcome,
           // ghost 订阅 did-turn-end 的 usage 上报(subscriptionGateway.normalizeTurnUsage
           // 认 camelCase);与 CC/Codex 的 done.usage 对齐,让插件能显示 pi turn 的用量。
           usage: {


### PR DESCRIPTION
## 这次改了什么

### 摘要

确保 Pi 通过 Cindy 本地 Gateway 调用支持 verbosity 的 GPT-5.x Responses 模型时显式请求短答案，并恢复 Codex 成功终态携带最终正文的出口契约。

Pi 的通用 `openai-responses` adapter 当前不会发送 `text.verbosity`。本 PR 在 Desktop loopback proxy 中仅对带 Pi session header、走 `/responses`、匹配 Cindy/XD 路由的 `codex/gpt-5*` 请求补 `text.verbosity: "low"`；显式值优先，既有 `text` 选项会保留。Provider 判定取认证 token 绑定的真实 Pi 路由，覆盖与父会话 Provider 不同的冻结子代理路由。Codex 侧按 turn 收集 assistant 正文，优先 `final_answer` phase，老 provider 无 phase 时回退最后一条 assistant message，并写入 `done.data.result`。

出口 hook 只消费成功终态：Pi 的 `done` 现在区分 `completed` / `failed` / `cancelled`，失败或取消不再把中间文本当最终答案；Claude 成功终态正文也与 UI 使用同一套内部引用归一化。

### 已知问题与裁定

- P1：verbosity 曾按父会话可变 Provider 判定，可能漏掉冻结到 Cindy/XD 的子代理路由或误伤第三方路由。**已修**：改为使用认证 token 绑定的 Provider，并增加 `subagent-route` 回归测试。
- P2：失败或取消的 turn 可能触发最终答案出口 hook。**已修**：增加终态 status，非成功 `result` 置空，并在 Desktop 边界排除 paired failure、terminal error、`is_error` 和非成功 status。
- P2：Claude `done.result` 可能保留 UI 已移除的内部 Web citation 标记。**已修**：成功结果统一调用 `stripInternalWebCitations` 并增加回归测试。
- 预审未发现 P0；上述问题修复后的 related tests 与 typecheck 均通过。

### 变更类型

- [ ] `feat` 新功能
- [x] `fix` 缺陷修复
- [ ] `refactor` / `perf` 重构或性能优化
- [ ] `docs` / `test` / `chore` 文档、测试或工程维护
- [ ] 其他：

### 范围

- 关联 Issue / 需求：Pi GPT-5.6 Sol 回复长度与普通 Codex 不一致
- 本 PR 包含：Pi→本地 Cindy Gateway 的 GPT-5.x verbosity 默认值；Codex `done.data.result` 最终正文；失败/取消终态的出口 hook 守卫；Claude 成功终态的引用归一化；对应请求契约和 turn 生命周期回归测试
- 明确不包含：修改 Codex CLI 的既有精简策略；硬截断输出；第三方 OpenAI-compatible provider；新增或默认启用 `will-assistant-message` 插件；远程 Pi 直连 Gateway 路径
- 用户可见变化：Pi 经本地 Cindy Gateway 使用 GPT-5.x 时默认偏向更精简的回答；需要详细内容的任务仍由模型按语义展开
- 是否存在 breaking change：无；请求字段和终态事件字段均为兼容性增量

### UI 变化

不涉及：只修改 Desktop main 进程请求变换及 maker-core 终态元数据，没有视觉、交互或 UI 文案变化。

- 引用的设计规范：不涉及

## 怎么验证的

### 自动验证

```text
pnpm test:unit:related
结果：通过

pnpm --filter desktop run --if-present typecheck
结果：通过

pnpm --filter @cindy/maker-core run --if-present typecheck
结果：通过（该 package 当前没有 typecheck script，按门禁规则跳过）

pnpm check:dco
结果：通过

Desktop 定向 Vitest：Pi verbosity proxy/assistant reply hook/subscription gateway
结果：94 passed

maker-core 定向 Vitest：Codex agent/Pi translator/Claude translator
结果：648 passed

pnpm test:unit
结果：受限执行器中除 packages/maker-pi-manager 外所有 workspace 通过；maker-pi-manager 的 4 个真实子进程用例因执行器禁止 spawn 而失败。随后在普通 shell 单独执行 pnpm --filter @cindy/maker-pi-manager test，314 passed。
```

新增的 HTTP 代理集成用例会启动假 upstream，断言穿过 `createAnthropicCompatProxy` 后的最终请求体包含 `text.verbosity: "low"`。

### 手工验证

不涉及 UI。请求级行为由假 Gateway 集成测试验证，没有使用真实用户凭证或生产模型额度。

### 未执行的验证

- 未运行 Desktop dev 实例：本 PR 不涉及 UI，且请求契约已有代理集成测试。
- 未对生产模型做回答字符数断言：`verbosity: low` 是模型行为偏好，不是硬字符截断；测试锁定实际可控的请求契约。

## 风险

### 风险分类

- [ ] 无已知风险
- [ ] SQLite / migration
- [ ] system prompt
- [ ] 协议兼容
- [ ] 权限 / 安全 / 用户数据
- [ ] 存量插件兼容（批准状态 / 指纹 / manifest 校验 / 安装布局 / 包格式）
- [ ] 原生层 / fingerprint / OTA
- [ ] 跨平台差异
- [x] 其他：模型请求路由与内部终态元数据

### 影响与回滚

- 影响范围：Pi session 的 Cindy/XD `codex/gpt-5*` Responses 请求；Pi/Codex/Claude 的最终答案出口元数据和成功终态筛选。第三方 provider、非 GPT-5、非 Responses 请求不变。
- 回滚 / 降级方式：移除 proxy request transform 即恢复旧请求；移除各 harness 的终态正文归一化和成功状态守卫即恢复旧出口行为。无持久化数据或 migration。

### 提交前检查

- [x] 已 review 完整 diff
- [x] 每个 commit 都带 DCO 签名（`git commit -s`，见 [DCO](../DCO)）
- [x] UI 改动已在「UI 变化」注明引用的设计规范章节（不涉及 UI 则跳过）
- [x] 未提交凭证、令牌或授权文件
- [x] 已补充必要文档（无需新增文档；行为由代码注释和回归测试约束）
- [x] 已确认测试结果或说明未执行原因

