### PR TITLE
fix(desktop): 同 owner 代际跳变后输入框草稿仍可写,修复「添加到对话」无效

### DIFF
--- a/apps/desktop/src/renderer/__tests__/chatInputSessionFocus.test.ts
+++ b/apps/desktop/src/renderer/__tests__/chatInputSessionFocus.test.ts
@@ -371,9 +371,9 @@ expect(capabilitySelectionBlock).toContain('!ghost?.enabled');
     expect(chatInputSource).toContain('recoveryBatch: error as object');
     expect(chatInputSource).toContain('recoveryBatch ? { recoveryBatch } : undefined');
     expect(chatInputSource).toContain('if (!updateLive || !isCurrentComposer) return;');
-    expect(chatInputSource).toContain('if (!isDataOwnerGenerationCurrent(dataOwnerAtEffect))');
+    expect(chatInputSource).toContain('if (!isDataOwnerIdCurrent(dataOwnerAtEffect))');
     expect(chatInputSource).toContain(
-      'if (!isDataOwnerGenerationCurrent(dataOwnerAtSubscription)) return;',
+      'if (!isDataOwnerIdCurrent(dataOwnerAtSubscription)) return;',
     );
     expect(chatInputSource).toContain('browserCommentsRef.current = nextBrowserComments;');
     expect(chatInputSource).toContain('browserCommentsRef.current = restoredComments;');

