### PR TITLE
feat(mobile): show discounted model prices in the options sheet

### DIFF
--- a/apps/desktop/src/main/maker-ipc/__tests__/authStatusUsageHandlers.test.ts
+++ b/apps/desktop/src/main/maker-ipc/__tests__/authStatusUsageHandlers.test.ts
@@ -3,7 +3,7 @@ import { describe, expect, it, vi } from 'vitest';
 import { parseCodexDeviceCodeProgress, registerMakerAuthHandlers } from '../authHandlers';
 import { MAKER_INVOKE, MAKER_PUSH } from '../channels';
 import { registerMakerStatusHandlers } from '../statusHandlers';
-import { registerMakerUsageHandlers } from '../usageHandlers';
+import { registerMakerUsageHandlers, toLegacyUsdModelPricing } from '../usageHandlers';
 import { CodexRateLimitResetRejectedError } from '../../usage/codexRateLimitReset';
 import { IpcHarness } from './helpers/ipcHarness';
 import { zeroUsageMoney } from '../../../shared/regionalMoney';
@@ -1302,6 +1302,55 @@ describe('maker usage IPC handlers', () => {
     });
     await expect(harness.invoke(MAKER_INVOKE.USAGE_MODEL_PRICING_V2)).resolves.toEqual(pricing);
     expect(readModelPricing).toHaveBeenCalledTimes(2);
