### PR TITLE
fix(desktop): embedding 确定性 INVALID_MODEL 终态化并熔断 source

### DIFF
--- a/apps/desktop/src/main/embedding-host/EmbeddingWorker.ts
+++ b/apps/desktop/src/main/embedding-host/EmbeddingWorker.ts
@@ -344,7 +344,25 @@ export class EmbeddingWorker {
           // 内存态,重启后首批失败会再次熔断,端点修好后自然恢复。
           // 其余错误码(AUTH_FAILED 可因重登恢复、网络/限流为瞬态)维持
           // 既有 backoff + attempts 计数语义不变。
-          const terminal = code === 'INVALID_MODEL';
+          //
+          // 但 INVALID_MODEL 这个 code 本身语义过宽(review #3674 P1):client 的
+          // mapStatusToCode 把 400/404/422 乃至一切未识别状态都映射成它,输入级
+          // 400(单条超长/畸形输入)会被误判成模型级失配。code 不可靠,判据改成
+          // 确定性是否跟着"模型"走 —— 用极小探针输入对同 model 补发一次探测:
+          //   - 探针同样 INVALID_MODEL → 端点确实不吃这个模型(#3416 场景)→ 终态+熔断;
+          //   - 探针成功 → 模型可用,是这批输入的问题 → 维持既有 backoff 语义
+          //     (确定性输入错误按 attempts 上限有界收敛,与修复前行为一致);
+          //   - 探针遇到其它错误(网络/限流)→ 不下结论,fail-open 不熔断。
+          // 成本有界:模型级场景熔断后不再产生新探针;输入级场景每 (source, model)
+          // 每 tick 至多一次。
+          const terminal =
+            code === 'INVALID_MODEL' && !this.aborted
+              ? await this.probeModelLevelInvalidModel(source, modelId as string)
+              : false;
+          // 探针是一次网络往返,期间可能已触发 stop() —— 与 embed 后的检查点同款,
+          // abort 后绝不再开写事务;该批 job 保持 pending,下次启动续跑。
+          if (this.aborted) return;
+          if (isProviderSuspended(source)) break;
           const fc = await this.recordFailureBatch(modelJobs, `[${code}] ${msg}`, terminal);
           failCount += fc;
           if (terminal && !isProviderSuspended(source)) {
@@ -371,6 +389,46 @@ export class EmbeddingWorker {
         failCount,
       }),
     );
