### PR TITLE
fix(pi): 未知自定义 Chat Completions 端点默认收敛 system role,修火山引擎 BYOM 必报 InvalidParameter

### DIFF
--- a/apps/desktop/src/main/maker-host/__tests__/piNativeProviders.test.ts
+++ b/apps/desktop/src/main/maker-host/__tests__/piNativeProviders.test.ts
@@ -281,7 +281,70 @@ describe('buildPiNativeProvidersFromConfigs', () => {
       id: 'models-url-only',
       name: 'Models URL Only',
       contextWindow: 64_000,
+      // 无目录元数据的 Chat Completions 模型默认收敛 system role(#3832)。
+      compat: { supportsDeveloperRole: false },
     });
+  });
+
+  it('defaults unknown custom Chat Completions models to system role (#3832)', () => {
+    const { providers } = buildPiNativeProvidersFromConfigs(
+      [
+        {
+          id: 'volcengine',
+          name: 'Volcengine Ark',
+          auth: { method: 'apiKey' },
+          runtimes: {
+            pi: piRuntime({
+              baseUrl: 'https://ark.cn-beijing.volces.com/api/v3',
+              wireProtocol: 'openai-chat',
+              models: [{ id: 'doubao-seed-2-0', name: 'Doubao Seed 2.0' }],
+            }),
+          },
+        },
+      ],
+      () => 'ark-key',
+    );
+    expect(providers[0]?.models[0]).toMatchObject({
+      id: 'doubao-seed-2-0',
+      compat: { supportsDeveloperRole: false },
+    });
+  });
+
+  it('does not inject the system-role fallback for non-Chat protocols (#3832)', () => {
+    const { providers } = buildPiNativeProvidersFromConfigs(
+      [
+        {
+          id: 'custom-anthropic',
+          name: 'Custom Anthropic Compatible',
+          auth: { method: 'apiKey' },
+          runtimes: {
+            pi: piRuntime({
+              baseUrl: 'https://compat.example/v1',
+              wireProtocol: 'anthropic-messages',
+              models: [{ id: 'compat-model' }],
+            }),
+          },
+        },
+        {
+          id: 'custom-responses',
+          name: 'Custom Responses Compatible',
+          auth: { method: 'apiKey' },
+          runtimes: {
+            pi: piRuntime({
+              baseUrl: 'https://responses.example/v1',
+              wireProtocol: 'openai-responses',
+              models: [{ id: 'responses-model' }],
+            }),
+          },
+        },
+      ],
+      () => 'key',
+    );
+    for (const provider of providers) {
+      for (const model of provider.models) {
+        expect(model).not.toHaveProperty('compat');
+      }
+    }
   });
 
   it('does not apply official per-model routing after the user changes endpoint or protocol', () => {
@@ -378,6 +441,8 @@ describe('buildPiNativeProvidersFromConfigs', () => {
         xhigh: null,
         max: null,
       },
+      // 目录标记清除后无同源元数据,Chat Completions 默认收敛 system role(#3832)。
+      compat: { supportsDeveloperRole: false },
     });
   });
 
@@ -1859,9 +1924,16 @@ describe('buildPiNativeProvidersFromConfigs', () => {
       ],
       () => null,
     );
+    const chatDefaultCompat = { compat: { supportsDeveloperRole: false } };
     expect(providers[0].models).toEqual([
-      { id: 'vision', name: 'Vision', contextWindow: undefined, input: ['text', 'image'] },
-      { id: 'legacy', name: 'Legacy', contextWindow: undefined },
+      {
+        id: 'vision',
+        name: 'Vision',
+        contextWindow: undefined,
+        input: ['text', 'image'],
+        ...chatDefaultCompat,
+      },
+      { id: 'legacy', name: 'Legacy', contextWindow: undefined, ...chatDefaultCompat },
     ]);
   });
 
@@ -2059,6 +2131,8 @@ describe('buildPiNativeProvidersFromConfigs', () => {
         xhigh: null,
         max: 'max',
       },
+      // 显式声明能力但无同源元数据,Chat Completions 默认收敛 system role(#3832)。
+      compat: { supportsDeveloperRole: false },
     });
   });
 });

--- a/apps/desktop/src/main/maker-host/pi-host.ts
+++ b/apps/desktop/src/main/maker-host/pi-host.ts
@@ -1344,7 +1344,17 @@ export function buildPiNativeProvidersFromConfigs(
               : {}),
           ...(bundledModel?.cost ? { cost: { ...bundledModel.cost } } : {}),
           ...(bundledModel?.headers ? { headers: { ...bundledModel.headers } } : {}),