+  });
+
+  it('appends a valid Gateway costDiscount onto the legacy USD pricing channel', () => {
+    expect(
+      toLegacyUsdModelPricing({
+        xd: {
+          'grok-4.6': {
+            providerId: 'xd',
+            modelId: 'grok-4.6',
+            currency: 'USD',
+            source: 'gateway',
+            approximate: false,
+            inputPerMtok: 2,
+            outputPerMtok: 6,
+            costDiscount: 0.4,
+          },
+          'invalid-discount': {
+            providerId: 'xd',
+            modelId: 'invalid-discount',
+            currency: 'USD',
+            source: 'gateway',
+            approximate: false,
+            inputPerMtok: 3,
+            outputPerMtok: 15,
+            costDiscount: 1.2,
+          },
+          'cny-discounted': {
+            providerId: 'xd',
+            modelId: 'cny-discounted',
+            currency: 'CNY',
+            source: 'gateway',
+            approximate: false,
+            inputPerMtok: 5,
+            outputPerMtok: 25,
+            costDiscount: 0.5,
+          },
+        },
+      }),
+    ).toEqual({
+      'grok-4.6': {
+        inputUsdPerMtok: 2,
+        outputUsdPerMtok: 6,
+        costDiscount: 0.4,
+      },
+      'invalid-discount': {
+        inputUsdPerMtok: 3,
+        outputUsdPerMtok: 15,
+      },
+    });
   });
 
   it('serves non-XD reference prices on a channel independent from XD pricing', async () => {

--- a/apps/desktop/src/main/maker-ipc/usageHandlers.ts
+++ b/apps/desktop/src/main/maker-ipc/usageHandlers.ts
@@ -26,13 +26,22 @@ export interface LegacyUsdModelPrice {
   outputUsdPerMtok: number;
   cacheReadUsdPerMtok?: number;
   cacheCreateUsdPerMtok?: number;
+  /** Gateway 折扣比例 0..1;旧控制端忽略。计费金额 = 原价 × (1 - costDiscount)。 */
+  costDiscount?: number;
 }
 
 export type LegacyUsdModelPricingMap = Record<string, LegacyUsdModelPrice>;
 
+function normalizedCostDiscount(value: unknown): number | undefined {
+  return typeof value === 'number' && Number.isFinite(value) && value > 0 && value <= 1
+    ? value
+    : undefined;
+}
+
 /**
  * device-link v1 兼容投影。旧控制端只能表达扁平 USD 价格，因此只投影真实 USD quote；
  * CNY 不能反算或写进 *Usd，旧端按既有“无价隐藏”语义降级。
+ * costDiscount 是 append-only：新控制端用来算折后价，旧端忽略未知字段。
  */
 export function toLegacyUsdModelPricing(
   pricing: ModelPricingMap | null,
@@ -40,6 +49,7 @@ export function toLegacyUsdModelPricing(
   const out: LegacyUsdModelPricingMap = {};
   for (const [modelId, quote] of Object.entries(pricing?.xd ?? {})) {
     if (quote.currency !== 'USD') continue;
+    const costDiscount = normalizedCostDiscount(quote.costDiscount);
     out[modelId] = {
       inputUsdPerMtok: quote.inputPerMtok,
       outputUsdPerMtok: quote.outputPerMtok,
@@ -49,6 +59,7 @@ export function toLegacyUsdModelPricing(
       ...(quote.cacheCreatePerMtok !== undefined
         ? { cacheCreateUsdPerMtok: quote.cacheCreatePerMtok }
         : {}),
+      ...(costDiscount !== undefined ? { costDiscount } : {}),
     };
   }
   return Object.keys(out).length > 0 ? out : null;

--- a/apps/mobile/src/__tests__/modelPickerRows.test.ts
+++ b/apps/mobile/src/__tests__/modelPickerRows.test.ts
@@ -18,6 +18,7 @@ import {
   formatContextWindow,
   formatPriceLine,
   modelRowAccessibilityLabel,
+  presentPickerPrice,
   providerDisplayTitle,
   rowEffortOf,
   rowFastEditable,
@@ -75,20 +76,105 @@ describe('providerDisplayTitle / formatPriceLine / buildRowMetaLine', () => {
     expect(formatPriceLine(undefined)).toBeNull();
   });
 
-  it('元信息行 = 供应商 · 上下文 · 单价 · 快速;全空 → null', () => {
+  it('元信息行 = 供应商 · 上下文 · 快速;单价改走独立价格块;全空 → null', () => {
     const full = buildRowMetaLine({
       provider: { id: 'xd', name: 'XD Gateway' },
       model: { id: 'gpt-5.5', contextWindow: 272_000, supportsFastMode: true },
-      pricing: { 'gpt-5.5': { inputUsdPerMtok: 3, outputUsdPerMtok: 15 } },
     });
-    expect(full).toBe('Cindy AI · 272K 上下文 · 输入 $3 · 输出 $15 / 百万 token · 快速');
+    expect(full).toBe('Cindy AI · 272K 上下文 · 快速');
 
     const minimal = buildRowMetaLine({
       provider: null,
       model: { id: 'm', contextWindow: 0 },
-      pricing: null,
     });
     expect(minimal).toBeNull();
+  });
+});
+
+function xdProviderWithCost(
+  modelId: string,
+  cost: { input: number; output: number },
+): ProviderView {
+  return {
+    id: 'xd',
+    name: 'Cindy AI',
+    agents: ['codex'],
+    connected: true,
+    models: { codex: [{ id: modelId, cost }] },
+  } as unknown as ProviderView;
+}
+
+describe('presentPickerPrice', () => {
+  it('无报价 → null;有报价无折扣 → 标准价', () => {
+    expect(
+      presentPickerPrice({
+        pricing: null,
+        provider: null,
+        modelId: 'grok-4.6',
+        agentKind: 'codex',
+      }),
+    ).toBeNull();
+    expect(
+      presentPickerPrice({
+        pricing: { 'grok-4.6': { inputUsdPerMtok: 2, outputUsdPerMtok: 6 } },
+        provider: null,
+        modelId: 'grok-4.6',
+        agentKind: 'codex',
+      }),
+    ).toEqual({
+      title: '每百万 token',
+      amountsLine: '输入 $2 · 输出 $6',
+      discountLabel: null,
+    });
+  });
+
+  it('目录折后价与标准价同比例时展示折后价 + 折扣说明', () => {
+    expect(
+      presentPickerPrice({
+        pricing: { 'grok-4.6': { inputUsdPerMtok: 2, outputUsdPerMtok: 6 } },
+        provider: xdProviderWithCost('grok-4.6', { input: 0.3, output: 0.9 }),
+        modelId: 'grok-4.6',
+        agentKind: 'codex',
+      }),
+    ).toEqual({
+      title: '每百万 token',
+      amountsLine: '输入 $0.3 · 输出 $0.9',
+      discountLabel: '折扣中，较标准价省 85%',
+      discountPct: 85,
+    });
+  });
+
+  it('目录缺失时回退报价 costDiscount', () => {
+    expect(
+      presentPickerPrice({
+        pricing: {
+          'grok-4.6': { inputUsdPerMtok: 2, outputUsdPerMtok: 6, costDiscount: 0.4 },
+        },
+        provider: null,
+        modelId: 'grok-4.6',
+        agentKind: 'codex',
+      }),
+    ).toEqual({
+      title: '每百万 token',
+      amountsLine: '输入 $1.2 · 输出 $3.6',
+      discountLabel: '折扣中，较标准价省 40%',
+      discountPct: 40,
+    });
+  });
+
+  it('目录折后价比例不一致时不挂折扣,保持标准价', () => {
+    expect(
+      presentPickerPrice({
+        pricing: { 'grok-4.6': { inputUsdPerMtok: 2, outputUsdPerMtok: 6 } },
+        provider: xdProviderWithCost('grok-4.6', { input: 1, output: 6 }),
+        modelId: 'grok-4.6',
+        agentKind: 'codex',
+      }),
+    ).toEqual({
+      title: '每百万 token',
+      amountsLine: '输入 $2 · 输出 $6',
+      discountLabel: null,
+    });
   });
 });
 

--- a/apps/mobile/src/__tests__/modelPickerRows.test.ts
+++ b/apps/mobile/src/__tests__/modelPickerRows.test.ts
@@ -176,6 +176,40 @@ describe('presentPickerPrice', () => {
       discountLabel: null,
     });
   });
+
+  it('非 XD 供应商即使 modelId 撞车也不套用 XD 报价', () => {
+    const openai = {
+      id: 'openai',
+      name: 'OpenAI',
+      agents: ['codex'],
+      connected: true,
+      models: { codex: [{ id: 'gpt-5.5', cost: { input: 1, output: 5 } }] },
+    } as unknown as ProviderView;
+    expect(
+      presentPickerPrice({
+        pricing: { 'gpt-5.5': { inputUsdPerMtok: 3, outputUsdPerMtok: 15, costDiscount: 0.4 } },
+        provider: openai,
+        modelId: 'gpt-5.5',
+        agentKind: 'codex',
+      }),
+    ).toBeNull();
+  });
+
+  it('折后价小于 1 分时保留最多 4 位小数,不显示成 $0', () => {
+    expect(
+      presentPickerPrice({
+        pricing: { cheap: { inputUsdPerMtok: 0.04, outputUsdPerMtok: 0.04, costDiscount: 0.9 } },
+        provider: null,
+        modelId: 'cheap',
+        agentKind: 'codex',
+      }),
+    ).toEqual({
+      title: '每百万 token',
+      amountsLine: '输入 $0.004 · 输出 $0.004',
+      discountLabel: '折扣中，较标准价省 90%',
+      discountPct: 90,
+    });
+  });
 });
 
 describe('effortLabelFor —— 五级优先(i18n → 模型覆盖 → capabilities → 兼容词表 → 原 id)', () => {

--- a/apps/mobile/src/device-link/mobileMakerTransport.ts
+++ b/apps/mobile/src/device-link/mobileMakerTransport.ts
@@ -278,6 +278,8 @@ export interface MobileActiveSessionSnapshot {
 export interface MobileModelPrice {
   inputUsdPerMtok: number;
   outputUsdPerMtok: number;
+  /** Gateway 折扣比例 0..1;旧被控端不下发。计费金额 = 原价 × (1 - costDiscount)。 */
+  costDiscount?: number;
 }
 
 export type MobileModelPricingMap = Record<string, MobileModelPrice>;

--- a/apps/mobile/src/i18n/locales/en/models.json
+++ b/apps/mobile/src/i18n/locales/en/models.json
@@ -18,6 +18,9 @@
     "configureAccessibility": "Configure {{model}}",
     "budgetDisabledHint": "This model needs an API key configured on the controlled device first",
     "priceLine": "Input {{input}} · Output {{output}} / million tokens",
+    "priceTitle": "Per 1M tokens",
+    "priceAmounts": "Input {{input}} · Output {{output}}",
+    "discountedVsStandard": "Discounted · {{percent}}% off standard",
     "contextSuffix": "{{size}} context",
     "fastTag": "Fast"
   },

--- a/apps/mobile/src/i18n/locales/ja/models.json
+++ b/apps/mobile/src/i18n/locales/ja/models.json
@@ -18,6 +18,9 @@
     "configureAccessibility": "{{model}} を設定",
     "budgetDisabledHint": "このモデルを使うには、先に操作対象のデバイスで API キーを設定してください",
     "priceLine": "入力 {{input}} · 出力 {{output}} / 100万トークン",
+    "priceTitle": "100万トークンあたり",
+    "priceAmounts": "入力 {{input}} · 出力 {{output}}",
+    "discountedVsStandard": "割引中 · 標準価格から {{percent}}% お得",
     "contextSuffix": "{{size}} コンテキスト",
     "fastTag": "高速"
   },

--- a/apps/mobile/src/i18n/locales/ko/models.json
+++ b/apps/mobile/src/i18n/locales/ko/models.json
@@ -18,6 +18,9 @@
     "configureAccessibility": "{{model}} 구성",
     "budgetDisabledHint": "이 모델을 사용하려면 먼저 제어 대상 기기에서 API 키를 설정해야 합니다",
     "priceLine": "입력 {{input}} · 출력 {{output}} / 100만 토큰",
+    "priceTitle": "100만 토큰당",
+    "priceAmounts": "입력 {{input}} · 출력 {{output}}",
+    "discountedVsStandard": "할인 중 · 표준가 대비 {{percent}}% 절약",
     "contextSuffix": "{{size}} 컨텍스트",
     "fastTag": "빠름"
   },

--- a/apps/mobile/src/i18n/locales/zh-CN/models.json
+++ b/apps/mobile/src/i18n/locales/zh-CN/models.json
@@ -18,6 +18,9 @@
     "configureAccessibility": "配置 {{model}}",
     "budgetDisabledHint": "该模型需先在被控设备配置 API key 才能使用",
     "priceLine": "输入 {{input}} · 输出 {{output}} / 百万 token",
+    "priceTitle": "每百万 token",
+    "priceAmounts": "输入 {{input}} · 输出 {{output}}",
+    "discountedVsStandard": "折扣中，较标准价省 {{percent}}%",
     "contextSuffix": "{{size}} 上下文",
     "fastTag": "快速"
   },

--- a/apps/mobile/src/i18n/locales/zh-TW/models.json
+++ b/apps/mobile/src/i18n/locales/zh-TW/models.json
@@ -18,6 +18,9 @@
     "configureAccessibility": "配置 {{model}}",
     "budgetDisabledHint": "該模型需先在被控裝置配置 API key 才能使用",
     "priceLine": "輸入 {{input}} · 輸出 {{output}} / 百萬 token",
+    "priceTitle": "每百萬 token",
+    "priceAmounts": "輸入 {{input}} · 輸出 {{output}}",
+    "discountedVsStandard": "折扣中，較標準價省 {{percent}}%",
     "contextSuffix": "{{size}} 上下文",
     "fastTag": "快速"
   },