+  }
+
+  /**
+   * INVALID_MODEL 的模型级/输入级仲裁探针(review #3674 P1)。
+   * 返回 true = 端点对极小合法输入也报 INVALID_MODEL,确认模型级失配,
+   * 调方可安全终态化并熔断;其余一律 false(探针成功 = 输入级;探针遇到
+   * 别的错误 = 不下结论,fail-open 交回既有 backoff)。
+   * 探针文本带时间戳后缀绕开 client 的 LRU 缓存 —— 命中旧缓存的"成功"
+   * 证明不了端点现在的状态。本地 catalog 白名单外的模型在 client 入口
+   * 同步抛 INVALID_MODEL,探针不打网络、零成本得出模型级结论。
+   */
+  private async probeModelLevelInvalidModel(source: string, modelId: string): Promise<boolean> {
+    try {
+      await this.opts.getClient().embed({
+        texts: [`cindy embedding probe ${Date.now()}`],
+        model: modelId as never,
+      });
+      this.opts.log.warn(
+        JSON.stringify({
+          event: 'embeddingWorker.invalidModelProbe.requestLevel',
+          source,
+          modelId,
+          reason: 'probe input embedded fine; batch failure is input-specific, keeping backoff semantics',
+        }),
+      );
+      return false;
+    } catch (probeErr) {
+      const probeCode = probeErr instanceof EmbeddingError ? probeErr.code : 'UNKNOWN';
+      if (probeCode === 'INVALID_MODEL') return true;
+      this.opts.log.warn(
+        JSON.stringify({
+          event: 'embeddingWorker.invalidModelProbe.inconclusive',
+          source,
+          modelId,
+          probeCode,
+          reason: 'probe failed with a different code; not suspending',
+        }),
+      );
+      return false;
+    }
   }
 
   /**

--- a/apps/desktop/src/main/embedding-host/EmbeddingWorker.ts
+++ b/apps/desktop/src/main/embedding-host/EmbeddingWorker.ts
@@ -31,6 +31,7 @@ import {
   getProvider,
   isProviderSuspended,
   listSuspendedProviderSources,
+  setProviderSuspended,
   type EmbeddingJobForProvider,
 } from './providers';
 
@@ -335,11 +336,29 @@ export class EmbeddingWorker {
               count: modelJobs.length,
             }),
           );
-          // AUTH_FAILED / INVALID_MODEL 在 client 内已经判断为不可重试 — 但 worker 这层
-          // 不分代码, 一律走 backoff + attempts 计数, MAX_ATTEMPTS 后 → 'failed'。
-          // 这样 INVALID_MODEL 不会立刻冲 5 次烧 token, 因为 client 抛错前没打 API。
-          const fc = await this.recordFailureBatch(modelJobs, `[${code}] ${msg}`);
+          // #3416:INVALID_MODEL 是确定性失败(模型 id 对当前端点必然 400,
+          // 目录门禁只查打包 catalog、不碰真实端点,自配置网关下必失配)——
+          // 重试永远不可能成功。整批立即终态 + 熔断该 source:后续 tick 的
+          // SQL 过滤(listSuspendedProviderSources)不再取它的 job,语义索引
+          // 停止空转;熔断态可经 isEmbeddingSourceSuspended 查询。挂起是
+          // 内存态,重启后首批失败会再次熔断,端点修好后自然恢复。
+          // 其余错误码(AUTH_FAILED 可因重登恢复、网络/限流为瞬态)维持
+          // 既有 backoff + attempts 计数语义不变。
+          const terminal = code === 'INVALID_MODEL';
+          const fc = await this.recordFailureBatch(modelJobs, `[${code}] ${msg}`, terminal);
           failCount += fc;
+          if (terminal && !isProviderSuspended(source)) {
+            setProviderSuspended(source, true);
+            this.opts.log.error(
+              JSON.stringify({
+                event: 'embeddingWorker.source.suspendedTerminal',
+                source,
+                modelId,
+                code,
+                reason: 'deterministic embedding failure; suspending source until restart or manual resume',
+              }),
+            );
+          }
         }
       }
     }
@@ -390,12 +409,17 @@ export class EmbeddingWorker {
    * attempts >= MAX → status='failed' 终态。
    * 返回失败数量 (>= MAX 进 'failed' 终态的部分)。
    */
