### PR TITLE
test(search): 锁定被控端按时间筛选

### DIFF
--- a/apps/desktop/src/main/localDb/__tests__/conversationSearch.test.ts
+++ b/apps/desktop/src/main/localDb/__tests__/conversationSearch.test.ts
@@ -1,7 +1,23 @@
 import { readFileSync } from 'node:fs';
 import { resolve } from 'node:path';
 
-import { describe, expect, it } from 'vitest';
+import Database from 'better-sqlite3';
+import { drizzle } from 'drizzle-orm/better-sqlite3';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+import type { DbClient } from '../client/DbClient.js';
+import { clearCurrentDbClient, setCurrentDbClient } from '../client/current.js';
+import * as schema from '../schema.js';
+
+const mocks = vi.hoisted(() => ({
+  searchChatHistoryHybrid: vi.fn(),
+}));
+
+vi.mock('../chatHistorySearch.js', () => ({
+  searchChatHistoryHybrid: mocks.searchChatHistoryHybrid,
+}));
+
+import { searchConversations } from '../conversationSearch.js';
 
 const conversationSearchSource = readFileSync(
   resolve(__dirname, '..', 'conversationSearch.ts'),
@@ -46,20 +62,149 @@ describe('conversationSearch source invariants', () => {
     );
   });
 
