### PR TITLE
fix(scheduler): notify sessionless automation failures

### DIFF
--- a/apps/desktop/src/main/scheduler-host/__tests__/notifier.test.ts
+++ b/apps/desktop/src/main/scheduler-host/__tests__/notifier.test.ts
@@ -37,6 +37,7 @@ function run(status: ScheduleRun['status']): ScheduleRun {
 function createNotifier(opts?: {
   sendMarkdownText?: ReturnType<typeof vi.fn>;
   shouldNotifyDesktop?: () => boolean;
+  isAgentIslandEnabled?: () => boolean;
   publishMarkdown?: ReturnType<typeof vi.fn>;
 }): {
   notifier: DesktopNotifier;
@@ -55,6 +56,7 @@ function createNotifier(opts?: {
     } as unknown as FeishuIM,
     logger: { warn },
     shouldNotifyDesktop: opts?.shouldNotifyDesktop ?? (() => true),
+    isAgentIslandEnabled: opts?.isAgentIslandEnabled ?? (() => false),
     wecomGroupPublisher: { publishMarkdown },
   });
   return { notifier, sendMarkdownText, warn, publishMarkdown };
@@ -114,6 +116,26 @@ describe('DesktopNotifier desktop status mapping', () => {
     await notifier.notify(schedule, { ...run('success'), sessionId: undefined });
 
     expect(sendMobileSessionNotify).not.toHaveBeenCalled();
+  });
+
+  it('lets Agent Island replace a desktop notification for a session-bound run', async () => {
+    const { notifier } = createNotifier({ isAgentIslandEnabled: () => true });
+
+    await notifier.notify(schedule, run('failed'));
+
+    expect(showDesktopSessionEvent).not.toHaveBeenCalled();
+  });
+
+  it('keeps a desktop error notification when Agent Island cannot represent the failed run', async () => {
+    const { notifier } = createNotifier({ isAgentIslandEnabled: () => true });
+
+    await notifier.notify(schedule, { ...run('failed'), sessionId: undefined });
+
+    expect(showDesktopSessionEvent).toHaveBeenCalledWith(expect.any(Function), {
+      sessionId: '',
+      title: '每日检查',
+      kind: 'error',
+    });
   });
 
   it('mobile 正文带运行结果摘要:成功用 resultText,失败用 errorMsg', async () => {

--- a/apps/desktop/src/main/scheduler-host/__tests__/notifier.test.ts
+++ b/apps/desktop/src/main/scheduler-host/__tests__/notifier.test.ts
@@ -138,6 +138,17 @@ describe('DesktopNotifier desktop status mapping', () => {
     });
   });
 
+  it.each(['success', 'aborted', 'interrupted'] as const)(
+    'does not bypass Agent Island for a sessionless %s run',
+    async (status) => {
+      const { notifier } = createNotifier({ isAgentIslandEnabled: () => true });
+
+      await notifier.notify(schedule, { ...run(status), sessionId: undefined });
+
+      expect(showDesktopSessionEvent).not.toHaveBeenCalled();
+    },
+  );
+
   it('mobile 正文带运行结果摘要:成功用 resultText,失败用 errorMsg', async () => {
     const { notifier } = createNotifier();
 

--- a/apps/desktop/src/main/scheduler-host/index.ts
+++ b/apps/desktop/src/main/scheduler-host/index.ts
@@ -96,8 +96,8 @@ async function startSchedulerInternal(deps: StartSchedulerDeps): Promise<Schedul
     getMainWindow: deps.getMainWindow,
     feishuIm: deps.feishuIm,
     logger: deps.logger,
-    shouldNotifyDesktop: () =>
-      getDesktopNotificationsEnabled() && !(getAgentIslandService()?.isEnabled() ?? false),
+    shouldNotifyDesktop: getDesktopNotificationsEnabled,
+    isAgentIslandEnabled: () => getAgentIslandService()?.isEnabled() ?? false,
     wecomGroupPublisher: wecomGroupNotificationService,
   });
   const promptRunner = new MakerScheduleRunner({

--- a/apps/desktop/src/main/scheduler-host/notifier.ts
+++ b/apps/desktop/src/main/scheduler-host/notifier.ts
@@ -25,8 +25,10 @@ export interface DesktopNotifierDeps {
   getMainWindow: () => BrowserWindow | null;
   feishuIm: FeishuIM;
   logger: Logger;
-  /** Global desktop preference and Agent Island arbitration, evaluated at send time. */
+  /** Global desktop preference, evaluated at send time. */
   shouldNotifyDesktop: () => boolean;
+  /** Agent Island only replaces desktop notifications for runs bound to a session. */
+  isAgentIslandEnabled: () => boolean;
   wecomGroupPublisher?: WecomGroupNotificationPublisher;
 }
 
@@ -37,7 +39,11 @@ export class DesktopNotifier implements Notifier {
     // 链路代次在任何 await 之前捕获:飞书分支的 await 期间可能发生登出/换号,
     // 发送侧按代次不一致丢弃,旧账号调度的通知不会进新账号的链路。
     const generation = getMobileNotifyGeneration();
-    if (schedule.notify.desktop && this.deps.shouldNotifyDesktop()) {
+    if (
+      schedule.notify.desktop &&
+      this.deps.shouldNotifyDesktop() &&
+      (!this.deps.isAgentIslandEnabled() || !run.sessionId)
+    ) {
       try {
         this.notifyDesktop(schedule, run);
       } catch (err) {

--- a/apps/desktop/src/main/scheduler-host/notifier.ts
+++ b/apps/desktop/src/main/scheduler-host/notifier.ts
@@ -27,7 +27,7 @@ export interface DesktopNotifierDeps {
   logger: Logger;
   /** Global desktop preference, evaluated at send time. */
   shouldNotifyDesktop: () => boolean;
-  /** Agent Island only replaces desktop notifications for runs bound to a session. */
+  /** Whether Agent Island should arbitrate routine scheduler desktop notifications. */
   isAgentIslandEnabled: () => boolean;
   wecomGroupPublisher?: WecomGroupNotificationPublisher;
 }
@@ -42,7 +42,7 @@ export class DesktopNotifier implements Notifier {
     if (
       schedule.notify.desktop &&
       this.deps.shouldNotifyDesktop() &&
-      (!this.deps.isAgentIslandEnabled() || !run.sessionId)
+      (!this.deps.isAgentIslandEnabled() || (run.status === 'failed' && !run.sessionId))
     ) {
       try {
         this.notifyDesktop(schedule, run);


### PR DESCRIPTION
## 这次改了什么

### 摘要

修复 Agent Island 开启时，自动化任务在 Agent session 创建前失败而没有全局错误提醒的问题。Scheduler 现在仅在失败运行没有 `sessionId` 时保留系统错误通知；有 `sessionId` 的失败继续交给 Agent Island 展示。

### 变更类型

- [ ] `feat` 新功能
- [x] `fix` 缺陷修复
- [ ] `refactor` / `perf` 重构或性能优化
- [ ] `docs` / `test` / `chore` 文档、测试或工程维护
- [ ] 其他：

### 范围

- 关联 Issue / 需求：Fixes #3712
- 本 PR 包含：拆分桌面通知偏好与 Agent Island 仲裁；补充有无 `sessionId` 的回归测试。
- 明确不包含：不修改自动化执行流程、任务状态语义或 Agent Island UI。
- 用户可见变化：Agent Island 开启时，前置检查等无 session 失败会恢复系统错误通知；有 session 的失败行为不变。
- 是否存在 breaking change：无

### UI 变化

- 不涉及：本 PR 仅调整 Scheduler 通知路由和单元测试，没有修改 UI、布局、样式、动效或文案。

## 怎么验证的

### 自动验证

```text
node ../../node_modules/vitest/vitest.mjs run src/main/scheduler-host/__tests__/notifier.test.ts
结果：14/14 passed

corepack pnpm --filter desktop run --if-present typecheck
结果：通过

corepack pnpm test:unit:related
结果：apps/desktop unit 通过；apps/mobile unit 通过
```

### 手工验证

未执行 macOS arm64 实机验证。建议维护者在开启 Agent Island、桌面通知和声音后，用前置检查命令 `sh -c 'exit 1'` 运行自动化，确认无 `sessionId` 时出现系统错误通知；再验证有 session 的失败仍由 Agent Island 承载。

### 未执行的验证

macOS arm64 实机验证未执行，当前开发环境为 Windows。

## 风险

### 风险分类

- [ ] 无已知风险
- [ ] SQLite / migration
- [ ] system prompt
- [ ] 协议兼容
- [ ] 权限 / 安全 / 用户数据
- [ ] 存量插件兼容（批准状态 / 指纹 / manifest 校验 / 安装布局 / 包格式）
- [ ] 原生层 / fingerprint / OTA
- [x] 跨平台差异
- [ ] 其他：

### 影响与回滚

- 影响范围：Desktop Scheduler 的桌面通知条件；移动端、数据库、协议和插件系统不受影响。逻辑本身平台无关，但 macOS 系统通知仍需实机确认。
- 回滚 / 降级方式：回退 commit `0fad8b13a` 即可恢复原通知仲裁逻辑。