-  private async recordFailureBatch(jobs: JobRow[], errMsg: string): Promise<number> {
+  private async recordFailureBatch(
+    jobs: JobRow[],
+    errMsg: string,
+    terminal = false,
+  ): Promise<number> {
     const now = Date.now();
     const result = await this.opts.getDbClient().tx('embedding.recordFailures', {
       jobs: jobs.map((job) => ({ rowid: job.rowid, attempts: job.attempts })),
       errMsg: truncate(errMsg, 2000),
       now,
+      terminal,
     });
     return result.failCount;
   }

--- a/apps/desktop/src/main/embedding-host/__tests__/hostLifecycle.test.ts
+++ b/apps/desktop/src/main/embedding-host/__tests__/hostLifecycle.test.ts
@@ -293,6 +293,58 @@ describe('embedding-host 多 consumer 启停', () => {
     expect(tx).toHaveBeenCalledWith('embedding.markDone', { rowids: [1] });
     expect(embed).not.toHaveBeenCalled();
   });
+
+  it('INVALID_MODEL 终态化:整批 terminal 记失败并熔断该 source;AUTH_FAILED 保持退避语义 (#3416)', async () => {
+    const host = await loadHost();
+    const { EmbeddingWorker } = await import('../EmbeddingWorker');
+    const { registerProvider } = await import('../providers');
+    const { EmbeddingError } = await import('@cindy/embedding-client');
+    registerProvider({
+      source: 'chat',
+      getTextsForJobs: vi.fn().mockResolvedValue([{ rowid: 1, text: 'hello' }]),
+    });
+    const chatJob = {
+      rowid: 1,
+      source: 'chat',
+      source_id: 'm1',
+      chunk_index: 0,
+      model_id: 'voyage/voyage-4',
+      vec_table: 'chat_messages_vec_v1',
+      attempts: 0,
+    };
+    const query = vi.fn().mockResolvedValue([chatJob]);
+    const tx = vi.fn(async () => ({ failCount: 1 }));
+    const embed = vi.fn().mockRejectedValue(
+      new EmbeddingError('Invalid model name passed in model=voyage/voyage-4', 'INVALID_MODEL', 400),
+    );
+    const worker = new EmbeddingWorker({
+      getDbClient: () => ({ query, tx }) as never,
+      getClient: () => ({ embed }) as never,
+      isVecAvailable: () => true,
+      log: { info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() } as never,
+    });
+    const runTick = () => (worker as unknown as { tick(): Promise<void> }).tick();
+
+    await runTick();
+    // 确定性失败:整批 terminal 进 'failed',并熔断该 source(后续 tick 的
+    // SQL 过滤不再取它的 job,语义索引失效不再静默空转 708 次)。
+    expect(tx).toHaveBeenCalledWith(
+      'embedding.recordFailures',
+      expect.objectContaining({ terminal: true }),
+    );
+    expect(host.isEmbeddingSourceSuspended('chat')).toBe(true);
+
+    // 边界:AUTH_FAILED 可因重登恢复,保持既有退避语义、不熔断。
+    host.setEmbeddingSourceSuspended('chat', false);
+    tx.mockClear();
+    embed.mockRejectedValue(new EmbeddingError('unauthorized', 'AUTH_FAILED', 401));
+    await runTick();
+    expect(tx).toHaveBeenCalledWith(
+      'embedding.recordFailures',
+      expect.objectContaining({ terminal: false }),
+    );
+    expect(host.isEmbeddingSourceSuspended('chat')).toBe(false);
+  });
 });
 
 describe('chat embedding availability wiring', () => {

--- a/apps/desktop/src/main/embedding-host/__tests__/hostLifecycle.test.ts
+++ b/apps/desktop/src/main/embedding-host/__tests__/hostLifecycle.test.ts
@@ -345,6 +345,68 @@ describe('embedding-host 多 consumer 启停', () => {
     );
     expect(host.isEmbeddingSourceSuspended('chat')).toBe(false);
   });
+
+  it('INVALID_MODEL 仲裁探针:输入级 400 保持退避不熔断;探针其它错误 fail-open (#3674 review P1)', async () => {
+    const host = await loadHost();
+    const { EmbeddingWorker } = await import('../EmbeddingWorker');
+    const { registerProvider } = await import('../providers');
+    const { EmbeddingError } = await import('@cindy/embedding-client');
+    registerProvider({
+      source: 'chat',
+      getTextsForJobs: vi.fn().mockResolvedValue([{ rowid: 1, text: 'hello' }]),
+    });
+    const chatJob = {
+      rowid: 1,
+      source: 'chat',
+      source_id: 'm1',
+      chunk_index: 0,
+      model_id: 'voyage/voyage-4',
+      vec_table: 'chat_messages_vec_v1',
+      attempts: 0,
+    };
+    const query = vi.fn().mockResolvedValue([chatJob]);
+    const tx = vi.fn(async () => ({ failCount: 1 }));
+    // client 的 mapStatusToCode 把 400/404/422 统一映射 INVALID_MODEL,单条坏
+    // 输入的 400 与"端点不托管该模型"同码。批失败后 worker 用极小探针输入仲裁:
+    // 探针成功 = 模型可用、是输入的问题 → 不熔断,整批走既有 backoff。
+    const embed = vi
+      .fn()
+      .mockRejectedValueOnce(new EmbeddingError('input exceeds max length', 'INVALID_MODEL', 400))
+      .mockResolvedValueOnce({
+        embeddings: [[0.1]],
+        modelUsed: 'voyage/voyage-4',
+        tokensUsed: 1,
+        cacheHits: 0,
+      });
+    const worker = new EmbeddingWorker({
+      getDbClient: () => ({ query, tx }) as never,
+      getClient: () => ({ embed }) as never,
+      isVecAvailable: () => true,
+      log: { info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() } as never,
+    });
+    const runTick = () => (worker as unknown as { tick(): Promise<void> }).tick();
+
+    await runTick();
+    expect(embed).toHaveBeenCalledTimes(2); // 批 + 探针
+    expect(tx).toHaveBeenCalledWith(
+      'embedding.recordFailures',
+      expect.objectContaining({ terminal: false }),
+    );
+    expect(host.isEmbeddingSourceSuspended('chat')).toBe(false);
+
+    // 探针自己撞上别的错误(网络/5xx)→ 证据不足,fail-open 不熔断。
+    tx.mockClear();
+    embed.mockReset();
+    embed
+      .mockRejectedValueOnce(new EmbeddingError('bad request', 'INVALID_MODEL', 400))
+      .mockRejectedValueOnce(new EmbeddingError('upstream boom', 'SERVER_ERROR', 500));
+    await runTick();
+    expect(tx).toHaveBeenCalledWith(
+      'embedding.recordFailures',
+      expect.objectContaining({ terminal: false }),
+    );
+    expect(host.isEmbeddingSourceSuspended('chat')).toBe(false);
+  });
 });
 
 describe('chat embedding availability wiring', () => {

--- a/apps/desktop/src/main/localDb/client/__tests__/tx.test.ts
+++ b/apps/desktop/src/main/localDb/client/__tests__/tx.test.ts
@@ -2548,6 +2548,23 @@ describe('db worker tx handlers', () => {
     });
   });
 