-  it('narrows keyword search by recent activity in SQLite before matching titles or content', () => {
-    expect(conversationSearchSource).toContain('const activityCond = activityCutoff === null');
-    expect(conversationSearchSource).toContain('gte(sessions.updatedAt, activityCutoff)');
-    expect(conversationSearchSource).toContain('gte(sessions.userSendAt, activityCutoff)');
-    expect(conversationSearchSource).toContain('workerCond,\n      activityCond,');
-    expect(conversationSearchSource.indexOf('listSearchableSessions(filters)')).toBeLessThan(
-      conversationSearchSource.indexOf('const titleMatches = sessionRows'),
-    );
-    expect(conversationSearchSource).toContain('sessionActivityFromMs: activityCutoff');
-  });
-
   it('keeps FTS hits only when visible text matches, not merely because preview is non-empty', () => {
     expect(conversationSearchSource).toContain('visibleTextMatchesMessagesFtsQuery');
     expect(conversationSearchSource).toContain('preview.keywordMatchedVisibleText');
     expect(conversationSearchSource).not.toContain('preview.preview.length === 0 ? null : hit.ftsRank');
+  });
+});
+
+function createSearchDb(): Database.Database {
+  const db = new Database(':memory:');
+  db.exec(`
+    CREATE TABLE sessions (
+      id TEXT PRIMARY KEY,
+      title TEXT NOT NULL DEFAULT 'New Maker',
+      working_dir TEXT,
+      workspace_kind TEXT NOT NULL DEFAULT 'project',
+      model TEXT NOT NULL DEFAULT 'claude-sonnet-4-6',
+      effort TEXT NOT NULL DEFAULT 'high',
+      permission_mode TEXT NOT NULL DEFAULT 'ask',
+      status TEXT NOT NULL DEFAULT 'active',
+      sdk_session_id TEXT,
+      total_token_usage INTEGER NOT NULL DEFAULT 0,
+      total_cost_usd REAL NOT NULL DEFAULT 0,
+      total_cost_amount REAL NOT NULL DEFAULT 0,
+      total_cost_currency TEXT,
+      total_cost_is_approximate INTEGER NOT NULL DEFAULT 0,
+      context_tokens INTEGER NOT NULL DEFAULT 0,
+      context_window INTEGER NOT NULL DEFAULT 0,
+      fast_mode INTEGER NOT NULL DEFAULT 0,
+      plan_mode_enabled INTEGER NOT NULL DEFAULT 0,
+      cleared_at INTEGER,
+      pinned_at INTEGER,
+      summary TEXT,
+      provider_id TEXT,
+      user_send_at INTEGER,
+      agent_kind TEXT NOT NULL DEFAULT 'cc',
+      orca_role TEXT,
+      parent_session_id TEXT,
+      forked_at_message_id TEXT,
+      worktree_path TEXT,
+      source TEXT NOT NULL DEFAULT 'desktop',
+      feishu_open_id TEXT,
+      feishu_bot_app_id TEXT,
+      im_bot_context_id TEXT,
+      im_user_id TEXT,
+      used_project_context INTEGER NOT NULL DEFAULT 0,
+      codex_history_has_product_prompt INTEGER,
+      codex_plan_json TEXT,
+      extra_dirs TEXT NOT NULL DEFAULT '[]',
+      writable_dirs TEXT NOT NULL DEFAULT '[]',
+      remote_host_id TEXT,
+      active_turn_started_at INTEGER,
+      active_turn_pid INTEGER,
+      last_turn_ended_at INTEGER,
+      list_preview TEXT,
+      list_preview_role TEXT,
+      list_message_count INTEGER,
+      created_at INTEGER NOT NULL,
+      updated_at INTEGER NOT NULL
+    );
+    CREATE TABLE messages (
+      id TEXT PRIMARY KEY,
+      client_id TEXT NOT NULL,
+      session_id TEXT NOT NULL,
+      role TEXT NOT NULL,
+      content TEXT NOT NULL,
+      tool_use_id TEXT,
+      agent_meta TEXT,
+      agent_kind TEXT,
+      created_at INTEGER NOT NULL,
+      rewind_at INTEGER
+    );
+  `);
+  return db;
+}
+
+function makeSearchDbClient(db: Database.Database): DbClient {
+  return {
+    drizzle: drizzle(db, { schema }),
+  } as unknown as DbClient;
+}
+
+function insertSearchSession(
+  db: Database.Database,
+  id: string,
+  updatedAt: number,
+  userSendAt: number | null,
+): void {
+  db.prepare(
+    `INSERT INTO sessions (id, title, status, source, agent_kind, user_send_at, created_at, updated_at)
+     VALUES (?, ?, 'active', 'desktop', 'cc', ?, ?, ?)`,
+  ).run(id, `needle ${id}`, userSendAt, updatedAt, updatedAt);
+}
+
+afterEach(() => {
+  clearCurrentDbClient();
+  vi.useRealTimers();
+  mocks.searchChatHistoryHybrid.mockReset();
+});
+
+describe('conversationSearch recent activity SQL filtering', () => {
+  it('filters the SQLite session candidates before title and content matching', async () => {
+    const db = createSearchDb();
+    const client = makeSearchDbClient(db);
+    setCurrentDbClient(client, 'test-user');
+    vi.useFakeTimers();
+    const now = Date.parse('2026-09-02T00:00:00.000Z');
+    vi.setSystemTime(now);
+    mocks.searchChatHistoryHybrid.mockResolvedValue({
+      hits: [],
+      sessions: {},
+      vectorUsed: false,
+      vectorSkipReason: null,
+      nextOffset: null,
+      hasMore: false,
+      poolSize: 0,
+      poolCapped: false,
+    });
+
+    try {
+      const day = 24 * 60 * 60 * 1000;
+      insertSearchSession(db, 'updated-recently', now - day, null);
+      insertSearchSession(db, 'sent-recently', now - 10 * day, now - day);
+      insertSearchSession(db, 'stale', now - 10 * day, now - 10 * day);
+
+      const response = await searchConversations({
+        query: 'needle',
+        semanticMode: 'keyword',
+        filters: { lastActivity: '3d' },
+      });
+
+      expect(response.results.map((result) => result.session.id).sort()).toEqual([
+        'updated-recently',
+        'sent-recently',
+      ].sort());
+      expect(mocks.searchChatHistoryHybrid).toHaveBeenCalledWith(
+        expect.objectContaining({
+          sessionIds: ['updated-recently', 'sent-recently'],
+          sessionActivityFromMs: now - 3 * day,
+        }),
+      );
+    } finally {
+      clearCurrentDbClient(client);
+      db.close();
+    }
   });
 });

--- a/apps/desktop/src/main/localDb/__tests__/conversationSearch.test.ts
+++ b/apps/desktop/src/main/localDb/__tests__/conversationSearch.test.ts
@@ -46,6 +46,17 @@ describe('conversationSearch source invariants', () => {
     );
   });
 
+  it('narrows keyword search by recent activity in SQLite before matching titles or content', () => {
+    expect(conversationSearchSource).toContain('const activityCond = activityCutoff === null');
+    expect(conversationSearchSource).toContain('gte(sessions.updatedAt, activityCutoff)');
+    expect(conversationSearchSource).toContain('gte(sessions.userSendAt, activityCutoff)');
+    expect(conversationSearchSource).toContain('workerCond,\n      activityCond,');
+    expect(conversationSearchSource.indexOf('listSearchableSessions(filters)')).toBeLessThan(
+      conversationSearchSource.indexOf('const titleMatches = sessionRows'),
+    );
+    expect(conversationSearchSource).toContain('sessionActivityFromMs: activityCutoff');
+  });
+
   it('keeps FTS hits only when visible text matches, not merely because preview is non-empty', () => {
     expect(conversationSearchSource).toContain('visibleTextMatchesMessagesFtsQuery');
     expect(conversationSearchSource).toContain('preview.keywordMatchedVisibleText');

--- a/apps/desktop/src/main/localDb/__tests__/conversationSearchIpc.test.ts
+++ b/apps/desktop/src/main/localDb/__tests__/conversationSearchIpc.test.ts
@@ -58,6 +58,31 @@ describe('local-db:conversations:search — agentKind=pi', () => {
   });
 });
 
