### PR TITLE
fix(desktop): 修复 Work Louder HID 重启风暴

### DIFF
--- a/apps/desktop/src/main/worklouder-codex/WorkLouderCodexHostClient.ts
+++ b/apps/desktop/src/main/worklouder-codex/WorkLouderCodexHostClient.ts
@@ -89,6 +89,8 @@ export class WorkLouderCodexHostClient implements WorkLouderCodexLightingSink {
   private wantsHidInput = false;
   private deviceEnabled = true;
   private wantsPresence = false;
+  /** Permission failures are user-actionable; stop automatic recovery until a probe or toggle. */
+  private permissionBlocked = false;
   /** True while the current host is stopping so re-enable cannot talk to it. */
   private hostStopping = false;
 
@@ -123,6 +125,7 @@ export class WorkLouderCodexHostClient implements WorkLouderCodexLightingSink {
   setDeviceEnabled(enabled: boolean): void {
     if (this.deviceEnabled === enabled) return;
     this.deviceEnabled = enabled;
+    this.permissionBlocked = false;
     if (enabled) {
       this.updateHidListeningIntent();
       if (this.latestFrame) this.update(this.latestFrame);
@@ -152,13 +155,15 @@ export class WorkLouderCodexHostClient implements WorkLouderCodexLightingSink {
   }
 
   setPresenceHandler(
-    handler: ((
-      present: boolean,
-      identity?: {
-        deviceType: 'codex-micro' | 'creator-micro-2';
-        isUsbConnection: boolean;
-      },
-    ) => void) | null,
+    handler:
+      | ((
+          present: boolean,
+          identity?: {
+            deviceType: 'codex-micro' | 'creator-micro-2';
+            isUsbConnection: boolean;
+          },
+        ) => void)
+      | null,
   ): void {
     this.presenceHandler = handler;
   }
@@ -220,6 +225,7 @@ export class WorkLouderCodexHostClient implements WorkLouderCodexLightingSink {
 
   private ensureChild(): WorkLouderCodexChildLike | null {
     if (this.hostStopping) return null;
+    if (this.permissionBlocked) return null;
     if (!this.deviceEnabled && !this.wantsPresence) return null;
     if (this.child) return this.child;
     const sdk = this.deps.resolveSdk();
@@ -287,11 +293,18 @@ export class WorkLouderCodexHostClient implements WorkLouderCodexLightingSink {
    */
   probe(): void {
     if (this.disposed) return;
+    this.permissionBlocked = false;
     if (!this.deviceEnabled) {
       this.discoverPresence();
       return;
     }
-    if (!this.child) return;
+    if (!this.child) {
+      if (this.wantsHidInput) this.requestHidListening();
+      else if (this.latestFrame && !isWorkLouderCodexLightingFrameOff(this.latestFrame)) {
+        this.update(this.latestFrame);
+      }
+      return;
+    }
     try {
       const request: WorkLouderCodexHostRequest = { kind: 'probe' };
       this.child.postMessage(request);
@@ -372,7 +385,11 @@ export class WorkLouderCodexHostClient implements WorkLouderCodexLightingSink {
     }
     if (message.kind !== 'state') return;
     this.clearConnectWatchdog();
+    if (this.permissionBlocked && message.status === 'connected') return;
     this.updateConnectionReason(message.reason ?? null);
+    const permissionRequired =
+      message.status === 'error' && message.reason === 'permission-required';
+    if (permissionRequired) this.permissionBlocked = true;
     if (message.status === this.lastStatus) return;
     const previousStatus = this.lastStatus;
     this.lastStatus = message.status;
@@ -387,10 +404,33 @@ export class WorkLouderCodexHostClient implements WorkLouderCodexLightingSink {
     } else {
       this.deps.log.warn('Codex Micro lighting host could not apply the current frame');
     }
+    if (permissionRequired) {
+      this.stopHostAfterPermission(child);
+      return;
+    }
     // Pairing / USB re-enumeration leaves the native SDK handle alive but
     // unusable. ChatGPT recovers by opening a fresh transport; we do the same
     // by recycling the utility process once the live session drops.
     if (previousStatus === 'connected') this.recycleStaleHost(child);
+  }
+
+  private stopHostAfterPermission(child: WorkLouderCodexChildLike): void {
+    if (this.disposed || this.child !== child) return;
+    this.clearConnectWatchdog();
+    this.clearStableConnection();
+    if (this.restartTimer) {
+      clearTimeout(this.restartTimer);
+      this.restartTimer = null;
+    }
+    this.deps.log.warn(
+      'Codex Micro lighting paused because HID permission is required; retry after permission changes',
+    );
+    try {
+      child.kill();
+    } catch {
+      // Permission failure owns the stop; the host may already have exited.
+    }
+    this.handleExit(child, 0);
   }
 
   private recycleStaleHost(child: WorkLouderCodexChildLike): void {
@@ -426,8 +466,13 @@ export class WorkLouderCodexHostClient implements WorkLouderCodexLightingSink {
       if (this.wantsPresence) this.scheduleRestart();
       return;
     }
+    if (this.permissionBlocked) {
+      this.updateConnectionReason('permission-required');
+      this.updateConnectionStatus('error');
+      return;
+    }
     if (recycled) {
-      this.restartHost();
+      this.scheduleRestart();
       return;
     }
     this.deps.log.warn('Codex Micro lighting host exited', { code });
@@ -445,7 +490,7 @@ export class WorkLouderCodexHostClient implements WorkLouderCodexLightingSink {
   }
 
   private scheduleRestart(): void {
-    if (this.restartTimer || !this.shouldRestartHost()) return;
+    if (this.restartTimer || this.permissionBlocked || !this.shouldRestartHost()) return;
     this.consecutiveCrashes += 1;
     if (this.consecutiveCrashes > 5) {
       this.deps.log.error('Codex Micro lighting host repeatedly crashed; disabled until restart');
@@ -581,6 +626,7 @@ export class WorkLouderCodexHostClient implements WorkLouderCodexLightingSink {
     }
     this.lastStatus = null;
     this.consecutiveCrashes = 0;
+    this.permissionBlocked = false;
     this.updateConnectionReason(null);
     this.updateConnectionStatus('disabled');
   }

--- a/apps/desktop/src/main/worklouder-codex/WorkLouderCodexHostClient.ts
+++ b/apps/desktop/src/main/worklouder-codex/WorkLouderCodexHostClient.ts
@@ -91,7 +91,7 @@ export class WorkLouderCodexHostClient implements WorkLouderCodexLightingSink {
   private wantsHidInput = false;
   private deviceEnabled = true;
   private wantsPresence = false;
-  /** Permission failures are user-actionable; stop automatic recovery until a probe or toggle. */
+  /** Permission failures are user-actionable; stop automatic recovery until an explicit retry or toggle. */
   private permissionBlocked = false;
   /** True while the current host is stopping so re-enable cannot talk to it. */
   private hostStopping = false;
@@ -227,6 +227,9 @@ export class WorkLouderCodexHostClient implements WorkLouderCodexLightingSink {
 
   private ensureChild(): WorkLouderCodexChildLike | null {
     if (this.hostStopping) return null;
+    // A scheduled recycle owns recovery; work/presence callers must not
+    // recreate the host early and bypass its exponential backoff.
+    if (this.restartTimer) return null;
     if (this.permissionBlocked) return null;
     if (this.isCrashBudgetExhausted()) return null;
     if (!this.deviceEnabled && !this.wantsPresence) return null;
@@ -300,13 +303,10 @@ export class WorkLouderCodexHostClient implements WorkLouderCodexLightingSink {
       this.discoverPresence();
       return;
     }
-    if (!this.child) {
-      if (this.wantsHidInput) this.requestHidListening();
-      else if (this.latestFrame && !isWorkLouderCodexLightingFrameOff(this.latestFrame)) {
-        this.update(this.latestFrame);
-      }
-      return;
-    }
+    // A background probe is observational only. If the host is gone, either
+    // the restart backoff or the crash budget owns recovery; do not recreate
+    // it indirectly through requestHidListening/update.
+    if (!this.child || this.restartTimer) return;
     try {
       const request: WorkLouderCodexHostRequest = { kind: 'probe' };
       this.child.postMessage(request);
@@ -328,7 +328,11 @@ export class WorkLouderCodexHostClient implements WorkLouderCodexLightingSink {
   retryPermission(): void {
     if (this.disposed || !this.permissionBlocked) return;
     this.permissionBlocked = false;
-    this.probe();
+    if (this.restartTimer) {
+      clearTimeout(this.restartTimer);
+      this.restartTimer = null;
+    }
+    this.restartHost();
   }
 
   private requestHidListening(): void {

--- a/apps/desktop/src/main/worklouder-codex/WorkLouderCodexHostClient.ts
+++ b/apps/desktop/src/main/worklouder-codex/WorkLouderCodexHostClient.ts
@@ -292,8 +292,7 @@ export class WorkLouderCodexHostClient implements WorkLouderCodexLightingSink {
    * no such keyboard.
    */
   probe(): void {
-    if (this.disposed) return;
-    this.permissionBlocked = false;
+    if (this.disposed || this.permissionBlocked) return;
     if (!this.deviceEnabled) {
       this.discoverPresence();
       return;
@@ -313,6 +312,20 @@ export class WorkLouderCodexHostClient implements WorkLouderCodexLightingSink {
         error: error instanceof Error ? error.message : String(error),
       });
     }
+  }
+
+  /**
+   * Clear a permission breaker only for an explicit recovery signal.
+   *
+   * Background connection polling must stay observational: repeatedly
+   * recreating a host while macOS still denies HID access is the restart storm
+   * this client is designed to prevent. The settings toggle and system unlock
+   * paths call this method when a permission change may have happened.
+   */
+  retryPermission(): void {
+    if (this.disposed) return;
+    this.permissionBlocked = false;
+    this.probe();
   }
 
   private requestHidListening(): void {

--- a/apps/desktop/src/main/worklouder-codex/WorkLouderCodexHostClient.ts
+++ b/apps/desktop/src/main/worklouder-codex/WorkLouderCodexHostClient.ts
@@ -410,10 +410,20 @@ export class WorkLouderCodexHostClient implements WorkLouderCodexLightingSink {
     const permissionRequired =
       message.status === 'error' && message.reason === 'permission-required';
     if (permissionRequired) this.permissionBlocked = true;
-    if (message.status === this.lastStatus) return;
     const previousStatus = this.lastStatus;
-    this.lastStatus = message.status;
-    this.updateConnectionStatus(message.status);
+    const statusChanged = message.status !== this.lastStatus;
+    if (statusChanged) {
+      this.lastStatus = message.status;
+      this.updateConnectionStatus(message.status);
+    }
+    // Permission errors own teardown even when a previous connection error
+    // already published the same coarse `error` status. The breaker must not
+    // leave a permission-blocked child alive and unable to honor retry.
+    if (permissionRequired) {
+      this.stopHostAfterPermission(child);
+      return;
+    }
+    if (!statusChanged) return;
     if (message.status === 'connected') {
       this.armStableConnection();
       this.deps.log.info('Codex Micro lighting connected');
@@ -423,10 +433,6 @@ export class WorkLouderCodexHostClient implements WorkLouderCodexLightingSink {
       this.deps.log.debug('Codex Micro lighting device not detected');
     } else {
       this.deps.log.warn('Codex Micro lighting host could not apply the current frame');
-    }
-    if (permissionRequired) {
-      this.stopHostAfterPermission(child);
-      return;
     }
     // Pairing / USB re-enumeration leaves the native SDK handle alive but
     // unusable. ChatGPT recovers by opening a fresh transport; we do the same

--- a/apps/desktop/src/main/worklouder-codex/WorkLouderCodexHostClient.ts
+++ b/apps/desktop/src/main/worklouder-codex/WorkLouderCodexHostClient.ts
@@ -14,6 +14,8 @@ import type {
 } from '../../shared/workLouderCodex.js';
 import type { WorkLouderCodexLightingSink } from './WorkLouderCodexLightingController.js';
 
+const MAX_CONSECUTIVE_CRASHES = 5;
+
 export interface WorkLouderCodexChildLike {
   postMessage(message: unknown): void;
   on(event: 'message', listener: (message: unknown) => void): void;
@@ -226,6 +228,7 @@ export class WorkLouderCodexHostClient implements WorkLouderCodexLightingSink {
   private ensureChild(): WorkLouderCodexChildLike | null {
     if (this.hostStopping) return null;
     if (this.permissionBlocked) return null;
+    if (this.isCrashBudgetExhausted()) return null;
     if (!this.deviceEnabled && !this.wantsPresence) return null;
     if (this.child) return this.child;
     const sdk = this.deps.resolveSdk();
@@ -505,7 +508,7 @@ export class WorkLouderCodexHostClient implements WorkLouderCodexLightingSink {
   private scheduleRestart(): void {
     if (this.restartTimer || this.permissionBlocked || !this.shouldRestartHost()) return;
     this.consecutiveCrashes += 1;
-    if (this.consecutiveCrashes > 5) {
+    if (this.isCrashBudgetExhausted()) {
       this.deps.log.error('Codex Micro lighting host repeatedly crashed; disabled until restart');
       return;
     }
@@ -521,6 +524,10 @@ export class WorkLouderCodexHostClient implements WorkLouderCodexLightingSink {
       if (this.latestFrame) this.update(this.latestFrame);
     }, delayMs);
     this.restartTimer.unref?.();
+  }
+
+  private isCrashBudgetExhausted(): boolean {
+    return this.consecutiveCrashes > MAX_CONSECUTIVE_CRASHES;
   }
 
   private shouldRestartHost(): boolean {

--- a/apps/desktop/src/main/worklouder-codex/WorkLouderCodexHostClient.ts
+++ b/apps/desktop/src/main/worklouder-codex/WorkLouderCodexHostClient.ts
@@ -326,7 +326,7 @@ export class WorkLouderCodexHostClient implements WorkLouderCodexLightingSink {
    * paths call this method when a permission change may have happened.
    */
   retryPermission(): void {
-    if (this.disposed) return;
+    if (this.disposed || !this.permissionBlocked) return;
     this.permissionBlocked = false;
     this.probe();
   }

--- a/apps/desktop/src/main/worklouder-codex/__tests__/WorkLouderCodexHostClient.test.ts
+++ b/apps/desktop/src/main/worklouder-codex/__tests__/WorkLouderCodexHostClient.test.ts
@@ -544,7 +544,7 @@ describe('WorkLouderCodexHostClient', () => {
     }
   });
 
-  it('does not restart after a permission-required failure until an explicit probe', async () => {
+  it('does not restart after a permission-required failure during background probes', async () => {
     vi.useFakeTimers();
     try {
       const children = [new FakeChild(), new FakeChild()];
@@ -564,10 +564,12 @@ describe('WorkLouderCodexHostClient', () => {
 
       expect(children[0].kill).toHaveBeenCalledOnce();
       expect(fork).toHaveBeenCalledTimes(1);
+      client.probe();
+      client.probe();
       await vi.advanceTimersByTimeAsync(60_000);
       expect(fork).toHaveBeenCalledTimes(1);
 
-      client.probe();
+      client.retryPermission();
       expect(fork).toHaveBeenCalledTimes(2);
       expect(children[1].postMessage).toHaveBeenCalledWith({ kind: 'listen' });
     } finally {

--- a/apps/desktop/src/main/worklouder-codex/__tests__/WorkLouderCodexHostClient.test.ts
+++ b/apps/desktop/src/main/worklouder-codex/__tests__/WorkLouderCodexHostClient.test.ts
@@ -222,6 +222,7 @@ describe('WorkLouderCodexHostClient', () => {
       expect(fork).toHaveBeenCalledTimes(1);
 
       child.emit('exit', 1);
+      client.probe();
       expect(fork).toHaveBeenCalledTimes(1);
 
       await vi.advanceTimersByTimeAsync(500);
@@ -575,6 +576,42 @@ describe('WorkLouderCodexHostClient', () => {
       await vi.advanceTimersByTimeAsync(500);
       expect(fork).toHaveBeenCalledTimes(2);
       expect(children[1].postMessage).toHaveBeenCalledWith({ kind: 'listen' });
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it('does not let background probes bypass host recycle backoff', async () => {
+    vi.useFakeTimers();
+    try {
+      const children = [new FakeChild(), new FakeChild()];
+      const fork = vi.fn(() => children[fork.mock.calls.length - 1]);
+      const client = new WorkLouderCodexHostClient({
+        resolveSdk: () => ({ entry: '/sdk', source: 'openai-app' }),
+        fork,
+        log: logger(),
+      });
+      client.setAgentKeyPressHandler(vi.fn());
+      children[0].emit('message', { kind: 'state', status: 'connected' });
+      children[0].emit('message', { kind: 'state', status: 'not-detected' });
+
+      expect(fork).toHaveBeenCalledTimes(1);
+      client.probe();
+      client.probe();
+      client.update(
+        createWorkLouderCodexLightingFrame([
+          {
+            sessionId: 'session-1',
+            phase: 'running',
+            compactDetail: '',
+            attention: false,
+          },
+        ]),
+      );
+      expect(fork).toHaveBeenCalledTimes(1);
+
+      await vi.advanceTimersByTimeAsync(500);
+      expect(fork).toHaveBeenCalledTimes(2);
     } finally {
       vi.useRealTimers();
     }

--- a/apps/desktop/src/main/worklouder-codex/__tests__/WorkLouderCodexHostClient.test.ts
+++ b/apps/desktop/src/main/worklouder-codex/__tests__/WorkLouderCodexHostClient.test.ts
@@ -650,6 +650,35 @@ describe('WorkLouderCodexHostClient', () => {
     }
   });
 
+  it('stops a host when permission-required follows another error status', () => {
+    const children = [new FakeChild(), new FakeChild()];
+    const fork = vi.fn(() => children[fork.mock.calls.length - 1]);
+    const client = new WorkLouderCodexHostClient({
+      resolveSdk: () => ({ entry: '/sdk', source: 'openai-app' }),
+      fork,
+      log: logger(),
+    });
+    client.setAgentKeyPressHandler(vi.fn());
+    children[0].emit('message', {
+      kind: 'state',
+      status: 'error',
+      reason: 'connection-failed',
+    });
+    children[0].emit('message', {
+      kind: 'state',
+      status: 'error',
+      reason: 'permission-required',
+    });
+
+    expect(children[0].kill).toHaveBeenCalledOnce();
+    expect(fork).toHaveBeenCalledTimes(1);
+
+    client.retryPermission();
+
+    expect(fork).toHaveBeenCalledTimes(2);
+    expect(children[1].postMessage).toHaveBeenCalledWith({ kind: 'listen' });
+  });
+
   it('does not discover presence when unlock arrives without a permission breaker', () => {
     const fork = vi.fn(() => new FakeChild());
     const client = new WorkLouderCodexHostClient({

--- a/apps/desktop/src/main/worklouder-codex/__tests__/WorkLouderCodexHostClient.test.ts
+++ b/apps/desktop/src/main/worklouder-codex/__tests__/WorkLouderCodexHostClient.test.ts
@@ -351,7 +351,6 @@ describe('WorkLouderCodexHostClient', () => {
       'connecting',
       'connected',
       'not-detected',
-      'connecting',
     ]);
     expect(child.kill).toHaveBeenCalledOnce();
   });
@@ -521,21 +520,59 @@ describe('WorkLouderCodexHostClient', () => {
     }
   });
 
-  it('recycles the host immediately after a live session drops', () => {
-    const children = [new FakeChild(), new FakeChild()];
-    const fork = vi.fn(() => children[fork.mock.calls.length - 1]);
-    const client = new WorkLouderCodexHostClient({
-      resolveSdk: () => ({ entry: '/sdk', source: 'openai-app' }),
-      fork,
-      log: logger(),
-    });
-    client.setAgentKeyPressHandler(vi.fn());
-    children[0].emit('message', { kind: 'state', status: 'connected' });
-    children[0].emit('message', { kind: 'state', status: 'not-detected' });
+  it('backs off a host recycle after a live session drops', async () => {
+    vi.useFakeTimers();
+    try {
+      const children = [new FakeChild(), new FakeChild()];
+      const fork = vi.fn(() => children[fork.mock.calls.length - 1]);
+      const client = new WorkLouderCodexHostClient({
+        resolveSdk: () => ({ entry: '/sdk', source: 'openai-app' }),
+        fork,
+        log: logger(),
+      });
+      client.setAgentKeyPressHandler(vi.fn());
+      children[0].emit('message', { kind: 'state', status: 'connected' });
+      children[0].emit('message', { kind: 'state', status: 'not-detected' });
 
-    expect(children[0].kill).toHaveBeenCalledOnce();
-    expect(fork).toHaveBeenCalledTimes(2);
-    expect(children[1].postMessage).toHaveBeenCalledWith({ kind: 'listen' });
+      expect(children[0].kill).toHaveBeenCalledOnce();
+      expect(fork).toHaveBeenCalledTimes(1);
+      await vi.advanceTimersByTimeAsync(500);
+      expect(fork).toHaveBeenCalledTimes(2);
+      expect(children[1].postMessage).toHaveBeenCalledWith({ kind: 'listen' });
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it('does not restart after a permission-required failure until an explicit probe', async () => {
+    vi.useFakeTimers();
+    try {
+      const children = [new FakeChild(), new FakeChild()];
+      const fork = vi.fn(() => children[fork.mock.calls.length - 1]);
+      const client = new WorkLouderCodexHostClient({
+        resolveSdk: () => ({ entry: '/sdk', source: 'openai-app' }),
+        fork,
+        log: logger(),
+      });
+      client.setAgentKeyPressHandler(vi.fn());
+      children[0].emit('message', { kind: 'state', status: 'connected' });
+      children[0].emit('message', {
+        kind: 'state',
+        status: 'error',
+        reason: 'permission-required',
+      });
+
+      expect(children[0].kill).toHaveBeenCalledOnce();
+      expect(fork).toHaveBeenCalledTimes(1);
+      await vi.advanceTimersByTimeAsync(60_000);
+      expect(fork).toHaveBeenCalledTimes(1);
+
+      client.probe();
+      expect(fork).toHaveBeenCalledTimes(2);
+      expect(children[1].postMessage).toHaveBeenCalledWith({ kind: 'listen' });
+    } finally {
+      vi.useRealTimers();
+    }
   });
 });
 

--- a/apps/desktop/src/main/worklouder-codex/__tests__/WorkLouderCodexHostClient.test.ts
+++ b/apps/desktop/src/main/worklouder-codex/__tests__/WorkLouderCodexHostClient.test.ts
@@ -612,6 +612,20 @@ describe('WorkLouderCodexHostClient', () => {
       vi.useRealTimers();
     }
   });
+
+  it('does not discover presence when unlock arrives without a permission breaker', () => {
+    const fork = vi.fn(() => new FakeChild());
+    const client = new WorkLouderCodexHostClient({
+      resolveSdk: () => ({ entry: '/sdk', source: 'openai-app' }),
+      fork,
+      log: logger(),
+    });
+
+    client.setDeviceEnabled(false);
+    client.retryPermission();
+
+    expect(fork).not.toHaveBeenCalled();
+  });
 });
 
 describe('Work Louder SDK resolution', () => {

--- a/apps/desktop/src/main/worklouder-codex/__tests__/WorkLouderCodexHostClient.test.ts
+++ b/apps/desktop/src/main/worklouder-codex/__tests__/WorkLouderCodexHostClient.test.ts
@@ -520,6 +520,42 @@ describe('WorkLouderCodexHostClient', () => {
     }
   });
 
+  it('does not let probes or lighting updates bypass an exhausted crash budget', async () => {
+    vi.useFakeTimers();
+    try {
+      const children = Array.from({ length: 7 }, () => new FakeChild());
+      const fork = vi.fn(() => children[fork.mock.calls.length - 1]);
+      const client = new WorkLouderCodexHostClient({
+        resolveSdk: () => ({ entry: '/sdk', source: 'openai-app' }),
+        fork,
+        log: logger(),
+      });
+      const frame = createWorkLouderCodexLightingFrame([
+        {
+          sessionId: 'session-1',
+          phase: 'running',
+          compactDetail: '',
+          attention: false,
+        },
+      ]);
+      client.setAgentKeyPressHandler(vi.fn());
+
+      for (let index = 0; index < 6; index += 1) {
+        children[index].emit('exit', 1);
+        await vi.advanceTimersByTimeAsync(Math.min(10_000, 500 * 2 ** index));
+      }
+
+      const forksAfterBudget = fork.mock.calls.length;
+      client.probe();
+      client.probe();
+      client.update(frame);
+
+      expect(fork).toHaveBeenCalledTimes(forksAfterBudget);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
   it('backs off a host recycle after a live session drops', async () => {
     vi.useFakeTimers();
     try {

--- a/apps/desktop/src/main/worklouder-codex/__tests__/WorkLouderCodexHostProcess.test.ts
+++ b/apps/desktop/src/main/worklouder-codex/__tests__/WorkLouderCodexHostProcess.test.ts
@@ -2,8 +2,8 @@ import { afterEach, describe, expect, it, vi } from 'vitest';
 
 import {
   classifyConnectionError,
+  isOptionalDeviceStatusError,
   postDeviceStatus,
-  shouldReconnectAfterProbeStatusFailure,
 } from '../workLouderCodexHostProcess.js';
 
 const originalPlatform = process.platform;
@@ -43,9 +43,14 @@ describe('Work Louder connection error classification', () => {
 });
 
 describe('Work Louder device status', () => {
-  it('does not recycle HID for an optional probe status failure', () => {
-    expect(shouldReconnectAfterProbeStatusFailure(false)).toBe(false);
-    expect(shouldReconnectAfterProbeStatusFailure(true)).toBe(true);
+  it('recognizes explicit unsupported status RPC errors as optional telemetry', () => {
+    expect(isOptionalDeviceStatusError(new Error('status RPC unsupported'))).toBe(true);
+    expect(isOptionalDeviceStatusError({ code: 'ERR_METHOD_NOT_FOUND' })).toBe(true);
+  });
+
+  it('keeps rejected hardware status probes fatal so unplugged handles are recycled', () => {
+    expect(isOptionalDeviceStatusError(new Error('device disconnected'))).toBe(false);
+    expect(isOptionalDeviceStatusError(new Error('HID request failed'))).toBe(false);
   });
 
   it('keeps the HID connection usable when optional status telemetry fails', async () => {
@@ -63,5 +68,21 @@ describe('Work Louder device status', () => {
       ),
     ).resolves.toBeUndefined();
     expect(getDeviceStatus).toHaveBeenCalledOnce();
+  });
+
+  it('rejects a status probe that fails without an unsupported-RPC signal', async () => {
+    const getDeviceStatus = vi.fn().mockRejectedValue(new Error('device disconnected'));
+
+    await expect(
+      postDeviceStatus(
+        {
+          sendLightingConfig: vi.fn(),
+          sendThreadsLighting: vi.fn(),
+          getDeviceStatus,
+        },
+        'codex-micro',
+        true,
+      ),
+    ).rejects.toThrow('device disconnected');
   });
 });

--- a/apps/desktop/src/main/worklouder-codex/__tests__/WorkLouderCodexHostProcess.test.ts
+++ b/apps/desktop/src/main/worklouder-codex/__tests__/WorkLouderCodexHostProcess.test.ts
@@ -1,6 +1,10 @@
 import { afterEach, describe, expect, it, vi } from 'vitest';
 
-import { classifyConnectionError, postDeviceStatus } from '../workLouderCodexHostProcess.js';
+import {
+  classifyConnectionError,
+  postDeviceStatus,
+  shouldReconnectAfterProbeStatusFailure,
+} from '../workLouderCodexHostProcess.js';
 
 const originalPlatform = process.platform;
 
@@ -39,6 +43,11 @@ describe('Work Louder connection error classification', () => {
 });
 
 describe('Work Louder device status', () => {
+  it('does not recycle HID for an optional probe status failure', () => {
+    expect(shouldReconnectAfterProbeStatusFailure(false)).toBe(false);
+    expect(shouldReconnectAfterProbeStatusFailure(true)).toBe(true);
+  });
+
   it('keeps the HID connection usable when optional status telemetry fails', async () => {
     const getDeviceStatus = vi.fn().mockRejectedValue(new Error('status RPC unsupported'));
 

--- a/apps/desktop/src/main/worklouder-codex/__tests__/WorkLouderCodexHostProcess.test.ts
+++ b/apps/desktop/src/main/worklouder-codex/__tests__/WorkLouderCodexHostProcess.test.ts
@@ -1,6 +1,6 @@
-import { afterEach, describe, expect, it } from 'vitest';
+import { afterEach, describe, expect, it, vi } from 'vitest';
 
-import { classifyConnectionError } from '../workLouderCodexHostProcess.js';
+import { classifyConnectionError, postDeviceStatus } from '../workLouderCodexHostProcess.js';
 
 const originalPlatform = process.platform;
 
@@ -35,5 +35,24 @@ describe('Work Louder connection error classification', () => {
     setPlatform('linux');
 
     expect(classifyConnectionError('not permitted')).toBe('connection-failed');
+  });
+});
+
+describe('Work Louder device status', () => {
+  it('keeps the HID connection usable when optional status telemetry fails', async () => {
+    const getDeviceStatus = vi.fn().mockRejectedValue(new Error('status RPC unsupported'));
+
+    await expect(
+      postDeviceStatus(
+        {
+          sendLightingConfig: vi.fn(),
+          sendThreadsLighting: vi.fn(),
+          getDeviceStatus,
+        },
+        'codex-micro',
+        true,
+      ),
+    ).resolves.toBeUndefined();
+    expect(getDeviceStatus).toHaveBeenCalledOnce();
   });
 });

--- a/apps/desktop/src/main/worklouder-codex/__tests__/WorkLouderCodexHostProcess.test.ts
+++ b/apps/desktop/src/main/worklouder-codex/__tests__/WorkLouderCodexHostProcess.test.ts
@@ -1,0 +1,39 @@
+import { afterEach, describe, expect, it } from 'vitest';
+
+import { classifyConnectionError } from '../workLouderCodexHostProcess.js';
+
+const originalPlatform = process.platform;
+
+function setPlatform(platform: NodeJS.Platform): void {
+  Object.defineProperty(process, 'platform', { value: platform, configurable: true });
+}
+
+afterEach(() => {
+  setPlatform(originalPlatform);
+});
+
+describe('Work Louder connection error classification', () => {
+  it('keeps macOS authorization failures on the permission circuit breaker path', () => {
+    setPlatform('darwin');
+
+    expect(classifyConnectionError('HID access denied by Input Monitoring')).toBe(
+      'permission-required',
+    );
+    expect(classifyConnectionError('operation not allowed')).toBe('permission-required');
+  });
+
+  it('keeps Windows access denied on the bounded connection retry path', () => {
+    setPlatform('win32');
+
+    expect(classifyConnectionError('HID access denied')).toBe('connection-failed');
+    expect(classifyConnectionError('permission denied while opening HID handle')).toBe(
+      'connection-failed',
+    );
+  });
+
+  it('does not treat permission-looking errors as permanent outside macOS', () => {
+    setPlatform('linux');
+
+    expect(classifyConnectionError('not permitted')).toBe('connection-failed');
+  });
+});

--- a/apps/desktop/src/main/worklouder-codex/index.ts
+++ b/apps/desktop/src/main/worklouder-codex/index.ts
@@ -1,7 +1,7 @@
 import fs from 'node:fs';
 import { createRequire } from 'node:module';
 import path from 'node:path';
-import { BrowserWindow, ipcMain, shell, utilityProcess } from 'electron';
+import { BrowserWindow, ipcMain, powerMonitor, shell, utilityProcess } from 'electron';
 
 import { createLogger } from '../logger.js';
 import { getDeepLinkMainWindow, openMainWindowSession, sendMainWindowMessage } from '../deepLink.js';
@@ -205,6 +205,12 @@ export function registerWorkLouderCodexInputDevice(): void {
 export function registerWorkLouderCodexSettingsIpc(): void {
   if (settingsIpcRegistered) return;
   settingsIpcRegistered = true;
+
+  // macOS can report the same HID denial while the screen is locked. The
+  // client keeps that failure circuit-broken until unlock, then makes one
+  // bounded recovery attempt instead of relying on the settings poller to
+  // recreate the host every two seconds.
+  powerMonitor.on('unlock-screen', () => hostClient.retryPermission());
 
   workLouderCodexLightingController.applySettings(readWorkLouderCodexSettings());
   workLouderCodexLightingController.start();

--- a/apps/desktop/src/main/worklouder-codex/index.ts
+++ b/apps/desktop/src/main/worklouder-codex/index.ts
@@ -1,7 +1,7 @@
 import fs from 'node:fs';
 import { createRequire } from 'node:module';
 import path from 'node:path';
-import { BrowserWindow, ipcMain, powerMonitor, shell, utilityProcess } from 'electron';
+import { app, BrowserWindow, ipcMain, powerMonitor, shell, utilityProcess } from 'electron';
 
 import { createLogger } from '../logger.js';
 import { getDeepLinkMainWindow, openMainWindowSession, sendMainWindowMessage } from '../deepLink.js';
@@ -172,6 +172,7 @@ const layoutPreviewLease = createLayoutPreviewLease((active) => {
 
 let settingsIpcRegistered = false;
 let inputDeviceRegistered = false;
+let permissionSettingsRetryPending = false;
 
 /** Register this board as one input-device adapter, not as the host keyboard layer. */
 export function registerWorkLouderCodexInputDevice(): void {
@@ -211,6 +212,11 @@ export function registerWorkLouderCodexSettingsIpc(): void {
   // bounded recovery attempt instead of relying on the settings poller to
   // recreate the host every two seconds.
   powerMonitor.on('unlock-screen', () => hostClient.retryPermission());
+  app.on('browser-window-focus', () => {
+    if (!permissionSettingsRetryPending) return;
+    permissionSettingsRetryPending = false;
+    hostClient.retryPermission();
+  });
 
   workLouderCodexLightingController.applySettings(readWorkLouderCodexSettings());
   workLouderCodexLightingController.start();
@@ -222,9 +228,15 @@ export function registerWorkLouderCodexSettingsIpc(): void {
     applySettings: (settings) => workLouderCodexLightingController.applySettings(settings),
     openInputMonitoringSettings: async () => {
       if (process.platform !== 'darwin') return;
-      await shell.openExternal(
-        'x-apple.systempreferences:com.apple.preference.security?Privacy_ListenEvent',
-      );
+      permissionSettingsRetryPending = true;
+      try {
+        await shell.openExternal(
+          'x-apple.systempreferences:com.apple.preference.security?Privacy_ListenEvent',
+        );
+      } catch (error) {
+        permissionSettingsRetryPending = false;
+        throw error;
+      }
     },
     probeDevice: () => hostClient.probe(),
     publishTasks: (tasks) => {

--- a/apps/desktop/src/main/worklouder-codex/workLouderCodexHostProcess.ts
+++ b/apps/desktop/src/main/worklouder-codex/workLouderCodexHostProcess.ts
@@ -280,9 +280,9 @@ async function probeConnection(): Promise<void> {
     let probeError: string | null = null;
     if (typeof api.getDeviceStatus === 'function' && !faulted) {
       try {
-        // Call it directly rather than through postDeviceStatus, which swallows
-        // failures — swallowing here would make every probe "succeed" and defeat
-        // the whole point. Same round trip also keeps battery and firmware fresh.
+        // Call it directly so a successful round trip keeps battery and firmware
+        // values fresh while still letting a rejected optional RPC trigger a
+        // reconnect below.
         const status = await api.getDeviceStatus();
         if (!transportFaulted) {
           const device = connectedDevice;
@@ -295,13 +295,18 @@ async function probeConnection(): Promise<void> {
         hostLog('debug', `probe found the device gone: ${probeError}`);
       }
     }
-    const transportError = transportFaulted ? lastTransportError : probeError;
+    const transportError = transportFaulted ? lastTransportError : null;
     if (transportError) {
       await disconnect();
       reportConnectionError(transportError);
       return;
     }
-    hostLog('debug', 'probe dropped a stale Work Louder transport');
+    hostLog(
+      'debug',
+      probeError
+        ? `probe status failed; reconnecting Work Louder transport: ${probeError}`
+        : 'probe dropped a stale Work Louder transport',
+    );
     await disconnect();
   }
 

--- a/apps/desktop/src/main/worklouder-codex/workLouderCodexHostProcess.ts
+++ b/apps/desktop/src/main/worklouder-codex/workLouderCodexHostProcess.ts
@@ -278,6 +278,7 @@ async function probeConnection(): Promise<void> {
   if (api) {
     const faulted = transportFaulted;
     let probeError: string | null = null;
+    let optionalStatusFailure = false;
     if (typeof api.getDeviceStatus === 'function' && !faulted) {
       try {
         // Call it directly so a successful round trip keeps battery and firmware
@@ -292,22 +293,31 @@ async function probeConnection(): Promise<void> {
         }
       } catch (error) {
         probeError = safeErrorMessage(error);
-        hostLog('debug', `probe status unavailable: ${probeError}`);
+        optionalStatusFailure = isOptionalDeviceStatusError(error);
+        hostLog(
+          'debug',
+          optionalStatusFailure
+            ? `probe status unavailable: ${probeError}`
+            : `probe found the device gone: ${probeError}`,
+        );
       }
     }
-    const transportError = shouldReconnectAfterProbeStatusFailure(transportFaulted)
-      ? lastTransportError
-      : null;
+    const transportError = transportFaulted ? lastTransportError : null;
     if (transportError) {
       await disconnect();
       reportConnectionError(transportError);
       return;
     }
-    if (probeError) {
+    if (probeError && optionalStatusFailure) {
       // Status is optional telemetry. Keep the healthy HID transport when a
-      // firmware/RPC implementation rejects this query; reconnect only when
-      // the SDK explicitly marked the transport as faulted above.
+      // firmware/RPC implementation explicitly reports that this query is not
+      // supported; a rejected hardware request must still invalidate the handle.
       post({ kind: 'state', status: 'connected' });
+      return;
+    }
+    if (probeError) {
+      await disconnect();
+      reportConnectionError(probeError);
       return;
     }
     hostLog('debug', 'probe dropped a stale Work Louder transport');
@@ -524,12 +534,31 @@ function postActivity(): void {
 }
 
 /**
- * Decide whether a failed status probe invalidates the HID transport.
- * Optional status telemetry may be unsupported while input remains usable;
- * only the SDK's explicit transport fault should trigger reconnect handling.
+ * The SDK exposes status as an optional RPC on some firmware versions. Keep
+ * that compatibility failure non-fatal, but treat every other rejection as a
+ * failed hardware round trip so unplugged handles are recycled promptly.
  */
-export function shouldReconnectAfterProbeStatusFailure(transportFaulted: boolean): boolean {
-  return transportFaulted;
+export function isOptionalDeviceStatusError(error: unknown): boolean {
+  const record =
+    typeof error === 'object' && error !== null ? (error as Record<string, unknown>) : null;
+  const code = typeof record?.code === 'string' ? record.code : '';
+  if (
+    /not[_ -]?supported|unsupported|not[_ -]?implemented|method[_ -]?not[_ -]?found|enosys/i.test(
+      code,
+    )
+  ) {
+    return true;
+  }
+
+  const message = safeErrorMessage(error);
+  return (
+    /(?:getDeviceStatus|device status|status rpc|status request).*(?:not supported|unsupported|not implemented|unknown method|method not found)/i.test(
+      message,
+    ) ||
+    /(?:not supported|unsupported|not implemented|unknown method|method not found).*(?:getDeviceStatus|device status|status rpc|status request)/i.test(
+      message,
+    )
+  );
 }
 
 export async function postDeviceStatus(
@@ -543,10 +572,10 @@ export async function postDeviceStatus(
       status = await deviceApi.getDeviceStatus();
     } catch (error) {
       hostLog('warn', `device status unavailable: ${safeErrorMessage(error)}`);
-      // Device status is optional telemetry. A firmware or RPC implementation
-      // may reject it even while the HID transport remains usable; only the
-      // SDK's explicit transport fault signal should tear down the connection.
-      if (transportFaulted) throw error;
+      // Device status is optional telemetry only when the SDK explicitly says
+      // this RPC is unsupported. A rejected hardware request still means the
+      // transport may be dead and must not be reported as connected.
+      if (transportFaulted || !isOptionalDeviceStatusError(error)) throw error;
     }
   }
   postDeviceState(deviceType, isUsbConnection, status);

--- a/apps/desktop/src/main/worklouder-codex/workLouderCodexHostProcess.ts
+++ b/apps/desktop/src/main/worklouder-codex/workLouderCodexHostProcess.ts
@@ -358,6 +358,10 @@ function discoverPresence(): void {
   } catch (error) {
     hostLog('debug', `presence discovery failed: ${safeErrorMessage(error)}`);
     post({ kind: 'presence', present: false });
+  } finally {
+    // Presence discovery does not own a HID transport. Do not let an SDK
+    // discovery diagnostic poison the next real connection attempt.
+    clearTransportFault();
   }
 }
 
@@ -462,7 +466,12 @@ function safeErrorMessage(error: unknown): string {
 async function ensureConnected(): Promise<WorkLouderApi | null> {
   if (api && transportFaulted) await disconnect();
   if (api) return api;
+  // Discovery runs with the same SDK logger as the HID transport, but it is
+  // independent of any connection. Start each new connection with a clean
+  // transport-fault state.
+  clearTransportFault();
   const candidate = findCandidates()[0];
+  clearTransportFault();
   if (!candidate) return null;
   const loaded = loadSdk();
   const nextComm = new loaded.WLDeviceCommImpl(sdkLogger);
@@ -654,8 +663,7 @@ function clearRetry(): void {
 }
 
 async function disconnect(): Promise<void> {
-  transportFaulted = false;
-  lastTransportError = null;
+  clearTransportFault();
   connectedDevice = null;
   const unsubscribe = unsubscribeHid;
   unsubscribeHid = null;
@@ -684,6 +692,11 @@ async function disconnect(): Promise<void> {
   } catch {
     // Connection teardown is best effort after a failed HID RPC.
   }
+}
+
+function clearTransportFault(): void {
+  transportFaulted = false;
+  lastTransportError = null;
 }
 
 async function stop(): Promise<void> {

--- a/apps/desktop/src/main/worklouder-codex/workLouderCodexHostProcess.ts
+++ b/apps/desktop/src/main/worklouder-codex/workLouderCodexHostProcess.ts
@@ -554,10 +554,17 @@ function postDeviceState(
   });
 }
 
-function classifyConnectionError(message: string): 'connection-failed' | 'permission-required' {
-  return /permission|not permitted|access denied|input monitoring|operation not allowed/i.test(
+export function classifyConnectionError(message: string):
+  | 'connection-failed'
+  | 'permission-required' {
+  const looksLikePermissionError = /permission|not permitted|access denied|input monitoring|operation not allowed/i.test(
     message,
-  )
+  );
+  // Input Monitoring is a macOS authorization boundary. On Windows, the HID
+  // backend also reports transient handle contention as "access denied"; that
+  // must stay on the bounded connection retry path instead of tripping the
+  // permanent permission circuit breaker.
+  return process.platform === 'darwin' && looksLikePermissionError
     ? 'permission-required'
     : 'connection-failed';
 }

--- a/apps/desktop/src/main/worklouder-codex/workLouderCodexHostProcess.ts
+++ b/apps/desktop/src/main/worklouder-codex/workLouderCodexHostProcess.ts
@@ -514,7 +514,7 @@ function postActivity(): void {
   post({ kind: 'activity' });
 }
 
-async function postDeviceStatus(
+export async function postDeviceStatus(
   deviceApi: WorkLouderApi,
   deviceType: 'codex-micro' | 'creator-micro-2',
   isUsbConnection: boolean,
@@ -525,7 +525,10 @@ async function postDeviceStatus(
       status = await deviceApi.getDeviceStatus();
     } catch (error) {
       hostLog('warn', `device status unavailable: ${safeErrorMessage(error)}`);
-      throw error;
+      // Device status is optional telemetry. A firmware or RPC implementation
+      // may reject it even while the HID transport remains usable; only the
+      // SDK's explicit transport fault signal should tear down the connection.
+      if (transportFaulted) throw error;
     }
   }
   postDeviceState(deviceType, isUsbConnection, status);
@@ -554,12 +557,11 @@ function postDeviceState(
   });
 }
 
-export function classifyConnectionError(message: string):
-  | 'connection-failed'
-  | 'permission-required' {
-  const looksLikePermissionError = /permission|not permitted|access denied|input monitoring|operation not allowed/i.test(
-    message,
-  );
+export function classifyConnectionError(
+  message: string,
+): 'connection-failed' | 'permission-required' {
+  const looksLikePermissionError =
+    /permission|not permitted|access denied|input monitoring|operation not allowed/i.test(message);
   // Input Monitoring is a macOS authorization boundary. On Windows, the HID
   // backend also reports transient handle contention as "access denied"; that
   // must stay on the bounded connection retry path instead of tripping the

--- a/apps/desktop/src/main/worklouder-codex/workLouderCodexHostProcess.ts
+++ b/apps/desktop/src/main/worklouder-codex/workLouderCodexHostProcess.ts
@@ -65,6 +65,8 @@ interface WorkLouderLogger {
 const parentPort = (process as unknown as { parentPort?: ParentPortLike }).parentPort;
 const requireFromHost = createRequire(__filename);
 const RETRY_MS = 3_000;
+const SDK_LOG_WINDOW_MS = 60_000;
+const SDK_LOG_BURST = 3;
 
 let sdk: WorkLouderSdk | null = null;
 let sdkEntry: string | null = null;
@@ -84,6 +86,9 @@ let stopping = false;
 let retryTimer: ReturnType<typeof setTimeout> | null = null;
 let lastLoggedError: string | null = null;
 let lastActivityPostedAt = 0;
+let lastTransportError: string | null = null;
+let permissionBlocked = false;
+const sdkLogBuckets = new Map<string, { startedAt: number; emitted: number; suppressed: number }>();
 /** The native SDK often logs a dead USB/BT handle instead of throwing. */
 let transportFaulted = false;
 /** Which device the current `api` handle belongs to, so probes can refresh it. */
@@ -95,6 +100,10 @@ if (parentPort) {
     const request = event.data as WorkLouderCodexHostRequest;
     if (request?.kind === 'init') {
       sdkEntry = request.sdkEntry;
+      permissionBlocked = false;
+      transportFaulted = false;
+      lastTransportError = null;
+      lastLoggedError = null;
     } else if (request?.kind === 'listen') {
       hidListeningRequested = true;
       requestListen();
@@ -102,6 +111,10 @@ if (parentPort) {
       latestFrame = request.frame;
       requestApply();
     } else if (request?.kind === 'probe') {
+      // A probe is an explicit recovery request (for example after the user
+      // grants Input Monitoring or unlocks macOS), so it is allowed to clear
+      // the permission circuit breaker once.
+      permissionBlocked = false;
       requestProbe();
     } else if (request?.kind === 'discover') {
       requestDiscover();
@@ -122,10 +135,12 @@ function hostLog(level: 'debug' | 'info' | 'warn' | 'error', message: string): v
 const sdkLogger: WorkLouderLogger = {
   debug: () => undefined,
   info: () => undefined,
-  warn: (...args) => hostLog('warn', `Work Louder SDK reported a warning${formatSdkLog(args)}`),
+  warn: (...args) => logSdkMessage('warn', 'Work Louder SDK reported a warning', args),
   error: (...args) => {
     transportFaulted = true;
-    hostLog('error', `Work Louder SDK reported an error${formatSdkLog(args)}`);
+    const detail = formatSdkLog(args);
+    lastTransportError = `Work Louder SDK reported an error${detail}`;
+    logSdkMessage('error', 'Work Louder SDK reported an error', args);
     if (api && !stopping && !probePending && !applying) requestProbe();
   },
 };
@@ -147,19 +162,19 @@ function loadSdk(): WorkLouderSdk {
 }
 
 function requestApply(): void {
-  if (stopping) return;
+  if (stopping || permissionBlocked) return;
   applyPending = true;
   kickQueue();
 }
 
 function requestListen(): void {
-  if (stopping) return;
+  if (stopping || permissionBlocked) return;
   listenPending = true;
   kickQueue();
 }
 
 function requestProbe(): void {
-  if (stopping) return;
+  if (stopping || permissionBlocked) return;
   probePending = true;
   kickQueue();
 }
@@ -226,7 +241,11 @@ async function applyFrame(frame: WorkLouderCodexLightingFrame): Promise<void> {
     });
     const threadsOk = await deviceApi.sendThreadsLighting(frame.threads);
     if (!lightingOk || !threadsOk || transportFaulted) {
-      throw new Error(transportFaulted ? 'lighting transport faulted' : 'lighting RPC returned false');
+      throw new Error(
+        transportFaulted
+          ? (lastTransportError ?? 'lighting transport faulted')
+          : 'lighting RPC returned false',
+      );
     }
     clearRetry();
     lastLoggedError = null;
@@ -238,8 +257,7 @@ async function applyFrame(frame: WorkLouderCodexLightingFrame): Promise<void> {
       hostLog('error', `lighting apply failed: ${message}`);
     }
     await disconnect();
-    post({ kind: 'state', status: 'error', reason: classifyConnectionError(message) });
-    scheduleRetry();
+    reportConnectionError(message);
   }
 }
 
@@ -256,9 +274,10 @@ async function applyFrame(frame: WorkLouderCodexLightingFrame): Promise<void> {
  * showing connection state, so an idle app is not waking the device on a timer.
  */
 async function probeConnection(): Promise<void> {
-  if (stopping) return;
+  if (stopping || permissionBlocked) return;
   if (api) {
     const faulted = transportFaulted;
+    let probeError: string | null = null;
     if (typeof api.getDeviceStatus === 'function' && !faulted) {
       try {
         // Call it directly rather than through postDeviceStatus, which swallows
@@ -272,8 +291,15 @@ async function probeConnection(): Promise<void> {
           return;
         }
       } catch (error) {
-        hostLog('debug', `probe found the device gone: ${safeErrorMessage(error)}`);
+        probeError = safeErrorMessage(error);
+        hostLog('debug', `probe found the device gone: ${probeError}`);
       }
+    }
+    const transportError = transportFaulted ? lastTransportError : probeError;
+    if (transportError) {
+      await disconnect();
+      reportConnectionError(transportError);
+      return;
     }
     hostLog('debug', 'probe dropped a stale Work Louder transport');
     await disconnect();
@@ -290,9 +316,10 @@ async function probeConnection(): Promise<void> {
     post({ kind: 'state', status: 'connected' });
     if (hidListeningRequested) requestListen();
     if (latestFrame && !isWorkLouderCodexLightingFrameOff(latestFrame)) requestApply();
-  } catch {
-    post({ kind: 'state', status: 'not-detected' });
-    scheduleRetry();
+  } catch (error) {
+    const message = safeErrorMessage(error);
+    await disconnect();
+    reportConnectionError(message);
   }
 }
 
@@ -355,8 +382,7 @@ async function listenForAgentKeys(): Promise<void> {
       hostLog('error', `HID listening failed: ${message}`);
     }
     await disconnect();
-    post({ kind: 'state', status: 'error', reason: classifyConnectionError(message) });
-    scheduleRetry();
+    reportConnectionError(message);
   }
 }
 
@@ -368,6 +394,42 @@ function formatSdkLog(args: unknown[]): string {
     .join(' ')
     .trim();
   return detail ? `: ${detail}` : '';
+}
+
+function logSdkMessage(level: 'warn' | 'error', prefix: string, args: unknown[]): void {
+  const detail = formatSdkLog(args);
+  const message = `${prefix}${detail}`;
+  const signature = normalizeSdkLogSignature(message);
+  const now = Date.now();
+  const previous = sdkLogBuckets.get(signature);
+  if (!previous || now - previous.startedAt >= SDK_LOG_WINDOW_MS) {
+    if (previous?.suppressed) {
+      hostLog(
+        level,
+        `${prefix} (suppressed ${previous.suppressed} repeated messages in the previous minute): ${signature}`,
+      );
+    }
+    if (!previous && sdkLogBuckets.size >= 128) {
+      const oldest = sdkLogBuckets.keys().next().value;
+      if (typeof oldest === 'string') sdkLogBuckets.delete(oldest);
+    }
+    sdkLogBuckets.set(signature, { startedAt: now, emitted: 1, suppressed: 0 });
+    hostLog(level, message);
+    return;
+  }
+  if (previous.emitted < SDK_LOG_BURST) {
+    previous.emitted += 1;
+    hostLog(level, message);
+  } else {
+    previous.suppressed += 1;
+  }
+}
+
+function normalizeSdkLogSignature(message: string): string {
+  return message
+    .replace(/0x[0-9a-f]+/gi, '<hex>')
+    .replace(/\b\d+\b/g, '<n>')
+    .slice(0, 240);
 }
 
 function safeErrorMessage(error: unknown): string {
@@ -385,7 +447,24 @@ async function ensureConnected(): Promise<WorkLouderApi | null> {
   if (!candidate) return null;
   const loaded = loadSdk();
   const nextComm = new loaded.WLDeviceCommImpl(sdkLogger);
-  if (!(await nextComm.connect(candidate.device))) return null;
+  let connected = false;
+  try {
+    connected = await nextComm.connect(candidate.device);
+  } catch (error) {
+    const message = transportFaulted ? (lastTransportError ?? safeErrorMessage(error)) : null;
+    try {
+      await nextComm.disconnect();
+    } catch {
+      // Connection setup failed; teardown is best effort.
+    }
+    throw new Error(message ?? safeErrorMessage(error));
+  }
+  if (!connected) {
+    if (transportFaulted) {
+      throw new Error(lastTransportError ?? 'Work Louder transport faulted');
+    }
+    return null;
+  }
   comm = nextComm;
   const nextApi = new loaded.RPCApiOAI(nextComm, sdkLogger);
   if (typeof nextApi.onHidReceived === 'function') {
@@ -411,7 +490,20 @@ async function ensureConnected(): Promise<WorkLouderApi | null> {
     deviceType: candidate.deviceType,
     isUsb: candidate.device.isUsbConnection === true,
   };
-  await postDeviceStatus(nextApi, candidate.deviceType, candidate.device.isUsbConnection === true);
+  try {
+    await postDeviceStatus(
+      nextApi,
+      candidate.deviceType,
+      candidate.device.isUsbConnection === true,
+    );
+    if (transportFaulted) {
+      throw new Error(lastTransportError ?? 'Work Louder transport faulted');
+    }
+  } catch (error) {
+    const message = transportFaulted ? (lastTransportError ?? safeErrorMessage(error)) : null;
+    await disconnect();
+    throw new Error(message ?? safeErrorMessage(error));
+  }
   return nextApi;
 }
 
@@ -433,6 +525,7 @@ async function postDeviceStatus(
       status = await deviceApi.getDeviceStatus();
     } catch (error) {
       hostLog('warn', `device status unavailable: ${safeErrorMessage(error)}`);
+      throw error;
     }
   }
   postDeviceState(deviceType, isUsbConnection, status);
@@ -469,10 +562,21 @@ function classifyConnectionError(message: string): 'connection-failed' | 'permis
     : 'connection-failed';
 }
 
+function reportConnectionError(message: string): void {
+  const reason = classifyConnectionError(message);
+  if (reason === 'permission-required') {
+    permissionBlocked = true;
+    clearRetry();
+  }
+  post({ kind: 'state', status: 'error', reason });
+  if (reason !== 'permission-required') scheduleRetry();
+}
+
 function scheduleRetry(): void {
   if (
     retryTimer ||
     stopping ||
+    permissionBlocked ||
     (!latestFrame && !hidListeningRequested) ||
     (latestFrame && isWorkLouderCodexLightingFrameOff(latestFrame) && !hidListeningRequested)
   ) {
@@ -495,6 +599,7 @@ function clearRetry(): void {
 
 async function disconnect(): Promise<void> {
   transportFaulted = false;
+  lastTransportError = null;
   connectedDevice = null;
   const unsubscribe = unsubscribeHid;
   unsubscribeHid = null;

--- a/apps/desktop/src/main/worklouder-codex/workLouderCodexHostProcess.ts
+++ b/apps/desktop/src/main/worklouder-codex/workLouderCodexHostProcess.ts
@@ -281,8 +281,8 @@ async function probeConnection(): Promise<void> {
     if (typeof api.getDeviceStatus === 'function' && !faulted) {
       try {
         // Call it directly so a successful round trip keeps battery and firmware
-        // values fresh while still letting a rejected optional RPC trigger a
-        // reconnect below.
+        // values fresh while still letting an explicit transport fault trigger
+        // reconnect handling below.
         const status = await api.getDeviceStatus();
         if (!transportFaulted) {
           const device = connectedDevice;
@@ -292,21 +292,25 @@ async function probeConnection(): Promise<void> {
         }
       } catch (error) {
         probeError = safeErrorMessage(error);
-        hostLog('debug', `probe found the device gone: ${probeError}`);
+        hostLog('debug', `probe status unavailable: ${probeError}`);
       }
     }
-    const transportError = transportFaulted ? lastTransportError : null;
+    const transportError = shouldReconnectAfterProbeStatusFailure(transportFaulted)
+      ? lastTransportError
+      : null;
     if (transportError) {
       await disconnect();
       reportConnectionError(transportError);
       return;
     }
-    hostLog(
-      'debug',
-      probeError
-        ? `probe status failed; reconnecting Work Louder transport: ${probeError}`
-        : 'probe dropped a stale Work Louder transport',
-    );
+    if (probeError) {
+      // Status is optional telemetry. Keep the healthy HID transport when a
+      // firmware/RPC implementation rejects this query; reconnect only when
+      // the SDK explicitly marked the transport as faulted above.
+      post({ kind: 'state', status: 'connected' });
+      return;
+    }
+    hostLog('debug', 'probe dropped a stale Work Louder transport');
     await disconnect();
   }
 
@@ -517,6 +521,15 @@ function postActivity(): void {
   if (now - lastActivityPostedAt < 250) return;
   lastActivityPostedAt = now;
   post({ kind: 'activity' });
+}
+
+/**
+ * Decide whether a failed status probe invalidates the HID transport.
+ * Optional status telemetry may be unsupported while input remains usable;
+ * only the SDK's explicit transport fault should trigger reconnect handling.
+ */
+export function shouldReconnectAfterProbeStatusFailure(transportFaulted: boolean): boolean {
+  return transportFaulted;
 }
 
 export async function postDeviceStatus(


### PR DESCRIPTION
## 这次改了什么

### 摘要

修复 Codex Micro 在 macOS 锁屏或 HID 权限错误期间触发的 Work Louder host 无限回收与重启风暴。权限类错误现在进入熔断，设备回收统一遵循指数退避和 crash budget；后台探测不会清除熔断，只有明确的恢复信号才会重新尝试连接。

### 变更类型

- [x] `fix` 缺陷修复
- [ ] `refactor` / `perf` 重构或性能优化
- [ ] `docs` / `test` / `chore` 文档、测试或工程维护

### 范围

- 关联 Issue / 需求：无
- 本 PR 包含：5 个 Desktop Work Louder 文件的权限错误分类、回收重启退避、连接状态校验、SDK 日志限频、权限恢复路径和回归测试。
- 明确不包含：ASR 服务超时、语音识别协议或服务端改动。
- 用户可见变化：锁屏或输入设备不可用时不再快速反复重启；设置页每两秒的后台 probe 保持观察性质，不会绕过权限熔断；macOS 解锁，或用户从 Input Monitoring 系统设置返回 Cindy 后，会各自触发一次有界恢复尝试。
- 是否存在 breaking change：无。

### UI 变化

- 不涉及：仅修改 Desktop main/utility host 与单元测试，没有界面、布局或 UI 文案变化。
- 引用的设计规范：不涉及。

## 怎么验证的

### 自动验证

```text
pnpm test:unit:related
结果：通过（apps/desktop related unit，13.2s）

pnpm --filter desktop typecheck
结果：通过

pnpm --filter desktop exec vitest run src/main/worklouder-codex/__tests__/WorkLouderCodexHostClient.test.ts
结果：通过（22/22）

pnpm --filter desktop exec vitest run src/main/worklouder-codex/__tests__/WorkLouderCodexHostProcess.test.ts
结果：通过（3/3，macOS 权限分类与 Windows 瞬时 access denied 重试分类）

git diff --check
结果：通过
```

### 手工验证

在 macOS Global 独立开发沙箱中运行 `pnpm restart:desktop:remote --region=global --isolated=@worktree`，收到 `DESKTOP_DEV_VERDICT=ready`。运行日志中未出现 `host recycled`、`host exited` 或 `not permitted` 风暴记录。

### 未执行的验证

未再次执行 macOS 锁屏 10 分钟后解锁的真实恢复验收；当前验证覆盖代码路径、定向测试、related unit、类型检查和开发版启动。Windows 未在本机实测。

## 风险

### 风险分类

- [ ] 无已知风险
- [ ] SQLite / migration
- [ ] system prompt
- [ ] 协议兼容
- [x] 权限 / 安全 / 用户数据
- [ ] 存量插件兼容（批准状态 / 指纹 / manifest 校验 / 安装布局 / 包格式）
- [x] 跨平台差异
- [ ] 其他：

### 影响与回滚

- 影响范围：Desktop Work Louder Codex host 的异常设备断连和权限错误恢复路径；正常连接路径保持不变。权限熔断仅用于 macOS Input Monitoring，Windows 的 `access denied` 仍走有界连接重试，避免瞬时 HID 句柄冲突被永久熔断。Windows 未在本机实测。
- 回滚 / 降级方式：回滚本 PR 的提交即可恢复旧逻辑；在发布前也可关闭 Codex Micro lighting。

### 提交前检查

- [x] 已 review 完整 diff
- [x] 每个 commit 都带 DCO 签名（`git commit -s`，见 [DCO](../DCO)）
- [x] UI 改动已在「UI 变化」注明引用的设计规范章节（不涉及 UI）
- [x] 未提交凭证、令牌或授权文件
- [x] 已补充必要文档
- [x] 已确认测试结果或说明未执行原因

补充说明：仓库完整单测门禁在 `packages/maker-core` 的 3 个 PI 集成测试失败；同一失败在干净 `origin/main` 基线上复现，确认与本 PR 无关。`apps/desktop` workspace 在 related 门禁中通过。