--- a/apps/mobile/src/session/ModelOptionsSheetView.tsx
+++ b/apps/mobile/src/session/ModelOptionsSheetView.tsx
@@ -1,8 +1,9 @@
 /**
  * ModelOptionsSheetView —— 模型浮窗二级「模型选项」视图的内容(SheetSurface 的 children)。
  *
- * 承接原先行内 accordion 的配置区语义:顶部元信息行(供应商全名 · 上下文 · 单价 · 极速,
- * 对齐桌面 hover tooltip 口径)+ 「快速模式」Switch + 「推理强度」竖排单选。
+ * 承接原先行内 accordion 的配置区语义:顶部元信息行(供应商全名 · 上下文 · 极速)+
+ * 价格块(折后价 + 可选折扣说明,对齐桌面 ModelConfigFlyout)+
+ * 「快速模式」Switch + 「推理强度」竖排单选。
  * 读写语义与桌面完全一致:目标行是**选中行** → 改 live(onChangeSelectedEffort/FastMode);
  * **非选中行** → 写注入记忆(草稿 = draftModelMemory / 会话 = sessionModelMirror 写穿被控端)。
  * effort 点击后停留(可连续调 Fast),返回/把手下拉由浮窗层负责。
@@ -23,6 +24,7 @@ import { useSessionModelMirrorVersion } from "@/session/sessionModelMirror";
 import {
   buildRowMetaLine,
   effortLabelFor,
+  presentPickerPrice,
   rowEffortOf,
   rowFastOn,
   type PickerRowModel,
@@ -69,12 +71,34 @@ export interface ModelOptionsSheetViewProps {
 
 const makeStyles = (c: ThemeColors) =>
   StyleSheet.create({
+    headerBlock: {
+      gap: spacing.xs,
+      paddingBottom: spacing.sm,
+      paddingTop: spacing.xs,
+    },
     metaLine: {
       color: c.textTertiary,
       fontSize: typeScale.footnote,
       lineHeight: lineHeight.caption,
-      paddingBottom: spacing.sm,
-      paddingTop: spacing.xs,
+    },
+    priceBlock: {
+      gap: spacing.xs,
+    },
+    priceTitle: {
+      color: c.textTertiary,
+      fontSize: typeScale.footnote,
+      lineHeight: lineHeight.caption,
+    },
+    // 折扣说明用 statusDone(#2AAE5B),与桌面 EFFORT_TIER_COLORS.low / «省 X%» 绿色加粗同源。
+    priceDiscount: {
+      color: c.statusDone,
+      fontWeight: fontWeight.semibold,
+    },
+    priceAmounts: {
+      color: c.textPrimary,
+      fontSize: typeScale.footnote,
+      fontWeight: fontWeight.medium,
+      lineHeight: lineHeight.caption,
     },
     // 与推理强度选项行同一水平内边距(effortOptionRow 的 pill 内距):
     // label 与选项文字左对齐,Switch 与选项行的 Check 右对齐。
@@ -154,7 +178,12 @@ export function ModelOptionsSheetView({
       contextWindow,
       supportsFastMode: model.supportsFastMode,
     },
+  });
+  const price = presentPickerPrice({
     pricing,
+    provider,
+    modelId: model.id,
+    agentKind,
   });
   const currentEffort = rowEffortOf({
     model,
@@ -195,10 +224,32 @@ export function ModelOptionsSheetView({
 
   return (
     <View testID={testID}>
-      {metaLine ? (
-        <Text style={styles.metaLine} testID={`${testID}.meta`}>
-          {metaLine}
-        </Text>
+      {metaLine || price ? (
+        <View style={styles.headerBlock}>
+          {metaLine ? (
+            <Text style={styles.metaLine} testID={`${testID}.meta`}>
+              {metaLine}
+            </Text>
+          ) : null}
+          {price ? (
+            <View style={styles.priceBlock} testID={`${testID}.price`}>
+              <Text style={styles.priceTitle}>
+                {price.title}
+                {price.discountLabel ? (
+                  <Text style={styles.priceDiscount}>
+                    {` · ${price.discountLabel}`}
+                  </Text>
+                ) : null}
+              </Text>
+              <Text
+                style={styles.priceAmounts}
+                testID={`${testID}.priceAmounts`}
+              >
+                {price.amountsLine}
+              </Text>
+            </View>
+          ) : null}
+        </View>
       ) : null}
       {fastEditable ? (
         <View style={styles.fastRow}>

--- a/apps/mobile/src/session/modelPickerRows.ts
+++ b/apps/mobile/src/session/modelPickerRows.ts
@@ -74,8 +74,16 @@ function normalizedCostDiscount(value: unknown): number | undefined {
     : undefined;
 }
 
+/** 对齐桌面 formatModelPriceAmount:小于 1 分保留最多 4 位,否则最多 2 位,不补零。 */
+function compactNumber(value: number): string {
+  return new Intl.NumberFormat('en-US', {
+    maximumFractionDigits: value > 0 && value < 0.01 ? 4 : 2,
+    useGrouping: false,
+  }).format(value);
+}
+
 function formatUsd(value: number): string {
-  return `$${Number(value.toFixed(2))}`;
+  return `$${compactNumber(value)}`;
 }
 
 function compactPercent(discount: number): string {
@@ -133,6 +141,8 @@ export interface PickerPricePresentation {
 /**
  * 模型选项页价格展示。报价表给标准价;目录 CatalogModel.cost 给折后价(桌面同口径)。
  * 目录缺失时回退报价上的 costDiscount。比例不一致时不挂折扣,避免把混用价当成折后价。
+ * v1 通道只有 XD USD 扁平表:明确非 xd 的供应商行不读这张表(对齐桌面 provider-aware
+ * 查找);provider === null 是旧被控端扁平回退,仍可用。
  */
 export function presentPickerPrice(args: {
   pricing: MobileModelPricingMap | null;
@@ -140,6 +150,7 @@ export function presentPickerPrice(args: {
   modelId: string;
   agentKind: AgentKind | null;
 }): PickerPricePresentation | null {
+  if (args.provider && args.provider.id !== 'xd') return null;
   const quote = args.pricing?.[args.modelId];
   if (
     !quote ||

--- a/apps/mobile/src/session/modelPickerRows.ts
+++ b/apps/mobile/src/session/modelPickerRows.ts
@@ -6,7 +6,7 @@
  * (mobile i18n 化后由 models.json catalog 供文案,在使用点求值 i18n.t)。组件只做渲染,
  * 这里可 node 单测。
  */
-import { modelSupportsFastMode, type ProviderView } from '@cindy/model-providers/registry';
+import { getModel, modelSupportsFastMode, type ProviderView } from '@cindy/model-providers/registry';
 import type { SectionModel } from '@cindy/model-providers/sections';
 import type { AgentKind } from '@cindy/model-providers/types';
 
@@ -64,34 +64,150 @@ export function providerDisplayTitle(p: Pick<ProviderView, 'id' | 'name'>): stri
   return PROVIDER_TITLE[p.id] ?? p.name;
 }
 
+function isNonNegativeFinite(value: unknown): value is number {
+  return typeof value === 'number' && Number.isFinite(value) && value >= 0;
+}
+
+function normalizedCostDiscount(value: unknown): number | undefined {
+  return typeof value === 'number' && Number.isFinite(value) && value > 0 && value <= 1
+    ? value
+    : undefined;
+}
+
+function formatUsd(value: number): string {
+  return `$${Number(value.toFixed(2))}`;
+}
+
+function compactPercent(discount: number): string {
+  return new Intl.NumberFormat('en-US', {
+    maximumFractionDigits: 2,
+    useGrouping: false,
+  }).format(discount * 100);
+}
+
+// 各价格维度的缩放比例小于这个阈值时视为浮点噪声,按标准价展示。对齐桌面 modelPriceFormat。
+const MIN_EFFECTIVE_PRICE_GAP = 0.0005;
+
+function inferInputOutputDiscount(
+  standardInput: number,
+  standardOutput: number,
+  effectiveInput: number,
+  effectiveOutput: number,
+): number | undefined {
+  const gaps: number[] = [];
+  for (const [standard, effective] of [
+    [standardInput, effectiveInput],
+    [standardOutput, effectiveOutput],
+  ] as const) {
+    if (standard === 0) {
+      if (effective !== 0) return undefined;
+      continue;
+    }
+    const gap = 1 - effective / standard;
+    if (gap < MIN_EFFECTIVE_PRICE_GAP || gap > 1) return undefined;
+    gaps.push(gap);
+  }
+  if (gaps.length === 0) return undefined;
+  return gaps.every((gap) => Math.abs(gap - gaps[0]) < 1e-9) ? gaps[0] : undefined;
+}
+
 /** 单价行(对齐桌面 zh-CN priceTip:「输入 $3 · 输出 $15 / 百万 token」);无价返回 null。 */
 export function formatPriceLine(
   price: { inputUsdPerMtok: number; outputUsdPerMtok: number } | undefined,
 ): string | null {
   if (!price) return null;
-  const fmt = (v: number) => `$${Number(v.toFixed(2))}`;
   return i18n.t('models.picker.priceLine', {
-    input: fmt(price.inputUsdPerMtok),
-    output: fmt(price.outputUsdPerMtok),
+    input: formatUsd(price.inputUsdPerMtok),
+    output: formatUsd(price.outputUsdPerMtok),
   });
 }
 
+/** 模型选项页的价格块:折后价 + 可选折扣说明。无报价 → null。 */
+export interface PickerPricePresentation {
+  title: string;
+  amountsLine: string;
+  discountLabel: string | null;
+  discountPct?: number;
+}
+
 /**
- * 行展开区顶部的元信息行(对齐桌面 hover tooltip 的拼接口径:
- * 供应商完整名 · {contextWindow} 上下文 · 单价 · 快速)。全部缺失 → null(不渲染)。
+ * 模型选项页价格展示。报价表给标准价;目录 CatalogModel.cost 给折后价(桌面同口径)。
+ * 目录缺失时回退报价上的 costDiscount。比例不一致时不挂折扣,避免把混用价当成折后价。
+ */
+export function presentPickerPrice(args: {
+  pricing: MobileModelPricingMap | null;
+  provider: ProviderView | null;
+  modelId: string;
+  agentKind: AgentKind | null;
+}): PickerPricePresentation | null {
+  const quote = args.pricing?.[args.modelId];
+  if (
+    !quote ||
+    !isNonNegativeFinite(quote.inputUsdPerMtok) ||
+    !isNonNegativeFinite(quote.outputUsdPerMtok)
+  ) {
+    return null;
+  }
+
+  let currentInput = quote.inputUsdPerMtok;
+  let currentOutput = quote.outputUsdPerMtok;
+  let discount: number | undefined;
+
+  const catalogCost =
+    args.provider && args.agentKind
+      ? getModel(args.provider, args.modelId, args.agentKind)?.cost
+      : undefined;
+  const catalogInput = catalogCost?.input;
+  const catalogOutput = catalogCost?.output;
+
+  if (isNonNegativeFinite(catalogInput) && isNonNegativeFinite(catalogOutput)) {
+    discount = inferInputOutputDiscount(
+      quote.inputUsdPerMtok,
+      quote.outputUsdPerMtok,
+      catalogInput,
+      catalogOutput,
+    );
+    if (discount !== undefined) {
+      currentInput = catalogInput;
+      currentOutput = catalogOutput;
+    }
+  } else {
+    const fromQuote = normalizedCostDiscount(quote.costDiscount);
+    if (fromQuote !== undefined) {
+      discount = fromQuote;
+      currentInput = quote.inputUsdPerMtok * (1 - fromQuote);
+      currentOutput = quote.outputUsdPerMtok * (1 - fromQuote);
+    }
+  }
+
+  const discountLabel =
+    discount !== undefined
+      ? i18n.t('models.picker.discountedVsStandard', { percent: compactPercent(discount) })
+      : null;
+  return {
+    title: i18n.t('models.picker.priceTitle'),
+    amountsLine: i18n.t('models.picker.priceAmounts', {
+      input: formatUsd(currentInput),
+      output: formatUsd(currentOutput),
+    }),
+    discountLabel,
+    ...(discount !== undefined ? { discountPct: Math.round(discount * 100) } : {}),
+  };
+}
+
+/**
+ * 行展开区顶部的元信息行(供应商完整名 · {contextWindow} 上下文 · 快速)。
+ * 单价改由 presentPickerPrice 单独成块,对齐桌面 ModelConfigFlyout。全部缺失 → null。
  */
 export function buildRowMetaLine(args: {
   provider: Pick<ProviderView, 'id' | 'name'> | null;
   model: Pick<SectionModel, 'id' | 'contextWindow' | 'supportsFastMode'>;
-  pricing: MobileModelPricingMap | null;
 }): string | null {
   const parts: string[] = [];
   if (args.provider) parts.push(providerDisplayTitle(args.provider));
   if (args.model.contextWindow > 0) {
     parts.push(i18n.t('models.picker.contextSuffix', { size: formatContextWindow(args.model.contextWindow) }));
   }
-  const price = formatPriceLine(args.pricing?.[args.model.id]);
-  if (price) parts.push(price);
   if (args.model.supportsFastMode) parts.push(i18n.t('models.picker.fastTag'));
   return parts.length > 0 ? parts.join(' · ') : null;
 }


### PR DESCRIPTION
## 这次改了什么

### 摘要

手机模型选项页现在展示**折后实价**，并标明相对标准价的折扣，对齐桌面 `ModelConfigFlyout`。旧桌面/旧手机忽略新增的 `costDiscount` 字段，v1 报价通道保持 append-only。

### 变更类型

- [x] `feat` 新功能
- [ ] `fix` 缺陷修复
- [ ] `refactor` / `perf` 重构或性能优化
- [ ] `docs` / `test` / `chore` 文档、测试或工程维护
- [ ] 其他：

### 范围

- 关联 Issue / 需求：手机选模型时只看到标准价（如 Grok 4.6 `$2 / $6`），看不到网关折扣后的实价
- 本 PR 包含：
  - device-link v1 `maker:usage:model-pricing` 在 USD 报价上 **append-only** 增加 `costDiscount?: number`（0..1）
  - 手机 `presentPickerPrice`：优先用目录 `CatalogModel.cost` 当折后价，缺失时回退报价上的 `costDiscount`；input/output 折扣比例不一致则不挂折扣
  - 模型选项页独立价格块（不再塞进元信息行）
  - 折扣文案用与桌面相同的绿（`statusDone` / `#2AAE5B`）+ semibold
  - 五语种 `priceTitle` / `priceAmounts` / `discountedVsStandard`
- 明确不包含：CNY 报价进 v1 通道、桌面飞窗改版、改 native fingerprint
- 用户可见变化：模型选项页显示「每百万 token · 折扣中，较标准价省 X%」和折后「输入 $… · 输出 $…」
- 是否存在 breaking change：无。旧控制端忽略未知字段；无折扣时展示与原来一致

### UI 变化

- 引用的设计规范：`docs/design-rules/DESIGN.md` §2 Semantic & Accent（完成绿 `--card-status-done` / `#2AAE5B`，与桌面 `EFFORT_TIER_COLORS.low` 同源，只给折扣说明着色；其余仍走灰度 token）；§1 克制用色；双模式均走 `statusDone` token（light/dark 同值、主题不变）。布局对齐桌面 `ModelConfigFlyout` 紧凑两行价格块，不引入删除线对照表。

模拟器（iPhone 17 Pro / `com.xd.cindy` / 连 vega.local）Grok 4.6：`Cindy AI · 500K context` / `Per 1M tokens · Discounted · 90% off standard` / `Input $0.2 · Output $0.6`。

## 怎么验证的

### 自动验证

```text
pnpm test:unit:related
结果：PASS apps/desktop unit (22.1s)；PASS apps/mobile unit (5.6s)

pnpm --filter desktop run typecheck
结果：通过

pnpm --filter mobile run typecheck
结果：通过
```

### 手工验证

- 平台：iOS Simulator iPhone 17 Pro，dev client `com.xd.cindy`，Metro `--region=cn`，被控电脑 vega.local
- 路径：新建远程会话 → 点输入框展开 composer → 模型药丸 → Configure Grok 4.6
- 结果：折扣行绿色加粗，实价 `$0.2 / $0.6`（标准 `$2 / $6` 的 90% off）

<img width="603" height="1311" alt="IMG_7438" src="https://github.com/user-attachments/assets/3d5bb5a3-80e5-4db2-a25b-e7247cffd8c1" />

### 未执行的验证

- Android 未跑
- Dark 模式未在模拟器里目检（token 双模式同值；未把「复用 themed 样式」当成已验证）

## 风险

### 风险分类

- [ ] 无已知风险
- [ ] SQLite / migration
- [ ] system prompt
- [x] 协议兼容
- [ ] 权限 / 安全 / 用户数据
- [ ] 存量插件兼容（批准状态 / 指纹 / manifest 校验 / 安装布局 / 包格式）
- [ ] 原生层 / fingerprint / OTA
- [x] 跨平台差异
- [ ] 其他：

### 影响与回滚

- 影响范围：device-link v1 报价 JSON 多一个可选字段；手机模型选项页价格展示。旧桌面忽略 `costDiscount`，行为与现在一致。无折扣或目录/报价比例不一致时仍展示标准价。
- 回滚 / 降级方式：revert 本 PR。旧客户端无需配合。不改 native fingerprint，无冷更。

### 提交前检查

- [x] 已 review 完整 diff
- [x] 每个 commit 都带 DCO 签名（`git commit -s`，见 [DCO](../DCO)）
- [x] UI 改动已在「UI 变化」注明引用的设计规范章节（不涉及 UI 则跳过）
- [x] 未提交凭证、令牌或授权文件
- [x] 已补充必要文档
- [x] 已确认测试结果或说明未执行原因