### PR TITLE
fix(desktop): active-Orca rehydrate 关旧 runtime 前先按 DB 对账 resumeSessionId,保住旧 transcript

### DIFF
--- a/apps/desktop/src/main/maker-ipc/__tests__/makerSendTransaction.test.ts
+++ b/apps/desktop/src/main/maker-ipc/__tests__/makerSendTransaction.test.ts
@@ -1425,6 +1425,73 @@ describe('maker SEND transaction', () => {
     expect(newSession.send).toHaveBeenCalled();
   });
 
+  it('reconciles createOpts against DB before closing the old runtime on active Orca rehydrate (#2882)', async () => {
+    const oldSession = createSession({ id: 'orca-session', workDir: 'C:\\repo' });
+    const newSession = createSession({ id: 'orca-session', workDir: 'C:\\repo' });
+    const reconcileCreateOptsWithDb = vi.fn(async (_sessionId: string, co: MakerSessionCreateOpts) => {
+      co.resumeSessionId = 'db-sdk-session-id';
+    });
+    const { deps } = createDeps({
+      getSession: vi.fn(() => oldSession),
+      isOrcaMcpHydrated: vi.fn(() => false),
+      synthesizeOrcaVendorOptionsFromDb: vi.fn(async () => true),
+      reconcileCreateOptsWithDb,
+      bootstrapSession: vi.fn(async () => ({
+        session: newSession,
+        didInjectOrcaInstructions: true,
+        didInjectProjectContext: false,
+      })),
+    });
+    const transaction = createMakerSendTransaction(deps);
+
+    await expect(
+      transaction.sendToAgentAccepted('orca-session', 'hello', {
+        id: 'orca-session',
+        agentKind: 'pi',
+        workingDir: 'C:\\repo',
+        model: 'k3',
+        // caller 快照携带陈旧 resume:DB 权威值必须胜出,而不是仅在缺省时补值。
+        resumeSessionId: 'stale-caller-resume',
+      }),
+    ).resolves.toMatchObject({ accepted: true });
+
+    expect(reconcileCreateOptsWithDb).toHaveBeenCalledOnce();
+    // 对账必须发生在 closeSession 之前:DB 读失败时旧 runtime 不能已被关闭。
+    expect(reconcileCreateOptsWithDb.mock.invocationCallOrder[0]).toBeLessThan(
+      vi.mocked(deps.closeSession).mock.invocationCallOrder[0]!,
+    );
+    expect(deps.bootstrapSession).toHaveBeenCalledWith(
+      expect.objectContaining({ resumeSessionId: 'db-sdk-session-id' }),
+    );
+    expect(newSession.send).toHaveBeenCalled();
+  });
+
+  it('fails rehydrate without closing the old runtime when DB reconciliation throws (#2882)', async () => {
+    const oldSession = createSession({ id: 'orca-session', workDir: 'C:\\repo' });
+    const { deps } = createDeps({
+      getSession: vi.fn(() => oldSession),
+      isOrcaMcpHydrated: vi.fn(() => false),
+      synthesizeOrcaVendorOptionsFromDb: vi.fn(async () => true),
+      reconcileCreateOptsWithDb: vi.fn(async () => {
+        throw new Error('db unavailable');
+      }),
+    });
+    const transaction = createMakerSendTransaction(deps);
+
+    await expect(
+      transaction.sendToAgentAccepted('orca-session', 'hello', {
+        id: 'orca-session',
+        agentKind: 'pi',
+        workingDir: 'C:\\repo',
+        model: 'k3',
+      }),
+    ).resolves.toMatchObject({ accepted: false, reason: 'REHYDRATE_FAILED' });
+
+    expect(deps.closeSession).not.toHaveBeenCalled();
+    expect(deps.bootstrapSession).not.toHaveBeenCalled();
+    expect(oldSession.send).not.toHaveBeenCalled();
+  });
+
   it('returns rehydrate failure without sending when active Orca rehydrate fails', async () => {
     const oldSession = createSession({ id: 'orca-session', workDir: 'C:\\repo' });
     const { deps } = createDeps({

--- a/apps/desktop/src/main/maker-ipc/makerSendTransaction.ts
+++ b/apps/desktop/src/main/maker-ipc/makerSendTransaction.ts
@@ -635,6 +635,12 @@ export function createMakerSendTransaction(deps: MakerSendTransactionDeps): Make
     }
     await loadExtraDirsIfNeeded(sessionId, createOpts, 'active-orca-rehydrate');
     try {
+      // 关旧 runtime 前先按 DB 权威口径对账执行字段(与 lazy-create 同源):caller /
+      // 队列的 createOpts 快照常不带 resumeSessionId(或带旧引擎的陈旧值),直接
+      // close+bootstrap 会启动一个没有旧 transcript 的全新原生会话(#2882:Pi 会话
+      // 中途 start_team 后丢失全部对话历史)。DB 读失败时 reconcile 抛错 → 落入下方
+      // REHYDRATE_FAILED,此时尚未 closeSession,旧 runtime 不受损。
+      await deps.reconcileCreateOptsWithDb?.(sessionId, createOpts);
       const session = await deps.withRehydrateCloseSuppressed(sessionId, async () => {
         await deps.closeSession(sessionId);
         // close 后重新 bootstrap，避免旧 SDK handle 缺 Orca MCP vendorOptions。


### PR DESCRIPTION
## 这次改了什么

### 摘要

修复 #2882:Pi 会话中途 `start_team` 启用 Orca 后,下一条消息丢失全部对话历史。

根因(与 issue 内维护者助手的分析一致):`makerSendTransaction.ts` 的 active-Orca rehydrate 分支为了给旧 SDK handle 换上 Orca MCP vendorOptions,会 `closeSession` + `bootstrapSession(createOpts)`;但 caller / 队列的 createOpts 快照常不带 `resumeSessionId`(或带旧引擎的陈旧值),bootstrap 便启动了一个没有旧 transcript 的全新原生会话。Pi 只在收到 `resumeSessionId` 时才发 `switch_session` 恢复旧 JSONL,因此 UI 历史仍在、模型却只看到最新追问。

修复:rehydrate 在关闭旧 runtime **之前**调用既有的 `reconcileCreateOptsWithDb`(即 lazy-create 分支已在用的 `reconcileCreateOptsAgainstDb`,DB 权威口径,无条件对齐 `resumeSessionId` / model / providerId / effort 等执行字段);DB 读失败时该函数抛错,落入既有 `REHYDRATE_FAILED` 收口,**此时尚未 closeSession,旧 runtime 不受损**。不改变「close+bootstrap 换 MCP vendorOptions」的既有重建方式。

### 变更类型

- [x] `fix` 缺陷修复

### 范围

- 关联 Issue / 需求:Fixes #2882
- 本 PR 包含:active-Orca rehydrate 前的 DB createOpts 对账(1 行调用 + 注释);两条新回归测试
- 明确不包含:`start_team` 当轮热加载 Orca MCP(issue 分析明确不建议作为首选);Pi `switch_session` 链路本身(未改)
- 用户可见变化:Pi(及其他 agent)会话中途开启 Orca 后继续对话,模型仍能看到此前全部历史
- 是否存在 breaking change:无

### UI 变化

不涉及:仅 main 进程 send 事务路径,无 UI 代码改动。

## 怎么验证的

### 自动验证

```text
pnpm vitest run src/main/maker-ipc/__tests__/makerSendTransaction.test.ts → 73/73 通过(含 2 条新增:
  ① 对账先于 closeSession,DB 权威 resumeSessionId 胜过 caller 陈旧值并传入 bootstrap;
  ② 对账抛错 → REHYDRATE_FAILED,不关旧 runtime、不 bootstrap、不 send)
pnpm test:unit:related → PASS(apps/desktop unit,33.4s)
pnpm --filter desktop run --if-present typecheck → 通过
```

### 手动验证

未做实机 Pi 端到端验收(本机当前无可复现的 Pi + Orca 环境)。风险敞口如实说明:`reconcileCreateOptsAgainstDb` 是 lazy-create 已长期在线的同一函数,本 PR 只是把它接到 rehydrate 入口,新增行为面有限;测试已覆盖对账时序与 fail-closed 边界。

## 风险与回滚

- 风险:rehydrate 路径新增一次 DB 读;DB 短暂不可用时该次发送会以 REHYDRATE_FAILED 失败(此前会「成功」但丢历史)——按 fail-closed 取舍,与 lazy-create 行为一致。
- 回滚:revert 单 commit 即可,无数据/协议变更。
