### PR TITLE
fix(maker-core): yield marker 检测收紧为执行器状态头形状(#3763)

### DIFF
--- a/packages/maker-core/src/agents/codex/index.test.ts
+++ b/packages/maker-core/src/agents/codex/index.test.ts
@@ -18183,7 +18183,7 @@ describe('CodexAgent yield continuation', () => {
         type: 'commandExecution',
         command: 'pnpm --filter desktop run typecheck',
         status: 'completed',
-        aggregatedOutput: 'Script running with cell ID 226',
+        aggregatedOutput: 'Script running with cell ID 226\nWall time 1.0 seconds\nOutput:\n',
       },
     });
     handlers.turnCompleted({
@@ -18262,7 +18262,7 @@ describe('CodexAgent yield continuation', () => {
         type: 'commandExecution',
         command: 'pnpm --filter desktop run typecheck',
         status: 'completed',
-        aggregatedOutput: 'Script running with cell ID 226',
+        aggregatedOutput: 'Script running with cell ID 226\nWall time 1.0 seconds\nOutput:\n',
       },
     });
     handlers.turnCompleted({
@@ -18344,7 +18344,7 @@ describe('CodexAgent yield continuation', () => {
           cmd: 'pnpm --filter desktop run typecheck',
           yield_time_ms: 10_000,
         }),
-        content: [{ type: 'output_text', text: 'Script running with cell ID 229' }],
+        content: [{ type: 'output_text', text: 'Script running with cell ID 229\nWall time 1.0 seconds\nOutput:\n' }],
       },
     });
     handlers.turnCompleted({
@@ -18396,7 +18396,7 @@ describe('CodexAgent yield continuation', () => {
           cmd: 'pnpm --filter desktop run typecheck',
           yield_time_ms: 10_000,
         }),
-        content: [{ type: 'output_text', text: 'Script running with cell ID 229' }],
+        content: [{ type: 'output_text', text: 'Script running with cell ID 229\nWall time 1.0 seconds\nOutput:\n' }],
       },
     });
     handlers.itemCompleted({
@@ -18456,7 +18456,7 @@ describe('CodexAgent yield continuation', () => {
         type: 'function_call',
         name: 'exec_command',
         arguments: JSON.stringify({ cmd: 'pnpm typecheck', yield_time_ms: 10_000 }),
-        content: [{ type: 'output_text', text: 'Script running with cell ID 226' }],
+        content: [{ type: 'output_text', text: 'Script running with cell ID 226\nWall time 1.0 seconds\nOutput:\n' }],
       },
     });
     handlers.itemCompleted({
@@ -18466,7 +18466,7 @@ describe('CodexAgent yield continuation', () => {
         type: 'function_call',
         name: 'exec_command',
         arguments: JSON.stringify({ cmd: 'pnpm lint', yield_time_ms: 10_000 }),
-        content: [{ type: 'output_text', text: 'Script running with cell ID 229' }],
+        content: [{ type: 'output_text', text: 'Script running with cell ID 229\nWall time 1.0 seconds\nOutput:\n' }],
       },
     });
     handlers.itemCompleted({
@@ -18529,7 +18529,7 @@ describe('CodexAgent yield continuation', () => {
           cmd: 'pnpm --filter desktop run typecheck',
           yield_time_ms: 10_000,
         }),
-        content: [{ type: 'output_text', text: 'Script running with cell ID 229' }],
+        content: [{ type: 'output_text', text: 'Script running with cell ID 229\nWall time 1.0 seconds\nOutput:\n' }],
       },
     });
     handlers.itemCompleted({
@@ -18698,7 +18698,7 @@ describe('CodexAgent yield continuation', () => {
         type: 'commandExecution',
         command: 'pnpm --filter desktop run typecheck',
         status: 'completed',
-        aggregatedOutput: 'Script running with cell ID 226',
+        aggregatedOutput: 'Script running with cell ID 226\nWall time 1.0 seconds\nOutput:\n',
       },
     });
     handlers.turnCompleted({
@@ -18808,7 +18808,7 @@ describe('CodexAgent yield continuation', () => {
         type: 'commandExecution',
         command: 'pnpm --filter desktop run typecheck',
         status: 'completed',
-        aggregatedOutput: 'Script running with cell ID 226',
+        aggregatedOutput: 'Script running with cell ID 226\nWall time 1.0 seconds\nOutput:\n',
       },
     });
     await new Promise((resolve) => setTimeout(resolve, 20));
@@ -18863,7 +18863,7 @@ describe('CodexAgent yield continuation', () => {
         type: 'commandExecution',
         command: 'pnpm --filter desktop run typecheck',
         status: 'completed',
-        aggregatedOutput: 'Script running with cell ID 226',
+        aggregatedOutput: 'Script running with cell ID 226\nWall time 1.0 seconds\nOutput:\n',
       },
     });
     handlers.turnCompleted({
@@ -18937,7 +18937,7 @@ describe('CodexAgent yield continuation', () => {
         type: 'commandExecution',
         command: 'pnpm --filter desktop run typecheck',
         status: 'completed',
-        aggregatedOutput: 'Script running with cell ID 226',
+        aggregatedOutput: 'Script running with cell ID 226\nWall time 1.0 seconds\nOutput:\n',
       },
     });
     handlers.turnCompleted({
@@ -18990,7 +18990,7 @@ describe('CodexAgent yield continuation', () => {
         type: 'commandExecution',
         command: 'pnpm --filter desktop run typecheck',
         status: 'completed',
-        aggregatedOutput: 'Script running with cell ID 226',
+        aggregatedOutput: 'Script running with cell ID 226\nWall time 1.0 seconds\nOutput:\n',
       },
     });
     handlers.turnStarted?.({
@@ -19053,7 +19053,7 @@ describe('CodexAgent yield continuation', () => {
         type: 'commandExecution',
         command: 'pnpm --filter desktop run typecheck',
         status: 'completed',
-        aggregatedOutput: 'Script running with cell ID 226',
+        aggregatedOutput: 'Script running with cell ID 226\nWall time 1.0 seconds\nOutput:\n',
       },
     });
     handlers.turnCompleted({
@@ -19122,7 +19122,7 @@ describe('CodexAgent yield continuation', () => {
         type: 'commandExecution',
         command: 'pnpm --filter desktop run typecheck',
         status: 'completed',
-        aggregatedOutput: 'Script running with cell ID 226',
+        aggregatedOutput: 'Script running with cell ID 226\nWall time 1.0 seconds\nOutput:\n',
       },
     });
     handlers.turnCompleted({
@@ -19198,7 +19198,7 @@ describe('CodexAgent yield continuation', () => {
         type: 'commandExecution',
         command: 'pnpm --filter desktop run typecheck',
         status: 'completed',
-        aggregatedOutput: 'Script running with cell ID 226',
+        aggregatedOutput: 'Script running with cell ID 226\nWall time 1.0 seconds\nOutput:\n',
       },
     });
     handlers.turnCompleted({
@@ -19304,7 +19304,7 @@ describe('CodexAgent yield continuation', () => {
         type: 'commandExecution',
         command: 'pnpm --filter desktop run typecheck',
         status: 'inProgress',
-        aggregatedOutput: 'Script running with cell ID 226',
+        aggregatedOutput: 'Script running with cell ID 226\nWall time 1.0 seconds\nOutput:\n',
       },
     });
     handlers.itemCompleted({
@@ -19356,7 +19356,7 @@ describe('CodexAgent yield continuation', () => {
         type: 'commandExecution',
         command: 'pnpm --filter desktop run typecheck',
         status: 'inProgress',
-        aggregatedOutput: 'Script running with cell ID 226',
+        aggregatedOutput: 'Script running with cell ID 226\nWall time 1.0 seconds\nOutput:\n',
       },
     });
     handlers.itemCompleted({
@@ -19413,7 +19413,7 @@ describe('CodexAgent yield continuation', () => {
         type: 'commandExecution',
         command: 'pnpm --filter desktop run typecheck',
         status: 'completed',
-        aggregatedOutput: 'Script running with cell ID 226',
+        aggregatedOutput: 'Script running with cell ID 226\nWall time 1.0 seconds\nOutput:\n',
       },
     });
     handlers.turnCompleted({
@@ -19541,7 +19541,7 @@ describe('CodexAgent yield continuation', () => {
         type: 'commandExecution',
         command: 'pnpm --filter desktop run typecheck',
         status: 'completed',
-        aggregatedOutput: 'Script running with cell ID 226',
+        aggregatedOutput: 'Script running with cell ID 226\nWall time 1.0 seconds\nOutput:\n',
       },
     });
     handlers.turnCompleted({
@@ -19601,7 +19601,7 @@ describe('CodexAgent yield continuation', () => {
         type: 'commandExecution',
         command: 'pnpm --filter desktop run typecheck',
         status: 'completed',
-        aggregatedOutput: 'Script running with cell ID 226',
+        aggregatedOutput: 'Script running with cell ID 226\nWall time 1.0 seconds\nOutput:\n',
       },
     });
     handlers.turnCompleted({
@@ -19623,7 +19623,7 @@ describe('CodexAgent yield continuation', () => {
         type: 'commandExecution',
         command: 'pnpm --filter desktop run typecheck',
         status: 'completed',
-        aggregatedOutput: 'Script running with cell ID 226',
+        aggregatedOutput: 'Script running with cell ID 226\nWall time 1.0 seconds\nOutput:\n',
       },
     });
     handlers.turnCompleted({
@@ -19645,7 +19645,7 @@ describe('CodexAgent yield continuation', () => {
         type: 'commandExecution',
         command: 'pnpm --filter desktop run typecheck',
         status: 'completed',
-        aggregatedOutput: 'Script running with cell ID 226',
+        aggregatedOutput: 'Script running with cell ID 226\nWall time 1.0 seconds\nOutput:\n',
       },
     });
     handlers.turnCompleted({
@@ -19688,7 +19688,7 @@ describe('CodexAgent yield continuation', () => {
         type: 'commandExecution',
         command: 'pnpm --filter desktop run typecheck',
         status: 'completed',
-        aggregatedOutput: 'Script running with cell ID 226',
+        aggregatedOutput: 'Script running with cell ID 226\nWall time 1.0 seconds\nOutput:\n',
       },
     });
     handlers.turnCompleted({
@@ -19741,7 +19741,7 @@ describe('CodexAgent yield continuation', () => {
         type: 'commandExecution',
         command: 'pnpm --filter desktop run typecheck',
         status: 'completed',
-        aggregatedOutput: 'Script running with cell ID 226',
+        aggregatedOutput: 'Script running with cell ID 226\nWall time 1.0 seconds\nOutput:\n',
       },
     });
     handlers.turnCompleted({
@@ -19798,7 +19798,7 @@ describe('CodexAgent yield continuation', () => {
         type: 'commandExecution',
         command: 'pnpm --filter desktop run typecheck',
         status: 'completed',
-        aggregatedOutput: 'Script running with cell ID 226',
+        aggregatedOutput: 'Script running with cell ID 226\nWall time 1.0 seconds\nOutput:\n',
       },
     });
     handlers.turnCompleted({
@@ -19889,7 +19889,7 @@ describe('CodexAgent yield continuation', () => {
         type: 'commandExecution',
         command: 'pnpm --filter desktop run typecheck',
         status: 'completed',
-        aggregatedOutput: 'Script running with cell ID 226',
+        aggregatedOutput: 'Script running with cell ID 226\nWall time 1.0 seconds\nOutput:\n',
       },
     });
     handlers.turnCompleted({
@@ -20000,7 +20000,7 @@ describe('CodexAgent yield continuation', () => {
         type: 'commandExecution',
         command: 'pnpm --filter desktop run typecheck',
         status: 'completed',
-        aggregatedOutput: 'Script running with cell ID 226',
+        aggregatedOutput: 'Script running with cell ID 226\nWall time 1.0 seconds\nOutput:\n',
       },
     });
     handlers.turnCompleted({
@@ -20070,7 +20070,7 @@ describe('CodexAgent yield continuation', () => {
         type: 'commandExecution',
         command: 'pnpm --filter desktop run typecheck',
         status: 'completed',
-        aggregatedOutput: 'Script running with cell ID 226',
+        aggregatedOutput: 'Script running with cell ID 226\nWall time 1.0 seconds\nOutput:\n',
       },
     });
     handlers.turnCompleted({
@@ -20154,7 +20154,7 @@ describe('CodexAgent yield continuation', () => {
         type: 'commandExecution',
         command: 'pnpm --filter desktop run typecheck',
         status: 'completed',
-        aggregatedOutput: 'Script running with cell ID 226',
+        aggregatedOutput: 'Script running with cell ID 226\nWall time 1.0 seconds\nOutput:\n',
       },
     });
     handlers.turnCompleted({
@@ -20231,7 +20231,7 @@ describe('CodexAgent yield continuation', () => {
         type: 'commandExecution',
         command: 'pnpm --filter desktop run typecheck',
         status: 'completed',
-        aggregatedOutput: 'Script running with cell ID 226',
+        aggregatedOutput: 'Script running with cell ID 226\nWall time 1.0 seconds\nOutput:\n',
       },
     });
     handlers.turnCompleted({
@@ -20319,7 +20319,7 @@ describe('CodexAgent yield continuation', () => {
         type: 'commandExecution',
         command: 'pnpm --filter desktop run typecheck',
         status: 'completed',
-        aggregatedOutput: 'Script running with cell ID 226',
+        aggregatedOutput: 'Script running with cell ID 226\nWall time 1.0 seconds\nOutput:\n',
       },
     });
     handlers.turnCompleted({

--- a/packages/maker-core/src/agents/codex/yielded-exec-cell.test.ts
+++ b/packages/maker-core/src/agents/codex/yielded-exec-cell.test.ts
@@ -27,6 +27,16 @@ describe('extractYieldedExecCellIds', () => {
     expect(extractYieldedExecCellIds('Exit 0\n\n> tsc --noEmit\n')).toEqual([]);
   });
 
+  // Windows 路径:执行器状态头以 CRLF 分行时同样是真实 yield,不得漏判(假完成)。
+  it('recognizes a CRLF-delimited executor status header', () => {
+    expect(extractYieldedExecCellIds(
+      'Script running with cell ID 226\r\nWall time 11.0 seconds\r\nOutput:\r\n',
+    )).toEqual(['226']);
+    expect(extractYieldedExecCellIds(
+      'chunk done\r\nScript running with cell ID 42\r\nWall time 1.0 seconds\r\n',
+    )).toEqual(['42']);
+  });
+
   // #3763:被引用/示例出现的 marker 文案不是执行器状态头,不得铸造 cell。
   it('ignores quoted or prefixed markers that are not executor status headers', () => {
     // grep 输出:路径:行号: 前缀,不在物理行首。

--- a/packages/maker-core/src/agents/codex/yielded-exec-cell.test.ts
+++ b/packages/maker-core/src/agents/codex/yielded-exec-cell.test.ts
@@ -17,14 +17,36 @@ describe('extractYieldedExecCellIds', () => {
 
   it('keeps later cells in order and dedupes repeats', () => {
     expect(extractYieldedExecCellIds([
-      'Script running with cell ID 226',
+      'Script running with cell ID 226\nWall time 1.0 seconds',
       'Script running with cell ID 229 Wall time 11.0 seconds Output:',
-      'Script running with cell ID 226',
+      'Script running with cell ID 226\nWall time 2.0 seconds',
     ].join('\n'))).toEqual(['226', '229']);
   });
 
   it('ignores finished command output without a yield marker', () => {
     expect(extractYieldedExecCellIds('Exit 0\n\n> tsc --noEmit\n')).toEqual([]);
+  });
+
+  // #3763:被引用/示例出现的 marker 文案不是执行器状态头,不得铸造 cell。
+  it('ignores quoted or prefixed markers that are not executor status headers', () => {
+    // grep 输出:路径:行号: 前缀,不在物理行首。
+    expect(extractYieldedExecCellIds(
+      "src/x.test.ts:14:      'Script running with cell ID 226\\nWall time 11.0 seconds',",
+    )).toEqual([]);
+    // 源码 cat:缩进 + 引号包裹,\n 是字面转义不是真实换行。
+    expect(extractYieldedExecCellIds(
+      "      'Script running with cell ID 229\\nWall time 11.0 seconds\\nOutput:\\n',",
+    )).toEqual([]);
+    // 行首但缺 Wall time 帧(裸引用一行文案)。
+    expect(extractYieldedExecCellIds('Script running with cell ID 777')).toEqual([]);
+    // issue 复现形态:一次读取源码把多个示例 ID 全炸出来 —— 现在必须为空。
+    expect(extractYieldedExecCellIds([
+      "  it('locks the #3179 rollout yield shape', () => {",
+      "    expect(extractYieldedExecCellIds(",
+      "      'Script running with cell ID 226\\nWall time 11.0 seconds\\nOutput:\\n',",
+      "    )).toEqual(['226']);",
+      "  'Script running with cell ID 229 Wall time', 'cell ID 11', 'cell ID 12',",
+    ].join('\n'))).toEqual([]);
   });
 });
 
@@ -51,11 +73,27 @@ describe('extractYieldedExecCellsFromCodexItem', () => {
         workdir: '/repo',
         yield_time_ms: 10_000,
       }),
-      content: [{ type: 'output_text', text: 'Script running with cell ID 229' }],
+      content: [{ type: 'output_text', text: 'Script running with cell ID 229\nWall time 10.0 seconds\nOutput:\n' }],
     })).toEqual([{
       cellId: '229',
       command: 'pnpm --filter desktop run typecheck',
     }]);
+  });
+
+  // #3763:已完成命令的 stdout 引用 marker 示例,不得铸造 continuation claim。
+  it('does not mint cells from a completed exec whose stdout merely quotes markers', () => {
+    expect(extractYieldedExecCellsFromCodexItem({
+      type: 'commandExecution',
+      id: 'item-quoted',
+      command: 'grep -rn "cell ID" src/',
+      status: 'completed',
+      exitCode: 0,
+      aggregatedOutput: [
+        "src/a.test.ts:14:      'Script running with cell ID 226\\nWall time 11.0 seconds',",
+        "src/a.test.ts:21:      'Script running with cell ID 229 Wall time 11.0 seconds Output:',",
+        "src/a.test.ts:75:      text: 'I will wait. Script running with cell ID 777',",
+      ].join('\n'),
+    })).toEqual([]);
   });
 
   it('does not treat a finished exec item as a yielded cell', () => {
@@ -82,7 +120,7 @@ describe('extractYieldedExecCellsFromCodexItem', () => {
       type: 'commandExecution',
       id: 'item-late-marker',
       command: 'pnpm --filter desktop run typecheck',
-      aggregatedOutput: `${padding}\nScript running with cell ID 226`,
+      aggregatedOutput: `${padding}\nScript running with cell ID 226\nWall time 30.0 seconds\nOutput:\n`,
     })).toEqual([{
       cellId: '226',
       command: 'pnpm --filter desktop run typecheck',

--- a/packages/maker-core/src/agents/codex/yielded-exec-cell.ts
+++ b/packages/maker-core/src/agents/codex/yielded-exec-cell.ts
@@ -26,7 +26,7 @@ export interface YieldedExecCell {
  * 接受(协议级 executionHandle 落地前的启发式边界)。
  */
 export const YIELDED_EXEC_CELL_RE =
-  /(?:^|\n)Script running with cell ID[ \t]+(\d+)(?:[ \t]+|\n)Wall time[ \t]/gi;
+  /(?:^|\r?\n)Script running with cell ID[ \t]+(\d+)(?:[ \t]+|\r?\n)Wall time[ \t]/gi;
 
 const MAX_SCAN_CHARS = 16_384;
 

--- a/packages/maker-core/src/agents/codex/yielded-exec-cell.ts
+++ b/packages/maker-core/src/agents/codex/yielded-exec-cell.ts
@@ -14,8 +14,19 @@ export interface YieldedExecCell {
   command?: string;
 }
 
-/** Locked to the #3179 Codex rollout shape. Do not loosen without a new fixture. */
-export const YIELDED_EXEC_CELL_RE = /Script running with cell ID[ \t]+(\d+)/gi;
+/**
+ * Locked to the #3179 Codex rollout shape. Do not loosen without a new fixture.
+ *
+ * #3763 收紧:真实 yield 通知是执行器的**状态头**——marker 行从物理行首开始,
+ * 且紧跟 `Wall time` 帧(同一行以空白分隔,或下一物理行)。被引用/示例出现的
+ * 文案(grep 的 `路径:行号:` 前缀、源码里的缩进+引号、字面 `\n` 转义)都不满足
+ * 这两条,不再被当成真实 cell 铸造 continuation claim —— 此前误判会让已成功的
+ * 命令等待不存在的 cell,升级成 yield-continuation-lost-handle 终态失败。
+ * 残余盲区:纯文本恰好在列 0 完整复刻两行状态头 —— 与真实执行器输出无法区分,
+ * 接受(协议级 executionHandle 落地前的启发式边界)。
+ */
+export const YIELDED_EXEC_CELL_RE =
+  /(?:^|\n)Script running with cell ID[ \t]+(\d+)(?:[ \t]+|\n)Wall time[ \t]/gi;
 
 const MAX_SCAN_CHARS = 16_384;
 


### PR DESCRIPTION
## 这次改了什么

### 摘要

fix #3763。#3315 为避免 Codex 长命令 yield 后「假完成」,从 exec 输出文案里识别 `Script running with cell ID N` 铸造有界 continuation claim。该启发式对输出**全文做无锚点扫描**:已成功完成的命令,只要 stdout 里引用了这段文案(读取/搜索含示例的源码或测试文本——grep 的 `路径:行号:` 前缀行、源码缩进+引号、字面 `\n` 转义),也会被当成真实 cell,一次能炸出多个假 ID;随后对这些 ID 的等待全部 `exec cell not found`,**原本成功的任务被升级成 `yield-continuation-lost-handle` 终态失败**。提报日志(`claim_created cellIds=[226,229,11]`)里的 ID 正是本仓 yielded-exec-cell.test.ts 夹具中的示例值——提报人读了这份测试文件。

修复:把检测收紧到**执行器状态头的结构化形状**(#3179 rollout:marker 从物理行首开始,紧跟 `Wall time` 帧——同行空白分隔或下一物理行)。引用形态全部不满足:grep 前缀行不在行首;源码引用带缩进+引号;字面 `\n` 是两个字符、不是真实换行,marker 与 `Wall time` 不构成合法邻接。residual 盲区(纯文本恰好在列 0 完整复刻两行状态头)与真实执行器输出不可区分,按启发式边界接受并在注释记录——协议级 executionHandle(跨仓长期项)落地前无法进一步收窄。

漏判方向验证:真实 yield / wait 输出恒带状态头帧(锁形测试 + 集成夹具),`Wall time` 同行/换行两种真实变体均覆盖,不引入「长命令假完成」回归。

### 变更类型

- [ ] `feat` 新功能
- [x] `fix` 缺陷修复
- [ ] `refactor` / `perf` 重构或性能优化
- [ ] `docs` / `test` / `chore` 文档、测试或工程维护
- [ ] 其他:

### 范围

- 关联 Issue / 需求:#3763
- 本 PR 包含:YIELDED_EXEC_CELL_RE 收紧(行首锚点 + Wall time 帧)+ 单元/集成夹具补齐真实执行器帧 + 引用形态反例回归
- 明确不包含:协议级 executionHandle(跨仓长期项);wait/claim 生命周期语义(不变)
- 用户可见变化:已完成命令的输出引用 yield 示例文案时,不再被误判为后台任务、不再产生 lost-handle 终态错误
- 是否存在 breaking change:无(真实 yield 识别行为不变,仅剔除引用误判)

### UI 变化

无 UI 变化。

## 怎么验证的

### 自动验证

```
pnpm --dir packages/maker-core exec vitest run src/agents/codex/yielded-exec-cell.test.ts src/agents/codex/index.test.ts
```
结果:yielded-exec-cell 17 过(新增 2 条反例:grep 前缀/缩进引号/字面 \n/裸行首单行引用均不铸 cell;issue 复现形态——一次读取源码含多个示例 ID——必须为空。既有锁形与 wait 语义用例照过)。index 581 过(集成夹具补齐真实状态头帧;agentMessage 引用反例保持裸样)。反证:stash yielded-exec-cell.ts 后恰好 2 条新反例如预期失败,其余 15 条照过。

maker-core typecheck 过。

```
pnpm test:unit:related
```
结果:exit 1,唯一失败为 desktop 段 vitest threads 池 SIGSEGV(本机已知环境基线,与本 diff 无关;maker-core 全量段通过)。

### 手工验证

无(执行器输出形状以 #3179 rollout 锁形测试与既有集成夹具为据)。

### 未执行的验证

- 未在真实 Codex 会话中端到端复现(误判/修复语义均由确定性单测覆盖;真实 yield 形状由既有锁形测试锁定)。

## 风险

### 风险分类

低风险。检测只收紧不放宽;真实 yield 的两种帧变体(同行/换行 Wall time)均有测试锁定;残余盲区已注释记录。

### 影响与回滚

影响面:maker-core 的 codex yield continuation 检测(claim 铸造与 wait 存活判定共用同一正则)。远程与移动端适配:检测在运行 codex 会话的宿主进程内生效,远端 daemon 会话同样受益,无需额外适配。回滚:revert 单 commit,无 schema 变更。

### 提交前检查

- [x] 已运行定向单测(含反证)、typecheck 与 `pnpm test:unit:related`(失败项已逐一归因)
- [x] commit 带 DCO 签名(Signed-off-by: ficowang <fico@xd.com>)
- [x] diff 聚焦单一问题,无无关改动
