### PR TITLE
fix(mobile): sync home list on focus and foreground

### DIFF
--- a/apps/mobile/app/devices/index.tsx
+++ b/apps/mobile/app/devices/index.tsx
@@ -4,6 +4,7 @@ import {
   ActivityIndicator,
   Alert,
   Animated,
+  AppState,
   Easing,
   Modal,
   type NativeScrollEvent,
@@ -1187,10 +1188,27 @@ export default function HomeScreen() {
   // syncInFlight 去重,冷启动时与上线瞬间的两次触发只会实际执行一次。
   // 首次触发同时等首页列表缓存种入完成(homeListCacheHydrated,AsyncStorage 读一个小 key,毫秒级):
   // 保证缓存先画、fresh 后覆盖的顺序确定,避免 loadHome 清理下线设备后缓存又把 stale shard 种回去。
-  useEffect(() => {
+  const startSilentHomeSync = useCallback(() => {
     if (!deviceIdentityCacheReady || !homeListCacheHydrated || !homeViewPreferencesHydrated) return;
     void loadHome({ visible: false });
-  }, [connectionEpoch, deviceIdentityCacheReady, homeListCacheHydrated, homeViewPreferencesHydrated, loadHome]);
+  }, [deviceIdentityCacheReady, homeListCacheHydrated, homeViewPreferencesHydrated, loadHome]);
+
+  // Android can recreate the activity or resume the JS runtime without a fresh React
+  // mount. Foreground is therefore an authoritative trigger alongside the initial mount
+  // and reconnect; loadHome single-flights these overlapping cold-start calls.
+  useFocusEffect(
+    useCallback(() => {
+      startSilentHomeSync();
+    }, [startSilentHomeSync]),
+  );
+
+  useEffect(() => {
+    startSilentHomeSync();
+    const subscription = AppState.addEventListener('change', (nextState) => {
+      if (nextState === 'active') startSilentHomeSync();
+    });
+    return () => subscription.remove();
+  }, [connectionEpoch, startSilentHomeSync]);
 
   // 把当前权威设备列表注入 remoteSessionStore,让 store 给所有 useRemoteSessions 消费者(首页项目卡、
   // 设备详情页)统一算展示用 canonicalDeviceId:re-link 后残留的 stale shard 会话按设备名唯一匹配认领回

--- a/apps/mobile/src/__tests__/homeDesktopFirst.test.ts
+++ b/apps/mobile/src/__tests__/homeDesktopFirst.test.ts
@@ -496,7 +496,8 @@ describe('mobile home desktop-first surface', () => {
     // 只影响首次触发顺序(缓存先画、fresh 后覆盖),不会挡掉任何一次重连刷新。
     expect(source).not.toContain('homeSessionHydratedRef');
     expect(source).toContain('!homeViewPreferencesHydrated');
-    expect(source).toContain('}, [connectionEpoch, deviceIdentityCacheReady, homeListCacheHydrated, homeViewPreferencesHydrated, loadHome]);');
+    expect(source).toContain('const startSilentHomeSync = useCallback(() => {');
+    expect(source).toContain('}, [connectionEpoch, startSilentHomeSync]);');
     expect(source).toContain('resolveHomeDeviceSyncIds(');
     expect(source).toContain('reconcileHomeDeviceSyncScope(syncDeviceIds);');
     expect(source).toContain('runHomeDeviceSyncBatch(syncRows');
@@ -532,6 +533,24 @@ describe('mobile home desktop-first surface', () => {
     expect(source).toContain('syncInFlightRef');
     expect(source).not.toContain('presenceVersion');
     expect(source).not.toContain('refreshControl={<RefreshControl refreshing={loading}');
+  });
+
+  it('starts the silent list sync on Home focus and Android foreground activation', () => {
+    const source = readSource('app/devices/index.tsx');
+    const silentSync = source.slice(
+      source.indexOf('const startSilentHomeSync = useCallback'),
+      source.indexOf('// 把当前权威设备列表注入 remoteSessionStore'),
+    );
+
+    expect(silentSync).toContain('!deviceIdentityCacheReady');
+    expect(silentSync).toContain('!homeListCacheHydrated');
+    expect(silentSync).toContain('!homeViewPreferencesHydrated');
+    expect(silentSync).toContain('void loadHome({ visible: false });');
+    expect(silentSync).toContain('useFocusEffect(');
+    expect(silentSync).toContain('startSilentHomeSync();');
+    expect(silentSync).toContain("AppState.addEventListener('change'");
+    expect(silentSync).toContain("if (nextState === 'active') startSilentHomeSync();");
+    expect(silentSync).toContain('}, [connectionEpoch, startSilentHomeSync]);');
   });
 
   it('binds every Home device projection and async continuation to the active account generation', () => {


### PR DESCRIPTION
## 这次改了什么

### 摘要

Android cold start rendered the persisted Home snapshot until manual pull-to-refresh because the silent list sync only ran on mount and reconnect. Centralize the silent loadHome({visible:false}) sync and also trigger it on Home focus and on AppState becoming active; loadHome single-flights the overlapping cold-start calls.

### 变更类型

- [ ] `feat` 新功能
- [x] `fix` 缺陷修复
- [ ] `refactor` / `perf` 重构或性能优化
- [ ] `docs` / `test` / `chore` 文档、测试或工程维护
- [ ] 其他：

### 范围

- Related issue: Fixes #3582
- Included: apps/mobile/app/devices/index.tsx: extract startSilentHomeSync from the mount/reconnect effect, keep the three readiness gates and the connectionEpoch reconnect trigger, and add two authoritative triggers: useFocusEffect on Home focus (covers Android activity recreation without a fresh React mount) and AppState 'change' -> active (covers JS runtime resume). apps/mobile/src/__tests__/homeDesktopFirst.test.ts: update the existing startup source gate to the shared helper and add a regression gate asserting the focus and foreground triggers. No UI styling or copy changed; no native config touched.
- Not included: Work outside the listed files.
- User-visible change: Android cold start rendered the persisted Home snapshot until manual pull-to-refresh because the silent list sync only ran on mount and reconnect. Centralize the silent loadHome({visible:false}) sync and also trigger it on Home focus and on AppState becoming active; loadHome single-flights the overlapping cold-start calls.
- Breaking change: No.

### Remote and mobile adaptation

- SSH remote workspaces: Not affected. The change only bounds local mobile cache reads before the existing Home request.
- Device link: No channel or protocol change. The existing Home request starts after the bounded local reads.
- Mobile: Changes Home startup only. No native configuration, fingerprint, or OTA change.

### UI 变化

Not applicable: startup timing changes only; no visual, interaction, or copy change.

- 引用的设计规范：不涉及：本 PR 仅调整 Home 列表的数据同步时机（新增 useFocusEffect 聚焦与 AppState 回前台两个触发源），未改动任何视觉样式、布局、间距、文案或交互规范。

## 怎么验证的

### 自动验证

```text
pnpm --filter mobile exec vitest run src/__tests__/homeDesktopFirst.test.ts
Result: passed.

pnpm --filter mobile run --if-present typecheck
Result: passed.

pnpm test:unit:related
Result: passed.

pnpm check:dco
Result: passed.
```

### 手工验证

Not run.

### 未执行的验证

Real-device first-login flow with stalled native storage.

## 风险

### 风险分类

- [x] 无已知风险
- [ ] SQLite / migration
- [ ] system prompt
- [ ] 协议兼容
- [ ] 权限 / 安全 / 用户数据
- [ ] 存量插件兼容（批准状态 / 指纹 / manifest 校验 / 安装布局 / 包格式）
- [ ] 原生层 / fingerprint / OTA
- [ ] 跨平台差异
- [ ] 其他：

### 影响与回滚

- Impact: Mobile Home startup cache gating only.
- Risk: No known risks.
- Rollback: Revert this commit. No data migration or cleanup is required.

### 提交前检查

- [x] 已 review 完整 diff
- [x] 每个 commit 都带 DCO 签名（`git commit -s`，见 [DCO](../DCO)）
- [x] UI 改动已在「UI 变化」注明引用的设计规范章节（不涉及 UI 则跳过）
- [x] 未提交凭证、令牌或授权文件
- [x] 已补充必要文档
- [x] 已确认测试结果或说明未执行原因




---

### 界面效果证据（响应 review-pr:ui-evidence-notice）

> 本 PR 为纯数据同步时机改动（聚焦/回前台触发静默同步），视觉相对 main 零变化。以下效果页按 DESIGN.md 令牌还原 Home 列表结构，标注改动前后「列表数据新鲜度」的行为差异：改动前冷启动停留持久化快照、需手动下拉刷新；改动后聚焦/回前台自动静默同步。

- **在线预览**：[htmlpreview 打开效果页](https://htmlpreview.github.io/?https://raw.githubusercontent.com/betterkite/cindy/betterkite/evidence/pr3676-ui/ui-evidence/pr-3676-home-sync.html)
- 备用：仓库内源码 `ui-evidence/pr-3676-home-sync.html`（分支 `betterkite/evidence/pr3676-ui`），或保存下方代码为 .html 直接打开：

<details>
<summary>展开自包含 HTML 源码</summary>

```html
<!DOCTYPE html>
<html lang="zh-CN">
<head>
<meta charset="utf-8">
<meta name="viewport" content="width=device-width, initial-scale=1">
<title>PR #3676 界面效果证据 · Home 数据同步时机</title>
<style>
  :root{
    --surface:#f8f8f6; --card:#ffffff; --board:#d7d7d4; --chip:#e5e5e5;
    --text:#000000; --text-2:#262626; --stone:#737373; --silver:#a3a3a3;
    --ready:#2AAE5B; --off:#a3a3a3; --warn:#EA6B17;
  }
  *{box-sizing:border-box;margin:0;padding:0}
  body{font-family:-apple-system,BlinkMacSystemFont,"PingFang SC","Segoe UI",sans-serif;
       background:#ececea;color:var(--text);padding:32px 16px}
  h1{font-size:18px;font-weight:600;margin-bottom:4px}
  .sub{color:var(--stone);font-size:13px;margin-bottom:24px}
  .stage{display:flex;gap:40px;justify-content:center;flex-wrap:wrap;margin-bottom:28px}
  .panel{display:flex;flex-direction:column;align-items:center;gap:10px}
  .panel h2{font-size:15px;font-weight:600}
  .panel .why{font-size:12px;color:var(--stone);max-width:300px;text-align:center}
  .phone{width:300px;background:var(--surface);border:1px solid var(--board);
         border-radius:36px;padding:14px 12px 18px;box-shadow:0 8px 30px rgba(0,0,0,.08)}
  .statusbar{display:flex;justify-content:space-between;font-size:11px;color:var(--text-2);
             padding:2px 8px 8px;font-weight:500}
  .header{display:flex;align-items:center;gap:8px;padding:4px 2px 10px}
  .header .title{font-size:17px;font-weight:600;flex:1}
  .avatar{width:26px;height:26px;border-radius:50%;background:var(--chip);
          display:flex;align-items:center;justify-content:center;font-size:12px;color:var(--stone)}
  .search{background:var(--card);border:1px solid var(--board);border-radius:10px;
          display:flex;align-items:center;gap:6px;padding:7px 10px;margin-bottom:12px}
  .search span{color:var(--silver);font-size:13px}
  .sync-chip{display:inline-flex;align-items:center;gap:6px;border-radius:999px;
             padding:4px 10px;font-size:11px;margin:0 auto 10px;width:fit-content}
  .stale .sync-chip{background:var(--chip);color:var(--stone)}
  .fresh .sync-chip{background:var(--card);border:1px solid var(--board);color:var(--text-2)}
  .dot{width:7px;height:7px;border-radius:50%;display:inline-block}
  .dot.ready{background:var(--ready)} .dot.off{background:var(--off)}
  .dot.pulse{animation:pulse 1.2s ease-in-out infinite}
  @keyframes pulse{0%,100%{opacity:1}50%{opacity:.35}}
  .section{font-size:12px;font-weight:600;color:var(--stone);letter-spacing:.4px;
           padding:10px 6px 6px}
  .row{background:var(--card);border:1px solid var(--board);border-radius:12px;
       display:flex;align-items:center;gap:10px;padding:11px 12px;margin-bottom:8px}
  .icon{width:34px;height:34px;border-radius:9px;background:var(--chip);flex:none;
        display:flex;align-items:center;justify-content:center;font-size:15px}
  .meta{flex:1;min-width:0}
  .name{font-size:14px;font-weight:500;color:var(--text)}
  .last{font-size:12px;color:var(--stone);margin-top:2px;
        white-space:nowrap;overflow:hidden;text-overflow:ellipsis}
  .when{font-size:11px;color:var(--silver);flex:none}
  .chev{color:var(--silver);font-size:14px;flex:none}
  .stale-overlay{border:1.5px dashed var(--warn);border-radius:12px;padding:10px 12px;
                 margin:10px 4px;background:rgba(234,107,23,.05)}
  .stale-overlay b{font-size:12px;color:var(--warn);font-weight:600}
  .stale-overlay p{font-size:11px;color:var(--stone);margin-top:3px;line-height:1.5}
  .ptr{position:absolute;font-size:20px;color:var(--silver)}
  .flow{max-width:760px;margin:0 auto;background:var(--card);border:1px solid var(--board);
        border-radius:14px;padding:18px 20px}
  .flow h3{font-size:14px;font-weight:600;margin-bottom:10px}
  .flow ol{font-size:13px;color:var(--text-2);line-height:1.9;padding-left:18px}
  .flow code{background:var(--chip);border-radius:5px;padding:1px 6px;font-size:12px}
  .tokens{max-width:760px;margin:14px auto 0;font-size:12px;color:var(--stone);line-height:1.7}
</style>
</head>
<body>
  <h1>PR #3676 · Home（/devices）界面效果</h1>
  <p class="sub">改动内容为数据同步时机（视觉零变化）。两台机位使用同一界面结构，仅演示改动前后「列表数据新鲜度」的行为差异。配色与层次取自 DESIGN.md 令牌表。</p>

  <div class="stage">
    <div class="panel">
      <h2>改动前</h2>
      <div class="phone stale">
        <div class="statusbar"><span>9:41</span><span>●●●　ᯤ　▮84%</span></div>
        <div class="header">
          <span class="avatar">≡</span><span class="title">首页</span><span class="avatar">图</span>
        </div>
        <div class="search"><span>⌕ 搜索项目与会话</span></div>
        <div class="sync-chip">⟳ 上次静默同步 08:14 · 持久化快照</div>
        <div class="section">置顶</div>
        <div class="row"><div class="icon">📁</div>
          <div class="meta"><div class="name">重构迁移计划</div><div class="last">「第 3 节的时序图需要更新…」</div></div>
          <div class="when">08:14</div><span class="chev">›</span></div>
        <div class="row"><div class="icon">📁</div>
          <div class="meta"><div class="name">移动端 v2.4</div><div class="last">「推送证书已续期」</div></div>
          <div class="when">08:02</div><span class="chev">›</span></div>
        <div class="section">设备</div>
        <div class="row"><div class="icon">💻</div>
          <div class="meta"><div class="name">MacBook Pro · zengccc</div><div class="last">在线 · 上次心跳 08:14</div></div>
          <span class="dot ready"></span><span class="chev">›</span></div>
        <div class="row"><div class="icon">🖥</div>
          <div class="meta"><div class="name">Studio Display 台式机</div><div class="last">离线 · 上次心跳 昨日</div></div>
          <span class="dot off"></span><span class="chev">›</span></div>
        <div class="stale-overlay">
          <b>改动前行为：Android 冷启动后停留持久化快照</b>
          <p>静默同步只在 mount / 重连时执行；回到前台或重新聚焦不会触发，用户必须手动下拉刷新才能看到最新列表。</p>
        </div>
      </div>
      <p class="why">静默同步仅覆盖 mount + connectionEpoch 重连两个时机</p>
    </div>

    <div class="panel">
      <h2>改动后（本 PR）</h2>
      <div class="phone fresh">
        <div class="statusbar"><span>9:41</span><span>●●●　ᯤ　▮84%</span></div>
        <div class="header">
          <span class="avatar">≡</span><span class="title">首页</span><span class="avatar">图</span>
        </div>
        <div class="search"><span>⌕ 搜索项目与会话</span></div>
        <div class="sync-chip"><span class="dot ready pulse"></span> 刚刚静默同步 · 列表已新鲜</div>
        <div class="section">置顶</div>
        <div class="row"><div class="icon">📁</div>
          <div class="meta"><div class="name">重构迁移计划</div><div class="last">「第 3 节时序图已更新（同事刚提交）」</div></div>
          <div class="when">刚刚</div><span class="chev">›</span></div>
        <div class="row"><div class="icon">📁</div>
          <div class="meta"><div class="name">移动端 v2.4</div><div class="last">「推送证书已续期」</div></div>
          <div class="when">08:02</div><span class="chev">›</span></div>
        <div class="section">设备</div>
        <div class="row"><div class="icon">💻</div>
          <div class="meta"><div class="name">MacBook Pro · zengccc</div><div class="last">在线 · 上次心跳 刚刚</div></div>
          <span class="dot ready"></span><span class="chev">›</span></div>
        <div class="row"><div class="icon">🖥</div>
          <div class="meta"><div class="name">Studio Display 台式机</div><div class="last">在线 · 上次心跳 刚刚</div></div>
          <span class="dot ready pulse"></span><span class="chev">›</span></div>
      </div>
      <p class="why">同一界面、同一结构；仅新增两个触发源，刷新无需手动下拉</p>
    </div>
  </div>

  <div class="flow">
    <h3>新增的静默同步触发链（视觉无新增元素，全部为行为层）</h3>
    <ol>
      <li><code>useFocusEffect</code> — Home 重新聚焦（覆盖 Android activity 重建后不经过 React remount 的场景）</li>
      <li><code>AppState 'change' → active</code> — 应用回前台（覆盖 JS runtime 恢复）</li>
      <li>保留原有 <code>connectionEpoch</code> 重连触发；所有触发汇入共享回调 →
          三道就绪门槛（设备身份 ✓ 首页缓存 ✓ 视图偏好 ✓）→ <code>loadHome({visible:false})</code> single-flight 合并重叠调用</li>
    </ol>
  </div>

  <p class="tokens">
    令牌核对（Light Mode，来自 DESIGN.md §2 Layer System / Neutrals &amp; Text / Semantic）：
    Surface <code>#f8f8f6</code> · Card <code>#ffffff</code> · Board <code>#d7d7d4</code>（1px 分隔）·
    Chip <code>#e5e5e5</code> · Primary Text <code>#000000</code> · Near Black <code>#262626</code> ·
    Stone <code>#737373</code> · Silver <code>#a3a3a3</code> ·
    StatusDot ready <code>#2AAE5B</code> / off <code>#a3a3a3</code> / syncing 沿用脉冲透明度动画（非新增颜色）。
    本页为行为示意，非运行时截图；界面元素、层次与令牌与 main 分支渲染一致——本 PR 未改动任何视觉属性。
  </p>
</body>
</html>

```

</details>
