### PR TITLE
fix(mcps): set_session_runtime 的 expected_generation 契约对齐为必填

### DIFF
--- a/packages/lizi-mcps/src/__tests__/sessionControlTools.test.ts
+++ b/packages/lizi-mcps/src/__tests__/sessionControlTools.test.ts
@@ -113,17 +113,23 @@ describe('cindy_helper session control tools', () => {
   });
 
   it('requires a bound current session when session_id is omitted', async () => {
+    // expected_generation 已是 schema 必填(#3535):带上合法值,隔离验证
+    // 会话上下文缺失的分支。
     const { registry } = setup({ sessionId: undefined });
     expect(
-      parse(await registry.call('set_session_runtime', { effort: 'high' })),
+      parse(await registry.call('set_session_runtime', { effort: 'high', expected_generation: 1 })),
     ).toMatchObject({ ok: false, errorCode: 'NO_SESSION_CONTEXT' });
   });
 
   it('requires a read-before-write generation token', async () => {
+    // #3535:schema 曾标 optional 而 handler 强制必传 —— 契约矛盾让缺参调用
+    // 只拿到裸 INVALID_ARGS。现在 schema 即必填:zod 层拒绝并回吐 schema 与
+    // 校验明细,调用方一轮自纠。
     const { registry } = setup();
-    expect(
-      parse(await registry.call('set_session_runtime', { effort: 'high' })),
-    ).toMatchObject({ ok: false, errorCode: 'INVALID_ARGS' });
+    const result = parse(await registry.call('set_session_runtime', { effort: 'high' }));
+    expect(result).toMatchObject({ ok: false, errorCode: 'INVALID_ARGS' });
+    expect(JSON.stringify(result.data?.validation_errors ?? result)).toContain('expected_generation');
+    expect(result.data?.schema).toBeTruthy();
   });
 
   it('updates and cancels only through the caller-bound ownership context', async () => {

--- a/packages/lizi-mcps/src/xdt-helper/session_control.ts
+++ b/packages/lizi-mcps/src/xdt-helper/session_control.ts
@@ -331,8 +331,9 @@ export function registerSetSessionRuntimeTool(
         .number()
         .int()
         .nonnegative()
-        .optional()
-        .describe('来自 get_session_runtime 的 generation。'),
+        .describe(
+          '必填:先调用 get_session_runtime 读取当前 generation 并原样传回,用于防止覆盖并发修改。',
+        ),
     },
     handler: async ({ session_id, provider_id, model, effort, fast, expected_generation }) => {
       const targetSessionId = session_id ?? requireCallerSession(deps);
@@ -348,7 +349,8 @@ export function registerSetSessionRuntimeTool(
         return errorPayload('INVALID_ARGS', '至少提供 provider_id、model、effort 或 fast 之一。');
       }
       if (expected_generation === undefined) {
-        return errorPayload('INVALID_ARGS', '请先调用 get_session_runtime，并传回 expected_generation。');
+        // schema 已必填,此分支为纵深防御:任何绕过 zod 的调用路径仍拿到同一引导。
+        return errorPayload('INVALID_ARGS', '请先调用 get_session_runtime 获取 generation,并作为 expected_generation 传回。');
       }
       const result = await deps.setSessionRuntime({
         targetSessionId,


### PR DESCRIPTION
## 这次改了什么

### 摘要

fix #3535。`set_session_runtime` 的 schema 把 `expected_generation` 标为可选,但 handler 强制必传:调用方按 schema 合法地省略该参数时,拿到的是一条不带 schema 回吐的裸 `INVALID_ARGS`,无从自纠——issue 实测手机端(device-link)切模型时会话停在原模型,切换必失败。

改动:契约对齐为 **schema 必填** + 引导性 `describe`(「先调用 get_session_runtime 读取当前 generation 并原样传回」)。缺参调用现在在 zod 层被拒,registry 按既有机制回吐完整 JSON Schema 与校验明细,调用方一轮自纠;handler 原有的 undefined 判定保留为纵深防御(任何绕过 zod 的调用路径仍拿到同一引导文案)。CAS 并发保护语义不变——没有采用「缺省跳过并发保护」的替代方案,那会静默削弱 read-before-write 契约。

### 变更类型

- [ ] `feat` 新功能
- [x] `fix` 缺陷修复
- [ ] `refactor` / `perf` 重构或性能优化
- [ ] `docs` / `test` / `chore` 文档、测试或工程维护
- [ ] 其他:

### 范围

- 关联 Issue / 需求:#3535
- 本 PR 包含:`packages/lizi-mcps` 的 `set_session_runtime` 参数 schema 与 handler 文案;对应测试(缺参用例断言回吐 schema 与校验明细;NO_SESSION_CONTEXT 用例补传合法 generation 以隔离会话上下文分支)
- 明确不包含:`setSessionRuntime` 宿主实现与 CAS 语义(不动);其它 session control 工具
- 用户可见变化:Agent 切换模型时不再因契约矛盾静默失败;缺参错误变为可自纠(带 schema)
- 是否存在 breaking change:无(handler 本就必传,仅把拒绝提前到 schema 层并变可自纠)

### UI 变化

不涉及。

- 引用的设计规范:不涉及

### 远程与移动端适配

不涉及新 IPC channel 或推送事件:本工具经既有 MCP 通道暴露,手机端 device-link 远程调用(正是 issue 的触发场景)与桌面同一路径,修复同时生效。

## 怎么验证的

### 自动验证

```text
pnpm --filter @cindy/mcps test
结果:671/671 通过。缺参用例升级为断言 INVALID_ARGS 载荷含 expected_generation
校验明细与完整 schema(锁住一轮自纠路径);正常 CAS 用例与 NO_SESSION_CONTEXT
用例保持通过。

pnpm test:unit:related
结果:通过(435 过 0 失败;maker-core 的 2 例 pi-agent 集成失败已在干净 main 上
逐字复现,为当日基线失败,与本 diff 无关)

typecheck:@cindy/mcps 无 typecheck script,按仓库门禁规则该步自动跳过
```

### 手工验证

不涉及(工具层契约由单测覆盖)。

### 未执行的验证

未在真实手机端复跑切模型流程(修复面在工具层 schema,device-link 与桌面走同一 MCP 路径)。

## 风险

### 风险分类

- [x] 无已知风险
- [ ] 其他:

### 影响与回滚

- 影响范围:仅 `set_session_runtime` 的参数校验时点与错误载荷;既有合法调用(先 get 后 set)零变化。
- 回滚 / 降级方式:revert 单 commit。

### 提交前检查

- [x] 已 review 完整 diff
- [x] 每个 commit 都带 DCO 签名(`git commit -s`,见 [DCO](../DCO))
- [ ] UI 改动已在「UI 变化」注明引用的设计规范章节(不涉及 UI 则跳过)
- [x] 未提交凭证、令牌或授权文件
- [x] 已补充必要文档
- [x] 已确认测试结果或说明未执行原因
