### PR TITLE
fix(desktop): 清除失效时间戳的残留文本

### DIFF
--- a/apps/desktop/src/renderer/hooks/__tests__/useRelativeTime.test.ts
+++ b/apps/desktop/src/renderer/hooks/__tests__/useRelativeTime.test.ts
@@ -2,9 +2,22 @@
  * useRelativeTime — chat message-action-bar relative timestamps follow app language.
  */
 
-import { describe, expect, it } from 'vitest';
+// @vitest-environment jsdom
+import { renderHook } from '@testing-library/react';
+import { afterEach, describe, expect, it, vi } from 'vitest';
 
-import { formatRelative } from '../useRelativeTime';
+import { formatRelative, useRelativeTime } from '../useRelativeTime';
+
+vi.mock('react-i18next', () => ({
+  useTranslation: () => ({
+    t: (key: string) => key,
+    i18n: { language: 'en' },
+  }),
+}));
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
 
 const JUST_NOW = 'chat.messageActionBar.relative.justNow';
 const MINUTES = 'chat.messageActionBar.relative.minutesAgo';
@@ -57,5 +70,32 @@ describe('formatRelative', () => {
 
     const otherYear = new Date(2025, 11, 25, 14, 30, 0).getTime();
     expect(formatRelative(otherYear, now, tReturnsKey)).toBe('2025-12-25 14:30');
+  });
+});
+
+describe('useRelativeTime', () => {
+  it('clears stale text when the timestamp becomes missing or unparseable', () => {
+    const now = new Date(2026, 4, 20, 12, 0, 0).getTime();
+    vi.spyOn(Date, 'now').mockReturnValue(now);
+
+    const { result, rerender } = renderHook<
+      string,
+      { createdAt: string | undefined }
+    >(
+      ({ createdAt }) => useRelativeTime(createdAt, { hovered: false }),
+      {
+        initialProps: {
+          createdAt: new Date(now - 5 * 60_000).toISOString(),
+        },
+      },
+    );
+
+    expect(result.current).toBe('5 minutes ago');
+
+    rerender({ createdAt: undefined });
+    expect(result.current).toBe('');
+
+    rerender({ createdAt: 'not-a-date' });
+    expect(result.current).toBe('');
   });
 });

--- a/apps/desktop/src/renderer/hooks/useRelativeTime.ts
+++ b/apps/desktop/src/renderer/hooks/useRelativeTime.ts
@@ -101,9 +101,15 @@ export function useRelativeTime(
   });
 
   useEffect(() => {
-    if (!createdAt) return;
+    if (!createdAt) {
+      setText('');
+      return;
+    }
     const ms = new Date(createdAt).getTime();
-    if (Number.isNaN(ms)) return;
+    if (Number.isNaN(ms)) {
+      setText('');
+      return;
+    }
 
     // Recompute once whenever hover toggles on so a long-unhovered message
     // shows the current value the moment it becomes visible.


### PR DESCRIPTION
## 这次改了什么

### 摘要

`useRelativeTime` 在拿到空值或无法解析的 `createdAt` 时会显式清空已有文本，避免组件从有效时间戳切换到无效输入后继续显示旧的相对时间。

同时补充 hook 级回归测试，覆盖“有效时间戳 → 缺失 → 非法字符串”的连续重渲染。

### 变更类型

- [ ] `feat` 新功能
- [x] `fix` 缺陷修复
- [ ] `refactor` / `perf` 重构或性能优化
- [ ] `docs` / `test` / `chore` 文档、测试或工程维护
- [ ] 其他：

### 范围

- 关联 Issue / 需求：无；#3484 的小型后续修复
- 本 PR 包含：失效时间戳的状态清理；对应回归测试
- 明确不包含：相对时间格式、刷新频率、i18n 文案、样式或布局调整
- 用户可见变化：时间戳数据变为空或非法值时，不再残留上一次的显示文本
- 是否存在 breaking change：无

### UI 变化

不涉及视觉、交互或文案变更：仅让既有时间戳在输入失效时按 hook 契约清空；未修改布局、样式、颜色或文案。

- 引用的设计规范：`docs/design-rules/DESIGN.md` §10 Light / Dark 双模式交付门槛；本次行为修复不引入模式差异，两种模式保持一致

## 怎么验证的

### 自动验证

```text
pnpm --filter desktop exec vitest run src/renderer/hooks/__tests__/useRelativeTime.test.ts
结果：1 个测试文件、4 个测试通过

pnpm --filter desktop exec eslint src/renderer/hooks/useRelativeTime.ts src/renderer/hooks/__tests__/useRelativeTime.test.ts
结果：通过

pnpm --filter desktop run --if-present typecheck
结果：通过

pnpm test:unit:related
结果：PASS apps/desktop unit（44.2s）

pnpm check:dco
结果：1 个 commit 通过 DCO 检查
```

### 手工验证

不涉及：状态迁移由 hook 重渲染回归用例直接覆盖。

### 未执行的验证

未运行全仓 `pnpm test:unit`；改动仅涉及一个 Desktop hook，仓库要求的 related 门禁已通过。

## 风险

### 风险分类

- [x] 无已知风险
- [ ] SQLite / migration
- [ ] system prompt
- [ ] 协议兼容
- [ ] 权限 / 安全 / 用户数据
- [ ] 存量插件兼容（批准状态 / 指纹 / manifest 校验 / 安装布局 / 包格式）
- [ ] 原生层 / fingerprint / OTA
- [ ] 跨平台差异
- [ ] 其他：

### 影响与回滚

- 影响范围：Desktop 消息操作栏的相对时间 hook
- 回滚 / 降级方式：回退本 PR 即恢复原行为；无数据迁移或持久化影响

### 提交前检查

- [x] 已 review 完整 diff
- [x] 每个 commit 都带 DCO 签名（`git commit -s`，见 [DCO](../DCO)）
- [x] UI 改动已在「UI 变化」注明引用的设计规范章节（不涉及 UI 则跳过）
- [x] 未提交凭证、令牌或授权文件
- [x] 已补充必要文档
- [x] 已确认测试结果或说明未执行原因
