### PR TITLE
fix(codex): 重连恢复后重置 retry episode

### DIFF
--- a/packages/maker-core/src/agents/codex/index.test.ts
+++ b/packages/maker-core/src/agents/codex/index.test.ts
@@ -21234,6 +21234,71 @@ describe('CodexAgent turn lifecycle', () => {
     },
   );
 
+  it('starts a fresh retry episode after same-turn progress (issue #3578)', async () => {
+    const agent = new CodexAgent(createDeps());
+    const host = installFakeHost(agent);
+    const handle = await agent.startSession({
+      sessionId: 'session-retry-episode-recovery',
+      model: 'gpt-5.4',
+      workingDir: '/repo',
+    });
+    const handlers = host.getThreadHandlers();
+    if (!handlers?.error || !handlers.reasoningTextDelta) {
+      throw new Error('expected retry and reasoning handlers');
+    }
+    const events: AgentEvent[] = [];
+    void (async () => {
+      for await (const event of handle.events()) events.push(event);
+    })();
+
+    handlers.turnStarted?.({
+      threadId: 'start-thread-id',
+      turn: { id: 'turn-retry-episode-recovery' },
+    } as never);
+    handlers.error({
+      threadId: 'start-thread-id',
+      turnId: 'turn-retry-episode-recovery',
+      willRetry: true,
+      error: { message: 'Reconnecting... 1/5' },
+    } as never);
+    handlers.reasoningTextDelta({
+      threadId: 'start-thread-id',
+      turnId: 'turn-retry-episode-recovery',
+      itemId: 'reasoning-recovered',
+      contentIndex: 0,
+      delta: 'recovered',
+    } as never);
+    await waitForExpectation(() => {
+      expect(events).toContainEqual(expect.objectContaining({
+        type: 'thinking',
+        data: expect.objectContaining({ text: 'recovered' }),
+      }));
+    });
+
+    const retryError = {
+      threadId: 'start-thread-id',
+      turnId: 'turn-retry-episode-recovery',
+      willRetry: true,
+      error: {
+        message: 'unexpected status 403 Forbidden, url: https://chatgpt.com/backend-api/codex/responses',
+      },
+    } as const;
+    for (let index = 0; index < 29; index += 1) {
+      handlers.error(retryError);
+    }
+
+    expect(handle.isTurnRunning?.()).toBe(true);
+    expect(events).not.toContainEqual(expect.objectContaining({
+      type: 'error',
+      data: expect.objectContaining({
+        isTerminal: true,
+        message: expect.stringContaining('Codex backend unreachable'),
+      }),
+    }));
+    expect(host.request).not.toHaveBeenCalledWith(Method.TurnInterrupt, expect.anything());
+    await handle.close();
+  });
+
   it('escalates a persistent willRetry retry-loop to a terminal error (issue #677)', async () => {
     // 远端摸不到 Codex 后端时 daemon 无限发 willRetry=true — 升级逻辑应在阈值处
     // 合成终态错误并复位 turn (isTurnRunning=false + Done status), 消息里带原始

--- a/packages/maker-core/src/agents/codex/index.test.ts
+++ b/packages/maker-core/src/agents/codex/index.test.ts
@@ -21299,6 +21299,89 @@ describe('CodexAgent turn lifecycle', () => {
     await handle.close();
   });
 
+  it('does not reset the active retry episode for a late foreign turn completion', async () => {
+    const agent = new CodexAgent(createDeps());
+    let turnSequence = 0;
+    const host = installFakeHost(agent, (method) => {
+      if (method === Method.TurnStart) {
+        return { turn: { id: `turn-${++turnSequence}` } };
+      }
+      if (method === Method.TurnInterrupt) return {};
+      return undefined;
+    });
+    const handle = await agent.startSession({
+      sessionId: 'session-retry-episode-late-foreign-completion',
+      model: 'gpt-5.4',
+      workingDir: '/repo',
+    });
+    const handlers = host.getThreadHandlers();
+    if (!handlers?.error || !handlers.turnCompleted) {
+      throw new Error('expected retry and completion handlers');
+    }
+    const events: AgentEvent[] = [];
+    void (async () => {
+      for await (const event of handle.events()) events.push(event);
+    })();
+
+    await handle.send({ type: 'user', content: 'old turn' });
+    handlers.turnStarted?.({
+      threadId: 'start-thread-id',
+      turn: { id: 'turn-1' },
+    } as never);
+    await handle.send({ type: 'user', content: 'current turn' });
+    handlers.turnStarted?.({
+      threadId: 'start-thread-id',
+      turn: { id: 'turn-2' },
+    } as never);
+    handlers.error({
+      threadId: 'start-thread-id',
+      turnId: 'turn-2',
+      willRetry: true,
+      error: { message: 'Reconnecting... 1/5' },
+    } as never);
+
+    handlers.turnCompleted({
+      threadId: 'start-thread-id',
+      turn: { id: 'turn-1', status: 'completed' },
+    } as never);
+    await new Promise((resolve) => setTimeout(resolve, 0));
+    expect(events).not.toContainEqual(expect.objectContaining({
+      type: 'status',
+      data: expect.objectContaining({ isRunning: false }),
+    }));
+    expect(events).not.toContainEqual(expect.objectContaining({
+      type: 'done',
+      data: expect.objectContaining({ raw: expect.objectContaining({ id: 'turn-1' }) }),
+    }));
+
+    const retryError = {
+      threadId: 'start-thread-id',
+      turnId: 'turn-2',
+      willRetry: true,
+      error: {
+        message: 'unexpected status 403 Forbidden, url: https://chatgpt.com/backend-api/codex/responses',
+      },
+    } as const;
+    for (let index = 0; index < 29; index += 1) {
+      handlers.error(retryError);
+    }
+
+    await waitForExpectation(() => {
+      expect(events).toContainEqual(expect.objectContaining({
+        type: 'error',
+        data: expect.objectContaining({
+          isTerminal: true,
+          message: expect.stringContaining('Codex backend unreachable'),
+        }),
+      }));
+    });
+    expect(host.request).toHaveBeenCalledWith(Method.TurnInterrupt, {
+      threadId: 'start-thread-id',
+      turnId: 'turn-2',
+    });
+    await handle.close();
+  });
+
   it('escalates a persistent willRetry retry-loop to a terminal error (issue #677)', async () => {
     // 远端摸不到 Codex 后端时 daemon 无限发 willRetry=true — 升级逻辑应在阈值处
     // 合成终态错误并复位 turn (isTurnRunning=false + Done status), 消息里带原始

--- a/packages/maker-core/src/agents/codex/index.ts
+++ b/packages/maker-core/src/agents/codex/index.ts
@@ -9054,8 +9054,15 @@ export class CodexAgent extends BaseAgent {
         }
       }
       clearActiveToolContextsForTurn(turn.id);
-      const overlapsActiveTurn = suppressTerminalUi && currentTurnId !== null && currentTurnId !== turn.id;
-      if (overlapsActiveTurn) return;
+      const overlapsActiveTurn = currentTurnId !== null && currentTurnId !== turn.id;
+      if (overlapsActiveTurn) {
+        // A late terminal from an older root turn may overlap a newer active
+        // turn. Keep its tombstone/bookkeeping above, but never settle the
+        // newer turn's usage, generation, retry episode, or product boundary.
+        latestPlanByTurn.delete(turn.id);
+        flushDeferredTerminalTurnCompletionsIfIdle();
+        return;
+      }
       const activeYieldClaim = activeYieldContinuationClaim();
       if (activeYieldClaim && !claimOwnsTurn(activeYieldClaim, turn.id)) {
         // Foreign terminals must not settle the live continuation's usage,

--- a/packages/maker-core/src/agents/codex/index.ts
+++ b/packages/maker-core/src/agents/codex/index.ts
@@ -6980,6 +6980,9 @@ export class CodexAgent extends BaseAgent {
       }
       if (isReconnectRecoveryEvent(event)) {
         clearReconnectStall();
+        // Descendant/background events are filtered by the queue probe. Real
+        // root-turn progress starts a new retry episode within the same turn.
+        turnRetryTracker.reset();
       }
     }
     /**


### PR DESCRIPTION
## 这次改了什么

### 摘要

修复 Codex app-server 的两个 retry episode 生命周期问题：同一 turn 从可恢复重连中恢复后，Cindy 会清理 reconnect stall 与 retry tracker，使后续独立重连从新的 count 和 elapsed 起点开始；旧 root turn 的迟到终态与新 turn 重叠时，只完成旧 turn 自身的 tombstone/bookkeeping，不再结算或重置新 turn 的 usage、generation、retry episode 与产品边界。既有 descendant/background 过滤边界保持不变。

Closes #3578

### 变更类型

- [ ] `feat` 新功能
- [x] `fix` 缺陷修复
- [ ] `refactor` / `perf` 重构或性能优化
- [ ] `docs` / `test` / `chore` 文档、测试或工程维护
- [ ] 其他：

### 范围

- 关联 Issue / 需求：Closes #3578
- 本 PR 包含：恢复事件重置 Codex retry episode；隔离迟到旧 root turn 的终态与当前 active turn 的 retry episode；新增相应事件级回归测试。
- 明确不包含：不调整 30 次 / 120 秒熔断阈值；不修改 translator、system prompt、模型路由或子 Agent 行为。
- 用户可见变化：已恢复并继续工作的 Codex turn，不会再因后续独立重连继承旧计数/计时，或被旧 turn 的迟到终态重置当前重试计数，而延后持续不可达判定。
- 是否存在 breaking change：无。

### 多端适配结论

- Desktop 本地：本 PR 已一并适配。修复位于 Desktop 使用的 Maker Core Codex root-turn 事件循环，不新增 UI、IPC、文件路径或平台分支。
- 设备互联 / Mobile 控制端：不需要新增适配。控制端继续消费既有任务事件；本 PR 未新增或修改 IPC channel、push topic、device-link allowlist、手机版入口或交互，也未触及 device-link 的重试、超时或断链恢复链路。
- SSH 远程工作区：本 PR 已一并适配。远程 Codex 会话复用同一 Maker Core turn 归属与 retry tracker 路径；修复不读取本机 workdir、不新增本地文件访问或执行位置假设，既有远程错误诊断分支保持不变。

### UI 变化

不涉及。

- 引用的设计规范：不涉及，本 PR 未修改 UI、交互或文案路径。

## 怎么验证的

### 自动验证

```text
..\..\node_modules\.bin\vitest.CMD run src\agents\codex\index.test.ts -t "starts a fresh retry episode after same-turn progress" --reporter=dot
结果：1 passed；修复前稳定失败，修复后通过。

..\..\node_modules\.bin\vitest.CMD run src\agents\codex\index.test.ts -t "does not reset the active retry episode for a late foreign turn completion" --reporter=dot
结果：1 passed；验证旧 turn 迟到完成后，当前 turn 仍在第 30 次连续重试时按既有阈值熔断。

..\..\node_modules\.bin\vitest.CMD run src\agents\codex\index.test.ts -t "starts a fresh retry episode|does not reset the active retry episode|persistent willRetry retry-loop|子代理进展不算主 turn 恢复|迟到的 background terminal|deadline 内重新收到 thinking" --reporter=dot
结果：6 passed；覆盖连续重试熔断、真实恢复、迟到旧 root turn、descendant 与 background 边界。

..\..\node_modules\.bin\vitest.CMD run src\agents\codex\index.test.ts -t "keeps foreign-terminal guard when retry already activated|does not cancel active yield claim for late foreign failed turn|does not settle active yield claim for late foreign completed turn|does not reset active turn usage when older terminal-error completes late|keeps stale turn guard after older terminal-error completes during another turn" --reporter=dot
结果：5 passed；验证迟到 foreign terminal 不结算当前 yield、usage 或 active turn 状态。

pnpm test:unit:related
结果：通过。基线 upstream/main@a25b6881d；apps/desktop、packages/lizi-mcps、packages/maker-core、packages/orca-workflow 全部 PASS。

pnpm --filter @cindy/maker-core run --if-present typecheck
结果：成功 no-op；该 package 未定义 typecheck script，按仓库规则记为不适用。

pnpm check:dco -- --base upstream/main
结果：通过，2 个 commit 均已签名。
```

核心指标实测：

- 性能 / 返回速度：2,000,000 次 `reset + track` 微基准中位总成本约 5.27 ns/事件；新增 foreign-terminal guard 仅位于终态事件路径，未引入 I/O、对象分配、遍历或异步等待。
- 返回内容准确性：上述事件级测试验证恢复后不误熔断、迟到旧 turn 不重置当前 retry episode，并保持连续重试及 descendant/background 既有行为。
- 缓存率、tool/MCP、translator、模型路由、usage 与 system prompt：本 PR 未触及这些路径。

### 手工验证

不涉及；未连接真实故障网络触发 Codex app-server 重连，行为由确定性事件级测试覆盖。

### 未执行的验证

- `pnpm --filter @cindy/maker-core build` 已尝试，但被当前基线中既有、且不位于本次新增行的测试类型错误阻断。
- 两个改动文件的 ESLint 已尝试，但当前 workspace 未提供 `eslint` 可执行文件。
- 未做 macOS/Linux 运行时验证；改动不含平台分支。

## 风险

### 风险分类

- [ ] 无已知风险
- [ ] SQLite / migration
- [ ] system prompt
- [ ] 协议兼容
- [ ] 权限 / 安全 / 用户数据
- [ ] 存量插件兼容（批准状态 / 指纹 / manifest 校验 / 安装布局 / 包格式）
- [ ] 原生层 / fingerprint / OTA
- [ ] 跨平台差异
- [x] 其他：Codex retry episode 生命周期与事件归属。

### 影响与回滚

- 影响范围：Codex root/foreground turn 在有效恢复事件后的 retry tracker，以及旧 root turn 迟到终态与当前 active turn 重叠时的状态隔离。auth/rate-limit 分类、连续重试阈值、descendant/background 隔离均不变。
- 回滚 / 降级方式：revert 本 PR 的两个 commit，即恢复原有累计与迟到终态结算行为。
- 存量插件影响：无。

### 提交前检查

- [x] 已 review 完整 diff
- [x] 每个 commit 都带 DCO 签名（`git commit -s`，见 [DCO](../DCO)）
- [x] UI 改动已在「UI 变化」注明引用的设计规范章节（不涉及 UI）
- [x] 未提交凭证、令牌或授权文件
- [x] 已补充必要文档（本次无需独立文档，已补回归测试）
- [x] 已确认测试结果或说明未执行原因
