### PR TITLE
fix(desktop): 协同启用时自动回收初始化中断遗留的孤儿空团队

### DIFF
--- a/apps/desktop/src/main/localDb/__tests__/orcaTeamStore.test.ts
+++ b/apps/desktop/src/main/localDb/__tests__/orcaTeamStore.test.ts
@@ -331,6 +331,39 @@ describe('orcaTeamStore', () => {
     ]);
   });
 
+  it('isOrphanedTeamInit:零 worker 且无存活 reservation 判孤儿;活租约或任意 worker 行则不判 (#3555)', async () => {
+    const { isOrphanedTeamInit } = await import('../orcaTeamStore.js');
+    const client = createTestDbClient();
+    setCurrentDbClient(client, 'test-user');
+    const now = Date.now();
+    await client.exec(
+      'INSERT INTO orca_teams (id, lead_session_id, status, created_at, updated_at) VALUES (?, ?, ?, ?, ?)',
+      ['team-orphan', 'lead-1', 'active', now, now],
+    );
+    await expect(isOrphanedTeamInit('team-orphan')).resolves.toBe(true);
+
+    await client.exec(
+      'INSERT INTO orca_worker_creation_reservations (id, team_id, label, created_at, expires_at) VALUES (?, ?, ?, ?, ?)',
+      ['resv-1', 'team-orphan', 'dev', now, now + 60_000],
+    );
+    await expect(isOrphanedTeamInit('team-orphan')).resolves.toBe(false);
+    await client.exec(
+      'UPDATE orca_worker_creation_reservations SET expires_at = ? WHERE id = ?',
+      [now - 1, 'resv-1'],
+    );
+    await expect(isOrphanedTeamInit('team-orphan')).resolves.toBe(true);
+
+    await client.exec(
+      'INSERT INTO sessions (id, status, created_at, updated_at) VALUES (?, ?, ?, ?)',
+      ['ws-1', 'archived', now, now],
+    );
+    await client.exec(
+      'INSERT INTO orca_workers (id, team_id, session_id, created_at, updated_at) VALUES (?, ?, ?, ?, ?)',
+      ['worker-1', 'team-orphan', 'ws-1', now, now],
+    );
+    await expect(isOrphanedTeamInit('team-orphan')).resolves.toBe(false);
+  });
+
   function createTestDbClient(): DbClient {
     const dbHandle = new Database(':memory:');
     rawDb = dbHandle;
@@ -384,6 +417,13 @@ describe('orcaTeamStore', () => {
         updated_at INTEGER NOT NULL
       );
 
+      CREATE TABLE orca_worker_creation_reservations (
+        id TEXT PRIMARY KEY,
+        team_id TEXT NOT NULL,
+        label TEXT NOT NULL,
+        created_at INTEGER NOT NULL,
+        expires_at INTEGER NOT NULL
+      );
       CREATE TABLE orca_teams (
         id TEXT PRIMARY KEY,
         lead_session_id TEXT NOT NULL,

--- a/apps/desktop/src/main/localDb/__tests__/orcaTeamStore.test.ts
+++ b/apps/desktop/src/main/localDb/__tests__/orcaTeamStore.test.ts
@@ -336,9 +336,16 @@ describe('orcaTeamStore', () => {
     const client = createTestDbClient();
     setCurrentDbClient(client, 'test-user');
     const now = Date.now();
+    // 年龄地板(review 反馈):刚创建的 team 可能仍在别处初始化,不判孤儿。
+    const staleCreatedAt = now - 120_000;
     await client.exec(
       'INSERT INTO orca_teams (id, lead_session_id, status, created_at, updated_at) VALUES (?, ?, ?, ?, ?)',
-      ['team-orphan', 'lead-1', 'active', now, now],
+      ['team-young', 'lead-1', 'active', now, now],
+    );
+    await expect(isOrphanedTeamInit('team-young')).resolves.toBe(false);
+    await client.exec(
+      'INSERT INTO orca_teams (id, lead_session_id, status, created_at, updated_at) VALUES (?, ?, ?, ?, ?)',
+      ['team-orphan', 'lead-1', 'active', staleCreatedAt, staleCreatedAt],
     );
     await expect(isOrphanedTeamInit('team-orphan')).resolves.toBe(true);
 

--- a/apps/desktop/src/main/localDb/orcaTeamStore.ts
+++ b/apps/desktop/src/main/localDb/orcaTeamStore.ts
@@ -1,9 +1,9 @@
 import { BrowserWindow } from 'electron';
-import { and, desc, eq, inArray, ne } from 'drizzle-orm';
+import { and, desc, eq, gt, inArray, ne } from 'drizzle-orm';
 import { createId } from '@paralleldrive/cuid2';
 
 import { getDbClient } from './client/current.js';
-import { orcaWorkers, orcaTeams, sessions } from './schema.js';
+import { orcaWorkers, orcaTeams, orcaWorkerCreationReservations, sessions } from './schema.js';
 import { createLogger } from '../logger.js';
 import { throwIpcError } from '../utils/ipcValidate.js';
 import { tapWindowBroadcast } from '../device-link/broadcast-tap.js';
@@ -199,6 +199,34 @@ export async function getActiveTeamByLead(
   }
 
   return teamToRecord(latest);
+}
+
+/**
+ * #3555:判定 active team 是否为「初始化被进程退出打断」遗留的孤儿。
+ * 判据取最保守的一档:该 team 从未挂上任何 worker 行(任意状态,含归档——
+ * 全员归档的 team 是用户可继续 create_worker 的合法状态,不算孤儿),且没有
+ * 仍在租期内的创建 reservation(有则说明另一进程正在为它建 worker)。两条都
+ * 满足的 team 不可能承载任何用户状态,调用方可安全按 failed 收口重新启用。
+ */
+export async function isOrphanedTeamInit(teamId: string): Promise<boolean> {
+  const db = getDbClient().drizzle;
+  const [worker] = await db
+    .select({ id: orcaWorkers.id })
+    .from(orcaWorkers)
+    .where(eq(orcaWorkers.teamId, teamId))
+    .limit(1);
+  if (worker) return false;
+  const [reservation] = await db
+    .select({ id: orcaWorkerCreationReservations.id })
+    .from(orcaWorkerCreationReservations)
+    .where(
+      and(
+        eq(orcaWorkerCreationReservations.teamId, teamId),
+        gt(orcaWorkerCreationReservations.expiresAt, Date.now()),
+      ),
+    )
+    .limit(1);
+  return !reservation;
 }
 
 /**

--- a/apps/desktop/src/main/localDb/orcaTeamStore.ts
+++ b/apps/desktop/src/main/localDb/orcaTeamStore.ts
@@ -208,8 +208,21 @@ export async function getActiveTeamByLead(
  * 仍在租期内的创建 reservation(有则说明另一进程正在为它建 worker)。两条都
  * 满足的 team 不可能承载任何用户状态,调用方可安全按 failed 收口重新启用。
  */
+/** #3555 review:太年轻的 team 视为「可能仍在别处初始化」,不判孤儿。 */
+const ORPHAN_TEAM_MIN_AGE_MS = 60_000;
+
 export async function isOrphanedTeamInit(teamId: string): Promise<boolean> {
   const db = getDbClient().drizzle;
+  // 并发初始化兜底(同进程窗口已由 lifecycle 的 in-flight 集合覆盖,这里
+  // 挡住其余场景):创建后不足 ORPHAN_TEAM_MIN_AGE_MS 的 team 不判孤儿——
+  // 进程中断遗留的孤儿在用户重启重试时天然老于该地板,收敛性不受影响。
+  const [team] = await db
+    .select({ createdAt: orcaTeams.createdAt })
+    .from(orcaTeams)
+    .where(eq(orcaTeams.id, teamId))
+    .limit(1);
+  if (!team) return false;
+  if (Date.now() - team.createdAt < ORPHAN_TEAM_MIN_AGE_MS) return false;
   const [worker] = await db
     .select({ id: orcaWorkers.id })
     .from(orcaWorkers)

--- a/apps/desktop/src/main/maker-ipc/__tests__/orcaLifecycleService.test.ts
+++ b/apps/desktop/src/main/maker-ipc/__tests__/orcaLifecycleService.test.ts
@@ -44,6 +44,7 @@ function createDeps(overrides: Partial<OrcaLifecycleDeps> = {}) {
       calls.push(`createActiveTeam:${leadSessionId}`);
       return { id: 'team-1', leadSessionId };
     }),
+    isOrphanedTeamInit: vi.fn(async () => false),
     getWorkerPermissionMode: vi.fn(() => 'auto' as const),
     setWorkerPermissionMode: vi.fn((workerPermissionMode) => {
       calls.push(`setWorkerPermissionMode:${workerPermissionMode}`);
@@ -878,5 +879,54 @@ describe('OrcaLifecycleService', () => {
       'markTeamEnded:team-1:failed',
       'setSessionOrcaRole:lead-1:null',
     ]);
+  });
+});
+
+describe('enableTeam — 孤儿空团队自动回收 (#3555)', () => {
+  const enableParams = {
+    leadSessionId: 'lead-1',
+    workerAgent: 'codex',
+    role: 'reviewer',
+    label: 'reviewer',
+  } as const;
+
+  it('active 空团队(零 worker 且无存活 reservation)→ 按 failed 收口后继续启用', async () => {
+    const { calls, deps, service } = createDeps({
+      getActiveTeamByLead: vi.fn(async () => activeTeam()),
+      isOrphanedTeamInit: vi.fn(async () => true),
+    });
+    await expect(service.enableTeam(enableParams)).resolves.toMatchObject({
+      teamId: 'team-1',
+      workerId: 'worker-1',
+    });
+    expect(deps.isOrphanedTeamInit).toHaveBeenCalledWith('team-existing');
+    expect(deps.markTeamEnded).toHaveBeenCalledWith('team-existing', 'failed');
+    expect(calls).toContain('createActiveTeam:lead-1');
+  });
+
+  it('非孤儿 → 维持 ALREADY_EXISTS,不动既有 team', async () => {
+    const { deps, service } = createDeps({
+      getActiveTeamByLead: vi.fn(async () => activeTeam()),
+      isOrphanedTeamInit: vi.fn(async () => false),
+    });
+    await expect(service.enableTeam(enableParams)).resolves.toMatchObject({
+      ok: false,
+      errorCode: 'ALREADY_EXISTS',
+    });
+    expect(deps.markTeamEnded).not.toHaveBeenCalled();
+  });
+
+  it('孤儿判定抛错 → 保守维持 ALREADY_EXISTS,绝不误收可能有内容的 team', async () => {
+    const { deps, service } = createDeps({
+      getActiveTeamByLead: vi.fn(async () => activeTeam()),
+      isOrphanedTeamInit: vi.fn(async () => {
+        throw new Error('db down');
+      }),
+    });
+    await expect(service.enableTeam(enableParams)).resolves.toMatchObject({
+      ok: false,
+      errorCode: 'ALREADY_EXISTS',
+    });
+    expect(deps.markTeamEnded).not.toHaveBeenCalled();
   });
 });

--- a/apps/desktop/src/main/maker-ipc/__tests__/orcaLifecycleService.test.ts
+++ b/apps/desktop/src/main/maker-ipc/__tests__/orcaLifecycleService.test.ts
@@ -929,4 +929,49 @@ describe('enableTeam — 孤儿空团队自动回收 (#3555)', () => {
     });
     expect(deps.markTeamEnded).not.toHaveBeenCalled();
   });
