### PR TITLE
fix(pi): keep gateway thinkingLevelMap when wire api differs

### DIFF
--- a/apps/desktop/src/main/maker-host/__tests__/piNativeProviders.test.ts
+++ b/apps/desktop/src/main/maker-host/__tests__/piNativeProviders.test.ts
@@ -2131,6 +2131,29 @@ describe('#3732: gateway thinkingLevelMap survives a front-door API change', () 
     expect(spec?.thinkingLevelMap).toMatchObject({ low: 'low', high: 'high', max: 'max' });
   });
 
+  it('does not replace a quirky probed map with the stale bundled canonical map', () => {
+    declareServerPiApi('deepseek/deepseek-v4-flash', 'openai-responses');
+    setLatestPiBundledModelCatalogForTest(
+      new Map([
+        [
+          'deepseek',
+          new Map([
+            [
+              'deepseek-v4-flash',
+              piBundledModel('deepseek-v4-flash', 'openai-completions', {
+                thinkingLevelMap: { low: 'thinking-budget-x', max: 'yarn.reasoning.max' },
+              }),
+            ],
+          ]),
+        ],
+      ]),
+    );
+
+    expect(resolvePiCindyGatewayModelSpec('xd', 'deepseek/deepseek-v4-flash')).toEqual({
+      api: 'openai-responses',
+    });
+  });
+
   it('still drops a map with provider-specific values across an API change', () => {
     declareServerPiApi('z-ai/glm-5.3-flash-quirky', 'openai-responses');
     setLatestPiBundledModelCatalogForTest(

--- a/apps/desktop/src/main/maker-host/__tests__/piNativeProviders.test.ts
+++ b/apps/desktop/src/main/maker-host/__tests__/piNativeProviders.test.ts
@@ -39,6 +39,7 @@ import {
   resolvePiBundledModelById,
   resolvePiCindyGatewayModelApi,
   resolvePiCindyGatewayModelSpec,
+  setLatestPiBundledModelCatalogForTest,
   type PiBundledModelInfo,
 } from '../pi-host.js';
 import { setActiveCatalog, setXdGatewayModels } from '../active-catalog.js';
@@ -70,6 +71,7 @@ const piBundledModel = (
 afterEach(() => {
   setActiveCatalog(BUNDLED_CATALOG);
   setXdGatewayModels([]);
+  setLatestPiBundledModelCatalogForTest(null);
 });
 
 describe('resolvePiCindyGatewayModelApi', () => {
@@ -2058,6 +2060,122 @@ describe('buildPiNativeProvidersFromConfigs', () => {
         xhigh: null,
         max: 'max',
       },
+    });
+  });
+});
+
+describe('#3732: gateway thinkingLevelMap survives a front-door API change', () => {
+  const declareServerPiApi = (modelId: string, wireProtocol: 'openai-responses') => {
+    const catalog = JSON.parse(JSON.stringify(BUNDLED_CATALOG)) as Catalog;
+    const presetId = 'server-pi-authority-test';
+    catalog.presets = [
+      ...(catalog.presets ?? []),
+      {
+        id: presetId,
+        name: 'Server Pi Authority Test',
+        runtimes: {
+          pi: {
+            baseUrl: 'https://server.example/v4',
+            wireProtocol,
+            models: [{ id: modelId, name: modelId }],
+          },
+        },
+      },
+    ];
+    catalog.modelRegistry = {
+      schemaVersion: 2,
+      updatedAt: '2026-08-29T00:00:00.000Z',
+      models: [
+        {
+          id: `canonical/${modelId}`,
+          name: modelId,
+          routes: [
+            { providerId: 'xd', modelId, agents: ['claude-code', 'codex'] },
+            { providerId: presetId, modelId, agents: ['claude-code', 'codex'] },
+          ],
+        },
+      ],
+    };
+    setActiveCatalog(catalog, { authorityCatalog: catalog });
+    setXdGatewayModels([{ id: modelId, agents: ['pi'], perAgent: { pi: { wireProtocol } } }]);
+  };
+
+  const glmProbedRow = piBundledModel('glm-5.3-flash', 'openai-completions', {
+    thinkingLevelMap: {
+      off: null,
+      minimal: null,
+      low: 'low',
+      medium: null,
+      high: 'high',
+      xhigh: null,
+      max: 'max',
+    },
+  });
+
+  it('keeps the probed completions map for z-ai/glm-5.3-flash over the responses front door', () => {
+    declareServerPiApi('z-ai/glm-5.3-flash', 'openai-responses');
+    setLatestPiBundledModelCatalogForTest(
+      new Map([['zai', new Map([['glm-5.3-flash', glmProbedRow]])]]),
+    );
+
+    const spec = resolvePiCindyGatewayModelSpec('xd', 'z-ai/glm-5.3-flash');
+    expect(spec).toMatchObject({ api: 'openai-responses' });
+    expect(spec?.thinkingLevelMap).toMatchObject({ low: 'low', high: 'high', max: 'max' });
+  });
+
+  it('keeps the static completions map when the Gateway carries deepseek over responses', () => {
+    declareServerPiApi('deepseek/deepseek-v4-flash', 'openai-responses');
+
+    const spec = resolvePiCindyGatewayModelSpec('xd', 'deepseek/deepseek-v4-flash');
+    expect(spec).toMatchObject({ api: 'openai-responses' });
+    expect(spec?.thinkingLevelMap).toMatchObject({ low: 'low', high: 'high', max: 'max' });
+  });
+
+  it('still drops a map with provider-specific values across an API change', () => {
+    declareServerPiApi('z-ai/glm-5.3-flash-quirky', 'openai-responses');
+    setLatestPiBundledModelCatalogForTest(
+      new Map([
+        [
+          'z-ai',
+          new Map([
+            [
+              'glm-5.3-flash-quirky',
+              piBundledModel('glm-5.3-flash-quirky', 'openai-completions', {
+                thinkingLevelMap: { low: 'thinking-budget-x', max: 'yarn.reasoning.max' },
+              }),
+            ],
+          ]),
+        ],
+      ]),
+    );
+
+    expect(resolvePiCindyGatewayModelSpec('xd', 'z-ai/glm-5.3-flash-quirky')).toEqual({
+      api: 'openai-responses',
+    });
+  });
+
+  it('still keeps compat gated to the API match while reusing the map', () => {
+    declareServerPiApi('z-ai/glm-5.3-flash', 'openai-responses');
+    setLatestPiBundledModelCatalogForTest(
+      new Map([
+        [
+          'zai',
+          new Map([
+            [
+              'glm-5.3-flash',
+              piBundledModel('glm-5.3-flash', 'openai-completions', {
+                compat: { thinkingFormat: 'zai', zaiToolStream: true },
+                thinkingLevelMap: { low: 'low', high: 'high', max: 'max' },
+              }),
+            ],
+          ]),
+        ],
+      ]),
+    );
+
+    expect(resolvePiCindyGatewayModelSpec('xd', 'z-ai/glm-5.3-flash')).toEqual({
+      api: 'openai-responses',
+      thinkingLevelMap: { low: 'low', high: 'high', max: 'max' },
     });
   });
 });

--- a/apps/desktop/src/main/maker-host/pi-host.ts
+++ b/apps/desktop/src/main/maker-host/pi-host.ts
@@ -144,6 +144,14 @@ const piBundledModelsByBinary = new Map<string, Promise<PiBundledModelCatalog | 
 const listedIdsByCatalog = new WeakMap<PiBundledModelCatalog, PiListedModelIds>();
 let latestPiBundledModelCatalog: PiBundledModelCatalog | null = null;
 
+/**
+ * 测试专用：注入/清除模拟的二进制探测结果。生产路径只有 readPiBundledModels 写这段
+ * 状态；这里不落 piBundledModelsByBinary 缓存，afterEach 必须显式清回 null。
+ */
+export function setLatestPiBundledModelCatalogForTest(catalog: PiBundledModelCatalog | null): void {
+  latestPiBundledModelCatalog = catalog;
+}
+
 export function listedPiModelIds(
   catalog: PiBundledModelCatalog | undefined,
 ): PiListedModelIds | undefined {
@@ -1540,6 +1548,32 @@ export function resolvePiCindyGatewayModelApi(
   return resolveBundledPiGatewayModelProfile(modelId)?.api ?? gatewayApi;
 }
 
+/**
+ * thinkingLevelMap 是否与 wire 协议无关（值全部是 null 或标准 reasoning 档名）。
+ *
+ * pi 在 responses / codex-responses / completions / messages 四种 api 上都以
+ * `map[level] ?? level` 同一方式消费这张表 —— 它描述的是模型自身的推理档命名，
+ * 不是某个 wire 协议的序列化 quirk。含任何 provider 专属 token 的 map 不算
+ * wire 无关，跨 api 一律丢弃（fail closed）。
+ */
+function isWireAgnosticThinkingLevelMap(
+  map: PiNativeModelSpec['thinkingLevelMap'] | undefined,
+): map is PiNativeModelSpec['thinkingLevelMap'] {
+  if (!map) return false;
+  const wireAgnosticValues: ReadonlySet<string> = new Set([
+    'none',
+    'minimal',
+    'low',
+    'medium',
+    'high',
+    'xhigh',
+    'max',
+  ]);
+  return Object.values(map).every(
+    (value) => value === null || wireAgnosticValues.has(value),
+  );
+}
+
 export function resolvePiCindyGatewayModelSpec(
   _selectedProviderId: string | null | undefined,
   modelId: string,
@@ -1573,6 +1607,26 @@ export function resolvePiCindyGatewayModelSpec(
   // probe takes precedence over the checked-in snapshot when both match that API.
   const compatibleBundled = bundled?.api === api ? bundled : undefined;
   const compatibleProbed = probed?.api === api ? probed : undefined;
+  // #3732: the Responses front door also carries completions-native models (z-ai/glm-5.3-flash,
+  // deepseek/*). Their catalog rows describe api 'openai-completions' plus a thinkingLevelMap of
+  // model-native reasoning level names. That map is not a wire-serialization quirk — every Pi
+  // API consumes it as `map[level] ?? level` — so for exactly this front-door mismatch the map
+  // still applies (values restricted to null or canonical effort level names), while compat and
+  // samplingParams stay dropped per #3627. Every other API disagreement keeps the whole local
+  // profile fail-closed; without the map, Pi clamps max/xhigh down to high.
+  const carriesCompletionsRowOverResponsesFrontDoor = (
+    row: Pick<PiBundledModelInfo, 'api' | 'thinkingLevelMap'> | undefined,
+  ): PiNativeModelSpec['thinkingLevelMap'] | undefined =>
+    row && api === 'openai-responses' && row.api === 'openai-completions'
+      ? isWireAgnosticThinkingLevelMap(row.thinkingLevelMap)
+        ? row.thinkingLevelMap
+        : undefined
+      : undefined;
+  const thinkingLevelMap =
+    compatibleProbed?.thinkingLevelMap ??
+    compatibleBundled?.thinkingLevelMap ??
+    carriesCompletionsRowOverResponsesFrontDoor(probed) ??
+    carriesCompletionsRowOverResponsesFrontDoor(bundled);
   return {
     api,
     ...(compatibleProbed?.compat ?? compatibleBundled?.compat
@@ -1585,13 +1639,7 @@ export function resolvePiCindyGatewayModelSpec(
           ),
         }
       : {}),
-    ...(compatibleProbed?.thinkingLevelMap ?? compatibleBundled?.thinkingLevelMap
-      ? {
-          thinkingLevelMap: {
-            ...(compatibleProbed?.thinkingLevelMap ?? compatibleBundled?.thinkingLevelMap),
-          },
-        }
-      : {}),
+    ...(thinkingLevelMap ? { thinkingLevelMap: { ...thinkingLevelMap } } : {}),
   };
 }
 

--- a/apps/desktop/src/main/maker-host/pi-host.ts
+++ b/apps/desktop/src/main/maker-host/pi-host.ts
@@ -1622,11 +1622,14 @@ export function resolvePiCindyGatewayModelSpec(
         ? row.thinkingLevelMap
         : undefined
       : undefined;
+  // An exact current-binary probe is the live catalog for this model. If that row exists,
+  // do not fall back to a stale bundled completions map — a quirky probed map must stay
+  // fail-closed, and a map-less probed row must not be filled from the snapshot.
   const thinkingLevelMap =
     compatibleProbed?.thinkingLevelMap ??
     compatibleBundled?.thinkingLevelMap ??
     carriesCompletionsRowOverResponsesFrontDoor(probed) ??
-    carriesCompletionsRowOverResponsesFrontDoor(bundled);
+    (probed ? undefined : carriesCompletionsRowOverResponsesFrontDoor(bundled));
   return {
     api,
     ...(compatibleProbed?.compat ?? compatibleBundled?.compat

--- a/packages/maker-core/src/agents/pi/__tests__/pi-provider-routing.test.ts
+++ b/packages/maker-core/src/agents/pi/__tests__/pi-provider-routing.test.ts
@@ -2089,6 +2089,10 @@ describe('Pi provider-aware model routing', () => {
       resolvePiGatewayModelApi: () => api,
       resolvePiGatewayModelSpec: () => ({
         api,
+        thinkingLevelMap:
+          api === 'openai-responses'
+            ? { minimal: null, low: 'low', medium: 'medium', high: 'high', xhigh: 'xhigh', max: 'max' }
+            : undefined,
         ...(api === 'openai-completions'
           ? {
               compat: {
@@ -2122,12 +2126,25 @@ describe('Pi provider-aware model routing', () => {
           baseUrl?: string;
           headers?: Record<string, string>;
           compat?: Record<string, unknown>;
+          thinkingLevelMap?: Record<string, string | null>;
         }>;
       }>;
     };
     expect(models.providers.cindy?.api).toBe('anthropic-messages');
     const model = models.providers.cindy?.models.find((candidate) => candidate.id === modelId);
     expect(model).toMatchObject({ api });
+    // #3732: the spec's thinkingLevelMap must reach the written cindy block verbatim so Pi
+    // keeps max/xhigh available instead of clamping them down to high.
+    if (api === 'openai-responses') {
+      expect(model?.thinkingLevelMap).toEqual({
+        minimal: null,
+        low: 'low',
+        medium: 'medium',
+        high: 'high',
+        xhigh: 'xhigh',
+        max: 'max',
+      });
+    }
     expect(model?.baseUrl).toBe(baseUrl);
     if (api === 'openai-completions') {
       expect(model?.compat).toMatchObject({


### PR DESCRIPTION
## 这次改了什么

### 摘要

Pi 走 XD 网关时，`z-ai/glm-5.3-flash` / DeepSeek 这类模型的 Pi 目录是 `openai-completions`，网关前门是 `openai-responses`。#3627 的 api 匹配门会把整份 `thinkingLevelMap` 丢掉，Pi 随即把用户选的 max 钳成 high。

本 PR 只在「responses 前门 + completions 目录行」且 map 值全是标准档名或 null 时，把 map 留下来。`compat` / `samplingParams` 仍按 #3627 丢掉。其它 api 不一致（例如 Server 声明 `anthropic-messages` 的 kimi-k3）维持整份 fail-closed。

### 变更类型

- [x] `fix` 缺陷修复
- [ ] `feat` 新功能
- [ ] `refactor` / `perf` 重构或性能优化
- [ ] `docs` / `test` / `chore` 文档、测试或工程维护
- [ ] 其他：

### 范围

- 关联 Issue / 需求：#3732
- 本 PR 包含：`resolvePiCindyGatewayModelSpec` 对 wire-agnostic `thinkingLevelMap` 的窄口复用；glm-5.3-flash / deepseek 回归；负例（专属 token 仍丢、compat 不泄漏）；writeModelsJson 透传锁定
- 明确不包含：重做 #3627；UI 同步 `thinking_level_changed`；远端 Pi 会话；服务端 catalog 改 wire；Claude Code / Codex
- 用户可见变化：含本修复的版本里，Pi + 网关 GLM 5.3 Flash 选 max 时，请求档位应保持 max（需重启任务以重写 models.json）
- 是否存在 breaking change：无

### UI 变化

- 引用的设计规范：不涉及

## 怎么验证的

### 自动验证

```text
pnpm test:unit:related
结果：apps/desktop unit PASS；packages/maker-core unit PASS；其余 workspace SKIP

pnpm --filter @cindy/maker-core run typecheck
结果：exit 0

pnpm --filter desktop run typecheck
结果：0 errors

红测：在 main 上只打测试 seam、还原 map 逻辑后，3 个带 map 断言的用例失败；3627 kimi fail-closed 与负例通过。
```

### 手工验证

不涉及。未用含 #3627 的正式客户端抓真实 HTTP 请求体。

### 未执行的验证

- 含 #3627 的安装包 + 本修复的真机 E2E（worktree 无 `apps/pi-bin`，probe 用注入目录覆盖）
- 远端 Pi 会话（按 3627 口径未扩）
- 网关把 `reasoning.effort` 翻译成 GLM 上游字段的服务端行为

## 风险

### 风险分类

- [x] 无已知风险
- [ ] SQLite / migration
- [ ] system prompt
- [ ] 协议兼容
- [ ] 权限 / 安全 / 用户数据
- [ ] 存量插件兼容（批准状态 / 指纹 / manifest 校验 / 安装布局 / 包格式）
- [ ] 原生层 / fingerprint / OTA
- [ ] 跨平台差异
- [ ] 其他：

### 影响与回滚

- 影响范围：仅 Pi 网关模型 spec 的 `thinkingLevelMap` 投影；compat 不变
- 回滚 / 降级方式：revert 本 PR。存量会话需重启任务才会重写 models.json

### 提交前检查

- [x] 已 review 完整 diff
- [x] 每个 commit 都带 DCO 签名（`git commit -s`，见 [DCO](../DCO)）
- [x] UI 改动已在「UI 变化」注明引用的设计规范章节（不涉及 UI 则跳过）
- [x] 未提交凭证、令牌或授权文件
- [ ] 已补充必要文档
- [x] 已确认测试结果或说明未执行原因
