### PR TITLE
fix(desktop): Windows 卸载前关闭正在运行的 Cindy

### DIFF
--- a/apps/desktop/resources/installer.nsh
+++ b/apps/desktop/resources/installer.nsh
@@ -7,21 +7,30 @@
 ; 接受);dev 仍独立名,dev 安装器绝不误伤同机并存的正式安装。注册表键名
 ; Windows 大小写不敏感,shell 键 "Cindy" 与历史写入的 "cindy" 是同一个键,
 ; 行为零变化。
-!macro customInit
-  ; Check if the app is already running
+; 安装与卸载都必须在改动安装目录前停掉正在运行的 app。尤其是卸载:
+; 如果先删 resources 再让存量窗口处理关闭事件,托盘图标创建会失败,主窗口也会
+; 因「收起到托盘」语义而保持打开。两个入口共用这段循环,避免以后只修一侧。
+!macro stopRunningProduct CONFIRM_MESSAGE
   check_running:
     nsProcess::_FindProcess "${APP_EXECUTABLE_FILENAME}"
     Pop $R0
     ${If} $R0 == 0
       MessageBox MB_OKCANCEL|MB_ICONEXCLAMATION \
-        "${PRODUCT_FILENAME} 正在运行，请先关闭后再继续安装。$\n$\n点击「确定」将在关闭后继续。" \
+        "${CONFIRM_MESSAGE}" \
+        /SD IDOK \
         IDOK kill_app
       Abort
       kill_app:
         nsProcess::_KillProcess "${APP_EXECUTABLE_FILENAME}"
+        Pop $R0
         Sleep 1000
         Goto check_running
     ${EndIf}
+!macroend
+
+!macro customInit
+  !insertmacro stopRunningProduct \
+    "${PRODUCT_FILENAME} 正在运行，请先关闭后再继续安装。$\n$\n点击「确定」将在关闭后继续。"
 
   ; 删旧快捷方式：老 .lnk 里 IconLocation 仍指向上一版 exe 的资源索引，
   ; 新版 .ico 内多尺寸顺序/数量变化后那个索引会落到另一张图。
@@ -34,6 +43,11 @@
 
   ; 同步清掉 PinnedTaskbar 里的副本（任务栏固定项也会缓存图标）
   Delete "$APPDATA\Microsoft\Internet Explorer\Quick Launch\User Pinned\TaskBar\${SHORTCUT_NAME}.lnk"
+!macroend
+
+!macro customUnInit
+  !insertmacro stopRunningProduct \
+    "${PRODUCT_FILENAME} 正在运行，需要先关闭才能卸载。$\n$\n点击「确定」将关闭 ${PRODUCT_FILENAME} 并继续卸载。"
 !macroend
 
 !macro customInstall

--- a/apps/desktop/src/main/__tests__/installerNsh.test.ts
+++ b/apps/desktop/src/main/__tests__/installerNsh.test.ts
@@ -1,0 +1,29 @@
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+import { describe, expect, it } from 'vitest';
+
+const installerScript = fs.readFileSync(
+  path.resolve(__dirname, '../../../resources/installer.nsh'),
+  'utf8',
+);
+
+function macroBody(name: string): string {
+  const match = installerScript.match(
+    new RegExp(`!macro ${name}(?: [^\\r\\n]*)?\\r?\\n([\\s\\S]*?)!macroend`),
+  );
+  expect(match, `missing NSIS macro: ${name}`).not.toBeNull();
+  return match?.[1] ?? '';
+}
+
+describe('Windows installer process shutdown contract', () => {
+  it('stops the packaged app before both install and uninstall mutate its files', () => {
+    const stopRunningProduct = macroBody('stopRunningProduct');
+
+    expect(stopRunningProduct).toContain('nsProcess::_FindProcess "${APP_EXECUTABLE_FILENAME}"');
+    expect(stopRunningProduct).toContain('nsProcess::_KillProcess "${APP_EXECUTABLE_FILENAME}"');
+    expect(stopRunningProduct).toContain('/SD IDOK');
+    expect(stopRunningProduct).toContain('Goto check_running');
+    expect(macroBody('customInit')).toContain('!insertmacro stopRunningProduct');
+    expect(macroBody('customUnInit')).toContain('!insertmacro stopRunningProduct');
+  });
+});


### PR DESCRIPTION
## 这次改了什么

### 摘要

修复 Windows 上 Cindy 仍在运行时卸载不干净的问题。安装与卸载现在复用同一套进程检测和终止循环；卸载器会在删除应用文件前关闭 Cindy，并确认进程已经退出。静默卸载默认继续关闭进程，不会被新增确认框卡住。

### 变更类型

- [ ] feat 新功能
- [x] fix 缺陷修复
- [ ] refactor / perf 重构或性能优化
- [ ] docs / test / chore 文档、测试或工程维护
- [ ] 其他：

### 范围

- 关联 Issue / 需求：Fixes #3748
- 本 PR 包含：Windows NSIS 安装/卸载进程停止宏，以及对应契约测试
- 明确不包含：Electron 应用内退出协议、用户数据清理、其他平台安装器改动
- 用户可见变化：运行中卸载时会先提示并关闭 Cindy，再继续删除应用文件
- 是否存在 breaking change：无

### UI 变化

- 引用的设计规范：docs/design-rules/DESIGN.md §11 Voice & Content；涉及 Windows NSIS 原生确认框文案，沿用现有简洁、直接并给出下一步动作的口径，不涉及应用内布局、主题或组件

## 怎么验证的

### 自动验证

```text
pnpm test:unit:related
结果：通过；Desktop related tests passed

pnpm --filter desktop run --if-present typecheck
结果：通过

pnpm --filter desktop exec eslint src/main/__tests__/installerNsh.test.ts
结果：通过

pnpm check:dco -- --base origin/main
结果：通过；1 commit signed off
```

### 手工验证

未执行完整 Windows 安装包的真实卸载流程。

### 未执行的验证

尚未生成完整 Windows 安装包。合并前需要验证：窗口打开时卸载、托盘中卸载、未运行时卸载、取消提示、静默卸载 /S，以及卸载后无 Cindy 相关进程和文件残留。

## 风险

### 风险分类

- [ ] 无已知风险
- [ ] SQLite / migration
- [ ] system prompt
- [ ] 协议兼容
- [ ] 权限 / 安全 / 用户数据
- [ ] 存量插件兼容（批准状态 / 指纹 / manifest 校验 / 安装布局 / 包格式）
- [ ] 原生层 / fingerprint / OTA
- [x] 跨平台差异
- [x] 其他：Windows NSIS 卸载生命周期

### 影响与回滚

- 影响范围：仅 Windows NSIS 安装器和卸载器；macOS、Linux、应用内退出链及用户数据不受影响
- 回滚 / 降级方式：回退本 PR，恢复原有 installer.nsh 行为

### 提交前检查

- [x] 已 review 完整 diff
- [x] 每个 commit 都带 DCO 签名
- [x] UI 改动已在「UI 变化」注明引用的设计规范章节
- [x] 未提交凭证、令牌或授权文件
- [x] 已补充必要文档（本次无需新增文档）
- [x] 已确认测试结果或说明未执行原因