### PR TITLE
fix(pi): honor downloaded catalog capabilities

### DIFF
--- a/apps/desktop/src/main/maker-host/__tests__/piNativeProviders.test.ts
+++ b/apps/desktop/src/main/maker-host/__tests__/piNativeProviders.test.ts
@@ -284,6 +284,86 @@ describe('buildPiNativeProvidersFromConfigs', () => {
     });
   });
 
+  it('enriches explicit runtime protocols from same-origin bundled metadata without overriding server context', () => {
+    const bundled = new Map([
+      [
+        'bundled-provider',
+        new Map([
+          [
+            'server-model',
+            piBundledModel('server-model', 'openai-completions', {
+              baseUrl: 'https://api.example/v1',
+              contextWindow: 272_000,
+              maxTokens: 128_000,
+              input: ['text', 'image'],
+            }),
+          ],
+        ]),
+      ],
+    ]);
+    const { providers } = buildPiNativeProvidersFromConfigs(
+      [
+        {
+          id: 'server-models',
+          name: 'Server Models',
+          auth: { method: 'none' },
+          runtimes: {
+            pi: piRuntime({
+              baseUrl: 'https://api.example/v1',
+              wireProtocol: 'openai-chat',
+              models: [{ id: 'server-model', name: 'Server Model', contextWindow: 64_000 }],
+            }),
+          },
+        },
+      ],
+      () => null,
+      undefined,
+      bundled,
+    );
+
+    expect(providers[0]?.models[0]).toMatchObject({
+      id: 'server-model',
+      contextWindow: 64_000,
+      maxTokens: 128_000,
+      input: ['text', 'image'],
+      reasoning: true,
+    });
+  });
+
+  it('does not borrow bundled Pi metadata when the explicit runtime protocol disagrees', () => {
+    const bundled = new Map([
+      [
+        'bundled-provider',
+        new Map([['server-model', piBundledModel('server-model', 'anthropic-messages')]]),
+      ],
+    ]);
+    const { providers } = buildPiNativeProvidersFromConfigs(
+      [
+        {
+          id: 'server-models',
+          name: 'Server Models',
+          auth: { method: 'none' },
+          runtimes: {
+            pi: piRuntime({
+              wireProtocol: 'openai-responses',
+              models: [{ id: 'server-model', name: 'Server Model' }],
+            }),
+          },
+        },
+      ],
+      () => null,
+      undefined,
+      bundled,
+    );
+
+    expect(providers[0]?.models[0]).toMatchObject({
+      id: 'server-model',
+      name: 'Server Model',
+    });
+    expect(providers[0]?.models[0]).not.toHaveProperty('reasoning');
+    expect(providers[0]?.models[0]).not.toHaveProperty('input');
+  });
+
   it('does not apply official per-model routing after the user changes endpoint or protocol', () => {
     const { providers } = buildPiNativeProvidersFromConfigs(
       [

--- a/apps/desktop/src/main/maker-host/pi-host.ts
+++ b/apps/desktop/src/main/maker-host/pi-host.ts
@@ -1232,11 +1232,16 @@ export function buildPiNativeProvidersFromConfigs(
     // strictly same-origin PI bundled knowledge, then an explicitly matched official
     // PI catalog. Missing protocol is not Chat: one unresolved model makes the whole
     // provider unusable so PI cannot silently send it to a guessed endpoint shape.
-    const bundledModels = rt.models.map((model) =>
-      !model.piApi && !runtimeApi
-        ? resolvePiBundledModelById(bundledModelsByProvider, model.id, rt.baseUrl)
-        : undefined,
-    );
+    const bundledModels = rt.models.map((model) => {
+      // An explicit runtime wireProtocol resolves the endpoint shape, but it
+      // must not disable same-origin bundled capability enrichment. Only a
+      // per-model piApi override opts out, and an explicit endpoint protocol
+      // may borrow bundled metadata when the APIs agree.
+      if (model.piApi) return undefined;
+      const bundled = resolvePiBundledModelById(bundledModelsByProvider, model.id, rt.baseUrl);
+      if (!bundled || !runtimeApi || bundled.api === runtimeApi) return bundled;
+      return undefined;
+    });
     const official =
       rt.piCatalogProviderId &&
       officialPiRouteMatches(rt.piCatalogProviderId, rt.baseUrl, rt.wireProtocol)
@@ -1317,7 +1322,9 @@ export function buildPiNativeProvidersFromConfigs(
           ...(m.piApi || modelApi !== providerApi ? { api: modelApi } : {}),
           ...(modelBaseUrl && modelBaseUrl !== rt.baseUrl ? { baseUrl: modelBaseUrl } : {}),
           name: bundledModel?.name ?? m.name,
-          contextWindow: bundledModel?.contextWindow ?? m.contextWindow,
+          // The downloaded preset is the user's selected endpoint contract;
+          // explicit values must win over a stale local Pi snapshot.
+          contextWindow: m.contextWindow ?? bundledModel?.contextWindow,
           ...(bundledModel?.maxTokens ? { maxTokens: bundledModel.maxTokens } : {}),
           ...(bundledModel?.input
             ? { input: [...bundledModel.input] }


### PR DESCRIPTION
## 这次改了什么

### 摘要

修复 Pi native provider 对下载 Catalog 与本地 bundled 能力的合并优先级：显式 runtime 协议不再错误地禁用同源 bundled 元数据补全；当服务端 preset 明确声明 `contextWindow` 时，它优先于陈旧本地快照。这样 Pi 的思考能力、图片输入与输出上限不会因“已有 wireProtocol”而整体丢失。

### 变更类型

- [ ] `feat` 新功能
- [x] `fix` 缺陷修复
- [ ] `refactor` / `perf` 重构或性能优化
- [x] `docs` / `test` / `chore` 文档、测试或工程维护
- [ ] 其他：

### 范围

- 关联 Issue / 需求：Pi harness 模型配置陈旧、思考/图片/输出能力下放不完整。
- 本 PR 包含：`apps/desktop/src/main/maker-host/pi-host.ts` 与对应 Pi native provider 定向测试。
- 明确不包含：服务端 Catalog 数据、Gateway/XD、价格策略、schema 实现、其它 harness 或模型。
- 用户可见变化：同源 Pi provider 在显式协议下仍能获得本地能力补全；服务端显式上下文值覆盖本地陈旧值；协议不匹配时继续 fail-closed。
- 是否存在 breaking change：无。

## UI 变化

- 不涉及：仅修改桌面端 Pi 配置合并逻辑，无视觉或交互变化。

## 怎么验证的

### 自动验证

```text
pnpm --filter desktop exec vitest run src/main/maker-host/__tests__/piNativeProviders.test.ts
结果：1 file / 63 tests passed / 2 skipped

pnpm --filter desktop typecheck
结果：通过
```

### 手工验证

不涉及：本 PR 未启动桌面端运行时。

### 未执行的验证

未执行真实桌面/Gateway E2E；需要配套服务端 Catalog PR 合并后，在目标环境验证动态下放。

## 风险

### 风险分类

- [ ] 无已知风险
- [ ] SQLite / migration
- [ ] system prompt
- [x] 协议兼容
- [ ] 权限 / 安全 / 用户数据
- [ ] 存量插件兼容
- [x] 跨平台差异
- [ ] 其他：

### 影响与回滚

- 影响范围：桌面端 Pi native provider 模型能力解析。
- 回滚 / 降级方式：回滚本 PR commit；旧的协议不匹配 fail-closed 行为保持不变。

### 提交前检查

- [x] 已 review 完整 diff
- [x] 每个 commit 都带 DCO 签名（`git commit -s`）
- [x] 未提交凭证、令牌或授权文件
- [x] 已补充必要文档：N/A，仅行为修复与测试。
- [x] 已确认测试结果或说明未执行原因
