### PR TITLE
fix(desktop): 修复 XD 网关向量模型能力投影

### DIFF
--- a/apps/desktop/src/main/maker-host/__tests__/activeCatalogXdAvailability.test.ts
+++ b/apps/desktop/src/main/maker-host/__tests__/activeCatalogXdAvailability.test.ts
@@ -44,6 +44,9 @@ describe('XD 网关权威模型清单重建', () => {
     const xd = getActiveCatalog().providers.find((provider) => provider.id === 'xd');
     expect(xd?.imageModels).toEqual([]);
     expect(xd?.videoModels).toEqual([]);
+    expect(xd?.embeddingModels).toEqual(
+      BUNDLED_CATALOG.providers.find((provider) => provider.id === 'xd')?.embeddingModels,
+    );
   });
 
   it('显式空列表保持 XD 模型不可用', () => {
@@ -118,6 +121,20 @@ describe('XD 网关权威模型清单重建', () => {
         agents: [],
         modalities: { input: ['text', 'image'], output: ['video'] },
       },
+      {
+        id: 'voyage/voyage-4',
+        name: 'Voyage 4',
+        mode: 'embedding',
+        availability: 'available',
+        agents: [],
+      },
+      {
+        id: 'voyage/voyage-4-large',
+        name: 'Voyage 4 Large',
+        mode: 'embedding',
+        availability: 'requires_payment',
+        agents: [],
+      },
     ]);
 
     const activeXd = getActiveCatalog().providers.find((provider) => provider.id === 'xd');
@@ -130,7 +147,8 @@ describe('XD 网关权威模型清单重建', () => {
       },
     ]);
     expect(activeXd?.imageDefaults).toEqual({ standard: 'openai/gpt-image-2' });
