### PR TITLE
fix(desktop): import renamed Codex session titles

### DIFF
--- a/apps/desktop/src/main/__tests__/codexLocalSessions.test.ts
+++ b/apps/desktop/src/main/__tests__/codexLocalSessions.test.ts
@@ -461,7 +461,7 @@ describe('Codex local session import', () => {
     expect(row.title).toBe('Compatible custom title');
   });
 
-  it('keeps the state title for malformed, unmatched, or blank index entries', async () => {
+  it('keeps the state title but applies time for malformed, unmatched, or blank index entries', async () => {
     const dbPath = createStateDb(externalHome);
     const rolloutPath = path.join(
       externalHome,
@@ -492,14 +492,17 @@ describe('Codex local session import', () => {
       ].join('\n'),
     );
 
+    const indexUpdatedAt = Date.parse('2026-05-13T00:00:05.000Z');
     const scan = await scanExternalCodexSessions();
-    expect(scan.candidates).toMatchObject([{ id: threadId, title: 'State title' }]);
+    expect(scan.candidates).toMatchObject([
+      { id: threadId, title: 'State title', updatedAt: indexUpdatedAt },
+    ]);
 
     await importExternalCodexSessions([threadId]);
     const row = currentTestDb()
-      .prepare('SELECT title FROM sessions WHERE id = ?')
-      .get(`codex-${threadId}`) as { title: string };
-    expect(row.title).toBe('State title');
+      .prepare('SELECT title, updated_at AS updatedAt FROM sessions WHERE id = ?')
+      .get(`codex-${threadId}`) as { title: string; updatedAt: number };
+    expect(row).toEqual({ title: 'State title', updatedAt: indexUpdatedAt });
   });
 
   it('updates an imported title when a later Codex rename advances the index time', async () => {

--- a/apps/desktop/src/main/__tests__/codexLocalSessions.test.ts
+++ b/apps/desktop/src/main/__tests__/codexLocalSessions.test.ts
@@ -249,6 +249,13 @@ function rolloutLineWithImage(id: string, text: string, timestamp: string): stri
   });
 }
 
+function writeSessionIndex(...entries: unknown[]): void {
+  fs.writeFileSync(
+    path.join(externalHome, 'session_index.jsonl'),
+    `${entries.map((entry) => JSON.stringify(entry)).join('\n')}\n`,
+  );
+}
+
 beforeEach(() => {
   originalCodexHome = process.env.CODEX_HOME;
   rootDir = fs.mkdtempSync(path.join(os.tmpdir(), 'codex-local-sessions-'));
@@ -390,6 +397,189 @@ describe('Codex local session import', () => {
     expect(result).toMatchObject({ scanned: 1, inserted: 1, updated: 0 });
     const rows = currentTestDb().prepare('SELECT id, title FROM sessions ORDER BY id').all();
     expect(rows).toEqual([{ id: `codex-${threadId}`, title: 'Import Me' }]);
+  });
+
+  it('imports a user-renamed Codex title from the session index', async () => {
+    const dbPath = createStateDb(externalHome);
+    const rolloutPath = path.join(
+      externalHome,
+      'sessions',
+      `rollout-2026-05-13-${threadId}.jsonl`,
+    );
+    fs.mkdirSync(path.dirname(rolloutPath), { recursive: true });
+    fs.writeFileSync(rolloutPath, '');
+    insertThread(dbPath, threadId, rolloutPath, {
+      updatedAt: 2_000,
+      title: 'Generated Codex title',
+    });
+    writeSessionIndex({
+      id: threadId,
+      thread_name: 'Fix login timeout',
+      updated_at: '2026-05-13T00:00:03.000Z',
+    });
+
+    const scan = await scanExternalCodexSessions();
+    expect(scan.candidates).toMatchObject([
+      { id: threadId, title: 'Fix login timeout' },
+    ]);
+
+    const result = await importExternalCodexSessions([threadId]);
+    expect(result).toMatchObject({ scanned: 1, inserted: 1, updated: 0 });
+    const rows = currentTestDb().prepare('SELECT id, title FROM sessions').all();
+    expect(rows).toEqual([{ id: `codex-${threadId}`, title: 'Fix login timeout' }]);
+  });
+
+  it('falls back to the session index title compatibility field', async () => {
+    const dbPath = createStateDb(externalHome);
+    const rolloutPath = path.join(
+      externalHome,
+      'sessions',
+      `rollout-2026-05-13-${threadId}.jsonl`,
+    );
+    fs.mkdirSync(path.dirname(rolloutPath), { recursive: true });
+    fs.writeFileSync(rolloutPath, '');
+    insertThread(dbPath, threadId, rolloutPath, {
+      updatedAt: 2_000,
+      title: 'Generated Codex title',
+    });
+    writeSessionIndex({
+      id: threadId,
+      thread_name: '   ',
+      title: 'Compatible custom title',
+      updated_at: '2026-05-13T00:00:03.000Z',
+    });
+
+    const scan = await scanExternalCodexSessions();
+    expect(scan.candidates).toMatchObject([
+      { id: threadId, title: 'Compatible custom title' },
+    ]);
+
+    await importExternalCodexSessions([threadId]);
+    const row = currentTestDb()
+      .prepare('SELECT title FROM sessions WHERE id = ?')
+      .get(`codex-${threadId}`) as { title: string };
+    expect(row.title).toBe('Compatible custom title');
+  });
+
+  it('keeps the state title for malformed, unmatched, or blank index entries', async () => {
+    const dbPath = createStateDb(externalHome);
+    const rolloutPath = path.join(
+      externalHome,
+      'sessions',
+      `rollout-2026-05-13-${threadId}.jsonl`,
+    );
+    fs.mkdirSync(path.dirname(rolloutPath), { recursive: true });
+    fs.writeFileSync(rolloutPath, '');
+    insertThread(dbPath, threadId, rolloutPath, {
+      updatedAt: 2_000,
+      title: 'State title',
+    });
+    fs.writeFileSync(
+      path.join(externalHome, 'session_index.jsonl'),
+      [
+        '{malformed',
+        JSON.stringify({
+          id: execThreadId,
+          thread_name: 'Different thread title',
+          updated_at: '2026-05-13T00:00:04.000Z',
+        }),
+        JSON.stringify({
+          id: threadId,
+          thread_name: '   ',
+          title: '',
+          updated_at: '2026-05-13T00:00:05.000Z',
+        }),
+      ].join('\n'),
+    );
+
+    const scan = await scanExternalCodexSessions();
+    expect(scan.candidates).toMatchObject([{ id: threadId, title: 'State title' }]);
+
+    await importExternalCodexSessions([threadId]);
+    const row = currentTestDb()
+      .prepare('SELECT title FROM sessions WHERE id = ?')
+      .get(`codex-${threadId}`) as { title: string };
+    expect(row.title).toBe('State title');
+  });
+
+  it('updates an imported title when a later Codex rename advances the index time', async () => {
+    const dbPath = createStateDb(externalHome);
+    const rolloutPath = path.join(
+      externalHome,
+      'sessions',
+      `rollout-2026-05-13-${threadId}.jsonl`,
+    );
+    fs.mkdirSync(path.dirname(rolloutPath), { recursive: true });
+    fs.writeFileSync(rolloutPath, '');
+    insertThread(dbPath, threadId, rolloutPath, {
+      updatedAt: 2_000,
+      title: 'Generated Codex title',
+    });
+    writeSessionIndex({
+      id: threadId,
+      thread_name: 'First custom title',
+      updated_at: '2026-05-13T00:00:03.000Z',
+    });
+
+    await importExternalCodexSessions([threadId]);
+    writeSessionIndex({
+      id: threadId,
+      thread_name: 'Renamed custom title',
+      updated_at: '2026-05-13T00:00:04.000Z',
+    });
+    const result = await importExternalCodexSessions([threadId]);
+
+    expect(result).toMatchObject({ scanned: 1, inserted: 0, updated: 1 });
+    const row = currentTestDb()
+      .prepare('SELECT title, updated_at AS updatedAt FROM sessions WHERE id = ?')
+      .get(`codex-${threadId}`) as { title: string; updatedAt: number };
+    expect(row).toEqual({
+      title: 'Renamed custom title',
+      updatedAt: Date.parse('2026-05-13T00:00:04.000Z'),
+    });
+  });
+
+  it('keeps the index title when the same thread is read from DB and rollout', async () => {
+    const dbPath = createStateDb(externalHome);
+    const rolloutPath = path.join(
+      externalHome,
+      'sessions',
+      `rollout-2026-05-13-${threadId}.jsonl`,
+    );
+    fs.mkdirSync(path.dirname(rolloutPath), { recursive: true });
+    fs.writeFileSync(
+      rolloutPath,
+      `${JSON.stringify({
+        timestamp: '2026-05-13T00:00:02.000Z',
+        type: 'session_meta',
+        payload: {
+          id: threadId,
+          timestamp: '2026-05-13T00:00:02.000Z',
+          cwd: '/tmp/project',
+          source: 'cli',
+          model: 'gpt-5.5',
+          reasoning_effort: 'high',
+          approval_mode: 'on-request',
+        },
+      })}\n`,
+    );
+    insertThread(dbPath, threadId, rolloutPath, {
+      updatedAt: 2_000,
+      title: 'Generated Codex title',
+    });
+    writeSessionIndex({
+      id: threadId,
+      thread_name: 'Authoritative index title',
+      updated_at: '2026-05-13T00:00:03.000Z',
+    });
+
+    const scan = await scanExternalCodexSessions();
+
+    expect(scan.candidates).toHaveLength(1);
+    expect(scan.candidates[0]).toMatchObject({
+      id: threadId,
+      title: 'Authoritative index title',
+    });
   });
 
   it('restores a soft-deleted imported Codex session without creating a duplicate', async () => {

--- a/apps/desktop/src/main/__tests__/codexLocalSessions.test.ts
+++ b/apps/desktop/src/main/__tests__/codexLocalSessions.test.ts
@@ -1002,6 +1002,49 @@ describe('Codex local session import', () => {
     expect(ids).toContain(`019dcd5a-6e54-7960-95e0-${String(1000).padStart(12, '0')}`);
   }, 15_000);
 
+  it('applies the session index time before capping rollout-only threads', async () => {
+    const sessionsDir = path.join(externalHome, 'sessions');
+    fs.mkdirSync(sessionsDir, { recursive: true });
+    const oldestId = `019dcd5a-6e54-7960-95e1-${'0'.padStart(12, '0')}`;
+    for (let i = 0; i < 1001; i += 1) {
+      const id = `019dcd5a-6e54-7960-95e1-${String(i).padStart(12, '0')}`;
+      const file = path.join(sessionsDir, `rollout-2026-05-13-${id}.jsonl`);
+      const timestamp = new Date(10_000 + i).toISOString();
+      fs.writeFileSync(
+        file,
+        `${JSON.stringify({
+          timestamp,
+          type: 'session_meta',
+          payload: {
+            id,
+            timestamp,
+            cwd: '/tmp/project',
+            source: 'cli',
+            model: 'gpt-5.5',
+            reasoning_effort: 'high',
+            approval_mode: 'on-request',
+          },
+        })}\n`,
+      );
+      fs.utimesSync(file, new Date(10_000 + i), new Date(10_000 + i));
+    }
+    writeSessionIndex({
+      id: oldestId,
+      thread_name: '   ',
+      updated_at: '2026-05-13T00:00:05.000Z',
+    });
+
+    const scan = await scanExternalCodexSessions();
+
+    expect(scan.candidates).toHaveLength(1000);
+    const ids = scan.candidates.map((candidate) => candidate.id);
+    expect(ids).toContain(oldestId);
+    expect(ids).not.toContain(`019dcd5a-6e54-7960-95e1-${String(1).padStart(12, '0')}`);
+    expect(
+      scan.candidates.find((candidate) => candidate.id === oldestId)?.updatedAt,
+    ).toBe(Date.parse('2026-05-13T00:00:05.000Z'));
+  }, 20_000);
+
   it('does not implicitly remove imported Codex rows during read-only scan', async () => {
     const dbPath = createStateDb(externalHome);
     const rolloutPath = path.join(externalHome, 'sessions', `rollout-2026-05-13-${threadId}.jsonl`);

--- a/apps/desktop/src/main/__tests__/codexLocalSessions.test.ts
+++ b/apps/desktop/src/main/__tests__/codexLocalSessions.test.ts
@@ -972,8 +972,8 @@ describe('Codex local session import', () => {
   });
 
   it('caps to newest MAX_THREADS_PER_HOME top-level threads when more than 1000 exist', async () => {
-    // 写 1001 个有效 thread（updatedAt 递增），cap=1000 时应该保留 updatedAt 最新的 1000 个。
-    // 被剔除的应该是 updatedAt 最小那个（id=...000000000000）。
+    // 写 1001 个有效 thread（updatedAt 递增），再用 index 把最旧一条提升为最新。
+    // cap=1000 时应该先合并 index 时间，再剔除新的最旧一条。
     const dbPath = createStateDb(externalHome);
     const rolloutPath = path.join(externalHome, 'sessions', `rollout-2026-05-13-${threadId}.jsonl`);
     fs.mkdirSync(path.dirname(rolloutPath), { recursive: true });
@@ -983,12 +983,21 @@ describe('Codex local session import', () => {
       const id = `019dcd5a-6e54-7960-95e0-${String(i).padStart(12, '0')}`;
       insertThread(dbPath, id, rolloutPath, { updatedAt: 10_000 + i });
     }
+    writeSessionIndex({
+      id: oldestId,
+      thread_name: '   ',
+      updated_at: '2026-05-13T00:00:05.000Z',
+    });
 
     const scan = await scanExternalCodexSessions();
 
     expect(scan.candidates).toHaveLength(1000);
     const ids = scan.candidates.map((c) => c.id);
-    expect(ids).not.toContain(oldestId);
+    expect(ids).toContain(oldestId);
+    expect(ids).not.toContain(`019dcd5a-6e54-7960-95e0-${String(1).padStart(12, '0')}`);
+    expect(
+      scan.candidates.find((candidate) => candidate.id === oldestId)?.updatedAt,
+    ).toBe(Date.parse('2026-05-13T00:00:05.000Z'));
     // 抽样：最新一条（updatedAt=11000）应当在结果里
     expect(ids).toContain(`019dcd5a-6e54-7960-95e0-${String(1000).padStart(12, '0')}`);
   }, 15_000);

--- a/apps/desktop/src/main/maker-host/codex-local-sessions.ts
+++ b/apps/desktop/src/main/maker-host/codex-local-sessions.ts
@@ -3787,19 +3787,30 @@ function readThreads(
       FROM threads
       ${orderSql}
     `).all() as SqlRow[];
+    const indexedRows = rows.map((row, originalIndex) => {
+      const threadId = stringValue(row.id);
+      return {
+        row: mergeThreadRowWithSessionIndex(row, index.get(threadId)),
+        originalIndex,
+      };
+    });
+    indexedRows.sort((left, right) => {
+      const byUpdatedAt =
+        threadRowOrderTimestamp(right.row) - threadRowOrderTimestamp(left.row);
+      return byUpdatedAt || left.originalIndex - right.originalIndex;
+    });
     const threads: CodexThreadSummary[] = [];
     const rejectedThreadIds = new Set<string>();
-    for (const row of rows) {
+    for (const { row } of indexedRows) {
       if (!isTopLevelThreadRow(row)) {
         addRejectedThreadId(row, rejectedThreadIds);
         continue;
       }
       if (threads.length >= MAX_THREADS_PER_HOME) continue;
-      const threadId = stringValue(row.id);
       const thread = normalizeThreadRow(
         home,
         dbPath,
-        mergeThreadRowWithSessionIndex(row, index.get(threadId)),
+        row,
         projectlessThreadIds,
       );
       if (thread) threads.push(thread);
@@ -3895,6 +3906,12 @@ function mergeThreadRowWithSessionIndex(
       ? { updated_at_ms: indexUpdatedAt }
       : {}),
   };
+}
+
+function threadRowOrderTimestamp(row: SqlRow): number {
+  return timestampMs(row.updated_at_ms, row.updated_at)
+    ?? timestampMs(row.created_at_ms, row.created_at)
+    ?? 0;
 }
 
 function readProjectlessThreadIds(home: string): Set<string> {

--- a/apps/desktop/src/main/maker-host/codex-local-sessions.ts
+++ b/apps/desktop/src/main/maker-host/codex-local-sessions.ts
@@ -3778,6 +3778,7 @@ function readThreads(
 ): CodexThreadReadResult | null {
   let db: Database.Database | null = null;
   try {
+    const index = readSessionIndex(home);
     db = openReadonlyDb(dbPath);
     if (!tableExists(db, 'threads')) return null;
     const orderSql = buildThreadOrderSql(db);
@@ -3794,7 +3795,13 @@ function readThreads(
         continue;
       }
       if (threads.length >= MAX_THREADS_PER_HOME) continue;
-      const thread = normalizeThreadRow(home, dbPath, row, projectlessThreadIds);
+      const threadId = stringValue(row.id);
+      const thread = normalizeThreadRow(
+        home,
+        dbPath,
+        mergeThreadRowWithSessionIndex(row, index.get(threadId)),
+        projectlessThreadIds,
+      );
       if (thread) threads.push(thread);
     }
     return { threads, rejectedThreadIds: [...rejectedThreadIds] };
@@ -3858,7 +3865,7 @@ function readSessionIndex(home: string): Map<string, CodexSessionIndexEntry> {
       const id = stringValue(obj.id);
       if (!isLikelyThreadId(id)) continue;
       out.set(id, {
-        title: firstNonEmpty(stringValue(obj.thread_name), stringValue(obj.title), 'Codex Session'),
+        title: stringValue(obj.thread_name).trim() || stringValue(obj.title).trim(),
         updatedAt: timestampFromAny(obj.updated_at),
       });
     }
@@ -3869,6 +3876,25 @@ function readSessionIndex(home: string): Map<string, CodexSessionIndexEntry> {
     });
   }
   return out;
+}
+
+/** Overlay the user-owned Codex index metadata without discarding DB/rollout state. */
+function mergeThreadRowWithSessionIndex(
+  row: SqlRow,
+  entry: CodexSessionIndexEntry | undefined,
+): SqlRow {
+  const title = entry?.title.trim() ?? '';
+  if (!title) return row;
+
+  const rowUpdatedAt = timestampMs(row.updated_at_ms, row.updated_at);
+  const indexUpdatedAt = entry?.updatedAt ?? null;
+  return {
+    ...row,
+    title,
+    ...(indexUpdatedAt && (!rowUpdatedAt || indexUpdatedAt > rowUpdatedAt)
+      ? { updated_at_ms: indexUpdatedAt }
+      : {}),
+  };
 }
 
 function readProjectlessThreadIds(home: string): Set<string> {
@@ -4022,21 +4048,24 @@ function rolloutThreadRowFromFirstLine(
   const payload = obj.payload;
   const threadId = stringValue(payload.id) || threadIdFromRolloutPath(file);
   if (!isLikelyThreadId(threadId)) return null;
-  return {
-    id: threadId,
-    rollout_path: file,
-    created_at: stringValue(payload.timestamp) || stringValue(obj.timestamp),
-    updated_at: index.get(threadId)?.updatedAt ?? fallbackMtime ?? safeStatMtime(file),
-    source: stringValue(payload.source),
-    originator: stringValue(payload.originator),
-    thread_source: stringValue(payload.thread_source),
-    cwd: stringValue(payload.cwd),
-    title: index.get(threadId)?.title ?? '',
-    model: stringValue(payload.model),
-    reasoning_effort: stringValue(payload.reasoning_effort),
-    approval_mode: stringValue(payload.approval_mode),
-    archived: isArchivedRolloutPath(file) ? 1 : 0,
-  };
+  return mergeThreadRowWithSessionIndex(
+    {
+      id: threadId,
+      rollout_path: file,
+      created_at: stringValue(payload.timestamp) || stringValue(obj.timestamp),
+      updated_at: fallbackMtime ?? safeStatMtime(file),
+      source: stringValue(payload.source),
+      originator: stringValue(payload.originator),
+      thread_source: stringValue(payload.thread_source),
+      cwd: stringValue(payload.cwd),
+      title: '',
+      model: stringValue(payload.model),
+      reasoning_effort: stringValue(payload.reasoning_effort),
+      approval_mode: stringValue(payload.approval_mode),
+      archived: isArchivedRolloutPath(file) ? 1 : 0,
+    },
+    index.get(threadId),
+  );
 }
 
 function readFirstLineSync(file: string): string | null {
@@ -4627,23 +4656,38 @@ function assertExternalEmptyObservationsUnchanged(
 function findThreadByIdInHome(home: string, threadId: string): CodexThreadSummary | null {
   const dbPath = findLatestStateDb(home);
   const projectlessThreadIds = readProjectlessThreadIds(home);
-  if (!dbPath) return findExternalThreadByIdFromRollouts(home, threadId);
+  const index = readSessionIndex(home);
+  if (!dbPath) return findExternalThreadByIdFromRollouts(home, threadId, index);
   let db: Database.Database | null = null;
   try {
     db = openReadonlyDb(dbPath);
-    if (!tableExists(db, 'threads')) return findExternalThreadByIdFromRollouts(home, threadId);
+    if (!tableExists(db, 'threads')) {
+      return findExternalThreadByIdFromRollouts(home, threadId, index);
+    }
     const row = db.prepare('SELECT * FROM threads WHERE id = ? LIMIT 1').get(threadId) as SqlRow | undefined;
-    if (!row || !isTopLevelThreadRow(row)) return findExternalThreadByIdFromRollouts(home, threadId);
-    return normalizeThreadRow(home, dbPath, row, projectlessThreadIds) ?? findExternalThreadByIdFromRollouts(home, threadId);
+    if (!row || !isTopLevelThreadRow(row)) {
+      return findExternalThreadByIdFromRollouts(home, threadId, index);
+    }
+    return (
+      normalizeThreadRow(
+        home,
+        dbPath,
+        mergeThreadRowWithSessionIndex(row, index.get(threadId)),
+        projectlessThreadIds,
+      ) ?? findExternalThreadByIdFromRollouts(home, threadId, index)
+    );
   } catch {
-    return findExternalThreadByIdFromRollouts(home, threadId);
+    return findExternalThreadByIdFromRollouts(home, threadId, index);
   } finally {
     closeDbQuietly(db);
   }
 }
 
-function findExternalThreadByIdFromRollouts(home: string, threadId: string): CodexThreadSummary | null {
-  const index = readSessionIndex(home);
+function findExternalThreadByIdFromRollouts(
+  home: string,
+  threadId: string,
+  index: Map<string, CodexSessionIndexEntry> = readSessionIndex(home),
+): CodexThreadSummary | null {
   const projectlessThreadIds = readProjectlessThreadIds(home);
   const file = collectRolloutFiles(home).find((candidate) => threadIdFromRolloutPath(candidate) === threadId);
   if (!file) return null;

--- a/apps/desktop/src/main/maker-host/codex-local-sessions.ts
+++ b/apps/desktop/src/main/maker-host/codex-local-sessions.ts
@@ -3883,9 +3883,11 @@ function mergeThreadRowWithSessionIndex(
   row: SqlRow,
   entry: CodexSessionIndexEntry | undefined,
 ): SqlRow {
-  const title = entry?.title.trim() ?? '';
+  if (!entry) return row;
+
+  const title = entry.title.trim();
   const rowUpdatedAt = timestampMs(row.updated_at_ms, row.updated_at);
-  const indexUpdatedAt = entry?.updatedAt ?? null;
+  const indexUpdatedAt = entry.updatedAt;
   return {
     ...row,
     ...(title ? { title } : {}),

--- a/apps/desktop/src/main/maker-host/codex-local-sessions.ts
+++ b/apps/desktop/src/main/maker-host/codex-local-sessions.ts
@@ -3838,9 +3838,9 @@ async function readThreadsFromRollouts(
 ): Promise<CodexThreadReadResult> {
   const index = readSessionIndex(home);
   const files = await collectRolloutFilesAsync(home);
-  const out: CodexThreadSummary[] = [];
+  const indexedRows: Array<{ row: SqlRow; originalIndex: number }> = [];
   const rejectedThreadIds = new Set<string>();
-  for (const { file, mtime } of files) {
+  for (const [originalIndex, { file, mtime }] of files.entries()) {
     const fileThreadId = threadIdFromRolloutPath(file);
     const knownDbArchived = fileThreadId ? knownDbArchivedByThreadId?.get(fileThreadId) : undefined;
     if (knownDbArchived === true || (knownDbArchived === false && !isArchivedRolloutPath(file))) continue;
@@ -3851,7 +3851,17 @@ async function readThreadsFromRollouts(
       addRejectedThreadId(row, rejectedThreadIds);
       continue;
     }
-    if (out.length >= MAX_THREADS_PER_HOME) continue;
+    indexedRows.push({ row, originalIndex });
+  }
+  indexedRows.sort((left, right) => {
+    const byUpdatedAt =
+      threadRowOrderTimestamp(right.row) - threadRowOrderTimestamp(left.row);
+    return byUpdatedAt || left.originalIndex - right.originalIndex;
+  });
+
+  const out: CodexThreadSummary[] = [];
+  for (const { row } of indexedRows) {
+    if (out.length >= MAX_THREADS_PER_HOME) break;
     const thread = normalizeThreadRow(home, null, row, projectlessThreadIds);
     if (thread) out.push(thread);
   }

--- a/apps/desktop/src/main/maker-host/codex-local-sessions.ts
+++ b/apps/desktop/src/main/maker-host/codex-local-sessions.ts
@@ -3884,13 +3884,11 @@ function mergeThreadRowWithSessionIndex(
   entry: CodexSessionIndexEntry | undefined,
 ): SqlRow {
   const title = entry?.title.trim() ?? '';
-  if (!title) return row;
-
   const rowUpdatedAt = timestampMs(row.updated_at_ms, row.updated_at);
   const indexUpdatedAt = entry?.updatedAt ?? null;
   return {
     ...row,
-    title,
+    ...(title ? { title } : {}),
     ...(indexUpdatedAt && (!rowUpdatedAt || indexUpdatedAt > rowUpdatedAt)
       ? { updated_at_ms: indexUpdatedAt }
       : {}),


### PR DESCRIPTION
## 这次改了什么

### 摘要

Cindy 现在会在扫描和按 ID 导入本地 Codex session 时读取 `session_index.jsonl`，保留用户在 Codex 中重命名后的标题，并合并索引里的最新更新时间。这样重新导入同一 session 时，Cindy 列表不会退回旧标题或默认标题。

### 变更类型

- [ ] `feat` 新功能
- [x] `fix` 缺陷修复
- [ ] `refactor` / `perf` 重构或性能优化
- [ ] `docs` / `test` / `chore` 文档、测试或工程维护
- [ ] 其他：

### 范围

- 关联 Issue / 需求：Closes #3482
- 本 PR 包含：统一扫描与按 ID 导入的索引合并逻辑；标题优先级为 `thread_name` > `title` > DB/rollout 回退值；空标题仍合并较新的 `updated_at`；DB 与 rollout-only 路径都在 1000 条上限截断前按合并后的有效时间稳定重排；补充重命名、重导入、空白/损坏/未匹配索引、DB-rollout 去重和超量截断测试。
- 明确不包含：UI、数据库 schema、migration、协议或配置变更。
- 用户可见变化：导入或重新导入已重命名的 Codex session 后，Cindy 显示该自定义标题，并按最新索引时间排序。
- 是否存在 breaking change：无。

### UI 变化

不涉及：改动仅位于 Desktop main 进程的本地 session 导入映射与测试，不修改界面、交互或文案。

- 引用的设计规范：不涉及。

## 怎么验证的

### 自动验证

```text
pnpm test:unit:related
结果：通过（apps/desktop unit，65.7s）。

pnpm --filter desktop exec vitest run src/main/__tests__/codexLocalSessions.test.ts --pool=forks --maxWorkers=1 --minWorkers=1 -t "session index|malformed, unmatched|later Codex rename|same thread is read|caps to newest"
结果：通过，7 个针对 #3482 的回归场景通过（含 DB 与 rollout-only 超量截断）。

pnpm --filter desktop typecheck
结果：通过。

GitHub DCO App
结果：通过；GitHub Web suggestion commit 由后续 Signed-off-by remediation commit 补签。
```

### 手工验证

不涉及独立 UI 操作；扫描与按 ID 导入路径均由同一组文件系统 fixture 回归测试覆盖。

### 未执行的验证

无。

## 风险

### 风险分类

- [x] 无已知风险
- [ ] SQLite / migration
- [ ] system prompt
- [ ] 协议兼容
- [ ] 权限 / 安全 / 用户数据
- [ ] 存量插件兼容（批准状态 / 指纹 / manifest 校验 / 安装布局 / 包格式）
- [ ] 原生层 / fingerprint / OTA
- [ ] 跨平台差异
- [ ] 其他：

### 影响与回滚

- 影响范围：仅本地 Codex session 元数据的标题、更新时间与导入候选顺序；空白、损坏、缺失或不匹配的索引记录继续使用现有 DB/rollout 回退值。
- 回滚 / 降级方式：回退本 PR 提交即可恢复原导入行为，无数据迁移或清理步骤。

### 提交前检查

- [x] 已 review 完整 diff
- [x] 每个 commit 均由 DCO App 确认签名或 remediation（见 [DCO](../DCO)）
- [ ] UI 改动已在「UI 变化」注明引用的设计规范章节（不涉及 UI，跳过）
- [x] 未提交凭证、令牌或授权文件
- [x] 已补充必要文档（本次无需新增用户文档）
- [x] 已确认测试结果或说明未执行原因