### PR TITLE
fix(maker-core): 放宽 Windows 后代清理超时以消除忙碌 runner 竞态

### DIFF
--- a/packages/maker-core/src/agents/pi/windows-git-path-powershell.test.ts
+++ b/packages/maker-core/src/agents/pi/windows-git-path-powershell.test.ts
@@ -253,7 +253,9 @@ describe('Windows Git PATH PowerShell probes', () => {
         }
       }
     },
-     30_000,
+    // waitFor(5s) + descendant cleanup exec(10s) + liveness probe exec(15s) already
+    // sum to 30s; leave headroom for coordinator exit, taskkill, and scheduling.
+     45_000,
   );
 
   it('reports recoverable script failures only when a logger is supplied', () => {

--- a/packages/maker-core/src/agents/pi/windows-git-path-powershell.test.ts
+++ b/packages/maker-core/src/agents/pi/windows-git-path-powershell.test.ts
@@ -227,7 +227,7 @@ describe('Windows Git PATH PowerShell probes', () => {
             '-NonInteractive',
             '-Command',
             [
-              '$deadline = [DateTime]::UtcNow.AddSeconds(3)',
+              '$deadline = [DateTime]::UtcNow.AddSeconds(8)',
               `while (Get-Process -Id ${childPid} -ErrorAction SilentlyContinue) {`,
               '  if ([DateTime]::UtcNow -ge $deadline) { exit 1 }',
               '  Start-Sleep -Milliseconds 50',
@@ -235,8 +235,8 @@ describe('Windows Git PATH PowerShell probes', () => {
             ].join('\n'),
           ],
            // PowerShell startup can exceed five seconds on a busy hosted Windows runner;
-           // allow cleanup to observe the child process exit without changing the probe budget.
-           { stdio: 'ignore', timeout: 10_000, windowsHide: true },
+           // the in-script deadline (8s) plus startup must fit the exec timeout.
+           { stdio: 'ignore', timeout: 15_000, windowsHide: true },
         );
       } finally {
         if (coordinatorPid) {
@@ -253,7 +253,7 @@ describe('Windows Git PATH PowerShell probes', () => {
         }
       }
     },
-     20_000,
+     30_000,
   );
 
   it('reports recoverable script failures only when a logger is supplied', () => {

--- a/packages/maker-core/src/agents/pi/windows-git-path-powershell.ts
+++ b/packages/maker-core/src/agents/pi/windows-git-path-powershell.ts
@@ -5,7 +5,11 @@ import type { Logger } from '../../interfaces/logger.js';
 export type WindowsGitPathLogger = Pick<Logger, 'warn'>;
 
 const DIAGNOSTIC_PREFIX = '__CINDY_WINDOWS_GIT_PATH_DIAGNOSTIC__';
-const WINDOWS_DESCENDANT_CLEANUP_TIMEOUT_MS = 2_000;
+// 忙碌的 Windows 宿主(如 CI hosted runner)上 PowerShell 冷启动就可能超过
+// 5 秒:2 秒预算会让清理进程在 Stop-Process 执行前就被 execFileSync 超时
+// 杀掉,后代进程泄漏(#3574 的偶发失败正是这个竞态)。清理只在探测已经
+// 失败的收尾路径运行,放宽预算不影响任何成功路径的耗时。
+const WINDOWS_DESCENDANT_CLEANUP_TIMEOUT_MS = 10_000;
 
 type WindowsPowerShellProbe = 'registry' | 'network-drives' | 'path-kinds' | 'path-cleanup';
 


### PR DESCRIPTION
## 这次改了什么

### 摘要

fix #3574(Windows PowerShell 后代清理测试偶发失败)。根因是一个真实的预算竞态,不只是测试超时太紧:

`terminateWindowsPowerShellDescendants` 用 `execFileSync` 启动清理 PowerShell(Get-CimInstance 遍历后代 + Stop-Process),超时预算 `WINDOWS_DESCENDANT_CLEANUP_TIMEOUT_MS = 2_000`。而忙碌的 Windows hosted runner 上 PowerShell 冷启动本身就可能超过 5 秒——测试文件里的既有注释自己就承认这一点("PowerShell startup can exceed five seconds on a busy hosted runner")。结果:清理进程在执行到 Stop-Process 之前就被 execFileSync 超时杀掉,后代进程泄漏,测试随后探测到子进程仍存活而失败。

修复分两层:

- **产线侧**(`windows-git-path-powershell.ts`):清理超时 2s → 10s,附注释说明依据。该常量唯一的生产调用点在 `windows-git-path.ts` 探测失败后的 catch 收尾路径——只有探测已经失败才会走到清理;放宽预算不影响任何成功路径的耗时。
- **测试侧**(`windows-git-path-powershell.test.ts`):脚本内探活 deadline 3s → 8s、exec 超时 10s → 15s、用例超时 20s → 30s,让各层预算彼此嵌套(脚本 deadline < exec 超时 < 用例超时),不再在忙碌 runner 上互相踩踏。

### 变更类型

- [ ] `feat` 新功能
- [x] `fix` 缺陷修复
- [ ] `refactor` / `perf` 重构或性能优化
- [ ] `docs` / `test` / `chore` 文档、测试或工程维护
- [ ] 其他:

### 范围

- 关联 Issue / 需求:#3574
- 本 PR 包含:清理超时常量放宽 + 该测试三层预算放宽
- 明确不包含:清理逻辑本身(Get-CimInstance 遍历/Stop-Process 语义)不动;探测成功路径不动
- 用户可见变化:无(仅影响 Windows 上探测失败后的收尾清理可靠性)
- 是否存在 breaking change:无

### UI 变化

无 UI 变化。

## 怎么验证的

### 自动验证

本机为 macOS,该文件的 win32 用例(`it.runIf(process.platform === 'win32')`)在本机跳过,Windows 行为以本 PR 的 CI(Windows job)为准——这点在认领 issue 时已说明。

```
pnpm exec vitest run --pool=forks src/agents/pi/windows-git-path-powershell.test.ts
```
结果:1 passed(8 passed | 2 skipped)——跳过的 2 例即 win32 用例。

```
pnpm --filter @cindy/maker-core run typecheck
```
结果:通过。

```
pnpm test:unit:related
```
结果:exit 1,失败两处均与本 diff 无关(逐一归因):apps/desktop 段被本机 vitest threads-pool SIGSEGV 杀掉(已知本机环境问题);packages/maker-core 段仅 `pi-agent.integration.test.ts` 3 例失败(真实 pi 二进制集成测试,与 diff 无关的既有环境性失败)。本 diff 的目标测试文件在同一门禁套件内通过(`✓ windows-git-path-powershell.test.ts (10 tests | 2 skipped)`)。

### 手工验证

无(纯超时预算调整,无可交互行为;Windows 端行为由 CI 验证)。

### 未执行的验证

- 本机无 Windows 环境,`kills probe descendants after the coordinator is terminated` 用例的实际执行依赖本 PR CI 的 Windows job。
- 未做忙碌 runner 的压力复现(该竞态本身依赖宿主负载,只能靠放宽预算消除)。

## 风险

### 风险分类

低风险。超时常量放宽只作用于「探测已失败」的错误收尾路径;最坏情形是该路径上清理进程多等最多 8 秒才被判超时,换来的是清理有机会真正执行完。

### 影响与回滚

影响面:Windows 平台 pi agent 的 Git PATH 探测失败收尾 + 对应测试。回滚:revert 单 commit 即可,无数据/schema 变更。

### 提交前检查

- [x] 已运行相关测试(macOS 可执行部分)与 typecheck
- [x] commit 带 DCO 签名(Signed-off-by: ficowang <fico@xd.com>)
- [x] diff 聚焦单一问题,无无关改动