--- a/apps/desktop/src/renderer/__tests__/composerDraftSameOwnerGenerationBump.test.ts
+++ b/apps/desktop/src/renderer/__tests__/composerDraftSameOwnerGenerationBump.test.ts
@@ -1,0 +1,106 @@
+/**
+ * composerDraftSameOwnerGenerationBump.test.ts — 同 owner 代际跳变后输入框仍可写
+ * ---------------------------------------------------------------------------
+ * main 侧每次 access-token 刷新触发 Ghost projection 同 owner 修复时,会把
+ * ownerGeneration +1 但 dataOwnerId 不变(2026-08-10 起)。renderer 这边没有任何
+ * 东西 remount:AuthContext 只 key 在 dataOwnerId 上,composerDraftStore 的
+ * 命名空间也只按 owner id 分区。ChatInput 在编辑器就位时把当时的 generation 存进
+ * editorDataOwnerRef,若之后所有守卫都拿它与「当前 generation」精确比对,一次
+ * 同 owner 跳变之后:
+ *   - 键击草稿保存被静默丢弃;
+ *   - 外部草稿写入(选中文字「添加到对话」/ rewind 预填)的订阅回调直接 return,
+ *     引用永远进不了编辑器 —— 用户看到的就是「点添加到对话没反应」。
+ *
+ * 契约:编辑器生命周期内的持久化守卫只按 owner id 判定;真正的账号切换仍会被
+ * 拦下。仅需跨运行时拆除的在途异步(乐观发送清空/恢复)才继续用精确 generation。
+ */
+import { readFileSync } from 'node:fs';
+import path from 'node:path';
+
+import { afterEach, describe, expect, it } from 'vitest';
+
+import {
+  __testing as dataOwnerTesting,
+  isDataOwnerGenerationCurrent,
+  isDataOwnerIdCurrent,
+  setDataOwnerGeneration,
+} from '@/contexts/dataOwnerGeneration';
+
+const chatInput = readFileSync(
+  path.join(path.resolve(__dirname, '..'), 'components/new-chat/ChatInput.tsx'),
+  'utf8',
+).replace(/\r\n?/g, '\n');
+
+function extractBetween(source: string, start: string, end: string): string {
+  const from = source.indexOf(start);
+  expect(from).toBeGreaterThan(-1);
+  const to = source.indexOf(end, from);
+  expect(to).toBeGreaterThan(from);
+  return source.slice(from, to);
+}
+
+describe('isDataOwnerIdCurrent', () => {
+  afterEach(() => {
+    dataOwnerTesting.reset();
+  });
+
+  it('stays current across a same-owner generation bump, unlike the exact check', () => {
+    setDataOwnerGeneration('owner-a', 1);
+    const captured = { dataOwnerId: 'owner-a', generation: 1 } as const;
+    expect(isDataOwnerGenerationCurrent(captured)).toBe(true);
+    expect(isDataOwnerIdCurrent(captured)).toBe(true);
+
+    // Same owner re-committed (Ghost projection repair on token refresh).
+    setDataOwnerGeneration('owner-a', 2);
+    expect(isDataOwnerGenerationCurrent(captured)).toBe(false);
+    expect(isDataOwnerIdCurrent(captured)).toBe(true);
+  });
+
+  it('still rejects a real owner change or sign-out boundary', () => {
+    setDataOwnerGeneration('owner-a', 1);
+    const captured = { dataOwnerId: 'owner-a', generation: 1 } as const;
+
+    setDataOwnerGeneration(null);
+    expect(isDataOwnerIdCurrent(captured)).toBe(false);
+
+    setDataOwnerGeneration('owner-b');
+    expect(isDataOwnerIdCurrent(captured)).toBe(false);
+  });
+});
+
+describe('ChatInput editor-lifetime draft guards use owner id only', () => {
+  it('keystroke draft saves survive a same-owner generation bump', () => {
+    const block = extractBetween(
+      chatInput,
+      'const dataOwnerAtSchedule = editorDataOwnerRef.current;',
+      'scheduleCaretScroll(ed);',
+    );
+    expect(block).toContain('if (!isDataOwnerIdCurrent(dataOwnerAtSchedule)) return;');
+    expect(block).not.toContain('isDataOwnerGenerationCurrent(dataOwnerAtSchedule)');
+  });
+
+  it('unmount draft snapshot survives a same-owner generation bump', () => {
+    const block = extractBetween(
+      chatInput,
+      'const dataOwnerAtEffect = editorDataOwnerRef.current;',
+      'draftSaveSchedulerRef.current?.flush();',
+    );
+    expect(block).toContain('if (!isDataOwnerIdCurrent(dataOwnerAtEffect))');
+    expect(block).not.toContain('isDataOwnerGenerationCurrent(dataOwnerAtEffect)');
+  });
+
+  it('external draft writes (selection quote / rewind pre-fill) still reach the editor', () => {
+    const block = extractBetween(
+      chatInput,
+      'const dataOwnerAtSubscription = editorDataOwnerRef.current;',
+      'const draft = getComposerDraft(storageKey);',
+    );
+    expect(block).toContain('return subscribeComposerDraft(storageKey, () => {');
+    expect(block).toContain('if (!isDataOwnerIdCurrent(dataOwnerAtSubscription)) return;');
+    expect(block).not.toContain('isDataOwnerGenerationCurrent(dataOwnerAtSubscription)');
+  });
+
+  it('keeps the exact generation fence for the in-flight optimistic send restore', () => {
+    expect(chatInput).toContain('!isDataOwnerGenerationCurrent(dataOwnerAtOptimisticClear)');
+  });
+});

--- a/apps/desktop/src/renderer/__tests__/composerDraftSameOwnerGenerationBump.test.ts
+++ b/apps/desktop/src/renderer/__tests__/composerDraftSameOwnerGenerationBump.test.ts
@@ -17,14 +17,27 @@
 import { readFileSync } from 'node:fs';
 import path from 'node:path';
 
-import { afterEach, describe, expect, it } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+
+import type { JSONContent } from '@tiptap/core';
 
 import {
   __testing as dataOwnerTesting,
+  getDataOwnerGeneration,
   isDataOwnerGenerationCurrent,
   isDataOwnerIdCurrent,
   setDataOwnerGeneration,
+  type DataOwnerGeneration,
 } from '@/contexts/dataOwnerGeneration';
