### PR TITLE
fix(dev): 修复 Windows 移动端一键调试与测试门禁

### DIFF
--- a/apps/desktop/src/main/__tests__/clientEndpointsService.test.ts
+++ b/apps/desktop/src/main/__tests__/clientEndpointsService.test.ts
@@ -19,6 +19,20 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 import { TEST_CLIENT_ENDPOINTS } from '../../test/vitest/clientEndpointsFixture';
 
+const canLinkFile = (() => {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), 'client-endpoints-file-link-probe-'));
+  try {
+    const target = path.join(root, 'target');
+    fs.writeFileSync(target, 'probe');
+    fs.symlinkSync(target, path.join(root, 'link'), 'file');
+    return true;
+  } catch {
+    return false;
+  } finally {
+    fs.rmSync(root, { recursive: true, force: true });
+  }
+})();
+
 const ipcOn = vi.hoisted(() => vi.fn());
 const netRequest = vi.hoisted(() => vi.fn());
 const showMessageBoxSync = vi.hoisted(() => vi.fn());
@@ -1387,12 +1401,15 @@ describe('netlog 产物事后核对(verifyEndpointNetLogCapture)', () => {
   it('目录项被换成 symlink → 不通过(产物丢弃)', () => {
     // 这是攻击的真实形状:把我们创建的目录项换成指向别处的 symlink,好让 Chromium
     // 写到别的地方去。lstat 不跟随 symlink,所以 isDirectory() 为 false。
-    if (process.platform === 'win32') return;
     const capture = prepareEndpointNetLogFile(logDir)!;
     const captureDir = path.dirname(capture.file);
     const elsewhere = fs.mkdtempSync(path.join(logDir, 'elsewhere-'));
     fs.rmSync(captureDir, { recursive: true, force: true });
-    fs.symlinkSync(elsewhere, captureDir);
+    fs.symlinkSync(
+      elsewhere,
+      captureDir,
+      process.platform === 'win32' ? 'junction' : 'dir',
+    );
     fs.writeFileSync(capture.file, '{}', 'utf8');
     expect(verifyEndpointNetLogCapture(capture)).toBe(false);
   });
@@ -1414,7 +1431,7 @@ describe('netlog 产物事后核对(verifyEndpointNetLogCapture)', () => {
   });
 
   it('目标被换成 symlink → 不通过', () => {
-    if (process.platform === 'win32') return;
+    if (!canLinkFile) return;
     const capture = prepareEndpointNetLogFile(logDir)!;
     const real = path.join(logDir, 'elsewhere.json');
     fs.writeFileSync(real, '{}', 'utf8');

--- a/apps/desktop/src/main/__tests__/codexAuthLink.test.ts
+++ b/apps/desktop/src/main/__tests__/codexAuthLink.test.ts
@@ -28,6 +28,23 @@ let myAuth: string;
 const SYSTEM_CONTENT = JSON.stringify({ tokens: { access_token: 'system-token' } });
 const MY_CONTENT = JSON.stringify({ tokens: { access_token: 'stale-local-token' } });
 
+/** 探测宿主真实能力，不假设每台 Windows 机器都能创建文件 symlink。 */
+function canCreateFileSymlink(): boolean {
+  const probeRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'cindy-codex-auth-link-probe-'));
+  try {
+    const target = path.join(probeRoot, 'target');
+    fs.writeFileSync(target, 'probe');
+    fs.symlinkSync(target, path.join(probeRoot, 'link'), 'file');
+    return true;
+  } catch {
+    return false;
+  } finally {
+    fs.rmSync(probeRoot, { recursive: true, force: true });
+  }
+}
+
+const canLinkFile = canCreateFileSymlink();
+
 beforeEach(() => {
   tmpRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'codex-auth-link-test-'));
   // 模拟 ~/.codex/auth.json 与 codex-home/auth.json 两个独立路径。
@@ -55,7 +72,7 @@ function leftoverSidecars(): string[] {
 }
 
 describe('relinkSharedCodexAuth', () => {
-  it('POSIX:myAuth 已存在→原子替换为 symlink', async () => {
+  it.skipIf(!canLinkFile)('POSIX:myAuth 已存在→原子替换为 symlink', async () => {
     fs.writeFileSync(systemAuth, SYSTEM_CONTENT);
     fs.writeFileSync(myAuth, MY_CONTENT);
 
@@ -70,7 +87,7 @@ describe('relinkSharedCodexAuth', () => {
     expect(leftoverSidecars()).toEqual([]);
   });
 
-  it('POSIX:myAuth 不存在 → linked,直接建出 symlink', async () => {
+  it.skipIf(!canLinkFile)('POSIX:myAuth 不存在 → linked,直接建出 symlink', async () => {
     fs.writeFileSync(systemAuth, SYSTEM_CONTENT);
 
     const out = await relinkSharedCodexAuth(systemAuth, myAuth, 'darwin');
@@ -82,7 +99,7 @@ describe('relinkSharedCodexAuth', () => {
     expect(leftoverSidecars()).toEqual([]);
   });
 
-  it('POSIX:系统 auth 原子替换后 symlink 自动跟随新 inode', async () => {
+  it.skipIf(!canLinkFile)('POSIX:系统 auth 原子替换后 symlink 自动跟随新 inode', async () => {
     fs.writeFileSync(systemAuth, SYSTEM_CONTENT);
     await relinkSharedCodexAuth(systemAuth, myAuth, 'darwin');
     const oldInode = fs.statSync(myAuth).ino;
@@ -120,7 +137,7 @@ describe('relinkSharedCodexAuth', () => {
     expect(leftoverSidecars()).toEqual([]);
   });
 
-  it('POSIX 会原子替换 dangling symlink', async () => {
+  it.skipIf(!canLinkFile)('POSIX 会原子替换 dangling symlink', async () => {
     fs.writeFileSync(systemAuth, SYSTEM_CONTENT);
     fs.symlinkSync(path.join(tmpRoot, 'missing-auth.json'), myAuth);
 
@@ -219,7 +236,7 @@ describe('inspectCodexAuthLink', () => {
     });
   });
 
-  it('返回 symlink 健康度与权威文件元数据', async () => {
+  it.skipIf(!canLinkFile)('返回 symlink 健康度与权威文件元数据', async () => {
     fs.writeFileSync(systemAuth, SYSTEM_CONTENT);
     await relinkSharedCodexAuth(systemAuth, myAuth, 'darwin');
 
@@ -230,7 +247,7 @@ describe('inspectCodexAuthLink', () => {
     expect(diagnostics.systemAuthLinkCount).toBe(1);
   });
 
-  it('识别 dangling symlink', async () => {
+  it.skipIf(!canLinkFile)('识别 dangling symlink', async () => {
     fs.symlinkSync(systemAuth, myAuth);
 
     await expect(inspectCodexAuthLink(systemAuth, myAuth)).resolves.toEqual({

--- a/apps/desktop/src/main/__tests__/codexFileRestoreExecutor.git-integration.test.ts
+++ b/apps/desktop/src/main/__tests__/codexFileRestoreExecutor.git-integration.test.ts
@@ -301,7 +301,6 @@ describe('executeCodexFileRestorePlan', () => {
   }, REAL_GIT_TEST_TIMEOUT_MS);
 
   it('never deletes through a symlinked parent that escapes the repository', async () => {
-    if (process.platform === 'win32') return; // 符号链接在 Windows CI 上需要特权
     await writeFile('a.txt', 'base\n');
     await commitAll('seed');
     const turnStart = await shadowSavepoint('turn-start');
@@ -313,7 +312,11 @@ describe('executeCodexFileRestorePlan', () => {
     try {
       await fs.writeFile(path.join(outside, 'target.txt'), 'precious external data\n', 'utf8');
       await fs.rm(path.join(repoPath, 'evil'), { recursive: true });
-      await fs.symlink(outside, path.join(repoPath, 'evil'));
+      await fs.symlink(
+        outside,
+        path.join(repoPath, 'evil'),
+        process.platform === 'win32' ? 'junction' : 'dir',
+      );
 
       const plan = buildPlan([{ commit: afterEdit, baselineCommit: turnStart }], await head());
       const result = await executeCodexFileRestorePlan(plan, {
@@ -335,7 +338,6 @@ describe('executeCodexFileRestorePlan', () => {
   }, REAL_GIT_TEST_TIMEOUT_MS);
 
   it('never restores through a symlinked parent that escapes the repository', async () => {
-    if (process.platform === 'win32') return; // 符号链接在 Windows CI 上需要特权
     await writeFile('evil/target.txt', 'baseline\n');
     await commitAll('seed evil');
     const turnStart = await shadowSavepoint('turn-start');
@@ -346,7 +348,11 @@ describe('executeCodexFileRestorePlan', () => {
     const outside = await fs.mkdtemp(path.join(path.dirname(repoPath), 'outside-'));
     try {
       await fs.writeFile(path.join(outside, 'target.txt'), 'external data\n', 'utf8');
-      await fs.symlink(outside, path.join(repoPath, 'evil'));
+      await fs.symlink(
+        outside,
+        path.join(repoPath, 'evil'),
+        process.platform === 'win32' ? 'junction' : 'dir',
+      );
 
       const plan = buildPlan([{ commit: afterEdit, baselineCommit: turnStart }], await head());
       // 恢复目标的最近存在祖先(evil)真实路径在仓库外 → 改动前中止:

--- a/apps/desktop/src/main/__tests__/codexGlobalPlugins.test.ts
+++ b/apps/desktop/src/main/__tests__/codexGlobalPlugins.test.ts
@@ -477,7 +477,7 @@ describe('prepareCodexGlobalPluginsBridge', () => {
     expect(isolatedMcp.mcpServers).not.toHaveProperty('feishu-delegate');
   });
 
-  it.skipIf(process.platform === 'win32')(
+  it(
     'fails closed instead of following symlinks out of a protected plugin',
     async () => {
       const { homeDir, codexHome, paths } = await setup();
@@ -498,7 +498,7 @@ describe('prepareCodexGlobalPluginsBridge', () => {
       await fs.symlink(
         outsideSkill,
         path.join(pluginDir, 'skills', 'message-feishu-coworkers'),
-        'dir',
+        process.platform === 'win32' ? 'junction' : 'dir',
       );
       await writePluginEnabledState(
         paths.sourceConfigFile,
@@ -521,7 +521,7 @@ describe('prepareCodexGlobalPluginsBridge', () => {
     },
   );
 
-  it.skipIf(process.platform === 'win32')(
+  it(
     'fails closed when the protected plugin root itself is a symlink',
     async () => {
       const { homeDir, codexHome, paths } = await setup();
@@ -543,7 +543,7 @@ describe('prepareCodexGlobalPluginsBridge', () => {
       await fs.symlink(
         realPluginDir,
         path.join(marketplaceDir, 'feishu-delegate'),
-        'dir',
+        process.platform === 'win32' ? 'junction' : 'dir',
       );
       await writePluginEnabledState(
         paths.sourceConfigFile,

--- a/apps/desktop/src/main/__tests__/gitSnapshotShadow.git-integration.test.ts
+++ b/apps/desktop/src/main/__tests__/gitSnapshotShadow.git-integration.test.ts
@@ -7,6 +7,8 @@
  */
 
 import { promises as fs } from 'node:fs';
+import fsSync from 'node:fs';
+import os from 'node:os';
 import path from 'node:path';
 
 import { afterAll, afterEach, beforeEach, describe, expect, it } from 'vitest';
@@ -32,6 +34,20 @@ import { gitExec } from '../worktree/gitExec';
 
 const REAL_GIT_TEST_TIMEOUT_MS = process.platform === 'win32' ? 60_000 : 20_000;
 const SESSION = 'shadow-sess-1';
+
+const canLinkFile = (() => {
+  const root = fsSync.mkdtempSync(path.join(os.tmpdir(), 'shadow-file-link-probe-'));
+  try {
+    const target = path.join(root, 'target');
+    fsSync.writeFileSync(target, 'probe');
+    fsSync.symlinkSync(target, path.join(root, 'link'), 'file');
+    return true;
+  } catch {
+    return false;
+  } finally {
+    fsSync.rmSync(root, { recursive: true, force: true });
+  }
+})();
 
 let repoPath: string;
 const originalGitLocaleEnv = {
@@ -226,8 +242,8 @@ describe('createShadowSavepoint', () => {
     expect(entries[0]?.baseHead).toBeUndefined();
   }, REAL_GIT_TEST_TIMEOUT_MS);
 
-  it('treats tracked files behind an out-of-repo symlinked parent as deleted', async () => {
-    if (process.platform === 'win32') return; // 符号链接在 Windows CI 上需要特权
+  it.skipIf(!canLinkFile)('treats tracked files behind an out-of-repo symlinked parent as deleted', async () => {
+    await gitExec(['config', 'core.symlinks', 'true'], repoPath);
     await commitSeed();
     await writeRepoFile('evil/target.txt', 'tracked base\n');
     await gitExec(['add', '-A'], repoPath);
@@ -238,7 +254,7 @@ describe('createShadowSavepoint', () => {
     try {
       await fs.writeFile(path.join(outside, 'target.txt'), 'external secret\n', 'utf8');
       await fs.rm(path.join(repoPath, 'evil'), { recursive: true });
-      await fs.symlink(outside, path.join(repoPath, 'evil'));
+      await fs.symlink(outside, path.join(repoPath, 'evil'), 'dir');
 
       const result = await createShadowSavepoint(repoPath, {
         sessionId: SESSION,

--- a/apps/desktop/src/main/cindy-brain/__tests__/GhostManager.test.ts
+++ b/apps/desktop/src/main/cindy-brain/__tests__/GhostManager.test.ts
@@ -23,6 +23,20 @@ import { GhostInstallReceiptStore, hashApprovedSkillContent } from '../ghostInst
 import { forgeInstallOriginForMembership } from '../forgeOidcInstallConfirmBridge';
 import { runGhostSnapshotWorkerRequest } from '../ghostSnapshotWorkerProcess';
 
+const canLinkFile = (() => {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), 'ghost-manager-file-link-probe-'));
+  try {
+    const target = path.join(root, 'target');
+    fs.writeFileSync(target, 'probe');
+    fs.symlinkSync(target, path.join(root, 'link'), 'file');
+    return true;
+  } catch {
+    return false;
+  } finally {
+    fs.rmSync(root, { recursive: true, force: true });
+  }
+})();
+
 /** 每个用例独立的临时仓库根 + 源文件目录(规则 23:测试路径一律 os.tmpdir)。 */
 let workDir: string;
 let rootDir: string;
@@ -857,7 +871,7 @@ describe('GhostManager · 迁移崩溃安全(in-progress 状态机)与隔离命�
     expect(await fs.promises.readFile(migrationLedgerPath(), 'utf8')).toBe('{ not valid json');
   });
 
-  it.skipIf(process.platform === 'win32')(
+  it.skipIf(!canLinkFile)(
     '台账是非普通文件(symlink)→ 门保守关死,不迁也不重写',
     async () => {
       await writeLegacyInstall('aaa', goodManifest('aaa'));

--- a/apps/desktop/src/main/cindy-brain/__tests__/ghostManual.test.ts
+++ b/apps/desktop/src/main/cindy-brain/__tests__/ghostManual.test.ts
@@ -8,6 +8,20 @@ import type { GhostManifest, InstalledGhost } from '../../../shared/ghost';
 import { readInstalledGhostManual } from '../ghostManual';
 
 let workDir: string;
+const directoryLinkType = process.platform === 'win32' ? 'junction' : 'dir';
+const canLinkFile = (() => {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), 'ghost-manual-file-link-probe-'));
+  try {
+    const target = path.join(root, 'target');
+    fs.writeFileSync(target, 'probe');
+    fs.symlinkSync(target, path.join(root, 'link'), 'file');
+    return true;
+  } catch {
+    return false;
+  } finally {
+    fs.rmSync(root, { recursive: true, force: true });
+  }
+})();
 
 beforeEach(async () => {
   workDir = await fs.promises.mkdtemp(path.join(os.tmpdir(), 'cindy-ghost-manual-test-'));
@@ -175,12 +189,15 @@ describe('readInstalledGhostManual', () => {
   });
 
   it('声明目录的中间层符号链接不能逃出插件安装根', async () => {
-    if (process.platform === 'win32') return;
     const outsideDir = await fs.promises.mkdtemp(path.join(os.tmpdir(), 'cindy-manual-outside-'));
     try {
       await fs.promises.mkdir(path.join(workDir, 'docs'), { recursive: true });
       await fs.promises.writeFile(path.join(outsideDir, 'MANUAL.md'), '# 根外私密正文');
-      await fs.promises.symlink(outsideDir, path.join(workDir, 'docs/physical-dir'));
+      await fs.promises.symlink(
+        outsideDir,
+        path.join(workDir, 'docs/physical-dir'),
+        directoryLinkType,
+      );
       const result = await readInstalledGhostManual(ghost(), 'logical-name');
       expect(result).toMatchObject({
         ok: false,
@@ -196,7 +213,6 @@ describe('readInstalledGhostManual', () => {
   });
 
   it('item.dir 任一中间组件是根内或根外 symlink 都不可用，普通中间目录可读', async () => {
-    if (process.platform === 'win32') return;
     await write('docs/plain/unit/MANUAL.md', '# 普通中间目录');
     expect(await readInstalledGhostManual(ghost('docs/plain/unit'), 'logical-name')).toMatchObject({
       ok: true,
@@ -215,7 +231,7 @@ describe('readInstalledGhostManual', () => {
       ] as const) {
         const linkPath = path.join(workDir, 'docs/link');
         await fs.promises.rm(linkPath, { force: true });
-        await fs.promises.symlink(target, linkPath);
+        await fs.promises.symlink(target, linkPath, directoryLinkType);
         const result = await readInstalledGhostManual(ghost('docs/link/unit'), 'logical-name');
         expect(result).toMatchObject({
           ok: false,
@@ -252,7 +268,7 @@ describe('readInstalledGhostManual', () => {
     await write('docs/physical-dir/MANUAL.md', Buffer.from([0xff, 0xfe, 0xfd]));
     await assertUnavailable();
 
-    if (process.platform !== 'win32') {
+    if (canLinkFile) {
       const target = path.join(workDir, 'outside.md');
       await fs.promises.writeFile(target, '# outside');
       await fs.promises.rm(path.join(workDir, 'docs/physical-dir/MANUAL.md'));
@@ -262,7 +278,6 @@ describe('readInstalledGhostManual', () => {
   });
 
   it('单元内的中间目录符号链接无论指向根内还是根外都不可读取', async () => {
-    if (process.platform === 'win32') return;
     await write('docs/physical-dir/MANUAL.md', '# 入口');
     await write('docs/physical-dir/real-inside/private.md', '# 根内私密正文');
     const outsideDir = await fs.promises.mkdtemp(path.join(os.tmpdir(), 'cindy-manual-child-'));
@@ -272,7 +287,11 @@ describe('readInstalledGhostManual', () => {
         ['inside-link', path.join(workDir, 'docs/physical-dir/real-inside'), '根内私密正文'],
         ['outside-link', outsideDir, '根外私密正文'],
       ] as const) {
-        await fs.promises.symlink(target, path.join(workDir, `docs/physical-dir/${linkName}`));
+        await fs.promises.symlink(
+          target,
+          path.join(workDir, `docs/physical-dir/${linkName}`),
+          directoryLinkType,
+        );
         const result = await readInstalledGhostManual(
           ghost(),
           `logical-name/${linkName}/private.md`,

--- a/apps/desktop/src/main/git-review/__tests__/stageOps.git-integration.test.ts
+++ b/apps/desktop/src/main/git-review/__tests__/stageOps.git-integration.test.ts
@@ -1,4 +1,5 @@
 import { promises as fs } from 'node:fs';
+import fsSync from 'node:fs';
 import os from 'node:os';
 import path from 'node:path';
 
@@ -14,6 +15,20 @@ import { readStatus } from '../statusReader';
 import type { DiffSelection, FileDiff, ReviewDiffReadOptions, ReviewFileTarget, ReviewScope } from '../types';
 
 let repoPath: string;
+
+const canLinkFile = (() => {
+  const root = fsSync.mkdtempSync(path.join(os.tmpdir(), 'git-review-file-link-probe-'));
+  try {
+    const target = path.join(root, 'target');
+    fsSync.writeFileSync(target, 'probe');
+    fsSync.symlinkSync(target, path.join(root, 'link'), 'file');
+    return true;
+  } catch {
+    return false;
+  } finally {
+    fsSync.rmSync(root, { recursive: true, force: true });
+  }
+})();
 
 const repoTemplate = new TestDirectoryTemplate('xdt-git-review-stage-', async (dir) => {
   await runGit(['init'], { cwd: dir });
@@ -395,7 +410,8 @@ describe('git-review stageOps', () => {
     await expect(applyHunkSelection(scope(), current, 'unstage', diff, selectLines(diff))).rejects.toThrow(GitReviewStageError);
   });
 
-  it.skipIf(process.platform === 'win32')('rejects partial typechange staging while whole-file staging remains valid', async () => {
+  it.skipIf(!canLinkFile)('rejects partial typechange staging while whole-file staging remains valid', async () => {
+    await runGit(['config', 'core.symlinks', 'true'], { cwd: repoPath });
     await fs.rm(path.join(repoPath, 'file.txt'));
     await fs.symlink('target.txt', path.join(repoPath, 'file.txt'));
 

--- a/apps/desktop/src/main/maker-host/__tests__/codexAuthInvalidation.test.ts
+++ b/apps/desktop/src/main/maker-host/__tests__/codexAuthInvalidation.test.ts
@@ -17,6 +17,23 @@ import {
 
 const dirs: string[] = [];
 const expectedSharedLinkType = process.platform === 'win32' ? 'hardlink' : 'symlink';
+
+/** 探测真实文件 symlink 能力；Windows 未启用 Developer Mode 时会返回 EPERM。 */
+function canCreateFileSymlink(): boolean {
+  const probeRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'cindy-codex-invalidation-link-probe-'));
+  try {
+    const target = path.join(probeRoot, 'target');
+    fs.writeFileSync(target, 'probe');
+    fs.symlinkSync(target, path.join(probeRoot, 'link'), 'file');
+    return true;
+  } catch {
+    return false;
+  } finally {
+    fs.rmSync(probeRoot, { recursive: true, force: true });
+  }
+}
+
+const canLinkFile = canCreateFileSymlink();
 const h = vi.hoisted(() => ({
   userDataDir: '',
   dataOwnerId: null as string | null,
@@ -1842,7 +1859,8 @@ describe('Codex system credential suppression marker', () => {
     }
   });
 
-  it('repairs a pre-upgrade POSIX hardlink rotated before provenance migration', async () => {
+  it('repairs a pre-upgrade POSIX hardlink rotated before provenance migration', async ({ skip }) => {
+    if (!canLinkFile) skip();
     const originalPlatform = process.platform;
     Object.defineProperty(process, 'platform', { value: 'darwin', configurable: true });
     try {
@@ -1984,10 +2002,7 @@ describe('Codex system credential suppression marker', () => {
     }
   });
 
-  it.each([
-    { platform: 'darwin', label: 'POSIX' },
-    { platform: 'win32', label: 'Windows' },
-  ])('attributes a detached shared F1 invalidation on $label', async ({ platform }) => {
+  async function assertDetachedSharedF1Invalidation(platform: 'darwin' | 'win32'): Promise<void> {
     const originalPlatform = process.platform;
     Object.defineProperty(process, 'platform', { value: platform, configurable: true });
     try {
@@ -2079,6 +2094,14 @@ describe('Codex system credential suppression marker', () => {
         configurable: true,
       });
     }
+  }
+
+  it.skipIf(!canLinkFile)('attributes a detached shared F1 invalidation on POSIX', async () => {
+    await assertDetachedSharedF1Invalidation('darwin');
+  });
+
+  it('attributes a detached shared F1 invalidation on Windows', async () => {
+    await assertDetachedSharedF1Invalidation('win32');
   });
 
   it('tracks a consumed symlink target generation until a later system replacement', async () => {

--- a/apps/desktop/src/main/maker-host/__tests__/grokOauthCallbackListener.test.ts
+++ b/apps/desktop/src/main/maker-host/__tests__/grokOauthCallbackListener.test.ts
@@ -31,6 +31,7 @@ import {
 
 const PORT = 56121;
 const XAI_ORIGIN = 'https://accounts.x.ai';
+let callbackPort = PORT;
 
 interface HttpResult {
   status: number;
@@ -48,7 +49,7 @@ function send(
     const req = httpRequest(
       // agent:false —— 每请求独立连接。全局 agent 的 keep-alive 会把上一个用例
       // 已关闭 server 的死 socket 复用给下一个用例,产生假 ECONNRESET。
-      { host: '127.0.0.1', port: PORT, method, path, headers, agent: false },
+      { host: '127.0.0.1', port: callbackPort, method, path, headers, agent: false },
       (res) => {
         let body = '';
         res.on('data', (chunk: Buffer) => (body += chunk.toString('utf-8')));
@@ -92,37 +93,15 @@ describe('xaiCallbackCorsHeaders', () => {
   });
 });
 
-/**
- * 绑 56121 时它可能短暂被别人占着,有两个来源:
- *   1. 文件内部:close() 同步返回但端口是异步释放的,上一个用例「调过 close」
- *      不等于端口已交还,下一个用例立刻重绑就撞上;
- *   2. 文件外部:56121 落在临时端口段内(macOS 49152–65535 / Linux 32768–60999),
- *      任何用 listen(0) 拿端口的并发用例都可能被内核分到它。desktop unit tier
- *      一轮 1330 个文件、threads 池下还共享同一个进程,这不是理论风险 —— CI 上
- *      两轮分别撞在不同用例的 beforeEach 上。而 xAI 只接受
- *      http://127.0.0.1:56121/callback,端口换不了。
- *
- * 两者是同一句话,所以只留一个判据:仅在引擎明确报出「端口被占用」时短暂重试,
- * 其它启动失败原样抛出,不掩盖真正的问题。每次重试用全新实例,免得复用一个
- * listen 失败过的 server。同族的客户端那一半由 send() 的 agent:false 处理。
- *
- * 判据必须与生产同源:start() 把底层错误包成新 Error、丢掉了 err.code,只剩文本可看,
- * 而按端口号做子串匹配会连 EACCES / EADDRNOTAVAIL 一起收进来(它们的原文里同样带端口
- * 号),把真正的启动故障当成「端口被占」白重试 100 次。所以整条比对生产导出的那句
- * EADDRINUSE 专属提示。
- */
+/** 默认单测用系统分配端口，避免与并行 worktree 或宿主端口保留范围互相干扰。 */
 async function startFreshListener(): Promise<CallbackListener> {
-  for (let attempt = 1; ; attempt += 1) {
-    const candidate = new CallbackListener();
-    try {
-      await candidate.start();
-      return candidate;
-    } catch (err) {
-      candidate.close();
-      const occupied = err instanceof Error && err.message === XAI_CALLBACK_PORT_OCCUPIED_MESSAGE;
-      if (!occupied || attempt >= 100) throw err;
-      await new Promise((resolve) => setTimeout(resolve, 20));
-    }
+  const candidate = new CallbackListener(0);
+  try {
+    callbackPort = await candidate.start();
+    return candidate;
+  } catch (err) {
+    candidate.close();
+    throw err;
   }
 }
 
@@ -134,7 +113,7 @@ describe('CallbackListener(xAI loopback 回调)', () => {
   });
 
   afterEach(() => {
-    listener.close();
+    listener?.close();
   });
 
   it('OPTIONS preflight 回 204 + CORS/PNA 头,且不终止登录流', async () => {
@@ -324,7 +303,7 @@ describe('CallbackListener(xAI loopback 回调)', () => {
       const req = httpRequest(
         {
           host: '127.0.0.1',
-          port: PORT,
+          port: callbackPort,
           method: 'GET',
           path: '/callback?code=abort-me&state=state-7',
           headers: { origin: XAI_ORIGIN },
@@ -359,9 +338,9 @@ describe('CallbackListener(xAI loopback 回调)', () => {
   });
 
   it('回调端口被占用时 start() 报可读错误', async () => {
-    const blocker = new CallbackListener();
-    // beforeEach 已占 56121,新实例 start 应失败。整条比对,不按端口号做子串匹配
-    // ——后者对任何带端口号的 listen 失败都成立(见 startFreshListener 说明)。
+    const blocker = new CallbackListener(callbackPort);
+    // 复用当前测试端口的新实例应失败。整条比对，不按端口号做子串匹配——后者
+    // 对任何带端口号的 listen 失败都成立，会误把 EACCES 等错误当成端口占用。
     await expect(blocker.start()).rejects.toThrow(XAI_CALLBACK_PORT_OCCUPIED_MESSAGE);
     blocker.close();
     // 上面那条是同源比对,改文案不会让它失败;这句守住「用户看得见端口号」这个可读性

--- a/apps/desktop/src/main/maker-host/grok-oauth-login.ts
+++ b/apps/desktop/src/main/maker-host/grok-oauth-login.ts
@@ -298,11 +298,12 @@ export class CallbackListener {
   private resolve: ((code: string) => void) | null = null;
   private reject: ((err: Error) => void) | null = null;
 
-  constructor() {
+  // 运行期始终使用默认固定端口；单测注入 0，让系统分配隔离的 loopback 端口。
+  constructor(private readonly listenPort = REDIRECT_PORT) {
     this.server = createServer();
   }
 
-  async start(): Promise<void> {
+  async start(): Promise<number> {
     return new Promise((resolve, reject) => {
       this.server.once('error', (err: NodeJS.ErrnoException) =>
         reject(
@@ -313,8 +314,11 @@ export class CallbackListener {
           ),
         ),
       );
-      // 必须监听固定端口 + 回环;xAI 只接受 http://127.0.0.1:56121/callback。
-      this.server.listen(REDIRECT_PORT, '127.0.0.1', () => resolve());
+      // 运行期必须监听固定端口 + 回环；xAI 只接受 http://127.0.0.1:56121/callback。
+      this.server.listen(this.listenPort, '127.0.0.1', () => {
+        const address = this.server.address();
+        resolve(typeof address === 'object' && address ? address.port : this.listenPort);
+      });
     });
   }
 

--- a/apps/desktop/src/main/reviewer/__tests__/reviewArtifactFingerprint.test.ts
+++ b/apps/desktop/src/main/reviewer/__tests__/reviewArtifactFingerprint.test.ts
@@ -1,4 +1,4 @@
-import { constants, promises as fs } from 'node:fs';
+import fsSync, { constants, promises as fs } from 'node:fs';
 import os from 'node:os';
 import path from 'node:path';
 
@@ -13,6 +13,20 @@ import {
 } from '../reviewArtifactFingerprint.js';
 
 const tempDirs: string[] = [];
+
+const canLinkFile = (() => {
+  const root = fsSync.mkdtempSync(path.join(os.tmpdir(), 'review-fingerprint-file-link-probe-'));
+  try {
+    const target = path.join(root, 'target');
+    fsSync.writeFileSync(target, 'probe');
+    fsSync.symlinkSync(target, path.join(root, 'link'), 'file');
+    return true;
+  } catch {
+    return false;
+  } finally {
+    fsSync.rmSync(root, { recursive: true, force: true });
+  }
+})();
 
 async function makeTempDir(): Promise<string> {
   const dir = await fs.mkdtemp(path.join(os.tmpdir(), 'cindy-review-fingerprint-'));
@@ -195,7 +209,7 @@ describe('review artifact fingerprint', () => {
   });
 
   it('does not follow a symlink that already replaced an artifact root', async () => {
-    if (process.platform === 'win32') return;
+    if (!canLinkFile) return;
     const dir = await makeTempDir();
     const link = path.join(dir, 'approved.txt');
     const sensitive = path.join(dir, 'private-key');
@@ -242,6 +256,7 @@ describe('review artifact fingerprint', () => {
     );
   });
 
+  // symlink-platform-skip: This case validates POSIX inode and hard-link confinement semantics.
   it('accepts a scoped pnpm mirror derived from confined package metadata', async () => {
     if (process.platform === 'win32') return;
     const root = await makeTempDir();

--- a/apps/desktop/src/main/reviewer/__tests__/reviewArtifactSnapshot.test.ts
+++ b/apps/desktop/src/main/reviewer/__tests__/reviewArtifactSnapshot.test.ts
@@ -1,4 +1,5 @@
 import { promises as fs } from 'node:fs';
+import fsSync from 'node:fs';
 import os from 'node:os';
 import path from 'node:path';
 
@@ -20,6 +21,19 @@ import {
 import { ReviewArtifactChangedDuringPreparationError } from '../reviewArtifactFingerprint.js';
 
 const tempDirs: string[] = [];
+const canLinkFile = (() => {
+  const root = fsSync.mkdtempSync(path.join(os.tmpdir(), 'review-snapshot-file-link-probe-'));
+  try {
+    const target = path.join(root, 'target');
+    fsSync.writeFileSync(target, 'probe');
+    fsSync.symlinkSync(target, path.join(root, 'link'), 'file');
+    return true;
+  } catch {
+    return false;
+  } finally {
+    fsSync.rmSync(root, { recursive: true, force: true });
+  }
+})();
 const TEST_OWNER: ReviewRunOwner = {
   instanceId: 'snapshot-test-owner',
   processId: process.pid,
@@ -212,7 +226,7 @@ describe('materializeReviewArtifactSnapshots', () => {
   });
 
   it('rejects a symlink substituted after the original path was authorized', async () => {
-    if (process.platform === 'win32') return;
+    if (!canLinkFile) return;
     const workingDir = await tempDir();
     const externalDir = await tempDir();
     const sourcePath = path.join(externalDir, 'poster.png');
@@ -373,13 +387,16 @@ describe('materializeReviewArtifactSnapshots', () => {
   });
 
   it('does not follow a snapshot-shaped symlink while reaping orphans', async () => {
-    if (process.platform === 'win32') return;
     const scanRoot = await tempDir();
     const targetRoot = await tempDir();
     const targetFile = path.join(targetRoot, 'keep.txt');
     const linkPath = path.join(scanRoot, 'cindy-review-artifacts-v1-424242-Ij56Kl');
     await fs.writeFile(targetFile, 'keep');
-    await fs.symlink(targetRoot, linkPath);
+    await fs.symlink(
+      targetRoot,
+      linkPath,
+      process.platform === 'win32' ? 'junction' : 'dir',
+    );
 
     await cleanupOrphanedReviewArtifactSnapshots({
       currentOwner: TEST_OWNER,

--- a/apps/desktop/src/main/reviewer/__tests__/reviewCappedWorkspaceFingerprint.test.ts
+++ b/apps/desktop/src/main/reviewer/__tests__/reviewCappedWorkspaceFingerprint.test.ts
@@ -1,4 +1,5 @@
 import { promises as fs } from 'node:fs';
+import fsSync from 'node:fs';
 import os from 'node:os';
 import path from 'node:path';
 
@@ -11,6 +12,20 @@ import {
 } from '../reviewCappedWorkspaceFingerprint.js';
 
 const tempDirs: string[] = [];
+
+const canLinkFile = (() => {
+  const root = fsSync.mkdtempSync(path.join(os.tmpdir(), 'review-capped-file-link-probe-'));
+  try {
+    const target = path.join(root, 'target');
+    fsSync.writeFileSync(target, 'probe');
+    fsSync.symlinkSync(target, path.join(root, 'link'), 'file');
+    return true;
+  } catch {
+    return false;
+  } finally {
+    fsSync.rmSync(root, { recursive: true, force: true });
+  }
+})();
 
 async function makeTempDir(): Promise<string> {
   const dir = await fs.mkdtemp(path.join(os.tmpdir(), 'cindy-review-capped-fingerprint-'));
@@ -65,7 +80,7 @@ describe('capped Review workspace fingerprint', () => {
       fingerprintReviewCappedWorkspaceFiles(repoRoot, ['../outside.ts']),
     ).rejects.toBeInstanceOf(ReviewCappedWorkspaceFingerprintError);
 
-    if (process.platform === 'win32') return;
+    if (!canLinkFile) return;
     const outside = await makeTempDir();
     await fs.writeFile(path.join(outside, 'outside.ts'), 'outside');
     await fs.symlink(path.join(outside, 'outside.ts'), path.join(repoRoot, 'linked.ts'));
@@ -80,7 +95,7 @@ describe('capped Review workspace fingerprint', () => {
     ).rejects.toBeInstanceOf(ReviewCappedWorkspaceFingerprintError);
   });
 
-  it.skipIf(process.platform === 'win32')(
+  it.skipIf(!canLinkFile)(
     'symlinkMode link-text binds the link text without resolving the target (#2463 review)',
     async () => {
       // 悬空 / 指向仓库外的 symlink 是合法 Git 改动(Git 记录的内容就是链接
@@ -101,6 +116,7 @@ describe('capped Review workspace fingerprint', () => {
     },
   );
 
+  // symlink-platform-skip: Windows cannot represent a symlink target containing arbitrary non-UTF-8 bytes.
   it.skipIf(process.platform === 'win32')(
     'symlinkMode link-text distinguishes non-UTF-8 target bytes (#2463 review)',
     async () => {
@@ -120,7 +136,7 @@ describe('capped Review workspace fingerprint', () => {
     },
   );
 
-  it.skipIf(process.platform === 'win32')(
+  it.skipIf(!canLinkFile)(
     'symlinkMode link-text never reads target bytes (#2463 review)',
     async () => {
       // 指向敏感文件的链接:只绑定文本,目标内容变化不得进入指纹 ——

--- a/apps/desktop/src/main/reviewer/__tests__/reviewSubmoduleIdentity.git-integration.test.ts
+++ b/apps/desktop/src/main/reviewer/__tests__/reviewSubmoduleIdentity.git-integration.test.ts
@@ -1,4 +1,6 @@
 import { promises as fs } from 'node:fs';
+import fsSync from 'node:fs';
+import os from 'node:os';
 import path from 'node:path';
 
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
@@ -16,6 +18,20 @@ import {
 
 let workRoot: string;
 let parentPath: string;
+
+const canLinkFile = (() => {
+  const root = fsSync.mkdtempSync(path.join(os.tmpdir(), 'review-submodule-file-link-probe-'));
+  try {
+    const target = path.join(root, 'target');
+    fsSync.writeFileSync(target, 'probe');
+    fsSync.symlinkSync(target, path.join(root, 'link'), 'file');
+    return true;
+  } catch {
+    return false;
+  } finally {
+    fsSync.rmSync(root, { recursive: true, force: true });
+  }
+})();
 
 // CI runner 没有全局 git 身份;每个会执行 commit 的仓库(含 submodule 克隆)都要配本地身份。
 async function configureRepo(dir: string): Promise<void> {
@@ -585,7 +601,7 @@ describe('readReviewSubmoduleIdentity intent-to-add 状态绑定 (#2463 review)'
 });
 
 describe('子仓 symlink 按链接文本绑定 (#2463 review)', () => {
-  it.skipIf(process.platform === 'win32')(
+  it.skipIf(!canLinkFile)(
     'binds a dirty submodule symlink pointing outside the sub without aborting',
     async () => {
       // 子仓里指向子仓外(../ 解析进父仓)或悬空的 symlink 是常见合法改动:
@@ -606,7 +622,7 @@ describe('子仓 symlink 按链接文本绑定 (#2463 review)', () => {
     },
   );
 
-  it.skipIf(process.platform === 'win32')(
+  it.skipIf(!canLinkFile)(
     'binds a gitlink replaced by an outside-pointing symlink (typechange) without aborting',
     async () => {
       // gitlink 整个被 symlink 替换(typechange):sub 字段仍标 S 路由到子仓
@@ -627,7 +643,7 @@ describe('子仓 symlink 按链接文本绑定 (#2463 review)', () => {
     },
   );
 
-  it.skipIf(process.platform === 'win32')(
+  it(
     'fails closed when a symlinked ancestor resolves the sub outside the parent repo',
     async () => {
       // 祖先目录 vendor 被换成指向父仓外的 symlink:lstat/realpath 跟随中间
@@ -643,7 +659,11 @@ describe('子仓 symlink 按链接文本绑定 (#2463 review)', () => {
       await runGit(['commit', '--no-gpg-sign', '-m', 'outside seed'], { cwd: escapeCheckout });
 
       await fs.rm(path.join(parent, 'vendor'), { recursive: true, force: true });
-      await fs.symlink(escapeRoot, path.join(parent, 'vendor'));
+      await fs.symlink(
+        escapeRoot,
+        path.join(parent, 'vendor'),
+        process.platform === 'win32' ? 'junction' : 'dir',
+      );
 
       await expect(
         readReviewSubmoduleIdentity(parentPath, ['vendor/lib']),

--- a/apps/desktop/src/main/skillhub/__tests__/scanner.test.ts
+++ b/apps/desktop/src/main/skillhub/__tests__/scanner.test.ts
@@ -25,6 +25,20 @@ import type { Maker } from '@cindy/maker-core';
 
 const tempRoots: string[] = [];
 
+const canLinkFile = (() => {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), 'skillhub-file-link-probe-'));
+  try {
+    const target = path.join(root, 'target');
+    fs.writeFileSync(target, 'probe');
+    fs.symlinkSync(target, path.join(root, 'link'), 'file');
+    return true;
+  } catch {
+    return false;
+  } finally {
+    fs.rmSync(root, { recursive: true, force: true });
+  }
+})();
+
 afterEach(() => {
   for (const root of tempRoots.splice(0)) {
     fs.rmSync(root, { recursive: true, force: true });
@@ -441,7 +455,7 @@ describe('scanAllSkills', () => {
 });
 
 describe('skill file access', () => {
-  it.skipIf(process.platform === 'win32')('rejects writing through a final file symlink', async () => {
+  it.skipIf(!canLinkFile)('rejects writing through a final file symlink', async () => {
     const root = fs.mkdtempSync(path.join(os.tmpdir(), 'skillhub-write-file-link-'));
     tempRoots.push(root);
     const skillDir = path.join(root, '.agents', 'skills', 'linked-file');
@@ -508,7 +522,7 @@ describe('skill file access', () => {
     );
   });
 
-  it.skipIf(process.platform === 'win32')('rejects renaming a skill whose SKILL.md is a symlink', async () => {
+  it.skipIf(!canLinkFile)('rejects renaming a skill whose SKILL.md is a symlink', async () => {
     const root = fs.mkdtempSync(path.join(os.tmpdir(), 'skillhub-pi-rename-md-link-'));
     tempRoots.push(root);
     const skillRoot = path.join(root, 'project', '.pi', 'skills');

--- a/apps/mobile/docs/simulator-debugging.md
+++ b/apps/mobile/docs/simulator-debugging.md
@@ -1,8 +1,24 @@
 # Mobile Simulator Debugging
 
-This guide is the fixed local loop for testing `apps/mobile` in an iOS
-Simulator. It exists because Expo Go, the iOS development client, and an installed
-distribution build look similar during manual testing but prove different things.
+This guide is the fixed local loop for testing `apps/mobile` in an iOS Simulator
+or Windows Android Emulator. It exists because Expo Go, a development client,
+and an installed distribution build look similar during manual testing but prove
+different things.
+
+On Windows, the explicit Mainland China one-command entry starts or reuses the
+`cindy-api36` AVD, waits for Android to finish booting, configures `adb reverse`,
+and then keeps the current worktree's Metro in the foreground:
+
+```bash
+pnpm mobile:sim:start:cn
+```
+
+`mobile:sim:start` keeps the repository-wide Global default. Use
+`-- --avd <name>` for another AVD or `-- --no-emulator` for Metro only. Android
+SDK tools are resolved from `ANDROID_SDK_ROOT`, `ANDROID_HOME`, or the standard
+Windows Android Studio SDK location; they do not need to be on `PATH`. The
+command does not rebuild the native app, so install the matching development
+package first when switching build identity.
 
 ## Current Source Verification Contract
 
@@ -33,6 +49,7 @@ apply". Treat the following as a contract, not optional steps:
 ```bash
 pnpm mobile:sim:start      # start THIS worktree's Global dev-client Metro; injects git
                            # branch/commit into the __DEV__ build label (EXPO_PUBLIC_*)
+pnpm mobile:sim:start:cn   # Mainland China; on Windows also starts cindy-api36
 pnpm mobile:sim:start -- --region=cn # 中国大陆版 JS region；先 rebuild 对应 native app
 pnpm mobile:sim:whoami     # doctor: booted install + which port = which worktree
 pnpm mobile:sim:whoami -- --region=cn # inspect the cn native app + Metro ownership

--- a/apps/mobile/scripts/lib/android-simulator.mjs
+++ b/apps/mobile/scripts/lib/android-simulator.mjs
@@ -1,6 +1,6 @@
 import { execFileSync, spawn } from 'node:child_process';
 import { existsSync } from 'node:fs';
-import { join } from 'node:path';
+import { win32 as win32Path } from 'node:path';
 
 export const DEFAULT_ANDROID_AVD = 'cindy-api36';
 const DEFAULT_BOOT_TIMEOUT_MS = 180_000;
@@ -54,12 +54,12 @@ export function resolveAndroidSdkTools({
   const candidates = [
     env.ANDROID_SDK_ROOT,
     env.ANDROID_HOME,
-    env.LOCALAPPDATA ? join(env.LOCALAPPDATA, 'Android', 'Sdk') : null,
+    env.LOCALAPPDATA ? win32Path.join(env.LOCALAPPDATA, 'Android', 'Sdk') : null,
   ].filter(Boolean);
 
   for (const sdkRoot of [...new Set(candidates)]) {
-    const adb = join(sdkRoot, 'platform-tools', 'adb.exe');
-    const emulator = join(sdkRoot, 'emulator', 'emulator.exe');
+    const adb = win32Path.join(sdkRoot, 'platform-tools', 'adb.exe');
+    const emulator = win32Path.join(sdkRoot, 'emulator', 'emulator.exe');
     if (exists(adb) && exists(emulator)) return { sdkRoot, adb, emulator };
   }
 

--- a/apps/mobile/scripts/lib/android-simulator.mjs
+++ b/apps/mobile/scripts/lib/android-simulator.mjs
@@ -1,0 +1,186 @@
+import { execFileSync, spawn } from 'node:child_process';
+import { existsSync } from 'node:fs';
+import { join } from 'node:path';
+
+export const DEFAULT_ANDROID_AVD = 'cindy-api36';
+const DEFAULT_BOOT_TIMEOUT_MS = 180_000;
+const DEFAULT_POLL_INTERVAL_MS = 1_000;
+
+/**
+ * 提取 Windows Android 模拟器参数，避免把本地工具参数透传给 Expo。
+ * Windows 默认启动模拟器；其它平台保持既有的 Metro-only 行为。
+ */
+export function extractAndroidSimulatorArgs(argv, platform = process.platform) {
+  let avd = DEFAULT_ANDROID_AVD;
+  let avdSpecified = false;
+  let startEmulator = platform === 'win32';
+  const passthrough = [];
+
+  for (let index = 0; index < argv.length; index += 1) {
+    const arg = argv[index];
+    if (arg === '--no-emulator') {
+      startEmulator = false;
+      continue;
+    }
+    if (arg === '--avd') {
+      if (avdSpecified) throw new Error('--avd 只能传一次');
+      avdSpecified = true;
+      avd = argv[index + 1];
+      index += 1;
+      continue;
+    }
+    if (arg.startsWith('--avd=')) {
+      if (avdSpecified) throw new Error('--avd 只能传一次');
+      avdSpecified = true;
+      avd = arg.slice('--avd='.length);
+      continue;
+    }
+    passthrough.push(arg);
+  }
+
+  avd = avd?.trim();
+  if (!avd) throw new Error('--avd 不能为空');
+  return { avd, startEmulator, passthrough };
+}
+
+/** 从 Android SDK 环境变量或 Windows 标准安装目录解析 adb / emulator。 */
+export function resolveAndroidSdkTools({
+  env = process.env,
+  platform = process.platform,
+  exists = existsSync,
+} = {}) {
+  if (platform !== 'win32') return null;
+
+  const candidates = [
+    env.ANDROID_SDK_ROOT,
+    env.ANDROID_HOME,
+    env.LOCALAPPDATA ? join(env.LOCALAPPDATA, 'Android', 'Sdk') : null,
+  ].filter(Boolean);
+
+  for (const sdkRoot of [...new Set(candidates)]) {
+    const adb = join(sdkRoot, 'platform-tools', 'adb.exe');
+    const emulator = join(sdkRoot, 'emulator', 'emulator.exe');
+    if (exists(adb) && exists(emulator)) return { sdkRoot, adb, emulator };
+  }
+
+  throw new Error(
+    '未找到完整 Android SDK。请设置 ANDROID_SDK_ROOT / ANDROID_HOME，或通过 Android Studio 安装 Platform Tools 与 Emulator。',
+  );
+}
+
+export function parseAdbEmulatorSerials(output) {
+  return String(output)
+    .split(/\r?\n/)
+    .map((line) => line.trim().match(/^(emulator-\d+)\s+device(?:\s|$)/)?.[1])
+    .filter(Boolean);
+}
+
+export function parseEmulatorAvdName(output) {
+  return String(output)
+    .split(/\r?\n/)
+    .map((line) => line.trim())
+    .find((line) => line && line !== 'OK') ?? null;
+}
+
+function runText(execFile, command, args) {
+  try {
+    return execFile(command, args, {
+      encoding: 'utf8',
+      stdio: ['ignore', 'pipe', 'ignore'],
+      windowsHide: true,
+    });
+  } catch {
+    return '';
+  }
+}
+
+function findRunningAvd(adb, avd, execFile) {
+  const devices = parseAdbEmulatorSerials(runText(execFile, adb, ['devices']));
+  for (const serial of devices) {
+    const runningAvd = parseEmulatorAvdName(
+      runText(execFile, adb, ['-s', serial, 'emu', 'avd', 'name']),
+    );
+    if (runningAvd === avd) return serial;
+  }
+  return null;
+}
+
+function availableAvds(emulator, execFile) {
+  return runText(execFile, emulator, ['-list-avds'])
+    .split(/\r?\n/)
+    .map((line) => line.trim())
+    .filter(Boolean);
+}
+
+function delay(ms) {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+/**
+ * 确保目标 AVD 已完成启动，并为当前 Metro 端口建立 adb reverse。
+ * 模拟器进程与 Metro 解耦，关闭 Metro 不会连带关闭开发者正在使用的 AVD。
+ */
+export async function ensureWindowsAndroidEmulator({
+  avd = DEFAULT_ANDROID_AVD,
+  port,
+  env = process.env,
+  platform = process.platform,
+  exists = existsSync,
+  execFile = execFileSync,
+  spawnProcess = spawn,
+  wait = delay,
+  now = Date.now,
+  timeoutMs = DEFAULT_BOOT_TIMEOUT_MS,
+  pollIntervalMs = DEFAULT_POLL_INTERVAL_MS,
+  log = console.log,
+} = {}) {
+  if (platform !== 'win32') return { action: 'skipped', serial: null };
+  if (!Number.isInteger(port) || port <= 0) throw new Error(`无效 Metro 端口: ${port}`);
+
+  const tools = resolveAndroidSdkTools({ env, platform, exists });
+  let serial = findRunningAvd(tools.adb, avd, execFile);
+  let action = 'reused';
+  let launchError = null;
+
+  if (!serial) {
+    if (!availableAvds(tools.emulator, execFile).includes(avd)) {
+      throw new Error(`未找到 Android AVD: ${avd}。请先在 Android Studio Device Manager 中创建它。`);
+    }
+    log(`› 正在启动 Android 模拟器 ${avd}…`);
+    const emulatorChild = spawnProcess(tools.emulator, ['-avd', avd], {
+      detached: true,
+      stdio: 'ignore',
+      windowsHide: false,
+    });
+    emulatorChild.once('error', (error) => { launchError = error; });
+    emulatorChild.unref();
+    action = 'started';
+  } else {
+    log(`✓ 复用 Android 模拟器 ${avd} (${serial})`);
+  }
+
+  const deadline = now() + timeoutMs;
+  while (now() < deadline) {
+    if (launchError) throw new Error(`无法启动 Android 模拟器 ${avd}: ${launchError.message}`);
+    serial ??= findRunningAvd(tools.adb, avd, execFile);
+    if (serial) {
+      const bootCompleted = runText(
+        execFile,
+        tools.adb,
+        ['-s', serial, 'shell', 'getprop', 'sys.boot_completed'],
+      ).trim();
+      if (bootCompleted === '1') {
+        execFile(
+          tools.adb,
+          ['-s', serial, 'reverse', `tcp:${port}`, `tcp:${port}`],
+          { stdio: 'ignore', windowsHide: true },
+        );
+        log(`✓ Android 模拟器已就绪 (${serial})，Metro 端口 ${port} 已反向代理`);
+        return { action, serial, avd, ...tools };
+      }
+    }
+    await wait(pollIntervalMs);
+  }
+
+  throw new Error(`等待 Android 模拟器 ${avd} 启动超时 (${Math.round(timeoutMs / 1000)}s)`);
+}

--- a/apps/mobile/scripts/sim-start.mjs
+++ b/apps/mobile/scripts/sim-start.mjs
@@ -19,16 +19,26 @@
 //
 // 用法(仓库根):
 //   pnpm mobile:sim:start                 # Global，起在 8081(app 默认连这个)
+//   pnpm mobile:sim:start:cn              # 中国大陆版；Windows 同时启动 cindy-api36
 //   pnpm mobile:sim:start -- --region=cn  # 中国大陆版
 //   pnpm mobile:sim:start -- --region=cn --takeover # 显式接管另一个 Metro
 //   pnpm mobile:sim:start -- --port 8082   # 显式换端口(透传给 expo;需自行把 app 指过去)
+//   pnpm mobile:sim:start -- --no-emulator # Windows 只启动 Metro
 
 import { execFileSync, spawn } from 'node:child_process';
 import { existsSync } from 'node:fs';
 import { dirname, resolve } from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { mobileClientBundleEnv } from '../../../scripts/shared/client-endpoint-build-env.mjs';
+import {
+  resolvePnpmInvocation,
+  usablePnpmExecPath,
+} from '../../../scripts/shared/pnpm-invocation.mjs';
 import { ensureMobileEnv, formatMobileEnvStatus } from './ensure-mobile-env.mjs';
+import {
+  ensureWindowsAndroidEmulator,
+  extractAndroidSimulatorArgs,
+} from './lib/android-simulator.mjs';
 import {
   extractMobileDevRegionArgs,
   withLocalMobileRegionConfig,
@@ -58,7 +68,8 @@ const worktreeRoot = resolve(mobileDir, '../..');
 const DEFAULT_PORT = 8081;
 const { region, passthrough: regionPassthrough } = extractMobileDevRegionArgs(process.argv.slice(2));
 const { takeover, passthrough: takeoverPassthrough } = extractSimTakeoverArgs(regionPassthrough);
-const portArgs = extractSimMetroPortArgs(takeoverPassthrough, DEFAULT_PORT);
+const androidArgs = extractAndroidSimulatorArgs(takeoverPassthrough);
+const portArgs = extractSimMetroPortArgs(androidArgs.passthrough, DEFAULT_PORT);
 if (takeover && portArgs.explicit) {
   console.error(`✗ --takeover 只用于隐式默认端口 ${DEFAULT_PORT},不能和显式 --port 混用。`);
   process.exit(1);
@@ -86,6 +97,11 @@ const branch = git(['branch', '--show-current']) || git(['rev-parse', '--short',
 const commit = git(['rev-parse', '--short', 'HEAD']);
 const sourceIdentity = gitSourceIdentity(worktreeRoot);
 
+async function ensureAndroidTarget() {
+  if (!androidArgs.startEmulator) return;
+  await ensureWindowsAndroidEmulator({ avd: androidArgs.avd, port: portArgs.port });
+}
+
 // 默认端口始终执行身份闸门;显式其它端口由开发者自行把 App 指过去。
 const args = ['exec', 'expo', 'start', '--dev-client', ...portArgs.passthrough];
 if (portArgs.port === DEFAULT_PORT) {
@@ -111,6 +127,7 @@ if (portArgs.port === DEFAULT_PORT) {
     });
     if (decision.action === 'reuse') {
       for (const line of decision.lines) console.log(line);
+      await ensureAndroidTarget();
       process.exit(0);
     }
     if (decision.action === 'refuse') {
@@ -136,6 +153,7 @@ if (portArgs.port === DEFAULT_PORT) {
     }
   }
 }
+await ensureAndroidTarget();
 // 统一规范化成 Expo 明确支持的 `--port <n>`，避免 `--port=<n>` 被本工具识别、
 // 却在端口归属检查和启动参数之间产生分歧。
 args.push('--port', String(portArgs.port));
@@ -147,16 +165,26 @@ console.log('  注入 EXPO_PUBLIC_XDT_GIT_SOURCE / EXPO_PUBLIC_XDT_GIT_BRANCH / 
 
 // 用 `pnpm exec expo`:pnpm 不在 apps/mobile/node_modules/.bin 放 expo bin,但 pnpm exec
 // 能按包依赖解析到 expo CLI(直接 node node_modules/.bin/expo 会 MODULE_NOT_FOUND)。
-const child = spawn('pnpm', args, {
+const invocation = resolvePnpmInvocation(args, {
+  npmExecPath: usablePnpmExecPath(process.env.npm_execpath, existsSync),
+});
+const child = spawn(invocation.command, invocation.args, {
   cwd: mobileDir,
   stdio: 'inherit',
   env: {
     ...process.env,
     ...buildEnv,
+    ...(invocation.env ?? {}),
     EXPO_PUBLIC_XDT_GIT_BRANCH: branch,
     EXPO_PUBLIC_XDT_GIT_COMMIT: commit,
     EXPO_PUBLIC_XDT_GIT_SOURCE: sourceIdentity,
   },
+  shell: invocation.shell,
+  windowsVerbatimArguments: invocation.windowsVerbatimArguments,
 });
 
+child.once('error', (error) => {
+  console.error(`✗ 无法启动 Metro: ${error.message}`);
+  process.exit(1);
+});
 child.on('exit', (code) => process.exit(code ?? 0));

--- a/apps/mobile/src/__tests__/mobileAndroidSimulator.test.ts
+++ b/apps/mobile/src/__tests__/mobileAndroidSimulator.test.ts
@@ -1,0 +1,198 @@
+// @ts-nocheck —— 被测对象是 .mjs 开发工具模块，vitest 跑其纯函数与注入式流程。
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+import { describe, expect, it, vi } from 'vitest';
+import {
+  DEFAULT_ANDROID_AVD,
+  ensureWindowsAndroidEmulator,
+  extractAndroidSimulatorArgs,
+  parseAdbEmulatorSerials,
+  parseEmulatorAvdName,
+  resolveAndroidSdkTools,
+} from '../../scripts/lib/android-simulator.mjs';
+
+describe('Windows Android 模拟器参数', () => {
+  it('sim:start 使用跨平台 pnpm 调用器，不再直接 spawn pnpm', () => {
+    const source = readFileSync(resolve(process.cwd(), 'scripts/sim-start.mjs'), 'utf8');
+    expect(source).toContain('resolvePnpmInvocation(args');
+    expect(source).toContain('usablePnpmExecPath(process.env.npm_execpath, existsSync)');
+    expect(source).not.toContain("spawn('pnpm'");
+  });
+
+  it('Windows 默认启动 cindy-api36，且不把本地参数透传给 Expo', () => {
+    expect(extractAndroidSimulatorArgs(['--avd', 'Pixel_API_36', '--port', '8082'], 'win32'))
+      .toEqual({
+        avd: 'Pixel_API_36',
+        startEmulator: true,
+        passthrough: ['--port', '8082'],
+      });
+    expect(extractAndroidSimulatorArgs(['--no-emulator', '--clear'], 'win32')).toEqual({
+      avd: DEFAULT_ANDROID_AVD,
+      startEmulator: false,
+      passthrough: ['--clear'],
+    });
+  });
+
+  it('非 Windows 平台保持 Metro-only 行为', () => {
+    expect(extractAndroidSimulatorArgs([], 'darwin')).toEqual({
+      avd: DEFAULT_ANDROID_AVD,
+      startEmulator: false,
+      passthrough: [],
+    });
+  });
+
+  it('拒绝空 AVD 与重复参数', () => {
+    expect(() => extractAndroidSimulatorArgs(['--avd='], 'win32')).toThrow(/不能为空/);
+    expect(() => extractAndroidSimulatorArgs(['--avd=a', '--avd=b'], 'win32')).toThrow(/只能传一次/);
+  });
+});
+
+describe('Android SDK 与 adb 输出解析', () => {
+  it('依次尝试显式 SDK 与 Windows 标准目录', () => {
+    const existing = new Set([
+      'C:\\Users\\dev\\AppData\\Local\\Android\\Sdk\\platform-tools\\adb.exe',
+      'C:\\Users\\dev\\AppData\\Local\\Android\\Sdk\\emulator\\emulator.exe',
+    ]);
+    expect(resolveAndroidSdkTools({
+      platform: 'win32',
+      env: {
+        ANDROID_SDK_ROOT: 'D:\\missing',
+        LOCALAPPDATA: 'C:\\Users\\dev\\AppData\\Local',
+      },
+      exists: (target) => existing.has(target),
+    })).toEqual({
+      sdkRoot: 'C:\\Users\\dev\\AppData\\Local\\Android\\Sdk',
+      adb: 'C:\\Users\\dev\\AppData\\Local\\Android\\Sdk\\platform-tools\\adb.exe',
+      emulator: 'C:\\Users\\dev\\AppData\\Local\\Android\\Sdk\\emulator\\emulator.exe',
+    });
+  });
+
+  it('只接受在线 emulator，并去掉 avd name 的 OK 尾行', () => {
+    expect(parseAdbEmulatorSerials([
+      'List of devices attached',
+      'emulator-5554 device product:sdk',
+      'emulator-5556 offline',
+      'R5CT device product:phone',
+      '',
+    ].join('\r\n'))).toEqual(['emulator-5554']);
+    expect(parseEmulatorAvdName('cindy-api36\r\nOK\r\n')).toBe('cindy-api36');
+  });
+});
+
+describe('Windows Android 模拟器启动流程', () => {
+  const env = { ANDROID_SDK_ROOT: 'C:\\Android\\Sdk' };
+  const adb = 'C:\\Android\\Sdk\\platform-tools\\adb.exe';
+  const emulator = 'C:\\Android\\Sdk\\emulator\\emulator.exe';
+  const exists = () => true;
+
+  it('复用已启动 AVD，等待 boot_completed 后设置 adb reverse', async () => {
+    const execFile = vi.fn((command, args) => {
+      if (command === adb && args.join(' ') === 'devices') {
+        return 'List of devices attached\nemulator-5554 device\n';
+      }
+      if (command === adb && args.includes('name')) return 'cindy-api36\nOK\n';
+      if (command === adb && args.includes('sys.boot_completed')) return '1\n';
+      return '';
+    });
+
+    await expect(ensureWindowsAndroidEmulator({
+      avd: 'cindy-api36',
+      port: 8081,
+      platform: 'win32',
+      env,
+      exists,
+      execFile,
+      log: vi.fn(),
+    })).resolves.toMatchObject({ action: 'reused', serial: 'emulator-5554' });
+    expect(execFile).toHaveBeenCalledWith(
+      adb,
+      ['-s', 'emulator-5554', 'reverse', 'tcp:8081', 'tcp:8081'],
+      { stdio: 'ignore', windowsHide: true },
+    );
+  });
+
+  it('没有在线 AVD 时启动目标模拟器，再等待并设置端口', async () => {
+    let devicesChecks = 0;
+    let clock = 0;
+    const execFile = vi.fn((command, args) => {
+      if (command === emulator && args[0] === '-list-avds') return 'cindy-api36\n';
+      if (command === adb && args.join(' ') === 'devices') {
+        devicesChecks += 1;
+        return devicesChecks >= 2
+          ? 'List of devices attached\nemulator-5554 device\n'
+          : 'List of devices attached\n';
+      }
+      if (command === adb && args.includes('name')) return 'cindy-api36\nOK\n';
+      if (command === adb && args.includes('sys.boot_completed')) return '1\n';
+      return '';
+    });
+    const child = { once: vi.fn(), unref: vi.fn() };
+    const spawnProcess = vi.fn(() => child);
+
+    await expect(ensureWindowsAndroidEmulator({
+      avd: 'cindy-api36',
+      port: 8081,
+      platform: 'win32',
+      env,
+      exists,
+      execFile,
+      spawnProcess,
+      wait: async (ms) => { clock += ms; },
+      now: () => clock,
+      log: vi.fn(),
+    })).resolves.toMatchObject({ action: 'started', serial: 'emulator-5554' });
+    expect(spawnProcess).toHaveBeenCalledWith(emulator, ['-avd', 'cindy-api36'], {
+      detached: true,
+      stdio: 'ignore',
+      windowsHide: false,
+    });
+    expect(child.unref).toHaveBeenCalledOnce();
+  });
+
+  it('目标 AVD 不存在时明确失败，不启动其它模拟器', async () => {
+    const execFile = vi.fn((command, args) => {
+      if (command === emulator && args[0] === '-list-avds') return 'other-avd\n';
+      if (command === adb && args.join(' ') === 'devices') return 'List of devices attached\n';
+      return '';
+    });
+    const spawnProcess = vi.fn();
+
+    await expect(ensureWindowsAndroidEmulator({
+      avd: 'cindy-api36',
+      port: 8081,
+      platform: 'win32',
+      env,
+      exists,
+      execFile,
+      spawnProcess,
+      log: vi.fn(),
+    })).rejects.toThrow(/未找到 Android AVD: cindy-api36/);
+    expect(spawnProcess).not.toHaveBeenCalled();
+  });
+
+  it('目标 AVD 一直未完成启动时超时失败', async () => {
+    let clock = 0;
+    const execFile = vi.fn((command, args) => {
+      if (command === adb && args.join(' ') === 'devices') {
+        return 'List of devices attached\nemulator-5554 device\n';
+      }
+      if (command === adb && args.includes('name')) return 'cindy-api36\nOK\n';
+      if (command === adb && args.includes('sys.boot_completed')) return '0\n';
+      return '';
+    });
+
+    await expect(ensureWindowsAndroidEmulator({
+      avd: 'cindy-api36',
+      port: 8081,
+      platform: 'win32',
+      env,
+      exists,
+      execFile,
+      wait: async (ms) => { clock += ms; },
+      now: () => clock,
+      timeoutMs: 2_000,
+      pollIntervalMs: 1_000,
+      log: vi.fn(),
+    })).rejects.toThrow(/启动超时 \(2s\)/);
+  });
+});

--- a/docs/dev-rules/mobile-development.md
+++ b/docs/dev-rules/mobile-development.md
@@ -14,6 +14,17 @@ pnpm mobile:sim:start
 pnpm mobile:sim:whoami
 ```
 
+Windows 下 `mobile:sim:start` 还会复用或启动 `cindy-api36` Android AVD，等待系统启动完成，
+并为 Metro 端口建立 `adb reverse`。中国大陆版的一键入口名称带有明确区域限定：
+
+```bash
+pnpm mobile:sim:start:cn
+```
+
+可用 `-- --avd <name>` 选择其它 AVD；只需 Metro 时传 `-- --no-emulator`。脚本从
+`ANDROID_SDK_ROOT`、`ANDROID_HOME` 或 Windows 标准 Android Studio SDK 目录解析工具，
+不要求把 `adb`、`emulator` 加进 `PATH`。
+
 修改原生依赖、Expo 原生配置，或切换到尚未安装对应开发包的区域时，重新构建：
 
 ```bash
@@ -23,7 +34,8 @@ pnpm mobile:sim:start -- --region=cn
 ```
 
 不传 `--region` 的日常入口默认运行 Cindy（Global）；中国大陆版必须显式传
-`--region=cn`。发布构建继续要求显式指定 region。
+`--region=cn`，或使用名称已明确限定区域的 `mobile:sim:start:cn`。发布构建继续要求显式
+指定 region。
 
 不要用临时 Metro、端口探测或手工修改 `.env` 代替这些脚本。多 worktree、原生构建、
 登录态和日志排查见 `apps/mobile/docs/simulator-debugging.md`。

--- a/package.json
+++ b/package.json
@@ -72,6 +72,7 @@
     "mobile:xcode": "node apps/mobile/scripts/open-ios-xcode.mjs",
     "mobile:sim:rebuild": "node scripts/ensure-deps.mjs --workspace-only && node apps/mobile/scripts/sim-rebuild.mjs",
     "mobile:sim:start": "node scripts/ensure-deps.mjs --workspace-only && node apps/mobile/scripts/sim-start.mjs",
+    "mobile:sim:start:cn": "node scripts/ensure-deps.mjs --workspace-only && node apps/mobile/scripts/sim-start.mjs --region=cn",
     "mobile:sim:whoami": "node scripts/ensure-deps.mjs --workspace-only && node apps/mobile/scripts/sim-whoami.mjs",
     "sync:mobile-rich-content-assets": "node apps/mobile/scripts/sync-rich-content-assets.mjs",
     "mobile:release:check": "node apps/mobile/scripts/release-with-env.mjs check",

--- a/packages/lizi-mcps/src/computer/computerMcpServer.test.ts
+++ b/packages/lizi-mcps/src/computer/computerMcpServer.test.ts
@@ -1,4 +1,5 @@
 import { promises as fs } from 'node:fs';
+import fsSync from 'node:fs';
 import os from 'node:os';
 import path from 'node:path';
 
@@ -7,6 +8,20 @@ import { Client } from '@modelcontextprotocol/sdk/client/index.js';
 import { InMemoryTransport } from '@modelcontextprotocol/sdk/inMemory.js';
 import { createComputerMcpServer } from './server.js';
 import type { ComputerMcpDeps } from '../types.js';
+
+const canLinkFile = (() => {
+  const root = fsSync.mkdtempSync(path.join(os.tmpdir(), 'computer-file-link-probe-'));
+  try {
+    const target = path.join(root, 'target');
+    fsSync.writeFileSync(target, 'probe');
+    fsSync.symlinkSync(target, path.join(root, 'link'), 'file');
+    return true;
+  } catch {
+    return false;
+  } finally {
+    fsSync.rmSync(root, { recursive: true, force: true });
+  }
+})();
 
 /** Temp session workingDir for path-boundary-constrained tools (recording/replay). */
 async function makeWorkingDir(): Promise<string> {
@@ -988,7 +1003,7 @@ describe('createComputerMcpServer', () => {
     await fs.rm(root, { recursive: true, force: true });
   });
 
-  it.skipIf(process.platform === 'win32')(
+  it(
     'replays inside a workingDir reached through a symbolic link',
     async () => {
       const deps: ComputerMcpDeps = {
@@ -999,7 +1014,11 @@ describe('createComputerMcpServer', () => {
       const realWorkingDir = path.join(container, 'real-workspace');
       const linkedWorkingDir = path.join(container, 'linked-workspace');
       await fs.mkdir(realWorkingDir);
-      await fs.symlink(realWorkingDir, linkedWorkingDir, 'dir');
+      await fs.symlink(
+        realWorkingDir,
+        linkedWorkingDir,
+        process.platform === 'win32' ? 'junction' : 'dir',
+      );
       await writeTrajectory(realWorkingDir, [
         {
           tool: 'get_window_state',
@@ -1123,7 +1142,7 @@ describe('createComputerMcpServer', () => {
     await fs.rm(root, { recursive: true, force: true });
   });
 
-  it.skipIf(process.platform === 'win32')(
+  it(
     'rejects a recorded turn that escapes through a symlink',
     async () => {
       const deps: ComputerMcpDeps = {
@@ -1138,7 +1157,11 @@ describe('createComputerMcpServer', () => {
         JSON.stringify({ tool: 'get_screen_size', arguments: {} }),
         'utf8',
       );
-      await fs.symlink(outside, path.join(root, 'rec', 'turn-00001'), 'dir');
+      await fs.symlink(
+        outside,
+        path.join(root, 'rec', 'turn-00001'),
+        process.platform === 'win32' ? 'junction' : 'dir',
+      );
       const h = await makeHarness(deps, {
         getSessionContext: () => ({
           agentKind: 'claude-code',
@@ -1166,7 +1189,7 @@ describe('createComputerMcpServer', () => {
     },
   );
 
-  it.skipIf(process.platform === 'win32')(
+  it.skipIf(!canLinkFile)(
     'rejects a symbolic-link action file even when its target stays in the task',
     async () => {
       const deps: ComputerMcpDeps = {

--- a/packages/maker-core/src/agents/claude-code/__tests__/auto-review-wiring.test.ts
+++ b/packages/maker-core/src/agents/claude-code/__tests__/auto-review-wiring.test.ts
@@ -671,12 +671,16 @@ describe('Auto-review wiring: safe builtin tools auto-approve silently', () => {
     await handle.close();
   });
 
-  it.skipIf(process.platform === 'win32')(
+  it(
     'prompts when a dangling link prevents proving the write target',
     async () => {
       const writableDir = await makeTempDir();
       const linkedDir = path.join(writableDir, 'dangling-output');
-      await fs.symlink(path.join(writableDir, 'missing-target'), linkedDir, 'dir');
+      await fs.symlink(
+        path.join(writableDir, 'missing-target'),
+        linkedDir,
+        process.platform === 'win32' ? 'junction' : 'dir',
+      );
       const { handle, canUseTool, reviewAutoPermissionAction, seen } = await startSession('auto', {
         writableDirs: [writableDir],
       });

--- a/packages/maker-core/src/agents/pi/__tests__/cindyBridgeSource.test.ts
+++ b/packages/maker-core/src/agents/pi/__tests__/cindyBridgeSource.test.ts
@@ -28,6 +28,20 @@ import {
   CINDY_PI_BASH_MAX_TIMEOUT_SECONDS,
 } from '../cindy-bridge-source.js';
 
+const canLinkFile = (() => {
+  const root = mkdtempSync(path.join(tmpdir(), 'cindy-bridge-file-link-probe-'));
+  try {
+    const target = path.join(root, 'target');
+    writeFileSync(target, 'probe');
+    symlinkSync(target, path.join(root, 'link'), 'file');
+    return true;
+  } catch {
+    return false;
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+})();
+
 type ReviewSearchHelpers = {
   collectReadonlyCredentialEvidence: (
     toolName: string,
@@ -527,6 +541,7 @@ describe('cindy-bridge extension source', () => {
     }
   });
 
+  // symlink-platform-skip: This case validates POSIX shell and filename semantics that Windows cannot represent.
   it.skipIf(process.platform === 'win32')(
     'collects canonical credential targets without flagging ordinary symlinks',
     () => {
@@ -1625,7 +1640,7 @@ describe('cindy-bridge extension source', () => {
     expect(source).toContain('REVIEW_CREDENTIAL_GLOB_PATTERNS.some');
   });
 
-  it.skipIf(process.platform === 'win32')(
+  it.skipIf(!canLinkFile)(
     'pins every Pi read tool to the real path that passed Review validation',
     () => {
       const source = CINDY_BRIDGE_EXTENSION_SOURCE;

--- a/packages/maker-core/src/agents/pi/__tests__/cindySubagentForeground.test.ts
+++ b/packages/maker-core/src/agents/pi/__tests__/cindySubagentForeground.test.ts
@@ -23,14 +23,14 @@ async function fixture() {
   const root = await mkdtemp(path.join(os.tmpdir(), 'cindy-pi-subagent-foreground-'));
   roots.push(root);
   const configHome = path.join(root, 'pi-home');
-  const extensions = path.join(configHome, 'extensions');
+  const internalExtensions = path.join(configHome, 'internal-extensions');
   const runRoot = path.join(root, 'runs');
-  await mkdir(extensions, { recursive: true });
+  await mkdir(internalExtensions, { recursive: true });
   await mkdir(runRoot, { recursive: true });
   await writeFile(path.join(configHome, 'models.json'), JSON.stringify({
     providers: { fixture: { models: [{ id: 'fixture-model' }] } },
   }));
-  await writeFile(path.join(extensions, 'cindy-bridge.ts'), 'export default function () {}\n');
+  await writeFile(path.join(internalExtensions, 'cindy-bridge.ts'), 'export default function () {}\n');
   const permissionFile = path.join(root, 'permission.json');
   const runtimeFile = path.join(root, 'runtime.json');
   const runnerFile = path.join(root, 'runner.cjs');

--- a/packages/maker-core/src/agents/pi/__tests__/cindySubagentRunner.test.ts
+++ b/packages/maker-core/src/agents/pi/__tests__/cindySubagentRunner.test.ts
@@ -1011,7 +1011,7 @@ describe('Cindy durable PI Subagent runner', () => {
     expect(resumedPrompts.at(-1)).toBe('continue for a second resumed generation');
   });
 
-  it.skipIf(process.platform === 'win32')('refuses a resume catalog redirected through a symlink', async () => {
+  it('refuses a resume catalog redirected through a symlink', async () => {
     const fixture = await makeFixture();
     const first = await waitFor(async () => {
       const runs = await listPiSubagentRuns(fixture.root);
@@ -1022,7 +1022,11 @@ describe('Cindy durable PI Subagent runner', () => {
     await mkdir(outside);
     await writeFile(path.join(outside, 'models.json'), '{"providers":{"redirected":{}}}\n');
     await rm(path.join(fixture.runDir, 'pi-home'), { recursive: true });
-    await symlink(outside, path.join(fixture.runDir, 'pi-home'), 'dir');
+    await symlink(
+      outside,
+      path.join(fixture.runDir, 'pi-home'),
+      process.platform === 'win32' ? 'junction' : 'dir',
+    );
 
     await expect(resumePiSubagentRun(
       fixture.root,

--- a/packages/maker-core/src/agents/pi/__tests__/cindySubagentSource.test.ts
+++ b/packages/maker-core/src/agents/pi/__tests__/cindySubagentSource.test.ts
@@ -144,6 +144,9 @@ describe('cindy-subagent extension source', () => {
     expect(CINDY_SUBAGENT_EXTENSION_SOURCE).toContain(
       "copyFileSync(join(configHome, 'models.json'), join(childConfigHome, 'models.json'))",
     );
+    expect(CINDY_SUBAGENT_EXTENSION_SOURCE).toContain(
+      "copyFileSync(join(configHome, 'internal-extensions', 'cindy-bridge.ts'), bridgeExtension)",
+    );
     expect(CINDY_SUBAGENT_EXTENSION_SOURCE).toContain('childConfigHome: childConfigHome');
   });
 

--- a/packages/maker-core/src/agents/pi/__tests__/customization-scanner.test.ts
+++ b/packages/maker-core/src/agents/pi/__tests__/customization-scanner.test.ts
@@ -288,14 +288,18 @@ describe('scanPiCustomizations', () => {
     expect(result.errors).toEqual([]);
   });
 
-  it.skipIf(process.platform === 'win32')('resolves a symlinked working directory for scanning while preserving its ownership path', async () => {
+  it.skipIf(!canLinkDirectory)('resolves a symlinked working directory for scanning while preserving its ownership path', async () => {
     const root = tempRoot();
     const repo = path.join(root, 'repo');
     const physicalCwd = path.join(repo, 'src');
     const linkedCwd = path.join(root, 'linked-cwd');
     mkdirSync(path.join(repo, '.git'), { recursive: true });
     mkdirSync(physicalCwd, { recursive: true });
-    symlinkSync(physicalCwd, linkedCwd, 'dir');
+    symlinkSync(
+      physicalCwd,
+      linkedCwd,
+      process.platform === 'win32' ? 'junction' : 'dir',
+    );
     writeSkill(repo, path.join('.agents', 'skills'), 'repo-skill');
 
     const result = await scanPiCustomizations({ workingDirs: [linkedCwd] });
@@ -305,12 +309,16 @@ describe('scanPiCustomizations', () => {
     expect(canonical(found?.absolutePath ?? '')).toBe(canonical(path.join(repo, '.agents', 'skills', 'repo-skill')));
   });
 
-  it.skipIf(process.platform === 'win32')('keeps lexical project aliases distinct for the same physical checkout', async () => {
+  it.skipIf(!canLinkDirectory)('keeps lexical project aliases distinct for the same physical checkout', async () => {
     const root = tempRoot();
     const repo = path.join(root, 'repo');
     const linkedRepo = path.join(root, 'linked-repo');
     mkdirSync(path.join(repo, '.git'), { recursive: true });
-    symlinkSync(repo, linkedRepo, 'dir');
+    symlinkSync(
+      repo,
+      linkedRepo,
+      process.platform === 'win32' ? 'junction' : 'dir',
+    );
     writeSkill(repo, path.join('.pi', 'skills'), 'aliased-skill');
 
     const items = projectItems(await scanPiCustomizations({ workingDirs: [repo, linkedRepo] }))

--- a/packages/maker-core/src/agents/pi/__tests__/pi-agent.integration.test.ts
+++ b/packages/maker-core/src/agents/pi/__tests__/pi-agent.integration.test.ts
@@ -2525,6 +2525,7 @@ describe.skipIf(!piAvailable)('PiAgent integration (real pi binary + fake gatewa
     },
   );
 
+  // symlink-platform-skip: CDPATH and the redirect commands in this case require a POSIX Bash host.
   it.skipIf(process.platform === 'win32' || !canSymlink)(
     'auto mode fail closes inherited CDPATH while explicit relative cd keeps ordinary reads fast',
     { timeout: 60_000 },

--- a/packages/maker-core/src/agents/pi/__tests__/pi-auto-review-dispatch.test.ts
+++ b/packages/maker-core/src/agents/pi/__tests__/pi-auto-review-dispatch.test.ts
@@ -750,7 +750,7 @@ describe('pi auto-review dispatch & spawn config (mocked pi process)', () => {
       ))).toBe(true));
       const published = JSON.stringify({ response, events });
       expect(published).toContain('restart-cindy-to-refresh-packages');
-      expect(captured.closed).toBe(true);
+      await vi.waitFor(() => expect(captured.closed).toBe(true));
     } finally {
       await handle.close();
     }

--- a/packages/maker-core/src/agents/pi/__tests__/pi-subagent-runs.test.ts
+++ b/packages/maker-core/src/agents/pi/__tests__/pi-subagent-runs.test.ts
@@ -2806,12 +2806,16 @@ describe('PI durable subagent run store', () => {
     expect(new Set(controls.map((control) => control.requestId)).size).toBe(2);
   });
 
-  it.skipIf(process.platform === 'win32')('refuses a control mailbox redirected through a symlink', async () => {
+  it('refuses a control mailbox redirected through a symlink', async () => {
     const root = await makeRoot();
     const runId = '123e4567-e89b-42d3-a456-426614174014';
     const outside = await makeRoot();
     await writeStatus(root, status(runId));
-    await symlink(outside, path.join(root, runId, 'controls'), 'dir');
+    await symlink(
+      outside,
+      path.join(root, runId, 'controls'),
+      process.platform === 'win32' ? 'junction' : 'dir',
+    );
 
     await expect(controlPiSubagentRuns(root, runId, 'stop')).rejects.toThrow(/control directory is unavailable/);
     await expect(readdir(outside)).resolves.toEqual([]);

--- a/packages/maker-core/src/agents/pi/cindy-subagent-source.ts
+++ b/packages/maker-core/src/agents/pi/cindy-subagent-source.ts
@@ -14,7 +14,7 @@
  *
  * 安全形态(重要,别当冗余删掉):
  *  - 子进程**继承 `PI_CODING_AGENT_DIR`**,但显式 `--no-extensions` 关闭隐式发现，再只用
- *    `--extension <configHome>/extensions/cindy-bridge.ts` 回装权限门。这样 project extension
+ *    `--extension <configHome>/internal-extensions/cindy-bridge.ts` 回装权限门。这样 project extension
  *    永远不会执行，bridge 的 tool_call 拦截 + 凭证路径硬拦仍对子代理生效。
  *  - 只读角色固定 read/grep/find/ls；worker/custom-write 才拿 edit/write/bash。Ask/Auto
  *    下 bridge 产生的 `extension_ui_request` 由 durable runner 记录，父 PI adapter 转交
@@ -896,7 +896,7 @@ async function launchDurableRun(binary, tasks, runtime, taskId, mode, context, d
     try { chmodSync(permissionFile, 0o600); } catch (err) { /* best effort on Windows */ }
     mkdirSync(childConfigHome, { recursive: true, mode: 0o700 });
     copyFileSync(join(configHome, 'models.json'), join(childConfigHome, 'models.json'));
-    copyFileSync(join(configHome, 'extensions', 'cindy-bridge.ts'), bridgeExtension);
+    copyFileSync(join(configHome, 'internal-extensions', 'cindy-bridge.ts'), bridgeExtension);
     try { chmodSync(join(childConfigHome, 'models.json'), 0o600); } catch (err) { /* best effort on Windows */ }
     try { chmodSync(bridgeExtension, 0o600); } catch (err) { /* best effort on Windows */ }
     mkdirSync(childSessionRoot, { recursive: true, mode: 0o700 });

--- a/packages/maker-core/src/agents/shared/image-resizer.test.ts
+++ b/packages/maker-core/src/agents/shared/image-resizer.test.ts
@@ -43,17 +43,21 @@ describe("ImageResizer private cache", () => {
   });
 
   it("refuses a symlink in place of the cache directory", async () => {
-    if (process.platform === "win32") return;
     const root = await tempDir();
     const target = path.join(root, "attacker-readable");
     const cacheDir = path.join(root, "cache-link");
     await fs.mkdir(target, { mode: 0o755 });
-    await fs.symlink(target, cacheDir);
+    const targetMode = (await fs.stat(target)).mode & 0o777;
+    await fs.symlink(
+      target,
+      cacheDir,
+      process.platform === "win32" ? "junction" : "dir",
+    );
 
     const resizer = new ImageResizer({ cacheDir });
     await expect(resizer.process("/does/not/matter.png")).resolves.toBe(
       "/does/not/matter.png",
     );
-    expect((await fs.stat(target)).mode & 0o777).toBe(0o755);
+    expect((await fs.stat(target)).mode & 0o777).toBe(targetMode);
   });
 });

--- a/packages/maker-core/src/agents/shared/review-read-scope.test.ts
+++ b/packages/maker-core/src/agents/shared/review-read-scope.test.ts
@@ -247,6 +247,7 @@ describe("review read scope", () => {
     expect(await resolveReviewReadPath(source, workspace, grants)).toBeNull();
   });
 
+  // symlink-platform-skip: This case validates POSIX inode and hard-link confinement semantics.
   it("uses a confined package manifest to resolve scoped pnpm mirrors", async () => {
     if (process.platform === "win32") return;
     const root = await makeTempDir();

--- a/scripts/__tests__/test-workspaces.test.mjs
+++ b/scripts/__tests__/test-workspaces.test.mjs
@@ -53,6 +53,7 @@ import {
 	resolvePnpmInvocation,
 	usablePnpmExecPath,
 } from "../shared/pnpm-invocation.mjs";
+import { findSymlinkPlatformSkips } from "../shared/symlink-test-guard.mjs";
 
 const ROOT = path.resolve(fileURLToPath(new URL("../..", import.meta.url)));
 
@@ -526,6 +527,65 @@ test("tests never bind a fixed numeric port", () => {
 			for (const match of source.matchAll(pattern)) {
 				if (Number(match[1]) !== 0) violations.push(`${file}:${match[1]}`);
 			}
+		}
+	}
+	assert.deepEqual(violations, []);
+});
+
+test("symlink platform-skip guard detects hard skips without flagging capability probes", () => {
+	assert.deepEqual(
+		findSymlinkPlatformSkips(`
+			it.skipIf(process.platform === "win32")("rejects escape", async () => {
+				await fs.symlink(outside, link);
+			});
+		`),
+		[{ line: 2 }],
+	);
+	assert.deepEqual(
+		findSymlinkPlatformSkips(`
+			it.skipIf(!canCreateSymlink)("rejects escape", async () => {
+				await fs.symlink(outside, link);
+			});
+			it.skipIf(process.platform === "win32")("sends SIGTERM", async () => {
+				await stopProcess();
+			});
+		`),
+		[],
+	);
+	assert.deepEqual(
+		findSymlinkPlatformSkips(`
+			it("rejects escape", async () => {
+				if (process.platform === "win32") return;
+				await fs.symlink(outside, link);
+			});
+		`),
+		[{ line: 3 }],
+	);
+});
+
+test("symlink platform-skip guard requires a concrete POSIX-only exception", () => {
+	const skippedTest = `
+		// symlink-platform-skip: Windows cannot represent non-UTF-8 link target bytes.
+		it.skipIf(process.platform === "win32")("hashes raw link bytes", async () => {
+			await fs.symlink(Buffer.from([0xff]), link);
+		});
+	`;
+	assert.deepEqual(findSymlinkPlatformSkips(skippedTest), []);
+	assert.deepEqual(
+		findSymlinkPlatformSkips(skippedTest.replace(
+			"Windows cannot represent non-UTF-8 link target bytes.",
+			"POSIX only",
+		)),
+		[{ line: 3 }],
+	);
+});
+
+test("symlink tests never skip solely because the host is Windows", () => {
+	const violations = [];
+	for (const file of discoverTestFiles(readAllFiles(ROOT))) {
+		const source = fs.readFileSync(path.join(ROOT, file), "utf8");
+		for (const violation of findSymlinkPlatformSkips(source)) {
+			violations.push(`${file}:${violation.line}`);
 		}
 	}
 	assert.deepEqual(violations, []);

--- a/scripts/help.mjs
+++ b/scripts/help.mjs
@@ -53,6 +53,9 @@ export function printHelp(log = console.log) {
   log('    pnpm mobile:sim:start');
   log('    # 中国大陆版模拟器：先 rebuild 安装，再 start 启动 Metro');
   log('    pnpm mobile:sim:rebuild -- --region=cn');
+  log('    # Windows 一键复用/启动 cindy-api36、配置 adb reverse，并启动中国大陆版 Metro');
+  log('    pnpm mobile:sim:start:cn');
+  log('    # 等价的显式区域写法；--no-emulator 可只启动 Metro');
   log('    pnpm mobile:sim:start -- --region=cn');
   log('    # 查看当前 Metro 对应的 checkout / branch');
   log('    pnpm mobile:sim:whoami');

--- a/scripts/shared/symlink-test-guard.mjs
+++ b/scripts/shared/symlink-test-guard.mjs
@@ -1,0 +1,136 @@
+const PLATFORM_SKIP_PATTERN = /\.\s*skipIf\s*\(/g;
+const TEST_CALL_PATTERN = /\b(?:it|test)\s*\(/g;
+const SYMLINK_CALL_PATTERN = /\b(?:symlink|symlinkSync)\s*\(/;
+const PLATFORM_EARLY_RETURN_PATTERN =
+	/\bif\s*\(\s*process\s*\.\s*platform\s*={2,3}\s+\)\s*(?:\{\s*)?return\b/g;
+const EXCEPTION_PATTERN = /^\s*\/\/\s*symlink-platform-skip:\s*(.{20,})\s*$/i;
+
+function maskNonCode(source) {
+	const chars = [...source];
+	let index = 0;
+	while (index < chars.length) {
+		const current = chars[index];
+		const next = chars[index + 1];
+		if (current === "/" && next === "/") {
+			chars[index] = " ";
+			chars[index + 1] = " ";
+			index += 2;
+			while (index < chars.length && chars[index] !== "\n") {
+				chars[index] = " ";
+				index += 1;
+			}
+			continue;
+		}
+		if (current === "/" && next === "*") {
+			chars[index] = " ";
+			chars[index + 1] = " ";
+			index += 2;
+			while (index < chars.length) {
+				if (chars[index] === "*" && chars[index + 1] === "/") {
+					chars[index] = " ";
+					chars[index + 1] = " ";
+					index += 2;
+					break;
+				}
+				if (chars[index] !== "\n") chars[index] = " ";
+				index += 1;
+			}
+			continue;
+		}
+		if (current === '"' || current === "'" || current === "`") {
+			const quote = current;
+			chars[index] = " ";
+			index += 1;
+			while (index < chars.length) {
+				if (chars[index] === "\\") {
+					chars[index] = " ";
+					if (chars[index + 1] !== "\n") chars[index + 1] = " ";
+					index += 2;
+					continue;
+				}
+				if (chars[index] === quote) {
+					chars[index] = " ";
+					index += 1;
+					break;
+				}
+				if (chars[index] !== "\n") chars[index] = " ";
+				index += 1;
+			}
+			continue;
+		}
+		index += 1;
+	}
+	return chars.join("");
+}
+
+function matchingParen(source, openIndex) {
+	let depth = 0;
+	for (let index = openIndex; index < source.length; index += 1) {
+		if (source[index] === "(") depth += 1;
+		else if (source[index] === ")") {
+			depth -= 1;
+			if (depth === 0) return index;
+		}
+	}
+	return -1;
+}
+
+function previousLine(source, index) {
+	const lineStart = source.lastIndexOf("\n", index - 1) + 1;
+	const previousEnd = lineStart > 0 ? lineStart - 1 : 0;
+	const previousStart = source.lastIndexOf("\n", previousEnd - 1) + 1;
+	return source.slice(previousStart, previousEnd).replace(/\r$/, "");
+}
+
+/**
+ * Finds test/suite calls that skip on win32 while exercising a real symlink.
+ * A genuinely POSIX-only contract may use an immediately preceding
+ * `symlink-platform-skip:` comment with a concrete rationale.
+ */
+export function findSymlinkPlatformSkips(source) {
+	const masked = maskNonCode(source);
+	const violations = [];
+	for (const match of masked.matchAll(PLATFORM_SKIP_PATTERN)) {
+		const conditionOpen = masked.indexOf("(", match.index);
+		const conditionClose = matchingParen(masked, conditionOpen);
+		if (conditionClose < 0) continue;
+		const condition = source.slice(conditionOpen + 1, conditionClose);
+		if (!/process\s*\.\s*platform/.test(condition) || !/["']win32["']/.test(condition)) {
+			continue;
+		}
+
+		let testOpen = conditionClose + 1;
+		while (/\s/.test(masked[testOpen] ?? "")) testOpen += 1;
+		if (masked[testOpen] !== "(") continue;
+		const testClose = matchingParen(masked, testOpen);
+		if (testClose < 0) continue;
+		if (!SYMLINK_CALL_PATTERN.test(masked.slice(testOpen + 1, testClose))) continue;
+		if (EXCEPTION_PATTERN.test(previousLine(source, match.index))) continue;
+
+		violations.push({
+			line: source.slice(0, match.index).split("\n").length,
+		});
+	}
+	for (const match of masked.matchAll(TEST_CALL_PATTERN)) {
+		const testOpen = masked.indexOf("(", match.index);
+		const testClose = matchingParen(masked, testOpen);
+		if (testClose < 0) continue;
+		const testBody = masked.slice(testOpen + 1, testClose);
+		if (!SYMLINK_CALL_PATTERN.test(testBody)) continue;
+		const earlyReturn = PLATFORM_EARLY_RETURN_PATTERN.exec(testBody);
+		PLATFORM_EARLY_RETURN_PATTERN.lastIndex = 0;
+		if (!earlyReturn) continue;
+		const earlyReturnStart = testOpen + 1 + earlyReturn.index;
+		const earlyReturnSource = source.slice(
+			earlyReturnStart,
+			earlyReturnStart + earlyReturn[0].length,
+		);
+		if (!/["']win32["']/.test(earlyReturnSource)) continue;
+		if (EXCEPTION_PATTERN.test(previousLine(source, match.index))) continue;
+
+		violations.push({
+			line: source.slice(0, earlyReturnStart).split("\n").length,
+		});
+	}
+	return violations;
+}


### PR DESCRIPTION
## 这次改了什么

### 摘要

- 修复 Windows 下 `mobile:sim:start` 直接 `spawn pnpm` 导致的 `ENOENT`，统一复用跨平台 pnpm 调用器。
- 增加 Android 模拟器启动链：默认复用或启动 `cindy-api36`、等待系统就绪并配置 `adb reverse`；新增区域明确的 `mobile:sim:start:cn` 一键入口。
- 新增全仓 symlink 测试自动门禁，阻止按 Windows 平台硬跳过真实 symlink 覆盖；目录 symlink 在 Windows 使用 junction，文件 symlink 改按宿主能力精确探测。
- 清理 Desktop、Maker Core 与 Lizi MCP 中现存的平台硬跳过，并为真正依赖 POSIX 语义的例外保留带原因的显式标记。
- 修复 Windows 全量单测暴露的固定 loopback 测试端口，以及 Pi 子代理读取旧 bridge 目录的问题。

### 变更类型

- [ ] `feat` 新功能
- [x] `fix` 缺陷修复
- [ ] `refactor` / `perf` 重构或性能优化
- [ ] `docs` / `test` / `chore` 文档、测试或工程维护
- [ ] 其他：

### 范围

- 关联 Issue / 需求：Windows Android 模拟器本地调试。
- 本 PR 包含：Mobile 开发启动脚本、Android AVD/SDK 辅助模块、symlink 测试自动门禁与存量硬跳过清理、Pi 子代理 bridge 路径修复及开发文档。
- 明确不包含：原生构建配置、原生依赖、发布配置、服务端改动。
- 用户可见变化：开发者可运行 `pnpm mobile:sim:start:cn` 一键启动或复用 Android 模拟器并启动中国大陆版 Metro。
- 是否存在 breaking change：无。

### UI 变化

不涉及。

- 引用的设计规范：不涉及 UI。

## 怎么验证的

### 自动验证

```text
node --test scripts/__tests__/test-workspaces.test.mjs
结果：通过，包含门禁正例、反例和例外原因校验

pnpm test:runner
结果：通过

pnpm --filter mobile run --if-present typecheck
结果：通过

pnpm --filter desktop run --if-present typecheck
结果：通过

pnpm --filter @cindy/maker-core run --if-present typecheck
结果：通过；该 package 未定义 typecheck，--if-present 正常跳过

pnpm --filter mobile exec vitest run src/__tests__/mobileAndroidSimulator.test.ts src/__tests__/mobileXcode.test.ts src/__tests__/mobileSimSource.test.ts
结果：33 个测试通过

pnpm --filter desktop exec vitest run src/main/__tests__/codexAuthLink.test.ts src/main/__tests__/codexAuthInvalidation.test.ts src/main/maker-host/__tests__/codexAuthInvalidation.test.ts src/main/maker-host/__tests__/grokOauthCallbackListener.test.ts
结果：98 个测试通过；8 个真实 symlink 用例因当前 Windows 宿主无该能力而按 capability probe 跳过

pnpm --filter @cindy/maker-core exec vitest run src/agents/pi/__tests__/cindySubagentSource.test.ts src/agents/pi/__tests__/pi-agent.integration.test.ts -t "cindy-subagent extension source|subagent tool spawns|subagent write boundary|BYOM: a subagent"
结果：43 个测试通过；47 个因名称筛选未执行

pnpm test:unit:related
结果：通过；因根 package.json 改动自动回退完整 unit workspace 调度

pnpm check:dco
结果：通过，PR 范围内 2 个 commit 均已签名
```

### 手工验证

- Windows：在 `cindy/dazzling-curie` worktree 冷启动 `cindy-api36`，确认 Metro 使用当前 worktree 的 8081 服务，并成功配置 `adb reverse`。
- 构建并安装中国大陆版 Debug APK `com.xd.cindycn`，启动 `com.xd.cindycn/.MainActivity`；日志出现 `Running "main"`，界面进入带 `+86` 的登录页。

### 未执行的验证

- 未在 macOS/iOS Simulator 手工复测；非 Windows 保持既有 Metro-only 分支，并有参数测试覆盖。
- 未额外记录 `__DEV__` build label 截图；已通过 Metro worktree 归属检查和应用启动日志确认当前 checkout。

## 风险

### 风险分类

- [ ] 无已知风险
- [ ] SQLite / migration
- [ ] system prompt
- [ ] 协议兼容
- [x] 权限 / 安全 / 用户数据
- [ ] 存量插件兼容（批准状态 / 指纹 / manifest 校验 / 安装布局 / 包格式）
- [ ] 原生层 / fingerprint / OTA
- [x] 跨平台差异
- [ ] 其他：

### 影响与回滚

- 影响范围：Windows Mobile 本地开发启动链、symlink 测试调度与相关跨平台测试，以及 Pi 子代理复制 Cindy 内部权限 bridge 的路径。Pi 权限策略本身未改变。
- 回滚 / 降级方式：回滚本提交；Mobile 可临时使用 `--no-emulator` 仅启动 Metro，并手工启动 AVD。
- symlink 门禁说明：禁止无理由的 Windows 平台硬跳过；真正依赖 POSIX shell、文件名字节或 inode/硬链接语义的用例使用 `symlink-platform-skip:` 记录原因。
- 冷更判断：不触发。Mobile 改动仅涉及开发脚本、测试和文档，未修改 runtime fingerprint 输入。
- 存量插件影响：无。

### 提交前检查

- [x] 已 review 完整 diff
- [x] 每个 commit 都带 DCO 签名（`git commit -s`，见 [DCO](../DCO)）
- [x] UI 改动已在「UI 变化」注明引用的设计规范章节（不涉及 UI 则跳过）
- [x] 未提交凭证、令牌或授权文件
- [x] 已补充必要文档
- [x] 已确认测试结果或说明未执行原因