### PR TITLE
fix(claude-code): 幽灵 tool id 不再冻死生成时钟,live tok/s 不再膨胀

### DIFF
--- a/packages/maker-core/src/agents/claude-code/generation-timing.test.ts
+++ b/packages/maker-core/src/agents/claude-code/generation-timing.test.ts
@@ -1507,4 +1507,233 @@ describe('claude generation pause boundaries', () => {
     resetClaudeGenerationTiming(ctx.rt.generation);
     vi.useRealTimers();
   });
+
+  it('does not freeze the next turn when a previous turn left an unresolved tool id', () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(1_000);
+    const ctx = createTranslatorCtx();
+    const queue = createAsyncQueue<AgentEvent>();
+
+    // Turn 1: a tool_use streams but its tool_result echo never arrives
+    // (SDK-internal tools like ToolSearch resolve without an echo), then the
+    // turn ends.
+    translateSdkMessage(
+      {
+        type: 'stream_event',
+        event: {
+          type: 'message_start',
+          message: { model: 'claude-sonnet-4.5', usage: { input_tokens: 10 } },
+        },
+      },
+      queue,
+      ctx,
+    );
+    translateSdkMessage(
+      {
+        type: 'stream_event',
+        event: {
+          type: 'content_block_start',
+          index: 0,
+          content_block: { type: 'tool_use', id: 'toolu_stale', name: 'ToolSearch', input: {} },
+        },
+      },
+      queue,
+      ctx,
+    );
+    vi.setSystemTime(1_500);
+    translateSdkMessage(
+      {
+        type: 'stream_event',
+        event: { type: 'message_delta', usage: { output_tokens: 40 } },
+      },
+      queue,
+      ctx,
+    );
+    vi.setSystemTime(2_000);
+    translateSdkMessage(
+      {
+        type: 'result',
+        stop_reason: 'end_turn',
+        total_cost_usd: 0,
+        num_turns: 1,
+        usage: { input_tokens: 10, output_tokens: 40 },
+      },
+      queue,
+      ctx,
+    );
+    expect(ctx.rt.generation.pendingToolIds.size).toBe(0);
+
+    // Turn 2: the stale id must not re-enter pending, and the clock must
+    // restart once this turn's only real tool resolves. Otherwise the
+    // denominator freezes while output keeps accruing → runaway live tok/s.
+    vi.setSystemTime(10_000);
+    translateSdkMessage(
+      {
+        type: 'stream_event',
+        event: {
+          type: 'message_start',
+          message: { model: 'claude-sonnet-4.5', usage: { input_tokens: 12 } },
+        },
+      },
+      queue,
+      ctx,
+    );
+    expect(ctx.rt.generation.startedAt).toBe(10_000);
+    translateSdkMessage(
+      {
+        type: 'stream_event',
+        event: {
+          type: 'content_block_start',
+          index: 0,
+          content_block: { type: 'tool_use', id: 'toolu_next', name: 'Read', input: {} },
+        },
+      },
+      queue,
+      ctx,
+    );
+    vi.setSystemTime(10_400);
+    translateSdkMessage(
+      {
+        type: 'stream_event',
+        event: { type: 'message_delta', usage: { output_tokens: 100 } },
+      },
+      queue,
+      ctx,
+    );
+    expect(ctx.rt.generation.pendingToolIds.has('toolu_stale')).toBe(false);
+    expect(ctx.rt.generation.pendingToolIds.has('toolu_next')).toBe(true);
+    expect(ctx.rt.generation.durationMs).toBe(400);
+
+    vi.setSystemTime(10_600);
+    translateSdkMessage(
+      {
+        type: 'user',
+        message: {
+          content: [{ type: 'tool_result', tool_use_id: 'toolu_next', content: 'ok' }],
+        },
+      },
+      queue,
+      ctx,
+    );
+    expect(ctx.rt.generation.pendingToolIds.size).toBe(0);
+    expect(ctx.rt.generation.startedAt).toBe(10_600);
+    expect(ctx.rt.generation.reliable).toBe(true);
+
+    resetClaudeGenerationTiming(ctx.rt.generation);
+    queue.end();
+    vi.useRealTimers();
+  });
+
+  it('unfreezes the clock at the next request when a tool result echo never arrives', async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(1_000);
+    const ctx = createTranslatorCtx();
+    const queue = createAsyncQueue<AgentEvent>();
+
+    translateSdkMessage(
+      {
+        type: 'stream_event',
+        event: {
+          type: 'message_start',
+          message: { model: 'claude-sonnet-4.5', usage: { input_tokens: 10 } },
+        },
+      },
+      queue,
+      ctx,
+    );
+    translateSdkMessage(
+      {
+        type: 'stream_event',
+        event: {
+          type: 'content_block_start',
+          index: 0,
+          content_block: { type: 'tool_use', id: 'toolu_search', name: 'ToolSearch', input: {} },
+        },
+      },
+      queue,
+      ctx,
+    );
+    vi.setSystemTime(1_500);
+    translateSdkMessage(
+      {
+        type: 'stream_event',
+        event: { type: 'message_delta', usage: { output_tokens: 50 } },
+      },
+      queue,
+      ctx,
+    );
+    expect(ctx.rt.generation.pendingToolIds.has('toolu_search')).toBe(true);
+    expect(ctx.rt.generation.durationMs).toBe(500);
+
+    // The SDK resolved the tool internally without echoing a tool_result. A
+    // new parent request proves every tool of the previous message settled —
+    // the clock must restart instead of staying frozen for the rest of the
+    // turn.
+    vi.setSystemTime(4_000);
+    translateSdkMessage(
+      {
+        type: 'stream_event',
+        event: {
+          type: 'message_start',
+          message: { model: 'claude-sonnet-4.5', usage: { input_tokens: 12 } },
+        },
+      },
+      queue,
+      ctx,
+    );
+    expect(ctx.rt.generation.pendingToolIds.size).toBe(0);
+    expect(ctx.rt.generation.startedAt).toBe(4_000);
+    expect(ctx.rt.generation.reliable).toBe(true);
+
+    // A late echo for the internally settled id stays a no-op.
+    vi.setSystemTime(4_100);
+    translateSdkMessage(
+      {
+        type: 'user',
+        message: {
+          content: [{ type: 'tool_result', tool_use_id: 'toolu_search', content: 'loaded' }],
+        },
+      },
+      queue,
+      ctx,
+    );
+    expect(ctx.rt.generation.startedAt).toBe(4_000);
+    expect(ctx.rt.generation.reliable).toBe(true);
+
+    vi.setSystemTime(4_500);
+    translateSdkMessage(
+      {
+        type: 'stream_event',
+        event: { type: 'message_delta', usage: { output_tokens: 100 } },
+      },
+      queue,
+      ctx,
+    );
+    vi.setSystemTime(4_800);
+    translateSdkMessage(
+      {
+        type: 'result',
+        stop_reason: 'end_turn',
+        total_cost_usd: 0,
+        num_turns: 1,
+        usage: { input_tokens: 22, output_tokens: 150 },
+      },
+      queue,
+      ctx,
+    );
+    queue.end();
+    const events: AgentEvent[] = [];
+    for await (const event of queue) events.push(event);
+    const doneStatus = events.find(
+      (event) => event.type === 'status' && (event.data as { status?: string }).status === 'Done',
+    );
+    expect(doneStatus?.data).toMatchObject({
+      outputTokens: 150,
+      generationReliable: true,
+      generationActive: false,
+      generationDurationMs: 1_300,
+    });
+    resetClaudeGenerationTiming(ctx.rt.generation);
+    vi.useRealTimers();
+  });
 });

