### PR TITLE
chore: ignore local Pi and Codex agent overlays

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -112,9 +112,13 @@ nul
 # ── AI coding agent 本地状态 ──────────────────────────────────
 # 国际主流
 # Agent 工具私有目录整体忽略；共享说明只通过 AGENTS.md / CLAUDE.md 提交。
+# 本机覆盖不入仓：CLAUDE.local.md（Claude 叠加）。
+# AGENTS.override.md 会整份替换 AGENTS.md，不得当本机备注用；出现也不入仓。
 .agents/
 .learnings/
 .claude/
+.pi/
+AGENTS.override.md
 CLAUDE.local.md
 .codex/
 .cursor/


### PR DESCRIPTION
## 这次改了什么

### 摘要

把本机 agent 说明挡在 Git 外面，避免误提交。`.pi/` 整目录 ignore（与 `.claude/`、`.codex/` 对齐）。`AGENTS.override.md` 也会 ignore：Codex / Pi 0.84+ 会拿它**整份替换**已提交的 `AGENTS.md`，不能当本机备注。可叠加的本机说明继续放 gitignored 的 `CLAUDE.local.md`。

### 变更类型

- [x] `docs` / `test` / `chore` 文档、测试或工程维护

### 范围

- 关联 Issue / 需求：无
- 本 PR 包含：`.gitignore` 增加 `.pi/` 与 `AGENTS.override.md`
- 明确不包含：不改 `AGENTS.md`；不提交任何本机说明正文
- 用户可见变化：无
- 是否存在 breaking change：无

### UI 变化

- 引用的设计规范：不涉及

## 怎么验证的

### 自动验证

```text
pnpm test:unit:related
结果：related 判定只改非代码文件，跑了根 test:runner；438 tests, 437 pass, 1 skipped, 0 fail

pnpm check:dco
结果：1 commit signed off — range origin/main..HEAD
```

无 package 源码改动，未跑 typecheck。

### 手工验证

```text
git check-ignore -v .pi/ .pi/APPEND_SYSTEM.md CLAUDE.local.md AGENTS.override.md
结果：均被 ignore
```

### 未执行的验证

无。本机 `CLAUDE.local.md` 不在本 PR 中。

## 风险

### 风险分类

- [x] 无已知风险

### 影响与回滚

- 影响范围：仅 gitignore。之后 `.pi/` 与 `AGENTS.override.md` 不会被跟踪。
- 回滚 / 降级方式：还原 `.gitignore` 这 4 行。

### 提交前检查

- [x] 已 review 完整 diff
- [x] 每个 commit 都带 DCO 签名（`git commit -s`，见 [DCO](../DCO)）
- [x] UI 改动已在「UI 变化」注明引用的设计规范章节（不涉及 UI 则跳过）
- [x] 未提交凭证、令牌或授权文件
- [x] 已补充必要文档
- [x] 已确认测试结果或说明未执行原因