### PR TITLE
fix(desktop): 修复流式消息偶发停止自动跟随

### DIFF
--- a/apps/desktop/src/renderer/__tests__/autoFollowIntent.test.ts
+++ b/apps/desktop/src/renderer/__tests__/autoFollowIntent.test.ts
@@ -26,6 +26,7 @@ import {
   resolveNearBottomOnScroll,
   resolveRenderPinDecision,
   resolveSendWindowHandoff,
+  resolveWindowCoverageLossAction,
   selectTailUserMessageId,
   isVerticalScrollbarPress,
   shouldRepinOnDownIntent,
@@ -711,6 +712,30 @@ describe('resolveSendWindowHandoff', () => {
   });
 });
 
+describe('resolveWindowCoverageLossAction', () => {
+  it('hands an automatically expanded window back to the tail when append breaks coverage', () => {
+    expect(
+      resolveWindowCoverageLossAction({
+        hasWindowAnchor: true,
+        wasCoveringEnd: true,
+        windowCoversEnd: false,
+        wasFollowingTail: true,
+      }),
+    ).toBe('handoff-to-tail');
+  });
+
+  it('preserves an active history anchor when append breaks coverage away from the tail', () => {
+    expect(
+      resolveWindowCoverageLossAction({
+        hasWindowAnchor: true,
+        wasCoveringEnd: true,
+        windowCoversEnd: false,
+        wasFollowingTail: false,
+      }),
+    ).toBe('preserve-anchor');
+  });
+});
+
 describe('resolveLastUserMessageObservation', () => {
   it('seeds a restored user tail hydrated after mount without treating it as a send', () => {
     expect(
@@ -780,6 +805,9 @@ describe('MessageStream send-window handoff wiring', () => {
   it('clears any anchored window on a local send and only defers pin for stale slices', () => {
     const source = readFileSync(resolve(__dirname, '../components/chat/MessageStream.tsx'), 'utf8');
     expect(source).toContain('resolveSendWindowHandoff({');
+    expect(source).toContain('resolveWindowCoverageLossAction({');
+    expect(source).toContain("if (coverageLossAction === 'handoff-to-tail')");
+    expect(source).toContain("if (coverageLossAction === 'preserve-anchor')");
     expect(source).toContain('if (windowHandoff.clearWindowAnchor)');
     expect(source).toContain('if (decision.pinToBottom && !windowHandoff.deferPinToNextRender)');
     expect(source).not.toContain('realTailUserSendOutsideWindow');

--- a/apps/desktop/src/renderer/__tests__/focusScrollLifecycle.test.ts
+++ b/apps/desktop/src/renderer/__tests__/focusScrollLifecycle.test.ts
@@ -317,22 +317,17 @@ describe('MessageStream focus cancellation wiring', () => {
     expect(railJumpEffect).toContain('topOffset: NAV_RAIL_JUMP_TOP_OFFSET_PX');
   });
 
-  it('unpins before anchoring an off-window message navigation target', () => {
-    const railJumpEffect = sourceBetween(
+  it('records navigation intent before requesting either a current-window or off-window target', () => {
+    const railJump = sourceBetween(
+      'const handleNavRailJump = useCallback(',
       'useLayoutEffect(() => {\n    if (!railJumpRequest) return;',
-      '// 第一条 user 消息没有',
     );
-    const offWindowIndex = railJumpEffect.indexOf(
-      'if (!visibleRenderItems.some((item) => item.key === targetKey))',
+    const unpinIndex = railJump.indexOf('isNearBottomRef.current = false;');
+    const requestIndex = railJump.indexOf(
+      'setRailJumpRequest({ id: clientId, seq: railJumpSeqRef.current });',
     );
-    const unpinIndex = railJumpEffect.indexOf(
-      'isNearBottomRef.current = false;',
-      offWindowIndex,
-    );
-    const anchorIndex = railJumpEffect.indexOf('setFirstVisibleItemKey(targetKey);', offWindowIndex);
-    expect(offWindowIndex).toBeGreaterThanOrEqual(0);
-    expect(unpinIndex).toBeGreaterThan(offWindowIndex);
-    expect(anchorIndex).toBeGreaterThan(unpinIndex);
+    expect(unpinIndex).toBeGreaterThanOrEqual(0);
+    expect(requestIndex).toBeGreaterThan(unpinIndex);
   });
 
   it('re-resolves the saved target before consuming an earlier deferred deletion', () => {

--- a/apps/desktop/src/renderer/__tests__/focusScrollLifecycle.test.ts
+++ b/apps/desktop/src/renderer/__tests__/focusScrollLifecycle.test.ts
@@ -317,6 +317,24 @@ describe('MessageStream focus cancellation wiring', () => {
     expect(railJumpEffect).toContain('topOffset: NAV_RAIL_JUMP_TOP_OFFSET_PX');
   });
 
+  it('unpins before anchoring an off-window message navigation target', () => {
+    const railJumpEffect = sourceBetween(
+      'useLayoutEffect(() => {\n    if (!railJumpRequest) return;',
+      '// 第一条 user 消息没有',
+    );
+    const offWindowIndex = railJumpEffect.indexOf(
+      'if (!visibleRenderItems.some((item) => item.key === targetKey))',
+    );
+    const unpinIndex = railJumpEffect.indexOf(
+      'isNearBottomRef.current = false;',
+      offWindowIndex,
+    );
+    const anchorIndex = railJumpEffect.indexOf('setFirstVisibleItemKey(targetKey);', offWindowIndex);
+    expect(offWindowIndex).toBeGreaterThanOrEqual(0);
+    expect(unpinIndex).toBeGreaterThan(offWindowIndex);
+    expect(anchorIndex).toBeGreaterThan(unpinIndex);
+  });
+
   it('re-resolves the saved target before consuming an earlier deferred deletion', () => {
     const settlement = sourceBetween(
       'const settleChipJump = useCallback(',

--- a/apps/desktop/src/renderer/components/chat/MessageStream.tsx
+++ b/apps/desktop/src/renderer/components/chat/MessageStream.tsx
@@ -5701,6 +5701,12 @@ export function MessageStream({
       // 导航条目标要到 layout effect 才能确认仍存在且 DOM 已就绪，因此这里不能提前消费
       // focus 期间延期的删除补偿：先重放补偿，目标有效时后续导航再覆盖最终落点。
       cancelFocusJump();
+      // 点击本身就是离开尾部的明确意图，必须在 request 进入下一次 render 前同步写入。
+      // 否则同一批流式 append 的 coverage-loss layout effect 会先按旧跟随态清掉锚点，
+      // 当前窗口内、但默认尾窗外的目标会在后续 rail effect 滚动时被卸载。
+      restoringRef.current = false;
+      isNearBottomRef.current = false;
+      setIsNearBottom(false);
       railJumpSeqRef.current += 1;
       setRailJumpRequest({ id: clientId, seq: railJumpSeqRef.current });
     },
@@ -5719,11 +5725,6 @@ export function MessageStream({
     if (!visibleRenderItems.some((item) => item.key === targetKey)) {
       // 目标在渲染窗口外:先把窗口锚到目标。本 effect 因 visibleRenderItems
       // 变化重跑,下一轮走下面的滚动分支(focus-jump 同款两段式)。
-      // 必须在建锚前同步解除跟随:下一轮更早执行的 coverage-loss effect 会读取
-      // 这份意图；仍为 true 会把刚建立的历史锚点当成自动扩窗并清回默认尾窗。
-      restoringRef.current = false;
-      isNearBottomRef.current = false;
-      setIsNearBottom(false);
       setFirstVisibleItemKey(targetKey);
       setAnchoredForwardItems(RENDER_WINDOW_FIRST_PAINT_ITEMS);
       return;
@@ -5735,11 +5736,8 @@ export function MessageStream({
     ) as HTMLElement | null;
     if (!el) return;
     lastAppliedRailJumpRef.current = railJumpRequest.seq;
-    // 从贴底态往上跳必须先解除 auto-follow 钉底,否则流式期间 pin effect 会把
-    // 视口拽回底部(focus-jump 同款处理;chip 不需要是因为它只在已上滚时出现)。
-    restoringRef.current = false;
-    isNearBottomRef.current = false;
-    setIsNearBottom(false);
+    // auto-follow 已由点击处理器在 request 进入 render 前解除，避免本轮更早的
+    // coverage-loss effect 清掉当前窗口内、默认尾窗外的导航目标。
     // smooth scroll 途经顶部区域时抑制 expandWindow/onLoadMore(chip-jump 协议,
     // 解抑靠用户 wheel/touch/keydown + 安全兜底 timer)。
     beginChipJump({

--- a/apps/desktop/src/renderer/components/chat/MessageStream.tsx
+++ b/apps/desktop/src/renderer/components/chat/MessageStream.tsx
@@ -314,6 +314,7 @@ import {
   resolveLastUserMessageObservation,
   resolveRenderPinDecision,
   resolveSendWindowHandoff,
+  resolveWindowCoverageLossAction,
   selectTailUserMessageId,
   readFollowLatestRequestKey,
   shouldBumpSendFollowCancelOnScroll,
@@ -4063,14 +4064,27 @@ export function MessageStream({
   const anchoredForwardItemsRef = useRef(anchoredForwardItems);
   anchoredForwardItemsRef.current = anchoredForwardItems;
 
-  // render-window-bidirectional P1 fix: 新消息导致锚定窗口不再覆盖末尾时，
-  // 重置 near-bottom 以触发未读提示（覆盖末尾→清锚回默认窗的逻辑在 handleScroll 里）。
+  // 新 item 导致锚定窗口不再覆盖末尾时，先保留此前的跟随意图：自动补历史建立的
+  // 锚点只是实现细节，用户仍在跟随就清锚回默认尾窗；用户已经离底才保留历史窗口。
   const prevWindowCoversEndRef = useRef(windowCoversEnd);
   useLayoutEffect(() => {
     const wasCovering = prevWindowCoversEndRef.current;
     prevWindowCoversEndRef.current = windowCoversEnd;
 
-    if (firstVisibleItemKey !== null && wasCovering && !windowCoversEnd) {
+    const coverageLossAction = resolveWindowCoverageLossAction({
+      hasWindowAnchor: firstVisibleItemKey !== null,
+      wasCoveringEnd: wasCovering,
+      windowCoversEnd,
+      wasFollowingTail: isNearBottomRef.current,
+    });
+    if (coverageLossAction === 'handoff-to-tail') {
+      isNearBottomRef.current = true;
+      setIsNearBottom(true);
+      setUnreadCount(0);
+      setFirstVisibleItemKey(null);
+      return;
+    }
+    if (coverageLossAction === 'preserve-anchor') {
       isNearBottomRef.current = false;
       setIsNearBottom(false);
       return;

--- a/apps/desktop/src/renderer/components/chat/MessageStream.tsx
+++ b/apps/desktop/src/renderer/components/chat/MessageStream.tsx
@@ -5719,6 +5719,11 @@ export function MessageStream({
     if (!visibleRenderItems.some((item) => item.key === targetKey)) {
       // 目标在渲染窗口外:先把窗口锚到目标。本 effect 因 visibleRenderItems
       // 变化重跑,下一轮走下面的滚动分支(focus-jump 同款两段式)。
+      // 必须在建锚前同步解除跟随:下一轮更早执行的 coverage-loss effect 会读取
+      // 这份意图；仍为 true 会把刚建立的历史锚点当成自动扩窗并清回默认尾窗。
+      restoringRef.current = false;
+      isNearBottomRef.current = false;
+      setIsNearBottom(false);
       setFirstVisibleItemKey(targetKey);
       setAnchoredForwardItems(RENDER_WINDOW_FIRST_PAINT_ITEMS);
       return;

--- a/apps/desktop/src/renderer/components/chat/autoFollowIntent.ts
+++ b/apps/desktop/src/renderer/components/chat/autoFollowIntent.ts
@@ -362,10 +362,11 @@ export interface ResolveSendWindowHandoff {
  * After a local send, leave any historical render window so later assistant /
  * tool items keep auto-following the real tail.
  *
- * An anchored window that still covers the end at send time would otherwise
- * stay anchored; the next appended items flip `windowCoversEnd` to false and
- * the stream treats that as "left the bottom", stopping follow. External
- * injections must not take this handoff (#2194).
+ * An anchored window that still covers the end at send time used to stop
+ * following as soon as the next item moved the real tail past its bound. Local
+ * sends hand off eagerly so the optimistic row is shown at the real tail; the
+ * generic coverage-loss handoff below protects anchors created by auto-fill.
+ * External injections must not take this eager handoff (#2194).
  */
 export function resolveSendWindowHandoff({
   isNewUserSend,
@@ -378,6 +379,38 @@ export function resolveSendWindowHandoff({
     clearWindowAnchor,
     deferPinToNextRender: clearWindowAnchor && !windowCoversEnd,
   };
+}
+
+export type WindowCoverageLossAction = 'none' | 'handoff-to-tail' | 'preserve-anchor';
+
+export interface ResolveWindowCoverageLossArgs {
+  /** The stream is currently showing an anchored (non-default-tail) window. */
+  hasWindowAnchor: boolean;
+  /** The anchored window covered the real session tail before this render. */
+  wasCoveringEnd: boolean;
+  /** The anchored window still covers the real session tail after this render. */
+  windowCoversEnd: boolean;
+  /** Auto-follow intent before the tail item was appended. */
+  wasFollowingTail: boolean;
+}
+
+/**
+ * Decide how an anchored render window should react when an appended item moves
+ * the real session tail beyond its bounded end.
+ *
+ * An automatically expanded window can still be following the tail. In that
+ * case the bounded anchor is only an implementation detail, so hand it back to
+ * the default tail window instead of interpreting the append as user scroll
+ * intent. A user who already left the tail keeps the anchored reading window.
+ */
+export function resolveWindowCoverageLossAction({
+  hasWindowAnchor,
+  wasCoveringEnd,
+  windowCoversEnd,
+  wasFollowingTail,
+}: ResolveWindowCoverageLossArgs): WindowCoverageLossAction {
+  if (!hasWindowAnchor || !wasCoveringEnd || windowCoversEnd) return 'none';
+  return wasFollowingTail ? 'handoff-to-tail' : 'preserve-anchor';
 }
 
 export interface ResolveNearBottomArgs {


### PR DESCRIPTION
## 这次改了什么

### 摘要

修复 Desktop 消息流在 Agent 运行期间新增回答段、工具段等渲染项时，偶发停止自动滚动到最新消息的问题。

根因是自动补历史建立的有界锚定窗口在新条目到达后不再覆盖真实尾部，旧逻辑会把这一变化误判为用户已经离底。现在会根据原有跟随意图区分处理：仍在跟随时交回默认尾窗，主动浏览历史时继续保留锚点。同时修复消息导航轨两阶段跳转与该交接逻辑的 effect 时序冲突。

### 变更类型

- [ ] `feat` 新功能
- [x] `fix` 缺陷修复
- [ ] `refactor` / `perf` 重构或性能优化
- [ ] `docs` / `test` / `chore` 文档、测试或工程维护
- [ ] 其他：

### 范围

- 关联 Issue / 需求：用户反馈 Session 有新消息时主窗口偶发不自动下滑，Agent 运行中概率较高
- 本 PR 包含：消息流尾部覆盖交接、导航轨历史锚点时序修复及回归测试
- 明确不包含：消息存储、流事件协议、其他窗口或 Mobile 行为
- 用户可见变化：贴底时新消息持续自动跟随；主动浏览历史或使用导航轨时不被错误拉回尾部
- 是否存在 breaking change：无

### UI 变化

无视觉、布局、样式或文案变化；仅修复既有滚动跟随行为。

- 界面效果证据：未提供截图或录屏。原问题没有稳定复现方式，且当前宿主 Desktop 不运行此 worktree；静态截图无法呈现滚动状态机行为，无法作为可信的改动前后对比。
- 替代证据：`autoFollowIntent.test.ts` 覆盖尾窗交接时保留/解除跟随意图，`focusScrollLifecycle.test.ts` 覆盖导航轨跳转与交接的 effect 顺序；定向验证共 95 项测试通过。
- 引用的设计规范：`docs/design-rules/DESIGN.md` §14 Interaction Conventions；保持用户主动导航意图优先，不新增控件或动效，Light / Dark 共用同一状态逻辑

## 怎么验证的

### 自动验证

```text
pnpm test:unit:related
结果：通过（apps/desktop related 4）

pnpm --filter desktop run --if-present typecheck
结果：通过

pnpm --filter desktop exec vitest run src/renderer/__tests__/autoFollowIntent.test.ts src/renderer/__tests__/focusScrollLifecycle.test.ts
结果：通过（2 files，95 tests）

pnpm --filter desktop exec eslint src/renderer/components/chat/MessageStream.tsx src/renderer/components/chat/autoFollowIntent.ts src/renderer/__tests__/autoFollowIntent.test.ts src/renderer/__tests__/focusScrollLifecycle.test.ts
结果：通过

pnpm check:dco
结果：通过（2 commits signed off）
```

### 手工验证

未执行：当前宿主 Desktop 不运行此 worktree，且原问题没有稳定复现方式。

### 未执行的验证

未执行实机 Light / Dark 目检：本次无视觉样式变化，两种模式共用同一滚动状态逻辑。

## 风险

### 风险分类

- [ ] 无已知风险
- [ ] SQLite / migration
- [ ] system prompt
- [ ] 协议兼容
- [ ] 权限 / 安全 / 用户数据
- [ ] 存量插件兼容（批准状态 / 指纹 / manifest 校验 / 安装布局 / 包格式）
- [ ] 原生层 / fingerprint / OTA
- [ ] 跨平台差异
- [x] 其他：Desktop 消息流滚动与历史导航状态

### 影响与回滚

- 影响范围：Desktop 主消息流的自动跟随、历史窗口和消息导航轨
- 回滚 / 降级方式：回滚本 PR 的两个提交即可恢复原逻辑；不涉及数据迁移或持久化格式

### 提交前检查

- [x] 已 review 完整 diff
- [x] 每个 commit 都带 DCO 签名（`git commit -s`，见 [DCO](../DCO)）
- [x] UI 改动已在「UI 变化」注明引用的设计规范章节（不涉及 UI 则跳过）
- [x] 未提交凭证、令牌或授权文件
- [x] 已补充必要文档（不涉及：无需新增用户文档）
- [x] 已确认测试结果或说明未执行原因