### PR TITLE
fix(scheduler): 自动化模板必填参数为空时改用本地化提示

### DIFF
--- a/apps/desktop/src/renderer/features/scheduler/components/ScheduleFormDialog.tsx
+++ b/apps/desktop/src/renderer/features/scheduler/components/ScheduleFormDialog.tsx
@@ -96,6 +96,19 @@ function showHookErrorToast(err: unknown): void {
   toast.error(message);
 }
 
+/** 返回模板参数校验失败时应展示的本地化字段，避免把引擎内部英文错误直接暴露给用户。 */
+function findMissingRequiredTemplateParam(
+  template: ScheduleTemplate,
+  values: Record<string, string>,
+) {
+  return (template.parameters ?? []).find(
+    (parameter) =>
+      parameter.required &&
+      !values[parameter.key]?.trim() &&
+      !parameter.default?.trim(),
+  );
+}
+
 interface Props {
   open: boolean;
   onOpenChange: (open: boolean) => void;
@@ -526,8 +539,15 @@ export function ScheduleFormDialog({
           ...input,
           prompt: applyTemplateParams(selectedTemplate.prompt ?? '', paramValues, selectedTemplate.parameters),
         };
-      } catch (e) {
-        toast.warning(e instanceof Error ? e.message : String(e));
+      } catch {
+        const missingParam = findMissingRequiredTemplateParam(selectedTemplate, paramValues);
+        if (missingParam) {
+          toast.warning(t('scheduler.editor.validation.templateParamRequired', {
+            label: missingParam.label,
+          }));
+        } else {
+          toast.warning(t('scheduler.editor.validation.templateApplyFailed'));
+        }
         return;
       }
     }

--- a/apps/desktop/src/renderer/i18n/locales/en/common.json
+++ b/apps/desktop/src/renderer/i18n/locales/en/common.json
@@ -9517,7 +9517,9 @@
         "selectProject": "Select a project directory",
         "modelUnavailable": "Model {{model}} is no longer available. Select another model.",
         "reasoningInvalid": "Reasoning must be one of {{values}}",
