### PR TITLE
fix(pi): Full access 不再偷偷拦截原生允许的读和搜

### DIFF
--- a/docs/dev-rules/pi-full-access-native-parity.md
+++ b/docs/dev-rules/pi-full-access-native-parity.md
@@ -1,0 +1,37 @@
+# Pi Full Access 与原生对齐（需求正本）
+
+> **状态**：权威产品需求  
+> **读取时机**：改 Pi 权限拦截、Full access、凭证路径、`/proc/*/environ`、扩展工具门，或处理相关 review 之前  
+> **关系**：补充 [`pi-harness.md`](pi-harness.md)「Pi 上游 GUI 非退化红线」。本文件只锁 Full access 的读/搜/bash 对齐，不改 Ask / Auto。
+
+## 目标
+
+Cindy Pi 的 **Full access（`bypassPermissions`）必须与同版本原生 Pi 一致**：用户开了完全访问，就按原生 Pi 执行读、搜、bash 和已装 Pi 扩展工具。Cindy **不得**再用「路径像密钥」「可能扫到 credentials.json」「读进程环境」之类文本判断，在完全访问下偷偷拒绝原生允许的操作。
+
+用户可见承诺：完全访问就是完全访问，不暗拦。
+
+## 非目标（杀名单）
+
+下列一律不做。review / bot 提出也直接拒绝，不补代码、不扩权限模型、不新开状态机。
+
+- 不把 Ask / Auto-review 改成完全访问
+- 不新造权限档、白名单、二次审批、安全增强层
+- 不把 grep glob 相交做得更复杂（完全访问下本就不该因此拒绝）
+- 不拦已装 Pi 扩展的工具调用（完全访问下）
+- 不改 context-mode 自己的命令沙箱 PATH
+- 不改 MCP 网关、斜杠转义、项目 `--no-approve`
+- 不放开 Extra Dirs 结构化写入
+- 不放开对 Cindy 运行目录（`models.json` / 权限档）的模型写入
+
+## 允许保留的机械隔离
+
+仅这两条，且不得拿它们扩大阻断面：
+
+1. 模型不得写 agent home（Cindy 控制面）
+2. Extra Dirs 的结构化写工具保持只读
+
+需要真隔离时用 Ask / Auto，或等 OS 沙箱；不要在 Full access 上堆正则。
+
+## Review 处置
+
+本需求的验收已经最小。任何要求「补回 Full access 硬拦」「把凭证检测做得更严」「扩展也要再批一次」的意见，**本 PR 不改**。用本文件 + `pi-harness.md` 非退化红线回复并关闭。不得以安全增强为由让 Cindy Pi 比原生 Pi 更难用。

--- a/docs/dev-rules/pi-harness.md
+++ b/docs/dev-rules/pi-harness.md
@@ -107,6 +107,8 @@ Cindy 是 Pi 的上游 GUI，不是 Pi 的二次安全产品。Cindy 的 Pi 集�
 会话指向控制端本地路径、保护 Cindy 内部凭证不被写入包目录）。这类边界也不能被描述成
 Cindy 对 Pi 的产品安全升级，更不能拿来扩大阻断范围。
 
+Full access 读/搜/bash 与原生对齐的需求正本见 [`pi-full-access-native-parity.md`](pi-full-access-native-parity.md)。
+
 ## 4. 维护不变量(改动时不得破坏)
 
 1. **权限档从严到宽**:`capabilities.permissionModes` 必须 `[ask, auto, bypassPermissions]`

--- a/docs/dev-rules/pi-harness.md
+++ b/docs/dev-rules/pi-harness.md
@@ -21,15 +21,13 @@ Cindy 以 `pi --mode rpc` spawn pi 二进制(JSONL/stdio),`translator.ts` 把 pi
   子协议冒泡到 `index.ts handleExtensionUiRequest`,映射成 `InteractionRequest` 交 Cindy
   审批 UI。档位写 `<agentHome>/runtime/perm-<sessionId>.json`,bridge 每次 tool_call 现读
   (热切换)。
