### PR TITLE
fix(desktop): auth.json 死 SID ACL 致 unlink EPERM 时自愈后重试

### DIFF
--- a/apps/desktop/src/main/__tests__/codexAuthLink.test.ts
+++ b/apps/desktop/src/main/__tests__/codexAuthLink.test.ts
@@ -275,3 +275,77 @@ describe('inspectCodexAuthLink', () => {
     });
   });
 });
+
+describe('Windows 死 SID ACL 自愈 (#3469)', () => {
+  // 迁移来的 auth.json 只带旧账户单条 ACE 时,当前账户 unlink 必 EPERM;
+  // 此前 reconcile 只能永久 swap-failed-intact,登录卡在最后一步。
+  function epermRmOnce(target: string): { calls: () => number } {
+    const originalRm = fs.promises.rm.bind(fs.promises);
+    let denied = false;
+    let targetCalls = 0;
+    vi.spyOn(fs.promises, 'rm').mockImplementation(async (p, opts) => {
+      if (String(p) === target) {
+        targetCalls += 1;
+        if (!denied) {
+          denied = true;
+          const err = new Error('EPERM: operation not permitted, unlink') as NodeJS.ErrnoException;
+          err.code = 'EPERM';
+          throw err;
+        }
+      }
+      return originalRm(p as never, opts as never);
+    });
+    return { calls: () => targetCalls };
+  }
+
+  it('unlink EPERM → icacls 自愈成功 → 重试完成替换 (linked)', async () => {
+    fs.writeFileSync(systemAuth, SYSTEM_CONTENT);
+    fs.writeFileSync(myAuth, MY_CONTENT);
+    const { calls } = epermRmOnce(myAuth);
+    const execFileImpl = vi.fn().mockResolvedValue({ stdout: '', stderr: '' });
+
+    const out = await relinkSharedCodexAuth(systemAuth, myAuth, 'win32', execFileImpl as never);
+
+    expect(out.kind).toBe('linked');
+    expect(execFileImpl).toHaveBeenCalledWith('icacls', [myAuth, '/reset']);
+    expect(calls()).toBe(2); // 首次 EPERM + 自愈后重试
+    expect(sameInode(systemAuth, myAuth)).toBe(true);
+  });
+
+  it('自愈两步都失败 → 按原路径 swap-failed-intact,myAuth 原样保留', async () => {
+    fs.writeFileSync(systemAuth, SYSTEM_CONTENT);
+    fs.writeFileSync(myAuth, MY_CONTENT);
+    epermRmOnce(myAuth);
+    const execFileImpl = vi.fn().mockRejectedValue(new Error('icacls denied'));
+
+    const out = await relinkSharedCodexAuth(systemAuth, myAuth, 'win32', execFileImpl as never);
+
+    expect(out.kind).toBe('swap-failed-intact');
+    expect((out.error as NodeJS.ErrnoException).code).toBe('EPERM');
+    // reset 与 grant 两步都试过。
+    expect(execFileImpl).toHaveBeenCalledTimes(2);
+    expect(fs.readFileSync(myAuth, 'utf8')).toBe(MY_CONTENT);
+  });
+
+  it('非 ACL 类失败(EBUSY)不触发自愈,行为与修复前一致', async () => {
+    fs.writeFileSync(systemAuth, SYSTEM_CONTENT);
+    fs.writeFileSync(myAuth, MY_CONTENT);
+    const originalRm = fs.promises.rm.bind(fs.promises);
+    let denied = false;
+    vi.spyOn(fs.promises, 'rm').mockImplementation(async (p, opts) => {
+      if (String(p) === myAuth && !denied) {
+        denied = true;
+        const err = new Error('EBUSY: resource busy') as NodeJS.ErrnoException;
+        err.code = 'EBUSY';
+        throw err;
+      }
+      return originalRm(p as never, opts as never);
+    });
+    const execFileImpl = vi.fn();
+
+    const out = await relinkSharedCodexAuth(systemAuth, myAuth, 'win32', execFileImpl as never);
+
+    expect(out.kind).toBe('swap-failed-intact');
+    expect(execFileImpl).not.toHaveBeenCalled();
+  });
+});

