### PR TITLE
fix(maker-core): bwrap 沙箱初始化失败的 exec 结果追加宿主归因(#3793)

### DIFF
--- a/packages/maker-core/src/agents/codex/sandbox-init-failure.test.ts
+++ b/packages/maker-core/src/agents/codex/sandbox-init-failure.test.ts
@@ -3,6 +3,7 @@ import { describe, expect, it } from 'vitest';
 import {
   CODEX_SANDBOX_INIT_FAILURE_NOTE,
   annotateSandboxInitFailure,
+  commandInvokesBwrap,
   isBwrapSandboxInitFailureOutput,
 } from './sandbox-init-failure.js';
 
@@ -38,7 +39,38 @@ describe('isBwrapSandboxInitFailureOutput (#3793)', () => {
   });
 });
 
+describe('commandInvokesBwrap', () => {
+  it('matches direct and pathed bwrap invocations', () => {
+    expect(commandInvokesBwrap('bwrap --ro-bind / / ls')).toBe(true);
+    expect(commandInvokesBwrap('/usr/bin/bwrap --help')).toBe(true);
+    expect(commandInvokesBwrap('sudo bwrap --unshare-net true')).toBe(true);
+    expect(commandInvokesBwrap('a && bwrap x')).toBe(true);
+  });
+
+  it('does not match commands that merely mention bwrap as data', () => {
+    expect(commandInvokesBwrap('ls bwrap.log')).toBe(false);
+    expect(commandInvokesBwrap('grep bwrapped notes.txt')).toBe(false);
+    expect(commandInvokesBwrap('pwd')).toBe(false);
+    expect(commandInvokesBwrap(null)).toBe(false);
+  });
+});
+
 describe('annotateSandboxInitFailure', () => {
+  // review P1:用户命令自身调用 bwrap 时,诊断行来自内层 bwrap,不得归因外层沙箱。
+  it('skips annotation when the failed command itself invokes bwrap', () => {
+    const text = 'bwrap: unknown option --bogus\n';
+    expect(annotateSandboxInitFailure(text, true, 'bwrap --bogus ls')).toBe(text);
+  });
+
+  it('still annotates a non-bwrap command with pure bwrap diagnostics', () => {
+    const out = annotateSandboxInitFailure(
+      'bwrap: loopback: Failed RTM_NEWADDR: Operation not permitted\n',
+      true,
+      'ls',
+    );
+    expect(out).toContain(CODEX_SANDBOX_INIT_FAILURE_NOTE);
+  });
+
   it('appends the host note for a failed init-failure item', () => {
     const out = annotateSandboxInitFailure(
       'bwrap: loopback: Failed RTM_NEWADDR: Operation not permitted\n',

--- a/packages/maker-core/src/agents/codex/sandbox-init-failure.test.ts
+++ b/packages/maker-core/src/agents/codex/sandbox-init-failure.test.ts
@@ -1,0 +1,60 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  CODEX_SANDBOX_INIT_FAILURE_NOTE,
+  annotateSandboxInitFailure,
+  isBwrapSandboxInitFailureOutput,
+} from './sandbox-init-failure.js';
+
+describe('isBwrapSandboxInitFailureOutput (#3793)', () => {
+  it('locks the reported RTM_NEWADDR init-failure shape', () => {
+    expect(isBwrapSandboxInitFailureOutput(
+      'bwrap: loopback: Failed RTM_NEWADDR: Operation not permitted\n',
+    )).toBe(true);
+  });
+
+  it('accepts multi-line pure bwrap diagnostics', () => {
+    expect(isBwrapSandboxInitFailureOutput([
+      'bwrap: setting up uid map: Permission denied',
+      '',
+      'bwrap: loopback: Failed RTM_NEWADDR: Operation not permitted',
+    ].join('\n'))).toBe(true);
+  });
+
+  it('rejects output once any command line appears (command actually ran)', () => {
+    expect(isBwrapSandboxInitFailureOutput(
+      'bwrap: some warning\nls: cannot access /x: No such file or directory\n',
+    )).toBe(false);
+    expect(isBwrapSandboxInitFailureOutput(
+      'total 0\ndrwxr-xr-x 2 u u 40 .\n',
+    )).toBe(false);
+  });
+
+  it('rejects empty and null output', () => {
+    expect(isBwrapSandboxInitFailureOutput('')).toBe(false);
+    expect(isBwrapSandboxInitFailureOutput('\n \n')).toBe(false);
+    expect(isBwrapSandboxInitFailureOutput(null)).toBe(false);
+    expect(isBwrapSandboxInitFailureOutput(undefined)).toBe(false);
+  });
+});
+
+describe('annotateSandboxInitFailure', () => {
+  it('appends the host note for a failed init-failure item', () => {
+    const out = annotateSandboxInitFailure(
+      'bwrap: loopback: Failed RTM_NEWADDR: Operation not permitted\n',
+      true,
+    );
+    expect(out).toContain('Failed RTM_NEWADDR');
+    expect(out).toContain(CODEX_SANDBOX_INIT_FAILURE_NOTE);
+  });
+
+  it('leaves ordinary command failures untouched', () => {
+    const text = 'tsc: error TS2322: type mismatch\n';
+    expect(annotateSandboxInitFailure(text, true)).toBe(text);
+  });
+
+  it('never annotates successful items even with bwrap-looking output', () => {
+    const text = 'bwrap: some diagnostic\n';
+    expect(annotateSandboxInitFailure(text, false)).toBe(text);
+  });
+});

--- a/packages/maker-core/src/agents/codex/sandbox-init-failure.ts
+++ b/packages/maker-core/src/agents/codex/sandbox-init-failure.ts
@@ -45,8 +45,27 @@ export const CODEX_SANDBOX_INIT_FAILURE_NOTE =
   'they can either switch this task to Full access (their explicit choice) or run Cindy on a host ' +
   'that permits sandbox namespaces.';
 
+/**
+ * 命令本身就在调用 bwrap 时不做归因:此时 `bwrap: ` 诊断行来自**用户命令内层**
+ * 的 bwrap(参数错误 / 嵌套沙箱被拒等),把它归因为 Codex 外层沙箱初始化失败并
+ * 建议切 Full access 是误导(review P1)。外层沙箱真的起不来时,任意命令都会
+ * 中招,下一条非 bwrap 命令仍会得到标注 —— 跳过的漏报代价可忽略。
+ */
+const COMMAND_INVOKES_BWRAP_RE = /(^|[\s/\\;|&('"`])bwrap(\s|$|['"`)])/;
+
+export function commandInvokesBwrap(command: string | null | undefined): boolean {
+  if (!command) return false;
+  return COMMAND_INVOKES_BWRAP_RE.test(command);
+}
+
 /** failed exec item 收口时对 fullText 的最终改写:检出初始化失败则追加标注。 */
-export function annotateSandboxInitFailure(fullText: string, isError: boolean): string {
-  if (!isError || !isBwrapSandboxInitFailureOutput(fullText)) return fullText;
+export function annotateSandboxInitFailure(
+  fullText: string,
+  isError: boolean,
+  command?: string | null,
+): string {
+  if (!isError || commandInvokesBwrap(command) || !isBwrapSandboxInitFailureOutput(fullText)) {
+    return fullText;
+  }
   return `${fullText.trimEnd()}\n\n${CODEX_SANDBOX_INIT_FAILURE_NOTE}`;
 }

--- a/packages/maker-core/src/agents/codex/sandbox-init-failure.ts
+++ b/packages/maker-core/src/agents/codex/sandbox-init-failure.ts
@@ -1,0 +1,52 @@
+/**
+ * Codex 命令沙箱**初始化失败**的输出形状检测(#3793)。
+ *
+ * 受限 Linux 宿主(容器 / 禁用非特权 user namespace / 缺 CAP_NET_ADMIN)上,
+ * codex 的 bubblewrap 沙箱会在配置 namespace / loopback 阶段直接死掉
+ * (如 `bwrap: loopback: Failed RTM_NEWADDR: Operation not permitted`),
+ * 用户命令从未执行。此时 exec item 以 failed 收尾,aggregatedOutput 里
+ * **只有** bwrap 自身的诊断行 —— 命令一旦真正跑起来,bwrap 即静默,输出
+ * 全部来自命令本身。据此把「全部非空行都是 `bwrap: ` 前缀」作为初始化
+ * 失败的判定形状:任何一行命令输出都会破坏该形状,不会误伤命令自身失败。
+ *
+ * 检出后在 tool_result 末尾追加宿主标注:模型不再对同一命令盲目重试,
+ * 用户在工具卡里能看到归因。恢复入口(重试按钮 / 切 Full access 确认)
+ * 属 renderer / 产品面,不在本模块范围。
+ */
+
+const BWRAP_LINE_PREFIX = 'bwrap: ';
+
+/** 判定形状只看头部若干行,防御异常超长输出(热路径仅 failed item 走到这里)。 */
+const MAX_SHAPE_LINES = 64;
+
+export function isBwrapSandboxInitFailureOutput(output: string | null | undefined): boolean {
+  if (!output) return false;
+  const lines = output.split('\n');
+  let nonEmpty = 0;
+  for (const rawLine of lines) {
+    const line = rawLine.trim();
+    if (line.length === 0) continue;
+    nonEmpty += 1;
+    if (nonEmpty > MAX_SHAPE_LINES) return false;
+    if (!line.startsWith(BWRAP_LINE_PREFIX)) return false;
+  }
+  return nonEmpty > 0;
+}
+
+/**
+ * 追加进 tool_result 的宿主标注。英文(模型消费面,与其余宿主注入一致);
+ * `[Cindy]` 前缀明示这是宿主归因而非命令输出。
+ */
+export const CODEX_SANDBOX_INIT_FAILURE_NOTE =
+  '[Cindy] The Codex command sandbox (bubblewrap) failed to initialize on this restricted Linux host — ' +
+  'the command above was never executed. This typically means the host blocks unprivileged user ' +
+  'namespaces or network namespace setup (CAP_NET_ADMIN). Retrying the same command will fail ' +
+  'identically; do not retry. Tell the user the sandbox cannot start in this environment and that ' +
+  'they can either switch this task to Full access (their explicit choice) or run Cindy on a host ' +
+  'that permits sandbox namespaces.';
+
+/** failed exec item 收口时对 fullText 的最终改写:检出初始化失败则追加标注。 */
+export function annotateSandboxInitFailure(fullText: string, isError: boolean): string {
+  if (!isError || !isBwrapSandboxInitFailureOutput(fullText)) return fullText;
+  return `${fullText.trimEnd()}\n\n${CODEX_SANDBOX_INIT_FAILURE_NOTE}`;
+}

--- a/packages/maker-core/src/agents/codex/translator.test.ts
+++ b/packages/maker-core/src/agents/codex/translator.test.ts
@@ -1536,6 +1536,67 @@ describe('translateItemNotification commandExecution output normalization', () =
       isError: false,
     });
   });
+
+  // #3793:bwrap 沙箱初始化失败(命令从未执行)的 failed exec 追加宿主归因标注;
+  // 普通失败不受影响。
+  it('annotates a failed exec whose output is pure bwrap init diagnostics', async () => {
+    const rt = newCodexRuntimeState();
+    const q = createAsyncQueue<AgentEvent>();
+    const ctx = makeCtx(rt);
+
+    translateItemNotification(
+      'completed',
+      {
+        threadId: 'thread-1',
+        turnId: 'turn-1',
+        item: {
+          type: 'commandExecution',
+          id: 'cmd-sandbox',
+          command: 'ls',
+          status: 'failed',
+          aggregatedOutput: 'bwrap: loopback: Failed RTM_NEWADDR: Operation not permitted\n',
+          exitCode: 1,
+        },
+      },
+      q,
+      ctx,
+    );
+
+    const events = await collect(q);
+    const full = events.find((event) => event.type === 'tool_result_full');
+    const fullText = (full?.data as { fullText?: string }).fullText ?? '';
+    expect(fullText).toContain('Failed RTM_NEWADDR');
+    expect(fullText).toContain('[Cindy] The Codex command sandbox (bubblewrap) failed to initialize');
+    expect(full?.data).toMatchObject({ isError: true });
+  });
+
+  it('does not annotate an ordinary failed exec', async () => {
+    const rt = newCodexRuntimeState();
+    const q = createAsyncQueue<AgentEvent>();
+    const ctx = makeCtx(rt);
+
+    translateItemNotification(
+      'completed',
+      {
+        threadId: 'thread-1',
+        turnId: 'turn-1',
+        item: {
+          type: 'commandExecution',
+          id: 'cmd-fail',
+          command: 'tsc',
+          status: 'failed',
+          aggregatedOutput: 'error TS2322: type mismatch\n',
+          exitCode: 2,
+        },
+      },
+      q,
+      ctx,
+    );
+
+    const events = await collect(q);
+    const full = events.find((event) => event.type === 'tool_result_full');
+    expect((full?.data as { fullText?: string }).fullText).toBe('error TS2322: type mismatch\n');
+  });
 });
 
 describe('translateItemNotification collabAgentToolCall', () => {

--- a/packages/maker-core/src/agents/codex/translator.ts
+++ b/packages/maker-core/src/agents/codex/translator.ts
@@ -47,6 +47,7 @@ import {
   isContextOverflowErrorMessage,
 } from '../shared/context-overflow-error.js';
 import { commandExecutionDisplayInput, type CommandExecutionDisplayInput } from './command-display.js';
+import { annotateSandboxInitFailure } from './sandbox-init-failure.js';
 import { codexErrorInfoTag } from './app-server/protocol.js';
 import {
   formatTerminalRateLimitRetryMessage,
@@ -1405,7 +1406,12 @@ function handleCommandExecution(
     type: 'tool_result_full',
     data: {
       toolUseId: item.id,
-      fullText: stripTerminalControlSequences(item.aggregatedOutput ?? ''),
+      // #3793:bwrap 沙箱初始化失败(命令从未执行)时追加宿主归因标注,
+      // 模型不再盲目重试,用户在工具卡里能看到原因。健康与普通失败路径原样。
+      fullText: annotateSandboxInitFailure(
+        stripTerminalControlSequences(item.aggregatedOutput ?? ''),
+        isError,
+      ),
       isError,
     },
     source: 'codex',

--- a/packages/maker-core/src/agents/codex/translator.ts
+++ b/packages/maker-core/src/agents/codex/translator.ts
@@ -1411,6 +1411,7 @@ function handleCommandExecution(
       fullText: annotateSandboxInitFailure(
         stripTerminalControlSequences(item.aggregatedOutput ?? ''),
         isError,
+        item.command,
       ),
       isError,
     },


### PR DESCRIPTION
## 这次改了什么

### 摘要

fix #3793 的 Cindy 侧归因部分。受限 Linux 宿主(容器 / 禁用非特权 user namespace / 缺 CAP_NET_ADMIN)上,codex 的 bubblewrap 沙箱在配置 namespace/loopback 阶段直接死掉(`bwrap: loopback: Failed RTM_NEWADDR: Operation not permitted`),用户命令**从未执行**——连 `ls`/`pwd` 也全部失败。当前 translator 把 failed exec 的裸 bwrap stderr 原样透传进 tool_result:模型把它当普通命令失败反复盲试,用户只看到不可理解的内部错误,与 issue 三角(dash-s-cindy)结论一致:「缺的是结构化归因,而不是无确认的权限绕过」。

修复:failed exec 且输出**全部非空行都是 `bwrap: ` 前缀**时(bwrap 一旦成功拉起命令即静默,任何一行命令输出都会破坏该形状——不会误伤普通命令失败),在 tool_result 末尾追加 `[Cindy]` 前缀的宿主归因标注:说明沙箱未能初始化、命令未执行、重试必然同败,引导模型停止重试并告知用户可显式切换 Full access(用户主动选择)或换宿主。**不做任何自动降级**(#129 的 Auto/Full access 语义边界保持不变)。

**诚实划界**:恢复入口 UI(重试按钮 / 切 Full access 确认卡)属 renderer/产品面,不在本 PR;bwrap 初始化本体的修复(如上游 Landlock 降级)属 codex 上游。本 PR 交付的是三角建议行动 2 的 maker-core 半边:归因落进模型与工具卡都能看到的位置。

### 变更类型

- [ ] `feat` 新功能
- [x] `fix` 缺陷修复
- [ ] `refactor` / `perf` 重构或性能优化
- [ ] `docs` / `test` / `chore` 文档、测试或工程维护
- [ ] 其他:

### 范围

- 关联 Issue / 需求:#3793(Cindy 侧归因部分)
- 本 PR 包含:sandbox-init-failure 检测器 + translator 接线 + 7 条回归
- 明确不包含:renderer 恢复入口(重试/切 Full access 卡);任何自动降级或沙箱策略变更;bwrap 上游修复
- 用户可见变化:该场景下工具卡输出末尾多一段 `[Cindy]` 归因说明;模型不再对同一命令反复盲试
- 是否存在 breaking change:无(仅「failed + 纯 bwrap 诊断输出」这一此前必然误导的分支追加文本;健康路径与普通失败逐字节不变,有回归锁住)

### UI 变化

无 UI 变化(工具卡内容为 translator 产出文本,非界面改动)。

## 怎么验证的

### 自动验证

```
pnpm --dir packages/maker-core exec vitest run src/agents/codex/sandbox-init-failure.test.ts src/agents/codex/translator.test.ts
```
结果:92 过(新增 7 条:锁 RTM_NEWADDR 形状;多行纯 bwrap 诊断;任一命令行输出即拒绝;空/null 拒绝;failed+bwrap 追加标注;普通失败不追加;成功项即使输出像 bwrap 也不追加。translator 级 2 条接线回归)。反证:`git checkout HEAD~1` 撤实现后恰好新增用例失败(translator 85 例中 1 失败 + 检测器文件导入失败),既有用例照过;恢复后 92/92。

maker-core typecheck 过。

```
pnpm test:unit:related
```
结果:exit 1,唯一失败为 desktop 段 vitest threads 池 SIGSEGV(本机已知环境基线,与本 diff 无关;maker-core 全量段通过)。

### 手工验证

无(判定形状由单测锁定;真实受限宿主复现依赖提报人环境,判读方式:失败工具卡末尾应出现 `[Cindy] The Codex command sandbox (bubblewrap) failed to initialize...` 标注)。

### 未执行的验证

- 未在真实禁用 userns 的 Linux 容器里端到端复现(需要提报人环境;检测形状以 issue 原始输出与 bubblewrap 诊断行为为据:init 失败时输出只有 `bwrap: ` 行)。

## 风险

### 风险分类

低风险。仅在「failed exec + 全部非空行为 bwrap 诊断」分支追加文本;判定 O(行数) 且上限 64 行,只在 failed item 上执行,不碰热路径;translator 四不变量(无丢失/无错序/无错配)不受影响。

### 影响与回滚

影响面:maker-core codex translator 的 exec 完成路径(本地与远端会话共用)。远程与移动端适配:标注在 translator 产出的事件内容里,远端/移动端消费同一事件流,无需适配。回滚:revert 单 commit,无 schema 变更。

### 提交前检查

- [x] 已运行定向单测(含反证)、typecheck 与 `pnpm test:unit:related`(失败项已逐一归因)
- [x] commit 带 DCO 签名(Signed-off-by: ficowang <fico@xd.com>)
- [x] diff 聚焦单一问题,无无关改动
