### PR TITLE
fix: 统一推理强度英文标签

### DIFF
--- a/apps/desktop/src/renderer/__tests__/composerNarrowToolbarContract.test.ts
+++ b/apps/desktop/src/renderer/__tests__/composerNarrowToolbarContract.test.ts
@@ -38,6 +38,8 @@ describe('composer narrow toolbar contract', () => {
     expect(modelSelectorSource).toContain(
       'const showTriggerTail = engineMarkOption ? !isUltraCompactToolbar : !isCompactToolbar;',
     );
+    // 长英文档名在固定宽度的紧凑 trigger 内允许省略显示，完整值仍由 title / aria-label 提供。
+    expect(modelSelectorSource).toContain("? 'min-w-0 shrink truncate'");
     expect(modelSelectorSource).toContain('{effortLabel && showTriggerTail && (');
     expect(permissionSelectorSource).toContain(
       'const isIconOnly = iconOnly && !isFieldTrigger;',

--- a/apps/desktop/src/renderer/__tests__/modelSelectorTriggerVariant.test.ts
+++ b/apps/desktop/src/renderer/__tests__/modelSelectorTriggerVariant.test.ts
@@ -1453,8 +1453,8 @@ describe('ModelSelector trigger variants', () => {
         'xhigh',
         '特高',
       ),
-    ).toBe('XHi');
-    expect(modelCompactEffortLabel('en-US', t, null, 'medium', '中')).toBe('Mid');
+    ).toBe('Extra');
+    expect(modelCompactEffortLabel('en-US', t, null, 'medium', '中')).toBe('Medium');
     expect(modelCompactEffortLabel('zh-CN', t, null, 'xhigh', 'Extra High')).toBe('超高');
     expect(
       modelCompactEffortLabel(

--- a/apps/desktop/src/renderer/components/new-chat/ModelSelector.tsx
+++ b/apps/desktop/src/renderer/components/new-chat/ModelSelector.tsx
@@ -3839,13 +3839,17 @@ export function ModelSelector({
               )}
               <span
                 title={fullEffortLabel ?? undefined}
+                // 紧凑工具条的固定宽度可能把尾部档名挤到不足一行；允许它收缩并显示省略号，
+                // 同时保留 title / aria-label 中的完整档名，避免固定宽度下发生硬裁切。
                 className={cn(
                   'min-w-0 font-normal',
                   isCreateAgentVariant
                     ? 'text-[var(--create-agent-control-text)]'
                     : 'text-[var(--text-primary)]',
                   engineMarkOption
-                    ? 'shrink-0 whitespace-nowrap'
+                    ? isCompactToolbar
+                      ? 'min-w-0 shrink truncate'
+                      : 'shrink-0 whitespace-nowrap'
                     : isCreateAgentVariant
                       ? 'truncate'
                       : isFieldTrigger

--- a/apps/desktop/src/renderer/i18n/locales/en/common.json
+++ b/apps/desktop/src/renderer/i18n/locales/en/common.json
@@ -3557,7 +3557,7 @@
       "prefs": {
         "agentLabel": "Agent",
         "modelLabel": "Model",
-        "effortLabel": "Reasoning effort",
+        "effortLabel": "Reasoning Effort",
         "permissionLabel": "Permission mode",
         "providerSlack": "Slack",
         "providerTelegram": "Telegram",
@@ -3953,7 +3953,7 @@
             "options": {
               "session-switch": "Switch tasks",
               "composer-navigation": "Navigate the composer",
-              "reasoning": "Reasoning effort",
+              "reasoning": "Reasoning Effort",
               "conversation-scroll": "Scroll the conversation",
               "custom": "Custom"
             }
@@ -6943,7 +6943,7 @@
       "remoteLoadFailedShort": "Model loading failed",
       "retryRemoteModels": "Reload models",
       "remoteEmpty": "This device has no available models",
-      "effortLabel": "Effort level",
+      "effortLabel": "Reasoning Effort",
       "thinking": "Thinking",
       "edit": "Edit",
       "options": "Options",
@@ -9094,7 +9094,7 @@
     "medium": "Medium",
     "high": "High",
     "xhigh": "Extra High",
-    "max": "Max",
+    "max": "Maximum",
     "ultra": "Ultra"
   },
   "scheduler": {
@@ -9534,13 +9534,13 @@
           "google": "Google",
           "china": "China"
         },
-        "effortHeading": "Effort",
+        "effortHeading": "Reasoning Effort",
         "effortDefault": "Default",
         "followSession": "Follow session",
         "modelListAria": "Model list",
         "modelSelectorAria": "Model selector",
         "categoryListAria": "{{category}} models",
-        "effortListAria": "Effort level"
+        "effortListAria": "Reasoning effort"
       }
     },
     "toast": {
@@ -10501,7 +10501,7 @@
     "workingDirPlaceholder": "Click the button on the right to pick a directory",
     "selectButton": "Select…",
     "modelLabel": "Model:",
-    "effortLabel": "Effort:",
+    "effortLabel": "Reasoning Effort:",
     "permissionLabel": "Permission:",
     "warningHint": "Modes marked ⚠ (ask/default/plan/acceptEdits) have no UI approval popup wired in stage 1; the experimental page hook auto-denies tool calls — only auto / bypassPermissions are recommended for real testing.",
     "createSession": "Create Session",
@@ -10682,7 +10682,7 @@
       "modelLabel": "Model",
       "permissionLabel": "Permission Mode",
       "noAvailableModels": "No available {{agent}} model. Check the provider connection and credentials in Settings.",
-      "effortLabel": "Effort",
+      "effortLabel": "Reasoning Effort",
       "initialTaskLabel": "Initial Task",
       "optional": "(optional)",
       "initialTaskPlaceholder": "Optional first task for this worker",

--- a/apps/mobile/src/__tests__/modelPickerRows.test.ts
+++ b/apps/mobile/src/__tests__/modelPickerRows.test.ts
@@ -256,20 +256,20 @@ describe('effortLabelFromRuntime —— 会话摘要按 app 语言覆盖 snapsho
   });
 });
 
-describe('compactEffortLabelFor —— 英文列表短码', () => {
-  it('英文按稳定 effort id 显示 2–3 字母，非英文仍用本地化全称', async () => {
+describe('compactEffortLabelFor —— 英文列表紧凑标签', () => {
+  it('英文只压缩长档位，非英文仍用本地化全称', async () => {
     const previousLanguage = i18n.language;
     try {
       await i18n.changeLanguage('en');
       expect(effortLabelFor({}, 'xhigh', capabilities)).toBe('Extra High');
       expect(
         compactEffortLabelFor({ effortDisplayNames: { xhigh: '特高' } }, 'xhigh', capabilities),
-      ).toBe('XHi');
-      expect(compactEffortLabelFor({}, 'minimal', capabilities)).toBe('Min');
-      expect(compactEffortLabelFor({}, 'low', capabilities)).toBe('Lo');
-      expect(compactEffortLabelFor({}, 'medium', capabilities)).toBe('Mid');
-      expect(compactEffortLabelFor({}, 'high', capabilities)).toBe('Hi');
-      expect(compactEffortLabelFor({}, 'ultra', capabilities)).toBe('Ult');
+      ).toBe('Extra');
+      expect(compactEffortLabelFor({}, 'minimal', capabilities)).toBe('Minimal');
+      expect(compactEffortLabelFor({}, 'low', capabilities)).toBe('Low');
+      expect(compactEffortLabelFor({}, 'medium', capabilities)).toBe('Medium');
+      expect(compactEffortLabelFor({}, 'high', capabilities)).toBe('High');
+      expect(compactEffortLabelFor({}, 'ultra', capabilities)).toBe('Ultra');
       expect(compactEffortLabelFor({}, 'max', capabilities)).toBe('Max');
       expect(
         compactEffortLabelFor(

--- a/apps/mobile/src/i18n/locales/en/models.json
+++ b/apps/mobile/src/i18n/locales/en/models.json
@@ -35,7 +35,7 @@
       "medium": "Medium",
       "high": "High",
       "xhigh": "Extra High",
-      "max": "Max",
+      "max": "Maximum",
       "ultra": "Ultra"
     }
   },

--- a/apps/mobile/src/session/modelPickerRows.ts
+++ b/apps/mobile/src/session/modelPickerRows.ts
@@ -265,7 +265,7 @@ export function effortLabelFromRuntime(
 }
 
 /**
- * 一级列表使用稳定 effort id 生成英文短码，避免被控端下发的长文案或混合语言挤占模型名。
+ * 一级列表使用稳定 effort id 生成英文紧凑标签，避免被控端下发的长文案或混合语言挤占模型名。
  * 非英文界面继续使用完整本地化标签；完整英文名称仍由模型选项页展示。
  */
 export function compactEffortLabelFor(

--- a/packages/maker-core/src/agents/claude-code/__tests__/models.test.ts
+++ b/packages/maker-core/src/agents/claude-code/__tests__/models.test.ts
@@ -58,7 +58,7 @@ describe('ClaudeCodeAgent model capabilities', () => {
       ['medium', 'Medium'],
       ['high', 'High'],
       ['xhigh', 'Extra High'],
-      ['max', 'Max'],
+      ['max', 'Maximum'],
     ]);
   });
 

--- a/packages/maker-core/src/agents/claude-code/index.ts
+++ b/packages/maker-core/src/agents/claude-code/index.ts
@@ -767,7 +767,7 @@ const CLAUDE_EFFORTS: EffortDescriptor[] = [
   { id: 'medium', displayName: 'Medium',     description: 'Balanced capability and token use' },
   { id: 'high',   displayName: 'High',       description: 'High capability for complex work' },
   { id: 'xhigh',  displayName: 'Extra High', description: 'Extended capability for long-horizon work' },
-  { id: 'max',    displayName: 'Max',        description: 'Maximum capability with unconstrained token use' },
+  { id: 'max',    displayName: 'Maximum',   description: 'Maximum capability with unconstrained token use' },
 ];
 
 // 注: plan 不再作为权限档暴露 —— 计划模式已独立成 Capabilities.planMode 一级开关

--- a/packages/maker-core/src/agents/codex/index.ts
+++ b/packages/maker-core/src/agents/codex/index.ts
@@ -1191,7 +1191,7 @@ const CODEX_EFFORTS: EffortDescriptor[] = [
   { id: 'xhigh', displayName: 'Extra High', description: 'Extended reasoning budget' },
   // max/ultra 仅部分模型支持(如 GPT-5.6 Sol);实际是否可选由该模型目录 efforts 决定,
   // 这里只提供 agent 级档名/描述兜底(桌面 i18n effortLevels.* 优先)。
-  { id: 'max', displayName: 'Max', description: 'Very high reasoning budget (model-dependent)' },
+  { id: 'max', displayName: 'Maximum', description: 'Very high reasoning budget (model-dependent)' },
   { id: 'ultra', displayName: 'Ultra', description: 'Maximum reasoning budget (model-dependent)' },
 ];
 

--- a/packages/maker-core/src/agents/pi/index.ts
+++ b/packages/maker-core/src/agents/pi/index.ts
@@ -1378,7 +1378,7 @@ export class PiAgent extends BaseAgent {
         { id: 'medium', displayName: 'Medium' },
         { id: 'high', displayName: 'High' },
         { id: 'xhigh', displayName: 'Extra High' },
-        { id: 'max', displayName: 'Max' },
+        { id: 'max', displayName: 'Maximum' },
       ],
       reasoningDisplay: ['off', 'full'],
       // 权限执行层在 cindy-bridge extension 的 tool_call 拦截:ask 档下只读内置

--- a/packages/maker-shared/src/__tests__/agentCapabilities.test.ts
+++ b/packages/maker-shared/src/__tests__/agentCapabilities.test.ts
@@ -16,7 +16,7 @@ const desktopCapabilitiesPayload = {
       description: 'Default remote Claude model',
       contextWindow: 200_000,
       efforts: ['low', 'medium', 'high', 'xhigh'],
-      effortDisplayNames: { xhigh: 'Max' },
+      effortDisplayNames: { xhigh: 'Extra High' },
       defaultEffort: 'medium',
       supportsFastMode: true,
       newSessionDefault: ['claude-code', 'invalid-agent', 'claude-code', 'codex', 'pi'],
@@ -45,13 +45,13 @@ const desktopCapabilitiesPayload = {
 };
 
 describe('agent capabilities shared model', () => {
-  it('uses the same 2–3 letter English effort codes on desktop and mobile', () => {
+  it('uses the same English compact effort labels on desktop and mobile', () => {
     expect(
-      ['minimal', 'low', 'medium', 'high', 'xhigh', 'ultra', 'max'].map(
-        compactEnglishEffortLabel,
+      ['minimal', 'low', 'medium', 'high', 'xhigh', 'ultra', 'max'].map((effort) =>
+        compactEnglishEffortLabel(effort),
       ),
-    ).toEqual(['Min', 'Lo', 'Mid', 'Hi', 'XHi', 'Ult', 'Max']);
-    expect(compactEnglishEffortLabel('extra-high')).toBe('XHi');
+    ).toEqual(['Minimal', 'Low', 'Medium', 'High', 'Extra', 'Ultra', 'Max']);
+    expect(compactEnglishEffortLabel('extra-high')).toBe('Extra');
     expect(compactEnglishEffortLabel('adaptive-fast', 'Adaptive Fast')).toBe('Adaptive Fast');
     expect(compactEnglishEffortLabel('adaptive-safe', 'Adaptive Safe')).toBe('Adaptive Safe');
     expect(compactEnglishEffortLabel('adaptive-fast')).toBe('adaptive-fast');
@@ -92,12 +92,12 @@ describe('agent capabilities shared model', () => {
 
     expect(runtime.modelOptions.map((item) => item.label)).toContain('Claude Sonnet 4.6');
     expect(runtime.currentModel?.id).toBe('claude-sonnet-4-6');
-    // 模型级 effortDisplayNames 覆盖(xhigh → 'Max')仍最优先;其余走中文词表。
+    // 模型级 effortDisplayNames 覆盖(xhigh → 'Extra High')仍最优先;其余走中文词表。
     expect(runtime.effortOptions.map((item) => [item.id, item.label])).toEqual([
       ['low', '低'],
       ['medium', '中'],
       ['high', '高'],
-      ['xhigh', 'Max'],
+      ['xhigh', 'Extra High'],
     ]);
     expect(runtime.permissionOptions.map((item) => item.id)).toEqual([
       'ask',

--- a/packages/maker-shared/src/agentCapabilities.ts
+++ b/packages/maker-shared/src/agentCapabilities.ts
@@ -88,27 +88,28 @@ export const MOBILE_EFFORT_LABELS: Record<string, string> = {
 };
 
 const ENGLISH_COMPACT_EFFORT_LABELS: Record<string, string> = {
-  auto: 'Aut',
-  balanced: 'Bal',
-  default: 'Def',
-  extrahigh: 'XHi',
-  high: 'Hi',
-  low: 'Lo',
+  auto: 'Auto',
+  balanced: 'Balanced',
+  default: 'Default',
+  extrahigh: 'Extra',
+  high: 'High',
+  low: 'Low',
   max: 'Max',
   maximum: 'Max',
-  medium: 'Mid',
-  minimal: 'Min',
+  medium: 'Medium',
+  minimal: 'Minimal',
   none: 'Off',
   off: 'Off',
-  standard: 'Std',
-  ultra: 'Ult',
-  xhigh: 'XHi',
+  standard: 'Standard',
+  ultra: 'Ultra',
+  xhigh: 'Extra',
 };
 
 /**
- * Windows、macOS 与移动端模型选择器共用的英文 effort 短码。
- * 仅已知标准档位缩写；未知档位保留下发的完整显示名（没有显示名时保留完整 id），
- * 避免不同技术 id 被截成同一个不可区分的前三字符。
+ * Windows、macOS 与移动端模型选择器共用的英文 effort 紧凑标签。
+ * 只压缩确实偏长的标准档位(Extra High → Extra、Maximum → Max)，其余保留完整名称；
+ * 未知档位保留下发的完整显示名（没有显示名时保留完整 id），避免把 provider-specific
+ * 能力截成不可区分的短码。
  */
 export function compactEnglishEffortLabel(effort: string, displayName?: string): string {
   const normalizedEffort = effort.toLowerCase().replace(/[^a-z0-9]/g, '');


### PR DESCRIPTION
## 这次改了什么

### 摘要

统一 Desktop、Mobile 以及 Codex / Claude Code / Pi 的推理强度英文名称，并按用户确认的规则提供紧凑显示：`Extra High` 显示为 `Extra`，`Maximum` 显示为 `Max`。

### 变更类型

- [x] `fix` 缺陷修复
- [ ] `feat` 新功能
- [ ] `refactor` / `perf` 重构或性能优化
- [ ] `docs` / `test` / `chore` 文档、测试或工程维护
- [ ] 其他：

### 范围

- 关联 Issue / 需求：无
- 本 PR 包含：统一完整英文标签、紧凑标签、agent capability fallback、Desktop / Mobile i18n 与相关测试。
- 明确不包含：不改变 effort id、协议值、模型能力判断或运行时推理行为。
- 用户可见变化：不再显示 `XHi / Mid / Ult / Min / Lo / Hi`；完整名称统一为 `Off / Minimal / Low / Medium / High / Extra High / Maximum / Ultra`。
- 是否存在 breaking change：无

### UI 变化

- 引用的设计规范：`DESIGN.md §11.2 Casing & Punctuation Per Language`（英文界面标签使用 Title Case）；`docs/dev-rules/engineering-conventions.md §5`（i18n 文案落在各语言资源并保持 key 对齐）。本次只调整既有标签文案与映射，复用现有 Light / Dark 样式，不改变布局、颜色或交互。

## 怎么验证的

### 自动验证

```text
pnpm --filter @cindy/maker-shared exec vitest run src/__tests__/agentCapabilities.test.ts
结果：11/11 通过

pnpm --filter @cindy/maker-core exec vitest run src/agents/claude-code/__tests__/models.test.ts
结果：13/13 通过

pnpm --filter mobile exec vitest run src/__tests__/modelPickerRows.test.ts src/__tests__/modelPickerTranslations.test.ts
结果：35/35 通过

pnpm --filter desktop exec vitest run src/renderer/__tests__/modelSelectorTriggerVariant.test.ts
结果：58/58 通过

pnpm check:i18n && pnpm check:i18n-glossary
结果：通过；仅有仓库既有警告

pnpm --filter desktop typecheck && pnpm --filter mobile typecheck
结果：通过

pnpm check:dco
结果：通过

git diff --check
结果：通过
```

### 手工验证

不涉及：本次仅调整已有模型选择器的文案与标签映射，未进行 UI 实机验收。

### 未执行的验证

`pnpm test:unit:related` 与 `bash /Users/dash/Code/XD/dash/Skills/git/scripts/run-unit-gate.sh /Users/dash/Code/Cindy/cindy-unify-effort-labels` 均被 maker-core 中 3 个 Pi 子代理集成测试阻断；同一组测试在干净的 `origin/main` 基线复现相同失败，因此确认与本 PR 无关。maker-shared / maker-core 的完整 typecheck 仍有仓库已有测试类型错误，与本 PR 改动无关。

## 风险

### 风险分类

- [ ] 无已知风险
- [ ] SQLite / migration
- [ ] system prompt
- [ ] 协议兼容
- [ ] 权限 / 安全 / 用户数据
- [ ] 存量插件兼容（批准状态 / 指纹 / manifest 校验 / 安装布局 / 包格式）
- [ ] 原生层 / fingerprint / OTA
- [x] 跨平台差异
- [x] 其他：用户可见文案统一

### 影响与回滚

- 影响范围：Desktop / Mobile 模型选择器及 agent capability fallback 的英文显示名称；不影响实际发送的 effort id 或推理预算。
- 回滚 / 降级方式：回滚本 PR commit 即恢复原有显示文案。

### 提交前检查

- [x] 已 review 完整 diff
- [x] 每个 commit 都带 DCO 签名（`git commit -s`，见 [DCO](../DCO)）
- [x] UI 改动已在「UI 变化」注明引用的设计规范章节
- [x] 未提交凭证、令牌或授权文件
- [x] 已补充必要文档
- [x] 已确认测试结果或说明未执行原因
