### PR TITLE
feat(desktop): 有任务在跑时延后弹出更新横幅

### DIFF
--- a/apps/desktop/src/main/__tests__/relaunchBusyActivityIpcBoundary.test.ts
+++ b/apps/desktop/src/main/__tests__/relaunchBusyActivityIpcBoundary.test.ts
@@ -16,6 +16,12 @@ const h = vi.hoisted(() => ({
   trusted: true,
   reads: 0,
   removed: [] as string[],
+  log: {
+    warn: vi.fn(),
+    error: vi.fn(),
+    info: vi.fn(),
+    debug: vi.fn(),
+  },
 }));
 
 // 仿 Electron 的真实行为:同一 channel 第二次 handle 直接抛。幂等注册要靠 removeHandler,
@@ -35,7 +41,7 @@ vi.mock('electron', () => ({
   },
 }));
 vi.mock('../logger', () => ({
-  createLogger: () => ({ warn: vi.fn(), error: vi.fn(), info: vi.fn(), debug: vi.fn() }),
+  createLogger: () => h.log,
 }));
 vi.mock('../security/trustedAppRenderer', () => ({
   assertTrustedAppRendererEvent: () => {
@@ -69,6 +75,7 @@ beforeEach(() => {
   h.trusted = true;
   h.reads = 0;
   h.removed = [];
+  h.log.info.mockClear();
 });
 
 describe('registerRelaunchBusyActivityIpc', () => {
@@ -94,6 +101,28 @@ describe('registerRelaunchBusyActivityIpc', () => {
 
     const handler = h.handlers.get(RELAUNCH_BLOCKING_ACTIVITY_CHANNEL)!;
     await expect(handler(fakeEvent)).resolves.toBe(true);
+  });
+
+  it('busy 的手动查询打 INFO', async () => {
+    registerRelaunchBusyActivityIpc(countingSources(true));
+    const handler = h.handlers.get(RELAUNCH_BLOCKING_ACTIVITY_CHANNEL)!;
+    await expect(handler(fakeEvent)).resolves.toBe(true);
+    expect(h.log.info).toHaveBeenCalledTimes(1);
+    expect(h.log.info.mock.calls[0]?.[0]).toBe('manual relaunch has live activity');
+  });
+
+  it('silent:true 的 busy 结果不打 INFO（横幅延后轮询）', async () => {
+    registerRelaunchBusyActivityIpc(countingSources(true));
+    const handler = h.handlers.get(RELAUNCH_BLOCKING_ACTIVITY_CHANNEL)!;
+    await expect(handler(fakeEvent, { silent: true })).resolves.toBe(true);
+    expect(h.log.info).not.toHaveBeenCalled();
+  });
+
+  it('非 boolean true 的 silent 不当静默', async () => {
+    registerRelaunchBusyActivityIpc(countingSources(true));
+    const handler = h.handlers.get(RELAUNCH_BLOCKING_ACTIVITY_CHANNEL)!;
+    await expect(handler(fakeEvent, { silent: 'true' })).resolves.toBe(true);
+    expect(h.log.info).toHaveBeenCalledTimes(1);
   });
 
   it('不可信 sender(WebView / 子 frame / 未登记窗口):拒绝，且一个来源都不读', async () => {

--- a/apps/desktop/src/main/relaunchBusyActivityIpc.ts
+++ b/apps/desktop/src/main/relaunchBusyActivityIpc.ts
@@ -22,6 +22,15 @@ export const RELAUNCH_BLOCKING_ACTIVITY_CHANNEL = 'update-relaunch:blocking-acti
 const log = createLogger('relaunch-activity');
 
 /**
+ * 横幅延后轮询会反复问同一条探针,但不能把每次 busy 都打成「manual relaunch」INFO。
+ * Renderer 传入的 payload 不可信:只有精确 `{ silent: true }` 才静默,其余一律按手动查询打日志。
+ */
+function isSilentBusyProbe(payload: unknown): boolean {
+  if (payload == null || typeof payload !== 'object' || Array.isArray(payload)) return false;
+  return (payload as { silent?: unknown }).silent === true;
+}
+
+/**
  * 注册手动更新重启的阻断查询。
  *
  * `sources` 用工厂形态传入(而非直接给值):handler 每次被调用都要拿**当时**的跟踪器,
@@ -38,10 +47,11 @@ export function registerRelaunchBusyActivityIpc(
   // 同一行 —— 结果是 maker 链路永久不可用。先 remove 再 handle,让重复调用总是收敛到
   // 「一个当前有效的 handler」。
   ipcMain.removeHandler(RELAUNCH_BLOCKING_ACTIVITY_CHANNEL);
-  ipcMain.handle(RELAUNCH_BLOCKING_ACTIVITY_CHANNEL, async (event) => {
+  ipcMain.handle(RELAUNCH_BLOCKING_ACTIVITY_CHANNEL, async (event, payload) => {
     assertTrustedAppRendererEvent(event);
+    const silent = isSilentBusyProbe(payload);
     const result = await evaluateRelaunchBusyActivity(resolveSources());
-    if (result.busy) {
+    if (result.busy && !silent) {
       log.info('manual relaunch has live activity', { reasons: result.reasons });
     }
     return result.busy;

--- a/apps/desktop/src/preload/preload.ts
+++ b/apps/desktop/src/preload/preload.ts
@@ -3955,9 +3955,11 @@ contextBridge.exposeInMainWorld('electronAPI', {
    * Ghost card-action 后台活动),判定与 fail-closed 口径都在 main 侧一处
    * (relaunchBusyActivity.ts)—— renderer 逐个枚举来源会漏,漏了就是静默打断用户任务。
    * 供 UpdateBanner 决定「直接重启」还是「先弹中断警告」。
+   * `silent: true` 只关掉 busy 时的「manual relaunch」INFO(横幅延后轮询用);
+   * 判定本身不变。
    */
-  anyActivityBlockingRelaunch: (): Promise<boolean> =>
-    ipcRenderer.invoke('update-relaunch:blocking-activity'),
+  anyActivityBlockingRelaunch: (opts?: { silent?: boolean }): Promise<boolean> =>
+    ipcRenderer.invoke('update-relaunch:blocking-activity', opts),
 
   /**
    * Tell the main process to apply the downloaded update and relaunch.

--- a/apps/desktop/src/renderer/__tests__/updateBannerBusyDefer.test.tsx
+++ b/apps/desktop/src/renderer/__tests__/updateBannerBusyDefer.test.tsx
@@ -1,0 +1,226 @@
+// @vitest-environment jsdom
+
+/**
+ * 更新就绪后完整 banner 的自动弹出时机:有任务在跑(与「立即重启」二次确认同一条
+ * 探针)就不占侧栏,只留最小化入口;全部停下后再弹出。用户点 X 关掉的不自动恢复。
+ *
+ * 本文件覆盖这条自动路径。点入口之后「拦不拦重启」仍由 updateBannerRelaunchEntry 负责。
+ */
+
+import { act, cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { UpdateBanner } from '@/components/sidebar/UpdateBanner';
+import {
+  UPDATE_BANNER_BUSY_POLL_MS,
+} from '@/hooks/useDeferUpdateBannerWhileBusy';
+import {
+  deferUpdateBannerBecauseBusy,
+  dismissUpdateBanner,
+  getUpdateBannerDismissState,
+  markUpdateBannerAutoShown,
+  resetUpdateBannerDismissStoreForTests,
+  restoreUpdateBanner,
+} from '@/hooks/useUpdateBannerDismiss';
+
+vi.mock('react-i18next', () => ({
+  useTranslation: () => ({
+    t: (key: string) => key,
+  }),
+}));
+
+vi.mock('@/hooks/useLocale', () => ({
+  useLocale: () => ({ locale: 'en', effectiveLocale: 'en', setLocale: vi.fn() }),
+}));
+
+const updateStatus = vi.hoisted(() => ({
+  current: { status: 'ready', version: '1.2.3', errorCode: null } as {
+    status: string;
+    version?: string;
+    errorCode: string | null;
+  },
+}));
+
+vi.mock('@/hooks/useUpdateStatus', () => ({
+  useUpdateStatus: () => updateStatus.current,
+}));
+
+vi.mock('@/components/ui/tooltip', () => ({
+  Tip: ({ children }: { children: React.ReactNode }) => children,
+}));
+
+const { anyActivityBlockingRelaunch, relaunchToUpdate } = vi.hoisted(() => ({
+  anyActivityBlockingRelaunch: vi.fn<() => Promise<boolean>>(),
+  relaunchToUpdate: vi.fn(),
+}));
+
+const EXPANDED = 'update.banner.ariaExpanded';
+const COLLAPSED = 'update.banner.ariaCollapsed';
+
+function deferredProbe(): (busy: boolean) => void {
+  let settle!: (busy: boolean) => void;
+  anyActivityBlockingRelaunch.mockImplementation(
+    () => new Promise<boolean>((resolve) => { settle = resolve; }),
+  );
+  return (busy: boolean) => settle(busy);
+}
+
+beforeEach(() => {
+  resetUpdateBannerDismissStoreForTests();
+  anyActivityBlockingRelaunch.mockReset();
+  relaunchToUpdate.mockReset();
+  updateStatus.current = { status: 'ready', version: '1.2.3', errorCode: null };
+  Object.defineProperty(window, 'electronAPI', {
+    configurable: true,
+    value: {
+      anyActivityBlockingRelaunch,
+      relaunchToUpdate,
+      clientEndpoints: { websiteUrl: 'https://cindy.ai' },
+    } as unknown as Window['electronAPI'],
+  });
+});
+
+afterEach(() => {
+  cleanup();
+  vi.useRealTimers();
+});
+
+describe('update banner dismiss store', () => {
+  it('does not let a busy defer overwrite a user dismiss', () => {
+    dismissUpdateBanner('ready', '1.0.0');
+    deferUpdateBannerBecauseBusy('ready', '1.0.0');
+    expect(getUpdateBannerDismissState().reason).toBe('user');
+    expect(getUpdateBannerDismissState().dismissed).toBe(true);
+  });
+
+  it('does not let idle auto-show restore a user dismiss', () => {
+    dismissUpdateBanner('ready', '1.0.0');
+    markUpdateBannerAutoShown('1.0.0');
+    expect(getUpdateBannerDismissState().dismissed).toBe(true);
+    expect(getUpdateBannerDismissState().reason).toBe('user');
+  });
+
+  it('is a no-op when the same busy snapshot is recorded twice', () => {
+    deferUpdateBannerBecauseBusy('ready', '1.0.0');
+    const first = getUpdateBannerDismissState();
+    deferUpdateBannerBecauseBusy('ready', '1.0.0');
+    expect(getUpdateBannerDismissState()).toBe(first);
+  });
+});
+
+describe('UpdateBanner busy defer', () => {
+  it('keeps the expanded banner hidden while the first probe is in flight', async () => {
+    const settle = deferredProbe();
+    render(<UpdateBanner isCollapsed={false} />);
+
+    expect(screen.queryByRole('button', { name: EXPANDED })).toBeNull();
+    await waitFor(() => expect(anyActivityBlockingRelaunch).toHaveBeenCalledTimes(1));
+
+    settle(false);
+    expect(await screen.findByRole('button', { name: EXPANDED })).toBeTruthy();
+    expect(getUpdateBannerDismissState().dismissed).toBe(false);
+  });
+
+  it('shows the expanded banner when main reports nothing running', async () => {
+    anyActivityBlockingRelaunch.mockResolvedValue(false);
+    render(<UpdateBanner isCollapsed={false} />);
+
+    expect(await screen.findByRole('button', { name: EXPANDED })).toBeTruthy();
+    expect(getUpdateBannerDismissState().reason).toBeNull();
+  });
+
+  it('hides the expanded banner when main reports live activity', async () => {
+    anyActivityBlockingRelaunch.mockResolvedValue(true);
+    render(<UpdateBanner isCollapsed={false} />);
+
+    await waitFor(() => expect(getUpdateBannerDismissState().reason).toBe('busy'));
+    expect(screen.queryByRole('button', { name: EXPANDED })).toBeNull();
+    expect(relaunchToUpdate).not.toHaveBeenCalled();
+  });
+
+  it('keeps the collapsed flame as the minimized reminder while busy', async () => {
+    anyActivityBlockingRelaunch.mockResolvedValue(true);
+    render(<UpdateBanner isCollapsed />);
+
+    expect(await screen.findByRole('button', { name: COLLAPSED })).toBeTruthy();
+    await waitFor(() => expect(getUpdateBannerDismissState().reason).toBe('busy'));
+    expect(screen.getByRole('button', { name: COLLAPSED })).toBeTruthy();
+  });
+
+  it('falls back to hiding the expanded banner when the busy probe throws', async () => {
+    anyActivityBlockingRelaunch.mockImplementation(() => {
+      throw new Error('electron bridge is not registered');
+    });
+    render(<UpdateBanner isCollapsed={false} />);
+
+    await waitFor(() => expect(getUpdateBannerDismissState().reason).toBe('busy'));
+    expect(screen.queryByRole('button', { name: EXPANDED })).toBeNull();
+  });
+
+  it('falls back to hiding the expanded banner when the busy probe rejects', async () => {
+    anyActivityBlockingRelaunch.mockRejectedValue(new Error('ipc channel closed'));
+    render(<UpdateBanner isCollapsed={false} />);
+
+    await waitFor(() => expect(getUpdateBannerDismissState().reason).toBe('busy'));
+    expect(screen.queryByRole('button', { name: EXPANDED })).toBeNull();
+  });
+
+  it('does not auto-restore a banner the user dismissed once the probe goes idle', async () => {
+    anyActivityBlockingRelaunch.mockResolvedValue(false);
+    render(<UpdateBanner isCollapsed={false} />);
+    expect(await screen.findByRole('button', { name: EXPANDED })).toBeTruthy();
+
+    fireEvent.click(screen.getByRole('button', { name: 'update.banner.dismissAria' }));
+    expect(screen.queryByRole('button', { name: EXPANDED })).toBeNull();
+    expect(getUpdateBannerDismissState().reason).toBe('user');
+
+    anyActivityBlockingRelaunch.mockResolvedValue(false);
+    await act(async () => {
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+    expect(screen.queryByRole('button', { name: EXPANDED })).toBeNull();
+    expect(getUpdateBannerDismissState().reason).toBe('user');
+  });
+
+  it('does not hide the banner again after the user reopens it while still busy', async () => {
+    anyActivityBlockingRelaunch.mockResolvedValue(true);
+    const { rerender } = render(<UpdateBanner isCollapsed={false} />);
+    await waitFor(() => expect(getUpdateBannerDismissState().reason).toBe('busy'));
+    expect(screen.queryByRole('button', { name: EXPANDED })).toBeNull();
+
+    act(() => {
+      restoreUpdateBanner();
+    });
+    rerender(<UpdateBanner isCollapsed={false} />);
+    expect(await screen.findByRole('button', { name: EXPANDED })).toBeTruthy();
+
+    await act(async () => {
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+    expect(screen.getByRole('button', { name: EXPANDED })).toBeTruthy();
+    expect(getUpdateBannerDismissState().dismissed).toBe(false);
+  });
+
+  it('pops the expanded banner once a later poll sees idle', async () => {
+    vi.useFakeTimers();
+    let busy = true;
+    anyActivityBlockingRelaunch.mockImplementation(() => Promise.resolve(busy));
+    render(<UpdateBanner isCollapsed={false} />);
+
+    await act(async () => {
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+    expect(getUpdateBannerDismissState().reason).toBe('busy');
+    expect(screen.queryByRole('button', { name: EXPANDED })).toBeNull();
+
+    busy = false;
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(UPDATE_BANNER_BUSY_POLL_MS);
+    });
+    expect(screen.getByRole('button', { name: EXPANDED })).toBeTruthy();
+    expect(getUpdateBannerDismissState().dismissed).toBe(false);
+  });
+});

--- a/apps/desktop/src/renderer/__tests__/updateBannerBusyDefer.test.tsx
+++ b/apps/desktop/src/renderer/__tests__/updateBannerBusyDefer.test.tsx
@@ -115,6 +115,7 @@ describe('UpdateBanner busy defer', () => {
 
     expect(screen.queryByRole('button', { name: EXPANDED })).toBeNull();
     await waitFor(() => expect(anyActivityBlockingRelaunch).toHaveBeenCalledTimes(1));
+    expect(anyActivityBlockingRelaunch).toHaveBeenCalledWith({ silent: true });
 
     settle(false);
     expect(await screen.findByRole('button', { name: EXPANDED })).toBeTruthy();
@@ -145,6 +146,7 @@ describe('UpdateBanner busy defer', () => {
     expect(await screen.findByRole('button', { name: COLLAPSED })).toBeTruthy();
     await waitFor(() => expect(getUpdateBannerDismissState().reason).toBe('busy'));
     expect(screen.getByRole('button', { name: COLLAPSED })).toBeTruthy();
+    expect(screen.queryByRole('button', { name: EXPANDED })).toBeNull();
   });
 
   it('falls back to hiding the expanded banner when the busy probe throws', async () => {

--- a/apps/desktop/src/renderer/__tests__/updateBannerRelaunchEntry.test.tsx
+++ b/apps/desktop/src/renderer/__tests__/updateBannerRelaunchEntry.test.tsx
@@ -52,10 +52,21 @@ vi.mock('@/hooks/useUpdateStatus', () => ({
 vi.mock('@/hooks/useUpdateBannerDismiss', () => ({
   useUpdateBannerDismiss: () => ({
     dismissed: dismissState.dismissed,
+    reason: null,
     dismiss: () => { dismissState.dismissed = true; },
     restore: () => { dismissState.dismissed = false; },
+    deferBecauseBusy: vi.fn(),
+    markAutoShown: vi.fn(),
+    clearAutoDecision: vi.fn(),
+    isDecidedFor: () => true,
     isNewUpdateAfterDismiss: () => false,
   }),
+}));
+
+// 本文件只测「点入口之后」的重启判定;自动弹出让路由 updateBannerBusyDefer 覆盖。
+vi.mock('@/hooks/useDeferUpdateBannerWhileBusy', () => ({
+  useDeferUpdateBannerWhileBusy: () => false,
+  UPDATE_BANNER_BUSY_POLL_MS: 2000,
 }));
 
 vi.mock('@/components/ui/tooltip', () => ({

--- a/apps/desktop/src/renderer/__tests__/updateBannerReleaseNotesLink.test.tsx
+++ b/apps/desktop/src/renderer/__tests__/updateBannerReleaseNotesLink.test.tsx
@@ -11,6 +11,7 @@ import { cleanup, fireEvent, render, screen, waitFor } from '@testing-library/re
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 import { UpdateBanner } from '@/components/sidebar/UpdateBanner';
+import { resetUpdateBannerDismissStoreForTests } from '@/hooks/useUpdateBannerDismiss';
 
 vi.mock('react-i18next', () => ({
   useTranslation: () => ({
@@ -50,6 +51,7 @@ const { anyActivityBlockingRelaunch, relaunchToUpdate } = vi.hoisted(() => ({
 }));
 
 beforeEach(() => {
+  resetUpdateBannerDismissStoreForTests();
   updateStatus.current = { status: 'ready', version: '1.4.2' };
   fetchReleaseNotes.mockReset();
   fetchReleaseNotes.mockResolvedValue(NOTES);
@@ -91,6 +93,8 @@ describe('UpdateBanner release-notes link', () => {
   });
 
   it('hides the link while the busy-turn interruption warning is showing', async () => {
+    // 自动弹出探针先给 idle,让完整横幅出来;点入口再报 busy,才进中断警告。
+    anyActivityBlockingRelaunch.mockResolvedValueOnce(false);
     anyActivityBlockingRelaunch.mockResolvedValue(true);
     render(<UpdateBanner isCollapsed={false} onOpenVersionNotice={vi.fn()} />);
     await screen.findByText(LINK);

--- a/apps/desktop/src/renderer/__tests__/userInfoSectionUpdateFlame.test.tsx
+++ b/apps/desktop/src/renderer/__tests__/userInfoSectionUpdateFlame.test.tsx
@@ -1,0 +1,83 @@
+// @vitest-environment jsdom
+
+/**
+ * 头像行火焰与 UpdateBanner 折叠火焰互斥:rail 的 UserInfoSection 不渲染火焰,
+ * 展开态才在 banner 被藏起时用这颗涂黑入口。钉住 Greptile 说的「busy 时两颗火焰」。
+ */
+
+import { cleanup, render, screen } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+vi.mock('react-i18next', () => ({
+  useTranslation: () => ({
+    t: (key: string) => key,
+  }),
+}));
+
+vi.mock('react-router-dom', () => ({
+  useLocation: () => ({ pathname: '/' }),
+  useNavigate: () => vi.fn(),
+}));
+
+vi.mock('@/contexts/AuthContext', () => ({
+  useAuth: () => ({
+    user: { name: 'Cindy user', avatar: null },
+    mode: 'cloud',
+    isCanary: false,
+  }),
+}));
+
+vi.mock('@/hooks/useUpdateStatus', () => ({
+  useUpdateStatus: () => ({ status: 'ready', version: '1.2.3', errorCode: null }),
+}));
+
+vi.mock('@/hooks/useUpdateBannerDismiss', () => ({
+  useUpdateBannerDismiss: () => ({ dismissed: true, restore: vi.fn(), reason: 'busy' }),
+}));
+
+vi.mock('@/hooks/useBetaChannelSettings', () => ({
+  useBetaChannelSettings: () => ({
+    state: { enableBeta: false, isCustomized: false, loading: false },
+  }),
+}));
+
+vi.mock('@/hooks/useLogout', () => ({
+  useLogout: () => ({ handleLogout: vi.fn() }),
+}));
+
+vi.mock('@/components/sidebar/MobileDownloadDialog', () => ({
+  MobileDownloadDialog: () => null,
+}));
+
+vi.mock('@/components/ui/tooltip', () => ({
+  Tip: ({ children }: { children: React.ReactNode }) => children,
+}));
+
+import { UserInfoSection } from '@/components/sidebar/UserInfoSection';
+
+beforeEach(() => {
+  Object.defineProperty(window, 'electronAPI', {
+    configurable: true,
+    value: {
+      appDisplayVersion: '1.0.0',
+      appDisplayVersionDetail: '1.0.0-test',
+    },
+  });
+});
+
+afterEach(cleanup);
+
+describe('UserInfoSection update flame vs rail', () => {
+  it('does not render the reopen flame in the rail layout while busy-deferred', () => {
+    render(<UserInfoSection isCollapsed onOpenUpdateNotice={() => {}} />);
+
+    expect(screen.queryByRole('button', { name: 'sidebar.user.reopenUpdateBanner' })).toBeNull();
+    expect(screen.queryByRole('button', { name: 'sidebar.user.viewReleaseNotes' })).toBeNull();
+  });
+
+  it('renders the reopen flame in the expanded layout while the banner is deferred', () => {
+    render(<UserInfoSection isCollapsed={false} onOpenUpdateNotice={() => {}} />);
+
+    expect(screen.getByRole('button', { name: 'sidebar.user.reopenUpdateBanner' })).toBeTruthy();
+  });
+});

--- a/apps/desktop/src/renderer/components/sidebar/Sidebar.tsx
+++ b/apps/desktop/src/renderer/components/sidebar/Sidebar.tsx
@@ -238,7 +238,9 @@ export function Sidebar({
         )}
 
         {/* Update banner: shown only when a verified update is ready
-          peek 抽屉视同展开(否则横幅在抽屉里消失,与「预览完整列表」语义相悖)。 */}
+          peek 抽屉视同展开(否则横幅在抽屉里消失,与「预览完整列表」语义相悖)。
+          最小化入口互斥:展开态 busy 让路时本组件不渲染、头像行火焰涂黑;rail 时
+          UserInfoSection 只回头像,折叠火焰就是那条提醒。 */}
         <UpdateBanner
           isCollapsed={(isCollapsed && !isPeek) || isRail}
           onOpenVersionNotice={onOpenVersionNotice}

--- a/apps/desktop/src/renderer/components/sidebar/UpdateBanner.tsx
+++ b/apps/desktop/src/renderer/components/sidebar/UpdateBanner.tsx
@@ -200,6 +200,10 @@ export function UpdateBanner({ isCollapsed, onOpenVersionNotice }: UpdateBannerP
   // 展开态的完整横幅:用户关掉、有任务在跑、或探针还没给出「弹出 / 让路」决定时
   // 都不渲染,避免闪一下再收成火焰。收起态那颗小火焰本身就是最小化提醒,busy
   // 让路和探针空窗都要留着;只有用户点过 X 才连它一起藏。
+  //
+  // 不会跟 UserInfoSection 头像行火焰叠两颗:Sidebar 把 UserInfoSection.isCollapsed
+  // 绑在 isRail 上,rail 分支只渲染头像、没有火焰;展开态本组件在 hideExpandedBanner
+  // 时 return null,只留头像行那颗。busy 时若把折叠火焰也藏掉,rail 会完全没入口。
   const hideExpandedBanner =
     hideUntilBusyDecision
     || (dismissed && (status === 'ready' || isPreparing));

--- a/apps/desktop/src/renderer/components/sidebar/UpdateBanner.tsx
+++ b/apps/desktop/src/renderer/components/sidebar/UpdateBanner.tsx
@@ -6,6 +6,10 @@
  * of the already-ready patch (status === 'superseding'). Sits between the upper
  * content slot and UserInfoSection in the Sidebar shell.
  *
+ * 自动弹出前先问「有没有任务在跑」(与「立即重启」二次确认同一条探针)。有任务时展开态
+ * 不占侧栏,只留头像行火焰;收起态那颗小火焰本身就是最小化提醒,继续留着。全部停下后再
+ * 弹出完整横幅。用户点 X 关掉的不自动恢复。
+ *
  * 点「立即重启」不再无条件多要一次确认:先查「有没有任务在跑」(逻辑 turn + turn 已结束但
  * 仍在调模型的后台活动,两个来源都要看),**只有真的有任务时**才就地切换成确认态,确认没有
  * 就直接重启。原先那句「应用会自动重启」的中性二次确认纯属多一次点击、不带信息,已退役。
@@ -47,6 +51,7 @@ import { cn } from '@/lib/utils';
 import { Spinner } from '@/components/ui/spinner';
 import { useUpdateStatus } from '@/hooks/useUpdateStatus';
 import { useUpdateBannerDismiss } from '@/hooks/useUpdateBannerDismiss';
+import { useDeferUpdateBannerWhileBusy } from '@/hooks/useDeferUpdateBannerWhileBusy';
 import { useLocale } from '@/hooks/useLocale';
 import { ConfirmDialog } from '@/components/ui/confirm-dialog';
 import { Tip } from '@/components/ui/tooltip';
@@ -68,9 +73,9 @@ export function UpdateBanner({ isCollapsed, onOpenVersionNotice }: UpdateBannerP
   const { status, version, errorCode } = useUpdateStatus();
   const { effectiveLocale } = useLocale();
   // 用户主动关闭态(仅本次进程内存,由 UserInfoSection 的火焰按钮唤回)。
-  // status/version 变化时下面 effect 会自动 restore,新一版更新到达时 banner
-  // 重新出现,不会被上一版的 dismiss 状态吞掉。
-  const { dismissed, dismiss, restore, isNewUpdateAfterDismiss } = useUpdateBannerDismiss();
+  // 新一版更新到达时 useDeferUpdateBannerWhileBusy 会清掉上一版的决定并重新探针。
+  const { dismissed, dismiss, reason } = useUpdateBannerDismiss();
+  const hideUntilBusyDecision = useDeferUpdateBannerWhileBusy(status, version);
   // 就地中断警告态:只在点击入口时探到「有任务在跑」才进入。
   const [confirming, setConfirming] = useState(false);
   // 入口点击的 busy 探针在飞标记 —— 防重入。探针是一次 IPC round trip(毫秒级),所以
@@ -134,16 +139,6 @@ export function UpdateBanner({ isCollapsed, onOpenVersionNotice }: UpdateBannerP
   // 会真的把 app 重启掉 —— 这条 cleanup 不是防 React 警告,是防意外重启。
   useEffect(() => () => { relaunchEpochRef.current += 1; }, []);
 
-  // 新更新到达时自动 restore:isNewUpdateAfterDismiss 先检查当前 status 是否为
-  // active update 态(ready / superseding),再对比 dismiss 时的快照——两个条件
-  // 都满足才 restore(),从而避免 remount 时 useUpdateStatus() 经历 idle→ready
-  // 的初始水合过程中误触 restore。
-  useEffect(() => {
-    if (isNewUpdateAfterDismiss(status, version ?? null)) {
-      restore();
-    }
-  }, [status, version, restore, isNewUpdateAfterDismiss]);
-
   // 焦点管理:进入确认态 → 聚焦「取消」(安全默认 + 键盘可达);主动取消退出确认态 →
   // 把焦点还给入口「立即重启」按钮,避免焦点掉到 body。
   useEffect(() => {
@@ -202,10 +197,16 @@ export function UpdateBanner({ isCollapsed, onOpenVersionNotice }: UpdateBannerP
   // dialogs. Everything else hides the banner.
   if (status !== 'ready' && !isPreparing && !isTranslocated && !isSpawnFailed) return null;
 
-  // 用户主动 dismiss 后隐藏 banner —— 只作用于 ready/superseding,error 态
-  // 只弹 modal 与 dismiss 无关。dismiss 逻辑在 handleDismiss 里把 confirming 一并
-  // 复位,这里只负责渲染分支。
-  if (dismissed && (status === 'ready' || isPreparing)) return null;
+  // 展开态的完整横幅:用户关掉、有任务在跑、或探针还没给出「弹出 / 让路」决定时
+  // 都不渲染,避免闪一下再收成火焰。收起态那颗小火焰本身就是最小化提醒,busy
+  // 让路和探针空窗都要留着;只有用户点过 X 才连它一起藏。
+  const hideExpandedBanner =
+    hideUntilBusyDecision
+    || (dismissed && (status === 'ready' || isPreparing));
+  if (!isCollapsed && hideExpandedBanner) return null;
+  if (isCollapsed && dismissed && reason === 'user' && (status === 'ready' || isPreparing)) {
+    return null;
+  }
 
   const handleRelaunch = () => {
     const theme = document.documentElement.classList.contains('dark') ? 'dark' : 'light';

--- a/apps/desktop/src/renderer/components/sidebar/UserInfoSection.tsx
+++ b/apps/desktop/src/renderer/components/sidebar/UserInfoSection.tsx
@@ -320,7 +320,8 @@ export function UserInfoSection({ isCollapsed, onOpenUpdateNotice }: UserInfoSec
 
         {/* Flame icon button — 默认打开更新历史;banner 被 dismiss 且有 pending
           update 时切换为「唤回 banner」入口,视觉涂黑(fill 实心 + foreground 主色)
-          告诉用户还有更新等待确认。 */}
+          告诉用户还有更新等待确认。rail 走上面的头像-only 分支,不会渲染这颗;
+          busy 让路时折叠火焰才是最小化提醒,展开态才用这颗涂黑入口。 */}
         {(onOpenUpdateNotice || isFlameReopen) && (
           <Tip
             text={

--- a/apps/desktop/src/renderer/hooks/useDeferUpdateBannerWhileBusy.ts
+++ b/apps/desktop/src/renderer/hooks/useDeferUpdateBannerWhileBusy.ts
@@ -15,10 +15,15 @@ import {
  * 不枚举活动来源。有任务(或探针失败,fail closed)→ 只留头像行火焰入口;全部停下
  * 后再弹出。用户点 X 关掉的不在这条自动恢复里。
  *
+ * 这条 IPC 是为点击「立即重启」设计的一次性探针(含 PI 目录同步扫描),不是廉价订阅。
+ * 要知道「任务何时停」必须再问同一条定义,但不能把它当成 2s 热循环,也不另做活动缓存
+ * 或事件总线。首次立刻问一次以免闪横幅;busy 之后才续询,间隔见
+ * UPDATE_BANNER_BUSY_POLL_MS;轮询带 silent,避免把延后展示打成「manual relaunch」INFO。
+ *
  * 返回值:当前这个版本还没做出弹出/让路决定时为 true,调用方据此先不渲染 banner,
  * 避免「闪一下完整横幅再收成火焰」。
  */
-export const UPDATE_BANNER_BUSY_POLL_MS = 2000;
+export const UPDATE_BANNER_BUSY_POLL_MS = 15_000;
 
 function isActiveUpdateStatus(status: string): boolean {
   return status === 'ready' || status === 'superseding';
@@ -26,7 +31,7 @@ function isActiveUpdateStatus(status: string): boolean {
 
 async function probeBusy(): Promise<boolean> {
   try {
-    return await window.electronAPI.anyActivityBlockingRelaunch();
+    return await window.electronAPI.anyActivityBlockingRelaunch({ silent: true });
   } catch {
     // 跟重启入口同一条 fail closed:拿不到可信答案就当有任务,不要突然弹出横幅。
     return true;

--- a/apps/desktop/src/renderer/hooks/useDeferUpdateBannerWhileBusy.ts
+++ b/apps/desktop/src/renderer/hooks/useDeferUpdateBannerWhileBusy.ts
@@ -1,0 +1,108 @@
+import { useEffect, useRef } from 'react';
+
+import {
+  deferUpdateBannerBecauseBusy,
+  getUpdateBannerDismissState,
+  isUpdateBannerDecidedFor,
+  markUpdateBannerAutoShown,
+  useUpdateBannerDismiss,
+} from '@/hooks/useUpdateBannerDismiss';
+
+/**
+ * 更新就绪后完整 banner 自动弹出前,先问「有没有任务在跑」。
+ *
+ * 判定复用「立即重启」二次确认的同一条 IPC(anyActivityBlockingRelaunch),renderer
+ * 不枚举活动来源。有任务(或探针失败,fail closed)→ 只留头像行火焰入口;全部停下
+ * 后再弹出。用户点 X 关掉的不在这条自动恢复里。
+ *
+ * 返回值:当前这个版本还没做出弹出/让路决定时为 true,调用方据此先不渲染 banner,
+ * 避免「闪一下完整横幅再收成火焰」。
+ */
+export const UPDATE_BANNER_BUSY_POLL_MS = 2000;
+
+function isActiveUpdateStatus(status: string): boolean {
+  return status === 'ready' || status === 'superseding';
+}
+
+async function probeBusy(): Promise<boolean> {
+  try {
+    return await window.electronAPI.anyActivityBlockingRelaunch();
+  } catch {
+    // 跟重启入口同一条 fail closed:拿不到可信答案就当有任务,不要突然弹出横幅。
+    return true;
+  }
+}
+
+export function useDeferUpdateBannerWhileBusy(
+  status: string,
+  version: string | undefined,
+): boolean {
+  const dismissApi = useUpdateBannerDismiss();
+  const apiRef = useRef(dismissApi);
+  apiRef.current = dismissApi;
+
+  const versionOrNull = version ?? null;
+  const hideUntilDecided =
+    isActiveUpdateStatus(status)
+    && !dismissApi.dismissed
+    && !dismissApi.isDecidedFor(versionOrNull);
+
+  useEffect(() => {
+    if (!isActiveUpdateStatus(status)) return;
+
+    const read = () => apiRef.current;
+
+    if (read().isNewUpdateAfterDismiss(status, versionOrNull)) {
+      if (read().reason === 'busy') {
+        read().deferBecauseBusy(status, versionOrNull);
+      } else {
+        read().restore();
+        read().clearAutoDecision();
+      }
+    }
+
+    const snap = getUpdateBannerDismissState();
+    const shouldProbe =
+      (!snap.dismissed && !isUpdateBannerDecidedFor(versionOrNull))
+      || (snap.dismissed && snap.reason === 'busy');
+    if (!shouldProbe) return;
+
+    let cancelled = false;
+    let timer: ReturnType<typeof setTimeout> | null = null;
+
+    const schedulePoll = () => {
+      timer = setTimeout(() => {
+        void run();
+      }, UPDATE_BANNER_BUSY_POLL_MS);
+    };
+
+    const run = async () => {
+      const busy = await probeBusy();
+      if (cancelled) return;
+
+      // 探针落地时必须读模块现态,不能读 render 快照:restore / dismiss 可能已经
+      // 发生、但这次 render 还没跟上。
+      const latest = getUpdateBannerDismissState();
+      if (latest.reason === 'user') return;
+
+      if (busy) {
+        // 用户已经点火焰把 banner 唤回来了:这是明确要看,不要再藏回去。
+        if (!latest.dismissed && isUpdateBannerDecidedFor(versionOrNull)) return;
+        deferUpdateBannerBecauseBusy(status, versionOrNull);
+        schedulePoll();
+        return;
+      }
+
+      markUpdateBannerAutoShown(versionOrNull);
+    };
+
+    void run();
+
+    return () => {
+      cancelled = true;
+      if (timer !== null) clearTimeout(timer);
+    };
+  }, [status, versionOrNull, dismissApi.dismissed, dismissApi.reason]);
+
+  return hideUntilDecided;
+}

--- a/apps/desktop/src/renderer/hooks/useUpdateBannerDismiss.ts
+++ b/apps/desktop/src/renderer/hooks/useUpdateBannerDismiss.ts
@@ -6,6 +6,11 @@ import { useSyncExternalStore } from 'react';
  * 场景:更新就绪(status='ready')时 banner 自动出现,用户想暂时不看可以点 X 关掉。
  * 关掉后头像行的 Flame 按钮涂黑,点击可以把 banner 再唤回来。
  *
+ * 另外一条自动路径:banner **即将自动弹出**时若有任务在跑(与「立即重启」二次确认同一
+ * 条 anyActivityBlockingRelaunch 探针),先不占侧栏,只走火焰按钮这份最小化提醒;
+ * 任务全部停下后再弹出。这条记 reason='busy',和用户点 X 的 reason='user' 必须分开:
+ * 任务停了只恢复 busy 让路,绝不把用户关掉的 banner 再塞回来。
+ *
  * 语义:
  * - **仅本次进程内存**:重启后回到 false(update 是关键状态,不能永久隐藏)。
  * - **新更新到达自动 reset**:dismiss 时会记录当时的 (status, version) 快照;
@@ -13,20 +18,34 @@ import { useSyncExternalStore } from 'react';
  *   (对比快照),只在真的发生变化时 restore()——这样 UpdateBanner 在
  *   /settings 往返后 remount、useUpdateStatus() 经历 idle→ready 的初始水合
  *   时,不会因为「版本和之前 dismiss 时一样」而误 restore。
+ * - **decidedVersion**:已经对某个待装版本做过「弹出 / 让路」决定。用来避免
+ *   remount 时再闪一次探针空窗,也避免用户点火焰唤回之后又被 busy 探针藏回去。
  * - 模块级 singleton store(useSyncExternalStore),让 UpdateBanner 与
  *   UserInfoSection 无需 context / prop-drill 就能共享同一状态。
  */
 
+export type UpdateBannerDismissReason = 'user' | 'busy';
+
 interface DismissState {
   dismissed: boolean;
+  reason: UpdateBannerDismissReason | null;
   dismissedStatus: string | null;
   dismissedVersion: string | null;
+  decidedVersion: string | null;
+}
+
+const UNVERSIONED = '<none>';
+
+export function updateBannerDecisionVersion(version: string | null): string {
+  return version ?? UNVERSIONED;
 }
 
 let state: DismissState = {
   dismissed: false,
+  reason: null,
   dismissedStatus: null,
   dismissedVersion: null,
+  decidedVersion: null,
 };
 const listeners = new Set<() => void>();
 
@@ -42,19 +61,87 @@ function subscribe(listener: () => void) {
 }
 
 function getSnapshot() {
-  return state.dismissed;
+  // 必须返回整份 state:markAutoShown 时常 dismissed 不变、只写 decidedVersion,
+  // 只订阅布尔值会让「探针空窗」永远不结束。
+  return state;
+}
+
+export function getUpdateBannerDismissState(): Readonly<DismissState> {
+  return state;
+}
+
+function sameBusyDefer(status: string, version: string | null): boolean {
+  return (
+    state.dismissed
+    && state.reason === 'busy'
+    && state.dismissedStatus === status
+    && state.dismissedVersion === version
+    && state.decidedVersion === updateBannerDecisionVersion(version)
+  );
 }
 
 export function dismissUpdateBanner(currentStatus: string, currentVersion: string | null) {
-  if (state.dismissed) return;
-  state = { dismissed: true, dismissedStatus: currentStatus, dismissedVersion: currentVersion };
+  if (state.dismissed && state.reason === 'user') return;
+  state = {
+    dismissed: true,
+    reason: 'user',
+    dismissedStatus: currentStatus,
+    dismissedVersion: currentVersion,
+    decidedVersion: state.decidedVersion,
+  };
+  emit();
+}
+
+/**
+ * 有任务在跑:不要弹出完整 banner,只留火焰入口。已经是用户关掉的,不要覆盖。
+ */
+export function deferUpdateBannerBecauseBusy(currentStatus: string, currentVersion: string | null) {
+  if (state.dismissed && state.reason === 'user') return;
+  if (sameBusyDefer(currentStatus, currentVersion)) return;
+  state = {
+    dismissed: true,
+    reason: 'busy',
+    dismissedStatus: currentStatus,
+    dismissedVersion: currentVersion,
+    decidedVersion: updateBannerDecisionVersion(currentVersion),
+  };
+  emit();
+}
+
+export function markUpdateBannerAutoShown(currentVersion: string | null) {
+  if (state.dismissed && state.reason === 'user') return;
+  const decidedVersion = updateBannerDecisionVersion(currentVersion);
+  if (!state.dismissed && state.reason === null && state.decidedVersion === decidedVersion) return;
+  state = {
+    dismissed: false,
+    reason: null,
+    dismissedStatus: null,
+    dismissedVersion: null,
+    decidedVersion,
+  };
   emit();
 }
 
 export function restoreUpdateBanner() {
   if (!state.dismissed) return;
-  state = { dismissed: false, dismissedStatus: null, dismissedVersion: null };
+  state = {
+    dismissed: false,
+    reason: null,
+    dismissedStatus: null,
+    dismissedVersion: null,
+    decidedVersion: state.decidedVersion,
+  };
   emit();
+}
+
+export function clearUpdateBannerAutoDecision() {
+  if (state.decidedVersion === null) return;
+  state = { ...state, decidedVersion: null };
+  emit();
+}
+
+export function isUpdateBannerDecidedFor(currentVersion: string | null): boolean {
+  return state.decidedVersion === updateBannerDecisionVersion(currentVersion);
 }
 
 /**
@@ -73,12 +160,28 @@ export function isNewUpdateAfterDismiss(currentStatus: string, currentVersion: s
   return currentStatus !== state.dismissedStatus || currentVersion !== state.dismissedVersion;
 }
 
+export function resetUpdateBannerDismissStoreForTests() {
+  state = {
+    dismissed: false,
+    reason: null,
+    dismissedStatus: null,
+    dismissedVersion: null,
+    decidedVersion: null,
+  };
+  emit();
+}
+
 export function useUpdateBannerDismiss() {
-  const isDismissed = useSyncExternalStore(subscribe, getSnapshot, getSnapshot);
+  const snap = useSyncExternalStore(subscribe, getSnapshot, getSnapshot);
   return {
-    dismissed: isDismissed,
+    dismissed: snap.dismissed,
+    reason: snap.reason,
     dismiss: dismissUpdateBanner,
     restore: restoreUpdateBanner,
+    deferBecauseBusy: deferUpdateBannerBecauseBusy,
+    markAutoShown: markUpdateBannerAutoShown,
+    clearAutoDecision: clearUpdateBannerAutoDecision,
+    isDecidedFor: isUpdateBannerDecidedFor,
     isNewUpdateAfterDismiss,
   };
 }

--- a/apps/desktop/src/renderer/vite-env.d.ts
+++ b/apps/desktop/src/renderer/vite-env.d.ts
@@ -3567,8 +3567,9 @@ interface ElectronAPI {
   /**
    * 现在重启会不会打断正在跑的活(逻辑 turn / Claude 后台活动 / Ghost card-action 后台活动
    * 三源聚合,判定在 main 侧一处)。UpdateBanner 用它决定「直接重启」还是「先弹中断警告」。
+   * `silent: true` 只抑制 busy 的「manual relaunch」INFO,供横幅延后轮询;判定不变。
    */
-  anyActivityBlockingRelaunch: () => Promise<boolean>;
+  anyActivityBlockingRelaunch: (opts?: { silent?: boolean }) => Promise<boolean>;
   /** Tell main process to apply the update and relaunch the app.
    *  `theme` is the renderer's *resolved* light/dark (after collapsing 'system'),
    *  forwarded to cindy-updater so its splash matches the app the user is seeing. */


### PR DESCRIPTION
## 这次改了什么

### 摘要

Desktop 更新就绪后，完整侧栏横幅不再在有 Agent 活动时自动弹出。弹出前先走与「立即重启」二次确认同一条 `anyActivityBlockingRelaunch` 探针：有任务（或探针失败）只留现有最小化火焰入口；全部停下后再自动弹出。用户点 X 关掉的，不会因为任务结束而被重新塞回来。

只改提醒展示时机，不改 `cindy-updater` 的下载、安装、替换。更新器改动已与 owner 确认（本次范围为展示时机）。

### 变更类型

- [x] `feat` 新功能
- [ ] `fix` 缺陷修复
- [ ] `refactor` / `perf` 重构或性能优化
- [ ] `docs` / `test` / `chore` 文档、测试或工程维护
- [ ] 其他：

### 范围

- 关联 Issue / 需求：无
- 本 PR 包含：`UpdateBanner` 自动弹出时机、`busy` / `user` 隐藏分流、busy 轮询与对应单测
- 明确不包含：更新器安装/替换逻辑、重启二次确认的活动来源判定、Mobile
- 用户可见变化：有任务在跑时更新就绪只留火焰入口，任务全部停止后自动弹出完整横幅
- 是否存在 breaking change：无

### UI 变化

- 引用的设计规范：`docs/design-rules/DESIGN.md` §5 Whitespace Philosophy（工具让路，不抢工作面）；同一节的 progressive disclosure——完整横幅让路到既有最小化火焰入口，任务停后再展开。横幅视觉、文案、颜色 token 未改；Light / Dark 复用既有 themed 样式，本次未实机目检双模式。

## 怎么验证的

### 自动验证

```text
pnpm --filter desktop run typecheck
结果：通过

pnpm test:unit:related
结果：PASS apps/desktop unit（15.7s），覆盖本 PR 6 个相关文件

本 worktree 全量 `pnpm test:unit`（经 git skill `run-unit-gate.sh`）
结果：apps/desktop unit PASS（132.5s）；packages/maker-core unit FAIL
  - `pi-agent.integration.test.ts`：bundled xAI baseline 超时 60s；随后 BYOM 用例看到 2 个 config home（期望 1）
  - 本 PR 不含 `packages/maker-core`；在同一 worktree 对上述两条单独复现仍失败，判定为当前基线问题，不混入本 PR
```

### 手工验证

未在实机走「更新刚下载完成且此时有任务在跑」路径。行为由 renderer 单测覆盖探针空窗、busy 隐藏、idle 弹出、探针失败 fail closed、用户关掉后不自动恢复、火焰唤回后不回藏。

### 未执行的验证

未跑 `pnpm test:all`。未实机目检 Light / Dark（无新视觉）。全量单测中与本 diff 无关的 maker-core PI 集成失败交给 CI 在干净基线上兜底。

## 风险

### 风险分类

- [ ] 无已知风险
- [ ] SQLite / migration
- [ ] system prompt
- [ ] 协议兼容
- [ ] 权限 / 安全 / 用户数据
- [ ] 存量插件兼容（批准状态 / 指纹 / manifest 校验 / 安装布局 / 包格式）
- [ ] 原生层 / fingerprint / OTA
- [ ] 跨平台差异
- [x] 其他：全量单测基线中 maker-core PI 集成测超时（与本 diff 无关）

### 影响与回滚

- 影响范围：仅 Desktop 侧栏更新横幅的自动展示时机；不改变补丁下载、校验、安装或重启替换。
- 回滚 / 降级方式：revert 本 PR 即回到「就绪后立即弹出完整横幅」。

### 提交前检查

- [x] 已 review 完整 diff
- [x] 每个 commit 都带 DCO 签名（`git commit -s`，见 [DCO](../DCO)）
- [x] UI 改动已在「UI 变化」注明引用的设计规范章节（不涉及 UI 则跳过）
- [x] 未提交凭证、令牌或授权文件
- [x] 已补充必要文档
- [x] 已确认测试结果或说明未执行原因
