### PR TITLE
test(desktop): 用文件级 beforeAll 焐热 SUT 冷 import

### DIFF
--- a/apps/desktop/src/main/maker-host/__tests__/codexProxyHost.test.ts
+++ b/apps/desktop/src/main/maker-host/__tests__/codexProxyHost.test.ts
@@ -1,7 +1,7 @@
 import fs from 'node:fs';
 import os from 'node:os';
 import path from 'node:path';
-import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { afterEach, beforeAll, beforeEach, describe, expect, it, vi } from 'vitest';
 import { TEST_XD_GATEWAY_BASE_URL as XD_GATEWAY_BASE_URL } from '../../../test/vitest/clientEndpointsFixture';
 
 type Registry = {
@@ -142,6 +142,14 @@ async function freshCodexProxyHost() {
   return import('../codex-proxy-host.js');
 }
 
+// CI 忙时本文件首次 import SUT 要付 Vitest transform 整个模块图的冷启动钱:Linux 分片
+// 实测超默认 5s,Windows 分片超 15s,继续抬单测超时只是把死亡线后推。这笔成本属于环境
+// 冷启动,不属于任何断言 —— 文件级 beforeAll 先把模块图焐热(hook 超时独立计),之后各
+// 用例里 resetModules + import 只剩模块求值开销,回到默认超时内。
+beforeAll(async () => {
+  await import('../codex-proxy-host.js');
+}, 60_000);
+
 describe('withCodexUpstreamRecording', () => {
   const DEFAULT_UPSTREAM = 'https://gateway.example/v1';
   const ctxFor = (threadId?: string) => ({
@@ -151,7 +159,6 @@ describe('withCodexUpstreamRecording', () => {
     headers: threadId ? { 'thread-id': threadId } : {},
   }) as never;
 
-  // Linux CI shard 下本文件首次 resetModules + import SUT 经常超过默认 5s；断言未变。
   it('records the override upstream origin for the request thread', async () => {
     const host = await freshCodexProxyHost();
     host.resetCodexThreadUpstreamForTest();
@@ -166,7 +173,7 @@ describe('withCodexUpstreamRecording', () => {
     expect(host.getCodexThreadUpstreamOrigin('t-xai')).toBe('https://api.x.ai');
     // 没记录过的 thread 不借用别人的结论。
     expect(host.getCodexThreadUpstreamOrigin('t-other')).toBe(null);
-  }, 15_000);
+  });
 
   it('falls back to the default upstream when the decision does not override it', async () => {
     const host = await freshCodexProxyHost();


### PR DESCRIPTION
## 这次改了什么

### 摘要

`codexProxyHost.test.ts` 的首条用例一直在替整个 SUT 模块图的 Vitest 冷 transform 买单：

- Linux CI 2/2 分片实测超默认 5s（PR #3584 连续两次复现：5018ms / 5025ms）
- #3592 把该用例超时抬到 15s 后，Windows 2/2 分片又以 15082ms 超线
- 同文件其余 35+ 次 `resetModules + import` 都很快（transform 缓存已热），只有首条抽中冷启动

本 PR 把这笔环境冷启动成本挪进**带独立 60s 超时的文件级 beforeAll**：先 import 一次 SUT 焐热模块图，各用例内的 `resetModules + import` 只剩模块求值开销。首条用例超时退回默认 5s——符合 engineering-conventions §3.1「不继续扩大 timeout」的口径。断言逻辑零改动。

### 变更类型

- [ ] `feat` 新功能
- [ ] `fix` 缺陷修复
- [ ] `refactor` / `perf` 重构或性能优化
- [x] `docs` / `test` / `chore` 文档、测试或工程维护
- [ ] 其他：

### 范围

- 关联 Issue / 需求：#3584（其 CI 连续三次挂在同一用例，横跨 Linux/Windows 分片）
- 本 PR 包含：`codexProxyHost.test.ts` 单文件测试基建调整
- 明确不包含：生产代码改动；其它测试文件的类似问题
- 用户可见变化：无
- 是否存在 breaking change：无

### UI 变化

不涉及

## 怎么验证的

### 自动验证

```text
pnpm exec vitest run src/main/maker-host/__tests__/codexProxyHost.test.ts --pool=threads
结果：192 passed (192)，文件整体 14.7s，首条用例不再承担冷启动

pnpm test:unit:related
结果：PASS apps/desktop unit (66.0s)

pnpm --filter desktop run typecheck
结果：通过（tsc --noEmit exit 0）

pnpm check:dco
结果：passed（1 commit signed off）
```

### 手工验证

不涉及

### 未执行的验证

实机双模式目检：不涉及（纯测试文件改动，无 UI）

## 风险

### 风险分类

- [x] 无已知风险
- [ ] SQLite / migration
- [ ] system prompt
- [ ] 协议兼容
- [ ] 权限 / 安全 / 用户数据
- [ ] 存量插件兼容（批准状态 / 指纹 / manifest 校验 / 安装布局 / 包格式）
- [ ] 原生层 / fingerprint / OTA
- [ ] 跨平台差异
- [ ] 其他：

### 影响与回滚

- 影响范围：仅 `codexProxyHost.test.ts` 的执行结构；测试隔离性不变（beforeAll 的 import 会被首条用例的 `vi.resetModules() + import` 重新求值覆盖，用例间状态隔离逻辑原样保留）
- 回滚 / 降级方式：revert 本 PR 即可恢复原状

### 提交前检查

- [x] 已 review 完整 diff
- [x] 每个 commit 都带 DCO 签名（`git commit -s`，见 [DCO](../DCO)）
- [x] UI 改动已在「UI 变化」注明引用的设计规范章节（不涉及 UI 则跳过）
- [x] 未提交凭证、令牌或授权文件
- [x] 已补充必要文档
- [x] 已确认测试结果或说明未执行原因