### PR TITLE
fix(desktop): drizzle proxy 写语句 .returning() 回传真实命中行

### DIFF
--- a/apps/desktop/src/main/localDb/client/__tests__/drizzleProxy.test.ts
+++ b/apps/desktop/src/main/localDb/client/__tests__/drizzleProxy.test.ts
@@ -50,6 +50,7 @@ const DRIZZLE_PROXY_SCHEMA = [
       used_project_context INTEGER NOT NULL DEFAULT 0,
       codex_history_has_product_prompt INTEGER,
       extra_dirs TEXT NOT NULL DEFAULT '[]',
+      writable_dirs TEXT NOT NULL DEFAULT '[]',
       remote_host_id TEXT,
       active_turn_started_at INTEGER,
       active_turn_pid INTEGER,
@@ -189,6 +190,56 @@ describe('drizzle proxy', () => {
       // DELETE 同样透传
       const del = await client.drizzle.delete(sessions).where(eq(sessions.id, 's1')).run();
       expect(del.changes).toBe(1);
+    } finally {
+      await client.dispose();
+    }
+  });
+
+  it('UPDATE ... RETURNING 回传命中行,不再固定返回 [](#3496 CAS 自愈误拦)', async () => {
+    // 回归测试 — 防退化:compareAndClearSdkSessionId 用
+    // .returning({ id }) 的行数判断条件 UPDATE 是否命中。此前 executeAll 对
+    // 非 select builder 固定返回 [],磁盘上成功的 CAS 清除被判失败,
+    // invalid-resume 的一次性 fresh fallback 被「refusing to overwrite
+    // concurrent ...」拦成 UI 终态错误(No conversation found)。
+    const client = await createDbClient({ useInlineWorker: true });
+    try {
+      await applyDrizzleProxySchema(client);
+      await client.drizzle
+        .insert(sessions as never)
+        .values({ id: 's1', sdkSessionId: 'sdk-old', title: 'a', createdAt: 1, updatedAt: 1 } as never);
+
+      // 命中:返回被更新行(CAS 判胜)
+      const hit = await client.drizzle
+        .update(sessions)
+        .set({ sdkSessionId: null })
+        .where(eq(sessions.sdkSessionId, 'sdk-old'))
+        .returning({ id: sessions.id });
+      expect(hit).toEqual([{ id: 's1' }]);
+
+      // 未命中:返回 [](CAS 判负),且与「查询失败」可区分地正常 resolve
+      const miss = await client.drizzle
+        .update(sessions)
+        .set({ sdkSessionId: null })
+        .where(eq(sessions.sdkSessionId, 'sdk-old'))
+        .returning({ id: sessions.id });
+      expect(miss).toEqual([]);
+
+      // 字段别名映射:key 用调用方命名,不透传裸列名
+      const aliased = await client.drizzle
+        .update(sessions)
+        .set({ title: 'renamed' })
+        .where(eq(sessions.id, 's1'))
+        .returning({ sessionId: sessions.id, newTitle: sessions.title });
+      expect(aliased).toEqual([{ sessionId: 's1', newTitle: 'renamed' }]);
+
+      // .returning().get() 走 executeGet 分支,同样按别名映射
+      const got = await client.drizzle
+        .update(sessions)
+        .set({ title: 'got' })
+        .where(eq(sessions.id, 's1'))
+        .returning({ sessionId: sessions.id })
+        .get();
+      expect(got).toEqual({ sessionId: 's1' });
     } finally {
       await client.dispose();
     }

--- a/apps/desktop/src/main/localDb/client/drizzleProxy.ts
+++ b/apps/desktop/src/main/localDb/client/drizzleProxy.ts
@@ -95,14 +95,33 @@ async function executeAll<T>(builder: AnyObject, transport: DbTransport): Promis
       mapResultRow(fieldsList, row, normalizeJoins(builder.joinsNotNullableMap)) as T,
     );
   }
