### PR TITLE
fix(auth): 登录准备态 30 秒超时后解锁到重试

### DIFF
--- a/apps/desktop/src/main/__tests__/authLoginFlowReset.test.ts
+++ b/apps/desktop/src/main/__tests__/authLoginFlowReset.test.ts
@@ -607,6 +607,26 @@ describe('auth login-flow reset', () => {
     expect(refreshBody).toContain('preservePersistedRefreshToken: true');
   });
 
+  it('unlocks login preparing with the splash startup gate after 30s', () => {
+    expect(source).toContain('const LOGIN_PREPARING_GATE_TIMEOUT_MS = 30_000;');
+
+    const loadStart = source.indexOf('async function loadLoginProviders(');
+    const loadEnd = source.indexOf('\n}\n\nasync function discoverOrganizationRealm(', loadStart);
+    const loadBody = source.slice(loadStart, loadEnd);
+    expect(loadBody).toContain('await awaitWithStartupTimeout(');
+    expect(loadBody).toContain('createAuthClient(AUTH_REGION).getProviders()');
+    expect(loadBody).toContain('timeoutMs: LOGIN_PREPARING_GATE_TIMEOUT_MS');
+    expect(loadBody).toContain("'AUTH_SERVICE_UNAVAILABLE'");
+    // 闸只限时等待,不 abort 在途 getProviders(与 splash 冷启动闸同一语义)。
+    expect(loadBody).not.toContain('.abort(');
+
+    const getLoginStart = source.indexOf('export async function getLoginState(');
+    const getLoginEnd = source.indexOf('\n}\n\nasync function completeLogin(', getLoginStart);
+    const getLoginBody = source.slice(getLoginStart, getLoginEnd);
+    expect(getLoginBody).toContain('await loadLoginProviders(expectedLoginFlowEpoch)');
+    expect(getLoginBody).toContain("{ step: 'error', code, recoverTo: 'identifier' }");
+  });
+
   it('does not call teardown for a fresh signed-out/null cold-start session', () => {
     const teardown = vi.fn();
     const previousAppSession = {

--- a/apps/desktop/src/main/__tests__/authLoginFlowReset.test.ts
+++ b/apps/desktop/src/main/__tests__/authLoginFlowReset.test.ts
@@ -608,15 +608,11 @@ describe('auth login-flow reset', () => {
   });
 
   it('unlocks login preparing with the splash startup gate after 30s', () => {
-    expect(source).toContain('const LOGIN_PREPARING_GATE_TIMEOUT_MS = 30_000;');
-
     const loadStart = source.indexOf('async function loadLoginProviders(');
     const loadEnd = source.indexOf('\n}\n\nasync function discoverOrganizationRealm(', loadStart);
     const loadBody = source.slice(loadStart, loadEnd);
-    expect(loadBody).toContain('await awaitWithStartupTimeout(');
+    expect(loadBody).toContain('await awaitLoginProvidersWithPreparingGate(');
     expect(loadBody).toContain('createAuthClient(AUTH_REGION).getProviders()');
-    expect(loadBody).toContain('timeoutMs: LOGIN_PREPARING_GATE_TIMEOUT_MS');
-    expect(loadBody).toContain("'AUTH_SERVICE_UNAVAILABLE'");
     // 闸只限时等待,不 abort 在途 getProviders(与 splash 冷启动闸同一语义)。
     expect(loadBody).not.toContain('.abort(');
 
@@ -624,7 +620,7 @@ describe('auth login-flow reset', () => {
     const getLoginEnd = source.indexOf('\n}\n\nasync function completeLogin(', getLoginStart);
     const getLoginBody = source.slice(getLoginStart, getLoginEnd);
     expect(getLoginBody).toContain('await loadLoginProviders(expectedLoginFlowEpoch)');
-    expect(getLoginBody).toContain("{ step: 'error', code, recoverTo: 'identifier' }");
+    expect(getLoginBody).toContain('mapLoginProvidersLoadFailure(error)');
   });
 
   it('does not call teardown for a fresh signed-out/null cold-start session', () => {

--- a/apps/desktop/src/main/__tests__/authStartupGate.test.ts
+++ b/apps/desktop/src/main/__tests__/authStartupGate.test.ts
@@ -131,6 +131,30 @@ describe('awaitWithStartupTimeout', () => {
     }
   });
 
+  it('超时且 onTimeout 抛错:waiter 收到该错误;flow 迟到 resolve 仍走 onLateResult', async () => {
+    let resolveFlow!: (v: string) => void;
+    const flow = new Promise<string>((r) => {
+      resolveFlow = r;
+    });
+    const boom = new Error('timeout-fallback-failed');
+    const onLateResult = vi.fn();
+    const p = awaitWithStartupTimeout(flow, {
+      timeoutMs: 1000,
+      onTimeout: () => {
+        throw boom;
+      },
+      onLateResult,
+    });
+    // 先挂上 rejection 断言再推进计时器,避免超时 reject 在 expect 之前变成 unhandled。
+    const rejected = expect(p).rejects.toBe(boom);
+    await vi.advanceTimersByTimeAsync(1000);
+    await rejected;
+
+    resolveFlow('late');
+    await vi.advanceTimersByTimeAsync(0);
+    expect(onLateResult).toHaveBeenCalledWith('late');
+  });
+
   it('timeoutMs <= 0:退化为直接 await,永不超时', async () => {
     const onTimeout = vi.fn(() => 'fallback');
     let resolveFlow!: (v: string) => void;

--- a/apps/desktop/src/main/__tests__/authStartupGate.test.ts
+++ b/apps/desktop/src/main/__tests__/authStartupGate.test.ts
@@ -9,7 +9,14 @@
  */
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
-import { awaitWithStartupTimeout } from '../authStartupGate';
+import { AuthApiError } from '@cindy/auth-client';
+
+import {
+  LOGIN_PREPARING_GATE_TIMEOUT_MS,
+  awaitLoginProvidersWithPreparingGate,
+  awaitWithStartupTimeout,
+  mapLoginProvidersLoadFailure,
+} from '../authStartupGate';
 
 describe('awaitWithStartupTimeout', () => {
   beforeEach(() => {
@@ -166,5 +173,65 @@ describe('awaitWithStartupTimeout', () => {
     resolveFlow('ok');
     await expect(p).resolves.toBe('ok');
     expect(onTimeout).not.toHaveBeenCalled();
+  });
+});
+
+describe('awaitLoginProvidersWithPreparingGate', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it('stalled getProviders becomes retryable AUTH_SERVICE_UNAVAILABLE after 30s', async () => {
+    const hung = new Promise<string>(() => undefined);
+    const log = { info: vi.fn(), warn: vi.fn() };
+    const p = awaitLoginProvidersWithPreparingGate(hung, log);
+    const rejected = expect(p).rejects.toMatchObject({
+      name: 'AuthApiError',
+      code: 'AUTH_SERVICE_UNAVAILABLE',
+    });
+
+    await vi.advanceTimersByTimeAsync(LOGIN_PREPARING_GATE_TIMEOUT_MS - 1);
+    expect(log.warn).not.toHaveBeenCalled();
+    await vi.advanceTimersByTimeAsync(1);
+    const error = await p.catch((err: unknown) => err);
+    await rejected;
+
+    expect(error).toBeInstanceOf(AuthApiError);
+    expect(mapLoginProvidersLoadFailure(error)).toEqual({
+      success: false,
+      code: 'AUTH_SERVICE_UNAVAILABLE',
+      state: { step: 'error', code: 'AUTH_SERVICE_UNAVAILABLE', recoverTo: 'identifier' },
+    });
+
+    const hungRetry = new Promise<string>(() => undefined);
+    const retry = awaitLoginProvidersWithPreparingGate(hungRetry, log);
+    const retryRejected = expect(retry).rejects.toMatchObject({
+      code: 'AUTH_SERVICE_UNAVAILABLE',
+    });
+    await vi.advanceTimersByTimeAsync(LOGIN_PREPARING_GATE_TIMEOUT_MS);
+    await retryRejected;
+  });
+
+  it('does not abort a late getProviders; only logs the late settle', async () => {
+    let resolveFlow!: (v: string) => void;
+    const flow = new Promise<string>((resolve) => {
+      resolveFlow = resolve;
+    });
+    const log = { info: vi.fn(), warn: vi.fn() };
+    const p = awaitLoginProvidersWithPreparingGate(flow, log);
+    const rejected = expect(p).rejects.toMatchObject({ code: 'AUTH_SERVICE_UNAVAILABLE' });
+    await vi.advanceTimersByTimeAsync(LOGIN_PREPARING_GATE_TIMEOUT_MS);
+    await rejected;
+
+    resolveFlow('late-providers');
+    await vi.advanceTimersByTimeAsync(0);
+    expect(log.info).toHaveBeenCalledWith('login providers settled after preparing gate timeout');
+    expect(log.warn).not.toHaveBeenCalledWith(
+      'login providers request failed after preparing gate timeout',
+      expect.anything(),
+    );
   });
 });

--- a/apps/desktop/src/main/authManager.ts
+++ b/apps/desktop/src/main/authManager.ts
@@ -2754,6 +2754,16 @@ let replacementIntegrationReloadTimers: ReturnType<typeof setTimeout>[] = [];
 const COLD_START_AUTH_GATE_TIMEOUT_MS = 20_000;
 
 /**
+ * 登录准备态(「正在连接登录服务」)最多阻塞 UI 的时长。getProviders 走
+ * CindyAuthClient 默认 15s AbortController,但黑洞 / captive-portal 下 Electron
+ * `net.fetch` 可能无视 abort,请求永不 settle → renderer 的 preparing 转圈永不
+ * 结束。冷启动 splash 的 `awaitWithStartupTimeout` 闸只包 initialize();登录页是
+ * initialize 完成、GuestRoute 放行之后才出现的。这里复用同一把闸,时限更保守
+ * (30s),超时后走既有 error 步(「暂时无法登录」+ 重试);不 abort 在途 getProviders。
+ */
+const LOGIN_PREPARING_GATE_TIMEOUT_MS = 30_000;
+
+/**
  * auth 状态代际计数:login / clearAuth(logout、会话过期、账号切换)
  * 每次改写全局登录态时 +1。冷启动流程在开跑时快照代际,超时转后台后的每个状态
  * 写入点都先核对代际——用户在流程挂起期间手动登录 / 登出过,则迟到结果整体丢弃,
@@ -4485,7 +4495,24 @@ async function loadLoginProviders(expectedLoginFlowEpoch = loginFlowEpoch): Prom
   pendingSsoVerificationTicket = null;
   pendingAccountDeletionRestored = false;
   pendingAuthRealm = null;
-  const providers = await createAuthClient(AUTH_REGION).getProviders();
+  // 与冷启动 splash 同一把闸:限时等待,超时先以 AUTH_SERVICE_UNAVAILABLE 解锁
+  // preparing UI,getProviders 继续后台跑;不 abort(net.fetch 本就可能无视 abort)。
+  const providers = await awaitWithStartupTimeout(createAuthClient(AUTH_REGION).getProviders(), {
+    timeoutMs: LOGIN_PREPARING_GATE_TIMEOUT_MS,
+    onTimeout: () => {
+      log.warn(
+        `login providers still pending after ${LOGIN_PREPARING_GATE_TIMEOUT_MS}ms — unlocking the preparing UI`,
+      );
+      throw new AuthApiError(
+        'AUTH_SERVICE_UNAVAILABLE',
+        0,
+        'Authentication server did not respond in time',
+      );
+    },
+    onLateResult: () => log.info('login providers settled after preparing gate timeout'),
+    onLateError: (err) =>
+      log.warn('login providers request failed after preparing gate timeout', err),
+  });
   assertLoginFlowCurrent(expectedLoginFlowEpoch);
   providerConfig = providers;
   loginFlowState = reduceAuthFlow(loginFlowState, {

--- a/apps/desktop/src/main/authManager.ts
+++ b/apps/desktop/src/main/authManager.ts
@@ -57,7 +57,11 @@ import {
   type RefreshFetchResult,
   type SessionExpiredReason,
 } from './authRefreshFailure';
-import { awaitWithStartupTimeout } from './authStartupGate';
+import {
+  awaitLoginProvidersWithPreparingGate,
+  awaitWithStartupTimeout,
+  mapLoginProvidersLoadFailure,
+} from './authStartupGate';
 import { syncCanaryFlagAfterAuth } from './canaryFlagSync';
 import {
   maybeEnableNonXdOrgBetaDefault,
@@ -2754,16 +2758,6 @@ let replacementIntegrationReloadTimers: ReturnType<typeof setTimeout>[] = [];
 const COLD_START_AUTH_GATE_TIMEOUT_MS = 20_000;
 
 /**
- * 登录准备态(「正在连接登录服务」)最多阻塞 UI 的时长。getProviders 走
- * CindyAuthClient 默认 15s AbortController,但黑洞 / captive-portal 下 Electron
- * `net.fetch` 可能无视 abort,请求永不 settle → renderer 的 preparing 转圈永不
- * 结束。冷启动 splash 的 `awaitWithStartupTimeout` 闸只包 initialize();登录页是
- * initialize 完成、GuestRoute 放行之后才出现的。这里复用同一把闸,时限更保守
- * (30s),超时后走既有 error 步(「暂时无法登录」+ 重试);不 abort 在途 getProviders。
- */
-const LOGIN_PREPARING_GATE_TIMEOUT_MS = 30_000;
-
-/**
  * auth 状态代际计数:login / clearAuth(logout、会话过期、账号切换)
  * 每次改写全局登录态时 +1。冷启动流程在开跑时快照代际,超时转后台后的每个状态
  * 写入点都先核对代际——用户在流程挂起期间手动登录 / 登出过,则迟到结果整体丢弃,
@@ -4497,22 +4491,10 @@ async function loadLoginProviders(expectedLoginFlowEpoch = loginFlowEpoch): Prom
   pendingAuthRealm = null;
   // 与冷启动 splash 同一把闸:限时等待,超时先以 AUTH_SERVICE_UNAVAILABLE 解锁
   // preparing UI,getProviders 继续后台跑;不 abort(net.fetch 本就可能无视 abort)。
-  const providers = await awaitWithStartupTimeout(createAuthClient(AUTH_REGION).getProviders(), {
-    timeoutMs: LOGIN_PREPARING_GATE_TIMEOUT_MS,
-    onTimeout: () => {
-      log.warn(
-        `login providers still pending after ${LOGIN_PREPARING_GATE_TIMEOUT_MS}ms — unlocking the preparing UI`,
-      );
-      throw new AuthApiError(
-        'AUTH_SERVICE_UNAVAILABLE',
-        0,
-        'Authentication server did not respond in time',
-      );
-    },
-    onLateResult: () => log.info('login providers settled after preparing gate timeout'),
-    onLateError: (err) =>
-      log.warn('login providers request failed after preparing gate timeout', err),
-  });
+  const providers = await awaitLoginProvidersWithPreparingGate(
+    createAuthClient(AUTH_REGION).getProviders(),
+    log,
+  );
   assertLoginFlowCurrent(expectedLoginFlowEpoch);
   providerConfig = providers;
   loginFlowState = reduceAuthFlow(loginFlowState, {
@@ -4561,13 +4543,13 @@ export async function getLoginState(): Promise<DesktopLoginActionResult> {
     if (loginFlowState) return { success: true, state: loginFlowState };
     return { success: true, state: await loadLoginProviders(expectedLoginFlowEpoch) };
   } catch (error) {
-    const code = error instanceof AuthApiError ? error.code : 'AUTH_SERVICE_UNAVAILABLE';
     if (loginFlowEpoch !== expectedLoginFlowEpoch) {
       return { success: false, code: 'AUTH_FLOW_SUPERSEDED', state: loginFlowState };
     }
-    log.warn(`load login providers failed code=${code}`);
-    loginFlowState = { step: 'error', code, recoverTo: 'identifier' };
-    return { success: false, code, state: loginFlowState };
+    const failure = mapLoginProvidersLoadFailure(error);
+    log.warn(`load login providers failed code=${failure.code}`);
+    loginFlowState = failure.state;
+    return failure;
   }
 }
 

--- a/apps/desktop/src/main/authStartupGate.ts
+++ b/apps/desktop/src/main/authStartupGate.ts
@@ -1,3 +1,5 @@
+import { AuthApiError } from '@cindy/auth-client';
+
 /**
  * 冷启动 auth 流程的「限时等待」编排 —— 与 Electron / 网络层解耦的纯逻辑,
  * 供 authManager 的 `initialize()`(splash)与 `loadLoginProviders()`(登录准备态)
@@ -71,4 +73,57 @@ export async function awaitWithStartupTimeout<T>(
   } finally {
     if (timer !== undefined) clearTimeout(timer);
   }
+}
+
+/**
+ * 登录准备态(「正在连接登录服务」)最多阻塞 UI 的时长。getProviders 走
+ * CindyAuthClient 默认 15s AbortController,但黑洞 / captive-portal 下 Electron
+ * `net.fetch` 可能无视 abort,请求永不 settle → renderer 的 preparing 转圈永不
+ * 结束。冷启动 splash 的 `awaitWithStartupTimeout` 闸只包 initialize();登录页是
+ * initialize 完成、GuestRoute 放行之后才出现的。这里复用同一把闸,时限更保守
+ * (30s),超时后走既有 error 步(「暂时无法登录」+ 重试);不 abort 在途 getProviders。
+ */
+export const LOGIN_PREPARING_GATE_TIMEOUT_MS = 30_000;
+
+export interface PreparingGateLog {
+  info: (...args: unknown[]) => void;
+  warn: (...args: unknown[]) => void;
+}
+
+export type LoginProvidersLoadFailure = {
+  success: false;
+  code: string;
+  state: { step: 'error'; code: string; recoverTo: 'identifier' };
+};
+
+/** 把 getProviders 失败(含准备态超时)映射成既有可重试错误步。 */
+export function mapLoginProvidersLoadFailure(error: unknown): LoginProvidersLoadFailure {
+  const code = error instanceof AuthApiError ? error.code : 'AUTH_SERVICE_UNAVAILABLE';
+  return { success: false, code, state: { step: 'error', code, recoverTo: 'identifier' } };
+}
+
+/**
+ * 限时等待登录 providers。超时抛 AUTH_SERVICE_UNAVAILABLE,不 abort 在途请求;
+ * 迟到 settle 只打日志。`getProviders` 由调用方注入,单测可挂起 Promise + 假计时器。
+ */
+export async function awaitLoginProvidersWithPreparingGate<T>(
+  getProviders: Promise<T>,
+  log: PreparingGateLog,
+): Promise<T> {
+  return awaitWithStartupTimeout(getProviders, {
+    timeoutMs: LOGIN_PREPARING_GATE_TIMEOUT_MS,
+    onTimeout: () => {
+      log.warn(
+        `login providers still pending after ${LOGIN_PREPARING_GATE_TIMEOUT_MS}ms — unlocking the preparing UI`,
+      );
+      throw new AuthApiError(
+        'AUTH_SERVICE_UNAVAILABLE',
+        0,
+        'Authentication server did not respond in time',
+      );
+    },
+    onLateResult: () => log.info('login providers settled after preparing gate timeout'),
+    onLateError: (err) =>
+      log.warn('login providers request failed after preparing gate timeout', err),
+  });
 }

--- a/apps/desktop/src/main/authStartupGate.ts
+++ b/apps/desktop/src/main/authStartupGate.ts
@@ -1,7 +1,8 @@
 /**
  * 冷启动 auth 流程的「限时等待」编排 —— 与 Electron / 网络层解耦的纯逻辑,
- * 供 authManager 的 `initialize()` 使用,并可独立单测(authManager 本身依赖
- * Electron,无法在 node 测试环境直接 import,同 authRefreshFailure.ts 的拆分理由)。
+ * 供 authManager 的 `initialize()`(splash)与 `loadLoginProviders()`(登录准备态)
+ * 使用,并可独立单测(authManager 本身依赖 Electron,无法在 node 测试环境直接
+ * import,同 authRefreshFailure.ts 的拆分理由)。
  *
  * 背景:冷启动 refresh 是 token-rotating 端点,**禁止 abort**(服务端已轮换而客户端
  * abort 后,重试旧 token 会命中 INVALID_REFRESH_TOKEN 永久登出)。因此在黑洞 / captive


### PR DESCRIPTION
## 这次改了什么

### 摘要

黑洞或 captive-portal 下，Electron `net.fetch` 可能无视 `CindyAuthClient` 的 15 秒 AbortController，登录准备态（「正在连接登录服务」）会一直转圈。冷启动 splash 那道 20 秒 `awaitWithStartupTimeout` 只包住 `initialize()`，管不到之后的 `loadLoginProviders()`。

本 PR 把同一道闸复用到登录准备态，时限 30 秒。超时后走既有「暂时无法登录」+ 重试，不 abort 在途 `getProviders()`。迟到完成只记日志，不会把已展示的登录流程冲掉。

### 变更类型

- [x] `fix` 缺陷修复
- [ ] `feat` 新功能
- [ ] `refactor` / `perf` 重构或性能优化
- [ ] `docs` / `test` / `chore` 文档、测试或工程维护
- [ ] 其他：

### 范围

- 关联 Issue / 需求：登录准备态卡住、没有超时解锁
- 本 PR 包含：
  - `loadLoginProviders()` 用 `awaitWithStartupTimeout` 包住 `getProviders()`，时限 30s
  - 超时抛既有 `AuthApiError('AUTH_SERVICE_UNAVAILABLE')`，`getLoginState` / `runLoginAction` 的 catch 把它落到 `{ step: 'error', recoverTo: 'identifier' }`
  - `awaitWithStartupTimeout` 的 onTimeout 抛错路径单测，以及 authManager 接线的源码断言
- 明确不包含：
  - 不加大 15s `getProviders` abort
  - 不 abort 在途请求
  - 不加 Ask / permission / stall 超时
  - 不改 LoginPage UI
- 用户可见变化：准备态若 30 秒仍无结果，会切到既有「暂时无法登录」面板，可点重试
- 是否存在 breaking change：无

### UI 变化

不涉及：未改 LoginPage 或任何 renderer 组件。超时后复用既有错误面板与重试入口。

- 引用的设计规范：不涉及

## 怎么验证的

### 自动验证

```text
pnpm test:unit:related
结果：PASS（含 desktop `awaitWithStartupTimeout` 与 `authLoginFlowReset` 接线断言）

pnpm --filter desktop run typecheck
结果：PASS

scripts/run-unit-gate.sh（全量单测）
结果：FAIL TEST_ASSERTION_FAILED packages/maker-core unit
  - pi-agent.integration.test.ts「uses PI bundled xAI APIs…」60s timeout
  - 同文件 BYOM「activeConfigHomes length 1 but got 2」（前一超时用例未清临时目录的级联）
  - 同一次全量中 apps/desktop unit PASS（121s）
  - 在干净 origin/main 基线单独复现上述两条，同样失败
  - 与本 PR diff 无关，不混入修复，交给 CI 兜底
```

### 手工验证

不涉及：未在黑洞 / captive-portal 网络下实机观察准备态 30 秒解锁。

### 未执行的验证

- 实机断网或 captive-portal 下打开登录页，确认约 30 秒切到「暂时无法登录」且重试可用
- 正常网络下确认准备态仍在 30 秒内进入账号输入，无误伤

## 风险

### 风险分类

- [ ] 无已知风险
- [ ] SQLite / migration
- [ ] system prompt
- [ ] 协议兼容
- [ ] 权限 / 安全 / 用户数据
- [ ] 存量插件兼容（批准状态 / 指纹 / manifest 校验 / 安装布局 / 包格式）
- [ ] 原生层 / fingerprint / OTA
- [ ] 跨平台差异
- [x] 其他：登录准备态超时体验。迟到成功不会自动翻页；用户需点重试。闸本身不 abort 在途请求。

### 影响与回滚

- 影响范围：Desktop 登录准备态（`loadLoginProviders` / `getLoginState` / 登录重试）
- 回滚 / 降级方式：revert 本 PR

### 提交前检查

- [x] 已 review 完整 diff
- [x] 每个 commit 都带 DCO 签名（`git commit -s`，见 [DCO](../DCO)）
- [x] UI 改动已在「UI 变化」注明引用的设计规范章节（不涉及 UI 则跳过）
- [x] 未提交凭证、令牌或授权文件
- [x] 已补充必要文档
- [x] 已确认测试结果或说明未执行原因
