### PR TITLE
fix(mcps): 飞书能力说明对齐 xd-feishu 插件架构,不再宣称已退役的顶层 MCP 工具

### DIFF
--- a/packages/lizi-mcps/src/xdt-helper/capabilities.ts
+++ b/packages/lizi-mcps/src/xdt-helper/capabilities.ts
@@ -193,11 +193,13 @@ export const CAPABILITIES: readonly CapabilityEntry[] = [
   {
     key: 'feishu-integration',
     title: '飞书集成(基础接入)',
-    oneLiner: '飞书 OAuth 登录、IM 通知、文件上传,以及 agent 可调用的飞书 MCP 工具集。',
+    oneLiner: '飞书 OAuth 登录与 IM 出站通知;飞书数据读写由企业档 xd-feishu 插件经 ghost 网关提供。',
     detail: [
-      `使用飞书 OAuth 登录 ${BRAND_NAME}。任务完成、权限超期等事件通过 IM 推送通知。`,
-      'agent 通过 MCP 工具读写飞书数据:文档(docx_search / read / append_blocks / insert_blocks / update_block)、多维表格(bitable_search / list_tables / list_fields / list_records)、Wiki 知识空间(wiki_search / read / create_node / recent_changes 等)、IM 消息(im_list_chats / read_messages / send_message)、联系人、日程、会议纪要。',
-      '支持上传图片 / 文件到飞书(im_upload_image / im_upload_file),还有跨类型全局搜索 search_and_read。',
+      `使用飞书 OAuth 登录 ${BRAND_NAME}。任务完成、权限超期等事件通过 IM 推送通知;`,
+      '出站通道(cindy_feishu_bot)负责给当前飞书用户发消息 / 发文件 / 发图片,不提供数据读取。',
+      '读写飞书数据(云文档 docx / 多维表格 bitable / Wiki 知识库 / IM 消息搜索阅读 / 联系人 / 日程 / 审批 / 会议纪要)属于企业档 xd-feishu 插件:',
+      '需在侧边栏「插件」安装并启用 xd-feishu、在其详情页连接账号;OAuth 登录成功不等于该插件可用。',
+      '这些操作不注册为顶层 MCP 工具——agent 须经 ghost 网关发现与调用(ghost_info({ghost_id:"xd-feishu"}) 查实时工具清单,再 ghost_call 执行)。',
       '把"接管 desktop session 移动办公"这条独立能力请查 mobile-takeover bucket。',
     ].join(' '),
   },


### PR DESCRIPTION
## 这次改了什么

### 摘要

修复 #3655 的说明性根因:`xdt-helper` 的 `feishu-integration` 能力条目仍在无条件宣称一组**已退役**的顶层飞书 MCP 工具(docx_search / bitable_search / wiki_search / im_list_chats / im_upload_image 等)。按 `builtin-plugins.ts` 正本,这些数据读写操作已迁入企业档 `xd-feishu` 插件,经 ghost 网关(`ghost_info` / `ghost_call`)发现与调用,不再注册为顶层 MCP 工具。过期说明导致 agent 与用户在飞书 OAuth 授权成功后误以为顶层工具应存在,实际只看到 `cindy_feishu_bot` 的两个出站工具,得到「已授权却无法读取日历」的体验——即 #3655 报告的现象,与 issue 内维护者助手分析指出的「最明确的说明缺口」一致。

改写该条目,与现架构对齐:
- **出站通道**(`cindy_feishu_bot`):发消息 / 发文件 / 发图片,不提供数据读取;
- **数据读写**(云文档 / 多维表格 / Wiki / IM 消息 / 联系人 / 日程 / 审批 / 会议纪要):属企业档 `xd-feishu` 插件,需安装、启用并连接账号,**OAuth 登录成功不等于该插件可用**;
- 明确这些操作经 ghost 网关发现调用(`ghost_info({ghost_id:"xd-feishu"})` → `ghost_call`)。

### 变更类型

- [x] `fix` 缺陷修复

### 范围

- 关联 Issue / 需求:Fixes #3655(说明一致性部分;若提报人后续证据显示企业档环境下 `ghost_info` 仍不可见,插件发现回归另行跟踪)
- 本 PR 包含:`packages/lizi-mcps/src/xdt-helper/capabilities.ts` 单条能力文本改写(+6/−4)
- 明确不包含:OAuth token 注入、插件发现链、顶层 MCP 注册(维护者分析明确不建议恢复)
- 用户可见变化:agent 回答「飞书能做什么」时按真实架构指路(先装/启用/连接 xd-feishu,经 ghost 网关调用),不再引用不存在的顶层工具名
- 是否存在 breaking change:无

### UI 变化

不涉及:agent 能力说明文本,无 UI 代码。

## 怎么验证的

### 自动验证

```text
pnpm test:unit:related → PASS(apps/desktop unit 151.1s;packages/lizi-mcps unit 4.4s)
pnpm --filter @cindy/mcps run --if-present typecheck → 通过(exit 0)
```

### 手动验证

本机企业档环境实测:`ghost_info({ghost_id:"xd-feishu"})` 经 ghost 网关可正常发现该插件及其日程等工具(即 issue 分析的第 1 分支成立——能力存在,缺口在说明/发现指引)。未做的:0.1.66 提报人环境的四态(未安装/未启用/待授权/ready)回归,按分析属发布验证范畴。

## 风险与回滚

- 风险:纯文本改写;若表述有误导,revert 单 commit 即可。
- 回滚:revert 本 commit。