+import {
+  appendQuoteToDraft,
+  clearDraft,
+  getDraft,
+  saveDraft,
+  setComposerDraftOwner,
+  subscribeDraft,
+} from '@/lib/composerDraftStore';
+import { COMPOSER_QUOTE_NODE_TYPE } from '@/lib/composerQuoteDocument';
 
 const chatInput = readFileSync(
   path.join(path.resolve(__dirname, '..'), 'components/new-chat/ChatInput.tsx'),
@@ -65,6 +78,143 @@ describe('isDataOwnerIdCurrent', () => {
 
     setDataOwnerGeneration('owner-b');
     expect(isDataOwnerIdCurrent(captured)).toBe(false);
+  });
+});
+
+/**
+ * 行为层复刻(同 composerDraftMountRace.test.ts 的做法:不引入 React + Tiptap,
+ * 只跑真实 composerDraftStore 数据流)。`ownerAtEditorReady` 对应 ChatInput 的
+ * editorDataOwnerRef —— 编辑器就位时捕获一次,之后不再更新;三条持久化路径都
+ * 拿它做守卫。守卫谓词作为参数注入,好把「修复前(精确 generation)」与
+ * 「修复后(仅 owner id)」两种行为放在同一套序列下对比。
+ */
+type OwnerGuard = (owner: DataOwnerGeneration) => boolean;
+
+function makeTextDoc(text: string): JSONContent {
+  return { type: 'doc', content: [{ type: 'paragraph', content: [{ type: 'text', text }] }] };
+}
+
+function docHasQuote(doc: JSONContent | null | undefined): boolean {
+  if (!doc) return false;
+  if (doc.type === COMPOSER_QUOTE_NODE_TYPE) return true;
+  return (doc.content ?? []).some(docHasQuote);
+}
+
+function mountComposer(sessionId: string, guard: OwnerGuard) {
+  const ownerAtEditorReady = getDataOwnerGeneration();
+  let editorDoc: JSONContent | null = null;
+  const editorSetContentCalls: JSONContent[] = [];
+
+  // ChatInput 的外部草稿写入订阅(选中文字「添加到对话」/ rewind 预填走这里)。
+  const unsubscribe = subscribeDraft(sessionId, () => {
+    if (!guard(ownerAtEditorReady)) return;
+    const draft = getDraft(sessionId);
+    if (!draft?.text) return;
+    editorDoc = draft.text;
+    editorSetContentCalls.push(draft.text);
+  });
+
+  return {
+    /** 用户在编辑器里敲字 → onUpdate 的 debounce 落盘。 */
+    type(text: string): boolean {
+      editorDoc = makeTextDoc(text);
+      if (!guard(ownerAtEditorReady)) return false;
+      const existing = getDraft(sessionId);
+      saveDraft(
+        sessionId,
+        { text: editorDoc, attachments: existing?.attachments ?? [] },
+        { silent: true },
+      );
+      return true;
+    },
+    /** 卸载 / 切路由时的编辑器快照。 */
+    unmount(): boolean {
+      unsubscribe();
+      if (!guard(ownerAtEditorReady)) return false;
+      const existing = getDraft(sessionId);
+      if (!editorDoc && !existing) return false;
+      saveDraft(
+        sessionId,
+        { text: editorDoc, attachments: existing?.attachments ?? [] },
+        { silent: true },
+      );
+      return true;
+    },
+    get editorDoc() {
+      return editorDoc;
+    },
+    get setContentCalls() {
+      return editorSetContentCalls;
+    },
+  };
+}
+
+describe('composer draft flow across a same-owner generation bump', () => {
+  const SESSION = 'session-quote-a';
+
+  beforeEach(() => {
+    dataOwnerTesting.reset();
+    setDataOwnerGeneration('owner-a', 1);
+    setComposerDraftOwner('owner-a');
+    clearDraft(SESSION);
+  });
+
+  afterEach(() => {
+    clearDraft(SESSION);
+    setComposerDraftOwner(null);
+    dataOwnerTesting.reset();
+  });
+
+  it('reproduces the bug with the exact-generation guard: quote never reaches the editor', () => {
+    const composer = mountComposer(SESSION, isDataOwnerGenerationCurrent);
+    expect(composer.type('hello')).toBe(true);
+
+    // Access-token refresh → Ghost projection same-owner repair → generation +1.
+    setDataOwnerGeneration('owner-a', 2);
+
+    appendQuoteToDraft(SESSION, { text: 'selected text' });
+    // The store did get the quote…
+    expect(docHasQuote(getDraft(SESSION)?.text)).toBe(true);
+    // …but the mounted editor never did, and typing stopped persisting too.
+    expect(composer.setContentCalls).toHaveLength(0);
+    expect(docHasQuote(composer.editorDoc)).toBe(false);
+    expect(composer.type('hello world')).toBe(false);
+    expect(composer.unmount()).toBe(false);
+  });
+
+  it('with the owner-id guard: "add to chat" and keystroke saves keep working after the bump', () => {
+    const composer = mountComposer(SESSION, isDataOwnerIdCurrent);
+    expect(composer.type('hello')).toBe(true);
+
+    setDataOwnerGeneration('owner-a', 2);
+
+    appendQuoteToDraft(SESSION, { text: 'selected text' });
+    expect(composer.setContentCalls).toHaveLength(1);
+    expect(docHasQuote(composer.editorDoc)).toBe(true);
+
+    expect(composer.type('hello world')).toBe(true);
+    expect(getDraft(SESSION)?.text).toEqual(makeTextDoc('hello world'));
+    expect(composer.unmount()).toBe(true);
+  });
+
+  it('with the owner-id guard: a real owner change still fences the stale editor', () => {
+    const composer = mountComposer(SESSION, isDataOwnerIdCurrent);
+    expect(composer.type('hello')).toBe(true);
+
+    // Sign-out boundary, then a different account signs in.
+    setDataOwnerGeneration(null);
+    expect(composer.type('leak?')).toBe(false);
+    setDataOwnerGeneration('owner-b');
+    setComposerDraftOwner('owner-b');
+
+    appendQuoteToDraft(SESSION, { text: 'owner-b quote' });
+    expect(composer.setContentCalls).toHaveLength(0);
+    expect(composer.type('leak?')).toBe(false);
+    expect(composer.unmount()).toBe(false);
+    // owner-b's namespace only holds what owner-b wrote.
+    expect(getDraft(SESSION)?.text).not.toEqual(makeTextDoc('leak?'));
+    expect(docHasQuote(getDraft(SESSION)?.text)).toBe(true);
+    clearDraft(SESSION);
   });
 });
 

