### PR TITLE
fix(desktop): 显式自定义供应商路由解析失败时 fail-closed

### DIFF
--- a/apps/desktop/src/main/maker-host/__tests__/claudeProxyScopeGate.test.ts
+++ b/apps/desktop/src/main/maker-host/__tests__/claudeProxyScopeGate.test.ts
@@ -56,7 +56,13 @@ import {
   readClaudeSessionRoute,
   resetClaudeSessionRouteRegistryForTest,
 } from '../claude-session-route-registry';
-import { setPendingCredentialSwitchReader, setProviderOAuthTokenReader } from '../provider-route';
+import {
+  setCustomProviderKeyReader,
+  setPendingCredentialSwitchReader,
+  setProviderOAuthTokenReader,
+} from '../provider-route';
+import { setCustomProviders } from '../active-catalog';
+import { buildUserProvider } from '@cindy/model-providers';
 import {
   authenticatePiProxySession,
   registerPiProxySession,
@@ -875,5 +881,78 @@ describe('pi routingTransform — xdt session header selects the Pi provider rou
       ],
     });
     expect(decision?.headerOverride).not.toHaveProperty('x-cindy-pi-session-token');
+  });
+});
+
+describe('cc routingTransform — 显式自定义供应商解析失败 fail-closed (issue #3631)', () => {
+  const RELAY_UPSTREAM = 'https://relay.example/v1';
+  const HEADERS = {
+    'x-claude-code-session-id': 'sdk-relay',
+    authorization: 'Bearer sk-ant-oat01',
+  };
+
+  beforeEach(() => {
+    resetClaudeSessionRouteRegistryForTest();
+    setClaudeProxyGatewayKeyReader(() => 'sk-gw');
+    setClaudeProxySessionIdResolver((sdkId) => (sdkId === 'sdk-relay' ? 'sess-relay' : null));
+    setPendingCredentialSwitchReader(() => undefined);
+    setProviderOAuthTokenReader(() => null);
+    setSessionProvider('sess-relay', 'relay-station');
+    setCustomProviders([
+      buildUserProvider({
+        id: 'relay-station',
+        name: 'Relay Station',
+        runtimes: {
+          'claude-code': {
+            baseUrl: RELAY_UPSTREAM,
+            wireProtocol: 'anthropic-messages',
+            models: [{ id: 'claude-opus-5', name: 'Claude Opus 5' }],
+          },
+        },
+      }),
+    ]);
+    setCustomProviderKeyReader(() => 'relay-user-key');
+  });
+
+  afterEach(() => {
+    setCustomProviders([]);
+    setCustomProviderKeyReader(() => null);
+    clearSessionProvider('sess-relay');
+    resetClaudeSessionRouteRegistryForTest();
+  });
+
+  it('前置校验:显式自定义供应商正常态照常路由到用户上游', async () => {
+    const decision = await Promise.resolve(
+      createModelRoutingTransform()({ model: 'claude-opus-5' }, ctxWith(HEADERS)),
+    );
+    expect(decision).toMatchObject({ upstreamOverride: RELAY_UPSTREAM });
+  });
+
+  it('绑定的自定义供应商从 catalog 缺席 → 503 explicit_provider_route_unavailable,不回落默认网关', async () => {
+    // 模拟移除 / 重载窗口:会话绑定仍在,catalog 已无此供应商。修复前 ① 段放空 →
+    // ② 段换网关 key 打官方网关,模型不在该用户可用集 → 403 user_model_access_denied,
+    // 前端呈现为「认证失败」误导用户重登自定义供应商(issue #3631)。
+    setCustomProviders([]);
+    const decision = await Promise.resolve(
+      createModelRoutingTransform()({ model: 'claude-opus-5' }, ctxWith(HEADERS)),
+    );
+    expect(decision?.localHandler).toBeDefined();
+    const writeHead = vi.fn();
+    const end = vi.fn();
+    await decision?.localHandler?.({ res: { writeHead, end } } as never);
+    expect(writeHead).toHaveBeenCalledWith(503, expect.any(Object));
+    expect(JSON.parse(end.mock.calls[0][0])).toMatchObject({
+      error: { code: 'explicit_provider_route_unavailable' },
+    });
+  });
+
+  it('builtin xd 会话缺网关 key → 照旧回落 ② 直连 Anthropic(builtin null 语义不变)', () => {
+    setSessionProvider('sess-relay', 'xd');
+    setClaudeProxyGatewayKeyReader(() => null);
+    const decision = createModelRoutingTransform()(
+      { model: 'claude-haiku-4-5-20251001' },
+      ctxWith(HEADERS),
+    );
+    expect(decision).toEqual({ upstreamOverride: 'https://api.anthropic.com' });
   });
 });

