### PR TITLE
fix(desktop): iOS 模拟器只认插件开关，从工具页拿掉入口

### DIFF
--- a/apps/desktop/src/main/maker-host/index.ts
+++ b/apps/desktop/src/main/maker-host/index.ts
@@ -763,23 +763,9 @@ export function getMaker(): Maker {
 
     const resolveIOSSimulatorAccess = (context?: IOSSimulatorMcpCallContext) => {
       const workingDir = context?.workingDir?.trim() || null;
-      const pluginAccess = getIOSSimulatorPluginAccessDecision(workingDir);
-      if (!pluginAccess.allowed) return pluginAccess;
-      if (!pluginRegistry.isEnabled('ios-simulator', workingDir ?? undefined)) {
-        return {
-          allowed: false as const,
-          errorCode: 'IOS_SIMULATOR_DISABLED' as const,
-          message:
-            'The embedded iOS Simulator capability is disabled for the current project. Enable it in the project plugin settings before retrying the embedded tool; other iOS workflows are unaffected.',
-          data: {
-            reason: 'disabled-in-workdir',
-            action: 'enable-plugin',
-            pluginId: 'ios-simulator',
-            pluginName: 'iOS Simulator',
-          },
-        };
-      }
-      return { allowed: true as const };
+      // Product access is the installed plugin (enable + workdir disable).
+      // Leftover Tools-page `builtinTools['ios-simulator']` must not gate runtime.
+      return getIOSSimulatorPluginAccessDecision(workingDir);
     };
 
     const makerMemoryProviderDeps = {

--- a/apps/desktop/src/main/maker-host/plugins/__tests__/plugin-registry.test.ts
+++ b/apps/desktop/src/main/maker-host/plugins/__tests__/plugin-registry.test.ts
@@ -120,25 +120,26 @@ describe('PluginRegistry — scoped priority', () => {
     expect(state.projectOverride).toBeNull();
   });
 
-  it('enables the embedded iOS Simulator by default but respects an explicit project disable', async () => {
+  it('hides the embedded iOS Simulator from Tools and ignores leftover Tools settings at runtime freeze', async () => {
+    expect(HOSTED_ELSEWHERE_PLUGIN_IDS.has('ios-simulator')).toBe(true);
     expect(registry.isEnabled('ios-simulator')).toBe(true);
     expect(registry.isEnabled('ios-simulator', workingDir)).toBe(true);
-    await expect(registry.getEnableState('ios-simulator', workingDir)).resolves.toMatchObject({
-      effectiveEnabled: true,
-      productDefaultEnabled: true,
-      projectOverride: null,
-      userOverride: null,
-    });
+    expect((await registry.listPlugins(workingDir)).map((item) => item.id)).not.toContain(
+      'ios-simulator',
+    );
+    expect((await registry.listPlugins()).map((item) => item.id)).not.toContain('ios-simulator');
+    expect(registry.getDisabledRuntimePluginIds(workingDir)).not.toContain('ios-simulator');
 
     writeProjectSettings(workingDir, { 'ios-simulator': false });
     registry = createRegistry();
 
+    // Leftover xdtMaker.builtinTools['ios-simulator'] still parses, but must not
+    // freeze Codex/Pi MCP off — live access is the Plugins-page gate.
     expect(registry.isEnabled('ios-simulator', workingDir)).toBe(false);
-    await expect(registry.getEnableState('ios-simulator', workingDir)).resolves.toMatchObject({
-      effectiveEnabled: false,
-      productDefaultEnabled: true,
-      projectOverride: { enabled: false, workingDir },
-    });
+    expect(registry.getDisabledRuntimePluginIds(workingDir)).not.toContain('ios-simulator');
+    expect((await registry.listPlugins(workingDir)).map((item) => item.id)).not.toContain(
+      'ios-simulator',
+    );
   });
 
   it('returns true by default with workingDir', () => {
@@ -423,6 +424,7 @@ describe('PluginRegistry — scoped priority', () => {
     expect(list.find((item) => item.id === 'android')).toBeUndefined();
     expect(list.find((item) => item.id === 'computer')).toBeUndefined();
     expect(list.find((item) => item.id === 'contacts')).toBeUndefined();
+    expect(list.find((item) => item.id === 'ios-simulator')).toBeUndefined();
   });
 
   it('listPlugins: non-essential defaults to true', async () => {

--- a/apps/desktop/src/main/maker-host/plugins/plugin-registry.ts
+++ b/apps/desktop/src/main/maker-host/plugins/plugin-registry.ts
@@ -245,6 +245,10 @@ export class PluginRegistry {
         // Freezing it here would keep an existing Codex thread disabled after
         // the project setting is enabled.
         plugin.id !== 'collab' &&
+        // iOS Simulator access is the live plugin gate (install / enable /
+        // workdir). Leftover Tools-page builtinTools['ios-simulator'] must not
+        // freeze Codex/Pi MCP off after that toggle left Settings.
+        plugin.id !== 'ios-simulator' &&
         !ESSENTIAL_PLUGIN_IDS.has(plugin.id) &&
         !GLOBAL_PLUGIN_IDS.has(plugin.id) &&
         !this.isEnabled(plugin.id, workingDir),

--- a/apps/desktop/src/main/maker-host/plugins/types.ts
+++ b/apps/desktop/src/main/maker-host/plugins/types.ts
@@ -79,6 +79,9 @@ export const HOSTED_ELSEWHERE_PLUGIN_IDS: ReadonlySet<string> = new Set([
   // 智能通讯录的开关在 Settings → 智能通讯录 专属页(contacts-settings-store),
   // 「内置工具」列表再出现一个 toggle 会造成双开关困惑。
   'contacts',
+  // iOS 模拟器的产品开关只在「插件」页（安装 / 启用 / 当前项目停用）。
+  // Host MCP cindy_ios_simulator 仍留给 Agent 自动化，但不再出现在「内置工具」列表。
+  'ios-simulator',
 ]);
 
 /** Builtin plugins that are intentionally opt-in by default.


### PR DESCRIPTION
## 这次改了什么

### 摘要

iOS 模拟器以前在「设置 → 工具」和「设置 → 插件」各有一个开关，两道门叠在一起。产品上它只是插件：工具页不再列出这个开关，Agent / 运行时访问只认插件的安装、启用和当前项目停用。工具页里留下的旧 `builtinTools['ios-simulator']` 不再挡住能力。Host 上的 `cindy_ios_simulator` MCP 仍留给 Agent 自动化，没有搬进插件沙箱。

### 变更类型

- [ ] `feat` 新功能
- [x] `fix` 缺陷修复
- [ ] `refactor` / `perf` 重构或性能优化
- [ ] `docs` / `test` / `chore` 文档、测试或工程维护
- [ ] 其他：

### 范围

- 关联 Issue / 需求：无（用户要求去掉工具页重复开关，只认插件门）
- 本 PR 包含：
  - 从 Settings → 工具 的通用列表隐藏 `ios-simulator`
  - `resolveIOSSimulatorAccess` 只走插件门
  - Codex / Pi 运行时冻结名单不再收录 `ios-simulator`，避免旧工具设置把 MCP 冻掉
- 明确不包含：不把模拟器运行时搬进 `.cindy` 沙箱；不删除 Host MCP；不改插件安装 / 批准 / 启用协议
- 用户可见变化：Settings → 工具 不再出现「iOS Simulator」开关；开关只在插件页
- 是否存在 breaking change：无。曾在工具页关掉、但插件仍启用的项目，升级后会重新允许使用——这是本改动的预期结果，不是协议或数据不兼容

### UI 变化

设置 → 工具 少一行 iOS 模拟器开关（Desktop）。未改 Settings 组件、样式或文案。

- 引用的设计规范：不涉及：未改 renderer / 样式 / 交互组件，只让 `listPlugins` 不再返回 `ios-simulator`

## 怎么验证的

### 自动验证

```text
pnpm test:unit:related
结果：PASS apps/desktop unit（含 plugin-registry 相关用例；rebase 到 origin/main 后复跑同样通过）

pnpm --filter desktop run --if-present typecheck
结果：通过
```

### 手工验证

不涉及。未打开 Desktop 设置页目检；工具页隐藏由 `listPlugins` 单测覆盖。

### 未执行的验证

未在实机 Settings UI 点开关核对插件页路径。macOS 外平台不涉及此能力。全量 `pnpm test:unit` 在无关的 `packages/maker-core` PI 集成测试失败（xAI baseline 超时、BYOM config home 数量断言）；本 PR 未改 maker-core，未混入修复。

## 风险

### 风险分类

- [ ] 无已知风险
- [ ] SQLite / migration
- [ ] system prompt
- [ ] 协议兼容
- [ ] 权限 / 安全 / 用户数据
- [ ] 存量插件兼容（批准状态 / 指纹 / manifest 校验 / 安装布局 / 包格式）
- [ ] 原生层 / fingerprint / OTA
- [ ] 跨平台差异
- [x] 其他：旧工具页 disable 失效后，插件仍启用的项目会重新放出模拟器能力

### 影响与回滚

- 影响范围：Desktop 设置工具列表；iOS 模拟器 MCP / Codex 动态工具 / IPC 的产品门。插件安装、启用、项目停用语义不变。
- 存量插件影响：无。不改批准状态、指纹、manifest、安装布局或包格式；已装已启用的 iOS 模拟器插件继续可用，不要求重装或重新确认。
- 回滚 / 降级方式：revert 本 PR。工具页开关会回来，旧 `builtinTools['ios-simulator']` 会重新生效。

### 提交前检查

- [x] 已 review 完整 diff
- [x] 每个 commit 都带 DCO 签名（`git commit -s`，见 [DCO](../DCO)）
- [x] UI 改动已在「UI 变化」注明引用的设计规范章节（不涉及 UI 则跳过）
- [x] 未提交凭证、令牌或授权文件
- [ ] 已补充必要文档
- [x] 已确认测试结果或说明未执行原因
