### PR TITLE
fix(chat): 回复完成后保持消息流贴底

### DIFF
--- a/apps/desktop/src/renderer/__tests__/focusScrollLifecycle.test.ts
+++ b/apps/desktop/src/renderer/__tests__/focusScrollLifecycle.test.ts
@@ -2,6 +2,7 @@ import { readFileSync } from 'node:fs';
 import { describe, expect, it } from 'vitest';
 
 import {
+  consumePendingReanchorForAutoFollow,
   pickIntersectingChildAnchor,
   readAnchorClientId,
   readViewportChildAnchorClientId,
@@ -58,6 +59,36 @@ describe('focus scroll cancellation decisions', () => {
         hasDeferredDelete: true,
       }),
     ).toBe('stale');
+  });
+});
+
+describe('render-item compensation priority', () => {
+  it('consumes pending reanchor and short-circuits old compensation while following the tail', () => {
+    let pendingReanchor = true;
+
+    const shouldShortCircuit = consumePendingReanchorForAutoFollow({
+      isNearBottom: true,
+      clearPendingReanchor: () => {
+        pendingReanchor = false;
+      },
+    });
+
+    expect(shouldShortCircuit).toBe(true);
+    expect(pendingReanchor).toBe(false);
+  });
+
+  it('preserves pending reanchor and continues compensation after the user scrolls up', () => {
+    let clearCount = 0;
+
+    const shouldShortCircuit = consumePendingReanchorForAutoFollow({
+      isNearBottom: false,
+      clearPendingReanchor: () => {
+        clearCount += 1;
+      },
+    });
+
+    expect(shouldShortCircuit).toBe(false);
+    expect(clearCount).toBe(0);
   });
 });
 
@@ -425,23 +456,24 @@ describe('MessageStream focus cancellation wiring', () => {
     expect(compensation).not.toContain('if (anchor.messageClientId && snapshotMessageGone) {');
   });
 
