### PR TITLE
fix(auth): 登录准备态失败或超时时解锁到重试

### DIFF
--- a/apps/desktop/src/main/authStartupGate.ts
+++ b/apps/desktop/src/main/authStartupGate.ts
@@ -1,5 +1,7 @@
 import { AuthApiError } from '@cindy/auth-client';
 
+import { LOGIN_PREPARING_UNLOCK_TIMEOUT_MS } from '../shared/authIpc';
+
 /**
  * 冷启动 auth 流程的「限时等待」编排 —— 与 Electron / 网络层解耦的纯逻辑,
  * 供 authManager 的 `initialize()`(splash)与 `loadLoginProviders()`(登录准备态)
@@ -83,7 +85,7 @@ export async function awaitWithStartupTimeout<T>(
  * initialize 完成、GuestRoute 放行之后才出现的。这里复用同一把闸,时限更保守
  * (30s),超时后走既有 error 步(「暂时无法登录」+ 重试);不 abort 在途 getProviders。
  */
-export const LOGIN_PREPARING_GATE_TIMEOUT_MS = 30_000;
+export const LOGIN_PREPARING_GATE_TIMEOUT_MS = LOGIN_PREPARING_UNLOCK_TIMEOUT_MS;
 
 export interface PreparingGateLog {
   info: (...args: unknown[]) => void;

--- a/apps/desktop/src/renderer/contexts/AuthContext.tsx
+++ b/apps/desktop/src/renderer/contexts/AuthContext.tsx
@@ -53,6 +53,7 @@ import { rememberSsoOrgIdentifier } from '@/state/ssoOrgHistory';
 import { setDeferredUiAssignmentOwner } from '@/features/cc-agent/deferredUiAssignment';
 import { invalidateProvidersSnapshot } from '@/lib/providersSnapshotStore';
 import { preloadLocalCatalogSnapshot } from '@/lib/localCatalogSnapshot';
+import { awaitDesktopLoginStateLoad } from '../../shared/authIpc';
 import { getDataOwnerGeneration, setDataOwnerGeneration } from './dataOwnerGeneration';
 
 /**
@@ -355,7 +356,12 @@ export function AuthProvider({
   }, [confirm, enableSessionExpiredPrompt, t]);
 
   const loadLoginState = useCallback(async (): Promise<DesktopLoginActionResult> => {
-    const result = await authServiceRef.current!.getLoginState();
+    // preparing 只允许在 load 进行中出现。settle / throw / 30s 超时都必须落到
+    // identifier 或既有 error 步,避免 AUTH_FLOW_SUPERSEDED + state=null 或 IPC
+    // 挂起把「正在连接登录服务」变成永不结束。
+    const result = await awaitDesktopLoginStateLoad(() =>
+      authServiceRef.current!.getLoginState(),
+    );
     setLoginState(result.state);
     return result;
   }, []);

--- a/apps/desktop/src/shared/__tests__/authIpc.test.ts
+++ b/apps/desktop/src/shared/__tests__/authIpc.test.ts
@@ -1,9 +1,12 @@
-import { describe, expect, it } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 import {
+  LOGIN_PREPARING_UNLOCK_TIMEOUT_MS,
+  awaitDesktopLoginStateLoad,
   parseDesktopAccountDeletionConfirmInput,
   parseDesktopAccountKey,
   parseDesktopLoginAction,
+  settleDesktopLoginResult,
 } from '../authIpc';
 
 describe('desktop auth IPC validation', () => {
@@ -185,5 +188,88 @@ describe('parseDesktopAccountDeletionConfirmInput', () => {
         code: '123456',
       }),
     ).toBeNull();
+  });
+});
+
+describe('settleDesktopLoginResult', () => {
+  it('keeps a successful identifier state', () => {
+    const state = {
+      step: 'identifier' as const,
+      providers: {
+        region: 'global' as const,
+        attribution: 'email' as const,
+        email: true,
+        phone: false,
+        social: [],
+      },
+    };
+    expect(settleDesktopLoginResult({ success: true, state })).toEqual({
+      success: true,
+      state,
+    });
+  });
+
+  it('maps a failed null state onto the retryable error step', () => {
+    expect(
+      settleDesktopLoginResult({
+        success: false,
+        code: 'AUTH_FLOW_SUPERSEDED',
+        state: null,
+      }),
+    ).toEqual({
+      success: false,
+      code: 'AUTH_FLOW_SUPERSEDED',
+      state: { step: 'error', code: 'AUTH_FLOW_SUPERSEDED', recoverTo: 'identifier' },
+    });
+  });
+});
+
+describe('awaitDesktopLoginStateLoad', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it('returns a settled identifier before the preparing timeout', async () => {
+    const state = {
+      step: 'identifier' as const,
+      providers: {
+        region: 'global' as const,
+        attribution: 'email' as const,
+        email: true,
+        phone: false,
+        social: [],
+      },
+    };
+    await expect(
+      awaitDesktopLoginStateLoad(async () => ({ success: true, state })),
+    ).resolves.toEqual({ success: true, state });
+  });
+
+  it('unlocks preparing after 30s when getLoginState never settles', async () => {
+    const hung = () => new Promise<never>(() => undefined);
+    const p = awaitDesktopLoginStateLoad(hung);
+    const rejected = expect(p).resolves.toEqual({
+      success: false,
+      code: 'AUTH_SERVICE_UNAVAILABLE',
+      state: { step: 'error', code: 'AUTH_SERVICE_UNAVAILABLE', recoverTo: 'identifier' },
+    });
+    await vi.advanceTimersByTimeAsync(LOGIN_PREPARING_UNLOCK_TIMEOUT_MS - 1);
+    await vi.advanceTimersByTimeAsync(1);
+    await rejected;
+  });
+
+  it('maps a thrown getLoginState onto the retryable error step', async () => {
+    await expect(
+      awaitDesktopLoginStateLoad(async () => {
+        throw new Error('ipc exploded');
+      }),
+    ).resolves.toEqual({
+      success: false,
+      code: 'AUTH_SERVICE_UNAVAILABLE',
+      state: { step: 'error', code: 'AUTH_SERVICE_UNAVAILABLE', recoverTo: 'identifier' },
+    });
   });
 });

--- a/apps/desktop/src/shared/authIpc.ts
+++ b/apps/desktop/src/shared/authIpc.ts
@@ -31,6 +31,67 @@ export type DesktopLoginActionResult =
   | { success: true; state: AuthFlowState }
   | { success: false; code: string; state: AuthFlowState | null };
 
+/**
+ * 登录准备态(「正在连接登录服务」)最多转圈的时长。
+ * main 的 getProviders 闸与 renderer `loadLoginState` 共用,超时后落到既有 error 步。
+ */
+export const LOGIN_PREPARING_UNLOCK_TIMEOUT_MS = 30_000;
+
+export type SettledDesktopLoginActionResult =
+  | { success: true; state: AuthFlowState }
+  | { success: false; code: string; state: AuthFlowState };
+
+export function loginPreparingErrorState(
+  code = 'AUTH_SERVICE_UNAVAILABLE',
+): Extract<AuthFlowState, { step: 'error' }> {
+  return { step: 'error', code, recoverTo: 'identifier' };
+}
+
+/** IPC 失败且 `state == null` 时不得让 renderer 停在 preparing。 */
+export function settleDesktopLoginResult(
+  result: DesktopLoginActionResult,
+): SettledDesktopLoginActionResult {
+  if (result.state) {
+    return result.success
+      ? { success: true, state: result.state }
+      : { success: false, code: result.code, state: result.state };
+  }
+  const code = result.success === false ? result.code : 'AUTH_SERVICE_UNAVAILABLE';
+  return { success: false, code, state: loginPreparingErrorState(code) };
+}
+
+/**
+ * 限时等待 getLoginState。超时或 throw 都落到可重试 error 步,不 abort 在途请求。
+ * 迟到 settle 忽略(与 main 准备态闸一致:只解锁 UI)。
+ */
+export async function awaitDesktopLoginStateLoad(
+  getLoginState: () => Promise<DesktopLoginActionResult>,
+  timeoutMs: number = LOGIN_PREPARING_UNLOCK_TIMEOUT_MS,
+): Promise<SettledDesktopLoginActionResult> {
+  const load = getLoginState().then(settleDesktopLoginResult, () => ({
+    success: false as const,
+    code: 'AUTH_SERVICE_UNAVAILABLE',
+    state: loginPreparingErrorState(),
+  }));
+  if (timeoutMs <= 0) return load;
+
+  let timer: ReturnType<typeof setTimeout> | undefined;
+  const timeout = new Promise<SettledDesktopLoginActionResult>((resolve) => {
+    timer = setTimeout(() => {
+      resolve({
+        success: false,
+        code: 'AUTH_SERVICE_UNAVAILABLE',
+        state: loginPreparingErrorState(),
+      });
+    }, timeoutMs);
+  });
+  try {
+    return await Promise.race([load, timeout]);
+  } finally {
+    if (timer !== undefined) clearTimeout(timer);
+  }
+}
+
 export interface DesktopSavedAccount {
   /** Opaque main-owned identifier. Renderer must not derive realm or membership ids from it. */
   accountKey: string;


### PR DESCRIPTION
## 这次改了什么

### 摘要

登录页「正在连接登录服务」在 `getLoginState` 失败且 `state == null`、IPC 抛错、或超过 30 秒仍未返回时，会一直转圈。主进程 #3605 的 getProviders 闸覆盖不到这些路径。这次让 renderer 的 `loadLoginState` 在 settle / 失败 / 超时后都落到既有的「暂时无法登录」+ 重试，不 abort 在途请求。

### 变更类型

- [x] `fix` 缺陷修复
- [ ] `feat` 新功能
- [ ] `refactor` / `perf` 重构或性能优化
- [ ] `docs` / `test` / `chore` 文档、测试或工程维护
- [ ] 其他：

### 范围

- 关联 Issue / 需求：无；接续 #3605 未覆盖的 renderer 准备态
- 本 PR 包含：共享 `awaitDesktopLoginStateLoad` / `settleDesktopLoginResult`；`AuthContext.loadLoginState` 使用它；main 准备态超时常量与之对齐
- 明确不包含：不改登录页视觉、不 abort getProviders、不改 Ask/permission 超时、不修 maker-core PI 集成测
- 用户可见变化：准备态在失败或 30 秒后进入既有错误页，可点重试
- 是否存在 breaking change：无

### UI 变化

- 引用的设计规范：不涉及：无新视觉/交互/文案。失败后进入登录页既有 error 步（`LoginPage` `login-panel-error`：标题「暂时无法登录」、副标题「登录失败，请稍后重试」、主按钮「重试」、错误文案 `login.errors.AUTH_SERVICE_UNAVAILABLE`）。准备态仍是既有 `login-panel-preparing`。

准备态（改前会一直停在这里）→ 失败/超时后的既有错误页：

```html
<div style="font-family:system-ui;background:#1a1a1a;color:#f5f5f5;padding:24px;display:flex;gap:24px">
  <section style="width:320px;background:#2a2a2a;border-radius:16px;padding:24px 20px">
    <h2 style="margin:0 0 8px;font-size:18px">正在连接登录服务</h2>
    <p style="margin:0 0 24px;color:#9a9a9a;font-size:13px">将为你加载当前区域可用的登录方式</p>
    <div style="width:40px;height:40px;margin:24px auto;border:3px solid #555;border-top-color:#fff;border-radius:50%"></div>
  </section>
  <section style="width:320px;background:#2a2a2a;border-radius:16px;padding:24px 20px">
    <h2 style="margin:0 0 8px;font-size:18px">暂时无法登录</h2>
    <p style="margin:0 0 20px;color:#9a9a9a;font-size:13px">登录失败，请稍后重试</p>
    <button style="width:100%;padding:10px 0;border:0;border-radius:8px;background:#fff;color:#111;font-size:14px">重试</button>
    <p style="margin:12px 0 0;color:#e07070;font-size:13px">登录服务暂不可用</p>
  </section>
</div>
```

## 怎么验证的

### 自动验证

```text
cd /Users/dash/Code/Cindy/cindy-login-preparing-unlock
pnpm test:unit:related
结果：PASS apps/desktop unit

pnpm --filter desktop run --if-present typecheck
结果：通过
```

### 手工验证

未在隔离沙箱复现进出「跳过登录」后的实机等待。用假计时器覆盖：null state、throw、30s hung。

### 未执行的验证

未在黑洞网络/captive portal 实机等 30 秒。全量 `pnpm test:unit` 未跑（与本 diff 无关的 maker-core PI 集成测在干净 main 上也会红）。

## 风险

### 风险分类

- [x] 无已知风险
- [ ] SQLite / migration
- [ ] system prompt
- [ ] 协议兼容
- [ ] 权限 / 安全 / 用户数据
- [ ] 存量插件兼容（批准状态 / 指纹 / manifest 校验 / 安装布局 / 包格式）
- [ ] 原生层 / fingerprint / OTA
- [ ] 跨平台差异
- [ ] 其他：

### 影响与回滚

- 影响范围：Desktop 登录准备态
- 回滚 / 降级方式：revert 本 PR

### 提交前检查

- [x] 已 review 完整 diff
- [x] 每个 commit 都带 DCO 签名（`git commit -s`，见 [DCO](../DCO)）
- [x] UI 改动已在「UI 变化」注明引用的设计规范章节（不涉及 UI 则跳过）
- [x] 未提交凭证、令牌或授权文件
- [x] 已补充必要文档
- [x] 已确认测试结果或说明未执行原因
