### PR TITLE
fix(desktop): claude-code / codex 保留本地更新版本，不再被 manifest 降级

### DIFF
--- a/apps/desktop/src/main/agent-binaries/__tests__/binary-version-probe.test.ts
+++ b/apps/desktop/src/main/agent-binaries/__tests__/binary-version-probe.test.ts
@@ -14,6 +14,12 @@ describe('binary version probe', () => {
     expect(parseBinaryVersionOutput('pi v0.84.4-beta.1\n', '')).toBe('0.84.4-beta.1');
   });
 
+  it('normalizes the Claude Code and codex --version shapes', () => {
+    expect(parseBinaryVersionOutput('2.1.258 (Claude Code)\n', '')).toBe('2.1.258');
+    expect(parseBinaryVersionOutput('codex-cli 0.145.0\n', '')).toBe('0.145.0');
+    expect(parseBinaryVersionOutput('codex-cli v0.145.0\n', '')).toBe('0.145.0');
+  });
+
   it('uses SemVer precedence for prerelease arbitration', () => {
     expect(isBinaryVersionNotOlder('0.84.5-beta.1', '0.84.4')).toBe(true);
     expect(isBinaryVersionNotOlder('0.84.5-beta.1', '0.84.5')).toBe(false);
@@ -22,6 +28,8 @@ describe('binary version probe', () => {
   it('rejects unrelated or multiline-leading output', () => {
     expect(parseBinaryVersionOutput('other 0.84.4\n', '')).toBeNull();
     expect(parseBinaryVersionOutput('warning\n0.84.4\n', '')).toBeNull();
+    expect(parseBinaryVersionOutput('codex-cli 0.145.0 (extra)\n', '')).toBeNull();
+    expect(parseBinaryVersionOutput('(Claude Code) 2.1.258\n', '')).toBeNull();
   });
 
   it('returns null instead of throwing when the executable cannot be spawned', async () => {

--- a/apps/desktop/src/main/agent-binaries/binary-version-probe.ts
+++ b/apps/desktop/src/main/agent-binaries/binary-version-probe.ts
@@ -19,19 +19,34 @@ export function isBinaryVersionNotOlder(candidate: string, required: string): bo
   return semver.gte(candidate, required);
 }
 
-/** Parse the supported Pi version forms from the first `--version` output line. */
+/** Managed CLIs that print `<name> <version>` instead of a leading bare version. */
+const NAMED_VERSION_PREFIXES = new Set(['pi', 'codex-cli']);
+
+function normalizeVersionToken(token: string | undefined): string | null {
+  return token ? normalizeBinaryVersion(token.replace(/^v(?=\d)/, '')) : null;
+}
+
+/**
+ * Parse the supported version forms from the first `--version` output line.
+ *
+ * Covers the three shapes the managed runtimes actually print:
+ *   - `0.84.4`              (pi)
+ *   - `2.1.258 (Claude Code)` (claude-code — version leads, suffix is a product label)
+ *   - `codex-cli 0.145.0`   (codex)
+ *
+ * Stays deliberately strict: an unknown leading token that is not itself a valid
+ * version yields null rather than scanning the line for anything semver-shaped.
+ */
 export function parseBinaryVersionOutput(stdout: string, stderr: string): string | null {
   const output = (stdout || stderr).trim();
   const firstLine = output.split(/\r?\n/, 1)[0]?.trim() ?? '';
   const tokens = firstLine.split(/\s+/);
-  const versionToken = tokens.length === 1
-    ? tokens[0]
-    : tokens.length === 2 && tokens[0]?.toLowerCase() === 'pi'
-      ? tokens[1]
-      : undefined;
-  return versionToken
-    ? normalizeBinaryVersion(versionToken.replace(/^v(?=\d)/, ''))
-    : null;
+  const leadingVersion = normalizeVersionToken(tokens[0]);
+  if (leadingVersion) return leadingVersion;
+  if (tokens.length === 2 && NAMED_VERSION_PREFIXES.has(tokens[0]?.toLowerCase() ?? '')) {
+    return normalizeVersionToken(tokens[1]);
+  }
+  return null;
 }
 
 /**

--- a/apps/desktop/src/main/agent-binaries/index.ts
+++ b/apps/desktop/src/main/agent-binaries/index.ts
@@ -186,6 +186,7 @@ const CONFIG: Record<AgentBinaryKind, AgentBinaryConfig> = {
     devBinDir: 'claude-code-bin',
     vendorTag: 'claude',
     artifactKind: 'gz',
+    preserveLocalVersion: true,
   },
   codex: {
     vendorKey: 'codex',
@@ -195,6 +196,7 @@ const CONFIG: Record<AgentBinaryKind, AgentBinaryConfig> = {
     devBinDir: 'codex-bin',
     vendorTag: 'codex',
     artifactKind: 'gz',
+    preserveLocalVersion: true,
   },
   pi: {
     vendorKey: 'pi',


### PR DESCRIPTION
## 这次改了什么

### 摘要

`preserveLocalVersion` 目前只有 pi 能用，claude-code 和 codex 开不了 —— 不是没配，而是配了也不生效：版本 probe 解析不出它们的 `--version` 输出。

`parseBinaryVersionOutput` 只认两种形态（裸版本号、`pi <version>`），而三个受管 runtime 实际打印的是：

```text
claude-code:  2.1.258 (Claude Code)      # 版本在行首，后面跟产品名
codex:        codex-cli 0.145.0          # 名字前缀不是 pi
pi:           0.84.4                     # 唯一被覆盖的形态
```

前两种都落到 `versionToken === undefined`，`probeBinaryVersion` 恒返回 null，`findPreferredLocalBinary` 直接短路。结果：`userData/<installSubdir>/` 下已有的更新版本不会被优选，manifest 指定的旧版本照用，CDN manifest 落后或回滚时用户被静默降级，且降级没有任何日志痕迹。

本 PR 把解析补齐到这三种形态，然后给 claude-code 与 codex 打开 `preserveLocalVersion`。

### 变更类型

- [ ] `feat` 新功能
- [x] `fix` 缺陷修复
- [ ] `refactor` / `perf` 重构或性能优化
- [ ] `docs` / `test` / `chore` 文档、测试或工程维护
- [ ] 其他：

### 范围

- 关联 Issue / 需求：无（自查发现）
- 本 PR 包含：
  - `parseBinaryVersionOutput` 支持「版本号位于行首」与 `codex-cli` 名字前缀两种形态
  - `CONFIG` 给 `claude-code`、`codex` 打开 `preserveLocalVersion`
- 明确不包含：
  - 不改 `tools/{claude,codex}/latest.json` 的 pinned 版本，也不动 CDN manifest 内容
  - 不改 `findPreferredLocalBinary` / `cleanupOldVersions` 的既有语义
  - 不新增测试文件（现有 6 条 probe 断言全部保留且仍然通过）
- 用户可见变化：本地已装的受管 runtime 版本高于 manifest 时，启动继续使用本地版本，不再回退到更旧的 manifest 版本
- 是否存在 breaking change：无

### UI 变化

不涉及。

- 引用的设计规范：不涉及

## 怎么验证的

### 自动验证

```text
pnpm --dir apps/desktop exec vitest run src/main/agent-binaries/__tests__ src/main/maker-host/__tests__/piBinaryDistribution.test.ts
结果：Test Files 9 passed (9) / Tests 68 passed (68)

pnpm --dir apps/desktop exec eslint src/main/agent-binaries/binary-version-probe.ts src/main/agent-binaries/index.ts
结果：exit 0，无 warning

pnpm --dir apps/desktop typecheck   （tsc --noEmit -p tsconfig.json）
结果：exit 0

pnpm check:dco
结果：DCO check passed: 1 commit signed off
```

解析行为用三个 runtime 的真实 `--version` 输出逐个核对过（临时脚本，未入仓）：

| 输入 | 结果 |
| --- | --- |
| `2.1.258 (Claude Code)` | `2.1.258` |
| `codex-cli 0.145.0` | `0.145.0` |
| `0.84.4` | `0.84.4` |
| `v0.84.4-beta.1` | `0.84.4-beta.1` |
| `pi 0.84.4` | `0.84.4` |
| `other 0.84.4` | `null`（保持严格） |
| `warning\n0.84.4` | `null`（保持严格） |
| `claude 2.1.258 extra` | `null`（保持严格） |

后三行对应 `binary-version-probe.test.ts` 里既有的「rejects unrelated or multiline-leading output」约束，改动没有放宽它：未知前缀不做全行 semver 扫描，只在「首 token 本身是合法版本」或「首 token 在已知 CLI 名白名单」两种情况下取值。

`--version` probe 的开销实测可忽略（macOS arm64，claude-code 二进制 190 MB）：

```text
real 0.01s / 0.00s / 0.00s（连续三次）
```

### 手工验证

复现路径：manifest 的 `claudeCode.version` 落后于 `userData/claude-code/` 下已有的版本时，改前启动用 manifest 的旧版本，改后启动保留本地新版本。

### 未执行的验证

- 未跑 packaged 桌面端的端到端启动验证（需要完整打包 + 重启，本地是在 dev 依赖树里跑的单测 / typecheck / lint）。`prepare()` 的这条分支已由 `factory-local-version.test.ts` 的 9 条断言覆盖，本 PR 未改动该函数。
- 未在 Windows / Linux 上验证。改动只涉及字符串解析与配置常量，不含平台分支。

## 风险

### 风险分类

- [x] 无已知风险
- [ ] SQLite / migration
- [ ] system prompt
- [ ] 协议兼容
- [ ] 权限 / 安全 / 用户数据
- [ ] 存量插件兼容（批准状态 / 指纹 / manifest 校验 / 安装布局 / 包格式）
- [ ] 原生层 / fingerprint / OTA
- [ ] 跨平台差异
- [ ] 其他：

### 影响与回滚

- 影响范围：`prepare()` 的 CDN 段在 claude-code / codex 上多一次 `--version` execFile（有 mtime+size memo，实测 0.01s 量级）。正常情况下 `cleanupOldVersions` 保证每个 installSubdir 只留一个版本目录，所以每个 vendor 每次启动最多多 probe 一次。probe 失败、超时、输出不合法都返回 null，退回改前的行为。
- 需要 reviewer 拿主意的一点：开了 `preserveLocalVersion` 之后，如果本地目录里存在版本高于 manifest 的二进制，Cindy 会用它。这正是「禁止降级」的本意，但也意味着 Agent SDK 与 CLI 的版本配对不再由 manifest 单方面决定。如果 claude-code / codex 需要严格版本配对而不是防降级，那这个 PR 应该只保留解析修复，CONFIG 那两行请直接砍掉 —— 解析修复本身独立成立（`codex-cli` 的输出形态目前解析不出来是确定的缺口）。
- 回滚 / 降级方式：revert 本 commit 即可，无状态残留、无数据迁移。

### 提交前检查

- [x] 已 review 完整 diff
- [x] 每个 commit 都带 DCO 签名（`git commit -s`）
- [x] UI 改动已在「UI 变化」注明引用的设计规范章节（不涉及 UI 则跳过）
- [x] 未提交凭证、令牌或授权文件
- [x] 已补充必要文档（本改动无需文档变更）
- [x] 已确认测试结果或说明未执行原因
