### PR TITLE
fix(pi): 网关 thinkingLevelMap 跟随 Server efforts 并同步 Pi 目录

### DIFF
--- a/apps/desktop/src/main/maker-host/__tests__/piGatewayModelCatalog.test.ts
+++ b/apps/desktop/src/main/maker-host/__tests__/piGatewayModelCatalog.test.ts
@@ -54,6 +54,7 @@ const currentGatewayModelsByApi = {
     'qwen/qwen3.8-max',
     'tencent/hy3',
     'z-ai/glm-5.3-flash',
+    'z-ai/glm-5.3-highspeed',
   ],
   'google-generative-ai': [
     'google/gemini-3.7-flash',
@@ -209,6 +210,7 @@ describe('Pi Gateway version-matched local supplement catalog', () => {
     ['deepseek/deepseek-v4-pro', 'openai-completions'],
     ['qwen/qwen3.8-flash', 'openai-completions'],
     ['z-ai/glm-5.3-flash', 'openai-completions'],
+    ['z-ai/glm-5.3-highspeed', 'openai-completions'],
   ] as const)('resolves %s from the local Pi model table', (modelId, api) => {
     expect(resolveBundledPiGatewayModelProfile(modelId)).toMatchObject({ api });
   });
@@ -221,7 +223,7 @@ describe('Pi Gateway version-matched local supplement catalog', () => {
         actualApi: resolveBundledPiGatewayModelProfile(modelId)?.api,
       })),
     );
-    expect(resolved).toHaveLength(46);
+    expect(resolved).toHaveLength(47);
     expect(resolved.filter((entry) => entry.actualApi !== entry.expectedApi)).toEqual([]);
   });
 
