### PR TITLE
test(desktop): 补齐 localDb 夹具缺失的 sessions.writable_dirs 列

### DIFF
--- a/apps/desktop/src/main/localDb/__tests__/orcaTeamStore.test.ts
+++ b/apps/desktop/src/main/localDb/__tests__/orcaTeamStore.test.ts
@@ -412,6 +412,7 @@ describe('orcaTeamStore', () => {
         codex_history_has_product_prompt INTEGER,
         codex_plan_json TEXT,
         extra_dirs TEXT NOT NULL DEFAULT '[]',
+        writable_dirs TEXT NOT NULL DEFAULT '[]',
         remote_host_id TEXT,
         provider_id TEXT,
         active_turn_started_at INTEGER,

--- a/apps/desktop/src/main/localDb/ipc/__tests__/sessionAutoTitlePersist.test.ts
+++ b/apps/desktop/src/main/localDb/ipc/__tests__/sessionAutoTitlePersist.test.ts
@@ -86,6 +86,7 @@ function createDb(initialTitle: string): void {
       feishu_bot_app_id TEXT,
       used_project_context INTEGER NOT NULL DEFAULT 0,
       extra_dirs TEXT NOT NULL DEFAULT '[]',
+      writable_dirs TEXT NOT NULL DEFAULT '[]',
       one_m INTEGER NOT NULL DEFAULT 0,
       workspace_kind TEXT NOT NULL DEFAULT 'project',
       orca_role TEXT,

--- a/apps/desktop/src/main/localDb/ipc/__tests__/sessionsRestoreIfArchived.test.ts
+++ b/apps/desktop/src/main/localDb/ipc/__tests__/sessionsRestoreIfArchived.test.ts
@@ -103,6 +103,7 @@ function createDb(): void {
       feishu_bot_app_id TEXT,
       used_project_context INTEGER NOT NULL DEFAULT 0,
       extra_dirs TEXT NOT NULL DEFAULT '[]',
+      writable_dirs TEXT NOT NULL DEFAULT '[]',
       one_m INTEGER NOT NULL DEFAULT 0,
       workspace_kind TEXT NOT NULL DEFAULT 'project',
       orca_role TEXT,


### PR DESCRIPTION
## 这次改了什么

### 摘要

#3587 给 `sessions` schema 新增 `writable_dirs` 列后，drizzle 的全列查询使三个手工 `CREATE TABLE` 的测试夹具（`orcaTeamStore` / `sessionAutoTitlePersist` / `sessionsRestoreIfArchived`）持续报 `no such column: sessions.writable_dirs`，`pnpm test:unit:related` 门禁因此常红。本 PR 按兄弟夹具 `sessionsUpdate.test.ts` 已有写法为三处补上 `writable_dirs TEXT NOT NULL DEFAULT '[]'`，每处一行，共 3 行。

纯测试夹具维护，无生产代码改动。从 PR #3829 拆出（review 意见：与侧栏 UI 决策正交，独立放行）。

### 变更类型

- [ ] `feat` 新功能
- [ ] `fix` 缺陷修复
- [ ] `refactor` / `perf` 重构或性能优化
- [ ] `docs` / `test` / `chore` 文档、测试或工程维护
- [x] 其他：测试夹具修复（test）

### 范围

- 关联 Issue / 需求：#3587（schema 变更来源）、#3833（拆分要求出处）
- 本 PR 包含：上述 3 个测试文件的夹具补列
- 明确不包含：任何生产代码、schema、migration 改动
- 用户可见变化：无
- 是否存在 breaking change：无

### UI 变化

不涉及：纯测试夹具改动，无 UI 代码路径变更。

## 怎么验证的

### 自动验证

```text
pnpm exec vitest run src/main/localDb/__tests__/orcaTeamStore.test.ts src/main/localDb/ipc/__tests__/sessionAutoTitlePersist.test.ts src/main/localDb/ipc/__tests__/sessionsRestoreIfArchived.test.ts
结果：35 passed（修复前 21 failed）

pnpm test:unit:related
结果：desktop related 218 文件 / 5454 用例全 PASS（在含本修复的工作区验证）
```

### 手工验证

不涉及。

### 未执行的验证

无。

## 风险

### 风险分类

- [x] 无已知风险
- [ ] SQLite / migration
- [ ] system prompt
- [ ] 协议兼容
- [ ] 权限 / 安全 / 用户数据
- [ ] 存量插件兼容（批准状态 / 指纹 / manifest 校验 / 安装布局 / 包格式）
- [ ] 原生层 / fingerprint / OTA
- [ ] 跨平台差异
- [ ] 其他：

### 影响与回滚

- 影响范围：仅本地测试门禁，无运行时影响。
- 回滚 / 降级方式：revert 即可。

### 提交前检查

- [x] 已 review 完整 diff
- [x] 每个 commit 都带 DCO 签名（`git commit -s`，见 [DCO](../DCO)）
- [x] UI 改动已在「UI 变化」注明引用的设计规范章节（不涉及 UI）
- [x] 未提交凭证、令牌或授权文件
- [x] 已补充必要文档（无新增文档需求）
- [x] 已确认测试结果或说明未执行原因
