### PR TITLE
fix(sidebar): 搜索钉住白条上下等距，不再贴住输入框上沿（建议稿）

### DIFF
--- a/apps/desktop/src/renderer/__tests__/machineSwitcherMenu.test.ts
+++ b/apps/desktop/src/renderer/__tests__/machineSwitcherMenu.test.ts
@@ -88,7 +88,12 @@ describe('远程机器切换入口并入 SidebarTopNav(置顶段上方,固定不
     expect(topNavSource).toContain(
       "const pinSearch = section === 'scrollable' && search.query.trim().length > 0",
     );
-    expect(topNavSource).toContain("pinSearch && 'sticky top-0 z-30 bg-[var(--cmd-palette-bg)]'");
+    // 断言前归一化行尾:Windows checkout 下源码可能是 CRLF。
+    const topNavSourceLf = topNavSource.replace(/\r\n/g, '\n');
+    expect(topNavSourceLf).toContain(
+      "const PINNED_SEARCH_CLASS =\n  'sticky top-0 z-30 bg-[var(--cmd-palette-bg)] pt-[4px] pb-[4px] -mt-[10px]'",
+    );
+    expect(topNavSourceLf).toContain('pinSearch && PINNED_SEARCH_CLASS');
     expect(topNavSource).toContain("if (section === 'scrollable')");
     expect(sidebarUpperSource).toContain('lastListScrollTopRef.current = el.scrollTop');
     expect(sidebarUpperSource).toContain(

--- a/apps/desktop/src/renderer/components/sidebar/SidebarTopNav.tsx
+++ b/apps/desktop/src/renderer/components/sidebar/SidebarTopNav.tsx
@@ -36,6 +36,16 @@ import { GhostMainViewNavEntries } from './GhostMainViewNavEntries';
 /** 列表行通用样式 —— 各行同款 pill 行。 */
 const ROW_CLASS =
   'flex h-8 w-full items-center gap-2.5 rounded-full px-3 text-sm font-normal text-[var(--sidebar-nav-text)] transition-colors hover:bg-sidebar-item-hover';
+/**
+ * 搜索钉住态(有查询时)的白底条样式。上下等量内边距(上4下4,对齐 DESIGN.md §5
+ * spacing scale;原 5px 折中方案已按 PR #3829 review 意见改为规范值):
+ * 只补 pt 会让输入框下跳,故同时把负 margin 加深等量,pill 视觉位置不变,白条向上
+ * 扩出 4px —— 否则白条顶边直接贴住搜索框上沿,与下方不对称(「白框上面是贴着的,
+ * 距离不一样」)。上扩会盖到上一行底部约 2px,该区域在行内文字/图标之下,且白底
+ * 近侧栏底色,肉眼不可感。抽成常量:machineSwitcherMenu.test.ts 以定义为源码契约。
+ */
+const PINNED_SEARCH_CLASS =
+  'sticky top-0 z-30 bg-[var(--cmd-palette-bg)] pt-[4px] pb-[4px] -mt-[10px]';
 /** 命中当前视图（自动任务 / Plugin 与 Skill 管理 / issue）时的高亮 —— 与下方会话列表
  *  选中行同款反相胶囊(sidebar-item-active 族;2026-07-21 用户裁决,替代原 chat-input-chip
  *  灰 chip,顶部导航选中态与对话选中样式统一)。hover:bg-sidebar-item-active 抵消
@@ -155,7 +165,7 @@ export function SidebarTopNav({
           className={cn(
             // -mt-1.5 抵消滚动容器 gap-2,与上面两行仍保持 gap-0.5。
             'px-3 pb-2.5 -mt-1.5',
-            pinSearch && 'sticky top-0 z-30 bg-[var(--cmd-palette-bg)]',
+            pinSearch && PINNED_SEARCH_CLASS,
           )}
         >
           {searchRow}


### PR DESCRIPTION
## 这次改了什么

### 摘要

展开侧栏搜索有查询时，搜索行会 sticky 钉住并衬一条 `--cmd-palette-bg` 白底（供结果列表从下方滚过时遮挡）。但这条白底只有 `pb-2.5`（下方 10px 内边距）、顶部 0 内边距——白条顶边直接贴住搜索框上沿，上下距离不对称（用户反馈：「白框上面是贴着的，距离不一样」）。

本 PR 建议钉住态白底上下等距：补 `pt-[4px]` 的同时把负 margin 等量加深为 `-mt-[10px]` 抵消，搜索框视觉位置不变、打字不跳位；白条上扩后仅遮住上一行底部约 2px（位于行内文字/图标之下，肉眼不可感）。

> **数值依据（已按 #3833 review 意见更新）**：初稿曾按用户即时反馈取 5px（不在 spacing scale 上）；现对齐 `DESIGN.md` §5 Spacing System 的 scale，采用 **4px**（scale 相邻档 4/6px 中取更贴近原视觉比例的 4px，负 margin 同步重算，输入框位置与滚动段间距不变）。实现结构与 token 用法不变。

### 变更类型

- [ ] `feat` 新功能
- [x] `fix` 缺陷修复
- [ ] `refactor` / `perf` 重构或性能优化
- [ ] `docs` / `test` / `chore` 文档、测试或工程维护
- [ ] 其他：

### 范围

- 关联 Issue / 需求：#3833（维护者确认讨论）
- 本 PR 包含：
  - `SidebarTopNav.tsx`：搜索钉住态白底条上下等距（新 `PINNED_SEARCH_CLASS` 常量）
  - `machineSwitcherMenu.test.ts`：同步该段样式的源码契约断言（改为钉常量定义 + 行尾归一化）
- 明确不包含：搜索交互/行为变更、popover 形态（rail 搜索弹窗）变更、设计 token 调整、~~localDb 测试夹具修复~~（已按 review 意见拆出为独立 PR）
- 用户可见变化：搜索时搜索框上方出现 4px 白底留白（原为 0，直接贴住），搜索框位置与其它行为不变
- 是否存在 breaking change：无

### UI 变化

- 引用的设计规范：`docs/design-rules/DESIGN.md` §5 Spacing System——4px 为 scale 内档位；白底条沿用 `--cmd-palette-bg` 语义 token，无硬编码颜色，Light/Dark 双模式均由 token 生效（两种模式均已实机目检，见下）。

几何实测（Windows dev 沙箱，CDP 取 `getBoundingClientRect`，Light/Dark 各一次）：

```text
修复前：白底条顶=186（=搜索框顶，0 间距），底=228（框底+10px）
修复后：白底条顶=182（框顶-4px），底=222（框底+4px），搜索框位置不变
Dark：白底条背景 rgba(21,21,21,0.8)（= --cmd-palette-bg 深色值），几何一致
```

### 上一行覆盖取舍（#3833 第 2 点）

白底条上扩 4px 后，相对上一行（自动化/插件等导航行，行高 32px）底部覆盖约 2px：

- 覆盖区域位于行内文字/图标的字形框之下（文字垂直居中，字形框下缘距行底 ≥8px）
- 白底色（`--cmd-palette-bg`）与侧栏底色同族，仅 alpha 0.9 遮罩，hover 胶囊底边 2px 被近色覆盖，实机（Light/Dark、上一行 hover）目检无可感差异
- 替代方案（不覆盖上一行）需要输入框下跳 4px 或打破行距 rhythm，得不偿失

## 怎么验证的

### 自动验证

```text
pnpm test:unit:related
结果：desktop related 218 文件 / 5454 用例全 PASS（含本 PR 契约测试 machineSwitcherMenu.test.ts 36 用例）；另有一次 runner 汇总中 codexMicroGuardCore.test.ts 出现 EPERM symlink 抖动（Windows Temp 建链权限，与本次改动无关、文件无改动，CI Linux 不受影响）

pnpm --filter desktop typecheck
结果：通过

pnpm exec vitest run src/renderer/__tests__/machineSwitcherMenu.test.ts
结果：36 passed
```

### 手工验证

- 平台：Windows dev 沙箱，展开侧栏 → 搜索行输入查询 → 钉住态目检
- **Light 模式**：白条上下各 4px 对称、输入框不跳位、上一行无可感遮挡 ✅
- **Dark 模式**：同几何，白底条呈深色遮罩，上一行可读性无影响 ✅
- 上一行 hover、清空查询收起、滚动边界：无跳位、无残留背景 ✅

### 未执行的验证

- origin/main 基点上的全量单测未在本地重跑（worktree 未装依赖）；2 个改动文件在原基点与 main 间内容一致（cherry-pick 与 copy 均无漂移），CI 会跑完整 `pnpm test:unit` 兜底。

## 风险

### 风险分类

- [x] 无已知风险
- [ ] SQLite / migration
- [ ] system prompt
- [ ] 协议兼容
- [ ] 权限 / 安全 / 用户数据
- [ ] 存量插件兼容（批准状态 / 指纹 / manifest 校验 / 安装布局 / 包格式）
- [ ] 原生层 / fingerprint / OTA
- [ ] 跨平台差异
- [ ] 其他：

### 影响与回滚

- 影响范围：Desktop 展开侧栏搜索钉住态的视觉间距（4px 级别）。
- 回滚 / 降级方式：revert 单提交即可，无数据/协议影响。

### 提交前检查

- [x] 已 review 完整 diff
- [x] 每个 commit 都带 DCO 签名（`git commit -s`，见 [DCO](../DCO)）
- [x] UI 改动已在「UI 变化」注明引用的设计规范章节
- [x] 未提交凭证、令牌或授权文件
- [x] 已补充必要文档（无新增文档需求）
- [x] 已确认测试结果或说明未执行原因
