### PR TITLE
fix(responses-chat-bridge): 兼容连续 system 前缀的模板拒绝

### DIFF
--- a/packages/responses-chat-bridge/src/__tests__/handler.test.ts
+++ b/packages/responses-chat-bridge/src/__tests__/handler.test.ts
@@ -3,6 +3,7 @@ import { EventEmitter } from 'node:events';
 import { describe, expect, it, vi } from 'vitest';
 
 import { createResponsesChatHandler } from '../handler.js';
+import type { ChatBridgeCapabilities, ChatCompletionsRequest, ResponsesRequest } from '../types.js';
 
 class FakeResponse extends EventEmitter {
   status = 0;
@@ -35,7 +36,318 @@ function streamResponse(lines: unknown[]): Response {
   return new Response(body, { status: 200, headers: { 'content-type': 'text/event-stream' } });
 }
 
+function systemOrderError(status = 400, message = 'System message must be at the beginning.'): Response {
+  return new Response(JSON.stringify({ error: { message, type: 'BadRequestError' } }), { status });
+}
+
+// Reduced shape of the real Codex capture: instructions + developer, user, user.
+// Exact captured text is replayed separately against the official Qwen template.
+function leadingSystemRequest(): ResponsesRequest {
+  return {
+    model: 'qwen3.8-27b-fp8',
+    instructions: 'base instructions',
+    input: [
+      { role: 'developer', content: 'permission instructions' },
+      { role: 'user', content: 'environment context' },
+      { role: 'user', content: 'hello' },
+    ],
+  };
+}
+
 describe('createResponsesChatHandler', () => {
+  it.each([undefined, 'coalesce-leading'] as const)(
+    'retries a rejected consecutive system prefix (#3583), policy=%s',
+    async (systemMessagePolicy) => {
+      const fetchImpl = vi.fn(async (_url: string | URL | Request, init?: RequestInit) => {
+        const body: ChatCompletionsRequest = JSON.parse(String(init?.body));
+        expect(body).not.toHaveProperty('reasoning_effort');
+        if (body.messages.slice(1).some((message) => message.role === 'system')) {
+          return systemOrderError();
+        }
+        expect(body.messages).toEqual([
+          { role: 'system', content: 'base instructions\n\npermission instructions' },
+          { role: 'user', content: 'environment context' },
+          { role: 'user', content: 'hello' },
+        ]);
+        return streamResponse([
+          { id: 'chat_1', choices: [{ delta: { content: 'hi' } }] },
+          { id: 'chat_1', choices: [{ delta: {}, finish_reason: 'stop' }] },
+        ]);
+      });
+      const onUpstreamError = vi.fn();
+      const handler = createResponsesChatHandler({
+        upstreamBase: 'https://vllm.example/v1',
+        buildHeaders: async () => ({}),
+        capabilities: { systemMessagePolicy },
+        onUpstreamError,
+      }, { fetchImpl });
+      const res = new FakeResponse();
+      await handler.handle({
+        parsedBody: { ...leadingSystemRequest(), reasoning: { effort: 'high' } },
+        res: res as never,
+      });
+      expect(res.status).toBe(200);
+      expect(res.chunks.join('')).toContain('event: response.completed');
+      expect(fetchImpl).toHaveBeenCalledTimes(systemMessagePolicy ? 1 : 2);
+      expect(onUpstreamError).not.toHaveBeenCalled();
+    },
+  );
+
+  it('leaves a consecutive system prefix intact when the upstream accepts it', async () => {
+    const fetchImpl = vi.fn(async (_url: string | URL | Request, init?: RequestInit) => {
+      expect(JSON.parse(String(init?.body)).messages).toEqual([
+        { role: 'system', content: 'base instructions' },
+        { role: 'system', content: 'permission instructions' },
+        { role: 'user', content: 'environment context' },
+        { role: 'user', content: 'hello' },
+      ]);
+      return streamResponse([{ choices: [{ delta: {}, finish_reason: 'stop' }] }]);
+    });
+    const handler = createResponsesChatHandler({
+      upstreamBase: 'https://provider.example/v1', buildHeaders: async () => ({}),
+    }, { fetchImpl });
+    const res = new FakeResponse();
+    await handler.handle({ parsedBody: leadingSystemRequest(), res: res as never });
+    expect(fetchImpl).toHaveBeenCalledOnce();
+    expect(res.status).toBe(200);
+  });
+
+  it('preserves whitespace and repeated instructions without depending on a model alias', async () => {
+    const bodies: ChatCompletionsRequest[] = [];
+    const instruction = '  permission boundary\r\nkeep this text\n';
+    const fetchImpl = vi.fn(async (_url: string | URL | Request, init?: RequestInit) => {
+      bodies.push(JSON.parse(String(init?.body)));
+      if (bodies.length === 1) return systemOrderError();
+      return streamResponse([{ choices: [{ delta: {}, finish_reason: 'stop' }] }]);
+    });
+    const handler = createResponsesChatHandler({
+      upstreamBase: 'https://provider.example/v1',
+      buildHeaders: async () => ({}),
+      capabilities: { reasoningField: 'reasoning_effort', reasoningEffortMap: { high: 'xhigh' } },
+    }, { fetchImpl });
+    const res = new FakeResponse();
+    await handler.handle({
+      parsedBody: {
+        model: 'custom-alias', instructions: instruction, reasoning: { effort: 'high' },
+        input: [
+          { role: 'developer', content: instruction },
+          { role: 'system', content: 'last instruction' },
+          { role: 'user', content: 'hello' },
+        ],
+      },
+      res: res as never,
+    });
+    expect(fetchImpl).toHaveBeenCalledTimes(2);
+    expect(bodies[1]).toEqual({
+      ...bodies[0],
+      messages: [
+        { role: 'system', content: `${instruction}\n\n${instruction}\n\nlast instruction` },
+        { role: 'user', content: 'hello' },
+      ],
+    });
+    expect(bodies[1].reasoning_effort).toBe('xhigh');
+    expect(res.status).toBe(200);
+  });
+
+  it.each<{
+    name: string;
+    status?: number;
+    message?: string;
+    errorBody?: string;
+    capabilities?: ChatBridgeCapabilities;
+    input?: ResponsesRequest;
+  }>([
+    { name: 'explicit preserve policy', capabilities: { systemMessagePolicy: 'preserve' } },
+    { name: 'native developer role', capabilities: { developerRole: 'developer' } },
+    { name: 'already coalesced policy', capabilities: { systemMessagePolicy: 'coalesce-leading' } },
+    { name: 'already leading system', input: { model: 'm', instructions: 'base', input: 'hello' } },
+    { name: 'system after user', input: { model: 'm', instructions: 'base', input: [
+      { role: 'user', content: 'hello' }, { role: 'developer', content: 'later instructions' },
+    ] } },
+    { name: 'leading prefix followed by a late system', input: { ...leadingSystemRequest(), input: [
+      { role: 'developer', content: 'initial permissions' },
+      { role: 'user', content: 'hello' },
+      { role: 'system', content: 'updated permissions' },
+    ] } },
+    { name: 'no leading prefix', input: { model: 'm', input: [
+      { role: 'user', content: 'hello' }, { role: 'system', content: 'later instructions' },
+    ] } },
+    { name: 'empty system only', input: { model: 'm', input: [
+      { role: 'user', content: 'hi' }, { role: 'system', content: '' },
+    ] } },
+    { name: 'authentication error', status: 401 },
+    { name: 'permission error', status: 403 },
+    { name: 'validation error', status: 422 },
+    { name: 'rate limit', status: 429 },
+    { name: 'server error', status: 500 },
+    { name: 'different role error', message: 'Unexpected message role.' },
+    { name: 'quoted error in unrelated rejection', message: 'Invalid content: System message must be at the beginning.' },
+    { name: 'unstructured error', errorBody: 'System message must be at the beginning.' },
+    { name: 'non-string error message', errorBody: '{"error":{"message":null}}' },
+  ])('does not retry system normalization for $name', async ({ status = 400, message, errorBody, capabilities, input }) => {
+    const fetchImpl = vi.fn(async () => errorBody === undefined
+      ? systemOrderError(status, message)
+      : new Response(errorBody, { status }));
+    const onUpstreamError = vi.fn();
+    const handler = createResponsesChatHandler({
+      upstreamBase: 'https://vllm.example/v1',
+      buildHeaders: async () => ({}),
+      capabilities,
+      onUpstreamError,
+    }, { fetchImpl });
+    const res = new FakeResponse();
+    await handler.handle({ parsedBody: input ?? leadingSystemRequest(), res: res as never });
+    expect(fetchImpl).toHaveBeenCalledOnce();
+    expect(res.status).toBe(status);
+    expect(onUpstreamError).toHaveBeenCalledOnce();
+    expect(res.listenerCount('close')).toBe(0);
+  });
+
+  it.each([400, 401, 503])('reports only the final error when the compatibility retry fails with %s', async (status) => {
+    const fetchImpl = vi.fn()
+      .mockResolvedValueOnce(systemOrderError())
+      .mockResolvedValueOnce(systemOrderError(status));
+    const onUpstreamError = vi.fn();
+    const handler = createResponsesChatHandler({
+      upstreamBase: 'https://vllm.example/v1',
+      buildHeaders: async () => ({}),
+      onUpstreamError,
+    }, { fetchImpl });
+    const res = new FakeResponse();
+    await handler.handle({ parsedBody: leadingSystemRequest(), res: res as never });
+    expect(fetchImpl).toHaveBeenCalledTimes(2);
+    expect(res.status).toBe(status);
+    expect(onUpstreamError).toHaveBeenCalledOnce();
+    expect(onUpstreamError).toHaveBeenCalledWith(expect.objectContaining({ status }));
+    expect(res.listenerCount('close')).toBe(0);
+  });
+
+  it('preserves tools, media, tuning and the original input across a request-local retry', async () => {
+    const bodies: ChatCompletionsRequest[] = [];
+    const fetchImpl = vi.fn(async (_url: string | URL | Request, init?: RequestInit) => {
+      const body = JSON.parse(String(init?.body));
+      bodies.push(body);
+      if (bodies.length === 1) return systemOrderError();
+      return new Response(JSON.stringify({
+        id: 'chat_json',
+        choices: [{ message: { role: 'assistant', content: 'done' }, finish_reason: 'stop' }],
+      }), { headers: { 'content-type': 'application/json' } });
+    });
+    const handler = createResponsesChatHandler({
+      upstreamBase: 'https://vllm.example/v1',
+      buildHeaders: async () => ({ authorization: 'Bearer test-token' }),
+      capabilities: { imageInput: 'image_url', passthroughFields: ['temperature'] },
+    }, { fetchImpl });
+    const source: ResponsesRequest = {
+      ...leadingSystemRequest(),
+      stream: false,
+      temperature: 0.2,
+      tools: [{ type: 'function', name: 'inspect', parameters: { type: 'object' } }],
+      input: [
+        { role: 'developer', content: 'permission instructions' },
+        { role: 'user', content: 'first' },
+        { type: 'function_call', call_id: 'c1', name: 'inspect', arguments: '{}' },
+        { type: 'function_call_output', call_id: 'c1', output: 'tool result' },
+        { role: 'user', content: [{ type: 'input_image', image_url: 'https://image.example/test.png' }] },
+      ],
+    };
+    const original = structuredClone(source);
+    const res = new FakeResponse();
+    await handler.handle({ parsedBody: source, res: res as never });
+    expect(res.status).toBe(200);
+    expect(JSON.parse(res.chunks.join('')).status).toBe('completed');
+    const { messages: firstMessages, ...firstFields } = bodies[0];
+    const { messages: retryMessages, ...retryFields } = bodies[1];
+    expect(retryFields).toEqual(firstFields);
+    expect(retryMessages).toEqual([
+      { role: 'system', content: 'base instructions\n\npermission instructions' },
+      ...firstMessages.filter((message) => message.role !== 'system'),
+    ]);
+    expect(source).toEqual(original);
+    expect(fetchImpl.mock.calls[1][0]).toBe(fetchImpl.mock.calls[0][0]);
+    expect(fetchImpl.mock.calls[1][1]?.headers).toEqual(fetchImpl.mock.calls[0][1]?.headers);
+    expect(fetchImpl.mock.calls[1][1]?.signal).toBe(fetchImpl.mock.calls[0][1]?.signal);
+
+    // A later request must not inherit a policy learned from this request's upstream error.
+    const next = new FakeResponse();
+    await handler.handle({ parsedBody: source, res: next as never });
+    expect(bodies[2]).toEqual(bodies[0]);
+    expect(fetchImpl).toHaveBeenCalledTimes(3);
+  });
+
+  it('does not retry after the client disconnects while reading the template error', async () => {
+    const res = new FakeResponse();
+    const response = systemOrderError();
+    const read = response.text.bind(response);
+    vi.spyOn(response, 'text').mockImplementation(async () => {
+      res.emit('close');
+      return read();
+    });
+    const fetchImpl = vi.fn(async () => response);
+    const handler = createResponsesChatHandler({
+      upstreamBase: 'https://vllm.example/v1', buildHeaders: async () => ({}),
+    }, { fetchImpl });
+    await handler.handle({ parsedBody: leadingSystemRequest(), res: res as never });
+    expect(fetchImpl).toHaveBeenCalledOnce();
+    expect(res.headersSent).toBe(false);
+    expect(res.listenerCount('close')).toBe(0);
+  });
+
+  it('cleans up when the compatibility retry cannot reach the upstream', async () => {
+    const fetchImpl = vi.fn()
+      .mockResolvedValueOnce(systemOrderError())
+      .mockRejectedValueOnce(new Error('network unavailable'));
+    const handler = createResponsesChatHandler({
+      upstreamBase: 'https://vllm.example/v1', buildHeaders: async () => ({}),
+    }, { fetchImpl });
+    const res = new FakeResponse();
+    await handler.handle({ parsedBody: leadingSystemRequest(), res: res as never });
+    expect(fetchImpl).toHaveBeenCalledTimes(2);
+    expect(res.status).toBe(502);
+    expect(res.chunks.join('')).toContain('upstream_unreachable');
+    expect(res.listenerCount('close')).toBe(0);
+  });
+
+  it('does not report or write a retry error after the client disconnects during its body read', async () => {
+    const res = new FakeResponse();
+    const response = systemOrderError();
+    const read = response.text.bind(response);
+    vi.spyOn(response, 'text').mockImplementation(async () => {
+      res.emit('close');
+      return read();
+    });
+    const fetchImpl = vi.fn()
+      .mockResolvedValueOnce(systemOrderError())
+      .mockResolvedValueOnce(response);
+    const onUpstreamError = vi.fn();
+    const handler = createResponsesChatHandler({
+      upstreamBase: 'https://vllm.example/v1', buildHeaders: async () => ({}), onUpstreamError,
+    }, { fetchImpl });
+    await handler.handle({ parsedBody: leadingSystemRequest(), res: res as never });
+    expect(fetchImpl).toHaveBeenCalledTimes(2);
+    expect(res.headersSent).toBe(false);
+    expect(onUpstreamError).not.toHaveBeenCalled();
+    expect(res.listenerCount('close')).toBe(0);
+  });
+
+  it('aborts the compatibility retry when the client disconnects', async () => {
+    const res = new FakeResponse();
+    const fetchImpl = vi.fn()
+      .mockResolvedValueOnce(systemOrderError())
+      .mockImplementationOnce(async (_url: string | URL | Request, init?: RequestInit) => {
+        res.emit('close');
+        expect(init?.signal?.aborted).toBe(true);
+        throw new Error('aborted');
+      });
+    const handler = createResponsesChatHandler({
+      upstreamBase: 'https://vllm.example/v1', buildHeaders: async () => ({}),
+    }, { fetchImpl });
+    await handler.handle({ parsedBody: leadingSystemRequest(), res: res as never });
+    expect(fetchImpl).toHaveBeenCalledTimes(2);
+    expect(res.headersSent).toBe(false);
+    expect(res.listenerCount('close')).toBe(0);
+  });
+
   it('posts translated Chat request and streams Responses events', async () => {
     const fetchImpl = vi.fn(async (_url: string | URL | Request, init?: RequestInit) => {
       const body = JSON.parse(String(init?.body));

--- a/packages/responses-chat-bridge/src/handler.ts
+++ b/packages/responses-chat-bridge/src/handler.ts
@@ -1,11 +1,12 @@
 import type { ServerResponse } from 'node:http';
 
 import { ChatSseTranslator } from './chat-sse-translator.js';
-import { translateResponsesRequestWithContext } from './translate-request.js';
+import { coalesceLeadingSystemMessages, translateResponsesRequestWithContext } from './translate-request.js';
 import {
   UnsupportedResponsesFeatureError,
   type ChatBridgeLogger,
   type ChatBridgeProviderConfig,
+  type ChatMessage,
   type ResponsesChatBridgeHandler,
   type ResponsesRequest,
 } from './types.js';
@@ -26,6 +27,28 @@ function classifyUpstreamErrorBody(text: string): 'empty' | 'json' | 'text' {
   } catch {
     return 'text';
   }
+}
+
+function isSystemMessageOrderError(status: number, text: string): boolean {
+  if (status !== 400) return false;
+  try {
+    const body: unknown = JSON.parse(text);
+    return isPlainObject(body)
+      && isPlainObject(body.error)
+      && typeof body.error.message === 'string'
+      && /^system message must be at the beginning\.?$/i.test(body.error.message.trim());
+  } catch {
+    return false;
+  }
+}
+
+/** Only retry a prefix merge; moving later instructions across a turn changes their scope. */
+function hasConsecutiveSystemPrefix(messages: ChatMessage[]): boolean {
+  let prefixLength = 0;
+  while (messages[prefixLength]?.role === 'system') prefixLength += 1;
+  return prefixLength > 1 && messages.every((message, index) => (
+    index < prefixLength || (message.role !== 'system' && message.role !== 'developer')
+  ));
 }
 
 function writeJson(res: ServerResponse, status: number, body: unknown): void {
@@ -235,8 +258,9 @@ export function createResponsesChatHandler(
       const abortUpstream = (): void => abort.abort();
       res.once('close', abortUpstream);
       let upstream: Response;
+      let upstreamErrorText: string | undefined;
       try {
-        upstream = await fetchImpl(upstreamUrl, {
+        const send = (): Promise<Response> => fetchImpl(upstreamUrl, {
           method: 'POST',
           headers: {
             ...providerHeaders,
@@ -246,6 +270,32 @@ export function createResponsesChatHandler(
           body: JSON.stringify(chatRequest),
           signal: abort.signal,
         });
+        upstream = await send();
+        if (!upstream.ok) {
+          upstreamErrorText = await readErrorText(upstream);
+          // Qwen can reject instructions + developer even before the first user (#3583).
+          // Retry only a precise pre-generation rejection, once and within this request.
+          // Explicit policies and native developer-role semantics remain authoritative.
+          if (
+            provider.capabilities?.systemMessagePolicy === undefined
+            && provider.capabilities?.developerRole !== 'developer'
+            && isSystemMessageOrderError(upstream.status, upstreamErrorText)
+            && !abort.signal.aborted
+            && hasConsecutiveSystemPrefix(chatRequest.messages)
+          ) {
+            const coalesced = coalesceLeadingSystemMessages(chatRequest.messages);
+            if (coalesced !== chatRequest.messages) {
+              chatRequest.messages = coalesced;
+              upstream = await send();
+              upstreamErrorText = upstream.ok ? undefined : await readErrorText(upstream);
+            }
+          }
+        }
+        if (abort.signal.aborted) {
+          res.off('close', abortUpstream);
+          void upstream.body?.cancel().catch(() => {});
+          return;
+        }
       } catch (error) {
         res.off('close', abortUpstream);
         if (abort.signal.aborted) return;
@@ -271,7 +321,7 @@ export function createResponsesChatHandler(
       };
 
       if (!upstream.ok || !upstream.body) {
-        const text = await readErrorText(upstream);
+        const text = upstreamErrorText ?? await readErrorText(upstream);
         log.warn?.('responses-chat bridge upstream error', {
           model: request.model,
           status: upstream.status,


### PR DESCRIPTION
## 这次改了什么

### 摘要

Responses → Chat 桥会把顶层 `instructions` 和输入中的 `developer` 分别转换为 system 消息，因此正常的单轮输入也可能生成 `system → system → user → user`。Qwen 官方模板只允许第一条消息使用 system，即使两条 system 都在用户输入之前，也会抛出 `System message must be at the beginning.`。

本 PR 在上游返回对应的结构化 HTTP 400 后，仅对连续 system 前缀合并并重试一次。复用现有合并逻辑，保留指令原文和顺序，不跨用户、助手或工具消息移动后续指令。正常成功请求保持原样，显式能力配置仍优先。

### 变更类型

- [ ] `feat` 新功能
- [x] `fix` 缺陷修复
- [ ] `refactor` / `perf` 重构或性能优化
- [ ] `docs` / `test` / `chore` 文档、测试或工程维护
- [ ] 其他：

### 范围

- 关联 Issue / 需求：Related to #3583。修复调查中独立确认的 Chat 模板兼容问题，不据此自动关闭整个 Issue。
- 本 PR 包含：bridge handler 的一次性兼容重试、连续前缀检查、取消清理，以及对应回归测试；仅两个文件。
- 明确不包含：原生 `/v1/responses` 路径的 reasoning effort 或 role 转换、模型名称猜测、跨请求能力缓存、服务端修改，以及移动中途 system/developer 指令。既有 `reasoning` 映射和显式 `systemMessagePolicy` 行为不变。
- 用户可见变化：满足上述条件的 Chat 模板拒绝可以在同一次请求内恢复；其他上游错误照常返回。
- 是否存在 breaking change：无；`preserve`、`coalesce-leading` 和原生 developer role 等显式能力配置保持权威。

### UI 变化

不涉及。

- 引用的设计规范：不涉及。

## 怎么验证的

### 自动验证

环境：Windows x64，Node 24.19.0，pnpm 10.33.2，Vitest 3.2.7。

仓库根目录：

```text
pnpm test:unit:related
结果：通过。选择器运行 Desktop 完整 unit（386.4 秒）及 bridge 相关 unit（1.2 秒）。

pnpm --filter @cindy/responses-chat-bridge run --if-present typecheck
结果：通过。

git diff --check
结果：通过。
```

在 `packages/responses-chat-bridge` 目录：

```text
node ../../node_modules/vitest/vitest.mjs run
结果：5 个测试文件、188 条测试通过，其中 handler 67 条。

node ../../node_modules/eslint/bin/eslint.js src/handler.ts src/__tests__/handler.test.ts
结果：通过。
```

回归覆盖连续 system 前缀、正常上游不改写、显式策略优先、后续指令不移动、非目标错误不重试、最多一次重试、重试再次失败、客户端取消、原始输入不变、工具/媒体/调参保留，以及重复指令和空白保留。

第一轮相关门禁因独立 worktree 缺少 SQLite 原生绑定及 Electron 运行文件失败；补齐锁定版本的依赖后，三个代表性失败文件的 131 条测试通过，重新预检和完整相关门禁均通过。没有修改或跳过失败测试，也没有修改依赖清单或锁文件。提交前复核了相同代码指纹的通过记录和同一执行边界的预检。

DCO：`pnpm check:dco` 通过，检查范围内 1 个提交带有与作者一致的 `Signed-off-by`。

### 手工验证

未执行 UI 手工操作；另完成真实捕获请求的离线组件回放：

- 从未修改的 v0.1.66 客户端核心链路和真实 Codex 0.145.0 进程捕获正常 `Hello.` 请求，使用其宿主预处理结果直接调用生产 bridge handler，首个 Chat 请求与原捕获输出完全一致。
- 使用 Transformers 5.16.1 / Jinja2 3.1.6 执行 [Qwen3.8-27B-FP8 官方模板固定版本](https://huggingface.co/Qwen/Qwen3.8-27B-FP8/resolve/017b9c7af6b5689d5dd426a76e0bc077eb5ca20a/chat_template.jinja)。模板 SHA256 为 `c3cf9e34abf4f9e36c2d72165aa9c132d3e2a725b6c2586aaa3a8af9d7a81041`。
- 原版输出 `system → system → user → user`，真实模板抛出上述 TemplateError；本补丁通过生产重试路径生成 `system → user → user` 后，模板渲染通过。断言全部指令原文按顺序保留，其他请求字段不变，原始 Responses 输入未被修改。
- 模板异常是真实执行结果；用于驱动 handler 的 HTTP 400 JSON 包装和终态 SSE 是测试适配器，不等同于启动真实 vLLM 服务或完成模型推理。

### 未执行的验证

- 未在报告者部署现场、完整 Electron UI 或真实 vLLM HTTP/模型推理链路中复测：缺少报告者原始请求、完整部署参数和模板覆盖配置，当前环境未启动这些运行时。因此不能声称已确认报告者现场根因，也不能声称解决原生 Responses 模式的其他报错。
- 未实机验证 macOS/Linux；生产改动仅涉及请求内的 TypeScript 消息检查及重试，无新增平台 API。
- 未测实际模型输出、推理延迟或缓存命中率；已验证请求内容、顺序、确定性及网络重试次数边界。
- 未额外运行全仓 `pnpm test:unit` 或 `pnpm test:all`；本地按相关选择器覆盖 Desktop 消费方完整 unit 和 bridge，完整 CI 结果以 PR checks 为准。

## 风险

### 风险分类

- [ ] 无已知风险
- [ ] SQLite / migration
- [x] system prompt
- [x] 协议兼容
- [ ] 权限 / 安全 / 用户数据
- [ ] 存量插件兼容（批准状态 / 指纹 / manifest 校验 / 安装布局 / 包格式）
- [ ] 原生层 / fingerprint / OTA
- [ ] 跨平台差异
- [ ] 其他：

### 影响与回滚

- 影响范围：仅 Responses → Chat 桥在未指定 system 策略、未使用原生 developer role、开头存在至少两条连续 system 且后续没有 system/developer 时，对精确匹配的结构化 HTTP 400 合并前缀并重试一次。不会修改 Cindy 的全局提示词文本、权限配置或用户持久数据；system prompt 风险来自 wire 消息分组变化，已验证指令原文、重复内容和顺序保留。
- 兼容与开销：正常成功请求没有额外网络往返；目标错误最多增加一次发送。不学习或持久化能力，因此后续请求仍从原始形态开始；认证头、工具上下文和取消信号保持在本请求内。再次失败仅报告最终错误，客户端取消后停止发送/回写。指令合并为线性处理，不进入逐 token 热路径。
- 回滚 / 降级方式：回退本 PR 即恢复原有拒绝行为，无数据迁移或恢复步骤；已有显式 `systemMessagePolicy: 'preserve'` 配置继续禁止自动合并。既有 `coalesce-leading` 配置行为不变。

### 提交前检查

- [x] 已 review 完整 diff
- [x] 每个 commit 都带 DCO 签名（`git commit -s`，见 [DCO](../DCO)）
- [x] UI 改动已在「UI 变化」注明引用的设计规范章节（不涉及 UI 则跳过）
- [x] 未提交凭证、令牌或授权文件
- [x] 已补充必要文档
- [x] 已确认测试结果或说明未执行原因
