### PR TITLE
fix(desktop): 修复页内查找打断中文输入法

### DIFF
--- a/apps/desktop/src/renderer/components/find-in-page/FindInPageBar.tsx
+++ b/apps/desktop/src/renderer/components/find-in-page/FindInPageBar.tsx
@@ -25,6 +25,10 @@ export function FindInPageBar() {
   const [matches, setMatches] = useState(0);
   const [active, setActive] = useState(0);
   const inputRef = useRef<HTMLInputElement>(null);
+  const isComposingRef = useRef(false);
+  // Chromium may emit the final input/change after compositionend. Remember
+  // that value so the committed IME text starts exactly one native search.
+  const compositionCommitRef = useRef<string | null>(null);
   // Track the requestId returned by `findInPage` so we can ignore stale
   // result events from an earlier query (Chromium fires `found-in-page`
   // multiple times per request as the search progresses).
@@ -53,6 +57,8 @@ export function FindInPageBar() {
     setText('');
     setMatches(0);
     setActive(0);
+    isComposingRef.current = false;
+    compositionCommitRef.current = null;
     lastRequestIdRef.current = null;
     window.electronAPI.stopFindInPage('clearSelection');
   }, []);
@@ -73,8 +79,8 @@ export function FindInPageBar() {
     return true;
   });
 
