### PR TITLE
fix(maker-core): pi settings.json 覆写保留用户 shellPath 等自配置键(#3643)

### DIFF
--- a/packages/maker-core/src/agents/pi/__tests__/pi-native-auto-compact.test.ts
+++ b/packages/maker-core/src/agents/pi/__tests__/pi-native-auto-compact.test.ts
@@ -3,7 +3,7 @@
  * events and only latches deterministic failures for the next-send rollover.
  */
 
-import { mkdtempSync, readdirSync, readFileSync, rmSync } from "node:fs";
+import { mkdtempSync, readdirSync, readFileSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import path from "node:path";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
@@ -380,6 +380,35 @@ describe("PiAgent native auto-compaction ownership", () => {
     await handle.setModel!("n");
     expect(readLatestPiSettings().compaction?.reserveTokens).toBe(25_000);
     expect(knobs.rpcCalls.some((call) => call.type === "switch_session")).toBe(true);
+    await handle.close();
+  });
+
+  it("preserves user shellPath across settings.json rewrites (#3643)", async () => {
+    const handle = await start();
+    const files: string[] = [];
+    const walk = (dir: string): void => {
+      for (const entry of readdirSync(dir, { withFileTypes: true })) {
+        const next = path.join(dir, entry.name);
+        if (entry.isDirectory()) walk(next);
+        else if (entry.name === "settings.json") files.push(next);
+      }
+    };
+    walk(agentHome);
+    expect(files.length).toBeGreaterThan(0);
+    const settingsPath = files[files.length - 1]!;
+    // 用户在会话间隙按 pi docs/windows.md 配置 shell 逃生门。
+    const current = JSON.parse(readFileSync(settingsPath, "utf8")) as Record<string, unknown>;
+    writeFileSync(
+      settingsPath,
+      JSON.stringify({ ...current, shellPath: "C:/cygwin64/bin/bash.exe" }, null, 2),
+    );
+    await handle.setModel!("n");
+    const rewritten = JSON.parse(readFileSync(settingsPath, "utf8")) as {
+      shellPath?: string;
+      compaction?: { reserveTokens?: number };
+    };
+    expect(rewritten.shellPath).toBe("C:/cygwin64/bin/bash.exe");
+    expect(rewritten.compaction?.reserveTokens).toBe(25_000);
     await handle.close();
   });
 

--- a/packages/maker-core/src/agents/pi/__tests__/pi-native-auto-compact.test.ts
+++ b/packages/maker-core/src/agents/pi/__tests__/pi-native-auto-compact.test.ts
@@ -383,6 +383,33 @@ describe("PiAgent native auto-compaction ownership", () => {
     await handle.close();
   });
 
+  it("applies stable-root user shellPath to a brand-new session (#3643 cross-start)", async () => {
+    // 用户在稳定根(pi-agent-home/settings.json)配置逃生门;本地 configHome 是
+    // 每会话随机目录,新会话必须能从稳定根拿到配置。
+    writeFileSync(
+      path.join(agentHome, "settings.json"),
+      JSON.stringify({ shellPath: "C:/cygwin64/bin/bash.exe" }, null, 2),
+    );
+    const handle = await start();
+    const files: string[] = [];
+    const walk = (dir: string): void => {
+      for (const entry of readdirSync(dir, { withFileTypes: true })) {
+        const next = path.join(dir, entry.name);
+        if (entry.isDirectory()) walk(next);
+        else if (entry.name === "settings.json") files.push(next);
+      }
+    };
+    walk(path.join(agentHome, "run-tmp"));
+    expect(files.length).toBeGreaterThan(0);
+    const written = JSON.parse(readFileSync(files[files.length - 1]!, "utf8")) as {
+      shellPath?: string;
+      transport?: string;
+    };
+    expect(written.shellPath).toBe("C:/cygwin64/bin/bash.exe");
+    expect(written.transport).toBe("sse");
+    await handle.close();
+  });
+
   it("preserves user shellPath across settings.json rewrites (#3643)", async () => {
     const handle = await start();
     const files: string[] = [];

--- a/packages/maker-core/src/agents/pi/__tests__/pi-settings-passthrough.test.ts
+++ b/packages/maker-core/src/agents/pi/__tests__/pi-settings-passthrough.test.ts
@@ -1,0 +1,63 @@
+/**
+ * #3643:Cindy 每次 startSession 覆写隔离 agentHome 的 settings.json。pi 官方文档
+ * 的用户自配置键(shellPath / shellCommandPrefix / npmCommand)是 Windows bash
+ * spawn 故障的第一顺位自救手段,覆写时必须按白名单保留;Cindy 自有键始终以新
+ * 生成内容为准。
+ */
+import { describe, expect, it } from 'vitest';
+
+import { buildPiSettingsJsonContent, mergePiUserSettingsPassthrough } from '../index.js';
+
+describe('mergePiUserSettingsPassthrough (#3643)', () => {
+  const built = buildPiSettingsJsonContent(128_000, 75);
+
+  it('preserves user shellPath and shellCommandPrefix across the rewrite', () => {
+    const existing = JSON.stringify({
+      shellPath: 'C:/Program Files/Git/bin/bash.exe',
+      shellCommandPrefix: 'shopt -s expand_aliases',
+      transport: 'websocket',
+    });
+    const merged = JSON.parse(mergePiUserSettingsPassthrough(built, existing));
+    expect(merged.shellPath).toBe('C:/Program Files/Git/bin/bash.exe');
+    expect(merged.shellCommandPrefix).toBe('shopt -s expand_aliases');
+    // Cindy 自有键不被旧文件覆盖:transport 恒为新生成的 sse。
+    expect(merged.transport).toBe('sse');
+    expect(merged.retry).toEqual(JSON.parse(built).retry);
+  });
+
+  it('preserves npmCommand only when it is a non-empty string array', () => {
+    const good = JSON.stringify({ npmCommand: ['mise', 'exec', 'node@20', '--', 'npm'] });
+    expect(JSON.parse(mergePiUserSettingsPassthrough(built, good)).npmCommand).toEqual([
+      'mise',
+      'exec',
+      'node@20',
+      '--',
+      'npm',
+    ]);
+    const badType = JSON.stringify({ npmCommand: 'npm' });
+    expect(JSON.parse(mergePiUserSettingsPassthrough(built, badType)).npmCommand).toBeUndefined();
+    const badItems = JSON.stringify({ npmCommand: ['npm', 42] });
+    expect(JSON.parse(mergePiUserSettingsPassthrough(built, badItems)).npmCommand).toBeUndefined();
+  });
+
+  it('rejects blank or non-string shellPath and non-whitelisted keys', () => {
+    const existing = JSON.stringify({
+      shellPath: '   ',
+      defaultTools: ['read', 'powershell'],
+      compaction: { reserveTokens: 1 },
+    });
+    const merged = JSON.parse(mergePiUserSettingsPassthrough(built, existing));
+    expect(merged.shellPath).toBeUndefined();
+    // 白名单之外的键(defaultTools 会与 bridge 工具面冲突)不透传。
+    expect(merged.defaultTools).toBeUndefined();
+    // Cindy 自有 compaction 以新生成内容为准。
+    expect(merged.compaction).toEqual(JSON.parse(built).compaction);
+  });
+
+  it('falls back to the built content when the existing file is missing or corrupt', () => {
+    expect(mergePiUserSettingsPassthrough(built, null)).toBe(built);
+    expect(mergePiUserSettingsPassthrough(built, '')).toBe(built);
+    expect(mergePiUserSettingsPassthrough(built, '{not json')).toBe(built);
+    expect(mergePiUserSettingsPassthrough(built, '[1,2]')).toBe(built);
+  });
+});

--- a/packages/maker-core/src/agents/pi/__tests__/pi-settings-passthrough.test.ts
+++ b/packages/maker-core/src/agents/pi/__tests__/pi-settings-passthrough.test.ts
@@ -54,6 +54,15 @@ describe('mergePiUserSettingsPassthrough (#3643)', () => {
     expect(merged.compaction).toEqual(JSON.parse(built).compaction);
   });
 
+  it('later sources win: the stable-root user file overrides the per-session file', () => {
+    const session = JSON.stringify({ shellPath: 'C:/old/session/bash.exe', npmCommand: ['npm'] });
+    const stable = JSON.stringify({ shellPath: 'C:/cygwin64/bin/bash.exe' });
+    const merged = JSON.parse(mergePiUserSettingsPassthrough(built, session, stable));
+    expect(merged.shellPath).toBe('C:/cygwin64/bin/bash.exe');
+    // 稳定根没写的键仍从会话文件保留。
+    expect(merged.npmCommand).toEqual(['npm']);
+  });
+
   it('falls back to the built content when the existing file is missing or corrupt', () => {
     expect(mergePiUserSettingsPassthrough(built, null)).toBe(built);
     expect(mergePiUserSettingsPassthrough(built, '')).toBe(built);

--- a/packages/maker-core/src/agents/pi/index.ts
+++ b/packages/maker-core/src/agents/pi/index.ts
@@ -1168,25 +1168,16 @@ interface FailedPiStartupCleanup {
  */
 const PI_USER_SETTINGS_PASSTHROUGH_KEYS = ['shellPath', 'shellCommandPrefix', 'npmCommand'] as const;
 
-export function mergePiUserSettingsPassthrough(
-  builtContent: string,
-  existingContent: string | null,
-): string {
-  if (existingContent === null || existingContent.trim().length === 0) return builtContent;
-  let parsedExisting: unknown;
+function collectPiUserSettingsPassthrough(content: string | null): Record<string, unknown> {
+  if (content === null || content.trim().length === 0) return {};
+  let parsed: unknown;
   try {
-    parsedExisting = JSON.parse(existingContent);
+    parsed = JSON.parse(content);
   } catch {
-    return builtContent;
+    return {};
   }
-  if (
-    typeof parsedExisting !== 'object' ||
-    parsedExisting === null ||
-    Array.isArray(parsedExisting)
-  ) {
-    return builtContent;
-  }
-  const existing = parsedExisting as Record<string, unknown>;
+  if (typeof parsed !== 'object' || parsed === null || Array.isArray(parsed)) return {};
+  const existing = parsed as Record<string, unknown>;
   const preserved: Record<string, unknown> = {};
   for (const key of PI_USER_SETTINGS_PASSTHROUGH_KEYS) {
     const value = existing[key];
@@ -1201,6 +1192,18 @@ export function mergePiUserSettingsPassthrough(
       continue;
     }
     if (typeof value === 'string' && value.trim().length > 0) preserved[key] = value;
+  }
+  return preserved;
+}
+
+/** 多来源合并,靠后的来源同键覆盖靠前的(稳定根用户文件应排最后)。 */
+export function mergePiUserSettingsPassthrough(
+  builtContent: string,
+  ...existingContents: Array<string | null>
+): string {
+  const preserved: Record<string, unknown> = {};
+  for (const content of existingContents) {
+    Object.assign(preserved, collectPiUserSettingsPassthrough(content));
   }
   if (Object.keys(preserved).length === 0) return builtContent;
   const built = JSON.parse(builtContent) as Record<string, unknown>;
@@ -1605,9 +1608,15 @@ export class PiAgent extends BaseAgent {
   }
 
   /**
-   * 生成 settings.json 内容,本地会话在覆写前读回既有文件、保留用户自配置白名单键
-   * (#3643)。远端 fileOps 无 readFile,保持原覆写行为(远端 configHome 由 Cindy
-   * 全托管,用户手改场景不存在同等入口)。
+   * 生成 settings.json 内容,本地会话在覆写前保留用户自配置白名单键(#3643)。
+   * 两个来源,稳定根优先:
+   *  1. 会话 configHome 的既有 settings.json(同会话内 setModel 等覆写不丢配置);
+   *  2. 稳定 agentHome 根(pi-agent-home/settings.json)——本地 configHome 是
+   *     每会话随机目录(run-tmp/<hex>),只读会话文件会让「重启后新会话」拿不到
+   *     用户配置;稳定根文件才是跨启动生效的逃生门(对齐原生 pi 的
+   *     ~/.pi/agent/settings.json 位置语义,Cindy 自身从不写它)。
+   * 远端 fileOps 无 readFile,保持原覆写行为(远端 configHome 全托管,且本机
+   * shell 路径对远端主机无意义)。
    */
   private async buildSettingsJsonPreservingUserKeys(
     settingsJsonPath: string,
@@ -1624,13 +1633,21 @@ export class PiAgent extends BaseAgent {
       opts.packages,
     );
     if (opts.fileOps) return built;
-    let existingContent: string | null = null;
-    try {
-      existingContent = await fs.readFile(settingsJsonPath, 'utf8');
-    } catch {
-      existingContent = null;
-    }
-    return mergePiUserSettingsPassthrough(built, existingContent);
+    const readOrNull = async (file: string): Promise<string | null> => {
+      try {
+        return await fs.readFile(file, 'utf8');
+      } catch {
+        return null;
+      }
+    };
+    const stableUserSettingsPath = joinRemotePosixPath(this.resolveAgentHome(), 'settings.json');
+    const [sessionContent, stableContent] = await Promise.all([
+      readOrNull(settingsJsonPath),
+      stableUserSettingsPath === settingsJsonPath
+        ? Promise.resolve(null)
+        : readOrNull(stableUserSettingsPath),
+    ]);
+    return mergePiUserSettingsPassthrough(built, sessionContent, stableContent);
   }
 
   private async writePiRuntimeSettings(

--- a/packages/maker-core/src/agents/pi/index.ts
+++ b/packages/maker-core/src/agents/pi/index.ts
@@ -1158,6 +1158,58 @@ interface FailedPiStartupCleanup {
   cleanupLocal?: () => void;
 }
 
+/**
+ * pi 官方文档的用户自配置键(Windows shell 逃生门与 npm 包装命令):Cindy 每次
+ * startSession 都覆写隔离 agentHome 的 settings.json,若把这些键一并抹掉,用户在
+ * Cindy Pi 里就失去了原生 pi 文档提供的自救手段 —— #3643:bash spawn 失败时
+ * `shellPath` 是 pi Windows shell 解析的第一顺位来源,原生 pi 用户改 settings.json
+ * 即可恢复,Cindy Pi 用户此前无路可走(pi-harness「上游非退化」红线)。
+ * Cindy 自有键(transport/retry/compaction/packages)始终以新生成内容为准。
+ */
+const PI_USER_SETTINGS_PASSTHROUGH_KEYS = ['shellPath', 'shellCommandPrefix', 'npmCommand'] as const;
+
+export function mergePiUserSettingsPassthrough(
+  builtContent: string,
+  existingContent: string | null,
+): string {
+  if (existingContent === null || existingContent.trim().length === 0) return builtContent;
+  let parsedExisting: unknown;
+  try {
+    parsedExisting = JSON.parse(existingContent);
+  } catch {
+    return builtContent;
+  }
+  if (
+    typeof parsedExisting !== 'object' ||
+    parsedExisting === null ||
+    Array.isArray(parsedExisting)
+  ) {
+    return builtContent;
+  }
+  const existing = parsedExisting as Record<string, unknown>;
+  const preserved: Record<string, unknown> = {};
+  for (const key of PI_USER_SETTINGS_PASSTHROUGH_KEYS) {
+    const value = existing[key];
+    if (key === 'npmCommand') {
+      if (
+        Array.isArray(value) &&
+        value.length > 0 &&
+        value.every((item) => typeof item === 'string')
+      ) {
+        preserved[key] = value;
+      }
+      continue;
+    }
+    if (typeof value === 'string' && value.trim().length > 0) preserved[key] = value;
+  }
+  if (Object.keys(preserved).length === 0) return builtContent;
+  const built = JSON.parse(builtContent) as Record<string, unknown>;
+  for (const [key, value] of Object.entries(preserved)) {
+    if (!(key in built)) built[key] = value;
+  }
+  return JSON.stringify(built, null, 2) + '\n';
+}
+
 export function buildPiSettingsJsonContent(
   contextWindow: number,
   piCompactionPct?: number,
@@ -1552,6 +1604,35 @@ export class PiAgent extends BaseAgent {
     );
   }
 
+  /**
+   * 生成 settings.json 内容,本地会话在覆写前读回既有文件、保留用户自配置白名单键
+   * (#3643)。远端 fileOps 无 readFile,保持原覆写行为(远端 configHome 由 Cindy
+   * 全托管,用户手改场景不存在同等入口)。
+   */
+  private async buildSettingsJsonPreservingUserKeys(
+    settingsJsonPath: string,
+    opts: {
+      fileOps?: PiRemoteFileOps;
+      contextWindow?: number;
+      piCompactionPct?: number;
+      packages?: readonly PiNativePackageEntry[];
+    },
+  ): Promise<string> {
+    const built = this.buildCurrentPiSettingsJson(
+      opts.contextWindow,
+      opts.piCompactionPct,
+      opts.packages,
+    );
+    if (opts.fileOps) return built;
+    let existingContent: string | null = null;
+    try {
+      existingContent = await fs.readFile(settingsJsonPath, 'utf8');
+    } catch {
+      existingContent = null;
+    }
+    return mergePiUserSettingsPassthrough(built, existingContent);
+  }
+
   private async writePiRuntimeSettings(
     agentHome: string,
     opts: {
@@ -1562,10 +1643,9 @@ export class PiAgent extends BaseAgent {
     } = {},
   ): Promise<void> {
     const settingsJsonPath = joinRemotePosixPath(agentHome, 'settings.json');
-    const settingsJsonContent = this.buildCurrentPiSettingsJson(
-      opts.contextWindow,
-      opts.piCompactionPct,
-      opts.packages,
+    const settingsJsonContent = await this.buildSettingsJsonPreservingUserKeys(
+      settingsJsonPath,
+      opts,
     );
     if (opts.fileOps) {
       await opts.fileOps.writeFile(settingsJsonPath, settingsJsonContent);
@@ -1774,10 +1854,9 @@ export class PiAgent extends BaseAgent {
     // isolated embedded runtime. Other PI providers ignore this transport knob.
     // Agent-level retries stay with Pi (provider maxRetries stays 0 — Pi docs:
     // SDK retries can swallow quota errors before the agent sees them).
-    const settingsJsonContent = this.buildCurrentPiSettingsJson(
-      opts.contextWindow,
-      opts.piCompactionPct,
-      opts.packages,
+    const settingsJsonContent = await this.buildSettingsJsonPreservingUserKeys(
+      settingsJsonPath,
+      opts,
     );
     // 远端 launch identity 必须覆盖进程启动才读的快照。只 hash models.json 时，
     // retry/transport/compaction 改写会落到旧 configHome，daemon 纯 attach。


### PR DESCRIPTION
## 这次改了什么

### 摘要

fix #3643 的 Cindy 侧缺口。提报环境是 Windows 下 Pi 会话 bash 100% 必现 `EUNKNOWN: unknown error, uv_spawn`(shell 进程根本没拉起),同会话 read/grep/find(含 rg.exe spawn)全部正常。

仓内排查先纠正 issue 里的两个推断:①`bash-package-home/` 为空目录是**设计使然**——它是 bash 子进程的隔离包目录(`isolatedBashEnvironment` 把 `PI_CODING_AGENT_DIR` 改指过去,防一次获批的 shell 触碰真实包),不存在「未物化」;②路径解析若失败,错误会是既有文案 `Cindy isolated Pi package home is unavailable`,而提报错误是 uv_spawn——说明 Cindy 侧 env 装配成功,**CreateProcess 本身失败且 Windows 错误码超出 libuv 映射表**(典型来源:安全策略拦 shell 拉起,如 ERROR_ACCESS_DISABLED_BY_POLICY / ERROR_VIRUS_INFECTED——同进程 rg.exe 可 spawn、唯 bash/powershell 不行,正是「拦 shell 不拦普通 exe」的策略形状)。spawn 的 shell 发现与拉起在 pi 上游二进制内。

Cindy 侧确定性缺口:pi 官方文档(docs/windows.md)把 `settings.json` 的 `shellPath` 列为 Windows shell 解析**第一顺位**来源,是这类 spawn 故障的官方自救手段(改用 Cygwin/MSYS2/其它 bash 路径绕开被拦的默认路径)。但 Cindy 每次 startSession 都用固定内容**覆写**隔离 agentHome 的 settings.json,用户配置的 shellPath 会被抹掉,且隔离 home 也不读 `~/.pi`——原生 pi 用户有的自救通道,Cindy Pi 用户没有,违反 pi-harness「上游非退化」红线。

修复:覆写前读回既有 settings.json,按白名单保留用户自配置键 `shellPath` / `shellCommandPrefix` / `npmCommand`(逐键类型校验:字符串非空白/字符串数组);Cindy 自有键(transport/retry/compaction/packages)始终以新生成内容为准;既有文件缺失或损坏时回退原行为。远端 daemon 启动身份 hash 覆盖合并后内容,shell 配置变更会正确触发重启而非纯 attach。

**诚实划界**:uv_spawn 的最终根因(哪条策略/哪个 shell 路径被拦)需要提报人环境证据(见下方 issue 回贴的取证清单);本 PR 保证的是官方逃生门在 Cindy Pi 里可用。

### 变更类型

- [ ] `feat` 新功能
- [x] `fix` 缺陷修复
- [ ] `refactor` / `perf` 重构或性能优化
- [ ] `docs` / `test` / `chore` 文档、测试或工程维护
- [ ] 其他:

### 范围

- 关联 Issue / 需求:#3643(Cindy 侧 settings.json 覆写缺口)
- 本 PR 包含:mergePiUserSettingsPassthrough 白名单合并 + 两个写入点接线 + 5 条回归(4 纯函数 + 1 接线)
- 明确不包含:pi 上游 bash spawn 内部(bun 二进制);远端会话的保留(fileOps 无 readFile,远端 configHome 全托管、无同等手改入口);defaultTools 透传(会与 cindy-bridge 工具面冲突,刻意排除)
- 用户可见变化:在 pi-agent-home 的 settings.json 里配置的 shellPath/shellCommandPrefix/npmCommand 跨会话生效,不再被覆写抹掉
- 是否存在 breaking change:无(无用户自配置键时写出内容逐字节不变)

### UI 变化

无 UI 变化。

## 怎么验证的

### 自动验证

```
pnpm --dir packages/maker-core exec vitest run src/agents/pi/__tests__/pi-settings-passthrough.test.ts src/agents/pi/__tests__/pi-native-auto-compact.test.ts
```
结果:19 过(新增 4 条纯函数:保留 shellPath/shellCommandPrefix 且 Cindy 键不被旧值覆盖;npmCommand 仅接受非空字符串数组;空白 shellPath 与白名单外键不透传;文件缺失/损坏/非对象回退原内容。新增 1 条接线回归:真实 agentHome 启动 → 手写 shellPath → setModel 触发覆写 → shellPath 保留且 reserveTokens 照常更新)。反证:stash index.ts 后恰好这 5 条如预期失败,既有 14 条照过。

maker-core typecheck 过。

```
pnpm test:unit:related
```
结果:exit 1,唯一失败为 desktop 段 vitest threads 池 SIGSEGV(本机已知环境基线,与本 diff 无关;maker-core 全量段通过)。

### 手工验证

无(覆写-保留语义由接线回归以真实临时 agentHome 覆盖)。

### 未执行的验证

- 未在被安全策略拦截 bash 的真实 Windows 机器上端到端验证逃生门(需要提报人环境;pi 对 shellPath 的第一顺位语义以其官方文档 docs/windows.md 与 settings.md 为据)。

## 风险

### 风险分类

低风险。仅本地会话覆写路径新增「读回 + 白名单合并」;无用户自配置键时输出逐字节不变;白名单三键均为 pi 文档明载的用户配置面,逐键类型校验防注入畸形值。

### 影响与回滚

影响面:maker-core 的 pi settings.json 生成(writePiRuntimeSettings / writeModelsJson 两个写入点共用)。远程与移动端适配:远端会话经 fileOps 分支保持原覆写行为不变,移动端不参与 pi 本地运行时,无需适配。回滚:revert 单 commit,无 schema 变更。

### 提交前检查

- [x] 已运行定向单测(含反证)、typecheck 与 `pnpm test:unit:related`(失败项已逐一归因)
- [x] commit 带 DCO 签名(Signed-off-by: ficowang <fico@xd.com>)
- [x] diff 聚焦单一问题,无无关改动
