### PR TITLE
fix(maker-core): 兜底模型映射链不改写命名空间自定义 Provider id(#3764)

### DIFF
--- a/packages/maker-core/src/agents/claude-code/__tests__/models.test.ts
+++ b/packages/maker-core/src/agents/claude-code/__tests__/models.test.ts
@@ -69,6 +69,19 @@ describe('ClaudeCodeAgent model capabilities', () => {
     expect(toSdkModelString('claude-sonnet-4-6')).toBe('claude-sonnet-4-6[1m]');
   });
 
+  // #3764:命名空间 id 是自定义 Provider 的路由键,兜底链不得含糊改写 ——
+  // 此前 cindy/claude-sonnet-5 被加 [1m] 而 cindy/claude-opus-5 透传,同一
+  // Provider 两个模型 wire id 形态不对称,被上游白名单逐一 403。
+  it('passes namespaced custom-provider ids through verbatim and symmetrically', () => {
+    expect(toSdkModelString('cindy/claude-sonnet-5')).toBe('cindy/claude-sonnet-5');
+    expect(toSdkModelString('cindy/claude-opus-5')).toBe('cindy/claude-opus-5');
+    expect(toSdkModelString('winky/claude-sonnet-4-6')).toBe('winky/claude-sonnet-4-6');
+    expect(toSdkModelString('winky/claude-opus-4-8')).toBe('winky/claude-opus-4-8');
+    // 目录窗口已知时仍按窗口决定 [1m](与命名空间无关)。
+    expect(toSdkModelString('cindy/claude-sonnet-5', 1_000_000)).toBe('cindy/claude-sonnet-5[1m]');
+    expect(toSdkModelString('cindy/claude-opus-5', 200_000)).toBe('cindy/claude-opus-5');
+  });
+
   it('never collapses a sonnet model to the bare drifting alias', () => {
     for (const model of ['claude-sonnet-5', 'claude-sonnet-4-6', 'claude-sonnet-9-9']) {
       const sdk = toSdkModelString(model);

--- a/packages/maker-core/src/agents/claude-code/index.ts
+++ b/packages/maker-core/src/agents/claude-code/index.ts
@@ -209,6 +209,29 @@ export function toSdkModelString(model: string, contextWindow?: number | null): 
 
 /** 目录窗口未知时的兜底映射链(与窗口规则引入前一致;haiku 日期重写已移除,见函数头)。 */
 function legacyToSdkModelString(model: string): string {
+  // #3764:含命名空间前缀(provider/…)的 id 是自定义/网关 Provider 的路由键,不属于
+  // 本兜底链的官方裸 id 知识范围 —— 除下面显式列出的已知命名空间条目外一律逐字透传。
+  // 此前 includes('sonnet') 的含糊匹配会把 `cindy/claude-sonnet-5` 改写成 `…[1m]`,
+  // 而 `cindy/claude-opus-5` 透传:同一自定义 Provider 的两个模型 wire id 形态不
+  // 对称,被上游按白名单逐一 403(官方 Claude Code CLI 对同上游是逐字发送、两个
+  // 模型均可用)。窗口已知的路径不经过本函数,不受影响。
+  if (model.includes('/')) {
+    // 折扣GPT(codex/* 经折扣网关)真实上下文上限远低于 1M(catalog cc 侧 = 272k),
+    // 绝不能带 [1m]: cc-code 的 has1mContext 只要在 model 串里见到 [1m] 就把窗口判成
+    // 1M(getContextWindowForModel 直接 return 1_000_000), 撑大 auto-compact 阈值 →
+    // 对话冲过折扣网关真实上限(~24 万 token)后空转, 用户侧表现为会话"假死"。
+    // 路由不依赖 [1m]: isAnthropicWireModel 只按 claude-/sonnet/opus/haiku/fable 前缀
+    // 判定, codex/ 前缀始终走 provider 网关, 去掉 [1m] 不改变路由判定;
+    // 真实窗口由 catalog 经 translator 窗口口径注入(=272k)。
+    if (model === 'codex/gpt-5.5' || model === 'codex/gpt-5.4') return model;
+    if (model === 'codex/gpt-5.6-sol' || model === 'codex/gpt-5.6-terra') return model;
+    // DeepSeek / GLM 的 [1m] 是历史兼容路由后缀; 上下文大小另走 maker capabilities。
+    if (model === 'deepseek/deepseek-v4-pro' || model === 'deepseek/deepseek-v4-flash') {
+      return `${model}[1m]`;
+    }
+    if (model === 'z-ai/glm-5.2') return `${model}[1m]`;
+    return model;
+  }
   if (model === 'claude-opus-5') return 'claude-opus-5[1m]';
   if (model.includes('opus-4-8')) return 'claude-opus-4-8[1m]';
   if (model.includes('opus-4-7')) return 'claude-opus-4-7[1m]';
@@ -220,26 +243,12 @@ function legacyToSdkModelString(model: string): string {
   // 目录内 sonnet 系列均为 1M 窗口(catalog providers.json),统一走 [1m] beta 通道。
   if (model === 'claude-sonnet-5') return 'claude-sonnet-5[1m]';
   if (model === 'claude-sonnet-4-6') return 'claude-sonnet-4-6[1m]';
-  // 兜底:未来新增 sonnet 型号在此映射更新前,也透传显式 id 而非裸别名。
+  // 兜底:未来新增裸 sonnet 型号在此映射更新前,也透传显式 id 而非裸别名。
   if (model.includes('sonnet')) return `${model}[1m]`;
   // 官方 gpt-5.5 / gpt-5.4 真实支持 1M, 走 [1m] beta 通道。
   if (model === 'gpt-5.5' || model === 'gpt-5.4') return `${model}[1m]`;
-  // 折扣GPT(codex/* 经折扣网关)真实上下文上限远低于 1M(catalog cc 侧 = 272k),
-  // 绝不能带 [1m]: cc-code 的 has1mContext 只要在 model 串里见到 [1m] 就把窗口判成 1M
-  // (getContextWindowForModel 直接 return 1_000_000), 撑大 auto-compact 阈值 →
-  // 对话冲过折扣网关真实上限(~24 万 token)后空转, 用户侧表现为会话"假死"。
-  // 路由不依赖 [1m]: isAnthropicWireModel 只按 claude-/sonnet/opus/haiku/fable 前缀判定,
-  // codex/ 前缀始终走 provider 网关、不命中 Anthropic wire, 去掉 [1m] 不改变路由判定;
-  // 真实窗口由 catalog 经 translator 窗口口径注入(=272k)。
-  if (model === 'codex/gpt-5.5' || model === 'codex/gpt-5.4') return model;
-  if (model === 'codex/gpt-5.6-sol' || model === 'codex/gpt-5.6-terra') return model;
-  // DeepSeek 的 [1m] 是历史兼容路由后缀; 上下文大小另走 maker capabilities。
-  if (
-    model === 'deepseek/deepseek-v4-pro' ||
-    model === 'deepseek/deepseek-v4-flash' ||
-    model === 'deepseek-v4-flash'
-  ) return `${model}[1m]`;
-  if (model === 'z-ai/glm-5.2') return `${model}[1m]`;
+  // DeepSeek 裸 id 的 [1m] 同上为历史兼容路由后缀。
+  if (model === 'deepseek-v4-flash') return `${model}[1m]`;
   return model;
 }
 


### PR DESCRIPTION
## 这次改了什么

### 摘要

fix #3764。自定义 Anthropic 兼容 Provider(非 Cindy 网关)下,同一把 key 在官方 Claude Code CLI 里 Sonnet 5 / Opus 5 都能用,在 Cindy 里两个模型轮流 403。根因在目录窗口未知时的兜底映射链 `legacyToSdkModelString`:`model.includes('sonnet')` 的含糊匹配把**任意**含 sonnet 的 id(含命名空间形式 `cindy/claude-sonnet-5`)都追加 `[1m]`,而 `cindy/claude-opus-5` 不命中任何分支、逐字透传——同一 Provider 的两个模型 wire id 形态不对称,上游白名单按收到的字符串逐一拒绝;UI 仍显示「Sonnet 5 / Opus 5」,改写对用户不可见。

修复:含命名空间前缀(`provider/…`)的 id 是自定义/网关 Provider 的**路由键**,不属于兜底链的官方裸 id 知识范围——除既有显式命名空间条目(`codex/*` 不带 `[1m]`、`deepseek/*` 与 `z-ai/glm-5.2` 的历史兼容后缀)外,一律逐字透传,与官方 CLI 行为一致、Sonnet/Opus 对称。裸 id 兜底链(官方 sonnet/opus/fable/gpt 映射)与窗口已知路径(`toSdkModelString` 按目录 contextWindow 决定 `[1m]`,含 #3497 方向的自定义 Provider 窗口)行为不变。

### 变更类型

- [ ] `feat` 新功能
- [x] `fix` 缺陷修复
- [ ] `refactor` / `perf` 重构或性能优化
- [ ] `docs` / `test` / `chore` 文档、测试或工程维护
- [ ] 其他:

### 范围

- 关联 Issue / 需求:#3764
- 本 PR 包含:legacyToSdkModelString 的命名空间 id 透传分支(既有命名空间条目原样保留)+ 对称性回归
- 明确不包含:窗口已知路径的 [1m] 语义(不变);自定义 Provider 的 contextWindow 传递(#3497 在途,互补不冲突)
- 用户可见变化:自定义 Anthropic 兼容 Provider 的命名空间模型 id 逐字发送,Sonnet/Opus 对称可用
- 是否存在 breaking change:无(官方裸 id、codex/deepseek/z-ai 显式条目、窗口已知路径均逐字节不变;唯一行为变化是「未知命名空间 id 不再被含糊加 [1m]」——即 issue 所报缺陷本身)

### UI 变化

无 UI 变化。

## 怎么验证的

### 自动验证

```
pnpm --dir packages/maker-core exec vitest run src/agents/claude-code/__tests__/models.test.ts
```
结果:14 过(新增 1 条对称性回归:cindy/claude-sonnet-5 与 cindy/claude-opus-5 均逐字透传;winky/claude-sonnet-4-6 与 winky/claude-opus-4-8 同;窗口已知时仍按窗口决定 [1m]。既有官方裸 id 映射、codex/deepseek/z-ai 条目、防漂移别名用例全部照过)。反证:stash index.ts 后恰好该条新用例失败,其余 13 条照过。

maker-core typecheck 过。

```
pnpm test:unit:related
```
结果:exit 0,全过(零失败)。

### 手工验证

无(改写语义由单测穷举锁定;官方 CLI 的逐字发送行为以 issue 提报人实测为据)。

### 未执行的验证

- 未对真实自定义 Anthropic 兼容上游端到端验证(需要提报人环境的上游白名单;wire id 生成语义已由单测覆盖)。

## 风险

### 风险分类

低风险。命名空间分支只透传不改写;所有既有显式条目原样迁移进该分支(输出逐字节不变,有回归锁定);裸 id 链不动。

### 影响与回滚

影响面:maker-core 的 Claude Code SDK 模型串生成(仅目录窗口未知的兜底路径)。远程与移动端适配:模型串在宿主 maker-core 生成后随会话下发,远端会话同样受益,无需额外适配。回滚:revert 单 commit,无 schema 变更。

### 提交前检查

- [x] 已运行定向单测(含反证)、typecheck 与 `pnpm test:unit:related`(失败项已逐一归因)
- [x] commit 带 DCO 签名(Signed-off-by: ficowang <fico@xd.com>)
- [x] diff 聚焦单一问题,无无关改动
