### PR TITLE
feat(desktop): support manual /compact context compaction

### DIFF
--- a/apps/desktop/src/renderer/__tests__/manualCompactCommand.test.ts
+++ b/apps/desktop/src/renderer/__tests__/manualCompactCommand.test.ts
@@ -1,0 +1,49 @@
+import { readFileSync } from 'node:fs';
+import { describe, expect, it } from 'vitest';
+
+import { isExactManualCompactCommand } from '@/lib/slashCommands';
+
+const viewSource = readFileSync(
+  new URL('../features/cc-agent/CCAgentSessionView.tsx', import.meta.url),
+  'utf8',
+);
+
+describe('manual /compact command', () => {
+  it('matches only the exact control command', () => {
+    expect(isExactManualCompactCommand('/compact')).toBe(true);
+    expect(isExactManualCompactCommand(' /compact ')).toBe(true);
+    expect(isExactManualCompactCommand('/COMPACT')).toBe(true);
+    expect(isExactManualCompactCommand('')).toBe(false);
+    expect(isExactManualCompactCommand('/compact focus on API decisions')).toBe(false);
+    expect(isExactManualCompactCommand('explain /compact')).toBe(false);
+  });
+
+  it('dispatches the command through the manual compact channels before sending it as a prompt', () => {
+    expect(viewSource).toContain('await maybeCompactSession(message, payloadsAttached)');
+    expect(viewSource).toContain('makerApiForSticky(sessionId).compactSession(sessionId)');
+    expect(viewSource).toContain('await compactSession(');
+  });
+
+  it('never intercepts /compact that carries composer payloads', () => {
+    // composer 已在调用 handleSend 前清空载荷:附件 / mention / 粘贴文本 / 内联引用
+    // / agent 引用任一存在都必须走原发送路径,不能被拦截提前返回吞掉(#3744 review P1)。
+    expect(viewSource).toContain('if (payloadsAttached) return false;');
+    expect(viewSource).toContain('(opts?.agentReferences?.length ?? 0) > 0');
+    expect(viewSource).toContain('(opts?.pastedTextRanges?.length ?? 0) > 0');
+    expect(viewSource).toContain('opts?.quotesEncoded === true');
+  });
+
+  it('refuses the claude-input channel for SSH remote sessions instead of misrouting to the local maker', () => {
+    expect(viewSource).toContain(
+      "channel === 'claude-input' && sessionRef.current?.remoteHostId",
+    );
+  });
+
+  it('shares the intercept with the NewMaker pending first-message path', () => {
+    // 新建任务的首条消息由 pending 消费路径投递,不经 handleSend:必须与
+    // handleSend 共用同一 /compact 拦截,否则首条 /compact 会被当成普通
+    // prompt(Pi 下还会变成字面 /compact 用户消息,#3744 review P1)。
+    expect(viewSource).toContain('await maybeCompactSession(pendingText, pendingPayloadsAttached)');
+    expect(viewSource).toContain('pending.quotesEncoded === true');
+  });
+});

