### PR TITLE
fix(desktop): 右侧栏 tab 添加失败时按错误码 toast 提示

### DIFF
--- a/apps/desktop/src/renderer/components/layout/SidebarWindowLayout.tsx
+++ b/apps/desktop/src/renderer/components/layout/SidebarWindowLayout.tsx
@@ -29,6 +29,7 @@ import { useTranslation } from 'react-i18next';
 import { PanelRight } from 'lucide-react';
 
 import { RightSidebarShell } from '@/features/right-sidebar/RightSidebarShell';
+import { ToastContainer } from '@/components/ui/toast';
 import { useDeviceLinkRemoteProjects } from '@/features/device-link/useDeviceLinkRemoteProjects';
 import { onRequestRightSidebarVisibility } from '@/features/right-sidebar/lib/sidebarCommands';
 import { executeSidebarCommand } from '@/features/right-sidebar/lib/executeSidebarCommand';
@@ -338,6 +339,7 @@ export function SidebarWindowLayout() {
           </div>
         )}
       </div>
+      <ToastContainer />
       <GhostMediaLightboxHost
         key={interactiveSessionId ?? 'hidden'}
         sessionId={interactiveSessionId ?? undefined}

--- a/apps/desktop/src/renderer/components/layout/__tests__/ReusableWindowChrome.test.tsx
+++ b/apps/desktop/src/renderer/components/layout/__tests__/ReusableWindowChrome.test.tsx
@@ -129,6 +129,7 @@ vi.mock('@/lib/logger', () => ({
   createLogger: () => ({ info: vi.fn(), warn: vi.fn(), error: vi.fn() }),
 }));
 vi.mock('@/lib/toast', () => ({ toast: { error: vi.fn() } }));
