### PR TITLE
fix(desktop): 固定 effort 模型切换不再把 null 写入 sessions.effort

### DIFF
--- a/apps/desktop/src/main/__tests__/sessionRuntimeControlWiring.test.ts
+++ b/apps/desktop/src/main/__tests__/sessionRuntimeControlWiring.test.ts
@@ -409,6 +409,25 @@ describe('session runtime control wiring', () => {
     expect(targetRoute).not.toContain('requiresCodexThreadRelink && atomicSelection');
   });
 
+  it('omits null runtime effort from the Codex relink SQLite commit', () => {
+    const setModel = handlerBody(
+      registerSource,
+      'const handleSetModel = async (',
+      'const recoverRemoteRuntimeAxisPersistence',
+    );
+    const relinkCommit = setModel.slice(
+      setModel.indexOf('commit: async ({ sessionId: targetSessionId, source, newSdkSessionId, target })'),
+      setModel.indexOf('if (write.changes === 0) return false;'),
+    );
+    expect(relinkCommit).toContain('persistableSessionEffort(target.effort)');
+    expect(relinkCommit).toContain(
+      '...(persistableEffort !== undefined ? { effort: persistableEffort } : {})',
+    );
+    expect(relinkCommit).not.toContain(
+      'effort: target.effort as (typeof sessions.$inferInsert)[\'effort\']',
+    );
+  });
+
   it('derives the Codex relink boundary from effective credential identities', () => {
     const setModel = handlerBody(
       registerSource,

--- a/apps/desktop/src/main/localDb/__tests__/sessionPatchToRow.effort.test.ts
+++ b/apps/desktop/src/main/localDb/__tests__/sessionPatchToRow.effort.test.ts
@@ -1,0 +1,25 @@
+import { describe, expect, it } from 'vitest';
+
+import { persistableSessionEffort, sessionPatchToRow } from '../mapper';
+
+describe('persistableSessionEffort', () => {
+  it('keeps legal enum values and drops runtime placeholders', () => {
+    expect(persistableSessionEffort('high')).toBe('high');
+    expect(persistableSessionEffort(' xhigh ')).toBe('xhigh');
+    expect(persistableSessionEffort(null)).toBeUndefined();
+    expect(persistableSessionEffort(undefined)).toBeUndefined();
+    expect(persistableSessionEffort('')).toBeUndefined();
+    expect(persistableSessionEffort('   ')).toBeUndefined();
+  });
+});
+
+describe('sessionPatchToRow effort persistence', () => {
+  it('writes a legal effort and omits null or blank placeholders', () => {
+    expect(sessionPatchToRow({ model: 'gpt-5.6', effort: 'low' })).toEqual(
+      expect.objectContaining({ model: 'gpt-5.6', effort: 'low' }),
+    );
+    expect(sessionPatchToRow({ model: 'grok-4.6', effort: null }).effort).toBeUndefined();
+    expect(sessionPatchToRow({ model: 'grok-4.6', effort: '' }).effort).toBeUndefined();
+    expect(sessionPatchToRow({ model: 'grok-4.6' }).effort).toBeUndefined();
+  });
+});

--- a/apps/desktop/src/main/localDb/ipc/__tests__/sessionsUpdate.test.ts
+++ b/apps/desktop/src/main/localDb/ipc/__tests__/sessionsUpdate.test.ts
@@ -124,6 +124,7 @@ vi.mock('../../../cindy-brain/index.js', () => ({
 
 import {
   patchSessionMetaInDb,
+  persistSessionFields,
   registerSessionIpc,
   resumeDeletedPiSubagentCleanup,
   setSessionRuntimeCleanup,
@@ -491,6 +492,23 @@ describe('local-db:sessions:update handler wiring', () => {
     expect(persisted.status).toBe('deleted');
     expect(h.tapWindowBroadcast).not.toHaveBeenCalled();
     expect(h.routeLock).toHaveBeenCalledWith('codex-local', expect.any(Function));
+  });
+
+  it('keeps the last legal sessions.effort when a fixed-effort model switch patches null', async () => {
+    await persistSessionFields('pi-local', {
+      model: 'x-ai-grok/grok-4.6',
+      effort: null,
+      fastMode: false,
+    });
+
+    const persisted = h
+      .sqlite!.prepare('SELECT model, effort, fast_mode FROM sessions WHERE id = ?')
+      .get('pi-local') as { model: string; effort: string; fast_mode: number };
+    expect(persisted).toEqual({
+      model: 'x-ai-grok/grok-4.6',
+      effort: 'high',
+      fast_mode: 0,
+    });
   });
 
   it('rejects setting drift for retained Review tasks while preserving metadata edits', async () => {

--- a/apps/desktop/src/main/localDb/ipc/sessions.ts
+++ b/apps/desktop/src/main/localDb/ipc/sessions.ts
@@ -38,6 +38,7 @@ import {
   sessionToCamel,
   sessionCreateToRow,
   sessionPatchToRow,
+  persistableSessionEffort,
   normalizeRemoteHostId,
   finalizePlainPreview,
   type SessionRowWithCount,
@@ -180,6 +181,7 @@ async function writeSessionPatch(
   setObj: ReturnType<typeof sessionPatchToRow>,
   status: unknown,
 ): Promise<void> {
+  if (Object.keys(setObj).length === 0) return;
   const deletedIsTerminal = status === 'active' || status === 'archived';
   const result = await db
     .update(sessions)
@@ -464,8 +466,10 @@ export async function applyAgentSwitchToSessionRow(
   if (patch.providerId !== undefined) setObj.providerId = patch.providerId;
   // effort 值域由 renderer 按目标引擎 capabilities 解析(schema 列是字面量联合,
   // 跨层传输后此处以 string 到达;非法值与直改 DB 同级,运行时由引擎侧收敛)。
-  if (patch.effort !== undefined) {
-    setObj.effort = patch.effort as (typeof sessions.$inferInsert)['effort'];
+  // 固定 effort 模型运行时为 null；sessions.effort NOT NULL，省略该字段。
+  const persistableEffort = persistableSessionEffort(patch.effort);
+  if (persistableEffort !== undefined) {
+    setObj.effort = persistableEffort;
   }
   if (patch.fastMode !== undefined) setObj.fastMode = patch.fastMode;
   if (typeof patch.contextWindow === 'number' && patch.contextWindow > 0) {
@@ -480,7 +484,7 @@ export async function applyAgentSwitchToSessionRow(
       model: patch.model,
       sdkSessionId: nextSdkSessionId,
       ...(patch.providerId !== undefined ? { providerId: patch.providerId } : {}),
-      ...(patch.effort !== undefined ? { effort: patch.effort } : {}),
+      ...(persistableEffort !== undefined ? { effort: persistableEffort } : {}),
       ...(patch.fastMode !== undefined ? { fastMode: patch.fastMode } : {}),
       ...(typeof patch.contextWindow === 'number' && patch.contextWindow > 0
         ? { contextWindow: Math.floor(patch.contextWindow) }
@@ -555,11 +559,17 @@ export async function persistSessionFields(
   for (const k of Object.keys(patch)) {
     if (REMOTE_PERSIST_FIELDS.has(k)) clean[k] = patch[k];
   }
+  if (Object.prototype.hasOwnProperty.call(clean, 'effort')) {
+    const persistableEffort = persistableSessionEffort(clean.effort);
+    if (persistableEffort === undefined) delete clean.effort;
+    else clean.effort = persistableEffort;
+  }
   if (Object.keys(clean).length === 0) return;
   const db = getDbClient().drizzle;
   const setObj = sessionPatchToRow(clean as Parameters<typeof sessionPatchToRow>[0], {
     bumpUpdatedAt: false,
   });
+  if (Object.keys(setObj).length === 0) return;
   await db.update(sessions).set(setObj).where(eq(sessions.id, sessionId));
   if (isOwnerScopeCurrent(ownerScope)) broadcastSessionPatched(sessionId, clean, ownerScope);
 }

--- a/apps/desktop/src/main/localDb/mapper.ts
+++ b/apps/desktop/src/main/localDb/mapper.ts
@@ -54,6 +54,19 @@ import {
 
 type SessionRow = typeof sessions.$inferSelect;
 type SessionInsert = typeof sessions.$inferInsert;
+
+/**
+ * 运行时固定 effort 模型用 `null`；`sessions.effort` 是 NOT NULL 枚举。
+ * 空白 / null 表示不落库，UPDATE 保留该行已有的合法档位。
+ */
+export function persistableSessionEffort(
+  effort: unknown,
+): SessionInsert['effort'] | undefined {
+  if (typeof effort !== 'string') return undefined;
+  const trimmed = effort.trim();
+  return trimmed ? (trimmed as SessionInsert['effort']) : undefined;
+}
+
 type MessageRow = typeof messages.$inferSelect;
 type MessageInsert = typeof messages.$inferInsert;
 type ScheduleRow = typeof schedules.$inferSelect;
@@ -384,7 +397,7 @@ export function sessionPatchToRow(
     workingDir?: string;
     workspaceKind?: WorkspaceKind;
     model?: string;
-    effort?: string;
+    effort?: string | null;
     permissionMode?: string;
     providerId?: string | null;
     fastMode?: boolean;
@@ -409,7 +422,8 @@ export function sessionPatchToRow(
     out.workingDir = normalizeWorkingDirForStorage(patch.workingDir);
   if (patch.workspaceKind !== undefined) out.workspaceKind = patch.workspaceKind;
   if (patch.model !== undefined) out.model = patch.model;
-  if (patch.effort !== undefined) out.effort = patch.effort as SessionInsert['effort'];
+  const persistableEffort = persistableSessionEffort(patch.effort);
+  if (persistableEffort !== undefined) out.effort = persistableEffort;
   if (patch.permissionMode !== undefined)
     out.permissionMode = patch.permissionMode as SessionInsert['permissionMode'];
   if (patch.providerId !== undefined) out.providerId = patch.providerId;

--- a/apps/desktop/src/main/maker-ipc/register.ts
+++ b/apps/desktop/src/main/maker-ipc/register.ts
@@ -298,6 +298,7 @@ import {
   recycleSessionWorktreeForStatusChange,
   setSessionRuntimeCleanup,
 } from '../localDb/ipc/sessions.js';
+import { persistableSessionEffort } from '../localDb/mapper.js';
 // sidebar-card-mode: turn-done 后刷新列表预览,并按需生成置顶卡片摘要
 import {
   maybeGenerateSessionTaskSummary,
@@ -15547,6 +15548,7 @@ export function registerMakerIpc(maker: Maker, options: RegisterMakerIpcOptions)
                     return false;
                   }
                   const now = Date.now();
+                  const persistableEffort = persistableSessionEffort(target.effort);
                   const sourceRouteConditions = [
                     eq(sessions.id, targetSessionId),
                     eq(sessions.sdkSessionId, source.sdkSessionId),
@@ -15568,7 +15570,7 @@ export function registerMakerIpc(maker: Maker, options: RegisterMakerIpcOptions)
                       sdkSessionId: newSdkSessionId,
                       model: target.model,
                       providerId: target.providerId,
-                      effort: target.effort as (typeof sessions.$inferInsert)['effort'],
+                      ...(persistableEffort !== undefined ? { effort: persistableEffort } : {}),
                       fastMode: target.fastMode,
                       updatedAt: now,
                     })
@@ -15581,7 +15583,7 @@ export function registerMakerIpc(maker: Maker, options: RegisterMakerIpcOptions)
                       sdkSessionId: newSdkSessionId,
                       model: target.model,
                       providerId: target.providerId,
-                      effort: target.effort,
+                      ...(persistableEffort !== undefined ? { effort: persistableEffort } : {}),
                       fastMode: target.fastMode,
                       updatedAt: new Date(now).toISOString(),
                     },


### PR DESCRIPTION
## 这次改了什么

### 摘要

已有 Pi 任务切到没有可调思考档的模型（例如自定义 Provider 的 grok-4.6）时，运行时会把 `effort` 收成 `null`，随后 `maker:set-model` 把它写进 `sessions.effort`。该列是 NOT NULL 枚举，SQLite 拒写，界面报「设置切换失败，未生效」。

本 PR 在落库边界省略 `null` / 空白 effort，保留行上已有合法档位。运行时仍用 `null` 表示固定档，重载时按模型能力归一化。

### 变更类型

- [x] `fix` 缺陷修复
- [ ] `feat` 新功能
- [ ] `refactor` / `perf` 重构或性能优化
- [ ] `docs` / `test` / `chore` 文档、测试或工程维护
- [ ] 其他：

### 范围

- 关联 Issue / 需求：#3691
- 本 PR 包含：`persistSessionFields` / `sessionPatchToRow` / agent-switch 行更新 / Codex relink CAS commit 对 `effort: null` 的省略
- 明确不包含：把 `sessions.effort` 改成 nullable、migration、`''`/`'none'` 新档位、#3601 缩窗护栏、手机原子 selection 补齐、改自定义 Provider 目录
- 用户可见变化：已有任务切到固定 effort 模型应成功，不再 toast 失败
- 是否存在 breaking change：无

### UI 变化

- 引用的设计规范：不涉及

## 怎么验证的

### 自动验证

```text
pnpm --filter desktop run typecheck
结果：通过

pnpm --filter desktop exec vitest run   src/main/localDb/__tests__/sessionPatchToRow.effort.test.ts   src/main/localDb/ipc/__tests__/sessionsUpdate.test.ts   src/main/__tests__/sessionRuntimeControlWiring.test.ts   src/main/maker-ipc/__tests__/codexProviderThreadRelink.test.ts
结果：4 files / 75 tests passed

pnpm test:unit:related
结果：apps/desktop unit passed (26.3s)

pnpm check:dco
结果：passed
```

### 手工验证

不涉及。未在实机从 `codex/gpt-5.6-luna` 切到 litellm `grok-4.6`。

### 未执行的验证

真机按 #3691 步骤复验：已有 Pi 任务切到固定 effort 自定义模型，确认切换成功、DB 未写 NULL、重启后不把旧档位显示成可调。

## 风险

### 风险分类

- [ ] 无已知风险
- [x] SQLite / migration
- [ ] system prompt
- [ ] 协议兼容
- [ ] 权限 / 安全 / 用户数据
- [ ] 存量插件兼容（批准状态 / 指纹 / manifest 校验 / 安装布局 / 包格式）
- [ ] 原生层 / fingerprint / OTA
- [ ] 跨平台差异
- [ ] 其他：

未改 schema / migration。只是 UPDATE 不再写 `effort = NULL`。

### 影响与回滚

- 影响范围：Desktop 会话模型/来源切换的 effort 落库；Codex 换凭证身份 relink
- 回滚 / 降级方式：revert 本 PR

### 提交前检查

- [x] 已 review 完整 diff
- [x] 每个 commit 都带 DCO 签名（`git commit -s`，见 [DCO](../DCO)）
- [x] UI 改动已在「UI 变化」注明引用的设计规范章节（不涉及 UI 则跳过）
- [x] 未提交凭证、令牌或授权文件
- [x] 已补充必要文档
- [x] 已确认测试结果或说明未执行原因