### PR TITLE
feat(orca): make worker validation errors actionable

### DIFF
--- a/packages/lizi-mcps/src/__tests__/sessionContext.test.ts
+++ b/packages/lizi-mcps/src/__tests__/sessionContext.test.ts
@@ -1,5 +1,7 @@
 import { createHash } from 'node:crypto';
 
+import { Client } from '@modelcontextprotocol/sdk/client/index.js';
+import { InMemoryTransport } from '@modelcontextprotocol/sdk/inMemory.js';
 import { describe, expect, it, vi } from 'vitest';
 
 import { createOrcaMcpServer } from '../orca/server.js';
@@ -152,6 +154,117 @@ describe('dynamic lizi MCP session context', () => {
     expect(first).toContain('get_worker_queue_status');
     expect(first).toContain('merge_queued_messages');
     expect(first).not.toContain('list_worker_queue');
+  });
+
+  it('returns actionable worker validation without weakening public schemas', async () => {
+    const deps = createOrcaDeps();
+    const server = createOrcaMcpServer(deps, {
+      agentKind: 'codex',
+      workingDir: '/repo',
+      sessionId: 'lead-1',
+      vendorOptions: { orcaRole: 'lead' },
+    });
+    const [clientTransport, serverTransport] = InMemoryTransport.createLinkedPair();
+    const client = new Client({ name: 'orca-validation-client', version: '0.0.0' });
+    await Promise.all([server.connect(serverTransport), client.connect(clientTransport)]);
+
+    try {
+      const listed = await client.listTools();
+      const publicSchema = listed.tools.find((tool) => tool.name === 'create_worker')?.inputSchema;
+      expect(publicSchema).toMatchObject({
+        type: 'object',
+        required: ['role', 'agent', 'label'],
+        additionalProperties: false,
+      });
+      expect(listed.tools.find((tool) => tool.name === 'create_workers')?.inputSchema).toMatchObject({
+        type: 'object',
+        required: ['workers'],
+        additionalProperties: false,
+      });
+
+      const result = await client.callTool({
+        name: 'create_worker',
+        arguments: {
+          args: { role: 'reviewer', agent: 'codex', label: 'reviewer_1' },
+          debug: true,
+        },
+      });
+      const payload = parse(result as never);
+      expect(payload).toMatchObject({
+        ok: false,
+        errorCode: 'INVALID_ARGS',
+        data: {
+          tool: 'create_worker',
+          missing_fields: ['role', 'agent', 'label'],
+          unexpected_fields: ['args', 'debug'],
+          expected_call:
+            'create_worker({"role":"reviewer","agent":"codex","label":"worker_1"})',
+        },
+      });
+      expect(payload.data.hint).toContain('top level');
+      expect(payload.data.validation_errors).toEqual(expect.arrayContaining([
+        expect.objectContaining({
+          path: 'role',
+          expected_type: 'string',
+          received_type: 'missing',
+          missing: true,
+        }),
+        expect.objectContaining({
+          path: 'args',
+          received_type: 'object',
+          missing: false,
+        }),
+      ]));
+
+      const privateValue = 'private-agent-value-that-must-not-leak';
+      const wrongTypes = await client.callTool({
+        name: 'create_worker',
+        arguments: { role: 42, agent: privateValue, label: { nested: true } },
+      });
+      const wrongTypePayload = parse(wrongTypes as never);
+      expect(JSON.stringify(wrongTypePayload)).not.toContain(privateValue);
+      expect(wrongTypePayload.data.validation_errors).toEqual(expect.arrayContaining([
+        expect.objectContaining({ path: 'role', received_type: 'number', missing: false }),
+        expect.objectContaining({ path: 'agent', received_type: 'string', missing: false }),
+        expect.objectContaining({ path: 'label', received_type: 'object', missing: false }),
+      ]));
+
+      const batchResult = await client.callTool({
+        name: 'create_workers',
+        arguments: { args: { workers: [] } },
+      });
+      expect(parse(batchResult as never)).toMatchObject({
+        ok: false,
+        errorCode: 'INVALID_ARGS',
+        data: {
+          tool: 'create_workers',
+          missing_fields: ['workers'],
+          unexpected_fields: ['args'],
+          expected_call:
+            'create_workers({"workers":[{"role":"reviewer","agent":"codex","label":"worker_1"},{"role":"tester","agent":"codex","label":"worker_2"}]})',
+        },
+      });
+      expect(deps.createWorker).not.toHaveBeenCalled();
+
+      const validResult = await client.callTool({
+        name: 'create_worker',
+        arguments: { role: 'reviewer', agent: 'codex', label: 'reviewer_1' },
+      });
+      expect(parse(validResult as never)).toMatchObject({
+        ok: true,
+        worker_id: 'worker-1',
+        worker_session_id: 'worker-session-1',
+      });
+      expect(deps.createWorker).toHaveBeenCalledWith(expect.objectContaining({
+        leadSessionId: 'lead-1',
+        role: 'reviewer',
+        agent: 'codex',
+        label: 'reviewer_1',
+      }));
+    } finally {
+      await client.close();
+      await server.close();
+    }
   });
 
   it('keeps send_to_worker public schema free of interrupt controls', () => {

--- a/packages/lizi-mcps/src/__tests__/sessionContext.test.ts
+++ b/packages/lizi-mcps/src/__tests__/sessionContext.test.ts
@@ -185,7 +185,12 @@ describe('dynamic lizi MCP session context', () => {
       const result = await client.callTool({
         name: 'create_worker',
         arguments: {
-          args: { role: 'reviewer', agent: 'codex', label: 'reviewer_1' },
+          args: {
+            role: 'architect',
+            agent: 'pi',
+            label: 'planner_1',
+            initial_task: 'plan the release',
+          },
           debug: true,
         },
       });
@@ -197,11 +202,14 @@ describe('dynamic lizi MCP session context', () => {
           tool: 'create_worker',
           missing_fields: ['role', 'agent', 'label'],
           unexpected_fields: ['args', 'debug'],
-          expected_call:
+          example_call:
             'create_worker({"role":"reviewer","agent":"codex","label":"worker_1"})',
+          example_only: true,
         },
       });
-      expect(payload.data.hint).toContain('top level');
+      expect(payload.data.hint).toContain('without changing their values');
+      expect(payload.data.example_note).toContain('Preserve the user-requested');
+      expect(JSON.stringify(payload)).not.toContain('plan the release');
       expect(payload.data.validation_errors).toEqual(expect.arrayContaining([
         expect.objectContaining({
           path: 'role',
@@ -240,8 +248,9 @@ describe('dynamic lizi MCP session context', () => {
           tool: 'create_workers',
           missing_fields: ['workers'],
           unexpected_fields: ['args'],
-          expected_call:
+          example_call:
             'create_workers({"workers":[{"role":"reviewer","agent":"codex","label":"worker_1"},{"role":"tester","agent":"codex","label":"worker_2"}]})',
+          example_only: true,
         },
       });
       expect(deps.createWorker).not.toHaveBeenCalled();

--- a/packages/lizi-mcps/src/orca/server.ts
+++ b/packages/lizi-mcps/src/orca/server.ts
@@ -396,7 +396,7 @@ function makeActionableValidationError(
   schema: z.ZodObject<ZodRawShape>,
   rawArgs: unknown,
   issues: ZodIssueLike[],
-  expectedCall: string,
+  exampleCall: string,
 ) {
   const validationErrors = summarizeValidationIssues(issues, rawArgs);
   const missingFields = validationErrors
@@ -407,15 +407,17 @@ function makeActionableValidationError(
     .map((issue) => issue.path);
   const wrappedArgs = unexpectedFields.includes('args');
   const hint = wrappedArgs
-    ? `Pass ${name} arguments at the top level; do not wrap them in "args". Follow expected_call, fix every listed field, and retry.`
-    : `Follow expected_call, fix every listed field, and retry ${name}.`;
+    ? `Move the fields inside "args" to the top level without changing their values, remove the "args" wrapper and any other unexpected fields, fix every listed field, and retry ${name}. example_call only demonstrates the argument shape; do not copy its business values.`
+    : `Fix every listed field against schema while preserving valid user-provided values, then retry ${name}. example_call only demonstrates the argument shape; do not copy its business values.`;
 
   return errorPayload('INVALID_ARGS', hint, {
     tool: name,
     validation_errors: validationErrors,
     missing_fields: missingFields,
     unexpected_fields: unexpectedFields,
-    expected_call: expectedCall,
+    example_call: exampleCall,
+    example_only: true,
+    example_note: 'Structure only. Preserve the user-requested worker count, roles, agents, labels, and tasks when retrying.',
     schema: z.toJSONSchema(schema, { target: 'draft-7' }),
   });
 }
@@ -460,7 +462,7 @@ class DirectToolSink extends XdtHelperToolRegistry {
       const schema = z.strictObject(def.inputShape);
       // Curated examples stay concise, while parsing them against the live schema
       // makes schema/example drift fail immediately during server construction.
-      const expectedCall = `${def.name}(${JSON.stringify(
+      const exampleCall = `${def.name}(${JSON.stringify(
         schema.parse(ACTIONABLE_VALIDATION_EXAMPLES[def.name]),
       )})`;
       this.mcp.registerTool(
@@ -477,7 +479,7 @@ class DirectToolSink extends XdtHelperToolRegistry {
               schema,
               rawArgs,
               parsed.error.issues as unknown as ZodIssueLike[],
-              expectedCall,
+              exampleCall,
             );
           }
           return def.handler(parsed.data as { [K in keyof T]: z.infer<T[K]> });

--- a/packages/lizi-mcps/src/orca/server.ts
+++ b/packages/lizi-mcps/src/orca/server.ts
@@ -291,6 +291,151 @@ export interface OrcaMcpSessionCtx {
   vendorOptions?: Record<string, unknown>;
 }
 
+const ACTIONABLE_VALIDATION_EXAMPLES = {
+  create_worker: { role: 'reviewer', agent: 'codex', label: 'worker_1' },
+  create_workers: {
+    workers: [
+      { role: 'reviewer', agent: 'codex', label: 'worker_1' },
+      { role: 'tester', agent: 'codex', label: 'worker_2' },
+    ],
+  },
+} as const;
+
+type ActionableValidationTool = keyof typeof ACTIONABLE_VALIDATION_EXAMPLES;
+
+function isActionableValidationTool(name: string): name is ActionableValidationTool {
+  return Object.hasOwn(ACTIONABLE_VALIDATION_EXAMPLES, name);
+}
+
+interface ValidationIssueSummary {
+  path: string;
+  code: string;
+  expected_type?: string;
+  received_type: string;
+  missing: boolean;
+}
+
+interface ZodIssueLike {
+  code: string;
+  path: PropertyKey[];
+  input?: unknown;
+  expected?: unknown;
+  keys?: string[];
+}
+
+interface ValidationTransportInternals {
+  def: {
+    shape?: ZodRawShape;
+  };
+  toJSONSchema?: () => unknown;
+}
+
+function valueType(value: unknown): string {
+  if (value === undefined) return 'missing';
+  if (value === null) return 'null';
+  if (Array.isArray(value)) return 'array';
+  return typeof value;
+}
+
+function formatPath(parts: PropertyKey[]): string {
+  return parts.reduce<string>((path, part) => {
+    if (typeof part === 'number') return `${path}[${part}]`;
+    const key = String(part);
+    return path.length === 0 ? key : `${path}.${key}`;
+  }, '');
+}
+
+function valueAtPath(root: unknown, path: PropertyKey[]): unknown {
+  let value = root;
+  for (const part of path) {
+    if (value === null || typeof value !== 'object') return undefined;
+    value = (value as Record<PropertyKey, unknown>)[part];
+  }
+  return value;
+}
+
+function summarizeValidationIssues(
+  issues: ZodIssueLike[],
+  rawArgs: unknown,
+): ValidationIssueSummary[] {
+  const summaries: ValidationIssueSummary[] = [];
+  for (const issue of issues) {
+    if (issue.code === 'unrecognized_keys') {
+      const parent = valueAtPath(rawArgs, issue.path);
+      for (const key of issue.keys ?? []) {
+        const input = parent !== null && typeof parent === 'object'
+          ? (parent as Record<string, unknown>)[key]
+          : undefined;
+        summaries.push({
+          path: formatPath([...issue.path, key]),
+          code: 'unrecognized_key',
+          received_type: valueType(input),
+          missing: false,
+        });
+      }
+      continue;
+    }
+
+    // Zod reports a missing enum as invalid_value (rather than invalid_type),
+    // so absence is identified from the input consistently across field kinds.
+    const input = valueAtPath(rawArgs, issue.path);
+    const missing = input === undefined;
+    summaries.push({
+      path: formatPath(issue.path),
+      code: issue.code,
+      ...(issue.expected === undefined ? {} : { expected_type: String(issue.expected) }),
+      received_type: valueType(input),
+      missing,
+    });
+  }
+  return summaries;
+}
+
+function makeActionableValidationError(
+  name: string,
+  schema: z.ZodObject<ZodRawShape>,
+  rawArgs: unknown,
+  issues: ZodIssueLike[],
+  expectedCall: string,
+) {
+  const validationErrors = summarizeValidationIssues(issues, rawArgs);
+  const missingFields = validationErrors
+    .filter((issue) => issue.missing)
+    .map((issue) => issue.path);
+  const unexpectedFields = validationErrors
+    .filter((issue) => issue.code === 'unrecognized_key')
+    .map((issue) => issue.path);
+  const wrappedArgs = unexpectedFields.includes('args');
+  const hint = wrappedArgs
+    ? `Pass ${name} arguments at the top level; do not wrap them in "args". Follow expected_call, fix every listed field, and retry.`
+    : `Follow expected_call, fix every listed field, and retry ${name}.`;
+
+  return errorPayload('INVALID_ARGS', hint, {
+    tool: name,
+    validation_errors: validationErrors,
+    missing_fields: missingFields,
+    unexpected_fields: unexpectedFields,
+    expected_call: expectedCall,
+    schema: z.toJSONSchema(schema, { target: 'draft-7' }),
+  });
+}
+
+/**
+ * The MCP SDK validates registered schemas before invoking a handler. For these
+ * two high-mistake tools we need the raw object so one response can report every
+ * missing/unexpected field. The transport schema therefore accepts the raw value,
+ * while Zod's JSON-schema hook keeps ListTools byte-equivalent to the strict schema.
+ * `shape` is attached because the SDK only serializes schemas it recognizes as
+ * object-like; the behavior is covered by the real-client manifest test.
+ */
+function makeValidationTransportSchema(schema: z.ZodObject<ZodRawShape>): z.ZodType {
+  const transportSchema = z.custom<unknown>(() => true);
+  const internals = transportSchema._zod as unknown as ValidationTransportInternals;
+  internals.def.shape = schema.shape;
+  internals.toJSONSchema = () => z.toJSONSchema(schema, { target: 'draft-7' });
+  return transportSchema;
+}
+
 /**
  * DirectToolSink —— 把 team 工具直接 server.tool() 注册的适配器。
  *
@@ -311,6 +456,36 @@ class DirectToolSink extends XdtHelperToolRegistry {
     inputShape: T;
     handler: XdtHelperToolHandler<{ [K in keyof T]: z.infer<T[K]> }>;
   }): void {
+    if (isActionableValidationTool(def.name)) {
+      const schema = z.strictObject(def.inputShape);
+      // Curated examples stay concise, while parsing them against the live schema
+      // makes schema/example drift fail immediately during server construction.
+      const expectedCall = `${def.name}(${JSON.stringify(
+        schema.parse(ACTIONABLE_VALIDATION_EXAMPLES[def.name]),
+      )})`;
+      this.mcp.registerTool(
+        def.name,
+        {
+          description: def.description,
+          inputSchema: makeValidationTransportSchema(schema),
+        },
+        async (rawArgs) => {
+          const parsed = schema.safeParse(rawArgs);
+          if (!parsed.success) {
+            return makeActionableValidationError(
+              def.name,
+              schema,
+              rawArgs,
+              parsed.error.issues as unknown as ZodIssueLike[],
+              expectedCall,
+            );
+          }
+          return def.handler(parsed.data as { [K in keyof T]: z.infer<T[K]> });
+        },
+      );
+      return;
+    }
+
     // McpServer.tool 是多重载函数, 传入泛型 handler 时 TS 选不中
     // (name, description, paramsSchema, cb) 那条重载(且 SDK 的 zod-compat 类型
     // 与本包 zod 可能版本漂移)。bind 住 this 后收窄成单签名转发, 运行时行为与


### PR DESCRIPTION
## 这次改了什么

### 摘要

让 Orca 的 `create_worker` / `create_workers` 在参数不合法时返回可直接自纠的 `INVALID_ARGS`：一次列全缺失字段和额外字段、只给出收到的类型而不回显原始值，并附一个经过当前 Zod schema 校验、明确标注为“仅展示结构”的最小调用示例。

SDK 传输层仍向模型暴露严格的原始字段 schema；有效调用继续走原 handler，错误调用不会触发 host 创建 Worker。

### 变更类型

- [x] `feat` 新功能
- [ ] `fix` 缺陷修复
- [ ] `refactor` / `perf` 重构或性能优化
- [ ] `docs` / `test` / `chore` 文档、测试或工程维护
- [ ] 其他：

### 范围

- 关联 Issue / 需求：Closes #2410
- 本 PR 包含：Orca 直接工具注册适配层的校验反馈；真实 MCP Client 回归测试
- 明确不包含：接受 `{ args: ... }` 兼容形态、其他 Orca 工具、UI / IPC / 数据库变更
- 用户可见变化：模型传错 Worker 参数时可在一次错误中看到全部缺失/额外字段、`received_type`、`missing` 和仅展示结构的调用示例
- 是否存在 breaking change：无；文档化的合法调用不变。此前被静默忽略的额外字段现在会明确报错

### UI 变化

不涉及。

- 引用的设计规范：不涉及

## 怎么验证的

### 自动验证

```text
pnpm --filter @cindy/mcps test
结果：49 个文件通过；669 passed，5 skipped

pnpm --filter @cindy/mcps run --if-present typecheck
结果：通过（该 package 当前没有 typecheck script）

pnpm check:dco
结果：通过，1 个 commit 已签署

pnpm test:unit:related
结果：packages/lizi-mcps related tests 通过；总命令被无关的 desktop 全量测试阻断：
3 个 Windows symlink 用例因 EPERM 失败，1 个 Codex exec E2E 30s 超时
```

### 手工验证

- 通过 MCP SDK `Client + InMemoryTransport` 验证 `listTools → callTool` 完整路径：
  - `args` 包裹 + 额外字段一次返回全部缺失/额外字段
  - 类型错误只返回 `received_type`，不会回显测试中的私有原始值
  - `create_workers` 返回包含两个 Worker 的合法最小示例
  - 合法 `create_worker` 仍调用 host 并返回原成功 payload
- 延迟实测（1000 次顺序、进程内真实 MCP 往返）：合法调用 62.79 ms（0.0628 ms/次）；错误调用 136.06 ms（0.1361 ms/次）；没有新增网络往返

### 未执行的验证

- `pnpm --filter @cindy/mcps build` 被主分支已有的 `src/__tests__/submitGithubIssueTool.test.ts` 7 处 Zod `description` 类型错误阻断；输出中没有本 PR 文件的类型错误。
- 不涉及 UI，未做视觉验证。

## 风险

### 风险分类

- [ ] 无已知风险
- [ ] SQLite / migration
- [ ] system prompt
- [x] 协议兼容
- [ ] 权限 / 安全 / 用户数据
- [ ] 存量插件兼容（批准状态 / 指纹 / manifest 校验 / 安装布局 / 包格式）
- [ ] 原生层 / fingerprint / OTA
- [ ] 跨平台差异
- [ ] 其他：

### 影响与回滚

- 影响范围：只影响 `cindy_orca` 的 `create_worker` / `create_workers` 参数校验。两个固定 tool schema 各新增一个 29-byte 的 `additionalProperties:false`，会在发布时产生一次预期的 tool manifest cache key 变化；工具数量、顺序和运行期 schema 均保持稳定。没有修改 prompt、translator、event loop、model route 或 usage 计量。返回准确性由真实 MCP 往返和全包测试覆盖。
- 回滚 / 降级方式：回退本提交即可恢复 SDK 默认校验；无数据迁移或持久化状态。

### 提交前检查

- [x] 已 review 完整 diff
- [x] 每个 commit 都带 DCO 签名（`git commit -s`，见 [DCO](../DCO)）
- [x] UI 改动已在「UI 变化」注明引用的设计规范章节（不涉及 UI）
- [x] 未提交凭证、令牌或授权文件
- [x] 已补充必要文档（本次不改变既有架构或权威规则，无需文档同步）
- [x] 已确认测试结果或说明未执行原因