@@ -229,7 +231,11 @@ describe('Pi Gateway version-matched local supplement catalog', () => {
     expect(resolveBundledPiGatewayModelProfile('z-ai/glm-5.2')).toMatchObject({
       api: 'openai-completions',
       compat: { thinkingFormat: 'zai', zaiToolStream: true },
-      thinkingLevelMap: { low: 'high', medium: 'high', high: 'high', max: 'max' },
+      thinkingLevelMap: { low: null, medium: null, high: 'high', max: 'max' },
+    });
+    expect(resolveBundledPiGatewayModelProfile('z-ai/glm-5.3-flash')).toMatchObject({
+      api: 'openai-completions',
+      thinkingLevelMap: { low: 'low', high: 'high', max: 'max', xhigh: null },
     });
     expect(resolveBundledPiGatewayModelProfile('z-ai/glm-5.1')).toEqual({
       api: 'openai-completions',

--- a/apps/desktop/src/main/maker-host/__tests__/piNativeProviders.test.ts
+++ b/apps/desktop/src/main/maker-host/__tests__/piNativeProviders.test.ts
@@ -332,8 +332,9 @@ describe('buildPiNativeProvidersFromConfigs', () => {
     );
     expect(providers[0]?.models[0]).toMatchObject({
       id: 'k3',
-      headers: { 'User-Agent': 'KimiCLI/1.5' },
+      compat: expect.objectContaining({ forceAdaptiveThinking: true }),
     });
+    expect(providers[0]?.models[0]).not.toHaveProperty('headers');
   });
 
   it('preserves explicit overrides for an exact official model after the catalog marker is cleared', () => {

--- a/apps/desktop/src/main/maker-host/pi-gateway-model-catalog.ts
+++ b/apps/desktop/src/main/maker-host/pi-gateway-model-catalog.ts
@@ -72,6 +72,7 @@ const gatewayModelIdsByApi: Record<PiModelApi, ReadonlySet<string>> = {
     'z-ai/glm-5.2',
     'z-ai/glm-5.3',
     'z-ai/glm-5.3-flash',
+    'z-ai/glm-5.3-highspeed',
   ]),
   'google-generative-ai': new Set([
     'gemini-3-flash-preview',
@@ -216,7 +217,7 @@ const gatewayCatalogIdentityOverrides = new Map<string, { provider: string; mode
   ...['qwen3.7-max', 'qwen3.8-27b', 'qwen3.8-flash', 'qwen3.8-max'].map(
     (id) => [`qwen/${id}`, { provider: 'qwen-token-plan-cn', modelId: id }] as const,
   ),
-  ...['glm-5.1', 'glm-5.2', 'glm-5.3', 'glm-5.3-flash'].map(
+  ...['glm-5.1', 'glm-5.2', 'glm-5.3', 'glm-5.3-flash', 'glm-5.3-highspeed'].map(
     (id) => [`z-ai/${id}`, { provider: 'zai', modelId: id }] as const,
   ),
   ...['grok-4.5', 'grok-4.6'].flatMap((id) => [

--- a/packages/maker-core/src/agents/pi/__tests__/pi-provider-routing.test.ts
+++ b/packages/maker-core/src/agents/pi/__tests__/pi-provider-routing.test.ts
@@ -2146,6 +2146,118 @@ describe('Pi provider-aware model routing', () => {
     await handle.close();
   });
 
+  it('writes Gateway thinkingLevelMap from server efforts when catalog api mismatches', async () => {
+    const deps: AgentDeps = {
+      auth: {
+        getState: async () => ({ authenticated: true, identity: 'test', authSource: 'api-key' as const }),
+        triggerLogin: async () => ({ authenticated: true }),
+        logout: async () => {},
+        getAuthEnv: async () => ({ CINDY_PI_API_KEY: 'gateway-key' }),
+      },
+      runtimeConfig: { endpoint: 'http://127.0.0.1:9988/' },
+      binaryPath: path.join(agentHome, 'pi'),
+      logger: noopLogger,
+      capabilityAdditions: {
+        availableModels: [{
+          id: 'z-ai/glm-5.3-flash',
+          displayName: 'GLM 5.3 Flash',
+          contextWindow: 200_000,
+          efforts: ['low', 'high', 'max'],
+          defaultEffort: 'high',
+        }],
+      },
+      resolvePiAgentHome: () => agentHome,
+      resolvePiGatewayModelApi: () => 'openai-responses',
+      // catalog api 与网关 wire 不一致时 spec 只剩 api，不得把 max 静默丢光。
+      resolvePiGatewayModelSpec: () => ({ api: 'openai-responses' }),
+    };
+
+    const handle = await new PiAgent(deps).startSession({
+      sessionId: 'gateway-server-efforts-max',
+      workingDir: cwd,
+      model: 'z-ai/glm-5.3-flash',
+      providerId: 'xd',
+      effort: 'max',
+    });
+    const models = JSON.parse(
+      readFileSync(path.join(captured.env.PI_CODING_AGENT_DIR as string, 'models.json'), 'utf8'),
+    ) as {
+      providers: Record<string, { models?: Array<{
+        id: string;
+        thinkingLevelMap?: Record<string, string | null>;
+      }> }>;
+    };
+    expect(models.providers.cindy?.models).toEqual([
+      expect.objectContaining({
+        id: 'z-ai/glm-5.3-flash',
+        api: 'openai-responses',
+        reasoning: true,
+        thinkingLevelMap: {
+          minimal: null,
+          low: 'low',
+          medium: null,
+          high: 'high',
+          xhigh: null,
+          max: 'max',
+        },
+      }),
+    ]);
+    expect(captured.requests).toContainEqual({ type: 'set_thinking_level', level: 'max' });
+    await handle.close();
+  });
+
+  it('keeps unsupported Gateway thinking levels null when server efforts omit them', async () => {
+    const deps: AgentDeps = {
+      auth: {
+        getState: async () => ({ authenticated: true, identity: 'test', authSource: 'api-key' as const }),
+        triggerLogin: async () => ({ authenticated: true }),
+        logout: async () => {},
+        getAuthEnv: async () => ({ CINDY_PI_API_KEY: 'gateway-key' }),
+      },
+      runtimeConfig: { endpoint: 'http://127.0.0.1:9988/' },
+      binaryPath: path.join(agentHome, 'pi'),
+      logger: noopLogger,
+      capabilityAdditions: {
+        availableModels: [{
+          id: 'z-ai/glm-5.3-flash',
+          displayName: 'GLM 5.3 Flash',
+          contextWindow: 200_000,
+          efforts: ['high'],
+          defaultEffort: 'high',
+        }],
+      },
+      resolvePiAgentHome: () => agentHome,
+      resolvePiGatewayModelSpec: () => ({
+        api: 'openai-completions',
+        thinkingLevelMap: { low: 'low', high: 'high', max: 'max', xhigh: 'xhigh' },
+      }),
+    };
+
+    const handle = await new PiAgent(deps).startSession({
+      sessionId: 'gateway-server-efforts-no-max',
+      workingDir: cwd,
+      model: 'z-ai/glm-5.3-flash',
+      providerId: 'xd',
+      effort: 'high',
+    });
+    const models = JSON.parse(
+      readFileSync(path.join(captured.env.PI_CODING_AGENT_DIR as string, 'models.json'), 'utf8'),
+    ) as {
+      providers: Record<string, { models?: Array<{
+        thinkingLevelMap?: Record<string, string | null>;
+      }> }>;
+    };
+    expect(models.providers.cindy?.models?.[0]?.thinkingLevelMap).toEqual({
+      minimal: null,
+      low: null,
+      medium: null,
+      high: 'high',
+      xhigh: null,
+      max: null,
+    });
+    await handle.close();
+  });
+
   it('keeps BYOM startup when the model is outside the XD v3 Pi catalog', async () => {
     const deps: AgentDeps = {
       auth: {

--- a/packages/maker-core/src/agents/pi/index.ts
+++ b/packages/maker-core/src/agents/pi/index.ts
@@ -495,6 +495,32 @@ function effortToPiThinkingLevel(effort: Effort): string {
 }
 
 const PI_NATIVE_THINKING_LEVELS = ['off', 'minimal', 'low', 'medium', 'high', 'xhigh', 'max'] as const;
+const PI_THINKING_LEVEL_MAP_KEYS = ['minimal', 'low', 'medium', 'high', 'xhigh', 'max'] as const;
+
+/**
+ * Server / XD 下放的 efforts 是网关 thinking level 的权威。
+ * Pi 本地目录 map 只在同名档仍被下放时保留 remap；api 不一致导致 bundled map 丢失时，仍按 efforts 写同名值，不能把 max/xhigh 静默丢光。
+ */
+function gatewayThinkingLevelMap(
+  efforts: readonly Effort[],
+  bundled?: Record<string, string | null>,
+): Record<string, string | null> | undefined {
+  const supported = new Set<string>();
+  for (const effort of efforts) {
+    if (effort === 'ultra') supported.add('max');
+    else supported.add(effort);
+  }
+  if (supported.size === 0) {
+    return bundled && Object.keys(bundled).length > 0 ? { ...bundled } : undefined;
+  }
+  return Object.fromEntries(
+    PI_THINKING_LEVEL_MAP_KEYS.map((level) => {
+      if (!supported.has(level)) return [level, null];
+      const bundledValue = bundled?.[level];
+      return [level, typeof bundledValue === 'string' ? bundledValue : level];
+    }),
+  );
+}
 
 /**
  * Last-resort maxTokens for models that provide no authoritative output limit.
@@ -1671,6 +1697,7 @@ export class PiAgent extends BaseAgent {
       gatewayApiByModel.set(m.id, api);
       const supportsImageInput = m.supportsImageInput === true;
       gatewayImageInputByModel.set(m.id, supportsImageInput);
+      const thinkingLevelMap = gatewayThinkingLevelMap(m.efforts, resolvedSpec?.thinkingLevelMap);
       return [{
         id: m.id,
         name: m.displayName,
@@ -1686,9 +1713,7 @@ export class PiAgent extends BaseAgent {
               },
             }
           : {}),
-        ...(resolvedSpec?.thinkingLevelMap
-          ? { thinkingLevelMap: { ...resolvedSpec.thinkingLevelMap } }
-          : {}),
+        ...(thinkingLevelMap ? { thinkingLevelMap } : {}),
         ...(resolvedSpec?.compat ? { compat: structuredClone(resolvedSpec.compat) } : {}),
         ...(resolvedSpec?.samplingParams
           ? { samplingParams: structuredClone(resolvedSpec.samplingParams) }

--- a/packages/model-providers/catalog/pi-model-catalog.json
+++ b/packages/model-providers/catalog/pi-model-catalog.json
@@ -1,5 +1,5 @@
 {
-  "generatedAt": "2026-08-20T08:58:50.000Z",
+  "generatedAt": "2026-09-01T09:09:09.000Z",
   "providers": {
     "deepseek": [
       {
@@ -11,6 +11,40 @@
         "reasoning": true,
         "input": [
           "text"
+        ],
+        "cost": {
+          "input": 0.14,
+          "output": 0.28,
+          "cacheRead": 0.0028,
+          "cacheWrite": 0
+        },
+        "contextWindow": 1000000,
+        "maxTokens": 384000,
+        "compat": {
+          "supportsStore": false,
+          "supportsDeveloperRole": false,
+          "maxTokensField": "max_tokens",
+          "requiresReasoningContentOnAssistantMessages": true,
+          "thinkingFormat": "deepseek"
+        },
+        "thinkingLevelMap": {
+          "minimal": null,
+          "low": "low",
+          "medium": null,
+          "high": "high",
+          "max": "max"
+        }
+      },
+      {
+        "id": "deepseek-v4-flash-vision-exp",
+        "name": "DeepSeek V4 Flash Vision Exp",
+        "api": "openai-completions",
+        "baseUrl": "https://api.deepseek.com",
+        "provider": "deepseek",
+        "reasoning": true,
+        "input": [
+          "text",
+          "image"
         ],
         "cost": {
           "input": 0.14,
@@ -76,9 +110,6 @@
         "api": "anthropic-messages",
         "provider": "kimi-coding",
         "baseUrl": "https://api.kimi.com/coding",
-        "headers": {
-          "User-Agent": "KimiCLI/1.5"
-        },
         "compat": {
           "allowEmptySignature": true,
           "forceAdaptiveThinking": true
@@ -112,9 +143,6 @@
         "api": "anthropic-messages",
         "provider": "kimi-coding",
         "baseUrl": "https://api.kimi.com/coding",
-        "headers": {
-          "User-Agent": "KimiCLI/1.5"
-        },
         "compat": {
           "forceAdaptiveThinking": true
         },
@@ -147,9 +175,6 @@
         "api": "anthropic-messages",
         "provider": "kimi-coding",
         "baseUrl": "https://api.kimi.com/coding",
-        "headers": {
-          "User-Agent": "KimiCLI/1.5"
-        },
         "compat": {
           "allowEmptySignature": true,
           "forceAdaptiveThinking": true
@@ -174,9 +199,6 @@
         "api": "anthropic-messages",
         "provider": "kimi-coding",
         "baseUrl": "https://api.kimi.com/coding",
-        "headers": {
-          "User-Agent": "KimiCLI/1.5"
-        },
         "compat": {
           "forceAdaptiveThinking": true
         },
@@ -251,8 +273,8 @@
           "cacheRead": 0.06,
           "cacheWrite": 0
         },
-        "contextWindow": 1000000,
-        "maxTokens": 128000
+        "contextWindow": 1048576,
+        "maxTokens": 512000
       }
     ],
     "minimax-cn": [
@@ -311,8 +333,8 @@
           "cacheRead": 0.06,
           "cacheWrite": 0
         },
-        "contextWindow": 1000000,
-        "maxTokens": 128000
+        "contextWindow": 1048576,
+        "maxTokens": 512000
       }
     ],
     "moonshotai": [
@@ -1054,6 +1076,39 @@
         "maxTokens": 384000
       },
       {
+        "id": "deepseek-v4-pro-0813",
+        "name": "DeepSeek V4 Pro 0813",
+        "api": "openai-completions",
+        "provider": "qwen-token-plan-cn",
+        "baseUrl": "https://token-plan.cn-beijing.maas.aliyuncs.com/compatible-mode/v1",
+        "compat": {
+          "thinkingFormat": "qwen",
+          "supportsDeveloperRole": false,
+          "supportsStore": false,
+          "supportsReasoningEffort": true
+        },
+        "thinkingLevelMap": {
+          "minimal": null,
+          "low": null,
+          "medium": null,
+          "high": "high",
+          "xhigh": null,
+          "max": "max"
+        },
+        "reasoning": true,
+        "input": [
+          "text"
+        ],
+        "cost": {
+          "input": 0,
+          "output": 0,
+          "cacheRead": 0,
+          "cacheWrite": 0
+        },
+        "contextWindow": 1000000,
+        "maxTokens": 384000
+      },
+      {
         "id": "glm-5",
         "name": "GLM-5",
         "api": "openai-completions",
@@ -1334,6 +1389,40 @@
         "maxTokens": 65536
       },
       {
+        "id": "qwen3.8-flash",
+        "name": "Qwen3.8 Flash",
+        "api": "openai-completions",
+        "provider": "qwen-token-plan-cn",
+        "baseUrl": "https://token-plan.cn-beijing.maas.aliyuncs.com/compatible-mode/v1",
+        "compat": {
+          "thinkingFormat": "qwen",
+          "supportsDeveloperRole": false,
+          "supportsStore": false,
+          "supportsReasoningEffort": true
+        },
+        "thinkingLevelMap": {
+          "minimal": null,
+          "low": null,
+          "medium": null,
+          "high": "high",
+          "xhigh": null,
+          "max": "max"
+        },
+        "reasoning": true,
+        "input": [
+          "text",
+          "image"
+        ],
+        "cost": {
+          "input": 0,
+          "output": 0,
+          "cacheRead": 0,
+          "cacheWrite": 0
+        },
+        "contextWindow": 1000000,
+        "maxTokens": 131072
+      },
+      {
         "id": "qwen3.8-max",
         "name": "Qwen3.8 Max",
         "api": "openai-completions",
@@ -1496,76 +1585,6 @@
     ],
     "xiaomi": [
       {
-        "id": "mimo-v2-flash",
-        "name": "MiMo-V2-Flash",
-        "api": "openai-completions",
-        "provider": "xiaomi",
-        "baseUrl": "https://api.xiaomimimo.com/v1",
-        "compat": {
-          "requiresReasoningContentOnAssistantMessages": true,
-          "thinkingFormat": "deepseek"
-        },
-        "reasoning": true,
-        "input": [
-          "text"
-        ],
-        "cost": {
-          "input": 0.14,
-          "output": 0.28,
-          "cacheRead": 0.0028,
-          "cacheWrite": 0
-        },
-        "contextWindow": 262144,
-        "maxTokens": 65536
-      },
-      {
-        "id": "mimo-v2-omni",
-        "name": "MiMo-V2-Omni",
-        "api": "openai-completions",
-        "provider": "xiaomi",
-        "baseUrl": "https://api.xiaomimimo.com/v1",
-        "compat": {
-          "requiresReasoningContentOnAssistantMessages": true,
-          "thinkingFormat": "deepseek"
-        },
-        "reasoning": true,
-        "input": [
-          "text",
-          "image"
-        ],
-        "cost": {
-          "input": 0.14,
-          "output": 0.28,
-          "cacheRead": 0.0028,
-          "cacheWrite": 0
-        },
-        "contextWindow": 262144,
-        "maxTokens": 131072
-      },
-      {
-        "id": "mimo-v2-pro",
-        "name": "MiMo-V2-Pro",
-        "api": "openai-completions",
-        "provider": "xiaomi",
-        "baseUrl": "https://api.xiaomimimo.com/v1",
-        "compat": {
-          "requiresReasoningContentOnAssistantMessages": true,
-          "thinkingFormat": "deepseek"
-        },
-        "reasoning": true,
-        "input": [
-          "text"
-        ],
-        "cost": {
-          "input": 0.435,
-          "output": 0.87,
-          "cacheRead": 0.0036,
-          "cacheWrite": 0
-        },
-        "contextWindow": 1048576,
-        "maxTokens": 131072
-      },
-      {
         "id": "mimo-v2.5",
         "name": "MiMo-V2.5",
         "api": "openai-completions",
@@ -1638,29 +1657,6 @@
     ],
     "xiaomi-token-plan-cn": [
       {
-        "id": "mimo-v2-pro",
-        "name": "MiMo-V2-Pro",
-        "api": "openai-completions",
-        "provider": "xiaomi-token-plan-cn",
-        "baseUrl": "https://token-plan-cn.xiaomimimo.com/v1",
-        "compat": {
-          "requiresReasoningContentOnAssistantMessages": true,
-          "thinkingFormat": "deepseek"
-        },
-        "reasoning": true,
-        "input": [
-          "text"
-        ],
-        "cost": {
-          "input": 0,
-          "output": 0,
-          "cacheRead": 0,
-          "cacheWrite": 0
-        },
-        "contextWindow": 1048576,
-        "maxTokens": 131072
-      },
-      {
         "id": "mimo-v2.5",
         "name": "MiMo-V2.5",
         "api": "openai-completions",
@@ -1720,9 +1716,9 @@
           "text"
         ],
         "cost": {
-          "input": 0,
-          "output": 0,
-          "cacheRead": 0,
+          "input": 0.6,
+          "output": 2.2,
+          "cacheRead": 0.11,
           "cacheWrite": 0
         },
         "compat": {
@@ -1747,9 +1743,9 @@
           "text"
         ],
         "cost": {
-          "input": 0,
-          "output": 0,
-          "cacheRead": 0,
+          "input": 1.2,
+          "output": 4,
+          "cacheRead": 0.24,
           "cacheWrite": 0
         },
         "compat": {
@@ -1771,10 +1767,48 @@
         "baseUrl": "https://api.z.ai/api/coding/paas/v4",
         "reasoning": true,
         "thinkingLevelMap": {
+          "off": "none",
           "minimal": null,
-          "low": "high",
-          "medium": "high",
+          "low": null,
+          "medium": null,
           "high": "high",
+          "xhigh": null,
+          "max": "max"
+        },
+        "input": [
+          "text"
+        ],
+        "cost": {
+          "input": 1.4,
+          "output": 4.4,
+          "cacheRead": 0.26,
+          "cacheWrite": 0
+        },
+        "compat": {
+          "supportsStore": false,
+          "supportsDeveloperRole": false,
+          "supportsReasoningEffort": true,
+          "maxTokensField": "max_tokens",
+          "thinkingFormat": "zai",
+          "zaiToolStream": true
+        },
+        "contextWindow": 1000000,
+        "maxTokens": 131072
+      },
+      {
+        "id": "glm-5.2-highspeed",
+        "name": "GLM-5.2 Highspeed",
+        "api": "openai-completions",
+        "provider": "zai",
+        "baseUrl": "https://api.z.ai/api/coding/paas/v4",
+        "reasoning": true,
+        "thinkingLevelMap": {
+          "off": "none",
+          "minimal": null,
+          "low": null,
+          "medium": null,
+          "high": "high",
+          "xhigh": null,
           "max": "max"
         },
         "input": [
@@ -1798,12 +1832,94 @@
         "maxTokens": 131072
       },
       {
-        "id": "glm-5.2-highspeed",
-        "name": "GLM-5.2 Highspeed",
+        "id": "glm-5.3",
+        "name": "GLM-5.3",
         "api": "openai-completions",
         "provider": "zai",
         "baseUrl": "https://api.z.ai/api/coding/paas/v4",
         "reasoning": true,
+        "thinkingLevelMap": {
+          "off": null,
+          "minimal": null,
+          "low": "low",
+          "medium": null,
+          "high": "high",
+          "xhigh": null,
+          "max": "max"
+        },
+        "input": [
+          "text"
+        ],
+        "cost": {
+          "input": 1.4,
+          "output": 4.4,
+          "cacheRead": 0.26,
+          "cacheWrite": 0
+        },
+        "compat": {
+          "supportsStore": false,
+          "supportsDeveloperRole": false,
+          "supportsReasoningEffort": true,
+          "maxTokensField": "max_tokens",
+          "thinkingFormat": "zai",
+          "zaiToolStream": true
+        },
+        "contextWindow": 1000000,
+        "maxTokens": 131072
+      },
+      {
+        "id": "glm-5.3-flash",
+        "name": "GLM-5.3-Flash",
+        "api": "openai-completions",
+        "provider": "zai",
+        "baseUrl": "https://api.z.ai/api/coding/paas/v4",
+        "reasoning": true,
+        "thinkingLevelMap": {
+          "off": null,
+          "minimal": null,
+          "low": "low",
+          "medium": null,
+          "high": "high",
+          "xhigh": null,
+          "max": "max"
+        },
+        "input": [
+          "text",
+          "image"
+        ],
+        "cost": {
+          "input": 0.075,
+          "output": 0.25,
+          "cacheRead": 0.015,
+          "cacheWrite": 0
+        },
+        "compat": {
+          "supportsStore": false,
+          "supportsDeveloperRole": false,
+          "supportsReasoningEffort": true,
+          "maxTokensField": "max_tokens",
+          "thinkingFormat": "zai",
+          "zaiToolStream": true
+        },
+        "contextWindow": 1000000,
+        "maxTokens": 131072
+      },
+      {
+        "id": "glm-5.3-highspeed",
+        "name": "GLM-5.3 Highspeed",
+        "api": "openai-completions",
+        "provider": "zai",
+        "baseUrl": "https://api.z.ai/api/coding/paas/v4",
+        "reasoning": true,
+        "thinkingLevelMap": {
+          "off": null,
+          "minimal": null,
+          "low": "low",
+          "medium": null,
+          "high": "high",
+          "xhigh": null,
+          "max": "max"
+        },
         "input": [
           "text"
         ],
@@ -1816,7 +1932,7 @@
         "compat": {
           "supportsStore": false,
           "supportsDeveloperRole": false,
-          "supportsReasoningEffort": false,
+          "supportsReasoningEffort": true,
           "maxTokensField": "max_tokens",
           "thinkingFormat": "zai",
           "zaiToolStream": true
@@ -1826,6 +1942,34 @@
       }
     ],
     "zai-coding-cn": [
+      {
+        "id": "glm-4.6v",
+        "name": "GLM-4.6V",
+        "api": "openai-completions",
+        "provider": "zai-coding-cn",
+        "baseUrl": "https://open.bigmodel.cn/api/coding/paas/v4",
+        "reasoning": true,
+        "input": [
+          "text",
+          "image"
+        ],
+        "cost": {
+          "input": 0.3,
+          "output": 0.9,
+          "cacheRead": 0,
+          "cacheWrite": 0
+        },
+        "compat": {
+          "supportsStore": false,
+          "supportsDeveloperRole": false,
+          "supportsReasoningEffort": false,
+          "maxTokensField": "max_tokens",
+          "thinkingFormat": "zai",
+          "zaiToolStream": true
+        },
+        "contextWindow": 128000,
+        "maxTokens": 32768
+      },
       {
         "id": "glm-4.7",
         "name": "GLM-4.7",
@@ -1837,9 +1981,9 @@
           "text"
         ],
         "cost": {
-          "input": 0,
-          "output": 0,
-          "cacheRead": 0,
+          "input": 0.6,
+          "output": 2.2,
+          "cacheRead": 0.11,
           "cacheWrite": 0
         },
         "compat": {
@@ -1864,9 +2008,36 @@
           "text"
         ],
         "cost": {
-          "input": 0,
-          "output": 0,
-          "cacheRead": 0,
+          "input": 1.2,
+          "output": 4,
+          "cacheRead": 0.24,
+          "cacheWrite": 0
+        },
+        "compat": {
+          "supportsStore": false,
+          "supportsDeveloperRole": false,
+          "supportsReasoningEffort": false,
+          "maxTokensField": "max_tokens",
+          "thinkingFormat": "zai",
+          "zaiToolStream": true
+        },
+        "contextWindow": 200000,
+        "maxTokens": 131072
+      },
+      {
+        "id": "glm-5.1",
+        "name": "GLM-5.1",
+        "api": "openai-completions",
+        "provider": "zai-coding-cn",
+        "baseUrl": "https://open.bigmodel.cn/api/coding/paas/v4",
+        "reasoning": true,
+        "input": [
+          "text"
+        ],
+        "cost": {
+          "input": 1.4,
+          "output": 4.4,
+          "cacheRead": 0.26,
           "cacheWrite": 0
         },
         "compat": {
@@ -1888,10 +2059,48 @@
         "baseUrl": "https://open.bigmodel.cn/api/coding/paas/v4",
         "reasoning": true,
         "thinkingLevelMap": {
+          "off": "none",
           "minimal": null,
-          "low": "high",
-          "medium": "high",
+          "low": null,
+          "medium": null,
           "high": "high",
+          "xhigh": null,
+          "max": "max"
+        },
+        "input": [
+          "text"
+        ],
+        "cost": {
+          "input": 1.4,
+          "output": 4.4,
+          "cacheRead": 0.26,
+          "cacheWrite": 0
+        },
+        "compat": {
+          "supportsStore": false,
+          "supportsDeveloperRole": false,
+          "supportsReasoningEffort": true,
+          "maxTokensField": "max_tokens",
+          "thinkingFormat": "zai",
+          "zaiToolStream": true
+        },
+        "contextWindow": 1000000,
+        "maxTokens": 131072
+      },
+      {
+        "id": "glm-5.2-highspeed",
+        "name": "GLM-5.2 Highspeed",
+        "api": "openai-completions",
+        "provider": "zai-coding-cn",
+        "baseUrl": "https://open.bigmodel.cn/api/coding/paas/v4",
+        "reasoning": true,
+        "thinkingLevelMap": {
+          "off": "none",
+          "minimal": null,
+          "low": null,
+          "medium": null,
+          "high": "high",
+          "xhigh": null,
           "max": "max"
         },
         "input": [
@@ -1915,12 +2124,94 @@
         "maxTokens": 131072
       },
       {
-        "id": "glm-5.2-highspeed",
-        "name": "GLM-5.2 Highspeed",
+        "id": "glm-5.3",
+        "name": "GLM-5.3",
         "api": "openai-completions",
         "provider": "zai-coding-cn",
         "baseUrl": "https://open.bigmodel.cn/api/coding/paas/v4",
         "reasoning": true,
+        "thinkingLevelMap": {
+          "off": null,
+          "minimal": null,
+          "low": "low",
+          "medium": null,
+          "high": "high",
+          "xhigh": null,
+          "max": "max"
+        },
+        "input": [
+          "text"
+        ],
+        "cost": {
+          "input": 1.4,
+          "output": 4.4,
+          "cacheRead": 0.26,
+          "cacheWrite": 0
+        },
+        "compat": {
+          "supportsStore": false,
+          "supportsDeveloperRole": false,
+          "supportsReasoningEffort": true,
+          "maxTokensField": "max_tokens",
+          "thinkingFormat": "zai",
+          "zaiToolStream": true
+        },
+        "contextWindow": 1000000,
+        "maxTokens": 131072
+      },
+      {
+        "id": "glm-5.3-flash",
+        "name": "GLM-5.3-Flash",
+        "api": "openai-completions",
+        "provider": "zai-coding-cn",
+        "baseUrl": "https://open.bigmodel.cn/api/coding/paas/v4",
+        "reasoning": true,
+        "thinkingLevelMap": {
+          "off": null,
+          "minimal": null,
+          "low": "low",
+          "medium": null,
+          "high": "high",
+          "xhigh": null,
+          "max": "max"
+        },
+        "input": [
+          "text",
+          "image"
+        ],
+        "cost": {
+          "input": 0.075,
+          "output": 0.25,
+          "cacheRead": 0.015,
+          "cacheWrite": 0
+        },
+        "compat": {
+          "supportsStore": false,
+          "supportsDeveloperRole": false,
+          "supportsReasoningEffort": true,
+          "maxTokensField": "max_tokens",
+          "thinkingFormat": "zai",
+          "zaiToolStream": true
+        },
+        "contextWindow": 1000000,
+        "maxTokens": 131072
+      },
+      {
+        "id": "glm-5.3-highspeed",
+        "name": "GLM-5.3 Highspeed",
+        "api": "openai-completions",
+        "provider": "zai-coding-cn",
+        "baseUrl": "https://open.bigmodel.cn/api/coding/paas/v4",
+        "reasoning": true,
+        "thinkingLevelMap": {
+          "off": null,
+          "minimal": null,
+          "low": "low",
+          "medium": null,
+          "high": "high",
+          "xhigh": null,
+          "max": "max"
+        },
         "input": [
           "text"
         ],
@@ -1933,12 +2224,40 @@
         "compat": {
           "supportsStore": false,
           "supportsDeveloperRole": false,
-          "supportsReasoningEffort": false,
+          "supportsReasoningEffort": true,
           "maxTokensField": "max_tokens",
           "thinkingFormat": "zai",
           "zaiToolStream": true
         },
         "contextWindow": 1000000,
+        "maxTokens": 131072
+      },
+      {
+        "id": "glm-5v-turbo",
+        "name": "GLM-5V-Turbo",
+        "api": "openai-completions",
+        "provider": "zai-coding-cn",
+        "baseUrl": "https://open.bigmodel.cn/api/coding/paas/v4",
+        "reasoning": true,
+        "input": [
+          "text",
+          "image"
+        ],
+        "cost": {
+          "input": 1.2,
+          "output": 4,
+          "cacheRead": 0.24,
+          "cacheWrite": 0
+        },
+        "compat": {
+          "supportsStore": false,
+          "supportsDeveloperRole": false,
+          "supportsReasoningEffort": false,
+          "maxTokensField": "max_tokens",
+          "thinkingFormat": "zai",
+          "zaiToolStream": true
+        },
+        "contextWindow": 200000,
         "maxTokens": 131072
       }
     ]

--- a/packages/model-providers/catalog/providers.json
+++ b/packages/model-providers/catalog/providers.json
@@ -529,6 +529,19 @@
               "reasoningDefaultEffort": "high"
             },
             {
+              "id": "deepseek-v4-flash-vision-exp",
+              "name": "DeepSeek V4 Flash Vision Exp",
+              "contextWindow": 1000000,
+              "supportsImageInput": true,
+              "reasoning": true,
+              "reasoningEfforts": [
+                "low",
+                "high",
+                "max"
+              ],
+              "reasoningDefaultEffort": "high"
+            },
+            {
               "id": "deepseek-v4-pro",
               "name": "DeepSeek V4 Pro",
               "contextWindow": 1000000,
@@ -1030,7 +1043,7 @@
             {
               "id": "MiniMax-M3",
               "name": "MiniMax-M3",
-              "contextWindow": 1000000,
+              "contextWindow": 1048576,
               "supportsImageInput": true
             }
           ]
@@ -1089,7 +1102,7 @@
             {
               "id": "MiniMax-M3",
               "name": "MiniMax-M3",
-              "contextWindow": 1000000,
+              "contextWindow": 1048576,
               "supportsImageInput": true
             }
           ]
@@ -1292,6 +1305,17 @@
               "reasoningDefaultEffort": "high"
             },
             {
+              "id": "deepseek-v4-pro-0813",
+              "name": "DeepSeek V4 Pro 0813",
+              "contextWindow": 1000000,
+              "reasoning": true,
+              "reasoningEfforts": [
+                "high",
+                "max"
+              ],
+              "reasoningDefaultEffort": "high"
+            },
+            {
               "id": "glm-5",
               "name": "GLM-5",
               "contextWindow": 202752,
@@ -1364,6 +1388,18 @@
               "name": "Qwen3.7 Plus",
               "contextWindow": 1000000,
               "supportsImageInput": true
+            },
+            {
+              "id": "qwen3.8-flash",
+              "name": "Qwen3.8 Flash",
+              "contextWindow": 1000000,
+              "supportsImageInput": true,
+              "reasoning": true,
+              "reasoningEfforts": [
+                "high",
+                "max"
+              ],
+              "reasoningDefaultEffort": "high"
             },
             {
               "id": "qwen3.8-max",
@@ -1603,6 +1639,17 @@
               "reasoningDefaultEffort": "high"
             },
             {
+              "id": "deepseek-v4-pro-0813",
+              "name": "DeepSeek V4 Pro 0813",
+              "contextWindow": 1000000,
+              "reasoning": true,
+              "reasoningEfforts": [
+                "high",
+                "max"
+              ],
+              "reasoningDefaultEffort": "high"
+            },
+            {
               "id": "glm-5",
               "name": "GLM-5",
               "contextWindow": 202752,
@@ -1675,6 +1722,18 @@
               "name": "Qwen3.7 Plus",
               "contextWindow": 1000000,
               "supportsImageInput": true
+            },
+            {
+              "id": "qwen3.8-flash",
+              "name": "Qwen3.8 Flash",
+              "contextWindow": 1000000,
+              "supportsImageInput": true,
+              "reasoning": true,
+              "reasoningEfforts": [
+                "high",
+                "max"
+              ],
+              "reasoningDefaultEffort": "high"
             },
             {
               "id": "qwen3.8-max",
@@ -1924,6 +1983,12 @@
           "piCatalogProviderId": "zai-coding-cn",
           "models": [
             {
+              "id": "glm-4.6v",
+              "name": "GLM-4.6V",
+              "contextWindow": 128000,
+              "supportsImageInput": true
+            },
+            {
               "id": "glm-4.7",
               "name": "GLM-4.7",
               "contextWindow": 204800
@@ -1934,22 +1999,74 @@
               "contextWindow": 200000
             },
             {
+              "id": "glm-5.1",
+              "name": "GLM-5.1",
+              "contextWindow": 200000
+            },
+            {
               "id": "glm-5.2",
               "name": "GLM-5.2",
               "contextWindow": 1000000,
               "reasoning": true,
               "reasoningEfforts": [
-                "low",
-                "medium",
                 "high",
                 "max"
               ],
-              "reasoningDefaultEffort": "medium"
+              "reasoningDefaultEffort": "high"
             },
             {
               "id": "glm-5.2-highspeed",
               "name": "GLM-5.2 Highspeed",
-              "contextWindow": 1000000
+              "contextWindow": 1000000,
+              "reasoning": true,
+              "reasoningEfforts": [
+                "high",
+                "max"
+              ],
+              "reasoningDefaultEffort": "high"
+            },
+            {
+              "id": "glm-5.3",
+              "name": "GLM-5.3",
+              "contextWindow": 1000000,
+              "reasoning": true,
+              "reasoningEfforts": [
+                "low",
+                "high",
+                "max"
+              ],
+              "reasoningDefaultEffort": "high"
+            },
+            {
+              "id": "glm-5.3-flash",
+              "name": "GLM-5.3-Flash",
+              "contextWindow": 1000000,
+              "supportsImageInput": true,
+              "reasoning": true,
+              "reasoningEfforts": [
+                "low",
+                "high",
+                "max"
+              ],
+              "reasoningDefaultEffort": "high"
+            },
+            {
+              "id": "glm-5.3-highspeed",
+              "name": "GLM-5.3 Highspeed",
+              "contextWindow": 1000000,
+              "reasoning": true,
+              "reasoningEfforts": [
+                "low",
+                "high",
+                "max"
+              ],
+              "reasoningDefaultEffort": "high"
+            },
+            {
+              "id": "glm-5v-turbo",
+              "name": "GLM-5V-Turbo",
+              "contextWindow": 200000,
+              "supportsImageInput": true
             }
           ]
         }
@@ -2014,17 +2131,58 @@
               "contextWindow": 1000000,
               "reasoning": true,
               "reasoningEfforts": [
-                "low",
-                "medium",
                 "high",
                 "max"
               ],
-              "reasoningDefaultEffort": "medium"
+              "reasoningDefaultEffort": "high"
             },
             {
               "id": "glm-5.2-highspeed",
               "name": "GLM-5.2 Highspeed",
-              "contextWindow": 1000000
+              "contextWindow": 1000000,
+              "reasoning": true,
+              "reasoningEfforts": [
+                "high",
+                "max"
+              ],
+              "reasoningDefaultEffort": "high"
+            },
+            {
+              "id": "glm-5.3",
+              "name": "GLM-5.3",
+              "contextWindow": 1000000,
+              "reasoning": true,
+              "reasoningEfforts": [
+                "low",
+                "high",
+                "max"
+              ],
+              "reasoningDefaultEffort": "high"
+            },
+            {
+              "id": "glm-5.3-flash",
+              "name": "GLM-5.3-Flash",
+              "contextWindow": 1000000,
+              "supportsImageInput": true,
+              "reasoning": true,
+              "reasoningEfforts": [
+                "low",
+                "high",
+                "max"
+              ],
+              "reasoningDefaultEffort": "high"
+            },
+            {
+              "id": "glm-5.3-highspeed",
+              "name": "GLM-5.3 Highspeed",
+              "contextWindow": 1000000,
+              "reasoning": true,
+              "reasoningEfforts": [
+                "low",
+                "high",
+                "max"
+              ],
+              "reasoningDefaultEffort": "high"
             }
           ]
         }
@@ -2073,22 +2231,6 @@
           "wireProtocol": "openai-chat",
           "piCatalogProviderId": "xiaomi",
           "models": [
-            {
-              "id": "mimo-v2-flash",
-              "name": "MiMo-V2-Flash",
-              "contextWindow": 262144
-            },
-            {
-              "id": "mimo-v2-omni",
-              "name": "MiMo-V2-Omni",
-              "contextWindow": 262144,
-              "supportsImageInput": true
-            },
-            {
-              "id": "mimo-v2-pro",
-              "name": "MiMo-V2-Pro",
-              "contextWindow": 1048576
-            },
             {
               "id": "mimo-v2.5",
               "name": "MiMo-V2.5",
@@ -2152,11 +2294,6 @@
           "wireProtocol": "openai-chat",
           "piCatalogProviderId": "xiaomi-token-plan-cn",
           "models": [
-            {
-              "id": "mimo-v2-pro",
-              "name": "MiMo-V2-Pro",
-              "contextWindow": 1048576
-            },
             {
               "id": "mimo-v2.5",
               "name": "MiMo-V2.5",

--- a/packages/model-providers/src/__tests__/catalog.test.ts
+++ b/packages/model-providers/src/__tests__/catalog.test.ts
@@ -268,6 +268,7 @@ describe('bundled catalog validity (dynamic-first contract)', () => {
       wireProtocol: 'openai-chat',
       models: [
         { id: 'deepseek-v4-flash' },
+        { id: 'deepseek-v4-flash-vision-exp' },
         { id: 'deepseek-v4-pro' },
       ],
     });


### PR DESCRIPTION
## 这次改了什么

### 摘要

Pi + XD 网关把 effort 设成 max 后，请求仍被 Pi 钳成 high。原因是 `models.json` 的 cindy 块只从打包的 Pi 目录拷 `thinkingLevelMap`，Server 已下放的 `efforts` 只画滑杆。本 PR 让 Server 下放的 efforts 写入 thinkingLevelMap（可加模型、加档位），并同步 pi.dev 本地快照作为基线。

### 变更类型

- [x] `fix` 缺陷修复
- [ ] `feat` 新功能
- [ ] `refactor` / `perf` 重构或性能优化
- [ ] `docs` / `test` / `chore` 文档、测试或工程维护
- [ ] 其他：

### 范围

- 关联 Issue / 需求：#3732
- 本 PR 包含：网关 `writeModelsJson` 按 Server/XD `efforts` 生成 thinkingLevelMap；同步 `pi-model-catalog.json` / `providers.json`
- 明确不包含：`thinking_level_changed` 回写 UI；Claude Code / Codex 路径；改服务端 catalog schema；未重启的存量 Pi 进程热补 models.json
- 用户可见变化：含本改动的客户端里，Pi 网关模型选 max 后请求 `reasoning.effort` 应为 max（需重启任务）
- 是否存在 breaking change：无

### UI 变化

- 引用的设计规范：不涉及：无界面、文案或交互改动，只改 Pi 网关 models.json 元数据与目录快照。

## 怎么验证的

### 自动验证

```text
pnpm test:unit:related
结果：PASS（desktop / mobile / maker-core / model-providers / lizi-mcps / orca-workflow）

pnpm --filter desktop run typecheck
结果：PASS
```

### 手工验证

不涉及。未打真实 XD 网关。

### 未执行的验证

真实 XD 网关对 `z-ai/glm-5.3-flash` 发 `reasoning.effort=max`。需含本 PR 的客户端 + 重启 Pi 任务后验证。

## 风险

### 风险分类

- [x] 无已知风险
- [ ] SQLite / migration
- [ ] system prompt
- [ ] 协议兼容
- [ ] 权限 / 安全 / 用户数据
- [ ] 存量插件兼容（批准状态 / 指纹 / manifest 校验 / 安装布局 / 包格式）
- [ ] 原生层 / fingerprint / OTA
- [ ] 跨平台差异
- [ ] 其他：

### 影响与回滚

- 影响范围：Pi 网关 `models.json` thinkingLevelMap；打包的 Pi 目录快照。
- 回滚 / 降级方式：revert 本 PR。存量任务需重启才会重写 models.json。

### 提交前检查

- [x] 已 review 完整 diff
- [x] 每个 commit 都带 DCO 签名
- [x] UI 改动已在「UI 变化」注明引用的设计规范章节（不涉及 UI 则跳过）
- [x] 未提交凭证、令牌或授权文件
- [x] 已补充必要文档
- [x] 已确认测试结果或说明未执行原因

## 远程连接 / 手机版适配说明

不涉及：改动只影响本机/远端 Pi 启动时写入的 models.json 元数据，不改 device-link 协议或 mobile UI。

## 规模说明

非测试 +649 行，其中 +451 为 `pi-model-catalog.json`、+168 为 `providers.json`（pi.dev 同步产物）。逻辑改动约 30 行。目录快照是 Server 下放通道的本地基线，与 efforts→map 是同一目标，不拆 PR。