### PR TITLE
fix(desktop): retire stale Codex sessions after transport crashes

### DIFF
--- a/apps/desktop/src/renderer/__tests__/makerChatStoreTextDeltaBatching.test.ts
+++ b/apps/desktop/src/renderer/__tests__/makerChatStoreTextDeltaBatching.test.ts
@@ -3081,6 +3081,111 @@ describe('makerChatStore text delta batching', () => {
     expect(snap.messages.some((m) => m.role === 'user' && m.content === 'queued')).toBe(false);
   });
 
+  it('shows a local busy send before the enqueue projection settles', async () => {
+    makerChatStore.__applyStatusUpdateForTest(SESSION_ID, {
+      sessionId: SESSION_ID,
+      status: 'running',
+      tokenUsage: 0,
+      contextTokens: 0,
+      contextWindow: 0,
+      isRunning: true,
+    });
+    let queued: AgentInputQueuedMessage | undefined;
+    let resolveEnqueue!: (value: AgentInputProjection) => void;
+    input.enqueue.mockImplementationOnce(
+      async (_sessionId: string, item: AgentInputQueuedMessage) => {
+        queued = item;
+        return new Promise<AgentInputProjection>((resolve) => {
+          resolveEnqueue = resolve;
+        });
+      },
+    );
+
+    const send = makerChatStore.sendMessage(
+      SESSION_ID,
+      'local busy message',
+      MODEL,
+      EFFORT,
+      PERMISSION_MODE,
+      WORKING_DIR,
+    );
+    await flushPromises();
+
+    expect(makerChatStore.getSnapshot(SESSION_ID).pendingQueue).toEqual([
+      expect.objectContaining({ text: 'local busy message', isPendingEnqueue: true }),
+    ]);
+    expect(makerChatStore.getSnapshot(SESSION_ID).messages).toEqual([]);
+
+    resolveEnqueue(projection(SESSION_ID, { pendingQueue: queued ? [queued] : [] }));
+    await expect(send).resolves.toBe(true);
+    expect(makerChatStore.getSnapshot(SESSION_ID).pendingQueue).toEqual([
+      expect.objectContaining({ text: 'local busy message' }),
+    ]);
+    expect(makerChatStore.getSnapshot(SESSION_ID).pendingQueue[0]?.isPendingEnqueue).toBeUndefined();
+  });
+
+  it('keeps a busy send visible when enqueue immediately dispatches and projects an empty queue', async () => {
+    makerChatStore.__applyStatusUpdateForTest(SESSION_ID, {
+      sessionId: SESSION_ID,
+      status: 'running',
+      tokenUsage: 0,
+      contextTokens: 0,
+      contextWindow: 0,
+      isRunning: true,
+    });
+    let resolveEnqueue!: (value: AgentInputProjection) => void;
+    input.enqueue.mockImplementationOnce(async () => new Promise<AgentInputProjection>((resolve) => {
+      resolveEnqueue = resolve;
+    }));
+
+    const send = makerChatStore.sendMessage(
+      SESSION_ID,
+      'immediately dispatched message',
+      MODEL,
+      EFFORT,
+      PERMISSION_MODE,
+      WORKING_DIR,
+    );
+    await flushPromises();
+    expect(makerChatStore.getSnapshot(SESSION_ID).pendingQueue).toHaveLength(1);
+
+    resolveEnqueue(projection(SESSION_ID, { pendingQueue: [] }));
+    await expect(send).resolves.toBe(true);
+    expect(makerChatStore.getSnapshot(SESSION_ID).pendingQueue).toEqual([]);
+    expect(makerChatStore.getSnapshot(SESSION_ID).messages).toEqual([
+      expect.objectContaining({
+        role: 'user',
+        content: 'immediately dispatched message',
+        isPendingPersist: true,
+      }),
+    ]);
+  });
+
+  it('removes a locally optimistic busy send when enqueue fails before acceptance', async () => {
+    makerChatStore.__applyStatusUpdateForTest(SESSION_ID, {
+      sessionId: SESSION_ID,
+      status: 'running',
+      tokenUsage: 0,
+      contextTokens: 0,
+      contextWindow: 0,
+      isRunning: true,
+    });
+    input.enqueue.mockRejectedValueOnce(new Error('transport unavailable'));
+
+    const send = makerChatStore.sendMessage(
+      SESSION_ID,
+      'failed busy message',
+      MODEL,
+      EFFORT,
+      PERMISSION_MODE,
+      WORKING_DIR,
+    );
+    await expect(send).resolves.toBe(false);
+    const snapshot = makerChatStore.getSnapshot(SESSION_ID);
+    expect(snapshot.pendingQueue.some((item) => item.text === 'failed busy message')).toBe(false);
+    expect(snapshot.messages.some((item) => item.content === 'failed busy message')).toBe(false);
+  });
+
   it('dedupes the main DB-created ack for optimistic user bubbles', async () => {
     input.enqueue.mockImplementationOnce(async (sessionId: string) => projection(sessionId));
 

--- a/apps/desktop/src/renderer/lib/makerChatStore.ts
+++ b/apps/desktop/src/renderer/lib/makerChatStore.ts
@@ -4093,6 +4093,7 @@ function applyInputProjection(
     }
   }
   let settlingClientIds: string[] = [];
+  let locallyDispatchedQueueItems: QueuedMessage[] = [];
   const deferredPersistFromProjection: {
     payload: {
       data: Record<string, unknown> | null;
@@ -4144,6 +4145,19 @@ function applyInputProjection(
       );
     });
     settlingClientIds = settlingQueueItems.map((item) => item.clientId);
+    // A local send can race with the main coordinator becoming idle between
+    // the renderer's busy check and `input.enqueue()`. In that case the
+    // coordinator starts the turn immediately and the returned projection has
+    // an empty pendingQueue. Keep the optimistic row visible as a pending
+    // transcript message until the durable messages:created echo arrives (or
+    // a later authoritative projection puts it back in the queue after a
+    // pre-accept failure).
+    locallyDispatchedQueueItems = s.pendingQueue.filter(
+      (item) =>
+        item.isPendingEnqueue === true &&
+        !currentQueueIds.has(item.clientId) &&
+        !persistedMessageIds.has(item.clientId),
+    );
     // Only trigger if the retried message is still stuck in the pending queue:
     // projection.error is queue-level (string | null, no clientId), so we correlate
     // via pendingQueue. If the retry message was already dispatched and the agent
@@ -4174,7 +4188,10 @@ function applyInputProjection(
       queuedIds.size > 0 && s.messages.some((m) => m.isPendingPersist && queuedIds.has(m.clientId))
         ? s.messages.filter((m) => !(m.isPendingPersist && queuedIds.has(m.clientId)))
         : s.messages;
-    const withSettlingMessages = settlingQueueItems.reduce<ChatMessage[]>((messages, item) => {
+    const withSettlingMessages = [
+      ...settlingQueueItems,
+      ...locallyDispatchedQueueItems,
+    ].reduce<ChatMessage[]>((messages, item) => {
       if (messages.some((message) => message.clientId === item.clientId)) return messages;
       return [...messages, { ...item.chatMessage, isPendingPersist: true }];
     }, dedupedMessages);
@@ -12755,8 +12772,13 @@ async function sendMessageCore(
     : undefined;
   if (deviceLinkRemote && !remoteRecord) return false;
 
-  // device-link 乐观第一拍：空闲沿用消息流气泡，忙时也立即显示 sending 队列行。
-  if (deviceLinkRemote && isSendBusyForQueue(current)) {
+  // Busy sends must be visible before the main projection round-trip.  This is
+  // especially important for local sessions: the coordinator can be waiting
+  // for a delayed/stale turn boundary, so waiting for `input.enqueue()` to
+  // resolve would make the user's message appear to disappear.  The
+  // authoritative projection will replace the temporary marker (or remove it
+  // on a pre-accept failure) once the IPC call settles.
+  if (isSendBusyForQueue(current)) {
     setState(sessionId, (s) =>
       s.pendingQueue.some((item) => item.clientId === queued.clientId)
         ? s
@@ -12886,6 +12908,12 @@ async function sendMessageCore(
       setState(sessionId, (s) => ({
         ...s,
         error: message,
+        pendingQueue: s.pendingQueue.filter(
+          (item) => !(item.clientId === queued.clientId && item.isPendingEnqueue === true),
+        ),
+        messages: s.messages.filter(
+          (item) => !(item.clientId === queued.clientId && item.isPendingPersist === true),
+        ),
         usageLimitRecovery: null,
         errorReason: null,
         recoverableError: null,

--- a/packages/maker-core/src/agents/codex/app-server/host.ts
+++ b/packages/maker-core/src/agents/codex/app-server/host.ts
@@ -1466,34 +1466,17 @@ export class AppServerHost {
   }
 
   /**
-   * 子进程 crash / IO 错误: 广播给所有 subscriber 的 error handler, 让上层每个
-   * session 都能 emit 'error' AgentEvent + 结束自己的 event queue, 然后强制 shutdown
-   * (此后任何 subscribeThread/request 都会拒绝, 上层下次需要时拿不到 host)。
-   *
-   * 注意: shutdown 之后 startPromise = null, 下一次 ensureStarted 可以重新 spawn。
-   * 但当前内存里的 subscribers 都已被清掉 — 上层 session 拿到 error 后该自己 close。
+   * 子进程 crash / IO 错误: 将所有 subscriber 作为 host 强制退役处理，让每个
+   * session 按自己的真实状态收口（空闲静默结束 event queue，在飞任务发终态
+   * error + Done），然后强制 shutdown。此后下一次 ensureStarted 可以重新 spawn。
    */
   private handleTransportError(err: Error): void {
-    this.logger.error('transport error, notifying subscribers + shutting down', { message: err.message });
-    this.broadcastTransportErrorToSubscribers(`app-server transport error: ${err.message}`);
+    this.logger.error('transport error, retiring subscribers + shutting down', { message: err.message });
+    // Treat a transport crash as a forced host replacement. Idle sessions must
+    // end their event queues, while sessions with in-flight work need the
+    // structured terminal error + Done sequence from their own handlers.
+    this.notifySubscribersOfForcedRetire(`transport error: ${err.message}`);
     void this.shutdown(`transport error: ${err.message}`);
-  }
-
-  /** ErrorNotification 的 shape 不能完全合成 (没真实 turnId), 用最小可信字段。 */
-  private broadcastTransportErrorToSubscribers(message: string): void {
-    for (const [threadId, handlers] of this.subscribers) {
-      try {
-        handlers.error?.({
-          threadId,
-          turnId: '',
-          willRetry: false,
-          scope: 'transport',
-          error: { message },
-        });
-      } catch (e) {
-        this.logger.warn('error broadcast handler threw', { threadId, message: (e as Error).message });
-      }
-    }
   }
 
   // ── 诊断辅助 (测试 / 日志) ────────────────────────────────────────────────

--- a/packages/maker-core/src/agents/codex/index.test.ts
+++ b/packages/maker-core/src/agents/codex/index.test.ts
@@ -7315,6 +7315,34 @@ describe('CodexAgent MCP thread context hooks', () => {
     await agent.dispose();
   });
 
+  it('closes idle session event streams when the shared app-server transport crashes', async () => {
+    const agent = new CodexAgent(createDeps());
+    const handle = await agent.startSession({
+      sessionId: 'session-idle-transport-crash',
+      model: 'gpt-5.4',
+      workingDir: '/repo-local',
+    });
+    const iterator = handle.events()[Symbol.asyncIterator]();
+    const transport = createdTransports[0];
+
+    await transport.close('simulated app-server crash');
+
+    const result = await Promise.race([
+      iterator.next(),
+      new Promise<never>((_, reject) => {
+        const timer = setTimeout(() => reject(new Error('idle session event stream did not close')), 200);
+        timer.unref?.();
+      }),
+    ]);
+    expect(result).toMatchObject({ done: true });
+    await expect(handle.send({ type: 'user', content: 'after crash' })).rejects.toThrow(
+      /Codex session expired because its app-server was replaced/,
+    );
+
+    await handle.close();
+    await agent.dispose();
+  });
+
   it('fails closed when the credential mode switch coordinator leaves sessions attached', async () => {
     const prepareCodexExtraSpawnConfig = vi.fn(async () => ({
       extraArgs: [],


### PR DESCRIPTION
## 这次改了什么

### 摘要

修复本地 Codex 任务在 transport 崩溃后仍保持活跃、导致后续发言无效且用户看不到自己消息的问题。transport 崩溃现在会统一收口对应 Session；本地任务繁忙时发送的消息会先显示为待发送/待持久化行，并在入队失败时清理临时显示。

### 变更类型

- [ ] `feat` 新功能
- [x] `fix` 缺陷修复
- [ ] `refactor` / `perf` 重构或性能优化
- [x] `docs` / `test` / `chore` 文档、测试或工程维护
- [ ] 其他：

### 范围

- 关联 Issue / 需求：用户反馈“任务后发言无效且看不到”
- 本 PR 包含：Codex app-server transport 崩溃后的 Session 收口；本地忙碌任务发送的乐观显示、投影同步及失败清理；对应回归测试。
- 明确不包含：voice-input 改动、服务端改动、历史丢失消息恢复。
- 用户可见变化：transport 异常后任务会进入明确终态，后续发送不会永久卡住；忙碌任务发送的用户消息会立即可见。
- 是否存在 breaking change：无。

### UI 变化

- 引用的设计规范：不涉及：本次只改 Renderer 消息投影与待发送/待持久化状态机，未新增视觉 token、布局、交互控件或文案；沿用现有消息行呈现和 Light/Dark 语义主题。

## 怎么验证的

### 自动验证

```text
corepack pnpm check:dco
结果：通过（Signed-off-by 与 author/committer 对齐）

git diff --check origin/main...HEAD
结果：通过

GitHub CI client-ci：Linux unit tests (1/2)(2/2)、Windows unit tests (1/2)(2/2)、verify 均已通过。
本轮将 rebase 到最新 origin/main 后由 CI 重跑。
```

### 手工验证

不涉及；本 PR 不依赖外部账号、远程服务或特定设备操作。

### 未执行的验证

未在 rebase 后的隔离 worktree 重跑全仓单测（worktree 无 node_modules；rebase 无冲突且 diff 与原提交相同）。以 rebase 后 CI 为准。

## 风险

### 风险分类

- [ ] 无已知风险
- [ ] SQLite / migration
- [ ] system prompt
- [ ] 协议兼容
- [ ] 权限 / 安全 / 用户数据
- [ ] 存量插件兼容（批准状态 / 指纹 / manifest 校验 / 安装布局 / 包格式）
- [ ] 原生层 / fingerprint / OTA
- [ ] 跨平台差异
- [x] 其他：transport 崩溃收口与消息投影时序

### 影响与回滚

- 影响范围：Desktop 本地 Codex Session 的异常终止路径，以及忙碌任务中的本地消息显示。
- 回滚 / 降级方式：回滚本 PR 提交即可恢复原有行为；不涉及数据库 migration 或持久数据格式变更。

### 提交前检查

- [x] 已 review 完整 diff
- [x] 每个 commit 都带 DCO 签名（`git commit -s`，见 [DCO](../DCO)）
- [x] UI 改动已在「UI 变化」注明引用的设计规范章节（不涉及 UI 则跳过）
- [x] 未提交凭证、令牌或授权文件
- [x] 已补充必要文档
- [x] 已确认测试结果或说明未执行原因
