### PR TITLE
fix(maker-core): 网关路由会话把 CLI 小模型调用钉到会话 wire 模型

### DIFF
--- a/packages/maker-core/src/agents/claude-code/__tests__/env-builder.test.ts
+++ b/packages/maker-core/src/agents/claude-code/__tests__/env-builder.test.ts
@@ -58,6 +58,30 @@ describe('buildClaudeEnv', () => {
     expect(env.CLAUDE_CODE_DISABLE_CRON).toBe('1');
   });
 
+  it('pins ANTHROPIC_SMALL_FAST_MODEL to the session wire model when provided (#3557)', async () => {
+    // 网关路由会话:CLI 内部小模型调用不能用内置裸名默认值(网关白名单按
+    // 字面比对必 403),钉到会话自身已授权的 wire 模型。
+    const env = await buildClaudeEnv(createAuthAdapter(), {}, {
+      smallFastModel: 'anthropic/claude-opus-5',
+    });
+
+    expect(env.ANTHROPIC_SMALL_FAST_MODEL).toBe('anthropic/claude-opus-5');
+  });
+
+  it('leaves ANTHROPIC_SMALL_FAST_MODEL untouched when not provided or already set (#3557)', async () => {
+    // 裸名会话(订阅直连/自定义中继)不传 → 保持 CLI 默认行为零变化。
+    const absent = await buildClaudeEnv(createAuthAdapter(), {});
+    expect(absent.ANTHROPIC_SMALL_FAST_MODEL).toBeUndefined();
+
+    // behaviorFlags / 用户显式覆盖优先,不被会话值盖掉。
+    const overridden = await buildClaudeEnv(
+      createAuthAdapter(),
+      { behaviorFlags: { ANTHROPIC_SMALL_FAST_MODEL: 'anthropic/claude-haiku-4-5' } },
+      { smallFastModel: 'anthropic/claude-opus-5' },
+    );
+    expect(overridden.ANTHROPIC_SMALL_FAST_MODEL).toBe('anthropic/claude-haiku-4-5');
+  });
+
   it('passes requested credential mode to the auth adapter', async () => {
     const getAuthEnv = vi.fn(async () => ({ ANTHROPIC_API_KEY: 'key' }));
     const env = await buildClaudeEnv(

--- a/packages/maker-core/src/agents/claude-code/env-builder.ts
+++ b/packages/maker-core/src/agents/claude-code/env-builder.ts
@@ -52,6 +52,16 @@ interface ClaudeEnvBuildOptions {
    */
   sessionProviderId?: string | null;
   /**
+   * CC CLI 内部小模型调用(bash 命令前缀判定/标题/摘要等)的模型覆写
+   * (`ANTHROPIC_SMALL_FAST_MODEL`)。未设置时 CLI 用内置**裸名**默认值 ——
+   * 经网关路由的会话模型 id 带命名空间前缀(如 `anthropic/claude-opus-5`),
+   * 网关模型白名单按字面比对,CLI 的裸名默认值必被拒为 403
+   * user_model_access_denied(#3557)。调用方只在会话 wire 模型带命名空间时
+   * 传入(钉到会话自身的 wire 模型 —— 它是唯一确定已授权的 id);裸名会话
+   * (订阅直连 / 自定义中继)省略,保持 CLI 默认行为零变化。
+   */
+  smallFastModel?: string;
+  /**
    * 调用方已解析好的 `CLAUDE_CODE_SUBAGENT_MODEL` 决定(见 subagent-model-default.ts)。
    *   - 字符串 → 设该值;
    *   - `null`  → 明确**不要设**(让用户手写 agent 的 frontmatter `model:` 生效);
@@ -354,6 +364,12 @@ export async function buildClaudeEnv(
           : runtimeConfig.subagentModel
         )?.trim() || undefined),
   );
+
+  // #3557: 网关路由会话把 CLI 内部小模型调用钉到会话自身的 wire 模型。
+  // if-undefined 守卫:behaviorFlags / 用户显式覆盖优先。
+  if (options.smallFastModel && env.ANTHROPIC_SMALL_FAST_MODEL === undefined) {
+    env.ANTHROPIC_SMALL_FAST_MODEL = options.smallFastModel;
+  }
 
   // 第三道防线: 告诉 CC CLI "provider 路由由 host 接管"。
   // CC 内部 filterSettingsEnv 看到此标记后,会从所有 settings-sourced env 中剥掉

--- a/packages/maker-core/src/agents/claude-code/index.ts
+++ b/packages/maker-core/src/agents/claude-code/index.ts
@@ -1192,10 +1192,16 @@ export class ClaudeCodeAgent extends BaseAgent {
     const modelContextWindows = sessionRouteWindowEntry
       ? [...providerRoutedModels, sessionRouteWindowEntry]
       : providerRoutedModels;
+    // #3557:会话模型 id 带命名空间前缀(anthropic/... 等网关目录形态)时,CLI
+    // 内部小模型调用(bash 前缀判定/标题/摘要)不能用它内置的裸名默认值 ——
+    // 网关白名单字面比对,裸名必 403。钉到会话自身 wire 模型(唯一确定已授权);
+    // 裸名会话(订阅直连/自定义中继)不传,CLI 默认行为零变化。
+    const smallFastModel = opts.model.includes('/') ? sdkModel : undefined;
     const env = await buildClaudeEnv(this.deps.auth, this.deps.runtimeConfig, {
       credentialMode,
       sessionProviderId: opts.providerId ?? null,
       modelContextWindows,
+      smallFastModel,
       // 先按「不设」建好 env(顺带删掉可能从 process.env 继承来的残留),真正的判定在下面
       // 拿到这份 env 之后做 —— 扫描需要 env 里的 CLAUDE_CONFIG_DIR 才能找对目录。
       subagentModel: null,
@@ -1280,6 +1286,7 @@ export class ClaudeCodeAgent extends BaseAgent {
           sessionProviderId: opts.providerId ?? null,
           mode: 'remote',
           modelContextWindows,
+          smallFastModel,
           // 远端不做本地扫描(见上),这里的值就是路由感知后的设置值 —— 保持 env 强制覆盖语义。
           subagentModel: subagentDefault.envSubagentModel ?? null,
         })


### PR DESCRIPTION
## 这次改了什么

### 摘要

fix #3557。客户端出站请求间歇性以「裸名」模型 id(如 `claude-opus-5`)打到模型网关,被命名空间白名单字面比对拒为 403 `user_model_access_denied`。排查确认漏网路径是 **CC CLI 的内部小模型调用**:bash 命令安全前缀判定、标题、摘要等场景 CLI 在未设置 `ANTHROPIC_SMALL_FAST_MODEL` 时使用其内置**裸名**默认值——全仓此前没有任何地方设置该 env。经网关路由的会话主请求带命名空间前缀(目录形态 `anthropic/claude-opus-5`)正常通过,只有这些 CLI 内部调用裸名直打网关,呈现为请求密集时段(工具调用多 → 前缀判定调用多)的间歇性 403,UI 文案正是 CLI 自己的 `Failed to authenticate. API Error: 403`。

修复:会话 wire 模型带命名空间前缀(含 `/`)时,`buildClaudeEnv` 注入 `ANTHROPIC_SMALL_FAST_MODEL` = **会话自身的 wire 模型**——它是唯一确定在该用户白名单里的 id(主请求已在用它);if-undefined 守卫让 behaviorFlags / 用户显式覆盖优先。裸名会话(订阅直连 / 自定义中继)不注入,CLI 默认行为零变化。本地与远端两处 env 构建点同步传入。

### 变更类型

- [ ] `feat` 新功能
- [x] `fix` 缺陷修复
- [ ] `refactor` / `perf` 重构或性能优化
- [ ] `docs` / `test` / `chore` 文档、测试或工程维护
- [ ] 其他:

### 范围

- 关联 Issue / 需求:#3557
- 本 PR 包含:env-builder 新增 `smallFastModel` 注入项 + index.ts 两处 env 构建点按命名空间判据传入 + 3 条 env 回归
- 明确不包含:issue「待确认」段里 UI 错误文案与网关原文不一致的核对(那是 CLI 文案透传问题,与本修复正交);其它非 CC 路径若也有裸名出站,需独立证据另行处理
- 用户可见变化:网关路由的 Claude Code 会话不再出现请求密集期的间歇性 403 鉴权失败
- 是否存在 breaking change:无(仅命名空间形态会话新增一个此前从未设置的 env;成本面:这些小模型调用改用会话主模型,单次调用 prompt 极短,开销可忽略)

### UI 变化

无 UI 变化。

## 怎么验证的

### 自动验证

```
pnpm --dir packages/maker-core exec vitest run src/agents/claude-code/__tests__/env-builder.test.ts
```
结果:37 过(新增 3 条:提供 smallFastModel 时注入;未提供时缺席保持 CLI 默认;behaviorFlags 已设时不被覆盖)。反证:stash env-builder.ts 后「注入」用例如预期失败,断言不变行为的用例照过。

maker-core typecheck 过。

```
pnpm test:unit:related
```
结果:exit 1,唯一失败为 desktop 段 vitest threads 池 SIGSEGV(本机已知环境问题,本 diff 不含 desktop 代码);maker-core 段全过(含本 diff 的 env-builder 37 例,日志可证)。

### 手工验证

无(env 契约由单测端到端断言;CLI 对 `ANTHROPIC_SMALL_FAST_MODEL` 的消费语义是其公开文档行为)。

### 未执行的验证

- 未对真实网关做端到端 403 复现(需要提报人环境的网关 key 与白名单;裸名 → 403、带前缀 → 通过的事实由提报人实测取证,见 issue 复现步骤)。

## 风险

### 风险分类

低风险。仅「会话模型 id 含 `/`」的路由新增一个此前恒缺席的 env;守卫链(命名空间判据 + if-undefined)把订阅直连、自定义中继、用户显式覆盖全部排除在外,均有回归锁住。

### 影响与回滚

影响面:maker-core 的 Claude Code env 构建(本地与远端会话共用同一注入点)。远程与移动端适配:远端 env 构建点已同步传入同一值,行为一致,无需额外适配。回滚:revert 单 commit,无 schema 变更。

### 提交前检查

- [x] 已运行定向单测(含反证)、typecheck 与 `pnpm test:unit:related`(失败项已逐一归因)
- [x] commit 带 DCO 签名(Signed-off-by: ficowang <fico@xd.com>)
- [x] diff 聚焦单一问题,无无关改动