+describe('local-db:conversations:search — lastActivity', () => {
+  it('forwards the recent-activity window with a keyword query', async () => {
+    await handler()(null, {
+      query: 'needle',
+      filters: { lastActivity: '3d' },
+    });
+
+    expect(h.searchConversations).toHaveBeenCalledWith(
+      expect.objectContaining({
+        query: 'needle',
+        filters: expect.objectContaining({ lastActivity: '3d' }),
+      }),
+    );
+  });
+
+  it('does not turn a time filter into an empty-keyword search', async () => {
+    const invoke = handler();
+    await expect(invoke(null, {
+      query: '',
+      filters: { lastActivity: '3d' },
+    })).rejects.toThrow();
+    expect(h.searchConversations).not.toHaveBeenCalled();
+  });
+});
+
 describe('local-db:conversations:search — workingDirs 透传', () => {
   it('keeps filters.workingDirs so project search is not widened to all sessions', async () => {
     await handler()(null, {


### PR DESCRIPTION
## 这次改了什么

### 摘要

补充任务搜索的回归测试，明确“关键词 + 最近活动时间”必须由 PC 在数据库阶段筛选。空关键词不会触发搜索。

### 变更类型

- [ ] `feat` 新功能
- [ ] `fix` 缺陷修复
- [ ] `refactor` / `perf` 重构或性能优化
- [x] `docs` / `test` / `chore` 文档、测试或工程维护
- [ ] 其他：

### 范围

- 关联 Issue / 需求：Slack 需求：任务搜索按时间范围筛选
- 本 PR 包含：锁定 PC SQLite 在标题搜索和内容搜索前应用 `lastActivity` 条件；锁定 IPC 只接受带关键词的搜索请求。
- 明确不包含：不新增空关键词筛选；不改变任务列表缓存、数据库 schema 或移动端原生配置。
- 用户可见变化：无新增界面变化；已有搜索在选择时间范围后按 PC 数据库结果返回。
- 是否存在 breaking change：无。

### UI 变化

- 不涉及：本 PR 仅增加搜索链路回归测试，没有 UI、布局、样式或文案改动。
- 引用的设计规范：不涉及。

## 怎么验证的

### 自动验证

```text
pnpm test:unit:related
结果：通过；Desktop、Mobile 及全部适用 packages 均 PASS。

pnpm --filter desktop exec vitest run src/main/localDb/__tests__/conversationSearch.test.ts src/main/localDb/__tests__/conversationSearchIpc.test.ts
结果：16 项通过。

pnpm --filter desktop exec vitest run src/renderer/lib/__tests__/conversationSearchFanout.test.ts src/renderer/features/cc-agent/sidebar/__tests__/conversationSearchSort.test.tsx
结果：35 项通过。

pnpm --filter mobile exec vitest run src/__tests__/conversationSearch.test.ts
结果：17 项通过。

pnpm --filter desktop run --if-present typecheck
结果：通过。

pnpm --filter mobile run --if-present typecheck
结果：通过。

pnpm check:dco
结果：通过。
```

### 手工验证

不涉及。

### 未执行的验证

无。

## 风险

### 风险分类

- [ ] 无已知风险
- [x] SQLite / migration
- [ ] system prompt
- [ ] 协议兼容
- [ ] 权限 / 安全 / 用户数据
- [ ] 存量插件兼容（批准状态 / 指纹 / manifest 校验 / 安装布局 / 包格式）
- [ ] 原生层 / fingerprint / OTA
- [ ] 跨平台差异
- [ ] 其他：

### 影响与回滚

- 影响范围：仅搜索查询的回归约束；不改变 schema。正常在线搜索由目标 PC 的 SQLite 先按活动时间收窄候选，再执行标题/内容匹配；旧版本或离线回退仍保留既有客户端兜底。
- 回滚 / 降级方式：回滚本 PR 即可；无数据迁移。

### 提交前检查

- [x] 已 review 完整 diff
- [x] 每个 commit 都带 DCO 签名（`git commit -s`，见 [DCO](../DCO)）
- [x] UI 改动已在「UI 变化」注明引用的设计规范章节（不涉及 UI）
- [x] 未提交凭证、令牌或授权文件
- [x] 已补充必要文档（不需要）
- [x] 已确认测试结果或说明未执行原因