-    expect(activeXd?.embeddingModels).toEqual([]);
+    expect(activeXd?.embeddingModels).toEqual([{ id: 'voyage/voyage-4', name: 'Voyage 4' }]);
+    expect(activeXd?.embeddingDefaults).toEqual({ standard: 'voyage/voyage-4' });
     expect(activeXd?.videoModels).toEqual([
       {
         id: 'bytedance/seedance-2.5',
@@ -140,6 +158,29 @@ describe('XD 网关权威模型清单重建', () => {
     ]);
     expect(activeXd?.videoDefaults).toEqual({ standard: 'bytedance/seedance-2.5' });
     expect(xdModels('claude-code')).toEqual([]);
+  });
+
+  it('网关明确返回仅付费 embedding 时不保留静态 embedding', () => {
+    const catalog = JSON.parse(JSON.stringify(BUNDLED_CATALOG)) as typeof BUNDLED_CATALOG;
+    const catalogXd = catalog.providers.find((provider) => provider.id === 'xd');
+    if (!catalogXd) throw new Error('missing XD provider fixture');
+    catalogXd.embeddingModels = [{ id: 'voyage/voyage-4', name: 'Voyage 4' }];
+    catalogXd.embeddingDefaults = { standard: 'voyage/voyage-4' };
+
+    setActiveCatalog(catalog);
+    setXdGatewayModels([
+      {
+        id: 'voyage/voyage-4',
+        name: 'Voyage 4',
+        mode: 'embedding',
+        availability: 'requires_payment',
+        agents: [],
+      },
+    ]);
+
+    const activeXd = getActiveCatalog().providers.find((provider) => provider.id === 'xd');
+    expect(activeXd?.embeddingModels).toBeUndefined();
+    expect(activeXd?.embeddingDefaults).toBeUndefined();
   });
 
   it('v3 未声明 agents 的模型不进入任何 runtime', () => {

--- a/apps/desktop/src/main/maker-host/__tests__/activeCatalogXdAvailability.test.ts
+++ b/apps/desktop/src/main/maker-host/__tests__/activeCatalogXdAvailability.test.ts
@@ -205,6 +205,21 @@ describe('XD 网关权威模型清单重建', () => {
     expect(activeXd?.embeddingDefaults).toBeUndefined();
   });
 
+  it('网关权威空快照清除静态 embedding', () => {
+    const catalog = JSON.parse(JSON.stringify(BUNDLED_CATALOG)) as typeof BUNDLED_CATALOG;
+    const catalogXd = catalog.providers.find((provider) => provider.id === 'xd');
+    if (!catalogXd) throw new Error('missing XD provider fixture');
+    catalogXd.embeddingModels = [{ id: 'voyage/voyage-4', name: 'Voyage 4' }];
+    catalogXd.embeddingDefaults = { standard: 'voyage/voyage-4' };
+
+    setActiveCatalog(catalog);
+    setXdGatewayModels([], { authoritative: true });
+
+    const activeXd = getActiveCatalog().providers.find((provider) => provider.id === 'xd');
+    expect(activeXd?.embeddingModels).toBeUndefined();
+    expect(activeXd?.embeddingDefaults).toBeUndefined();
+  });
+
   it('v3 未声明 agents 的模型不进入任何 runtime', () => {
     setActiveCatalog(BUNDLED_CATALOG);
     setXdGatewayModels([{ id: 'brand-new-model' }]);

--- a/apps/desktop/src/main/maker-host/__tests__/activeCatalogXdAvailability.test.ts
+++ b/apps/desktop/src/main/maker-host/__tests__/activeCatalogXdAvailability.test.ts
@@ -176,11 +176,20 @@ describe('XD 网关权威模型清单重建', () => {
         availability: 'requires_payment',
         agents: [],
       },
-    ]);
+    ], { authoritative: true });
 
     const activeXd = getActiveCatalog().providers.find((provider) => provider.id === 'xd');
     expect(activeXd?.embeddingModels).toBeUndefined();
     expect(activeXd?.embeddingDefaults).toBeUndefined();
+
+    setXdGatewayModels([], {
+      authoritative: false,
+      preservePaymentRequiredRoutes: true,
+    });
+
+    const afterRefreshFailure = getActiveCatalog().providers.find((provider) => provider.id === 'xd');
+    expect(afterRefreshFailure?.embeddingModels).toBeUndefined();
+    expect(afterRefreshFailure?.embeddingDefaults).toBeUndefined();
   });
 
   it('网关 embedding 缺少 availability 时不解锁静态 embedding', () => {

--- a/apps/desktop/src/main/maker-host/__tests__/activeCatalogXdAvailability.test.ts
+++ b/apps/desktop/src/main/maker-host/__tests__/activeCatalogXdAvailability.test.ts
@@ -229,6 +229,21 @@ describe('XD 网关权威模型清单重建', () => {
     expect(activeXd?.embeddingDefaults).toBeUndefined();
   });
 
+  it('账号边界等待新快照时不回退到静态 embedding', () => {
+    const catalog = JSON.parse(JSON.stringify(BUNDLED_CATALOG)) as typeof BUNDLED_CATALOG;
+    const catalogXd = catalog.providers.find((provider) => provider.id === 'xd');
+    if (!catalogXd) throw new Error('missing XD provider fixture');
+    catalogXd.embeddingModels = [{ id: 'voyage/voyage-4', name: 'Voyage 4' }];
+    catalogXd.embeddingDefaults = { standard: 'voyage/voyage-4' };
+
+    setActiveCatalog(catalog);
+    setXdGatewayModels([], { suppressEmbeddingFallback: true });
+
+    const activeXd = getActiveCatalog().providers.find((provider) => provider.id === 'xd');
+    expect(activeXd?.embeddingModels).toBeUndefined();
+    expect(activeXd?.embeddingDefaults).toBeUndefined();
+  });
+
   it('v3 未声明 agents 的模型不进入任何 runtime', () => {
     setActiveCatalog(BUNDLED_CATALOG);
     setXdGatewayModels([{ id: 'brand-new-model' }]);

--- a/apps/desktop/src/main/maker-host/__tests__/activeCatalogXdAvailability.test.ts
+++ b/apps/desktop/src/main/maker-host/__tests__/activeCatalogXdAvailability.test.ts
@@ -183,6 +183,28 @@ describe('XD 网关权威模型清单重建', () => {
     expect(activeXd?.embeddingDefaults).toBeUndefined();
   });
 
+  it('网关 embedding 缺少 availability 时不解锁静态 embedding', () => {
+    const catalog = JSON.parse(JSON.stringify(BUNDLED_CATALOG)) as typeof BUNDLED_CATALOG;
+    const catalogXd = catalog.providers.find((provider) => provider.id === 'xd');
+    if (!catalogXd) throw new Error('missing XD provider fixture');
+    catalogXd.embeddingModels = [{ id: 'voyage/voyage-4', name: 'Voyage 4' }];
+    catalogXd.embeddingDefaults = { standard: 'voyage/voyage-4' };
+
+    setActiveCatalog(catalog);
+    setXdGatewayModels([
+      {
+        id: 'voyage/voyage-4',
+        name: 'Voyage 4',
+        mode: 'embedding',
+        agents: [],
+      },
+    ]);
+
+    const activeXd = getActiveCatalog().providers.find((provider) => provider.id === 'xd');
+    expect(activeXd?.embeddingModels).toBeUndefined();
+    expect(activeXd?.embeddingDefaults).toBeUndefined();
+  });
+
   it('v3 未声明 agents 的模型不进入任何 runtime', () => {
     setActiveCatalog(BUNDLED_CATALOG);
     setXdGatewayModels([{ id: 'brand-new-model' }]);

--- a/apps/desktop/src/main/maker-host/active-catalog.ts
+++ b/apps/desktop/src/main/maker-host/active-catalog.ts
@@ -199,6 +199,14 @@ let xdGatewayModels: XdGatewayModelInfo[] = [];
 /** 当前账号最近一次 `/models` 成功响应；false 时清单缺席不能作为模型不存在的 deny 证据。 */
 let xdGatewayModelsAuthoritative = false;
 /**
+ * 当前认证世代是否已经观察到过权威的网关模型快照。
+ *
+ * 刷新失败时会把过期的 requires_payment 行从活动目录移除；即使因此暂时没有
+ * embedding 条目，也不能再回退到 bundled embedding。空的非保留快照(登出、禁用
+ * 或测试清理)会重置这个边界，避免把上一账号的 deny 状态带入下一账号。
+ */
+let xdGatewayEmbeddingSnapshotKnown = false;
+/**
  * 最近一次成功 v5 响应明确拒绝的 XD 对话路由。
  *
  * 刷新失败时活动目录会隐藏过期的付费营销行，但既有会话的派发终检仍须保留这份
@@ -898,7 +906,7 @@ function projectXdGatewayMediaModels(
   delete identity.imageDefaults;
   delete identity.videoModels;
   delete identity.videoDefaults;
-  if (options.authoritative || hasEmbeddingEntries) {
+  if (options.authoritative || hasEmbeddingEntries || xdGatewayEmbeddingSnapshotKnown) {
     delete identity.embeddingModels;
     delete identity.embeddingDefaults;
   }
@@ -1558,6 +1566,11 @@ export function setXdGatewayModels(
   xdGatewayModels = [...models];
   if (options?.authoritative !== undefined) {
     xdGatewayModelsAuthoritative = options.authoritative;
+  }
+  if (options?.authoritative === true) {
+    xdGatewayEmbeddingSnapshotKnown = true;
+  } else if (models.length === 0 && options?.preservePaymentRequiredRoutes !== true) {
+    xdGatewayEmbeddingSnapshotKnown = false;
   }
   if (options?.preservePaymentRequiredRoutes !== true) {
     xdGatewayPaymentRequiredRoutes = new Set(

--- a/apps/desktop/src/main/maker-host/active-catalog.ts
+++ b/apps/desktop/src/main/maker-host/active-catalog.ts
@@ -886,7 +886,7 @@ function projectXdGatewayMediaModels(
   // agent-bound `models`. A gateway snapshot that explicitly includes embedding models is
   // authoritative for the current account; payment-only entries must not unlock chat indexing.
   const embeddingModels = gatewayModels
-    .filter((model) => model.mode === 'embedding' && model.availability !== 'requires_payment')
+    .filter((model) => model.mode === 'embedding' && model.availability === 'available')
     .map((model) => ({
       id: model.id,
       name: model.name ?? model.id,

--- a/apps/desktop/src/main/maker-host/active-catalog.ts
+++ b/apps/desktop/src/main/maker-host/active-catalog.ts
@@ -199,13 +199,13 @@ let xdGatewayModels: XdGatewayModelInfo[] = [];
 /** 当前账号最近一次 `/models` 成功响应；false 时清单缺席不能作为模型不存在的 deny 证据。 */
 let xdGatewayModelsAuthoritative = false;
 /**
- * 当前认证世代是否已经观察到过权威的网关模型快照。
+ * 最近一次网关快照是否已把 embedding 能力交给网关判定。
  *
  * 刷新失败时会把过期的 requires_payment 行从活动目录移除；即使因此暂时没有
- * embedding 条目，也不能再回退到 bundled embedding。空的非保留快照(登出、禁用
- * 或测试清理)会重置这个边界，避免把上一账号的 deny 状态带入下一账号。
+ * embedding 条目，也不能再回退到 bundled embedding。账号边界显式置为 true，
+ * 直到新账号收到首个权威快照；测试清理和非账号的空快照才会重置它。
  */
-let xdGatewayEmbeddingSnapshotKnown = false;
+let xdGatewayEmbeddingFallbackSuppressed = false;
 /**
  * 最近一次成功 v5 响应明确拒绝的 XD 对话路由。
  *
@@ -906,7 +906,11 @@ function projectXdGatewayMediaModels(
   delete identity.imageDefaults;
   delete identity.videoModels;
   delete identity.videoDefaults;
-  if (options.authoritative || hasEmbeddingEntries || xdGatewayEmbeddingSnapshotKnown) {
+  if (
+    options.authoritative ||
+    hasEmbeddingEntries ||
+    xdGatewayEmbeddingFallbackSuppressed
+  ) {
     delete identity.embeddingModels;
     delete identity.embeddingDefaults;
   }
@@ -1561,16 +1565,20 @@ export function setDiscoveredProviderMediaModels(
  */
 export function setXdGatewayModels(
   models: XdGatewayModelInfo[],
-  options?: { authoritative?: boolean; preservePaymentRequiredRoutes?: boolean },
+  options?: {
+    authoritative?: boolean;
+    preservePaymentRequiredRoutes?: boolean;
+    suppressEmbeddingFallback?: boolean;
+  },
 ): void {
   xdGatewayModels = [...models];
   if (options?.authoritative !== undefined) {
     xdGatewayModelsAuthoritative = options.authoritative;
   }
-  if (options?.authoritative === true) {
-    xdGatewayEmbeddingSnapshotKnown = true;
+  if (options?.authoritative === true || options?.suppressEmbeddingFallback === true) {
+    xdGatewayEmbeddingFallbackSuppressed = true;
   } else if (models.length === 0 && options?.preservePaymentRequiredRoutes !== true) {
-    xdGatewayEmbeddingSnapshotKnown = false;
+    xdGatewayEmbeddingFallbackSuppressed = false;
   }
   if (options?.preservePaymentRequiredRoutes !== true) {
     xdGatewayPaymentRequiredRoutes = new Set(

--- a/apps/desktop/src/main/maker-host/active-catalog.ts
+++ b/apps/desktop/src/main/maker-host/active-catalog.ts
@@ -865,6 +865,7 @@ function withEmptyModels(p: Provider): Provider {
 function projectXdGatewayMediaModels(
   provider: Provider,
   gatewayModels: readonly XdGatewayModelInfo[],
+  options: { authoritative: boolean },
 ): Provider {
   const imageModels = gatewayModels
     .filter((model) => model.mode === 'image_generation')
@@ -897,7 +898,7 @@ function projectXdGatewayMediaModels(
   delete identity.imageDefaults;
   delete identity.videoModels;
   delete identity.videoDefaults;
-  if (hasEmbeddingEntries) {
+  if (options.authoritative || hasEmbeddingEntries) {
     delete identity.embeddingModels;
     delete identity.embeddingDefaults;
   }
@@ -1286,7 +1287,12 @@ function computeMerged(): Catalog {
         )
         .map(({ model }) => model);
     }
-    return { ...projectXdGatewayMediaModels(p, gwModels), models };
+    return {
+      ...projectXdGatewayMediaModels(p, gwModels, {
+        authoritative: xdGatewayModelsAuthoritative,
+      }),
+      models,
+    };
   });
 
   if (providers === b.providers) return b; // 无 augment、无 custom → 原样返回

--- a/apps/desktop/src/main/maker-host/active-catalog.ts
+++ b/apps/desktop/src/main/maker-host/active-catalog.ts
@@ -882,17 +882,35 @@ function projectXdGatewayMediaModels(
       ...(model.availability ? { availability: model.availability } : {}),
       ...(model.modalities ? { modalities: model.modalities } : {}),
     }));
+  // Embedding is a provider-level capability, so it must be projected separately from
+  // agent-bound `models`. A gateway snapshot that explicitly includes embedding models is
+  // authoritative for the current account; payment-only entries must not unlock chat indexing.
+  const embeddingModels = gatewayModels
+    .filter((model) => model.mode === 'embedding' && model.availability !== 'requires_payment')
+    .map((model) => ({
+      id: model.id,
+      name: model.name ?? model.id,
+    }));
+  const hasEmbeddingEntries = gatewayModels.some((model) => model.mode === 'embedding');
   const identity = { ...provider };
   delete identity.imageModels;
   delete identity.imageDefaults;
   delete identity.videoModels;
   delete identity.videoDefaults;
+  if (hasEmbeddingEntries) {
+    delete identity.embeddingModels;
+    delete identity.embeddingDefaults;
+  }
   return {
     ...identity,
     imageModels,
     videoModels,
+    ...(embeddingModels.length > 0 ? { embeddingModels } : {}),
     ...(imageModels[0] ? { imageDefaults: { standard: imageModels[0].id } } : {}),
     ...(videoModels[0] ? { videoDefaults: { standard: videoModels[0].id } } : {}),
+    ...(embeddingModels[0]
+      ? { embeddingDefaults: { standard: embeddingModels[0].id } }
+      : {}),
   };
 }
 

--- a/apps/desktop/src/main/model-access/index.ts
+++ b/apps/desktop/src/main/model-access/index.ts
@@ -181,6 +181,7 @@ function applyGatewayModels(
     authenticatedUserId?: string;
     authoritative?: boolean;
     preservePaymentRequiredRoutes?: boolean;
+    suppressEmbeddingFallback?: boolean;
   } = {},
 ): void {
   // 同一次 /models 响应建立 XD 模型与价格投影。空成功响应会同时清空模型和价格；请求失败不会调用本函数，
@@ -221,6 +222,7 @@ function applyGatewayModels(
   setXdGatewayModels(models, {
     authoritative: options.authoritative ?? false,
     preservePaymentRequiredRoutes: options.preservePaymentRequiredRoutes,
+    suppressEmbeddingFallback: options.suppressEmbeddingFallback,
   });
 }
 
@@ -364,7 +366,7 @@ function getSync(): CredentialsSync {
             preservePaymentRequiredRoutes: shouldPreservePaymentRequiredRoutes(status),
           });
         } else if (['disabled', 'unsupported', 'idle'].includes(status.state)) {
-          applyGatewayModels([]);
+          applyGatewayModels([], { suppressEmbeddingFallback: true });
         }
       },
       log: {
@@ -472,7 +474,7 @@ export function initModelAccess(): void {
       authGeneration++;
       accountTier = null;
       // 旧身份模型清单不能跨账号/区域继续显示;新身份拉取成功后再注入。
-      applyGatewayModels([]);
+      applyGatewayModels([], { suppressEmbeddingFallback: true });
     }
     lastAuthUserId = isAuthenticated ? (userId ?? lastAuthUserId) : null;
     lastAuthRealm = isAuthenticated ? (realm ?? lastAuthRealm) : null;

--- a/packages/model-providers/src/__tests__/modelAccessValidator.test.ts
+++ b/packages/model-providers/src/__tests__/modelAccessValidator.test.ts
@@ -332,6 +332,43 @@ describe('model access catalog contract', () => {
     }
   });
 
+  it('v4/v5 允许 provider-level embedding 模型使用空 agents 且省略 contextWindow', () => {
+    const embeddingModel = {
+      id: 'voyage/voyage-4',
+      name: 'Voyage 4',
+      mode: 'embedding',
+      currency: 'CNY',
+      agents: [],
+    } as const;
+
+    expect(
+      parseListModelsResponse({
+        schemaVersion: MODEL_ACCESS_CATALOG_SCHEMA_VERSION,
+        models: [embeddingModel],
+      }).ok,
+    ).toBe(true);
+    expect(
+      parseListModelsResponse({
+        schemaVersion: MODEL_ACCESS_CATALOG_V5_SCHEMA_VERSION,
+        accountTier: 'paid',
+        models: [{ ...embeddingModel, availability: 'available' }],
+      }).ok,
+    ).toBe(true);
+    expect(
+      parseListModelsResponse({
+        schemaVersion: MODEL_ACCESS_CATALOG_V3_SCHEMA_VERSION,
+        models: [embeddingModel],
+      }).ok,
+    ).toBe(false);
+    expectReject(
+      {
+        schemaVersion: MODEL_ACCESS_CATALOG_SCHEMA_VERSION,
+        models: [{ ...embeddingModel, agents: ['codex'] }],
+      },
+      'response.models[0].agents must be empty',
+    );
+  });
+
   it.each(['CNY', 'USD'] as const)('accepts the supported %s currency', (currency) => {
     const result = parseListModelsResponse({
       ...VALID_RESPONSE,

--- a/packages/model-providers/src/modelAccessValidator.ts
+++ b/packages/model-providers/src/modelAccessValidator.ts
@@ -467,19 +467,21 @@ function modelEntryError(
     );
     if (defaultError) return defaultError;
   }
-  const isV4MediaModel =
+  const isV4StandaloneModel =
     schemaVersion === MODEL_ACCESS_CATALOG_SCHEMA_VERSION &&
-    (value.mode === 'image_generation' || value.mode === 'video_generation');
-  if (isV4MediaModel && supportedAgents.length > 0) {
-    return `${path}.agents must be empty for a v4 Gateway media mode`;
+    (value.mode === 'image_generation' ||
+      value.mode === 'video_generation' ||
+      value.mode === 'embedding');
+  if (isV4StandaloneModel && supportedAgents.length > 0) {
+    return `${path}.agents must be empty for a v4 Gateway standalone capability mode`;
   }
   if (
     (schemaVersion === MODEL_ACCESS_CATALOG_V3_SCHEMA_VERSION ||
       schemaVersion === MODEL_ACCESS_CATALOG_SCHEMA_VERSION) &&
     supportedAgents.length === 0 &&
-    !isV4MediaModel
+    !isV4StandaloneModel
   ) {
-    return `${path}.agents may be empty only for a v4 Gateway media mode`;
+    return `${path}.agents may be empty only for a v4 Gateway standalone capability mode`;
   }
 
   for (const [key, max] of [
@@ -509,7 +511,7 @@ function modelEntryError(
   }
   if (
     (schemaVersion === MODEL_ACCESS_CATALOG_V3_SCHEMA_VERSION ||
-      (schemaVersion === MODEL_ACCESS_CATALOG_SCHEMA_VERSION && !isV4MediaModel)) &&
+      (schemaVersion === MODEL_ACCESS_CATALOG_SCHEMA_VERSION && !isV4StandaloneModel)) &&
     value.contextWindow === undefined
   ) {
     return `${path}.contextWindow is required for schema version 3 and v4 chat models`;


### PR DESCRIPTION
## 这次改了什么

### 摘要

修复 XD 网关向量搜索能力在客户端目录和协议边界上的五处缺陷：

1. `/models` 返回 embedding 模型时，将其投影到 provider-level `embeddingModels`；只有明确 `availability: "available"` 的模型才会解锁向量索引。
2. Model Access v4/v5 校验器允许 provider-level embedding 使用 `mode: "embedding", agents: []`，避免合法响应在进入投影前被整包拒绝。
3. 权威空 `/models` 快照即使不含 embedding，也会清掉静态 provider-level embedding，避免旧能力残留。
4. 刷新失败降级为非权威 LKG 时，保留最近一次权威 embedding 能力边界，避免移除付费行后又重新暴露 bundled embedding。
5. 账号/区域切换或网关能力进入 disabled、unsupported、idle 边界时，先锁住静态 embedding，直到新账号收到首个权威快照。

### 变更类型

- [x] `fix` 缺陷修复
- [ ] `feat` 新功能
- [ ] `refactor` / `perf` 重构或性能优化
- [ ] `docs` / `test` / `chore` 文档、测试或工程维护
- [ ] 其他：

### 范围

- 关联 Issue / 需求：无（用户反馈及本 PR review）
- 本 PR 包含：XD embedding 能力投影、可用性门控、权威空快照清理、刷新失败后的 embedding deny 保留、账号边界静态 embedding 锁定、Model Access v4/v5 协议校验修复，以及对应回归测试。
- 明确不包含：不绕过地区或账号权限；不修改服务端模型目录；不修改向量索引数据和数据库 schema。
- 用户可见变化：账号的网关模型清单明确包含可用 embedding 模型时，向量搜索选项可正常打开；仅付费、缺少可用性证明、未下发、权威清单明确省略或刷新失败时仍保持不可用。
- 是否存在 breaking change：无

### UI 变化

- 不涉及：仅修改 Desktop main 侧模型目录/协议解析和单元测试，没有 UI 布局、样式或文案变更。
- 引用的设计规范：不涉及。

## 怎么验证的

### 自动验证

```text
pnpm --filter desktop exec vitest run src/main/maker-host/__tests__/activeCatalogXdAvailability.test.ts
结果：28 个测试全部通过。

pnpm --filter @cindy/model-providers exec vitest run src/__tests__/modelAccessValidator.test.ts
结果：41 个测试全部通过。

pnpm --filter desktop run typecheck
结果：通过。

pnpm --filter @cindy/model-providers run --if-present typecheck
结果：通过（脚本无输出）。

pnpm test:unit:related
结果：apps/desktop、apps/mobile、packages/model-providers 全部通过。

bash /Users/dash/Code/XD/dash/Skills/git/scripts/run-unit-gate.sh /Users/dash/Code/Cindy/cindy/.cindy-worktrees/silent-ritchie
结果：GATE_EXIT=0。

pnpm check:dco
结果：5 个 commit 均已通过 DCO。

git diff --check
结果：通过。
```

### 手工验证

不涉及：本 PR 不包含 UI 代码；运行中的客户端需在包含该修复的构建中重新同步网关模型目录后验证开关。

### 未执行的验证

未在当前登录账号上启动 Desktop 并重新点击向量选项；服务端是否向该账号下发可用 embedding 模型仍需登录态环境确认。

## 风险

### 风险分类

- [ ] 无已知风险
- [ ] SQLite / migration
- [ ] system prompt
- [x] 协议兼容（客户端放宽 v4/v5 的 provider-level embedding 合法形状；不改变已有 chat/media 语义）
- [x] 权限 / 安全 / 用户数据（仅复用服务端明确的 `availability: "available"`，不放宽权限）
- [ ] 存量插件兼容（批准状态 / 指纹 / manifest 校验 / 安装布局 / 包格式）
- [ ] 原生层 / fingerprint / OTA
- [ ] 跨平台差异
- [ ] 其他：

### 影响与回滚

- 影响范围：XD 网关 embedding 模型的协议解析和 provider-level 能力投影；没有可用性证明或权威清单明确省略的模型不会解锁向量搜索。
- 回滚 / 降级方式：回滚本 PR 即可恢复原有行为；不涉及数据库或服务端迁移。

### 提交前检查

- [x] 已 review 完整 diff
- [x] 每个 commit 都带 DCO 签名（`git commit -s`，见 [DCO](../DCO)）
- [x] UI 改动已在「UI 变化」注明引用的设计规范章节（不涉及 UI 则跳过）
- [x] 未提交凭证、令牌或授权文件
- [x] 已补充必要文档
- [x] 已确认测试结果或说明未执行原因