-  // Run a search. `findNext=true` walks within the current term; false starts
-  // a fresh search (used when the text changes).
+  // Electron uses `findNext=true` to start a new request and false to continue
+  // walking the current search session.
   const runSearch = useCallback(
     async (nextText: string, opts: { forward?: boolean; findNext?: boolean } = {}) => {
       if (!nextText) {
@@ -87,7 +93,7 @@ export function FindInPageBar() {
       const id = await window.electronAPI.findInPage({
         text: nextText,
         forward: opts.forward ?? true,
-        findNext: opts.findNext ?? false,
+        findNext: opts.findNext ?? true,
       });
       if (typeof id === 'number') {
         lastRequestIdRef.current = id;
@@ -123,16 +129,39 @@ export function FindInPageBar() {
         placeholder={t('findInPage.placeholder')}
         onChange={(e) => {
           const next = e.target.value;
+          const nativeIsComposing =
+            'isComposing' in e.nativeEvent && e.nativeEvent.isComposing === true;
           setText(next);
-          void runSearch(next, { forward: true, findNext: false });
+          if (isComposingRef.current || nativeIsComposing) return;
+          if (compositionCommitRef.current !== null) {
+            const committed = compositionCommitRef.current;
+            compositionCommitRef.current = null;
+            if (next === committed) return;
+          }
+          void runSearch(next, { forward: true, findNext: true });
+        }}
+        onCompositionStart={() => {
+          isComposingRef.current = true;
+          compositionCommitRef.current = null;
+        }}
+        onCompositionEnd={(e) => {
+          const committed = e.currentTarget.value;
+          isComposingRef.current = false;
+          compositionCommitRef.current = committed;
+          setText(committed);
+          void runSearch(committed, { forward: true, findNext: true });
         }}
         onKeyDown={(e) => {
           if (e.key === 'Escape') {
             e.preventDefault();
             close();
-          } else if (e.key === 'Enter' && !e.nativeEvent.isComposing) {
+          } else if (
+            e.key === 'Enter' &&
+            !e.nativeEvent.isComposing &&
+            e.nativeEvent.keyCode !== 229
+          ) {
             e.preventDefault();
-            if (text) void runSearch(text, { forward: !e.shiftKey, findNext: true });
+            if (text) void runSearch(text, { forward: !e.shiftKey, findNext: false });
           }
         }}
         className={cn(
@@ -152,7 +181,7 @@ export function FindInPageBar() {
         type="button"
         aria-label={t('findInPage.previous')}
         disabled={!text || matches === 0}
-        onClick={() => void runSearch(text, { forward: false, findNext: true })}
+        onClick={() => void runSearch(text, { forward: false, findNext: false })}
         className={cn(
           'flex h-6 w-6 items-center justify-center rounded',
           'hover:bg-titlebar-button-hover',
@@ -166,7 +195,7 @@ export function FindInPageBar() {
         type="button"
         aria-label={t('findInPage.next')}
         disabled={!text || matches === 0}
-        onClick={() => void runSearch(text, { forward: true, findNext: true })}
+        onClick={() => void runSearch(text, { forward: true, findNext: false })}
         className={cn(
           'flex h-6 w-6 items-center justify-center rounded',
           'hover:bg-titlebar-button-hover',

--- a/apps/desktop/src/renderer/components/find-in-page/__tests__/FindInPageBar.test.tsx
+++ b/apps/desktop/src/renderer/components/find-in-page/__tests__/FindInPageBar.test.tsx
@@ -1,0 +1,118 @@
+// @vitest-environment jsdom
+
+import { act, cleanup, fireEvent, render, waitFor } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+const shortcut = vi.hoisted(() => ({ handler: null as null | (() => boolean) }));
+
+vi.mock('@/hooks/useAppShortcut', () => ({
+  useAppShortcut: (_id: string, handler: () => boolean) => {
+    shortcut.handler = handler;
+  },
+}));
+
+vi.mock('react-i18next', () => ({
+  useTranslation: () => ({ t: (key: string) => key }),
+}));
+
+import { FindInPageBar } from '../FindInPageBar';
+
+describe('FindInPageBar', () => {
+  const findInPage = vi.fn<(params: {
+    text: string;
+    forward?: boolean;
+    findNext?: boolean;
+  }) => Promise<number>>();
+  const stopFindInPage = vi.fn();
+
+  beforeEach(() => {
+    findInPage.mockReset();
+    findInPage.mockResolvedValue(1);
+    stopFindInPage.mockReset();
+    shortcut.handler = null;
+    (window as unknown as { electronAPI: unknown }).electronAPI = {
+      findInPage,
+      stopFindInPage,
+      onFindInPageResult: vi.fn(() => vi.fn()),
+    };
+  });
+
+  afterEach(cleanup);
+
+  async function openFindBar() {
+    const view = render(<FindInPageBar />);
+    expect(shortcut.handler).not.toBeNull();
+    await act(async () => {
+      shortcut.handler?.();
+    });
+    return { view, input: view.getByRole('textbox') as HTMLInputElement };
+  }
+
+  it('waits for IME composition to finish before searching the committed text', async () => {
+    const { input } = await openFindBar();
+
+    fireEvent.compositionStart(input);
+    fireEvent.change(input, { target: { value: 'n' } });
+    fireEvent.change(input, { target: { value: 'ni' } });
+    expect(findInPage).not.toHaveBeenCalled();
+
+    fireEvent.change(input, { target: { value: '你' } });
+    fireEvent.compositionEnd(input);
+
+    await waitFor(() => {
+      expect(findInPage).toHaveBeenCalledTimes(1);
+      expect(findInPage).toHaveBeenCalledWith({ text: '你', forward: true, findNext: true });
+    });
+
+    // Some Chromium versions emit one final change after compositionend.
+    fireEvent.change(input, { target: { value: '你' } });
+    expect(findInPage).toHaveBeenCalledTimes(1);
+  });
+
+  it('keeps IME composition intact after an earlier search', async () => {
+    const { input } = await openFindBar();
+
+    fireEvent.change(input, { target: { value: 'a' } });
+    await waitFor(() => expect(findInPage).toHaveBeenCalledTimes(1));
+    findInPage.mockClear();
+
+    fireEvent.compositionStart(input);
+    fireEvent.change(input, { target: { value: 'z' } });
+    fireEvent.change(input, { target: { value: 'zhong' } });
+    expect(findInPage).not.toHaveBeenCalled();
+    fireEvent.change(input, { target: { value: '中' } });
+    fireEvent.compositionEnd(input);
+
+    await waitFor(() =>
+      expect(findInPage).toHaveBeenCalledWith({ text: '中', forward: true, findNext: true }),
+    );
+  });
+
+  it('continues the current Electron search session for Enter navigation', async () => {
+    const { input } = await openFindBar();
+
+    fireEvent.change(input, { target: { value: 'term' } });
+    await waitFor(() => expect(findInPage).toHaveBeenCalledTimes(1));
+    findInPage.mockClear();
+
+    fireEvent.keyDown(input, { key: 'Enter' });
+    expect(findInPage).toHaveBeenCalledWith({ text: 'term', forward: true, findNext: false });
+    fireEvent.keyDown(input, { key: 'Enter', shiftKey: true });
+    expect(findInPage).toHaveBeenLastCalledWith({
+      text: 'term',
+      forward: false,
+      findNext: false,
+    });
+  });
+
+  it('does not treat a Windows IME confirmation key as find-next', async () => {
+    const { input } = await openFindBar();
+
+    fireEvent.change(input, { target: { value: 'term' } });
+    await waitFor(() => expect(findInPage).toHaveBeenCalledTimes(1));
+    findInPage.mockClear();
+
+    fireEvent.keyDown(input, { key: 'Enter', keyCode: 229 });
+    expect(findInPage).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## 这次改了什么

### 摘要

修复 Desktop 页内查找在中文输入法组合输入期间提前触发原生查找、导致候选输入被截断的问题。同时纠正 Electron `findNext` 参数方向，确保文本变化开启新查找会话，Enter 和前后按钮在当前会话中导航。

### 变更类型

- [ ] `feat` 新功能
- [x] `fix` 缺陷修复
- [ ] `refactor` / `perf` 重构或性能优化
- [ ] `docs` / `test` / `chore` 文档、测试或工程维护
- [ ] 其他：

### 范围

- 关联 Issue / 需求：Fixes #3762
- 本 PR 包含：组合输入期间暂停原生查找；组合结束后只查询一次最终文本；兼容 Windows IME `keyCode 229`；修正新查询与继续查找的 `findNext` 参数；补充组件回归测试。
- 明确不包含：查找范围、高亮样式、计数展示和 IPC 契约调整。
- 用户可见变化：使用微软拼音等输入法时，中文候选组合不再被页内查找提前打断；Enter、Shift+Enter 和前后按钮继续按现有方式导航匹配项。
- 是否存在 breaking change：无。

### UI 变化

无视觉或文案变化，仅修复查找输入框的 IME 交互时序。

- 引用的设计规范：`docs/design-rules/DESIGN.md` §4 Inputs。本次保留既有输入框布局、语义 token、焦点和键盘交互，只确保组合输入完成后再执行查找；Light / Dark 样式均未改变。

## 怎么验证的

### 自动验证

```text
pnpm test:unit:related
结果：通过（Desktop related 2）。

pnpm --filter desktop run --if-present typecheck
结果：通过。

pnpm check:dco -- --base origin/main
结果：通过（1 commit signed off）。
```

### 手工验证

未执行。

### 未执行的验证

- 未在 Windows 实机使用微软拼音全拼、双拼验证，建议合并前确认候选词可完整生成、输入框焦点稳定、最终中文词高亮和计数正常。
- 未在 macOS 实机验证；组合事件处理使用标准 React / DOM 事件，Windows 专属 `keyCode 229` 仅作为额外保护。
- 未单独进行 Light / Dark 模式目检；本次没有样式变化。

## 风险

### 风险分类

- [x] 无已知风险
- [ ] SQLite / migration
- [ ] system prompt
- [ ] 协议兼容
- [ ] 权限 / 安全 / 用户数据
- [ ] 存量插件兼容（批准状态 / 指纹 / manifest 校验 / 安装布局 / 包格式）
- [ ] 原生层 / fingerprint / OTA
- [ ] 跨平台差异
- [ ] 其他：

### 影响与回滚

- 影响范围：仅 Desktop 全局页内查找栏的输入与匹配项导航。
- 回滚 / 降级方式：回滚本提交即可；不涉及数据迁移、持久化或协议变化。

### 提交前检查

- [x] 已 review 完整 diff
- [x] 每个 commit 都带 DCO 签名（`git commit -s`，见 [DCO](../DCO)）
- [x] UI 改动已在「UI 变化」注明引用的设计规范章节（不涉及 UI 则跳过）
- [x] 未提交凭证、令牌或授权文件
- [x] 已补充必要文档
- [x] 已确认测试结果或说明未执行原因