+
+  it('并发 enableTeam:in-flight 初始化中的 team 不会被误判孤儿收口(review P1)', async () => {
+    // 竞态:A 已 createActiveTeam、worker/reservation 尚未落地时,B 进来看到
+    // 零 worker 团队。若无 in-flight 守卫,B 会把 A 的 team 判孤儿标 failed,
+    // A 随后把 worker 写进 failed team 并返回成功——结果与持久化状态不一致。
+    let releaseCreate!: () => void;
+    const gate = new Promise<void>((resolve) => {
+      releaseCreate = resolve;
+    });
+    const { deps, service } = createDeps({
+      // 若守卫失效,B 会调用它并走收口——断言它根本不被咨询。
+      isOrphanedTeamInit: vi.fn(async () => true),
+    });
+    let activeTeam: OrcaTeamSnapshot | null = null;
+    vi.mocked(deps.getActiveTeamByLead).mockImplementation(async () => activeTeam);
+    vi.mocked(deps.createActiveTeam).mockImplementation(async (leadSessionId) => {
+      activeTeam = { id: 'team-a', leadSessionId };
+      return activeTeam;
+    });
+    vi.mocked(deps.createWorkerInTeam).mockImplementation(async (params) => {
+      await gate;
+      return createdWorker({ teamId: params.teamId });
+    });
+
+    const first = service.enableTeam({
+      leadSessionId: 'lead-1',
+      workerAgent: 'codex',
+      role: 'reviewer',
+      label: 'reviewer',
+    });
+    await vi.waitFor(() => expect(deps.createWorkerInTeam).toHaveBeenCalled());
+
+    const second = await service.enableTeam({
+      leadSessionId: 'lead-1',
+      workerAgent: 'codex',
+      role: 'reviewer',
+      label: 'reviewer-2',
+    });
+    expect(second).toMatchObject({ ok: false, errorCode: 'ALREADY_EXISTS' });
+    expect(deps.isOrphanedTeamInit).not.toHaveBeenCalled();
+    expect(deps.markTeamEnded).not.toHaveBeenCalled();
+
+    releaseCreate();
+    await expect(first).resolves.toMatchObject({ teamId: 'team-a' });
+  });
 });

