### PR TITLE
feat(desktop): support native image generation for custom Codex providers

### DIFF
--- a/apps/desktop/src/main/im/shared/__tests__/cardActionTakeoverReplace.test.ts
+++ b/apps/desktop/src/main/im/shared/__tests__/cardActionTakeoverReplace.test.ts
@@ -23,6 +23,7 @@ const mocks = vi.hoisted(() => ({
   resolveLenientSessionRoute: vi.fn(),
   applyRuntimeSetModelChange:
     vi.fn<(input: unknown) => Promise<{ status: 'applied' | 'deferred' }>>(),
+  actualApplyRuntimeSetModelChange: null as null | ((input: never) => Promise<unknown>),
   registerPendingCredentialSwitchForSession: vi.fn(),
   clearPendingCredentialSwitchForSession: vi.fn(),
   wakeSessionInputAfterCredentialSwitch: vi.fn(),
@@ -37,9 +38,7 @@ const mocks = vi.hoisted(() => ({
   setSessionProvider: vi.fn(),
   isSessionInTurn: vi.fn(() => false),
   cancelPendingAgentSwitchForSession: vi.fn(),
-  withSendToSessionLock: vi.fn(
-    async (_sessionId: string, task: () => Promise<unknown>) => task(),
-  ),
+  withSendToSessionLock: vi.fn(async (_sessionId: string, task: () => Promise<unknown>) => task()),
   // 禁止回落 cwd:TEMP 是 Windows 独有变量,macOS 上回落 cwd 会让传递 import 的
   // 写盘副作用落进仓库工作区(见 authAdaptersImportPurity.test.ts 记录的事故)。
   userDataDir: process.env.TMPDIR ?? process.env.TEMP ?? '/tmp',
@@ -91,9 +90,11 @@ vi.mock('../../../maker-host/session-provider-store', () => ({
     providerId === undefined ? undefined : providerId?.trim() || null,
   setSessionProvider: mocks.setSessionProvider,
 }));
-vi.mock('../../../maker-ipc/runtimeSetModel', () => ({
-  applyRuntimeSetModelChange: mocks.applyRuntimeSetModelChange,
-}));
+vi.mock('../../../maker-ipc/runtimeSetModel', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../../../maker-ipc/runtimeSetModel')>();
+  mocks.actualApplyRuntimeSetModelChange = actual.applyRuntimeSetModelChange as never;
+  return { applyRuntimeSetModelChange: mocks.applyRuntimeSetModelChange };
+});
 vi.mock('../../../maker-ipc/register', () => ({
   cancelPendingAgentSwitchForSession: mocks.cancelPendingAgentSwitchForSession,
   isSessionInTurn: mocks.isSessionInTurn,
@@ -121,6 +122,10 @@ import {
 import type { ImCardBuilders } from '../cardBuilders';
 import type { ImChannelAdapter } from '../types';
 import type { ImTurnRunner } from '../turnRunner';
+import {
+  setCodexAppliedImageGenerationRoutes,
+  type CodexImageGenerationRoute,
+} from '../../../maker-host/codex-image-generation-route';
 
 function makeIm() {
   const im = {
@@ -203,6 +208,7 @@ async function pressSessionPick(
 }
 
 beforeEach(() => {
+  setCodexAppliedImageGenerationRoutes([]);
   vi.clearAllMocks();
   activateImAccountBoundary();
   (resolvePending as ReturnType<typeof vi.fn>).mockReturnValue(false);
@@ -218,11 +224,7 @@ beforeEach(() => {
     createSession: vi.fn(async () => ({ id: 'sess-new' })),
     closeSession: mocks.closeSession,
     getCapabilities: vi.fn(() => ({
-      permissionModes: [
-        { id: 'ask' },
-        { id: 'auto' },
-        { id: 'bypassPermissions' },
-      ],
+      permissionModes: [{ id: 'ask' }, { id: 'auto' }, { id: 'bypassPermissions' }],
     })),
   });
   mocks.getDesktopCcPrefs.mockReturnValue(null);
@@ -613,10 +615,7 @@ describe('model:pick 持久化失败', () => {
 
     const pickPromise = pressModelPick(im);
     await vi.waitFor(() => {
-      expect(mocks.withSendToSessionLock).toHaveBeenCalledWith(
-        'sess-target',
-        expect.any(Function),
-      );
+      expect(mocks.withSendToSessionLock).toHaveBeenCalledWith('sess-target', expect.any(Function));
     });
     expect(mocks.updateModelEffort).not.toHaveBeenCalled();
     expect(mocks.applyRuntimeSetModelChange).not.toHaveBeenCalled();
@@ -642,6 +641,72 @@ describe('model:pick 持久化失败', () => {
     );
     expect(mocks.applyRuntimeSetModelChange).toHaveBeenCalledWith(
       expect.objectContaining({ providerId: 'anthropic' }),
+    );
+  });
+
+  it('IM 模型卡片跨 dynamic Provider 时关闭旧 thread，下一次发送再按新路由创建', async () => {
+    const routeA: CodexImageGenerationRoute = {
+      providerId: 'provider-a',
+      routeId: 'a'.repeat(20),
+      modelProviderId: `cindy_imagegen_${'a'.repeat(20)}`,
+      supportedModels: ['shared-model'],
+      routing: {
+        upstream: 'https://a.invalid/v1',
+        wireProtocol: 'openai-responses',
+        authStrategy: 'none',
+      },
+      responseRoutingByModel: {},
+      credentialRevision: 1,
+    };
+    const routeB: CodexImageGenerationRoute = {
+      ...routeA,
+      providerId: 'provider-b',
+      routeId: 'b'.repeat(20),
+      modelProviderId: `cindy_imagegen_${'b'.repeat(20)}`,
+      supportedModels: ['claude-opus-4-7'],
+    };
+    setCodexAppliedImageGenerationRoutes([routeA, routeB]);
+    let livePresent = true;
+    const live = {
+      id: 'sess-target',
+      agentKind: 'codex' as const,
+      remoteHostId: null,
+      codexProxyActive: true,
+      codexThreadModelProviderId: routeA.modelProviderId,
+      model: 'shared-model',
+      setModel: vi.fn(async () => {}),
+      setEffort: vi.fn(async () => {}),
+      isTurnRunning: () => false,
+    };
+    const closeSession = vi.fn(async () => {
+      livePresent = false;
+    });
+    mocks.getSessionProvider.mockReturnValue('provider-a');
+    mocks.getMaker.mockReturnValue({
+      getSession: () => (livePresent ? live : undefined),
+      listActiveSessions: () => (livePresent ? [live] : []),
+      closeSession,
+      getCapabilities: vi.fn(() => ({ permissionModes: [] })),
+    });
+    (turnRunner.getMakerSessionById as ReturnType<typeof vi.fn>).mockImplementation(() =>
+      livePresent ? live : null,
+    );
+    mocks.applyRuntimeSetModelChange.mockImplementationOnce(async (input: unknown) => {
+      if (!mocks.actualApplyRuntimeSetModelChange) throw new Error('actual runtime switch missing');
+      return mocks.actualApplyRuntimeSetModelChange(input as never) as Promise<{
+        status: 'applied' | 'deferred';
+      }>;
+    });
+    const im = makeIm();
+
+    await pressModelPick(im, 'provider-b');
+
+    expect(closeSession).toHaveBeenCalledWith('sess-target');
+    expect(live.setModel).not.toHaveBeenCalled();
+    expect(mocks.setSessionProvider).toHaveBeenCalledWith('sess-target', 'provider-b');
+    expect(im.updateInteractiveCard).toHaveBeenCalledWith(
+      'model-card',
+      expect.objectContaining({ body: slackUi.cards.model.resolved('Opus 4.7', 'high') }),
     );
   });
 

--- a/apps/desktop/src/main/maker-host/__tests__/codexImageGenerationRoute.test.ts
+++ b/apps/desktop/src/main/maker-host/__tests__/codexImageGenerationRoute.test.ts
@@ -1,0 +1,263 @@
+import { afterEach, describe, expect, it } from 'vitest';
+
+import {
+  BUNDLED_CATALOG,
+  buildUserProvider,
+  type CustomProviderConfig,
+} from '@cindy/model-providers';
+
+import {
+  buildCodexImageGenerationProviderArgs,
+  codexImageGenerationRouteSignature,
+  crossesCodexAppliedImageGenerationIdentity,
+  deriveCodexImageGenerationRoutes,
+  isCodexImageGenerationNamespacePath,
+  parseCodexImageGenerationPath,
+  relativeProviderRequestPath,
+  resolveCodexImageGenerationProviderId,
+  setCodexAppliedImageGenerationRoutes,
+} from '../codex-image-generation-route.js';
+import { beginProviderRouteMutation } from '../provider-route.js';
+
+function customProvider(overrides: Partial<CustomProviderConfig> = {}) {
+  return buildUserProvider({
+    id: 'haoplay-local',
+    name: 'HaoPlay',
+    runtimes: {
+      codex: {
+        baseUrl: 'https://provider.example/v1',
+        requestPath: '/v1/responses',
+        wireProtocol: 'openai-responses',
+        supportsImageGeneration: true,
+        models: [
+          { id: 'chat-image', name: 'Chat Image' },
+          { id: 'chat-image-alt', name: 'Chat Image Alt' },
+          {
+            id: 'chat-text',
+            name: 'Chat Text',
+            supportsImageInput: true,
+            route: {
+              baseUrl: 'https://provider.example/v1',
+              wireProtocol: 'openai-chat',
+            },
+          },
+        ],
+      },
+    },
+    ...overrides,
+  });
+}
+
+function catalog(provider = customProvider()) {
+  return { ...BUNDLED_CATALOG, providers: [...BUNDLED_CATALOG.providers, provider] };
+}
+
+afterEach(() => {
+  setCodexAppliedImageGenerationRoutes([]);
+});
+
+describe('Codex custom Provider image-generation identity', () => {
+  it('derives one stable identity per enabled Provider for every eligible Responses model', () => {
+    const routes = deriveCodexImageGenerationRoutes(catalog());
+    expect(routes).toHaveLength(1);
+    expect(routes[0]).toMatchObject({
+      providerId: 'haoplay-local',
+      supportedModels: ['chat-image', 'chat-image-alt'],
+    });
+    expect(routes[0]?.modelProviderId).toMatch(/^cindy_imagegen_[a-f0-9]{20}$/);
+    expect(resolveCodexImageGenerationProviderId(routes, 'haoplay-local', 'chat-image')).toBe(
+      routes[0]?.modelProviderId,
+    );
+    expect(resolveCodexImageGenerationProviderId(routes, 'haoplay-local', 'chat-image-alt')).toBe(
+      routes[0]?.modelProviderId,
+    );
+    expect(resolveCodexImageGenerationProviderId(routes, 'haoplay-local', 'chat-text')).toBeNull();
+
+    const disabled = customProvider({
+      runtimes: {
+        codex: {
+          baseUrl: 'https://provider.example/v1',
+          wireProtocol: 'openai-responses',
+          models: [{ id: 'vision-input', name: 'Vision Input', supportsImageInput: true }],
+        },
+      },
+    });
+    expect(deriveCodexImageGenerationRoutes(catalog(disabled))).toEqual([]);
+  });
+
+  it('uses the applied Host snapshot to identify only real dynamic identity crossings', () => {
+    const routeA = deriveCodexImageGenerationRoutes(catalog())[0]!;
+    const routeB = deriveCodexImageGenerationRoutes(
+      catalog(customProvider({ id: 'provider-b', name: 'Provider B' })),
+    )[0]!;
+    setCodexAppliedImageGenerationRoutes([routeA, routeB]);
+    const base = {
+      agentKind: 'codex',
+      remoteHostId: null,
+      currentCodexProxyActive: true,
+      currentThreadModelProviderId: routeA.modelProviderId,
+    };
+
+    expect(
+      crossesCodexAppliedImageGenerationIdentity({
+        ...base,
+        targetProviderId: routeA.providerId,
+        targetModel: 'chat-image-alt',
+      }),
+    ).toBe(false);
+    expect(
+      crossesCodexAppliedImageGenerationIdentity({
+        ...base,
+        targetProviderId: routeA.providerId,
+        targetModel: 'chat-text',
+      }),
+    ).toBe(true);
+    expect(
+      crossesCodexAppliedImageGenerationIdentity({
+        ...base,
+        currentThreadModelProviderId: 'cindy_gateway',
+        targetProviderId: routeA.providerId,
+        targetModel: 'chat-image',
+      }),
+    ).toBe(true);
+    expect(
+      crossesCodexAppliedImageGenerationIdentity({
+        ...base,
+        targetProviderId: routeB.providerId,
+        targetModel: 'chat-image',
+      }),
+    ).toBe(true);
+    expect(
+      crossesCodexAppliedImageGenerationIdentity({
+        ...base,
+        currentThreadModelProviderId: 'cindy_gateway',
+        targetProviderId: 'ordinary-provider',
+        targetModel: 'ordinary-model',
+      }),
+    ).toBe(false);
+  });
+
+  it('keeps the identity stable while including capability changes in the host snapshot', () => {
+    const before = deriveCodexImageGenerationRoutes(catalog())[0]!;
+    const changed = customProvider({
+      runtimes: {
+        codex: {
+          baseUrl: 'https://other.example/openai',
+          wireProtocol: 'openai-responses',
+          supportsImageGeneration: true,
+          models: [{ id: 'new-image', name: 'New Image' }],
+        },
+      },
+    });
+    const afterCatalog = catalog(changed);
+    const after = deriveCodexImageGenerationRoutes(afterCatalog)[0]!;
+    expect(after.modelProviderId).toBe(before.modelProviderId);
+    expect(codexImageGenerationRouteSignature(afterCatalog)).not.toBe(
+      codexImageGenerationRouteSignature(catalog()),
+    );
+  });
+
+  it('builds actor-gated loopback config without upstream URLs or user credentials', () => {
+    const route = deriveCodexImageGenerationRoutes(catalog())[0]!;
+    const config = buildCodexImageGenerationProviderArgs('http://127.0.0.1:43210', 'oauth-bearer', [
+      route,
+    ]);
+    const argv = config.extraArgs.join(' ');
+    expect(argv).toContain(
+      `model_providers.${route.modelProviderId}.name="Cindy Image Generation"`,
+    );
+    expect(argv).toContain('x-openai-actor-authorization = "local-image-extension"');
+    expect(argv).toContain('supports_websockets=false');
+    expect(argv).toContain(`/_cindy/imagegen/${route.routeId}`);
+    expect(argv).not.toContain('provider.example');
+    expect(argv).not.toContain('haoplay-local');
+    expect(config.extraEnv.XDT_CODEX_API_KEY).toBeTruthy();
+  });
+
+  it('keeps custom header credentials out of the Host snapshot and signature input', () => {
+    const secret = 'Bearer fake-vendor-secret';
+    const provider = customProvider({
+      runtimes: {
+        codex: {
+          baseUrl: 'https://provider.example/v1',
+          wireProtocol: 'openai-responses',
+          supportsImageGeneration: true,
+          headers: { Authorization: secret, 'x-vendor-token': 'fake-token' },
+          models: [{ id: 'chat-image', name: 'Chat Image' }],
+        },
+      },
+    });
+    const route = deriveCodexImageGenerationRoutes(catalog(provider))[0]!;
+    expect(JSON.stringify(route)).not.toContain(secret);
+    expect(JSON.stringify(route)).not.toContain('fake-token');
+    expect(route.routing.headerOverride).toBeUndefined();
+
+    const before = codexImageGenerationRouteSignature(catalog(provider));
+    const mutation = beginProviderRouteMutation(provider.id);
+    mutation.commit();
+    mutation();
+    const after = codexImageGenerationRouteSignature(catalog(provider));
+    expect(after).not.toBe(before);
+    expect(after).not.toContain(secret);
+  });
+
+  it('parses only the dedicated route and strips the prefix completely', () => {
+    const routeId = 'a'.repeat(20);
+    expect(parseCodexImageGenerationPath(`/_cindy/imagegen/${routeId}/responses?x=1`)).toEqual({
+      kind: 'route',
+      routeId,
+      upstreamPath: '/responses?x=1',
+      pathKind: 'responses',
+    });
+    expect(parseCodexImageGenerationPath(`/_cindy/imagegen/${routeId}/images/generations`)).toEqual(
+      {
+        kind: 'route',
+        routeId,
+        upstreamPath: '/images/generations',
+        pathKind: 'images',
+      },
+    );
+    expect(parseCodexImageGenerationPath(`/_cindy/imagegen/${routeId}/images/edits`)).toEqual({
+      kind: 'route',
+      routeId,
+      upstreamPath: '/images/edits',
+      pathKind: 'images',
+    });
+    expect(parseCodexImageGenerationPath('/v1/images/generations')).toEqual({
+      kind: 'not-image-generation-route',
+    });
+  });
+
+  it('claims raw private namespace variants before normalization and rejects non-canonical paths', () => {
+    const routeId = 'a'.repeat(20);
+    const invalid = [
+      '/_cindy/imagegen',
+      '/_cindy/imagegen/',
+      '/_cindy/imagegen//',
+      '/_cindy/imagegen/../responses',
+      '/_cindy/imagegen/%2e%2e/responses',
+      '/_CINDY/IMAGEGEN/' + routeId + '/responses',
+      '/_%63indy/image%67en/' + routeId + '/responses',
+      '/_cindy/imagegen%2f' + routeId + '/responses',
+      '/_cindy/imagegen%5c' + routeId + '/responses',
+      '/_cindy/imagegen/' + routeId + '/images/edits/extra',
+      '/_cindy/imagegen/' + routeId + '/images/edits#fragment',
+      'https://localhost/_cindy/imagegen/../responses',
+    ];
+    for (const path of invalid) {
+      expect(isCodexImageGenerationNamespacePath(path), path).toBe(true);
+      expect(parseCodexImageGenerationPath(path), path).toEqual({ kind: 'invalid' });
+    }
+    expect(isCodexImageGenerationNamespacePath('/v1/not-imagegen/responses')).toBe(false);
+  });
+
+  it('uses chat requestPath without duplicating an upstream /v1 base path', () => {
+    expect(relativeProviderRequestPath('https://provider.example/v1', '/v1/responses')).toBe(
+      '/responses',
+    );
+    expect(relativeProviderRequestPath('https://provider.example/v1/', '/responses')).toBe(
+      '/responses',
+    );
+    expect(relativeProviderRequestPath('https://provider.example/v1', '//evil')).toBeNull();
+  });
+});

--- a/apps/desktop/src/main/maker-host/__tests__/codexProxyHost.test.ts
+++ b/apps/desktop/src/main/maker-host/__tests__/codexProxyHost.test.ts
@@ -1,4 +1,6 @@
 import fs from 'node:fs';
+import { createServer, request as httpRequest } from 'node:http';
+import type { AddressInfo } from 'node:net';
 import os from 'node:os';
 import path from 'node:path';
 import { afterEach, beforeAll, beforeEach, describe, expect, it, vi } from 'vitest';
@@ -14,6 +16,7 @@ type Registry = {
 const mockState = vi.hoisted(() => {
   let capturedRegistry: Registry | null = null;
   const state = {
+    logLevel: 'debug' as 'info' | 'debug',
     userData: '/tmp/xdt-maker-test',
     logDir: '/tmp/xdt-maker-test/logs',
     logger: {
@@ -57,7 +60,7 @@ vi.mock('../../appCapabilities.js', () => ({
 
 vi.mock('../../logger.js', () => ({
   createLogger: () => mockState.logger,
-  getLogLevel: () => 'debug',
+  getLogLevel: () => mockState.logLevel,
   getLogDir: () => mockState.logDir,
 }));
 
@@ -138,6 +141,7 @@ async function freshCodexProxyHost() {
   mockState.injectionTransform.mockReturnValue(null);
   mockState.stripNonAnthropicFields.mockReset();
   mockState.stripNonAnthropicFields.mockReturnValue(null);
+  mockState.logLevel = 'debug';
   mockState.resetCapturedRegistry();
   return import('../codex-proxy-host.js');
 }
@@ -4568,7 +4572,7 @@ describe('codex proxy host', () => {
     // the schema 400 (PR #2444 Codex P1).
     const host = await freshCodexProxyHost();
     const { setXdGatewayModels, markXdGatewayModelAccessUnknown } = await import('../active-catalog.js');
-    const { setSessionProvider, clearSessionProvider } = await import('../session-provider-store.js');
+    const { clearSessionProvider } = await import('../session-provider-store.js');
     setXdGatewayModels([]);
     markXdGatewayModelAccessUnknown();
     mockState.createAnthropicCompatProxy.mockResolvedValueOnce({
@@ -4853,7 +4857,7 @@ describe('codex proxy host', () => {
     // transform claims this request for xd; the compat transform must match.
     const host = await freshCodexProxyHost();
     const { setXdGatewayModels } = await import('../active-catalog.js');
-    const { setSessionProvider, clearSessionProvider } = await import('../session-provider-store.js');
+    const { clearSessionProvider } = await import('../session-provider-store.js');
     setXdGatewayModels([{ id: 'x-ai/grok-4.5', agents: ['codex'] }]);
     mockState.createAnthropicCompatProxy.mockResolvedValueOnce({
       url: 'http://127.0.0.1:43210',
@@ -6079,5 +6083,907 @@ describe('createModelRoutingTransform —— Anthropic 桥的额度回调安装�
       setCustomProviders([]);
       setCustomProviderKeyReader(() => null);
     }
+  });
+});
+
+describe('createModelRoutingTransform —— custom Provider native imagegen prefix', () => {
+  it('routes generate/edit to the selected custom Provider and strips internal actor auth', async () => {
+    const host = await freshCodexProxyHost();
+    const { BUNDLED_CATALOG, buildUserProvider } = await import('@cindy/model-providers');
+    const { setActiveCatalog } = await import('../active-catalog.js');
+    const { setCustomProviderKeyReader } = await import('../provider-route.js');
+    const { deriveCodexImageGenerationRoutes } = await import('../codex-image-generation-route.js');
+    const provider = buildUserProvider({
+      id: 'image-provider',
+      name: 'Image Provider',
+      runtimes: {
+        codex: {
+          baseUrl: 'https://images.example/v1',
+          requestPath: '/v1/responses',
+          wireProtocol: 'openai-responses',
+          supportsImageGeneration: true,
+          models: [
+            { id: 'chat-image', name: 'Chat Image' },
+            { id: 'chat-text', name: 'Chat Text', supportsImageInput: true },
+          ],
+        },
+      },
+    });
+    const catalog = { ...BUNDLED_CATALOG, providers: [...BUNDLED_CATALOG.providers, provider] };
+    setActiveCatalog(catalog);
+    setCustomProviderKeyReader(() => 'provider-key');
+    const route = deriveCodexImageGenerationRoutes(catalog)[0]!;
+    host.setCodexAppliedImageGenerationRoutes([route]);
+
+    try {
+      const imageDecision = await Promise.resolve(
+        host.createModelRoutingTransform()(
+          { model: 'gpt-image-2', prompt: 'draw' },
+          {
+            reqId: 1,
+            method: 'POST',
+            url: `/_cindy/imagegen/${route.routeId}/images/generations`,
+            headers: {
+              authorization: 'Bearer chatgpt-oauth',
+              'chatgpt-account-id': 'account',
+              'x-openai-actor-authorization': 'local-image-extension',
+            },
+          },
+        ),
+      );
+      expect(imageDecision).toEqual(
+        expect.objectContaining({
+          upstreamOverride: 'https://images.example/v1',
+          pathOverride: '/images/generations',
+          headerOverride: expect.objectContaining({ authorization: 'Bearer provider-key' }),
+          headerDelete: expect.arrayContaining([
+            'chatgpt-account-id',
+            'x-openai-actor-authorization',
+          ]),
+        }),
+      );
+
+      const responseDecision = await Promise.resolve(
+        host.createModelRoutingTransform()(
+          { model: 'chat-image', input: [] },
+          {
+            reqId: 2,
+            method: 'POST',
+            url: `/_cindy/imagegen/${route.routeId}/responses`,
+            headers: { authorization: 'Bearer placeholder' },
+          },
+        ),
+      );
+      expect(responseDecision).toEqual(
+        expect.objectContaining({
+          upstreamOverride: 'https://images.example/v1',
+          pathOverride: '/responses',
+        }),
+      );
+
+      const secondModelDecision = await Promise.resolve(
+        host.createModelRoutingTransform()(
+          { model: 'chat-text', input: [] },
+          {
+            reqId: 3,
+            method: 'POST',
+            url: `/_cindy/imagegen/${route.routeId}/responses`,
+            headers: {},
+          },
+        ),
+      );
+      expect(secondModelDecision).toEqual(
+        expect.objectContaining({
+          upstreamOverride: 'https://images.example/v1',
+          pathOverride: '/responses',
+        }),
+      );
+    } finally {
+      setCustomProviderKeyReader(() => null);
+      host.setCodexAppliedImageGenerationRoutes([]);
+      setActiveCatalog(BUNDLED_CATALOG);
+    }
+  });
+
+  it('keeps auth-none, generic OAuth, and Provider-owned actor headers isolated on the prefix', async () => {
+    const host = await freshCodexProxyHost();
+    const { BUNDLED_CATALOG, buildUserProvider } = await import('@cindy/model-providers');
+    const { setActiveCatalog } = await import('../active-catalog.js');
+    const {
+      setCustomProviderHeaderReader,
+      setCustomProviderKeyReader,
+      setOAuthTokenReader,
+    } = await import('../provider-route.js');
+    const { deriveCodexImageGenerationRoutes } = await import('../codex-image-generation-route.js');
+    const providers = [
+      buildUserProvider({
+        id: 'none-images',
+        name: 'None Images',
+        auth: { method: 'none' },
+        runtimes: {
+          codex: {
+            baseUrl: 'http://127.0.0.1:44551/v1',
+            wireProtocol: 'openai-responses',
+            supportsImageGeneration: true,
+            models: [{ id: 'none-image', name: 'None Image' }],
+          },
+        },
+      }),
+      buildUserProvider({
+        id: 'oauth-images',
+        name: 'OAuth Images',
+        auth: {
+          method: 'oauth',
+          oauth: {
+            authorizeUrl: 'https://oauth-images.example/authorize',
+            tokenUrl: 'https://oauth-images.example/token',
+            clientId: 'public-client',
+            scopes: 'images',
+          },
+        },
+        runtimes: {
+          codex: {
+            baseUrl: 'https://oauth-images.example/v1',
+            wireProtocol: 'openai-responses',
+            supportsImageGeneration: true,
+            models: [{ id: 'oauth-image', name: 'OAuth Image' }],
+          },
+        },
+      }),
+      buildUserProvider({
+        id: 'actor-images',
+        name: 'Actor Images',
+        runtimes: {
+          codex: {
+            baseUrl: 'https://actor-images.example/v1',
+            wireProtocol: 'openai-responses',
+            supportsImageGeneration: true,
+            headers: { 'X-OpenAI-Actor-Authorization': 'provider-owned-actor' },
+            models: [{ id: 'actor-image', name: 'Actor Image' }],
+          },
+        },
+      }),
+    ];
+    const catalog = {
+      ...BUNDLED_CATALOG,
+      providers: [...BUNDLED_CATALOG.providers, ...providers],
+    };
+    const routes = deriveCodexImageGenerationRoutes(catalog);
+    setActiveCatalog(catalog);
+    setCustomProviderKeyReader(() => 'fake-api-key');
+    setCustomProviderHeaderReader((providerId) =>
+      providerId === 'actor-images'
+        ? { 'X-OpenAI-Actor-Authorization': 'provider-owned-actor' }
+        : null,
+    );
+    setOAuthTokenReader(() => 'fake-oauth-token');
+    host.setCodexAppliedImageGenerationRoutes(routes);
+
+    try {
+      const decisionFor = (providerId: string) => {
+        const route = routes.find((candidate) => candidate.providerId === providerId)!;
+        return Promise.resolve(host.createModelRoutingTransform()(
+          { model: 'gpt-image-2' },
+          {
+            reqId: 1,
+            method: 'POST',
+            url: `/_cindy/imagegen/${route.routeId}/images/generations`,
+            headers: {
+              authorization: 'Bearer loopback-placeholder',
+              'x-openai-actor-authorization': 'local-image-extension',
+            },
+          },
+        ));
+      };
+      const none = await decisionFor('none-images');
+      expect(none).toEqual(expect.objectContaining({
+        upstreamOverride: 'http://127.0.0.1:44551/v1',
+        headerDelete: expect.arrayContaining([
+          'authorization',
+          'x-openai-actor-authorization',
+        ]),
+      }));
+      expect(none?.headerOverride?.authorization).toBeUndefined();
+
+      none?.forwardLifecycle?.onStart?.();
+      none?.forwardLifecycle?.onFailure?.('retry-rejected');
+      const noneLifecycleLogs = [
+        ...mockState.logger.info.mock.calls,
+        ...mockState.logger.warn.mock.calls,
+      ]
+        .map((call) => String(call[0] ?? ''))
+        .filter((line) => line.includes('codex_image_generation_forward_'));
+      expect(noneLifecycleLogs).toHaveLength(2);
+      expect(JSON.stringify(noneLifecycleLogs)).not.toContain('authSource');
+      expect(noneLifecycleLogs[1]).toContain('outcome       : local_retry_rejected');
+
+      const oauth = await decisionFor('oauth-images');
+      expect(oauth).toEqual(expect.objectContaining({
+        upstreamOverride: 'https://oauth-images.example/v1',
+        headerOverride: expect.objectContaining({ authorization: 'Bearer fake-oauth-token' }),
+        headerDelete: expect.arrayContaining(['x-openai-actor-authorization']),
+      }));
+
+      const actor = await decisionFor('actor-images');
+      expect(actor).toEqual(expect.objectContaining({
+        headerOverride: expect.objectContaining({
+          authorization: 'Bearer fake-api-key',
+          'x-openai-actor-authorization': 'provider-owned-actor',
+        }),
+      }));
+      expect(actor?.headerDelete ?? []).not.toContain('x-openai-actor-authorization');
+    } finally {
+      host.setCodexAppliedImageGenerationRoutes([]);
+      setCustomProviderHeaderReader(() => null);
+      setCustomProviderKeyReader(() => null);
+      setOAuthTokenReader(() => null);
+      setActiveCatalog(BUNDLED_CATALOG);
+    }
+  });
+
+  it('rejects malformed, deleted and stale prefixed routes without falling back', async () => {
+    const host = await freshCodexProxyHost();
+    const invalid = await Promise.resolve(
+      host.createModelRoutingTransform()(
+        { model: 'gpt-image-2' },
+        {
+          reqId: 1,
+          method: 'POST',
+          url: '/_cindy/imagegen/not-a-route/images/edits',
+          headers: {},
+        },
+      ),
+    );
+    expect(invalid).toEqual(expect.objectContaining({ localHandler: expect.any(Function) }));
+
+    const deleted = await Promise.resolve(
+      host.createModelRoutingTransform()(
+        { model: 'gpt-image-2' },
+        {
+          reqId: 2,
+          method: 'POST',
+          url: '/_cindy/imagegen/0123456789abcdefabcd/images/edits',
+          headers: {},
+        },
+      ),
+    );
+    expect(deleted).toEqual(expect.objectContaining({ localHandler: expect.any(Function) }));
+  });
+
+  it('keeps the running Host snapshot during capability/model changes and fails closed after deletion', async () => {
+    const host = await freshCodexProxyHost();
+    const { BUNDLED_CATALOG, buildUserProvider } = await import('@cindy/model-providers');
+    const { setActiveCatalog } = await import('../active-catalog.js');
+    const { setCustomProviderKeyReader } = await import('../provider-route.js');
+    const { deriveCodexImageGenerationRoutes } = await import('../codex-image-generation-route.js');
+    const beforeProvider = buildUserProvider({
+      id: 'busy-image-provider',
+      name: 'Busy Image Provider',
+      runtimes: {
+        codex: {
+          baseUrl: 'https://busy-images.example/v1',
+          requestPath: '/v1/responses',
+          wireProtocol: 'openai-responses',
+          supportsImageGeneration: true,
+          models: [{ id: 'old-image-chat', name: 'Old Image Chat' }],
+        },
+      },
+    });
+    const beforeCatalog = {
+      ...BUNDLED_CATALOG,
+      providers: [...BUNDLED_CATALOG.providers, beforeProvider],
+    };
+    const route = deriveCodexImageGenerationRoutes(beforeCatalog)[0]!;
+    setActiveCatalog(beforeCatalog);
+    setCustomProviderKeyReader(() => 'provider-key');
+    host.setCodexAppliedImageGenerationRoutes([route]);
+
+    try {
+      // Settings is already ahead (last true cancelled and model list replaced),
+      // while a busy turn still runs on the old app-server snapshot.
+      const changedProvider = buildUserProvider({
+        id: 'busy-image-provider',
+        name: 'Busy Image Provider',
+        runtimes: {
+          codex: {
+            baseUrl: 'https://busy-images.example/v1',
+            requestPath: '/v1/responses',
+            wireProtocol: 'openai-responses',
+            models: [{ id: 'new-text-chat', name: 'New Text Chat' }],
+          },
+        },
+      });
+      setActiveCatalog({
+        ...BUNDLED_CATALOG,
+        providers: [...BUNDLED_CATALOG.providers, changedProvider],
+      });
+
+      const oldTurnDecision = await Promise.resolve(host.createModelRoutingTransform()(
+        { model: 'old-image-chat', input: [] },
+        {
+          reqId: 1,
+          method: 'POST',
+          url: `/_cindy/imagegen/${route.routeId}/responses`,
+          headers: {},
+        },
+      ));
+      expect(oldTurnDecision).toEqual(expect.objectContaining({
+        upstreamOverride: 'https://busy-images.example/v1',
+        pathOverride: '/responses',
+      }));
+
+      // Provider deletion is an irrecoverable boundary: retain the prefix
+      // ownership but reject locally, never fall through to Gateway/ChatGPT.
+      setActiveCatalog(BUNDLED_CATALOG);
+      const deletedDecision = await Promise.resolve(host.createModelRoutingTransform()(
+        { model: 'gpt-image-2' },
+        {
+          reqId: 2,
+          method: 'POST',
+          url: `/_cindy/imagegen/${route.routeId}/images/edits`,
+          headers: {},
+        },
+      ));
+      expect(deletedDecision).toEqual(expect.objectContaining({ localHandler: expect.any(Function) }));
+
+      // Once idle restart applies the new Host snapshot, the old prefix stops selecting.
+      host.setCodexAppliedImageGenerationRoutes([]);
+      const afterRestartDecision = await Promise.resolve(host.createModelRoutingTransform()(
+        { model: 'gpt-image-2' },
+        {
+          reqId: 3,
+          method: 'POST',
+          url: `/_cindy/imagegen/${route.routeId}/images/generations`,
+          headers: {},
+        },
+      ));
+      expect(afterRestartDecision).toEqual(
+        expect.objectContaining({ localHandler: expect.any(Function) }),
+      );
+    } finally {
+      host.setCodexAppliedImageGenerationRoutes([]);
+      setCustomProviderKeyReader(() => null);
+      setActiveCatalog(BUNDLED_CATALOG);
+    }
+  });
+
+  it('never combines an old Host image route with a newer credential generation', async () => {
+    const host = await freshCodexProxyHost();
+    const { BUNDLED_CATALOG, buildUserProvider } = await import('@cindy/model-providers');
+    const { setActiveCatalog } = await import('../active-catalog.js');
+    const { beginProviderRouteMutation, setCustomProviderKeyReader } =
+      await import('../provider-route.js');
+    const { deriveCodexImageGenerationRoutes } = await import('../codex-image-generation-route.js');
+    const providerFor = (baseUrl: string) =>
+      buildUserProvider({
+        id: 'busy-credential-image-provider',
+        name: 'Busy Credential Image Provider',
+        runtimes: {
+          codex: {
+            baseUrl,
+            wireProtocol: 'openai-responses',
+            supportsImageGeneration: true,
+            models: [{ id: 'image-chat', name: 'Image Chat' }],
+          },
+        },
+      });
+    const oldProvider = providerFor('https://old-credential-images.example/v1');
+    const oldCatalog = {
+      ...BUNDLED_CATALOG,
+      providers: [...BUNDLED_CATALOG.providers, oldProvider],
+    };
+    setActiveCatalog(oldCatalog);
+    setCustomProviderKeyReader(() => 'old-provider-key');
+    const oldRoute = deriveCodexImageGenerationRoutes(oldCatalog)[0]!;
+    host.setCodexAppliedImageGenerationRoutes([oldRoute]);
+    let finishMutation: ReturnType<typeof beginProviderRouteMutation> | null = null;
+
+    try {
+      finishMutation = beginProviderRouteMutation(oldProvider.id);
+      const newProvider = providerFor('https://new-credential-images.example/v1');
+      const newCatalog = {
+        ...BUNDLED_CATALOG,
+        providers: [...BUNDLED_CATALOG.providers, newProvider],
+      };
+      setActiveCatalog(newCatalog);
+      setCustomProviderKeyReader(() => 'new-provider-key');
+
+      const duringMutation = await Promise.resolve(
+        host.createModelRoutingTransform()(
+          { model: 'gpt-image-2' },
+          {
+            reqId: 1,
+            method: 'POST',
+            url: `/_cindy/imagegen/${oldRoute.routeId}/images/generations`,
+            headers: {},
+          },
+        ),
+      );
+      expect(duringMutation).toEqual(
+        expect.objectContaining({ localHandler: expect.any(Function) }),
+      );
+
+      finishMutation.commit();
+      finishMutation();
+      const staleHost = await Promise.resolve(
+        host.createModelRoutingTransform()(
+          { model: 'gpt-image-2' },
+          {
+            reqId: 2,
+            method: 'POST',
+            url: `/_cindy/imagegen/${oldRoute.routeId}/images/generations`,
+            headers: {},
+          },
+        ),
+      );
+      expect(staleHost).toEqual(expect.objectContaining({ localHandler: expect.any(Function) }));
+
+      const newRoute = deriveCodexImageGenerationRoutes(newCatalog)[0]!;
+      host.setCodexAppliedImageGenerationRoutes([newRoute]);
+      const restartedHost = await Promise.resolve(
+        host.createModelRoutingTransform()(
+          { model: 'gpt-image-2' },
+          {
+            reqId: 3,
+            method: 'POST',
+            url: `/_cindy/imagegen/${newRoute.routeId}/images/generations`,
+            headers: {},
+          },
+        ),
+      );
+      expect(restartedHost).toEqual(
+        expect.objectContaining({
+          upstreamOverride: 'https://new-credential-images.example/v1',
+          headerOverride: expect.objectContaining({ authorization: 'Bearer new-provider-key' }),
+        }),
+      );
+      expect(JSON.stringify(newRoute)).not.toContain('new-provider-key');
+    } finally {
+      finishMutation?.();
+      host.setCodexAppliedImageGenerationRoutes([]);
+      setCustomProviderKeyReader(() => null);
+      setActiveCatalog(BUNDLED_CATALOG);
+    }
+  });
+
+  it('routes a real multipart edit through the prefix with byte-identical body and Provider auth', async () => {
+    const sensitiveResponseBody = '{"result":"private-upstream-response"}';
+    const received: Array<{
+      path: string;
+      headers: Record<string, string | string[] | undefined>;
+      body: Buffer;
+    }> = [];
+    const upstream = createServer((req, res) => {
+      const chunks: Buffer[] = [];
+      req.on('data', (chunk: Buffer) => chunks.push(chunk));
+      req.on('end', () => {
+        received.push({ path: req.url ?? '', headers: req.headers, body: Buffer.concat(chunks) });
+        res.writeHead(200, { 'content-type': 'application/json' }).end(sensitiveResponseBody);
+      });
+    });
+    await new Promise<void>((resolve) => upstream.listen(0, '127.0.0.1', resolve));
+    let upstreamClosed = false;
+    const upstreamOrigin = `http://127.0.0.1:${(upstream.address() as AddressInfo).port}`;
+    const upstreamUrl = `http://private-user:private-password@127.0.0.1:${(upstream.address() as AddressInfo).port}/v1?private-query=value#private-fragment`;
+    const expectedLoggedUpstream = `${upstreamOrigin}/v1`;
+    const host = await freshCodexProxyHost();
+    const actualProxy = await vi.importActual<typeof import('@cindy/anthropic-compat-proxy')>(
+      '@cindy/anthropic-compat-proxy',
+    );
+    mockState.createAnthropicCompatProxy.mockImplementationOnce(
+      actualProxy.createAnthropicCompatProxy,
+    );
+    const { BUNDLED_CATALOG, buildUserProvider } = await import('@cindy/model-providers');
+    const { setActiveCatalog } = await import('../active-catalog.js');
+    const { setCustomProviderHeaderReader, setCustomProviderKeyReader } = await import('../provider-route.js');
+    const { deriveCodexImageGenerationRoutes } = await import('../codex-image-generation-route.js');
+    const provider = buildUserProvider({
+      id: 'private-stored-provider-id',
+      name: 'Private Provider Display Name',
+      runtimes: {
+        codex: {
+          baseUrl: upstreamUrl,
+          requestPath: '/v1/responses',
+          wireProtocol: 'openai-responses',
+          supportsImageGeneration: true,
+          models: [{ id: 'image-chat', name: 'Image Chat' }],
+        },
+      },
+    });
+    const catalog = {
+      ...BUNDLED_CATALOG,
+      providers: [...BUNDLED_CATALOG.providers, provider],
+    };
+    const route = deriveCodexImageGenerationRoutes(catalog)[0]!;
+    setActiveCatalog(catalog);
+    setCustomProviderKeyReader(() => 'fake-provider-authorization-secret');
+    setCustomProviderHeaderReader(() => ({
+      'x-private-vendor-header': 'private-vendor-header-value',
+    }));
+    host.setCodexAppliedImageGenerationRoutes([route]);
+    const boundary = 'cindy-native-edit';
+    const body = Buffer.concat([
+      Buffer.from(`--${boundary}\r\nContent-Disposition: form-data; name="prompt"\r\n\r\nedit\r\n`),
+      Buffer.from(
+        `--${boundary}\r\nContent-Disposition: form-data; name="image"; filename="private-image-name.bin"\r\nContent-Type: application/octet-stream\r\n\r\n`,
+      ),
+      Buffer.from([0, 255, 128, 13, 10, 77]),
+      Buffer.from(`\r\n--${boundary}--\r\n`),
+    ]);
+    const requestRawTarget = (
+      proxyEndpoint: string,
+      target: string,
+      method: string,
+      contentType?: string,
+      rawBody?: Buffer | string,
+    ) =>
+      new Promise<number>((resolve, reject) => {
+        const proxy = new URL(proxyEndpoint);
+        const requestBody = rawBody === undefined
+          ? undefined
+          : Buffer.isBuffer(rawBody)
+            ? rawBody
+            : Buffer.from(rawBody);
+        const req = httpRequest(
+          {
+            hostname: proxy.hostname,
+            port: proxy.port,
+            method,
+            path: target,
+            headers: {
+              ...(contentType ? { 'content-type': contentType } : {}),
+              ...(requestBody ? { 'content-length': String(requestBody.length) } : {}),
+              authorization: 'Bearer loopback-placeholder',
+            },
+          },
+          (res) => {
+            res.resume();
+            res.on('end', () => resolve(res.statusCode ?? 0));
+          },
+        );
+        req.on('error', reject);
+        if (requestBody) req.write(requestBody);
+        req.end();
+      });
+
+    try {
+      await host.ensureCodexProxyReady();
+      const proxyEndpoint = host.getCodexProxyEndpoint();
+      mockState.logger.info.mockClear();
+      mockState.logger.warn.mockClear();
+      mockState.logger.debug.mockClear();
+      const invalidRequests = [
+        {
+          path: '/_cindy/imagegen/not-a-route/images/edits',
+          method: 'POST',
+          contentType: `multipart/form-data; boundary=${boundary}`,
+          requestBody: body,
+        },
+        {
+          path: `/_cindy/imagegen/${route.routeId}/images/edits/extra`,
+          method: 'POST',
+          contentType: 'application/json',
+          requestBody: '{}',
+        },
+        {
+          path: `/_cindy/imagegen%2F${route.routeId}%2Fimages%2Fedits`,
+          method: 'POST',
+          contentType: 'application/octet-stream',
+          requestBody: body,
+        },
+        {
+          path: `/_cindy/imagegen/${route.routeId}/images/edits`,
+          method: 'PUT',
+          contentType: `multipart/form-data; boundary=${boundary}`,
+          requestBody: body,
+        },
+        {
+          path: `/_cindy/imagegen/${route.routeId}/files`,
+          method: 'POST',
+          contentType: 'application/json',
+          requestBody: '{}',
+        },
+        { path: '/_cindy/imagegen', method: 'POST' },
+        { path: '/_cindy/imagegen/', method: 'POST' },
+        { path: '//_cindy//imagegen//', method: 'GET' },
+        { path: '/_cindy/imagegen/../responses', method: 'POST', contentType: 'application/json', requestBody: '{}' },
+        { path: '/_cindy/imagegen/./responses', method: 'POST' },
+        { path: '/_cindy/imagegen/%2e%2e/responses', method: 'POST', contentType: 'text/plain', requestBody: 'opaque' },
+        { path: '/_CINDY/ImageGen/anything', method: 'POST' },
+        { path: '/_cindy/image%67en/anything', method: 'POST' },
+        { path: `/_cindy/imagegen%2f${route.routeId}%2fimages%2fedits`, method: 'POST' },
+        { path: `/_cindy/imagegen%5c${route.routeId}%5cimages%5cedits`, method: 'POST' },
+        { path: `/_cindy\\imagegen\\${route.routeId}\\images\\edits`, method: 'POST' },
+        { path: `/_cindy/imagegen/${route.routeId}/images/edits#fragment`, method: 'POST' },
+        { path: `/other/../_cindy/imagegen/${route.routeId}/images/edits`, method: 'POST' },
+        {
+          path: `${proxyEndpoint}/_cindy/imagegen/${route.routeId}/images/edits/extra`,
+          method: 'POST',
+          contentType: `multipart/form-data; boundary=${boundary}`,
+          requestBody: body,
+        },
+        {
+          path: `${proxyEndpoint}\\_cindy\\imagegen\\${route.routeId}\\images\\edits`,
+          method: 'POST',
+          contentType: 'application/octet-stream',
+          requestBody: body,
+        },
+      ];
+      for (const invalidRequest of invalidRequests) {
+        const status = await requestRawTarget(
+          proxyEndpoint,
+          invalidRequest.path,
+          invalidRequest.method,
+          invalidRequest.contentType,
+          invalidRequest.requestBody,
+        );
+        expect(status, invalidRequest.path).toBeGreaterThanOrEqual(400);
+      }
+      expect(received).toHaveLength(0);
+      const imageGenerationLogLines = (): string[] =>
+        [...mockState.logger.info.mock.calls, ...mockState.logger.warn.mock.calls]
+          .map((call) => String(call[0] ?? ''))
+          .filter((line) => line.includes('codex_image_generation_forward_'));
+      expect(imageGenerationLogLines()).toEqual([]);
+
+      const response = await fetch(
+        `${proxyEndpoint}/_cindy/imagegen/${route.routeId}/images/edits`,
+        {
+          method: 'POST',
+          headers: {
+            'content-type': `multipart/form-data; boundary=${boundary}`,
+            authorization: 'Bearer loopback-placeholder',
+            'x-openai-actor-authorization': 'local-image-extension',
+          },
+          body,
+        },
+      );
+      expect(response.status).toBe(200);
+      const generationBody = JSON.stringify({
+        model: 'gpt-image-2',
+        prompt: 'private-generation-prompt',
+        size: '1536x1024',
+        quality: 'high',
+        background: 'transparent',
+        n: 2,
+        output_format: 'png',
+        output_compression: 85,
+        moderation: 'auto',
+        partial_images: 1,
+        stream: false,
+        response_format: 'b64_json',
+        unknown_private_field: 'private-unknown-value',
+        input: { image_url: 'data:image/png;base64,private-base64-payload' },
+      });
+      const generationResponse = await fetch(
+        `${proxyEndpoint}/_cindy/imagegen/${route.routeId}/images/generations`,
+        {
+          method: 'POST',
+          headers: {
+            'content-type': 'application/json',
+            authorization: 'Bearer loopback-placeholder',
+            'x-openai-actor-authorization': 'local-image-extension',
+          },
+          body: generationBody,
+        },
+      );
+      expect(generationResponse.status).toBe(200);
+      const customModelBody = JSON.stringify({
+        model: 'vendor-image-model-v2',
+        prompt: 'second-private-prompt',
+      });
+      expect(
+        (
+          await fetch(`${proxyEndpoint}/_cindy/imagegen/${route.routeId}/images/generations`, {
+            method: 'POST',
+            headers: { 'content-type': 'application/json' },
+            body: customModelBody,
+          })
+        ).status,
+      ).toBe(200);
+      const overlongModel = `private-overlong-prefix-${'x'.repeat(140)}-private-overlong-tail`;
+      expect(
+        (
+          await fetch(`${proxyEndpoint}/_cindy/imagegen/${route.routeId}/images/generations`, {
+            method: 'POST',
+            headers: { 'content-type': 'application/json' },
+            body: JSON.stringify({ model: overlongModel, prompt: 'third-private-prompt' }),
+          })
+        ).status,
+      ).toBe(200);
+      expect(received).toHaveLength(4);
+      expect(received[0]?.path).toBe('/v1/images/edits?private-query=value');
+      expect(received[0]?.body).toEqual(body);
+      expect(received[0]?.headers['content-type']).toBe(
+        `multipart/form-data; boundary=${boundary}`,
+      );
+      expect(received[0]?.headers['content-length']).toBe(String(body.length));
+      expect(received[0]?.headers.authorization).toBe('Bearer fake-provider-authorization-secret');
+      expect(received[0]?.headers['x-private-vendor-header']).toBe('private-vendor-header-value');
+      expect(received[0]?.headers['x-openai-actor-authorization']).toBeUndefined();
+      expect(received[1]?.path).toBe('/v1/images/generations?private-query=value');
+      expect(received[1]?.body.toString('utf8')).toBe(generationBody);
+      expect(received[1]?.headers.authorization).toBe('Bearer fake-provider-authorization-secret');
+
+      const successfulLogs = imageGenerationLogLines();
+      expect(successfulLogs).toHaveLength(8);
+      for (const [operation, expectedCount] of [
+        ['edit', 2],
+        ['generation', 6],
+      ] as const) {
+        const operationLogs = successfulLogs.filter((line) =>
+          line.includes(`operation     : ${operation}`),
+        );
+        expect(operationLogs).toHaveLength(expectedCount);
+        expect(operationLogs[0]).toContain('codex_image_generation_forward_start');
+        expect(operationLogs[1]).toContain('codex_image_generation_forward_complete');
+        const correlationIds = operationLogs.map(
+          (line) => /correlationId\s+:\s+([0-9a-f-]{36})/.exec(line)?.[1],
+        );
+        expect(correlationIds[0]).toBeTruthy();
+        expect(correlationIds[1]).toBe(correlationIds[0]);
+        expect(operationLogs[1]).toContain('status        : 200');
+        expect(operationLogs[1]).toContain('outcome       : success');
+        expect(operationLogs[1]).toMatch(/durationMs\s+:\s+\d+/);
+      }
+      for (const line of successfulLogs) {
+        expect(line).toContain(`routeId       : ${route.routeId}`);
+        expect(line).toContain('target        : custom-provider');
+        expect(line).not.toContain('authSource');
+        expect(line).not.toContain('upstreamUrl');
+        expect(line).not.toContain('imageParams');
+      }
+
+      const detailLogs = mockState.logger.debug.mock.calls
+        .map((call) => String(call[0] ?? ''))
+        .filter((line) => line.includes('codex_image_generation_forward_details'));
+      expect(detailLogs).toHaveLength(4);
+      const editDetails = detailLogs.filter((line) => /operation\s+:\s+edit/.test(line));
+      expect(editDetails).toHaveLength(1);
+      expect(editDetails[0]).toContain('upstreamUrl');
+      expect(editDetails[0]).toContain(`${expectedLoggedUpstream}/images/edits`);
+      expect(editDetails[0]).not.toContain('imageParams');
+      const generationDetails = detailLogs.filter((line) =>
+        /operation\s+:\s+generation/.test(line),
+      );
+      expect(generationDetails).toHaveLength(3);
+      expect(generationDetails[0]).toContain('upstreamUrl');
+      expect(generationDetails[0]).toContain(`${expectedLoggedUpstream}/images/generations`);
+      for (const expected of [
+        '"model": "gpt-image-2"',
+        '"size": "1536x1024"',
+        '"quality": "high"',
+        '"background": "transparent"',
+        '"n": 2',
+        '"output_format": "png"',
+        '"output_compression": 85',
+        '"moderation": "auto"',
+        '"partial_images": 1',
+        '"stream": false',
+        '"response_format": "b64_json"',
+      ]) {
+        expect(generationDetails[0]).toContain(expected);
+      }
+      expect(generationDetails[1]).toContain('"model": "vendor-image-model-v2"');
+      expect(generationDetails[2]).toContain('"model": "[truncated]"');
+      expect(JSON.stringify(detailLogs)).not.toContain('private-overlong-tail');
+
+      const sensitiveValues = [
+        'authSource',
+        upstreamUrl,
+        '127.0.0.1',
+        'private-user',
+        'private-password',
+        'private-query',
+        'private-fragment',
+        'private-stored-provider-id',
+        'Private Provider Display Name',
+        'fake-provider-authorization-secret',
+        'authorization',
+        'x-private-vendor-header',
+        'private-vendor-header-value',
+        'private-generation-prompt',
+        'private-base64-payload',
+        'private-unknown-value',
+        'second-private-prompt',
+        'third-private-prompt',
+        'private-image-name.bin',
+        'private-upstream-response',
+      ];
+      const serializedSuccessfulLogs = JSON.stringify(successfulLogs);
+      for (const sensitiveValue of sensitiveValues) {
+        expect(serializedSuccessfulLogs).not.toContain(sensitiveValue);
+      }
+      const serializedDetails = JSON.stringify(detailLogs);
+      for (const sensitiveValue of sensitiveValues.filter((value) =>
+        [upstreamUrl, '127.0.0.1'].includes(value),
+      )) {
+        expect(serializedDetails).toContain(
+          sensitiveValue === upstreamUrl ? expectedLoggedUpstream : sensitiveValue,
+        );
+      }
+      for (const sensitiveValue of sensitiveValues.filter(
+        (value) => ![upstreamUrl, '127.0.0.1'].includes(value),
+      )) {
+        expect(serializedDetails).not.toContain(sensitiveValue);
+      }
+
+      await new Promise<void>((resolve) => upstream.close(() => resolve()));
+      upstreamClosed = true;
+      mockState.logLevel = 'info';
+      const transportResponse = await fetch(
+        `${proxyEndpoint}/_cindy/imagegen/${route.routeId}/images/generations`,
+        {
+          method: 'POST',
+          headers: { 'content-type': 'application/json' },
+          body: generationBody,
+        },
+      );
+      expect(transportResponse.status).toBe(502);
+      const transportLogs = imageGenerationLogLines().slice(8);
+      expect(transportLogs).toHaveLength(2);
+      expect(transportLogs[0]).toContain('codex_image_generation_forward_start');
+      expect(transportLogs[1]).toContain('codex_image_generation_forward_failure');
+      expect(transportLogs[1]).toContain('outcome       : network_error');
+      const transportCorrelationIds = transportLogs.map(
+        (line) => /correlationId\s+:\s+([0-9a-f-]{36})/.exec(line)?.[1],
+      );
+      expect(transportCorrelationIds[0]).toBeTruthy();
+      expect(transportCorrelationIds[1]).toBe(transportCorrelationIds[0]);
+      const serializedTransportLogs = JSON.stringify(transportLogs);
+      for (const sensitiveValue of [...sensitiveValues, 'ECONNREFUSED']) {
+        expect(serializedTransportLogs).not.toContain(sensitiveValue);
+      }
+      expect(
+        mockState.logger.debug.mock.calls.filter((call) =>
+          String(call[0] ?? '').includes('codex_image_generation_forward_details'),
+        ),
+      ).toHaveLength(4);
+      expect(mockState.createAnthropicCompatProxy.mock.calls[0]?.[0]).not.toHaveProperty(
+        'forwardLifecycleObserver',
+      );
+    } finally {
+      await host.disposeCodexProxy();
+      host.setCodexAppliedImageGenerationRoutes([]);
+      setCustomProviderHeaderReader(() => null);
+      setCustomProviderKeyReader(() => null);
+      setActiveCatalog(BUNDLED_CATALOG);
+      if (!upstreamClosed) {
+        await new Promise<void>((resolve) => upstream.close(() => resolve()));
+      }
+    }
+  });
+
+  it('owns every private imagegen prefix before opaque body transforms', async () => {
+    const host = await freshCodexProxyHost();
+    mockState.createAnthropicCompatProxy.mockResolvedValueOnce({
+      url: 'http://127.0.0.1:43210',
+      dispose: vi.fn(async () => undefined),
+    });
+    await host.ensureCodexProxyReady();
+    const options = mockState.createAnthropicCompatProxy.mock.calls[0]?.[0];
+    expect(
+      options.bypassRequestTransforms(
+        {},
+        {
+          url: '/_cindy/imagegen/0123456789abcdefabcd/images/edits',
+        },
+      ),
+    ).toBe(true);
+    expect(options.bypassRequestTransforms({}, { url: '/images/edits' })).toBe(false);
+    expect(
+      options.bypassRequestTransforms(
+        {},
+        {
+          url: '/_cindy/imagegen/0123456789abcdefabcd/responses',
+        },
+      ),
+    ).toBe(true);
+    expect(
+      options.routeOpaqueRequestBody({
+        url: '/_cindy/imagegen%2F0123456789abcdefabcd%2Fimages%2Fedits',
+      }),
+    ).toBe(true);
+    expect(options.routeOpaqueRequestBody({ url: '/images/edits' })).toBe(false);
   });
 });

--- a/apps/desktop/src/main/maker-host/__tests__/custom-provider-store.test.ts
+++ b/apps/desktop/src/main/maker-host/__tests__/custom-provider-store.test.ts
@@ -370,6 +370,74 @@ describe('validateCustomProviderConfig (per-runtime)', () => {
 });
 
 describe('custom-provider-store CRUD (per-runtime)', () => {
+  it('accepts image generation only for a Codex runtime with an OpenAI Responses route', () => {
+    const model = { id: 'image-chat', name: 'Image Chat' };
+    expect(
+      validateCustomProviderConfig({
+        id: 'image-provider',
+        name: 'Image Provider',
+        runtimes: {
+          codex: {
+            baseUrl: 'https://example.com/v1',
+            wireProtocol: 'openai-responses',
+            supportsImageGeneration: true,
+            models: [model],
+          },
+        },
+      }),
+    ).toEqual({ ok: true });
+    expect(
+      validateCustomProviderConfig({
+        id: 'chat-provider',
+        name: 'Chat Provider',
+        runtimes: {
+          codex: {
+            baseUrl: 'https://example.com/v1',
+            wireProtocol: 'openai-chat',
+            supportsImageGeneration: true,
+            models: [model],
+          },
+        },
+      }).ok,
+    ).toBe(false);
+    expect(
+      validateCustomProviderConfig({
+        id: 'pi-provider',
+        name: 'Pi Provider',
+        runtimes: {
+          pi: {
+            baseUrl: 'https://example.com/v1',
+            wireProtocol: 'openai-responses',
+            supportsImageGeneration: true,
+            models: [model],
+          },
+        },
+      }).ok,
+    ).toBe(false);
+    expect(
+      validateCustomProviderConfig({
+        id: 'mixed-provider',
+        name: 'Mixed Provider',
+        runtimes: {
+          codex: {
+            baseUrl: 'https://example.com/v1',
+            wireProtocol: 'openai-chat',
+            supportsImageGeneration: true,
+            models: [
+              {
+                ...model,
+                route: {
+                  baseUrl: 'https://example.com/responses',
+                  wireProtocol: 'openai-responses',
+                },
+              },
+            ],
+          },
+        },
+      }),
+    ).toEqual({ ok: true });
+  });
+
   it('creates, lists, gets, updates, deletes', async () => {
     mountDb();
     expect(await listCustomProviders()).toEqual([]);
@@ -536,6 +604,26 @@ describe('custom-provider-store CRUD (per-runtime)', () => {
       { id: 'legacy', name: 'Legacy' },
       { id: 'explicit-text', name: 'Explicit text' },
     ]);
+  });
+
+  it('round-trips only an explicitly enabled Codex image-generation capability', async () => {
+    mountDb();
+    await createCustomProvider({
+      id: 'imagegen-provider',
+      name: 'Imagegen Provider',
+      runtimes: {
+        codex: {
+          baseUrl: 'https://example.com/v1',
+          wireProtocol: 'openai-responses',
+          supportsImageGeneration: true,
+          models: [{ id: 'enabled', name: 'Enabled' }, { id: 'legacy', name: 'Legacy' }],
+        },
+      },
+    });
+    expect((await getCustomProvider('imagegen-provider'))?.runtimes.codex).toMatchObject({
+      supportsImageGeneration: true,
+      models: [{ id: 'enabled', name: 'Enabled' }, { id: 'legacy', name: 'Legacy' }],
+    });
   });
 
   it('round-trips the Pi official catalog provider id without adding it to other runtimes', async () => {

--- a/apps/desktop/src/main/maker-host/__tests__/providerCatalogRealmReload.test.ts
+++ b/apps/desktop/src/main/maker-host/__tests__/providerCatalogRealmReload.test.ts
@@ -138,11 +138,13 @@ vi.mock('../generic-oauth.js', () => ({
 }));
 vi.mock('../../secrets/providerSecretStore.js', () => ({
   genericOAuthSecretIo: {},
+  readCustomProviderHeaders: () => null,
   readCustomProviderKey: () => null,
   setProviderSecretsClearedListener: () => undefined,
   addProviderSecretsClearedListener: () => undefined,
 }));
 vi.mock('../provider-route.js', () => ({
+  setCustomProviderHeaderReader: () => undefined,
   setCustomProviderKeyReader: () => undefined,
   setOAuthTokenReader: () => undefined,
   setProviderOAuthTokenReader: () => undefined,

--- a/apps/desktop/src/main/maker-host/__tests__/providerRoute.test.ts
+++ b/apps/desktop/src/main/maker-host/__tests__/providerRoute.test.ts
@@ -20,13 +20,17 @@ import {
   beginProviderRouteMutation,
   buildLocalHandlerHeaders,
   buildRouteDecision,
+  getProviderRouteCredentialRevision,
   getSessionRoutingDescriptor,
   resolveSessionRoute,
   resolveSessionRouteDecision,
+  resolveFrozenProviderRouteDecision,
   resolveImplicitLocalBridgeRoute,
   inferProviderIdForModel,
   isUserProviderSession,
   setCustomProviderKeyReader,
+  setCustomProviderHeaderReader,
+  setOAuthTokenReader,
   setPendingCredentialSwitchReader,
   setProviderOAuthTokenReader,
   setProviderViewsReader,
@@ -76,6 +80,7 @@ const CODEX_ACCOUNT_HEADER_DELETE = [
 afterEach(() => {
   mockGetAppCapabilities.mockReturnValue({ canUseCindyGateway: true });
   setProviderOAuthTokenReader(() => null);
+  setOAuthTokenReader(() => null);
   setPendingCredentialSwitchReader(() => undefined);
   clearSessionProvider('s-xai');
   clearSessionProvider('s-xai-rewrite');
@@ -84,6 +89,7 @@ afterEach(() => {
   setXdGatewayModels([]);
   setAnthropicDiscoveredModels([]);
   setProviderViewsReader(async () => []);
+  setCustomProviderHeaderReader(() => null);
 });
 
 describe('Pi per-model protocol routing', () => {
@@ -1189,6 +1195,196 @@ describe('resolveSessionRouteDecision — 自定义供应商(resolve 时注入 k
       upstreamOverride: 'https://new.example/v1',
       headerOverride: { authorization: 'Bearer new-key' },
     });
+  });
+
+  it('keeps frozen image routes and credentials on one generation and closes async read races', async () => {
+    const providerId = 'image-route-generation';
+    const makeProvider = (baseUrl: string) =>
+      buildUserProvider({
+        id: providerId,
+        name: 'Image Route Generation',
+        runtimes: {
+          codex: {
+            baseUrl,
+            wireProtocol: 'openai-responses',
+            supportsImageGeneration: true,
+            models: [{ id: 'image-chat', name: 'Image Chat' }],
+          },
+        },
+      });
+    const oldProvider = makeProvider('https://old-images.example/v1');
+    setCustomProviders([oldProvider]);
+    setCustomProviderKeyReader(() => 'old-key');
+    const oldRevision = getProviderRouteCredentialRevision(providerId);
+    const oldRouting = oldProvider.routing.codex!;
+    await expect(
+      resolveFrozenProviderRouteDecision(providerId, oldRouting, oldRevision, 'codex', KEY),
+    ).resolves.toMatchObject({
+      decision: {
+        upstreamOverride: 'https://old-images.example/v1',
+        headerOverride: { authorization: 'Bearer old-key' },
+      },
+    });
+
+    const finishMutation = beginProviderRouteMutation(providerId);
+    setCustomProviders([makeProvider('https://new-images.example/v1')]);
+    setCustomProviderKeyReader(() => 'new-key');
+    await expect(
+      resolveFrozenProviderRouteDecision(providerId, oldRouting, oldRevision, 'codex', KEY),
+    ).resolves.toBeNull();
+    finishMutation.commit();
+    finishMutation();
+
+    await expect(
+      resolveFrozenProviderRouteDecision(providerId, oldRouting, oldRevision, 'codex', KEY),
+    ).resolves.toBeNull();
+    const newRevision = getProviderRouteCredentialRevision(providerId);
+    const newProvider = makeProvider('https://new-images.example/v1');
+    await expect(
+      resolveFrozenProviderRouteDecision(
+        providerId,
+        newProvider.routing.codex!,
+        newRevision,
+        'codex',
+        KEY,
+      ),
+    ).resolves.toMatchObject({
+      decision: {
+        upstreamOverride: 'https://new-images.example/v1',
+        headerOverride: { authorization: 'Bearer new-key' },
+      },
+    });
+
+    let finishTokenRead!: (token: string) => void;
+    setProviderOAuthTokenReader(
+      () =>
+        new Promise<string>((resolve) => {
+          finishTokenRead = resolve;
+        }),
+    );
+    const asyncRouting = {
+      ...newProvider.routing.codex!,
+      authStrategy: 'provider-oauth-header' as const,
+    };
+    const pending = resolveFrozenProviderRouteDecision(
+      providerId,
+      asyncRouting,
+      newRevision,
+      'codex',
+      KEY,
+    );
+    await vi.waitFor(() => expect(finishTokenRead).toBeTypeOf('function'));
+    const finishTokenMutation = beginProviderRouteMutation(providerId);
+    finishTokenMutation.commit();
+    finishTokenMutation();
+    finishTokenRead('new-oauth-token');
+    await expect(pending).resolves.toBeNull();
+
+    // Recreating the same stored id cannot revive an older Host snapshot (ABA).
+    setCustomProviders([]);
+    const finishDelete = beginProviderRouteMutation(providerId);
+    finishDelete.commit();
+    finishDelete();
+    setCustomProviders([oldProvider]);
+    const finishRecreate = beginProviderRouteMutation(providerId);
+    finishRecreate.commit();
+    finishRecreate();
+    expect(getProviderRouteCredentialRevision(providerId)).not.toBe(newRevision);
+    await expect(
+      resolveFrozenProviderRouteDecision(providerId, oldRouting, oldRevision, 'codex', KEY),
+    ).resolves.toBeNull();
+  });
+
+  it('reads custom headers at request time and rejects a stale frozen route after header mutation', async () => {
+    const providerId = 'image-header-generation';
+    const makeProvider = (header: string) =>
+      buildUserProvider({
+        id: providerId,
+        name: 'Image Header Generation',
+        runtimes: {
+          codex: {
+            baseUrl: 'https://header-images.example/v1',
+            wireProtocol: 'openai-responses',
+            supportsImageGeneration: true,
+            headers: { Authorization: header, 'x-vendor-token': header },
+            models: [{ id: 'image-chat', name: 'Image Chat' }],
+          },
+        },
+      });
+    const oldProvider = makeProvider('Bearer old-header-secret');
+    setCustomProviders([oldProvider]);
+    setCustomProviderKeyReader(() => null);
+    setCustomProviderHeaderReader(() => ({
+      Authorization: 'Bearer old-header-secret',
+      'x-vendor-token': 'old-header-secret',
+    }));
+    const oldRevision = getProviderRouteCredentialRevision(providerId);
+    const frozenRouting = { ...oldProvider.routing.codex! };
+    delete frozenRouting.headerOverride;
+
+    const oldDecision = await resolveFrozenProviderRouteDecision(
+      providerId,
+      frozenRouting,
+      oldRevision,
+      'codex',
+      KEY,
+    );
+    expect(oldDecision).toMatchObject({
+      decision: {
+        headerOverride: {
+          authorization: 'Bearer old-header-secret',
+          'x-vendor-token': 'old-header-secret',
+        },
+      },
+    });
+    expect(oldDecision?.routing).not.toHaveProperty('headerOverride');
+
+    const finishMutation = beginProviderRouteMutation(providerId);
+    setCustomProviders([makeProvider('Bearer new-header-secret')]);
+    setCustomProviderHeaderReader(() => ({
+      Authorization: 'Bearer new-header-secret',
+      'x-vendor-token': 'new-header-secret',
+    }));
+    await expect(
+      resolveFrozenProviderRouteDecision(
+        providerId,
+        frozenRouting,
+        oldRevision,
+        'codex',
+        KEY,
+      ),
+    ).resolves.toBeNull();
+    finishMutation.commit();
+    finishMutation();
+
+    await expect(
+      resolveFrozenProviderRouteDecision(
+        providerId,
+        frozenRouting,
+        oldRevision,
+        'codex',
+        KEY,
+      ),
+    ).resolves.toBeNull();
+    const newProvider = makeProvider('Bearer new-header-secret');
+    const newFrozenRouting = { ...newProvider.routing.codex! };
+    delete newFrozenRouting.headerOverride;
+    const newDecision = await resolveFrozenProviderRouteDecision(
+      providerId,
+      newFrozenRouting,
+      getProviderRouteCredentialRevision(providerId),
+      'codex',
+      KEY,
+    );
+    expect(newDecision).toMatchObject({
+      decision: {
+        headerOverride: {
+          authorization: 'Bearer new-header-secret',
+          'x-vendor-token': 'new-header-secret',
+        },
+      },
+    });
+    expect(newDecision?.routing).not.toHaveProperty('headerOverride');
   });
 
   it('精确请求路径只覆盖带 model 的推理请求，不改写无 body 的控制面请求', () => {

--- a/apps/desktop/src/main/maker-host/codex-credential-switch.ts
+++ b/apps/desktop/src/main/maker-host/codex-credential-switch.ts
@@ -13,6 +13,7 @@ import {
   CODEX_GATEWAY_PROVIDER_ID,
   CODEX_OPENAI_COMPACT_PROVIDER_ID,
 } from './codex-gateway-config.js';
+import { crossesCodexAppliedImageGenerationIdentity } from './codex-image-generation-route.js';
 import type { CodexProxyAuthInjection } from './codex-proxy-host.js';
 import { withRehydrateCloseSuppressed } from './rehydrateCloseSuppression.js';
 
@@ -95,7 +96,10 @@ export interface PrepareLocalSessionCredentialModeSwitchResult {
 export class CredentialModeSwitchBusyError extends Error {
   readonly sessionIds: string[];
 
-  constructor(sessionIds: string[], message = `Cannot switch credential mode while local session(s) are busy: ${sessionIds.join(', ')}`) {
+  constructor(
+    sessionIds: string[],
+    message = `Cannot switch credential mode while local session(s) are busy: ${sessionIds.join(', ')}`,
+  ) {
     super(message);
     this.name = 'CredentialModeSwitchBusyError';
     this.sessionIds = sessionIds;
@@ -149,12 +153,21 @@ function normalizeProviderId(providerId: string | null | undefined): string | nu
 export function isCodexThreadModelProviderIdentityMismatch(
   input: ShouldCloseSessionForCredentialSwitchInput,
 ): boolean {
-  if (
-    input.remoteHostId ||
-    input.agentKind !== 'codex' ||
-    input.currentCodexProxyActive !== true
-  ) {
+  if (input.remoteHostId || input.agentKind !== 'codex' || input.currentCodexProxyActive !== true) {
     return false;
+  }
+
+  if (
+    crossesCodexAppliedImageGenerationIdentity({
+      agentKind: input.agentKind,
+      remoteHostId: input.remoteHostId,
+      currentCodexProxyActive: input.currentCodexProxyActive,
+      currentThreadModelProviderId: input.currentCodexThreadModelProviderId,
+      targetProviderId: input.nextProviderId,
+      targetModel: input.nextModel,
+    })
+  ) {
+    return true;
   }
 
   const nextProviderId = normalizeProviderId(input.nextProviderId);
@@ -177,9 +190,7 @@ export function isCodexThreadModelProviderIdentityMismatch(
       : effectiveNextMode !== undefined
         ? CODEX_GATEWAY_PROVIDER_ID
         : null;
-  const actualThreadModelProviderId = normalizeProviderId(
-    input.currentCodexThreadModelProviderId,
-  );
+  const actualThreadModelProviderId = normalizeProviderId(input.currentCodexThreadModelProviderId);
   const actualThreadIdentityKnown =
     actualThreadModelProviderId === CODEX_OPENAI_COMPACT_PROVIDER_ID ||
     actualThreadModelProviderId === CODEX_CINDY_COMPACT_PROVIDER_ID ||
@@ -340,10 +351,10 @@ export async function prepareLocalCodexCredentialModeSwitch(
   input: PrepareLocalCodexCredentialModeSwitchInput,
 ): Promise<PrepareLocalCodexCredentialModeSwitchResult> {
   throwIfCredentialSwitchAborted(input.signal);
-  const localCodexSessions = input.maker
-    .listActiveSessions()
-    .filter(isLocalCodexSession);
-  const busySessions = localCodexSessions.filter((session) => isSessionBusy(session, input.isSessionInTurn));
+  const localCodexSessions = input.maker.listActiveSessions().filter(isLocalCodexSession);
+  const busySessions = localCodexSessions.filter((session) =>
+    isSessionBusy(session, input.isSessionInTurn),
+  );
   if (busySessions.length > 0) {
     throw new CodexCredentialModeSwitchBusyError(
       busySessions.map((session) => session.id),

--- a/apps/desktop/src/main/maker-host/codex-image-generation-route.ts
+++ b/apps/desktop/src/main/maker-host/codex-image-generation-route.ts
@@ -1,0 +1,331 @@
+import { createHash } from 'node:crypto';
+
+import type { Catalog, Provider, RoutingDescriptor } from '@cindy/model-providers';
+import { storedCustomProviderId } from '@cindy/model-providers';
+
+import {
+  CODEX_GATEWAY_ENV_KEY,
+  CODEX_PROVIDER_OAUTH_PLACEHOLDER_KEY,
+  type CodexProxySpawnAuthMode,
+} from './codex-gateway-config.js';
+import { getProviderRouteCredentialRevision } from './provider-route.js';
+
+export const CODEX_IMAGE_GENERATION_ACTOR_HEADER = 'x-openai-actor-authorization';
+export const CODEX_IMAGE_GENERATION_ACTOR_VALUE = 'local-image-extension';
+export const CODEX_IMAGE_GENERATION_ROUTE_ROOT = '/_cindy/imagegen';
+
+export interface CodexImageGenerationRoute {
+  /** Runtime catalog id (legacy xAI rows may be projected as custom:xai). */
+  providerId: string;
+  /** Stable, non-sensitive handle derived only from the stored custom Provider id. */
+  routeId: string;
+  modelProviderId: string;
+  supportedModels: readonly string[];
+  /** Host-spawn snapshot used only inside Desktop's loopback routing boundary. */
+  routing: RoutingDescriptor;
+  /** Per-model Responses routes frozen with the same Host snapshot. */
+  responseRoutingByModel: Readonly<Record<string, RoutingDescriptor>>;
+  /** Non-sensitive credential generation frozen with this Host snapshot. */
+  credentialRevision: number;
+}
+
+/** Routes actually frozen into the currently running local Codex Host. */
+let appliedImageGenerationRoutes: readonly CodexImageGenerationRoute[] = [];
+
+export function setCodexAppliedImageGenerationRoutes(
+  routes: readonly CodexImageGenerationRoute[],
+): void {
+  appliedImageGenerationRoutes = [...routes];
+}
+
+export function findCodexAppliedImageGenerationRoute(
+  routeId: string,
+): CodexImageGenerationRoute | undefined {
+  return appliedImageGenerationRoutes.find((route) => route.routeId === routeId);
+}
+
+export function hasCodexAppliedImageGenerationProvider(providerId: string): boolean {
+  const storedProviderId = storedCustomProviderId(providerId);
+  return appliedImageGenerationRoutes.some(
+    (route) => storedCustomProviderId(route.providerId) === storedProviderId,
+  );
+}
+
+function stableRouteId(providerId: string): string {
+  return createHash('sha256').update(providerId, 'utf8').digest('hex').slice(0, 20);
+}
+
+function effectiveModelWireProtocol(
+  model: { route?: { wireProtocol: string } },
+  routing: RoutingDescriptor,
+): string {
+  return model.route?.wireProtocol ?? routing.wireProtocol ?? 'openai-responses';
+}
+
+function frozenRoutingDescriptor(routing: RoutingDescriptor): RoutingDescriptor {
+  const frozen = { ...routing };
+  // Custom headers are credentials. Keep only their non-sensitive availability state in the Host
+  // snapshot; values are read at request time behind provider-route's credential generation gate.
+  delete frozen.headerOverride;
+  return frozen;
+}
+
+function routeForProvider(provider: Provider): CodexImageGenerationRoute | null {
+  if (provider.source !== 'user' || !provider.agents.includes('codex')) return null;
+  const routing = provider.routing.codex;
+  if (!routing || routing.disabled || routing.supportsImageGeneration !== true) return null;
+  const supported = (provider.models.codex ?? []).filter(
+    (model) => effectiveModelWireProtocol(model, routing) === 'openai-responses',
+  );
+  const supportedModels = supported.map((model) => model.id);
+  if (supportedModels.length === 0) return null;
+  const routeId = stableRouteId(storedCustomProviderId(provider.id));
+  const frozenRouting = frozenRoutingDescriptor(routing);
+  return {
+    providerId: provider.id,
+    routeId,
+    modelProviderId: `cindy_imagegen_${routeId}`,
+    supportedModels,
+    credentialRevision: getProviderRouteCredentialRevision(provider.id),
+    routing: frozenRouting,
+    responseRoutingByModel: Object.fromEntries(
+      supported.map((model) => {
+        if (!model.route) return [model.id, { ...frozenRouting }];
+        const inherited = { ...frozenRouting };
+        delete inherited.requestPath;
+        return [
+          model.id,
+          {
+            ...inherited,
+            upstream: model.route.baseUrl,
+            wireProtocol: model.route.wireProtocol,
+            ...(model.route.requestPath ? { requestPath: model.route.requestPath } : {}),
+          },
+        ];
+      }),
+    ),
+  };
+}
+
+/** Strip Desktop-only routing data before the snapshot crosses into maker-core. */
+export function toCodexImageGenerationHostRoutes(
+  routes: readonly CodexImageGenerationRoute[],
+): Array<Pick<CodexImageGenerationRoute, 'providerId' | 'modelProviderId' | 'supportedModels'>> {
+  return routes.map(({ providerId, modelProviderId, supportedModels }) => ({
+    providerId,
+    modelProviderId,
+    supportedModels: [...supportedModels],
+  }));
+}
+
+export function deriveCodexImageGenerationRoutes(catalog: Catalog): CodexImageGenerationRoute[] {
+  return catalog.providers.flatMap((provider) => {
+    const route = routeForProvider(provider);
+    return route ? [route] : [];
+  });
+}
+
+export function codexImageGenerationRouteSignature(catalog: Catalog): string {
+  const snapshot = deriveCodexImageGenerationRoutes(catalog)
+    .map((route) => ({
+      providerId: route.providerId,
+      modelProviderId: route.modelProviderId,
+      supportedModels: [...route.supportedModels].sort(),
+      routing: route.routing,
+      responseRoutingByModel: route.responseRoutingByModel,
+      credentialRevision: route.credentialRevision,
+    }))
+    .sort((left, right) => left.modelProviderId.localeCompare(right.modelProviderId));
+  return snapshot.length === 0
+    ? ''
+    : createHash('sha256').update(JSON.stringify(snapshot), 'utf8').digest('hex');
+}
+
+export function resolveCodexImageGenerationProviderId(
+  routes: readonly CodexImageGenerationRoute[],
+  providerId: string | null | undefined,
+  model: string | null | undefined,
+): string | null {
+  if (!providerId || !model) return null;
+  const route = routes.find((candidate) => candidate.providerId === providerId);
+  return route?.supportedModels.includes(model) ? route.modelProviderId : null;
+}
+
+export interface CodexAppliedImageGenerationIdentityInput {
+  agentKind: string;
+  remoteHostId?: string | null;
+  currentCodexProxyActive?: boolean | null;
+  currentThreadModelProviderId?: string | null;
+  targetProviderId?: string | null;
+  targetModel?: string | null;
+}
+
+/**
+ * Whether a local Codex thread would cross the image-generation identity frozen into its Host.
+ * Membership in the applied snapshot is the authority: do not infer private identities from ids.
+ */
+export function crossesCodexAppliedImageGenerationIdentity(
+  input: CodexAppliedImageGenerationIdentityInput,
+): boolean {
+  if (input.agentKind !== 'codex' || input.remoteHostId || input.currentCodexProxyActive !== true) {
+    return false;
+  }
+
+  const actual = input.currentThreadModelProviderId?.trim() || null;
+  const target = resolveCodexImageGenerationProviderId(
+    appliedImageGenerationRoutes,
+    input.targetProviderId?.trim() || null,
+    input.targetModel?.trim() || null,
+  );
+  const actualIsAppliedImageGenerationIdentity = appliedImageGenerationRoutes.some(
+    (route) => route.modelProviderId === actual,
+  );
+
+  return target !== null ? actual !== target : actualIsAppliedImageGenerationIdentity;
+}
+
+export function buildCodexImageGenerationProviderArgs(
+  proxyEndpoint: string,
+  authMode: CodexProxySpawnAuthMode,
+  routes: readonly CodexImageGenerationRoute[],
+): { extraArgs: string[]; extraEnv: Record<string, string> } {
+  const endpoint = proxyEndpoint.replace(/\/+$/, '');
+  const extraArgs: string[] = [];
+  for (const route of routes) {
+    const baseUrl = `${endpoint}${CODEX_IMAGE_GENERATION_ROUTE_ROOT}/${route.routeId}`;
+    const p = route.modelProviderId;
+    extraArgs.push(
+      '-c',
+      `model_providers.${p}.name="Cindy Image Generation"`,
+      '-c',
+      `model_providers.${p}.base_url="${baseUrl}"`,
+      '-c',
+      `model_providers.${p}.wire_api="responses"`,
+      '-c',
+      `model_providers.${p}.env_key="${CODEX_GATEWAY_ENV_KEY}"`,
+      '-c',
+      `model_providers.${p}.supports_websockets=false`,
+      '-c',
+      `model_providers.${p}.http_headers={ ${CODEX_IMAGE_GENERATION_ACTOR_HEADER} = "${CODEX_IMAGE_GENERATION_ACTOR_VALUE}" }`,
+    );
+  }
+  return {
+    extraArgs,
+    // OAuth hosts normally do not need the gateway env key. Dynamic custom identities do:
+    // the value is only a loopback placeholder and is replaced by the Provider route boundary.
+    extraEnv:
+      authMode === 'oauth-bearer'
+        ? { [CODEX_GATEWAY_ENV_KEY]: CODEX_PROVIDER_OAUTH_PLACEHOLDER_KEY }
+        : {},
+  };
+}
+
+export type ParsedCodexImageGenerationPath =
+  | { kind: 'not-image-generation-route' }
+  | { kind: 'invalid' }
+  | { kind: 'route'; routeId: string; upstreamPath: string; pathKind: 'responses' | 'images' };
+
+interface RawRequestTarget {
+  pathname: string;
+  search: string;
+  hasFragment: boolean;
+}
+
+/** Split origin-form or absolute-form HTTP request targets without URL normalization/decoding. */
+function splitRawRequestTarget(rawUrl: string): RawRequestTarget | null {
+  let target = rawUrl;
+  const absoluteMatch = /^[A-Za-z][A-Za-z0-9+.-]*:\/\//.exec(target);
+  if (absoluteMatch) {
+    const authorityStart = absoluteMatch[0].length;
+    const pathStart = target.slice(authorityStart).search(/[/?#\\]/);
+    if (pathStart < 0) return { pathname: '/', search: '', hasFragment: false };
+    target = target.slice(authorityStart + pathStart);
+    if (!target.startsWith('/')) target = `/${target}`;
+  }
+  if (!target.startsWith('/')) return null;
+  const fragmentIndex = target.indexOf('#');
+  const beforeFragment = fragmentIndex < 0 ? target : target.slice(0, fragmentIndex);
+  const queryIndex = beforeFragment.indexOf('?');
+  return {
+    pathname: queryIndex < 0 ? beforeFragment : beforeFragment.slice(0, queryIndex),
+    search: queryIndex < 0 ? '' : beforeFragment.slice(queryIndex),
+    hasFragment: fragmentIndex >= 0,
+  };
+}
+
+function decodePercentBytesForOwnership(pathname: string): string {
+  return pathname.replace(/%([0-9A-Fa-f]{2})/g, (_match, hex: string) =>
+    String.fromCharCode(Number.parseInt(hex, 16)),
+  );
+}
+
+function beginsWithImageGenerationNamespace(segments: readonly string[]): boolean {
+  return segments[0] === '_cindy' && segments[1] === 'imagegen';
+}
+
+/**
+ * Match ownership of the private loopback namespace before content-type parsing.
+ * Encoded slashes deliberately count as owned-but-invalid so they can never fall through to the
+ * default Gateway/ChatGPT route.
+ */
+export function isCodexImageGenerationNamespacePath(rawUrl: string): boolean {
+  const target = splitRawRequestTarget(rawUrl);
+  if (!target) return false;
+  const decoded = decodePercentBytesForOwnership(target.pathname).replace(/\\/g, '/').toLowerCase();
+  const lexicalSegments = decoded.split('/').filter((segment) => segment && segment !== '.');
+  if (beginsWithImageGenerationNamespace(lexicalSegments)) return true;
+
+  const semanticSegments: string[] = [];
+  for (const segment of decoded.split('/')) {
+    if (!segment || segment === '.') continue;
+    if (segment === '..') semanticSegments.pop();
+    else semanticSegments.push(segment);
+  }
+  return beginsWithImageGenerationNamespace(semanticSegments);
+}
+
+export function parseCodexImageGenerationPath(rawUrl: string): ParsedCodexImageGenerationPath {
+  const owned = isCodexImageGenerationNamespacePath(rawUrl);
+  const target = splitRawRequestTarget(rawUrl);
+  if (!target || target.hasFragment) {
+    return owned ? { kind: 'invalid' } : { kind: 'not-image-generation-route' };
+  }
+  const { pathname, search } = target;
+  if (!pathname.startsWith(`${CODEX_IMAGE_GENERATION_ROUTE_ROOT}/`)) {
+    return isCodexImageGenerationNamespacePath(rawUrl)
+      ? { kind: 'invalid' }
+      : { kind: 'not-image-generation-route' };
+  }
+  const rest = pathname.slice(CODEX_IMAGE_GENERATION_ROUTE_ROOT.length + 1);
+  const slash = rest.indexOf('/');
+  if (slash <= 0) return { kind: 'invalid' };
+  const routeId = rest.slice(0, slash);
+  const upstreamPath = rest.slice(slash);
+  if (!/^[a-f0-9]{20}$/.test(routeId)) return { kind: 'invalid' };
+  const pathKind =
+    upstreamPath === '/responses'
+      ? 'responses'
+      : upstreamPath === '/images/generations' || upstreamPath === '/images/edits'
+        ? 'images'
+        : null;
+  if (!pathKind) return { kind: 'invalid' };
+  return { kind: 'route', routeId, upstreamPath: `${upstreamPath}${search}`, pathKind };
+}
+
+/** Convert an absolute Provider requestPath into a path relative to its upstream base. */
+export function relativeProviderRequestPath(upstream: string, requestPath: string): string | null {
+  let basePath: string;
+  try {
+    basePath = new URL(upstream).pathname.replace(/\/+$/, '');
+  } catch {
+    return null;
+  }
+  const queryIndex = requestPath.indexOf('?');
+  const pathname = queryIndex >= 0 ? requestPath.slice(0, queryIndex) : requestPath;
+  const query = queryIndex >= 0 ? requestPath.slice(queryIndex) : '';
+  if (!pathname.startsWith('/') || pathname.startsWith('//')) return null;
+  if (basePath && (pathname === basePath || pathname.startsWith(`${basePath}/`))) {
+    return `${pathname.slice(basePath.length) || '/'}${query}`;
+  }
+  return requestPath;
+}

--- a/apps/desktop/src/main/maker-host/codex-proxy-host.ts
+++ b/apps/desktop/src/main/maker-host/codex-proxy-host.ts
@@ -27,6 +27,8 @@ import {
   stripEncryptedContentFromBody,
   stripImageGenerationItemsWithoutIdFromBody,
   stripNonAnthropicFields,
+  type ForwardLifecycleFailure,
+  type ForwardLifecycleObserver,
   type ProxyHandle,
   type ResponseObserver,
   type ResponseObserverCtx,
@@ -63,6 +65,7 @@ import {
   getSessionRoutingDescriptor,
   resolveProviderRouteById,
   resolveProviderRouteDecision,
+  resolveFrozenProviderRouteDecision,
   resolveSessionRoute,
   resolveSessionRouteDecision,
   resolvePendingSessionRouteDecision,
@@ -101,9 +104,25 @@ import { desktopAnthropicImageCodec } from './anthropic-image-codec.js';
 import { readSilentEncryptedRetrySettings } from './silent-encrypted-retry-store.js';
 import { getLogDir } from '../logger.js';
 import { recordXaiRateLimitSnapshot } from '../usageBroadcaster.js';
+import {
+  CODEX_IMAGE_GENERATION_ACTOR_HEADER,
+  findCodexAppliedImageGenerationRoute,
+  isCodexImageGenerationNamespacePath,
+  parseCodexImageGenerationPath,
+  relativeProviderRequestPath,
+  setCodexAppliedImageGenerationRoutes as setAppliedImageGenerationRoutes,
+  type CodexImageGenerationRoute,
+} from './codex-image-generation-route.js';
 
 // scope = 'codex-proxy'。保持独立 scope,方便后续 E2E 日志脚本按 codex proxy 过滤。
 const log = createMakerLogger('codex-proxy');
+const imageGenerationLog = log.child('imagegen');
+
+export function setCodexAppliedImageGenerationRoutes(
+  routes: readonly CodexImageGenerationRoute[],
+): void {
+  setAppliedImageGenerationRoutes(routes);
+}
 
 const registry = createInstructionsRegistry();
 const sessionToThread = new Map<string, string>();
@@ -2546,10 +2565,318 @@ export function decideCodexRoute(opts: {
   return { upstreamOverride: CODEX_OAUTH_UPSTREAM };
 }
 
+function codexImageGenerationRouteFailure(status: number, code: string): RoutingDecision {
+  return {
+    localHandler: async ({ res }) => {
+      res.writeHead(status, {
+        'content-type': 'application/json; charset=utf-8',
+        'cache-control': 'no-store',
+      });
+      res.end(
+        JSON.stringify({
+          error: {
+            type: 'invalid_request_error',
+            code,
+            message: 'This custom Provider image-generation route is unavailable.',
+          },
+        }),
+      );
+    },
+  };
+}
+
+type CodexImageGenerationOperation = 'generation' | 'edit';
+type CodexImageGenerationPathClass = '/images/generations' | '/images/edits';
+interface CodexImageGenerationLogParams {
+  model?: string;
+  size?: string;
+  quality?: string;
+  background?: string;
+  n?: number;
+  output_format?: string;
+  output_compression?: number;
+  moderation?: string;
+  partial_images?: number;
+  stream?: boolean;
+  response_format?: string;
+}
+
+const IMAGE_GENERATION_STRING_LOG_MAX_LENGTH = 128;
+const IMAGE_GENERATION_URL_LOG_MAX_LENGTH = 2_048;
+const IMAGE_GENERATION_LOG_TRUNCATED = '[truncated]';
+
+function hasLogUnsafeControlCharacter(value: string): boolean {
+  for (const character of value) {
+    const codePoint = character.codePointAt(0) ?? 0;
+    if (codePoint <= 0x1f || codePoint === 0x7f) return true;
+  }
+  return false;
+}
+
+/** Build a new primitive-only object from the Codex 0.145 generation request allowlist. */
+function codexImageGenerationLogParams(body: unknown): CodexImageGenerationLogParams | undefined {
+  if (!isPlainObject(body)) return undefined;
+  const params: CodexImageGenerationLogParams = {};
+  const safeString = (value: unknown): string | undefined => {
+    if (typeof value !== 'string' || value.length === 0) return undefined;
+    if (hasLogUnsafeControlCharacter(value)) return undefined;
+    return value.length <= IMAGE_GENERATION_STRING_LOG_MAX_LENGTH
+      ? value
+      : IMAGE_GENERATION_LOG_TRUNCATED;
+  };
+  const stringFields = [
+    'model',
+    'size',
+    'quality',
+    'background',
+    'output_format',
+    'moderation',
+    'response_format',
+  ] as const;
+  for (const field of stringFields) {
+    const value = safeString(body[field]);
+    if (value !== undefined) params[field] = value;
+  }
+  if (Number.isSafeInteger(body.n)) params.n = body.n as number;
+  if (
+    typeof body.output_compression === 'number' &&
+    Number.isFinite(body.output_compression)
+  ) {
+    params.output_compression = body.output_compression;
+  }
+  if (Number.isSafeInteger(body.partial_images)) {
+    params.partial_images = body.partial_images as number;
+  }
+  if (typeof body.stream === 'boolean') params.stream = body.stream;
+  return Object.keys(params).length > 0 ? params : undefined;
+}
+
+/** Mirror compat-proxy's final base-path + request-path join without retaining URL secrets. */
+function codexImageGenerationLogUpstreamUrl(
+  upstream: string,
+  pathOverride: string,
+): string | undefined {
+  try {
+    const parsed = new URL(upstream);
+    if (parsed.protocol !== 'http:' && parsed.protocol !== 'https:') return undefined;
+    const path = pathOverride.split('?', 1)[0] ?? '';
+    const basePath = parsed.pathname === '/' ? '' : parsed.pathname.replace(/\/+$/, '');
+    parsed.pathname = `${basePath}${path.startsWith('/') ? path : `/${path}`}`;
+    parsed.username = '';
+    parsed.password = '';
+    parsed.search = '';
+    parsed.hash = '';
+    const normalized = `${parsed.origin}${parsed.pathname}`;
+    return normalized.length <= IMAGE_GENERATION_URL_LOG_MAX_LENGTH
+      ? normalized
+      : IMAGE_GENERATION_LOG_TRUNCATED;
+  } catch {
+    return undefined;
+  }
+}
+
+function imageGenerationTransportOutcome(
+  failure: ForwardLifecycleFailure,
+):
+  | 'client_aborted'
+  | 'network_error'
+  | 'timeout'
+  | 'upstream_interrupted'
+  | 'local_retry_rejected'
+  | 'local_retry_error' {
+  if (failure === 'client-aborted') return 'client_aborted';
+  if (failure === 'request-timeout') return 'timeout';
+  if (failure === 'request-error') return 'network_error';
+  if (failure === 'retry-rejected') return 'local_retry_rejected';
+  if (failure === 'retry-error') return 'local_retry_error';
+  return 'upstream_interrupted';
+}
+
+/**
+ * Safe operational observer for the private custom-Provider Images route.
+ *
+ * This accepts only metadata already validated by the private route resolver. The returned
+ * callbacks close over fixed enums, the anonymous route hash, and the explicitly sanitized debug
+ * metadata. Neither the observer nor its factory can receive Provider identity, raw upstream
+ * input, headers, request/response bytes, or Error objects.
+ */
+function createCodexImageGenerationForwardLifecycleObserver(
+  routeId: string,
+  pathClass: CodexImageGenerationPathClass,
+  metadata: {
+    upstreamUrl?: string;
+    imageParams?: CodexImageGenerationLogParams;
+  },
+): ForwardLifecycleObserver {
+  const operation: CodexImageGenerationOperation =
+    pathClass === '/images/generations' ? 'generation' : 'edit';
+  const correlationId = randomUUID();
+  const base = {
+    correlationId,
+    operation,
+    method: 'POST' as const,
+    routeId,
+    target: 'custom-provider' as const,
+    pathClass,
+  };
+  let startedAt: number | null = null;
+  let settled = false;
+
+  const start = (): void => {
+    if (startedAt !== null) return;
+    startedAt = Date.now();
+    imageGenerationLog.info('codex_image_generation_forward_start', {
+      event: 'codex_image_generation_forward_start',
+      ...base,
+    });
+    if (
+      (
+        imageGenerationLog as typeof imageGenerationLog & { isDebugEnabled?: () => boolean }
+      ).isDebugEnabled?.() === true
+    ) {
+      imageGenerationLog.debug('codex_image_generation_forward_details', {
+        event: 'codex_image_generation_forward_details',
+        ...base,
+        ...(metadata.upstreamUrl ? { upstreamUrl: metadata.upstreamUrl } : {}),
+        ...(metadata.imageParams ? { imageParams: metadata.imageParams } : {}),
+      });
+    }
+  };
+  const durationMs = (): number => Math.max(0, Date.now() - (startedAt ?? Date.now()));
+
+  return {
+    onStart: start,
+    onComplete: (status) => {
+      if (settled || startedAt === null) return;
+      settled = true;
+      imageGenerationLog.info('codex_image_generation_forward_complete', {
+        event: 'codex_image_generation_forward_complete',
+        ...base,
+        status,
+        durationMs: durationMs(),
+        outcome: status >= 200 && status < 300 ? 'success' : 'http_error',
+      });
+    },
+    onFailure: (failure, status) => {
+      if (settled || startedAt === null) return;
+      settled = true;
+      imageGenerationLog.warn('codex_image_generation_forward_failure', {
+        event: 'codex_image_generation_forward_failure',
+        ...base,
+        ...(status === undefined ? {} : { status }),
+        durationMs: durationMs(),
+        outcome: imageGenerationTransportOutcome(failure),
+      });
+    },
+  };
+}
+
+function resolveCodexImageGenerationRoutingDecision(
+  body: unknown,
+  ctx: RequestTransformCtx,
+): RoutingDecision | null | Promise<RoutingDecision | null> | undefined {
+  const parsed = parseCodexImageGenerationPath(ctx.url);
+  if (parsed.kind === 'not-image-generation-route') return undefined;
+  if (parsed.kind === 'invalid' || ctx.method !== 'POST') {
+    return codexImageGenerationRouteFailure(400, 'invalid_image_generation_route');
+  }
+
+  const route = findCodexAppliedImageGenerationRoute(parsed.routeId);
+  if (!route) return codexImageGenerationRouteFailure(403, 'image_generation_route_unavailable');
+
+  const requestModel = isPlainObject(body) && typeof body.model === 'string' ? body.model : '';
+  if (
+    parsed.pathKind === 'responses' &&
+    (!requestModel || !route.supportedModels.includes(requestModel))
+  ) {
+    return codexImageGenerationRouteFailure(403, 'image_generation_model_mismatch');
+  }
+
+  const frozenRouting =
+    parsed.pathKind === 'responses' ? route.responseRoutingByModel[requestModel] : route.routing;
+  if (!frozenRouting) {
+    return codexImageGenerationRouteFailure(403, 'image_generation_model_mismatch');
+  }
+  const wireModel = parsed.pathKind === 'responses' ? requestModel : undefined;
+  return resolveFrozenProviderRouteDecision(
+    route.providerId,
+    frozenRouting,
+    route.credentialRevision,
+    'codex',
+    _readGatewayKey(),
+    wireModel,
+  )
+    .then((resolved) => {
+      if (!resolved?.decision || resolved.routing.disabled) {
+        return codexImageGenerationRouteFailure(503, 'image_generation_provider_unavailable');
+      }
+      const pathOverride =
+        parsed.pathKind === 'responses'
+          ? relativeProviderRequestPath(
+              resolved.routing.upstream,
+              resolved.routing.requestPath || parsed.upstreamPath,
+            )
+          : parsed.upstreamPath;
+      if (!pathOverride) {
+        return codexImageGenerationRouteFailure(502, 'image_generation_request_path_invalid');
+      }
+
+      const headerOverride = { ...(resolved.decision.headerOverride ?? {}) };
+      const actorHeader = Object.entries(resolved.decision.headerOverride ?? {}).find(
+        ([name]) => name.toLowerCase() === CODEX_IMAGE_GENERATION_ACTOR_HEADER,
+      );
+      for (const name of Object.keys(headerOverride)) {
+        if (name.toLowerCase() === CODEX_IMAGE_GENERATION_ACTOR_HEADER) {
+          delete headerOverride[name];
+        }
+      }
+      const headerDelete = new Set(
+        (resolved.decision.headerDelete ?? []).filter(
+          (name) => name.toLowerCase() !== CODEX_IMAGE_GENERATION_ACTOR_HEADER,
+        ),
+      );
+      if (actorHeader) {
+        headerOverride[CODEX_IMAGE_GENERATION_ACTOR_HEADER] = actorHeader[1];
+      } else {
+        headerDelete.add(CODEX_IMAGE_GENERATION_ACTOR_HEADER);
+      }
+
+      const imagePathClass = parsed.upstreamPath.split('?', 1)[0] as CodexImageGenerationPathClass;
+      const upstreamUrl = codexImageGenerationLogUpstreamUrl(
+        resolved.decision.upstreamOverride ?? resolved.routing.upstream,
+        pathOverride,
+      );
+
+      return {
+        ...resolved.decision,
+        pathOverride,
+        ...(Object.keys(headerOverride).length > 0 ? { headerOverride } : {}),
+        ...(headerDelete.size > 0 ? { headerDelete: [...headerDelete] } : {}),
+        ...(parsed.pathKind === 'images'
+          ? {
+              forwardLifecycle: createCodexImageGenerationForwardLifecycleObserver(
+                parsed.routeId,
+                imagePathClass,
+                {
+                  ...(upstreamUrl ? { upstreamUrl } : {}),
+                  ...(imagePathClass === '/images/generations'
+                    ? { imageParams: codexImageGenerationLogParams(body) }
+                    : {}),
+                },
+              ),
+            }
+          : {}),
+      };
+    })
+    .catch(() => codexImageGenerationRouteFailure(503, 'image_generation_provider_unavailable'));
+}
+
 export function createModelRoutingTransform(
   frozenAuthInjection?: CodexProxyAuthInjection,
 ): RoutingTransform {
   return (body, ctx) => {
+    const imageGenerationRoute = resolveCodexImageGenerationRoutingDecision(body, ctx);
+    if (imageGenerationRoute !== undefined) return imageGenerationRoute;
     // body 可能为 undefined —— 无 body 的 GET(典型: codex models-manager 的 `GET /models` 轮询,
     // 引擎现在也会对它跑路由)。不再因 body 非对象就短路;会话解析只依赖 headers,model 字段可选。
     const gatewayKey = _readGatewayKey();
@@ -2896,6 +3223,8 @@ function createCodexProxyHandle(
     // 默认上游 = gateway(含 /v1)；普通模型 + oauth 由 routingTransform 覆盖到 ChatGPT。
     upstream: () => buildCodexGatewayBaseUrl(),
     transformRequest: createTransformRequestChain(frozenAuthInjection, execAdapter),
+    routeOpaqueRequestBody: (ctx) => isCodexImageGenerationNamespacePath(ctx.url),
+    bypassRequestTransforms: (_body, ctx) => isCodexImageGenerationNamespacePath(ctx.url),
     transformResponse: (ctx) => execAdapter.createResponseTransform(ctx.reqId, {
       contentType: ctx.responseHeaders['content-type'] ?? '',
       contentEncoding: ctx.responseHeaders['content-encoding'] ?? '',

--- a/apps/desktop/src/main/maker-host/createDesktopProviderService.ts
+++ b/apps/desktop/src/main/maker-host/createDesktopProviderService.ts
@@ -74,6 +74,7 @@ import { migrateManagedOllamaProvider } from '../local-model-runtime/managedOlla
 import { migrateLocalConnectProvider } from '../../shared/localConnectHarness.js';
 import {
   setCustomProviderKeyReader,
+  setCustomProviderHeaderReader,
   setOAuthTokenReader,
   setProviderOAuthTokenReader,
   setProviderViewsReader,
@@ -91,7 +92,11 @@ import {
   addProviderSecretsClearedListener,
 } from '../secrets/providerSecretStore.js';
 import { readClaudeApiKey, desktopCodexAuthAdapter } from './auth-adapters.js';
-import { getProviderSecretStore, readCustomProviderKey } from '../secrets/providerSecretStore.js';
+import {
+  getProviderSecretStore,
+  readCustomProviderHeaders,
+  readCustomProviderKey,
+} from '../secrets/providerSecretStore.js';
 import { hasClaudeAiOAuth, hasClaudeAiOAuthUnbound } from './claude-credentials-store.js';
 import { getValidClaudeAiOAuth } from './claude-oauth-refresh.js';
 import {
@@ -429,6 +434,7 @@ export function ensureActiveCatalogLoaded(): Promise<Catalog> {
   // 接通自定义供应商密钥读取器（idempotent）：provider-route 用 setter 注入避免触电，
   // 这里在路由发生前（splash 早于任何 turn）把真实 safeStorage 读取接进去。
   setCustomProviderKeyReader(readCustomProviderKey);
+  setCustomProviderHeaderReader(readCustomProviderHeaders);
   setProviderOAuthTokenReader((providerId, agent, options) => {
     if (providerId === 'xai') return readXaiProviderOAuthToken(options);
     // Codex and Pi processes do not carry Claude Code's native OAuth credential.

--- a/apps/desktop/src/main/maker-host/custom-provider-store.ts
+++ b/apps/desktop/src/main/maker-host/custom-provider-store.ts
@@ -211,6 +211,12 @@ function validateRuntime(agent: string, rt: unknown): ValidationResult {
   if (r.requestPath !== undefined && !isProviderRequestPath(r.requestPath)) {
     return invalid(`runtime '${agent}' requestPath invalid`);
   }
+  if (r.supportsImageGeneration !== undefined && typeof r.supportsImageGeneration !== 'boolean') {
+    return invalid(`runtime '${agent}' supportsImageGeneration must be a boolean`);
+  }
+  if (r.supportsImageGeneration === true && agent !== 'codex') {
+    return invalid(`runtime '${agent}' supportsImageGeneration requires Codex`);
+  }
   if (!Array.isArray(r.models)) return invalid(`runtime '${agent}' models must be an array`);
   for (const m of r.models) {
     if (!m || typeof m !== 'object') return invalid(`runtime '${agent}' model must be an object`);
@@ -303,6 +309,20 @@ function validateRuntime(agent: string, rt: unknown): ValidationResult {
     if (!isAllowedWireProtocol(agent, r.wireProtocol)) {
       return invalid(`runtime '${agent}' wireProtocol invalid`);
     }
+  }
+  const defaultWireProtocol =
+    r.wireProtocol ?? (agent === 'codex' ? 'openai-responses' : undefined);
+  const hasResponsesRoute =
+    defaultWireProtocol === 'openai-responses' ||
+    r.models.some((model) => {
+      if (!model || typeof model !== 'object') return false;
+      const route = (model as Record<string, unknown>).route;
+      return route && typeof route === 'object' && !Array.isArray(route)
+        ? (route as Record<string, unknown>).wireProtocol === 'openai-responses'
+        : false;
+    });
+  if (r.supportsImageGeneration === true && !hasResponsesRoute) {
+    return invalid(`runtime '${agent}' supportsImageGeneration requires OpenAI Responses`);
   }
   if (r.headers !== undefined) {
     if (!r.headers || typeof r.headers !== 'object' || Array.isArray(r.headers)) {
@@ -544,6 +564,9 @@ function normalizeRuntime(
     });
   const out: CustomProviderRuntimeConfig = { baseUrl: rt.baseUrl.trim(), models };
   if (rt.wireProtocol) out.wireProtocol = rt.wireProtocol;
+  if (agent === 'codex' && rt.supportsImageGeneration === true) {
+    out.supportsImageGeneration = true;
+  }
   if (agent !== 'pi' && rt.requestPath && rt.requestPath.trim()) {
     out.requestPath = rt.requestPath.trim();
   }
@@ -743,6 +766,9 @@ function parseRuntimes(raw: string): Partial<Record<AgentKind, CustomProviderRun
       // 旧版把 Pi 的缺省协议解释为 Chat。新写入口已要求显式 wireProtocol；仅在读取
       // 历史持久化记录时把旧语义物化，避免运行时重新猜测或按供应商穷举兼容。
       entry.wireProtocol = 'openai-chat';
+    }
+    if (agent === 'codex' && r.supportsImageGeneration === true) {
+      entry.supportsImageGeneration = true;
     }
     if (agent !== 'pi' && isProviderRequestPath(r.requestPath)) {
       entry.requestPath = r.requestPath;

--- a/apps/desktop/src/main/maker-host/index.ts
+++ b/apps/desktop/src/main/maker-host/index.ts
@@ -163,6 +163,7 @@ import {
   setCodexProxyGatewayKeyReader,
   registerComposed as registerCodexProxyComposed,
   registerChildThread as registerCodexProxyChildThread,
+  setCodexAppliedImageGenerationRoutes,
   unregister as unregisterCodexProxyPrompt,
 } from './codex-proxy-host.js';
 import { createDesktopMcpProviders } from '../mcp-integrations/mcp-providers.js';
@@ -228,6 +229,11 @@ import {
   CODEX_CINDY_COMPACT_PROVIDER_ID,
   CODEX_OPENAI_COMPACT_PROVIDER_ID,
 } from './codex-gateway-config.js';
+import {
+  buildCodexImageGenerationProviderArgs,
+  deriveCodexImageGenerationRoutes,
+  toCodexImageGenerationHostRoutes,
+} from './codex-image-generation-route.js';
 import {
   buildCodexSubagentSpawnArgs,
   codexSubagentRouteUsesChatGptOAuth,
@@ -1434,6 +1440,18 @@ export function getMaker(): Maker {
         const endpoint = usesIsolatedProxy
           ? getCodexControlPlaneProxyEndpoint(authInjection)
           : getCodexProxyEndpoint();
+        const codexImageGenerationRoutes =
+          !usesIsolatedProxy && ready ? deriveCodexImageGenerationRoutes(getActiveCatalog()) : [];
+        if (!usesIsolatedProxy) {
+          // The proxy must follow the exact capability/routing snapshot frozen into
+          // this task Host, not the catalog that may already be ahead during a busy restart.
+          setCodexAppliedImageGenerationRoutes(codexImageGenerationRoutes);
+        }
+        const codexImageGenerationSpawn = buildCodexImageGenerationProviderArgs(
+          endpoint,
+          authInjection,
+          codexImageGenerationRoutes,
+        );
         const storedSubagentModelSettings = readSubagentModelSettings();
         const mainTaskCredentialMode = ctx.requestedCredentialMode ?? credentialMode;
         let subagentProviderViews: ProviderView[] | undefined;
@@ -1547,14 +1565,18 @@ export function getMaker(): Maker {
                 })
               : []),
             ...buildCodexProxySpawnArgs(endpoint, authInjection),
+            ...codexImageGenerationSpawn.extraArgs,
           ],
-          extraEnv: mcpExtraEnv,
+          extraEnv: { ...mcpExtraEnv, ...codexImageGenerationSpawn.extraEnv },
           ...(subagentModelFallback ? { subagentModelFallback } : {}),
           ...(subagentRoute ? { subagentRoute } : {}),
           ...(buildSessionMcpConfig ? { buildSessionMcpConfig } : {}),
           codexProxyActive: ready,
           codexOpenAiWebSocketsEnabled: useOAuthBearer && ready,
           codexSubagentRoutingProfile,
+          ...(codexImageGenerationRoutes.length > 0
+            ? { codexImageGenerationRoutes: toCodexImageGenerationHostRoutes(codexImageGenerationRoutes) }
+            : {}),
           codexBrowserUseAvailable: browserCompanionSpawnConfig.codexBrowserUseAvailable,
           ...(browserCompanion?.status === 'ready'
             ? {
@@ -2319,6 +2341,7 @@ export function registerPiAgentIfAvailable(): boolean {
  */
 export function resetMaker(): void {
   cancelCodexAuthModeChange();
+  setCodexAppliedImageGenerationRoutes([]);
   _maker = null;
   _registerPiAgent = null;
   _codexAgent = null;

--- a/apps/desktop/src/main/maker-host/provider-route.ts
+++ b/apps/desktop/src/main/maker-host/provider-route.ts
@@ -50,11 +50,28 @@ import { getSessionProvider } from './session-provider-store.js';
  */
 type CustomProviderKeyReader = (providerId: string, agent: AgentKind) => string | null;
 let customProviderKeyReader: CustomProviderKeyReader = () => null;
+type CustomProviderHeaderReader = (
+  providerId: string,
+  agent: AgentKind,
+) => Record<string, string> | null;
+let customProviderHeaderReader: CustomProviderHeaderReader = () => null;
 const providerRouteMutationCounts = new Map<string, number>();
+const providerRouteCredentialRevisions = new Map<string, number>();
+let nextProviderRouteCredentialRevision = 1;
+
+export type ProviderRouteMutationRelease = (() => void) & {
+  /** Publish the new non-sensitive credential generation before releasing the mutation gate. */
+  commit(): void;
+};
 
 /** host 启动期接通真实 safeStorage 读取（按 `provider_key_<id>_<agent>`，per-runtime 独立密钥）。 */
 export function setCustomProviderKeyReader(reader: CustomProviderKeyReader): void {
   customProviderKeyReader = reader;
+}
+
+/** Host-side secure header reader. Header values never enter Provider route snapshots. */
+export function setCustomProviderHeaderReader(reader: CustomProviderHeaderReader): void {
+  customProviderHeaderReader = reader;
 }
 
 /**
@@ -64,20 +81,37 @@ export function setCustomProviderKeyReader(reader: CustomProviderKeyReader): voi
  * endpoint 与新 key（或新 endpoint 与旧 key）拼成一次上游请求。计数使排队的多窗口
  * mutation 之间不会短暂恢复路由。
  */
-export function beginProviderRouteMutation(providerId: string): () => void {
+export function beginProviderRouteMutation(providerId: string): ProviderRouteMutationRelease {
   providerId = runtimeCustomProviderId(providerId);
+  const revision = nextProviderRouteCredentialRevision++;
   providerRouteMutationCounts.set(
     providerId,
     (providerRouteMutationCounts.get(providerId) ?? 0) + 1,
   );
   let finished = false;
-  return () => {
+  let committed = false;
+  const finish = (() => {
     if (finished) return;
     finished = true;
     const remaining = (providerRouteMutationCounts.get(providerId) ?? 1) - 1;
     if (remaining <= 0) providerRouteMutationCounts.delete(providerId);
     else providerRouteMutationCounts.set(providerId, remaining);
+  }) as ProviderRouteMutationRelease;
+  finish.commit = () => {
+    if (finished || committed) return;
+    committed = true;
+    providerRouteCredentialRevisions.set(providerId, revision);
   };
+  return finish;
+}
+
+/**
+ * Non-sensitive generation for endpoint-bound Provider credentials.
+ * Kept for the process lifetime (including after delete) so deleting and recreating the same id
+ * cannot make an old Host snapshot valid again.
+ */
+export function getProviderRouteCredentialRevision(providerId: string): number {
+  return providerRouteCredentialRevisions.get(runtimeCustomProviderId(providerId)) ?? 0;
 }
 
 export function isProviderRouteMutationInProgress(providerId: string): boolean {
@@ -499,7 +533,8 @@ export function providerRoutingForModel(
 
   // 鉴权、固定 headers 与模型 namespace 门继续继承 provider/runtime；请求路径不能在
   // 协议切换后误继承旧 runtime 的路径，只有模型覆盖显式声明时才带回。
-  const { requestPath: _runtimeRequestPath, ...inherited } = routing;
+  const inherited = { ...routing };
+  delete inherited.requestPath;
   return {
     ...inherited,
     upstream: agent === 'pi' ? piRoute!.baseUrl : modelRoute!.baseUrl,
@@ -728,6 +763,42 @@ export async function resolveProviderRouteDecision(
       ? { ...decision, pathOverride: routing.requestPath }
       : decision,
   };
+}
+
+/**
+ * Resolve a route descriptor frozen with a Codex Host spawn snapshot.
+ * Provider existence and credentials remain live safety boundaries: deleting the
+ * Provider or removing its credential fails closed instead of falling through.
+ */
+export async function resolveFrozenProviderRouteDecision(
+  providerId: string,
+  routing: RoutingDescriptor,
+  credentialRevision: number,
+  agent: AgentKind,
+  gatewayKey: string | null,
+  wireModel?: string,
+): Promise<ResolvedProviderRouteDecision | null> {
+  const id = providerId.trim();
+  if (!id || isProviderRouteMutationInProgress(id)) return null;
+  if (getProviderRouteCredentialRevision(id) !== credentialRevision) return null;
+  const provider = getActiveCatalog().providers.find((candidate) => candidate.id === id);
+  if (!provider || provider.source !== 'user' || !provider.agents.includes(agent)) return null;
+  if (!routingServesWireModel(routing, wireModel)) return null;
+  const { apiKey, oauthToken } = await readProviderRouteCredentials(provider, routing, agent);
+  const customHeaders = customProviderHeaderReader(storedCustomProviderId(provider.id), agent);
+  // A provider-OAuth reader may await refresh. Recheck both guards after the credential read so a
+  // concurrent endpoint/key/token mutation can only yield the old coherent decision or fail closed.
+  if (
+    isProviderRouteMutationInProgress(id) ||
+    getProviderRouteCredentialRevision(id) !== credentialRevision
+  ) {
+    return null;
+  }
+  const hasCustomHeaders = Boolean(customHeaders && Object.keys(customHeaders).length > 0);
+  if (routing.headerOverrideState && !hasCustomHeaders) return null;
+  const requestRouting = hasCustomHeaders ? { ...routing, headerOverride: customHeaders! } : routing;
+  const decision = buildRouteDecision(requestRouting, gatewayKey, agent, apiKey, oauthToken);
+  return { providerId: id, routing, decision };
 }
 
 export function resolveSessionRouteDecision(

--- a/apps/desktop/src/main/maker-ipc/__tests__/deferredCodexRestart.test.ts
+++ b/apps/desktop/src/main/maker-ipc/__tests__/deferredCodexRestart.test.ts
@@ -168,6 +168,34 @@ describe('DeferredCodexRestartService', () => {
     expect(service.isPending()).toBe(false);
   });
 
+  it('等待所有并行本地 Codex turn 都结束后只重启一次', async () => {
+    const restart = vi.fn(async () => {});
+    const busy = new Set(['codex-1', 'codex-2', 'codex-3']);
+    const { service } = createService({
+      restart,
+      hasBusyLocalCodexSession: () => busy.size > 0,
+    });
+    service.schedule('custom-provider-image-generation-enabled');
+
+    for (const sessionId of ['codex-1', 'codex-2']) {
+      busy.delete(sessionId);
+      service.onSessionSettled();
+      await vi.runOnlyPendingTimersAsync();
+      expect(restart).not.toHaveBeenCalled();
+      expect(service.isPending()).toBe(true);
+    }
+
+    busy.delete('codex-3');
+    service.onSessionSettled();
+    await vi.runOnlyPendingTimersAsync();
+    expect(restart).toHaveBeenCalledOnce();
+    expect(service.isPending()).toBe(false);
+
+    service.onSessionSettled();
+    await vi.runOnlyPendingTimersAsync();
+    expect(restart).toHaveBeenCalledOnce();
+  });
+
   it('restart 抛 busy(settle 与新 turn 竞态)时保留 pending 且不刷 warn, 之后重试成功', async () => {
     const restart = vi
       .fn<() => Promise<void>>()

--- a/apps/desktop/src/main/maker-ipc/__tests__/providerHandlers.test.ts
+++ b/apps/desktop/src/main/maker-ipc/__tests__/providerHandlers.test.ts
@@ -924,6 +924,702 @@ describe('provider:custom:* CRUD handlers', () => {
     expect(deps.broadcastChanged).toHaveBeenCalledOnce();
   });
 
+  it('requires a manual policy before creating an image Provider while local Codex turns are busy', async () => {
+    mountDb();
+    const harness = new IpcHarness();
+    let signature = '';
+    const refreshCatalog = vi.fn(async () => {
+      const saved = await getCustomProvider('new-image-provider');
+      signature = saved?.runtimes.codex?.supportsImageGeneration === true ? 'enabled' : '';
+    });
+    const refreshCodexImageGenerationHost = vi.fn(async () => {});
+    const storeCustomProviderKey = vi.fn(() => true);
+    const storeCustomProviderHeaders = vi.fn(() => true);
+    const interruptBusyLocalCodexTurns = vi.fn(async () => {});
+    registerProviderHandlers(
+      harness,
+      makeDeps({
+        refreshCatalog,
+        codexImageGenerationSignature: () => signature,
+        refreshCodexImageGenerationHost,
+        hasAppliedCodexImageGenerationProvider: () => false,
+        listBusyLocalCodexSessionIds: () => ['codex-1', 'codex-2', 'codex-3'],
+        interruptBusyLocalCodexTurns,
+        storeCustomProviderKey,
+        storeCustomProviderHeaders,
+      }),
+    );
+    const config: CustomProviderConfig = {
+      id: 'new-image-provider',
+      name: 'New image provider',
+      runtimes: {
+        codex: {
+          baseUrl: 'https://images.example/v1',
+          supportsImageGeneration: true,
+          headers: { 'x-test': 'header-value' },
+          models: [{ id: 'chat-model', name: 'Chat model' }],
+        },
+      },
+    };
+
+    await expect(
+      harness.invoke(
+        MAKER_INVOKE.PROVIDER_CUSTOM_CREATE,
+        config,
+        { codex: 'new-key' },
+        { source: 'manual-settings' },
+      ),
+    ).resolves.toEqual({
+      ok: false,
+      confirmationRequired: 'codex-image-generation-reload',
+      busyCount: 3,
+    });
+    expect(await getCustomProvider(config.id)).toBeNull();
+    expect(storeCustomProviderKey).not.toHaveBeenCalled();
+    expect(storeCustomProviderHeaders).not.toHaveBeenCalled();
+    expect(refreshCatalog).not.toHaveBeenCalled();
+    expect(refreshCodexImageGenerationHost).not.toHaveBeenCalled();
+
+    await expect(
+      harness.invoke(
+        MAKER_INVOKE.PROVIDER_CUSTOM_CREATE,
+        config,
+        { codex: 'new-key' },
+        {
+          source: 'manual-settings',
+          codexImageGenerationRestartPolicy: 'wait',
+        },
+      ),
+    ).resolves.toEqual({ ok: true });
+    expect((await getCustomProvider(config.id))?.runtimes.codex?.supportsImageGeneration).toBe(
+      true,
+    );
+    expect(storeCustomProviderKey).toHaveBeenCalledOnce();
+    expect(storeCustomProviderHeaders).toHaveBeenCalledOnce();
+    expect(interruptBusyLocalCodexTurns).not.toHaveBeenCalled();
+    expect(refreshCodexImageGenerationHost).toHaveBeenCalledOnce();
+  });
+
+  it('interrupts before creating and leaves no Provider when interruption fails', async () => {
+    mountDb();
+    const harness = new IpcHarness();
+    const order: string[] = [];
+    let failInterruption = true;
+    const interruptBusyLocalCodexTurns = vi.fn(async () => {
+      order.push('interrupted');
+      if (failInterruption) throw new Error('abort failed');
+    });
+    const refreshCatalog = vi.fn(async () => {
+      order.push('persisted');
+    });
+    const refreshCodexImageGenerationHost = vi.fn(async () => {
+      order.push('restarted');
+    });
+    registerProviderHandlers(
+      harness,
+      makeDeps({
+        refreshCatalog,
+        codexImageGenerationSignature: () => (order.includes('persisted') ? 'enabled' : ''),
+        refreshCodexImageGenerationHost,
+        hasAppliedCodexImageGenerationProvider: () => false,
+        listBusyLocalCodexSessionIds: () => ['local-codex-1', 'local-codex-2'],
+        interruptBusyLocalCodexTurns,
+      }),
+    );
+    const config: CustomProviderConfig = {
+      id: 'interrupt-create-provider',
+      name: 'Interrupt create provider',
+      runtimes: {
+        codex: {
+          baseUrl: 'https://images.example/v1',
+          supportsImageGeneration: true,
+          models: [{ id: 'chat-model', name: 'Chat model' }],
+        },
+      },
+    };
+
+    await expect(
+      harness.invoke(
+        MAKER_INVOKE.PROVIDER_CUSTOM_CREATE,
+        config,
+        {},
+        { source: 'manual-settings', codexImageGenerationRestartPolicy: 'interrupt' },
+      ),
+    ).rejects.toThrow('abort failed');
+    expect(await getCustomProvider(config.id)).toBeNull();
+    expect(order).toEqual(['interrupted']);
+
+    failInterruption = false;
+    order.length = 0;
+    await expect(
+      harness.invoke(
+        MAKER_INVOKE.PROVIDER_CUSTOM_CREATE,
+        config,
+        {},
+        { source: 'manual-settings', codexImageGenerationRestartPolicy: 'interrupt' },
+      ),
+    ).resolves.toEqual({ ok: true });
+    expect(order).toEqual(['interrupted', 'persisted', 'restarted']);
+    expect(interruptBusyLocalCodexTurns).toHaveBeenCalledTimes(2);
+    expect(refreshCodexImageGenerationHost).toHaveBeenCalledOnce();
+  });
+
+  it('rechecks create state and never blocks idle or programmatic creation', async () => {
+    mountDb();
+    const harness = new IpcHarness();
+    let busyIds = ['local-codex'];
+    let applied = false;
+    const interruptBusyLocalCodexTurns = vi.fn(async () => {});
+    registerProviderHandlers(
+      harness,
+      makeDeps({
+        hasAppliedCodexImageGenerationProvider: () => applied,
+        listBusyLocalCodexSessionIds: () => busyIds,
+        interruptBusyLocalCodexTurns,
+      }),
+    );
+    const config = (id: string): CustomProviderConfig => ({
+      id,
+      name: id,
+      runtimes: {
+        codex: {
+          baseUrl: 'https://images.example/v1',
+          supportsImageGeneration: true,
+          models: [{ id: 'chat-model', name: 'Chat model' }],
+        },
+      },
+    });
+
+    await expect(
+      harness.invoke(MAKER_INVOKE.PROVIDER_CUSTOM_CREATE, config('programmatic-create')),
+    ).resolves.toEqual({ ok: true });
+
+    busyIds = [];
+    await expect(
+      harness.invoke(
+        MAKER_INVOKE.PROVIDER_CUSTOM_CREATE,
+        config('idle-manual-create'),
+        {},
+        { source: 'manual-settings' },
+      ),
+    ).resolves.toEqual({ ok: true });
+
+    busyIds = ['local-codex'];
+    applied = true;
+    await expect(
+      harness.invoke(
+        MAKER_INVOKE.PROVIDER_CUSTOM_CREATE,
+        config('applied-race-create'),
+        {},
+        { source: 'manual-settings', codexImageGenerationRestartPolicy: 'interrupt' },
+      ),
+    ).resolves.toEqual({ ok: true });
+
+    applied = false;
+    busyIds = [];
+    await expect(
+      harness.invoke(
+        MAKER_INVOKE.PROVIDER_CUSTOM_CREATE,
+        config('idle-race-create'),
+        {},
+        { source: 'manual-settings', codexImageGenerationRestartPolicy: 'interrupt' },
+      ),
+    ).resolves.toEqual({ ok: true });
+    expect(interruptBusyLocalCodexTurns).not.toHaveBeenCalled();
+  });
+
+  it('refreshes the shared Codex host only when the image-generation snapshot changes', async () => {
+    mountDb();
+    const harness = new IpcHarness();
+    let signature = '';
+    const refreshCodexImageGenerationHost = vi.fn(async () => {});
+    registerProviderHandlers(
+      harness,
+      makeDeps({
+        codexImageGenerationSignature: () => signature,
+        refreshCatalog: vi.fn(async () => {
+          const saved = await getCustomProvider('image-provider');
+          const runtime = saved?.runtimes.codex;
+          const responseModels = runtime?.models
+            .filter(
+              (model) =>
+                (model.route?.wireProtocol ?? runtime.wireProtocol ?? 'openai-responses') ===
+                'openai-responses',
+            )
+            .map((model) => model.id)
+            .join('|');
+          signature = runtime?.supportsImageGeneration && responseModels
+            ? `${runtime.baseUrl}:${runtime.requestPath ?? ''}:${responseModels}`
+            : '';
+        }),
+        refreshCodexImageGenerationHost,
+      }),
+    );
+    await harness.invoke(MAKER_INVOKE.PROVIDER_CUSTOM_CREATE, {
+      id: 'image-provider',
+      name: 'Image Provider',
+      runtimes: {
+        codex: {
+          baseUrl: 'https://images.example/v1',
+          wireProtocol: 'openai-responses',
+          supportsImageGeneration: true,
+          models: [{ id: 'image-chat', name: 'Image Chat' }],
+        },
+      },
+    });
+    expect(refreshCodexImageGenerationHost).toHaveBeenCalledOnce();
+    refreshCodexImageGenerationHost.mockClear();
+    await harness.invoke(MAKER_INVOKE.PROVIDER_CUSTOM_UPDATE, {
+      id: 'image-provider',
+      name: 'Image Provider renamed',
+      runtimes: {
+        codex: {
+          baseUrl: 'https://renamed.example/v1',
+          wireProtocol: 'openai-responses',
+          supportsImageGeneration: true,
+          models: [{ id: 'image-chat', name: 'Image Chat' }],
+        },
+      },
+    });
+    expect(refreshCodexImageGenerationHost).toHaveBeenCalledOnce();
+    refreshCodexImageGenerationHost.mockClear();
+    await harness.invoke(MAKER_INVOKE.PROVIDER_CUSTOM_UPDATE, {
+      id: 'image-provider',
+      name: 'Image Provider renamed',
+      runtimes: {
+        codex: {
+          baseUrl: 'https://renamed.example/v1',
+          wireProtocol: 'openai-responses',
+          models: [{ id: 'image-chat', name: 'Image Chat' }],
+        },
+      },
+    });
+    expect(refreshCodexImageGenerationHost).toHaveBeenCalledOnce();
+  });
+
+  it('requires an explicit manual-save policy before enabling a missing image identity while three local Codex turns are busy', async () => {
+    mountDb();
+    const harness = new IpcHarness();
+    let signature = '';
+    const refreshCatalog = vi.fn(async () => {
+      const saved = await getCustomProvider('manual-image-provider');
+      signature = saved?.runtimes.codex?.supportsImageGeneration === true ? 'enabled' : '';
+    });
+    const refreshCodexImageGenerationHost = vi.fn(async () => {});
+    const interruptBusyLocalCodexTurns = vi.fn(async () => {});
+    const deps = makeDeps({
+      refreshCatalog,
+      codexImageGenerationSignature: () => signature,
+      refreshCodexImageGenerationHost,
+      hasAppliedCodexImageGenerationProvider: () => false,
+      listBusyLocalCodexSessionIds: () => ['codex-1', 'codex-2', 'codex-3'],
+      interruptBusyLocalCodexTurns,
+    });
+    registerProviderHandlers(harness, deps);
+    const disabled: CustomProviderConfig = {
+      id: 'manual-image-provider',
+      name: 'Manual image provider',
+      runtimes: {
+        codex: {
+          baseUrl: 'https://images.example/v1',
+          wireProtocol: 'openai-responses',
+          models: [{ id: 'chat-model', name: 'Chat model' }],
+        },
+      },
+    };
+    await harness.invoke(MAKER_INVOKE.PROVIDER_CUSTOM_CREATE, disabled);
+    refreshCatalog.mockClear();
+    refreshCodexImageGenerationHost.mockClear();
+    const enabled: CustomProviderConfig = {
+      ...disabled,
+      runtimes: {
+        codex: { ...disabled.runtimes.codex!, supportsImageGeneration: true },
+      },
+    };
+
+    await expect(
+      harness.invoke(
+        MAKER_INVOKE.PROVIDER_CUSTOM_UPDATE,
+        enabled,
+        {},
+        { source: 'manual-settings' },
+      ),
+    ).resolves.toEqual({
+      ok: false,
+      confirmationRequired: 'codex-image-generation-reload',
+      busyCount: 3,
+    });
+    expect((await getCustomProvider(disabled.id))?.runtimes.codex?.supportsImageGeneration).not.toBe(
+      true,
+    );
+    expect(refreshCatalog).not.toHaveBeenCalled();
+    expect(refreshCodexImageGenerationHost).not.toHaveBeenCalled();
+    expect(interruptBusyLocalCodexTurns).not.toHaveBeenCalled();
+
+    await expect(
+      harness.invoke(
+        MAKER_INVOKE.PROVIDER_CUSTOM_UPDATE,
+        enabled,
+        {},
+        {
+          source: 'manual-settings',
+          codexImageGenerationRestartPolicy: 'wait',
+        },
+      ),
+    ).resolves.toEqual({ ok: true });
+    expect((await getCustomProvider(disabled.id))?.runtimes.codex?.supportsImageGeneration).toBe(
+      true,
+    );
+    expect(interruptBusyLocalCodexTurns).not.toHaveBeenCalled();
+    expect(refreshCodexImageGenerationHost).toHaveBeenCalledOnce();
+  });
+
+  it('interrupt policy stops busy local Codex turns before one image Host refresh', async () => {
+    mountDb();
+    const harness = new IpcHarness();
+    let signature = '';
+    let busyIds = ['local-codex-1', 'local-codex-2'];
+    const order: string[] = [];
+    const refreshCatalog = vi.fn(async () => {
+      signature = 'enabled';
+      order.push('persisted');
+    });
+    const refreshCodexImageGenerationHost = vi.fn(async () => {
+      order.push('restarted');
+    });
+    const interruptBusyLocalCodexTurns = vi.fn(async () => {
+      order.push('interrupted');
+      busyIds = [];
+    });
+    registerProviderHandlers(
+      harness,
+      makeDeps({
+        refreshCatalog,
+        codexImageGenerationSignature: () => signature,
+        refreshCodexImageGenerationHost,
+        hasAppliedCodexImageGenerationProvider: () => false,
+        listBusyLocalCodexSessionIds: () => busyIds,
+        interruptBusyLocalCodexTurns,
+      }),
+    );
+    const disabled: CustomProviderConfig = {
+      id: 'interrupt-image-provider',
+      name: 'Interrupt image provider',
+      runtimes: {
+        codex: {
+          baseUrl: 'https://images.example/v1',
+          models: [{ id: 'chat-model', name: 'Chat model' }],
+        },
+      },
+    };
+    await harness.invoke(MAKER_INVOKE.PROVIDER_CUSTOM_CREATE, disabled);
+    order.length = 0;
+    signature = '';
+    refreshCodexImageGenerationHost.mockClear();
+
+    await expect(
+      harness.invoke(
+        MAKER_INVOKE.PROVIDER_CUSTOM_UPDATE,
+        {
+          ...disabled,
+          runtimes: {
+            codex: { ...disabled.runtimes.codex!, supportsImageGeneration: true },
+          },
+        },
+        {},
+        {
+          source: 'manual-settings',
+          codexImageGenerationRestartPolicy: 'interrupt',
+        },
+      ),
+    ).resolves.toEqual({ ok: true });
+    expect(interruptBusyLocalCodexTurns).toHaveBeenCalledOnce();
+    expect(refreshCodexImageGenerationHost).toHaveBeenCalledOnce();
+    expect(order).toEqual(['interrupted', 'persisted', 'restarted']);
+  });
+
+  it('rechecks busy/applied state on confirmation and does not persist when interruption fails', async () => {
+    mountDb();
+    const harness = new IpcHarness();
+    let busyIds = ['local-codex'];
+    let identityApplied = false;
+    const interruptBusyLocalCodexTurns = vi.fn(async () => {
+      throw new Error('abort failed');
+    });
+    registerProviderHandlers(
+      harness,
+      makeDeps({
+        hasAppliedCodexImageGenerationProvider: () => identityApplied,
+        listBusyLocalCodexSessionIds: () => busyIds,
+        interruptBusyLocalCodexTurns,
+      }),
+    );
+    const disabled: CustomProviderConfig = {
+      id: 'confirmation-race-provider',
+      name: 'Confirmation race provider',
+      runtimes: {
+        codex: {
+          baseUrl: 'https://images.example/v1',
+          models: [{ id: 'chat-model', name: 'Chat model' }],
+        },
+      },
+    };
+    const enabled: CustomProviderConfig = {
+      ...disabled,
+      runtimes: {
+        codex: { ...disabled.runtimes.codex!, supportsImageGeneration: true },
+      },
+    };
+    await harness.invoke(MAKER_INVOKE.PROVIDER_CUSTOM_CREATE, disabled);
+
+    await expect(
+      harness.invoke(
+        MAKER_INVOKE.PROVIDER_CUSTOM_UPDATE,
+        enabled,
+        {},
+        { source: 'manual-settings', codexImageGenerationRestartPolicy: 'interrupt' },
+      ),
+    ).rejects.toThrow('abort failed');
+    expect((await getCustomProvider(disabled.id))?.runtimes.codex?.supportsImageGeneration).not.toBe(
+      true,
+    );
+
+    interruptBusyLocalCodexTurns.mockClear();
+    busyIds = [];
+    await expect(
+      harness.invoke(
+        MAKER_INVOKE.PROVIDER_CUSTOM_UPDATE,
+        enabled,
+        {},
+        { source: 'manual-settings', codexImageGenerationRestartPolicy: 'interrupt' },
+      ),
+    ).resolves.toEqual({ ok: true });
+    expect(interruptBusyLocalCodexTurns).not.toHaveBeenCalled();
+
+    await harness.invoke(MAKER_INVOKE.PROVIDER_CUSTOM_UPDATE, disabled);
+    busyIds = ['local-codex'];
+    identityApplied = true;
+    await expect(
+      harness.invoke(
+        MAKER_INVOKE.PROVIDER_CUSTOM_UPDATE,
+        enabled,
+        {},
+        { source: 'manual-settings', codexImageGenerationRestartPolicy: 'interrupt' },
+      ),
+    ).resolves.toEqual({ ok: true });
+    expect(interruptBusyLocalCodexTurns).not.toHaveBeenCalled();
+  });
+
+  it('does not block programmatic updates, idle manual saves, or a manual save whose identity is already applied', async () => {
+    mountDb();
+    const harness = new IpcHarness();
+    let busyIds = ['local-codex'];
+    let identityApplied = false;
+    const interruptBusyLocalCodexTurns = vi.fn(async () => {});
+    registerProviderHandlers(
+      harness,
+      makeDeps({
+        hasAppliedCodexImageGenerationProvider: () => identityApplied,
+        listBusyLocalCodexSessionIds: () => busyIds,
+        interruptBusyLocalCodexTurns,
+      }),
+    );
+    const base = (id: string): CustomProviderConfig => ({
+      id,
+      name: id,
+      runtimes: {
+        codex: {
+          baseUrl: 'https://images.example/v1',
+          models: [{ id: 'chat-model', name: 'Chat model' }],
+        },
+      },
+    });
+
+    const programmatic = base('programmatic-image-provider');
+    await harness.invoke(MAKER_INVOKE.PROVIDER_CUSTOM_CREATE, programmatic);
+    await expect(
+      harness.invoke(MAKER_INVOKE.PROVIDER_CUSTOM_UPDATE, {
+        ...programmatic,
+        runtimes: {
+          codex: { ...programmatic.runtimes.codex!, supportsImageGeneration: true },
+        },
+      }),
+    ).resolves.toEqual({ ok: true });
+
+    const idle = base('idle-image-provider');
+    await harness.invoke(MAKER_INVOKE.PROVIDER_CUSTOM_CREATE, idle);
+    busyIds = [];
+    await expect(
+      harness.invoke(
+        MAKER_INVOKE.PROVIDER_CUSTOM_UPDATE,
+        {
+          ...idle,
+          runtimes: { codex: { ...idle.runtimes.codex!, supportsImageGeneration: true } },
+        },
+        {},
+        { source: 'manual-settings' },
+      ),
+    ).resolves.toEqual({ ok: true });
+
+    const applied = base('applied-image-provider');
+    await harness.invoke(MAKER_INVOKE.PROVIDER_CUSTOM_CREATE, applied);
+    busyIds = ['local-codex'];
+    identityApplied = true;
+    await expect(
+      harness.invoke(
+        MAKER_INVOKE.PROVIDER_CUSTOM_UPDATE,
+        {
+          ...applied,
+          runtimes: { codex: { ...applied.runtimes.codex!, supportsImageGeneration: true } },
+        },
+        {},
+        { source: 'manual-settings' },
+      ),
+    ).resolves.toEqual({ ok: true });
+    expect(interruptBusyLocalCodexTurns).not.toHaveBeenCalled();
+
+    await expect(
+      harness.invoke(
+        MAKER_INVOKE.PROVIDER_CUSTOM_UPDATE,
+        {
+          ...applied,
+          runtimes: { codex: { ...applied.runtimes.codex!, supportsImageGeneration: true } },
+        },
+        {},
+        { source: 'manual-settings' },
+      ),
+    ).resolves.toEqual({ ok: true });
+    await expect(
+      harness.invoke(
+        MAKER_INVOKE.PROVIDER_CUSTOM_UPDATE,
+        applied,
+        {},
+        { source: 'manual-settings' },
+      ),
+    ).resolves.toEqual({ ok: true });
+    expect(interruptBusyLocalCodexTurns).not.toHaveBeenCalled();
+  });
+
+  it('rebuilds image routes for key/OAuth generations but not model-only catalog edits', async () => {
+    mountDb();
+    const harness = new IpcHarness();
+    let credentialRevision = 0;
+    let imageCapability = false;
+    const headers = new Map<AgentKind, Record<string, string>>();
+    const refreshCodexImageGenerationHost = vi.fn(async () => {});
+    const beginRouteMutation = vi.fn(() => {
+      const release = (() => {}) as (() => void) & { commit: () => void };
+      release.commit = () => {
+        credentialRevision += 1;
+      };
+      return release;
+    });
+    const refreshCatalog = vi.fn(async () => {
+      const saved = await getCustomProvider('credential-image-provider');
+      imageCapability = saved?.runtimes.codex?.supportsImageGeneration === true;
+    });
+    const deps = makeDeps({
+      beginRouteMutation,
+      refreshCatalog,
+      codexImageGenerationSignature: () =>
+        imageCapability ? `image-route-revision:${credentialRevision}` : '',
+      refreshCodexImageGenerationHost,
+      readCustomProviderKeyForMutation: vi.fn(() => 'old-key'),
+      storeCustomProviderKey: vi.fn(() => true),
+      readCustomProviderHeadersForMutation: vi.fn(
+        (_providerId, agent: AgentKind) => headers.get(agent) ?? null,
+      ),
+      storeCustomProviderHeaders: vi.fn((_providerId, agent: AgentKind, value) => {
+        headers.set(agent, { ...value });
+        return true;
+      }),
+      removeCustomProviderHeaders: vi.fn((_providerId, agent: AgentKind) => {
+        headers.delete(agent);
+        return { success: true };
+      }),
+      oauthLogin: vi.fn(async () => ({ ok: true })),
+      oauthLogout: vi.fn(async () => {}),
+    });
+    registerProviderHandlers(harness, deps);
+    const imageConfig: CustomProviderConfig = {
+      id: 'credential-image-provider',
+      name: 'Credential Image Provider',
+      runtimes: {
+        codex: {
+          baseUrl: 'https://credential-images.example/v1',
+          wireProtocol: 'openai-responses',
+          supportsImageGeneration: true,
+          headers: { Authorization: 'Bearer old-header-secret' },
+          models: [{ id: 'image-chat', name: 'Image Chat' }],
+        },
+      },
+    };
+
+    await harness.invoke(MAKER_INVOKE.PROVIDER_CUSTOM_CREATE, imageConfig, { codex: 'old-key' });
+    expect(credentialRevision).toBe(1);
+    refreshCodexImageGenerationHost.mockClear();
+    await harness.invoke(MAKER_INVOKE.PROVIDER_CUSTOM_UPDATE, imageConfig, { codex: 'new-key' });
+    expect(refreshCodexImageGenerationHost).toHaveBeenCalledOnce();
+    expect(credentialRevision).toBe(2);
+
+    refreshCodexImageGenerationHost.mockClear();
+    const newHeaderConfig: CustomProviderConfig = {
+      ...imageConfig,
+      runtimes: {
+        codex: {
+          ...imageConfig.runtimes.codex!,
+          headers: { Authorization: 'Bearer new-header-secret' },
+        },
+      },
+    };
+    await harness.invoke(MAKER_INVOKE.PROVIDER_CUSTOM_UPDATE, newHeaderConfig);
+    expect(headers.get('codex')).toEqual({ Authorization: 'Bearer new-header-secret' });
+    expect(refreshCodexImageGenerationHost).toHaveBeenCalledOnce();
+    expect(credentialRevision).toBe(3);
+
+    refreshCodexImageGenerationHost.mockClear();
+    const runtimeWithoutHeaders = { ...newHeaderConfig.runtimes.codex! };
+    delete runtimeWithoutHeaders.headers;
+    await harness.invoke(MAKER_INVOKE.PROVIDER_CUSTOM_UPDATE, {
+      ...newHeaderConfig,
+      name: 'Model metadata only',
+      runtimes: {
+        codex: {
+          ...runtimeWithoutHeaders,
+          models: [{ id: 'image-chat', name: 'Renamed Image Chat' }],
+        },
+      },
+    });
+    expect(refreshCodexImageGenerationHost).not.toHaveBeenCalled();
+    expect(credentialRevision).toBe(3);
+
+    refreshCodexImageGenerationHost.mockClear();
+    await harness.invoke(MAKER_INVOKE.PROVIDER_CUSTOM_UPDATE, {
+      ...newHeaderConfig,
+      runtimes: {
+        codex: {
+          ...newHeaderConfig.runtimes.codex!,
+          baseUrl: 'https://new-credential-images.example/v1',
+        },
+      },
+    });
+    expect(refreshCodexImageGenerationHost).toHaveBeenCalledOnce();
+    expect(credentialRevision).toBe(4);
+
+    refreshCodexImageGenerationHost.mockClear();
+    await harness.invoke(MAKER_INVOKE.PROVIDER_OAUTH_LOGIN, imageConfig.id);
+    expect(refreshCodexImageGenerationHost).toHaveBeenCalledOnce();
+    expect(credentialRevision).toBe(5);
+    refreshCodexImageGenerationHost.mockClear();
+    await harness.invoke(MAKER_INVOKE.PROVIDER_OAUTH_LOGOUT, imageConfig.id);
+    expect(refreshCodexImageGenerationHost).toHaveBeenCalledOnce();
+    expect(credentialRevision).toBe(6);
+    expect(deps.codexImageGenerationSignature?.()).not.toContain('old-key');
+    expect(deps.codexImageGenerationSignature?.()).not.toContain('new-key');
+    expect(deps.codexImageGenerationSignature?.()).not.toContain('old-header-secret');
+    expect(deps.codexImageGenerationSignature?.()).not.toContain('new-header-secret');
+  });
+
   it('accepts and stages a Pi-native runtime key', async () => {
     mountDb();
     const harness = new IpcHarness();

--- a/apps/desktop/src/main/maker-ipc/__tests__/runtimeSetModel.test.ts
+++ b/apps/desktop/src/main/maker-ipc/__tests__/runtimeSetModel.test.ts
@@ -6,6 +6,10 @@ import {
   setSessionProvider,
 } from '../../maker-host/session-provider-store.js';
 import {
+  setCodexAppliedImageGenerationRoutes,
+  type CodexImageGenerationRoute,
+} from '../../maker-host/codex-image-generation-route.js';
+import {
   applyRuntimeSetModelChange,
   isRemoteModelSwitchRouteChangeError,
   type RuntimeSetModelMaker,
@@ -32,6 +36,7 @@ const touchedSessions = new Set<string>();
 
 afterEach(() => {
   sessionProviderWriteObserver.current = null;
+  setCodexAppliedImageGenerationRoutes([]);
   for (const sessionId of touchedSessions) {
     clearSessionProvider(sessionId);
   }
@@ -42,6 +47,35 @@ function rememberSession(sessionId: string): string {
   touchedSessions.add(sessionId);
   return sessionId;
 }
+
+const imageGenerationRoutes: readonly CodexImageGenerationRoute[] = [
+  {
+    providerId: 'provider-a',
+    routeId: 'a'.repeat(20),
+    modelProviderId: `cindy_imagegen_${'a'.repeat(20)}`,
+    supportedModels: ['shared-model', 'a-alt-model'],
+    routing: {
+      upstream: 'https://a.invalid/v1',
+      wireProtocol: 'openai-responses',
+      authStrategy: 'none',
+    },
+    responseRoutingByModel: {},
+    credentialRevision: 1,
+  },
+  {
+    providerId: 'provider-b',
+    routeId: 'b'.repeat(20),
+    modelProviderId: `cindy_imagegen_${'b'.repeat(20)}`,
+    supportedModels: ['shared-model'],
+    routing: {
+      upstream: 'https://b.invalid/v1',
+      wireProtocol: 'openai-responses',
+      authStrategy: 'none',
+    },
+    responseRoutingByModel: {},
+    credentialRevision: 1,
+  },
+];
 
 describe('isRemoteModelSwitchRouteChangeError', () => {
   it('recognizes both IPC codes and remote daemon message markers', () => {
@@ -60,6 +94,111 @@ describe('isRemoteModelSwitchRouteChangeError', () => {
 });
 
 describe('applyRuntimeSetModelChange', () => {
+  async function applyImageGenerationRouteChange(input: {
+    testId: string;
+    currentThreadModelProviderId: string;
+    currentProviderId: string;
+    currentModel: string;
+    nextProviderId: string;
+    nextModel: string;
+  }) {
+    setCodexAppliedImageGenerationRoutes(imageGenerationRoutes);
+    const sessionId = rememberSession(input.testId);
+    setSessionProvider(sessionId, input.currentProviderId);
+    const setModel = vi.fn(async () => {});
+    const closeSession = vi.fn(async () => {});
+    const maker: RuntimeSetModelMaker = {
+      getSession: () => ({
+        agentKind: 'codex',
+        remoteHostId: null,
+        codexProxyActive: true,
+        codexThreadModelProviderId: input.currentThreadModelProviderId,
+        model: input.currentModel,
+        setModel,
+      }),
+      listActiveSessions: () => [
+        { id: sessionId, agentKind: 'codex', remoteHostId: null, isTurnRunning: () => false },
+      ],
+      closeSession,
+    };
+
+    const result = await applyRuntimeSetModelChange({
+      maker,
+      sessionId,
+      model: input.nextModel,
+      providerId: input.nextProviderId,
+    });
+    return { result, sessionId, setModel, closeSession };
+  }
+
+  it('keeps one dynamic identity across eligible Responses models of the same Provider', async () => {
+    const routeA = imageGenerationRoutes[0]!;
+    const result = await applyImageGenerationRouteChange({
+      testId: 'imagegen-same-provider',
+      currentThreadModelProviderId: routeA.modelProviderId,
+      currentProviderId: routeA.providerId,
+      currentModel: 'shared-model',
+      nextProviderId: routeA.providerId,
+      nextModel: 'a-alt-model',
+    });
+
+    expect(result.closeSession).not.toHaveBeenCalled();
+    expect(result.setModel).toHaveBeenCalledWith('a-alt-model', { providerId: 'provider-a' });
+  });
+
+  it.each([
+    {
+      name: 'dynamic to non-Responses',
+      currentIdentity: imageGenerationRoutes[0]!.modelProviderId,
+      currentProvider: 'provider-a',
+      targetProvider: 'provider-a',
+      targetModel: 'chat-model',
+    },
+    {
+      name: 'ordinary to dynamic',
+      currentIdentity: 'cindy_gateway',
+      currentProvider: 'ordinary-provider',
+      targetProvider: 'provider-a',
+      targetModel: 'shared-model',
+    },
+    {
+      name: 'dynamic Provider A to Provider B with the same model id',
+      currentIdentity: imageGenerationRoutes[0]!.modelProviderId,
+      currentProvider: 'provider-a',
+      targetProvider: 'provider-b',
+      targetModel: 'shared-model',
+    },
+  ])('closes the live thread when crossing $name', async (testCase) => {
+    const result = await applyImageGenerationRouteChange({
+      testId: `imagegen-cross-${testCase.name}`,
+      currentThreadModelProviderId: testCase.currentIdentity,
+      currentProviderId: testCase.currentProvider,
+      currentModel: 'shared-model',
+      nextProviderId: testCase.targetProvider,
+      nextModel: testCase.targetModel,
+    });
+
+    expect(result.closeSession).toHaveBeenCalledWith(result.sessionId);
+    expect(result.setModel).not.toHaveBeenCalled();
+    expect(getSessionProvider(result.sessionId)).toBe(testCase.targetProvider);
+  });
+
+  it('does not rebuild an unrelated ordinary Codex route', async () => {
+    const result = await applyImageGenerationRouteChange({
+      testId: 'imagegen-ordinary-control',
+      currentThreadModelProviderId: 'cindy_gateway',
+      currentProviderId: 'ordinary-provider',
+      currentModel: 'ordinary-model',
+      nextProviderId: 'ordinary-provider',
+      nextModel: 'ordinary-model-next',
+    });
+
+    expect(result.closeSession).not.toHaveBeenCalled();
+    expect(result.setModel).toHaveBeenCalledWith('ordinary-model-next', {
+      providerId: 'ordinary-provider',
+    });
+  });
+
   it('rolls back provider route when live setModel rejects', async () => {
     const sessionId = rememberSession('runtime-set-model-rollback');
     setSessionProvider(sessionId, 'xd');

--- a/apps/desktop/src/main/maker-ipc/providerHandlers.ts
+++ b/apps/desktop/src/main/maker-ipc/providerHandlers.ts
@@ -27,6 +27,11 @@ import {
 
 import type { LocalCliDetection } from '../../shared/localCliDetect.js';
 import { MANAGED_OLLAMA_PROVIDER_ID } from '../../shared/localModelRuntime.js';
+import type {
+  CodexImageGenerationRestartPolicy,
+  CustomProviderUpdateOptions,
+  CustomProviderUpdateResult,
+} from '../../shared/customProviderUpdate.js';
 import { notifyManagedOllamaRemoved } from '../local-model-runtime/ipc.js';
 import { isIpcError } from '../../shared/ipc-errors.js';
 import type {
@@ -153,6 +158,23 @@ function parseRuntimeKeys(input: unknown): RuntimeKeys | null {
   return Object.fromEntries(entries) as RuntimeKeys;
 }
 
+function parseCustomProviderUpdateOptions(input: unknown): CustomProviderUpdateOptions | null {
+  if (input === undefined) return {};
+  if (!input || typeof input !== 'object' || Array.isArray(input)) return null;
+  const entries = Object.entries(input as Record<string, unknown>);
+  if (entries.some(([key]) => key !== 'source' && key !== 'codexImageGenerationRestartPolicy'))
+    return null;
+  const source = (input as Record<string, unknown>).source;
+  if (source !== undefined && source !== 'manual-settings') return null;
+  const policy = (input as Record<string, unknown>).codexImageGenerationRestartPolicy;
+  if (policy === undefined) return source === 'manual-settings' ? { source } : {};
+  if (policy !== 'wait' && policy !== 'interrupt') return null;
+  return {
+    ...(source === 'manual-settings' ? { source } : {}),
+    codexImageGenerationRestartPolicy: policy,
+  };
+}
+
 function sortedStringRecord(
   value: Record<string, string> | undefined,
 ): Record<string, string> | undefined {
@@ -220,9 +242,19 @@ export interface ProviderHandlerDeps {
    * 配置、secret 与 active catalog 切换期间暂停该 provider 的新请求；返回幂等 release。
    * 生产 = beginProviderRouteMutation。
    */
-  beginRouteMutation(providerId: string): () => void;
+  beginRouteMutation(providerId: string): (() => void) & { commit?: () => void };
   /** CRUD 成功后广播变更（生产 = 向所有窗口 send PROVIDER_CHANGED）。 */
   broadcastChanged(): void;
+  /** Current custom Codex image-generation capability snapshot (contains no credentials). */
+  codexImageGenerationSignature?(): string;
+  /** Rebuild the shared Codex host when that spawn-time snapshot changes. */
+  refreshCodexImageGenerationHost?(): Promise<void>;
+  /** Whether the running Host snapshot already contains this custom Provider identity. */
+  hasAppliedCodexImageGenerationProvider?(providerId: string): boolean;
+  /** Busy local Codex turns only; remote Codex and other agents are excluded. */
+  listBusyLocalCodexSessionIds?(): string[];
+  /** Stop every currently busy local Codex turn before an immediate shared-Host reload. */
+  interruptBusyLocalCodexTurns?(): Promise<void>;
   /** Current selectable catalog ids, used to validate visible provider order entries. */
   listProviderIds(): string[];
   /** Merge the currently visible order into the persisted observed-provider order. */
@@ -587,9 +619,10 @@ export function registerProviderHandlers(
   };
   const withProviderConfigMutation = async <T>(
     providerId: string,
-    operation: () => Promise<T>,
+    operation: (commitRouteMutation: () => void) => Promise<T>,
   ): Promise<T> => {
     const finishRouteMutation = deps.beginRouteMutation(providerId);
+    const commitRouteMutation = (): void => finishRouteMutation.commit?.();
     const previous = providerConfigMutationTails.get(providerId) ?? Promise.resolve();
     let release!: () => void;
     const gate = new Promise<void>((resolve) => {
@@ -601,7 +634,7 @@ export function registerProviderHandlers(
     beginProviderConfigMutation(providerId);
     try {
       await previous.catch(() => undefined);
-      return await operation();
+      return await operation(commitRouteMutation);
     } finally {
       release();
       if (providerConfigMutationTails.get(providerId) === tail) {
@@ -668,6 +701,7 @@ export function registerProviderHandlers(
   const stageProviderKeys = (
     providerId: string,
     mutations: readonly KeyMutation[],
+    markCredentialStateUncertain?: () => void,
   ): KeySnapshot[] => {
     const snapshots: KeySnapshot[] = [];
     try {
@@ -690,6 +724,7 @@ export function registerProviderHandlers(
       return snapshots;
     } catch (error) {
       if (!restoreProviderKeys(providerId, snapshots)) {
+        markCredentialStateUncertain?.();
         throwIpcError('INTERNAL', 'provider credential update failed and could not be rolled back');
       }
       throw error;
@@ -762,6 +797,7 @@ export function registerProviderHandlers(
   const stageProviderHeaders = (
     providerId: string,
     mutations: readonly HeaderMutation[],
+    markCredentialStateUncertain?: () => void,
   ): HeaderSnapshot[] => {
     const snapshots: HeaderSnapshot[] = [];
     try {
@@ -783,6 +819,7 @@ export function registerProviderHandlers(
       return snapshots;
     } catch (error) {
       if (!restoreProviderHeaders(providerId, snapshots)) {
+        markCredentialStateUncertain?.();
         throwIpcError('INTERNAL', 'provider header update failed and could not be rolled back');
       }
       throw error;
@@ -792,15 +829,21 @@ export function registerProviderHandlers(
     providerId: string,
     keyMutations: readonly KeyMutation[],
     headerMutations: readonly HeaderMutation[],
+    markCredentialStateUncertain?: () => void,
   ): { keySnapshots: KeySnapshot[]; headerSnapshots: HeaderSnapshot[] } => {
-    const keySnapshots = stageProviderKeys(providerId, keyMutations);
+    const keySnapshots = stageProviderKeys(providerId, keyMutations, markCredentialStateUncertain);
     try {
       return {
         keySnapshots,
-        headerSnapshots: stageProviderHeaders(providerId, headerMutations),
+        headerSnapshots: stageProviderHeaders(
+          providerId,
+          headerMutations,
+          markCredentialStateUncertain,
+        ),
       };
     } catch (error) {
       if (!restoreProviderKeys(providerId, keySnapshots)) {
+        markCredentialStateUncertain?.();
         throwIpcError('INTERNAL', 'provider credential update failed and could not be rolled back');
       }
       throw error;
@@ -929,8 +972,20 @@ export function registerProviderHandlers(
   );
 
   // CRUD 成功后统一收尾：刷新 active-catalog + 广播。
-  async function afterChange(): Promise<void> {
+  async function afterChange(
+    previousImageGenerationSignature?: string,
+    commitRouteMutation?: () => void,
+  ): Promise<void> {
+    // Publish the new endpoint-bound credential generation before rebuilding the catalog/Host.
+    // If either later step fails, old Host snapshots fail closed instead of mixing generations.
+    commitRouteMutation?.();
     await deps.refreshCatalog();
+    if (
+      previousImageGenerationSignature !== undefined &&
+      previousImageGenerationSignature !== deps.codexImageGenerationSignature?.()
+    ) {
+      await deps.refreshCodexImageGenerationHost?.();
+    }
     deps.broadcastChanged();
   }
 
@@ -939,6 +994,40 @@ export function registerProviderHandlers(
       throwIpcError('PERMISSION_DENIED', 'sender trust guard unavailable');
     }
     deps.assertTrustedSender(event);
+  }
+
+  async function prepareManualImageGenerationActivation(
+    providerId: string,
+    enablesImageGeneration: boolean,
+    options: CustomProviderUpdateOptions,
+    ownerAtIngress: ReturnType<typeof captureProviderOwnerSession>,
+  ): Promise<CustomProviderUpdateResult | null> {
+    if (
+      options.source !== 'manual-settings' ||
+      !enablesImageGeneration ||
+      deps.hasAppliedCodexImageGenerationProvider?.(providerId) === true
+    ) {
+      return null;
+    }
+    const busySessionIds = deps.listBusyLocalCodexSessionIds?.() ?? [];
+    if (busySessionIds.length === 0) return null;
+    const policy: CodexImageGenerationRestartPolicy | undefined =
+      options.codexImageGenerationRestartPolicy;
+    if (!policy) {
+      return {
+        ok: false,
+        confirmationRequired: 'codex-image-generation-reload',
+        busyCount: busySessionIds.length,
+      };
+    }
+    if (policy === 'interrupt') {
+      if (!deps.interruptBusyLocalCodexTurns) {
+        throwIpcError('INTERNAL', 'local Codex interruption is unavailable');
+      }
+      await deps.interruptBusyLocalCodexTurns();
+      assertProviderMutationOwner(ownerAtIngress);
+    }
+    return null;
   }
 
   // 供应商显示顺序是 owner-scoped 设置。Renderer 只提交当前左栏可见项；store 会
@@ -1272,12 +1361,14 @@ export function registerProviderHandlers(
 
   registry.handle(
     MAKER_INVOKE.PROVIDER_CUSTOM_CREATE,
-    async (event, input: unknown, keyInput?: unknown) => {
+    async (event, input: unknown, keyInput?: unknown, optionsInput?: unknown) => {
       assertTrustedProviderMutationSender(event);
       const v = validateCustomProviderConfig(input);
       if (!v.ok) throwIpcError(v.code, v.message);
       const keys = parseRuntimeKeys(keyInput);
       if (!keys) throwIpcError('INVALID_PARAMS', 'invalid provider runtime keys');
+      const options = parseCustomProviderUpdateOptions(optionsInput);
+      if (!options) throwIpcError('INVALID_PARAMS', 'invalid custom provider create options');
       const config = input as CustomProviderConfig;
       if (config.id === MANAGED_OLLAMA_PROVIDER_ID) {
         throwIpcError(
@@ -1287,17 +1378,26 @@ export function registerProviderHandlers(
       }
       const separated = splitCustomProviderHeaders(config);
       const ownerAtIngress = captureProviderOwnerSession();
-      return withProviderConfigMutation(config.id, async () => {
+      return withProviderConfigMutation(config.id, async (commitRouteMutation) => {
+        const previousImageGenerationSignature = deps.codexImageGenerationSignature?.();
         assertProviderMutationOwner(ownerAtIngress);
         if (await customProviderExists(config.id)) {
           throwIpcError('ALREADY_EXISTS', `custom provider '${config.id}' already exists`);
         }
         // 前面的异步存在性查询期间可能换号；写 key/header 前复核。
         assertProviderMutationOwner(ownerAtIngress);
+        const confirmation = await prepareManualImageGenerationActivation(
+          config.id,
+          config.runtimes.codex?.supportsImageGeneration === true,
+          options,
+          ownerAtIngress,
+        );
+        if (confirmation) return confirmation;
         const credentialSnapshots = stageProviderCredentials(
           config.id,
           planProviderKeyMutations(config, keys, 'create'),
           planProviderHeaderMutations(config, separated.headers, 'create'),
+          commitRouteMutation,
         );
         try {
           await createCustomProvider(separated.config);
@@ -1306,6 +1406,7 @@ export function registerProviderHandlers(
           // 换号后不在 B 的 secret store 执行 A 的回滚。
           assertProviderMutationOwner(ownerAtIngress);
           if (!restoreProviderCredentials(config.id, credentialSnapshots)) {
+            commitRouteMutation();
             throwIpcError(
               'INTERNAL',
               'provider creation failed and credentials could not be rolled back',
@@ -1314,7 +1415,7 @@ export function registerProviderHandlers(
           throw error;
         }
         assertProviderMutationOwner(ownerAtIngress);
-        await afterChange();
+        await afterChange(previousImageGenerationSignature, commitRouteMutation);
         assertProviderMutationOwner(ownerAtIngress);
         return { ok: true };
       });
@@ -1323,12 +1424,14 @@ export function registerProviderHandlers(
 
   registry.handle(
     MAKER_INVOKE.PROVIDER_CUSTOM_UPDATE,
-    async (event, input: unknown, keyInput?: unknown) => {
+    async (event, input: unknown, keyInput?: unknown, optionsInput?: unknown) => {
       assertTrustedProviderMutationSender(event);
       const v = validateCustomProviderConfig(input, { allowLegacyXai: true });
       if (!v.ok) throwIpcError(v.code, v.message);
       const keys = parseRuntimeKeys(keyInput);
       if (!keys) throwIpcError('INVALID_PARAMS', 'invalid provider runtime keys');
+      const options = parseCustomProviderUpdateOptions(optionsInput);
+      if (!options) throwIpcError('INVALID_PARAMS', 'invalid custom provider update options');
       const config = input as CustomProviderConfig;
       if (config.id === MANAGED_OLLAMA_PROVIDER_ID) {
         throwIpcError(
@@ -1338,7 +1441,8 @@ export function registerProviderHandlers(
       }
       const separated = splitCustomProviderHeaders(config);
       const ownerAtIngress = captureProviderOwnerSession();
-      return withProviderConfigMutation(config.id, async () => {
+      return withProviderConfigMutation(config.id, async (commitRouteMutation) => {
+        const previousImageGenerationSignature = deps.codexImageGenerationSignature?.();
         let generation: symbol | null = null;
         try {
           // per-provider 队列等待结束后才读取该 owner 的 DB / secrets。
@@ -1346,21 +1450,49 @@ export function registerProviderHandlers(
           const previous = await getCustomProvider(config.id);
           assertProviderMutationOwner(ownerAtIngress);
           if (!previous) throwIpcError('NOT_FOUND', `custom provider '${config.id}' not found`);
+          const enablesImageGeneration =
+            previous.runtimes.codex?.supportsImageGeneration !== true &&
+            config.runtimes.codex?.supportsImageGeneration === true;
+          const confirmation = await prepareManualImageGenerationActivation(
+            config.id,
+            enablesImageGeneration,
+            options,
+            ownerAtIngress,
+          );
+          if (confirmation) return confirmation;
           // 即便 OAuth 描述符没变，runtime / model 编辑也必须让旧登录尾部的自动发现失效，
           // 否则旧 endpoint 的迟到结果可能合并进刚保存的新配置。
           generation = beginOAuthMutation(config.id);
           const shouldResetOAuth =
             config.auth?.method !== 'oauth' ||
             oauthDescriptorSignature(previous) !== oauthDescriptorSignature(config);
+          const authMethodChanged =
+            (previous.auth?.method ?? 'apiKey') !== (config.auth?.method ?? 'apiKey');
+          const oauthDescriptorChanged =
+            oauthDescriptorSignature(previous) !== oauthDescriptorSignature(config);
           // API key 的写 / 删与配置更新处于同一 main 队列；若后续 OAuth 清理或 DB 写失败，
           // 用原值回滚，确保并发窗口不能把另一份配置和密钥拼在一起。
           // key/header 的 storage key 按当前 owner 动态解析，写入前必须仍是发起方。
           assertProviderMutationOwner(ownerAtIngress);
+          const keyMutations = planProviderKeyMutations(config, keys, 'update', previous);
+          const headerMutations = planProviderHeaderMutations(
+            config,
+            separated.headers,
+            'update',
+            previous,
+          );
           const credentialSnapshots = stageProviderCredentials(
             config.id,
-            planProviderKeyMutations(config, keys, 'update', previous),
-            planProviderHeaderMutations(config, separated.headers, 'update', previous),
+            keyMutations,
+            headerMutations,
+            commitRouteMutation,
           );
+          const codexCredentialGenerationChanged =
+            endpointChangedForAgent(config, previous, 'codex') ||
+            keyMutations.some((mutation) => mutation.agent === 'codex') ||
+            headerMutations.some((mutation) => mutation.agent === 'codex') ||
+            authMethodChanged ||
+            (config.auth?.method === 'oauth' && oauthDescriptorChanged);
           // 先阻止在途 flow 写回，再改描述符；否则旧 flow 可能在 clear 后迟到落一枚旧 token。
           if (shouldResetOAuth) deps.oauthCancel(config.id);
           // 旧 client / endpoint 下签发的 token 不能沿用到新 OAuth 描述符；切到 API key /
@@ -1384,6 +1516,7 @@ export function registerProviderHandlers(
             const oauthRestored = !restoreOAuthCredentials || restoreOAuthCredentials();
             const credentialsRestored = restoreProviderCredentials(config.id, credentialSnapshots);
             if (!oauthRestored || !credentialsRestored) {
+              commitRouteMutation();
               throwIpcError(
                 'INTERNAL',
                 'provider update failed and existing credentials could not be restored',
@@ -1396,6 +1529,7 @@ export function registerProviderHandlers(
             const oauthRestored = !restoreOAuthCredentials || restoreOAuthCredentials();
             const credentialsRestored = restoreProviderCredentials(config.id, credentialSnapshots);
             if (!oauthRestored || !credentialsRestored) {
+              commitRouteMutation();
               throwIpcError(
                 'INTERNAL',
                 'provider disappeared during update and existing credentials could not be restored',
@@ -1404,7 +1538,10 @@ export function registerProviderHandlers(
             throwIpcError('NOT_FOUND', `custom provider '${config.id}' not found`);
           }
           assertProviderMutationOwner(ownerAtIngress);
-          await afterChange();
+          await afterChange(
+            previousImageGenerationSignature,
+            codexCredentialGenerationChanged ? commitRouteMutation : undefined,
+          );
           assertProviderMutationOwner(ownerAtIngress);
           return { ok: true };
         } finally {
@@ -1421,7 +1558,8 @@ export function registerProviderHandlers(
     }
     const runtimeProviderId = runtimeCustomProviderId(providerId);
     const ownerAtIngress = captureProviderOwnerSession();
-    return withProviderConfigMutation(providerId, async () => {
+    return withProviderConfigMutation(providerId, async (commitRouteMutation) => {
+      const previousImageGenerationSignature = deps.codexImageGenerationSignature?.();
       // 同类 delete 也会在 per-provider 队列后写 owner-scoped 凭证。
       assertProviderMutationOwner(ownerAtIngress);
       const generation = beginOAuthMutation(providerId);
@@ -1438,6 +1576,7 @@ export function registerProviderHandlers(
             {},
             'delete',
           ),
+          commitRouteMutation,
         );
         // OAuth 形态自定义供应商的凭证 blob 一并清掉（apiKey 形态无 blob，幂等无害）。
         let restoreOAuthCredentials: (() => boolean) | null = null;
@@ -1476,6 +1615,7 @@ export function registerProviderHandlers(
             const oauthRestored = !restoreOAuthCredentials || restoreOAuthCredentials();
             const credentialsRestored = restoreProviderCredentials(providerId, credentialSnapshots);
             if (!oauthRestored || !credentialsRestored || !overridesRestored || !pricesRestored) {
+              commitRouteMutation();
               throwIpcError(
                 'INTERNAL',
                 'provider deletion failed and existing credentials could not be restored',
@@ -1487,7 +1627,7 @@ export function registerProviderHandlers(
           // provider。afterChange 失败时配置已删,凭证/override 不回写(与改动前
           // 语义一致 —— 恢复只覆盖删除本身失败的场景)。
           assertProviderMutationOwner(ownerAtIngress);
-          await afterChange();
+          await afterChange(previousImageGenerationSignature, commitRouteMutation);
           assertProviderMutationOwner(ownerAtIngress);
           deps.broadcastPricingChanged();
         });
@@ -1635,6 +1775,8 @@ export function registerProviderHandlers(
       if (providerConfigMutationCounts.has(id)) {
         return { ok: false, reason: 'provider_update_in_progress' };
       }
+      const previousImageGenerationSignature = deps.codexImageGenerationSignature?.();
+      const finishRouteMutation = deps.beginRouteMutation(id);
       const generation = beginOAuthMutation(id);
       let owner: ProviderOAuthOwner | null = null;
       try {
@@ -1643,9 +1785,19 @@ export function registerProviderHandlers(
         }
         const result = await deps.oauthLogin(id, () => isOAuthMutationCurrent(id, generation));
         if (isOAuthMutationCurrent(id, generation)) {
+          if (result.ok) {
+            finishRouteMutation.commit?.();
+            if (
+              previousImageGenerationSignature !== undefined &&
+              previousImageGenerationSignature !== deps.codexImageGenerationSignature?.()
+            ) {
+              await deps.refreshCodexImageGenerationHost?.();
+            }
+          }
           return { ok: result.ok, ...(result.reason ? { reason: result.reason } : {}) };
         }
         if (result.ok && result.rollbackCredentials && !result.rollbackCredentials()) {
+          finishRouteMutation.commit?.();
           throwIpcError('INTERNAL', 'failed to remove credentials from cancelled OAuth login');
         }
         return { ok: false, reason: 'login_cancelled' };
@@ -1655,6 +1807,7 @@ export function registerProviderHandlers(
       } finally {
         if (ownerId && owner) removeProviderOAuthOwner(ownerId, sender ?? undefined, owner);
         finishOAuthMutation(id, generation);
+        finishRouteMutation();
       }
     },
   );
@@ -1665,12 +1818,14 @@ export function registerProviderHandlers(
     // config CRUD so a failed earlier update cannot restore a token after this explicit logout.
     deps.oauthCancel(id);
     try {
-      return await withProviderConfigMutation(id, async () => {
+      return await withProviderConfigMutation(id, async (commitRouteMutation) => {
         try {
+          const previousImageGenerationSignature = deps.codexImageGenerationSignature?.();
           await deps.oauthLogout(id);
-          await afterChange();
+          await afterChange(previousImageGenerationSignature, commitRouteMutation);
           return { ok: true };
         } catch (err) {
+          commitRouteMutation();
           throwIpcError('INTERNAL', err instanceof Error ? err.message : String(err));
         }
       });

--- a/apps/desktop/src/main/maker-ipc/register.ts
+++ b/apps/desktop/src/main/maker-ipc/register.ts
@@ -918,6 +918,10 @@ import {
   isRemoteModelSwitchRouteChangeError,
 } from './runtimeSetModel.js';
 import {
+  codexImageGenerationRouteSignature,
+  hasCodexAppliedImageGenerationProvider,
+} from '../maker-host/codex-image-generation-route.js';
+import {
   decideCodexProviderThreadRelink,
   relinkCodexProviderThread,
   type CodexProviderThreadRoute,
@@ -6820,6 +6824,33 @@ export function registerMakerIpc(maker: Maker, options: RegisterMakerIpcOptions)
     listProviders: (opts) => getDesktopProviderService().listProviders(opts),
     getModelVisibilityOverrides: () => getModelVisibilityMirrorSnapshot(),
     refreshCatalog: () => refreshCustomProvidersIntoCatalog(),
+    codexImageGenerationSignature: () => codexImageGenerationRouteSignature(getActiveCatalog()),
+    hasAppliedCodexImageGenerationProvider: (providerId) =>
+      hasCodexAppliedImageGenerationProvider(providerId),
+    listBusyLocalCodexSessionIds: () =>
+      maker
+        .listActiveSessions()
+        .filter(
+          (session) =>
+            session.agentKind === 'codex' &&
+            !session.remoteHostId &&
+            isLocalSessionBusy(session, isSessionInTurn),
+        )
+        .map((session) => session.id),
+    interruptBusyLocalCodexTurns: async () => {
+      const busySessions = maker
+        .listActiveSessions()
+        .filter(
+          (session) =>
+            session.agentKind === 'codex' &&
+            !session.remoteHostId &&
+            isLocalSessionBusy(session, isSessionInTurn),
+        );
+      await Promise.all(busySessions.map((session) => session.abort()));
+    },
+    refreshCodexImageGenerationHost: async () => {
+      await applyCodexSpawnConfigChangeWithRestart(async () => ({ ok: true }));
+    },
     beginRouteMutation: (providerId) => beginProviderRouteMutation(providerId),
     broadcastChanged: () => broadcastToAllWindows(MAKER_PUSH.PROVIDER_CHANGED, {}),
     listProviderIds: () => getDesktopSelectableCatalog().providers.map((provider) => provider.id),

--- a/apps/desktop/src/main/scheduler-host/__tests__/runnerModelSelection.test.ts
+++ b/apps/desktop/src/main/scheduler-host/__tests__/runnerModelSelection.test.ts
@@ -19,6 +19,10 @@ import { describe, expect, it, vi, beforeEach } from 'vitest';
 
 import type { AgentEvent, Maker, Session, SessionSendResult } from '@cindy/maker-core';
 import type { FireContext, Logger, Notifier, Schedule } from '@cindy/maker-scheduler';
+import {
+  setCodexAppliedImageGenerationRoutes,
+  type CodexImageGenerationRoute,
+} from '../../maker-host/codex-image-generation-route.js';
 
 const mocks = vi.hoisted(() => ({
   createMessage: vi.fn(),
@@ -180,6 +184,35 @@ interface RunnerHarness {
   closeSession: ReturnType<typeof vi.fn>;
 }
 
+const schedulerImageGenerationRoutes: readonly CodexImageGenerationRoute[] = [
+  {
+    providerId: 'provider-a',
+    routeId: 'a'.repeat(20),
+    modelProviderId: `cindy_imagegen_${'a'.repeat(20)}`,
+    supportedModels: ['shared-model', 'a-alt-model'],
+    routing: {
+      upstream: 'https://a.invalid/v1',
+      wireProtocol: 'openai-responses',
+      authStrategy: 'none',
+    },
+    responseRoutingByModel: {},
+    credentialRevision: 1,
+  },
+  {
+    providerId: 'provider-b',
+    routeId: 'b'.repeat(20),
+    modelProviderId: `cindy_imagegen_${'b'.repeat(20)}`,
+    supportedModels: ['shared-model'],
+    routing: {
+      upstream: 'https://b.invalid/v1',
+      wireProtocol: 'openai-responses',
+      authStrategy: 'none',
+    },
+    responseRoutingByModel: {},
+    credentialRevision: 1,
+  },
+];
+
 function createRunnerHarness(
   h: FakeSessionHarness,
   meta: {
@@ -248,6 +281,7 @@ async function fireToCompletion(
 
 describe('MakerScheduleRunner model selection', () => {
   beforeEach(() => {
+    setCodexAppliedImageGenerationRoutes([]);
     vi.clearAllMocks();
     mocks.createMessage.mockResolvedValue(undefined);
     mocks.backfillSessionMeta.mockResolvedValue(undefined);
@@ -1062,11 +1096,7 @@ describe('MakerScheduleRunner model selection', () => {
       }));
       const harness = createRunnerHarness(h, null, { resolveDefaultModelRoute });
 
-      await fireToCompletion(
-        harness,
-        h,
-        baseSchedule({ model: 'claude-from-future' }),
-      );
+      await fireToCompletion(harness, h, baseSchedule({ model: 'claude-from-future' }));
 
       expect(harness.createSession).toHaveBeenCalledWith(
         expect.objectContaining({ model: 'claude-from-future', providerId: null }),
@@ -1256,6 +1286,125 @@ describe('MakerScheduleRunner model selection', () => {
       );
     });
 
+    it('heartbeat 在同一 dynamic Provider 的两个 Responses 模型间热切且不重建', async () => {
+      const routeA = schedulerImageGenerationRoutes[0]!;
+      setCodexAppliedImageGenerationRoutes(schedulerImageGenerationRoutes);
+      mocks.getSessionRowSnapshot.mockResolvedValue({
+        status: 'active',
+        providerId: routeA.providerId,
+      });
+      mocks.getSessionProvider.mockReturnValue(routeA.providerId);
+      const h = createSessionHarness();
+      Object.defineProperties(h.session, {
+        agentKind: { value: 'codex' },
+        model: { value: 'shared-model', writable: true },
+        codexProxyActive: { value: true },
+        codexThreadModelProviderId: { value: routeA.modelProviderId },
+      });
+      const harness = createRunnerHarness(
+        h,
+        { model: 'shared-model', workDir: '/work', sdkSessionId: 'sdk-image-a' },
+        { sessionAlive: true },
+      );
+
+      await fireToCompletion(
+        harness,
+        h,
+        baseSchedule({
+          agentKind: 'codex',
+          model: 'a-alt-model',
+          providerId: routeA.providerId,
+          targetSessionId: 'scheduler-session',
+        }),
+      );
+
+      expect(harness.closeSession).not.toHaveBeenCalled();
+      expect(h.setModel).toHaveBeenCalledWith('a-alt-model');
+    });
+
+    it('heartbeat 从 dynamic Provider A 切到 B 时只关闭目标 thread 并按 B 重建', async () => {
+      const [routeA, routeB] = schedulerImageGenerationRoutes;
+      setCodexAppliedImageGenerationRoutes(schedulerImageGenerationRoutes);
+      mocks.getSessionRowSnapshot.mockResolvedValue({
+        status: 'active',
+        providerId: routeA!.providerId,
+      });
+      mocks.getSessionProvider.mockReturnValue(routeA!.providerId);
+      const h = createSessionHarness();
+      Object.defineProperties(h.session, {
+        agentKind: { value: 'codex' },
+        model: { value: 'shared-model', writable: true },
+        codexProxyActive: { value: true },
+        codexThreadModelProviderId: { value: routeA!.modelProviderId },
+      });
+      const unrelatedBusyCodex = {
+        id: 'unrelated-busy-codex',
+        agentKind: 'codex',
+        remoteHostId: null,
+        isTurnRunning: () => true,
+      } as unknown as Session;
+      const harness = createRunnerHarness(
+        h,
+        { model: 'shared-model', workDir: '/work', sdkSessionId: 'sdk-image-a' },
+        { sessionAlive: true, activeSessions: [h.session, unrelatedBusyCodex] },
+      );
+
+      await fireToCompletion(
+        harness,
+        h,
+        baseSchedule({
+          agentKind: 'codex',
+          model: 'shared-model',
+          providerId: routeB!.providerId,
+          targetSessionId: 'scheduler-session',
+        }),
+      );
+
+      expect(harness.closeSession).toHaveBeenCalledTimes(1);
+      expect(harness.closeSession).toHaveBeenCalledWith('scheduler-session');
+      expect(harness.createSession).toHaveBeenCalledWith(
+        expect.objectContaining({ providerId: routeB!.providerId, model: 'shared-model' }),
+      );
+    });
+
+    it('heartbeat 从 dynamic identity 切到同 Provider 非 Responses 模型时重建', async () => {
+      const routeA = schedulerImageGenerationRoutes[0]!;
+      setCodexAppliedImageGenerationRoutes(schedulerImageGenerationRoutes);
+      mocks.getSessionRowSnapshot.mockResolvedValue({
+        status: 'active',
+        providerId: routeA.providerId,
+      });
+      mocks.getSessionProvider.mockReturnValue(routeA.providerId);
+      const h = createSessionHarness();
+      Object.defineProperties(h.session, {
+        agentKind: { value: 'codex' },
+        model: { value: 'shared-model', writable: true },
+        codexProxyActive: { value: true },
+        codexThreadModelProviderId: { value: routeA.modelProviderId },
+      });
+      const harness = createRunnerHarness(
+        h,
+        { model: 'shared-model', workDir: '/work', sdkSessionId: 'sdk-image-a' },
+        { sessionAlive: true },
+      );
+
+      await fireToCompletion(
+        harness,
+        h,
+        baseSchedule({
+          agentKind: 'codex',
+          model: 'chat-model',
+          providerId: routeA.providerId,
+          targetSessionId: 'scheduler-session',
+        }),
+      );
+
+      expect(harness.closeSession).toHaveBeenCalledWith('scheduler-session');
+      expect(harness.createSession).toHaveBeenCalledWith(
+        expect.objectContaining({ providerId: routeA.providerId, model: 'chat-model' }),
+      );
+    });
+
     it('heartbeat 修复 Codex thread/store 错配时只关闭目标会话，不受其它忙会话阻塞', async () => {
       mocks.getSessionRowSnapshot.mockResolvedValue({
         status: 'active',
@@ -1426,11 +1575,7 @@ describe('MakerScheduleRunner model selection', () => {
       (h.session as { agentKind: string }).agentKind = 'pi';
       const harness = createRunnerHarness(h);
 
-      await fireToCompletion(
-        harness,
-        h,
-        baseSchedule({ agentKind: 'pi', model: 'gpt-5.6-sol' }),
-      );
+      await fireToCompletion(harness, h, baseSchedule({ agentKind: 'pi', model: 'gpt-5.6-sol' }));
 
       expect(harness.createSession).toHaveBeenCalledWith(
         expect.objectContaining({ providerId: null }),

--- a/apps/desktop/src/main/scheduler-host/__tests__/runnerQueuedDispatch.test.ts
+++ b/apps/desktop/src/main/scheduler-host/__tests__/runnerQueuedDispatch.test.ts
@@ -22,6 +22,10 @@ import { AcceptedCallbackDispatchCancelled } from '../../maker-ipc/acceptedCallb
 import type { AgentEvent, Maker, Session, SessionSendResult } from '@cindy/maker-core';
 import { SCHEDULER_RUN_ID_VENDOR_OPTION } from '@cindy/maker-scheduler';
 import type { FireContext, Logger, Notifier, Schedule, ScheduleRun } from '@cindy/maker-scheduler';
+import {
+  setCodexAppliedImageGenerationRoutes,
+  type CodexImageGenerationRoute,
+} from '../../maker-host/codex-image-generation-route.js';
 
 const mocks = vi.hoisted(() => ({
   createMessage: vi.fn(),
@@ -92,6 +96,34 @@ type SendImpl = (
 ) => Promise<SessionSendResult>;
 
 const SESSION_ID = 'bound-session';
+const queuedImageGenerationRoutes: readonly CodexImageGenerationRoute[] = [
+  {
+    providerId: 'provider-a',
+    routeId: 'a'.repeat(20),
+    modelProviderId: `cindy_imagegen_${'a'.repeat(20)}`,
+    supportedModels: ['shared-model', 'a-alt-model'],
+    routing: {
+      upstream: 'https://a.invalid/v1',
+      wireProtocol: 'openai-responses',
+      authStrategy: 'none',
+    },
+    responseRoutingByModel: {},
+    credentialRevision: 1,
+  },
+  {
+    providerId: 'provider-b',
+    routeId: 'b'.repeat(20),
+    modelProviderId: `cindy_imagegen_${'b'.repeat(20)}`,
+    supportedModels: ['shared-model'],
+    routing: {
+      upstream: 'https://b.invalid/v1',
+      wireProtocol: 'openai-responses',
+      authStrategy: 'none',
+    },
+    responseRoutingByModel: {},
+    credentialRevision: 1,
+  },
+];
 const SCHEDULER_TURN_ORIGIN = {
   kind: 'scheduler',
   scheduleId: 'schedule-hb',
@@ -389,6 +421,7 @@ function latestNotifiedRun(notifier: Notifier & { notify: ReturnType<typeof vi.f
 }
 
 beforeEach(() => {
+  setCodexAppliedImageGenerationRoutes([]);
   vi.clearAllMocks();
   mocks.getSessionRowSnapshot.mockResolvedValue({
     status: 'active',
@@ -535,7 +568,11 @@ describe('MakerScheduleRunner queued dispatch (busy bound session)', () => {
     expect(harness.vendorOptions[SCHEDULER_RUN_ID_VENDOR_OPTION]).toBe('run-q1');
 
     autoResumePending = false;
-    harness.emit({ type: 'text', data: { text: 'continued result', isFinal: true }, source: 'claude-code' });
+    harness.emit({
+      type: 'text',
+      data: { text: 'continued result', isFinal: true },
+      source: 'claude-code',
+    });
     harness.emit({ type: 'done', data: {}, source: 'claude-code' });
 
     await expect(firePromise).resolves.toMatchObject({
@@ -740,9 +777,7 @@ describe('MakerScheduleRunner queued dispatch (busy bound session)', () => {
     ctx.abortController.abort();
 
     await expect(firePromise).rejects.toThrow(/abort/i);
-    expect(queue.cancelAutoResumeCalls).toEqual([
-      { sessionId: SESSION_ID, runId: 'run-q1' },
-    ]);
+    expect(queue.cancelAutoResumeCalls).toEqual([{ sessionId: SESSION_ID, runId: 'run-q1' }]);
     expect(harness.listenerCount()).toBe(0);
   });
 
@@ -774,9 +809,7 @@ describe('MakerScheduleRunner queued dispatch (busy bound session)', () => {
     ctx.abortController.abort();
 
     await expect(firePromise).rejects.toThrow(/aborted/i);
-    expect(queue.cancelAutoResumeCalls).toEqual([
-      { sessionId: SESSION_ID, runId: 'run-q1' },
-    ]);
+    expect(queue.cancelAutoResumeCalls).toEqual([{ sessionId: SESSION_ID, runId: 'run-q1' }]);
     expect(
       (replacement.session as unknown as { abort: ReturnType<typeof vi.fn> }).abort,
     ).toHaveBeenCalledTimes(1);
@@ -925,6 +958,82 @@ describe('MakerScheduleRunner queued dispatch (busy bound session)', () => {
     expect(harness.setModel).not.toHaveBeenCalled();
     expect(harness.setEffort).not.toHaveBeenCalled();
     expect(mocks.setSessionProvider).not.toHaveBeenCalled();
+  });
+
+  it('busy 心跳跨 dynamic identity 时不入旧 thread 队列，而是顺延到安全重建点', async () => {
+    const [routeA, routeB] = queuedImageGenerationRoutes;
+    setCodexAppliedImageGenerationRoutes(queuedImageGenerationRoutes);
+    mocks.getSessionRowSnapshot.mockResolvedValue({
+      status: 'active',
+      userSendAt: null,
+      providerId: routeA!.providerId,
+    });
+    mocks.getSessionProvider.mockReturnValue(routeA!.providerId);
+    const harness = createSessionHarness(async () => ({ accepted: true }));
+    Object.defineProperties(harness.session, {
+      agentKind: { value: 'codex' },
+      model: { value: 'shared-model', writable: true },
+      codexProxyActive: { value: true },
+      codexThreadModelProviderId: { value: routeA!.modelProviderId },
+    });
+    const queue = createQueueHarness({ busy: true });
+    const { runner, maker } = createRunnerHarness(harness.session, queue.deps, {
+      metaModel: 'shared-model',
+    });
+
+    const result = await runner.fire(
+      heartbeatSchedule({
+        agentKind: 'codex',
+        model: 'shared-model',
+        providerId: routeB!.providerId,
+      }),
+      createFireContext(),
+    );
+
+    expect(result).toMatchObject({ sessionId: SESSION_ID, deferred: true });
+    expect(queue.enqueueCalls).toHaveLength(0);
+    expect(maker.closeSession).not.toHaveBeenCalled();
+    expect(harness.send).not.toHaveBeenCalled();
+  });
+
+  it('排队期间目标变为另一个 dynamic Provider 时在 vendor dispatch 前 fail-closed', async () => {
+    const [routeA, routeB] = queuedImageGenerationRoutes;
+    setCodexAppliedImageGenerationRoutes(queuedImageGenerationRoutes);
+    mocks.getSessionRowSnapshot.mockResolvedValue({
+      status: 'active',
+      userSendAt: null,
+      providerId: routeA!.providerId,
+    });
+    mocks.getSessionProvider.mockReturnValue(routeA!.providerId);
+    const harness = createSessionHarness(async () => ({ accepted: true }));
+    Object.defineProperties(harness.session, {
+      agentKind: { value: 'codex' },
+      model: { value: 'shared-model', writable: true },
+      codexProxyActive: { value: true },
+      codexThreadModelProviderId: { value: routeA!.modelProviderId },
+    });
+    const queue = createQueueHarness({ busy: true });
+    const { runner } = createRunnerHarness(harness.session, queue.deps, {
+      metaModel: 'shared-model',
+    });
+    const schedule = heartbeatSchedule({
+      agentKind: 'codex',
+      model: 'shared-model',
+      providerId: routeA!.providerId,
+    });
+
+    const firePromise = runner.fire(schedule, createFireContext());
+    await vi.waitFor(() => expect(queue.enqueueCalls).toHaveLength(1));
+    schedule.providerId = routeB!.providerId;
+    const rejected = expect(firePromise).rejects.toThrow(
+      'queued heartbeat Codex thread provider identity does not match the target session route',
+    );
+    await queue.accept();
+
+    await rejected;
+    expect(harness.session.abort).toHaveBeenCalled();
+    expect(harness.setModel).not.toHaveBeenCalled();
+    expect(harness.send).not.toHaveBeenCalled();
   });
 
   it('排队 Cindy Codex 在独立 Subagent 不兼容时接受正确的本地压缩身份', async () => {
@@ -1607,11 +1716,16 @@ describe('MakerScheduleRunner queued dispatch: slot accounting and wait cap', ()
     });
 
     const firePromise = runner.fire(heartbeatSchedule(), ctx);
+    // 这条拒绝会在 queue.accept() 内同步触发。先登记消费方，避免测试自己把
+    // 预期错误留到下一拍才观察，造成 PromiseRejectionHandledWarning。
+    const fireRejected = expect(firePromise).rejects.toThrow(/abort/i);
     await vi.waitFor(() => expect(queue.enqueueCalls.length).toBe(1));
     await queue.accept();
 
     // 修复前这里永不 settle(fire 挂死);修复后以"用户中断"收口
-    await expect(firePromise).rejects.toThrow(/abort/i);
+    await fireRejected;
+    expect(harness.session.abort).toHaveBeenCalledTimes(1);
+    expect(harness.send).not.toHaveBeenCalled();
   });
 
   it('排队期间系统挂起:睡着的时间不计入等待额度', async () => {

--- a/apps/desktop/src/main/scheduler-host/runner.ts
+++ b/apps/desktop/src/main/scheduler-host/runner.ts
@@ -70,6 +70,7 @@ import {
   prepareLocalSessionCredentialModeSwitch,
   shouldCloseSessionForCredentialSwitch,
 } from '../maker-host/codex-credential-switch.js';
+import { crossesCodexAppliedImageGenerationIdentity } from '../maker-host/codex-image-generation-route.js';
 import { ensureDialogueWorkspaceDir } from '../localDb/dialogueWorkspace';
 import { AcceptedCallbackDispatchCancelled } from '../maker-ipc/acceptedCallbackRunner.js';
 import {
@@ -291,7 +292,7 @@ class QueuedRouteDisabledError extends Error {}
 /** Pi 原生路由热切失败；继续派发会把任务发给旧 provider，必须在 vendor 前站下。 */
 class QueuedPiRouteSyncError extends Error {}
 
-/** 当前 Codex provider store 与 live thread 身份错配；继续派发会把模型送到错误上游。 */
+/** 当前或目标 Codex 路由与 live thread 身份错配；继续派发会把模型送到错误上游。 */
 class QueuedCodexThreadIdentityMismatchError extends Error {}
 
 /**
@@ -694,6 +695,22 @@ export class MakerScheduleRunner implements ScheduleRunner {
         // 升级为可见排队)。B1 活跃礼让仍优先:用户正在对话时连队都不排,顺延到
         // 用户空闲再说。桥未注入(测试/启动早期)时走原直发路径,行为不变。
         if (this.deps.schedulerQueue?.isSessionBusy(sessionId)) {
+          const liveSession = this.deps.maker.getSession(sessionId);
+          if (
+            liveSession &&
+            crossesCodexAppliedImageGenerationIdentity({
+              agentKind: liveSession.agentKind,
+              remoteHostId: liveSession.remoteHostId,
+              currentCodexProxyActive: liveSession.codexProxyActive,
+              currentThreadModelProviderId: liveSession.codexThreadModelProviderId,
+              targetProviderId: schedule.providerId?.trim() || row?.providerId || null,
+              targetModel: schedule.model?.trim() || meta?.model || liveSession.model,
+            })
+          ) {
+            holder.releaseAgentSwitchLock?.();
+            holder.releaseAgentSwitchLock = undefined;
+            return this.failOrDeferSessionRunning(schedule, ctx, sessionId, true);
+          }
           // 同任务去重快路径(内存视角)。权威判定在 enqueuePrompt 内部:它会先
           // await 崩溃恢复快照读回再查重,覆盖"重启后快照未恢复、内存队列还空"
           // 的窗口(review P1)—— 命中时返回 duplicate,下方按同一语义收口。
@@ -930,6 +947,16 @@ export class MakerScheduleRunner implements ScheduleRunner {
               liveSession.codexCindyRemoteCompactionCompatible,
           }
         : null;
+      const crossesImageGenerationIdentity = credentialSwitchInput
+        ? crossesCodexAppliedImageGenerationIdentity({
+            agentKind: credentialSwitchInput.agentKind,
+            remoteHostId: credentialSwitchInput.remoteHostId,
+            currentCodexProxyActive: credentialSwitchInput.currentCodexProxyActive,
+            currentThreadModelProviderId: credentialSwitchInput.currentCodexThreadModelProviderId,
+            targetProviderId: credentialSwitchInput.nextProviderId,
+            targetModel: credentialSwitchInput.nextModel,
+          })
+        : false;
       if (
         liveSession &&
         credentialSwitchInput &&
@@ -950,7 +977,11 @@ export class MakerScheduleRunner implements ScheduleRunner {
         }
         try {
           throwIfFireAborted(ctx.signal, 'credential mode switch');
-          if (liveSession.agentKind === 'codex' && !currentThreadRouteMismatch) {
+          if (
+            liveSession.agentKind === 'codex' &&
+            !currentThreadRouteMismatch &&
+            !crossesImageGenerationIdentity
+          ) {
             await prepareLocalCodexCredentialModeSwitch({
               maker: this.deps.maker,
               isSessionInTurn,
@@ -979,7 +1010,10 @@ export class MakerScheduleRunner implements ScheduleRunner {
           nextProviderId,
           fromModel: liveSession.model,
           toModel: model,
-          closeScope: currentThreadRouteMismatch ? 'session' : 'all-local-codex',
+          closeScope:
+            currentThreadRouteMismatch || crossesImageGenerationIdentity
+              ? 'session'
+              : 'all-local-codex',
         });
       }
     }
@@ -2070,8 +2104,8 @@ export class MakerScheduleRunner implements ScheduleRunner {
    * 排队派发时刻的路由热同步:schedule 显式设置的 model / effort / 来源(供应商)
    * 优先于绑定会话当前值(与直发路径 4.4.1/4.4.2 同语义);留空沿用会话当前值。
    * 凭证形态需要关会话重建的组合(shouldCloseSessionForCredentialSwitch)无法在
-   * 派发时刻热切 —— 当前 thread 与当前 provider store 一致时跳过本轮同步、沿用
-   * 当前路由；两者已经错配时必须在 vendor dispatch 前失败，不能把新模型送到旧身份。
+   * 派发时刻热切 —— dynamic imagegen identity 跨界或 thread/store 已错配时必须在
+   * vendor dispatch 前失败；其它可保留当前路由的凭证切换才跳过本轮同步。
    * setModel / setEffort 成功才落库 meta,失败保留旧值让下轮重试(与直发路径的
    * 复用会话语义一致)。
    */
@@ -2119,6 +2153,20 @@ export class MakerScheduleRunner implements ScheduleRunner {
       }
     }
     const nextProviderId = applyProviderId ?? currentProviderId;
+    if (
+      crossesCodexAppliedImageGenerationIdentity({
+        agentKind: live.agentKind,
+        remoteHostId: live.remoteHostId,
+        currentCodexProxyActive: live.codexProxyActive,
+        currentThreadModelProviderId: live.codexThreadModelProviderId,
+        targetProviderId: nextProviderId,
+        targetModel,
+      })
+    ) {
+      throw new QueuedCodexThreadIdentityMismatchError(
+        `queued heartbeat Codex thread provider identity does not match the target session route (session "${live.id}")`,
+      );
+    }
     if (
       isCodexThreadModelProviderIdentityMismatch({
         agentKind: live.agentKind,

--- a/apps/desktop/src/preload/preload.ts
+++ b/apps/desktop/src/preload/preload.ts
@@ -1,6 +1,10 @@
 import { contextBridge, ipcRenderer, webUtils } from 'electron';
 import type { MobileCodexRateLimitsResult } from '@cindy/maker-shared/device-link-contract';
 import type { AppearanceSettings } from '../shared/appearanceSettings';
+import type {
+  CustomProviderUpdateOptions,
+  CustomProviderUpdateResult,
+} from '../shared/customProviderUpdate';
 import {
   isWindowsBackdropMaterial,
   readWindowBackdropMaterialFromArgv,
@@ -5324,11 +5328,15 @@ contextBridge.exposeInMainWorld('electronAPI', {
     createCustomProvider: (
       config: import('@cindy/model-providers').CustomProviderConfig,
       keys: Partial<Record<'claude-code' | 'codex' | 'pi', string>>,
-    ): Promise<{ ok: true }> => ipcRenderer.invoke('maker:provider:custom:create', config, keys),
+      options?: CustomProviderUpdateOptions,
+    ): Promise<CustomProviderUpdateResult> =>
+      ipcRenderer.invoke('maker:provider:custom:create', config, keys, options),
     updateCustomProvider: (
       config: import('@cindy/model-providers').CustomProviderConfig,
       keys: Partial<Record<'claude-code' | 'codex' | 'pi', string>>,
-    ): Promise<{ ok: true }> => ipcRenderer.invoke('maker:provider:custom:update', config, keys),
+      options?: CustomProviderUpdateOptions,
+    ): Promise<CustomProviderUpdateResult> =>
+      ipcRenderer.invoke('maker:provider:custom:update', config, keys, options),
     deleteCustomProvider: (providerId: string): Promise<{ ok: true }> =>
       ipcRenderer.invoke('maker:provider:custom:delete', providerId),
     /** 自定义供应商创建模板（目录 presets 段，纯 UI 模板数据）。 */

--- a/apps/desktop/src/renderer/components/settings/AddProviderWizard.tsx
+++ b/apps/desktop/src/renderer/components/settings/AddProviderWizard.tsx
@@ -1124,6 +1124,9 @@ export function AddProviderWizard({
           baseUrl: presetRuntimeBaseUrl(preset, agent, presetBaseUrls),
           ...(rt.wireProtocol ? { wireProtocol: rt.wireProtocol } : {}),
           ...(rt.requestPath ? { requestPath: rt.requestPath } : {}),
+          ...(agent === 'codex' && rt.supportsImageGeneration === true
+            ? { supportsImageGeneration: true }
+            : {}),
           models: agentModels,
           ...(rt.headers ? { headers: rt.headers } : {}),
           ...(rt.modelsUrl ? { modelsUrl: rt.modelsUrl } : {}),

--- a/apps/desktop/src/renderer/components/settings/CustomProviderDialog.tsx
+++ b/apps/desktop/src/renderer/components/settings/CustomProviderDialog.tsx
@@ -17,12 +17,22 @@
 import * as Dialog from '@radix-ui/react-dialog';
 import { useCallback, useEffect, useLayoutEffect, useRef, useState, type RefObject } from 'react';
 import { useTranslation } from 'react-i18next';
-import { Check, ChevronDown, Plug, Plus, RefreshCw, Sparkles, Trash2 } from 'lucide-react';
+import {
+  Check,
+  ChevronDown,
+  CircleHelp,
+  Plug,
+  Plus,
+  RefreshCw,
+  Sparkles,
+  Trash2,
+  X,
+} from 'lucide-react';
 
 import { cn } from '@/lib/utils';
 import { toast } from '@/lib/toast';
 import { Spinner } from '@/components/ui/spinner';
-import { Popover, PopoverContent, PopoverTrigger } from '@/components/ui/popover';
+import { Popover, PopoverAnchor, PopoverContent, PopoverTrigger } from '@/components/ui/popover';
 import {
   DropdownMenu,
   DropdownMenuContent,
@@ -51,6 +61,7 @@ import {
   updateCustomProvider,
   type RuntimeKeys,
 } from '@/lib/customProviders';
+import type { CodexImageGenerationRestartPolicy } from '@/../shared/customProviderUpdate';
 import { uniqueCustomProviderId } from '@/lib/customProviderId';
 import {
   areProviderRequestUrlsAllowed,
@@ -165,6 +176,12 @@ interface CustomProviderDialogProps {
   onClose: () => void;
 }
 
+interface ImageGenerationReloadConfirmation {
+  config: CustomProviderConfig;
+  keys: RuntimeKeys;
+  busyCount: number;
+}
+
 type ModelRow = ProviderRuntimeModelConfig;
 interface ModelPickerState {
   agent: DialogAgentKind;
@@ -188,6 +205,33 @@ interface RuntimeFields extends RuntimeFillDraft {
   modelsUrl: string;
   /** 隐藏字段：从 Pi 官方目录生成该 runtime；编辑保存必须无损保留。 */
   piCatalogProviderId?: string;
+  /** Codex Responses runtime 级原生图片生成能力。 */
+  supportsImageGeneration: boolean;
+}
+
+function canRuntimeUseNativeImageGeneration(runtime: RuntimeFields): boolean {
+  return (
+    runtime.wireProtocol === 'openai-responses' ||
+    runtime.models.some((model) => model.route?.wireProtocol === 'openai-responses')
+  );
+}
+
+/**
+ * Runtime 表单的唯一图片能力归一化入口。任何编辑一旦移除最后一个 Responses 前门，
+ * 立即清掉声明；之后重新加入 Responses 也不会替用户静默恢复，需要显式重新开启。
+ */
+function normalizeRuntimeImageGenerationCapability(
+  agent: DialogAgentKind,
+  runtime: RuntimeFields,
+): RuntimeFields {
+  if (
+    agent === 'codex' &&
+    runtime.supportsImageGeneration &&
+    !canRuntimeUseNativeImageGeneration(runtime)
+  ) {
+    return { ...runtime, supportsImageGeneration: false };
+  }
+  return runtime;
 }
 
 /** 每个 runtime Tab 的「测试连接」状态（idle → testing → ok/fail）。 */
@@ -209,6 +253,7 @@ function emptyRuntime(agent: DialogAgentKind): RuntimeFields {
     headers: [{ name: '', value: '' }],
     modelsUrl: '',
     piCatalogProviderId: undefined,
+    supportsImageGeneration: false,
   };
 }
 
@@ -222,7 +267,7 @@ function initRuntimes(initial?: CustomProviderConfig): Record<DialogAgentKind, R
     for (const a of AGENTS) {
       const rc = initial.runtimes[a];
       if (!rc) continue;
-      out[a] = {
+      out[a] = normalizeRuntimeImageGenerationCapability(a, {
         baseUrl: rc.baseUrl,
         requestPath: a === 'pi' ? '' : (rc.requestPath ?? ''),
         apiKey: '',
@@ -234,8 +279,9 @@ function initRuntimes(initial?: CustomProviderConfig): Record<DialogAgentKind, R
             : [{ name: '', value: '' }],
         modelsUrl: rc.modelsUrl ?? '',
         piCatalogProviderId: rc.piCatalogProviderId,
+        supportsImageGeneration: a === 'codex' && rc.supportsImageGeneration === true,
         headersState: rc.headersState,
-      };
+      });
     }
   }
   return out;
@@ -477,6 +523,8 @@ export function CustomProviderDialog({
     pi: false,
   });
   const [saving, setSaving] = useState(false);
+  const [imageGenerationReloadConfirmation, setImageGenerationReloadConfirmation] =
+    useState<ImageGenerationReloadConfirmation | null>(null);
   // 鉴权形态：API key（默认）/ OAuth / 无鉴权（本机或受信自托管代理）。
   const [authMode, setAuthModeState] = useState<CustomProviderAuthMode>(
     initial?.auth?.method === 'oauth'
@@ -504,6 +552,10 @@ export function CustomProviderDialog({
   });
   // OAuth 模式下模型 / 请求头收进默认折叠的「高级配置」——模型授权后自动发现,普通用户无需碰。
   const [showAdvanced, setShowAdvanced] = useState(false);
+  const [showImageGenerationAdvanced, setShowImageGenerationAdvanced] = useState(false);
+  const [imageGenerationHelpPinned, setImageGenerationHelpPinned] = useState(false);
+  const [imageGenerationHelpHovered, setImageGenerationHelpHovered] = useState(false);
+  const [imageGenerationHelpFocused, setImageGenerationHelpFocused] = useState(false);
   // 上下文窗口输入的行级草稿:受控输入若只回显已提交值,逐字符键入 `1,` 这类
   // 合法中间态会被整体校验拒绝后回滚,声明支持的分组格式只能粘贴、无法键入
   // (review P1)。草稿承载显示文本;合法完整值仍即时提交,失焦只清可提交
@@ -539,25 +591,112 @@ export function CustomProviderDialog({
   });
   const runtimeFillTriggerRef = useRef<HTMLButtonElement>(null);
   const modelPickerTriggerRef = useRef<HTMLButtonElement>(null);
+  const imageGenerationHelpTriggerRef = useRef<HTMLButtonElement>(null);
+  const imageGenerationHelpPointerLeaveTimerRef = useRef<number | null>(null);
+  const imageGenerationHelpFocusPreviewSuppressedRef = useRef(false);
+  const imageGenerationHelpPointerPreviewSuppressedRef = useRef(false);
+  const imageGenerationHelpPointerInsideRef = useRef(false);
+  const imageGenerationHelpPointerSuppressionFrameRef = useRef<number | null>(null);
+  const imageGenerationHelpPointerSuppressionGenerationRef = useRef(0);
   const modelFetchInFlightRef = useRef(false);
   const scrimRef = useRef<HTMLDivElement>(null);
   const dialogPanelRef = useRef<HTMLDivElement>(null);
+  const saveButtonRef = useRef<HTMLButtonElement>(null);
   // 原生 window listener 的生命周期不跟着每次 render 重绑；layout effect 只把
   // 已提交的层状态写入 ref，既避开 passive effect 延迟，也不暴露被放弃的并发 render。
   const childLayerRef = useRef(childLayer);
   const runtimeFillRef = useRef(runtimeFill);
   const savingRef = useRef(saving);
+  const imageGenerationReloadConfirmationRef = useRef(imageGenerationReloadConfirmation);
   const onCloseRef = useRef(onClose);
+  const showImageGenerationHelp =
+    imageGenerationHelpPinned || imageGenerationHelpHovered || imageGenerationHelpFocused;
+  const cancelImageGenerationHelpPointerLeave = useCallback(() => {
+    if (imageGenerationHelpPointerLeaveTimerRef.current === null) return;
+    window.clearTimeout(imageGenerationHelpPointerLeaveTimerRef.current);
+    imageGenerationHelpPointerLeaveTimerRef.current = null;
+  }, []);
+  const cancelImageGenerationHelpPointerSuppression = useCallback(() => {
+    imageGenerationHelpPointerSuppressionGenerationRef.current += 1;
+    if (imageGenerationHelpPointerSuppressionFrameRef.current !== null) {
+      window.cancelAnimationFrame(imageGenerationHelpPointerSuppressionFrameRef.current);
+      imageGenerationHelpPointerSuppressionFrameRef.current = null;
+    }
+    imageGenerationHelpPointerPreviewSuppressedRef.current = false;
+  }, []);
+  const suppressImageGenerationHelpPointerForExitFrame = useCallback(() => {
+    cancelImageGenerationHelpPointerSuppression();
+    if (!imageGenerationHelpPointerInsideRef.current) return;
+    imageGenerationHelpPointerPreviewSuppressedRef.current = true;
+    const generation = imageGenerationHelpPointerSuppressionGenerationRef.current;
+    imageGenerationHelpPointerSuppressionFrameRef.current = window.requestAnimationFrame(() => {
+      if (imageGenerationHelpPointerSuppressionGenerationRef.current !== generation) return;
+      imageGenerationHelpPointerSuppressionFrameRef.current = null;
+      imageGenerationHelpPointerPreviewSuppressedRef.current = false;
+    });
+  }, [cancelImageGenerationHelpPointerSuppression]);
+  const closeImageGenerationHelp = useCallback(() => {
+    cancelImageGenerationHelpPointerLeave();
+    setImageGenerationHelpPinned(false);
+    setImageGenerationHelpHovered(false);
+    setImageGenerationHelpFocused(false);
+  }, [cancelImageGenerationHelpPointerLeave]);
+  const resetImageGenerationHelp = useCallback(() => {
+    cancelImageGenerationHelpPointerSuppression();
+    imageGenerationHelpFocusPreviewSuppressedRef.current = false;
+    imageGenerationHelpPointerInsideRef.current = false;
+    closeImageGenerationHelp();
+  }, [cancelImageGenerationHelpPointerSuppression, closeImageGenerationHelp]);
+  const dismissImageGenerationHelp = useCallback(
+    (restoreTriggerFocus: boolean) => {
+      // Popover 退场和回焦可能在同一物理 focus / hover 周期内再次派发事件。
+      // focus 防护延续到真实 blur；pointer 防护仅覆盖指针确实位于交互区时的
+      // 退场帧，不能变成等待未来 pointerLeave 才解除的长期闩锁。
+      imageGenerationHelpFocusPreviewSuppressedRef.current = true;
+      suppressImageGenerationHelpPointerForExitFrame();
+      closeImageGenerationHelp();
+      if (restoreTriggerFocus) {
+        imageGenerationHelpTriggerRef.current?.focus({ preventScroll: true });
+      }
+    },
+    [closeImageGenerationHelp, suppressImageGenerationHelpPointerForExitFrame],
+  );
+  const previewImageGenerationHelp = useCallback(() => {
+    cancelImageGenerationHelpPointerLeave();
+    setImageGenerationHelpHovered(true);
+  }, [cancelImageGenerationHelpPointerLeave]);
+  const scheduleImageGenerationHelpPointerLeave = useCallback(() => {
+    cancelImageGenerationHelpPointerLeave();
+    imageGenerationHelpPointerLeaveTimerRef.current = window.setTimeout(() => {
+      imageGenerationHelpPointerLeaveTimerRef.current = null;
+      setImageGenerationHelpHovered(false);
+    }, 100);
+  }, [cancelImageGenerationHelpPointerLeave]);
+  useEffect(() => {
+    return () => {
+      cancelImageGenerationHelpPointerLeave();
+      cancelImageGenerationHelpPointerSuppression();
+      imageGenerationHelpFocusPreviewSuppressedRef.current = false;
+      imageGenerationHelpPointerInsideRef.current = false;
+    };
+  }, [cancelImageGenerationHelpPointerLeave, cancelImageGenerationHelpPointerSuppression]);
   useLayoutEffect(() => {
     childLayerRef.current = childLayer;
     runtimeFillRef.current = runtimeFill;
     savingRef.current = saving;
+    imageGenerationReloadConfirmationRef.current = imageGenerationReloadConfirmation;
     onCloseRef.current = onClose;
-  }, [childLayer, onClose, runtimeFill, saving]);
+  }, [childLayer, imageGenerationReloadConfirmation, onClose, runtimeFill, saving]);
 
   // Dismissible form contract:一个关闭输入只结算最上层一次。runtime fill / 模型选择器
   // 优先于预设菜单，最后才是表单；Cancel 仍直接表示用户要关闭表单，且无重复 ×。
   const dismissTopmostLayer = useCallback(() => {
+    if (imageGenerationReloadConfirmationRef.current) {
+      if (savingRef.current) return;
+      imageGenerationReloadConfirmationRef.current = null;
+      setImageGenerationReloadConfirmation(null);
+      return;
+    }
     if (runtimeFillRef.current) {
       runtimeFillRef.current = null;
       setRuntimeFill((current) => (current ? null : current));
@@ -579,6 +718,18 @@ export function CustomProviderDialog({
       if (event.key !== 'Escape') return;
       // IME 候选窗的 Escape 是组合输入控制，不是弹层关闭意图。
       if (event.defaultPrevented || event.isComposing || event.keyCode === 229) return;
+      if (imageGenerationReloadConfirmationRef.current) {
+        event.preventDefault();
+        event.stopPropagation();
+        dismissTopmostLayer();
+        return;
+      }
+      if (showImageGenerationHelp) {
+        event.preventDefault();
+        event.stopPropagation();
+        dismissImageGenerationHelp(true);
+        return;
+      }
       // 单选协议菜单由 Radix 自己完成键盘关闭和焦点归还；这里只保留表单层级
       // 记录，避免 window capture 抢先吞掉它的 Escape。
       if (childLayerRef.current?.kind === 'model-protocol') return;
@@ -590,7 +741,7 @@ export function CustomProviderDialog({
     };
     window.addEventListener('keydown', onKeyDown, { capture: true });
     return () => window.removeEventListener('keydown', onKeyDown, true);
-  }, [dismissTopmostLayer]);
+  }, [dismissImageGenerationHelp, dismissTopmostLayer, showImageGenerationHelp]);
 
   useEffect(() => {
     const onPointerDown = (event: PointerEvent) => {
@@ -638,12 +789,18 @@ export function CustomProviderDialog({
     ) => {
       setRt((prev) => {
         const updated = fn(prev);
+        const normalized = Object.fromEntries(
+          AGENTS.map((agent) => [
+            agent,
+            normalizeRuntimeImageGenerationCapability(agent, updated[agent]),
+          ]),
+        ) as Record<DialogAgentKind, RuntimeFields>;
         // Do not consume the catalog marker while the user is still editing.
         // A temporary route/model change can be reverted before Save; marker
         // ownership is decided once below from the persisted baseline and the
         // final serialized values.
-        rtRef.current = updated;
-        return updated;
+        rtRef.current = normalized;
+        return normalized;
       });
     },
     [],
@@ -774,6 +931,7 @@ export function CustomProviderDialog({
                 : [{ name: '', value: '' }],
             modelsUrl: rc.modelsUrl ?? '',
             piCatalogProviderId: rc.piCatalogProviderId,
+            supportsImageGeneration: a === 'codex' && rc.supportsImageGeneration === true,
           };
         }
         return next;
@@ -1017,7 +1175,11 @@ export function CustomProviderDialog({
           keyEditRevisionRef.current[target.agent] === 0
             ? { ...filled, apiKey: '' }
             : filled;
-        next[target.agent] = restoreHydratedKey(target.agent, endpointSafeFilled);
+        const restored = restoreHydratedKey(target.agent, {
+          ...prev[target.agent],
+          ...endpointSafeFilled,
+        });
+        next[target.agent] = restored;
       }
       return next;
     });
@@ -1094,6 +1256,12 @@ export function CustomProviderDialog({
   );
 
   const f = rt[activeTab];
+  const canShowImageGenerationAdvanced =
+    activeTab === 'codex' && canRuntimeUseNativeImageGeneration(f);
+  useEffect(() => {
+    if (canShowImageGenerationAdvanced && showImageGenerationAdvanced) return;
+    resetImageGenerationHelp();
+  }, [canShowImageGenerationAdvanced, resetImageGenerationHelp, showImageGenerationAdvanced]);
 
   /** 测试当前 Tab 的表单值（未保存也能测；key 仅内存透传给 main，不落盘）。 */
   const handleTest = useCallback(async () => {
@@ -1570,6 +1738,9 @@ export function CustomProviderDialog({
         baseUrl: rf.baseUrl.trim(),
         ...(requestPath ? { requestPath } : {}),
         ...(savedWireProtocol ? { wireProtocol: savedWireProtocol } : {}),
+        ...(a === 'codex' && rf.supportsImageGeneration && canRuntimeUseNativeImageGeneration(rf)
+          ? { supportsImageGeneration: true }
+          : {}),
         models,
         ...(Object.keys(savedHeaders).length > 0 ? { headers: savedHeaders } : {}),
         ...(rf.modelsUrl.trim() ? { modelsUrl: rf.modelsUrl.trim() } : {}),
@@ -1685,10 +1856,20 @@ export function CustomProviderDialog({
     setSaving(true);
     try {
       if (editing) {
-        await updateCustomProvider(config, keys);
+        const result = await updateCustomProvider(config, keys, { source: 'manual-settings' });
+        if (result?.ok === false) {
+          setImageGenerationReloadConfirmation({ config, keys, busyCount: result.busyCount });
+          setSaving(false);
+          return;
+        }
         toast.success(t('settings.providers.custom.toast.updated'));
       } else {
-        await createCustomProvider(config, keys);
+        const result = await createCustomProvider(config, keys, { source: 'manual-settings' });
+        if (result?.ok === false) {
+          setImageGenerationReloadConfirmation({ config, keys, busyCount: result.busyCount });
+          setSaving(false);
+          return;
+        }
         toast.success(t('settings.providers.custom.toast.created'));
       }
       // 成功:onSaved 关闭弹窗(父级 setDialog(null) 卸载本组件)。不在此 setSaving(false)——
@@ -1717,6 +1898,43 @@ export function CustomProviderDialog({
     t,
   ]);
 
+  const saveWithImageGenerationRestartPolicy = useCallback(
+    async (policy: CodexImageGenerationRestartPolicy) => {
+      const pending = imageGenerationReloadConfirmationRef.current;
+      if (!pending || savingRef.current) return;
+      setSaving(true);
+      try {
+        const options = {
+          source: 'manual-settings' as const,
+          codexImageGenerationRestartPolicy: policy,
+        };
+        const result = editing
+          ? await updateCustomProvider(pending.config, pending.keys, options)
+          : await createCustomProvider(pending.config, pending.keys, options);
+        if (result.ok === false) {
+          const next = { ...pending, busyCount: result.busyCount };
+          imageGenerationReloadConfirmationRef.current = next;
+          setImageGenerationReloadConfirmation(next);
+          setSaving(false);
+          return;
+        }
+        toast.success(
+          t(
+            editing
+              ? 'settings.providers.custom.toast.updated'
+              : 'settings.providers.custom.toast.created',
+          ),
+        );
+        onSaved();
+      } catch (error) {
+        const ipc = extractIpcError(error);
+        toast.error(ipc?.message ?? t('settings.providers.custom.toast.saveFailed'));
+        setSaving(false);
+      }
+    },
+    [editing, onSaved, t],
+  );
+
   const activeSavedBaseline = savedBaselineFor(activeTab);
   // 共享判据：当前表单的端点相对已存基线是否未变。密钥与请求头都只在
   // 端点未变时继续有效——main 侧改端点后会清掉已存头，renderer 的徽标
@@ -1736,6 +1954,55 @@ export function CustomProviderDialog({
     ? t('settings.providers.custom.fields.apiKeyEditPlaceholder')
     : t('settings.providers.custom.fields.apiKeyPlaceholder');
 
+  const renderImageGenerationHelpContent = () => {
+    const idPrefix = 'custom-provider-image-generation-help';
+    return (
+      <div className="flex flex-col gap-3">
+        <section aria-labelledby={`${idPrefix}-condition`} className="flex flex-col gap-1">
+          <div
+            id={`${idPrefix}-condition`}
+            className="text-12 font-semibold text-[var(--text-primary)]"
+          >
+            {t('settings.providers.custom.fields.runtimeSupportsImageGenerationConditionTitle')}
+          </div>
+          <p className="leading-5">
+            {t('settings.providers.custom.fields.runtimeSupportsImageGenerationCondition')}
+          </p>
+        </section>
+        <section aria-labelledby={`${idPrefix}-endpoints`} className="flex flex-col gap-1">
+          <div
+            id={`${idPrefix}-endpoints`}
+            className="text-12 font-semibold text-[var(--text-primary)]"
+          >
+            {t('settings.providers.custom.fields.runtimeSupportsImageGenerationEndpointsTitle')}
+          </div>
+          <p className="leading-5">
+            {t('settings.providers.custom.fields.runtimeSupportsImageGenerationEndpoints')}
+          </p>
+          <div className="flex flex-col items-start gap-1.5">
+            <code className="max-w-full break-all rounded-md bg-[var(--surface-chip)] px-2 py-1 font-mono text-11 leading-4 text-[var(--text-primary)]">
+              /images/generations
+            </code>
+            <code className="max-w-full break-all rounded-md bg-[var(--surface-chip)] px-2 py-1 font-mono text-11 leading-4 text-[var(--text-primary)]">
+              /images/edits
+            </code>
+          </div>
+        </section>
+        <section aria-labelledby={`${idPrefix}-permissions`} className="flex flex-col gap-1">
+          <div
+            id={`${idPrefix}-permissions`}
+            className="text-12 font-semibold text-[var(--text-primary)]"
+          >
+            {t('settings.providers.custom.fields.runtimeSupportsImageGenerationPermissionsTitle')}
+          </div>
+          <p className="leading-5">
+            {t('settings.providers.custom.fields.runtimeSupportsImageGenerationPermissions')}
+          </p>
+        </section>
+      </div>
+    );
+  };
+
   return (
     <div
       ref={scrimRef}
@@ -1751,7 +2018,7 @@ export function CustomProviderDialog({
         }
       }}
       onKeyDown={(event) => {
-        if (childLayer || runtimeFill) return;
+        if (childLayer || runtimeFill || imageGenerationReloadConfirmation) return;
         if (event.key !== 'Tab') return;
         const focusable = Array.from(
           dialogPanelRef.current?.querySelectorAll<HTMLElement>(DIALOG_FOCUSABLE_SELECTOR) ?? [],
@@ -2495,6 +2762,144 @@ export function CustomProviderDialog({
                     {t('settings.providers.custom.fields.addHeader')}
                   </button>
                 </div>
+
+                {/* Codex Responses Provider 级能力。放在自定义请求头之后，默认收起；
+                    同一张说明卡片支持 hover/focus 临时预览和 click/tap 固定。 */}
+                {canShowImageGenerationAdvanced && (
+                  <div className="flex flex-col gap-2 border-t border-[var(--border-subtle)] pt-3">
+                    <button
+                      type="button"
+                      onClick={() => {
+                        if (showImageGenerationAdvanced) resetImageGenerationHelp();
+                        setShowImageGenerationAdvanced((open) => !open);
+                      }}
+                      aria-expanded={showImageGenerationAdvanced}
+                      aria-controls="custom-provider-image-generation-advanced"
+                      className="group flex w-full items-center justify-between gap-3 text-left"
+                    >
+                      <span className="text-13 font-medium text-[var(--settings-section-title)]">
+                        {t('settings.providers.custom.fields.runtimeAdvanced')}
+                      </span>
+                      <ChevronDown
+                        size={14}
+                        aria-hidden
+                        className={cn(
+                          'shrink-0 text-[var(--text-tertiary)] transition-transform group-hover:text-[var(--text-primary)]',
+                          showImageGenerationAdvanced && 'rotate-180',
+                        )}
+                      />
+                    </button>
+                    {showImageGenerationAdvanced && (
+                      <div
+                        id="custom-provider-image-generation-advanced"
+                        className="flex min-h-11 items-center justify-between gap-3 rounded-lg bg-[var(--surface-elevated)] px-3 py-2.5"
+                      >
+                        <label className="flex min-w-0 cursor-pointer items-center gap-2 text-[var(--settings-section-desc)]">
+                          <input
+                            type="checkbox"
+                            checked={f.supportsImageGeneration}
+                            onChange={(event) => {
+                              const supportsImageGeneration = event.currentTarget.checked;
+                              patch('codex', (runtime) => ({
+                                ...runtime,
+                                supportsImageGeneration,
+                              }));
+                            }}
+                            className="h-4 w-4 shrink-0 cursor-pointer accent-[var(--settings-menu-text-selected)]"
+                          />
+                          <span className="text-12 font-medium leading-5 text-[var(--settings-section-sublabel)]">
+                            {t('settings.providers.custom.fields.runtimeSupportsImageGeneration')}
+                          </span>
+                        </label>
+                        <Popover
+                          open={showImageGenerationHelp}
+                          onOpenChange={(open) => {
+                            if (!open) closeImageGenerationHelp();
+                          }}
+                        >
+                          <PopoverAnchor asChild>
+                            <button
+                              ref={imageGenerationHelpTriggerRef}
+                              type="button"
+                              aria-label={t(
+                                'settings.providers.custom.fields.runtimeSupportsImageGenerationHelpLabel',
+                              )}
+                              aria-expanded={showImageGenerationHelp}
+                              aria-controls="custom-provider-image-generation-help-card"
+                              onPointerEnter={() => {
+                                imageGenerationHelpPointerInsideRef.current = true;
+                                if (imageGenerationHelpPointerPreviewSuppressedRef.current) return;
+                                previewImageGenerationHelp();
+                              }}
+                              onPointerLeave={() => {
+                                imageGenerationHelpPointerInsideRef.current = false;
+                                scheduleImageGenerationHelpPointerLeave();
+                              }}
+                              onFocus={() => {
+                                if (imageGenerationHelpFocusPreviewSuppressedRef.current) return;
+                                setImageGenerationHelpFocused(true);
+                              }}
+                              onBlur={() => {
+                                imageGenerationHelpFocusPreviewSuppressedRef.current = false;
+                                setImageGenerationHelpFocused(false);
+                              }}
+                              onClick={() => {
+                                if (imageGenerationHelpPinned) {
+                                  dismissImageGenerationHelp(false);
+                                  return;
+                                }
+                                cancelImageGenerationHelpPointerLeave();
+                                imageGenerationHelpFocusPreviewSuppressedRef.current = false;
+                                imageGenerationHelpPointerPreviewSuppressedRef.current = false;
+                                setImageGenerationHelpPinned(true);
+                              }}
+                              className="flex h-6 w-6 shrink-0 items-center justify-center rounded-full text-[var(--text-tertiary)] transition-colors hover:bg-[var(--surface-hover)] hover:text-[var(--text-primary)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--focus-ring)]"
+                            >
+                              <CircleHelp size={15} aria-hidden />
+                            </button>
+                          </PopoverAnchor>
+                          <PopoverContent
+                            id="custom-provider-image-generation-help-card"
+                            side="top"
+                            align="end"
+                            sideOffset={8}
+                            collisionPadding={12}
+                            role={imageGenerationHelpPinned ? 'dialog' : 'tooltip'}
+                            aria-label={t(
+                              'settings.providers.custom.fields.runtimeSupportsImageGenerationHelpLabel',
+                            )}
+                            onOpenAutoFocus={(event) => event.preventDefault()}
+                            onCloseAutoFocus={(event) => event.preventDefault()}
+                            onPointerEnter={() => {
+                              imageGenerationHelpPointerInsideRef.current = true;
+                              if (imageGenerationHelpPointerPreviewSuppressedRef.current) return;
+                              previewImageGenerationHelp();
+                            }}
+                            onPointerLeave={() => {
+                              imageGenerationHelpPointerInsideRef.current = false;
+                              scheduleImageGenerationHelpPointerLeave();
+                            }}
+                            onPointerDownOutside={(event) => {
+                              if (
+                                imageGenerationHelpTriggerRef.current?.contains(
+                                  event.target as Node,
+                                )
+                              ) {
+                                event.preventDefault();
+                              }
+                            }}
+                            onFocusOutside={(event) => {
+                              if (imageGenerationHelpPinned) event.preventDefault();
+                            }}
+                            className="z-[10001] w-72 max-w-[calc(100vw-2rem)] rounded-xl border-[var(--border-default)] bg-[var(--surface-elevated)] p-3 text-12 text-[var(--text-secondary)]"
+                          >
+                            {renderImageGenerationHelpContent()}
+                          </PopoverContent>
+                        </Popover>
+                      </div>
+                    )}
+                  </div>
+                )}
               </>
             )}
 
@@ -2561,6 +2966,7 @@ export function CustomProviderDialog({
         {/* Footer */}
         <div className="flex justify-end gap-2.5 px-6 py-4">
           <button
+            ref={saveButtonRef}
             type="button"
             onClick={onClose}
             className={cn(
@@ -2618,6 +3024,85 @@ export function CustomProviderDialog({
           onToggleField={toggleRuntimeFillField}
           onApply={applyRuntimeFill}
         />
+      )}
+      {imageGenerationReloadConfirmation && (
+        <Dialog.Root
+          open
+          onOpenChange={(open) => {
+            if (!open && !savingRef.current) {
+              imageGenerationReloadConfirmationRef.current = null;
+              setImageGenerationReloadConfirmation(null);
+            }
+          }}
+        >
+          <Dialog.Portal>
+            <Dialog.Overlay className="fixed inset-0 z-[10002] bg-[var(--overlay-modal)] data-[state=open]:animate-confirm-overlay-in data-[state=closed]:animate-confirm-overlay-out" />
+            <Dialog.Content
+              aria-describedby="custom-provider-image-generation-reload-description"
+              onOpenAutoFocus={(event) => {
+                event.preventDefault();
+                document.getElementById('custom-provider-image-generation-reload-primary')?.focus();
+              }}
+              onCloseAutoFocus={(event) => {
+                event.preventDefault();
+                saveButtonRef.current?.focus();
+              }}
+              onEscapeKeyDown={(event) => {
+                if (saving) event.preventDefault();
+              }}
+              className={cn(
+                'fixed inset-0 z-[10002] m-auto flex h-fit max-h-[85vh] w-[520px] max-w-[calc(100vw-2rem)] flex-col rounded-xl p-4 outline-none',
+                'bg-[var(--confirm-bg)] shadow-[var(--confirm-shadow)]',
+                'data-[state=open]:animate-confirm-content-layout-in data-[state=closed]:animate-confirm-content-layout-out',
+              )}
+            >
+              <button
+                type="button"
+                aria-label={t('settings.providers.custom.imageGenerationReload.close')}
+                disabled={saving}
+                onClick={() => {
+                  imageGenerationReloadConfirmationRef.current = null;
+                  setImageGenerationReloadConfirmation(null);
+                }}
+                className="absolute right-3 top-3 rounded-full p-1.5 text-[var(--text-tertiary)] transition-colors hover:bg-[var(--surface-hover)] hover:text-[var(--text-primary)] focus-visible:ring-2 focus-visible:ring-[var(--focus-ring)] disabled:opacity-50"
+              >
+                <X size={16} />
+              </button>
+              <Dialog.Title className="pr-9 text-lg font-medium text-[var(--confirm-title)]">
+                {t('settings.providers.custom.imageGenerationReload.title')}
+              </Dialog.Title>
+              <Dialog.Description
+                id="custom-provider-image-generation-reload-description"
+                className="mt-2 whitespace-pre-line text-base leading-relaxed text-[var(--confirm-desc)]"
+              >
+                {t('settings.providers.custom.imageGenerationReload.description')}
+              </Dialog.Description>
+              <div className="mt-6 flex flex-wrap justify-end gap-2.5">
+                <button
+                  type="button"
+                  disabled={saving}
+                  onClick={() => void saveWithImageGenerationRestartPolicy('wait')}
+                  className="inline-flex min-w-[96px] items-center justify-center rounded-full border border-[var(--confirm-btn-secondary-border)] bg-transparent px-6 py-2.5 text-13 font-medium text-[var(--confirm-btn-secondary-text)] transition-colors hover:bg-[var(--confirm-btn-secondary-hover)] focus-visible:ring-2 focus-visible:ring-[var(--confirm-btn-secondary-border)] disabled:opacity-50"
+                >
+                  {t('settings.providers.custom.imageGenerationReload.wait')}
+                </button>
+                <button
+                  id="custom-provider-image-generation-reload-primary"
+                  type="button"
+                  disabled={saving}
+                  onClick={() => void saveWithImageGenerationRestartPolicy('interrupt')}
+                  className="inline-flex min-w-[96px] items-center justify-center rounded-full bg-[hsl(var(--destructive))] px-6 py-2.5 text-13 font-medium text-[var(--accent-pure-cta-fg)] transition-opacity hover:opacity-90 focus-visible:ring-2 focus-visible:ring-[var(--focus-ring)] disabled:opacity-50"
+                >
+                  {saving ? (
+                    <Spinner size={14} />
+                  ) : (
+                    t('settings.providers.custom.imageGenerationReload.interrupt')
+                  )}
+                </button>
+              </div>
+            </Dialog.Content>
+          </Dialog.Portal>
+        </Dialog.Root>
       )}
     </div>
   );

--- a/apps/desktop/src/renderer/components/settings/__tests__/CustomProviderDialogAccessibility.test.tsx
+++ b/apps/desktop/src/renderer/components/settings/__tests__/CustomProviderDialogAccessibility.test.tsx
@@ -1,6 +1,6 @@
 // @vitest-environment jsdom
 import { useRef, useState } from 'react';
-import { cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { act, cleanup, fireEvent, render, screen, waitFor, within } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import type { CustomProviderConfig } from '@cindy/model-providers';
@@ -9,24 +9,28 @@ import { CustomProviderDialog } from '../CustomProviderDialog';
 
 const customProviderMocks = vi.hoisted(() => ({
   readCustomProviderKey: vi.fn(),
+  createCustomProvider: vi.fn(),
   updateCustomProvider: vi.fn(),
 }));
 
 vi.mock('@/lib/customProviders', async (importOriginal) => ({
   ...(await importOriginal<typeof import('@/lib/customProviders')>()),
   readCustomProviderKey: customProviderMocks.readCustomProviderKey,
+  createCustomProvider: customProviderMocks.createCustomProvider,
   updateCustomProvider: customProviderMocks.updateCustomProvider,
 }));
 
 vi.mock('react-i18next', () => ({
   useTranslation: () => ({
-    t: (key: string) => key,
+    t: (key: string) =>
+      key === 'settings.providers.custom.imageGenerationReload.wait' ? '结束后自动加载' : key,
     i18n: { language: 'en' },
   }),
 }));
 
 beforeEach(() => {
   customProviderMocks.readCustomProviderKey.mockReset();
+  customProviderMocks.createCustomProvider.mockReset().mockResolvedValue({ ok: true });
   customProviderMocks.updateCustomProvider.mockReset().mockResolvedValue(undefined);
   Object.defineProperty(window, 'electronAPI', {
     configurable: true,
@@ -42,9 +46,7 @@ beforeEach(() => {
 afterEach(cleanup);
 
 async function waitForInitialDialogFocus(): Promise<void> {
-  const nameInput = screen.getByPlaceholderText(
-    'settings.providers.custom.fields.namePlaceholder',
-  );
+  const nameInput = screen.getByPlaceholderText('settings.providers.custom.fields.namePlaceholder');
   await waitFor(() => expect(document.activeElement).toBe(nameInput));
 }
 
@@ -74,7 +76,328 @@ function modelRoutedCodexProvider(): CustomProviderConfig {
   };
 }
 
+function imageGenerationFromModelRouteProvider(): CustomProviderConfig {
+  return {
+    id: 'model-route-images',
+    name: 'Model route images',
+    auth: { method: 'apiKey' },
+    runtimes: {
+      codex: {
+        baseUrl: 'https://chat.example.test/v1',
+        wireProtocol: 'openai-chat',
+        requestPath: '/chat/completions',
+        supportsImageGeneration: true,
+        models: [
+          {
+            id: 'routed-model',
+            name: 'Routed Model',
+            route: {
+              baseUrl: 'https://responses.example.test/v1',
+              wireProtocol: 'openai-responses',
+              requestPath: '/responses',
+            },
+          },
+        ],
+      },
+    },
+  };
+}
+
+async function renderImageGenerationHelp() {
+  const initial: CustomProviderConfig = {
+    id: 'image-help-provider',
+    name: 'Image help provider',
+    auth: { method: 'apiKey' },
+    runtimes: {
+      codex: {
+        baseUrl: 'https://images.example.test/v1',
+        models: [{ id: 'responses-model', name: 'Responses Model' }],
+        supportsImageGeneration: true,
+      },
+    },
+  };
+  customProviderMocks.readCustomProviderKey.mockResolvedValue(null);
+  const user = userEvent.setup();
+  render(<CustomProviderDialog initial={initial} onSaved={vi.fn()} onClose={vi.fn()} />);
+  await waitFor(() => expect(customProviderMocks.readCustomProviderKey).toHaveBeenCalled());
+  const advanced = screen.getByRole('button', {
+    name: 'settings.providers.custom.fields.runtimeAdvanced',
+  });
+  await user.click(advanced);
+  const help = screen.getByRole('button', {
+    name: 'settings.providers.custom.fields.runtimeSupportsImageGenerationHelpLabel',
+  });
+  return { advanced, help, user };
+}
+
+async function renderImageGenerationReloadConfirmation(onSaved = vi.fn(), onClose = vi.fn()) {
+  const initial: CustomProviderConfig = {
+    id: 'reload-image-provider',
+    name: 'Reload image provider',
+    auth: { method: 'apiKey' },
+    runtimes: {
+      codex: {
+        baseUrl: 'https://images.example.test/v1',
+        models: [{ id: 'responses-model', name: 'Responses model' }],
+      },
+    },
+  };
+  customProviderMocks.readCustomProviderKey.mockResolvedValue(null);
+  customProviderMocks.updateCustomProvider.mockResolvedValueOnce({
+    ok: false,
+    confirmationRequired: 'codex-image-generation-reload',
+    busyCount: 3,
+  });
+  const user = userEvent.setup();
+  render(<CustomProviderDialog initial={initial} onSaved={onSaved} onClose={onClose} />);
+  await waitFor(() => expect(customProviderMocks.readCustomProviderKey).toHaveBeenCalled());
+  await user.click(
+    screen.getByRole('button', { name: 'settings.providers.custom.fields.runtimeAdvanced' }),
+  );
+  await user.click(
+    screen.getByRole('checkbox', {
+      name: 'settings.providers.custom.fields.runtimeSupportsImageGeneration',
+    }),
+  );
+  await user.click(screen.getByRole('button', { name: 'settings.providers.custom.save' }));
+  const confirmation = await screen.findByRole('dialog', {
+    name: 'settings.providers.custom.imageGenerationReload.title',
+  });
+  return { confirmation, onClose, onSaved, user };
+}
+
+async function renderNewImageGenerationReloadConfirmation(onSaved = vi.fn(), onClose = vi.fn()) {
+  customProviderMocks.createCustomProvider.mockResolvedValueOnce({
+    ok: false,
+    confirmationRequired: 'codex-image-generation-reload',
+    busyCount: 3,
+  });
+  const user = userEvent.setup();
+  render(<CustomProviderDialog onSaved={onSaved} onClose={onClose} />);
+  await user.type(
+    screen.getByPlaceholderText('settings.providers.custom.fields.namePlaceholder'),
+    'New image provider',
+  );
+  await user.click(screen.getByRole('tab', { name: 'settings.providers.custom.protocol.codex' }));
+  await user.type(
+    screen.getByPlaceholderText('settings.providers.custom.fields.baseUrlPlaceholder'),
+    'https://images.example.test/v1',
+  );
+  await user.type(
+    screen.getByPlaceholderText('settings.providers.custom.fields.modelIdPlaceholder'),
+    'responses-model',
+  );
+  await user.type(
+    screen.getByPlaceholderText('settings.providers.custom.fields.modelNamePlaceholder'),
+    'Responses model',
+  );
+  await user.click(
+    screen.getByRole('button', { name: 'settings.providers.custom.fields.runtimeAdvanced' }),
+  );
+  await user.click(
+    screen.getByRole('checkbox', {
+      name: 'settings.providers.custom.fields.runtimeSupportsImageGeneration',
+    }),
+  );
+  await user.click(screen.getByRole('button', { name: 'settings.providers.custom.save' }));
+  const confirmation = await screen.findByRole('dialog', {
+    name: 'settings.providers.custom.imageGenerationReload.title',
+  });
+  return { confirmation, onClose, onSaved, user };
+}
+
 describe('CustomProviderDialog accessibility', () => {
+  it('asks before manually creating an image Provider and X, Escape, or outside do not create it', async () => {
+    const { confirmation, onClose, onSaved, user } =
+      await renderNewImageGenerationReloadConfirmation();
+    const pendingId = customProviderMocks.createCustomProvider.mock.calls[0]?.[0].id;
+    expect(pendingId).toBeTruthy();
+    expect(customProviderMocks.createCustomProvider).toHaveBeenCalledWith(
+      expect.objectContaining({ id: pendingId }),
+      {},
+      { source: 'manual-settings' },
+    );
+
+    await user.click(
+      within(confirmation).getByRole('button', {
+        name: 'settings.providers.custom.imageGenerationReload.close',
+      }),
+    );
+    expect(customProviderMocks.createCustomProvider).toHaveBeenCalledOnce();
+
+    customProviderMocks.createCustomProvider.mockResolvedValueOnce({
+      ok: false,
+      confirmationRequired: 'codex-image-generation-reload',
+      busyCount: 2,
+    });
+    await user.click(screen.getByRole('button', { name: 'settings.providers.custom.save' }));
+    await screen.findByRole('dialog', {
+      name: 'settings.providers.custom.imageGenerationReload.title',
+    });
+    await user.keyboard('{Escape}');
+    expect(customProviderMocks.createCustomProvider).toHaveBeenCalledTimes(2);
+
+    customProviderMocks.createCustomProvider.mockResolvedValueOnce({
+      ok: false,
+      confirmationRequired: 'codex-image-generation-reload',
+      busyCount: 1,
+    });
+    await user.click(screen.getByRole('button', { name: 'settings.providers.custom.save' }));
+    const outsideConfirmation = await screen.findByRole('dialog', {
+      name: 'settings.providers.custom.imageGenerationReload.title',
+    });
+    const overlay = outsideConfirmation.previousElementSibling;
+    expect(overlay).not.toBeNull();
+    fireEvent.pointerDown(overlay!);
+    fireEvent.click(overlay!);
+    await waitFor(() =>
+      expect(
+        screen.queryByRole('dialog', {
+          name: 'settings.providers.custom.imageGenerationReload.title',
+        }),
+      ).toBeNull(),
+    );
+    expect(customProviderMocks.createCustomProvider).toHaveBeenCalledTimes(3);
+    expect(customProviderMocks.createCustomProvider.mock.calls.map((call) => call[0].id)).toEqual([
+      pendingId,
+      pendingId,
+      pendingId,
+    ]);
+    expect(onSaved).not.toHaveBeenCalled();
+    expect(onClose).not.toHaveBeenCalled();
+  });
+
+  it.each([
+    ['wait', '结束后自动加载'],
+    ['interrupt', 'settings.providers.custom.imageGenerationReload.interrupt'],
+  ] as const)('creates once after the %s reload strategy is confirmed', async (policy, label) => {
+    const onSaved = vi.fn();
+    const { confirmation, user } = await renderNewImageGenerationReloadConfirmation(onSaved);
+    const pendingConfig = customProviderMocks.createCustomProvider.mock.calls[0]?.[0];
+    customProviderMocks.createCustomProvider.mockResolvedValueOnce({ ok: true });
+
+    await user.click(within(confirmation).getByRole('button', { name: label }));
+
+    await waitFor(() => expect(onSaved).toHaveBeenCalledOnce());
+    expect(customProviderMocks.createCustomProvider).toHaveBeenCalledTimes(2);
+    expect(customProviderMocks.createCustomProvider).toHaveBeenLastCalledWith(
+      pendingConfig,
+      {},
+      {
+        source: 'manual-settings',
+        codexImageGenerationRestartPolicy: policy,
+      },
+    );
+  });
+
+  it('asks before a manual image-generation save and closes via X, Escape, or outside without saving', async () => {
+    const { confirmation, onClose, onSaved, user } =
+      await renderImageGenerationReloadConfirmation();
+    expect(customProviderMocks.updateCustomProvider).toHaveBeenCalledWith(
+      expect.any(Object),
+      {},
+      { source: 'manual-settings' },
+    );
+    expect(screen.getAllByRole('dialog', { hidden: true })).toHaveLength(2);
+
+    await user.click(
+      within(confirmation).getByRole('button', {
+        name: 'settings.providers.custom.imageGenerationReload.close',
+      }),
+    );
+    expect(
+      screen.queryByRole('dialog', {
+        name: 'settings.providers.custom.imageGenerationReload.title',
+      }),
+    ).toBeNull();
+    expect(
+      screen.getByRole('dialog', { name: 'settings.providers.custom.dialog.editTitle' }),
+    ).toBeTruthy();
+    expect(customProviderMocks.updateCustomProvider).toHaveBeenCalledTimes(1);
+
+    customProviderMocks.updateCustomProvider.mockResolvedValueOnce({
+      ok: false,
+      confirmationRequired: 'codex-image-generation-reload',
+      busyCount: 3,
+    });
+    await user.click(screen.getByRole('button', { name: 'settings.providers.custom.save' }));
+    await screen.findByRole('dialog', {
+      name: 'settings.providers.custom.imageGenerationReload.title',
+    });
+    await user.keyboard('{Escape}');
+    expect(
+      screen.queryByRole('dialog', {
+        name: 'settings.providers.custom.imageGenerationReload.title',
+      }),
+    ).toBeNull();
+
+    customProviderMocks.updateCustomProvider.mockResolvedValueOnce({
+      ok: false,
+      confirmationRequired: 'codex-image-generation-reload',
+      busyCount: 3,
+    });
+    await user.click(screen.getByRole('button', { name: 'settings.providers.custom.save' }));
+    const outsideConfirmation = await screen.findByRole('dialog', {
+      name: 'settings.providers.custom.imageGenerationReload.title',
+    });
+    const overlay = outsideConfirmation.previousElementSibling;
+    expect(overlay).not.toBeNull();
+    fireEvent.pointerDown(overlay!);
+    fireEvent.click(overlay!);
+    await waitFor(() =>
+      expect(
+        screen.queryByRole('dialog', {
+          name: 'settings.providers.custom.imageGenerationReload.title',
+        }),
+      ).toBeNull(),
+    );
+    expect(customProviderMocks.updateCustomProvider).toHaveBeenCalledTimes(3);
+    expect(onSaved).not.toHaveBeenCalled();
+    expect(onClose).not.toHaveBeenCalled();
+  });
+
+  it('saves with the wait policy without requesting interruption', async () => {
+    const onSaved = vi.fn();
+    const { confirmation, user } = await renderImageGenerationReloadConfirmation(onSaved);
+    customProviderMocks.updateCustomProvider.mockResolvedValueOnce({ ok: true });
+
+    await user.click(
+      within(confirmation).getByRole('button', {
+        name: '结束后自动加载',
+      }),
+    );
+    await waitFor(() => expect(onSaved).toHaveBeenCalledOnce());
+    expect(customProviderMocks.updateCustomProvider).toHaveBeenLastCalledWith(
+      expect.any(Object),
+      {},
+      {
+        source: 'manual-settings',
+        codexImageGenerationRestartPolicy: 'wait',
+      },
+    );
+  });
+
+  it('saves with the interrupt policy only after explicit confirmation', async () => {
+    const onSaved = vi.fn();
+    const { confirmation, user } = await renderImageGenerationReloadConfirmation(onSaved);
+    customProviderMocks.updateCustomProvider.mockResolvedValueOnce({ ok: true });
+
+    await user.click(
+      within(confirmation).getByRole('button', {
+        name: 'settings.providers.custom.imageGenerationReload.interrupt',
+      }),
+    );
+    await waitFor(() => expect(onSaved).toHaveBeenCalledOnce());
+    expect(customProviderMocks.updateCustomProvider).toHaveBeenLastCalledWith(
+      expect.any(Object),
+      {},
+      {
+        source: 'manual-settings',
+        codexImageGenerationRestartPolicy: 'interrupt',
+      },
+    );
+  });
+
   it('ignores consumed and IME Escape events, then restores focus after closing', async () => {
     function Harness() {
       const [open, setOpen] = useState(false);
@@ -200,7 +523,9 @@ describe('CustomProviderDialog accessibility', () => {
     await user.click(screen.getByRole('button', { name: 'settings.providers.custom.save' }));
 
     await waitFor(() => expect(customProviderMocks.updateCustomProvider).toHaveBeenCalledOnce());
-    expect(customProviderMocks.updateCustomProvider.mock.calls[0]?.[0].runtimes.codex?.models).toEqual([
+    expect(
+      customProviderMocks.updateCustomProvider.mock.calls[0]?.[0].runtimes.codex?.models,
+    ).toEqual([
       {
         id: 'glm-5.3',
         name: 'GLM-5.3',
@@ -474,7 +799,6 @@ describe('CustomProviderDialog accessibility', () => {
       },
     };
     customProviderMocks.readCustomProviderKey.mockResolvedValue(null);
-
     const user = userEvent.setup();
     render(<CustomProviderDialog initial={initial} onSaved={vi.fn()} onClose={vi.fn()} />);
     await waitFor(() => expect(customProviderMocks.readCustomProviderKey).toHaveBeenCalled());
@@ -505,8 +829,462 @@ describe('CustomProviderDialog accessibility', () => {
     await waitFor(() => expect(configuredBadge()).not.toBeNull());
 
     // 切到无鉴权：none 模式剥凭证头，已存头不再有效，徽标隐藏。
-    await user.click(screen.getByRole('button', { name: 'settings.providers.custom.authMode.none' }));
+    await user.click(
+      screen.getByRole('button', { name: 'settings.providers.custom.authMode.none' }),
+    );
     await waitFor(() => expect(configuredBadge()).toBeNull());
     expect(document.body.textContent).not.toContain('configured-header-secret');
+  });
+
+  it('places the provider image capability below headers in a collapsed accessible disclosure', async () => {
+    const initial: CustomProviderConfig = {
+      id: 'image-provider',
+      name: 'Image provider',
+      auth: { method: 'apiKey' },
+      runtimes: {
+        codex: {
+          baseUrl: 'https://images.example.test/v1',
+          models: [{ id: 'responses-model', name: 'Responses Model' }],
+          supportsImageGeneration: true,
+        },
+      },
+    };
+    customProviderMocks.readCustomProviderKey.mockResolvedValue(null);
+    const consoleError = vi.spyOn(console, 'error');
+    const onClose = vi.fn();
+
+    const user = userEvent.setup();
+    render(<CustomProviderDialog initial={initial} onSaved={vi.fn()} onClose={onClose} />);
+    await waitFor(() => expect(customProviderMocks.readCustomProviderKey).toHaveBeenCalled());
+
+    const headersLabel = screen.getByText('settings.providers.custom.fields.headers');
+    const advanced = screen.getByRole('button', {
+      name: 'settings.providers.custom.fields.runtimeAdvanced',
+    });
+    expect(
+      headersLabel.compareDocumentPosition(advanced) & Node.DOCUMENT_POSITION_FOLLOWING,
+    ).toBeTruthy();
+    expect(advanced.getAttribute('aria-expanded')).toBe('false');
+    expect(
+      screen.queryByRole('checkbox', {
+        name: 'settings.providers.custom.fields.runtimeSupportsImageGeneration',
+      }),
+    ).toBeNull();
+
+    await user.click(advanced);
+    const capability = screen.getByRole('checkbox', {
+      name: 'settings.providers.custom.fields.runtimeSupportsImageGeneration',
+    });
+    expect((capability as HTMLInputElement).checked).toBe(true);
+    expect(advanced.getAttribute('aria-expanded')).toBe('true');
+
+    const help = screen.getByRole('button', {
+      name: 'settings.providers.custom.fields.runtimeSupportsImageGenerationHelpLabel',
+    });
+    expect(help.getAttribute('aria-label')).toBe(
+      'settings.providers.custom.fields.runtimeSupportsImageGenerationHelpLabel',
+    );
+    expect(help.querySelector('button')).toBeNull();
+    const capabilityLabel = capability.closest('label');
+    const capabilityRow = capabilityLabel?.parentElement;
+    expect(capabilityLabel?.className).toContain('items-center');
+    expect(capability.className).not.toContain('mt-0.5');
+    expect(capabilityRow?.className).toContain('min-h-11');
+    expect(capabilityRow?.className).toContain('items-center');
+
+    const expectCompleteImageGenerationHelp = (content: HTMLElement) => {
+      const helpContent = within(content);
+      expect(
+        helpContent.getByText(
+          'settings.providers.custom.fields.runtimeSupportsImageGenerationConditionTitle',
+        ),
+      ).toBeTruthy();
+      expect(
+        helpContent.getByText(
+          'settings.providers.custom.fields.runtimeSupportsImageGenerationCondition',
+        ),
+      ).toBeTruthy();
+      expect(
+        helpContent.getByText(
+          'settings.providers.custom.fields.runtimeSupportsImageGenerationEndpointsTitle',
+        ),
+      ).toBeTruthy();
+      expect(helpContent.getByText('/images/generations').tagName).toBe('CODE');
+      expect(helpContent.getByText('/images/edits').tagName).toBe('CODE');
+      expect(
+        helpContent.getByText(
+          'settings.providers.custom.fields.runtimeSupportsImageGenerationPermissionsTitle',
+        ),
+      ).toBeTruthy();
+      expect(
+        helpContent.getByText(
+          'settings.providers.custom.fields.runtimeSupportsImageGenerationPermissions',
+        ),
+      ).toBeTruthy();
+    };
+
+    await user.hover(help);
+    expectCompleteImageGenerationHelp(await screen.findByRole('tooltip'));
+    expect(document.querySelectorAll('#custom-provider-image-generation-help-card')).toHaveLength(
+      1,
+    );
+    await user.unhover(help);
+    await user.hover(screen.getByRole('tooltip'));
+    await act(() => new Promise((resolve) => window.setTimeout(resolve, 150)));
+    expectCompleteImageGenerationHelp(screen.getByRole('tooltip'));
+    await user.unhover(screen.getByRole('tooltip'));
+    await waitFor(() => expect(screen.queryByRole('tooltip')).toBeNull());
+
+    await user.hover(help);
+    expectCompleteImageGenerationHelp(await screen.findByRole('tooltip'));
+    await user.keyboard('{Escape}');
+    await waitFor(() => expect(screen.queryByRole('tooltip')).toBeNull());
+    expect(
+      screen.getByRole('dialog', { name: 'settings.providers.custom.dialog.editTitle' }),
+    ).toBeTruthy();
+    expect(document.activeElement).toBe(help);
+    expect(onClose).not.toHaveBeenCalled();
+    await act(() => new Promise((resolve) => window.setTimeout(resolve, 0)));
+    expect(screen.queryByRole('tooltip')).toBeNull();
+    await user.unhover(help);
+
+    await act(async () => help.focus());
+    expect(screen.queryByRole('tooltip')).toBeNull();
+    await act(async () => capability.focus());
+    await act(async () => help.focus());
+    expectCompleteImageGenerationHelp(await screen.findByRole('tooltip'));
+    await act(async () => help.blur());
+    await waitFor(() => expect(screen.queryByRole('tooltip')).toBeNull());
+
+    await user.hover(help);
+    expectCompleteImageGenerationHelp(await screen.findByRole('tooltip'));
+    await user.click(help);
+    let helpPopover = await screen.findByRole('dialog', {
+      name: 'settings.providers.custom.fields.runtimeSupportsImageGenerationHelpLabel',
+    });
+    expect(screen.queryByRole('tooltip')).toBeNull();
+    expectCompleteImageGenerationHelp(helpPopover);
+    await user.keyboard('{Escape}');
+    await waitFor(() =>
+      expect(
+        screen.queryByRole('dialog', {
+          name: 'settings.providers.custom.fields.runtimeSupportsImageGenerationHelpLabel',
+        }),
+      ).toBeNull(),
+    );
+    expect(
+      screen.getByRole('dialog', { name: 'settings.providers.custom.dialog.editTitle' }),
+    ).toBeTruthy();
+    expect(document.activeElement).toBe(help);
+    expect(onClose).not.toHaveBeenCalled();
+    await act(() => new Promise((resolve) => window.setTimeout(resolve, 0)));
+    expect(screen.queryByRole('tooltip')).toBeNull();
+    await user.unhover(help);
+
+    await user.click(help);
+    helpPopover = await screen.findByRole('dialog', {
+      name: 'settings.providers.custom.fields.runtimeSupportsImageGenerationHelpLabel',
+    });
+    expectCompleteImageGenerationHelp(helpPopover);
+    await user.unhover(help);
+    await act(() => new Promise((resolve) => window.setTimeout(resolve, 150)));
+    expect(
+      screen.getByRole('dialog', {
+        name: 'settings.providers.custom.fields.runtimeSupportsImageGenerationHelpLabel',
+      }),
+    ).toBeTruthy();
+
+    await user.click(help);
+    await waitFor(() =>
+      expect(
+        screen.queryByRole('dialog', {
+          name: 'settings.providers.custom.fields.runtimeSupportsImageGenerationHelpLabel',
+        }),
+      ).toBeNull(),
+    );
+
+    await user.click(help);
+    helpPopover = await screen.findByRole('dialog', {
+      name: 'settings.providers.custom.fields.runtimeSupportsImageGenerationHelpLabel',
+    });
+    expectCompleteImageGenerationHelp(helpPopover);
+    await user.click(capability);
+    await waitFor(() =>
+      expect(
+        screen.queryByRole('dialog', {
+          name: 'settings.providers.custom.fields.runtimeSupportsImageGenerationHelpLabel',
+        }),
+      ).toBeNull(),
+    );
+
+    await act(async () => help.focus());
+    expectCompleteImageGenerationHelp(await screen.findByRole('tooltip'));
+    await user.keyboard('{Enter}');
+    await screen.findByRole('dialog', {
+      name: 'settings.providers.custom.fields.runtimeSupportsImageGenerationHelpLabel',
+    });
+    await act(async () => capability.focus());
+    expect(
+      screen.getByRole('dialog', {
+        name: 'settings.providers.custom.fields.runtimeSupportsImageGenerationHelpLabel',
+      }),
+    ).toBeTruthy();
+    await user.keyboard('{Escape}');
+    await waitFor(() =>
+      expect(
+        screen.queryByRole('dialog', {
+          name: 'settings.providers.custom.fields.runtimeSupportsImageGenerationHelpLabel',
+        }),
+      ).toBeNull(),
+    );
+    expect(
+      screen.getByRole('dialog', { name: 'settings.providers.custom.dialog.editTitle' }),
+    ).toBeTruthy();
+    expect(document.activeElement).toBe(help);
+    expect(onClose).not.toHaveBeenCalled();
+
+    await act(async () => capability.focus());
+    await act(async () => help.focus());
+    expectCompleteImageGenerationHelp(await screen.findByRole('tooltip'));
+    await user.keyboard('{Escape}');
+    await waitFor(() => expect(screen.queryByRole('tooltip')).toBeNull());
+    expect(document.activeElement).toBe(help);
+    expect(onClose).not.toHaveBeenCalled();
+    await act(async () => capability.focus());
+    await user.keyboard('{Escape}');
+    expect(onClose).toHaveBeenCalledOnce();
+
+    await act(async () => help.focus());
+    expectCompleteImageGenerationHelp(await screen.findByRole('tooltip'));
+    await user.keyboard(' ');
+    await screen.findByRole('dialog', {
+      name: 'settings.providers.custom.fields.runtimeSupportsImageGenerationHelpLabel',
+    });
+    await user.keyboard('{Escape}');
+    await waitFor(() =>
+      expect(
+        screen.queryByRole('dialog', {
+          name: 'settings.providers.custom.fields.runtimeSupportsImageGenerationHelpLabel',
+        }),
+      ).toBeNull(),
+    );
+
+    expect(consoleError.mock.calls.flat().join('\n')).not.toMatch(
+      /changing an (uncontrolled|controlled).*component/i,
+    );
+    consoleError.mockRestore();
+  });
+
+  it('lets the first real hover open after dismissing a focus-only preview', async () => {
+    const { help, user } = await renderImageGenerationHelp();
+
+    await act(async () => help.focus());
+    await screen.findByRole('tooltip');
+    await user.keyboard('{Escape}');
+    await waitFor(() => expect(screen.queryByRole('tooltip')).toBeNull());
+    expect(document.activeElement).toBe(help);
+
+    await act(async () => help.blur());
+    await user.hover(help);
+    expect(await screen.findByRole('tooltip')).toBeTruthy();
+  });
+
+  it('resets help interaction state when Advanced is collapsed and remounted', async () => {
+    const { advanced, help, user } = await renderImageGenerationHelp();
+
+    await act(async () => help.focus());
+    await screen.findByRole('tooltip');
+    await user.keyboard('{Escape}');
+    await act(async () => help.blur());
+    await user.click(advanced);
+    expect(
+      screen.queryByRole('button', {
+        name: 'settings.providers.custom.fields.runtimeSupportsImageGenerationHelpLabel',
+      }),
+    ).toBeNull();
+
+    await user.click(advanced);
+    const remountedHelp = screen.getByRole('button', {
+      name: 'settings.providers.custom.fields.runtimeSupportsImageGenerationHelpLabel',
+    });
+    await user.hover(remountedHelp);
+    expect(await screen.findByRole('tooltip')).toBeTruthy();
+  });
+
+  it('suppresses only same-exit-frame pointer re-entry after Escape', async () => {
+    const { help, user } = await renderImageGenerationHelp();
+
+    await user.hover(help);
+    await screen.findByRole('tooltip');
+    fireEvent.keyDown(window, { key: 'Escape' });
+    fireEvent.pointerEnter(help);
+    expect(help.getAttribute('aria-expanded')).toBe('false');
+
+    await act(() => new Promise<void>((resolve) => window.requestAnimationFrame(() => resolve())));
+    expect(help.getAttribute('aria-expanded')).toBe('false');
+    fireEvent.pointerLeave(help);
+    fireEvent.pointerEnter(help);
+    await waitFor(() => expect(help.getAttribute('aria-expanded')).toBe('true'));
+    expect(await screen.findByRole('tooltip')).toBeTruthy();
+  });
+
+  it('clears and omits the provider image capability when Codex loses a Responses route', async () => {
+    const initial: CustomProviderConfig = {
+      id: 'image-provider',
+      name: 'Image provider',
+      auth: { method: 'apiKey' },
+      runtimes: {
+        codex: {
+          baseUrl: 'https://images.example.test/v1',
+          models: [{ id: 'responses-model', name: 'Responses Model' }],
+          supportsImageGeneration: true,
+        },
+      },
+    };
+    customProviderMocks.readCustomProviderKey.mockResolvedValue(null);
+
+    const user = userEvent.setup();
+    render(<CustomProviderDialog initial={initial} onSaved={vi.fn()} onClose={vi.fn()} />);
+    await waitFor(() => expect(customProviderMocks.readCustomProviderKey).toHaveBeenCalled());
+    await user.click(
+      screen.getByRole('button', { name: 'settings.providers.custom.fields.runtimeAdvanced' }),
+    );
+    expect(
+      (
+        screen.getByRole('checkbox', {
+          name: 'settings.providers.custom.fields.runtimeSupportsImageGeneration',
+        }) as HTMLInputElement
+      ).checked,
+    ).toBe(true);
+
+    await user.click(
+      screen.getByRole('button', { name: 'settings.providers.custom.wireProtocol.chat' }),
+    );
+    expect(
+      screen.queryByRole('button', {
+        name: 'settings.providers.custom.fields.runtimeAdvanced',
+      }),
+    ).toBeNull();
+
+    await user.click(screen.getByRole('button', { name: 'settings.providers.custom.save' }));
+    await waitFor(() => expect(customProviderMocks.updateCustomProvider).toHaveBeenCalledOnce());
+    expect(
+      customProviderMocks.updateCustomProvider.mock.calls[0]?.[0].runtimes.codex
+        ?.supportsImageGeneration,
+    ).toBeUndefined();
+  });
+
+  it('immediately clears image generation when the picker replaces the last Responses override', async () => {
+    const fetchProviderModels = vi.fn(async () => ({
+      ok: true as const,
+      models: [
+        { id: 'routed-model', name: 'Routed Model' },
+        { id: 'replacement-model', name: 'Replacement Model' },
+      ],
+    }));
+    Object.defineProperty(window, 'electronAPI', {
+      configurable: true,
+      value: {
+        maker: {
+          listProviderPresets: vi.fn(async () => ({ presets: [] })),
+          testProviderConnection: vi.fn(async () => ({ ok: true, latencyMs: 1 })),
+          fetchProviderModels,
+        },
+      },
+    });
+    customProviderMocks.readCustomProviderKey.mockResolvedValue(null);
+
+    const user = userEvent.setup();
+    render(
+      <CustomProviderDialog
+        initial={imageGenerationFromModelRouteProvider()}
+        onSaved={vi.fn()}
+        onClose={vi.fn()}
+      />,
+    );
+    await waitFor(() => expect(customProviderMocks.readCustomProviderKey).toHaveBeenCalled());
+    await user.click(
+      screen.getByRole('button', { name: 'settings.providers.custom.fields.runtimeAdvanced' }),
+    );
+    expect(
+      (
+        screen.getByRole('checkbox', {
+          name: 'settings.providers.custom.fields.runtimeSupportsImageGeneration',
+        }) as HTMLInputElement
+      ).checked,
+    ).toBe(true);
+
+    await user.click(
+      screen.getByRole('button', { name: 'settings.providers.custom.fetch.button' }),
+    );
+    await screen.findByRole('heading', {
+      name: 'settings.providers.custom.fetch.pickerTitle',
+    });
+    await user.click(screen.getByRole('checkbox', { name: /Routed Model/ }));
+    await user.click(screen.getByRole('checkbox', { name: /Replacement Model/ }));
+    await user.click(
+      screen.getByRole('button', { name: 'settings.providers.custom.fetch.confirm' }),
+    );
+
+    expect(
+      screen.queryByRole('button', {
+        name: 'settings.providers.custom.fields.runtimeAdvanced',
+      }),
+    ).toBeNull();
+
+    // 重新形成 Responses 前门不会恢复旧 true；必须由用户再次显式开启。
+    await user.click(
+      screen.getByRole('button', { name: 'settings.providers.custom.wireProtocol.responses' }),
+    );
+    const capability = screen.getByRole('checkbox', {
+      name: 'settings.providers.custom.fields.runtimeSupportsImageGeneration',
+    }) as HTMLInputElement;
+    expect(capability.checked).toBe(false);
+    await user.click(capability);
+    expect(capability.checked).toBe(true);
+  });
+
+  it('immediately clears image generation when deleting the last Responses override row', async () => {
+    customProviderMocks.readCustomProviderKey.mockResolvedValue(null);
+
+    const user = userEvent.setup();
+    render(
+      <CustomProviderDialog
+        initial={imageGenerationFromModelRouteProvider()}
+        onSaved={vi.fn()}
+        onClose={vi.fn()}
+      />,
+    );
+    await waitFor(() => expect(customProviderMocks.readCustomProviderKey).toHaveBeenCalled());
+    await user.click(
+      screen.getByRole('button', { name: 'settings.providers.custom.fields.runtimeAdvanced' }),
+    );
+    expect(
+      (
+        screen.getByRole('checkbox', {
+          name: 'settings.providers.custom.fields.runtimeSupportsImageGeneration',
+        }) as HTMLInputElement
+      ).checked,
+    ).toBe(true);
+
+    const removeButtons = screen.getAllByRole('button', {
+      name: 'settings.providers.custom.fields.removeRow',
+    });
+    await user.click(removeButtons[0]!);
+    expect(
+      screen.queryByRole('button', {
+        name: 'settings.providers.custom.fields.runtimeAdvanced',
+      }),
+    ).toBeNull();
+
+    await user.click(
+      screen.getByRole('button', { name: 'settings.providers.custom.wireProtocol.responses' }),
+    );
+    const capability = screen.getByRole('checkbox', {
+      name: 'settings.providers.custom.fields.runtimeSupportsImageGeneration',
+    }) as HTMLInputElement;
+    expect(capability.checked).toBe(false);
+    await user.click(capability);
+    expect(capability.checked).toBe(true);
   });
 });

--- a/apps/desktop/src/renderer/i18n/locales/en/common.json
+++ b/apps/desktop/src/renderer/i18n/locales/en/common.json
@@ -1474,6 +1474,13 @@
           "editTitle": "Edit custom provider",
           "desc": "Configure an OpenAI / Anthropic-compatible provider."
         },
+        "imageGenerationReload": {
+          "title": "Reload Codex to enable image generation",
+          "description": "Image generation requires reloading Codex before it can take effect. Reloading now will interrupt the Codex tasks currently in progress.",
+          "interrupt": "Reload now",
+          "wait": "Auto-load when finished",
+          "close": "Close"
+        },
         "fields": {
           "name": "Display name",
           "namePlaceholder": "My AI provider",
@@ -1495,6 +1502,15 @@
           "modelContextWindowTitle": "Context window in tokens. Leave empty for the conservative 200K default; affects the window display and compaction threshold.",
           "modelSupportsImageInput": "Supports image input",
           "modelSupportsImageInputHelp": "Enable only when the model actually accepts visual input. Start a new Pi task after saving.",
+          "runtimeAdvanced": "Advanced",
+          "runtimeSupportsImageGeneration": "Supports image generation and editing",
+          "runtimeSupportsImageGenerationHelpLabel": "About image generation and editing support",
+          "runtimeSupportsImageGenerationConditionTitle": "When to enable",
+          "runtimeSupportsImageGenerationCondition": "Your gateway must be compatible with the OpenAI Responses API and support image generation and editing.",
+          "runtimeSupportsImageGenerationEndpointsTitle": "Required endpoints",
+          "runtimeSupportsImageGenerationEndpoints": "The gateway must handle these requests:",
+          "runtimeSupportsImageGenerationPermissionsTitle": "Access and failures",
+          "runtimeSupportsImageGenerationPermissions": "The current API key, account, or user group needs access to the image model. This switch only declares the gateway's capability and does not grant upstream access. If a request fails, Cindy shows the actual upstream error and does not switch to another image service.",
           "modelSupportsReasoning": "Supports reasoning",
           "modelSupportsReasoningHelp": "Enable only when the model accepts reasoning effort, then select every supported level. Changes take effect in the next Pi Agent session.",
           "modelReasoningEfforts": "Supported reasoning effort levels",

--- a/apps/desktop/src/renderer/i18n/locales/ja/common.json
+++ b/apps/desktop/src/renderer/i18n/locales/ja/common.json
@@ -1474,6 +1474,13 @@
           "editTitle": "カスタムプロバイダーを編集",
           "desc": "OpenAI / Anthropic 互換のプロバイダーを設定します。"
         },
+        "imageGenerationReload": {
+          "title": "画像生成を有効にするため Codex を再読み込み",
+          "description": "画像生成を有効にするには Codex の再読み込みが必要です。今すぐ再読み込みすると、現在実行中の Codex タスクが中断されます。",
+          "interrupt": "今すぐ再読み込み",
+          "wait": "終了後に自動読み込み",
+          "close": "閉じる"
+        },
         "fields": {
           "name": "表示名",
           "namePlaceholder": "マイ AI プロバイダー",
@@ -1495,6 +1502,15 @@
           "modelContextWindowTitle": "コンテキストウィンドウ(トークン数)。空欄の場合は保守的な既定値 200K。ウィンドウ表示と圧縮しきい値に影響します。",
           "modelSupportsImageInput": "画像入力に対応",
           "modelSupportsImageInputHelp": "モデルが実際に画像入力へ対応している場合のみ有効にしてください。保存後、新しい Pi タスクで反映されます。",
+          "runtimeAdvanced": "詳細設定",
+          "runtimeSupportsImageGeneration": "画像の生成と編集に対応",
+          "runtimeSupportsImageGenerationHelpLabel": "画像の生成と編集への対応について",
+          "runtimeSupportsImageGenerationConditionTitle": "適用条件",
+          "runtimeSupportsImageGenerationCondition": "ゲートウェイは OpenAI Responses API と互換性があり、画像の生成と編集に対応している必要があります。",
+          "runtimeSupportsImageGenerationEndpointsTitle": "エンドポイント要件",
+          "runtimeSupportsImageGenerationEndpoints": "ゲートウェイは次のリクエストを処理する必要があります。",
+          "runtimeSupportsImageGenerationPermissionsTitle": "権限とエラー処理",
+          "runtimeSupportsImageGenerationPermissions": "現在の API キー、アカウント、またはユーザーグループに画像モデルへのアクセス権が必要です。この設定はゲートウェイの機能を宣言するだけで、上流へのアクセス権を自動的に付与しません。呼び出しに失敗した場合は実際の上流エラーを表示し、別の画像サービスへ切り替えません。",
           "modelSupportsReasoning": "推論に対応",
           "modelSupportsReasoningHelp": "モデルが推論強度を受け付ける場合のみ有効にし、実際に対応するすべてのレベルを選択してください。保存後、次の Pi Agent セッションから反映されます。",
           "modelReasoningEfforts": "対応する推論強度",

--- a/apps/desktop/src/renderer/i18n/locales/ko/common.json
+++ b/apps/desktop/src/renderer/i18n/locales/ko/common.json
@@ -1474,6 +1474,13 @@
           "editTitle": "사용자 지정 제공자 편집",
           "desc": "OpenAI / Anthropic 호환 제공자를 구성합니다."
         },
+        "imageGenerationReload": {
+          "title": "이미지 생성을 사용하도록 Codex 다시 로드",
+          "description": "이미지 생성 기능을 적용하려면 Codex를 다시 로드해야 합니다. 지금 다시 로드하면 현재 실행 중인 Codex 작업이 중단됩니다.",
+          "interrupt": "지금 다시 로드",
+          "wait": "종료 후 자동 로드",
+          "close": "닫기"
+        },
         "fields": {
           "name": "표시 이름",
           "namePlaceholder": "내 AI 제공자",
@@ -1495,6 +1502,15 @@
           "modelContextWindowTitle": "컨텍스트 윈도우(토큰 수). 비워 두면 보수적 기본값 200K가 적용되며, 윈도우 표시와 압축 임계값에 영향을 줍니다.",
           "modelSupportsImageInput": "이미지 입력 지원",
           "modelSupportsImageInputHelp": "모델이 실제로 시각 입력을 지원할 때만 켜세요. 저장 후 새 Pi 작업부터 적용됩니다.",
+          "runtimeAdvanced": "고급",
+          "runtimeSupportsImageGeneration": "이미지 생성 및 편집 지원",
+          "runtimeSupportsImageGenerationHelpLabel": "이미지 생성 및 편집 지원 정보",
+          "runtimeSupportsImageGenerationConditionTitle": "적용 조건",
+          "runtimeSupportsImageGenerationCondition": "게이트웨이는 OpenAI Responses API와 호환되고 이미지 생성 및 편집을 지원해야 합니다.",
+          "runtimeSupportsImageGenerationEndpointsTitle": "엔드포인트 요구사항",
+          "runtimeSupportsImageGenerationEndpoints": "게이트웨이는 다음 요청을 처리해야 합니다.",
+          "runtimeSupportsImageGenerationPermissionsTitle": "권한 및 실패 처리",
+          "runtimeSupportsImageGenerationPermissions": "현재 API 키, 계정 또는 사용자 그룹에 이미지 모델 권한이 필요합니다. 이 설정은 게이트웨이 기능을 선언할 뿐이며 업스트림 권한을 자동으로 부여하지 않습니다. 호출이 실패하면 실제 업스트림 오류를 표시하며 다른 이미지 서비스로 전환하지 않습니다.",
           "modelSupportsReasoning": "추론 지원",
           "modelSupportsReasoningHelp": "모델이 추론 강도를 허용할 때만 켜고 실제로 지원하는 모든 단계를 선택하세요. 저장 후 다음 Pi Agent 세션부터 적용됩니다.",
           "modelReasoningEfforts": "지원되는 추론 강도",

--- a/apps/desktop/src/renderer/i18n/locales/zh-CN/common.json
+++ b/apps/desktop/src/renderer/i18n/locales/zh-CN/common.json
@@ -1474,6 +1474,13 @@
           "editTitle": "编辑自定义供应商",
           "desc": "配置与 OpenAI / Anthropic 兼容的供应商。"
         },
+        "imageGenerationReload": {
+          "title": "重新加载 Codex 以启用图片生成",
+          "description": "图片生成能力需要重新加载 Codex 后才能生效。立即重新加载会中断当前正在执行的 Codex 任务。",
+          "interrupt": "立即重新加载",
+          "wait": "结束后自动加载",
+          "close": "关闭"
+        },
         "fields": {
           "name": "显示名称",
           "namePlaceholder": "我的 AI 供应商",
@@ -1495,6 +1502,15 @@
           "modelContextWindowTitle": "上下文窗口(tokens)。留空按 200K 保守默认；影响窗口显示与压缩阈值。",
           "modelSupportsImageInput": "支持图片输入",
           "modelSupportsImageInputHelp": "仅在该模型确实支持视觉输入时开启。保存后新建 Pi 任务生效。",
+          "runtimeAdvanced": "高级",
+          "runtimeSupportsImageGeneration": "支持图片生成与编辑",
+          "runtimeSupportsImageGenerationHelpLabel": "了解图片生成与编辑支持",
+          "runtimeSupportsImageGenerationConditionTitle": "适用条件",
+          "runtimeSupportsImageGenerationCondition": "网关需兼容 OpenAI Responses API，并支持图片生成与编辑。",
+          "runtimeSupportsImageGenerationEndpointsTitle": "接口要求",
+          "runtimeSupportsImageGenerationEndpoints": "网关必须处理以下请求：",
+          "runtimeSupportsImageGenerationPermissionsTitle": "权限与失败处理",
+          "runtimeSupportsImageGenerationPermissions": "当前 API Key、账号或用户组需有图片模型权限。此开关只声明网关能力，不会自动开通上游权限。调用失败时会显示真实上游错误，不会切换到其他图片服务。",
           "modelSupportsReasoning": "支持推理",
           "modelSupportsReasoningHelp": "仅在该模型接受推理强度时开启，并勾选它实际支持的所有档位。保存后，下一个 Pi Agent 会话生效。",
           "modelReasoningEfforts": "支持的推理强度",

--- a/apps/desktop/src/renderer/i18n/locales/zh-TW/common.json
+++ b/apps/desktop/src/renderer/i18n/locales/zh-TW/common.json
@@ -1474,6 +1474,13 @@
           "editTitle": "編輯自定義供應商",
           "desc": "配置與 OpenAI / Anthropic 相容的供應商。"
         },
+        "imageGenerationReload": {
+          "title": "重新載入 Codex 以啟用圖片生成",
+          "description": "圖片生成能力需要重新載入 Codex 後才能生效。立即重新載入會中斷目前正在執行的 Codex 任務。",
+          "interrupt": "立即重新載入",
+          "wait": "結束後自動載入",
+          "close": "關閉"
+        },
         "fields": {
           "name": "顯示名稱",
           "namePlaceholder": "我的 AI 供應商",
@@ -1495,6 +1502,15 @@
           "modelContextWindowTitle": "上下文視窗(tokens)。留空按 200K 保守預設；影響視窗顯示與壓縮閾值。",
           "modelSupportsImageInput": "支援圖片輸入",
           "modelSupportsImageInputHelp": "僅在該模型確實支援視覺輸入時開啟。儲存後新建 Pi 任務生效。",
+          "runtimeAdvanced": "進階",
+          "runtimeSupportsImageGeneration": "支援圖片生成與編輯",
+          "runtimeSupportsImageGenerationHelpLabel": "瞭解圖片生成與編輯支援",
+          "runtimeSupportsImageGenerationConditionTitle": "適用條件",
+          "runtimeSupportsImageGenerationCondition": "閘道需相容 OpenAI Responses API，並支援圖片生成與編輯。",
+          "runtimeSupportsImageGenerationEndpointsTitle": "介面要求",
+          "runtimeSupportsImageGenerationEndpoints": "閘道必須處理以下請求：",
+          "runtimeSupportsImageGenerationPermissionsTitle": "權限與失敗處理",
+          "runtimeSupportsImageGenerationPermissions": "目前的 API Key、帳號或使用者群組需有圖片模型權限。此開關只宣告閘道能力，不會自動開通上游權限。呼叫失敗時會顯示真實的上游錯誤，不會切換到其他圖片服務。",
           "modelSupportsReasoning": "支援推理",
           "modelSupportsReasoningHelp": "僅在該模型接受推理強度時開啟，並勾選它實際支援的所有檔位。儲存後，下一個 Pi Agent 會話生效。",
           "modelReasoningEfforts": "支援的推理強度",

--- a/apps/desktop/src/renderer/lib/__tests__/customProviders.test.ts
+++ b/apps/desktop/src/renderer/lib/__tests__/customProviders.test.ts
@@ -645,6 +645,43 @@ describe('providerViewToCustomProviderConfig', () => {
     ]);
   });
 
+  it('round-trips Codex image generation independently from image input', () => {
+    const provider = {
+      id: 'image-provider',
+      name: 'Image Provider',
+      source: 'user',
+      agents: ['codex'],
+      auth: { method: 'apiKey' },
+      access: { kind: 'api' },
+      routing: {
+        codex: {
+          upstream: 'https://image.example/v1',
+          authStrategy: 'api-key-header',
+          wireProtocol: 'openai-responses',
+          supportsImageGeneration: true,
+        },
+      },
+      models: {
+        codex: [
+          {
+            id: 'image-model',
+            name: 'Image Model',
+            contextWindow: 200_000,
+            efforts: [],
+            defaultEffort: null,
+            supportsImageInput: false,
+          },
+        ],
+      },
+      connected: true,
+    } satisfies ProviderView;
+
+    expect(providerViewToCustomProviderConfig(provider).runtimes.codex).toMatchObject({
+      supportsImageGeneration: true,
+      models: [{ id: 'image-model', name: 'Image Model' }],
+    });
+  });
+
   it('round-trips Pi reasoning efforts from a provider view', () => {
     const provider = {
       id: 'local-reasoning',
@@ -814,6 +851,34 @@ describe('custom provider credential lifecycle', () => {
     await createCustomProvider(config, keys);
 
     expect(create).toHaveBeenCalledWith(config, keys);
+  });
+
+  it('forwards the explicit manual create restart policy through the same mutation', async () => {
+    const create = vi.fn(async () => ({ ok: true as const }));
+    vi.stubGlobal('window', {
+      electronAPI: {
+        maker: { createCustomProvider: create },
+      },
+    });
+    const config = {
+      id: 'new-image-provider',
+      name: 'New image provider',
+      runtimes: {
+        codex: {
+          baseUrl: 'https://api.example/v1',
+          supportsImageGeneration: true,
+          models: [{ id: 'model', name: 'Model' }],
+        },
+      },
+    };
+    const options = {
+      source: 'manual-settings' as const,
+      codexImageGenerationRestartPolicy: 'wait' as const,
+    };
+
+    await createCustomProvider(config, {}, options);
+
+    expect(create).toHaveBeenCalledWith(config, {}, options);
   });
 
   it('surfaces an atomic main-process create failure', async () => {

--- a/apps/desktop/src/renderer/lib/customProviders.ts
+++ b/apps/desktop/src/renderer/lib/customProviders.ts
@@ -10,6 +10,10 @@
  */
 
 import { customProviderSecretStorageKey } from '@/../shared/providerSecrets';
+import type {
+  CustomProviderUpdateOptions,
+  CustomProviderUpdateResult,
+} from '@/../shared/customProviderUpdate';
 
 import {
   DEFAULT_CUSTOM_CONTEXT_WINDOW,
@@ -228,6 +232,9 @@ export function providerViewToCustomProviderConfig(p: ProviderView): CustomProvi
       baseUrl: routing?.upstream ?? '',
       ...(routing?.requestPath ? { requestPath: routing.requestPath } : {}),
       ...(routing?.wireProtocol ? { wireProtocol: routing.wireProtocol } : {}),
+      ...(agent === 'codex' && routing?.supportsImageGeneration === true
+        ? { supportsImageGeneration: true }
+        : {}),
       models: models.map((model) => customProviderModelConfigFromCatalogModel(model, agent)),
       ...(routing?.headerOverride && Object.keys(routing.headerOverride).length > 0
         ? { headers: { ...routing.headerOverride } }
@@ -298,19 +305,23 @@ export async function readCustomProviderKey(
 export async function createCustomProvider(
   config: CustomProviderConfig,
   keys: RuntimeKeys,
-): Promise<void> {
-  await window.electronAPI.maker.createCustomProvider(config, keys);
+  options?: CustomProviderUpdateOptions,
+): Promise<CustomProviderUpdateResult> {
+  return options === undefined
+    ? window.electronAPI.maker.createCustomProvider(config, keys)
+    : window.electronAPI.maker.createCustomProvider(config, keys, options);
 }
 
 /** 编辑：main 在同一 provider mutation queue 内提交配置与 runtime 密钥。 */
 export async function updateCustomProvider(
   config: CustomProviderConfig,
   keys: RuntimeKeys,
-): Promise<void> {
-  await window.electronAPI.maker.updateCustomProvider(
-    { ...config, id: storedCustomProviderId(config.id) },
-    keys,
-  );
+  options?: CustomProviderUpdateOptions,
+): Promise<CustomProviderUpdateResult> {
+  const storedConfig = { ...config, id: storedCustomProviderId(config.id) };
+  return options === undefined
+    ? window.electronAPI.maker.updateCustomProvider(storedConfig, keys)
+    : window.electronAPI.maker.updateCustomProvider(storedConfig, keys, options);
 }
 
 /** 删除：main 在同一 provider mutation queue 内清配置与所有凭证。 */

--- a/apps/desktop/src/renderer/vite-env.d.ts
+++ b/apps/desktop/src/renderer/vite-env.d.ts
@@ -18,6 +18,10 @@ type ModelAccessStatusPayload = import('../shared/modelAccess').ModelAccessStatu
 type AnalyticsSettingsPayload = import('../shared/analyticsSettings').AnalyticsSettingsPayload;
 type LogUploadSettingsPayload = import('../shared/logUpload').LogUploadSettingsPayload;
 type LogUploadResult = import('../shared/logUpload').LogUploadResult;
+type CustomProviderUpdateOptions =
+  import('../shared/customProviderUpdate').CustomProviderUpdateOptions;
+type CustomProviderUpdateResult =
+  import('../shared/customProviderUpdate').CustomProviderUpdateResult;
 type RsbWindowCommand = import('../shared/rightSidebarWindow').RsbWindowCommand;
 type VoiceInputPowerStatePayload =
   import('../shared/voiceInputPowerIpc').VoiceInputPowerStatePayload;
@@ -4817,11 +4821,13 @@ interface ElectronAPI {
     createCustomProvider: (
       config: import('@cindy/model-providers').CustomProviderConfig,
       keys: Partial<Record<'claude-code' | 'codex' | 'pi', string>>,
-    ) => Promise<{ ok: true }>;
+      options?: CustomProviderUpdateOptions,
+    ) => Promise<CustomProviderUpdateResult>;
     updateCustomProvider: (
       config: import('@cindy/model-providers').CustomProviderConfig,
       keys: Partial<Record<'claude-code' | 'codex' | 'pi', string>>,
-    ) => Promise<{ ok: true }>;
+      options?: CustomProviderUpdateOptions,
+    ) => Promise<CustomProviderUpdateResult>;
     deleteCustomProvider: (providerId: string) => Promise<{ ok: true }>;
     localModelStatus: () => Promise<import('../shared/localModelRuntime').LocalRuntimeStatus>;
     localModelStart: () => Promise<import('../shared/localModelRuntime').LocalRuntimeStatus>;

--- a/apps/desktop/src/shared/customProviderUpdate.ts
+++ b/apps/desktop/src/shared/customProviderUpdate.ts
@@ -1,0 +1,14 @@
+export type CodexImageGenerationRestartPolicy = 'wait' | 'interrupt';
+
+export interface CustomProviderUpdateOptions {
+  source?: 'manual-settings';
+  codexImageGenerationRestartPolicy?: CodexImageGenerationRestartPolicy;
+}
+
+export type CustomProviderUpdateResult =
+  | { ok: true }
+  | {
+      ok: false;
+      confirmationRequired: 'codex-image-generation-reload';
+      busyCount: number;
+    };

--- a/packages/anthropic-compat-proxy/src/index.ts
+++ b/packages/anthropic-compat-proxy/src/index.ts
@@ -81,6 +81,8 @@ export type {
   InstructionsRegistry,
 } from './instructions-injection.js';
 export type {
+  ForwardLifecycleObserver,
+  ForwardLifecycleFailure,
   LocalRequestHandler,
   OversizedRequestCompactor,
   ProxyHandle,

--- a/packages/anthropic-compat-proxy/src/server.test.ts
+++ b/packages/anthropic-compat-proxy/src/server.test.ts
@@ -43,17 +43,20 @@ const TEST_PI_BINARY = path.join(
 
 function startFakeUpstream(
   handler: (reqIndex: number, body: string, res: ServerResponse) => void,
-): Promise<{ url: string; bodies: string[]; headers: Array<Record<string, string>>; paths: string[]; close: () => Promise<void> }> {
+): Promise<{ url: string; bodies: string[]; rawBodies: Buffer[]; headers: Array<Record<string, string>>; paths: string[]; close: () => Promise<void> }> {
   const bodies: string[] = [];
+  const rawBodies: Buffer[] = [];
   const headers: Array<Record<string, string>> = [];
   const paths: string[] = [];
   const server: Server = createServer((req: IncomingMessage, res: ServerResponse) => {
     const chunks: Buffer[] = [];
     req.on('data', (c: Buffer) => chunks.push(c));
     req.on('end', () => {
-      const body = Buffer.concat(chunks).toString('utf8');
+      const rawBody = Buffer.concat(chunks);
+      const body = rawBody.toString('utf8');
       const idx = bodies.length;
       bodies.push(body);
+      rawBodies.push(rawBody);
       const flat: Record<string, string> = {};
       for (const [k, v] of Object.entries(req.headers)) flat[k.toLowerCase()] = Array.isArray(v) ? v.join(', ') : String(v ?? '');
       headers.push(flat);
@@ -64,6 +67,7 @@ function startFakeUpstream(
   return listenOnAvailableLoopbackPort(server).then((port) => ({
     url: `http://127.0.0.1:${port}`,
     bodies,
+    rawBodies,
     headers,
     paths,
     close: () => new Promise<void>((r) => server.close(() => r())),
@@ -173,6 +177,368 @@ describe('anthropic-compat-proxy loopback port guard', () => {
     expect(await response.json()).toEqual({ source: 'adapted-provider' });
     expect(response.headers.get('content-length')).toBeNull();
     expect(JSON.parse(requestBody)).toEqual({ model: 'test-model', routed: true });
+  });
+
+  it('can preserve an image request body without changing normal response transforms', async () => {
+    const upstream = await startFakeUpstream((_idx, _body, res) => {
+      res.writeHead(200, { 'content-type': 'application/json' });
+      res.end('{}');
+    });
+    upstreamClose = upstream.close;
+
+    proxy = await createAnthropicCompatProxy({
+      upstream: upstream.url,
+      transformRequest: [(body) => ({ ...(body as object), transformed: true })],
+      bypassRequestTransforms: (_body, ctx) => ctx.url.endsWith('/images/generations'),
+    });
+
+    await fetch(`${proxy.url}/v1/images/generations`, {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: '{"model":"gpt-image-2","prompt":"draw"}',
+    });
+    await fetch(`${proxy.url}/v1/responses`, {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: '{"model":"chat-model"}',
+    });
+
+    expect(upstream.bodies).toEqual([
+      '{"model":"gpt-image-2","prompt":"draw"}',
+      '{"model":"chat-model","transformed":true}',
+    ]);
+  });
+
+  it('routes selected multipart requests while preserving their original bytes and headers', async () => {
+    const defaultUpstream = await startFakeUpstream((_idx, _body, res) => {
+      res.writeHead(500).end();
+    });
+    const routedUpstream = await startFakeUpstream((_idx, _body, res) => {
+      res.writeHead(200, { 'content-type': 'application/json' }).end('{}');
+    });
+    upstreamClose = async () => {
+      await Promise.all([defaultUpstream.close(), routedUpstream.close()]);
+    };
+    const boundary = 'cindy-image-boundary';
+    const body = Buffer.concat([
+      Buffer.from(`--${boundary}\r\nContent-Disposition: form-data; name="prompt"\r\n\r\ndraw\r\n`),
+      Buffer.from(`--${boundary}\r\nContent-Disposition: form-data; name="image"; filename="raw.bin"\r\nContent-Type: application/octet-stream\r\n\r\n`),
+      Buffer.from([0, 255, 13, 10, 128, 42]),
+      Buffer.from(`\r\n--${boundary}--\r\n`),
+    ]);
+
+    proxy = await createAnthropicCompatProxy({
+      upstream: defaultUpstream.url,
+      transformRequest: [() => ({ should: 'never run' })],
+      routeOpaqueRequestBody: (ctx) => ctx.url === '/_cindy/imagegen/route/images/edits',
+      bypassRequestTransforms: (_body, ctx) =>
+        ctx.url === '/_cindy/imagegen/route/images/edits',
+      routingTransform: (parsed, ctx) => {
+        expect(parsed).toBeUndefined();
+        expect(ctx.headers['content-type']).toBe(`multipart/form-data; boundary=${boundary}`);
+        return {
+          upstreamOverride: routedUpstream.url,
+          pathOverride: '/images/edits',
+          headerOverride: { authorization: 'Bearer routed-key' },
+        };
+      },
+    });
+
+    const response = await fetch(`${proxy.url}/_cindy/imagegen/route/images/edits`, {
+      method: 'POST',
+      headers: {
+        'content-type': `multipart/form-data; boundary=${boundary}`,
+        'content-length': String(body.length),
+        authorization: 'Bearer loopback-placeholder',
+      },
+      body,
+    });
+
+    expect(response.status).toBe(200);
+    expect(defaultUpstream.rawBodies).toHaveLength(0);
+    expect(routedUpstream.paths).toEqual(['/images/edits']);
+    expect(routedUpstream.rawBodies[0]).toEqual(body);
+    expect(routedUpstream.headers[0]?.['content-type']).toBe(
+      `multipart/form-data; boundary=${boundary}`,
+    );
+    expect(routedUpstream.headers[0]?.['content-length']).toBe(String(body.length));
+    expect(routedUpstream.headers[0]?.authorization).toBe('Bearer routed-key');
+  });
+
+  it('reports content-free lifecycle events at real JSON, multipart, and transport terminal points', async () => {
+    const upstream = await startFakeUpstream((_idx, _body, res) => {
+      res.writeHead(201, { 'content-type': 'application/json' }).end('{"private":"response"}');
+    });
+    upstreamClose = upstream.close;
+    const events: Array<Record<string, unknown>> = [];
+    const prefix = '/_cindy/imagegen/0123456789abcdefabcd';
+
+    proxy = await createAnthropicCompatProxy({
+      upstream: upstream.url,
+      transformRequest: [],
+      routeOpaqueRequestBody: (ctx) => ctx.url === `${prefix}/images/edits`,
+      routingTransform: (_body, ctx) => ({
+        pathOverride: ctx.url.endsWith('/images/edits')
+          ? '/images/edits'
+          : ctx.url.endsWith('/images/generations')
+            ? '/images/generations'
+            : ctx.url,
+        ...(ctx.url.startsWith(`${prefix}/images/`)
+          ? { forwardLifecycle: {
+          onStart: () => events.push({ type: 'start' }),
+          onComplete: (status) => events.push({ type: 'complete', status }),
+          onFailure: (failure, status) => events.push({
+            type: 'transport-error',
+            failure,
+            ...(status === undefined ? {} : { status }),
+          }),
+            } }
+          : {}),
+      }),
+    });
+
+    const generation = await fetch(`${proxy.url}${prefix}/images/generations`, {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: '{"prompt":"private prompt"}',
+    });
+    expect(generation.status).toBe(201);
+
+    const multipart = Buffer.from('private multipart bytes');
+    const edit = await fetch(`${proxy.url}${prefix}/images/edits`, {
+      method: 'POST',
+      headers: { 'content-type': 'multipart/form-data; boundary=private-boundary' },
+      body: multipart,
+    });
+    expect(edit.status).toBe(201);
+
+    await fetch(`${proxy.url}/responses`, {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: '{}',
+    });
+    await fetch(`${proxy.url}/images/generations`, {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: '{}',
+    });
+    expect(events).toEqual([
+      { type: 'start' },
+      { type: 'complete', status: 201 },
+      { type: 'start' },
+      { type: 'complete', status: 201 },
+    ]);
+
+    await upstream.close();
+    upstreamClose = async () => undefined;
+    const unavailable = await fetch(`${proxy.url}${prefix}/images/generations`, {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: '{"prompt":"must not reach lifecycle callbacks"}',
+    });
+    expect(unavailable.status).toBe(502);
+    expect(events.slice(4)).toEqual([
+      { type: 'start' },
+      { type: 'transport-error', failure: 'request-error' },
+    ]);
+    expect(JSON.stringify(events)).not.toMatch(
+      /private prompt|multipart|boundary|response|127\.0\.0\.1|ECONNREFUSED/,
+    );
+  });
+
+  it('emits one terminal lifecycle event for HTTP errors, aborted responses, and successful retry', async () => {
+    const retryAttempts = new Map<string, number>();
+    const upstream = await startFakeUpstream((_idx, body, res) => {
+      const request = JSON.parse(body) as { mode?: string };
+      if (request.mode === 'http-error') {
+        res.writeHead(503, { 'content-type': 'application/json' }).end('{"private":"failure"}');
+        return;
+      }
+      if (request.mode === 'aborted-response') {
+        res.writeHead(200, { 'content-type': 'application/json' });
+        res.write('{"private":"partial"');
+        setImmediate(() => res.destroy());
+        return;
+      }
+      const attempts = (retryAttempts.get(request.mode ?? '') ?? 0) + 1;
+      retryAttempts.set(request.mode ?? '', attempts);
+      if (request.mode === 'retry-success' && attempts === 1) {
+        res.writeHead(400, { 'content-type': 'application/json' }).end(ENC_ERROR_BODY);
+        return;
+      }
+      res.writeHead(200, { 'content-type': 'application/json' }).end('{}');
+    });
+    upstreamClose = upstream.close;
+    const events: Array<Record<string, unknown>> = [];
+    let requestId = 0;
+
+    proxy = await createAnthropicCompatProxy({
+      upstream: upstream.url,
+      transformRequest: [],
+      recoveryRules: [createEncryptedContentRecoveryRule({ enabled: () => true })],
+      routingTransform: () => {
+        const id = ++requestId;
+        return {
+          forwardLifecycle: {
+            onStart: () => events.push({ id, type: 'start' }),
+            onComplete: (status) => events.push({ id, type: 'complete', status }),
+            onFailure: (failure, status) => events.push({
+              id,
+              type: 'failure',
+              failure,
+              ...(status === undefined ? {} : { status }),
+            }),
+          },
+        };
+      },
+    });
+
+    expect((await post(proxy.url, { mode: 'http-error' })).status).toBe(503);
+    await fetch(`${proxy.url}/v1/responses`, {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({ mode: 'aborted-response' }),
+    }).then((response) => response.text()).catch(() => undefined);
+    expect((await post(proxy.url, {
+      mode: 'retry-success',
+      input: [{ type: 'reasoning', encrypted_content: 'gAAA-private' }],
+    })).status).toBe(200);
+
+    expect(upstream.bodies).toHaveLength(4);
+    expect(events.filter((event) => event.id === 1)).toEqual([
+      { id: 1, type: 'start' },
+      { id: 1, type: 'complete', status: 503 },
+    ]);
+    expect(events.filter((event) => event.id === 2)).toEqual([
+      { id: 2, type: 'start' },
+      {
+        id: 2,
+        type: 'failure',
+        failure: expect.stringMatching(/^response-(error|aborted|closed)$/),
+        status: 200,
+      },
+    ]);
+    expect(events.filter((event) => event.id === 3)).toEqual([
+      { id: 3, type: 'start' },
+      { id: 3, type: 'complete', status: 200 },
+    ]);
+  });
+
+  it('settles retry rejection and retry hook failure without a second upstream attempt', async () => {
+    let mode: 'idle' | 'reject' | 'throw' = 'idle';
+    const upstream = await startFakeUpstream((_idx, body, res) => {
+      mode = (JSON.parse(body) as { mode: 'reject' | 'throw' }).mode;
+      res.writeHead(400, { 'content-type': 'application/json' }).end(ENC_ERROR_BODY);
+    });
+    upstreamClose = upstream.close;
+    const events: Array<Record<string, unknown>> = [];
+    let requestId = 0;
+
+    proxy = await createAnthropicCompatProxy({
+      upstream: upstream.url,
+      transformRequest: [],
+      recoveryRules: [createEncryptedContentRecoveryRule({ enabled: () => true })],
+      routingTransform: () => {
+        const id = ++requestId;
+        return {
+          forwardLifecycle: {
+            onStart: () => events.push({ id, type: 'start' }),
+            onComplete: (status) => events.push({ id, type: 'complete', status }),
+            onFailure: (failure) => events.push({ id, type: 'failure', failure }),
+          },
+        };
+      },
+      revalidateBeforeDispatch: () => {
+        if (mode === 'throw') throw new Error('private retry hook error');
+        if (mode === 'reject') {
+          return {
+            localHandler: async ({ res }) => {
+              res.writeHead(503, { 'content-type': 'application/json' }).end('{}');
+            },
+          };
+        }
+        return null;
+      },
+    });
+
+    expect((await post(proxy.url, {
+      mode: 'reject',
+      input: [{ type: 'reasoning', encrypted_content: 'gAAA-private' }],
+    })).status).toBe(503);
+    mode = 'idle';
+    expect((await post(proxy.url, {
+      mode: 'throw',
+      input: [{ type: 'reasoning', encrypted_content: 'gAAA-private' }],
+    })).status).toBe(503);
+
+    expect(upstream.bodies).toHaveLength(2);
+    expect(events).toEqual([
+      { id: 1, type: 'start' },
+      { id: 1, type: 'failure', failure: 'retry-rejected' },
+      { id: 2, type: 'start' },
+      { id: 2, type: 'failure', failure: 'retry-error' },
+    ]);
+    expect(JSON.stringify(events)).not.toContain('private retry hook error');
+  });
+
+  it('settles a client cancellation while waiting for retry revalidation', async () => {
+    let releaseGate!: () => void;
+    let markGateEntered!: () => void;
+    const gateEntered = new Promise<void>((resolve) => { markGateEntered = resolve; });
+    const gateReleased = new Promise<void>((resolve) => { releaseGate = resolve; });
+    let retryPending = false;
+    const upstream = await startFakeUpstream((_idx, _body, res) => {
+      retryPending = true;
+      res.writeHead(400, { 'content-type': 'application/json' }).end(ENC_ERROR_BODY);
+    });
+    upstreamClose = upstream.close;
+    const events: Array<Record<string, unknown>> = [];
+
+    proxy = await createAnthropicCompatProxy({
+      upstream: upstream.url,
+      transformRequest: [],
+      recoveryRules: [createEncryptedContentRecoveryRule({ enabled: () => true })],
+      routingTransform: () => ({
+        forwardLifecycle: {
+          onStart: () => events.push({ type: 'start' }),
+          onComplete: (status) => events.push({ type: 'complete', status }),
+          onFailure: (failure) => events.push({ type: 'failure', failure }),
+        },
+      }),
+      revalidateBeforeDispatch: () => retryPending
+        ? {
+            localHandler: async () => {
+              markGateEntered();
+              await gateReleased;
+            },
+          }
+        : null,
+    });
+
+    const controller = new AbortController();
+    const request = fetch(`${proxy.url}/v1/responses`, {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({
+        input: [{ type: 'reasoning', encrypted_content: 'gAAA-private' }],
+      }),
+      signal: controller.signal,
+    }).catch(() => null);
+    await gateEntered;
+    controller.abort();
+    await request;
+    await vi.waitFor(() => expect(events).toEqual([
+      { type: 'start' },
+      { type: 'failure', failure: 'client-aborted' },
+    ]));
+    releaseGate();
+    await new Promise((resolve) => setImmediate(resolve));
+
+    expect(upstream.bodies).toHaveLength(1);
+    expect(events).toEqual([
+      { type: 'start' },
+      { type: 'failure', failure: 'client-aborted' },
+    ]);
   });
 
   it('settles request-scoped transform state after a non-2xx response', async () => {

--- a/packages/anthropic-compat-proxy/src/server.ts
+++ b/packages/anthropic-compat-proxy/src/server.ts
@@ -42,6 +42,8 @@ import {
   ToolUseIdRewriteTransform,
 } from './tool-use-id-stream-rewrite.js';
 import type {
+  ForwardLifecycleObserver,
+  ForwardLifecycleFailure,
   LocalRequestHandler,
   ProxyHandle,
   ProxyLogger,
@@ -525,6 +527,32 @@ function isPromiseLike<T>(value: unknown): value is PromiseLike<T> {
   );
 }
 
+/** Enforce one real start and one terminal callback across transparent retry recursion. */
+function guardForwardLifecycleObserver(
+  observer: ForwardLifecycleObserver | undefined,
+): ForwardLifecycleObserver | null {
+  if (!observer) return null;
+  let started = false;
+  let settled = false;
+  return {
+    onStart: () => {
+      if (started || settled) return;
+      started = true;
+      observer.onStart?.();
+    },
+    onComplete: (status) => {
+      if (!started || settled) return;
+      settled = true;
+      observer.onComplete?.(status);
+    },
+    onFailure: (failure, status) => {
+      if (!started || settled) return;
+      settled = true;
+      observer.onFailure?.(failure, status);
+    },
+  };
+}
+
 /**
  * 执行路由决策命中的本地 handler(见 types.LocalRequestHandler 契约)。
  *
@@ -916,10 +944,23 @@ function forward(
   // 透明重试前再跑同一条 dispatch gate。返回 false = 已改道(典型 503),
   // 不得带着旧 headerOverride 再发一次。省略 = 与扩展前一样直接重发。
   beforeRetry?: () => Promise<boolean>,
+  // Optional request-local operational observer. It never receives raw request/response data.
+  forwardLifecycle?: ForwardLifecycleObserver | null,
 ): void {
+  // Diagnostics are a strict side channel: callback failures must never change forwarding.
+  const notifyForwardLifecycle = (notify: () => void): void => {
+    try {
+      notify();
+    } catch {
+      // Diagnostic callback: deliberately ignored.
+    }
+  };
   // 客户端已断开(典型:400 缓冲期间断开后走到透明重试)——'close' 已经发过,
   // 下面挂的中断传播 listener 永远不会触发,直接不发起上游请求。
   if (clientRes.destroyed) {
+    if (forwardLifecycle?.onFailure) {
+      notifyForwardLifecycle(() => forwardLifecycle.onFailure?.('client-aborted'));
+    }
     logger.info?.('client already disconnected — skipping upstream forward', { reqId, method, path });
     return;
   }
@@ -982,6 +1023,9 @@ function forward(
     }
   }
   const upstreamReq = reqFn(upstreamOptions);
+  if (forwardLifecycle?.onStart) {
+    notifyForwardLifecycle(() => forwardLifecycle.onStart?.());
+  }
 
   // ── 客户端中断传播 ────────────────────────────────────────────────────────
   // CC 掐流(stall 检测 / 用户 Stop / watchdog interrupt)时只会断开与本代理的
@@ -1051,6 +1095,9 @@ function forward(
     if (proxyDestroyedClient || upstreamResponseTerminal === 'end' || clientRes.writableEnded) return;
     clientAborted = true;
     if (upstreamResponseTerminal === null) upstreamResponseTerminal = 'client-aborted';
+    if (forwardLifecycle?.onFailure) {
+      notifyForwardLifecycle(() => forwardLifecycle.onFailure?.('client-aborted'));
+    }
     logger.info?.('client disconnected mid-response — aborting upstream request', {
       reqId,
       method,
@@ -1098,6 +1145,13 @@ function forward(
           : new Error(rawError === undefined
             ? `upstream response ${reason} before completion`
             : String(rawError));
+        if (forwardLifecycle?.onFailure) {
+          const failure: ForwardLifecycleFailure =
+            reason === 'close' ? 'response-closed' : `response-${reason}`;
+          notifyForwardLifecycle(() =>
+            forwardLifecycle.onFailure?.(failure, status),
+          );
+        }
         logger.error?.('upstream response stream error (during 400 buffering)', {
           reqId,
           err: String(err),
@@ -1186,21 +1240,43 @@ function forward(
               threadMintedIdCache,
               requestDeclaredStream,
               beforeRetry,
+              forwardLifecycle,
             );
           };
           if (!beforeRetry) {
             retry();
             return;
           }
+          const onRetryClientClose = (): void => {
+            if (clientRes.writableEnded) return;
+            if (forwardLifecycle?.onFailure) {
+              notifyForwardLifecycle(() => forwardLifecycle.onFailure?.('client-aborted'));
+            }
+          };
+          clientRes.once('close', onRetryClientClose);
           void beforeRetry().then((proceed) => {
-            if (!proceed) return;
-            if (clientRes.destroyed) return;
+            clientRes.off('close', onRetryClientClose);
+            if (!proceed) {
+              if (forwardLifecycle?.onFailure) {
+                notifyForwardLifecycle(() => forwardLifecycle.onFailure?.('retry-rejected'));
+              }
+              return;
+            }
+            if (clientRes.destroyed) {
+              if (forwardLifecycle?.onFailure) {
+                notifyForwardLifecycle(() => forwardLifecycle.onFailure?.('client-aborted'));
+              }
+              return;
+            }
             retry();
-          }).catch((err) => {
-            logger.error?.('retry dispatch gate failed', {
-              reqId,
-              err: err instanceof Error ? err.message : String(err),
-            });
+          }).catch(() => {
+            clientRes.off('close', onRetryClientClose);
+            if (forwardLifecycle?.onFailure) {
+              notifyForwardLifecycle(() => forwardLifecycle.onFailure?.(
+                clientRes.destroyed && !clientRes.writableEnded ? 'client-aborted' : 'retry-error',
+              ));
+            }
+            logger.error?.('retry dispatch gate failed', { reqId });
             if (clientRes.destroyed || clientRes.headersSent) return;
             clientRes.writeHead(503, {
               'content-type': 'application/json',
@@ -1247,6 +1323,9 @@ function forward(
         if (errorType) baseCtx.errorType = errorType;
         if (logger.isDebugEnabled?.()) baseCtx.body = dumpBody(decodedErrBody, ERROR_RESPONSE_DUMP_MAX_BYTES);
         logger.warn?.('◀ upstream response (non-2xx)', baseCtx);
+        if (forwardLifecycle?.onComplete) {
+          notifyForwardLifecycle(() => forwardLifecycle.onComplete?.(status));
+        }
         if (!clientRes.headersSent) {
           clientRes.writeHead(status, upstreamRes.statusMessage, respHeaders);
         }
@@ -1330,6 +1409,13 @@ function forward(
         : new Error(rawError === undefined
           ? `upstream response ${reason} before completion`
           : String(rawError));
+      if (forwardLifecycle?.onFailure) {
+        const failure: ForwardLifecycleFailure =
+          reason === 'close' ? 'response-closed' : `response-${reason}`;
+        notifyForwardLifecycle(() =>
+          forwardLifecycle.onFailure?.(failure, status),
+        );
+      }
       observerError(err);
       logger.error?.('upstream response stream error', {
         reqId,
@@ -1581,6 +1667,9 @@ function forward(
           if (errorType) detail.errorType = errorType;
         }
         rejectInvalidStreamResponse(code, detail);
+        if (forwardLifecycle?.onComplete) {
+          notifyForwardLifecycle(() => forwardLifecycle.onComplete?.(status));
+        }
         return;
       }
       // 4xx/5xx 用 warn 级别冒泡, 默认只记低风险摘要 (status / content-type / bytes / errorType),
@@ -1617,6 +1706,9 @@ function forward(
         logger.debug?.('◀ upstream response', baseCtx);
       }
       observerEnd();
+      if (forwardLifecycle?.onComplete) {
+        notifyForwardLifecycle(() => forwardLifecycle.onComplete?.(status));
+      }
     });
     upstreamRes.on('error', (err) => failStreamingResponse('error', err));
     upstreamRes.on('aborted', () => failStreamingResponse('aborted'));
@@ -1627,6 +1719,7 @@ function forward(
 
   });
 
+  let requestTimedOut = false;
   upstreamReq.on('error', (err) => {
     // 客户端主动断开触发的 destroy 是预期路径:客户端已不在,不写 502、不按
     // 上游故障记 error(上面 'close' 处已记过 info)。
@@ -1641,6 +1734,13 @@ function forward(
       failActiveResponse(err);
       return;
     }
+    if (forwardLifecycle?.onFailure) {
+      notifyForwardLifecycle(() =>
+        forwardLifecycle.onFailure?.(
+          requestTimedOut ? 'request-timeout' : 'request-error',
+        ),
+      );
+    }
     logger.error?.('upstream request failed', {
       reqId,
       err: String(err),
@@ -1654,6 +1754,7 @@ function forward(
   });
 
   upstreamReq.on('timeout', () => {
+    requestTimedOut = true;
     upstreamReq.destroy(new Error('upstream socket timeout'));
   });
 
@@ -1911,7 +2012,10 @@ export async function createAnthropicCompatProxy(opts: ProxyOptions): Promise<Pr
     // 会把 body 上传期间完成的 owner 切换当成「起始」scope。
     let decision: RoutingDecision | null = applyDispatchGate(null, reqId, requestCtx);
     const beforeRetry = async (): Promise<boolean> => {
-      const gated = applyDispatchGate(decision, reqId, requestCtx);
+      let gated = decision;
+      if (opts.revalidateBeforeDispatch) {
+        gated = opts.revalidateBeforeDispatch(decision, requestCtx) ?? decision;
+      }
       if (gated?.localHandler) {
         await runLocalHandler(
           gated.localHandler,
@@ -2008,6 +2112,7 @@ export async function createAnthropicCompatProxy(opts: ProxyOptions): Promise<Pr
         undefined,
         false,
         beforeRetry,
+        guardForwardLifecycleObserver(decision?.forwardLifecycle),
       );
       return;
     }
@@ -2053,9 +2158,11 @@ export async function createAnthropicCompatProxy(opts: ProxyOptions): Promise<Pr
     // runTransforms 的输出无关,提前是安全的; 这样 inbound 日志能直接打出本请求**最终**发往的
     // upstream(订阅直连 api.anthropic.com / 走网关 endpoint),而非静态默认上游。
     let rawParsed: unknown = undefined;
-    if (opts.routingTransform && contentType.toLowerCase().startsWith('application/json')) {
+    const jsonRequest = contentType.toLowerCase().startsWith('application/json');
+    const routeOpaqueRequest = !jsonRequest && opts.routeOpaqueRequestBody?.(requestCtx) === true;
+    if (opts.routingTransform && (jsonRequest || routeOpaqueRequest)) {
       try {
-        rawParsed = JSON.parse(rawBody.toString('utf8'));
+        if (jsonRequest) rawParsed = JSON.parse(rawBody.toString('utf8'));
       } catch {
         // Some native clients (notably PI's ChatGPT adapter) send compressed
         // JSON while keeping content-type=application/json. Header/path based
@@ -2086,7 +2193,7 @@ export async function createAnthropicCompatProxy(opts: ProxyOptions): Promise<Pr
         const originalLocalBodyBytes = rawBody.length;
         const compactStartedAt = Date.now();
         let oversizedParsed: unknown = rawParsed;
-        if (oversizedParsed === undefined && contentType.toLowerCase().startsWith('application/json')) {
+        if (oversizedParsed === undefined && jsonRequest) {
           try {
             oversizedParsed = JSON.parse(rawBody.toString('utf8'));
           } catch {
@@ -2181,7 +2288,7 @@ export async function createAnthropicCompatProxy(opts: ProxyOptions): Promise<Pr
     if (rawBody.length > maxBodyBytes && oversizedRequestCompactor) {
       const compactStartedAt = Date.now();
       let oversizedParsed: unknown = rawParsed;
-      if (oversizedParsed === undefined && contentType.toLowerCase().startsWith('application/json')) {
+      if (oversizedParsed === undefined && jsonRequest) {
         try {
           oversizedParsed = JSON.parse(rawBody.toString('utf8'));
         } catch {
@@ -2224,14 +2331,18 @@ export async function createAnthropicCompatProxy(opts: ProxyOptions): Promise<Pr
     }
     let transformed: Buffer | null;
     try {
-      transformed = await runTransforms(
-        bodyForTransforms,
-        contentType,
-        transforms,
-        transformCtx,
-        logger,
-        parsedForTransforms,
-      );
+      const bypassTransforms =
+        opts.bypassRequestTransforms?.(rawParsed ?? parsedForTransforms, transformCtx) === true;
+      transformed = bypassTransforms
+        ? null
+        : await runTransforms(
+            bodyForTransforms,
+            contentType,
+            transforms,
+            transformCtx,
+            logger,
+            parsedForTransforms,
+          );
     } catch (err) {
       transformsCompleted = true;
       notifyTransformSettlement();
@@ -2259,7 +2370,7 @@ export async function createAnthropicCompatProxy(opts: ProxyOptions): Promise<Pr
     }
 
     let parsedForRewrite: unknown = rawParsed ?? parsedForTransforms;
-    if (parsedForRewrite === undefined && contentType.toLowerCase().startsWith('application/json')) {
+    if (parsedForRewrite === undefined && jsonRequest) {
       try {
         parsedForRewrite = JSON.parse(rawBody.toString('utf8'));
       } catch {
@@ -2336,6 +2447,8 @@ export async function createAnthropicCompatProxy(opts: ProxyOptions): Promise<Pr
       return;
     }
 
+    const forwardLifecycle = guardForwardLifecycleObserver(decision?.forwardLifecycle);
+
     forward(
       route.target,
       method,
@@ -2359,6 +2472,7 @@ export async function createAnthropicCompatProxy(opts: ProxyOptions): Promise<Pr
       threadMintedIdCache,
       requestDeclaredStream,
       beforeRetry,
+      forwardLifecycle,
     );
   });
 

--- a/packages/anthropic-compat-proxy/src/types.ts
+++ b/packages/anthropic-compat-proxy/src/types.ts
@@ -128,6 +128,12 @@ export interface RoutingDecision {
    * 字段忽略、不发生任何上游转发。省略 = 转发语义,与本字段引入前字节级一致。
    */
   localHandler?: LocalRequestHandler;
+  /**
+   * Optional request-local forwarding observer created by a trusted routing decision.
+   * It receives no request context or payload; the forwarding layer only supplies fixed terminal
+   * classifications and an HTTP status after the real upstream request starts.
+   */
+  forwardLifecycle?: ForwardLifecycleObserver;
 }
 
 /**
@@ -140,6 +146,28 @@ export type RoutingTransform = (
   body: unknown,
   ctx: RequestTransformCtx,
 ) => RoutingDecision | null | Promise<RoutingDecision | null>;
+
+export type ForwardLifecycleFailure =
+  | 'client-aborted'
+  | 'request-error'
+  | 'request-timeout'
+  | 'response-error'
+  | 'response-aborted'
+  | 'response-closed'
+  | 'retry-rejected'
+  | 'retry-error';
+
+/**
+ * Request-local forwarding lifecycle observer.
+ *
+ * The proxy deliberately exposes only fixed terminal classifications and an HTTP status. Raw
+ * targets, headers, bodies, response bytes, and Error objects stay inside the forwarding layer.
+ */
+export interface ForwardLifecycleObserver {
+  onStart?(): void;
+  onComplete?(status: number): void;
+  onFailure?(failure: ForwardLifecycleFailure, status?: number): void;
+}
 
 export interface ResponseObserverCtx {
   readonly reqId: number;
@@ -255,6 +283,17 @@ export interface ProxyOptions {
    * 传空数组 [] = 显式禁用所有 transform,纯透传。
    */
   transformRequest?: RequestTransform[];
+  /**
+   * Optional byte-preservation gate for non-chat endpoints sharing this proxy.
+   * Returning true skips every request-body transform for this request only.
+   */
+  bypassRequestTransforms?: (body: unknown, ctx: RequestTransformCtx) => boolean;
+  /**
+   * Opt selected opaque/non-JSON requests into routing without parsing their body.
+   * The routing transform receives `undefined`; the original bytes remain available
+   * to the forwarding path and can be preserved with `bypassRequestTransforms`.
+   */
+  routeOpaqueRequestBody?: (ctx: RequestTransformCtx) => boolean;
   /**
    * 可选: per-request 路由 override(按 body.model 等选上游 / 换鉴权 header)。
    * 不传 = 永远走 `upstream` + 透传 headers(字节级行为与不传时完全一致,向后兼容)。

--- a/packages/maker-core/src/agents/base-agent.ts
+++ b/packages/maker-core/src/agents/base-agent.ts
@@ -374,6 +374,12 @@ export interface CodexExtraSpawnConfig {
   codexRemoteCompactionProviderId?: string;
   /** Cindy Provider codex/* 的内部 OpenAI transport identity；固定走 HTTP。 */
   codexCindyRemoteCompactionProviderId?: string;
+  /** Custom Provider image-generation identities frozen into this app-server spawn. */
+  codexImageGenerationRoutes?: Array<{
+    providerId: string;
+    modelProviderId: string;
+    supportedModels: readonly string[];
+  }>;
 }
 
 export type CodexAppServerProcessRole = 'task-host' | 'control-plane-service';

--- a/packages/maker-core/src/agents/codex/app-server/host.test.ts
+++ b/packages/maker-core/src/agents/codex/app-server/host.test.ts
@@ -151,6 +151,74 @@ describe('AppServerHost assistant text delta routing', () => {
   });
 });
 
+describe('AppServerHost image-generation subagent policy', () => {
+  const routes = [
+    {
+      providerId: 'images-a',
+      modelProviderId: 'cindy_imagegen_aaaaaaaaaaaaaaaaaaaa',
+      supportedModels: ['image-a', 'image-a-alt'],
+    },
+    {
+      providerId: 'images-b',
+      modelProviderId: 'cindy_imagegen_bbbbbbbbbbbbbbbbbbbb',
+      supportedModels: ['image-b'],
+    },
+  ];
+
+  function policy(
+    root: { providerId: string; model: string },
+    child?: { providerId: string; catalogModel: string },
+  ) {
+    const host = new AppServerHost({
+      createTransport: () => new HangingTransport(),
+      logger,
+      clientInfo: { name: 'cindy-test', version: '0.0.0' },
+      codexImageGenerationRoutes: routes,
+      ...(child
+        ? { subagentRoute: { ...child, reasoningEffort: null } }
+        : {}),
+    });
+    return host.getImageGenerationThreadPolicy(root.providerId, root.model);
+  }
+
+  it('does not affect a non-image parent', () => {
+    expect(policy({ providerId: 'images-a', model: 'text-a' }, {
+      providerId: 'images-b',
+      catalogModel: 'image-b',
+    })).toEqual({
+      dynamicIdentity: false,
+      disableSubagents: false,
+      disableModelOverrides: false,
+    });
+  });
+
+  it.each([
+    ['same Provider eligible child', 'images-a', 'image-a-alt', false],
+    ['same Provider non-Responses child', 'images-a', 'text-a', true],
+    ['different Provider child', 'images-b', 'image-b', true],
+  ] as const)('%s', (_label, providerId, catalogModel, disableSubagents) => {
+    expect(policy(
+      { providerId: 'images-a', model: 'image-a' },
+      { providerId, catalogModel },
+    )).toEqual({
+      dynamicIdentity: true,
+      disableSubagents,
+      disableModelOverrides: true,
+    });
+  });
+
+  it('allows the second dynamic Provider with its own matching child', () => {
+    expect(policy(
+      { providerId: 'images-b', model: 'image-b' },
+      { providerId: 'images-b', catalogModel: 'image-b' },
+    )).toEqual({
+      dynamicIdentity: true,
+      disableSubagents: false,
+      disableModelOverrides: true,
+    });
+  });
+});
+
 describe('AppServerHost MCP readiness', () => {
   it('retries a negative tool probe instead of permanently caching it', async () => {
     let available = false;

--- a/packages/maker-core/src/agents/codex/app-server/host.ts
+++ b/packages/maker-core/src/agents/codex/app-server/host.ts
@@ -278,6 +278,12 @@ export interface AppServerHostOptions {
   remoteCompactionProviderId?: string;
   /** Cindy Provider codex/* 的内部 OpenAI transport identity。 */
   cindyRemoteCompactionProviderId?: string;
+  /** Custom Provider image-generation identities frozen into this process. */
+  codexImageGenerationRoutes?: Array<{
+    providerId: string;
+    modelProviderId: string;
+    supportedModels: readonly string[];
+  }>;
   /** Per-thread host-owned MCP URL overrides keyed by the Session instance. */
   buildSessionMcpConfig?: (sessionInstanceId: string) => Record<string, unknown>;
   /** Cindy-side fallback used only when a subagent's actual model is not reported. */
@@ -439,6 +445,45 @@ export class AppServerHost {
 
   getCindyRemoteCompactionProviderId(): string | null {
     return this.opts.cindyRemoteCompactionProviderId ?? null;
+  }
+
+  getImageGenerationProviderId(
+    providerId: string | null | undefined,
+    model: string | null | undefined,
+  ): string | null {
+    if (!providerId || !model) return null;
+    const route = this.opts.codexImageGenerationRoutes?.find(
+      (candidate) => candidate.providerId === providerId,
+    );
+    return route?.supportedModels.includes(model) ? route.modelProviderId : null;
+  }
+
+  getImageGenerationThreadPolicy(
+    providerId: string | null | undefined,
+    model: string | null | undefined,
+  ): {
+    dynamicIdentity: boolean;
+    disableSubagents: boolean;
+    disableModelOverrides: boolean;
+  } {
+    const route = providerId && model
+      ? this.opts.codexImageGenerationRoutes?.find(
+          (candidate) =>
+            candidate.providerId === providerId && candidate.supportedModels.includes(model),
+        )
+      : undefined;
+    if (!route) {
+      return { dynamicIdentity: false, disableSubagents: false, disableModelOverrides: false };
+    }
+    const child = this.opts.subagentRoute;
+    const childCompatible = !child || (
+      child.providerId === route.providerId && route.supportedModels.includes(child.catalogModel)
+    );
+    return {
+      dynamicIdentity: true,
+      disableSubagents: !childCompatible,
+      disableModelOverrides: true,
+    };
   }
 
   /**

--- a/packages/maker-core/src/agents/codex/index.test.ts
+++ b/packages/maker-core/src/agents/codex/index.test.ts
@@ -440,6 +440,11 @@ function installFakeHost(
     codexBrowserMcpToolAvailable?: boolean;
     remoteCompactionProviderId?: string;
     cindyRemoteCompactionProviderId?: string;
+    codexImageGenerationRoutes?: Array<{
+      providerId: string;
+      modelProviderId: string;
+      supportedModels: readonly string[];
+    }>;
     subagentModelFallback?: string;
     subagentRoute?: {
       providerId: string;
@@ -517,6 +522,35 @@ function installFakeHost(
   const getCindyRemoteCompactionProviderId = vi.fn(
     () => opts.cindyRemoteCompactionProviderId ?? null,
   );
+  const getImageGenerationProviderId = vi.fn(
+    (providerId?: string | null, model?: string | null) => {
+      const route = opts.codexImageGenerationRoutes?.find(
+        (candidate) => candidate.providerId === providerId,
+      );
+      return model && route?.supportedModels.includes(model) ? route.modelProviderId : null;
+    },
+  );
+  const getImageGenerationThreadPolicy = vi.fn(
+    (providerId?: string | null, model?: string | null) => {
+      const route = opts.codexImageGenerationRoutes?.find(
+        (candidate) =>
+          candidate.providerId === providerId &&
+          Boolean(model && candidate.supportedModels.includes(model)),
+      );
+      if (!route) {
+        return { dynamicIdentity: false, disableSubagents: false, disableModelOverrides: false };
+      }
+      const child = opts.subagentRoute;
+      const compatible = !child || (
+        child.providerId === route.providerId && route.supportedModels.includes(child.catalogModel)
+      );
+      return {
+        dynamicIdentity: true,
+        disableSubagents: !compatible,
+        disableModelOverrides: true,
+      };
+    },
+  );
   const getSessionMcpConfig = vi.fn((sessionInstanceId?: string) =>
     opts.buildSessionMcpConfig?.(sessionInstanceId) ?? {},
   );
@@ -537,6 +571,8 @@ function installFakeHost(
     waitForMcpTool,
     getRemoteCompactionProviderId,
     getCindyRemoteCompactionProviderId,
+    getImageGenerationProviderId,
+    getImageGenerationThreadPolicy,
     getSessionMcpConfig,
     getSubagentModelFallback,
     getSubagentRoute,
@@ -4043,6 +4079,221 @@ describe('CodexAgent.startSession developerInstructions', () => {
     };
     expect(xaiParams.modelProvider).toBeUndefined();
     await xaiHandle.close();
+  });
+
+  it('selects one custom image-generation identity for every eligible Provider model', async () => {
+    const registerCodexSystemPromptForThread = vi.fn();
+    const agent = new CodexAgent(createDeps(
+      { systemPrompt: 'HOST PRODUCT PROMPT' },
+      { registerCodexSystemPromptForThread },
+    ));
+    const host = installFakeHost(agent, undefined, {
+      codexProxyActive: true,
+      remoteCompactionProviderId: 'cindy_openai',
+      codexImageGenerationRoutes: [
+        {
+          providerId: 'custom-images',
+          modelProviderId: 'cindy_imagegen_0123456789abcdefabcd',
+          supportedModels: ['chat-image', 'chat-image-alt'],
+        },
+      ],
+    });
+    (agent as unknown as { hostEffectiveCredentialModes: Map<string, string> })
+      .hostEffectiveCredentialModes.set('local', 'oauth-bearer');
+
+    const startHandle = await agent.startSession({
+      sessionId: 'session-custom-image-start',
+      model: 'chat-image',
+      providerId: 'custom-images',
+      workingDir: '/repo',
+    });
+    const startParams = host.request.mock.calls.find(
+      ([method]) => method === Method.ThreadStart,
+    )?.[1] as {
+      modelProvider?: string;
+      config?: Record<string, unknown>;
+      developerInstructions?: string;
+    };
+    expect(startParams.modelProvider).toBe('cindy_imagegen_0123456789abcdefabcd');
+    expect(startParams.developerInstructions).toBeUndefined();
+    expect(registerCodexSystemPromptForThread).toHaveBeenCalledWith({
+      sessionId: 'session-custom-image-start',
+      threadId: 'start-thread-id',
+      text: expect.stringContaining('HOST PRODUCT PROMPT'),
+    });
+    expect(startHandle.codexProductPromptDelivery).toEqual({
+      threadId: 'start-thread-id',
+      historyHasProductPrompt: false,
+    });
+    expect(startParams.config).toMatchObject({
+      web_search: 'disabled',
+      'features.standalone_web_search': false,
+      'features.multi_agent_v2.expose_spawn_agent_model_overrides': false,
+    });
+    expect(startParams.config).not.toHaveProperty('agents.enabled');
+    await startHandle.close();
+
+    host.request.mock.calls.length = 0;
+    const resumeHandle = await agent.startSession({
+      sessionId: 'session-custom-image-resume',
+      model: 'chat-image',
+      providerId: 'custom-images',
+      workingDir: '/repo',
+      resumeSessionId: '123e4567-e89b-12d3-a456-426614174000',
+    });
+    const resumeParams = host.request.mock.calls.find(
+      ([method]) => method === Method.ThreadResume,
+    )?.[1] as { modelProvider?: string };
+    expect(resumeParams.modelProvider).toBe('cindy_imagegen_0123456789abcdefabcd');
+    await resumeHandle.close();
+
+    // env-key/gateway-key Host 上 dynamic identity 同样固定走 HTTP proxy，不因 Host 仍
+    // 广告 OpenAI WebSocket 能力而改成订阅 WS 通道。
+    (agent as unknown as { hostEffectiveCredentialModes: Map<string, string> })
+      .hostEffectiveCredentialModes.set('local', 'gateway-key');
+    host.request.mock.calls.length = 0;
+    registerCodexSystemPromptForThread.mockClear();
+    const envKeyHandle = await agent.startSession({
+      sessionId: 'session-custom-image-env-key',
+      model: 'chat-image',
+      providerId: 'custom-images',
+      workingDir: '/repo',
+    });
+    const envKeyParams = host.request.mock.calls.find(
+      ([method]) => method === Method.ThreadStart,
+    )?.[1] as { modelProvider?: string; developerInstructions?: string };
+    expect(envKeyParams.modelProvider).toBe('cindy_imagegen_0123456789abcdefabcd');
+    expect(envKeyParams.developerInstructions).toBeUndefined();
+    expect(registerCodexSystemPromptForThread).toHaveBeenCalledWith({
+      sessionId: 'session-custom-image-env-key',
+      threadId: 'start-thread-id',
+      text: expect.stringContaining('HOST PRODUCT PROMPT'),
+    });
+    expect(envKeyHandle.codexProductPromptDelivery).toEqual({
+      threadId: 'start-thread-id',
+      historyHasProductPrompt: false,
+    });
+    await envKeyHandle.close();
+
+    host.request.mock.calls.length = 0;
+    const alternateHandle = await agent.startSession({
+      sessionId: 'session-custom-image-alternate',
+      model: 'chat-image-alt',
+      providerId: 'custom-images',
+      workingDir: '/repo',
+    });
+    const alternateParams = host.request.mock.calls.find(
+      ([method]) => method === Method.ThreadStart,
+    )?.[1] as { modelProvider?: string };
+    expect(alternateParams.modelProvider).toBe('cindy_imagegen_0123456789abcdefabcd');
+    await alternateHandle.close();
+
+    host.request.mock.calls.length = 0;
+    const falseHandle = await agent.startSession({
+      sessionId: 'session-custom-image-false',
+      model: 'chat-text',
+      providerId: 'custom-images',
+      workingDir: '/repo',
+    });
+    const falseParams = host.request.mock.calls.find(
+      ([method]) => method === Method.ThreadStart,
+    )?.[1] as { modelProvider?: string; config?: Record<string, unknown> };
+    expect(falseParams.modelProvider).toBeUndefined();
+    expect(falseParams.config).not.toHaveProperty('web_search');
+    expect(falseParams.config).not.toHaveProperty('features.standalone_web_search');
+    await falseHandle.close();
+  });
+
+  it.each([
+    {
+      label: 'same Provider eligible child',
+      subagentRoute: {
+        providerId: 'custom-images-a',
+        catalogModel: 'image-a',
+        reasoningEffort: 'high' as const,
+      },
+      rootProviderId: 'custom-images-a',
+      rootModel: 'image-a',
+      disabled: false,
+    },
+    {
+      label: 'same Provider non-Responses child',
+      subagentRoute: {
+        providerId: 'custom-images-a',
+        catalogModel: 'text-a',
+        reasoningEffort: 'high' as const,
+      },
+      rootProviderId: 'custom-images-a',
+      rootModel: 'image-a',
+      disabled: true,
+    },
+    {
+      label: 'different dynamic Provider child',
+      subagentRoute: {
+        providerId: 'custom-images-b',
+        catalogModel: 'image-b',
+        reasoningEffort: 'high' as const,
+      },
+      rootProviderId: 'custom-images-a',
+      rootModel: 'image-a',
+      disabled: true,
+    },
+    {
+      label: 'second dynamic Provider with matching child',
+      subagentRoute: {
+        providerId: 'custom-images-b',
+        catalogModel: 'image-b',
+        reasoningEffort: 'high' as const,
+      },
+      rootProviderId: 'custom-images-b',
+      rootModel: 'image-b',
+      disabled: false,
+    },
+  ])('scopes dynamic-image subagent protection: $label', async ({
+    subagentRoute,
+    rootProviderId,
+    rootModel,
+    disabled,
+  }) => {
+    const agent = new CodexAgent(createDeps());
+    const host = installFakeHost(agent, undefined, {
+      codexProxyActive: true,
+      codexImageGenerationRoutes: [
+        {
+          providerId: 'custom-images-a',
+          modelProviderId: 'cindy_imagegen_aaaaaaaaaaaaaaaaaaaa',
+          supportedModels: ['image-a', 'image-a-alt'],
+        },
+        {
+          providerId: 'custom-images-b',
+          modelProviderId: 'cindy_imagegen_bbbbbbbbbbbbbbbbbbbb',
+          supportedModels: ['image-b'],
+        },
+      ],
+      subagentRoute,
+    });
+
+    const handle = await agent.startSession({
+      sessionId: `session-image-policy-${rootProviderId}`,
+      model: rootModel,
+      providerId: rootProviderId,
+      workingDir: '/repo',
+    });
+    const params = host.request.mock.calls.find(
+      ([method]) => method === Method.ThreadStart,
+    )?.[1] as { config?: Record<string, unknown> };
+    expect(params.config).toMatchObject({
+      web_search: 'disabled',
+      'features.standalone_web_search': false,
+      ...(disabled
+        ? {
+            'features.multi_agent': false,
+            'features.multi_agent_v2': false,
+            'agents.enabled': false,
+          }
+        : { 'features.multi_agent_v2.expose_spawn_agent_model_overrides': false }),
+    });
+    await handle.close();
   });
 
   it('keeps Cindy codex root compaction local when an independent subagent uses another backend', async () => {

--- a/packages/maker-core/src/agents/codex/index.ts
+++ b/packages/maker-core/src/agents/codex/index.ts
@@ -2576,6 +2576,7 @@ export class CodexAgent extends BaseAgent {
     let codexBrowserUseStartupTimeoutMs: number | undefined;
     let remoteCompactionProviderId: string | undefined;
     let cindyRemoteCompactionProviderId: string | undefined;
+    let codexImageGenerationRoutes: CodexExtraSpawnConfig['codexImageGenerationRoutes'];
     let buildSessionMcpConfig: CodexExtraSpawnConfig['buildSessionMcpConfig'];
     let subagentModelFallback: string | undefined;
     let subagentRoute: CodexExtraSpawnConfig['subagentRoute'];
@@ -2605,6 +2606,7 @@ export class CodexAgent extends BaseAgent {
       codexBrowserUseStartupTimeoutMs = undefined;
       remoteCompactionProviderId = undefined;
       cindyRemoteCompactionProviderId = undefined;
+      codexImageGenerationRoutes = undefined;
       buildSessionMcpConfig = undefined;
       subagentModelFallback = undefined;
       subagentRoute = undefined;
@@ -2658,6 +2660,9 @@ export class CodexAgent extends BaseAgent {
           }
           if (codexProxyActive && cfg.codexCindyRemoteCompactionProviderId) {
             cindyRemoteCompactionProviderId = cfg.codexCindyRemoteCompactionProviderId;
+          }
+          if (codexProxyActive && cfg.codexImageGenerationRoutes?.length) {
+            codexImageGenerationRoutes = cfg.codexImageGenerationRoutes;
           }
           this.deps.logger.info('codex MCP bridge ready', {
             providers: this.deps.mcpProviders?.length ?? 0,
@@ -2747,6 +2752,7 @@ export class CodexAgent extends BaseAgent {
       codexBrowserUseStartupTimeoutMs,
       remoteCompactionProviderId,
       cindyRemoteCompactionProviderId,
+      codexImageGenerationRoutes,
       buildSessionMcpConfig,
       subagentModelFallback,
       subagentRoute,
@@ -5175,6 +5181,8 @@ export class CodexAgent extends BaseAgent {
       return JSON.stringify(mutableWritableDirs);
     }
 
+    let imageGenerationThreadConfig: Record<string, unknown> = {};
+
     function currentThreadWorkspaceConfig(): Pick<
       ThreadStartParams,
       | 'approvalPolicy'
@@ -5187,6 +5195,7 @@ export class CodexAgent extends BaseAgent {
       const { approvalPolicy, approvalsReviewer, sandbox } = currentApprovalConfig();
       const config = {
         ...capabilityRoutingConfig,
+        ...imageGenerationThreadConfig,
         ...(readonlyReferenceDirsSupported ? readonlyReferencesConfig() : {}),
         ...(reviewMode ? reviewPermissionsConfig : {}),
         ...(reviewMode
@@ -5368,13 +5377,40 @@ export class CodexAgent extends BaseAgent {
       cindyProviderRemoteCompactionRequested && cindyProviderRemoteCompactionCompatible;
     const threadCredentialFamily =
       credentialMode ?? this.hostEffectiveCredentialModes.get(currentHostKey);
+    const imageGenerationModelProvider = opts.remoteHostId
+      ? null
+      : host.getImageGenerationProviderId?.(mutableProviderId, mutableCatalogModel);
+    const imageGenerationThreadPolicy = opts.remoteHostId
+      ? { dynamicIdentity: false, disableSubagents: false, disableModelOverrides: false }
+      : host.getImageGenerationThreadPolicy?.(mutableProviderId, mutableCatalogModel) ?? {
+          dynamicIdentity: false,
+          disableSubagents: false,
+          disableModelOverrides: false,
+        };
+    if (imageGenerationThreadPolicy.dynamicIdentity) {
+      imageGenerationThreadConfig = {
+        web_search: 'disabled',
+        'features.standalone_web_search': false,
+        ...(imageGenerationThreadPolicy.disableSubagents
+          ? {
+              'features.multi_agent': false,
+              'features.multi_agent_v2': false,
+              'agents.enabled': false,
+            }
+          : imageGenerationThreadPolicy.disableModelOverrides
+            ? { 'features.multi_agent_v2.expose_spawn_agent_model_overrides': false }
+            : {}),
+      };
+    }
     const threadModelProvider = opts.remoteHostId
       ? undefined
-      : cindyProviderRemoteCompaction
-        ? host.getCindyRemoteCompactionProviderId?.() ?? undefined
-        : threadCredentialFamily === 'oauth-bearer'
-          ? host.getRemoteCompactionProviderId?.() ?? undefined
-          : undefined;
+      : imageGenerationModelProvider
+        ? imageGenerationModelProvider
+        : cindyProviderRemoteCompaction
+          ? host.getCindyRemoteCompactionProviderId?.() ?? undefined
+          : threadCredentialFamily === 'oauth-bearer'
+            ? host.getRemoteCompactionProviderId?.() ?? undefined
+            : undefined;
 
     /**
      * 本 thread 的 Responses 请求是否走 WebSocket。
@@ -5386,7 +5422,8 @@ export class CodexAgent extends BaseAgent {
      * 单独起名是为了把「选没选 provider」和「实际走不走 WS」分开，避免 prompt 注入
      * 通道错误地只看 provider 身份。
      */
-    const threadUsesWebSocket = !cindyProviderRemoteCompaction
+    const threadUsesWebSocket = !imageGenerationThreadPolicy.dynamicIdentity
+      && !cindyProviderRemoteCompaction
       && !!threadModelProvider
       && (host.getOpenAiWebSocketsEnabled?.() ?? true);
 

--- a/packages/model-providers/src/__tests__/presets.test.ts
+++ b/packages/model-providers/src/__tests__/presets.test.ts
@@ -372,6 +372,60 @@ describe('sanitizePresets', () => {
     }])).toEqual([]);
   });
 
+  it('图片生成能力只接受显式布尔值', () => {
+    const imagegen = {
+      id: 'imagegen',
+      name: 'Imagegen',
+      runtimes: {
+        codex: {
+          baseUrl: 'https://images.example/v1',
+          wireProtocol: 'openai-responses',
+          supportsImageGeneration: true,
+          models: [{ id: 'image-chat', name: 'Image Chat' }],
+        },
+      },
+    };
+    expect(sanitizePresets([imagegen])).toEqual([imagegen]);
+    expect(
+      sanitizePresets([
+        {
+          ...imagegen,
+          runtimes: {
+            codex: {
+              ...imagegen.runtimes.codex,
+              supportsImageGeneration: 'yes',
+            },
+          },
+        },
+      ]),
+    ).toEqual([]);
+    expect(
+      sanitizePresets([
+        {
+          ...imagegen,
+          runtimes: {
+            codex: {
+              ...imagegen.runtimes.codex,
+              wireProtocol: 'openai-chat',
+            },
+          },
+        },
+      ]),
+    ).toEqual([]);
+    expect(
+      sanitizePresets([
+        {
+          ...imagegen,
+          runtimes: {
+            pi: {
+              ...imagegen.runtimes.codex,
+            },
+          },
+        },
+      ]),
+    ).toEqual([]);
+  });
+
   it('requestPath 合法时保留；跨主机、fragment 与 CRLF 形态剥字段但保留预设', () => {
     const runtime = (requestPath: unknown) => ({
       codex: {

--- a/packages/model-providers/src/__tests__/user-provider.test.ts
+++ b/packages/model-providers/src/__tests__/user-provider.test.ts
@@ -730,6 +730,27 @@ it('strips xd/ prefix to match registry effort metadata (entry.id ≠ custom id)
     expect(p.routing.pi?.wireProtocol).toBe('openai-chat');
   });
 
+  it('projects image generation independently from image input', () => {
+    const p = buildUserProvider({
+      id: 'images',
+      name: 'Images',
+      runtimes: {
+        codex: {
+          baseUrl: 'https://images.example/v1',
+          wireProtocol: 'openai-responses',
+          supportsImageGeneration: true,
+          models: [
+            { id: 'generate', name: 'Generate' },
+            { id: 'input', name: 'Input', supportsImageInput: true },
+          ],
+        },
+      },
+    });
+    expect(p.routing.codex?.supportsImageGeneration).toBe(true);
+    expect(p.models.codex?.[0]?.supportsImageInput).toBeUndefined();
+    expect(p.models.codex?.[1]?.supportsImageInput).toBe(true);
+  });
+
   it("does not export unverified CC/Codex efforts for managed Ollama", () => {
     const p = buildUserProvider({
       id: "cindy-local-ollama",

--- a/packages/model-providers/src/catalog.ts
+++ b/packages/model-providers/src/catalog.ts
@@ -545,6 +545,24 @@ function isValidPreset(v: unknown): v is ProviderPreset {
     }
     if (r.wireProtocol !== undefined && !isWireProtocol(r.wireProtocol)) return false;
     if (agent === 'claude-code' && r.wireProtocol === 'openai-chat') return false;
+    if (
+      r.supportsImageGeneration !== undefined &&
+      typeof r.supportsImageGeneration !== 'boolean'
+    ) {
+      return false;
+    }
+    if (r.supportsImageGeneration === true && agent !== 'codex') return false;
+    const defaultWireProtocol = r.wireProtocol ?? (agent === 'codex' ? 'openai-responses' : undefined);
+    const hasResponsesRoute =
+      defaultWireProtocol === 'openai-responses' ||
+      r.models.some((model) => {
+        if (!model || typeof model !== 'object') return false;
+        const route = (model as Record<string, unknown>).route;
+        return route && typeof route === 'object' && !Array.isArray(route)
+          ? (route as Record<string, unknown>).wireProtocol === 'openai-responses'
+          : false;
+      });
+    if (r.supportsImageGeneration === true && !hasResponsesRoute) return false;
     if (r.headers !== undefined) {
       if (!r.headers || typeof r.headers !== 'object' || Array.isArray(r.headers)) return false;
       if (Object.values(r.headers as Record<string, unknown>).some((x) => typeof x !== 'string')) return false;

--- a/packages/model-providers/src/types.ts
+++ b/packages/model-providers/src/types.ts
@@ -170,6 +170,11 @@ export interface RoutingDescriptor {
    * 未声明表示没有足够能力信息，调用方不得按模型名猜测。
    */
   supportsResponsesCustomTools?: boolean;
+  /**
+   * 该自定义 Provider 的 Codex Responses runtime 是否支持原生图片生成与编辑。
+   * 缺省按 false 处理；它与模型图片输入能力独立，也不得从模型名推断。
+   */
+  supportsImageGeneration?: boolean;
   /** 真实上游 base URL（direct 时是供应商自家；gateway 时是 XD 网关 base）。 */
   upstream: string;
   /**
@@ -567,6 +572,8 @@ export interface ProviderPresetRuntime {
   baseUrl: string;
   /** 非标准推理端点的相对路径；缺省由 wire protocol 推导。 */
   requestPath?: string;
+  /** Codex Responses runtime 是否支持原生图片生成与编辑；缺省为 false。 */
+  supportsImageGeneration?: boolean;
   /** 推荐模型清单（预填进表单，用户可增删改）。 */
   models: ProviderRuntimeModelConfig[];
   /** 可选预填请求头。 */
@@ -661,6 +668,8 @@ export interface CustomProviderRuntimeConfig {
   baseUrl: string;
   /** 非标准推理端点的相对路径；缺省由 wire protocol 推导。 */
   requestPath?: string;
+  /** Codex Responses runtime 是否支持原生图片生成与编辑；缺省为 false。 */
+  supportsImageGeneration?: boolean;
   /** 用户模型；contextWindow 可由预设带入，缺省时由 `buildUserProvider` 补保守默认。 */
   models: ProviderRuntimeModelConfig[];
   /**

--- a/packages/model-providers/src/user-provider.ts
+++ b/packages/model-providers/src/user-provider.ts
@@ -232,6 +232,7 @@ function toRouting(
   modelsUrl?: string,
   wireProtocol?: "anthropic-messages" | "openai-responses" | "openai-chat",
   piCatalogProviderId?: string,
+  supportsImageGeneration?: boolean,
 ): RoutingDescriptor {
   const r: RoutingDescriptor = {
     upstream: baseUrl,
@@ -239,6 +240,9 @@ function toRouting(
     ...(agent === 'codex'
       && (wireProtocol ?? defaultWireProtocol(agent)) === 'openai-responses'
       ? { supportsResponsesCustomTools: false }
+      : {}),
+    ...(agent === 'codex' && supportsImageGeneration === true
+      ? { supportsImageGeneration: true }
       : {}),
     ...(strategy === "none" &&
     (!isLoopbackProviderUrl(baseUrl) ||
@@ -298,6 +302,7 @@ export function buildUserProvider(
       rt.modelsUrl,
       rt.wireProtocol,
       rt.piCatalogProviderId,
+      rt.supportsImageGeneration,
     );
     models[agent] = rt.models.map((m) =>
       toCatalogModel(m, config.id, agent, options.modelRegistry),


### PR DESCRIPTION
## 这次改了什么

### 摘要

让自定义 Provider 的 Codex Responses runtime 可以显式声明原生图片生成与编辑能力。启用后，Cindy 为每个 Provider 派生一份独立的 Codex imagegen identity，并把 `/images/generations`、`/images/edits` 安全路由回同一个自定义 Provider，不会静默切换到 Cindy AI、ChatGPT 或其他图片服务。

### 变更类型

- [x] `feat` 新功能
- [ ] `fix` 缺陷修复
- [ ] `refactor` / `perf` 重构或性能优化
- [ ] `docs` / `test` / `chore` 文档、测试或工程维护
- [ ] 其他：

### 范围

- 关联 Issue / 需求：自定义 Codex Provider 原生图片生成与编辑
- 本 PR 包含：
  - Provider/Codex runtime 级 `runtimes.codex.supportsImageGeneration` 契约；旧配置缺省为关闭，模型对象不携带该字段。
  - 设置页“高级”区域中的 Provider 级开关、完整帮助说明，以及首次人工开启时的 Codex 重新加载确认。
  - 每个启用 Provider 一份动态 identity；符合条件的 Responses 模型共享该 identity，generate/edit 使用专属私有前缀回到同一 Provider。
  - 路由、凭证和 Host 快照同代校验；凭证或自定义 Header 变化时 fail closed；multipart edit 保持原始字节。
  - 动态 identity 强制走 HTTP，不继承订阅 WebSocket；不额外开放 Web Search，并保护子任务和 Renderer、IM、Scheduler 的 identity 跨界切换。
  - 人工首次开启时可选择“立即重新加载”或“结束后自动加载”；程序化 Provider create/update 不受交互确认阻塞，并沿用安全 Host 刷新机制。
  - release info 记录紧凑的 imagegen 转发生命周期；Debug 每次请求最多记录一条最终 HTTP URL 与严格白名单过滤的图片控制参数，不扩大日志上传白名单。
- 明确不包含：服务端、Codex 二进制、无私有前缀的存量 `/images/*`、Cindy AI / `cindy_*` 图片语义、媒体通道，以及仓库外插件包或插件侧 schema/打包改动。
- 用户可见变化：兼容 OpenAI Responses 图片接口的自定义 Provider 可在高级设置中开启原生图片生成与编辑；人工首次开启且本地 Codex 正忙时会先询问重载方式。
- 是否存在 breaking change：无。

### UI 变化

- 自定义 Provider 的 Header 区域下方新增默认收起的“高级”区域；开关只在能形成 Codex + effective OpenAI Responses 路由时出现。
- `?` 帮助入口使用单一可聚焦按钮和单一完整说明卡片，支持 hover、focus、click/tap、Escape 与外部点击；确认弹窗沿用现有 Dialog 组件和按钮层级。
- 引用的设计规范：`docs/design-rules/DESIGN.md` §4（Buttons、Inputs & Forms、Dialog & Modal）、§10（Light / Dark Dual-Mode Delivery Gate 与语义 token）、§11（Voice & Content）、§14.2（Focus Management）与 §14.6（Icon-only Controls and Tooltips）。所有颜色沿用语义 token，五语文案同步。
- 未附设置页截图：实际环境包含 Provider 配置信息，避免把可能敏感的界面证据带入 PR。

## 怎么验证的

### 自动验证

```text
env -u CDPATH pnpm --filter desktop exec vitest run src/main/voice-input/__tests__/RealtimeAsrWebSocketProvider.test.ts -t 'closes a prewarmed socket when readiness fails after upgrade'
结果：通过（1 passed，18 skipped）；用于确认首次完整门禁中的偶发 5 秒超时不可重复。

env -u CDPATH pnpm test:unit:related
结果：通过。apps/desktop、apps/mobile、@cindy/anthropic-compat-proxy、lizi-mcps、@cindy/maker-core、@cindy/model-providers、orca-workflow 全部通过。

pnpm --filter desktop run --if-present typecheck
pnpm --filter @cindy/anthropic-compat-proxy run --if-present typecheck
pnpm --filter @cindy/maker-core run --if-present typecheck
pnpm --filter @cindy/model-providers run --if-present typecheck
结果：Desktop 与 compat 实际执行通过；maker-core 与 model-providers 没有 typecheck script，按 --if-present 正常跳过。

pnpm check:i18n
pnpm check:i18n-glossary
git diff --check
结果：全部通过；i18n 与 glossary 仅有仓库既有的非阻断警告。

目标 ESLint / Prettier
结果：compat 与本次新增文件、UI/i18n 目标检查通过；Desktop / maker-core 全文件 lint 仅报告 HEAD 已存在且位于本次未改行的规则违例，未为存量告警扩大改动。
```

### 手工验证

- macOS 实际自定义 Provider（Lizi）环境验证：原生 generate/edit 均由同一 Provider 完成；同 Provider 的合格模型切换不跨 identity；等待与立即两种重载策略生效；Debug 日志可看到实际请求模型 `gpt-image-2`；上游失败时没有回退到其他图片服务。
- 帮助卡片的 hover / focus / click 与 Escape 行为由用户手工复验。
- 最终 diff 已经过多轮常规 reviewer 与 reviewer-grok 复核，没有遗留 P0/P1 finding。

### 未执行的验证

- 未执行 Windows 实机 E2E。
- 未做独立 Light / Dark 双主题截图对比；实现使用现有语义 token，相关 DOM、键盘与交互测试已覆盖。
- 仓库外插件包不属于本 PR，没有作为本 PR 的交付或验证结果。

## 风险

### 风险分类

- [ ] 无已知风险
- [ ] SQLite / migration
- [ ] system prompt
- [x] 协议兼容
- [x] 权限 / 安全 / 用户数据
- [ ] 存量插件兼容（批准状态 / 指纹 / manifest 校验 / 安装布局 / 包格式）
- [ ] 原生层 / fingerprint / OTA
- [x] 跨平台差异
- [x] 其他：共享 Codex Host 生命周期与安全刷新

### 影响与回滚

- 影响范围：仅显式开启 `runtimes.codex.supportsImageGeneration` 且可形成 effective OpenAI Responses 路由的自定义 Provider。未开启 Provider、非 Responses runtime、Cindy AI、无私有前缀图片请求和其他 Agent 保持原行为。
- 安全边界：动态 route 与凭证 revision 同代；Provider 删除、凭证/Header 更新或 route 不匹配时本地拒绝，不回退其他上游。Debug 详情只在本地按白名单生成，本 PR 未扩大自动上传字段。
- 回滚 / 降级方式：Provider 可关闭或省略该字段，Host 到达安全空闲点后移除动态配置；代码层可回滚本提交恢复此前行为。旧配置缺少字段时始终按关闭处理。
- 跨平台：路径拼接和代理逻辑使用现有 URL / HTTP 基础设施；macOS 已实测，Windows 留待 CI 与后续实机验证。

### 提交前检查

- [x] 已 review 完整 diff
- [x] 每个 commit 都带 DCO 签名（`git commit -s`，见 [DCO](../DCO)）
- [x] UI 改动已在「UI 变化」注明引用的设计规范章节
- [x] 未提交凭证、令牌或授权文件
- [x] 已补充必要文档（插件作者接入说明作为仓库外独立交付，不进入本 PR）
- [x] 已确认测试结果或说明未执行原因
