### PR TITLE
fix(maker-core): 显式来源会话把路由核实窗口注入 CC 上下文映射

### DIFF
--- a/packages/maker-core/src/agents/claude-code/__tests__/env-builder.test.ts
+++ b/packages/maker-core/src/agents/claude-code/__tests__/env-builder.test.ts
@@ -242,6 +242,35 @@ describe('buildClaudeEnv', () => {
     });
   });
 
+  it('大写 [1M] 后缀不再镜像出 [1M][1m] 垃圾键 (#3661)', async () => {
+    const env = await buildClaudeEnv(createAuthAdapter(), {}, {
+      modelContextWindows: [
+        { id: 'claude-opus-4-6[1M]', contextWindow: 1_000_000 },
+      ],
+    });
+
+    expect(JSON.parse(env[MODEL_CONTEXT_WINDOWS_ENV] ?? '{}')).toEqual({
+      'claude-opus-4-6[1M]': 1_000_000,
+    });
+  });
+
+  it('mirrorOneMillionSuffix=false 的条目只写原样键,不镜像 [1m] (#3661)', async () => {
+    // claude-* 的 [1m] 是真实 1M 通道,不是同窗口路由别名:按会话路由注入的
+    // 中转站窗口若被镜像,会把 200K 压到 Fast 切换后的 [1m] 形态上。
+    const env = await buildClaudeEnv(createAuthAdapter(), {}, {
+      modelContextWindows: [
+        { id: 'claude-opus-4-6', contextWindow: 1_000_000, mirrorOneMillionSuffix: false },
+        { id: 'deepseek/deepseek-v4-pro', contextWindow: 1_048_576 },
+      ],
+    });
+
+    expect(JSON.parse(env[MODEL_CONTEXT_WINDOWS_ENV] ?? '{}')).toEqual({
+      'claude-opus-4-6': 1_000_000,
+      'deepseek/deepseek-v4-pro': 1_048_576,
+      'deepseek/deepseek-v4-pro[1m]': 1_048_576,
+    });
+  });
+
   it('does not inject empty or invalid context windows', async () => {
     const env = await buildClaudeEnv(createAuthAdapter(), {}, {
       modelContextWindows: [

--- a/packages/maker-core/src/agents/claude-code/env-builder.ts
+++ b/packages/maker-core/src/agents/claude-code/env-builder.ts
@@ -18,6 +18,13 @@ export const MAKER_MODEL_CONTEXT_WINDOWS_ENV = 'XDT_MAKER_MODEL_CONTEXT_WINDOWS'
 interface ModelContextWindowSource {
   id: string;
   contextWindow: number;
+  /**
+   * 是否把无 [1m] 后缀的 id 镜像出一个同窗口的 `${id}[1m]` 键(缺省 true,
+   * 兼容 provider 路由模型把 [1m] 当同窗口路由别名的历史语义)。claude-* 的
+   * [1m] 是真实的 1M 通道、不是同窗口别名,按会话路由注入的条目必须传 false,
+   * 否则 200K 会被镜像到 Fast 切换后的 [1m] 形态上(#3661)。
+   */
+  mirrorOneMillionSuffix?: boolean;
 }
 
 interface ClaudeEnvBuildOptions {
@@ -66,7 +73,10 @@ function serializeModelContextWindows(
     }
     const window = Math.floor(model.contextWindow);
     entries[model.id] = window;
-    if (!model.id.endsWith('[1m]')) {
+    // 后缀判定大小写不敏感(#3661):用户配置 `...[1M]` 时不能再镜像出
+    // `...[1M][1m]` 垃圾键。镜像本身仍按原样键写入,消费侧按字面匹配。
+    const hasOneMillionSuffix = /\[1m\]$/i.test(model.id);
+    if (model.mirrorOneMillionSuffix !== false && !hasOneMillionSuffix) {
       entries[`${model.id}[1m]`] = window;
     }
   }

--- a/packages/maker-core/src/agents/claude-code/index.ts
+++ b/packages/maker-core/src/agents/claude-code/index.ts
@@ -1166,10 +1166,36 @@ export class ClaudeCodeAgent extends BaseAgent {
     const providerRoutedModels = this.capabilities.availableModels.filter((model) =>
       isProviderRoutedModel(model.id),
     );
+    // #3661:扁平表按「CC 内建 resolver 认识 Anthropic 名」排除了 claude-*,但
+    // 中转/自定义来源上的 claude 模型窗口以用户配置为准(如 1M);CLI 内建
+    // resolver 会按 Anthropic 缺省收敛(~200K)并过早判满/auto-compact。显式
+    // 来源会话把「该路由已核实」的窗口(resolveVerifiedContextWindow:多来源
+    // 歧义或未核实返回 null,fail-open 回落 CLI 自解析)按本会话模型单点注入;
+    // 不做 [1m] 镜像 —— claude 的 [1m] 是真实 1M 通道,不是同窗口路由别名。
+    // 会话中途 setModel 到其它 claude 模型时该 env 键不覆盖新模型,行为与
+    // 修复前一致(CLI 自解析),无回归面。
+    const sessionRouteWindowEntry = ((): {
+      id: string;
+      contextWindow: number;
+      mirrorOneMillionSuffix: false;
+    } | null => {
+      if (!opts.providerId) return null;
+      if (!opts.model.startsWith('claude-')) return null;
+      const verified = this.deps.resolveVerifiedContextWindow?.(opts.providerId, opts.model);
+      if (typeof verified !== 'number' || verified <= 0) return null;
+      return {
+        id: sdkModelFor(opts.model),
+        contextWindow: verified,
+        mirrorOneMillionSuffix: false,
+      };
+    })();
+    const modelContextWindows = sessionRouteWindowEntry
+      ? [...providerRoutedModels, sessionRouteWindowEntry]
+      : providerRoutedModels;
     const env = await buildClaudeEnv(this.deps.auth, this.deps.runtimeConfig, {
       credentialMode,
       sessionProviderId: opts.providerId ?? null,
-      modelContextWindows: providerRoutedModels,
+      modelContextWindows,
       // 先按「不设」建好 env(顺带删掉可能从 process.env 继承来的残留),真正的判定在下面
       // 拿到这份 env 之后做 —— 扫描需要 env 里的 CLAUDE_CONFIG_DIR 才能找对目录。
       subagentModel: null,
@@ -1253,7 +1279,7 @@ export class ClaudeCodeAgent extends BaseAgent {
           credentialMode,
           sessionProviderId: opts.providerId ?? null,
           mode: 'remote',
-          modelContextWindows: providerRoutedModels,
+          modelContextWindows,
           // 远端不做本地扫描(见上),这里的值就是路由感知后的设置值 —— 保持 env 强制覆盖语义。
           subagentModel: subagentDefault.envSubagentModel ?? null,
         })


### PR DESCRIPTION
## 这次改了什么

### 摘要

fix #3661。中继/自定义供应商上配置了 1M 上下文的 claude 系模型,Claude Code 会话仍按 ~200K 提前报上下文已满。根因是两个叠加的确定性缺陷:

1. **claude-* 被整类排除在窗口注入之外**:`isProviderRoutedModel` 直接 `!model.startsWith('claude-')`(claude-code/index.ts),于是用户在自定义供应商上显式配置、已被 `user-provider.ts` 标记 `contextWindowVerified: true` 的窗口值,永远进不了 `XDT_MAKER_MODEL_CONTEXT_WINDOWS` 环境映射;CC CLI 内部解析器对认不出的路由回落 ~200K 默认。
2. **序列化器 `[1M]` 大小写缺陷**:镜像键判定用大小写敏感的 `endsWith('[1m]')`,模型 id 带大写 `[1M]` 时会生成 `x[1M][1m]` 这样的垃圾镜像键。

修复走该架构本来的意图路径——按会话路由注入:

- `index.ts` 新增 `sessionRouteWindowEntry`:仅当会话显式绑定 provider、模型是 claude-*、且 `deps.resolveVerifiedContextWindow(providerId, modelId)` 返回**已核实**的正值时,才把该窗口作为附加 entry 注入两处 env 构建点(本地 + 远程);多来源歧义或未核实一律返回 null,fail-open 交还 CLI 自行解析(不猜)。
- env-builder 的 `ModelContextWindowSource` 新增 `mirrorOneMillionSuffix?: boolean`(缺省 true 保持旧语义):claude 条目显式置 false——claude 的 `[1m]` 是**真实的 1M 通道**(Fast Mode 切换用),不是同窗口路由别名,镜像会把原生 1M 通道钳到普通窗口;后缀判定改为大小写不敏感 `/\[1m\]$/i`。
- 会话中途 `setModel` 切到其它 claude 模型:env 键不覆盖新模型 → 行为回到修复前的 CLI 自解析,无回归面。

### 变更类型

- [ ] `feat` 新功能
- [x] `fix` 缺陷修复
- [ ] `refactor` / `perf` 重构或性能优化
- [ ] `docs` / `test` / `chore` 文档、测试或工程维护
- [ ] 其他:

### 范围

- 关联 Issue / 需求:#3661
- 本 PR 包含:会话路由窗口注入(index.ts 两处 env 构建点)+ mirrorOneMillionSuffix 语义 + 大小写不敏感后缀判定 + env-builder 两条回归
- 明确不包含:`isProviderRoutedModel` 的通用判定不动(非 claude 模型路径零变化);CLI 内部解析逻辑不动
- 用户可见变化:自定义供应商上显式配置并核实过窗口的 claude 模型,会话按配置窗口计满,不再 ~200K 提前截断
- 是否存在 breaking change:无(未配置/未核实/歧义场景与既有行为完全一致)

### UI 变化

无 UI 变化。

## 怎么验证的

### 自动验证

```
pnpm --dir packages/maker-core exec vitest run src/agents/claude-code/__tests__/env-builder.test.ts
```
结果:35 过(新增 2 条:大写 `[1M]` id 只产生字面键不再生成垃圾镜像;`mirrorOneMillionSuffix: false` 的 claude 条目不镜像、同批 deepseek 条目照旧镜像)。反证:stash env-builder.ts 后新增 2 条如预期失败。

maker-core typecheck 过。

```
pnpm test:unit:related
```
结果:exit 1,两处失败均与本 diff 无关——maker-core 段 3715 例仅 `pi-agent.integration` ×3 失败(本机环境性既有失败,依赖真 pi binary),本 diff 的 env-builder 35 例在同一运行内全过(日志可证);desktop 段 vitest threads 池 SIGSEGV(本机已知环境问题,本 diff 不含 desktop 代码)。

### 手工验证

无(注入条件与序列化语义由单测覆盖;`resolveVerifiedContextWindow` 的核实语义由 user-provider 既有链路提供)。

### 未执行的验证

- 未对真实 1M 中继端点做端到端长上下文验证(需要真实中继与长会话;窗口值进入 CLI 后的消费逻辑属 CC CLI 内部,以 env 契约为界)。

## 风险

### 风险分类

低风险。注入有三重前置守卫(显式 provider + claude-* + 已核实正值),任一不满足即回落既有行为;镜像语义变化仅影响显式置 false 的新增条目,存量调用方缺省值不变。

### 影响与回滚

影响面:maker-core 的 Claude Code env 构建(本地与远程会话共用)。远程与移动端适配:远程会话的 env 构建点已同步传入同一 entry 列表,行为一致,无需额外适配。回滚:revert 单 commit,无 schema 变更。

### 提交前检查

- [x] 已运行定向单测(含反证)、typecheck 与 `pnpm test:unit:related`(失败项已逐一归因)
- [x] commit 带 DCO 签名(Signed-off-by: ficowang <fico@xd.com>)
- [x] diff 聚焦单一问题,无无关改动