--- a/apps/desktop/src/main/maker-host/anthropic-compat-proxy-host.ts
+++ b/apps/desktop/src/main/maker-host/anthropic-compat-proxy-host.ts
@@ -76,6 +76,7 @@ import { shouldApplyExclusiveProviderReroute } from './model-route-guard.js';
 import { getSessionProvider } from './session-provider-store.js';
 import {
   buildRouteDecision,
+  explicitProviderRouteNullCause,
   gatewayDefaultRouteDecision,
   getUserProviderIdForSession,
   resolveImplicitLocalBridgeRouteResolution,
@@ -404,6 +405,24 @@ function routingTemporarilyUnavailableRoute(): RoutingDecision {
   );
 }
 
+/**
+ * issue #3631:显式绑定的自定义供应商解析失败时 fail-closed,不回落默认网关。
+ * 回落会带着网关 key 打官方网关,模型不在用户可用集 → 403 user_model_access_denied,
+ * 前端呈现为「认证失败」,误导用户重登自定义供应商。503 + retry-after 让 catalog
+ * 重载等瞬态窗口自愈;持久错配则给出可定位的独立错误语义。
+ */
+function explicitProviderRouteUnavailableRoute(
+  providerId: string,
+  wireModel: string,
+): RoutingDecision {
+  return retryableLocalRoute(
+    'explicit_provider_route_unavailable',
+    `Session is bound to custom provider "${providerId}" but no route could be resolved`
+      + ` for model "${wireModel}". Refusing to fall back to the default gateway;`
+      + ' check the provider configuration, then retry.',
+  );
+}
+
 function carriesProviderAuthPlaceholder(headers: Readonly<Record<string, string>>): boolean {
   return headerValue(headers, 'x-api-key') === CLAUDE_PROVIDER_AUTH_PLACEHOLDER_KEY;
 }
@@ -701,8 +720,26 @@ export function createModelRoutingTransform(): RoutingTransform {
         }
         return isPiGatewayRequest ? sanitizePiGatewayDecision(route, ctx.url) : route;
       };
-      if (perSession instanceof Promise) return perSession.then(recordSelectedRoute);
+      // #3631:显式绑定的自定义供应商解析失败(catalog 缺席 / 无路由)时 fail-closed。
+      // 'scope'(#886 辅助调用出服务范围)与 builtin 供应商的 null 照旧回落 ①.5/②。
+      const refuseUnresolvedExplicitRoute = (): RoutingDecision | null => {
+        if (!explicitCustomProvider || !selectedProviderId) return null;
+        const cause = explicitProviderRouteNullCause(selectedProviderId, requestAgent, wireModel);
+        if (cause !== 'unresolvable') return null;
+        log.warn('explicit custom provider route unresolvable; refusing default upstream', {
+          selectedProviderId,
+          wireModel,
+        });
+        return explicitProviderRouteUnavailableRoute(selectedProviderId, wireModel);
+      };
+      if (perSession instanceof Promise) {
+        // async 解析出 null 时此前直接透传默认上游(连 ② 的换 key 都不走),同样必须过守卫。
+        return perSession.then((route) =>
+          route ? recordSelectedRoute(route) : (refuseUnresolvedExplicitRoute() ?? recordSelectedRoute(route)));
+      }
       if (perSession) return recordSelectedRoute(perSession);
+      const explicitRefusal = refuseUnresolvedExplicitRoute();
+      if (explicitRefusal) return explicitRefusal;
       if (isPiGatewayRequest && selectedProviderId === 'xd') {
         return sanitizePiGatewayDecision(null, ctx.url);
       }