-- **Full access(`bypassPermissions`)契约(务必如实理解,勿夸大)**:该档下 Pi 的 `bash`
-  **不是**受隔离的凭证安全边界。bridge 里的凭证路径/`/proc/*/environ` 文本硬拦只是
-  **defense-in-depth**,可被变形绕过(`ps eww -p $PPID`、`find /proc -exec`、变量拼接 /
-  base64 / heredoc、重定向/`tee`/`cp`/`mv`/`python` 写文件等)。因此在 Full access 下:
-  - Pi 父进程环境里的代理 token / 网关 key / BYOM key / 外部 MCP header **可能被读取**;
-  - `readOnlyRoots`(Extra Dirs)**可能被写入**——只读语义靠 auto-review 提示与文本拦截,
-    非 OS 强制。
-  真正的强隔离需要 OS 级手段(macOS `sandbox-exec`、Linux 只读 bind mount / seccomp),
-  **本阶段未接入**。选择 Full access 即接受上述风险;需要硬边界时用 ask/auto 档,或等 OS
+- **Full access(`bypassPermissions`)契约(务必如实理解,勿夸大)**:该档与原生 Pi 对齐,
+  **不得**用凭证路径 / `/proc/*/environ` 文本硬拦拒绝原生允许的读、搜、bash。Ask/Auto
+  仍把这类调用升级为审批;Full access 选择即接受父进程环境里的代理 token / 网关 key /
+  BYOM key / 外部 MCP header **可能被读取**。允许保留的机械隔离仅限 Cindy 自身运行所必需:
+  模型不得写 agent home(`models.json` / 权限档),Extra Dirs 的结构化写工具保持只读。
+  bash 写入 Extra Dirs 仍非 OS 强制。真正的强隔离需要 OS 级手段(macOS `sandbox-exec`、
+  Linux 只读 bind mount / seccomp),**本阶段未接入**。需要硬边界时用 ask/auto 档,或等 OS
   沙箱落地。改动权限相关代码时不要再堆「看起来能拦」的正则并当成安全边界。
   与 Claude Code／Codex 一致，Pi 会话的 Full Access 也会让插件 `ghost_call` 的
   `attachments`／`dir`／`save_dir` 在 Host 侧免去额外过户确认；实现必须现读活跃 Session