-        "preRunHookCommandRequired": "Enter the pre-run check command"
+        "preRunHookCommandRequired": "Enter the pre-run check command",
+        "templateParamRequired": "Enter {{label}}",
+        "templateApplyFailed": "Could not apply the template. Please try again."
       }
     },
     "chips": {

--- a/apps/desktop/src/renderer/i18n/locales/ja/common.json
+++ b/apps/desktop/src/renderer/i18n/locales/ja/common.json
@@ -9496,7 +9496,9 @@
         "selectProject": "プロジェクトディレクトリを選択してください",
         "modelUnavailable": "モデル {{model}} は利用できません。別のモデルを選択してください",
         "reasoningInvalid": "Reasoning は {{values}} のいずれかである必要があります",
-        "preRunHookCommandRequired": "事前チェックスクリプトのコマンドを入力してください"
+        "preRunHookCommandRequired": "事前チェックスクリプトのコマンドを入力してください",
+        "templateParamRequired": "{{label}}を入力してください",
+        "templateApplyFailed": "テンプレートを適用できませんでした。もう一度お試しください"
       }
     },
     "chips": {

--- a/apps/desktop/src/renderer/i18n/locales/ko/common.json
+++ b/apps/desktop/src/renderer/i18n/locales/ko/common.json
@@ -9496,7 +9496,9 @@
         "selectProject": "프로젝트 디렉토리를 선택하세요",
         "modelUnavailable": "모델 {{model}}을 더 이상 사용할 수 없습니다. 다른 모델을 선택하세요.",
         "reasoningInvalid": "Reasoning은 {{values}} 중 하나여야 합니다",
-        "preRunHookCommandRequired": "사전 검사 스크립트 명령을 입력하세요"
+        "preRunHookCommandRequired": "사전 검사 스크립트 명령을 입력하세요",
+        "templateParamRequired": "{{label}}을(를) 입력하세요",
+        "templateApplyFailed": "템플릿을 적용하지 못했습니다. 다시 시도하세요"
       }
     },
     "chips": {

--- a/apps/desktop/src/renderer/i18n/locales/zh-CN/common.json
+++ b/apps/desktop/src/renderer/i18n/locales/zh-CN/common.json
@@ -9488,7 +9488,9 @@
         "selectProject": "请选择项目目录",
         "modelUnavailable": "模型 {{model}} 已不可用，请重新选择",
         "reasoningInvalid": "Reasoning 必须是 {{values}} 之一",
-        "preRunHookCommandRequired": "请填写前置检查脚本命令"
+        "preRunHookCommandRequired": "请填写前置检查脚本命令",
+        "templateParamRequired": "请填写{{label}}",
+        "templateApplyFailed": "模板应用失败，请重试"
       }
     },
     "chips": {

--- a/apps/desktop/src/renderer/i18n/locales/zh-TW/common.json
+++ b/apps/desktop/src/renderer/i18n/locales/zh-TW/common.json
@@ -9488,7 +9488,9 @@
         "selectProject": "請選擇專案目錄",
         "modelUnavailable": "模型 {{model}} 已不可用，請重新選擇",
         "reasoningInvalid": "Reasoning 必須是 {{values}} 之一",
-        "preRunHookCommandRequired": "請填寫前置檢查指令碼命令"
+        "preRunHookCommandRequired": "請填寫前置檢查指令碼命令",
+        "templateParamRequired": "請填寫{{label}}",
+        "templateApplyFailed": "模板套用失敗，請重試"
       }
     },
     "chips": {


### PR DESCRIPTION
## 这次改了什么

### 摘要

新建自动化时，从「新手帮助」选择带必填模板参数的模板（领域雷达 / 竞品动态追踪），必填参数留空直接点「创建」，会把模板引擎抛出的英文内部错误（`Missing required template parameter: topic`）原样透传到 toast。中文界面也显示英文，且暴露内部参数 key。

本 PR 在捕获模板参数应用异常时先定位缺失的必填参数，改用当前语言的本地化提示（如「请填写关注主题」），其余模板应用异常也走本地化兜底文案；5 种 locale 同步补齐 `scheduler.editor.validation.templateParamRequired` / `templateApplyFailed`。

关联 Issue：#3795

### 变更类型

- [ ] `feat` 新功能
- [x] `fix` 缺陷修复
- [ ] `refactor` / `perf` 重构或性能优化
- [ ] `docs` / `test` / `chore` 文档、测试或工程维护
- [ ] 其他：

### 范围

- 关联 Issue / 需求：#3795（用户报告：0.1.71 版本，领域雷达/竞品动态追踪必填参数留空提示英文）
- 本 PR 包含：`ScheduleFormDialog.tsx` 提交路径的模板参数异常本地化处理 + 5 locale 文案
- 明确不包含：模板引擎（`packages/maker-scheduler/src/engine/template.ts`）的错误类型重构——引擎异常信息保留英文，供开发排查；后续如需结构化错误码另行处理
- 用户可见变化：必填模板参数留空点「创建」时，toast 从英文内部错误变为本地化提示（zh-CN：请填写{{字段名}}）
- 是否存在 breaking change：无

### UI 变化

- 引用的设计规范：DESIGN.md Voice & Content——提示文案使用用户可理解的语言与界面既有字段名；toast 复用现有组件（pill 通知、warning 语义），无新增视觉样式，无布局/交互变化。

## 怎么验证的

### 自动验证

```text
pnpm test:unit:related
结果：PASS（apps/desktop，6164 tests 全绿，0 failed）

pnpm --filter desktop run typecheck
结果：exit 0

pnpm check:i18n
结果：✅ zh-CN / zh-TW / en / ja / ko 共 8554 个 key 全部一致

pnpm check:i18n-glossary
结果：✅ 无新增违规（仅存量 proposed 术语告警）
```

说明：本地环境 Node 22.23.2（与 CI `node-version: 22` 一致）。

### 手工验证

未执行（本地无运行中的 dev 实例）。手工路径：自动化 → 新建自动化 → 新手帮助 → 领域雷达（关注主题留空）/ 竞品动态追踪（竞品名单留空）→ 点「创建」，预期 toast 显示「请填写关注主题」/「请填写竞品名单」。

### 未执行的验证

- 移动端未验证：mobile 侧模板经 `maker:schedule:list-templates` 获取，参数校验失败发生在 desktop 表单提交路径，mobile 不涉及本次改动的代码路径。

## 风险

### 风险分类

- [x] 无已知风险
- [ ] SQLite / migration
- [ ] system prompt
- [ ] 协议兼容
- [ ] 权限 / 安全 / 用户数据
- [ ] 存量插件兼容（批准状态 / 指纹 / manifest 校验 / 安装布局 / 包格式）
- [ ] 原生层 / fingerprint / OTA
- [ ] 跨平台差异
- [ ] 其他：

### 影响与回滚

- 影响范围：仅 desktop renderer 新建/编辑自动化表单提交时模板参数异常的 toast 文案；不改动模板引擎行为、调度逻辑与数据结构。
- 回滚 / 降级方式：revert 本 commit 即可，无数据/兼容影响。

### 提交前检查

- [x] 已 review 完整 diff
- [x] 每个 commit 都带 DCO 签名（`git commit -s`，见 [DCO](../DCO)）
- [x] UI 改动已在「UI 变化」注明引用的设计规范章节（不涉及 UI 则跳过）
- [x] 未提交凭证、令牌或授权文件
- [x] 已补充必要文档
- [x] 已确认测试结果或说明未执行原因