-  // 非 SELECT(INSERT/UPDATE/DELETE 无 RETURNING)走 'run' op。worker 内 'query' op
-  // 用 stmt.all(),better-sqlite3 对写操作 .all() 会抛 "This statement does not
-  // return data. Use run() instead"。await db.insert(...) / db.update(...) 这种隐式
-  // terminal 落到 executeAll,调用方通常忽略返回值。RETURNING 当前未使用,未来若加
-  // .returning() 需要在此分支(查 SQL 末尾 RETURNING)再走 query。
+  // 写语句带 .returning()(#3496):此前该分支固定回 [],UPDATE ... RETURNING 在
+  // 磁盘上成功、调用方却判未命中 —— compareAndClearSdkSessionId 的 CAS 清除被
+  // 误判失败,invalid-resume 的一次性 fresh fallback 被拦成 UI 终态错误。
+  // config.returning 是 drizzle 已排序的字段列表;RETURNING 语句是 reader
+  // statement,worker 'rawAll'(stmt.raw().all())合法,按 select 同款映射回行。
+  const returningFields = returningFieldsList(builder);
   const { sql, params } = toSql(builder);
+  if (returningFields) {
+    const rawRows = await transport.send<unknown[][]>('rawAll', { sql, params });
+    return rawRows.map((row) => mapResultRow(returningFields, row, undefined) as T);
+  }
+  // 非 SELECT 且无 RETURNING:走 'run' op(worker 'query' 用 stmt.all(),
+  // better-sqlite3 对纯写语句 .all() 会抛 "This statement does not return
+  // data")。await db.insert(...) / db.update(...) 这种隐式 terminal 落到
+  // executeAll,调用方忽略返回值。
   await transport.send('run', { sql, params });
   return [];
+}
+
+/** drizzle 写 builder 的 .returning() 字段列表(SelectedFieldsOrdered);无则 null。 */
+function returningFieldsList(value: AnyObject): SelectedField[] | null {
+  const config = value.config;
+  if (!config || typeof config !== 'object') return null;
+  const returning = (config as { returning?: unknown }).returning;
+  return Array.isArray(returning) && returning.length > 0
+    ? (returning as SelectedField[])
+    : null;
 }
 
 async function executeGet<T>(builder: AnyObject, transport: DbTransport): Promise<T | undefined> {
@@ -114,7 +133,14 @@ async function executeGet<T>(builder: AnyObject, transport: DbTransport): Promis
       ? (mapResultRow(fieldsList, row, normalizeJoins(builder.joinsNotNullableMap)) as T)
       : undefined;
   }
+  // 写语句带 .returning() 的 .get():与 executeAll 同因(#3496),字段别名与列名
+  // 不一致时 queryOne 的按列名对象会映射错,统一走 rawGet + mapResultRow。
+  const returningFields = returningFieldsList(builder);
   const { sql, params } = toSql(builder);
+  if (returningFields) {
+    const row = await transport.send<unknown[] | undefined>('rawGet', { sql, params });
+    return row ? (mapResultRow(returningFields, row, undefined) as T) : undefined;
+  }
   return transport.send<T | undefined>('queryOne', { sql, params });
 }
 


### PR DESCRIPTION
## 这次改了什么

### 摘要

fix #3496。重开长期闲置(CLI `cleanupPeriodDays=30` 清理过转录)的 Claude Code 任务时,Cindy 本已具备完整的 invalid-resume 自愈链:transcript preflight → 运行期识别 → `compareAndClearSdkSessionId` CAS 清除 → 一次性 fresh fallback。但链条断在本地数据库代理的返回契约上:

`drizzleProxy.executeAll()` 对无 select 字段的 builder 统一走 worker `run` op 并**固定返回 `[]`**(源码注释自己写着「RETURNING 当前未使用,未来若加需再走 query」)。于是 `UPDATE ... RETURNING` 在磁盘上已成功清空 `sdk_session_id`,调用方拿到的仍是空数组 → CAS 被误判失败 → 恢复逻辑按「refusing to overwrite concurrent ...」放弃 → 本可静默自愈的场景暴露为 UI 红色终态错误 `No conversation found with session ID`。

