### PR TITLE
fix(desktop): 按逻辑 MCP session 缓存不可用光标能力

### DIFF
--- a/apps/desktop/src/main/mcp-integrations/__tests__/computer.test.ts
+++ b/apps/desktop/src/main/mcp-integrations/__tests__/computer.test.ts
@@ -1124,7 +1124,49 @@ describe('computer mcp integration', () => {
     expect(mcpConnectMock).toHaveBeenCalledTimes(1);
   });
 
-  it('retries unsupported cursor setup after the MCP session is recreated', async () => {
+  it('does not retry unsupported cursor setup after stale driver recovery', async () => {
+    mcpCallToolMock
+      .mockResolvedValueOnce({ content: [{ type: 'text', text: '{"ok":true}' }] })
+      .mockResolvedValueOnce({
+        isError: true,
+        content: [{ type: 'text', text: "Permission denied: tool 'set_agent_cursor_style' has no reviewed risk classification" }],
+      })
+      .mockImplementationOnce((call: { name: string; arguments: Record<string, unknown> }) => ({
+        isError: true,
+        content: [{
+          type: 'text',
+          text: `session '${String(call.arguments.session)}' has ended; tool call '${call.name}' was rejected`,
+        }],
+      }))
+      .mockResolvedValueOnce({ content: [{ type: 'text', text: '{"ok":true}' }] })
+      .mockResolvedValueOnce({ content: [{ type: 'text', text: '{"ok":true}' }] })
+      .mockResolvedValueOnce({ content: [{ type: 'text', text: '{"ok":true,"clicked":true}' }] });
+
+    await expect(callComputerDriverTool('click', {
+      pid: 123,
+      window_id: 7,
+      x: 10,
+      y: 20,
+    }, { sessionId: 'session-style-stale-recovery' })).resolves.toEqual({ ok: true, clicked: true });
+
+    expect(mcpCallToolMock.mock.calls.map((call) => call[0]?.name)).toEqual([
+      'set_agent_cursor_motion',
+      'set_agent_cursor_style',
+      'click',
+      'end_session',
+      'set_agent_cursor_motion',
+      'click',
+    ]);
+    expect(mcpConnectMock).toHaveBeenCalledTimes(2);
+    expect(mcpCloseMock).toHaveBeenCalledTimes(1);
+    const clickSessions = mcpCallToolMock.mock.calls
+      .map((call) => call[0])
+      .filter((call) => call?.name === 'click')
+      .map((call) => (call?.arguments as { session: string }).session);
+    expectDriverSessionGenerations(clickSessions, 'session-style-stale-recovery', [0, 1]);
+  });
+
+  it('re-probes unsupported cursor setup after the logical MCP session is closed', async () => {
     mcpCallToolMock
       .mockResolvedValueOnce({ content: [{ type: 'text', text: '{"ok":true}' }] })
       .mockResolvedValueOnce({

--- a/apps/desktop/src/main/mcp-integrations/computer.ts
+++ b/apps/desktop/src/main/mcp-integrations/computer.ts
@@ -278,6 +278,7 @@ interface DaemonStatus {
 }
 
 interface CuaMcpSessionEntry {
+  logicalSessionId: string;
   client: Client;
   transport: StdioClientTransport;
   ready: Promise<void>;
@@ -288,6 +289,12 @@ interface CuaMcpSessionEntry {
   };
 }
 type CursorSetupState = 'pending' | 'applied' | 'unavailable';
+type CursorCapabilityState = 'unknown' | 'unavailable';
+
+interface CuaMcpSessionCursorCapabilities {
+  motion: CursorCapabilityState;
+  style: CursorCapabilityState;
+}
 
 interface ProcessSnapshotEntry {
   pid: number;
@@ -523,6 +530,9 @@ function probeDriverPermissionsOnce(options: { forceNew?: boolean } = {}): Promi
 }
 const cuaMcpSessions = new Map<string, CuaMcpSessionEntry>();
 const cuaMcpSessionCleanups = new Map<string, Promise<void>>();
+// 永久的能力/策略拒绝属于逻辑 MCP session，而不是某一代 driver transport。
+// applied/pending 仍保留在 entry 内，因为新 generation 必须重新应用成功的设置。
+const cuaMcpSessionCursorCapabilities = new Map<string, CuaMcpSessionCursorCapabilities>();
 const cuaDriverSessionGenerations = new Map<string, number>();
 const cuaMcpSessionCloseVersions = new Map<string, number>();
 
@@ -2114,13 +2124,15 @@ function createCuaMcpSession(sessionId: string): CuaMcpSessionEntry {
     name: 'xdt-maker-cua-driver',
     version: '0.1.0',
   });
+  const capabilities = cuaMcpSessionCursorCapabilities.get(sessionId);
   const entry: CuaMcpSessionEntry = {
+    logicalSessionId: sessionId,
     client,
     transport,
     driverSessionId: getDriverSessionId(sessionId),
     cursorSetup: {
-      motion: 'pending',
-      style: 'pending',
+      motion: capabilities?.motion === 'unavailable' ? 'unavailable' : 'pending',
+      style: capabilities?.style === 'unavailable' ? 'unavailable' : 'pending',
     },
     ready: withTimeout(
       client.connect(transport),
@@ -2267,6 +2279,7 @@ async function initializeDefaultCursorStyle(
   _args: Record<string, unknown>,
   entry: CuaMcpSessionEntry,
   session: string,
+  sessionCloseVersion: number,
 ): Promise<void> {
   if (!CURSOR_STYLED_TOOL_NAMES.has(name)) return;
 
@@ -2308,6 +2321,16 @@ async function initializeDefaultCursorStyle(
       const message = err instanceof Error ? err.message : String(err);
       if (isCursorSetupUnavailableError(message)) {
         entry.cursorSetup[call.stateKey] = 'unavailable';
+        if (getCuaMcpSessionCloseVersion(entry.logicalSessionId) === sessionCloseVersion) {
+          const capabilities = cuaMcpSessionCursorCapabilities.get(entry.logicalSessionId) ?? {
+            motion: 'unknown',
+            style: 'unknown',
+          };
+          cuaMcpSessionCursorCapabilities.set(entry.logicalSessionId, {
+            ...capabilities,
+            [call.stateKey]: 'unavailable',
+          });
+        }
         logger.info('cua-driver cursor setup unavailable; continuing without it', {
           tool: name,
           cursorTool: call.tool,
@@ -2327,9 +2350,10 @@ async function initializeDefaultCursorStyle(
 }
 
 /**
- * Driver capability/policy failures cannot recover while the same MCP process
- * remains alive. Remember them on the session entry so an optional cursor
- * decoration never adds a rejected tool call to every real computer action.
+ * Driver capability/policy failures cannot recover while the same logical MCP
+ * session remains alive. Remember them outside the generation-specific entry
+ * so an optional cursor decoration never adds a rejected tool call after a
+ * stale driver transport is replaced.
  */
 function isCursorSetupUnavailableError(message: string): boolean {
   return /has no reviewed risk classification|method not found|unknown tool|tool .+ not found/i.test(message);
@@ -3325,7 +3349,7 @@ export async function callComputerDriverTool(
   const entry = await getCuaMcpSession(sessionId);
   assertComputerDriverToolDispatchAvailable();
   const driverArgs = applyDriverSessionArgs(name, normalizedArgs, entry.driverSessionId);
-  await initializeDefaultCursorStyle(name, driverArgs, entry, entry.driverSessionId);
+  await initializeDefaultCursorStyle(name, driverArgs, entry, entry.driverSessionId, sessionCloseVersion);
   const timeoutMs = getCuaMcpToolTimeoutMs(name);
   try {
     const result = await callCuaMcpToolWithTypeTextChunks(entry, name, driverArgs, timeoutMs);
@@ -3372,7 +3396,13 @@ export async function callComputerDriverTool(
             }
           : normalizedArgs;
         const freshArgs = applyDriverSessionArgs(name, retryArgs, freshEntry.driverSessionId);
-        await initializeDefaultCursorStyle(name, freshArgs, freshEntry, freshEntry.driverSessionId);
+        await initializeDefaultCursorStyle(
+          name,
+          freshArgs,
+          freshEntry,
+          freshEntry.driverSessionId,
+          sessionCloseVersion,
+        );
         if (getCuaMcpSessionCloseVersion(sessionId) !== sessionCloseVersion) {
           await cleanupComputerDriverSessionInternal(sessionId, {
             resetGeneration: false,
@@ -3448,6 +3478,7 @@ async function cleanupComputerDriverSessionEntry(sessionId: string, entry: CuaMc
 }
 
 export function cleanupComputerDriverSession(sessionId: string): Promise<void> {
+  cuaMcpSessionCursorCapabilities.delete(sessionId);
   markCuaMcpSessionClosed(sessionId);
   const entry = cuaMcpSessions.get(sessionId);
   if (entry) {
@@ -3489,6 +3520,7 @@ export async function cleanupAllComputerDriverSessions(): Promise<void> {
   stopPermissionGrantFlow('cleanup');
   clearProcessSnapshotCache();
   await cleanupActiveComputerDriverSessions();
+  cuaMcpSessionCursorCapabilities.clear();
   cuaDriverSessionGenerations.clear();
   cuaMcpSessionCloseVersions.clear();
 }


### PR DESCRIPTION
## 这次改了什么

### 摘要

修复 `set_agent_cursor_style` 被 driver 以永久能力/策略错误拒绝后，在 stale driver recovery 轮换 generation 时被重复探测的问题。永久不可用状态现在按逻辑 MCP session 缓存；driver generation 仍各自维护已应用状态，以便新 generation 重新应用可用的光标设置。

### 变更类型

- [x] `fix` 缺陷修复
- [ ] `feat` 新功能
- [ ] `refactor` / `perf` 重构或性能优化
- [ ] `docs` / `test` / `chore` 文档、测试或工程维护
- [ ] 其他：

### 范围

- 关联 Issue / 需求：无
- 本 PR 包含：在 Cindy wrapper 中按逻辑 MCP session 缓存永久不可用的 Computer Use 光标能力；新 generation 继承该状态；补充 stale recovery 回归测试。
- 明确不包含：不修改 `cua-driver`、`lizi_computer` MCP server、system prompt、translator、usage、event loop 或权限边界；不改变临时错误的重试行为。
- 用户可见变化：遇到被策略永久拒绝的可选光标设置时，不再在同一逻辑 MCP session 的每个 driver generation 中重复调用；其它 Computer Use 调用继续执行。
- 是否存在 breaking change：无

### UI 变化

不涉及：仅修改 Desktop main 侧 Computer Use wrapper 状态管理与单测，没有改变界面、布局、样式或文案。

- 引用的设计规范：不涉及 UI。

## 怎么验证的

### 自动验证

```text
pnpm --filter desktop exec vitest run src/main/mcp-integrations/__tests__/computer.test.ts
结果：141/141 通过。

bash /Users/dash/Code/XD/dash/Skills/git/scripts/run-unit-gate.sh /Users/dash/Code/Cindy/cindy-fix-cursor-capability-session-cache
结果：GATE_EXIT=0；根 pnpm test:unit 全部通过。

pnpm --filter desktop run --if-present typecheck
结果：通过。

pnpm check:dco
结果：1 个 commit 的 DCO 签名检查通过。

git diff --check origin/main...HEAD
结果：通过。
```

### 手工验证

在 macOS 隔离 Desktop 开发版中发起两次只读 Computer Use 请求读取当前窗口标题。第一次真实遇到 stale generation `-0` 后仍成功返回 `Current window title: Cindy`；第二次 generation 已轮换到 `-1`，请求同样成功。运行日志中 `set_agent_cursor_style` 的永久拒绝仅有此前的首次探测记录，后续 generation 没有再次出现 `cursor setup unavailable`。

### 未执行的验证

未做脚本化的 cua-driver 端到端 session 失效演练；手工测试捕获到了真实 stale 文案并验证了用户请求最终成功，但没有人为注入 driver session 失效。

## 风险

### 风险分类

- [ ] 无已知风险
- [ ] SQLite / migration
- [ ] system prompt
- [ ] 协议兼容
- [ ] 权限 / 安全 / 用户数据
- [ ] 存量插件兼容（批准状态 / 指纹 / manifest 校验 / 安装布局 / 包格式）
- [ ] 原生层 / fingerprint / OTA
- [ ] 跨平台差异
- [x] 其他：Computer Use wrapper 的逻辑 session / driver generation 状态边界

### 影响与回滚

- 影响范围：仅影响 Desktop main 侧 Computer Use 的可选光标 motion/style 初始化；永久拒绝在逻辑 MCP session 内跳过，`applied` 状态仍按 driver generation 管理，逻辑 session 真正关闭后会清除缓存并重新探测。
- 回滚 / 降级方式：回滚 commit `47499677ca62ce3746c946b993f37a844cb15321` 即可恢复原行为；不涉及数据迁移或用户配置。

### 提交前检查

- [x] 已 review 完整 diff
- [x] 每个 commit 都带 DCO 签名（`git commit -s`，见 [DCO](../DCO)）
- [x] UI 改动已在「UI 变化」注明引用的设计规范章节（不涉及 UI 则跳过）
- [x] 未提交凭证、令牌或授权文件
- [x] 已补充必要文档
- [x] 已确认测试结果或说明未执行原因
