### PR TITLE
perf(desktop): 降低 Windows 语音输入启动与提交延迟

### DIFF
--- a/apps/desktop/src/main/voice-input/CindyVoiceSessionClient.ts
+++ b/apps/desktop/src/main/voice-input/CindyVoiceSessionClient.ts
@@ -5,6 +5,9 @@ import { getClientEndpoint } from '../clientEndpointsService.js';
 import { outboundFetch } from '../maker-host/outbound-fetch.js';
 import { ServerApiError, serverApiFetch } from '../serverApiClient.js';
 import { getAppCapabilities, requireAppCapability } from '../appCapabilities.js';
+import { createLogger } from '../logger.js';
+
+const log = createLogger('voice-input:cindy-voice-session');
 
 const VOICE_SESSION_REQUEST_TIMEOUT_MS = 10_000;
 const VOICE_REFINE_WARMUP_TIMEOUT_MS = 10_000;
@@ -38,6 +41,11 @@ export type CindyVoiceAsrSession = {
 /** Session-scoped bridge from Cindy identity to one-shot voice data-plane tickets. */
 export class CindyVoiceRunContext {
   private latestSessionId: string | null = null;
+  // A client-side ASR candidate can time out while its session allocation is
+  // still in flight. Do not let that late response overwrite the session used
+  // by a newer fallback candidate (which would attach refinement to the wrong
+  // upstream run).
+  private connectionGeneration = 0;
   /**
    * Set when session allocation had to drop the 'auto' refiner marker for a
    * voice-server that predates the delegated-refinement contract. Dictation
@@ -55,7 +63,10 @@ export class CindyVoiceRunContext {
     websocketUrl: string;
     authorizationToken: string;
   }> {
+    const requestGeneration = ++this.connectionGeneration;
+    const allocationStartedAt = performance.now();
     let session: CindyVoiceAsrSession;
+    let usedLegacyRefinerFallback = false;
     try {
       session = await createCindyVoiceSession({
         asrProvider,
@@ -80,9 +91,21 @@ export class CindyVoiceRunContext {
         refinerProvider: undefined,
         sourceLanguage: this.sourceLanguage,
       });
-      this.refinerUnavailableOnServer = true;
+      usedLegacyRefinerFallback = true;
     }
+    if (requestGeneration !== this.connectionGeneration) {
+      throw new Error('Cindy voice ASR session allocation was superseded by a newer provider attempt.');
+    }
+    if (usedLegacyRefinerFallback) this.refinerUnavailableOnServer = true;
     this.latestSessionId = session.sessionId;
+    // Session allocation is the HTTP half of managed ASR startup; the socket
+    // handshake that follows is timed separately by the provider. Splitting the
+    // two is what makes a slow start attributable.
+    log.debug('asr session allocated', {
+      asrProvider,
+      elapsedMs: Math.round(performance.now() - allocationStartedAt),
+      legacyRefinerFallback: usedLegacyRefinerFallback,
+    });
     return { websocketUrl: session.asr.websocketUrl, authorizationToken: session.ticket };
   }
 

--- a/apps/desktop/src/main/voice-input/FallbackAsrProvider.ts
+++ b/apps/desktop/src/main/voice-input/FallbackAsrProvider.ts
@@ -22,10 +22,6 @@ const MAX_PENDING_AUDIO_CHUNKS = 1_024;
  * session is opened at a time and every losing session is explicitly closed.
  */
 const DEFAULT_HEDGE_DELAY_MS = 1_500;
-// Keep this below the providers' own 5s websocket timeout so an actually
-// stalled connection advances promptly, but leave enough room for the ~4.2s
-// successful managed connection observed on slower Windows/network starts.
-const DEFAULT_START_TIMEOUT_MS = 4_500;
 
 export type FallbackAsrCandidate = {
   kind: VoiceInputProviderKind;
@@ -34,10 +30,8 @@ export type FallbackAsrCandidate = {
 };
 
 export type FallbackAsrProviderOptions = {
-  /** Delay between launching unresolved candidates. Defaults to 1.5s. */
+  /** Delay between launching unresolved candidates. Defaults to 1.5s; null disables hedging. */
   hedgeDelayMs?: number | null;
-  /** Maximum time allowed for one candidate to become usable; null disables the wrapper timeout. */
-  startTimeoutMs?: number | null;
 };
 
 type CandidateAttemptResult = {
@@ -79,7 +73,6 @@ type CandidateAttempt = {
 export class FallbackAsrProvider implements AsrProvider {
   private readonly candidates: FallbackAsrCandidate[];
   private readonly hedgeDelayMs: number | null;
-  private readonly startTimeoutMs: number | null;
   private active: AsrProvider | null = null;
   private activeKind: VoiceInputProviderKind | null = null;
   private readonly eventCallbacks: Array<(event: AsrEvent) => void> = [];
@@ -105,9 +98,6 @@ export class FallbackAsrProvider implements AsrProvider {
     this.hedgeDelayMs = options.hedgeDelayMs === null
       ? null
       : Math.max(0, options.hedgeDelayMs ?? DEFAULT_HEDGE_DELAY_MS);
-    this.startTimeoutMs = options.startTimeoutMs === null
-      ? null
-      : Math.max(0, options.startTimeoutMs ?? DEFAULT_START_TIMEOUT_MS);
   }
 
   /** Provider kind that actually connected; null until start() succeeds. */
@@ -324,7 +314,11 @@ export class FallbackAsrProvider implements AsrProvider {
       });
       try {
         attempt.started = true;
-        await this.startWithTimeout(provider.start(), candidate.kind);
+        // Each provider owns its connection deadline (measured from the socket
+        // dial, after credential/proxy lookup). A wrapper-level cap that starts
+        // earlier can reject a slow-but-valid connection; the staggered hedge
+        // above is the only mechanism for advancing past a slow candidate.
+        await provider.start();
       } catch (error) {
         if (attempt.cancelled || this.disposed || this.active) {
           await this.cleanupAttempt(attempt);
@@ -398,25 +392,6 @@ export class FallbackAsrProvider implements AsrProvider {
         error: disposeError instanceof Error ? disposeError.message : String(disposeError),
       });
     });
-  }
-
-  private async startWithTimeout(startPromise: Promise<void>, kind: VoiceInputProviderKind): Promise<void> {
-    const timeoutMs = this.startTimeoutMs;
-    if (timeoutMs === null) return startPromise;
-    let timer: ReturnType<typeof setTimeout> | undefined;
-    const timeoutPromise = new Promise<never>((_, reject) => {
-      timer = setTimeout(() => {
-        reject(new Error(`${kind} ASR start timed out after ${timeoutMs}ms.`));
-      }, timeoutMs);
-    });
-    // A timed-out provider may still settle after its socket is closed. Attach
-    // a rejection handler so the late settlement never becomes unhandled.
-    void startPromise.catch(() => undefined);
-    try {
-      await Promise.race([startPromise, timeoutPromise]);
-    } finally {
-      if (timer !== undefined) clearTimeout(timer);
-    }
   }
 
   private handleCandidateFailure(

--- a/apps/desktop/src/main/voice-input/FallbackAsrProvider.ts
+++ b/apps/desktop/src/main/voice-input/FallbackAsrProvider.ts
@@ -15,11 +15,52 @@ const log = createLogger('voice-input:asr-fallback');
 // callers; the cap only guards against a pathological caller, at 100ms chunks
 // it covers well over a minute of audio.
 const MAX_PENDING_AUDIO_CHUNKS = 1_024;
+/**
+ * After this grace period an unresolved candidate is considered slow enough
+ * to justify starting the next candidate.  This is deliberately a staggered
+ * hedge rather than Promise.any(all providers): only one additional upstream
+ * session is opened at a time and every losing session is explicitly closed.
+ */
+const DEFAULT_HEDGE_DELAY_MS = 1_500;
+// Keep this below the providers' own 5s websocket timeout so an actually
+// stalled connection advances promptly, but leave enough room for the ~4.2s
+// successful managed connection observed on slower Windows/network starts.
+const DEFAULT_START_TIMEOUT_MS = 4_500;
 
 export type FallbackAsrCandidate = {
   kind: VoiceInputProviderKind;
   /** Lazily constructs the underlying provider; only called when this candidate is attempted. */
   create: () => Promise<AsrProvider>;
+};
+
+export type FallbackAsrProviderOptions = {
+  /** Delay between launching unresolved candidates. Defaults to 1.5s. */
+  hedgeDelayMs?: number | null;
+  /** Maximum time allowed for one candidate to become usable; null disables the wrapper timeout. */
+  startTimeoutMs?: number | null;
+};
+
+type CandidateAttemptResult = {
+  index: number;
+  status: 'success' | 'failed' | 'cancelled';
+  phase?: 'create' | 'start';
+  error?: unknown;
+};
+
+type CandidateAttempt = {
+  index: number;
+  provider: AsrProvider | null;
+  started: boolean;
+  cancelled: boolean;
+  cleanupPromise: Promise<void> | null;
+  /**
+   * Providers emit `connected` from inside start(), before this wrapper has
+   * committed them as active. Hold that event so the controller's
+   * `asr_connected` timeline entry is replayed once the candidate wins instead
+   * of being dropped by the active-only forwarding filter.
+   */
+  connectedEvent: AsrEvent | null;
+  promise: Promise<CandidateAttemptResult>;
 };
 
 /**
@@ -37,12 +78,16 @@ export type FallbackAsrCandidate = {
  */
 export class FallbackAsrProvider implements AsrProvider {
   private readonly candidates: FallbackAsrCandidate[];
+  private readonly hedgeDelayMs: number | null;
+  private readonly startTimeoutMs: number | null;
   private active: AsrProvider | null = null;
   private activeKind: VoiceInputProviderKind | null = null;
   private readonly eventCallbacks: Array<(event: AsrEvent) => void> = [];
   private readonly pendingAudio: Array<{ chunk: ArrayBuffer; trace?: AudioTrace }> = [];
   private pendingAudioOverflowWarned = false;
   private disposed = false;
+  private stopping = false;
+  private readonly attempts = new Map<number, CandidateAttempt>();
 
   /**
    * Assigned in start() only when the committed provider itself supports
@@ -52,11 +97,17 @@ export class FallbackAsrProvider implements AsrProvider {
    */
   recover?: () => Promise<void>;
 
-  constructor(candidates: FallbackAsrCandidate[]) {
+  constructor(candidates: FallbackAsrCandidate[], options: FallbackAsrProviderOptions = {}) {
     if (candidates.length === 0) {
       throw new Error('FallbackAsrProvider requires at least one ASR provider candidate.');
     }
     this.candidates = candidates;
+    this.hedgeDelayMs = options.hedgeDelayMs === null
+      ? null
+      : Math.max(0, options.hedgeDelayMs ?? DEFAULT_HEDGE_DELAY_MS);
+    this.startTimeoutMs = options.startTimeoutMs === null
+      ? null
+      : Math.max(0, options.startTimeoutMs ?? DEFAULT_START_TIMEOUT_MS);
   }
 
   /** Provider kind that actually connected; null until start() succeeds. */
@@ -65,6 +116,8 @@ export class FallbackAsrProvider implements AsrProvider {
   }
 
   async start(): Promise<void> {
+    if (this.active) return;
+    if (this.disposed) throw new Error('Voice input ASR fallback disposed during start.');
     let lastError: unknown = null;
     const failures: Array<{
       kind: VoiceInputProviderKind;
@@ -72,70 +125,75 @@ export class FallbackAsrProvider implements AsrProvider {
       message: string;
       error: unknown;
     }> = [];
-    for (const [index, candidate] of this.candidates.entries()) {
-      // The host can dispose this wrapper while a candidate is still mid
-      // connect (every `await` below is a suspension point). Re-check after
-      // each one so a late-connecting candidate is shut down instead of
-      // being committed as a leaked session nobody will ever stop.
-      if (this.disposed) throw new Error('Voice input ASR fallback disposed during start.');
-      let provider: AsrProvider;
+    let nextIndex = 0;
+    let nextLaunchAt = Date.now();
+    const launch = (index: number): void => {
+      const attempt = this.startCandidate(index);
+      this.attempts.set(index, attempt);
+      nextIndex = Math.max(nextIndex, index + 1);
+      // The delay is relative to this launch, not to the original primary.
+      // Explicit failures call launch() immediately, so the following hedge
+      // should still get a fresh grace period rather than inheriting a stale
+      // timer and drifting farther out with every failed candidate.
+      nextLaunchAt = this.hedgeDelayMs === null
+        ? Number.POSITIVE_INFINITY
+        : Date.now() + this.hedgeDelayMs;
+    };
+
+    launch(nextIndex);
+    while (!this.active && !this.disposed) {
+      const pending = [...this.attempts.values()];
+      const waitMs = this.hedgeDelayMs !== null && nextIndex < this.candidates.length
+        ? Math.max(0, nextLaunchAt - Date.now())
+        : null;
+      let timerHandle: ReturnType<typeof setTimeout> | undefined;
+      const timer = waitMs === null
+        ? new Promise<'timer'>(() => undefined)
+        : new Promise<'timer'>((resolve) => {
+          timerHandle = setTimeout(() => resolve('timer'), waitMs);
+        });
+      let result: CandidateAttemptResult | 'timer';
       try {
-        provider = await candidate.create();
-      } catch (error) {
-        lastError = error;
-        failures.push(this.handleCandidateFailure(candidate.kind, index, 'create', error));
-        continue;
+        result = await Promise.race([
+          ...pending.map((attempt) => attempt.promise),
+          timer,
+        ]);
+      } finally {
+        if (timerHandle !== undefined) clearTimeout(timerHandle);
       }
-      if (this.disposed) {
-        // Disposed while this candidate was being created: dispose it before
-        // it ever dials, instead of letting start() open a doomed session.
-        void provider.dispose?.().catch(() => undefined);
-        throw new Error('Voice input ASR fallback disposed during start.');
-      }
-      // Events from a candidate are only forwarded while it is the committed
-      // active provider. A failed start attempt may emit error/disconnected
-      // events; leaking those to VoiceInputController would surface a user
-      // visible failure even though the next candidate succeeds.
-      provider.onEvent((event) => {
-        if (this.active === provider) {
-          for (const callback of this.eventCallbacks) callback(event);
+      if (result === 'timer') {
+        // A timer from a previous race may still fire after an explicit
+        // candidate failure launched the next attempt. Ignore that stale tick
+        // and wait for the current deadline instead of opening a third socket
+        // earlier than the configured hedge interval.
+        if (this.hedgeDelayMs !== null && Date.now() >= nextLaunchAt && !this.active && !this.disposed && nextIndex < this.candidates.length) {
+          launch(nextIndex);
         }
-      });
-      try {
-        await provider.start();
-      } catch (error) {
-        lastError = error;
-        failures.push(this.handleCandidateFailure(candidate.kind, index, 'start', error));
-        void provider.dispose?.().catch((disposeError: unknown) => {
-          log.debug('failed ASR candidate dispose error ignored', {
-            provider: candidate.kind,
-            error: disposeError instanceof Error ? disposeError.message : String(disposeError),
-          });
-        });
         continue;
       }
-      if (this.disposed) {
-        // Disposed while this candidate was connecting: do not commit it.
-        void provider.stop().catch(() => undefined);
-        void provider.dispose?.().catch(() => undefined);
-        throw new Error('Voice input ASR fallback disposed during start.');
+      this.attempts.delete(result.index);
+      if (result.status === 'failed') {
+        lastError = result.error;
+        const candidate = this.candidates[result.index];
+        failures.push(this.handleCandidateFailure(
+          candidate.kind,
+          result.index,
+          result.phase ?? 'start',
+          result.error,
+        ));
+        // An explicit failure should not wait for the hedge timer. Start the
+        // next candidate immediately while retaining the timer for the one
+        // after it.
+        if (!this.active && !this.disposed && this.attempts.size === 0 && nextIndex < this.candidates.length) {
+          launch(nextIndex);
+        }
       }
-      this.active = provider;
-      this.activeKind = candidate.kind;
-      this.recover = provider.recover
-        ? () => this.recoverActiveProvider(provider, candidate.kind)
-        : undefined;
-      markVoiceInputProviderSuccess('asr', candidate.kind);
-      if (index > 0) {
-        log.info('asr fallback succeeded', {
-          provider: candidate.kind,
-          attempt: index + 1,
-          skipped: this.candidates.slice(0, index).map((skipped) => skipped.kind),
-        });
-      }
-      this.flushPendingAudio(provider);
-      return;
+      // A successful attempt commits active before resolving its result.
+      if (this.active) break;
+      if (this.attempts.size === 0 && nextIndex >= this.candidates.length) break;
     }
+    if (this.disposed) throw new Error('Voice input ASR fallback disposed during start.');
+    if (this.active) return;
     // Aggregate every candidate's failure instead of surfacing only the last
     // one: a chain-wide outage (e.g. issue #220, gateway missing all ASR
     // passthrough routes) is undiagnosable from a single tail error. Keep the
@@ -159,7 +217,15 @@ export class FallbackAsrProvider implements AsrProvider {
   }
 
   async stop(): Promise<void> {
-    await this.active?.stop();
+    this.stopping = true;
+    for (const attempt of this.attempts.values()) attempt.cancelled = true;
+    const providers = [...this.attempts.values()]
+      .filter((attempt) => attempt.provider !== null);
+    await Promise.all([
+      this.active?.stop(),
+      ...providers.map((attempt) => this.cleanupAttempt(attempt)),
+    ]);
+    this.stopping = false;
   }
 
   appendAudio(chunk: ArrayBuffer, trace?: AudioTrace): void {
@@ -206,7 +272,151 @@ export class FallbackAsrProvider implements AsrProvider {
 
   async dispose(): Promise<void> {
     this.disposed = true;
-    await this.active?.dispose?.();
+    for (const attempt of this.attempts.values()) attempt.cancelled = true;
+    const attempts = [...this.attempts.values()];
+    await Promise.all([
+      this.active
+        ? this.active.dispose?.()
+        : undefined,
+      ...attempts
+        .filter((attempt) => attempt.provider !== null && attempt.provider !== this.active)
+        .map((attempt) => this.cleanupAttempt(attempt)),
+    ]);
+  }
+
+  private startCandidate(index: number): CandidateAttempt {
+    const candidate = this.candidates[index];
+    const attempt: CandidateAttempt = {
+      index,
+      provider: null,
+      started: false,
+      cancelled: false,
+      cleanupPromise: null,
+      connectedEvent: null,
+      promise: Promise.resolve({ index, status: 'cancelled' as const }),
+    };
+    attempt.promise = (async (): Promise<CandidateAttemptResult> => {
+      let provider: AsrProvider;
+      try {
+        provider = await candidate.create();
+      } catch (error) {
+        if (attempt.cancelled || this.disposed || this.active) return { index, status: 'cancelled' };
+        return {
+          index,
+          status: 'failed',
+          phase: 'create',
+          error: error instanceof Error ? error : new Error(String(error)),
+        };
+      }
+      attempt.provider = provider;
+      if (attempt.cancelled || this.disposed || this.active || this.stopping) {
+        await this.cleanupAttempt(attempt);
+        return { index, status: 'cancelled' };
+      }
+      provider.onEvent((event) => {
+        if (this.active === provider) {
+          for (const callback of this.eventCallbacks) callback(event);
+          return;
+        }
+        if (event.type === 'connected' && !attempt.connectedEvent) {
+          attempt.connectedEvent = event;
+        }
+      });
+      try {
+        attempt.started = true;
+        await this.startWithTimeout(provider.start(), candidate.kind);
+      } catch (error) {
+        if (attempt.cancelled || this.disposed || this.active) {
+          await this.cleanupAttempt(attempt);
+          return { index, status: 'cancelled' };
+        }
+        // Closing a failed socket must not hold up the next candidate. The
+        // cleanup path is idempotent and consumes its own errors, so it can
+        // finish in parallel with the fallback connection.
+        void this.cleanupAttempt(attempt);
+        return {
+          index,
+          status: 'failed',
+          phase: 'start',
+          error: error instanceof Error ? error : new Error(String(error)),
+        };
+      }
+      if (attempt.cancelled || this.disposed || this.active || this.stopping) {
+        await this.cleanupAttempt(attempt);
+        return { index, status: 'cancelled' };
+      }
+      this.active = provider;
+      this.activeKind = candidate.kind;
+      this.recover = provider.recover
+        ? () => this.recoverActiveProvider(provider, candidate.kind)
+        : undefined;
+      markVoiceInputProviderSuccess('asr', candidate.kind);
+      if (attempt.connectedEvent) {
+        const connected = attempt.connectedEvent;
+        attempt.connectedEvent = null;
+        for (const callback of this.eventCallbacks) callback(connected);
+      }
+      if (index > 0) {
+        log.info('asr fallback succeeded', {
+          provider: candidate.kind,
+          attempt: index + 1,
+          skipped: this.candidates.slice(0, index).map((skipped) => skipped.kind),
+        });
+      }
+      this.flushPendingAudio(provider);
+      // Cancel every still-pending loser as soon as a winner is committed.
+      for (const other of this.attempts.values()) {
+        if (other.index === index) continue;
+        other.cancelled = true;
+        if (other.provider) {
+          void this.cleanupAttempt(other);
+        }
+        this.attempts.delete(other.index);
+      }
+      return { index, status: 'success' };
+    })();
+    return attempt;
+  }
+
+  private cleanupAttempt(attempt: CandidateAttempt): Promise<void> {
+    if (!attempt.provider) return Promise.resolve();
+    if (!attempt.cleanupPromise) {
+      attempt.cleanupPromise = this.disposeCandidate(
+        attempt.provider,
+        this.candidates[attempt.index].kind,
+        attempt.started,
+      );
+    }
+    return attempt.cleanupPromise;
+  }
+
+  private async disposeCandidate(provider: AsrProvider, kind: VoiceInputProviderKind, started = true): Promise<void> {
+    if (started) await provider.stop().catch(() => undefined);
+    await provider.dispose?.().catch((disposeError: unknown) => {
+      log.debug('failed ASR candidate dispose error ignored', {
+        provider: kind,
+        error: disposeError instanceof Error ? disposeError.message : String(disposeError),
+      });
+    });
+  }
+
+  private async startWithTimeout(startPromise: Promise<void>, kind: VoiceInputProviderKind): Promise<void> {
+    const timeoutMs = this.startTimeoutMs;
+    if (timeoutMs === null) return startPromise;
+    let timer: ReturnType<typeof setTimeout> | undefined;
+    const timeoutPromise = new Promise<never>((_, reject) => {
+      timer = setTimeout(() => {
+        reject(new Error(`${kind} ASR start timed out after ${timeoutMs}ms.`));
+      }, timeoutMs);
+    });
+    // A timed-out provider may still settle after its socket is closed. Attach
+    // a rejection handler so the late settlement never becomes unhandled.
+    void startPromise.catch(() => undefined);
+    try {
+      await Promise.race([startPromise, timeoutPromise]);
+    } finally {
+      if (timer !== undefined) clearTimeout(timer);
+    }
   }
 
   private handleCandidateFailure(

--- a/apps/desktop/src/main/voice-input/RealtimeAsrWebSocketProvider.ts
+++ b/apps/desktop/src/main/voice-input/RealtimeAsrWebSocketProvider.ts
@@ -1092,6 +1092,10 @@ export class RealtimeAsrWebSocketProvider implements AsrProvider {
   // pending refines). Ensures the recorder flushes its WAV/meta before the
   // provider is GC'd.
   async dispose(): Promise<void> {
+    // Fallback candidates can be disposed directly when their start attempt
+    // times out or loses a hedge. Make dispose self-contained so a provider
+    // cannot leave a connecting websocket alive when the wrapper skips it.
+    if (!this.stopRequested) await this.stop();
     this.stopHealthLog();
     if (this.recorder) {
       await this.recorder.finalize({

--- a/apps/desktop/src/main/voice-input/VolcengineSaucAsrProvider.ts
+++ b/apps/desktop/src/main/voice-input/VolcengineSaucAsrProvider.ts
@@ -131,6 +131,7 @@ export class VolcengineSaucAsrProvider implements AsrProvider {
   }
 
   private async openSocket(): Promise<void> {
+    const openStartedAt = performance.now();
     const connection = this.connectionProvider
       ? await this.connectionProvider()
       : {
@@ -138,10 +139,13 @@ export class VolcengineSaucAsrProvider implements AsrProvider {
           authorizationToken: this.proxyApiKey!,
         };
     if (this.stopRequested) throw new Error('Volcengine SAUC ASR connection stopped.');
+    const connectionResolvedAt = performance.now();
     // `ws` 不吃系统代理;直连时为 undefined,行为与不传一致。
     const agent = await createOutboundHttpAgent(connection.websocketUrl);
     // 解析代理是一次异步往返,期间可能已停录 —— 复查后再建连,不留孤儿 socket。
     if (this.stopRequested) throw new Error('Volcengine SAUC ASR connection stopped.');
+    const dialStartedAt = performance.now();
+    let socketOpenedAt = 0;
     const socket = new WebSocket(connection.websocketUrl, {
       headers: {
         Authorization: `Bearer ${connection.authorizationToken}`,
@@ -193,6 +197,7 @@ export class VolcengineSaucAsrProvider implements AsrProvider {
           fail(new Error('Volcengine SAUC ASR connection opened after stop.'), true);
           return;
         }
+        socketOpenedAt = performance.now();
         this.startKeepAlive();
         this.sendInitialRequest();
       };
@@ -221,6 +226,14 @@ export class VolcengineSaucAsrProvider implements AsrProvider {
         cleanup();
         this.connected = true;
         this.started = true;
+        const readyAt = performance.now();
+        log.debug('connected', {
+          connectionMs: Math.round(connectionResolvedAt - openStartedAt),
+          proxyResolveMs: Math.round(dialStartedAt - connectionResolvedAt),
+          socketOpenMs: socketOpenedAt ? Math.round(socketOpenedAt - dialStartedAt) : undefined,
+          firstResponseMs: socketOpenedAt ? Math.round(readyAt - socketOpenedAt) : undefined,
+          totalMs: Math.round(readyAt - openStartedAt),
+        });
         this.callback({ type: 'connected', at: Date.now() });
         resolve();
       };
@@ -276,12 +289,26 @@ export class VolcengineSaucAsrProvider implements AsrProvider {
     // cut off by an empty final marker.
     const finalChunk = silencePcm16(this.pcmSampleRate, NONSTREAM_END_WINDOW_MS);
     socket.send(encodeAudioOnlyRequest(finalChunk, -this.nextSequence()));
+    const flushStartedAt = performance.now();
+    let flushTimedOut = false;
     await new Promise<void>((resolve) => {
-      const timer = setTimeout(resolve, FLUSH_TIMEOUT_MS);
+      const timer = setTimeout(() => {
+        flushTimedOut = true;
+        resolve();
+      }, FLUSH_TIMEOUT_MS);
       this.flushResolvers.push(() => {
         clearTimeout(timer);
         resolve();
       });
+    });
+    // Stop-to-submit latency is dominated by this wait for the server's last
+    // response; log it so a slow final pass is distinguishable from the
+    // controller's own stable wait.
+    log.debug('flush settled', {
+      waitMs: Math.round(performance.now() - flushStartedAt),
+      timedOut: flushTimedOut,
+      sentAudioMs: Math.round(this.sentAudioMs),
+      hasStable: this.stableEmitted,
     });
     if (this.lastTranscript && !this.stableEmitted) {
       this.callback({ type: 'stable', text: this.lastTranscript, at: Date.now() });
@@ -315,6 +342,10 @@ export class VolcengineSaucAsrProvider implements AsrProvider {
     }
     this.teardownSocketForReconnect();
     this.callback({ type: 'disconnected', at: Date.now() });
+  }
+
+  async dispose(): Promise<void> {
+    if (!this.stopRequested) await this.stop();
   }
 
   private resetState(): void {

--- a/apps/desktop/src/main/voice-input/__tests__/CindyVoiceSessionClient.test.ts
+++ b/apps/desktop/src/main/voice-input/__tests__/CindyVoiceSessionClient.test.ts
@@ -119,4 +119,26 @@ describe('CindyVoiceRunContext', () => {
     const thirdBody = (serverApiFetch.mock.calls[2][1] as { body: { refinerProvider?: string } }).body;
     expect(thirdBody.refinerProvider).toBe('auto');
   });
+
+  it('does not let a late session allocation overwrite a newer fallback attempt', async () => {
+    serverApiFetch.mockReset();
+    let resolveFirst!: (session: typeof SESSION) => void;
+    const firstResponse = new Promise<typeof SESSION>((resolve) => {
+      resolveFirst = resolve;
+    });
+    serverApiFetch
+      .mockReturnValueOnce(firstResponse)
+      .mockResolvedValueOnce(SESSION);
+    const context = new CindyVoiceRunContext('zh-CN', 'auto');
+
+    const first = context.createAsrConnection('qwen-asr-flash-realtime');
+    await Promise.resolve();
+    const second = context.createAsrConnection('qwen-asr-flash-realtime');
+    await expect(second).resolves.toEqual({
+      websocketUrl: SESSION.asr.websocketUrl,
+      authorizationToken: SESSION.ticket,
+    });
+    resolveFirst(SESSION);
+    await expect(first).rejects.toThrow('superseded by a newer provider attempt');
+  });
 });

--- a/apps/desktop/src/main/voice-input/__tests__/FallbackAsrProvider.test.ts
+++ b/apps/desktop/src/main/voice-input/__tests__/FallbackAsrProvider.test.ts
@@ -16,6 +16,8 @@ type MockAsrProvider = AsrProvider & {
 
 function makeMockProvider(options?: {
   startError?: Error;
+  startGate?: Promise<void>;
+  stopGate?: Promise<void>;
   recover?: () => Promise<void>;
 }): MockAsrProvider {
   const callbacks: Array<(event: AsrEvent) => void> = [];
@@ -24,8 +26,11 @@ function makeMockProvider(options?: {
     appended,
     start: vi.fn(async () => {
       if (options?.startError) throw options.startError;
+      await options?.startGate;
     }),
-    stop: vi.fn(async () => {}),
+    stop: vi.fn(async () => {
+      await options?.stopGate;
+    }),
     appendAudio: vi.fn((chunk: ArrayBuffer) => {
       appended.push(chunk);
     }),
@@ -74,6 +79,66 @@ describe('FallbackAsrProvider', () => {
     expect(events).toEqual([{ type: 'partial', text: 'hello', at: 1 }]);
     fallback.appendAudio(chunk(1));
     expect(first.appended).toHaveLength(1);
+  });
+
+  it('replays the connected event emitted during start() once the candidate wins', async () => {
+    const callbacks: Array<(event: AsrEvent) => void> = [];
+    const provider: AsrProvider = {
+      start: vi.fn(async () => {
+        // Real providers emit `connected` from inside start(), before the
+        // wrapper has committed them as active.
+        for (const callback of callbacks) callback({ type: 'connected', at: 7 });
+      }),
+      stop: vi.fn(async () => {}),
+      appendAudio: vi.fn(),
+      flushAudio: vi.fn(async () => {}),
+      onEvent: (callback) => {
+        callbacks.push(callback);
+      },
+    };
+    const fallback = new FallbackAsrProvider([candidate('litellm-volcengine-sauc-asr', async () => provider)]);
+    const events: AsrEvent[] = [];
+    fallback.onEvent((event) => events.push(event));
+
+    await fallback.start();
+
+    expect(events).toEqual([{ type: 'connected', at: 7 }]);
+  });
+
+  it('drops the connected event of a losing candidate', async () => {
+    let releaseFirst!: () => void;
+    const firstGate = new Promise<void>((resolve) => {
+      releaseFirst = resolve;
+    });
+    const firstCallbacks: Array<(event: AsrEvent) => void> = [];
+    const first: AsrProvider = {
+      start: vi.fn(async () => {
+        await firstGate;
+        for (const callback of firstCallbacks) callback({ type: 'connected', at: 1 });
+      }),
+      stop: vi.fn(async () => {}),
+      appendAudio: vi.fn(),
+      flushAudio: vi.fn(async () => {}),
+      onEvent: (callback) => {
+        firstCallbacks.push(callback);
+      },
+      dispose: vi.fn(async () => {}),
+    };
+    const second = makeMockProvider();
+    const fallback = new FallbackAsrProvider([
+      candidate('litellm-volcengine-sauc-asr', async () => first),
+      candidate('litellm-qwen3-asr-flash-realtime', second),
+    ], { hedgeDelayMs: 0 });
+    const events: AsrEvent[] = [];
+    fallback.onEvent((event) => events.push(event));
+
+    await fallback.start();
+    expect(fallback.activeProviderKind).toBe('litellm-qwen3-asr-flash-realtime');
+    releaseFirst();
+    await Promise.resolve();
+    await Promise.resolve();
+
+    expect(events).toEqual([]);
   });
 
   it('falls back to the next candidate when start() fails and suppresses events from the failed attempt', async () => {
@@ -244,5 +309,79 @@ describe('FallbackAsrProvider', () => {
     expect(typeof fallbackWithRecover.recover).toBe('function');
     await expect(fallbackWithRecover.recover!()).rejects.toThrow('recover exhausted');
     expect(isVoiceInputProviderCoolingDown('asr', 'litellm-qwen3-asr-flash-realtime')).toBe(true);
+  });
+
+  it('starts a delayed hedge when the primary is slow and disposes the losing attempt', async () => {
+    let releasePrimary!: () => void;
+    const primaryGate = new Promise<void>((resolve) => { releasePrimary = resolve; });
+    const primary = makeMockProvider({ startGate: primaryGate });
+    const backup = makeMockProvider();
+    const fallback = new FallbackAsrProvider([
+      candidate('litellm-volcengine-sauc-asr', primary),
+      candidate('litellm-qwen3-asr-flash-realtime', backup),
+    ], { hedgeDelayMs: 10 });
+
+    const startPromise = fallback.start();
+    await new Promise((resolve) => setTimeout(resolve, 20));
+    expect(backup.start).toHaveBeenCalledTimes(1);
+    expect(fallback.activeProviderKind).toBe('litellm-qwen3-asr-flash-realtime');
+    expect(primary.stop).toHaveBeenCalled();
+    expect(primary.dispose).toHaveBeenCalled();
+    releasePrimary();
+    await startPromise;
+  });
+
+  it('launches the next candidate immediately after an explicit start failure', async () => {
+    const first = makeMockProvider({ startError: new Error('connection refused') });
+    const second = makeMockProvider();
+    const fallback = new FallbackAsrProvider([
+      candidate('litellm-volcengine-sauc-asr', first),
+      candidate('litellm-qwen3-asr-flash-realtime', second),
+    ], { hedgeDelayMs: 10_000 });
+
+    await fallback.start();
+
+    expect(second.start).toHaveBeenCalledTimes(1);
+    expect(fallback.activeProviderKind).toBe('litellm-qwen3-asr-flash-realtime');
+  });
+
+  it('does not wait for failed-candidate cleanup before starting the fallback', async () => {
+    let releaseStop!: () => void;
+    const stopGate = new Promise<void>((resolve) => { releaseStop = resolve; });
+    const first = makeMockProvider({
+      startError: new Error('connection refused'),
+      stopGate,
+    });
+    const second = makeMockProvider();
+    const fallback = new FallbackAsrProvider([
+      candidate('litellm-volcengine-sauc-asr', first),
+      candidate('litellm-qwen3-asr-flash-realtime', second),
+    ], { hedgeDelayMs: null });
+
+    await fallback.start();
+
+    expect(first.stop).toHaveBeenCalledTimes(1);
+    expect(first.dispose).not.toHaveBeenCalled();
+    expect(second.start).toHaveBeenCalledTimes(1);
+    expect(fallback.activeProviderKind).toBe('litellm-qwen3-asr-flash-realtime');
+    releaseStop();
+    await vi.waitFor(() => expect(first.dispose).toHaveBeenCalledTimes(1));
+  });
+
+  it('fast-fails a candidate that never becomes ready and cleans it up', async () => {
+    const stalled = makeMockProvider({ startGate: new Promise<void>(() => undefined) });
+    const backup = makeMockProvider();
+    const fallback = new FallbackAsrProvider([
+      candidate('litellm-volcengine-sauc-asr', stalled),
+      candidate('litellm-qwen3-asr-flash-realtime', backup),
+    ], { hedgeDelayMs: null, startTimeoutMs: 10 });
+
+    await fallback.start();
+
+    expect(stalled.start).toHaveBeenCalledTimes(1);
+    expect(stalled.stop).toHaveBeenCalledTimes(1);
+    expect(stalled.dispose).toHaveBeenCalledTimes(1);
+    expect(backup.start).toHaveBeenCalledTimes(1);
+    expect(fallback.activeProviderKind).toBe('litellm-qwen3-asr-flash-realtime');
   });
 });

--- a/apps/desktop/src/main/voice-input/__tests__/FallbackAsrProvider.test.ts
+++ b/apps/desktop/src/main/voice-input/__tests__/FallbackAsrProvider.test.ts
@@ -368,20 +368,28 @@ describe('FallbackAsrProvider', () => {
     await vi.waitFor(() => expect(first.dispose).toHaveBeenCalledTimes(1));
   });
 
-  it('fast-fails a candidate that never becomes ready and cleans it up', async () => {
-    const stalled = makeMockProvider({ startGate: new Promise<void>(() => undefined) });
-    const backup = makeMockProvider();
+  it('lets a slow single candidate finish on its own deadline instead of imposing a wrapper timeout', async () => {
+    let releaseStart!: () => void;
+    const slow = makeMockProvider({
+      startGate: new Promise<void>((resolve) => {
+        releaseStart = resolve;
+      }),
+    });
     const fallback = new FallbackAsrProvider([
-      candidate('litellm-volcengine-sauc-asr', stalled),
-      candidate('litellm-qwen3-asr-flash-realtime', backup),
-    ], { hedgeDelayMs: null, startTimeoutMs: 10 });
+      candidate('litellm-volcengine-sauc-asr', slow),
+    ]);
 
-    await fallback.start();
+    const startPromise = fallback.start();
+    await new Promise((resolve) => setTimeout(resolve, 30));
+    expect(fallback.activeProviderKind).toBeNull();
+    expect(slow.stop).not.toHaveBeenCalled();
 
-    expect(stalled.start).toHaveBeenCalledTimes(1);
-    expect(stalled.stop).toHaveBeenCalledTimes(1);
-    expect(stalled.dispose).toHaveBeenCalledTimes(1);
-    expect(backup.start).toHaveBeenCalledTimes(1);
-    expect(fallback.activeProviderKind).toBe('litellm-qwen3-asr-flash-realtime');
+    releaseStart();
+    await startPromise;
+
+    expect(slow.start).toHaveBeenCalledTimes(1);
+    expect(slow.stop).not.toHaveBeenCalled();
+    expect(slow.dispose).not.toHaveBeenCalled();
+    expect(fallback.activeProviderKind).toBe('litellm-volcengine-sauc-asr');
   });
 });

--- a/apps/desktop/src/main/voice-input/global.ts
+++ b/apps/desktop/src/main/voice-input/global.ts
@@ -66,6 +66,7 @@ const log = createLogger('voice-input-global');
 type GlobalVoiceInputShortcutPhase = 'start' | 'tap' | 'end';
 
 const modifierShortcutRecordingWebContentsIds = new Set<number>();
+const modifierShortcutRecordingCleanupWebContentsIds = new Set<number>();
 /**
  * 正在录制快捷键的 renderer —— 与上面那个「keys 转发名单」是两件事。
  *
@@ -77,6 +78,7 @@ const modifierShortcutRecordingWebContentsIds = new Set<number>();
  */
 const modifierShortcutRecordingSessionIds = new Set<number>();
 const activeInlineVoiceInputWebContentsIds = new Set<number>();
+const activeInlineVoiceInputCleanupWebContentsIds = new Set<number>();
 
 /**
  * 有任何窗口的快捷键录制框开着时，全局快捷键的**新激活**一律丢弃。
@@ -651,10 +653,13 @@ async function classifyMacNativeListenerFailure(): Promise<VoiceInputGlobalError
 
 export function registerActiveInlineVoiceInputWebContents(sender: WebContents): void {
   if (isGlobalVoiceInputOverlaySender(sender)) return;
-  if (activeInlineVoiceInputWebContentsIds.has(sender.id)) return;
   activeInlineVoiceInputWebContentsIds.add(sender.id);
+  if (activeInlineVoiceInputCleanupWebContentsIds.has(sender.id)) return;
+  const webContentsId = sender.id;
+  activeInlineVoiceInputCleanupWebContentsIds.add(webContentsId);
   sender.once('destroyed', () => {
-    activeInlineVoiceInputWebContentsIds.delete(sender.id);
+    activeInlineVoiceInputCleanupWebContentsIds.delete(webContentsId);
+    activeInlineVoiceInputWebContentsIds.delete(webContentsId);
   });
 }
 
@@ -1012,8 +1017,20 @@ async function recoverPendingNativeShortcutRegistration(): Promise<void> {
 function markModifierShortcutRecordingSession(sender: WebContents): void {
   if (modifierShortcutRecordingSessionIds.has(sender.id)) return;
   modifierShortcutRecordingSessionIds.add(sender.id);
+  registerModifierShortcutRecordingCleanup(sender);
+}
+
+function registerModifierShortcutRecordingCleanup(sender: WebContents): void {
+  if (modifierShortcutRecordingCleanupWebContentsIds.has(sender.id)) return;
+  const webContentsId = sender.id;
+  modifierShortcutRecordingCleanupWebContentsIds.add(webContentsId);
   sender.once('destroyed', () => {
-    modifierShortcutRecordingSessionIds.delete(sender.id);
+    modifierShortcutRecordingCleanupWebContentsIds.delete(webContentsId);
+    modifierShortcutRecordingSessionIds.delete(webContentsId);
+    modifierShortcutRecordingWebContentsIds.delete(webContentsId);
+    if (modifierShortcutRecordingWebContentsIds.size === 0) {
+      macModifierShortcutListener.stopKeyCapture();
+    }
   });
 }
 
@@ -1143,12 +1160,6 @@ export function registerGlobalVoiceInputIpc(deps: GlobalVoiceInputIpcDeps): void
       // 录制会话在**尝试之前**就登记：capture 起不起来都不影响「用户正在录」这个事实。
       // （显式挂起时其实已经登记过了，这里幂等补一次，不依赖调用顺序。）
       markModifierShortcutRecordingSession(event.sender);
-      event.sender.once('destroyed', () => {
-        modifierShortcutRecordingWebContentsIds.delete(event.sender.id);
-        if (modifierShortcutRecordingWebContentsIds.size === 0) {
-          macModifierShortcutListener.stopKeyCapture();
-        }
-      });
       // 走 startMacNativeListener：startKeyCapture 也会抛（helper 源码缺失 / swiftc
       // 失败）。不接住的话下面的清理与 errorCode 分类都跑不到，本 renderer 会留在
       // 转发名单里、原始路径还会过桥给它。

--- a/apps/desktop/src/main/voice-input/index.ts
+++ b/apps/desktop/src/main/voice-input/index.ts
@@ -2189,11 +2189,6 @@ export function registerVoiceInputIpc(): void {
         // losing session. BYOK providers have independent credentials and
         // may use the staggered client-side hedge.
         hedgeDelayMs: voiceContext ? null : undefined,
-        // Managed startup already has separate session-allocation and socket
-        // deadlines. An outer cap would combine those phases and can reject a
-        // slow-but-valid connection. BYOK has no allocation round trip, so the
-        // wrapper can fail its stalled sockets more aggressively.
-        startTimeoutMs: voiceContext ? null : 4_500,
       });
     } catch (error) {
       const message = error instanceof Error ? error.message : String(error);

--- a/apps/desktop/src/main/voice-input/index.ts
+++ b/apps/desktop/src/main/voice-input/index.ts
@@ -1,4 +1,4 @@
-import { app, ipcMain, shell, systemPreferences } from 'electron';
+import { app, ipcMain, shell, systemPreferences, type WebContents } from 'electron';
 import fs from 'node:fs/promises';
 
 import {
@@ -279,6 +279,7 @@ export type DictionaryAdviceIpcResult =
   | { ok: false; error: string };
 
 const activeByWebContentsId = new Map<number, ActiveVoiceInput>();
+const destroyedWebContentsListeners = new Set<number>();
 let appRestoreRegistered = false;
 let cachedMicrophonePermission: VoiceInputMicrophonePermissionCache | null = null;
 let rendererVerifiedMicrophonePermission = false;
@@ -481,6 +482,52 @@ function summarizeTimelineEventForLog(event: VoiceTimelineEvent): Record<string,
     }
   }
   return summary;
+}
+
+function summarizeVoiceLatency(
+  events: ReadonlyMap<string, VoiceTimelineEvent>,
+  submitted: Extract<VoiceTimelineEvent, { type: 'submitted' }>,
+  provider: string | null,
+): Record<string, unknown> {
+  const start = events.get(`${submitted.runId}:start_clicked`);
+  const elapsed = (type: VoiceTimelineEvent['type']): number | undefined => {
+    const event = events.get(`${submitted.runId}:${type}`);
+    if (!event || !start) return undefined;
+    if ('elapsedMs' in event && typeof event.elapsedMs === 'number') return Math.round(event.elapsedMs);
+    return Math.max(0, event.at - start.at);
+  };
+  return {
+    runId: submitted.runId,
+    provider: provider ?? undefined,
+    totalMs: elapsed('submitted'),
+    firstAudioChunkMs: elapsed('first_audio_chunk'),
+    asrConnectedMs: elapsed('asr_connected'),
+    firstPartialMs: elapsed('first_partial'),
+    stableReceivedMs: elapsed('stable_received'),
+    submittedMs: elapsed('submitted'),
+    submitSource: submitted.source,
+  };
+}
+
+function registerVoiceInputWebContentsDestroyedCleanup(sender: WebContents): void {
+  const webContentsId = sender.id;
+  if (destroyedWebContentsListeners.has(webContentsId)) return;
+  destroyedWebContentsListeners.add(webContentsId);
+  sender.once('destroyed', () => {
+    destroyedWebContentsListeners.delete(webContentsId);
+    const active = activeByWebContentsId.get(webContentsId);
+    if (!active) return;
+    unregisterActiveInlineVoiceInputWebContents(webContentsId);
+    activeByWebContentsId.delete(webContentsId);
+    void (async () => {
+      await active.controller.cancel();
+      await disposeVoiceInputProvider(active.provider, 'web_contents_destroyed', {
+        sourceLanguage: active.sourceLanguage,
+        refinementEnabled: active.refinementEnabled,
+      });
+      await restoreSystemAudioForSender(webContentsId);
+    })();
+  });
 }
 
 // 'auto' must mean "let the ASR provider auto-detect", not "fall back to the
@@ -2051,13 +2098,22 @@ export function registerVoiceInputIpc(): void {
     // Refiner fallback chain: credential-ready profiles in runtime priority
     // order. The built-in default is readiness-aware (Codex ready: Codex →
     // Kimi; Codex unavailable: LiteLLM GPT → Kimi), then cooldown-aware.
-    const {
-      refinerChainProfiles,
-      refinerReadinessList,
-      readyRefinerProfiles,
-    } = shouldRefine
-      ? await resolveVoiceInputRefinerChainForRuntime(useCindyVoiceService)
-      : { refinerChainProfiles: [], refinerReadinessList: [], readyRefinerProfiles: [] };
+    // Refiner-chain and ASR-chain resolution are independent reads (settings,
+    // secret store, Codex auth state); resolving them concurrently keeps the
+    // Codex auth round trip off the ASR dial's critical path.
+    const [
+      {
+        refinerChainProfiles,
+        refinerReadinessList,
+        readyRefinerProfiles,
+      },
+      startableAsrChain,
+    ] = await Promise.all([
+      shouldRefine
+        ? resolveVoiceInputRefinerChainForRuntime(useCindyVoiceService)
+        : Promise.resolve({ refinerChainProfiles: [], refinerReadinessList: [], readyRefinerProfiles: [] }),
+      resolveStartableAsrChain(),
+    ]);
     const primaryRefinerProfile = refinerChainProfiles[0] ?? null;
     const primaryRefinerReadiness = refinerReadinessList[0] ?? null;
     const canRefine = readyRefinerProfiles.length > 0;
@@ -2089,7 +2145,6 @@ export function registerVoiceInputIpc(): void {
     // Connect-phase fallback: hand FallbackAsrProvider the full startable
     // chain. Construction is lazy — providers beyond the first are only
     // instantiated when an earlier candidate fails to connect.
-    const startableAsrChain = await resolveStartableAsrChain();
     const effectiveRefinerProfile = readyRefinerProfiles[0] ?? null;
     // BYOK mode must never allocate a managed voice-server session even when
     // the service is reachable — the user explicitly chose their own
@@ -2127,7 +2182,19 @@ export function registerVoiceInputIpc(): void {
           }
           return createVoiceInputProvider(kind, asrLanguageHint, voiceContext);
         },
-      })));
+      })), {
+        // Managed candidates allocate one voice-server session per provider.
+        // Do not hedge those requests: concurrent sessions race the shared
+        // run context's session id and can leave refinement attached to the
+        // losing session. BYOK providers have independent credentials and
+        // may use the staggered client-side hedge.
+        hedgeDelayMs: voiceContext ? null : undefined,
+        // Managed startup already has separate session-allocation and socket
+        // deadlines. An outer cap would combine those phases and can reject a
+        // slow-but-valid connection. BYOK has no allocation round trip, so the
+        // wrapper can fail its stalled sockets more aggressively.
+        startTimeoutMs: voiceContext ? null : 4_500,
+      });
     } catch (error) {
       const message = error instanceof Error ? error.message : String(error);
       log.warn('provider create failed', { error: message });
@@ -2220,8 +2287,25 @@ export function registerVoiceInputIpc(): void {
         });
       }
     }
+    const timelineEvents = new Map<string, VoiceTimelineEvent>();
     const logger = new VoiceTimelineLogger((timelineEvent) => {
       log.debug('timeline', summarizeTimelineEventForLog(timelineEvent));
+      timelineEvents.set(`${timelineEvent.runId}:${timelineEvent.type}`, timelineEvent);
+      if (timelineEvent.type === 'submitted') {
+        log.info('latency summary', summarizeVoiceLatency(
+          timelineEvents,
+          timelineEvent,
+          provider.activeProviderKind,
+        ));
+      } else if (timelineEvent.type === 'refine_accepted' || timelineEvent.type === 'refine_rejected') {
+        const start = timelineEvents.get(`${timelineEvent.runId}:start_clicked`);
+        log.info('refinement latency summary', {
+          runId: timelineEvent.runId,
+          outcome: timelineEvent.type === 'refine_accepted' ? 'accepted' : 'rejected',
+          elapsedMs: timelineEvent.elapsedMs === undefined ? undefined : Math.round(timelineEvent.elapsedMs),
+          totalMs: start ? Math.max(0, timelineEvent.at - start.at) : undefined,
+        });
+      }
       logRefineSummary(timelineEvent, refinementContext);
       if (runId) emit({ type: 'timeline', runId, event: timelineEvent });
     });
@@ -2298,20 +2382,7 @@ export function registerVoiceInputIpc(): void {
         sourceLanguage: payload?.sourceLanguage,
         refinementEnabled: Boolean(refiner),
       });
-      event.sender.once('destroyed', () => {
-        const active = activeByWebContentsId.get(event.sender.id);
-        if (active?.controller !== controller) return;
-        unregisterActiveInlineVoiceInputWebContents(event.sender.id);
-        activeByWebContentsId.delete(event.sender.id);
-        void (async () => {
-          await controller.cancel();
-          await disposeVoiceInputProvider(provider, 'web_contents_destroyed', {
-            sourceLanguage: active.sourceLanguage,
-            refinementEnabled: active.refinementEnabled,
-          });
-          await restoreSystemAudioForSender(event.sender.id);
-        })();
-      });
+      registerVoiceInputWebContentsDestroyedCleanup(event.sender);
       log.info('started', {
         runId,
         webContentsId: event.sender.id,

--- a/apps/desktop/src/renderer/components/ui/__tests__/tipControlledOpen.test.tsx
+++ b/apps/desktop/src/renderer/components/ui/__tests__/tipControlledOpen.test.tsx
@@ -1,0 +1,41 @@
+// @vitest-environment jsdom
+/**
+ * Tip 的 controlledOpen 在「受控 → 交回 hover」之间切换时不能触发 Radix 的
+ * uncontrolled/controlled 切换警告。语音按钮就是这种用法:精修中强制展示,结束后
+ * 交回 hover;之前每次提交都会在控制台报一次警告。
+ */
+import { cleanup, render } from '@testing-library/react';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+import { Tip } from '../tooltip';
+
+describe('Tip controlledOpen transitions', () => {
+  afterEach(() => {
+    cleanup();
+    vi.restoreAllMocks();
+  });
+
+  it('does not warn when controlledOpen goes from boolean back to undefined', () => {
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => undefined);
+    const error = vi.spyOn(console, 'error').mockImplementation(() => undefined);
+
+    const { rerender } = render(
+      <Tip text="tip" controlledOpen={undefined}>
+        <button type="button">voice</button>
+      </Tip>,
+    );
+    rerender(
+      <Tip text="tip" controlledOpen>
+        <button type="button">voice</button>
+      </Tip>,
+    );
+    rerender(
+      <Tip text="tip" controlledOpen={undefined}>
+        <button type="button">voice</button>
+      </Tip>,
+    );
+
+    const messages = [...warn.mock.calls, ...error.mock.calls].map((call) => String(call[0]));
+    expect(messages.filter((message) => /uncontrolled to controlled|controlled to uncontrolled/i.test(message))).toEqual([]);
+  });
+});

--- a/apps/desktop/src/renderer/components/ui/tooltip.tsx
+++ b/apps/desktop/src/renderer/components/ui/tooltip.tsx
@@ -131,8 +131,8 @@ export interface TipProps {
 // 注意:不写出 React.HTMLAttributes 的具体类型,因为外层 Trigger(Popover/Dropdown 等)
 // 注入的 props 形态各异——用 ...rest 直接转发即可,Radix 的 Slot 会正确合并。
 // ref 类型用 unknown:外层 Trigger 可能是任何元素(button/span/img 等),Tip 不该限定。
-export const Tip = React.forwardRef<unknown, TipProps>(function Tip(
-  {
+export const Tip = React.forwardRef<unknown, TipProps>(function Tip(props, forwardedRef) {
+  const {
     text,
     children,
     mono,
@@ -143,14 +143,25 @@ export const Tip = React.forwardRef<unknown, TipProps>(function Tip(
     controlledOpen,
     contentClassName,
     ...rest
-  },
-  forwardedRef,
-) {
+  } = props;
   const isEmpty =
     disabled ||
     text === null ||
     text === undefined ||
     (typeof text === 'string' && text.length === 0);
+
+  // Radix Tooltip 要求 open 在整个生命周期里要么一直受控、要么一直非受控,来回切换
+  // 会抛 "changing from uncontrolled to controlled"。调用方常按状态临时受控(拖拽、
+  // 录音精修中),之后又交回 hover 驱动 —— 只要调用方**声明了**受控意图(传了
+  // controlledOpen / forceOpen 这两个 prop,哪怕当前值是 undefined),就从挂载起
+  // 走受控路径,交回时用本地 hover 状态模拟非受控行为。
+  const requestedOpen = controlledOpen ?? (forceOpen ? true : undefined);
+  const [hoverOpen, setHoverOpen] = React.useState(false);
+  const controlledRef = React.useRef(
+    'controlledOpen' in props || 'forceOpen' in props || requestedOpen !== undefined,
+  );
+  if (requestedOpen !== undefined) controlledRef.current = true;
+  const open = requestedOpen ?? (controlledRef.current ? hoverOpen : undefined);
 
   // 没有 tooltip 内容时,Tip 仍要保持"透明传递":把外层 props/ref 直接合并到 children,
   // 避免在复合 trigger 里成为 ref/事件断点。React 18 的 cloneElement 类型签名不接受 ref
@@ -164,7 +175,7 @@ export const Tip = React.forwardRef<unknown, TipProps>(function Tip(
 
   return (
     <TooltipProvider delayDuration={delay}>
-      <TooltipRoot open={controlledOpen ?? (forceOpen ? true : undefined)}>
+      <TooltipRoot open={open} onOpenChange={setHoverOpen}>
         <TooltipTrigger
           asChild
           ref={forwardedRef as React.Ref<HTMLButtonElement>}

--- a/apps/desktop/src/renderer/hooks/__tests__/useVoiceInputSettings.shortcutSync.test.ts
+++ b/apps/desktop/src/renderer/hooks/__tests__/useVoiceInputSettings.shortcutSync.test.ts
@@ -1,0 +1,94 @@
+// @vitest-environment jsdom
+
+import { act, renderHook } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import {
+  getDefaultVoiceInputSettings,
+  type VoiceInputDataSnapshot,
+  type VoiceInputSettings,
+} from '../../../shared/voiceInputData';
+import { useVoiceInputSettings } from '../useVoiceInputSettings';
+
+vi.mock('react-i18next', () => ({
+  useTranslation: () => ({ t: (key: string) => key }),
+}));
+
+vi.mock('@/lib/logger', () => ({
+  createLogger: () => ({ warn: vi.fn(), debug: vi.fn() }),
+}));
+
+vi.mock('@/lib/toast', () => ({
+  toast: { error: vi.fn(), info: vi.fn(), success: vi.fn() },
+}));
+
+const shortcut = {
+  trigger: 'keyboard' as const,
+  code: 'Space',
+  key: ' ',
+  modifiers: { meta: false, ctrl: true, alt: false, shift: true, fn: false },
+};
+
+let settings: VoiceInputSettings;
+let setGlobalShortcut: ReturnType<typeof vi.fn>;
+let emitDataChanged: (snapshot: VoiceInputDataSnapshot) => void;
+
+function installElectronApi(): void {
+  setGlobalShortcut = vi.fn().mockResolvedValue({ ok: true });
+  Object.defineProperty(window, 'electronAPI', {
+    configurable: true,
+    value: {
+      platform: 'win32',
+      voiceInput: {
+        getDataSnapshot: () => ({ settings }),
+        updateShortcutSetting: vi.fn(),
+        updateSettings: vi.fn(),
+        setGlobalShortcut,
+        onDataChanged: vi.fn((listener: (snapshot: VoiceInputDataSnapshot) => void) => {
+          emitDataChanged = listener;
+          return () => {};
+        }),
+      },
+    },
+  });
+}
+
+describe('useVoiceInputSettings global shortcut sync', () => {
+  beforeEach(() => {
+    settings = { ...getDefaultVoiceInputSettings('win32'), shortcut };
+    installElectronApi();
+  });
+
+  afterEach(() => {
+    Reflect.deleteProperty(window, 'electronAPI');
+  });
+
+  it('does not re-sync when a data broadcast carries an equal shortcut object', async () => {
+    renderHook(() => useVoiceInputSettings());
+    expect(setGlobalShortcut).toHaveBeenCalledTimes(1);
+
+    // Main clones the snapshot per broadcast (e.g. history append after a
+    // dictation), so the shortcut arrives as a new object with the same value.
+    await act(async () => {
+      emitDataChanged({
+        settings: { ...settings, shortcut: { ...shortcut, modifiers: { ...shortcut.modifiers } } },
+        history: [],
+      } as VoiceInputDataSnapshot);
+    });
+
+    expect(setGlobalShortcut).toHaveBeenCalledTimes(1);
+  });
+
+  it('re-syncs when the broadcast shortcut value actually changes', async () => {
+    renderHook(() => useVoiceInputSettings());
+    expect(setGlobalShortcut).toHaveBeenCalledTimes(1);
+
+    const next = { ...shortcut, code: 'KeyV', key: 'v' };
+    await act(async () => {
+      emitDataChanged({ settings: { ...settings, shortcut: next }, history: [] } as VoiceInputDataSnapshot);
+    });
+
+    expect(setGlobalShortcut).toHaveBeenCalledTimes(2);
+    expect(setGlobalShortcut).toHaveBeenLastCalledWith(next, undefined);
+  });
+});

--- a/apps/desktop/src/renderer/hooks/useVoiceInputSettings.ts
+++ b/apps/desktop/src/renderer/hooks/useVoiceInputSettings.ts
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useState } from 'react';
+import { useCallback, useEffect, useRef, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import type { DictationDictionaryLearningAction } from '@cindy/voice-input-core';
 
@@ -357,9 +357,17 @@ export function useVoiceInputSettings(): {
     [],
   );
 
+  // Every main-side data-changed broadcast (history appends after each
+  // dictation included) delivers a freshly cloned settings object, so keying
+  // this effect on `settings.shortcut` re-syncs after every recording — and
+  // re-logs a registration failure each time when the accelerator is held by
+  // another process. Key on the shortcut's value instead.
+  const shortcutKey = serializeVoiceInputShortcut(settings.shortcut);
+  const shortcutRef = useRef(settings.shortcut);
+  shortcutRef.current = settings.shortcut;
   useEffect(() => {
-    void syncVoiceInputGlobalShortcut(settings.shortcut);
-  }, [settings.shortcut]);
+    void syncVoiceInputGlobalShortcut(shortcutRef.current);
+  }, [shortcutKey]);
 
   useEffect(() => subscribeVoiceInputSettings(setSettings), []);
 
@@ -393,9 +401,24 @@ function formatVoiceInputPersistenceError(
   return t('settings.voiceInput.saveFailed', { message });
 }
 
+function serializeVoiceInputShortcut(shortcut: VoiceInputShortcut | null): string {
+  if (!shortcut) return '';
+  const { modifiers } = shortcut;
+  return [
+    shortcut.trigger ?? '',
+    shortcut.code,
+    shortcut.key,
+    modifiers.meta ? '1' : '0',
+    modifiers.ctrl ? '1' : '0',
+    modifiers.alt ? '1' : '0',
+    modifiers.shift ? '1' : '0',
+    modifiers.fn ? '1' : '0',
+  ].join('|');
+}
+
 function areVoiceInputShortcutsEqual(
   lhs: VoiceInputShortcut | null,
   rhs: VoiceInputShortcut | null,
 ): boolean {
-  return JSON.stringify(lhs) === JSON.stringify(rhs);
+  return serializeVoiceInputShortcut(lhs) === serializeVoiceInputShortcut(rhs);
 }

--- a/apps/desktop/src/renderer/voice-input/VoiceInputOverlay.tsx
+++ b/apps/desktop/src/renderer/voice-input/VoiceInputOverlay.tsx
@@ -194,14 +194,7 @@ export function VoiceInputOverlay() {
   const systemAudioMutedRef = useRef(false);
   const pendingSystemAudioMutePromiseRef = useRef<Promise<void> | null>(null);
   const systemAudioMuteGateOpenRef = useRef(true);
-  // Keep a short opening window while Windows/macOS finishes muting system
-  // audio. Chunks are flushed once the mute IPC settles instead of being
-  // discarded, which previously could lose the first syllables.
-  const pendingSystemAudioChunksRef = useRef<PcmChunk[]>([]);
-  const pendingSystemAudioChunksWarnedRef = useRef(false);
-  // 128 x ~40ms covers several seconds of provider/mute startup while staying
-  // below 200 KiB of 16 kHz PCM per voice surface.
-  const MAX_PENDING_SYSTEM_AUDIO_CHUNKS = 128;
+  const systemAudioMuteGateDropLoggedRef = useRef(false);
   const closingRef = useRef(false);
   const startAttemptIdRef = useRef(0);
   const pasteAttemptIdRef = useRef(0);
@@ -410,38 +403,17 @@ export function VoiceInputOverlay() {
   }, [formatVoiceInputStartError, t]);
 
   const appendAudioChunk = useCallback((chunk: PcmChunk) => {
-    if (!systemAudioMuteGateOpenRef.current) {
-      const pending = pendingSystemAudioChunksRef.current;
-      if (pending.length >= MAX_PENDING_SYSTEM_AUDIO_CHUNKS) {
-        pending.shift();
-        if (!pendingSystemAudioChunksWarnedRef.current) {
-          pendingSystemAudioChunksWarnedRef.current = true;
-          log.warn('global voice input opening audio buffer overflow while muting system audio', {
-            maxChunks: MAX_PENDING_SYSTEM_AUDIO_CHUNKS,
-          });
-        }
-      }
-      pending.push(chunk);
-      return;
-    }
     sentAudioMsRef.current += chunk.trace.durationMs;
     window.electronAPI.voiceInput.appendAudio(chunk);
   }, []);
 
-  const flushPendingSystemAudioChunks = useCallback(() => {
-    if (!systemAudioMuteGateOpenRef.current || !runIdRef.current) return;
-    const pending = pendingSystemAudioChunksRef.current.splice(0);
-    pendingSystemAudioChunksWarnedRef.current = false;
-    pending.forEach((chunk) => {
-      sentAudioMsRef.current += chunk.trace.durationMs;
-      window.electronAPI.voiceInput.appendAudio(chunk);
-    });
-  }, []);
-
   const canAcceptAudioChunk = useCallback(() => {
-    // Audio is buffered by appendAudioChunk while the asynchronous system
-    // mute is in flight; do not drop the opening frames.
-    return true;
+    if (systemAudioMuteGateOpenRef.current) return true;
+    if (!systemAudioMuteGateDropLoggedRef.current) {
+      systemAudioMuteGateDropLoggedRef.current = true;
+      log.debug('global dropping pcm until system audio mute completes');
+    }
+    return false;
   }, []);
 
   const cancelStartedRun = useCallback((startPromise: Promise<StartVoiceInputResult>) => {
@@ -483,18 +455,16 @@ export function VoiceInputOverlay() {
         if (pendingSystemAudioMutePromiseRef.current === mutePromise) {
           pendingSystemAudioMutePromiseRef.current = null;
         }
-        flushPendingSystemAudioChunks();
       });
     pendingSystemAudioMutePromiseRef.current = mutePromise;
     return mutePromise;
-  }, [flushPendingSystemAudioChunks]);
+  }, []);
 
   const restoreSystemAudioForRecording = useCallback(async () => {
+    systemAudioMuteGateOpenRef.current = true;
     if (!supportsSystemAudioMute()) return;
     const pendingMute = pendingSystemAudioMutePromiseRef.current;
     if (pendingMute) await pendingMute;
-    systemAudioMuteGateOpenRef.current = true;
-    flushPendingSystemAudioChunks();
     if (!systemAudioMutedRef.current) return;
     systemAudioMutedRef.current = false;
     try {
@@ -505,7 +475,7 @@ export function VoiceInputOverlay() {
     } catch (restoreError) {
       log.warn('system audio restore failed:', restoreError instanceof Error ? restoreError.message : String(restoreError));
     }
-  }, [flushPendingSystemAudioChunks]);
+  }, []);
 
   const restoreSystemAudioAndMaybePlayEndCue = useCallback((playEndCue: boolean) => {
     return restoreSystemAudioForRecording().finally(() => {
@@ -765,11 +735,10 @@ export function VoiceInputOverlay() {
     historyEntryIdRef.current = null;
     sentAudioMsRef.current = 0;
     terminalOutcomeRef.current = 'success';
-    pendingSystemAudioChunksRef.current = [];
-    pendingSystemAudioChunksWarnedRef.current = false;
     runIdRef.current = null;
     ownedRunIdRef.current = null;
     systemAudioMuteGateOpenRef.current = true;
+    systemAudioMuteGateDropLoggedRef.current = false;
     if (settings.muteSystemAudio && supportsSystemAudioMute()) {
       systemAudioMuteGateOpenRef.current = false;
       void muteSystemAudioForRecording();
@@ -891,6 +860,16 @@ export function VoiceInputOverlay() {
       cancelStartedRun(startResultPromise);
       suppressedStartErrorAttemptsRef.current.delete(attemptId);
       await restoreSystemAudioForRecording();
+      // Permission revoked after the start guard trusted a positive cache:
+      // show the same recovery prompt as a guard-time denial so the user gets
+      // the fix on this attempt instead of a raw capture error.
+      if (captureStart.permissionDenied) {
+        setError(t('voiceInputOverlay.permissionPrompts.microphone.message'));
+        setPermissionPrompt('microphone');
+        setVoiceState('done');
+        closingRef.current = false;
+        return;
+      }
       setError(captureStart.error);
       setVoiceState('error');
       scheduleErrorClose();
@@ -928,14 +907,12 @@ export function VoiceInputOverlay() {
     runIdRef.current = result.runId;
     ownedRunIdRef.current = result.runId;
     suppressedStartErrorAttemptsRef.current.delete(attemptId);
-    flushPendingSystemAudioChunks();
     captureStart.drainPendingChunks();
     resolveStartReadyState(attemptId, result);
   }, [
     appendAudioChunk,
     buildRefinementContext,
     canAcceptAudioChunk,
-    flushPendingSystemAudioChunks,
     cancelStartedRun,
     clearErrorCloseTimer,
     closeOverlay,

--- a/apps/desktop/src/renderer/voice-input/VoiceInputOverlay.tsx
+++ b/apps/desktop/src/renderer/voice-input/VoiceInputOverlay.tsx
@@ -194,7 +194,14 @@ export function VoiceInputOverlay() {
   const systemAudioMutedRef = useRef(false);
   const pendingSystemAudioMutePromiseRef = useRef<Promise<void> | null>(null);
   const systemAudioMuteGateOpenRef = useRef(true);
-  const systemAudioMuteGateDropLoggedRef = useRef(false);
+  // Keep a short opening window while Windows/macOS finishes muting system
+  // audio. Chunks are flushed once the mute IPC settles instead of being
+  // discarded, which previously could lose the first syllables.
+  const pendingSystemAudioChunksRef = useRef<PcmChunk[]>([]);
+  const pendingSystemAudioChunksWarnedRef = useRef(false);
+  // 128 x ~40ms covers several seconds of provider/mute startup while staying
+  // below 200 KiB of 16 kHz PCM per voice surface.
+  const MAX_PENDING_SYSTEM_AUDIO_CHUNKS = 128;
   const closingRef = useRef(false);
   const startAttemptIdRef = useRef(0);
   const pasteAttemptIdRef = useRef(0);
@@ -403,17 +410,38 @@ export function VoiceInputOverlay() {
   }, [formatVoiceInputStartError, t]);
 
   const appendAudioChunk = useCallback((chunk: PcmChunk) => {
+    if (!systemAudioMuteGateOpenRef.current) {
+      const pending = pendingSystemAudioChunksRef.current;
+      if (pending.length >= MAX_PENDING_SYSTEM_AUDIO_CHUNKS) {
+        pending.shift();
+        if (!pendingSystemAudioChunksWarnedRef.current) {
+          pendingSystemAudioChunksWarnedRef.current = true;
+          log.warn('global voice input opening audio buffer overflow while muting system audio', {
+            maxChunks: MAX_PENDING_SYSTEM_AUDIO_CHUNKS,
+          });
+        }
+      }
+      pending.push(chunk);
+      return;
+    }
     sentAudioMsRef.current += chunk.trace.durationMs;
     window.electronAPI.voiceInput.appendAudio(chunk);
   }, []);
 
+  const flushPendingSystemAudioChunks = useCallback(() => {
+    if (!systemAudioMuteGateOpenRef.current || !runIdRef.current) return;
+    const pending = pendingSystemAudioChunksRef.current.splice(0);
+    pendingSystemAudioChunksWarnedRef.current = false;
+    pending.forEach((chunk) => {
+      sentAudioMsRef.current += chunk.trace.durationMs;
+      window.electronAPI.voiceInput.appendAudio(chunk);
+    });
+  }, []);
+
   const canAcceptAudioChunk = useCallback(() => {
-    if (systemAudioMuteGateOpenRef.current) return true;
-    if (!systemAudioMuteGateDropLoggedRef.current) {
-      systemAudioMuteGateDropLoggedRef.current = true;
-      log.debug('global dropping pcm until system audio mute completes');
-    }
-    return false;
+    // Audio is buffered by appendAudioChunk while the asynchronous system
+    // mute is in flight; do not drop the opening frames.
+    return true;
   }, []);
 
   const cancelStartedRun = useCallback((startPromise: Promise<StartVoiceInputResult>) => {
@@ -455,16 +483,18 @@ export function VoiceInputOverlay() {
         if (pendingSystemAudioMutePromiseRef.current === mutePromise) {
           pendingSystemAudioMutePromiseRef.current = null;
         }
+        flushPendingSystemAudioChunks();
       });
     pendingSystemAudioMutePromiseRef.current = mutePromise;
     return mutePromise;
-  }, []);
+  }, [flushPendingSystemAudioChunks]);
 
   const restoreSystemAudioForRecording = useCallback(async () => {
-    systemAudioMuteGateOpenRef.current = true;
     if (!supportsSystemAudioMute()) return;
     const pendingMute = pendingSystemAudioMutePromiseRef.current;
     if (pendingMute) await pendingMute;
+    systemAudioMuteGateOpenRef.current = true;
+    flushPendingSystemAudioChunks();
     if (!systemAudioMutedRef.current) return;
     systemAudioMutedRef.current = false;
     try {
@@ -475,7 +505,7 @@ export function VoiceInputOverlay() {
     } catch (restoreError) {
       log.warn('system audio restore failed:', restoreError instanceof Error ? restoreError.message : String(restoreError));
     }
-  }, []);
+  }, [flushPendingSystemAudioChunks]);
 
   const restoreSystemAudioAndMaybePlayEndCue = useCallback((playEndCue: boolean) => {
     return restoreSystemAudioForRecording().finally(() => {
@@ -735,10 +765,11 @@ export function VoiceInputOverlay() {
     historyEntryIdRef.current = null;
     sentAudioMsRef.current = 0;
     terminalOutcomeRef.current = 'success';
+    pendingSystemAudioChunksRef.current = [];
+    pendingSystemAudioChunksWarnedRef.current = false;
     runIdRef.current = null;
     ownedRunIdRef.current = null;
     systemAudioMuteGateOpenRef.current = true;
-    systemAudioMuteGateDropLoggedRef.current = false;
     if (settings.muteSystemAudio && supportsSystemAudioMute()) {
       systemAudioMuteGateOpenRef.current = false;
       void muteSystemAudioForRecording();
@@ -752,7 +783,7 @@ export function VoiceInputOverlay() {
     // async path so newly granted permission / freshly completed Codex login
     // can be picked up immediately. Main verifies readiness again in start().
     const guards = await resolveVoiceInputStartGuards({ requireAccessibility: true });
-    log.debug('global voice input start guards checked', {
+    log.info('global voice input start guards checked', {
       ok: guards.ok,
       failed: guards.ok ? undefined : guards.failed,
       permissionSource: guards.permissionSource,
@@ -897,12 +928,14 @@ export function VoiceInputOverlay() {
     runIdRef.current = result.runId;
     ownedRunIdRef.current = result.runId;
     suppressedStartErrorAttemptsRef.current.delete(attemptId);
+    flushPendingSystemAudioChunks();
     captureStart.drainPendingChunks();
     resolveStartReadyState(attemptId, result);
   }, [
     appendAudioChunk,
     buildRefinementContext,
     canAcceptAudioChunk,
+    flushPendingSystemAudioChunks,
     cancelStartedRun,
     clearErrorCloseTimer,
     closeOverlay,

--- a/apps/desktop/src/renderer/voice-input/WebMicAudioEngine.ts
+++ b/apps/desktop/src/renderer/voice-input/WebMicAudioEngine.ts
@@ -323,6 +323,11 @@ export function isMicrophoneDeviceUnavailableError(error: unknown): boolean {
   return isSelectedMicrophoneUnavailableError(error) || isDeviceConstraintError(error);
 }
 
+export function isMicrophonePermissionDeniedError(error: unknown): boolean {
+  const name = readErrorString(error, 'name');
+  return name === 'NotAllowedError' || name === 'SecurityError';
+}
+
 function isDeviceConstraintError(error: unknown): boolean {
   const name = readErrorString(error, 'name');
   const message = readErrorString(error, 'message')?.toLowerCase() ?? '';

--- a/apps/desktop/src/renderer/voice-input/__tests__/WebMicAudioEngine.errors.test.ts
+++ b/apps/desktop/src/renderer/voice-input/__tests__/WebMicAudioEngine.errors.test.ts
@@ -1,0 +1,12 @@
+import { describe, expect, it } from 'vitest';
+
+import { isMicrophonePermissionDeniedError } from '../WebMicAudioEngine';
+
+describe('WebMicAudioEngine error classification', () => {
+  it('recognizes microphone permission revocation errors structurally', () => {
+    expect(isMicrophonePermissionDeniedError(new DOMException('denied', 'NotAllowedError'))).toBe(true);
+    expect(isMicrophonePermissionDeniedError({ name: 'SecurityError', message: 'blocked' })).toBe(true);
+    expect(isMicrophonePermissionDeniedError({ name: 'NotReadableError' })).toBe(false);
+    expect(isMicrophonePermissionDeniedError(new Error('permission denied'))).toBe(false);
+  });
+});

--- a/apps/desktop/src/renderer/voice-input/__tests__/captureSession.permissionDenied.test.ts
+++ b/apps/desktop/src/renderer/voice-input/__tests__/captureSession.permissionDenied.test.ts
@@ -1,0 +1,80 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { startVoiceInputCaptureSession } from '../captureSession';
+
+const engineStart = vi.fn<() => Promise<void>>();
+
+vi.mock('../WebMicAudioEngine', () => ({
+  WebMicAudioEngine: class {
+    onPcm16k() {}
+    start() {
+      return engineStart();
+    }
+    stop() {
+      return Promise.resolve();
+    }
+  },
+  currentPowerReleaseGeneration: () => 0,
+  isMicrophonePermissionDeniedError: (error: unknown) =>
+    (error as { name?: string } | null)?.name === 'NotAllowedError',
+  isPowerReleaseCancellation: () => false,
+  isSelectedMicrophoneUnavailableError: () => false,
+  powerReleaseCancellation: () => new Error('power release'),
+}));
+
+vi.mock('../audioProfile', () => ({
+  createVoiceInputAudioProfile: () => ({}),
+}));
+
+function startSession() {
+  return startVoiceInputCaptureSession({
+    label: 'test',
+    workletUrl: 'blob:worklet',
+    fastActivationEnabled: false,
+    getRunId: () => null,
+    setEngine: () => undefined,
+    appendAudioChunk: () => undefined,
+    onInterrupted: () => undefined,
+    onStateChange: () => undefined,
+    getFallbackMessage: () => 'fallback',
+    onFallback: () => undefined,
+    formatStartError: (error) => (error instanceof Error ? error.message : String(error)),
+  });
+}
+
+describe('startVoiceInputCaptureSession permission revocation', () => {
+  let setRendererMicrophonePermissionVerified: ReturnType<typeof vi.fn>;
+
+  beforeEach(() => {
+    setRendererMicrophonePermissionVerified = vi.fn(async () => ({ ok: true as const }));
+    vi.stubGlobal('window', {
+      electronAPI: {
+        voiceInput: { setRendererMicrophonePermissionVerified },
+      },
+    });
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    engineStart.mockReset();
+  });
+
+  it('reports permissionDenied and invalidates the cached permission when getUserMedia is not allowed', async () => {
+    engineStart.mockRejectedValue(new DOMException('Permission denied', 'NotAllowedError'));
+
+    const result = await startSession();
+
+    expect(result).toMatchObject({ ok: false, permissionDenied: true, error: 'Permission denied' });
+    expect(setRendererMicrophonePermissionVerified).toHaveBeenCalledWith(false);
+  });
+
+  it('leaves other capture failures on the generic error path', async () => {
+    engineStart.mockRejectedValue(new DOMException('Device busy', 'NotReadableError'));
+
+    const result = await startSession();
+
+    expect(result).toMatchObject({ ok: false, error: 'Device busy' });
+    expect((result as { permissionDenied?: boolean }).permissionDenied).toBeUndefined();
+    expect(setRendererMicrophonePermissionVerified).not.toHaveBeenCalled();
+  });
+});

--- a/apps/desktop/src/renderer/voice-input/__tests__/startGuards.test.ts
+++ b/apps/desktop/src/renderer/voice-input/__tests__/startGuards.test.ts
@@ -3,6 +3,9 @@ import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { resolveVoiceInputStartGuards } from '../startGuards';
 
 const grantedPermission = { ok: true as const, status: 'granted' };
+type PermissionSnapshot =
+  | { ok: true; status: string }
+  | { ok: false; status: string; error: string };
 const ready = {
   ok: true,
   provider: 'litellm',
@@ -11,7 +14,10 @@ const ready = {
   settingsTab: 'api-keys' as const,
 };
 
-function stubVoiceInputApis(platform: 'darwin' | 'win32') {
+function stubVoiceInputApis(
+  platform: 'darwin' | 'win32',
+  microphonePermission: PermissionSnapshot = grantedPermission,
+) {
   const getUserMedia = vi.fn();
   const setRendererMicrophonePermissionVerified = vi.fn(async () => ({ ok: true as const }));
   const requestMicrophonePermission = vi.fn();
@@ -22,7 +28,7 @@ function stubVoiceInputApis(platform: 'darwin' | 'win32') {
     electronAPI: {
       platform,
       voiceInput: {
-        getMicrophonePermissionCached: vi.fn(() => grantedPermission),
+        getMicrophonePermissionCached: vi.fn(() => microphonePermission),
         getSystemPermissionsCached: vi.fn(() => ({
           microphone: grantedPermission,
           inputMonitoring: grantedPermission,
@@ -51,8 +57,26 @@ beforeEach(() => {
 });
 
 describe('resolveVoiceInputStartGuards', () => {
-  it('revalidates a positive Windows cache before allowing voice input to start', async () => {
+  it('uses a positive Windows permission cache without opening a probe stream', async () => {
     const apis = stubVoiceInputApis('win32');
+    const result = await resolveVoiceInputStartGuards();
+
+    expect(result).toMatchObject({
+      ok: true,
+      permission: grantedPermission,
+      permissionSource: 'cache',
+    });
+    expect(apis.getUserMedia).not.toHaveBeenCalled();
+    expect(apis.setRendererMicrophonePermissionVerified).not.toHaveBeenCalled();
+  });
+
+  it('refreshes a missing Windows permission cache before allowing voice input to start', async () => {
+    const unknownPermission = {
+      ok: false as const,
+      status: 'unknown',
+      error: 'Microphone permission is required for voice input. Enable it in Windows Settings.',
+    };
+    const apis = stubVoiceInputApis('win32', unknownPermission);
     const denial = {
       ok: false as const,
       status: 'denied',
@@ -76,27 +100,6 @@ describe('resolveVoiceInputStartGuards', () => {
     });
     expect(apis.getUserMedia).toHaveBeenCalledWith({ audio: true });
     expect(apis.setRendererMicrophonePermissionVerified).toHaveBeenCalledWith(false);
-  });
-
-  it('allows Windows voice input after renderer permission is granted', async () => {
-    const apis = stubVoiceInputApis('win32');
-    const stop = vi.fn();
-    apis.getUserMedia.mockResolvedValue({ getTracks: () => [{ stop }] });
-    apis.getSystemPermissions.mockResolvedValue({
-      microphone: grantedPermission,
-      inputMonitoring: grantedPermission,
-      accessibility: grantedPermission,
-    });
-
-    const result = await resolveVoiceInputStartGuards();
-
-    expect(result).toMatchObject({
-      ok: true,
-      permission: grantedPermission,
-      permissionSource: 'async',
-    });
-    expect(stop).toHaveBeenCalledOnce();
-    expect(apis.setRendererMicrophonePermissionVerified).toHaveBeenCalledWith(true);
   });
 
   it('keeps trusting a positive macOS cache on the start path', async () => {

--- a/apps/desktop/src/renderer/voice-input/captureSession.ts
+++ b/apps/desktop/src/renderer/voice-input/captureSession.ts
@@ -2,6 +2,7 @@ import { createLogger } from '@/lib/logger';
 import {
   WebMicAudioEngine,
   currentPowerReleaseGeneration,
+  isMicrophonePermissionDeniedError,
   isPowerReleaseCancellation,
   isSelectedMicrophoneUnavailableError,
   powerReleaseCancellation,
@@ -152,6 +153,15 @@ export async function startVoiceInputCaptureSession(
         cancelled: true,
         error: options.formatStartError(error),
       };
+    }
+    // The fast Windows path trusts the last positive renderer verification so
+    // it does not open a throwaway microphone stream before every recording.
+    // If the real capture discovers that permission was revoked, invalidate
+    // that cache immediately so the next start returns to the permission gate.
+    if (isMicrophonePermissionDeniedError(error)) {
+      void window.electronAPI.voiceInput
+        .setRendererMicrophonePermissionVerified(false)
+        .catch(() => undefined);
     }
     return {
       ok: false,

--- a/apps/desktop/src/renderer/voice-input/captureSession.ts
+++ b/apps/desktop/src/renderer/voice-input/captureSession.ts
@@ -32,6 +32,13 @@ export type VoiceInputCaptureSessionStartResult =
        * silently instead of surfacing `error`, which is an internal message.
        */
       cancelled?: boolean;
+      /**
+       * getUserMedia reported that microphone access is (no longer) allowed.
+       * The start guard may have trusted a positive permission cache, so this
+       * is the first place the revocation becomes visible; callers should show
+       * the permission recovery UI now instead of a generic capture error.
+       */
+      permissionDenied?: boolean;
     };
 
 type VoiceInputCaptureSessionOptions = {
@@ -154,14 +161,21 @@ export async function startVoiceInputCaptureSession(
         error: options.formatStartError(error),
       };
     }
-    // The fast Windows path trusts the last positive renderer verification so
-    // it does not open a throwaway microphone stream before every recording.
-    // If the real capture discovers that permission was revoked, invalidate
-    // that cache immediately so the next start returns to the permission gate.
+    // The start guard trusts a positive permission cache so it does not open a
+    // throwaway microphone stream before every recording. If the real capture
+    // discovers that permission was revoked, invalidate that cache so the next
+    // start returns to the permission gate, and tell the caller so the current
+    // attempt surfaces the permission recovery UI rather than a raw error.
     if (isMicrophonePermissionDeniedError(error)) {
+      log.warn(message(options.label, 'microphone permission denied during capture start'));
       void window.electronAPI.voiceInput
         .setRendererMicrophonePermissionVerified(false)
         .catch(() => undefined);
+      return {
+        ok: false,
+        permissionDenied: true,
+        error: options.formatStartError(error),
+      };
     }
     return {
       ok: false,

--- a/apps/desktop/src/renderer/voice-input/startGuards.ts
+++ b/apps/desktop/src/renderer/voice-input/startGuards.ts
@@ -89,10 +89,14 @@ export async function resolveVoiceInputStartGuards(
     ? cachedSystemPermissions.accessibility
     : ({ ok: true, status: 'not-required' } as const);
   const cachedReadiness = window.electronAPI.voiceInput.getReadinessCached();
-  // Windows permission can be revoked while Cindy is running. Probe the
-  // renderer before every start so a stale positive main cache cannot let ASR
-  // connect before getUserMedia reports the denial.
-  const shouldVerifyPermission = window.electronAPI.platform === 'win32' || !cachedPermission.ok;
+  // A positive OS permission snapshot is sufficient for the start guard. The
+  // real capture engine calls getUserMedia immediately after this gate and is
+  // the authoritative revocation check; opening a second, short-lived stream
+  // here made every Windows recording pay the microphone cold-start cost twice.
+  // Keep the async path for missing/negative/unknown snapshots so newly granted
+  // permission still takes effect without restarting the app.
+  const shouldVerifyPermission = !cachedPermission.ok
+    || cachedPermission.status !== 'granted';
   const permissionSource = shouldVerifyPermission ? 'async' : 'cache';
   const readinessSource = cachedReadiness?.ok ? 'cache' : 'async';
 

--- a/apps/desktop/src/renderer/voice-input/useVoiceInput.ts
+++ b/apps/desktop/src/renderer/voice-input/useVoiceInput.ts
@@ -200,7 +200,15 @@ export function useVoiceInput(
   // checking the muted ref, preventing leaked mute state.
   const pendingSystemAudioMutePromiseRef = useRef<Promise<void> | null>(null);
   const systemAudioMuteGateOpenRef = useRef(true);
-  const systemAudioMuteGateDropLoggedRef = useRef(false);
+  // Keep a short opening window while Windows/macOS finishes muting system
+  // audio. Previously chunks produced during that IPC call were discarded,
+  // which could remove the first syllables from a dictation. The bounded queue
+  // is flushed as soon as mute completes (or a run id becomes available).
+  const pendingSystemAudioChunksRef = useRef<PcmChunk[]>([]);
+  const pendingSystemAudioChunksWarnedRef = useRef(false);
+  // 128 x ~40ms covers several seconds of provider/mute startup while staying
+  // below 200 KiB of 16 kHz PCM per voice surface.
+  const MAX_PENDING_SYSTEM_AUDIO_CHUNKS = 128;
   const stopCompletionWaitersRef = useRef<StopCompletionWaiter[]>([]);
   const sentAudioMsRef = useRef(0);
   const terminalOutcomeRef = useRef<VoiceInputUsageOutcome>('success');
@@ -425,17 +433,38 @@ export function useVoiceInput(
   }, [formatVoiceInputStartError, t]);
 
   const appendAudioChunk = useCallback((chunk: PcmChunk) => {
+    if (!systemAudioMuteGateOpenRef.current) {
+      const pending = pendingSystemAudioChunksRef.current;
+      if (pending.length >= MAX_PENDING_SYSTEM_AUDIO_CHUNKS) {
+        pending.shift();
+        if (!pendingSystemAudioChunksWarnedRef.current) {
+          pendingSystemAudioChunksWarnedRef.current = true;
+          log.warn('voice input opening audio buffer overflow while muting system audio', {
+            maxChunks: MAX_PENDING_SYSTEM_AUDIO_CHUNKS,
+          });
+        }
+      }
+      pending.push(chunk);
+      return;
+    }
     sentAudioMsRef.current += chunk.trace.durationMs;
     window.electronAPI.voiceInput.appendAudio(chunk);
   }, []);
 
+  const flushPendingSystemAudioChunks = useCallback(() => {
+    if (!systemAudioMuteGateOpenRef.current || !runIdRef.current) return;
+    const pending = pendingSystemAudioChunksRef.current.splice(0);
+    pendingSystemAudioChunksWarnedRef.current = false;
+    pending.forEach((chunk) => {
+      sentAudioMsRef.current += chunk.trace.durationMs;
+      window.electronAPI.voiceInput.appendAudio(chunk);
+    });
+  }, []);
+
   const canAcceptAudioChunk = useCallback(() => {
-    if (systemAudioMuteGateOpenRef.current) return true;
-    if (!systemAudioMuteGateDropLoggedRef.current) {
-      systemAudioMuteGateDropLoggedRef.current = true;
-      log.debug('dropping voice input pcm until system audio mute completes');
-    }
-    return false;
+    // Audio is buffered by appendAudioChunk while the asynchronous system
+    // mute is in flight; do not drop the opening frames.
+    return true;
   }, []);
 
   const commitUsageStats = useCallback(() => {
@@ -473,18 +502,20 @@ export function useVoiceInput(
         if (pendingSystemAudioMutePromiseRef.current === mutePromise) {
           pendingSystemAudioMutePromiseRef.current = null;
         }
+        flushPendingSystemAudioChunks();
       });
     pendingSystemAudioMutePromiseRef.current = mutePromise;
     return mutePromise;
-  }, []);
+  }, [flushPendingSystemAudioChunks]);
 
   const restoreSystemAudioForRecording = useCallback(async () => {
-    systemAudioMuteGateOpenRef.current = true;
     if (!supportsSystemAudioMute()) return;
     // Await any in-flight mute so we never skip a restore for a mute that
     // hadn't yet flipped systemAudioMutedRef when restore began.
     const pendingMute = pendingSystemAudioMutePromiseRef.current;
     if (pendingMute) await pendingMute;
+    systemAudioMuteGateOpenRef.current = true;
+    flushPendingSystemAudioChunks();
     if (!systemAudioMutedRef.current) return;
     systemAudioMutedRef.current = false;
     try {
@@ -495,7 +526,7 @@ export function useVoiceInput(
     } catch (error) {
       log.warn('system audio restore failed:', error instanceof Error ? error.message : String(error));
     }
-  }, []);
+  }, [flushPendingSystemAudioChunks]);
 
   const failActiveRecording = useCallback(async (message: string) => {
     if (stateRef.current !== 'listening') return;
@@ -1255,8 +1286,9 @@ export function useVoiceInput(
     lastSubmittedTextRef.current = '';
     sentAudioMsRef.current = 0;
     terminalOutcomeRef.current = 'success';
+    pendingSystemAudioChunksRef.current = [];
+    pendingSystemAudioChunksWarnedRef.current = false;
     systemAudioMuteGateOpenRef.current = true;
-    systemAudioMuteGateDropLoggedRef.current = false;
     if (voiceInputSettings.muteSystemAudio && supportsSystemAudioMute()) {
       systemAudioMuteGateOpenRef.current = false;
       void muteSystemAudioForRecording();
@@ -1280,7 +1312,7 @@ export function useVoiceInput(
     //    microphone PCM is gated so system audio playing during the mute delay
     //    cannot enter ASR.
     const guards = await resolveVoiceInputStartGuards();
-    log.debug('voice input start guards checked', {
+    log.info('voice input start guards checked', {
       ok: guards.ok,
       failed: guards.ok ? undefined : guards.failed,
       permissionSource: guards.permissionSource,
@@ -1469,6 +1501,7 @@ export function useVoiceInput(
       restoreEditorFocusAfterVoiceInput();
       return;
     }
+    flushPendingSystemAudioChunks();
     captureStart.drainPendingChunks();
     resolveStartReadyState(attemptId, result);
   }, [
@@ -1498,6 +1531,7 @@ export function useVoiceInput(
     voiceInputSettings.muteSystemAudio,
     voiceInputSettings.refinementEnabled,
     options,
+    flushPendingSystemAudioChunks,
   ]);
 
   const notifyReadyForEndCue = useCallback((options?: VoiceInputStopOptions) => {

--- a/apps/desktop/src/renderer/voice-input/useVoiceInput.ts
+++ b/apps/desktop/src/renderer/voice-input/useVoiceInput.ts
@@ -200,15 +200,7 @@ export function useVoiceInput(
   // checking the muted ref, preventing leaked mute state.
   const pendingSystemAudioMutePromiseRef = useRef<Promise<void> | null>(null);
   const systemAudioMuteGateOpenRef = useRef(true);
-  // Keep a short opening window while Windows/macOS finishes muting system
-  // audio. Previously chunks produced during that IPC call were discarded,
-  // which could remove the first syllables from a dictation. The bounded queue
-  // is flushed as soon as mute completes (or a run id becomes available).
-  const pendingSystemAudioChunksRef = useRef<PcmChunk[]>([]);
-  const pendingSystemAudioChunksWarnedRef = useRef(false);
-  // 128 x ~40ms covers several seconds of provider/mute startup while staying
-  // below 200 KiB of 16 kHz PCM per voice surface.
-  const MAX_PENDING_SYSTEM_AUDIO_CHUNKS = 128;
+  const systemAudioMuteGateDropLoggedRef = useRef(false);
   const stopCompletionWaitersRef = useRef<StopCompletionWaiter[]>([]);
   const sentAudioMsRef = useRef(0);
   const terminalOutcomeRef = useRef<VoiceInputUsageOutcome>('success');
@@ -433,38 +425,17 @@ export function useVoiceInput(
   }, [formatVoiceInputStartError, t]);
 
   const appendAudioChunk = useCallback((chunk: PcmChunk) => {
-    if (!systemAudioMuteGateOpenRef.current) {
-      const pending = pendingSystemAudioChunksRef.current;
-      if (pending.length >= MAX_PENDING_SYSTEM_AUDIO_CHUNKS) {
-        pending.shift();
-        if (!pendingSystemAudioChunksWarnedRef.current) {
-          pendingSystemAudioChunksWarnedRef.current = true;
-          log.warn('voice input opening audio buffer overflow while muting system audio', {
-            maxChunks: MAX_PENDING_SYSTEM_AUDIO_CHUNKS,
-          });
-        }
-      }
-      pending.push(chunk);
-      return;
-    }
     sentAudioMsRef.current += chunk.trace.durationMs;
     window.electronAPI.voiceInput.appendAudio(chunk);
   }, []);
 
-  const flushPendingSystemAudioChunks = useCallback(() => {
-    if (!systemAudioMuteGateOpenRef.current || !runIdRef.current) return;
-    const pending = pendingSystemAudioChunksRef.current.splice(0);
-    pendingSystemAudioChunksWarnedRef.current = false;
-    pending.forEach((chunk) => {
-      sentAudioMsRef.current += chunk.trace.durationMs;
-      window.electronAPI.voiceInput.appendAudio(chunk);
-    });
-  }, []);
-
   const canAcceptAudioChunk = useCallback(() => {
-    // Audio is buffered by appendAudioChunk while the asynchronous system
-    // mute is in flight; do not drop the opening frames.
-    return true;
+    if (systemAudioMuteGateOpenRef.current) return true;
+    if (!systemAudioMuteGateDropLoggedRef.current) {
+      systemAudioMuteGateDropLoggedRef.current = true;
+      log.debug('dropping voice input pcm until system audio mute completes');
+    }
+    return false;
   }, []);
 
   const commitUsageStats = useCallback(() => {
@@ -502,20 +473,18 @@ export function useVoiceInput(
         if (pendingSystemAudioMutePromiseRef.current === mutePromise) {
           pendingSystemAudioMutePromiseRef.current = null;
         }
-        flushPendingSystemAudioChunks();
       });
     pendingSystemAudioMutePromiseRef.current = mutePromise;
     return mutePromise;
-  }, [flushPendingSystemAudioChunks]);
+  }, []);
 
   const restoreSystemAudioForRecording = useCallback(async () => {
+    systemAudioMuteGateOpenRef.current = true;
     if (!supportsSystemAudioMute()) return;
     // Await any in-flight mute so we never skip a restore for a mute that
     // hadn't yet flipped systemAudioMutedRef when restore began.
     const pendingMute = pendingSystemAudioMutePromiseRef.current;
     if (pendingMute) await pendingMute;
-    systemAudioMuteGateOpenRef.current = true;
-    flushPendingSystemAudioChunks();
     if (!systemAudioMutedRef.current) return;
     systemAudioMutedRef.current = false;
     try {
@@ -526,7 +495,7 @@ export function useVoiceInput(
     } catch (error) {
       log.warn('system audio restore failed:', error instanceof Error ? error.message : String(error));
     }
-  }, [flushPendingSystemAudioChunks]);
+  }, []);
 
   const failActiveRecording = useCallback(async (message: string) => {
     if (stateRef.current !== 'listening') return;
@@ -1286,9 +1255,8 @@ export function useVoiceInput(
     lastSubmittedTextRef.current = '';
     sentAudioMsRef.current = 0;
     terminalOutcomeRef.current = 'success';
-    pendingSystemAudioChunksRef.current = [];
-    pendingSystemAudioChunksWarnedRef.current = false;
     systemAudioMuteGateOpenRef.current = true;
+    systemAudioMuteGateDropLoggedRef.current = false;
     if (voiceInputSettings.muteSystemAudio && supportsSystemAudioMute()) {
       systemAudioMuteGateOpenRef.current = false;
       void muteSystemAudioForRecording();
@@ -1438,7 +1406,14 @@ export function useVoiceInput(
       draftDisplayRangeRef.current = null;
       insertionRangeRef.current = null;
       setVoiceState('error');
-      reportVoiceInputError(captureStart.error);
+      // Permission revoked after the start guard trusted a positive cache:
+      // route to the same recovery prompt as a guard-time denial instead of
+      // making the user retry before they see how to fix it.
+      if (captureStart.permissionDenied && options?.onMicrophonePermissionRequired) {
+        void options.onMicrophonePermissionRequired(captureStart.error);
+      } else {
+        reportVoiceInputError(captureStart.error);
+      }
       restoreEditorFocusAfterVoiceInput();
       return;
     }
@@ -1501,7 +1476,6 @@ export function useVoiceInput(
       restoreEditorFocusAfterVoiceInput();
       return;
     }
-    flushPendingSystemAudioChunks();
     captureStart.drainPendingChunks();
     resolveStartReadyState(attemptId, result);
   }, [
@@ -1531,7 +1505,6 @@ export function useVoiceInput(
     voiceInputSettings.muteSystemAudio,
     voiceInputSettings.refinementEnabled,
     options,
-    flushPendingSystemAudioChunks,
   ]);
 
   const notifyReadyForEndCue = useCallback((options?: VoiceInputStopOptions) => {

--- a/scripts/voice-input-benchmark.mjs
+++ b/scripts/voice-input-benchmark.mjs
@@ -1986,6 +1986,66 @@ function parseVoiceInputReport(logPath, latest) {
       continue;
     }
 
+    // Packaged/default logging omits debug timeline rows. The main process
+    // therefore emits one redacted info summary per run; accept that compact
+    // shape so `report` remains useful against real user logs.
+    if (line.includes('[voice-input] latency summary {')) {
+      const { block, nextIndex } = readBraceBlock(lines, i);
+      i = nextIndex;
+      const runId = extractQuoted(block, 'runId');
+      if (!runId) continue;
+      let session = [...sessions].reverse().find((candidate) => candidate.runId === runId);
+      if (!session) {
+        const submittedMs = extractNumber(block, 'submittedMs') ?? extractNumber(block, 'totalMs');
+        session = {
+          runId,
+          startAt: submittedMs === undefined ? ts : ts - submittedMs,
+          shortcutToStartMs: pendingShortcutAt && submittedMs !== undefined
+            ? (ts - submittedMs) - pendingShortcutAt
+            : undefined,
+          mic: pendingMic,
+          timeline: {},
+        };
+        sessions.push(session);
+        pendingMic = {};
+        pendingShortcutAt = undefined;
+      }
+      const summaryFields = [
+        ['asr_connected', 'asrConnectedMs'],
+        ['first_audio_chunk', 'firstAudioChunkMs'],
+        ['first_partial', 'firstPartialMs'],
+        ['stable_received', 'stableReceivedMs'],
+        ['submitted', 'submittedMs'],
+      ];
+      for (const [type, field] of summaryFields) {
+        const elapsedMs = extractNumber(block, field);
+        if (elapsedMs === undefined || session.timeline[type]) continue;
+        session.timeline[type] = {
+          at: session.startAt + elapsedMs,
+          elapsedMs,
+        };
+      }
+      continue;
+    }
+
+    if (line.includes('[voice-input] refinement latency summary {')) {
+      const { block, nextIndex } = readBraceBlock(lines, i);
+      i = nextIndex;
+      const runId = extractQuoted(block, 'runId');
+      const outcome = extractQuoted(block, 'outcome');
+      const session = runId
+        ? [...sessions].reverse().find((candidate) => candidate.runId === runId)
+        : undefined;
+      if (!session || (outcome !== 'accepted' && outcome !== 'rejected')) continue;
+      const type = outcome === 'accepted' ? 'refine_accepted' : 'refine_rejected';
+      const totalMs = extractNumber(block, 'totalMs');
+      session.timeline[type] = {
+        at: totalMs === undefined ? ts : session.startAt + totalMs,
+        elapsedMs: extractNumber(block, 'elapsedMs'),
+      };
+      continue;
+    }
+
     if (line.includes('global background paste started')) {
       const session = sessions[sessions.length - 1];
       if (session) {


### PR DESCRIPTION
## 这次改了什么

### 摘要

Windows 上语音输入从按下到出字、从停止到提交都偏慢。用真实录音的 `latency summary` 定位后，这个 PR 把客户端侧能省的都省掉，并补齐分段耗时打点，剩余延迟能直接从日志归因到具体阶段（会话分配 / socket 握手 / 首响应 / 停止后 flush）。同时顺手修掉三处每次录音都会触发的噪音：`WebContents destroyed` 监听器累积、全局快捷键按对象引用重复同步导致的反复 `registration failed`、提交时 Radix Tooltip 的受控切换警告。

主要改动：

- 已授权后跳过重复的临时麦克风探测流（Windows 省 ~1–2s 冷启动）；权限运行期被撤销时，真实 `getUserMedia` 报错即刻使缓存失效，并在**当前这次**尝试就走权限恢复提示（inline 弹授权对话框、global overlay 显示麦克风权限提示），不用再点一次才看到。
- 系统静音期间的开头 PCM 仍按基线丢弃（不缓存、不补发）：那段音频含静音生效前的系统播放内容，补发会把它送进 ASR。首个版本曾改成缓存补发，已按 review 回退。
- BYOK ASR 支持 1.5s 错峰竞速，输家连接显式 `stop + dispose`；托管模式保持串行，避免并发会话互相覆盖 session id。各 provider 自己的 5s 连接超时保持不变，不再叠加外层 4.5s 启动超时（它从凭证/代理解析就开始计时，单 provider 配置下会误杀慢但正常的连接；已按 review 删除）。
- `CindyVoiceRunContext` 加代次号，超时后迟到的会话分配不再覆盖新的 fallback 候选。
- `FallbackAsrProvider` 暂存候选胜出前发出的 `connected` 事件并在胜出后补发，`asrConnectedMs` 不再恒为 `undefined`。
- 新增 `asr session allocated` / `connected`（分段）/ `flush settled` debug 日志与脱敏 `latency summary`；`scripts/voice-input-benchmark.mjs` 可从生产日志生成报告。
- `voice-input:start` 里 refiner 链与 ASR 链解析改为 `Promise.all` 并行。
- `useVoiceInputSettings` 的快捷键同步 effect 改为按值依赖：main 每次广播都深克隆 settings，原先每次录音后都会重新注册一次。
- `Tip` 只要调用方声明了 `controlledOpen` / `forceOpen`，就从挂载起走受控路径，交回 hover 时用本地状态模拟。

### 变更类型

- [ ] `feat` 新功能
- [x] `fix` 缺陷修复
- [x] `refactor` / `perf` 重构或性能优化
- [ ] `docs` / `test` / `chore` 文档、测试或工程维护
- [ ] 其他：

### 范围

- 关联 Issue / 需求：无
- 本 PR 包含：`apps/desktop/src/{main,renderer}/voice-input/**`、`useVoiceInputSettings.ts`、`components/ui/tooltip.tsx`、`scripts/voice-input-benchmark.mjs` 及对应测试
- 明确不包含：服务端；「快速激活」默认值（它会让麦克风后台待命最长 30 分钟，保留用户选择）；托管模式错峰竞速与冷却时长调整（需要更多样本再定）；跳过短文本润色（产品行为，另行讨论）
- 用户可见变化：语音输入启动更快；麦克风权限被撤销后第一次按下就出现权限恢复提示；无 UI 视觉变化
- 是否存在 breaking change：无

### UI 变化

不涉及。`tooltip.tsx` 与 `VoiceInputOverlay.tsx` 命中 renderer 路径，但只改 open 状态逻辑与事件接线，无视觉 / 交互 / 文案变化。

- 引用的设计规范：不涉及：本 PR 未改任何样式、布局、动效或文案，`Tip` 只修正受控/非受控切换的 React 警告，渲染结果不变。

## 怎么验证的

### 自动验证

```text
pnpm test:unit:related
结果：PASS test:runner；PASS apps/desktop unit（vitest related，含 3 个新增测试文件）

pnpm --filter desktop run --if-present typecheck
结果：通过（@cindy/maker-core 无 typecheck script，自动跳过）

pnpm check:dco
结果：通过

npx eslint <本 PR 改动文件>
结果：0 问题
```

新增测试均先在旧代码上确认失败、再在新代码上通过：`FallbackAsrProvider` 补发 connected / 丢弃输家 connected；`useVoiceInputSettings` 同值广播不重同步；`Tip` 受控→非受控无警告；`captureSession` 在 `NotAllowedError` 时返回 `permissionDenied` 并使缓存失效（其它采集错误不带该标记）。

Review 回合 1（Codex + Greptile 各 1 条 P1，同一族「静音前音频补发」+ 1 条「撤权后当前尝试没走权限 UI」）后的补验：`pnpm test:unit:related` PASS（test:runner 495 / desktop vitest related）；`pnpm --filter desktop typecheck` 通过；eslint 改动文件 0 问题；`pnpm check:dco` 通过。

Review 回合 2（Codex 1 条 P1「外层 4.5s 超时覆盖了 provider 自身期限」）后的补验：同上四项全部通过；`FallbackAsrProvider.test.ts` 15/15，其中原「fast-fail 停滞候选」用例替换为「单候选慢启动按自身期限成功、不被外层超时误杀」。

### 手工验证

Windows 11，`pnpm restart:desktop:remote --region=global`（dev 隔离沙箱，托管模式，volcengine-sauc）。三次真实录音的日志分段：

| 阶段 | 第 1 次 | 第 2 次 | 第 3 次 |
|---|---|---|---|
| Cindy 会话分配 | 650 ms | 342 ms | 333 ms |
| 火山 socket 握手 | 1191 ms | 1086 ms | >5000 ms 超时，5.3s 后 fallback 到 qwen 成功 |
| ASR 就绪（asrConnectedMs） | 2484 ms | 1959 ms | 7502 ms |
| 停止后 flush 等待 | 411 ms | 428 ms | — |

修复后每次录音结束不再出现 `global shortcut registration failed` 与 Tooltip 警告（实测时正式版 Cindy 同时在跑，占着 `Ctrl+Shift+Space`，冲突本身是真实的，本 PR 只是不再每次录音重试）。

### 未执行的验证

- macOS 未实测（Windows 快速路径与 `global.ts` 的 `destroyed` 监听去重是跨平台代码，但只在 Windows 上跑过）。
- BYOK 错峰竞速只有单测覆盖，没有用真实 BYOK 凭证实测。
- `Tip` 其它 `controlledOpen` 消费方（sidebar SessionItem / RailNav 拖拽 tooltip）只跑了单测，未实机目检；Light / Dark 未目检——本 PR 未改样式。

## 风险

### 风险分类

- [ ] 无已知风险
- [ ] SQLite / migration
- [ ] system prompt
- [ ] 协议兼容
- [ ] 权限 / 安全 / 用户数据
- [ ] 存量插件兼容（批准状态 / 指纹 / manifest 校验 / 安装布局 / 包格式）
- [ ] 原生层 / fingerprint / OTA
- [x] 跨平台差异
- [x] 其他：`components/ui/tooltip.tsx` 是共享 primitive

### 影响与回滚

- 影响范围：Desktop 语音输入启动 / 提交路径；所有使用 `Tip` 的 `controlledOpen` / `forceOpen` 调用方（行为应不变，仅消除警告）。跨平台：Windows 走信任 `granted` 缓存的快速路径，macOS 路径不变。
- 回滚 / 降级方式：revert 本 PR 即可，无数据格式或协议变更。

### 提交前检查

- [x] 已 review 完整 diff
- [x] 每个 commit 都带 DCO 签名（`git commit -s`，见 [DCO](../DCO)）
- [x] UI 改动已在「UI 变化」注明引用的设计规范章节（不涉及 UI 则跳过）
- [x] 未提交凭证、令牌或授权文件
- [x] 已补充必要文档
- [x] 已确认测试结果或说明未执行原因