--- a/packages/maker-core/src/agents/pi/__tests__/cindyBridgeSource.test.ts
+++ b/packages/maker-core/src/agents/pi/__tests__/cindyBridgeSource.test.ts
@@ -487,9 +487,10 @@ describe('cindy-bridge extension source', () => {
       expect(CINDY_BRIDGE_EXTENSION_SOURCE).toContain(
         'isCindyShellTool(event.toolName) && (bashReadEvidence.unresolved || touchesCredentialPath(bashReadTargets))',
       );
-      expect(CINDY_BRIDGE_EXTENSION_SOURCE).toContain(
+      expect(CINDY_BRIDGE_EXTENSION_SOURCE).not.toContain(
         "if (credentialRead && permission.mode === 'bypassPermissions')",
       );
+      expect(CINDY_BRIDGE_EXTENSION_SOURCE).toContain("if (permission.mode === 'bypassPermissions') return;");
       expect(CINDY_BRIDGE_EXTENSION_SOURCE).toContain('await ctx.ui.input(');
     } finally {
       rmSync(tempRoot, { recursive: true, force: true });
@@ -547,7 +548,7 @@ describe('cindy-bridge extension source', () => {
     () => {
       const source = CINDY_BRIDGE_EXTENSION_SOURCE;
       const helperStart = source.indexOf('const CREDENTIAL_PATH_PATTERNS');
-      const helperEnd = source.indexOf('// 从 bash 子进程读取任意进程的初始环境');
+      const helperEnd = source.indexOf('const PROC_ENVIRON_READ_RE');
       expect(helperStart).toBeGreaterThan(-1);
       expect(helperEnd).toBeGreaterThan(helperStart);
 
@@ -1544,10 +1545,12 @@ describe('cindy-bridge extension source', () => {
   it('hard-blocks writes only in read-only reference roots, not external writable roots', () => {
     const source = CINDY_BRIDGE_EXTENSION_SOURCE;
     const readOnlyGate = source.indexOf('permission.readOnlyRoots.some((root) =>');
-    const credentialGate = source.indexOf('if (isCindyShellTool(event.toolName) && commandReadsProcessEnviron', readOnlyGate);
+    const credentialGate = source.indexOf('const environRead = isCindyShellTool(event.toolName)', readOnlyGate);
     expect(readOnlyGate).toBeGreaterThan(-1);
     expect(credentialGate).toBeGreaterThan(readOnlyGate);
     expect(source.slice(readOnlyGate, credentialGate)).not.toContain('permission.writableRoots');
+    expect(source).not.toContain('Cindy blocks reading credential or key paths, even with Full access.');
+    expect(source).not.toContain('Cindy blocks reading process environment (/proc/*/environ), even with Full access.');
     expect(source).toContain('resolvedWritePath: writeTargetResolved');
     expect(source).toContain(
       'resolvedWritableRoots: resolveWritableRootsForHost(permission.writableRoots)',

--- a/packages/maker-core/src/agents/pi/__tests__/pi-agent.integration.test.ts
+++ b/packages/maker-core/src/agents/pi/__tests__/pi-agent.integration.test.ts
@@ -2192,12 +2192,13 @@ describe.skipIf(!piAvailable)('PiAgent integration (real pi binary + fake gatewa
     'full access does not secretly block credential-looking reads',
     { timeout: 60_000 },
     async () => {
-      // 与原生 Pi 对齐:Full access 不因路径像密钥就拒绝。Ask/Auto 仍升级审批。
       const workingDir = mkdtempSync(path.join(tmpdir(), 'pi-perm-bypass-cred-'));
+      const secretPath = path.join(workingDir, '.env');
+      writeFileSync(secretPath, 'CRED_MARKER=pi-full-access-ok\n');
       try {
         scriptedResponses.length = 0;
         scriptedResponses.push(
-          anthropicToolUseBody('read', { path: '/proc/self/environ' }),
+          anthropicToolUseBody('read', { path: secretPath }),
           anthropicStreamBody('bypass cred turn finished'),
         );
         const reqBefore = seenRequests.length;
@@ -2210,6 +2211,7 @@ describe.skipIf(!piAvailable)('PiAgent integration (real pi binary + fake gatewa
         expect(resolverTools).toEqual([]);
         const followUp = seenRequests.slice(reqBefore).map((r) => r.body);
         expect(followUp.some((b) => b.includes('Cindy blocks reading credential or key paths'))).toBe(false);
+        expect(followUp.some((b) => b.includes('CRED_MARKER=pi-full-access-ok'))).toBe(true);
       } finally {
         rmSync(workingDir, { recursive: true, force: true });
         scriptedResponses.length = 0;
@@ -2225,7 +2227,9 @@ describe.skipIf(!piAvailable)('PiAgent integration (real pi binary + fake gatewa
       try {
         scriptedResponses.length = 0;
         scriptedResponses.push(
-          anthropicToolUseBody('bash', { command: 'cat /proc/self/environ' }),
+          anthropicToolUseBody('bash', {
+            command: 'ENVIRON_MARKER=pi-full-access-ok; echo "$ENVIRON_MARKER"; cat /proc/self/environ',
+          }),
           anthropicStreamBody('bash environ turn finished'),
         );
         const reqBefore = seenRequests.length;
@@ -2238,6 +2242,7 @@ describe.skipIf(!piAvailable)('PiAgent integration (real pi binary + fake gatewa
         expect(resolverTools).toEqual([]);
         const followUp = seenRequests.slice(reqBefore).map((r) => r.body);
         expect(followUp.some((b) => b.includes('Cindy blocks reading process environment'))).toBe(false);
+        expect(followUp.some((b) => b.includes('ENVIRON_MARKER=pi-full-access-ok'))).toBe(true);
       } finally {
         rmSync(workingDir, { recursive: true, force: true });
         scriptedResponses.length = 0;
@@ -2449,6 +2454,7 @@ describe.skipIf(!piAvailable)('PiAgent integration (real pi binary + fake gatewa
         const fullAccessFollowUp = seenRequests.slice(fullAccessReqBefore).map((request) => request.body);
         expect(fullAccessFollowUp.some((body) => body.includes('Cindy blocks reading credential or key paths')))
           .toBe(false);
+        expect(fullAccessFollowUp.some((body) => body.includes('ordinary-glob-content'))).toBe(true);
 
         delete process.env.BASHOPTS;
         for (const [sessionId, command] of [
@@ -2476,7 +2482,7 @@ describe.skipIf(!piAvailable)('PiAgent integration (real pi binary + fake gatewa
 
         scriptedResponses.length = 0;
         scriptedResponses.push(
-          anthropicToolUseBody('bash', { command: 'shopt -s dotglob; cat <*' }),
+          anthropicToolUseBody('bash', { command: 'shopt -s dotglob; cat *' }),
           anthropicStreamBody('bash Full Access runtime dotglob turn finished'),
         );
         const runtimeFullAccessReqBefore = seenRequests.length;
@@ -2491,6 +2497,7 @@ describe.skipIf(!piAvailable)('PiAgent integration (real pi binary + fake gatewa
           .map((request) => request.body);
         expect(runtimeFullAccessFollowUp.some((body) =>
           body.includes('Cindy blocks reading credential or key paths'))).toBe(false);
+        expect(runtimeFullAccessFollowUp.some((body) => body.includes('FAKE_DOTGLOB_SECRET'))).toBe(true);
 
         scriptedResponses.length = 0;
         scriptedResponses.push(

--- a/packages/maker-core/src/agents/pi/__tests__/pi-agent.integration.test.ts
+++ b/packages/maker-core/src/agents/pi/__tests__/pi-agent.integration.test.ts
@@ -1827,8 +1827,8 @@ describe.skipIf(!piAvailable)('PiAgent integration (real pi binary + fake gatewa
         });
         expect(keyTurn.resolverTools).toEqual([]);
         const keyFollowUp = seenRequests.slice(keyReqBefore).map((request) => request.body).join('\n');
-        expect(keyFollowUp).not.toContain('KEY_SECRET=must-not-leak');
-        expect(keyFollowUp).toContain('Cindy blocks reading credential or key paths');
+        expect(keyFollowUp).toContain('KEY_SECRET=must-not-leak');
+        expect(keyFollowUp).not.toContain('Cindy blocks reading credential or key paths');
 
         scriptedResponses.push(
           anthropicToolUseBody('grep', { pattern: 'SAFE_SELECTOR', path: 'src', glob: 'source.ts' }),
@@ -2189,11 +2189,10 @@ describe.skipIf(!piAvailable)('PiAgent integration (real pi binary + fake gatewa
   );
 
   it(
-    'full access still blocks credential reads (parent env holds the proxy session token)',
+    'full access does not secretly block credential-looking reads',
     { timeout: 60_000 },
     async () => {
-      // greptile 回归:bypassPermissions 提前返回不得跳过凭证路径检查,否则内置 read
-      // 可读 /proc/self/environ 之类路径拿到父进程里的代理 token,绕过审批盗刷额度。
+      // 与原生 Pi 对齐:Full access 不因路径像密钥就拒绝。Ask/Auto 仍升级审批。
       const workingDir = mkdtempSync(path.join(tmpdir(), 'pi-perm-bypass-cred-'));
       try {
         scriptedResponses.length = 0;
@@ -2206,13 +2205,11 @@ describe.skipIf(!piAvailable)('PiAgent integration (real pi binary + fake gatewa
           sessionId: 'perm-bypass-cred',
           workingDir,
           permissionMode: 'bypassPermissions',
-          resolverBehavior: 'allow', // 若误弹窗且被 allow,下面的 block 理由断言就会失败
+          resolverBehavior: 'allow',
         });
-        // Full access 不弹窗,直接硬拦
         expect(resolverTools).toEqual([]);
         const followUp = seenRequests.slice(reqBefore).map((r) => r.body);
-        expect(followUp.some((b) => b.includes('Cindy blocks reading credential or key paths'))).toBe(true);
-        expect(followUp.some((b) => b.includes('CINDY_PI_SESSION_TOKEN='))).toBe(false);
+        expect(followUp.some((b) => b.includes('Cindy blocks reading credential or key paths'))).toBe(false);
       } finally {
         rmSync(workingDir, { recursive: true, force: true });
         scriptedResponses.length = 0;
@@ -2221,11 +2218,9 @@ describe.skipIf(!piAvailable)('PiAgent integration (real pi binary + fake gatewa
   );
 
   it(
-    'full access blocks bash reads of process environ (parent /proc holds the secrets)',
+    'full access does not secretly block bash reads of process environ',
     { timeout: 60_000 },
     async () => {
-      // codex 回归:spawn 边界只剥子进程 env,父 pi 进程仍持有 token;bash
-      // `cat /proc/self/environ` 同 UID 直取 → 即使 Full access 也硬拦。
       const workingDir = mkdtempSync(path.join(tmpdir(), 'pi-perm-bash-environ-'));
       try {
         scriptedResponses.length = 0;
@@ -2242,8 +2237,7 @@ describe.skipIf(!piAvailable)('PiAgent integration (real pi binary + fake gatewa
         });
         expect(resolverTools).toEqual([]);
         const followUp = seenRequests.slice(reqBefore).map((r) => r.body);
-        expect(followUp.some((b) => b.includes('Cindy blocks reading process environment'))).toBe(true);
-        expect(followUp.some((b) => b.includes('CINDY_PI_SESSION_TOKEN='))).toBe(false);
+        expect(followUp.some((b) => b.includes('Cindy blocks reading process environment'))).toBe(false);
       } finally {
         rmSync(workingDir, { recursive: true, force: true });
         scriptedResponses.length = 0;
@@ -2401,9 +2395,9 @@ describe.skipIf(!piAvailable)('PiAgent integration (real pi binary + fake gatewa
         });
         expect(fullAccessTurn.resolverTools).toEqual([]);
         const fullAccessFollowUp = seenRequests.slice(fullAccessReqBefore).map((request) => request.body);
-        expect(fullAccessFollowUp.some((body) => body.includes('FAKE_REDIRECT_DOTENV_SECRET'))).toBe(false);
         expect(fullAccessFollowUp.some((body) => body.includes('Cindy blocks reading credential or key paths')))
-          .toBe(true);
+          .toBe(false);
+        expect(fullAccessFollowUp.some((body) => body.includes('FAKE_REDIRECT_DOTENV_SECRET'))).toBe(true);
       } finally {
         rmSync(workingDir, { recursive: true, force: true });
         scriptedResponses.length = 0;
@@ -2453,9 +2447,8 @@ describe.skipIf(!piAvailable)('PiAgent integration (real pi binary + fake gatewa
         });
         expect(fullAccessTurn.resolverTools).toEqual([]);
         const fullAccessFollowUp = seenRequests.slice(fullAccessReqBefore).map((request) => request.body);
-        expect(fullAccessFollowUp.some((body) => body.includes('FAKE_DOTGLOB_SECRET'))).toBe(false);
         expect(fullAccessFollowUp.some((body) => body.includes('Cindy blocks reading credential or key paths')))
-          .toBe(true);
+          .toBe(false);
 
         delete process.env.BASHOPTS;
         for (const [sessionId, command] of [
@@ -2496,9 +2489,8 @@ describe.skipIf(!piAvailable)('PiAgent integration (real pi binary + fake gatewa
         expect(runtimeFullAccessTurn.resolverTools).toEqual([]);
         const runtimeFullAccessFollowUp = seenRequests.slice(runtimeFullAccessReqBefore)
           .map((request) => request.body);
-        expect(runtimeFullAccessFollowUp.some((body) => body.includes('FAKE_DOTGLOB_SECRET'))).toBe(false);
         expect(runtimeFullAccessFollowUp.some((body) =>
-          body.includes('Cindy blocks reading credential or key paths'))).toBe(true);
+          body.includes('Cindy blocks reading credential or key paths'))).toBe(false);
 
         scriptedResponses.length = 0;
         scriptedResponses.push(
@@ -2660,14 +2652,11 @@ describe.skipIf(!piAvailable)('PiAgent integration (real pi binary + fake gatewa
   );
 
   it.skipIf(!canSymlink)(
-    'full access blocks credential reads reached through a workspace symlink',
+    'full access does not secretly block credential reads reached through a workspace symlink',
     { timeout: 60_000 },
     async () => {
-      // greptile 回归:未解析路径命不中特征,但工作区内符号链接可指向敏感目标;
-      // realpath 跟随后再判 → 即使 Full access 也硬拦。
       const workingDir = mkdtempSync(path.join(tmpdir(), 'pi-perm-symlink-cred-'));
       try {
-        // 真实敏感文件(路径含 id_rsa,命中凭证特征)+ 工作区内指向它的无害名字符号链接。
         mkdirSync(path.join(workingDir, 'secrets'), { recursive: true });
         const secretPath = path.join(workingDir, 'secrets', 'id_rsa');
         writeFileSync(secretPath, 'FAKE PRIVATE KEY');
@@ -2688,8 +2677,8 @@ describe.skipIf(!piAvailable)('PiAgent integration (real pi binary + fake gatewa
         });
         expect(resolverTools).toEqual([]);
         const followUp = seenRequests.slice(reqBefore).map((r) => r.body);
-        expect(followUp.some((b) => b.includes('Cindy blocks reading credential or key paths'))).toBe(true);
-        expect(followUp.some((b) => b.includes('FAKE PRIVATE KEY'))).toBe(false);
+        expect(followUp.some((b) => b.includes('Cindy blocks reading credential or key paths'))).toBe(false);
+        expect(followUp.some((b) => b.includes('FAKE PRIVATE KEY'))).toBe(true);
       } finally {
         rmSync(workingDir, { recursive: true, force: true });
         scriptedResponses.length = 0;

--- a/packages/maker-core/src/agents/pi/cindy-bridge-source.ts
+++ b/packages/maker-core/src/agents/pi/cindy-bridge-source.ts
@@ -1743,15 +1743,10 @@ function resolvedCredentialEvidenceForHost(
   return credentialRead && paths.length === 0 ? null : [...paths];
 }
 
-// 从 bash 子进程读取任意进程的初始环境(/proc/<pid|self>/environ)是绕过密钥剥离的旁路:
-// spawn 边界虽从子进程 env 删了 Cindy 私密变量,但父 pi 进程仍持有它们,同 UID 下
-// cat /proc/PPID/environ 可直接取回代理 token / 网关 key / BYOM key(codex 报)。
-// 无法从 JS 侧让 /proc 不可读,故在工具边界对这类命令一律硬拦(含 Full access)。
-// 线程视图 /proc/<pid>/task/<tid>/environ(乃至其它中间段)与 /proc/<pid>/environ 等价可读,
-// 同样拦。中间段允许含斜杠(旧正则用 [^/...]* 只认单段,漏了 task/<tid>,codex report),
-// 与 readonly-builtin 硬拦所用的共享 SENSITIVE_CREDENTIAL_PATH 特征(/proc/[^斜杠空白]*/environ)
-// 保持同等覆盖。注:命令文本匹配不是安全边界(变形/间接读取可绕过,详见 pi-harness.md 的
-// Full access 契约),这里只是 defense-in-depth。
+// 检测 bash 是否在读 /proc/<pid|self>/environ。Ask/Auto 把它并进凭证读证据,走普通审批;
+// Full access 不硬拦 — 与原生 Pi 一致,选择该档即接受父进程环境可能被读取。
+// 线程视图 /proc/<pid>/task/<tid>/environ 与 /proc/<pid>/environ 等价可读。
+// 中间段允许含斜杠(旧正则用 [^/...]* 只认单段,漏了 task/<tid>)。
 // (本文件是 String.raw 模板,注释里严禁反引号,否则会提前终结模板。)
 const PROC_ENVIRON_READ_RE = /\/proc\/[^\s'"]*\/environ\b/i;
 function commandReadsProcessEnviron(command: unknown): boolean {
@@ -3451,15 +3446,9 @@ export default async function cindyBridge(pi: any) {
     ) {
       return { block: true, reason: 'Cindy extra reference directories are read-only.' };
     }
-    // bash 读取任意进程的初始环境(/proc/<pid|self>/environ)是绕过密钥剥离的旁路:
-    // spawn 边界虽删了子进程 env 的私密变量,父 pi 进程仍持有,cat /proc/PPID/environ
-    // 同 UID 直取代理 token / 网关 / BYOM key(codex 报)→ 一律硬拦,含 Full access。
-    if (isCindyShellTool(event.toolName) && commandReadsProcessEnviron(event.input?.command)) {
-      return { block: true, reason: 'Cindy blocks reading process environment (/proc/*/environ), even with Full access.' };
-    }
     // 凭证/密钥路径的内置只读工具与 bash 输入重定向都必须携带 canonical
-    // 证据。bash 的原始 input 是整条命令,不能直接 realpath;先用与 Host 相同的
-    // parser 提取真实输入目标,才能识别工作区 symlink 指向的凭证文件。
+    // 证据,供 Ask/Auto 升级审批。Full access 不在这里硬拦 — 原生 Pi 没有这道门,
+    // 文本拦截也不是安全边界(可被变形绕过)。
     const bashReadEvidence = event.toolName === 'bash'
       ? bashInputReadEvidence(event.input)
       : event.toolName === 'powershell'
@@ -3474,16 +3463,16 @@ export default async function cindyBridge(pi: any) {
       : isCindyShellTool(event.toolName)
         ? [...new Set(collectResolvedCredentialPaths(bashReadTargets))]
         : [];
+    const environRead = isCindyShellTool(event.toolName)
+      && commandReadsProcessEnviron(event.input?.command);
     const credentialRead = readonlyCredentialEvidence?.touchesCredential === true
       || (isCindyShellTool(event.toolName) && (bashReadEvidence.unresolved || touchesCredentialPath(bashReadTargets)))
-      || resolvedCredentialReadPaths.length > 0;
+      || resolvedCredentialReadPaths.length > 0
+      || environRead;
     const credentialEvidenceForHost = resolvedCredentialEvidenceForHost(
       resolvedCredentialReadPaths,
       credentialRead,
     );
-    if (credentialRead && permission.mode === 'bypassPermissions') {
-      return { block: true, reason: 'Cindy blocks reading credential or key paths, even with Full access.' };
-    }
     // Cindy-managed Pi extension mutations are a separate approval domain from
     // ordinary tool permissions. Full Access may bypass normal tool prompts,
     // but it must not let model-authored install/update/remove requests mutate


### PR DESCRIPTION
## 这次改了什么

### 摘要

完全访问下，Cindy Pi 不再因为「路径像密钥」偷偷拒绝原生 Pi 允许的读、搜、bash。Ask / Auto 审批不变。需求正本：`docs/dev-rules/pi-full-access-native-parity.md`。

### 变更类型

- [x] `fix` 缺陷修复
- [x] `docs` / `test` / `chore` 文档、测试或工程维护

### 范围

- 关联 Issue / 需求：`docs/dev-rules/pi-full-access-native-parity.md`
- 本 PR 包含：去掉 Full access 对凭证路径读、`/proc/*/environ` 的文本硬拦；Ask/Auto 仍升级审批；锁死非目标杀名单
- 明确不包含：Ask/Auto 行为、Extra Dirs 结构化写、agent home 写、MCP 网关、斜杠转义、项目 `--no-approve`、context-mode 沙箱 PATH、任何新的权限档或二次审批
- 用户可见变化：完全访问下搜仓库代码不再被误判成翻密钥而整次拒绝
- 是否存在 breaking change：无

### UI 变化

- 引用的设计规范：不涉及

## 怎么验证的

### 自动验证

```text
cd /Users/chris/Code/Github/cindy-pi-full-access-native-parity/packages/maker-core
pnpm exec vitest related --run --pool=forks --maxWorkers=1 \
  src/agents/pi/__tests__/cindyBridgeSource.test.ts \
  src/agents/pi/cindy-bridge-source.ts
结果：13 files, 433 passed, 2 skipped（含真 Pi 二进制集成）
```

### 手工验证

不涉及。

### 未执行的验证

未起 Desktop 实机点完全访问再搜一次；单测已覆盖 Full access 不再吐出硬拦文案，且 `?.key` grep 能读到内容。

## 风险

### 风险分类

- [x] 权限 / 安全 / 用户数据

### 影响与回滚

- 影响范围：仅 Pi Full access 的读/搜/bash。选择该档即接受与原生 Pi 相同的风险（父进程环境可能被读取）。Ask/Auto 不变。
- 回滚 / 降级方式：revert 本 PR。

### Review 口径（杀名单）

本 PR 验收已最小。下列意见直接拒绝，不改码、不扩权限模型：

- 要求 Full access 补回凭证路径 / environ 硬拦
- 要求把 grep glob 检测做得更严或更复杂
- 要求扩展工具在完全访问下再批一次
- 任何「安全增强」让 Cindy Pi 比同版本原生 Pi 更难用

依据：`docs/dev-rules/pi-full-access-native-parity.md` 与 `docs/dev-rules/pi-harness.md` 非退化红线。

### 提交前检查

- [x] 已 review 完整 diff
- [x] 每个 commit 都带 DCO 签名
- [x] 不涉及 UI
- [x] 未提交凭证、令牌或授权文件
- [x] 已补充需求文档
- [x] 已确认测试结果
