### PR TITLE
perf(mobile): 优化长任务详情与首页长列表渲染性能

### DIFF
--- a/apps/mobile/app/devices/[deviceId].tsx
+++ b/apps/mobile/app/devices/[deviceId].tsx
@@ -1,4 +1,4 @@
-import { useLocalSearchParams, useRouter } from 'expo-router';
+import { useIsFocused, useLocalSearchParams, useRouter } from 'expo-router';
 import { useCallback, useEffect, useMemo, useState } from 'react';
 import {
   ActivityIndicator,
@@ -81,6 +81,7 @@ import type { SessionSwipeAction } from '@/session/swipeRowRegistry';
 import { useSessionListActions } from '@/session/useSessionListActions';
 import { useMobileMakerTransport } from '@/device-link/useMobileMakerTransport';
 import {
+  RemoteSessionStoreSubscriptionGate,
   remoteSessionStore,
   useRemoteMessageVersion,
   useRemoteSessions,
@@ -115,6 +116,15 @@ const STATUS_FILTERS: Array<{ value: RemoteSessionStatusFilter; labelKey: string
 type RemoteListStatusFilter = Extract<RemoteSessionStatusFilter, 'active' | 'archived' | 'all'>;
 
 export default function DeviceDetailScreen() {
+  const screenFocused = useIsFocused();
+  return (
+    <RemoteSessionStoreSubscriptionGate enabled={screenFocused}>
+      <DeviceDetailScreenContent />
+    </RemoteSessionStoreSubscriptionGate>
+  );
+}
+
+function DeviceDetailScreenContent() {
   const styles = useThemedStyles(makeStyles);
   const { colors } = useTheme();
   const { t, i18n: i18nInstance } = useTranslation();
@@ -790,6 +800,9 @@ export default function DeviceDetailScreen() {
         <SectionList
           sections={displaySections}
           keyExtractor={(item) => item.automationGroup?.key ?? item.session.id}
+          // Fabric can reattach a clipped Swipeable child before its old native parent removes it.
+          // Keep JS virtualization, but avoid the Android native detach/reattach race for this list.
+          removeClippedSubviews={false}
           refreshControl={<RefreshControl refreshing={loading} onRefresh={loadSessions} />}
           stickySectionHeadersEnabled={false}
           renderSectionHeader={() => null}

--- a/apps/mobile/app/devices/index.tsx
+++ b/apps/mobile/app/devices/index.tsx
@@ -135,6 +135,11 @@ import {
   type HomeStatusFilter,
 } from '@/session/homeListPriority';
 import {
+  buildHomeProjectChildOffsets,
+  findHomeProjectChildIndex,
+  resolveHomeProjectChildWindow,
+} from '@/session/homeProjectChildWindow';
+import {
   projectDropIndexFromY,
   reorderVisibleProjectByDropIndex,
   resolveVirtualizedDropIndex,
@@ -231,6 +236,8 @@ const PROJECT_CHILD_WINDOW_THRESHOLD = 20;
 const PROJECT_CHILD_WINDOW_SIZE = 15;
 const PROJECT_CHILD_WINDOW_OVERSCAN = 4;
 const PROJECT_CHILD_WINDOW_SHIFT = 4;
+const HOME_PROJECT_HEADER_HEIGHT = 56;
+const HOME_AUTOMATION_VIEW_ALL_ROW_HEIGHT = 54;
 const HOME_SESSION_ROW_HEIGHT = 78;
 const HOME_SESSION_SINGLE_LINE_ROW_HEIGHT = 60;
 const CINDY_LIST_GUTTER = 20;
@@ -248,6 +255,26 @@ function estimateHomeSessionRowHeight(item: RemoteSessionListItem): number {
     || !!item.scheduleInfo
     || !!item.session.pinnedAt;
   return hasPreview ? HOME_SESSION_ROW_HEIGHT : HOME_SESSION_SINGLE_LINE_ROW_HEIGHT;
+}
+
+function estimateHomeProjectChildHeight(
+  item: RemoteSessionListItem,
+  expandedAutomationGroups: ReadonlySet<string>,
+): number {
+  const rowHeight = estimateHomeSessionRowHeight(item);
+  const group = item.automationGroup;
+  if (!group || !expandedAutomationGroups.has(group.key)) return rowHeight;
+  const { visibleItems, hiddenCount } = getRemoteSessionPreviewCollapse(group.items, {
+    limit: PROJECT_PREVIEW_LIMIT,
+    isSessionRunning: (sessionId) => remoteSessionStore.isSessionRunning(sessionId),
+  });
+  const childrenHeight = visibleItems.reduce(
+    (height, child) => height + estimateHomeSessionRowHeight(child),
+    0,
+  );
+  return rowHeight
+    + childrenHeight
+    + (hiddenCount > 0 ? HOME_AUTOMATION_VIEW_ALL_ROW_HEIGHT : 0);
 }
 
 type RemoteListStatusFilter = Extract<RemoteSessionStatusFilter, 'active' | 'archived' | 'all'>;
@@ -3347,53 +3374,58 @@ function ProjectRow({
     },
   );
   const projectTop = useSharedValue(0);
+  const projectHeaderHeight = useSharedValue(HOME_PROJECT_HEADER_HEIGHT);
   const projectRef = useRef<View>(null);
   const [windowAnchor, setWindowAnchor] = useState(0);
   const [projectLayoutReady, setProjectLayoutReady] = useState(false);
-  const estimatedChildHeights = useMemo(
-    () => visibleSessions.map(estimateHomeSessionRowHeight),
-    [visibleSessions, storeVersion],
+  const estimatedChildHeights = useMemo(() => {
+    const expandedKeys = new Set(expandedAutomationGroups);
+    return visibleSessions.map((item) => estimateHomeProjectChildHeight(item, expandedKeys));
+  }, [expandedAutomationGroups, visibleSessions, storeVersion]);
+  const estimatedChildOffsets = useMemo(
+    () => buildHomeProjectChildOffsets(estimatedChildHeights),
+    [estimatedChildHeights],
   );
-  // Windowing is only enabled for genuinely large, uniform child trees. The
-  // common project preview (five rows) remains byte-for-byte unchanged, while
-  // a large expanded group avoids mounting all rows at once without relying on
-  // a nested virtualized list.
+  // Keep the common five-row preview unchanged. Large expanded groups use
+  // prefix-sum windowing for both 60/78px rows and expanded automation groups,
+  // so mixed content never falls back to mounting the whole project.
   const windowingEligible = !!homeScrollY
     && !collapsed
     && projectLayoutReady
-    && visibleSessions.length > PROJECT_CHILD_WINDOW_THRESHOLD
-    && estimatedChildHeights.every((height) => height === estimatedChildHeights[0]);
+    && visibleSessions.length > PROJECT_CHILD_WINDOW_THRESHOLD;
   const scrollY = homeScrollY;
-  const estimatedRowHeight = estimatedChildHeights[0] ?? HOME_SESSION_ROW_HEIGHT;
   useAnimatedReaction(
     () => {
       if (!windowingEligible) return -1;
-      const relativeY = Math.max(0, scrollY!.value - projectTop.value - HOME_SESSION_ROW_HEIGHT);
-      return Math.floor(relativeY / Math.max(1, estimatedRowHeight) / PROJECT_CHILD_WINDOW_SHIFT)
+      const relativeY = Math.max(0, scrollY!.value - projectTop.value - projectHeaderHeight.value);
+      const visibleIndex = findHomeProjectChildIndex(estimatedChildOffsets, relativeY);
+      return Math.floor(visibleIndex / PROJECT_CHILD_WINDOW_SHIFT)
         * PROJECT_CHILD_WINDOW_SHIFT;
     },
     (next, previous) => {
       if (next < 0 || next === previous) return;
       runOnJS(setWindowAnchor)(next);
     },
-    [scrollY, windowingEligible, estimatedRowHeight],
+    [estimatedChildOffsets, projectHeaderHeight, scrollY, windowingEligible],
   );
-  const windowStart = windowingEligible
-    ? Math.max(0, Math.min(
-      Math.max(0, visibleSessions.length - PROJECT_CHILD_WINDOW_SIZE),
-      windowAnchor - PROJECT_CHILD_WINDOW_OVERSCAN,
-    ))
-    : 0;
-  const windowEnd = windowingEligible
-    ? Math.min(visibleSessions.length, windowStart + PROJECT_CHILD_WINDOW_SIZE + PROJECT_CHILD_WINDOW_OVERSCAN * 2)
-    : visibleSessions.length;
+  const childWindow = windowingEligible
+    ? resolveHomeProjectChildWindow({
+        anchor: windowAnchor,
+        childOffsets: estimatedChildOffsets,
+        overscan: PROJECT_CHILD_WINDOW_OVERSCAN,
+        windowSize: PROJECT_CHILD_WINDOW_SIZE,
+      })
+    : {
+        end: visibleSessions.length,
+        leadingSpacerHeight: 0,
+        start: 0,
+        trailingSpacerHeight: 0,
+      };
+  const windowStart = childWindow.start;
+  const windowEnd = childWindow.end;
   const renderedSessions = windowingEligible ? visibleSessions.slice(windowStart, windowEnd) : visibleSessions;
-  const leadingSpacerHeight = windowingEligible
-    ? estimatedChildHeights.slice(0, windowStart).reduce((sum, height) => sum + height, 0)
-    : 0;
-  const trailingSpacerHeight = windowingEligible
-    ? estimatedChildHeights.slice(windowEnd).reduce((sum, height) => sum + height, 0)
-    : 0;
+  const leadingSpacerHeight = childWindow.leadingSpacerHeight;
+  const trailingSpacerHeight = childWindow.trailingSpacerHeight;
   const groupTestID = kind === 'dialogue' ? 'home.dialogueGroup' : 'home.projectGroup';
   const rowTestID = kind === 'dialogue' ? 'home.dialogueRow' : 'home.projectRow';
   const childTestID = kind === 'dialogue' ? 'home.chatRow' : 'home.projectSessionRow';
@@ -3428,6 +3460,10 @@ function ProjectRow({
         : t('devices.list.a11y.project', { title: project.title })}
       accessibilityRole="button"
       accessibilityState={{ expanded: !collapsed }}
+      onLayout={(event) => {
+        const height = event.nativeEvent.layout.height;
+        if (Number.isFinite(height) && height > 0) projectHeaderHeight.value = height;
+      }}
       onPress={dragging ? undefined : onToggle}
       ref={(node) => {
         if (!headerRefs || kind !== 'project') return;

--- a/apps/mobile/app/devices/index.tsx
+++ b/apps/mobile/app/devices/index.tsx
@@ -43,7 +43,7 @@ import {
   X,
 } from 'lucide-react-native';
 import { Gesture, GestureDetector } from '@/platform/gestureHandler';
-import Reanimated, { runOnJS, useAnimatedStyle, useSharedValue, type SharedValue } from 'react-native-reanimated';
+import Reanimated, { runOnJS, useAnimatedReaction, useAnimatedStyle, useSharedValue, type SharedValue } from 'react-native-reanimated';
 import { useSafeAreaInsets } from 'react-native-safe-area-context';
 import { useTranslation } from 'react-i18next';
 import type { TFunction } from 'i18next';
@@ -221,8 +221,16 @@ import { fontWeight, iconSize, iconStroke, lineHeight, radius, spacing, typeScal
 const LIST_LIMIT = 200;
 const DEVICE_LIST_TIMEOUT_MS = 12_000;
 const HOME_LIST_SUBSCRIPTION_OWNER = 'device-list';
+// Keep the device-link channel responsive while All Sessions hydrates several
+// computers. This does not change the 200-row server limit; it only bounds the
+// number of device snapshots processed at once.
+const HOME_DEVICE_HYDRATE_CONCURRENCY = 2;
 // 项目组与自动化组展开后的子列表共用同一个预览限量(设备详情页也 import 复用,避免两处漂移)。
 export const PROJECT_PREVIEW_LIMIT = 5;
+const PROJECT_CHILD_WINDOW_THRESHOLD = 20;
+const PROJECT_CHILD_WINDOW_SIZE = 15;
+const PROJECT_CHILD_WINDOW_OVERSCAN = 4;
+const PROJECT_CHILD_WINDOW_SHIFT = 4;
 const HOME_SESSION_ROW_HEIGHT = 78;
 const HOME_SESSION_SINGLE_LINE_ROW_HEIGHT = 60;
 const CINDY_LIST_GUTTER = 20;
@@ -230,6 +238,17 @@ const CINDY_LIST_FAB_SIZE = 55;
 const CINDY_LIST_FAB_BOTTOM = 45;
 const HOME_HEADER_MIN_HEIGHT = 48;
 const AnimatedPressable = Animated.createAnimatedComponent(Pressable);
+
+function estimateHomeSessionRowHeight(item: RemoteSessionListItem): number {
+  const running = remoteSessionStore.isSessionRunning(item.session.id)
+    || item.scheduleInfo?.running === true
+    || item.liveActivity?.phase === 'running';
+  const hasPreview = item.automationGroup != null
+    || !!buildRemoteSessionCardPreview(item, { running })?.trim()
+    || !!item.scheduleInfo
+    || !!item.session.pinnedAt;
+  return hasPreview ? HOME_SESSION_ROW_HEIGHT : HOME_SESSION_SINGLE_LINE_ROW_HEIGHT;
+}
 
 type RemoteListStatusFilter = Extract<RemoteSessionStatusFilter, 'active' | 'archived' | 'all'>;
 type HomeDeviceConnectionState = 'idle' | 'syncing' | 'failed';
@@ -304,6 +323,9 @@ export default function HomeScreen() {
   const syncInFlightRef = useRef<Promise<void> | null>(null);
   const syncQueuedRef = useRef<{ visible?: boolean } | null>(null);
   const loadHomeRef = useRef<(options?: { visible?: boolean }) => Promise<void>>(async () => undefined);
+  const homePreviewCacheRef = useRef(new Map<string, { messages: readonly unknown[]; preview?: string }>());
+  const homePendingCacheRef = useRef(new Map<string, { pending: readonly unknown[]; count: number }>());
+  const homeLiveActivityIndexRef = useRef(new Map<string, RemoteSessionLiveActivity>());
   const devicesRef = useRef<DeviceView[]>([]);
   // HomeScreen stays mounted while switching saved accounts. Keep an owner generation beside every
   // local projection so requests started by the previous account cannot repopulate the new screen.
@@ -413,6 +435,7 @@ export default function HomeScreen() {
   const projectDragEpochRef = useRef(0);
   const [projectDrag, setProjectDrag] = useState<ProjectDragSession | null>(null);
   const projectDragY = useSharedValue(0);
+  const homeScrollY = useSharedValue(0);
   const [dialogueShowAll, setDialogueShowAll] = useState(false);
   const [priorityHoldEpoch, setPriorityHoldEpoch] = useState(0);
   // deviceId of the revoked-access device whose explanation tip is open (null = closed).
@@ -691,18 +714,20 @@ export default function HomeScreen() {
         };
       }
       const nextSessions = Array.isArray(list) ? list : [];
-      remoteSessionStore.setDeviceSessions(
-        device.deviceId,
-        device.name,
-        nextSessions,
-      );
-      if (Array.isArray(activeSessions)) {
-        remoteSessionStore.setActiveSessionSnapshots(
+      remoteSessionStore.batch(() => {
+        remoteSessionStore.setDeviceSessions(
           device.deviceId,
-          activeSessions,
-          activeSessionSnapshotEpoch,
+          device.name,
+          nextSessions,
         );
-      }
+        if (Array.isArray(activeSessions)) {
+          remoteSessionStore.setActiveSessionSnapshots(
+            device.deviceId,
+            activeSessions,
+            activeSessionSnapshotEpoch,
+          );
+        }
+      });
       // schedule-index(1+N 个 listRuns)是次要徽标数据,延后发,避开"开 app→立刻点会话"时和会话关键读
       // 抢同一条 WS 管道(见 scheduleIndexDefer / issue #324)。home 自动化分组与名称已由 fallbackScheduleInfo
       // 兜底,徽标晚半拍出现即可。
@@ -920,7 +945,7 @@ export default function HomeScreen() {
       const hydrateResults = await runHomeDeviceSyncBatch(syncRows, async (item) => {
         const result = await hydrateDeviceSessions(item.device, accountGenerationAtStart);
         return { deviceId: item.device.deviceId, result };
-      });
+      }, HOME_DEVICE_HYDRATE_CONCURRENCY);
       for (const { deviceId, result } of hydrateResults) {
         if (result.superseded || homeAccountGenerationRef.current !== accountGenerationAtStart) continue;
         if (result.failure) failures.push(result.failure);
@@ -1338,9 +1363,10 @@ export default function HomeScreen() {
   }, []);
 
   const onListScroll = useCallback((event: NativeSyntheticEvent<NativeScrollEvent>) => {
+    homeScrollY.value = event.nativeEvent.contentOffset.y;
     const next = event.nativeEvent.contentOffset.y > 8;
     setHeaderFrosted((current) => (current === next ? current : next));
-  }, []);
+  }, [homeScrollY]);
 
   const closeRenameDevice = useCallback(() => {
     if (renameSaving) return;
@@ -1586,27 +1612,63 @@ export default function HomeScreen() {
   // 重建出内容相同的新 Map——若不做内容稳定化,home → sections → 全列表行整链每次
   // emit 都重建(2026-07-18 重渲染风暴 trace 实锤)。useStableValue 在内容未变时保留
   // 旧引用,下游 useMemo 依赖即可短路;内容真变(某会话预览/交互数/活动态变化)照常穿透。
-  const messagePreviewIndexRaw = useMemo(
-    () => buildSessionMessagePreviewIndex(
-      sessions.map((session) => session.id),
-      (sessionId) => remoteSessionStore.getMessages(sessionId),
-    ),
-    [messageVersion, sessions],
-  );
+  const messagePreviewIndexRaw = useMemo(() => {
+    const next = new Map<string, string>();
+    const activeIds = new Set<string>();
+    for (const session of sessions) {
+      activeIds.add(session.id);
+      const messages = remoteSessionStore.getMessages(session.id);
+      const cached = homePreviewCacheRef.current.get(session.id);
+      if (cached?.messages === messages) {
+        if (cached.preview) next.set(session.id, cached.preview);
+        continue;
+      }
+      const preview = buildSessionMessagePreviewIndex([session.id], () => messages).get(session.id);
+      homePreviewCacheRef.current.set(session.id, { messages, preview });
+      if (preview) next.set(session.id, preview);
+    }
+    for (const sessionId of homePreviewCacheRef.current.keys()) {
+      if (!activeIds.has(sessionId)) homePreviewCacheRef.current.delete(sessionId);
+    }
+    return next;
+  }, [messageVersion, sessions]);
   const messagePreviewIndex = useStableValue(messagePreviewIndexRaw, mapContentEqual);
-  const pendingInteractionIndexRaw = useMemo(() => new Map(
-    sessions
-      .map((session) => [session.id, remoteSessionStore.getPendingInteractions(session.id).length] as const)
-      .filter(([, count]) => count > 0),
-  ), [sessions, storeVersion]);
+  const pendingInteractionIndexRaw = useMemo(() => {
+    const next = new Map<string, number>();
+    const activeIds = new Set<string>();
+    for (const session of sessions) {
+      activeIds.add(session.id);
+      const pending = remoteSessionStore.getPendingInteractions(session.id);
+      const cached = homePendingCacheRef.current.get(session.id);
+      const count = cached?.pending === pending ? cached.count : pending.length;
+      if (!cached || cached.pending !== pending) homePendingCacheRef.current.set(session.id, { pending, count });
+      if (count > 0) next.set(session.id, count);
+    }
+    for (const sessionId of homePendingCacheRef.current.keys()) {
+      if (!activeIds.has(sessionId)) homePendingCacheRef.current.delete(sessionId);
+    }
+    return next;
+  }, [sessions, storeVersion]);
   const pendingInteractionIndex = useStableValue(pendingInteractionIndexRaw, mapContentEqual);
   const liveActivityIndexRaw = useMemo(() => {
-    const entries: Array<[string, RemoteSessionLiveActivity]> = [];
+    const next = new Map<string, RemoteSessionLiveActivity>();
     for (const session of sessions) {
       const liveActivity = remoteSessionStore.getSessionLiveActivity(session.id);
-      if (liveActivity) entries.push([session.id, liveActivity]);
+      if (liveActivity) next.set(session.id, liveActivity);
     }
-    return new Map(entries);
+    const previous = homeLiveActivityIndexRef.current;
+    if (previous.size === next.size) {
+      let unchanged = true;
+      for (const [sessionId, value] of next) {
+        if (previous.get(sessionId) !== value) {
+          unchanged = false;
+          break;
+        }
+      }
+      if (unchanged) return previous;
+    }
+    homeLiveActivityIndexRef.current = next;
+    return next;
   }, [sessions, storeVersion]);
   const liveActivityIndex = useStableValue(liveActivityIndexRaw, mapContentEqual);
   // 列表隐藏 Orca worker 子会话(本期不支持进 worker 聊天);Lead + 普通会话保留。仅 mobile 侧过滤。
@@ -2200,6 +2262,7 @@ export default function HomeScreen() {
       onToggleProject={toggleProject}
       projectDragging={projectDrag?.key === (item.kind === 'project' ? item.project.key : '')}
       projectHeaderRefs={projectHeaderRefs}
+      homeScrollY={homeScrollY}
       onTogglePin={toggleSessionPinned}
       prevIsBlock={isBlockHomeRow(homeRowBefore(sections, section.key, index))}
       projectCollapsed={isFolderHomeRow(item) && collapsedProjectKeys.includes(item.project.key)}
@@ -2230,6 +2293,7 @@ export default function HomeScreen() {
     toggleAutomationGroup,
     toggleProject,
     toggleSessionPinned,
+    homeScrollY,
   ]);
 
   // 底部边到边:列表填满到物理屏底(内容滚到 home indicator 下方),用 inset 兜底而非靠 SafeAreaView 留白带。
@@ -3236,6 +3300,7 @@ function ProjectRow({
   onToggle,
   onToggleAutomationGroup,
   project,
+  homeScrollY,
   showAll = false,
   suppressTopBorder = false,
   swipe,
@@ -3254,6 +3319,7 @@ function ProjectRow({
   onToggle(): void;
   onToggleAutomationGroup(key: string): void;
   project: MobileHomeProjectGroup;
+  homeScrollY?: SharedValue<number>;
   /** 对话组「查看全部」在原地展开,不跳设备详情。 */
   showAll?: boolean;
   /** 前一行也是块(项目组 / 自动化组)时不画顶线:前块底线已是这根分割线。 */
@@ -3268,6 +3334,7 @@ function ProjectRow({
   // PureComponent bail)——以 storeVersion 订阅兜底感知运行态变化,与 AutomationGroup-
   // Children 同款(否则折叠线以下转入 running 的会话不会被豁免展开,review P1)。
   useRemoteSessionStoreVersion();
+  const storeVersion = remoteSessionStore.getStoreVersion();
   // 与桌面侧栏项目组同一套折叠策略:前 N 条之外豁免最近 24h 活动 / 需关注 / 运行中的条目
   // (豁免语义见共享层 getRemoteSessionPreviewCollapse 注释)。
   // 自动化折叠后 sessions 是"行"(组行代表多条会话):按钮显隐看隐藏行数(hiddenCount),
@@ -3279,6 +3346,54 @@ function ProjectRow({
       isSessionRunning: (sessionId) => remoteSessionStore.isSessionRunning(sessionId),
     },
   );
+  const projectTop = useSharedValue(0);
+  const projectRef = useRef<View>(null);
+  const [windowAnchor, setWindowAnchor] = useState(0);
+  const [projectLayoutReady, setProjectLayoutReady] = useState(false);
+  const estimatedChildHeights = useMemo(
+    () => visibleSessions.map(estimateHomeSessionRowHeight),
+    [visibleSessions, storeVersion],
+  );
+  // Windowing is only enabled for genuinely large, uniform child trees. The
+  // common project preview (five rows) remains byte-for-byte unchanged, while
+  // a large expanded group avoids mounting all rows at once without relying on
+  // a nested virtualized list.
+  const windowingEligible = !!homeScrollY
+    && !collapsed
+    && projectLayoutReady
+    && visibleSessions.length > PROJECT_CHILD_WINDOW_THRESHOLD
+    && estimatedChildHeights.every((height) => height === estimatedChildHeights[0]);
+  const scrollY = homeScrollY;
+  const estimatedRowHeight = estimatedChildHeights[0] ?? HOME_SESSION_ROW_HEIGHT;
+  useAnimatedReaction(
+    () => {
+      if (!windowingEligible) return -1;
+      const relativeY = Math.max(0, scrollY!.value - projectTop.value - HOME_SESSION_ROW_HEIGHT);
+      return Math.floor(relativeY / Math.max(1, estimatedRowHeight) / PROJECT_CHILD_WINDOW_SHIFT)
+        * PROJECT_CHILD_WINDOW_SHIFT;
+    },
+    (next, previous) => {
+      if (next < 0 || next === previous) return;
+      runOnJS(setWindowAnchor)(next);
+    },
+    [scrollY, windowingEligible, estimatedRowHeight],
+  );
+  const windowStart = windowingEligible
+    ? Math.max(0, Math.min(
+      Math.max(0, visibleSessions.length - PROJECT_CHILD_WINDOW_SIZE),
+      windowAnchor - PROJECT_CHILD_WINDOW_OVERSCAN,
+    ))
+    : 0;
+  const windowEnd = windowingEligible
+    ? Math.min(visibleSessions.length, windowStart + PROJECT_CHILD_WINDOW_SIZE + PROJECT_CHILD_WINDOW_OVERSCAN * 2)
+    : visibleSessions.length;
+  const renderedSessions = windowingEligible ? visibleSessions.slice(windowStart, windowEnd) : visibleSessions;
+  const leadingSpacerHeight = windowingEligible
+    ? estimatedChildHeights.slice(0, windowStart).reduce((sum, height) => sum + height, 0)
+    : 0;
+  const trailingSpacerHeight = windowingEligible
+    ? estimatedChildHeights.slice(windowEnd).reduce((sum, height) => sum + height, 0)
+    : 0;
   const groupTestID = kind === 'dialogue' ? 'home.dialogueGroup' : 'home.projectGroup';
   const rowTestID = kind === 'dialogue' ? 'home.dialogueRow' : 'home.projectRow';
   const childTestID = kind === 'dialogue' ? 'home.chatRow' : 'home.projectSessionRow';
@@ -3344,6 +3459,21 @@ function ProjectRow({
   );
   return (
     <View
+      onLayout={(event) => {
+        const fallbackY = event.nativeEvent.layout.y;
+        projectRef.current?.measureInWindow((_x, screenY) => {
+          projectTop.value = screenY + (homeScrollY?.value ?? 0);
+          setProjectLayoutReady(true);
+        });
+        // A native measure can be unavailable in shallow/unit renderers. Keep
+        // the local layout as a safe fallback; the real device measurement
+        // above is used whenever the row is mounted in a ScrollView.
+        if (!projectRef.current) {
+          projectTop.value = fallbackY;
+          setProjectLayoutReady(true);
+        }
+      }}
+      ref={projectRef}
       style={[styles.projectGroup, suppressTopBorder && styles.projectGroupNoTop]}
       testID={groupTestID}
     >
@@ -3351,7 +3481,22 @@ function ProjectRow({
 
       {collapsed ? null : (
         <View style={styles.projectChildren} testID="home.projectChildren">
-          {visibleSessions.map((item, index) => {
+          {leadingSpacerHeight > 0 ? <View pointerEvents="none" style={{ height: leadingSpacerHeight }} /> : null}
+          {renderedSessions.map((item, renderedIndex) => {
+            const index = windowStart + renderedIndex;
+            const itemKey = item.automationGroup?.key ?? item.session.id;
+            const swipeable = !!swipe
+              && !item.automationGroup
+              && conversationSearchAllowsLocalWrites(item);
+            // Window shifts used to key rows by session id, so crossing one
+            // four-row boundary destroyed and recreated four complete native
+            // swipe trees in the same frame. Keep a stable pool of render
+            // slots while windowing; the row receives new data without paying
+            // the native mount/unmount cost. Preserve identity keys outside the
+            // windowed path, and remount a slot when its outer shell changes.
+            const reactKey = windowingEligible
+              ? `${project.key}:window:${renderedIndex}:${swipeable ? 'swipe' : 'plain'}`
+              : itemKey;
             const row = (
               <HomeSessionRow
                 expandedAutomationGroups={expandedAutomationGroups}
@@ -3368,12 +3513,12 @@ function ProjectRow({
             );
             // 与顶层同一条规则:普通会话子行挂滑动,自动化组行不挂(组行语义含混,
             // 其展开子行由 AutomationGroupChildren 内的透传包裹)。
-            if (!swipe || item.automationGroup || !conversationSearchAllowsLocalWrites(item)) {
-              return <Fragment key={item.automationGroup?.key ?? item.session.id}>{row}</Fragment>;
+            if (!swipeable) {
+              return <Fragment key={reactKey}>{row}</Fragment>;
             }
             return (
               <SwipeableSessionRow
-                key={item.session.id}
+                key={reactKey}
                 onArchive={swipe.onArchive}
                 onShowOptions={swipe.onShowOptions}
                 onTogglePin={swipe.onTogglePin}
@@ -3385,6 +3530,7 @@ function ProjectRow({
               </SwipeableSessionRow>
             );
           })}
+          {trailingSpacerHeight > 0 ? <View pointerEvents="none" style={{ height: trailingSpacerHeight }} /> : null}
           {hiddenRowCount > 0 ? (
             <Pressable
               accessibilityLabel={t('devices.list.viewAllConversations', { count: project.sessionCount })}
@@ -3444,6 +3590,7 @@ function HomeListRowInner({
   projectCollapsed,
   projectDragging,
   projectHeaderRefs,
+  homeScrollY,
   registry,
   showAllDialogue,
   swipe,
@@ -3469,6 +3616,7 @@ function HomeListRowInner({
   projectCollapsed: boolean;
   projectDragging: boolean;
   projectHeaderRefs: MutableRefObject<Map<string, View>>;
+  homeScrollY?: SharedValue<number>;
   registry: ReturnType<typeof createSwipeRowRegistry>;
   showAllDialogue: boolean;
   swipe: SessionSwipeControls;
@@ -3490,6 +3638,7 @@ function HomeListRowInner({
         onToggle={() => onToggleProject(item.project.key)}
         onToggleAutomationGroup={onToggleAutomationGroup}
         project={item.project}
+        homeScrollY={homeScrollY}
         showAll={item.kind === 'dialogue' && showAllDialogue}
         suppressTopBorder={prevIsBlock}
         swipe={swipe}

--- a/apps/mobile/app/devices/index.tsx
+++ b/apps/mobile/app/devices/index.tsx
@@ -1,4 +1,4 @@
-import { useFocusEffect } from 'expo-router';
+import { useFocusEffect, useIsFocused } from 'expo-router';
 import { Fragment, memo, useCallback, useEffect, useLayoutEffect, useMemo, useRef, useState, type MutableRefObject, type ReactNode } from 'react';
 import {
   ActivityIndicator,
@@ -192,6 +192,7 @@ import {
   type RemoteSessionStatusFilter,
 } from '@/session/sessionList';
 import {
+  RemoteSessionStoreSubscriptionGate,
   remoteSessionStore,
   useRemoteMessageVersion,
   useRemoteSessions,
@@ -323,6 +324,15 @@ class HomeSyncScopeSupersededError extends Error {
 }
 
 export default function HomeScreen() {
+  const screenFocused = useIsFocused();
+  return (
+    <RemoteSessionStoreSubscriptionGate enabled={screenFocused}>
+      <HomeScreenContent />
+    </RemoteSessionStoreSubscriptionGate>
+  );
+}
+
+function HomeScreenContent() {
   const styles = useThemedStyles(makeStyles);
   const { colors } = useTheme();
   const { t, i18n: i18nInstance } = useTranslation();

--- a/apps/mobile/app/devices/index.tsx
+++ b/apps/mobile/app/devices/index.tsx
@@ -136,8 +136,9 @@ import {
 } from '@/session/homeListPriority';
 import {
   buildHomeProjectChildOffsets,
-  findHomeProjectChildIndex,
+  resolveHomeProjectChildAnchor,
   resolveHomeProjectChildWindow,
+  shouldWindowHomeProjectChildren,
 } from '@/session/homeProjectChildWindow';
 import {
   projectDropIndexFromY,
@@ -162,7 +163,14 @@ import {
   UNAVAILABLE_PROJECT_ORDER_SNAPSHOT,
   type SyncedProjectOrderSnapshot,
 } from '@cindy/maker-shared/project-order-sync';
-import { buildHomeSections, homeRowBefore, isFolderHomeRow, type HomeRow, type HomeSection } from '@/session/homeSections';
+import {
+  buildHomeSections,
+  homeRowsShareRenderData,
+  homeRowBefore,
+  isFolderHomeRow,
+  type HomeRow,
+  type HomeSection,
+} from '@/session/homeSections';
 import {
   readHomeViewPreferences,
   saveHomeViewPreferences,
@@ -237,6 +245,9 @@ const PROJECT_CHILD_WINDOW_THRESHOLD = 20;
 const PROJECT_CHILD_WINDOW_SIZE = 15;
 const PROJECT_CHILD_WINDOW_OVERSCAN = 4;
 const PROJECT_CHILD_WINDOW_SHIFT = 4;
+const HOME_LIST_INITIAL_RENDER_COUNT = 12;
+const HOME_LIST_RENDER_BATCH_SIZE = 12;
+const HOME_LIST_WINDOW_SIZE = 5;
 const HOME_PROJECT_HEADER_HEIGHT = 56;
 const HOME_AUTOMATION_VIEW_ALL_ROW_HEIGHT = 54;
 const HOME_SESSION_ROW_HEIGHT = 78;
@@ -2300,6 +2311,7 @@ function HomeScreenContent() {
       projectDragging={projectDrag?.key === (item.kind === 'project' ? item.project.key : '')}
       projectHeaderRefs={projectHeaderRefs}
       homeScrollY={homeScrollY}
+      viewportHeight={screenHeight}
       onTogglePin={toggleSessionPinned}
       prevIsBlock={isBlockHomeRow(homeRowBefore(sections, section.key, index))}
       projectCollapsed={isFolderHomeRow(item) && collapsedProjectKeys.includes(item.project.key)}
@@ -2331,6 +2343,7 @@ function HomeScreenContent() {
     toggleProject,
     toggleSessionPinned,
     homeScrollY,
+    screenHeight,
   ]);
 
   // 底部边到边:列表填满到物理屏底(内容滚到 home indicator 下方),用 inset 兜底而非靠 SafeAreaView 留白带。
@@ -2563,6 +2576,10 @@ function HomeScreenContent() {
         sections={sections}
         style={styles.homeList}
         keyExtractor={(item) => item.key}
+        initialNumToRender={HOME_LIST_INITIAL_RENDER_COUNT}
+        maxToRenderPerBatch={HOME_LIST_RENDER_BATCH_SIZE}
+        updateCellsBatchingPeriod={32}
+        windowSize={HOME_LIST_WINDOW_SIZE}
         refreshControl={
           <RefreshControl
             progressViewOffset={chromeHeight}
@@ -3322,6 +3339,44 @@ function ProjectDragOverlay({
   );
 }
 
+function HomeProjectWindowAnchorTracker({
+  childOffsets,
+  onAnchorChange,
+  projectHeaderHeight,
+  projectLayoutReady,
+  projectTop,
+  scrollY,
+  viewportHeight,
+}: {
+  childOffsets: readonly number[];
+  onAnchorChange(anchor: number): void;
+  projectHeaderHeight: SharedValue<number>;
+  projectLayoutReady: SharedValue<boolean>;
+  projectTop: SharedValue<number>;
+  scrollY: SharedValue<number>;
+  viewportHeight: number;
+}) {
+  useAnimatedReaction(
+    () => {
+      if (!projectLayoutReady.value) return -1;
+      return resolveHomeProjectChildAnchor({
+        childOffsets,
+        projectHeaderHeight: projectHeaderHeight.value,
+        projectTop: projectTop.value,
+        shift: PROJECT_CHILD_WINDOW_SHIFT,
+        viewportHeight,
+        viewportTop: scrollY.value,
+      });
+    },
+    (next, previous) => {
+      if (next === previous) return;
+      runOnJS(onAnchorChange)(next);
+    },
+    [childOffsets, onAnchorChange, projectHeaderHeight, projectLayoutReady, projectTop, scrollY, viewportHeight],
+  );
+  return null;
+}
+
 function ProjectRow({
   collapsed,
   dragging = false,
@@ -3338,6 +3393,7 @@ function ProjectRow({
   onToggleAutomationGroup,
   project,
   homeScrollY,
+  viewportHeight,
   showAll = false,
   suppressTopBorder = false,
   swipe,
@@ -3357,6 +3413,7 @@ function ProjectRow({
   onToggleAutomationGroup(key: string): void;
   project: MobileHomeProjectGroup;
   homeScrollY?: SharedValue<number>;
+  viewportHeight: number;
   /** 对话组「查看全部」在原地展开,不跳设备详情。 */
   showAll?: boolean;
   /** 前一行也是块(项目组 / 自动化组)时不画顶线:前块底线已是这根分割线。 */
@@ -3386,8 +3443,8 @@ function ProjectRow({
   const projectTop = useSharedValue(0);
   const projectHeaderHeight = useSharedValue(HOME_PROJECT_HEADER_HEIGHT);
   const projectRef = useRef<View>(null);
-  const [windowAnchor, setWindowAnchor] = useState(0);
-  const [projectLayoutReady, setProjectLayoutReady] = useState(false);
+  const [windowAnchor, setWindowAnchor] = useState(-1);
+  const projectLayoutReady = useSharedValue(false);
   const estimatedChildHeights = useMemo(() => {
     const expandedKeys = new Set(expandedAutomationGroups);
     return visibleSessions.map((item) => estimateHomeProjectChildHeight(item, expandedKeys));
@@ -3396,35 +3453,33 @@ function ProjectRow({
     () => buildHomeProjectChildOffsets(estimatedChildHeights),
     [estimatedChildHeights],
   );
-  // Keep the common five-row preview unchanged. Large expanded groups use
-  // prefix-sum windowing for both 60/78px rows and expanded automation groups,
-  // so mixed content never falls back to mounting the whole project.
-  const windowingEligible = !!homeScrollY
-    && !collapsed
-    && projectLayoutReady
-    && visibleSessions.length > PROJECT_CHILD_WINDOW_THRESHOLD;
+  // Keep the common five-row preview unchanged. A large expanded group keeps
+  // its complete estimated height as a spacer until native layout establishes
+  // that its child area intersects the viewport. This avoids mounting an
+  // off-screen child window just because the folder header entered the outer
+  // SectionList render window.
+  const windowingEnabled = shouldWindowHomeProjectChildren({
+    collapsed,
+    itemCount: visibleSessions.length,
+    scrollTrackingAvailable: !!homeScrollY,
+    threshold: PROJECT_CHILD_WINDOW_THRESHOLD,
+  });
   const scrollY = homeScrollY;
-  useAnimatedReaction(
-    () => {
-      if (!windowingEligible) return -1;
-      const relativeY = Math.max(0, scrollY!.value - projectTop.value - projectHeaderHeight.value);
-      const visibleIndex = findHomeProjectChildIndex(estimatedChildOffsets, relativeY);
-      return Math.floor(visibleIndex / PROJECT_CHILD_WINDOW_SHIFT)
-        * PROJECT_CHILD_WINDOW_SHIFT;
-    },
-    (next, previous) => {
-      if (next < 0 || next === previous) return;
-      runOnJS(setWindowAnchor)(next);
-    },
-    [estimatedChildOffsets, projectHeaderHeight, scrollY, windowingEligible],
-  );
-  const childWindow = windowingEligible
-    ? resolveHomeProjectChildWindow({
+  const childContentHeight = estimatedChildOffsets[estimatedChildOffsets.length - 1] ?? 0;
+  const childWindow = windowingEnabled
+    ? windowAnchor >= 0
+      ? resolveHomeProjectChildWindow({
         anchor: windowAnchor,
         childOffsets: estimatedChildOffsets,
         overscan: PROJECT_CHILD_WINDOW_OVERSCAN,
         windowSize: PROJECT_CHILD_WINDOW_SIZE,
       })
+      : {
+          end: 0,
+          leadingSpacerHeight: 0,
+          start: 0,
+          trailingSpacerHeight: childContentHeight,
+        }
     : {
         end: visibleSessions.length,
         leadingSpacerHeight: 0,
@@ -3433,7 +3488,7 @@ function ProjectRow({
       };
   const windowStart = childWindow.start;
   const windowEnd = childWindow.end;
-  const renderedSessions = windowingEligible ? visibleSessions.slice(windowStart, windowEnd) : visibleSessions;
+  const renderedSessions = windowingEnabled ? visibleSessions.slice(windowStart, windowEnd) : visibleSessions;
   const leadingSpacerHeight = childWindow.leadingSpacerHeight;
   const trailingSpacerHeight = childWindow.trailingSpacerHeight;
   const groupTestID = kind === 'dialogue' ? 'home.dialogueGroup' : 'home.projectGroup';
@@ -3506,23 +3561,36 @@ function ProjectRow({
   return (
     <View
       onLayout={(event) => {
+        if (!windowingEnabled) return;
+        projectLayoutReady.value = false;
         const fallbackY = event.nativeEvent.layout.y;
         projectRef.current?.measureInWindow((_x, screenY) => {
           projectTop.value = screenY + (homeScrollY?.value ?? 0);
-          setProjectLayoutReady(true);
+          projectLayoutReady.value = true;
         });
         // A native measure can be unavailable in shallow/unit renderers. Keep
         // the local layout as a safe fallback; the real device measurement
         // above is used whenever the row is mounted in a ScrollView.
         if (!projectRef.current) {
           projectTop.value = fallbackY;
-          setProjectLayoutReady(true);
+          projectLayoutReady.value = true;
         }
       }}
       ref={projectRef}
       style={[styles.projectGroup, suppressTopBorder && styles.projectGroupNoTop]}
       testID={groupTestID}
     >
+      {windowingEnabled && scrollY ? (
+        <HomeProjectWindowAnchorTracker
+          childOffsets={estimatedChildOffsets}
+          onAnchorChange={setWindowAnchor}
+          projectHeaderHeight={projectHeaderHeight}
+          projectLayoutReady={projectLayoutReady}
+          projectTop={projectTop}
+          scrollY={scrollY}
+          viewportHeight={viewportHeight}
+        />
+      ) : null}
       {dragGesture ? <GestureDetector gesture={dragGesture}>{header}</GestureDetector> : header}
 
       {collapsed ? null : (
@@ -3540,7 +3608,7 @@ function ProjectRow({
             // slots while windowing; the row receives new data without paying
             // the native mount/unmount cost. Preserve identity keys outside the
             // windowed path, and remount a slot when its outer shell changes.
-            const reactKey = windowingEligible
+            const reactKey = windowingEnabled
               ? `${project.key}:window:${renderedIndex}:${swipeable ? 'swipe' : 'plain'}`
               : itemKey;
             const row = (
@@ -3613,7 +3681,22 @@ function ProjectRow({
  * useMemo 单例。给本组件新增函数 prop 时必须复审闭包稳定性。projectCollapsed /
  * prevIsBlock 等邻接派生位由 renderItem 计算成标量传入,天然参与比较。
  */
-const HomeListRow = memo(HomeListRowInner, dataPropsEqual);
+const HomeListRow = memo(HomeListRowInner, homeListRowPropsEqual);
+
+function homeListRowPropsEqual(
+  previous: Readonly<Record<string, unknown>>,
+  next: Readonly<Record<string, unknown>>,
+): boolean {
+  const previousItem = previous.item as HomeRow;
+  const nextItem = next.item as HomeRow;
+  if (!homeRowsShareRenderData(previousItem, nextItem)) {
+    return dataPropsEqual(previous, next);
+  }
+  // dataPropsEqual retains the existing semantics for every other prop. Point
+  // the previous row at the already-proven-equivalent next item so the
+  // generic comparator takes its Object.is path instead of JSON.stringify.
+  return dataPropsEqual({ ...previous, item: nextItem }, next);
+}
 
 function HomeListRowInner({
   expandedAutomationGroups,
@@ -3637,6 +3720,7 @@ function HomeListRowInner({
   projectDragging,
   projectHeaderRefs,
   homeScrollY,
+  viewportHeight,
   registry,
   showAllDialogue,
   swipe,
@@ -3663,6 +3747,7 @@ function HomeListRowInner({
   projectDragging: boolean;
   projectHeaderRefs: MutableRefObject<Map<string, View>>;
   homeScrollY?: SharedValue<number>;
+  viewportHeight: number;
   registry: ReturnType<typeof createSwipeRowRegistry>;
   showAllDialogue: boolean;
   swipe: SessionSwipeControls;
@@ -3685,6 +3770,7 @@ function HomeListRowInner({
         onToggleAutomationGroup={onToggleAutomationGroup}
         project={item.project}
         homeScrollY={homeScrollY}
+        viewportHeight={viewportHeight}
         showAll={item.kind === 'dialogue' && showAllDialogue}
         suppressTopBorder={prevIsBlock}
         swipe={swipe}

--- a/apps/mobile/app/listperf.tsx
+++ b/apps/mobile/app/listperf.tsx
@@ -4,7 +4,7 @@
  * 顶层路由(不在 (auth) 组)→ 已登录用户可直接访问,auth 守卫不拦。
  *
  * 用法(deeplink):
- *   lizcn://listperf?turns=300&media=1&auto=1&vel=45
+ *   lizcn://listperf?turns=300&media=1&auto=1&vel=45&recycle=1
  *   - turns: 轮数(每轮 1 user + 1 assistant),默认 300
  *   - media: 1=含 mermaid/math(WebView),0=纯文本(隔离 WebView 成本),默认 1
  *   - auto:  1=进入后自动做一次「底→顶」匀速滚动扫描并测帧,默认 0
@@ -17,24 +17,34 @@ import { SafeAreaView } from 'react-native-safe-area-context';
 import { buildListPerfRenderItems } from '@/debug/listPerfFixture';
 import { runScrollSweep, type FrameStats } from '@/debug/scrollProfiler';
 import { MessageRenderer } from '@/session/MessageRenderer';
+import type { MobileMessageWebViewMetrics } from '@/session/mobileMessageWebViewMetrics';
+import {
+  resetMobileMarkdownRenderMetrics,
+  type MobileMarkdownRenderMetrics,
+} from '@/session/mobileMarkdownRenderMetrics';
 
 type ListApi = {
   scrollTo: (y: number) => void;
   getMetrics: () => { contentHeight: number; offsetY: number; viewportHeight: number };
+  getWebViewMetrics: () => MobileMessageWebViewMetrics;
+  getMarkdownMetrics: () => MobileMarkdownRenderMetrics;
 };
 
 export default function ListPerfHarness() {
-  const params = useLocalSearchParams<{ turns?: string; media?: string; auto?: string; vel?: string; run?: string }>();
+  const params = useLocalSearchParams<{ turns?: string; media?: string; auto?: string; vel?: string; recycle?: string; run?: string }>();
   const turns = Math.max(1, Math.min(2000, Number(params.turns) || 300));
   const media = params.media !== '0';
   const auto = params.auto === '1';
+  const recycle = params.recycle === '1';
   const pxPerFrame = Math.max(5, Math.min(200, Number(params.vel) || 45));
 
   const items = useMemo(() => buildListPerfRenderItems(turns, { media }), [turns, media]);
-  const runKey = `${turns}|${media ? 1 : 0}|${pxPerFrame}|${params.run ?? '0'}`;
+  const runKey = `${turns}|${media ? 1 : 0}|${pxPerFrame}|${recycle ? 1 : 0}|${params.run ?? '0'}`;
   const apiRef = useRef<ListApi | null>(null);
   const startedKeyRef = useRef<string | null>(null);
   const [stats, setStats] = useState<FrameStats | null>(null);
+  const [webViewMetrics, setWebViewMetrics] = useState<MobileMessageWebViewMetrics | null>(null);
+  const [markdownMetrics, setMarkdownMetrics] = useState<MobileMarkdownRenderMetrics | null>(null);
   const [phase, setPhase] = useState<string>(auto ? 'waiting…' : 'manual');
 
   const devExposeList = useCallback((api: ListApi) => {
@@ -45,6 +55,11 @@ export default function ListPerfHarness() {
     if (!auto || startedKeyRef.current === runKey) return undefined;
     let cancelled = false;
     setStats(null);
+    setWebViewMetrics(null);
+    setMarkdownMetrics(null);
+    // Counters are process-global so repeated A/B deeplinks must start from a
+    // clean window; otherwise B includes all parses performed by A.
+    resetMobileMarkdownRenderMetrics();
     // 轮询等列表布局稳定(contentHeight 被 onContentSizeChange/onScroll 填好),再开扫。
     const waitAndRun = (attempt: number) => {
       if (cancelled) return;
@@ -63,7 +78,7 @@ export default function ListPerfHarness() {
       api!.scrollTo(0);
       setTimeout(() => {
         runScrollSweep({
-          label: `list=Legend turns=${turns} media=${media ? 1 : 0} vel=${pxPerFrame}`,
+          label: `list=Legend turns=${turns} media=${media ? 1 : 0} recycle=${recycle ? 1 : 0} vel=${pxPerFrame}`,
           fromY: 0,
           toY: 1_000_000,
           pxPerFrame,
@@ -72,6 +87,10 @@ export default function ListPerfHarness() {
           onDone: (s) => {
             if (cancelled) return;
             setStats(s);
+            const currentWebViewMetrics = apiRef.current?.getWebViewMetrics();
+            if (currentWebViewMetrics) setWebViewMetrics(currentWebViewMetrics);
+            const currentMarkdownMetrics = apiRef.current?.getMarkdownMetrics();
+            if (currentMarkdownMetrics) setMarkdownMetrics(currentMarkdownMetrics);
             setPhase('done');
             // 打到 Metro 日志,便于抓取。
             // eslint-disable-next-line no-console
@@ -96,17 +115,28 @@ export default function ListPerfHarness() {
     <SafeAreaView style={styles.fill} edges={['top']}>
       <View style={styles.bar}>
         <Text style={styles.barText}>
-          PERF · LegendList · turns={turns} · items={items.length} · media={media ? 1 : 0} · {phase}
+          PERF · LegendList · turns={turns} · items={items.length} · media={media ? 1 : 0} · recycle={recycle ? 1 : 0} · {phase}
         </Text>
         {stats ? (
           <Text style={styles.statText}>
             fps={stats.fps} avg={stats.avgMs}ms p50={stats.p50} p95={stats.p95} p99={stats.p99} max={stats.maxMs} | jank&gt;32={stats.jank32}/{stats.frames} &gt;50={stats.jank50}
           </Text>
         ) : null}
+        {webViewMetrics ? (
+          <Text style={styles.statText}>
+            webview mounted={webViewMetrics.mounted} mermaid={webViewMetrics.mountedByKind.mermaid} math={webViewMetrics.mountedByKind.math} media={webViewMetrics.mountedByKind.media} composer={webViewMetrics.mountedByKind.composer}
+          </Text>
+        ) : null}
+        {markdownMetrics ? (
+          <Text style={styles.statText}>
+            markdown full={markdownMetrics.fullParseCount} incremental={markdownMetrics.incrementalParseCount} reusedBlocks={markdownMetrics.reusedBlockCount} parsedUtf16={markdownMetrics.parsedSourceUtf16Length} parseMs={markdownMetrics.parseDurationMsTotal.toFixed(1)} maxMs={markdownMetrics.parseDurationMsMax.toFixed(1)} renderItems={markdownMetrics.renderItemRebuildCount}
+          </Text>
+        ) : null}
       </View>
       <View style={styles.fill}>
         <MessageRenderer
           items={items}
+          devRecycleItems={recycle}
           testID="perf.list"
           devExposeList={devExposeList}
         />

--- a/apps/mobile/app/listperf.tsx
+++ b/apps/mobile/app/listperf.tsx
@@ -9,6 +9,7 @@
  *   - media: 1=含 mermaid/math(WebView),0=纯文本(隔离 WebView 成本),默认 1
  *   - auto:  1=进入后自动做一次「底→顶」匀速滚动扫描并测帧,默认 0
  *   - vel:   滚动速度 px/帧(模拟 fling),默认 45
+ *   - recycle: 0=关闭 cell 回收做 A/B,默认 1
  */
 import { useLocalSearchParams } from 'expo-router';
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
@@ -35,7 +36,7 @@ export default function ListPerfHarness() {
   const turns = Math.max(1, Math.min(2000, Number(params.turns) || 300));
   const media = params.media !== '0';
   const auto = params.auto === '1';
-  const recycle = params.recycle === '1';
+  const recycle = params.recycle !== '0';
   const pxPerFrame = Math.max(5, Math.min(200, Number(params.vel) || 45));
 
   const items = useMemo(() => buildListPerfRenderItems(turns, { media }), [turns, media]);

--- a/apps/mobile/app/sessions/[sessionId].tsx
+++ b/apps/mobile/app/sessions/[sessionId].tsx
@@ -454,6 +454,7 @@ import {
   hasOlderMessagesByServerCount,
   listMessagesWithPayloadRetry,
   oldestMessageCursor,
+  projectLoadedMessageWindow,
   shouldRefreshLatestMessageWindowOnReopen,
   shouldKeepOlderMessagesAffordance,
 } from '@/session/messagePaging';
@@ -4623,7 +4624,7 @@ export default function SessionScreen() {
         // (含本地 sending / canStopQueue,发送→status 间隙会闪现残留),也不用
         // remoteSessionRunning(activity 推送 / 活跃快照会先置 true,重连场景渲染先于清理)。
         buildMobileMessageRenderItems(
-          messages,
+          projectLoadedMessageWindow(messages),
           { autoResumePending: inputProjection.autoResumePending, isSessionStreaming, renderOrphanTaskUpdates: makerTurnRunning, sessionId },
           taskUpdates,
         ),
@@ -9346,6 +9347,7 @@ export default function SessionScreen() {
                     items={messageListItems}
                     pendingSend={pendingSendActions}
                     loadingEarlier={loadingEarlier}
+                    loadEarlierProgressKey={oldestMessageCursor(messages)}
                     onCopyMessageLink={copyMessageLink}
                     onAddMessageToComposer={canUseComposer ? addMessageToComposer : undefined}
                     onDeleteMessage={collaborationReadOnlyReason ? undefined : deleteMessage}

--- a/apps/mobile/app/sessions/[sessionId].tsx
+++ b/apps/mobile/app/sessions/[sessionId].tsx
@@ -1823,6 +1823,8 @@ export default function SessionScreen() {
       // 退屏后才完成的 in-flight 取件:缓存已被 releaseAll 清空接管不到,这里直接
       // 补 DELETE,避免「退出时正在取件」的对象漏出退屏统一清理悬到生命周期兜底。
       onOrphanResolved: (media) => deleteRemoteMediaObject(media),
+    }, {
+      maxCacheBytes: 16 * 1024 * 1024,
     }), [deleteRemoteMediaObject]);
   remoteMediaQueueRef.current ??= createRemoteMediaQueue();
   const voiceRecordingActiveRef = useRef(false);
@@ -4845,15 +4847,41 @@ export default function SessionScreen() {
   // 变化与 unmount 时都执行:releaseAll + 补删(fire-and-forget;App 被杀等不触发
   // cleanup 的情况由 OSS 生命周期规则兜底),并换上全新队列实例(released 标志
   // 一次性,释放过的队列不能复用;unmount 分支多建一个空队列无害)。
-  useEffect(() => () => {
+  const releaseRemoteMediaQueue = useCallback(() => {
     const released = remoteMediaQueueRef.current?.releaseAll() ?? [];
     for (const media of released) {
       // 仍在后台落盘的对象等落盘结束再删,避免 DELETE 抢先把落盘下载打成 404;
       // 磁盘缓存命中的空 ossKey 条目在 deleteRemoteMediaObject 内跳过。
       deleteRemoteMediaObject(media);
     }
-    remoteMediaQueueRef.current = createRemoteMediaQueue();
-  }, [sessionId, createRemoteMediaQueue, deleteRemoteMediaObject]);
+    remoteMediaQueueRef.current = null;
+  }, [deleteRemoteMediaObject]);
+
+  useFocusEffect(
+    useCallback(() => () => {
+      releaseRemoteMediaQueue();
+    }, [releaseRemoteMediaQueue]),
+  );
+
+  useEffect(() => () => {
+    releaseRemoteMediaQueue();
+  }, [releaseRemoteMediaQueue, sessionId]);
+
+  // Navigation focus does not change when Android backgrounds the activity.
+  // Release resolved media and queued fetches at the AppState boundary too;
+  // the next foreground request lazily creates a fresh queue.
+  useEffect(() => {
+    const subscription = AppState.addEventListener('change', (nextState) => {
+      if (nextState !== 'active') {
+        releaseRemoteMediaQueue();
+        return;
+      }
+      if (!remoteMediaQueueRef.current) {
+        remoteMediaQueueRef.current = createRemoteMediaQueue();
+      }
+    });
+    return () => subscription.remove();
+  }, [createRemoteMediaQueue, releaseRemoteMediaQueue]);
 
   /** 单调递增的补齐轮次计数器;`latest` 是本屏最新那一轮的序号(旧轮据此自我作废)。 */
   const backfillRunSeqRef = useRef(0);

--- a/apps/mobile/app/sessions/[sessionId].tsx
+++ b/apps/mobile/app/sessions/[sessionId].tsx
@@ -1677,8 +1677,9 @@ export default function SessionScreen() {
   }
   // 远程媒体取件队列:屏实例级缓存 + 同 url 去重 + 并发上限(每次取件都让桌面端
   // 真实上传一次 OSS,列表缩略图懒取件后必须收敛)。deps 经 ref 透传保持队列实例稳定;
-  // 队列生命周期 = 单个会话:切 sessionId / 退屏时 releaseAll + 补删 + 换新实例
-  // (见下方 sessionId 键控的清理 effect),上一会话的 OSS 对象不跨会话累积。
+  // 队列生命周期 = 单个会话:切 sessionId / 页面卸载时 releaseAll + 补删,
+  // 下个会话首次取件再懒建新实例(见下方 sessionId 键控的清理 effect),
+  // 上一会话的 OSS 对象不跨会话累积。
   const remoteMediaDepsRef = useRef({ auth, maker });
   // useLayoutEffect 而非 useEffect:子组件(MediaPreview)的取件是被动 effect,
   // 会晚于父层 layout effect、早于父层被动 effect——切会话首批取件必须已看到
@@ -4780,18 +4781,14 @@ export default function SessionScreen() {
     [createRemoteMediaQueue],
   );
 
-  // 仅 video/audio 仍走「查看器关闭即删」;image 缩略图常驻列表,缓存保留到退屏统一清理。
+  // 查看器关闭只逐出 JS cache。OSS 对象仍可能被同屏其它已挂载行持有,
+  // 统一延迟到换会话或页面卸载时删除。
   const releaseRemoteMedia = useCallback((
     sourceUrl: string,
-    media: MobileResolvedRemoteMedia,
+    _media: MobileResolvedRemoteMedia,
   ) => {
     remoteMediaQueueRef.current?.evict(sourceUrl);
-    void auth.apiFetch('/api/device-link/media', {
-      baseUrl: DEVICE_LINK_API_BASE_URL,
-      method: 'DELETE',
-      body: { key: media.ossKey },
-    }).catch(() => undefined);
-  }, [auth]);
+  }, []);
 
   // 全屏查看器的分享:确保拿到本地 file://(磁盘缓存命中或先落盘)再唤起系统分享单。
   // 分享失败静默提示——旧 dev client 未包含 expo-sharing 原生模块时也走这条兜底。
@@ -4842,11 +4839,11 @@ export default function SessionScreen() {
     }
   }, [diskCacheSourceOf, t]);
 
-  // 换会话与退屏共用一套清理:本屏切 sessionId 不重挂载,若只在 unmount 清理,
+  // 换会话与页面卸载共用一套最终清理:本屏切 sessionId 不重挂载,若只在 unmount 清理,
   // 连续浏览多个多图会话会让上一会话的 OSS 对象一路累积。cleanup 在 sessionId
   // 变化与 unmount 时都执行:releaseAll + 补删(fire-and-forget;App 被杀等不触发
-  // cleanup 的情况由 OSS 生命周期规则兜底),并换上全新队列实例(released 标志
-  // 一次性,释放过的队列不能复用;unmount 分支多建一个空队列无害)。
+  // cleanup 的情况由 OSS 生命周期规则兜底)。队列实例带一次性 released 标志,
+  // 下个会话首次取件时由 resolveRemoteMedia 懒创建新实例。
   const releaseRemoteMediaQueue = useCallback(() => {
     const released = remoteMediaQueueRef.current?.releaseAll() ?? [];
     for (const media of released) {
@@ -4857,31 +4854,9 @@ export default function SessionScreen() {
     remoteMediaQueueRef.current = null;
   }, [deleteRemoteMediaObject]);
 
-  useFocusEffect(
-    useCallback(() => () => {
-      releaseRemoteMediaQueue();
-    }, [releaseRemoteMediaQueue]),
-  );
-
   useEffect(() => () => {
     releaseRemoteMediaQueue();
   }, [releaseRemoteMediaQueue, sessionId]);
-
-  // Navigation focus does not change when Android backgrounds the activity.
-  // Release resolved media and queued fetches at the AppState boundary too;
-  // the next foreground request lazily creates a fresh queue.
-  useEffect(() => {
-    const subscription = AppState.addEventListener('change', (nextState) => {
-      if (nextState !== 'active') {
-        releaseRemoteMediaQueue();
-        return;
-      }
-      if (!remoteMediaQueueRef.current) {
-        remoteMediaQueueRef.current = createRemoteMediaQueue();
-      }
-    });
-    return () => subscription.remove();
-  }, [createRemoteMediaQueue, releaseRemoteMediaQueue]);
 
   /** 单调递增的补齐轮次计数器;`latest` 是本屏最新那一轮的序号(旧轮据此自我作废)。 */
   const backfillRunSeqRef = useRef(0);

--- a/apps/mobile/app/sessions/[sessionId].tsx
+++ b/apps/mobile/app/sessions/[sessionId].tsx
@@ -2222,7 +2222,7 @@ export default function SessionScreen() {
   const showSyncingShell = sessionOperationLayout.composerSlot === 'missing-session'
     && !remoteUnavailableReason;
   // 同步/加载期消息区不显示「暂无消息」(会话其实在加载、不是空),改为渲染「正在同步」
-  // loading 占位(MessageRenderer 的 SyncingMessages,延迟显形防快速路径闪烁);看过的会话
+  // loading 占位(MessageRenderer 的 SyncingMessages);看过的会话
   // 此时已被本地缓存(②)填充正常渲染,不进 empty 分支。还包含冷开首帧:currentSession 立即
   // 就有但消息未到、loading 尚未翻 true 的窗口(本次打开未同步过)。只有同步完成过
   // (lastSyncedAt 有值)且确实 0 条时才显示「暂无消息」;离线/被撤销(remoteUnavailableReason)

--- a/apps/mobile/app/sessions/[sessionId].tsx
+++ b/apps/mobile/app/sessions/[sessionId].tsx
@@ -467,11 +467,14 @@ import {
   historyWindowGapKey,
 } from '@/session/historyWindowGap';
 import {
-  buildMobileMessageRenderItems,
   insertMobileForkOriginItem,
   type MobileMessageRenderItem,
 } from '@/session/messageRenderModel';
 import { reconcileMobileMessageRenderItems } from '@/session/messageRenderReconcile';
+import {
+  buildMobileStreamingRenderWindow,
+  type MobileStreamingRenderPrefixCache,
+} from '@/session/messageRenderStreamingCache';
 import { shouldSuppressEmptyMessageState } from '@/session/sessionEmptyState';
 import { deferScheduleIndexHydration } from '@/session/scheduleIndexDefer';
 import { markSessionScheduleRunsRead, unreadRunIdFromProjection } from '@/session/scheduleRunRead';
@@ -4616,18 +4619,27 @@ export default function SessionScreen() {
     sessionId: string;
     items: readonly MobileMessageRenderItem[];
   } | null>(null);
+  const streamingRenderPrefixRef = useRef<MobileStreamingRenderPrefixCache | null>(null);
   const renderItems = useMemo(
     () => {
+      const builtWindow = buildMobileStreamingRenderWindow({
+        cacheKey: i18nInstance.language,
+        messages: projectLoadedMessageWindow(messages),
+        options: {
+          autoResumePending: inputProjection.autoResumePending,
+          isSessionStreaming,
+          renderOrphanTaskUpdates: makerTurnRunning,
+          sessionId,
+        },
+        prefixCache: streamingRenderPrefixRef,
+        taskUpdates,
+      });
       let items = insertMobileForkOriginItem(
         // 孤儿 agent_task 兜底用 maker status 驱动的权威 turn 边界 gate,与 store 的
         // turn-start 清理同源闭环——渲染开启时 map 必已清过 stale。不用 isSessionStreaming
         // (含本地 sending / canStopQueue,发送→status 间隙会闪现残留),也不用
         // remoteSessionRunning(activity 推送 / 活跃快照会先置 true,重连场景渲染先于清理)。
-        buildMobileMessageRenderItems(
-          projectLoadedMessageWindow(messages),
-          { autoResumePending: inputProjection.autoResumePending, isSessionStreaming, renderOrphanTaskUpdates: makerTurnRunning, sessionId },
-          taskUpdates,
-        ),
+        builtWindow.items,
         forkOrigin,
       );
       if (errorTailClientId) {
@@ -4643,8 +4655,8 @@ export default function SessionScreen() {
     },
     [errorTailClientId, forkOrigin, i18nInstance.language, inputProjection.autoResumePending, isSessionStreaming, makerTurnRunning, messages, sessionId, taskUpdates],
   );
-  // 只在本次 render 真正 commit 后更新 reconcile 基准。写入 useMemo/ref 会让
-  // Concurrent Mode 下被丢弃的 render 泄漏成下一轮的 previous,破坏尾行 memo 的稳定性。
+  // Reconciliation must only use committed rows. Unlike the prefix cache above, a speculative
+  // render-item baseline could leak rows from an abandoned render and destabilize tail memoization.
   useLayoutEffect(() => {
     previousRenderItemsRef.current = { sessionId, items: renderItems };
   }, [renderItems, sessionId]);

--- a/apps/mobile/src/__tests__/deviceDetailProjectListFabric.test.ts
+++ b/apps/mobile/src/__tests__/deviceDetailProjectListFabric.test.ts
@@ -1,0 +1,20 @@
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+import { describe, expect, it } from 'vitest';
+
+const source = readFileSync(
+  resolve(process.cwd(), 'app/devices/[deviceId].tsx'),
+  'utf8',
+);
+
+describe('device detail project list Fabric lifecycle', () => {
+  it('keeps Android clipping disabled for the swipeable project list', () => {
+    const testIdIndex = source.indexOf('testID="deviceDetail.projectSessionList"');
+    const listStart = source.lastIndexOf('<SectionList', testIdIndex);
+    const listProps = source.slice(listStart, testIdIndex);
+
+    expect(testIdIndex).toBeGreaterThan(0);
+    expect(listStart).toBeGreaterThan(0);
+    expect(listProps).toContain('removeClippedSubviews={false}');
+  });
+});

--- a/apps/mobile/src/__tests__/homeProjectChildWindow.test.ts
+++ b/apps/mobile/src/__tests__/homeProjectChildWindow.test.ts
@@ -1,0 +1,62 @@
+import { describe, expect, it } from 'vitest';
+import {
+  buildHomeProjectChildOffsets,
+  findHomeProjectChildIndex,
+  resolveHomeProjectChildWindow,
+} from '@/session/homeProjectChildWindow';
+
+describe('home project child window', () => {
+  it('locates mixed-height rows without changing their total occupied height', () => {
+    const offsets = buildHomeProjectChildOffsets([60, 78, 60, 78, 60, 78]);
+
+    expect(offsets).toEqual([0, 60, 138, 198, 276, 336, 414]);
+    expect(findHomeProjectChildIndex(offsets, 0)).toBe(0);
+    expect(findHomeProjectChildIndex(offsets, 59)).toBe(0);
+    expect(findHomeProjectChildIndex(offsets, 60)).toBe(1);
+    expect(findHomeProjectChildIndex(offsets, 275)).toBe(3);
+
+    const range = resolveHomeProjectChildWindow({
+      anchor: 3,
+      childOffsets: offsets,
+      overscan: 1,
+      windowSize: 2,
+    });
+    expect(range).toEqual({
+      end: 6,
+      leadingSpacerHeight: 138,
+      start: 2,
+      trailingSpacerHeight: 0,
+    });
+    expect(
+      range.leadingSpacerHeight
+      + (offsets[range.end] - offsets[range.start])
+      + range.trailingSpacerHeight,
+    ).toBe(offsets.at(-1));
+  });
+
+  it('keeps a tall expanded automation group inside the same prefix-sum model', () => {
+    const offsets = buildHomeProjectChildOffsets([60, 78 + 60 + 78 + 54, 78, 60, 78]);
+
+    expect(findHomeProjectChildIndex(offsets, 59)).toBe(0);
+    expect(findHomeProjectChildIndex(offsets, 60)).toBe(1);
+    expect(findHomeProjectChildIndex(offsets, 329)).toBe(1);
+    expect(findHomeProjectChildIndex(offsets, 330)).toBe(2);
+  });
+
+  it('clamps the window at both ends and ignores invalid height estimates', () => {
+    const offsets = buildHomeProjectChildOffsets([60, Number.NaN, -1, 78, 60]);
+
+    expect(offsets).toEqual([0, 60, 60, 60, 138, 198]);
+    expect(resolveHomeProjectChildWindow({
+      anchor: 99,
+      childOffsets: offsets,
+      overscan: 1,
+      windowSize: 2,
+    })).toEqual({
+      end: 5,
+      leadingSpacerHeight: 60,
+      start: 3,
+      trailingSpacerHeight: 0,
+    });
+  });
+});

--- a/apps/mobile/src/__tests__/homeProjectChildWindow.test.ts
+++ b/apps/mobile/src/__tests__/homeProjectChildWindow.test.ts
@@ -1,11 +1,107 @@
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
 import { describe, expect, it } from 'vitest';
 import {
   buildHomeProjectChildOffsets,
   findHomeProjectChildIndex,
+  resolveHomeProjectChildAnchor,
   resolveHomeProjectChildWindow,
+  shouldWindowHomeProjectChildren,
 } from '@/session/homeProjectChildWindow';
 
 describe('home project child window', () => {
+  it('marks a large expanded group eligible for windowing before layout tracking is ready', () => {
+    const offsets = buildHomeProjectChildOffsets(Array.from({ length: 200 }, () => 78));
+
+    expect(shouldWindowHomeProjectChildren({
+      collapsed: false,
+      itemCount: 200,
+      scrollTrackingAvailable: true,
+      threshold: 20,
+    })).toBe(true);
+
+    const initialRange = resolveHomeProjectChildWindow({
+      anchor: 0,
+      childOffsets: offsets,
+      overscan: 4,
+      windowSize: 15,
+    });
+    expect(initialRange.start).toBe(0);
+    expect(initialRange.end).toBeLessThan(200);
+    expect(initialRange.trailingSpacerHeight).toBeGreaterThan(0);
+  });
+
+  it('keeps off-screen child content unmounted and anchors it once visible', () => {
+    const childOffsets = buildHomeProjectChildOffsets(Array.from({ length: 112 }, () => 78));
+
+    expect(resolveHomeProjectChildAnchor({
+      childOffsets,
+      projectHeaderHeight: 56,
+      projectTop: 780,
+      shift: 4,
+      viewportHeight: 800,
+      viewportTop: 0,
+    })).toBe(-1);
+    expect(resolveHomeProjectChildAnchor({
+      childOffsets,
+      projectHeaderHeight: 56,
+      projectTop: 200,
+      shift: 4,
+      viewportHeight: 800,
+      viewportTop: 500,
+    })).toBe(0);
+    expect(resolveHomeProjectChildAnchor({
+      childOffsets,
+      projectHeaderHeight: 56,
+      projectTop: 200,
+      shift: 4,
+      viewportHeight: 800,
+      viewportTop: 900,
+    })).toBe(8);
+  });
+
+  it('does not measure or window ordinary previews and collapsed groups', () => {
+    expect(shouldWindowHomeProjectChildren({
+      collapsed: false,
+      itemCount: 20,
+      scrollTrackingAvailable: true,
+      threshold: 20,
+    })).toBe(false);
+    expect(shouldWindowHomeProjectChildren({
+      collapsed: true,
+      itemCount: 200,
+      scrollTrackingAvailable: true,
+      threshold: 20,
+    })).toBe(false);
+  });
+
+  it('keeps layout readiness out of the first-render window gate', () => {
+    const source = readFileSync(resolve(process.cwd(), 'app/devices/index.tsx'), 'utf8');
+    const setupStart = source.indexOf('const windowingEnabled = shouldWindowHomeProjectChildren({');
+    const setupEnd = source.indexOf('const scrollY = homeScrollY;', setupStart);
+    const setup = source.slice(setupStart, setupEnd);
+
+    expect(setupStart).toBeGreaterThan(-1);
+    expect(setup).not.toContain('projectLayoutReady');
+    expect(source).toContain('function HomeProjectWindowAnchorTracker({');
+    expect(source).toContain('if (!projectLayoutReady.value) return -1;');
+    expect(source).toContain('return resolveHomeProjectChildAnchor({');
+    expect(source).toContain('const [windowAnchor, setWindowAnchor] = useState(-1);');
+    expect(source).toContain('trailingSpacerHeight: childContentHeight');
+    expect(source).toContain('{windowingEnabled && scrollY ? (');
+    expect(source).toContain('const renderedSessions = windowingEnabled ? visibleSessions.slice');
+    expect(source).toContain('if (!windowingEnabled) return;');
+  });
+
+  it('bounds the outer home list window instead of retaining every flat row', () => {
+    const source = readFileSync(resolve(process.cwd(), 'app/devices/index.tsx'), 'utf8');
+
+    expect(source).toContain('initialNumToRender={HOME_LIST_INITIAL_RENDER_COUNT}');
+    expect(source).toContain('maxToRenderPerBatch={HOME_LIST_RENDER_BATCH_SIZE}');
+    expect(source).toContain('updateCellsBatchingPeriod={32}');
+    expect(source).toContain('windowSize={HOME_LIST_WINDOW_SIZE}');
+  });
+
   it('locates mixed-height rows without changing their total occupied height', () => {
     const offsets = buildHomeProjectChildOffsets([60, 78, 60, 78, 60, 78]);
 

--- a/apps/mobile/src/__tests__/homeSections.test.ts
+++ b/apps/mobile/src/__tests__/homeSections.test.ts
@@ -1,6 +1,14 @@
 import { beforeAll, describe, expect, it } from 'vitest';
 import { i18n } from '@/i18n';
-import { buildGroupedHomeRows, buildHomeSections, buildMixedHomeRows, homeRowBefore } from '@/session/homeSections';
+import {
+  buildGroupedHomeRows,
+  buildHomeSections,
+  buildMixedHomeRows,
+  HOME_MAIN_SECTION_KEY,
+  homeFolderRowsShareRenderData,
+  homeRowsShareRenderData,
+  homeRowBefore,
+} from '@/session/homeSections';
 import type { MobileHomePresentation, MobileHomeProjectGroup } from '@/session/mobileHome';
 import type { RemoteSessionListItem } from '@/session/sessionList';
 
@@ -12,7 +20,7 @@ beforeAll(async () => {
 // 最小 fixture:buildHomeSections / rows 只读取下面这几个字段,其余字段对本测试无关,
 // 用 cast 避免构造完整 RemoteSessionListItem / MobileHomeProjectGroup。
 function listItem(id: string, lastActivityAt: string): RemoteSessionListItem {
-  return { session: { id }, lastActivityAt } as unknown as RemoteSessionListItem;
+  return { session: { id }, lastActivityAt, pendingInteractionCount: 0 } as unknown as RemoteSessionListItem;
 }
 
 function projectGroup(
@@ -65,10 +73,53 @@ describe('buildHomeSections', () => {
       chats: [listItem('c1', '2026-06-01T00:00:00Z')],
       projects: [projectGroup('proj-a', '2026-06-02T00:00:00Z', [listItem('s1', '2026-06-02T00:00:00Z')])],
     });
-    expect(buildHomeSections(home, false, false).find((s) => s.title === null)?.key).toBe('mixed');
+    expect(buildHomeSections(home, false, false).find((s) => s.title === null)?.key).toBe(HOME_MAIN_SECTION_KEY);
     expect(buildHomeSections(home, true, false).map((s) => [s.key, s.title])).toEqual([
-      ['grouped', null],
+      [HOME_MAIN_SECTION_KEY, null],
     ]);
+  });
+
+  it('recognizes a rebuilt large folder backed by the same session items', () => {
+    const home = presentation({
+      chats: Array.from({ length: 112 }, (_, index) => (
+        listItem(`chat-${index}`, `2026-06-${String((index % 28) + 1).padStart(2, '0')}T00:00:00Z`)
+      )),
+    });
+    const previous = buildGroupedHomeRows(home, { groupDialogue: true })
+      .find((row) => row.kind === 'dialogue');
+    const next = buildMixedHomeRows(home, { groupDialogue: true })
+      .find((row) => row.kind === 'dialogue');
+
+    expect(previous).toBeDefined();
+    expect(next).toBeDefined();
+    expect(previous).not.toBe(next);
+    expect(homeFolderRowsShareRenderData(previous!, next!)).toBe(true);
+    if (!next || next.kind !== 'dialogue') throw new Error('expected dialogue row');
+    const changed = {
+      ...next,
+      project: {
+        ...next.project,
+        sessions: [{ ...next.project.sessions[0] }, ...next.project.sessions.slice(1)],
+      },
+    };
+    expect(homeFolderRowsShareRenderData(previous!, changed)).toBe(false);
+  });
+
+  it('recognizes rebuilt session row wrappers backed by the same list item', () => {
+    const item = listItem('chat-1', '2026-06-01T00:00:00Z');
+    const home = presentation({ chats: [item] });
+    const previous = buildGroupedHomeRows(home)[0];
+    const next = buildGroupedHomeRows(home)[0];
+
+    if (previous.kind !== 'session' || next.kind !== 'session') {
+      throw new Error('expected session rows');
+    }
+    expect(previous).not.toBe(next);
+    expect(homeRowsShareRenderData(previous, next)).toBe(true);
+    expect(homeRowsShareRenderData(previous, {
+      ...next,
+      sourceLabel: 'Chat',
+    })).toBe(false);
   });
 });
 
@@ -90,21 +141,21 @@ describe('homeRowBefore(跨 section 邻接:分割线唯一化的 prevIsBlock 依
 
   it('置顶区 → 主列表首行:跨区取到末位置顶会话', () => {
     const sections = buildHomeSections(home, true, false);
-    const prev = homeRowBefore(sections, 'grouped', 0);
+    const prev = homeRowBefore(sections, HOME_MAIN_SECTION_KEY, 0);
     expect(prev?.kind).toBe('session');
     expect(prev && prev.kind === 'session' ? prev.item.session.id : null).toBe('pin-1');
   });
 
   it('同区内仍取 index-1,不受跨区逻辑影响', () => {
     const sections = buildHomeSections(home, true, false);
-    const prev = homeRowBefore(sections, 'grouped', 1);
+    const prev = homeRowBefore(sections, HOME_MAIN_SECTION_KEY, 1);
     expect(prev?.kind).toBe('session');
     expect(prev && prev.kind === 'session' ? prev.item.session.id : null).toBe('auto-1');
   });
 
   it('置顶收起时 pinned 区 data 为空:跨区回溯要跳过空区', () => {
     const sections = buildHomeSections(home, true, true);
-    const prev = homeRowBefore(sections, 'grouped', 0);
+    const prev = homeRowBefore(sections, HOME_MAIN_SECTION_KEY, 0);
     expect(prev).toBeUndefined();
   });
 

--- a/apps/mobile/src/__tests__/inactiveSessionListSubscriptions.test.ts
+++ b/apps/mobile/src/__tests__/inactiveSessionListSubscriptions.test.ts
@@ -3,7 +3,7 @@ import { resolve } from 'node:path';
 import { describe, expect, it } from 'vitest';
 
 function source(path: string): string {
-  return readFileSync(resolve(process.cwd(), path), 'utf8');
+  return readFileSync(resolve(process.cwd(), path), 'utf8').replace(/\r\n/g, '\n');
 }
 
 describe('inactive session list subscriptions', () => {

--- a/apps/mobile/src/__tests__/inactiveSessionListSubscriptions.test.ts
+++ b/apps/mobile/src/__tests__/inactiveSessionListSubscriptions.test.ts
@@ -1,0 +1,34 @@
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+import { describe, expect, it } from 'vitest';
+
+function source(path: string): string {
+  return readFileSync(resolve(process.cwd(), path), 'utf8');
+}
+
+describe('inactive session list subscriptions', () => {
+  it('gates both mounted list routes by navigation focus', () => {
+    for (const path of ['app/devices/index.tsx', 'app/devices/[deviceId].tsx']) {
+      const screen = source(path);
+      expect(screen).toContain('const screenFocused = useIsFocused();');
+      expect(screen).toContain(
+        '<RemoteSessionStoreSubscriptionGate enabled={screenFocused}>',
+      );
+    }
+  });
+
+  it('pauses list and row subscriptions while their route is covered', () => {
+    const store = source('src/session/remoteSessionStore.ts');
+    expect(store).toContain(
+      'enabled ? remoteSessionStore.subscribe : INACTIVE_REMOTE_SESSION_STORE_SUBSCRIBE',
+    );
+    expect(store).toContain(
+      "usePausableRemoteSessionStoreSnapshot('sessions', remoteSessionStore.getSessions)",
+    );
+    expect(store).toContain("'message-version',\n    remoteSessionStore.getMessageVersion");
+    expect(store).toContain("'store-version',\n    remoteSessionStore.getStoreVersion");
+    expect(store).toContain(
+      '() => remoteSessionStore.isSessionRunning(sessionId)',
+    );
+  });
+});

--- a/apps/mobile/src/__tests__/mediaPlayerWebView.test.ts
+++ b/apps/mobile/src/__tests__/mediaPlayerWebView.test.ts
@@ -4,8 +4,26 @@ import {
   buildMediaPlayerWebViewHtml,
   parseMediaPlayerWebViewMessage,
 } from '@/session/mediaPlayerWebViewHtml';
+import { createMediaPlayerWebViewLifecycle } from '@/session/mediaPlayerWebViewLifecycle';
 
 describe('mediaPlayerWebView', () => {
+  it('reloads only when backgrounding interrupted an unfinished load', () => {
+    const lifecycle = createMediaPlayerWebViewLifecycle();
+
+    lifecycle.onBackground();
+    lifecycle.onLoadEnd();
+    expect(lifecycle.consumeReloadOnActive()).toBe(true);
+    expect(lifecycle.consumeReloadOnActive()).toBe(false);
+
+    lifecycle.onLoadEnd();
+    lifecycle.onBackground();
+    expect(lifecycle.consumeReloadOnActive()).toBe(false);
+
+    lifecycle.onLoadStart();
+    lifecycle.onBackground();
+    expect(lifecycle.consumeReloadOnActive()).toBe(true);
+  });
+
   it('builds a video player document with controls and source metadata', () => {
     const html = buildMediaPlayerWebViewHtml({
       kind: 'video',

--- a/apps/mobile/src/__tests__/messageActionDesktopFirst.test.ts
+++ b/apps/mobile/src/__tests__/messageActionDesktopFirst.test.ts
@@ -120,6 +120,8 @@ describe('mobile message actions desktop-first surface', () => {
     const start = source.indexOf('function WorkGroupCard');
     const end = source.indexOf('function FoldablePanel', start);
     const workGroupSource = source.slice(start, end);
+    const expandedBodyStart = workGroupSource.indexOf('{expanded ? (');
+    const childrenMapStart = workGroupSource.indexOf('{item.children.map((child) => {');
 
     // 运行中用状态图标,结束后回到桌面同款 Layers 工作摘要图标。
     expect(source).toContain('Layers,');
@@ -128,10 +130,10 @@ describe('mobile message actions desktop-first surface', () => {
     expect(workGroupSource).toContain('chevronSize={header.chevronSize}');
     expect(workGroupSource).toContain('title={title}');
     expect(workGroupSource).toContain('subtitle={header.subtitle ?? undefined}');
-    // Work group 需要受控展开:运行中只在最近 5 条与全部历史之间切换。
+    // Work group 受控展开；折叠态只保留卡头，不提前构造任何隐藏活动行。
     expect(workGroupSource).not.toContain('defaultExpanded');
     expect(workGroupSource).toContain('controlledExpanded={expanded}');
-    expect(workGroupSource).toContain('collapsedBody={livePreview}');
+    expect(workGroupSource).not.toContain('collapsedBody=');
     expect(workGroupSource).toContain('onControlledToggle={onToggle}');
     expect(workGroupSource).not.toContain('live-preview-dismissed');
     expect(workGroupSource).toContain('? <CompactActivityIndicator color={colors.textTertiary}');
@@ -139,7 +141,9 @@ describe('mobile message actions desktop-first surface', () => {
     expect(workGroupSource).toContain('variant={header.variant}');
     expect(workGroupSource).toContain('summaryCount: header.summaryCount');
     expect(workGroupSource).toContain('<RenderItemView key={child.key} item={child} actions={actions} />');
-    expect(workGroupSource).toContain('projectRecentMobileWorkActivities(item.children, isStreaming, MAX_LIVE_WORK_ACTIVITIES)');
+    expect(workGroupSource).not.toContain('projectRecentMobileWorkActivities');
+    expect(expandedBodyStart).toBeGreaterThan(-1);
+    expect(childrenMapStart).toBeGreaterThan(expandedBodyStart);
     expect(workGroupSource).toContain('<ExpandedWorkThinkingRow key={child.key} item={child} />');
     expect(workGroupSource).toContain('activityProjection?.toolActivitiesByChildKey.get(child.key)');
     // thinking / tool 行都固定 28pt，外层不能再给 thinking 子项追加组间距。

--- a/apps/mobile/src/__tests__/messageActionDesktopFirst.test.ts
+++ b/apps/mobile/src/__tests__/messageActionDesktopFirst.test.ts
@@ -142,6 +142,9 @@ describe('mobile message actions desktop-first surface', () => {
     expect(workGroupSource).toContain('summaryCount: header.summaryCount');
     expect(workGroupSource).toContain('<RenderItemView key={child.key} item={child} actions={actions} />');
     expect(workGroupSource).not.toContain('projectRecentMobileWorkActivities');
+    expect(workGroupSource).toContain('() => (expanded');
+    expect(workGroupSource).not.toContain('expanded || !isStreaming');
+    expect(workGroupSource).toContain('const contentLayout = useMemo(() => (expanded');
     expect(expandedBodyStart).toBeGreaterThan(-1);
     expect(childrenMapStart).toBeGreaterThan(expandedBodyStart);
     expect(workGroupSource).toContain('<ExpandedWorkThinkingRow key={child.key} item={child} />');
@@ -367,8 +370,9 @@ describe('mobile message actions desktop-first surface', () => {
     expect(foldableSource).toContain('useFoldableExpandedState(blockId, defaultExpanded)');
     expect(thinkingSource).toContain('blockId={item.key}');
     expect(renderItemSource).toContain('<ToolGroupCard item={item} actions={actions} />');
-    // 思考卡接收会话流式信号,用于流式实时时长(对齐桌面 500ms tick)。
+    // 思考卡接收会话流式信号；界面只显示到秒，不需要半秒级刷新。
     expect(renderItemSource).toContain('isSessionStreaming={actions.isSessionStreaming === true}');
+    expect(source).toContain('setInterval(() => setNow(Date.now()), 1_000)');
   });
 
   it('does not render user or assistant role labels inside message bubbles', () => {

--- a/apps/mobile/src/__tests__/messageHistoryAnchor.test.ts
+++ b/apps/mobile/src/__tests__/messageHistoryAnchor.test.ts
@@ -1,0 +1,124 @@
+import { describe, expect, it } from 'vitest';
+import {
+  captureMobileHistoryAnchor,
+  isMobileHistoryAnchorSettled,
+  resolveMobileHistoryAnchorOffset,
+} from '@/session/messageHistoryAnchor';
+
+describe('messageHistoryAnchor', () => {
+  it('captures the first visible row in LegendList coordinates', () => {
+    const anchor = captureMobileHistoryAnchor({
+      data: [{ key: 'm1' }, { key: 'm2' }, { key: 'm3' }],
+      positionAtIndex: (index) => [0, 140, 320][index],
+      scroll: 170,
+      start: 1,
+    }, (item) => item.key);
+
+    expect(anchor).toEqual({
+      key: 'm2',
+      viewportOffset: -30,
+      fallbacks: [
+        { key: 'm3', viewportOffset: 150 },
+        { key: 'm1', viewportOffset: -170 },
+      ],
+    });
+  });
+
+  it('captures the closest measured row when LegendList has not resolved its visible range', () => {
+    expect(captureMobileHistoryAnchor({
+      data: [{ key: 'm1' }, { key: 'm2' }],
+      positionAtIndex: (index) => [40, 190][index],
+      scroll: 170,
+      start: -1,
+    }, (item) => item.key)).toEqual({
+      key: 'm2',
+      viewportOffset: 20,
+      fallbacks: [{ key: 'm1', viewportOffset: -130 }],
+    });
+  });
+
+  it('uses logarithmic position lookup and only captures nearby fallback rows', () => {
+    const positionReads: number[] = [];
+    const data = Array.from({ length: 800 }, (_, index) => ({ key: `m${index}` }));
+    const anchor = captureMobileHistoryAnchor({
+      data,
+      positionAtIndex: (index) => {
+        positionReads.push(index);
+        return index * 100;
+      },
+      scroll: 40_050,
+      start: -1,
+    }, (item) => item.key);
+
+    expect(anchor?.key).toBe('m400');
+    expect(anchor?.fallbacks).toHaveLength(7);
+    expect(positionReads.length).toBeLessThan(30);
+  });
+
+  it('bounds nearby probes when row positions are temporarily unavailable', () => {
+    let positionReads = 0;
+    const data = Array.from({ length: 800 }, (_, index) => ({ key: `m${index}` }));
+    expect(captureMobileHistoryAnchor({
+      data,
+      positionAtIndex: (index) => {
+        positionReads += 1;
+        return index === 400 ? 40_000 : undefined;
+      },
+      scroll: 40_000,
+      start: 400,
+    }, (item) => item.key)).toEqual({ key: 'm400', viewportOffset: 0 });
+    expect(positionReads).toBeLessThanOrEqual(24);
+  });
+
+  it('rejects a state with no measured rows', () => {
+    expect(captureMobileHistoryAnchor({
+      data: [{ key: 'm1' }],
+      positionAtIndex: () => undefined,
+      scroll: 0,
+      start: -1,
+    }, (item) => item.key)).toBeNull();
+  });
+
+  it('keeps the same row at the same viewport offset after a prepend', () => {
+    const target = resolveMobileHistoryAnchorOffset(
+      { key: 'm80', viewportOffset: -30 },
+      { positionByKey: (key) => key === 'm80' ? 11_300 : undefined },
+    );
+
+    expect(target).toBe(11_330);
+  });
+
+  it('re-resolves the target when older row measurements settle', () => {
+    const anchor = { key: 'm80', viewportOffset: 12 };
+    expect(resolveMobileHistoryAnchorOffset(anchor, {
+      positionByKey: () => 11_300,
+    })).toBe(11_288);
+    expect(resolveMobileHistoryAnchorOffset(anchor, {
+      positionByKey: () => 11_348,
+    })).toBe(11_336);
+  });
+
+  it('uses a nearby captured row if a live render group replaces the primary key', () => {
+    expect(resolveMobileHistoryAnchorOffset({
+      key: 'live-group-old',
+      viewportOffset: -30,
+      fallbacks: [{ key: 'm79', viewportOffset: 120 }],
+    }, {
+      positionByKey: (key) => key === 'm79' ? 11_500 : undefined,
+    })).toBe(11_380);
+  });
+
+  it('falls back to the current data index while LegendList rebuilds its key cache', () => {
+    expect(resolveMobileHistoryAnchorOffset({ key: 'm80', viewportOffset: -30 }, {
+      data: [{ key: 'older' }, { key: 'm80' }],
+      positionAtIndex: (index) => [0, 11_300][index],
+      positionByKey: () => undefined,
+    })).toBe(11_330);
+  });
+
+  it('requires both the scroll offset and target position to be stable', () => {
+    expect(isMobileHistoryAnchorSettled(11_330, 11_330, null, 2)).toBe(false);
+    expect(isMobileHistoryAnchorSettled(11_330, 11_330, 11_340, 2)).toBe(false);
+    expect(isMobileHistoryAnchorSettled(11_329, 11_330, 11_331, 2)).toBe(true);
+  });
+});

--- a/apps/mobile/src/__tests__/messageHistoryAnchor.test.ts
+++ b/apps/mobile/src/__tests__/messageHistoryAnchor.test.ts
@@ -2,8 +2,16 @@ import { describe, expect, it } from 'vitest';
 import {
   captureMobileHistoryAnchor,
   isMobileHistoryAnchorSettled,
+  mobileHistoryTopOffsetAdjustment,
   resolveMobileHistoryAnchorOffset,
 } from '@/session/messageHistoryAnchor';
+import {
+  mobileMessageHistoryAnchorIdentity,
+  mobileMessageHistoryOnlyExpandedFirstWorkGroup,
+  mobileMessageHistoryRowKeyByIdentity,
+} from '@/session/messageHistoryAnchorIdentity';
+import { buildMobileMessageRenderItems } from '@/session/messageRenderModel';
+import type { RemoteMessage } from '@/session/types';
 
 describe('messageHistoryAnchor', () => {
   it('captures the first visible row in LegendList coordinates', () => {
@@ -80,12 +88,48 @@ describe('messageHistoryAnchor', () => {
   });
 
   it('keeps the same row at the same viewport offset after a prepend', () => {
+    let identityScans = 0;
     const target = resolveMobileHistoryAnchorOffset(
-      { key: 'm80', viewportOffset: -30 },
-      { positionByKey: (key) => key === 'm80' ? 11_300 : undefined },
+      { key: 'm80', identityKey: 'leaf-m80', viewportOffset: -30 },
+      {
+        keyByIdentity: () => {
+          identityScans += 1;
+          return 'm80';
+        },
+        positionByKey: (key) => key === 'm80' ? 11_300 : undefined,
+      },
     );
 
     expect(target).toBe(11_330);
+    expect(identityScans).toBe(0);
+  });
+
+  it('recovers the align-at-end spacer for an under-one-screen list', () => {
+    expect(mobileHistoryTopOffsetAdjustment({
+      contentLength: 720,
+      data: [{ key: 'm1' }, { key: 'm2' }],
+      positionAtIndex: (index) => [0, 120][index],
+      scrollLength: 720,
+      sizeAtIndex: (index) => [96, 168][index],
+    }, {
+      baseTopOffset: 64,
+      bottomPadding: 32,
+      footerSize: 0,
+    })).toBe(400);
+  });
+
+  it('uses the explicit header and padding baseline once content overflows', () => {
+    expect(mobileHistoryTopOffsetAdjustment({
+      contentLength: 1_200,
+      data: [{ key: 'm1' }, { key: 'm2' }],
+      positionAtIndex: (index) => [0, 840][index],
+      scrollLength: 720,
+      sizeAtIndex: (index) => [816, 296][index],
+    }, {
+      baseTopOffset: 64,
+      bottomPadding: 32,
+      footerSize: 0,
+    })).toBe(64);
   });
 
   it('re-resolves the target when older row measurements settle', () => {
@@ -108,6 +152,51 @@ describe('messageHistoryAnchor', () => {
     })).toBe(11_380);
   });
 
+  it('resolves an aggregate row whose outer key changed after same-turn history was prepended', () => {
+    const before = buildMobileMessageRenderItems([
+      toolUse('tool-b', 2),
+      assistantMessage('answer', 3),
+    ]);
+    const after = buildMobileMessageRenderItems([
+      toolUse('tool-a', 1),
+      toolUse('tool-b', 2),
+      assistantMessage('answer', 3),
+    ]);
+    const beforeGroup = before[0];
+    const afterGroup = after[0];
+    expect(beforeGroup.type).toBe('work_group');
+    expect(afterGroup.type).toBe('work_group');
+    expect(after).toHaveLength(before.length);
+    expect(afterGroup.key).not.toBe(beforeGroup.key);
+
+    const identityKey = mobileMessageHistoryAnchorIdentity(beforeGroup);
+    expect(identityKey).toBeTruthy();
+    expect(mobileMessageHistoryRowKeyByIdentity(after, identityKey!)).toBe(afterGroup.key);
+    expect(mobileMessageHistoryOnlyExpandedFirstWorkGroup(before, before)).toBe(false);
+    expect(mobileMessageHistoryOnlyExpandedFirstWorkGroup(before, after)).toBe(true);
+    expect(mobileMessageHistoryOnlyExpandedFirstWorkGroup(before, buildMobileMessageRenderItems([
+      userMessage('earlier-user', 0),
+      toolUse('tool-a', 1),
+      toolUse('tool-b', 2),
+      assistantMessage('answer', 3),
+    ]))).toBe(false);
+    const anchor = captureMobileHistoryAnchor({
+      data: before,
+      positionAtIndex: (index) => [0, 180][index],
+      scroll: 0,
+      start: 0,
+      topOffsetAdjustment: 400,
+    }, (item) => item.key, mobileMessageHistoryAnchorIdentity);
+    expect(anchor?.key).toBe(beforeGroup.key);
+    expect(anchor?.viewportOffset).toBe(400);
+    expect(resolveMobileHistoryAnchorOffset(anchor!, {
+      data: after,
+      keyByIdentity: (identity) => mobileMessageHistoryRowKeyByIdentity(after, identity),
+      positionByKey: (key) => key === afterGroup.key ? 600 : undefined,
+      topOffsetAdjustment: 64,
+    })).toBe(264);
+  });
+
   it('falls back to the current data index while LegendList rebuilds its key cache', () => {
     expect(resolveMobileHistoryAnchorOffset({ key: 'm80', viewportOffset: -30 }, {
       data: [{ key: 'older' }, { key: 'm80' }],
@@ -122,3 +211,46 @@ describe('messageHistoryAnchor', () => {
     expect(isMobileHistoryAnchorSettled(11_329, 11_330, 11_331, 2)).toBe(true);
   });
 });
+
+function toolUse(id: string, seconds: number): RemoteMessage {
+  return {
+    id,
+    clientId: id,
+    sessionId: 's1',
+    role: 'tool_use',
+    content: {
+      toolUseId: id,
+      toolName: 'Read',
+      input: { file_path: `/${id}.ts` },
+    },
+    toolUseId: id,
+    agentMeta: null,
+    createdAt: `2026-01-01T00:00:0${seconds}.000Z`,
+  };
+}
+
+function assistantMessage(id: string, seconds: number): RemoteMessage {
+  return {
+    id,
+    clientId: id,
+    sessionId: 's1',
+    role: 'assistant',
+    content: 'done',
+    toolUseId: null,
+    agentMeta: null,
+    createdAt: `2026-01-01T00:00:0${seconds}.000Z`,
+  };
+}
+
+function userMessage(id: string, seconds: number): RemoteMessage {
+  return {
+    id,
+    clientId: id,
+    sessionId: 's1',
+    role: 'user',
+    content: id,
+    toolUseId: null,
+    agentMeta: null,
+    createdAt: `2026-01-01T00:00:0${seconds}.000Z`,
+  };
+}

--- a/apps/mobile/src/__tests__/messageListVirtualization.test.ts
+++ b/apps/mobile/src/__tests__/messageListVirtualization.test.ts
@@ -22,16 +22,14 @@ describe('mobile message list container', () => {
     // 估高 + 小预渲窗口:挂载集小、mount 帧压进一帧(不可退回大挂载树)。
     expect(listSource).toContain('estimatedItemSize={MOBILE_MESSAGE_ESTIMATED_ITEM_SIZE}');
     expect(listSource).toContain('drawDistance={MOBILE_MESSAGE_DRAW_DISTANCE}');
-    // 首批 cell 必须从尾部创建；否则长任务会先在顶部创建少量 cell，再花数秒测量/补滚到底。
-    // 完整 render model 仍供业务逻辑使用，LegendList 首帧只接尾部 4 项；用户上翻时
-    // 再按 12 项小块 prepend，不能在首绘后一次灌回完整长任务。
-    expect(source).toContain('const MOBILE_INITIAL_TAIL_ITEM_COUNT = 4;');
-    expect(source).toContain('const MOBILE_TAIL_REVEAL_ITEM_COUNT = 12;');
-    expect(source).toContain('const [tailWindowAnchor, setTailWindowAnchor] = useState<{');
-    expect(source).toContain('listData.slice(tailWindowStartIndex)');
-    expect(source).toContain('tailWindowStartIndex - MOBILE_TAIL_REVEAL_ITEM_COUNT');
-    expect(listSource).toContain('data={visibleListData}');
-    expect(source).not.toContain('const initialTailTarget = useMemo(');
+    // 完整历史始终交给 LegendList，由其虚拟化/回收屏外 cell；初始位置使用原生
+    // offset-only 路径，不能退回会长时间隐藏 cell 的 index/end 测量 bootstrap。
+    expect(listSource).toContain('data={listData}');
+    expect(source).toContain('const initialScrollOffset = useMemo(() => {');
+    expect(listSource).toContain('initialScrollOffset={initialScrollOffset}');
+    expect(source).not.toContain('listData.slice(');
+    expect(source).not.toContain('MOBILE_INITIAL_TAIL_ITEM_COUNT');
+    expect(source).not.toContain('MOBILE_TAIL_REVEAL_ITEM_COUNT');
     expect(listSource).not.toMatch(/\binitialScrollIndex\s*=/);
     expect(listSource).not.toMatch(/\binitialScrollAtEnd\s*=/);
     // 内置贴底 + prepend 防跳(替代手搓 open-settle / follow rAF / prepend-settle,勿回潮)。
@@ -67,7 +65,7 @@ describe('mobile message list container', () => {
     expect(focusEffectSource).toContain('lastAutoLoadEarlierKeyRef.current = null');
   });
 
-  it('protects follow state while revealing the local tail window in bounded chunks', () => {
+  it('protects follow state while applying a visible offset-only initial position', () => {
     const source = readFileSync(resolve(process.cwd(), 'src/session/MessageRenderer.tsx'), 'utf8');
     expect(source).toContain('programmaticScrollInFlight: programmaticScrollInFlightRef.current');
     expect(source).toContain('evaluateMobileAnchorVerify({');
@@ -83,24 +81,16 @@ describe('mobile message list container', () => {
     expect(source.match(/isMobileMvcpSettling\(Date\.now\(\), mvcpSettleAtRef\.current\)/g))
       .toHaveLength(1);
 
-    // 冷开的空列表不能吞掉真实首批消息的尾部索引；empty → ready 明确重挂一次。
+    // 冷开的空列表不能吞掉真实首批消息的初始 offset；empty → ready 明确重挂一次。
     expect(source).toContain("listData.length === 0 ? 'empty' : 'ready'");
     expect(source).toContain('key={listMountKey}');
-    expect(source).toContain('setTailWindowAnchor({ identity: listMountKey, firstKey: nextFirstKey })');
-    expect(source).toContain('if (userScrollForOlderRef.current) revealEarlierTailWindow();');
-    expect(source).toContain('revealEarlierTailWindow(true);');
-    expect(source).toContain('if (initialTailWindowActive) return;');
-    expect(source).toContain('previousUserMessageJumpTargetForWindow(');
-    expect(source).toContain('if (previousUserTarget.windowIndex !== null)');
-    expect(source).toContain('revealTailWindowFromIndex(previousUserTarget.index)');
-    expect(source).toContain(
-      '!initialTailWindowActive && loadEarlierAction.visible',
-    );
-    // 非空尾窗一挂载就直接显示；完整数组的后台接回不能用 overlay / opacity 再把
-    // 已经创建好的 cell 遮住。只有 data 仍为空的真实同步期才显示 SyncingMessages。
+    expect(source).not.toContain('tailWindowAnchor');
+    expect(source).toContain('previousUserMessageJumpTarget(listData, firstVisibleIndex)');
+    // 非空完整列表直接显示；不能用 overlay / opacity 再把已经创建好的 cell 遮住。
+    // 只有 data 仍为空的真实同步期才显示 SyncingMessages。
     expect(source).not.toContain('initialTailLoadingOverlay');
-    // 普通 index=0 首绘完成后才做一次贴底校正并交给 content-size 跟随。列表不使用
-    // initialScrollIndex、opacity 或 timer 遮罩，因此 JS 忙也不会白屏。
+    // offset-only 首绘完成后做一次贴底校正并交给 content-size 跟随。列表不使用
+    // initialScrollIndex、业务 opacity 或 timer 遮罩，因此 JS 忙也不会白屏。
     expect(source).toContain('onLoad={handleListLoad}');
     expect(source).toContain('if (!initialListReadyRef.current) return;');
     expect(source).not.toContain('messageListSettling');

--- a/apps/mobile/src/__tests__/messageListVirtualization.test.ts
+++ b/apps/mobile/src/__tests__/messageListVirtualization.test.ts
@@ -26,16 +26,20 @@ describe('mobile message list container', () => {
     expect(listSource).toContain('alignItemsAtEnd');
     expect(listSource).toContain('maintainScrollAtEnd');
     expect(listSource).toContain('maintainVisibleContentPosition={{ data: true, size: true }}');
-    // cell 含内部 state(展开态 / 手势图 / mermaid·math WebView),关闭回收避免实例错误复用。
-    expect(source).toContain('const recycleItems = __DEV__ && devRecycleItems === true;');
+    // Release 开启 native cell 回收；DEV 仍保留 listperf 的 on/off 单变量开关。
+    // item type 分池 + recycling-aware state 防止菜单/展开态/媒体状态串到另一条消息。
+    expect(source).toContain('const recycleItems = __DEV__ ? devRecycleItems === true : true;');
     expect(listSource).toContain('recycleItems={recycleItems}');
+    expect(listSource).toContain('getItemType={mobileMessageListItemType}');
+    expect(source).toContain('useRecyclingState');
     // 上滑加载:LegendList 近顶阈值触发自动预取(替代手搓的滚动 metric 判定)。
     expect(listSource).toContain('onStartReached={handleStartReached}');
     // 自动预取必须是电平判定(shouldAutoLoadEarlier + 多时机重评估),不许退回只吃 onStartReached
     // 边沿——边沿被业务 guard 吞掉后条件再就绪也等不到下一个边沿(顶部停留永不加载的回归)。
     expect(source).toContain('shouldAutoLoadEarlier({');
-    // 冷开允许有限补页,把短初窗上方历史自动补齐；预算耗尽或首项无进展即停止。
+    // 冷开只在列表同时贴住 start/end(首屏未填满)时有限补页。
     expect(source).toContain('MAX_INITIAL_HISTORY_AUTOFILL_PAGES');
+    expect(source).toContain('atStart: listState.isAtStart');
     expect(source).toContain('initialHistoryAutofillRemainingRef.current -= 1');
     // 所有 prepend 在请求期间抑制贴底，成功/空页/失败后延迟一帧释放；generation
     // 防止旧会话请求 settle 后误清新会话 / 新请求状态。
@@ -66,6 +70,21 @@ describe('mobile message list container', () => {
     expect(source).not.toContain('[itemKeys, markMobileMvcpSettle]');
     expect(source.match(/isMobileMvcpSettling\(Date\.now\(\), mvcpSettleAtRef\.current\)/g))
       .toHaveLength(2);
+  });
+
+  it('resets identity-bound row state before a recycled cell displays another item', () => {
+    const source = readFileSync(resolve(process.cwd(), 'src/session/MessageRenderer.tsx'), 'utf8');
+    const bubbleStart = source.indexOf('function MessageBubble');
+    const bubbleEnd = source.indexOf('function copyActionLabel', bubbleStart);
+    const bubbleSource = source.slice(bubbleStart, bubbleEnd);
+
+    expect(bubbleSource).toContain('useRecyclingState<CopyMessageStatus');
+    expect(bubbleSource).toContain('useRecyclingState(false)');
+    expect(bubbleSource).toContain('useRecyclingState<{');
+    expect(bubbleSource).toContain('useRecyclingState<string | null>(null)');
+    expect(source).toContain('const [contentWidth, setContentWidth] = useRecyclingState(0);');
+    expect(source).toContain('const [resolveState, setResolveState] = useRecyclingState<MediaThumbnailResolveState>');
+    expect(source).toContain('const [recycledLocalExpanded, setRecycledLocalExpanded] = useRecyclingState(defaultExpanded);');
   });
 
   it('clears stale history intent before verifying an explicit follow-latest request', () => {

--- a/apps/mobile/src/__tests__/messageListVirtualization.test.ts
+++ b/apps/mobile/src/__tests__/messageListVirtualization.test.ts
@@ -8,6 +8,7 @@ import { describe, expect, it } from 'vitest';
 describe('mobile message list container', () => {
   it('uses LegendList virtualization with app-owned history anchoring', () => {
     const source = readFileSync(resolve(process.cwd(), 'src/session/MessageRenderer.tsx'), 'utf8');
+    const perfHarness = readFileSync(resolve(process.cwd(), 'app/listperf.tsx'), 'utf8');
 
     // 已完全迁出 FlatList:不再出现 FlatList 容器,也不再有其虚拟化专有 prop。
     expect(source).not.toContain('<FlatList');
@@ -57,6 +58,7 @@ describe('mobile message list container', () => {
     // item type 分池 + recycling-aware state 防止菜单/展开态/媒体状态串到另一条消息。
     expect(source).toContain('devRecycleItems = true,');
     expect(source).toContain('const recycleItems = __DEV__ ? devRecycleItems === true : true;');
+    expect(perfHarness).toContain("const recycle = params.recycle !== '0';");
     expect(listSource).toContain('recycleItems={recycleItems}');
     expect(listSource).toContain('getItemType={mobileMessageListItemType}');
     expect(source).toContain('useRecyclingState');

--- a/apps/mobile/src/__tests__/messageListVirtualization.test.ts
+++ b/apps/mobile/src/__tests__/messageListVirtualization.test.ts
@@ -80,6 +80,13 @@ describe('mobile message list container', () => {
     // 自动预取必须是电平判定(shouldAutoLoadEarlier + 多时机重评估),不许退回只吃 onStartReached
     // 边沿——边沿被业务 guard 吞掉后条件再就绪也等不到下一个边沿(顶部停留永不加载的回归)。
     expect(source).toContain('shouldAutoLoadEarlier({');
+    expect(source).toContain('MOBILE_SCROLL_HISTORY_EVALUATION_INTERVAL_MS = 64');
+    expect(source).toContain('now - lastScrollHistoryEvaluationAtRef.current');
+    expect(source).toContain('nativeMetrics.offsetY > MOBILE_ANCHOR_VERIFY_TOLERANCE');
+    expect(source).toContain('pendingScrollHistoryMetricsRef.current = nativeMetrics;');
+    expect(source).toContain('attemptAutoLoadEarlierRef.current(pendingMetrics ?? undefined);');
+    expect(source).toContain('if (hasNewMessagesRef.current === next) return;');
+    expect(source).toContain('if (isAwayFromBottomRef.current === next) return;');
     // 冷开只在列表同时贴住 start/end(首屏未填满)时有限补页。
     expect(source).toContain('MAX_INITIAL_HISTORY_AUTOFILL_PAGES');
     expect(source).toContain('const initialAutoFillAllowed = listRevealed');
@@ -199,7 +206,10 @@ describe('mobile message list container', () => {
 
     expect(source).toContain('key={scrollResetKey}');
     expect(source).not.toContain('tailWindowAnchor');
-    expect(source).toContain('previousUserMessageJumpTarget(listData, firstVisibleIndex)');
+    expect(source).toContain('previousUserMessageJumpTarget(listDataRef.current, firstVisibleIndexRef.current)');
+    expect(source).toContain('firstVisibleIndexRef.current = info.index;');
+    expect(source).not.toContain('setFirstVisibleIndex');
+    expect(source).toContain('refreshPreviousUserTarget();');
     // 首次校正仍会命令式落底，但 opacity 揭示必须立即交给 UI-thread native driver；
     // 复杂消息占满 JS 时不能把 300ms 隐藏窗拖成长达数秒的白屏。
     expect(source).not.toContain('onLoad={handleListLoad}');
@@ -225,6 +235,10 @@ describe('mobile message list container', () => {
 
   it('resets identity-bound row state before a recycled cell displays another item', () => {
     const source = readFileSync(resolve(process.cwd(), 'src/session/MessageRenderer.tsx'), 'utf8');
+    const expandedStateSource = readFileSync(
+      resolve(process.cwd(), 'src/session/expandedBlockMemory.ts'),
+      'utf8',
+    );
     const bubbleStart = source.indexOf('function MessageBubble');
     const bubbleEnd = source.indexOf('function copyActionLabel', bubbleStart);
     const bubbleSource = source.slice(bubbleStart, bubbleEnd);
@@ -236,6 +250,7 @@ describe('mobile message list container', () => {
     expect(source).toContain('const [contentWidth, setContentWidth] = useRecyclingState(0);');
     expect(source).toContain('const [resolveState, setResolveState] = useRecyclingState<MediaThumbnailResolveState>');
     expect(source).toContain('const [recycledLocalExpanded, setRecycledLocalExpanded] = useRecyclingState(defaultExpanded);');
+    expect(expandedStateSource).toContain('blockId ? store.subscribe(listener) : () => {}');
   });
 
   it('clears stale history intent before verifying an explicit follow-latest request', () => {

--- a/apps/mobile/src/__tests__/messageListVirtualization.test.ts
+++ b/apps/mobile/src/__tests__/messageListVirtualization.test.ts
@@ -16,7 +16,9 @@ describe('mobile message list container', () => {
 
     const listStart = source.search(/<LegendList\s/);
     expect(listStart).toBeGreaterThan(-1);
-    const listSource = source.slice(listStart, source.indexOf('onViewableItemsChanged', listStart));
+    const listEnd = source.indexOf('      />', listStart);
+    expect(listEnd).toBeGreaterThan(listStart);
+    const listSource = source.slice(listStart, listEnd);
 
     // 估高 + 小预渲窗口:挂载集小、mount 帧压进一帧(不可退回大挂载树)。
     expect(listSource).toContain('estimatedItemSize={MOBILE_MESSAGE_ESTIMATED_ITEM_SIZE}');
@@ -39,7 +41,11 @@ describe('mobile message list container', () => {
     expect(listSource).toContain('? false');
     expect(listSource).toContain(': { data: true, size: true }}');
     expect(source).toContain('captureMobileHistoryAnchor(');
-    expect(source).toContain('resolveMobileHistoryAnchorOffset(anchor, listState)');
+    expect(source).toContain('resolveMobileMessageHistoryAnchorOffset(');
+    expect(source).toContain('getCurrentHistoryTopOffsetAdjustment()');
+    expect(source).toContain('onMetricsChange={handleListMetricsChange}');
+    expect(source).toContain('mobileMessageHistoryAnchorIdentity(item as MobileMessageRenderItem)');
+    expect(source).toContain('mobileMessageHistoryRowKeyByIdentity(');
     expect(source).toContain('scheduleHistoryAnchorRestore(transaction.generation)');
     const historyRestoreStart = source.indexOf('const scheduleHistoryAnchorRestore = useCallback');
     const historyRestoreStep = source.indexOf('const step = (', historyRestoreStart);
@@ -47,12 +53,26 @@ describe('mobile message list container', () => {
     expect(historyRestoreSetup).toContain('if (historyAnchorVerifyFrameRef.current !== null) return;');
     expect(historyRestoreSetup).not.toContain('cancelAnimationFrame(historyAnchorVerifyFrameRef.current)');
     expect(source).toContain('useLayoutEffect(() => {');
-    // Release 开启 native cell 回收；DEV 仍保留 listperf 的 on/off 单变量开关。
+    // 普通 Release/DEV 详情页都开启 native cell 回收；listperf 仍可显式做 on/off A/B。
     // item type 分池 + recycling-aware state 防止菜单/展开态/媒体状态串到另一条消息。
+    expect(source).toContain('devRecycleItems = true,');
     expect(source).toContain('const recycleItems = __DEV__ ? devRecycleItems === true : true;');
     expect(listSource).toContain('recycleItems={recycleItems}');
     expect(listSource).toContain('getItemType={mobileMessageListItemType}');
     expect(source).toContain('useRecyclingState');
+    // 可见性必须由 cell 自己订阅。把可见 key 集合放进 React Context 会在每个
+    // onViewableItemsChanged 回调里广播给所有已挂载长消息，快滑时造成整窗重渲染、GC 和白屏。
+    expect(source).not.toContain('MessageListVisibleKeysContext');
+    expect(source).not.toContain('visibleMessageKeys');
+    expect(source).toContain("const MESSAGE_LIST_VIEWABILITY_CONFIG_ID = 'message-heavy-content';");
+    expect(source).toContain('id: MESSAGE_LIST_VIEWABILITY_CONFIG_ID');
+    expect(source).toContain('useViewability<MobileMessageRenderItem>(');
+    expect(source).toContain('MESSAGE_LIST_VIEWABILITY_CONFIG_ID,');
+    expect(source).toContain('const [isViewable, setIsViewable] = useRecyclingState(false);');
+    expect(source).toContain('if (token.key !== itemKeyRef.current) return;');
+    expect(source).toContain('maxTextRunInlineFragments: ANDROID_SELECTABLE_TEXT_RUN_MAX_INLINE_FRAGMENTS');
+    expect(listSource).toContain('onFirstVisibleItemChanged={handleFirstVisibleItemChangedRef.current}');
+    expect(listSource).not.toContain('onViewableItemsChanged=');
     // 上滑加载:LegendList 近顶阈值触发自动预取(替代手搓的滚动 metric 判定)。
     expect(listSource).toContain('onStartReached={handleStartReached}');
     // 自动预取必须是电平判定(shouldAutoLoadEarlier + 多时机重评估),不许退回只吃 onStartReached
@@ -73,7 +93,8 @@ describe('mobile message list container', () => {
     expect(source).toContain('onTouchCancel={handleHistoryTouchCancel}');
     expect(listSource).not.toContain('onTouchMove={handleHistoryTouchMove}');
     expect(source).toContain('if (readingOlderRef.current || queuedLoadEarlierRef.current) return;');
-    expect(source).toContain('const firstItemKey = loadEarlierProgressKey ?? itemKeys[0] ?? null;');
+    expect(source).toContain('const firstItemKey = itemKeys[0] ?? null;');
+    expect(source).toContain('const historyProgressKey = loadEarlierProgressKey ?? firstItemKey;');
     expect(source).toContain('initialHistoryAutofillRemainingRef.current -= 1');
     // 所有 prepend 在请求、新页提交和锚点恢复期间抑制贴底。Promise settlement 强制
     // 一次 render，layout effect 确认新 cursor 已提交后才允许释放；generation 隔离旧请求。
@@ -81,12 +102,19 @@ describe('mobile message list container', () => {
     expect(source).toContain('readingOlderRef.current = true');
     expect(source).toContain('void Promise.resolve(result).then(');
     expect(source).toContain('transaction.promiseSettled = true');
-    expect(source).toContain('transaction.startProgressKey !== firstItemKey');
+    expect(source).toContain('transaction.startProgressKey !== historyProgressKey');
     expect(source).toContain('transaction.pageCommitted = true');
     expect(source).toContain('transaction.anchorStable = true');
     expect(source).toContain('loadingEarlierRef.current || !transaction.promiseSettled');
     expect(source).toContain('setLoadEarlierEvaluationVersion((version) => version + 1);');
     expect(source).toContain('[attemptAutoLoadEarlier, loadEarlierEvaluationVersion]');
+    // 若一页只扩进顶部折叠的 Worked for，事务保位不能改变 main 的连续分页语义：
+    // 锚点稳定后绕过一次 near-start 复判继续拉，直到出现可见顶层历史或到头。
+    expect(source).toContain('mobileMessageHistoryOnlyExpandedFirstWorkGroup(');
+    expect(source).toContain('regroupedHistoryContinuationRef.current = transaction.continueAfterRegroup');
+    expect(source).toContain('const continueAfterRegroup = userScrolledForOlder');
+    expect(source).toContain('if (continueAfterRegroup) {');
+    expect(source).not.toContain('message.historyLoadConfirmation');
     expect(source).toContain('MOBILE_HISTORY_ANCHOR_VERIFY_MAX_FRAMES');
     expect(source).toContain('MOBILE_HISTORY_ANCHOR_VERIFY_MAX_MS');
     expect(source).toContain('Date.now() < currentTransaction.verifyDeadlineAt');

--- a/apps/mobile/src/__tests__/messageListVirtualization.test.ts
+++ b/apps/mobile/src/__tests__/messageListVirtualization.test.ts
@@ -22,6 +22,18 @@ describe('mobile message list container', () => {
     // 估高 + 小预渲窗口:挂载集小、mount 帧压进一帧(不可退回大挂载树)。
     expect(listSource).toContain('estimatedItemSize={MOBILE_MESSAGE_ESTIMATED_ITEM_SIZE}');
     expect(listSource).toContain('drawDistance={MOBILE_MESSAGE_DRAW_DISTANCE}');
+    // 首批 cell 必须从尾部创建；否则长任务会先在顶部创建少量 cell，再花数秒测量/补滚到底。
+    // 完整 render model 仍供业务逻辑使用，LegendList 首帧只接尾部 4 项；用户上翻时
+    // 再按 12 项小块 prepend，不能在首绘后一次灌回完整长任务。
+    expect(source).toContain('const MOBILE_INITIAL_TAIL_ITEM_COUNT = 4;');
+    expect(source).toContain('const MOBILE_TAIL_REVEAL_ITEM_COUNT = 12;');
+    expect(source).toContain('const [tailWindowAnchor, setTailWindowAnchor] = useState<{');
+    expect(source).toContain('listData.slice(tailWindowStartIndex)');
+    expect(source).toContain('tailWindowStartIndex - MOBILE_TAIL_REVEAL_ITEM_COUNT');
+    expect(listSource).toContain('data={visibleListData}');
+    expect(source).not.toContain('const initialTailTarget = useMemo(');
+    expect(listSource).not.toMatch(/\binitialScrollIndex\s*=/);
+    expect(listSource).not.toMatch(/\binitialScrollAtEnd\s*=/);
     // 内置贴底 + prepend 防跳(替代手搓 open-settle / follow rAF / prepend-settle,勿回潮)。
     expect(listSource).toContain('alignItemsAtEnd');
     expect(listSource).toContain('maintainScrollAtEnd');
@@ -55,21 +67,45 @@ describe('mobile message list container', () => {
     expect(focusEffectSource).toContain('lastAutoLoadEarlierKeyRef.current = null');
   });
 
-  it('protects follow state while imperative scroll and verifies the cold-open anchor', () => {
+  it('protects follow state while revealing the local tail window in bounded chunks', () => {
     const source = readFileSync(resolve(process.cwd(), 'src/session/MessageRenderer.tsx'), 'utf8');
     expect(source).toContain('programmaticScrollInFlight: programmaticScrollInFlightRef.current');
     expect(source).toContain('evaluateMobileAnchorVerify({');
-    expect(source).toContain('initialAnchorVerifyFrameRef');
+    expect(source).not.toContain('initialAnchorVerifyFrameRef');
     expect(source).toContain('scrollToEndProgrammatically(false)');
     // mVCP 对 data / size 都常开；普通尾部追加与流式 resize 必须先记 settle 安静窗，
-    // 两套 verifier 都不能再只依赖 readingOlderRef 判断是否等待。
+    // 跟随 verifier 不能只依赖 readingOlderRef 判断是否等待。
     expect(source).toContain('mvcpSettleAtRef.current = mobileMvcpSettleDeadline(');
     expect(source).toContain('markMobileMvcpSettle();');
     expect(source).toContain('mobileMessageListKeysSignature(itemKeys)');
     expect(source).toContain('[itemKeysSignature, markMobileMvcpSettle]');
     expect(source).not.toContain('[itemKeys, markMobileMvcpSettle]');
     expect(source.match(/isMobileMvcpSettling\(Date\.now\(\), mvcpSettleAtRef\.current\)/g))
-      .toHaveLength(2);
+      .toHaveLength(1);
+
+    // 冷开的空列表不能吞掉真实首批消息的尾部索引；empty → ready 明确重挂一次。
+    expect(source).toContain("listData.length === 0 ? 'empty' : 'ready'");
+    expect(source).toContain('key={listMountKey}');
+    expect(source).toContain('setTailWindowAnchor({ identity: listMountKey, firstKey: nextFirstKey })');
+    expect(source).toContain('if (userScrollForOlderRef.current) revealEarlierTailWindow();');
+    expect(source).toContain('revealEarlierTailWindow(true);');
+    expect(source).toContain('if (initialTailWindowActive) return;');
+    expect(source).toContain('previousUserMessageJumpTargetForWindow(');
+    expect(source).toContain('if (previousUserTarget.windowIndex !== null)');
+    expect(source).toContain('revealTailWindowFromIndex(previousUserTarget.index)');
+    expect(source).toContain(
+      '!initialTailWindowActive && loadEarlierAction.visible',
+    );
+    // 非空尾窗一挂载就直接显示；完整数组的后台接回不能用 overlay / opacity 再把
+    // 已经创建好的 cell 遮住。只有 data 仍为空的真实同步期才显示 SyncingMessages。
+    expect(source).not.toContain('initialTailLoadingOverlay');
+    // 普通 index=0 首绘完成后才做一次贴底校正并交给 content-size 跟随。列表不使用
+    // initialScrollIndex、opacity 或 timer 遮罩，因此 JS 忙也不会白屏。
+    expect(source).toContain('onLoad={handleListLoad}');
+    expect(source).toContain('if (!initialListReadyRef.current) return;');
+    expect(source).not.toContain('messageListSettling');
+    expect(source).not.toContain('MOBILE_INITIAL_ANCHOR_SETTLE_MS');
+    expect(source).not.toContain('MOBILE_INITIAL_ANCHOR_REVEAL_MAX_MS');
   });
 
   it('resets identity-bound row state before a recycled cell displays another item', () => {

--- a/apps/mobile/src/__tests__/messageListVirtualization.test.ts
+++ b/apps/mobile/src/__tests__/messageListVirtualization.test.ts
@@ -4,10 +4,9 @@ import { describe, expect, it } from 'vitest';
 
 // 消息列表容器契约:LegendList(替代 FlatList —— 滚动 mount 卡顿的实测解,见 listperf profiling:
 // windowSize=21 的大挂载树 p95≈167ms/jank46,换 LegendList 小预渲窗口后 p95≈20ms/jank4)。
-// 关键 prop 不可回退:估高 + 小 drawDistance(挂载集小)+ 内置贴底/防跳(替代已删除的手搓 open-settle
-// / follow rAF / prepend-settle 锚定机制)。
+// 关键 prop 不可回退:估高 + 小 drawDistance(挂载集小)+ 尺寸锚定 + 应用层 prepend 事务。
 describe('mobile message list container', () => {
-  it('uses LegendList with estimated-size virtualization and built-in chat anchoring', () => {
+  it('uses LegendList virtualization with app-owned history anchoring', () => {
     const source = readFileSync(resolve(process.cwd(), 'src/session/MessageRenderer.tsx'), 'utf8');
 
     // 已完全迁出 FlatList:不再出现 FlatList 容器,也不再有其虚拟化专有 prop。
@@ -32,10 +31,22 @@ describe('mobile message list container', () => {
     expect(source).not.toContain('MOBILE_INITIAL_TAIL_ITEM_COUNT');
     expect(source).not.toContain('MOBILE_TAIL_REVEAL_ITEM_COUNT');
     expect(listSource).not.toMatch(/\binitialScrollIndex\s*=/);
-    // 内置贴底 + prepend 防跳(替代手搓 open-settle / follow rAF / prepend-settle,勿回潮)。
+    // Manual data prepend 不能与 Android native MVCP 并行:它会在 cell 位置提交后异步补
+    // offset，中间坐标窗无 cell 而白屏。普通 data / size 变化仍由 LegendList 锚定。
     expect(listSource).toContain('alignItemsAtEnd');
     expect(listSource).toContain('maintainScrollAtEnd');
-    expect(listSource).toContain('maintainVisibleContentPosition={{ data: true, size: true }}');
+    expect(listSource).toContain('maintainVisibleContentPosition={historyPrependNativeMvcpDisabled');
+    expect(listSource).toContain('? false');
+    expect(listSource).toContain(': { data: true, size: true }}');
+    expect(source).toContain('captureMobileHistoryAnchor(');
+    expect(source).toContain('resolveMobileHistoryAnchorOffset(anchor, listState)');
+    expect(source).toContain('scheduleHistoryAnchorRestore(transaction.generation)');
+    const historyRestoreStart = source.indexOf('const scheduleHistoryAnchorRestore = useCallback');
+    const historyRestoreStep = source.indexOf('const step = (', historyRestoreStart);
+    const historyRestoreSetup = source.slice(historyRestoreStart, historyRestoreStep);
+    expect(historyRestoreSetup).toContain('if (historyAnchorVerifyFrameRef.current !== null) return;');
+    expect(historyRestoreSetup).not.toContain('cancelAnimationFrame(historyAnchorVerifyFrameRef.current)');
+    expect(source).toContain('useLayoutEffect(() => {');
     // Release 开启 native cell 回收；DEV 仍保留 listperf 的 on/off 单变量开关。
     // item type 分池 + recycling-aware state 防止菜单/展开态/媒体状态串到另一条消息。
     expect(source).toContain('const recycleItems = __DEV__ ? devRecycleItems === true : true;');
@@ -49,6 +60,7 @@ describe('mobile message list container', () => {
     expect(source).toContain('shouldAutoLoadEarlier({');
     // 冷开只在列表同时贴住 start/end(首屏未填满)时有限补页。
     expect(source).toContain('MAX_INITIAL_HISTORY_AUTOFILL_PAGES');
+    expect(source).toContain('const initialAutoFillAllowed = listRevealed');
     expect(source).toContain('atStart: listState.isAtStart');
     expect(source).toContain('listState.isAtStart || nativeAtStart');
     expect(source).toContain('listState.isNearStart || nativeNearStart');
@@ -60,37 +72,75 @@ describe('mobile message list container', () => {
     expect(source).toContain('onTouchEnd={handleHistoryTouchEnd}');
     expect(source).toContain('onTouchCancel={handleHistoryTouchCancel}');
     expect(listSource).not.toContain('onTouchMove={handleHistoryTouchMove}');
-    expect(source).toContain('if (readingOlderRef.current) return;');
+    expect(source).toContain('if (readingOlderRef.current || queuedLoadEarlierRef.current) return;');
     expect(source).toContain('const firstItemKey = loadEarlierProgressKey ?? itemKeys[0] ?? null;');
     expect(source).toContain('initialHistoryAutofillRemainingRef.current -= 1');
-    // 所有 prepend 在请求和新页提交期间抑制贴底；只有 loadingEarlier 的完成态进入
-    // 当前 render commit 后才延迟释放。generation 防止旧请求误清新会话 / 新请求。
+    // 所有 prepend 在请求、新页提交和锚点恢复期间抑制贴底。Promise settlement 强制
+    // 一次 render，layout effect 确认新 cursor 已提交后才允许释放；generation 隔离旧请求。
     expect(source).toContain('onLoadEarlier?: () => void | Promise<void>');
     expect(source).toContain('readingOlderRef.current = true');
-    expect(source).toContain('readingOlderLoadingObservedRef.current = true');
     expect(source).toContain('void Promise.resolve(result).then(');
-    expect(source).toContain('const releaseAfterRequestSettles = () => {');
-    expect(source).toContain('scheduleReadingOlderRelease(readingOlderRequestGenerationRef.current)');
-    expect(source).toContain('readingOlderRequestGenerationRef.current === generation');
-    expect(source).toContain('!loadingEarlierRef.current');
-    // The settle deadline bounds only native prepend layout. It must never unlock while a slow
-    // active-session page still reports loadingEarlier=true.
-    expect(source).toContain('if (loadingEarlierRef.current) {');
-    expect(source).toContain('readingOlderReleaseDeadlineRef.current = 0;');
-    expect(source).not.toContain('|| Date.now() >= readingOlderReleaseDeadlineRef.current');
+    expect(source).toContain('transaction.promiseSettled = true');
+    expect(source).toContain('transaction.startProgressKey !== firstItemKey');
+    expect(source).toContain('transaction.pageCommitted = true');
+    expect(source).toContain('transaction.anchorStable = true');
+    expect(source).toContain('loadingEarlierRef.current || !transaction.promiseSettled');
     expect(source).toContain('setLoadEarlierEvaluationVersion((version) => version + 1);');
     expect(source).toContain('[attemptAutoLoadEarlier, loadEarlierEvaluationVersion]');
-    expect(source).toMatch(/Math\.min\(\r?\n\s+mvcpSettleAtRef\.current,/);
-    expect(source).toContain('MOBILE_HISTORY_PREPEND_SETTLE_MAX_MS');
-    const loadEarlierStart = source.indexOf('const requestLoadEarlier = useCallback');
-    const loadEarlierEnd = source.indexOf('const attemptAutoLoadEarlier', loadEarlierStart);
-    const loadEarlierSource = source.slice(loadEarlierStart, loadEarlierEnd);
-    expect(loadEarlierSource).toContain('if (userScrollForOlderRef.current)');
-    expect(loadEarlierSource).toContain('nearBottomRef.current = false');
+    expect(source).toContain('MOBILE_HISTORY_ANCHOR_VERIFY_MAX_FRAMES');
+    expect(source).toContain('MOBILE_HISTORY_ANCHOR_VERIFY_MAX_MS');
+    expect(source).toContain('Date.now() < currentTransaction.verifyDeadlineAt');
+    expect(source).toContain('Complex pages can keep refining estimates beyond the retry window');
+    expect(source).toContain('if (finalTarget !== null) scrollToOffsetProgrammatically(finalTarget, false);');
+    expect(source).toContain('const restoreHistoryAnchorOnce = useCallback');
+    expect(source).toContain('restoreHistoryAnchorOnce(transaction.generation)');
+    expect(source).toContain('transaction.userControlledAfterCommit = true');
+    // 直接拖动结束前不发请求，避免远端页在手指仍控制 ScrollView 时落地。
+    expect(source).toContain('queuedLoadEarlierRef.current = true');
+    expect(source).toContain('setHistoryPrependNativeMvcpDisabled(true)');
+    expect(source).toContain('if (!historyPrependNativeMvcpDisabledRef.current)');
+    expect(source).toContain('if (!historyPrependNativeMvcpDisabled) return;');
+    expect(source).toContain('flushQueuedLoadEarlier();');
+    expect(source).toContain('isMomentumScrollingRef.current');
+    expect(listSource).toContain('onMomentumScrollBegin={handleMomentumScrollBegin}');
+    expect(listSource).toContain('onMomentumScrollEnd={handleMomentumScrollEnd}');
+    const beginLoadEarlierStart = source.indexOf('const beginLoadEarlier = useCallback');
+    const beginLoadEarlierEnd = source.indexOf('const flushQueuedLoadEarlier', beginLoadEarlierStart);
+    const beginLoadEarlierSource = source.slice(beginLoadEarlierStart, beginLoadEarlierEnd);
+    const flushLoadEarlierStart = source.indexOf('const flushQueuedLoadEarlier = useCallback');
+    const flushLoadEarlierEnd = source.indexOf('const requestLoadEarlier', flushLoadEarlierStart);
+    const flushLoadEarlierSource = source.slice(flushLoadEarlierStart, flushLoadEarlierEnd);
+    expect(beginLoadEarlierSource).toContain('if (userScrollForOlderRef.current)');
+    expect(beginLoadEarlierSource).toContain('nearBottomRef.current = false');
+    expect(flushLoadEarlierSource).toContain('isDraggingRef.current');
+    expect(flushLoadEarlierSource).toContain('isMomentumScrollingRef.current');
+    expect(flushLoadEarlierSource).toContain('historyTouchStartYRef.current !== null');
     // A second touch while the page is in flight must not reopen follow-to-latest.
     const dragStart = source.indexOf('const handleScrollBeginDrag = useCallback');
     const dragEnd = source.indexOf('const handleScrollEndDrag', dragStart);
-    expect(source.slice(dragStart, dragEnd)).not.toContain('readingOlderRef.current = false');
+    const dragSource = source.slice(dragStart, dragEnd);
+    expect(dragSource).not.toContain('readingOlderRef.current = false');
+    expect(dragSource).toContain('isMomentumScrollingRef.current = false');
+    expect(dragSource).toContain('handoffHistoryPrependToUser();');
+    const touchStart = source.indexOf('const handleHistoryTouchStart = useCallback');
+    const touchMove = source.indexOf('const maybeTriggerHistoryTouch', touchStart);
+    expect(source.slice(touchStart, touchMove)).toContain('isMomentumScrollingRef.current = false');
+    const scrollStart = source.indexOf('const handleScroll = useCallback');
+    const scrollEnd = source.indexOf('const handleHistoryTouchStart', scrollStart);
+    const scrollSource = source.slice(scrollStart, scrollEnd);
+    expect(scrollSource.indexOf('if (readingOlderRef.current)'))
+      .toBeLessThan(scrollSource.indexOf('resolveMobileNearBottomOnScroll({'));
+    expect(scrollSource.slice(
+      scrollSource.indexOf('if (readingOlderRef.current)'),
+      scrollSource.indexOf('const wasNearBottom'),
+    )).toContain('handoffHistoryPrependToUser();');
+    expect(scrollSource.slice(
+      scrollSource.indexOf('if (readingOlderRef.current)'),
+      scrollSource.indexOf('const wasNearBottom'),
+    )).toContain('return;');
+    expect(scrollSource).toContain('shouldPreserveMobileHistoryBrowseIntent({');
+    expect(scrollSource).toContain('historyBrowseIntent: userScrollForOlderRef.current');
+    expect(scrollSource).toContain('userControllingScroll: isDraggingRef.current');
     // 深链 / 搜索定位本身就是明确的历史浏览意图,后续近顶自动补页无需再拖一下。
     const focusEffectStart = source.indexOf('// 深链/搜索:滚到指定消息');
     const focusEffectEnd = source.indexOf('// 新消息红点', focusEffectStart);
@@ -100,14 +150,14 @@ describe('mobile message list container', () => {
     expect(focusEffectSource).toContain('lastAutoLoadEarlierKeyRef.current = null');
   });
 
-  it('hides main-compatible initial correction while keeping full history mounted', () => {
+  it('bounds the hidden initial correction while keeping full history mounted', () => {
     const source = readFileSync(resolve(process.cwd(), 'src/session/MessageRenderer.tsx'), 'utf8');
     expect(source).toContain('programmaticScrollInFlight: programmaticScrollInFlightRef.current');
     expect(source).toContain('evaluateMobileAnchorVerify({');
     expect(source).toContain('initialAnchorVerifyFrameRef');
     expect(source).toContain('scrollToEndProgrammatically(false)');
-    // mVCP 对 data / size 都常开；普通尾部追加与流式 resize 必须先记 settle 安静窗，
-    // 跟随 verifier 不能只依赖 readingOlderRef 判断是否等待。
+    // mVCP 只对 size 常开；流式 resize 仍需记 settle 安静窗，跟随 verifier 不能只依赖
+    // readingOlderRef 判断是否等待。
     expect(source).toContain('mvcpSettleAtRef.current = mobileMvcpSettleDeadline(');
     expect(source).toContain('markMobileMvcpSettle();');
     expect(source).toContain('mobileMessageListKeysSignature(itemKeys)');
@@ -115,19 +165,32 @@ describe('mobile message list container', () => {
     expect(source).not.toContain('[itemKeys, markMobileMvcpSettle]');
     expect(source.match(/isMobileMvcpSettling\(Date\.now\(\), mvcpSettleAtRef\.current\)/g))
       .toHaveLength(2);
+    expect(source).toContain('const nextStableFrames = settled ? stableFrames + 1 : 0;');
 
     expect(source).toContain('key={scrollResetKey}');
     expect(source).not.toContain('tailWindowAnchor');
     expect(source).toContain('previousUserMessageJumpTarget(listData, firstVisibleIndex)');
-    // main 的校正仍会命令式落底，但整个过程处于 opacity 遮罩下，settled/give-up 后
-    // 才一次性揭开；进入详情不暴露任何补滚帧。
+    // 首次校正仍会命令式落底，但 opacity 揭示必须立即交给 UI-thread native driver；
+    // 复杂消息占满 JS 时不能把 300ms 隐藏窗拖成长达数秒的白屏。
     expect(source).not.toContain('onLoad={handleListLoad}');
     expect(source).toContain('const [listRevealed, setListRevealed] = useState(false);');
     expect(source).toContain('setListRevealed(true);');
-    expect(source).toContain('style={[styles.messageList, !listRevealed && styles.messageListSettling]}');
-    expect(source).toContain('messageListSettling: { opacity: 0 }');
+    expect(source).toContain('const initialRevealProgress = useMemo(');
+    expect(source).toContain('const initialRevealOpacity = useMemo(');
+    expect(source).toContain('<Animated.View style={[styles.messageList, { opacity: initialRevealOpacity }]}>');
     expect(source).toContain('MOBILE_INITIAL_ANCHOR_SETTLE_MS');
-    expect(source).not.toContain('MOBILE_INITIAL_ANCHOR_REVEAL_MAX_MS');
+    expect(source).toContain('MOBILE_INITIAL_REVEAL_MAX_MS');
+    const initialAnchorEffectStart = source.indexOf('// 首次落底：完整历史已经在列表里');
+    const initialAnchorEffectEnd = source.indexOf('// 会话切换(scrollResetKey)', initialAnchorEffectStart);
+    const initialAnchorEffectSource = source.slice(initialAnchorEffectStart, initialAnchorEffectEnd);
+    expect(initialAnchorEffectSource).toContain('Animated.timing(initialRevealProgress, {');
+    expect(initialAnchorEffectSource).toContain('useNativeDriver: true');
+    expect(initialAnchorEffectSource).toContain('Date.now() >= revealDeadlineAt');
+    expect(initialAnchorEffectSource).not.toContain('setTimeout(');
+    expect(initialAnchorEffectSource).toContain('scrollToEndProgrammatically(false);');
+    expect(initialAnchorEffectSource).toContain('initialAnchorVerifyFrameRef.current = requestAnimationFrame(() => {');
+    expect(source).not.toContain('initialRevealTimerRef');
+    expect(source).not.toContain('messageListSettling');
   });
 
   it('resets identity-bound row state before a recycled cell displays another item', () => {
@@ -172,7 +235,7 @@ describe('mobile message list container', () => {
     expect(scrollAt).toBeGreaterThan(-1);
     expect(verifyAt).toBeGreaterThan(scrollAt);
     expect(callbackSource).toContain(
-      '}, [runStickToLatestVerify, scrollToEndProgrammatically]);',
+      '}, [cancelHistoryPrependTransaction, runStickToLatestVerify, scrollToEndProgrammatically]);',
     );
   });
 

--- a/apps/mobile/src/__tests__/messageListVirtualization.test.ts
+++ b/apps/mobile/src/__tests__/messageListVirtualization.test.ts
@@ -27,7 +27,8 @@ describe('mobile message list container', () => {
     expect(listSource).toContain('maintainScrollAtEnd');
     expect(listSource).toContain('maintainVisibleContentPosition={{ data: true, size: true }}');
     // cell 含内部 state(展开态 / 手势图 / mermaid·math WebView),关闭回收避免实例错误复用。
-    expect(listSource).toContain('recycleItems={false}');
+    expect(source).toContain('const recycleItems = __DEV__ && devRecycleItems === true;');
+    expect(listSource).toContain('recycleItems={recycleItems}');
     // 上滑加载:LegendList 近顶阈值触发自动预取(替代手搓的滚动 metric 判定)。
     expect(listSource).toContain('onStartReached={handleStartReached}');
     // 自动预取必须是电平判定(shouldAutoLoadEarlier + 多时机重评估),不许退回只吃 onStartReached

--- a/apps/mobile/src/__tests__/messageListVirtualization.test.ts
+++ b/apps/mobile/src/__tests__/messageListVirtualization.test.ts
@@ -15,23 +15,23 @@ describe('mobile message list container', () => {
     expect(source).not.toContain('windowSize={');
     expect(source).not.toContain('getItemLayout={');
 
-    const listStart = source.indexOf('<LegendList');
+    const listStart = source.search(/<LegendList\s/);
     expect(listStart).toBeGreaterThan(-1);
     const listSource = source.slice(listStart, source.indexOf('onViewableItemsChanged', listStart));
 
     // 估高 + 小预渲窗口:挂载集小、mount 帧压进一帧(不可退回大挂载树)。
     expect(listSource).toContain('estimatedItemSize={MOBILE_MESSAGE_ESTIMATED_ITEM_SIZE}');
     expect(listSource).toContain('drawDistance={MOBILE_MESSAGE_DRAW_DISTANCE}');
-    // 完整历史始终交给 LegendList，由其虚拟化/回收屏外 cell；初始位置使用原生
-    // offset-only 路径，不能退回会长时间隐藏 cell 的 index/end 测量 bootstrap。
+    // 与 main 一致，完整历史从首次挂载起就在列表中；不可退回只挂末尾几条的业务尾窗，
+    // 否则短尾窗未撑满首屏时 Android 无法拖动历史。
     expect(listSource).toContain('data={listData}');
-    expect(source).toContain('const initialScrollOffset = useMemo(() => {');
-    expect(listSource).toContain('initialScrollOffset={initialScrollOffset}');
+    expect(listSource).toContain('key={scrollResetKey}');
     expect(source).not.toContain('listData.slice(');
+    expect(source).not.toContain('initialEntryBootstrapActive');
+    expect(source).not.toContain('initialScrollOffset={');
     expect(source).not.toContain('MOBILE_INITIAL_TAIL_ITEM_COUNT');
     expect(source).not.toContain('MOBILE_TAIL_REVEAL_ITEM_COUNT');
     expect(listSource).not.toMatch(/\binitialScrollIndex\s*=/);
-    expect(listSource).not.toMatch(/\binitialScrollAtEnd\s*=/);
     // 内置贴底 + prepend 防跳(替代手搓 open-settle / follow rAF / prepend-settle,勿回潮)。
     expect(listSource).toContain('alignItemsAtEnd');
     expect(listSource).toContain('maintainScrollAtEnd');
@@ -50,26 +50,61 @@ describe('mobile message list container', () => {
     // 冷开只在列表同时贴住 start/end(首屏未填满)时有限补页。
     expect(source).toContain('MAX_INITIAL_HISTORY_AUTOFILL_PAGES');
     expect(source).toContain('atStart: listState.isAtStart');
+    expect(source).toContain('listState.isAtStart || nativeAtStart');
+    expect(source).toContain('listState.isNearStart || nativeNearStart');
+    expect(source).toContain('historyTouchTriggeredRef.current = true');
+    // LegendList does not forward every raw touch callback to its native ScrollView. Observe the
+    // bubbling gesture on the stable outer frame so a deliberate pull at offset 0 can request a page.
+    expect(source).toContain('onTouchStart={handleHistoryTouchStart}');
+    expect(source).toContain('onTouchMove={handleHistoryTouchMove}');
+    expect(source).toContain('onTouchEnd={handleHistoryTouchEnd}');
+    expect(source).toContain('onTouchCancel={handleHistoryTouchCancel}');
+    expect(listSource).not.toContain('onTouchMove={handleHistoryTouchMove}');
+    expect(source).toContain('if (readingOlderRef.current) return;');
+    expect(source).toContain('const firstItemKey = loadEarlierProgressKey ?? itemKeys[0] ?? null;');
     expect(source).toContain('initialHistoryAutofillRemainingRef.current -= 1');
-    // 所有 prepend 在请求期间抑制贴底，成功/空页/失败后延迟一帧释放；generation
-    // 防止旧会话请求 settle 后误清新会话 / 新请求状态。
+    // 所有 prepend 在请求和新页提交期间抑制贴底；只有 loadingEarlier 的完成态进入
+    // 当前 render commit 后才延迟释放。generation 防止旧请求误清新会话 / 新请求。
     expect(source).toContain('onLoadEarlier?: () => void | Promise<void>');
     expect(source).toContain('readingOlderRef.current = true');
-    expect(source).toContain('Promise.resolve(result).then(releaseReadingOlder, releaseReadingOlder)');
+    expect(source).toContain('readingOlderLoadingObservedRef.current = true');
+    expect(source).toContain('void Promise.resolve(result).then(');
+    expect(source).toContain('const releaseAfterRequestSettles = () => {');
+    expect(source).toContain('scheduleReadingOlderRelease(readingOlderRequestGenerationRef.current)');
     expect(source).toContain('readingOlderRequestGenerationRef.current === generation');
+    expect(source).toContain('!loadingEarlierRef.current');
+    // The settle deadline bounds only native prepend layout. It must never unlock while a slow
+    // active-session page still reports loadingEarlier=true.
+    expect(source).toContain('if (loadingEarlierRef.current) {');
+    expect(source).toContain('readingOlderReleaseDeadlineRef.current = 0;');
+    expect(source).not.toContain('|| Date.now() >= readingOlderReleaseDeadlineRef.current');
+    expect(source).toContain('setLoadEarlierEvaluationVersion((version) => version + 1);');
+    expect(source).toContain('[attemptAutoLoadEarlier, loadEarlierEvaluationVersion]');
+    expect(source).toMatch(/Math\.min\(\r?\n\s+mvcpSettleAtRef\.current,/);
+    expect(source).toContain('MOBILE_HISTORY_PREPEND_SETTLE_MAX_MS');
+    const loadEarlierStart = source.indexOf('const requestLoadEarlier = useCallback');
+    const loadEarlierEnd = source.indexOf('const attemptAutoLoadEarlier', loadEarlierStart);
+    const loadEarlierSource = source.slice(loadEarlierStart, loadEarlierEnd);
+    expect(loadEarlierSource).toContain('if (userScrollForOlderRef.current)');
+    expect(loadEarlierSource).toContain('nearBottomRef.current = false');
+    // A second touch while the page is in flight must not reopen follow-to-latest.
+    const dragStart = source.indexOf('const handleScrollBeginDrag = useCallback');
+    const dragEnd = source.indexOf('const handleScrollEndDrag', dragStart);
+    expect(source.slice(dragStart, dragEnd)).not.toContain('readingOlderRef.current = false');
     // 深链 / 搜索定位本身就是明确的历史浏览意图,后续近顶自动补页无需再拖一下。
     const focusEffectStart = source.indexOf('// 深链/搜索:滚到指定消息');
     const focusEffectEnd = source.indexOf('// 新消息红点', focusEffectStart);
     const focusEffectSource = source.slice(focusEffectStart, focusEffectEnd);
+    expect(focusEffectSource).toContain('if (!listRevealed) return;');
     expect(focusEffectSource).toContain('userScrollForOlderRef.current = true');
     expect(focusEffectSource).toContain('lastAutoLoadEarlierKeyRef.current = null');
   });
 
-  it('protects follow state while applying a visible offset-only initial position', () => {
+  it('hides main-compatible initial correction while keeping full history mounted', () => {
     const source = readFileSync(resolve(process.cwd(), 'src/session/MessageRenderer.tsx'), 'utf8');
     expect(source).toContain('programmaticScrollInFlight: programmaticScrollInFlightRef.current');
     expect(source).toContain('evaluateMobileAnchorVerify({');
-    expect(source).not.toContain('initialAnchorVerifyFrameRef');
+    expect(source).toContain('initialAnchorVerifyFrameRef');
     expect(source).toContain('scrollToEndProgrammatically(false)');
     // mVCP 对 data / size 都常开；普通尾部追加与流式 resize 必须先记 settle 安静窗，
     // 跟随 verifier 不能只依赖 readingOlderRef 判断是否等待。
@@ -79,22 +114,19 @@ describe('mobile message list container', () => {
     expect(source).toContain('[itemKeysSignature, markMobileMvcpSettle]');
     expect(source).not.toContain('[itemKeys, markMobileMvcpSettle]');
     expect(source.match(/isMobileMvcpSettling\(Date\.now\(\), mvcpSettleAtRef\.current\)/g))
-      .toHaveLength(1);
+      .toHaveLength(2);
 
-    // 冷开的空列表不能吞掉真实首批消息的初始 offset；empty → ready 明确重挂一次。
-    expect(source).toContain("listData.length === 0 ? 'empty' : 'ready'");
-    expect(source).toContain('key={listMountKey}');
+    expect(source).toContain('key={scrollResetKey}');
     expect(source).not.toContain('tailWindowAnchor');
     expect(source).toContain('previousUserMessageJumpTarget(listData, firstVisibleIndex)');
-    // 非空完整列表直接显示；不能用 overlay / opacity 再把已经创建好的 cell 遮住。
-    // 只有 data 仍为空的真实同步期才显示 SyncingMessages。
-    expect(source).not.toContain('initialTailLoadingOverlay');
-    // offset-only 首绘完成后做一次贴底校正并交给 content-size 跟随。列表不使用
-    // initialScrollIndex、业务 opacity 或 timer 遮罩，因此 JS 忙也不会白屏。
-    expect(source).toContain('onLoad={handleListLoad}');
-    expect(source).toContain('if (!initialListReadyRef.current) return;');
-    expect(source).not.toContain('messageListSettling');
-    expect(source).not.toContain('MOBILE_INITIAL_ANCHOR_SETTLE_MS');
+    // main 的校正仍会命令式落底，但整个过程处于 opacity 遮罩下，settled/give-up 后
+    // 才一次性揭开；进入详情不暴露任何补滚帧。
+    expect(source).not.toContain('onLoad={handleListLoad}');
+    expect(source).toContain('const [listRevealed, setListRevealed] = useState(false);');
+    expect(source).toContain('setListRevealed(true);');
+    expect(source).toContain('style={[styles.messageList, !listRevealed && styles.messageListSettling]}');
+    expect(source).toContain('messageListSettling: { opacity: 0 }');
+    expect(source).toContain('MOBILE_INITIAL_ANCHOR_SETTLE_MS');
     expect(source).not.toContain('MOBILE_INITIAL_ANCHOR_REVEAL_MAX_MS');
   });
 

--- a/apps/mobile/src/__tests__/messageListVirtualization.test.ts
+++ b/apps/mobile/src/__tests__/messageListVirtualization.test.ts
@@ -54,10 +54,10 @@ describe('mobile message list container', () => {
     expect(historyRestoreSetup).toContain('if (historyAnchorVerifyFrameRef.current !== null) return;');
     expect(historyRestoreSetup).not.toContain('cancelAnimationFrame(historyAnchorVerifyFrameRef.current)');
     expect(source).toContain('useLayoutEffect(() => {');
-    // 普通 Release/DEV 详情页都开启 native cell 回收；listperf 仍可显式做 on/off A/B。
-    // item type 分池 + recycling-aware state 防止菜单/展开态/媒体状态串到另一条消息。
-    expect(source).toContain('devRecycleItems = true,');
-    expect(source).toContain('const recycleItems = __DEV__ ? devRecycleItems === true : true;');
+    // 普通 Release/DEV 详情页使用 keyed remount，避免 Fabric 在异构消息树之间回收容器时
+    // 重挂仍属于旧父节点的原生 child；listperf 仍可显式做 on/off A/B。
+    expect(source).toContain('devRecycleItems = false,');
+    expect(source).toContain('const recycleItems = __DEV__ ? devRecycleItems === true : false;');
     expect(perfHarness).toContain("const recycle = params.recycle !== '0';");
     expect(listSource).toContain('recycleItems={recycleItems}');
     expect(listSource).toContain('getItemType={mobileMessageListItemType}');

--- a/apps/mobile/src/__tests__/messageMarkdown.test.ts
+++ b/apps/mobile/src/__tests__/messageMarkdown.test.ts
@@ -10,6 +10,8 @@ import {
   MOBILE_MARKDOWN_IMAGE_ALT_CHIP_MAX_UTF16_LENGTH,
   mobileMarkdownInlineImageSize,
   parseMobileMarkdown,
+  parseMobileMarkdownDocument,
+  parseMobileMarkdownIncremental,
   parseMobileMarkdownInlines,
   groupMobileMarkdownSelectableBlocks,
 } from '@/session/messageMarkdown';
@@ -17,6 +19,102 @@ import {
 // 文案已 i18n 化;固定 zh-CN 让字面量断言与语言环境解耦(全局 mock 默认 en-US)。
 beforeAll(async () => {
   await i18n.changeLanguage('zh-CN');
+});
+
+describe('incremental mobile Markdown parsing', () => {
+  it('reuses completed blocks after a safe blank-line checkpoint', () => {
+    const first = parseMobileMarkdownDocument('# title\n\nfirst paragraph');
+    const next = parseMobileMarkdownIncremental(
+      '# title\n\nfirst paragraph\n\nsecond paragraph',
+      first,
+    );
+    const full = parseMobileMarkdownDocument(next.source);
+
+    expect(next.incremental).toBe(true);
+    expect(next.reusedBlockCount).toBe(1);
+    expect(next.blocks).toEqual(full.blocks);
+    expect(next.blocks[0]).toBe(first.blocks[0]);
+    expect(next.parsedSourceUtf16Length).toBe('first paragraph\n\nsecond paragraph'.length);
+  });
+
+  it('falls back to a full parse for an edit in the existing prefix', () => {
+    const first = parseMobileMarkdownDocument('# title\n\nfirst paragraph');
+    const next = parseMobileMarkdownIncremental(
+      '# changed\n\nfirst paragraph\n\nsecond paragraph',
+      first,
+    );
+
+    expect(next.incremental).toBe(false);
+    expect(next.reusedBlockCount).toBe(0);
+    expect(next.blocks).toEqual(parseMobileMarkdownDocument(next.source).blocks);
+  });
+
+  it('keeps fenced code and display math semantics when appending', () => {
+    const codeFirst = parseMobileMarkdownDocument('intro\n\n```ts\nconst x = 1;\n```');
+    const codeNext = parseMobileMarkdownIncremental(
+      `${codeFirst.source}\n\nend`,
+      codeFirst,
+    );
+    expect(codeNext.blocks).toEqual(parseMobileMarkdownDocument(codeNext.source).blocks);
+
+    const mathFirst = parseMobileMarkdownDocument('intro\n\n$$\nx = 1\n$$');
+    const mathNext = parseMobileMarkdownIncremental(
+      `${mathFirst.source}\n\nend`,
+      mathFirst,
+    );
+    expect(mathNext.blocks).toEqual(parseMobileMarkdownDocument(mathNext.source).blocks);
+  });
+
+  it('falls back when an escaped inline math opener is closed by a later flush', () => {
+    const first = parseMobileMarkdownDocument('intro\n\nvalue \\(');
+    const next = parseMobileMarkdownIncremental(`${first.source}x\\)`, first);
+    const full = parseMobileMarkdownDocument(next.source);
+
+    expect(next.incremental).toBe(false);
+    expect(next.reusedBlockCount).toBe(0);
+    expect(next.blocks).toEqual(full.blocks);
+  });
+
+  it('keeps line offsets when appending after a closed fence without a trailing newline', () => {
+    const first = parseMobileMarkdownDocument('intro\n\n```ts\nconst x = 1;\n```');
+    const next = parseMobileMarkdownIncremental(`${first.source}\n\nend`, first);
+    const full = parseMobileMarkdownDocument(next.source);
+
+    expect(next.blocks).toEqual(full.blocks);
+    expect(next.blocks.at(-1)?.key).toBe(full.blocks.at(-1)?.key);
+  });
+
+  it('does not reuse an EOF checkpoint when an append mutates its last line', () => {
+    const first = parseMobileMarkdownDocument('```ts\nconst x = 1;\n```');
+    const next = parseMobileMarkdownIncremental(`${first.source}continued`, first);
+
+    expect(next.incremental).toBe(false);
+    expect(next.blocks).toEqual(parseMobileMarkdownDocument(next.source).blocks);
+  });
+
+  it('preserves full-parser semantics across character-by-character streaming flushes', () => {
+    const fixtures = [
+      '# heading\n\nplain text\n\n- item\n\nend',
+      'intro\n\n```ts\nconst x = 1;\n```\n\nresult',
+      'intro\n\n$$\nx = 1\n$$\n\nresult',
+      'prefix \\(x + 1\\) suffix\n\nnext',
+      '<!-- hidden\n\ntext -->\n\nvisible',
+    ];
+    for (const fixture of fixtures) {
+      let previous: ReturnType<typeof parseMobileMarkdownDocument> | null = null;
+      for (let end = 1; end <= fixture.length; end += 1) {
+        const source = fixture.slice(0, end);
+        const result = parseMobileMarkdownIncremental(source, previous);
+        expect(result.blocks, `prefix length ${end}`).toEqual(
+          parseMobileMarkdownDocument(source).blocks,
+        );
+        expect(result.ranges, `ranges at prefix length ${end}`).toEqual(
+          parseMobileMarkdownDocument(source).ranges,
+        );
+        previous = result;
+      }
+    }
+  });
 });
 
 describe('messageMarkdown', () => {

--- a/apps/mobile/src/__tests__/messageMarkdown.test.ts
+++ b/apps/mobile/src/__tests__/messageMarkdown.test.ts
@@ -1611,6 +1611,43 @@ describe('groupMobileMarkdownSelectableBlocks', () => {
     expect(groups.map((group) => (group.type === 'text_run' ? group.blocks.length : 0))).toEqual([1, 1, 2]);
   });
 
+  it('can bound one native text run by inline fragment count', () => {
+    const blocks = [{
+      type: 'paragraph' as const,
+      key: 'paragraph:0',
+      inlines: Array.from({ length: 7 }, (_, index) => ({
+        type: 'strong' as const,
+        text: String(index),
+      })),
+    }];
+    const groups = groupMobileMarkdownSelectableBlocks(blocks, {
+      maxTextRunInlineFragments: 3,
+    });
+    const chunks = groups.flatMap((group) => (group.type === 'text_run' ? group.blocks : []));
+
+    expect(groups.map((group) => group.type)).toEqual(['text_run', 'text_run', 'text_run']);
+    expect(chunks.map((block) => block.inlines.length)).toEqual([3, 3, 1]);
+    expect(chunks.map((block) => block.textRunContinuation === true)).toEqual([false, true, true]);
+    expect(chunks.flatMap((block) => block.inlines).map((inline) => (
+      inline.type === 'image' ? inline.alt : inline.text
+    )).join('')).toBe('0123456');
+  });
+
+  it('counts inline fragments across adjacent text blocks', () => {
+    const blocks = Array.from({ length: 5 }, (_, index) => ({
+      type: 'paragraph' as const,
+      key: `paragraph:${index}`,
+      inlines: [{ type: 'text' as const, text: String(index) }],
+    }));
+    const groups = groupMobileMarkdownSelectableBlocks(blocks, {
+      maxTextRunInlineFragments: 2,
+    });
+
+    expect(groups.map((group) => (
+      group.type === 'text_run' ? group.blocks.length : 0
+    ))).toEqual([2, 2, 1]);
+  });
+
   it('counts rendered block separators when bounding text runs by text length', () => {
     const blocks = parseMobileMarkdown(['aaaa', '', 'bbbb'].join('\n'));
     const groups = groupMobileMarkdownSelectableBlocks(blocks, { maxTextRunUtf16Length: 8 });
@@ -1693,6 +1730,7 @@ describe('groupMobileMarkdownSelectableBlocks', () => {
     const groups = groupMobileMarkdownSelectableBlocks(blocks, {
       maxTextRunBlocks: 0.5,
       maxTextRunUtf16Length: 0.5,
+      maxTextRunInlineFragments: 0.5,
     });
     expect(groups).toHaveLength(1);
     expect(groups[0].type).toBe('text_run');

--- a/apps/mobile/src/__tests__/messageMediaThumbnailWiring.test.ts
+++ b/apps/mobile/src/__tests__/messageMediaThumbnailWiring.test.ts
@@ -8,7 +8,7 @@ const readTextLf = (...args: Parameters<typeof readFileSync>): string =>
 
 /**
  * 聊天列表图片缩略图懒取件的接线断言(源码字符串模式,同 messageContentDesktopFirst):
- * 保证 strip → MediaPreview 的取件回调透传、payload 查看器的 image 关闭即删豁免、
+ * 保证 strip → MediaPreview 的取件回调透传、payload 查看器的 image 关闭逐出豁免、
  * 以及缩略图三态帧不被后续重构悄悄拆掉。
  */
 describe('mobile message media thumbnail wiring', () => {
@@ -77,9 +77,14 @@ describe('mobile message media thumbnail wiring', () => {
     expect(screenSource).toContain('createRemoteMediaResolveQueue');
     expect(screenSource).toContain('.request(media, opts)');
     expect(screenSource).toContain('releaseAll()');
-    // 切 sessionId(本屏不重挂载)与退屏共用清理:释放 + 补删 + 换新队列实例
-    expect(screenSource).toContain('[sessionId, createRemoteMediaQueue, deleteRemoteMediaObject]');
-    expect(screenSource).toContain('remoteMediaQueueRef.current = createRemoteMediaQueue()');
+    // 切 sessionId(本屏不重挂载)与页面卸载共用最终清理;下次取件懒建新队列。
+    expect(screenSource).toContain('[releaseRemoteMediaQueue, sessionId]');
+    expect(screenSource).toContain('(remoteMediaQueueRef.current ??= createRemoteMediaQueue()).request(media, opts)');
+    const releaseStart = screenSource.indexOf('const releaseRemoteMedia = useCallback');
+    const releaseEnd = screenSource.indexOf('const shareLightboxImage', releaseStart);
+    const releaseBlock = screenSource.slice(releaseStart, releaseEnd);
+    expect(releaseBlock).toContain('remoteMediaQueueRef.current?.evict(sourceUrl)');
+    expect(releaseBlock).not.toContain("method: 'DELETE'");
   });
 
   it('routes image payloads to the fullscreen ImageLightbox instead of the generic modal', () => {

--- a/apps/mobile/src/__tests__/messageMediaThumbnailWiring.test.ts
+++ b/apps/mobile/src/__tests__/messageMediaThumbnailWiring.test.ts
@@ -91,6 +91,9 @@ describe('mobile message media thumbnail wiring', () => {
     expect(rendererSource).toContain("payload?.kind === 'media' && payload.media.kind === 'image'");
     expect(rendererSource).toContain('<ImageLightbox');
     expect(rendererSource).toContain('lightboxImagesForPayload(galleryImages, payload)');
+    expect(rendererSource).toContain("const imageLightboxOpen = payload?.kind === 'media' && payload.media.kind === 'image';");
+    expect(rendererSource).toContain('() => (imageLightboxOpen');
+    expect(rendererSource).toContain(': null),');
     // 旧的内嵌缩放查看器与图库箭头已退役
     expect(rendererSource).not.toContain('ZoomablePayloadImage');
     expect(rendererSource).not.toContain('message.imageZoomInButton');

--- a/apps/mobile/src/__tests__/messagePaging.test.ts
+++ b/apps/mobile/src/__tests__/messagePaging.test.ts
@@ -9,6 +9,7 @@ import {
   listMessagesWithPayloadRetry,
   MESSAGE_PAGE_SIZE,
   oldestMessageCursor,
+  projectLoadedMessageWindow,
   shouldKeepOlderMessagesAffordance,
   shouldRefreshLatestMessageWindowOnReopen,
 } from '@/session/messagePaging';
@@ -64,6 +65,113 @@ describe('messagePaging', () => {
     expect(oldestMessageCursor([
       { ...message('', '2026-01-01T00:00:01.000Z'), clientId: 'client-only' },
     ])).toBeNull();
+  });
+
+  describe('projectLoadedMessageWindow', () => {
+    const compact = (id: string, createdAt: string): RemoteMessage => ({
+      ...message(`mobile-system-compact:${id}`, createdAt),
+      systemCardType: 'compact',
+    });
+
+    it('hides detached Compact cards older than the loaded host window', () => {
+      const detached = compact('old', '2026-01-01T00:00:01.000Z');
+      const rows = [
+        detached,
+        message('m10', '2026-01-01T00:00:10.000Z'),
+        message('m11', '2026-01-01T00:00:11.000Z'),
+      ];
+
+      expect(projectLoadedMessageWindow(rows).map((row) => row.id)).toEqual(['m10', 'm11']);
+    });
+
+    it('restores a Compact card when older host rows reach its time range', () => {
+      const rows = [
+        message('m0', '2026-01-01T00:00:00.000Z'),
+        compact('in-window', '2026-01-01T00:00:01.000Z'),
+        message('m2', '2026-01-01T00:00:02.000Z'),
+      ];
+
+      expect(projectLoadedMessageWindow(rows)).toBe(rows);
+    });
+
+    it('collapses adjacent replay-time Compact cards to the latest boundary', () => {
+      const rows = [
+        message('m1', '2026-01-01T00:00:01.000Z'),
+        compact('replay-1', '2026-01-01T00:00:10.000Z'),
+        compact('replay-2', '2026-01-01T00:00:11.000Z'),
+        compact('replay-3', '2026-01-01T00:00:12.000Z'),
+      ];
+
+      expect(projectLoadedMessageWindow(rows).map((row) => row.id)).toEqual([
+        'm1',
+        'mobile-system-compact:replay-3',
+      ]);
+    });
+
+    it('keeps only the latest detached tail Compact across temporary streaming rows', () => {
+      const temporaryStream = message('mobile-stream-1', '2026-01-01T00:00:11.000Z');
+      const rows = [
+        message('m1', '2026-01-01T00:00:01.000Z'),
+        compact('replay-1', '2026-01-01T00:00:10.000Z'),
+        temporaryStream,
+        compact('replay-2', '2026-01-01T00:00:12.000Z'),
+      ];
+
+      expect(projectLoadedMessageWindow(rows).map((row) => row.id)).toEqual([
+        'm1',
+        'mobile-stream-1',
+        'mobile-system-compact:replay-2',
+      ]);
+    });
+
+    it('does not let a generated streaming client id widen the persisted host window', () => {
+      const temporaryStream = {
+        ...message('temporary-row', '2026-01-01T00:00:11.000Z'),
+        clientId: 'mobile-stream-2',
+      };
+      const rows = [
+        message('m1', '2026-01-01T00:00:01.000Z'),
+        compact('replay-1', '2026-01-01T00:00:10.000Z'),
+        temporaryStream,
+        compact('replay-2', '2026-01-01T00:00:12.000Z'),
+      ];
+
+      expect(projectLoadedMessageWindow(rows).map((row) => row.id)).toEqual([
+        'm1',
+        'temporary-row',
+        'mobile-system-compact:replay-2',
+      ]);
+    });
+
+    it('keeps Compact boundaries separated by host body rows', () => {
+      const rows = [
+        message('m0', '2026-01-01T00:00:00.000Z'),
+        compact('first', '2026-01-01T00:00:01.000Z'),
+        message('body', '2026-01-01T00:00:02.000Z'),
+        compact('second', '2026-01-01T00:00:03.000Z'),
+      ];
+
+      expect(projectLoadedMessageWindow(rows)).toBe(rows);
+    });
+
+    it('keeps current-tail Compact and unrelated local system cards', () => {
+      const contextCard = {
+        ...message('mobile-system-context:1', '2025-12-31T23:59:59.000Z'),
+        systemCardType: 'context' as const,
+      };
+      const rows = [
+        contextCard,
+        message('m1', '2026-01-01T00:00:01.000Z'),
+        compact('tail', '2026-01-01T00:00:02.000Z'),
+      ];
+
+      expect(projectLoadedMessageWindow(rows)).toBe(rows);
+    });
+
+    it('does not erase Compact-only local state when no host cursor is loaded', () => {
+      const rows = [compact('only', '2026-01-01T00:00:01.000Z')];
+      expect(projectLoadedMessageWindow(rows)).toBe(rows);
+    });
   });
 
   it('keeps the load-earlier affordance only when the remote page is full', () => {

--- a/apps/mobile/src/__tests__/messagePaging.test.ts
+++ b/apps/mobile/src/__tests__/messagePaging.test.ts
@@ -172,6 +172,18 @@ describe('messagePaging', () => {
       const rows = [compact('only', '2026-01-01T00:00:01.000Z')];
       expect(projectLoadedMessageWindow(rows)).toBe(rows);
     });
+
+    it('collapses an adjacent Compact-only wall when no host cursor is loaded', () => {
+      const rows = [
+        compact('first', '2026-01-01T00:00:01.000Z'),
+        compact('second', '2026-01-01T00:00:02.000Z'),
+        compact('latest', '2026-01-01T00:00:03.000Z'),
+      ];
+
+      expect(projectLoadedMessageWindow(rows).map((row) => row.id)).toEqual([
+        'mobile-system-compact:latest',
+      ]);
+    });
   });
 
   it('keeps the load-earlier affordance only when the remote page is full', () => {

--- a/apps/mobile/src/__tests__/messagePerformance.test.ts
+++ b/apps/mobile/src/__tests__/messagePerformance.test.ts
@@ -1,7 +1,9 @@
 import { performance } from 'node:perf_hooks';
+import type { AgentTaskUpdate } from '@cindy/maker-shared/agent-task';
 import { describe, expect, it } from 'vitest';
 import { buildMobileMessageRenderItems, type MobileMessageRenderItem } from '@/session/messageRenderModel';
 import { reconcileMobileMessageRenderItems } from '@/session/messageRenderReconcile';
+import { buildMobileStreamingRenderWindow } from '@/session/messageRenderStreamingCache';
 import type { RemoteMessage } from '@/session/types';
 
 const BASE_TIME = Date.UTC(2026, 0, 1, 0, 0, 0);
@@ -163,5 +165,683 @@ describe('message render performance', () => {
       expect(changedRows).toBe(1);
       previous = reconciled;
     }
+  });
+
+  it('reuses the normalized historical prefix while only the active turn streams', () => {
+    const messages = createLargeDesktopMessageFixture(20);
+    const activeUser = message({
+      id: 'active-user',
+      role: 'user',
+      content: 'Continue',
+      createdAt: timestamp(101),
+    });
+    const activeAssistant = message({
+      id: 'active-assistant',
+      role: 'assistant',
+      content: 'Partial',
+      agentMeta: { isStreaming: true },
+      createdAt: timestamp(102),
+    });
+    const first = buildMobileStreamingRenderWindow({
+      cacheKey: 'en',
+      messages: [...messages, activeUser, activeAssistant],
+      options: { isSessionStreaming: true, sessionId: 's1' },
+    });
+    expect(first.prefix).not.toBeNull();
+
+    const next = buildMobileStreamingRenderWindow({
+      cacheKey: 'en',
+      messages: [
+        ...messages,
+        activeUser,
+        { ...activeAssistant, content: 'Partial update' },
+      ],
+      options: { isSessionStreaming: true, sessionId: 's1' },
+      previousPrefix: first.prefix,
+    });
+
+    expect(next.prefix).toBe(first.prefix);
+    expect(next.prefix?.items).toBe(first.prefix?.items);
+    expect(next.items.slice(0, first.prefix!.items.length)).toEqual(first.prefix!.items);
+  });
+
+  it('publishes a reusable prefix before a streaming render commits', () => {
+    const history = createLargeDesktopMessageFixture(20);
+    const activeUser = message({
+      id: 'active-user',
+      role: 'user',
+      content: 'Continue',
+      createdAt: timestamp(101),
+    });
+    const activeAssistant = message({
+      id: 'active-assistant',
+      role: 'assistant',
+      content: 'Partial',
+      agentMeta: { isStreaming: true },
+      createdAt: timestamp(102),
+    });
+    const prefixCache: {
+      current: ReturnType<typeof buildMobileStreamingRenderWindow>['prefix'];
+    } = { current: null };
+
+    const interrupted = buildMobileStreamingRenderWindow({
+      cacheKey: 'en',
+      messages: [...history, activeUser, activeAssistant],
+      options: { isSessionStreaming: true, sessionId: 's1' },
+      prefixCache,
+    });
+    expect(prefixCache.current).toBe(interrupted.prefix);
+
+    const retry = buildMobileStreamingRenderWindow({
+      cacheKey: 'en',
+      messages: [
+        ...history,
+        activeUser,
+        { ...activeAssistant, content: 'Partial update' },
+      ],
+      options: { isSessionStreaming: true, sessionId: 's1' },
+      prefixCache,
+    });
+
+    expect(retry.prefix).toBe(interrupted.prefix);
+    expect(prefixCache.current).toBe(interrupted.prefix);
+  });
+
+  it('reuses a stable assistant boundary when the active user row is outside the window', () => {
+    const toolUse = message({
+      id: 'tool-use',
+      role: 'tool_use',
+      toolUseId: 'tool-use',
+      content: { toolUseId: 'tool-use', toolName: 'Read', input: { file_path: '/repo/a.ts' } },
+      createdAt: timestamp(1),
+    });
+    const toolResult = message({
+      id: 'tool-result',
+      role: 'tool_result',
+      toolUseId: 'tool-use',
+      content: 'contents',
+      createdAt: timestamp(2),
+    });
+    const stableAssistant = message({
+      id: 'stable-assistant',
+      role: 'assistant',
+      content: 'The first check is complete.',
+      createdAt: timestamp(3),
+    });
+    const activeThinking = message({
+      id: 'active-thinking',
+      role: 'thinking',
+      content: { kind: 'thinking', text: 'Continuing', isStreaming: true },
+      createdAt: timestamp(4),
+    });
+    const activeAssistant = message({
+      id: 'active-assistant',
+      role: 'assistant',
+      content: 'Partial',
+      agentMeta: { isStreaming: true },
+      createdAt: timestamp(5),
+    });
+    const messages = [toolUse, toolResult, stableAssistant, activeThinking, activeAssistant];
+    const prefixCache: {
+      current: ReturnType<typeof buildMobileStreamingRenderWindow>['prefix'];
+    } = { current: null };
+    const options = { isSessionStreaming: true, sessionId: 's1' } as const;
+
+    const first = buildMobileStreamingRenderWindow({
+      cacheKey: 'en',
+      messages,
+      options,
+      prefixCache,
+    });
+    expect(first.prefix?.mode).toBe('truncated-turn');
+    expect(first.prefix?.boundaryMessage).toBe(stableAssistant);
+    expect(first.items).toEqual(buildMobileMessageRenderItems(messages, options));
+
+    const updatedMessages = [
+      toolUse,
+      toolResult,
+      stableAssistant,
+      activeThinking,
+      { ...activeAssistant, content: 'Partial update' },
+    ];
+    const retry = buildMobileStreamingRenderWindow({
+      cacheKey: 'en',
+      messages: updatedMessages,
+      options,
+      prefixCache,
+    });
+
+    expect(retry.prefix).toBe(first.prefix);
+    expect(retry.items).toEqual(buildMobileMessageRenderItems(updatedMessages, options));
+  });
+
+  it('advances the reusable prefix into a long visible active turn', () => {
+    const history = createLargeDesktopMessageFixture(20);
+    const activeUser = message({
+      id: 'active-user',
+      role: 'user',
+      content: 'Continue',
+      createdAt: timestamp(101),
+    });
+    const stableAssistant = message({
+      id: 'stable-assistant',
+      role: 'assistant',
+      content: 'The first pass is complete.',
+      createdAt: timestamp(102),
+    });
+    const activeThinking = message({
+      id: 'active-thinking',
+      role: 'thinking',
+      content: { kind: 'thinking', text: 'Continuing', isStreaming: true },
+      createdAt: timestamp(103),
+    });
+    const activeAssistant = message({
+      id: 'active-assistant',
+      role: 'assistant',
+      content: 'Partial',
+      agentMeta: { isStreaming: true },
+      createdAt: timestamp(104),
+    });
+    const prefixCache: {
+      current: ReturnType<typeof buildMobileStreamingRenderWindow>['prefix'];
+    } = { current: null };
+    const options = { isSessionStreaming: true, sessionId: 's1' } as const;
+
+    const first = buildMobileStreamingRenderWindow({
+      cacheKey: 'en',
+      messages: [...history, activeUser, stableAssistant, activeThinking, activeAssistant],
+      options,
+      prefixCache,
+    });
+    expect(first.prefix?.mode).toBe('truncated-turn');
+    expect(first.prefix?.boundaryMessage).toBe(stableAssistant);
+
+    const updatedMessages = [
+      ...history,
+      activeUser,
+      stableAssistant,
+      activeThinking,
+      { ...activeAssistant, content: 'Partial update' },
+    ];
+    const retry = buildMobileStreamingRenderWindow({
+      cacheKey: 'en',
+      messages: updatedMessages,
+      options,
+      prefixCache,
+    });
+
+    expect(retry.prefix).toBe(first.prefix);
+    expect(retry.items).toEqual(buildMobileMessageRenderItems(updatedMessages, options));
+  });
+
+  it('invalidates only when a task update used by the stable prefix changes', () => {
+    const prefixTask = message({
+      id: 'prefix-task',
+      role: 'tool_use',
+      toolUseId: 'prefix-task',
+      content: {
+        toolUseId: 'prefix-task',
+        toolName: 'collab:spawn',
+        input: { task: 'Review the prefix' },
+      },
+      createdAt: timestamp(1),
+    });
+    const stableAssistant = message({
+      id: 'stable-after-task',
+      role: 'assistant',
+      content: 'The review has started.',
+      createdAt: timestamp(2),
+    });
+    const activeThinking = message({
+      id: 'active-thinking-after-task',
+      role: 'thinking',
+      content: { kind: 'thinking', text: 'Continuing', isStreaming: true },
+      createdAt: timestamp(3),
+    });
+    const prefixUpdate: AgentTaskUpdate = {
+      provider: 'codex',
+      taskId: 'prefix-task',
+      status: 'running',
+    };
+    const prefixCache: {
+      current: ReturnType<typeof buildMobileStreamingRenderWindow>['prefix'];
+    } = { current: null };
+    const options = {
+      isSessionStreaming: true,
+      renderOrphanTaskUpdates: true,
+      sessionId: 's1',
+    } as const;
+    const messages = [prefixTask, stableAssistant, activeThinking];
+    const first = buildMobileStreamingRenderWindow({
+      cacheKey: 'en',
+      messages,
+      options,
+      prefixCache,
+      taskUpdates: new Map<string, AgentTaskUpdate>([['prefix-task', prefixUpdate]]),
+    });
+
+    const unrelatedUpdate: AgentTaskUpdate = {
+      provider: 'codex',
+      taskId: 'tail-task',
+      status: 'running',
+    };
+    const unrelated = buildMobileStreamingRenderWindow({
+      cacheKey: 'en',
+      messages,
+      options,
+      prefixCache,
+      taskUpdates: new Map<string, AgentTaskUpdate>([
+        ['prefix-task', prefixUpdate],
+        ['tail-task', unrelatedUpdate],
+      ]),
+    });
+    expect(unrelated.prefix).toBe(first.prefix);
+
+    const completedPrefixUpdate = { ...prefixUpdate, status: 'completed' as const };
+    const changedUpdates = new Map<string, AgentTaskUpdate>([
+      ['prefix-task', completedPrefixUpdate],
+      ['tail-task', unrelatedUpdate],
+    ]);
+    const changed = buildMobileStreamingRenderWindow({
+      cacheKey: 'en',
+      messages,
+      options,
+      prefixCache,
+      taskUpdates: changedUpdates,
+    });
+
+    expect(changed.prefix).not.toBe(first.prefix);
+    expect(changed.items).toEqual(
+      buildMobileMessageRenderItems(messages, options, changedUpdates),
+    );
+  });
+
+  it('keeps whole-turn transforms together until a later stable assistant boundary', () => {
+    const stableAssistant = message({
+      id: 'stable-assistant-before-structural-tail',
+      role: 'assistant',
+      content: 'The first phase is complete.',
+      createdAt: timestamp(2),
+    });
+    const activeThinking = message({
+      id: 'active-thinking-structural-tail',
+      role: 'thinking',
+      content: { kind: 'thinking', text: 'Continuing', isStreaming: true },
+      createdAt: timestamp(3),
+    });
+    const options = { isSessionStreaming: true, sessionId: 's1' } as const;
+
+    const scenarios: RemoteMessage[][] = [
+      [
+        message({
+          id: 'agent-before-boundary',
+          role: 'tool_use',
+          toolUseId: 'agent-before-boundary',
+          content: {
+            toolUseId: 'agent-before-boundary',
+            toolName: 'Agent',
+            input: { prompt: 'Inspect the code' },
+          },
+          createdAt: timestamp(1),
+        }),
+        stableAssistant,
+        message({
+          id: 'late-subagent-child',
+          role: 'assistant',
+          content: 'Late child output',
+          agentMeta: { parentUuid: 'agent-before-boundary', isStreaming: true },
+          createdAt: timestamp(3),
+        }),
+      ],
+      [
+        message({
+          id: 'plan-before-boundary',
+          role: 'tool_use',
+          toolUseId: 'plan-before-boundary',
+          content: {
+            toolUseId: 'plan-before-boundary',
+            toolName: 'update_plan',
+            input: { plan: [{ step: 'First', status: 'completed' }] },
+          },
+          createdAt: timestamp(1),
+        }),
+        stableAssistant,
+        message({
+          id: 'plan-after-boundary',
+          role: 'tool_use',
+          toolUseId: 'plan-after-boundary',
+          content: {
+            toolUseId: 'plan-after-boundary',
+            toolName: 'update_plan',
+            input: { plan: [{ step: 'Second', status: 'in_progress' }] },
+          },
+          createdAt: timestamp(3),
+        }),
+      ],
+      [
+        message({
+          id: 'tool-before-boundary',
+          role: 'tool_use',
+          toolUseId: 'tool-before-boundary',
+          content: {
+            toolUseId: 'tool-before-boundary',
+            toolName: 'Read',
+            input: { file_path: '/repo/image.png' },
+          },
+          createdAt: timestamp(1),
+        }),
+        stableAssistant,
+        message({
+          id: 'late-tool-result',
+          role: 'tool_result',
+          toolUseId: 'tool-before-boundary',
+          content: 'late result',
+          createdAt: timestamp(3),
+        }),
+      ],
+      [
+        message({
+          id: 'tool-image-before-boundary',
+          role: 'tool_use',
+          toolUseId: 'tool-image-before-boundary',
+          content: {
+            toolUseId: 'tool-image-before-boundary',
+            toolName: 'Read',
+            input: { file_path: '/repo/image.png' },
+          },
+          createdAt: timestamp(1),
+        }),
+        stableAssistant,
+        message({
+          id: 'assistant-image-after-boundary',
+          role: 'assistant',
+          content: '![Preview](https://example.com/image.png)',
+          agentMeta: { isStreaming: true },
+          createdAt: timestamp(3),
+        }),
+      ],
+    ];
+
+    for (const messages of scenarios) {
+      const result = buildMobileStreamingRenderWindow({
+        cacheKey: 'en',
+        messages: [...messages, activeThinking],
+        options,
+      });
+      expect(result.prefix).toBeNull();
+      expect(result.items).toEqual(
+        buildMobileMessageRenderItems([...messages, activeThinking], options),
+      );
+    }
+  });
+
+  it('does not treat steering or auto-resume user rows as the active turn root', () => {
+    const history = createLargeDesktopMessageFixture(4);
+    const activeUser = message({
+      id: 'real-active-user',
+      role: 'user',
+      content: 'Continue',
+      createdAt: timestamp(50),
+    });
+    const stableAssistant = message({
+      id: 'stable-before-synthetic-user',
+      role: 'assistant',
+      content: 'First phase complete.',
+      createdAt: timestamp(51),
+    });
+    const syntheticUsers = [
+      message({
+        id: 'steer-user',
+        role: 'user',
+        content: 'Adjust the current work',
+        agentMeta: { delivery: 'steer' },
+        createdAt: timestamp(52),
+      }),
+      message({
+        id: 'auto-resume-user',
+        role: 'user',
+        content: '',
+        agentMeta: { autoResume: true },
+        createdAt: timestamp(52),
+      }),
+    ];
+
+    for (const syntheticUser of syntheticUsers) {
+      const messages = [
+        ...history,
+        activeUser,
+        stableAssistant,
+        syntheticUser,
+        message({
+          id: `streaming-after-${syntheticUser.id}`,
+          role: 'assistant',
+          content: 'Partial',
+          agentMeta: { isStreaming: true },
+          createdAt: timestamp(53),
+        }),
+      ];
+      const result = buildMobileStreamingRenderWindow({
+        cacheKey: 'en',
+        messages,
+        options: { isSessionStreaming: true, sessionId: 's1' },
+      });
+
+      expect(result.prefix?.mode).toBe('history');
+      expect(result.prefix?.messages).toEqual(history);
+      expect(result.items).toEqual(
+        buildMobileMessageRenderItems(messages, { isSessionStreaming: true, sessionId: 's1' }),
+      );
+    }
+  });
+
+  it('invalidates a truncated-turn prefix when a late tool result settles it', () => {
+    const toolUse = message({
+      id: 'late-tool-use',
+      role: 'tool_use',
+      toolUseId: 'late-tool-use',
+      content: {
+        toolUseId: 'late-tool-use',
+        toolName: 'Read',
+        input: { file_path: '/repo/late.ts' },
+      },
+      createdAt: timestamp(1),
+    });
+    const stableAssistant = message({
+      id: 'stable-after-tool',
+      role: 'assistant',
+      content: 'Waiting for the remaining work.',
+      createdAt: timestamp(2),
+    });
+    const activeThinking = message({
+      id: 'late-active-thinking',
+      role: 'thinking',
+      content: { kind: 'thinking', text: 'Continuing', isStreaming: true },
+      createdAt: timestamp(3),
+    });
+    const options = { isSessionStreaming: true, sessionId: 's1' } as const;
+    const prefixCache: {
+      current: ReturnType<typeof buildMobileStreamingRenderWindow>['prefix'];
+    } = { current: null };
+    const first = buildMobileStreamingRenderWindow({
+      cacheKey: 'en',
+      messages: [toolUse, stableAssistant, activeThinking],
+      options,
+      prefixCache,
+    });
+    const lateResult = message({
+      id: 'late-tool-result',
+      role: 'tool_result',
+      toolUseId: 'late-tool-use',
+      content: 'late contents',
+      createdAt: timestamp(4),
+    });
+    const settledMessages = [toolUse, stableAssistant, activeThinking, lateResult];
+
+    const settled = buildMobileStreamingRenderWindow({
+      cacheKey: 'en',
+      messages: settledMessages,
+      options,
+      prefixCache,
+    });
+
+    expect(settled.prefix).not.toBe(first.prefix);
+    expect(settled.items).toEqual(buildMobileMessageRenderItems(settledMessages, options));
+
+    const retry = buildMobileStreamingRenderWindow({
+      cacheKey: 'en',
+      messages: settledMessages,
+      options,
+      prefixCache,
+    });
+    expect(retry.items).toEqual(buildMobileMessageRenderItems(settledMessages, options));
+  });
+
+  it('keeps full-turn image dedupe when an image assistant becomes the split boundary in one batch', () => {
+    const imageUrl = 'xdt-image://lizi-art-media-images/cache-boundary.png';
+    const toolUse = message({
+      id: 'image-tool-use',
+      role: 'tool_use',
+      toolUseId: 'image-tool-use',
+      content: {
+        toolUseId: 'image-tool-use',
+        toolName: 'Read',
+        input: { file_path: '/repo/image.png' },
+      },
+      createdAt: timestamp(1),
+    });
+    const toolResult = message({
+      id: 'image-tool-result',
+      role: 'tool_result',
+      toolUseId: 'image-tool-use',
+      content: JSON.stringify({ xdt_image_url: imageUrl }),
+      createdAt: timestamp(2),
+    });
+    const firstBoundary = message({
+      id: 'first-boundary',
+      role: 'assistant',
+      content: 'First phase complete.',
+      createdAt: timestamp(3),
+    });
+    const initialTail = message({
+      id: 'initial-tail',
+      role: 'thinking',
+      content: { kind: 'thinking', text: 'Continuing', isStreaming: true },
+      createdAt: timestamp(4),
+    });
+    const options = { isSessionStreaming: true, sessionId: 's1' } as const;
+    const prefixCache: {
+      current: ReturnType<typeof buildMobileStreamingRenderWindow>['prefix'];
+    } = { current: null };
+
+    buildMobileStreamingRenderWindow({
+      cacheKey: 'en',
+      messages: [toolUse, toolResult, firstBoundary, initialTail],
+      options,
+      prefixCache,
+    });
+
+    const imageBoundary = message({
+      id: 'image-boundary',
+      role: 'assistant',
+      content: `![Preview](${imageUrl})`,
+      createdAt: timestamp(5),
+    });
+    const nextTail = message({
+      id: 'next-tail',
+      role: 'thinking',
+      content: { kind: 'thinking', text: 'Still working', isStreaming: true },
+      createdAt: timestamp(6),
+    });
+    const messages = [toolUse, toolResult, firstBoundary, imageBoundary, nextTail];
+    const result = buildMobileStreamingRenderWindow({
+      cacheKey: 'en',
+      messages,
+      options,
+      prefixCache,
+    });
+
+    expect(result.items).toEqual(buildMobileMessageRenderItems(messages, options));
+  });
+
+  it('keeps full-turn image dedupe between an earlier assistant and a tail tool result', () => {
+    const imageUrl = 'xdt-image://lizi-art-media-images/cache-prefix.png';
+    const user = message({
+      id: 'image-prefix-user',
+      role: 'user',
+      content: 'Create an image',
+      createdAt: timestamp(1),
+    });
+    const imageAssistant = message({
+      id: 'image-prefix-assistant',
+      role: 'assistant',
+      content: `![Preview](${imageUrl})`,
+      createdAt: timestamp(2),
+    });
+    const textBoundary = message({
+      id: 'image-prefix-text-boundary',
+      role: 'assistant',
+      content: 'The first phase is complete.',
+      createdAt: timestamp(3),
+    });
+    const initialTail = message({
+      id: 'image-prefix-initial-tail',
+      role: 'thinking',
+      content: { kind: 'thinking', text: 'Continuing', isStreaming: true },
+      createdAt: timestamp(4),
+    });
+    const options = { isSessionStreaming: true, sessionId: 's1' } as const;
+    const prefixCache: {
+      current: ReturnType<typeof buildMobileStreamingRenderWindow>['prefix'];
+    } = { current: null };
+
+    buildMobileStreamingRenderWindow({
+      cacheKey: 'en',
+      messages: [user, imageAssistant, textBoundary, initialTail],
+      options,
+      prefixCache,
+    });
+
+    const tailToolUse = message({
+      id: 'image-prefix-tail-tool',
+      role: 'tool_use',
+      toolUseId: 'image-prefix-tail-tool',
+      content: {
+        toolUseId: 'image-prefix-tail-tool',
+        toolName: 'image_generate',
+        input: { prompt: 'variant' },
+      },
+      createdAt: timestamp(5),
+    });
+    const tailToolResult = message({
+      id: 'image-prefix-tail-result',
+      role: 'tool_result',
+      toolUseId: 'image-prefix-tail-tool',
+      content: JSON.stringify({ xdt_image_url: imageUrl }),
+      createdAt: timestamp(6),
+    });
+    const streamingTail = message({
+      id: 'image-prefix-streaming-tail',
+      role: 'assistant',
+      content: 'Still working',
+      agentMeta: { isStreaming: true },
+      createdAt: timestamp(7),
+    });
+    const messages = [
+      user,
+      imageAssistant,
+      textBoundary,
+      tailToolUse,
+      tailToolResult,
+      streamingTail,
+    ];
+    const result = buildMobileStreamingRenderWindow({
+      cacheKey: 'en',
+      messages,
+      options,
+      prefixCache,
+    });
+
+    expect(result.items).toEqual(buildMobileMessageRenderItems(messages, options));
+    expect(result.items.some((item) => item.type === 'tool_media')).toBe(false);
   });
 });

--- a/apps/mobile/src/__tests__/messagePerformance.test.ts
+++ b/apps/mobile/src/__tests__/messagePerformance.test.ts
@@ -205,6 +205,110 @@ describe('message render performance', () => {
     expect(next.items.slice(0, first.prefix!.items.length)).toEqual(first.prefix!.items);
   });
 
+  it('invalidates a historical prefix only when one of its task updates changes', () => {
+    const prefixTask = message({
+      id: 'historical-prefix-task',
+      role: 'tool_use',
+      toolUseId: 'historical-prefix-task',
+      content: {
+        toolUseId: 'historical-prefix-task',
+        toolName: 'collab:spawn',
+        input: { task: 'Review the historical prefix' },
+      },
+      createdAt: timestamp(1),
+    });
+    const stableAssistant = message({
+      id: 'historical-prefix-assistant',
+      role: 'assistant',
+      content: 'The review has started.',
+      createdAt: timestamp(2),
+    });
+    const activeUser = message({
+      id: 'historical-prefix-active-user',
+      role: 'user',
+      content: 'Continue',
+      createdAt: timestamp(3),
+    });
+    const activeAssistant = message({
+      id: 'historical-prefix-active-assistant',
+      role: 'assistant',
+      content: 'Partial',
+      agentMeta: { isStreaming: true },
+      createdAt: timestamp(4),
+    });
+    const prefixUpdate: AgentTaskUpdate = {
+      provider: 'codex',
+      taskId: 'historical-prefix-task',
+      status: 'running',
+    };
+    const prefixCache: {
+      current: ReturnType<typeof buildMobileStreamingRenderWindow>['prefix'];
+    } = { current: null };
+    const options = {
+      isSessionStreaming: true,
+      renderOrphanTaskUpdates: true,
+      sessionId: 's1',
+    } as const;
+    const messages = [prefixTask, stableAssistant, activeUser, activeAssistant];
+    const firstUpdates = new Map<string, AgentTaskUpdate>([
+      ['historical-prefix-task', prefixUpdate],
+    ]);
+    const first = buildMobileStreamingRenderWindow({
+      cacheKey: 'en',
+      messages,
+      options,
+      prefixCache,
+      taskUpdates: firstUpdates,
+    });
+
+    expect(first.prefix?.mode).toBe('history');
+    expect(first.items.filter((item) => item.type === 'agent_task')).toMatchObject([
+      { key: 'task-historical-prefix-task', update: prefixUpdate },
+    ]);
+
+    const unrelatedUpdate: AgentTaskUpdate = {
+      provider: 'codex',
+      taskId: 'active-orphan-task',
+      status: 'running',
+    };
+    const unrelatedUpdates = new Map<string, AgentTaskUpdate>([
+      ['historical-prefix-task', prefixUpdate],
+      ['active-orphan-task', unrelatedUpdate],
+    ]);
+    const unrelated = buildMobileStreamingRenderWindow({
+      cacheKey: 'en',
+      messages,
+      options,
+      prefixCache,
+      taskUpdates: unrelatedUpdates,
+    });
+
+    expect(unrelated.prefix).toBe(first.prefix);
+    expect(unrelated.items.filter((item) => item.type === 'agent_task')).toMatchObject([
+      { key: 'task-historical-prefix-task', update: prefixUpdate },
+      { key: 'task-update-active-orphan-task', update: unrelatedUpdate },
+    ]);
+
+    const changedPrefixUpdate = { ...prefixUpdate, title: 'Updated historical task' };
+    const changedUpdates = new Map<string, AgentTaskUpdate>([
+      ['historical-prefix-task', changedPrefixUpdate],
+      ['active-orphan-task', unrelatedUpdate],
+    ]);
+    const changed = buildMobileStreamingRenderWindow({
+      cacheKey: 'en',
+      messages,
+      options,
+      prefixCache,
+      taskUpdates: changedUpdates,
+    });
+
+    expect(changed.prefix).not.toBe(first.prefix);
+    expect(changed.items.filter((item) => item.type === 'agent_task')).toMatchObject([
+      { key: 'task-historical-prefix-task', update: changedPrefixUpdate },
+      { key: 'task-update-active-orphan-task', update: unrelatedUpdate },
+    ]);
+  });
+
   it('publishes a reusable prefix before a streaming render commits', () => {
     const history = createLargeDesktopMessageFixture(20);
     const activeUser = message({

--- a/apps/mobile/src/__tests__/messageScroll.test.ts
+++ b/apps/mobile/src/__tests__/messageScroll.test.ts
@@ -33,6 +33,7 @@ import {
   mobileMessageListBottomPadding,
   mobileMessageListNearBottomThreshold,
   previousUserMessageJumpTarget,
+  previousUserMessageJumpTargetForWindow,
   shouldAutoFollowMessages,
   shouldAutoLoadEarlier,
   shouldShowNewMessageIndicator,
@@ -208,6 +209,19 @@ describe('messageScroll', () => {
       preview: 'first question',
     });
     expect(previousUserMessageJumpTarget(items, 0)).toBeNull();
+
+    // The mounted list may be a tail slice. Relative viewability indices must be translated
+    // back to the complete model, while navigation keeps track of whether the target is mounted.
+    expect(previousUserMessageJumpTargetForWindow(items, 2, 1)).toMatchObject({
+      itemKey: 'message-u2',
+      index: 2,
+      windowIndex: 0,
+    });
+    expect(previousUserMessageJumpTargetForWindow(items, 3, 0)).toMatchObject({
+      itemKey: 'message-u2',
+      index: 2,
+      windowIndex: null,
+    });
   });
 
   it('maps client ids inside folded render items to the top-level scroll target', () => {

--- a/apps/mobile/src/__tests__/messageScroll.test.ts
+++ b/apps/mobile/src/__tests__/messageScroll.test.ts
@@ -300,9 +300,17 @@ describe('shouldAutoLoadEarlier', () => {
     })).toBe(false);
   });
 
-  it('keeps user-driven history prefetch disabled while pinned at the end', () => {
-    // 短会话整窗都在近顶阈值内:nearStart 与贴底可同时成立,贴底跟流优先。
-    expect(shouldAutoLoadEarlier({ ...eligible, atEnd: true })).toBe(false);
+  it('keeps user-driven history prefetch disabled while only pinned at the end', () => {
+    expect(shouldAutoLoadEarlier({ ...eligible, atEnd: true, atStart: false })).toBe(false);
+  });
+
+  it('loads history after an explicit drag when a short window is both at-start and at-end', () => {
+    expect(shouldAutoLoadEarlier({
+      ...eligible,
+      atEnd: true,
+      atStart: true,
+      userScrolledForOlder: true,
+    })).toBe(true);
   });
 
   it('allows bounded cold-fill while a short initial window is both near-start and at-end', () => {

--- a/apps/mobile/src/__tests__/messageScroll.test.ts
+++ b/apps/mobile/src/__tests__/messageScroll.test.ts
@@ -33,7 +33,6 @@ import {
   mobileMessageListBottomPadding,
   mobileMessageListNearBottomThreshold,
   previousUserMessageJumpTarget,
-  previousUserMessageJumpTargetForWindow,
   shouldAutoFollowMessages,
   shouldAutoLoadEarlier,
   shouldShowNewMessageIndicator,
@@ -209,19 +208,6 @@ describe('messageScroll', () => {
       preview: 'first question',
     });
     expect(previousUserMessageJumpTarget(items, 0)).toBeNull();
-
-    // The mounted list may be a tail slice. Relative viewability indices must be translated
-    // back to the complete model, while navigation keeps track of whether the target is mounted.
-    expect(previousUserMessageJumpTargetForWindow(items, 2, 1)).toMatchObject({
-      itemKey: 'message-u2',
-      index: 2,
-      windowIndex: 0,
-    });
-    expect(previousUserMessageJumpTargetForWindow(items, 3, 0)).toMatchObject({
-      itemKey: 'message-u2',
-      index: 2,
-      windowIndex: null,
-    });
   });
 
   it('maps client ids inside folded render items to the top-level scroll target', () => {

--- a/apps/mobile/src/__tests__/messageScroll.test.ts
+++ b/apps/mobile/src/__tests__/messageScroll.test.ts
@@ -253,6 +253,7 @@ describe('shouldAutoLoadEarlier', () => {
     actionDisabled: false,
     actionVisible: true,
     atEnd: false,
+    atStart: true,
     firstItemKey: 'message-a',
     initialAutoFillAllowed: false,
     lastAttemptedFirstItemKey: null,
@@ -283,9 +284,20 @@ describe('shouldAutoLoadEarlier', () => {
   it('cold-fills a near-start window while the initial bounded budget is available', () => {
     expect(shouldAutoLoadEarlier({
       ...eligible,
+      atEnd: true,
       initialAutoFillAllowed: true,
       userScrolledForOlder: false,
     })).toBe(true);
+  });
+
+  it('does not cold-fill after the initial window already fills the viewport', () => {
+    expect(shouldAutoLoadEarlier({
+      ...eligible,
+      atEnd: true,
+      atStart: false,
+      initialAutoFillAllowed: true,
+      userScrolledForOlder: false,
+    })).toBe(false);
   });
 
   it('keeps user-driven history prefetch disabled while pinned at the end', () => {
@@ -297,6 +309,7 @@ describe('shouldAutoLoadEarlier', () => {
     expect(shouldAutoLoadEarlier({
       ...eligible,
       atEnd: true,
+      atStart: true,
       initialAutoFillAllowed: true,
       userScrolledForOlder: false,
     })).toBe(true);

--- a/apps/mobile/src/__tests__/messageSelectionDesktopFirst.test.ts
+++ b/apps/mobile/src/__tests__/messageSelectionDesktopFirst.test.ts
@@ -67,6 +67,8 @@ describe('mobile message text selection', () => {
     // 跨段选择:连续纯文本块合并进同一个原生文本视图(text_run),原生选择手柄可横跨段落。
     // Android 上长 selectable Text 分块,避免单个超高原生文本视图干扰列表测高/滚动。
     expect(markdownBodySource).toContain('ANDROID_SELECTABLE_TEXT_RUN_GROUPING_OPTIONS');
+    expect(markdownBodySource).toContain("const textRunGroupingOptions = Platform.OS === 'android'");
+    expect(markdownBodySource).not.toContain("selectable === true && Platform.OS === 'android'");
     expect(markdownBodySource).toContain('groupMobileMarkdownSelectableBlocks(blocks, textRunGroupingOptions)');
     expect(markdownBodySource).toContain('testID="message.markdownTextRun"');
     expect(markdownBodySource).toContain("lineHeight: layout.markdownBodyGap");

--- a/apps/mobile/src/__tests__/messageWebViewGovernance.test.ts
+++ b/apps/mobile/src/__tests__/messageWebViewGovernance.test.ts
@@ -49,8 +49,9 @@ describe('message WebView visibility wiring', () => {
     expect(renderer).toContain('active={heavyContentVisible}');
     expect(renderer).toContain('getWebViewMetrics: getMobileMessageWebViewMetrics');
     expect(renderer).toContain('getMarkdownMetrics: getMobileMarkdownRenderMetrics');
-    expect(renderer).toContain('const recycleItems = __DEV__ && devRecycleItems === true;');
+    expect(renderer).toContain('const recycleItems = __DEV__ ? devRecycleItems === true : true;');
     expect(renderer).toContain('recycleItems={recycleItems}');
+    expect(renderer).toContain('getItemType={mobileMessageListItemType}');
     expect(mermaid).toContain('active?: boolean;');
     expect(mermaid).toMatch(/active\s*\?\s*<WebView/);
     expect(math).toContain('active?: boolean;');

--- a/apps/mobile/src/__tests__/messageWebViewGovernance.test.ts
+++ b/apps/mobile/src/__tests__/messageWebViewGovernance.test.ts
@@ -69,6 +69,8 @@ describe('message WebView visibility wiring', () => {
     expect(mermaid).toContain('}, [active, source]);');
     expect(media).toContain('stopPlaybackAndLoading');
     expect(media).toContain('webViewRef.current?.stopLoading();');
+    expect(media).toContain('lifecycleRef.current.consumeReloadOnActive()');
+    expect(media).toContain('key={reloadGeneration}');
     expect(media).toContain('if (!mountedRef.current) return;');
     expect(composer).toContain('if (disposedRef.current) return;');
   });

--- a/apps/mobile/src/__tests__/messageWebViewGovernance.test.ts
+++ b/apps/mobile/src/__tests__/messageWebViewGovernance.test.ts
@@ -1,0 +1,66 @@
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+import { beforeEach, describe, expect, it } from 'vitest';
+import {
+  getMobileMessageWebViewMetrics,
+  registerMobileMessageWebView,
+  resetMobileMessageWebViewMetrics,
+} from '@/session/mobileMessageWebViewMetrics';
+
+describe('mobile message WebView lifecycle accounting', () => {
+  beforeEach(() => resetMobileMessageWebViewMetrics());
+
+  it('counts active instances by kind and makes cleanup idempotent', () => {
+    const releaseMermaid = registerMobileMessageWebView('mermaid');
+    const releaseMath = registerMobileMessageWebView('math');
+
+    expect(getMobileMessageWebViewMetrics()).toMatchObject({
+      mounted: 2,
+      mountedByKind: { mermaid: 1, math: 1, media: 0, composer: 0 },
+      mounts: 2,
+      unmounts: 0,
+    });
+
+    releaseMermaid();
+    releaseMermaid();
+    releaseMath();
+    expect(getMobileMessageWebViewMetrics()).toMatchObject({
+      mounted: 0,
+      mountedByKind: { mermaid: 0, math: 0, media: 0, composer: 0 },
+      mounts: 2,
+      unmounts: 2,
+    });
+  });
+});
+
+describe('message WebView visibility wiring', () => {
+  it('gates heavy message blocks without changing the list virtualization contract', () => {
+    const renderer = readFileSync(
+      resolve(process.cwd(), 'src/session/MessageRenderer.tsx'),
+      'utf8',
+    );
+    const mermaid = readFileSync(resolve(process.cwd(), 'src/session/mermaidWebView.tsx'), 'utf8');
+    const math = readFileSync(resolve(process.cwd(), 'src/session/mathWebView.tsx'), 'utf8');
+    const media = readFileSync(resolve(process.cwd(), 'src/session/mediaPlayerWebView.tsx'), 'utf8');
+    const composer = readFileSync(resolve(process.cwd(), 'src/session/ComposerRichInput.tsx'), 'utf8');
+
+    expect(renderer).toContain('MessageListVisibleKeysContext.Provider');
+    expect(renderer).toContain('isListItem');
+    expect(renderer).toContain('active={heavyContentVisible}');
+    expect(renderer).toContain('getWebViewMetrics: getMobileMessageWebViewMetrics');
+    expect(renderer).toContain('getMarkdownMetrics: getMobileMarkdownRenderMetrics');
+    expect(renderer).toContain('const recycleItems = __DEV__ && devRecycleItems === true;');
+    expect(renderer).toContain('recycleItems={recycleItems}');
+    expect(mermaid).toContain('active?: boolean;');
+    expect(mermaid).toMatch(/active\s*\?\s*<WebView/);
+    expect(math).toContain('active?: boolean;');
+    expect(math).toMatch(/active\s*\?\s*<WebView/);
+    expect(math).toContain('renderGenerationRef.current !== renderGeneration');
+    expect(mermaid).toContain('pendingExportsRef.current.clear();');
+    expect(mermaid).toContain('}, [active, source]);');
+    expect(media).toContain('stopPlaybackAndLoading');
+    expect(media).toContain('webViewRef.current?.stopLoading();');
+    expect(media).toContain('if (!mountedRef.current) return;');
+    expect(composer).toContain('if (disposedRef.current) return;');
+  });
+});

--- a/apps/mobile/src/__tests__/messageWebViewGovernance.test.ts
+++ b/apps/mobile/src/__tests__/messageWebViewGovernance.test.ts
@@ -44,11 +44,19 @@ describe('message WebView visibility wiring', () => {
     const media = readFileSync(resolve(process.cwd(), 'src/session/mediaPlayerWebView.tsx'), 'utf8');
     const composer = readFileSync(resolve(process.cwd(), 'src/session/ComposerRichInput.tsx'), 'utf8');
 
-    expect(renderer).toContain('MessageListVisibleKeysContext.Provider');
-    expect(renderer).toContain('isListItem');
+    expect(renderer).not.toContain('MessageListVisibleKeysContext');
+    expect(renderer).toContain('useViewability<MobileMessageRenderItem>(');
+    expect(renderer).toContain('const heavyContentVisible = focused || isViewable;');
+    expect(renderer).toContain('function ViewabilityGatedMermaidDiagram(');
+    expect(renderer).toContain('function ViewabilityGatedMathFormula(');
     expect(renderer).toContain('active={heavyContentVisible}');
+    const markdownBodyStart = renderer.indexOf('function MarkdownBody(');
+    const markdownBodyEnd = renderer.indexOf('\nfunction ', markdownBodyStart + 1);
+    const markdownBody = renderer.slice(markdownBodyStart, markdownBodyEnd);
+    expect(markdownBody).not.toContain('useContext(MessageHeavyContentVisibilityContext)');
     expect(renderer).toContain('getWebViewMetrics: getMobileMessageWebViewMetrics');
     expect(renderer).toContain('getMarkdownMetrics: getMobileMarkdownRenderMetrics');
+    expect(renderer).toContain('devRecycleItems = true,');
     expect(renderer).toContain('const recycleItems = __DEV__ ? devRecycleItems === true : true;');
     expect(renderer).toContain('recycleItems={recycleItems}');
     expect(renderer).toContain('getItemType={mobileMessageListItemType}');

--- a/apps/mobile/src/__tests__/messageWebViewGovernance.test.ts
+++ b/apps/mobile/src/__tests__/messageWebViewGovernance.test.ts
@@ -56,8 +56,8 @@ describe('message WebView visibility wiring', () => {
     expect(markdownBody).not.toContain('useContext(MessageHeavyContentVisibilityContext)');
     expect(renderer).toContain('getWebViewMetrics: getMobileMessageWebViewMetrics');
     expect(renderer).toContain('getMarkdownMetrics: getMobileMarkdownRenderMetrics');
-    expect(renderer).toContain('devRecycleItems = true,');
-    expect(renderer).toContain('const recycleItems = __DEV__ ? devRecycleItems === true : true;');
+    expect(renderer).toContain('devRecycleItems = false,');
+    expect(renderer).toContain('const recycleItems = __DEV__ ? devRecycleItems === true : false;');
     expect(renderer).toContain('recycleItems={recycleItems}');
     expect(renderer).toContain('getItemType={mobileMessageListItemType}');
     expect(mermaid).toContain('active?: boolean;');

--- a/apps/mobile/src/__tests__/mobileMarkdownRenderMetrics.test.ts
+++ b/apps/mobile/src/__tests__/mobileMarkdownRenderMetrics.test.ts
@@ -1,0 +1,32 @@
+import { beforeEach, describe, expect, it } from 'vitest';
+import { parseMobileMarkdownDocument } from '@/session/messageMarkdown';
+import {
+  getMobileMarkdownRenderMetrics,
+  recordMobileMarkdownParse,
+  recordMobileMessageRenderItem,
+  resetMobileMarkdownRenderMetrics,
+} from '@/session/mobileMarkdownRenderMetrics';
+
+describe('mobile Markdown/render metrics', () => {
+  beforeEach(() => resetMobileMarkdownRenderMetrics());
+
+  it('separates full and incremental parses and accumulates allocation counters', () => {
+    const full = parseMobileMarkdownDocument('one');
+    const incremental = { ...full, incremental: true, reusedBlockCount: 1, parsedSourceUtf16Length: 4 };
+
+    recordMobileMarkdownParse(full, 2.5);
+    recordMobileMarkdownParse(incremental, 1.25);
+    recordMobileMessageRenderItem();
+    recordMobileMessageRenderItem();
+
+    expect(getMobileMarkdownRenderMetrics()).toEqual({
+      fullParseCount: 1,
+      incrementalParseCount: 1,
+      reusedBlockCount: 1,
+      parsedSourceUtf16Length: 7,
+      parseDurationMsTotal: 3.75,
+      parseDurationMsMax: 2.5,
+      renderItemRebuildCount: 2,
+    });
+  });
+});

--- a/apps/mobile/src/__tests__/remoteMediaResolveQueue.test.ts
+++ b/apps/mobile/src/__tests__/remoteMediaResolveQueue.test.ts
@@ -98,7 +98,7 @@ describe('remoteMediaResolveQueue', () => {
     expect(resolve).toHaveBeenCalledTimes(1);
   });
 
-  it('bounds resolved cache bytes and evicts the least recently used entry', async () => {
+  it('bounds resolved cache bytes without deleting an LRU entry still held by mounted rows', async () => {
     const { pending, resolve } = manualResolver();
     const orphaned: MobileResolvedRemoteMedia[] = [];
     const queue = createRemoteMediaResolveQueue(
@@ -121,7 +121,12 @@ describe('remoteMediaResolveQueue', () => {
     expect(queue.peekFresh(imageRequest('a.png').url)).not.toBeNull();
     expect(queue.peekFresh(imageRequest('b.png').url)).toBeNull();
     expect(queue.peekFresh(imageRequest('c.png').url)).not.toBeNull();
-    expect(orphaned.map((media) => media.ossKey)).toEqual(['key/b.png']);
+    expect(orphaned).toEqual([]);
+    expect(queue.releaseAll().map((media) => media.ossKey).sort()).toEqual([
+      'key/a.png',
+      'key/b.png',
+      'key/c.png',
+    ]);
   });
 
   it('dedupes concurrent requests for the same url into one resolve call', async () => {
@@ -315,6 +320,26 @@ describe('remoteMediaResolveQueue', () => {
     expect(resolve).toHaveBeenCalledTimes(2);
   });
 
+  it('keeps only a small cleanup record after evicting inline bytes', async () => {
+    const resolve = vi.fn(async (media: RemoteMediaRequest) => resolvedMedia(media.url, {
+      ossKey: 'key/inline',
+      inlineBase64: 'large-inline-payload',
+    }));
+    const onOrphanResolved = vi.fn();
+    const queue = createRemoteMediaResolveQueue({ resolve, onOrphanResolved });
+
+    await queue.request(imageRequest('a.png'));
+    queue.evict('xdt-image://cache/a.png');
+
+    expect(onOrphanResolved).not.toHaveBeenCalled();
+    const released = queue.releaseAll();
+    expect(released).toEqual([
+      expect.objectContaining({ ossKey: 'key/inline', url: '' }),
+    ]);
+    expect(released[0]).not.toHaveProperty('inlineBase64');
+    expect(queue.releaseAll()).toEqual([]);
+  });
+
   it('releaseAll empties the cache and returns every resolved entry', async () => {
     const resolve = vi.fn(async (media: RemoteMediaRequest) => resolvedMedia(media.url));
     const queue = createRemoteMediaResolveQueue({ resolve });
@@ -376,7 +401,7 @@ describe('remoteMediaResolveQueue', () => {
     expect(onOrphanResolved).toHaveBeenCalledTimes(1); // 只有 in-flight 的 a.png 走 orphan
   });
 
-  it('hands the replaced entry to onOrphanResolved when a refresh overwrites the cache', async () => {
+  it('defers cleanup of a refresh-replaced entry until final releaseAll', async () => {
     const { pending, resolve } = manualResolver();
     const onOrphanResolved = vi.fn();
     const queue = createRemoteMediaResolveQueue({ resolve, onOrphanResolved });
@@ -386,23 +411,22 @@ describe('remoteMediaResolveQueue', () => {
     pending[0]?.resolve(resolvedMedia('a.png', { ossKey: 'key/old' }));
     await p1;
 
-    // forceRefresh 重取,拿到不同 ossKey → 旧对象交还宿主补删
+    // forceRefresh 重取,拿到不同 ossKey → 旧对象退出 cache,但仍可能被挂载行持有。
     const p2 = queue.request(imageRequest('a.png'), { forceRefresh: true });
     await flush();
     pending[1]?.resolve(resolvedMedia('a.png', { ossKey: 'key/new' }));
     await p2;
-    expect(onOrphanResolved).toHaveBeenCalledTimes(1);
-    expect(onOrphanResolved).toHaveBeenCalledWith(expect.objectContaining({ ossKey: 'key/old' }));
+    expect(onOrphanResolved).not.toHaveBeenCalled();
 
     // 同 ossKey 覆盖(被控端去重返回同一对象)→ 不误删仍在用的对象
     const p3 = queue.request(imageRequest('a.png'), { forceRefresh: true });
     await flush();
     pending[2]?.resolve(resolvedMedia('a.png', { ossKey: 'key/new' }));
     await p3;
-    expect(onOrphanResolved).toHaveBeenCalledTimes(1);
+    expect(onOrphanResolved).not.toHaveBeenCalled();
 
-    // releaseAll 只返回当前条目(新 key)
-    expect(queue.releaseAll().map((m) => m.ossKey)).toEqual(['key/new']);
+    // 真正离场时旧对象和当前对象一起交还宿主,且按 ossKey 去重。
+    expect(queue.releaseAll().map((m) => m.ossKey).sort()).toEqual(['key/new', 'key/old']);
   });
 
   it('re-flies forceRefresh with skipCache instead of joining an in-flight plain resolve', async () => {
@@ -429,7 +453,7 @@ describe('remoteMediaResolveQueue', () => {
     expect(queue.peekFresh('xdt-image://cache/a.png')?.ossKey).toBe('key/fresh');
   });
 
-  it('evicts the proven-bad cache entry when a forced refresh fails', async () => {
+  it('evicts a proven-bad cache entry but defers its OSS cleanup until final release', async () => {
     const { pending, resolve } = manualResolver();
     const onOrphanResolved = vi.fn();
     let clock = 1_000;
@@ -440,14 +464,14 @@ describe('remoteMediaResolveQueue', () => {
     pending[0]?.resolve(resolvedMedia('a.png', { ossKey: 'key/bad' }));
     await p1;
 
-    // Image onError 后的强制重取失败(桌面离线):坏条目必须逐出并交还补删,
+    // Image onError 后的强制重取失败(桌面离线):坏条目必须逐出,
     // 否则后续被动请求会继续命中已证伪的对象。
     const p2 = queue.request(imageRequest('a.png'), { forceRefresh: true });
     await flush();
     pending[1]?.reject(new Error('desktop offline'));
     await expect(p2).rejects.toThrow('desktop offline');
     expect(queue.peekFresh('xdt-image://cache/a.png')).toBeNull();
-    expect(onOrphanResolved).toHaveBeenCalledWith(expect.objectContaining({ ossKey: 'key/bad' }));
+    expect(onOrphanResolved).not.toHaveBeenCalled();
 
     // 负缓存过期后,新的被动请求走全新取件而不是旧缓存
     clock += 30_000;
@@ -456,6 +480,7 @@ describe('remoteMediaResolveQueue', () => {
     expect(resolve).toHaveBeenCalledTimes(3);
     pending[2]?.resolve(resolvedMedia('a.png', { ossKey: 'key/new' }));
     await expect(p3).resolves.toMatchObject({ ossKey: 'key/new' });
+    expect(queue.releaseAll().map((media) => media.ossKey).sort()).toEqual(['key/bad', 'key/new']);
   });
 
   it('routes in-flight resolves that complete after releaseAll to onOrphanResolved', async () => {

--- a/apps/mobile/src/__tests__/remoteMediaResolveQueue.test.ts
+++ b/apps/mobile/src/__tests__/remoteMediaResolveQueue.test.ts
@@ -98,6 +98,32 @@ describe('remoteMediaResolveQueue', () => {
     expect(resolve).toHaveBeenCalledTimes(1);
   });
 
+  it('bounds resolved cache bytes and evicts the least recently used entry', async () => {
+    const { pending, resolve } = manualResolver();
+    const orphaned: MobileResolvedRemoteMedia[] = [];
+    const queue = createRemoteMediaResolveQueue(
+      { resolve, onOrphanResolved: (media) => orphaned.push(media) },
+      { maxConcurrent: 1, maxCacheBytes: 2_000 },
+    );
+    const resolveOne = async (name: string): Promise<MobileResolvedRemoteMedia> => {
+      const promise = queue.request(imageRequest(name));
+      await flush();
+      pending.at(-1)?.resolve(resolvedMedia(name, { size: 1_000 }));
+      return promise;
+    };
+
+    await resolveOne('a.png');
+    await resolveOne('b.png');
+    // Refresh A so B becomes the oldest entry.
+    expect(queue.peekFresh(imageRequest('a.png').url)).not.toBeNull();
+    await resolveOne('c.png');
+
+    expect(queue.peekFresh(imageRequest('a.png').url)).not.toBeNull();
+    expect(queue.peekFresh(imageRequest('b.png').url)).toBeNull();
+    expect(queue.peekFresh(imageRequest('c.png').url)).not.toBeNull();
+    expect(orphaned.map((media) => media.ossKey)).toEqual(['key/b.png']);
+  });
+
   it('dedupes concurrent requests for the same url into one resolve call', async () => {
     const { pending, resolve } = manualResolver();
     const queue = createRemoteMediaResolveQueue({ resolve });

--- a/apps/mobile/src/__tests__/remoteSessionStore.test.ts
+++ b/apps/mobile/src/__tests__/remoteSessionStore.test.ts
@@ -4761,6 +4761,32 @@ describe('任务消息内存治理', () => {
     expect(sessions.slice(1).some((item) => remoteSessionStore.getMessages(item.id).length === 0)).toBe(true);
   });
 
+  it('regular 字节 LRU 会计入深层容器中的大字符串', () => {
+    remoteSessionStore.setDeviceSessions('dev-1', 'Mac', [session('s0'), session('s1')]);
+    const currentAuthority = remoteSessionStore.enterSessionMessageDetail('s1');
+    remoteSessionStore.setMessages('s1', [message('current', 's1')], { authority: currentAuthority });
+
+    // 同一字符串引用复用四次,避免测试本身额外分配 72 MiB;逻辑 payload 序列化后
+    // 仍会产生四份内容。旧 depth=3 截断会在 chunks 外层直接按 64 bytes 低估。
+    const chunk = 'x'.repeat(9 * 1024 * 1024);
+    const deepPayload = {
+      level1: {
+        level2: {
+          level3: {
+            chunks: [chunk, chunk, chunk, chunk],
+          },
+        },
+      },
+    };
+    remoteSessionStore.setMessages('s0', [{
+      ...message('deep', 's0'),
+      content: deepPayload,
+    }]);
+
+    expect(remoteSessionStore.getMessages('s0')).toEqual([]);
+    expect(remoteSessionStore.getMessages('s1').map((row) => row.id)).toEqual(['current']);
+  });
+
   it('regular LRU 只淘汰可重取正文，不丢尚未落盘的本地系统卡', () => {
     const sessions = Array.from({ length: 9 }, (_, index) => session(`s${index}`));
     remoteSessionStore.setDeviceSessions('dev-1', 'Mac', sessions);

--- a/apps/mobile/src/__tests__/scrollWindowModel.test.ts
+++ b/apps/mobile/src/__tests__/scrollWindowModel.test.ts
@@ -7,11 +7,12 @@ import {
   MOBILE_ANCHOR_VERIFY_MAX_ATTEMPTS,
   MOBILE_ANCHOR_VERIFY_MAX_WAIT_ROUNDS,
   MOBILE_ANCHOR_VERIFY_TOLERANCE,
+  shouldPreserveMobileHistoryBrowseIntent,
 } from '@/session/messageScroll';
 
 // evaluateMessageWindowUpdate 是容器无关的纯函数,驱动「新消息红点 / 近底自动跟随」判定。
 // 迁移到 LegendList 后仍由它决定 hasNewMessages(贴底跟随交给 maintainScrollAtEnd,防跳交给
-// maintainVisibleContentPosition);容器 prop 契约见 messageListVirtualization.test.ts。
+// 应用层 key/offset 锚定);容器 prop 契约见 messageListVirtualization.test.ts。
 describe('scrollWindowModel', () => {
   it('auto-follows the initial visible window without showing a new-message chip', () => {
     expect(evaluateMessageWindowUpdate({
@@ -108,6 +109,23 @@ describe('scrollWindowModel', () => {
     expect(source).toMatch(
       /setLatestMessageWindow\(sessionId, historyPage, \{\s*authority: messageAuthority,\s*moreBeyondWindow,\s*\}\)/,
     );
+  });
+});
+
+describe('history browse intent', () => {
+  it('rejects passive anchor offsets but allows a real user-controlled return to latest', () => {
+    expect(shouldPreserveMobileHistoryBrowseIntent({
+      historyBrowseIntent: true,
+      userControllingScroll: false,
+    })).toBe(true);
+    expect(shouldPreserveMobileHistoryBrowseIntent({
+      historyBrowseIntent: true,
+      userControllingScroll: true,
+    })).toBe(false);
+    expect(shouldPreserveMobileHistoryBrowseIntent({
+      historyBrowseIntent: false,
+      userControllingScroll: false,
+    })).toBe(false);
   });
 });
 

--- a/apps/mobile/src/__tests__/sessionMainLayerDesktopFirst.test.ts
+++ b/apps/mobile/src/__tests__/sessionMainLayerDesktopFirst.test.ts
@@ -19,7 +19,7 @@ describe('mobile session main layer desktop-first noise budget', () => {
     const rendererSource = readFileSync(resolve(process.cwd(), 'src/session/MessageRenderer.tsx'), 'utf8');
     const routeSource = readFileSync(resolve(process.cwd(), 'app/sessions/[sessionId].tsx'), 'utf8');
 
-    // 首同步期消息区渲染 SyncingMessages(spinner + 「正在同步」,延迟显形防快速路径闪烁),
+    // 首同步期消息区立即渲染 SyncingMessages(spinner + 「正在同步」),
     // 而不是干净空白——手机消息要走 device-link 往返桌面,空白会被读成"卡住了"。
     const syncingStart = rendererSource.indexOf('function SyncingMessages');
     expect(syncingStart).toBeGreaterThan(-1);
@@ -27,7 +27,7 @@ describe('mobile session main layer desktop-first noise budget', () => {
     const syncingSource = rendererSource.slice(syncingStart, syncingEnd);
     expect(syncingSource).toContain('message.renderer.syncing');
     expect(syncingSource).toContain('ActivityIndicator');
-    expect(rendererSource).toContain('SYNCING_PLACEHOLDER_DELAY_MS');
+    expect(syncingSource).not.toContain('setTimeout');
     expect(rendererSource).toContain('ListEmptyComponent={syncingWhileEmpty');
     expect(rendererSource).toContain('<SyncingMessages />');
     expect(routeSource).toContain('syncingWhileEmpty={syncingWhileEmpty}');

--- a/apps/mobile/src/__tests__/sessionMessageMemoryWiring.test.ts
+++ b/apps/mobile/src/__tests__/sessionMessageMemoryWiring.test.ts
@@ -98,14 +98,17 @@ describe('任务消息内存治理页面接线', () => {
     expect(store).toContain('remoteSessionStore.isSessionMessageAuthorityCurrent(authority)');
   });
 
-  it('屏幕失焦时也释放媒体队列，避免栈页面切换后累积内存条目', () => {
+  it('只在任务切换或页面卸载时最终释放媒体队列', () => {
     const queueStart = screen.indexOf('const releaseRemoteMediaQueue = useCallback');
     expect(queueStart).toBeGreaterThanOrEqual(0);
-    const queueBlock = screen.slice(queueStart, queueStart + 1400);
+    const queueEnd = screen.indexOf('const backfillRunSeqRef', queueStart);
+    const queueBlock = screen.slice(queueStart, queueEnd);
     expect(queueBlock).toContain('remoteMediaQueueRef.current?.releaseAll()');
     expect(queueBlock).toContain('remoteMediaQueueRef.current = null;');
-    expect(queueBlock).toContain('remoteMediaQueueRef.current = createRemoteMediaQueue();');
-    expect(queueBlock).toContain('useFocusEffect(');
+    expect(queueBlock).toContain('[releaseRemoteMediaQueue, sessionId]');
     expect(queueBlock).toContain('releaseRemoteMediaQueue();');
+    // 失焦或退后台时组件仍挂载且持有 resolved URL,不能提前 DELETE OSS。
+    expect(queueBlock).not.toContain('useFocusEffect(');
+    expect(queueBlock).not.toContain("AppState.addEventListener('change'");
   });
 });

--- a/apps/mobile/src/__tests__/sessionMessageMemoryWiring.test.ts
+++ b/apps/mobile/src/__tests__/sessionMessageMemoryWiring.test.ts
@@ -97,4 +97,15 @@ describe('任务消息内存治理页面接线', () => {
     expect(store).toContain('isSessionMessageCacheWriteAuthorityCurrent(cacheAuthority)');
     expect(store).toContain('remoteSessionStore.isSessionMessageAuthorityCurrent(authority)');
   });
+
+  it('屏幕失焦时也释放媒体队列，避免栈页面切换后累积内存条目', () => {
+    const queueStart = screen.indexOf('const releaseRemoteMediaQueue = useCallback');
+    expect(queueStart).toBeGreaterThanOrEqual(0);
+    const queueBlock = screen.slice(queueStart, queueStart + 1400);
+    expect(queueBlock).toContain('remoteMediaQueueRef.current?.releaseAll()');
+    expect(queueBlock).toContain('remoteMediaQueueRef.current = null;');
+    expect(queueBlock).toContain('remoteMediaQueueRef.current = createRemoteMediaQueue();');
+    expect(queueBlock).toContain('useFocusEffect(');
+    expect(queueBlock).toContain('releaseRemoteMediaQueue();');
+  });
 });

--- a/apps/mobile/src/__tests__/swipeableSessionRowLifecycle.test.ts
+++ b/apps/mobile/src/__tests__/swipeableSessionRowLifecycle.test.ts
@@ -1,0 +1,20 @@
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+import { describe, expect, it } from 'vitest';
+
+const source = readFileSync(
+  resolve(process.cwd(), 'src/session/SwipeableSessionRow.tsx'),
+  'utf8',
+);
+
+describe('SwipeableSessionRow native animation lifecycle', () => {
+  it('does not schedule a no-op timing animation when an action panel mounts', () => {
+    expect(source).toContain('const armedProgress = useSharedValue(0);');
+    expect(source).toContain('if (previous === null) {');
+    expect(source).toContain('armedProgress.value = next ? 1 : 0;');
+    expect(source).toContain(
+      'armedProgress.value = withTiming(next ? 1 : 0, { duration: ARM_ANIMATION_MS });',
+    );
+    expect(source).not.toContain('const armedProgress = useDerivedValue(');
+  });
+});

--- a/apps/mobile/src/__tests__/swipeableSessionRowLifecycle.test.ts
+++ b/apps/mobile/src/__tests__/swipeableSessionRowLifecycle.test.ts
@@ -8,13 +8,27 @@ const source = readFileSync(
 );
 
 describe('SwipeableSessionRow native animation lifecycle', () => {
-  it('does not schedule a no-op timing animation when an action panel mounts', () => {
-    expect(source).toContain('const armedProgress = useSharedValue(0);');
-    expect(source).toContain('if (previous === null) {');
-    expect(source).toContain('armedProgress.value = next ? 1 : 0;');
-    expect(source).toContain(
-      'armedProgress.value = withTiming(next ? 1 : 0, { duration: ARM_ANIMATION_MS });',
-    );
-    expect(source).not.toContain('const armedProgress = useDerivedValue(');
+  it('uses the classic RNGH Swipeable instead of Reanimated synchronous UI props', () => {
+    expect(source).toContain('ClassicSwipeable as Swipeable');
+    expect(source).not.toContain('ReanimatedSwipeable as Swipeable');
+    expect(source).not.toContain("from 'react-native-reanimated'");
+  });
+
+  it('reads the release position instead of a peak and disposes Animated listeners', () => {
+    expect(source).toContain('const value = translationRef.current?.__getValue?.();');
+    expect(source).toContain('const releaseTranslation = readReleaseTranslation();');
+    expect(source).not.toContain('peakTranslationRef');
+    expect(source).toContain('translation.removeListener(listenerId)');
+    expect(source).toContain('armedProgress.stopAnimation();');
+  });
+
+  it('keeps only fixed action shells mounted until a swipe starts', () => {
+    expect(source).toContain('const [mountedActionRowKey, setMountedActionRowKey] = useState<string | null>(null);');
+    expect(source).toContain('const actionsMounted = mountedActionRowKey === rowKey;');
+    expect(source).toContain('setMountedActionRowKey(rowKey);');
+    expect(source).toContain('setMountedActionRowKey(null);');
+    expect(source).toContain('{actionsMounted ? (');
+    expect(source).toContain('<View style={styles.pinShell}>');
+    expect(source).toContain('<View style={styles.rightShell}>');
   });
 });

--- a/apps/mobile/src/__tests__/swipeableSessionRowLifecycle.test.ts
+++ b/apps/mobile/src/__tests__/swipeableSessionRowLifecycle.test.ts
@@ -31,4 +31,9 @@ describe('SwipeableSessionRow native animation lifecycle', () => {
     expect(source).toContain('<View style={styles.pinShell}>');
     expect(source).toContain('<View style={styles.rightShell}>');
   });
+
+  it('keeps the two right-side action buttons evenly spaced', () => {
+    expect(source).toMatch(/optionsButton:\s*\{[\s\S]*?right: BUTTON_GAP \* 2 \+ BUTTON_SIZE,/);
+    expect(source).toMatch(/archiveButton:\s*\{[\s\S]*?right: BUTTON_GAP,/);
+  });
 });

--- a/apps/mobile/src/platform/gestureHandler.tsx
+++ b/apps/mobile/src/platform/gestureHandler.tsx
@@ -15,16 +15,20 @@ import type {
   SwipeableMethods,
   SwipeableProps,
 } from 'react-native-gesture-handler/ReanimatedSwipeable';
+import type { SwipeableProps as ClassicSwipeableProps } from 'react-native-gesture-handler/Swipeable';
 
 type GestureHandlerModule = typeof import('react-native-gesture-handler');
 type ReanimatedSwipeableModule =
   typeof import('react-native-gesture-handler/ReanimatedSwipeable');
+type ClassicSwipeableModule =
+  typeof import('react-native-gesture-handler/Swipeable');
 
 const isStoreClient =
   Constants.executionEnvironment === ExecutionEnvironment.StoreClient;
 
 let gestureHandlerModule: GestureHandlerModule | null | undefined;
 let reanimatedSwipeableModule: ReanimatedSwipeableModule | null | undefined;
+let classicSwipeableModule: ClassicSwipeableModule | null | undefined;
 
 function loadGestureHandler(): GestureHandlerModule | null {
   if (isStoreClient) return null;
@@ -44,6 +48,16 @@ function loadReanimatedSwipeable(): ReanimatedSwipeableModule | null {
     ) as ReanimatedSwipeableModule;
   }
   return reanimatedSwipeableModule;
+}
+
+function loadClassicSwipeable(): ClassicSwipeableModule | null {
+  if (isStoreClient) return null;
+  if (classicSwipeableModule === undefined) {
+    classicSwipeableModule = require(
+      'react-native-gesture-handler/Swipeable',
+    ) as ClassicSwipeableModule;
+  }
+  return classicSwipeableModule;
 }
 
 function NoopGestureHandlerRootView(props: ViewProps) {
@@ -91,6 +105,25 @@ const NoopReanimatedSwipeable = forwardRef<SwipeableMethods, SwipeableProps>(
 );
 NoopReanimatedSwipeable.displayName = 'NoopReanimatedSwipeable';
 
+export interface ClassicSwipeableMethods {
+  close(): void;
+  openLeft(): void;
+  openRight(): void;
+  reset(): void;
+}
+
+const NoopClassicSwipeable = forwardRef<ClassicSwipeableMethods, ClassicSwipeableProps>(
+  ({ children, containerStyle, testID }, ref) => {
+    useImperativeHandle(ref, () => noopSwipeableMethods, []);
+    return (
+      <View style={containerStyle} testID={testID}>
+        {children}
+      </View>
+    );
+  },
+);
+NoopClassicSwipeable.displayName = 'NoopClassicSwipeable';
+
 export const GestureHandlerRootView =
   loadGestureHandler()?.GestureHandlerRootView ??
   (NoopGestureHandlerRootView as unknown as typeof GestureHandlerRootViewApi);
@@ -104,6 +137,12 @@ export const Gesture = loadGestureHandler()?.Gesture ?? noopGestureApi;
 export const ReanimatedSwipeable =
   loadReanimatedSwipeable()?.default ??
   (NoopReanimatedSwipeable as unknown as React.ComponentType<SwipeableProps>);
+
+export const ClassicSwipeable = (
+  loadClassicSwipeable()?.default ?? NoopClassicSwipeable
+) as unknown as React.ComponentType<
+  ClassicSwipeableProps & React.RefAttributes<ClassicSwipeableMethods>
+>;
 
 export const SwipeDirection = loadReanimatedSwipeable()?.SwipeDirection ?? {
   LEFT: 'left',

--- a/apps/mobile/src/session/ComposerRichInput.tsx
+++ b/apps/mobile/src/session/ComposerRichInput.tsx
@@ -18,6 +18,7 @@ import {
   type ComposerWebMessage,
 } from '@/session/composerRichInputProtocol';
 import { COMPOSER_PASTED_IMAGE_FILE_PREFIX } from '@/session/pastedImageAttachment';
+import { registerMobileMessageWebView } from '@/session/mobileMessageWebViewMetrics';
 
 export interface ComposerRichInputHandle {
   applyDocumentAndSetSelectionToEnd(document: ComposerDocument): void;
@@ -78,6 +79,7 @@ export const ComposerRichInput = forwardRef<ComposerRichInputHandle, ComposerRic
     theme,
   }, forwardedRef) {
     const webViewRef = useRef<WebView | null>(null);
+    useEffect(() => registerMobileMessageWebView('composer'), []);
     const readyRef = useRef(false);
     const webSignatureRef = useRef('');
     const pendingDocumentRef = useRef<{
@@ -313,6 +315,7 @@ export const ComposerRichInput = forwardRef<ComposerRichInputHandle, ComposerRic
     }, [inject, resolveSessionLinkLabel]);
 
     const handleMessage = useCallback((event: WebViewMessageEvent) => {
+      if (disposedRef.current) return;
       const message = parseComposerWebMessage(event.nativeEvent.data);
       if (!message) return;
       if (message.type === 'ready') {

--- a/apps/mobile/src/session/MessageRenderer.tsx
+++ b/apps/mobile/src/session/MessageRenderer.tsx
@@ -319,7 +319,7 @@ import {
   MOBILE_MESSAGE_LIST_BOTTOM_PADDING,
   type MessageScrollMetrics,
   mobileMessageListBottomPadding,
-  previousUserMessageJumpTargetForWindow,
+  previousUserMessageJumpTarget,
   resolveMobileNearBottomOnScroll,
   shouldAutoLoadEarlier,
   shouldUnpinMobileFollowOnDrag,
@@ -366,13 +366,6 @@ const MOBILE_PROGRAMMATIC_ANIMATED_SCROLL_SETTLE_MS = 1400;
 /** Cold-open history fill is useful, but bounded so a short/duplicate host page cannot drain history forever. */
 const MAX_INITIAL_HISTORY_AUTOFILL_PAGES = 3;
 const MOBILE_MESSAGE_ESTIMATED_ITEM_SIZE = 140;
-/**
- * Cold/warm entry paints a tiny tail first, then prepends the full render model in-place.
- * A small tail avoids LegendList's hidden initial-scroll bootstrap. Older local items are
- * prepended in bounded chunks only when the user scrolls upward.
- */
-const MOBILE_INITIAL_TAIL_ITEM_COUNT = 4;
-const MOBILE_TAIL_REVEAL_ITEM_COUNT = 12;
 const ANDROID_SELECTABLE_TEXT_RUN_MAX_BLOCKS = 12;
 const ANDROID_SELECTABLE_TEXT_RUN_MAX_UTF16_LENGTH = 1800;
 const ANDROID_SELECTABLE_TEXT_RUN_GROUPING_OPTIONS: MobileMarkdownTextRunGroupingOptions = {
@@ -682,9 +675,6 @@ export function MessageRenderer({
   // load-earlier 的 prepend 撑高会被误当成底部增长 → scrollToEnd 把用户从刚加载的历史拽回最新(review P1)。
   // 用户重新拖动 / 主动跳底 / 切会话时解除。
   const readingOlderRef = useRef(false);
-  // “上一条用户消息”可能位于尚未挂载的本地尾窗之外；记录一次跳转，等目标 slice
-  // commit 后再用窗口内索引滚动。切会话必须同步清空，避免旧目标落到新列表。
-  const pendingPreviousUserJumpKeyRef = useRef<string | null>(null);
   // 每次补页分配 generation：旧会话 / 旧请求的异步 settle 不得清掉新请求的抑制态。
   const readingOlderRequestGenerationRef = useRef(0);
   // LegendList mVCP 始终开启；普通尾部 append / 流式 resize 同样会触发 native 锚点
@@ -734,7 +724,6 @@ export function MessageRenderer({
     initialHistoryAutofillRemainingRef.current = MAX_INITIAL_HISTORY_AUTOFILL_PAGES;
     lastAutoLoadEarlierKeyRef.current = null;
     readingOlderRef.current = false;
-    pendingPreviousUserJumpKeyRef.current = null;
     readingOlderRequestGenerationRef.current += 1;
     mvcpSettleAtRef.current = 0;
     programmaticScrollGenerationRef.current += 1;
@@ -923,52 +912,17 @@ export function MessageRenderer({
     });
   }, [devExposeList, scrollToOffsetProgrammatically]);
 
-  // 完整 render model 始终保留给搜索、画廊、分享、红点等业务逻辑。LegendList 首帧只接
-  // 尾部少量项，index 从 0 开始，不走 initialScrollIndex 的隐藏式 bootstrap。用户上翻时
-  // 再按小块 prepend 已在内存中的更早项，避免一次接回 100+ 变高行引发 mVCP 跳位。
+  // LegendList 始终接收完整 render model，由自身虚拟化 / 回收屏外 cell。冷进入常先以
+  // data=[] 挂载、再收到首批消息，因此 empty → ready 重挂一次，让非空列表重新应用初始
+  // offset。offset-only 路径直接写原生 contentOffset，不走 initialScrollIndex / AtEnd 的
+  // 多轮测量 bootstrap，也就不会在 bootstrap settle 期间长期隐藏 cell。
   const listData = useMemo(() => [...items], [items]);
-  // 冷进入常先以 data=[] 挂载、再收到首批消息；LegendList 的 onLoad 对同一实例只触发一次，
-  // 因此 empty → ready 重挂一次，让真实尾窗拥有独立的首绘回调。
   const listMountKey = `${scrollResetKey ?? 'default'}:${listData.length === 0 ? 'empty' : 'ready'}`;
-  const [tailWindowAnchor, setTailWindowAnchor] = useState<{
-    identity: string;
-    firstKey: string;
-  } | null>(null);
-  const defaultTailWindowStartIndex = Math.max(0, listData.length - MOBILE_INITIAL_TAIL_ITEM_COUNT);
-  const anchoredTailWindowStartIndex = tailWindowAnchor?.identity === listMountKey
-    ? listData.findIndex((item) => item.key === tailWindowAnchor.firstKey)
-    : -1;
-  const tailWindowStartIndex = anchoredTailWindowStartIndex >= 0
-    ? anchoredTailWindowStartIndex
-    : defaultTailWindowStartIndex;
-  const initialTailWindowActive = tailWindowStartIndex > 0;
-  const visibleListData = useMemo(
-    () => listData.slice(tailWindowStartIndex),
-    [listData, tailWindowStartIndex],
-  );
-  const tailWindowRevealGenerationRef = useRef(0);
-  const revealTailWindowFromIndex = useCallback((nextStartIndex: number) => {
-    if (nextStartIndex < 0 || nextStartIndex >= tailWindowStartIndex) return false;
-    const nextFirstKey = listData[nextStartIndex]?.key;
-    if (!nextFirstKey) return false;
-    const generation = tailWindowRevealGenerationRef.current + 1;
-    tailWindowRevealGenerationRef.current = generation;
-    readingOlderRef.current = true;
-    markMobileMvcpSettle();
-    setTailWindowAnchor({ identity: listMountKey, firstKey: nextFirstKey });
-    requestAnimationFrame(() => {
-      if (tailWindowRevealGenerationRef.current === generation) {
-        readingOlderRef.current = false;
-      }
-    });
-    return true;
-  }, [listData, listMountKey, markMobileMvcpSettle, tailWindowStartIndex]);
-  const revealEarlierTailWindow = useCallback((all = false) => {
-    if (tailWindowStartIndex <= 0) return false;
-    return revealTailWindowFromIndex(all
-      ? 0
-      : Math.max(0, tailWindowStartIndex - MOBILE_TAIL_REVEAL_ITEM_COUNT));
-  }, [revealTailWindowFromIndex, tailWindowStartIndex]);
+  const initialScrollOffset = useMemo(() => {
+    if (listData.length === 0) return 0;
+    const estimatedContentHeight = listData.length * MOBILE_MESSAGE_ESTIMATED_ITEM_SIZE;
+    return Math.max(0, estimatedContentHeight - windowDimensions.height);
+  }, [listData.length, windowDimensions.height]);
   const prevListMountKeyRef = useRef(listMountKey);
   if (prevListMountKeyRef.current !== listMountKey) {
     prevListMountKeyRef.current = listMountKey;
@@ -1123,14 +1077,10 @@ export function MessageRenderer({
   const previousUserTarget = useMemo(
     () => (
       isAwayFromBottom
-        ? previousUserMessageJumpTargetForWindow(
-          listData,
-          tailWindowStartIndex,
-          firstVisibleIndex,
-        )
+        ? previousUserMessageJumpTarget(listData, firstVisibleIndex)
         : null
     ),
-    [firstVisibleIndex, isAwayFromBottom, listData, tailWindowStartIndex],
+    [firstVisibleIndex, isAwayFromBottom, listData],
   );
   const showJumpToLatest = isAwayFromBottom && !hasNewMessages;
   const focusRunKey = focusedItemKey
@@ -1295,23 +1245,8 @@ export function MessageRenderer({
     lastAutoLoadEarlierKeyRef.current = null;
     nearBottomRef.current = false;
     setIsAwayFromBottom(true);
-    if (previousUserTarget.windowIndex !== null) {
-      scrollToIndexProgrammatically(previousUserTarget.windowIndex, 0.12);
-      return;
-    }
-    // The target exists in the complete local model but is older than the mounted tail window.
-    // Mount only through that target, then issue the relative scroll after React commits the slice.
-    pendingPreviousUserJumpKeyRef.current = previousUserTarget.itemKey;
-    revealTailWindowFromIndex(previousUserTarget.index);
-  }, [previousUserTarget, revealTailWindowFromIndex, scrollToIndexProgrammatically]);
-  useEffect(() => {
-    const pendingKey = pendingPreviousUserJumpKeyRef.current;
-    if (!pendingKey) return;
-    const windowIndex = visibleListData.findIndex((item) => item.key === pendingKey);
-    if (windowIndex < 0) return;
-    pendingPreviousUserJumpKeyRef.current = null;
-    scrollToIndexProgrammatically(windowIndex, 0.12);
-  }, [scrollToIndexProgrammatically, visibleListData]);
+    scrollToIndexProgrammatically(previousUserTarget.index, 0.12);
+  }, [previousUserTarget, scrollToIndexProgrammatically]);
 
   // 「跳到最新」请求(会话外部触发,含发送消息后的跟随):命令式滚到底,随后跑一轮有界
   // 校验/补滚(runStickToLatestVerify)——单发的 scrollToEnd 落地一刻的 metrics 可能仍陈旧,
@@ -1374,9 +1309,6 @@ export function MessageRenderer({
 
   const attemptAutoLoadEarlier = useCallback(() => {
     if (!onLoadEarlier) return;
-    // 尾部本地窗口尚未展开完时，列表的“位于顶部”只代表临时尾窗，
-    // 不能据此请求网络历史；等 mVCP 锚定完整数组后再恢复正常电平判定。
-    if (initialTailWindowActive) return;
     // 热路径前置短路(滚动事件每 16ms 评估一次,getState() 每次新建状态对象):没有用户浏览意图
     // 且冷开预算已耗尽、或当前首项已尝试过时不碰 getState。完整判定仍以
     // shouldAutoLoadEarlier 为唯一真相,这里只做它的子集提前返回。
@@ -1404,7 +1336,6 @@ export function MessageRenderer({
     requestLoadEarlier();
   }, [
     firstItemKey,
-    initialTailWindowActive,
     loadEarlierAction.disabled,
     loadEarlierAction.visible,
     onLoadEarlier,
@@ -1479,21 +1410,11 @@ export function MessageRenderer({
     // 用户重新拖动 → 结束「读历史」态;解除态下滑回底的跟随恢复由 handleScroll
     // 的方向判定负责(nearBottomRef 翻 true 即重新打开贴底补滚)。
     readingOlderRef.current = false;
-    // 短尾窗可能一开始就同时位于 start/end，onStartReached 的初始边沿已被业务 guard
-    // 消费。用户在窗口顶部主动拖动时，先 prepend 一小块本地历史，不一次灌回完整任务。
-    if (initialTailWindowActive) {
-      const state = listRef.current?.getState();
-      if (state?.isAtStart || state?.isNearStart) revealEarlierTailWindow();
-    }
     // 翻完 refs 立即补一次电平评估:列表已顶死时(Android 无 bounce 尤甚)这次拖动不产生
     // offset 变化,不会有 onScroll / onStartReached,ref 写入也不驱动 effect——没有这一刀,
     // 「失败后停在顶部再拖一下重试」的信号会整体丢失(review P2)。
     attemptAutoLoadEarlier();
-  }, [
-    attemptAutoLoadEarlier,
-    initialTailWindowActive,
-    revealEarlierTailWindow,
-  ]);
+  }, [attemptAutoLoadEarlier]);
 
   // 拖动结束(手指离开,可能进入惯性滚动)→ 关闭拖动追踪。惯性阶段的上滑不需要再判
   // 解除:上滑手势的拖动段必然已越过死区完成解除;下滑回底的恢复由 scroll 方向判定接手。
@@ -1503,12 +1424,8 @@ export function MessageRenderer({
   }, []);
 
   const handleStartReached = useCallback(() => {
-    if (initialTailWindowActive) {
-      if (userScrollForOlderRef.current) revealEarlierTailWindow();
-      return;
-    }
     attemptAutoLoadEarlier();
-  }, [attemptAutoLoadEarlier, initialTailWindowActive, revealEarlierTailWindow]);
+  }, [attemptAutoLoadEarlier]);
 
   // eligibility 变化时重评估:上一页加载结束(disabled 翻 false)、入口点亮(visible 翻 true)、
   // prepend 落地(firstItemKey 变)。覆盖「用户停在顶部等待、无滚动事件」的全部哑火场景;
@@ -1523,17 +1440,15 @@ export function MessageRenderer({
     scrollMetricsRef.current = { ...scrollMetricsRef.current, viewportHeight };
   }, []);
 
-  // 尾窗完成首绘后直接显示并贴底；本地更早项只在用户上翻时按块前插。
-  // 不使用 initialScrollIndex：LegendList 会在该 bootstrap 完成前把 cell 容器 opacity 置 0，
-  // 即使目标只有几项也会人为制造“数据已在、消息仍空白”的窗口。
-  // 后续小块 prepend 由 maintainVisibleContentPosition 保住当前可见项。
+  // offset-only 初始定位不等待变高 cell 的多轮测量；onLoad 后仍做一次真实贴底校正，
+  // 随后的高度结算交给 content-size 跟随与 verifier。
   const handleListLoad = useCallback(() => {
     initialListReadyRef.current = true;
-    if (visibleListData.length > 0) {
+    if (listData.length > 0) {
       scrollToEndProgrammatically(false);
       runStickToLatestVerify();
     }
-  }, [runStickToLatestVerify, scrollToEndProgrammatically, visibleListData.length]);
+  }, [listData.length, runStickToLatestVerify, scrollToEndProgrammatically]);
 
   // 记录 contentHeight 供近底判定 fallback + DEV harness 就绪判定;并承担**唯一的贴底跟随**:
   // 内容长高(流式增长、大块一帧撑高、冷开测量结算)时,用户本就贴底(nearBottomRef,与
@@ -1597,7 +1512,7 @@ export function MessageRenderer({
   ]);
 
   // 会话切换(scrollResetKey):重置浮标/近底等 UI 状态;LegendList 本体经 listMountKey
-  // 重挂并从 index=0 建立有界尾窗。
+  // 重挂并用完整 data 的 offset-only 路径定位末尾。
   // 滚动/自动加载相关的 ref 复位已在渲染期同步块完成(见 prevScrollResetKeyRef,防切会话
   // 竞态误触发自动拉历史),此处不重复。
   useEffect(() => {
@@ -1644,12 +1559,6 @@ export function MessageRenderer({
       lastAppliedFocusKeyRef.current = null;
       return;
     }
-    // 深链/搜索使用完整数组索引；先一次展开本地尾窗，再定位，避免把完整数组的 index
-    // 发给临时窗口。下一次 effect 在完整 data 落地后继续执行。
-    if (initialTailWindowActive) {
-      revealEarlierTailWindow(true);
-      return;
-    }
     if (lastAppliedFocusKeyRef.current === focusRunKey) return;
     const index = listData.findIndex((item) => item.key === focusedItemKey);
     if (index < 0) return;
@@ -1664,9 +1573,7 @@ export function MessageRenderer({
   }, [
     focusRunKey,
     focusedItemKey,
-    initialTailWindowActive,
     listData,
-    revealEarlierTailWindow,
     scrollToIndexProgrammatically,
   ]);
 
@@ -1727,9 +1634,9 @@ export function MessageRenderer({
     <View style={styles.messageFrame}>
       <MessageListVisibleKeysContext.Provider value={visibleMessageKeys}>
       <LegendList
-        // 每会话重挂；冷开的 empty → ready 也重挂一次，让真实尾窗重新触发 onLoad。
+        // 每会话重挂；冷开的 empty → ready 也重挂一次，让非空完整列表应用初始 offset。
         key={listMountKey}
-        data={visibleListData}
+        data={listData}
         extraData={messageListExtraData}
         getItemType={mobileMessageListItemType}
         keyExtractor={(item) => item.key}
@@ -1737,10 +1644,11 @@ export function MessageRenderer({
         recycleItems={recycleItems}
         estimatedItemSize={MOBILE_MESSAGE_ESTIMATED_ITEM_SIZE}
         drawDistance={MOBILE_MESSAGE_DRAW_DISTANCE}
+        initialScrollOffset={initialScrollOffset}
         // 冷开不用 initialScrollIndex / initialScrollAtEnd、贴底跟随不用
-        // maintainScrollAtEnd：这些内部程序化滚动会先隐藏 cell，且曾在特定内容形态下
-        // 与手动贴底互相触发。首帧只喂尾部 4 项，用户上翻时再按 12 项小块前插
-        // 本地历史；后续贴底由 handleContentSize 的手动补滚（带振荡断路器）接管。
+        // maintainScrollAtEnd：index/end 的测量 bootstrap 会长时间隐藏 cell，且曾在特定
+        // 内容形态下与手动贴底互相触发。这里用 offset-only 直接给原生初值，完整 data
+        // 始终在列表内；后续贴底由 handleContentSize 的手动补滚（带振荡断路器）接管。
         //
         // 历史：initialScrollAtEnd / initialScrollIndex 的程序化滚动在特定
         // 内容形态下会与布局结算互相触发,形成无限 onScroll 风暴把 JS 线程打满——表现为
@@ -1759,7 +1667,7 @@ export function MessageRenderer({
           ? <SyncingMessages />
           : <EmptyMessages testID={emptyTestID} />}
         ListHeaderComponent={
-          !initialTailWindowActive && loadEarlierAction.visible ? (
+          loadEarlierAction.visible ? (
             <MessageListActionButton
               accessibilityLabel={loadEarlierAction.accessibilityLabel}
               disabled={loadEarlierAction.disabled}

--- a/apps/mobile/src/session/MessageRenderer.tsx
+++ b/apps/mobile/src/session/MessageRenderer.tsx
@@ -397,6 +397,7 @@ const MOBILE_MESSAGE_ESTIMATED_ITEM_SIZE = 140;
 const MOBILE_HISTORY_ANCHOR_VERIFY_MAX_FRAMES = 180;
 const MOBILE_HISTORY_ANCHOR_VERIFY_MAX_MS = 3000;
 const MOBILE_HISTORY_ANCHOR_STABLE_FRAMES = 2;
+const MOBILE_SCROLL_HISTORY_EVALUATION_INTERVAL_MS = 64;
 const ANDROID_SELECTABLE_TEXT_RUN_MAX_BLOCKS = 12;
 const ANDROID_SELECTABLE_TEXT_RUN_MAX_UTF16_LENGTH = 1800;
 const ANDROID_SELECTABLE_TEXT_RUN_MAX_INLINE_FRAGMENTS = 20;
@@ -710,6 +711,7 @@ export function MessageRenderer({
   const focusedItemKeyRef = useRef(focusedItemKey);
   focusedItemKeyRef.current = focusedItemKey;
   const listRef = useRef<LegendListRef>(null);
+  const firstVisibleIndexRef = useRef(0);
   const listMetricsRef = useRef<LegendListMetrics>({ footerSize: 0, headerSize: 0 });
   const listTopPaddingRef = useRef(0);
   const listBottomPaddingRef = useRef(0);
@@ -744,6 +746,10 @@ export function MessageRenderer({
   // 上一次自动 load-earlier 触发时的首项 key:相同 = 上次尝试无进展(失败 / 拉回重复页),
   // 不再自动重试,防止对着打不出进展的 host 无限拉取。用户重新拖动 / 切会话时清除。
   const lastAutoLoadEarlierKeyRef = useRef<string | null>(null);
+  const lastScrollHistoryEvaluationAtRef = useRef(0);
+  const pendingScrollHistoryMetricsRef = useRef<MessageScrollMetrics | null>(null);
+  const scrollHistoryEvaluationTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const attemptAutoLoadEarlierRef = useRef<(nativeMetrics?: MessageScrollMetrics) => void>(() => {});
   // 正在读「加载更早」拉回来的历史:抑制 handleContentSize 的大块撑高贴底,否则短会话(内容仍近底)
   // load-earlier 的 prepend 撑高会被误当成底部增长 → scrollToEnd 把用户从刚加载的历史拽回最新(review P1)。
   // 用户重新拖动 / 主动跳底 / 切会话时解除。
@@ -835,6 +841,12 @@ export function MessageRenderer({
     historyTouchTriggeredRef.current = false;
     initialHistoryAutofillRemainingRef.current = MAX_INITIAL_HISTORY_AUTOFILL_PAGES;
     lastAutoLoadEarlierKeyRef.current = null;
+    lastScrollHistoryEvaluationAtRef.current = 0;
+    pendingScrollHistoryMetricsRef.current = null;
+    if (scrollHistoryEvaluationTimerRef.current !== null) {
+      clearTimeout(scrollHistoryEvaluationTimerRef.current);
+      scrollHistoryEvaluationTimerRef.current = null;
+    }
     readingOlderRef.current = false;
     readingOlderRequestGenerationRef.current += 1;
     historyPrependTransactionRef.current = null;
@@ -859,6 +871,7 @@ export function MessageRenderer({
       programmaticScrollTimerRef.current = null;
     }
     previousItemKeysRef.current = [];
+    firstVisibleIndexRef.current = 0;
     scrollMetricsRef.current = { contentHeight: 0, offsetY: 0, viewportHeight: 0 };
     followEndPinStateRef.current = createMobileFollowEndPinState();
     initialAnchorDoneRef.current = false;
@@ -885,9 +898,23 @@ export function MessageRenderer({
     setListRevealed(false);
   }
   const lastAppliedFocusKeyRef = useRef<string | null>(null);
-  const [hasNewMessages, setHasNewMessages] = useState(false);
-  const [isAwayFromBottom, setIsAwayFromBottom] = useState(false);
-  const [firstVisibleIndex, setFirstVisibleIndex] = useState(0);
+  const [hasNewMessages, setHasNewMessagesState] = useState(false);
+  const hasNewMessagesRef = useRef(false);
+  const setHasNewMessages = useCallback((next: boolean) => {
+    if (hasNewMessagesRef.current === next) return;
+    hasNewMessagesRef.current = next;
+    setHasNewMessagesState(next);
+  }, []);
+  const [isAwayFromBottom, setIsAwayFromBottomState] = useState(false);
+  const isAwayFromBottomRef = useRef(false);
+  const setIsAwayFromBottom = useCallback((next: boolean) => {
+    if (isAwayFromBottomRef.current === next) return;
+    isAwayFromBottomRef.current = next;
+    setIsAwayFromBottomState(next);
+  }, []);
+  const [previousUserTarget, setPreviousUserTarget] = useState<
+    ReturnType<typeof previousUserMessageJumpTarget>
+  >(null);
   const [payload, setPayload] = useState<MessagePayload | null>(null);
   const payloadRef = useRef(payload);
   payloadRef.current = payload;
@@ -1352,29 +1379,32 @@ export function MessageRenderer({
   // hydrate / 新注册后 gallery 需要重建,否则点开气泡本地图时 initialUrl 对不上图集条目。
   const sentThumbsVersion = useSentAttachmentThumbsVersion();
   const chatFilePathContext = useContext(ChatFilePathContext);
+  const imageLightboxOpen = payload?.kind === 'media' && payload.media.kind === 'image';
   const galleryImages = useMemo(
-    () => collectMobileMessageGalleryImages(
-      listData,
-      chatFilePathContext?.workdir,
-      chatFilePathContext?.remoteHostId,
-      chatFilePathContext?.sessionId,
-    ),
+    () => (imageLightboxOpen
+      ? collectMobileMessageGalleryImages(
+          listData,
+          chatFilePathContext?.workdir,
+          chatFilePathContext?.remoteHostId,
+          chatFilePathContext?.sessionId,
+        )
+      : null),
     // eslint-disable-next-line react-hooks/exhaustive-deps -- sentThumbsVersion 是 collect 内部读的全局 store 的失效信号
     [
       chatFilePathContext?.remoteHostId,
       chatFilePathContext?.sessionId,
       chatFilePathContext?.workdir,
+      imageLightboxOpen,
       listData,
       sentThumbsVersion,
     ],
   );
-  // 稳定 lightbox images 的引用:galleryImages 在流式回复期间每 token 重建
-  // (item 对象全新但语义未变),若直接透传,查看器的取件 effect / FlatList /
-  // LightboxPage memo 每帧全部失效。语义相同(key/url/previewable 逐项一致)
-  // 时复用上一份数组,查看器打开期间对流式更新完全免疫。
+  // 只在图片查看器打开时扫描完整历史；关闭态不能让每个流式 token 都递归遍历
+  // message / work group / subagent 树。查看器打开期间若语义相同，则继续复用图集引用，
+  // 避免取件 effect / FlatList / LightboxPage memo 每帧全部失效。
   const lightboxImagesRef = useRef<readonly MobileMessageGalleryImage[] | null>(null);
   const lightboxImages = useMemo(() => {
-    if (!(payload?.kind === 'media' && payload.media.kind === 'image')) return null;
+    if (!(payload?.kind === 'media' && payload.media.kind === 'image') || !galleryImages) return null;
     const next = lightboxImagesForPayload(galleryImages, payload);
     const prev = lightboxImagesRef.current;
     if (prev && prev.length === next.length && prev.every((p, i) => {
@@ -1388,7 +1418,7 @@ export function MessageRenderer({
     }
     lightboxImagesRef.current = next;
     return next;
-  }, [galleryImages, payload]);
+  }, [galleryImages, imageLightboxOpen, payload]);
   const bottomPadding = mobileMessageListBottomPadding(bottomOverlayHeight);
   const topPadding = mobileMessageListTopPadding(topOverlayHeight);
   listBottomPaddingRef.current = bottomPadding;
@@ -1485,14 +1515,6 @@ export function MessageRenderer({
       : null),
     [onQuoteSelection, selectionQuoteEnabled],
   );
-  const previousUserTarget = useMemo(
-    () => (
-      isAwayFromBottom
-        ? previousUserMessageJumpTarget(listData, firstVisibleIndex)
-        : null
-    ),
-    [firstVisibleIndex, isAwayFromBottom, listData],
-  );
   const showJumpToLatest = isAwayFromBottom && !hasNewMessages;
   const focusRunKey = focusedItemKey
     ? `${focusedRequestKey ?? 'default'}:${focusedItemKey}`
@@ -1569,10 +1591,22 @@ export function MessageRenderer({
   useEffect(() => () => {
     if (stickyCheckTimerRef.current) clearTimeout(stickyCheckTimerRef.current);
   }, []);
+  const refreshPreviousUserTarget = useCallback(() => {
+    const next = nearBottomRef.current
+      ? null
+      : previousUserMessageJumpTarget(listDataRef.current, firstVisibleIndexRef.current);
+    setPreviousUserTarget((previous) => (
+      previous?.itemKey === next?.itemKey
+      && previous?.index === next?.index
+      && previous?.preview === next?.preview
+        ? previous
+        : next
+    ));
+  }, []);
   const handleFirstVisibleItemChangedRef = useRef((info: {
     index: number;
   }) => {
-    setFirstVisibleIndex((previous) => previous === info.index ? previous : info.index);
+    firstVisibleIndexRef.current = info.index;
   });
   const readActuallyVisibleShareableMessageIds = useCallback(async (
     viewport: ShareableMessageViewport,
@@ -1628,12 +1662,17 @@ export function MessageRenderer({
     }
     setIsAwayFromBottom(false);
     setHasNewMessages(false);
+    setPreviousUserTarget(null);
     scrollToEndProgrammatically(true);
     runStickToLatestVerify();
   }, [cancelHistoryPrependTransaction, runStickToLatestVerify, scrollToEndProgrammatically]);
 
   const jumpToPreviousUserMessage = useCallback(() => {
-    if (!previousUserTarget) return;
+    const target = previousUserMessageJumpTarget(
+      listDataRef.current,
+      firstVisibleIndexRef.current,
+    );
+    if (!target) return;
     // 上跳导航与拖动同为真实「上翻意图」:落点若在近顶区,自动加载更早应当接得上,
     // 不要求用户额外再拖一下。与拖动开始同语义,一并作废上次无进展的去重记录,
     // 否则上次失败/重复页后跳进近顶区仍会被去重短路(review P1)。
@@ -1641,8 +1680,8 @@ export function MessageRenderer({
     lastAutoLoadEarlierKeyRef.current = null;
     nearBottomRef.current = false;
     setIsAwayFromBottom(true);
-    scrollToIndexProgrammatically(previousUserTarget.index, 0.12);
-  }, [previousUserTarget, scrollToIndexProgrammatically]);
+    scrollToIndexProgrammatically(target.index, 0.12);
+  }, [scrollToIndexProgrammatically]);
 
   // 「跳到最新」请求(会话外部触发,含发送消息后的跟随):命令式滚到底,随后跑一轮有界
   // 校验/补滚(runStickToLatestVerify)——单发的 scrollToEnd 落地一刻的 metrics 可能仍陈旧,
@@ -1819,6 +1858,47 @@ export function MessageRenderer({
       requestLoadEarlier();
       return;
     }
+    if (
+      nativeMetrics
+      && nativeMetrics.offsetY <= MOBILE_ANCHOR_VERIFY_TOLERANCE
+      && scrollHistoryEvaluationTimerRef.current !== null
+    ) {
+      pendingScrollHistoryMetricsRef.current = null;
+      clearTimeout(scrollHistoryEvaluationTimerRef.current);
+      scrollHistoryEvaluationTimerRef.current = null;
+    }
+    if (
+      nativeMetrics
+      && nativeMetrics.offsetY > MOBILE_ANCHOR_VERIFY_TOLERANCE
+    ) {
+      const now = Date.now();
+      if (
+        now - lastScrollHistoryEvaluationAtRef.current
+        < MOBILE_SCROLL_HISTORY_EVALUATION_INTERVAL_MS
+      ) {
+        // 保留最后一帧再补一次尾调用：否则快滑恰好停在近顶区时，最后一次判定可能
+        // 被节流吞掉，用户必须再拖一下才能继续分页。
+        pendingScrollHistoryMetricsRef.current = nativeMetrics;
+        if (scrollHistoryEvaluationTimerRef.current === null) {
+          const remainingMs = MOBILE_SCROLL_HISTORY_EVALUATION_INTERVAL_MS
+            - (now - lastScrollHistoryEvaluationAtRef.current);
+          scrollHistoryEvaluationTimerRef.current = setTimeout(() => {
+            scrollHistoryEvaluationTimerRef.current = null;
+            const pendingMetrics = pendingScrollHistoryMetricsRef.current;
+            pendingScrollHistoryMetricsRef.current = null;
+            lastScrollHistoryEvaluationAtRef.current = 0;
+            attemptAutoLoadEarlierRef.current(pendingMetrics ?? undefined);
+          }, remainingMs);
+        }
+        return;
+      }
+      pendingScrollHistoryMetricsRef.current = null;
+      if (scrollHistoryEvaluationTimerRef.current !== null) {
+        clearTimeout(scrollHistoryEvaluationTimerRef.current);
+        scrollHistoryEvaluationTimerRef.current = null;
+      }
+      lastScrollHistoryEvaluationAtRef.current = now;
+    }
     const listState = listRef.current?.getState();
     if (!listState) return;
     // LegendList's edge bookkeeping can lag behind the native ScrollView during recycling,
@@ -1851,6 +1931,7 @@ export function MessageRenderer({
     onLoadEarlier,
     requestLoadEarlier,
   ]);
+  attemptAutoLoadEarlierRef.current = attemptAutoLoadEarlier;
 
   // 近底/跟随态迁移 + 「跳到底部」浮标与新消息红点;metrics 也供 DEV harness 读取。
   // 「解除跟随」的主路径是拖动意图(shouldUnpinMobileFollowOnDrag):拖动中相对起点
@@ -1917,7 +1998,10 @@ export function MessageRenderer({
         userScrollForOlderRef.current = false;
       }
       setIsAwayFromBottom(!nearBottom);
-      if (nearBottom) setHasNewMessages(false);
+      if (nearBottom) {
+        setHasNewMessages(false);
+        setPreviousUserTarget(null);
+      }
     }
     // 拖动进近顶区时 onStartReached 边沿可能早已被消费(见 attemptAutoLoadEarlier 注释),
     // 滚动事件兜底重评估;前置短路让稳态滚动只付 1~2 次 ref 比较的成本。
@@ -2002,9 +2086,10 @@ export function MessageRenderer({
   const handleScrollEndDrag = useCallback(() => {
     isDraggingRef.current = false;
     dragStartOffsetYRef.current = null;
+    refreshPreviousUserTarget();
     // Wait one frame so Android can report whether this drag transitioned into momentum.
     scheduleQueuedLoadEarlierFlush();
-  }, [scheduleQueuedLoadEarlierFlush]);
+  }, [refreshPreviousUserTarget, scheduleQueuedLoadEarlierFlush]);
 
   const handleMomentumScrollBegin = useCallback(() => {
     isMomentumScrollingRef.current = true;
@@ -2012,8 +2097,9 @@ export function MessageRenderer({
 
   const handleMomentumScrollEnd = useCallback(() => {
     isMomentumScrollingRef.current = false;
+    refreshPreviousUserTarget();
     scheduleQueuedLoadEarlierFlush();
-  }, [scheduleQueuedLoadEarlierFlush]);
+  }, [refreshPreviousUserTarget, scheduleQueuedLoadEarlierFlush]);
 
   const handleStartReached = useCallback(() => {
     attemptAutoLoadEarlier();
@@ -2239,7 +2325,7 @@ export function MessageRenderer({
       followEndPinRecoveryTimerRef.current = null;
     }
     setIsAwayFromBottom(false);
-    setFirstVisibleIndex(0);
+    setPreviousUserTarget(null);
     setHasNewMessages(false);
   }, [scrollResetKey]);
   // 卸载时清掉在飞的定时器/rAF(闭包引用 listRef,卸载后触发是无害 no-op,
@@ -2257,6 +2343,7 @@ export function MessageRenderer({
     if (queuedLoadEarlierFlushFrameRef.current !== null) cancelAnimationFrame(queuedLoadEarlierFlushFrameRef.current);
     if (historyAnchorVerifyFrameRef.current !== null) cancelAnimationFrame(historyAnchorVerifyFrameRef.current);
     if (followVerifyTimerRef.current !== null) clearTimeout(followVerifyTimerRef.current);
+    if (scrollHistoryEvaluationTimerRef.current !== null) clearTimeout(scrollHistoryEvaluationTimerRef.current);
     initialRevealAnimationRef.current?.stop();
   }, [clearProgrammaticScroll]);
 
@@ -2435,7 +2522,7 @@ export function MessageRenderer({
         onFirstVisibleItemChanged={handleFirstVisibleItemChangedRef.current}
       />
       </Animated.View>
-      {previousUserTarget && previousUserButtonTop !== null ? (
+      {isAwayFromBottom && previousUserTarget && previousUserButtonTop !== null ? (
         <MessageListActionButton
           accessibilityLabel={t('message.renderer.previousQuestionJump', { preview: previousUserTarget.preview || t('message.renderer.noPreview') })}
           onPress={jumpToPreviousUserMessage}
@@ -3410,15 +3497,15 @@ function copyActionLabel(state: CopyMessageStatus | 'idle' | 'copying'): string 
 }
 
 /**
- * 流式思考的实时时长(对齐桌面 ThinkingCard 的 500ms tick):active 时每 500ms
- * 刷新一次自 sinceIso 起的耗时;非 active 或时间戳无效时返回 null(标题回退静态文案)。
+ * 流式思考的实时时长：界面只显示到秒，active 时每秒刷新一次自 sinceIso 起的耗时；
+ * 非 active 或时间戳无效时返回 null(标题回退静态文案)。
  */
 function useLiveElapsedMs(active: boolean, sinceIso: string | undefined): number | null {
   const [now, setNow] = useState(() => Date.now());
   useEffect(() => {
     if (!active) return;
     setNow(Date.now());
-    const timer = setInterval(() => setNow(Date.now()), 500);
+    const timer = setInterval(() => setNow(Date.now()), 1_000);
     return () => clearInterval(timer);
   }, [active]);
   if (!active || !sinceIso) return null;
@@ -3935,16 +4022,16 @@ function WorkGroupCard({
     screenWidth: actions.screenWidth,
     summaryCount: header.summaryCount,
   }), [actions.screenWidth, header.summaryCount]);
-  const contentLayout = useMemo(() => buildMessageContentLayout({
-    screenWidth: actions.screenWidth,
-  }), [actions.screenWidth]);
+  const contentLayout = useMemo(() => (expanded
+    ? buildMessageContentLayout({ screenWidth: actions.screenWidth })
+    : null), [actions.screenWidth, expanded]);
   const activityProjection = useMemo(
-    () => (expanded || !isStreaming
+    () => (expanded
       ? projectMobileWorkActivities(item.children, isStreaming)
       : null),
     [expanded, isStreaming, item.children],
   );
-  const startedAtIso = item.startedAtMs !== undefined
+  const startedAtIso = isStreaming && item.startedAtMs !== undefined
     ? new Date(item.startedAtMs).toISOString()
     : undefined;
   const elapsedMs = useLiveElapsedMs(isStreaming, startedAtIso);
@@ -3999,7 +4086,7 @@ function WorkGroupCard({
                         key={activity.key}
                         actions={actions}
                         activity={activity}
-                        contentLayout={contentLayout}
+                        contentLayout={contentLayout!}
                       />
                     ))}
                   </View>

--- a/apps/mobile/src/session/MessageRenderer.tsx
+++ b/apps/mobile/src/session/MessageRenderer.tsx
@@ -325,8 +325,15 @@ import {
   previousUserMessageJumpTarget,
   resolveMobileNearBottomOnScroll,
   shouldAutoLoadEarlier,
+  shouldPreserveMobileHistoryBrowseIntent,
   shouldUnpinMobileFollowOnDrag,
 } from '@/session/messageScroll';
+import {
+  captureMobileHistoryAnchor,
+  isMobileHistoryAnchorSettled,
+  resolveMobileHistoryAnchorOffset,
+  type MobileHistoryAnchor,
+} from '@/session/messageHistoryAnchor';
 import { ImageLightbox, type ImageLightboxAnnotationConfig } from '@/session/ImageLightbox';
 import {
   MermaidDiagramWebView,
@@ -362,8 +369,12 @@ const SHARE_STICKY_CHECK_HEIGHT = 44;
 const STICKY_SHARE_CHECK_THROTTLE_MS = 150;
 const SCREENSHOT_SHARE_VISIBLE_PERCENT_THRESHOLD = 10;
 // LegendList 变高 item 的初始估高(仅影响首帧布局定位,LegendList 挂载后按实测尺寸修正)。
-/** Keep main's initial correction hidden until the latest-message anchor has settled. */
+/** Bound the hidden initial correction so live measurement churn cannot blank the list for seconds. */
 const MOBILE_INITIAL_ANCHOR_SETTLE_MS = 300;
+/** Fade in on the UI thread after the hidden correction window; JS may be busy mounting cells. */
+const MOBILE_INITIAL_REVEAL_FADE_MS = 100;
+const MOBILE_INITIAL_REVEAL_MAX_MS = MOBILE_INITIAL_ANCHOR_SETTLE_MS
+  + MOBILE_INITIAL_REVEAL_FADE_MS;
 /** Maximum time a native imperative scroll may be reported as in-flight. */
 const MOBILE_PROGRAMMATIC_SCROLL_SETTLE_MS = 1000;
 /** Animated jump-to-latest commands get a little more time to settle. */
@@ -371,8 +382,10 @@ const MOBILE_PROGRAMMATIC_ANIMATED_SCROLL_SETTLE_MS = 1400;
 /** Cold-open history fill is useful, but bounded so a short/duplicate host page cannot drain history forever. */
 const MAX_INITIAL_HISTORY_AUTOFILL_PAGES = 3;
 const MOBILE_MESSAGE_ESTIMATED_ITEM_SIZE = 140;
-/** Streaming/async measurement must not keep history-pagination protection alive forever. */
-const MOBILE_HISTORY_PREPEND_SETTLE_MAX_MS = 500;
+/** Manual prepend anchoring retries layout positions for at most ~3 seconds, even under resize churn. */
+const MOBILE_HISTORY_ANCHOR_VERIFY_MAX_FRAMES = 180;
+const MOBILE_HISTORY_ANCHOR_VERIFY_MAX_MS = 3000;
+const MOBILE_HISTORY_ANCHOR_STABLE_FRAMES = 2;
 const ANDROID_SELECTABLE_TEXT_RUN_MAX_BLOCKS = 12;
 const ANDROID_SELECTABLE_TEXT_RUN_MAX_UTF16_LENGTH = 1800;
 const ANDROID_SELECTABLE_TEXT_RUN_GROUPING_OPTIONS: MobileMarkdownTextRunGroupingOptions = {
@@ -387,6 +400,17 @@ const FOLDABLE_HEADER_HIT_SLOP = { bottom: 10, left: 4, right: 4, top: 10 };
 
 function mobileMessageListItemType(item: MobileMessageRenderItem): MobileMessageRenderItem['type'] {
   return item.type;
+}
+
+interface MobileHistoryPrependTransaction {
+  anchor: MobileHistoryAnchor | null;
+  anchorStable: boolean;
+  generation: number;
+  pageCommitted: boolean;
+  promiseSettled: boolean;
+  startProgressKey: string | null;
+  userControlledAfterCommit: boolean;
+  verifyDeadlineAt: number;
 }
 // 「跳到底部」浮标直径:比 composer 里的语音按钮(28)大一档但不压过它,Telegram 同款层级感。
 const SCROLL_TO_BOTTOM_FAB_SIZE = 36;
@@ -671,6 +695,7 @@ export function MessageRenderer({
   // 距离阈值(≥228px)在流式期间与程序化贴底滚动竞态,慢速小幅上滑会被反复拽回
   // (桌面版同源 bug 的手机版变体,见 messageScroll.ts)。
   const isDraggingRef = useRef(false);
+  const isMomentumScrollingRef = useRef(false);
   const dragStartOffsetYRef = useRef<number | null>(null);
   // 用户是否主动拖动过(区分「冷开初始布局」与「用户上翻」):自动加载更早只在用户真拖过之后才允许,
   // 否则短会话(只加载了少量最新消息但 hasOlderMessages)冷开时会落在 onStartReachedThreshold 内、
@@ -691,16 +716,23 @@ export function MessageRenderer({
   const readingOlderRef = useRef(false);
   // 每次补页分配 generation：旧会话 / 旧请求的异步 settle 不得清掉新请求的抑制态。
   const readingOlderRequestGenerationRef = useRef(0);
-  const readingOlderReleaseTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
-  const readingOlderReleaseDeadlineRef = useRef(0);
-  // 分页 Promise 会早于 React/LegendList 完成新页提交。只有真正观察到 loadingEarlier
-  // 从 true 回到 false，才把“请求完成”视为“新页已进入当前 render commit”。
-  const readingOlderLoadingObservedRef = useRef(false);
+  // data-change anchoring is app-owned instead of delegated to Android MVCP. The transaction
+  // keeps the old visible row pinned until the new page, layout, and non-animated correction all
+  // settle; this removes the frame where cells move before native contentOffset catches up.
+  const historyPrependTransactionRef = useRef<MobileHistoryPrependTransaction | null>(null);
+  const historyAnchorVerifyFrameRef = useRef<number | null>(null);
+  const queuedLoadEarlierRef = useRef(false);
+  const queuedLoadEarlierFlushFrameRef = useRef<number | null>(null);
+  // Keep native MVCP for ordinary data/size changes, but turn it fully off before starting a
+  // history request. LegendList maps either `data` or `size` to the same RN ScrollView prop, so
+  // `{ data:false, size:true }` would still race the app-owned prepend correction on Android.
+  const [historyPrependNativeMvcpDisabled, setHistoryPrependNativeMvcpDisabled] = useState(false);
+  const historyPrependNativeMvcpDisabledRef = useRef(historyPrependNativeMvcpDisabled);
+  historyPrependNativeMvcpDisabledRef.current = historyPrependNativeMvcpDisabled;
   const loadingEarlierRef = useRef(loadingEarlier === true);
   loadingEarlierRef.current = loadingEarlier === true;
-  // LegendList mVCP 始终开启；普通尾部 append / 流式 resize 同样会触发 native 锚点
-  // 调整，不能只拿 readingOlderRef 代表 settle 状态。每次 data / size 变化延长一个短
-  // 安静窗，verifier 在窗内只等待，不消耗 6 次补滚预算。
+  // Data/size changes extend a short quiet window. During a manual prepend, the app-owned anchor
+  // keeps correcting against the same key until that layout window ends.
   const mvcpSettleAtRef = useRef(0);
   const programmaticScrollGenerationRef = useRef(0);
   const programmaticScrollTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
@@ -720,13 +752,26 @@ export function MessageRenderer({
   // 断路到期后的 one-shot 贴底清账 timer:断路窗内错过的最终高度可能停在半空且
   // 之后再无 contentSize 事件,到期补一次(仍在贴底跟随时)把账清平(review P1)。
   const followEndPinRecoveryTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
-  // main 已验证的首次进入锚定：完整历史从挂载起就在列表中，命令式落底与测量校正
-  // 只在 opacity 遮罩下运行；settle 后一次性揭开，不能把补滚画面暴露给用户。
+  // 首次进入锚定：完整历史从挂载起就在列表中，命令式落底与测量校正只在短暂
+  // opacity 遮罩下运行；揭示动画启动后完全交给 UI 线程，首批复杂消息占满 JS 时也不会
+  // 把 300ms 窗口拖成长达数秒的白屏。
   const initialAnchorDoneRef = useRef(false);
   const initialAnchorGenerationRef = useRef(0);
   const initialAnchorVerifyFrameRef = useRef<number | null>(null);
   const initialAnchorFrameRef = useRef<number | null>(null);
-  const initialRevealTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const initialRevealAnimationRef = useRef<Animated.CompositeAnimation | null>(null);
+  const initialRevealProgress = useMemo(
+    () => new Animated.Value(0),
+    [scrollResetKey],
+  );
+  const initialRevealOpacity = useMemo(() => initialRevealProgress.interpolate({
+    inputRange: [
+      0,
+      MOBILE_INITIAL_ANCHOR_SETTLE_MS / MOBILE_INITIAL_REVEAL_MAX_MS,
+      1,
+    ],
+    outputRange: [0, 0, 1],
+  }), [initialRevealProgress]);
   const followVerifyGenerationRef = useRef(0);
   const followVerifyFrameRef = useRef<number | null>(null);
   const followVerifyTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
@@ -748,6 +793,7 @@ export function MessageRenderer({
     prevScrollResetKeyRef.current = scrollResetKey;
     nearBottomRef.current = true;
     isDraggingRef.current = false;
+    isMomentumScrollingRef.current = false;
     dragStartOffsetYRef.current = null;
     userScrollForOlderRef.current = false;
     historyTouchStartYRef.current = null;
@@ -756,11 +802,16 @@ export function MessageRenderer({
     lastAutoLoadEarlierKeyRef.current = null;
     readingOlderRef.current = false;
     readingOlderRequestGenerationRef.current += 1;
-    readingOlderLoadingObservedRef.current = false;
-    readingOlderReleaseDeadlineRef.current = 0;
-    if (readingOlderReleaseTimerRef.current !== null) {
-      clearTimeout(readingOlderReleaseTimerRef.current);
-      readingOlderReleaseTimerRef.current = null;
+    historyPrependTransactionRef.current = null;
+    queuedLoadEarlierRef.current = false;
+    if (historyPrependNativeMvcpDisabled) setHistoryPrependNativeMvcpDisabled(false);
+    if (queuedLoadEarlierFlushFrameRef.current !== null) {
+      cancelAnimationFrame(queuedLoadEarlierFlushFrameRef.current);
+      queuedLoadEarlierFlushFrameRef.current = null;
+    }
+    if (historyAnchorVerifyFrameRef.current !== null) {
+      cancelAnimationFrame(historyAnchorVerifyFrameRef.current);
+      historyAnchorVerifyFrameRef.current = null;
     }
     mvcpSettleAtRef.current = 0;
     programmaticScrollGenerationRef.current += 1;
@@ -784,10 +835,8 @@ export function MessageRenderer({
       cancelAnimationFrame(initialAnchorVerifyFrameRef.current);
       initialAnchorVerifyFrameRef.current = null;
     }
-    if (initialRevealTimerRef.current !== null) {
-      clearTimeout(initialRevealTimerRef.current);
-      initialRevealTimerRef.current = null;
-    }
+    initialRevealAnimationRef.current?.stop();
+    initialRevealAnimationRef.current = null;
     followVerifyGenerationRef.current += 1;
     if (followVerifyTimerRef.current !== null) {
       clearTimeout(followVerifyTimerRef.current);
@@ -877,6 +926,212 @@ export function MessageRenderer({
     markProgrammaticScroll(true);
     void listRef.current?.scrollToIndex({ animated: true, index, viewPosition });
   }, [markProgrammaticScroll]);
+
+  const captureCurrentHistoryAnchor = useCallback((): MobileHistoryAnchor | null => {
+    const listState = listRef.current?.getState();
+    return listState
+      ? captureMobileHistoryAnchor(
+        listState,
+        (item) => (item as MobileMessageRenderItem).key,
+      )
+      : null;
+  }, []);
+
+  const finishHistoryPrependTransaction = useCallback((generation: number) => {
+    const transaction = historyPrependTransactionRef.current;
+    if (!transaction || transaction.generation !== generation) return;
+    if (historyAnchorVerifyFrameRef.current !== null) {
+      cancelAnimationFrame(historyAnchorVerifyFrameRef.current);
+      historyAnchorVerifyFrameRef.current = null;
+    }
+    historyPrependTransactionRef.current = null;
+    readingOlderRef.current = false;
+    setHistoryPrependNativeMvcpDisabled(false);
+    setLoadEarlierEvaluationVersion((version) => version + 1);
+  }, []);
+
+  const maybeFinishHistoryPrependTransaction = useCallback((generation: number) => {
+    const transaction = historyPrependTransactionRef.current;
+    if (!transaction || transaction.generation !== generation) return;
+    if (loadingEarlierRef.current || !transaction.promiseSettled) return;
+    if (transaction.pageCommitted && !transaction.anchorStable) return;
+    finishHistoryPrependTransaction(generation);
+  }, [finishHistoryPrependTransaction]);
+
+  const handoffHistoryPrependToUser = useCallback(() => {
+    const transaction = historyPrependTransactionRef.current;
+    if (!transaction) return;
+    const currentAnchor = captureCurrentHistoryAnchor();
+    if (currentAnchor) transaction.anchor = currentAnchor;
+    if (!transaction.pageCommitted) return;
+    transaction.userControlledAfterCommit = true;
+    transaction.anchorStable = true;
+    if (historyAnchorVerifyFrameRef.current !== null) {
+      cancelAnimationFrame(historyAnchorVerifyFrameRef.current);
+      historyAnchorVerifyFrameRef.current = null;
+    }
+    maybeFinishHistoryPrependTransaction(transaction.generation);
+  }, [captureCurrentHistoryAnchor, maybeFinishHistoryPrependTransaction]);
+
+  const cancelHistoryPrependTransaction = useCallback(() => {
+    readingOlderRequestGenerationRef.current += 1;
+    readingOlderRef.current = false;
+    historyPrependTransactionRef.current = null;
+    queuedLoadEarlierRef.current = false;
+    setHistoryPrependNativeMvcpDisabled(false);
+    if (queuedLoadEarlierFlushFrameRef.current !== null) {
+      cancelAnimationFrame(queuedLoadEarlierFlushFrameRef.current);
+      queuedLoadEarlierFlushFrameRef.current = null;
+    }
+    if (historyAnchorVerifyFrameRef.current !== null) {
+      cancelAnimationFrame(historyAnchorVerifyFrameRef.current);
+      historyAnchorVerifyFrameRef.current = null;
+    }
+  }, []);
+
+  const scheduleHistoryAnchorRestore = useCallback((generation: number) => {
+    const transaction = historyPrependTransactionRef.current;
+    if (
+      !transaction
+      || transaction.generation !== generation
+      || !transaction.pageCommitted
+      || transaction.userControlledAfterCommit
+    ) return;
+    // The running verifier already re-resolves the anchor on every frame. Restarting it for every
+    // tail content-size event prevents a live session from ever accumulating two stable frames.
+    if (historyAnchorVerifyFrameRef.current !== null) return;
+    transaction.anchorStable = false;
+    if (transaction.verifyDeadlineAt === 0) {
+      transaction.verifyDeadlineAt = Date.now() + MOBILE_HISTORY_ANCHOR_VERIFY_MAX_MS;
+    }
+    markMobileMvcpSettle();
+
+    const step = (
+      attempts: number,
+      stableFrames: number,
+      previousTargetOffset: number | null,
+    ) => {
+      const currentTransaction = historyPrependTransactionRef.current;
+      if (
+        !currentTransaction
+        || currentTransaction.generation !== generation
+        || currentTransaction.userControlledAfterCommit
+      ) return;
+      const withinDeadline = Date.now() < currentTransaction.verifyDeadlineAt;
+      const anchor = currentTransaction.anchor;
+      const listState = listRef.current?.getState();
+      const targetOffset = anchor && listState
+        ? resolveMobileHistoryAnchorOffset(anchor, listState)
+        : null;
+
+      if (targetOffset !== null && listState) {
+        const currentOffset = listState.scroll;
+        const settled = isMobileHistoryAnchorSettled(
+          currentOffset,
+          targetOffset,
+          previousTargetOffset,
+          MOBILE_ANCHOR_VERIFY_TOLERANCE,
+        );
+        // Only the anchor row's resolved position matters here. A running session can keep
+        // growing below the reader while history is settling; treating every tail size change as
+        // anchor instability keeps this verifier alive for the full retry bound and needlessly
+        // churns cells/GC. If a layout change above the anchor matters, targetOffset changes and
+        // the two-frame stability check resets on its own.
+        const nextStableFrames = settled ? stableFrames + 1 : 0;
+        if (Math.abs(currentOffset - targetOffset) > MOBILE_ANCHOR_VERIFY_TOLERANCE) {
+          scrollToOffsetProgrammatically(targetOffset, false);
+        }
+        if (nextStableFrames >= MOBILE_HISTORY_ANCHOR_STABLE_FRAMES) {
+          historyAnchorVerifyFrameRef.current = null;
+          currentTransaction.anchorStable = true;
+          maybeFinishHistoryPrependTransaction(generation);
+          return;
+        }
+        if (withinDeadline && attempts < MOBILE_HISTORY_ANCHOR_VERIFY_MAX_FRAMES) {
+          historyAnchorVerifyFrameRef.current = requestAnimationFrame(() => {
+            historyAnchorVerifyFrameRef.current = null;
+            step(attempts + 1, nextStableFrames, targetOffset);
+          });
+          return;
+        }
+      } else if (withinDeadline && attempts < MOBILE_HISTORY_ANCHOR_VERIFY_MAX_FRAMES) {
+        historyAnchorVerifyFrameRef.current = requestAnimationFrame(() => {
+          historyAnchorVerifyFrameRef.current = null;
+          step(attempts + 1, 0, null);
+        });
+        return;
+      }
+
+      if (targetOffset !== null && listState) {
+        // Complex pages can keep refining estimates beyond the retry window even though the anchor
+        // key remains valid. End with two bounded, non-animated corrections instead of warning and
+        // re-enabling native MVCP against a stale offset. The history-intent guard keeps these
+        // resulting scroll events from being mistaken for a user return to the latest edge.
+        scrollToOffsetProgrammatically(targetOffset, false);
+        historyAnchorVerifyFrameRef.current = requestAnimationFrame(() => {
+          const finalTransaction = historyPrependTransactionRef.current;
+          if (
+            !finalTransaction
+            || finalTransaction.generation !== generation
+            || finalTransaction.userControlledAfterCommit
+          ) return;
+          const finalState = listRef.current?.getState();
+          const finalTarget = finalTransaction.anchor && finalState
+            ? resolveMobileHistoryAnchorOffset(finalTransaction.anchor, finalState)
+            : null;
+          if (finalTarget !== null) scrollToOffsetProgrammatically(finalTarget, false);
+          historyAnchorVerifyFrameRef.current = requestAnimationFrame(() => {
+            historyAnchorVerifyFrameRef.current = null;
+            const settledTransaction = historyPrependTransactionRef.current;
+            if (
+              !settledTransaction
+              || settledTransaction.generation !== generation
+              || settledTransaction.userControlledAfterCommit
+            ) return;
+            settledTransaction.anchorStable = true;
+            maybeFinishHistoryPrependTransaction(generation);
+          });
+        });
+        return;
+      }
+
+      // The key should survive a prepend. Keep an actually unresolved page bounded so malformed
+      // host data cannot lock history browsing forever; follow-to-latest remains disabled.
+      console.warn('[message-list] history prepend anchor could not be resolved before the retry bound');
+      historyAnchorVerifyFrameRef.current = null;
+      currentTransaction.anchorStable = true;
+      maybeFinishHistoryPrependTransaction(generation);
+    };
+
+    // useLayoutEffect calls this before paint. Run the first correction synchronously so Android
+    // never displays the intermediate coordinate system where the old rows have moved but the
+    // ScrollView offset still belongs to the pre-prepend data.
+    step(0, 0, null);
+  }, [
+    markMobileMvcpSettle,
+    maybeFinishHistoryPrependTransaction,
+    scrollToOffsetProgrammatically,
+  ]);
+
+  const restoreHistoryAnchorOnce = useCallback((generation: number) => {
+    const transaction = historyPrependTransactionRef.current;
+    if (
+      !transaction
+      || transaction.generation !== generation
+      || transaction.userControlledAfterCommit
+    ) return;
+    const listState = listRef.current?.getState();
+    const targetOffset = transaction.anchor && listState
+      ? resolveMobileHistoryAnchorOffset(transaction.anchor, listState)
+      : null;
+    if (
+      targetOffset !== null
+      && listState
+      && Math.abs(listState.scroll - targetOffset) > MOBILE_ANCHOR_VERIFY_TOLERANCE
+    ) {
+      scrollToOffsetProgrammatically(targetOffset, false);
+    }
+  }, [scrollToOffsetProgrammatically]);
 
   // 贴底跟随的落底校验/补滚环:两条手动补滚路径——「跳到最新」(followLatestRequestKey)
   // 与 handleContentSize 的贴底追赶——都只发一次命令式 scrollToEnd,不校验是否真的到达内容
@@ -985,11 +1240,37 @@ export function MessageRenderer({
     () => mobileMessageListKeysSignature(itemKeys),
     [itemKeys],
   );
+  const firstItemKey = loadEarlierProgressKey ?? itemKeys[0] ?? null;
+  // A successful history page changes the oldest host cursor. Restore the captured visible row
+  // in a layout effect: LegendList has accepted the new data, but React Native has not painted the
+  // shifted absolute positions yet. This is the atomic point missing from Android native MVCP.
+  useLayoutEffect(() => {
+    const transaction = historyPrependTransactionRef.current;
+    if (!transaction) return;
+    if (transaction.startProgressKey !== firstItemKey) {
+      transaction.pageCommitted = true;
+      scheduleHistoryAnchorRestore(transaction.generation);
+      maybeFinishHistoryPrependTransaction(transaction.generation);
+      return;
+    }
+    if (transaction.promiseSettled && !loadingEarlier) {
+      // Failed, empty, or duplicate page: the current render has observed Promise settlement with
+      // no oldest-cursor progress, so there is no prepend coordinate change to restore.
+      transaction.anchorStable = true;
+      maybeFinishHistoryPrependTransaction(transaction.generation);
+    }
+  }, [
+    firstItemKey,
+    itemKeysSignature,
+    loadEarlierEvaluationVersion,
+    loadingEarlier,
+    maybeFinishHistoryPrependTransaction,
+    scheduleHistoryAnchorRestore,
+  ]);
   // 只认行身份（追加 / 换行 / 重排）。流式改内容会换 items 引用，但不能续安静窗。
   useEffect(() => {
     markMobileMvcpSettle();
   }, [itemKeysSignature, markMobileMvcpSettle]);
-  const firstItemKey = loadEarlierProgressKey ?? itemKeys[0] ?? null;
   // 本地缩略兜底映射版本:collect 内部对 cindy-oss-attach:// 附件读全局 store 做 overlay,
   // hydrate / 新注册后 gallery 需要重建,否则点开气泡本地图时 initialUrl 对不上图集条目。
   const sentThumbsVersion = useSentAttachmentThumbsVersion();
@@ -1271,7 +1552,7 @@ export function MessageRenderer({
   // 跳底先命令式 scrollToEnd,随后复用同一轮有界落底校验。
   const scrollToBottom = useCallback(() => {
     nearBottomRef.current = true;
-    readingOlderRef.current = false;
+    cancelHistoryPrependTransaction();
     userScrollForOlderRef.current = false;
     // 用户主动跳底是明确的重锚意图:重建补滚护栏(清掉可能仍开着的断路窗,
     // 让跳底后的贴底跟随立即恢复;振荡若还在会重新跳闸,review P2)。在飞的
@@ -1285,7 +1566,7 @@ export function MessageRenderer({
     setHasNewMessages(false);
     scrollToEndProgrammatically(true);
     runStickToLatestVerify();
-  }, [runStickToLatestVerify, scrollToEndProgrammatically]);
+  }, [cancelHistoryPrependTransaction, runStickToLatestVerify, scrollToEndProgrammatically]);
 
   const jumpToPreviousUserMessage = useCallback(() => {
     if (!previousUserTarget) return;
@@ -1308,7 +1589,7 @@ export function MessageRenderer({
     previousFollowLatestRequestKeyRef.current = followLatestRequestKey;
     if (followLatestRequestKey === null || followLatestRequestKey === undefined) return;
     nearBottomRef.current = true;
-    readingOlderRef.current = false;
+    cancelHistoryPrependTransaction();
     // 发送后的显式贴底已经取代旧的历史浏览意图。先清掉该标记,否则 verifier 的
     // stickToLatest 会被一次更早的拖动永久压成 false,退化回不可靠的单次 scrollToEnd。
     // 用户若在校验期间再次拖动,onScrollBeginDrag 会重新置 true 并自然中止补滚。
@@ -1323,7 +1604,12 @@ export function MessageRenderer({
     setIsAwayFromBottom(false);
     scrollToEndProgrammatically(true);
     runStickToLatestVerify();
-  }, [followLatestRequestKey, runStickToLatestVerify, scrollToEndProgrammatically]);
+  }, [
+    cancelHistoryPrependTransaction,
+    followLatestRequestKey,
+    runStickToLatestVerify,
+    scrollToEndProgrammatically,
+  ]);
 
   // 自动加载更早:电平触发判定(shouldAutoLoadEarlier),在所有可能改变判定结果的时机重评估
   // (scroll 事件 / LegendList onStartReached 边沿 / eligibility 变化 effect)。
@@ -1331,94 +1617,32 @@ export function MessageRenderer({
   // (或阈值内 data 变化)才会再发;这里的业务 guard(没拖动过 / 正在加载 / 入口未点亮)吞掉一次
   // 边沿后,条件就绪时不会有下一个边沿,用户就停在顶部干等(短加载窗口的会话冷开即中招:
   // 列表底部已落在近顶阈值内,边沿在拖动前就被消费,之后永远滚不出复位区 → 永久哑火)。
-  // nearStart / atEnd 读 LegendList getState() 的实时账:它的 scroll 记账含 prepend 锚点补偿,
-  // 而 app 侧 onScroll 的原生 offsetY 在 prepend 后不再代表「距内容顶端的距离」,不可用于判顶。
-  // prepend 防跳由内置 maintainVisibleContentPosition 处理,无需手动开 maintain。
+  // nearStart / atEnd 读 LegendList getState() 的实时账；app 侧 onScroll 的原生 offsetY
+  // 在 prepend 提交期间不代表「距内容顶端的距离」，不可用于判顶。prepend 防跳由上面的
+  // key + viewportOffset 事务处理；请求开始前会暂时关闭 Android native MVCP，恢复完成后重开。
   // 冷开只在列表同时位于 start/end(内容未撑满首屏)时有界补页；真实上翻意图继续沿用
   // 不限页的近顶预取。两条路径都受首项进展去重保护,失败/重复页不会循环打 host。
-  const scheduleReadingOlderRelease = useCallback((generation: number) => {
-    if (readingOlderReleaseTimerRef.current !== null) {
-      clearTimeout(readingOlderReleaseTimerRef.current);
-      readingOlderReleaseTimerRef.current = null;
-    }
-    const attemptRelease = () => {
-      readingOlderReleaseTimerRef.current = null;
-      if (
-        readingOlderRequestGenerationRef.current !== generation
-        || !readingOlderRef.current
-      ) return;
-      // Never apply the native-anchor settle deadline to the remote request itself. A legitimately
-      // slow active-session page must keep prepend protection until the parent commits
-      // loadingEarlier=false; the 500 ms bound starts only after that network/loading phase ends.
-      if (loadingEarlierRef.current) {
-        readingOlderReleaseDeadlineRef.current = 0;
-        readingOlderReleaseTimerRef.current = setTimeout(attemptRelease, 16);
-        return;
-      }
-      if (readingOlderReleaseDeadlineRef.current === 0) {
-        readingOlderReleaseDeadlineRef.current = Date.now()
-          + MOBILE_HISTORY_PREPEND_SETTLE_MAX_MS;
-      }
-      const quietWindowRemainingMs = Math.max(
-        0,
-        Math.min(
-          mvcpSettleAtRef.current,
-          readingOlderReleaseDeadlineRef.current,
-        ) - Date.now(),
-      );
-      if (quietWindowRemainingMs > 0) {
-        readingOlderReleaseTimerRef.current = setTimeout(
-          attemptRelease,
-          quietWindowRemainingMs,
-        );
-        return;
-      }
-      // Passive effects run after the page has joined the React tree; two more frames leave the
-      // native ScrollView/LegendList MVCP adjustment ahead of any follow-to-end compensation.
-      requestAnimationFrame(() => {
-        requestAnimationFrame(() => {
-          if (
-            readingOlderRequestGenerationRef.current === generation
-            && readingOlderRef.current
-            && !loadingEarlierRef.current
-          ) {
-            const extendedQuietWindowMs = Math.max(
-              0,
-              Math.min(
-                mvcpSettleAtRef.current,
-                readingOlderReleaseDeadlineRef.current,
-              ) - Date.now(),
-            );
-            if (extendedQuietWindowMs > 0) {
-              readingOlderReleaseTimerRef.current = setTimeout(
-                attemptRelease,
-                extendedQuietWindowMs,
-              );
-              return;
-            }
-            readingOlderRef.current = false;
-            readingOlderLoadingObservedRef.current = false;
-            readingOlderReleaseDeadlineRef.current = 0;
-            setLoadEarlierEvaluationVersion((version) => version + 1);
-          } else if (
-            readingOlderRequestGenerationRef.current === generation
-            && readingOlderRef.current
-          ) {
-            readingOlderReleaseDeadlineRef.current = 0;
-            readingOlderReleaseTimerRef.current = setTimeout(attemptRelease, 16);
-          }
-        });
-      });
-    };
-    attemptRelease();
-  }, []);
-
-  const requestLoadEarlier = useCallback(() => {
+  const beginLoadEarlier = useCallback(() => {
     if (!onLoadEarlier) return;
     const generation = readingOlderRequestGenerationRef.current + 1;
     readingOlderRequestGenerationRef.current = generation;
-    readingOlderLoadingObservedRef.current = false;
-    readingOlderReleaseDeadlineRef.current = 0;
+    const listState = listRef.current?.getState();
+    const anchor = listState
+      ? captureMobileHistoryAnchor(
+        listState,
+        (item) => (item as MobileMessageRenderItem).key,
+      )
+      : null;
+    historyPrependTransactionRef.current = {
+      anchor,
+      anchorStable: false,
+      generation,
+      pageCommitted: false,
+      promiseSettled: false,
+      startProgressKey: firstItemKey,
+      userControlledAfterCommit: false,
+      verifyDeadlineAt: 0,
+    };
     readingOlderRef.current = true;
     // A short list can be simultaneously atStart and atEnd. Once the user explicitly browses
     // older history, it must no longer be treated as following the latest edge; otherwise the
@@ -1427,44 +1651,84 @@ export function MessageRenderer({
       nearBottomRef.current = false;
       setIsAwayFromBottom(true);
     }
-    const releaseAfterRequestSettles = () => {
-      // React Native may batch loadingEarlier=true and loadingEarlier=false around a fast page,
-      // so the child is not guaranteed to observe the intermediate loading render. Promise
-      // settlement is the authoritative bounded fallback; the effect below still releases after
-      // the committed loading transition when it is observable.
-      if (readingOlderRequestGenerationRef.current === generation) {
-        scheduleReadingOlderRelease(generation);
-      }
+    const markRequestSettled = () => {
+      const transaction = historyPrependTransactionRef.current;
+      if (!transaction || transaction.generation !== generation) return;
+      transaction.promiseSettled = true;
+      // Force one render after Promise settlement. The parent may batch loading=true, the merged
+      // page, and loading=false; the layout effect above is the authoritative point where we decide
+      // whether a page actually committed before releasing the transaction.
+      setLoadEarlierEvaluationVersion((version) => version + 1);
     };
     try {
       const result = onLoadEarlier();
       void Promise.resolve(result).then(
-        releaseAfterRequestSettles,
-        releaseAfterRequestSettles,
+        markRequestSettled,
+        markRequestSettled,
       );
     } catch {
-      releaseAfterRequestSettles();
+      markRequestSettled();
     }
-  }, [onLoadEarlier, scheduleReadingOlderRelease]);
+  }, [firstItemKey, onLoadEarlier]);
 
-  useEffect(() => {
-    if (!readingOlderRef.current) return;
-    if (loadingEarlier === true) {
-      readingOlderLoadingObservedRef.current = true;
+  const flushQueuedLoadEarlier = useCallback(() => {
+    if (
+      !queuedLoadEarlierRef.current
+      || isDraggingRef.current
+      || isMomentumScrollingRef.current
+      || historyTouchStartYRef.current !== null
+    ) return;
+    // The request must not start until a committed render has removed RN's native MVCP prop.
+    // Otherwise a fast local/relay response can prepend before the prop update reaches Android.
+    if (!historyPrependNativeMvcpDisabledRef.current) {
+      setHistoryPrependNativeMvcpDisabled(true);
       return;
     }
-    if (!readingOlderLoadingObservedRef.current) return;
-    scheduleReadingOlderRelease(readingOlderRequestGenerationRef.current);
-  }, [itemKeysSignature, loadingEarlier, scheduleReadingOlderRelease]);
+    queuedLoadEarlierRef.current = false;
+    beginLoadEarlier();
+  }, [beginLoadEarlier]);
+
+  const scheduleQueuedLoadEarlierFlush = useCallback(() => {
+    if (queuedLoadEarlierFlushFrameRef.current !== null) return;
+    queuedLoadEarlierFlushFrameRef.current = requestAnimationFrame(() => {
+      queuedLoadEarlierFlushFrameRef.current = null;
+      flushQueuedLoadEarlier();
+    });
+  }, [flushQueuedLoadEarlier]);
+
+  const requestLoadEarlier = useCallback(() => {
+    if (!onLoadEarlier || readingOlderRef.current || queuedLoadEarlierRef.current) return;
+    // Queueing itself owns the history-browse lock: a running task may append/resize messages while
+    // the current drag or momentum is still settling, and those contentSize events must not follow
+    // the latest edge before the history request actually starts.
+    queuedLoadEarlierRef.current = true;
+    readingOlderRef.current = true;
+    if (userScrollForOlderRef.current) {
+      nearBottomRef.current = false;
+      setIsAwayFromBottom(true);
+    }
+    // The first safe frame disables native MVCP. Its committed layout effect below then starts the
+    // request, keeping the unanchored interval to a single React commit with no network in flight.
+    scheduleQueuedLoadEarlierFlush();
+  }, [onLoadEarlier, scheduleQueuedLoadEarlierFlush]);
+
+  useLayoutEffect(() => {
+    if (!historyPrependNativeMvcpDisabled) return;
+    flushQueuedLoadEarlier();
+  }, [flushQueuedLoadEarlier, historyPrependNativeMvcpDisabled]);
 
   const attemptAutoLoadEarlier = useCallback((nativeMetrics?: MessageScrollMetrics) => {
     if (!onLoadEarlier) return;
-    if (readingOlderRef.current) return;
+    if (readingOlderRef.current || queuedLoadEarlierRef.current) return;
     // 热路径前置短路(滚动事件每 16ms 评估一次,getState() 每次新建状态对象):没有用户浏览意图
     // 且冷开预算已耗尽、或当前首项已尝试过时不碰 getState。完整判定仍以
     // shouldAutoLoadEarlier 为唯一真相,这里只做它的子集提前返回。
     const userScrolledForOlder = userScrollForOlderRef.current;
-    const initialAutoFillAllowed = !userScrolledForOlder
+    // Reveal the latest cached page before cold-open autofill starts. Otherwise the initial
+    // scroll-to-end verifier waits behind one or more history requests while the whole list is
+    // still opacity-hidden, which turns a background prefetch into a multi-second blank screen.
+    const initialAutoFillAllowed = listRevealed
+      && !userScrolledForOlder
       && initialHistoryAutofillRemainingRef.current > 0;
     if (!userScrolledForOlder && !initialAutoFillAllowed) return;
     if (firstItemKey !== null && lastAutoLoadEarlierKeyRef.current === firstItemKey) return;
@@ -1496,6 +1760,7 @@ export function MessageRenderer({
     firstItemKey,
     loadEarlierAction.disabled,
     loadEarlierAction.visible,
+    listRevealed,
     onLoadEarlier,
     requestLoadEarlier,
   ]);
@@ -1513,9 +1778,24 @@ export function MessageRenderer({
       viewportHeight: event.nativeEvent.layoutMeasurement.height,
     };
     const previousOffsetY = scrollMetricsRef.current.offsetY;
-    const wasNearBottom = nearBottomRef.current;
-    const scrollDelta = readingOlderRef.current ? 0 : metrics.offsetY - previousOffsetY;
     scrollMetricsRef.current = metrics;
+    if (readingOlderRef.current) {
+      if (
+        isDraggingRef.current
+        || isMomentumScrollingRef.current
+        || historyTouchTriggeredRef.current
+      ) {
+        handoffHistoryPrependToUser();
+      }
+      // Prepend layout can transiently report an empty/short content range. Never feed those
+      // metrics into near-bottom resolution: it would flip false→true and the next size event
+      // would force the reader to the latest message.
+      attemptAutoLoadEarlier(metrics);
+      if (shareSelectionActiveRef.current) scheduleStickyShareCheck();
+      return;
+    }
+    const wasNearBottom = nearBottomRef.current;
+    const scrollDelta = metrics.offsetY - previousOffsetY;
     if (
       nearBottomRef.current
       && shouldUnpinMobileFollowOnDrag({
@@ -1527,13 +1807,21 @@ export function MessageRenderer({
       nearBottomRef.current = false;
       setIsAwayFromBottom(true);
     } else {
-      const nearBottom = resolveMobileNearBottomOnScroll({
-        wasNearBottom: nearBottomRef.current,
-        metrics,
-        programmaticScrollInFlight: programmaticScrollInFlightRef.current,
-        scrollDelta,
-        bottomOverlayHeight,
+      const preserveHistoryBrowseIntent = shouldPreserveMobileHistoryBrowseIntent({
+        historyBrowseIntent: userScrollForOlderRef.current,
+        userControllingScroll: isDraggingRef.current
+          || isMomentumScrollingRef.current
+          || historyTouchStartYRef.current !== null,
       });
+      const nearBottom = preserveHistoryBrowseIntent
+        ? false
+        : resolveMobileNearBottomOnScroll({
+          wasNearBottom: nearBottomRef.current,
+          metrics,
+          programmaticScrollInFlight: programmaticScrollInFlightRef.current,
+          scrollDelta,
+          bottomOverlayHeight,
+        });
       nearBottomRef.current = nearBottom;
       // A genuine downward false→true transition means the user manually returned to the
       // latest edge. The old history-browsing intent no longer owns follow verification;
@@ -1552,10 +1840,14 @@ export function MessageRenderer({
   }, [
     attemptAutoLoadEarlier,
     bottomOverlayHeight,
+    handoffHistoryPrependToUser,
     scheduleStickyShareCheck,
   ]);
 
   const handleHistoryTouchStart = useCallback((event: GestureResponderEvent) => {
+    // Android may omit momentum-end when a new finger stops a fling. The new touch owns the
+    // ScrollView now, so the old momentum flag must not keep a queued history request suspended.
+    isMomentumScrollingRef.current = false;
     historyTouchStartYRef.current = event.nativeEvent.pageY;
     historyTouchTriggeredRef.current = false;
   }, []);
@@ -1570,8 +1862,9 @@ export function MessageRenderer({
     historyTouchTriggeredRef.current = true;
     userScrollForOlderRef.current = true;
     lastAutoLoadEarlierKeyRef.current = null;
+    handoffHistoryPrependToUser();
     attemptAutoLoadEarlier(scrollMetricsRef.current);
-  }, [attemptAutoLoadEarlier]);
+  }, [attemptAutoLoadEarlier, handoffHistoryPrependToUser]);
 
   const handleHistoryTouchMove = useCallback((event: GestureResponderEvent) => {
     maybeTriggerHistoryTouch(event.nativeEvent.pageY);
@@ -1583,12 +1876,14 @@ export function MessageRenderer({
     maybeTriggerHistoryTouch(event.nativeEvent.pageY);
     historyTouchStartYRef.current = null;
     historyTouchTriggeredRef.current = false;
-  }, [maybeTriggerHistoryTouch]);
+    scheduleQueuedLoadEarlierFlush();
+  }, [maybeTriggerHistoryTouch, scheduleQueuedLoadEarlierFlush]);
 
   const handleHistoryTouchCancel = useCallback(() => {
     historyTouchStartYRef.current = null;
     historyTouchTriggeredRef.current = false;
-  }, []);
+    scheduleQueuedLoadEarlierFlush();
+  }, [scheduleQueuedLoadEarlierFlush]);
 
   // 用户开始拖动 → 标记「上翻意图」,放行自动加载更早(onScrollBeginDrag 仅用户手势触发,
   // 程序化 scrollToEnd 不会触发,故不会误置);同时记录拖动起点 offset,供
@@ -1600,25 +1895,38 @@ export function MessageRenderer({
       viewportHeight: event.nativeEvent.layoutMeasurement.height,
     };
     clearProgrammaticScroll();
+    isMomentumScrollingRef.current = false;
     isDraggingRef.current = true;
     dragStartOffsetYRef.current = event.nativeEvent.contentOffset.y;
     userScrollForOlderRef.current = true;
     // 新手势 = 允许重新尝试一次自动加载(上次失败 / 无进展的去重记录随手势作废)。
     lastAutoLoadEarlierKeyRef.current = null;
     attemptAutoLoadEarlier(nativeMetrics);
+    handoffHistoryPrependToUser();
     // 请求仍在飞或新页仍在做 mVCP 布局时，新的触摸不能提前解除历史锚点保护。
     // 下滑回底的显式按钮/跟随请求会主动清理；普通手势在分页落地后由方向判定恢复。
     // 翻完 refs 立即补一次电平评估:列表已顶死时(Android 无 bounce 尤甚)这次拖动不产生
     // offset 变化,不会有 onScroll / onStartReached,ref 写入也不驱动 effect——没有这一刀,
     // 「失败后停在顶部再拖一下重试」的信号会整体丢失(review P2)。
-  }, [attemptAutoLoadEarlier]);
+  }, [attemptAutoLoadEarlier, handoffHistoryPrependToUser]);
 
   // 拖动结束(手指离开,可能进入惯性滚动)→ 关闭拖动追踪。惯性阶段的上滑不需要再判
   // 解除:上滑手势的拖动段必然已越过死区完成解除;下滑回底的恢复由 scroll 方向判定接手。
   const handleScrollEndDrag = useCallback(() => {
     isDraggingRef.current = false;
     dragStartOffsetYRef.current = null;
+    // Wait one frame so Android can report whether this drag transitioned into momentum.
+    scheduleQueuedLoadEarlierFlush();
+  }, [scheduleQueuedLoadEarlierFlush]);
+
+  const handleMomentumScrollBegin = useCallback(() => {
+    isMomentumScrollingRef.current = true;
   }, []);
+
+  const handleMomentumScrollEnd = useCallback(() => {
+    isMomentumScrollingRef.current = false;
+    scheduleQueuedLoadEarlierFlush();
+  }, [scheduleQueuedLoadEarlierFlush]);
 
   const handleStartReached = useCallback(() => {
     attemptAutoLoadEarlier();
@@ -1647,7 +1955,23 @@ export function MessageRenderer({
     const { viewportHeight } = scrollMetricsRef.current;
     scrollMetricsRef.current = { ...scrollMetricsRef.current, contentHeight: height };
     // readingOlderRef:load-earlier 的 prepend 也会撑高 contentHeight,但那是顶部增长、不该贴底(review P1)。
-    if (readingOlderRef.current) return;
+    if (readingOlderRef.current) {
+      const transaction = historyPrependTransactionRef.current;
+      if (transaction) {
+        if (transaction.pageCommitted) {
+          scheduleHistoryAnchorRestore(transaction.generation);
+        } else if (
+          !isDraggingRef.current
+          && !isMomentumScrollingRef.current
+          && historyTouchStartYRef.current === null
+        ) {
+          // Native MVCP is intentionally disabled before the request starts. Keep the current row
+          // pinned while an image/Markdown/live row changes height during that network window.
+          restoreHistoryAnchorOnce(transaction.generation);
+        }
+      }
+      return;
+    }
     if (nearBottomRef.current && viewportHeight > 0 && height > viewportHeight) {
       // Animated jump/send follow owns the viewport until its settle window closes. Content
       // growth during that animation only reschedules the verifier; a false-animated pin here
@@ -1693,15 +2017,19 @@ export function MessageRenderer({
     }
   }, [
     markMobileMvcpSettle,
+    restoreHistoryAnchorOnce,
     runStickToLatestVerify,
+    scheduleHistoryAnchorRestore,
     scrollToEndProgrammatically,
   ]);
 
-  // 与 main 一致的首次落底：完整历史已经在列表里，所有命令式补滚与动态高度校正
-  // 都在 opacity 遮罩下完成；确认到达内容末端（或有界放弃）后再一次性揭开。
-  useEffect(() => {
+  // 首次落底：完整历史已经在列表里。短暂遮住命令式落底与首轮测量校正，随后由 native
+  // Animated 在 UI 线程按真实时间揭开；运行中消息持续 resize 或复杂 cell 占满 JS 时，
+  // 都不能把数据已在本地的消息区继续隐藏数秒。
+  useLayoutEffect(() => {
     if (initialAnchorDoneRef.current) return;
     if (listData.length === 0) {
+      initialRevealProgress.setValue(1);
       setListRevealed(true);
       return;
     }
@@ -1711,7 +2039,10 @@ export function MessageRenderer({
     initialAnchorGenerationRef.current = generation;
     if (initialAnchorFrameRef.current !== null) cancelAnimationFrame(initialAnchorFrameRef.current);
     if (initialAnchorVerifyFrameRef.current !== null) cancelAnimationFrame(initialAnchorVerifyFrameRef.current);
-    if (initialRevealTimerRef.current) clearTimeout(initialRevealTimerRef.current);
+    initialRevealAnimationRef.current?.stop();
+    initialRevealProgress.setValue(0);
+    setListRevealed(false);
+    const revealDeadlineAt = Date.now() + MOBILE_INITIAL_REVEAL_MAX_MS;
 
     const finish = () => {
       if (initialAnchorGenerationRef.current !== generation) return;
@@ -1719,13 +2050,32 @@ export function MessageRenderer({
         cancelAnimationFrame(initialAnchorVerifyFrameRef.current);
         initialAnchorVerifyFrameRef.current = null;
       }
-      initialRevealTimerRef.current = null;
       setListRevealed(true);
     };
 
-    const startedAt = Date.now();
+    const revealAnimation = Animated.timing(initialRevealProgress, {
+      duration: MOBILE_INITIAL_REVEAL_MAX_MS,
+      easing: Easing.linear,
+      toValue: 1,
+      useNativeDriver: true,
+    });
+    initialRevealAnimationRef.current = revealAnimation;
+    revealAnimation.start(({ finished }) => {
+      if (initialRevealAnimationRef.current === revealAnimation) {
+        initialRevealAnimationRef.current = null;
+      }
+      if (finished) finish();
+    });
+
     const verify = (attempts: number, waitRounds: number) => {
       if (initialAnchorGenerationRef.current !== generation) return;
+      // The native reveal is a real wall-clock deadline. If JS resumes after it, do not expose a
+      // late corrective scroll on an already-visible list.
+      if (Date.now() >= revealDeadlineAt) {
+        initialAnchorVerifyFrameRef.current = null;
+        setListRevealed(true);
+        return;
+      }
       const preserveVisibleContentPosition = readingOlderRef.current
         || isMobileMvcpSettling(Date.now(), mvcpSettleAtRef.current);
       const action = evaluateMobileAnchorVerify({
@@ -1737,12 +2087,9 @@ export function MessageRenderer({
         waitRounds,
       });
       if (action === 'settled' || action === 'give-up') {
-        const remaining = Math.max(
-          0,
-          MOBILE_INITIAL_ANCHOR_SETTLE_MS - (Date.now() - startedAt),
-        );
-        if (remaining === 0) finish();
-        else initialRevealTimerRef.current = setTimeout(finish, remaining);
+        // The native animation owns the visual deadline. Settling early only stops verification;
+        // it must not replace that deadline or expose the hidden correction frames.
+        initialAnchorVerifyFrameRef.current = null;
         return;
       }
       if (action === 'retry') scrollToEndProgrammatically(false);
@@ -1757,10 +2104,12 @@ export function MessageRenderer({
       });
     };
 
+    // Issue the first correction synchronously in the layout effect so native receives it before
+    // the UI-thread reveal starts, even when subsequent Markdown/cell work blocks JS.
+    scrollToEndProgrammatically(false);
     initialAnchorFrameRef.current = requestAnimationFrame(() => {
       initialAnchorFrameRef.current = null;
       if (initialAnchorGenerationRef.current !== generation) return;
-      scrollToEndProgrammatically(false);
       initialAnchorVerifyFrameRef.current = requestAnimationFrame(() => {
         initialAnchorVerifyFrameRef.current = requestAnimationFrame(() => {
           initialAnchorVerifyFrameRef.current = null;
@@ -1769,7 +2118,12 @@ export function MessageRenderer({
         });
       });
     });
-  }, [listData.length, scrollResetKey, scrollToEndProgrammatically]);
+  }, [
+    initialRevealProgress,
+    listData.length,
+    scrollResetKey,
+    scrollToEndProgrammatically,
+  ]);
 
   // 会话切换(scrollResetKey):重置浮标/近底等 UI 状态;LegendList 本体完整重挂并重新落底。
   // 滚动/自动加载相关的 ref 复位已在渲染期同步块完成(见 prevScrollResetKeyRef,防切会话
@@ -1790,14 +2144,18 @@ export function MessageRenderer({
   // 但不留悬挂句柄)。
   useEffect(() => () => {
     initialAnchorGenerationRef.current += 1;
+    readingOlderRequestGenerationRef.current += 1;
+    historyPrependTransactionRef.current = null;
     followVerifyGenerationRef.current += 1;
     if (followEndPinRecoveryTimerRef.current) clearTimeout(followEndPinRecoveryTimerRef.current);
     clearProgrammaticScroll();
     if (initialAnchorFrameRef.current !== null) cancelAnimationFrame(initialAnchorFrameRef.current);
     if (initialAnchorVerifyFrameRef.current !== null) cancelAnimationFrame(initialAnchorVerifyFrameRef.current);
     if (followVerifyFrameRef.current !== null) cancelAnimationFrame(followVerifyFrameRef.current);
+    if (queuedLoadEarlierFlushFrameRef.current !== null) cancelAnimationFrame(queuedLoadEarlierFlushFrameRef.current);
+    if (historyAnchorVerifyFrameRef.current !== null) cancelAnimationFrame(historyAnchorVerifyFrameRef.current);
     if (followVerifyTimerRef.current !== null) clearTimeout(followVerifyTimerRef.current);
-    if (initialRevealTimerRef.current) clearTimeout(initialRevealTimerRef.current);
+    initialRevealAnimationRef.current?.stop();
   }, [clearProgrammaticScroll]);
 
   // 顶部 chrome(如连接横幅)出现/消失 → topPadding 变 → contentContainerStyle.paddingTop 变 →
@@ -1912,6 +2270,7 @@ export function MessageRenderer({
       onTouchCancel={handleHistoryTouchCancel}
     >
       <MessageListVisibleKeysContext.Provider value={visibleMessageKeys}>
+      <Animated.View style={[styles.messageList, { opacity: initialRevealOpacity }]}>
       <LegendList
         // 与 main 一致：每个任务用完整历史重挂；首次命令式落底在 opacity 遮罩下完成。
         key={scrollResetKey}
@@ -1929,7 +2288,12 @@ export function MessageRenderer({
         // 二分实锤,3.3.2 / 3.3.3 均复现)。
         alignItemsAtEnd
         maintainScrollAtEnd={false}
-        maintainVisibleContentPosition={{ data: true, size: true }}
+        // Ordinary updates keep LegendList's native data/size anchoring. Manual history prepends
+        // disable the whole prop before the request starts because RN exposes one native switch:
+        // leaving either flag on would race the app-owned key/offset correction on Android.
+        maintainVisibleContentPosition={historyPrependNativeMvcpDisabled
+          ? false
+          : { data: true, size: true }}
         contentContainerStyle={[
           styles.messages,
           { paddingBottom: bottomPadding, paddingTop: topPadding },
@@ -1958,15 +2322,18 @@ export function MessageRenderer({
         onScroll={handleScroll}
         onScrollBeginDrag={handleScrollBeginDrag}
         onScrollEndDrag={handleScrollEndDrag}
+        onMomentumScrollBegin={handleMomentumScrollBegin}
+        onMomentumScrollEnd={handleMomentumScrollEnd}
         onStartReached={handleStartReached}
         onStartReachedThreshold={2}
         scrollEventThrottle={16}
         ref={listRef}
-        style={[styles.messageList, !listRevealed && styles.messageListSettling]}
+        style={styles.messageList}
         testID={testID ?? 'message.list'}
         viewabilityConfig={viewabilityConfigRef.current}
         onViewableItemsChanged={handleViewableItemsChangedRef.current}
       />
+      </Animated.View>
       </MessageListVisibleKeysContext.Provider>
       {previousUserTarget && previousUserButtonTop !== null ? (
         <MessageListActionButton
@@ -6953,8 +7320,6 @@ function headingSizeStyle(
 const makeStyles = (colors: ThemeColors) => StyleSheet.create({
   messageFrame: { flex: 1, minHeight: 0 },
   messageList: { flex: 1 },
-  // main 的首次锚定遮罩：列表仍正常布局/测量，只是不把内部补滚过程暴露出来。
-  messageListSettling: { opacity: 0 },
   messages: {
     flexGrow: 1,
     // Anchor a short conversation to the bottom (just above the composer) like a normal chat,

--- a/apps/mobile/src/session/MessageRenderer.tsx
+++ b/apps/mobile/src/session/MessageRenderer.tsx
@@ -618,7 +618,7 @@ export function MessageRenderer({
   /** 空列表且本次打开的首同步未完成:渲染「正在同步」占位(延迟显形防闪)而非「暂无消息」。 */
   syncingWhileEmpty?: boolean;
   testID?: string;
-  /** DEV-only A/B switch; production keeps row recycling disabled until verified. */
+  /** DEV-only A/B switch; production always enables verified row recycling. */
   devRecycleItems?: boolean;
   /** 全屏图片查看器的分享回调(由会话屏落地本地文件后唤起系统分享单)。 */
   onShareImage?: (
@@ -5835,8 +5835,8 @@ function MessagePayloadBody({
 
   useEffect(() => () => {
     const resolved = resolvedRemoteMediaRef.current;
-    // image 不再关闭即删:缩略图常驻列表共用同一 OSS 对象,删了会把列表缩略图弄坏,
-    // 改为退出会话屏时统一清理(见 [sessionId].tsx)。video/audio 保持关闭即删。
+    // image 缩略图常驻列表,不随 payload viewer 关闭逐出。video/audio 关闭时只
+    // 逐出 JS cache,OSS 对象延迟到换会话/页面卸载统一删除(见 [sessionId].tsx)。
     if (remoteMedia?.url && resolved && remoteMedia.kind !== 'image') {
       onReleaseRemoteMedia?.(remoteMedia.url, resolved);
     }

--- a/apps/mobile/src/session/MessageRenderer.tsx
+++ b/apps/mobile/src/session/MessageRenderer.tsx
@@ -304,8 +304,6 @@ import {
 import type { ContinuationInFlightProjectionCapability } from '@/session/types';
 import {
   projectMobileWorkActivities,
-  projectRecentMobileWorkActivities,
-  type MobileProjectedThinkingActivity,
   type MobileProjectedToolActivity,
 } from '@/session/workActivityProjection';
 import { logUnhandledRenderItem } from '@/session/assertNever';
@@ -407,8 +405,6 @@ const ANDROID_SELECTABLE_TEXT_RUN_GROUPING_OPTIONS: MobileMarkdownTextRunGroupin
   maxTextRunUtf16Length: ANDROID_SELECTABLE_TEXT_RUN_MAX_UTF16_LENGTH,
   maxTextRunInlineFragments: ANDROID_SELECTABLE_TEXT_RUN_MAX_INLINE_FRAGMENTS,
 };
-/** Running work groups expose only the same latest-five activity window as desktop. */
-const MAX_LIVE_WORK_ACTIVITIES = 5;
 // LegendList 预渲距离(px,视口外每侧):约 1 屏,挂载集小 → 滚动 mount 帧压进一帧内(见 listperf 实测)。
 const MOBILE_MESSAGE_DRAW_DISTANCE = 800;
 const FOLDABLE_HEADER_HIT_SLOP = { bottom: 10, left: 4, right: 4, top: 10 };
@@ -3942,17 +3938,12 @@ function WorkGroupCard({
   const contentLayout = useMemo(() => buildMessageContentLayout({
     screenWidth: actions.screenWidth,
   }), [actions.screenWidth]);
-  const liveActivities = useMemo(
-    () => projectRecentMobileWorkActivities(item.children, isStreaming, MAX_LIVE_WORK_ACTIVITIES),
-    [isStreaming, item.children],
-  );
   const activityProjection = useMemo(
     () => (expanded || !isStreaming
       ? projectMobileWorkActivities(item.children, isStreaming)
       : null),
     [expanded, isStreaming, item.children],
   );
-  const isLivePreviewVisible = isStreaming && !expanded && liveActivities.length > 0;
   const startedAtIso = item.startedAtMs !== undefined
     ? new Date(item.startedAtMs).toISOString()
     : undefined;
@@ -3975,30 +3966,11 @@ function WorkGroupCard({
     explorationSummary,
   ].filter(Boolean).join(' · ');
   const onToggle = toggleExpanded;
-  const livePreview = isLivePreviewVisible ? (
-    <Rail layout={layout}>
-      <View style={styles.workActivityStack}>
-        {liveActivities.map((activity) => (
-          activity.kind === 'tool'
-            ? (
-                <WorkToolActivityRow
-                  key={activity.key}
-                  actions={actions}
-                  activity={activity}
-                  contentLayout={contentLayout}
-                />
-              )
-            : <WorkThinkingPreviewRow key={activity.key} activity={activity} />
-        ))}
-      </View>
-    </Rail>
-  ) : undefined;
   return (
     <FoldablePanel
       chevronPosition={header.chevronPosition}
       chevronSize={header.chevronSize}
       controlledExpanded={expanded}
-      collapsedBody={livePreview}
       onControlledToggle={onToggle}
       title={title}
       subtitle={header.subtitle ?? undefined}
@@ -4012,30 +3984,32 @@ function WorkGroupCard({
       testID="message.workGroupToggle"
       variant={header.variant}
     >
-      <Rail layout={layout}>
-        <View style={styles.workGroupStack}>
-          {item.children.map((child) => {
-            if (child.type === 'thinking') {
-              return <ExpandedWorkThinkingRow key={child.key} item={child} />;
-            }
-            if (child.type === 'tool_group') {
-              return (
-                <View key={child.key} style={styles.workActivityStack}>
-                  {(activityProjection?.toolActivitiesByChildKey.get(child.key) ?? []).map((activity) => (
-                    <WorkToolActivityRow
-                      key={activity.key}
-                      actions={actions}
-                      activity={activity}
-                      contentLayout={contentLayout}
-                    />
-                  ))}
-                </View>
-              );
-            }
-            return <RenderItemView key={child.key} item={child} actions={actions} />;
-          })}
-        </View>
-      </Rail>
+      {expanded ? (
+        <Rail layout={layout}>
+          <View style={styles.workGroupStack}>
+            {item.children.map((child) => {
+              if (child.type === 'thinking') {
+                return <ExpandedWorkThinkingRow key={child.key} item={child} />;
+              }
+              if (child.type === 'tool_group') {
+                return (
+                  <View key={child.key} style={styles.workActivityStack}>
+                    {(activityProjection?.toolActivitiesByChildKey.get(child.key) ?? []).map((activity) => (
+                      <WorkToolActivityRow
+                        key={activity.key}
+                        actions={actions}
+                        activity={activity}
+                        contentLayout={contentLayout}
+                      />
+                    ))}
+                  </View>
+                );
+              }
+              return <RenderItemView key={child.key} item={child} actions={actions} />;
+            })}
+          </View>
+        </Rail>
+      ) : null}
     </FoldablePanel>
   );
 }
@@ -4065,28 +4039,6 @@ function WorkToolActivityRow({
       rowKey={activity.key}
       tool={tool}
     />
-  );
-}
-
-function WorkThinkingPreviewRow({
-  activity,
-}: {
-  activity: MobileProjectedThinkingActivity;
-}) {
-  const { colors } = useTheme();
-  const styles = useThemedStyles(makeStyles);
-  return (
-    <View
-      style={styles.workThinkingRow}
-      testID="message.workThinkingPreview"
-    >
-      <View style={stylesStatic.workActivityIconSlot}>
-        <Sparkles color={colors.textTertiary} size={iconSize.sm} strokeWidth={iconStroke.regular} />
-      </View>
-      <Text numberOfLines={1} style={[styles.workActivityText, styles.italicText, styles.workThinkingText]}>
-        <ThinkingInlineText content={activity.content} />
-      </Text>
-    </View>
   );
 }
 
@@ -4207,7 +4159,6 @@ function FoldablePanel({
   title,
   subtitle,
   children,
-  collapsedBody,
   controlledExpanded,
   defaultExpanded = false,
   layout,
@@ -4229,9 +4180,7 @@ function FoldablePanel({
   title: string;
   subtitle?: string;
   children: ReactNode;
-  /** Optional running preview rendered while the full body remains collapsed. */
-  collapsedBody?: ReactNode;
-  /** Controlled mode used by work groups with a preview state separate from expansion. */
+  /** Controlled mode used by work groups. */
   controlledExpanded?: boolean;
   /** 仅无 blockId 的本地 state 路径生效;blockId 存在时由共享记忆决定(默认折叠)。 */
   defaultExpanded?: boolean;
@@ -4313,18 +4262,6 @@ function FoldablePanel({
             },
         ]}>
           {children}
-        </View>
-      ) : collapsedBody ? (
-        <View style={[
-          styles.foldBody,
-          variant === 'plain'
-            ? styles.foldBodyPlain
-            : {
-              paddingBottom: layout.foldBodyPaddingBottom,
-              paddingHorizontal: layout.foldBodyPaddingHorizontal,
-            },
-        ]}>
-          {collapsedBody}
         </View>
       ) : null}
     </View>

--- a/apps/mobile/src/session/MessageRenderer.tsx
+++ b/apps/mobile/src/session/MessageRenderer.tsx
@@ -57,7 +57,7 @@ import {
   type ViewToken,
 } from 'react-native';
 import { UITextView } from 'react-native-uitextview';
-import { LegendList, type LegendListRef } from '@legendapp/list/react-native';
+import { LegendList, useRecyclingState, type LegendListRef } from '@legendapp/list/react-native';
 import { tokenizeCode, type CodeTokenKind } from '@/session/codeHighlight';
 import { buildComposerTouchLayout } from '@/session/composerTouchLayout';
 import { useFoldableExpandedState } from '@/session/expandedBlockMemory';
@@ -384,6 +384,10 @@ const MAX_LIVE_WORK_ACTIVITIES = 5;
 // LegendList 预渲距离(px,视口外每侧):约 1 屏,挂载集小 → 滚动 mount 帧压进一帧内(见 listperf 实测)。
 const MOBILE_MESSAGE_DRAW_DISTANCE = 800;
 const FOLDABLE_HEADER_HIT_SLOP = { bottom: 10, left: 4, right: 4, top: 10 };
+
+function mobileMessageListItemType(item: MobileMessageRenderItem): MobileMessageRenderItem['type'] {
+  return item.type;
+}
 // 「跳到底部」浮标直径:比 composer 里的语音按钮(28)大一档但不压过它,Telegram 同款层级感。
 const SCROLL_TO_BOTTOM_FAB_SIZE = 36;
 const stylesStatic = StyleSheet.create({
@@ -1303,7 +1307,7 @@ export function MessageRenderer({
   // nearStart / atEnd 读 LegendList getState() 的实时账:它的 scroll 记账含 prepend 锚点补偿,
   // 而 app 侧 onScroll 的原生 offsetY 在 prepend 后不再代表「距内容顶端的距离」,不可用于判顶。
   // prepend 防跳由内置 maintainVisibleContentPosition 处理,无需手动开 maintain。
-  // 冷开初始布局允许有界补三页,把短初窗上方的上下文补齐；真实上翻意图则继续沿用
+  // 冷开只在列表同时位于 start/end(内容未撑满首屏)时有界补页；真实上翻意图继续沿用
   // 不限页的近顶预取。两条路径都受首项进展去重保护,失败/重复页不会循环打 host。
   const requestLoadEarlier = useCallback(() => {
     if (!onLoadEarlier) return;
@@ -1343,6 +1347,7 @@ export function MessageRenderer({
       actionDisabled: loadEarlierAction.disabled,
       actionVisible: loadEarlierAction.visible,
       atEnd: listState.isAtEnd,
+      atStart: listState.isAtStart,
       firstItemKey,
       initialAutoFillAllowed,
       lastAttemptedFirstItemKey: lastAutoLoadEarlierKeyRef.current,
@@ -1691,7 +1696,10 @@ export function MessageRenderer({
     ),
     [pendingSend?.selectedClientId, shareSelectionActive],
   );
-  const recycleItems = __DEV__ && devRecycleItems === true;
+  // Production uses native cell recycling after every identity-bound local
+  // state below was made recycling-aware. DEV stays opt-in so listperf can
+  // continue running the on/off control with one bundle.
+  const recycleItems = __DEV__ ? devRecycleItems === true : true;
 
   return (
     // chat-text-quote:Provider 恒挂载(值可为 null),避免启用态翻转时整棵消息树
@@ -1705,6 +1713,7 @@ export function MessageRenderer({
         key={scrollResetKey}
         data={listData}
         extraData={messageListExtraData}
+        getItemType={mobileMessageListItemType}
         keyExtractor={(item) => item.key}
         renderItem={renderMessageItem}
         recycleItems={recycleItems}
@@ -2072,8 +2081,8 @@ function MessageBubble({
   const styles = useThemedStyles(makeStyles);
   const { colors, mode } = useTheme();
   const { t, i18n: i18nInstance } = useTranslation();
-  const [copyState, setCopyState] = useState<CopyMessageStatus | 'idle' | 'copying'>('idle');
-  const [actionSheetOpen, setActionSheetOpen] = useState(false);
+  const [copyState, setCopyState] = useRecyclingState<CopyMessageStatus | 'idle' | 'copying'>('idle');
+  const [actionSheetOpen, setActionSheetOpen] = useRecyclingState(false);
   // chat-text-quote:只解析持久化 quotesEncoded 明确标记的产品引用消息，避免
   // 把用户手写的 Markdown blockquote 误当产品引用。兼容 desktop 的交错
   // marker 块和 mobile 的前置引用。旧 markerless 消息保持 leading-only，
@@ -2252,13 +2261,13 @@ function MessageBubble({
   // 实测行数与被测 body 绑定存储:FlatList 复用组件实例时 body 可能原地变化
   // (服务端同步补丁等),旧实测值若不随内容失效,会在下一次 onTextLayout 到达
   // 前产生"过期行数"的错误收起判定;body 不匹配时视为未测量,回落估算兜底。
-  const [measuredBody, setMeasuredBody] = useState<{
+  const [measuredBody, setMeasuredBody] = useRecyclingState<{
     body: string;
     lines: number;
   } | null>(null);
   const measuredBodyLines =
     measuredBody && measuredBody.body === displayBubbleBody ? measuredBody.lines : null;
-  const [longMessageExpanded, setLongMessageExpanded] = useState(false);
+  const [longMessageExpanded, setLongMessageExpanded] = useRecyclingState(false);
   // 折叠判定单向闩锁(绑定 body,FlatList 复用换消息时自动失效):测量 Text
   // 的排版宽度跟随气泡宽度,而气泡宽度又随折叠状态变化(展开态的 markdown
   // 块级内容——公式 WebView / 表格等——会把气泡撑到最大宽)。行数恰好骑在
@@ -2266,7 +2275,7 @@ function MessageBubble({
   // 无限振荡(2026-07 数学公式块实测:14/15 行边界整屏闪动)。闩锁让「该
   // 收起」的判定只进不出:后续宽度变化跌回阈值以下不再自动展开;用户手动
   // 点「展开」走 longMessageExpanded,不受闩锁影响。
-  const [collapseLatchBody, setCollapseLatchBody] = useState<string | null>(null);
+  const [collapseLatchBody, setCollapseLatchBody] = useRecyclingState<string | null>(null);
   const collapseLatched = collapseLatchBody === displayBubbleBody;
   const collapseResolved = collapseMeasureEnabled
     && resolveUserMessageCollapse(displayBubbleBody, measuredBodyLines, collapseThreshold);
@@ -2304,11 +2313,16 @@ function MessageBubble({
     return () => clearTimeout(timer);
   }, [copyState]);
 
+  const copyOwnerRef = useRef(clientId);
+  copyOwnerRef.current = clientId;
   const copyMessage = useCallback(() => {
     if (!canCopy || copyState === 'copying') return;
     setCopyState('copying');
-    void copyMessageText(copyText).then(setCopyState);
-  }, [canCopy, copyState, copyText]);
+    const owner = clientId;
+    void copyMessageText(copyText).then((status) => {
+      if (copyOwnerRef.current === owner) setCopyState(status);
+    });
+  }, [canCopy, clientId, copyState, copyText, setCopyState]);
   const selectControlAction = useCallback((id: MobileMessageControlActionId) => {
     if (id === 'copy') {
       copyMessage();
@@ -3405,7 +3419,7 @@ function ExpandedWorkThinkingRow({
   const { t } = useTranslation();
   const styles = useThemedStyles(makeStyles);
   const [expanded, toggleExpanded] = useFoldableExpandedState(`work-${item.key}`, false);
-  const [measuredLineCount, setMeasuredLineCount] = useState(1);
+  const [measuredLineCount, setMeasuredLineCount] = useRecyclingState(1);
   const rawContent = item.message.body.trim();
   const canExpand = rawContent.includes('\n') || measuredLineCount > 1;
   return (
@@ -3555,8 +3569,18 @@ function FoldablePanel({
   const { t } = useTranslation();
   const styles = useThemedStyles(makeStyles);
   const [rememberedExpanded, toggleRememberedExpanded] = useFoldableExpandedState(blockId, defaultExpanded);
-  const expanded = controlledExpanded ?? rememberedExpanded;
-  const toggleExpanded = onControlledToggle ?? toggleRememberedExpanded;
+  // Todo/Orca panels intentionally do not use the process-wide block memory.
+  // Their local default must still be restored when LegendList assigns this
+  // recycled cell to another render item.
+  const [recycledLocalExpanded, setRecycledLocalExpanded] = useRecyclingState(defaultExpanded);
+  const localExpanded = blockId ? rememberedExpanded : recycledLocalExpanded;
+  const toggleLocalExpanded = useCallback(
+    () => setRecycledLocalExpanded((value) => !value),
+    [setRecycledLocalExpanded],
+  );
+  const expanded = controlledExpanded ?? localExpanded;
+  const toggleExpanded = onControlledToggle
+    ?? (blockId ? toggleRememberedExpanded : toggleLocalExpanded);
   const headerLayoutStyle = variant === 'plain'
     ? styles.foldHeaderPlain
     : {
@@ -3735,7 +3759,7 @@ function MobileAgentSwitchCard({ data }: { data?: Record<string, unknown> }) {
   const styles = useThemedStyles(makeStyles);
   const { colors } = useTheme();
   const { t } = useTranslation();
-  const [expanded, setExpanded] = useState(false);
+  const [expanded, setExpanded] = useRecyclingState(false);
   const from = agentSwitchEngineLabel(data?.fromAgentKind);
   const to = agentSwitchEngineLabel(data?.toAgentKind);
   const toModel = typeof data?.toModel === 'string' ? data.toModel : '';
@@ -3842,7 +3866,7 @@ function MobileAutoResumeActionRow({
   const styles = useThemedStyles(makeStyles);
   const { colors } = useTheme();
   const { t } = useTranslation();
-  const [expanded, setExpanded] = useState(false);
+  const [expanded, setExpanded] = useRecyclingState(false);
   const presentation = getMobileAutoResumePresentation(data, inFlight);
   const { canExpand, hasProgress, info, state, summary } = presentation;
 
@@ -4031,7 +4055,7 @@ function MarkdownBody({
   // 偏矮的 onLayout 裁切 agent 回复;点分享会换上确定宽度的容器从而完整显示。
   // 外层始终 stretch 测可用宽,内层再钉像素宽:测宽不能钉在自己身上,否则旋转/
   // 分屏变宽后 onLayout 仍报旧值。1px 内抖动忽略,避免公式 WebView 重挂。
-  const [contentWidth, setContentWidth] = useState(0);
+  const [contentWidth, setContentWidth] = useRecyclingState(0);
   const handleSettledWidthLayout = useCallback((event: LayoutChangeEvent) => {
     if (!pinContentWidth) return;
     const nextWidth = Math.round(event.nativeEvent.layout.width);
@@ -4450,7 +4474,7 @@ function ChatPathChipSpan({
         : undefined,
     [ctx, target],
   );
-  const [verdict, setVerdict] = useState<RemotePathVerdict | undefined>(readVerdict);
+  const [verdict, setVerdict] = useRecyclingState<RemotePathVerdict | undefined>(readVerdict);
 
   // 本 key 的缓存变化(确定态落库 / 负缓存到期)→ 递增,**驱动下面的验证副作用重跑**。
   // 按 key 过滤:一屏几十个 chip 各自订阅,全量广播会让首屏 N 次 stat 引发 N×N 次重渲染。
@@ -4461,7 +4485,7 @@ function ChatPathChipSpan({
   // ForRender 回 undefined,于是 chip 只完成「降级成纯文本」、没完成「重验」,挂载期间
   // 永不自愈 —— 比重构前(一直乐观点亮)更糟。桌面同一处把 cacheGen 放进了验证副作用的
   // 依赖,手机漏了这一环(PR #1144 review 实捉:第 10 轮重构只做对了桌面那一半)。
-  const [cacheGen, setCacheGen] = useState(0);
+  const [cacheGen, setCacheGen] = useRecyclingState(0);
   useEffect(() => {
     if (!ctx || !target) return;
     const mine = remotePathVerdictKey(ctx.deviceId, ctx.workdir, target.absPath);
@@ -4993,11 +5017,11 @@ function MediaPreview({
   const styles = useThemedStyles(makeStyles);
   const preview = summarizeMessagePayloadPreview(buildMediaPayload(media, label));
   const autoResolve = shouldAutoResolveMediaThumbnail(media, !!onResolveRemoteMedia);
-  const [resolveState, setResolveState] = useState<MediaThumbnailResolveState>({ status: 'idle' });
+  const [resolveState, setResolveState] = useRecyclingState<MediaThumbnailResolveState>({ status: 'idle' });
   // attachment 变体的原图尺寸。初值走模块级缓存:FlatList 虚拟化会反复
   // unmount/remount 本组件,不缓存的话每次划回都重新 getSize、重演一次
   // 占位帧 → 真图尺寸的切换(规则 7 的跳变)。
-  const [intrinsicSize, setIntrinsicSize] = useState<AttachmentImageIntrinsicSize | null>(
+  const [intrinsicSize, setIntrinsicSize] = useRecyclingState<AttachmentImageIntrinsicSize | null>(
     () => attachmentIntrinsicSizeCache.get(media.url) ?? null,
   );
   // Image 加载失败(典型:presign 过期)只强制重取一次,防 onError↔重取死循环。

--- a/apps/mobile/src/session/MessageRenderer.tsx
+++ b/apps/mobile/src/session/MessageRenderer.tsx
@@ -54,10 +54,16 @@ import {
   type StyleProp,
   type TextStyle,
   type ViewStyle,
-  type ViewToken,
 } from 'react-native';
 import { UITextView } from 'react-native-uitextview';
-import { LegendList, useRecyclingState, type LegendListRef } from '@legendapp/list/react-native';
+import {
+  LegendList,
+  useRecyclingState,
+  useViewability,
+  type LegendListMetrics,
+  type LegendListRef,
+  type ViewToken as LegendListViewToken,
+} from '@legendapp/list/react-native';
 import { tokenizeCode, type CodeTokenKind } from '@/session/codeHighlight';
 import { buildComposerTouchLayout } from '@/session/composerTouchLayout';
 import { useFoldableExpandedState } from '@/session/expandedBlockMemory';
@@ -331,9 +337,16 @@ import {
 import {
   captureMobileHistoryAnchor,
   isMobileHistoryAnchorSettled,
+  mobileHistoryTopOffsetAdjustment,
   resolveMobileHistoryAnchorOffset,
   type MobileHistoryAnchor,
+  type MobileHistoryAnchorResolveState,
 } from '@/session/messageHistoryAnchor';
+import {
+  mobileMessageHistoryAnchorIdentity,
+  mobileMessageHistoryOnlyExpandedFirstWorkGroup,
+  mobileMessageHistoryRowKeyByIdentity,
+} from '@/session/messageHistoryAnchorIdentity';
 import { ImageLightbox, type ImageLightboxAnnotationConfig } from '@/session/ImageLightbox';
 import {
   MermaidDiagramWebView,
@@ -358,11 +371,11 @@ import { mobileToolRowWording } from '@/i18n/toolWording';
 const MESSAGE_CONTROL_HIT_SLOP = { bottom: 10, left: 10, right: 10, top: 10 };
 const MESSAGE_CONTROL_TOUCH_SIZE = 44;
 const MESSAGE_LIST_VISIBLE_PERCENT_THRESHOLD = 5;
+const MESSAGE_LIST_VIEWABILITY_CONFIG_ID = 'message-heavy-content';
 
 // Heavy Markdown blocks inherit the visibility of their outer list cell. Nested
 // work/sub-agent cards should not create a second visibility window of their own.
 const MessageHeavyContentVisibilityContext = createContext(true);
-const MessageListVisibleKeysContext = createContext<ReadonlySet<string> | null>(null);
 
 /** 分享模式吸顶 check 与行内 check 共用 44px 触达高度。 */
 const SHARE_STICKY_CHECK_HEIGHT = 44;
@@ -388,9 +401,11 @@ const MOBILE_HISTORY_ANCHOR_VERIFY_MAX_MS = 3000;
 const MOBILE_HISTORY_ANCHOR_STABLE_FRAMES = 2;
 const ANDROID_SELECTABLE_TEXT_RUN_MAX_BLOCKS = 12;
 const ANDROID_SELECTABLE_TEXT_RUN_MAX_UTF16_LENGTH = 1800;
+const ANDROID_SELECTABLE_TEXT_RUN_MAX_INLINE_FRAGMENTS = 20;
 const ANDROID_SELECTABLE_TEXT_RUN_GROUPING_OPTIONS: MobileMarkdownTextRunGroupingOptions = {
   maxTextRunBlocks: ANDROID_SELECTABLE_TEXT_RUN_MAX_BLOCKS,
   maxTextRunUtf16Length: ANDROID_SELECTABLE_TEXT_RUN_MAX_UTF16_LENGTH,
+  maxTextRunInlineFragments: ANDROID_SELECTABLE_TEXT_RUN_MAX_INLINE_FRAGMENTS,
 };
 /** Running work groups expose only the same latest-five activity window as desktop. */
 const MAX_LIVE_WORK_ACTIVITIES = 5;
@@ -402,13 +417,33 @@ function mobileMessageListItemType(item: MobileMessageRenderItem): MobileMessage
   return item.type;
 }
 
+function resolveMobileMessageHistoryAnchorOffset(
+  anchor: MobileHistoryAnchor,
+  state: MobileHistoryAnchorResolveState,
+  topOffsetAdjustment: number,
+): number | null {
+  return resolveMobileHistoryAnchorOffset(anchor, {
+    ...state,
+    topOffsetAdjustment,
+    keyByIdentity: state.data
+      ? (identityKey) => mobileMessageHistoryRowKeyByIdentity(
+        state.data as readonly MobileMessageRenderItem[],
+        identityKey,
+      )
+      : undefined,
+  });
+}
+
 interface MobileHistoryPrependTransaction {
   anchor: MobileHistoryAnchor | null;
   anchorStable: boolean;
+  continueAfterRegroup: boolean;
   generation: number;
   pageCommitted: boolean;
   promiseSettled: boolean;
+  startItems: readonly MobileMessageRenderItem[];
   startProgressKey: string | null;
+  userInitiated: boolean;
   userControlledAfterCommit: boolean;
   verifyDeadlineAt: number;
 }
@@ -627,7 +662,7 @@ export function MessageRenderer({
   syncingWhileEmpty,
   testID,
   devExposeList,
-  devRecycleItems = false,
+  devRecycleItems = true,
 }: {
   bottomOverlayHeight?: number;
   /** 顶部 chrome(绝对定位半透明工具栏)实测高度:内容顶部按此让位,详见 mobileMessageListTopPadding。 */
@@ -645,7 +680,7 @@ export function MessageRenderer({
   /** 空列表且本次打开的首同步未完成:渲染「正在同步」占位(延迟显形防闪)而非「暂无消息」。 */
   syncingWhileEmpty?: boolean;
   testID?: string;
-  /** DEV-only A/B switch; production always enables verified row recycling. */
+  /** DEV-only A/B override for listperf; regular screens match production and recycle rows. */
   devRecycleItems?: boolean;
   /** 全屏图片查看器的分享回调(由会话屏落地本地文件后唤起系统分享单)。 */
   onShareImage?: (
@@ -679,6 +714,9 @@ export function MessageRenderer({
   const focusedItemKeyRef = useRef(focusedItemKey);
   focusedItemKeyRef.current = focusedItemKey;
   const listRef = useRef<LegendListRef>(null);
+  const listMetricsRef = useRef<LegendListMetrics>({ footerSize: 0, headerSize: 0 });
+  const listTopPaddingRef = useRef(0);
+  const listBottomPaddingRef = useRef(0);
   const shareableMessageViewsRef = useRef(new Map<string, View>());
   const windowDimensions = useWindowDimensions();
   const viewportLayout = useMemo(() => buildMobileReadableViewportLayout({
@@ -780,9 +818,9 @@ export function MessageRenderer({
   // Without a render tick, a user who remains at the top can stall after one page because the
   // page commit effect ran while readingOlderRef was still true.
   const [loadEarlierEvaluationVersion, setLoadEarlierEvaluationVersion] = useState(0);
-  const [visibleMessageKeys, setVisibleMessageKeys] = useState<ReadonlySet<string>>(
-    () => new Set(),
-  );
+  // Main immediately requests another page when a prepend only expands the first collapsed
+  // `Worked for` row. The app-owned anchor transaction settles first, then consumes this one-shot.
+  const regroupedHistoryContinuationRef = useRef(false);
   // 会话切换(scrollResetKey)的 ref 复位必须在渲染期同步完成,不能只靠下方的 reset effect:
   // effect 在 paint 后异步执行,而重挂的新列表(key={scrollResetKey})的首批 scroll /
   // onStartReached 回调、以及先于 reset effect 定义的 eligibility effect,都可能带着上个会话的
@@ -791,6 +829,7 @@ export function MessageRenderer({
   const prevScrollResetKeyRef = useRef(scrollResetKey);
   if (prevScrollResetKeyRef.current !== scrollResetKey) {
     prevScrollResetKeyRef.current = scrollResetKey;
+    listMetricsRef.current = { footerSize: 0, headerSize: 0 };
     nearBottomRef.current = true;
     isDraggingRef.current = false;
     isMomentumScrollingRef.current = false;
@@ -804,6 +843,7 @@ export function MessageRenderer({
     readingOlderRequestGenerationRef.current += 1;
     historyPrependTransactionRef.current = null;
     queuedLoadEarlierRef.current = false;
+    regroupedHistoryContinuationRef.current = false;
     if (historyPrependNativeMvcpDisabled) setHistoryPrependNativeMvcpDisabled(false);
     if (queuedLoadEarlierFlushFrameRef.current !== null) {
       cancelAnimationFrame(queuedLoadEarlierFlushFrameRef.current);
@@ -927,15 +967,29 @@ export function MessageRenderer({
     void listRef.current?.scrollToIndex({ animated: true, index, viewPosition });
   }, [markProgrammaticScroll]);
 
+  const getCurrentHistoryTopOffsetAdjustment = useCallback(() => {
+    const listState = listRef.current?.getState();
+    if (!listState) return listTopPaddingRef.current + listMetricsRef.current.headerSize;
+    return mobileHistoryTopOffsetAdjustment(listState, {
+      baseTopOffset: listTopPaddingRef.current + listMetricsRef.current.headerSize,
+      bottomPadding: listBottomPaddingRef.current,
+      footerSize: listMetricsRef.current.footerSize,
+    });
+  }, []);
+
   const captureCurrentHistoryAnchor = useCallback((): MobileHistoryAnchor | null => {
     const listState = listRef.current?.getState();
     return listState
       ? captureMobileHistoryAnchor(
-        listState,
+        {
+          ...listState,
+          topOffsetAdjustment: getCurrentHistoryTopOffsetAdjustment(),
+        },
         (item) => (item as MobileMessageRenderItem).key,
+        (item) => mobileMessageHistoryAnchorIdentity(item as MobileMessageRenderItem),
       )
       : null;
-  }, []);
+  }, [getCurrentHistoryTopOffsetAdjustment]);
 
   const finishHistoryPrependTransaction = useCallback((generation: number) => {
     const transaction = historyPrependTransactionRef.current;
@@ -944,6 +998,9 @@ export function MessageRenderer({
       cancelAnimationFrame(historyAnchorVerifyFrameRef.current);
       historyAnchorVerifyFrameRef.current = null;
     }
+    regroupedHistoryContinuationRef.current = transaction.continueAfterRegroup
+      && transaction.userInitiated
+      && !transaction.userControlledAfterCommit;
     historyPrependTransactionRef.current = null;
     readingOlderRef.current = false;
     setHistoryPrependNativeMvcpDisabled(false);
@@ -978,6 +1035,7 @@ export function MessageRenderer({
     readingOlderRef.current = false;
     historyPrependTransactionRef.current = null;
     queuedLoadEarlierRef.current = false;
+    regroupedHistoryContinuationRef.current = false;
     setHistoryPrependNativeMvcpDisabled(false);
     if (queuedLoadEarlierFlushFrameRef.current !== null) {
       cancelAnimationFrame(queuedLoadEarlierFlushFrameRef.current);
@@ -1021,7 +1079,11 @@ export function MessageRenderer({
       const anchor = currentTransaction.anchor;
       const listState = listRef.current?.getState();
       const targetOffset = anchor && listState
-        ? resolveMobileHistoryAnchorOffset(anchor, listState)
+        ? resolveMobileMessageHistoryAnchorOffset(
+          anchor,
+          listState,
+          getCurrentHistoryTopOffsetAdjustment(),
+        )
         : null;
 
       if (targetOffset !== null && listState) {
@@ -1077,7 +1139,11 @@ export function MessageRenderer({
           ) return;
           const finalState = listRef.current?.getState();
           const finalTarget = finalTransaction.anchor && finalState
-            ? resolveMobileHistoryAnchorOffset(finalTransaction.anchor, finalState)
+            ? resolveMobileMessageHistoryAnchorOffset(
+              finalTransaction.anchor,
+              finalState,
+              getCurrentHistoryTopOffsetAdjustment(),
+            )
             : null;
           if (finalTarget !== null) scrollToOffsetProgrammatically(finalTarget, false);
           historyAnchorVerifyFrameRef.current = requestAnimationFrame(() => {
@@ -1108,6 +1174,7 @@ export function MessageRenderer({
     // ScrollView offset still belongs to the pre-prepend data.
     step(0, 0, null);
   }, [
+    getCurrentHistoryTopOffsetAdjustment,
     markMobileMvcpSettle,
     maybeFinishHistoryPrependTransaction,
     scrollToOffsetProgrammatically,
@@ -1122,7 +1189,11 @@ export function MessageRenderer({
     ) return;
     const listState = listRef.current?.getState();
     const targetOffset = transaction.anchor && listState
-      ? resolveMobileHistoryAnchorOffset(transaction.anchor, listState)
+      ? resolveMobileMessageHistoryAnchorOffset(
+        transaction.anchor,
+        listState,
+        getCurrentHistoryTopOffsetAdjustment(),
+      )
       : null;
     if (
       targetOffset !== null
@@ -1131,7 +1202,7 @@ export function MessageRenderer({
     ) {
       scrollToOffsetProgrammatically(targetOffset, false);
     }
-  }, [scrollToOffsetProgrammatically]);
+  }, [getCurrentHistoryTopOffsetAdjustment, scrollToOffsetProgrammatically]);
 
   // 贴底跟随的落底校验/补滚环:两条手动补滚路径——「跳到最新」(followLatestRequestKey)
   // 与 handleContentSize 的贴底追赶——都只发一次命令式 scrollToEnd,不校验是否真的到达内容
@@ -1222,6 +1293,8 @@ export function MessageRenderer({
   // LegendList 虚拟化/回收。不能用业务尾窗代替完整数据，否则短尾窗未撑满首屏时
   // Android 无法产生有效滚动，运行中任务会重现“上半屏空白且历史不可拖动”。
   const listData = useMemo(() => [...items], [items]);
+  const listDataRef = useRef(listData);
+  listDataRef.current = listData;
   const prevListLengthRef = useRef(listData.length);
   if (prevListLengthRef.current !== listData.length) {
     if (
@@ -1240,15 +1313,23 @@ export function MessageRenderer({
     () => mobileMessageListKeysSignature(itemKeys),
     [itemKeys],
   );
-  const firstItemKey = loadEarlierProgressKey ?? itemKeys[0] ?? null;
+  // Keep main's rendered-row progress signal for near-start auto paging. The host cursor remains
+  // the stronger transaction commit signal because local synthetic rows can sit before host data.
+  const firstItemKey = itemKeys[0] ?? null;
+  const historyProgressKey = loadEarlierProgressKey ?? firstItemKey;
   // A successful history page changes the oldest host cursor. Restore the captured visible row
   // in a layout effect: LegendList has accepted the new data, but React Native has not painted the
   // shifted absolute positions yet. This is the atomic point missing from Android native MVCP.
   useLayoutEffect(() => {
     const transaction = historyPrependTransactionRef.current;
     if (!transaction) return;
-    if (transaction.startProgressKey !== firstItemKey) {
+    if (transaction.startProgressKey !== historyProgressKey) {
       transaction.pageCommitted = true;
+      transaction.continueAfterRegroup = transaction.userInitiated
+        && mobileMessageHistoryOnlyExpandedFirstWorkGroup(
+          transaction.startItems,
+          listDataRef.current,
+        );
       scheduleHistoryAnchorRestore(transaction.generation);
       maybeFinishHistoryPrependTransaction(transaction.generation);
       return;
@@ -1260,7 +1341,7 @@ export function MessageRenderer({
       maybeFinishHistoryPrependTransaction(transaction.generation);
     }
   }, [
-    firstItemKey,
+    historyProgressKey,
     itemKeysSignature,
     loadEarlierEvaluationVersion,
     loadingEarlier,
@@ -1314,6 +1395,8 @@ export function MessageRenderer({
   }, [galleryImages, payload]);
   const bottomPadding = mobileMessageListBottomPadding(bottomOverlayHeight);
   const topPadding = mobileMessageListTopPadding(topOverlayHeight);
+  listBottomPaddingRef.current = bottomPadding;
+  listTopPaddingRef.current = topPadding;
   const previousUserButtonTop = topPadding > 0 ? topPadding : null;
   // 上一次 topPadding,供顶部 chrome 高度变化时补偿 scroll offset(见下方 effect)。
   const prevTopPaddingRef = useRef(topPadding);
@@ -1419,6 +1502,7 @@ export function MessageRenderer({
     ? `${focusedRequestKey ?? 'default'}:${focusedItemKey}`
     : null;
   const viewabilityConfigRef = useRef({
+    id: MESSAGE_LIST_VIEWABILITY_CONFIG_ID,
     itemVisiblePercentThreshold: MESSAGE_LIST_VISIBLE_PERCENT_THRESHOLD,
   });
   const shareSelectionActiveRef = useRef(shareSelectionActive);
@@ -1489,26 +1573,10 @@ export function MessageRenderer({
   useEffect(() => () => {
     if (stickyCheckTimerRef.current) clearTimeout(stickyCheckTimerRef.current);
   }, []);
-  const handleViewableItemsChangedRef = useRef((info: {
-    viewableItems: ViewToken<MobileMessageRenderItem>[];
+  const handleFirstVisibleItemChangedRef = useRef((info: {
+    index: number;
   }) => {
-    let nextIndex: number | null = null;
-    const nextVisibleMessageKeys = new Set<string>();
-    for (const token of info.viewableItems) {
-      if (typeof token.index !== 'number') continue;
-      nextIndex = nextIndex === null ? token.index : Math.min(nextIndex, token.index);
-      if (token.isViewable && token.item?.key) nextVisibleMessageKeys.add(token.item.key);
-    }
-    if (nextIndex !== null) setFirstVisibleIndex(nextIndex);
-    setVisibleMessageKeys((previous) => {
-      if (
-        previous.size === nextVisibleMessageKeys.size
-        && [...previous].every((key) => nextVisibleMessageKeys.has(key))
-      ) {
-        return previous;
-      }
-      return nextVisibleMessageKeys;
-    });
+    setFirstVisibleIndex((previous) => previous === info.index ? previous : info.index);
   });
   const readActuallyVisibleShareableMessageIds = useCallback(async (
     viewport: ShareableMessageViewport,
@@ -1629,17 +1697,24 @@ export function MessageRenderer({
     const listState = listRef.current?.getState();
     const anchor = listState
       ? captureMobileHistoryAnchor(
-        listState,
+        {
+          ...listState,
+          topOffsetAdjustment: getCurrentHistoryTopOffsetAdjustment(),
+        },
         (item) => (item as MobileMessageRenderItem).key,
+        (item) => mobileMessageHistoryAnchorIdentity(item as MobileMessageRenderItem),
       )
       : null;
     historyPrependTransactionRef.current = {
       anchor,
       anchorStable: false,
+      continueAfterRegroup: false,
       generation,
       pageCommitted: false,
       promiseSettled: false,
-      startProgressKey: firstItemKey,
+      startItems: listDataRef.current,
+      startProgressKey: historyProgressKey,
+      userInitiated: userScrollForOlderRef.current,
       userControlledAfterCommit: false,
       verifyDeadlineAt: 0,
     };
@@ -1669,7 +1744,7 @@ export function MessageRenderer({
     } catch {
       markRequestSettled();
     }
-  }, [firstItemKey, onLoadEarlier]);
+  }, [getCurrentHistoryTopOffsetAdjustment, historyProgressKey, onLoadEarlier]);
 
   const flushQueuedLoadEarlier = useCallback(() => {
     if (
@@ -1730,8 +1805,24 @@ export function MessageRenderer({
     const initialAutoFillAllowed = listRevealed
       && !userScrolledForOlder
       && initialHistoryAutofillRemainingRef.current > 0;
-    if (!userScrolledForOlder && !initialAutoFillAllowed) return;
+    const continueAfterRegroup = userScrolledForOlder
+      && regroupedHistoryContinuationRef.current;
+    if (!userScrolledForOlder && !initialAutoFillAllowed && !continueAfterRegroup) return;
     if (firstItemKey !== null && lastAutoLoadEarlierKeyRef.current === firstItemKey) return;
+    if (continueAfterRegroup) {
+      if (!loadEarlierAction.visible) {
+        regroupedHistoryContinuationRef.current = false;
+        return;
+      }
+      // A merged page did make host-cursor progress but added no visible top-level history. Do not
+      // reapply the near-start gate after app-owned anchor restoration moved the viewport; main
+      // immediately continues from the changed first rendered row in the same situation.
+      if (loadEarlierAction.disabled || firstItemKey === null) return;
+      regroupedHistoryContinuationRef.current = false;
+      lastAutoLoadEarlierKeyRef.current = firstItemKey;
+      requestLoadEarlier();
+      return;
+    }
     const listState = listRef.current?.getState();
     if (!listState) return;
     // LegendList's edge bookkeeping can lag behind the native ScrollView during recycling,
@@ -1945,6 +2036,22 @@ export function MessageRenderer({
     scrollMetricsRef.current = { ...scrollMetricsRef.current, viewportHeight };
   }, []);
 
+  const handleListMetricsChange = useCallback((metrics: LegendListMetrics) => {
+    listMetricsRef.current = metrics;
+    if (!readingOlderRef.current) return;
+    const transaction = historyPrependTransactionRef.current;
+    if (!transaction) return;
+    if (transaction.pageCommitted) {
+      scheduleHistoryAnchorRestore(transaction.generation);
+    } else if (
+      !isDraggingRef.current
+      && !isMomentumScrollingRef.current
+      && historyTouchStartYRef.current === null
+    ) {
+      restoreHistoryAnchorOnce(transaction.generation);
+    }
+  }, [restoreHistoryAnchorOnce, scheduleHistoryAnchorRestore]);
+
   // 记录 contentHeight 供近底判定 fallback + DEV harness 就绪判定;并承担**唯一的贴底跟随**:
   // 内容长高(流式增长、大块一帧撑高、冷开测量结算)时,用户本就贴底(nearBottomRef,与
   // 「跳到底部」浮标同源)则无论这次长多少都跟到底(仿 filo onContentSizeChange → scrollToEnd);
@@ -2138,7 +2245,6 @@ export function MessageRenderer({
     setIsAwayFromBottom(false);
     setFirstVisibleIndex(0);
     setHasNewMessages(false);
-    setVisibleMessageKeys(new Set());
   }, [scrollResetKey]);
   // 卸载时清掉在飞的定时器/rAF(闭包引用 listRef,卸载后触发是无害 no-op,
   // 但不留悬挂句柄)。
@@ -2235,10 +2341,9 @@ export function MessageRenderer({
   const renderMessageItem = useCallback(({ item }: { item: MobileMessageRenderItem }) => {
     if (__DEV__) recordMobileMessageRenderItem();
     return (
-      <RenderItemView
+      <RenderListItemView
         actions={actions}
         focused={item.key === focusedItemKey}
-        isListItem
         item={item}
       />
     );
@@ -2253,9 +2358,9 @@ export function MessageRenderer({
     ),
     [pendingSend?.selectedClientId, shareSelectionActive],
   );
-  // Production uses native cell recycling after every identity-bound local
-  // state below was made recycling-aware. DEV stays opt-in so listperf can
-  // continue running the on/off control with one bundle.
+  // Production and regular DEV screens use native cell recycling after every
+  // identity-bound local state below was made recycling-aware. listperf passes
+  // this DEV-only override explicitly so its on/off control remains available.
   const recycleItems = __DEV__ ? devRecycleItems === true : true;
 
   return (
@@ -2269,7 +2374,6 @@ export function MessageRenderer({
       onTouchEnd={handleHistoryTouchEnd}
       onTouchCancel={handleHistoryTouchCancel}
     >
-      <MessageListVisibleKeysContext.Provider value={visibleMessageKeys}>
       <Animated.View style={[styles.messageList, { opacity: initialRevealOpacity }]}>
       <LegendList
         // 与 main 一致：每个任务用完整历史重挂；首次命令式落底在 opacity 遮罩下完成。
@@ -2318,6 +2422,7 @@ export function MessageRenderer({
         }
         ListFooterComponent={queueFooter ? <>{queueFooter}</> : null}
         onLayout={handleListLayout}
+        onMetricsChange={handleListMetricsChange}
         onContentSizeChange={handleContentSize}
         onScroll={handleScroll}
         onScrollBeginDrag={handleScrollBeginDrag}
@@ -2331,10 +2436,9 @@ export function MessageRenderer({
         style={styles.messageList}
         testID={testID ?? 'message.list'}
         viewabilityConfig={viewabilityConfigRef.current}
-        onViewableItemsChanged={handleViewableItemsChangedRef.current}
+        onFirstVisibleItemChanged={handleFirstVisibleItemChangedRef.current}
       />
       </Animated.View>
-      </MessageListVisibleKeysContext.Provider>
       {previousUserTarget && previousUserButtonTop !== null ? (
         <MessageListActionButton
           accessibilityLabel={t('message.renderer.previousQuestionJump', { preview: previousUserTarget.preview || t('message.renderer.noPreview') })}
@@ -2406,19 +2510,12 @@ const RenderItemView = memo(function RenderItemView({
   item,
   actions,
   focused = false,
-  isListItem = false,
 }: {
   item: MobileMessageRenderItem | MobileWorkChildItem;
   actions: MessageActions & { firstUserMessageClientId?: string };
   focused?: boolean;
-  isListItem?: boolean;
 }) {
   const styles = useThemedStyles(makeStyles);
-  const inheritedHeavyContentVisible = useContext(MessageHeavyContentVisibilityContext);
-  const visibleKeys = useContext(MessageListVisibleKeysContext);
-  const heavyContentVisible = isListItem
-    ? focused || visibleKeys === null || visibleKeys.has(item.key)
-    : inheritedHeavyContentVisible;
   // 「user 行渲染系统卡」形态(silent-stop 自动续跑 agentMeta.autoResume):渲染层
   // 降级为 kind='system' 再进 MessageBubble——presentation 的 isUserAligned 判定是
   // `align==='user' || kind==='user'`,保持 user kind 会右对齐成用户气泡并挂上
@@ -2508,10 +2605,36 @@ const RenderItemView = memo(function RenderItemView({
       break;
   }
   return (
+    <View style={focused ? styles.focusedItem : undefined} testID={focused ? 'message.focusedItem' : undefined}>
+      {node}
+    </View>
+  );
+});
+
+const RenderListItemView = memo(function RenderListItemView({
+  item,
+  actions,
+  focused,
+}: {
+  item: MobileMessageRenderItem;
+  actions: MessageActions & { firstUserMessageClientId?: string };
+  focused: boolean;
+}) {
+  const [isViewable, setIsViewable] = useRecyclingState(false);
+  const itemKeyRef = useRef(item.key);
+  itemKeyRef.current = item.key;
+  const handleViewabilityChange = useCallback((token: LegendListViewToken<MobileMessageRenderItem>) => {
+    if (token.key !== itemKeyRef.current) return;
+    setIsViewable((previous) => previous === token.isViewable ? previous : token.isViewable);
+  }, [setIsViewable]);
+  useViewability<MobileMessageRenderItem>(
+    handleViewabilityChange,
+    MESSAGE_LIST_VIEWABILITY_CONFIG_ID,
+  );
+  const heavyContentVisible = focused || isViewable;
+  return (
     <MessageHeavyContentVisibilityContext.Provider value={heavyContentVisible}>
-      <View style={focused ? styles.focusedItem : undefined} testID={focused ? 'message.focusedItem' : undefined}>
-        {node}
-      </View>
+      <RenderItemView actions={actions} focused={focused} item={item} />
     </MessageHeavyContentVisibilityContext.Provider>
   );
 });
@@ -4567,6 +4690,40 @@ function OrcaCollabCard({ card, screenWidth }: { card: OrcaCollabCardModel; scre
   );
 }
 
+const ViewabilityGatedMermaidDiagram = memo(function ViewabilityGatedMermaidDiagram({
+  source,
+  testID,
+}: {
+  source: string;
+  testID?: string;
+}) {
+  const heavyContentVisible = useContext(MessageHeavyContentVisibilityContext);
+  return (
+    <MermaidDiagramWebView
+      active={heavyContentVisible}
+      source={source}
+      testID={testID}
+    />
+  );
+});
+
+const ViewabilityGatedMathFormula = memo(function ViewabilityGatedMathFormula({
+  source,
+  testID,
+}: {
+  source: string;
+  testID?: string;
+}) {
+  const heavyContentVisible = useContext(MessageHeavyContentVisibilityContext);
+  return (
+    <MathFormulaWebView
+      active={heavyContentVisible}
+      source={source}
+      testID={testID}
+    />
+  );
+});
+
 // 消息正文统一走原生 markdown 渲染(流式与完成态同一条路径,完成时无"原生→WebView"的切换跳变)。
 // 文本选择 = 完成态消息的各块 Text 原生 selectable:长按文字就地弹系统选择手柄/Copy 菜单,
 // 不跳转界面;整条复制走操作条按钮。选择按块进行(原生 Text 能力边界,跨段选择做不到)。
@@ -4606,7 +4763,6 @@ function MarkdownBody({
   const { colors } = useTheme();
   const { t } = useTranslation();
   const styles = useThemedStyles(makeStyles);
-  const heavyContentVisible = useContext(MessageHeavyContentVisibilityContext);
   const chatFilePathContext = useContext(ChatFilePathContext);
   // iOS UITextView 在 stretch/百分比宽度下会偶发只量出部分高度,LegendList 按这次
   // 偏矮的 onLayout 裁切 agent 回复;点分享会换上确定宽度的容器从而完整显示。
@@ -4712,7 +4868,7 @@ function MarkdownBody({
     ),
     [onOpenSessionLink, openMarkdownImage, sessionLinkTitles, sessionReferenceDetails, streaming, styles],
   );
-  const textRunGroupingOptions = selectable === true && Platform.OS === 'android'
+  const textRunGroupingOptions = Platform.OS === 'android'
     ? ANDROID_SELECTABLE_TEXT_RUN_GROUPING_OPTIONS
     : undefined;
   // 连续纯文本块合并为 text_run(跨段选择),代码块/表格/mermaid/含直连图块保持独立。
@@ -4801,7 +4957,7 @@ function MarkdownBody({
           // 盖住整块——WebView 会吞掉触摸事件,不盖层拿不到点击)。
           return (
             <View key={block.key} testID="message.mermaidPreviewButton">
-              <MermaidDiagramWebView active={heavyContentVisible} source={block.text} testID="message.mermaidDiagram" />
+              <ViewabilityGatedMermaidDiagram source={block.text} testID="message.mermaidDiagram" />
               {onOpenPayload ? (
                 <Pressable
                   accessibilityLabel={t('message.renderer.openDiagramDetail')}
@@ -4818,8 +4974,7 @@ function MarkdownBody({
           // display 公式:WebView + KaTeX(形态对齐 mermaid 块,无 chip 卡壳——
           // 公式在视觉上是正文的一部分,背景与气泡底色一致)。
           return (
-            <MathFormulaWebView
-              active={heavyContentVisible}
+            <ViewabilityGatedMathFormula
               key={block.key}
               source={block.text}
               testID="message.mathFormula"

--- a/apps/mobile/src/session/MessageRenderer.tsx
+++ b/apps/mobile/src/session/MessageRenderer.tsx
@@ -1,4 +1,4 @@
-import { Fragment, memo, useCallback, useContext, useEffect, useMemo, useRef, useState, type ComponentProps, type ReactNode } from 'react';
+import { createContext, Fragment, memo, useCallback, useContext, useEffect, useLayoutEffect, useMemo, useRef, useState, type ComponentProps, type ReactNode } from 'react';
 import { useTranslation } from 'react-i18next';
 import {
   ArrowLeftRight,
@@ -172,8 +172,9 @@ import {
   mobileMarkdownImageTitle,
   mobileMarkdownImageUrlForWorkdir,
   mobileMarkdownInlineImageSize,
-  parseMobileMarkdown,
+  parseMobileMarkdownIncremental,
   parseMobileMarkdownInlines,
+  type MobileMarkdownParseResult,
   type MobileMarkdownBlockGroup,
   type MobileMarkdownInline,
   type MobileMarkdownTextRunGroupingOptions,
@@ -330,6 +331,12 @@ import {
   type MermaidDiagramWebViewHandle,
 } from '@/session/mermaidWebView';
 import { MathFormulaWebView } from '@/session/mathWebView';
+import { getMobileMessageWebViewMetrics } from '@/session/mobileMessageWebViewMetrics';
+import {
+  getMobileMarkdownRenderMetrics,
+  recordMobileMarkdownParse,
+  recordMobileMessageRenderItem,
+} from '@/session/mobileMarkdownRenderMetrics';
 import { latexToUnicodeApproximation } from '@cindy/maker-shared/math-markdown';
 import type { RemoteTextFilePreviewResult } from '@/device-link/mobileMakerTransport';
 import { fontWeight, lineHeight, radius, spacing, typeScale } from '@/theme/tokens';
@@ -341,6 +348,11 @@ import { mobileToolRowWording } from '@/i18n/toolWording';
 const MESSAGE_CONTROL_HIT_SLOP = { bottom: 10, left: 10, right: 10, top: 10 };
 const MESSAGE_CONTROL_TOUCH_SIZE = 44;
 const MESSAGE_LIST_VISIBLE_PERCENT_THRESHOLD = 5;
+
+// Heavy Markdown blocks inherit the visibility of their outer list cell. Nested
+// work/sub-agent cards should not create a second visibility window of their own.
+const MessageHeavyContentVisibilityContext = createContext(true);
+const MessageListVisibleKeysContext = createContext<ReadonlySet<string> | null>(null);
 
 /** 分享模式吸顶 check 与行内 check 共用 44px 触达高度。 */
 const SHARE_STICKY_CHECK_HEIGHT = 44;
@@ -586,6 +598,7 @@ export function MessageRenderer({
   syncingWhileEmpty,
   testID,
   devExposeList,
+  devRecycleItems = false,
 }: {
   bottomOverlayHeight?: number;
   /** 顶部 chrome(绝对定位半透明工具栏)实测高度:内容顶部按此让位,详见 mobileMessageListTopPadding。 */
@@ -601,6 +614,8 @@ export function MessageRenderer({
   /** 空列表且本次打开的首同步未完成:渲染「正在同步」占位(延迟显形防闪)而非「暂无消息」。 */
   syncingWhileEmpty?: boolean;
   testID?: string;
+  /** DEV-only A/B switch; production keeps row recycling disabled until verified. */
+  devRecycleItems?: boolean;
   /** 全屏图片查看器的分享回调(由会话屏落地本地文件后唤起系统分享单)。 */
   onShareImage?: (
     media: Extract<MessagePayload, { kind: 'media' }>['media'],
@@ -621,6 +636,8 @@ export function MessageRenderer({
   devExposeList?: (api: {
     scrollTo: (y: number) => void;
     getMetrics: () => { contentHeight: number; offsetY: number; viewportHeight: number };
+    getWebViewMetrics: typeof getMobileMessageWebViewMetrics;
+    getMarkdownMetrics: typeof getMobileMarkdownRenderMetrics;
   }) => void;
 } & MessageActions) {
   const { colors } = useTheme();
@@ -701,6 +718,9 @@ export function MessageRenderer({
   const followVerifyTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   // settle 遮罩:落底两段式期间列表保持 opacity 0,settle 窗口后揭开(规则 7 防跳动)。
   const [listRevealed, setListRevealed] = useState(false);
+  const [visibleMessageKeys, setVisibleMessageKeys] = useState<ReadonlySet<string>>(
+    () => new Set(),
+  );
   // 会话切换(scrollResetKey)的 ref 复位必须在渲染期同步完成,不能只靠下方的 reset effect:
   // effect 在 paint 后异步执行,而重挂的新列表(key={scrollResetKey})的首批 scroll /
   // onStartReached 回调、以及先于 reset effect 定义的 eligibility effect,都可能带着上个会话的
@@ -911,6 +931,8 @@ export function MessageRenderer({
     devExposeList?.({
       scrollTo: (y: number) => scrollToOffsetProgrammatically(y, false),
       getMetrics: () => scrollMetricsRef.current,
+      getWebViewMetrics: getMobileMessageWebViewMetrics,
+      getMarkdownMetrics: getMobileMarkdownRenderMetrics,
     });
   }, [devExposeList, scrollToOffsetProgrammatically]);
 
@@ -1159,11 +1181,22 @@ export function MessageRenderer({
     viewableItems: ViewToken<MobileMessageRenderItem>[];
   }) => {
     let nextIndex: number | null = null;
+    const nextVisibleMessageKeys = new Set<string>();
     for (const token of info.viewableItems) {
       if (typeof token.index !== 'number') continue;
       nextIndex = nextIndex === null ? token.index : Math.min(nextIndex, token.index);
+      if (token.isViewable && token.item?.key) nextVisibleMessageKeys.add(token.item.key);
     }
     if (nextIndex !== null) setFirstVisibleIndex(nextIndex);
+    setVisibleMessageKeys((previous) => {
+      if (
+        previous.size === nextVisibleMessageKeys.size
+        && [...previous].every((key) => nextVisibleMessageKeys.has(key))
+      ) {
+        return previous;
+      }
+      return nextVisibleMessageKeys;
+    });
   });
   const readActuallyVisibleShareableMessageIds = useCallback(async (
     viewport: ShareableMessageViewport,
@@ -1562,6 +1595,7 @@ export function MessageRenderer({
     setIsAwayFromBottom(false);
     setFirstVisibleIndex(0);
     setHasNewMessages(false);
+    setVisibleMessageKeys(new Set());
   }, [scrollResetKey]);
   // 卸载时清掉在飞的定时器/rAF(闭包引用 listRef,卸载后触发是无害 no-op,
   // 但不留悬挂句柄)。
@@ -1636,13 +1670,17 @@ export function MessageRenderer({
     requestLoadEarlier();
   }, [requestLoadEarlier]);
 
-  const renderMessageItem = useCallback(({ item }: { item: MobileMessageRenderItem }) => (
-    <RenderItemView
-      actions={actions}
-      focused={item.key === focusedItemKey}
-      item={item}
-    />
-  ), [actions, focusedItemKey]);
+  const renderMessageItem = useCallback(({ item }: { item: MobileMessageRenderItem }) => {
+    if (__DEV__) recordMobileMessageRenderItem();
+    return (
+      <RenderItemView
+        actions={actions}
+        focused={item.key === focusedItemKey}
+        isListItem
+        item={item}
+      />
+    );
+  }, [actions, focusedItemKey]);
   // pending_send 的展开态不改变 listData；LegendList 会复用现有行，单靠 renderItem
   // 闭包更新不足以保证可见行重绘。把选中项显式纳入 extraData，确保轻点气泡后
   // 「取消 / 编辑 / 插话」操作行立即出现，不依赖滚动触发回收重渲染。
@@ -1653,12 +1691,14 @@ export function MessageRenderer({
     ),
     [pendingSend?.selectedClientId, shareSelectionActive],
   );
+  const recycleItems = __DEV__ && devRecycleItems === true;
 
   return (
     // chat-text-quote:Provider 恒挂载(值可为 null),避免启用态翻转时整棵消息树
     // 因 Provider 增删而重挂;value 稳定(useMemo),不触发订阅方重渲。
     <SelectionQuoteContext.Provider value={selectionQuoteContextValue}>
     <View style={styles.messageFrame}>
+      <MessageListVisibleKeysContext.Provider value={visibleMessageKeys}>
       <LegendList
         // 每会话重挂:alignItemsAtEnd + initialScrollAtEnd 让新会话干净地重新锚到底部
         // (替代手搓的隐藏+rAF 落底 + open-settle)。
@@ -1667,7 +1707,7 @@ export function MessageRenderer({
         extraData={messageListExtraData}
         keyExtractor={(item) => item.key}
         renderItem={renderMessageItem}
-        recycleItems={false}
+        recycleItems={recycleItems}
         estimatedItemSize={MOBILE_MESSAGE_ESTIMATED_ITEM_SIZE}
         drawDistance={MOBILE_MESSAGE_DRAW_DISTANCE}
         // 冷开落底不用 initialScrollAtEnd、贴底跟随不用 maintainScrollAtEnd:两者的内部
@@ -1716,6 +1756,7 @@ export function MessageRenderer({
         viewabilityConfig={viewabilityConfigRef.current}
         onViewableItemsChanged={handleViewableItemsChangedRef.current}
       />
+      </MessageListVisibleKeysContext.Provider>
       {previousUserTarget && previousUserButtonTop !== null ? (
         <MessageListActionButton
           accessibilityLabel={t('message.renderer.previousQuestionJump', { preview: previousUserTarget.preview || t('message.renderer.noPreview') })}
@@ -1787,12 +1828,19 @@ const RenderItemView = memo(function RenderItemView({
   item,
   actions,
   focused = false,
+  isListItem = false,
 }: {
   item: MobileMessageRenderItem | MobileWorkChildItem;
   actions: MessageActions & { firstUserMessageClientId?: string };
   focused?: boolean;
+  isListItem?: boolean;
 }) {
   const styles = useThemedStyles(makeStyles);
+  const inheritedHeavyContentVisible = useContext(MessageHeavyContentVisibilityContext);
+  const visibleKeys = useContext(MessageListVisibleKeysContext);
+  const heavyContentVisible = isListItem
+    ? focused || visibleKeys === null || visibleKeys.has(item.key)
+    : inheritedHeavyContentVisible;
   // 「user 行渲染系统卡」形态(silent-stop 自动续跑 agentMeta.autoResume):渲染层
   // 降级为 kind='system' 再进 MessageBubble——presentation 的 isUserAligned 判定是
   // `align==='user' || kind==='user'`,保持 user kind 会右对齐成用户气泡并挂上
@@ -1882,9 +1930,11 @@ const RenderItemView = memo(function RenderItemView({
       break;
   }
   return (
-    <View style={focused ? styles.focusedItem : undefined} testID={focused ? 'message.focusedItem' : undefined}>
-      {node}
-    </View>
+    <MessageHeavyContentVisibilityContext.Provider value={heavyContentVisible}>
+      <View style={focused ? styles.focusedItem : undefined} testID={focused ? 'message.focusedItem' : undefined}>
+        {node}
+      </View>
+    </MessageHeavyContentVisibilityContext.Provider>
   );
 });
 
@@ -3975,6 +4025,7 @@ function MarkdownBody({
   const { colors } = useTheme();
   const { t } = useTranslation();
   const styles = useThemedStyles(makeStyles);
+  const heavyContentVisible = useContext(MessageHeavyContentVisibilityContext);
   const chatFilePathContext = useContext(ChatFilePathContext);
   // iOS UITextView 在 stretch/百分比宽度下会偶发只量出部分高度,LegendList 按这次
   // 偏矮的 onLayout 裁切 agent 回复;点分享会换上确定宽度的容器从而完整显示。
@@ -3990,7 +4041,25 @@ function MarkdownBody({
   const settledTextStyle = pinSettledWidth
     ? [styles.messageText, { width: contentWidth }]
     : styles.messageText;
-  const blocks = useMemo(() => parseMobileMarkdown(text), [text]);
+  const markdownParseRef = useRef<MobileMarkdownParseResult | null>(null);
+  const markdownParse = useMemo(() => {
+    const startedAt = typeof performance !== 'undefined' && typeof performance.now === 'function'
+      ? performance.now()
+      : Date.now();
+    const result = parseMobileMarkdownIncremental(text, markdownParseRef.current);
+    const finishedAt = typeof performance !== 'undefined' && typeof performance.now === 'function'
+      ? performance.now()
+      : Date.now();
+    return {
+      result,
+      durationMs: Math.max(0, finishedAt - startedAt),
+    };
+  }, [text]);
+  useLayoutEffect(() => {
+    markdownParseRef.current = markdownParse.result;
+    if (__DEV__) recordMobileMarkdownParse(markdownParse.result, markdownParse.durationMs);
+  }, [markdownParse]);
+  const blocks = markdownParse.result.blocks;
   // Android 的 selectable Text 内嵌 View(直连内联图)行为未定义,含这类 inline 的块不开选中。
   const inlinesSelectable = useCallback((inlines: readonly MobileMarkdownInline[]) => (
     selectable === true
@@ -4151,7 +4220,7 @@ function MarkdownBody({
           // 盖住整块——WebView 会吞掉触摸事件,不盖层拿不到点击)。
           return (
             <View key={block.key} testID="message.mermaidPreviewButton">
-              <MermaidDiagramWebView source={block.text} testID="message.mermaidDiagram" />
+              <MermaidDiagramWebView active={heavyContentVisible} source={block.text} testID="message.mermaidDiagram" />
               {onOpenPayload ? (
                 <Pressable
                   accessibilityLabel={t('message.renderer.openDiagramDetail')}
@@ -4169,6 +4238,7 @@ function MarkdownBody({
           // 公式在视觉上是正文的一部分,背景与气泡底色一致)。
           return (
             <MathFormulaWebView
+              active={heavyContentVisible}
               key={block.key}
               source={block.text}
               testID="message.mathFormula"

--- a/apps/mobile/src/session/MessageRenderer.tsx
+++ b/apps/mobile/src/session/MessageRenderer.tsx
@@ -319,7 +319,7 @@ import {
   MOBILE_MESSAGE_LIST_BOTTOM_PADDING,
   type MessageScrollMetrics,
   mobileMessageListBottomPadding,
-  previousUserMessageJumpTarget,
+  previousUserMessageJumpTargetForWindow,
   resolveMobileNearBottomOnScroll,
   shouldAutoLoadEarlier,
   shouldUnpinMobileFollowOnDrag,
@@ -359,13 +359,6 @@ const SHARE_STICKY_CHECK_HEIGHT = 44;
 const STICKY_SHARE_CHECK_THROTTLE_MS = 150;
 const SCREENSHOT_SHARE_VISIBLE_PERCENT_THRESHOLD = 10;
 // LegendList 变高 item 的初始估高(仅影响首帧布局定位,LegendList 挂载后按实测尺寸修正)。
-/**
- * 冷开落底的 settle 窗口(ms):rAF 落底 + 初窗测量 + 贴底补滚在此窗口内基本结算,
- * 期间列表以 opacity 0 遮罩(规则 7 防两段式落底的可见跳动),到期揭开。
- * 取 300ms:初窗 ~15 个 render item 的测量在 2-4 帧内完成,补滚各一帧,慢设备留裕量;
- * 更长会放大「进入会话到内容可见」的感知延迟,不取。
- */
-const MOBILE_INITIAL_ANCHOR_SETTLE_MS = 300;
 /** Maximum time a native imperative scroll may be reported as in-flight. */
 const MOBILE_PROGRAMMATIC_SCROLL_SETTLE_MS = 1000;
 /** Animated jump-to-latest commands get a little more time to settle. */
@@ -373,6 +366,13 @@ const MOBILE_PROGRAMMATIC_ANIMATED_SCROLL_SETTLE_MS = 1400;
 /** Cold-open history fill is useful, but bounded so a short/duplicate host page cannot drain history forever. */
 const MAX_INITIAL_HISTORY_AUTOFILL_PAGES = 3;
 const MOBILE_MESSAGE_ESTIMATED_ITEM_SIZE = 140;
+/**
+ * Cold/warm entry paints a tiny tail first, then prepends the full render model in-place.
+ * A small tail avoids LegendList's hidden initial-scroll bootstrap. Older local items are
+ * prepended in bounded chunks only when the user scrolls upward.
+ */
+const MOBILE_INITIAL_TAIL_ITEM_COUNT = 4;
+const MOBILE_TAIL_REVEAL_ITEM_COUNT = 12;
 const ANDROID_SELECTABLE_TEXT_RUN_MAX_BLOCKS = 12;
 const ANDROID_SELECTABLE_TEXT_RUN_MAX_UTF16_LENGTH = 1800;
 const ANDROID_SELECTABLE_TEXT_RUN_GROUPING_OPTIONS: MobileMarkdownTextRunGroupingOptions = {
@@ -682,6 +682,9 @@ export function MessageRenderer({
   // load-earlier 的 prepend 撑高会被误当成底部增长 → scrollToEnd 把用户从刚加载的历史拽回最新(review P1)。
   // 用户重新拖动 / 主动跳底 / 切会话时解除。
   const readingOlderRef = useRef(false);
+  // “上一条用户消息”可能位于尚未挂载的本地尾窗之外；记录一次跳转，等目标 slice
+  // commit 后再用窗口内索引滚动。切会话必须同步清空，避免旧目标落到新列表。
+  const pendingPreviousUserJumpKeyRef = useRef<string | null>(null);
   // 每次补页分配 generation：旧会话 / 旧请求的异步 settle 不得清掉新请求的抑制态。
   const readingOlderRequestGenerationRef = useRef(0);
   // LegendList mVCP 始终开启；普通尾部 append / 流式 resize 同样会触发 native 锚点
@@ -706,22 +709,13 @@ export function MessageRenderer({
   // 断路到期后的 one-shot 贴底清账 timer:断路窗内错过的最终高度可能停在半空且
   // 之后再无 contentSize 事件,到期补一次(仍在贴底跟随时)把账清平(review P1)。
   const followEndPinRecoveryTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
-  // 冷开落底是否已发起(每个 scrollResetKey 一次):替代 LegendList initialScrollAtEnd
-  // (弃用原因见下方 LegendList props 注释)。首批 items commit 后 rAF 命令式落底一次,
-  // 目标偏差由 handleContentSize 的贴底补滚随后续测量自然校正。
-  const initialAnchorDoneRef = useRef(false);
-  const initialAnchorGenerationRef = useRef(0);
-  const initialAnchorVerifyFrameRef = useRef<number | null>(null);
-  // 落底 rAF / verify loop / 揭开 timer 的句柄(生命周期 = 每个 scrollResetKey 一轮)。
-  const initialAnchorFrameRef = useRef<number | null>(null);
-  const initialRevealTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
-  // 贴底跟随的落底校验/补滚环(runStickToLatestVerify,独立于冷开锚定的 generation/frame——
-  // 两条校验环可能各自独立触发,互不打断/互不清对方的句柄)。
+  // LegendList 首次普通布局完成前，禁止 content-size 贴底介入；onLoad 后才由统一
+  // scrollToEnd / verifier 接管，避免布局未就绪时发空命令。
+  const initialListReadyRef = useRef(false);
+  // 贴底跟随的落底校验/补滚环同样在 onLoad 后介入。
   const followVerifyGenerationRef = useRef(0);
   const followVerifyFrameRef = useRef<number | null>(null);
   const followVerifyTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
-  // settle 遮罩:落底两段式期间列表保持 opacity 0,settle 窗口后揭开(规则 7 防跳动)。
-  const [listRevealed, setListRevealed] = useState(false);
   const [visibleMessageKeys, setVisibleMessageKeys] = useState<ReadonlySet<string>>(
     () => new Set(),
   );
@@ -740,6 +734,7 @@ export function MessageRenderer({
     initialHistoryAutofillRemainingRef.current = MAX_INITIAL_HISTORY_AUTOFILL_PAGES;
     lastAutoLoadEarlierKeyRef.current = null;
     readingOlderRef.current = false;
+    pendingPreviousUserJumpKeyRef.current = null;
     readingOlderRequestGenerationRef.current += 1;
     mvcpSettleAtRef.current = 0;
     programmaticScrollGenerationRef.current += 1;
@@ -753,16 +748,7 @@ export function MessageRenderer({
     previousItemKeysRef.current = [];
     scrollMetricsRef.current = { contentHeight: 0, offsetY: 0, viewportHeight: 0 };
     followEndPinStateRef.current = createMobileFollowEndPinState();
-    initialAnchorDoneRef.current = false;
-    initialAnchorGenerationRef.current += 1;
-    if (initialAnchorFrameRef.current !== null) {
-      cancelAnimationFrame(initialAnchorFrameRef.current);
-      initialAnchorFrameRef.current = null;
-    }
-    if (initialAnchorVerifyFrameRef.current !== null) {
-      cancelAnimationFrame(initialAnchorVerifyFrameRef.current);
-      initialAnchorVerifyFrameRef.current = null;
-    }
+    initialListReadyRef.current = false;
     followVerifyGenerationRef.current += 1;
     if (followVerifyTimerRef.current !== null) {
       clearTimeout(followVerifyTimerRef.current);
@@ -772,9 +758,6 @@ export function MessageRenderer({
       cancelAnimationFrame(followVerifyFrameRef.current);
       followVerifyFrameRef.current = null;
     }
-    // settle 遮罩复位必须与列表重挂同帧(渲染期 setState,React 官方 prop-change 模式):
-    // 走 effect 会晚一帧,新列表以旧 revealed=true 裸挂一帧,未锚定内容闪现。
-    setListRevealed(false);
   }
   const lastAppliedFocusKeyRef = useRef<string | null>(null);
   const [hasNewMessages, setHasNewMessages] = useState(false);
@@ -940,18 +923,57 @@ export function MessageRenderer({
     });
   }, [devExposeList, scrollToOffsetProgrammatically]);
 
+  // 完整 render model 始终保留给搜索、画廊、分享、红点等业务逻辑。LegendList 首帧只接
+  // 尾部少量项，index 从 0 开始，不走 initialScrollIndex 的隐藏式 bootstrap。用户上翻时
+  // 再按小块 prepend 已在内存中的更早项，避免一次接回 100+ 变高行引发 mVCP 跳位。
   const listData = useMemo(() => [...items], [items]);
-  // 遮罩重武装(review P1):真冷开(无缓存)时列表以空挂载,落底 effect 的空分支已把
-  // 遮罩揭开;首批消息到达(0→N)且本会话尚未落底时,必须在**渲染期**重新武装遮罩——
-  // 等 effect 就晚一帧,长历史会先裸露顶部再跳底(规则 7)。渲染期 setState 同组件
-  // 官方 prop-change 模式,prev 判定保证只在转变那一次触发。
-  const prevListLengthRef = useRef(listData.length);
-  if (prevListLengthRef.current !== listData.length) {
-    if (prevListLengthRef.current === 0 && listData.length > 0
-      && !initialAnchorDoneRef.current && listRevealed) {
-      setListRevealed(false);
-    }
-    prevListLengthRef.current = listData.length;
+  // 冷进入常先以 data=[] 挂载、再收到首批消息；LegendList 的 onLoad 对同一实例只触发一次，
+  // 因此 empty → ready 重挂一次，让真实尾窗拥有独立的首绘回调。
+  const listMountKey = `${scrollResetKey ?? 'default'}:${listData.length === 0 ? 'empty' : 'ready'}`;
+  const [tailWindowAnchor, setTailWindowAnchor] = useState<{
+    identity: string;
+    firstKey: string;
+  } | null>(null);
+  const defaultTailWindowStartIndex = Math.max(0, listData.length - MOBILE_INITIAL_TAIL_ITEM_COUNT);
+  const anchoredTailWindowStartIndex = tailWindowAnchor?.identity === listMountKey
+    ? listData.findIndex((item) => item.key === tailWindowAnchor.firstKey)
+    : -1;
+  const tailWindowStartIndex = anchoredTailWindowStartIndex >= 0
+    ? anchoredTailWindowStartIndex
+    : defaultTailWindowStartIndex;
+  const initialTailWindowActive = tailWindowStartIndex > 0;
+  const visibleListData = useMemo(
+    () => listData.slice(tailWindowStartIndex),
+    [listData, tailWindowStartIndex],
+  );
+  const tailWindowRevealGenerationRef = useRef(0);
+  const revealTailWindowFromIndex = useCallback((nextStartIndex: number) => {
+    if (nextStartIndex < 0 || nextStartIndex >= tailWindowStartIndex) return false;
+    const nextFirstKey = listData[nextStartIndex]?.key;
+    if (!nextFirstKey) return false;
+    const generation = tailWindowRevealGenerationRef.current + 1;
+    tailWindowRevealGenerationRef.current = generation;
+    readingOlderRef.current = true;
+    markMobileMvcpSettle();
+    setTailWindowAnchor({ identity: listMountKey, firstKey: nextFirstKey });
+    requestAnimationFrame(() => {
+      if (tailWindowRevealGenerationRef.current === generation) {
+        readingOlderRef.current = false;
+      }
+    });
+    return true;
+  }, [listData, listMountKey, markMobileMvcpSettle, tailWindowStartIndex]);
+  const revealEarlierTailWindow = useCallback((all = false) => {
+    if (tailWindowStartIndex <= 0) return false;
+    return revealTailWindowFromIndex(all
+      ? 0
+      : Math.max(0, tailWindowStartIndex - MOBILE_TAIL_REVEAL_ITEM_COUNT));
+  }, [revealTailWindowFromIndex, tailWindowStartIndex]);
+  const prevListMountKeyRef = useRef(listMountKey);
+  if (prevListMountKeyRef.current !== listMountKey) {
+    prevListMountKeyRef.current = listMountKey;
+    initialListReadyRef.current = false;
+    followEndPinStateRef.current = createMobileFollowEndPinState();
   }
   const itemKeys = useMemo(() => listData.map((item) => item.key), [listData]);
   const itemKeysSignature = useMemo(
@@ -1101,10 +1123,14 @@ export function MessageRenderer({
   const previousUserTarget = useMemo(
     () => (
       isAwayFromBottom
-        ? previousUserMessageJumpTarget(listData, firstVisibleIndex)
+        ? previousUserMessageJumpTargetForWindow(
+          listData,
+          tailWindowStartIndex,
+          firstVisibleIndex,
+        )
         : null
     ),
-    [firstVisibleIndex, isAwayFromBottom, listData],
+    [firstVisibleIndex, isAwayFromBottom, listData, tailWindowStartIndex],
   );
   const showJumpToLatest = isAwayFromBottom && !hasNewMessages;
   const focusRunKey = focusedItemKey
@@ -1269,8 +1295,23 @@ export function MessageRenderer({
     lastAutoLoadEarlierKeyRef.current = null;
     nearBottomRef.current = false;
     setIsAwayFromBottom(true);
-    scrollToIndexProgrammatically(previousUserTarget.index, 0.12);
-  }, [previousUserTarget, scrollToIndexProgrammatically]);
+    if (previousUserTarget.windowIndex !== null) {
+      scrollToIndexProgrammatically(previousUserTarget.windowIndex, 0.12);
+      return;
+    }
+    // The target exists in the complete local model but is older than the mounted tail window.
+    // Mount only through that target, then issue the relative scroll after React commits the slice.
+    pendingPreviousUserJumpKeyRef.current = previousUserTarget.itemKey;
+    revealTailWindowFromIndex(previousUserTarget.index);
+  }, [previousUserTarget, revealTailWindowFromIndex, scrollToIndexProgrammatically]);
+  useEffect(() => {
+    const pendingKey = pendingPreviousUserJumpKeyRef.current;
+    if (!pendingKey) return;
+    const windowIndex = visibleListData.findIndex((item) => item.key === pendingKey);
+    if (windowIndex < 0) return;
+    pendingPreviousUserJumpKeyRef.current = null;
+    scrollToIndexProgrammatically(windowIndex, 0.12);
+  }, [scrollToIndexProgrammatically, visibleListData]);
 
   // 「跳到最新」请求(会话外部触发,含发送消息后的跟随):命令式滚到底,随后跑一轮有界
   // 校验/补滚(runStickToLatestVerify)——单发的 scrollToEnd 落地一刻的 metrics 可能仍陈旧,
@@ -1333,6 +1374,9 @@ export function MessageRenderer({
 
   const attemptAutoLoadEarlier = useCallback(() => {
     if (!onLoadEarlier) return;
+    // 尾部本地窗口尚未展开完时，列表的“位于顶部”只代表临时尾窗，
+    // 不能据此请求网络历史；等 mVCP 锚定完整数组后再恢复正常电平判定。
+    if (initialTailWindowActive) return;
     // 热路径前置短路(滚动事件每 16ms 评估一次,getState() 每次新建状态对象):没有用户浏览意图
     // 且冷开预算已耗尽、或当前首项已尝试过时不碰 getState。完整判定仍以
     // shouldAutoLoadEarlier 为唯一真相,这里只做它的子集提前返回。
@@ -1358,7 +1402,14 @@ export function MessageRenderer({
     lastAutoLoadEarlierKeyRef.current = firstItemKey;
     if (initialAutoFillAllowed) initialHistoryAutofillRemainingRef.current -= 1;
     requestLoadEarlier();
-  }, [firstItemKey, loadEarlierAction.disabled, loadEarlierAction.visible, onLoadEarlier, requestLoadEarlier]);
+  }, [
+    firstItemKey,
+    initialTailWindowActive,
+    loadEarlierAction.disabled,
+    loadEarlierAction.visible,
+    onLoadEarlier,
+    requestLoadEarlier,
+  ]);
 
   // 近底/跟随态迁移 + 「跳到底部」浮标与新消息红点;metrics 也供 DEV harness 读取。
   // 「解除跟随」的主路径是拖动意图(shouldUnpinMobileFollowOnDrag):拖动中相对起点
@@ -1409,7 +1460,11 @@ export function MessageRenderer({
     attemptAutoLoadEarlier();
     // 分享模式:滚动驱动吸顶 check 的几何重判(内部节流,非分享模式直接返回)。
     if (shareSelectionActiveRef.current) scheduleStickyShareCheck();
-  }, [attemptAutoLoadEarlier, bottomOverlayHeight, scheduleStickyShareCheck]);
+  }, [
+    attemptAutoLoadEarlier,
+    bottomOverlayHeight,
+    scheduleStickyShareCheck,
+  ]);
 
   // 用户开始拖动 → 标记「上翻意图」,放行自动加载更早(onScrollBeginDrag 仅用户手势触发,
   // 程序化 scrollToEnd 不会触发,故不会误置);同时记录拖动起点 offset,供
@@ -1424,11 +1479,21 @@ export function MessageRenderer({
     // 用户重新拖动 → 结束「读历史」态;解除态下滑回底的跟随恢复由 handleScroll
     // 的方向判定负责(nearBottomRef 翻 true 即重新打开贴底补滚)。
     readingOlderRef.current = false;
+    // 短尾窗可能一开始就同时位于 start/end，onStartReached 的初始边沿已被业务 guard
+    // 消费。用户在窗口顶部主动拖动时，先 prepend 一小块本地历史，不一次灌回完整任务。
+    if (initialTailWindowActive) {
+      const state = listRef.current?.getState();
+      if (state?.isAtStart || state?.isNearStart) revealEarlierTailWindow();
+    }
     // 翻完 refs 立即补一次电平评估:列表已顶死时(Android 无 bounce 尤甚)这次拖动不产生
     // offset 变化,不会有 onScroll / onStartReached,ref 写入也不驱动 effect——没有这一刀,
     // 「失败后停在顶部再拖一下重试」的信号会整体丢失(review P2)。
     attemptAutoLoadEarlier();
-  }, [attemptAutoLoadEarlier]);
+  }, [
+    attemptAutoLoadEarlier,
+    initialTailWindowActive,
+    revealEarlierTailWindow,
+  ]);
 
   // 拖动结束(手指离开,可能进入惯性滚动)→ 关闭拖动追踪。惯性阶段的上滑不需要再判
   // 解除:上滑手势的拖动段必然已越过死区完成解除;下滑回底的恢复由 scroll 方向判定接手。
@@ -1438,8 +1503,12 @@ export function MessageRenderer({
   }, []);
 
   const handleStartReached = useCallback(() => {
+    if (initialTailWindowActive) {
+      if (userScrollForOlderRef.current) revealEarlierTailWindow();
+      return;
+    }
     attemptAutoLoadEarlier();
-  }, [attemptAutoLoadEarlier]);
+  }, [attemptAutoLoadEarlier, initialTailWindowActive, revealEarlierTailWindow]);
 
   // eligibility 变化时重评估:上一页加载结束(disabled 翻 false)、入口点亮(visible 翻 true)、
   // prepend 落地(firstItemKey 变)。覆盖「用户停在顶部等待、无滚动事件」的全部哑火场景;
@@ -1454,6 +1523,18 @@ export function MessageRenderer({
     scrollMetricsRef.current = { ...scrollMetricsRef.current, viewportHeight };
   }, []);
 
+  // 尾窗完成首绘后直接显示并贴底；本地更早项只在用户上翻时按块前插。
+  // 不使用 initialScrollIndex：LegendList 会在该 bootstrap 完成前把 cell 容器 opacity 置 0，
+  // 即使目标只有几项也会人为制造“数据已在、消息仍空白”的窗口。
+  // 后续小块 prepend 由 maintainVisibleContentPosition 保住当前可见项。
+  const handleListLoad = useCallback(() => {
+    initialListReadyRef.current = true;
+    if (visibleListData.length > 0) {
+      scrollToEndProgrammatically(false);
+      runStickToLatestVerify();
+    }
+  }, [runStickToLatestVerify, scrollToEndProgrammatically, visibleListData.length]);
+
   // 记录 contentHeight 供近底判定 fallback + DEV harness 就绪判定;并承担**唯一的贴底跟随**:
   // 内容长高(流式增长、大块一帧撑高、冷开测量结算)时,用户本就贴底(nearBottomRef,与
   // 「跳到底部」浮标同源)则无论这次长多少都跟到底(仿 filo onContentSizeChange → scrollToEnd);
@@ -1463,6 +1544,7 @@ export function MessageRenderer({
     markMobileMvcpSettle();
     const { viewportHeight } = scrollMetricsRef.current;
     scrollMetricsRef.current = { ...scrollMetricsRef.current, contentHeight: height };
+    if (!initialListReadyRef.current) return;
     // readingOlderRef:load-earlier 的 prepend 也会撑高 contentHeight,但那是顶部增长、不该贴底(review P1)。
     if (readingOlderRef.current) return;
     if (nearBottomRef.current && viewportHeight > 0 && height > viewportHeight) {
@@ -1508,91 +1590,19 @@ export function MessageRenderer({
         runStickToLatestVerify();
       }
     }
-  }, [markMobileMvcpSettle, runStickToLatestVerify, scrollToEndProgrammatically]);
+  }, [
+    markMobileMvcpSettle,
+    runStickToLatestVerify,
+    scrollToEndProgrammatically,
+  ]);
 
-  // 冷开落底(替代 initialScrollAtEnd,弃用原因见 LegendList props 注释):首批 items
-  // commit 后先命令式落底,随后双帧校验 native metrics 是否真的到达 content end。
-  // LegendList 可能仍在以估高换实高或等待 mVCP/data settle,所以一次 scrollToEnd 的
-  // Promise/回调不等价于真实落底；verify 带独立 wait/retry 上限,只在跟随仍归本流程
-  // 所有且用户未开始浏览历史时补滚。settled/give-up 后才揭开列表,固定 300ms 仅作
-  // 首次校验前的最短遮罩窗口,不再是“已经落底”的假定。
-  useEffect(() => {
-    if (initialAnchorDoneRef.current) return;
-    if (listData.length === 0) {
-      setListRevealed(true);
-      return;
-    }
-
-    initialAnchorDoneRef.current = true;
-    const generation = initialAnchorGenerationRef.current + 1;
-    initialAnchorGenerationRef.current = generation;
-    if (initialAnchorFrameRef.current !== null) cancelAnimationFrame(initialAnchorFrameRef.current);
-    if (initialAnchorVerifyFrameRef.current !== null) cancelAnimationFrame(initialAnchorVerifyFrameRef.current);
-    if (initialRevealTimerRef.current) clearTimeout(initialRevealTimerRef.current);
-
-    const finish = () => {
-      if (initialAnchorGenerationRef.current !== generation) return;
-      if (initialAnchorVerifyFrameRef.current !== null) {
-        cancelAnimationFrame(initialAnchorVerifyFrameRef.current);
-        initialAnchorVerifyFrameRef.current = null;
-      }
-      initialRevealTimerRef.current = null;
-      setListRevealed(true);
-    };
-
-    const startedAt = Date.now();
-    const verify = (attempts: number, waitRounds: number) => {
-      if (initialAnchorGenerationRef.current !== generation) return;
-      const preserveVisibleContentPosition = readingOlderRef.current
-        || isMobileMvcpSettling(Date.now(), mvcpSettleAtRef.current);
-      const action = evaluateMobileAnchorVerify({
-        attempts,
-        listVisible: true,
-        metrics: scrollMetricsRef.current,
-        preserveVisibleContentPosition,
-        stickToLatest: nearBottomRef.current && !userScrollForOlderRef.current,
-        waitRounds,
-      });
-      if (action === 'settled' || action === 'give-up') {
-        const remaining = Math.max(0, MOBILE_INITIAL_ANCHOR_SETTLE_MS - (Date.now() - startedAt));
-        if (remaining === 0) finish();
-        else initialRevealTimerRef.current = setTimeout(finish, remaining);
-        return;
-      }
-      if (action === 'retry') scrollToEndProgrammatically(false);
-      initialAnchorVerifyFrameRef.current = requestAnimationFrame(() => {
-        initialAnchorVerifyFrameRef.current = requestAnimationFrame(() => {
-          initialAnchorVerifyFrameRef.current = null;
-          verify(
-            attempts + (action === 'retry' ? 1 : 0),
-            waitRounds + (action === 'wait' ? 1 : 0),
-          );
-        });
-      });
-    };
-
-    initialAnchorFrameRef.current = requestAnimationFrame(() => {
-      initialAnchorFrameRef.current = null;
-      if (initialAnchorGenerationRef.current !== generation) return;
-      scrollToEndProgrammatically(false);
-      initialAnchorVerifyFrameRef.current = requestAnimationFrame(() => {
-        initialAnchorVerifyFrameRef.current = requestAnimationFrame(() => {
-          initialAnchorVerifyFrameRef.current = null;
-          if (initialAnchorGenerationRef.current !== generation) return;
-          verify(0, 0);
-        });
-      });
-    });
-  }, [listData.length, scrollResetKey, scrollToEndProgrammatically]);
-
-  // 会话切换(scrollResetKey):重置浮标/近底等 UI 状态;LegendList 本体经 key={scrollResetKey}
-  // 重挂并重新落底(上方冷开落底 effect;initialAnchorDoneRef 已在渲染期同步块复位)。
+  // 会话切换(scrollResetKey):重置浮标/近底等 UI 状态;LegendList 本体经 listMountKey
+  // 重挂并从 index=0 建立有界尾窗。
   // 滚动/自动加载相关的 ref 复位已在渲染期同步块完成(见 prevScrollResetKeyRef,防切会话
   // 竞态误触发自动拉历史),此处不重复。
   useEffect(() => {
     lastAppliedFocusKeyRef.current = null;
     // 上个会话遗留的断路清账 timer 作废(护栏状态本体已在渲染期同步块重建)。
-    // 冷开落底的 rAF / 揭开 timer 不在这清:清旧职责在落底 effect 自身(声明序原因见彼处)。
     if (followEndPinRecoveryTimerRef.current) {
       clearTimeout(followEndPinRecoveryTimerRef.current);
       followEndPinRecoveryTimerRef.current = null;
@@ -1605,15 +1615,11 @@ export function MessageRenderer({
   // 卸载时清掉在飞的定时器/rAF(闭包引用 listRef,卸载后触发是无害 no-op,
   // 但不留悬挂句柄)。
   useEffect(() => () => {
-    initialAnchorGenerationRef.current += 1;
     followVerifyGenerationRef.current += 1;
     if (followEndPinRecoveryTimerRef.current) clearTimeout(followEndPinRecoveryTimerRef.current);
     clearProgrammaticScroll();
-    if (initialAnchorFrameRef.current !== null) cancelAnimationFrame(initialAnchorFrameRef.current);
-    if (initialAnchorVerifyFrameRef.current !== null) cancelAnimationFrame(initialAnchorVerifyFrameRef.current);
     if (followVerifyFrameRef.current !== null) cancelAnimationFrame(followVerifyFrameRef.current);
     if (followVerifyTimerRef.current !== null) clearTimeout(followVerifyTimerRef.current);
-    if (initialRevealTimerRef.current) clearTimeout(initialRevealTimerRef.current);
   }, [clearProgrammaticScroll]);
 
   // 顶部 chrome(如连接横幅)出现/消失 → topPadding 变 → contentContainerStyle.paddingTop 变 →
@@ -1638,6 +1644,12 @@ export function MessageRenderer({
       lastAppliedFocusKeyRef.current = null;
       return;
     }
+    // 深链/搜索使用完整数组索引；先一次展开本地尾窗，再定位，避免把完整数组的 index
+    // 发给临时窗口。下一次 effect 在完整 data 落地后继续执行。
+    if (initialTailWindowActive) {
+      revealEarlierTailWindow(true);
+      return;
+    }
     if (lastAppliedFocusKeyRef.current === focusRunKey) return;
     const index = listData.findIndex((item) => item.key === focusedItemKey);
     if (index < 0) return;
@@ -1649,7 +1661,14 @@ export function MessageRenderer({
     nearBottomRef.current = false;
     setIsAwayFromBottom(true);
     scrollToIndexProgrammatically(index, 0.45);
-  }, [focusRunKey, focusedItemKey, listData, scrollToIndexProgrammatically]);
+  }, [
+    focusRunKey,
+    focusedItemKey,
+    initialTailWindowActive,
+    listData,
+    revealEarlierTailWindow,
+    scrollToIndexProgrammatically,
+  ]);
 
   // 新消息红点:滚离底时来新消息(尾部 append)→ 提示。贴底时由 handleContentSize 补滚
   // 自动跟随、不提示。wasNearBottom 只看 nearBottomRef(跟随态唯一真相):以前 || 距离兜底
@@ -1708,10 +1727,9 @@ export function MessageRenderer({
     <View style={styles.messageFrame}>
       <MessageListVisibleKeysContext.Provider value={visibleMessageKeys}>
       <LegendList
-        // 每会话重挂:alignItemsAtEnd + initialScrollAtEnd 让新会话干净地重新锚到底部
-        // (替代手搓的隐藏+rAF 落底 + open-settle)。
-        key={scrollResetKey}
-        data={listData}
+        // 每会话重挂；冷开的 empty → ready 也重挂一次，让真实尾窗重新触发 onLoad。
+        key={listMountKey}
+        data={visibleListData}
         extraData={messageListExtraData}
         getItemType={mobileMessageListItemType}
         keyExtractor={(item) => item.key}
@@ -1719,12 +1737,15 @@ export function MessageRenderer({
         recycleItems={recycleItems}
         estimatedItemSize={MOBILE_MESSAGE_ESTIMATED_ITEM_SIZE}
         drawDistance={MOBILE_MESSAGE_DRAW_DISTANCE}
-        // 冷开落底不用 initialScrollAtEnd、贴底跟随不用 maintainScrollAtEnd:两者的内部
-        // 程序化滚动(冷开锚定 watchdog 的 fallback 补滚、贴底的 pending 自我续排)在特定
+        // 冷开不用 initialScrollIndex / initialScrollAtEnd、贴底跟随不用
+        // maintainScrollAtEnd：这些内部程序化滚动会先隐藏 cell，且曾在特定内容形态下
+        // 与手动贴底互相触发。首帧只喂尾部 4 项，用户上翻时再按 12 项小块前插
+        // 本地历史；后续贴底由 handleContentSize 的手动补滚（带振荡断路器）接管。
+        //
+        // 历史：initialScrollAtEnd / initialScrollIndex 的程序化滚动在特定
         // 内容形态下会与布局结算互相触发,形成无限 onScroll 风暴把 JS 线程打满——表现为
         // 冷开会话消息区空白、无 loading、返回键无响应,只能杀 App(2026-07 模拟器逐项
-        // 二分实锤,3.3.2 / 3.3.3 均复现)。落底改为下方 rAF 一次命令式 scrollToEnd,
-        // 后续贴底由 handleContentSize 的手动补滚(带振荡断路器)接管。
+        // 二分实锤,3.3.2 / 3.3.3 均复现)。
         alignItemsAtEnd
         maintainScrollAtEnd={false}
         maintainVisibleContentPosition={{ data: true, size: true }}
@@ -1738,7 +1759,7 @@ export function MessageRenderer({
           ? <SyncingMessages />
           : <EmptyMessages testID={emptyTestID} />}
         ListHeaderComponent={
-          loadEarlierAction.visible ? (
+          !initialTailWindowActive && loadEarlierAction.visible ? (
             <MessageListActionButton
               accessibilityLabel={loadEarlierAction.accessibilityLabel}
               disabled={loadEarlierAction.disabled}
@@ -1752,6 +1773,7 @@ export function MessageRenderer({
         }
         ListFooterComponent={queueFooter ? <>{queueFooter}</> : null}
         onLayout={handleListLayout}
+        onLoad={handleListLoad}
         onContentSizeChange={handleContentSize}
         onScroll={handleScroll}
         onScrollBeginDrag={handleScrollBeginDrag}
@@ -1760,7 +1782,7 @@ export function MessageRenderer({
         onStartReachedThreshold={2}
         scrollEventThrottle={16}
         ref={listRef}
-        style={[styles.messageList, !listRevealed && styles.messageListSettling]}
+        style={styles.messageList}
         testID={testID ?? 'message.list'}
         viewabilityConfig={viewabilityConfigRef.current}
         onViewableItemsChanged={handleViewableItemsChangedRef.current}
@@ -1978,22 +2000,10 @@ function EmptyMessages({ testID }: { testID?: string }) {
   );
 }
 
-/**
- * 首同步进行中的消息区占位(spinner + 「正在同步」)。延迟显形:同步在窗口内完成时
- * 保持空白直接上内容,避免快速路径闪一帧 spinner(视觉连续性)。
- */
-const SYNCING_PLACEHOLDER_DELAY_MS = 200;
-
 function SyncingMessages() {
   const styles = useThemedStyles(makeStyles);
   const { colors } = useTheme();
   const { t } = useTranslation();
-  const [visible, setVisible] = useState(false);
-  useEffect(() => {
-    const timer = setTimeout(() => setVisible(true), SYNCING_PLACEHOLDER_DELAY_MS);
-    return () => clearTimeout(timer);
-  }, []);
-  if (!visible) return <View style={styles.emptyCard} testID="message.syncingPending" />;
   return (
     <View style={styles.emptyCard} testID="message.syncing">
       <ActivityIndicator color={colors.textTertiary} size="small" />
@@ -6763,9 +6773,6 @@ function headingSizeStyle(
 const makeStyles = (colors: ThemeColors) => StyleSheet.create({
   messageFrame: { flex: 1, minHeight: 0 },
   messageList: { flex: 1 },
-  // 冷开落底 settle 期的遮罩(不影响布局/测量,只视觉隐藏;防两段式落底跳动,
-  // 见 MOBILE_INITIAL_ANCHOR_SETTLE_MS)。
-  messageListSettling: { opacity: 0 },
   messages: {
     flexGrow: 1,
     // Anchor a short conversation to the bottom (just above the composer) like a normal chat,

--- a/apps/mobile/src/session/MessageRenderer.tsx
+++ b/apps/mobile/src/session/MessageRenderer.tsx
@@ -311,10 +311,13 @@ import {
   evaluateMobileAnchorVerify,
   evaluateMobileFollowEndContentSizePin,
   isMobileMvcpSettling,
+  MOBILE_ANCHOR_VERIFY_TOLERANCE,
   mobileFollowVerifyStartDelayMs,
+  mobileLoadEarlierPrefetchThreshold,
   mobileMessageListKeysSignature,
   mobileMvcpSettleDeadline,
   mobileMessageListTopPadding,
+  MOBILE_FOLLOW_UNPIN_DRAG_DEAD_ZONE,
   MOBILE_FOLLOW_END_PIN_SUPPRESS_MS,
   MOBILE_MESSAGE_LIST_BOTTOM_PADDING,
   type MessageScrollMetrics,
@@ -359,6 +362,8 @@ const SHARE_STICKY_CHECK_HEIGHT = 44;
 const STICKY_SHARE_CHECK_THROTTLE_MS = 150;
 const SCREENSHOT_SHARE_VISIBLE_PERCENT_THRESHOLD = 10;
 // LegendList 变高 item 的初始估高(仅影响首帧布局定位,LegendList 挂载后按实测尺寸修正)。
+/** Keep main's initial correction hidden until the latest-message anchor has settled. */
+const MOBILE_INITIAL_ANCHOR_SETTLE_MS = 300;
 /** Maximum time a native imperative scroll may be reported as in-flight. */
 const MOBILE_PROGRAMMATIC_SCROLL_SETTLE_MS = 1000;
 /** Animated jump-to-latest commands get a little more time to settle. */
@@ -366,6 +371,8 @@ const MOBILE_PROGRAMMATIC_ANIMATED_SCROLL_SETTLE_MS = 1400;
 /** Cold-open history fill is useful, but bounded so a short/duplicate host page cannot drain history forever. */
 const MAX_INITIAL_HISTORY_AUTOFILL_PAGES = 3;
 const MOBILE_MESSAGE_ESTIMATED_ITEM_SIZE = 140;
+/** Streaming/async measurement must not keep history-pagination protection alive forever. */
+const MOBILE_HISTORY_PREPEND_SETTLE_MAX_MS = 500;
 const ANDROID_SELECTABLE_TEXT_RUN_MAX_BLOCKS = 12;
 const ANDROID_SELECTABLE_TEXT_RUN_MAX_UTF16_LENGTH = 1800;
 const ANDROID_SELECTABLE_TEXT_RUN_GROUPING_OPTIONS: MobileMarkdownTextRunGroupingOptions = {
@@ -589,6 +596,7 @@ export function MessageRenderer({
   continuationTurnClientId,
   continuationInFlightProjectionCapability,
   loadingEarlier,
+  loadEarlierProgressKey,
   focusedRequestKey,
   queueFooter,
   scrollResetKey,
@@ -604,6 +612,8 @@ export function MessageRenderer({
   focusedRequestKey?: number | string | null;
   followLatestRequestKey?: number | string | null;
   items: readonly MobileMessageRenderItem[];
+  /** Oldest loaded host cursor; synthetic cards must not mask successful history prepends. */
+  loadEarlierProgressKey?: string | null;
   emptyTestID?: string;
   /** 排队消息 inline 区(InlineQueueSection),渲染在最后一条消息之后、随内容滚动。 */
   queueFooter?: ReactNode;
@@ -666,6 +676,10 @@ export function MessageRenderer({
   // 否则短会话(只加载了少量最新消息但 hasOlderMessages)冷开时会落在 onStartReachedThreshold 内、
   // 未经用户操作就自动拉历史(review P2)。切会话重置。
   const userScrollForOlderRef = useRef(false);
+  // Android does not always emit onScrollBeginDrag when a list is already hard-clamped at
+  // offset 0. Track raw downward touch displacement as a fallback history-browse intent.
+  const historyTouchStartYRef = useRef<number | null>(null);
+  const historyTouchTriggeredRef = useRef(false);
   // 冷开时自动补齐短初窗,最多连续拉三页；用户主动浏览后改走既有不限页的近顶预取。
   const initialHistoryAutofillRemainingRef = useRef(MAX_INITIAL_HISTORY_AUTOFILL_PAGES);
   // 上一次自动 load-earlier 触发时的首项 key:相同 = 上次尝试无进展(失败 / 拉回重复页),
@@ -677,6 +691,13 @@ export function MessageRenderer({
   const readingOlderRef = useRef(false);
   // 每次补页分配 generation：旧会话 / 旧请求的异步 settle 不得清掉新请求的抑制态。
   const readingOlderRequestGenerationRef = useRef(0);
+  const readingOlderReleaseTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const readingOlderReleaseDeadlineRef = useRef(0);
+  // 分页 Promise 会早于 React/LegendList 完成新页提交。只有真正观察到 loadingEarlier
+  // 从 true 回到 false，才把“请求完成”视为“新页已进入当前 render commit”。
+  const readingOlderLoadingObservedRef = useRef(false);
+  const loadingEarlierRef = useRef(loadingEarlier === true);
+  loadingEarlierRef.current = loadingEarlier === true;
   // LegendList mVCP 始终开启；普通尾部 append / 流式 resize 同样会触发 native 锚点
   // 调整，不能只拿 readingOlderRef 代表 settle 状态。每次 data / size 变化延长一个短
   // 安静窗，verifier 在窗内只等待，不消耗 6 次补滚预算。
@@ -699,13 +720,21 @@ export function MessageRenderer({
   // 断路到期后的 one-shot 贴底清账 timer:断路窗内错过的最终高度可能停在半空且
   // 之后再无 contentSize 事件,到期补一次(仍在贴底跟随时)把账清平(review P1)。
   const followEndPinRecoveryTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
-  // LegendList 首次普通布局完成前，禁止 content-size 贴底介入；onLoad 后才由统一
-  // scrollToEnd / verifier 接管，避免布局未就绪时发空命令。
-  const initialListReadyRef = useRef(false);
-  // 贴底跟随的落底校验/补滚环同样在 onLoad 后介入。
+  // main 已验证的首次进入锚定：完整历史从挂载起就在列表中，命令式落底与测量校正
+  // 只在 opacity 遮罩下运行；settle 后一次性揭开，不能把补滚画面暴露给用户。
+  const initialAnchorDoneRef = useRef(false);
+  const initialAnchorGenerationRef = useRef(0);
+  const initialAnchorVerifyFrameRef = useRef<number | null>(null);
+  const initialAnchorFrameRef = useRef<number | null>(null);
+  const initialRevealTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   const followVerifyGenerationRef = useRef(0);
   const followVerifyFrameRef = useRef<number | null>(null);
   const followVerifyTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const [listRevealed, setListRevealed] = useState(false);
+  // Re-evaluate the near-start predicate after a prepend request releases its ref-only lock.
+  // Without a render tick, a user who remains at the top can stall after one page because the
+  // page commit effect ran while readingOlderRef was still true.
+  const [loadEarlierEvaluationVersion, setLoadEarlierEvaluationVersion] = useState(0);
   const [visibleMessageKeys, setVisibleMessageKeys] = useState<ReadonlySet<string>>(
     () => new Set(),
   );
@@ -721,10 +750,18 @@ export function MessageRenderer({
     isDraggingRef.current = false;
     dragStartOffsetYRef.current = null;
     userScrollForOlderRef.current = false;
+    historyTouchStartYRef.current = null;
+    historyTouchTriggeredRef.current = false;
     initialHistoryAutofillRemainingRef.current = MAX_INITIAL_HISTORY_AUTOFILL_PAGES;
     lastAutoLoadEarlierKeyRef.current = null;
     readingOlderRef.current = false;
     readingOlderRequestGenerationRef.current += 1;
+    readingOlderLoadingObservedRef.current = false;
+    readingOlderReleaseDeadlineRef.current = 0;
+    if (readingOlderReleaseTimerRef.current !== null) {
+      clearTimeout(readingOlderReleaseTimerRef.current);
+      readingOlderReleaseTimerRef.current = null;
+    }
     mvcpSettleAtRef.current = 0;
     programmaticScrollGenerationRef.current += 1;
     programmaticScrollInFlightRef.current = false;
@@ -737,7 +774,20 @@ export function MessageRenderer({
     previousItemKeysRef.current = [];
     scrollMetricsRef.current = { contentHeight: 0, offsetY: 0, viewportHeight: 0 };
     followEndPinStateRef.current = createMobileFollowEndPinState();
-    initialListReadyRef.current = false;
+    initialAnchorDoneRef.current = false;
+    initialAnchorGenerationRef.current += 1;
+    if (initialAnchorFrameRef.current !== null) {
+      cancelAnimationFrame(initialAnchorFrameRef.current);
+      initialAnchorFrameRef.current = null;
+    }
+    if (initialAnchorVerifyFrameRef.current !== null) {
+      cancelAnimationFrame(initialAnchorVerifyFrameRef.current);
+      initialAnchorVerifyFrameRef.current = null;
+    }
+    if (initialRevealTimerRef.current !== null) {
+      clearTimeout(initialRevealTimerRef.current);
+      initialRevealTimerRef.current = null;
+    }
     followVerifyGenerationRef.current += 1;
     if (followVerifyTimerRef.current !== null) {
       clearTimeout(followVerifyTimerRef.current);
@@ -747,6 +797,7 @@ export function MessageRenderer({
       cancelAnimationFrame(followVerifyFrameRef.current);
       followVerifyFrameRef.current = null;
     }
+    setListRevealed(false);
   }
   const lastAppliedFocusKeyRef = useRef<string | null>(null);
   const [hasNewMessages, setHasNewMessages] = useState(false);
@@ -912,22 +963,22 @@ export function MessageRenderer({
     });
   }, [devExposeList, scrollToOffsetProgrammatically]);
 
-  // LegendList 始终接收完整 render model，由自身虚拟化 / 回收屏外 cell。冷进入常先以
-  // data=[] 挂载、再收到首批消息，因此 empty → ready 重挂一次，让非空列表重新应用初始
-  // offset。offset-only 路径直接写原生 contentOffset，不走 initialScrollIndex / AtEnd 的
-  // 多轮测量 bootstrap，也就不会在 bootstrap settle 期间长期隐藏 cell。
+  // 与 main 保持一致：完整历史从首次挂载起就在同一个 LegendList 中，屏外 cell 交给
+  // LegendList 虚拟化/回收。不能用业务尾窗代替完整数据，否则短尾窗未撑满首屏时
+  // Android 无法产生有效滚动，运行中任务会重现“上半屏空白且历史不可拖动”。
   const listData = useMemo(() => [...items], [items]);
-  const listMountKey = `${scrollResetKey ?? 'default'}:${listData.length === 0 ? 'empty' : 'ready'}`;
-  const initialScrollOffset = useMemo(() => {
-    if (listData.length === 0) return 0;
-    const estimatedContentHeight = listData.length * MOBILE_MESSAGE_ESTIMATED_ITEM_SIZE;
-    return Math.max(0, estimatedContentHeight - windowDimensions.height);
-  }, [listData.length, windowDimensions.height]);
-  const prevListMountKeyRef = useRef(listMountKey);
-  if (prevListMountKeyRef.current !== listMountKey) {
-    prevListMountKeyRef.current = listMountKey;
-    initialListReadyRef.current = false;
-    followEndPinStateRef.current = createMobileFollowEndPinState();
+  const prevListLengthRef = useRef(listData.length);
+  if (prevListLengthRef.current !== listData.length) {
+    if (
+      prevListLengthRef.current === 0
+      && listData.length > 0
+      && !initialAnchorDoneRef.current
+      && listRevealed
+    ) {
+      // 冷进入常先挂空列表再收到首批缓存；必须在同一 render 重新遮住，不能先露顶部。
+      setListRevealed(false);
+    }
+    prevListLengthRef.current = listData.length;
   }
   const itemKeys = useMemo(() => listData.map((item) => item.key), [listData]);
   const itemKeysSignature = useMemo(
@@ -938,7 +989,7 @@ export function MessageRenderer({
   useEffect(() => {
     markMobileMvcpSettle();
   }, [itemKeysSignature, markMobileMvcpSettle]);
-  const firstItemKey = itemKeys[0] ?? null;
+  const firstItemKey = loadEarlierProgressKey ?? itemKeys[0] ?? null;
   // 本地缩略兜底映射版本:collect 内部对 cindy-oss-attach:// 附件读全局 store 做 overlay,
   // hydrate / 新注册后 gallery 需要重建,否则点开气泡本地图时 initialUrl 对不上图集条目。
   const sentThumbsVersion = useSentAttachmentThumbsVersion();
@@ -1285,30 +1336,130 @@ export function MessageRenderer({
   // prepend 防跳由内置 maintainVisibleContentPosition 处理,无需手动开 maintain。
   // 冷开只在列表同时位于 start/end(内容未撑满首屏)时有界补页；真实上翻意图继续沿用
   // 不限页的近顶预取。两条路径都受首项进展去重保护,失败/重复页不会循环打 host。
+  const scheduleReadingOlderRelease = useCallback((generation: number) => {
+    if (readingOlderReleaseTimerRef.current !== null) {
+      clearTimeout(readingOlderReleaseTimerRef.current);
+      readingOlderReleaseTimerRef.current = null;
+    }
+    const attemptRelease = () => {
+      readingOlderReleaseTimerRef.current = null;
+      if (
+        readingOlderRequestGenerationRef.current !== generation
+        || !readingOlderRef.current
+      ) return;
+      // Never apply the native-anchor settle deadline to the remote request itself. A legitimately
+      // slow active-session page must keep prepend protection until the parent commits
+      // loadingEarlier=false; the 500 ms bound starts only after that network/loading phase ends.
+      if (loadingEarlierRef.current) {
+        readingOlderReleaseDeadlineRef.current = 0;
+        readingOlderReleaseTimerRef.current = setTimeout(attemptRelease, 16);
+        return;
+      }
+      if (readingOlderReleaseDeadlineRef.current === 0) {
+        readingOlderReleaseDeadlineRef.current = Date.now()
+          + MOBILE_HISTORY_PREPEND_SETTLE_MAX_MS;
+      }
+      const quietWindowRemainingMs = Math.max(
+        0,
+        Math.min(
+          mvcpSettleAtRef.current,
+          readingOlderReleaseDeadlineRef.current,
+        ) - Date.now(),
+      );
+      if (quietWindowRemainingMs > 0) {
+        readingOlderReleaseTimerRef.current = setTimeout(
+          attemptRelease,
+          quietWindowRemainingMs,
+        );
+        return;
+      }
+      // Passive effects run after the page has joined the React tree; two more frames leave the
+      // native ScrollView/LegendList MVCP adjustment ahead of any follow-to-end compensation.
+      requestAnimationFrame(() => {
+        requestAnimationFrame(() => {
+          if (
+            readingOlderRequestGenerationRef.current === generation
+            && readingOlderRef.current
+            && !loadingEarlierRef.current
+          ) {
+            const extendedQuietWindowMs = Math.max(
+              0,
+              Math.min(
+                mvcpSettleAtRef.current,
+                readingOlderReleaseDeadlineRef.current,
+              ) - Date.now(),
+            );
+            if (extendedQuietWindowMs > 0) {
+              readingOlderReleaseTimerRef.current = setTimeout(
+                attemptRelease,
+                extendedQuietWindowMs,
+              );
+              return;
+            }
+            readingOlderRef.current = false;
+            readingOlderLoadingObservedRef.current = false;
+            readingOlderReleaseDeadlineRef.current = 0;
+            setLoadEarlierEvaluationVersion((version) => version + 1);
+          } else if (
+            readingOlderRequestGenerationRef.current === generation
+            && readingOlderRef.current
+          ) {
+            readingOlderReleaseDeadlineRef.current = 0;
+            readingOlderReleaseTimerRef.current = setTimeout(attemptRelease, 16);
+          }
+        });
+      });
+    };
+    attemptRelease();
+  }, []);
+
   const requestLoadEarlier = useCallback(() => {
     if (!onLoadEarlier) return;
     const generation = readingOlderRequestGenerationRef.current + 1;
     readingOlderRequestGenerationRef.current = generation;
+    readingOlderLoadingObservedRef.current = false;
+    readingOlderReleaseDeadlineRef.current = 0;
     readingOlderRef.current = true;
-    const releaseReadingOlder = () => {
-      // Promise settle 后再让 LegendList 完成一帧 prepend / mVCP 布局；成功、空页、
-      // 失败都必须释放，且旧请求不能干扰切会话后或后发的新请求。
-      requestAnimationFrame(() => {
-        if (readingOlderRequestGenerationRef.current === generation) {
-          readingOlderRef.current = false;
-        }
-      });
+    // A short list can be simultaneously atStart and atEnd. Once the user explicitly browses
+    // older history, it must no longer be treated as following the latest edge; otherwise the
+    // prepend height is mistaken for a tail append and handleContentSize scrolls to the end.
+    if (userScrollForOlderRef.current) {
+      nearBottomRef.current = false;
+      setIsAwayFromBottom(true);
+    }
+    const releaseAfterRequestSettles = () => {
+      // React Native may batch loadingEarlier=true and loadingEarlier=false around a fast page,
+      // so the child is not guaranteed to observe the intermediate loading render. Promise
+      // settlement is the authoritative bounded fallback; the effect below still releases after
+      // the committed loading transition when it is observable.
+      if (readingOlderRequestGenerationRef.current === generation) {
+        scheduleReadingOlderRelease(generation);
+      }
     };
     try {
       const result = onLoadEarlier();
-      void Promise.resolve(result).then(releaseReadingOlder, releaseReadingOlder);
+      void Promise.resolve(result).then(
+        releaseAfterRequestSettles,
+        releaseAfterRequestSettles,
+      );
     } catch {
-      releaseReadingOlder();
+      releaseAfterRequestSettles();
     }
-  }, [onLoadEarlier]);
+  }, [onLoadEarlier, scheduleReadingOlderRelease]);
 
-  const attemptAutoLoadEarlier = useCallback(() => {
+  useEffect(() => {
+    if (!readingOlderRef.current) return;
+    if (loadingEarlier === true) {
+      readingOlderLoadingObservedRef.current = true;
+      return;
+    }
+    if (!readingOlderLoadingObservedRef.current) return;
+    scheduleReadingOlderRelease(readingOlderRequestGenerationRef.current);
+  }, [itemKeysSignature, loadingEarlier, scheduleReadingOlderRelease]);
+
+  const attemptAutoLoadEarlier = useCallback((nativeMetrics?: MessageScrollMetrics) => {
     if (!onLoadEarlier) return;
+    if (readingOlderRef.current) return;
     // 热路径前置短路(滚动事件每 16ms 评估一次,getState() 每次新建状态对象):没有用户浏览意图
     // 且冷开预算已耗尽、或当前首项已尝试过时不碰 getState。完整判定仍以
     // shouldAutoLoadEarlier 为唯一真相,这里只做它的子集提前返回。
@@ -1319,15 +1470,22 @@ export function MessageRenderer({
     if (firstItemKey !== null && lastAutoLoadEarlierKeyRef.current === firstItemKey) return;
     const listState = listRef.current?.getState();
     if (!listState) return;
+    // LegendList's edge bookkeeping can lag behind the native ScrollView during recycling,
+    // initial anchoring, and a no-bounce drag at offset 0. Native metrics are only a positive
+    // fallback: they may prove this gesture is at/near the history edge, never disqualify it.
+    const nativeAtStart = nativeMetrics !== undefined
+      && nativeMetrics.offsetY <= MOBILE_ANCHOR_VERIFY_TOLERANCE;
+    const nativeNearStart = nativeMetrics !== undefined
+      && nativeMetrics.offsetY <= mobileLoadEarlierPrefetchThreshold(nativeMetrics.viewportHeight);
     const eligible = shouldAutoLoadEarlier({
       actionDisabled: loadEarlierAction.disabled,
       actionVisible: loadEarlierAction.visible,
       atEnd: listState.isAtEnd,
-      atStart: listState.isAtStart,
+      atStart: listState.isAtStart || nativeAtStart,
       firstItemKey,
       initialAutoFillAllowed,
       lastAttemptedFirstItemKey: lastAutoLoadEarlierKeyRef.current,
-      nearStart: listState.isNearStart,
+      nearStart: listState.isNearStart || nativeNearStart,
       userScrolledForOlder,
     });
     if (!eligible) return;
@@ -1388,7 +1546,7 @@ export function MessageRenderer({
     }
     // 拖动进近顶区时 onStartReached 边沿可能早已被消费(见 attemptAutoLoadEarlier 注释),
     // 滚动事件兜底重评估;前置短路让稳态滚动只付 1~2 次 ref 比较的成本。
-    attemptAutoLoadEarlier();
+    attemptAutoLoadEarlier(metrics);
     // 分享模式:滚动驱动吸顶 check 的几何重判(内部节流,非分享模式直接返回)。
     if (shareSelectionActiveRef.current) scheduleStickyShareCheck();
   }, [
@@ -1397,23 +1555,62 @@ export function MessageRenderer({
     scheduleStickyShareCheck,
   ]);
 
+  const handleHistoryTouchStart = useCallback((event: GestureResponderEvent) => {
+    historyTouchStartYRef.current = event.nativeEvent.pageY;
+    historyTouchTriggeredRef.current = false;
+  }, []);
+
+  const maybeTriggerHistoryTouch = useCallback((pageY: number) => {
+    const startY = historyTouchStartYRef.current;
+    if (
+      startY === null
+      || historyTouchTriggeredRef.current
+      || pageY - startY < MOBILE_FOLLOW_UNPIN_DRAG_DEAD_ZONE
+    ) return;
+    historyTouchTriggeredRef.current = true;
+    userScrollForOlderRef.current = true;
+    lastAutoLoadEarlierKeyRef.current = null;
+    attemptAutoLoadEarlier(scrollMetricsRef.current);
+  }, [attemptAutoLoadEarlier]);
+
+  const handleHistoryTouchMove = useCallback((event: GestureResponderEvent) => {
+    maybeTriggerHistoryTouch(event.nativeEvent.pageY);
+  }, [maybeTriggerHistoryTouch]);
+
+  const handleHistoryTouchEnd = useCallback((event: GestureResponderEvent) => {
+    // Android may suppress move callbacks when ScrollView is already clamped at offset 0.
+    // The completed touch still carries the final coordinate, so apply the same threshold here.
+    maybeTriggerHistoryTouch(event.nativeEvent.pageY);
+    historyTouchStartYRef.current = null;
+    historyTouchTriggeredRef.current = false;
+  }, [maybeTriggerHistoryTouch]);
+
+  const handleHistoryTouchCancel = useCallback(() => {
+    historyTouchStartYRef.current = null;
+    historyTouchTriggeredRef.current = false;
+  }, []);
+
   // 用户开始拖动 → 标记「上翻意图」,放行自动加载更早(onScrollBeginDrag 仅用户手势触发,
   // 程序化 scrollToEnd 不会触发,故不会误置);同时记录拖动起点 offset,供
   // shouldUnpinMobileFollowOnDrag 判「相对起点累计上移」。
   const handleScrollBeginDrag = useCallback((event: NativeSyntheticEvent<NativeScrollEvent>) => {
+    const nativeMetrics = {
+      contentHeight: event.nativeEvent.contentSize.height,
+      offsetY: event.nativeEvent.contentOffset.y,
+      viewportHeight: event.nativeEvent.layoutMeasurement.height,
+    };
     clearProgrammaticScroll();
     isDraggingRef.current = true;
     dragStartOffsetYRef.current = event.nativeEvent.contentOffset.y;
     userScrollForOlderRef.current = true;
     // 新手势 = 允许重新尝试一次自动加载(上次失败 / 无进展的去重记录随手势作废)。
     lastAutoLoadEarlierKeyRef.current = null;
-    // 用户重新拖动 → 结束「读历史」态;解除态下滑回底的跟随恢复由 handleScroll
-    // 的方向判定负责(nearBottomRef 翻 true 即重新打开贴底补滚)。
-    readingOlderRef.current = false;
+    attemptAutoLoadEarlier(nativeMetrics);
+    // 请求仍在飞或新页仍在做 mVCP 布局时，新的触摸不能提前解除历史锚点保护。
+    // 下滑回底的显式按钮/跟随请求会主动清理；普通手势在分页落地后由方向判定恢复。
     // 翻完 refs 立即补一次电平评估:列表已顶死时(Android 无 bounce 尤甚)这次拖动不产生
     // offset 变化,不会有 onScroll / onStartReached,ref 写入也不驱动 effect——没有这一刀,
     // 「失败后停在顶部再拖一下重试」的信号会整体丢失(review P2)。
-    attemptAutoLoadEarlier();
   }, [attemptAutoLoadEarlier]);
 
   // 拖动结束(手指离开,可能进入惯性滚动)→ 关闭拖动追踪。惯性阶段的上滑不需要再判
@@ -1432,23 +1629,13 @@ export function MessageRenderer({
   // 小页(payload 重试降到 1~5 条)prepend 后仍在近顶区也由此级联补拉,直到填满预取区。
   useEffect(() => {
     attemptAutoLoadEarlier();
-  }, [attemptAutoLoadEarlier]);
+  }, [attemptAutoLoadEarlier, loadEarlierEvaluationVersion]);
 
   const handleListLayout = useCallback((event: LayoutChangeEvent) => {
     const viewportHeight = event.nativeEvent.layout.height;
     if (!Number.isFinite(viewportHeight) || viewportHeight <= 0) return;
     scrollMetricsRef.current = { ...scrollMetricsRef.current, viewportHeight };
   }, []);
-
-  // offset-only 初始定位不等待变高 cell 的多轮测量；onLoad 后仍做一次真实贴底校正，
-  // 随后的高度结算交给 content-size 跟随与 verifier。
-  const handleListLoad = useCallback(() => {
-    initialListReadyRef.current = true;
-    if (listData.length > 0) {
-      scrollToEndProgrammatically(false);
-      runStickToLatestVerify();
-    }
-  }, [listData.length, runStickToLatestVerify, scrollToEndProgrammatically]);
 
   // 记录 contentHeight 供近底判定 fallback + DEV harness 就绪判定;并承担**唯一的贴底跟随**:
   // 内容长高(流式增长、大块一帧撑高、冷开测量结算)时,用户本就贴底(nearBottomRef,与
@@ -1459,7 +1646,6 @@ export function MessageRenderer({
     markMobileMvcpSettle();
     const { viewportHeight } = scrollMetricsRef.current;
     scrollMetricsRef.current = { ...scrollMetricsRef.current, contentHeight: height };
-    if (!initialListReadyRef.current) return;
     // readingOlderRef:load-earlier 的 prepend 也会撑高 contentHeight,但那是顶部增长、不该贴底(review P1)。
     if (readingOlderRef.current) return;
     if (nearBottomRef.current && viewportHeight > 0 && height > viewportHeight) {
@@ -1511,8 +1697,81 @@ export function MessageRenderer({
     scrollToEndProgrammatically,
   ]);
 
-  // 会话切换(scrollResetKey):重置浮标/近底等 UI 状态;LegendList 本体经 listMountKey
-  // 重挂并用完整 data 的 offset-only 路径定位末尾。
+  // 与 main 一致的首次落底：完整历史已经在列表里，所有命令式补滚与动态高度校正
+  // 都在 opacity 遮罩下完成；确认到达内容末端（或有界放弃）后再一次性揭开。
+  useEffect(() => {
+    if (initialAnchorDoneRef.current) return;
+    if (listData.length === 0) {
+      setListRevealed(true);
+      return;
+    }
+
+    initialAnchorDoneRef.current = true;
+    const generation = initialAnchorGenerationRef.current + 1;
+    initialAnchorGenerationRef.current = generation;
+    if (initialAnchorFrameRef.current !== null) cancelAnimationFrame(initialAnchorFrameRef.current);
+    if (initialAnchorVerifyFrameRef.current !== null) cancelAnimationFrame(initialAnchorVerifyFrameRef.current);
+    if (initialRevealTimerRef.current) clearTimeout(initialRevealTimerRef.current);
+
+    const finish = () => {
+      if (initialAnchorGenerationRef.current !== generation) return;
+      if (initialAnchorVerifyFrameRef.current !== null) {
+        cancelAnimationFrame(initialAnchorVerifyFrameRef.current);
+        initialAnchorVerifyFrameRef.current = null;
+      }
+      initialRevealTimerRef.current = null;
+      setListRevealed(true);
+    };
+
+    const startedAt = Date.now();
+    const verify = (attempts: number, waitRounds: number) => {
+      if (initialAnchorGenerationRef.current !== generation) return;
+      const preserveVisibleContentPosition = readingOlderRef.current
+        || isMobileMvcpSettling(Date.now(), mvcpSettleAtRef.current);
+      const action = evaluateMobileAnchorVerify({
+        attempts,
+        listVisible: true,
+        metrics: scrollMetricsRef.current,
+        preserveVisibleContentPosition,
+        stickToLatest: nearBottomRef.current && !userScrollForOlderRef.current,
+        waitRounds,
+      });
+      if (action === 'settled' || action === 'give-up') {
+        const remaining = Math.max(
+          0,
+          MOBILE_INITIAL_ANCHOR_SETTLE_MS - (Date.now() - startedAt),
+        );
+        if (remaining === 0) finish();
+        else initialRevealTimerRef.current = setTimeout(finish, remaining);
+        return;
+      }
+      if (action === 'retry') scrollToEndProgrammatically(false);
+      initialAnchorVerifyFrameRef.current = requestAnimationFrame(() => {
+        initialAnchorVerifyFrameRef.current = requestAnimationFrame(() => {
+          initialAnchorVerifyFrameRef.current = null;
+          verify(
+            attempts + (action === 'retry' ? 1 : 0),
+            waitRounds + (action === 'wait' ? 1 : 0),
+          );
+        });
+      });
+    };
+
+    initialAnchorFrameRef.current = requestAnimationFrame(() => {
+      initialAnchorFrameRef.current = null;
+      if (initialAnchorGenerationRef.current !== generation) return;
+      scrollToEndProgrammatically(false);
+      initialAnchorVerifyFrameRef.current = requestAnimationFrame(() => {
+        initialAnchorVerifyFrameRef.current = requestAnimationFrame(() => {
+          initialAnchorVerifyFrameRef.current = null;
+          if (initialAnchorGenerationRef.current !== generation) return;
+          verify(0, 0);
+        });
+      });
+    });
+  }, [listData.length, scrollResetKey, scrollToEndProgrammatically]);
+
+  // 会话切换(scrollResetKey):重置浮标/近底等 UI 状态;LegendList 本体完整重挂并重新落底。
   // 滚动/自动加载相关的 ref 复位已在渲染期同步块完成(见 prevScrollResetKeyRef,防切会话
   // 竞态误触发自动拉历史),此处不重复。
   useEffect(() => {
@@ -1530,11 +1789,15 @@ export function MessageRenderer({
   // 卸载时清掉在飞的定时器/rAF(闭包引用 listRef,卸载后触发是无害 no-op,
   // 但不留悬挂句柄)。
   useEffect(() => () => {
+    initialAnchorGenerationRef.current += 1;
     followVerifyGenerationRef.current += 1;
     if (followEndPinRecoveryTimerRef.current) clearTimeout(followEndPinRecoveryTimerRef.current);
     clearProgrammaticScroll();
+    if (initialAnchorFrameRef.current !== null) cancelAnimationFrame(initialAnchorFrameRef.current);
+    if (initialAnchorVerifyFrameRef.current !== null) cancelAnimationFrame(initialAnchorVerifyFrameRef.current);
     if (followVerifyFrameRef.current !== null) cancelAnimationFrame(followVerifyFrameRef.current);
     if (followVerifyTimerRef.current !== null) clearTimeout(followVerifyTimerRef.current);
+    if (initialRevealTimerRef.current) clearTimeout(initialRevealTimerRef.current);
   }, [clearProgrammaticScroll]);
 
   // 顶部 chrome(如连接横幅)出现/消失 → topPadding 变 → contentContainerStyle.paddingTop 变 →
@@ -1559,6 +1822,7 @@ export function MessageRenderer({
       lastAppliedFocusKeyRef.current = null;
       return;
     }
+    if (!listRevealed) return;
     if (lastAppliedFocusKeyRef.current === focusRunKey) return;
     const index = listData.findIndex((item) => item.key === focusedItemKey);
     if (index < 0) return;
@@ -1574,6 +1838,7 @@ export function MessageRenderer({
     focusRunKey,
     focusedItemKey,
     listData,
+    listRevealed,
     scrollToIndexProgrammatically,
   ]);
 
@@ -1588,6 +1853,12 @@ export function MessageRenderer({
       nextKeys: itemKeys,
       wasNearBottom: nearBottomRef.current,
     });
+    if (decision.preserveVisibleAnchor && userScrollForOlderRef.current) {
+      // Belt-and-suspenders for externally initiated prepends: preserve the reader's anchor even
+      // when data arrived without passing through requestLoadEarlier in this renderer.
+      nearBottomRef.current = false;
+      setIsAwayFromBottom(true);
+    }
     if (!focusedItemKey && decision.shouldAutoFollow && decision.autoFollowTarget === 'content-end') {
       setHasNewMessages(false);
       setIsAwayFromBottom(false);
@@ -1598,6 +1869,8 @@ export function MessageRenderer({
   }, [focusedItemKey, itemKeys]);
 
   const handleLoadEarlierPress = useCallback(() => {
+    userScrollForOlderRef.current = true;
+    lastAutoLoadEarlierKeyRef.current = null;
     requestLoadEarlier();
   }, [requestLoadEarlier]);
 
@@ -1631,11 +1904,17 @@ export function MessageRenderer({
     // chat-text-quote:Provider 恒挂载(值可为 null),避免启用态翻转时整棵消息树
     // 因 Provider 增删而重挂;value 稳定(useMemo),不触发订阅方重渲。
     <SelectionQuoteContext.Provider value={selectionQuoteContextValue}>
-    <View style={styles.messageFrame}>
+    <View
+      style={styles.messageFrame}
+      onTouchStart={handleHistoryTouchStart}
+      onTouchMove={handleHistoryTouchMove}
+      onTouchEnd={handleHistoryTouchEnd}
+      onTouchCancel={handleHistoryTouchCancel}
+    >
       <MessageListVisibleKeysContext.Provider value={visibleMessageKeys}>
       <LegendList
-        // 每会话重挂；冷开的 empty → ready 也重挂一次，让非空完整列表应用初始 offset。
-        key={listMountKey}
+        // 与 main 一致：每个任务用完整历史重挂；首次命令式落底在 opacity 遮罩下完成。
+        key={scrollResetKey}
         data={listData}
         extraData={messageListExtraData}
         getItemType={mobileMessageListItemType}
@@ -1644,13 +1923,7 @@ export function MessageRenderer({
         recycleItems={recycleItems}
         estimatedItemSize={MOBILE_MESSAGE_ESTIMATED_ITEM_SIZE}
         drawDistance={MOBILE_MESSAGE_DRAW_DISTANCE}
-        initialScrollOffset={initialScrollOffset}
-        // 冷开不用 initialScrollIndex / initialScrollAtEnd、贴底跟随不用
-        // maintainScrollAtEnd：index/end 的测量 bootstrap 会长时间隐藏 cell，且曾在特定
-        // 内容形态下与手动贴底互相触发。这里用 offset-only 直接给原生初值，完整 data
-        // 始终在列表内；后续贴底由 handleContentSize 的手动补滚（带振荡断路器）接管。
-        //
-        // 历史：initialScrollAtEnd / initialScrollIndex 的程序化滚动在特定
+        // initialScrollAtEnd / initialScrollIndex 的程序化滚动在特定
         // 内容形态下会与布局结算互相触发,形成无限 onScroll 风暴把 JS 线程打满——表现为
         // 冷开会话消息区空白、无 loading、返回键无响应,只能杀 App(2026-07 模拟器逐项
         // 二分实锤,3.3.2 / 3.3.3 均复现)。
@@ -1681,7 +1954,6 @@ export function MessageRenderer({
         }
         ListFooterComponent={queueFooter ? <>{queueFooter}</> : null}
         onLayout={handleListLayout}
-        onLoad={handleListLoad}
         onContentSizeChange={handleContentSize}
         onScroll={handleScroll}
         onScrollBeginDrag={handleScrollBeginDrag}
@@ -1690,7 +1962,7 @@ export function MessageRenderer({
         onStartReachedThreshold={2}
         scrollEventThrottle={16}
         ref={listRef}
-        style={styles.messageList}
+        style={[styles.messageList, !listRevealed && styles.messageListSettling]}
         testID={testID ?? 'message.list'}
         viewabilityConfig={viewabilityConfigRef.current}
         onViewableItemsChanged={handleViewableItemsChangedRef.current}
@@ -6681,6 +6953,8 @@ function headingSizeStyle(
 const makeStyles = (colors: ThemeColors) => StyleSheet.create({
   messageFrame: { flex: 1, minHeight: 0 },
   messageList: { flex: 1 },
+  // main 的首次锚定遮罩：列表仍正常布局/测量，只是不把内部补滚过程暴露出来。
+  messageListSettling: { opacity: 0 },
   messages: {
     flexGrow: 1,
     // Anchor a short conversation to the bottom (just above the composer) like a normal chat,

--- a/apps/mobile/src/session/MessageRenderer.tsx
+++ b/apps/mobile/src/session/MessageRenderer.tsx
@@ -392,7 +392,10 @@ const MOBILE_PROGRAMMATIC_SCROLL_SETTLE_MS = 1000;
 const MOBILE_PROGRAMMATIC_ANIMATED_SCROLL_SETTLE_MS = 1400;
 /** Cold-open history fill is useful, but bounded so a short/duplicate host page cannot drain history forever. */
 const MAX_INITIAL_HISTORY_AUTOFILL_PAGES = 3;
-const MOBILE_MESSAGE_ESTIMATED_ITEM_SIZE = 140;
+// Keep the initial pool large enough for short message/work-group rows. An
+// overestimate forces on-demand container growth during a fast fling, which is
+// both a mount spike and a DEV LogBox update in the middle of Fabric commits.
+const MOBILE_MESSAGE_ESTIMATED_ITEM_SIZE = 100;
 /** Manual prepend anchoring retries layout positions for at most ~3 seconds, even under resize churn. */
 const MOBILE_HISTORY_ANCHOR_VERIFY_MAX_FRAMES = 180;
 const MOBILE_HISTORY_ANCHOR_VERIFY_MAX_MS = 3000;
@@ -659,7 +662,7 @@ export function MessageRenderer({
   syncingWhileEmpty,
   testID,
   devExposeList,
-  devRecycleItems = true,
+  devRecycleItems = false,
 }: {
   bottomOverlayHeight?: number;
   /** 顶部 chrome(绝对定位半透明工具栏)实测高度:内容顶部按此让位,详见 mobileMessageListTopPadding。 */
@@ -2441,10 +2444,11 @@ export function MessageRenderer({
     ),
     [pendingSend?.selectedClientId, shareSelectionActive],
   );
-  // Production and regular DEV screens use native cell recycling after every
-  // identity-bound local state below was made recycling-aware. listperf passes
-  // this DEV-only override explicitly so its on/off control remains available.
-  const recycleItems = __DEV__ ? devRecycleItems === true : true;
+  // Keep production and regular DEV screens on keyed remounts. With Fabric,
+  // recycling an Android container across heterogeneous message trees can race
+  // native detach/attach batches and try to mount a child that still belongs to
+  // the previous row. listperf keeps the DEV-only override for explicit A/Bs.
+  const recycleItems = __DEV__ ? devRecycleItems === true : false;
 
   return (
     // chat-text-quote:Provider 恒挂载(值可为 null),避免启用态翻转时整棵消息树

--- a/apps/mobile/src/session/SwipeableSessionRow.tsx
+++ b/apps/mobile/src/session/SwipeableSessionRow.tsx
@@ -106,6 +106,19 @@ function SwipeableSessionRowInner({
   // render*Actions 的回调参数是库内部的 translation SharedValue,渲染期存进 ref,
   // 供松手回调(handleWillOpen)同步读取当前位移做全滑判定。
   const translationRef = useRef<SharedValue<number> | null>(null);
+  const previousRowKeyRef = useRef(rowKey);
+
+  // Project child windowing reuses a small pool of native swipe rows. When a
+  // slot starts representing another session, clear the previous gesture
+  // position immediately so an open/partially-open row cannot follow the slot
+  // onto the new session. The registry cleanup below separately retires the
+  // previous session id.
+  useEffect(() => {
+    if (previousRowKeyRef.current === rowKey) return;
+    methodsRef.current?.reset();
+    translationRef.current = null;
+    previousRowKeyRef.current = rowKey;
+  }, [rowKey]);
 
   // 行卸载(归档/删除后随数据消失、列表虚拟化回收)时注销;registry 内部只清
   // 「当前记录仍是自己」的条目,不会误伤已经接管的新行。

--- a/apps/mobile/src/session/SwipeableSessionRow.tsx
+++ b/apps/mobile/src/session/SwipeableSessionRow.tsx
@@ -31,7 +31,6 @@ import Animated, {
   interpolate,
   useAnimatedReaction,
   useAnimatedStyle,
-  useDerivedValue,
   useSharedValue,
   withTiming,
   type SharedValue,
@@ -307,17 +306,21 @@ function RightActionsPanel({
   const { colors } = useTheme();
   const { t } = useTranslation();
   const StatusIcon = archived ? ArchiveRestore : Archive;
-  // armed = 位移越过全滑阈值。独立 SharedValue 只在跨越阈值时写入,避免
-  // useDerivedValue 里对逐帧变化的 translation 直接 withTiming(目标每帧重设,动画走不完)。
-  const armed = useSharedValue(false);
+  // 挂载时同步落初值,只在真正跨越阈值时启动 timing。若每个面板挂载都执行
+  // withTiming(0),大项目从完整首帧切到窗口行时会留下仍在更新已卸载 Fabric tag
+  // 的空动画,最终用 Reanimated 警告栈堵住 Android 主线程。
+  const armedProgress = useSharedValue(0);
   useAnimatedReaction(
     () => -translation.value >= fullSwipeThreshold,
-    (next) => {
-      if (next !== armed.value) armed.value = next;
+    (next, previous) => {
+      if (previous === null) {
+        armedProgress.value = next ? 1 : 0;
+        return;
+      }
+      if (next !== previous) {
+        armedProgress.value = withTiming(next ? 1 : 0, { duration: ARM_ANIMATION_MS });
+      }
     },
-  );
-  const armedProgress = useDerivedValue(
-    () => withTiming(armed.value ? 1 : 0, { duration: ARM_ANIMATION_MS }),
   );
 
   const optionsStyle = useAnimatedStyle(() => {

--- a/apps/mobile/src/session/SwipeableSessionRow.tsx
+++ b/apps/mobile/src/session/SwipeableSessionRow.tsx
@@ -541,6 +541,7 @@ const makeStyles = (colors: ThemeColors) => StyleSheet.create({
     marginTop: -BUTTON_SIZE / 2,
     overflow: 'hidden',
     position: 'absolute',
+    right: BUTTON_GAP * 2 + BUTTON_SIZE,
     top: '50%',
     width: BUTTON_SIZE,
   },

--- a/apps/mobile/src/session/SwipeableSessionRow.tsx
+++ b/apps/mobile/src/session/SwipeableSessionRow.tsx
@@ -12,29 +12,20 @@
  * 继续拖动时主按钮从圆**拉长成胶囊**(宽度跟手、圆角恒为半高),图标钉在行边缘一侧跟手,
  * 全滑阈值后主按钮拉伸盖满整个露出区。非全高色块、非方角浮块。
  *
- * 实现要点(RNGH ReanimatedSwipeable 的测量机制决定的结构约束):
+ * 实现要点(RNGH 经典 Swipeable 的测量机制决定的结构约束):
  *  - 面板 snap 宽度由 render*Actions 返回内容的布局宽度决定(库用 marker 元素测量),
  *    因此外层「壳」必须定宽;会随拖动伸缩的按钮全部 position:'absolute',不参与测量;
  *  - friction / overshootFriction 保持默认 1:面板 1:1 跟手,overshoot 不衰减,
  *    全滑阈值才够得着(overshootFriction>1 时 translation 被压缩,永远到不了阈值);
- *  - 全滑判定在 onSwipeableWillOpen(松手后的 JS 回调)同步读 translation,不在
- *    worklet 拖动中触发 —— 手指还按着时行被移除会拆手势树。
+ *  - 全滑判定在 onSwipeableWillOpen 同步读取松手位移;不在手指按住时移除行,
+ *    避免拆手势树。读取失败时才回退到 Animated listener 的最近值。
  */
-import { memo, useCallback, useEffect, useRef, type ReactNode } from 'react';
-import { Pressable, StyleSheet, View, useWindowDimensions } from 'react-native';
+import { memo, useCallback, useEffect, useRef, useState, type ReactNode } from 'react';
+import { Animated, Pressable, StyleSheet, View, useWindowDimensions } from 'react-native';
 import {
-  ReanimatedSwipeable as Swipeable,
-  SwipeDirection,
-  type SwipeableMethods,
+  ClassicSwipeable as Swipeable,
+  type ClassicSwipeableMethods,
 } from '@/platform/gestureHandler';
-import Animated, {
-  interpolate,
-  useAnimatedReaction,
-  useAnimatedStyle,
-  useSharedValue,
-  withTiming,
-  type SharedValue,
-} from 'react-native-reanimated';
 import { Archive, ArchiveRestore, Ellipsis, Pin, PinOff } from 'lucide-react-native';
 import { useTranslation } from 'react-i18next';
 import { pinToggleAction, statusToggleAction, type SwipeRowRegistry } from '@/session/swipeRowRegistry';
@@ -54,6 +45,9 @@ const FULL_SWIPE_RATIO = 0.55;
 /** 「归档」按钮越过全滑阈值时扩展盖满右侧面板的过渡时长。 */
 const ARM_ANIMATION_MS = 150;
 const ICON_SIZE = iconSize.swipeAction;
+type SwipeTranslation = Animated.AnimatedInterpolation<number>;
+type ReadableSwipeTranslation = SwipeTranslation & { __getValue?(): unknown };
+type ClassicSwipeDirection = 'left' | 'right';
 
 /**
  * 页面级滑动控制 bundle:registry + 三个动作回调打包成一个稳定引用(useMemo),
@@ -101,11 +95,22 @@ function SwipeableSessionRowInner({
   const { width: windowWidth } = useWindowDimensions();
   const fullSwipeThreshold = windowWidth * FULL_SWIPE_RATIO;
 
-  const methodsRef = useRef<SwipeableMethods | null>(null);
-  // render*Actions 的回调参数是库内部的 translation SharedValue,渲染期存进 ref,
-  // 供松手回调(handleWillOpen)同步读取当前位移做全滑判定。
-  const translationRef = useRef<SharedValue<number> | null>(null);
+  const methodsRef = useRef<ClassicSwipeableMethods | null>(null);
+  // 经典 Swipeable 在调用 WillOpen 前会把松手位移写入 transX 的 JS Animated 图。
+  // 保留该节点可同步读取真正的松手位置;listener 最近值只作 RN 内部读值不可用时的兜底。
+  const translationRef = useRef<ReadableSwipeTranslation | null>(null);
+  const latestTranslationRef = useRef(0);
+  const armedRef = useRef(false);
+  const armedProgress = useRef(new Animated.Value(0)).current;
   const previousRowKeyRef = useRef(rowKey);
+  const [mountedActionRowKey, setMountedActionRowKey] = useState<string | null>(null);
+  const actionsMounted = mountedActionRowKey === rowKey;
+
+  const stopActionAnimation = useCallback(() => {
+    armedRef.current = false;
+    armedProgress.stopAnimation();
+    armedProgress.setValue(0);
+  }, [armedProgress]);
 
   // Project child windowing reuses a small pool of native swipe rows. When a
   // slot starts representing another session, clear the previous gesture
@@ -116,45 +121,78 @@ function SwipeableSessionRowInner({
     if (previousRowKeyRef.current === rowKey) return;
     methodsRef.current?.reset();
     translationRef.current = null;
+    latestTranslationRef.current = 0;
+    stopActionAnimation();
+    setMountedActionRowKey(null);
     previousRowKeyRef.current = rowKey;
-  }, [rowKey]);
+  }, [rowKey, stopActionAnimation]);
 
   // 行卸载(归档/删除后随数据消失、列表虚拟化回收)时注销;registry 内部只清
   // 「当前记录仍是自己」的条目,不会误伤已经接管的新行。
   useEffect(() => () => {
+    armedProgress.stopAnimation();
     registry.onRowClose(rowKey);
-  }, [registry, rowKey]);
+  }, [armedProgress, registry, rowKey]);
 
   const close = useCallback(() => {
     methodsRef.current?.close();
   }, []);
 
   const handleOpenStartDrag = useCallback(() => {
+    stopActionAnimation();
+    // The fixed shells are measured on the initial row mount. Only the one active
+    // row pays for both action trees, which also keeps direction reversal during
+    // the same gesture from revealing an empty panel.
+    setMountedActionRowKey(rowKey);
     registry.onRowOpen(rowKey, close);
-  }, [registry, rowKey, close]);
+  }, [registry, rowKey, close, stopActionAnimation]);
 
   const handleClose = useCallback(() => {
+    latestTranslationRef.current = 0;
+    stopActionAnimation();
+    setMountedActionRowKey(null);
     registry.onRowClose(rowKey);
-  }, [registry, rowKey]);
+  }, [registry, rowKey, stopActionAnimation]);
 
-  // 全滑判定:松手瞬间(库在 release 时派发 WillOpen)读当前位移,超阈值即触发。
-  // direction 语义:RIGHT = 右滑(露出左面板/置顶),LEFT = 左滑(露出右面板/归档)。
-  const handleWillOpen = useCallback((direction: (typeof SwipeDirection)[keyof typeof SwipeDirection]) => {
-    const translation = translationRef.current;
-    if (!translation) return;
-    if (direction === SwipeDirection.RIGHT) {
-      if (translation.value >= fullSwipeThreshold) {
-        // 置顶后行只重排不消失:先关再发,避免重排后行停在打开态。
-        close();
-        onTogglePin(session);
-      }
+  const handleTranslationValue = useCallback((value: number) => {
+    latestTranslationRef.current = value;
+    const nextArmed = -value >= fullSwipeThreshold;
+    if (nextArmed === armedRef.current) return;
+    armedRef.current = nextArmed;
+    Animated.timing(armedProgress, {
+      duration: ARM_ANIMATION_MS,
+      toValue: nextArmed ? 1 : 0,
+      useNativeDriver: true,
+    }).start();
+  }, [armedProgress, fullSwipeThreshold]);
+
+  const readReleaseTranslation = useCallback((): number => {
+    try {
+      const value = translationRef.current?.__getValue?.();
+      if (typeof value === 'number' && Number.isFinite(value)) return value;
+    } catch {
+      // Native Animated implementations may decline synchronous reads. The listener value
+      // remains a conservative fallback: missing a borderline full swipe is safer than
+      // archiving after the user crossed the threshold and then deliberately dragged back.
+    }
+    return latestTranslationRef.current;
+  }, []);
+
+  // 经典 Swipeable 的 direction 表示露出的 action 面板:left = 右滑露出左面板,
+  // right = 左滑露出右面板。
+  const handleWillOpen = useCallback((direction: ClassicSwipeDirection) => {
+    const releaseTranslation = readReleaseTranslation();
+    if (direction === 'left') {
+      if (releaseTranslation < fullSwipeThreshold) return;
+      // 置顶后行只重排不消失:先关再发,避免重排后行停在打开态。
+      close();
+      onTogglePin(session);
       return;
     }
-    if (-translation.value >= fullSwipeThreshold) {
-      // 归档刻意不先关:乐观更新立即把行移出列表(卸载即收行);失败由页面层回滚 + Alert 收口。
-      onArchive(session);
-    }
-  }, [fullSwipeThreshold, close, onTogglePin, onArchive, session]);
+    if (-releaseTranslation < fullSwipeThreshold) return;
+    // 归档刻意不先关:乐观更新立即把行移出列表(卸载即收行);失败由页面层回滚 + Alert 收口。
+    onArchive(session);
+  }, [fullSwipeThreshold, close, onTogglePin, onArchive, readReleaseTranslation, session]);
 
   const handlePinPress = useCallback(() => {
     close();
@@ -174,41 +212,72 @@ function SwipeableSessionRowInner({
   const pinLabel = pinToggleAction(pinnedAt).label;
 
   const renderLeftActions = useCallback(
-    (_progress: SharedValue<number>, translation: SharedValue<number>) => {
-      translationRef.current = translation;
+    (_progress: SwipeTranslation, translation: SwipeTranslation) => {
+      translationRef.current = translation as ReadableSwipeTranslation;
       return (
-        <PinActionPanel
-          label={pinLabel}
-          onPress={handlePinPress}
-          pinned={pinned}
-          styles={styles}
-          testID={testID ? `${testID}.pinAction` : undefined}
-          translation={translation}
-        />
+        <View style={styles.pinShell}>
+          {actionsMounted ? (
+            <PinActionContent
+              label={pinLabel}
+              onTranslationValue={handleTranslationValue}
+              onPress={handlePinPress}
+              pinned={pinned}
+              styles={styles}
+              testID={testID ? `${testID}.pinAction` : undefined}
+              translation={translation}
+              windowWidth={windowWidth}
+            />
+          ) : null}
+        </View>
       );
     },
-    [pinLabel, pinned, handlePinPress, styles, testID],
+    [
+      handlePinPress,
+      handleTranslationValue,
+      actionsMounted,
+      pinLabel,
+      pinned,
+      styles,
+      testID,
+      windowWidth,
+    ],
   );
 
   const statusToggle = statusToggleAction(session.status);
 
   const renderRightActions = useCallback(
-    (_progress: SharedValue<number>, translation: SharedValue<number>) => {
-      translationRef.current = translation;
+    (_progress: SwipeTranslation, translation: SwipeTranslation) => {
+      translationRef.current = translation as ReadableSwipeTranslation;
       return (
-        <RightActionsPanel
-          archiveLabel={statusToggle.label}
-          archived={statusToggle.action === 'restore'}
-          fullSwipeThreshold={fullSwipeThreshold}
-          onArchive={handleArchivePress}
-          onOptions={handleOptionsPress}
-          styles={styles}
-          testID={testID}
-          translation={translation}
-        />
+        <View style={styles.rightShell}>
+          {actionsMounted ? (
+            <RightActionsContent
+              armedProgress={armedProgress}
+              archiveLabel={statusToggle.label}
+              archived={statusToggle.action === 'restore'}
+              onArchive={handleArchivePress}
+              onOptions={handleOptionsPress}
+              onTranslationValue={handleTranslationValue}
+              styles={styles}
+              testID={testID}
+              translation={translation}
+              windowWidth={windowWidth}
+            />
+          ) : null}
+        </View>
       );
     },
-    [statusToggle, fullSwipeThreshold, handleArchivePress, handleOptionsPress, styles, testID],
+    [
+      armedProgress,
+      handleArchivePress,
+      handleOptionsPress,
+      handleTranslationValue,
+      actionsMounted,
+      statusToggle,
+      styles,
+      testID,
+      windowWidth,
+    ],
   );
 
   return (
@@ -229,126 +298,158 @@ function SwipeableSessionRowInner({
 }
 
 /**
- * 右滑露出的「置顶」浮块:定宽壳决定 snap 位;按钮绝对定位、随露出进度淡入 + 微缩放
- * 弹入;overshoot / 全滑时按钮保持圆角横向拉伸(宽度 = 位移 - 两侧 gap),图标钉在
- * 行边缘一侧跟手(iOS Mail 同款)。
+ * 右滑露出的「置顶」浮块:定宽壳决定 snap 位;按钮绝对定位;overshoot / 全滑时
+ * 背景用 native-driver transform 拉成长胶囊,图标跟着行边缘移动。经典 Animated
+ * 不经过 Reanimated synchronouslyUpdateUIProps,列表批量卸载时不会追写失效 Fabric tag。
  */
-function PinActionPanel({
+function PinActionContent({
   label,
+  onTranslationValue,
   onPress,
   pinned,
   styles,
   testID,
   translation,
+  windowWidth,
 }: {
   label: string;
+  onTranslationValue(value: number): void;
   onPress(): void;
   pinned: boolean;
   styles: SwipeStyles;
   testID?: string;
-  translation: SharedValue<number>;
+  translation: SwipeTranslation;
+  windowWidth: number;
 }) {
   const { colors } = useTheme();
-  const buttonStyle = useAnimatedStyle(() => {
-    const revealed = Math.max(0, translation.value);
-    const progress = Math.min(1, revealed / LEFT_PANEL_WIDTH);
-    return {
-      opacity: interpolate(progress, [0.15, 0.7], [0, 1], 'clamp'),
-      transform: [{ scale: interpolate(progress, [0.15, 1], [0.5, 1], 'clamp') }],
-      // 静置是正圆;继续拖动从圆拉长成胶囊(radius.pill 让圆角恒为半高)。
-      width: Math.max(BUTTON_SIZE, revealed - BUTTON_GAP * 2),
-    };
+  const opacity = translation.interpolate({
+    extrapolate: 'clamp',
+    inputRange: [LEFT_PANEL_WIDTH * 0.15, LEFT_PANEL_WIDTH * 0.7],
+    outputRange: [0, 1],
   });
+  const scale = translation.interpolate({
+    extrapolate: 'clamp',
+    inputRange: [LEFT_PANEL_WIDTH * 0.15, LEFT_PANEL_WIDTH],
+    outputRange: [0.5, 1],
+  });
+  const extension = translation.interpolate({
+    extrapolate: 'clamp',
+    inputRange: [LEFT_PANEL_WIDTH, Math.max(LEFT_PANEL_WIDTH + 1, windowWidth)],
+    outputRange: [0, Math.max(0, windowWidth - LEFT_PANEL_WIDTH)],
+  });
+  const backgroundScaleX = Animated.add(1, Animated.divide(extension, BUTTON_SIZE));
+  const halfExtension = Animated.divide(extension, 2);
   const IconComponent = pinned ? PinOff : Pin;
   return (
-    <View style={styles.pinShell}>
-      <Animated.View style={[styles.pinButton, buttonStyle]}>
-        <Pressable
-          accessibilityLabel={label}
-          accessibilityRole="button"
-          onPress={onPress}
-          style={styles.actionPressable}
-          testID={testID}
-        >
-          <View style={styles.pinIconWrap}>
+    <>
+      <TranslationObserver onValue={onTranslationValue} translation={translation} />
+      <Animated.View style={[styles.pinButton, { opacity, transform: [{ scale }] }]}>
+        <Animated.View
+          pointerEvents="none"
+          style={[
+            styles.pinButtonBackground,
+            { transform: [{ translateX: halfExtension }, { scaleX: backgroundScaleX }] },
+          ]}
+        />
+        <Animated.View style={[styles.actionPressableFrame, { transform: [{ translateX: extension }] }]}>
+          <Pressable
+            accessibilityLabel={label}
+            accessibilityRole="button"
+            onPress={onPress}
+            style={styles.actionPressable}
+            testID={testID}
+          >
+            <View style={styles.actionIconWrap}>
             <IconComponent color={colors.swipeActionText} size={ICON_SIZE} strokeWidth={iconStroke.regular} />
-          </View>
-        </Pressable>
+            </View>
+          </Pressable>
+        </Animated.View>
       </Animated.View>
-    </View>
+    </>
   );
 }
 
 /**
- * 左滑露出的「选项 + 归档」浮块:定宽壳(152)决定 snap 位;两块绝对定位锚右缘,
- * 随露出进度错峰淡入(靠屏缘的「归档」先现身);overshoot 时「选项」跟着行边缘
- * 外扩保持贴行间距;越过全滑阈值「归档」150ms 拉伸盖满(预告松手即归档)、「选项」淡出。
+ * 左滑露出的「选项 + 归档」浮块:定宽壳决定 snap 位;两块绝对定位锚右缘。
+ * overshoot 时「选项」跟着行边缘外扩;越过全滑阈值后「归档」用 transform
+ * 拉伸盖满露出区。所有跟手属性均可由 RN Animated native driver 执行。
  */
-function RightActionsPanel({
+function RightActionsContent({
+  armedProgress,
   archiveLabel,
   archived,
-  fullSwipeThreshold,
   onArchive,
   onOptions,
+  onTranslationValue,
   styles,
   testID,
   translation,
+  windowWidth,
 }: {
+  armedProgress: Animated.Value;
   archiveLabel: string;
   archived: boolean;
-  fullSwipeThreshold: number;
   onArchive(): void;
   onOptions(): void;
+  onTranslationValue(value: number): void;
   styles: SwipeStyles;
   testID?: string;
-  translation: SharedValue<number>;
+  translation: SwipeTranslation;
+  windowWidth: number;
 }) {
   const { colors } = useTheme();
   const { t } = useTranslation();
   const StatusIcon = archived ? ArchiveRestore : Archive;
-  // 挂载时同步落初值,只在真正跨越阈值时启动 timing。若每个面板挂载都执行
-  // withTiming(0),大项目从完整首帧切到窗口行时会留下仍在更新已卸载 Fabric tag
-  // 的空动画,最终用 Reanimated 警告栈堵住 Android 主线程。
-  const armedProgress = useSharedValue(0);
-  useAnimatedReaction(
-    () => -translation.value >= fullSwipeThreshold,
-    (next, previous) => {
-      if (previous === null) {
-        armedProgress.value = next ? 1 : 0;
-        return;
-      }
-      if (next !== previous) {
-        armedProgress.value = withTiming(next ? 1 : 0, { duration: ARM_ANIMATION_MS });
-      }
-    },
+  const revealed = Animated.multiply(translation, -1);
+  const optionsOpacity = Animated.multiply(
+    revealed.interpolate({
+      extrapolate: 'clamp',
+      inputRange: [RIGHT_PANEL_WIDTH * 0.3, RIGHT_PANEL_WIDTH * 0.8],
+      outputRange: [0, 1],
+    }),
+    Animated.subtract(1, armedProgress),
   );
-
-  const optionsStyle = useAnimatedStyle(() => {
-    const revealed = Math.max(0, -translation.value);
-    const progress = Math.min(1, revealed / RIGHT_PANEL_WIDTH);
-    return {
-      // 错峰弹入(靠内的「选项」后现身);armed 时淡出让位给拉伸的「归档」。
-      opacity: interpolate(progress, [0.3, 0.8], [0, 1], 'clamp') * (1 - armedProgress.value),
-      // overshoot(revealed > 面板宽)时跟着行边缘外扩,保持「贴着行」的间距不脱节。
-      right: Math.max(BUTTON_GAP * 2 + BUTTON_SIZE, revealed - BUTTON_SIZE - BUTTON_GAP),
-      transform: [{ scale: interpolate(progress, [0.3, 1], [0.5, 1], 'clamp') }],
-    };
+  const optionsScale = revealed.interpolate({
+    extrapolate: 'clamp',
+    inputRange: [RIGHT_PANEL_WIDTH * 0.3, RIGHT_PANEL_WIDTH],
+    outputRange: [0.5, 1],
   });
-  const archiveStyle = useAnimatedStyle(() => {
-    const revealed = Math.max(0, -translation.value);
-    const progress = Math.min(1, revealed / RIGHT_PANEL_WIDTH);
-    return {
-      opacity: interpolate(progress, [0.08, 0.45], [0, 1], 'clamp'),
-      transform: [{ scale: interpolate(progress, [0.08, 0.6], [0.5, 1], 'clamp') }],
-      // armed 时从正圆拉长成胶囊铺满整个露出区(保留两侧 gap),盖过「选项」。
-      width: BUTTON_SIZE
-        + Math.max(0, revealed - BUTTON_GAP * 2 - BUTTON_SIZE) * armedProgress.value,
-    };
+  const optionsExtension = revealed.interpolate({
+    extrapolate: 'clamp',
+    inputRange: [RIGHT_PANEL_WIDTH, Math.max(RIGHT_PANEL_WIDTH + 1, windowWidth)],
+    outputRange: [0, Math.max(0, windowWidth - RIGHT_PANEL_WIDTH)],
   });
+  const archiveOpacity = revealed.interpolate({
+    extrapolate: 'clamp',
+    inputRange: [RIGHT_PANEL_WIDTH * 0.08, RIGHT_PANEL_WIDTH * 0.45],
+    outputRange: [0, 1],
+  });
+  const archiveScale = revealed.interpolate({
+    extrapolate: 'clamp',
+    inputRange: [RIGHT_PANEL_WIDTH * 0.08, RIGHT_PANEL_WIDTH * 0.6],
+    outputRange: [0.5, 1],
+  });
+  const archiveStretchStart = BUTTON_GAP * 2 + BUTTON_SIZE;
+  const availableArchiveExtension = revealed.interpolate({
+    extrapolate: 'clamp',
+    inputRange: [archiveStretchStart, Math.max(archiveStretchStart + 1, windowWidth)],
+    outputRange: [0, Math.max(0, windowWidth - archiveStretchStart)],
+  });
+  const archiveExtension = Animated.multiply(availableArchiveExtension, armedProgress);
+  const archiveScaleX = Animated.add(1, Animated.divide(archiveExtension, BUTTON_SIZE));
+  const negativeOptionsExtension = Animated.multiply(optionsExtension, -1);
+  const negativeArchiveExtension = Animated.multiply(archiveExtension, -1);
+  const negativeHalfArchiveExtension = Animated.divide(negativeArchiveExtension, 2);
 
   return (
-    <View style={styles.rightShell}>
-      <Animated.View style={[styles.optionsButton, optionsStyle]}>
+    <>
+      <TranslationObserver onValue={onTranslationValue} translation={translation} />
+      <Animated.View
+        style={[
+          styles.optionsButton,
+          { opacity: optionsOpacity, transform: [{ translateX: negativeOptionsExtension }, { scale: optionsScale }] },
+        ]}
+      >
         <Pressable
           accessibilityLabel={t('session.row.moreOptions')}
           accessibilityRole="button"
@@ -356,26 +457,49 @@ function RightActionsPanel({
           style={styles.actionPressable}
           testID={testID ? `${testID}.optionsAction` : undefined}
         >
-          <View style={styles.rightIconWrap}>
+          <View style={styles.actionIconWrap}>
             <Ellipsis color={colors.swipeActionText} size={ICON_SIZE} strokeWidth={iconStroke.regular} />
           </View>
         </Pressable>
       </Animated.View>
-      <Animated.View style={[styles.archiveButton, archiveStyle]}>
-        <Pressable
-          accessibilityLabel={archiveLabel}
-          accessibilityRole="button"
-          onPress={onArchive}
-          style={styles.actionPressable}
-          testID={testID ? `${testID}.archiveAction` : undefined}
-        >
-          <View style={styles.rightIconWrap}>
-            <StatusIcon color={colors.swipeActionText} size={ICON_SIZE} strokeWidth={iconStroke.regular} />
-          </View>
-        </Pressable>
+      <Animated.View style={[styles.archiveButton, { opacity: archiveOpacity, transform: [{ scale: archiveScale }] }]}>
+        <Animated.View
+          pointerEvents="none"
+          style={[
+            styles.archiveButtonBackground,
+            { transform: [{ translateX: negativeHalfArchiveExtension }, { scaleX: archiveScaleX }] },
+          ]}
+        />
+        <Animated.View style={[styles.actionPressableFrame, { transform: [{ translateX: negativeArchiveExtension }] }]}>
+          <Pressable
+            accessibilityLabel={archiveLabel}
+            accessibilityRole="button"
+            onPress={onArchive}
+            style={styles.actionPressable}
+            testID={testID ? `${testID}.archiveAction` : undefined}
+          >
+            <View style={styles.actionIconWrap}>
+              <StatusIcon color={colors.swipeActionText} size={ICON_SIZE} strokeWidth={iconStroke.regular} />
+            </View>
+          </Pressable>
+        </Animated.View>
       </Animated.View>
-    </View>
+    </>
   );
+}
+
+function TranslationObserver({
+  onValue,
+  translation,
+}: {
+  onValue(value: number): void;
+  translation: SwipeTranslation;
+}) {
+  useEffect(() => {
+    const listenerId = translation.addListener(({ value }) => onValue(value));
+    return () => translation.removeListener(listenerId);
+  }, [onValue, translation]);
+  return null;
 }
 
 type SwipeStyles = ReturnType<typeof makeStyles>;
@@ -388,26 +512,23 @@ const makeStyles = (colors: ThemeColors) => StyleSheet.create({
     width: LEFT_PANEL_WIDTH,
   },
   pinButton: {
-    backgroundColor: colors.swipeActionPin,
-    // radius.pill:正圆起步,拉长后自动变胶囊(圆角恒为半高),iOS 26 同款。
-    borderRadius: radius.pill,
     height: BUTTON_SIZE,
     left: BUTTON_GAP,
     // 行高内垂直居中(面板 wrapper 与行等高):50% 锚点 + 负半径回拉,不写死行高。
     marginTop: -BUTTON_SIZE / 2,
-    overflow: 'hidden',
+    overflow: 'visible',
     position: 'absolute',
     top: '50%',
+    width: BUTTON_SIZE,
   },
-  pinIconWrap: {
-    // 图标钉在按钮尾缘(紧贴行内容边缘),按钮拉长成胶囊时图标跟着行走(iOS Mail 同款)。
-    alignItems: 'center',
+  pinButtonBackground: {
+    backgroundColor: colors.swipeActionPin,
+    borderRadius: radius.pill,
     bottom: 0,
-    justifyContent: 'center',
+    left: 0,
     position: 'absolute',
     right: 0,
     top: 0,
-    width: BUTTON_SIZE,
   },
   rightShell: {
     overflow: 'visible',
@@ -424,24 +545,34 @@ const makeStyles = (colors: ThemeColors) => StyleSheet.create({
     width: BUTTON_SIZE,
   },
   archiveButton: {
-    backgroundColor: colors.swipeActionArchive,
-    borderRadius: radius.pill,
     height: BUTTON_SIZE,
     marginTop: -BUTTON_SIZE / 2,
-    overflow: 'hidden',
+    overflow: 'visible',
     position: 'absolute',
     right: BUTTON_GAP,
     top: '50%',
+    width: BUTTON_SIZE,
   },
-  rightIconWrap: {
-    // 图标钉在按钮首缘(紧贴行内容一侧):归档拉伸盖满时图标不跳中心,停在行边附近。
-    alignItems: 'center',
+  archiveButtonBackground: {
+    backgroundColor: colors.swipeActionArchive,
+    borderRadius: radius.pill,
     bottom: 0,
-    justifyContent: 'center',
     left: 0,
     position: 'absolute',
+    right: 0,
     top: 0,
-    width: BUTTON_SIZE,
+  },
+  actionPressableFrame: {
+    bottom: 0,
+    left: 0,
+    position: 'absolute',
+    right: 0,
+    top: 0,
+  },
+  actionIconWrap: {
+    alignItems: 'center',
+    flex: 1,
+    justifyContent: 'center',
   },
   actionPressable: {
     flex: 1,

--- a/apps/mobile/src/session/expandedBlockMemory.ts
+++ b/apps/mobile/src/session/expandedBlockMemory.ts
@@ -39,8 +39,8 @@ export function useFoldableExpandedState(
 ): [boolean, () => void] {
   const [localExpanded, setLocalExpanded] = useState(defaultExpanded);
   const subscribe = useCallback(
-    (listener: () => void) => store.subscribe(listener),
-    [],
+    (listener: () => void) => (blockId ? store.subscribe(listener) : () => {}),
+    [blockId],
   );
   const rememberedExpanded = useSyncExternalStore(
     subscribe,

--- a/apps/mobile/src/session/homeProjectChildWindow.ts
+++ b/apps/mobile/src/session/homeProjectChildWindow.ts
@@ -1,0 +1,63 @@
+export interface HomeProjectChildWindowRange {
+  end: number;
+  leadingSpacerHeight: number;
+  start: number;
+  trailingSpacerHeight: number;
+}
+
+/**
+ * Builds stable child offsets for a project block. Keeping the full height in
+ * spacers lets the outer SectionList preserve exactly the same layout while
+ * only mounting the nearby rows.
+ */
+export function buildHomeProjectChildOffsets(rowHeights: readonly number[]): number[] {
+  const offsets = [0];
+  for (const height of rowHeights) {
+    const safeHeight = Number.isFinite(height) && height > 0 ? height : 0;
+    offsets.push(offsets[offsets.length - 1] + safeHeight);
+  }
+  return offsets;
+}
+
+/** Returns the child containing the supplied offset, using O(log n) lookup. */
+export function findHomeProjectChildIndex(
+  childOffsets: readonly number[],
+  relativeOffset: number,
+): number {
+  'worklet';
+  const itemCount = Math.max(0, childOffsets.length - 1);
+  if (itemCount === 0) return 0;
+  const target = Math.max(0, relativeOffset);
+  let low = 0;
+  let high = itemCount - 1;
+  while (low < high) {
+    const middle = Math.floor((low + high) / 2);
+    if (childOffsets[middle + 1] <= target) low = middle + 1;
+    else high = middle;
+  }
+  return low;
+}
+
+export function resolveHomeProjectChildWindow(input: {
+  anchor: number;
+  childOffsets: readonly number[];
+  overscan: number;
+  windowSize: number;
+}): HomeProjectChildWindowRange {
+  const itemCount = Math.max(0, input.childOffsets.length - 1);
+  if (itemCount === 0) {
+    return { end: 0, leadingSpacerHeight: 0, start: 0, trailingSpacerHeight: 0 };
+  }
+  const overscan = Math.max(0, Math.floor(input.overscan));
+  const windowSize = Math.max(1, Math.floor(input.windowSize));
+  const maxStart = Math.max(0, itemCount - windowSize);
+  const start = Math.max(0, Math.min(maxStart, Math.floor(input.anchor) - overscan));
+  const end = Math.min(itemCount, start + windowSize + overscan * 2);
+  const totalHeight = input.childOffsets[itemCount] ?? 0;
+  return {
+    end,
+    leadingSpacerHeight: input.childOffsets[start] ?? 0,
+    start,
+    trailingSpacerHeight: Math.max(0, totalHeight - (input.childOffsets[end] ?? totalHeight)),
+  };
+}

--- a/apps/mobile/src/session/homeProjectChildWindow.ts
+++ b/apps/mobile/src/session/homeProjectChildWindow.ts
@@ -5,6 +5,17 @@ export interface HomeProjectChildWindowRange {
   trailingSpacerHeight: number;
 }
 
+export function shouldWindowHomeProjectChildren(input: {
+  collapsed: boolean;
+  itemCount: number;
+  scrollTrackingAvailable: boolean;
+  threshold: number;
+}): boolean {
+  return input.scrollTrackingAvailable
+    && !input.collapsed
+    && input.itemCount > Math.max(0, Math.floor(input.threshold));
+}
+
 /**
  * Builds stable child offsets for a project block. Keeping the full height in
  * spacers lets the outer SectionList preserve exactly the same layout while
@@ -36,6 +47,34 @@ export function findHomeProjectChildIndex(
     else high = middle;
   }
   return low;
+}
+
+/**
+ * Keeps a large nested group as a spacer until its child area intersects the
+ * viewport. This prevents an off-screen folder header from eagerly mounting a
+ * complete child window during a grouping-mode switch.
+ */
+export function resolveHomeProjectChildAnchor(input: {
+  childOffsets: readonly number[];
+  projectHeaderHeight: number;
+  projectTop: number;
+  shift: number;
+  viewportHeight: number;
+  viewportTop: number;
+}): number {
+  'worklet';
+  const childContentHeight = Math.max(0, input.childOffsets[input.childOffsets.length - 1] ?? 0);
+  const childTop = input.projectTop + Math.max(0, input.projectHeaderHeight);
+  const childBottom = childTop + childContentHeight;
+  const viewportTop = Math.max(0, input.viewportTop);
+  const viewportBottom = viewportTop + Math.max(0, input.viewportHeight);
+  if (childContentHeight === 0 || childTop >= viewportBottom || childBottom <= viewportTop) {
+    return -1;
+  }
+  const shift = Math.max(1, Math.floor(input.shift));
+  const relativeY = Math.max(0, viewportTop - childTop);
+  const visibleIndex = findHomeProjectChildIndex(input.childOffsets, relativeY);
+  return Math.floor(visibleIndex / shift) * shift;
 }
 
 export function resolveHomeProjectChildWindow(input: {

--- a/apps/mobile/src/session/homeSections.ts
+++ b/apps/mobile/src/session/homeSections.ts
@@ -30,6 +30,9 @@ export type HomeRow =
 /** SectionList 的一个分区。title 为 null 的分区不渲染表头。 */
 export type HomeSection = { data: HomeRow[]; key: string; title: string | null };
 
+/** 主列表分区跨分组模式保持同一身份，避免 SectionList 把仍存在的行整批卸载重挂。 */
+export const HOME_MAIN_SECTION_KEY = 'main';
+
 export interface HomeSectionOptions {
   groupDialogue?: boolean;
   sortBy?: HomeListSortBy;
@@ -69,7 +72,7 @@ export function buildHomeSections(
   if (rows.length > 0) {
     sections.push({
       data: rows,
-      key: groupByProject ? 'grouped' : 'mixed',
+      key: HOME_MAIN_SECTION_KEY,
       title: null,
     });
   }
@@ -99,6 +102,48 @@ export function homeRowBefore(
 
 export function isFolderHomeRow(row: HomeRow | undefined): row is Extract<HomeRow, { kind: 'project' | 'dialogue' }> {
   return !!row && (row.kind === 'project' || row.kind === 'dialogue');
+}
+
+/**
+ * Fast path for folder rows rebuilt from the same home presentation. Switching
+ * grouping modes sorts into fresh arrays, but the session items themselves are
+ * still the same objects. Recognizing that case keeps HomeListRow from
+ * serializing a large project/dialogue tree just to prove it did not change.
+ */
+export function homeFolderRowsShareRenderData(previous: HomeRow, next: HomeRow): boolean {
+  if (Object.is(previous, next)) return true;
+  if (!isFolderHomeRow(previous) || !isFolderHomeRow(next)) return false;
+  if (previous.kind !== next.kind || previous.key !== next.key) return false;
+  const a = previous.project;
+  const b = next.project;
+  return a.deviceId === b.deviceId
+    && a.deviceName === b.deviceName
+    && a.key === b.key
+    && a.latestActivityAt === b.latestActivityAt
+    && a.pendingInteractionCount === b.pendingInteractionCount
+    && a.sessionCount === b.sessionCount
+    && a.subtitle === b.subtitle
+    && a.title === b.title
+    && a.workingDir === b.workingDir
+    && a.sessions.length === b.sessions.length
+    && a.sessions.every((item, index) => item === b.sessions[index]);
+}
+
+/**
+ * Recognizes rebuilt row wrappers that still describe the exact same rendered
+ * data. buildHomeSections creates fresh wrappers whenever a display preference
+ * changes; session rows can use the same reference fast path as folder rows
+ * instead of serializing the complete RemoteSessionListItem for comparison.
+ */
+export function homeRowsShareRenderData(previous: HomeRow, next: HomeRow): boolean {
+  if (Object.is(previous, next)) return true;
+  if (previous.kind === 'session' && next.kind === 'session') {
+    return previous.key === next.key
+      && previous.source === next.source
+      && previous.sourceLabel === next.sourceLabel
+      && previous.item === next.item;
+  }
+  return homeFolderRowsShareRenderData(previous, next);
 }
 
 export function buildProjectHomeRows(

--- a/apps/mobile/src/session/mathWebView.tsx
+++ b/apps/mobile/src/session/mathWebView.tsx
@@ -1,7 +1,8 @@
-import { useCallback, useMemo, useRef, useState } from 'react';
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { StyleSheet, View } from 'react-native';
 import { WebView, type WebViewMessageEvent } from 'react-native-webview';
 import { buildMathWebViewHtml } from '@/session/mathWebViewHtml';
+import { registerMobileMessageWebView } from '@/session/mobileMessageWebViewMetrics';
 import { useTheme, useThemedStyles, type ThemeColors } from '@/theme';
 import { radius } from '@/theme/tokens';
 
@@ -39,31 +40,57 @@ function rememberMeasuredHeight(source: string, height: number): void {
  * (稳定性约束见上方常量注释,改动前先理解闪动循环的成因)。
  */
 export function MathFormulaWebView({
+  active = true,
   source,
   testID,
 }: {
+  active?: boolean;
   source: string;
   testID?: string;
 }) {
   const styles = useThemedStyles(makeStyles);
   const { colors } = useTheme();
+  const renderIdentityRef = useRef({ active, source });
+  const renderGenerationRef = useRef(0);
+  if (
+    renderIdentityRef.current.active !== active
+    || renderIdentityRef.current.source !== source
+  ) {
+    renderIdentityRef.current = { active, source };
+    renderGenerationRef.current += 1;
+  }
+  const renderGeneration = renderGenerationRef.current;
   const [height, setHeight] = useState(
     () => measuredHeightCache.get(source) ?? MATH_WEBVIEW_DEFAULT_HEIGHT,
   );
   const heightRef = useRef(height);
+  const katexHeightAppliedRef = useRef(false);
+  useEffect(() => {
+    const cachedHeight = measuredHeightCache.get(source);
+    const nextHeight = cachedHeight ?? MATH_WEBVIEW_DEFAULT_HEIGHT;
+    katexHeightAppliedRef.current = cachedHeight !== undefined;
+    heightRef.current = nextHeight;
+    setHeight((current) => current === nextHeight ? current : nextHeight);
+  }, [source]);
+  useEffect(() => {
+    if (!active) return undefined;
+    return registerMobileMessageWebView('math');
+  }, [active]);
   const html = useMemo(
     () =>
-      buildMathWebViewHtml(source, {
-        background: colors.surface,
-        textPrimary: colors.textPrimary,
-        textSecondary: colors.textSecondary,
-      }),
-    [colors.surface, colors.textPrimary, colors.textSecondary, source],
+      active
+        ? buildMathWebViewHtml(source, {
+            background: colors.surface,
+            textPrimary: colors.textPrimary,
+            textSecondary: colors.textSecondary,
+          })
+        : '',
+    [active, colors.surface, colors.textPrimary, colors.textSecondary, source],
   );
   // 本次挂载是否已应用过 KaTeX 最终态高度:应用过之后,迟到的过渡态上报
   // (乱序消息)不允许再把高度拉回去。
-  const katexHeightAppliedRef = useRef(false);
   const onMessage = useCallback((event: WebViewMessageEvent) => {
+    if (!active || renderGenerationRef.current !== renderGeneration) return;
     // 消息门:只认页面脚本上报的 math-height 形态,其它一律忽略
     // (WebView 消息通道是不可信输入,不做任何超出高度设置的行为)。
     try {
@@ -97,10 +124,10 @@ export function MathFormulaWebView({
     } catch {
       // 非 JSON 消息不属于本组件协议,忽略。
     }
-  }, [source]);
+  }, [active, renderGeneration, source]);
   return (
-    <View style={styles.container} testID={testID}>
-      <WebView
+    <View style={[styles.container, { height }]} testID={testID}>
+      {active ? <WebView
         automaticallyAdjustContentInsets={false}
         javaScriptEnabled
         nestedScrollEnabled
@@ -115,7 +142,7 @@ export function MathFormulaWebView({
         // backgroundColor transparent → RNW 关掉 WKWebView 的 opaque,首帧
         // 提交前透出容器的 surface 底色,消掉默认白底闪一下的空白帧(规则 7)。
         style={[styles.webView, { height }]}
-      />
+      /> : null}
     </View>
   );
 }

--- a/apps/mobile/src/session/mediaPlayerWebView.tsx
+++ b/apps/mobile/src/session/mediaPlayerWebView.tsx
@@ -8,6 +8,7 @@ import {
   type MobileMediaPlayerKind,
   type MobileMediaPlayerStatus,
 } from '@/session/mediaPlayerWebViewHtml';
+import { registerMobileMessageWebView } from '@/session/mobileMessageWebViewMetrics';
 import { useTheme } from '@/theme';
 
 export function RemoteMediaPlayerWebView({
@@ -29,25 +30,40 @@ export function RemoteMediaPlayerWebView({
 }) {
   const { colors } = useTheme();
   const webViewRef = useRef<ComponentRef<typeof WebView>>(null);
+  const mountedRef = useRef(true);
+  useEffect(() => registerMobileMessageWebView('media'), []);
   const pausePlayback = useCallback(() => {
     webViewRef.current?.postMessage(buildMediaPlayerWebViewCommand('pause'));
   }, []);
-
-  useEffect(() => {
-    const subscription = AppState.addEventListener('change', state => {
-      if (state !== 'active') pausePlayback();
-    });
-    return () => subscription.remove();
+  const stopPlaybackAndLoading = useCallback(() => {
+    pausePlayback();
+    webViewRef.current?.stopLoading();
   }, [pausePlayback]);
 
   useEffect(() => {
-    return pausePlayback;
-  }, [kind, pausePlayback, url]);
+    const subscription = AppState.addEventListener('change', state => {
+      if (state !== 'active') stopPlaybackAndLoading();
+    });
+    return () => {
+      subscription.remove();
+      stopPlaybackAndLoading();
+    };
+  }, [stopPlaybackAndLoading]);
 
-  const handleMessage = (event: WebViewMessageEvent) => {
+  useEffect(() => {
+    return stopPlaybackAndLoading;
+  }, [kind, stopPlaybackAndLoading, url]);
+
+  useEffect(() => () => {
+    mountedRef.current = false;
+    stopPlaybackAndLoading();
+  }, [stopPlaybackAndLoading]);
+
+  const handleMessage = useCallback((event: WebViewMessageEvent) => {
+    if (!mountedRef.current) return;
     const status = parseMediaPlayerWebViewMessage(event.nativeEvent.data);
     if (status) onStatusChange?.(status);
-  };
+  }, [onStatusChange]);
 
   return (
     <View style={style} testID={testID}>

--- a/apps/mobile/src/session/mediaPlayerWebView.tsx
+++ b/apps/mobile/src/session/mediaPlayerWebView.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useRef, type ComponentRef } from 'react';
+import { useCallback, useEffect, useRef, useState, type ComponentRef } from 'react';
 import { AppState, View, type StyleProp, type ViewStyle } from 'react-native';
 import { WebView, type WebViewMessageEvent } from 'react-native-webview';
 import {
@@ -8,6 +8,7 @@ import {
   type MobileMediaPlayerKind,
   type MobileMediaPlayerStatus,
 } from '@/session/mediaPlayerWebViewHtml';
+import { createMediaPlayerWebViewLifecycle } from '@/session/mediaPlayerWebViewLifecycle';
 import { registerMobileMessageWebView } from '@/session/mobileMessageWebViewMetrics';
 import { useTheme } from '@/theme';
 
@@ -30,7 +31,9 @@ export function RemoteMediaPlayerWebView({
 }) {
   const { colors } = useTheme();
   const webViewRef = useRef<ComponentRef<typeof WebView>>(null);
+  const lifecycleRef = useRef(createMediaPlayerWebViewLifecycle());
   const mountedRef = useRef(true);
+  const [reloadGeneration, setReloadGeneration] = useState(0);
   useEffect(() => registerMobileMessageWebView('media'), []);
   const pausePlayback = useCallback(() => {
     webViewRef.current?.postMessage(buildMediaPlayerWebViewCommand('pause'));
@@ -42,7 +45,14 @@ export function RemoteMediaPlayerWebView({
 
   useEffect(() => {
     const subscription = AppState.addEventListener('change', state => {
-      if (state !== 'active') stopPlaybackAndLoading();
+      if (state !== 'active') {
+        lifecycleRef.current.onBackground();
+        stopPlaybackAndLoading();
+        return;
+      }
+      if (lifecycleRef.current.consumeReloadOnActive()) {
+        setReloadGeneration(generation => generation + 1);
+      }
     });
     return () => {
       subscription.remove();
@@ -54,9 +64,12 @@ export function RemoteMediaPlayerWebView({
     return stopPlaybackAndLoading;
   }, [kind, stopPlaybackAndLoading, url]);
 
-  useEffect(() => () => {
-    mountedRef.current = false;
-    stopPlaybackAndLoading();
+  useEffect(() => {
+    mountedRef.current = true;
+    return () => {
+      mountedRef.current = false;
+      stopPlaybackAndLoading();
+    };
   }, [stopPlaybackAndLoading]);
 
   const handleMessage = useCallback((event: WebViewMessageEvent) => {
@@ -68,10 +81,13 @@ export function RemoteMediaPlayerWebView({
   return (
     <View style={style} testID={testID}>
       <WebView
+        key={reloadGeneration}
         ref={webViewRef}
         allowsInlineMediaPlayback
         javaScriptEnabled
         mediaPlaybackRequiresUserAction={false}
+        onLoadEnd={lifecycleRef.current.onLoadEnd}
+        onLoadStart={lifecycleRef.current.onLoadStart}
         onMessage={handleMessage}
         originWhitelist={['*']}
         scrollEnabled={false}

--- a/apps/mobile/src/session/mediaPlayerWebViewLifecycle.ts
+++ b/apps/mobile/src/session/mediaPlayerWebViewLifecycle.ts
@@ -1,0 +1,22 @@
+export function createMediaPlayerWebViewLifecycle() {
+  let loading = true;
+  let reloadOnActive = false;
+
+  return {
+    onLoadStart() {
+      loading = true;
+    },
+    onLoadEnd() {
+      loading = false;
+    },
+    onBackground() {
+      reloadOnActive ||= loading;
+    },
+    consumeReloadOnActive() {
+      if (!reloadOnActive) return false;
+      reloadOnActive = false;
+      loading = true;
+      return true;
+    },
+  };
+}

--- a/apps/mobile/src/session/mermaidWebView.tsx
+++ b/apps/mobile/src/session/mermaidWebView.tsx
@@ -3,6 +3,7 @@ import { StyleSheet, View } from 'react-native';
 import { Directory, File, Paths } from 'expo-file-system';
 import { WebView, type WebViewMessageEvent } from 'react-native-webview';
 import { buildMermaidWebViewHtml } from '@/session/mermaidWebViewHtml';
+import { registerMobileMessageWebView } from '@/session/mobileMessageWebViewMetrics';
 import { useTheme, useThemedStyles, type ThemeColors } from '@/theme';
 import { radius } from '@/theme/tokens';
 
@@ -35,7 +36,9 @@ export const MermaidDiagramWebView = forwardRef<MermaidDiagramWebViewHandle, {
   testID?: string;
   /** true 时页面允许双指缩放(详情查看用;内联预览保持锁定)。 */
   zoomable?: boolean;
+  active?: boolean;
 }>(function MermaidDiagramWebView({
+  active = true,
   bare = false,
   deferSource = false,
   fill = false,
@@ -50,6 +53,11 @@ export const MermaidDiagramWebView = forwardRef<MermaidDiagramWebViewHandle, {
   // 导出任务信箱(id → promise 两端):按 id 配对回包,超时/卸载显式 reject。
   const pendingExportsRef = useRef(new Map<string, PendingExport>());
   const exportSeqRef = useRef(0);
+
+  useEffect(() => {
+    if (!active) return undefined;
+    return registerMobileMessageWebView('mermaid');
+  }, [active]);
 
   useImperativeHandle(ref, () => ({
     exportPng() {
@@ -80,6 +88,7 @@ export const MermaidDiagramWebView = forwardRef<MermaidDiagramWebViewHandle, {
   }), []);
 
   const handleMessage = useCallback((event: WebViewMessageEvent) => {
+    if (!active) return;
     let message: unknown;
     try {
       message = JSON.parse(event.nativeEvent.data);
@@ -103,7 +112,7 @@ export const MermaidDiagramWebView = forwardRef<MermaidDiagramWebViewHandle, {
     } else {
       pending.reject(new Error(typeof error === 'string' && error ? error : 'mermaid export failed'));
     }
-  }, []);
+  }, [active]);
 
   // 卸载时清空信箱:不兜底的话 exportPng promise 永不 settle。
   useEffect(() => () => {
@@ -112,13 +121,14 @@ export const MermaidDiagramWebView = forwardRef<MermaidDiagramWebViewHandle, {
       pending.reject(new Error('mermaid webview unmounted'));
     }
     pendingExportsRef.current.clear();
-  }, []);
+  }, [active, source]);
 
   // 构建完整 HTML 非平凡字符串工作——memo 掉,只有源码或主题变化才重建,
   // 父级无关重渲染不重付。
   const html = useMemo(
-    () =>
-      buildMermaidWebViewHtml(source, {
+    () => {
+      if (!active) return '';
+      return buildMermaidWebViewHtml(source, {
         surfaceChip: colors.surfaceChip,
         textPrimary: colors.textPrimary,
         textSecondary: colors.textSecondary,
@@ -126,8 +136,9 @@ export const MermaidDiagramWebView = forwardRef<MermaidDiagramWebViewHandle, {
         dark: mode === 'dark',
         deferSource,
         zoomable,
-      }),
-    [source, colors.surfaceChip, colors.textPrimary, colors.textSecondary, colors.textTertiary, mode, deferSource, zoomable],
+      });
+    },
+    [active, source, colors.surfaceChip, colors.textPrimary, colors.textSecondary, colors.textTertiary, mode, deferSource, zoomable],
   );
   return (
     // 尺寸必须钉在容器上(height 或 flex:1)、WebView 用 flex:1 填满:
@@ -142,7 +153,7 @@ export const MermaidDiagramWebView = forwardRef<MermaidDiagramWebViewHandle, {
       ]}
       testID={testID}
     >
-      <WebView
+      {active ? <WebView
         automaticallyAdjustContentInsets={false}
         javaScriptEnabled
         nestedScrollEnabled
@@ -156,7 +167,7 @@ export const MermaidDiagramWebView = forwardRef<MermaidDiagramWebViewHandle, {
           baseUrl: 'https://xdt-maker-mobile.local',
         }}
         style={styles.webView}
-      />
+      /> : null}
     </View>
   );
 });

--- a/apps/mobile/src/session/messageHistoryAnchor.ts
+++ b/apps/mobile/src/session/messageHistoryAnchor.ts
@@ -1,0 +1,157 @@
+export interface MobileHistoryAnchor {
+  key: string;
+  /** Item top relative to the viewport top before older rows are prepended. */
+  viewportOffset: number;
+  /** Nearby rows captured at the same time, used if a live render group replaces the primary key. */
+  fallbacks?: readonly MobileHistoryAnchorCandidate[];
+}
+
+export interface MobileHistoryAnchorCandidate {
+  key: string;
+  viewportOffset: number;
+}
+
+export interface MobileHistoryAnchorCaptureState<ItemT> {
+  data: readonly ItemT[];
+  positionAtIndex(index: number): number | undefined;
+  scroll: number;
+  start: number;
+}
+
+export interface MobileHistoryAnchorResolveState {
+  positionByKey(key: string): number | undefined;
+  /** LegendList can briefly omit a key from its position cache while committing a prepend. */
+  data?: readonly { key: string }[];
+  positionAtIndex?(index: number): number | undefined;
+}
+
+const MAX_MOBILE_HISTORY_ANCHOR_CANDIDATES = 8;
+const MAX_MOBILE_HISTORY_ANCHOR_POSITION_PROBES = 24;
+
+function findClosestMobileHistoryAnchorIndex<ItemT>(
+  state: MobileHistoryAnchorCaptureState<ItemT>,
+): number | null {
+  if (Number.isInteger(state.start) && state.start >= 0 && state.start < state.data.length) {
+    return state.start;
+  }
+
+  // Item positions are monotonic. When LegendList has not published `start` yet, locate the
+  // viewport with O(log n) position reads instead of scanning the whole retained history.
+  let lower = 0;
+  let upper = state.data.length - 1;
+  let closestIndex: number | null = null;
+  let closestDistance = Number.POSITIVE_INFINITY;
+  while (lower <= upper) {
+    const index = Math.floor((lower + upper) / 2);
+    const position = state.positionAtIndex(index);
+    if (!Number.isFinite(position)) break;
+    const distance = Math.abs((position as number) - state.scroll);
+    if (distance < closestDistance) {
+      closestDistance = distance;
+      closestIndex = index;
+    }
+    if ((position as number) < state.scroll) lower = index + 1;
+    else upper = index - 1;
+  }
+  return closestIndex;
+}
+
+/**
+ * Capture the first visible row in LegendList's own coordinate space.
+ *
+ * Native `contentOffset` is deliberately not used here: during a prepend,
+ * Android may report the old physical offset while LegendList has already
+ * moved its item positions to the new data coordinates.
+ */
+export function captureMobileHistoryAnchor<ItemT>(
+  state: MobileHistoryAnchorCaptureState<ItemT>,
+  keyOf: (item: ItemT) => string,
+): MobileHistoryAnchor | null {
+  if (!Number.isFinite(state.scroll)) return null;
+
+  const closestIndex = findClosestMobileHistoryAnchorIndex(state);
+  if (closestIndex === null) return null;
+  const candidates: MobileHistoryAnchorCandidate[] = [];
+  const seenKeys = new Set<string>();
+  let positionProbes = 0;
+  for (
+    let distance = 0;
+    candidates.length < MAX_MOBILE_HISTORY_ANCHOR_CANDIDATES
+      && positionProbes < MAX_MOBILE_HISTORY_ANCHOR_POSITION_PROBES;
+    distance++
+  ) {
+    const indices = distance === 0
+      ? [closestIndex]
+      : [closestIndex + distance, closestIndex - distance];
+    let hasIndexInRange = false;
+    for (const index of indices) {
+      if (index < 0 || index >= state.data.length) continue;
+      hasIndexInRange = true;
+      if (positionProbes >= MAX_MOBILE_HISTORY_ANCHOR_POSITION_PROBES) break;
+      positionProbes += 1;
+      const key = keyOf(state.data[index]);
+      const position = state.positionAtIndex(index);
+      if (!key || seenKeys.has(key) || !Number.isFinite(position)) continue;
+      seenKeys.add(key);
+      candidates.push({
+        key,
+        viewportOffset: (position as number) - state.scroll,
+      });
+      if (
+        candidates.length >= MAX_MOBILE_HISTORY_ANCHOR_CANDIDATES
+        || positionProbes >= MAX_MOBILE_HISTORY_ANCHOR_POSITION_PROBES
+      ) break;
+    }
+    if (!hasIndexInRange) break;
+  }
+  if (candidates.length === 0) return null;
+
+  const startKey = keyOf(state.data[closestIndex]);
+  candidates.sort((left, right) => {
+    if (left.key === startKey) return -1;
+    if (right.key === startKey) return 1;
+    return Math.abs(left.viewportOffset) - Math.abs(right.viewportOffset);
+  });
+
+  const [primary, ...fallbacks] = candidates.slice(0, MAX_MOBILE_HISTORY_ANCHOR_CANDIDATES);
+  return {
+    ...primary,
+    ...(fallbacks.length > 0 ? { fallbacks } : {}),
+  };
+}
+
+/** Resolve the non-animated scroll offset that keeps the captured row in place. */
+export function resolveMobileHistoryAnchorOffset(
+  anchor: MobileHistoryAnchor,
+  state: MobileHistoryAnchorResolveState,
+): number | null {
+  const candidates: readonly MobileHistoryAnchorCandidate[] = [anchor, ...(anchor.fallbacks ?? [])];
+  for (const candidate of candidates) {
+    let position = state.positionByKey(candidate.key);
+    if (
+      !Number.isFinite(position)
+      && state.data
+      && state.positionAtIndex
+    ) {
+      const index = state.data.findIndex((item) => item.key === candidate.key);
+      if (index >= 0) position = state.positionAtIndex(index);
+    }
+    if (Number.isFinite(position)) {
+      return Math.max(0, (position as number) - candidate.viewportOffset);
+    }
+  }
+  return null;
+}
+
+export function isMobileHistoryAnchorSettled(
+  currentOffset: number,
+  targetOffset: number,
+  previousTargetOffset: number | null,
+  tolerance: number,
+): boolean {
+  return Number.isFinite(currentOffset)
+    && Number.isFinite(targetOffset)
+    && previousTargetOffset !== null
+    && Math.abs(currentOffset - targetOffset) <= tolerance
+    && Math.abs(previousTargetOffset - targetOffset) <= tolerance;
+}

--- a/apps/mobile/src/session/messageHistoryAnchor.ts
+++ b/apps/mobile/src/session/messageHistoryAnchor.ts
@@ -1,5 +1,7 @@
 export interface MobileHistoryAnchor {
   key: string;
+  /** Stable child identity used when a prepend changes an aggregate row's outer key. */
+  identityKey?: string;
   /** Item top relative to the viewport top before older rows are prepended. */
   viewportOffset: number;
   /** Nearby rows captured at the same time, used if a live render group replaces the primary key. */
@@ -8,6 +10,8 @@ export interface MobileHistoryAnchor {
 
 export interface MobileHistoryAnchorCandidate {
   key: string;
+  /** Stable child identity used when a prepend changes an aggregate row's outer key. */
+  identityKey?: string;
   viewportOffset: number;
 }
 
@@ -16,17 +20,79 @@ export interface MobileHistoryAnchorCaptureState<ItemT> {
   positionAtIndex(index: number): number | undefined;
   scroll: number;
   start: number;
+  /** Header, content padding, and align-at-end spacer before the data coordinate space. */
+  topOffsetAdjustment?: number;
 }
 
 export interface MobileHistoryAnchorResolveState {
   positionByKey(key: string): number | undefined;
+  /** Resolve a captured child identity to its current top-level row key. */
+  keyByIdentity?(identityKey: string): string | undefined;
   /** LegendList can briefly omit a key from its position cache while committing a prepend. */
   data?: readonly { key: string }[];
   positionAtIndex?(index: number): number | undefined;
+  /** Header, content padding, and align-at-end spacer before the data coordinate space. */
+  topOffsetAdjustment?: number;
+}
+
+export interface MobileHistoryTopOffsetState {
+  contentLength: number;
+  data: readonly unknown[];
+  positionAtIndex(index: number): number | undefined;
+  scrollLength: number;
+  sizeAtIndex(index: number): number | undefined;
 }
 
 const MAX_MOBILE_HISTORY_ANCHOR_CANDIDATES = 8;
 const MAX_MOBILE_HISTORY_ANCHOR_POSITION_PROBES = 24;
+const MOBILE_HISTORY_SHORT_LIST_TOLERANCE = 2;
+
+/**
+ * Translate LegendList's data-relative item positions into its raw ScrollView coordinates.
+ *
+ * LegendList does not expose its align-at-end spacer through `getState()`. For an under-one-screen
+ * list every row is measured, so the leading space can be recovered from the content length and
+ * the measured end of the final row. Overflowing lists have no align spacer and use the explicit
+ * header + content-padding baseline instead.
+ */
+export function mobileHistoryTopOffsetAdjustment(
+  state: MobileHistoryTopOffsetState,
+  input: {
+    baseTopOffset: number;
+    bottomPadding: number;
+    footerSize: number;
+  },
+): number {
+  const baseTopOffset = Number.isFinite(input.baseTopOffset)
+    ? Math.max(0, input.baseTopOffset)
+    : 0;
+  if (
+    state.data.length === 0
+    || !Number.isFinite(state.contentLength)
+    || !Number.isFinite(state.scrollLength)
+    || state.contentLength > state.scrollLength + MOBILE_HISTORY_SHORT_LIST_TOLERANCE
+  ) {
+    return baseTopOffset;
+  }
+
+  const lastIndex = state.data.length - 1;
+  const lastPosition = state.positionAtIndex(lastIndex);
+  const lastSize = state.sizeAtIndex(lastIndex);
+  if (!Number.isFinite(lastPosition) || !Number.isFinite(lastSize)) return baseTopOffset;
+
+  const footerSize = Number.isFinite(input.footerSize) ? Math.max(0, input.footerSize) : 0;
+  const bottomPadding = Number.isFinite(input.bottomPadding)
+    ? Math.max(0, input.bottomPadding)
+    : 0;
+  const measuredLeadingSpace = state.contentLength
+    - footerSize
+    - bottomPadding
+    - (lastPosition as number)
+    - (lastSize as number);
+  return Number.isFinite(measuredLeadingSpace)
+    ? Math.max(baseTopOffset, measuredLeadingSpace)
+    : baseTopOffset;
+}
 
 function findClosestMobileHistoryAnchorIndex<ItemT>(
   state: MobileHistoryAnchorCaptureState<ItemT>,
@@ -45,12 +111,13 @@ function findClosestMobileHistoryAnchorIndex<ItemT>(
     const index = Math.floor((lower + upper) / 2);
     const position = state.positionAtIndex(index);
     if (!Number.isFinite(position)) break;
-    const distance = Math.abs((position as number) - state.scroll);
+    const dataScroll = state.scroll - (state.topOffsetAdjustment ?? 0);
+    const distance = Math.abs((position as number) - dataScroll);
     if (distance < closestDistance) {
       closestDistance = distance;
       closestIndex = index;
     }
-    if ((position as number) < state.scroll) lower = index + 1;
+    if ((position as number) < dataScroll) lower = index + 1;
     else upper = index - 1;
   }
   return closestIndex;
@@ -66,8 +133,12 @@ function findClosestMobileHistoryAnchorIndex<ItemT>(
 export function captureMobileHistoryAnchor<ItemT>(
   state: MobileHistoryAnchorCaptureState<ItemT>,
   keyOf: (item: ItemT) => string,
+  identityOf?: (item: ItemT) => string | undefined,
 ): MobileHistoryAnchor | null {
   if (!Number.isFinite(state.scroll)) return null;
+  const topOffsetAdjustment = Number.isFinite(state.topOffsetAdjustment)
+    ? state.topOffsetAdjustment as number
+    : 0;
 
   const closestIndex = findClosestMobileHistoryAnchorIndex(state);
   if (closestIndex === null) return null;
@@ -93,9 +164,11 @@ export function captureMobileHistoryAnchor<ItemT>(
       const position = state.positionAtIndex(index);
       if (!key || seenKeys.has(key) || !Number.isFinite(position)) continue;
       seenKeys.add(key);
+      const identityKey = identityOf?.(state.data[index]);
       candidates.push({
         key,
-        viewportOffset: (position as number) - state.scroll,
+        ...(identityKey && identityKey !== key ? { identityKey } : {}),
+        viewportOffset: (position as number) + topOffsetAdjustment - state.scroll,
       });
       if (
         candidates.length >= MAX_MOBILE_HISTORY_ANCHOR_CANDIDATES
@@ -127,17 +200,41 @@ export function resolveMobileHistoryAnchorOffset(
 ): number | null {
   const candidates: readonly MobileHistoryAnchorCandidate[] = [anchor, ...(anchor.fallbacks ?? [])];
   for (const candidate of candidates) {
-    let position = state.positionByKey(candidate.key);
+    let currentKey = candidate.key;
+    let position = state.positionByKey(currentKey);
     if (
       !Number.isFinite(position)
       && state.data
       && state.positionAtIndex
     ) {
-      const index = state.data.findIndex((item) => item.key === candidate.key);
+      const index = state.data.findIndex((item) => item.key === currentKey);
       if (index >= 0) position = state.positionAtIndex(index);
     }
+    // Most prepends preserve the outer row key. Only scan aggregate children after both of
+    // LegendList's direct-key paths miss, keeping the per-frame settle verifier O(1) normally.
+    if (!Number.isFinite(position) && candidate.identityKey && state.keyByIdentity) {
+      const replacementKey = state.keyByIdentity(candidate.identityKey);
+      if (replacementKey) {
+        currentKey = replacementKey;
+        position = state.positionByKey(currentKey);
+        if (
+          !Number.isFinite(position)
+          && state.data
+          && state.positionAtIndex
+        ) {
+          const index = state.data.findIndex((item) => item.key === currentKey);
+          if (index >= 0) position = state.positionAtIndex(index);
+        }
+      }
+    }
     if (Number.isFinite(position)) {
-      return Math.max(0, (position as number) - candidate.viewportOffset);
+      const topOffsetAdjustment = Number.isFinite(state.topOffsetAdjustment)
+        ? state.topOffsetAdjustment as number
+        : 0;
+      return Math.max(
+        0,
+        (position as number) + topOffsetAdjustment - candidate.viewportOffset,
+      );
     }
   }
   return null;

--- a/apps/mobile/src/session/messageHistoryAnchorIdentity.ts
+++ b/apps/mobile/src/session/messageHistoryAnchorIdentity.ts
@@ -1,0 +1,87 @@
+import type {
+  MobileMessageRenderItem,
+  MobileWorkChildItem,
+} from '@/session/messageRenderModel';
+
+type MobileHistoryAnchorItem = MobileMessageRenderItem | MobileWorkChildItem;
+
+/**
+ * Aggregate rows are keyed by their first activity, so prepending an older activity from the same
+ * turn legitimately replaces the outer key. A leaf message/tool identity survives that regrouping
+ * and lets the history transaction recognize the replacement row without changing product grouping.
+ */
+export function mobileMessageHistoryAnchorIdentity(
+  item: MobileHistoryAnchorItem,
+): string | undefined {
+  switch (item.type) {
+    case 'work_group':
+      for (const child of item.children) {
+        const identity = mobileMessageHistoryAnchorIdentity(child);
+        if (identity) return identity;
+      }
+      return item.key;
+    case 'tool_group':
+    case 'tool_media':
+      return item.tools[0]?.key ?? item.key;
+    case 'subagent_group':
+      for (const child of item.childItems) {
+        const identity = mobileMessageHistoryAnchorIdentity(child);
+        if (identity) return identity;
+      }
+      return item.key;
+    default:
+      return item.key;
+  }
+}
+
+/** Find the current top-level row that still contains a captured stable leaf identity. */
+export function mobileMessageHistoryRowKeyByIdentity(
+  items: readonly MobileMessageRenderItem[],
+  identityKey: string,
+): string | undefined {
+  return items.find((item) => mobileMessageHistoryItemContainsIdentity(item, identityKey))?.key;
+}
+
+/**
+ * A history page can consist only of earlier activities from the completed turn already shown as
+ * the first collapsed `Worked for` row. Its outer key changes, but it remains the first rendered
+ * row, so the page added no visible top-level history for the reader. Main continues paging in this
+ * case; the app-owned anchor transaction must preserve that behavior after it finishes settling.
+ */
+export function mobileMessageHistoryOnlyExpandedFirstWorkGroup(
+  previousItems: readonly MobileMessageRenderItem[],
+  nextItems: readonly MobileMessageRenderItem[],
+): boolean {
+  const previousFirst = previousItems[0];
+  const nextFirst = nextItems[0];
+  if (
+    previousFirst?.type !== 'work_group'
+    || nextFirst?.type !== 'work_group'
+    || previousFirst.key === nextFirst.key
+  ) return false;
+  const identityKey = mobileMessageHistoryAnchorIdentity(previousFirst);
+  return identityKey !== undefined
+    && mobileMessageHistoryItemContainsIdentity(nextFirst, identityKey);
+}
+
+function mobileMessageHistoryItemContainsIdentity(
+  item: MobileHistoryAnchorItem,
+  identityKey: string,
+): boolean {
+  if (item.key === identityKey) return true;
+  switch (item.type) {
+    case 'work_group':
+      return item.children.some((child) => (
+        mobileMessageHistoryItemContainsIdentity(child, identityKey)
+      ));
+    case 'tool_group':
+    case 'tool_media':
+      return item.tools.some((tool) => tool.key === identityKey);
+    case 'subagent_group':
+      return item.childItems.some((child) => (
+        mobileMessageHistoryItemContainsIdentity(child, identityKey)
+      ));
+    default:
+      return false;
+  }
+}

--- a/apps/mobile/src/session/messageMarkdown.ts
+++ b/apps/mobile/src/session/messageMarkdown.ts
@@ -653,6 +653,8 @@ export interface MobileMarkdownTextRunGroupingOptions {
   maxTextRunBlocks?: number;
   /** Same guard by rendered inline text length, measured in JS UTF-16 units. */
   maxTextRunUtf16Length?: number;
+  /** Same guard by the number of inline fragments rendered as nested native text spans. */
+  maxTextRunInlineFragments?: number;
 }
 
 const MOBILE_MARKDOWN_TEXT_RUN_BLOCK_SEPARATOR_UTF16_LENGTH = 2;
@@ -665,8 +667,10 @@ export function groupMobileMarkdownSelectableBlocks(
   const groups: MobileMarkdownBlockGroup[] = [];
   let run: MobileMarkdownTextRunBlock[] = [];
   let runTextLength = 0;
+  let runInlineFragmentCount = 0;
   const maxTextRunBlocks = normalizePositiveLimit(options?.maxTextRunBlocks);
   const maxTextRunUtf16Length = normalizePositiveLimit(options?.maxTextRunUtf16Length);
+  const maxTextRunInlineFragments = normalizePositiveLimit(options?.maxTextRunInlineFragments);
   const flushRun = () => {
     if (run.length === 0) return;
     groups.push({
@@ -677,11 +681,17 @@ export function groupMobileMarkdownSelectableBlocks(
     });
     run = [];
     runTextLength = 0;
+    runInlineFragmentCount = 0;
   };
   for (const block of blocks) {
     if (isTextRunBlock(block)) {
-      for (const chunk of splitOversizedTextRunBlock(block, maxTextRunUtf16Length)) {
+      for (const chunk of splitOversizedTextRunBlock(
+        block,
+        maxTextRunUtf16Length,
+        maxTextRunInlineFragments,
+      )) {
         const blockTextLength = mobileMarkdownTextRunBlockLength(chunk);
+        const blockInlineFragmentCount = chunk.inlines.length;
         const separatorLength = run.length > 0 && !chunk.textRunContinuation
           ? MOBILE_MARKDOWN_TEXT_RUN_BLOCK_SEPARATOR_UTF16_LENGTH
           : 0;
@@ -690,6 +700,7 @@ export function groupMobileMarkdownSelectableBlocks(
           && (
             run.length >= maxTextRunBlocks
             || runTextLength + separatorLength + blockTextLength > maxTextRunUtf16Length
+            || runInlineFragmentCount + blockInlineFragmentCount > maxTextRunInlineFragments
           )
         ) {
           flushRun();
@@ -699,6 +710,7 @@ export function groupMobileMarkdownSelectableBlocks(
           : 0;
         run.push(chunk);
         runTextLength += pushedSeparatorLength + blockTextLength;
+        runInlineFragmentCount += blockInlineFragmentCount;
       }
     } else {
       flushRun();
@@ -751,10 +763,13 @@ export function mobileMarkdownImageAltChipText(alt: string): string {
 function splitOversizedTextRunBlock(
   block: MobileMarkdownTextRunBlock,
   maxTextRunUtf16Length: number,
+  maxTextRunInlineFragments: number,
 ): MobileMarkdownTextRunBlock[] {
   if (
-    !Number.isFinite(maxTextRunUtf16Length)
-    || mobileMarkdownTextRunBlockLength(block) <= maxTextRunUtf16Length
+    (!Number.isFinite(maxTextRunUtf16Length)
+      || mobileMarkdownTextRunBlockLength(block) <= maxTextRunUtf16Length)
+    && (!Number.isFinite(maxTextRunInlineFragments)
+      || block.inlines.length <= maxTextRunInlineFragments)
   ) {
     return [block];
   }
@@ -778,7 +793,12 @@ function splitOversizedTextRunBlock(
   ) => {
     let start = 0;
     while (start < text.length) {
-      if (currentTextLength >= currentLimit()) flushCurrent();
+      if (
+        currentTextLength >= currentLimit()
+        || current.length >= maxTextRunInlineFragments
+      ) {
+        flushCurrent();
+      }
       const capacity = currentLimit() - currentTextLength;
       if (
         currentTextLength > 0
@@ -798,12 +818,23 @@ function splitOversizedTextRunBlock(
   for (const inline of block.inlines) {
     if (inline.type === 'image') {
       const inlineLength = mobileMarkdownInlineTextLength(inline);
-      if (current.length > 0 && currentTextLength + inlineLength > currentLimit()) {
+      if (
+        current.length > 0
+        && (
+          currentTextLength + inlineLength > currentLimit()
+          || current.length >= maxTextRunInlineFragments
+        )
+      ) {
         flushCurrent();
       }
       current.push(inline);
       currentTextLength += inlineLength;
-      if (currentTextLength >= currentLimit()) flushCurrent();
+      if (
+        currentTextLength >= currentLimit()
+        || current.length >= maxTextRunInlineFragments
+      ) {
+        flushCurrent();
+      }
       continue;
     }
 

--- a/apps/mobile/src/session/messageMarkdown.ts
+++ b/apps/mobile/src/session/messageMarkdown.ts
@@ -65,6 +65,35 @@ export interface ParseMobileMarkdownOptions {
    * 默认关闭:聊天气泡路径不需要,且既有消费方/测试按无此字段的形状断言。
    */
   srcLines?: boolean;
+  /** Internal offsets used when parsing an append-only suffix. */
+  lineOffset?: number;
+  blockIndexOffset?: number;
+  charOffset?: number;
+  sourceIsNormalized?: boolean;
+}
+
+export interface MobileMarkdownBlockRange {
+  startLine: number;
+  endLineExclusive: number;
+}
+
+export interface MobileMarkdownParseCheckpoint {
+  /** UTF-16 offset in the normalized source immediately after a safe boundary. */
+  charOffset: number;
+  /** Global line index at the beginning of the suffix. */
+  lineIndex: number;
+  /** Number of blocks already emitted at this boundary. */
+  blockCount: number;
+}
+
+export interface MobileMarkdownParseResult {
+  source: string;
+  blocks: MobileMarkdownBlock[];
+  ranges: MobileMarkdownBlockRange[];
+  checkpoints: MobileMarkdownParseCheckpoint[];
+  incremental: boolean;
+  reusedBlockCount: number;
+  parsedSourceUtf16Length: number;
 }
 
 interface ParsedTableBlock {
@@ -93,15 +122,64 @@ export function parseMobileMarkdown(
   input: string,
   options?: ParseMobileMarkdownOptions,
 ): MobileMarkdownBlock[] {
+  return parseMobileMarkdownDocument(input, options).blocks;
+}
+
+/**
+ * Parse Markdown while retaining enough source metadata to reuse completed
+ * blocks when a streaming message only grows at the end.
+ *
+ * The incremental path is deliberately conservative: it only starts after a
+ * parser-safe blank-line boundary. If the source is edited in the middle, or
+ * no safe checkpoint exists, callers get the normal full parse result.
+ */
+export function parseMobileMarkdownDocument(
+  input: string,
+  options?: ParseMobileMarkdownOptions,
+): MobileMarkdownParseResult {
   const withSrc = options?.srcLines === true;
   // LaTeX 定界符归一化(\(...\) / \[...\] → $...$ / $$...$$,desktop/mobile 共用
   // 实现)。srcLines 模式走保行数变体:单行 inline 照常转换(同行替换,不破坏
   // 「块 srcLine ↔ 源码行」映射),会插行的 display 保持源码——与桌面端
   // emitSourceLines 门控同一原则。
-  const source = input.replace(/\r\n/g, '\n');
-  const normalized = normalizeMathDelimiters(source, { preserveLineCount: withSrc });
+  const lineOffset = options?.lineOffset ?? 0;
+  const blockIndexOffset = options?.blockIndexOffset ?? 0;
+  const charOffset = options?.charOffset ?? 0;
+  const source = options?.sourceIsNormalized === true ? input : input.replace(/\r\n/g, '\n');
+  const normalized = options?.sourceIsNormalized === true
+    ? source
+    : normalizeMathDelimiters(source, { preserveLineCount: withSrc });
   const lines = normalized.split('\n');
   const blocks: MobileMarkdownBlock[] = [];
+  const ranges: MobileMarkdownBlockRange[] = [];
+  const checkpoints: MobileMarkdownParseCheckpoint[] = [{
+    charOffset,
+    lineIndex: lineOffset,
+    blockCount: blockIndexOffset,
+  }];
+  const lineNumber = (index: number) => lineOffset + index;
+  const blockNumber = () => blockIndexOffset + blocks.length;
+  const lineEndOffsets: number[] = [];
+  let sourceOffset = charOffset;
+  for (let index = 0; index < lines.length; index += 1) {
+    sourceOffset += lines[index].length;
+    if (index < lines.length - 1) sourceOffset += 1;
+    lineEndOffsets[index] = sourceOffset;
+  }
+  const lineEndOffset = (index: number): number => (
+    lineEndOffsets[Math.max(0, Math.min(index, lineEndOffsets.length - 1))] ?? charOffset
+  );
+  const pushBlock = (
+    block: MobileMarkdownBlock,
+    startLine: number,
+    endLineExclusive: number,
+  ): void => {
+    blocks.push(block);
+    ranges.push({
+      startLine: lineNumber(startLine),
+      endLineExclusive: lineNumber(endLineExclusive),
+    });
+  };
   let paragraph: string[] = [];
   let code: CodeFenceState | null = null;
   // display math 围栏状态($$ 与 $$ 之间;与 code fence 一样跨行收集)。
@@ -117,20 +195,29 @@ export function parseMobileMarkdown(
     const text = paragraph.join('\n').trim();
     paragraph = [];
     if (!text) return;
-    blocks.push({
+    pushBlock({
       type: 'paragraph',
-      key: `p:${lineIndex}:${blocks.length}`,
-      ...(withSrc ? { srcLine: paragraphStart } : {}),
+      key: `p:${lineNumber(lineIndex)}:${blockNumber()}`,
+      ...(withSrc ? { srcLine: lineNumber(paragraphStart) } : {}),
       inlines: parseMobileMarkdownInlines(text, paragraphStartsInComment),
-    });
+    }, paragraphStart, lineIndex);
   };
 
   for (let index = 0; index < lines.length; index++) {
     const line = lines[index];
     if (code) {
       if (isClosingCodeFence(line, code)) {
-        blocks.push(buildCodeBlock(code, blocks.length, withSrc));
+        pushBlock(
+          buildCodeBlock(code, blockNumber(), withSrc, lineOffset),
+          code.start,
+          index + 1,
+        );
         code = null;
+        checkpoints.push({
+          charOffset: lineEndOffset(index),
+          lineIndex: lineNumber(index + 1),
+          blockCount: blockNumber(),
+        });
       } else {
         code.lines.push(stripCodeFenceIndent(line, code.indent));
       }
@@ -141,7 +228,16 @@ export function parseMobileMarkdown(
       if (line.trim() === '$$') {
         const mathText = math.lines.join('\n').trim();
         if (mathText) {
-          blocks.push(buildMathBlock(mathText, math.start, blocks.length, withSrc));
+          pushBlock(
+            buildMathBlock(mathText, math.start, blockNumber(), withSrc, lineOffset),
+            math.start,
+            index + 1,
+          );
+          checkpoints.push({
+            charOffset: lineEndOffset(index),
+            lineIndex: lineNumber(index + 1),
+            blockCount: blockNumber(),
+          });
         } else {
           // 空围栏($$ 与 $$ 之间无内容):没有可渲染的公式,保持原文段落。
           // 渲染层(math WebView)因此永远不需要「空公式」占位文案,规避
@@ -178,7 +274,11 @@ export function parseMobileMarkdown(
     const singleLineMath = mathTrimmed.match(/^\$\$(.+)\$\$$/);
     if (singleLineMath && singleLineMath[1].trim()) {
       flushParagraph(index);
-      blocks.push(buildMathBlock(singleLineMath[1], index, blocks.length, withSrc));
+      pushBlock(
+        buildMathBlock(singleLineMath[1], index, blockNumber(), withSrc, lineOffset),
+        index,
+        index + 1,
+      );
       continue;
     }
     if (mathTrimmed === '$$') {
@@ -189,6 +289,16 @@ export function parseMobileMarkdown(
 
     if (!line.trim()) {
       flushParagraph(index);
+      // The final empty split segment after a trailing newline is not itself
+      // a terminated line yet; retaining a checkpoint for it would advance
+      // lineIndex one extra step on the next streaming append.
+      if (!inHtmlComment && paragraph.length === 0 && index < lines.length - 1) {
+        checkpoints.push({
+          charOffset: lineEndOffset(index),
+          lineIndex: lineNumber(index + 1),
+          blockCount: blockNumber(),
+        });
+      }
       continue;
     }
 
@@ -198,13 +308,13 @@ export function parseMobileMarkdown(
     const heading = line.match(/^(#{1,6})\s+(.+?)(?:\s+#+)?\s*$/);
     if (heading) {
       flushParagraph(index);
-      blocks.push({
+      pushBlock({
         type: 'heading',
-        key: `h:${index}:${blocks.length}`,
-        ...(withSrc ? { srcLine: index } : {}),
+        key: `h:${lineNumber(index)}:${blockNumber()}`,
+        ...(withSrc ? { srcLine: lineNumber(index) } : {}),
         level: heading[1].length,
         inlines: parseMobileMarkdownInlines(heading[2].trim(), lineStartsInComment),
-      });
+      }, index, index + 1);
       continue;
     }
 
@@ -218,12 +328,12 @@ export function parseMobileMarkdown(
         index += 1;
       }
       index -= 1;
-      blocks.push({
+      pushBlock({
         type: 'blockquote',
-        key: `quote:${quoteStart}:${blocks.length}`,
-        ...(withSrc ? { srcLine: quoteStart } : {}),
+        key: `quote:${lineNumber(quoteStart)}:${blockNumber()}`,
+        ...(withSrc ? { srcLine: lineNumber(quoteStart) } : {}),
         inlines: parseMobileMarkdownInlines(quoteLines.join('\n').trim(), lineStartsInComment),
-      });
+      }, quoteStart, index + 1);
       continue;
     }
 
@@ -250,17 +360,17 @@ export function parseMobileMarkdown(
       }
       const header = parseCellsWithCommentState(table.header, lineStartsInComment);
       const rows = table.rows.map((row, rowIndex): MobileMarkdownTableRow => ({
-        key: `tr:${row.lineIndex}:${rowIndex}`,
+        key: `tr:${lineNumber(row.lineIndex)}:${rowIndex}`,
         cells: parseCellsWithCommentState(row.cells, rowStartsInComment.get(row.lineIndex) ?? lineStartsInComment),
       }));
       index = table.endIndex;
-      blocks.push({
+      pushBlock({
         type: 'table',
-        key: `table:${tableStart}:${blocks.length}`,
-        ...(withSrc ? { srcLine: tableStart } : {}),
+        key: `table:${lineNumber(tableStart)}:${blockNumber()}`,
+        ...(withSrc ? { srcLine: lineNumber(tableStart) } : {}),
         header,
         rows,
-      });
+      }, tableStart, table.endIndex + 1);
       continue;
     }
 
@@ -269,15 +379,15 @@ export function parseMobileMarkdown(
       flushParagraph(index);
       const marker = list[2];
       const task = list[3].match(/^\[([ xX])\]\s+(.+)$/);
-      blocks.push({
+      pushBlock({
         type: 'list_item',
-        key: `li:${index}:${blocks.length}`,
-        ...(withSrc ? { srcLine: index } : {}),
+        key: `li:${lineNumber(index)}:${blockNumber()}`,
+        ...(withSrc ? { srcLine: lineNumber(index) } : {}),
         ordered: /^\d/.test(marker),
         marker,
         checked: task ? task[1].toLowerCase() === 'x' : undefined,
         inlines: parseMobileMarkdownInlines(task ? task[2] : list[3], lineStartsInComment),
-      });
+      }, index, index + 1);
       continue;
     }
 
@@ -289,7 +399,11 @@ export function parseMobileMarkdown(
   }
 
   if (code) {
-    blocks.push(buildCodeBlock(code, blocks.length, withSrc));
+    pushBlock(
+      buildCodeBlock(code, blockNumber(), withSrc, lineOffset),
+      code.start,
+      lines.length,
+    );
   }
   if (math) {
     // 未闭合的 $$ 围栏(streaming 中途):不升级成 math 块——math 块渲染在
@@ -302,7 +416,113 @@ export function parseMobileMarkdown(
     paragraph = ['$$', ...math.lines];
   }
   flushParagraph(lines.length);
-  return blocks;
+  return {
+    source: normalized,
+    blocks,
+    ranges,
+    checkpoints,
+    incremental: false,
+    reusedBlockCount: 0,
+    parsedSourceUtf16Length: normalized.length,
+  };
+}
+
+/**
+ * Reparse only the suffix of an append-only Markdown stream when a previously
+ * parsed document exposes a safe block boundary. Any non-append edit falls
+ * back to the regular parser so callers retain the existing semantics.
+ */
+export function parseMobileMarkdownIncremental(
+  input: string,
+  previous?: MobileMarkdownParseResult | null,
+): MobileMarkdownParseResult {
+  const normalizedInput = normalizeMathDelimiters(input.replace(/\r\n/g, '\n'));
+
+  if (!previous || !normalizedInput.startsWith(previous.source)) {
+    return parseMobileMarkdownDocument(input);
+  }
+
+  // normalizeMathDelimiters can resolve a delimiter that was incomplete in an
+  // earlier streaming flush. In that case the normalized prefix itself changes
+  // when new text closes `\\(` / `\\[`, so reusing blocks from the old result
+  // would preserve stale inline semantics. Complete escaped math pairs are
+  // stable and do not need to disable incremental parsing.
+  if (hasUnclosedEscapedMathDelimiter(previous.source)
+    || hasUnclosedEscapedMathDelimiter(normalizedInput)) {
+    return parseMobileMarkdownDocument(input);
+  }
+
+  const checkpoint = [...previous.checkpoints]
+    .reverse()
+    .find((candidate) => (
+      candidate.charOffset > 0
+      && candidate.charOffset <= previous.source.length
+      && candidate.blockCount <= previous.blocks.length
+      // A checkpoint at EOF without a trailing newline points into the last
+      // line. An append that does not begin with a newline mutates that line,
+      // so this checkpoint is no longer safe to reuse (an earlier checkpoint,
+      // if any, may still be selected by the reverse scan).
+      && !(
+        candidate.charOffset === previous.source.length
+        && !previous.source.endsWith('\n')
+        && normalizedInput[candidate.charOffset] !== '\n'
+      )
+    ));
+
+  if (!checkpoint) return parseMobileMarkdownDocument(input);
+
+  let suffixCharOffset = checkpoint.charOffset;
+  let suffix = normalizedInput.slice(suffixCharOffset);
+  // A checkpoint after a line's final character points at the next logical
+  // line. If the old source did not already contain that line terminator, the
+  // first appended newline is only the separator and must not create an extra
+  // empty line in the suffix parser.
+  if (
+    checkpoint.charOffset === previous.source.length
+    && !previous.source.endsWith('\n')
+    && suffix.startsWith('\n')
+  ) {
+    suffix = suffix.slice(1);
+    suffixCharOffset += 1;
+  }
+  const suffixResult = parseMobileMarkdownDocument(
+    suffix,
+    {
+      sourceIsNormalized: true,
+      lineOffset: checkpoint.lineIndex,
+      blockIndexOffset: checkpoint.blockCount,
+      charOffset: suffixCharOffset,
+    },
+  );
+
+  return {
+    source: normalizedInput,
+    blocks: [
+      ...previous.blocks.slice(0, checkpoint.blockCount),
+      ...suffixResult.blocks,
+    ],
+    ranges: [
+      ...previous.ranges.slice(0, checkpoint.blockCount),
+      ...suffixResult.ranges,
+    ],
+    checkpoints: [
+      ...previous.checkpoints.filter(
+        (candidate) => candidate.charOffset < checkpoint.charOffset,
+      ),
+      ...suffixResult.checkpoints,
+    ],
+    incremental: true,
+    reusedBlockCount: checkpoint.blockCount,
+    parsedSourceUtf16Length: suffixResult.parsedSourceUtf16Length,
+  };
+}
+
+function hasUnclosedEscapedMathDelimiter(source: string): boolean {
+  const openParen = source.lastIndexOf('\\(');
+  const closeParen = source.lastIndexOf('\\)');
+  const openBracket = source.lastIndexOf('\\[');
+  const closeBracket = source.lastIndexOf('\\]');
+  return openParen > closeParen || openBracket > closeBracket;
 }
 
 /** display math 块构造:text 存去围栏后的 LaTeX 源码(trim 掉围栏内缘空白)。 */
@@ -311,11 +531,12 @@ function buildMathBlock(
   startLine: number,
   blockIndex: number,
   withSrc: boolean,
+  lineOffset = 0,
 ): MobileMarkdownBlock {
   return {
     type: 'math',
-    key: `math:${startLine}:${blockIndex}`,
-    ...(withSrc ? { srcLine: startLine } : {}),
+    key: `math:${startLine + lineOffset}:${blockIndex}`,
+    ...(withSrc ? { srcLine: startLine + lineOffset } : {}),
     text: text.trim(),
   };
 }
@@ -685,21 +906,22 @@ function buildCodeBlock(
   code: CodeFenceState,
   blockIndex: number,
   withSrc = false,
+  lineOffset = 0,
 ): MobileMarkdownBlock {
   const normalized = normalizeCodeFencePayload(code);
   const text = normalized.lines.join('\n');
   if (isMermaidLanguage(normalized.language)) {
     return {
       type: 'mermaid',
-      key: `mermaid:${code.start}:${blockIndex}`,
-      ...(withSrc ? { srcLine: code.start } : {}),
+      key: `mermaid:${code.start + lineOffset}:${blockIndex}`,
+      ...(withSrc ? { srcLine: code.start + lineOffset } : {}),
       text,
     };
   }
   return {
     type: 'code',
-    key: `code:${code.start}:${blockIndex}`,
-    ...(withSrc ? { srcLine: code.start } : {}),
+    key: `code:${code.start + lineOffset}:${blockIndex}`,
+    ...(withSrc ? { srcLine: code.start + lineOffset } : {}),
     language: normalized.language,
     text,
   };

--- a/apps/mobile/src/session/messageNormalize.ts
+++ b/apps/mobile/src/session/messageNormalize.ts
@@ -180,6 +180,9 @@ interface ToolUsePayload extends MessageNormalizeToolUse {
   diff?: NormalizedToolDiff;
 }
 
+const toolResultPreviewByContent = new WeakMap<object, { language: string; preview: string }>();
+const toolUsePayloadByMessage = new WeakMap<RemoteMessage, ToolUsePayload>();
+
 export function normalizeRemoteMessages(messages: readonly RemoteMessage[]): NormalizedRemoteMessage[] {
   const sorted = sortMessagesByCreatedAt(messages);
   const toolResultPairing = buildMessageToolResultPairing(sorted, {
@@ -466,6 +469,18 @@ function dedupeToolImagesAgainstAssistantMarkdown(
 }
 
 function toolResultContentToPreview(content: unknown): string {
+  if (content !== null && typeof content === 'object') {
+    const language = i18n.resolvedLanguage ?? i18n.language;
+    const cached = toolResultPreviewByContent.get(content);
+    if (cached?.language === language) return cached.preview;
+    const preview = uncachedToolResultContentToPreview(content);
+    toolResultPreviewByContent.set(content, { language, preview });
+    return preview;
+  }
+  return uncachedToolResultContentToPreview(content);
+}
+
+function uncachedToolResultContentToPreview(content: unknown): string {
   const compacted = parseToolResultCompactionMarker(content);
   if (!compacted) return contentToPreview(content);
   return i18n.t('message.renderer.toolResultCompacted', {
@@ -482,11 +497,15 @@ function toolResultContentFor(
 }
 
 function parseToolUse(message: RemoteMessage): ToolUsePayload {
+  const cached = toolUsePayloadByMessage.get(message);
+  if (cached) return cached;
   const sharedTool = parseMessageToolUse(message);
   const { toolName, input } = sharedTool;
   const summary = toolName ? formatToolUseSummary(toolName, input) : contentToPreview(message.content);
   const diff = buildToolDiff(toolName, input);
-  return { ...sharedTool, summary, diff };
+  const payload = { ...sharedTool, summary, diff };
+  toolUsePayloadByMessage.set(message, payload);
+  return payload;
 }
 
 function parseUserContent(content: unknown): {

--- a/apps/mobile/src/session/messagePaging.ts
+++ b/apps/mobile/src/session/messagePaging.ts
@@ -26,6 +26,57 @@ export function oldestMessageCursor(messages: readonly RemoteMessage[]): string 
   return oldest?.id ?? null;
 }
 
+/**
+ * A reclaimed message window can retain locally generated Compact cards after the host rows that
+ * originally surrounded them have been evicted. Transcript replay also lacks the original boundary
+ * timestamp, so several historical boundaries can be stamped "now" and become adjacent. Rendering
+ * either shape produces a misleading wall of Compact cards. Keep every card in the store (they are
+ * local-only and cannot be fetched again), while the visible projection hides a detached prefix,
+ * keeps only the newest detached trailing boundary, and collapses adjacent in-window Compact cards.
+ * A persisted host row between boundaries always preserves both. Temporary `mobile-stream-*` rows
+ * are rendered, but do not widen the authoritative persisted-host window.
+ */
+export function projectLoadedMessageWindow(
+  messages: readonly RemoteMessage[],
+): readonly RemoteMessage[] {
+  let firstHostIndex = -1;
+  let lastHostIndex = -1;
+  for (let index = 0; index < messages.length; index += 1) {
+    if (!isHostMessageRow(messages[index])) continue;
+    if (firstHostIndex < 0) firstHostIndex = index;
+    lastHostIndex = index;
+  }
+  if (firstHostIndex < 0) return messages;
+
+  let latestDetachedTailCompactIndex = -1;
+  for (let index = lastHostIndex + 1; index < messages.length; index += 1) {
+    if (isLocalCompactCard(messages[index])) latestDetachedTailCompactIndex = index;
+  }
+
+  let changed = false;
+  const projected: RemoteMessage[] = [];
+  for (let index = 0; index < messages.length; index += 1) {
+    const message = messages[index];
+    const localCompact = isLocalCompactCard(message);
+    const detachedPrefix = localCompact && index < firstHostIndex;
+    const staleDetachedTail = localCompact
+      && index > lastHostIndex
+      && index !== latestDetachedTailCompactIndex;
+    if (detachedPrefix || staleDetachedTail) {
+      changed = true;
+      continue;
+    }
+    const previous = projected.at(-1);
+    if (isLocalCompactCard(message) && previous && isLocalCompactCard(previous)) {
+      projected[projected.length - 1] = message;
+      changed = true;
+      continue;
+    }
+    projected.push(message);
+  }
+  return changed ? projected : messages;
+}
+
 export function hasMoreOlderMessages(page: readonly RemoteMessage[], pageSize = MESSAGE_PAGE_SIZE): boolean {
   if (page.length >= pageSize) return true;
   // 被控端结果帧超限时会静默裁行,并在保留行打 agentMeta.remoteRowsTrimmed 标记
@@ -124,6 +175,17 @@ function countRealMessages(messages: readonly RemoteMessage[]): number {
     count += 1;
   }
   return count;
+}
+
+function isHostMessageRow(message: RemoteMessage): boolean {
+  if (!message.id || message.id.startsWith('mobile-system-')) return false;
+  return !message.id.startsWith('mobile-stream-')
+    && !message.clientId.startsWith('mobile-stream-');
+}
+
+function isLocalCompactCard(message: RemoteMessage): boolean {
+  return message.systemCardType === 'compact'
+    && message.id.startsWith('mobile-system-compact:');
 }
 
 export function isPayloadTooLargeError(error: unknown): boolean {

--- a/apps/mobile/src/session/messagePaging.ts
+++ b/apps/mobile/src/session/messagePaging.ts
@@ -46,7 +46,20 @@ export function projectLoadedMessageWindow(
     if (firstHostIndex < 0) firstHostIndex = index;
     lastHostIndex = index;
   }
-  if (firstHostIndex < 0) return messages;
+  if (firstHostIndex < 0) {
+    let changed = false;
+    const projected: RemoteMessage[] = [];
+    for (const message of messages) {
+      const previous = projected.at(-1);
+      if (isLocalCompactCard(message) && previous && isLocalCompactCard(previous)) {
+        projected[projected.length - 1] = message;
+        changed = true;
+        continue;
+      }
+      projected.push(message);
+    }
+    return changed ? projected : messages;
+  }
 
   let latestDetachedTailCompactIndex = -1;
   for (let index = lastHostIndex + 1; index < messages.length; index += 1) {

--- a/apps/mobile/src/session/messageRenderStreamingCache.ts
+++ b/apps/mobile/src/session/messageRenderStreamingCache.ts
@@ -1,0 +1,521 @@
+import {
+  findAgentTaskUpdate,
+  type AgentTaskUpdate,
+} from '@cindy/maker-shared/agent-task';
+import type { MessageRenderOptions } from '@cindy/maker-shared/message-render';
+import { isPlanUserBoundary } from '@cindy/maker-shared/message-render';
+import { parseMessageToolUse } from '@cindy/maker-shared/message-normalize';
+import { extractPayloadToolResultMedia } from '@cindy/maker-shared/payload-summary';
+import { isSyntheticTriggerText } from '@cindy/maker-shared/synthetic-trigger';
+import {
+  buildMobileMessageRenderItems,
+  type MobileMessageRenderItem,
+} from '@/session/messageRenderModel';
+import { collectMobileMarkdownImages } from '@/session/messageMarkdown';
+import type { RemoteMessage } from '@/session/types';
+import { contentToPreview } from '@/utils/contentPreview';
+
+export interface MobileStreamingRenderPrefixCache {
+  boundaryMessage?: RemoteMessage;
+  cacheKey: string;
+  items: readonly MobileMessageRenderItem[];
+  markdownImageUrls?: ReadonlySet<string>;
+  messages: readonly RemoteMessage[];
+  mode: 'history' | 'truncated-turn';
+  sessionId: string;
+  tailToolResults?: readonly RemoteMessage[];
+  taskUpdateDependencies?: readonly MobileStreamingTaskUpdateDependency[];
+  toolUseIds?: ReadonlySet<string>;
+}
+
+interface MobileStreamingTaskUpdateDependency {
+  clientId: string;
+  toolUseId: string | null;
+  update: AgentTaskUpdate | undefined;
+}
+
+export interface MobileStreamingRenderPrefixCacheRef {
+  current: MobileStreamingRenderPrefixCache | null;
+}
+
+interface BuildMobileStreamingRenderWindowInput {
+  cacheKey: string;
+  messages: readonly RemoteMessage[];
+  options: MessageRenderOptions & {
+    autoResumePending?: Record<string, unknown> | null;
+    sessionId?: string;
+  };
+  prefixCache?: MobileStreamingRenderPrefixCacheRef;
+  previousPrefix?: MobileStreamingRenderPrefixCache | null;
+  taskUpdates?: ReadonlyMap<string, AgentTaskUpdate>;
+}
+
+export interface MobileStreamingRenderWindowResult {
+  items: MobileMessageRenderItem[];
+  prefix: MobileStreamingRenderPrefixCache | null;
+}
+
+/**
+ * Rebuild only the active turn while a session streams.
+ *
+ * The loaded history is immutable during ordinary text deltas. Normalizing and grouping that
+ * entire window for every token creates a large allocation stream even though row reconciliation
+ * later reuses the resulting React props. Prefer a real root-user boundary. Very large active
+ * turns can push that row outside the retained window, so the fallback advances across an already
+ * rendered assistant boundary and keeps explicit dependencies for late tool results/task updates.
+ */
+export function buildMobileStreamingRenderWindow(
+  input: BuildMobileStreamingRenderWindowInput,
+): MobileStreamingRenderWindowResult {
+  const {
+    cacheKey,
+    messages,
+    options,
+    prefixCache,
+    previousPrefix = prefixCache?.current,
+    taskUpdates,
+  } = input;
+  const sessionId = options.sessionId ?? messages[0]?.sessionId ?? '';
+  const activeTurnStart = options.isSessionStreaming === true
+    ? findLastRootUserMessageIndex(messages)
+    : -1;
+  const stableAssistantBoundary = options.isSessionStreaming === true
+    ? findLastStableAssistantBoundaryIndex(messages)
+    : -1;
+  if (
+    options.isSessionStreaming === true
+    && (activeTurnStart < 0 || stableAssistantBoundary > activeTurnStart)
+    && stableAssistantBoundary > 0
+    && stableAssistantBoundaryCanSplit(
+      messages,
+      stableAssistantBoundary,
+      previousPrefix?.mode === 'truncated-turn'
+        && previousPrefix.messages.length === stableAssistantBoundary + 1
+        && previousPrefix.boundaryMessage === messages[stableAssistantBoundary]
+        ? previousPrefix.toolUseIds
+        : undefined,
+      previousPrefix?.mode === 'truncated-turn'
+        && previousPrefix.messages.length === stableAssistantBoundary + 1
+        && previousPrefix.boundaryMessage === messages[stableAssistantBoundary]
+        ? previousPrefix.markdownImageUrls
+        : undefined,
+    )
+  ) {
+    return buildTruncatedActiveTurnWindow({
+      boundaryIndex: stableAssistantBoundary,
+      cacheKey,
+      messages,
+      options,
+      prefixCache,
+      previousPrefix,
+      sessionId,
+      taskUpdates,
+    });
+  }
+  if (activeTurnStart <= 0) {
+    const result = {
+      items: buildMobileMessageRenderItems(messages, options, taskUpdates),
+      prefix: null,
+    };
+    if (prefixCache) prefixCache.current = null;
+    return result;
+  }
+
+  const canReusePrefix = previousPrefix?.mode === 'history'
+    && previousPrefix.sessionId === sessionId
+    && previousPrefix.cacheKey === cacheKey
+    && sameMessagePrefixReferences(previousPrefix.messages, messages, activeTurnStart);
+  const prefixMessages = canReusePrefix
+    ? previousPrefix.messages
+    : messages.slice(0, activeTurnStart);
+  const prefixItems = canReusePrefix
+    ? previousPrefix.items
+    : buildMobileMessageRenderItems(prefixMessages, {
+      ...options,
+      autoResumePending: null,
+      isSessionStreaming: false,
+      renderOrphanTaskUpdates: false,
+    });
+  const prefix = canReusePrefix
+    ? previousPrefix
+    : { cacheKey, items: prefixItems, messages: prefixMessages, mode: 'history' as const, sessionId };
+  const activeItems = buildMobileMessageRenderItems(
+    messages.slice(activeTurnStart),
+    options,
+    taskUpdates,
+  );
+  const result = {
+    items: [...prefixItems, ...activeItems],
+    prefix,
+  };
+  // Token updates may interrupt a concurrent render before it commits. Publishing this purely
+  // derived prefix only from a layout effect would then make every retry rebuild the full history.
+  // A speculative entry is safe: reuse still requires the same session, render options key, and
+  // exact message references, so a superseded render can affect performance but never output.
+  if (prefixCache) prefixCache.current = prefix;
+  return result;
+}
+
+function buildTruncatedActiveTurnWindow(
+  input: BuildMobileStreamingRenderWindowInput & {
+    boundaryIndex: number;
+    sessionId: string;
+  },
+): MobileStreamingRenderWindowResult {
+  const {
+    boundaryIndex,
+    cacheKey,
+    messages,
+    options,
+    prefixCache,
+    previousPrefix,
+    sessionId,
+    taskUpdates,
+  } = input;
+  let items: MobileMessageRenderItem[] | null = null;
+  let reusedPrefix = false;
+
+  if (
+    previousPrefix?.mode === 'truncated-turn'
+    && previousPrefix.sessionId === sessionId
+    && previousPrefix.cacheKey === cacheKey
+    && sameTaskUpdateDependencies(previousPrefix.taskUpdateDependencies, taskUpdates)
+    && previousPrefix.boundaryMessage
+    && previousPrefix.messages.length === boundaryIndex + 1
+    && previousPrefix.boundaryMessage === messages[boundaryIndex]
+    && sameMessagePrefixReferences(
+      previousPrefix.messages,
+      messages,
+      previousPrefix.messages.length,
+    )
+    && sameDependentTailToolResults(
+      previousPrefix.tailToolResults ?? [],
+      messages,
+      previousPrefix.messages.length,
+      previousPrefix.toolUseIds,
+    )
+  ) {
+    const activeItems = buildMobileMessageRenderItems(
+      messages.slice(boundaryIndex),
+      options,
+      taskUpdates,
+    );
+    const duplicateBoundaryIndex = findTopLevelMessageItemIndex(
+      activeItems,
+      previousPrefix.boundaryMessage,
+    );
+    if (duplicateBoundaryIndex >= 0) {
+      items = [
+        ...previousPrefix.items,
+        ...activeItems.slice(duplicateBoundaryIndex + 1),
+      ];
+      reusedPrefix = true;
+    }
+  }
+
+  if (!items) items = buildMobileMessageRenderItems(messages, options, taskUpdates);
+  if (reusedPrefix && previousPrefix) {
+    if (prefixCache) prefixCache.current = previousPrefix;
+    return { items, prefix: previousPrefix };
+  }
+  const builtPrefix = buildTruncatedTurnPrefix({
+    boundaryIndex,
+    cacheKey,
+    items,
+    messages,
+    sessionId,
+    taskUpdates,
+  });
+  const prefix = previousPrefix?.mode === 'truncated-turn'
+    && builtPrefix !== null
+    && builtPrefix.boundaryMessage === previousPrefix.boundaryMessage
+    && sameTaskUpdateDependencySnapshots(
+      builtPrefix.taskUpdateDependencies,
+      previousPrefix.taskUpdateDependencies,
+    )
+    && sameMessageReferences(builtPrefix.messages, previousPrefix.messages)
+    && sameMessageReferences(
+      builtPrefix.tailToolResults ?? [],
+      previousPrefix.tailToolResults ?? [],
+    )
+    ? previousPrefix
+    : builtPrefix;
+  if (prefixCache) prefixCache.current = prefix;
+  return { items, prefix };
+}
+
+function buildTruncatedTurnPrefix(input: {
+  boundaryIndex: number;
+  cacheKey: string;
+  items: readonly MobileMessageRenderItem[];
+  messages: readonly RemoteMessage[];
+  sessionId: string;
+  taskUpdates?: ReadonlyMap<string, AgentTaskUpdate>;
+}): MobileStreamingRenderPrefixCache | null {
+  const { boundaryIndex } = input;
+  if (boundaryIndex <= 0) return null;
+  const boundaryMessage = input.messages[boundaryIndex];
+  const boundaryItemIndex = findTopLevelMessageItemIndex(input.items, boundaryMessage);
+  if (boundaryItemIndex < 0) return null;
+  const prefixMessages = input.messages.slice(0, boundaryIndex + 1);
+  return {
+    boundaryMessage,
+    cacheKey: input.cacheKey,
+    items: input.items.slice(0, boundaryItemIndex + 1),
+    markdownImageUrls: collectAssistantMarkdownImageUrls(prefixMessages, prefixMessages.length),
+    messages: prefixMessages,
+    mode: 'truncated-turn',
+    sessionId: input.sessionId,
+    tailToolResults: collectDependentTailToolResults(input.messages, prefixMessages.length),
+    taskUpdateDependencies: collectTaskUpdateDependencies(prefixMessages, input.taskUpdates),
+    toolUseIds: collectToolUseIds(prefixMessages, prefixMessages.length),
+  };
+}
+
+function collectTaskUpdateDependencies(
+  messages: readonly RemoteMessage[],
+  taskUpdates: ReadonlyMap<string, AgentTaskUpdate> | undefined,
+): MobileStreamingTaskUpdateDependency[] {
+  const dependencies: MobileStreamingTaskUpdateDependency[] = [];
+  for (const message of messages) {
+    if (message.role !== 'tool_use') continue;
+    const toolUseId = remoteToolUseId(message);
+    dependencies.push({
+      clientId: message.clientId,
+      toolUseId,
+      update: findAgentTaskUpdate(taskUpdates, toolUseId, message.clientId),
+    });
+  }
+  return dependencies;
+}
+
+function sameTaskUpdateDependencies(
+  dependencies: readonly MobileStreamingTaskUpdateDependency[] | undefined,
+  taskUpdates: ReadonlyMap<string, AgentTaskUpdate> | undefined,
+): boolean {
+  if (!dependencies) return false;
+  return dependencies.every((dependency) =>
+    findAgentTaskUpdate(taskUpdates, dependency.toolUseId, dependency.clientId)
+      === dependency.update);
+}
+
+function sameTaskUpdateDependencySnapshots(
+  previous: readonly MobileStreamingTaskUpdateDependency[] | undefined,
+  next: readonly MobileStreamingTaskUpdateDependency[] | undefined,
+): boolean {
+  if (!previous || !next || previous.length !== next.length) return false;
+  return previous.every((dependency, index) => {
+    const candidate = next[index];
+    return dependency.clientId === candidate.clientId
+      && dependency.toolUseId === candidate.toolUseId
+      && dependency.update === candidate.update;
+  });
+}
+
+function findLastStableAssistantBoundaryIndex(messages: readonly RemoteMessage[]): number {
+  for (let index = messages.length - 2; index > 0; index -= 1) {
+    const message = messages[index];
+    const parentUuid = message.agentMeta?.parentUuid;
+    if (
+      message.role === 'assistant'
+      && !(typeof parentUuid === 'string' && parentUuid.length > 0)
+      && message.agentMeta?.isStreaming !== true
+      && message.agentMeta?.streaming !== true
+      && !contentIsStreaming(message.content)
+    ) {
+      return index;
+    }
+  }
+  return -1;
+}
+
+/**
+ * Some render transforms intentionally inspect a whole turn. Keep those messages together until
+ * a later stable assistant moves the split past them; otherwise an independently rebuilt tail can
+ * duplicate a plan/subagent row or miss cross-boundary media/tool-result reconciliation.
+ */
+function stableAssistantBoundaryCanSplit(
+  messages: readonly RemoteMessage[],
+  boundaryIndex: number,
+  cachedPrefixToolUseIds?: ReadonlySet<string>,
+  cachedPrefixMarkdownImageUrls?: ReadonlySet<string>,
+): boolean {
+  // The boundary assistant is rebuilt with the active tail and then discarded as a duplicate.
+  // If it contains an inline image, however, full-turn normalization may use it to remove an
+  // earlier tool-media row. Keep that boundary in the full build so cross-boundary image dedupe
+  // cannot diverge when the completed assistant and its following delta arrive in one batch.
+  if (
+    collectMobileMarkdownImages(contentToPreview(messages[boundaryIndex]?.content)).length > 0
+  ) {
+    return false;
+  }
+
+  const prefixToolUseIds = cachedPrefixToolUseIds
+    ?? collectToolUseIds(messages, boundaryIndex + 1);
+  const prefixMarkdownImageUrls = cachedPrefixMarkdownImageUrls
+    ?? collectAssistantMarkdownImageUrls(messages, boundaryIndex + 1);
+
+  for (let index = boundaryIndex + 1; index < messages.length; index += 1) {
+    const message = messages[index];
+    if (message.role === 'user') return false;
+    if (typeof message.agentMeta?.parentUuid === 'string' && message.agentMeta.parentUuid) {
+      return false;
+    }
+    if (message.role === 'tool_result') {
+      const toolUseId = remoteToolUseId(message);
+      if (toolUseId && prefixToolUseIds.has(toolUseId)) return false;
+      if (
+        prefixMarkdownImageUrls.size > 0
+        && extractPayloadToolResultMedia(contentToPreview(message.content)).some(
+          (media) => media.kind === 'image' && prefixMarkdownImageUrls.has(media.url),
+        )
+      ) {
+        return false;
+      }
+    }
+    if (message.role === 'tool_use' && isPlanToolName(parseMessageToolUse(message).toolName)) {
+      return false;
+    }
+    if (
+      message.role === 'assistant'
+      && collectMobileMarkdownImages(contentToPreview(message.content)).length > 0
+    ) {
+      return false;
+    }
+  }
+  return true;
+}
+
+function isPlanToolName(toolName: string): boolean {
+  return toolName === 'TodoWrite'
+    || toolName === 'update_plan'
+    || toolName === 'TaskCreate'
+    || toolName === 'TaskUpdate'
+    || toolName === 'TaskList'
+    || toolName === 'TaskGet';
+}
+
+function contentIsStreaming(content: unknown): boolean {
+  if (!content || typeof content !== 'object') return false;
+  if (Array.isArray(content)) return content.some(contentIsStreaming);
+  const record = content as Record<string, unknown>;
+  return record.isStreaming === true || record.streaming === true;
+}
+
+function findTopLevelMessageItemIndex(
+  items: readonly MobileMessageRenderItem[],
+  source: RemoteMessage,
+): number {
+  return items.findIndex(
+    (item) => item.type === 'message' && item.message.source === source,
+  );
+}
+
+function collectDependentTailToolResults(
+  messages: readonly RemoteMessage[],
+  prefixLength: number,
+  prefixToolUseIds = collectToolUseIds(messages, prefixLength),
+): RemoteMessage[] {
+  if (prefixToolUseIds.size === 0) return [];
+  const results: RemoteMessage[] = [];
+  for (let index = prefixLength; index < messages.length; index += 1) {
+    const message = messages[index];
+    if (message.role !== 'tool_result') continue;
+    const toolUseId = remoteToolUseId(message);
+    if (toolUseId && prefixToolUseIds.has(toolUseId)) results.push(message);
+  }
+  return results;
+}
+
+function sameDependentTailToolResults(
+  expected: readonly RemoteMessage[],
+  messages: readonly RemoteMessage[],
+  prefixLength: number,
+  prefixToolUseIds: ReadonlySet<string> | undefined,
+): boolean {
+  if (!prefixToolUseIds || prefixToolUseIds.size === 0) return expected.length === 0;
+  let expectedIndex = 0;
+  for (let index = prefixLength; index < messages.length; index += 1) {
+    const message = messages[index];
+    if (message.role !== 'tool_result') continue;
+    const toolUseId = remoteToolUseId(message);
+    if (!toolUseId || !prefixToolUseIds.has(toolUseId)) continue;
+    if (expected[expectedIndex] !== message) return false;
+    expectedIndex += 1;
+  }
+  return expectedIndex === expected.length;
+}
+
+function collectToolUseIds(
+  messages: readonly RemoteMessage[],
+  endExclusive: number,
+): Set<string> {
+  const toolUseIds = new Set<string>();
+  const end = Math.min(messages.length, Math.max(0, endExclusive));
+  for (let index = 0; index < end; index += 1) {
+    const message = messages[index];
+    if (message.role !== 'tool_use') continue;
+    const toolUseId = remoteToolUseId(message);
+    if (toolUseId) toolUseIds.add(toolUseId);
+  }
+  return toolUseIds;
+}
+
+function collectAssistantMarkdownImageUrls(
+  messages: readonly RemoteMessage[],
+  endExclusive: number,
+): Set<string> {
+  const urls = new Set<string>();
+  const end = Math.min(messages.length, Math.max(0, endExclusive));
+  for (let index = 0; index < end; index += 1) {
+    const message = messages[index];
+    if (message.role !== 'assistant') continue;
+    for (const image of collectMobileMarkdownImages(contentToPreview(message.content))) {
+      urls.add(image.url);
+    }
+  }
+  return urls;
+}
+
+function remoteToolUseId(message: RemoteMessage): string | null {
+  if (typeof message.toolUseId === 'string' && message.toolUseId.length > 0) {
+    return message.toolUseId;
+  }
+  if (!message.content || typeof message.content !== 'object' || Array.isArray(message.content)) {
+    return null;
+  }
+  const value = (message.content as Record<string, unknown>).toolUseId;
+  return typeof value === 'string' && value.length > 0 ? value : null;
+}
+
+function findLastRootUserMessageIndex(messages: readonly RemoteMessage[]): number {
+  for (let index = messages.length - 1; index >= 0; index -= 1) {
+    const message = messages[index];
+    if (
+      message.role === 'user'
+      && isPlanUserBoundary(message)
+      && !isSyntheticTriggerText(contentToPreview(message.content))
+    ) {
+      return index;
+    }
+  }
+  return -1;
+}
+
+function sameMessageReferences(
+  previous: readonly RemoteMessage[],
+  next: readonly RemoteMessage[],
+): boolean {
+  return previous.length === next.length
+    && previous.every((message, index) => message === next[index]);
+}
+
+function sameMessagePrefixReferences(
+  previous: readonly RemoteMessage[],
+  next: readonly RemoteMessage[],
+  prefixLength: number,
+): boolean {
+  return previous.length === prefixLength
+    && prefixLength <= next.length
+    && previous.every((message, index) => message === next[index]);
+}

--- a/apps/mobile/src/session/messageRenderStreamingCache.ts
+++ b/apps/mobile/src/session/messageRenderStreamingCache.ts
@@ -124,10 +124,14 @@ export function buildMobileStreamingRenderWindow(
   const canReusePrefix = previousPrefix?.mode === 'history'
     && previousPrefix.sessionId === sessionId
     && previousPrefix.cacheKey === cacheKey
+    && sameTaskUpdateDependencies(previousPrefix.taskUpdateDependencies, taskUpdates)
     && sameMessagePrefixReferences(previousPrefix.messages, messages, activeTurnStart);
   const prefixMessages = canReusePrefix
     ? previousPrefix.messages
     : messages.slice(0, activeTurnStart);
+  const prefixTaskUpdateDependencies = canReusePrefix
+    ? previousPrefix.taskUpdateDependencies ?? []
+    : collectTaskUpdateDependencies(prefixMessages, taskUpdates);
   const prefixItems = canReusePrefix
     ? previousPrefix.items
     : buildMobileMessageRenderItems(prefixMessages, {
@@ -135,14 +139,21 @@ export function buildMobileStreamingRenderWindow(
       autoResumePending: null,
       isSessionStreaming: false,
       renderOrphanTaskUpdates: false,
-    });
+    }, taskUpdates);
   const prefix = canReusePrefix
     ? previousPrefix
-    : { cacheKey, items: prefixItems, messages: prefixMessages, mode: 'history' as const, sessionId };
+    : {
+        cacheKey,
+        items: prefixItems,
+        messages: prefixMessages,
+        mode: 'history' as const,
+        sessionId,
+        taskUpdateDependencies: prefixTaskUpdateDependencies,
+      };
   const activeItems = buildMobileMessageRenderItems(
     messages.slice(activeTurnStart),
     options,
-    taskUpdates,
+    omitTaskUpdatesConsumedByPrefix(taskUpdates, prefixTaskUpdateDependencies),
   );
   const result = {
     items: [...prefixItems, ...activeItems],
@@ -310,6 +321,22 @@ function sameTaskUpdateDependencySnapshots(
       && dependency.toolUseId === candidate.toolUseId
       && dependency.update === candidate.update;
   });
+}
+
+function omitTaskUpdatesConsumedByPrefix(
+  taskUpdates: ReadonlyMap<string, AgentTaskUpdate> | undefined,
+  dependencies: readonly MobileStreamingTaskUpdateDependency[],
+): ReadonlyMap<string, AgentTaskUpdate> | undefined {
+  if (!taskUpdates || taskUpdates.size === 0) return taskUpdates;
+  const consumedUpdates = new Set(
+    dependencies
+      .map((dependency) => dependency.update)
+      .filter((update): update is AgentTaskUpdate => update !== undefined),
+  );
+  if (consumedUpdates.size === 0) return taskUpdates;
+  return new Map(
+    [...taskUpdates].filter(([, update]) => !consumedUpdates.has(update)),
+  );
 }
 
 function findLastStableAssistantBoundaryIndex(messages: readonly RemoteMessage[]): number {

--- a/apps/mobile/src/session/messageScroll.ts
+++ b/apps/mobile/src/session/messageScroll.ts
@@ -499,6 +499,11 @@ export interface MobilePreviousUserJumpTarget {
   preview: string;
 }
 
+export interface MobileWindowedPreviousUserJumpTarget extends MobilePreviousUserJumpTarget {
+  /** Index inside the currently mounted list window, or null when the target is still outside it. */
+  windowIndex: number | null;
+}
+
 export function previousUserMessageJumpTarget(
   items: readonly MobileMessageRenderItem[],
   firstVisibleIndex: number,
@@ -519,6 +524,26 @@ export function previousUserMessageJumpTarget(
     };
   }
   return null;
+}
+
+export function previousUserMessageJumpTargetForWindow(
+  items: readonly MobileMessageRenderItem[],
+  windowStartIndex: number,
+  firstVisibleWindowIndex: number,
+): MobileWindowedPreviousUserJumpTarget | null {
+  const safeWindowStartIndex = Number.isFinite(windowStartIndex)
+    ? Math.max(0, Math.floor(windowStartIndex))
+    : 0;
+  const target = previousUserMessageJumpTarget(
+    items,
+    safeWindowStartIndex + firstVisibleWindowIndex,
+  );
+  if (!target) return null;
+  const windowIndex = target.index - safeWindowStartIndex;
+  return {
+    ...target,
+    windowIndex: windowIndex >= 0 ? windowIndex : null,
+  };
 }
 
 export function findMobileRenderItemKeyByClientId(

--- a/apps/mobile/src/session/messageScroll.ts
+++ b/apps/mobile/src/session/messageScroll.ts
@@ -445,9 +445,11 @@ export interface MobileAutoLoadEarlierDecisionInput {
   actionVisible: boolean;
   /** 列表当前贴在内容末端(LegendList getState().isAtEnd,含 prepend 补偿后的记账)。 */
   atEnd: boolean;
+  /** 列表当前也贴在内容开头；与 atEnd 同时成立才说明内容未撑满视口。 */
+  atStart: boolean;
   /** 当前首个渲染项 key(prepend 落地后必变,作为「上次尝试有进展」的信号)。 */
   firstItemKey: string | null;
-  /** 冷开补齐预算尚有余额；只用于未经手势的初始短窗口。 */
+  /** 冷开补齐预算尚有余额；仍需 atStart + atEnd 确认视口未填满。 */
   initialAutoFillAllowed: boolean;
   /** 上一次自动触发时的首项 key;相同说明上次尝试无进展(失败/重复页),不再自动重试。 */
   lastAttemptedFirstItemKey: string | null;
@@ -479,10 +481,13 @@ export interface MobileAutoLoadEarlierDecisionInput {
  *   保证手势永远能重新驱动一次尝试。
  */
 export function shouldAutoLoadEarlier(input: MobileAutoLoadEarlierDecisionInput): boolean {
-  if (!input.userScrolledForOlder && !input.initialAutoFillAllowed) return false;
+  if (
+    !input.userScrolledForOlder
+    && (!input.initialAutoFillAllowed || !input.atStart || !input.atEnd)
+  ) return false;
   if (!input.actionVisible || input.actionDisabled) return false;
   if (!input.nearStart) return false;
-  if (input.atEnd && !input.initialAutoFillAllowed) return false;
+  if (input.atEnd && input.userScrolledForOlder) return false;
   if (!input.firstItemKey) return false;
   return input.lastAttemptedFirstItemKey !== input.firstItemKey;
 }

--- a/apps/mobile/src/session/messageScroll.ts
+++ b/apps/mobile/src/session/messageScroll.ts
@@ -499,11 +499,6 @@ export interface MobilePreviousUserJumpTarget {
   preview: string;
 }
 
-export interface MobileWindowedPreviousUserJumpTarget extends MobilePreviousUserJumpTarget {
-  /** Index inside the currently mounted list window, or null when the target is still outside it. */
-  windowIndex: number | null;
-}
-
 export function previousUserMessageJumpTarget(
   items: readonly MobileMessageRenderItem[],
   firstVisibleIndex: number,
@@ -524,26 +519,6 @@ export function previousUserMessageJumpTarget(
     };
   }
   return null;
-}
-
-export function previousUserMessageJumpTargetForWindow(
-  items: readonly MobileMessageRenderItem[],
-  windowStartIndex: number,
-  firstVisibleWindowIndex: number,
-): MobileWindowedPreviousUserJumpTarget | null {
-  const safeWindowStartIndex = Number.isFinite(windowStartIndex)
-    ? Math.max(0, Math.floor(windowStartIndex))
-    : 0;
-  const target = previousUserMessageJumpTarget(
-    items,
-    safeWindowStartIndex + firstVisibleWindowIndex,
-  );
-  if (!target) return null;
-  const windowIndex = target.index - safeWindowStartIndex;
-  return {
-    ...target,
-    windowIndex: windowIndex >= 0 ? windowIndex : null,
-  };
 }
 
 export function findMobileRenderItemKeyByClientId(

--- a/apps/mobile/src/session/messageScroll.ts
+++ b/apps/mobile/src/session/messageScroll.ts
@@ -146,6 +146,27 @@ export function resolveMobileNearBottomOnScroll(input: MobileNearBottomResolveIn
   return input.scrollDelta > MOBILE_FOLLOW_REPIN_DIRECTION_DEAD_ZONE;
 }
 
+export interface MobileHistoryBrowseIntentInput {
+  /** The reader explicitly requested or dragged into older history. */
+  historyBrowseIntent: boolean;
+  /** A finger drag or its native momentum currently owns the viewport. */
+  userControllingScroll: boolean;
+}
+
+/**
+ * Keep history browsing authoritative across app/native anchor corrections.
+ *
+ * A completed prepend can emit one more positive-offset scroll event when MVCP is re-enabled.
+ * Without this guard that programmatic event looks like a downward user gesture and silently
+ * re-pins a live session to the tail. Only an active drag/momentum may recover follow from an
+ * explicit history-browse intent; the jump-to-latest path clears the intent separately.
+ */
+export function shouldPreserveMobileHistoryBrowseIntent(
+  input: MobileHistoryBrowseIntentInput,
+): boolean {
+  return input.historyBrowseIntent && !input.userControllingScroll;
+}
+
 // ── 贴底跟随的 contentSize 补滚护栏(振荡断路器)──
 // 背景(bug:冷开会话消息区空白 + 无 loading + 返回键无响应,杀 App 才恢复):
 // handleContentSize 的「贴底且内容长高 → 命令式 scrollToEnd」补偿,与 LegendList
@@ -287,16 +308,16 @@ export const MOBILE_ANCHOR_VERIFY_TOLERANCE = 2;
 export const MOBILE_ANCHOR_VERIFY_MAX_ATTEMPTS = 6;
 
 /**
- * 校验等待上限(独立于补滚预算):mVCP 还在结算 / metrics 未就绪时环只等不滚,等待
- * 不消耗补滚额度——否则连续的 data / size 调整会先把 6 次补滚预算烧光,布局安静后
+ * 校验等待上限(独立于补滚预算):列表布局还在结算 / metrics 未就绪时环只等不滚,等待
+ * 不消耗补滚额度——否则连续的行身份 / size 调整会先把 6 次补滚预算烧光,布局安静后
  * 反而没额度补滚,遮挡残留(review P1)。双帧一轮约 33ms,75 轮约 2.5s；超过该
  * 上限说明布局持续变化或状态异常,结束环交给后续 contentSize 事件继续跟随。
  */
 export const MOBILE_ANCHOR_VERIFY_MAX_WAIT_ROUNDS = 75;
 
 /**
- * LegendList 的 mVCP 没有公开“本轮 native 调整已完成”信号。data / size 变化后保留
- * 一个短安静窗：期间 verifier 只等待；连续流式测量会延长窗口，但仍受上面的 2.5s
+ * LegendList 没有公开“本轮行坐标 / native size 调整已完成”信号。行身份 / size 变化后
+ * 保留一个短安静窗：期间 verifier 只等待；连续流式测量会延长窗口，但仍受上面的 2.5s
  * 总等待预算约束。120ms 约 7 帧，覆盖 JS commit、native layout 与滚动回传的常见链路。
  */
 export const MOBILE_MVCP_SETTLE_QUIET_MS = 120;
@@ -358,8 +379,7 @@ export type MobileAnchorVerifyAction =
  * 贴底锚定校验判定(纯函数,供 MessageRenderer 的 verify 环使用)。
  *
  * 背景:贴底跟随的落底 scrollToOffset 存在两类静默落空——
- * (a) maintainVisibleContentPosition 尚未真正关闭的帧里执行,被 mVCP 当成上方内容
- *     增长吸收/抵消(组件内 open-settle 注释实测过的偶发路径);
+ * (a) 行坐标或 size 锚定尚在结算的帧里执行,被后续布局调整吸收/抵消;
  * (b) 落底一刻 scrollMetricsRef 里的 contentHeight / viewportHeight 是陈旧值,目标
  *     offset 偏短,且之后再无 contentSize / layout 事件来纠正。
  * 两类的共同结果都是「最新消息停在底部浮层(composer)后面」。verify 环在每次落底后
@@ -367,8 +387,8 @@ export type MobileAnchorVerifyAction =
  */
 export function evaluateMobileAnchorVerify(input: MobileAnchorVerifyInput): MobileAnchorVerifyAction {
   if (!input.stickToLatest || !input.listVisible) return 'settled';
-  // mVCP 还开着(state 已请求关闭但 prop 未下发,或 settle 窗口仍在):此刻补滚会再次
-  // 被吸收,等窗口真正关闭后的下一轮再判。等待走独立预算,不消耗补滚额度。
+  // 行坐标 / size 锚定仍在 settle 窗口:此刻补滚可能被后续布局吸收,下一轮再判。
+  // 等待走独立预算,不消耗补滚额度。
   const { contentHeight, offsetY, viewportHeight } = input.metrics;
   if (input.preserveVisibleContentPosition || contentHeight <= 0 || viewportHeight <= 0) {
     return input.waitRounds >= MOBILE_ANCHOR_VERIFY_MAX_WAIT_ROUNDS ? 'give-up' : 'wait';
@@ -426,9 +446,9 @@ export function mobileTopPaddingCompensationOffset(input: MobileTopPaddingCompen
 /**
  * 「加载更早」预取触发距离:离顶还有约两屏时就开始拉上一页,而不是撞到顶(旧默认 96px)才拉。
  * 目标是无感翻页——用户滑到旧内容顶端之前,更早的消息已经 prepend 完毕,浏览像连续对话一样;
- * 同时触发时刻锚点(首个可见消息 cell)远离接缝,mVCP 的视口补偿也最稳定。
+ * 同时触发时刻锚点(首个可见消息 cell)远离接缝,应用层视口补偿也最稳定。
  * 视口高度未知(布局前)时退回旧默认,不凭空放大。
- * 不会级联连拉:每页 80 条消息的高度远超两屏,prepend 落地后 offsetY 被 mVCP 顶高、立即脱离阈值。
+ * 不会级联连拉:每页 80 条消息的高度远超两屏,prepend 落地后手动锚定会顶高 offsetY、立即脱离阈值。
  * 边界假设(review P2):上一行成立的前提是页均高度 > 两屏,即平均每条 > viewportHeight/40
  * (典型视口 844px 约 21px/条,低于单行气泡的最小实高)。理论上整页全是极短消息才可能连拉一页,
  * 且有 loadingEarlier 门禁串行化,最坏是多拉一页,不会失控循环。
@@ -443,7 +463,7 @@ export interface MobileAutoLoadEarlierDecisionInput {
   actionDisabled: boolean;
   /** 「加载更早」入口可见(hasOlderMessages 且列表非空)。 */
   actionVisible: boolean;
-  /** 列表当前贴在内容末端(LegendList getState().isAtEnd,含 prepend 补偿后的记账)。 */
+  /** 列表当前贴在内容末端(LegendList getState().isAtEnd,含应用层 prepend 补偿后的记账)。 */
   atEnd: boolean;
   /** 列表当前也贴在内容开头；与 atEnd 同时成立才说明内容未撑满视口。 */
   atStart: boolean;
@@ -470,7 +490,7 @@ export interface MobileAutoLoadEarlierDecisionInput {
  *   用户之后永远滚不出 1.3 × 阈值的复位区 → 永久哑火(实机高频复现的截图场景);
  * - 上一页在途时到达顶部(disabled guard 吞边沿),加载完成后停在顶部无任何重评估 → 哑火。
  * 修复:把判定改成电平语义——nearStart / atEnd 直接读 LegendList getState() 的实时账
- * (它的 scroll 记账含 prepend 锚点补偿,app 侧 onScroll 的原生 offsetY 在 prepend 后不可信),
+ * (它的 scroll 记账会接收应用层 prepend 锚点补偿,app 侧 onScroll 的原生 offsetY 在提交瞬间不可信),
  * 并在 scroll 事件、onStartReached、eligibility 变化(加载结束/入口点亮/首项变化)时都重新评估。
  *
  * 防失控:

--- a/apps/mobile/src/session/messageScroll.ts
+++ b/apps/mobile/src/session/messageScroll.ts
@@ -487,7 +487,10 @@ export function shouldAutoLoadEarlier(input: MobileAutoLoadEarlierDecisionInput)
   ) return false;
   if (!input.actionVisible || input.actionDisabled) return false;
   if (!input.nearStart) return false;
-  if (input.atEnd && input.userScrolledForOlder) return false;
+  // A short window can be both atStart and atEnd. After an explicit upward drag, allow it to
+  // request the previous page; only suppress user-driven prefetch when a longer list is still
+  // pinned at the latest edge without also being at the history edge.
+  if (input.atEnd && input.userScrolledForOlder && !input.atStart) return false;
   if (!input.firstItemKey) return false;
   return input.lastAttemptedFirstItemKey !== input.firstItemKey;
 }

--- a/apps/mobile/src/session/mobileMarkdownRenderMetrics.ts
+++ b/apps/mobile/src/session/mobileMarkdownRenderMetrics.ts
@@ -1,0 +1,53 @@
+import type { MobileMarkdownParseResult } from '@/session/messageMarkdown';
+
+/** DEV/perf-harness counters for Markdown parsing and list item allocation. */
+export interface MobileMarkdownRenderMetrics {
+  fullParseCount: number;
+  incrementalParseCount: number;
+  reusedBlockCount: number;
+  parsedSourceUtf16Length: number;
+  parseDurationMsTotal: number;
+  parseDurationMsMax: number;
+  renderItemRebuildCount: number;
+}
+
+const metrics: MobileMarkdownRenderMetrics = {
+  fullParseCount: 0,
+  incrementalParseCount: 0,
+  reusedBlockCount: 0,
+  parsedSourceUtf16Length: 0,
+  parseDurationMsTotal: 0,
+  parseDurationMsMax: 0,
+  renderItemRebuildCount: 0,
+};
+
+export function recordMobileMarkdownParse(
+  result: Pick<MobileMarkdownParseResult, 'incremental' | 'reusedBlockCount' | 'parsedSourceUtf16Length'>,
+  durationMs: number,
+): void {
+  if (result.incremental) metrics.incrementalParseCount += 1;
+  else metrics.fullParseCount += 1;
+  metrics.reusedBlockCount += result.reusedBlockCount;
+  metrics.parsedSourceUtf16Length += result.parsedSourceUtf16Length;
+  metrics.parseDurationMsTotal += Math.max(0, durationMs);
+  metrics.parseDurationMsMax = Math.max(metrics.parseDurationMsMax, Math.max(0, durationMs));
+}
+
+export function recordMobileMessageRenderItem(): void {
+  metrics.renderItemRebuildCount += 1;
+}
+
+export function getMobileMarkdownRenderMetrics(): MobileMarkdownRenderMetrics {
+  return { ...metrics };
+}
+
+/** Test/perf-harness reset; production behavior does not depend on these counters. */
+export function resetMobileMarkdownRenderMetrics(): void {
+  metrics.fullParseCount = 0;
+  metrics.incrementalParseCount = 0;
+  metrics.reusedBlockCount = 0;
+  metrics.parsedSourceUtf16Length = 0;
+  metrics.parseDurationMsTotal = 0;
+  metrics.parseDurationMsMax = 0;
+  metrics.renderItemRebuildCount = 0;
+}

--- a/apps/mobile/src/session/mobileMessageWebViewMetrics.ts
+++ b/apps/mobile/src/session/mobileMessageWebViewMetrics.ts
@@ -1,0 +1,62 @@
+export type MobileMessageWebViewKind = 'mermaid' | 'math' | 'media' | 'composer';
+
+export interface MobileMessageWebViewMetrics {
+  mounted: number;
+  mountedByKind: Record<MobileMessageWebViewKind, number>;
+  mounts: number;
+  unmounts: number;
+}
+
+const mounted = new Map<string, MobileMessageWebViewKind>();
+const mountCounts: Record<MobileMessageWebViewKind, number> = {
+  mermaid: 0,
+  math: 0,
+  media: 0,
+  composer: 0,
+};
+const unmountCounts: Record<MobileMessageWebViewKind, number> = {
+  mermaid: 0,
+  math: 0,
+  media: 0,
+  composer: 0,
+};
+let sequence = 0;
+
+/** Register one native WebView while it is mounted and return its idempotent cleanup. */
+export function registerMobileMessageWebView(kind: MobileMessageWebViewKind): () => void {
+  const id = `${kind}:${++sequence}`;
+  mounted.set(id, kind);
+  mountCounts[kind] += 1;
+  let released = false;
+  return () => {
+    if (released) return;
+    released = true;
+    if (mounted.delete(id)) unmountCounts[kind] += 1;
+  };
+}
+
+export function getMobileMessageWebViewMetrics(): MobileMessageWebViewMetrics {
+  const mountedByKind: Record<MobileMessageWebViewKind, number> = {
+    mermaid: 0,
+    math: 0,
+    media: 0,
+    composer: 0,
+  };
+  for (const kind of mounted.values()) mountedByKind[kind] += 1;
+  return {
+    mounted: mounted.size,
+    mountedByKind,
+    mounts: Object.values(mountCounts).reduce((total, count) => total + count, 0),
+    unmounts: Object.values(unmountCounts).reduce((total, count) => total + count, 0),
+  };
+}
+
+/** Test-only reset; production callers should only read the snapshot. */
+export function resetMobileMessageWebViewMetrics(): void {
+  mounted.clear();
+  for (const kind of Object.keys(mountCounts) as MobileMessageWebViewKind[]) {
+    mountCounts[kind] = 0;
+    unmountCounts[kind] = 0;
+  }
+  sequence = 0;
+}

--- a/apps/mobile/src/session/remoteMediaResolveQueue.ts
+++ b/apps/mobile/src/session/remoteMediaResolveQueue.ts
@@ -80,6 +80,8 @@ export interface RemoteMediaResolveQueueOptions {
   maxConcurrent?: number;
   /** 失败负缓存时长(ms),默认 20s。 */
   errorTtlMs?: number;
+  /** Approximate byte budget for resolved entries retained by this screen. */
+  maxCacheBytes?: number;
 }
 
 export interface RemoteMediaRequestOptions {
@@ -110,6 +112,7 @@ export interface RemoteMediaResolveQueue {
 
 const DEFAULT_MAX_CONCURRENT = 2;
 const DEFAULT_ERROR_TTL_MS = 20 * 1000;
+const DEFAULT_MAX_CACHE_BYTES = 32 * 1024 * 1024;
 
 interface QueueEntry {
   media: RemoteMediaRequest;
@@ -135,11 +138,13 @@ export function createRemoteMediaResolveQueue(
 ): RemoteMediaResolveQueue {
   const maxConcurrent = Math.max(1, options.maxConcurrent ?? DEFAULT_MAX_CONCURRENT);
   const errorTtlMs = options.errorTtlMs ?? DEFAULT_ERROR_TTL_MS;
+  const maxCacheBytes = Math.max(0, options.maxCacheBytes ?? DEFAULT_MAX_CACHE_BYTES);
   const isFresh = deps.isFresh ?? ((media, now) => isResolvedRemoteMediaFresh(media, now));
   const now = deps.now ?? (() => Date.now());
 
   // 以下四个容器一律以 requestKeyOf 产出的**缓存键**为键(缩略图带前缀,原图 = 裸 url)。
   const cache = new Map<string, MobileResolvedRemoteMedia>();
+  let cacheBytes = 0;
   const errorCache = new Map<string, { message: string; until: number }>();
   /** key → entry;排队与 in-flight 的都在这里,靠 entry.inFlight 区分。 */
   const entries = new Map<string, QueueEntry>();
@@ -148,6 +153,51 @@ export function createRemoteMediaResolveQueue(
   let inFlightCount = 0;
   /** releaseAll 已执行:此后完成的 in-flight 结果改走 onOrphanResolved,不回填缓存。 */
   let released = false;
+
+  function estimateCacheBytes(media: MobileResolvedRemoteMedia): number {
+    const inlineBytes = media.inlineBase64 ? media.inlineBase64.length * 2 : 0;
+    const metadataBytes = 256 + media.url.length * 2 + media.ossKey.length * 2;
+    const declaredBytes = Number.isFinite(media.size) && media.size > 0
+      ? Math.min(media.size, 8 * 1024 * 1024)
+      : 0;
+    return Math.max(metadataBytes + inlineBytes, declaredBytes);
+  }
+
+  function deleteCacheEntry(key: string): MobileResolvedRemoteMedia | null {
+    const current = cache.get(key);
+    if (!current) return null;
+    cache.delete(key);
+    cacheBytes = Math.max(0, cacheBytes - estimateCacheBytes(current));
+    return current;
+  }
+
+  function setCacheEntry(key: string, media: MobileResolvedRemoteMedia): MobileResolvedRemoteMedia[] {
+    const evicted: MobileResolvedRemoteMedia[] = [];
+    deleteCacheEntry(key);
+    cache.set(key, media);
+    cacheBytes += estimateCacheBytes(media);
+    // Keep the just-resolved item when it alone exceeds the budget: callers
+    // are about to receive it, and deleting its OSS object would invalidate the
+    // result. The next insertion can evict it normally once another entry exists.
+    while (cacheBytes > maxCacheBytes && cache.size > 1) {
+      const oldest = cache.keys().next().value as string | undefined;
+      if (oldest === undefined) break;
+      const removed = deleteCacheEntry(oldest);
+      if (removed) evicted.push(removed);
+    }
+    return evicted;
+  }
+
+  function notifyEvicted(entriesToRelease: readonly MobileResolvedRemoteMedia[]): void {
+    for (const media of entriesToRelease) {
+      deps.onOrphanResolved?.(media);
+    }
+  }
+
+  function touchCacheEntry(key: string, media: MobileResolvedRemoteMedia): void {
+    cache.delete(key);
+    cache.set(key, media);
+  }
 
   function detachWaiter(entry: QueueEntry, waiter: QueueEntry['waiters'][number]): void {
     if (waiter.signal && waiter.onAbort) {
@@ -184,7 +234,7 @@ export function createRemoteMediaResolveQueue(
     const current = cache.get(key);
     if (!current) return;
     if (current.ossKey !== local.ossKey) return;
-    cache.set(key, local);
+    notifyEvicted(setCacheEntry(key, local));
   }
 
   function pump(): void {
@@ -217,7 +267,7 @@ export function createRemoteMediaResolveQueue(
           if (prev && prev.ossKey && prev.ossKey !== resolved.ossKey) {
             deps.onOrphanResolved?.(prev);
           }
-          cache.set(key, resolved);
+          notifyEvicted(setCacheEntry(key, resolved));
           errorCache.delete(key);
           const followUp = entry.forcedFollowUp;
           entry.forcedFollowUp = undefined;
@@ -248,7 +298,7 @@ export function createRemoteMediaResolveQueue(
               // 重新走全新取件。
               const prev = cache.get(key);
               if (prev) {
-                cache.delete(key);
+                deleteCacheEntry(key);
                 if (prev.ossKey) deps.onOrphanResolved?.(prev);
               }
             }
@@ -269,7 +319,10 @@ export function createRemoteMediaResolveQueue(
     // key 是队列/缓存键(缩略图带前缀,原图 = 裸 url),entry.media 才是原始请求。
     const key = requestKeyOf(media);
     const cached = cache.get(key);
-    if (cached && !opts.forceRefresh && isFresh(cached, now())) return Promise.resolve(cached);
+    if (cached && !opts.forceRefresh && isFresh(cached, now())) {
+      touchCacheEntry(key, cached);
+      return Promise.resolve(cached);
+    }
     if (opts.cachedOnly) {
       // 只读缓存模式:未命中直接拒绝,不入队、不碰负缓存(不污染同键的真实取件)。
       return Promise.reject(new Error(i18n.t('composer.attachments.mediaCacheMiss')));
@@ -346,11 +399,12 @@ export function createRemoteMediaResolveQueue(
     request,
     peekFresh(url) {
       const cached = cache.get(url);
-      return cached && isFresh(cached, now()) ? cached : null;
+      if (!cached || !isFresh(cached, now())) return null;
+      touchCacheEntry(url, cached);
+      return cached;
     },
     evict(url) {
-      const cached = cache.get(url) ?? null;
-      cache.delete(url);
+      const cached = deleteCacheEntry(url);
       errorCache.delete(url);
       return cached;
     },
@@ -366,6 +420,7 @@ export function createRemoteMediaResolveQueue(
       }
       const all = [...cache.values()];
       cache.clear();
+      cacheBytes = 0;
       errorCache.clear();
       return all;
     },

--- a/apps/mobile/src/session/remoteMediaResolveQueue.ts
+++ b/apps/mobile/src/session/remoteMediaResolveQueue.ts
@@ -67,10 +67,8 @@ export interface RemoteMediaResolveQueueDeps {
   /** 时钟注入,测试用;默认 Date.now。 */
   now?(): number;
   /**
-   * 不再被缓存持有、但对应 OSS 对象仍在世的条目的下水道,宿主拿到后补 DELETE:
-   *   - releaseAll 之后才完成的 in-flight 取件(缓存已被退屏清理接管);
-   *   - 刷新重取(presign 过期 / forceRefresh)时被新结果覆盖掉的旧条目。
-   * 不经此回调这些对象会漏出统一清理、悬到生命周期兜底。
+   * releaseAll 之后才完成的 in-flight 取件的下水道。此时队列已经完成最终释放,
+   * 无法再把新结果纳入 releaseAll,宿主拿到后立即补 DELETE。
    */
   onOrphanResolved?(media: MobileResolvedRemoteMedia): void;
 }
@@ -103,9 +101,9 @@ export interface RemoteMediaResolveQueue {
   request(media: RemoteMediaRequest, opts?: RemoteMediaRequestOptions): Promise<MobileResolvedRemoteMedia>;
   /** 同步读 fresh 缓存(未过期才返回),缓存命中的缩略图首帧直接出图。 */
   peekFresh(url: string): MobileResolvedRemoteMedia | null;
-  /** 使某 url 缓存失效(Image 加载失败重试 / video-audio 关闭即删路径用)。 */
+  /** 使某 url 缓存失效;对应 OSS 对象延迟到 releaseAll 统一交还宿主。 */
   evict(url: string): MobileResolvedRemoteMedia | null;
-  /** 清空缓存并返回全部已 resolve 条目,供退出会话屏批量 DELETE OSS。 */
+  /** 清空缓存并返回本屏产生过且仍在世的 OSS 条目,供最终离场批量 DELETE。 */
   releaseAll(): MobileResolvedRemoteMedia[];
   stats(): { inFlight: number; queued: number };
 }
@@ -144,6 +142,9 @@ export function createRemoteMediaResolveQueue(
 
   // 以下四个容器一律以 requestKeyOf 产出的**缓存键**为键(缩略图带前缀,原图 = 裸 url)。
   const cache = new Map<string, MobileResolvedRemoteMedia>();
+  // 从 JS cache 逐出的条目不能立刻 DELETE:列表行或播放器可能仍持有它的
+  // presign URL。这里只保留最终删除需要的小记录,不保留 inlineBase64 大字节。
+  const retired = new Map<string, MobileResolvedRemoteMedia>();
   let cacheBytes = 0;
   const errorCache = new Map<string, { message: string; until: number }>();
   /** key → entry;排队与 in-flight 的都在这里,靠 entry.inFlight 区分。 */
@@ -171,8 +172,21 @@ export function createRemoteMediaResolveQueue(
     return current;
   }
 
-  function setCacheEntry(key: string, media: MobileResolvedRemoteMedia): MobileResolvedRemoteMedia[] {
-    const evicted: MobileResolvedRemoteMedia[] = [];
+  function retire(media: MobileResolvedRemoteMedia | null | undefined): void {
+    if (!media?.ossKey) return;
+    // 最终 DELETE 只需要 key。不要让 retired 通过 url(data URI 也可能很大)
+    // 或 inlineBase64 间接抵消 cache 的字节上限。
+    retired.set(media.ossKey, {
+      url: '',
+      ossKey: media.ossKey,
+      mimeType: '',
+      size: 0,
+      expiresAt: '',
+      previewable: false,
+    });
+  }
+
+  function setCacheEntry(key: string, media: MobileResolvedRemoteMedia): void {
     deleteCacheEntry(key);
     cache.set(key, media);
     cacheBytes += estimateCacheBytes(media);
@@ -183,14 +197,7 @@ export function createRemoteMediaResolveQueue(
       const oldest = cache.keys().next().value as string | undefined;
       if (oldest === undefined) break;
       const removed = deleteCacheEntry(oldest);
-      if (removed) evicted.push(removed);
-    }
-    return evicted;
-  }
-
-  function notifyEvicted(entriesToRelease: readonly MobileResolvedRemoteMedia[]): void {
-    for (const media of entriesToRelease) {
-      deps.onOrphanResolved?.(media);
+      retire(removed);
     }
   }
 
@@ -234,7 +241,7 @@ export function createRemoteMediaResolveQueue(
     const current = cache.get(key);
     if (!current) return;
     if (current.ossKey !== local.ossKey) return;
-    notifyEvicted(setCacheEntry(key, local));
+    setCacheEntry(key, local);
   }
 
   function pump(): void {
@@ -262,19 +269,19 @@ export function createRemoteMediaResolveQueue(
             return;
           }
           // 刷新重取覆盖旧条目时,旧 OSS 对象(ossKey 不同才是真被替换,相同则仍在用)
-          // 交还宿主补删,否则它不再出现在 releaseAll 里、悬到生命周期兜底。
+          // 退出 cache 但仍可能被已挂载行持有,延迟到最终 releaseAll 再删除。
           const prev = cache.get(key);
           if (prev && prev.ossKey && prev.ossKey !== resolved.ossKey) {
-            deps.onOrphanResolved?.(prev);
+            retire(prev);
           }
-          notifyEvicted(setCacheEntry(key, resolved));
+          setCacheEntry(key, resolved);
           errorCache.delete(key);
           const followUp = entry.forcedFollowUp;
           entry.forcedFollowUp = undefined;
           settleEntry(key, entry, resolved);
           if (followUp?.length) {
             // 强制重取等待者:携带 skipCache 立刻重飞一轮(插队头),
-            // 新结果经上面的 replaced-entry 路径覆盖缓存并补删旧对象。
+            // 新结果经上面的 replaced-entry 路径覆盖缓存并延后回收旧对象。
             const follow: QueueEntry = { media: entry.media, waiters: followUp, inFlight: false, skipCache: true };
             entries.set(key, follow);
             pendingOrder.unshift(key);
@@ -294,12 +301,12 @@ export function createRemoteMediaResolveQueue(
             });
             if (entry.skipCache) {
               // 强制重取失败:旧缓存条目已被 onError / 显式重试证伪,留着会让
-              // 后续被动请求继续命中坏对象;逐出并交还宿主补删,负缓存过期后
+              // 后续被动请求继续命中坏对象;逐出并登记最终回收,负缓存过期后
               // 重新走全新取件。
               const prev = cache.get(key);
               if (prev) {
                 deleteCacheEntry(key);
-                if (prev.ossKey) deps.onOrphanResolved?.(prev);
+                retire(prev);
               }
             }
           }
@@ -405,6 +412,7 @@ export function createRemoteMediaResolveQueue(
     },
     evict(url) {
       const cached = deleteCacheEntry(url);
+      retire(cached);
       errorCache.delete(url);
       return cached;
     },
@@ -418,8 +426,19 @@ export function createRemoteMediaResolveQueue(
         if (!entry || entry.inFlight) continue;
         settleEntry(key, entry, null, abortError());
       }
-      const all = [...cache.values()];
+      const allByOssKey = new Map(retired);
+      for (const media of cache.values()) {
+        if (!media.ossKey) continue;
+        if (media.inlineBase64 === undefined) {
+          allByOssKey.set(media.ossKey, media);
+        } else {
+          const { inlineBase64: _inlineBase64, ...smallRecord } = media;
+          allByOssKey.set(media.ossKey, smallRecord);
+        }
+      }
+      const all = [...allByOssKey.values()];
       cache.clear();
+      retired.clear();
       cacheBytes = 0;
       errorCache.clear();
       return all;

--- a/apps/mobile/src/session/remoteSessionStore.ts
+++ b/apps/mobile/src/session/remoteSessionStore.ts
@@ -639,6 +639,7 @@ const EMPTY_TASK_UPDATES: ReadonlyMap<string, AgentTaskUpdate> = new Map();
 const REGULAR_SESSION_GLOBAL_MESSAGE_BUDGET = 800;
 const REGULAR_SESSION_GLOBAL_MESSAGE_BYTES_BUDGET = 64 * 1024 * 1024;
 const MESSAGE_STRUCTURAL_BYTES_ESTIMATE = 512;
+const MESSAGE_BYTES_ESTIMATE_LIMIT = REGULAR_SESSION_GLOBAL_MESSAGE_BYTES_BUDGET + 1;
 const messageBytesEstimates = new WeakMap<RemoteMessage, number>();
 const sessionLastAccessOrder = new Map<string, number>();
 let nextSessionAccessOrder = 0;
@@ -663,34 +664,91 @@ function touchSessionAccess(sessionId: string): void {
  * conservative walk counts primitive payloads and container overhead without
  * materializing a large temporary string.
  */
-function estimateValueBytes(value: unknown, depth = 0, seen = new Set<object>()): number {
-  if (value == null) return 0;
-  if (typeof value === 'string') return value.length * 2;
-  if (typeof value === 'number' || typeof value === 'boolean') return 16;
-  if (typeof value !== 'object') return 8;
-  if (seen.has(value)) return 0;
-  seen.add(value);
-  if (depth >= 3) return 64;
-  if (Array.isArray(value)) {
-    let bytes = 24;
-    for (const item of value) bytes += 8 + estimateValueBytes(item, depth + 1, seen);
-    return bytes;
+function estimateValueBytes(value: unknown, maxBytes = MESSAGE_BYTES_ESTIMATE_LIMIT): number {
+  type ContainerFrame =
+    | { kind: 'array'; value: readonly unknown[]; nextIndex: number }
+    | { kind: 'object'; value: Record<string, unknown>; keys: string[]; nextIndex: number };
+
+  if (maxBytes <= 0) return 0;
+  const seen = new Set<object>();
+  const frames: ContainerFrame[] = [];
+  let bytes = 0;
+  let current: unknown = value;
+
+  // Walk one child at a time instead of recursively visiting or pushing an
+  // entire container. Deep payloads cannot overflow the JS stack, and large
+  // arrays do not create a second array-sized work queue just for accounting.
+  while (true) {
+    if (current == null) {
+      // null/undefined carry no payload bytes beyond their container slot.
+    } else if (typeof current === 'string') {
+      bytes += current.length * 2;
+    } else if (typeof current === 'number' || typeof current === 'boolean') {
+      bytes += 16;
+    } else if (typeof current !== 'object') {
+      bytes += 8;
+    } else if (!seen.has(current)) {
+      seen.add(current);
+      if (Array.isArray(current)) {
+        bytes += 24;
+        if (current.length > 0) {
+          bytes += 8;
+          frames.push({ kind: 'array', value: current, nextIndex: 1 });
+          current = current[0];
+          if (bytes >= maxBytes) return maxBytes;
+          continue;
+        }
+      } else {
+        const objectValue = current as Record<string, unknown>;
+        const keys = Object.keys(objectValue);
+        bytes += 32;
+        if (keys.length > 0) {
+          const key = keys[0]!;
+          bytes += 16 + key.length * 2;
+          frames.push({ kind: 'object', value: objectValue, keys, nextIndex: 1 });
+          current = objectValue[key];
+          if (bytes >= maxBytes) return maxBytes;
+          continue;
+        }
+      }
+    }
+
+    if (bytes >= maxBytes) return maxBytes;
+    let advanced = false;
+    while (frames.length > 0) {
+      const frame = frames[frames.length - 1]!;
+      if (frame.kind === 'array' && frame.nextIndex < frame.value.length) {
+        current = frame.value[frame.nextIndex];
+        frame.nextIndex += 1;
+        bytes += 8;
+        advanced = true;
+        break;
+      }
+      if (frame.kind === 'object' && frame.nextIndex < frame.keys.length) {
+        const key = frame.keys[frame.nextIndex]!;
+        frame.nextIndex += 1;
+        current = frame.value[key];
+        bytes += 16 + key.length * 2;
+        advanced = true;
+        break;
+      }
+      frames.pop();
+    }
+    if (!advanced) return bytes;
   }
-  let bytes = 32;
-  for (const [key, item] of Object.entries(value)) {
-    bytes += 16 + key.length * 2 + estimateValueBytes(item, depth + 1, seen);
-  }
-  return bytes;
 }
 
 function estimateMessageBytes(message: RemoteMessage): number {
   const cached = messageBytesEstimates.get(message);
   if (cached !== undefined) return cached;
   let bytes = MESSAGE_STRUCTURAL_BYTES_ESTIMATE;
-  if (typeof message.content === 'string') bytes += message.content.length * 2;
-  else if (message.content != null) bytes += estimateValueBytes(message.content);
-  if (message.agentMeta) bytes += estimateValueBytes(message.agentMeta);
-  if (message.systemCardData) bytes += estimateValueBytes(message.systemCardData);
+  const addValue = (value: unknown): void => {
+    if (value == null || bytes >= MESSAGE_BYTES_ESTIMATE_LIMIT) return;
+    bytes += estimateValueBytes(value, MESSAGE_BYTES_ESTIMATE_LIMIT - bytes);
+  };
+  addValue(message.content);
+  addValue(message.agentMeta);
+  addValue(message.systemCardData);
   messageBytesEstimates.set(message, bytes);
   return bytes;
 }

--- a/apps/mobile/src/session/remoteSessionStore.ts
+++ b/apps/mobile/src/session/remoteSessionStore.ts
@@ -1,4 +1,13 @@
-import { useEffect, useRef, useSyncExternalStore } from 'react';
+import {
+  createContext,
+  createElement,
+  useCallback,
+  useContext,
+  useEffect,
+  useRef,
+  useSyncExternalStore,
+  type ReactNode,
+} from 'react';
 import {
   MAKER_EVENT_BATCH_CHANNEL,
   SESSION_ACTIVITY_CHANNEL,
@@ -5155,8 +5164,52 @@ function readNumber(value: unknown, key: string): number | null {
   return typeof raw === 'number' && Number.isFinite(raw) ? raw : null;
 }
 
+const RemoteSessionStoreSubscriptionEnabledContext = createContext(true);
+const INACTIVE_REMOTE_SESSION_STORE_SUBSCRIBE = () => () => undefined;
+
+/**
+ * Keep a mounted route's remote-session projection stable while it is covered by another screen.
+ * The store itself keeps receiving data; consumers resubscribe and jump to the latest snapshot when
+ * the route regains focus. This preserves native list state without rendering hidden row trees for
+ * every streaming token.
+ */
+export function RemoteSessionStoreSubscriptionGate({
+  children,
+  enabled,
+}: {
+  children: ReactNode;
+  enabled: boolean;
+}) {
+  return createElement(
+    RemoteSessionStoreSubscriptionEnabledContext.Provider,
+    { value: enabled },
+    children,
+  );
+}
+
+function usePausableRemoteSessionStoreSnapshot<T>(
+  identity: unknown,
+  getSnapshot: () => T,
+): T {
+  const enabled = useContext(RemoteSessionStoreSubscriptionEnabledContext);
+  const frozenSnapshotRef = useRef<{ identity: unknown; value: T } | null>(null);
+  const readSnapshot = useCallback(() => {
+    const frozen = frozenSnapshotRef.current;
+    if (enabled || frozen === null || !Object.is(frozen.identity, identity)) {
+      const next = { identity, value: getSnapshot() };
+      frozenSnapshotRef.current = next;
+      return next.value;
+    }
+    return frozen.value;
+  }, [enabled, getSnapshot, identity]);
+  return useSyncExternalStore(
+    enabled ? remoteSessionStore.subscribe : INACTIVE_REMOTE_SESSION_STORE_SUBSCRIBE,
+    readSnapshot,
+  );
+}
+
 export function useRemoteSessions(): RemoteSession[] {
-  return useSyncExternalStore(remoteSessionStore.subscribe, remoteSessionStore.getSessions);
+  return usePausableRemoteSessionStoreSnapshot('sessions', remoteSessionStore.getSessions);
 }
 
 /** Subscribe to one session's message mirror without triggering cache hydration side effects. */
@@ -5273,11 +5326,17 @@ function useSessionMessageCacheSync(
 }
 
 export function useRemoteMessageVersion(): number {
-  return useSyncExternalStore(remoteSessionStore.subscribe, remoteSessionStore.getMessageVersion);
+  return usePausableRemoteSessionStoreSnapshot(
+    'message-version',
+    remoteSessionStore.getMessageVersion,
+  );
 }
 
 export function useRemoteSessionStoreVersion(): number {
-  return useSyncExternalStore(remoteSessionStore.subscribe, remoteSessionStore.getStoreVersion);
+  return usePausableRemoteSessionStoreSnapshot(
+    'store-version',
+    remoteSessionStore.getStoreVersion,
+  );
 }
 
 export function useRemoteNewMakerWorktreePreference(
@@ -5321,8 +5380,8 @@ export function useSessionInputProjection(sessionId: string): InputProjection {
 }
 
 export function useSessionRunning(sessionId: string): boolean {
-  return useSyncExternalStore(
-    remoteSessionStore.subscribe,
+  return usePausableRemoteSessionStoreSnapshot(
+    sessionId,
     () => remoteSessionStore.isSessionRunning(sessionId),
   );
 }

--- a/apps/mobile/src/session/remoteSessionStore.ts
+++ b/apps/mobile/src/session/remoteSessionStore.ts
@@ -578,7 +578,8 @@ const GENERATED_FALLBACK_MIN_PREFIX_LENGTH = 12;
 const TEXT_DELTA_BATCH_INTERVAL_MS = 32;
 const DEVICE_LINK_TRUNCATED_FLAG = '__deviceLinkTruncated';
 const pendingTextDeltaBatches = new Map<string, {
-  text: string;
+  /** Keep deltas as chunks; joining once per flush avoids O(n²) string copies. */
+  chunks: string[];
   persistId?: string;
   deviceId?: string;
   agentMeta: Record<string, unknown> | null;
@@ -654,14 +655,42 @@ function touchSessionAccess(sessionId: string): void {
   sessionLastAccessOrder.set(sessionId, ++nextSessionAccessOrder);
 }
 
+/**
+ * Budget accounting runs on every regular-session sweep.  Do not serialize the
+ * whole payload here: streaming rows replace their object on every flush, so a
+ * stringify would allocate a second copy of every large tool result and make
+ * the accounting pass itself a noticeable GC source.  This intentionally
+ * conservative walk counts primitive payloads and container overhead without
+ * materializing a large temporary string.
+ */
+function estimateValueBytes(value: unknown, depth = 0, seen = new Set<object>()): number {
+  if (value == null) return 0;
+  if (typeof value === 'string') return value.length * 2;
+  if (typeof value === 'number' || typeof value === 'boolean') return 16;
+  if (typeof value !== 'object') return 8;
+  if (seen.has(value)) return 0;
+  seen.add(value);
+  if (depth >= 3) return 64;
+  if (Array.isArray(value)) {
+    let bytes = 24;
+    for (const item of value) bytes += 8 + estimateValueBytes(item, depth + 1, seen);
+    return bytes;
+  }
+  let bytes = 32;
+  for (const [key, item] of Object.entries(value)) {
+    bytes += 16 + key.length * 2 + estimateValueBytes(item, depth + 1, seen);
+  }
+  return bytes;
+}
+
 function estimateMessageBytes(message: RemoteMessage): number {
   const cached = messageBytesEstimates.get(message);
   if (cached !== undefined) return cached;
   let bytes = MESSAGE_STRUCTURAL_BYTES_ESTIMATE;
   if (typeof message.content === 'string') bytes += message.content.length * 2;
-  else if (message.content != null) bytes += safeStableStringify(message.content).length * 2;
-  if (message.agentMeta) bytes += safeStableStringify(message.agentMeta).length * 2;
-  if (message.systemCardData) bytes += safeStableStringify(message.systemCardData).length * 2;
+  else if (message.content != null) bytes += estimateValueBytes(message.content);
+  if (message.agentMeta) bytes += estimateValueBytes(message.agentMeta);
+  if (message.systemCardData) bytes += estimateValueBytes(message.systemCardData);
   messageBytesEstimates.set(message, bytes);
   return bytes;
 }
@@ -894,6 +923,10 @@ function releaseSessionDetailProjections(sessionId: string): boolean {
   let changed = livePlanSnapshots.delete(sessionId);
   changed = sessionTaskUpdates.delete(sessionId) || changed;
   changed = sessionParkedTaskUpdates.delete(sessionId) || changed;
+  // Goal status is queried when the context sheet opens; retaining a full
+  // status payload for every backgrounded task only keeps detail-only data
+  // alive and can show stale state after a long absence.
+  changed = sessionGoalStatus.delete(sessionId) || changed;
   changed = inputProjections.delete(sessionId) || changed;
   // 即使投影已经为空也要抬升 authority：离场/LRU 前启动的慢查询不能在下一次
   // 打开同一任务后把旧 pending queue 或 continuation owner 写回来。
@@ -973,6 +1006,12 @@ function applyMessageWriteRetention(sessionId: string): void {
 let mergedSessions: RemoteSession[] = [];
 let messageVersion = 0;
 let storeVersion = 0;
+// A single remote snapshot often updates both the session shard and its
+// activity projection. Keep the writes synchronous, but notify subscribers
+// once after the snapshot is complete so the home screen does not render the
+// same device twice in one turn.
+let emitBatchDepth = 0;
+let emitBatchPending = false;
 
 type LiveRowCreatedAtAnchor = {
   createdAt: string | undefined;
@@ -1059,9 +1098,30 @@ let conversationSearchDeviceModels: readonly {
   state: string;
 }[] = [];
 
-function emit(): void {
+function emitNow(): void {
   storeVersion += 1;
   for (const sub of subs) sub();
+}
+
+function emit(): void {
+  if (emitBatchDepth > 0) {
+    emitBatchPending = true;
+    return;
+  }
+  emitNow();
+}
+
+function batch<T>(work: () => T): T {
+  emitBatchDepth += 1;
+  try {
+    return work();
+  } finally {
+    emitBatchDepth -= 1;
+    if (emitBatchDepth === 0 && emitBatchPending) {
+      emitBatchPending = false;
+      emitNow();
+    }
+  }
 }
 
 function bumpInputProjectionAuthorityEpoch(sessionId: string): number {
@@ -2019,7 +2079,11 @@ function streamingClientIdFor(sessionId: string, persistId: string | undefined):
 function upsertMessage(
   sessionId: string,
   message: RemoteMessage,
-  options: { retirePendingAssistantIdentityOnEqual?: boolean } = {},
+  options: {
+    retirePendingAssistantIdentityOnEqual?: boolean;
+    /** Streaming replacement preserves the already sorted message order. */
+    preserveOrderOnReplace?: boolean;
+  } = {},
 ): boolean {
   const existing = messages.get(sessionId) ?? [];
   const index = existing.findIndex((item) => messageIdentityMatches(item, message));
@@ -2076,7 +2140,13 @@ function upsertMessage(
   }
   const next = existing.slice();
   next[index] = replacement;
-  messages.set(sessionId, normalizeMessages(next));
+  // A live delta only changes content/metadata; sorting the whole window on
+  // every 32 ms flush needlessly allocates and scans all rows.  Callers that
+  // replace an authoritative row keep the historical normalization path.
+  messages.set(
+    sessionId,
+    options.preserveOrderOnReplace ? next : normalizeMessages(next),
+  );
   applyMessageWriteRetention(sessionId);
   if (message.role === 'assistant') {
     forgetPendingLiveAssistantMessageIdentity(
@@ -2283,7 +2353,7 @@ function applyRemoteTextEvent(
       new Date().toISOString(),
       hostCreatedAtAnchor?.createdAt,
     ),
-  });
+  }, { preserveOrderOnReplace: true });
   if (resetsTransportAssembly && !changed) {
     forgetPendingLiveAssistantMessageIdentity(
       sessionId,
@@ -2347,14 +2417,19 @@ function enqueueRemoteTextDelta(
   }
   const current = pendingTextDeltaBatches.get(sessionId);
   const incomingMeta = isRecord(event.agentMeta) ? event.agentMeta : null;
-  pendingTextDeltaBatches.set(sessionId, {
-    text: `${current?.text ?? ''}${text}`,
-    persistId: current?.persistId ?? persistId,
-    deviceId: current?.deviceId ?? deviceId,
-    agentMeta: incomingMeta
-      ? { ...(current?.agentMeta ?? {}), ...incomingMeta }
-      : current?.agentMeta ?? null,
-  });
+  if (current) {
+    current.chunks.push(text);
+    if (incomingMeta) current.agentMeta = { ...(current.agentMeta ?? {}), ...incomingMeta };
+    if (!current.persistId) current.persistId = persistId;
+    if (current.deviceId === undefined) current.deviceId = deviceId;
+  } else {
+    pendingTextDeltaBatches.set(sessionId, {
+      chunks: [text],
+      persistId,
+      deviceId,
+      agentMeta: incomingMeta,
+    });
+  }
   scheduleTextDeltaFlush();
   return changed;
 }
@@ -2368,7 +2443,7 @@ function flushPendingTextDelta(sessionId: string): boolean {
     sessionId,
     {
       type: 'text',
-      data: { text: batch.text, isFinal: false },
+      data: { text: batch.chunks.join(''), isFinal: false },
       ...(batch.agentMeta ? { agentMeta: batch.agentMeta } : {}),
     },
     batch.persistId,
@@ -2532,6 +2607,11 @@ function recallParkedTaskUpdates(
 }
 
 export const remoteSessionStore = {
+  /** Coalesce notifications for one logically atomic remote snapshot. */
+  batch<T>(work: () => T): T {
+    return batch(work);
+  },
+
   /**
    * 新建任务第一帧标题预览。只盖哨兵,权威标题一旦离开哨兵就让位。
    * 失败撤回走 {@link clearPendingTitlePreview}。


### PR DESCRIPTION
## 这次改了什么

### 摘要

针对 #3567 的移动端长任务详情与首页长列表性能问题，降低流式消息、历史分页、折叠 Worked for、分组切换和滑动操作区带来的临时分配、原生视图挂载与 Android Fabric 压力，并修复首次进入、历史锚定、后台媒体恢复和快速滑动期间的稳定性问题。

### 变更类型

- [ ] `feat` 新功能
- [x] `fix` 缺陷修复
- [x] `refactor` / `perf` 重构或性能优化
- [ ] `docs` / `test` / `chore` 文档、测试或工程维护
- [ ] 其他：

### 范围

- 关联 Issue / 需求：#3567
- 本 PR 包含：
  - 长任务详情增加稳定历史前缀缓存，流式更新只重建活动尾部，避免每个 token 重新 normalize、分组并构造整段已加载历史。
  - 首次进入在不可见状态完成最新位置锚定；历史 prepend 保持阅读位置，运行中新增消息不会强制拉回底部。
  - 分页使用服务端最旧消息游标判断进展；当新页只扩展首个 Worked for 时，锚点稳定后继续自动拉取，不增加“已加载更早消息”提示。
  - 折叠 Worked for 时不构造或渲染内部活动，展开后再按需构造；同时降低超大 Text 树、Markdown 测量、图片图库扫描及 Mermaid、Math、媒体 WebView 的屏外开销。
  - 修复 Compact 前后正文、跨分页媒体、晚到工具结果、计划更新、子代理回包和合成 user 等缓存边界，并恢复后台中断的媒体加载。
  - 首页和设备列表为大项目子任务增加视口窗口化与稳定槽位复用；大组进入外层渲染窗口时先保留等高 spacer，仅在子区域进入视口后挂载约 23 个子 cell。
  - 首页主 Section 使用稳定 key，分组模式切换复用等价行数据，并限制首帧和批次挂载量，减少 `Group chats together` 切换时的全量重挂。
  - 会话行从 `ReanimatedSwipeable` 迁移到经典 `Swipeable`，初始只挂固定宽度空壳；开始滑动时仅为活动行挂载左右操作区、SVG 与 Animated 图，关闭后卸载。
  - 详情消息列表保持 `recycleItems=false`；仅 `listperf` 保留 DEV A/B 开关，避免异构消息树回收时出现 Fabric stale tag 与挂载竞态。
- 明确不包含：不调整消息保留策略；不修改服务端、device-link wire payload、IPC allowlist、原生依赖、原生配置或 runtime fingerprint。
- 远程与 Mobile 适配：继续使用既有 device-link 数据和分页接口；未新增协议、IPC、重试、超时或断链恢复行为。
- 用户可见变化：首次进入直接显示最新正文；加载历史保持当前位置；运行中可持续向上浏览；折叠 Worked for 只显示卡头；首页分组切换和长列表滚动响应更快；滑动操作的入口、文案和结果不变。
- 是否存在 breaking change：无。

### UI 变化

- 没有新增颜色、间距、文案体系、页面层级或操作入口。
- 折叠 Worked for 不渲染内部活动；展开后完整显示。
- 会话行的操作区改为首次滑动时挂载，但视觉、左右方向、按钮和全滑行为保持不变。
- 引用的设计规范：`docs/design-rules/DESIGN.md` §5 Layout Principles（保持既有布局层级与留白）和 §10 Light / Dark Dual-Mode Delivery Gate（未新增颜色或模式分支，继续使用既有语义 token 与 themed styles）。

## 怎么验证的

### 自动验证

```text
pnpm test:unit:related
结果：通过（apps/mobile related unit，48 个相关目标）

pnpm --filter mobile run --if-present typecheck
结果：通过

pnpm --filter mobile exec vitest run src/__tests__/swipeableSessionRowLifecycle.test.ts
结果：通过（3/3）

git diff --check / git diff --cached --check
结果：通过

pnpm check:dco
结果：通过（origin/main..HEAD 共 14 个 commit 均已签名）
```

### 手工验证

- 平台：Android 模拟器，固定使用 CN 开发包 `com.xd.cindycn`、真实登录账号和持续输出的大任务；测试期间 Global `com.xd.cindy` 无运行进程。
- 长任务详情按正常用户路径各重复 3 次：首次进入旧大任务、非运行中任务连续分页、运行中持续输出时连续向上加载多页、Compact 正文完整性、在 3 个大任务间切换并回访、展开/折叠 Worked for。
- 首页使用 All Sessions、`Group by Project=true`，每轮切换 `Group chats together` 10 次，共 3 轮；追加 300 ms 间隔快速切换 10 次。
- 首页快速上下滚动 5 轮；左右滑开/关闭各 3 轮。stale tag、JS stall、ANR 和代码异常均为 0，`/data/anr` 无本轮新增记录。
- 未执行会修改真实任务状态的全滑归档/置顶；普通打开、关闭和按钮区域渲染已验证。

### 性能对比

长任务详情口径：同一 CN Android 模拟器、同一持续输出大任务、Worked for 保持折叠；静置采样 15 秒，快滑每轮使用相同手势脚本并取 3 轮中位数。

| 指标 | 原折叠基线 | 优化后可比负载 | 变化 |
| --- | ---: | ---: | ---: |
| 静置 GC 次数 | 27 | 6 | -77.8% |
| 静置 GC 总耗时 | 4217.6 ms | 782.9 ms | -81.4% |
| 静置回收量 | 约 1060 MiB | 226 MiB | -78.7% |
| 快滑 GC 中位数 | 23 | 9 | -60.9% |
| 卡顿帧中位数 | 39.80% | 34.88% | -4.92 个百分点 |
| P99 | 101 ms | 77 ms | -23.8% |
| PSS 中位数 | 1,517,291 KiB | 1,468,711 KiB | 下降约 47 MiB |
| JS stall | 0 | 0 | 持平 |

首页分组切换口径：固定 CN、All Sessions、`Group by Project=true`；每轮切换 `Group chats together` 10 次，共 3 轮。对比“经典 Swipeable 全量操作树”和“固定空壳 + 活动行懒挂载操作树”。

| 指标 | 全量操作树 | 空壳懒挂载 |
| --- | ---: | ---: |
| P99（三轮） | 400 / 450 / 400 ms | 200 / 200 / 200 ms |
| 卡顿帧（三轮） | 96.99% / 96.79% / 97.32% | 93.09% / 97.48% / 96.68% |
| GC（三轮） | 6 / 5 / 5 | 5 / 4 / 5 |
| 轮末 PSS（三轮） | 约 1.05 / 1.09 / 1.15 GB | 0.956 / 0.999 / 1.044 GB |
| 静置 15 秒 PSS | 约 1.145 GB | 1.031 GB |
| Native Heap | 约 765 MB | 676 MB |

结论：详情页的 GC、临时分配和 P99 明显下降；首页滑动行懒挂载进一步降低 P99、PSS 与 Native Heap，但分组切换的卡顿帧仍高且三轮波动明显，反复切换后的 Native Heap 仍会增长，不能表述为卡顿已完全解决。

### 未执行的验证

- 未在 iOS 上做同口径黑盒与性能测试；JS 逻辑共用，但 LegendList、WebView、经典 Swipeable 和原生视图生命周期仍需 iOS 实测确认。
- Dark 未单独目检；Light 已实机目检。本 PR 未增加颜色或主题分支，因此不把复用 themed styles 表述为双模式已验证。
- 未执行会修改真实任务状态的全滑归档/置顶，合并前建议使用测试数据补做一次全滑与回拉取消验证。
- 未在本地执行全仓 `pnpm test:unit`；按团队流程由远端 CI 统一执行。

## 风险

### 风险分类

- [ ] 无已知风险
- [ ] SQLite / migration
- [ ] system prompt
- [ ] 协议兼容
- [ ] 权限 / 安全 / 用户数据
- [ ] 存量插件兼容（批准状态 / 指纹 / manifest 校验 / 安装布局 / 包格式）
- [ ] 原生层 / fingerprint / OTA
- [x] 跨平台差异
- [x] 其他：长列表窗口化、历史锚定、流式缓存、折叠内容懒构造、经典 Swipeable 和 WebView 可见性治理。

### 影响与回滚

- 影响范围：移动端 All Sessions / 设备详情列表，以及长任务消息列表、Markdown、Mermaid/Math WebView、远程媒体、流式更新、首次进入和历史分页。
- 主要风险：详情列表关闭行回收后，极深历史的常驻内存仍较高；首页分组切换仍有较高卡顿帧和反复切换后的 Native Heap 增长；iOS 尚未做同口径实测；全滑归档/置顶未用测试数据完成黑盒。
- 移动端冷更分析：无冷更风险。本 PR 只修改 JS/TS/TSX 和测试文件，未修改 `app.json`、`app.config.js`、`eas.json`、`apps/mobile/package.json`、原生模块、config plugin 或原生依赖，不改变 runtime fingerprint。
- 回滚 / 降级方式：回退本 PR 的 14 个 commit；不涉及数据 migration、协议或 fingerprint，无需用户迁移或重新安装。

### 提交前检查

- [x] 已 review 完整 diff
- [x] 每个 commit 都带 DCO 签名（`git commit -s`，见 [DCO](../DCO)）
- [x] UI 改动已在“UI 变化”注明引用的设计规范章节
- [x] 未提交凭证、令牌或授权文件
- [x] 已补充必要测试；不新增用户文档入口或协议文档
- [x] 已确认测试结果并说明未执行项