### PR TITLE
fix(mobile): 限制首页过期快照的无界重拉

### DIFF
--- a/apps/mobile/app/devices/index.tsx
+++ b/apps/mobile/app/devices/index.tsx
@@ -221,6 +221,8 @@ import { fontWeight, iconSize, iconStroke, lineHeight, radius, spacing, typeScal
 const LIST_LIMIT = 200;
 const DEVICE_LIST_TIMEOUT_MS = 12_000;
 const HOME_LIST_SUBSCRIPTION_OWNER = 'device-list';
+const HOME_HYDRATE_MAX_TRAILING_RERUNS = 2;
+const HOME_HYDRATE_RERUN_BACKOFF_MS = 100;
 // 项目组与自动化组展开后的子列表共用同一个预览限量(设备详情页也 import 复用,避免两处漂移)。
 export const PROJECT_PREVIEW_LIMIT = 5;
 const HOME_SESSION_ROW_HEIGHT = 78;
@@ -260,13 +262,15 @@ type HomeHydrateInFlightEntry = {
   device: DeviceView;
   homeSyncGeneration: number;
   promise: Promise<HydrateDeviceSessionsResult>;
+  rerunCount: number;
   rerunRequested: boolean;
+  rerunScheduled: boolean;
 };
 
 type HydrateDeviceSessions = (
   device: DeviceView,
   expectedAccountGeneration?: number,
-  options?: { trailingIfInFlight?: boolean },
+  options?: { trailingIfInFlight?: boolean; rerunCount?: number },
 ) => Promise<HydrateDeviceSessionsResult>;
 
 class HomeSyncScopeSupersededError extends Error {
@@ -747,7 +751,7 @@ export default function HomeScreen() {
   const hydrateDeviceSessions = useCallback((
     device: DeviceView,
     expectedAccountGeneration = accountGeneration,
-    options: { trailingIfInFlight?: boolean } = {},
+    options: { trailingIfInFlight?: boolean; rerunCount?: number } = {},
   ): Promise<HydrateDeviceSessionsResult> => {
     const expectedHomeSyncGeneration = homeSyncGenerationByDeviceRef.current.get(device.deviceId);
     if (
@@ -779,21 +783,41 @@ export default function HomeScreen() {
       device,
       homeSyncGeneration: expectedHomeSyncGeneration,
       promise,
+      rerunCount: options.rerunCount ?? 0,
       rerunRequested: false,
+      rerunScheduled: false,
     };
     homeHydrateInFlightByDeviceRef.current.set(device.deviceId, entry);
     const settle = (needsRerun: boolean) => {
       if (homeHydrateInFlightByDeviceRef.current.get(device.deviceId) !== entry) return;
-      homeHydrateInFlightByDeviceRef.current.delete(device.deviceId);
-      if (
-        !needsRerun
-        && !entry.rerunRequested
-      ) return;
+      if (!needsRerun && !entry.rerunRequested) {
+        homeHydrateInFlightByDeviceRef.current.delete(device.deviceId);
+        return;
+      }
+      // A live sessions push can invalidate a whole-list snapshot. Coalesce it into a small,
+      // bounded trailing pull instead of allowing an unbounded invalidation/rerun loop to starve
+      // the JS thread while the desktop is actively streaming messages.
+      if (entry.rerunScheduled || entry.rerunCount >= HOME_HYDRATE_MAX_TRAILING_RERUNS) {
+        homeHydrateInFlightByDeviceRef.current.delete(device.deviceId);
+        updateDeviceConnectionState(device.deviceId, 'idle');
+        return;
+      }
+      entry.rerunScheduled = true;
       if (
         homeAccountGenerationRef.current !== entry.accountGeneration
         || !isCurrentHomeSyncTarget(device.deviceId, entry.homeSyncGeneration)
-      ) return;
-      void hydrateDeviceSessionsRef.current(entry.device, entry.accountGeneration);
+      ) {
+        homeHydrateInFlightByDeviceRef.current.delete(device.deviceId);
+        return;
+      }
+      const delayMs = HOME_HYDRATE_RERUN_BACKOFF_MS * (2 ** entry.rerunCount);
+      setTimeout(() => {
+        if (homeHydrateInFlightByDeviceRef.current.get(device.deviceId) !== entry) return;
+        homeHydrateInFlightByDeviceRef.current.delete(device.deviceId);
+        void hydrateDeviceSessionsRef.current(entry.device, entry.accountGeneration, {
+          rerunCount: entry.rerunCount + 1,
+        });
+      }, delayMs);
     };
     void promise.then(
       (result) => settle(result.needsRerun === true),

--- a/apps/mobile/src/__tests__/homeDesktopFirst.test.ts
+++ b/apps/mobile/src/__tests__/homeDesktopFirst.test.ts
@@ -513,6 +513,11 @@ describe('mobile home desktop-first surface', () => {
     expect(source).toContain('captureDeviceSessionListMutationEpoch(');
     expect(source).toContain('isDeviceSessionListMutationEpochCurrent(');
     expect(source).toContain('needsRerun: true');
+    expect(source).toContain('HOME_HYDRATE_MAX_TRAILING_RERUNS');
+    expect(source).toContain('HOME_HYDRATE_RERUN_BACKOFF_MS');
+    expect(source).toContain('entry.rerunCount >= HOME_HYDRATE_MAX_TRAILING_RERUNS');
+    expect(source).toContain("updateDeviceConnectionState(device.deviceId, 'idle');");
+    expect(source).toContain('setTimeout(() => {');
     expect(source).toContain('homeDeviceSyncLimiterRef.current.run');
     const hydrateSource = source.slice(
       source.indexOf('const hydrateDeviceSessions = useCallback'),


### PR DESCRIPTION
## 这次改了什么

### 摘要

修复 Mobile 首页设备会话全量快照在持续收到 `sessions` 推送时可能形成的无界尾随重拉。

v0.1.70 诊断报告已经确认：快照拉取期间 mutation epoch 一旦失效，原实现会立即再次执行 `local-db:sessions:list`，没有退避和次数上限。桌面端有活跃流式消息时，连续的 `sessions:patched` / usage 推送可能让这条路径反复执行，叠加分组切换的大量行重挂载后造成 Android JS/UI 线程压力、卡顿，甚至 ANR。

本 PR 不把该缺陷表述为已确认的唯一根因，只收敛代码已直接证明的无界 rerun 风险。

### 修补措施

1. 每台设备的一轮 Home hydrate 最多执行 2 次尾随重拉，超过上限后保留已由增量推送维护的 store，不再继续全量拉取。
2. 尾随重拉采用 100ms、200ms 指数退避，给连续推送合并窗口，避免完成后立即抢占 JS 线程。
3. 增加 `rerunScheduled` 防护，同一 in-flight entry 只调度一次尾随任务。
4. 延续现有 account generation 与 Home sync generation 栅栏；账号或设备范围已经切换时，延迟任务不会写回旧投影。
5. 达到上限或放弃尾随拉取时恢复设备连接状态为 `idle`，避免 UI 永久停留在“同步中”。
6. 更新 Home 源码契约测试，锁定次数上限、退避调度与 idle 收口。

### 变更类型

- [x] `fix` 缺陷修复

### 范围

Fixes #3728

- 关联：v0.1.70 Android 分组切换卡死/闪退诊断报告；#3590 引入的 mutation epoch rerun 路径。
- 本 PR 包含：Mobile Home 会话快照尾随重拉的限次、退避、范围栅栏复用与状态收口。
- 明确不包含：RNGH / RN / Reanimated 原生依赖回退；分组/非分组行 key 统一；folder 子行虚拟化；默认折叠策略。
- 用户可见变化：持续推送与分组切换叠加时，不再允许后台全量列表重拉无限占用 JS 线程。
- Breaking change：无。

### UI 变化

- 引用的设计规范：不涉及；没有视觉、交互或 UI 文案改动，只调整既有 Home 数据同步调度。

## 怎么验证的

### 自动验证

```text
pnpm test:unit:related
结果：通过；apps/mobile related tests 通过。

pnpm --filter mobile run --if-present typecheck
结果：通过。

pnpm check:dco
结果：通过；1 个 commit 带匹配 author 的 Signed-off-by。
```

### 手工验证

尚未在报告中的 M2007J1SC（小米 10 青春版）或同等级 Android 真机上验证。该项必须在正式发布前完成。

### 未执行的验证

- 未做 v0.1.70 灰度真机复现对照：当前环境没有报告设备与对应 production build。
- 未执行 E1（Android 临时替换 plain View）：本 PR 优先修复代码已证实的 #3590 无界 rerun，不先改动手势栈或 runtime fingerprint。
- 未做 Light/Dark 目检：没有 UI 样式或文案改动。

## 风险

### 风险分类

- [x] 其他：同步新鲜度与性能取舍。

### 影响与回滚

- 影响范围：仅 Mobile Home 对远端设备会话列表的权威 hydrate 尾随重拉。
- 新鲜度：达到 2 次上限时不应用已经过期的整表快照，保留实时增量推送已写入的状态；下一次 focus、foreground、下拉刷新或恢复触发仍可重新 hydrate。
- 回滚方式：回滚本提交即可恢复原有立即、无上限 rerun 行为。
- 原生层 / fingerprint / OTA：不涉及；只修改 TS 与测试，不改变 runtime fingerprint 输入。

## 正式发布前的下一步

1. 用 v0.1.70 同一账号数据量，在报告设备 M2007J1SC 或同等级中低端 Android 上灰度构建。
2. 同时保持桌面端活跃流式回合，分别在“对话归为一组”开启/关闭时反复切换“按项目分组”，记录卡顿、ANR 与 `local-db:sessions:list` 调用次数。
3. 验收标准：不存在持续重拉；切换不再 ANR/闪退；列表最终可通过增量推送或下一次正常 hydrate 收敛。
4. 若问题消失，说明 #3590 的运行时压力贡献坐实，可进入正式发布评审。
5. 若仍复现，立即执行诊断报告 E1：Android 诊断包临时把 `SwipeableSessionRow` 替换为 plain View，用于确认 Expo 57 / RN 0.86 / RNGH / Reanimated 栈下的单行挂载成本回归。
6. 无论 E1 结果如何，后续治理分组切换的全量重挂载：稳定 grouped/mixed 行 key、将 folder 子行纳入虚拟化或调整默认折叠；该结构性改动单独 PR，并补真机性能基线。

## 提交前检查

- [x] 已 review 完整 diff；未发现 P0/P1。
- [x] commit 带 DCO 签名。
- [x] 未提交凭证、令牌或授权文件。
- [x] 已如实记录测试结果与未执行项。

> 当前为 Draft PR。请勿转 Ready、合并或进入正式发布，直到维护者查看本草稿并完成上述真机验证。