-          ...(bundledModel?.compat ? { compat: structuredClone(bundledModel.compat) } : {}),
+          ...(bundledModel?.compat
+            ? { compat: structuredClone(bundledModel.compat) }
+            : !bundledModel && modelApi === 'openai-completions'
+              ? // 未知自定义 Chat Completions 端点保守回落(#3832):火山引擎等
+                // OpenAI 兼容网关只接受 system/assistant/user/tool,而 Pi 的
+                // detectCompat 对陌生端点默认 supportsDeveloperRole=true,会把
+                // system 指令按 role=developer 发出 → 整个模型不可用。system
+                // role 在所有 OpenAI 兼容端点均可用,故无同源 bundled 元数据时
+                // 默认收敛为 system;有 bundled 元数据的端点维持 Pi 原生判定。
+                { compat: { supportsDeveloperRole: false } }
+              : {}),
           ...(bundledModel?.samplingParams
             ? { samplingParams: structuredClone(bundledModel.samplingParams) }
             : {}),


### PR DESCRIPTION
## 这次改了什么

### 摘要

修复 #3832(用户报告 #3830):自定义 BYOM 提供商(火山引擎等 OpenAI 兼容端点)的 Pi 模型每次发消息必报 `InvalidParameter: invalid value 'developer'`,模型完全不可用。

根因(与 issue 内提报人定位及维护者助手分析一致):Pi 上游 `detectCompat()` 对陌生 OpenAI 兼容端点默认 `supportsDeveloperRole = true`,将 system 指令以 `role: "developer"` 发送;火山引擎等国内兼容网关只接受 `system` / `assistant` / `user` / `tool` 四种角色。而 Cindy 的 `buildPiNativeProvidersFromConfigs()` 装配自定义模型 spec 时,只在有同源 bundled 元数据时复制 `compat`,无元数据时不注入——于是未知端点落进 Pi 的默认 true。

修复:对解析为 `openai-completions` 且**无同源 bundled/官方目录元数据**的自定义模型,默认注入 `compat.supportsDeveloperRole: false`(system role 在所有 OpenAI 兼容端点均可用,与内置目录全部模型标注 false 的行为对齐)。范围守卫:有目录元数据的端点维持 Pi 原生判定;`anthropic-messages` / `openai-responses` 协议不注入;不做任何全局 role 重写或错误重试。

### 变更类型

- [x] `fix` 缺陷修复

### 范围

- 关联 Issue / 需求:Fixes #3832,fix #3830
- 本 PR 包含:`pi-host.ts` 装配层单点默认注入(+9 行);回归测试(新增 2 用例 + 更新 4 处既有严格断言以包含新默认值)
- 明确不包含:「用户可编辑 compat 开关」的设置面(维护者助手分析标注为独立产品决策);Pi 上游 `detectCompat()` 本身(仓库边界外,提报人已附上游侧建议)
- 用户可见变化:火山引擎等自定义 OpenAI 兼容端点的 Pi 模型可正常对话;既有已知端点(bundled/官方目录、responses/anthropic 协议)行为不变
- 是否存在 breaking change:无(若某自定义 Chat 端点确实依赖 developer 语义,可经模型级 route/piApi 显式配置绕开;目前无此类已知端点)

### UI 变化

不涉及:main 进程 Pi provider 装配,无 UI 代码。

## 怎么验证的

### 自动验证

```text
pnpm vitest run src/main/maker-host/__tests__/piNativeProviders.test.ts → 63 passed | 2 skipped
反证:stash 掉 pi-host.ts 修复后重跑 → 6 用例失败(新增 2 例 + 更新的 4 处断言),确认测试真实覆盖缺陷
pnpm test:unit:related → PASS(apps/desktop unit 31.7s)
pnpm --filter desktop run --if-present typecheck → 通过(exit 0)
```

### 手动验证

未做火山引擎真实端点端到端(本机无该账号);按 issue 分析,最终验收需真实环境一轮普通文本 + 一轮工具调用,PR 如实标注留给发布验证。models.json 内容变化不触及 Pi spawn env(pi-harness 稳定性不变量不受影响)。

## 风险与回滚

- 风险:极低——只影响「无目录元数据的自定义 Chat Completions 模型」,方向是从「Pi 猜 true」收敛为「保守 false」;system role 是 OpenAI 兼容协议的通用最小公分母。
- 回滚:revert 单 commit。
