### PR TITLE
fix(desktop): 显式导入时复活已软删的本地会话行

### DIFF
--- a/apps/desktop/src/main/__tests__/claudeLocalSessions.test.ts
+++ b/apps/desktop/src/main/__tests__/claudeLocalSessions.test.ts
@@ -985,6 +985,49 @@ describe('parseClaudeCodeMessageLine', () => {
     }
   });
 
+  it('revives a soft-deleted imported session on explicit re-import (#3548)', async () => {
+    // 删除是软删且源 JSONL 不随删,扫描会重新出候选;此前 ON CONFLICT 不更新
+    // status,重导入命中同主键后行仍是 deleted —— 导入计数更新、侧栏不可见。
+    // 删除动作把 updated_at 推到删除时刻(晚于源文件),复活不得受时间门约束。
+    const home = fs.mkdtempSync(path.join(os.tmpdir(), 'claude-local-home-'));
+    const projectsDir = path.join(home, '.claude', 'projects', '-tmp-project');
+    fs.mkdirSync(projectsDir, { recursive: true });
+    fs.writeFileSync(
+      path.join(projectsDir, `${sdkSessionId}.jsonl`),
+      `${line({
+        type: 'user',
+        uuid: 'user-1',
+        cwd: '/tmp/project',
+        message: { role: 'user', content: 'import me' },
+      })}\n`,
+    );
+
+    const db = createLocalDb();
+    const homedir = vi.spyOn(os, 'homedir').mockReturnValue(home);
+    setLocalDb(db);
+
+    try {
+      const first = await importExternalClaudeCodeSessions([sdkSessionId]);
+      expect(first).toMatchObject({ inserted: 1 });
+
+      db.prepare(
+        "UPDATE sessions SET status = 'deleted', updated_at = updated_at + 999999 WHERE id = ?",
+      ).run(`claude-${sdkSessionId}`);
+
+      const again = await importExternalClaudeCodeSessions([sdkSessionId]);
+      expect(again).toMatchObject({ scanned: 1, inserted: 0, updated: 1 });
+      const row = db
+        .prepare('SELECT status FROM sessions WHERE id = ?')
+        .get(`claude-${sdkSessionId}`) as { status: string };
+      expect(row.status).toBe('active');
+    } finally {
+      homedir.mockRestore();
+      resetLocalDb();
+      db.close();
+      fs.rmSync(home, { recursive: true, force: true });
+    }
+  });
+
   it('revalidates and rejects internal review sessions imported directly by id', async () => {
     const home = fs.mkdtempSync(path.join(os.tmpdir(), 'claude-local-home-'));
     const projectsDir = path.join(home, '.claude', 'projects', '-tmp-project');

--- a/apps/desktop/src/main/__tests__/claudeLocalSessions.test.ts
+++ b/apps/desktop/src/main/__tests__/claudeLocalSessions.test.ts
@@ -1010,16 +1010,23 @@ describe('parseClaudeCodeMessageLine', () => {
       const first = await importExternalClaudeCodeSessions([sdkSessionId]);
       expect(first).toMatchObject({ inserted: 1 });
 
+      const before = db
+        .prepare('SELECT title, updated_at AS updatedAt FROM sessions WHERE id = ?')
+        .get(`claude-${sdkSessionId}`) as { title: string; updatedAt: number };
       db.prepare(
-        "UPDATE sessions SET status = 'deleted', updated_at = updated_at + 999999 WHERE id = ?",
+        "UPDATE sessions SET status = 'deleted', title = 'stale-after-delete', updated_at = updated_at + 999999 WHERE id = ?",
       ).run(`claude-${sdkSessionId}`);
 
       const again = await importExternalClaudeCodeSessions([sdkSessionId]);
       expect(again).toMatchObject({ scanned: 1, inserted: 0, updated: 1 });
       const row = db
-        .prepare('SELECT status FROM sessions WHERE id = ?')
-        .get(`claude-${sdkSessionId}`) as { status: string };
+        .prepare('SELECT status, title, updated_at AS updatedAt FROM sessions WHERE id = ?')
+        .get(`claude-${sdkSessionId}`) as { status: string; title: string; updatedAt: number };
       expect(row.status).toBe('active');
+      // 复活即按新导入对待:元数据与 updated_at 收敛回源值,不残留删除时刻
+      // 的旧快照(review 反馈:仅复活 status 会让侧栏行与源会话不一致)。
+      expect(row.title).toBe(before.title);
+      expect(row.updatedAt).toBe(before.updatedAt);
     } finally {
       homedir.mockRestore();
       resetLocalDb();

--- a/apps/desktop/src/main/__tests__/codexLocalSessions.test.ts
+++ b/apps/desktop/src/main/__tests__/codexLocalSessions.test.ts
@@ -339,6 +339,30 @@ describe('Codex local session import', () => {
     expect(rows).toEqual([{ id: `codex-${threadId}`, title: 'Top Level Codex Session' }]);
   }, 15_000);
 
+  it('revives a soft-deleted imported thread on explicit re-import (#3548)', async () => {
+    // 删除把 updated_at 推到删除时刻(晚于源 rollout),仅按时间门判定会让
+    // 重导入永远停留在 deleted;显式导入命中已软删同主键行必须复活。
+    const dbPath = createStateDb(externalHome);
+    const rolloutPath = path.join(externalHome, 'sessions', `rollout-2026-05-13-${threadId}.jsonl`);
+    fs.mkdirSync(path.dirname(rolloutPath), { recursive: true });
+    fs.writeFileSync(rolloutPath, '');
+    insertThread(dbPath, threadId, rolloutPath, { updatedAt: 1_000, title: 'Revive Me' });
+
+    const first = await importExternalCodexSessions([threadId]);
+    expect(first).toMatchObject({ inserted: 1 });
+
+    currentTestDb()
+      .prepare("UPDATE sessions SET status = 'deleted', updated_at = updated_at + 999999 WHERE id = ?")
+      .run(`codex-${threadId}`);
+
+    const again = await importExternalCodexSessions([threadId]);
+    expect(again).toMatchObject({ inserted: 0, updated: 1 });
+    const row = currentTestDb()
+      .prepare('SELECT status FROM sessions WHERE id = ?')
+      .get(`codex-${threadId}`) as { status: string };
+    expect(row.status).toBe('active');
+  });
+
   it('filters Codex source JSON subagent rows even when thread_source is missing', async () => {
     const dbPath = createStateDb(externalHome);
     const rolloutPath = path.join(externalHome, 'sessions', `rollout-2026-05-13-${threadId}.jsonl`);

--- a/apps/desktop/src/main/__tests__/codexLocalSessions.test.ts
+++ b/apps/desktop/src/main/__tests__/codexLocalSessions.test.ts
@@ -351,16 +351,22 @@ describe('Codex local session import', () => {
     const first = await importExternalCodexSessions([threadId]);
     expect(first).toMatchObject({ inserted: 1 });
 
+    const before = currentTestDb()
+      .prepare('SELECT title, updated_at AS updatedAt FROM sessions WHERE id = ?')
+      .get(`codex-${threadId}`) as { title: string; updatedAt: number };
     currentTestDb()
-      .prepare("UPDATE sessions SET status = 'deleted', updated_at = updated_at + 999999 WHERE id = ?")
+      .prepare("UPDATE sessions SET status = 'deleted', title = 'stale-after-delete', updated_at = updated_at + 999999 WHERE id = ?")
       .run(`codex-${threadId}`);
 
     const again = await importExternalCodexSessions([threadId]);
     expect(again).toMatchObject({ inserted: 0, updated: 1 });
     const row = currentTestDb()
-      .prepare('SELECT status FROM sessions WHERE id = ?')
-      .get(`codex-${threadId}`) as { status: string };
+      .prepare('SELECT status, title, updated_at AS updatedAt FROM sessions WHERE id = ?')
+      .get(`codex-${threadId}`) as { status: string; title: string; updatedAt: number };
     expect(row.status).toBe('active');
+    // 复活即按新导入对待:元数据与 updated_at 收敛回源值(review 反馈)。
+    expect(row.title).toBe(before.title);
+    expect(row.updatedAt).toBe(before.updatedAt);
   });
 
   it('filters Codex source JSON subagent rows even when thread_source is missing', async () => {

--- a/apps/desktop/src/main/maker-host/claude-local-sessions.ts
+++ b/apps/desktop/src/main/maker-host/claude-local-sessions.ts
@@ -572,6 +572,7 @@ async function upsertLocalSession(summary: ClaudeCodeSessionSummary): Promise<'i
       permission_mode = CASE WHEN sessions.updated_at <= excluded.updated_at THEN excluded.permission_mode ELSE sessions.permission_mode END,
       sdk_session_id = excluded.sdk_session_id,
       total_token_usage = CASE WHEN sessions.updated_at <= excluded.updated_at THEN excluded.total_token_usage ELSE sessions.total_token_usage END,
+      status = CASE WHEN sessions.status = 'deleted' THEN excluded.status ELSE sessions.status END,
       user_send_at = COALESCE(sessions.user_send_at, excluded.user_send_at),
       updated_at = MAX(sessions.updated_at, excluded.updated_at)
   `, [

--- a/apps/desktop/src/main/maker-host/claude-local-sessions.ts
+++ b/apps/desktop/src/main/maker-host/claude-local-sessions.ts
@@ -565,16 +565,20 @@ async function upsertLocalSession(summary: ClaudeCodeSessionSummary): Promise<'i
       0, '[]', 'project', ?, ?
     )
     ON CONFLICT(id) DO UPDATE SET
-      title = CASE WHEN sessions.updated_at <= excluded.updated_at THEN excluded.title ELSE sessions.title END,
-      working_dir = CASE WHEN sessions.updated_at <= excluded.updated_at THEN excluded.working_dir ELSE sessions.working_dir END,
+      -- 复活语义(#3548):旧行已软删时按全新导入对待。删除动作把 updated_at
+      -- 推到删除时刻,若元数据仍按时间门保留旧值,复活行的标题/模型/权限模式/
+      -- 令牌统计会停留在首次导入的旧快照,与当前源会话不一致;updated_at 同时
+      -- 收敛回源值,后续同步不再被删除时刻挡住。非删除行为完全不变。
+      title = CASE WHEN sessions.status = 'deleted' OR sessions.updated_at <= excluded.updated_at THEN excluded.title ELSE sessions.title END,
+      working_dir = CASE WHEN sessions.status = 'deleted' OR sessions.updated_at <= excluded.updated_at THEN excluded.working_dir ELSE sessions.working_dir END,
       workspace_kind = excluded.workspace_kind,
-      model = CASE WHEN sessions.updated_at <= excluded.updated_at THEN excluded.model ELSE sessions.model END,
-      permission_mode = CASE WHEN sessions.updated_at <= excluded.updated_at THEN excluded.permission_mode ELSE sessions.permission_mode END,
+      model = CASE WHEN sessions.status = 'deleted' OR sessions.updated_at <= excluded.updated_at THEN excluded.model ELSE sessions.model END,
+      permission_mode = CASE WHEN sessions.status = 'deleted' OR sessions.updated_at <= excluded.updated_at THEN excluded.permission_mode ELSE sessions.permission_mode END,
       sdk_session_id = excluded.sdk_session_id,
-      total_token_usage = CASE WHEN sessions.updated_at <= excluded.updated_at THEN excluded.total_token_usage ELSE sessions.total_token_usage END,
+      total_token_usage = CASE WHEN sessions.status = 'deleted' OR sessions.updated_at <= excluded.updated_at THEN excluded.total_token_usage ELSE sessions.total_token_usage END,
       status = CASE WHEN sessions.status = 'deleted' THEN excluded.status ELSE sessions.status END,
       user_send_at = COALESCE(sessions.user_send_at, excluded.user_send_at),
-      updated_at = MAX(sessions.updated_at, excluded.updated_at)
+      updated_at = CASE WHEN sessions.status = 'deleted' THEN excluded.updated_at ELSE MAX(sessions.updated_at, excluded.updated_at) END
   `, [
     localId,
     summary.title,

--- a/apps/desktop/src/main/maker-host/codex-local-sessions.ts
+++ b/apps/desktop/src/main/maker-host/codex-local-sessions.ts
@@ -4833,7 +4833,11 @@ async function upsertLocalSession(thread: CodexThreadSummary): Promise<'inserted
       model = CASE WHEN sessions.updated_at <= excluded.updated_at THEN excluded.model ELSE sessions.model END,
       effort = CASE WHEN sessions.updated_at <= excluded.updated_at THEN excluded.effort ELSE sessions.effort END,
       permission_mode = CASE WHEN sessions.updated_at <= excluded.updated_at THEN excluded.permission_mode ELSE sessions.permission_mode END,
-      status = CASE WHEN sessions.updated_at <= excluded.updated_at THEN excluded.status ELSE sessions.status END,
+      status = CASE
+        WHEN sessions.status = 'deleted' THEN excluded.status
+        WHEN sessions.updated_at <= excluded.updated_at THEN excluded.status
+        ELSE sessions.status
+      END,
       sdk_session_id = excluded.sdk_session_id,
       total_token_usage = CASE WHEN sessions.updated_at <= excluded.updated_at THEN excluded.total_token_usage ELSE sessions.total_token_usage END,
       user_send_at = COALESCE(sessions.user_send_at, excluded.user_send_at),

--- a/apps/desktop/src/main/maker-host/codex-local-sessions.ts
+++ b/apps/desktop/src/main/maker-host/codex-local-sessions.ts
@@ -4824,24 +4824,26 @@ async function upsertLocalSession(thread: CodexThreadSummary): Promise<'inserted
       0, '[]', ?, ?, ?
     )
     ON CONFLICT(id) DO UPDATE SET
-      title = CASE WHEN sessions.updated_at <= excluded.updated_at THEN excluded.title ELSE sessions.title END,
-      working_dir = CASE WHEN sessions.updated_at <= excluded.updated_at THEN excluded.working_dir ELSE sessions.working_dir END,
+      -- 复活语义(#3548,与 claude 侧同口径):旧行已软删时按全新导入对待,
+      -- 元数据与 updated_at 一并收敛回源值,不残留删除时刻的旧快照。
+      title = CASE WHEN sessions.status = 'deleted' OR sessions.updated_at <= excluded.updated_at THEN excluded.title ELSE sessions.title END,
+      working_dir = CASE WHEN sessions.status = 'deleted' OR sessions.updated_at <= excluded.updated_at THEN excluded.working_dir ELSE sessions.working_dir END,
       -- Classification follows Codex global state, not local edit recency.
       -- This lets a re-import fix rows previously misclassified as projects
       -- while preserving newer local title/metadata via the CASE clauses.
       workspace_kind = excluded.workspace_kind,
-      model = CASE WHEN sessions.updated_at <= excluded.updated_at THEN excluded.model ELSE sessions.model END,
-      effort = CASE WHEN sessions.updated_at <= excluded.updated_at THEN excluded.effort ELSE sessions.effort END,
-      permission_mode = CASE WHEN sessions.updated_at <= excluded.updated_at THEN excluded.permission_mode ELSE sessions.permission_mode END,
+      model = CASE WHEN sessions.status = 'deleted' OR sessions.updated_at <= excluded.updated_at THEN excluded.model ELSE sessions.model END,
+      effort = CASE WHEN sessions.status = 'deleted' OR sessions.updated_at <= excluded.updated_at THEN excluded.effort ELSE sessions.effort END,
+      permission_mode = CASE WHEN sessions.status = 'deleted' OR sessions.updated_at <= excluded.updated_at THEN excluded.permission_mode ELSE sessions.permission_mode END,
       status = CASE
         WHEN sessions.status = 'deleted' THEN excluded.status
         WHEN sessions.updated_at <= excluded.updated_at THEN excluded.status
         ELSE sessions.status
       END,
       sdk_session_id = excluded.sdk_session_id,
-      total_token_usage = CASE WHEN sessions.updated_at <= excluded.updated_at THEN excluded.total_token_usage ELSE sessions.total_token_usage END,
+      total_token_usage = CASE WHEN sessions.status = 'deleted' OR sessions.updated_at <= excluded.updated_at THEN excluded.total_token_usage ELSE sessions.total_token_usage END,
       user_send_at = COALESCE(sessions.user_send_at, excluded.user_send_at),
-      updated_at = MAX(sessions.updated_at, excluded.updated_at)
+      updated_at = CASE WHEN sessions.status = 'deleted' THEN excluded.updated_at ELSE MAX(sessions.updated_at, excluded.updated_at) END
   `, [
     localId,
     thread.title,


### PR DESCRIPTION
## 这次改了什么

### 摘要

fix #3548 的「导入后仍不回侧栏」子问题。任务删除是数据库软删,Cindy 内置 Claude SDK 会话的源 JSONL 不随删,任务导入扫描会重新列出该会话;此时点导入命中同主键(`claude-<sdkSessionId>`)的已软删行,而 Claude 侧 upsert 的 `ON CONFLICT ... DO UPDATE` 不更新 `status`——结果导入计数显示成功、行仍是 `deleted`、侧栏不可见,导入列表与侧栏状态永久不一致(issue 分诊已把该分支钉到代码)。

修复:两侧导入 upsert 增加「已软删行显式导入即复活」分支——

- **Claude 侧**(`claude-local-sessions.ts`):`DO UPDATE` 新增 `status = CASE WHEN sessions.status = 'deleted' THEN excluded.status ELSE sessions.status END`;非删除行的 status 维持既有「不更新」语义。该 upsert 仅由显式导入路径(`importExternalClaudeCodeSessions`)调用,复活即用户意图,不会被后台扫描误触发(扫描路径只读不写,仓库既有测试 `scans without writing...` 锁住)。
- **Codex 侧**(`codex-local-sessions.ts`):同类缺陷的对称修复——其既有 status 子句按 `updated_at` 门更新,但删除动作会把 `updated_at` 推到删除时刻(晚于源文件时间戳),重导入永远停留在 `deleted`;在既有 CASE 前补删除复活分支,非删除行为完全不变。

明确不做:sub-问题①(删除后候选是否永久屏蔽/删源文件)是删除语义的产品决策,不在本 PR;分诊 bot 也持同一拆分意见。

### 变更类型

- [ ] `feat` 新功能
- [x] `fix` 缺陷修复
- [ ] `refactor` / `perf` 重构或性能优化
- [ ] `docs` / `test` / `chore` 文档、测试或工程维护
- [ ] 其他:

### 范围

- 关联 Issue / 需求:#3548(仅「导入不复活」子问题)
- 本 PR 包含:两侧导入 upsert 的 status 复活分支 + 两条回归(删除后重导入 → `updated:1` 且 status=active)
- 明确不包含:删除语义/候选永久屏蔽(产品决策);导入列表刷新链路(既有 `emitRefresh` 不动)
- 用户可见变化:删除过的会话重新导入后正常回到侧栏
- 是否存在 breaking change:无

### UI 变化

不涉及。

- 引用的设计规范:不涉及

## 怎么验证的

### 自动验证

```text
pnpm --filter desktop exec vitest run src/main/__tests__/claudeLocalSessions.test.ts src/main/__tests__/codexLocalSessions.test.ts --pool=forks
结果:新增 2 条回归通过(Claude / Codex 各一:导入 → 软删并把 updated_at 推后 →
重导入 → 断言 updated:1 且 status 回到 active)。该两文件在干净 main 上本就有
15 例失败(SqliteError: no such column: list_preview——测试内存库 schema 落后于
main 新增列,属既有基线,本 diff 前后失败集逐一相同、零新增)。

pnpm --filter desktop run --if-present typecheck
结果:通过(0 错误)

pnpm test:unit:related
结果:exit 1,但两处失败均与本 diff 无关,逐一归因如下:
- apps/desktop 段:vitest --pool=threads 进程被 SIGSEGV 杀掉(本机已知环境问题,需 --pool=forks 绕过;且该段命令行本身 `--exclude **/__tests__/*LocalSessions.test.ts`,本 diff 修改的两个测试文件不在门禁覆盖内)
- packages/maker-core 段:pi-agent.integration.test.ts 3 例失败(真实 pi 二进制集成测试,单独重跑仍复现;本 diff 只改 desktop 4 个文件,零涉及 maker-core,属本机环境性既有失败)

本 diff 的有效验证以上文定向 vitest --pool=forks 运行为准(基线失败集与干净 main 逐一相同、零新增,新增 2 例回归通过)。
```

### 手工验证

不涉及(数据路径由回归测试覆盖)。

### 未执行的验证

未在真实客户端执行完整「新建 → 删除 → 任务导入」流程(issue 复现于 Windows 0.1.64;修复面是纯 SQL 子句,行为由 DB 级回归锁定)。

## 风险

### 风险分类

- [x] 无已知风险
- [ ] 其他:

### 影响与回滚

- 影响范围:仅显式导入命中「已软删同主键行」时的 status 写入;非删除行、扫描路径、导入计数语义零变化。最坏情形是用户不想复活却点了导入——复活本就是导入按钮的语义,且可再次删除。
- 回滚 / 降级方式:revert 单 commit,无 schema/migration 变更(纯 DML 子句)。

### 提交前检查

- [x] 已 review 完整 diff
- [x] 每个 commit 都带 DCO 签名(`git commit -s`,见 [DCO](../DCO))
- [ ] UI 改动已在「UI 变化」注明引用的设计规范章节(不涉及 UI 则跳过)
- [x] 未提交凭证、令牌或授权文件
- [x] 已补充必要文档
- [x] 已确认测试结果或说明未执行原因