--- a/packages/maker-core/src/agents/claude-code/generation-timing.ts
+++ b/packages/maker-core/src/agents/claude-code/generation-timing.ts
@@ -97,6 +97,22 @@ export function beginClaudeGeneration(state: ClaudeGenerationState, startedAt = 
   }
 }
 
+/**
+ * A new parent request can only be dispatched after every tool_result of the
+ * previous message reached the provider, so ids still pending here belong to
+ * tools whose results the SDK resolved without echoing (e.g. ToolSearch).
+ * Settle them instead of letting one phantom id freeze the clock for the rest
+ * of the turn while output keeps accruing (runaway live tok/s).
+ */
+export function beginClaudeGenerationAtRequestStart(
+  state: ClaudeGenerationState,
+  startedAt = Date.now(),
+): void {
+  for (const pauseId of state.pendingToolIds) state.settledPauseIds.add(pauseId);
+  state.pendingToolIds.clear();
+  beginClaudeGeneration(state, startedAt);
+}
+
 export function pauseClaudeGeneration(
   state: ClaudeGenerationState,
   pauseId: string,
@@ -123,6 +139,9 @@ export function resumeClaudeGeneration(
   pauseId: string,
   resumedAt = Date.now(),
 ): void {
+  // A late echo for an already-settled id (internally resolved at the next
+  // request boundary, or a duplicate result) is a no-op, not an imbalance.
+  if (state.settledPauseIds.has(pauseId)) return;
   if (!state.pendingToolIds.delete(pauseId)) {
     state.reliable = false;
     return;

--- a/packages/maker-core/src/agents/claude-code/translator.ts
+++ b/packages/maker-core/src/agents/claude-code/translator.ts
@@ -39,6 +39,7 @@ import type { UsageTracker } from '../shared/usage-tracker.js';
 import { attachLiveGeneration } from '../shared/live-generation-snapshot.js';
 import {
   beginClaudeGeneration,
+  beginClaudeGenerationAtRequestStart,
   finalizeClaudeGeneration,
   markClaudeGenerationUnreliable,
   newClaudeGenerationState,
@@ -142,6 +143,14 @@ export interface RuntimeState {
   /** tool_use.id → tool_use.name。用于在 tool_result echo 时区分命令输出和内容结果。 */
   toolUseIdToName: Map<string, string>;
   /**
+   * 主(parent)流当前请求 streamed 出来的 tool_use id;message_start 清空,
+   * message_delta 停表后清空。生成时钟只允许停在这批 id 上 —— toolUseIdToName
+   * 是跨请求、跨 turn 的命名表,里面可能留着 echo 永远不会来的旧 id(ToolSearch
+   * 等 SDK 内部工具、错误中断的 turn),按它扫全量停表会让 pendingToolIds 永不
+   * 排空、时钟冻死,而 output 还在涨,live tok/s 无限膨胀。
+   */
+  mainRequestToolUseIds: Set<string>;
+  /**
    * SDK child assistant 消息按 parent_tool_use_id 隔离的真实模型。
    * 并发 subagent 的完整消息与 stream_event 都会交错，不能用会话级元数据推断。
    */
@@ -198,6 +207,7 @@ export function newRuntimeState(): RuntimeState {
   return {
     currentThinking: null,
     toolUseIdToName: new Map(),
+    mainRequestToolUseIds: new Set(),
     streamModelByParentToolUseId: new Map(),
     resolvedSubagentModelByParentToolUseId: new Map(),
     publishedSubagentModelByParentToolUseId: new Map(),
@@ -1558,10 +1568,12 @@ function pauseClaudeGenerationForToolUse(
   pauseClaudeGeneration(ctx.rt.generation, toolUseId);
 }
 
-function pauseClaudeGenerationForKnownTools(ctx: TranslateContext): void {
-  for (const toolUseId of ctx.rt.toolUseIdToName.keys()) {
+/** 只停本次主流请求 streamed 出来的 tool_use;见 mainRequestToolUseIds 字段注释。 */
+function pauseClaudeGenerationForCurrentRequestTools(ctx: TranslateContext): void {
+  for (const toolUseId of ctx.rt.mainRequestToolUseIds) {
     pauseClaudeGenerationForToolUse(ctx, toolUseId);
   }
+  ctx.rt.mainRequestToolUseIds.clear();
 }
 
 /**
@@ -1626,6 +1638,7 @@ function handleStreamEvent(
         // message_delta 或完整 assistant tool_use: content_block_start
         // 早于参数 input_json_delta,这里停表会把参数生成时间从分母抠掉,
         // 而后续 message_delta 仍把这些 token 加进 outputTokens。
+        if (!parentToolUseId) ctx.rt.mainRequestToolUseIds.add(toolUseId);
         ctx.onToolUseStart?.(toolUseId, cb.name, cb.input, parentToolUseId);
       }
     }
@@ -1718,8 +1731,9 @@ function handleStreamEvent(
   if (event.type === 'message_delta') {
     // message_delta 是整条 assistant 消息(含工具参数 token)生成完毕后的
     // 第一个事件。在此停表,才能排除工具执行/审批等待,又不把参数生成
-    // 区间从 tok/s 分母里抠掉。
-    pauseClaudeGenerationForKnownTools(ctx);
+    // 区间从 tok/s 分母里抠掉。只有主流自己的 message_delta 才停主时钟:
+    // 子代理 delta 到达时父级可能正在并行生成(后台 Agent),不许提前切断。
+    if (!parentToolUseId) pauseClaudeGenerationForCurrentRequestTools(ctx);
     const usage = event.usage;
     if (usage) {
       const dIn = usage.input_tokens ?? 0;
@@ -1818,7 +1832,13 @@ function handleStreamEvent(
     // 子代理 stream 不占用父级生成时钟。若对应 Agent 工具尚未停表，在此用
     // parent_tool_use_id 补上既有 pause 边界，避免分母吞进子代理时间。
     if (parentToolUseId) observeClaudeSubagentStream(ctx, parentToolUseId);
-    else beginClaudeGeneration(ctx.rt.generation);
+    else {
+      // 新主流请求边界: 上一请求残留的 tool id 已过期(失败重试的请求不会再有
+      // message_delta);还挂着的 pending 视作已在 SDK 内部收口(echo 不会来了),
+      // 由 beginClaudeGenerationAtRequestStart 结清并重启时钟。
+      ctx.rt.mainRequestToolUseIds.clear();
+      beginClaudeGenerationAtRequestStart(ctx.rt.generation);
+    }
     queue.push({
       type: 'status',
       data: ccLiveStatus(ctx, 'Generating...', true),
@@ -2259,6 +2279,7 @@ function handleResult(
     // 否则下一真实 turn 会从 0 起算、把整段历史 token 全算到那一轮(Codex P2)。
     ctx.rt.lastResultUsageAggregate = aggregateBeforeThisResult;
     resetTurnState(ctx.turn);
+    ctx.rt.mainRequestToolUseIds.clear();
     resetClaudeGenerationTiming(ctx.rt.generation);
     ctx.onTurnEnd?.();
     return;
@@ -2379,6 +2400,7 @@ function handleResult(
   // reset turn 累积 (tracker 内部已经在 endTurn 里 reset 了 currentTurn,这里只清非 usage 状态)
   resetTurnState(ctx.turn);
   ctx.rt.activeUsageSegmentByParent.clear();
+  ctx.rt.mainRequestToolUseIds.clear();
   resetClaudeGenerationTiming(ctx.rt.generation);
   // turn 结束钩子 — agent 用来清 turnInFlight 标记 (rewind preview/commit 前置守卫读它)
   ctx.onTurnEnd?.();


### PR DESCRIPTION
## 这次改了什么

### 摘要

手机端(桌面端同理)运行中状态栏的 live tok/s 会离谱膨胀(实测 claude-opus-5 会话显示 358 tok/s)。根因在 claude-code translator 的生成计时:`message_delta` 停表按 `toolUseIdToName` 扫**全量** tool id,而这张命名表跨请求、跨 turn 存活,只在 tool_result echo 到达时删除。echo 永远不会来的 id(ToolSearch 等 SDK 内部工具、错误中断的 turn)一旦入表,`pendingToolIds` 永不排空 → 时钟冻死、output 继续涨 → tok/s = 增长的分子 ÷ 冻结的分母,一路涨到荒谬;`generationReliable` 要到 turn 结束才 fail closed,所以整轮都显示着假数。

在实际会话数据里验证过:出问题的会话本地 DB 里恰有 2 个无 tool_result 的 ToolSearch tool_use(2/2 全部无回执),app 进程已运行近 5 天,RuntimeState 一直带着这两个幽灵 id,之后每一轮的 tok/s 都被第一条 `message_delta` 冻住分母。

三处修正(都在 maker-core claude-code):

- 停表只停**本次主流请求** streamed 出来的 tool_use(新增 `mainRequestToolUseIds`,`message_start` 清空、`message_delta` 停表后清空);子代理 delta 不再碰主时钟。
- 新主流 `message_start` 意味着上一条消息的 tool_result 已全部到达 provider,仍挂着的 pending 视作 SDK 内部收口,结清并重启时钟(`beginClaudeGenerationAtRequestStart`)。
- 已结清 id 的迟到 echo 按 no-op 处理,不再把整轮计时打成不可靠。

mobile / desktop 均消费同一份 status 字段,两端一起修复,无 UI 改动。

### 变更类型

- [x] `fix` 缺陷修复

### 范围

- 关联 Issue / 需求:无(手机端实测发现)
- 本 PR 包含:claude-code translator 生成计时的停表/复位逻辑修正 + 2 个回归测试
- 明确不包含:codex / pi translator(各自独立计时,未见同类扫全量逻辑);tok/s 的展示层
- 用户可见变化:运行中状态栏 tok/s 恢复真实值,不再随 turn 时长膨胀
- 是否存在 breaking change:无

### UI 变化

不涉及。

- 引用的设计规范:不涉及

## 怎么验证的

### 自动验证

```text
pnpm --filter @cindy/maker-core exec vitest run src/agents/claude-code/generation-timing.test.ts
结果:23 passed(含 2 个新回归测试;修复前它们按预期失败)

pnpm --filter @cindy/maker-core exec vitest related --run src/agents/claude-code/{generation-timing.test.ts,generation-timing.ts,translator.ts}
结果:21 files / 459 tests passed(基于 origin/main 865ccfb25)

pnpm --filter @cindy/maker-core run typecheck
结果:通过

apps/desktop 定向:vitest run src/renderer/__tests__/{runningTokenUsage,makerChatStoreLiveGeneration,reducedMotionEscape}.test.ts
结果:15 passed
```

### 手工验证

对实际出问题的会话做了取证(本地 DB + 会话日志):确认该会话存在 2 个无 tool_result echo 的 ToolSearch tool_use;当日 daily_model_usage 的 output 总量证明分子正常、分母被冻结;时间线与截图中的 358 tok/s 吻合。

### 未执行的验证

- 真机端到端复现修复效果:需重启桌面 app 才能加载新代码并清掉内存里的存量幽灵 id,尚未执行。
- 本地曾跑仓库根 `pnpm test:unit:related`:maker-core / mobile / orca-workflow / lizi-mcps 全过;`test:runner` 自检在本机因仓库内存在另一会话的 `.cindy-worktrees/browser-proxy-server` 内嵌 worktree 而失败(clean tree 复现同样失败,与本改动无关);apps/desktop 全量在本机并行跑存在环境性批量失败(有一次直接 SIGSEGV),抽样单文件隔离跑均通过,且带/不带本改动结果一致。以 CI 为准。

## 风险

### 风险分类

- [x] 无已知风险

### 影响与回滚

- 影响范围:仅 claude-code 会话运行中的生成计时/tok/s 统计;计时不可靠时仍按既有机制隐藏 tok/s(fail closed 路径未变)。
- 回滚 / 降级方式:revert 本 commit 即可,无数据/协议/存储影响。

### 提交前检查

- [x] 已 review 完整 diff
- [x] 每个 commit 都带 DCO 签名(`git commit -s`,见 [DCO](../DCO))
- [x] 未提交凭证、令牌或授权文件
- [x] 已补充必要文档(注释即文档,无独立规则文档需更新)
- [x] 已确认测试结果或说明未执行原因
