### PR TITLE
fix(maker-core): pi RPC 帧级定界诊断,锁定成功轮正文单帧丢失(#3696)

### DIFF
--- a/packages/maker-core/src/agents/pi/rpc-client.test.ts
+++ b/packages/maker-core/src/agents/pi/rpc-client.test.ts
@@ -58,6 +58,95 @@ beforeEach(() => {
   mocks.spawn.mockReset();
 });
 
+describe('PiRpcProcess frame diagnostics (#3696)', () => {
+  function createProcessWithMocks() {
+    const child = makeChild();
+    mocks.spawn.mockReturnValue(child);
+    const logger = {
+      trace: vi.fn(),
+      debug: vi.fn(),
+      info: vi.fn(),
+      warn: vi.fn(),
+      error: vi.fn(),
+      fatal: vi.fn(),
+      child: vi.fn(),
+    };
+    logger.child.mockReturnValue(logger);
+    const transport = createPiStdioTransport({
+      binaryPath: '/pi',
+      args: ['--mode', 'rpc'],
+      cwd: '/work',
+      env: {},
+      logger,
+    });
+    const onEvent = vi.fn();
+    const proc = new PiRpcProcess({ transport, logger, onEvent, onExit: vi.fn() });
+    const feed = (frame: Record<string, unknown>): void => {
+      child.stdout.emit('data', Buffer.from(`${JSON.stringify(frame)}\n`));
+    };
+    return { proc, logger, onEvent, feed };
+  }
+
+  it('logs message_end frame metadata (block types + char counts) without message content', () => {
+    const { logger, onEvent, feed } = createProcessWithMocks();
+    feed({
+      type: 'message_end',
+      message: {
+        role: 'assistant',
+        stopReason: 'stop',
+        content: [
+          { type: 'thinking', thinking: '思考中' },
+          { type: 'text', text: 'hello world' },
+        ],
+      },
+    });
+
+    expect(logger.info).toHaveBeenCalledWith('pi rpc message_end frame', {
+      role: 'assistant',
+      stopReason: 'stop',
+      blockTypes: ['thinking', 'text'],
+      textChars: 'hello world'.length,
+      thinkingChars: '思考中'.length,
+    });
+    // 事件仍照常透传,诊断不改变协议行为。
+    expect(onEvent).toHaveBeenCalledTimes(1);
+    // 隐私:任何日志载荷里不得出现消息正文。
+    const serializedLogs = JSON.stringify([
+      logger.info.mock.calls,
+      logger.warn.mock.calls,
+      logger.debug.mock.calls,
+    ]);
+    expect(serializedLogs).not.toContain('hello world');
+    expect(serializedLogs).not.toContain('思考中');
+  });
+
+  it('logs a per-turn frame histogram at agent_settled and resets counts', () => {
+    const { logger, feed } = createProcessWithMocks();
+    feed({ type: 'agent_start' });
+    feed({ type: 'message_update', assistantMessageEvent: { type: 'text_delta' } });
+    feed({ type: 'message_update', assistantMessageEvent: { type: 'text_delta' } });
+    feed({ type: 'message_end', message: { role: 'assistant', stopReason: 'stop', content: [] } });
+    feed({ type: 'agent_settled' });
+
+    expect(logger.info).toHaveBeenCalledWith('pi rpc turn frame histogram', {
+      frames: {
+        agent_start: 1,
+        message_update: 2,
+        message_end: 1,
+        agent_settled: 1,
+      },
+    });
+
+    logger.info.mockClear();
+    feed({ type: 'agent_start' });
+    feed({ type: 'agent_settled' });
+    // 第二轮直方图不包含第一轮计数(settled 后已清零)。
+    expect(logger.info).toHaveBeenCalledWith('pi rpc turn frame histogram', {
+      frames: { agent_start: 1, agent_settled: 1 },
+    });
+  });
+});
+
 describe('PiRpcProcess process observer', () => {
   it('registers the concrete PID and disposes that generation once on close', () => {
     const child = makeChild();

--- a/packages/maker-core/src/agents/pi/rpc-client.test.ts
+++ b/packages/maker-core/src/agents/pi/rpc-client.test.ts
@@ -120,6 +120,53 @@ describe('PiRpcProcess frame diagnostics (#3696)', () => {
     expect(serializedLogs).not.toContain('思考中');
   });
 
+  it('flushes an unsettled turn histogram at the next agent_start (no cross-turn bleed)', () => {
+    const { logger, feed } = createProcessWithMocks();
+    // 第一轮:abort 类结束,收不到 agent_settled。
+    feed({ type: 'agent_start' });
+    feed({ type: 'message_update', assistantMessageEvent: { type: 'text_delta' } });
+    // 第二轮开始:先冲刷上一轮直方图并清零。
+    feed({ type: 'agent_start' });
+    expect(logger.info).toHaveBeenCalledWith('pi rpc turn frame histogram (no agent_settled)', {
+      frames: { agent_start: 1, message_update: 1 },
+    });
+    feed({ type: 'agent_settled' });
+    // 第二轮直方图不含第一轮的 message_update 计数。
+    expect(logger.info).toHaveBeenCalledWith('pi rpc turn frame histogram', {
+      frames: { agent_start: 1, agent_settled: 1 },
+    });
+  });
+
+  it('normalizes non-identifier labels to (other) so hostile fields never reach logs', () => {
+    const { logger, feed } = createProcessWithMocks();
+    const smuggled = 'secret token value with spaces';
+    feed({
+      type: smuggled,
+    });
+    feed({
+      type: 'message_end',
+      message: {
+        role: smuggled,
+        stopReason: smuggled,
+        content: [{ type: smuggled, text: 'x' }],
+      },
+    });
+    feed({ type: 'agent_settled' });
+    expect(logger.info).toHaveBeenCalledWith('pi rpc message_end frame', {
+      role: '(other)',
+      stopReason: '(other)',
+      blockTypes: ['(other)'],
+      textChars: 0,
+      thinkingChars: 0,
+    });
+    const serializedLogs = JSON.stringify([logger.info.mock.calls, logger.warn.mock.calls]);
+    expect(serializedLogs).not.toContain(smuggled);
+    // 直方图键同样被归一化。
+    expect(logger.info).toHaveBeenCalledWith('pi rpc turn frame histogram', {
+      frames: { '(other)': 1, message_end: 1, agent_settled: 1 },
+    });
+  });
+
   it('logs a per-turn frame histogram at agent_settled and resets counts', () => {
     const { logger, feed } = createProcessWithMocks();
     feed({ type: 'agent_start' });

--- a/packages/maker-core/src/agents/pi/rpc-client.ts
+++ b/packages/maker-core/src/agents/pi/rpc-client.ts
@@ -105,6 +105,13 @@ export class PiRpcProcess {
    */
   private closePromise: Promise<void> | null = null;
   private readonly logger: Logger;
+  /**
+   * #3696 定界诊断:成功轮的正文可能整帧消失(jsonl 有正文、DB/UI 均无),离线
+   * 无法复现。这里按事件类型计数、在 message_end/agent_settled 落两行元数据日志
+   * (块类型与字符数,不含任何消息内容),让下一次复现能区分「pi 未发出该帧」
+   * 与「Cindy 收到后在下游丢失」。
+   */
+  private readonly eventFrameCounts = new Map<string, number>();
 
   constructor(private readonly opts: PiRpcSpawnOptions) {
     this.logger = opts.logger;
@@ -292,6 +299,7 @@ export class PiRpcProcess {
     }
 
     const event = obj as PiRpcEvent;
+    this.recordEventFrameDiagnostics(event);
     for (const [id, entry] of this.pending) {
       if (!entry.refreshTimeoutOnEvent?.(event)) continue;
       clearTimeout(entry.timer);
@@ -302,6 +310,48 @@ export class PiRpcProcess {
       }, entry.timeoutMs);
     }
     this.opts.onEvent(event);
+  }
+
+  /** 只记帧元数据(类型 / 块类型 / 字符数),绝不落消息正文 —— 日志白名单方向。 */
+  private recordEventFrameDiagnostics(event: PiRpcEvent): void {
+    const type = typeof event.type === 'string' && event.type.length > 0 ? event.type : '(untyped)';
+    this.eventFrameCounts.set(type, (this.eventFrameCounts.get(type) ?? 0) + 1);
+    if (type === 'message_end') {
+      const message = event.message as
+        | { role?: unknown; stopReason?: unknown; content?: unknown }
+        | undefined;
+      const blocks = Array.isArray(message?.content) ? message.content : [];
+      const blockTypes: string[] = [];
+      let textChars = 0;
+      let thinkingChars = 0;
+      for (const block of blocks) {
+        if (!block || typeof block !== 'object') {
+          blockTypes.push('(invalid)');
+          continue;
+        }
+        const rec = block as Record<string, unknown>;
+        const blockType = typeof rec.type === 'string' ? rec.type : '(untyped)';
+        blockTypes.push(blockType);
+        if (blockType === 'text' && typeof rec.text === 'string') textChars += rec.text.length;
+        if (blockType === 'thinking' && typeof rec.thinking === 'string') {
+          thinkingChars += rec.thinking.length;
+        }
+      }
+      this.logger.info('pi rpc message_end frame', {
+        role: typeof message?.role === 'string' ? message.role : '(missing)',
+        stopReason: typeof message?.stopReason === 'string' ? message.stopReason : null,
+        blockTypes,
+        textChars,
+        thinkingChars,
+      });
+      return;
+    }
+    if (type === 'agent_settled') {
+      this.logger.info('pi rpc turn frame histogram', {
+        frames: Object.fromEntries(this.eventFrameCounts),
+      });
+      this.eventFrameCounts.clear();
+    }
   }
 
   private failAllPending(err: Error): void {

--- a/packages/maker-core/src/agents/pi/rpc-client.ts
+++ b/packages/maker-core/src/agents/pi/rpc-client.ts
@@ -85,6 +85,18 @@ function redactCredentialText(text: string): string {
   return out;
 }
 
+/**
+ * 帧诊断日志的标签白名单:pi 协议的事件类型 / role / stopReason / 块类型都是短
+ * 标识符。扩展或畸形事件可能把任意正文塞进这些字段 —— 不符合标识符形态的一律
+ * 归一为 '(other)',落实「不落消息内容」的白名单方向(不是靠脱敏兜底)。
+ */
+const FRAME_LABEL_RE = /^[A-Za-z0-9_.:-]{1,64}$/;
+
+function sanitizeFrameLabel(value: unknown): string {
+  if (typeof value !== 'string' || value.length === 0) return '(untyped)';
+  return FRAME_LABEL_RE.test(value) ? value : '(other)';
+}
+
 export class PiRpcProcess {
   private readonly transport: PiTransport;
   private nextRequestId = 1;
@@ -314,7 +326,16 @@ export class PiRpcProcess {
 
   /** 只记帧元数据(类型 / 块类型 / 字符数),绝不落消息正文 —— 日志白名单方向。 */
   private recordEventFrameDiagnostics(event: PiRpcEvent): void {
-    const type = typeof event.type === 'string' && event.type.length > 0 ? event.type : '(untyped)';
+    const type = sanitizeFrameLabel(event.type);
+    // abort / 重试失败 / 进程异常的轮次收不到 agent_settled:计数留到下一轮会把
+    // 「message_end 是否到达」污染成不可归属。新轮 agent_start 先冲刷再清零 ——
+    // 既保住未收口轮的证据,又保证每份直方图只属于一轮。
+    if (type === 'agent_start' && this.eventFrameCounts.size > 0) {
+      this.logger.info('pi rpc turn frame histogram (no agent_settled)', {
+        frames: Object.fromEntries(this.eventFrameCounts),
+      });
+      this.eventFrameCounts.clear();
+    }
     this.eventFrameCounts.set(type, (this.eventFrameCounts.get(type) ?? 0) + 1);
     if (type === 'message_end') {
       const message = event.message as
@@ -330,16 +351,19 @@ export class PiRpcProcess {
           continue;
         }
         const rec = block as Record<string, unknown>;
-        const blockType = typeof rec.type === 'string' ? rec.type : '(untyped)';
+        const blockType = sanitizeFrameLabel(rec.type);
         blockTypes.push(blockType);
-        if (blockType === 'text' && typeof rec.text === 'string') textChars += rec.text.length;
-        if (blockType === 'thinking' && typeof rec.thinking === 'string') {
+        if (rec.type === 'text' && typeof rec.text === 'string') textChars += rec.text.length;
+        if (rec.type === 'thinking' && typeof rec.thinking === 'string') {
           thinkingChars += rec.thinking.length;
         }
       }
       this.logger.info('pi rpc message_end frame', {
-        role: typeof message?.role === 'string' ? message.role : '(missing)',
-        stopReason: typeof message?.stopReason === 'string' ? message.stopReason : null,
+        role: sanitizeFrameLabel(message?.role),
+        stopReason:
+          message?.stopReason === undefined || message?.stopReason === null
+            ? null
+            : sanitizeFrameLabel(message.stopReason),
         blockTypes,
         textChars,
         thinkingChars,


### PR DESCRIPTION
## 这次改了什么

### 摘要

面向 #3696 的定界诊断。该 issue 的现象是:Pi 成功轮(`stopReason: "stop"`)的正文在 pi 会话 jsonl 里完整存在,但 Cindy 的 DB 只有 thinking 行、UI 不显示正文。issue 内三轮取证(含 pi v0.84.4 源码复核)已把嫌疑收窄到两种:**pi 未把 message_end 帧发出到 stdout**,或 **Cindy 收到后在下游丢失**;并确认这不是稳定复现的系统性缺陷(同会话同进程几分钟后同形状消息正常),缺的是帧级证据。

本仓复核结论(与楼上取证互证):`attachJsonlReader` 分帧合规(LF 切分、跨 chunk 缓冲、StringDecoder 多字节边界、16MB OOM 守卫远超单帧);`PiRpcProcess.handleStdoutLine` 对所有事件帧无条件透传,无世代/abort 过滤;translator 的 message_end 门禁(`isPiTransientAssistantFailure`)按消息自身 stopReason 逐条判定、不粘滞——**帧到达 Cindy 就不会被静默丢**。因此落地 issue 里提议的定案手段:在 RPC 事件分发处记录帧级元数据,下一次复现即可一锤定音。

改动:`PiRpcProcess` 按事件类型计数;`message_end` 记一行日志(role/stopReason/块类型列表/text 与 thinking 字符数);`agent_settled` 记本轮帧类型直方图并清零。均为元数据,**不落任何消息内容**(测试断言日志载荷不含正文),遵守日志白名单方向。每轮至多 2 行日志,无噪音风险。

复现后的判读:有 `message_end frame` 日志且 `textChars>0` 而 DB 无正文行 → Cindy 下游丢失;日志缺失或直方图无 message_end → pi 侧未发出(转上游)。

### 变更类型

- [ ] `feat` 新功能
- [x] `fix` 缺陷修复
- [ ] `refactor` / `perf` 重构或性能优化
- [ ] `docs` / `test` / `chore` 文档、测试或工程维护
- [ ] 其他:

### 范围

- 关联 Issue / 需求:#3696(定界诊断部分)
- 本 PR 包含:PiRpcProcess 帧级元数据日志 + 2 条回归
- 明确不包含:丢帧根因修复(未定位到可复现的 Cindy 侧缺陷;若定界结果指向 pi bun 二进制 stdout 侧,属上游)
- 用户可见变化:无(仅新增诊断日志)
- 是否存在 breaking change:无

### UI 变化

无 UI 变化。

## 怎么验证的

### 自动验证

```
pnpm --dir packages/maker-core exec vitest run src/agents/pi/rpc-client.test.ts
```
结果:4 过(新增 2 条:message_end 元数据日志且载荷不含正文字符;agent_settled 直方图记录并跨轮清零)。反证:stash rpc-client.ts 后两条新用例如预期失败,既有 2 条照过。

maker-core typecheck 过。

```
pnpm test:unit:related
```
结果:exit 1,唯一失败为 desktop 段 vitest threads 池 SIGSEGV(本机已知环境基线,与本 diff 无关;maker-core 全量段通过)。

### 手工验证

无(诊断日志的判读依赖提报人环境复现;日志形状由单测锁定)。

### 未执行的验证

- 未复现原始丢帧场景(issue 结论:一次性事件,离线不可复现——本 PR 正是为下一次复现提供定界证据)。

## 风险

### 风险分类

低风险。纯增量诊断:事件透传路径行为零变化,新增逻辑只读帧元数据;日志每轮至多 2 行。

### 影响与回滚

影响面:maker-core 的 pi RPC 客户端(本地与远端 transport 共用)。远程与移动端适配:诊断在运行 pi transport 的宿主进程内生效,远端会话同样受益,无需额外适配。回滚:revert 单 commit,无 schema 变更。

### 提交前检查

- [x] 已运行定向单测(含反证)、typecheck 与 `pnpm test:unit:related`(失败项已逐一归因)
- [x] commit 带 DCO 签名(Signed-off-by: ficowang <fico@xd.com>)
- [x] diff 聚焦单一问题,无无关改动