+  it('embedding.recordFailures terminal=true 整批直接进 failed,不消耗退避尝试 (#3416)', async () => {
+    await withClient(async (client) => {
+      const freshRowid = await insertJob(client, { sourceId: 'fresh', attempts: 0 });
+      const result = await client.tx('embedding.recordFailures', {
+        jobs: [{ rowid: freshRowid, attempts: 0 }],
+        errMsg: '[INVALID_MODEL] Invalid model name',
+        now: 10_000,
+        terminal: true,
+      });
+
+      expect(result).toEqual({ failCount: 1 });
+      await expect(
+        client.query('SELECT rowid, status, attempts FROM embedding_jobs ORDER BY rowid'),
+      ).resolves.toEqual([{ rowid: freshRowid, status: 'failed', attempts: 1 }]);
+    });
+  });
+
   it('embedding.enqueue inserts only new natural-key jobs', async () => {
     await withClient(async (client) => {
       const result = await client.tx('embedding.enqueue', {

--- a/apps/desktop/src/main/localDb/client/tx/types.ts
+++ b/apps/desktop/src/main/localDb/client/tx/types.ts
@@ -182,6 +182,8 @@ export interface EmbeddingRecordFailuresArgs {
   jobs: Array<{ rowid: number; attempts: number }>;
   errMsg: string;
   now: number;
+  /** #3416:确定性失败(INVALID_MODEL 等)整批直接进 'failed' 终态,不走退避。 */
+  terminal?: boolean;
 }
 
 export interface EmbeddingEnqueueArgs {

--- a/apps/desktop/src/main/localDb/worker/opHandlers/tx.ts
+++ b/apps/desktop/src/main/localDb/worker/opHandlers/tx.ts
@@ -1729,6 +1729,9 @@ function embeddingRecordFailures(db: Database.Database, args: unknown): { failCo
   const jobs = expectArray(payload.jobs, 'jobs');
   const errMsg = truncate(expectString(payload.errMsg, 'errMsg'), 2000);
   const now = expectNumber(payload.now, 'now');
+  // #3416:确定性失败(如 INVALID_MODEL)重试永远不可能成功,terminal=true 时
+  // 整批直接进 'failed' 终态,不再烧 5 次退避尝试。缺省 false 保持旧语义。
+  const terminal = payload.terminal === true;
   const updReschedule = db.prepare(
     `UPDATE embedding_jobs
         SET attempts = ?, last_error = ?, scheduled_at = ?
@@ -1745,7 +1748,7 @@ function embeddingRecordFailures(db: Database.Database, args: unknown): { failCo
       const job = asRecord(rawJob, 'failure job');
       const rowid = expectNumber(job.rowid, 'job.rowid');
       const nextAttempts = expectNumber(job.attempts, 'job.attempts') + 1;
-      if (nextAttempts >= MAX_ATTEMPTS) {
+      if (terminal || nextAttempts >= MAX_ATTEMPTS) {
         updFail.run(nextAttempts, errMsg, rowid);
         failCount++;
       } else {


### PR DESCRIPTION
## 这次改了什么

### 摘要

fix #3416 的静默空转部分。自配置/第三方网关不托管 voyage 系模型时,打包 catalog 的可用性门禁照样放行(`XD_PROVIDER.embeddingModels` 是恒定字面量),每次 `/v1/embeddings` 都确定性 400 `INVALID_MODEL`;此前 worker 对所有错误码一律走 backoff + attempts 计数,每个 job 各烧 5 次退避(提报人观测窗口:14 小时 708 次失败、成功 0),语义索引全线失效且对用户完全静默。

修复(对应提报人更正评论的建议修法 1+2):

- `embedding.recordFailures` 事务新增可选 `terminal`:整批直接进 `'failed'` 终态,不消耗退避尝试;缺省 false 保持旧语义。
- worker 对 `INVALID_MODEL` 置 terminal 并熔断该 source(`setProviderSuspended`):后续 tick 的 SQL 过滤(`listSuspendedProviderSources`)不再取其 job,停止空转;熔断态可经既有 `isEmbeddingSourceSuspended` 查询,并落一条结构化 `embeddingWorker.source.suspendedTerminal` error 日志。挂起为内存态:重启后首批失败会再次熔断,端点修好后自然恢复。
- `AUTH_FAILED`(可因重登恢复)与瞬态错误(网络/限流/5xx)保持既有退避语义,有回归锁住边界。

### 变更类型

- [ ] `feat` 新功能
- [x] `fix` 缺陷修复
- [ ] `refactor` / `perf` 重构或性能优化
- [ ] `docs` / `test` / `chore` 文档、测试或工程维护
- [ ] 其他:

### 范围

- 关联 Issue / 需求:#3416(静默空转部分)
- 本 PR 包含:recordFailures terminal 语义 + worker 终态归类与熔断 + tx / worker 两层回归
- 明确不包含(认领评论已声明):① 以真实端点能力取代打包 catalog 门禁 + `chat_messages_vec_v1` 向量表维度迁移(产品与 schema 决策);② unavailable 的 toast 触达——现无可复用的 main→renderer 通道,新增 IPC 涉及远程适配与产品面,留待呈现层接线,本 PR 先保证熔断状态可查、日志可诊断
- 用户可见变化:无直接 UI 变化;行为上确定性失配不再每 5 秒空转打日志
- 是否存在 breaking change:无(terminal 缺省 false)

### UI 变化

无 UI 变化。

## 怎么验证的

### 自动验证

```
pnpm --dir apps/desktop exec vitest run --pool=forks src/main/embedding-host/__tests__/hostLifecycle.test.ts src/main/localDb/client/__tests__/tx.test.ts
```
结果:82 过(新增 2 条:worker 层 INVALID_MODEL → terminal + 熔断、AUTH_FAILED 保持退避不熔断;tx 层 terminal=true 首次失败即 `failed`)。反证:stash 三个 src 文件后新增 2 条如预期失败、其余 80 照过。

desktop typecheck 过。

```
pnpm test:unit:related
```
结果:exit 1,两处失败均与本 diff 无关——desktop 段 vitest threads 池 SIGSEGV(本机已知环境问题;本 diff 的 hostLifecycle 19 例在同一运行内先行全过,日志可证),maker-core 段 pi-agent.integration 环境性既有失败。注:门禁的 desktop 命令行 `--exclude src/main/localDb/**`,tx.test.ts 的覆盖以上文定向运行为准。

### 手工验证

无(错误注入由 EmbeddingError mock 覆盖;提报人已对真实网关完成 400 复现取证)。

### 未执行的验证

- 未对真实第三方网关做端到端复现(确定性 400 的事实由提报人实测取证,见 issue 更正评论)。

## 风险

### 风险分类

低风险。terminal 仅在 INVALID_MODEL 命中;熔断是内存态、可随重启/手动恢复;其余错误码路径零变化且有回归锁住。

### 影响与回滚

影响面:desktop main 的 embedding worker 与 recordFailures 事务。远程与移动端适配:embedding 全部发生在 desktop main 本机,远程/移动端不参与,无需适配。回滚:revert 单 commit,无 schema 变更(job 表已有 'failed' 状态)。

### 提交前检查

- [x] 已运行定向单测(含反证)与 typecheck;related 门禁分批执行中,结果如实补充
- [x] commit 带 DCO 签名(Signed-off-by: ficowang <fico@xd.com>)
- [x] diff 聚焦单一问题,无无关改动