-  it('keeps auto-follow authoritative when turn completion rebuilds grouping keys', () => {
+  it('uses the auto-follow decision as a hard return before viewport compensation', () => {
     const compensation = sourceBetween(
       '// ── 删除靠前 message 后的视口保位（#2289）──',
       '// ── post-load auto-expand ──',
     );
-    const followGuard = compensation.indexOf('if (isNearBottomRef.current) {');
-    const pendingRestore = compensation.indexOf(
-      'const pending = pendingReanchorScrollRef.current;',
+    const guardStart = compensation.indexOf('consumePendingReanchorForAutoFollow({');
+    const guardEnd = compensation.indexOf(
+      'const snapshot = lastViewportTopRef.current;',
+      guardStart,
     );
-    const recoveredGroupingKey = compensation.indexOf(
-      'if (snapshot && recoveredKey && !snapshotMessageGone)',
-    );
+    expect(guardStart).toBeGreaterThanOrEqual(0);
+    expect(guardEnd).toBeGreaterThan(guardStart);
+    const guard = compensation.slice(guardStart, guardEnd);
 
-    expect(followGuard).toBeGreaterThanOrEqual(0);
-    expect(compensation).toContain('pendingReanchorScrollRef.current = null;');
-    expect(followGuard).toBeLessThan(pendingRestore);
-    expect(followGuard).toBeLessThan(recoveredGroupingKey);
+    expect(guard).toContain('isNearBottom: isNearBottomRef.current');
+    expect(guard).toContain('pendingReanchorScrollRef.current = null;');
+    expect(guard).toMatch(/\)\s*\{\s*return;\s*\}/);
+    expect(compensation).not.toContain('if (isNearBottomRef.current) return;');
   });
 
   it('finishes an older chip or rail navigation before starting a jump to bottom', () => {

--- a/apps/desktop/src/renderer/__tests__/focusScrollLifecycle.test.ts
+++ b/apps/desktop/src/renderer/__tests__/focusScrollLifecycle.test.ts
@@ -425,6 +425,25 @@ describe('MessageStream focus cancellation wiring', () => {
     expect(compensation).not.toContain('if (anchor.messageClientId && snapshotMessageGone) {');
   });
 
+  it('keeps auto-follow authoritative when turn completion rebuilds grouping keys', () => {
+    const compensation = sourceBetween(
+      '// ── 删除靠前 message 后的视口保位（#2289）──',
+      '// ── post-load auto-expand ──',
+    );
+    const followGuard = compensation.indexOf('if (isNearBottomRef.current) {');
+    const pendingRestore = compensation.indexOf(
+      'const pending = pendingReanchorScrollRef.current;',
+    );
+    const recoveredGroupingKey = compensation.indexOf(
+      'if (snapshot && recoveredKey && !snapshotMessageGone)',
+    );
+
+    expect(followGuard).toBeGreaterThanOrEqual(0);
+    expect(compensation).toContain('pendingReanchorScrollRef.current = null;');
+    expect(followGuard).toBeLessThan(pendingRestore);
+    expect(followGuard).toBeLessThan(recoveredGroupingKey);
+  });
+
   it('finishes an older chip or rail navigation before starting a jump to bottom', () => {
     const jumpToBottom = sourceBetween(
       'const scrollToBottomSmooth = useCallback(() => {',

--- a/apps/desktop/src/renderer/components/chat/MessageStream.tsx
+++ b/apps/desktop/src/renderer/components/chat/MessageStream.tsx
@@ -125,6 +125,22 @@ export function resolveProgrammaticScrollEndDecision({
   return consumeDeferredDelete ? 'consume-deferred-delete' : 'replay-deferred-delete';
 }
 
+/**
+ * 贴底时由 auto-follow 独占本轮布局变化，并消费此前记录的视口重锚。
+ * 返回 true 表示调用方必须立即结束旧视口补偿，避免其覆盖同一提交里的 pinToBottom。
+ */
+export function consumePendingReanchorForAutoFollow({
+  isNearBottom,
+  clearPendingReanchor,
+}: {
+  isNearBottom: boolean;
+  clearPendingReanchor: () => void;
+}): boolean {
+  if (!isNearBottom) return false;
+  clearPendingReanchor();
+  return true;
+}
+
 /** 以落定时的最新 DOM 几何重新计算 chip / 导航轨道目标，而不是复用 smooth 开始前的像素。 */
 export function resolveChipJumpTargetScrollTop({
   scrollTop,
@@ -5136,8 +5152,14 @@ export function MessageStream({
     // #3067: turn 完成会把运行中工作组重建为完成态分组，key / 数量都可能变化。
     // 贴底态必须始终由 auto-follow 接管；若先执行旧锚点恢复，会覆盖上方同一提交里的
     // pinToBottom，把视口拉回本轮 user 消息。同步消费待重锚，避免用户稍后上滚时重放旧落点。
-    if (isNearBottomRef.current) {
-      pendingReanchorScrollRef.current = null;
+    if (
+      consumePendingReanchorForAutoFollow({
+        isNearBottom: isNearBottomRef.current,
+        clearPendingReanchor: () => {
+          pendingReanchorScrollRef.current = null;
+        },
+      })
+    ) {
       return;
     }
 

--- a/apps/desktop/src/renderer/components/chat/MessageStream.tsx
+++ b/apps/desktop/src/renderer/components/chat/MessageStream.tsx
@@ -5132,6 +5132,15 @@ export function MessageStream({
     const prevAllItems = prevAllItemsRef.current;
     prevVisibleItemsRef.current = visibleRenderItems;
     prevAllItemsRef.current = allRenderItems;
+
+    // #3067: turn 完成会把运行中工作组重建为完成态分组，key / 数量都可能变化。
+    // 贴底态必须始终由 auto-follow 接管；若先执行旧锚点恢复，会覆盖上方同一提交里的
+    // pinToBottom，把视口拉回本轮 user 消息。同步消费待重锚，避免用户稍后上滚时重放旧落点。
+    if (isNearBottomRef.current) {
+      pendingReanchorScrollRef.current = null;
+      return;
+    }
+
     const snapshot = lastViewportTopRef.current;
     const prevSeq = prevAllItems.length > 0 ? prevAllItems : prevVisibleItems;
 
@@ -5191,8 +5200,6 @@ export function MessageStream({
       if (programmaticScrollRef.current) deferredDeleteCompensationRef.current = true;
       return;
     }
-    if (isNearBottomRef.current) return;
-
     let anchor = snapshot;
     if (restoringRef.current) {
       const snap = restoreSnapshotRef.current;


### PR DESCRIPTION
## 这次改了什么

### 摘要

回复完成时，运行中的工作组会重建为完成态分组。现有的删除／重锚 layout effect 会在贴底状态下先恢复旧视口锚点，覆盖同一提交中的 `pinToBottom`，因此长对话可能跳回本轮提问位置。

本 PR 让贴底 auto-follow 在该时序中拥有最高优先级，并消费已失效的待重锚；用户主动上滚后的既有阅读位置保护保持不变。

### 变更类型

- [ ] `feat` 新功能
- [x] `fix` 缺陷修复
- [ ] `refactor` / `perf` 重构或性能优化
- [ ] `docs` / `test` / `chore` 文档、测试或工程维护
- [ ] 其他：

### 范围

- 关联 Issue / 需求：Fixes #3067
- 本 PR 包含：调整 Desktop `MessageStream` 的贴底与视口重锚优先级；补充回复完成时工作组 key 重建的回归测试。
- 明确不包含：样式、文案、Mobile、服务端、消息协议或分组算法调整。
- 用户可见变化：用户停留在消息流底部时，回复完成后继续保持贴底，不再自动跳回本轮提问。
- 是否存在 breaking change：无。

### UI 变化

- 引用的设计规范：`docs/design-rules/DESIGN.md` §7（禁止无意的视觉跳变）与 §14.4（交互保持快速、直接，流式内容本身已构成运动）。本修复移除无用户操作的视口跳转，不新增样式、布局、文案或动效，因此无截图差异。

## 怎么验证的

### 自动验证

```text
pnpm --filter desktop run --if-present typecheck
结果：通过

pnpm test:unit:related
结果：通过（apps/desktop related 2）

pnpm check:dco
结果：通过，1 个 commit 已签名
```

### 手工验证

未执行 Desktop 实机长会话验证；本次通过滚动生命周期的定向回归测试和相关单测覆盖。

### 未执行的验证

- macOS 0.1.56 与当前 main 的长会话对照验证：当前执行环境为 Windows，且隔离 worktree 未下载 Desktop runtime 二进制。
- Windows 实机视觉验证：未启动 Desktop；本 PR 不改视觉资源或样式。

## 风险

### 风险分类

- [ ] 无已知风险
- [ ] SQLite / migration
- [ ] system prompt
- [ ] 协议兼容
- [ ] 权限 / 安全 / 用户数据
- [ ] 存量插件兼容（批准状态 / 指纹 / manifest 校验 / 安装布局 / 包格式）
- [ ] 原生层 / fingerprint / OTA
- [ ] 跨平台差异
- [x] 其他：Desktop 消息流滚动生命周期时序

### 影响与回滚

- 影响范围：仅 Desktop `MessageStream` 贴底状态下的删除／分组重建补偿；非贴底阅读、历史恢复和显式导航仍走原逻辑。
- 回滚 / 降级方式：回退本 PR 的单个 commit 即可恢复原有优先级，无数据迁移或持久化影响。

### 提交前检查

- [x] 已 review 完整 diff
- [x] 每个 commit 都带 DCO 签名（`git commit -s`，见 [DCO](../DCO)）
- [x] UI 改动已在「UI 变化」注明引用的设计规范章节（不涉及 UI 则跳过）
- [x] 未提交凭证、令牌或授权文件
- [x] 已补充必要文档（本次无需文档变更）
- [x] 已确认测试结果或说明未执行原因
