### PR TITLE
fix(device-link): 收敛远程会话列表探测与缓存体积

### DIFF
--- a/apps/desktop/src/main/device-link/__tests__/mirrorCacheIpc.test.ts
+++ b/apps/desktop/src/main/device-link/__tests__/mirrorCacheIpc.test.ts
@@ -568,6 +568,32 @@ describe('session list get / put', () => {
     expect((cache.writeSessionList.mock.calls[0]?.[0] as unknown[]).length).toBe(64);
   });
 
+  it('先投影会话字段再做预算,未缓存的大字段不会阻塞有效会话', async () => {
+    await handleMirrorCachePutSessionList(cache, [
+      {
+        deviceId: 'dev-1',
+        deviceName: 'Mac',
+        sessions: [{
+          id: 's1',
+          status: 'active',
+          title: 'Keep me',
+          summary: 'x'.repeat(600 * 1024),
+          extraRuntimeState: { nested: 'also ignored' },
+        }],
+      },
+    ]);
+
+    expect(cache.writeSessionList).toHaveBeenCalledWith(
+      [{
+        deviceId: 'dev-1',
+        deviceName: 'Mac',
+        sessions: [{ id: 's1', status: 'active', title: 'Keep me' }],
+      }],
+      undefined,
+      undefined,
+    );
+  });
+
   it('列表账号代际只接受非负整数,opaque token 验证后才还原内部 root', async () => {
     const devices = [{ deviceId: 'dev-1', deviceName: 'Mac', sessions: [] }];
     const { ownerToken } = await handleMirrorCacheGetSessionList(cache);

--- a/apps/desktop/src/main/device-link/__tests__/responsivenessTracker.test.ts
+++ b/apps/desktop/src/main/device-link/__tests__/responsivenessTracker.test.ts
@@ -223,7 +223,7 @@ describe('responsivenessTracker', () => {
     expect(h.probeInvoke).toHaveBeenCalledWith(
       DEV,
       DEVICE_RESPONSIVENESS_PROBE_CHANNEL,
-      [1, 'all', { includePinned: true }],
+      [1, 'all', { includePinned: false }],
     );
     // 在途探测占住单飞席位:再 tick 不重复发
     h.tracker.probeTick();

--- a/apps/desktop/src/main/device-link/ipc.ts
+++ b/apps/desktop/src/main/device-link/ipc.ts
@@ -68,7 +68,9 @@ import {
 } from './settings-store';
 import { activeOwnerScopeKey, ownerScopedUserDataPath } from '../appSessionState';
 import {
+  coerceCachedSession,
   getMirrorCache,
+  MAX_CACHED_TEXT_CHARS,
   MirrorCachePurgeError,
   type CachedDeviceSessions,
   type MirrorCache,
@@ -1100,16 +1102,29 @@ export async function handleMirrorCachePutSessionList(
   // 已经吃进去了。截断之后才是「设备数不多但某台带着几十万个 session」这一层(review: codex P1)。
   // 逐台**只挑需要的三个字段**,不做对象展开:一台设备对象可以带上几十万个自有属性,
   // 展开会让 main 先枚举 + 复制整份,结构 / 字节预算要等 boundedItems 才生效(review: codex P1)。
-  // main 侧的 normalizeDeviceSessions 也只消费这三个字段,别的原本就会被白名单丢掉。
+  // session 先经过与落盘侧相同的白名单投影;否则完整 session 上的 summary / extra
+  // 字段会在投影前触发预算,把本可缓存的会话误判成 oversized(review: codex P1)。
   const trimmed = devices.slice(0, MIRROR_CACHE_MAX_INBOUND_DEVICES).map((device) => {
     if (!device || typeof device !== 'object') return device;
     const source = device as { deviceId?: unknown; deviceName?: unknown; sessions?: unknown };
+    const sessions: Record<string, unknown>[] = [];
+    if (Array.isArray(source.sessions)) {
+      for (
+        const rawSession of source.sessions.slice(0, MIRROR_CACHE_MAX_INBOUND_SESSIONS_PER_DEVICE)
+      ) {
+        const session = coerceCachedSession(rawSession);
+        if (session) sessions.push(session);
+      }
+    }
     return {
-      deviceId: source.deviceId,
-      deviceName: source.deviceName,
-      sessions: Array.isArray(source.sessions)
-        ? source.sessions.slice(0, MIRROR_CACHE_MAX_INBOUND_SESSIONS_PER_DEVICE)
-        : [],
+      deviceId: typeof source.deviceId === 'string'
+        && source.deviceId.length <= MIRROR_CACHE_MAX_ID_LENGTH
+        ? source.deviceId
+        : undefined,
+      deviceName: typeof source.deviceName === 'string'
+        ? source.deviceName.slice(0, MAX_CACHED_TEXT_CHARS)
+        : undefined,
+      sessions,
     };
   });
   const ownerRootAtHandler = ownerScopedUserDataPath('device-link-mirror-cache');

--- a/apps/desktop/src/main/device-link/responsivenessTracker.ts
+++ b/apps/desktop/src/main/device-link/responsivenessTracker.ts
@@ -45,12 +45,13 @@ export function createDeviceUnresponsiveError(deviceId: string): DeviceLinkError
  * 代表性探测请求:half-open 探测必须穿过被控端 runInvoke → dispatchLocalInvoke →
  * local-db 读路径才算数(subscribe / unsubscribe / link-accept 在被控端 dispatch 里
  * 于 runInvoke 之前特判应答,IPC/DB 卡死时它们照常回包,不能作恢复证据)。
- * sessions:list limit=1 是最便宜的真实 DB 读;与 mobile 的探测通道一致。
+ * sessions:list limit=1 是最便宜的真实 DB 读;探测刻意不加载全部置顶会话,
+ * 只验证远端 DB / IPC 是否恢复。
  */
 export const DEVICE_RESPONSIVENESS_PROBE_CHANNEL = 'local-db:sessions:list';
 
 export function buildDeviceResponsivenessProbeArgs(): unknown[] {
-  return [1, 'all', { includePinned: true }];
+  return [1, 'all', { includePinned: false }];
 }
 
 export interface DeviceResponsivenessProbeEligibility {

--- a/apps/mobile/src/__tests__/deviceResponsivenessProbe.test.ts
+++ b/apps/mobile/src/__tests__/deviceResponsivenessProbe.test.ts
@@ -28,8 +28,8 @@ describe('DEVICE_RESPONSIVENESS_PROBE_CHANNEL 契约', () => {
     expect(DEVICE_RESPONSIVENESS_PROBE_CHANNEL.startsWith('local-db:')).toBe(true);
   });
 
-  it('探测参数是最小读:limit=1,与 devices 页正常拉取同一参数形状', () => {
-    expect(buildDeviceResponsivenessProbeArgs()).toEqual([1, 'all', { includePinned: true }]);
+  it('探测参数是最小读:limit=1且不加载全部置顶会话', () => {
+    expect(buildDeviceResponsivenessProbeArgs()).toEqual([1, 'all', { includePinned: false }]);
     // 每次新数组,调用方可安全透传给 invoke(不共享可变引用)。
     expect(buildDeviceResponsivenessProbeArgs()).not.toBe(buildDeviceResponsivenessProbeArgs());
   });

--- a/apps/mobile/src/device-link/unresponsiveDevicesStore.ts
+++ b/apps/mobile/src/device-link/unresponsiveDevicesStore.ts
@@ -100,13 +100,14 @@ export function isDeviceProbeDue(deviceId: string): boolean {
  * runInvoke → dispatchLocalInvoke → local-db 读路径才算数——link-accept 与
  * subscribe/unsubscribe 都在 dispatch 里于 runInvoke **之前**特判应答,
  * IPC/DB 子系统卡死时它们照常回包,不能作为恢复证据。sessions:list limit=1
- * 是最便宜的真实 DB 读,恰好就是事故里被卡死的那类请求;args 形状与
- * devices 页的正常拉取一致([limit, statusFilter, opts])。
+ * 是最便宜的真实 DB 读,恰好就是事故里被卡死的那类请求;探测刻意不加载全部置顶
+ * 会话,只验证远端 DB / IPC 是否恢复;args 形状与 devices 页的正常拉取一致
+ * ([limit, statusFilter, opts])。
  */
 export const DEVICE_RESPONSIVENESS_PROBE_CHANNEL = 'local-db:sessions:list';
 
 export function buildDeviceResponsivenessProbeArgs(): unknown[] {
-  return [1, 'all', { includePinned: true }];
+  return [1, 'all', { includePinned: false }];
 }
 
 /**


### PR DESCRIPTION
## 这次改了什么

### 摘要

修复 Device Link 巡检发现的远程会话探测与镜像缓存问题：探测只查询非置顶会话，避免 `limit=1` 仍额外扫描全部置顶会话；镜像缓存先按现有会话白名单归一化，再执行字节预算，避免无关的大字段把有效会话挤出缓存。

### 变更类型

- [x] `fix` 缺陷修复
- [ ] `feat` 新功能
- [ ] `refactor` / `perf` 重构或优化
- [ ] `docs` / `test` / `chore` 工程维护
- [ ] 其他：

### 范围

- 关联 Issue / 需求：无（来自 Device Link 使用体验巡检 P1）
- 本 PR 包含：Desktop / Mobile 的设备响应探测参数收敛；Desktop mirror-cache session-list IPC 的缓存字段归一化、字段限长与预算前过滤。
- 明确不包含：服务端、Device Link wire protocol / relay、system prompt、translator、usage、event loop，以及新增队列或第二套重试机制。
- 用户可见变化：设备响应探测减少不必要的数据库扫描；远程会话列表缓存不再因无关的大字段丢弃有效会话。
- 是否存在 breaking change：无

### UI 变化

- 不涉及：仅调整 Device Link 探测与缓存数据边界，没有 UI、交互或文案变化。
- 引用的设计规范：不涉及 UI。

## 怎么验证的

### 自动验证

```text
pnpm test:unit:related
结果：通过

Desktop Device Link 定向测试
结果：62/62 通过

Mobile Device Link 定向测试
结果：8/8 通过

pnpm --filter @cindy/device-link test
结果：171/171 通过

pnpm --filter desktop typecheck
结果：通过

pnpm --filter mobile typecheck
结果：通过

pnpm check:dco
结果：通过
```

### 手工验证

不涉及：本 PR 未改变运行时 UI；未做真实多设备 cua-driver / Device Link 端到端演练。

### 未执行的验证

未完成根 `run-unit-gate.sh` 的全绿结果：本轮全量 gate 报告 `apps/desktop` 的 AgentIsland headless 测试超时，以及 `@cindy/maker-core` 的两个 PI integration 测试失败。Desktop 失败文件在干净 `origin/main` 基线单文件复现为 127/127 通过；maker-core PI integration 在干净 `origin/main` 基线复现为同样的 2 个失败（46 通过、1 跳过）。这些失败不涉及本 PR 修改的 6 个 device-link 文件，完整日志已保留在本机 gate 输出中。

## 风险

### 风险分类

- [ ] 无已知风险
- [ ] SQLite / migration
- [ ] system prompt
- [ ] 协议兼容
- [ ] 权限 / 安全 / 用户数据
- [ ] 存量插件兼容（批准状态 / 指纹 / manifest 校验 / 安装布局 / 包格式）
- [x] 跨平台差异
- [ ] 其他：

### 影响与回滚

- 影响范围：Desktop 与 Mobile 的设备响应探测，以及 Desktop 的 Device Link 镜像会话列表缓存；不改变跨端 wire protocol。
- 回滚 / 降级方式：回退本 PR commit 即可恢复原有探测参数与缓存筛选行为，不需要数据迁移。

### 提交前检查

- [x] 已 review 完整 diff
- [x] 每个 commit 都带 DCO 签名（`git commit -s`，见 [DCO](../DCO)）
- [x] UI 改动已在「UI 变化」注明引用的设计规范章节（不涉及 UI）
- [x] 未提交凭证、令牌或授权文件
- [x] 已补充必要文档
- [x] 已确认测试结果或说明未执行原因