--- a/apps/desktop/src/main/maker-host/auth-adapters.ts
+++ b/apps/desktop/src/main/maker-host/auth-adapters.ts
@@ -36,7 +36,13 @@ import { prepareCodexGlobalRulesCopy } from './codex-global-rules.js';
 import { prepareCodexGlobalPluginsBridge } from './codex-global-plugins.js';
 import { DESKTOP_CAPABILITY_ROUTING_POLICY } from './capability-routing.js';
 import { prepareSharedGlobalSkillLinks } from './shared-global-skills.js';
-import { inspectCodexAuthLink, relinkSharedCodexAuth } from './codex-auth-link.js';
+import {
+  inspectCodexAuthLink,
+  relinkSharedCodexAuth,
+  resolveWindowsAclPrincipal,
+} from './codex-auth-link.js';
+
+export { resolveWindowsAclPrincipal } from './codex-auth-link.js';
 import { claudeOAuthSpawnEnv } from './claude-oauth-spawn-env.js';
 import {
   CODEX_USER_DISCONNECT_REASON,
@@ -480,17 +486,9 @@ export async function clearCodexAuthBoundaryStateBeforeLogin(
 /**
  * Windows: 用 icacls 把文件权限收紧为"仅当前用户 Full"。
  * 失败仅 stderr 告警, 不抛 —— userData ACL + 0o600 已经是双保险, icacls 是第三道。
+ * principal 解析单源迁至 codex-auth-link(#3469 的 ACL 自愈也要用,反向 import
+ * 会成环);这里 re-export 保持既有导入路径不变。
  */
-export function resolveWindowsAclPrincipal(
-  env: Partial<Pick<NodeJS.ProcessEnv, 'USERDOMAIN' | 'USERNAME'>> = process.env,
-  fallbackUsername = os.userInfo().username,
-): string {
-  const username = env.USERNAME?.trim() || fallbackUsername.trim();
-  const domain = env.USERDOMAIN?.trim();
-  if (!domain || username.includes('\\') || username.includes('@')) return username;
-  return `${domain}\\${username}`;
-}
-
 async function tightenAclWindows(file: string): Promise<void> {
   const principal = resolveWindowsAclPrincipal();
   try {

--- a/apps/desktop/src/main/maker-host/codex-auth-link.ts
+++ b/apps/desktop/src/main/maker-host/codex-auth-link.ts
@@ -22,7 +22,61 @@
  * 注意: 本模块只管"安全替换"这一件事, 不做账号比对 / inode 短路 / suppress 标记等判定 ——
  * 那些仍由 auth-adapters 的 reconcile 主流程负责。
  */
+import { execFile } from 'node:child_process';
 import { promises as fsp } from 'node:fs';
+import os from 'node:os';
+import { promisify } from 'node:util';
+
+const execFileP = promisify(execFile);
+
+/**
+ * Windows: icacls 授权主体。域账户组合 `DOMAIN\\user`(缺域回退裸用户名);
+ * username 自带 `\\` 或 `@`(UPN)时视为已限定,不再拼接。
+ * 单源在本模块 —— auth-adapters 的 tightenAclWindows 同样消费(它 import 本模块,
+ * 反向 import 会成环)。
+ */
+export function resolveWindowsAclPrincipal(
+  env: Partial<Pick<NodeJS.ProcessEnv, 'USERDOMAIN' | 'USERNAME'>> = process.env,
+  fallbackUsername = os.userInfo().username,
+): string {
+  const username = env.USERNAME?.trim() || fallbackUsername.trim();
+  const domain = env.USERDOMAIN?.trim();
+  if (!domain || username.includes('\\') || username.includes('@')) return username;
+  return `${domain}\\${username}`;
+}
+
+/** unlink/rename 因 ACL 拒绝(而非文件缺席/占用等)失败。 */
+function isWindowsAclDenied(error: unknown): boolean {
+  const code = (error as NodeJS.ErrnoException | null)?.code;
+  return code === 'EPERM' || code === 'EACCES';
+}
+
+/**
+ * #3469: 迁移来的 auth.json 可能带着"死 SID"ACL —— 旧机器/旧账户的单条 ACE、
+ * 无继承,当前账户连 unlink 都 EPERM。best-effort 自愈:
+ *   1. `icacls /reset` 恢复父目录继承 —— codex-home 是 Cindy 在本机建的目录,
+ *      当前用户可达,继承回来即可读写删;
+ *   2. 兜底显式授当前主体 Full(reset 需要 WRITE_DAC,极端 ACL 下可能也被拒)。
+ * 只在调用方确认 EPERM/EACCES 后调用;两步都失败返回 false,由调用方按原
+ * 失败路径处理(行为不变),绝不把"修 ACL 失败"升级成新错误。
+ */
+async function healWindowsAuthAcl(
+  file: string,
+  execFileImpl: typeof execFileP = execFileP,
+): Promise<boolean> {
+  try {
+    await execFileImpl('icacls', [file, '/reset']);
+    return true;
+  } catch {
+    // fallthrough: reset 被拒时试显式授权。
+  }
+  try {
+    await execFileImpl('icacls', [file, '/grant:r', `${resolveWindowsAclPrincipal()}:F`]);
+    return true;
+  } catch {
+    return false;
+  }
+}
 
 /**
  * relinkSharedCodexAuth 的结果分类:
@@ -62,6 +116,7 @@ export async function relinkSharedCodexAuth(
   systemAuth: string,
   myAuth: string,
   platform: NodeJS.Platform = process.platform,
+  execFileImpl: typeof execFileP = execFileP,
 ): Promise<RelinkOutcome> {
   // 唯一 sidecar 名 (pid + 自增计数): 同进程内并发 reconcile 各用各的, 不再撞 EEXIST / ENOENT。
   const sidecar = `${myAuth}.${process.pid}.${sidecarCounter++}.linktmp`;
@@ -79,7 +134,19 @@ export async function relinkSharedCodexAuth(
 
   // POSIX rename 可原子覆盖旧文件，没有“先删后建”空窗。Windows 仍需先删目标。
   try {
-    if (platform === 'win32') await fsp.rm(myAuth, { force: true });
+    if (platform === 'win32') {
+      try {
+        await fsp.rm(myAuth, { force: true });
+      } catch (rmError) {
+        // #3469: 死 SID ACL 让 unlink EPERM → reconcile 永久 swap-failed-intact、
+        // 登录卡在最后一步。先 best-effort 修 ACL 再重试一次;修不动按原失败
+        // 路径返回,行为与修复前一致。
+        if (!isWindowsAclDenied(rmError) || !(await healWindowsAuthAcl(myAuth, execFileImpl))) {
+          throw rmError;
+        }
+        await fsp.rm(myAuth, { force: true });
+      }
+    }
     await fsp.rename(sidecar, myAuth);
     // 顺手清掉可能残留的 sidecar，避免并发下 .linktmp 堆积。
     await fsp.rm(sidecar, { force: true }).catch(() => undefined);


### PR DESCRIPTION
## 这次改了什么

### 摘要

fix #3469 的 Cindy 侧死局部分。迁移旧机器/旧账户的 `~/.codex` 后,auth.json 可能带着只授权「死 SID」的单条 ACE(无继承)——旧机器本地账户在新机器上不存在,当前域账户对该文件连 unlink 都 EPERM。提报日志显示 OAuth token exchange 已成功,卡死发生在 Cindy 的 reconcile swap:`relinkSharedCodexAuth` 在 win32 先删目标再 rename,unlink EPERM 后只返回 `swap-failed-intact` 打日志放弃,reconcile 每次触发都原样复发,ChatGPT 登录永远停在最后一步。

修复:win32 unlink 遇 EPERM/EACCES 时 best-effort ACL 自愈后**重试一次**——先 `icacls /reset` 恢复父目录继承(codex-home 是 Cindy 在本机建的目录,当前用户可达,继承回来即可读写删),兜底 `icacls /grant:r 当前主体:F`;两步都失败按原失败路径返回,行为与修复前完全一致。非 ACL 类失败(EBUSY 等)不触发自愈。`resolveWindowsAclPrincipal` 单源迁至 codex-auth-link(auth-adapters re-export 保持既有导入路径),避免反向依赖成环。

**诚实划界**:把坏 ACL 写上去的一方是 vendored codex sandbox(用迁移残留的旧 SID 缓存),其身份缓存刷新属上游;本 PR 保证的是 Cindy 侧登录收尾不再被死 SID 卡死——codex 若再次覆盖 ACL,下一次 reconcile 的自愈会再次修复,死局不再存在。

### 变更类型

- [ ] `feat` 新功能
- [x] `fix` 缺陷修复
- [ ] `refactor` / `perf` 重构或性能优化
- [ ] `docs` / `test` / `chore` 文档、测试或工程维护
- [ ] 其他:

### 范围

- 关联 Issue / 需求:#3469(Cindy 侧 reconcile 死局部分)
- 本 PR 包含:codex-auth-link 的 win32 ACL 自愈重试 + principal 解析单源迁移(re-export 兼容)+ 3 条回归
- 明确不包含:vendored codex sandbox 的旧 SID 身份缓存刷新(上游);`.sandbox`/`cap_sid` 等迁移残留的自动清理(需上游确认语义)
- 用户可见变化:迁移机器/切换域账户后 ChatGPT 授权可正常完成,不再卡「无法连接」
- 是否存在 breaking change:无(仅 EPERM/EACCES 这一此前必然失败的分支新增自愈,健康路径零变化)

### UI 变化

无 UI 变化。

## 怎么验证的

### 自动验证

```
pnpm --dir apps/desktop exec vitest run --pool=forks src/main/__tests__/codexAuthLink.test.ts src/main/maker-host/__tests__/codexAuthInvalidation.test.ts
```
结果:codexAuthLink 20 过(新增 3 条:EPERM → icacls /reset 自愈 → 重试成功 linked;自愈两步全败 → 原路径 swap-failed-intact 且 myAuth 原样;EBUSY 非 ACL 失败不触发自愈)。codexAuthInvalidation 59 过(覆盖 principal 解析的 re-export 路径)。反证:stash codex-auth-link.ts 后两条自愈用例如预期失败,断言不变行为的用例照过。

desktop typecheck 过。

```
pnpm test:unit:related
```
结果:exit 1,唯一失败为 desktop 段 vitest threads 池 SIGSEGV(本机已知环境问题);本 diff 测试文件的覆盖以上文定向运行(含反证)为准,其余各段全过。

### 手工验证

无(死 SID ACL 语义以 EPERM 注入 + execFile mock 覆盖;icacls 真实行为按 Windows 文档语义——/reset 恢复继承需调用方对文件有 WRITE_DAC 或经父目录可达,失败即走兜底与原路径)。

### 未执行的验证

- 未在真实迁移后的 Windows 机器上端到端复现(需要旧账户 SID 环境;提报人已实测「takeown + icacls 修 ACL 后可恢复」,本 PR 即把该恢复动作自动化进失败路径)。

## 风险

### 风险分类

低风险。自愈只在「win32 + unlink EPERM/EACCES」这一此前必然失败的分支触发;icacls 只作用于 Cindy 自管 codex-home 下的 auth.json 单文件;失败 fail-open 回原路径。

### 影响与回滚

影响面:desktop main 的 codex auth.json reconcile 替换原语(所有 reconcile 调用点共用)。远程与移动端适配:该原语只在 desktop main 本机执行,远程/移动端不参与,无需适配。回滚:revert 单 commit,无 schema 变更。

### 提交前检查

- [x] 已运行定向单测(含反证)、typecheck 与 `pnpm test:unit:related`(失败项已逐一归因)
- [x] commit 带 DCO 签名(Signed-off-by: ficowang <fico@xd.com>)
- [x] diff 聚焦单一问题,无无关改动
