### PR TITLE
fix(desktop): 回环 chat 上游一律启用 system 消息前置归并

### DIFF
--- a/apps/desktop/src/main/maker-host/__tests__/codexProxyHost.test.ts
+++ b/apps/desktop/src/main/maker-host/__tests__/codexProxyHost.test.ts
@@ -657,6 +657,30 @@ describe('chatBridgeCapabilitiesForRoute', () => {
   });
 
   it.each([
+    ['cindy-local-ollama', 'http://127.0.0.1:11434/v1'],
+    ['my-custom-ollama', 'http://127.0.0.1:11434/v1'],
+    ['my-custom-ollama', 'http://localhost:8080/v1'],
+    ['my-custom-lmstudio', 'http://[::1]:1234/v1'],
+  ])('coalesces leading system for loopback chat upstreams: %s / %s (#3531)', async (providerId, upstream) => {
+    // 本地模板运行器(Qwen3 系 Jinja 模板)硬校验 system 在首,消息中段的
+    // system/developer 直接 500;回环上游一律 coalesce,不再限 Qwen3.8 白名单。
+    const { chatBridgeSystemMessagePolicyForRoute } = await freshCodexProxyHost();
+    expect(chatBridgeSystemMessagePolicyForRoute(providerId, upstream)).toBe('coalesce-leading');
+  });
+
+  it.each([
+    // 远程供应商保持 preserve 缺省:coalesce 会把 developer 并成 system,对
+    // 原生区分 developer 的云端兼容层是语义变更。127.example.com 是合法公网
+    // 域名,不得按前缀误判为 loopback。
+    ['my-custom-remote', 'https://api.example.com/v1'],
+    ['my-custom-remote', 'https://127.example.com/v1'],
+    ['my-custom-remote', 'not-a-url'],
+  ])('keeps preserve for non-loopback chat upstreams: %s / %s (#3531)', async (providerId, upstream) => {
+    const { chatBridgeSystemMessagePolicyForRoute } = await freshCodexProxyHost();
+    expect(chatBridgeSystemMessagePolicyForRoute(providerId, upstream)).toBeUndefined();
+  });
+
+  it.each([
     ['https://ark.cn-beijing.volces.com/api/v3', 'doubao-seed-2-1-pro-260628'],
     ['https://ark.ap-southeast-1.volces.com/api/v3/', 'doubao-seed-1-6-vision-260615'],
   ])('enables image_url for Doubao Seed on official Volcengine Ark host: %s (#771)', async (upstream, model) => {

--- a/apps/desktop/src/main/maker-host/codex-proxy-host.ts
+++ b/apps/desktop/src/main/maker-host/codex-proxy-host.ts
@@ -47,7 +47,6 @@ import { createHash, randomUUID } from 'node:crypto';
 import fs from 'node:fs';
 import path from 'node:path';
 
-import { isCuratedQwen38Tag } from '../../shared/localModelRuntime.js';
 import {
   buildCodexGatewayBaseUrl,
   CODEX_OAUTH_UPSTREAM,
@@ -815,6 +814,44 @@ function rewriteChatBridgeModel(model: string, stripPrefix: string | undefined):
  * id),也不对所有 openai-chat 供应商放开。未命中继续沿用 fail-closed 默认——
  * 无图片能力的上游(如 DeepSeek)保持发送前显式报错,不静默吞图。
  */
+/**
+ * Chat bridge 的 system 消息策略(#3531)。
+ *
+ * 本地模板运行器(Ollama / LM Studio / llama.cpp 的 OpenAI 兼容层)用 Jinja
+ * chat template 渲染消息,Qwen3 系等模板硬校验 system 必须在开头,消息中段的
+ * system/developer 直接 500(Ornith 实测 `System message must be at the
+ * beginning`);这类运行器也不支持 developer 角色,合并成唯一首条 system 是
+ * 严格更安全的形态。因此**回环上游一律 coalesce-leading**(内置 Ollama 面板
+ * 与指向 127.0.0.1 等本机端点的自定义供应商都覆盖,不再限 Qwen3.8 白名单)。
+ * 远程供应商保持 preserve 缺省:coalesce 会把 developer 并为 system,对原生
+ * 区分 developer 角色的云端兼容层是语义变更,不能默认开。
+ */
+export function chatBridgeSystemMessagePolicyForRoute(
+  providerId: string,
+  upstream: string,
+): 'coalesce-leading' | undefined {
+  if (providerId === 'cindy-local-ollama') return 'coalesce-leading';
+  return isLoopbackChatUpstream(upstream) ? 'coalesce-leading' : undefined;
+}
+
+function isLoopbackChatUpstream(upstream: string): boolean {
+  let url: URL;
+  try {
+    url = new URL(upstream);
+  } catch {
+    return false;
+  }
+  // 精确 loopback 判定(与 pi-host 同裁决):不能用 startsWith('127.'),
+  // 会误伤 127.example.com 这类合法域名。URL.hostname 已去方括号。
+  const host = url.hostname.toLowerCase();
+  return (
+    host === 'localhost' ||
+    /^127\.\d{1,3}\.\d{1,3}\.\d{1,3}$/.test(host) ||
+    host === '::1' ||
+    host === '[::1]'
+  );
+}
+
 export function chatBridgeCapabilitiesForRoute(
   upstream: string,
   realModel: string,
@@ -882,10 +919,13 @@ function createChatBridgeDecision(
     realModel,
     baseCapabilities,
   );
-  const capabilities =
-    route.providerId === 'cindy-local-ollama' && isCuratedQwen38Tag(realModel)
-      ? { ...routedCapabilities, systemMessagePolicy: 'coalesce-leading' as const }
-      : routedCapabilities;
+  const systemMessagePolicy = chatBridgeSystemMessagePolicyForRoute(
+    route.providerId,
+    route.routing.upstream,
+  );
+  const capabilities = systemMessagePolicy
+    ? { ...routedCapabilities, systemMessagePolicy }
+    : routedCapabilities;
   const onUpstreamError = route.providerSource === 'user'
     ? ({ status, body }: { status: number; body: string }): void => {
         reportProviderUpstreamError({ agent: 'codex', providerId, providerName, status, bodyText: body });


### PR DESCRIPTION
## 这次改了什么

### 摘要

fix #3531。本地模板运行器(Ollama / LM Studio / llama.cpp 的 OpenAI 兼容层)用 Jinja chat template 渲染消息,Qwen3 系模板硬校验 system 必须在开头,消息中段的 system/developer 直接 500(issue 实测 Ornith 报 `System message must be at the beginning`,并给出 `[user, system]` → 500 / `[system, user]` → 200 的对照)。

此前 chat bridge 的 `systemMessagePolicy: 'coalesce-leading'` 只在「`providerId === 'cindy-local-ollama'` 且命中 Qwen3.8 白名单标签」时启用——自定义供应商指向本机 Ollama(`source: 'user'`)或非白名单标签(如 `ornith-1.0:9b`)全部踩 500,该路由完全不可用。

改动:抽出导出的纯函数 `chatBridgeSystemMessagePolicyForRoute(providerId, upstream)`——**内置 Ollama 全标签 + 回环上游一律 coalesce-leading**;回环判定为精确 loopback(`localhost` / `127.x.x.x` 正则 / `::1`,与 pi-host 同裁决,不误伤 `127.example.com` 这类合法公网域名)。**远程供应商保持 preserve 缺省不变**:coalesce 会把 developer 并成 system,对原生区分 developer 角色的云端兼容层是语义变更,不能默认开;本地模板运行器不支持 developer 角色,合并成唯一首条 system 是严格更安全的形态。

**已知取舍(回环 ≠ 一定是模板运行器)**:指向回环地址的通用网关/反代(如本机 LiteLLM 转发云端)也会被并入。取舍依据是不对称的失败代价:模板运行器下不归并 = 必现 500、路由完全不可用;OpenAI 兼容语义下 developer 本就是 system 的替代角色(两者同层、可互换),归并为唯一首条 system 是 developer 角色出现前所有客户端的规范形态,对回环代理是近似无损的排列规整,请求照常工作。如需精确区分,可作为后续项给自定义供应商加 per-provider 策略覆盖。

### 变更类型

- [ ] `feat` 新功能
- [x] `fix` 缺陷修复
- [ ] `refactor` / `perf` 重构或性能优化
- [ ] `docs` / `test` / `chore` 文档、测试或工程维护
- [ ] 其他:

### 范围

- 关联 Issue / 需求:#3531
- 本 PR 包含:`apps/desktop` codex-proxy-host 的 chat bridge system 消息策略判定(新导出纯函数 + gating 替换)与参数化回归
- 明确不包含:桥接层 `coalesce-leading` 的实现(`packages/responses-chat-bridge` 既有逻辑不动);远程供应商的策略(preserve 缺省保持)
- 用户可见变化:自定义供应商指向本机 Ollama、或内置 Ollama 面板的非白名单标签(Qwen3 系模板)不再必现 5xx
- 是否存在 breaking change:无

### UI 变化

不涉及。

- 引用的设计规范:不涉及

## 怎么验证的

### 自动验证

```text
pnpm --filter desktop exec vitest run src/main/maker-host/__tests__/codexProxyHost.test.ts --pool=forks
结果:192/192 通过。新增 7 条参数化用例:回环上游(内置 Ollama、自定义供应商指向
127.0.0.1:11434 / localhost / [::1])→ coalesce-leading;远程 https、127.example.com
伪 loopback 域名、非法 URL → 保持 preserve 缺省。

pnpm --filter desktop run --if-present typecheck
结果:通过(0 错误)

pnpm test:unit:related
结果:通过(435 过 0 失败;maker-core 的 2 例 pi-agent 集成失败已在干净 main 上
逐字复现,为当日基线失败,与本 diff 无关)
```

### 手工验证

不涉及(策略判定为纯函数,行为由参数化用例覆盖;issue 报告者已给出两种消息顺序对 Ollama 的实测对照)。

### 未执行的验证

未在本机跑真实 Ollama + ornith-1.0:9b 端到端复测(无该模型环境);修复面是把 issue 已实测可行的消息形态(system 在首)应用到其报告的两个配置路径。

## 风险

### 风险分类

- [ ] 无已知风险
- [x] 其他:回环上游的模型可见消息排列变更(system/developer 归并为唯一首条 system)

### 影响与回滚

- 影响范围:仅回环上游的 chat bridge 请求消息排列(system/developer 合并为首条 system),属模型可见的行为变更,需维护者经本 PR review 确认——行为风险评估:提示词**内容**逐字不变,变化仅是排列位置(移到开头,即 Chat Completions 的规范位置)与 developer→system 的角色标签(OpenAI 兼容语义下两者同层可互换);模板运行器侧该排列是从必现 500 到可用的先决条件。远程供应商零变化。最坏情形是回环反代后的某个上游对 developer 与 system 有截然不同的解释——未见于任何 OpenAI 兼容实现,且可用后续 per-provider 覆盖精确化。
- 维护者确认渠道:本仓 PR 必经维护者 review/Approve,该确认即在本 PR 上完成;如触发产品/架构确认门照其流程走。
- 回滚 / 降级方式:revert 单 commit,无数据或格式迁移。

### 提交前检查

- [x] 已 review 完整 diff
- [x] 每个 commit 都带 DCO 签名(`git commit -s`,见 [DCO](../DCO))
- [ ] UI 改动已在「UI 变化」注明引用的设计规范章节(不涉及 UI 则跳过)
- [x] 未提交凭证、令牌或授权文件
- [x] 已补充必要文档
- [x] 已确认测试结果或说明未执行原因