--- a/apps/desktop/src/renderer/__tests__/newMakerOrcaCreateOrder.test.ts
+++ b/apps/desktop/src/renderer/__tests__/newMakerOrcaCreateOrder.test.ts
@@ -407,8 +407,9 @@ describe('NewMakerDraftRoute Orca worker create order', () => {
       expect(sessionViewSource).not.toContain('forgetRecoverableHandoff(');
       expect(pendingHandoffSource).toContain('function forgetRecoverableHandoff(');
       expect(pendingHandoffSource).not.toContain('export function forgetRecoverableHandoff(');
-      // 三处交接(命令派发 / 首轮发送 / 起目标)都要走它。
-      expect(sessionViewSource.match(/deliverRecoverableHandoff\(sessionId,/g)).toHaveLength(3);
+      // 四处交接(命令派发 / 首条 /compact 拦截 / 首轮发送 / 起目标)都要走它:
+      // /compact 首条拦截同样消费交接副本(命令不发正文),必须经 deliver 判定。
+      expect(sessionViewSource.match(/deliverRecoverableHandoff\(sessionId,/g)).toHaveLength(4);
     });
 
     it('内存里没有 pending 时才走恢复,且只回填输入框、不自动补发', () => {

--- a/apps/desktop/src/renderer/features/cc-agent/CCAgentSessionView.tsx
+++ b/apps/desktop/src/renderer/features/cc-agent/CCAgentSessionView.tsx
@@ -171,6 +171,7 @@ import {
 import {
   loadAllCommands,
   dispatchCommand,
+  isExactManualCompactCommand,
   leadingSlashInvocation,
   PI_RUNTIME_SKILL_RETRY_DELAYS_MS,
   rebaseInlineRangesAfterSlashCommandRewrite,
@@ -1868,6 +1869,28 @@ export function CCAgentSessionView({
   // 仍调 compact-session → pi 拒绝 → confirm 后吃 rejection toast」(codex P2)。
   const isRunningRef = useRef(agentStatus.isRunning);
   isRunningRef.current = agentStatus.isRunning;
+  // 防双击重入:ConfirmDialogProvider 是队列语义,弹窗 mount 前的连续点击会入队
+  // 多个 confirm,逐个确认就会发多次 compact 请求。锁按 sessionId 隔离:A 的长请求不
+  // 阻塞切换后的 B，A 的迟到 finally 也不能清掉 B 的锁。/compact 命令与上下文环
+  // 共用同一把锁,避免两个入口并发压缩同一个任务。
+  const compactRequestGuardRef = useRef<SessionScopedRequestGuard | null>(null);
+  if (!compactRequestGuardRef.current) {
+    compactRequestGuardRef.current = createSessionScopedRequestGuard();
+  }
+  const compactRequestGuard = compactRequestGuardRef.current;
+  // commit 阶段切换当前会话:中断 render 不应提前作废旧视图请求；layout effect 又早于用户
+  // 交互与异步回调。setup 也要重写 sessionId，确保 React StrictMode 的 setup→cleanup→setup
+  // 重放后不会停在 null。
+  useLayoutEffect(() => {
+    const committedSessionId = sessionId ?? null;
+    compactRequestGuard.setCurrentSession(committedSessionId);
+    return () => {
+      // session 变更 / 路由离开 / 登出后旧请求的确认结果与迟到响应立即失效。
+      if (committedSessionId && compactRequestGuard.isCurrent(committedSessionId)) {
+        compactRequestGuard.setCurrentSession(null);
+      }
+    };
+  }, [compactRequestGuard, sessionId]);
   // live 供应商目录(含内置 + 自定义,按 agent 挂模型)—— vendor↔model 一致性校验的真源,
   // 与模型选择器同源(见下方 M35 vendor fallback effect)。本地 IPC 极快返回,有模块级缓存。
   // device-link 远程会话用被控端经隧道带来的 providers(per-provider,fast 判定与本地同口径)。
@@ -3301,6 +3324,95 @@ export function CCAgentSessionView({
     [fastMode, insertSystemCard, remoteDeviceId, session, sessionId, t, updateSystemCardData],
   );
 
+  const maybeCompactSession = useCallback(
+    async (message: string, payloadsAttached: boolean): Promise<boolean> => {
+      if (!isExactManualCompactCommand(message)) return false;
+      // composer 在调用 handleSend 前已清空附件 / mention / 内联引用 / 粘贴文本等
+      // 载荷;拦截后提前返回会让这些载荷既不发送也无法找回。带载荷的 /compact 不
+      // 拦截,走原发送路径按普通消息消费(#3744 review P1)。
+      if (payloadsAttached) return false;
+      const channel = compactChannelRef.current;
+      if (!sessionId || channel === null) {
+        toast.warning(
+          realAgentKind === 'codex'
+            ? t('ccAgent.layout.contextRing.codexAutoHint')
+            : t('ccAgent.sidebar.sessionMenu.manualCompactUnavailable'),
+        );
+        return true;
+      }
+      if (channel === 'compact-session' && isRunningRef.current) {
+        toast.warning(t('ccAgent.sidebar.sessionMenu.compactRunningBlocked'));
+        return true;
+      }
+      if (channel === 'compact-session' && sessionRef.current?.remoteHostId) {
+        toast.warning(t('ccAgent.sidebar.sessionMenu.manualCompactUnavailable'));
+        return true;
+      }
+      // SSH 远程 Claude 会话没有 device-link 隧道路由:inputCoordinator 通道会落回
+      // 控制端本机 maker,压缩请求既到不了远端运行时,还可能作用于错误会话——与
+      // compact-session 分支同口径,显式提示不可用而不是静默错投(#3744 review P1)。
+      if (channel === 'claude-input' && sessionRef.current?.remoteHostId) {
+        toast.warning(t('ccAgent.sidebar.sessionMenu.manualCompactUnavailable'));
+        return true;
+      }
+      const begun = compactRequestGuard.tryBegin(sessionId);
+      if (!begun) return true;
+      try {
+        toast.info(t('ccAgent.sidebar.sessionMenu.compacting'));
+        if (channel === 'compact-session') {
+          const result = await makerApiForSticky(sessionId).compactSession(sessionId);
+          if (!compactRequestGuard.isCurrent(sessionId, begun.epoch)) return true;
+          if (result?.noop) {
+            toast.info(t('ccAgent.sidebar.sessionMenu.compactNothing'));
+          } else if (result) {
+            const before = result.tokensBefore;
+            const after = result.estimatedTokensAfter;
+            toast.success(
+              before !== undefined && after !== undefined && before > 0
+                ? t('ccAgent.sidebar.sessionMenu.compactSuccessWithTokens', {
+                    before: Math.round(before / 1000),
+                    after: Math.round(after / 1000),
+                  })
+                : t('ccAgent.sidebar.sessionMenu.compactSuccess'),
+            );
+          } else {
+            toast.warning(t('ccAgent.sidebar.sessionMenu.manualCompactUnavailable'));
+          }
+          return true;
+        }
+        const sessionNow = sessionRef.current;
+        if (sessionNow?.workingDir) {
+          const accepted = await compactSession(
+            sessionNow.model,
+            sessionNow.effort as Effort,
+            sessionNow.permissionMode as PermissionMode,
+            sessionNow.workingDir,
+          );
+          if (!compactRequestGuard.isCurrent(sessionId, begun.epoch)) return true;
+          // Claude's input coordinator returns when the compact turn is accepted;
+          // the compact_boundary event is the authoritative completion projection.
+          if (!accepted) toast.warning(t('ccAgent.sidebar.sessionMenu.compactFailed'));
+        } else {
+          toast.warning(t('ccAgent.sidebar.sessionMenu.manualCompactUnavailable'));
+        }
+      } catch (err) {
+        if (!compactRequestGuard.isCurrent(sessionId, begun.epoch)) return true;
+        log.warn('manual /compact failed', err);
+        toast.warning(t('ccAgent.sidebar.sessionMenu.compactFailed'));
+      } finally {
+        begun.release();
+      }
+      return true;
+    },
+    [
+      compactRequestGuard,
+      compactSession,
+      realAgentKind,
+      sessionId,
+      t,
+    ],
+  );
+
   const handleSend = useCallback(
     async (
       message: string,
@@ -3346,6 +3458,20 @@ export function CCAgentSessionView({
         return;
       }
 
+      // /compact 拦截只认"无载荷的精确命令":附件 / mention / 内联引用 / 粘贴文本
+      // / agent 引用任一存在时不拦截,载荷随原发送路径消费(#3744 review P1)。
+      // 拦截放在 Bot /new 重写之前:重写产物(`/compact [instructions]`)按 main 的
+      // Bot 语义继续走原发送路径,不再二次进入本拦截。
+      const payloadsAttached =
+        (files?.length ?? 0) > 0 ||
+        (mentions?.length ?? 0) > 0 ||
+        (opts?.agentReferences?.length ?? 0) > 0 ||
+        (opts?.pastedTextRanges?.length ?? 0) > 0 ||
+        opts?.quotesEncoded === true;
+
+      if (deliveryMode !== 'steer' && (await maybeCompactSession(message, payloadsAttached))) {
+        return;
+      }
       // Hermes-compatible Bot lifecycle: `/new` inside the fixed canonical
       // task means "compact and keep this Bot task", never "silently create a
       // replacement Session". Claude accepts /compact as an agent command;
@@ -3584,6 +3710,7 @@ export function CCAgentSessionView({
     },
     [
       maybeDispatchDesktopSlashCommand,
+      maybeCompactSession,
       maybeShowContextUsage,
       folderPickerOpen,
       isCodex,
@@ -3645,27 +3772,6 @@ export function CCAgentSessionView({
   }, [handleSend, readOnly, session, sessionId, t]);
 
   const { confirm: confirmDialog } = useConfirmDialog();
-  // 防双击重入:ConfirmDialogProvider 是队列语义,弹窗 mount 前的连续点击会入队
-  // 多个 confirm,逐个确认就会发多次 compact 请求。锁按 sessionId 隔离:A 的长请求不
-  // 阻塞切换后的 B，A 的迟到 finally 也不能清掉 B 的锁。
-  const compactRequestGuardRef = useRef<SessionScopedRequestGuard | null>(null);
-  if (!compactRequestGuardRef.current) {
-    compactRequestGuardRef.current = createSessionScopedRequestGuard();
-  }
-  const compactRequestGuard = compactRequestGuardRef.current;
-  // commit 阶段切换当前会话:中断 render 不应提前作废旧视图请求；layout effect 又早于用户
-  // 交互与异步回调。setup 也要重写 sessionId，确保 React StrictMode 的 setup→cleanup→setup
-  // 重放后不会停在 null。
-  useLayoutEffect(() => {
-    const committedSessionId = sessionId ?? null;
-    compactRequestGuard.setCurrentSession(committedSessionId);
-    return () => {
-      // session 变更 / 路由离开 / 登出后旧请求的确认结果与迟到响应立即失效。
-      if (committedSessionId && compactRequestGuard.isCurrent(committedSessionId)) {
-        compactRequestGuard.setCurrentSession(null);
-      }
-    };
-  }, [compactRequestGuard, sessionId]);
   const handleCompactRequest = useCallback(async () => {
     const sourceSession = session;
     if (!sourceSession) return;
@@ -4096,6 +4202,27 @@ export function CCAgentSessionView({
           }
           return;
         }
+        // NewMaker 首条消费与 handleSend 共用同一 /compact 拦截:精确命令不落成
+        // 字面用户消息(否则 Pi 会经 escapeLeadingSlashCommand 把 /compact 写进首条
+        // 消息,#3744 review P1)。带载荷的首条不拦截,载荷随原发送路径消费。
+        const pendingPayloadsAttached =
+          (pending.files?.length ?? 0) > 0 ||
+          (pending.mentions?.length ?? 0) > 0 ||
+          (pending.pastedTextRanges?.length ?? 0) > 0 ||
+          pending.quotesEncoded === true ||
+          (pending.agentReferences?.length ?? 0) > 0;
+        if (await maybeCompactSession(pendingText, pendingPayloadsAttached)) {
+          await deliverRecoverableHandoff(sessionId, () => true);
+          if (deferredUiAssignment) {
+            void dispatchDeferredUiAssignment(sessionId, deferredUiAssignment, {
+              waitForLeadHistory: false,
+            }).catch((err) => {
+              log.error('deferred Worker assignment after slash command failed', err);
+              toast.error(t('newChat.collaboration.assignmentFailed'));
+            });
+          }
+          return;
+        }
         const pendingAgentReferences = pending.agentReferences
           ? rebaseInlineRangesAfterSlashCommandRewrite(
               pending.agentReferences,
@@ -4166,6 +4293,7 @@ export function CCAgentSessionView({
     })();
   }, [
     historyLoaded,
+    maybeCompactSession,
     maybeDispatchDesktopSlashCommand,
     restoreRecoverableHandoff,
     requestFollowLatest,

--- a/apps/desktop/src/renderer/i18n/locales/en/common.json
+++ b/apps/desktop/src/renderer/i18n/locales/en/common.json
@@ -9459,6 +9459,8 @@
         "compactSuccessWithTokens": "Context compacted: {{before}}k → {{after}}k tokens",
         "compactFailed": "Compaction failed",
         "compactNothing": "Nothing to compact yet",
+        "manualCompactUnavailable": "Manual compaction is unavailable for this task.",
+        "compactRunningBlocked": "Wait for the current message to finish before compacting.",
         "sessionBranches": "Session branches",
         "copySessionLink": "Copy session link"
       },

--- a/apps/desktop/src/renderer/i18n/locales/ja/common.json
+++ b/apps/desktop/src/renderer/i18n/locales/ja/common.json
@@ -9444,6 +9444,8 @@
         "compactSuccessWithTokens": "コンテキストを圧縮しました:{{before}}k → {{after}}k tokens",
         "compactFailed": "圧縮に失敗しました",
         "compactNothing": "圧縮できる内容がまだありません",
+        "manualCompactUnavailable": "このタスクでは手動圧縮を利用できません。",
+        "compactRunningBlocked": "現在のメッセージの処理が完了してから圧縮してください。",
         "sessionBranches": "セッション分岐",
         "copySessionLink": "セッションリンクをコピー"
       },

--- a/apps/desktop/src/renderer/i18n/locales/ko/common.json
+++ b/apps/desktop/src/renderer/i18n/locales/ko/common.json
@@ -9444,6 +9444,8 @@
         "compactSuccessWithTokens": "컨텍스트를 압축했습니다: {{before}}k → {{after}}k tokens",
         "compactFailed": "압축 실패",
         "compactNothing": "아직 압축할 내용이 없습니다",
+        "manualCompactUnavailable": "이 작업에서는 수동 압축을 사용할 수 없습니다.",
+        "compactRunningBlocked": "현재 메시지 처리가 끝난 후 압축해 주세요.",
         "sessionBranches": "세션 분기",
         "copySessionLink": "세션 링크 복사"
       },

--- a/apps/desktop/src/renderer/i18n/locales/zh-CN/common.json
+++ b/apps/desktop/src/renderer/i18n/locales/zh-CN/common.json
@@ -9444,6 +9444,8 @@
         "compactSuccessWithTokens": "上下文已压缩：{{before}}k → {{after}}k tokens",
         "compactFailed": "压缩失败",
         "compactNothing": "暂无可压缩内容",
+        "manualCompactUnavailable": "此任务暂不支持手动压缩。",
+        "compactRunningBlocked": "请等待当前消息处理完成后再压缩。",
         "sessionBranches": "任务分支",
         "copySessionLink": "复制任务链接"
       },

--- a/apps/desktop/src/renderer/i18n/locales/zh-TW/common.json
+++ b/apps/desktop/src/renderer/i18n/locales/zh-TW/common.json
@@ -9444,6 +9444,8 @@
         "compactSuccessWithTokens": "上下文已壓縮：{{before}}k → {{after}}k tokens",
         "compactFailed": "壓縮失敗",
         "compactNothing": "暫無可壓縮內容",
+        "manualCompactUnavailable": "此任務暫不支援手動壓縮。",
+        "compactRunningBlocked": "請等待目前訊息處理完成後再壓縮。",
         "sessionBranches": "任務分支",
         "copySessionLink": "複製任務連結"
       },

--- a/apps/desktop/src/renderer/lib/slashCommands.ts
+++ b/apps/desktop/src/renderer/lib/slashCommands.ts
@@ -31,6 +31,15 @@ export type { UnifiedCommand } from '@cindy/maker-core';
 
 export const PI_RUNTIME_SKILL_RETRY_DELAYS_MS = [100, 250, 500, 1_000, 2_000, 4_000] as const;
 
+/**
+ * Manual compact is a host-owned control command, not a prompt. Accept the exact
+ * command only; qualified text such as `/compact focus on APIs` keeps the
+ * agent-specific SDK/skill path.
+ */
+export function isExactManualCompactCommand(message: string): boolean {
+  return /^\/compact\s*$/i.test(message.trim());
+}
+
 export function isSlashCommandUnavailable(command: UnifiedCommand): boolean {
   return command.kind === 'agent-skill'
     && (

--- a/packages/maker-core/src/agents/pi/__tests__/pi-compact.test.ts
+++ b/packages/maker-core/src/agents/pi/__tests__/pi-compact.test.ts
@@ -105,6 +105,13 @@ describe('PiAgent.compactSession (mocked pi process)', () => {
     expect(new PiAgent(buildDeps()).capabilities.manualCompact?.supported).toBe(true);
   });
 
+  it('does not advertise a compact builtin command on shared palette surfaces', () => {
+    // 手动压缩的精确 /compact 拦截只在桌面发送路径存在;共享 listAgentCommands
+    // 会同时喂给移动端命令面板,未适配面暴露会把命令降级成普通 prompt
+    // (#3744 review P1)。桌面单测断言 Pi 不再发布该目录项。
+    expect(new PiAgent(buildDeps()).listAgentCommands()).toEqual([]);
+  });
+
   it('parses tokensBefore/estimatedTokensAfter and omits missing numbers', async () => {
     knobs.compactResponse = {
       success: true,

--- a/packages/maker-core/src/agents/pi/index.ts
+++ b/packages/maker-core/src/agents/pi/index.ts
@@ -148,7 +148,10 @@ import type {
 } from '../../types/events.js';
 import type { MemoryResetResult, MemorySetResult, MemoryStatus } from '../../types/memory.js';
 import type { AgentKind, Effort, UserMessage, UserContentBlock } from '../../types/common.js';
-import type { ListAgentSkillsOptions, ListAgentSkillsResult } from '../../types/palette.js';
+import type {
+  ListAgentSkillsOptions,
+  ListAgentSkillsResult,
+} from '../../types/palette.js';
 import type { ListCustomizationsOptions, ListCustomizationsResult } from '../../types/customizations.js';
 import { scanPiCustomizations } from './customization-scanner.js';
 import {


### PR DESCRIPTION
## 这次改了什么

### 摘要

在 SessionView 的两条发送路径(NewMaker 首条 pending 消费与 handleSend)精确拦截 /compact 控制指令,复用既有手动压缩通道:claude-code 走输入协调器 maker:input:compact,pi 走能力感知 compact-session 通道;codex、SSH 远程及不支持场景给出明确提示。不在共享命令面板暴露 pi compact 目录项(移动端发送面未适配)。补桌面回归测试与五语言文案。

### 变更类型

- [x] `feat` 新功能
- [ ] `fix` 缺陷修复
- [ ] `refactor` / `perf` 重构或性能优化
- [ ] `docs` / `test` / `chore` 文档、测试或工程维护
- [ ] 其他：

### 范围

- Related issue: Fixes #3711
- Included: 实现要点:1) isExactManualCompactCommand 仅匹配精确 /compact(带参数仍走原路径);2) maybeCompactSession 在 palette dispatch 前拦截,与既有 /context 处理同构,steer 模式不拦截;3) 复用 compactRequestGuard 防重入,纯代码前移;4) codex 会话提示服务端自动压缩,pi 回合运行中提示等待,SSH 远程 pi 提示不可用;5) NewMaker 首条 pending 消费路径与 handleSend 共用同一拦截并消费交接副本;6) 不向共享命令面板暴露 pi compact 目录项(listAgentCommands 返回空,移动端发送面未适配,#3744 review);7) claude 路径接受后不提前报成功,由既有 compact_boundary 投影呈现完成。
- Not included: Work outside the listed files.
- User-visible change: 在 SessionView 的两条发送路径(NewMaker 首条 pending 消费与 handleSend)精确拦截 /compact 控制指令,复用既有手动压缩通道:claude-code 走输入协调器 maker:input:compact,pi 走能力感知 compact-session 通道;codex、SSH 远程及不支持场景给出明确提示。不在共享命令面板暴露 pi compact 目录项(移动端发送面未适配)。补桌面回归测试与五语言文案。
- Breaking change: No.

### Remote and mobile adaptation

- SSH remote workspaces: Not affected.
- Device link: No channel or protocol change.
- Mobile: Not affected.

### UI 变化

无新增视觉样式：未新增任何组件、颜色、字号或圆角。用户可见变化仅为交互/文案层——`/compact` 命令入口复用既有 composer 命令解析与命令面板交互,全部反馈提示复用既有 toast 组件,文案走既有 i18n 通道。

- 引用的设计规范：`DESIGN.md` §4 (Component Stylings) 与 §7 (Do's and Don'ts)——本 PR 复用既有 toast / 命令面板组件,不引入新组件或新视觉样式,不新增色彩、圆角、阴影与字重;§7 的 Don'ts(无渐变、无装饰动画、≤150ms 功能性状态过渡)对新增提示同样适用。

## 怎么验证的

### 自动验证

```text
pnpm --filter desktop exec vitest run src/renderer/__tests__/manualCompactCommand.test.ts
Result: passed.

pnpm --filter desktop exec vitest run src/renderer/__tests__/sessionAgentSwitchRemoteRouting.test.ts
Result: passed.

pnpm --filter @cindy/maker-core exec vitest run src/agents/pi/__tests__/pi-compact.test.ts
Result: passed.

pnpm --filter @cindy/maker-core exec tsc --noEmit --strict --skipLibCheck --module esnext --moduleResolution bundler --target esnext --esModuleInterop --isolatedModules src/agents/pi/commands.ts
Result: passed.

pnpm --filter mobile run --if-present typecheck
Result: passed.

pnpm check:dco
Result: passed.
```

### 手工验证

Not run.

### 未执行的验证

- desktop 全量 typecheck 与全量单测未在本地验证容器执行:desktop 工程 tsc 需 8GB 堆、全量单测在本地 Docker VM(约 3.9GB 内存)bind-mount I/O 下超出部分文件遍历型用例的 vitest 5s 超时,均属环境限制而非代码问题;CI(Linux/Windows)会完整执行。本地已在容器内运行与改动直接相关的全部聚焦用例(见上)并对新增 maker-core 文件执行严格 tsc。
- 手工端到端压缩流程(macOS/Windows 桌面客户端实际触发 claude-code 与 pi 会话压缩)未执行:无对应本地客户端环境。

## 风险

### 风险分类

- [x] 无已知风险
- [ ] SQLite / migration
- [ ] system prompt
- [ ] 协议兼容
- [ ] 权限 / 安全 / 用户数据
- [ ] 存量插件兼容（批准状态 / 指纹 / manifest 校验 / 安装布局 / 包格式）
- [ ] 原生层 / fingerprint / OTA
- [ ] 跨平台差异
- [ ] 其他：

### 影响与回滚

- Impact: Limited to the files listed in this pull request.
- Risk: No known risks.
- Rollback: Revert this commit. No data migration or cleanup is required.

### 提交前检查

- [x] 已 review 完整 diff
- [x] 每个 commit 都带 DCO 签名（`git commit -s`，见 [DCO](../DCO)）
- [x] UI 改动已在「UI 变化」注明引用的设计规范章节（不涉及 UI 则跳过）
- [x] 未提交凭证、令牌或授权文件
- [x] 已补充必要文档
- [x] 已确认测试结果或说明未执行原因


