### PR TITLE
fix(pi): BYOM Chat 模型默认回落 system role，修复火山引擎等端点 InvalidParameter

### DIFF
--- a/apps/desktop/src/main/maker-host/__tests__/piNativeProviders.test.ts
+++ b/apps/desktop/src/main/maker-host/__tests__/piNativeProviders.test.ts
@@ -217,6 +217,120 @@ describe('resolvePiCindyGatewayModelApi', () => {
 });
 
 describe('buildPiNativeProvidersFromConfigs', () => {
+  it('pins developer role off for undeclared custom chat-completions models', () => {
+    const { providers } = buildPiNativeProvidersFromConfigs(
+      [
+        {
+          id: 'volc',
+          name: 'Volcano Engine',
+          auth: { method: 'apiKey' },
+          runtimes: {
+            pi: piRuntime({
+              baseUrl: 'https://ark.cn-beijing.volces.com/api/v3',
+              models: [{ id: 'doubao-seed', name: 'Doubao Seed' }],
+            }),
+          },
+        },
+      ],
+      () => 'custom-key',
+    );
+
+    expect(providers[0]?.api).toBe('openai-completions');
+    expect(providers[0]?.models[0]).toMatchObject({
+      id: 'doubao-seed',
+      compat: { supportsDeveloperRole: false },
+    });
+  });
+
+  it('leaves non-chat custom models without a developer-role compat pin', () => {
+    const { providers } = buildPiNativeProvidersFromConfigs(
+      [
+        {
+          id: 'local-responses',
+          name: 'Local Responses',
+          auth: { method: 'none' },
+          runtimes: {
+            pi: piRuntime({
+              wireProtocol: 'openai-responses',
+              models: [{ id: 'local-model', name: 'Local Model' }],
+            }),
+          },
+        },
+        {
+          id: 'local-messages',
+          name: 'Local Messages',
+          auth: { method: 'none' },
+          runtimes: {
+            pi: piRuntime({
+              wireProtocol: 'anthropic-messages',
+              models: [{ id: 'claude-local', name: 'Claude Local' }],
+            }),
+          },
+        },
+      ],
+      () => null,
+    );
+
+    expect(providers[0]?.api).toBe('openai-responses');
+    expect(providers[0]?.models[0]).toMatchObject({ id: 'local-model' });
+    expect(providers[0]?.models[0]).not.toHaveProperty('compat');
+    expect(providers[1]?.api).toBe('anthropic-messages');
+    expect(providers[1]?.models[0]).toMatchObject({ id: 'claude-local' });
+    expect(providers[1]?.models[0]).not.toHaveProperty('compat');
+  });
+
+  it('keeps bundled compat authoritative and still pins undeclared chat models', () => {
+    const bundled = new Map([
+      [
+        'volc',
+        new Map([
+          [
+            'declared',
+            piBundledModel('declared', 'openai-completions', {
+              baseUrl: 'https://ark.cn-beijing.volces.com/api/v3',
+              compat: { supportsDeveloperRole: true },
+            }),
+          ],
+          [
+            'undeclared',
+            piBundledModel('undeclared', 'openai-completions', {
+              baseUrl: 'https://ark.cn-beijing.volces.com/api/v3',
+              compat: { supportsStrictTools: true },
+            }),
+          ],
+        ]),
+      ],
+    ]);
+    const { providers } = buildPiNativeProvidersFromConfigs(
+      [
+        {
+          id: 'volc',
+          name: 'Volcano Engine',
+          auth: { method: 'apiKey' },
+          runtimes: {
+            pi: piRuntime({
+              baseUrl: 'https://ark.cn-beijing.volces.com/api/v3',
+              wireProtocol: undefined,
+              models: [
+                { id: 'declared', name: 'Declared' },
+                { id: 'undeclared', name: 'Undeclared' },
+              ],
+            }),
+          },
+        },
+      ],
+      () => 'custom-key',
+      undefined,
+      bundled,
+    );
+
+    expect(providers[0]?.models[0]?.compat).toEqual({ supportsDeveloperRole: true });
+    expect(providers[0]?.models[1]?.compat).toEqual({
+      supportsStrictTools: true,
+      supportsDeveloperRole: false,
+    });
+  });
+
   it('keeps a legacy custom xai endpoint separate from the official SuperGrok provider', () => {
     const { providers, env } = buildPiNativeProvidersFromConfigs(
       [
@@ -281,6 +395,7 @@ describe('buildPiNativeProvidersFromConfigs', () => {
       id: 'models-url-only',
       name: 'Models URL Only',
       contextWindow: 64_000,
+      compat: { supportsDeveloperRole: false },
     });
   });
 
@@ -369,6 +484,7 @@ describe('buildPiNativeProvidersFromConfigs', () => {
       name: 'My DeepSeek Flash',
       contextWindow: 64_000,
       input: ['text', 'image'],
+      compat: { supportsDeveloperRole: false },
       reasoning: true,
       thinkingLevelMap: {
         minimal: null,
@@ -1860,8 +1976,19 @@ describe('buildPiNativeProvidersFromConfigs', () => {
       () => null,
     );
     expect(providers[0].models).toEqual([
-      { id: 'vision', name: 'Vision', contextWindow: undefined, input: ['text', 'image'] },
-      { id: 'legacy', name: 'Legacy', contextWindow: undefined },
+      {
+        id: 'vision',
+        name: 'Vision',
+        contextWindow: undefined,
+        input: ['text', 'image'],
+        compat: { supportsDeveloperRole: false },
+      },
+      {
+        id: 'legacy',
+        name: 'Legacy',
+        contextWindow: undefined,
+        compat: { supportsDeveloperRole: false },
+      },
     ]);
   });
 
@@ -2050,6 +2177,7 @@ describe('buildPiNativeProvidersFromConfigs', () => {
       name,
       contextWindow: undefined,
       ...(visual ? { input: ['text', 'image'] } : {}),
+      compat: { supportsDeveloperRole: false },
       reasoning: true,
       thinkingLevelMap: {
         minimal: null,

--- a/apps/desktop/src/main/maker-host/pi-host.ts
+++ b/apps/desktop/src/main/maker-host/pi-host.ts
@@ -503,6 +503,26 @@ function catalogCostForPiNative(cost: {
 }
 
 /**
+ * 自定义 openai-completions 端点（火山引擎、vLLM 等）普遍只接受
+ * system/assistant/user/tool 四种 role；Pi 运行时对未识别端点默认
+ * supportsDeveloperRole=true，会把 system 消息改写成 role:"developer" 并被上游
+ * 整单拒绝。bundled/官方目录显式声明的兼容位保持权威，其余自定义 Chat 模型
+ * 保守回落 supportsDeveloperRole:false（system 在所有兼容端点都可接受）。
+ */
+function piNativeModelCompat(
+  modelApi: PiNativeApi,
+  bundledCompat: Record<string, unknown> | undefined,
+): Record<string, unknown> | undefined {
+  if (bundledCompat && 'supportsDeveloperRole' in bundledCompat) {
+    return structuredClone(bundledCompat);
+  }
+  if (modelApi !== 'openai-completions') {
+    return bundledCompat ? structuredClone(bundledCompat) : undefined;
+  }
+  return { ...(bundledCompat ? structuredClone(bundledCompat) : {}), supportsDeveloperRole: false };
+}
+
+/**
  * Overlay Cindy's host-managed subscription endpoints onto PI's bundled
  * provider catalog. Registry metadata is authoritative for OpenAI subscription
  * models; the version-matched PI binary remains authoritative for native API and
@@ -1312,6 +1332,7 @@ export function buildPiNativeProvidersFromConfigs(
             : bundledModel?.api === modelApi
               ? bundledModel.baseUrl
               : undefined;
+        const modelCompat = piNativeModelCompat(modelApi, bundledModel?.compat);
         const spec = {
           id: m.id,
           ...(m.piApi || modelApi !== providerApi ? { api: modelApi } : {}),
@@ -1344,7 +1365,7 @@ export function buildPiNativeProvidersFromConfigs(
               : {}),
           ...(bundledModel?.cost ? { cost: { ...bundledModel.cost } } : {}),
           ...(bundledModel?.headers ? { headers: { ...bundledModel.headers } } : {}),
-          ...(bundledModel?.compat ? { compat: structuredClone(bundledModel.compat) } : {}),
+          ...(modelCompat ? { compat: modelCompat } : {}),
           ...(bundledModel?.samplingParams
             ? { samplingParams: structuredClone(bundledModel.samplingParams) }
             : {}),


### PR DESCRIPTION
## 这次改了什么

### 摘要

自定义 openai-completions 端点（火山引擎、vLLM 等）普遍只接受 `system/assistant/user/tool` 四种 role。Pi 运行时对未识别端点默认 `supportsDeveloperRole=true`，会把 system 消息改写成 `role:"developer"` 并被上游整单拒绝（InvalidParameter），导致该模型完全不可用。

本 PR 在 `buildPiNativeProvidersFromConfigs()` 装配层为自定义 Chat 模型保守回落 `compat.supportsDeveloperRole: false`（system 在所有 OpenAI 兼容端点都可接受）。bundled/官方目录**显式声明**的兼容位保持权威，不覆盖 `openai-responses`、`anthropic-messages` 等其他协议。与 upstream 新增的 Qwen3.8 overlay 组合方向一致（同样回落 false），无冲突。

Fixes #3832, fixes #3830。

### 变更类型

- [x] `fix` 缺陷修复

### 范围

- 关联 Issue / 需求：#3830（用户报告）、#3832（根因定位与维护者核对意见）
- 本 PR 包含：`apps/desktop/src/main/maker-host/pi-host.ts` 的 compat 回落逻辑；`piNativeProviders.test.ts` 回归测试（注入/非 Chat 不受影响/bundled 权威三分支）+ 既有严格断言更新
- 明确不包含：Pi 上游 `detectCompat()` 默认值修改（上游侧另议）；用户可编辑的 developer-role 开关（产品决策，后续再议）
- 用户可见变化：自定义 Chat Completions 端点的 Pi 会话从「必报 InvalidParameter」恢复可用；system 提示词以 `role:"system"` 发送
- 是否存在 breaking change：无

### UI 变化

- 不涉及

## 怎么验证的

### 自动验证

```text
pnpm --filter desktop exec vitest related --run ...（官方 exclude 参数）
  apps/desktop：Test Files 145 passed (145)，Tests 3545 passed | 2 skipped
pnpm --filter desktop run typecheck
  结果：通过
pnpm check:dco（提交时）
  结果：DCO check passed
```

### 手工验证

不涉及（无真实火山引擎凭证；协议行为由单测夹具覆盖）

### 未执行的验证

- 全量 `pnpm test:unit` 在本机因两处与本 PR 无关的环境噪声未全绿，逐项核实如下：
  - `packages/maker-core` 的 `pi-agent.integration.test.ts > xAI Responses API`：在**未含本 PR 的 upstream/main（0db1c11eb）detached checkout 上同样失败**，为存量失败；
  - desktop renderer `agentIslandSettings` 等用例：本机 node 环境无 localStorage（`--localstorage-file` 未配置）导致的收集/串扰噪声，与 main-process 改动无关。

## 风险

### 风险分类

- [x] 无已知风险

（触及 Pi BYOM 装配路径：改动仅影响「无显式声明 compat 的自定义 openai-completions 模型」，此前该路径对火山类端点本就 100% 失败；对已可用端点仅把 developer role 换成普遍兼容的 system role。）

### 影响与回滚

- 影响范围：Pi BYOM 自定义 Chat 模型的 models.json compat 字段
- 回滚 / 降级方式：revert 本 PR 即可，无数据/配置迁移

### 提交前检查

- [x] 已 review 完整 diff
- [x] 每个 commit 都带 DCO 签名（`git commit -s`，见 [DCO](../DCO)）
- [x] UI 改动已在「UI 变化」注明引用的设计规范章节（不涉及 UI 则跳过）
- [x] 未提交凭证、令牌或授权文件
- [x] 已补充必要文档
- [x] 已确认测试结果或说明未执行原因