--- a/apps/desktop/src/main/maker-ipc/orcaLifecycleService.ts
+++ b/apps/desktop/src/main/maker-ipc/orcaLifecycleService.ts
@@ -84,6 +84,8 @@ export type OrcaEnableTeamResult =
 export interface OrcaLifecycleDeps {
   getActiveTeamByLead(leadSessionId: string): Promise<OrcaTeamSnapshot | null>;
   createActiveTeam(leadSessionId: string): Promise<OrcaTeamSnapshot>;
+  /** #3555:active team 是否为初始化中断遗留的孤儿(零 worker 行且无存活创建 reservation)。 */
+  isOrphanedTeamInit(teamId: string): Promise<boolean>;
   getWorkerPermissionMode(): OrcaWorkerPermissionMode;
   setWorkerPermissionMode(workerPermissionMode: OrcaWorkerPermissionMode): void;
   createWorkerInTeam(params: OrcaWorkerCreateInTeamParams): Promise<OrcaWorkerCreationResult>;
@@ -335,11 +337,20 @@ export function createOrcaLifecycleService(deps: OrcaLifecycleDeps): OrcaLifecyc
 
     const existing = await deps.getActiveTeamByLead(params.leadSessionId);
     if (existing) {
-      return {
-        ok: false,
-        errorCode: 'ALREADY_EXISTS',
-        message: `lead session already has active orca team ${existing.id}`,
-      };
+      // #3555:初始化补偿依赖原进程的 finally / failCreatedTeam,跨进程不原子——
+      // 进程在 createActiveTeam 之后、worker 落地之前退出会遗留 active 空团队,
+      // 此后每次启用都撞 ALREADY_EXISTS,永久阻塞。零 worker 行(任意状态)且无
+      // 存活创建 reservation 的 team 不可能承载用户状态,按 failed 收口后继续本
+      // 次启用;判定失败时保守维持 ALREADY_EXISTS,绝不误收可能有内容的 team。
+      const orphaned = await deps.isOrphanedTeamInit(existing.id).catch(() => false);
+      if (!orphaned) {
+        return {
+          ok: false,
+          errorCode: 'ALREADY_EXISTS',
+          message: `lead session already has active orca team ${existing.id}`,
+        };
+      }
+      await deps.markTeamEnded(existing.id, 'failed');
     }
 
     const team = await deps.createActiveTeam(params.leadSessionId);

--- a/apps/desktop/src/main/maker-ipc/orcaLifecycleService.ts
+++ b/apps/desktop/src/main/maker-ipc/orcaLifecycleService.ts
@@ -175,6 +175,12 @@ function hasNonEmptyInitialTask(value: string | undefined): value is string {
 }
 
 export function createOrcaLifecycleService(deps: OrcaLifecycleDeps): OrcaLifecycleService {
+  // #3555 review(并发误判竞态):本进程正在初始化的 team(已 createActiveTeam、
+  // worker/reservation 尚未落地)绝不能被并发的 enableTeam 判为孤儿收口——
+  // 否则先到的请求会把 worker 写进已被标 failed 的 team,返回成功但 worker
+  // 不出现在 active team 列表。in-flight 集合覆盖同进程全部并发窗口(含长
+  // 初始化);跨进程残余由 store 侧孤儿判定的最小年龄地板兜底。
+  const initializingTeamIds = new Set<string>();
   const dispatchSource = 'maker-ipc/collab';
 
   function workerPermissionModeForCreate(
@@ -321,10 +327,13 @@ export function createOrcaLifecycleService(deps: OrcaLifecycleDeps): OrcaLifecyc
     }
 
     const team = await deps.createActiveTeam(params.leadSessionId);
+    initializingTeamIds.add(team.id);
     try {
       await activateLeadTeam({ leadSessionId: params.leadSessionId, teamId: team.id });
     } catch (err) {
       return failCreatedTeamOnly({ teamId: team.id, leadSessionId: params.leadSessionId, err });
+    } finally {
+      initializingTeamIds.delete(team.id);
     }
     return { ok: true, teamId: team.id, workerPermissionMode };
   }
@@ -342,7 +351,9 @@ export function createOrcaLifecycleService(deps: OrcaLifecycleDeps): OrcaLifecyc
       // 此后每次启用都撞 ALREADY_EXISTS,永久阻塞。零 worker 行(任意状态)且无
       // 存活创建 reservation 的 team 不可能承载用户状态,按 failed 收口后继续本
       // 次启用;判定失败时保守维持 ALREADY_EXISTS,绝不误收可能有内容的 team。
-      const orphaned = await deps.isOrphanedTeamInit(existing.id).catch(() => false);
+      const orphaned = initializingTeamIds.has(existing.id)
+        ? false
+        : await deps.isOrphanedTeamInit(existing.id).catch(() => false);
       if (!orphaned) {
         return {
           ok: false,
@@ -354,10 +365,14 @@ export function createOrcaLifecycleService(deps: OrcaLifecycleDeps): OrcaLifecyc
     }
 
     const team = await deps.createActiveTeam(params.leadSessionId);
+    initializingTeamIds.add(team.id);
     const created = await deps.createWorkerInTeam({
       ...normalized,
       teamId: team.id,
       workerPermissionMode,
+    }).finally(() => {
+      // worker 行(或其失败补偿)落地后,后续判定交还给持久化状态。
+      initializingTeamIds.delete(team.id);
     });
     if (!created.ok) {
       return failCreatedTeam({

--- a/apps/desktop/src/main/maker-ipc/register.ts
+++ b/apps/desktop/src/main/maker-ipc/register.ts
@@ -312,6 +312,7 @@ import {
   getSessionOrcaRole,
   getWorkerLink,
   isActiveWorkerStatus,
+  isOrphanedTeamInit,
   listWorkersByLead,
   markTeamEnded,
   markWorkersStatusByTeam,
@@ -11059,6 +11060,7 @@ export function registerMakerIpc(maker: Maker, options: RegisterMakerIpcOptions)
 
   const orcaLifecycleService = createOrcaLifecycleService({
     getActiveTeamByLead,
+    isOrphanedTeamInit,
     createActiveTeam: async (leadSessionId) => createActiveTeam({ leadSessionId }),
     getWorkerPermissionMode: getWorkerPermissionModeFromCreationPrefs,
     setWorkerPermissionMode: applyWorkerPermissionModePreference,


### PR DESCRIPTION
## 这次改了什么

### 摘要

fix #3555 的协同永久阻塞部分。协同初始化的补偿(`failCreatedTeam`、reservation 释放)全部依赖原进程继续执行,跨进程不原子:进程在 `createActiveTeam` 之后、worker 落地之前退出(崩溃 / 强退),会遗留 `status='active'` 的空团队;此后该 lead 每次启用协同都在 `enableTeam` 的前置检查撞 `ALREADY_EXISTS`,永久阻塞。

勘察确认 reservation 侧无此问题——DB 层 reserve 事务本就先 DELETE 过期租约(`orcaReserveWorkerCreation`),`WORKER_CREATION_IN_PROGRESS` 至多阻塞到租约到期即自愈;真正没有恢复机制的只有 team 侧。

修复:`enableTeam` 遇既有 active team 时新增孤儿判定 `isOrphanedTeamInit`(orcaTeamStore)——该 team **从未挂上任何 worker 行**(任意状态,含归档;全员归档的 team 是用户可继续 create_worker 的合法状态,不算孤儿)**且无仍在租期内的创建 reservation**(有则说明另一进程正在为它建 worker)。两条都满足的 team 不可能承载用户状态,按 failed 收口(`markTeamEnded`)后继续本次启用;判定不满足或判定本身失败(catch)一律保守维持 `ALREADY_EXISTS`,绝不误收可能有内容的 team。

明确不做:issue 里 Codex turn 反复重连至上限的另一半——按分诊意见其根因尚未被源码或仓库记录证明,需单独取日志与复现证据,不在本 PR(认领评论已说明)。`startTeam` 本就复用既有 team,无此问题,不动。

### 变更类型

- [ ] `feat` 新功能
- [x] `fix` 缺陷修复
- [ ] `refactor` / `perf` 重构或性能优化
- [ ] `docs` / `test` / `chore` 文档、测试或工程维护
- [ ] 其他:

### 范围

- 关联 Issue / 需求:#3555(仅协同 `ALREADY_EXISTS` 阻塞部分)
- 本 PR 包含:store 孤儿判定 + `enableTeam` 回收分支 + register 接线 + service / store 两层回归
- 明确不包含:Codex 重连另行取证;`startTeam` 不动
- 用户可见变化:此前被中断遗留的空团队卡死的对话,再次点启用协同即自动恢复,不再永久 `ALREADY_EXISTS`
- 是否存在 breaking change:无

### UI 变化

无 UI 变化。

## 怎么验证的

### 自动验证

```
pnpm --dir apps/desktop exec vitest run --pool=forks src/main/maker-ipc/__tests__/orcaLifecycleService.test.ts src/main/localDb/__tests__/orcaTeamStore.test.ts
```
结果:

- orcaLifecycleService:31 过(新增 3 条:孤儿收口后继续启用 / 非孤儿维持 ALREADY_EXISTS / 判定抛错保守拒绝)。反证:stash 掉 service 修复后「孤儿收口」用例如预期失败,另两条(断言不变行为)仍过。
- orcaTeamStore:新增真 DB(better-sqlite3 :memory:)用例覆盖零 worker / 活租约 / 过期租约 / 含归档 worker 行四种边界,通过;该文件既有 3 例失败(`no such column: sessions.writable_dirs`——测试 DDL 落后 main 新增列)经 stash 反证与干净 main 逐一相同,零新增。

desktop typecheck 过。

```
pnpm test:unit:related
```
结果:exit 1,两处失败均与本 diff 无关——desktop 段 vitest threads 池 SIGSEGV(本机已知环境问题;本 diff 的 lifecycle 测试在同一门禁运行内先行 31 例全过,日志可证),maker-core 段 `pi-agent.integration` 环境性既有失败。

### 手工验证

无(进程中断语义以注入式 mock 模拟)。

### 未执行的验证

- 未做真实进程 kill 的端到端复现——中断点语义由 deps mock 覆盖,真实进程退出与 mock 在「补偿未执行」这一点上等价。

## 风险

### 风险分类

低风险。回收分支仅命中「零 worker 行 + 无活租约」这一不可能承载用户状态的 team;判定失败 fail-safe 到既有 ALREADY_EXISTS 行为。

### 影响与回滚

影响面:desktop main 的协同启用入口(IPC 与 MCP enable_collab_mode 共用同一 service)。远程与移动端适配:入口在 desktop main,远程触发的启用走同一代码路径,行为一致、无需额外适配。回滚:revert 单 commit 即可,无 schema 变更(孤儿判定只读既有表)。

### 提交前检查

- [x] 已运行相关单测、typecheck 与 `pnpm test:unit:related`(失败项已逐一归因为本机环境 / 基线)
- [x] commit 带 DCO 签名(Signed-off-by: ficowang <fico@xd.com>)
- [x] diff 聚焦单一问题,无无关改动
