### PR TITLE
fix(desktop): 优化登录成功回调页自动关闭

### DIFF
--- a/apps/desktop/scripts/export-login-callback-template.ts
+++ b/apps/desktop/scripts/export-login-callback-template.ts
@@ -9,7 +9,8 @@
  * 产物特性:
  *  - 每份 HTML 自带 light / dark(不写 data-theme,页面用 prefers-color-scheme
  *    跟随系统),服务端不需要也不应该分主题挑文件;
- *  - 成功页完全静态;失败页留 `{{ERROR_DETAIL}}` 一个占位符给错误码;
+ *  - 成功页带 3 秒倒计时并在倒计时结束时自动关闭;失败页留 `{{ERROR_DETAIL}}`
+ *    一个占位符给错误码;
  *  - chibi 立绘等资源已是构建期 data URI,HTML 自包含,无外链依赖。
  *
  * 用法:
@@ -41,7 +42,7 @@ import {
  */
 const ERROR_DETAIL_PLACEHOLDER = '{{ERROR_DETAIL}}';
 
-/** 回到客户端的 CTA。与生产 buildFocusDeepLink('desktop-login') 同形。 */
+/** 失败页回到客户端的 CTA。与生产 buildFocusDeepLink('desktop-login') 同形。 */
 const FOCUS_DEEP_LINK = `${DEEP_LINK_URL_PREFIX}focus/desktop-login`;
 
 const DEFAULT_OUT_DIR = path.join(
@@ -77,8 +78,9 @@ function renderPage(
     variant,
     title: isError ? copy.errorTitle : copy.successTitle,
     body: isError ? copy.errorBody : copy.successBody,
+    closeCountdown: isError ? undefined : copy.closeCountdown,
     detail: isError ? ERROR_DETAIL_PLACEHOLDER : undefined,
-    action: { href: FOCUS_DEEP_LINK, label: copy.returnButton },
+    action: isError ? { href: FOCUS_DEEP_LINK, label: copy.returnButton } : undefined,
   });
 }
 
@@ -129,7 +131,7 @@ function main(): void {
       // 回调阶段已被消费,托管回调这一步拿不到 authorize 时传的 ui_locale。
       '语言按浏览器 Accept-Language 选择(托管回调阶段已取不到 ui_locale);缺省回落 en。',
       '模板随客户端文案变更需重新导出,不要在服务端侧手改 HTML。',
-      'pages[].scriptHashes 直接拼进结果页的 CSP script-src;该内联脚本是布局必需的(整卡等比缩放+水平居中),不要改成 unsafe-inline,也不要自行解析 HTML 重算。',
+      'pages[].scriptHashes 直接拼进结果页的 CSP script-src;该内联脚本负责布局、成功页 3 秒倒计时与自动关闭,不要改成 unsafe-inline,也不要自行解析 HTML 重算。',
     ],
     pages,
   };

--- a/apps/desktop/scripts/lib/loginCallbackCopy.ts
+++ b/apps/desktop/scripts/lib/loginCallbackCopy.ts
@@ -36,6 +36,7 @@ export const OAUTH_RESULT_LANGS = Object.keys(OAUTH_LANG_TO_APP_LOCALES) as OAut
 export interface LoginBrowserCallbackCopy {
   successTitle: string;
   successBody: string;
+  closeCountdown: string;
   errorTitle: string;
   errorBody: string;
   returnButton: string;
@@ -61,6 +62,7 @@ export function loadLoginCallbackCopy(lang: OAuthResultPageLang): LoginBrowserCa
     return {
       successTitle: resolve('successTitle'),
       successBody: resolve('successBody'),
+      closeCountdown: resolve('closeCountdown'),
       errorTitle: resolve('errorTitle'),
       errorBody: resolve('errorBody'),
       returnButton: resolve('returnButton'),

--- a/apps/desktop/scripts/preview-oauth-pages.ts
+++ b/apps/desktop/scripts/preview-oauth-pages.ts
@@ -98,10 +98,11 @@ function renderPreviewPage(
       ...base,
       pageKind: 'desktop-login',
       copyKind: 'login.browserCallback',
-      action: { ...action, label: login.returnButton },
+      action: success ? undefined : { ...action, label: login.returnButton },
       variant: success ? 'success' : 'error',
       title: success ? login.successTitle : login.errorTitle,
       body: success ? login.successBody : login.errorBody,
+      closeCountdown: success ? login.closeCountdown : undefined,
       detail: success ? undefined : 'STATE_MISMATCH',
     });
   }
