### PR TITLE
fix(maker-core): app-server 弃用后 SIGTERM 无效时补 SIGKILL 收尸

### DIFF
--- a/packages/maker-core/src/agents/codex/app-server/stdioTransport.test.ts
+++ b/packages/maker-core/src/agents/codex/app-server/stdioTransport.test.ts
@@ -109,3 +109,59 @@ describe('createStdioTransport process observer', () => {
     })).not.toThrow();
   });
 });
+
+describe('close() 强杀兜底 (#3699)', () => {
+  it('SIGTERM 后进程未退出 → 宽限期到点补 SIGKILL(卡死 app-server 不再活体泄漏)', async () => {
+    vi.useFakeTimers();
+    try {
+      const child = makeChild();
+      mocks.spawn.mockReturnValue(child);
+      const transport = createStdioTransport({ binaryPath: '/codex' });
+
+      await transport.close();
+      expect(child.kill).toHaveBeenCalledWith('SIGTERM');
+      expect(child.kill).not.toHaveBeenCalledWith('SIGKILL');
+
+      // 进程无视 SIGTERM(exitCode/signalCode 保持 null)→ 宽限期后强杀。
+      vi.advanceTimersByTime(5_000);
+      expect(child.kill).toHaveBeenCalledWith('SIGKILL');
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it('宽限期内正常退出 → 不发 SIGKILL', async () => {
+    vi.useFakeTimers();
+    try {
+      const child = makeChild();
+      mocks.spawn.mockReturnValue(child);
+      const transport = createStdioTransport({ binaryPath: '/codex' });
+
+      await transport.close();
+      child.signalCode = 'SIGTERM';
+      child.emit('exit', null, 'SIGTERM');
+      vi.advanceTimersByTime(5_000);
+      expect(child.kill).toHaveBeenCalledTimes(1); // 仅 SIGTERM
+      expect(child.kill).not.toHaveBeenCalledWith('SIGKILL');
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it('close() 前已退出 → 全程不发信号', async () => {
+    vi.useFakeTimers();
+    try {
+      const child = makeChild();
+      mocks.spawn.mockReturnValue(child);
+      const transport = createStdioTransport({ binaryPath: '/codex' });
+
+      child.exitCode = 0;
+      child.emit('exit', 0, null);
+      await transport.close();
+      vi.advanceTimersByTime(5_000);
+      expect(child.kill).not.toHaveBeenCalled();
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+});

--- a/packages/maker-core/src/agents/codex/app-server/stdioTransport.ts
+++ b/packages/maker-core/src/agents/codex/app-server/stdioTransport.ts
@@ -32,7 +32,16 @@ export interface StdioTransportOptions {
   extraArgs?: string[];
   /** 本地进程生命周期观察器；仅用于宿主诊断，不得影响 transport 启动。 */
   onProcessSpawned?: (pid: number) => void | (() => void);
+  /** SIGTERM 后强杀宽限毫秒数;仅测试注入,生产走默认值。 */
+  forceKillGraceMs?: number;
 }
+
+/**
+ * close() 发出 SIGTERM 后等待进程自行退出的宽限期。健康的 app-server 在毫秒级
+ * 退出;卡死的(见 close() 内注释)永远不退,5s 已足够区分两者且不拖慢关闭方
+ * (close() 本身不等待,timer 在后台收尸)。
+ */
+const FORCE_KILL_GRACE_MS = 5_000;
 
 export function createStdioTransport(opts: StdioTransportOptions): Transport {
   if (!opts.binaryPath) {
@@ -174,6 +183,21 @@ export function createStdioTransport(opts: StdioTransportOptions): Transport {
       try { child.stdin.end(); } catch { /* swallow */ }
       if (child.exitCode === null && child.signalCode === null) {
         try { child.kill('SIGTERM'); } catch { /* swallow */ }
+        // #3699: SIGTERM 只对健康的 app-server 有效。当它的主循环卡死(实测
+        // 场景:内部模型刷新子进程 wedged,manager 反复报 "timeout waiting for
+        // child process to exit")时,进程可能既不响应 stdin EOF 也不处理
+        // SIGTERM —— 而调用方(retireHostKey / 切换凭证 / 关闭会话)在 close()
+        // 后即视其为已弃用,不再持有引用。此前没有任何强杀兜底,弃用的
+        // app-server 会以活体泄漏:继续周期性模型刷新、打错误日志、占用
+        // 网络与文件句柄。宽限期后仍未退出则 SIGKILL 收尸;timer unref,
+        // 不阻塞父进程退出(父进程退出时同进程组的子进程本就会被收割)。
+        const killTimer = setTimeout(() => {
+          if (child.exitCode === null && child.signalCode === null) {
+            try { child.kill('SIGKILL'); } catch { /* swallow */ }
+          }
+        }, opts.forceKillGraceMs ?? FORCE_KILL_GRACE_MS);
+        killTimer.unref?.();
+        child.once('exit', () => clearTimeout(killTimer));
       }
       fireClose(reason);
     },


### PR DESCRIPTION
## 这次改了什么

### 摘要

fix 部分 #3699(弃用 app-server 活体泄漏部分)。issue 日志显示 codex runtime 的 `codex_models_manager` 周期性(约 1 分钟)报 `failed to refresh available models: timeout waiting for child process to exit`,同时对话生成阶段静默挂起。仓内排查确认一个确定性缺口:`StdioTransport.close()` 只发 stdin EOF + SIGTERM 且**不等退出确认、没有强杀兜底**——当 app-server 主循环卡死(恰是其内部刷新子进程 wedged、manager 反复超时的状态)时,进程对两者都无响应,而调用方(`retireHostKey` 弃用超时 host / 切换凭证 / 关闭会话)在 `close()` 后即弃引用。结果:被弃用的 app-server 以**活体泄漏**,继续周期性模型刷新、打错误日志、占用网络与文件句柄——与 issue 中「重启短暂改善、刷新错误按固定频率复发」的观测吻合。

修复:SIGTERM 后 5s 宽限期仍未退出则补 SIGKILL 收尸。timer unref 不阻塞父进程退出;宽限期内正常退出不发强杀;close() 本身不等待(收尸在后台完成)。

**诚实划界**:manager 等待的那个刷新子进程本身位于 vendored Codex runtime(Rust)内部,其「超时未 kill、无退避」不在本仓修复范围(仓库边界),需上游跟进;本 PR 消除的是我方生命周期管理里同类缺口造成的泄漏放大器。生成挂起与刷新失败是否共享同一失效资源,仍需提报人环境的运行期取证(进程列表中是否存在多个 codex app-server 实例是最直接的验证信号)。

### 变更类型

- [ ] `feat` 新功能
- [x] `fix` 缺陷修复
- [ ] `refactor` / `perf` 重构或性能优化
- [ ] `docs` / `test` / `chore` 文档、测试或工程维护
- [ ] 其他:

### 范围

- 关联 Issue / 需求:#3699(活体泄漏部分)
- 本 PR 包含:StdioTransport.close() 强杀兜底 + 3 条生命周期回归
- 明确不包含:vendored codex runtime 内部刷新子进程的超时清理/退避(上游);生成挂起根因的最终定界(需运行期证据)
- 用户可见变化:弃用的 codex app-server 不再泄漏为常驻进程;周期性刷新错误日志不再随弃用次数累积
- 是否存在 breaking change:无(健康进程毫秒级响应 SIGTERM,永远到不了强杀分支)

### UI 变化

无 UI 变化。

## 怎么验证的

### 自动验证

```
pnpm --dir packages/maker-core exec vitest run src/agents/codex/app-server/stdioTransport.test.ts
```
结果:7 过(新增 3 条:无视 SIGTERM → 宽限期到点 SIGKILL;宽限期内退出 → 不强杀;close 前已退出 → 全程不发信号)。反证:stash stdioTransport.ts 后仅「补 SIGKILL」用例如预期失败,两条断言不变行为的用例照过。

maker-core typecheck 过。

```
pnpm test:unit:related
```
结果:exit 0,全过(零失败,含 maker-core 全量段)。

### 手工验证

无(信号语义由 mock child 断言;SIGTERM 在 Windows 上由 Node 以 TerminateProcess 实现、必然退出,强杀分支只在 POSIX 卡死场景生效)。

### 未执行的验证

- 未复现真实卡死 app-server 的端到端场景(需要提报人环境的 wedged 刷新子进程;缺口本身——SIGTERM 后无兜底——由源码与回归证明)。

## 风险

### 风险分类

低风险。仅在「SIGTERM 发出 5s 后进程仍未退出」这一此前必然泄漏的分支新增 SIGKILL;健康路径零变化,有回归锁住。

### 影响与回滚

影响面:maker-core 的 codex app-server 本地 transport(所有 spawn 的 app-server 共用)。远程与移动端适配:transport 只在运行 app-server 的宿主机使用,远端 daemon 场景同样受益于泄漏收敛,无需额外适配。回滚:revert 单 commit,无 schema 变更。

### 提交前检查

- [x] 已运行定向单测(含反证)、typecheck 与 `pnpm test:unit:related`(失败项已逐一归因)
- [x] commit 带 DCO 签名(Signed-off-by: ficowang <fico@xd.com>)
- [x] diff 聚焦单一问题,无无关改动
