### PR TITLE
fix(pi): 热切供应商后重建会话，避免 pi_provider_mismatch

### DIFF
--- a/apps/desktop/src/main/maker-host/__tests__/claudeProxyScopeGate.test.ts
+++ b/apps/desktop/src/main/maker-host/__tests__/claudeProxyScopeGate.test.ts
@@ -726,6 +726,36 @@ describe('pi routingTransform — xdt session header selects the Pi provider rou
     expect(decision).toEqual({ localHandler: expect.any(Function) });
   });
 
+  it.each([
+    ['openai', 'xai', '/v1/responses'],
+    ['xai', 'openai', '/codex/responses'],
+  ] as const)(
+    'rejects a stale %s header after the host re-pins the PI session to %s',
+    async (staleHeader, pinnedProvider, url) => {
+      setSessionProvider('sess-pi', pinnedProvider);
+      registerPiProxySession('sess-pi', 'session-secret', () => pinnedProvider);
+      const decision = await createModelRoutingTransform()(
+        undefined,
+        ctxWith({
+          'x-cindy-pi-session-id': 'sess-pi',
+          'x-cindy-pi-session-token': 'session-secret',
+          'x-cindy-pi-provider-id': staleHeader,
+        }, url),
+      );
+      const response = {
+        status: 0,
+        body: '',
+        writeHead(status: number) { this.status = status; },
+        end(body: string) { this.body = body; },
+      };
+
+      await decision?.localHandler?.({ res: response } as never);
+
+      expect(response.status).toBe(403);
+      expect(response.body).toContain('pi_provider_mismatch');
+    },
+  );
+
   it('rejects an implicit native header that differs from the host-resolved PI source', async () => {
     clearSessionProvider('sess-pi');
     registerPiProxySession('sess-pi', 'session-secret', () => 'xai');

--- a/apps/desktop/src/main/maker-host/__tests__/codexCredentialSwitch.test.ts
+++ b/apps/desktop/src/main/maker-host/__tests__/codexCredentialSwitch.test.ts
@@ -2,6 +2,7 @@ import { afterEach, describe, expect, it, vi } from 'vitest';
 
 import {
   isCodexThreadModelProviderIdentityMismatch,
+  piProxyProviderIdentity,
   prepareLocalSessionCredentialModeSwitch,
   prepareLocalCodexCredentialModeSwitch,
   shouldCloseSessionForCredentialSwitch,
@@ -253,6 +254,94 @@ describe('shouldCloseSessionForCredentialSwitch codex mode', () => {
       nextProviderId: 'openai',
       currentModel: 'codex/gpt-5.5',
       nextModel: 'gpt-5.4',
+    })).toBe(false);
+  });
+});
+
+describe('piProxyProviderIdentity', () => {
+  it('collapses Cindy gateway aliases to the headerless proxy identity', () => {
+    expect(piProxyProviderIdentity(null)).toBeNull();
+    expect(piProxyProviderIdentity(undefined)).toBeNull();
+    expect(piProxyProviderIdentity('xd')).toBeNull();
+    expect(piProxyProviderIdentity('cindy')).toBeNull();
+    expect(piProxyProviderIdentity('  xd  ')).toBeNull();
+  });
+
+  it('pins native subscription and BYOM sources', () => {
+    expect(piProxyProviderIdentity('xai')).toBe('xai');
+    expect(piProxyProviderIdentity('openai')).toBe('openai');
+    expect(piProxyProviderIdentity('anthropic')).toBe('anthropic');
+    expect(piProxyProviderIdentity('litellm-custom')).toBe('litellm-custom');
+  });
+});
+
+describe('shouldCloseSessionForCredentialSwitch pi proxy identity', () => {
+  it('closes idle Pi when crossing xAI and OpenAI even though both are provider-oauth', () => {
+    expect(shouldCloseSessionForCredentialSwitch({
+      agentKind: 'pi',
+      currentProviderId: 'xai',
+      nextProviderId: 'openai',
+      currentModel: 'grok-4.6',
+      nextModel: 'gpt-5.6-sol',
+    })).toBe(true);
+    expect(shouldCloseSessionForCredentialSwitch({
+      agentKind: 'pi',
+      currentProviderId: 'openai',
+      nextProviderId: 'xai',
+      currentModel: 'gpt-5.6-sol',
+      nextModel: 'grok-4.6',
+    })).toBe(true);
+  });
+
+  it('closes idle Pi when crossing native xAI and Cindy AI gateway', () => {
+    expect(shouldCloseSessionForCredentialSwitch({
+      agentKind: 'pi',
+      currentProviderId: 'xai',
+      nextProviderId: 'xd',
+      currentModel: 'grok-4.6',
+      nextModel: 'gpt-5.6-sol',
+    })).toBe(true);
+    expect(shouldCloseSessionForCredentialSwitch({
+      agentKind: 'pi',
+      currentProviderId: 'xd',
+      nextProviderId: 'xai',
+      currentModel: 'gpt-5.6-sol',
+      nextModel: 'grok-4.6',
+    })).toBe(true);
+  });
+
+  it('keeps a live Pi process for same-family model changes', () => {
+    expect(shouldCloseSessionForCredentialSwitch({
+      agentKind: 'pi',
+      currentProviderId: 'xai',
+      nextProviderId: 'xai',
+      currentModel: 'grok-4.6',
+      nextModel: 'grok-4.5',
+    })).toBe(false);
+    expect(shouldCloseSessionForCredentialSwitch({
+      agentKind: 'pi',
+      currentProviderId: 'openai',
+      nextProviderId: 'openai',
+      currentModel: 'gpt-5.6-sol',
+      nextModel: 'gpt-5.4',
+    })).toBe(false);
+    expect(shouldCloseSessionForCredentialSwitch({
+      agentKind: 'pi',
+      currentProviderId: 'xd',
+      nextProviderId: 'cindy',
+      currentModel: 'gpt-5.6-sol',
+      nextModel: 'gpt-5.4',
+    })).toBe(false);
+  });
+
+  it('does not close remote Pi sessions for proxy-identity switches', () => {
+    expect(shouldCloseSessionForCredentialSwitch({
+      agentKind: 'pi',
+      remoteHostId: 'remote-1',
+      currentProviderId: 'xai',
+      nextProviderId: 'openai',
+      currentModel: 'grok-4.6',
+      nextModel: 'gpt-5.6-sol',
     })).toBe(false);
   });
 });