--- a/apps/desktop/src/renderer/components/new-chat/ChatInput.tsx
+++ b/apps/desktop/src/renderer/components/new-chat/ChatInput.tsx
@@ -102,6 +102,7 @@ import {
 import {
   getDataOwnerGeneration,
   isDataOwnerGenerationCurrent,
+  isDataOwnerIdCurrent,
 } from '@/contexts/dataOwnerGeneration';
 import { subscribeSessionLinkInsert } from '@/lib/composerActionsBus';
 import {
@@ -2672,7 +2673,11 @@ export function ChatInput({
       // 跳过这次写入(旧会话的最终内容已由 saveCurrentEditorDraft 在切换前存妥)。
       draftSaveSchedulerRef.current?.schedule(() => {
         if (storageKeyForDraftRef.current !== sk) return;
-        if (!isDataOwnerGenerationCurrent(dataOwnerAtSchedule)) return;
+        // Owner id only: a same-owner generation bump (Ghost projection repair
+        // every access-token refresh) keeps this editor and its draft namespace
+        // valid, and nothing remounts to re-capture the generation. Gating on
+        // the exact generation silently dropped every keystroke save afterwards.
+        if (!isDataOwnerIdCurrent(dataOwnerAtSchedule)) return;
         const existing = getComposerDraft(sk);
         saveComposerDraft(
           sk,
@@ -2996,7 +3001,9 @@ export function ChatInput({
     if (!editor) return;
     const dataOwnerAtEffect = editorDataOwnerRef.current;
     return () => {
-      if (!isDataOwnerGenerationCurrent(dataOwnerAtEffect)) {
+      // Owner id only (see the keystroke save above): only a real owner change
+      // must discard the editor's snapshot instead of persisting it.
+      if (!isDataOwnerIdCurrent(dataOwnerAtEffect)) {
         draftSaveSchedulerRef.current?.cancel();
         return;
       }
@@ -3770,7 +3777,11 @@ export function ChatInput({
     if (!editor || !storageKey) return;
     const dataOwnerAtSubscription = editorDataOwnerRef.current;
     return subscribeComposerDraft(storageKey, () => {
-      if (!isDataOwnerGenerationCurrent(dataOwnerAtSubscription)) return;
+      // Owner id only: this subscription lives as long as the editor, and the
+      // draft store is namespaced by owner id, not generation. Gating on the
+      // exact generation made "add selection to chat" / rewind pre-fill silently
+      // stop reaching the editor after the first same-owner token refresh.
+      if (!isDataOwnerIdCurrent(dataOwnerAtSubscription)) return;
       const draft = getComposerDraft(storageKey);
       if (!draft) return;
       const nextBrowserComments = [...(draft.browserComments ?? [])];

--- a/apps/desktop/src/renderer/contexts/dataOwnerGeneration.ts
+++ b/apps/desktop/src/renderer/contexts/dataOwnerGeneration.ts
@@ -39,6 +39,20 @@ export function isDataOwnerGenerationCurrent(
   );
 }
 
+/**
+ * Whether `owner` still names the active data owner, regardless of generation.
+ *
+ * A same-owner re-commit (Ghost projection repair, account-free repair) advances
+ * `generation` without changing the owner or its renderer-side storage
+ * namespaces, and nothing remounts. Long-lived UI that persists into the owner's
+ * namespace (a mounted composer editor) must keep working across such bumps, so
+ * it qualifies by owner id only. In-flight async work that must not span a
+ * runtime teardown keeps using {@link isDataOwnerGenerationCurrent}.
+ */
+export function isDataOwnerIdCurrent(owner: DataOwnerGeneration): boolean {
+  return current.dataOwnerId === owner.dataOwnerId;
+}
+
 /** Validate a main-process live push against the renderer's current owner. */
 export function isDataOwnerPushStampCurrent(stamp: unknown): stamp is DataOwnerPushStamp {
   if (!isDataOwnerPushStamp(stamp)) return false;


### PR DESCRIPTION
## 这次改了什么

### 摘要

选中对话里的文字点「添加到对话」没反应(右键菜单的「添加到对话」、rewind 预填同样受影响),而且现象只在 app 开着一段时间后出现,重启就好。

根因是两条独立改动叠在一起:

1. `main` 侧 2026-08-10 起(`efa1fce9b` / `901183f1f`),每次 access-token 刷新触发 Ghost projection **同 owner** 修复时,会把 `ownerGeneration +1`,`dataOwnerId` 不变。本机日志可见:`stable app session committed { generation: 1 }` → 约 5 小时后 `generation: 2`,期间没有重启。
2. `ChatInput` 在编辑器就位时把当时的 owner generation 存进 `editorDataOwnerRef`,之后**三处**编辑器生命周期内的持久化守卫都拿它与当前 generation **精确比对**:键击草稿保存、卸载快照、以及外部草稿写入订阅(`subscribeComposerDraft`)。

而 renderer 侧对同 owner 跳变**没有任何东西 remount**:`OwnerScopedRouter` 只 key 在 `dataOwnerId + dataOwnerRecoveryEpoch`,`composerDraftStore` 命名空间也只按 owner id 分区,`editorDataOwnerRef` 只在 storageKey 切换时才重新捕获。于是一次同 owner 跳变后,`appendQuoteToDraft` 确实把引用写进了 store,但 ChatInput 的订阅回调第一行 `if (!isDataOwnerGenerationCurrent(dataOwnerAtSubscription)) return;` 直接返回,引用永远进不了编辑器;同时所有键击草稿保存也被静默丢弃。

修法:新增 `isDataOwnerIdCurrent`(只按 owner id 判定),编辑器生命周期内的三处守卫改用它。真正的账号切换 / 登出(owner id 变化或变 `null`)仍照旧拦下。乐观发送清空/恢复(`dataOwnerAtOptimisticClear`)这类**跨运行时拆除的在途异步**继续用精确 generation,不动。

### 变更类型

- [x] `fix` 缺陷修复

### 范围

- 关联 Issue / 需求:用户实机反馈「选中对话文字点添加到对话没用」
- 本 PR 包含:`dataOwnerGeneration.ts` 新增 `isDataOwnerIdCurrent`;`ChatInput.tsx` 三处守卫改用它;源码契约测试同步;新增 `composerDraftSameOwnerGenerationBump.test.ts`(helper 单测 + 真实 store 数据流行为测试 + 源码契约)
- 明确不包含:`useAttachments` 的附件侧守卫(它的 `dataOwner` 在每次 render 重新读取,不会卡在旧 generation);main 侧的 generation bump 语义
- 用户可见变化:app 运行超过一个 token 刷新周期后,「添加到对话」/ rewind 预填 / 键击草稿保存恢复正常
- 是否存在 breaking change:无

### UI 变化

不涉及:只改 renderer 内部守卫逻辑,无视觉 / 交互 / 文案变化。

- 引用的设计规范:不涉及:纯逻辑修复,只改 renderer 内部的 owner 守卫谓词,无视觉 / 交互 / 文案变化

## 怎么验证的

### 自动验证

```text
(已 rebase 到 origin/main d42265481,head 588381d82)

pnpm --filter desktop run --if-present typecheck
结果:通过

pnpm test:unit:related
结果:PASS apps/desktop unit(related 4 文件,166.7s),其余 workspace 无相关测试跳过。

定向:vitest run composerDraftSameOwnerGenerationBump / chatInputSessionFocus → 25 passed
(新增 9 个用例,含跑真实 composerDraftStore 的行为测试:精确 generation 守卫复现
「引用写进 store 但进不了编辑器」,owner id 守卫修复后引用到达编辑器、键击保存与
卸载快照照常,真实切号仍被拦下。)

pnpm check:dco → 通过

首轮 CI 的 Windows unit tests (1/2) 失败是 src/main/reviewer/__tests__/reviewSourceLease.test.ts
20s 超时(本 PR 未触碰该目录),rebase 后已重跑。
rebase 后 CI:Linux / Windows unit tests、Desktop Git integration、verify、DCO、CodeQL 全部通过。
```

### 手工验证

未在打包 app 内复现-修复闭环(需要等一次 token 刷新周期或手动触发同 owner 修复)。根因链路由本机 `main-2026-09-02.log` 的 generation 1→2 记录与源码守卫逻辑确认。

### 未执行的验证

- 实机目检:本 PR 不改 UI。
- 打包 app 内跨 token 刷新周期的端到端复现:见上。

## 风险

### 风险分类

- [x] 权限 / 安全 / 用户数据

### 影响与回滚

- 影响范围:仅 renderer `ChatInput` 的三处草稿持久化守卫。放宽的是「同 owner id 不同 generation」这一种情况;owner id 变化(切号 / 登出 / auth boundary 置 `null`)的行为逐字节不变,不会把 A 账号草稿写进 B 账号命名空间(store 本身就按 owner id 分区)。
- 回滚 / 降级方式:revert 本 commit 即可,无数据迁移。

### 提交前检查

- [x] 已 review 完整 diff
- [x] 每个 commit 都带 DCO 签名(`git commit -s`,见 [DCO](../DCO))
- [x] UI 改动已在「UI 变化」注明引用的设计规范章节(不涉及 UI 则跳过)
- [x] 未提交凭证、令牌或授权文件
- [x] 已补充必要文档
- [x] 已确认测试结果或说明未执行原因