@@ -170,7 +171,7 @@ function renderToolbar(
 <title>Cindy OAuth 回调页预览</title>
 <style>
 *{box-sizing:border-box}body{margin:0;height:100vh;display:grid;grid-template-rows:auto 1fr;font-family:Inter,system-ui,-apple-system,"Segoe UI",sans-serif;background:#ececea;color:#262626}
-.toolbar{display:flex;align-items:center;gap:12px;padding:12px 16px;border-bottom:1px solid #d7d7d4;background:#f8f8f6}.title{font-size:14px;font-weight:600;margin-right:auto}.field{display:flex;align-items:center;gap:6px;font-size:12px;color:#737373}select,.open{height:34px;border:1px solid #c7c7c3;border-radius:8px;background:#fff;color:#262626;padding:0 10px;font:inherit}.open{display:inline-flex;align-items:center;text-decoration:none;font-size:12px}iframe{width:100%;height:100%;border:0;background:#f8f8f6}@media(max-width:720px){.toolbar{align-items:stretch;flex-wrap:wrap}.title{width:100%;margin:0}.field{flex:1;min-width:140px}.field select{width:100%}}
+.toolbar{display:flex;align-items:center;gap:12px;padding:12px 16px;border-bottom:1px solid #d7d7d4;background:#f8f8f6}.title{font-size:14px;font-weight:600;margin-right:auto}.field{display:flex;align-items:center;gap:6px;font-size:12px;color:#737373}select,.open,.script-open{height:34px;border:1px solid #c7c7c3;border-radius:8px;background:#fff;color:#262626;padding:0 10px;font:inherit}.open,.script-open{display:inline-flex;align-items:center;text-decoration:none;font-size:12px;cursor:pointer}.script-open{appearance:none}iframe{width:100%;height:100%;border:0;background:#f8f8f6}@media(max-width:720px){.toolbar{align-items:stretch;flex-wrap:wrap}.title{width:100%;margin:0}.field{flex:1;min-width:140px}.field select{width:100%}}
 </style>
 </head>
 <body>
@@ -180,13 +181,15 @@ function renderToolbar(
   <label class="field">语言<select id="lang">${langOptions}</select></label>
   <label class="field">主题<select id="theme">${themeOptions}</select></label>
   <a class="open" id="open" target="_blank" rel="noreferrer">单独打开</a>
+  <button class="script-open" id="script-open" type="button">脚本打开测试</button>
 </div>
 <iframe id="preview" title="OAuth result page preview"></iframe>
 <script>
 const fields={kind:document.querySelector('#kind'),lang:document.querySelector('#lang'),theme:document.querySelector('#theme')};
-const frame=document.querySelector('#preview');const open=document.querySelector('#open');
+const frame=document.querySelector('#preview');const open=document.querySelector('#open');const scriptOpen=document.querySelector('#script-open');
 function refresh(){const query=new URLSearchParams({kind:fields.kind.value,lang:fields.lang.value,theme:fields.theme.value});const page='/page?'+query;frame.src=page;open.href=page;history.replaceState(null,'','/?'+query)}
 Object.values(fields).forEach((field)=>field.addEventListener('change',refresh));refresh();
+scriptOpen.addEventListener('click',()=>window.open(open.href,'_blank'));
 </script>
 </body>
 </html>`;

--- a/apps/desktop/src/main/__tests__/authLoopbackCallback.test.ts
+++ b/apps/desktop/src/main/__tests__/authLoopbackCallback.test.ts
@@ -41,21 +41,24 @@ describe('auth loopback callback page', () => {
       htmlLang: 'zh-CN',
       variant: 'success',
       title: '登录成功',
-      body: '你可以关闭此页面，回到 Cindy 继续。',
+      body: '登录已成功，现在可以关闭此页面了。',
+      closeCountdown: '{{count}}秒后自动关闭',
     });
     expect(html).toContain('<html lang="zh-CN">');
     expect(html).toContain('<h1>登录成功</h1>');
-    expect(html).toContain('你可以关闭此页面，回到 Cindy 继续。');
+    expect(html).toContain('登录已成功，现在可以关闭此页面了。');
+    expect(html).toContain('3秒后自动关闭');
+    expect(html).toContain('id="close-countdown"');
     expect(html).not.toContain('class="detail"');
     expect(html).not.toContain('class="cta"');
   });
 
-  it('renders the return-to-app CTA when an action is provided', () => {
+  it('renders the return-to-app CTA on an error page when an action is provided', () => {
     const html = renderAuthLoopbackPage({
       htmlLang: 'zh-CN',
-      variant: 'success',
-      title: '登录成功',
-      body: '你可以关闭此页面，回到 Cindy 继续。',
+      variant: 'error',
+      title: '登录未完成',
+      body: '请回到 Cindy 重新登录。',
       action: { href: 'cindy://focus/desktop-login', label: '回到 Cindy' },
     });
     expect(html).toContain('<a class="cta" href="cindy://focus/desktop-login">回到 Cindy</a>');
@@ -129,11 +132,14 @@ describe('auth loopback page brand wiring (PR3)', () => {
       htmlLang: 'zh-CN',
       variant: 'success',
       title: '登录成功',
-      body: '你可以关闭此页面，回到 Cindy 继续。',
+      body: '登录已成功，现在可以关闭此页面了。',
+      closeCountdown: '{{count}}秒后自动关闭',
     });
     expect(html).toContain('data-cindy-oauth-visual="success"');
     expect(html).toContain('data-cindy-oauth-copy="login.browserCallback"');
-    expect(html).toContain('width:680px;height:680px');
+    expect(html).toContain('data-cindy-oauth-layout="compact"');
+    expect(html).toContain('data-card-width="560" data-card-height="500"');
+    expect(html).toContain('3秒后自动关闭');
   });
 });
 

--- a/apps/desktop/src/main/__tests__/oauthResultPage.test.ts
+++ b/apps/desktop/src/main/__tests__/oauthResultPage.test.ts
@@ -202,32 +202,53 @@ describe('renderOAuthResultPage', () => {
 const BRAND_BASE = {
   htmlLang: 'zh-CN',
   title: '登录成功',
-  body: '你可以关闭此页面，回到 Cindy 继续。',
+  body: '登录已成功，现在可以关闭此页面了。',
+  closeCountdown: '{{count}}秒后自动关闭',
   action: { href: 'cindy://focus/desktop-login', label: '回到 Cindy' },
 } as const;
 
 describe('wave4 brand login callback card (pageKind=desktop-login)', () => {
-  it('renders the 680 brand card with the frozen U-10 scale formula', () => {
+  it('renders the compact success card with the frozen U-10 scale formula', () => {
     const html = renderOAuthResultPage({
       ...BRAND_BASE,
       variant: 'success',
       pageKind: 'desktop-login',
     });
-    // 卡内几何零响应式:680×680 r36 + 立绘/标题/副文案/CTA 冻结坐标(figma §6.1)
-    expect(html).toContain('width:680px;height:680px');
+    // 成功态移除 CTA 后使用紧凑流式卡,避免沿用失败态卡片的底部空白。
+    expect(html).toContain('data-cindy-oauth-layout="compact"');
+    expect(html).toContain('data-card-width="560" data-card-height="500"');
+    expect(html).toContain('.card.success{width:560px;height:500px;display:flex;flex-direction:column;align-items:center;padding:48px 40px 44px}');
+    expect(html).toContain('.card.success .visual{position:static;flex:0 0 240px;width:240px;height:240px}');
+    expect(html).toContain('.card.success .content{display:flex;flex-direction:column;align-items:center;width:100%;margin-top:24px;gap:10px}');
+    expect(html).toContain('.card.success .body{position:static;flex:0 0 auto;width:100%;max-width:480px;height:auto;min-height:28px;margin:0;font-size:20px;line-height:28px;white-space:normal;overflow:visible;text-overflow:clip;overflow-wrap:anywhere}');
+    expect(html).toContain('.card.success .close-countdown{flex:0 0 auto;margin:auto 0 0;color:var(--detail);font-size:16px;line-height:23px;text-align:center;white-space:nowrap}');
+    expect(html).toContain('id="close-countdown" data-template="{{count}}秒后自动关闭">3秒后自动关闭</p>');
+    expect(html).not.toContain('尝试自动关闭');
     expect(html).toContain('border-radius:36px');
-    expect(html).toContain('left:200px;top:60px;width:280px;height:280px');
-    expect(html).toContain('left:42px;top:352px;width:598px');
-    expect(html).toContain('left:41px;top:396px;width:599px');
-    expect(html).toContain('left:70px;top:529px;width:540px;height:80px;border-radius:40px');
     // U-10 demo 冻结公式逐字面出现在内联脚本中
     expect(html).toContain('w<760?88:80');
-    expect(html).toContain('Math.min(1,(w-32)/680,(h-topOffset-24)/680)');
+    expect(html).toContain('Math.min(1,(w-32)/cardWidth,(h-topOffset-24)/cardHeight)');
     // chibi data URI(U-7)+ 加载失败降级
     expect(html).toContain(LOGIN_CALLBACK_CHIBI.success.slice(0, 64));
     expect(html).toContain('onerror=');
     expect(html).toContain('data-cindy-oauth-visual="success"');
+    expect(html).toContain("document.body.dataset.cindyOauthResult==='success'");
+    expect(html).toContain('var remaining=3,timer');
+    expect(html).toContain('remaining-=1');
+    expect(html).toContain('countdown.remove()');
+    expect(html).toContain('window.close()');
+    expect(html).not.toContain('<a class="cta"');
+  });
+
+  it('keeps the return CTA on branded error pages', () => {
+    const html = renderOAuthResultPage({
+      ...BRAND_BASE,
+      variant: 'error',
+      title: '登录未完成',
+      body: '请回到 Cindy 重新登录。',
+    });
     expect(html).toContain('<a class="cta" href="cindy://focus/desktop-login">回到 Cindy</a>');
+    expect(html).not.toContain('id="close-countdown"');
   });
 
   it('maps legacy variants to visual kinds (error→failure, warning→neutral)', () => {
@@ -314,8 +335,14 @@ describe('wave4 brand login callback card (pageKind=desktop-login)', () => {
         });
         expect(html).toContain(`data-theme="${theme}"`);
         expect(html).toContain(`data-cindy-oauth-visual="${visualKind}"`);
-        expect(html).toContain('width:680px;height:680px');
-        expect(html).toContain('left:70px;top:529px;width:540px;height:80px;border-radius:40px');
+        if (variant === 'success') {
+          expect(html).toContain('width:560px;height:500px');
+          expect(html).toContain('data-card-width="560" data-card-height="500"');
+        } else {
+          expect(html).toContain('width:680px;height:680px');
+          expect(html).toContain('data-card-width="680" data-card-height="680"');
+          expect(html).toContain('left:70px;top:529px;width:540px;height:80px;border-radius:40px');
+        }
       }
     }
   });

--- a/apps/desktop/src/main/authLoopbackCallback.ts
+++ b/apps/desktop/src/main/authLoopbackCallback.ts
@@ -81,7 +81,7 @@ export type AuthLoopbackPageInput = Omit<OAuthResultPageInput, 'variant'> & {
  * outside Electron; all copy arrives pre-translated from the caller.
  *
  * PR3(wave4):desktop-login source 固定走新品牌卡(pageKind='desktop-login',
- * 680×680 r36 + chibi 三表情 + U-10 跨视口缩放;参数权威见 oauthResultPage.ts
+ * 成功 560×500、失败/警告 680×680 + chibi 三表情 + U-10 跨视口缩放;参数权威见 oauthResultPage.ts
  * 的 renderBrandLoginCallbackPage 头注)。visualKind 由 variant 默认映射
  * (success→success / error→failure);文案仍由调用方经 main i18n 预翻译传入
  * (login.browserCallback.* 骨架维持现状,copyKind 仅作验收定位标签)。

--- a/apps/desktop/src/main/authManager.ts
+++ b/apps/desktop/src/main/authManager.ts
@@ -2628,10 +2628,15 @@ async function openLoopbackBrowserAuthorization(
         ),
         body: t(isError ? 'login.browserCallback.errorBody' : 'login.browserCallback.successBody'),
         detail: isError ? result.error : undefined,
-        action: {
-          href: buildFocusDeepLink('desktop-login'),
-          label: t('login.browserCallback.returnButton'),
-        },
+        closeCountdown: isError ? undefined : t('login.browserCallback.closeCountdown'),
+        // The success page is self-closing when the browser permits it, so it
+        // only needs the return CTA on error pages where the user must retry.
+        action: isError
+          ? {
+              href: buildFocusDeepLink('desktop-login'),
+              label: t('login.browserCallback.returnButton'),
+            }
+          : undefined,
       });
     };
     const server = createServer((req, res) => {

--- a/apps/desktop/src/main/oauthResultPage.ts
+++ b/apps/desktop/src/main/oauthResultPage.ts
@@ -366,7 +366,8 @@ updateCountdown();
  * wave4 新品牌回调卡(仅 pageKind='desktop-login',PR3)。
  *
  * 参数权威:callback-pages-classification.md「新设计三类卡片规格」(figma §6.1,
- * 失败/警告卡 680×680 r36;成功卡在移除 CTA 后采用 560×500 紧凑流式布局。
+ * 失败/警告卡 680×680 r36;成功卡在移除 CTA 后采用 560×500 紧凑流式布局,
+ * 这是 2026-09-02 登录成功回调 UX 裁决对旧成功态 Figma 帧的覆盖。
  * White 卡 #FBFBFB/#D4D4D4、Dark 卡 #312F2F/#434343;页面底色浅 #EEEEEE/深
  * #2A2828,design.md §7.4 条 1)+ U-10 裁决(topOffset = w<760?88:80;scale 按
  * 页面标记的卡片尺寸计算,transform-origin=top center,水平居中,缩不下时纵向

--- a/apps/desktop/src/main/oauthResultPage.ts
+++ b/apps/desktop/src/main/oauthResultPage.ts
@@ -33,6 +33,8 @@ export interface OAuthResultPageInput {
   body: string;
   /** Raw diagnostic text rendered as escaped monospace detail. */
   detail?: string;
+  /** Success-only countdown template; must contain a `{{count}}` placeholder. */
+  closeCountdown?: string;
   /** Optional CTA, normally a cindy://focus/... link back to the app. */
   action?: { href: string; label: string };
   /** Preview-only override. Production omits it and follows the OS setting. */
@@ -40,7 +42,7 @@ export interface OAuthResultPageInput {
   /**
    * 三层 adapter(PR3,全部 optional——旧调用不传即 legacy 页壳,ghost/claude/
    * xai/generic 视觉零变化):
-   * - pageKind:业务来源;'desktop-login' → wave4 新品牌卡(680×680 r36 +
+   * - pageKind:业务来源;'desktop-login' → wave4 新品牌卡(成功 560×500、失败/警告 680×680,
    *   chibi 立绘 + U-10 跨视口缩放),其余值与缺省 = legacy 页壳。
    * - copyKind:文案族标签,不参与渲染分支,仅输出为 data-cindy-oauth-copy
    *   供测试与验收矩阵定位文案来源。
@@ -310,7 +312,9 @@ const RESULT_ICON: Record<OAuthResultPageVariant, string> = {
 };
 
 /**
- * 结果页内联布局脚本(U-10:整卡等比缩放 + 水平居中)。
+ * 结果页内联布局脚本(U-10:整卡等比缩放 + 水平居中),并在登录成功页尝试
+ * 自动关闭当前浏览器页面。成功卡和失败卡的尺寸由页面标记提供,这样成功态
+ * 可以在移除 CTA 后收紧卡片而不改变失败态的既有几何。
  *
  * 抽成导出常量而不是直接内联在模板串里,是为了让**需要它 CSP sha256 的一方直接对
  * 这段源文本取值**——托管回调把结果页搬到 auth-server 后,导出脚本要为每页算
@@ -318,25 +322,43 @@ const RESULT_ICON: Record<OAuthResultPageVariant, string> = {
  * 也会被 CodeQL 当成「对渲染结果做哈希」误报。直接引用常量则两端拿到同一份逐字节
  * 内容。
  *
- * 改动这里等于改动 CSP hash,必须重新导出模板并同步到 auth-server。
+ * `window.close()` 受浏览器的 script-closable 限制,失败时无副作用,正文仍告知用户
+ * 手动关闭页面。改动这里等于改动 CSP hash,必须重新导出模板并同步到 auth-server。
  */
 export const LOGIN_CALLBACK_LAYOUT_SCRIPT = `
-/* U-10 demo 冻结公式:卡内 680 几何零响应式,整卡等比缩放,transform-origin=top
-   center 语义经「缩放尺寸 wrapper + margin auto」实现水平居中;stage 布局高度取
-   缩放后尺寸,缩到仍放不下时溢出走 body 纵向滚动,不裁 CTA。 */
+/* U-10:整卡等比缩放,transform-origin=top center 语义经「缩放尺寸 wrapper +
+   margin auto」实现水平居中;stage 布局尺寸取页面标记,缩到仍放不下时溢出走
+   body 纵向滚动,不裁内容。 */
 (function(){
-var card=document.getElementById('card'),stage=document.getElementById('stage');
+var card=document.getElementById('card'),stage=document.getElementById('stage'),countdown=document.getElementById('close-countdown');
+var cardWidth=Number(stage.dataset.cardWidth)||680,cardHeight=Number(stage.dataset.cardHeight)||680;
 function fit(){
 var w=window.innerWidth,h=window.innerHeight;
 var topOffset=w<760?88:80;
-var scale=Math.min(1,(w-32)/680,(h-topOffset-24)/680);
+var scale=Math.min(1,(w-32)/cardWidth,(h-topOffset-24)/cardHeight);
 card.style.transform='scale('+scale+')';
-stage.style.width=(680*scale)+'px';
-stage.style.height=(680*scale)+'px';
+stage.style.width=(cardWidth*scale)+'px';
+stage.style.height=(cardHeight*scale)+'px';
 stage.style.marginTop=topOffset+'px';
 }
 window.addEventListener('resize',fit);
 fit();
+if(document.body.dataset.cindyOauthResult==='success'&&countdown){
+var remaining=3,timer;
+var template=countdown.dataset.template||'';
+function updateCountdown(){countdown.textContent=template.replace('{{count}}',String(remaining));}
+function attemptClose(){
+window.clearInterval(timer);
+countdown.remove();
+try{window.close();}catch(_){/* Browser may reject closing this tab. */}
+}
+updateCountdown();
+timer=window.setInterval(function(){
+remaining-=1;
+if(remaining<=0){attemptClose();return;}
+updateCountdown();
+},1000);
+}
 })();
 `;
 
@@ -344,11 +366,11 @@ fit();
  * wave4 新品牌回调卡(仅 pageKind='desktop-login',PR3)。
  *
  * 参数权威:callback-pages-classification.md「新设计三类卡片规格」(figma §6.1,
- * 卡 680×680 r36;White 卡 #FBFBFB/#D4D4D4、Dark 卡 #312F2F/#434343;页面底色
- * 浅 #EEEEEE/深 #2A2828,design.md §7.4 条 1)+ U-10 裁决(demo 冻结公式:
- * topOffset = w<760?88:80;scale = min(1,(w-32)/680,(h-topOffset-24)/680),
- * transform-origin=top center,水平居中,卡内 680 几何零响应式,缩不下时纵向
- * 滚动不裁 CTA)。色值按 token-decision-table 决策以可序列化常量内联(系统
+ * 失败/警告卡 680×680 r36;成功卡在移除 CTA 后采用 560×500 紧凑流式布局。
+ * White 卡 #FBFBFB/#D4D4D4、Dark 卡 #312F2F/#434343;页面底色浅 #EEEEEE/深
+ * #2A2828,design.md §7.4 条 1)+ U-10 裁决(topOffset = w<760?88:80;scale 按
+ * 页面标记的卡片尺寸计算,transform-origin=top center,水平居中,缩不下时纵向
+ * 滚动不裁内容)。色值按 token-decision-table 决策以可序列化常量内联(系统
  * 浏览器页拿不到 renderer token,表内「browser callback main 使用同一份可
  * 序列化常量」)。hover 仅 hover-capable 设备生效(触摸浏览器无 hover 差异)。
  * detail 按 U-2 = 现网行为:错误码单行(nowrap + ellipsis),仍走 escapeHtml。
@@ -359,14 +381,27 @@ function renderBrandLoginCallbackPage(
   input: OAuthResultPageInput,
   visual: OAuthResultVisualKind,
 ): string {
+  const isSuccess = input.variant === 'success';
   const title = escapeHtml(input.title);
   const body = escapeHtml(input.body);
   const detail = input.detail ? `<p class="detail">${escapeHtml(input.detail)}</p>` : '';
-  const action = input.action
-    ? `<a class="cta" href="${escapeHtml(input.action.href)}">${escapeHtml(input.action.label)}</a>`
-    : '';
+  const action =
+    input.variant === 'success'
+      ? ''
+      : input.action
+        ? `<a class="cta" href="${escapeHtml(input.action.href)}">${escapeHtml(input.action.label)}</a>`
+        : '';
   const themeAttr = input.theme ? ` data-theme="${input.theme}"` : '';
   const copyAttr = input.copyKind ? ` data-cindy-oauth-copy="${escapeHtml(input.copyKind)}"` : '';
+  const layoutAttr = isSuccess ? ' data-cindy-oauth-layout="compact"' : '';
+  const cardWidth = isSuccess ? 560 : 680;
+  const cardHeight = isSuccess ? 500 : 680;
+  const cardClass = isSuccess ? 'card success' : 'card';
+  const initialCountdown = input.closeCountdown?.replaceAll('{{count}}', '3');
+  const closeCountdown =
+    isSuccess && input.closeCountdown
+      ? `<p class="close-countdown" id="close-countdown" data-template="${escapeHtml(input.closeCountdown)}">${escapeHtml(initialCountdown ?? '')}</p>`
+      : '';
   return `<!DOCTYPE html>
 <html lang="${escapeHtml(input.htmlLang)}"${themeAttr}>
 <head>
@@ -391,16 +426,25 @@ h1{position:absolute;left:42px;top:352px;width:598px;height:38px;margin:0;font-s
 @media(hover:hover){.cta:hover::after{opacity:1;background:var(--cta-hover)}}
 .cta:active::after{opacity:1;background:var(--cta-active)}
 .cta:focus-visible{outline:3px solid rgba(59,130,246,.5);outline-offset:3px}
+.card.success{width:560px;height:500px;display:flex;flex-direction:column;align-items:center;padding:48px 40px 44px}
+.card.success .visual{position:static;flex:0 0 240px;width:240px;height:240px}
+.card.success .content{display:flex;flex-direction:column;align-items:center;width:100%;margin-top:24px;gap:10px}
+.card.success h1{position:static;flex:0 0 auto;width:100%;height:auto;margin:0;font-size:32px;line-height:38px;white-space:normal;overflow:visible;text-overflow:clip}
+.card.success .body{position:static;flex:0 0 auto;width:100%;max-width:480px;height:auto;min-height:28px;margin:0;font-size:20px;line-height:28px;white-space:normal;overflow:visible;text-overflow:clip;overflow-wrap:anywhere}
+.card.success .close-countdown{flex:0 0 auto;margin:auto 0 0;color:var(--detail);font-size:16px;line-height:23px;text-align:center;white-space:nowrap}
 </style>
 </head>
-<body data-cindy-oauth-result="${input.variant}" data-cindy-oauth-visual="${visual}"${copyAttr}>
-<div class="stage" id="stage">
-<main class="card" id="card">
+<body data-cindy-oauth-result="${input.variant}" data-cindy-oauth-visual="${visual}"${layoutAttr}${copyAttr}>
+<div class="stage" id="stage" data-card-width="${cardWidth}" data-card-height="${cardHeight}">
+<main class="${cardClass}" id="card">
 <img class="visual" src="${LOGIN_CALLBACK_CHIBI[visual]}" alt="" onerror="this.style.visibility='hidden'">
+<div class="content">
 <h1>${title}</h1>
 <p class="body">${body}</p>
 ${detail}
 ${action}
+</div>
+${closeCountdown}
 </main>
 </div>
 <script>${LOGIN_CALLBACK_LAYOUT_SCRIPT}</script>

--- a/apps/desktop/src/renderer/i18n/locales/en/common.json
+++ b/apps/desktop/src/renderer/i18n/locales/en/common.json
@@ -5441,7 +5441,8 @@
     "browserWaiting": "Complete verification in your browser",
     "browserCallback": {
       "successTitle": "Signed in",
-      "successBody": "You can close this page and return to {{appName}}.",
+      "successBody": "You’re signed in. You can close this page now.",
+      "closeCountdown": "Closing in {{count}}s",
       "errorTitle": "Sign-in not completed",
       "errorBody": "Please return to {{appName}} and sign in again.",
       "returnButton": "Return to {{appName}}"

--- a/apps/desktop/src/renderer/i18n/locales/ja/common.json
+++ b/apps/desktop/src/renderer/i18n/locales/ja/common.json
@@ -5433,7 +5433,8 @@
     "browserWaiting": "ブラウザで認証を完了してください",
     "browserCallback": {
       "successTitle": "ログイン完了",
-      "successBody": "このページを閉じて {{appName}} に戻れます。",
+      "successBody": "ログインが完了しました。このページは閉じて構いません。",
+      "closeCountdown": "{{count}}秒後に自動で閉じます",
       "errorTitle": "ログインを完了できませんでした",
       "errorBody": "{{appName}} に戻ってもう一度ログインしてください。",
       "returnButton": "{{appName}} に戻る"

--- a/apps/desktop/src/renderer/i18n/locales/ko/common.json
+++ b/apps/desktop/src/renderer/i18n/locales/ko/common.json
@@ -5433,7 +5433,8 @@
     "browserWaiting": "브라우저에서 인증을 완료하세요",
     "browserCallback": {
       "successTitle": "로그인 완료",
-      "successBody": "이 페이지를 닫고 {{appName}}(으)로 돌아가세요.",
+      "successBody": "로그인이 완료되었습니다. 이제 이 페이지를 닫아도 됩니다.",
+      "closeCountdown": "{{count}}초 후 자동으로 닫힙니다",
       "errorTitle": "로그인이 완료되지 않았습니다",
       "errorBody": "{{appName}}(으)로 돌아가 다시 로그인해 주세요.",
       "returnButton": "{{appName}}(으)로 돌아가기"

--- a/apps/desktop/src/renderer/i18n/locales/zh-CN/common.json
+++ b/apps/desktop/src/renderer/i18n/locales/zh-CN/common.json
@@ -5425,7 +5425,8 @@
     "browserWaiting": "请在浏览器中完成验证",
     "browserCallback": {
       "successTitle": "登录成功",
-      "successBody": "你可以关闭此页面，回到 {{appName}} 继续。",
+      "successBody": "登录已成功，现在可以关闭此页面了。",
+      "closeCountdown": "{{count}}秒后自动关闭",
       "errorTitle": "登录未完成",
       "errorBody": "请回到 {{appName}} 重新登录。",
       "returnButton": "回到 {{appName}}"

--- a/apps/desktop/src/renderer/i18n/locales/zh-TW/common.json
+++ b/apps/desktop/src/renderer/i18n/locales/zh-TW/common.json
@@ -5425,7 +5425,8 @@
     "browserWaiting": "請在瀏覽器中完成驗證",
     "browserCallback": {
       "successTitle": "登入成功",
-      "successBody": "你可以關閉此頁面，回到 {{appName}} 繼續。",
+      "successBody": "登入已成功，現在可以關閉此頁面了。",
+      "closeCountdown": "{{count}}秒後自動關閉",
       "errorTitle": "登入未完成",
       "errorBody": "請回到 {{appName}} 重新登入。",
       "returnButton": "回到 {{appName}}"

--- a/docs/design-rules/DESIGN.md
+++ b/docs/design-rules/DESIGN.md
@@ -1315,6 +1315,8 @@ The execution rulebook for subsequent desktop / mobile UI updates. Sources: the 
 
 ### 16.2 设计规则
 
+**Desktop 登录成功回调页当前覆盖（2026-09-02）**：成功态移除「回到 Cindy」按钮，卡片收紧为 **560×500** 的内容流布局，并在底部显示本地化 3 秒倒计时；倒计时结束先移除倒计时文字，再调用 `window.close()`。失败 / Warning 保留原 **680×680** 卡片与返回操作。该条是当前产品 UX 对旧 Figma 成功态回调帧（680×680 + CTA）的明确覆盖；`figma-component-spec.md §6` 的旧节点仍作为历史视觉来源记录，现行客户端实现以本条与代码测试为准。
+
 **Token 体系**：`--login-*` 已注册于 `apps/desktop/src/renderer/themes/colors.ts`（dark 槽位当前为 light 占位值，待实现 PR 填入 §16.1 表中的目标深色值）。组件经 `LOGIN_COLORS`（桌面 `loginDesignTokens.ts`）/ `loginColors`（手机 `theme/tokens.ts`）单点消费。**禁止硬编码 hex pair**（呼应 §10）——`hardcoded-color-audit` 守护全绿才允许合入。`--login-*` 随基础 **light / dark 二态**切换（对齐 `callback-*` 族与 §15 CINDY 皮肤族的双态做法），但**不跟随具体扩展主题**——登录页只认 light / dark 模式，扩展主题不 override `--login-*`（首次亮、后续跟随上次模式见 §16.5）。
 
 **几何 / 布局常量**：固化在两个常量文件，数值权威 = `figma-component-spec §5.1` + `token-decision-table §4`，不按截图目测补值。

--- a/docs/design-rules/cindy-design-system.md
+++ b/docs/design-rules/cindy-design-system.md
@@ -23,6 +23,8 @@
 
 ## 版本记录
 
+- **2026-09-02（Desktop 登录成功回调页 UX 覆盖）**：成功态移除返回 Cindy 按钮，改为 560×500 紧凑内容流卡片，底部显示本地化 3 秒倒计时并在结束时先移除文字再调用 `window.close()`；失败 / Warning 继续使用 680×680 卡片与返回操作。同步更新 `DESIGN.md §16`、`figma-component-spec.md §6`、`token-decision-table.md §4` 与客户端模板测试。
+
 - **2026-08-31（Switch / 通用手柄交稿包入仓）**：登记 `gamepads/nintendo-switch-pro/`、`gamepads/switch-joy-con/`、`gamepads/ultimate-c1/` 三组同事线稿，设置页 Nintendo 默认 Switch Pro、接上 Joy-Con 时换 Joy-Con 图，通用手柄用 Ultimate C1。零视觉规范改写。
 - **2026-08-30（治理合同修订：管道/记账、已知边界、路线图勘误；同日按 review 收口）**：[`design-governance.md`](./design-governance.md) 新增 §1.1「管道与记账」（守卫红灯不是禁令——管道规则不许绕、记账值走「同 PR 更新快照/台账 + 设计师批」的合法路径改，消灭的是「没人决定过的变化」；**保护值例外**：CINDY 皮肤族 / U2 二级信息色 / `annotation-accent` 不适用通用路径，须按 `DESIGN.md` 各自的用户裁决或冻结条款；正式豁免登记是合法路径，只禁未经裁决为消红灯加豁免）与 §13「已知边界」（正则扫描边界——内联样式字面量会被 `hardcoded-color-audit` 发现、真正扫不到的是动态值与 canvas/xterm 自绘；复用道路唯一靠 review 不靠机器；**新代码默认走语义层**、保留 §3.3/§3.4 既有准入、仅存量渐进），两节自
   mivo-canvas-plugin 仓 4/7 张 PR 实战沉淀移植。勘误三处：§2 旧编号「PR-8」→「DS-8」；§12 依赖行 DS-6 前置由已关闭的圆角裁决改为「Permission 迁移余项」并补 DS-7 受 `radius` 覆盖裁决约束；§12 路线图回填 DS-1 = #3609（合入日期修正为 2026-08-30）。零视觉，非 DS 序号。

--- a/docs/design-rules/figma-component-spec.md
+++ b/docs/design-rules/figma-component-spec.md
@@ -442,11 +442,13 @@ wave6 追加 · 2026-07-27（登录改版新稿手机帧）：两帧共用主容
 
 ### 6.1 回调结果卡片
 
-卡片尺寸 680 x 680，radius 36。Light 卡片 fill `#FBFBFB`、stroke `#D4D4D4`；Dark 卡片 fill `#312F2F`、stroke `#434343`。
+失败 / Warning 卡片尺寸 680 x 680，radius 36。Light 卡片 fill `#FBFBFB`、stroke `#D4D4D4`；Dark 卡片 fill `#312F2F`、stroke `#434343`。
+
+**现行 Desktop 登录成功回调覆盖（2026-09-02）**：成功态不显示返回按钮，使用 560 x 500、radius 36 的紧凑内容流卡片；标题 / 正文 / 立绘改为流式排列，卡片底部显示本地化 3 秒倒计时，结束时移除倒计时文字并调用 `window.close()`。以下成功态 Figma 节点与 680 x 680 + CTA 参数保留为历史设计来源，不再约束当前客户端成功页；失败 / Warning 仍沿用下表的 680 x 680 几何与 CTA。
 
 | 状态 | 国区 Light | 国区 Dark | 国际区 Light | 国际区 Dark | 文案 | 图像参数 |
 |---|---|---|---|---|---|---|
-| 成功 | `343:355` | `347:2503` | `347:3149` | `347:3155` | 标题 `登录成功`；副文案 `你可以关闭此页面，回到 Cindy 继续`；按钮 `回到 CINDY` | emoj x=200 y=60，280 x 280；成功图 image crop w=311.89%, h=313.21%, left=-100.32%, top=-202.18% |
+| 成功（历史 Figma 来源） | `343:355` | `347:2503` | `347:3149` | `347:3155` | 旧标题 `登录成功`；旧副文案 `你可以关闭此页面，回到 Cindy 继续`；旧按钮 `回到 CINDY`。现行实现见上方覆盖条目 | 旧稿 emoj x=200 y=60，280 x 280；成功图 image crop w=311.89%, h=313.21%, left=-100.32%, top=-202.18% |
 | 失败 | `347:1353` | `347:2509` | `347:3161` | `347:3167` | 标题 `登录未完成`；副文案 `请回到 CINDY 重新登录`；按钮 `回到 CINDY` | emoj x=200 y=60，280 x 280 |
 | Warning | `347:1461` | `347:2515` | `347:3173` | `347:3179` | 标题 `需要继续操作`；副文案 `请返回 Cindy，完成当前工作区的安装后继续`；按钮 `返回 CINDY` | emoj frame 280 x 280；可见图层 273 x 272；image w=327.4%, h=329.15%, left=-212.69%, top=-112.97% |
 
@@ -459,21 +461,23 @@ wave6 追加 · 2026-07-27（登录改版新稿手机帧）：两帧共用主容
 | CTA | x=70 y=529，540 x 80；fill `#2A2828`，stroke `#434343`，radius 40；文字 Bold 24 `#D4D4D4` | fill `#EEEEEE`，stroke `#FFFFFF`，radius 40；文字 `#2A2828` |
 | hover | 仅桌面端，Light CTA 可用 `log_in_button:hover` 参数 | 仅桌面端，Dark CTA 可用 `white_button:hover` 参数 |
 
+成功态当前实现的内部几何：卡片 560 x 500；内边距 `48px 40px 44px`；立绘 240 x 240；标题 / 正文采用内容流排列；底部倒计时字号 16、行高 23。该布局仅适用于成功态，不改变失败 / Warning 的共享 680 x 680 卡片几何。
+
 ### 6.2 桌面浏览器页壳
 
 | 场景 | nodeId | 画板 / 背景 | 卡片放置 |
 |---|---|---|---|
-| 国区 Browser 页壳 | `347:3016` | 1831 x 1831；内容区域 x=0 y=146.630，1831 x 1684.370；顶部控件 `#FEFEFE` x=169.189 y=26.318，203.027 x 48.877；地址栏 `#F1F2F3` x=259.423 y=95.874，404.174 x 33.838 | success card x=576 y=226，680 x 680 |
-| 国际区 Browser 页壳 | `347:3185` | 与国区同构；同一 browser chrome 参数 | success card x=576 y=226，680 x 680 |
+| 国区 Browser 页壳 | `347:3016` | 1831 x 1831；内容区域 x=0 y=146.630，1831 x 1684.370；顶部控件 `#FEFEFE` x=169.189 y=26.318，203.027 x 48.877；地址栏 `#F1F2F3` x=259.423 y=95.874，404.174 x 33.838 | 历史 success card x=576 y=226，680 x 680；现行 Desktop 成功页由 U-10 wrapper 居中缩放 560 x 500，失败 / Warning 保持 680 x 680 |
+| 国际区 Browser 页壳 | `347:3185` | 与国区同构；同一 browser chrome 参数 | 历史 success card x=576 y=226，680 x 680；现行 Desktop 成功页由 U-10 wrapper 居中缩放 560 x 500，失败 / Warning 保持 680 x 680 |
 
 ### 6.3 移动 Chrome 回调页
 
 | 场景 | nodeId | 画板 / 内容底色 | 卡片放置 |
 |---|---|---|---|
-| 国区 Mobile Chrome Dark 成功 | `347:3052` | 750 x 1623；内容底色块 x=0 y=171，750 x 1315，`#2A2828` | success card x=35 y=251，680 x 680 |
-| 国区 Mobile Chrome White 成功 | `347:3066` | 750 x 1623；内容底色块 x=0 y=160，750 x 1315，`#EEEEEE` | success card x=35 y=251，680 x 680 |
-| 国际区 Mobile Chrome Dark 成功 | `347:3203` | 与国区 Dark 同构 | success card x=35 y=251，680 x 680 |
-| 国际区 Mobile Chrome White 成功 | `347:3212` | 与国区 White 同构 | success card x=35 y=251，680 x 680 |
+| 国区 Mobile Chrome Dark 成功 | `347:3052` | 750 x 1623；内容底色块 x=0 y=171，750 x 1315，`#2A2828` | 历史 success card x=35 y=251，680 x 680；现行 Desktop 成功页使用 560 x 500 紧凑卡，失败 / Warning 保持 680 x 680 |
+| 国区 Mobile Chrome White 成功 | `347:3066` | 750 x 1623；内容底色块 x=0 y=160，750 x 1315，`#EEEEEE` | 历史 success card x=35 y=251，680 x 680；现行 Desktop 成功页使用 560 x 500 紧凑卡，失败 / Warning 保持 680 x 680 |
+| 国际区 Mobile Chrome Dark 成功 | `347:3203` | 与国区 Dark 同构 | 历史 success card x=35 y=251，680 x 680；现行 Desktop 成功页使用 560 x 500 紧凑卡，失败 / Warning 保持 680 x 680 |
+| 国际区 Mobile Chrome White 成功 | `347:3212` | 与国区 White 同构 | 历史 success card x=35 y=251，680 x 680；现行 Desktop 成功页使用 560 x 500 紧凑卡，失败 / Warning 保持 680 x 680 |
 
 ## 7. 国区 / 国际区 / 移动端差异清单
 

--- a/docs/design-rules/token-decision-table.md
+++ b/docs/design-rules/token-decision-table.md
@@ -70,7 +70,8 @@
 | `1819` | 桌面设计画布宽 | 新增 | `login-stage-width` / singleton constant | 仅设计坐标基准，不必直接等于窗口宽 |
 | `2098` | 桌面设计画布高 | 新增 | `login-stage-height` / singleton constant | 与 `login-stage-width` 成组，用于 scale / transform 计算 |
 | `934` | 桌面 Cindy 立绘尺寸 | 新增 | `login-desktop-hero-size` | `CINDY_Client` 正方形 |
-| `680` | 桌面登录组宽、WORD_MARK 宽、回调卡片尺寸 | 新增 | `login-panel-width`、`login-wordmark-frame-width`、`login-result-card-size` | 语义不同，不建议只留一个 magic number |
+| `680` | 桌面登录组宽、WORD_MARK 宽、失败 / Warning 回调卡片尺寸 | 新增 | `login-panel-width`、`login-wordmark-frame-width`、`login-result-card-size` | 语义不同，不建议只留一个 magic number；成功回调当前使用独立紧凑尺寸 |
+| `560 x 500` | Desktop 登录成功回调紧凑卡片 | 新增 | `login-result-success-card-size`（browser callback serialized layout constant） | 2026-09-02 产品 UX 覆盖旧成功态 680 x 680 + CTA；仅成功态使用，失败 / Warning 不变 |
 | `180` | 桌面 / 移动 WORD_MARK frame 高 | 新增 | `login-wordmark-frame-height` | 字标外框高度，不等于内部实际图片高度 |
 | `460 x 134` | SLOGAN frame | 新增 | `login-slogan-width`、`login-slogan-height` | 短屏移动端会缩放该 frame，但设计基准仍需保留 |
 | `620` | 登录整体高度含第三方入口 | 新增 | `login-flow-height` | 面板 `500` + gap `40` + social `80`。**2026-07-27 登录改版由 `560` 改 `620`**（面板增高 60 随之）；双端落码 = 桌面 `LOGIN_GROUP.height` / 手机 `loginSizes.flowHeight` + `LOGIN_GROUP.height` |
@@ -226,7 +227,6 @@ composer pill `#272727` / 菜单 hover / 卡片锚定选中 `#282828`(`settings-
 ### 9.5 预览与杂项
 
 `settings-theme-auto-light` = `#F2F2ED`、`settings-theme-auto-dark` = `#181818`(两模式文件同步);
-`md-table-bg` 随页底;`surface-translucent-overlay` light 暖化 / dark 平移。
+ `md-table-bg` 随页底;`surface-translucent-overlay` light 暖化 / dark 平移。
 移动端未随本轮同步(342 处命中 + 冷更确认),为已登记 follow-up;
 `text-secondary`/`text-tertiary` 命名倒置(改名方案)见 issue #2559。
-

--- a/docs/desktop-login-hosted-callback.md
+++ b/docs/desktop-login-hosted-callback.md
@@ -190,7 +190,7 @@ pnpm --filter desktop run export:login-callback-template
 - 每份 HTML 自带 light / dark（`prefers-color-scheme`），不按主题拆分；
 - 失败页含 `{{ERROR_DETAIL}}` 一个占位符，替换错误码前按 HTML 文本节点转义；无错误码
   时连同它所在的 `<p class="detail">` 一并删除；
-- 成功页不显示返回按钮，使用更紧凑的内容流卡片，正文告知登录已成功并可关闭当前页面；页面底部显示
+- 成功页不显示返回按钮，使用 560×500 的紧凑内容流布局，正文告知登录已成功并可关闭当前页面；页面底部显示
   `3秒后自动关闭` 并倒计时到 0，随后先移除倒计时文字再调用 `window.close()`；浏览器不允许时不
   留任何关闭提示或残留文案，失败页仍保留回到 Cindy 的按钮；
 - 页面自包含（立绘是构建期内嵌的 webp data URI），无外链依赖；

--- a/docs/desktop-login-hosted-callback.md
+++ b/docs/desktop-login-hosted-callback.md
@@ -49,7 +49,7 @@ Firefox 早已按规范放行，只有 Safari 没跟，而 Safari 是 macOS 默�
    而是在签发处直接按 client_state 寄存进 Redis
 ⑤ 302 到结果展示页（URL 既不含 code 也不含 state）
 ⑥ 客户端自②起持续轮询 poll 接口，取到 code 后照常 POST /api/auth/token 完成 PKCE 兑换
-⑦ 用户在展示页点「回到 Cindy」→ cindy://focus/desktop-login
+⑦ 成功结果页显示 3 秒倒计时，结束时自动关闭并移除倒计时文字；失败页仍可点「回到 Cindy」→ cindy://focus/desktop-login
 ```
 
 关键点：`redirect_uri` 是「auth-server 完事后往哪跳」，**不是 provider 的回调地址**。
@@ -190,6 +190,9 @@ pnpm --filter desktop run export:login-callback-template
 - 每份 HTML 自带 light / dark（`prefers-color-scheme`），不按主题拆分；
 - 失败页含 `{{ERROR_DETAIL}}` 一个占位符，替换错误码前按 HTML 文本节点转义；无错误码
   时连同它所在的 `<p class="detail">` 一并删除；
+- 成功页不显示返回按钮，使用更紧凑的内容流卡片，正文告知登录已成功并可关闭当前页面；页面底部显示
+  `3秒后自动关闭` 并倒计时到 0，随后先移除倒计时文字再调用 `window.close()`；浏览器不允许时不
+  留任何关闭提示或残留文案，失败页仍保留回到 Cindy 的按钮；
 - 页面自包含（立绘是构建期内嵌的 webp data URI），无外链依赖；
 - 客户端改文案后需重新导出同步，**不要在服务端侧手改 HTML**。
 
@@ -199,7 +202,8 @@ pnpm --filter desktop run export:login-callback-template
 loopback 与 mobile 共用的回调路径。两者不一致（如 app 设日语、浏览器为中文）只影响这张
 结果页的文案，不影响登录本身，故选择不动共用路径。缺省回落 `en`。
 
-**CSP 与内联脚本**：模板里有一段**布局必需**的内联脚本（整卡等比缩放 + 水平居中）。
+**CSP 与内联脚本**：模板里有一段内联脚本（整卡等比缩放 + 水平居中、成功页 3 秒倒计时，并在倒计时
+结束时先移除倒计时文字再自动关闭）。
 CSP 用 `script-src 'sha256-…'` 精确放行它，而不是放 `'unsafe-inline'`。
 
 **hash 由导出方算好写进 `manifest.json` 的 `pages[].scriptHashes`，服务端直接读取拼进
@@ -262,6 +266,8 @@ CodeQL 的 `js/bad-tag-filter` 判为不完整的标签过滤。
 
 - [ ] Safari 与 Chrome 各跑一次**真实 provider** 登录：地址栏全程
       `https://auth.<域名>/...`，唤起弹框显示的是域名而非 IP
+- [ ] Chrome 若允许脚本关闭，成功页在 3 秒倒计时后自动关闭；若不允许，倒计时文字会先消失，页面不留下
+      关闭提示且正文仍告知用户可手动关闭，无返回按钮
 - [ ] 四种语言各看一次（zh / en / ja / ko）
 - [ ] 用户中途关闭浏览器：客户端 5 分钟后按取消收场，不报错
 - [ ] 清空清单字段后回退 loopback 仍正常


### PR DESCRIPTION
## 这次改了什么

### 摘要

优化 Desktop 登录成功后的独立浏览器回调页：移除成功态的“回到 Cindy”按钮，收紧成功卡片布局，增加 3 秒倒计时并在倒计时结束后自动关闭页面。

### 变更类型

- [x] `fix` 缺陷修复
- [ ] `feat` 新功能

### 范围

- 关联 Issue / 需求：无，本 PR 对应登录成功页体验优化需求。
- 本 PR 包含：成功页布局、自动关闭倒计时、五种语言文案、预览与托管模板导出、回归测试和文档。
- 明确不包含：auth-server 仓库改动；失败页的返回 Cindy 操作保持不变。
- 用户可见变化：成功页显示“3秒后自动关闭”并倒计时到 0；成功页不再显示返回按钮。倒计时结束后清理倒计时文字并调用浏览器关闭当前页面。
- 是否存在 breaking change：无。

### UI 变化

本地 macOS Chrome 预览已打开并目检成功页亮色布局；截图未上传，复现地址见“手工验证”。

- 引用的设计规范：`docs/design-rules/DESIGN.md` §10“Light / Dark 双模式交付门槛”与 §16.1–§16.2“登录链路视觉风格、双模式色板与几何布局”。成功态使用紧凑内容流卡片，失败态保留既有 680×680 卡片和 CTA；两种主题均由页面内联 light/dark 语义变量覆盖。

## 怎么验证的

### 自动验证

```text
pnpm test:unit:related
结果：test:runner 494 通过、1 跳过；apps/desktop unit 通过。

pnpm --filter desktop exec vitest run src/main/__tests__/oauthResultPage.test.ts src/main/__tests__/authLoopbackCallback.test.ts
结果：41/41 通过。

pnpm --filter desktop typecheck
结果：通过。

pnpm check:dco
结果：1 个提交均已通过 DCO 签名检查。

pnpm check:i18n
结果：5 种语言共 8517 个 key 一致；仅保留既有非阻塞告警。

pnpm check:i18n-glossary
结果：通过；仅保留既有待裁决术语告警。

pnpm --filter desktop run export:login-callback-template
结果：成功导出 10 个登录回调页面。
```

### 手工验证

- macOS Chrome：启动 `pnpm --filter desktop preview:oauth-pages`，打开：
  `http://127.0.0.1:56088/page?kind=login-success&lang=zh&theme=light`。
- 已确认页面显示 `3秒后自动关闭`，并验证成功页的自动关闭调用；成功页脚本在关闭前移除倒计时文字。

### 未执行的验证

- 未执行真实 provider 登录；需部署后由 auth-server 环境分别验证 Safari / Chrome 的真实回调域名和自动关闭行为。
- 未执行 Windows 实机验证。

## 风险

### 风险分类

- [x] 跨平台差异
- [ ] 无已知风险

### 影响与回滚

- 影响范围：Desktop 登录成功后的系统浏览器回调页；失败页仍保留原返回 Cindy CTA。托管模板需要在 auth-server 侧重新同步本次导出产物。
- 回滚 / 降级方式：回滚本 PR 即恢复原成功页布局和文案；若浏览器策略不允许 `window.close()`，页面仍停留在成功页，但倒计时文字会被清理，不影响登录结果。

### 提交前检查

- [x] 已 review 完整 diff
- [x] 每个 commit 都带 DCO 签名（`git commit -s`，见 [DCO](../DCO)）
- [x] UI 改动已在“UI 变化”注明引用的设计规范章节
- [x] 未提交凭证、令牌或授权文件
- [x] 已补充必要文档
- [x] 已确认测试结果或说明未执行原因
