### PR TITLE
fix(desktop): Codex 导入统一采用 session_index 的用户自定义标题

### DIFF
--- a/apps/desktop/src/main/__tests__/codexLocalSessions.test.ts
+++ b/apps/desktop/src/main/__tests__/codexLocalSessions.test.ts
@@ -416,6 +416,39 @@ describe('Codex local session import', () => {
     expect(row.updatedAt).toBe(2_000_000);
   });
 
+  it('batch import parses session_index.jsonl once per home while unchanged (#3673 review P2)', async () => {
+    // 按 ID 导入对每个所选会话都会解析一次索引;(mtimeMs, size) 缓存把同一
+    // home 未变化的索引收敛到单次读取,批量导入不再随会话数线性重复 IO。
+    const dbPath = createStateDb(externalHome);
+    for (const id of [threadId, execThreadId]) {
+      const rolloutPath = path.join(externalHome, 'sessions', `rollout-2026-05-13-${id}.jsonl`);
+      fs.mkdirSync(path.dirname(rolloutPath), { recursive: true });
+      fs.writeFileSync(rolloutPath, '');
+      insertThread(dbPath, id, rolloutPath, { updatedAt: 1_000, title: 'Auto Title' });
+    }
+    fs.writeFileSync(
+      path.join(externalHome, 'session_index.jsonl'),
+      `${[
+        JSON.stringify({ id: threadId, thread_name: 'Named A', updated_at: 2_000 }),
+        JSON.stringify({ id: execThreadId, thread_name: 'Named B', updated_at: 2_000 }),
+      ].join('\n')}\n`,
+    );
+
+    const readSpy = vi.spyOn(fs, 'readFileSync');
+    const result = await importExternalCodexSessions([threadId, execThreadId]);
+    const indexReads = readSpy.mock.calls.filter(
+      ([target]) => typeof target === 'string' && target.endsWith('session_index.jsonl'),
+    );
+    readSpy.mockRestore();
+
+    expect(result).toMatchObject({ inserted: 2 });
+    expect(indexReads).toHaveLength(1);
+    const titles = (currentTestDb()
+      .prepare('SELECT title FROM sessions ORDER BY title')
+      .all() as Array<{ title: string }>).map((r) => r.title);
+    expect(titles).toEqual(['Named A', 'Named B']);
+  });
+
   it('filters Codex source JSON subagent rows even when thread_source is missing', async () => {
     const dbPath = createStateDb(externalHome);
     const rolloutPath = path.join(externalHome, 'sessions', `rollout-2026-05-13-${threadId}.jsonl`);

--- a/apps/desktop/src/main/__tests__/codexLocalSessions.test.ts
+++ b/apps/desktop/src/main/__tests__/codexLocalSessions.test.ts
@@ -369,6 +369,53 @@ describe('Codex local session import', () => {
     expect(row.updatedAt).toBe(before.updatedAt);
   });
 
+  it('explicit import prefers session_index thread_name over stale state DB title (#3482)', async () => {
+    // Codex 侧重命名写入 session_index.jsonl 的 thread_name;state DB 行的 title
+    // 仍是旧自动标题。导入必须按 thread_name > state DB 标题取值,且索引
+    // updated_at 合入有效更新时间。
+    const dbPath = createStateDb(externalHome);
+    const rolloutPath = path.join(externalHome, 'sessions', `rollout-2026-05-13-${threadId}.jsonl`);
+    fs.mkdirSync(path.dirname(rolloutPath), { recursive: true });
+    fs.writeFileSync(rolloutPath, '');
+    insertThread(dbPath, threadId, rolloutPath, { updatedAt: 1_000, title: 'Auto Title' });
+    fs.writeFileSync(
+      path.join(externalHome, 'session_index.jsonl'),
+      `${JSON.stringify({ id: threadId, thread_name: 'My Renamed Session', updated_at: 2_000 })}\n`,
+    );
+
+    const first = await importExternalCodexSessions([threadId]);
+    expect(first).toMatchObject({ inserted: 1 });
+    const row = currentTestDb()
+      .prepare('SELECT title, updated_at AS updatedAt FROM sessions WHERE id = ?')
+      .get(`codex-${threadId}`) as { title: string; updatedAt: number };
+    expect(row.title).toBe('My Renamed Session');
+    // timestampFromAny 把小数值按秒解释并归一为毫秒:2_000s → 2_000_000ms。
+    expect(row.updatedAt).toBe(2_000_000);
+  });
+
+  it('re-import after Codex-side rename refreshes the stored title (#3482)', async () => {
+    const dbPath = createStateDb(externalHome);
+    const rolloutPath = path.join(externalHome, 'sessions', `rollout-2026-05-13-${threadId}.jsonl`);
+    fs.mkdirSync(path.dirname(rolloutPath), { recursive: true });
+    fs.writeFileSync(rolloutPath, '');
+    insertThread(dbPath, threadId, rolloutPath, { updatedAt: 1_000, title: 'Auto Title' });
+
+    const first = await importExternalCodexSessions([threadId]);
+    expect(first).toMatchObject({ inserted: 1 });
+
+    fs.writeFileSync(
+      path.join(externalHome, 'session_index.jsonl'),
+      `${JSON.stringify({ id: threadId, thread_name: 'Renamed Later', updated_at: 2_000 })}\n`,
+    );
+    const again = await importExternalCodexSessions([threadId]);
+    expect(again).toMatchObject({ inserted: 0, updated: 1 });
+    const row = currentTestDb()
+      .prepare('SELECT title, updated_at AS updatedAt FROM sessions WHERE id = ?')
+      .get(`codex-${threadId}`) as { title: string; updatedAt: number };
+    expect(row.title).toBe('Renamed Later');
+    expect(row.updatedAt).toBe(2_000_000);
+  });
+
   it('filters Codex source JSON subagent rows even when thread_source is missing', async () => {
     const dbPath = createStateDb(externalHome);
     const rolloutPath = path.join(externalHome, 'sessions', `rollout-2026-05-13-${threadId}.jsonl`);

--- a/apps/desktop/src/main/maker-host/codex-local-sessions.ts
+++ b/apps/desktop/src/main/maker-host/codex-local-sessions.ts
@@ -316,6 +316,8 @@ interface CodexThreadSummary {
 
 interface CodexSessionIndexEntry {
   title: string;
+  /** 用户真实自定义标题(thread_name > title,无 fallback);无则 null(#3482)。 */
+  customTitle: string | null;
   updatedAt: number | null;
 }
 
@@ -3780,6 +3782,7 @@ function readThreads(
   try {
     db = openReadonlyDb(dbPath);
     if (!tableExists(db, 'threads')) return null;
+    const index = readSessionIndex(home);
     const orderSql = buildThreadOrderSql(db);
     const rows = db.prepare(`
       SELECT *
@@ -3794,7 +3797,7 @@ function readThreads(
         continue;
       }
       if (threads.length >= MAX_THREADS_PER_HOME) continue;
-      const thread = normalizeThreadRow(home, dbPath, row, projectlessThreadIds);
+      const thread = normalizeThreadRow(home, dbPath, row, projectlessThreadIds, index);
       if (thread) threads.push(thread);
     }
     return { threads, rejectedThreadIds: [...rejectedThreadIds] };
@@ -3834,7 +3837,7 @@ async function readThreadsFromRollouts(
       continue;
     }
     if (out.length >= MAX_THREADS_PER_HOME) continue;
-    const thread = normalizeThreadRow(home, null, row, projectlessThreadIds);
+    const thread = normalizeThreadRow(home, null, row, projectlessThreadIds, index);
     if (thread) out.push(thread);
   }
   return { threads: out, rejectedThreadIds: [...rejectedThreadIds] };
@@ -3857,8 +3860,10 @@ function readSessionIndex(home: string): Map<string, CodexSessionIndexEntry> {
       if (!isRecord(obj)) continue;
       const id = stringValue(obj.id);
       if (!isLikelyThreadId(id)) continue;
+      const customTitle = firstNonEmpty(stringValue(obj.thread_name), stringValue(obj.title), '');
       out.set(id, {
-        title: firstNonEmpty(stringValue(obj.thread_name), stringValue(obj.title), 'Codex Session'),
+        title: customTitle || 'Codex Session',
+        customTitle: customTitle || null,
         updatedAt: timestampFromAny(obj.updated_at),
       });
     }
@@ -3995,7 +4000,7 @@ function normalizeRolloutFile(
 ): CodexThreadSummary | null {
   const row = readRolloutThreadRow(file, index);
   if (!row || !isTopLevelThreadRow(row)) return null;
-  return normalizeThreadRow(home, null, row, projectlessThreadIds);
+  return normalizeThreadRow(home, null, row, projectlessThreadIds, index);
 }
 
 function readRolloutThreadRow(
@@ -4634,7 +4639,8 @@ function findThreadByIdInHome(home: string, threadId: string): CodexThreadSummar
     if (!tableExists(db, 'threads')) return findExternalThreadByIdFromRollouts(home, threadId);
     const row = db.prepare('SELECT * FROM threads WHERE id = ? LIMIT 1').get(threadId) as SqlRow | undefined;
     if (!row || !isTopLevelThreadRow(row)) return findExternalThreadByIdFromRollouts(home, threadId);
-    return normalizeThreadRow(home, dbPath, row, projectlessThreadIds) ?? findExternalThreadByIdFromRollouts(home, threadId);
+    return normalizeThreadRow(home, dbPath, row, projectlessThreadIds, readSessionIndex(home))
+      ?? findExternalThreadByIdFromRollouts(home, threadId);
   } catch {
     return findExternalThreadByIdFromRollouts(home, threadId);
   } finally {
@@ -4755,17 +4761,27 @@ function normalizeThreadRow(
   dbPath: string | null,
   row: SqlRow,
   projectlessThreadIds: ReadonlySet<string>,
+  index?: ReadonlyMap<string, CodexSessionIndexEntry>,
 ): CodexThreadSummary | null {
   const threadId = stringValue(row.id);
   if (!isLikelyThreadId(threadId)) return null;
+  // #3482:session_index.jsonl 的 thread_name 是用户在 Codex 侧的重命名,
+  // state DB 行里的 title 可能仍是旧的自动标题;索引记录存在时按
+  // thread_name > title(index) > state DB/rollout 标题 兜底链取值,并把索引
+  // updated_at 合入有效更新时间(重命名要能通过导入 upsert 的时间门)。
+  const indexEntry = index?.get(threadId);
   const archived = numberValue(row.archived) === 1;
   const baseUpdatedAt = timestampMs(row.updated_at_ms, row.updated_at) ?? Date.now();
   const archivedAt = timestampFromAny(row.archived_at);
-  const updatedAt = archived && archivedAt ? Math.max(baseUpdatedAt, archivedAt) : baseUpdatedAt;
+  const rowUpdatedAt = archived && archivedAt ? Math.max(baseUpdatedAt, archivedAt) : baseUpdatedAt;
+  const updatedAt = indexEntry?.updatedAt
+    ? Math.max(rowUpdatedAt, indexEntry.updatedAt)
+    : rowUpdatedAt;
   const createdAt = timestampMs(row.created_at_ms, row.created_at) ?? updatedAt;
   const cwd = stringValue(row.cwd) || os.homedir();
   const rolloutPath = stringValue(row.rollout_path);
   const title = firstNonEmpty(
+    indexEntry?.customTitle ?? '',
     stringValue(row.title),
     stringValue(row.preview),
     stringValue(row.first_user_message).split(/\r?\n/)[0],

--- a/apps/desktop/src/main/maker-host/codex-local-sessions.ts
+++ b/apps/desktop/src/main/maker-host/codex-local-sessions.ts
@@ -3843,10 +3843,44 @@ async function readThreadsFromRollouts(
   return { threads: out, rejectedThreadIds: [...rejectedThreadIds] };
 }
 
+/**
+ * session_index.jsonl 解析缓存(review #3673 P2):按 ID 导入路径对每个所选
+ * 会话 × 每个候选 home 都要读一次索引,批量导入时主进程同步 IO 随会话数 ×
+ * home 数 × 索引大小线性增长。以 (mtimeMs, size) 做新鲜度判据 —— 索引是
+ * append-only jsonl,追加必然改变 size,同秒内 mtime 粒度不足由 size 兜住;
+ * appendSessionIndexEntry 写入后下一次读取自然失效重解析。命中时直接复用
+ * 解析结果,跨扫描/导入批次同样生效。返回的 Map 视为只读,调用方只做 .get()。
+ */
+const sessionIndexCache = new Map<
+  string,
+  { mtimeMs: number; size: number; entries: Map<string, CodexSessionIndexEntry> }
+>();
+
 function readSessionIndex(home: string): Map<string, CodexSessionIndexEntry> {
   const indexPath = path.join(home, 'session_index.jsonl');
+  let stat: fs.Stats;
+  try {
+    stat = fs.statSync(indexPath);
+  } catch {
+    // 索引缺席(或不可 stat):行为与旧实现的 existsSync 早退一致。不缓存
+    // 空结果 —— 文件随时可能出现,缺席路径本身已是零解析成本。
+    sessionIndexCache.delete(home);
+    return new Map();
+  }
+  const cached = sessionIndexCache.get(home);
+  if (cached && cached.mtimeMs === stat.mtimeMs && cached.size === stat.size) {
+    return cached.entries;
+  }
+  const entries = parseSessionIndexFile(indexPath, home);
+  sessionIndexCache.set(home, { mtimeMs: stat.mtimeMs, size: stat.size, entries });
+  return entries;
+}
+
+function parseSessionIndexFile(
+  indexPath: string,
+  home: string,
+): Map<string, CodexSessionIndexEntry> {
   const out = new Map<string, CodexSessionIndexEntry>();
-  if (!fs.existsSync(indexPath)) return out;
   try {
     const lines = fs.readFileSync(indexPath, 'utf-8').split(/\r?\n/);
     for (const line of lines) {


### PR DESCRIPTION
## 这次改了什么

### 摘要

fix #3482。Codex 侧对会话重命名时,自定义标题写入 `session_index.jsonl` 的 `thread_name`;state SQLite 的 `threads.title` 仍是旧自动标题。Cindy 此前只有 rollout 回退路径消费该索引——常见的 state DB 扫描(`readThreads` → `normalizeThreadRow` 直接取 `row.title`)与按 ID 导入(`findThreadByIdInHome`)都绕过它,用户精心起的名字带不到 Cindy 会话列表,多会话场景难以辨认。

修复:`normalizeThreadRow` 增加可选 index 参数,统一标题解析为 `thread_name > title(index) > state DB/rollout 标题 > "Codex Session"`;索引条目新增 `customTitle`(真实重命名值,不带 `"Codex Session"` fallback),避免「索引无自定义名」时哨兵字符串反过来覆盖 state DB 里的正常标题。同时把索引 `updated_at` 合入 thread 的有效更新时间——否则「导入过一次 → Codex 里重命名 → 再导入」会被 upsert 的 `updated_at` 时间门挡住,标题永远刷不进来。state DB 扫描、rollout 扫描、按 ID 导入三条路径共用同一索引解析。

### 变更类型

- [ ] `feat` 新功能
- [x] `fix` 缺陷修复
- [ ] `refactor` / `perf` 重构或性能优化
- [ ] `docs` / `test` / `chore` 文档、测试或工程维护
- [ ] 其他:

### 范围

- 关联 Issue / 需求:#3482
- 本 PR 包含:标题解析统一(三条路径)+ 索引 updated_at 合入 + 两条导入回归(首次导入取 thread_name / 重命名后再导入刷新标题)
- 明确不包含:未知 schema 的猜测性兼容(分诊意见:提报环境若仍不命中,需先收集该版本 `session_index.jsonl` 与 state 行再定)
- 用户可见变化:导入的 Codex 会话在 Cindy 列表显示 Codex 侧重命名后的标题;重命名后重新导入也会刷新
- 是否存在 breaking change:无(索引缺席或无自定义名时,取值链与既有行为完全一致)

### UI 变化

无 UI 变化(仅数据正确性,展示组件不动)。

## 怎么验证的

### 自动验证

```
pnpm --dir apps/desktop exec vitest run --pool=forks src/main/__tests__/codexLocalSessions.test.ts
```
结果:新增 2 条回归通过(首次导入优先 thread_name 且 updated_at 合入索引值;重命名后再导入刷新标题);该文件既有 10 例失败经 stash 反证与干净 main 逐一相同(测试内存库 DDL 落后 main 的既有基线),零新增。反证:仅 stash `codex-local-sessions.ts` 时新增 2 条如预期失败。

desktop typecheck 过。

```
pnpm test:unit:related
```
结果:exit 1,两处失败均与本 diff 无关——desktop 段 vitest threads 池 SIGSEGV(本机已知环境问题),maker-core 段 pi-agent.integration 环境性既有失败。注:门禁的 desktop 命令行 `--exclude src/main/__tests__/*LocalSessions.test.ts`,本 diff 测试文件的覆盖以上文定向运行为准。

### 手工验证

无(导入行为由真 SQLite state DB + 真实 session_index.jsonl 文件端到端断言)。

### 未执行的验证

- 未做 Codex Desktop 安装版的端到端验证(本机以 CLI 数据形态覆盖;分诊建议的 Desktop/CLI 双端安装版验证需要真实 Codex Desktop 环境,认领评论已声明)。

## 风险

### 风险分类

低风险。索引缺席/无自定义名时行为不变;customTitle 设计排除了哨兵覆盖;时间合入只会让 updated_at 变大(单调),不影响归档时间语义。

### 影响与回滚

影响面:desktop main 的 Codex 会话扫描与导入。远程与移动端适配:导入发生在 desktop main,产物是普通 sessions 行,远程/移动端按既有会话同步链路消费,无需适配。回滚:revert 单 commit,无 schema 变更。

### 提交前检查

- [x] 已运行定向单测(含双反证)与 typecheck;related 门禁分批执行中,结果如实补充
- [x] commit 带 DCO 签名(Signed-off-by: ficowang <fico@xd.com>)
- [x] diff 聚焦单一问题,无无关改动
