### PR TITLE
fix(maker-ipc): omit null effort from sessions DB patch for fixed-effort models

### DIFF
--- a/apps/desktop/src/main/__tests__/sessionRuntimeControlWiring.test.ts
+++ b/apps/desktop/src/main/__tests__/sessionRuntimeControlWiring.test.ts
@@ -280,6 +280,25 @@ describe('session runtime control wiring', () => {
     expect(axisValidation).toBeLessThan(setModel.indexOf('persistSessionFields(sessionId'));
   });
 
+  it('omits effort from the DB patch for fixed-effort models (sessions.effort NOT NULL)', () => {
+    const setModel = handlerBody(
+      registerSource,
+      'const handleSetModel = async (',
+      'const recoverRemoteRuntimeAxisPersistence',
+    );
+    // 固定 effort 模型(efforts.length === 0)的运行时语义是 effort: null,但
+    // sessions.effort 列是 NOT NULL——把 null 写进 DB patch 会让整个模型切换被
+    // NOT NULL 约束炸掉(issue #3691)。持久化 patch 必须省略该字段,内存 store
+    // 照常清 null,重启后按目标模型能力重新归一化。
+    const atomicPatch = setModel.indexOf('if (atomicSelection) {', setModel.indexOf('const patch: Record<string, unknown>'));
+    expect(atomicPatch).toBeGreaterThan(-1);
+    const persistCall = setModel.indexOf('persistSessionFields(sessionId', atomicPatch);
+    expect(persistCall).toBeGreaterThan(atomicPatch);
+    const patchBlock = setModel.slice(atomicPatch, persistCall);
+    expect(patchBlock).toContain('if (atomicSelection.effort !== null) {');
+    expect(patchBlock).toContain('patch.effort = atomicSelection.effort;');
+  });
+
   it('commits user effort and Fast state only after the live runtime call succeeds', () => {
     const effort = handlerBody(
       registerSource,

--- a/apps/desktop/src/main/__tests__/sessionRuntimeControlWiring.test.ts
+++ b/apps/desktop/src/main/__tests__/sessionRuntimeControlWiring.test.ts
@@ -299,6 +299,15 @@ describe('session runtime control wiring', () => {
     expect(patchBlock).toContain('patch.effort = atomicSelection.effort;');
   });
 
+  it('normalizes hydrated effort to the current model capability on restart', () => {
+    // 重启后 DB 行里的 effort 是历史值;bootstrapSession hydrate 必须按当前模型
+    // 能力归一化(固定 effort → null,可调 → 兼容档),否则旧值会作为
+    // reasoningEffort 打给不支持的模型被 provider 拒绝(Greptile P1)。
+    expect(registerSource).toContain(
+      'resolveCompatibleSessionRuntimeEffort(hydrateModel, efRow?.effort ?? null)',
+    );
+  });
+
   it('commits user effort and Fast state only after the live runtime call succeeds', () => {
     const effort = handlerBody(
       registerSource,

--- a/apps/desktop/src/main/maker-ipc/register.ts
+++ b/apps/desktop/src/main/maker-ipc/register.ts
@@ -945,6 +945,7 @@ import {
   recordRecoveredSessionRuntimeAxisMutation,
   recordUserSessionRuntimeAxisMutation,
   recordUserSessionRuntimeMutation,
+  resolveCompatibleSessionRuntimeEffort,
   resolveCompatibleSessionRuntimeAxisPatch,
   resolveSessionRuntimeAxes,
   sessionRuntimeGenerationMatches,
@@ -7859,7 +7860,25 @@ export function registerMakerIpc(maker: Maker, options: RegisterMakerIpcOptions)
         setSessionEffort(session.id, runtimeOverride.effort);
         setSessionFastMode(session.id, runtimeOverride.fastMode);
       } else {
-        setSessionEffort(session.id, efRow?.effort);
+        // DB 行里的 effort 是历史合法值(固定 effort 模型切换时省略了字段),
+        // hydrate 时必须按**当前模型能力**归一化:固定 effort 模型 → null,
+        // 可调模型 → 兼容档位。直接回灌旧值会把不支持 reasoningEffort 的模型
+        // 请求打给 provider 被拒(issue #3691 / PR #3727 Greptile P1)。
+        const hydrateProviderId = getSessionProvider(session.id) ?? o.providerId ?? null;
+        const hydrateProvider = getActiveCatalog().providers.find(
+          (candidate) => candidate.id === hydrateProviderId,
+        );
+        const hydrateModel = findCatalogModel(
+          hydrateProvider,
+          session.model,
+          o.agentKind,
+        );
+        setSessionEffort(
+          session.id,
+          hydrateModel
+            ? resolveCompatibleSessionRuntimeEffort(hydrateModel, efRow?.effort ?? null)
+            : efRow?.effort,
+        );
         setSessionFastMode(session.id, !!efRow?.fastMode);
       }
     } catch (err) {

--- a/apps/desktop/src/main/maker-ipc/register.ts
+++ b/apps/desktop/src/main/maker-ipc/register.ts
@@ -15808,7 +15808,14 @@ export function registerMakerIpc(maker: Maker, options: RegisterMakerIpcOptions)
             );
           }
           if (atomicSelection) {
-            patch.effort = atomicSelection.effort;
+            // 固定 effort 模型(efforts.length === 0)的运行时语义是 effort: null,
+            // 但 sessions.effort 列是 NOT NULL —— 运行时能力与持久化表示在此分离:
+            // DB patch 省略该字段,行内保留旧模型的历史合法值;内存 store(上面
+            // commitControlStores / setSessionEffort)照常清为 null,重启后按目标
+            // 模型能力重新归一化。不写 ''/"none" 等枚举外值,不改 schema。
+            if (atomicSelection.effort !== null) {
+              patch.effort = atomicSelection.effort;
+            }
             patch.fastMode = atomicSelection.fastMode;
           }
           try {


### PR DESCRIPTION
## 这次改了什么

### 摘要

已有会话切换到固定 effort 模型（`model.efforts.length === 0`）时，`resolveSessionRuntimeAxes()` 返回运行时语义 `effort: null`，而 `register.ts` 的原子模型切换路径把该值原样写进 DB patch。`sessions.effort` 列是 `NOT NULL`，SQLite 拒绝写入后整个 `maker:set-model` 失败（issue #3691）。

修复：运行时能力与持久化表示分离——固定 effort 模型在 DB patch 中**省略** `effort` 字段（行内保留旧模型的历史合法值），内存 effort store 照常清为 `null`，重启后由现有 hydrate 路径按目标模型能力重新归一化。不写 `''`/`'none'` 等枚举外值，不改 schema、不加 migration。

### 变更类型

- [x] `fix` 缺陷修复

### 范围

- 关联 Issue / 需求：#3691
- 本 PR 包含：`register.ts` 原子模型切换路径的 DB patch 收口 + wiring 回归测试
- 明确不包含：schema/migration 变更、固定 effort 模型的行为限制、provider 路由改动
- 用户可见变化：已有 Pi 会话切换到固定 effort 模型（如自定义 Provider 的 grok-4.6）不再报「设置切换失败」
- 是否存在 breaking change：无

### UI 变化

不涉及

## 怎么验证的

### 自动验证

```text
pnpm --filter desktop typecheck
结果：通过（0 错误）

npx vitest run src/main/__tests__/sessionRuntimeControlWiring.test.ts \
  src/main/maker-ipc/__tests__/runtimeSetModel.test.ts \
  src/main/maker-ipc/__tests__/runtimeSelectionAxes.test.ts \
  src/main/maker-ipc/__tests__/runtimeSetEffort.test.ts
结果：4 文件 / 76 条全过

pnpm test:unit:related
结果：desktop 之外的 package 全 PASS；desktop 批跑里有 3 个与本改动无关的
并发 flake（agentIslandSettings / createRemoteSessionWithPrecreatedWorktree /
usePlanChange），单跑逐条复跑均 PASS（本改动未触及 renderer / remote-session / plan 代码路径）
```

### 手工验证

不涉及（需要 Pi 真实会话 + 自定义 Provider 环境）

### 未执行的验证

- Pi 真实 RPC 集成验证：本机无 litellm/grok 自定义 Provider 环境，已有 wiring 测试钉住「DB patch 不含 null effort」的契约。

## 风险

### 风险分类

- [x] 无已知风险

### 影响与回滚

- 影响范围：仅 `maker:set-model` 原子切换的持久化 patch 组装；固定 effort 模型切换后 DB 行保留旧 effort 值（与切换前一致），运行时投影不变。
- 回滚 / 降级方式：revert 单 commit 即可。

### 提交前检查

- [x] 已 review 完整 diff
- [x] 每个 commit 都带 DCO 签名（`git commit -s`，见 [DCO](../DCO)）
- [x] UI 改动已在「UI 变化」注明引用的设计规范章节（不涉及 UI 则跳过）
- [x] 未提交凭证、令牌或授权文件
- [x] 已补充必要文档
- [x] 已确认测试结果或说明未执行原因