--- a/apps/desktop/src/main/maker-host/provider-route.ts
+++ b/apps/desktop/src/main/maker-host/provider-route.ts
@@ -535,6 +535,33 @@ export function providerRoutingServesWireModel(
 }
 
 /**
+ * 显式绑定供应商的会话在 ① 段解析出 null 时的归因(issue #3631)。
+ * 只对 user-source 自定义供应商给出 fail-closed 判定;builtin 供应商
+ * (xd / anthropic / openai-cc / …)的 null 语义由 ② 段既有回落负责,不在此改变。
+ *
+ * - 'not-custom':builtin 供应商 → 保持既有回落。
+ * - 'scope':供应商存在且有路由,但 wireModel 不在其声明的服务范围
+ *   (modelPrefixes,#886 的辅助调用语义)→ 保持既有回落。
+ * - 'unresolvable':catalog 缺席(移除 / 重载窗口)、该 agent 无路由,或服务
+ *   范围内仍建不出决策 → 调用方应 fail-closed,不得回落默认网关:回落会带着
+ *   网关 key 打官方上游,模型不在用户可用集时返回 403 user_model_access_denied,
+ *   被前端呈现为「认证失败」,误导用户去重登自定义供应商。
+ */
+export function explicitProviderRouteNullCause(
+  providerId: string,
+  agent: AgentKind,
+  wireModel?: string,
+): 'not-custom' | 'scope' | 'unresolvable' {
+  const provider = getActiveCatalog().providers.find((p) => p.id === providerId);
+  if (!provider) return 'unresolvable';
+  if (provider.source !== 'user') return 'not-custom';
+  const routing = providerRoutingForModel(provider, agent, wireModel);
+  if (!routing) return 'unresolvable';
+  if (!routingServesWireModel(routing, wireModel)) return 'scope';
+  return 'unresolvable';
+}
+
+/**
  * 据某会话**显式选定的供应商**解析本次请求的路由决策。
  * 返回 null = 该会话未显式选供应商(或该供应商对此 agent 无路由,或本次请求的 wire model
  * 不在该路由声明的服务范围内)→ 调用方回落 decideXxxRoute / spawn 默认(no-break)。


### PR DESCRIPTION
## 这次改了什么

### 摘要

fix #3631。会话显式绑定 user-source 自定义供应商(中转站)后,cc routingTransform ① 段解析返回 null 时(catalog 缺席 / 该 agent 无路由),请求会回落 ② 段默认网关:带着网关 key 打官方上游,模型不在该用户可用集 → 403 `user_model_access_denied`,被前端呈现为「认证失败」,误导用户去重登自定义供应商(实际重发即成功,与鉴权无关);async 解析路径(provider-oauth-header 策略)此前更是 null 即直接透传默认上游,连 ② 段换 key 都不走。

修复分两处:

- `provider-route.ts` 新增 `explicitProviderRouteNullCause` 归因:builtin 供应商(xd / anthropic / openai-cc)→ `'not-custom'`,保持既有 ② 段回落;供应商存在且有路由但 wireModel 出其声明的 `modelPrefixes` 服务范围 → `'scope'`(#886 辅助调用语义),同样保持回落;仅 user-source 供应商的 catalog 缺席 / 无路由 / 范围内建不出决策 → `'unresolvable'`。
- `anthropic-compat-proxy-host.ts` ① 段(sync 与 async 两条路径)对 `'unresolvable'` 返回 503 `explicit_provider_route_unavailable`(retryableLocalRoute,带 `retry-after: 1`)——catalog 重载等瞬态窗口下 CLI 重试自愈;持久错配则给出可定位的独立错误语义,而不是误导性 403。

与 `buildRouteDecision` 既有哲学同口径:oauth-token 策略的注释早已写明「回落会让模型跑错上游 + 凭证泄漏,宁可上游 401」——本修复把同一原则前移到解析层。

### 变更类型

- [ ] `feat` 新功能
- [x] `fix` 缺陷修复
- [ ] `refactor` / `perf` 重构或性能优化
- [ ] `docs` / `test` / `chore` 文档、测试或工程维护
- [ ] 其他:

### 范围

- 关联 Issue / 需求:#3631
- 本 PR 包含:归因助手 + ① 段 fail-closed 守卫(sync / async)+ 3 条回归
- 明确不包含:上游真实返回 403 时的错误文案分层(呈现层,涉及产品文案);#886 / builtin 回落行为零变化(有回归锁住)
- 用户可见变化:显式绑定的中转站解析失败时,得到明确的 `explicit_provider_route_unavailable` 错误并自动重试,而不是误导性「认证失败」
- 是否存在 breaking change:无

### UI 变化

无 UI 变化。

## 怎么验证的

### 自动验证

```
pnpm --dir apps/desktop exec vitest run --pool=forks src/main/maker-host/__tests__/claudeProxyScopeGate.test.ts
```
结果:51 过(新增 3 条:catalog 缺席 → 503 独立错误码;正常态照常路由用户上游;builtin xd 缺网关 key 照旧回落 ② 直连 Anthropic)。反证:stash 掉 src 修复后「catalog 缺席」用例如预期失败、其余 50 过。

相邻 6 套件(claudeProxyImplicitRoute / providerRoute / claudeSessionRouteObservation / genericOAuth / xaiBridgeAuthInvalidation / codexProxyHost)332 例全过;desktop typecheck 过。

```
pnpm test:unit:related
```
结果:exit 1,唯一失败为 maker-core `pi-agent.integration.test.ts` 3 例(真实 pi 二进制集成测试,本机环境性既有失败,与本 diff 无关;desktop 段本轮通过)。

### 手工验证

无(决策级行为全部由套件断言;中转站故障场景依赖运行期 catalog 状态,由单测以 `setCustomProviders([])` 模拟移除 / 重载窗口)。

### 未执行的验证

- 未对真实中转站上游做端到端复现(触发条件是运行期 catalog 状态,已由单测模拟)。

## 风险

### 风险分类

低风险。fail-closed 只作用于「显式绑定 user-source 供应商 + 解析 unresolvable」这一此前必然打错上游的路径;builtin 与 scope 回落语义有回归锁住。

### 影响与回滚

影响面:desktop main 的 cc 路由决策。远程与移动端适配:决策发生在 desktop main 的本地 proxy 内,远程会话与移动端经同一 proxy,行为一致、无需额外适配。回滚:revert 单 commit 即可,无数据 / schema 变更。

### 提交前检查

- [x] 已运行相关单测、typecheck 与 `pnpm test:unit:related`(失败项已逐一归因为本机环境基线)
- [x] commit 带 DCO 签名(Signed-off-by: ficowang <fico@xd.com>)
- [x] diff 聚焦单一问题,无无关改动