+vi.mock('@/components/ui/toast', () => ({ ToastContainer: () => null }));
 vi.mock('@/utils/ipcError', () => ({ extractIpcError: () => null }));
 vi.mock('lucide-react', () => ({
   PanelRight: () => null,

--- a/apps/desktop/src/renderer/features/right-sidebar/RightSidebarShell.tsx
+++ b/apps/desktop/src/renderer/features/right-sidebar/RightSidebarShell.tsx
@@ -12,7 +12,7 @@
  * Phase 3 同步:Shell 顶层 import `./plugins`,触发各 plugin 的 import-side-effect
  * 注册(`registerTabKind`)。后续新 plugin 只需在 plugins/index.ts 加一行 import。
  *
- * Phase 2 简化保留:错误打日志、所有 IPC 失败本地回滚 + log(无 toast),Phase 7 收尾接 toast。
+ * Phase 2 简化保留:错误打日志、所有 IPC 失败本地回滚 + log;Phase 7 已收尾:添加失败按错误码 toast 统一暴露(见 handleAdd)。
  *
  * sessionId / workdir 由 host 透:
  *   - sessionId 为 null = 不在 cc-agent 路由,Shell 渲染空状态,store 不工作;
@@ -31,6 +31,8 @@ import {
 import { useTranslation } from 'react-i18next';
 
 import { createLogger } from '@/lib/logger';
+import { toast } from '@/lib/toast';
+import { mapIpcErrorToI18nKey } from '@/utils/ipcError';
 import { isSecondaryWindow } from '@/lib/secondaryWindow';
 import { useAppShortcut } from '@/hooks/useAppShortcut';
 import { useMacFullscreen } from '@/hooks/useMacFullscreen';
@@ -442,11 +444,18 @@ export function RightSidebarShell({
         ? addOrFocusSingletonTab(sessionId, kind, initialState)
         : addTab(sessionId, kind, initialState);
       void action.catch((err) => {
-        // TODO(Phase 7): toast 暴露 RIGHT_SIDEBAR_TOO_MANY_TABS / STATE_TOO_LARGE 等错误码。
+        // 按错误码 toast:专属文案挂在全局 ipcError 命名空间(RIGHT_SIDEBAR_*),其余错误落通用 addFailed 兜底。
+        toast.error(
+          t(
+            mapIpcErrorToI18nKey(err, {
+              fallback: 'rightSidebar.tabs.addFailed',
+            }),
+          ),
+        );
         log.error('handleAdd failed', { sessionId, kind, err });
       });
     },
-    [iosSimulatorPluginAvailable, sessionId, subagentsEnabled],
+    [iosSimulatorPluginAvailable, sessionId, subagentsEnabled, t],
   );
 
   const handleClose = useCallback(

--- a/apps/desktop/src/renderer/features/right-sidebar/__tests__/RightSidebarShell.test.ts
+++ b/apps/desktop/src/renderer/features/right-sidebar/__tests__/RightSidebarShell.test.ts
@@ -2,7 +2,7 @@
 
 import { createElement, useEffect } from 'react';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
-import { act, render, screen, waitFor } from '@testing-library/react';
+import { act, fireEvent, render, screen, waitFor } from '@testing-library/react';
 import type { AppShortcutOverrides } from '../../../../shared/appShortcuts';
 import type { LucideIcon } from 'lucide-react';
 
@@ -15,6 +15,15 @@ vi.mock('react-i18next', () => ({
 
 vi.mock('@/features/device-link/remoteProjectsStore', () => ({
   getSessionDeviceId: () => undefined,
+}));
+
+vi.mock('@/lib/toast', () => ({
+  toast: {
+    error: vi.fn(),
+    success: vi.fn(),
+    warning: vi.fn(),
+    info: vi.fn(),
+  },
 }));
 
 vi.mock('../plugins', () => ({}));
@@ -43,6 +52,7 @@ import {
   type SidebarVisibilityRequestOptions,
 } from '../lib/sidebarCommands';
 import { _resetStore, closeTab, getBucket, setActiveTab } from '../store';
+import { toast } from '@/lib/toast';
 import { writePanelCollapsed } from '@/layout/collapsePrefs';
 import { CHROME_ACTIONS_GEOMETRY } from '@/components/layout/chromeActionsGeometry';
 
@@ -1304,5 +1314,120 @@ describe('RightSidebarShell 跨 session popup 归属', () => {
     });
     expect(getBucket('s2').tabs).toHaveLength(0);
     expect(requests).toHaveLength(0);
+  });
+});
+
+describe('RightSidebarShell add-tab failure toast', () => {
+  const toastError = vi.mocked(toast.error);
+  let tabsIpc: RightSidebarTabsIpcStub;
+
+  beforeEach(() => {
+    toastError.mockClear();
+    Object.defineProperty(HTMLElement.prototype, 'scrollTo', {
+      configurable: true,
+      value: vi.fn(),
+    });
+    _resetStore();
+    _resetRsbBrowserBridgeForTests();
+    _resetPopupRouterForTests();
+    _resetNativePopupTabsForTests();
+    _resetSidebarCommandsForTests();
+    rsbBrowserCommandListeners = [];
+    rsbBrowserPopupListeners = [];
+    rsbNativePopupEventListeners = [];
+    rsbNativePopupClaim.mockClear();
+    rsbNativePopupClose.mockClear();
+    eagerSpawnAndReport.mockClear();
+    eagerSpawnAndReport.mockImplementation(async () => undefined);
+    tabsIpc = makeRightSidebarTabsIpc();
+    installElectronApi(tabsIpc);
+  });
+
+  afterEach(() => {
+    _resetSidebarCommandsForTests();
+    _resetStore();
+    _resetRsbBrowserBridgeForTests();
+    _resetPopupRouterForTests();
+    _resetNativePopupTabsForTests();
+    delete (window as unknown as { electronAPI?: unknown }).electronAPI;
+  });
+
+  function renderShellWithTerminalKind(): void {
+    registerTabKind({
+      kind: 'terminal',
+      menu: {
+        kind: 'terminal',
+        labelKey: 'rightSidebar.tabs.kinds.terminal',
+        icon: (() => null) as unknown as LucideIcon,
+        order: 1,
+        enabled: true,
+      },
+      TabPillTitle: () => createElement('span'),
+      TabBody: () => createElement('div'),
+      defaultState: () => null,
+    });
+    render(
+      createElement(RightSidebarShell, {
+        sessionId: 's1',
+        workdir: '/tmp/repo',
+        remoteHostId: null,
+        shellVisible: true,
+        isMac: true,
+      }),
+    );
+  }
+
+  it.each([
+    ['RIGHT_SIDEBAR_TOO_MANY_TABS', 'ipcError.RIGHT_SIDEBAR_TOO_MANY_TABS'],
+    ['RIGHT_SIDEBAR_STATE_TOO_LARGE', 'ipcError.RIGHT_SIDEBAR_STATE_TOO_LARGE'],
+    ['RIGHT_SIDEBAR_UNKNOWN_KIND', 'ipcError.RIGHT_SIDEBAR_UNKNOWN_KIND'],
+  ])('toasts the %s message when addTab fails', async (code, expectedKey) => {
+    tabsIpc.upsert.mockRejectedValueOnce(new Error(`[${code}] tab rejected`));
+    try {
+      renderShellWithTerminalKind();
+      await waitFor(() => expect(tabsIpc.list).toHaveBeenCalledWith({ sessionId: 's1' }));
+      const addButton = screen.getByRole('button', { name: 'rightSidebar.tabs.addAria' });
+      vi.spyOn(addButton.parentElement as HTMLElement, 'getBoundingClientRect').mockReturnValue({
+        x: 20,
+        y: 20,
+        top: 20,
+        right: 44,
+        bottom: 44,
+        left: 20,
+        width: 24,
+        height: 24,
+        toJSON: () => ({}),
+      });
+      fireEvent.click(addButton);
+      fireEvent.click(screen.getByRole('menuitem', { name: 'rightSidebar.tabs.kinds.terminal' }));
+      await waitFor(() => expect(toastError).toHaveBeenCalledWith(expectedKey));
+    } finally {
+      unregisterTabKind('terminal');
+    }
+  });
+
+  it('falls back to the generic addFailed toast for uncoded errors', async () => {
+    tabsIpc.upsert.mockRejectedValueOnce(new Error('boom'));
+    try {
+      renderShellWithTerminalKind();
+      await waitFor(() => expect(tabsIpc.list).toHaveBeenCalledWith({ sessionId: 's1' }));
+      const addButton = screen.getByRole('button', { name: 'rightSidebar.tabs.addAria' });
+      vi.spyOn(addButton.parentElement as HTMLElement, 'getBoundingClientRect').mockReturnValue({
+        x: 20,
+        y: 20,
+        top: 20,
+        right: 44,
+        bottom: 44,
+        left: 20,
+        width: 24,
+        height: 24,
+        toJSON: () => ({}),
+      });
+      fireEvent.click(addButton);
+      fireEvent.click(screen.getByRole('menuitem', { name: 'rightSidebar.tabs.kinds.terminal' }));
+      await waitFor(() => expect(toastError).toHaveBeenCalledWith('rightSidebar.tabs.addFailed'));
+    } finally {
+      unregisterTabKind('terminal');
+    }
   });
 });

--- a/apps/desktop/src/renderer/features/right-sidebar/__tests__/store.test.ts
+++ b/apps/desktop/src/renderer/features/right-sidebar/__tests__/store.test.ts
@@ -366,9 +366,13 @@ describe('RSB store', () => {
         await store.addTab('ghost-s1', 'web-browser', { url: `https://example.com/${i}` });
       }
 
-      await expect(
-        store.addTab('ghost-s1', 'web-browser', { url: 'https://example.com/overflow' }),
-      ).rejects.toThrow(/limit reached/);
+      const rejection = store.addTab(
+        'ghost-s1',
+        'web-browser',
+        { url: 'https://example.com/overflow' },
+      );
+      await expect(rejection).rejects.toMatchObject({ code: 'RIGHT_SIDEBAR_TOO_MANY_TABS' });
+      await expect(rejection).rejects.toThrow(/limit reached/);
       expect(store.getBucket('ghost-s1').tabs).toHaveLength(20);
       expect(ipc.upsert).not.toHaveBeenCalled();
     });

--- a/apps/desktop/src/renderer/features/right-sidebar/store.ts
+++ b/apps/desktop/src/renderer/features/right-sidebar/store.ts
@@ -11,7 +11,7 @@
  *  - subscribe(listener) 接收 sessionId-aware 通知;消费方(RightSidebarShell)通过
  *    React 的 useSyncExternalStore 订阅当前 sessionId 的桶变化。
  *
- * 错误暴露走 caller 的 catch + console.error;Phase 7 加 toast 统一暴露。
+ * 错误暴露走 caller 的 catch + console.error;Phase 7 收尾:添加失败由 Shell 按错误码 toast 统一暴露。
  *
  * 模块单例 → RightSidebar 整树 unmount/remount(session 切换时 MainLayout L553 条件渲染)也不丢数据。
  */
@@ -613,7 +613,8 @@ export async function addTab(
   const activate = opts?.activate !== false;
   const prev = getBucket(sessionId);
   if (prev.tabs.length >= MAX_TABS_PER_SESSION) {
-    throw new Error(
+    throw createIpcError(
+      'RIGHT_SIDEBAR_TOO_MANY_TABS',
       `session ${sessionId} already has ${MAX_TABS_PER_SESSION} tabs (limit reached)`,
     );
   }

--- a/apps/desktop/src/renderer/i18n/locales/en/common.json
+++ b/apps/desktop/src/renderer/i18n/locales/en/common.json
@@ -15,7 +15,10 @@
     "REMOTE_PROVIDER_UNSUPPORTED": "This provider is not supported in SSH remote sessions — pick another source",
     "REMOTE_NATIVE_OAUTH_UNAVAILABLE": "Claude.ai subscription is not connected — connect it first or pick a gateway model",
     "DEVICE_LINK_DEVICE_UNRESPONSIVE": "The target device is not responding. Check the remote device and try again.",
-    "INTERNAL": "Operation failed. Please try again later."
+    "INTERNAL": "Operation failed. Please try again later.",
+    "RIGHT_SIDEBAR_TOO_MANY_TABS": "This task has reached its tab limit. Close some tabs first",
+    "RIGHT_SIDEBAR_STATE_TOO_LARGE": "Tab content is too large to add",
+    "RIGHT_SIDEBAR_UNKNOWN_KIND": "This tab type is unavailable"
   },
   "providerError": {
     "AUTH_INVALID": "Invalid or expired API key (401). Check the key and try again",

--- a/apps/desktop/src/renderer/i18n/locales/ja/common.json
+++ b/apps/desktop/src/renderer/i18n/locales/ja/common.json
@@ -15,7 +15,10 @@
     "REMOTE_PROVIDER_UNSUPPORTED": "このプロバイダーは SSH リモートセッションに対応していません。別のソースを選択してください",
     "REMOTE_NATIVE_OAUTH_UNAVAILABLE": "Claude.ai サブスクリプションが未接続です。先に接続するか、ゲートウェイモデルを選択してください",
     "DEVICE_LINK_DEVICE_UNRESPONSIVE": "対象デバイスが応答していません。リモートデバイスを確認して再試行してください。",
-    "INTERNAL": "操作に失敗しました。しばらくしてから再試行してください。"
+    "INTERNAL": "操作に失敗しました。しばらくしてから再試行してください。",
+    "RIGHT_SIDEBAR_TOO_MANY_TABS": "このタスクのタブ数の上限に達しました。いくつかのタブを閉じてください",
+    "RIGHT_SIDEBAR_STATE_TOO_LARGE": "タブの内容が大きすぎるため、追加できません",
+    "RIGHT_SIDEBAR_UNKNOWN_KIND": "このタブの種類は現在使用できません"
   },
   "providerError": {
     "AUTH_INVALID": "API キーが無効か期限切れです（401）。キーを確認して再試行してください",

--- a/apps/desktop/src/renderer/i18n/locales/ko/common.json
+++ b/apps/desktop/src/renderer/i18n/locales/ko/common.json
@@ -15,7 +15,10 @@
     "REMOTE_PROVIDER_UNSUPPORTED": "이 제공자는 SSH 원격 세션을 지원하지 않습니다. 다른 소스를 선택하세요",
     "REMOTE_NATIVE_OAUTH_UNAVAILABLE": "Claude.ai 구독이 연결되지 않았습니다. 먼저 연결하거나 게이트웨이 모델을 선택하세요",
     "DEVICE_LINK_DEVICE_UNRESPONSIVE": "대상 장치가 응답하지 않습니다. 원격 장치를 확인한 후 다시 시도하세요.",
-    "INTERNAL": "작업에 실패했습니다. 잠시 후 다시 시도하세요."
+    "INTERNAL": "작업에 실패했습니다. 잠시 후 다시 시도하세요.",
+    "RIGHT_SIDEBAR_TOO_MANY_TABS": "이 작업의 탭 한도에 도달했습니다. 일부 탭을 닫아 주세요",
+    "RIGHT_SIDEBAR_STATE_TOO_LARGE": "탭 내용이 너무 커서 추가할 수 없습니다",
+    "RIGHT_SIDEBAR_UNKNOWN_KIND": "이 탭 유형은 현재 사용할 수 없습니다"
   },
   "providerError": {
     "AUTH_INVALID": "API 키가 유효하지 않거나 만료되었습니다(401). 키를 확인한 후 다시 시도하세요",

--- a/apps/desktop/src/renderer/i18n/locales/zh-CN/common.json
+++ b/apps/desktop/src/renderer/i18n/locales/zh-CN/common.json
@@ -15,7 +15,10 @@
     "REMOTE_WORKDIR_INVALID": "远程项目目录无效，请重新选择项目目录。",
     "REMOTE_WORKDIR_NOT_FOUND": "远程项目目录不存在，请重新选择项目目录。",
     "REMOTE_WORKDIR_NOT_DIRECTORY": "远程项目路径不是文件夹，请重新选择项目目录。",
-    "REMOTE_WORKDIR_UNAVAILABLE": "远程项目目录不可访问，请恢复网络盘连接后重试。"
+    "REMOTE_WORKDIR_UNAVAILABLE": "远程项目目录不可访问，请恢复网络盘连接后重试。",
+    "RIGHT_SIDEBAR_TOO_MANY_TABS": "当前任务已达标签数量上限，请先关闭一些标签",
+    "RIGHT_SIDEBAR_STATE_TOO_LARGE": "标签内容过大，无法添加",
+    "RIGHT_SIDEBAR_UNKNOWN_KIND": "该标签类型暂不可用"
   },
   "providerError": {
     "AUTH_INVALID": "API 密钥无效或已过期（401），请检查密钥后重试",

--- a/apps/desktop/src/renderer/i18n/locales/zh-TW/common.json
+++ b/apps/desktop/src/renderer/i18n/locales/zh-TW/common.json
@@ -15,7 +15,10 @@
     "REMOTE_WORKDIR_INVALID": "遠端專案目錄無效，請重新選擇專案目錄。",
     "REMOTE_WORKDIR_NOT_FOUND": "遠端專案目錄不存在，請重新選擇專案目錄。",
     "REMOTE_WORKDIR_NOT_DIRECTORY": "遠端專案路徑不是資料夾，請重新選擇專案目錄。",
-    "REMOTE_WORKDIR_UNAVAILABLE": "遠端專案目錄不可訪問，請恢復網路盤連線後重試。"
+    "REMOTE_WORKDIR_UNAVAILABLE": "遠端專案目錄不可訪問，請恢復網路盤連線後重試。",
+    "RIGHT_SIDEBAR_TOO_MANY_TABS": "目前任務已達標籤數量上限，請先關閉一些標籤",
+    "RIGHT_SIDEBAR_STATE_TOO_LARGE": "標籤內容過大，無法新增",
+    "RIGHT_SIDEBAR_UNKNOWN_KIND": "此標籤類型暫時無法使用"
   },
   "providerError": {
     "AUTH_INVALID": "API 金鑰無效或已過期（401），請檢查金鑰後重試",


### PR DESCRIPTION
## 这次改了什么

### 摘要

右侧栏添加 tab 失败时（如单任务超过 20 个标签上限、tab state 超 16KB、kind 未注册），此前只写日志、界面毫无反馈，用户点「+」像没反应。本次在添加入口统一按错误码 toast 提示：专属错误码（`RIGHT_SIDEBAR_TOO_MANY_TABS` / `RIGHT_SIDEBAR_STATE_TOO_LARGE` / `RIGHT_SIDEBAR_UNKNOWN_KIND`）给出可理解的专属文案，其余错误落通用兜底「添加标签失败」。同时把 renderer 侧「超上限」预检抛错对齐为与 main 一致的错误码，并给独立侧栏窗口补挂 ToastContainer，保证两种形态的右侧栏都能看到提示。

### 变更类型

- [x] `fix` 缺陷修复
- [ ] `feat` 新功能
- [ ] `refactor` / `perf` 重构或性能优化
- [ ] `docs` / `test` / `chore` 文档、测试或工程维护
- [ ] 其他：

### 范围

- 关联 Issue / 需求：无（收尾 `RightSidebarShell.tsx` 内既有 `TODO(Phase 7)`）
- 本 PR 包含：
  - `RightSidebarShell.tsx`：`handleAdd` 失败改走 `mapIpcErrorToI18nKey(err, { fallback: 'rightSidebar.tabs.addFailed' })` → `toast.error`，覆盖「+」菜单与 EmptyState 快捷入口
  - 5 个 locale（zh-CN / zh-TW / en / ja / ko）全局 `ipcError` 命名空间新增 3 条错误码文案
  - `store.ts`：renderer 预检超 20 个 tab 改抛 `createIpcError('RIGHT_SIDEBAR_TOO_MANY_TABS')`（原为无错误码的裸 `Error`，与 main 侧契约对齐）
  - `SidebarWindowLayout.tsx`：挂 `<ToastContainer />`，独立侧栏窗口同样可显示 toast
  - 测试：`RightSidebarShell.test.ts` 新增 4 个用例（3 个错误码映射 + 1 个通用兜底）；`store.test.ts` 强化超限用例断言错误码；`ReusableWindowChrome.test.tsx` mock `@/components/ui/toast`
- 明确不包含：不改变 tab 数量上限 / state 大小上限的数值；不改 main 侧 `localDb/ipc/rightSidebarTabs.ts` 逻辑
- 用户可见变化：右侧栏添加 tab 失败时出现 toast 提示（此前无反馈），文案随错误码区分
- 是否存在 breaking change：无

### UI 变化

- 截图 / 录屏：无（未启动应用；toast 为既有组件，无新增视觉样式）
- 引用的设计规范：
  - DESIGN.md §11 Voice & Content（微文案规范）：toast 命名对象、不出现「成功」类填充词；zh-CN toast 结尾无句号；en 用 sentence case
  - Toast 视觉复用既有 `components/ui/toast`，未新增样式或硬编码颜色；icon 四色遵循 DESIGN.md §2 status-color 家族，pill 主体保持灰阶
  - 双模式：toast 容器为既有主题化基础设施，不引入模式相关硬编码；本次未做双模式实机目检（未启动应用），如实说明 Dark 模式未单独目检
  - 术语：「任务」按 task-and-conversation-naming 指 session；「标签」沿用右侧栏既有 tab 译法

## 怎么验证的

### 自动验证

```text
corepack pnpm --filter desktop exec vitest run src/renderer/features/right-sidebar
结果：56 files passed, 743 tests passed

corepack pnpm --filter desktop exec vitest run src/renderer/components/layout
结果：8 files passed, 44 tests passed

corepack pnpm test:unit:related
结果：PASS apps/desktop unit（related 11 个文件，184.2s）

corepack pnpm --filter desktop run typecheck
结果：通过（exit 0）

corepack pnpm check:i18n
结果：✅ 8520 个 key 五语一致

corepack pnpm check:i18n-glossary
结果：✅ 无新增违规（仅既有 proposed 术语告警）

corepack pnpm check:dco
结果：DCO check passed: 1 commit signed off（447321b3e）
```

### 手工验证

不涉及（未启动应用；未做双模式实机目检，原因见下）。

### 未执行的验证

- 未启动 Desktop 实机目检 toast 的 Light / Dark 表现：本环境无法交互运行 Electron；electron 二进制由 npmmirror 镜像补装，仅用于跑测试
- lint：改动源码文件（`RightSidebarShell.tsx` / `store.ts` / `SidebarWindowLayout.tsx`）eslint 通过；`RightSidebarShell.test.ts` 存在 4 个既有 eslint 报错（`_s/_t/_u` 未使用参数、`writePanelCollapsed` 未使用导入），HEAD 原版同样存在，非本次引入

## 风险

### 风险分类

- [x] 无已知风险
- [ ] SQLite / migration
- [ ] system prompt
- [ ] 协议兼容
- [ ] 权限 / 安全 / 用户数据
- [ ] 存量插件兼容（批准状态 / 指纹 / manifest 校验 / 安装布局 / 包格式）
- [ ] 原生层 / fingerprint / OTA
- [ ] 跨平台差异
- [ ] 其他：

### 影响与回滚

- 影响范围：renderer 右侧栏添加 tab 失败提示链路 + 独立侧栏窗口新增 ToastContainer 挂载（仅渲染既有组件）
- 回滚 / 降级方式：无状态迁移，直接 revert 提交 `447321b3e` 即可，不影响既有数据与已持久化 tab

### 提交前检查

- [x] 已 review 完整 diff
- [x] 每个 commit 都带 DCO 签名（`git commit -s`，见 [DCO](../DCO)）
- [x] UI 改动已在「UI 变化」注明引用的设计规范章节
- [x] 未提交凭证、令牌或授权文件
- [x] 已补充必要文档（`store.ts` / `RightSidebarShell.tsx` 的 Phase 7 注释同步更新）
- [x] 已确认测试结果或说明未执行原因