修复:`config.returning`(drizzle 已排序的字段列表)存在时,`executeAll` 改走 `rawAll`——RETURNING 语句是 reader statement,`stmt.raw().all()` 合法——并按 select 同款 `mapResultRow` 映射回行;`.returning().get()` 同因改走 `rawGet`,别名字段不再按裸列名透传。无 RETURNING 的写语句维持 `run` op 与 `changes` 契约完全不变。

顺带:该测试文件的最小 DDL 落后 main 新增的 `sessions.writable_dirs` 列,4 例已全部挂在此(干净 main 可复现),同步追平使本回归可运行。

### 变更类型

- [ ] `feat` 新功能
- [x] `fix` 缺陷修复
- [ ] `refactor` / `perf` 重构或性能优化
- [ ] `docs` / `test` / `chore` 文档、测试或工程维护
- [ ] 其他:

### 范围

- 关联 Issue / 需求:#3496
- 本 PR 包含:executeAll / executeGet 的 RETURNING 分支 + 回归(命中回行 / 未命中回空 / 别名映射 / .get() 变体)+ 测试 DDL 追平
- 明确不包含:resume 语义本身(preflight / fresh fallback / CAS 调用方 `compareAndClearSdkSessionId` 一行未动,修好契约后其 `changed.length > 0` 判断自然成立)
- 用户可见变化:30 天闲置后的旧 Claude 任务重开时静默续为新会话,不再弹 No conversation found 终态错误
- 是否存在 breaking change:无(此前该路径固定返回 `[]`,不存在依赖旧值的正确用法)

### UI 变化

无 UI 变化。

## 怎么验证的

### 自动验证

```
pnpm --dir apps/desktop exec vitest run --pool=forks src/main/localDb/client/__tests__/drizzleProxy.test.ts
```
结果:4 过(3 例既有 + 新增 RETURNING 回归)。反证 ①:stash 全部改动后该文件 3 例全部失败于 `no such column: sessions.writable_dirs`(基线即挂,与本 diff 无关);反证 ②:仅 stash `drizzleProxy.ts` 时新增回归如预期失败、其余照过。

desktop typecheck 过。

```
pnpm test:unit:related
```
结果:exit 1,唯一失败为 maker-core 段 pi-agent.integration(本机环境性既有失败,与本 diff 无关);desktop 段本轮通过。注:门禁的 desktop 命令行 `--exclude src/main/localDb/**`,本 diff 测试文件的覆盖以上文定向运行(含双反证)为准。

### 手工验证

无(契约级行为全部由真 better-sqlite3 + inline worker 端到端断言)。

### 未执行的验证

- 未做真实 30 天闲置 Claude 会话的端到端复现(触发条件是 CLI 清理转录,由 CAS 契约测试等价覆盖;issue 分诊已把断点钉在本契约上)。

## 风险

### 风险分类

低风险。仅当 builder 携带 `config.returning` 时行为改变,该路径此前固定返回 `[]`、不存在正确消费方;run/changes 契约有既有回归锁住。

### 影响与回滚

影响面:desktop main 的本地 DB 代理与其所有 `.returning()` 调用方(当前仓内即 CAS 清除一处)。远程与移动端适配:本地 DB 代理只在 desktop main 使用,远程/移动端不直接消费该代理,无需适配。回滚:revert 单 commit,无 schema 变更。

### 提交前检查

- [x] 已运行定向单测(含双反证)与 typecheck;related 门禁分批执行中,结果如实补充
- [x] commit 带 DCO 签名(Signed-off-by: ficowang <fico@xd.com>)
- [x] diff 聚焦单一问题,无无关改动
