### PR TITLE
fix(settings): 修复窄窗口用量表格列重叠

### DIFF
--- a/apps/desktop/src/renderer/components/settings/usage/UsageBreakdownTables.tsx
+++ b/apps/desktop/src/renderer/components/settings/usage/UsageBreakdownTables.tsx
@@ -40,8 +40,17 @@ const TD_CLASS =
  * `w-full + max-w-0` 让它先塌到 0 (打破"按最长内容取列宽"的默认行为) 再领走
  * 其余列分完后剩下的空间, 内层的 truncate 由此生效 (见 #3393 的同一段分析)。
  * pl-3 是列间距, 否则相邻两列的数字会贴到一起; 首列自身取 pl-0。
+ *
+ * `overflow-hidden` 是最后一道单元格边界: 模型行还有不可收缩的色块与 agent 标签,
+ * 即使浏览器在边界宽度下给首列算出异常小的宽度, 它们也不能穿透到数字列 (#3546)。
+ * 表本身另有明确的最小宽度, 空间不足时由外层 overflow-x-auto 横向滚动, 而不是
+ * 继续把首列压到不可读。
  */
-const FIRST_COL_CLASS = 'w-full max-w-0 pl-0';
+const FIRST_COL_CLASS = 'w-full max-w-0 overflow-hidden pl-0';
+
+/** 数字列保持完整可读所需的最小表宽; 低于该宽度时交给 Card 的横向滚动容器。 */
+const AGENT_TABLE_CLASS = 'w-full min-w-[520px] border-collapse';
+const MODEL_TABLE_CLASS = 'w-full min-w-[720px] border-collapse';
 
 function Swatch({ rank }: { rank: number }): React.JSX.Element {
   return (
@@ -92,7 +101,7 @@ export function UsageAgentTable({ rows }: { rows: AgentTokenRow[] }): React.JSX.
           />
         ))}
       </div>
-      <table className="w-full border-collapse">
+      <table className={AGENT_TABLE_CLASS}>
         <thead>
           <tr>
             <th className={cn(TH_CLASS, FIRST_COL_CLASS, 'text-left')}>
@@ -140,7 +149,7 @@ export function UsageModelTable({ rows }: { rows: ModelTokenRow[] }): React.JSX.
   const { t } = useTranslation();
 
   return (
-    <table className="w-full border-collapse">
+    <table className={MODEL_TABLE_CLASS}>
       <thead>
         <tr>
           <th className={cn(TH_CLASS, FIRST_COL_CLASS, 'text-left')}>

--- a/apps/desktop/src/renderer/components/settings/usage/__tests__/UsageBreakdownTables.test.tsx
+++ b/apps/desktop/src/renderer/components/settings/usage/__tests__/UsageBreakdownTables.test.tsx
@@ -1,0 +1,61 @@
+// @vitest-environment jsdom
+
+import React from 'react';
+import { render } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+
+import { UsageAgentTable, UsageModelTable } from '../UsageBreakdownTables';
+
+vi.mock('react-i18next', () => ({
+  useTranslation: () => ({
+    t: (key: string) => key,
+  }),
+}));
+
+describe('UsageBreakdownTables responsive layout', () => {
+  it('keeps the agent table wide enough for numeric columns to scroll instead of overlap', () => {
+    const { container } = render(
+      <UsageAgentTable
+        rows={[
+          {
+            agentKind: 'claude-code',
+            tokens: 1_000,
+            share: 1,
+            todayTokens: 100,
+            cacheHitRate: 0.5,
+            modelCount: 1,
+          },
+        ]}
+      />,
+    );
+
+    const table = container.querySelector('table');
+    expect(table?.className).toContain('min-w-[520px]');
+    expect(table?.querySelector('tbody td')?.className).toContain('overflow-hidden');
+  });
+
+  it('keeps the wider model table scrollable and clips first-column decorations at its boundary', () => {
+    const { container } = render(
+      <UsageModelTable
+        rows={[
+          {
+            key: 'codex:very-long-model-name',
+            agentKind: 'codex',
+            model: 'very-long-model-name-that-must-not-overlap-token-columns',
+            tokens: 1_000,
+            share: 1,
+            inputTokens: 400,
+            outputTokens: 300,
+            cacheReadTokens: 200,
+            cacheCreateTokens: 100,
+            cacheHitRate: 0.5,
+          },
+        ]}
+      />,
+    );
+
+    const table = container.querySelector('table');
+    expect(table?.className).toContain('min-w-[720px]');
+    expect(table?.querySelector('tbody td')?.className).toContain('overflow-hidden');
+  });
+});


### PR DESCRIPTION
## 这次改了什么

### 摘要

修复窄窗口下「用量历史」的“按 Agent / harness”和“按模型”表格列重叠问题。为两张表建立最小宽度，并在首列增加溢出边界；空间不足时沿用现有横向滚动容器查看完整数字列，不再继续压缩首列导致名称、标签、表头与相邻列重叠。

### 变更类型

- [ ] `feat` 新功能
- [x] `fix` 缺陷修复
- [ ] `refactor` / `perf` 重构或性能优化
- [ ] `docs` / `test` / `chore` 文档、测试或工程维护
- [ ] 其他：

### 范围

- 关联 Issue / 需求：Fixes #3546
- 本 PR 包含：为 Agent 表设置 520px 最小宽度，为模型表设置 720px 最小宽度；限制首列内容溢出；补充响应式布局回归测试。
- 明确不包含：用量数据聚合、其他设置页面及“最耗 token 的任务”表格调整。
- 用户可见变化：窄窗口中表格列不再重叠；右侧数字列可通过横向滚动完整查看。
- 是否存在 breaking change：无。

### UI 变化

平台：Windows 10，Cindy Desktop，CN / zh-CN，窗口最窄状态。

**窄窗口初始位置：首列、相邻数字列和表头不再重叠**

![窄窗口下用量历史表格初始位置](https://raw.githubusercontent.com/Stella-xixi/cindy/pr-assets-3754/pr-assets/3754/usage-history-narrow-initial.png)

**横向滚动入口：空间不足时可滚动查看右侧完整列**

![窄窗口下用量历史表格横向滚动](https://raw.githubusercontent.com/Stella-xixi/cindy/pr-assets-3754/pr-assets/3754/usage-history-horizontal-scroll.png)

- 引用的设计规范：`docs/design-rules/DESIGN.md` §5 间距与栅格、§10 Theme System & Token Reference。本次保留既有 12px 列间距与语义 token，不新增颜色或单模式样式；响应式空间不足时通过横向滚动保持信息完整。

## 怎么验证的

### 自动验证

```text
pnpm test:unit:related
结果：通过（Desktop related 2）。

pnpm --filter desktop run --if-present typecheck
结果：通过。
```

### 手工验证

- Windows 10 / Cindy Desktop / CN / zh-CN。
- 将窗口缩到应用允许的最窄宽度，检查“按 Agent / harness”和“按模型”表格。
- 首列、相邻数字列及表头无重叠。
- Windows 自动隐藏滚动条时，表格仍可横向移动并查看全部右侧列。

### 未执行的验证

- 未在 macOS 实机验证；改动仅使用跨平台 CSS 布局类，不涉及平台分支。
- 未单独进行 Dark 模式实机目检；改动不涉及颜色，继续复用现有主题 token。

## 风险

### 风险分类

- [x] 无已知风险
- [ ] SQLite / migration
- [ ] system prompt
- [ ] 协议兼容
- [ ] 权限 / 安全 / 用户数据
- [ ] 存量插件兼容（批准状态 / 指纹 / manifest 校验 / 安装布局 / 包格式）
- [ ] 原生层 / fingerprint / OTA
- [ ] 跨平台差异
- [ ] 其他：

### 影响与回滚

- 影响范围：仅 Desktop 设置 → 用量历史的两张明细表。
- 回滚 / 降级方式：回滚本提交即可；不涉及数据迁移或清理。

### 提交前检查

- [x] 已 review 完整 diff
- [x] 每个 commit 都带 DCO 签名（`git commit -s`，见 [DCO](../DCO)）
- [x] UI 改动已在「UI 变化」注明引用的设计规范章节（不涉及 UI 则跳过）
- [x] 未提交凭证、令牌或授权文件
- [x] 已补充必要文档
- [x] 已确认测试结果或说明未执行原因