--- a/apps/desktop/src/main/maker-host/codex-credential-switch.ts
+++ b/apps/desktop/src/main/maker-host/codex-credential-switch.ts
@@ -222,10 +222,29 @@ function throwIfCredentialSwitchAborted(signal: AbortSignal | undefined): void {
 }
 
 /**
+ * Pi loopback proxy identity that must agree across request header
+ * `x-cindy-pi-provider-id`, `registerPiProxySession`, and `sessions.provider_id`.
+ *
+ * Cindy gateway (`xd` / `cindy` / unset) sends no provider header. Native
+ * subscription and BYOM sources pin that id. Pi `set_model` does not reread
+ * spawn-time `models.json`, so crossing this identity on a live process leaves
+ * a stale header and the proxy returns 403 `pi_provider_mismatch`.
+ */
+export function piProxyProviderIdentity(
+  providerId: string | null | undefined,
+): string | null {
+  const normalized = normalizeProviderId(providerId);
+  if (!normalized || normalized === 'xd' || normalized === 'cindy') return null;
+  return normalized;
+}
+
+/**
  * 判断运行中的本地会话是否必须关闭后重建。
  *
  * provider route 可以在空闲时或 turn 边界热切，但 agent 子进程的凭证形态是 spawn-time 状态；
  * 只要旧/新来源解析出的 credential family 不同，就不能继续复用当前进程。
+ * Pi 还要额外对齐 proxy 供应商身份：Grok/xAI 与 GPT/OpenAI 同属
+ * `provider-oauth`，但活进程仍会带旧 `x-cindy-pi-provider-id`。
  */
 export function shouldCloseSessionForCredentialSwitch(
   input: ShouldCloseSessionForCredentialSwitchInput,
@@ -234,6 +253,12 @@ export function shouldCloseSessionForCredentialSwitch(
 
   const currentProviderId = normalizeProviderId(input.currentProviderId);
   const nextProviderId = normalizeProviderId(input.nextProviderId);
+  if (
+    input.agentKind === 'pi'
+    && piProxyProviderIdentity(currentProviderId) !== piProxyProviderIdentity(nextProviderId)
+  ) {
+    return true;
+  }
   const currentMode = resolveAgentCredentialMode({
     agentKind: input.agentKind,
     providerId: currentProviderId,

--- a/apps/desktop/src/main/maker-ipc/__tests__/runtimeSetModel.test.ts
+++ b/apps/desktop/src/main/maker-ipc/__tests__/runtimeSetModel.test.ts
@@ -891,6 +891,114 @@ describe('applyRuntimeSetModelChange', () => {
     expect(wakeSessionInputQueue).toHaveBeenCalledOnce();
   });
 
+  it.each([
+    { fromProvider: 'xai', fromModel: 'grok-4.6', toProvider: 'openai', toModel: 'gpt-5.6-sol' },
+    { fromProvider: 'openai', fromModel: 'gpt-5.6-sol', toProvider: 'xai', toModel: 'grok-4.6' },
+    { fromProvider: 'xai', fromModel: 'grok-4.6', toProvider: 'xd', toModel: 'gpt-5.6-sol' },
+    { fromProvider: 'xd', fromModel: 'gpt-5.6-sol', toProvider: 'xai', toModel: 'grok-4.6' },
+  ] as const)(
+    'closes idle Pi before $fromProvider → $toProvider so the next send lazy-creates',
+    async ({ fromProvider, fromModel, toProvider, toModel }) => {
+      const sessionId = rememberSession(`runtime-set-model-pi-${fromProvider}-to-${toProvider}`);
+      setSessionProvider(sessionId, fromProvider);
+      const setModel = vi.fn(async () => {});
+      const closeSession = vi.fn(async () => {
+        expect(getSessionProvider(sessionId)).toBe(fromProvider);
+      });
+      const maker: RuntimeSetModelMaker = {
+        getSession: () => ({
+          agentKind: 'pi',
+          remoteHostId: null,
+          model: fromModel,
+          setModel,
+        }),
+        listActiveSessions: () => [
+          { id: sessionId, agentKind: 'pi', remoteHostId: null, isTurnRunning: () => false },
+        ],
+        closeSession,
+      };
+
+      await expect(applyRuntimeSetModelChange({
+        maker,
+        sessionId,
+        model: toModel,
+        providerId: toProvider,
+        clearPendingCredentialSwitch: vi.fn(),
+        wakeSessionInputQueue: vi.fn(),
+      })).resolves.toEqual({ status: 'applied' });
+
+      expect(closeSession).toHaveBeenCalledWith(sessionId);
+      expect(setModel).not.toHaveBeenCalled();
+      expect(getSessionProvider(sessionId)).toBe(toProvider);
+    },
+  );
+
+  it('hot-switches idle Pi inside the same proxy identity without closing', async () => {
+    const sessionId = rememberSession('runtime-set-model-pi-same-xai');
+    setSessionProvider(sessionId, 'xai');
+    const setModel = vi.fn(async () => {});
+    const closeSession = vi.fn(async () => {});
+    const maker: RuntimeSetModelMaker = {
+      getSession: () => ({
+        agentKind: 'pi',
+        remoteHostId: null,
+        model: 'grok-4.6',
+        setModel,
+      }),
+      listActiveSessions: () => [
+        { id: sessionId, agentKind: 'pi', remoteHostId: null, isTurnRunning: () => false },
+      ],
+      closeSession,
+    };
+
+    await expect(applyRuntimeSetModelChange({
+      maker,
+      sessionId,
+      model: 'grok-4.5',
+      providerId: 'xai',
+    })).resolves.toEqual({ status: 'applied' });
+
+    expect(closeSession).not.toHaveBeenCalled();
+    expect(setModel).toHaveBeenCalledWith('grok-4.5', { providerId: 'xai' });
+    expect(getSessionProvider(sessionId)).toBe('xai');
+  });
+
+  it('defers a busy Pi proxy-identity switch until the turn boundary', async () => {
+    const sessionId = rememberSession('runtime-set-model-pi-busy-xai-to-openai');
+    setSessionProvider(sessionId, 'xai');
+    const setModel = vi.fn(async () => {});
+    const closeSession = vi.fn(async () => {});
+    const registerPendingCredentialSwitch = vi.fn();
+    const maker: RuntimeSetModelMaker = {
+      getSession: () => ({
+        agentKind: 'pi',
+        remoteHostId: null,
+        model: 'grok-4.6',
+        setModel,
+      }),
+      listActiveSessions: () => [
+        { id: sessionId, agentKind: 'pi', remoteHostId: null, isTurnRunning: () => true },
+      ],
+      closeSession,
+    };
+
+    await expect(applyRuntimeSetModelChange({
+      maker,
+      sessionId,
+      model: 'gpt-5.6-sol',
+      providerId: 'openai',
+      registerPendingCredentialSwitch,
+    })).resolves.toEqual({ status: 'deferred' });
+
+    expect(registerPendingCredentialSwitch).toHaveBeenCalledWith(sessionId, {
+      model: 'gpt-5.6-sol',
+      providerId: 'openai',
+    });
+    expect(closeSession).not.toHaveBeenCalled();
+    expect(setModel).not.toHaveBeenCalled();
+    expect(getSessionProvider(sessionId)).toBe('xai');
+  });
+
   it('rebuilds an idle Orca Worker instead of hot-switching its live model', async () => {
     const sessionId = rememberSession('runtime-set-model-orca-worker-rebuild');
     setSessionProvider(sessionId, 'xd');

--- a/apps/desktop/src/main/scheduler-host/__tests__/runnerModelSelection.test.ts
+++ b/apps/desktop/src/main/scheduler-host/__tests__/runnerModelSelection.test.ts
@@ -333,7 +333,7 @@ describe('MakerScheduleRunner model selection', () => {
   });
 
   describe('Pi 派发前路由重裁决', () => {
-    it('晚到 reroute 在 send 前同步 Pi 原生 provider-model，再更新 host store', async () => {
+    it('晚到 reroute 跨 Pi proxy 身份时本轮失败，留给下次 fire 关进程重建', async () => {
       const checkModelRoute = vi
         .fn()
         .mockResolvedValueOnce({ kind: 'pass' as const })
@@ -341,31 +341,6 @@ describe('MakerScheduleRunner model selection', () => {
       const h = createSessionHarness();
       (h.session as { agentKind: string }).agentKind = 'pi';
       (h.session as { model: string }).model = 'chatgpt/gpt-5.6-sol';
-      const harness = createRunnerHarness(h, null, { checkModelRoute });
-
-      await fireToCompletion(
-        harness,
-        h,
-        baseSchedule({ agentKind: 'pi', model: 'chatgpt/gpt-5.6-sol' }),
-      );
-
-      expect(checkModelRoute).toHaveBeenCalledTimes(2);
-      expect(h.setModel).toHaveBeenCalledWith('chatgpt/gpt-5.6-sol', { providerId: 'byom-b' });
-      expect(h.setModel.mock.invocationCallOrder[0]).toBeLessThan(
-        h.send.mock.invocationCallOrder[0],
-      );
-      expect(mocks.setSessionProvider).toHaveBeenCalledWith('scheduler-session', 'byom-b');
-    });
-
-    it('晚到 reroute 的 Pi 原生同步失败时不写 store，也不发送 prompt', async () => {
-      const checkModelRoute = vi
-        .fn()
-        .mockResolvedValueOnce({ kind: 'pass' as const })
-        .mockResolvedValueOnce({ kind: 'reroute' as const, providerId: 'byom-b' });
-      const h = createSessionHarness();
-      (h.session as { agentKind: string }).agentKind = 'pi';
-      (h.session as { model: string }).model = 'chatgpt/gpt-5.6-sol';
-      h.setModel.mockRejectedValue(new Error('provider snapshot unavailable'));
       const harness = createRunnerHarness(h, null, { checkModelRoute });
 
       await expect(
@@ -373,8 +348,9 @@ describe('MakerScheduleRunner model selection', () => {
           baseSchedule({ agentKind: 'pi', model: 'chatgpt/gpt-5.6-sol' }),
           createFireContext(),
         ),
-      ).rejects.toThrow('Session send failed before dispatch');
-      expect(h.setModel).toHaveBeenCalledWith('chatgpt/gpt-5.6-sol', { providerId: 'byom-b' });
+      ).rejects.toThrow(/Session send failed before dispatch/);
+      expect(checkModelRoute).toHaveBeenCalledTimes(2);
+      expect(h.setModel).not.toHaveBeenCalled();
       expect(mocks.setSessionProvider).not.toHaveBeenCalled();
       expect(h.send).not.toHaveBeenCalled();
     });
@@ -1148,7 +1124,7 @@ describe('MakerScheduleRunner model selection', () => {
       );
     });
 
-    it('heartbeat 复用 Pi 时即使模型不变也把 provider-model 原子同步到原生进程', async () => {
+    it('heartbeat 复用 Pi 跨 proxy 身份时先关闭再按新来源重建', async () => {
       mocks.getSessionRowSnapshot.mockResolvedValue({ status: 'active', providerId: 'byom-a' });
       mocks.getSessionProvider.mockReturnValue('byom-a');
       const h = createSessionHarness();
@@ -1175,14 +1151,51 @@ describe('MakerScheduleRunner model selection', () => {
         }),
       );
 
-      expect(h.setModel).toHaveBeenCalledWith('gpt-5.6-sol', { providerId: 'byom-b' });
+      expect(harness.closeSession).toHaveBeenCalledWith('scheduler-session');
+      expect(harness.closeSession.mock.invocationCallOrder[0]).toBeLessThan(
+        harness.createSession.mock.invocationCallOrder[0],
+      );
+      expect(h.setModel).not.toHaveBeenCalled();
+      expect(harness.createSession).toHaveBeenCalledWith(
+        expect.objectContaining({ providerId: 'byom-b', model: 'gpt-5.6-sol' }),
+      );
+    });
+
+    it('heartbeat 复用 Pi 同身份时即使模型不变也把 provider-model 原子同步到原生进程', async () => {
+      mocks.getSessionRowSnapshot.mockResolvedValue({ status: 'active', providerId: 'byom-a' });
+      mocks.getSessionProvider.mockReturnValue('byom-a');
+      const h = createSessionHarness();
+      (h.session as { agentKind: string }).agentKind = 'pi';
+      (h.session as { model: string }).model = 'gpt-5.6-sol';
+      const harness = createRunnerHarness(
+        h,
+        {
+          model: 'gpt-5.6-sol',
+          workDir: '/work',
+          sdkSessionId: 'sdk-pi-1',
+        },
+        { sessionAlive: true },
+      );
+
+      await fireToCompletion(
+        harness,
+        h,
+        baseSchedule({
+          agentKind: 'pi',
+          model: 'gpt-5.6-sol',
+          providerId: 'byom-a',
+          targetSessionId: 'scheduler-session',
+        }),
+      );
+
+      expect(harness.closeSession).not.toHaveBeenCalled();
+      expect(h.setModel).toHaveBeenCalledWith('gpt-5.6-sol', { providerId: 'byom-a' });
       expect(h.setModel.mock.invocationCallOrder[0]).toBeLessThan(
         h.send.mock.invocationCallOrder[0],
       );
-      expect(mocks.setSessionProvider).toHaveBeenCalledWith('scheduler-session', 'byom-b');
     });
 
-    it('heartbeat 复用 Pi 的原生路由同步失败时在 send 前 fail-closed', async () => {
+    it('heartbeat 复用 Pi 同身份的原生路由同步失败时在 send 前 fail-closed', async () => {
       mocks.getSessionRowSnapshot.mockResolvedValue({ status: 'active', providerId: 'byom-a' });
       mocks.getSessionProvider.mockReturnValue('byom-a');
       const h = createSessionHarness();
@@ -1204,7 +1217,7 @@ describe('MakerScheduleRunner model selection', () => {
           baseSchedule({
             agentKind: 'pi',
             model: 'gpt-5.6-sol',
-            providerId: 'byom-b',
+            providerId: 'byom-a',
             targetSessionId: 'scheduler-session',
           }),
           createFireContext(),

--- a/apps/desktop/src/main/scheduler-host/__tests__/runnerQueuedDispatch.test.ts
+++ b/apps/desktop/src/main/scheduler-host/__tests__/runnerQueuedDispatch.test.ts
@@ -819,7 +819,7 @@ describe('MakerScheduleRunner queued dispatch (busy bound session)', () => {
     expect(harness.listenerCount()).toBe(0);
   });
 
-  it('排队 Pi 即使模型不变也同步原生 provider-model，并在派发前写 Fast', async () => {
+  it('排队 Pi 跨 proxy 身份时本轮沿用当前路由，不热切 setModel', async () => {
     mocks.getSessionRowSnapshot.mockResolvedValue({
       status: 'active',
       userSendAt: null,
@@ -846,14 +846,47 @@ describe('MakerScheduleRunner queued dispatch (busy bound session)', () => {
     await vi.waitFor(() => expect(queue.enqueueCalls.length).toBe(1));
     await queue.accept();
 
-    expect(harness.setModel).toHaveBeenCalledWith('gpt-5.6-sol', { providerId: 'byom-b' });
-    expect(mocks.setSessionProvider).toHaveBeenCalledWith(SESSION_ID, 'byom-b');
+    expect(harness.setModel).not.toHaveBeenCalled();
+    expect(mocks.setSessionProvider).not.toHaveBeenCalled();
+    harness.emit({ type: 'done', data: {}, source: 'pi' });
+    await expect(firePromise).resolves.toMatchObject({ sessionId: SESSION_ID });
+  });
+
+  it('排队 Pi 同身份时即使模型不变也同步原生 provider-model，并在派发前写 Fast', async () => {
+    mocks.getSessionRowSnapshot.mockResolvedValue({
+      status: 'active',
+      userSendAt: null,
+      providerId: 'byom-a',
+    });
+    mocks.getSessionProvider.mockReturnValue('byom-a');
+    const harness = createSessionHarness(async () => ({ accepted: true }));
+    (harness.session as { agentKind: string }).agentKind = 'pi';
+    (harness.session as { model: string }).model = 'gpt-5.6-sol';
+    const queue = createQueueHarness({ busy: true });
+    const { runner } = createRunnerHarness(harness.session, queue.deps, {
+      metaModel: 'gpt-5.6-sol',
+      metaFastMode: true,
+    });
+
+    const firePromise = runner.fire(
+      heartbeatSchedule({
+        agentKind: 'pi',
+        model: 'gpt-5.6-sol',
+        providerId: 'byom-a',
+      }),
+      createFireContext(),
+    );
+    await vi.waitFor(() => expect(queue.enqueueCalls.length).toBe(1));
+    await queue.accept();
+
+    expect(harness.setModel).toHaveBeenCalledWith('gpt-5.6-sol', { providerId: 'byom-a' });
+    expect(mocks.setSessionProvider).toHaveBeenCalledWith(SESSION_ID, 'byom-a');
     expect(mocks.setSessionFastMode).toHaveBeenCalledWith(SESSION_ID, true);
     harness.emit({ type: 'done', data: {}, source: 'pi' });
     await expect(firePromise).resolves.toMatchObject({ sessionId: SESSION_ID });
   });
 
-  it('排队 Pi 的原生路由同步失败时在 vendor dispatch 前 fail-closed', async () => {
+  it('排队 Pi 同身份的原生路由同步失败时在 vendor dispatch 前 fail-closed', async () => {
     mocks.getSessionRowSnapshot.mockResolvedValue({
       status: 'active',
       userSendAt: null,
@@ -873,7 +906,7 @@ describe('MakerScheduleRunner queued dispatch (busy bound session)', () => {
       heartbeatSchedule({
         agentKind: 'pi',
         model: 'gpt-5.6-sol',
-        providerId: 'byom-b',
+        providerId: 'byom-a',
       }),
       createFireContext(),
     );


### PR DESCRIPTION
## 这次改了什么

### 摘要

空闲 Pi 任务从 Grok/xAI 热切到 GPT（Cindy AI 或 OpenAI）后，下一条发送会 403 `pi_provider_mismatch`。根因是 Pi `set_model` 不重读 spawn 时的 `models.json`，活进程仍带旧的 `x-cindy-pi-provider-id`，而 host 已把注册 provider 和 `sessions.provider_id` 改成新来源。xAI 与 OpenAI 同属 `provider-oauth`，旧的凭证家族判定不会关进程。

本 PR 在 `shouldCloseSessionForCredentialSwitch` 为 Pi 增加 proxy 供应商身份判定：身份变化时关掉活进程，下次 send 按新路由 lazy create。反向 GPT → Grok、以及 Cindy AI ↔ xAI 同样关闭。代理门禁不放宽。

### 变更类型

- [x] `fix` 缺陷修复
- [ ] `feat` 新功能
- [ ] `refactor` / `perf` 重构或性能优化
- [ ] `docs` / `test` / `chore` 文档、测试或工程维护
- [ ] 其他：

### 范围

- 关联 Issue / 需求：实机 Cindy CN 0.1.37，Pi 任务从 grok-4.6 切到 GPT-5.6-Sol 后发送 403
- 本 PR 包含：Pi proxy 身份变化时关闭本会话；空闲路径下次 send lazy create；忙碌路径仍 deferred 到 turn 结束；相关单测
- 明确不包含：#3691 / PR #3703 的 `sessions.effort NOT NULL`；放宽 `pi_provider_mismatch` 门禁；把 effort/provider 列改 nullable；关闭或改写自动重试；压缩产品/压缩卡片百分比；schema / migration；`localDb.sessions.update is not a function`；Mobile / Claude Code / Codex 热切；已损坏活进程的自动自愈（需再切一次来源或停掉任务）
- 用户可见变化：空闲 Pi 任务跨 Grok/xAI、GPT/OpenAI、Cindy AI 后，下一条发送走新供应商，不再 403
- 是否存在 breaking change：无

### UI 变化

- 引用的设计规范：不涉及

## 怎么验证的

### 自动验证

```text
pnpm --filter desktop run typecheck
结果：通过

pnpm --filter desktop exec vitest run \
  src/main/maker-host/__tests__/codexCredentialSwitch.test.ts \
  src/main/maker-ipc/__tests__/runtimeSetModel.test.ts \
  src/main/maker-host/__tests__/claudeProxyScopeGate.test.ts \
  src/main/scheduler-host/__tests__/runnerModelSelection.test.ts \
  src/main/scheduler-host/__tests__/runnerQueuedDispatch.test.ts
结果：5 files / 212 tests passed

pnpm test:unit:related
结果：apps/desktop unit passed (27.2s)

pnpm check:dco
结果：passed（1 commit signed off）
```

### 手工验证

不涉及。未在 Cindy CN 实机从 grok-4.6 切到 GPT-5.6-Sol。

### 未执行的验证

真机复验（请用新开的空闲 Pi 任务，或先把已坏任务切走再切回）：

1. 新开 Pi 任务，用 Grok/xAI（如 grok-4.6）发一条，再切到 GPT-5.6-Sol（Cindy AI 或 OpenAI），下一条发送应走新供应商，不 403 `pi_provider_mismatch`
2. 反向：GPT → Grok 同样不 403，历史消息仍在
3. 同家族内切模型（grok-4.6 → grok-4.5）仍热切，不关进程
4. 伪造头与注册 provider 不一致的请求仍 403
5. 已损坏的活进程：若界面已是 GPT 但进程仍带着 xAI 头，只点发送不会自愈；需要再切一次来源/停掉任务后再发，或新开任务

未验证面：远端 Pi / SSH、任务进行中热切（应 deferred）、Mobile。

## 风险

### 风险分类

- [x] 无已知风险
- [ ] SQLite / migration
- [ ] system prompt
- [ ] 协议兼容
- [ ] 权限 / 安全 / 用户数据
- [ ] 存量插件兼容（批准状态 / 指纹 / manifest 校验 / 安装布局 / 包格式）
- [ ] 原生层 / fingerprint / OTA
- [ ] 跨平台差异
- [ ] 其他：

### 影响与回滚

- 影响范围：本地 Pi 跨 proxy 供应商身份的热切会关本会话进程，下次发送按新路由重建。消息不删。同身份热切不变。代理仍拒身份不一致的请求。
- 回滚 / 降级方式：revert 本 PR 即回到旧热切；会重新出现 Grok→GPT 403。

### 提交前检查

- [x] 已 review 完整 diff
- [x] 每个 commit 都带 DCO 签名（`git commit -s`，见 [DCO](../DCO)）
- [x] UI 改动已在「UI 变化」注明引用的设计规范章节（不涉及 UI 则跳过）
- [x] 未提交凭证、令牌或授权文件
- [x] 已补充必要文档
- [x] 已确认测试结果或说明未执行原因
