### PR TITLE
fix(desktop): 官方 DeepSeek 路由启用历史 reasoning_content 回传

### DIFF
--- a/apps/desktop/src/main/maker-host/__tests__/codexProxyHost.test.ts
+++ b/apps/desktop/src/main/maker-host/__tests__/codexProxyHost.test.ts
@@ -650,6 +650,20 @@ describe('chatBridgeCapabilitiesForRoute', () => {
   });
 
   it.each([
+    ['https://api.deepseek.com/v1', 'deepseek-v4-flash', 'reasoning_content'],
+    ['https://api.deepseek.com', 'deepseek-chat', 'reasoning_content'],
+    ['https://relay.example/v1', 'deepseek-v4-flash', undefined],
+    ['http://api.deepseek.com/v1', 'deepseek-v4-flash', undefined],
+    ['https://api.deepseek.com/v1', 'kimi-k3', undefined],
+  ] as const)(
+    'reasoning_content 历史回传只对官方 DeepSeek 路由开启 (#3441): %s %s → %s',
+    async (upstream, model, expected) => {
+      const { chatBridgeCapabilitiesForRoute } = await freshCodexProxyHost();
+      expect(chatBridgeCapabilitiesForRoute(upstream, model).reasoningHistoryField).toBe(expected);
+    },
+  );
+
+  it.each([
     ['https://api.kimi.com/coding/v1', 'k3'],
     ['https://api.kimi.com/coding/v1/', 'k3-256k'],
   ])('enables image_url for Kimi Code coding-plan route: %s / %s (#2732)', async (upstream, model) => {

--- a/apps/desktop/src/main/maker-host/codex-proxy-host.ts
+++ b/apps/desktop/src/main/maker-host/codex-proxy-host.ts
@@ -857,11 +857,37 @@ export function chatBridgeCapabilitiesForRoute(
   realModel: string,
   fallback: ChatBridgeCapabilities = CHAT_BRIDGE_DEFAULT_CAPABILITIES,
 ): ChatBridgeCapabilities {
-  if (!isVerifiedImageChatRoute(upstream, realModel)) return fallback;
-  return {
-    ...fallback,
-    imageInput: 'image_url',
-  };
+  let capabilities = fallback;
+  if (isDeepSeekReasoningHistoryRoute(upstream, realModel)) {
+    capabilities = { ...capabilities, reasoningHistoryField: 'reasoning_content' };
+  }
+  if (isVerifiedImageChatRoute(upstream, realModel)) {
+    capabilities = { ...capabilities, imageInput: 'image_url' };
+  }
+  return capabilities;
+}
+
+/**
+ * DeepSeek 官方 DNS 边界(#3441):其 thinking 模式 API 要求把历史
+ * reasoning_content 回传,否则复杂多轮 + 工具任务偶发
+ * 400 "The `reasoning_content` in the thinking mode must be passed back"。
+ * 该厂商扩展由 DeepSeek 官方文档定义,api.deepseek.com 上游确认接受;
+ * 中转/未知兼容端点不放行(types.ts 边界:只有明确接受该扩展的上游才应
+ * 开启,未知端点可能拒绝该字段)。判据与图片白名单同款:官方 host +
+ * 上游 model 前缀,不认 provider id。
+ */
+const DEEPSEEK_CHAT_HOST = 'api.deepseek.com';
+
+function isDeepSeekReasoningHistoryRoute(upstream: string, realModel: string): boolean {
+  let url: URL;
+  try {
+    url = new URL(upstream);
+  } catch {
+    return false;
+  }
+  if (url.protocol !== 'https:') return false;
+  if (url.hostname.toLowerCase() !== DEEPSEEK_CHAT_HOST) return false;
+  return realModel.toLowerCase().startsWith('deepseek');
 }
 
 function isVerifiedImageChatRoute(upstream: string, realModel: string): boolean {


### PR DESCRIPTION
## 这次改了什么

### 摘要

fix #3441。官方 DeepSeek(`api.deepseek.com`)经 Codex 代理走 chat completions 桥时,思维链历史断链:responses-chat-bridge 其实**两端机制早已齐备**——`translate-request` 消费 `reasoningHistoryField: 'reasoning_content'` 时会把历史 reasoning item 回放进 assistant 消息的 `reasoning_content` 字段,`chat-sse-translator` 也一直在从流里捕获 `reasoning_content`——缺的只是路由启用:`codex-proxy-host` 的 `chatBridgeCapabilitiesForRoute` 从未对任何路由下发该 capability,于是多轮对话里 DeepSeek 拿不到自己上一轮的思维链,推理连续性依赖被静默截断。

修复:`chatBridgeCapabilitiesForRoute` 重写为组合式(逐项能力叠加而非互斥返回),新增 `isDeepSeekReasoningHistoryRoute` 判据——https + host 精确等于 `api.deepseek.com` + 真实上游模型 id 以 `deepseek` 开头,三条全中才启用 `reasoningHistoryField: 'reasoning_content'`。判据对齐仓内已验证上游能力的既有口径(与 image whitelist 同款:官方 DNS 边界 + 上游模型 id,绝不看 provider id),中继/自定义网关域名不启用(无法保证转发语义)。

### 变更类型

- [ ] `feat` 新功能
- [x] `fix` 缺陷修复
- [ ] `refactor` / `perf` 重构或性能优化
- [ ] `docs` / `test` / `chore` 文档、测试或工程维护
- [ ] 其他:

### 范围

- 关联 Issue / 需求:#3441
- 本 PR 包含:路由 capability 启用判据 + capability 组合化 + 5 条路由判据回归
- 明确不包含:bridge 两端的回放/捕获逻辑(一行未动,机制已存在且有既有测试)
- 用户可见变化:官方 DeepSeek 模型多轮对话中模型可见自己此前的思维链,推理连续性恢复
- 是否存在 breaking change:无(既有路由的 capability 取值全部不变,组合化只是让多能力可叠加)

### UI 变化

无 UI 变化。

## 怎么验证的

### 自动验证

```
pnpm --dir apps/desktop exec vitest run --pool=forks src/main/maker-host/__tests__/codexProxyHost.test.ts
```
结果:197 过(新增 it.each 5 例:官方域 + deepseek 模型两种形态启用;中继 host / http / 非 deepseek 模型三种形态维持 undefined)。反证:stash 后新增用例如预期失败、其余照过。

desktop typecheck 过。

```
pnpm test:unit:related
```
结果:exit 1,两处失败均与本 diff 无关——maker-core 段 `pi-agent.integration` ×3(本机环境性既有失败,依赖真 pi binary);desktop 段 vitest threads 池 SIGSEGV(本机已知环境问题),本 diff 的 codexProxyHost 197 例在同一门禁运行内先行全过(日志可证)。

### 手工验证

无(路由判据与 capability 下发由单测端到端断言;bridge 端回放行为由 responses-chat-bridge 既有测试覆盖)。

### 未执行的验证

- 未对真实 DeepSeek API 做端到端多轮验证(需要真实 key;`reasoning_content` 的请求/响应字段语义以 DeepSeek 官方 API 文档与 bridge 既有实现为准)。

## 风险

### 风险分类

低风险。仅官方 DeepSeek 域 + deepseek 模型的路由新增一项 capability;其余路由 capability 取值不变,有回归锁住。

### 影响与回滚

影响面:desktop main 的 codex-proxy-host 路由 capability 下发。远程与移动端适配:代理宿主只在 desktop main 运行,远程/移动端经同一宿主转发、行为一致,无需额外适配。回滚:revert 单 commit,无 schema 变更。

### 提交前检查

- [x] 已运行定向单测(含反证)、typecheck 与 `pnpm test:unit:related`(失败项已逐一归因)
- [x] commit 带 DCO 签名(Signed-off-by: ficowang <fico@xd.com>)
- [x] diff 聚焦单一问题,无无关改动
