### PR TITLE
fix(legal): 重新生成第三方声明并修复生成器登记缺口(追平 Claude Code 2.1.259)

### DIFF
--- a/apps/desktop/resources/THIRD-PARTY-NOTICES.txt
+++ b/apps/desktop/resources/THIRD-PARTY-NOTICES.txt
@@ -3696,7 +3696,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
 ------------------------------------------------------------------------------
-pi coding agent (runtime-downloaded binary) 0.83.0
+pi coding agent (runtime-downloaded binary) 0.84.4
 License: MIT
 Source: https://github.com/earendil-works/pi
 ------------------------------------------------------------------------------
@@ -4023,12 +4023,16 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
 ==============================================================================
-SECTION 2: npm packages (813 packages)
+SECTION 2: npm packages (884 packages)
 ==============================================================================
 
 - @antfu/install-pkg@1.1.0 — MIT — https://github.com/antfu/install-pkg
 - @anthropic-ai/sdk@0.91.1 — MIT — https://github.com/anthropics/anthropic-sdk-typescript
+- @babel/helper-string-parser@7.29.7 — MIT — https://github.com/babel/babel
+- @babel/helper-validator-identifier@7.29.7 — MIT — https://github.com/babel/babel
+- @babel/parser@7.29.7 — MIT — https://github.com/babel/babel
 - @babel/runtime@7.29.7 — MIT — https://github.com/babel/babel
+- @babel/types@7.29.7 — MIT — https://github.com/babel/babel
 - @braintree/sanitize-url@7.1.2 — MIT — https://github.com/braintree/sanitize-url
 - @chevrotain/types@11.1.2 — Apache-2.0 — https://github.com/Chevrotain/chevrotain
 - @chinese-fonts/font-contours@1.0.0 — ISC
@@ -4061,6 +4065,8 @@ SECTION 2: npm packages (813 packages)
 - @discordjs/rest@2.6.2 — Apache-2.0 — https://github.com/discordjs/discord.js
 - @discordjs/util@1.2.0 — Apache-2.0 — https://github.com/discordjs/discord.js
 - @discordjs/ws@1.2.3 — Apache-2.0 — https://github.com/discordjs/discord.js
+- @fast-csv/format@4.3.5 — MIT — https://github.com/C2FO/fast-csv
+- @fast-csv/parse@4.3.6 — MIT — https://github.com/C2FO/fast-csv
 - @floating-ui/core@1.8.0 — MIT — https://github.com/floating-ui/floating-ui
 - @floating-ui/dom@1.8.0 — MIT — https://github.com/floating-ui/floating-ui
 - @floating-ui/react-dom@2.1.9 — MIT — https://github.com/floating-ui/floating-ui
@@ -4242,6 +4248,8 @@ SECTION 2: npm packages (813 packages)
 - @types/katex@0.16.8 — MIT — https://github.com/DefinitelyTyped/DefinitelyTyped
 - @types/mdast@4.0.4 — MIT — https://github.com/DefinitelyTyped/DefinitelyTyped
 - @types/ms@2.1.0 — MIT — https://github.com/DefinitelyTyped/DefinitelyTyped
+- @types/node@14.18.63 — MIT — https://github.com/DefinitelyTyped/DefinitelyTyped
+- @types/node@22.20.1 — MIT — https://github.com/DefinitelyTyped/DefinitelyTyped
 - @types/node@25.9.5 — MIT — https://github.com/DefinitelyTyped/DefinitelyTyped
 - @types/trusted-types@2.0.7 — MIT — https://github.com/DefinitelyTyped/DefinitelyTyped
 - @types/unist@2.0.11 — MIT — https://github.com/DefinitelyTyped/DefinitelyTyped
@@ -4267,10 +4275,14 @@ SECTION 2: npm packages (813 packages)
 - ansi-regex@6.2.2 — MIT — https://github.com/chalk/ansi-regex
 - ansi-styles@4.3.0 — MIT — https://github.com/chalk/ansi-styles
 - ansi-styles@6.2.3 — MIT — https://github.com/chalk/ansi-styles
+- archiver@5.3.2 — MIT — https://github.com/archiverjs/node-archiver
+- archiver-utils@2.1.0 — MIT — https://github.com/archiverjs/archiver-utils
+- archiver-utils@3.0.4 — MIT — https://github.com/archiverjs/archiver-utils
 - argparse@1.0.10 — MIT — https://github.com/nodeca/argparse
 - argparse@2.0.1 — Python-2.0 — https://github.com/nodeca/argparse
 - aria-hidden@1.2.6 — MIT — https://github.com/theKashey/aria-hidden
 - asn1@0.2.6 — MIT — https://github.com/joyent/node-asn1
+- async@3.2.6 — MIT — https://github.com/caolan/async
 - asynckit@0.4.0 — MIT — https://github.com/alexindigo/asynckit
 - atomically@1.7.0 — MIT — https://github.com/fabiospampinato/atomically
 - axios@1.18.1 — MIT — https://github.com/axios/axios
@@ -4279,13 +4291,20 @@ SECTION 2: npm packages (813 packages)
 - base64-js@1.5.1 — MIT — https://github.com/beatgammit/base64-js
 - bcrypt-pbkdf@1.0.2 — BSD-3-Clause — https://github.com/joyent/node-bcrypt-pbkdf
 - better-sqlite3@12.11.1 — MIT — https://github.com/WiseLibs/better-sqlite3
+- big-integer@1.6.52 — Unlicense — https://github.com/peterolson/BigInteger.js
 - bignumber.js@9.3.1 — MIT — https://github.com/MikeMcl/bignumber.js
+- binary@0.3.0 — MIT — http://github.com/substack/node-binary
 - bindings@1.5.0 — MIT — https://github.com/TooTallNate/node-bindings
 - bl@4.1.0 — MIT — https://github.com/rvagg/bl
+- bluebird@3.4.7 — MIT — https://github.com/petkaantonov/bluebird
 - body-parser@2.3.0 — MIT — https://github.com/expressjs/body-parser
+- brace-expansion@1.1.16 — MIT — https://github.com/juliangruber/brace-expansion
 - brace-expansion@2.1.2 — MIT — https://github.com/juliangruber/brace-expansion
 - buffer@5.7.1 — MIT — https://github.com/feross/buffer
+- buffer-crc32@0.2.13 — MIT — https://github.com/brianloveswords/buffer-crc32
 - buffer-equal-constant-time@1.0.1 — BSD-3-Clause — https://github.com/goinstant/buffer-equal-constant-time
+- buffer-indexof-polyfill@1.0.2 — MIT — https://github.com/sarosia/buffer-indexof-polyfill
+- buffers@0.1.1 — MIT — http://github.com/substack/node-buffers
 - buildcheck@0.0.7 — MIT — http://github.com/mscdex/buildcheck
 - byte-size@8.2.1 — MIT — https://github.com/75lb/byte-size
 - bytes@3.1.2 — MIT — https://github.com/visionmedia/bytes.js
@@ -4293,6 +4312,7 @@ SECTION 2: npm packages (813 packages)
 - call-bound@1.0.4 — MIT — https://github.com/ljharb/call-bound
 - camelcase@5.3.1 — MIT — https://github.com/sindresorhus/camelcase
 - ccount@2.0.1 — MIT — https://github.com/wooorm/ccount
+- chainsaw@0.1.0 — MIT — http://github.com/substack/node-chainsaw
 - character-entities@2.0.2 — MIT — https://github.com/wooorm/character-entities
 - character-entities-html4@2.1.0 — MIT — https://github.com/wooorm/character-entities-html4
 - character-entities-legacy@3.0.0 — MIT — https://github.com/wooorm/character-entities-legacy
@@ -4309,6 +4329,8 @@ SECTION 2: npm packages (813 packages)
 - comma-separated-tokens@2.0.3 — MIT — https://github.com/wooorm/comma-separated-tokens
 - commander@7.2.0 — MIT — https://github.com/tj/commander.js
 - commander@8.3.0 — MIT — https://github.com/tj/commander.js
+- compress-commons@4.1.2 — MIT — https://github.com/archiverjs/node-compress-commons
+- concat-map@0.0.1 — MIT — https://github.com/substack/node-concat-map
 - conf@9.0.2 — MIT — https://github.com/sindresorhus/conf
 - content-disposition@1.1.0 — MIT — https://github.com/jshttp/content-disposition
 - content-type@1.0.5 — MIT — https://github.com/jshttp/content-type
@@ -4321,6 +4343,8 @@ SECTION 2: npm packages (813 packages)
 - cose-base@1.0.3 — MIT — https://github.com/iVis-at-Bilkent/cose-base
 - cose-base@2.2.0 — MIT — https://github.com/iVis-at-Bilkent/cose-base
 - cpu-features@0.0.10 — MIT — https://github.com/mscdex/cpu-features
+- crc-32@1.2.2 — Apache-2.0 — https://github.com/SheetJS/js-crc32
+- crc32-stream@4.0.3 — MIT — https://github.com/archiverjs/node-crc32-stream
 - crelt@1.0.7 — MIT — https://code.haverbeke.berlin/marijn/crelt
 - cross-spawn@7.0.6 — MIT — https://github.com/moxystudio/node-cross-spawn
 - crypt@0.0.2 — BSD-3-Clause — https://github.com/pvorb/node-crypt
@@ -4385,10 +4409,12 @@ SECTION 2: npm packages (813 packages)
 - dingtalk-stream@v2.1.5 — MIT — https://github.com/open-dingtalk/dingtalk-stream-sdk-nodejs
 - discord-api-types@0.38.50 — MIT — https://github.com/discordjs/discord-api-types
 - discord.js@14.27.0 — Apache-2.0 — https://github.com/discordjs/discord.js
+- docx@9.7.1 — MIT — https://github.com/dolanmiu/docx
 - dompurify@3.4.12 — (MPL-2.0 OR Apache-2.0) — https://github.com/cure53/DOMPurify
 - dot-prop@6.0.1 — MIT — https://github.com/sindresorhus/dot-prop
 - drizzle-orm@0.45.2 — Apache-2.0 — https://github.com/drizzle-team/drizzle-orm
 - dunder-proto@1.0.1 — MIT — https://github.com/es-shims/dunder-proto
+- duplexer2@0.1.4 — BSD-3-Clause — https://github.com/deoxxa/duplexer2
 - eastasianwidth@0.2.0 — MIT — https://github.com/komagata/eastasianwidth
 - ecdsa-sig-formatter@1.0.11 — Apache-2.0 — https://github.com/Brightspace/node-ecdsa-sig-formatter
 - ee-first@1.1.1 — MIT — https://github.com/jonathanong/ee-first
@@ -4414,6 +4440,7 @@ SECTION 2: npm packages (813 packages)
 - eventemitter3@5.0.4 — MIT — https://github.com/primus/eventemitter3
 - eventsource@3.0.7 — MIT — https://git@github.com/EventSource/eventsource
 - eventsource-parser@3.1.0 — MIT — https://github.com/rexxars/eventsource-parser
+- exceljs@4.4.0 — MIT — https://github.com/exceljs/exceljs
 - execa@4.1.0 — MIT — https://github.com/sindresorhus/execa
 - execa@5.1.1 — MIT — https://github.com/sindresorhus/execa
 - expand-template@2.0.3 — (MIT OR WTFPL) — https://github.com/ralphtheninja/expand-template
@@ -4421,6 +4448,7 @@ SECTION 2: npm packages (813 packages)
 - express-rate-limit@8.5.2 — MIT — https://github.com/express-rate-limit/express-rate-limit
 - extend@3.0.2 — MIT — https://github.com/justmoon/node-extend
 - extend-shallow@2.0.1 — MIT — https://github.com/jonschlinkert/extend-shallow
+- fast-csv@4.3.6 — MIT — https://github.com/C2FO/fast-csv
 - fast-deep-equal@3.1.3 — MIT — https://github.com/epoberezkin/fast-deep-equal
 - fast-equals@5.4.1 — MIT — https://github.com/planttheidea/fast-equals
 - fast-uri@3.1.4 — BSD-3-Clause — https://github.com/fastify/fast-uri
@@ -4438,6 +4466,8 @@ SECTION 2: npm packages (813 packages)
 - fresh@2.0.0 — MIT — https://github.com/jshttp/fresh
 - fs-constants@1.0.0 — MIT — https://github.com/mafintosh/fs-constants
 - fs-extra@11.3.6 — MIT — https://github.com/jprichardson/node-fs-extra
+- fs.realpath@1.0.0 — ISC — https://github.com/isaacs/fs.realpath
+- fstream@1.0.12 — ISC — https://github.com/npm/fstream
 - function-bind@1.1.2 — MIT — https://github.com/Raynos/function-bind
 - gaxios@7.1.3 — Apache-2.0 — https://github.com/googleapis/google-cloud-node-core
 - gaxios@7.2.0 — Apache-2.0 — https://github.com/googleapis/google-cloud-node
@@ -4453,6 +4483,7 @@ SECTION 2: npm packages (813 packages)
 - github-from-package@0.0.0 — MIT — https://github.com/substack/github-from-package
 - github-slugger@2.0.0 — ISC — https://github.com/Flet/github-slugger
 - glob@10.5.0 — ISC — https://github.com/isaacs/node-glob
+- glob@7.2.3 — ISC — https://github.com/isaacs/node-glob
 - google-auth-library@10.5.0 — Apache-2.0 — https://github.com/googleapis/google-auth-library-nodejs
 - google-auth-library@10.9.0 — Apache-2.0 — https://github.com/googleapis/google-cloud-node
 - google-logging-utils@1.1.3 — Apache-2.0 — https://github.com/googleapis/google-cloud-node-core
@@ -4465,6 +4496,7 @@ SECTION 2: npm packages (813 packages)
 - harmonyos-sans-sc-webfont-splitted@1.1.0 — Unlicense — https://github.com/SunsetMkt/HarmonyOS_Sans_SC_Webfont_Splitted
 - has-symbols@1.1.0 — MIT — https://github.com/inspect-js/has-symbols
 - has-tostringtag@1.0.2 — MIT — https://github.com/inspect-js/has-tostringtag
+- hash.js@1.1.7 — MIT — https://github.com/indutny/hash.js
 - hasown@2.0.4 — MIT — https://github.com/inspect-js/hasOwn
 - hast-util-from-dom@5.0.1 — ISC — https://github.com/syntax-tree/hast-util-from-dom
 - hast-util-from-html@2.0.3 — MIT — https://github.com/syntax-tree/hast-util-from-html
@@ -4484,6 +4516,7 @@ SECTION 2: npm packages (813 packages)
 - html-to-image@1.11.13 — MIT — https://github.com/bubkoo/html-to-image
 - html-url-attributes@3.0.1 — MIT — https://github.com/rehypejs/rehype-minify/tree/main/packages/html-url-attributes
 - http-errors@2.0.1 — MIT — https://github.com/jshttp/http-errors
+- https@1.0.0 — ISC
 - https-proxy-agent@5.0.1 — MIT — https://github.com/TooTallNate/node-https-proxy-agent
 - https-proxy-agent@7.0.6 — MIT — https://github.com/TooTallNate/proxy-agents
 - human-signals@1.1.1 — Apache-2.0 — https://github.com/ehmicky/human-signals
@@ -4493,8 +4526,10 @@ SECTION 2: npm packages (813 packages)
 - iconv-lite@0.7.3 — MIT — https://github.com/pillarjs/iconv-lite
 - ieee754@1.2.1 — BSD-3-Clause — https://github.com/feross/ieee754
 - ignore@7.0.6 — MIT — https://github.com/kaelzhang/node-ignore
+- image-size@1.2.1 — MIT — https://github.com/image-size/image-size
 - immediate@3.0.6 — MIT — https://github.com/calvinmetcalf/immediate
 - import-meta-resolve@4.2.0 — MIT — https://github.com/wooorm/import-meta-resolve
+- inflight@1.0.6 — ISC — https://github.com/npm/inflight
 - inherits@2.0.4 — ISC — https://github.com/isaacs/inherits
 - ini@1.3.8 — ISC — https://github.com/isaacs/ini
 - inline-style-parser@0.2.7 — MIT — https://github.com/remarkablemark/inline-style-parser
@@ -4540,8 +4575,10 @@ SECTION 2: npm packages (813 packages)
 - kind-of@6.0.3 — MIT — https://github.com/jonschlinkert/kind-of
 - layout-base@1.0.2 — MIT — https://github.com/iVis-at-Bilkent/layout-base
 - layout-base@2.0.1 — MIT — https://github.com/iVis-at-Bilkent/layout-base
+- lazystream@1.0.1 — MIT — https://github.com/jpommerening/node-lazystream
 - lcid@3.1.1 — MIT — https://github.com/sindresorhus/lcid
 - lie@3.3.0 — MIT — https://github.com/calvinmetcalf/lie
+- listenercount@1.0.1 — ISC — https://github.com/jden/node-listenercount
 - lit@3.3.3 — BSD-3-Clause — https://github.com/lit/lit
 - lit-element@4.2.2 — BSD-3-Clause — https://github.com/lit/lit
 - lit-html@3.3.3 — BSD-3-Clause — https://github.com/lit/lit
@@ -4549,10 +4586,23 @@ SECTION 2: npm packages (813 packages)
 - locate-path@5.0.0 — MIT — https://github.com/sindresorhus/locate-path
 - lodash@4.18.1 — MIT — https://github.com/lodash/lodash
 - lodash-es@4.18.1 — MIT — https://github.com/lodash/lodash
+- lodash.defaults@4.2.0 — MIT — https://github.com/lodash/lodash
+- lodash.difference@4.5.0 — MIT — https://github.com/lodash/lodash
+- lodash.escaperegexp@4.1.2 — MIT — https://github.com/lodash/lodash
+- lodash.flatten@4.4.0 — MIT — https://github.com/lodash/lodash
+- lodash.groupby@4.6.0 — MIT — https://github.com/lodash/lodash
 - lodash.identity@3.0.0 — MIT — https://github.com/lodash/lodash
+- lodash.isboolean@3.0.3 — MIT — https://github.com/lodash/lodash
+- lodash.isequal@4.5.0 — MIT — https://github.com/lodash/lodash
+- lodash.isfunction@3.0.9 — MIT — https://github.com/lodash/lodash
+- lodash.isnil@4.0.0 — MIT — https://github.com/lodash/lodash
+- lodash.isplainobject@4.0.6 — MIT — https://github.com/lodash/lodash
+- lodash.isundefined@3.0.1 — MIT — https://github.com/lodash/lodash
 - lodash.merge@4.6.2 — MIT — https://github.com/lodash/lodash
 - lodash.pickby@4.6.0 — MIT — https://github.com/lodash/lodash
 - lodash.snakecase@4.1.1 — MIT — https://github.com/lodash/lodash
+- lodash.union@4.6.0 — MIT — https://github.com/lodash/lodash
+- lodash.uniq@4.5.0 — MIT — https://github.com/lodash/lodash
 - long@5.3.2 — Apache-2.0 — https://github.com/dcodeIO/long.js
 - longest-streak@3.1.0 — MIT — https://github.com/wooorm/longest-streak
 - loudness@0.4.2 — MIT — https://github.com/LinusU/node-loudness
@@ -4624,6 +4674,9 @@ SECTION 2: npm packages (813 packages)
 - mimic-fn@2.1.0 — MIT — https://github.com/sindresorhus/mimic-fn
 - mimic-fn@3.1.0 — MIT — https://github.com/sindresorhus/mimic-fn
 - mimic-response@3.1.0 — MIT — https://github.com/sindresorhus/mimic-response
+- minimalistic-assert@1.0.1 — ISC — https://github.com/calvinmetcalf/minimalistic-assert
+- minimatch@3.1.5 — ISC — https://github.com/isaacs/minimatch
+- minimatch@5.1.9 — ISC — https://github.com/isaacs/minimatch
 - minimatch@9.0.9 — ISC — https://github.com/isaacs/minimatch
 - minimist@1.2.8 — MIT — https://github.com/minimistjs/minimist
 - minipass@7.1.3 — BlueOak-1.0.0 — https://github.com/isaacs/minipass
@@ -4634,6 +4687,7 @@ SECTION 2: npm packages (813 packages)
 - ms@2.0.0 — MIT — https://github.com/zeit/ms
 - ms@2.1.3 — MIT — https://github.com/vercel/ms
 - nan@2.28.0 — MIT — https://github.com/nodejs/nan
+- nanoid@5.1.16 — MIT — https://github.com/ai/nanoid
 - napi-build-utils@2.0.0 — MIT — https://github.com/inspiredware/napi-build-utils
 - negotiator@1.0.0 — MIT — https://github.com/jshttp/negotiator
 - node-abi@3.94.0 — MIT — https://github.com/electron/node-abi
@@ -4642,6 +4696,7 @@ SECTION 2: npm packages (813 packages)
 - node-fetch@3.3.2 — MIT — https://github.com/node-fetch/node-fetch
 - node-machine-id@1.1.12 — MIT — https://github.com/automation-stack/node-machine-id
 - node-pty@1.1.0 — MIT — https://github.com/microsoft/node-pty
+- normalize-path@3.0.0 — MIT — https://github.com/jonschlinkert/normalize-path
 - npm-run-path@4.0.1 — MIT — https://github.com/sindresorhus/npm-run-path
 - object-assign@4.1.1 — MIT — https://github.com/sindresorhus/object-assign
 - object-inspect@1.13.4 — MIT — https://github.com/inspect-js/object-inspect
@@ -4663,6 +4718,7 @@ SECTION 2: npm packages (813 packages)
 - path-data-parser@0.1.0 — MIT — https://github.com/pshihn/path-data-parser
 - path-exists@3.0.0 — MIT — https://github.com/sindresorhus/path-exists
 - path-exists@4.0.0 — MIT — https://github.com/sindresorhus/path-exists
+- path-is-absolute@1.0.1 — MIT — https://github.com/sindresorhus/path-is-absolute
 - path-key@3.1.1 — MIT — https://github.com/sindresorhus/path-key
 - path-scurry@1.11.1 — BlueOak-1.0.0 — https://github.com/isaacs/path-scurry
 - path-to-regexp@8.4.2 — MIT — https://github.com/pillarjs/path-to-regexp
@@ -4674,6 +4730,7 @@ SECTION 2: npm packages (813 packages)
 - pngjs@5.0.0 — MIT — https://github.com/lukeapage/pngjs
 - points-on-curve@0.2.0 — MIT — https://github.com/pshihn/bezier-points
 - points-on-path@0.2.1 — MIT — https://github.com/pshihn/points-on-path
+- pptxgenjs@4.0.1 — MIT — https://github.com/gitbrent/PptxGenJS
 - prebuild-install@7.1.3 — MIT — https://github.com/prebuild/prebuild-install
 - process-nextick-args@2.0.1 — MIT — https://github.com/calvinmetcalf/process-nextick-args
 - promise-worker-transferable@1.0.4 — Apache-2.0 — https://github.com/terikon/promise-worker-transferable
@@ -4698,6 +4755,7 @@ SECTION 2: npm packages (813 packages)
 - punycode@2.3.1 — MIT — https://github.com/mathiasbynens/punycode.js
 - qrcode@1.5.4 — MIT — https://github.com/soldair/node-qrcode
 - qs@6.15.3 — BSD-3-Clause — https://github.com/ljharb/qs
+- queue@6.0.2 — MIT — https://github.com/jessetane/queue
 - range-parser@1.3.0 — MIT — https://github.com/jshttp/range-parser
 - raw-body@3.0.2 — MIT — https://github.com/stream-utils/raw-body
 - rc@1.2.8 — (BSD-2-Clause OR MIT OR Apache-2.0) — https://github.com/dominictarr/rc
@@ -4712,6 +4770,7 @@ SECTION 2: npm packages (813 packages)
 - react-style-singleton@2.2.3 — MIT — https://github.com/theKashey/react-style-singleton
 - readable-stream@2.3.8 — MIT — https://github.com/nodejs/readable-stream
 - readable-stream@3.6.2 — MIT — https://github.com/nodejs/readable-stream
+- readdir-glob@1.1.3 — Apache-2.0 — https://github.com/Yqnn/node-readdir-glob
 - rehype-highlight@7.0.2 — MIT — https://github.com/rehypejs/rehype-highlight
 - rehype-katex@7.0.1 — MIT — https://github.com/remarkjs/remark-math/tree/main/packages/rehype-katex
 - rehype-slug@6.0.0 — MIT — https://github.com/rehypejs/rehype-slug
@@ -4724,6 +4783,7 @@ SECTION 2: npm packages (813 packages)
 - require-directory@2.1.1 — MIT — https://github.com/troygoode/node-require-directory
 - require-from-string@2.0.2 — MIT — https://github.com/floatdrop/require-from-string
 - require-main-filename@2.0.0 — ISC — https://github.com/yargs/require-main-filename
+- rimraf@2.6.3 — ISC — https://github.com/isaacs/rimraf
 - rimraf@5.0.10 — ISC — https://github.com/isaacs/rimraf
 - robust-predicates@3.0.3 — Unlicense — https://github.com/mourner/robust-predicates
 - rope-sequence@1.3.4 — MIT — https://github.com/marijnh/rope-sequence
@@ -4733,6 +4793,8 @@ SECTION 2: npm packages (813 packages)
 - safe-buffer@5.1.2 — MIT — https://github.com/feross/safe-buffer
 - safe-buffer@5.2.1 — MIT — https://github.com/feross/safe-buffer
 - safer-buffer@2.1.2 — MIT — https://github.com/ChALkeR/safer-buffer
+- sax@1.6.0 — BlueOak-1.0.0 — https://github.com/isaacs/sax-js
+- saxes@5.0.1 — ISC — https://github.com/lddubeau/saxes
 - scheduler@0.27.0 — MIT — https://github.com/facebook/react
 - section-matter@1.0.0 — MIT — https://github.com/jonschlinkert/section-matter
 - semver@6.3.1 — ISC — https://github.com/npm/node-semver
@@ -4783,7 +4845,9 @@ SECTION 2: npm packages (813 packages)
 - tar-fs@2.1.5 — MIT — https://github.com/mafintosh/tar-fs
 - tar-stream@2.2.0 — MIT — https://github.com/mafintosh/tar-stream
 - tinyexec@1.2.4 — MIT — https://github.com/tinylibs/tinyexec
+- tmp@0.2.7 — MIT — https://github.com/raszi/node-tmp
 - toidentifier@1.0.1 — MIT — https://github.com/component/toidentifier
+- traverse@0.3.9 — MIT — http://github.com/substack/js-traverse
 - trim-lines@3.0.1 — MIT — https://github.com/wooorm/trim-lines
 - trough@2.2.0 — MIT — https://github.com/wooorm/trough
 - ts-algebra@2.0.0 — MIT — https://github.com/ThomasAribart/ts-algebra
@@ -4798,6 +4862,7 @@ SECTION 2: npm packages (813 packages)
 - typebox@1.1.39 — MIT — https://github.com/sinclairzx81/typebox
 - undici@6.27.0 — MIT — https://github.com/nodejs/undici
 - undici@8.7.0 — MIT — https://github.com/nodejs/undici
+- undici-types@6.21.0 — MIT — https://github.com/nodejs/undici
 - undici-types@7.24.6 — MIT — https://github.com/nodejs/undici
 - unified@11.0.5 — MIT — https://github.com/unifiedjs/unified
 - unist-util-find-after@5.0.0 — MIT — https://github.com/syntax-tree/unist-util-find-after
@@ -4809,6 +4874,7 @@ SECTION 2: npm packages (813 packages)
 - unist-util-visit-parents@6.0.2 — MIT — https://github.com/syntax-tree/unist-util-visit-parents
 - universalify@2.0.1 — MIT — https://github.com/RyanZim/universalify
 - unpipe@1.0.0 — MIT — https://github.com/stream-utils/unpipe
+- unzipper@0.10.14 — MIT — https://github.com/ZJONSSON/node-unzipper
 - uri-js@4.4.1 — BSD-2-Clause — http://github.com/garycourt/uri-js
 - url-template@2.0.8 — LicenseRef-BSD-Variant — https://github.com/bramstein/url-template
 - use-callback-ref@1.3.3 — MIT — https://github.com/theKashey/use-callback-ref/
@@ -4816,6 +4882,7 @@ SECTION 2: npm packages (813 packages)
 - use-sync-external-store@1.6.0 — MIT — https://github.com/facebook/react
 - util-deprecate@1.0.2 — MIT — https://github.com/TooTallNate/util-deprecate
 - uuid@14.0.1 — MIT — https://github.com/uuidjs/uuid
+- uuid@8.3.2 — MIT — https://github.com/uuidjs/uuid
 - vary@1.1.2 — MIT — https://github.com/jshttp/vary
 - vfile@6.0.3 — MIT — https://github.com/vfile/vfile
 - vfile-location@5.0.3 — MIT — https://github.com/vfile/vfile-location
@@ -4832,10 +4899,14 @@ SECTION 2: npm packages (813 packages)
 - wrap-ansi@8.1.0 — MIT — https://github.com/chalk/wrap-ansi
 - wrappy@1.0.2 — ISC — https://github.com/npm/wrappy
 - ws@8.21.1 — MIT — https://github.com/websockets/ws
+- xml@1.0.1 — MIT — http://github.com/dylang/node-xml
+- xml-js@1.6.11 — MIT — https://github.com/nashwaan/xml-js
+- xmlchars@2.2.0 — MIT — https://github.com/lddubeau/xmlchars
 - y18n@4.0.3 — ISC — https://github.com/yargs/y18n
 - yallist@5.0.0 — BlueOak-1.0.0 — https://github.com/isaacs/yallist
 - yargs@15.4.1 — MIT — https://github.com/yargs/yargs
 - yargs-parser@18.1.3 — ISC — https://github.com/yargs/yargs-parser
+- zip-stream@4.1.1 — MIT — https://github.com/archiverjs/node-zip-stream
 - zod@4.3.6 — MIT — https://github.com/colinhacks/zod
 - zod-to-json-schema@3.25.2 — ISC — https://github.com/StefanTerdell/zod-to-json-schema
 - zwitch@2.0.4 — MIT — https://github.com/wooorm/zwitch
@@ -25718,7 +25789,7 @@ The above copyright notice and this permission notice shall be included in all c
 THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[121] Applies to: npm:@babel/runtime@7.29.7
+[121] Applies to: npm:@babel/helper-string-parser@7.29.7, npm:@babel/helper-validator-identifier@7.29.7, npm:@babel/runtime@7.29.7, npm:@babel/types@7.29.7
 ------------------------------------------------------------------------------
 MIT License
 
@@ -25744,7 +25815,30 @@ OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
 WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[122] Applies to: npm:@braintree/sanitize-url@7.1.2
+[122] Applies to: npm:@babel/parser@7.29.7
+------------------------------------------------------------------------------
+Copyright (C) 2012-2014 by various contributors (see AUTHORS)
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+
+------------------------------------------------------------------------------
+[123] Applies to: npm:@braintree/sanitize-url@7.1.2
 ------------------------------------------------------------------------------
 MIT License
 
@@ -25769,7 +25863,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
 ------------------------------------------------------------------------------
-[123] Applies to: npm:@chevrotain/types@11.1.2, npm:@google/model-viewer@4.3.1, npm:@pkgjs/parseargs@0.11.0, npm:gaxios@7.1.3, npm:gaxios@7.2.0, npm:gcp-metadata@8.1.2, npm:gcp-metadata@8.1.3, npm:google-auth-library@10.5.0, npm:google-auth-library@10.9.0, npm:google-logging-utils@1.1.3, npm:googleapis-common@8.0.2, npm:long@5.3.2
+[124] Applies to: npm:@chevrotain/types@11.1.2, npm:@google/model-viewer@4.3.1, npm:@pkgjs/parseargs@0.11.0, npm:gaxios@7.1.3, npm:gaxios@7.2.0, npm:gcp-metadata@8.1.2, npm:gcp-metadata@8.1.3, npm:google-auth-library@10.5.0, npm:google-auth-library@10.9.0, npm:google-logging-utils@1.1.3, npm:googleapis-common@8.0.2, npm:long@5.3.2
 ------------------------------------------------------------------------------
 Apache License
                            Version 2.0, January 2004
@@ -25974,7 +26068,7 @@ Apache License
    limitations under the License.
 
 ------------------------------------------------------------------------------
-[124] Applies to: npm:@codemirror/autocomplete@6.20.3, npm:@codemirror/commands@6.10.4, npm:@codemirror/lang-cpp@6.0.3, npm:@codemirror/lang-css@6.3.1, npm:@codemirror/lang-html@6.4.11, npm:@codemirror/lang-java@6.0.2, npm:@codemirror/lang-javascript@6.2.5, npm:@codemirror/lang-json@6.0.2, npm:@codemirror/lang-markdown@6.5.1, npm:@codemirror/lang-php@6.0.2, npm:@codemirror/lang-python@6.2.1, npm:@codemirror/lang-rust@6.0.2, npm:@codemirror/lang-sql@6.10.0, npm:@codemirror/lang-xml@6.1.0, npm:@codemirror/language@6.12.4, npm:@codemirror/legacy-modes@6.5.3, npm:@codemirror/lint@6.9.7, npm:@codemirror/search@6.7.1, npm:@codemirror/state@6.7.1, npm:@codemirror/view@6.43.6
+[125] Applies to: npm:@codemirror/autocomplete@6.20.3, npm:@codemirror/commands@6.10.4, npm:@codemirror/lang-cpp@6.0.3, npm:@codemirror/lang-css@6.3.1, npm:@codemirror/lang-html@6.4.11, npm:@codemirror/lang-java@6.0.2, npm:@codemirror/lang-javascript@6.2.5, npm:@codemirror/lang-json@6.0.2, npm:@codemirror/lang-markdown@6.5.1, npm:@codemirror/lang-php@6.0.2, npm:@codemirror/lang-python@6.2.1, npm:@codemirror/lang-rust@6.0.2, npm:@codemirror/lang-sql@6.10.0, npm:@codemirror/lang-xml@6.1.0, npm:@codemirror/language@6.12.4, npm:@codemirror/legacy-modes@6.5.3, npm:@codemirror/lint@6.9.7, npm:@codemirror/search@6.7.1, npm:@codemirror/state@6.7.1, npm:@codemirror/view@6.43.6
 ------------------------------------------------------------------------------
 MIT License
 
@@ -25999,7 +26093,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[125] Applies to: npm:@codemirror/lang-go@6.0.1, npm:@codemirror/lang-yaml@6.1.3
+[126] Applies to: npm:@codemirror/lang-go@6.0.1, npm:@codemirror/lang-yaml@6.1.3
 ------------------------------------------------------------------------------
 MIT License
 
@@ -26024,7 +26118,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[126] Applies to: npm:@discordjs/builders@1.14.1, npm:@discordjs/formatters@0.6.2
+[127] Applies to: npm:@discordjs/builders@1.14.1, npm:@discordjs/formatters@0.6.2
 ------------------------------------------------------------------------------
 Apache License
                            Version 2.0, January 2004
@@ -26219,7 +26313,7 @@ Apache License
    limitations under the License.
 
 ------------------------------------------------------------------------------
-[127] Applies to: npm:@discordjs/collection@1.5.3, npm:@discordjs/collection@2.1.1, npm:discord.js@14.27.0
+[128] Applies to: npm:@discordjs/collection@1.5.3, npm:@discordjs/collection@2.1.1, npm:discord.js@14.27.0
 ------------------------------------------------------------------------------
 Apache License
                            Version 2.0, January 2004
@@ -26414,7 +26508,7 @@ Apache License
    limitations under the License.
 
 ------------------------------------------------------------------------------
-[128] Applies to: npm:@discordjs/rest@2.6.2
+[129] Applies to: npm:@discordjs/rest@2.6.2
 ------------------------------------------------------------------------------
 Apache License
                            Version 2.0, January 2004
@@ -26610,7 +26704,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 
 ------------------------------------------------------------------------------
-[129] Applies to: npm:@discordjs/util@1.2.0
+[130] Applies to: npm:@discordjs/util@1.2.0
 ------------------------------------------------------------------------------
 Apache License
                            Version 2.0, January 2004
@@ -26804,7 +26898,7 @@ Apache License
    limitations under the License.
 
 ------------------------------------------------------------------------------
-[130] Applies to: npm:@discordjs/ws@1.2.3
+[131] Applies to: npm:@discordjs/ws@1.2.3
 ------------------------------------------------------------------------------
 Apache License
                            Version 2.0, January 2004
@@ -26999,7 +27093,32 @@ Apache License
    limitations under the License.
 
 ------------------------------------------------------------------------------
-[131] Applies to: npm:@floating-ui/core@1.8.0, npm:@floating-ui/dom@1.8.0, npm:@floating-ui/react-dom@2.1.9, npm:@floating-ui/utils@0.2.12
+[132] Applies to: npm:@fast-csv/format@4.3.5, npm:@fast-csv/parse@4.3.6, npm:fast-csv@4.3.6
+------------------------------------------------------------------------------
+The MIT License
+
+Copyright (c) 2011-2019 C2FO
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+
+------------------------------------------------------------------------------
+[133] Applies to: npm:@floating-ui/core@1.8.0, npm:@floating-ui/dom@1.8.0, npm:@floating-ui/react-dom@2.1.9, npm:@floating-ui/utils@0.2.12
 ------------------------------------------------------------------------------
 MIT License
 
@@ -27023,7 +27142,7 @@ IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
 CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[132] Applies to: npm:@fontsource-variable/inter@5.2.8
+[134] Applies to: npm:@fontsource-variable/inter@5.2.8
 ------------------------------------------------------------------------------
 Copyright 2016 The Inter Project Authors (https://github.com/rsms/inter) Inter-Italic[opsz,wght].ttf: Copyright 2016 The Inter Project Authors (https://github.com/rsms/inter)
 
@@ -27120,7 +27239,7 @@ FROM, OUT OF THE USE OR INABILITY TO USE THE FONT SOFTWARE OR FROM
 OTHER DEALINGS IN THE FONT SOFTWARE.
 
 ------------------------------------------------------------------------------
-[133] Applies to: npm:@fontsource-variable/jetbrains-mono@5.2.8
+[135] Applies to: npm:@fontsource-variable/jetbrains-mono@5.2.8
 ------------------------------------------------------------------------------
 Copyright 2020 The JetBrains Mono Project Authors (https://github.com/JetBrains/JetBrainsMono) JetBrainsMono-Italic[wght].ttf: Copyright 2020 The JetBrains Mono Project Authors (https://github.com/JetBrains/JetBrainsMono)
 
@@ -27217,7 +27336,7 @@ FROM, OUT OF THE USE OR INABILITY TO USE THE FONT SOFTWARE OR FROM
 OTHER DEALINGS IN THE FONT SOFTWARE.
 
 ------------------------------------------------------------------------------
-[134] Applies to: npm:@hono/node-server@1.19.14
+[136] Applies to: npm:@hono/node-server@1.19.14
 ------------------------------------------------------------------------------
 MIT License
 
@@ -27242,7 +27361,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
 ------------------------------------------------------------------------------
-[135] Applies to: npm:@iconify/types@2.0.0
+[137] Applies to: npm:@iconify/types@2.0.0
 ------------------------------------------------------------------------------
 MIT License
 
@@ -27267,7 +27386,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
 ------------------------------------------------------------------------------
-[136] Applies to: npm:@iconify/utils@3.1.4
+[138] Applies to: npm:@iconify/utils@3.1.4
 ------------------------------------------------------------------------------
 MIT License
 
@@ -27292,7 +27411,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
 ------------------------------------------------------------------------------
-[137] Applies to: npm:@img/colour@1.1.0
+[139] Applies to: npm:@img/colour@1.1.0
 ------------------------------------------------------------------------------
 # Licensing
 
@@ -27378,7 +27497,7 @@ The above copyright notice and this permission notice shall be included in all c
 THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[138] Applies to: npm:@img/sharp-darwin-arm64@0.34.5, npm:@img/sharp-darwin-arm64@0.35.3, npm:@img/sharp-darwin-x64@0.34.5, npm:@img/sharp-darwin-x64@0.35.3, npm:@img/sharp-linux-arm64@0.34.5, npm:@img/sharp-linux-arm64@0.35.3, npm:@img/sharp-linux-x64@0.34.5, npm:@img/sharp-linux-x64@0.35.3, npm:@img/sharp-win32-x64@0.34.5, npm:@img/sharp-win32-x64@0.35.3, npm:sharp@0.35.3
+[140] Applies to: npm:@img/sharp-darwin-arm64@0.34.5, npm:@img/sharp-darwin-arm64@0.35.3, npm:@img/sharp-darwin-x64@0.34.5, npm:@img/sharp-darwin-x64@0.35.3, npm:@img/sharp-linux-arm64@0.34.5, npm:@img/sharp-linux-arm64@0.35.3, npm:@img/sharp-linux-x64@0.34.5, npm:@img/sharp-linux-x64@0.35.3, npm:@img/sharp-win32-x64@0.34.5, npm:@img/sharp-win32-x64@0.35.3, npm:sharp@0.35.3
 ------------------------------------------------------------------------------
 Apache License
 Version 2.0, January 2004
@@ -27573,7 +27692,7 @@ third-party archives.
    limitations under the License.
 
 ------------------------------------------------------------------------------
-[139] Applies to: npm:@isaacs/cliui@8.0.2, npm:cliui@6.0.0
+[141] Applies to: npm:@isaacs/cliui@8.0.2, npm:cliui@6.0.0
 ------------------------------------------------------------------------------
 Copyright (c) 2015, Contributors
 
@@ -27591,7 +27710,7 @@ WHETHER IN AN ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION,
 ARISING OUT OF OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
 
 ------------------------------------------------------------------------------
-[140] Applies to: npm:@isaacs/fs-minipass@4.0.1, npm:chownr@1.1.4, npm:ini@1.3.8, npm:isexe@2.0.0, npm:once@1.4.0, npm:semver@6.3.1, npm:semver@7.8.5, npm:which@2.0.2, npm:wrappy@1.0.2
+[142] Applies to: npm:@isaacs/fs-minipass@4.0.1, npm:chownr@1.1.4, npm:fstream@1.0.12, npm:ini@1.3.8, npm:isexe@2.0.0, npm:minimatch@3.1.5, npm:once@1.4.0, npm:rimraf@2.6.3, npm:semver@6.3.1, npm:semver@7.8.5, npm:which@2.0.2, npm:wrappy@1.0.2
 ------------------------------------------------------------------------------
 The ISC License
 
@@ -27610,7 +27729,7 @@ ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF OR
 IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
 
 ------------------------------------------------------------------------------
-[141] Applies to: npm:@japont/unicode-range@1.0.0
+[143] Applies to: npm:@japont/unicode-range@1.0.0
 ------------------------------------------------------------------------------
 The MIT License (MIT)
 Copyright © 2018 3846masa
@@ -27634,7 +27753,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[142] Applies to: npm:@larksuiteoapi/node-sdk@1.71.1
+[144] Applies to: npm:@larksuiteoapi/node-sdk@1.71.1
 ------------------------------------------------------------------------------
 MIT License
 
@@ -27647,7 +27766,7 @@ The above copyright notice and this permission notice, shall be included in all 
 THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[143] Applies to: npm:@lezer/common@1.5.2, npm:@lezer/css@1.3.4, npm:@lezer/highlight@1.2.3, npm:@lezer/html@1.3.13, npm:@lezer/javascript@1.5.4, npm:@lezer/lr@1.4.10, npm:@lezer/php@1.0.5, npm:@lezer/rust@1.0.2, npm:@lezer/xml@1.0.6
+[145] Applies to: npm:@lezer/common@1.5.2, npm:@lezer/css@1.3.4, npm:@lezer/highlight@1.2.3, npm:@lezer/html@1.3.13, npm:@lezer/javascript@1.5.4, npm:@lezer/lr@1.4.10, npm:@lezer/php@1.0.5, npm:@lezer/rust@1.0.2, npm:@lezer/xml@1.0.6
 ------------------------------------------------------------------------------
 MIT License
 
@@ -27672,7 +27791,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[144] Applies to: npm:@lezer/cpp@1.1.6, npm:@lezer/go@1.0.1, npm:@lezer/java@1.1.3, npm:@lezer/markdown@1.7.2, npm:@lezer/python@1.1.19
+[146] Applies to: npm:@lezer/cpp@1.1.6, npm:@lezer/go@1.0.1, npm:@lezer/java@1.1.3, npm:@lezer/markdown@1.7.2, npm:@lezer/python@1.1.19
 ------------------------------------------------------------------------------
 MIT License
 
@@ -27697,7 +27816,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[145] Applies to: npm:@lezer/json@1.0.3
+[147] Applies to: npm:@lezer/json@1.0.3
 ------------------------------------------------------------------------------
 MIT License
 
@@ -27722,7 +27841,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[146] Applies to: npm:@lezer/yaml@1.0.4
+[148] Applies to: npm:@lezer/yaml@1.0.4
 ------------------------------------------------------------------------------
 MIT License
 
@@ -27747,7 +27866,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[147] Applies to: npm:@lit/reactive-element@2.1.2, npm:lit@3.3.3, npm:lit-element@4.2.2, npm:lit-html@3.3.3
+[149] Applies to: npm:@lit/reactive-element@2.1.2, npm:lit@3.3.3, npm:lit-element@4.2.2, npm:lit-html@3.3.3
 ------------------------------------------------------------------------------
 BSD 3-Clause License
 
@@ -27779,7 +27898,7 @@ OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 ------------------------------------------------------------------------------
-[148] Applies to: npm:@marijn/find-cluster-break@1.0.3
+[150] Applies to: npm:@marijn/find-cluster-break@1.0.3
 ------------------------------------------------------------------------------
 MIT License
 
@@ -27804,7 +27923,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[149] Applies to: npm:@mermaid-js/parser@1.2.0
+[151] Applies to: npm:@mermaid-js/parser@1.2.0
 ------------------------------------------------------------------------------
 The MIT License (MIT)
 
@@ -27829,7 +27948,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
 ------------------------------------------------------------------------------
-[150] Applies to: npm:@modelcontextprotocol/sdk@1.29.0
+[152] Applies to: npm:@modelcontextprotocol/sdk@1.29.0
 ------------------------------------------------------------------------------
 MIT License
 
@@ -27854,7 +27973,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
 ------------------------------------------------------------------------------
-[151] Applies to: npm:@monogrid/gainmap-js@3.4.0
+[153] Applies to: npm:@monogrid/gainmap-js@3.4.0
 ------------------------------------------------------------------------------
 MIT License
 
@@ -27879,7 +27998,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
 ------------------------------------------------------------------------------
-[152] Applies to: npm:@napi-rs/canvas@0.1.100
+[154] Applies to: npm:@napi-rs/canvas@0.1.100
 ------------------------------------------------------------------------------
 MIT License
 
@@ -27904,7 +28023,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
 ------------------------------------------------------------------------------
-[153] Applies to: npm:@noble/hashes@1.8.0
+[155] Applies to: npm:@noble/hashes@1.8.0
 ------------------------------------------------------------------------------
 The MIT License (MIT)
 
@@ -27929,7 +28048,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[154] Applies to: npm:@paralleldrive/cuid2@2.3.1
+[156] Applies to: npm:@paralleldrive/cuid2@2.3.1
 ------------------------------------------------------------------------------
 MIT License
 
@@ -27954,7 +28073,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
 ------------------------------------------------------------------------------
-[155] Applies to: npm:@parcel/watcher@2.5.6, npm:@parcel/watcher-darwin-arm64@2.5.6, npm:@parcel/watcher-darwin-x64@2.5.6, npm:@parcel/watcher-linux-arm64-glibc@2.5.6, npm:@parcel/watcher-linux-x64-glibc@2.5.6, npm:@parcel/watcher-win32-x64@2.5.6
+[157] Applies to: npm:@parcel/watcher@2.5.6, npm:@parcel/watcher-darwin-arm64@2.5.6, npm:@parcel/watcher-darwin-x64@2.5.6, npm:@parcel/watcher-linux-arm64-glibc@2.5.6, npm:@parcel/watcher-linux-x64-glibc@2.5.6, npm:@parcel/watcher-win32-x64@2.5.6
 ------------------------------------------------------------------------------
 MIT License
 
@@ -27979,7 +28098,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
 ------------------------------------------------------------------------------
-[156] Applies to: npm:@protobufjs/aspromise@1.1.2, npm:@protobufjs/base64@1.1.2, npm:@protobufjs/codegen@2.0.5, npm:@protobufjs/eventemitter@1.1.1, npm:@protobufjs/fetch@1.1.1, npm:@protobufjs/float@1.0.2, npm:@protobufjs/path@1.1.2, npm:@protobufjs/pool@1.1.0, npm:@protobufjs/utf8@1.1.2
+[158] Applies to: npm:@protobufjs/aspromise@1.1.2, npm:@protobufjs/base64@1.1.2, npm:@protobufjs/codegen@2.0.5, npm:@protobufjs/eventemitter@1.1.1, npm:@protobufjs/fetch@1.1.1, npm:@protobufjs/float@1.0.2, npm:@protobufjs/path@1.1.2, npm:@protobufjs/pool@1.1.0, npm:@protobufjs/utf8@1.1.2
 ------------------------------------------------------------------------------
 Copyright (c) 2016, Daniel Wirtz  All rights reserved.
 
@@ -28009,7 +28128,7 @@ THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
 OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 ------------------------------------------------------------------------------
-[157] Applies to: npm:@radix-ui/number@1.1.2, npm:@radix-ui/primitive@1.1.5, npm:@radix-ui/react-alert-dialog@1.1.19, npm:@radix-ui/react-arrow@1.1.11, npm:@radix-ui/react-collection@1.1.12, npm:@radix-ui/react-compose-refs@1.1.3, npm:@radix-ui/react-context@1.2.0, npm:@radix-ui/react-dialog@1.1.19, npm:@radix-ui/react-direction@1.1.2, npm:@radix-ui/react-dismissable-layer@1.1.15, npm:@radix-ui/react-dropdown-menu@2.1.20, npm:@radix-ui/react-focus-guards@1.1.4, npm:@radix-ui/react-focus-scope@1.1.12, npm:@radix-ui/react-id@1.1.2, npm:@radix-ui/react-menu@2.1.20, npm:@radix-ui/react-popover@1.1.19, npm:@radix-ui/react-popper@1.3.3, npm:@radix-ui/react-portal@1.1.13, npm:@radix-ui/react-presence@1.1.7, npm:@radix-ui/react-primitive@2.1.7, npm:@radix-ui/react-roving-focus@1.1.15, npm:@radix-ui/react-select@2.3.3, npm:@radix-ui/react-slider@1.4.3, npm:@radix-ui/react-slot@1.3.0, npm:@radix-ui/react-switch@1.3.3, npm:@radix-ui/react-tooltip@1.2.12, npm:@radix-ui/react-use-callback-ref@1.1.2, npm:@radix-ui/react-use-controllable-state@1.2.3, npm:@radix-ui/react-use-effect-event@0.0.3, npm:@radix-ui/react-use-is-hydrated@0.1.1, npm:@radix-ui/react-use-layout-effect@1.1.2, npm:@radix-ui/react-use-previous@1.1.2, npm:@radix-ui/react-use-rect@1.1.2, npm:@radix-ui/react-use-size@1.1.2, npm:@radix-ui/react-visually-hidden@1.2.7, npm:@radix-ui/rect@1.1.2
+[159] Applies to: npm:@radix-ui/number@1.1.2, npm:@radix-ui/primitive@1.1.5, npm:@radix-ui/react-alert-dialog@1.1.19, npm:@radix-ui/react-arrow@1.1.11, npm:@radix-ui/react-collection@1.1.12, npm:@radix-ui/react-compose-refs@1.1.3, npm:@radix-ui/react-context@1.2.0, npm:@radix-ui/react-dialog@1.1.19, npm:@radix-ui/react-direction@1.1.2, npm:@radix-ui/react-dismissable-layer@1.1.15, npm:@radix-ui/react-dropdown-menu@2.1.20, npm:@radix-ui/react-focus-guards@1.1.4, npm:@radix-ui/react-focus-scope@1.1.12, npm:@radix-ui/react-id@1.1.2, npm:@radix-ui/react-menu@2.1.20, npm:@radix-ui/react-popover@1.1.19, npm:@radix-ui/react-popper@1.3.3, npm:@radix-ui/react-portal@1.1.13, npm:@radix-ui/react-presence@1.1.7, npm:@radix-ui/react-primitive@2.1.7, npm:@radix-ui/react-roving-focus@1.1.15, npm:@radix-ui/react-select@2.3.3, npm:@radix-ui/react-slider@1.4.3, npm:@radix-ui/react-slot@1.3.0, npm:@radix-ui/react-switch@1.3.3, npm:@radix-ui/react-tooltip@1.2.12, npm:@radix-ui/react-use-callback-ref@1.1.2, npm:@radix-ui/react-use-controllable-state@1.2.3, npm:@radix-ui/react-use-effect-event@0.0.3, npm:@radix-ui/react-use-is-hydrated@0.1.1, npm:@radix-ui/react-use-layout-effect@1.1.2, npm:@radix-ui/react-use-previous@1.1.2, npm:@radix-ui/react-use-rect@1.1.2, npm:@radix-ui/react-use-size@1.1.2, npm:@radix-ui/react-visually-hidden@1.2.7, npm:@radix-ui/rect@1.1.2
 ------------------------------------------------------------------------------
 MIT License
 
@@ -28034,7 +28153,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
 ------------------------------------------------------------------------------
-[158] Applies to: npm:@replit/codemirror-lang-csharp@6.2.0
+[160] Applies to: npm:@replit/codemirror-lang-csharp@6.2.0
 ------------------------------------------------------------------------------
 MIT License
 
@@ -28059,7 +28178,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
 ------------------------------------------------------------------------------
-[159] Applies to: npm:@sapphire/shapeshift@4.0.0
+[161] Applies to: npm:@sapphire/shapeshift@4.0.0
 ------------------------------------------------------------------------------
 # The MIT License (MIT)
 
@@ -28087,7 +28206,7 @@ FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
 OTHER DEALINGS IN THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[160] Applies to: npm:@tanstack/react-virtual@3.14.6, npm:@tanstack/virtual-core@3.17.4
+[162] Applies to: npm:@tanstack/react-virtual@3.14.6, npm:@tanstack/virtual-core@3.17.4
 ------------------------------------------------------------------------------
 MIT License
 
@@ -28112,7 +28231,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
 ------------------------------------------------------------------------------
-[161] Applies to: npm:@tiptap/core@3.28.0, npm:@tiptap/extension-bubble-menu@3.28.0, npm:@tiptap/extension-document@3.28.0, npm:@tiptap/extension-floating-menu@3.28.0, npm:@tiptap/extension-hard-break@3.28.0, npm:@tiptap/extension-history@3.28.0, npm:@tiptap/extension-paragraph@3.28.0, npm:@tiptap/extension-placeholder@3.28.0, npm:@tiptap/extension-text@3.28.0, npm:@tiptap/pm@3.28.0, npm:@tiptap/react@3.28.0
+[163] Applies to: npm:@tiptap/core@3.28.0, npm:@tiptap/extension-bubble-menu@3.28.0, npm:@tiptap/extension-document@3.28.0, npm:@tiptap/extension-floating-menu@3.28.0, npm:@tiptap/extension-hard-break@3.28.0, npm:@tiptap/extension-history@3.28.0, npm:@tiptap/extension-paragraph@3.28.0, npm:@tiptap/extension-placeholder@3.28.0, npm:@tiptap/extension-text@3.28.0, npm:@tiptap/pm@3.28.0, npm:@tiptap/react@3.28.0
 ------------------------------------------------------------------------------
 MIT License
 
@@ -28137,7 +28256,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
 ------------------------------------------------------------------------------
-[162] Applies to: npm:@types/d3@7.4.3, npm:@types/d3-array@3.2.2, npm:@types/d3-axis@3.0.6, npm:@types/d3-brush@3.0.6, npm:@types/d3-chord@3.0.6, npm:@types/d3-color@3.1.3, npm:@types/d3-contour@3.0.6, npm:@types/d3-delaunay@6.0.4, npm:@types/d3-dispatch@3.0.7, npm:@types/d3-drag@3.0.7, npm:@types/d3-dsv@3.0.7, npm:@types/d3-ease@3.0.2, npm:@types/d3-fetch@3.0.7, npm:@types/d3-force@3.0.10, npm:@types/d3-format@3.0.4, npm:@types/d3-geo@3.1.0, npm:@types/d3-hierarchy@3.1.7, npm:@types/d3-interpolate@3.0.4, npm:@types/d3-path@3.1.1, npm:@types/d3-polygon@3.0.2, npm:@types/d3-quadtree@3.0.6, npm:@types/d3-random@3.0.4, npm:@types/d3-scale@4.0.9, npm:@types/d3-scale-chromatic@3.1.0, npm:@types/d3-selection@3.0.11, npm:@types/d3-shape@3.1.8, npm:@types/d3-time@3.0.4, npm:@types/d3-time-format@4.0.3, npm:@types/d3-timer@3.0.2, npm:@types/d3-transition@3.0.9, npm:@types/d3-zoom@3.0.8, npm:@types/debug@4.1.13, npm:@types/estree@1.0.9, npm:@types/estree-jsx@1.0.5, npm:@types/geojson@7946.0.16, npm:@types/hast@3.0.5, npm:@types/katex@0.16.8, npm:@types/mdast@4.0.4, npm:@types/ms@2.1.0, npm:@types/node@25.9.5, npm:@types/trusted-types@2.0.7, npm:@types/unist@2.0.11, npm:@types/unist@3.0.3, npm:@types/use-sync-external-store@0.0.6, npm:@types/ws@8.18.1
+[164] Applies to: npm:@types/d3@7.4.3, npm:@types/d3-array@3.2.2, npm:@types/d3-axis@3.0.6, npm:@types/d3-brush@3.0.6, npm:@types/d3-chord@3.0.6, npm:@types/d3-color@3.1.3, npm:@types/d3-contour@3.0.6, npm:@types/d3-delaunay@6.0.4, npm:@types/d3-dispatch@3.0.7, npm:@types/d3-drag@3.0.7, npm:@types/d3-dsv@3.0.7, npm:@types/d3-ease@3.0.2, npm:@types/d3-fetch@3.0.7, npm:@types/d3-force@3.0.10, npm:@types/d3-format@3.0.4, npm:@types/d3-geo@3.1.0, npm:@types/d3-hierarchy@3.1.7, npm:@types/d3-interpolate@3.0.4, npm:@types/d3-path@3.1.1, npm:@types/d3-polygon@3.0.2, npm:@types/d3-quadtree@3.0.6, npm:@types/d3-random@3.0.4, npm:@types/d3-scale@4.0.9, npm:@types/d3-scale-chromatic@3.1.0, npm:@types/d3-selection@3.0.11, npm:@types/d3-shape@3.1.8, npm:@types/d3-time@3.0.4, npm:@types/d3-time-format@4.0.3, npm:@types/d3-timer@3.0.2, npm:@types/d3-transition@3.0.9, npm:@types/d3-zoom@3.0.8, npm:@types/debug@4.1.13, npm:@types/estree@1.0.9, npm:@types/estree-jsx@1.0.5, npm:@types/geojson@7946.0.16, npm:@types/hast@3.0.5, npm:@types/katex@0.16.8, npm:@types/mdast@4.0.4, npm:@types/ms@2.1.0, npm:@types/node@14.18.63, npm:@types/node@22.20.1, npm:@types/node@25.9.5, npm:@types/trusted-types@2.0.7, npm:@types/unist@2.0.11, npm:@types/unist@3.0.3, npm:@types/use-sync-external-store@0.0.6, npm:@types/ws@8.18.1
 ------------------------------------------------------------------------------
 MIT License
 
@@ -28162,7 +28281,7 @@ MIT License
     SOFTWARE
 
 ------------------------------------------------------------------------------
-[163] Applies to: npm:@ungap/structured-clone@1.3.3
+[165] Applies to: npm:@ungap/structured-clone@1.3.3
 ------------------------------------------------------------------------------
 ISC License
 
@@ -28181,7 +28300,7 @@ OR OTHER TORTIOUS ACTION, ARISING OUT OF OR IN CONNECTION WITH THE USE OR
 PERFORMANCE OF THIS SOFTWARE.
 
 ------------------------------------------------------------------------------
-[164] Applies to: npm:@upsetjs/venn.js@2.0.0
+[166] Applies to: npm:@upsetjs/venn.js@2.0.0
 ------------------------------------------------------------------------------
 MIT License
 
@@ -28207,7 +28326,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
 ------------------------------------------------------------------------------
-[165] Applies to: npm:@vladfrangu/async_event_emitter@2.4.7
+[167] Applies to: npm:@vladfrangu/async_event_emitter@2.4.7
 ------------------------------------------------------------------------------
 # The MIT License (MIT)
 
@@ -28235,7 +28354,7 @@ FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
 OTHER DEALINGS IN THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[166] Applies to: npm:@xterm/addon-clipboard@0.1.0
+[168] Applies to: npm:@xterm/addon-clipboard@0.1.0
 ------------------------------------------------------------------------------
 Copyright (c) 2023, The xterm.js authors (https://github.com/xtermjs/xterm.js)
 
@@ -28258,7 +28377,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[167] Applies to: npm:@xterm/addon-fit@0.10.0
+[169] Applies to: npm:@xterm/addon-fit@0.10.0
 ------------------------------------------------------------------------------
 Copyright (c) 2019, The xterm.js authors (https://github.com/xtermjs/xterm.js)
 
@@ -28281,7 +28400,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[168] Applies to: npm:@xterm/addon-web-links@0.11.0
+[170] Applies to: npm:@xterm/addon-web-links@0.11.0
 ------------------------------------------------------------------------------
 Copyright (c) 2017, The xterm.js authors (https://github.com/xtermjs/xterm.js)
 
@@ -28304,7 +28423,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[169] Applies to: npm:@xterm/xterm@5.5.0
+[171] Applies to: npm:@xterm/xterm@5.5.0
 ------------------------------------------------------------------------------
 Copyright (c) 2017-2019, The xterm.js authors (https://github.com/xtermjs/xterm.js)
 Copyright (c) 2014-2016, SourceLair Private Company (https://www.sourcelair.com)
@@ -28329,7 +28448,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[170] Applies to: npm:accepts@2.0.0, npm:mime-types@2.1.35, npm:mime-types@3.0.2
+[172] Applies to: npm:accepts@2.0.0, npm:mime-types@2.1.35, npm:mime-types@3.0.2
 ------------------------------------------------------------------------------
 (The MIT License)
 
@@ -28356,7 +28475,7 @@ TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
 SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[171] Applies to: npm:agent-base@7.1.4, npm:https-proxy-agent@7.0.6
+[173] Applies to: npm:agent-base@7.1.4, npm:https-proxy-agent@7.0.6
 ------------------------------------------------------------------------------
 (The MIT License)
 
@@ -28382,7 +28501,7 @@ TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
 SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[172] Applies to: npm:ajv@7.2.4, npm:ajv@8.20.0
+[174] Applies to: npm:ajv@7.2.4, npm:ajv@8.20.0
 ------------------------------------------------------------------------------
 The MIT License (MIT)
 
@@ -28407,7 +28526,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
 ------------------------------------------------------------------------------
-[173] Applies to: npm:ajv-formats@1.6.1, npm:ajv-formats@3.0.1
+[175] Applies to: npm:ajv-formats@1.6.1, npm:ajv-formats@3.0.1
 ------------------------------------------------------------------------------
 MIT License
 
@@ -28432,7 +28551,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
 ------------------------------------------------------------------------------
-[174] Applies to: npm:ansi-regex@5.0.1, npm:ansi-styles@4.3.0, npm:camelcase@5.3.1, npm:env-paths@2.2.1, npm:find-up@3.0.0, npm:find-up@4.1.0, npm:is-fullwidth-code-point@3.0.0, npm:is-obj@2.0.0, npm:lcid@3.1.1, npm:locate-path@3.0.0, npm:locate-path@5.0.0, npm:make-dir@3.1.0, npm:mimic-fn@2.1.0, npm:mimic-fn@3.1.0, npm:npm-run-path@4.0.1, npm:p-limit@2.3.0, npm:p-locate@3.0.0, npm:p-locate@4.1.0, npm:p-try@2.2.0, npm:path-exists@4.0.0, npm:path-key@3.1.1, npm:pkg-up@3.1.0, npm:shebang-regex@3.0.0, npm:string-width@4.2.3, npm:strip-ansi@6.0.1, npm:strip-final-newline@2.0.0, npm:wrap-ansi@6.2.0
+[176] Applies to: npm:ansi-regex@5.0.1, npm:ansi-styles@4.3.0, npm:camelcase@5.3.1, npm:env-paths@2.2.1, npm:find-up@3.0.0, npm:find-up@4.1.0, npm:is-fullwidth-code-point@3.0.0, npm:is-obj@2.0.0, npm:lcid@3.1.1, npm:locate-path@3.0.0, npm:locate-path@5.0.0, npm:make-dir@3.1.0, npm:mimic-fn@2.1.0, npm:mimic-fn@3.1.0, npm:npm-run-path@4.0.1, npm:p-limit@2.3.0, npm:p-locate@3.0.0, npm:p-locate@4.1.0, npm:p-try@2.2.0, npm:path-exists@4.0.0, npm:path-key@3.1.1, npm:pkg-up@3.1.0, npm:shebang-regex@3.0.0, npm:string-width@4.2.3, npm:strip-ansi@6.0.1, npm:strip-final-newline@2.0.0, npm:wrap-ansi@6.2.0
 ------------------------------------------------------------------------------
 MIT License
 
@@ -28445,7 +28564,7 @@ The above copyright notice and this permission notice shall be included in all c
 THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[175] Applies to: npm:ansi-regex@6.2.2, npm:ansi-styles@6.2.3, npm:conf@9.0.2, npm:debounce-fn@4.0.0, npm:decompress-response@6.0.0, npm:default-shell@2.2.0, npm:dot-prop@6.0.1, npm:electron-store@7.0.3, npm:escape-string-regexp@5.0.0, npm:execa@4.1.0, npm:execa@5.1.1, npm:fix-path@5.0.0, npm:get-east-asian-width@1.6.0, npm:get-stream@5.2.0, npm:get-stream@6.0.1, npm:invert-kv@3.0.1, npm:is-plain-obj@4.1.0, npm:is-stream@2.0.1, npm:mimic-response@3.1.0, npm:onetime@5.1.2, npm:os-locale@6.0.2, npm:shell-env@4.0.3, npm:shell-path@3.1.0, npm:string-width@5.1.2, npm:strip-ansi@7.2.0, npm:wrap-ansi@7.0.0, npm:wrap-ansi@8.1.0
+[177] Applies to: npm:ansi-regex@6.2.2, npm:ansi-styles@6.2.3, npm:conf@9.0.2, npm:debounce-fn@4.0.0, npm:decompress-response@6.0.0, npm:default-shell@2.2.0, npm:dot-prop@6.0.1, npm:electron-store@7.0.3, npm:escape-string-regexp@5.0.0, npm:execa@4.1.0, npm:execa@5.1.1, npm:fix-path@5.0.0, npm:get-east-asian-width@1.6.0, npm:get-stream@5.2.0, npm:get-stream@6.0.1, npm:invert-kv@3.0.1, npm:is-plain-obj@4.1.0, npm:is-stream@2.0.1, npm:mimic-response@3.1.0, npm:onetime@5.1.2, npm:os-locale@6.0.2, npm:shell-env@4.0.3, npm:shell-path@3.1.0, npm:string-width@5.1.2, npm:strip-ansi@7.2.0, npm:wrap-ansi@7.0.0, npm:wrap-ansi@8.1.0
 ------------------------------------------------------------------------------
 MIT License
 
@@ -28458,7 +28577,59 @@ The above copyright notice and this permission notice shall be included in all c
 THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[176] Applies to: npm:argparse@1.0.10
+[178] Applies to: npm:archiver@5.3.2
+------------------------------------------------------------------------------
+Copyright (c) 2012-2014 Chris Talkington, contributors.
+
+Permission is hereby granted, free of charge, to any person
+obtaining a copy of this software and associated documentation
+files (the "Software"), to deal in the Software without
+restriction, including without limitation the rights to use,
+copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the
+Software is furnished to do so, subject to the following
+conditions:
+
+The above copyright notice and this permission notice shall be
+included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
+OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+OTHER DEALINGS IN THE SOFTWARE.
+
+------------------------------------------------------------------------------
+[179] Applies to: npm:archiver-utils@2.1.0, npm:archiver-utils@3.0.4
+------------------------------------------------------------------------------
+Copyright (c) 2015 Chris Talkington.
+
+Permission is hereby granted, free of charge, to any person
+obtaining a copy of this software and associated documentation
+files (the "Software"), to deal in the Software without
+restriction, including without limitation the rights to use,
+copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the
+Software is furnished to do so, subject to the following
+conditions:
+
+The above copyright notice and this permission notice shall be
+included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
+OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+OTHER DEALINGS IN THE SOFTWARE.
+
+------------------------------------------------------------------------------
+[180] Applies to: npm:argparse@1.0.10
 ------------------------------------------------------------------------------
 (The MIT License)
 
@@ -28483,7 +28654,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[177] Applies to: npm:argparse@2.0.1
+[181] Applies to: npm:argparse@2.0.1
 ------------------------------------------------------------------------------
 A. HISTORY OF THE SOFTWARE
 ==========================
@@ -28741,7 +28912,7 @@ ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT
 OF OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
 
 ------------------------------------------------------------------------------
-[178] Applies to: npm:aria-hidden@1.2.6, npm:react-remove-scroll@2.7.2, npm:react-style-singleton@2.2.3, npm:use-callback-ref@1.3.3, npm:use-sidecar@1.1.3
+[182] Applies to: npm:aria-hidden@1.2.6, npm:react-remove-scroll@2.7.2, npm:react-style-singleton@2.2.3, npm:use-callback-ref@1.3.3, npm:use-sidecar@1.1.3
 ------------------------------------------------------------------------------
 MIT License
 
@@ -28766,7 +28937,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
 ------------------------------------------------------------------------------
-[179] Applies to: npm:asn1@0.2.6
+[183] Applies to: npm:asn1@0.2.6
 ------------------------------------------------------------------------------
 Copyright (c) 2011 Mark Cavage, All rights reserved.
 
@@ -28789,7 +28960,30 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE
 
 ------------------------------------------------------------------------------
-[180] Applies to: npm:asynckit@0.4.0
+[184] Applies to: npm:async@3.2.6
+------------------------------------------------------------------------------
+Copyright (c) 2010-2018 Caolan McMahon
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+
+------------------------------------------------------------------------------
+[185] Applies to: npm:asynckit@0.4.0
 ------------------------------------------------------------------------------
 The MIT License (MIT)
 
@@ -28814,7 +29008,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
 ------------------------------------------------------------------------------
-[181] Applies to: npm:atomically@1.7.0
+[186] Applies to: npm:atomically@1.7.0
 ------------------------------------------------------------------------------
 The MIT License (MIT)
 
@@ -28839,7 +29033,7 @@ FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
 DEALINGS IN THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[182] Applies to: npm:axios@1.18.1
+[187] Applies to: npm:axios@1.18.1
 ------------------------------------------------------------------------------
 # Copyright (c) 2014-present Matt Zabriskie & Collaborators
 
@@ -28850,7 +29044,7 @@ The above copyright notice and this permission notice shall be included in all c
 THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[183] Applies to: npm:bail@2.0.2, npm:ccount@2.0.1, npm:character-entities@2.0.2, npm:character-entities-html4@2.1.0, npm:character-entities-legacy@3.0.0, npm:character-reference-invalid@2.0.1, npm:mdast-util-to-string@4.0.0, npm:unist-util-find-after@5.0.0, npm:unist-util-position@5.0.0, npm:unist-util-visit@5.1.0
+[188] Applies to: npm:bail@2.0.2, npm:ccount@2.0.1, npm:character-entities@2.0.2, npm:character-entities-html4@2.1.0, npm:character-entities-legacy@3.0.0, npm:character-reference-invalid@2.0.1, npm:mdast-util-to-string@4.0.0, npm:unist-util-find-after@5.0.0, npm:unist-util-position@5.0.0, npm:unist-util-visit@5.1.0
 ------------------------------------------------------------------------------
 (The MIT License)
 
@@ -28876,7 +29070,7 @@ TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
 SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[184] Applies to: npm:balanced-match@1.0.2
+[189] Applies to: npm:balanced-match@1.0.2
 ------------------------------------------------------------------------------
 (MIT)
 
@@ -28901,7 +29095,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
 ------------------------------------------------------------------------------
-[185] Applies to: npm:base64-js@1.5.1
+[190] Applies to: npm:base64-js@1.5.1
 ------------------------------------------------------------------------------
 The MIT License (MIT)
 
@@ -28926,7 +29120,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[186] Applies to: npm:bcrypt-pbkdf@1.0.2
+[191] Applies to: npm:bcrypt-pbkdf@1.0.2
 ------------------------------------------------------------------------------
 The Blowfish portions are under the following license:
 
@@ -28996,7 +29190,7 @@ ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
 OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
 
 ------------------------------------------------------------------------------
-[187] Applies to: npm:better-sqlite3@12.11.1
+[192] Applies to: npm:better-sqlite3@12.11.1
 ------------------------------------------------------------------------------
 The MIT License (MIT)
 
@@ -29021,7 +29215,35 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
 ------------------------------------------------------------------------------
-[188] Applies to: npm:bignumber.js@9.3.1
+[193] Applies to: npm:big-integer@1.6.52, npm:robust-predicates@3.0.3, npm:tweetnacl@0.14.5
+------------------------------------------------------------------------------
+This is free and unencumbered software released into the public domain.
+
+Anyone is free to copy, modify, publish, use, compile, sell, or
+distribute this software, either in source code form or as a compiled
+binary, for any purpose, commercial or non-commercial, and by any
+means.
+
+In jurisdictions that recognize copyright laws, the author or authors
+of this software dedicate any and all copyright interest in the
+software to the public domain. We make this dedication for the benefit
+of the public at large and to the detriment of our heirs and
+successors. We intend this dedication to be an overt act of
+relinquishment in perpetuity of all present and future rights to this
+software under copyright law.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+IN NO EVENT SHALL THE AUTHORS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+OTHER DEALINGS IN THE SOFTWARE.
+
+For more information, please refer to <http://unlicense.org>
+
+------------------------------------------------------------------------------
+[194] Applies to: npm:bignumber.js@9.3.1
 ------------------------------------------------------------------------------
 The MIT License (MIT)
 =====================
@@ -29050,7 +29272,7 @@ FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
 OTHER DEALINGS IN THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[189] Applies to: npm:bindings@1.5.0
+[195] Applies to: npm:bindings@1.5.0
 ------------------------------------------------------------------------------
 (The MIT License)
 
@@ -29076,7 +29298,7 @@ TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
 SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[190] Applies to: npm:bl@4.1.0
+[196] Applies to: npm:bl@4.1.0
 ------------------------------------------------------------------------------
 The MIT License (MIT)
 =====================
@@ -29093,7 +29315,32 @@ The above copyright notice and this permission notice shall be included in all c
 THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[191] Applies to: npm:body-parser@2.3.0, npm:type-is@2.1.0
+[197] Applies to: npm:bluebird@3.4.7
+------------------------------------------------------------------------------
+The MIT License (MIT)
+
+Copyright (c) 2013-2015 Petka Antonov
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.  IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+
+------------------------------------------------------------------------------
+[198] Applies to: npm:body-parser@2.3.0, npm:type-is@2.1.0
 ------------------------------------------------------------------------------
 (The MIT License)
 
@@ -29120,7 +29367,7 @@ TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
 SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[192] Applies to: npm:brace-expansion@2.1.2
+[199] Applies to: npm:brace-expansion@1.1.16, npm:brace-expansion@2.1.2
 ------------------------------------------------------------------------------
 MIT License
 
@@ -29145,7 +29392,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
 ------------------------------------------------------------------------------
-[193] Applies to: npm:buffer@5.7.1
+[200] Applies to: npm:buffer@5.7.1
 ------------------------------------------------------------------------------
 The MIT License (MIT)
 
@@ -29170,7 +29417,30 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[194] Applies to: npm:buffer-equal-constant-time@1.0.1
+[201] Applies to: npm:buffer-crc32@0.2.13
+------------------------------------------------------------------------------
+The MIT License
+
+Copyright (c) 2013 Brian J. Brennan
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal in
+the Software without restriction, including without limitation the rights to use,
+copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the
+Software, and to permit persons to whom the Software is furnished to do so,
+subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED,
+INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR
+PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE
+FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+------------------------------------------------------------------------------
+[202] Applies to: npm:buffer-equal-constant-time@1.0.1
 ------------------------------------------------------------------------------
 Copyright (c) 2013, GoInstant Inc., a salesforce.com company
 All rights reserved.
@@ -29186,7 +29456,32 @@ Redistribution and use in source and binary forms, with or without modification,
 THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 ------------------------------------------------------------------------------
-[195] Applies to: npm:buildcheck@0.0.7, npm:cpu-features@0.0.10, npm:ssh2@1.17.0
+[203] Applies to: npm:buffer-indexof-polyfill@1.0.2
+------------------------------------------------------------------------------
+The MIT License (MIT)
+
+Copyright (c) 2015 Sarosia
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+
+------------------------------------------------------------------------------
+[204] Applies to: npm:buildcheck@0.0.7, npm:cpu-features@0.0.10, npm:ssh2@1.17.0
 ------------------------------------------------------------------------------
 Copyright Brian White. All rights reserved.
 
@@ -29209,7 +29504,7 @@ FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
 IN THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[196] Applies to: npm:byte-size@8.2.1
+[205] Applies to: npm:byte-size@8.2.1
 ------------------------------------------------------------------------------
 The MIT License (MIT)
 
@@ -29234,7 +29529,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
 ------------------------------------------------------------------------------
-[197] Applies to: npm:bytes@3.1.2
+[206] Applies to: npm:bytes@3.1.2
 ------------------------------------------------------------------------------
 (The MIT License)
 
@@ -29261,7 +29556,7 @@ TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
 SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[198] Applies to: npm:call-bind-apply-helpers@1.0.2, npm:call-bound@1.0.4, npm:es-define-property@1.0.1, npm:es-errors@1.3.0, npm:es-object-atoms@1.1.2, npm:side-channel-list@1.0.1, npm:side-channel-map@1.0.1
+[207] Applies to: npm:call-bind-apply-helpers@1.0.2, npm:call-bound@1.0.4, npm:es-define-property@1.0.1, npm:es-errors@1.3.0, npm:es-object-atoms@1.1.2, npm:side-channel-list@1.0.1, npm:side-channel-map@1.0.1
 ------------------------------------------------------------------------------
 MIT License
 
@@ -29286,7 +29581,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
 ------------------------------------------------------------------------------
-[199] Applies to: npm:charenc@0.0.2, npm:crypt@0.0.2
+[208] Applies to: npm:charenc@0.0.2, npm:crypt@0.0.2
 ------------------------------------------------------------------------------
 Copyright © 2011, Paul Vorbach. All rights reserved.
 Copyright © 2009, Jeff Mott. All rights reserved.
@@ -29317,7 +29612,7 @@ ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
 SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 ------------------------------------------------------------------------------
-[200] Applies to: npm:chownr@3.0.0, npm:package-json-from-dist@1.0.1, npm:yallist@5.0.0
+[209] Applies to: npm:chownr@3.0.0, npm:package-json-from-dist@1.0.1, npm:yallist@5.0.0
 ------------------------------------------------------------------------------
 All packages under `src/` are licensed according to the terms in
 their respective `LICENSE` or `LICENSE.md` files.
@@ -29384,7 +29679,7 @@ will be liable to anyone for any damages related to this
 software or this license, under any kind of legal claim.***
 
 ------------------------------------------------------------------------------
-[201] Applies to: npm:clsx@2.1.1
+[210] Applies to: npm:clsx@2.1.1
 ------------------------------------------------------------------------------
 MIT License
 
@@ -29397,7 +29692,7 @@ The above copyright notice and this permission notice shall be included in all c
 THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[202] Applies to: npm:cn-font-split@6.0.3
+[211] Applies to: npm:cn-font-split@6.0.3
 ------------------------------------------------------------------------------
 Apache License
                            Version 2.0, January 2004
@@ -29602,7 +29897,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 
 ------------------------------------------------------------------------------
-[203] Applies to: npm:color-convert@2.0.1
+[212] Applies to: npm:color-convert@2.0.1
 ------------------------------------------------------------------------------
 Copyright (c) 2011-2016 Heather Arthur <fayearthur@gmail.com>
 
@@ -29626,7 +29921,7 @@ OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
 WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[204] Applies to: npm:color-name@1.1.4
+[213] Applies to: npm:color-name@1.1.4
 ------------------------------------------------------------------------------
 The MIT License (MIT)
 Copyright (c) 2015 Dmitry Ivanov
@@ -29638,7 +29933,7 @@ The above copyright notice and this permission notice shall be included in all c
 THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[205] Applies to: npm:combined-stream@1.0.8, npm:delayed-stream@1.0.0
+[214] Applies to: npm:combined-stream@1.0.8, npm:delayed-stream@1.0.0
 ------------------------------------------------------------------------------
 Copyright (c) 2011 Debuggable Limited <felix@debuggable.com>
 
@@ -29661,7 +29956,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[206] Applies to: npm:comma-separated-tokens@2.0.3, npm:hast-util-is-element@3.0.0, npm:hast-util-parse-selector@4.0.0, npm:hast-util-whitespace@3.0.0, npm:is-alphabetical@2.0.1, npm:is-alphanumerical@2.0.1, npm:is-decimal@2.0.1, npm:is-hexadecimal@2.0.1, npm:mdast-util-to-hast@13.2.1, npm:rehype-slug@6.0.0, npm:space-separated-tokens@2.0.2, npm:unist-util-remove-position@5.0.0, npm:unist-util-stringify-position@4.0.0, npm:unist-util-visit-parents@6.0.2, npm:vfile-location@5.0.3, npm:web-namespaces@2.0.1, npm:zwitch@2.0.4
+[215] Applies to: npm:comma-separated-tokens@2.0.3, npm:hast-util-is-element@3.0.0, npm:hast-util-parse-selector@4.0.0, npm:hast-util-whitespace@3.0.0, npm:is-alphabetical@2.0.1, npm:is-alphanumerical@2.0.1, npm:is-decimal@2.0.1, npm:is-hexadecimal@2.0.1, npm:mdast-util-to-hast@13.2.1, npm:rehype-slug@6.0.0, npm:space-separated-tokens@2.0.2, npm:unist-util-remove-position@5.0.0, npm:unist-util-stringify-position@4.0.0, npm:unist-util-visit-parents@6.0.2, npm:vfile-location@5.0.3, npm:web-namespaces@2.0.1, npm:zwitch@2.0.4
 ------------------------------------------------------------------------------
 (The MIT License)
 
@@ -29687,7 +29982,7 @@ TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
 SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[207] Applies to: npm:commander@7.2.0, npm:commander@8.3.0
+[216] Applies to: npm:commander@7.2.0, npm:commander@8.3.0
 ------------------------------------------------------------------------------
 (The MIT License)
 
@@ -29713,7 +30008,55 @@ TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
 SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[208] Applies to: npm:content-disposition@1.1.0, npm:forwarded@0.2.0, npm:media-typer@1.1.0, npm:vary@1.1.2
+[217] Applies to: npm:compress-commons@4.1.2, npm:crc32-stream@4.0.3, npm:zip-stream@4.1.1
+------------------------------------------------------------------------------
+Copyright (c) 2014 Chris Talkington, contributors.
+
+Permission is hereby granted, free of charge, to any person
+obtaining a copy of this software and associated documentation
+files (the "Software"), to deal in the Software without
+restriction, including without limitation the rights to use,
+copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the
+Software is furnished to do so, subject to the following
+conditions:
+
+The above copyright notice and this permission notice shall be
+included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
+OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+OTHER DEALINGS IN THE SOFTWARE.
+
+------------------------------------------------------------------------------
+[218] Applies to: npm:concat-map@0.0.1, npm:github-from-package@0.0.0, npm:minimist@1.2.8
+------------------------------------------------------------------------------
+This software is released under the MIT license:
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of
+this software and associated documentation files (the "Software"), to deal in
+the Software without restriction, including without limitation the rights to
+use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+the Software, and to permit persons to whom the Software is furnished to do so,
+subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+------------------------------------------------------------------------------
+[219] Applies to: npm:content-disposition@1.1.0, npm:forwarded@0.2.0, npm:media-typer@1.1.0, npm:vary@1.1.2
 ------------------------------------------------------------------------------
 (The MIT License)
 
@@ -29739,7 +30082,7 @@ TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
 SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[209] Applies to: npm:content-type@1.0.5, npm:content-type@2.0.0
+[220] Applies to: npm:content-type@1.0.5, npm:content-type@2.0.0
 ------------------------------------------------------------------------------
 (The MIT License)
 
@@ -29765,7 +30108,7 @@ TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
 SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[210] Applies to: npm:cookie@0.7.2, npm:cookie@1.1.1
+[221] Applies to: npm:cookie@0.7.2, npm:cookie@1.1.1
 ------------------------------------------------------------------------------
 (The MIT License)
 
@@ -29792,7 +30135,7 @@ TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
 SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[211] Applies to: npm:cookie-signature@1.2.2
+[222] Applies to: npm:cookie-signature@1.2.2
 ------------------------------------------------------------------------------
 (The MIT License)
 
@@ -29818,7 +30161,7 @@ TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
 SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[212] Applies to: npm:core-util-is@1.0.3
+[223] Applies to: npm:core-util-is@1.0.3
 ------------------------------------------------------------------------------
 Copyright Node.js contributors. All rights reserved.
 
@@ -29841,7 +30184,7 @@ FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
 IN THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[213] Applies to: npm:cors@2.8.6
+[224] Applies to: npm:cors@2.8.6
 ------------------------------------------------------------------------------
 (The MIT License)
 
@@ -29867,7 +30210,7 @@ TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
 SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[214] Applies to: npm:cose-base@1.0.3, npm:cose-base@2.2.0
+[225] Applies to: npm:cose-base@1.0.3, npm:cose-base@2.2.0
 ------------------------------------------------------------------------------
 MIT License
 
@@ -29892,7 +30235,212 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
 ------------------------------------------------------------------------------
-[215] Applies to: npm:crelt@1.0.7
+[226] Applies to: npm:crc-32@1.2.2
+------------------------------------------------------------------------------
+Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "{}"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright (C) 2014-present   SheetJS LLC
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+
+------------------------------------------------------------------------------
+[227] Applies to: npm:crelt@1.0.7
 ------------------------------------------------------------------------------
 Copyright (C) 2020 by Marijn Haverbeke <marijn@haverbeke.berlin>
 
@@ -29915,7 +30463,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[216] Applies to: npm:cross-spawn@7.0.6
+[228] Applies to: npm:cross-spawn@7.0.6
 ------------------------------------------------------------------------------
 The MIT License (MIT)
 
@@ -29940,7 +30488,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[217] Applies to: npm:cytoscape@3.34.0
+[229] Applies to: npm:cytoscape@3.34.0
 ------------------------------------------------------------------------------
 Copyright (c) 2016-2026, The Cytoscape Consortium.
 
@@ -29996,7 +30544,7 @@ SOFTWARE.`;
 fs.writeFileSync(path.join(__dirname, 'LICENSE'), license);
 
 ------------------------------------------------------------------------------
-[218] Applies to: npm:cytoscape-cose-bilkent@4.1.0
+[230] Applies to: npm:cytoscape-cose-bilkent@4.1.0
 ------------------------------------------------------------------------------
 Copyright (c) 2016-2018, The Cytoscape Consortium.
 
@@ -30019,7 +30567,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
 ------------------------------------------------------------------------------
-[219] Applies to: npm:cytoscape-fcose@2.2.0
+[231] Applies to: npm:cytoscape-fcose@2.2.0
 ------------------------------------------------------------------------------
 Copyright (c) 2018 - present, iVis-at-Bilkent.
 
@@ -30042,7 +30590,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
 ------------------------------------------------------------------------------
-[220] Applies to: npm:d3@7.9.0, npm:d3-array@3.2.4
+[232] Applies to: npm:d3@7.9.0, npm:d3-array@3.2.4
 ------------------------------------------------------------------------------
 Copyright 2010-2023 Mike Bostock
 
@@ -30059,7 +30607,7 @@ TORTIOUS ACTION, ARISING OUT OF OR IN CONNECTION WITH THE USE OR PERFORMANCE OF
 THIS SOFTWARE.
 
 ------------------------------------------------------------------------------
-[221] Applies to: npm:d3-array@2.12.1
+[233] Applies to: npm:d3-array@2.12.1
 ------------------------------------------------------------------------------
 Copyright 2010-2020 Mike Bostock
 All rights reserved.
@@ -30090,7 +30638,7 @@ ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
 SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 ------------------------------------------------------------------------------
-[222] Applies to: npm:d3-axis@3.0.0, npm:d3-brush@3.0.0, npm:d3-chord@3.0.1, npm:d3-dispatch@3.0.1, npm:d3-drag@3.0.0, npm:d3-force@3.0.0, npm:d3-hierarchy@3.1.2, npm:d3-interpolate@3.0.1, npm:d3-polygon@3.0.1, npm:d3-quadtree@3.0.1, npm:d3-random@3.0.1, npm:d3-scale@4.0.2, npm:d3-selection@3.0.0, npm:d3-time-format@4.1.0, npm:d3-timer@3.0.1, npm:d3-transition@3.0.1, npm:d3-zoom@3.0.0
+[234] Applies to: npm:d3-axis@3.0.0, npm:d3-brush@3.0.0, npm:d3-chord@3.0.1, npm:d3-dispatch@3.0.1, npm:d3-drag@3.0.0, npm:d3-force@3.0.0, npm:d3-hierarchy@3.1.2, npm:d3-interpolate@3.0.1, npm:d3-polygon@3.0.1, npm:d3-quadtree@3.0.1, npm:d3-random@3.0.1, npm:d3-scale@4.0.2, npm:d3-selection@3.0.0, npm:d3-time-format@4.1.0, npm:d3-timer@3.0.1, npm:d3-transition@3.0.1, npm:d3-zoom@3.0.0
 ------------------------------------------------------------------------------
 Copyright 2010-2021 Mike Bostock
 
@@ -30107,7 +30655,7 @@ TORTIOUS ACTION, ARISING OUT OF OR IN CONNECTION WITH THE USE OR PERFORMANCE OF
 THIS SOFTWARE.
 
 ------------------------------------------------------------------------------
-[223] Applies to: npm:d3-color@3.1.0, npm:d3-shape@3.2.0, npm:d3-time@3.1.0
+[235] Applies to: npm:d3-color@3.1.0, npm:d3-shape@3.2.0, npm:d3-time@3.1.0
 ------------------------------------------------------------------------------
 Copyright 2010-2022 Mike Bostock
 
@@ -30124,7 +30672,7 @@ TORTIOUS ACTION, ARISING OUT OF OR IN CONNECTION WITH THE USE OR PERFORMANCE OF
 THIS SOFTWARE.
 
 ------------------------------------------------------------------------------
-[224] Applies to: npm:d3-contour@4.0.2
+[236] Applies to: npm:d3-contour@4.0.2
 ------------------------------------------------------------------------------
 Copyright 2012-2023 Mike Bostock
 
@@ -30141,7 +30689,7 @@ TORTIOUS ACTION, ARISING OUT OF OR IN CONNECTION WITH THE USE OR PERFORMANCE OF
 THIS SOFTWARE.
 
 ------------------------------------------------------------------------------
-[225] Applies to: npm:d3-delaunay@6.0.4
+[237] Applies to: npm:d3-delaunay@6.0.4
 ------------------------------------------------------------------------------
 Copyright 2018-2021 Observable, Inc.
 Copyright 2021 Mapbox
@@ -30159,7 +30707,7 @@ TORTIOUS ACTION, ARISING OUT OF OR IN CONNECTION WITH THE USE OR PERFORMANCE OF
 THIS SOFTWARE.
 
 ------------------------------------------------------------------------------
-[226] Applies to: npm:d3-dsv@3.0.1
+[238] Applies to: npm:d3-dsv@3.0.1
 ------------------------------------------------------------------------------
 Copyright 2013-2021 Mike Bostock
 
@@ -30176,7 +30724,7 @@ TORTIOUS ACTION, ARISING OUT OF OR IN CONNECTION WITH THE USE OR PERFORMANCE OF
 THIS SOFTWARE.
 
 ------------------------------------------------------------------------------
-[227] Applies to: npm:d3-ease@3.0.1
+[239] Applies to: npm:d3-ease@3.0.1
 ------------------------------------------------------------------------------
 Copyright 2010-2021 Mike Bostock
 Copyright 2001 Robert Penner
@@ -30208,7 +30756,7 @@ ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
 SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 ------------------------------------------------------------------------------
-[228] Applies to: npm:d3-fetch@3.0.1
+[240] Applies to: npm:d3-fetch@3.0.1
 ------------------------------------------------------------------------------
 Copyright 2016-2021 Mike Bostock
 
@@ -30225,7 +30773,7 @@ TORTIOUS ACTION, ARISING OUT OF OR IN CONNECTION WITH THE USE OR PERFORMANCE OF
 THIS SOFTWARE.
 
 ------------------------------------------------------------------------------
-[229] Applies to: npm:d3-format@3.1.2
+[241] Applies to: npm:d3-format@3.1.2
 ------------------------------------------------------------------------------
 Copyright 2010-2026 Mike Bostock
 
@@ -30242,7 +30790,7 @@ TORTIOUS ACTION, ARISING OUT OF OR IN CONNECTION WITH THE USE OR PERFORMANCE OF
 THIS SOFTWARE.
 
 ------------------------------------------------------------------------------
-[230] Applies to: npm:d3-geo@3.1.1
+[242] Applies to: npm:d3-geo@3.1.1
 ------------------------------------------------------------------------------
 Copyright 2010-2024 Mike Bostock
 
@@ -30280,7 +30828,7 @@ IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
 CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[231] Applies to: npm:d3-path@1.0.9
+[243] Applies to: npm:d3-path@1.0.9
 ------------------------------------------------------------------------------
 Copyright 2015-2016 Mike Bostock
 All rights reserved.
@@ -30311,7 +30859,7 @@ ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
 SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 ------------------------------------------------------------------------------
-[232] Applies to: npm:d3-path@3.1.0
+[244] Applies to: npm:d3-path@3.1.0
 ------------------------------------------------------------------------------
 Copyright 2015-2022 Mike Bostock
 
@@ -30328,7 +30876,7 @@ TORTIOUS ACTION, ARISING OUT OF OR IN CONNECTION WITH THE USE OR PERFORMANCE OF
 THIS SOFTWARE.
 
 ------------------------------------------------------------------------------
-[233] Applies to: npm:d3-sankey@0.12.3
+[245] Applies to: npm:d3-sankey@0.12.3
 ------------------------------------------------------------------------------
 Copyright 2015, Mike Bostock
 All rights reserved.
@@ -30359,7 +30907,7 @@ ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
 SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 ------------------------------------------------------------------------------
-[234] Applies to: npm:d3-scale-chromatic@3.1.0
+[246] Applies to: npm:d3-scale-chromatic@3.1.0
 ------------------------------------------------------------------------------
 Copyright 2010-2024 Mike Bostock
 
@@ -30391,7 +30939,7 @@ CONDITIONS OF ANY KIND, either express or implied. See the License for the
 specific language governing permissions and limitations under the License.
 
 ------------------------------------------------------------------------------
-[235] Applies to: npm:d3-shape@1.3.7
+[247] Applies to: npm:d3-shape@1.3.7
 ------------------------------------------------------------------------------
 Copyright 2010-2015 Mike Bostock
 All rights reserved.
@@ -30422,7 +30970,7 @@ ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
 SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 ------------------------------------------------------------------------------
-[236] Applies to: npm:dagre-d3-es@7.0.14
+[248] Applies to: npm:dagre-d3-es@7.0.14
 ------------------------------------------------------------------------------
 Original dagre-d3 copyright: Copyright (c) 2013 Chris Pettitt
 Original dagre copyright: Copyright (c) 2012-2014 Chris Pettitt
@@ -30449,7 +30997,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[237] Applies to: npm:dayjs@1.11.21
+[249] Applies to: npm:dayjs@1.11.21
 ------------------------------------------------------------------------------
 MIT License
 
@@ -30474,7 +31022,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
 ------------------------------------------------------------------------------
-[238] Applies to: npm:debug@2.6.9
+[250] Applies to: npm:debug@2.6.9
 ------------------------------------------------------------------------------
 (The MIT License)
 
@@ -30496,7 +31044,7 @@ WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN 
 SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[239] Applies to: npm:debug@4.4.3
+[251] Applies to: npm:debug@4.4.3
 ------------------------------------------------------------------------------
 (The MIT License)
 
@@ -30519,7 +31067,7 @@ WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN 
 SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[240] Applies to: npm:decamelize@1.2.0, npm:object-assign@4.1.1, npm:path-exists@3.0.0, npm:strip-json-comments@2.0.1
+[252] Applies to: npm:decamelize@1.2.0, npm:object-assign@4.1.1, npm:path-exists@3.0.0, npm:path-is-absolute@1.0.1, npm:strip-json-comments@2.0.1
 ------------------------------------------------------------------------------
 The MIT License (MIT)
 
@@ -30544,7 +31092,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[241] Applies to: npm:decode-named-character-reference@1.3.0, npm:hast-util-from-parse5@8.0.3, npm:hast-util-to-jsx-runtime@2.3.6, npm:hastscript@9.0.1, npm:lowlight@3.3.0, npm:markdown-table@3.0.4, npm:mdast-util-find-and-replace@3.0.2, npm:mdast-util-from-markdown@2.0.3, npm:mdast-util-gfm@3.1.0, npm:mdast-util-gfm-footnote@2.1.0, npm:mdast-util-to-markdown@2.1.2, npm:micromark@4.0.2, npm:micromark-core-commonmark@2.0.3, npm:micromark-extension-gfm-table@2.1.1, npm:micromark-factory-destination@2.0.1, npm:micromark-factory-label@2.0.1, npm:micromark-factory-space@2.0.1, npm:micromark-factory-title@2.0.1, npm:micromark-factory-whitespace@2.0.1, npm:micromark-util-character@2.1.1, npm:micromark-util-chunked@2.0.1, npm:micromark-util-classify-character@2.0.1, npm:micromark-util-combine-extensions@2.0.1, npm:micromark-util-decode-numeric-character-reference@2.0.2, npm:micromark-util-decode-string@2.0.1, npm:micromark-util-encode@2.0.1, npm:micromark-util-html-tag-name@2.0.1, npm:micromark-util-normalize-identifier@2.0.1, npm:micromark-util-resolve-all@2.0.1, npm:micromark-util-sanitize-uri@2.0.1, npm:micromark-util-subtokenize@2.1.0, npm:micromark-util-symbol@2.0.1, npm:micromark-util-types@2.0.2, npm:rehype-highlight@7.0.2, npm:remark-gfm@4.0.1, npm:remark-rehype@11.1.2, npm:vfile-message@4.0.3
+[253] Applies to: npm:decode-named-character-reference@1.3.0, npm:hast-util-from-parse5@8.0.3, npm:hast-util-to-jsx-runtime@2.3.6, npm:hastscript@9.0.1, npm:lowlight@3.3.0, npm:markdown-table@3.0.4, npm:mdast-util-find-and-replace@3.0.2, npm:mdast-util-from-markdown@2.0.3, npm:mdast-util-gfm@3.1.0, npm:mdast-util-gfm-footnote@2.1.0, npm:mdast-util-to-markdown@2.1.2, npm:micromark@4.0.2, npm:micromark-core-commonmark@2.0.3, npm:micromark-extension-gfm-table@2.1.1, npm:micromark-factory-destination@2.0.1, npm:micromark-factory-label@2.0.1, npm:micromark-factory-space@2.0.1, npm:micromark-factory-title@2.0.1, npm:micromark-factory-whitespace@2.0.1, npm:micromark-util-character@2.1.1, npm:micromark-util-chunked@2.0.1, npm:micromark-util-classify-character@2.0.1, npm:micromark-util-combine-extensions@2.0.1, npm:micromark-util-decode-numeric-character-reference@2.0.2, npm:micromark-util-decode-string@2.0.1, npm:micromark-util-encode@2.0.1, npm:micromark-util-html-tag-name@2.0.1, npm:micromark-util-normalize-identifier@2.0.1, npm:micromark-util-resolve-all@2.0.1, npm:micromark-util-sanitize-uri@2.0.1, npm:micromark-util-subtokenize@2.1.0, npm:micromark-util-symbol@2.0.1, npm:micromark-util-types@2.0.2, npm:rehype-highlight@7.0.2, npm:remark-gfm@4.0.1, npm:remark-rehype@11.1.2, npm:vfile-message@4.0.3
 ------------------------------------------------------------------------------
 (The MIT License)
 
@@ -30570,7 +31118,7 @@ TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
 SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[242] Applies to: npm:deep-extend@0.6.0
+[254] Applies to: npm:deep-extend@0.6.0
 ------------------------------------------------------------------------------
 The MIT License (MIT)
 
@@ -30594,7 +31142,7 @@ IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
 CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[243] Applies to: npm:delaunator@5.1.0
+[255] Applies to: npm:delaunator@5.1.0
 ------------------------------------------------------------------------------
 ISC License
 
@@ -30613,7 +31161,7 @@ TORTIOUS ACTION, ARISING OUT OF OR IN CONNECTION WITH THE USE OR PERFORMANCE OF
 THIS SOFTWARE.
 
 ------------------------------------------------------------------------------
-[244] Applies to: npm:depd@2.0.0
+[256] Applies to: npm:depd@2.0.0
 ------------------------------------------------------------------------------
 (The MIT License)
 
@@ -30639,7 +31187,7 @@ TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
 SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[245] Applies to: npm:dequal@2.0.3, npm:mri@1.2.0
+[257] Applies to: npm:dequal@2.0.3, npm:mri@1.2.0
 ------------------------------------------------------------------------------
 The MIT License (MIT)
 
@@ -30664,7 +31212,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[246] Applies to: npm:detect-libc@2.1.2
+[258] Applies to: npm:detect-libc@2.1.2
 ------------------------------------------------------------------------------
 Apache License
                            Version 2.0, January 2004
@@ -30869,7 +31417,7 @@ Apache License
    limitations under the License.
 
 ------------------------------------------------------------------------------
-[247] Applies to: npm:detect-node-es@1.1.0
+[259] Applies to: npm:detect-node-es@1.1.0
 ------------------------------------------------------------------------------
 MIT License
 
@@ -30894,7 +31442,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
 ------------------------------------------------------------------------------
-[248] Applies to: npm:devlop@1.1.0
+[260] Applies to: npm:devlop@1.1.0
 ------------------------------------------------------------------------------
 (The MIT License)
 
@@ -30920,7 +31468,7 @@ TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
 SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[249] Applies to: npm:diff@8.0.4
+[261] Applies to: npm:diff@8.0.4
 ------------------------------------------------------------------------------
 BSD 3-Clause License
 
@@ -30953,7 +31501,7 @@ OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 ------------------------------------------------------------------------------
-[250] Applies to: npm:dijkstrajs@1.0.3
+[262] Applies to: npm:dijkstrajs@1.0.3
 ------------------------------------------------------------------------------
 ```
 Dijkstra path-finding functions. Adapted from the Dijkstar Python project.
@@ -30976,7 +31524,7 @@ THE SOFTWARE.
 ```
 
 ------------------------------------------------------------------------------
-[251] Applies to: npm:dingtalk-stream@v2.1.5
+[263] Applies to: npm:dingtalk-stream@v2.1.5
 ------------------------------------------------------------------------------
 MIT License
 
@@ -31001,7 +31549,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
 ------------------------------------------------------------------------------
-[252] Applies to: npm:discord-api-types@0.38.50
+[264] Applies to: npm:discord-api-types@0.38.50
 ------------------------------------------------------------------------------
 MIT License
 
@@ -31026,7 +31574,32 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
 ------------------------------------------------------------------------------
-[253] Applies to: npm:dompurify@3.4.12
+[265] Applies to: npm:docx@9.7.1
+------------------------------------------------------------------------------
+The MIT License (MIT)
+
+Copyright (c) 2016 Dolan
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+
+------------------------------------------------------------------------------
+[266] Applies to: npm:dompurify@3.4.12
 ------------------------------------------------------------------------------
 Apache License
                            Version 2.0, January 2004
@@ -31605,7 +32178,7 @@ Exhibit B - "Incompatible With Secondary Licenses" Notice
   defined by the Mozilla Public License, v. 2.0.
 
 ------------------------------------------------------------------------------
-[254] Applies to: npm:dunder-proto@1.0.1, npm:math-intrinsics@1.1.0
+[267] Applies to: npm:dunder-proto@1.0.1, npm:math-intrinsics@1.1.0
 ------------------------------------------------------------------------------
 MIT License
 
@@ -31630,7 +32203,37 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
 ------------------------------------------------------------------------------
-[255] Applies to: npm:ecdsa-sig-formatter@1.0.11
+[268] Applies to: npm:duplexer2@0.1.4
+------------------------------------------------------------------------------
+Copyright (c) 2013, Deoxxa Development
+======================================
+All rights reserved.
+--------------------
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+1. Redistributions of source code must retain the above copyright
+   notice, this list of conditions and the following disclaimer.
+2. Redistributions in binary form must reproduce the above copyright
+   notice, this list of conditions and the following disclaimer in the
+   documentation and/or other materials provided with the distribution.
+3. Neither the name of Deoxxa Development nor the names of its contributors
+   may be used to endorse or promote products derived from this software
+   without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY DEOXXA DEVELOPMENT ''AS IS'' AND ANY
+EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL DEOXXA DEVELOPMENT BE LIABLE FOR ANY
+DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+(INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+------------------------------------------------------------------------------
+[269] Applies to: npm:ecdsa-sig-formatter@1.0.11
 ------------------------------------------------------------------------------
 Apache License
                            Version 2.0, January 2004
@@ -31835,7 +32438,7 @@ Apache License
    limitations under the License.
 
 ------------------------------------------------------------------------------
-[256] Applies to: npm:ee-first@1.1.1
+[270] Applies to: npm:ee-first@1.1.1
 ------------------------------------------------------------------------------
 The MIT License (MIT)
 
@@ -31860,7 +32463,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[257] Applies to: npm:electron-squirrel-startup@1.0.1
+[271] Applies to: npm:electron-squirrel-startup@1.0.1
 ------------------------------------------------------------------------------
 Apache License
 Version 2.0, January 2004
@@ -32065,7 +32668,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 
 ------------------------------------------------------------------------------
-[258] Applies to: npm:electron-window-state@5.0.3
+[272] Applies to: npm:electron-window-state@5.0.3
 ------------------------------------------------------------------------------
 The MIT License (MIT)
 
@@ -32091,7 +32694,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[259] Applies to: npm:emoji-regex@8.0.0, npm:emoji-regex@9.2.2, npm:punycode@2.3.1
+[273] Applies to: npm:emoji-regex@8.0.0, npm:emoji-regex@9.2.2, npm:punycode@2.3.1
 ------------------------------------------------------------------------------
 Copyright Mathias Bynens <https://mathiasbynens.be/>
 
@@ -32115,7 +32718,7 @@ OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
 WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[260] Applies to: npm:encodeurl@2.0.0
+[274] Applies to: npm:encodeurl@2.0.0
 ------------------------------------------------------------------------------
 (The MIT License)
 
@@ -32141,7 +32744,7 @@ TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
 SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[261] Applies to: npm:end-of-stream@1.4.5, npm:pump@3.0.4, npm:tar-fs@2.1.5, npm:tar-stream@2.2.0
+[275] Applies to: npm:end-of-stream@1.4.5, npm:pump@3.0.4, npm:tar-fs@2.1.5, npm:tar-stream@2.2.0
 ------------------------------------------------------------------------------
 The MIT License (MIT)
 
@@ -32166,7 +32769,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[262] Applies to: npm:entities@6.0.1
+[276] Applies to: npm:entities@6.0.1
 ------------------------------------------------------------------------------
 Copyright (c) Felix Böhm
 All rights reserved.
@@ -32181,7 +32784,7 @@ THIS IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRE
 EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 ------------------------------------------------------------------------------
-[263] Applies to: npm:es-set-tostringtag@2.1.0
+[277] Applies to: npm:es-set-tostringtag@2.1.0
 ------------------------------------------------------------------------------
 MIT License
 
@@ -32206,7 +32809,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
 ------------------------------------------------------------------------------
-[264] Applies to: npm:es-toolkit@1.49.0
+[278] Applies to: npm:es-toolkit@1.49.0
 ------------------------------------------------------------------------------
 MIT License
 
@@ -32231,7 +32834,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
 ------------------------------------------------------------------------------
-[265] Applies to: npm:escape-html@1.0.3
+[279] Applies to: npm:escape-html@1.0.3
 ------------------------------------------------------------------------------
 (The MIT License)
 
@@ -32259,7 +32862,7 @@ TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
 SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[266] Applies to: npm:esprima@4.0.1
+[280] Applies to: npm:esprima@4.0.1
 ------------------------------------------------------------------------------
 Copyright JS Foundation and other contributors, https://js.foundation/
 
@@ -32284,7 +32887,7 @@ ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
 THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 ------------------------------------------------------------------------------
-[267] Applies to: npm:estree-util-is-identifier-name@3.0.0, npm:hast-util-heading-rank@3.0.0, npm:mdast-util-gfm-autolink-literal@2.0.1, npm:mdast-util-gfm-strikethrough@2.0.0, npm:mdast-util-gfm-table@2.0.0, npm:mdast-util-gfm-task-list-item@2.0.0, npm:mdast-util-math@3.0.0, npm:mdast-util-mdx-expression@2.0.1, npm:mdast-util-mdx-jsx@3.2.0, npm:mdast-util-mdxjs-esm@2.0.1, npm:micromark-extension-gfm@3.0.0, npm:micromark-extension-gfm-autolink-literal@2.1.0, npm:micromark-extension-gfm-strikethrough@2.1.0, npm:micromark-extension-gfm-tagfilter@2.0.0, npm:micromark-extension-gfm-task-list-item@2.1.0, npm:micromark-extension-math@3.1.0
+[281] Applies to: npm:estree-util-is-identifier-name@3.0.0, npm:hast-util-heading-rank@3.0.0, npm:mdast-util-gfm-autolink-literal@2.0.1, npm:mdast-util-gfm-strikethrough@2.0.0, npm:mdast-util-gfm-table@2.0.0, npm:mdast-util-gfm-task-list-item@2.0.0, npm:mdast-util-math@3.0.0, npm:mdast-util-mdx-expression@2.0.1, npm:mdast-util-mdx-jsx@3.2.0, npm:mdast-util-mdxjs-esm@2.0.1, npm:micromark-extension-gfm@3.0.0, npm:micromark-extension-gfm-autolink-literal@2.1.0, npm:micromark-extension-gfm-strikethrough@2.1.0, npm:micromark-extension-gfm-tagfilter@2.0.0, npm:micromark-extension-gfm-task-list-item@2.1.0, npm:micromark-extension-math@3.1.0
 ------------------------------------------------------------------------------
 (The MIT License)
 
@@ -32310,7 +32913,7 @@ TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
 SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[268] Applies to: npm:etag@1.8.1, npm:proxy-addr@2.0.7
+[282] Applies to: npm:etag@1.8.1, npm:proxy-addr@2.0.7
 ------------------------------------------------------------------------------
 (The MIT License)
 
@@ -32336,7 +32939,7 @@ TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
 SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[269] Applies to: npm:eventemitter3@5.0.4
+[283] Applies to: npm:eventemitter3@5.0.4
 ------------------------------------------------------------------------------
 The MIT License (MIT)
 
@@ -32361,7 +32964,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
 ------------------------------------------------------------------------------
-[270] Applies to: npm:eventsource@3.0.7
+[284] Applies to: npm:eventsource@3.0.7
 ------------------------------------------------------------------------------
 The MIT License
 
@@ -32387,7 +32990,7 @@ OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
 WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[271] Applies to: npm:eventsource-parser@3.1.0
+[285] Applies to: npm:eventsource-parser@3.1.0
 ------------------------------------------------------------------------------
 MIT License
 
@@ -32412,7 +33015,32 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
 ------------------------------------------------------------------------------
-[272] Applies to: npm:expand-template@2.0.3
+[286] Applies to: npm:exceljs@4.4.0
+------------------------------------------------------------------------------
+The MIT License (MIT)
+
+Copyright (c) 2014-2019 Guyon Roche
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+
+------------------------------------------------------------------------------
+[287] Applies to: npm:expand-template@2.0.3
 ------------------------------------------------------------------------------
 The MIT License (MIT)
 
@@ -32437,7 +33065,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[273] Applies to: npm:express@5.2.1
+[288] Applies to: npm:express@5.2.1
 ------------------------------------------------------------------------------
 (The MIT License)
 
@@ -32465,7 +33093,7 @@ TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
 SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[274] Applies to: npm:express-rate-limit@8.5.2
+[289] Applies to: npm:express-rate-limit@8.5.2
 ------------------------------------------------------------------------------
 # MIT License
 
@@ -32489,7 +33117,7 @@ IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
 CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[275] Applies to: npm:extend@3.0.2
+[290] Applies to: npm:extend@3.0.2
 ------------------------------------------------------------------------------
 The MIT License (MIT)
 
@@ -32515,7 +33143,7 @@ OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
 WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[276] Applies to: npm:extend-shallow@2.0.1
+[291] Applies to: npm:extend-shallow@2.0.1
 ------------------------------------------------------------------------------
 The MIT License (MIT)
 
@@ -32540,7 +33168,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[277] Applies to: npm:fast-deep-equal@3.1.3, npm:json-schema-traverse@1.0.0
+[292] Applies to: npm:fast-deep-equal@3.1.3, npm:json-schema-traverse@1.0.0
 ------------------------------------------------------------------------------
 MIT License
 
@@ -32565,7 +33193,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
 ------------------------------------------------------------------------------
-[278] Applies to: npm:fast-equals@5.4.1
+[293] Applies to: npm:fast-equals@5.4.1
 ------------------------------------------------------------------------------
 MIT License
 
@@ -32590,7 +33218,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
 ------------------------------------------------------------------------------
-[279] Applies to: npm:fast-uri@3.1.4
+[294] Applies to: npm:fast-uri@3.1.4
 ------------------------------------------------------------------------------
 Copyright (c) 2011-2021, Gary Court until https://github.com/garycourt/uri-js/commit/a1acf730b4bba3f1097c9f52e7d9d3aba8cdcaae
 Copyright (c) 2021-present The Fastify team <https://github.com/fastify/fastify#team>
@@ -32624,7 +33252,7 @@ The complete list of contributors can be found at:
 - https://github.com/garycourt/uri-js/graphs/contributors
 
 ------------------------------------------------------------------------------
-[280] Applies to: npm:fetch-blob@3.2.0
+[295] Applies to: npm:fetch-blob@3.2.0
 ------------------------------------------------------------------------------
 MIT License
 
@@ -32649,7 +33277,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
 ------------------------------------------------------------------------------
-[281] Applies to: npm:file-uri-to-path@1.0.0
+[296] Applies to: npm:file-uri-to-path@1.0.0
 ------------------------------------------------------------------------------
 Copyright (c) 2014 Nathan Rajlich <nathan@tootallnate.net>
 
@@ -32673,7 +33301,7 @@ TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
 SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[282] Applies to: npm:finalhandler@2.1.1
+[297] Applies to: npm:finalhandler@2.1.1
 ------------------------------------------------------------------------------
 (The MIT License)
 
@@ -32699,7 +33327,7 @@ TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
 SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[283] Applies to: npm:follow-redirects@1.16.0
+[298] Applies to: npm:follow-redirects@1.16.0
 ------------------------------------------------------------------------------
 Copyright 2014–present Olivier Lalonde <olalonde@gmail.com>, James Talmage <james@talmage.io>, Ruben Verborgh
 
@@ -32721,7 +33349,7 @@ WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR
 IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[284] Applies to: npm:foreground-child@3.3.1
+[299] Applies to: npm:foreground-child@3.3.1
 ------------------------------------------------------------------------------
 The ISC License
 
@@ -32740,7 +33368,7 @@ ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF OR
 IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
 
 ------------------------------------------------------------------------------
-[285] Applies to: npm:form-data@4.0.6
+[300] Applies to: npm:form-data@4.0.6
 ------------------------------------------------------------------------------
 Copyright (c) 2012 Felix Geisendörfer (felix@debuggable.com) and contributors
 
@@ -32763,7 +33391,7 @@ Copyright (c) 2012 Felix Geisendörfer (felix@debuggable.com) and contributors
  THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[286] Applies to: npm:formdata-polyfill@4.0.10
+[301] Applies to: npm:formdata-polyfill@4.0.10
 ------------------------------------------------------------------------------
 MIT License
 
@@ -32788,7 +33416,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
 ------------------------------------------------------------------------------
-[287] Applies to: npm:fresh@2.0.0
+[302] Applies to: npm:fresh@2.0.0
 ------------------------------------------------------------------------------
 (The MIT License)
 
@@ -32815,7 +33443,7 @@ TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
 SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[288] Applies to: npm:fs-constants@1.0.0
+[303] Applies to: npm:fs-constants@1.0.0
 ------------------------------------------------------------------------------
 The MIT License (MIT)
 
@@ -32840,7 +33468,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[289] Applies to: npm:fs-extra@11.3.6
+[304] Applies to: npm:fs-extra@11.3.6
 ------------------------------------------------------------------------------
 (The MIT License)
 
@@ -32859,7 +33487,54 @@ OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHE
  ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[290] Applies to: npm:function-bind@1.1.2
+[305] Applies to: npm:fs.realpath@1.0.0
+------------------------------------------------------------------------------
+The ISC License
+
+Copyright (c) Isaac Z. Schlueter and Contributors
+
+Permission to use, copy, modify, and/or distribute this software for any
+purpose with or without fee is hereby granted, provided that the above
+copyright notice and this permission notice appear in all copies.
+
+THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
+ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF OR
+IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+
+----
+
+This library bundles a version of the `fs.realpath` and `fs.realpathSync`
+methods from Node.js v0.10 under the terms of the Node.js MIT license.
+
+Node's license follows, also included at the header of `old.js` which contains
+the licensed code:
+
+  Copyright Joyent, Inc. and other Node contributors.
+
+  Permission is hereby granted, free of charge, to any person obtaining a
+  copy of this software and associated documentation files (the "Software"),
+  to deal in the Software without restriction, including without limitation
+  the rights to use, copy, modify, merge, publish, distribute, sublicense,
+  and/or sell copies of the Software, and to permit persons to whom the
+  Software is furnished to do so, subject to the following conditions:
+
+  The above copyright notice and this permission notice shall be included in
+  all copies or substantial portions of the Software.
+
+  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+  FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+  DEALINGS IN THE SOFTWARE.
+
+------------------------------------------------------------------------------
+[306] Applies to: npm:function-bind@1.1.2
 ------------------------------------------------------------------------------
 Copyright (c) 2013 Raynos.
 
@@ -32882,7 +33557,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[291] Applies to: npm:get-caller-file@2.0.5
+[307] Applies to: npm:get-caller-file@2.0.5
 ------------------------------------------------------------------------------
 ISC License (ISC)
 Copyright 2018 Stefan Penner
@@ -32892,7 +33567,7 @@ Permission to use, copy, modify, and/or distribute this software for any purpose
 THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
 
 ------------------------------------------------------------------------------
-[292] Applies to: npm:get-intrinsic@1.3.0
+[308] Applies to: npm:get-intrinsic@1.3.0
 ------------------------------------------------------------------------------
 MIT License
 
@@ -32917,7 +33592,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
 ------------------------------------------------------------------------------
-[293] Applies to: npm:get-nonce@1.0.1
+[309] Applies to: npm:get-nonce@1.0.1
 ------------------------------------------------------------------------------
 MIT License
 
@@ -32942,7 +33617,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
 ------------------------------------------------------------------------------
-[294] Applies to: npm:get-proto@1.0.1
+[310] Applies to: npm:get-proto@1.0.1
 ------------------------------------------------------------------------------
 MIT License
 
@@ -32967,29 +33642,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
 ------------------------------------------------------------------------------
-[295] Applies to: npm:github-from-package@0.0.0, npm:minimist@1.2.8
-------------------------------------------------------------------------------
-This software is released under the MIT license:
-
-Permission is hereby granted, free of charge, to any person obtaining a copy of
-this software and associated documentation files (the "Software"), to deal in
-the Software without restriction, including without limitation the rights to
-use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
-the Software, and to permit persons to whom the Software is furnished to do so,
-subject to the following conditions:
-
-The above copyright notice and this permission notice shall be included in all
-copies or substantial portions of the Software.
-
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
-FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
-COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
-IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
-CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
-
-------------------------------------------------------------------------------
-[296] Applies to: npm:github-slugger@2.0.0
+[311] Applies to: npm:github-slugger@2.0.0
 ------------------------------------------------------------------------------
 Copyright (c) 2015, Dan Flettre <fletd01@yahoo.com>
 
@@ -32998,7 +33651,7 @@ Permission to use, copy, modify, and/or distribute this software for any purpose
 THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
 
 ------------------------------------------------------------------------------
-[297] Applies to: npm:glob@10.5.0
+[312] Applies to: npm:glob@10.5.0
 ------------------------------------------------------------------------------
 The ISC License
 
@@ -33017,7 +33670,32 @@ ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF OR
 IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
 
 ------------------------------------------------------------------------------
-[298] Applies to: npm:gopd@1.2.0
+[313] Applies to: npm:glob@7.2.3
+------------------------------------------------------------------------------
+The ISC License
+
+Copyright (c) Isaac Z. Schlueter and Contributors
+
+Permission to use, copy, modify, and/or distribute this software for any
+purpose with or without fee is hereby granted, provided that the above
+copyright notice and this permission notice appear in all copies.
+
+THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
+ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF OR
+IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+
+## Glob Logo
+
+Glob's logo created by Tanya Brassie <http://tanyabrassie.com/>, licensed
+under a Creative Commons Attribution-ShareAlike 4.0 International License
+https://creativecommons.org/licenses/by-sa/4.0/
+
+------------------------------------------------------------------------------
+[314] Applies to: npm:gopd@1.2.0
 ------------------------------------------------------------------------------
 MIT License
 
@@ -33042,7 +33720,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
 ------------------------------------------------------------------------------
-[299] Applies to: npm:graceful-fs@4.2.11
+[315] Applies to: npm:graceful-fs@4.2.11
 ------------------------------------------------------------------------------
 The ISC License
 
@@ -33061,7 +33739,7 @@ ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF OR
 IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
 
 ------------------------------------------------------------------------------
-[300] Applies to: npm:gray-matter@4.0.3
+[316] Applies to: npm:gray-matter@4.0.3, npm:normalize-path@3.0.0
 ------------------------------------------------------------------------------
 The MIT License (MIT)
 
@@ -33086,7 +33764,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[301] Applies to: npm:gtoken@8.0.0
+[317] Applies to: npm:gtoken@8.0.0
 ------------------------------------------------------------------------------
 The MIT License (MIT)
 
@@ -33111,7 +33789,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[302] Applies to: npm:hachure-fill@0.5.2
+[318] Applies to: npm:hachure-fill@0.5.2
 ------------------------------------------------------------------------------
 MIT License
 
@@ -33136,7 +33814,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
 ------------------------------------------------------------------------------
-[303] Applies to: npm:harmonyos-sans-sc-webfont-splitted@1.1.0
+[319] Applies to: npm:harmonyos-sans-sc-webfont-splitted@1.1.0
 ------------------------------------------------------------------------------
 This is free and unencumbered software released into the public domain.
 
@@ -33164,7 +33842,7 @@ OTHER DEALINGS IN THE SOFTWARE.
 For more information, please refer to <https://unlicense.org>
 
 ------------------------------------------------------------------------------
-[304] Applies to: npm:has-symbols@1.1.0
+[320] Applies to: npm:has-symbols@1.1.0
 ------------------------------------------------------------------------------
 MIT License
 
@@ -33189,7 +33867,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
 ------------------------------------------------------------------------------
-[305] Applies to: npm:has-tostringtag@1.0.2
+[321] Applies to: npm:has-tostringtag@1.0.2
 ------------------------------------------------------------------------------
 MIT License
 
@@ -33214,7 +33892,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
 ------------------------------------------------------------------------------
-[306] Applies to: npm:hasown@2.0.4
+[322] Applies to: npm:hasown@2.0.4
 ------------------------------------------------------------------------------
 MIT License
 
@@ -33239,7 +33917,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
 ------------------------------------------------------------------------------
-[307] Applies to: npm:hast-util-from-dom@5.0.1
+[323] Applies to: npm:hast-util-from-dom@5.0.1
 ------------------------------------------------------------------------------
 (ISC License)
 
@@ -33258,7 +33936,7 @@ TORTIOUS ACTION, ARISING OUT OF OR IN CONNECTION WITH THE USE OR PERFORMANCE OF
 THIS SOFTWARE.
 
 ------------------------------------------------------------------------------
-[308] Applies to: npm:hast-util-from-html@2.0.3
+[324] Applies to: npm:hast-util-from-html@2.0.3
 ------------------------------------------------------------------------------
 (The MIT License)
 
@@ -33284,7 +33962,7 @@ TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
 SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[309] Applies to: npm:hast-util-from-html-isomorphic@2.0.0
+[325] Applies to: npm:hast-util-from-html-isomorphic@2.0.0
 ------------------------------------------------------------------------------
 (The MIT License)
 
@@ -33310,7 +33988,7 @@ TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
 SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[310] Applies to: npm:hast-util-to-string@3.0.1, npm:html-url-attributes@3.0.1
+[326] Applies to: npm:hast-util-to-string@3.0.1, npm:html-url-attributes@3.0.1
 ------------------------------------------------------------------------------
 (The MIT License)
 
@@ -33335,7 +34013,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[311] Applies to: npm:hast-util-to-text@4.0.2
+[327] Applies to: npm:hast-util-to-text@4.0.2
 ------------------------------------------------------------------------------
 (The MIT License)
 
@@ -33361,7 +34039,7 @@ TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
 SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[312] Applies to: npm:highlight.js@11.11.1
+[328] Applies to: npm:highlight.js@11.11.1
 ------------------------------------------------------------------------------
 BSD 3-Clause License
 
@@ -33394,7 +34072,7 @@ OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 ------------------------------------------------------------------------------
-[313] Applies to: npm:hono@4.12.30
+[329] Applies to: npm:hono@4.12.30
 ------------------------------------------------------------------------------
 MIT License
 
@@ -33419,7 +34097,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
 ------------------------------------------------------------------------------
-[314] Applies to: npm:html-to-image@1.11.13
+[330] Applies to: npm:html-to-image@1.11.13
 ------------------------------------------------------------------------------
 MIT License
 
@@ -33444,7 +34122,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
 ------------------------------------------------------------------------------
-[315] Applies to: npm:http-errors@2.0.1
+[331] Applies to: npm:http-errors@2.0.1
 ------------------------------------------------------------------------------
 The MIT License (MIT)
 
@@ -33470,7 +34148,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[316] Applies to: npm:human-signals@1.1.1, npm:human-signals@2.1.0
+[332] Applies to: npm:human-signals@1.1.1, npm:human-signals@2.1.0
 ------------------------------------------------------------------------------
 Apache License
                            Version 2.0, January 2004
@@ -33675,7 +34353,7 @@ Apache License
    limitations under the License.
 
 ------------------------------------------------------------------------------
-[317] Applies to: npm:i18next@26.3.6
+[333] Applies to: npm:i18next@26.3.6
 ------------------------------------------------------------------------------
 The MIT License (MIT)
 
@@ -33700,7 +34378,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
 ------------------------------------------------------------------------------
-[318] Applies to: npm:iconv-lite@0.6.3, npm:iconv-lite@0.7.3
+[334] Applies to: npm:iconv-lite@0.6.3, npm:iconv-lite@0.7.3
 ------------------------------------------------------------------------------
 Copyright (c) 2011 Alexander Shtuchkin
 
@@ -33724,7 +34402,7 @@ OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
 WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[319] Applies to: npm:ieee754@1.2.1
+[335] Applies to: npm:ieee754@1.2.1
 ------------------------------------------------------------------------------
 Copyright 2008 Fair Oaks Labs, Inc.
 
@@ -33739,7 +34417,7 @@ Redistribution and use in source and binary forms, with or without modification,
 THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 ------------------------------------------------------------------------------
-[320] Applies to: npm:ignore@7.0.6
+[336] Applies to: npm:ignore@7.0.6
 ------------------------------------------------------------------------------
 Copyright (c) 2013 Kael Zhang <i@kael.me>, contributors
 http://kael.me/
@@ -33764,7 +34442,20 @@ OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
 WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[321] Applies to: npm:immediate@3.0.6
+[337] Applies to: npm:image-size@1.2.1
+------------------------------------------------------------------------------
+The MIT License (MIT)
+
+Copyright © 2013-Present Aditya Yadav, http://netroy.in
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the “Software”), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+------------------------------------------------------------------------------
+[338] Applies to: npm:immediate@3.0.6
 ------------------------------------------------------------------------------
 Copyright (c) 2012 Barnesandnoble.com, llc, Donavon West, Domenic Denicola, Brian Cavalier
 
@@ -33788,7 +34479,7 @@ OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
 WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[322] Applies to: npm:import-meta-resolve@4.2.0
+[339] Applies to: npm:import-meta-resolve@4.2.0
 ------------------------------------------------------------------------------
 (The MIT License)
 
@@ -33866,7 +34557,26 @@ IN THE SOFTWARE.
 """
 
 ------------------------------------------------------------------------------
-[323] Applies to: npm:inherits@2.0.4
+[340] Applies to: npm:inflight@1.0.6
+------------------------------------------------------------------------------
+The ISC License
+
+Copyright (c) Isaac Z. Schlueter
+
+Permission to use, copy, modify, and/or distribute this software for any
+purpose with or without fee is hereby granted, provided that the above
+copyright notice and this permission notice appear in all copies.
+
+THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
+ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF OR
+IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+
+------------------------------------------------------------------------------
+[341] Applies to: npm:inherits@2.0.4
 ------------------------------------------------------------------------------
 The ISC License
 
@@ -33885,7 +34595,7 @@ OTHER TORTIOUS ACTION, ARISING OUT OF OR IN CONNECTION WITH THE USE OR
 PERFORMANCE OF THIS SOFTWARE.
 
 ------------------------------------------------------------------------------
-[324] Applies to: npm:inline-style-parser@0.2.7
+[342] Applies to: npm:inline-style-parser@0.2.7
 ------------------------------------------------------------------------------
 (The MIT License)
 
@@ -33898,7 +34608,7 @@ The above copyright notice and this permission notice shall be included in all c
 THE SOFTWARE IS PROVIDED 'AS IS', WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[325] Applies to: npm:internmap@1.0.1, npm:internmap@2.0.3
+[343] Applies to: npm:internmap@1.0.1, npm:internmap@2.0.3
 ------------------------------------------------------------------------------
 Copyright 2021 Mike Bostock
 
@@ -33915,7 +34625,7 @@ TORTIOUS ACTION, ARISING OUT OF OR IN CONNECTION WITH THE USE OR PERFORMANCE OF
 THIS SOFTWARE.
 
 ------------------------------------------------------------------------------
-[326] Applies to: npm:ip-address@10.2.0
+[344] Applies to: npm:ip-address@10.2.0
 ------------------------------------------------------------------------------
 Copyright (C) 2011 by Beau Gunderson
 
@@ -33938,7 +34648,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[327] Applies to: npm:ipaddr.js@1.9.1, npm:ipaddr.js@2.4.0
+[345] Applies to: npm:ipaddr.js@1.9.1, npm:ipaddr.js@2.4.0
 ------------------------------------------------------------------------------
 Copyright (C) 2011-2017 whitequark <whitequark@whitequark.org>
 
@@ -33961,7 +34671,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[328] Applies to: npm:is-buffer@1.1.6, npm:safe-buffer@5.1.2, npm:safe-buffer@5.2.1
+[346] Applies to: npm:is-buffer@1.1.6, npm:safe-buffer@5.1.2, npm:safe-buffer@5.2.1
 ------------------------------------------------------------------------------
 The MIT License (MIT)
 
@@ -33986,7 +34696,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[329] Applies to: npm:is-extendable@0.1.1
+[347] Applies to: npm:is-extendable@0.1.1
 ------------------------------------------------------------------------------
 The MIT License (MIT)
 
@@ -34011,7 +34721,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[330] Applies to: npm:is-extglob@2.1.1
+[348] Applies to: npm:is-extglob@2.1.1
 ------------------------------------------------------------------------------
 The MIT License (MIT)
 
@@ -34036,7 +34746,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[331] Applies to: npm:is-glob@4.0.3, npm:kind-of@6.0.3
+[349] Applies to: npm:is-glob@4.0.3, npm:kind-of@6.0.3
 ------------------------------------------------------------------------------
 The MIT License (MIT)
 
@@ -34061,7 +34771,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[332] Applies to: npm:is-promise@2.2.2, npm:is-promise@4.0.0
+[350] Applies to: npm:is-promise@2.2.2, npm:is-promise@4.0.0
 ------------------------------------------------------------------------------
 Copyright (c) 2014 Forbes Lindesay
 
@@ -34084,7 +34794,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[333] Applies to: npm:jackspeak@3.4.3
+[351] Applies to: npm:jackspeak@3.4.3
 ------------------------------------------------------------------------------
 # Blue Oak Model License
 
@@ -34143,7 +34853,7 @@ will be liable to anyone for any damages related to this
 software or this license, under any kind of legal claim._**
 
 ------------------------------------------------------------------------------
-[334] Applies to: npm:jose@6.2.3
+[352] Applies to: npm:jose@6.2.3
 ------------------------------------------------------------------------------
 The MIT License (MIT)
 
@@ -34168,7 +34878,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
 ------------------------------------------------------------------------------
-[335] Applies to: npm:js-base64@3.9.1
+[353] Applies to: npm:js-base64@3.9.1
 ------------------------------------------------------------------------------
 Copyright (c) 2014, Dan Kogai
 All rights reserved.
@@ -34199,7 +34909,7 @@ OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 ------------------------------------------------------------------------------
-[336] Applies to: npm:js-yaml@3.15.0, npm:js-yaml@4.3.0
+[354] Applies to: npm:js-yaml@3.15.0, npm:js-yaml@4.3.0
 ------------------------------------------------------------------------------
 (The MIT License)
 
@@ -34224,7 +34934,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[337] Applies to: npm:json-bigint@1.0.0
+[355] Applies to: npm:json-bigint@1.0.0
 ------------------------------------------------------------------------------
 The MIT License (MIT)
 
@@ -34248,7 +34958,7 @@ IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
 CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[338] Applies to: npm:json-schema-to-ts@3.1.1, npm:ts-algebra@2.0.0
+[356] Applies to: npm:json-schema-to-ts@3.1.1, npm:ts-algebra@2.0.0
 ------------------------------------------------------------------------------
 MIT License
 
@@ -34273,7 +34983,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
 ------------------------------------------------------------------------------
-[339] Applies to: npm:json-schema-typed@7.0.3
+[357] Applies to: npm:json-schema-typed@7.0.3
 ------------------------------------------------------------------------------
 BSD-2-Clause License
 
@@ -34303,7 +35013,7 @@ ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 POSSIBILITY OF SUCH DAMAGE.
 
 ------------------------------------------------------------------------------
-[340] Applies to: npm:json-schema-typed@8.0.2
+[358] Applies to: npm:json-schema-typed@8.0.2
 ------------------------------------------------------------------------------
 BSD 2-Clause License
 
@@ -34364,7 +35074,7 @@ ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
 SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 ------------------------------------------------------------------------------
-[341] Applies to: npm:jsonfile@4.0.0, npm:jsonfile@6.2.1
+[359] Applies to: npm:jsonfile@4.0.0, npm:jsonfile@6.2.1
 ------------------------------------------------------------------------------
 (The MIT License)
 
@@ -34383,7 +35093,7 @@ OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHE
  ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[342] Applies to: npm:jszip@3.10.1
+[360] Applies to: npm:jszip@3.10.1
 ------------------------------------------------------------------------------
 JSZip is dual licensed. At your choice you may use it under the MIT license *or* the GPLv3
 license.
@@ -35038,7 +35748,7 @@ copy of the Program in return for a fee.
                      END OF TERMS AND CONDITIONS
 
 ------------------------------------------------------------------------------
-[343] Applies to: npm:jwa@2.0.1, npm:jws@4.0.1
+[361] Applies to: npm:jwa@2.0.1, npm:jws@4.0.1
 ------------------------------------------------------------------------------
 Copyright (c) 2013 Brian J. Brennan
 
@@ -35059,7 +35769,7 @@ FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TOR
 ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[344] Applies to: npm:katex@0.16.47
+[362] Applies to: npm:katex@0.16.47
 ------------------------------------------------------------------------------
 The MIT License (MIT)
 
@@ -35084,7 +35794,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
 ------------------------------------------------------------------------------
-[345] Applies to: npm:khroma@2.1.0
+[363] Applies to: npm:khroma@2.1.0
 ------------------------------------------------------------------------------
 The MIT License (MIT)
 
@@ -35109,7 +35819,7 @@ FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
 DEALINGS IN THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[346] Applies to: npm:layout-base@1.0.2, npm:layout-base@2.0.1
+[364] Applies to: npm:layout-base@1.0.2, npm:layout-base@2.0.1
 ------------------------------------------------------------------------------
 MIT License
 
@@ -35134,7 +35844,33 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
 ------------------------------------------------------------------------------
-[347] Applies to: npm:lie@3.3.0
+[365] Applies to: npm:lazystream@1.0.1
+------------------------------------------------------------------------------
+Copyright (c) 2013 J. Pommerening, contributors.
+
+Permission is hereby granted, free of charge, to any person
+obtaining a copy of this software and associated documentation
+files (the "Software"), to deal in the Software without
+restriction, including without limitation the rights to use,
+copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the
+Software is furnished to do so, subject to the following
+conditions:
+
+The above copyright notice and this permission notice shall be
+included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
+OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+OTHER DEALINGS IN THE SOFTWARE.
+
+------------------------------------------------------------------------------
+[366] Applies to: npm:lie@3.3.0
 ------------------------------------------------------------------------------
 #Copyright (c) 2014-2018 Calvin Metcalf, Jordan Harband
 
@@ -35145,7 +35881,16 @@ The above copyright notice and this permission notice shall be included in all c
 **THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.**
 
 ------------------------------------------------------------------------------
-[348] Applies to: npm:lodash@4.18.1, npm:lodash-es@4.18.1, npm:lodash.merge@4.6.2
+[367] Applies to: npm:listenercount@1.0.1
+------------------------------------------------------------------------------
+Copyright (c) MMXV jden <jason@denizac.org>
+
+Permission to use, copy, modify, and/or distribute this software for any purpose with or without fee is hereby granted, provided that the above copyright notice and this permission notice appear in all copies.
+
+THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+
+------------------------------------------------------------------------------
+[368] Applies to: npm:lodash@4.18.1, npm:lodash-es@4.18.1, npm:lodash.merge@4.6.2
 ------------------------------------------------------------------------------
 Copyright OpenJS Foundation and other contributors <https://openjsf.org/>
 
@@ -35196,33 +35941,7 @@ licenses; we recommend you read them, as their terms may differ from the
 terms above.
 
 ------------------------------------------------------------------------------
-[349] Applies to: npm:lodash.identity@3.0.0
-------------------------------------------------------------------------------
-Copyright 2012-2015 The Dojo Foundation <http://dojofoundation.org/>
-Based on Underscore.js 1.7.0, copyright 2009-2015 Jeremy Ashkenas,
-DocumentCloud and Investigative Reporters & Editors <http://underscorejs.org/>
-
-Permission is hereby granted, free of charge, to any person obtaining
-a copy of this software and associated documentation files (the
-"Software"), to deal in the Software without restriction, including
-without limitation the rights to use, copy, modify, merge, publish,
-distribute, sublicense, and/or sell copies of the Software, and to
-permit persons to whom the Software is furnished to do so, subject to
-the following conditions:
-
-The above copyright notice and this permission notice shall be
-included in all copies or substantial portions of the Software.
-
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
-EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
-MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
-NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
-LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
-OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
-WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
-
-------------------------------------------------------------------------------
-[350] Applies to: npm:lodash.pickby@4.6.0, npm:lodash.snakecase@4.1.1
+[369] Applies to: npm:lodash.defaults@4.2.0, npm:lodash.difference@4.5.0, npm:lodash.escaperegexp@4.1.2, npm:lodash.flatten@4.4.0, npm:lodash.groupby@4.6.0, npm:lodash.isplainobject@4.0.6, npm:lodash.pickby@4.6.0, npm:lodash.snakecase@4.1.1, npm:lodash.union@4.6.0, npm:lodash.uniq@4.5.0
 ------------------------------------------------------------------------------
 Copyright jQuery Foundation and other contributors <https://jquery.org/>
 
@@ -35273,7 +35992,136 @@ licenses; we recommend you read them, as their terms may differ from the
 terms above.
 
 ------------------------------------------------------------------------------
-[351] Applies to: npm:longest-streak@3.1.0, npm:stringify-entities@4.0.4, npm:trim-lines@3.0.1
+[370] Applies to: npm:lodash.identity@3.0.0
+------------------------------------------------------------------------------
+Copyright 2012-2015 The Dojo Foundation <http://dojofoundation.org/>
+Based on Underscore.js 1.7.0, copyright 2009-2015 Jeremy Ashkenas,
+DocumentCloud and Investigative Reporters & Editors <http://underscorejs.org/>
+
+Permission is hereby granted, free of charge, to any person obtaining
+a copy of this software and associated documentation files (the
+"Software"), to deal in the Software without restriction, including
+without limitation the rights to use, copy, modify, merge, publish,
+distribute, sublicense, and/or sell copies of the Software, and to
+permit persons to whom the Software is furnished to do so, subject to
+the following conditions:
+
+The above copyright notice and this permission notice shall be
+included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+------------------------------------------------------------------------------
+[371] Applies to: npm:lodash.isboolean@3.0.3, npm:lodash.isnil@4.0.0
+------------------------------------------------------------------------------
+Copyright 2012-2016 The Dojo Foundation <http://dojofoundation.org/>
+Based on Underscore.js, copyright 2009-2016 Jeremy Ashkenas,
+DocumentCloud and Investigative Reporters & Editors <http://underscorejs.org/>
+
+Permission is hereby granted, free of charge, to any person obtaining
+a copy of this software and associated documentation files (the
+"Software"), to deal in the Software without restriction, including
+without limitation the rights to use, copy, modify, merge, publish,
+distribute, sublicense, and/or sell copies of the Software, and to
+permit persons to whom the Software is furnished to do so, subject to
+the following conditions:
+
+The above copyright notice and this permission notice shall be
+included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+------------------------------------------------------------------------------
+[372] Applies to: npm:lodash.isequal@4.5.0, npm:lodash.isfunction@3.0.9
+------------------------------------------------------------------------------
+Copyright JS Foundation and other contributors <https://js.foundation/>
+
+Based on Underscore.js, copyright Jeremy Ashkenas,
+DocumentCloud and Investigative Reporters & Editors <http://underscorejs.org/>
+
+This software consists of voluntary contributions made by many
+individuals. For exact contribution history, see the revision history
+available at https://github.com/lodash/lodash
+
+The following license applies to all parts of this software except as
+documented below:
+
+====
+
+Permission is hereby granted, free of charge, to any person obtaining
+a copy of this software and associated documentation files (the
+"Software"), to deal in the Software without restriction, including
+without limitation the rights to use, copy, modify, merge, publish,
+distribute, sublicense, and/or sell copies of the Software, and to
+permit persons to whom the Software is furnished to do so, subject to
+the following conditions:
+
+The above copyright notice and this permission notice shall be
+included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+====
+
+Copyright and related rights for sample code are waived via CC0. Sample
+code is defined as all source code displayed within the prose of the
+documentation.
+
+CC0: http://creativecommons.org/publicdomain/zero/1.0/
+
+====
+
+Files located in the node_modules and vendor directories are externally
+maintained libraries used by this software which have their own
+licenses; we recommend you read them, as their terms may differ from the
+terms above.
+
+------------------------------------------------------------------------------
+[373] Applies to: npm:lodash.isundefined@3.0.1
+------------------------------------------------------------------------------
+Copyright 2012-2015 The Dojo Foundation <http://dojofoundation.org/>
+Based on Underscore.js, copyright 2009-2015 Jeremy Ashkenas,
+DocumentCloud and Investigative Reporters & Editors <http://underscorejs.org/>
+
+Permission is hereby granted, free of charge, to any person obtaining
+a copy of this software and associated documentation files (the
+"Software"), to deal in the Software without restriction, including
+without limitation the rights to use, copy, modify, merge, publish,
+distribute, sublicense, and/or sell copies of the Software, and to
+permit persons to whom the Software is furnished to do so, subject to
+the following conditions:
+
+The above copyright notice and this permission notice shall be
+included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+------------------------------------------------------------------------------
+[374] Applies to: npm:longest-streak@3.1.0, npm:stringify-entities@4.0.4, npm:trim-lines@3.0.1
 ------------------------------------------------------------------------------
 (The MIT License)
 
@@ -35299,7 +36147,7 @@ TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
 SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[352] Applies to: npm:loudness@0.4.2
+[375] Applies to: npm:loudness@0.4.2
 ------------------------------------------------------------------------------
 The MIT License (MIT)
 
@@ -35323,7 +36171,7 @@ IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
 CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[353] Applies to: npm:lru-cache@10.4.3
+[376] Applies to: npm:lru-cache@10.4.3
 ------------------------------------------------------------------------------
 The ISC License
 
@@ -35342,7 +36190,7 @@ ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF OR
 IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
 
 ------------------------------------------------------------------------------
-[354] Applies to: npm:lucide-react@0.468.0
+[377] Applies to: npm:lucide-react@0.468.0
 ------------------------------------------------------------------------------
 ISC License
 
@@ -35361,7 +36209,7 @@ ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
 OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
 
 ------------------------------------------------------------------------------
-[355] Applies to: npm:magic-bytes.js@1.13.0
+[378] Applies to: npm:magic-bytes.js@1.13.0
 ------------------------------------------------------------------------------
 MIT License
 
@@ -35386,7 +36234,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
 ------------------------------------------------------------------------------
-[356] Applies to: npm:marked@16.4.2
+[379] Applies to: npm:marked@16.4.2
 ------------------------------------------------------------------------------
 # License information
 
@@ -35434,7 +36282,7 @@ Redistribution and use in source and binary forms, with or without modification,
 This software is provided by the copyright holders and contributors “as is” and any express or implied warranties, including, but not limited to, the implied warranties of merchantability and fitness for a particular purpose are disclaimed. In no event shall the copyright owner or contributors be liable for any direct, indirect, incidental, special, exemplary, or consequential damages (including, but not limited to, procurement of substitute goods or services; loss of use, data, or profits; or business interruption) however caused and on any theory of liability, whether in contract, strict liability, or tort (including negligence or otherwise) arising in any way out of the use of this software, even if advised of the possibility of such damage.
 
 ------------------------------------------------------------------------------
-[357] Applies to: npm:md5@2.3.0
+[380] Applies to: npm:md5@2.3.0
 ------------------------------------------------------------------------------
 Copyright © 2011-2012, Paul Vorbach.
 Copyright © 2009, Jeff Mott.
@@ -35465,7 +36313,7 @@ ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
 SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 ------------------------------------------------------------------------------
-[358] Applies to: npm:mdast-util-phrasing@4.1.0
+[381] Applies to: npm:mdast-util-phrasing@4.1.0
 ------------------------------------------------------------------------------
 (The MIT License)
 
@@ -35492,7 +36340,7 @@ TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
 SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[359] Applies to: npm:mdast-util-to-markdown-cjk-friendly@1.0.0, npm:remark-cjk-friendly@2.3.1
+[382] Applies to: npm:mdast-util-to-markdown-cjk-friendly@1.0.0, npm:remark-cjk-friendly@2.3.1
 ------------------------------------------------------------------------------
 Copyright (c) 2025 Tatsunori Uchino <tats.u@live.jp>
 
@@ -35524,7 +36372,7 @@ TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
 SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[360] Applies to: npm:merge-descriptors@2.0.0
+[383] Applies to: npm:merge-descriptors@2.0.0
 ------------------------------------------------------------------------------
 MIT License
 
@@ -35539,7 +36387,7 @@ The above copyright notice and this permission notice shall be included in all c
 THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[361] Applies to: npm:merge-stream@2.0.0
+[384] Applies to: npm:merge-stream@2.0.0
 ------------------------------------------------------------------------------
 The MIT License (MIT)
 
@@ -35564,7 +36412,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[362] Applies to: npm:mermaid@11.16.0
+[385] Applies to: npm:mermaid@11.16.0
 ------------------------------------------------------------------------------
 The MIT License (MIT)
 
@@ -35589,7 +36437,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
 ------------------------------------------------------------------------------
-[363] Applies to: npm:micromark-extension-cjk-friendly@2.0.1
+[386] Applies to: npm:micromark-extension-cjk-friendly@2.0.1
 ------------------------------------------------------------------------------
 Copyright (c) 2025 Tatsunori Uchino <tats.u@live.jp>
 
@@ -35621,7 +36469,7 @@ TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
 SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[364] Applies to: npm:micromark-extension-cjk-friendly-util@3.0.1
+[387] Applies to: npm:micromark-extension-cjk-friendly-util@3.0.1
 ------------------------------------------------------------------------------
 Copyright (c) 2025 Tatsunori Uchino <tats.u@live.jp>
 
@@ -35653,7 +36501,7 @@ TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
 SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[365] Applies to: npm:micromark-extension-gfm-footnote@2.1.0
+[388] Applies to: npm:micromark-extension-gfm-footnote@2.1.0
 ------------------------------------------------------------------------------
 (The MIT License)
 
@@ -35679,7 +36527,7 @@ TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
 SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[366] Applies to: npm:mime-db@1.52.0, npm:mime-db@1.54.0
+[389] Applies to: npm:mime-db@1.52.0, npm:mime-db@1.54.0
 ------------------------------------------------------------------------------
 (The MIT License)
 
@@ -35706,7 +36554,24 @@ TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
 SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[367] Applies to: npm:minimatch@9.0.9, npm:rimraf@5.0.10
+[390] Applies to: npm:minimalistic-assert@1.0.1
+------------------------------------------------------------------------------
+Copyright 2015 Calvin Metcalf
+
+Permission to use, copy, modify, and/or distribute this software for any purpose
+with or without fee is hereby granted, provided that the above copyright notice
+and this permission notice appear in all copies.
+
+THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES WITH
+REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF MERCHANTABILITY AND
+FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY SPECIAL, DIRECT,
+INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES WHATSOEVER RESULTING FROM
+LOSS OF USE, DATA OR PROFITS, WHETHER IN AN ACTION OF CONTRACT, NEGLIGENCE
+OR OTHER TORTIOUS ACTION, ARISING OUT OF OR IN CONNECTION WITH THE USE OR
+PERFORMANCE OF THIS SOFTWARE.
+
+------------------------------------------------------------------------------
+[391] Applies to: npm:minimatch@5.1.9, npm:minimatch@9.0.9, npm:rimraf@5.0.10
 ------------------------------------------------------------------------------
 The ISC License
 
@@ -35725,7 +36590,7 @@ ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF OR
 IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
 
 ------------------------------------------------------------------------------
-[368] Applies to: npm:minipass@7.1.3, npm:path-scurry@1.11.1, npm:tar@7.5.22
+[392] Applies to: npm:minipass@7.1.3, npm:path-scurry@1.11.1, npm:sax@1.6.0, npm:tar@7.5.22
 ------------------------------------------------------------------------------
 # Blue Oak Model License
 
@@ -35784,7 +36649,7 @@ will be liable to anyone for any damages related to this
 software or this license, under any kind of legal claim.***
 
 ------------------------------------------------------------------------------
-[369] Applies to: npm:minizlib@3.1.0
+[393] Applies to: npm:minizlib@3.1.0
 ------------------------------------------------------------------------------
 Minizlib was created by Isaac Z. Schlueter.
 It is a derivative work of the Node.js project.
@@ -35814,7 +36679,7 @@ SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 """
 
 ------------------------------------------------------------------------------
-[370] Applies to: npm:mkdirp@0.5.6
+[394] Applies to: npm:mkdirp@0.5.6
 ------------------------------------------------------------------------------
 Copyright 2010 James Halliday (mail@substack.net)
 
@@ -35839,7 +36704,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[371] Applies to: npm:mkdirp-classic@0.5.3
+[395] Applies to: npm:mkdirp-classic@0.5.3
 ------------------------------------------------------------------------------
 The MIT License (MIT)
 
@@ -35864,7 +36729,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[372] Applies to: npm:ms@2.0.0
+[396] Applies to: npm:ms@2.0.0
 ------------------------------------------------------------------------------
 The MIT License (MIT)
 
@@ -35889,7 +36754,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
 ------------------------------------------------------------------------------
-[373] Applies to: npm:ms@2.1.3
+[397] Applies to: npm:ms@2.1.3
 ------------------------------------------------------------------------------
 The MIT License (MIT)
 
@@ -35914,7 +36779,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
 ------------------------------------------------------------------------------
-[374] Applies to: npm:nan@2.28.0
+[398] Applies to: npm:nan@2.28.0
 ------------------------------------------------------------------------------
 The MIT License (MIT)
 
@@ -35927,7 +36792,31 @@ The above copyright notice and this permission notice shall be included in all c
 THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[375] Applies to: npm:napi-build-utils@2.0.0
+[399] Applies to: npm:nanoid@5.1.16
+------------------------------------------------------------------------------
+The MIT License (MIT)
+
+Copyright 2017 Andrey Sitnik <andrey@sitnik.es>
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of
+this software and associated documentation files (the "Software"), to deal in
+the Software without restriction, including without limitation the rights to
+use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+the Software, and to permit persons to whom the Software is furnished to do so,
+subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+------------------------------------------------------------------------------
+[400] Applies to: npm:napi-build-utils@2.0.0
 ------------------------------------------------------------------------------
 MIT License
 
@@ -35952,7 +36841,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
 ------------------------------------------------------------------------------
-[376] Applies to: npm:negotiator@1.0.0
+[401] Applies to: npm:negotiator@1.0.0
 ------------------------------------------------------------------------------
 (The MIT License)
 
@@ -35980,7 +36869,7 @@ TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
 SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[377] Applies to: npm:node-abi@3.94.0
+[402] Applies to: npm:node-abi@3.94.0
 ------------------------------------------------------------------------------
 MIT License
 
@@ -36005,7 +36894,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
 ------------------------------------------------------------------------------
-[378] Applies to: npm:node-addon-api@7.1.1
+[403] Applies to: npm:node-addon-api@7.1.1
 ------------------------------------------------------------------------------
 The MIT License (MIT)
 
@@ -36018,7 +36907,7 @@ The above copyright notice and this permission notice shall be included in all c
 THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[379] Applies to: npm:node-domexception@1.0.0
+[404] Applies to: npm:node-domexception@1.0.0
 ------------------------------------------------------------------------------
 MIT License
 
@@ -36043,7 +36932,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
 ------------------------------------------------------------------------------
-[380] Applies to: npm:node-fetch@3.3.2
+[405] Applies to: npm:node-fetch@3.3.2
 ------------------------------------------------------------------------------
 The MIT License (MIT)
 
@@ -36068,7 +36957,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
 ------------------------------------------------------------------------------
-[381] Applies to: npm:node-machine-id@1.1.12
+[406] Applies to: npm:node-machine-id@1.1.12
 ------------------------------------------------------------------------------
 The MIT License (MIT)
 
@@ -36093,7 +36982,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
 ------------------------------------------------------------------------------
-[382] Applies to: npm:node-pty@1.1.0
+[407] Applies to: npm:node-pty@1.1.0
 ------------------------------------------------------------------------------
 Copyright (c) 2012-2015, Christopher Jeffrey (https://github.com/chjj/)
 
@@ -36166,7 +37055,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
 ------------------------------------------------------------------------------
-[383] Applies to: npm:object-inspect@1.13.4
+[408] Applies to: npm:object-inspect@1.13.4
 ------------------------------------------------------------------------------
 MIT License
 
@@ -36191,7 +37080,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
 ------------------------------------------------------------------------------
-[384] Applies to: npm:on-finished@2.4.1
+[409] Applies to: npm:on-finished@2.4.1
 ------------------------------------------------------------------------------
 (The MIT License)
 
@@ -36218,7 +37107,7 @@ TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
 SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[385] Applies to: npm:orderedmap@2.1.1, npm:w3c-keyname@2.2.8
+[410] Applies to: npm:orderedmap@2.1.1, npm:w3c-keyname@2.2.8
 ------------------------------------------------------------------------------
 Copyright (C) 2016 by Marijn Haverbeke <marijn@haverbeke.berlin> and others
 
@@ -36241,7 +37130,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[386] Applies to: npm:package-manager-detector@1.7.0
+[411] Applies to: npm:package-manager-detector@1.7.0
 ------------------------------------------------------------------------------
 MIT License
 
@@ -36266,7 +37155,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
 ------------------------------------------------------------------------------
-[387] Applies to: npm:pako@1.0.11
+[412] Applies to: npm:pako@1.0.11
 ------------------------------------------------------------------------------
 (The MIT License)
 
@@ -36291,7 +37180,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[388] Applies to: npm:parse-entities@4.0.2, npm:property-information@7.2.0
+[413] Applies to: npm:parse-entities@4.0.2, npm:property-information@7.2.0
 ------------------------------------------------------------------------------
 (The MIT License)
 
@@ -36317,7 +37206,7 @@ TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
 SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[389] Applies to: npm:parse5@7.3.0
+[414] Applies to: npm:parse5@7.3.0
 ------------------------------------------------------------------------------
 Copyright (c) 2013-2019 Ivan Nikulin (ifaaan@gmail.com, https://github.com/inikulin)
 
@@ -36340,7 +37229,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[390] Applies to: npm:parseurl@1.3.3
+[415] Applies to: npm:parseurl@1.3.3
 ------------------------------------------------------------------------------
 (The MIT License)
 
@@ -36367,7 +37256,7 @@ TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
 SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[391] Applies to: npm:path-data-parser@0.1.0, npm:points-on-curve@0.2.0
+[416] Applies to: npm:path-data-parser@0.1.0, npm:points-on-curve@0.2.0
 ------------------------------------------------------------------------------
 MIT License
 
@@ -36392,7 +37281,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
 ------------------------------------------------------------------------------
-[392] Applies to: npm:path-to-regexp@8.4.2
+[417] Applies to: npm:path-to-regexp@8.4.2
 ------------------------------------------------------------------------------
 The MIT License (MIT)
 
@@ -36417,7 +37306,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[393] Applies to: npm:pdfjs-dist@5.7.284
+[418] Applies to: npm:pdfjs-dist@5.7.284
 ------------------------------------------------------------------------------
 Apache License
                            Version 2.0, January 2004
@@ -36597,7 +37486,7 @@ Apache License
    END OF TERMS AND CONDITIONS
 
 ------------------------------------------------------------------------------
-[394] Applies to: npm:picomatch@4.0.5
+[419] Applies to: npm:picomatch@4.0.5
 ------------------------------------------------------------------------------
 The MIT License (MIT)
 
@@ -36622,7 +37511,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[395] Applies to: npm:pkce-challenge@5.0.1
+[420] Applies to: npm:pkce-challenge@5.0.1
 ------------------------------------------------------------------------------
 MIT License
 
@@ -36647,7 +37536,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
 ------------------------------------------------------------------------------
-[396] Applies to: npm:playwright-core@1.60.0
+[421] Applies to: npm:playwright-core@1.60.0
 ------------------------------------------------------------------------------
 Apache License
                            Version 2.0, January 2004
@@ -36853,7 +37742,7 @@ Apache License
    limitations under the License.
 
 ------------------------------------------------------------------------------
-[397] Applies to: npm:playwright-core@1.60.0 (NOTICE)
+[422] Applies to: npm:playwright-core@1.60.0 (NOTICE)
 ------------------------------------------------------------------------------
 NOTICE for npm:playwright-core@1.60.0:
 
@@ -36864,7 +37753,7 @@ This software contains code derived from the Puppeteer project (https://github.c
 available under the Apache 2.0 license (https://github.com/puppeteer/puppeteer/blob/master/LICENSE).
 
 ------------------------------------------------------------------------------
-[398] Applies to: npm:pngjs@5.0.0
+[423] Applies to: npm:pngjs@5.0.0
 ------------------------------------------------------------------------------
 pngjs2 original work Copyright (c) 2015 Luke Page & Original Contributors
 pngjs derived work Copyright (c) 2012 Kuba Niegowski
@@ -36888,7 +37777,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[399] Applies to: npm:points-on-path@0.2.1
+[424] Applies to: npm:points-on-path@0.2.1
 ------------------------------------------------------------------------------
 MIT License
 
@@ -36913,7 +37802,32 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
 ------------------------------------------------------------------------------
-[400] Applies to: npm:prebuild-install@7.1.3
+[425] Applies to: npm:pptxgenjs@4.0.1
+------------------------------------------------------------------------------
+The MIT License (MIT)
+
+Copyright (c) 2015-2022 Brent Ely
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+
+------------------------------------------------------------------------------
+[426] Applies to: npm:prebuild-install@7.1.3
 ------------------------------------------------------------------------------
 The MIT License (MIT)
 
@@ -36938,7 +37852,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[401] Applies to: npm:process-nextick-args@2.0.1
+[427] Applies to: npm:process-nextick-args@2.0.1
 ------------------------------------------------------------------------------
 # Copyright (c) 2015 Calvin Metcalf
 
@@ -36961,7 +37875,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.**
 
 ------------------------------------------------------------------------------
-[402] Applies to: npm:promise-worker-transferable@1.0.4
+[428] Applies to: npm:promise-worker-transferable@1.0.4
 ------------------------------------------------------------------------------
 Apache License
                           Version 2.0, January 2004
@@ -37166,7 +38080,7 @@ Apache License
   limitations under the License.
 
 ------------------------------------------------------------------------------
-[403] Applies to: npm:prosemirror-changeset@2.4.1
+[429] Applies to: npm:prosemirror-changeset@2.4.1
 ------------------------------------------------------------------------------
 Copyright (C) 2017 by Marijn Haverbeke <marijn@haverbeke.berlin> and others
 
@@ -37189,7 +38103,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[404] Applies to: npm:prosemirror-commands@1.7.1, npm:prosemirror-dropcursor@1.8.3, npm:prosemirror-gapcursor@1.4.1, npm:prosemirror-history@1.5.0, npm:prosemirror-inputrules@1.5.1, npm:prosemirror-keymap@1.2.3, npm:prosemirror-model@1.25.11, npm:prosemirror-schema-list@1.5.1, npm:prosemirror-state@1.4.4, npm:prosemirror-transform@1.12.0, npm:prosemirror-view@1.42.1
+[430] Applies to: npm:prosemirror-commands@1.7.1, npm:prosemirror-dropcursor@1.8.3, npm:prosemirror-gapcursor@1.4.1, npm:prosemirror-history@1.5.0, npm:prosemirror-inputrules@1.5.1, npm:prosemirror-keymap@1.2.3, npm:prosemirror-model@1.25.11, npm:prosemirror-schema-list@1.5.1, npm:prosemirror-state@1.4.4, npm:prosemirror-transform@1.12.0, npm:prosemirror-view@1.42.1
 ------------------------------------------------------------------------------
 Copyright (C) 2015-2017 by Marijn Haverbeke <marijn@haverbeke.berlin> and others
 
@@ -37212,7 +38126,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[405] Applies to: npm:prosemirror-tables@1.8.5
+[431] Applies to: npm:prosemirror-tables@1.8.5
 ------------------------------------------------------------------------------
 Copyright (C) 2015-2016 by Marijn Haverbeke <marijnh@gmail.com> and others
 
@@ -37235,7 +38149,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[406] Applies to: npm:protobufjs@7.6.5
+[432] Applies to: npm:protobufjs@7.6.5
 ------------------------------------------------------------------------------
 This license applies to all parts of protobuf.js except those files
 either explicitly including or referencing a different license or
@@ -37278,7 +38192,7 @@ standalone and requires a support library to be linked with it. This
 support library is itself covered by the above license.
 
 ------------------------------------------------------------------------------
-[407] Applies to: npm:proxy-from-env@2.1.0
+[433] Applies to: npm:proxy-from-env@2.1.0
 ------------------------------------------------------------------------------
 The MIT License
 
@@ -37302,7 +38216,7 @@ IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
 CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[408] Applies to: npm:qrcode@1.5.4
+[434] Applies to: npm:qrcode@1.5.4
 ------------------------------------------------------------------------------
 The MIT License (MIT)
 
@@ -37315,7 +38229,7 @@ The above copyright notice and this permission notice shall be included in all c
 THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[409] Applies to: npm:qs@6.15.3
+[435] Applies to: npm:qs@6.15.3
 ------------------------------------------------------------------------------
 BSD 3-Clause License
 
@@ -37348,7 +38262,19 @@ OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 ------------------------------------------------------------------------------
-[410] Applies to: npm:range-parser@1.3.0
+[436] Applies to: npm:queue@6.0.2
+------------------------------------------------------------------------------
+The MIT License (MIT)
+Copyright (c) 2014 Jesse Tane <jesse.tane@gmail.com>
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+------------------------------------------------------------------------------
+[437] Applies to: npm:range-parser@1.3.0
 ------------------------------------------------------------------------------
 (The MIT License)
 
@@ -37375,7 +38301,7 @@ TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
 SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[411] Applies to: npm:raw-body@3.0.2
+[438] Applies to: npm:raw-body@3.0.2
 ------------------------------------------------------------------------------
 The MIT License (MIT)
 
@@ -37401,7 +38327,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[412] Applies to: npm:rc@1.2.8
+[439] Applies to: npm:rc@1.2.8
 ------------------------------------------------------------------------------
 Apache License, Version 2.0
 
@@ -37472,7 +38398,7 @@ TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
 SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[413] Applies to: npm:react@19.2.3, npm:react-dom@19.2.3, npm:scheduler@0.27.0, npm:use-sync-external-store@1.6.0
+[440] Applies to: npm:react@19.2.3, npm:react-dom@19.2.3, npm:scheduler@0.27.0, npm:use-sync-external-store@1.6.0
 ------------------------------------------------------------------------------
 MIT License
 
@@ -37497,7 +38423,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
 ------------------------------------------------------------------------------
-[414] Applies to: npm:react-i18next@17.0.10
+[441] Applies to: npm:react-i18next@17.0.10
 ------------------------------------------------------------------------------
 The MIT License (MIT)
 
@@ -37522,7 +38448,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
 ------------------------------------------------------------------------------
-[415] Applies to: npm:react-markdown@10.1.0
+[442] Applies to: npm:react-markdown@10.1.0
 ------------------------------------------------------------------------------
 The MIT License (MIT)
 
@@ -37547,7 +38473,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
 ------------------------------------------------------------------------------
-[416] Applies to: npm:react-router@7.18.1, npm:react-router-dom@7.18.1
+[443] Applies to: npm:react-router@7.18.1, npm:react-router-dom@7.18.1
 ------------------------------------------------------------------------------
 MIT License
 
@@ -37574,7 +38500,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
 ------------------------------------------------------------------------------
-[417] Applies to: npm:readable-stream@2.3.8, npm:readable-stream@3.6.2, npm:string_decoder@1.1.1, npm:string_decoder@1.3.0
+[444] Applies to: npm:readable-stream@2.3.8, npm:readable-stream@3.6.2, npm:string_decoder@1.1.1, npm:string_decoder@1.3.0
 ------------------------------------------------------------------------------
 Node.js is licensed for use as follows:
 
@@ -37625,7 +38551,212 @@ IN THE SOFTWARE.
 """
 
 ------------------------------------------------------------------------------
-[418] Applies to: npm:remark-parse@11.0.0, npm:remark-stringify@11.0.0
+[445] Applies to: npm:readdir-glob@1.1.3
+------------------------------------------------------------------------------
+Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright 2020 Yann Armelin
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+
+------------------------------------------------------------------------------
+[446] Applies to: npm:remark-parse@11.0.0, npm:remark-stringify@11.0.0
 ------------------------------------------------------------------------------
 (The MIT License)
 
@@ -37650,7 +38781,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[419] Applies to: npm:require-directory@2.1.1
+[447] Applies to: npm:require-directory@2.1.1
 ------------------------------------------------------------------------------
 The MIT License (MIT)
 
@@ -37676,7 +38807,7 @@ TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
 SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[420] Applies to: npm:require-from-string@2.0.2
+[448] Applies to: npm:require-from-string@2.0.2
 ------------------------------------------------------------------------------
 The MIT License (MIT)
 
@@ -37701,7 +38832,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[421] Applies to: npm:require-main-filename@2.0.0, npm:set-blocking@2.0.0, npm:yargs-parser@18.1.3
+[449] Applies to: npm:require-main-filename@2.0.0, npm:set-blocking@2.0.0, npm:yargs-parser@18.1.3
 ------------------------------------------------------------------------------
 Copyright (c) 2016, Contributors
 
@@ -37719,35 +38850,7 @@ WHETHER IN AN ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION,
 ARISING OUT OF OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
 
 ------------------------------------------------------------------------------
-[422] Applies to: npm:robust-predicates@3.0.3, npm:tweetnacl@0.14.5
-------------------------------------------------------------------------------
-This is free and unencumbered software released into the public domain.
-
-Anyone is free to copy, modify, publish, use, compile, sell, or
-distribute this software, either in source code form or as a compiled
-binary, for any purpose, commercial or non-commercial, and by any
-means.
-
-In jurisdictions that recognize copyright laws, the author or authors
-of this software dedicate any and all copyright interest in the
-software to the public domain. We make this dedication for the benefit
-of the public at large and to the detriment of our heirs and
-successors. We intend this dedication to be an overt act of
-relinquishment in perpetuity of all present and future rights to this
-software under copyright law.
-
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
-EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
-MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
-IN NO EVENT SHALL THE AUTHORS BE LIABLE FOR ANY CLAIM, DAMAGES OR
-OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
-ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
-OTHER DEALINGS IN THE SOFTWARE.
-
-For more information, please refer to <http://unlicense.org>
-
-------------------------------------------------------------------------------
-[423] Applies to: npm:rope-sequence@1.3.4
+[450] Applies to: npm:rope-sequence@1.3.4
 ------------------------------------------------------------------------------
 Copyright (C) 2016 by Marijn Haverbeke <marijn@haverbeke.berlin>
 
@@ -37770,7 +38873,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[424] Applies to: npm:roughjs@4.6.6
+[451] Applies to: npm:roughjs@4.6.6
 ------------------------------------------------------------------------------
 MIT License
 
@@ -37795,7 +38898,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
 ------------------------------------------------------------------------------
-[425] Applies to: npm:router@2.2.0
+[452] Applies to: npm:router@2.2.0
 ------------------------------------------------------------------------------
 (The MIT License)
 
@@ -37822,7 +38925,7 @@ TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
 SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[426] Applies to: npm:rw@1.3.3
+[453] Applies to: npm:rw@1.3.3
 ------------------------------------------------------------------------------
 Copyright (c) 2014-2016, Michael Bostock
 All rights reserved.
@@ -37852,7 +38955,7 @@ NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE,
 EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 ------------------------------------------------------------------------------
-[427] Applies to: npm:safer-buffer@2.1.2
+[454] Applies to: npm:safer-buffer@2.1.2
 ------------------------------------------------------------------------------
 MIT License
 
@@ -37877,7 +38980,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
 ------------------------------------------------------------------------------
-[428] Applies to: npm:section-matter@1.0.0
+[455] Applies to: npm:section-matter@1.0.0
 ------------------------------------------------------------------------------
 The MIT License (MIT)
 
@@ -37902,7 +39005,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
 ------------------------------------------------------------------------------
-[429] Applies to: npm:send@1.2.1
+[456] Applies to: npm:send@1.2.1
 ------------------------------------------------------------------------------
 (The MIT License)
 
@@ -37929,7 +39032,7 @@ TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
 SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[430] Applies to: npm:serve-static@2.2.1
+[457] Applies to: npm:serve-static@2.2.1
 ------------------------------------------------------------------------------
 (The MIT License)
 
@@ -37958,7 +39061,7 @@ TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
 SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[431] Applies to: npm:set-cookie-parser@2.7.2
+[458] Applies to: npm:set-cookie-parser@2.7.2
 ------------------------------------------------------------------------------
 The MIT License (MIT)
 
@@ -37983,7 +39086,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[432] Applies to: npm:setimmediate@1.0.5
+[459] Applies to: npm:setimmediate@1.0.5
 ------------------------------------------------------------------------------
 Copyright (c) 2012 Barnesandnoble.com, llc, Donavon West, and Domenic Denicola
 
@@ -38007,7 +39110,7 @@ OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
 WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[433] Applies to: npm:setprototypeof@1.2.0
+[460] Applies to: npm:setprototypeof@1.2.0
 ------------------------------------------------------------------------------
 Copyright (c) 2015, Wes Todd
 
@@ -38024,7 +39127,7 @@ OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF OR IN
 CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
 
 ------------------------------------------------------------------------------
-[434] Applies to: npm:shebang-command@2.0.0
+[461] Applies to: npm:shebang-command@2.0.0
 ------------------------------------------------------------------------------
 MIT License
 
@@ -38037,7 +39140,7 @@ The above copyright notice and this permission notice shall be included in all c
 THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[435] Applies to: npm:side-channel@1.1.1, npm:side-channel-weakmap@1.0.2
+[462] Applies to: npm:side-channel@1.1.1, npm:side-channel-weakmap@1.0.2
 ------------------------------------------------------------------------------
 MIT License
 
@@ -38062,7 +39165,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
 ------------------------------------------------------------------------------
-[436] Applies to: npm:signal-exit@3.0.7
+[463] Applies to: npm:signal-exit@3.0.7
 ------------------------------------------------------------------------------
 The ISC License
 
@@ -38082,7 +39185,7 @@ WHETHER IN AN ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION,
 ARISING OUT OF OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
 
 ------------------------------------------------------------------------------
-[437] Applies to: npm:signal-exit@4.1.0
+[464] Applies to: npm:signal-exit@4.1.0
 ------------------------------------------------------------------------------
 The ISC License
 
@@ -38102,7 +39205,7 @@ WHETHER IN AN ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION,
 ARISING OUT OF OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
 
 ------------------------------------------------------------------------------
-[438] Applies to: npm:silk-wasm@3.7.1
+[465] Applies to: npm:silk-wasm@3.7.1
 ------------------------------------------------------------------------------
 MIT License
 
@@ -38127,7 +39230,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
 ------------------------------------------------------------------------------
-[439] Applies to: npm:simple-concat@1.0.1, npm:simple-get@4.0.1
+[466] Applies to: npm:simple-concat@1.0.1, npm:simple-get@4.0.1
 ------------------------------------------------------------------------------
 The MIT License (MIT)
 
@@ -38151,7 +39254,7 @@ IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
 CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[440] Applies to: npm:smol-toml@1.7.0
+[467] Applies to: npm:smol-toml@1.7.0
 ------------------------------------------------------------------------------
 Copyright (c) Squirrel Chat et al., All rights reserved.
 
@@ -38179,7 +39282,7 @@ OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 ------------------------------------------------------------------------------
-[441] Applies to: npm:sortablejs@1.15.7
+[468] Applies to: npm:sortablejs@1.15.7
 ------------------------------------------------------------------------------
 MIT License
 
@@ -38204,7 +39307,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
 ------------------------------------------------------------------------------
-[442] Applies to: npm:sprintf-js@1.0.3
+[469] Applies to: npm:sprintf-js@1.0.3
 ------------------------------------------------------------------------------
 Copyright (c) 2007-2014, Alexandru Marasteanu <hello [at) alexei (dot] ro>
 All rights reserved.
@@ -38232,7 +39335,7 @@ ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
 SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 ------------------------------------------------------------------------------
-[443] Applies to: npm:ssh-config@5.2.0
+[470] Applies to: npm:ssh-config@5.2.0
 ------------------------------------------------------------------------------
 MIT License
 
@@ -38257,7 +39360,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
 ------------------------------------------------------------------------------
-[444] Applies to: npm:statuses@2.0.2
+[471] Applies to: npm:statuses@2.0.2
 ------------------------------------------------------------------------------
 The MIT License (MIT)
 
@@ -38283,7 +39386,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[445] Applies to: npm:strip-bom-string@1.0.0
+[472] Applies to: npm:strip-bom-string@1.0.0
 ------------------------------------------------------------------------------
 The MIT License (MIT)
 
@@ -38308,7 +39411,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[446] Applies to: npm:style-mod@4.1.3
+[473] Applies to: npm:style-mod@4.1.3
 ------------------------------------------------------------------------------
 Copyright (C) 2018 by Marijn Haverbeke <marijn@haverbeke.berlin> and others
 
@@ -38331,7 +39434,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[447] Applies to: npm:style-to-js@1.1.21
+[474] Applies to: npm:style-to-js@1.1.21
 ------------------------------------------------------------------------------
 The MIT License (MIT)
 
@@ -38357,7 +39460,7 @@ OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
 WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[448] Applies to: npm:style-to-object@1.0.14
+[475] Applies to: npm:style-to-object@1.0.14
 ------------------------------------------------------------------------------
 The MIT License (MIT)
 
@@ -38383,7 +39486,7 @@ OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
 WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[449] Applies to: npm:stylis@4.4.0
+[476] Applies to: npm:stylis@4.4.0
 ------------------------------------------------------------------------------
 MIT License
 
@@ -38408,7 +39511,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
 ------------------------------------------------------------------------------
-[450] Applies to: npm:tailwind-merge@2.6.1
+[477] Applies to: npm:tailwind-merge@2.6.1
 ------------------------------------------------------------------------------
 MIT License
 
@@ -38433,7 +39536,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
 ------------------------------------------------------------------------------
-[451] Applies to: npm:tinyexec@1.2.4
+[478] Applies to: npm:tinyexec@1.2.4
 ------------------------------------------------------------------------------
 MIT License
 
@@ -38458,7 +39561,32 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
 ------------------------------------------------------------------------------
-[452] Applies to: npm:toidentifier@1.0.1
+[479] Applies to: npm:tmp@0.2.7
+------------------------------------------------------------------------------
+The MIT License (MIT)
+
+Copyright (c) 2014 KARASZI István
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+
+------------------------------------------------------------------------------
+[480] Applies to: npm:toidentifier@1.0.1
 ------------------------------------------------------------------------------
 MIT License
 
@@ -38483,7 +39611,35 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
 ------------------------------------------------------------------------------
-[453] Applies to: npm:trough@2.2.0
+[481] Applies to: npm:traverse@0.3.9
+------------------------------------------------------------------------------
+Copyright 2010 James Halliday (mail@substack.net)
+
+This project is free software released under the MIT/X11 license:
+http://www.opensource.org/licenses/mit-license.php
+
+Copyright 2010 James Halliday (mail@substack.net)
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+
+------------------------------------------------------------------------------
+[482] Applies to: npm:trough@2.2.0
 ------------------------------------------------------------------------------
 (The MIT License)
 
@@ -38508,7 +39664,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[454] Applies to: npm:ts-dedent@2.3.0
+[483] Applies to: npm:ts-dedent@2.3.0
 ------------------------------------------------------------------------------
 MIT License
 
@@ -38533,7 +39689,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
 ------------------------------------------------------------------------------
-[455] Applies to: npm:ts-mixer@6.0.4
+[484] Applies to: npm:ts-mixer@6.0.4
 ------------------------------------------------------------------------------
 MIT License
 
@@ -38558,7 +39714,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
 ------------------------------------------------------------------------------
-[456] Applies to: npm:tslib@2.8.1
+[485] Applies to: npm:tslib@2.8.1
 ------------------------------------------------------------------------------
 Copyright (c) Microsoft Corporation.
 
@@ -38574,7 +39730,7 @@ OTHER TORTIOUS ACTION, ARISING OUT OF OR IN CONNECTION WITH THE USE OR
 PERFORMANCE OF THIS SOFTWARE.
 
 ------------------------------------------------------------------------------
-[457] Applies to: npm:tslog@4.11.0
+[486] Applies to: npm:tslog@4.11.0
 ------------------------------------------------------------------------------
 MIT License
 
@@ -38599,7 +39755,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
 ------------------------------------------------------------------------------
-[458] Applies to: npm:tunnel-agent@0.6.0
+[487] Applies to: npm:tunnel-agent@0.6.0
 ------------------------------------------------------------------------------
 Apache License
 
@@ -38658,7 +39814,7 @@ If the Work includes a "NOTICE" text file as part of its distribution, then any 
 END OF TERMS AND CONDITIONS
 
 ------------------------------------------------------------------------------
-[459] Applies to: npm:type-fest@0.20.2
+[488] Applies to: npm:type-fest@0.20.2
 ------------------------------------------------------------------------------
 MIT License
 
@@ -38671,7 +39827,7 @@ The above copyright notice and this permission notice shall be included in all c
 THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[460] Applies to: npm:typebox@1.1.39
+[489] Applies to: npm:typebox@1.1.39
 ------------------------------------------------------------------------------
 TypeBox
 
@@ -38698,7 +39854,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[461] Applies to: npm:undici@6.27.0, npm:undici@8.7.0, npm:undici-types@7.24.6
+[490] Applies to: npm:undici@6.27.0, npm:undici@8.7.0, npm:undici-types@6.21.0, npm:undici-types@7.24.6
 ------------------------------------------------------------------------------
 MIT License
 
@@ -38723,7 +39879,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
 ------------------------------------------------------------------------------
-[462] Applies to: npm:unified@11.0.5, npm:vfile@6.0.3
+[491] Applies to: npm:unified@11.0.5, npm:vfile@6.0.3
 ------------------------------------------------------------------------------
 (The MIT License)
 
@@ -38748,7 +39904,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[463] Applies to: npm:unist-util-is@6.0.1
+[492] Applies to: npm:unist-util-is@6.0.1
 ------------------------------------------------------------------------------
 (The MIT license)
 
@@ -38774,7 +39930,7 @@ TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
 SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[464] Applies to: npm:universalify@2.0.1
+[493] Applies to: npm:universalify@2.0.1
 ------------------------------------------------------------------------------
 (The MIT License)
 
@@ -38798,7 +39954,7 @@ IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
 CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[465] Applies to: npm:unpipe@1.0.0
+[494] Applies to: npm:unpipe@1.0.0
 ------------------------------------------------------------------------------
 (The MIT License)
 
@@ -38824,7 +39980,36 @@ TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
 SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[466] Applies to: npm:uri-js@4.4.1
+[495] Applies to: npm:unzipper@0.10.14
+------------------------------------------------------------------------------
+Copyright (c) 2012 - 2013 Near Infinity Corporation
+
+Permission is hereby granted, free of charge, to any person obtaining
+a copy of this software and associated documentation files (the
+"Software"), to deal in the Software without restriction, including
+without limitation the rights to use, copy, modify, merge, publish,
+distribute, sublicense, and/or sell copies of the Software, and to
+permit persons to whom the Software is furnished to do so, subject to
+the following conditions:
+
+The above copyright notice and this permission notice shall be
+included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+---
+
+Commits in this fork are (c) Ziggy Jonsson (ziggy.jonsson.nyc@gmail.com)
+and fall under same licence structure as the original repo (MIT)
+
+------------------------------------------------------------------------------
+[496] Applies to: npm:uri-js@4.4.1
 ------------------------------------------------------------------------------
 Copyright 2011 Gary Court. All rights reserved.
 
@@ -38839,7 +40024,7 @@ THIS SOFTWARE IS PROVIDED BY GARY COURT "AS IS" AND ANY EXPRESS OR IMPLIED WARRA
 The views and conclusions contained in the software and documentation are those of the authors and should not be interpreted as representing official policies, either expressed or implied, of Gary Court.
 
 ------------------------------------------------------------------------------
-[467] Applies to: npm:url-template@2.0.8
+[497] Applies to: npm:url-template@2.0.8
 ------------------------------------------------------------------------------
 Copyright (c) 2012-2014, Bram Stein
 All rights reserved.
@@ -38868,7 +40053,7 @@ NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE,
 EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 ------------------------------------------------------------------------------
-[468] Applies to: npm:util-deprecate@1.0.2
+[498] Applies to: npm:util-deprecate@1.0.2
 ------------------------------------------------------------------------------
 (The MIT License)
 
@@ -38896,7 +40081,7 @@ FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
 OTHER DEALINGS IN THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[469] Applies to: npm:uuid@14.0.1
+[499] Applies to: npm:uuid@14.0.1, npm:uuid@8.3.2
 ------------------------------------------------------------------------------
 The MIT License (MIT)
 
@@ -38909,7 +40094,7 @@ The above copyright notice and this permission notice shall be included in all c
 THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[470] Applies to: npm:void-elements@3.1.0
+[500] Applies to: npm:void-elements@3.1.0
 ------------------------------------------------------------------------------
 (The MIT License)
 
@@ -38935,7 +40120,7 @@ TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
 SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[471] Applies to: npm:web-streams-polyfill@3.3.3
+[501] Applies to: npm:web-streams-polyfill@3.3.3
 ------------------------------------------------------------------------------
 The MIT License (MIT)
 
@@ -38961,7 +40146,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
 ------------------------------------------------------------------------------
-[472] Applies to: npm:which-module@2.0.1
+[502] Applies to: npm:which-module@2.0.1
 ------------------------------------------------------------------------------
 Copyright (c) 2016, Contributors
 
@@ -38978,7 +40163,7 @@ TORTIOUS ACTION, ARISING OUT OF OR IN CONNECTION WITH THE USE OR PERFORMANCE OF
 THIS SOFTWARE.
 
 ------------------------------------------------------------------------------
-[473] Applies to: npm:workerpool@9.1.1
+[503] Applies to: npm:workerpool@9.1.1
 ------------------------------------------------------------------------------
 Apache License
                            Version 2.0, January 2004
@@ -39183,7 +40368,7 @@ Apache License
    limitations under the License.
 
 ------------------------------------------------------------------------------
-[474] Applies to: npm:ws@8.21.1
+[504] Applies to: npm:ws@8.21.1
 ------------------------------------------------------------------------------
 Copyright (c) 2011 Einar Otto Stangvik <einaros@gmail.com>
 Copyright (c) 2013 Arnout Kazemier and contributors
@@ -39207,7 +40392,80 @@ IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
 CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[475] Applies to: npm:y18n@4.0.3
+[505] Applies to: npm:xml@1.0.1
+------------------------------------------------------------------------------
+(The MIT License)
+
+Copyright (c) 2011-2016 Dylan Greene <dylang@gmail.com>
+
+Permission is hereby granted, free of charge, to any person obtaining
+a copy of this software and associated documentation files (the
+'Software'), to deal in the Software without restriction, including
+without limitation the rights to use, copy, modify, merge, publish,
+distribute, sublicense, and/or sell copies of the Software, and to
+permit persons to whom the Software is furnished to do so, subject to
+the following conditions:
+
+The above copyright notice and this permission notice shall be
+included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED 'AS IS', WITHOUT WARRANTY OF ANY KIND,
+EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+------------------------------------------------------------------------------
+[506] Applies to: npm:xml-js@1.6.11
+------------------------------------------------------------------------------
+The MIT License (MIT)
+
+Copyright (c) 2016-2017 Yousuf Almarzooqi
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+
+------------------------------------------------------------------------------
+[507] Applies to: npm:xmlchars@2.2.0
+------------------------------------------------------------------------------
+Copyright Louis-Dominique Dubeau and contributors to xmlchars
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of
+this software and associated documentation files (the "Software"), to deal in
+the Software without restriction, including without limitation the rights to
+use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+the Software, and to permit persons to whom the Software is furnished to do so,
+subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+------------------------------------------------------------------------------
+[508] Applies to: npm:y18n@4.0.3
 ------------------------------------------------------------------------------
 Copyright (c) 2015, Contributors
 
@@ -39224,7 +40482,7 @@ TORTIOUS ACTION, ARISING OUT OF OR IN CONNECTION WITH THE USE OR PERFORMANCE OF
 THIS SOFTWARE.
 
 ------------------------------------------------------------------------------
-[476] Applies to: npm:yargs@15.4.1
+[509] Applies to: npm:yargs@15.4.1
 ------------------------------------------------------------------------------
 MIT License
 
@@ -39249,7 +40507,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[477] Applies to: npm:zod@4.3.6
+[510] Applies to: npm:zod@4.3.6
 ------------------------------------------------------------------------------
 MIT License
 
@@ -39274,7 +40532,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
 ------------------------------------------------------------------------------
-[478] Applies to: npm:zod-to-json-schema@3.25.2
+[511] Applies to: npm:zod-to-json-schema@3.25.2
 ------------------------------------------------------------------------------
 ISC License
 
@@ -39340,12 +40598,18 @@ Packages without a standalone license file (license per package.json):
 - npm:@sapphire/snowflake@3.5.5 (MIT)
 - npm:@wecom/aibot-node-sdk@1.0.7 (MIT)
 - npm:agent-base@6.0.2 (MIT)
+- npm:binary@0.3.0 (MIT)
+- npm:buffers@0.1.1 (MIT)
+- npm:chainsaw@0.1.0 (MIT)
 - npm:data-uri-to-buffer@4.0.1 (MIT)
 - npm:drizzle-orm@0.45.2 (Apache-2.0)
 - npm:eastasianwidth@0.2.0 (MIT)
+- npm:hash.js@1.1.7 (MIT)
 - npm:html-parse-stringify@3.0.1 (MIT)
+- npm:https@1.0.0 (ISC)
 - npm:https-proxy-agent@5.0.1 (MIT)
 - npm:isarray@1.0.0 (MIT)
 - npm:react-remove-scroll-bar@2.3.8 (MIT)
 - npm:rehype-katex@7.0.1 (MIT)
 - npm:remark-math@6.0.0 (MIT)
+- npm:saxes@5.0.1 (ISC)

--- a/apps/desktop/resources/THIRD-PARTY-RESTRICTED.txt
+++ b/apps/desktop/resources/THIRD-PARTY-RESTRICTED.txt
@@ -7,7 +7,7 @@ Cindy desktop application — all supported platforms
 This file separately discloses components not distributed under open-source licenses.
 
 ------------------------------------------------------------------------------
-Claude Code CLI@2.1.219
+Claude Code CLI@2.1.259
 Category: proprietary
 License: LicenseRef-Anthropic-Commercial-Terms
 Source: https://www.anthropic.com/legal/commercial-terms

--- a/docs/legal/notices/THIRD-PARTY-NOTICES.txt
+++ b/docs/legal/notices/THIRD-PARTY-NOTICES.txt
@@ -4002,7 +4002,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
 ------------------------------------------------------------------------------
-pi coding agent (runtime-downloaded binary) 0.83.0
+pi coding agent (runtime-downloaded binary) 0.84.4
 License: MIT
 Source: https://github.com/earendil-works/pi
 ------------------------------------------------------------------------------
@@ -4354,10 +4354,9 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
 ==============================================================================
-SECTION 2: npm packages (1323 packages)
+SECTION 2: npm packages (1395 packages)
 ==============================================================================
 
-- @adobe/css-tools@4.5.0 — MIT — https://github.com/adobe/css-tools
 - @antfu/install-pkg@1.1.0 — MIT — https://github.com/antfu/install-pkg
 - @anthropic-ai/sdk@0.91.1 — MIT — https://github.com/anthropics/anthropic-sdk-typescript
 - @babel/code-frame@7.29.7 — MIT — https://github.com/babel/babel
@@ -4461,44 +4460,43 @@ SECTION 2: npm packages (1323 packages)
 - @discordjs/rest@2.6.2 — Apache-2.0 — https://github.com/discordjs/discord.js
 - @discordjs/util@1.2.0 — Apache-2.0 — https://github.com/discordjs/discord.js
 - @discordjs/ws@1.2.3 — Apache-2.0 — https://github.com/discordjs/discord.js
+- @egjs/hammerjs@2.0.17 — MIT — https://github.com/naver/hammer.js
 - @expo-google-fonts/material-symbols@0.4.40 — MIT AND Apache-2.0 — https://github.com/expo/google-fonts
-- @expo/cli@56.1.20 — MIT — https://github.com/expo/expo
+- @expo/cli@57.0.19 — MIT — https://github.com/expo/expo
 - @expo/code-signing-certificates@0.0.6 — MIT — https://github.com/expo/code-signing-certificates
-- @expo/config@56.0.12 — MIT — https://github.com/expo/expo
-- @expo/config-plugins@56.0.13 — MIT — https://github.com/expo/expo
-- @expo/config-types@56.0.7 — MIT — https://github.com/expo/expo
+- @expo/config@57.0.9 — MIT — https://github.com/expo/expo
+- @expo/config-plugins@57.0.9 — MIT — https://github.com/expo/expo
+- @expo/config-types@57.0.2 — MIT — https://github.com/expo/expo
 - @expo/devcert@1.2.1 — MIT — https://github.com/expo/devcert
-- @expo/devtools@56.0.2 — MIT — https://github.com/expo/expo
-- @expo/dom-webview@56.0.6 — MIT — https://github.com/expo/expo
-- @expo/env@2.3.1 — MIT — https://github.com/expo/expo
+- @expo/devtools@57.0.1 — MIT — https://github.com/expo/expo
+- @expo/dom-webview@57.0.1 — MIT — https://github.com/expo/expo
 - @expo/env@2.4.2 — MIT — https://github.com/expo/expo
-- @expo/expo-modules-macros-plugin@0.2.2 — MIT — https://github.com/expo/expo-modules-macros-plugin
-- @expo/fingerprint@0.19.8 — MIT — https://github.com/expo/expo
-- @expo/image-utils@0.10.3 — MIT — https://github.com/expo/expo
-- @expo/image-utils@0.10.4 — MIT — https://github.com/expo/expo
-- @expo/inline-modules@0.0.14 — MIT — https://github.com/expo/expo
-- @expo/json-file@10.2.0 — MIT — https://github.com/expo/expo
+- @expo/expo-modules-macros-plugin@0.6.1 — MIT — https://github.com/expo/expo-modules-macros-plugin
+- @expo/fingerprint@0.20.10 — MIT — https://github.com/expo/expo
+- @expo/image-utils@0.11.5 — MIT — https://github.com/expo/expo
+- @expo/inline-modules@0.1.7 — MIT — https://github.com/expo/expo
 - @expo/json-file@11.0.1 — MIT — https://github.com/expo/expo
-- @expo/local-build-cache-provider@56.0.10 — MIT — https://github.com/expo/expo
-- @expo/log-box@56.0.14 — MIT — https://github.com/expo/expo/tree/main/packages/@expo/log-box
-- @expo/metro@56.0.0 — MIT — https://github.com/expo/expo-metro
-- @expo/metro-config@56.0.17 — MIT — https://github.com/expo/expo
-- @expo/metro-file-map@56.0.3 — MIT — https://github.com/expo/expo
-- @expo/metro-runtime@56.0.17 — MIT — https://github.com/expo/expo
+- @expo/local-build-cache-provider@57.0.8 — MIT — https://github.com/expo/expo
+- @expo/log-box@57.0.4 — MIT — https://github.com/expo/expo/tree/main/packages/@expo/log-box
+- @expo/metro@56.0.2 — MIT — https://github.com/expo/expo-metro
+- @expo/metro-config@57.0.11 — MIT — https://github.com/expo/expo
+- @expo/metro-file-map@57.0.2 — MIT — https://github.com/expo/expo
+- @expo/metro-runtime@57.0.14 — MIT — https://github.com/expo/expo
 - @expo/osascript@2.7.1 — MIT — https://github.com/expo/expo
 - @expo/package-manager@1.13.1 — MIT — https://github.com/expo/expo
-- @expo/plist@0.7.0 — MIT — https://github.com/expo/expo
-- @expo/prebuild-config@56.0.20 — MIT — https://github.com/expo/expo
-- @expo/require-utils@56.1.5 — MIT — https://github.com/expo/expo
-- @expo/require-utils@56.1.6 — MIT — https://github.com/expo/expo
-- @expo/router-server@56.0.16 — MIT — https://github.com/expo/expo
-- @expo/schema-utils@56.0.2 — MIT — https://github.com/expo/expo
+- @expo/plist@0.8.1 — MIT — https://github.com/expo/expo
+- @expo/prebuild-config@57.0.15 — MIT — https://github.com/expo/expo
+- @expo/require-utils@57.0.5 — MIT — https://github.com/expo/expo
+- @expo/router-server@57.0.8 — MIT — https://github.com/expo/expo
+- @expo/schema-utils@57.0.2 — MIT — https://github.com/expo/expo
 - @expo/sdk-runtime-versions@1.0.0 — MIT
 - @expo/spawn-async@1.8.0 — MIT — https://github.com/expo/spawn-async
 - @expo/sudo-prompt@9.3.2 — MIT — https://github.com/expo/sudo-prompt
-- @expo/ui@56.0.22 — MIT — https://github.com/expo/expo
+- @expo/ui@57.0.14 — MIT — https://github.com/expo/expo
 - @expo/ws-tunnel@2.0.0 — MIT
 - @expo/xcpretty@4.4.4 — BSD-3-Clause — https://github.com/expo/expo-cli
+- @fast-csv/format@4.3.5 — MIT — https://github.com/C2FO/fast-csv
+- @fast-csv/parse@4.3.6 — MIT — https://github.com/C2FO/fast-csv
 - @floating-ui/core@1.8.0 — MIT — https://github.com/floating-ui/floating-ui
 - @floating-ui/dom@1.8.0 — MIT — https://github.com/floating-ui/floating-ui
 - @floating-ui/react-dom@2.1.9 — MIT — https://github.com/floating-ui/floating-ui
@@ -4645,18 +4643,19 @@ SECTION 2: npm packages (1323 packages)
 - @react-native-async-storage/async-storage@2.2.0 — MIT — https://github.com/react-native-async-storage/async-storage
 - @react-native-google-signin/google-signin@16.1.2 — MIT — https://github.com/react-native-google-signin/google-signin
 - @react-native-masked-view/masked-view@0.3.2 — MIT — https://github.com/react-native-masked-view/masked-view
-- @react-native/assets-registry@0.85.3 — MIT — https://github.com/facebook/react-native
-- @react-native/babel-plugin-codegen@0.85.3 — MIT — https://github.com/facebook/react-native
-- @react-native/codegen@0.85.3 — MIT — https://github.com/facebook/react-native
-- @react-native/community-cli-plugin@0.85.3 — MIT — https://github.com/facebook/react-native
-- @react-native/debugger-frontend@0.85.3 — BSD-3-Clause — https://github.com/facebook/react-native
-- @react-native/debugger-shell@0.85.3 — MIT — https://github.com/facebook/react-native
-- @react-native/dev-middleware@0.85.3 — MIT — https://github.com/facebook/react-native
-- @react-native/gradle-plugin@0.85.3 — MIT — https://github.com/facebook/react-native
-- @react-native/js-polyfills@0.85.3 — MIT — https://github.com/facebook/react-native
+- @react-native-menu/menu@2.0.0 — MIT — https://github.com/react-native-menu/menu
+- @react-native/assets-registry@0.86.3 — MIT — https://github.com/react/react-native
+- @react-native/babel-plugin-codegen@0.86.3 — MIT — https://github.com/react/react-native
+- @react-native/codegen@0.86.3 — MIT — https://github.com/react/react-native
+- @react-native/community-cli-plugin@0.86.3 — MIT — https://github.com/react/react-native
+- @react-native/debugger-frontend@0.86.3 — BSD-3-Clause — https://github.com/react/react-native
+- @react-native/debugger-shell@0.86.3 — MIT — https://github.com/react/react-native
+- @react-native/dev-middleware@0.86.3 — MIT — https://github.com/react/react-native
+- @react-native/gradle-plugin@0.86.3 — MIT — https://github.com/react/react-native
+- @react-native/js-polyfills@0.86.3 — MIT — https://github.com/react/react-native
 - @react-native/normalize-colors@0.74.89 — MIT — https://github.com/facebook/react-native
-- @react-native/normalize-colors@0.85.3 — MIT — https://github.com/facebook/react-native
-- @react-native/virtualized-lists@0.85.3 — MIT — https://github.com/facebook/react-native
+- @react-native/normalize-colors@0.86.3 — MIT — https://github.com/react/react-native
+- @react-native/virtualized-lists@0.86.3 — MIT — https://github.com/react/react-native
 - @replit/codemirror-lang-csharp@6.2.0 — MIT — https://github.com/replit/codemirror-lang-csharp
 - @sapphire/async-queue@1.5.5 — MIT — https://github.com/sapphiredev/utilities
 - @sapphire/shapeshift@4.0.0 — MIT — https://github.com/sapphiredev/shapeshift
@@ -4666,8 +4665,6 @@ SECTION 2: npm packages (1323 packages)
 - @sinclair/typebox@0.27.10 — MIT — https://github.com/sinclairzx81/typebox-legacy
 - @tanstack/react-virtual@3.14.6 — MIT — https://github.com/TanStack/virtual
 - @tanstack/virtual-core@3.17.4 — MIT — https://github.com/TanStack/virtual
-- @testing-library/jest-dom@6.9.1 — MIT — https://github.com/testing-library/jest-dom
-- @testing-library/user-event@14.6.1 — MIT — https://github.com/testing-library/user-event
 - @tiptap/core@3.28.0 — MIT — https://github.com/ueberdosis/tiptap
 - @tiptap/extension-bubble-menu@3.28.0 — MIT — https://github.com/ueberdosis/tiptap
 - @tiptap/extension-document@3.28.0 — MIT — https://github.com/ueberdosis/tiptap
@@ -4714,6 +4711,7 @@ SECTION 2: npm packages (1323 packages)
 - @types/estree@1.0.9 — MIT — https://github.com/DefinitelyTyped/DefinitelyTyped
 - @types/estree-jsx@1.0.5 — MIT — https://github.com/DefinitelyTyped/DefinitelyTyped
 - @types/geojson@7946.0.16 — MIT — https://github.com/DefinitelyTyped/DefinitelyTyped
+- @types/hammerjs@2.0.46 — MIT — https://github.com/DefinitelyTyped/DefinitelyTyped
 - @types/hast@3.0.5 — MIT — https://github.com/DefinitelyTyped/DefinitelyTyped
 - @types/istanbul-lib-coverage@2.0.6 — MIT — https://github.com/DefinitelyTyped/DefinitelyTyped
 - @types/istanbul-lib-report@3.0.3 — MIT — https://github.com/DefinitelyTyped/DefinitelyTyped
@@ -4721,6 +4719,8 @@ SECTION 2: npm packages (1323 packages)
 - @types/katex@0.16.8 — MIT — https://github.com/DefinitelyTyped/DefinitelyTyped
 - @types/mdast@4.0.4 — MIT — https://github.com/DefinitelyTyped/DefinitelyTyped
 - @types/ms@2.1.0 — MIT — https://github.com/DefinitelyTyped/DefinitelyTyped
+- @types/node@14.18.63 — MIT — https://github.com/DefinitelyTyped/DefinitelyTyped
+- @types/node@22.20.1 — MIT — https://github.com/DefinitelyTyped/DefinitelyTyped
 - @types/node@25.9.5 — MIT — https://github.com/DefinitelyTyped/DefinitelyTyped
 - @types/pako@2.0.4 — MIT — https://github.com/DefinitelyTyped/DefinitelyTyped
 - @types/react@19.2.17 — MIT — https://github.com/DefinitelyTyped/DefinitelyTyped
@@ -4748,7 +4748,7 @@ SECTION 2: npm packages (1323 packages)
 - acorn@8.17.0 — MIT — https://github.com/acornjs/acorn
 - agent-base@6.0.2 — MIT — https://github.com/TooTallNate/node-agent-base
 - agent-base@7.1.4 — MIT — https://github.com/TooTallNate/proxy-agents
-- agent-cli-detector@0.1.2 — MIT
+- agent-cli-detector@0.1.6 — MIT — https://github.com/expo/agent-cli-detector
 - ajv@7.2.4 — MIT — https://github.com/ajv-validator/ajv
 - ajv@8.20.0 — MIT — https://github.com/ajv-validator/ajv
 - ajv-formats@1.6.1 — MIT — https://github.com/ajv-validator/ajv-formats
@@ -4762,14 +4762,17 @@ SECTION 2: npm packages (1323 packages)
 - ansi-styles@4.3.0 — MIT — https://github.com/chalk/ansi-styles
 - ansi-styles@5.2.0 — MIT — https://github.com/chalk/ansi-styles
 - ansi-styles@6.2.3 — MIT — https://github.com/chalk/ansi-styles
+- archiver@5.3.2 — MIT — https://github.com/archiverjs/node-archiver
+- archiver-utils@2.1.0 — MIT — https://github.com/archiverjs/archiver-utils
+- archiver-utils@3.0.4 — MIT — https://github.com/archiverjs/archiver-utils
 - arg@4.1.3 — MIT — https://github.com/zeit/arg
 - arg@5.0.2 — MIT — https://github.com/vercel/arg
 - argparse@1.0.10 — MIT — https://github.com/nodeca/argparse
 - argparse@2.0.1 — Python-2.0 — https://github.com/nodeca/argparse
 - aria-hidden@1.2.6 — MIT — https://github.com/theKashey/aria-hidden
-- aria-query@5.3.2 — Apache-2.0 — https://github.com/A11yance/aria-query
 - asap@2.0.6 — MIT — https://github.com/kriskowal/asap
 - asn1@0.2.6 — MIT — https://github.com/joyent/node-asn1
+- async@3.2.6 — MIT — https://github.com/caolan/async
 - asynckit@0.4.0 — MIT — https://github.com/alexindigo/asynckit
 - atomically@1.7.0 — MIT — https://github.com/fabiospampinato/atomically
 - axios@1.18.1 — MIT — https://github.com/axios/axios
@@ -4778,9 +4781,10 @@ SECTION 2: npm packages (1323 packages)
 - babel-plugin-polyfill-regenerator@0.6.8 — MIT — https://github.com/babel/babel-polyfills
 - babel-plugin-react-compiler@1.0.0 — MIT — https://github.com/facebook/react
 - babel-plugin-react-native-web@0.21.2 — MIT — https://github.com/necolas/react-native-web
-- babel-plugin-syntax-hermes-parser@0.33.3 — MIT — https://github.com/facebook/hermes
+- babel-plugin-syntax-hermes-parser@0.36.0 — MIT — https://github.com/facebook/hermes
+- babel-plugin-syntax-hermes-parser@0.36.1 — MIT — https://github.com/facebook/hermes
 - babel-plugin-transform-flow-enums@0.0.2 — MIT — https://github.com/facebook/flow
-- babel-preset-expo@56.0.17 — MIT — https://github.com/expo/expo
+- babel-preset-expo@57.0.9 — MIT — https://github.com/expo/expo
 - badgin@1.2.3 — MIT — https://github.com/jaulz/badgin
 - bail@2.0.2 — MIT — https://github.com/wooorm/bail
 - balanced-match@1.0.2 — MIT — https://github.com/juliangruber/balanced-match
@@ -4791,21 +4795,27 @@ SECTION 2: npm packages (1323 packages)
 - better-sqlite3@12.11.1 — MIT — https://github.com/WiseLibs/better-sqlite3
 - big-integer@1.6.52 — Unlicense — https://github.com/peterolson/BigInteger.js
 - bignumber.js@9.3.1 — MIT — https://github.com/MikeMcl/bignumber.js
+- binary@0.3.0 — MIT — http://github.com/substack/node-binary
 - bindings@1.5.0 — MIT — https://github.com/TooTallNate/node-bindings
 - bl@4.1.0 — MIT — https://github.com/rvagg/bl
+- bluebird@3.4.7 — MIT — https://github.com/petkaantonov/bluebird
 - body-parser@2.3.0 — MIT — https://github.com/expressjs/body-parser
 - boolbase@1.0.0 — ISC — https://github.com/fb55/boolbase
 - bplist-creator@0.1.0 — MIT — https://github.com/nearinfinity/node-bplist-creator
 - bplist-parser@0.3.1 — MIT — https://github.com/nearinfinity/node-bplist-parser
 - bplist-parser@0.3.2 — MIT — https://github.com/nearinfinity/node-bplist-parser
+- brace-expansion@1.1.16 — MIT — https://github.com/juliangruber/brace-expansion
 - brace-expansion@2.1.2 — MIT — https://github.com/juliangruber/brace-expansion
 - brace-expansion@5.0.8 — MIT — https://github.com/juliangruber/brace-expansion
 - braces@3.0.3 — MIT — https://github.com/micromatch/braces
 - browserslist@4.28.6 — MIT — https://github.com/browserslist/browserslist
 - bser@2.1.1 — Apache-2.0 — https://github.com/facebook/watchman
 - buffer@5.7.1 — MIT — https://github.com/feross/buffer
+- buffer-crc32@0.2.13 — MIT — https://github.com/brianloveswords/buffer-crc32
 - buffer-equal-constant-time@1.0.1 — BSD-3-Clause — https://github.com/goinstant/buffer-equal-constant-time
 - buffer-from@1.1.2 — MIT — https://github.com/LinusU/buffer-from
+- buffer-indexof-polyfill@1.0.2 — MIT — https://github.com/sarosia/buffer-indexof-polyfill
+- buffers@0.1.1 — MIT — http://github.com/substack/node-buffers
 - buildcheck@0.0.7 — MIT — http://github.com/mscdex/buildcheck
 - byte-size@8.2.1 — MIT — https://github.com/75lb/byte-size
 - bytes@3.1.2 — MIT — https://github.com/visionmedia/bytes.js
@@ -4815,6 +4825,7 @@ SECTION 2: npm packages (1323 packages)
 - camelcase@6.3.0 — MIT — https://github.com/sindresorhus/camelcase
 - caniuse-lite@1.0.30001805 — CC-BY-4.0 — https://github.com/browserslist/caniuse-lite
 - ccount@2.0.1 — MIT — https://github.com/wooorm/ccount
+- chainsaw@0.1.0 — MIT — http://github.com/substack/node-chainsaw
 - chalk@2.4.2 — MIT — https://github.com/chalk/chalk
 - chalk@4.1.2 — MIT — https://github.com/chalk/chalk
 - chalk@5.6.2 — MIT — https://github.com/chalk/chalk
@@ -4849,8 +4860,10 @@ SECTION 2: npm packages (1323 packages)
 - commander@2.20.3 — MIT — https://github.com/tj/commander.js
 - commander@7.2.0 — MIT — https://github.com/tj/commander.js
 - commander@8.3.0 — MIT — https://github.com/tj/commander.js
+- compress-commons@4.1.2 — MIT — https://github.com/archiverjs/node-compress-commons
 - compressible@2.0.18 — MIT — https://github.com/jshttp/compressible
 - compression@1.8.1 — MIT — https://github.com/expressjs/compression
+- concat-map@0.0.1 — MIT — https://github.com/substack/node-concat-map
 - conf@9.0.2 — MIT — https://github.com/sindresorhus/conf
 - connect@3.7.0 — MIT — https://github.com/senchalabs/connect
 - content-disposition@1.1.0 — MIT — https://github.com/jshttp/content-disposition
@@ -4866,6 +4879,8 @@ SECTION 2: npm packages (1323 packages)
 - cose-base@1.0.3 — MIT — https://github.com/iVis-at-Bilkent/cose-base
 - cose-base@2.2.0 — MIT — https://github.com/iVis-at-Bilkent/cose-base
 - cpu-features@0.0.10 — MIT — https://github.com/mscdex/cpu-features
+- crc-32@1.2.2 — Apache-2.0 — https://github.com/SheetJS/js-crc32
+- crc32-stream@4.0.3 — MIT — https://github.com/archiverjs/node-crc32-stream
 - crelt@1.0.7 — MIT — https://code.haverbeke.berlin/marijn/crelt
 - cross-fetch@3.2.0 — MIT — https://github.com/lquixada/cross-fetch
 - cross-spawn@7.0.6 — MIT — https://github.com/moxystudio/node-cross-spawn
@@ -4874,7 +4889,6 @@ SECTION 2: npm packages (1323 packages)
 - css-select@5.2.2 — BSD-2-Clause — https://github.com/fb55/css-select
 - css-tree@1.1.3 — MIT — https://github.com/csstree/csstree
 - css-what@6.2.2 — BSD-2-Clause — https://github.com/fb55/css-what
-- css.escape@1.5.1 — MIT — https://github.com/mathiasbynens/CSS.escape
 - csstype@3.2.3 — MIT — https://github.com/frenic/csstype
 - cytoscape@3.34.0 — MIT — https://github.com/cytoscape/cytoscape.js
 - cytoscape-cose-bilkent@4.1.0 — MIT — https://github.com/cytoscape/cytoscape.js-cose-bilkent
@@ -4943,7 +4957,7 @@ SECTION 2: npm packages (1323 packages)
 - discord-api-types@0.38.50 — MIT — https://github.com/discordjs/discord-api-types
 - discord.js@14.27.0 — Apache-2.0 — https://github.com/discordjs/discord.js
 - dnssd-advertise@1.1.6 — MIT — https://github.com/kitten/dnssd-advertise
-- dom-accessibility-api@0.6.3 — MIT — https://github.com/eps1lon/dom-accessibility-api
+- docx@9.7.1 — MIT — https://github.com/dolanmiu/docx
 - dom-serializer@2.0.0 — MIT — https://github.com/cheeriojs/dom-serializer
 - domelementtype@2.3.0 — BSD-2-Clause — https://github.com/fb55/domelementtype
 - domhandler@5.0.3 — BSD-2-Clause — https://github.com/fb55/domhandler
@@ -4952,6 +4966,7 @@ SECTION 2: npm packages (1323 packages)
 - dot-prop@6.0.1 — MIT — https://github.com/sindresorhus/dot-prop
 - drizzle-orm@0.45.2 — Apache-2.0 — https://github.com/drizzle-team/drizzle-orm
 - dunder-proto@1.0.1 — MIT — https://github.com/es-shims/dunder-proto
+- duplexer2@0.1.4 — BSD-3-Clause — https://github.com/deoxxa/duplexer2
 - eastasianwidth@0.2.0 — MIT — https://github.com/komagata/eastasianwidth
 - ecdsa-sig-formatter@1.0.11 — Apache-2.0 — https://github.com/Brightspace/node-ecdsa-sig-formatter
 - ee-first@1.1.1 — MIT — https://github.com/jonathanong/ee-first
@@ -4985,57 +5000,58 @@ SECTION 2: npm packages (1323 packages)
 - eventemitter3@5.0.4 — MIT — https://github.com/primus/eventemitter3
 - eventsource@3.0.7 — MIT — https://git@github.com/EventSource/eventsource
 - eventsource-parser@3.1.0 — MIT — https://github.com/rexxars/eventsource-parser
+- exceljs@4.4.0 — MIT — https://github.com/exceljs/exceljs
 - execa@4.1.0 — MIT — https://github.com/sindresorhus/execa
 - execa@5.1.1 — MIT — https://github.com/sindresorhus/execa
 - expand-template@2.0.3 — (MIT OR WTFPL) — https://github.com/ralphtheninja/expand-template
-- expo@56.0.16 — MIT — https://github.com/expo/expo
-- expo-apple-authentication@56.0.4 — MIT — https://github.com/expo/expo
-- expo-application@56.0.3 — MIT — https://github.com/expo/expo
-- expo-asset@56.0.20 — MIT — https://github.com/expo/expo
-- expo-audio@56.0.12 — MIT — https://github.com/expo/expo
-- expo-auth-session@56.0.15 — MIT — https://github.com/expo/expo
-- expo-blur@56.0.4 — MIT — https://github.com/expo/expo
-- expo-build-properties@56.0.23 — MIT — https://github.com/expo/expo
-- expo-clipboard@56.0.4 — MIT — https://github.com/expo/expo
-- expo-constants@56.0.21 — MIT — https://github.com/expo/expo
-- expo-constants@56.0.22 — MIT — https://github.com/expo/expo
-- expo-crypto@56.0.4 — MIT — https://github.com/expo/expo
-- expo-document-picker@56.0.4 — MIT — https://github.com/expo/expo
-- expo-eas-client@56.0.1 — MIT — https://github.com/expo/expo
-- expo-file-system@56.0.8 — MIT — https://github.com/expo/expo
-- expo-font@56.0.7 — MIT — https://github.com/expo/expo
-- expo-glass-effect@56.0.4 — MIT — https://github.com/expo/expo
-- expo-image@56.0.11 — MIT — https://github.com/expo/expo
-- expo-image-loader@56.0.3 — MIT — https://github.com/expo/expo
-- expo-image-manipulator@56.0.22 — MIT — https://github.com/expo/expo
-- expo-image-picker@56.0.21 — MIT — https://github.com/expo/expo
-- expo-json-utils@56.0.0 — MIT — https://github.com/expo/expo
-- expo-keep-awake@56.0.3 — MIT — https://github.com/expo/expo
-- expo-linking@56.0.15 — MIT — https://github.com/expo/expo
-- expo-localization@56.0.6 — MIT — https://github.com/expo/expo
-- expo-manifests@56.0.4 — MIT — https://github.com/expo/expo
-- expo-media-library@56.0.9 — MIT — https://github.com/expo/expo
-- expo-modules-autolinking@56.0.20 — MIT — https://github.com/expo/expo
-- expo-modules-core@56.0.21 — MIT — https://github.com/expo/expo
-- expo-modules-jsi@56.0.12 — MIT — https://github.com/expo/expo
-- expo-notifications@56.0.22 — MIT — https://github.com/expo/expo
+- expo@57.0.17 — MIT — https://github.com/expo/expo
+- expo-apple-authentication@57.0.1 — MIT — https://github.com/expo/expo
+- expo-application@57.0.2 — MIT — https://github.com/expo/expo
+- expo-asset@57.0.15 — MIT — https://github.com/expo/expo
+- expo-audio@57.0.4 — MIT — https://github.com/expo/expo
+- expo-auth-session@57.0.10 — MIT — https://github.com/expo/expo
+- expo-blur@57.0.2 — MIT — https://github.com/expo/expo
+- expo-build-properties@57.0.15 — MIT — https://github.com/expo/expo
+- expo-clipboard@57.0.1 — MIT — https://github.com/expo/expo
+- expo-constants@57.0.15 — MIT — https://github.com/expo/expo
+- expo-crypto@57.0.2 — MIT — https://github.com/expo/expo
+- expo-document-picker@57.0.1 — MIT — https://github.com/expo/expo
+- expo-eas-client@57.0.2 — MIT — https://github.com/expo/expo
+- expo-file-system@57.0.6 — MIT — https://github.com/expo/expo
+- expo-font@57.0.1 — MIT — https://github.com/expo/expo
+- expo-glass-effect@57.0.1 — MIT — https://github.com/expo/expo
+- expo-image@57.0.3 — MIT — https://github.com/expo/expo
+- expo-image-loader@57.0.1 — MIT — https://github.com/expo/expo
+- expo-image-manipulator@57.0.14 — MIT — https://github.com/expo/expo
+- expo-image-picker@57.0.14 — MIT — https://github.com/expo/expo
+- expo-json-utils@57.0.1 — MIT — https://github.com/expo/expo
+- expo-keep-awake@57.0.1 — MIT — https://github.com/expo/expo
+- expo-linking@57.0.8 — MIT — https://github.com/expo/expo
+- expo-localization@57.0.1 — MIT — https://github.com/expo/expo
+- expo-manifests@57.0.1 — MIT — https://github.com/expo/expo
+- expo-media-library@57.0.4 — MIT — https://github.com/expo/expo
+- expo-modules-autolinking@57.0.12 — MIT — https://github.com/expo/expo
+- expo-modules-core@57.0.14 — MIT — https://github.com/expo/expo
+- expo-modules-jsi@57.0.6 — MIT — https://github.com/expo/expo
+- expo-notifications@57.0.15 — MIT — https://github.com/expo/expo
 - expo-paste-input@0.2.2 — MIT — https://github.com/arunabhverma/expo-paste-input
-- expo-router@56.2.15 — MIT — https://github.com/expo/expo
-- expo-secure-store@56.0.4 — MIT — https://github.com/expo/expo
-- expo-server@56.0.5 — MIT — https://github.com/expo/expo
-- expo-sharing@56.0.22 — MIT — https://github.com/expo/expo
-- expo-splash-screen@56.0.13 — MIT — https://github.com/expo/expo
-- expo-status-bar@56.0.4 — MIT — https://github.com/expo/expo
-- expo-structured-headers@56.0.0 — MIT — https://github.com/expo/expo
-- expo-symbols@56.0.6 — MIT — https://github.com/expo/expo
-- expo-updates@56.0.22 — MIT — https://github.com/expo/expo
-- expo-updates-interface@56.0.2 — MIT — https://github.com/expo/expo
-- expo-web-browser@56.0.5 — MIT — https://github.com/expo/expo
+- expo-router@57.0.17 — MIT — https://github.com/expo/expo
+- expo-secure-store@57.0.2 — MIT — https://github.com/expo/expo
+- expo-server@57.0.3 — MIT — https://github.com/expo/expo
+- expo-sharing@57.0.16 — MIT — https://github.com/expo/expo
+- expo-splash-screen@57.0.8 — MIT — https://github.com/expo/expo
+- expo-status-bar@57.0.1 — MIT — https://github.com/expo/expo
+- expo-structured-headers@57.0.0 — MIT — https://github.com/expo/expo
+- expo-symbols@57.0.2 — MIT — https://github.com/expo/expo
+- expo-updates@57.0.18 — MIT — https://github.com/expo/expo
+- expo-updates-interface@57.0.1 — MIT — https://github.com/expo/expo
+- expo-web-browser@57.0.2 — MIT — https://github.com/expo/expo
 - exponential-backoff@3.1.3 — Apache-2.0 — https://github.com/coveooss/exponential-backoff
 - express@5.2.1 — MIT — https://github.com/expressjs/express
 - express-rate-limit@8.5.2 — MIT — https://github.com/express-rate-limit/express-rate-limit
 - extend@3.0.2 — MIT — https://github.com/justmoon/node-extend
 - extend-shallow@2.0.1 — MIT — https://github.com/jonschlinkert/extend-shallow
+- fast-csv@4.3.6 — MIT — https://github.com/C2FO/fast-csv
 - fast-deep-equal@3.1.3 — MIT — https://github.com/epoberezkin/fast-deep-equal
 - fast-equals@5.4.1 — MIT — https://github.com/planttheidea/fast-equals
 - fast-uri@3.1.4 — BSD-3-Clause — https://github.com/fastify/fast-uri
@@ -5065,6 +5081,8 @@ SECTION 2: npm packages (1323 packages)
 - fresh@2.0.0 — MIT — https://github.com/jshttp/fresh
 - fs-constants@1.0.0 — MIT — https://github.com/mafintosh/fs-constants
 - fs-extra@11.3.6 — MIT — https://github.com/jprichardson/node-fs-extra
+- fs.realpath@1.0.0 — ISC — https://github.com/isaacs/fs.realpath
+- fstream@1.0.12 — ISC — https://github.com/npm/fstream
 - function-bind@1.1.2 — MIT — https://github.com/Raynos/function-bind
 - gaxios@7.1.3 — Apache-2.0 — https://github.com/googleapis/google-cloud-node-core
 - gaxios@7.2.0 — Apache-2.0 — https://github.com/googleapis/google-cloud-node
@@ -5083,6 +5101,7 @@ SECTION 2: npm packages (1323 packages)
 - github-slugger@2.0.0 — ISC — https://github.com/Flet/github-slugger
 - glob@10.5.0 — ISC — https://github.com/isaacs/node-glob
 - glob@13.0.6 — BlueOak-1.0.0 — https://github.com/isaacs/node-glob
+- glob@7.2.3 — ISC — https://github.com/isaacs/node-glob
 - google-auth-library@10.5.0 — Apache-2.0 — https://github.com/googleapis/google-auth-library-nodejs
 - google-auth-library@10.9.0 — Apache-2.0 — https://github.com/googleapis/google-cloud-node
 - google-logging-utils@1.1.3 — Apache-2.0 — https://github.com/googleapis/google-cloud-node-core
@@ -5097,6 +5116,7 @@ SECTION 2: npm packages (1323 packages)
 - has-flag@4.0.0 — MIT — https://github.com/sindresorhus/has-flag
 - has-symbols@1.1.0 — MIT — https://github.com/inspect-js/has-symbols
 - has-tostringtag@1.0.2 — MIT — https://github.com/inspect-js/has-tostringtag
+- hash.js@1.1.7 — MIT — https://github.com/indutny/hash.js
 - hasown@2.0.4 — MIT — https://github.com/inspect-js/hasOwn
 - hast-util-from-dom@5.0.1 — ISC — https://github.com/syntax-tree/hast-util-from-dom
 - hast-util-from-html@2.0.3 — MIT — https://github.com/syntax-tree/hast-util-from-html
@@ -5110,18 +5130,22 @@ SECTION 2: npm packages (1323 packages)
 - hast-util-to-text@4.0.2 — MIT — https://github.com/syntax-tree/hast-util-to-text
 - hast-util-whitespace@3.0.0 — MIT — https://github.com/syntax-tree/hast-util-whitespace
 - hastscript@9.0.1 — MIT — https://github.com/syntax-tree/hastscript
-- hermes-compiler@250829098.0.10 — MIT — https://github.com/facebook/hermes
-- hermes-estree@0.33.3 — MIT — https://github.com/facebook/hermes
+- hermes-compiler@250829098.0.17 — MIT — https://github.com/facebook/hermes
 - hermes-estree@0.35.0 — MIT — https://github.com/facebook/hermes
-- hermes-parser@0.33.3 — MIT — https://github.com/facebook/hermes
+- hermes-estree@0.36.0 — MIT — https://github.com/facebook/hermes
+- hermes-estree@0.36.1 — MIT — https://github.com/facebook/hermes
 - hermes-parser@0.35.0 — MIT — https://github.com/facebook/hermes
+- hermes-parser@0.36.0 — MIT — https://github.com/facebook/hermes
+- hermes-parser@0.36.1 — MIT — https://github.com/facebook/hermes
 - highlight.js@11.11.1 — BSD-3-Clause — https://github.com/highlightjs/highlight.js
+- hoist-non-react-statics@3.3.2 — BSD-3-Clause — https://github.com/mridgway/hoist-non-react-statics
 - hono@4.12.30 — MIT — https://github.com/honojs/hono
 - hosted-git-info@7.0.2 — ISC — https://github.com/npm/hosted-git-info
 - html-parse-stringify@3.0.1 — MIT — https://github.com/henrikjoreteg/html-parse-stringify
 - html-to-image@1.11.13 — MIT — https://github.com/bubkoo/html-to-image
 - html-url-attributes@3.0.1 — MIT — https://github.com/rehypejs/rehype-minify/tree/main/packages/html-url-attributes
 - http-errors@2.0.1 — MIT — https://github.com/jshttp/http-errors
+- https@1.0.0 — ISC
 - https-proxy-agent@5.0.1 — MIT — https://github.com/TooTallNate/node-https-proxy-agent
 - https-proxy-agent@7.0.6 — MIT — https://github.com/TooTallNate/proxy-agents
 - human-signals@1.1.1 — Apache-2.0 — https://github.com/ehmicky/human-signals
@@ -5136,7 +5160,7 @@ SECTION 2: npm packages (1323 packages)
 - image-size@1.2.1 — MIT — https://github.com/image-size/image-size
 - immediate@3.0.6 — MIT — https://github.com/calvinmetcalf/immediate
 - import-meta-resolve@4.2.0 — MIT — https://github.com/wooorm/import-meta-resolve
-- indent-string@4.0.0 — MIT — https://github.com/sindresorhus/indent-string
+- inflight@1.0.6 — ISC — https://github.com/npm/inflight
 - inherits@2.0.4 — ISC — https://github.com/isaacs/inherits
 - ini@1.3.8 — ISC — https://github.com/isaacs/ini
 - inline-style-parser@0.2.7 — MIT — https://github.com/remarkablemark/inline-style-parser
@@ -5201,6 +5225,7 @@ SECTION 2: npm packages (1323 packages)
 - lan-network@0.2.1 — MIT — https://github.com/kitten/lan-network
 - layout-base@1.0.2 — MIT — https://github.com/iVis-at-Bilkent/layout-base
 - layout-base@2.0.1 — MIT — https://github.com/iVis-at-Bilkent/layout-base
+- lazystream@1.0.1 — MIT — https://github.com/jpommerening/node-lazystream
 - lcid@3.1.1 — MIT — https://github.com/sindresorhus/lcid
 - leven@3.1.0 — MIT — https://github.com/sindresorhus/leven
 - lie@3.3.0 — MIT — https://github.com/calvinmetcalf/lie
@@ -5212,6 +5237,7 @@ SECTION 2: npm packages (1323 packages)
 - lightningcss-linux-x64-gnu@1.32.0 — MPL-2.0 — https://github.com/parcel-bundler/lightningcss
 - lightningcss-win32-arm64-msvc@1.32.0 — MPL-2.0 — https://github.com/parcel-bundler/lightningcss
 - lightningcss-win32-x64-msvc@1.32.0 — MPL-2.0 — https://github.com/parcel-bundler/lightningcss
+- listenercount@1.0.1 — ISC — https://github.com/jden/node-listenercount
 - lit@3.3.3 — BSD-3-Clause — https://github.com/lit/lit
 - lit-element@4.2.2 — BSD-3-Clause — https://github.com/lit/lit
 - lit-html@3.3.3 — BSD-3-Clause — https://github.com/lit/lit
@@ -5220,11 +5246,24 @@ SECTION 2: npm packages (1323 packages)
 - lodash@4.18.1 — MIT — https://github.com/lodash/lodash
 - lodash-es@4.18.1 — MIT — https://github.com/lodash/lodash
 - lodash.debounce@4.0.8 — MIT — https://github.com/lodash/lodash
+- lodash.defaults@4.2.0 — MIT — https://github.com/lodash/lodash
+- lodash.difference@4.5.0 — MIT — https://github.com/lodash/lodash
+- lodash.escaperegexp@4.1.2 — MIT — https://github.com/lodash/lodash
+- lodash.flatten@4.4.0 — MIT — https://github.com/lodash/lodash
+- lodash.groupby@4.6.0 — MIT — https://github.com/lodash/lodash
 - lodash.identity@3.0.0 — MIT — https://github.com/lodash/lodash
+- lodash.isboolean@3.0.3 — MIT — https://github.com/lodash/lodash
+- lodash.isequal@4.5.0 — MIT — https://github.com/lodash/lodash
+- lodash.isfunction@3.0.9 — MIT — https://github.com/lodash/lodash
+- lodash.isnil@4.0.0 — MIT — https://github.com/lodash/lodash
+- lodash.isplainobject@4.0.6 — MIT — https://github.com/lodash/lodash
+- lodash.isundefined@3.0.1 — MIT — https://github.com/lodash/lodash
 - lodash.merge@4.6.2 — MIT — https://github.com/lodash/lodash
 - lodash.pickby@4.6.0 — MIT — https://github.com/lodash/lodash
 - lodash.snakecase@4.1.1 — MIT — https://github.com/lodash/lodash
 - lodash.throttle@4.1.1 — MIT — https://github.com/lodash/lodash
+- lodash.union@4.6.0 — MIT — https://github.com/lodash/lodash
+- lodash.uniq@4.5.0 — MIT — https://github.com/lodash/lodash
 - log-symbols@2.2.0 — MIT — https://github.com/sindresorhus/log-symbols
 - long@5.3.2 — Apache-2.0 — https://github.com/dcodeIO/long.js
 - longest-streak@3.1.0 — MIT — https://github.com/wooorm/longest-streak
@@ -5270,19 +5309,33 @@ SECTION 2: npm packages (1323 packages)
 - merge-stream@2.0.0 — MIT — https://github.com/grncdr/merge-stream
 - mermaid@11.16.0 — MIT — https://github.com/mermaid-js/mermaid
 - metro@0.84.4 — MIT — https://github.com/facebook/metro
+- metro@0.84.5 — MIT — https://github.com/react/metro
 - metro-babel-transformer@0.84.4 — MIT — https://github.com/facebook/metro
+- metro-babel-transformer@0.84.5 — MIT — https://github.com/react/metro
 - metro-cache@0.84.4 — MIT — https://github.com/facebook/metro
+- metro-cache@0.84.5 — MIT — https://github.com/react/metro
 - metro-cache-key@0.84.4 — MIT — https://github.com/facebook/metro
+- metro-cache-key@0.84.5 — MIT — https://github.com/react/metro
 - metro-config@0.84.4 — MIT — https://github.com/facebook/metro
+- metro-config@0.84.5 — MIT — https://github.com/react/metro
 - metro-core@0.84.4 — MIT — https://github.com/facebook/metro
+- metro-core@0.84.5 — MIT — https://github.com/react/metro
 - metro-file-map@0.84.4 — MIT — https://github.com/facebook/metro
+- metro-file-map@0.84.5 — MIT — https://github.com/react/metro
 - metro-minify-terser@0.84.4 — MIT — https://github.com/facebook/metro
+- metro-minify-terser@0.84.5 — MIT — https://github.com/react/metro
 - metro-resolver@0.84.4 — MIT — https://github.com/facebook/metro
+- metro-resolver@0.84.5 — MIT — https://github.com/react/metro
 - metro-runtime@0.84.4 — MIT — https://github.com/facebook/metro
+- metro-runtime@0.84.5 — MIT — https://github.com/react/metro
 - metro-source-map@0.84.4 — MIT — https://github.com/facebook/metro
+- metro-source-map@0.84.5 — MIT — https://github.com/react/metro
 - metro-symbolicate@0.84.4 — MIT — https://github.com/facebook/metro
+- metro-symbolicate@0.84.5 — MIT — https://github.com/react/metro
 - metro-transform-plugins@0.84.4 — MIT — https://github.com/facebook/metro
+- metro-transform-plugins@0.84.5 — MIT — https://github.com/react/metro
 - metro-transform-worker@0.84.4 — MIT — https://github.com/facebook/metro
+- metro-transform-worker@0.84.5 — MIT — https://github.com/react/metro
 - micromark@4.0.2 — MIT — https://github.com/micromark/micromark/tree/main/packages/micromark
 - micromark-core-commonmark@2.0.3 — MIT — https://github.com/micromark/micromark/tree/main/packages/micromark-core-commonmark
 - micromark-extension-cjk-friendly@2.0.1 — MIT — https://github.com/tats-u/markdown-cjk-friendly
@@ -5324,8 +5377,10 @@ SECTION 2: npm packages (1323 packages)
 - mimic-fn@2.1.0 — MIT — https://github.com/sindresorhus/mimic-fn
 - mimic-fn@3.1.0 — MIT — https://github.com/sindresorhus/mimic-fn
 - mimic-response@3.1.0 — MIT — https://github.com/sindresorhus/mimic-response
-- min-indent@1.0.1 — MIT — https://github.com/thejameskyle/min-indent
+- minimalistic-assert@1.0.1 — ISC — https://github.com/calvinmetcalf/minimalistic-assert
 - minimatch@10.2.5 — BlueOak-1.0.0 — https://github.com/isaacs/minimatch
+- minimatch@3.1.5 — ISC — https://github.com/isaacs/minimatch
+- minimatch@5.1.9 — ISC — https://github.com/isaacs/minimatch
 - minimatch@9.0.9 — ISC — https://github.com/isaacs/minimatch
 - minimist@1.2.8 — MIT — https://github.com/minimistjs/minimist
 - minipass@7.1.3 — BlueOak-1.0.0 — https://github.com/isaacs/minipass
@@ -5336,9 +5391,10 @@ SECTION 2: npm packages (1323 packages)
 - mri@1.2.0 — MIT — https://github.com/lukeed/mri
 - ms@2.0.0 — MIT — https://github.com/zeit/ms
 - ms@2.1.3 — MIT — https://github.com/vercel/ms
-- multitars@1.0.0 — MIT — https://github.com/kitten/multitars
+- multitars@1.0.2 — MIT — https://github.com/expo/multitars
 - nan@2.28.0 — MIT — https://github.com/nodejs/nan
 - nanoid@3.3.16 — MIT — https://github.com/ai/nanoid
+- nanoid@5.1.16 — MIT — https://github.com/ai/nanoid
 - napi-build-utils@2.0.0 — MIT — https://github.com/inspiredware/napi-build-utils
 - negotiator@0.6.3 — MIT — https://github.com/jshttp/negotiator
 - negotiator@0.6.4 — MIT — https://github.com/jshttp/negotiator
@@ -5353,11 +5409,13 @@ SECTION 2: npm packages (1323 packages)
 - node-machine-id@1.1.12 — MIT — https://github.com/automation-stack/node-machine-id
 - node-pty@1.1.0 — MIT — https://github.com/microsoft/node-pty
 - node-releases@2.0.51 — MIT — https://github.com/chicoxyzzy/node-releases
+- normalize-path@3.0.0 — MIT — https://github.com/jonschlinkert/normalize-path
 - npm-package-arg@11.0.3 — ISC — https://github.com/npm/npm-package-arg
 - npm-run-path@4.0.1 — MIT — https://github.com/sindresorhus/npm-run-path
 - nth-check@2.1.1 — BSD-2-Clause — https://github.com/fb55/nth-check
 - nullthrows@1.1.1 — MIT — https://github.com/zertosh/nullthrows
 - ob1@0.84.4 — MIT — https://github.com/facebook/metro
+- ob1@0.84.5 — MIT — https://github.com/react/metro
 - object-assign@4.1.1 — MIT — https://github.com/sindresorhus/object-assign
 - object-inspect@1.13.4 — MIT — https://github.com/inspect-js/object-inspect
 - on-finished@2.3.0 — MIT — https://github.com/jshttp/on-finished
@@ -5385,6 +5443,7 @@ SECTION 2: npm packages (1323 packages)
 - path-data-parser@0.1.0 — MIT — https://github.com/pshihn/path-data-parser
 - path-exists@3.0.0 — MIT — https://github.com/sindresorhus/path-exists
 - path-exists@4.0.0 — MIT — https://github.com/sindresorhus/path-exists
+- path-is-absolute@1.0.1 — MIT — https://github.com/sindresorhus/path-is-absolute
 - path-key@3.1.1 — MIT — https://github.com/sindresorhus/path-key
 - path-parse@1.0.7 — MIT — https://github.com/jbgutierrez/path-parse
 - path-scurry@1.11.1 — BlueOak-1.0.0 — https://github.com/isaacs/path-scurry
@@ -5404,6 +5463,7 @@ SECTION 2: npm packages (1323 packages)
 - points-on-path@0.2.1 — MIT — https://github.com/pshihn/points-on-path
 - postcss@8.5.19 — MIT — https://github.com/postcss/postcss
 - postcss-value-parser@4.2.0 — MIT — https://github.com/TrySound/postcss-value-parser
+- pptxgenjs@4.0.1 — MIT — https://github.com/gitbrent/PptxGenJS
 - prebuild-install@7.1.3 — MIT — https://github.com/prebuild/prebuild-install
 - pretty-format@29.7.0 — MIT — https://github.com/jestjs/jest
 - proc-log@4.2.0 — ISC — https://github.com/npm/proc-log
@@ -5446,21 +5506,22 @@ SECTION 2: npm packages (1323 packages)
 - react-fast-compare@3.2.2 — MIT — https://github.com/FormidableLabs/react-fast-compare
 - react-freeze@1.0.4 — MIT — https://github.com/software-mansion/react-freeze
 - react-i18next@17.0.10 — MIT — https://github.com/i18next/react-i18next
+- react-is@16.13.1 — MIT — https://github.com/facebook/react
 - react-is@18.3.1 — MIT — https://github.com/facebook/react
 - react-is@19.2.7 — MIT — https://github.com/facebook/react
 - react-markdown@10.1.0 — MIT — https://github.com/remarkjs/react-markdown
-- react-native@0.85.3 — MIT — https://github.com/facebook/react-native
+- react-native@0.86.3 — MIT — https://github.com/react/react-native
 - react-native-drawer-layout@4.2.7 — MIT — https://github.com/react-navigation/react-navigation
-- react-native-gesture-handler@3.0.2 — MIT — https://github.com/software-mansion/react-native-gesture-handler
+- react-native-gesture-handler@2.32.0 — MIT — https://github.com/software-mansion/react-native-gesture-handler
 - react-native-is-edge-to-edge@1.3.1 — MIT — https://github.com/zoontek/react-native-edge-to-edge
-- react-native-reanimated@4.3.1 — MIT — https://github.com/software-mansion/react-native-reanimated
+- react-native-reanimated@4.5.1 — MIT — https://github.com/software-mansion/react-native-reanimated
 - react-native-safe-area-context@5.7.0 — MIT — https://github.com/AppAndFlow/react-native-safe-area-context
-- react-native-screens@4.25.2 — MIT — https://github.com/software-mansion/react-native-screens
+- react-native-screens@4.26.2 — MIT — https://github.com/software-mansion/react-native-screens
 - react-native-svg@15.15.4 — MIT — https://github.com/react-native-community/react-native-svg
 - react-native-uitextview@2.2.0 — MIT — https://github.com/bluesky-social/react-native-uitextview
 - react-native-web@0.21.2 — MIT — https://github.com/necolas/react-native-web
 - react-native-webview@13.16.1 — MIT — https://github.com/react-native-webview/react-native-webview
-- react-native-worklets@0.8.3 — MIT — https://github.com/software-mansion/react-native-reanimated
+- react-native-worklets@0.10.1 — MIT — https://github.com/software-mansion/react-native-reanimated
 - react-refresh@0.14.2 — MIT — https://github.com/facebook/react
 - react-remove-scroll@2.7.2 — MIT — https://github.com/theKashey/react-remove-scroll
 - react-remove-scroll-bar@2.3.8 — MIT — https://github.com/theKashey/react-remove-scroll-bar
@@ -5469,7 +5530,7 @@ SECTION 2: npm packages (1323 packages)
 - react-style-singleton@2.2.3 — MIT — https://github.com/theKashey/react-style-singleton
 - readable-stream@2.3.8 — MIT — https://github.com/nodejs/readable-stream
 - readable-stream@3.6.2 — MIT — https://github.com/nodejs/readable-stream
-- redent@3.0.0 — MIT — https://github.com/sindresorhus/redent
+- readdir-glob@1.1.3 — Apache-2.0 — https://github.com/Yqnn/node-readdir-glob
 - regenerate@1.4.2 — MIT — https://github.com/mathiasbynens/regenerate
 - regenerate-unicode-properties@10.2.2 — MIT — https://github.com/mathiasbynens/regenerate-unicode-properties
 - regenerator-runtime@0.13.11 — MIT — https://github.com/facebook/regenerator/tree/main/packages/runtime
@@ -5492,6 +5553,7 @@ SECTION 2: npm packages (1323 packages)
 - resolve-from@5.0.0 — MIT — https://github.com/sindresorhus/resolve-from
 - resolve-workspace-root@2.0.1 — MIT — https://github.com/byCedric/resolve-workspace-root
 - restore-cursor@2.0.0 — MIT — https://github.com/sindresorhus/restore-cursor
+- rimraf@2.6.3 — ISC — https://github.com/isaacs/rimraf
 - rimraf@5.0.10 — ISC — https://github.com/isaacs/rimraf
 - robust-predicates@3.0.3 — Unlicense — https://github.com/mourner/robust-predicates
 - rope-sequence@1.3.4 — MIT — https://github.com/marijnh/rope-sequence
@@ -5502,7 +5564,9 @@ SECTION 2: npm packages (1323 packages)
 - safe-buffer@5.1.2 — MIT — https://github.com/feross/safe-buffer
 - safe-buffer@5.2.1 — MIT — https://github.com/feross/safe-buffer
 - safer-buffer@2.1.2 — MIT — https://github.com/ChALkeR/safer-buffer
+- sandbox-cli-detector@0.2.0 — MIT — https://github.com/davidmokos/sandbox-cli-detector
 - sax@1.6.0 — BlueOak-1.0.0 — https://github.com/isaacs/sax-js
+- saxes@5.0.1 — ISC — https://github.com/lddubeau/saxes
 - scheduler@0.27.0 — MIT — https://github.com/facebook/react
 - section-matter@1.0.0 — MIT — https://github.com/jonschlinkert/section-matter
 - semver@6.3.1 — ISC — https://github.com/npm/node-semver
@@ -5567,7 +5631,6 @@ SECTION 2: npm packages (1323 packages)
 - strip-ansi@7.2.0 — MIT — https://github.com/chalk/strip-ansi
 - strip-bom-string@1.0.0 — MIT — https://github.com/jonschlinkert/strip-bom-string
 - strip-final-newline@2.0.0 — MIT — https://github.com/sindresorhus/strip-final-newline
-- strip-indent@3.0.0 — MIT — https://github.com/sindresorhus/strip-indent
 - strip-json-comments@2.0.1 — MIT — https://github.com/sindresorhus/strip-json-comments
 - structured-headers@0.4.1 — MIT — https://github.com/evert/structured-header
 - style-mod@4.1.3 — MIT — https://github.com/marijnh/style-mod
@@ -5589,11 +5652,13 @@ SECTION 2: npm packages (1323 packages)
 - throat@5.0.0 — MIT — https://github.com/ForbesLindesay/throat
 - tinyexec@1.2.4 — MIT — https://github.com/tinylibs/tinyexec
 - tinyglobby@0.2.17 — MIT — https://github.com/SuperchupuDev/tinyglobby
+- tmp@0.2.7 — MIT — https://github.com/raszi/node-tmp
 - tmpl@1.0.5 — BSD-3-Clause — https://github.com/daaku/nodejs-tmpl
 - to-regex-range@5.0.1 — MIT — https://github.com/micromatch/to-regex-range
 - toidentifier@1.0.1 — MIT — https://github.com/component/toidentifier
 - toqr@0.1.1 — MIT — https://github.com/kitten/toqr
 - tr46@0.0.3 — MIT — https://github.com/Sebmaster/tr46.js
+- traverse@0.3.9 — MIT — http://github.com/substack/js-traverse
 - trim-lines@3.0.1 — MIT — https://github.com/wooorm/trim-lines
 - trough@2.2.0 — MIT — https://github.com/wooorm/trough
 - ts-algebra@2.0.0 — MIT — https://github.com/ThomasAribart/ts-algebra
@@ -5611,6 +5676,7 @@ SECTION 2: npm packages (1323 packages)
 - ua-parser-js@1.0.41 — MIT — https://github.com/faisalman/ua-parser-js
 - undici@6.27.0 — MIT — https://github.com/nodejs/undici
 - undici@8.7.0 — MIT — https://github.com/nodejs/undici
+- undici-types@6.21.0 — MIT — https://github.com/nodejs/undici
 - undici-types@7.24.6 — MIT — https://github.com/nodejs/undici
 - unicode-canonical-property-names-ecmascript@2.0.1 — MIT — https://github.com/mathiasbynens/unicode-canonical-property-names-ecmascript
 - unicode-match-property-ecmascript@2.0.0 — MIT — https://github.com/mathiasbynens/unicode-match-property-ecmascript
@@ -5626,6 +5692,7 @@ SECTION 2: npm packages (1323 packages)
 - unist-util-visit-parents@6.0.2 — MIT — https://github.com/syntax-tree/unist-util-visit-parents
 - universalify@2.0.1 — MIT — https://github.com/RyanZim/universalify
 - unpipe@1.0.0 — MIT — https://github.com/stream-utils/unpipe
+- unzipper@0.10.14 — MIT — https://github.com/ZJONSSON/node-unzipper
 - update-browserslist-db@1.2.3 — MIT — https://github.com/browserslist/update-db
 - uri-js@4.4.1 — BSD-2-Clause — http://github.com/garycourt/uri-js
 - url-template@2.0.8 — LicenseRef-BSD-Variant — https://github.com/bramstein/url-template
@@ -5637,6 +5704,7 @@ SECTION 2: npm packages (1323 packages)
 - utils-merge@1.0.1 — MIT — https://github.com/jaredhanson/utils-merge
 - uuid@14.0.1 — MIT — https://github.com/uuidjs/uuid
 - uuid@7.0.3 — MIT — https://github.com/uuidjs/uuid
+- uuid@8.3.2 — MIT — https://github.com/uuidjs/uuid
 - validate-npm-package-name@5.0.1 — ISC — https://github.com/npm/validate-npm-package-name
 - vary@1.1.2 — MIT — https://github.com/jshttp/vary
 - vaul@1.1.2 — MIT — https://github.com/emilkowalski/vaul
@@ -5665,9 +5733,12 @@ SECTION 2: npm packages (1323 packages)
 - ws@7.5.12 — MIT — https://github.com/websockets/ws
 - ws@8.21.1 — MIT — https://github.com/websockets/ws
 - xcode@3.0.1 — Apache-2.0 — https://github.com/apache/cordova-node-xcode
+- xml@1.0.1 — MIT — http://github.com/dylang/node-xml
+- xml-js@1.6.11 — MIT — https://github.com/nashwaan/xml-js
 - xml2js@0.6.0 — MIT — https://github.com/Leonidas-from-XIV/node-xml2js
 - xmlbuilder@11.0.1 — MIT — https://github.com/oozcitak/xmlbuilder-js
 - xmlbuilder@15.1.1 — MIT — https://github.com/oozcitak/xmlbuilder-js
+- xmlchars@2.2.0 — MIT — https://github.com/lddubeau/xmlchars
 - y18n@4.0.3 — ISC — https://github.com/yargs/y18n
 - y18n@5.0.8 — ISC — https://github.com/yargs/y18n
 - yallist@3.1.1 — ISC — https://github.com/isaacs/yallist
@@ -5677,6 +5748,7 @@ SECTION 2: npm packages (1323 packages)
 - yargs@17.7.3 — MIT — https://github.com/yargs/yargs
 - yargs-parser@18.1.3 — ISC — https://github.com/yargs/yargs-parser
 - yargs-parser@21.1.1 — ISC — https://github.com/yargs/yargs-parser
+- zip-stream@4.1.1 — MIT — https://github.com/archiverjs/node-zip-stream
 - zod@4.3.6 — MIT — https://github.com/colinhacks/zod
 - zod-to-json-schema@3.25.2 — ISC — https://github.com/StefanTerdell/zod-to-json-schema
 - zwitch@2.0.4 — MIT — https://github.com/wooorm/zwitch
@@ -26523,21 +26595,7 @@ Apache License
    limitations under the License.
 
 ------------------------------------------------------------------------------
-[119] Applies to: npm:@adobe/css-tools@4.5.0
-------------------------------------------------------------------------------
-(The MIT License)
-
-Copyright (c) 2012 TJ Holowaychuk <tj@vision-media.ca>
-Copyright (c) 2022 Jean-Philippe Zolesio <holblin@gmail.com>
-
-Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the 'Software'), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
-
-The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
-
-THE SOFTWARE IS PROVIDED 'AS IS', WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
-
-------------------------------------------------------------------------------
-[120] Applies to: npm:@antfu/install-pkg@1.1.0
+[119] Applies to: npm:@antfu/install-pkg@1.1.0
 ------------------------------------------------------------------------------
 MIT License
 
@@ -26562,7 +26620,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
 ------------------------------------------------------------------------------
-[121] Applies to: npm:@anthropic-ai/sdk@0.91.1
+[120] Applies to: npm:@anthropic-ai/sdk@0.91.1
 ------------------------------------------------------------------------------
 Copyright 2023 Anthropic, PBC.
 
@@ -26573,7 +26631,7 @@ The above copyright notice and this permission notice shall be included in all c
 THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[122] Applies to: npm:@babel/code-frame@7.29.7, npm:@babel/compat-data@7.29.7, npm:@babel/core@7.29.7, npm:@babel/generator@7.29.7, npm:@babel/helper-annotate-as-pure@7.29.7, npm:@babel/helper-compilation-targets@7.29.7, npm:@babel/helper-create-class-features-plugin@7.29.7, npm:@babel/helper-create-regexp-features-plugin@7.29.7, npm:@babel/helper-globals@7.29.7, npm:@babel/helper-member-expression-to-functions@7.29.7, npm:@babel/helper-module-imports@7.29.7, npm:@babel/helper-module-transforms@7.29.7, npm:@babel/helper-optimise-call-expression@7.29.7, npm:@babel/helper-plugin-utils@7.29.7, npm:@babel/helper-remap-async-to-generator@7.29.7, npm:@babel/helper-replace-supers@7.29.7, npm:@babel/helper-skip-transparent-expression-wrappers@7.29.7, npm:@babel/helper-string-parser@7.29.7, npm:@babel/helper-validator-identifier@7.29.7, npm:@babel/helper-validator-option@7.29.7, npm:@babel/helper-wrap-function@7.29.7, npm:@babel/plugin-proposal-decorators@7.29.7, npm:@babel/plugin-proposal-export-default-from@7.29.7, npm:@babel/plugin-syntax-decorators@7.29.7, npm:@babel/plugin-syntax-dynamic-import@7.8.3, npm:@babel/plugin-syntax-export-default-from@7.29.7, npm:@babel/plugin-syntax-flow@7.29.7, npm:@babel/plugin-syntax-jsx@7.29.7, npm:@babel/plugin-syntax-nullish-coalescing-operator@7.8.3, npm:@babel/plugin-syntax-optional-chaining@7.8.3, npm:@babel/plugin-syntax-typescript@7.29.7, npm:@babel/plugin-transform-arrow-functions@7.29.7, npm:@babel/plugin-transform-async-generator-functions@7.29.7, npm:@babel/plugin-transform-async-to-generator@7.29.7, npm:@babel/plugin-transform-block-scoping@7.29.7, npm:@babel/plugin-transform-class-properties@7.29.7, npm:@babel/plugin-transform-class-static-block@7.29.7, npm:@babel/plugin-transform-classes@7.29.7, npm:@babel/plugin-transform-destructuring@7.29.7, npm:@babel/plugin-transform-export-namespace-from@7.29.7, npm:@babel/plugin-transform-flow-strip-types@7.29.7, npm:@babel/plugin-transform-for-of@7.29.7, npm:@babel/plugin-transform-logical-assignment-operators@7.29.7, npm:@babel/plugin-transform-modules-commonjs@7.29.7, npm:@babel/plugin-transform-named-capturing-groups-regex@7.29.7, npm:@babel/plugin-transform-nullish-coalescing-operator@7.29.7, npm:@babel/plugin-transform-object-rest-spread@7.29.7, npm:@babel/plugin-transform-optional-catch-binding@7.29.7, npm:@babel/plugin-transform-optional-chaining@7.29.7, npm:@babel/plugin-transform-parameters@7.29.7, npm:@babel/plugin-transform-private-methods@7.29.7, npm:@babel/plugin-transform-private-property-in-object@7.29.7, npm:@babel/plugin-transform-react-display-name@7.29.7, npm:@babel/plugin-transform-react-jsx@7.29.7, npm:@babel/plugin-transform-react-jsx-development@7.29.7, npm:@babel/plugin-transform-react-pure-annotations@7.29.7, npm:@babel/plugin-transform-runtime@7.29.7, npm:@babel/plugin-transform-shorthand-properties@7.29.7, npm:@babel/plugin-transform-template-literals@7.29.7, npm:@babel/plugin-transform-typescript@7.29.7, npm:@babel/plugin-transform-unicode-regex@7.29.7, npm:@babel/preset-typescript@7.29.7, npm:@babel/runtime@7.29.7, npm:@babel/template@7.29.7, npm:@babel/traverse@7.29.7, npm:@babel/types@7.29.7
+[121] Applies to: npm:@babel/code-frame@7.29.7, npm:@babel/compat-data@7.29.7, npm:@babel/core@7.29.7, npm:@babel/generator@7.29.7, npm:@babel/helper-annotate-as-pure@7.29.7, npm:@babel/helper-compilation-targets@7.29.7, npm:@babel/helper-create-class-features-plugin@7.29.7, npm:@babel/helper-create-regexp-features-plugin@7.29.7, npm:@babel/helper-globals@7.29.7, npm:@babel/helper-member-expression-to-functions@7.29.7, npm:@babel/helper-module-imports@7.29.7, npm:@babel/helper-module-transforms@7.29.7, npm:@babel/helper-optimise-call-expression@7.29.7, npm:@babel/helper-plugin-utils@7.29.7, npm:@babel/helper-remap-async-to-generator@7.29.7, npm:@babel/helper-replace-supers@7.29.7, npm:@babel/helper-skip-transparent-expression-wrappers@7.29.7, npm:@babel/helper-string-parser@7.29.7, npm:@babel/helper-validator-identifier@7.29.7, npm:@babel/helper-validator-option@7.29.7, npm:@babel/helper-wrap-function@7.29.7, npm:@babel/plugin-proposal-decorators@7.29.7, npm:@babel/plugin-proposal-export-default-from@7.29.7, npm:@babel/plugin-syntax-decorators@7.29.7, npm:@babel/plugin-syntax-dynamic-import@7.8.3, npm:@babel/plugin-syntax-export-default-from@7.29.7, npm:@babel/plugin-syntax-flow@7.29.7, npm:@babel/plugin-syntax-jsx@7.29.7, npm:@babel/plugin-syntax-nullish-coalescing-operator@7.8.3, npm:@babel/plugin-syntax-optional-chaining@7.8.3, npm:@babel/plugin-syntax-typescript@7.29.7, npm:@babel/plugin-transform-arrow-functions@7.29.7, npm:@babel/plugin-transform-async-generator-functions@7.29.7, npm:@babel/plugin-transform-async-to-generator@7.29.7, npm:@babel/plugin-transform-block-scoping@7.29.7, npm:@babel/plugin-transform-class-properties@7.29.7, npm:@babel/plugin-transform-class-static-block@7.29.7, npm:@babel/plugin-transform-classes@7.29.7, npm:@babel/plugin-transform-destructuring@7.29.7, npm:@babel/plugin-transform-export-namespace-from@7.29.7, npm:@babel/plugin-transform-flow-strip-types@7.29.7, npm:@babel/plugin-transform-for-of@7.29.7, npm:@babel/plugin-transform-logical-assignment-operators@7.29.7, npm:@babel/plugin-transform-modules-commonjs@7.29.7, npm:@babel/plugin-transform-named-capturing-groups-regex@7.29.7, npm:@babel/plugin-transform-nullish-coalescing-operator@7.29.7, npm:@babel/plugin-transform-object-rest-spread@7.29.7, npm:@babel/plugin-transform-optional-catch-binding@7.29.7, npm:@babel/plugin-transform-optional-chaining@7.29.7, npm:@babel/plugin-transform-parameters@7.29.7, npm:@babel/plugin-transform-private-methods@7.29.7, npm:@babel/plugin-transform-private-property-in-object@7.29.7, npm:@babel/plugin-transform-react-display-name@7.29.7, npm:@babel/plugin-transform-react-jsx@7.29.7, npm:@babel/plugin-transform-react-jsx-development@7.29.7, npm:@babel/plugin-transform-react-pure-annotations@7.29.7, npm:@babel/plugin-transform-runtime@7.29.7, npm:@babel/plugin-transform-shorthand-properties@7.29.7, npm:@babel/plugin-transform-template-literals@7.29.7, npm:@babel/plugin-transform-typescript@7.29.7, npm:@babel/plugin-transform-unicode-regex@7.29.7, npm:@babel/preset-typescript@7.29.7, npm:@babel/runtime@7.29.7, npm:@babel/template@7.29.7, npm:@babel/traverse@7.29.7, npm:@babel/types@7.29.7
 ------------------------------------------------------------------------------
 MIT License
 
@@ -26599,7 +26657,7 @@ OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
 WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[123] Applies to: npm:@babel/helper-define-polyfill-provider@0.6.8, npm:babel-plugin-polyfill-corejs2@0.4.17, npm:babel-plugin-polyfill-corejs3@0.13.0, npm:babel-plugin-polyfill-regenerator@0.6.8
+[122] Applies to: npm:@babel/helper-define-polyfill-provider@0.6.8, npm:babel-plugin-polyfill-corejs2@0.4.17, npm:babel-plugin-polyfill-corejs3@0.13.0, npm:babel-plugin-polyfill-regenerator@0.6.8
 ------------------------------------------------------------------------------
 MIT License
 
@@ -26625,7 +26683,7 @@ OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
 WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[124] Applies to: npm:@babel/helpers@7.29.7
+[123] Applies to: npm:@babel/helpers@7.29.7
 ------------------------------------------------------------------------------
 MIT License
 
@@ -26652,7 +26710,7 @@ OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
 WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[125] Applies to: npm:@babel/parser@7.29.7
+[124] Applies to: npm:@babel/parser@7.29.7
 ------------------------------------------------------------------------------
 Copyright (C) 2012-2014 by various contributors (see AUTHORS)
 
@@ -26675,7 +26733,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[126] Applies to: npm:@braintree/sanitize-url@7.1.2
+[125] Applies to: npm:@braintree/sanitize-url@7.1.2
 ------------------------------------------------------------------------------
 MIT License
 
@@ -26700,7 +26758,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
 ------------------------------------------------------------------------------
-[127] Applies to: npm:@chevrotain/types@11.1.2, npm:@google/model-viewer@4.3.1, npm:@pkgjs/parseargs@0.11.0, npm:baseline-browser-mapping@2.10.43, npm:gaxios@7.1.3, npm:gaxios@7.2.0, npm:gcp-metadata@8.1.2, npm:gcp-metadata@8.1.3, npm:google-auth-library@10.5.0, npm:google-auth-library@10.9.0, npm:google-logging-utils@1.1.3, npm:googleapis-common@8.0.2, npm:long@5.3.2, npm:xcode@3.0.1
+[126] Applies to: npm:@chevrotain/types@11.1.2, npm:@google/model-viewer@4.3.1, npm:@pkgjs/parseargs@0.11.0, npm:baseline-browser-mapping@2.10.43, npm:gaxios@7.1.3, npm:gaxios@7.2.0, npm:gcp-metadata@8.1.2, npm:gcp-metadata@8.1.3, npm:google-auth-library@10.5.0, npm:google-auth-library@10.9.0, npm:google-logging-utils@1.1.3, npm:googleapis-common@8.0.2, npm:long@5.3.2, npm:xcode@3.0.1
 ------------------------------------------------------------------------------
 Apache License
                            Version 2.0, January 2004
@@ -26905,7 +26963,7 @@ Apache License
    limitations under the License.
 
 ------------------------------------------------------------------------------
-[128] Applies to: npm:@codemirror/autocomplete@6.20.3, npm:@codemirror/commands@6.10.4, npm:@codemirror/lang-cpp@6.0.3, npm:@codemirror/lang-css@6.3.1, npm:@codemirror/lang-html@6.4.11, npm:@codemirror/lang-java@6.0.2, npm:@codemirror/lang-javascript@6.2.5, npm:@codemirror/lang-json@6.0.2, npm:@codemirror/lang-markdown@6.5.1, npm:@codemirror/lang-php@6.0.2, npm:@codemirror/lang-python@6.2.1, npm:@codemirror/lang-rust@6.0.2, npm:@codemirror/lang-sql@6.10.0, npm:@codemirror/lang-xml@6.1.0, npm:@codemirror/language@6.12.4, npm:@codemirror/legacy-modes@6.5.3, npm:@codemirror/lint@6.9.7, npm:@codemirror/search@6.7.1, npm:@codemirror/state@6.7.1, npm:@codemirror/view@6.43.6
+[127] Applies to: npm:@codemirror/autocomplete@6.20.3, npm:@codemirror/commands@6.10.4, npm:@codemirror/lang-cpp@6.0.3, npm:@codemirror/lang-css@6.3.1, npm:@codemirror/lang-html@6.4.11, npm:@codemirror/lang-java@6.0.2, npm:@codemirror/lang-javascript@6.2.5, npm:@codemirror/lang-json@6.0.2, npm:@codemirror/lang-markdown@6.5.1, npm:@codemirror/lang-php@6.0.2, npm:@codemirror/lang-python@6.2.1, npm:@codemirror/lang-rust@6.0.2, npm:@codemirror/lang-sql@6.10.0, npm:@codemirror/lang-xml@6.1.0, npm:@codemirror/language@6.12.4, npm:@codemirror/legacy-modes@6.5.3, npm:@codemirror/lint@6.9.7, npm:@codemirror/search@6.7.1, npm:@codemirror/state@6.7.1, npm:@codemirror/view@6.43.6
 ------------------------------------------------------------------------------
 MIT License
 
@@ -26930,7 +26988,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[129] Applies to: npm:@codemirror/lang-go@6.0.1, npm:@codemirror/lang-yaml@6.1.3
+[128] Applies to: npm:@codemirror/lang-go@6.0.1, npm:@codemirror/lang-yaml@6.1.3
 ------------------------------------------------------------------------------
 MIT License
 
@@ -26955,7 +27013,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[130] Applies to: npm:@discordjs/builders@1.14.1, npm:@discordjs/formatters@0.6.2
+[129] Applies to: npm:@discordjs/builders@1.14.1, npm:@discordjs/formatters@0.6.2
 ------------------------------------------------------------------------------
 Apache License
                            Version 2.0, January 2004
@@ -27150,7 +27208,7 @@ Apache License
    limitations under the License.
 
 ------------------------------------------------------------------------------
-[131] Applies to: npm:@discordjs/collection@1.5.3, npm:@discordjs/collection@2.1.1, npm:discord.js@14.27.0
+[130] Applies to: npm:@discordjs/collection@1.5.3, npm:@discordjs/collection@2.1.1, npm:discord.js@14.27.0
 ------------------------------------------------------------------------------
 Apache License
                            Version 2.0, January 2004
@@ -27345,7 +27403,7 @@ Apache License
    limitations under the License.
 
 ------------------------------------------------------------------------------
-[132] Applies to: npm:@discordjs/rest@2.6.2
+[131] Applies to: npm:@discordjs/rest@2.6.2
 ------------------------------------------------------------------------------
 Apache License
                            Version 2.0, January 2004
@@ -27541,7 +27599,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 
 ------------------------------------------------------------------------------
-[133] Applies to: npm:@discordjs/util@1.2.0
+[132] Applies to: npm:@discordjs/util@1.2.0
 ------------------------------------------------------------------------------
 Apache License
                            Version 2.0, January 2004
@@ -27735,7 +27793,7 @@ Apache License
    limitations under the License.
 
 ------------------------------------------------------------------------------
-[134] Applies to: npm:@discordjs/ws@1.2.3
+[133] Applies to: npm:@discordjs/ws@1.2.3
 ------------------------------------------------------------------------------
 Apache License
                            Version 2.0, January 2004
@@ -27930,6 +27988,32 @@ Apache License
    limitations under the License.
 
 ------------------------------------------------------------------------------
+[134] Applies to: npm:@egjs/hammerjs@2.0.17
+------------------------------------------------------------------------------
+The MIT License (MIT)
+
+Copyright (c) 2018-present NAVER Corp.
+Copyright (C) 2011-2017 by Jorik Tangelder (Eight Media)
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+
+------------------------------------------------------------------------------
 [135] Applies to: npm:@expo-google-fonts/material-symbols@0.4.40
 ------------------------------------------------------------------------------
 MIT License
@@ -27955,7 +28039,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
 ------------------------------------------------------------------------------
-[136] Applies to: npm:@expo/cli@56.1.20, npm:@expo/config@56.0.12, npm:@expo/config-plugins@56.0.13, npm:@expo/devtools@56.0.2, npm:@expo/dom-webview@56.0.6, npm:@expo/expo-modules-macros-plugin@0.2.2, npm:@expo/fingerprint@0.19.8, npm:@expo/image-utils@0.10.3, npm:@expo/image-utils@0.10.4, npm:@expo/inline-modules@0.0.14, npm:@expo/json-file@10.2.0, npm:@expo/json-file@11.0.1, npm:@expo/local-build-cache-provider@56.0.10, npm:@expo/log-box@56.0.14, npm:@expo/metro-config@56.0.17, npm:@expo/metro-file-map@56.0.3, npm:@expo/metro-runtime@56.0.17, npm:@expo/osascript@2.7.1, npm:@expo/package-manager@1.13.1, npm:@expo/plist@0.7.0, npm:@expo/prebuild-config@56.0.20, npm:@expo/router-server@56.0.16, npm:babel-preset-expo@56.0.17, npm:expo@56.0.16, npm:expo-apple-authentication@56.0.4, npm:expo-application@56.0.3, npm:expo-asset@56.0.20, npm:expo-audio@56.0.12, npm:expo-auth-session@56.0.15, npm:expo-blur@56.0.4, npm:expo-build-properties@56.0.23, npm:expo-clipboard@56.0.4, npm:expo-constants@56.0.21, npm:expo-constants@56.0.22, npm:expo-crypto@56.0.4, npm:expo-document-picker@56.0.4, npm:expo-eas-client@56.0.1, npm:expo-file-system@56.0.8, npm:expo-font@56.0.7, npm:expo-glass-effect@56.0.4, npm:expo-image@56.0.11, npm:expo-image-loader@56.0.3, npm:expo-image-manipulator@56.0.22, npm:expo-image-picker@56.0.21, npm:expo-keep-awake@56.0.3, npm:expo-linking@56.0.15, npm:expo-localization@56.0.6, npm:expo-manifests@56.0.4, npm:expo-media-library@56.0.9, npm:expo-modules-autolinking@56.0.20, npm:expo-modules-core@56.0.21, npm:expo-modules-jsi@56.0.12, npm:expo-notifications@56.0.22, npm:expo-secure-store@56.0.4, npm:expo-server@56.0.5, npm:expo-sharing@56.0.22, npm:expo-splash-screen@56.0.13, npm:expo-status-bar@56.0.4, npm:expo-symbols@56.0.6, npm:expo-updates-interface@56.0.2, npm:expo-web-browser@56.0.5
+[136] Applies to: npm:@expo/cli@57.0.19, npm:@expo/config@57.0.9, npm:@expo/config-plugins@57.0.9, npm:@expo/devtools@57.0.1, npm:@expo/dom-webview@57.0.1, npm:@expo/expo-modules-macros-plugin@0.6.1, npm:@expo/fingerprint@0.20.10, npm:@expo/image-utils@0.11.5, npm:@expo/inline-modules@0.1.7, npm:@expo/json-file@11.0.1, npm:@expo/local-build-cache-provider@57.0.8, npm:@expo/log-box@57.0.4, npm:@expo/metro-config@57.0.11, npm:@expo/metro-file-map@57.0.2, npm:@expo/metro-runtime@57.0.14, npm:@expo/osascript@2.7.1, npm:@expo/package-manager@1.13.1, npm:@expo/plist@0.8.1, npm:@expo/prebuild-config@57.0.15, npm:@expo/router-server@57.0.8, npm:babel-preset-expo@57.0.9, npm:expo@57.0.17, npm:expo-apple-authentication@57.0.1, npm:expo-application@57.0.2, npm:expo-asset@57.0.15, npm:expo-audio@57.0.4, npm:expo-auth-session@57.0.10, npm:expo-blur@57.0.2, npm:expo-build-properties@57.0.15, npm:expo-clipboard@57.0.1, npm:expo-constants@57.0.15, npm:expo-crypto@57.0.2, npm:expo-document-picker@57.0.1, npm:expo-eas-client@57.0.2, npm:expo-file-system@57.0.6, npm:expo-font@57.0.1, npm:expo-glass-effect@57.0.1, npm:expo-image@57.0.3, npm:expo-image-loader@57.0.1, npm:expo-image-manipulator@57.0.14, npm:expo-image-picker@57.0.14, npm:expo-json-utils@57.0.1, npm:expo-keep-awake@57.0.1, npm:expo-linking@57.0.8, npm:expo-localization@57.0.1, npm:expo-manifests@57.0.1, npm:expo-media-library@57.0.4, npm:expo-modules-autolinking@57.0.12, npm:expo-modules-core@57.0.14, npm:expo-modules-jsi@57.0.6, npm:expo-notifications@57.0.15, npm:expo-secure-store@57.0.2, npm:expo-server@57.0.3, npm:expo-sharing@57.0.16, npm:expo-splash-screen@57.0.8, npm:expo-status-bar@57.0.1, npm:expo-symbols@57.0.2, npm:expo-updates-interface@57.0.1, npm:expo-web-browser@57.0.2
 ------------------------------------------------------------------------------
 The MIT License (MIT)
 
@@ -27980,7 +28064,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
 ------------------------------------------------------------------------------
-[137] Applies to: npm:@expo/code-signing-certificates@0.0.6, npm:@expo/config-types@56.0.7
+[137] Applies to: npm:@expo/code-signing-certificates@0.0.6, npm:@expo/config-types@57.0.2
 ------------------------------------------------------------------------------
 The MIT License (MIT)
 
@@ -28005,7 +28089,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
 ------------------------------------------------------------------------------
-[138] Applies to: npm:@expo/env@2.3.1, npm:@expo/env@2.4.2
+[138] Applies to: npm:@expo/env@2.4.2
 ------------------------------------------------------------------------------
 The MIT License (MIT)
 
@@ -28030,7 +28114,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
 ------------------------------------------------------------------------------
-[139] Applies to: npm:@expo/metro@56.0.0
+[139] Applies to: npm:@expo/metro@56.0.2
 ------------------------------------------------------------------------------
 MIT License
 
@@ -28056,7 +28140,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
 ------------------------------------------------------------------------------
-[140] Applies to: npm:@expo/require-utils@56.1.5, npm:@expo/require-utils@56.1.6, npm:@expo/schema-utils@56.0.2
+[140] Applies to: npm:@expo/require-utils@57.0.5, npm:@expo/schema-utils@57.0.2
 ------------------------------------------------------------------------------
 The MIT License (MIT)
 
@@ -28131,7 +28215,32 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
 ------------------------------------------------------------------------------
-[143] Applies to: npm:@floating-ui/core@1.8.0, npm:@floating-ui/dom@1.8.0, npm:@floating-ui/react-dom@2.1.9, npm:@floating-ui/utils@0.2.12
+[143] Applies to: npm:@fast-csv/format@4.3.5, npm:@fast-csv/parse@4.3.6, npm:fast-csv@4.3.6
+------------------------------------------------------------------------------
+The MIT License
+
+Copyright (c) 2011-2019 C2FO
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+
+------------------------------------------------------------------------------
+[144] Applies to: npm:@floating-ui/core@1.8.0, npm:@floating-ui/dom@1.8.0, npm:@floating-ui/react-dom@2.1.9, npm:@floating-ui/utils@0.2.12
 ------------------------------------------------------------------------------
 MIT License
 
@@ -28155,7 +28264,7 @@ IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
 CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[144] Applies to: npm:@fontsource-variable/inter@5.2.8
+[145] Applies to: npm:@fontsource-variable/inter@5.2.8
 ------------------------------------------------------------------------------
 Copyright 2016 The Inter Project Authors (https://github.com/rsms/inter) Inter-Italic[opsz,wght].ttf: Copyright 2016 The Inter Project Authors (https://github.com/rsms/inter)
 
@@ -28252,7 +28361,7 @@ FROM, OUT OF THE USE OR INABILITY TO USE THE FONT SOFTWARE OR FROM
 OTHER DEALINGS IN THE FONT SOFTWARE.
 
 ------------------------------------------------------------------------------
-[145] Applies to: npm:@fontsource-variable/jetbrains-mono@5.2.8
+[146] Applies to: npm:@fontsource-variable/jetbrains-mono@5.2.8
 ------------------------------------------------------------------------------
 Copyright 2020 The JetBrains Mono Project Authors (https://github.com/JetBrains/JetBrainsMono) JetBrainsMono-Italic[wght].ttf: Copyright 2020 The JetBrains Mono Project Authors (https://github.com/JetBrains/JetBrainsMono)
 
@@ -28349,7 +28458,7 @@ FROM, OUT OF THE USE OR INABILITY TO USE THE FONT SOFTWARE OR FROM
 OTHER DEALINGS IN THE FONT SOFTWARE.
 
 ------------------------------------------------------------------------------
-[146] Applies to: npm:@hono/node-server@1.19.14
+[147] Applies to: npm:@hono/node-server@1.19.14
 ------------------------------------------------------------------------------
 MIT License
 
@@ -28374,7 +28483,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
 ------------------------------------------------------------------------------
-[147] Applies to: npm:@iconify/types@2.0.0
+[148] Applies to: npm:@iconify/types@2.0.0
 ------------------------------------------------------------------------------
 MIT License
 
@@ -28399,7 +28508,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
 ------------------------------------------------------------------------------
-[148] Applies to: npm:@iconify/utils@3.1.4
+[149] Applies to: npm:@iconify/utils@3.1.4
 ------------------------------------------------------------------------------
 MIT License
 
@@ -28424,7 +28533,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
 ------------------------------------------------------------------------------
-[149] Applies to: npm:@img/colour@1.1.0
+[150] Applies to: npm:@img/colour@1.1.0
 ------------------------------------------------------------------------------
 # Licensing
 
@@ -28510,7 +28619,7 @@ The above copyright notice and this permission notice shall be included in all c
 THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[150] Applies to: npm:@img/sharp-darwin-arm64@0.34.5, npm:@img/sharp-darwin-arm64@0.35.3, npm:@img/sharp-darwin-x64@0.34.5, npm:@img/sharp-darwin-x64@0.35.3, npm:@img/sharp-linux-arm64@0.34.5, npm:@img/sharp-linux-arm64@0.35.3, npm:@img/sharp-linux-x64@0.34.5, npm:@img/sharp-linux-x64@0.35.3, npm:@img/sharp-win32-arm64@0.34.5, npm:@img/sharp-win32-arm64@0.35.3, npm:@img/sharp-win32-x64@0.34.5, npm:@img/sharp-win32-x64@0.35.3, npm:sharp@0.35.3
+[151] Applies to: npm:@img/sharp-darwin-arm64@0.34.5, npm:@img/sharp-darwin-arm64@0.35.3, npm:@img/sharp-darwin-x64@0.34.5, npm:@img/sharp-darwin-x64@0.35.3, npm:@img/sharp-linux-arm64@0.34.5, npm:@img/sharp-linux-arm64@0.35.3, npm:@img/sharp-linux-x64@0.34.5, npm:@img/sharp-linux-x64@0.35.3, npm:@img/sharp-win32-arm64@0.34.5, npm:@img/sharp-win32-arm64@0.35.3, npm:@img/sharp-win32-x64@0.34.5, npm:@img/sharp-win32-x64@0.35.3, npm:sharp@0.35.3
 ------------------------------------------------------------------------------
 Apache License
 Version 2.0, January 2004
@@ -28705,7 +28814,7 @@ third-party archives.
    limitations under the License.
 
 ------------------------------------------------------------------------------
-[151] Applies to: npm:@isaacs/cliui@8.0.2, npm:cliui@6.0.0, npm:cliui@8.0.1
+[152] Applies to: npm:@isaacs/cliui@8.0.2, npm:cliui@6.0.0, npm:cliui@8.0.1
 ------------------------------------------------------------------------------
 Copyright (c) 2015, Contributors
 
@@ -28723,7 +28832,7 @@ WHETHER IN AN ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION,
 ARISING OUT OF OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
 
 ------------------------------------------------------------------------------
-[152] Applies to: npm:@isaacs/fs-minipass@4.0.1, npm:chownr@1.1.4, npm:ini@1.3.8, npm:isexe@2.0.0, npm:lru-cache@5.1.1, npm:once@1.4.0, npm:semver@6.3.1, npm:semver@7.8.5, npm:which@2.0.2, npm:wrappy@1.0.2, npm:yallist@3.1.1
+[153] Applies to: npm:@isaacs/fs-minipass@4.0.1, npm:chownr@1.1.4, npm:fstream@1.0.12, npm:ini@1.3.8, npm:isexe@2.0.0, npm:lru-cache@5.1.1, npm:minimatch@3.1.5, npm:once@1.4.0, npm:rimraf@2.6.3, npm:semver@6.3.1, npm:semver@7.8.5, npm:which@2.0.2, npm:wrappy@1.0.2, npm:yallist@3.1.1
 ------------------------------------------------------------------------------
 The ISC License
 
@@ -28742,7 +28851,7 @@ ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF OR
 IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
 
 ------------------------------------------------------------------------------
-[153] Applies to: npm:@isaacs/ttlcache@1.4.1
+[154] Applies to: npm:@isaacs/ttlcache@1.4.1
 ------------------------------------------------------------------------------
 The ISC License
 
@@ -28761,7 +28870,7 @@ ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF OR
 IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
 
 ------------------------------------------------------------------------------
-[154] Applies to: npm:@japont/unicode-range@1.0.0
+[155] Applies to: npm:@japont/unicode-range@1.0.0
 ------------------------------------------------------------------------------
 The MIT License (MIT)
 Copyright © 2018 3846masa
@@ -28785,7 +28894,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[155] Applies to: npm:@jest/schemas@29.6.3, npm:@jest/types@29.6.3, npm:babel-plugin-syntax-hermes-parser@0.33.3, npm:hermes-estree@0.33.3, npm:hermes-estree@0.35.0, npm:hermes-parser@0.33.3, npm:hermes-parser@0.35.0, npm:jest-get-type@29.6.3, npm:jest-util@29.7.0, npm:jest-validate@29.7.0, npm:jest-worker@29.7.0, npm:pretty-format@29.7.0, npm:react@19.2.3, npm:react-dom@19.2.3, npm:react-is@19.2.7, npm:react-native@0.85.3, npm:scheduler@0.27.0, npm:use-sync-external-store@1.6.0
+[156] Applies to: npm:@jest/schemas@29.6.3, npm:@jest/types@29.6.3, npm:babel-plugin-syntax-hermes-parser@0.36.0, npm:babel-plugin-syntax-hermes-parser@0.36.1, npm:hermes-estree@0.35.0, npm:hermes-estree@0.36.0, npm:hermes-estree@0.36.1, npm:hermes-parser@0.35.0, npm:hermes-parser@0.36.0, npm:hermes-parser@0.36.1, npm:jest-get-type@29.6.3, npm:jest-util@29.7.0, npm:jest-validate@29.7.0, npm:jest-worker@29.7.0, npm:pretty-format@29.7.0, npm:react@19.2.3, npm:react-dom@19.2.3, npm:react-is@19.2.7, npm:react-native@0.86.3, npm:scheduler@0.27.0, npm:use-sync-external-store@1.6.0
 ------------------------------------------------------------------------------
 MIT License
 
@@ -28810,7 +28919,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
 ------------------------------------------------------------------------------
-[156] Applies to: npm:@jridgewell/gen-mapping@0.3.13, npm:@jridgewell/remapping@2.3.5, npm:@jridgewell/source-map@0.3.11, npm:@jridgewell/sourcemap-codec@1.5.5, npm:@jridgewell/trace-mapping@0.3.31
+[157] Applies to: npm:@jridgewell/gen-mapping@0.3.13, npm:@jridgewell/remapping@2.3.5, npm:@jridgewell/source-map@0.3.11, npm:@jridgewell/sourcemap-codec@1.5.5, npm:@jridgewell/trace-mapping@0.3.31
 ------------------------------------------------------------------------------
 Copyright 2024 Justin Ridgewell <justin@ridgewell.name>
 
@@ -28833,7 +28942,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
 ------------------------------------------------------------------------------
-[157] Applies to: npm:@jridgewell/resolve-uri@3.1.2
+[158] Applies to: npm:@jridgewell/resolve-uri@3.1.2
 ------------------------------------------------------------------------------
 Copyright 2019 Justin Ridgewell <jridgewell@google.com>
 
@@ -28856,7 +28965,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
 ------------------------------------------------------------------------------
-[158] Applies to: npm:@kwsites/file-exists@1.1.1
+[159] Applies to: npm:@kwsites/file-exists@1.1.1
 ------------------------------------------------------------------------------
 The MIT License (MIT)
 
@@ -28880,7 +28989,7 @@ IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
 CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[159] Applies to: npm:@kwsites/promise-deferred@1.1.1
+[160] Applies to: npm:@kwsites/promise-deferred@1.1.1
 ------------------------------------------------------------------------------
 MIT License
 
@@ -28905,7 +29014,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
 ------------------------------------------------------------------------------
-[160] Applies to: npm:@larksuiteoapi/node-sdk@1.71.1
+[161] Applies to: npm:@larksuiteoapi/node-sdk@1.71.1
 ------------------------------------------------------------------------------
 MIT License
 
@@ -28918,7 +29027,7 @@ The above copyright notice and this permission notice, shall be included in all 
 THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[161] Applies to: npm:@legendapp/list@3.3.3
+[162] Applies to: npm:@legendapp/list@3.3.3
 ------------------------------------------------------------------------------
 MIT License
 
@@ -28943,7 +29052,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
 ------------------------------------------------------------------------------
-[162] Applies to: npm:@lezer/common@1.5.2, npm:@lezer/css@1.3.4, npm:@lezer/highlight@1.2.3, npm:@lezer/html@1.3.13, npm:@lezer/javascript@1.5.4, npm:@lezer/lr@1.4.10, npm:@lezer/php@1.0.5, npm:@lezer/rust@1.0.2, npm:@lezer/xml@1.0.6
+[163] Applies to: npm:@lezer/common@1.5.2, npm:@lezer/css@1.3.4, npm:@lezer/highlight@1.2.3, npm:@lezer/html@1.3.13, npm:@lezer/javascript@1.5.4, npm:@lezer/lr@1.4.10, npm:@lezer/php@1.0.5, npm:@lezer/rust@1.0.2, npm:@lezer/xml@1.0.6
 ------------------------------------------------------------------------------
 MIT License
 
@@ -28968,7 +29077,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[163] Applies to: npm:@lezer/cpp@1.1.6, npm:@lezer/go@1.0.1, npm:@lezer/java@1.1.3, npm:@lezer/markdown@1.7.2, npm:@lezer/python@1.1.19
+[164] Applies to: npm:@lezer/cpp@1.1.6, npm:@lezer/go@1.0.1, npm:@lezer/java@1.1.3, npm:@lezer/markdown@1.7.2, npm:@lezer/python@1.1.19
 ------------------------------------------------------------------------------
 MIT License
 
@@ -28993,7 +29102,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[164] Applies to: npm:@lezer/json@1.0.3
+[165] Applies to: npm:@lezer/json@1.0.3
 ------------------------------------------------------------------------------
 MIT License
 
@@ -29018,7 +29127,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[165] Applies to: npm:@lezer/yaml@1.0.4
+[166] Applies to: npm:@lezer/yaml@1.0.4
 ------------------------------------------------------------------------------
 MIT License
 
@@ -29043,7 +29152,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[166] Applies to: npm:@lit/reactive-element@2.1.2, npm:lit@3.3.3, npm:lit-element@4.2.2, npm:lit-html@3.3.3
+[167] Applies to: npm:@lit/reactive-element@2.1.2, npm:lit@3.3.3, npm:lit-element@4.2.2, npm:lit-html@3.3.3
 ------------------------------------------------------------------------------
 BSD 3-Clause License
 
@@ -29075,7 +29184,7 @@ OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 ------------------------------------------------------------------------------
-[167] Applies to: npm:@marijn/find-cluster-break@1.0.3
+[168] Applies to: npm:@marijn/find-cluster-break@1.0.3
 ------------------------------------------------------------------------------
 MIT License
 
@@ -29100,7 +29209,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[168] Applies to: npm:@mermaid-js/parser@1.2.0
+[169] Applies to: npm:@mermaid-js/parser@1.2.0
 ------------------------------------------------------------------------------
 The MIT License (MIT)
 
@@ -29125,7 +29234,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
 ------------------------------------------------------------------------------
-[169] Applies to: npm:@modelcontextprotocol/sdk@1.29.0
+[170] Applies to: npm:@modelcontextprotocol/sdk@1.29.0
 ------------------------------------------------------------------------------
 MIT License
 
@@ -29150,7 +29259,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
 ------------------------------------------------------------------------------
-[170] Applies to: npm:@monogrid/gainmap-js@3.4.0
+[171] Applies to: npm:@monogrid/gainmap-js@3.4.0
 ------------------------------------------------------------------------------
 MIT License
 
@@ -29175,7 +29284,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
 ------------------------------------------------------------------------------
-[171] Applies to: npm:@napi-rs/canvas@0.1.100
+[172] Applies to: npm:@napi-rs/canvas@0.1.100
 ------------------------------------------------------------------------------
 MIT License
 
@@ -29200,7 +29309,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
 ------------------------------------------------------------------------------
-[172] Applies to: npm:@noble/hashes@1.8.0
+[173] Applies to: npm:@noble/hashes@1.8.0
 ------------------------------------------------------------------------------
 The MIT License (MIT)
 
@@ -29225,7 +29334,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[173] Applies to: npm:@paralleldrive/cuid2@2.3.1
+[174] Applies to: npm:@paralleldrive/cuid2@2.3.1
 ------------------------------------------------------------------------------
 MIT License
 
@@ -29250,7 +29359,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
 ------------------------------------------------------------------------------
-[174] Applies to: npm:@parcel/watcher@2.5.6, npm:@parcel/watcher-darwin-arm64@2.5.6, npm:@parcel/watcher-darwin-x64@2.5.6, npm:@parcel/watcher-linux-arm64-glibc@2.5.6, npm:@parcel/watcher-linux-x64-glibc@2.5.6, npm:@parcel/watcher-win32-arm64@2.5.6, npm:@parcel/watcher-win32-x64@2.5.6
+[175] Applies to: npm:@parcel/watcher@2.5.6, npm:@parcel/watcher-darwin-arm64@2.5.6, npm:@parcel/watcher-darwin-x64@2.5.6, npm:@parcel/watcher-linux-arm64-glibc@2.5.6, npm:@parcel/watcher-linux-x64-glibc@2.5.6, npm:@parcel/watcher-win32-arm64@2.5.6, npm:@parcel/watcher-win32-x64@2.5.6
 ------------------------------------------------------------------------------
 MIT License
 
@@ -29275,7 +29384,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
 ------------------------------------------------------------------------------
-[175] Applies to: npm:@protobufjs/aspromise@1.1.2, npm:@protobufjs/base64@1.1.2, npm:@protobufjs/codegen@2.0.5, npm:@protobufjs/eventemitter@1.1.1, npm:@protobufjs/fetch@1.1.1, npm:@protobufjs/float@1.0.2, npm:@protobufjs/path@1.1.2, npm:@protobufjs/pool@1.1.0, npm:@protobufjs/utf8@1.1.2
+[176] Applies to: npm:@protobufjs/aspromise@1.1.2, npm:@protobufjs/base64@1.1.2, npm:@protobufjs/codegen@2.0.5, npm:@protobufjs/eventemitter@1.1.1, npm:@protobufjs/fetch@1.1.1, npm:@protobufjs/float@1.0.2, npm:@protobufjs/path@1.1.2, npm:@protobufjs/pool@1.1.0, npm:@protobufjs/utf8@1.1.2
 ------------------------------------------------------------------------------
 Copyright (c) 2016, Daniel Wirtz  All rights reserved.
 
@@ -29305,7 +29414,7 @@ THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
 OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 ------------------------------------------------------------------------------
-[176] Applies to: npm:@radix-ui/number@1.1.2, npm:@radix-ui/primitive@1.1.5, npm:@radix-ui/react-alert-dialog@1.1.19, npm:@radix-ui/react-arrow@1.1.11, npm:@radix-ui/react-collection@1.1.12, npm:@radix-ui/react-compose-refs@1.1.3, npm:@radix-ui/react-context@1.2.0, npm:@radix-ui/react-dialog@1.1.19, npm:@radix-ui/react-direction@1.1.2, npm:@radix-ui/react-dismissable-layer@1.1.15, npm:@radix-ui/react-dropdown-menu@2.1.20, npm:@radix-ui/react-focus-guards@1.1.4, npm:@radix-ui/react-focus-scope@1.1.12, npm:@radix-ui/react-id@1.1.2, npm:@radix-ui/react-menu@2.1.20, npm:@radix-ui/react-popover@1.1.19, npm:@radix-ui/react-popper@1.3.3, npm:@radix-ui/react-portal@1.1.13, npm:@radix-ui/react-presence@1.1.7, npm:@radix-ui/react-primitive@2.1.7, npm:@radix-ui/react-roving-focus@1.1.15, npm:@radix-ui/react-select@2.3.3, npm:@radix-ui/react-slider@1.4.3, npm:@radix-ui/react-slot@1.3.0, npm:@radix-ui/react-switch@1.3.3, npm:@radix-ui/react-tabs@1.1.17, npm:@radix-ui/react-tooltip@1.2.12, npm:@radix-ui/react-use-callback-ref@1.1.2, npm:@radix-ui/react-use-controllable-state@1.2.3, npm:@radix-ui/react-use-effect-event@0.0.3, npm:@radix-ui/react-use-is-hydrated@0.1.1, npm:@radix-ui/react-use-layout-effect@1.1.2, npm:@radix-ui/react-use-previous@1.1.2, npm:@radix-ui/react-use-rect@1.1.2, npm:@radix-ui/react-use-size@1.1.2, npm:@radix-ui/react-visually-hidden@1.2.7, npm:@radix-ui/rect@1.1.2
+[177] Applies to: npm:@radix-ui/number@1.1.2, npm:@radix-ui/primitive@1.1.5, npm:@radix-ui/react-alert-dialog@1.1.19, npm:@radix-ui/react-arrow@1.1.11, npm:@radix-ui/react-collection@1.1.12, npm:@radix-ui/react-compose-refs@1.1.3, npm:@radix-ui/react-context@1.2.0, npm:@radix-ui/react-dialog@1.1.19, npm:@radix-ui/react-direction@1.1.2, npm:@radix-ui/react-dismissable-layer@1.1.15, npm:@radix-ui/react-dropdown-menu@2.1.20, npm:@radix-ui/react-focus-guards@1.1.4, npm:@radix-ui/react-focus-scope@1.1.12, npm:@radix-ui/react-id@1.1.2, npm:@radix-ui/react-menu@2.1.20, npm:@radix-ui/react-popover@1.1.19, npm:@radix-ui/react-popper@1.3.3, npm:@radix-ui/react-portal@1.1.13, npm:@radix-ui/react-presence@1.1.7, npm:@radix-ui/react-primitive@2.1.7, npm:@radix-ui/react-roving-focus@1.1.15, npm:@radix-ui/react-select@2.3.3, npm:@radix-ui/react-slider@1.4.3, npm:@radix-ui/react-slot@1.3.0, npm:@radix-ui/react-switch@1.3.3, npm:@radix-ui/react-tabs@1.1.17, npm:@radix-ui/react-tooltip@1.2.12, npm:@radix-ui/react-use-callback-ref@1.1.2, npm:@radix-ui/react-use-controllable-state@1.2.3, npm:@radix-ui/react-use-effect-event@0.0.3, npm:@radix-ui/react-use-is-hydrated@0.1.1, npm:@radix-ui/react-use-layout-effect@1.1.2, npm:@radix-ui/react-use-previous@1.1.2, npm:@radix-ui/react-use-rect@1.1.2, npm:@radix-ui/react-use-size@1.1.2, npm:@radix-ui/react-visually-hidden@1.2.7, npm:@radix-ui/rect@1.1.2
 ------------------------------------------------------------------------------
 MIT License
 
@@ -29330,7 +29439,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
 ------------------------------------------------------------------------------
-[177] Applies to: npm:@react-native-async-storage/async-storage@2.2.0, npm:@react-native-masked-view/masked-view@0.3.2, npm:react-native-webview@13.16.1
+[178] Applies to: npm:@react-native-async-storage/async-storage@2.2.0, npm:@react-native-masked-view/masked-view@0.3.2, npm:react-native-webview@13.16.1
 ------------------------------------------------------------------------------
 MIT License
 
@@ -29355,7 +29464,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
 ------------------------------------------------------------------------------
-[178] Applies to: npm:@react-native-google-signin/google-signin@16.1.2
+[179] Applies to: npm:@react-native-google-signin/google-signin@16.1.2
 ------------------------------------------------------------------------------
 The MIT License (MIT)
 
@@ -29380,7 +29489,32 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
 ------------------------------------------------------------------------------
-[179] Applies to: npm:@replit/codemirror-lang-csharp@6.2.0
+[180] Applies to: npm:@react-native-menu/menu@2.0.0
+------------------------------------------------------------------------------
+MIT License
+
+Copyright (c) 2020 Jesse Katsumata
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+
+------------------------------------------------------------------------------
+[181] Applies to: npm:@replit/codemirror-lang-csharp@6.2.0
 ------------------------------------------------------------------------------
 MIT License
 
@@ -29405,7 +29539,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
 ------------------------------------------------------------------------------
-[180] Applies to: npm:@sapphire/shapeshift@4.0.0
+[182] Applies to: npm:@sapphire/shapeshift@4.0.0
 ------------------------------------------------------------------------------
 # The MIT License (MIT)
 
@@ -29433,7 +29567,7 @@ FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
 OTHER DEALINGS IN THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[181] Applies to: npm:@sinclair/typebox@0.27.10
+[183] Applies to: npm:@sinclair/typebox@0.27.10
 ------------------------------------------------------------------------------
 TypeBox: JSON Schema Type Builder with Static Type Resolution for TypeScript
 
@@ -29460,59 +29594,11 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[182] Applies to: npm:@tanstack/react-virtual@3.14.6, npm:@tanstack/virtual-core@3.17.4
+[184] Applies to: npm:@tanstack/react-virtual@3.14.6, npm:@tanstack/virtual-core@3.17.4
 ------------------------------------------------------------------------------
 MIT License
 
 Copyright (c) 2021-present Tanner Linsley
-
-Permission is hereby granted, free of charge, to any person obtaining a copy
-of this software and associated documentation files (the "Software"), to deal
-in the Software without restriction, including without limitation the rights
-to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-copies of the Software, and to permit persons to whom the Software is
-furnished to do so, subject to the following conditions:
-
-The above copyright notice and this permission notice shall be included in all
-copies or substantial portions of the Software.
-
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
-SOFTWARE.
-
-------------------------------------------------------------------------------
-[183] Applies to: npm:@testing-library/jest-dom@6.9.1
-------------------------------------------------------------------------------
-The MIT License (MIT)
-Copyright (c) 2017 Kent C. Dodds
-
-Permission is hereby granted, free of charge, to any person obtaining a copy
-of this software and associated documentation files (the "Software"), to deal
-in the Software without restriction, including without limitation the rights
-to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-copies of the Software, and to permit persons to whom the Software is
-furnished to do so, subject to the following conditions:
-
-The above copyright notice and this permission notice shall be included in all
-copies or substantial portions of the Software.
-
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
-SOFTWARE.
-
-------------------------------------------------------------------------------
-[184] Applies to: npm:@testing-library/user-event@14.6.1
-------------------------------------------------------------------------------
-The MIT License (MIT)
-Copyright (c) 2020 Giorgio Polvara
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal
@@ -29558,7 +29644,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
 ------------------------------------------------------------------------------
-[186] Applies to: npm:@types/d3@7.4.3, npm:@types/d3-array@3.2.2, npm:@types/d3-axis@3.0.6, npm:@types/d3-brush@3.0.6, npm:@types/d3-chord@3.0.6, npm:@types/d3-color@3.1.3, npm:@types/d3-contour@3.0.6, npm:@types/d3-delaunay@6.0.4, npm:@types/d3-dispatch@3.0.7, npm:@types/d3-drag@3.0.7, npm:@types/d3-dsv@3.0.7, npm:@types/d3-ease@3.0.2, npm:@types/d3-fetch@3.0.7, npm:@types/d3-force@3.0.10, npm:@types/d3-format@3.0.4, npm:@types/d3-geo@3.1.0, npm:@types/d3-hierarchy@3.1.7, npm:@types/d3-interpolate@3.0.4, npm:@types/d3-path@3.1.1, npm:@types/d3-polygon@3.0.2, npm:@types/d3-quadtree@3.0.6, npm:@types/d3-random@3.0.4, npm:@types/d3-scale@4.0.9, npm:@types/d3-scale-chromatic@3.1.0, npm:@types/d3-selection@3.0.11, npm:@types/d3-shape@3.1.8, npm:@types/d3-time@3.0.4, npm:@types/d3-time-format@4.0.3, npm:@types/d3-timer@3.0.2, npm:@types/d3-transition@3.0.9, npm:@types/d3-zoom@3.0.8, npm:@types/debug@4.1.13, npm:@types/estree@1.0.9, npm:@types/estree-jsx@1.0.5, npm:@types/geojson@7946.0.16, npm:@types/hast@3.0.5, npm:@types/istanbul-lib-coverage@2.0.6, npm:@types/istanbul-lib-report@3.0.3, npm:@types/istanbul-reports@3.0.4, npm:@types/katex@0.16.8, npm:@types/mdast@4.0.4, npm:@types/ms@2.1.0, npm:@types/node@25.9.5, npm:@types/pako@2.0.4, npm:@types/react@19.2.17, npm:@types/react-test-renderer@19.1.0, npm:@types/trusted-types@2.0.7, npm:@types/unist@2.0.11, npm:@types/unist@3.0.3, npm:@types/use-sync-external-store@0.0.6, npm:@types/ws@8.18.1, npm:@types/yargs@17.0.35, npm:@types/yargs-parser@21.0.3
+[186] Applies to: npm:@types/d3@7.4.3, npm:@types/d3-array@3.2.2, npm:@types/d3-axis@3.0.6, npm:@types/d3-brush@3.0.6, npm:@types/d3-chord@3.0.6, npm:@types/d3-color@3.1.3, npm:@types/d3-contour@3.0.6, npm:@types/d3-delaunay@6.0.4, npm:@types/d3-dispatch@3.0.7, npm:@types/d3-drag@3.0.7, npm:@types/d3-dsv@3.0.7, npm:@types/d3-ease@3.0.2, npm:@types/d3-fetch@3.0.7, npm:@types/d3-force@3.0.10, npm:@types/d3-format@3.0.4, npm:@types/d3-geo@3.1.0, npm:@types/d3-hierarchy@3.1.7, npm:@types/d3-interpolate@3.0.4, npm:@types/d3-path@3.1.1, npm:@types/d3-polygon@3.0.2, npm:@types/d3-quadtree@3.0.6, npm:@types/d3-random@3.0.4, npm:@types/d3-scale@4.0.9, npm:@types/d3-scale-chromatic@3.1.0, npm:@types/d3-selection@3.0.11, npm:@types/d3-shape@3.1.8, npm:@types/d3-time@3.0.4, npm:@types/d3-time-format@4.0.3, npm:@types/d3-timer@3.0.2, npm:@types/d3-transition@3.0.9, npm:@types/d3-zoom@3.0.8, npm:@types/debug@4.1.13, npm:@types/estree@1.0.9, npm:@types/estree-jsx@1.0.5, npm:@types/geojson@7946.0.16, npm:@types/hammerjs@2.0.46, npm:@types/hast@3.0.5, npm:@types/istanbul-lib-coverage@2.0.6, npm:@types/istanbul-lib-report@3.0.3, npm:@types/istanbul-reports@3.0.4, npm:@types/katex@0.16.8, npm:@types/mdast@4.0.4, npm:@types/ms@2.1.0, npm:@types/node@14.18.63, npm:@types/node@22.20.1, npm:@types/node@25.9.5, npm:@types/pako@2.0.4, npm:@types/react@19.2.17, npm:@types/react-test-renderer@19.1.0, npm:@types/trusted-types@2.0.7, npm:@types/unist@2.0.11, npm:@types/unist@3.0.3, npm:@types/use-sync-external-store@0.0.6, npm:@types/ws@8.18.1, npm:@types/yargs@17.0.35, npm:@types/yargs-parser@21.0.3
 ------------------------------------------------------------------------------
 MIT License
 
@@ -29865,7 +29951,7 @@ TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
 SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[199] Applies to: npm:agent-cli-detector@0.1.2
+[199] Applies to: npm:agent-cli-detector@0.1.6, npm:sandbox-cli-detector@0.2.0
 ------------------------------------------------------------------------------
 MIT License
 
@@ -29978,7 +30064,7 @@ The above copyright notice and this permission notice shall be included in all c
 THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[204] Applies to: npm:ansi-regex@4.1.1, npm:ansi-regex@5.0.1, npm:ansi-styles@3.2.1, npm:ansi-styles@4.3.0, npm:ansi-styles@5.2.0, npm:camelcase@5.3.1, npm:chalk@2.4.2, npm:chalk@4.1.2, npm:env-paths@2.2.1, npm:find-up@3.0.0, npm:find-up@4.1.0, npm:has-flag@3.0.0, npm:has-flag@4.0.0, npm:indent-string@4.0.0, npm:is-fullwidth-code-point@3.0.0, npm:is-obj@2.0.0, npm:is-plain-obj@2.1.0, npm:is-wsl@2.2.0, npm:lcid@3.1.1, npm:leven@3.1.0, npm:locate-path@3.0.0, npm:locate-path@5.0.0, npm:log-symbols@2.2.0, npm:make-dir@3.1.0, npm:mimic-fn@1.2.0, npm:mimic-fn@2.1.0, npm:mimic-fn@3.1.0, npm:npm-run-path@4.0.1, npm:ora@3.4.0, npm:p-limit@2.3.0, npm:p-locate@3.0.0, npm:p-locate@4.1.0, npm:p-try@2.2.0, npm:path-exists@4.0.0, npm:path-key@3.1.1, npm:pkg-up@3.1.0, npm:redent@3.0.0, npm:resolve-from@5.0.0, npm:shebang-regex@3.0.0, npm:split-on-first@1.1.0, npm:string-width@4.2.3, npm:strip-ansi@5.2.0, npm:strip-ansi@6.0.1, npm:strip-final-newline@2.0.0, npm:strip-indent@3.0.0, npm:supports-color@5.5.0, npm:supports-color@7.2.0, npm:terminal-link@2.1.1, npm:type-fest@0.7.1, npm:wrap-ansi@6.2.0
+[204] Applies to: npm:ansi-regex@4.1.1, npm:ansi-regex@5.0.1, npm:ansi-styles@3.2.1, npm:ansi-styles@4.3.0, npm:ansi-styles@5.2.0, npm:camelcase@5.3.1, npm:chalk@2.4.2, npm:chalk@4.1.2, npm:env-paths@2.2.1, npm:find-up@3.0.0, npm:find-up@4.1.0, npm:has-flag@3.0.0, npm:has-flag@4.0.0, npm:is-fullwidth-code-point@3.0.0, npm:is-obj@2.0.0, npm:is-plain-obj@2.1.0, npm:is-wsl@2.2.0, npm:lcid@3.1.1, npm:leven@3.1.0, npm:locate-path@3.0.0, npm:locate-path@5.0.0, npm:log-symbols@2.2.0, npm:make-dir@3.1.0, npm:mimic-fn@1.2.0, npm:mimic-fn@2.1.0, npm:mimic-fn@3.1.0, npm:npm-run-path@4.0.1, npm:ora@3.4.0, npm:p-limit@2.3.0, npm:p-locate@3.0.0, npm:p-locate@4.1.0, npm:p-try@2.2.0, npm:path-exists@4.0.0, npm:path-key@3.1.1, npm:pkg-up@3.1.0, npm:resolve-from@5.0.0, npm:shebang-regex@3.0.0, npm:split-on-first@1.1.0, npm:string-width@4.2.3, npm:strip-ansi@5.2.0, npm:strip-ansi@6.0.1, npm:strip-final-newline@2.0.0, npm:supports-color@5.5.0, npm:supports-color@7.2.0, npm:terminal-link@2.1.1, npm:type-fest@0.7.1, npm:wrap-ansi@6.2.0
 ------------------------------------------------------------------------------
 MIT License
 
@@ -29991,7 +30077,59 @@ The above copyright notice and this permission notice shall be included in all c
 THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[205] Applies to: npm:arg@4.1.3
+[205] Applies to: npm:archiver@5.3.2
+------------------------------------------------------------------------------
+Copyright (c) 2012-2014 Chris Talkington, contributors.
+
+Permission is hereby granted, free of charge, to any person
+obtaining a copy of this software and associated documentation
+files (the "Software"), to deal in the Software without
+restriction, including without limitation the rights to use,
+copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the
+Software is furnished to do so, subject to the following
+conditions:
+
+The above copyright notice and this permission notice shall be
+included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
+OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+OTHER DEALINGS IN THE SOFTWARE.
+
+------------------------------------------------------------------------------
+[206] Applies to: npm:archiver-utils@2.1.0, npm:archiver-utils@3.0.4
+------------------------------------------------------------------------------
+Copyright (c) 2015 Chris Talkington.
+
+Permission is hereby granted, free of charge, to any person
+obtaining a copy of this software and associated documentation
+files (the "Software"), to deal in the Software without
+restriction, including without limitation the rights to use,
+copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the
+Software is furnished to do so, subject to the following
+conditions:
+
+The above copyright notice and this permission notice shall be
+included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
+OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+OTHER DEALINGS IN THE SOFTWARE.
+
+------------------------------------------------------------------------------
+[207] Applies to: npm:arg@4.1.3
 ------------------------------------------------------------------------------
 MIT License
 
@@ -30016,7 +30154,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
 ------------------------------------------------------------------------------
-[206] Applies to: npm:arg@5.0.2
+[208] Applies to: npm:arg@5.0.2
 ------------------------------------------------------------------------------
 The MIT License (MIT)
 
@@ -30041,7 +30179,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
 ------------------------------------------------------------------------------
-[207] Applies to: npm:argparse@1.0.10
+[209] Applies to: npm:argparse@1.0.10
 ------------------------------------------------------------------------------
 (The MIT License)
 
@@ -30066,7 +30204,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[208] Applies to: npm:argparse@2.0.1
+[210] Applies to: npm:argparse@2.0.1
 ------------------------------------------------------------------------------
 A. HISTORY OF THE SOFTWARE
 ==========================
@@ -30324,7 +30462,7 @@ ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT
 OF OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
 
 ------------------------------------------------------------------------------
-[209] Applies to: npm:aria-hidden@1.2.6, npm:react-remove-scroll@2.7.2, npm:react-style-singleton@2.2.3, npm:use-callback-ref@1.3.3, npm:use-sidecar@1.1.3
+[211] Applies to: npm:aria-hidden@1.2.6, npm:react-remove-scroll@2.7.2, npm:react-style-singleton@2.2.3, npm:use-callback-ref@1.3.3, npm:use-sidecar@1.1.3
 ------------------------------------------------------------------------------
 MIT License
 
@@ -30349,212 +30487,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
 ------------------------------------------------------------------------------
-[210] Applies to: npm:aria-query@5.3.2
-------------------------------------------------------------------------------
-Apache License
-Version 2.0, January 2004
-http://www.apache.org/licenses/
-
-TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
-
-1. Definitions.
-
-"License" shall mean the terms and conditions for use, reproduction,
-and distribution as defined by Sections 1 through 9 of this document.
-
-"Licensor" shall mean the copyright owner or entity authorized by
-the copyright owner that is granting the License.
-
-"Legal Entity" shall mean the union of the acting entity and all
-other entities that control, are controlled by, or are under common
-control with that entity. For the purposes of this definition,
-"control" means (i) the power, direct or indirect, to cause the
-direction or management of such entity, whether by contract or
-otherwise, or (ii) ownership of fifty percent (50%) or more of the
-outstanding shares, or (iii) beneficial ownership of such entity.
-
-"You" (or "Your") shall mean an individual or Legal Entity
-exercising permissions granted by this License.
-
-"Source" form shall mean the preferred form for making modifications,
-including but not limited to software source code, documentation
-source, and configuration files.
-
-"Object" form shall mean any form resulting from mechanical
-transformation or translation of a Source form, including but
-not limited to compiled object code, generated documentation,
-and conversions to other media types.
-
-"Work" shall mean the work of authorship, whether in Source or
-Object form, made available under the License, as indicated by a
-copyright notice that is included in or attached to the work
-(an example is provided in the Appendix below).
-
-"Derivative Works" shall mean any work, whether in Source or Object
-form, that is based on (or derived from) the Work and for which the
-editorial revisions, annotations, elaborations, or other modifications
-represent, as a whole, an original work of authorship. For the purposes
-of this License, Derivative Works shall not include works that remain
-separable from, or merely link (or bind by name) to the interfaces of,
-the Work and Derivative Works thereof.
-
-"Contribution" shall mean any work of authorship, including
-the original version of the Work and any modifications or additions
-to that Work or Derivative Works thereof, that is intentionally
-submitted to Licensor for inclusion in the Work by the copyright owner
-or by an individual or Legal Entity authorized to submit on behalf of
-the copyright owner. For the purposes of this definition, "submitted"
-means any form of electronic, verbal, or written communication sent
-to the Licensor or its representatives, including but not limited to
-communication on electronic mailing lists, source code control systems,
-and issue tracking systems that are managed by, or on behalf of, the
-Licensor for the purpose of discussing and improving the Work, but
-excluding communication that is conspicuously marked or otherwise
-designated in writing by the copyright owner as "Not a Contribution."
-
-"Contributor" shall mean Licensor and any individual or Legal Entity
-on behalf of whom a Contribution has been received by Licensor and
-subsequently incorporated within the Work.
-
-2. Grant of Copyright License. Subject to the terms and conditions of
-this License, each Contributor hereby grants to You a perpetual,
-worldwide, non-exclusive, no-charge, royalty-free, irrevocable
-copyright license to reproduce, prepare Derivative Works of,
-publicly display, publicly perform, sublicense, and distribute the
-Work and such Derivative Works in Source or Object form.
-
-3. Grant of Patent License. Subject to the terms and conditions of
-this License, each Contributor hereby grants to You a perpetual,
-worldwide, non-exclusive, no-charge, royalty-free, irrevocable
-(except as stated in this section) patent license to make, have made,
-use, offer to sell, sell, import, and otherwise transfer the Work,
-where such license applies only to those patent claims licensable
-by such Contributor that are necessarily infringed by their
-Contribution(s) alone or by combination of their Contribution(s)
-with the Work to which such Contribution(s) was submitted. If You
-institute patent litigation against any entity (including a
-cross-claim or counterclaim in a lawsuit) alleging that the Work
-or a Contribution incorporated within the Work constitutes direct
-or contributory patent infringement, then any patent licenses
-granted to You under this License for that Work shall terminate
-as of the date such litigation is filed.
-
-4. Redistribution. You may reproduce and distribute copies of the
-Work or Derivative Works thereof in any medium, with or without
-modifications, and in Source or Object form, provided that You
-meet the following conditions:
-
-(a) You must give any other recipients of the Work or
-Derivative Works a copy of this License; and
-
-(b) You must cause any modified files to carry prominent notices
-stating that You changed the files; and
-
-(c) You must retain, in the Source form of any Derivative Works
-that You distribute, all copyright, patent, trademark, and
-attribution notices from the Source form of the Work,
-excluding those notices that do not pertain to any part of
-the Derivative Works; and
-
-(d) If the Work includes a "NOTICE" text file as part of its
-distribution, then any Derivative Works that You distribute must
-include a readable copy of the attribution notices contained
-within such NOTICE file, excluding those notices that do not
-pertain to any part of the Derivative Works, in at least one
-of the following places: within a NOTICE text file distributed
-as part of the Derivative Works; within the Source form or
-documentation, if provided along with the Derivative Works; or,
-within a display generated by the Derivative Works, if and
-wherever such third-party notices normally appear. The contents
-of the NOTICE file are for informational purposes only and
-do not modify the License. You may add Your own attribution
-notices within Derivative Works that You distribute, alongside
-or as an addendum to the NOTICE text from the Work, provided
-that such additional attribution notices cannot be construed
-as modifying the License.
-
-You may add Your own copyright statement to Your modifications and
-may provide additional or different license terms and conditions
-for use, reproduction, or distribution of Your modifications, or
-for any such Derivative Works as a whole, provided Your use,
-reproduction, and distribution of the Work otherwise complies with
-the conditions stated in this License.
-
-5. Submission of Contributions. Unless You explicitly state otherwise,
-any Contribution intentionally submitted for inclusion in the Work
-by You to the Licensor shall be under the terms and conditions of
-this License, without any additional terms or conditions.
-Notwithstanding the above, nothing herein shall supersede or modify
-the terms of any separate license agreement you may have executed
-with Licensor regarding such Contributions.
-
-6. Trademarks. This License does not grant permission to use the trade
-names, trademarks, service marks, or product names of the Licensor,
-except as required for reasonable and customary use in describing the
-origin of the Work and reproducing the content of the NOTICE file.
-
-7. Disclaimer of Warranty. Unless required by applicable law or
-agreed to in writing, Licensor provides the Work (and each
-Contributor provides its Contributions) on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
-implied, including, without limitation, any warranties or conditions
-of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
-PARTICULAR PURPOSE. You are solely responsible for determining the
-appropriateness of using or redistributing the Work and assume any
-risks associated with Your exercise of permissions under this License.
-
-8. Limitation of Liability. In no event and under no legal theory,
-whether in tort (including negligence), contract, or otherwise,
-unless required by applicable law (such as deliberate and grossly
-negligent acts) or agreed to in writing, shall any Contributor be
-liable to You for damages, including any direct, indirect, special,
-incidental, or consequential damages of any character arising as a
-result of this License or out of the use or inability to use the
-Work (including but not limited to damages for loss of goodwill,
-work stoppage, computer failure or malfunction, or any and all
-other commercial damages or losses), even if such Contributor
-has been advised of the possibility of such damages.
-
-9. Accepting Warranty or Additional Liability. While redistributing
-the Work or Derivative Works thereof, You may choose to offer,
-and charge a fee for, acceptance of support, warranty, indemnity,
-or other liability obligations and/or rights consistent with this
-License. However, in accepting such obligations, You may act only
-on Your own behalf and on Your sole responsibility, not on behalf
-of any other Contributor, and only if You agree to indemnify,
-defend, and hold each Contributor harmless for any liability
-incurred by, or claims asserted against, such Contributor by reason
-of your accepting any such warranty or additional liability.
-
-END OF TERMS AND CONDITIONS
-
-APPENDIX: How to apply the Apache License to your work.
-
-To apply the Apache License to your work, attach the following
-boilerplate notice, with the fields enclosed by brackets "{}"
-replaced with your own identifying information. (Don't include
-the brackets!)  The text should be enclosed in the appropriate
-comment syntax for the file format. We also recommend that a
-file or class name and description of purpose be included on the
-same "printed page" as the copyright notice for easier
-identification within third-party archives.
-
-Copyright 2020 A11yance
-
-Licensed under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License.
-You may obtain a copy of the License at
-
-http://www.apache.org/licenses/LICENSE-2.0
-
-Unless required by applicable law or agreed to in writing, software
-distributed under the License is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-See the License for the specific language governing permissions and
-limitations under the License.
-
-------------------------------------------------------------------------------
-[211] Applies to: npm:asap@2.0.6
+[212] Applies to: npm:asap@2.0.6
 ------------------------------------------------------------------------------
 Copyright 2009–2014 Contributors. All rights reserved.
 
@@ -30577,7 +30510,7 @@ FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
 IN THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[212] Applies to: npm:asn1@0.2.6
+[213] Applies to: npm:asn1@0.2.6
 ------------------------------------------------------------------------------
 Copyright (c) 2011 Mark Cavage, All rights reserved.
 
@@ -30600,7 +30533,30 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE
 
 ------------------------------------------------------------------------------
-[213] Applies to: npm:asynckit@0.4.0
+[214] Applies to: npm:async@3.2.6
+------------------------------------------------------------------------------
+Copyright (c) 2010-2018 Caolan McMahon
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+
+------------------------------------------------------------------------------
+[215] Applies to: npm:asynckit@0.4.0
 ------------------------------------------------------------------------------
 The MIT License (MIT)
 
@@ -30625,7 +30581,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
 ------------------------------------------------------------------------------
-[214] Applies to: npm:atomically@1.7.0
+[216] Applies to: npm:atomically@1.7.0
 ------------------------------------------------------------------------------
 The MIT License (MIT)
 
@@ -30650,7 +30606,7 @@ FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
 DEALINGS IN THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[215] Applies to: npm:axios@1.18.1
+[217] Applies to: npm:axios@1.18.1
 ------------------------------------------------------------------------------
 # Copyright (c) 2014-present Matt Zabriskie & Collaborators
 
@@ -30661,7 +30617,7 @@ The above copyright notice and this permission notice shall be included in all c
 THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[216] Applies to: npm:babel-plugin-react-native-web@0.21.2
+[218] Applies to: npm:babel-plugin-react-native-web@0.21.2
 ------------------------------------------------------------------------------
 MIT License
 
@@ -30686,7 +30642,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
 ------------------------------------------------------------------------------
-[217] Applies to: npm:babel-plugin-transform-flow-enums@0.0.2, npm:flow-enums-runtime@0.0.6, npm:react-is@18.3.1, npm:react-refresh@0.14.2
+[219] Applies to: npm:babel-plugin-transform-flow-enums@0.0.2, npm:flow-enums-runtime@0.0.6, npm:react-is@16.13.1, npm:react-is@18.3.1, npm:react-refresh@0.14.2
 ------------------------------------------------------------------------------
 MIT License
 
@@ -30711,7 +30667,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
 ------------------------------------------------------------------------------
-[218] Applies to: npm:bail@2.0.2, npm:ccount@2.0.1, npm:character-entities@2.0.2, npm:character-entities-html4@2.1.0, npm:character-entities-legacy@3.0.0, npm:character-reference-invalid@2.0.1, npm:mdast-util-to-string@4.0.0, npm:unist-util-find-after@5.0.0, npm:unist-util-position@5.0.0, npm:unist-util-visit@5.1.0
+[220] Applies to: npm:bail@2.0.2, npm:ccount@2.0.1, npm:character-entities@2.0.2, npm:character-entities-html4@2.1.0, npm:character-entities-legacy@3.0.0, npm:character-reference-invalid@2.0.1, npm:mdast-util-to-string@4.0.0, npm:unist-util-find-after@5.0.0, npm:unist-util-position@5.0.0, npm:unist-util-visit@5.1.0
 ------------------------------------------------------------------------------
 (The MIT License)
 
@@ -30737,7 +30693,7 @@ TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
 SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[219] Applies to: npm:balanced-match@1.0.2
+[221] Applies to: npm:balanced-match@1.0.2
 ------------------------------------------------------------------------------
 (MIT)
 
@@ -30762,7 +30718,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
 ------------------------------------------------------------------------------
-[220] Applies to: npm:balanced-match@4.0.4
+[222] Applies to: npm:balanced-match@4.0.4
 ------------------------------------------------------------------------------
 (MIT)
 
@@ -30789,7 +30745,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
 ------------------------------------------------------------------------------
-[221] Applies to: npm:base64-js@1.5.1
+[223] Applies to: npm:base64-js@1.5.1
 ------------------------------------------------------------------------------
 The MIT License (MIT)
 
@@ -30814,7 +30770,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[222] Applies to: npm:bcrypt-pbkdf@1.0.2
+[224] Applies to: npm:bcrypt-pbkdf@1.0.2
 ------------------------------------------------------------------------------
 The Blowfish portions are under the following license:
 
@@ -30884,7 +30840,7 @@ ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
 OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
 
 ------------------------------------------------------------------------------
-[223] Applies to: npm:better-sqlite3@12.11.1
+[225] Applies to: npm:better-sqlite3@12.11.1
 ------------------------------------------------------------------------------
 The MIT License (MIT)
 
@@ -30909,7 +30865,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
 ------------------------------------------------------------------------------
-[224] Applies to: npm:big-integer@1.6.52, npm:robust-predicates@3.0.3, npm:tweetnacl@0.14.5
+[226] Applies to: npm:big-integer@1.6.52, npm:robust-predicates@3.0.3, npm:tweetnacl@0.14.5
 ------------------------------------------------------------------------------
 This is free and unencumbered software released into the public domain.
 
@@ -30937,7 +30893,7 @@ OTHER DEALINGS IN THE SOFTWARE.
 For more information, please refer to <http://unlicense.org>
 
 ------------------------------------------------------------------------------
-[225] Applies to: npm:bignumber.js@9.3.1
+[227] Applies to: npm:bignumber.js@9.3.1
 ------------------------------------------------------------------------------
 The MIT License (MIT)
 =====================
@@ -30966,7 +30922,7 @@ FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
 OTHER DEALINGS IN THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[226] Applies to: npm:bindings@1.5.0
+[228] Applies to: npm:bindings@1.5.0
 ------------------------------------------------------------------------------
 (The MIT License)
 
@@ -30992,7 +30948,7 @@ TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
 SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[227] Applies to: npm:bl@4.1.0
+[229] Applies to: npm:bl@4.1.0
 ------------------------------------------------------------------------------
 The MIT License (MIT)
 =====================
@@ -31009,7 +30965,32 @@ The above copyright notice and this permission notice shall be included in all c
 THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[228] Applies to: npm:body-parser@2.3.0, npm:compression@1.8.1, npm:type-is@2.1.0
+[230] Applies to: npm:bluebird@3.4.7
+------------------------------------------------------------------------------
+The MIT License (MIT)
+
+Copyright (c) 2013-2015 Petka Antonov
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.  IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+
+------------------------------------------------------------------------------
+[231] Applies to: npm:body-parser@2.3.0, npm:compression@1.8.1, npm:type-is@2.1.0
 ------------------------------------------------------------------------------
 (The MIT License)
 
@@ -31036,7 +31017,7 @@ TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
 SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[229] Applies to: npm:bplist-creator@0.1.0
+[232] Applies to: npm:bplist-creator@0.1.0
 ------------------------------------------------------------------------------
 (The MIT License)
 
@@ -31058,7 +31039,7 @@ WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN 
 OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[230] Applies to: npm:brace-expansion@2.1.2
+[233] Applies to: npm:brace-expansion@1.1.16, npm:brace-expansion@2.1.2
 ------------------------------------------------------------------------------
 MIT License
 
@@ -31083,7 +31064,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
 ------------------------------------------------------------------------------
-[231] Applies to: npm:brace-expansion@5.0.8
+[234] Applies to: npm:brace-expansion@5.0.8
 ------------------------------------------------------------------------------
 MIT License
 
@@ -31110,7 +31091,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
 ------------------------------------------------------------------------------
-[232] Applies to: npm:braces@3.0.3, npm:fill-range@7.1.1, npm:is-number@7.0.0, npm:micromatch@4.0.8
+[235] Applies to: npm:braces@3.0.3, npm:fill-range@7.1.1, npm:is-number@7.0.0, npm:micromatch@4.0.8
 ------------------------------------------------------------------------------
 The MIT License (MIT)
 
@@ -31135,7 +31116,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[233] Applies to: npm:browserslist@4.28.6
+[236] Applies to: npm:browserslist@4.28.6
 ------------------------------------------------------------------------------
 The MIT License (MIT)
 
@@ -31159,7 +31140,7 @@ IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
 CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[234] Applies to: npm:buffer@5.7.1
+[237] Applies to: npm:buffer@5.7.1
 ------------------------------------------------------------------------------
 The MIT License (MIT)
 
@@ -31184,7 +31165,30 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[235] Applies to: npm:buffer-equal-constant-time@1.0.1
+[238] Applies to: npm:buffer-crc32@0.2.13
+------------------------------------------------------------------------------
+The MIT License
+
+Copyright (c) 2013 Brian J. Brennan
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal in
+the Software without restriction, including without limitation the rights to use,
+copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the
+Software, and to permit persons to whom the Software is furnished to do so,
+subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED,
+INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR
+PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE
+FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+------------------------------------------------------------------------------
+[239] Applies to: npm:buffer-equal-constant-time@1.0.1
 ------------------------------------------------------------------------------
 Copyright (c) 2013, GoInstant Inc., a salesforce.com company
 All rights reserved.
@@ -31200,7 +31204,7 @@ Redistribution and use in source and binary forms, with or without modification,
 THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 ------------------------------------------------------------------------------
-[236] Applies to: npm:buffer-from@1.1.2
+[240] Applies to: npm:buffer-from@1.1.2
 ------------------------------------------------------------------------------
 MIT License
 
@@ -31225,7 +31229,32 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
 ------------------------------------------------------------------------------
-[237] Applies to: npm:buildcheck@0.0.7, npm:cpu-features@0.0.10, npm:ssh2@1.17.0
+[241] Applies to: npm:buffer-indexof-polyfill@1.0.2
+------------------------------------------------------------------------------
+The MIT License (MIT)
+
+Copyright (c) 2015 Sarosia
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+
+------------------------------------------------------------------------------
+[242] Applies to: npm:buildcheck@0.0.7, npm:cpu-features@0.0.10, npm:ssh2@1.17.0
 ------------------------------------------------------------------------------
 Copyright Brian White. All rights reserved.
 
@@ -31248,7 +31277,7 @@ FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
 IN THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[238] Applies to: npm:byte-size@8.2.1
+[243] Applies to: npm:byte-size@8.2.1
 ------------------------------------------------------------------------------
 The MIT License (MIT)
 
@@ -31273,7 +31302,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
 ------------------------------------------------------------------------------
-[239] Applies to: npm:bytes@3.1.2
+[244] Applies to: npm:bytes@3.1.2
 ------------------------------------------------------------------------------
 (The MIT License)
 
@@ -31300,7 +31329,7 @@ TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
 SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[240] Applies to: npm:call-bind-apply-helpers@1.0.2, npm:call-bound@1.0.4, npm:es-define-property@1.0.1, npm:es-errors@1.3.0, npm:es-object-atoms@1.1.2, npm:side-channel-list@1.0.1, npm:side-channel-map@1.0.1
+[245] Applies to: npm:call-bind-apply-helpers@1.0.2, npm:call-bound@1.0.4, npm:es-define-property@1.0.1, npm:es-errors@1.3.0, npm:es-object-atoms@1.1.2, npm:side-channel-list@1.0.1, npm:side-channel-map@1.0.1
 ------------------------------------------------------------------------------
 MIT License
 
@@ -31325,7 +31354,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
 ------------------------------------------------------------------------------
-[241] Applies to: npm:caniuse-lite@1.0.30001805
+[246] Applies to: npm:caniuse-lite@1.0.30001805
 ------------------------------------------------------------------------------
 Attribution 4.0 International
 
@@ -31724,7 +31753,7 @@ public licenses.
 Creative Commons may be contacted at creativecommons.org.
 
 ------------------------------------------------------------------------------
-[242] Applies to: npm:charenc@0.0.2, npm:crypt@0.0.2
+[247] Applies to: npm:charenc@0.0.2, npm:crypt@0.0.2
 ------------------------------------------------------------------------------
 Copyright © 2011, Paul Vorbach. All rights reserved.
 Copyright © 2009, Jeff Mott. All rights reserved.
@@ -31755,7 +31784,7 @@ ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
 SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 ------------------------------------------------------------------------------
-[243] Applies to: npm:chownr@3.0.0, npm:glob@13.0.6, npm:package-json-from-dist@1.0.1, npm:yallist@5.0.0
+[248] Applies to: npm:chownr@3.0.0, npm:glob@13.0.6, npm:package-json-from-dist@1.0.1, npm:yallist@5.0.0
 ------------------------------------------------------------------------------
 All packages under `src/` are licensed according to the terms in
 their respective `LICENSE` or `LICENSE.md` files.
@@ -31822,7 +31851,7 @@ will be liable to anyone for any damages related to this
 software or this license, under any kind of legal claim.***
 
 ------------------------------------------------------------------------------
-[244] Applies to: npm:chrome-launcher@0.15.2, npm:chromium-edge-launcher@0.3.0, npm:lighthouse-logger@1.4.2
+[249] Applies to: npm:chrome-launcher@0.15.2, npm:chromium-edge-launcher@0.3.0, npm:lighthouse-logger@1.4.2
 ------------------------------------------------------------------------------
 Apache License
                            Version 2.0, January 2004
@@ -32027,7 +32056,7 @@ Apache License
    limitations under the License.
 
 ------------------------------------------------------------------------------
-[245] Applies to: npm:ci-info@2.0.0
+[250] Applies to: npm:ci-info@2.0.0
 ------------------------------------------------------------------------------
 The MIT License (MIT)
 
@@ -32052,7 +32081,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
 ------------------------------------------------------------------------------
-[246] Applies to: npm:ci-info@3.9.0
+[251] Applies to: npm:ci-info@3.9.0
 ------------------------------------------------------------------------------
 The MIT License (MIT)
 
@@ -32077,7 +32106,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
 ------------------------------------------------------------------------------
-[247] Applies to: npm:cli-cursor@2.1.0, npm:decamelize@1.2.0, npm:escape-string-regexp@1.0.5, npm:filter-obj@1.1.0, npm:object-assign@4.1.1, npm:onetime@2.0.1, npm:path-exists@3.0.0, npm:restore-cursor@2.0.0, npm:serialize-error@2.1.0, npm:strip-json-comments@2.0.1
+[252] Applies to: npm:cli-cursor@2.1.0, npm:decamelize@1.2.0, npm:escape-string-regexp@1.0.5, npm:filter-obj@1.1.0, npm:object-assign@4.1.1, npm:onetime@2.0.1, npm:path-exists@3.0.0, npm:path-is-absolute@1.0.1, npm:restore-cursor@2.0.0, npm:serialize-error@2.1.0, npm:strip-json-comments@2.0.1
 ------------------------------------------------------------------------------
 The MIT License (MIT)
 
@@ -32102,7 +32131,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[248] Applies to: npm:clone@1.0.4
+[253] Applies to: npm:clone@1.0.4
 ------------------------------------------------------------------------------
 Copyright © 2011-2015 Paul Vorbach <paul@vorba.ch>
 
@@ -32124,7 +32153,7 @@ IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, OUT OF OR IN CONNECTION WITH THE
 SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[249] Applies to: npm:clsx@2.1.1, npm:escalade@3.2.0
+[254] Applies to: npm:clsx@2.1.1, npm:escalade@3.2.0
 ------------------------------------------------------------------------------
 MIT License
 
@@ -32137,7 +32166,7 @@ The above copyright notice and this permission notice shall be included in all c
 THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[250] Applies to: npm:cn-font-split@6.0.3
+[255] Applies to: npm:cn-font-split@6.0.3
 ------------------------------------------------------------------------------
 Apache License
                            Version 2.0, January 2004
@@ -32342,7 +32371,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 
 ------------------------------------------------------------------------------
-[251] Applies to: npm:color@4.2.3
+[256] Applies to: npm:color@4.2.3
 ------------------------------------------------------------------------------
 Copyright (c) 2012 Heather Arthur
 
@@ -32366,7 +32395,7 @@ OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
 WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[252] Applies to: npm:color-convert@1.9.3, npm:color-convert@2.0.1
+[257] Applies to: npm:color-convert@1.9.3, npm:color-convert@2.0.1
 ------------------------------------------------------------------------------
 Copyright (c) 2011-2016 Heather Arthur <fayearthur@gmail.com>
 
@@ -32390,7 +32419,7 @@ OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
 WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[253] Applies to: npm:color-name@1.1.3, npm:color-name@1.1.4
+[258] Applies to: npm:color-name@1.1.3, npm:color-name@1.1.4
 ------------------------------------------------------------------------------
 The MIT License (MIT)
 Copyright (c) 2015 Dmitry Ivanov
@@ -32402,7 +32431,7 @@ The above copyright notice and this permission notice shall be included in all c
 THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[254] Applies to: npm:color-string@1.9.1
+[259] Applies to: npm:color-string@1.9.1
 ------------------------------------------------------------------------------
 Copyright (c) 2011 Heather Arthur <fayearthur@gmail.com>
 
@@ -32426,7 +32455,7 @@ OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
 WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[255] Applies to: npm:combined-stream@1.0.8, npm:delayed-stream@1.0.0
+[260] Applies to: npm:combined-stream@1.0.8, npm:delayed-stream@1.0.0
 ------------------------------------------------------------------------------
 Copyright (c) 2011 Debuggable Limited <felix@debuggable.com>
 
@@ -32449,7 +32478,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[256] Applies to: npm:comma-separated-tokens@2.0.3, npm:hast-util-is-element@3.0.0, npm:hast-util-parse-selector@4.0.0, npm:hast-util-whitespace@3.0.0, npm:is-alphabetical@2.0.1, npm:is-alphanumerical@2.0.1, npm:is-decimal@2.0.1, npm:is-hexadecimal@2.0.1, npm:mdast-util-to-hast@13.2.1, npm:rehype-slug@6.0.0, npm:space-separated-tokens@2.0.2, npm:unist-util-remove-position@5.0.0, npm:unist-util-stringify-position@4.0.0, npm:unist-util-visit-parents@6.0.2, npm:vfile-location@5.0.3, npm:web-namespaces@2.0.1, npm:zwitch@2.0.4
+[261] Applies to: npm:comma-separated-tokens@2.0.3, npm:hast-util-is-element@3.0.0, npm:hast-util-parse-selector@4.0.0, npm:hast-util-whitespace@3.0.0, npm:is-alphabetical@2.0.1, npm:is-alphanumerical@2.0.1, npm:is-decimal@2.0.1, npm:is-hexadecimal@2.0.1, npm:mdast-util-to-hast@13.2.1, npm:rehype-slug@6.0.0, npm:space-separated-tokens@2.0.2, npm:unist-util-remove-position@5.0.0, npm:unist-util-stringify-position@4.0.0, npm:unist-util-visit-parents@6.0.2, npm:vfile-location@5.0.3, npm:web-namespaces@2.0.1, npm:zwitch@2.0.4
 ------------------------------------------------------------------------------
 (The MIT License)
 
@@ -32475,7 +32504,7 @@ TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
 SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[257] Applies to: npm:commander@12.1.0, npm:commander@2.20.3, npm:commander@7.2.0, npm:commander@8.3.0
+[262] Applies to: npm:commander@12.1.0, npm:commander@2.20.3, npm:commander@7.2.0, npm:commander@8.3.0
 ------------------------------------------------------------------------------
 (The MIT License)
 
@@ -32501,7 +32530,33 @@ TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
 SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[258] Applies to: npm:compressible@2.0.18
+[263] Applies to: npm:compress-commons@4.1.2, npm:crc32-stream@4.0.3, npm:zip-stream@4.1.1
+------------------------------------------------------------------------------
+Copyright (c) 2014 Chris Talkington, contributors.
+
+Permission is hereby granted, free of charge, to any person
+obtaining a copy of this software and associated documentation
+files (the "Software"), to deal in the Software without
+restriction, including without limitation the rights to use,
+copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the
+Software is furnished to do so, subject to the following
+conditions:
+
+The above copyright notice and this permission notice shall be
+included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
+OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+OTHER DEALINGS IN THE SOFTWARE.
+
+------------------------------------------------------------------------------
+[264] Applies to: npm:compressible@2.0.18
 ------------------------------------------------------------------------------
 (The MIT License)
 
@@ -32529,7 +32584,29 @@ TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
 SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[259] Applies to: npm:connect@3.7.0
+[265] Applies to: npm:concat-map@0.0.1, npm:github-from-package@0.0.0, npm:minimist@1.2.8
+------------------------------------------------------------------------------
+This software is released under the MIT license:
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of
+this software and associated documentation files (the "Software"), to deal in
+the Software without restriction, including without limitation the rights to
+use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+the Software, and to permit persons to whom the Software is furnished to do so,
+subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+------------------------------------------------------------------------------
+[266] Applies to: npm:connect@3.7.0
 ------------------------------------------------------------------------------
 (The MIT License)
 
@@ -32558,7 +32635,7 @@ TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
 SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[260] Applies to: npm:content-disposition@1.1.0, npm:forwarded@0.2.0, npm:media-typer@1.1.0, npm:vary@1.1.2
+[267] Applies to: npm:content-disposition@1.1.0, npm:forwarded@0.2.0, npm:media-typer@1.1.0, npm:vary@1.1.2
 ------------------------------------------------------------------------------
 (The MIT License)
 
@@ -32584,7 +32661,7 @@ TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
 SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[261] Applies to: npm:content-type@1.0.5, npm:content-type@2.0.0
+[268] Applies to: npm:content-type@1.0.5, npm:content-type@2.0.0
 ------------------------------------------------------------------------------
 (The MIT License)
 
@@ -32610,7 +32687,7 @@ TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
 SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[262] Applies to: npm:convert-source-map@2.0.0
+[269] Applies to: npm:convert-source-map@2.0.0
 ------------------------------------------------------------------------------
 Copyright 2013 Thorsten Lorenz.
 All rights reserved.
@@ -32637,7 +32714,7 @@ FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
 OTHER DEALINGS IN THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[263] Applies to: npm:cookie@0.7.2, npm:cookie@1.1.1
+[270] Applies to: npm:cookie@0.7.2, npm:cookie@1.1.1
 ------------------------------------------------------------------------------
 (The MIT License)
 
@@ -32664,7 +32741,7 @@ TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
 SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[264] Applies to: npm:cookie-signature@1.2.2
+[271] Applies to: npm:cookie-signature@1.2.2
 ------------------------------------------------------------------------------
 (The MIT License)
 
@@ -32690,7 +32767,7 @@ TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
 SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[265] Applies to: npm:core-js-compat@3.49.0
+[272] Applies to: npm:core-js-compat@3.49.0
 ------------------------------------------------------------------------------
 Copyright (c) 2013–2025 Denis Pushkarev (zloirock.ru)
 Copyright (c) 2025–2026 CoreJS Company (core-js.io)
@@ -32714,7 +32791,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[266] Applies to: npm:core-util-is@1.0.3
+[273] Applies to: npm:core-util-is@1.0.3
 ------------------------------------------------------------------------------
 Copyright Node.js contributors. All rights reserved.
 
@@ -32737,7 +32814,7 @@ FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
 IN THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[267] Applies to: npm:cors@2.8.6
+[274] Applies to: npm:cors@2.8.6
 ------------------------------------------------------------------------------
 (The MIT License)
 
@@ -32763,7 +32840,7 @@ TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
 SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[268] Applies to: npm:cose-base@1.0.3, npm:cose-base@2.2.0
+[275] Applies to: npm:cose-base@1.0.3, npm:cose-base@2.2.0
 ------------------------------------------------------------------------------
 MIT License
 
@@ -32788,7 +32865,212 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
 ------------------------------------------------------------------------------
-[269] Applies to: npm:crelt@1.0.7
+[276] Applies to: npm:crc-32@1.2.2
+------------------------------------------------------------------------------
+Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "{}"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright (C) 2014-present   SheetJS LLC
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+
+------------------------------------------------------------------------------
+[277] Applies to: npm:crelt@1.0.7
 ------------------------------------------------------------------------------
 Copyright (C) 2020 by Marijn Haverbeke <marijn@haverbeke.berlin>
 
@@ -32811,7 +33093,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[270] Applies to: npm:cross-fetch@3.2.0
+[278] Applies to: npm:cross-fetch@3.2.0
 ------------------------------------------------------------------------------
 The MIT License (MIT)
 
@@ -32836,7 +33118,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
 ------------------------------------------------------------------------------
-[271] Applies to: npm:cross-spawn@7.0.6
+[279] Applies to: npm:cross-spawn@7.0.6
 ------------------------------------------------------------------------------
 The MIT License (MIT)
 
@@ -32861,7 +33143,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[272] Applies to: npm:css-in-js-utils@3.1.0
+[280] Applies to: npm:css-in-js-utils@3.1.0
 ------------------------------------------------------------------------------
 MIT License
 
@@ -32886,7 +33168,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
 ------------------------------------------------------------------------------
-[273] Applies to: npm:css-select@5.2.2, npm:css-what@6.2.2, npm:domelementtype@2.3.0, npm:domhandler@5.0.3, npm:domutils@3.2.2, npm:entities@4.5.0, npm:entities@6.0.1, npm:nth-check@2.1.1
+[281] Applies to: npm:css-select@5.2.2, npm:css-what@6.2.2, npm:domelementtype@2.3.0, npm:domhandler@5.0.3, npm:domutils@3.2.2, npm:entities@4.5.0, npm:entities@6.0.1, npm:nth-check@2.1.1
 ------------------------------------------------------------------------------
 Copyright (c) Felix Böhm
 All rights reserved.
@@ -32901,7 +33183,7 @@ THIS IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRE
 EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 ------------------------------------------------------------------------------
-[274] Applies to: npm:css-tree@1.1.3
+[282] Applies to: npm:css-tree@1.1.3
 ------------------------------------------------------------------------------
 Copyright (C) 2016-2019 by Roman Dvornov
 
@@ -32924,31 +33206,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[275] Applies to: npm:css.escape@1.5.1, npm:emoji-regex@8.0.0, npm:emoji-regex@9.2.2, npm:jsesc@3.1.0, npm:punycode@2.3.1, npm:regenerate@1.4.2, npm:regenerate-unicode-properties@10.2.2, npm:regexpu-core@6.4.0, npm:unicode-canonical-property-names-ecmascript@2.0.1, npm:unicode-match-property-ecmascript@2.0.0, npm:unicode-match-property-value-ecmascript@2.2.1, npm:unicode-property-aliases-ecmascript@2.2.0
-------------------------------------------------------------------------------
-Copyright Mathias Bynens <https://mathiasbynens.be/>
-
-Permission is hereby granted, free of charge, to any person obtaining
-a copy of this software and associated documentation files (the
-"Software"), to deal in the Software without restriction, including
-without limitation the rights to use, copy, modify, merge, publish,
-distribute, sublicense, and/or sell copies of the Software, and to
-permit persons to whom the Software is furnished to do so, subject to
-the following conditions:
-
-The above copyright notice and this permission notice shall be
-included in all copies or substantial portions of the Software.
-
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
-EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
-MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
-NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
-LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
-OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
-WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
-
-------------------------------------------------------------------------------
-[276] Applies to: npm:csstype@3.2.3
+[283] Applies to: npm:csstype@3.2.3
 ------------------------------------------------------------------------------
 Copyright (c) 2017-2018 Fredrik Nicol
 
@@ -32971,7 +33229,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
 ------------------------------------------------------------------------------
-[277] Applies to: npm:cytoscape@3.34.0
+[284] Applies to: npm:cytoscape@3.34.0
 ------------------------------------------------------------------------------
 Copyright (c) 2016-2026, The Cytoscape Consortium.
 
@@ -33027,7 +33285,7 @@ SOFTWARE.`;
 fs.writeFileSync(path.join(__dirname, 'LICENSE'), license);
 
 ------------------------------------------------------------------------------
-[278] Applies to: npm:cytoscape-cose-bilkent@4.1.0
+[285] Applies to: npm:cytoscape-cose-bilkent@4.1.0
 ------------------------------------------------------------------------------
 Copyright (c) 2016-2018, The Cytoscape Consortium.
 
@@ -33050,7 +33308,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
 ------------------------------------------------------------------------------
-[279] Applies to: npm:cytoscape-fcose@2.2.0
+[286] Applies to: npm:cytoscape-fcose@2.2.0
 ------------------------------------------------------------------------------
 Copyright (c) 2018 - present, iVis-at-Bilkent.
 
@@ -33073,7 +33331,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
 ------------------------------------------------------------------------------
-[280] Applies to: npm:d3@7.9.0, npm:d3-array@3.2.4
+[287] Applies to: npm:d3@7.9.0, npm:d3-array@3.2.4
 ------------------------------------------------------------------------------
 Copyright 2010-2023 Mike Bostock
 
@@ -33090,7 +33348,7 @@ TORTIOUS ACTION, ARISING OUT OF OR IN CONNECTION WITH THE USE OR PERFORMANCE OF
 THIS SOFTWARE.
 
 ------------------------------------------------------------------------------
-[281] Applies to: npm:d3-array@2.12.1
+[288] Applies to: npm:d3-array@2.12.1
 ------------------------------------------------------------------------------
 Copyright 2010-2020 Mike Bostock
 All rights reserved.
@@ -33121,7 +33379,7 @@ ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
 SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 ------------------------------------------------------------------------------
-[282] Applies to: npm:d3-axis@3.0.0, npm:d3-brush@3.0.0, npm:d3-chord@3.0.1, npm:d3-dispatch@3.0.1, npm:d3-drag@3.0.0, npm:d3-force@3.0.0, npm:d3-hierarchy@3.1.2, npm:d3-interpolate@3.0.1, npm:d3-polygon@3.0.1, npm:d3-quadtree@3.0.1, npm:d3-random@3.0.1, npm:d3-scale@4.0.2, npm:d3-selection@3.0.0, npm:d3-time-format@4.1.0, npm:d3-timer@3.0.1, npm:d3-transition@3.0.1, npm:d3-zoom@3.0.0
+[289] Applies to: npm:d3-axis@3.0.0, npm:d3-brush@3.0.0, npm:d3-chord@3.0.1, npm:d3-dispatch@3.0.1, npm:d3-drag@3.0.0, npm:d3-force@3.0.0, npm:d3-hierarchy@3.1.2, npm:d3-interpolate@3.0.1, npm:d3-polygon@3.0.1, npm:d3-quadtree@3.0.1, npm:d3-random@3.0.1, npm:d3-scale@4.0.2, npm:d3-selection@3.0.0, npm:d3-time-format@4.1.0, npm:d3-timer@3.0.1, npm:d3-transition@3.0.1, npm:d3-zoom@3.0.0
 ------------------------------------------------------------------------------
 Copyright 2010-2021 Mike Bostock
 
@@ -33138,7 +33396,7 @@ TORTIOUS ACTION, ARISING OUT OF OR IN CONNECTION WITH THE USE OR PERFORMANCE OF
 THIS SOFTWARE.
 
 ------------------------------------------------------------------------------
-[283] Applies to: npm:d3-color@3.1.0, npm:d3-shape@3.2.0, npm:d3-time@3.1.0
+[290] Applies to: npm:d3-color@3.1.0, npm:d3-shape@3.2.0, npm:d3-time@3.1.0
 ------------------------------------------------------------------------------
 Copyright 2010-2022 Mike Bostock
 
@@ -33155,7 +33413,7 @@ TORTIOUS ACTION, ARISING OUT OF OR IN CONNECTION WITH THE USE OR PERFORMANCE OF
 THIS SOFTWARE.
 
 ------------------------------------------------------------------------------
-[284] Applies to: npm:d3-contour@4.0.2
+[291] Applies to: npm:d3-contour@4.0.2
 ------------------------------------------------------------------------------
 Copyright 2012-2023 Mike Bostock
 
@@ -33172,7 +33430,7 @@ TORTIOUS ACTION, ARISING OUT OF OR IN CONNECTION WITH THE USE OR PERFORMANCE OF
 THIS SOFTWARE.
 
 ------------------------------------------------------------------------------
-[285] Applies to: npm:d3-delaunay@6.0.4
+[292] Applies to: npm:d3-delaunay@6.0.4
 ------------------------------------------------------------------------------
 Copyright 2018-2021 Observable, Inc.
 Copyright 2021 Mapbox
@@ -33190,7 +33448,7 @@ TORTIOUS ACTION, ARISING OUT OF OR IN CONNECTION WITH THE USE OR PERFORMANCE OF
 THIS SOFTWARE.
 
 ------------------------------------------------------------------------------
-[286] Applies to: npm:d3-dsv@3.0.1
+[293] Applies to: npm:d3-dsv@3.0.1
 ------------------------------------------------------------------------------
 Copyright 2013-2021 Mike Bostock
 
@@ -33207,7 +33465,7 @@ TORTIOUS ACTION, ARISING OUT OF OR IN CONNECTION WITH THE USE OR PERFORMANCE OF
 THIS SOFTWARE.
 
 ------------------------------------------------------------------------------
-[287] Applies to: npm:d3-ease@3.0.1
+[294] Applies to: npm:d3-ease@3.0.1
 ------------------------------------------------------------------------------
 Copyright 2010-2021 Mike Bostock
 Copyright 2001 Robert Penner
@@ -33239,7 +33497,7 @@ ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
 SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 ------------------------------------------------------------------------------
-[288] Applies to: npm:d3-fetch@3.0.1
+[295] Applies to: npm:d3-fetch@3.0.1
 ------------------------------------------------------------------------------
 Copyright 2016-2021 Mike Bostock
 
@@ -33256,7 +33514,7 @@ TORTIOUS ACTION, ARISING OUT OF OR IN CONNECTION WITH THE USE OR PERFORMANCE OF
 THIS SOFTWARE.
 
 ------------------------------------------------------------------------------
-[289] Applies to: npm:d3-format@3.1.2
+[296] Applies to: npm:d3-format@3.1.2
 ------------------------------------------------------------------------------
 Copyright 2010-2026 Mike Bostock
 
@@ -33273,7 +33531,7 @@ TORTIOUS ACTION, ARISING OUT OF OR IN CONNECTION WITH THE USE OR PERFORMANCE OF
 THIS SOFTWARE.
 
 ------------------------------------------------------------------------------
-[290] Applies to: npm:d3-geo@3.1.1
+[297] Applies to: npm:d3-geo@3.1.1
 ------------------------------------------------------------------------------
 Copyright 2010-2024 Mike Bostock
 
@@ -33311,7 +33569,7 @@ IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
 CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[291] Applies to: npm:d3-path@1.0.9
+[298] Applies to: npm:d3-path@1.0.9
 ------------------------------------------------------------------------------
 Copyright 2015-2016 Mike Bostock
 All rights reserved.
@@ -33342,7 +33600,7 @@ ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
 SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 ------------------------------------------------------------------------------
-[292] Applies to: npm:d3-path@3.1.0
+[299] Applies to: npm:d3-path@3.1.0
 ------------------------------------------------------------------------------
 Copyright 2015-2022 Mike Bostock
 
@@ -33359,7 +33617,7 @@ TORTIOUS ACTION, ARISING OUT OF OR IN CONNECTION WITH THE USE OR PERFORMANCE OF
 THIS SOFTWARE.
 
 ------------------------------------------------------------------------------
-[293] Applies to: npm:d3-sankey@0.12.3
+[300] Applies to: npm:d3-sankey@0.12.3
 ------------------------------------------------------------------------------
 Copyright 2015, Mike Bostock
 All rights reserved.
@@ -33390,7 +33648,7 @@ ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
 SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 ------------------------------------------------------------------------------
-[294] Applies to: npm:d3-scale-chromatic@3.1.0
+[301] Applies to: npm:d3-scale-chromatic@3.1.0
 ------------------------------------------------------------------------------
 Copyright 2010-2024 Mike Bostock
 
@@ -33422,7 +33680,7 @@ CONDITIONS OF ANY KIND, either express or implied. See the License for the
 specific language governing permissions and limitations under the License.
 
 ------------------------------------------------------------------------------
-[295] Applies to: npm:d3-shape@1.3.7
+[302] Applies to: npm:d3-shape@1.3.7
 ------------------------------------------------------------------------------
 Copyright 2010-2015 Mike Bostock
 All rights reserved.
@@ -33453,7 +33711,7 @@ ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
 SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 ------------------------------------------------------------------------------
-[296] Applies to: npm:dagre-d3-es@7.0.14
+[303] Applies to: npm:dagre-d3-es@7.0.14
 ------------------------------------------------------------------------------
 Original dagre-d3 copyright: Copyright (c) 2013 Chris Pettitt
 Original dagre copyright: Copyright (c) 2012-2014 Chris Pettitt
@@ -33480,7 +33738,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[297] Applies to: npm:dayjs@1.11.21
+[304] Applies to: npm:dayjs@1.11.21
 ------------------------------------------------------------------------------
 MIT License
 
@@ -33505,7 +33763,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
 ------------------------------------------------------------------------------
-[298] Applies to: npm:debug@2.6.9, npm:debug@3.2.7
+[305] Applies to: npm:debug@2.6.9, npm:debug@3.2.7
 ------------------------------------------------------------------------------
 (The MIT License)
 
@@ -33527,7 +33785,7 @@ WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN 
 SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[299] Applies to: npm:debug@4.4.3
+[306] Applies to: npm:debug@4.4.3
 ------------------------------------------------------------------------------
 (The MIT License)
 
@@ -33550,7 +33808,7 @@ WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN 
 SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[300] Applies to: npm:decode-named-character-reference@1.3.0, npm:hast-util-from-parse5@8.0.3, npm:hast-util-to-jsx-runtime@2.3.6, npm:hastscript@9.0.1, npm:lowlight@3.3.0, npm:markdown-table@3.0.4, npm:mdast-util-find-and-replace@3.0.2, npm:mdast-util-from-markdown@2.0.3, npm:mdast-util-gfm@3.1.0, npm:mdast-util-gfm-footnote@2.1.0, npm:mdast-util-to-markdown@2.1.2, npm:micromark@4.0.2, npm:micromark-core-commonmark@2.0.3, npm:micromark-extension-gfm-table@2.1.1, npm:micromark-factory-destination@2.0.1, npm:micromark-factory-label@2.0.1, npm:micromark-factory-space@2.0.1, npm:micromark-factory-title@2.0.1, npm:micromark-factory-whitespace@2.0.1, npm:micromark-util-character@2.1.1, npm:micromark-util-chunked@2.0.1, npm:micromark-util-classify-character@2.0.1, npm:micromark-util-combine-extensions@2.0.1, npm:micromark-util-decode-numeric-character-reference@2.0.2, npm:micromark-util-decode-string@2.0.1, npm:micromark-util-encode@2.0.1, npm:micromark-util-html-tag-name@2.0.1, npm:micromark-util-normalize-identifier@2.0.1, npm:micromark-util-resolve-all@2.0.1, npm:micromark-util-sanitize-uri@2.0.1, npm:micromark-util-subtokenize@2.1.0, npm:micromark-util-symbol@2.0.1, npm:micromark-util-types@2.0.2, npm:rehype-highlight@7.0.2, npm:remark-gfm@4.0.1, npm:remark-rehype@11.1.2, npm:vfile-message@4.0.3
+[307] Applies to: npm:decode-named-character-reference@1.3.0, npm:hast-util-from-parse5@8.0.3, npm:hast-util-to-jsx-runtime@2.3.6, npm:hastscript@9.0.1, npm:lowlight@3.3.0, npm:markdown-table@3.0.4, npm:mdast-util-find-and-replace@3.0.2, npm:mdast-util-from-markdown@2.0.3, npm:mdast-util-gfm@3.1.0, npm:mdast-util-gfm-footnote@2.1.0, npm:mdast-util-to-markdown@2.1.2, npm:micromark@4.0.2, npm:micromark-core-commonmark@2.0.3, npm:micromark-extension-gfm-table@2.1.1, npm:micromark-factory-destination@2.0.1, npm:micromark-factory-label@2.0.1, npm:micromark-factory-space@2.0.1, npm:micromark-factory-title@2.0.1, npm:micromark-factory-whitespace@2.0.1, npm:micromark-util-character@2.1.1, npm:micromark-util-chunked@2.0.1, npm:micromark-util-classify-character@2.0.1, npm:micromark-util-combine-extensions@2.0.1, npm:micromark-util-decode-numeric-character-reference@2.0.2, npm:micromark-util-decode-string@2.0.1, npm:micromark-util-encode@2.0.1, npm:micromark-util-html-tag-name@2.0.1, npm:micromark-util-normalize-identifier@2.0.1, npm:micromark-util-resolve-all@2.0.1, npm:micromark-util-sanitize-uri@2.0.1, npm:micromark-util-subtokenize@2.1.0, npm:micromark-util-symbol@2.0.1, npm:micromark-util-types@2.0.2, npm:rehype-highlight@7.0.2, npm:remark-gfm@4.0.1, npm:remark-rehype@11.1.2, npm:vfile-message@4.0.3
 ------------------------------------------------------------------------------
 (The MIT License)
 
@@ -33576,7 +33834,7 @@ TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
 SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[301] Applies to: npm:decode-uri-component@0.2.2
+[308] Applies to: npm:decode-uri-component@0.2.2
 ------------------------------------------------------------------------------
 The MIT License (MIT)
 
@@ -33589,7 +33847,7 @@ The above copyright notice and this permission notice shall be included in all c
 THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[302] Applies to: npm:deep-extend@0.6.0
+[309] Applies to: npm:deep-extend@0.6.0
 ------------------------------------------------------------------------------
 The MIT License (MIT)
 
@@ -33613,7 +33871,7 @@ IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
 CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[303] Applies to: npm:deepmerge@4.3.1
+[310] Applies to: npm:deepmerge@4.3.1
 ------------------------------------------------------------------------------
 The MIT License (MIT)
 
@@ -33638,7 +33896,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[304] Applies to: npm:defaults@1.0.4
+[311] Applies to: npm:defaults@1.0.4
 ------------------------------------------------------------------------------
 The MIT License (MIT)
 
@@ -33664,7 +33922,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[305] Applies to: npm:delaunator@5.1.0
+[312] Applies to: npm:delaunator@5.1.0
 ------------------------------------------------------------------------------
 ISC License
 
@@ -33683,7 +33941,7 @@ TORTIOUS ACTION, ARISING OUT OF OR IN CONNECTION WITH THE USE OR PERFORMANCE OF
 THIS SOFTWARE.
 
 ------------------------------------------------------------------------------
-[306] Applies to: npm:depd@2.0.0
+[313] Applies to: npm:depd@2.0.0
 ------------------------------------------------------------------------------
 (The MIT License)
 
@@ -33709,7 +33967,7 @@ TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
 SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[307] Applies to: npm:dequal@2.0.3, npm:kleur@3.0.3, npm:mri@1.2.0
+[314] Applies to: npm:dequal@2.0.3, npm:kleur@3.0.3, npm:mri@1.2.0
 ------------------------------------------------------------------------------
 The MIT License (MIT)
 
@@ -33734,7 +33992,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[308] Applies to: npm:destroy@1.2.0
+[315] Applies to: npm:destroy@1.2.0
 ------------------------------------------------------------------------------
 The MIT License (MIT)
 
@@ -33760,7 +34018,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[309] Applies to: npm:detect-libc@2.1.2
+[316] Applies to: npm:detect-libc@2.1.2
 ------------------------------------------------------------------------------
 Apache License
                            Version 2.0, January 2004
@@ -33965,7 +34223,7 @@ Apache License
    limitations under the License.
 
 ------------------------------------------------------------------------------
-[310] Applies to: npm:detect-node-es@1.1.0
+[317] Applies to: npm:detect-node-es@1.1.0
 ------------------------------------------------------------------------------
 MIT License
 
@@ -33990,7 +34248,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
 ------------------------------------------------------------------------------
-[311] Applies to: npm:devlop@1.1.0
+[318] Applies to: npm:devlop@1.1.0
 ------------------------------------------------------------------------------
 (The MIT License)
 
@@ -34016,7 +34274,7 @@ TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
 SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[312] Applies to: npm:diff@8.0.4
+[319] Applies to: npm:diff@8.0.4
 ------------------------------------------------------------------------------
 BSD 3-Clause License
 
@@ -34049,7 +34307,7 @@ OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 ------------------------------------------------------------------------------
-[313] Applies to: npm:dijkstrajs@1.0.3
+[320] Applies to: npm:dijkstrajs@1.0.3
 ------------------------------------------------------------------------------
 ```
 Dijkstra path-finding functions. Adapted from the Dijkstar Python project.
@@ -34072,7 +34330,7 @@ THE SOFTWARE.
 ```
 
 ------------------------------------------------------------------------------
-[314] Applies to: npm:dingtalk-stream@v2.1.5
+[321] Applies to: npm:dingtalk-stream@v2.1.5
 ------------------------------------------------------------------------------
 MIT License
 
@@ -34097,7 +34355,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
 ------------------------------------------------------------------------------
-[315] Applies to: npm:discord-api-types@0.38.50
+[322] Applies to: npm:discord-api-types@0.38.50
 ------------------------------------------------------------------------------
 MIT License
 
@@ -34122,7 +34380,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
 ------------------------------------------------------------------------------
-[316] Applies to: npm:dnssd-advertise@1.1.6, npm:multitars@1.0.0, npm:toqr@0.1.1
+[323] Applies to: npm:dnssd-advertise@1.1.6, npm:multitars@1.0.2, npm:toqr@0.1.1
 ------------------------------------------------------------------------------
 MIT License
 
@@ -34148,11 +34406,11 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
 ------------------------------------------------------------------------------
-[317] Applies to: npm:dom-accessibility-api@0.6.3
+[324] Applies to: npm:docx@9.7.1
 ------------------------------------------------------------------------------
-MIT License
+The MIT License (MIT)
 
-Copyright (c) 2020 Sebastian Silbermann
+Copyright (c) 2016 Dolan
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal
@@ -34173,7 +34431,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
 ------------------------------------------------------------------------------
-[318] Applies to: npm:dom-serializer@2.0.0
+[325] Applies to: npm:dom-serializer@2.0.0
 ------------------------------------------------------------------------------
 License
 
@@ -34188,7 +34446,7 @@ The above copyright notice and this permission notice shall be included in all c
 THE SOFTWARE IS PROVIDED 'AS IS', WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[319] Applies to: npm:dompurify@3.4.12
+[326] Applies to: npm:dompurify@3.4.12
 ------------------------------------------------------------------------------
 Apache License
                            Version 2.0, January 2004
@@ -34767,7 +35025,7 @@ Exhibit B - "Incompatible With Secondary Licenses" Notice
   defined by the Mozilla Public License, v. 2.0.
 
 ------------------------------------------------------------------------------
-[320] Applies to: npm:dunder-proto@1.0.1, npm:math-intrinsics@1.1.0
+[327] Applies to: npm:dunder-proto@1.0.1, npm:math-intrinsics@1.1.0
 ------------------------------------------------------------------------------
 MIT License
 
@@ -34792,7 +35050,37 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
 ------------------------------------------------------------------------------
-[321] Applies to: npm:ecdsa-sig-formatter@1.0.11
+[328] Applies to: npm:duplexer2@0.1.4
+------------------------------------------------------------------------------
+Copyright (c) 2013, Deoxxa Development
+======================================
+All rights reserved.
+--------------------
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+1. Redistributions of source code must retain the above copyright
+   notice, this list of conditions and the following disclaimer.
+2. Redistributions in binary form must reproduce the above copyright
+   notice, this list of conditions and the following disclaimer in the
+   documentation and/or other materials provided with the distribution.
+3. Neither the name of Deoxxa Development nor the names of its contributors
+   may be used to endorse or promote products derived from this software
+   without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY DEOXXA DEVELOPMENT ''AS IS'' AND ANY
+EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL DEOXXA DEVELOPMENT BE LIABLE FOR ANY
+DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+(INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+------------------------------------------------------------------------------
+[329] Applies to: npm:ecdsa-sig-formatter@1.0.11
 ------------------------------------------------------------------------------
 Apache License
                            Version 2.0, January 2004
@@ -34997,7 +35285,7 @@ Apache License
    limitations under the License.
 
 ------------------------------------------------------------------------------
-[322] Applies to: npm:ee-first@1.1.1
+[330] Applies to: npm:ee-first@1.1.1
 ------------------------------------------------------------------------------
 The MIT License (MIT)
 
@@ -35022,7 +35310,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[323] Applies to: npm:electron-squirrel-startup@1.0.1
+[331] Applies to: npm:electron-squirrel-startup@1.0.1
 ------------------------------------------------------------------------------
 Apache License
 Version 2.0, January 2004
@@ -35227,7 +35515,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 
 ------------------------------------------------------------------------------
-[324] Applies to: npm:electron-to-chromium@1.5.392
+[332] Applies to: npm:electron-to-chromium@1.5.392
 ------------------------------------------------------------------------------
 Copyright 2018 Kilian Valkhof
 
@@ -35236,7 +35524,7 @@ Permission to use, copy, modify, and/or distribute this software for any purpose
 THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
 
 ------------------------------------------------------------------------------
-[325] Applies to: npm:electron-window-state@5.0.3
+[333] Applies to: npm:electron-window-state@5.0.3
 ------------------------------------------------------------------------------
 The MIT License (MIT)
 
@@ -35262,7 +35550,31 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[326] Applies to: npm:encodeurl@1.0.2, npm:encodeurl@2.0.0
+[334] Applies to: npm:emoji-regex@8.0.0, npm:emoji-regex@9.2.2, npm:jsesc@3.1.0, npm:punycode@2.3.1, npm:regenerate@1.4.2, npm:regenerate-unicode-properties@10.2.2, npm:regexpu-core@6.4.0, npm:unicode-canonical-property-names-ecmascript@2.0.1, npm:unicode-match-property-ecmascript@2.0.0, npm:unicode-match-property-value-ecmascript@2.2.1, npm:unicode-property-aliases-ecmascript@2.2.0
+------------------------------------------------------------------------------
+Copyright Mathias Bynens <https://mathiasbynens.be/>
+
+Permission is hereby granted, free of charge, to any person obtaining
+a copy of this software and associated documentation files (the
+"Software"), to deal in the Software without restriction, including
+without limitation the rights to use, copy, modify, merge, publish,
+distribute, sublicense, and/or sell copies of the Software, and to
+permit persons to whom the Software is furnished to do so, subject to
+the following conditions:
+
+The above copyright notice and this permission notice shall be
+included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+------------------------------------------------------------------------------
+[335] Applies to: npm:encodeurl@1.0.2, npm:encodeurl@2.0.0
 ------------------------------------------------------------------------------
 (The MIT License)
 
@@ -35288,7 +35600,7 @@ TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
 SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[327] Applies to: npm:end-of-stream@1.4.5, npm:pump@3.0.4, npm:tar-fs@2.1.5, npm:tar-stream@2.2.0
+[336] Applies to: npm:end-of-stream@1.4.5, npm:pump@3.0.4, npm:tar-fs@2.1.5, npm:tar-stream@2.2.0
 ------------------------------------------------------------------------------
 The MIT License (MIT)
 
@@ -35313,7 +35625,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[328] Applies to: npm:error-stack-parser@2.1.4, npm:stackframe@1.3.4
+[337] Applies to: npm:error-stack-parser@2.1.4, npm:stackframe@1.3.4
 ------------------------------------------------------------------------------
 Copyright (c) 2017 Eric Wendelin and other contributors
 
@@ -35336,7 +35648,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
 ------------------------------------------------------------------------------
-[329] Applies to: npm:es-set-tostringtag@2.1.0
+[338] Applies to: npm:es-set-tostringtag@2.1.0
 ------------------------------------------------------------------------------
 MIT License
 
@@ -35361,7 +35673,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
 ------------------------------------------------------------------------------
-[330] Applies to: npm:es-toolkit@1.49.0
+[339] Applies to: npm:es-toolkit@1.49.0
 ------------------------------------------------------------------------------
 MIT License
 
@@ -35386,7 +35698,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
 ------------------------------------------------------------------------------
-[331] Applies to: npm:escape-html@1.0.3
+[340] Applies to: npm:escape-html@1.0.3
 ------------------------------------------------------------------------------
 (The MIT License)
 
@@ -35414,7 +35726,7 @@ TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
 SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[332] Applies to: npm:esprima@4.0.1
+[341] Applies to: npm:esprima@4.0.1
 ------------------------------------------------------------------------------
 Copyright JS Foundation and other contributors, https://js.foundation/
 
@@ -35439,7 +35751,7 @@ ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
 THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 ------------------------------------------------------------------------------
-[333] Applies to: npm:estree-util-is-identifier-name@3.0.0, npm:hast-util-heading-rank@3.0.0, npm:mdast-util-gfm-autolink-literal@2.0.1, npm:mdast-util-gfm-strikethrough@2.0.0, npm:mdast-util-gfm-table@2.0.0, npm:mdast-util-gfm-task-list-item@2.0.0, npm:mdast-util-math@3.0.0, npm:mdast-util-mdx-expression@2.0.1, npm:mdast-util-mdx-jsx@3.2.0, npm:mdast-util-mdxjs-esm@2.0.1, npm:micromark-extension-gfm@3.0.0, npm:micromark-extension-gfm-autolink-literal@2.1.0, npm:micromark-extension-gfm-strikethrough@2.1.0, npm:micromark-extension-gfm-tagfilter@2.0.0, npm:micromark-extension-gfm-task-list-item@2.1.0, npm:micromark-extension-math@3.1.0
+[342] Applies to: npm:estree-util-is-identifier-name@3.0.0, npm:hast-util-heading-rank@3.0.0, npm:mdast-util-gfm-autolink-literal@2.0.1, npm:mdast-util-gfm-strikethrough@2.0.0, npm:mdast-util-gfm-table@2.0.0, npm:mdast-util-gfm-task-list-item@2.0.0, npm:mdast-util-math@3.0.0, npm:mdast-util-mdx-expression@2.0.1, npm:mdast-util-mdx-jsx@3.2.0, npm:mdast-util-mdxjs-esm@2.0.1, npm:micromark-extension-gfm@3.0.0, npm:micromark-extension-gfm-autolink-literal@2.1.0, npm:micromark-extension-gfm-strikethrough@2.1.0, npm:micromark-extension-gfm-tagfilter@2.0.0, npm:micromark-extension-gfm-task-list-item@2.1.0, npm:micromark-extension-math@3.1.0
 ------------------------------------------------------------------------------
 (The MIT License)
 
@@ -35465,7 +35777,7 @@ TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
 SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[334] Applies to: npm:etag@1.8.1, npm:proxy-addr@2.0.7
+[343] Applies to: npm:etag@1.8.1, npm:proxy-addr@2.0.7
 ------------------------------------------------------------------------------
 (The MIT License)
 
@@ -35491,7 +35803,7 @@ TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
 SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[335] Applies to: npm:event-target-shim@5.0.1
+[344] Applies to: npm:event-target-shim@5.0.1
 ------------------------------------------------------------------------------
 The MIT License (MIT)
 
@@ -35516,7 +35828,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
 ------------------------------------------------------------------------------
-[336] Applies to: npm:eventemitter3@5.0.4
+[345] Applies to: npm:eventemitter3@5.0.4
 ------------------------------------------------------------------------------
 The MIT License (MIT)
 
@@ -35541,7 +35853,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
 ------------------------------------------------------------------------------
-[337] Applies to: npm:eventsource@3.0.7
+[346] Applies to: npm:eventsource@3.0.7
 ------------------------------------------------------------------------------
 The MIT License
 
@@ -35567,7 +35879,7 @@ OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
 WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[338] Applies to: npm:eventsource-parser@3.1.0
+[347] Applies to: npm:eventsource-parser@3.1.0
 ------------------------------------------------------------------------------
 MIT License
 
@@ -35592,7 +35904,32 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
 ------------------------------------------------------------------------------
-[339] Applies to: npm:expand-template@2.0.3
+[348] Applies to: npm:exceljs@4.4.0
+------------------------------------------------------------------------------
+The MIT License (MIT)
+
+Copyright (c) 2014-2019 Guyon Roche
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+
+------------------------------------------------------------------------------
+[349] Applies to: npm:expand-template@2.0.3
 ------------------------------------------------------------------------------
 The MIT License (MIT)
 
@@ -35617,7 +35954,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[340] Applies to: npm:expo-paste-input@0.2.2
+[350] Applies to: npm:expo-paste-input@0.2.2
 ------------------------------------------------------------------------------
 MIT License
 
@@ -35642,7 +35979,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
 ------------------------------------------------------------------------------
-[341] Applies to: npm:exponential-backoff@3.1.3
+[351] Applies to: npm:exponential-backoff@3.1.3
 ------------------------------------------------------------------------------
 Apache License
                            Version 2.0, January 2004
@@ -35847,7 +36184,7 @@ Apache License
    limitations under the License.
 
 ------------------------------------------------------------------------------
-[342] Applies to: npm:express@5.2.1
+[352] Applies to: npm:express@5.2.1
 ------------------------------------------------------------------------------
 (The MIT License)
 
@@ -35875,7 +36212,7 @@ TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
 SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[343] Applies to: npm:express-rate-limit@8.5.2
+[353] Applies to: npm:express-rate-limit@8.5.2
 ------------------------------------------------------------------------------
 # MIT License
 
@@ -35899,7 +36236,7 @@ IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
 CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[344] Applies to: npm:extend@3.0.2
+[354] Applies to: npm:extend@3.0.2
 ------------------------------------------------------------------------------
 The MIT License (MIT)
 
@@ -35925,7 +36262,7 @@ OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
 WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[345] Applies to: npm:extend-shallow@2.0.1
+[355] Applies to: npm:extend-shallow@2.0.1
 ------------------------------------------------------------------------------
 The MIT License (MIT)
 
@@ -35950,7 +36287,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[346] Applies to: npm:fast-deep-equal@3.1.3, npm:json-schema-traverse@1.0.0
+[356] Applies to: npm:fast-deep-equal@3.1.3, npm:json-schema-traverse@1.0.0
 ------------------------------------------------------------------------------
 MIT License
 
@@ -35975,7 +36312,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
 ------------------------------------------------------------------------------
-[347] Applies to: npm:fast-equals@5.4.1
+[357] Applies to: npm:fast-equals@5.4.1
 ------------------------------------------------------------------------------
 MIT License
 
@@ -36000,7 +36337,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
 ------------------------------------------------------------------------------
-[348] Applies to: npm:fast-uri@3.1.4
+[358] Applies to: npm:fast-uri@3.1.4
 ------------------------------------------------------------------------------
 Copyright (c) 2011-2021, Gary Court until https://github.com/garycourt/uri-js/commit/a1acf730b4bba3f1097c9f52e7d9d3aba8cdcaae
 Copyright (c) 2021-present The Fastify team <https://github.com/fastify/fastify#team>
@@ -36034,7 +36371,7 @@ The complete list of contributors can be found at:
 - https://github.com/garycourt/uri-js/graphs/contributors
 
 ------------------------------------------------------------------------------
-[349] Applies to: npm:fbjs@3.0.5, npm:fbjs-css-vars@1.0.2, npm:invariant@2.2.4
+[359] Applies to: npm:fbjs@3.0.5, npm:fbjs-css-vars@1.0.2, npm:invariant@2.2.4
 ------------------------------------------------------------------------------
 MIT License
 
@@ -36059,7 +36396,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
 ------------------------------------------------------------------------------
-[350] Applies to: npm:fdir@6.5.0
+[360] Applies to: npm:fdir@6.5.0
 ------------------------------------------------------------------------------
 Copyright 2023 Abdullah Atta
 
@@ -36070,7 +36407,7 @@ The above copyright notice and this permission notice shall be included in all c
 THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[351] Applies to: npm:fetch-blob@3.2.0
+[361] Applies to: npm:fetch-blob@3.2.0
 ------------------------------------------------------------------------------
 MIT License
 
@@ -36095,7 +36432,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
 ------------------------------------------------------------------------------
-[352] Applies to: npm:fetch-nodeshim@0.4.10
+[362] Applies to: npm:fetch-nodeshim@0.4.10
 ------------------------------------------------------------------------------
 MIT License
 
@@ -36124,7 +36461,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
 ------------------------------------------------------------------------------
-[353] Applies to: npm:file-uri-to-path@1.0.0
+[363] Applies to: npm:file-uri-to-path@1.0.0
 ------------------------------------------------------------------------------
 Copyright (c) 2014 Nathan Rajlich <nathan@tootallnate.net>
 
@@ -36148,7 +36485,7 @@ TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
 SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[354] Applies to: npm:finalhandler@1.1.2
+[364] Applies to: npm:finalhandler@1.1.2
 ------------------------------------------------------------------------------
 (The MIT License)
 
@@ -36174,7 +36511,7 @@ TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
 SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[355] Applies to: npm:finalhandler@2.1.1
+[365] Applies to: npm:finalhandler@2.1.1
 ------------------------------------------------------------------------------
 (The MIT License)
 
@@ -36200,7 +36537,7 @@ TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
 SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[356] Applies to: npm:follow-redirects@1.16.0
+[366] Applies to: npm:follow-redirects@1.16.0
 ------------------------------------------------------------------------------
 Copyright 2014–present Olivier Lalonde <olalonde@gmail.com>, James Talmage <james@talmage.io>, Ruben Verborgh
 
@@ -36222,7 +36559,7 @@ WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR
 IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[357] Applies to: npm:fontfaceobserver@2.3.0
+[367] Applies to: npm:fontfaceobserver@2.3.0
 ------------------------------------------------------------------------------
 Copyright (c) 2014 - Bram Stein
 
@@ -36247,7 +36584,7 @@ ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
 SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 ------------------------------------------------------------------------------
-[358] Applies to: npm:foreground-child@3.3.1
+[368] Applies to: npm:foreground-child@3.3.1
 ------------------------------------------------------------------------------
 The ISC License
 
@@ -36266,7 +36603,7 @@ ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF OR
 IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
 
 ------------------------------------------------------------------------------
-[359] Applies to: npm:form-data@4.0.6
+[369] Applies to: npm:form-data@4.0.6
 ------------------------------------------------------------------------------
 Copyright (c) 2012 Felix Geisendörfer (felix@debuggable.com) and contributors
 
@@ -36289,7 +36626,7 @@ Copyright (c) 2012 Felix Geisendörfer (felix@debuggable.com) and contributors
  THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[360] Applies to: npm:formdata-polyfill@4.0.10
+[370] Applies to: npm:formdata-polyfill@4.0.10
 ------------------------------------------------------------------------------
 MIT License
 
@@ -36314,7 +36651,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
 ------------------------------------------------------------------------------
-[361] Applies to: npm:fresh@0.5.2, npm:fresh@2.0.0
+[371] Applies to: npm:fresh@0.5.2, npm:fresh@2.0.0
 ------------------------------------------------------------------------------
 (The MIT License)
 
@@ -36341,7 +36678,7 @@ TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
 SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[362] Applies to: npm:fs-constants@1.0.0
+[372] Applies to: npm:fs-constants@1.0.0
 ------------------------------------------------------------------------------
 The MIT License (MIT)
 
@@ -36366,7 +36703,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[363] Applies to: npm:fs-extra@11.3.6
+[373] Applies to: npm:fs-extra@11.3.6
 ------------------------------------------------------------------------------
 (The MIT License)
 
@@ -36385,7 +36722,54 @@ OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHE
  ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[364] Applies to: npm:function-bind@1.1.2
+[374] Applies to: npm:fs.realpath@1.0.0
+------------------------------------------------------------------------------
+The ISC License
+
+Copyright (c) Isaac Z. Schlueter and Contributors
+
+Permission to use, copy, modify, and/or distribute this software for any
+purpose with or without fee is hereby granted, provided that the above
+copyright notice and this permission notice appear in all copies.
+
+THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
+ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF OR
+IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+
+----
+
+This library bundles a version of the `fs.realpath` and `fs.realpathSync`
+methods from Node.js v0.10 under the terms of the Node.js MIT license.
+
+Node's license follows, also included at the header of `old.js` which contains
+the licensed code:
+
+  Copyright Joyent, Inc. and other Node contributors.
+
+  Permission is hereby granted, free of charge, to any person obtaining a
+  copy of this software and associated documentation files (the "Software"),
+  to deal in the Software without restriction, including without limitation
+  the rights to use, copy, modify, merge, publish, distribute, sublicense,
+  and/or sell copies of the Software, and to permit persons to whom the
+  Software is furnished to do so, subject to the following conditions:
+
+  The above copyright notice and this permission notice shall be included in
+  all copies or substantial portions of the Software.
+
+  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+  FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+  DEALINGS IN THE SOFTWARE.
+
+------------------------------------------------------------------------------
+[375] Applies to: npm:function-bind@1.1.2
 ------------------------------------------------------------------------------
 Copyright (c) 2013 Raynos.
 
@@ -36408,7 +36792,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[365] Applies to: npm:gensync@1.0.0-beta.2
+[376] Applies to: npm:gensync@1.0.0-beta.2
 ------------------------------------------------------------------------------
 Copyright 2018 Logan Smyth <loganfsmyth@gmail.com>
 
@@ -36419,7 +36803,7 @@ The above copyright notice and this permission notice shall be included in all c
 THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[366] Applies to: npm:get-caller-file@2.0.5
+[377] Applies to: npm:get-caller-file@2.0.5
 ------------------------------------------------------------------------------
 ISC License (ISC)
 Copyright 2018 Stefan Penner
@@ -36429,7 +36813,7 @@ Permission to use, copy, modify, and/or distribute this software for any purpose
 THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
 
 ------------------------------------------------------------------------------
-[367] Applies to: npm:get-intrinsic@1.3.0
+[378] Applies to: npm:get-intrinsic@1.3.0
 ------------------------------------------------------------------------------
 MIT License
 
@@ -36454,7 +36838,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
 ------------------------------------------------------------------------------
-[368] Applies to: npm:get-nonce@1.0.1
+[379] Applies to: npm:get-nonce@1.0.1
 ------------------------------------------------------------------------------
 MIT License
 
@@ -36479,7 +36863,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
 ------------------------------------------------------------------------------
-[369] Applies to: npm:get-proto@1.0.1
+[380] Applies to: npm:get-proto@1.0.1
 ------------------------------------------------------------------------------
 MIT License
 
@@ -36504,7 +36888,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
 ------------------------------------------------------------------------------
-[370] Applies to: npm:getenv@2.0.0
+[381] Applies to: npm:getenv@2.0.0
 ------------------------------------------------------------------------------
 The MIT License (MIT)
 Copyright (c) 2012-2019 Christoph Tavan <dev@tavan.de>
@@ -36528,29 +36912,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
 ------------------------------------------------------------------------------
-[371] Applies to: npm:github-from-package@0.0.0, npm:minimist@1.2.8
-------------------------------------------------------------------------------
-This software is released under the MIT license:
-
-Permission is hereby granted, free of charge, to any person obtaining a copy of
-this software and associated documentation files (the "Software"), to deal in
-the Software without restriction, including without limitation the rights to
-use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
-the Software, and to permit persons to whom the Software is furnished to do so,
-subject to the following conditions:
-
-The above copyright notice and this permission notice shall be included in all
-copies or substantial portions of the Software.
-
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
-FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
-COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
-IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
-CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
-
-------------------------------------------------------------------------------
-[372] Applies to: npm:github-slugger@2.0.0
+[382] Applies to: npm:github-slugger@2.0.0
 ------------------------------------------------------------------------------
 Copyright (c) 2015, Dan Flettre <fletd01@yahoo.com>
 
@@ -36559,7 +36921,7 @@ Permission to use, copy, modify, and/or distribute this software for any purpose
 THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
 
 ------------------------------------------------------------------------------
-[373] Applies to: npm:glob@10.5.0
+[383] Applies to: npm:glob@10.5.0
 ------------------------------------------------------------------------------
 The ISC License
 
@@ -36578,7 +36940,32 @@ ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF OR
 IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
 
 ------------------------------------------------------------------------------
-[374] Applies to: npm:gopd@1.2.0
+[384] Applies to: npm:glob@7.2.3
+------------------------------------------------------------------------------
+The ISC License
+
+Copyright (c) Isaac Z. Schlueter and Contributors
+
+Permission to use, copy, modify, and/or distribute this software for any
+purpose with or without fee is hereby granted, provided that the above
+copyright notice and this permission notice appear in all copies.
+
+THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
+ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF OR
+IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+
+## Glob Logo
+
+Glob's logo created by Tanya Brassie <http://tanyabrassie.com/>, licensed
+under a Creative Commons Attribution-ShareAlike 4.0 International License
+https://creativecommons.org/licenses/by-sa/4.0/
+
+------------------------------------------------------------------------------
+[385] Applies to: npm:gopd@1.2.0
 ------------------------------------------------------------------------------
 MIT License
 
@@ -36603,7 +36990,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
 ------------------------------------------------------------------------------
-[375] Applies to: npm:graceful-fs@4.2.11
+[386] Applies to: npm:graceful-fs@4.2.11
 ------------------------------------------------------------------------------
 The ISC License
 
@@ -36622,7 +37009,7 @@ ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF OR
 IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
 
 ------------------------------------------------------------------------------
-[376] Applies to: npm:gray-matter@4.0.3
+[387] Applies to: npm:gray-matter@4.0.3, npm:normalize-path@3.0.0
 ------------------------------------------------------------------------------
 The MIT License (MIT)
 
@@ -36647,7 +37034,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[377] Applies to: npm:gtoken@8.0.0
+[388] Applies to: npm:gtoken@8.0.0
 ------------------------------------------------------------------------------
 The MIT License (MIT)
 
@@ -36672,7 +37059,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[378] Applies to: npm:hachure-fill@0.5.2
+[389] Applies to: npm:hachure-fill@0.5.2
 ------------------------------------------------------------------------------
 MIT License
 
@@ -36697,7 +37084,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
 ------------------------------------------------------------------------------
-[379] Applies to: npm:harmonyos-sans-sc-webfont-splitted@1.1.0
+[390] Applies to: npm:harmonyos-sans-sc-webfont-splitted@1.1.0
 ------------------------------------------------------------------------------
 This is free and unencumbered software released into the public domain.
 
@@ -36725,7 +37112,7 @@ OTHER DEALINGS IN THE SOFTWARE.
 For more information, please refer to <https://unlicense.org>
 
 ------------------------------------------------------------------------------
-[380] Applies to: npm:has-symbols@1.1.0
+[391] Applies to: npm:has-symbols@1.1.0
 ------------------------------------------------------------------------------
 MIT License
 
@@ -36750,7 +37137,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
 ------------------------------------------------------------------------------
-[381] Applies to: npm:has-tostringtag@1.0.2
+[392] Applies to: npm:has-tostringtag@1.0.2
 ------------------------------------------------------------------------------
 MIT License
 
@@ -36775,7 +37162,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
 ------------------------------------------------------------------------------
-[382] Applies to: npm:hasown@2.0.4
+[393] Applies to: npm:hasown@2.0.4
 ------------------------------------------------------------------------------
 MIT License
 
@@ -36800,7 +37187,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
 ------------------------------------------------------------------------------
-[383] Applies to: npm:hast-util-from-dom@5.0.1
+[394] Applies to: npm:hast-util-from-dom@5.0.1
 ------------------------------------------------------------------------------
 (ISC License)
 
@@ -36819,7 +37206,7 @@ TORTIOUS ACTION, ARISING OUT OF OR IN CONNECTION WITH THE USE OR PERFORMANCE OF
 THIS SOFTWARE.
 
 ------------------------------------------------------------------------------
-[384] Applies to: npm:hast-util-from-html@2.0.3
+[395] Applies to: npm:hast-util-from-html@2.0.3
 ------------------------------------------------------------------------------
 (The MIT License)
 
@@ -36845,7 +37232,7 @@ TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
 SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[385] Applies to: npm:hast-util-from-html-isomorphic@2.0.0
+[396] Applies to: npm:hast-util-from-html-isomorphic@2.0.0
 ------------------------------------------------------------------------------
 (The MIT License)
 
@@ -36871,7 +37258,7 @@ TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
 SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[386] Applies to: npm:hast-util-to-string@3.0.1, npm:html-url-attributes@3.0.1
+[397] Applies to: npm:hast-util-to-string@3.0.1, npm:html-url-attributes@3.0.1
 ------------------------------------------------------------------------------
 (The MIT License)
 
@@ -36896,7 +37283,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[387] Applies to: npm:hast-util-to-text@4.0.2
+[398] Applies to: npm:hast-util-to-text@4.0.2
 ------------------------------------------------------------------------------
 (The MIT License)
 
@@ -36922,7 +37309,7 @@ TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
 SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[388] Applies to: npm:highlight.js@11.11.1
+[399] Applies to: npm:highlight.js@11.11.1
 ------------------------------------------------------------------------------
 BSD 3-Clause License
 
@@ -36955,7 +37342,40 @@ OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 ------------------------------------------------------------------------------
-[389] Applies to: npm:hono@4.12.30
+[400] Applies to: npm:hoist-non-react-statics@3.3.2
+------------------------------------------------------------------------------
+Software License Agreement (BSD License)
+========================================
+
+Copyright (c) 2015, Yahoo! Inc. All rights reserved.
+----------------------------------------------------
+
+Redistribution and use of this software in source and binary forms, with or
+without modification, are permitted provided that the following conditions are
+met:
+
+  * Redistributions of source code must retain the above copyright notice, this
+    list of conditions and the following disclaimer.
+  * Redistributions in binary form must reproduce the above copyright notice,
+    this list of conditions and the following disclaimer in the documentation
+    and/or other materials provided with the distribution.
+  * Neither the name of Yahoo! Inc. nor the names of YUI's contributors may be
+    used to endorse or promote products derived from this software without
+    specific prior written permission of Yahoo! Inc.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+(INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+------------------------------------------------------------------------------
+[401] Applies to: npm:hono@4.12.30
 ------------------------------------------------------------------------------
 MIT License
 
@@ -36980,7 +37400,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
 ------------------------------------------------------------------------------
-[390] Applies to: npm:hosted-git-info@7.0.2
+[402] Applies to: npm:hosted-git-info@7.0.2
 ------------------------------------------------------------------------------
 Copyright (c) 2015, Rebecca Turner
 
@@ -36997,7 +37417,7 @@ OTHER TORTIOUS ACTION, ARISING OUT OF OR IN CONNECTION WITH THE USE OR
 PERFORMANCE OF THIS SOFTWARE.
 
 ------------------------------------------------------------------------------
-[391] Applies to: npm:html-to-image@1.11.13
+[403] Applies to: npm:html-to-image@1.11.13
 ------------------------------------------------------------------------------
 MIT License
 
@@ -37022,7 +37442,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
 ------------------------------------------------------------------------------
-[392] Applies to: npm:http-errors@2.0.1
+[404] Applies to: npm:http-errors@2.0.1
 ------------------------------------------------------------------------------
 The MIT License (MIT)
 
@@ -37048,7 +37468,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[393] Applies to: npm:human-signals@1.1.1, npm:human-signals@2.1.0
+[405] Applies to: npm:human-signals@1.1.1, npm:human-signals@2.1.0
 ------------------------------------------------------------------------------
 Apache License
                            Version 2.0, January 2004
@@ -37253,7 +37673,7 @@ Apache License
    limitations under the License.
 
 ------------------------------------------------------------------------------
-[394] Applies to: npm:hyphenate-style-name@1.1.0
+[406] Applies to: npm:hyphenate-style-name@1.1.0
 ------------------------------------------------------------------------------
 BSD 3-Clause License
 
@@ -37286,7 +37706,7 @@ OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 ------------------------------------------------------------------------------
-[395] Applies to: npm:i18next@26.3.6
+[407] Applies to: npm:i18next@26.3.6
 ------------------------------------------------------------------------------
 The MIT License (MIT)
 
@@ -37311,7 +37731,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
 ------------------------------------------------------------------------------
-[396] Applies to: npm:iconv-lite@0.6.3, npm:iconv-lite@0.7.3
+[408] Applies to: npm:iconv-lite@0.6.3, npm:iconv-lite@0.7.3
 ------------------------------------------------------------------------------
 Copyright (c) 2011 Alexander Shtuchkin
 
@@ -37335,7 +37755,7 @@ OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
 WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[397] Applies to: npm:ieee754@1.2.1
+[409] Applies to: npm:ieee754@1.2.1
 ------------------------------------------------------------------------------
 Copyright 2008 Fair Oaks Labs, Inc.
 
@@ -37350,7 +37770,7 @@ Redistribution and use in source and binary forms, with or without modification,
 THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 ------------------------------------------------------------------------------
-[398] Applies to: npm:ignore@5.3.2, npm:ignore@7.0.6
+[410] Applies to: npm:ignore@5.3.2, npm:ignore@7.0.6
 ------------------------------------------------------------------------------
 Copyright (c) 2013 Kael Zhang <i@kael.me>, contributors
 http://kael.me/
@@ -37375,7 +37795,7 @@ OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
 WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[399] Applies to: npm:image-size@1.2.1
+[411] Applies to: npm:image-size@1.2.1
 ------------------------------------------------------------------------------
 The MIT License (MIT)
 
@@ -37388,7 +37808,7 @@ The above copyright notice and this permission notice shall be included in all c
 THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[400] Applies to: npm:immediate@3.0.6
+[412] Applies to: npm:immediate@3.0.6
 ------------------------------------------------------------------------------
 Copyright (c) 2012 Barnesandnoble.com, llc, Donavon West, Domenic Denicola, Brian Cavalier
 
@@ -37412,7 +37832,7 @@ OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
 WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[401] Applies to: npm:import-meta-resolve@4.2.0
+[413] Applies to: npm:import-meta-resolve@4.2.0
 ------------------------------------------------------------------------------
 (The MIT License)
 
@@ -37490,7 +37910,26 @@ IN THE SOFTWARE.
 """
 
 ------------------------------------------------------------------------------
-[402] Applies to: npm:inherits@2.0.4
+[414] Applies to: npm:inflight@1.0.6
+------------------------------------------------------------------------------
+The ISC License
+
+Copyright (c) Isaac Z. Schlueter
+
+Permission to use, copy, modify, and/or distribute this software for any
+purpose with or without fee is hereby granted, provided that the above
+copyright notice and this permission notice appear in all copies.
+
+THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
+ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF OR
+IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+
+------------------------------------------------------------------------------
+[415] Applies to: npm:inherits@2.0.4
 ------------------------------------------------------------------------------
 The ISC License
 
@@ -37509,7 +37948,7 @@ OTHER TORTIOUS ACTION, ARISING OUT OF OR IN CONNECTION WITH THE USE OR
 PERFORMANCE OF THIS SOFTWARE.
 
 ------------------------------------------------------------------------------
-[403] Applies to: npm:inline-style-parser@0.2.7
+[416] Applies to: npm:inline-style-parser@0.2.7
 ------------------------------------------------------------------------------
 (The MIT License)
 
@@ -37522,7 +37961,7 @@ The above copyright notice and this permission notice shall be included in all c
 THE SOFTWARE IS PROVIDED 'AS IS', WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[404] Applies to: npm:inline-style-prefixer@7.0.1
+[417] Applies to: npm:inline-style-prefixer@7.0.1
 ------------------------------------------------------------------------------
 The MIT License (MIT)
 
@@ -37547,7 +37986,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
 ------------------------------------------------------------------------------
-[405] Applies to: npm:internmap@1.0.1, npm:internmap@2.0.3
+[418] Applies to: npm:internmap@1.0.1, npm:internmap@2.0.3
 ------------------------------------------------------------------------------
 Copyright 2021 Mike Bostock
 
@@ -37564,7 +38003,7 @@ TORTIOUS ACTION, ARISING OUT OF OR IN CONNECTION WITH THE USE OR PERFORMANCE OF
 THIS SOFTWARE.
 
 ------------------------------------------------------------------------------
-[406] Applies to: npm:ip-address@10.2.0
+[419] Applies to: npm:ip-address@10.2.0
 ------------------------------------------------------------------------------
 Copyright (C) 2011 by Beau Gunderson
 
@@ -37587,7 +38026,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[407] Applies to: npm:ipaddr.js@1.9.1, npm:ipaddr.js@2.4.0
+[420] Applies to: npm:ipaddr.js@1.9.1, npm:ipaddr.js@2.4.0
 ------------------------------------------------------------------------------
 Copyright (C) 2011-2017 whitequark <whitequark@whitequark.org>
 
@@ -37610,7 +38049,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[408] Applies to: npm:is-arrayish@0.3.4
+[421] Applies to: npm:is-arrayish@0.3.4
 ------------------------------------------------------------------------------
 The MIT License (MIT)
 
@@ -37635,7 +38074,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[409] Applies to: npm:is-buffer@1.1.6, npm:safe-buffer@5.1.2, npm:safe-buffer@5.2.1
+[422] Applies to: npm:is-buffer@1.1.6, npm:safe-buffer@5.1.2, npm:safe-buffer@5.2.1
 ------------------------------------------------------------------------------
 The MIT License (MIT)
 
@@ -37660,7 +38099,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[410] Applies to: npm:is-core-module@2.16.2
+[423] Applies to: npm:is-core-module@2.16.2
 ------------------------------------------------------------------------------
 The MIT License (MIT)
 
@@ -37684,7 +38123,7 @@ IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
 CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[411] Applies to: npm:is-extendable@0.1.1
+[424] Applies to: npm:is-extendable@0.1.1
 ------------------------------------------------------------------------------
 The MIT License (MIT)
 
@@ -37709,7 +38148,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[412] Applies to: npm:is-extglob@2.1.1
+[425] Applies to: npm:is-extglob@2.1.1
 ------------------------------------------------------------------------------
 The MIT License (MIT)
 
@@ -37734,7 +38173,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[413] Applies to: npm:is-glob@4.0.3, npm:kind-of@6.0.3
+[426] Applies to: npm:is-glob@4.0.3, npm:kind-of@6.0.3
 ------------------------------------------------------------------------------
 The MIT License (MIT)
 
@@ -37759,7 +38198,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[414] Applies to: npm:is-promise@2.2.2, npm:is-promise@4.0.0, npm:promise@7.3.1, npm:promise@8.3.0
+[427] Applies to: npm:is-promise@2.2.2, npm:is-promise@4.0.0, npm:promise@7.3.1, npm:promise@8.3.0
 ------------------------------------------------------------------------------
 Copyright (c) 2014 Forbes Lindesay
 
@@ -37782,7 +38221,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[415] Applies to: npm:jackspeak@3.4.3, npm:minimatch@10.2.5
+[428] Applies to: npm:jackspeak@3.4.3, npm:minimatch@10.2.5
 ------------------------------------------------------------------------------
 # Blue Oak Model License
 
@@ -37841,7 +38280,7 @@ will be liable to anyone for any damages related to this
 software or this license, under any kind of legal claim._**
 
 ------------------------------------------------------------------------------
-[416] Applies to: npm:jose@6.2.3
+[429] Applies to: npm:jose@6.2.3
 ------------------------------------------------------------------------------
 The MIT License (MIT)
 
@@ -37866,7 +38305,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
 ------------------------------------------------------------------------------
-[417] Applies to: npm:js-base64@3.9.1
+[430] Applies to: npm:js-base64@3.9.1
 ------------------------------------------------------------------------------
 Copyright (c) 2014, Dan Kogai
 All rights reserved.
@@ -37897,7 +38336,7 @@ OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 ------------------------------------------------------------------------------
-[418] Applies to: npm:js-tokens@4.0.0
+[431] Applies to: npm:js-tokens@4.0.0
 ------------------------------------------------------------------------------
 The MIT License (MIT)
 
@@ -37922,7 +38361,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[419] Applies to: npm:js-yaml@3.15.0, npm:js-yaml@4.3.0
+[432] Applies to: npm:js-yaml@3.15.0, npm:js-yaml@4.3.0
 ------------------------------------------------------------------------------
 (The MIT License)
 
@@ -37947,7 +38386,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[420] Applies to: npm:jsc-safe-url@0.2.4
+[433] Applies to: npm:jsc-safe-url@0.2.4
 ------------------------------------------------------------------------------
 Zero-Clause BSD
 =============
@@ -37964,7 +38403,7 @@ AN ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT
 OF OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
 
 ------------------------------------------------------------------------------
-[421] Applies to: npm:json-bigint@1.0.0
+[434] Applies to: npm:json-bigint@1.0.0
 ------------------------------------------------------------------------------
 The MIT License (MIT)
 
@@ -37988,7 +38427,7 @@ IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
 CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[422] Applies to: npm:json-schema-to-ts@3.1.1, npm:ts-algebra@2.0.0
+[435] Applies to: npm:json-schema-to-ts@3.1.1, npm:ts-algebra@2.0.0
 ------------------------------------------------------------------------------
 MIT License
 
@@ -38013,7 +38452,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
 ------------------------------------------------------------------------------
-[423] Applies to: npm:json-schema-typed@7.0.3
+[436] Applies to: npm:json-schema-typed@7.0.3
 ------------------------------------------------------------------------------
 BSD-2-Clause License
 
@@ -38043,7 +38482,7 @@ ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 POSSIBILITY OF SUCH DAMAGE.
 
 ------------------------------------------------------------------------------
-[424] Applies to: npm:json-schema-typed@8.0.2
+[437] Applies to: npm:json-schema-typed@8.0.2
 ------------------------------------------------------------------------------
 BSD 2-Clause License
 
@@ -38104,7 +38543,7 @@ ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
 SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 ------------------------------------------------------------------------------
-[425] Applies to: npm:json5@2.2.3
+[438] Applies to: npm:json5@2.2.3
 ------------------------------------------------------------------------------
 MIT License
 
@@ -38131,7 +38570,7 @@ SOFTWARE.
 [others]: https://github.com/json5/json5/contributors
 
 ------------------------------------------------------------------------------
-[426] Applies to: npm:jsonfile@4.0.0, npm:jsonfile@6.2.1
+[439] Applies to: npm:jsonfile@4.0.0, npm:jsonfile@6.2.1
 ------------------------------------------------------------------------------
 (The MIT License)
 
@@ -38150,7 +38589,7 @@ OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHE
  ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[427] Applies to: npm:jszip@3.10.1
+[440] Applies to: npm:jszip@3.10.1
 ------------------------------------------------------------------------------
 JSZip is dual licensed. At your choice you may use it under the MIT license *or* the GPLv3
 license.
@@ -38805,7 +39244,7 @@ copy of the Program in return for a fee.
                      END OF TERMS AND CONDITIONS
 
 ------------------------------------------------------------------------------
-[428] Applies to: npm:jwa@2.0.1, npm:jws@4.0.1
+[441] Applies to: npm:jwa@2.0.1, npm:jws@4.0.1
 ------------------------------------------------------------------------------
 Copyright (c) 2013 Brian J. Brennan
 
@@ -38826,7 +39265,7 @@ FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TOR
 ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[429] Applies to: npm:katex@0.16.47
+[442] Applies to: npm:katex@0.16.47
 ------------------------------------------------------------------------------
 The MIT License (MIT)
 
@@ -38851,7 +39290,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
 ------------------------------------------------------------------------------
-[430] Applies to: npm:khroma@2.1.0
+[443] Applies to: npm:khroma@2.1.0
 ------------------------------------------------------------------------------
 The MIT License (MIT)
 
@@ -38876,7 +39315,7 @@ FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
 DEALINGS IN THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[431] Applies to: npm:lan-network@0.2.1
+[444] Applies to: npm:lan-network@0.2.1
 ------------------------------------------------------------------------------
 MIT License
 
@@ -38901,7 +39340,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
 ------------------------------------------------------------------------------
-[432] Applies to: npm:layout-base@1.0.2, npm:layout-base@2.0.1
+[445] Applies to: npm:layout-base@1.0.2, npm:layout-base@2.0.1
 ------------------------------------------------------------------------------
 MIT License
 
@@ -38926,7 +39365,33 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
 ------------------------------------------------------------------------------
-[433] Applies to: npm:lie@3.3.0
+[446] Applies to: npm:lazystream@1.0.1
+------------------------------------------------------------------------------
+Copyright (c) 2013 J. Pommerening, contributors.
+
+Permission is hereby granted, free of charge, to any person
+obtaining a copy of this software and associated documentation
+files (the "Software"), to deal in the Software without
+restriction, including without limitation the rights to use,
+copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the
+Software is furnished to do so, subject to the following
+conditions:
+
+The above copyright notice and this permission notice shall be
+included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
+OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+OTHER DEALINGS IN THE SOFTWARE.
+
+------------------------------------------------------------------------------
+[447] Applies to: npm:lie@3.3.0
 ------------------------------------------------------------------------------
 #Copyright (c) 2014-2018 Calvin Metcalf, Jordan Harband
 
@@ -38937,7 +39402,7 @@ The above copyright notice and this permission notice shall be included in all c
 **THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.**
 
 ------------------------------------------------------------------------------
-[434] Applies to: npm:lightningcss@1.32.0, npm:lightningcss-darwin-arm64@1.32.0, npm:lightningcss-darwin-x64@1.32.0, npm:lightningcss-linux-arm64-gnu@1.32.0, npm:lightningcss-linux-x64-gnu@1.32.0, npm:lightningcss-win32-arm64-msvc@1.32.0, npm:lightningcss-win32-x64-msvc@1.32.0
+[448] Applies to: npm:lightningcss@1.32.0, npm:lightningcss-darwin-arm64@1.32.0, npm:lightningcss-darwin-x64@1.32.0, npm:lightningcss-linux-arm64-gnu@1.32.0, npm:lightningcss-linux-x64-gnu@1.32.0, npm:lightningcss-win32-arm64-msvc@1.32.0, npm:lightningcss-win32-x64-msvc@1.32.0
 ------------------------------------------------------------------------------
 Mozilla Public License Version 2.0
 ==================================
@@ -39314,7 +39779,16 @@ This Source Code Form is "Incompatible With Secondary Licenses", as
 defined by the Mozilla Public License, v. 2.0.
 
 ------------------------------------------------------------------------------
-[435] Applies to: npm:lodash@4.18.1, npm:lodash-es@4.18.1, npm:lodash.merge@4.6.2
+[449] Applies to: npm:listenercount@1.0.1
+------------------------------------------------------------------------------
+Copyright (c) MMXV jden <jason@denizac.org>
+
+Permission to use, copy, modify, and/or distribute this software for any purpose with or without fee is hereby granted, provided that the above copyright notice and this permission notice appear in all copies.
+
+THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+
+------------------------------------------------------------------------------
+[450] Applies to: npm:lodash@4.18.1, npm:lodash-es@4.18.1, npm:lodash.merge@4.6.2
 ------------------------------------------------------------------------------
 Copyright OpenJS Foundation and other contributors <https://openjsf.org/>
 
@@ -39365,7 +39839,7 @@ licenses; we recommend you read them, as their terms may differ from the
 terms above.
 
 ------------------------------------------------------------------------------
-[436] Applies to: npm:lodash.debounce@4.0.8, npm:lodash.pickby@4.6.0, npm:lodash.snakecase@4.1.1, npm:lodash.throttle@4.1.1
+[451] Applies to: npm:lodash.debounce@4.0.8, npm:lodash.defaults@4.2.0, npm:lodash.difference@4.5.0, npm:lodash.escaperegexp@4.1.2, npm:lodash.flatten@4.4.0, npm:lodash.groupby@4.6.0, npm:lodash.isplainobject@4.0.6, npm:lodash.pickby@4.6.0, npm:lodash.snakecase@4.1.1, npm:lodash.throttle@4.1.1, npm:lodash.union@4.6.0, npm:lodash.uniq@4.5.0
 ------------------------------------------------------------------------------
 Copyright jQuery Foundation and other contributors <https://jquery.org/>
 
@@ -39416,7 +39890,7 @@ licenses; we recommend you read them, as their terms may differ from the
 terms above.
 
 ------------------------------------------------------------------------------
-[437] Applies to: npm:lodash.identity@3.0.0
+[452] Applies to: npm:lodash.identity@3.0.0
 ------------------------------------------------------------------------------
 Copyright 2012-2015 The Dojo Foundation <http://dojofoundation.org/>
 Based on Underscore.js 1.7.0, copyright 2009-2015 Jeremy Ashkenas,
@@ -39442,7 +39916,110 @@ OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
 WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[438] Applies to: npm:longest-streak@3.1.0, npm:stringify-entities@4.0.4, npm:trim-lines@3.0.1
+[453] Applies to: npm:lodash.isboolean@3.0.3, npm:lodash.isnil@4.0.0
+------------------------------------------------------------------------------
+Copyright 2012-2016 The Dojo Foundation <http://dojofoundation.org/>
+Based on Underscore.js, copyright 2009-2016 Jeremy Ashkenas,
+DocumentCloud and Investigative Reporters & Editors <http://underscorejs.org/>
+
+Permission is hereby granted, free of charge, to any person obtaining
+a copy of this software and associated documentation files (the
+"Software"), to deal in the Software without restriction, including
+without limitation the rights to use, copy, modify, merge, publish,
+distribute, sublicense, and/or sell copies of the Software, and to
+permit persons to whom the Software is furnished to do so, subject to
+the following conditions:
+
+The above copyright notice and this permission notice shall be
+included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+------------------------------------------------------------------------------
+[454] Applies to: npm:lodash.isequal@4.5.0, npm:lodash.isfunction@3.0.9
+------------------------------------------------------------------------------
+Copyright JS Foundation and other contributors <https://js.foundation/>
+
+Based on Underscore.js, copyright Jeremy Ashkenas,
+DocumentCloud and Investigative Reporters & Editors <http://underscorejs.org/>
+
+This software consists of voluntary contributions made by many
+individuals. For exact contribution history, see the revision history
+available at https://github.com/lodash/lodash
+
+The following license applies to all parts of this software except as
+documented below:
+
+====
+
+Permission is hereby granted, free of charge, to any person obtaining
+a copy of this software and associated documentation files (the
+"Software"), to deal in the Software without restriction, including
+without limitation the rights to use, copy, modify, merge, publish,
+distribute, sublicense, and/or sell copies of the Software, and to
+permit persons to whom the Software is furnished to do so, subject to
+the following conditions:
+
+The above copyright notice and this permission notice shall be
+included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+====
+
+Copyright and related rights for sample code are waived via CC0. Sample
+code is defined as all source code displayed within the prose of the
+documentation.
+
+CC0: http://creativecommons.org/publicdomain/zero/1.0/
+
+====
+
+Files located in the node_modules and vendor directories are externally
+maintained libraries used by this software which have their own
+licenses; we recommend you read them, as their terms may differ from the
+terms above.
+
+------------------------------------------------------------------------------
+[455] Applies to: npm:lodash.isundefined@3.0.1
+------------------------------------------------------------------------------
+Copyright 2012-2015 The Dojo Foundation <http://dojofoundation.org/>
+Based on Underscore.js, copyright 2009-2015 Jeremy Ashkenas,
+DocumentCloud and Investigative Reporters & Editors <http://underscorejs.org/>
+
+Permission is hereby granted, free of charge, to any person obtaining
+a copy of this software and associated documentation files (the
+"Software"), to deal in the Software without restriction, including
+without limitation the rights to use, copy, modify, merge, publish,
+distribute, sublicense, and/or sell copies of the Software, and to
+permit persons to whom the Software is furnished to do so, subject to
+the following conditions:
+
+The above copyright notice and this permission notice shall be
+included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+------------------------------------------------------------------------------
+[456] Applies to: npm:longest-streak@3.1.0, npm:stringify-entities@4.0.4, npm:trim-lines@3.0.1
 ------------------------------------------------------------------------------
 (The MIT License)
 
@@ -39468,7 +40045,7 @@ TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
 SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[439] Applies to: npm:loose-envify@1.4.0
+[457] Applies to: npm:loose-envify@1.4.0
 ------------------------------------------------------------------------------
 The MIT License (MIT)
 
@@ -39493,7 +40070,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[440] Applies to: npm:loudness@0.4.2
+[458] Applies to: npm:loudness@0.4.2
 ------------------------------------------------------------------------------
 The MIT License (MIT)
 
@@ -39517,7 +40094,7 @@ IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
 CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[441] Applies to: npm:lru-cache@10.4.3
+[459] Applies to: npm:lru-cache@10.4.3
 ------------------------------------------------------------------------------
 The ISC License
 
@@ -39536,7 +40113,7 @@ ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF OR
 IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
 
 ------------------------------------------------------------------------------
-[442] Applies to: npm:lru-cache@11.5.2, npm:minipass@7.1.3, npm:path-scurry@1.11.1, npm:path-scurry@2.0.2, npm:sax@1.6.0, npm:tar@7.5.22
+[460] Applies to: npm:lru-cache@11.5.2, npm:minipass@7.1.3, npm:path-scurry@1.11.1, npm:path-scurry@2.0.2, npm:sax@1.6.0, npm:tar@7.5.22
 ------------------------------------------------------------------------------
 # Blue Oak Model License
 
@@ -39595,7 +40172,7 @@ will be liable to anyone for any damages related to this
 software or this license, under any kind of legal claim.***
 
 ------------------------------------------------------------------------------
-[443] Applies to: npm:lucide-react@0.468.0, npm:lucide-react-native@0.468.0
+[461] Applies to: npm:lucide-react@0.468.0, npm:lucide-react-native@0.468.0
 ------------------------------------------------------------------------------
 ISC License
 
@@ -39614,7 +40191,7 @@ ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
 OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
 
 ------------------------------------------------------------------------------
-[444] Applies to: npm:magic-bytes.js@1.13.0
+[462] Applies to: npm:magic-bytes.js@1.13.0
 ------------------------------------------------------------------------------
 MIT License
 
@@ -39639,7 +40216,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
 ------------------------------------------------------------------------------
-[445] Applies to: npm:makeerror@1.0.12, npm:tmpl@1.0.5
+[463] Applies to: npm:makeerror@1.0.12, npm:tmpl@1.0.5
 ------------------------------------------------------------------------------
 BSD License
 
@@ -39671,7 +40248,7 @@ ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
 SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 ------------------------------------------------------------------------------
-[446] Applies to: npm:marked@16.4.2
+[464] Applies to: npm:marked@16.4.2
 ------------------------------------------------------------------------------
 # License information
 
@@ -39719,7 +40296,7 @@ Redistribution and use in source and binary forms, with or without modification,
 This software is provided by the copyright holders and contributors “as is” and any express or implied warranties, including, but not limited to, the implied warranties of merchantability and fitness for a particular purpose are disclaimed. In no event shall the copyright owner or contributors be liable for any direct, indirect, incidental, special, exemplary, or consequential damages (including, but not limited to, procurement of substitute goods or services; loss of use, data, or profits; or business interruption) however caused and on any theory of liability, whether in contract, strict liability, or tort (including negligence or otherwise) arising in any way out of the use of this software, even if advised of the possibility of such damage.
 
 ------------------------------------------------------------------------------
-[447] Applies to: npm:marky@1.3.0
+[465] Applies to: npm:marky@1.3.0
 ------------------------------------------------------------------------------
 Apache License
 Version 2.0, January 2004
@@ -39931,7 +40508,7 @@ APPENDIX: How to apply the Apache License to your work
         permissions and limitations under the License.
 
 ------------------------------------------------------------------------------
-[448] Applies to: npm:md5@2.3.0
+[466] Applies to: npm:md5@2.3.0
 ------------------------------------------------------------------------------
 Copyright © 2011-2012, Paul Vorbach.
 Copyright © 2009, Jeff Mott.
@@ -39962,7 +40539,7 @@ ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
 SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 ------------------------------------------------------------------------------
-[449] Applies to: npm:mdast-util-phrasing@4.1.0
+[467] Applies to: npm:mdast-util-phrasing@4.1.0
 ------------------------------------------------------------------------------
 (The MIT License)
 
@@ -39989,7 +40566,7 @@ TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
 SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[450] Applies to: npm:mdast-util-to-markdown-cjk-friendly@1.0.0, npm:remark-cjk-friendly@2.3.1
+[468] Applies to: npm:mdast-util-to-markdown-cjk-friendly@1.0.0, npm:remark-cjk-friendly@2.3.1
 ------------------------------------------------------------------------------
 Copyright (c) 2025 Tatsunori Uchino <tats.u@live.jp>
 
@@ -40021,7 +40598,7 @@ TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
 SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[451] Applies to: npm:mdn-data@2.0.14
+[469] Applies to: npm:mdn-data@2.0.14
 ------------------------------------------------------------------------------
 CC0 1.0 Universal
 
@@ -40141,7 +40718,7 @@ For more information, please see
 <http://creativecommons.org/publicdomain/zero/1.0/>
 
 ------------------------------------------------------------------------------
-[452] Applies to: npm:memoize-one@5.2.1, npm:memoize-one@6.0.0
+[470] Applies to: npm:memoize-one@5.2.1, npm:memoize-one@6.0.0
 ------------------------------------------------------------------------------
 MIT License
 
@@ -40166,7 +40743,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
 ------------------------------------------------------------------------------
-[453] Applies to: npm:merge-descriptors@2.0.0
+[471] Applies to: npm:merge-descriptors@2.0.0
 ------------------------------------------------------------------------------
 MIT License
 
@@ -40181,7 +40758,7 @@ The above copyright notice and this permission notice shall be included in all c
 THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[454] Applies to: npm:merge-options@3.0.4
+[472] Applies to: npm:merge-options@3.0.4
 ------------------------------------------------------------------------------
 The MIT License (MIT)
 
@@ -40206,7 +40783,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
 ------------------------------------------------------------------------------
-[455] Applies to: npm:merge-stream@2.0.0
+[473] Applies to: npm:merge-stream@2.0.0
 ------------------------------------------------------------------------------
 The MIT License (MIT)
 
@@ -40231,7 +40808,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[456] Applies to: npm:mermaid@11.16.0
+[474] Applies to: npm:mermaid@11.16.0
 ------------------------------------------------------------------------------
 The MIT License (MIT)
 
@@ -40256,7 +40833,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
 ------------------------------------------------------------------------------
-[457] Applies to: npm:micromark-extension-cjk-friendly@2.0.1
+[475] Applies to: npm:micromark-extension-cjk-friendly@2.0.1
 ------------------------------------------------------------------------------
 Copyright (c) 2025 Tatsunori Uchino <tats.u@live.jp>
 
@@ -40288,7 +40865,7 @@ TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
 SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[458] Applies to: npm:micromark-extension-cjk-friendly-util@3.0.1
+[476] Applies to: npm:micromark-extension-cjk-friendly-util@3.0.1
 ------------------------------------------------------------------------------
 Copyright (c) 2025 Tatsunori Uchino <tats.u@live.jp>
 
@@ -40320,7 +40897,7 @@ TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
 SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[459] Applies to: npm:micromark-extension-gfm-footnote@2.1.0
+[477] Applies to: npm:micromark-extension-gfm-footnote@2.1.0
 ------------------------------------------------------------------------------
 (The MIT License)
 
@@ -40346,7 +40923,7 @@ TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
 SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[460] Applies to: npm:mime@1.6.0
+[478] Applies to: npm:mime@1.6.0
 ------------------------------------------------------------------------------
 The MIT License (MIT)
 
@@ -40371,7 +40948,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[461] Applies to: npm:mime-db@1.52.0, npm:mime-db@1.54.0
+[479] Applies to: npm:mime-db@1.52.0, npm:mime-db@1.54.0
 ------------------------------------------------------------------------------
 (The MIT License)
 
@@ -40398,32 +40975,24 @@ TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
 SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[462] Applies to: npm:min-indent@1.0.1
+[480] Applies to: npm:minimalistic-assert@1.0.1
 ------------------------------------------------------------------------------
-The MIT License (MIT)
+Copyright 2015 Calvin Metcalf
 
-Copyright (c) Sindre Sorhus <sindresorhus@gmail.com> (sindresorhus.com), James Kyle <me@thejameskyle.com> (thejameskyle.com)
+Permission to use, copy, modify, and/or distribute this software for any purpose
+with or without fee is hereby granted, provided that the above copyright notice
+and this permission notice appear in all copies.
 
-Permission is hereby granted, free of charge, to any person obtaining a copy
-of this software and associated documentation files (the "Software"), to deal
-in the Software without restriction, including without limitation the rights
-to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-copies of the Software, and to permit persons to whom the Software is
-furnished to do so, subject to the following conditions:
-
-The above copyright notice and this permission notice shall be included in
-all copies or substantial portions of the Software.
-
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
-THE SOFTWARE.
+THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES WITH
+REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF MERCHANTABILITY AND
+FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY SPECIAL, DIRECT,
+INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES WHATSOEVER RESULTING FROM
+LOSS OF USE, DATA OR PROFITS, WHETHER IN AN ACTION OF CONTRACT, NEGLIGENCE
+OR OTHER TORTIOUS ACTION, ARISING OUT OF OR IN CONNECTION WITH THE USE OR
+PERFORMANCE OF THIS SOFTWARE.
 
 ------------------------------------------------------------------------------
-[463] Applies to: npm:minimatch@9.0.9, npm:rimraf@5.0.10
+[481] Applies to: npm:minimatch@5.1.9, npm:minimatch@9.0.9, npm:rimraf@5.0.10
 ------------------------------------------------------------------------------
 The ISC License
 
@@ -40442,7 +41011,7 @@ ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF OR
 IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
 
 ------------------------------------------------------------------------------
-[464] Applies to: npm:minizlib@3.1.0
+[482] Applies to: npm:minizlib@3.1.0
 ------------------------------------------------------------------------------
 Minizlib was created by Isaac Z. Schlueter.
 It is a derivative work of the Node.js project.
@@ -40472,7 +41041,7 @@ SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 """
 
 ------------------------------------------------------------------------------
-[465] Applies to: npm:mkdirp@0.5.6
+[483] Applies to: npm:mkdirp@0.5.6
 ------------------------------------------------------------------------------
 Copyright 2010 James Halliday (mail@substack.net)
 
@@ -40497,7 +41066,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[466] Applies to: npm:mkdirp@1.0.4
+[484] Applies to: npm:mkdirp@1.0.4
 ------------------------------------------------------------------------------
 Copyright James Halliday (mail@substack.net) and Isaac Z. Schlueter (i@izs.me)
 
@@ -40522,7 +41091,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[467] Applies to: npm:mkdirp-classic@0.5.3
+[485] Applies to: npm:mkdirp-classic@0.5.3
 ------------------------------------------------------------------------------
 The MIT License (MIT)
 
@@ -40547,7 +41116,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[468] Applies to: npm:ms@2.0.0
+[486] Applies to: npm:ms@2.0.0
 ------------------------------------------------------------------------------
 The MIT License (MIT)
 
@@ -40572,7 +41141,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
 ------------------------------------------------------------------------------
-[469] Applies to: npm:ms@2.1.3
+[487] Applies to: npm:ms@2.1.3
 ------------------------------------------------------------------------------
 The MIT License (MIT)
 
@@ -40597,7 +41166,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
 ------------------------------------------------------------------------------
-[470] Applies to: npm:nan@2.28.0
+[488] Applies to: npm:nan@2.28.0
 ------------------------------------------------------------------------------
 The MIT License (MIT)
 
@@ -40610,7 +41179,7 @@ The above copyright notice and this permission notice shall be included in all c
 THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[471] Applies to: npm:nanoid@3.3.16
+[489] Applies to: npm:nanoid@3.3.16
 ------------------------------------------------------------------------------
 The MIT License (MIT)
 
@@ -40634,7 +41203,31 @@ IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
 CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[472] Applies to: npm:napi-build-utils@2.0.0
+[490] Applies to: npm:nanoid@5.1.16
+------------------------------------------------------------------------------
+The MIT License (MIT)
+
+Copyright 2017 Andrey Sitnik <andrey@sitnik.es>
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of
+this software and associated documentation files (the "Software"), to deal in
+the Software without restriction, including without limitation the rights to
+use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+the Software, and to permit persons to whom the Software is furnished to do so,
+subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+------------------------------------------------------------------------------
+[491] Applies to: npm:napi-build-utils@2.0.0
 ------------------------------------------------------------------------------
 MIT License
 
@@ -40659,7 +41252,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
 ------------------------------------------------------------------------------
-[473] Applies to: npm:negotiator@0.6.3, npm:negotiator@0.6.4, npm:negotiator@1.0.0
+[492] Applies to: npm:negotiator@0.6.3, npm:negotiator@0.6.4, npm:negotiator@1.0.0
 ------------------------------------------------------------------------------
 (The MIT License)
 
@@ -40687,7 +41280,7 @@ TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
 SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[474] Applies to: npm:node-abi@3.94.0
+[493] Applies to: npm:node-abi@3.94.0
 ------------------------------------------------------------------------------
 MIT License
 
@@ -40712,7 +41305,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
 ------------------------------------------------------------------------------
-[475] Applies to: npm:node-addon-api@7.1.1
+[494] Applies to: npm:node-addon-api@7.1.1
 ------------------------------------------------------------------------------
 The MIT License (MIT)
 
@@ -40725,7 +41318,7 @@ The above copyright notice and this permission notice shall be included in all c
 THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[476] Applies to: npm:node-domexception@1.0.0
+[495] Applies to: npm:node-domexception@1.0.0
 ------------------------------------------------------------------------------
 MIT License
 
@@ -40750,7 +41343,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
 ------------------------------------------------------------------------------
-[477] Applies to: npm:node-fetch@2.7.0
+[496] Applies to: npm:node-fetch@2.7.0
 ------------------------------------------------------------------------------
 The MIT License (MIT)
 
@@ -40775,7 +41368,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
 ------------------------------------------------------------------------------
-[478] Applies to: npm:node-fetch@3.3.2
+[497] Applies to: npm:node-fetch@3.3.2
 ------------------------------------------------------------------------------
 The MIT License (MIT)
 
@@ -40800,7 +41393,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
 ------------------------------------------------------------------------------
-[479] Applies to: npm:node-forge@1.4.0
+[498] Applies to: npm:node-forge@1.4.0
 ------------------------------------------------------------------------------
 You may use the Forge project under the terms of either the BSD License or the
 GNU General Public License (GPL) Version 2.
@@ -41134,7 +41727,7 @@ PROGRAMS), EVEN IF SUCH HOLDER OR OTHER PARTY HAS BEEN ADVISED OF THE
 POSSIBILITY OF SUCH DAMAGES.
 
 ------------------------------------------------------------------------------
-[480] Applies to: npm:node-int64@0.4.0
+[499] Applies to: npm:node-int64@0.4.0
 ------------------------------------------------------------------------------
 Copyright (c) 2014 Robert Kieffer
 
@@ -41157,7 +41750,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[481] Applies to: npm:node-machine-id@1.1.12
+[500] Applies to: npm:node-machine-id@1.1.12
 ------------------------------------------------------------------------------
 The MIT License (MIT)
 
@@ -41182,7 +41775,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
 ------------------------------------------------------------------------------
-[482] Applies to: npm:node-pty@1.1.0
+[501] Applies to: npm:node-pty@1.1.0
 ------------------------------------------------------------------------------
 Copyright (c) 2012-2015, Christopher Jeffrey (https://github.com/chjj/)
 
@@ -41255,7 +41848,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
 ------------------------------------------------------------------------------
-[483] Applies to: npm:node-releases@2.0.51
+[502] Applies to: npm:node-releases@2.0.51
 ------------------------------------------------------------------------------
 The MIT License
 
@@ -41280,7 +41873,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[484] Applies to: npm:npm-package-arg@11.0.3
+[503] Applies to: npm:npm-package-arg@11.0.3
 ------------------------------------------------------------------------------
 The ISC License
 
@@ -41299,7 +41892,7 @@ ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF OR
 IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
 
 ------------------------------------------------------------------------------
-[485] Applies to: npm:nullthrows@1.1.1
+[504] Applies to: npm:nullthrows@1.1.1
 ------------------------------------------------------------------------------
 The MIT License (MIT)
 Copyright (c) 2016 Andres Suarez
@@ -41311,7 +41904,7 @@ The above copyright notice and this permission notice shall be included in all c
 THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[486] Applies to: npm:object-inspect@1.13.4
+[505] Applies to: npm:object-inspect@1.13.4
 ------------------------------------------------------------------------------
 MIT License
 
@@ -41336,7 +41929,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
 ------------------------------------------------------------------------------
-[487] Applies to: npm:on-finished@2.3.0, npm:on-finished@2.4.1
+[506] Applies to: npm:on-finished@2.3.0, npm:on-finished@2.4.1
 ------------------------------------------------------------------------------
 (The MIT License)
 
@@ -41363,7 +41956,7 @@ TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
 SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[488] Applies to: npm:on-headers@1.1.0
+[507] Applies to: npm:on-headers@1.1.0
 ------------------------------------------------------------------------------
 (The MIT License)
 
@@ -41389,7 +41982,7 @@ TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
 SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[489] Applies to: npm:orderedmap@2.1.1, npm:w3c-keyname@2.2.8
+[508] Applies to: npm:orderedmap@2.1.1, npm:w3c-keyname@2.2.8
 ------------------------------------------------------------------------------
 Copyright (C) 2016 by Marijn Haverbeke <marijn@haverbeke.berlin> and others
 
@@ -41412,7 +42005,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[490] Applies to: npm:package-manager-detector@1.7.0
+[509] Applies to: npm:package-manager-detector@1.7.0
 ------------------------------------------------------------------------------
 MIT License
 
@@ -41437,7 +42030,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
 ------------------------------------------------------------------------------
-[491] Applies to: npm:pako@1.0.11, npm:pako@2.2.0
+[510] Applies to: npm:pako@1.0.11, npm:pako@2.2.0
 ------------------------------------------------------------------------------
 (The MIT License)
 
@@ -41462,7 +42055,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[492] Applies to: npm:parse-entities@4.0.2, npm:property-information@7.2.0
+[511] Applies to: npm:parse-entities@4.0.2, npm:property-information@7.2.0
 ------------------------------------------------------------------------------
 (The MIT License)
 
@@ -41488,7 +42081,7 @@ TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
 SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[493] Applies to: npm:parse-png@2.1.0, npm:shebang-command@2.0.0
+[512] Applies to: npm:parse-png@2.1.0, npm:shebang-command@2.0.0
 ------------------------------------------------------------------------------
 MIT License
 
@@ -41501,7 +42094,7 @@ The above copyright notice and this permission notice shall be included in all c
 THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[494] Applies to: npm:parse5@7.3.0
+[513] Applies to: npm:parse5@7.3.0
 ------------------------------------------------------------------------------
 Copyright (c) 2013-2019 Ivan Nikulin (ifaaan@gmail.com, https://github.com/inikulin)
 
@@ -41524,7 +42117,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[495] Applies to: npm:parseurl@1.3.3
+[514] Applies to: npm:parseurl@1.3.3
 ------------------------------------------------------------------------------
 (The MIT License)
 
@@ -41551,7 +42144,7 @@ TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
 SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[496] Applies to: npm:path-data-parser@0.1.0, npm:points-on-curve@0.2.0
+[515] Applies to: npm:path-data-parser@0.1.0, npm:points-on-curve@0.2.0
 ------------------------------------------------------------------------------
 MIT License
 
@@ -41576,7 +42169,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
 ------------------------------------------------------------------------------
-[497] Applies to: npm:path-parse@1.0.7
+[516] Applies to: npm:path-parse@1.0.7
 ------------------------------------------------------------------------------
 The MIT License (MIT)
 
@@ -41601,7 +42194,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
 ------------------------------------------------------------------------------
-[498] Applies to: npm:path-to-regexp@8.4.2
+[517] Applies to: npm:path-to-regexp@8.4.2
 ------------------------------------------------------------------------------
 The MIT License (MIT)
 
@@ -41626,7 +42219,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[499] Applies to: npm:pdfjs-dist@5.7.284
+[518] Applies to: npm:pdfjs-dist@5.7.284
 ------------------------------------------------------------------------------
 Apache License
                            Version 2.0, January 2004
@@ -41806,7 +42399,7 @@ Apache License
    END OF TERMS AND CONDITIONS
 
 ------------------------------------------------------------------------------
-[500] Applies to: npm:picocolors@1.1.1
+[519] Applies to: npm:picocolors@1.1.1
 ------------------------------------------------------------------------------
 ISC License
 
@@ -41825,7 +42418,7 @@ ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
 OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
 
 ------------------------------------------------------------------------------
-[501] Applies to: npm:picomatch@2.3.2, npm:picomatch@4.0.5
+[520] Applies to: npm:picomatch@2.3.2, npm:picomatch@4.0.5
 ------------------------------------------------------------------------------
 The MIT License (MIT)
 
@@ -41850,7 +42443,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[502] Applies to: npm:pkce-challenge@5.0.1
+[521] Applies to: npm:pkce-challenge@5.0.1
 ------------------------------------------------------------------------------
 MIT License
 
@@ -41875,7 +42468,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
 ------------------------------------------------------------------------------
-[503] Applies to: npm:playwright-core@1.60.0
+[522] Applies to: npm:playwright-core@1.60.0
 ------------------------------------------------------------------------------
 Apache License
                            Version 2.0, January 2004
@@ -42081,7 +42674,7 @@ Apache License
    limitations under the License.
 
 ------------------------------------------------------------------------------
-[504] Applies to: npm:playwright-core@1.60.0 (NOTICE)
+[523] Applies to: npm:playwright-core@1.60.0 (NOTICE)
 ------------------------------------------------------------------------------
 NOTICE for npm:playwright-core@1.60.0:
 
@@ -42092,7 +42685,7 @@ This software contains code derived from the Puppeteer project (https://github.c
 available under the Apache 2.0 license (https://github.com/puppeteer/puppeteer/blob/master/LICENSE).
 
 ------------------------------------------------------------------------------
-[505] Applies to: npm:plist@3.1.1
+[524] Applies to: npm:plist@3.1.1
 ------------------------------------------------------------------------------
 (The MIT License)
 
@@ -42120,7 +42713,7 @@ FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
 OTHER DEALINGS IN THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[506] Applies to: npm:pngjs@3.4.0, npm:pngjs@5.0.0
+[525] Applies to: npm:pngjs@3.4.0, npm:pngjs@5.0.0
 ------------------------------------------------------------------------------
 pngjs2 original work Copyright (c) 2015 Luke Page & Original Contributors
 pngjs derived work Copyright (c) 2012 Kuba Niegowski
@@ -42144,7 +42737,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[507] Applies to: npm:points-on-path@0.2.1
+[526] Applies to: npm:points-on-path@0.2.1
 ------------------------------------------------------------------------------
 MIT License
 
@@ -42169,7 +42762,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
 ------------------------------------------------------------------------------
-[508] Applies to: npm:postcss@8.5.19
+[527] Applies to: npm:postcss@8.5.19
 ------------------------------------------------------------------------------
 The MIT License (MIT)
 
@@ -42193,7 +42786,7 @@ IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
 CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[509] Applies to: npm:postcss-value-parser@4.2.0
+[528] Applies to: npm:postcss-value-parser@4.2.0
 ------------------------------------------------------------------------------
 Copyright (c) Bogdan Chadkin <trysound@yandex.ru>
 
@@ -42219,7 +42812,32 @@ FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
 OTHER DEALINGS IN THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[510] Applies to: npm:prebuild-install@7.1.3
+[529] Applies to: npm:pptxgenjs@4.0.1
+------------------------------------------------------------------------------
+The MIT License (MIT)
+
+Copyright (c) 2015-2022 Brent Ely
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+
+------------------------------------------------------------------------------
+[530] Applies to: npm:prebuild-install@7.1.3
 ------------------------------------------------------------------------------
 The MIT License (MIT)
 
@@ -42244,7 +42862,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[511] Applies to: npm:proc-log@4.2.0
+[531] Applies to: npm:proc-log@4.2.0
 ------------------------------------------------------------------------------
 The ISC License
 
@@ -42263,7 +42881,7 @@ ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF OR
 IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
 
 ------------------------------------------------------------------------------
-[512] Applies to: npm:process-nextick-args@2.0.1
+[532] Applies to: npm:process-nextick-args@2.0.1
 ------------------------------------------------------------------------------
 # Copyright (c) 2015 Calvin Metcalf
 
@@ -42286,7 +42904,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.**
 
 ------------------------------------------------------------------------------
-[513] Applies to: npm:progress@2.0.3
+[533] Applies to: npm:progress@2.0.3
 ------------------------------------------------------------------------------
 (The MIT License)
 
@@ -42312,7 +42930,7 @@ TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
 SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[514] Applies to: npm:promise-worker-transferable@1.0.4
+[534] Applies to: npm:promise-worker-transferable@1.0.4
 ------------------------------------------------------------------------------
 Apache License
                           Version 2.0, January 2004
@@ -42517,7 +43135,7 @@ Apache License
   limitations under the License.
 
 ------------------------------------------------------------------------------
-[515] Applies to: npm:prompts@2.4.2, npm:sisteransi@1.0.5
+[535] Applies to: npm:prompts@2.4.2, npm:sisteransi@1.0.5
 ------------------------------------------------------------------------------
 MIT License
 
@@ -42542,7 +43160,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
 ------------------------------------------------------------------------------
-[516] Applies to: npm:prosemirror-changeset@2.4.1
+[536] Applies to: npm:prosemirror-changeset@2.4.1
 ------------------------------------------------------------------------------
 Copyright (C) 2017 by Marijn Haverbeke <marijn@haverbeke.berlin> and others
 
@@ -42565,7 +43183,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[517] Applies to: npm:prosemirror-commands@1.7.1, npm:prosemirror-dropcursor@1.8.3, npm:prosemirror-gapcursor@1.4.1, npm:prosemirror-history@1.5.0, npm:prosemirror-inputrules@1.5.1, npm:prosemirror-keymap@1.2.3, npm:prosemirror-model@1.25.11, npm:prosemirror-schema-list@1.5.1, npm:prosemirror-state@1.4.4, npm:prosemirror-transform@1.12.0, npm:prosemirror-view@1.42.1
+[537] Applies to: npm:prosemirror-commands@1.7.1, npm:prosemirror-dropcursor@1.8.3, npm:prosemirror-gapcursor@1.4.1, npm:prosemirror-history@1.5.0, npm:prosemirror-inputrules@1.5.1, npm:prosemirror-keymap@1.2.3, npm:prosemirror-model@1.25.11, npm:prosemirror-schema-list@1.5.1, npm:prosemirror-state@1.4.4, npm:prosemirror-transform@1.12.0, npm:prosemirror-view@1.42.1
 ------------------------------------------------------------------------------
 Copyright (C) 2015-2017 by Marijn Haverbeke <marijn@haverbeke.berlin> and others
 
@@ -42588,7 +43206,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[518] Applies to: npm:prosemirror-tables@1.8.5
+[538] Applies to: npm:prosemirror-tables@1.8.5
 ------------------------------------------------------------------------------
 Copyright (C) 2015-2016 by Marijn Haverbeke <marijnh@gmail.com> and others
 
@@ -42611,7 +43229,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[519] Applies to: npm:protobufjs@7.6.5
+[539] Applies to: npm:protobufjs@7.6.5
 ------------------------------------------------------------------------------
 This license applies to all parts of protobuf.js except those files
 either explicitly including or referencing a different license or
@@ -42654,7 +43272,7 @@ standalone and requires a support library to be linked with it. This
 support library is itself covered by the above license.
 
 ------------------------------------------------------------------------------
-[520] Applies to: npm:proxy-from-env@2.1.0
+[540] Applies to: npm:proxy-from-env@2.1.0
 ------------------------------------------------------------------------------
 The MIT License
 
@@ -42678,7 +43296,7 @@ IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
 CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[521] Applies to: npm:qrcode@1.5.4
+[541] Applies to: npm:qrcode@1.5.4
 ------------------------------------------------------------------------------
 The MIT License (MIT)
 
@@ -42691,7 +43309,7 @@ The above copyright notice and this permission notice shall be included in all c
 THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[522] Applies to: npm:qs@6.15.3
+[542] Applies to: npm:qs@6.15.3
 ------------------------------------------------------------------------------
 BSD 3-Clause License
 
@@ -42724,7 +43342,7 @@ OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 ------------------------------------------------------------------------------
-[523] Applies to: npm:query-string@7.1.3
+[543] Applies to: npm:query-string@7.1.3
 ------------------------------------------------------------------------------
 MIT License
 
@@ -42737,7 +43355,7 @@ The above copyright notice and this permission notice shall be included in all c
 THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[524] Applies to: npm:queue@6.0.2
+[544] Applies to: npm:queue@6.0.2
 ------------------------------------------------------------------------------
 The MIT License (MIT)
 Copyright (c) 2014 Jesse Tane <jesse.tane@gmail.com>
@@ -42749,7 +43367,7 @@ The above copyright notice and this permission notice shall be included in all c
 THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[525] Applies to: npm:range-parser@1.2.1, npm:range-parser@1.3.0
+[545] Applies to: npm:range-parser@1.2.1, npm:range-parser@1.3.0
 ------------------------------------------------------------------------------
 (The MIT License)
 
@@ -42776,7 +43394,7 @@ TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
 SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[526] Applies to: npm:raw-body@3.0.2
+[546] Applies to: npm:raw-body@3.0.2
 ------------------------------------------------------------------------------
 The MIT License (MIT)
 
@@ -42802,7 +43420,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[527] Applies to: npm:rc@1.2.8
+[547] Applies to: npm:rc@1.2.8
 ------------------------------------------------------------------------------
 Apache License, Version 2.0
 
@@ -42873,7 +43491,7 @@ TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
 SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[528] Applies to: npm:react-fast-compare@3.2.2
+[548] Applies to: npm:react-fast-compare@3.2.2
 ------------------------------------------------------------------------------
 MIT License
 
@@ -42899,7 +43517,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
 ------------------------------------------------------------------------------
-[529] Applies to: npm:react-freeze@1.0.4
+[549] Applies to: npm:react-freeze@1.0.4
 ------------------------------------------------------------------------------
 The MIT License (MIT)
 
@@ -42924,7 +43542,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
 ------------------------------------------------------------------------------
-[530] Applies to: npm:react-i18next@17.0.10
+[550] Applies to: npm:react-i18next@17.0.10
 ------------------------------------------------------------------------------
 The MIT License (MIT)
 
@@ -42949,7 +43567,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
 ------------------------------------------------------------------------------
-[531] Applies to: npm:react-markdown@10.1.0
+[551] Applies to: npm:react-markdown@10.1.0
 ------------------------------------------------------------------------------
 The MIT License (MIT)
 
@@ -42974,7 +43592,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
 ------------------------------------------------------------------------------
-[532] Applies to: npm:react-native-drawer-layout@4.2.7
+[552] Applies to: npm:react-native-drawer-layout@4.2.7
 ------------------------------------------------------------------------------
 MIT License
 
@@ -42999,7 +43617,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
 ------------------------------------------------------------------------------
-[533] Applies to: npm:react-native-gesture-handler@3.0.2, npm:react-native-reanimated@4.3.1
+[553] Applies to: npm:react-native-gesture-handler@2.32.0, npm:react-native-reanimated@4.5.1
 ------------------------------------------------------------------------------
 The MIT License (MIT)
 
@@ -43024,7 +43642,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
 ------------------------------------------------------------------------------
-[534] Applies to: npm:react-native-is-edge-to-edge@1.3.1
+[554] Applies to: npm:react-native-is-edge-to-edge@1.3.1
 ------------------------------------------------------------------------------
 MIT License
 
@@ -43049,7 +43667,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
 ------------------------------------------------------------------------------
-[535] Applies to: npm:react-native-safe-area-context@5.7.0
+[555] Applies to: npm:react-native-safe-area-context@5.7.0
 ------------------------------------------------------------------------------
 MIT License
 
@@ -43074,7 +43692,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
 ------------------------------------------------------------------------------
-[536] Applies to: npm:react-native-screens@4.25.2
+[556] Applies to: npm:react-native-screens@4.26.2
 ------------------------------------------------------------------------------
 The MIT License (MIT)
 
@@ -43099,7 +43717,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
 ------------------------------------------------------------------------------
-[537] Applies to: npm:react-native-svg@15.15.4
+[557] Applies to: npm:react-native-svg@15.15.4
 ------------------------------------------------------------------------------
 The MIT License (MIT)
 
@@ -43124,7 +43742,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
 ------------------------------------------------------------------------------
-[538] Applies to: npm:react-native-uitextview@2.2.0
+[558] Applies to: npm:react-native-uitextview@2.2.0
 ------------------------------------------------------------------------------
 MIT License
 
@@ -43148,7 +43766,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
 ------------------------------------------------------------------------------
-[539] Applies to: npm:react-native-web@0.21.2
+[559] Applies to: npm:react-native-web@0.21.2
 ------------------------------------------------------------------------------
 MIT License
 
@@ -43174,7 +43792,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
 ------------------------------------------------------------------------------
-[540] Applies to: npm:react-native-worklets@0.8.3
+[560] Applies to: npm:react-native-worklets@0.10.1
 ------------------------------------------------------------------------------
 MIT License
 
@@ -43198,7 +43816,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
 ------------------------------------------------------------------------------
-[541] Applies to: npm:react-router@7.18.1, npm:react-router-dom@7.18.1
+[561] Applies to: npm:react-router@7.18.1, npm:react-router-dom@7.18.1
 ------------------------------------------------------------------------------
 MIT License
 
@@ -43225,7 +43843,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
 ------------------------------------------------------------------------------
-[542] Applies to: npm:readable-stream@2.3.8, npm:readable-stream@3.6.2, npm:string_decoder@1.1.1, npm:string_decoder@1.3.0
+[562] Applies to: npm:readable-stream@2.3.8, npm:readable-stream@3.6.2, npm:string_decoder@1.1.1, npm:string_decoder@1.3.0
 ------------------------------------------------------------------------------
 Node.js is licensed for use as follows:
 
@@ -43276,7 +43894,212 @@ IN THE SOFTWARE.
 """
 
 ------------------------------------------------------------------------------
-[543] Applies to: npm:regenerator-runtime@0.13.11
+[563] Applies to: npm:readdir-glob@1.1.3
+------------------------------------------------------------------------------
+Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright 2020 Yann Armelin
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+
+------------------------------------------------------------------------------
+[564] Applies to: npm:regenerator-runtime@0.13.11
 ------------------------------------------------------------------------------
 MIT License
 
@@ -43301,7 +44124,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
 ------------------------------------------------------------------------------
-[544] Applies to: npm:regjsgen@0.8.0
+[565] Applies to: npm:regjsgen@0.8.0
 ------------------------------------------------------------------------------
 The MIT License (MIT)
 
@@ -43327,7 +44150,7 @@ OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
 WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[545] Applies to: npm:regjsparser@0.13.2
+[566] Applies to: npm:regjsparser@0.13.2
 ------------------------------------------------------------------------------
 Copyright (c) Julian Viereck and Contributors, All Rights Reserved.
 
@@ -43352,7 +44175,7 @@ ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
 THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 ------------------------------------------------------------------------------
-[546] Applies to: npm:remark-parse@11.0.0, npm:remark-stringify@11.0.0
+[567] Applies to: npm:remark-parse@11.0.0, npm:remark-stringify@11.0.0
 ------------------------------------------------------------------------------
 (The MIT License)
 
@@ -43377,7 +44200,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[547] Applies to: npm:require-directory@2.1.1
+[568] Applies to: npm:require-directory@2.1.1
 ------------------------------------------------------------------------------
 The MIT License (MIT)
 
@@ -43403,7 +44226,7 @@ TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
 SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[548] Applies to: npm:require-from-string@2.0.2
+[569] Applies to: npm:require-from-string@2.0.2
 ------------------------------------------------------------------------------
 The MIT License (MIT)
 
@@ -43428,7 +44251,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[549] Applies to: npm:require-main-filename@2.0.0, npm:set-blocking@2.0.0, npm:yargs-parser@18.1.3, npm:yargs-parser@21.1.1
+[570] Applies to: npm:require-main-filename@2.0.0, npm:set-blocking@2.0.0, npm:yargs-parser@18.1.3, npm:yargs-parser@21.1.1
 ------------------------------------------------------------------------------
 Copyright (c) 2016, Contributors
 
@@ -43446,7 +44269,7 @@ WHETHER IN AN ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION,
 ARISING OUT OF OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
 
 ------------------------------------------------------------------------------
-[550] Applies to: npm:resolve@1.22.12
+[571] Applies to: npm:resolve@1.22.12
 ------------------------------------------------------------------------------
 MIT License
 
@@ -43471,7 +44294,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
 ------------------------------------------------------------------------------
-[551] Applies to: npm:resolve-workspace-root@2.0.1
+[572] Applies to: npm:resolve-workspace-root@2.0.1
 ------------------------------------------------------------------------------
 # The MIT License (MIT)
 
@@ -43496,7 +44319,7 @@ Copyright (c) 2024-present Cedric van Putten <me@cedric.dev>
 > THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[552] Applies to: npm:rope-sequence@1.3.4
+[573] Applies to: npm:rope-sequence@1.3.4
 ------------------------------------------------------------------------------
 Copyright (C) 2016 by Marijn Haverbeke <marijn@haverbeke.berlin>
 
@@ -43519,7 +44342,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[553] Applies to: npm:roughjs@4.6.6
+[574] Applies to: npm:roughjs@4.6.6
 ------------------------------------------------------------------------------
 MIT License
 
@@ -43544,7 +44367,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
 ------------------------------------------------------------------------------
-[554] Applies to: npm:router@2.2.0
+[575] Applies to: npm:router@2.2.0
 ------------------------------------------------------------------------------
 (The MIT License)
 
@@ -43571,7 +44394,7 @@ TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
 SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[555] Applies to: npm:rtl-detect@1.1.2
+[576] Applies to: npm:rtl-detect@1.1.2
 ------------------------------------------------------------------------------
 Copyright 2015 Yahoo Inc.
 All rights reserved.
@@ -43602,7 +44425,7 @@ ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
 SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 ------------------------------------------------------------------------------
-[556] Applies to: npm:rw@1.3.3
+[577] Applies to: npm:rw@1.3.3
 ------------------------------------------------------------------------------
 Copyright (c) 2014-2016, Michael Bostock
 All rights reserved.
@@ -43632,7 +44455,7 @@ NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE,
 EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 ------------------------------------------------------------------------------
-[557] Applies to: npm:safer-buffer@2.1.2
+[578] Applies to: npm:safer-buffer@2.1.2
 ------------------------------------------------------------------------------
 MIT License
 
@@ -43657,7 +44480,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
 ------------------------------------------------------------------------------
-[558] Applies to: npm:section-matter@1.0.0
+[579] Applies to: npm:section-matter@1.0.0
 ------------------------------------------------------------------------------
 The MIT License (MIT)
 
@@ -43682,7 +44505,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
 ------------------------------------------------------------------------------
-[559] Applies to: npm:send@0.19.2, npm:send@1.2.1
+[580] Applies to: npm:send@0.19.2, npm:send@1.2.1
 ------------------------------------------------------------------------------
 (The MIT License)
 
@@ -43709,7 +44532,7 @@ TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
 SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[560] Applies to: npm:serve-static@1.16.3, npm:serve-static@2.2.1
+[581] Applies to: npm:serve-static@1.16.3, npm:serve-static@2.2.1
 ------------------------------------------------------------------------------
 (The MIT License)
 
@@ -43738,7 +44561,7 @@ TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
 SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[561] Applies to: npm:set-cookie-parser@2.7.2
+[582] Applies to: npm:set-cookie-parser@2.7.2
 ------------------------------------------------------------------------------
 The MIT License (MIT)
 
@@ -43763,7 +44586,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[562] Applies to: npm:setimmediate@1.0.5
+[583] Applies to: npm:setimmediate@1.0.5
 ------------------------------------------------------------------------------
 Copyright (c) 2012 Barnesandnoble.com, llc, Donavon West, and Domenic Denicola
 
@@ -43787,7 +44610,7 @@ OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
 WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[563] Applies to: npm:setprototypeof@1.2.0
+[584] Applies to: npm:setprototypeof@1.2.0
 ------------------------------------------------------------------------------
 Copyright (c) 2015, Wes Todd
 
@@ -43804,7 +44627,7 @@ OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF OR IN
 CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
 
 ------------------------------------------------------------------------------
-[564] Applies to: npm:sf-symbols-typescript@2.2.0
+[585] Applies to: npm:sf-symbols-typescript@2.2.0
 ------------------------------------------------------------------------------
 MIT License
 
@@ -43829,7 +44652,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
 ------------------------------------------------------------------------------
-[565] Applies to: npm:shallowequal@1.1.0
+[586] Applies to: npm:shallowequal@1.1.0
 ------------------------------------------------------------------------------
 MIT License
 
@@ -43854,7 +44677,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
 ------------------------------------------------------------------------------
-[566] Applies to: npm:shell-quote@1.10.0
+[587] Applies to: npm:shell-quote@1.10.0
 ------------------------------------------------------------------------------
 The MIT License
 
@@ -43882,7 +44705,7 @@ TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
 SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[567] Applies to: npm:side-channel@1.1.1, npm:side-channel-weakmap@1.0.2
+[588] Applies to: npm:side-channel@1.1.1, npm:side-channel-weakmap@1.0.2
 ------------------------------------------------------------------------------
 MIT License
 
@@ -43907,7 +44730,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
 ------------------------------------------------------------------------------
-[568] Applies to: npm:signal-exit@3.0.7
+[589] Applies to: npm:signal-exit@3.0.7
 ------------------------------------------------------------------------------
 The ISC License
 
@@ -43927,7 +44750,7 @@ WHETHER IN AN ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION,
 ARISING OUT OF OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
 
 ------------------------------------------------------------------------------
-[569] Applies to: npm:signal-exit@4.1.0
+[590] Applies to: npm:signal-exit@4.1.0
 ------------------------------------------------------------------------------
 The ISC License
 
@@ -43947,7 +44770,7 @@ WHETHER IN AN ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION,
 ARISING OUT OF OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
 
 ------------------------------------------------------------------------------
-[570] Applies to: npm:silk-wasm@3.7.1
+[591] Applies to: npm:silk-wasm@3.7.1
 ------------------------------------------------------------------------------
 MIT License
 
@@ -43972,7 +44795,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
 ------------------------------------------------------------------------------
-[571] Applies to: npm:simple-concat@1.0.1, npm:simple-get@4.0.1
+[592] Applies to: npm:simple-concat@1.0.1, npm:simple-get@4.0.1
 ------------------------------------------------------------------------------
 The MIT License (MIT)
 
@@ -43996,7 +44819,7 @@ IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
 CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[572] Applies to: npm:simple-plist@1.3.1
+[593] Applies to: npm:simple-plist@1.3.1
 ------------------------------------------------------------------------------
 The MIT License (MIT)
 
@@ -44020,7 +44843,7 @@ IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
 CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[573] Applies to: npm:simple-swizzle@0.2.4
+[594] Applies to: npm:simple-swizzle@0.2.4
 ------------------------------------------------------------------------------
 The MIT License (MIT)
 
@@ -44045,7 +44868,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[574] Applies to: npm:slugify@1.6.9
+[595] Applies to: npm:slugify@1.6.9
 ------------------------------------------------------------------------------
 The MIT License (MIT)
 
@@ -44070,7 +44893,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
 ------------------------------------------------------------------------------
-[575] Applies to: npm:smol-toml@1.7.0
+[596] Applies to: npm:smol-toml@1.7.0
 ------------------------------------------------------------------------------
 Copyright (c) Squirrel Chat et al., All rights reserved.
 
@@ -44098,7 +44921,7 @@ OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 ------------------------------------------------------------------------------
-[576] Applies to: npm:sortablejs@1.15.7
+[597] Applies to: npm:sortablejs@1.15.7
 ------------------------------------------------------------------------------
 MIT License
 
@@ -44123,7 +44946,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
 ------------------------------------------------------------------------------
-[577] Applies to: npm:source-map@0.5.7, npm:source-map@0.6.1, npm:source-map-js@1.2.1
+[598] Applies to: npm:source-map@0.5.7, npm:source-map@0.6.1, npm:source-map-js@1.2.1
 ------------------------------------------------------------------------------
 Copyright (c) 2009-2011, Mozilla Foundation and contributors
 All rights reserved.
@@ -44154,7 +44977,7 @@ OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 ------------------------------------------------------------------------------
-[578] Applies to: npm:source-map-support@0.5.21
+[599] Applies to: npm:source-map-support@0.5.21
 ------------------------------------------------------------------------------
 The MIT License (MIT)
 
@@ -44179,7 +45002,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
 ------------------------------------------------------------------------------
-[579] Applies to: npm:sprintf-js@1.0.3
+[600] Applies to: npm:sprintf-js@1.0.3
 ------------------------------------------------------------------------------
 Copyright (c) 2007-2014, Alexandru Marasteanu <hello [at) alexei (dot] ro>
 All rights reserved.
@@ -44207,7 +45030,7 @@ ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
 SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 ------------------------------------------------------------------------------
-[580] Applies to: npm:ssh-config@5.2.0
+[601] Applies to: npm:ssh-config@5.2.0
 ------------------------------------------------------------------------------
 MIT License
 
@@ -44232,7 +45055,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
 ------------------------------------------------------------------------------
-[581] Applies to: npm:stacktrace-parser@0.1.11
+[602] Applies to: npm:stacktrace-parser@0.1.11
 ------------------------------------------------------------------------------
 MIT License
 
@@ -44257,7 +45080,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
 ------------------------------------------------------------------------------
-[582] Applies to: npm:statuses@1.5.0, npm:statuses@2.0.2
+[603] Applies to: npm:statuses@1.5.0, npm:statuses@2.0.2
 ------------------------------------------------------------------------------
 The MIT License (MIT)
 
@@ -44283,7 +45106,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[583] Applies to: npm:stream-buffers@2.2.0
+[604] Applies to: npm:stream-buffers@2.2.0
 ------------------------------------------------------------------------------
 This is free and unencumbered software released into the public domain.
 
@@ -44311,7 +45134,7 @@ OTHER DEALINGS IN THE SOFTWARE.
 For more information, please refer to <http://unlicense.org/>
 
 ------------------------------------------------------------------------------
-[584] Applies to: npm:strict-uri-encode@2.0.0
+[605] Applies to: npm:strict-uri-encode@2.0.0
 ------------------------------------------------------------------------------
 The MIT License (MIT)
 
@@ -44336,7 +45159,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[585] Applies to: npm:strip-bom-string@1.0.0
+[606] Applies to: npm:strip-bom-string@1.0.0
 ------------------------------------------------------------------------------
 The MIT License (MIT)
 
@@ -44361,7 +45184,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[586] Applies to: npm:style-mod@4.1.3
+[607] Applies to: npm:style-mod@4.1.3
 ------------------------------------------------------------------------------
 Copyright (C) 2018 by Marijn Haverbeke <marijn@haverbeke.berlin> and others
 
@@ -44384,7 +45207,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[587] Applies to: npm:style-to-js@1.1.21
+[608] Applies to: npm:style-to-js@1.1.21
 ------------------------------------------------------------------------------
 The MIT License (MIT)
 
@@ -44410,7 +45233,7 @@ OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
 WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[588] Applies to: npm:style-to-object@1.0.14
+[609] Applies to: npm:style-to-object@1.0.14
 ------------------------------------------------------------------------------
 The MIT License (MIT)
 
@@ -44436,7 +45259,7 @@ OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
 WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[589] Applies to: npm:styleq@0.1.3
+[610] Applies to: npm:styleq@0.1.3
 ------------------------------------------------------------------------------
 MIT License
 
@@ -44461,7 +45284,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
 ------------------------------------------------------------------------------
-[590] Applies to: npm:stylis@4.4.0
+[611] Applies to: npm:stylis@4.4.0
 ------------------------------------------------------------------------------
 MIT License
 
@@ -44486,7 +45309,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
 ------------------------------------------------------------------------------
-[591] Applies to: npm:supports-hyperlinks@2.3.0
+[612] Applies to: npm:supports-hyperlinks@2.3.0
 ------------------------------------------------------------------------------
 MIT License
 
@@ -44499,7 +45322,7 @@ The above copyright notice and this permission notice shall be included in all c
 THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[592] Applies to: npm:supports-preserve-symlinks-flag@1.0.0
+[613] Applies to: npm:supports-preserve-symlinks-flag@1.0.0
 ------------------------------------------------------------------------------
 MIT License
 
@@ -44524,7 +45347,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
 ------------------------------------------------------------------------------
-[593] Applies to: npm:tailwind-merge@2.6.1
+[614] Applies to: npm:tailwind-merge@2.6.1
 ------------------------------------------------------------------------------
 MIT License
 
@@ -44549,7 +45372,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
 ------------------------------------------------------------------------------
-[594] Applies to: npm:terser@5.49.0
+[615] Applies to: npm:terser@5.49.0
 ------------------------------------------------------------------------------
 Copyright 2012-2018 (c) Mihai Bazon <mihai.bazon@gmail.com>
 
@@ -44580,7 +45403,7 @@ THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
 SUCH DAMAGE.
 
 ------------------------------------------------------------------------------
-[595] Applies to: npm:throat@5.0.0
+[616] Applies to: npm:throat@5.0.0
 ------------------------------------------------------------------------------
 Copyright (c) 2013 Forbes Lindesay
 
@@ -44603,7 +45426,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[596] Applies to: npm:tinyexec@1.2.4
+[617] Applies to: npm:tinyexec@1.2.4
 ------------------------------------------------------------------------------
 MIT License
 
@@ -44628,7 +45451,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
 ------------------------------------------------------------------------------
-[597] Applies to: npm:tinyglobby@0.2.17
+[618] Applies to: npm:tinyglobby@0.2.17
 ------------------------------------------------------------------------------
 MIT License
 
@@ -44653,7 +45476,32 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
 ------------------------------------------------------------------------------
-[598] Applies to: npm:to-regex-range@5.0.1
+[619] Applies to: npm:tmp@0.2.7
+------------------------------------------------------------------------------
+The MIT License (MIT)
+
+Copyright (c) 2014 KARASZI István
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+
+------------------------------------------------------------------------------
+[620] Applies to: npm:to-regex-range@5.0.1
 ------------------------------------------------------------------------------
 The MIT License (MIT)
 
@@ -44678,7 +45526,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[599] Applies to: npm:toidentifier@1.0.1
+[621] Applies to: npm:toidentifier@1.0.1
 ------------------------------------------------------------------------------
 MIT License
 
@@ -44703,7 +45551,35 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
 ------------------------------------------------------------------------------
-[600] Applies to: npm:trough@2.2.0
+[622] Applies to: npm:traverse@0.3.9
+------------------------------------------------------------------------------
+Copyright 2010 James Halliday (mail@substack.net)
+
+This project is free software released under the MIT/X11 license:
+http://www.opensource.org/licenses/mit-license.php
+
+Copyright 2010 James Halliday (mail@substack.net)
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+
+------------------------------------------------------------------------------
+[623] Applies to: npm:trough@2.2.0
 ------------------------------------------------------------------------------
 (The MIT License)
 
@@ -44728,7 +45604,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[601] Applies to: npm:ts-dedent@2.3.0
+[624] Applies to: npm:ts-dedent@2.3.0
 ------------------------------------------------------------------------------
 MIT License
 
@@ -44753,7 +45629,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
 ------------------------------------------------------------------------------
-[602] Applies to: npm:ts-mixer@6.0.4
+[625] Applies to: npm:ts-mixer@6.0.4
 ------------------------------------------------------------------------------
 MIT License
 
@@ -44778,7 +45654,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
 ------------------------------------------------------------------------------
-[603] Applies to: npm:tslib@2.8.1
+[626] Applies to: npm:tslib@2.8.1
 ------------------------------------------------------------------------------
 Copyright (c) Microsoft Corporation.
 
@@ -44794,7 +45670,7 @@ OTHER TORTIOUS ACTION, ARISING OUT OF OR IN CONNECTION WITH THE USE OR
 PERFORMANCE OF THIS SOFTWARE.
 
 ------------------------------------------------------------------------------
-[604] Applies to: npm:tslog@4.11.0
+[627] Applies to: npm:tslog@4.11.0
 ------------------------------------------------------------------------------
 MIT License
 
@@ -44819,7 +45695,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
 ------------------------------------------------------------------------------
-[605] Applies to: npm:tunnel-agent@0.6.0
+[628] Applies to: npm:tunnel-agent@0.6.0
 ------------------------------------------------------------------------------
 Apache License
 
@@ -44878,7 +45754,7 @@ If the Work includes a "NOTICE" text file as part of its distribution, then any 
 END OF TERMS AND CONDITIONS
 
 ------------------------------------------------------------------------------
-[606] Applies to: npm:type-fest@0.20.2, npm:type-fest@0.21.3
+[629] Applies to: npm:type-fest@0.20.2, npm:type-fest@0.21.3
 ------------------------------------------------------------------------------
 MIT License
 
@@ -44891,7 +45767,7 @@ The above copyright notice and this permission notice shall be included in all c
 THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[607] Applies to: npm:typebox@1.1.39
+[630] Applies to: npm:typebox@1.1.39
 ------------------------------------------------------------------------------
 TypeBox
 
@@ -44918,7 +45794,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[608] Applies to: npm:ua-parser-js@1.0.41
+[631] Applies to: npm:ua-parser-js@1.0.41
 ------------------------------------------------------------------------------
 MIT License
 
@@ -44943,7 +45819,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
 ------------------------------------------------------------------------------
-[609] Applies to: npm:undici@6.27.0, npm:undici@8.7.0, npm:undici-types@7.24.6
+[632] Applies to: npm:undici@6.27.0, npm:undici@8.7.0, npm:undici-types@6.21.0, npm:undici-types@7.24.6
 ------------------------------------------------------------------------------
 MIT License
 
@@ -44968,7 +45844,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
 ------------------------------------------------------------------------------
-[610] Applies to: npm:unified@11.0.5, npm:vfile@6.0.3
+[633] Applies to: npm:unified@11.0.5, npm:vfile@6.0.3
 ------------------------------------------------------------------------------
 (The MIT License)
 
@@ -44993,7 +45869,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[611] Applies to: npm:unist-util-is@6.0.1
+[634] Applies to: npm:unist-util-is@6.0.1
 ------------------------------------------------------------------------------
 (The MIT license)
 
@@ -45019,7 +45895,7 @@ TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
 SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[612] Applies to: npm:universalify@2.0.1
+[635] Applies to: npm:universalify@2.0.1
 ------------------------------------------------------------------------------
 (The MIT License)
 
@@ -45043,7 +45919,7 @@ IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
 CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[613] Applies to: npm:unpipe@1.0.0
+[636] Applies to: npm:unpipe@1.0.0
 ------------------------------------------------------------------------------
 (The MIT License)
 
@@ -45069,7 +45945,36 @@ TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
 SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[614] Applies to: npm:update-browserslist-db@1.2.3
+[637] Applies to: npm:unzipper@0.10.14
+------------------------------------------------------------------------------
+Copyright (c) 2012 - 2013 Near Infinity Corporation
+
+Permission is hereby granted, free of charge, to any person obtaining
+a copy of this software and associated documentation files (the
+"Software"), to deal in the Software without restriction, including
+without limitation the rights to use, copy, modify, merge, publish,
+distribute, sublicense, and/or sell copies of the Software, and to
+permit persons to whom the Software is furnished to do so, subject to
+the following conditions:
+
+The above copyright notice and this permission notice shall be
+included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+---
+
+Commits in this fork are (c) Ziggy Jonsson (ziggy.jonsson.nyc@gmail.com)
+and fall under same licence structure as the original repo (MIT)
+
+------------------------------------------------------------------------------
+[638] Applies to: npm:update-browserslist-db@1.2.3
 ------------------------------------------------------------------------------
 The MIT License (MIT)
 
@@ -45093,7 +45998,7 @@ IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
 CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[615] Applies to: npm:uri-js@4.4.1
+[639] Applies to: npm:uri-js@4.4.1
 ------------------------------------------------------------------------------
 Copyright 2011 Gary Court. All rights reserved.
 
@@ -45108,7 +46013,7 @@ THIS SOFTWARE IS PROVIDED BY GARY COURT "AS IS" AND ANY EXPRESS OR IMPLIED WARRA
 The views and conclusions contained in the software and documentation are those of the authors and should not be interpreted as representing official policies, either expressed or implied, of Gary Court.
 
 ------------------------------------------------------------------------------
-[616] Applies to: npm:url-template@2.0.8
+[640] Applies to: npm:url-template@2.0.8
 ------------------------------------------------------------------------------
 Copyright (c) 2012-2014, Bram Stein
 All rights reserved.
@@ -45137,7 +46042,7 @@ NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE,
 EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 ------------------------------------------------------------------------------
-[617] Applies to: npm:use-latest-callback@0.2.6
+[641] Applies to: npm:use-latest-callback@0.2.6
 ------------------------------------------------------------------------------
 MIT License
 
@@ -45162,7 +46067,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
 ------------------------------------------------------------------------------
-[618] Applies to: npm:util-deprecate@1.0.2
+[642] Applies to: npm:util-deprecate@1.0.2
 ------------------------------------------------------------------------------
 (The MIT License)
 
@@ -45190,7 +46095,7 @@ FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
 OTHER DEALINGS IN THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[619] Applies to: npm:utils-merge@1.0.1
+[643] Applies to: npm:utils-merge@1.0.1
 ------------------------------------------------------------------------------
 The MIT License (MIT)
 
@@ -45214,7 +46119,7 @@ IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
 CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[620] Applies to: npm:uuid@14.0.1
+[644] Applies to: npm:uuid@14.0.1, npm:uuid@8.3.2
 ------------------------------------------------------------------------------
 The MIT License (MIT)
 
@@ -45227,7 +46132,7 @@ The above copyright notice and this permission notice shall be included in all c
 THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[621] Applies to: npm:uuid@7.0.3
+[645] Applies to: npm:uuid@7.0.3
 ------------------------------------------------------------------------------
 The MIT License (MIT)
 
@@ -45252,7 +46157,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
 ------------------------------------------------------------------------------
-[622] Applies to: npm:validate-npm-package-name@5.0.1
+[646] Applies to: npm:validate-npm-package-name@5.0.1
 ------------------------------------------------------------------------------
 Copyright (c) 2015, npm, Inc
 
@@ -45262,7 +46167,7 @@ Permission to use, copy, modify, and/or distribute this software for any purpose
 THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
 
 ------------------------------------------------------------------------------
-[623] Applies to: npm:vaul@1.1.2
+[647] Applies to: npm:vaul@1.1.2
 ------------------------------------------------------------------------------
 MIT License
 
@@ -45275,7 +46180,7 @@ The above copyright notice and this permission notice shall be included in all c
 THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[624] Applies to: npm:vlq@1.0.1
+[648] Applies to: npm:vlq@1.0.1
 ------------------------------------------------------------------------------
 Copyright (c) 2017 [these people](https://github.com/Rich-Harris/vlq/graphs/contributors)
 
@@ -45286,7 +46191,7 @@ The above copyright notice and this permission notice shall be included in all c
 THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[625] Applies to: npm:void-elements@3.1.0
+[649] Applies to: npm:void-elements@3.1.0
 ------------------------------------------------------------------------------
 (The MIT License)
 
@@ -45312,7 +46217,7 @@ TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
 SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[626] Applies to: npm:walker@1.0.8
+[650] Applies to: npm:walker@1.0.8
 ------------------------------------------------------------------------------
 Copyright 2013 Naitik Shah
 
@@ -45329,7 +46234,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 
 ------------------------------------------------------------------------------
-[627] Applies to: npm:warn-once@0.1.1
+[651] Applies to: npm:warn-once@0.1.1
 ------------------------------------------------------------------------------
 MIT License
 
@@ -45354,7 +46259,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
 ------------------------------------------------------------------------------
-[628] Applies to: npm:wcwidth@1.0.1
+[652] Applies to: npm:wcwidth@1.0.1
 ------------------------------------------------------------------------------
 wcwidth.js: JavaScript Portng of Markus Kuhn's wcwidth() Implementation
 =======================================================================
@@ -45387,7 +46292,7 @@ ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 POSSIBILITY OF SUCH DAMAGE.
 
 ------------------------------------------------------------------------------
-[629] Applies to: npm:web-streams-polyfill@3.3.3
+[653] Applies to: npm:web-streams-polyfill@3.3.3
 ------------------------------------------------------------------------------
 The MIT License (MIT)
 
@@ -45413,7 +46318,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
 ------------------------------------------------------------------------------
-[630] Applies to: npm:webidl-conversions@3.0.1
+[654] Applies to: npm:webidl-conversions@3.0.1
 ------------------------------------------------------------------------------
 # The BSD 2-Clause License
 
@@ -45429,7 +46334,7 @@ Redistribution and use in source and binary forms, with or without modification,
 THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 ------------------------------------------------------------------------------
-[631] Applies to: npm:whatwg-fetch@3.6.20
+[655] Applies to: npm:whatwg-fetch@3.6.20
 ------------------------------------------------------------------------------
 Copyright (c) 2014-2023 GitHub, Inc.
 
@@ -45453,7 +46358,7 @@ OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
 WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[632] Applies to: npm:whatwg-url@5.0.0
+[656] Applies to: npm:whatwg-url@5.0.0
 ------------------------------------------------------------------------------
 The MIT License (MIT)
 
@@ -45478,7 +46383,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[633] Applies to: npm:whatwg-url-minimum@0.1.2
+[657] Applies to: npm:whatwg-url-minimum@0.1.2
 ------------------------------------------------------------------------------
 MIT License
 
@@ -45505,7 +46410,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
 ------------------------------------------------------------------------------
-[634] Applies to: npm:which-module@2.0.1
+[658] Applies to: npm:which-module@2.0.1
 ------------------------------------------------------------------------------
 Copyright (c) 2016, Contributors
 
@@ -45522,7 +46427,7 @@ TORTIOUS ACTION, ARISING OUT OF OR IN CONNECTION WITH THE USE OR PERFORMANCE OF
 THIS SOFTWARE.
 
 ------------------------------------------------------------------------------
-[635] Applies to: npm:workerpool@9.1.1
+[659] Applies to: npm:workerpool@9.1.1
 ------------------------------------------------------------------------------
 Apache License
                            Version 2.0, January 2004
@@ -45727,7 +46632,7 @@ Apache License
    limitations under the License.
 
 ------------------------------------------------------------------------------
-[636] Applies to: npm:ws@7.5.12
+[660] Applies to: npm:ws@7.5.12
 ------------------------------------------------------------------------------
 The MIT License (MIT)
 
@@ -45752,7 +46657,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
 ------------------------------------------------------------------------------
-[637] Applies to: npm:ws@8.21.1
+[661] Applies to: npm:ws@8.21.1
 ------------------------------------------------------------------------------
 Copyright (c) 2011 Einar Otto Stangvik <einaros@gmail.com>
 Copyright (c) 2013 Arnout Kazemier and contributors
@@ -45776,7 +46681,7 @@ IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
 CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[638] Applies to: npm:xcode@3.0.1 (NOTICE)
+[662] Applies to: npm:xcode@3.0.1 (NOTICE)
 ------------------------------------------------------------------------------
 NOTICE for npm:xcode@3.0.1:
 
@@ -45787,7 +46692,58 @@ This product includes software developed at
 The Apache Software Foundation (http://www.apache.org/).
 
 ------------------------------------------------------------------------------
-[639] Applies to: npm:xml2js@0.6.0
+[663] Applies to: npm:xml@1.0.1
+------------------------------------------------------------------------------
+(The MIT License)
+
+Copyright (c) 2011-2016 Dylan Greene <dylang@gmail.com>
+
+Permission is hereby granted, free of charge, to any person obtaining
+a copy of this software and associated documentation files (the
+'Software'), to deal in the Software without restriction, including
+without limitation the rights to use, copy, modify, merge, publish,
+distribute, sublicense, and/or sell copies of the Software, and to
+permit persons to whom the Software is furnished to do so, subject to
+the following conditions:
+
+The above copyright notice and this permission notice shall be
+included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED 'AS IS', WITHOUT WARRANTY OF ANY KIND,
+EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+------------------------------------------------------------------------------
+[664] Applies to: npm:xml-js@1.6.11
+------------------------------------------------------------------------------
+The MIT License (MIT)
+
+Copyright (c) 2016-2017 Yousuf Almarzooqi
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+
+------------------------------------------------------------------------------
+[665] Applies to: npm:xml2js@0.6.0
 ------------------------------------------------------------------------------
 Copyright 2010, 2011, 2012, 2013. All rights reserved.
 
@@ -45810,7 +46766,7 @@ FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
 IN THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[640] Applies to: npm:xmlbuilder@11.0.1, npm:xmlbuilder@15.1.1
+[666] Applies to: npm:xmlbuilder@11.0.1, npm:xmlbuilder@15.1.1
 ------------------------------------------------------------------------------
 The MIT License (MIT)
 
@@ -45835,7 +46791,29 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[641] Applies to: npm:y18n@4.0.3, npm:y18n@5.0.8
+[667] Applies to: npm:xmlchars@2.2.0
+------------------------------------------------------------------------------
+Copyright Louis-Dominique Dubeau and contributors to xmlchars
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of
+this software and associated documentation files (the "Software"), to deal in
+the Software without restriction, including without limitation the rights to
+use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+the Software, and to permit persons to whom the Software is furnished to do so,
+subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+------------------------------------------------------------------------------
+[668] Applies to: npm:y18n@4.0.3, npm:y18n@5.0.8
 ------------------------------------------------------------------------------
 Copyright (c) 2015, Contributors
 
@@ -45852,7 +46830,7 @@ TORTIOUS ACTION, ARISING OUT OF OR IN CONNECTION WITH THE USE OR PERFORMANCE OF
 THIS SOFTWARE.
 
 ------------------------------------------------------------------------------
-[642] Applies to: npm:yaml@2.9.0
+[669] Applies to: npm:yaml@2.9.0
 ------------------------------------------------------------------------------
 Copyright Eemeli Aro <eemeli@gmail.com>
 
@@ -45869,7 +46847,7 @@ TORTIOUS ACTION, ARISING OUT OF OR IN CONNECTION WITH THE USE OR PERFORMANCE OF
 THIS SOFTWARE.
 
 ------------------------------------------------------------------------------
-[643] Applies to: npm:yargs@15.4.1, npm:yargs@17.7.3
+[670] Applies to: npm:yargs@15.4.1, npm:yargs@17.7.3
 ------------------------------------------------------------------------------
 MIT License
 
@@ -45894,7 +46872,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[644] Applies to: npm:zod@4.3.6
+[671] Applies to: npm:zod@4.3.6
 ------------------------------------------------------------------------------
 MIT License
 
@@ -45919,7 +46897,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
 ------------------------------------------------------------------------------
-[645] Applies to: npm:zod-to-json-schema@3.25.2
+[672] Applies to: npm:zod-to-json-schema@3.25.2
 ------------------------------------------------------------------------------
 ISC License
 
@@ -45959,7 +46937,7 @@ Packages without a standalone license file (license per package.json):
 - npm:@chinese-fonts/font-contours@1.0.0 (ISC)
 - npm:@expo/devcert@1.2.1 (MIT)
 - npm:@expo/sdk-runtime-versions@1.0.0 (MIT)
-- npm:@expo/ui@56.0.22 (MIT)
+- npm:@expo/ui@57.0.14 (MIT)
 - npm:@expo/ws-tunnel@2.0.0 (MIT)
 - npm:@expo/xcpretty@4.4.4 (BSD-3-Clause)
 - npm:@googleapis/calendar@15.0.0 (Apache-2.0)
@@ -45988,18 +46966,18 @@ Packages without a standalone license file (license per package.json):
 - npm:@napi-rs/woff-build-linux-x64-gnu@0.2.2 (MIT)
 - npm:@napi-rs/woff-build-win32-arm64-msvc@0.2.2 (MIT)
 - npm:@napi-rs/woff-build-win32-x64-msvc@0.2.2 (MIT)
-- npm:@react-native/assets-registry@0.85.3 (MIT)
-- npm:@react-native/babel-plugin-codegen@0.85.3 (MIT)
-- npm:@react-native/codegen@0.85.3 (MIT)
-- npm:@react-native/community-cli-plugin@0.85.3 (MIT)
-- npm:@react-native/debugger-frontend@0.85.3 (BSD-3-Clause)
-- npm:@react-native/debugger-shell@0.85.3 (MIT)
-- npm:@react-native/dev-middleware@0.85.3 (MIT)
-- npm:@react-native/gradle-plugin@0.85.3 (MIT)
-- npm:@react-native/js-polyfills@0.85.3 (MIT)
+- npm:@react-native/assets-registry@0.86.3 (MIT)
+- npm:@react-native/babel-plugin-codegen@0.86.3 (MIT)
+- npm:@react-native/codegen@0.86.3 (MIT)
+- npm:@react-native/community-cli-plugin@0.86.3 (MIT)
+- npm:@react-native/debugger-frontend@0.86.3 (BSD-3-Clause)
+- npm:@react-native/debugger-shell@0.86.3 (MIT)
+- npm:@react-native/dev-middleware@0.86.3 (MIT)
+- npm:@react-native/gradle-plugin@0.86.3 (MIT)
+- npm:@react-native/js-polyfills@0.86.3 (MIT)
 - npm:@react-native/normalize-colors@0.74.89 (MIT)
-- npm:@react-native/normalize-colors@0.85.3 (MIT)
-- npm:@react-native/virtualized-lists@0.85.3 (MIT)
+- npm:@react-native/normalize-colors@0.86.3 (MIT)
+- npm:@react-native/virtualized-lists@0.86.3 (MIT)
 - npm:@sapphire/async-queue@1.5.5 (MIT)
 - npm:@sapphire/snowflake@3.5.5 (MIT)
 - npm:@simple-git/args-pathspec@1.0.3 (MIT)
@@ -46008,44 +46986,64 @@ Packages without a standalone license file (license per package.json):
 - npm:agent-base@6.0.2 (MIT)
 - npm:babel-plugin-react-compiler@1.0.0 (MIT)
 - npm:badgin@1.2.3 (MIT)
+- npm:binary@0.3.0 (MIT)
 - npm:boolbase@1.0.0 (ISC)
 - npm:bplist-parser@0.3.1 (MIT)
 - npm:bplist-parser@0.3.2 (MIT)
 - npm:bser@2.1.1 (Apache-2.0)
+- npm:buffers@0.1.1 (MIT)
+- npm:chainsaw@0.1.0 (MIT)
 - npm:client-only@0.0.1 (MIT)
 - npm:data-uri-to-buffer@4.0.1 (MIT)
 - npm:drizzle-orm@0.45.2 (Apache-2.0)
 - npm:eastasianwidth@0.2.0 (MIT)
-- npm:expo-json-utils@56.0.0 (MIT)
-- npm:expo-router@56.2.15 (MIT)
-- npm:expo-structured-headers@56.0.0 (MIT)
-- npm:expo-updates@56.0.22 (MIT)
+- npm:expo-router@57.0.17 (MIT)
+- npm:expo-structured-headers@57.0.0 (MIT)
+- npm:expo-updates@57.0.18 (MIT)
 - npm:fb-dotslash@0.5.8 ((MIT OR Apache-2.0))
 - npm:fb-watchman@2.0.2 (Apache-2.0)
-- npm:hermes-compiler@250829098.0.10 (MIT)
+- npm:hash.js@1.1.7 (MIT)
+- npm:hermes-compiler@250829098.0.17 (MIT)
 - npm:html-parse-stringify@3.0.1 (MIT)
+- npm:https@1.0.0 (ISC)
 - npm:https-proxy-agent@5.0.1 (MIT)
 - npm:isarray@1.0.0 (MIT)
 - npm:jimp-compact@0.16.1 (MIT)
 - npm:metro@0.84.4 (MIT)
+- npm:metro@0.84.5 (MIT)
 - npm:metro-babel-transformer@0.84.4 (MIT)
+- npm:metro-babel-transformer@0.84.5 (MIT)
 - npm:metro-cache@0.84.4 (MIT)
+- npm:metro-cache@0.84.5 (MIT)
 - npm:metro-cache-key@0.84.4 (MIT)
+- npm:metro-cache-key@0.84.5 (MIT)
 - npm:metro-config@0.84.4 (MIT)
+- npm:metro-config@0.84.5 (MIT)
 - npm:metro-core@0.84.4 (MIT)
+- npm:metro-core@0.84.5 (MIT)
 - npm:metro-file-map@0.84.4 (MIT)
+- npm:metro-file-map@0.84.5 (MIT)
 - npm:metro-minify-terser@0.84.4 (MIT)
+- npm:metro-minify-terser@0.84.5 (MIT)
 - npm:metro-resolver@0.84.4 (MIT)
+- npm:metro-resolver@0.84.5 (MIT)
 - npm:metro-runtime@0.84.4 (MIT)
+- npm:metro-runtime@0.84.5 (MIT)
 - npm:metro-source-map@0.84.4 (MIT)
+- npm:metro-source-map@0.84.5 (MIT)
 - npm:metro-symbolicate@0.84.4 (MIT)
+- npm:metro-symbolicate@0.84.5 (MIT)
 - npm:metro-transform-plugins@0.84.4 (MIT)
+- npm:metro-transform-plugins@0.84.5 (MIT)
 - npm:metro-transform-worker@0.84.4 (MIT)
+- npm:metro-transform-worker@0.84.5 (MIT)
 - npm:ob1@0.84.4 (MIT)
+- npm:ob1@0.84.5 (MIT)
 - npm:react-devtools-core@6.1.5 (MIT)
 - npm:react-remove-scroll-bar@2.3.8 (MIT)
 - npm:rehype-katex@7.0.1 (MIT)
 - npm:remark-math@6.0.0 (MIT)
+- npm:saxes@5.0.1 (ISC)
 - npm:server-only@0.0.1 (MIT)
 - npm:simple-git@3.36.0 (MIT)
 - npm:standard-navigation@0.0.5 (MIT)

--- a/docs/legal/notices/THIRD-PARTY-RESTRICTED.txt
+++ b/docs/legal/notices/THIRD-PARTY-RESTRICTED.txt
@@ -7,7 +7,7 @@ Cindy project distributions
 This file separately discloses components not distributed under open-source licenses.
 
 ------------------------------------------------------------------------------
-Claude Code CLI@2.1.219
+Claude Code CLI@2.1.259
 Category: proprietary
 License: LicenseRef-Anthropic-Commercial-Terms
 Source: https://www.anthropic.com/legal/commercial-terms

--- a/docs/legal/notices/desktop-linux-restricted.txt
+++ b/docs/legal/notices/desktop-linux-restricted.txt
@@ -7,7 +7,7 @@ Cindy desktop application — Linux x64/arm64 glibc
 This file separately discloses components not distributed under open-source licenses.
 
 ------------------------------------------------------------------------------
-Claude Code CLI@2.1.219
+Claude Code CLI@2.1.259
 Category: proprietary
 License: LicenseRef-Anthropic-Commercial-Terms
 Source: https://www.anthropic.com/legal/commercial-terms

--- a/docs/legal/notices/desktop-linux.txt
+++ b/docs/legal/notices/desktop-linux.txt
@@ -259,7 +259,7 @@ Apache License
 Copyright (c) OpenAI
 
 ------------------------------------------------------------------------------
-pi coding agent (runtime-downloaded binary) 0.83.0
+pi coding agent (runtime-downloaded binary) 0.84.4
 License: MIT
 Source: https://github.com/earendil-works/pi
 ------------------------------------------------------------------------------
@@ -1080,12 +1080,16 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 
 ==============================================================================
-SECTION 2: npm packages (794 packages)
+SECTION 2: npm packages (865 packages)
 ==============================================================================
 
 - @antfu/install-pkg@1.1.0 — MIT — https://github.com/antfu/install-pkg
 - @anthropic-ai/sdk@0.91.1 — MIT — https://github.com/anthropics/anthropic-sdk-typescript
+- @babel/helper-string-parser@7.29.7 — MIT — https://github.com/babel/babel
+- @babel/helper-validator-identifier@7.29.7 — MIT — https://github.com/babel/babel
+- @babel/parser@7.29.7 — MIT — https://github.com/babel/babel
 - @babel/runtime@7.29.7 — MIT — https://github.com/babel/babel
+- @babel/types@7.29.7 — MIT — https://github.com/babel/babel
 - @braintree/sanitize-url@7.1.2 — MIT — https://github.com/braintree/sanitize-url
 - @chevrotain/types@11.1.2 — Apache-2.0 — https://github.com/Chevrotain/chevrotain
 - @chinese-fonts/font-contours@1.0.0 — ISC
@@ -1118,6 +1122,8 @@ SECTION 2: npm packages (794 packages)
 - @discordjs/rest@2.6.2 — Apache-2.0 — https://github.com/discordjs/discord.js
 - @discordjs/util@1.2.0 — Apache-2.0 — https://github.com/discordjs/discord.js
 - @discordjs/ws@1.2.3 — Apache-2.0 — https://github.com/discordjs/discord.js
+- @fast-csv/format@4.3.5 — MIT — https://github.com/C2FO/fast-csv
+- @fast-csv/parse@4.3.6 — MIT — https://github.com/C2FO/fast-csv
 - @floating-ui/core@1.8.0 — MIT — https://github.com/floating-ui/floating-ui
 - @floating-ui/dom@1.8.0 — MIT — https://github.com/floating-ui/floating-ui
 - @floating-ui/react-dom@2.1.9 — MIT — https://github.com/floating-ui/floating-ui
@@ -1280,6 +1286,8 @@ SECTION 2: npm packages (794 packages)
 - @types/katex@0.16.8 — MIT — https://github.com/DefinitelyTyped/DefinitelyTyped
 - @types/mdast@4.0.4 — MIT — https://github.com/DefinitelyTyped/DefinitelyTyped
 - @types/ms@2.1.0 — MIT — https://github.com/DefinitelyTyped/DefinitelyTyped
+- @types/node@14.18.63 — MIT — https://github.com/DefinitelyTyped/DefinitelyTyped
+- @types/node@22.20.1 — MIT — https://github.com/DefinitelyTyped/DefinitelyTyped
 - @types/node@25.9.5 — MIT — https://github.com/DefinitelyTyped/DefinitelyTyped
 - @types/trusted-types@2.0.7 — MIT — https://github.com/DefinitelyTyped/DefinitelyTyped
 - @types/unist@2.0.11 — MIT — https://github.com/DefinitelyTyped/DefinitelyTyped
@@ -1305,10 +1313,14 @@ SECTION 2: npm packages (794 packages)
 - ansi-regex@6.2.2 — MIT — https://github.com/chalk/ansi-regex
 - ansi-styles@4.3.0 — MIT — https://github.com/chalk/ansi-styles
 - ansi-styles@6.2.3 — MIT — https://github.com/chalk/ansi-styles
+- archiver@5.3.2 — MIT — https://github.com/archiverjs/node-archiver
+- archiver-utils@2.1.0 — MIT — https://github.com/archiverjs/archiver-utils
+- archiver-utils@3.0.4 — MIT — https://github.com/archiverjs/archiver-utils
 - argparse@1.0.10 — MIT — https://github.com/nodeca/argparse
 - argparse@2.0.1 — Python-2.0 — https://github.com/nodeca/argparse
 - aria-hidden@1.2.6 — MIT — https://github.com/theKashey/aria-hidden
 - asn1@0.2.6 — MIT — https://github.com/joyent/node-asn1
+- async@3.2.6 — MIT — https://github.com/caolan/async
 - asynckit@0.4.0 — MIT — https://github.com/alexindigo/asynckit
 - atomically@1.7.0 — MIT — https://github.com/fabiospampinato/atomically
 - axios@1.18.1 — MIT — https://github.com/axios/axios
@@ -1317,13 +1329,20 @@ SECTION 2: npm packages (794 packages)
 - base64-js@1.5.1 — MIT — https://github.com/beatgammit/base64-js
 - bcrypt-pbkdf@1.0.2 — BSD-3-Clause — https://github.com/joyent/node-bcrypt-pbkdf
 - better-sqlite3@12.11.1 — MIT — https://github.com/WiseLibs/better-sqlite3
+- big-integer@1.6.52 — Unlicense — https://github.com/peterolson/BigInteger.js
 - bignumber.js@9.3.1 — MIT — https://github.com/MikeMcl/bignumber.js
+- binary@0.3.0 — MIT — http://github.com/substack/node-binary
 - bindings@1.5.0 — MIT — https://github.com/TooTallNate/node-bindings
 - bl@4.1.0 — MIT — https://github.com/rvagg/bl
+- bluebird@3.4.7 — MIT — https://github.com/petkaantonov/bluebird
 - body-parser@2.3.0 — MIT — https://github.com/expressjs/body-parser
+- brace-expansion@1.1.16 — MIT — https://github.com/juliangruber/brace-expansion
 - brace-expansion@2.1.2 — MIT — https://github.com/juliangruber/brace-expansion
 - buffer@5.7.1 — MIT — https://github.com/feross/buffer
+- buffer-crc32@0.2.13 — MIT — https://github.com/brianloveswords/buffer-crc32
 - buffer-equal-constant-time@1.0.1 — BSD-3-Clause — https://github.com/goinstant/buffer-equal-constant-time
+- buffer-indexof-polyfill@1.0.2 — MIT — https://github.com/sarosia/buffer-indexof-polyfill
+- buffers@0.1.1 — MIT — http://github.com/substack/node-buffers
 - buildcheck@0.0.7 — MIT — http://github.com/mscdex/buildcheck
 - byte-size@8.2.1 — MIT — https://github.com/75lb/byte-size
 - bytes@3.1.2 — MIT — https://github.com/visionmedia/bytes.js
@@ -1331,6 +1350,7 @@ SECTION 2: npm packages (794 packages)
 - call-bound@1.0.4 — MIT — https://github.com/ljharb/call-bound
 - camelcase@5.3.1 — MIT — https://github.com/sindresorhus/camelcase
 - ccount@2.0.1 — MIT — https://github.com/wooorm/ccount
+- chainsaw@0.1.0 — MIT — http://github.com/substack/node-chainsaw
 - character-entities@2.0.2 — MIT — https://github.com/wooorm/character-entities
 - character-entities-html4@2.1.0 — MIT — https://github.com/wooorm/character-entities-html4
 - character-entities-legacy@3.0.0 — MIT — https://github.com/wooorm/character-entities-legacy
@@ -1347,6 +1367,8 @@ SECTION 2: npm packages (794 packages)
 - comma-separated-tokens@2.0.3 — MIT — https://github.com/wooorm/comma-separated-tokens
 - commander@7.2.0 — MIT — https://github.com/tj/commander.js
 - commander@8.3.0 — MIT — https://github.com/tj/commander.js
+- compress-commons@4.1.2 — MIT — https://github.com/archiverjs/node-compress-commons
+- concat-map@0.0.1 — MIT — https://github.com/substack/node-concat-map
 - conf@9.0.2 — MIT — https://github.com/sindresorhus/conf
 - content-disposition@1.1.0 — MIT — https://github.com/jshttp/content-disposition
 - content-type@1.0.5 — MIT — https://github.com/jshttp/content-type
@@ -1359,6 +1381,8 @@ SECTION 2: npm packages (794 packages)
 - cose-base@1.0.3 — MIT — https://github.com/iVis-at-Bilkent/cose-base
 - cose-base@2.2.0 — MIT — https://github.com/iVis-at-Bilkent/cose-base
 - cpu-features@0.0.10 — MIT — https://github.com/mscdex/cpu-features
+- crc-32@1.2.2 — Apache-2.0 — https://github.com/SheetJS/js-crc32
+- crc32-stream@4.0.3 — MIT — https://github.com/archiverjs/node-crc32-stream
 - crelt@1.0.7 — MIT — https://code.haverbeke.berlin/marijn/crelt
 - cross-spawn@7.0.6 — MIT — https://github.com/moxystudio/node-cross-spawn
 - crypt@0.0.2 — BSD-3-Clause — https://github.com/pvorb/node-crypt
@@ -1423,10 +1447,12 @@ SECTION 2: npm packages (794 packages)
 - dingtalk-stream@v2.1.5 — MIT — https://github.com/open-dingtalk/dingtalk-stream-sdk-nodejs
 - discord-api-types@0.38.50 — MIT — https://github.com/discordjs/discord-api-types
 - discord.js@14.27.0 — Apache-2.0 — https://github.com/discordjs/discord.js
+- docx@9.7.1 — MIT — https://github.com/dolanmiu/docx
 - dompurify@3.4.12 — (MPL-2.0 OR Apache-2.0) — https://github.com/cure53/DOMPurify
 - dot-prop@6.0.1 — MIT — https://github.com/sindresorhus/dot-prop
 - drizzle-orm@0.45.2 — Apache-2.0 — https://github.com/drizzle-team/drizzle-orm
 - dunder-proto@1.0.1 — MIT — https://github.com/es-shims/dunder-proto
+- duplexer2@0.1.4 — BSD-3-Clause — https://github.com/deoxxa/duplexer2
 - eastasianwidth@0.2.0 — MIT — https://github.com/komagata/eastasianwidth
 - ecdsa-sig-formatter@1.0.11 — Apache-2.0 — https://github.com/Brightspace/node-ecdsa-sig-formatter
 - ee-first@1.1.1 — MIT — https://github.com/jonathanong/ee-first
@@ -1452,6 +1478,7 @@ SECTION 2: npm packages (794 packages)
 - eventemitter3@5.0.4 — MIT — https://github.com/primus/eventemitter3
 - eventsource@3.0.7 — MIT — https://git@github.com/EventSource/eventsource
 - eventsource-parser@3.1.0 — MIT — https://github.com/rexxars/eventsource-parser
+- exceljs@4.4.0 — MIT — https://github.com/exceljs/exceljs
 - execa@4.1.0 — MIT — https://github.com/sindresorhus/execa
 - execa@5.1.1 — MIT — https://github.com/sindresorhus/execa
 - expand-template@2.0.3 — (MIT OR WTFPL) — https://github.com/ralphtheninja/expand-template
@@ -1459,6 +1486,7 @@ SECTION 2: npm packages (794 packages)
 - express-rate-limit@8.5.2 — MIT — https://github.com/express-rate-limit/express-rate-limit
 - extend@3.0.2 — MIT — https://github.com/justmoon/node-extend
 - extend-shallow@2.0.1 — MIT — https://github.com/jonschlinkert/extend-shallow
+- fast-csv@4.3.6 — MIT — https://github.com/C2FO/fast-csv
 - fast-deep-equal@3.1.3 — MIT — https://github.com/epoberezkin/fast-deep-equal
 - fast-equals@5.4.1 — MIT — https://github.com/planttheidea/fast-equals
 - fast-uri@3.1.4 — BSD-3-Clause — https://github.com/fastify/fast-uri
@@ -1476,6 +1504,8 @@ SECTION 2: npm packages (794 packages)
 - fresh@2.0.0 — MIT — https://github.com/jshttp/fresh
 - fs-constants@1.0.0 — MIT — https://github.com/mafintosh/fs-constants
 - fs-extra@11.3.6 — MIT — https://github.com/jprichardson/node-fs-extra
+- fs.realpath@1.0.0 — ISC — https://github.com/isaacs/fs.realpath
+- fstream@1.0.12 — ISC — https://github.com/npm/fstream
 - function-bind@1.1.2 — MIT — https://github.com/Raynos/function-bind
 - gaxios@7.1.3 — Apache-2.0 — https://github.com/googleapis/google-cloud-node-core
 - gaxios@7.2.0 — Apache-2.0 — https://github.com/googleapis/google-cloud-node
@@ -1491,6 +1521,7 @@ SECTION 2: npm packages (794 packages)
 - github-from-package@0.0.0 — MIT — https://github.com/substack/github-from-package
 - github-slugger@2.0.0 — ISC — https://github.com/Flet/github-slugger
 - glob@10.5.0 — ISC — https://github.com/isaacs/node-glob
+- glob@7.2.3 — ISC — https://github.com/isaacs/node-glob
 - google-auth-library@10.5.0 — Apache-2.0 — https://github.com/googleapis/google-auth-library-nodejs
 - google-auth-library@10.9.0 — Apache-2.0 — https://github.com/googleapis/google-cloud-node
 - google-logging-utils@1.1.3 — Apache-2.0 — https://github.com/googleapis/google-cloud-node-core
@@ -1503,6 +1534,7 @@ SECTION 2: npm packages (794 packages)
 - harmonyos-sans-sc-webfont-splitted@1.1.0 — Unlicense — https://github.com/SunsetMkt/HarmonyOS_Sans_SC_Webfont_Splitted
 - has-symbols@1.1.0 — MIT — https://github.com/inspect-js/has-symbols
 - has-tostringtag@1.0.2 — MIT — https://github.com/inspect-js/has-tostringtag
+- hash.js@1.1.7 — MIT — https://github.com/indutny/hash.js
 - hasown@2.0.4 — MIT — https://github.com/inspect-js/hasOwn
 - hast-util-from-dom@5.0.1 — ISC — https://github.com/syntax-tree/hast-util-from-dom
 - hast-util-from-html@2.0.3 — MIT — https://github.com/syntax-tree/hast-util-from-html
@@ -1522,6 +1554,7 @@ SECTION 2: npm packages (794 packages)
 - html-to-image@1.11.13 — MIT — https://github.com/bubkoo/html-to-image
 - html-url-attributes@3.0.1 — MIT — https://github.com/rehypejs/rehype-minify/tree/main/packages/html-url-attributes
 - http-errors@2.0.1 — MIT — https://github.com/jshttp/http-errors
+- https@1.0.0 — ISC
 - https-proxy-agent@5.0.1 — MIT — https://github.com/TooTallNate/node-https-proxy-agent
 - https-proxy-agent@7.0.6 — MIT — https://github.com/TooTallNate/proxy-agents
 - human-signals@1.1.1 — Apache-2.0 — https://github.com/ehmicky/human-signals
@@ -1531,8 +1564,10 @@ SECTION 2: npm packages (794 packages)
 - iconv-lite@0.7.3 — MIT — https://github.com/pillarjs/iconv-lite
 - ieee754@1.2.1 — BSD-3-Clause — https://github.com/feross/ieee754
 - ignore@7.0.6 — MIT — https://github.com/kaelzhang/node-ignore
+- image-size@1.2.1 — MIT — https://github.com/image-size/image-size
 - immediate@3.0.6 — MIT — https://github.com/calvinmetcalf/immediate
 - import-meta-resolve@4.2.0 — MIT — https://github.com/wooorm/import-meta-resolve
+- inflight@1.0.6 — ISC — https://github.com/npm/inflight
 - inherits@2.0.4 — ISC — https://github.com/isaacs/inherits
 - ini@1.3.8 — ISC — https://github.com/isaacs/ini
 - inline-style-parser@0.2.7 — MIT — https://github.com/remarkablemark/inline-style-parser
@@ -1578,8 +1613,10 @@ SECTION 2: npm packages (794 packages)
 - kind-of@6.0.3 — MIT — https://github.com/jonschlinkert/kind-of
 - layout-base@1.0.2 — MIT — https://github.com/iVis-at-Bilkent/layout-base
 - layout-base@2.0.1 — MIT — https://github.com/iVis-at-Bilkent/layout-base
+- lazystream@1.0.1 — MIT — https://github.com/jpommerening/node-lazystream
 - lcid@3.1.1 — MIT — https://github.com/sindresorhus/lcid
 - lie@3.3.0 — MIT — https://github.com/calvinmetcalf/lie
+- listenercount@1.0.1 — ISC — https://github.com/jden/node-listenercount
 - lit@3.3.3 — BSD-3-Clause — https://github.com/lit/lit
 - lit-element@4.2.2 — BSD-3-Clause — https://github.com/lit/lit
 - lit-html@3.3.3 — BSD-3-Clause — https://github.com/lit/lit
@@ -1587,10 +1624,23 @@ SECTION 2: npm packages (794 packages)
 - locate-path@5.0.0 — MIT — https://github.com/sindresorhus/locate-path
 - lodash@4.18.1 — MIT — https://github.com/lodash/lodash
 - lodash-es@4.18.1 — MIT — https://github.com/lodash/lodash
+- lodash.defaults@4.2.0 — MIT — https://github.com/lodash/lodash
+- lodash.difference@4.5.0 — MIT — https://github.com/lodash/lodash
+- lodash.escaperegexp@4.1.2 — MIT — https://github.com/lodash/lodash
+- lodash.flatten@4.4.0 — MIT — https://github.com/lodash/lodash
+- lodash.groupby@4.6.0 — MIT — https://github.com/lodash/lodash
 - lodash.identity@3.0.0 — MIT — https://github.com/lodash/lodash
+- lodash.isboolean@3.0.3 — MIT — https://github.com/lodash/lodash
+- lodash.isequal@4.5.0 — MIT — https://github.com/lodash/lodash
+- lodash.isfunction@3.0.9 — MIT — https://github.com/lodash/lodash
+- lodash.isnil@4.0.0 — MIT — https://github.com/lodash/lodash
+- lodash.isplainobject@4.0.6 — MIT — https://github.com/lodash/lodash
+- lodash.isundefined@3.0.1 — MIT — https://github.com/lodash/lodash
 - lodash.merge@4.6.2 — MIT — https://github.com/lodash/lodash
 - lodash.pickby@4.6.0 — MIT — https://github.com/lodash/lodash
 - lodash.snakecase@4.1.1 — MIT — https://github.com/lodash/lodash
+- lodash.union@4.6.0 — MIT — https://github.com/lodash/lodash
+- lodash.uniq@4.5.0 — MIT — https://github.com/lodash/lodash
 - long@5.3.2 — Apache-2.0 — https://github.com/dcodeIO/long.js
 - longest-streak@3.1.0 — MIT — https://github.com/wooorm/longest-streak
 - loudness@0.4.2 — MIT — https://github.com/LinusU/node-loudness
@@ -1662,6 +1712,9 @@ SECTION 2: npm packages (794 packages)
 - mimic-fn@2.1.0 — MIT — https://github.com/sindresorhus/mimic-fn
 - mimic-fn@3.1.0 — MIT — https://github.com/sindresorhus/mimic-fn
 - mimic-response@3.1.0 — MIT — https://github.com/sindresorhus/mimic-response
+- minimalistic-assert@1.0.1 — ISC — https://github.com/calvinmetcalf/minimalistic-assert
+- minimatch@3.1.5 — ISC — https://github.com/isaacs/minimatch
+- minimatch@5.1.9 — ISC — https://github.com/isaacs/minimatch
 - minimatch@9.0.9 — ISC — https://github.com/isaacs/minimatch
 - minimist@1.2.8 — MIT — https://github.com/minimistjs/minimist
 - minipass@7.1.3 — BlueOak-1.0.0 — https://github.com/isaacs/minipass
@@ -1672,6 +1725,7 @@ SECTION 2: npm packages (794 packages)
 - ms@2.0.0 — MIT — https://github.com/zeit/ms
 - ms@2.1.3 — MIT — https://github.com/vercel/ms
 - nan@2.28.0 — MIT — https://github.com/nodejs/nan
+- nanoid@5.1.16 — MIT — https://github.com/ai/nanoid
 - napi-build-utils@2.0.0 — MIT — https://github.com/inspiredware/napi-build-utils
 - negotiator@1.0.0 — MIT — https://github.com/jshttp/negotiator
 - node-abi@3.94.0 — MIT — https://github.com/electron/node-abi
@@ -1680,6 +1734,7 @@ SECTION 2: npm packages (794 packages)
 - node-fetch@3.3.2 — MIT — https://github.com/node-fetch/node-fetch
 - node-machine-id@1.1.12 — MIT — https://github.com/automation-stack/node-machine-id
 - node-pty@1.1.0 — MIT — https://github.com/microsoft/node-pty
+- normalize-path@3.0.0 — MIT — https://github.com/jonschlinkert/normalize-path
 - npm-run-path@4.0.1 — MIT — https://github.com/sindresorhus/npm-run-path
 - object-assign@4.1.1 — MIT — https://github.com/sindresorhus/object-assign
 - object-inspect@1.13.4 — MIT — https://github.com/inspect-js/object-inspect
@@ -1701,6 +1756,7 @@ SECTION 2: npm packages (794 packages)
 - path-data-parser@0.1.0 — MIT — https://github.com/pshihn/path-data-parser
 - path-exists@3.0.0 — MIT — https://github.com/sindresorhus/path-exists
 - path-exists@4.0.0 — MIT — https://github.com/sindresorhus/path-exists
+- path-is-absolute@1.0.1 — MIT — https://github.com/sindresorhus/path-is-absolute
 - path-key@3.1.1 — MIT — https://github.com/sindresorhus/path-key
 - path-scurry@1.11.1 — BlueOak-1.0.0 — https://github.com/isaacs/path-scurry
 - path-to-regexp@8.4.2 — MIT — https://github.com/pillarjs/path-to-regexp
@@ -1712,6 +1768,7 @@ SECTION 2: npm packages (794 packages)
 - pngjs@5.0.0 — MIT — https://github.com/lukeapage/pngjs
 - points-on-curve@0.2.0 — MIT — https://github.com/pshihn/bezier-points
 - points-on-path@0.2.1 — MIT — https://github.com/pshihn/points-on-path
+- pptxgenjs@4.0.1 — MIT — https://github.com/gitbrent/PptxGenJS
 - prebuild-install@7.1.3 — MIT — https://github.com/prebuild/prebuild-install
 - process-nextick-args@2.0.1 — MIT — https://github.com/calvinmetcalf/process-nextick-args
 - promise-worker-transferable@1.0.4 — Apache-2.0 — https://github.com/terikon/promise-worker-transferable
@@ -1736,6 +1793,7 @@ SECTION 2: npm packages (794 packages)
 - punycode@2.3.1 — MIT — https://github.com/mathiasbynens/punycode.js
 - qrcode@1.5.4 — MIT — https://github.com/soldair/node-qrcode
 - qs@6.15.3 — BSD-3-Clause — https://github.com/ljharb/qs
+- queue@6.0.2 — MIT — https://github.com/jessetane/queue
 - range-parser@1.3.0 — MIT — https://github.com/jshttp/range-parser
 - raw-body@3.0.2 — MIT — https://github.com/stream-utils/raw-body
 - rc@1.2.8 — (BSD-2-Clause OR MIT OR Apache-2.0) — https://github.com/dominictarr/rc
@@ -1750,6 +1808,7 @@ SECTION 2: npm packages (794 packages)
 - react-style-singleton@2.2.3 — MIT — https://github.com/theKashey/react-style-singleton
 - readable-stream@2.3.8 — MIT — https://github.com/nodejs/readable-stream
 - readable-stream@3.6.2 — MIT — https://github.com/nodejs/readable-stream
+- readdir-glob@1.1.3 — Apache-2.0 — https://github.com/Yqnn/node-readdir-glob
 - rehype-highlight@7.0.2 — MIT — https://github.com/rehypejs/rehype-highlight
 - rehype-katex@7.0.1 — MIT — https://github.com/remarkjs/remark-math/tree/main/packages/rehype-katex
 - rehype-slug@6.0.0 — MIT — https://github.com/rehypejs/rehype-slug
@@ -1762,6 +1821,7 @@ SECTION 2: npm packages (794 packages)
 - require-directory@2.1.1 — MIT — https://github.com/troygoode/node-require-directory
 - require-from-string@2.0.2 — MIT — https://github.com/floatdrop/require-from-string
 - require-main-filename@2.0.0 — ISC — https://github.com/yargs/require-main-filename
+- rimraf@2.6.3 — ISC — https://github.com/isaacs/rimraf
 - rimraf@5.0.10 — ISC — https://github.com/isaacs/rimraf
 - robust-predicates@3.0.3 — Unlicense — https://github.com/mourner/robust-predicates
 - rope-sequence@1.3.4 — MIT — https://github.com/marijnh/rope-sequence
@@ -1771,6 +1831,8 @@ SECTION 2: npm packages (794 packages)
 - safe-buffer@5.1.2 — MIT — https://github.com/feross/safe-buffer
 - safe-buffer@5.2.1 — MIT — https://github.com/feross/safe-buffer
 - safer-buffer@2.1.2 — MIT — https://github.com/ChALkeR/safer-buffer
+- sax@1.6.0 — BlueOak-1.0.0 — https://github.com/isaacs/sax-js
+- saxes@5.0.1 — ISC — https://github.com/lddubeau/saxes
 - scheduler@0.27.0 — MIT — https://github.com/facebook/react
 - section-matter@1.0.0 — MIT — https://github.com/jonschlinkert/section-matter
 - semver@6.3.1 — ISC — https://github.com/npm/node-semver
@@ -1821,7 +1883,9 @@ SECTION 2: npm packages (794 packages)
 - tar-fs@2.1.5 — MIT — https://github.com/mafintosh/tar-fs
 - tar-stream@2.2.0 — MIT — https://github.com/mafintosh/tar-stream
 - tinyexec@1.2.4 — MIT — https://github.com/tinylibs/tinyexec
+- tmp@0.2.7 — MIT — https://github.com/raszi/node-tmp
 - toidentifier@1.0.1 — MIT — https://github.com/component/toidentifier
+- traverse@0.3.9 — MIT — http://github.com/substack/js-traverse
 - trim-lines@3.0.1 — MIT — https://github.com/wooorm/trim-lines
 - trough@2.2.0 — MIT — https://github.com/wooorm/trough
 - ts-algebra@2.0.0 — MIT — https://github.com/ThomasAribart/ts-algebra
@@ -1836,6 +1900,7 @@ SECTION 2: npm packages (794 packages)
 - typebox@1.1.39 — MIT — https://github.com/sinclairzx81/typebox
 - undici@6.27.0 — MIT — https://github.com/nodejs/undici
 - undici@8.7.0 — MIT — https://github.com/nodejs/undici
+- undici-types@6.21.0 — MIT — https://github.com/nodejs/undici
 - undici-types@7.24.6 — MIT — https://github.com/nodejs/undici
 - unified@11.0.5 — MIT — https://github.com/unifiedjs/unified
 - unist-util-find-after@5.0.0 — MIT — https://github.com/syntax-tree/unist-util-find-after
@@ -1847,6 +1912,7 @@ SECTION 2: npm packages (794 packages)
 - unist-util-visit-parents@6.0.2 — MIT — https://github.com/syntax-tree/unist-util-visit-parents
 - universalify@2.0.1 — MIT — https://github.com/RyanZim/universalify
 - unpipe@1.0.0 — MIT — https://github.com/stream-utils/unpipe
+- unzipper@0.10.14 — MIT — https://github.com/ZJONSSON/node-unzipper
 - uri-js@4.4.1 — BSD-2-Clause — http://github.com/garycourt/uri-js
 - url-template@2.0.8 — LicenseRef-BSD-Variant — https://github.com/bramstein/url-template
 - use-callback-ref@1.3.3 — MIT — https://github.com/theKashey/use-callback-ref/
@@ -1854,6 +1920,7 @@ SECTION 2: npm packages (794 packages)
 - use-sync-external-store@1.6.0 — MIT — https://github.com/facebook/react
 - util-deprecate@1.0.2 — MIT — https://github.com/TooTallNate/util-deprecate
 - uuid@14.0.1 — MIT — https://github.com/uuidjs/uuid
+- uuid@8.3.2 — MIT — https://github.com/uuidjs/uuid
 - vary@1.1.2 — MIT — https://github.com/jshttp/vary
 - vfile@6.0.3 — MIT — https://github.com/vfile/vfile
 - vfile-location@5.0.3 — MIT — https://github.com/vfile/vfile-location
@@ -1870,10 +1937,14 @@ SECTION 2: npm packages (794 packages)
 - wrap-ansi@8.1.0 — MIT — https://github.com/chalk/wrap-ansi
 - wrappy@1.0.2 — ISC — https://github.com/npm/wrappy
 - ws@8.21.1 — MIT — https://github.com/websockets/ws
+- xml@1.0.1 — MIT — http://github.com/dylang/node-xml
+- xml-js@1.6.11 — MIT — https://github.com/nashwaan/xml-js
+- xmlchars@2.2.0 — MIT — https://github.com/lddubeau/xmlchars
 - y18n@4.0.3 — ISC — https://github.com/yargs/y18n
 - yallist@5.0.0 — BlueOak-1.0.0 — https://github.com/isaacs/yallist
 - yargs@15.4.1 — MIT — https://github.com/yargs/yargs
 - yargs-parser@18.1.3 — ISC — https://github.com/yargs/yargs-parser
+- zip-stream@4.1.1 — MIT — https://github.com/archiverjs/node-zip-stream
 - zod@4.3.6 — MIT — https://github.com/colinhacks/zod
 - zod-to-json-schema@3.25.2 — ISC — https://github.com/StefanTerdell/zod-to-json-schema
 - zwitch@2.0.4 — MIT — https://github.com/wooorm/zwitch
@@ -1922,7 +1993,7 @@ The above copyright notice and this permission notice shall be included in all c
 THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[3] Applies to: npm:@babel/runtime@7.29.7
+[3] Applies to: npm:@babel/helper-string-parser@7.29.7, npm:@babel/helper-validator-identifier@7.29.7, npm:@babel/runtime@7.29.7, npm:@babel/types@7.29.7
 ------------------------------------------------------------------------------
 MIT License
 
@@ -1948,7 +2019,30 @@ OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
 WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[4] Applies to: npm:@braintree/sanitize-url@7.1.2
+[4] Applies to: npm:@babel/parser@7.29.7
+------------------------------------------------------------------------------
+Copyright (C) 2012-2014 by various contributors (see AUTHORS)
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+
+------------------------------------------------------------------------------
+[5] Applies to: npm:@braintree/sanitize-url@7.1.2
 ------------------------------------------------------------------------------
 MIT License
 
@@ -1973,7 +2067,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
 ------------------------------------------------------------------------------
-[5] Applies to: npm:@chevrotain/types@11.1.2, npm:@google/model-viewer@4.3.1, npm:@pkgjs/parseargs@0.11.0, npm:gaxios@7.1.3, npm:gaxios@7.2.0, npm:gcp-metadata@8.1.2, npm:gcp-metadata@8.1.3, npm:google-auth-library@10.5.0, npm:google-auth-library@10.9.0, npm:google-logging-utils@1.1.3, npm:googleapis-common@8.0.2, npm:long@5.3.2
+[6] Applies to: npm:@chevrotain/types@11.1.2, npm:@google/model-viewer@4.3.1, npm:@pkgjs/parseargs@0.11.0, npm:gaxios@7.1.3, npm:gaxios@7.2.0, npm:gcp-metadata@8.1.2, npm:gcp-metadata@8.1.3, npm:google-auth-library@10.5.0, npm:google-auth-library@10.9.0, npm:google-logging-utils@1.1.3, npm:googleapis-common@8.0.2, npm:long@5.3.2
 ------------------------------------------------------------------------------
 Apache License
                            Version 2.0, January 2004
@@ -2178,7 +2272,7 @@ Apache License
    limitations under the License.
 
 ------------------------------------------------------------------------------
-[6] Applies to: npm:@codemirror/autocomplete@6.20.3, npm:@codemirror/commands@6.10.4, npm:@codemirror/lang-cpp@6.0.3, npm:@codemirror/lang-css@6.3.1, npm:@codemirror/lang-html@6.4.11, npm:@codemirror/lang-java@6.0.2, npm:@codemirror/lang-javascript@6.2.5, npm:@codemirror/lang-json@6.0.2, npm:@codemirror/lang-markdown@6.5.1, npm:@codemirror/lang-php@6.0.2, npm:@codemirror/lang-python@6.2.1, npm:@codemirror/lang-rust@6.0.2, npm:@codemirror/lang-sql@6.10.0, npm:@codemirror/lang-xml@6.1.0, npm:@codemirror/language@6.12.4, npm:@codemirror/legacy-modes@6.5.3, npm:@codemirror/lint@6.9.7, npm:@codemirror/search@6.7.1, npm:@codemirror/state@6.7.1, npm:@codemirror/view@6.43.6
+[7] Applies to: npm:@codemirror/autocomplete@6.20.3, npm:@codemirror/commands@6.10.4, npm:@codemirror/lang-cpp@6.0.3, npm:@codemirror/lang-css@6.3.1, npm:@codemirror/lang-html@6.4.11, npm:@codemirror/lang-java@6.0.2, npm:@codemirror/lang-javascript@6.2.5, npm:@codemirror/lang-json@6.0.2, npm:@codemirror/lang-markdown@6.5.1, npm:@codemirror/lang-php@6.0.2, npm:@codemirror/lang-python@6.2.1, npm:@codemirror/lang-rust@6.0.2, npm:@codemirror/lang-sql@6.10.0, npm:@codemirror/lang-xml@6.1.0, npm:@codemirror/language@6.12.4, npm:@codemirror/legacy-modes@6.5.3, npm:@codemirror/lint@6.9.7, npm:@codemirror/search@6.7.1, npm:@codemirror/state@6.7.1, npm:@codemirror/view@6.43.6
 ------------------------------------------------------------------------------
 MIT License
 
@@ -2203,7 +2297,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[7] Applies to: npm:@codemirror/lang-go@6.0.1, npm:@codemirror/lang-yaml@6.1.3
+[8] Applies to: npm:@codemirror/lang-go@6.0.1, npm:@codemirror/lang-yaml@6.1.3
 ------------------------------------------------------------------------------
 MIT License
 
@@ -2228,7 +2322,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[8] Applies to: npm:@discordjs/builders@1.14.1, npm:@discordjs/formatters@0.6.2
+[9] Applies to: npm:@discordjs/builders@1.14.1, npm:@discordjs/formatters@0.6.2
 ------------------------------------------------------------------------------
 Apache License
                            Version 2.0, January 2004
@@ -2423,7 +2517,7 @@ Apache License
    limitations under the License.
 
 ------------------------------------------------------------------------------
-[9] Applies to: npm:@discordjs/collection@1.5.3, npm:@discordjs/collection@2.1.1, npm:discord.js@14.27.0
+[10] Applies to: npm:@discordjs/collection@1.5.3, npm:@discordjs/collection@2.1.1, npm:discord.js@14.27.0
 ------------------------------------------------------------------------------
 Apache License
                            Version 2.0, January 2004
@@ -2618,7 +2712,7 @@ Apache License
    limitations under the License.
 
 ------------------------------------------------------------------------------
-[10] Applies to: npm:@discordjs/rest@2.6.2
+[11] Applies to: npm:@discordjs/rest@2.6.2
 ------------------------------------------------------------------------------
 Apache License
                            Version 2.0, January 2004
@@ -2814,7 +2908,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 
 ------------------------------------------------------------------------------
-[11] Applies to: npm:@discordjs/util@1.2.0
+[12] Applies to: npm:@discordjs/util@1.2.0
 ------------------------------------------------------------------------------
 Apache License
                            Version 2.0, January 2004
@@ -3008,7 +3102,7 @@ Apache License
    limitations under the License.
 
 ------------------------------------------------------------------------------
-[12] Applies to: npm:@discordjs/ws@1.2.3
+[13] Applies to: npm:@discordjs/ws@1.2.3
 ------------------------------------------------------------------------------
 Apache License
                            Version 2.0, January 2004
@@ -3203,7 +3297,32 @@ Apache License
    limitations under the License.
 
 ------------------------------------------------------------------------------
-[13] Applies to: npm:@floating-ui/core@1.8.0, npm:@floating-ui/dom@1.8.0, npm:@floating-ui/react-dom@2.1.9, npm:@floating-ui/utils@0.2.12
+[14] Applies to: npm:@fast-csv/format@4.3.5, npm:@fast-csv/parse@4.3.6, npm:fast-csv@4.3.6
+------------------------------------------------------------------------------
+The MIT License
+
+Copyright (c) 2011-2019 C2FO
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+
+------------------------------------------------------------------------------
+[15] Applies to: npm:@floating-ui/core@1.8.0, npm:@floating-ui/dom@1.8.0, npm:@floating-ui/react-dom@2.1.9, npm:@floating-ui/utils@0.2.12
 ------------------------------------------------------------------------------
 MIT License
 
@@ -3227,7 +3346,7 @@ IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
 CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[14] Applies to: npm:@fontsource-variable/inter@5.2.8
+[16] Applies to: npm:@fontsource-variable/inter@5.2.8
 ------------------------------------------------------------------------------
 Copyright 2016 The Inter Project Authors (https://github.com/rsms/inter) Inter-Italic[opsz,wght].ttf: Copyright 2016 The Inter Project Authors (https://github.com/rsms/inter)
 
@@ -3324,7 +3443,7 @@ FROM, OUT OF THE USE OR INABILITY TO USE THE FONT SOFTWARE OR FROM
 OTHER DEALINGS IN THE FONT SOFTWARE.
 
 ------------------------------------------------------------------------------
-[15] Applies to: npm:@fontsource-variable/jetbrains-mono@5.2.8
+[17] Applies to: npm:@fontsource-variable/jetbrains-mono@5.2.8
 ------------------------------------------------------------------------------
 Copyright 2020 The JetBrains Mono Project Authors (https://github.com/JetBrains/JetBrainsMono) JetBrainsMono-Italic[wght].ttf: Copyright 2020 The JetBrains Mono Project Authors (https://github.com/JetBrains/JetBrainsMono)
 
@@ -3421,7 +3540,7 @@ FROM, OUT OF THE USE OR INABILITY TO USE THE FONT SOFTWARE OR FROM
 OTHER DEALINGS IN THE FONT SOFTWARE.
 
 ------------------------------------------------------------------------------
-[16] Applies to: npm:@hono/node-server@1.19.14
+[18] Applies to: npm:@hono/node-server@1.19.14
 ------------------------------------------------------------------------------
 MIT License
 
@@ -3446,7 +3565,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
 ------------------------------------------------------------------------------
-[17] Applies to: npm:@iconify/types@2.0.0
+[19] Applies to: npm:@iconify/types@2.0.0
 ------------------------------------------------------------------------------
 MIT License
 
@@ -3471,7 +3590,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
 ------------------------------------------------------------------------------
-[18] Applies to: npm:@iconify/utils@3.1.4
+[20] Applies to: npm:@iconify/utils@3.1.4
 ------------------------------------------------------------------------------
 MIT License
 
@@ -3496,7 +3615,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
 ------------------------------------------------------------------------------
-[19] Applies to: npm:@img/colour@1.1.0
+[21] Applies to: npm:@img/colour@1.1.0
 ------------------------------------------------------------------------------
 # Licensing
 
@@ -3582,7 +3701,7 @@ The above copyright notice and this permission notice shall be included in all c
 THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[20] Applies to: npm:@img/sharp-linux-arm64@0.34.5, npm:@img/sharp-linux-arm64@0.35.3, npm:@img/sharp-linux-x64@0.34.5, npm:@img/sharp-linux-x64@0.35.3, npm:sharp@0.35.3
+[22] Applies to: npm:@img/sharp-linux-arm64@0.34.5, npm:@img/sharp-linux-arm64@0.35.3, npm:@img/sharp-linux-x64@0.34.5, npm:@img/sharp-linux-x64@0.35.3, npm:sharp@0.35.3
 ------------------------------------------------------------------------------
 Apache License
 Version 2.0, January 2004
@@ -3777,7 +3896,7 @@ third-party archives.
    limitations under the License.
 
 ------------------------------------------------------------------------------
-[21] Applies to: npm:@isaacs/cliui@8.0.2, npm:cliui@6.0.0
+[23] Applies to: npm:@isaacs/cliui@8.0.2, npm:cliui@6.0.0
 ------------------------------------------------------------------------------
 Copyright (c) 2015, Contributors
 
@@ -3795,7 +3914,7 @@ WHETHER IN AN ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION,
 ARISING OUT OF OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
 
 ------------------------------------------------------------------------------
-[22] Applies to: npm:@isaacs/fs-minipass@4.0.1, npm:chownr@1.1.4, npm:ini@1.3.8, npm:isexe@2.0.0, npm:once@1.4.0, npm:semver@6.3.1, npm:semver@7.8.5, npm:which@2.0.2, npm:wrappy@1.0.2
+[24] Applies to: npm:@isaacs/fs-minipass@4.0.1, npm:chownr@1.1.4, npm:fstream@1.0.12, npm:ini@1.3.8, npm:isexe@2.0.0, npm:minimatch@3.1.5, npm:once@1.4.0, npm:rimraf@2.6.3, npm:semver@6.3.1, npm:semver@7.8.5, npm:which@2.0.2, npm:wrappy@1.0.2
 ------------------------------------------------------------------------------
 The ISC License
 
@@ -3814,7 +3933,7 @@ ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF OR
 IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
 
 ------------------------------------------------------------------------------
-[23] Applies to: npm:@japont/unicode-range@1.0.0
+[25] Applies to: npm:@japont/unicode-range@1.0.0
 ------------------------------------------------------------------------------
 The MIT License (MIT)
 Copyright © 2018 3846masa
@@ -3838,7 +3957,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[24] Applies to: npm:@larksuiteoapi/node-sdk@1.71.1
+[26] Applies to: npm:@larksuiteoapi/node-sdk@1.71.1
 ------------------------------------------------------------------------------
 MIT License
 
@@ -3851,7 +3970,7 @@ The above copyright notice and this permission notice, shall be included in all 
 THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[25] Applies to: npm:@lezer/common@1.5.2, npm:@lezer/css@1.3.4, npm:@lezer/highlight@1.2.3, npm:@lezer/html@1.3.13, npm:@lezer/javascript@1.5.4, npm:@lezer/lr@1.4.10, npm:@lezer/php@1.0.5, npm:@lezer/rust@1.0.2, npm:@lezer/xml@1.0.6
+[27] Applies to: npm:@lezer/common@1.5.2, npm:@lezer/css@1.3.4, npm:@lezer/highlight@1.2.3, npm:@lezer/html@1.3.13, npm:@lezer/javascript@1.5.4, npm:@lezer/lr@1.4.10, npm:@lezer/php@1.0.5, npm:@lezer/rust@1.0.2, npm:@lezer/xml@1.0.6
 ------------------------------------------------------------------------------
 MIT License
 
@@ -3876,7 +3995,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[26] Applies to: npm:@lezer/cpp@1.1.6, npm:@lezer/go@1.0.1, npm:@lezer/java@1.1.3, npm:@lezer/markdown@1.7.2, npm:@lezer/python@1.1.19
+[28] Applies to: npm:@lezer/cpp@1.1.6, npm:@lezer/go@1.0.1, npm:@lezer/java@1.1.3, npm:@lezer/markdown@1.7.2, npm:@lezer/python@1.1.19
 ------------------------------------------------------------------------------
 MIT License
 
@@ -3901,7 +4020,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[27] Applies to: npm:@lezer/json@1.0.3
+[29] Applies to: npm:@lezer/json@1.0.3
 ------------------------------------------------------------------------------
 MIT License
 
@@ -3926,7 +4045,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[28] Applies to: npm:@lezer/yaml@1.0.4
+[30] Applies to: npm:@lezer/yaml@1.0.4
 ------------------------------------------------------------------------------
 MIT License
 
@@ -3951,7 +4070,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[29] Applies to: npm:@lit/reactive-element@2.1.2, npm:lit@3.3.3, npm:lit-element@4.2.2, npm:lit-html@3.3.3
+[31] Applies to: npm:@lit/reactive-element@2.1.2, npm:lit@3.3.3, npm:lit-element@4.2.2, npm:lit-html@3.3.3
 ------------------------------------------------------------------------------
 BSD 3-Clause License
 
@@ -3983,7 +4102,7 @@ OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 ------------------------------------------------------------------------------
-[30] Applies to: npm:@marijn/find-cluster-break@1.0.3
+[32] Applies to: npm:@marijn/find-cluster-break@1.0.3
 ------------------------------------------------------------------------------
 MIT License
 
@@ -4008,7 +4127,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[31] Applies to: npm:@mermaid-js/parser@1.2.0
+[33] Applies to: npm:@mermaid-js/parser@1.2.0
 ------------------------------------------------------------------------------
 The MIT License (MIT)
 
@@ -4033,7 +4152,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
 ------------------------------------------------------------------------------
-[32] Applies to: npm:@modelcontextprotocol/sdk@1.29.0
+[34] Applies to: npm:@modelcontextprotocol/sdk@1.29.0
 ------------------------------------------------------------------------------
 MIT License
 
@@ -4058,7 +4177,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
 ------------------------------------------------------------------------------
-[33] Applies to: npm:@monogrid/gainmap-js@3.4.0
+[35] Applies to: npm:@monogrid/gainmap-js@3.4.0
 ------------------------------------------------------------------------------
 MIT License
 
@@ -4083,7 +4202,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
 ------------------------------------------------------------------------------
-[34] Applies to: npm:@napi-rs/canvas@0.1.100
+[36] Applies to: npm:@napi-rs/canvas@0.1.100
 ------------------------------------------------------------------------------
 MIT License
 
@@ -4108,7 +4227,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
 ------------------------------------------------------------------------------
-[35] Applies to: npm:@noble/hashes@1.8.0
+[37] Applies to: npm:@noble/hashes@1.8.0
 ------------------------------------------------------------------------------
 The MIT License (MIT)
 
@@ -4133,7 +4252,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[36] Applies to: npm:@paralleldrive/cuid2@2.3.1
+[38] Applies to: npm:@paralleldrive/cuid2@2.3.1
 ------------------------------------------------------------------------------
 MIT License
 
@@ -4158,7 +4277,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
 ------------------------------------------------------------------------------
-[37] Applies to: npm:@parcel/watcher@2.5.6, npm:@parcel/watcher-linux-arm64-glibc@2.5.6, npm:@parcel/watcher-linux-x64-glibc@2.5.6
+[39] Applies to: npm:@parcel/watcher@2.5.6, npm:@parcel/watcher-linux-arm64-glibc@2.5.6, npm:@parcel/watcher-linux-x64-glibc@2.5.6
 ------------------------------------------------------------------------------
 MIT License
 
@@ -4183,7 +4302,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
 ------------------------------------------------------------------------------
-[38] Applies to: npm:@protobufjs/aspromise@1.1.2, npm:@protobufjs/base64@1.1.2, npm:@protobufjs/codegen@2.0.5, npm:@protobufjs/eventemitter@1.1.1, npm:@protobufjs/fetch@1.1.1, npm:@protobufjs/float@1.0.2, npm:@protobufjs/path@1.1.2, npm:@protobufjs/pool@1.1.0, npm:@protobufjs/utf8@1.1.2
+[40] Applies to: npm:@protobufjs/aspromise@1.1.2, npm:@protobufjs/base64@1.1.2, npm:@protobufjs/codegen@2.0.5, npm:@protobufjs/eventemitter@1.1.1, npm:@protobufjs/fetch@1.1.1, npm:@protobufjs/float@1.0.2, npm:@protobufjs/path@1.1.2, npm:@protobufjs/pool@1.1.0, npm:@protobufjs/utf8@1.1.2
 ------------------------------------------------------------------------------
 Copyright (c) 2016, Daniel Wirtz  All rights reserved.
 
@@ -4213,7 +4332,7 @@ THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
 OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 ------------------------------------------------------------------------------
-[39] Applies to: npm:@radix-ui/number@1.1.2, npm:@radix-ui/primitive@1.1.5, npm:@radix-ui/react-alert-dialog@1.1.19, npm:@radix-ui/react-arrow@1.1.11, npm:@radix-ui/react-collection@1.1.12, npm:@radix-ui/react-compose-refs@1.1.3, npm:@radix-ui/react-context@1.2.0, npm:@radix-ui/react-dialog@1.1.19, npm:@radix-ui/react-direction@1.1.2, npm:@radix-ui/react-dismissable-layer@1.1.15, npm:@radix-ui/react-dropdown-menu@2.1.20, npm:@radix-ui/react-focus-guards@1.1.4, npm:@radix-ui/react-focus-scope@1.1.12, npm:@radix-ui/react-id@1.1.2, npm:@radix-ui/react-menu@2.1.20, npm:@radix-ui/react-popover@1.1.19, npm:@radix-ui/react-popper@1.3.3, npm:@radix-ui/react-portal@1.1.13, npm:@radix-ui/react-presence@1.1.7, npm:@radix-ui/react-primitive@2.1.7, npm:@radix-ui/react-roving-focus@1.1.15, npm:@radix-ui/react-select@2.3.3, npm:@radix-ui/react-slider@1.4.3, npm:@radix-ui/react-slot@1.3.0, npm:@radix-ui/react-switch@1.3.3, npm:@radix-ui/react-tooltip@1.2.12, npm:@radix-ui/react-use-callback-ref@1.1.2, npm:@radix-ui/react-use-controllable-state@1.2.3, npm:@radix-ui/react-use-effect-event@0.0.3, npm:@radix-ui/react-use-is-hydrated@0.1.1, npm:@radix-ui/react-use-layout-effect@1.1.2, npm:@radix-ui/react-use-previous@1.1.2, npm:@radix-ui/react-use-rect@1.1.2, npm:@radix-ui/react-use-size@1.1.2, npm:@radix-ui/react-visually-hidden@1.2.7, npm:@radix-ui/rect@1.1.2
+[41] Applies to: npm:@radix-ui/number@1.1.2, npm:@radix-ui/primitive@1.1.5, npm:@radix-ui/react-alert-dialog@1.1.19, npm:@radix-ui/react-arrow@1.1.11, npm:@radix-ui/react-collection@1.1.12, npm:@radix-ui/react-compose-refs@1.1.3, npm:@radix-ui/react-context@1.2.0, npm:@radix-ui/react-dialog@1.1.19, npm:@radix-ui/react-direction@1.1.2, npm:@radix-ui/react-dismissable-layer@1.1.15, npm:@radix-ui/react-dropdown-menu@2.1.20, npm:@radix-ui/react-focus-guards@1.1.4, npm:@radix-ui/react-focus-scope@1.1.12, npm:@radix-ui/react-id@1.1.2, npm:@radix-ui/react-menu@2.1.20, npm:@radix-ui/react-popover@1.1.19, npm:@radix-ui/react-popper@1.3.3, npm:@radix-ui/react-portal@1.1.13, npm:@radix-ui/react-presence@1.1.7, npm:@radix-ui/react-primitive@2.1.7, npm:@radix-ui/react-roving-focus@1.1.15, npm:@radix-ui/react-select@2.3.3, npm:@radix-ui/react-slider@1.4.3, npm:@radix-ui/react-slot@1.3.0, npm:@radix-ui/react-switch@1.3.3, npm:@radix-ui/react-tooltip@1.2.12, npm:@radix-ui/react-use-callback-ref@1.1.2, npm:@radix-ui/react-use-controllable-state@1.2.3, npm:@radix-ui/react-use-effect-event@0.0.3, npm:@radix-ui/react-use-is-hydrated@0.1.1, npm:@radix-ui/react-use-layout-effect@1.1.2, npm:@radix-ui/react-use-previous@1.1.2, npm:@radix-ui/react-use-rect@1.1.2, npm:@radix-ui/react-use-size@1.1.2, npm:@radix-ui/react-visually-hidden@1.2.7, npm:@radix-ui/rect@1.1.2
 ------------------------------------------------------------------------------
 MIT License
 
@@ -4238,7 +4357,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
 ------------------------------------------------------------------------------
-[40] Applies to: npm:@replit/codemirror-lang-csharp@6.2.0
+[42] Applies to: npm:@replit/codemirror-lang-csharp@6.2.0
 ------------------------------------------------------------------------------
 MIT License
 
@@ -4263,7 +4382,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
 ------------------------------------------------------------------------------
-[41] Applies to: npm:@sapphire/shapeshift@4.0.0
+[43] Applies to: npm:@sapphire/shapeshift@4.0.0
 ------------------------------------------------------------------------------
 # The MIT License (MIT)
 
@@ -4291,7 +4410,7 @@ FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
 OTHER DEALINGS IN THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[42] Applies to: npm:@tanstack/react-virtual@3.14.6, npm:@tanstack/virtual-core@3.17.4
+[44] Applies to: npm:@tanstack/react-virtual@3.14.6, npm:@tanstack/virtual-core@3.17.4
 ------------------------------------------------------------------------------
 MIT License
 
@@ -4316,7 +4435,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
 ------------------------------------------------------------------------------
-[43] Applies to: npm:@tiptap/core@3.28.0, npm:@tiptap/extension-bubble-menu@3.28.0, npm:@tiptap/extension-document@3.28.0, npm:@tiptap/extension-floating-menu@3.28.0, npm:@tiptap/extension-hard-break@3.28.0, npm:@tiptap/extension-history@3.28.0, npm:@tiptap/extension-paragraph@3.28.0, npm:@tiptap/extension-placeholder@3.28.0, npm:@tiptap/extension-text@3.28.0, npm:@tiptap/pm@3.28.0, npm:@tiptap/react@3.28.0
+[45] Applies to: npm:@tiptap/core@3.28.0, npm:@tiptap/extension-bubble-menu@3.28.0, npm:@tiptap/extension-document@3.28.0, npm:@tiptap/extension-floating-menu@3.28.0, npm:@tiptap/extension-hard-break@3.28.0, npm:@tiptap/extension-history@3.28.0, npm:@tiptap/extension-paragraph@3.28.0, npm:@tiptap/extension-placeholder@3.28.0, npm:@tiptap/extension-text@3.28.0, npm:@tiptap/pm@3.28.0, npm:@tiptap/react@3.28.0
 ------------------------------------------------------------------------------
 MIT License
 
@@ -4341,7 +4460,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
 ------------------------------------------------------------------------------
-[44] Applies to: npm:@types/d3@7.4.3, npm:@types/d3-array@3.2.2, npm:@types/d3-axis@3.0.6, npm:@types/d3-brush@3.0.6, npm:@types/d3-chord@3.0.6, npm:@types/d3-color@3.1.3, npm:@types/d3-contour@3.0.6, npm:@types/d3-delaunay@6.0.4, npm:@types/d3-dispatch@3.0.7, npm:@types/d3-drag@3.0.7, npm:@types/d3-dsv@3.0.7, npm:@types/d3-ease@3.0.2, npm:@types/d3-fetch@3.0.7, npm:@types/d3-force@3.0.10, npm:@types/d3-format@3.0.4, npm:@types/d3-geo@3.1.0, npm:@types/d3-hierarchy@3.1.7, npm:@types/d3-interpolate@3.0.4, npm:@types/d3-path@3.1.1, npm:@types/d3-polygon@3.0.2, npm:@types/d3-quadtree@3.0.6, npm:@types/d3-random@3.0.4, npm:@types/d3-scale@4.0.9, npm:@types/d3-scale-chromatic@3.1.0, npm:@types/d3-selection@3.0.11, npm:@types/d3-shape@3.1.8, npm:@types/d3-time@3.0.4, npm:@types/d3-time-format@4.0.3, npm:@types/d3-timer@3.0.2, npm:@types/d3-transition@3.0.9, npm:@types/d3-zoom@3.0.8, npm:@types/debug@4.1.13, npm:@types/estree@1.0.9, npm:@types/estree-jsx@1.0.5, npm:@types/geojson@7946.0.16, npm:@types/hast@3.0.5, npm:@types/katex@0.16.8, npm:@types/mdast@4.0.4, npm:@types/ms@2.1.0, npm:@types/node@25.9.5, npm:@types/trusted-types@2.0.7, npm:@types/unist@2.0.11, npm:@types/unist@3.0.3, npm:@types/use-sync-external-store@0.0.6, npm:@types/ws@8.18.1
+[46] Applies to: npm:@types/d3@7.4.3, npm:@types/d3-array@3.2.2, npm:@types/d3-axis@3.0.6, npm:@types/d3-brush@3.0.6, npm:@types/d3-chord@3.0.6, npm:@types/d3-color@3.1.3, npm:@types/d3-contour@3.0.6, npm:@types/d3-delaunay@6.0.4, npm:@types/d3-dispatch@3.0.7, npm:@types/d3-drag@3.0.7, npm:@types/d3-dsv@3.0.7, npm:@types/d3-ease@3.0.2, npm:@types/d3-fetch@3.0.7, npm:@types/d3-force@3.0.10, npm:@types/d3-format@3.0.4, npm:@types/d3-geo@3.1.0, npm:@types/d3-hierarchy@3.1.7, npm:@types/d3-interpolate@3.0.4, npm:@types/d3-path@3.1.1, npm:@types/d3-polygon@3.0.2, npm:@types/d3-quadtree@3.0.6, npm:@types/d3-random@3.0.4, npm:@types/d3-scale@4.0.9, npm:@types/d3-scale-chromatic@3.1.0, npm:@types/d3-selection@3.0.11, npm:@types/d3-shape@3.1.8, npm:@types/d3-time@3.0.4, npm:@types/d3-time-format@4.0.3, npm:@types/d3-timer@3.0.2, npm:@types/d3-transition@3.0.9, npm:@types/d3-zoom@3.0.8, npm:@types/debug@4.1.13, npm:@types/estree@1.0.9, npm:@types/estree-jsx@1.0.5, npm:@types/geojson@7946.0.16, npm:@types/hast@3.0.5, npm:@types/katex@0.16.8, npm:@types/mdast@4.0.4, npm:@types/ms@2.1.0, npm:@types/node@14.18.63, npm:@types/node@22.20.1, npm:@types/node@25.9.5, npm:@types/trusted-types@2.0.7, npm:@types/unist@2.0.11, npm:@types/unist@3.0.3, npm:@types/use-sync-external-store@0.0.6, npm:@types/ws@8.18.1
 ------------------------------------------------------------------------------
 MIT License
 
@@ -4366,7 +4485,7 @@ MIT License
     SOFTWARE
 
 ------------------------------------------------------------------------------
-[45] Applies to: npm:@ungap/structured-clone@1.3.3
+[47] Applies to: npm:@ungap/structured-clone@1.3.3
 ------------------------------------------------------------------------------
 ISC License
 
@@ -4385,7 +4504,7 @@ OR OTHER TORTIOUS ACTION, ARISING OUT OF OR IN CONNECTION WITH THE USE OR
 PERFORMANCE OF THIS SOFTWARE.
 
 ------------------------------------------------------------------------------
-[46] Applies to: npm:@upsetjs/venn.js@2.0.0
+[48] Applies to: npm:@upsetjs/venn.js@2.0.0
 ------------------------------------------------------------------------------
 MIT License
 
@@ -4411,7 +4530,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
 ------------------------------------------------------------------------------
-[47] Applies to: npm:@vladfrangu/async_event_emitter@2.4.7
+[49] Applies to: npm:@vladfrangu/async_event_emitter@2.4.7
 ------------------------------------------------------------------------------
 # The MIT License (MIT)
 
@@ -4439,7 +4558,7 @@ FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
 OTHER DEALINGS IN THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[48] Applies to: npm:@xterm/addon-clipboard@0.1.0
+[50] Applies to: npm:@xterm/addon-clipboard@0.1.0
 ------------------------------------------------------------------------------
 Copyright (c) 2023, The xterm.js authors (https://github.com/xtermjs/xterm.js)
 
@@ -4462,7 +4581,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[49] Applies to: npm:@xterm/addon-fit@0.10.0
+[51] Applies to: npm:@xterm/addon-fit@0.10.0
 ------------------------------------------------------------------------------
 Copyright (c) 2019, The xterm.js authors (https://github.com/xtermjs/xterm.js)
 
@@ -4485,7 +4604,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[50] Applies to: npm:@xterm/addon-web-links@0.11.0
+[52] Applies to: npm:@xterm/addon-web-links@0.11.0
 ------------------------------------------------------------------------------
 Copyright (c) 2017, The xterm.js authors (https://github.com/xtermjs/xterm.js)
 
@@ -4508,7 +4627,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[51] Applies to: npm:@xterm/xterm@5.5.0
+[53] Applies to: npm:@xterm/xterm@5.5.0
 ------------------------------------------------------------------------------
 Copyright (c) 2017-2019, The xterm.js authors (https://github.com/xtermjs/xterm.js)
 Copyright (c) 2014-2016, SourceLair Private Company (https://www.sourcelair.com)
@@ -4533,7 +4652,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[52] Applies to: npm:accepts@2.0.0, npm:mime-types@2.1.35, npm:mime-types@3.0.2
+[54] Applies to: npm:accepts@2.0.0, npm:mime-types@2.1.35, npm:mime-types@3.0.2
 ------------------------------------------------------------------------------
 (The MIT License)
 
@@ -4560,7 +4679,7 @@ TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
 SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[53] Applies to: npm:agent-base@7.1.4, npm:https-proxy-agent@7.0.6
+[55] Applies to: npm:agent-base@7.1.4, npm:https-proxy-agent@7.0.6
 ------------------------------------------------------------------------------
 (The MIT License)
 
@@ -4586,7 +4705,7 @@ TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
 SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[54] Applies to: npm:ajv@7.2.4, npm:ajv@8.20.0
+[56] Applies to: npm:ajv@7.2.4, npm:ajv@8.20.0
 ------------------------------------------------------------------------------
 The MIT License (MIT)
 
@@ -4611,7 +4730,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
 ------------------------------------------------------------------------------
-[55] Applies to: npm:ajv-formats@1.6.1, npm:ajv-formats@3.0.1
+[57] Applies to: npm:ajv-formats@1.6.1, npm:ajv-formats@3.0.1
 ------------------------------------------------------------------------------
 MIT License
 
@@ -4636,7 +4755,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
 ------------------------------------------------------------------------------
-[56] Applies to: npm:ansi-regex@5.0.1, npm:ansi-styles@4.3.0, npm:camelcase@5.3.1, npm:env-paths@2.2.1, npm:find-up@3.0.0, npm:find-up@4.1.0, npm:is-fullwidth-code-point@3.0.0, npm:is-obj@2.0.0, npm:lcid@3.1.1, npm:locate-path@3.0.0, npm:locate-path@5.0.0, npm:make-dir@3.1.0, npm:mimic-fn@2.1.0, npm:mimic-fn@3.1.0, npm:npm-run-path@4.0.1, npm:p-limit@2.3.0, npm:p-locate@3.0.0, npm:p-locate@4.1.0, npm:p-try@2.2.0, npm:path-exists@4.0.0, npm:path-key@3.1.1, npm:pkg-up@3.1.0, npm:shebang-regex@3.0.0, npm:string-width@4.2.3, npm:strip-ansi@6.0.1, npm:strip-final-newline@2.0.0, npm:wrap-ansi@6.2.0
+[58] Applies to: npm:ansi-regex@5.0.1, npm:ansi-styles@4.3.0, npm:camelcase@5.3.1, npm:env-paths@2.2.1, npm:find-up@3.0.0, npm:find-up@4.1.0, npm:is-fullwidth-code-point@3.0.0, npm:is-obj@2.0.0, npm:lcid@3.1.1, npm:locate-path@3.0.0, npm:locate-path@5.0.0, npm:make-dir@3.1.0, npm:mimic-fn@2.1.0, npm:mimic-fn@3.1.0, npm:npm-run-path@4.0.1, npm:p-limit@2.3.0, npm:p-locate@3.0.0, npm:p-locate@4.1.0, npm:p-try@2.2.0, npm:path-exists@4.0.0, npm:path-key@3.1.1, npm:pkg-up@3.1.0, npm:shebang-regex@3.0.0, npm:string-width@4.2.3, npm:strip-ansi@6.0.1, npm:strip-final-newline@2.0.0, npm:wrap-ansi@6.2.0
 ------------------------------------------------------------------------------
 MIT License
 
@@ -4649,7 +4768,7 @@ The above copyright notice and this permission notice shall be included in all c
 THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[57] Applies to: npm:ansi-regex@6.2.2, npm:ansi-styles@6.2.3, npm:conf@9.0.2, npm:debounce-fn@4.0.0, npm:decompress-response@6.0.0, npm:default-shell@2.2.0, npm:dot-prop@6.0.1, npm:electron-store@7.0.3, npm:escape-string-regexp@5.0.0, npm:execa@4.1.0, npm:execa@5.1.1, npm:fix-path@5.0.0, npm:get-east-asian-width@1.6.0, npm:get-stream@5.2.0, npm:get-stream@6.0.1, npm:invert-kv@3.0.1, npm:is-plain-obj@4.1.0, npm:is-stream@2.0.1, npm:mimic-response@3.1.0, npm:onetime@5.1.2, npm:os-locale@6.0.2, npm:shell-env@4.0.3, npm:shell-path@3.1.0, npm:string-width@5.1.2, npm:strip-ansi@7.2.0, npm:wrap-ansi@7.0.0, npm:wrap-ansi@8.1.0
+[59] Applies to: npm:ansi-regex@6.2.2, npm:ansi-styles@6.2.3, npm:conf@9.0.2, npm:debounce-fn@4.0.0, npm:decompress-response@6.0.0, npm:default-shell@2.2.0, npm:dot-prop@6.0.1, npm:electron-store@7.0.3, npm:escape-string-regexp@5.0.0, npm:execa@4.1.0, npm:execa@5.1.1, npm:fix-path@5.0.0, npm:get-east-asian-width@1.6.0, npm:get-stream@5.2.0, npm:get-stream@6.0.1, npm:invert-kv@3.0.1, npm:is-plain-obj@4.1.0, npm:is-stream@2.0.1, npm:mimic-response@3.1.0, npm:onetime@5.1.2, npm:os-locale@6.0.2, npm:shell-env@4.0.3, npm:shell-path@3.1.0, npm:string-width@5.1.2, npm:strip-ansi@7.2.0, npm:wrap-ansi@7.0.0, npm:wrap-ansi@8.1.0
 ------------------------------------------------------------------------------
 MIT License
 
@@ -4662,7 +4781,59 @@ The above copyright notice and this permission notice shall be included in all c
 THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[58] Applies to: npm:argparse@1.0.10
+[60] Applies to: npm:archiver@5.3.2
+------------------------------------------------------------------------------
+Copyright (c) 2012-2014 Chris Talkington, contributors.
+
+Permission is hereby granted, free of charge, to any person
+obtaining a copy of this software and associated documentation
+files (the "Software"), to deal in the Software without
+restriction, including without limitation the rights to use,
+copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the
+Software is furnished to do so, subject to the following
+conditions:
+
+The above copyright notice and this permission notice shall be
+included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
+OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+OTHER DEALINGS IN THE SOFTWARE.
+
+------------------------------------------------------------------------------
+[61] Applies to: npm:archiver-utils@2.1.0, npm:archiver-utils@3.0.4
+------------------------------------------------------------------------------
+Copyright (c) 2015 Chris Talkington.
+
+Permission is hereby granted, free of charge, to any person
+obtaining a copy of this software and associated documentation
+files (the "Software"), to deal in the Software without
+restriction, including without limitation the rights to use,
+copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the
+Software is furnished to do so, subject to the following
+conditions:
+
+The above copyright notice and this permission notice shall be
+included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
+OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+OTHER DEALINGS IN THE SOFTWARE.
+
+------------------------------------------------------------------------------
+[62] Applies to: npm:argparse@1.0.10
 ------------------------------------------------------------------------------
 (The MIT License)
 
@@ -4687,7 +4858,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[59] Applies to: npm:argparse@2.0.1
+[63] Applies to: npm:argparse@2.0.1
 ------------------------------------------------------------------------------
 A. HISTORY OF THE SOFTWARE
 ==========================
@@ -4945,7 +5116,7 @@ ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT
 OF OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
 
 ------------------------------------------------------------------------------
-[60] Applies to: npm:aria-hidden@1.2.6, npm:react-remove-scroll@2.7.2, npm:react-style-singleton@2.2.3, npm:use-callback-ref@1.3.3, npm:use-sidecar@1.1.3
+[64] Applies to: npm:aria-hidden@1.2.6, npm:react-remove-scroll@2.7.2, npm:react-style-singleton@2.2.3, npm:use-callback-ref@1.3.3, npm:use-sidecar@1.1.3
 ------------------------------------------------------------------------------
 MIT License
 
@@ -4970,7 +5141,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
 ------------------------------------------------------------------------------
-[61] Applies to: npm:asn1@0.2.6
+[65] Applies to: npm:asn1@0.2.6
 ------------------------------------------------------------------------------
 Copyright (c) 2011 Mark Cavage, All rights reserved.
 
@@ -4993,7 +5164,30 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE
 
 ------------------------------------------------------------------------------
-[62] Applies to: npm:asynckit@0.4.0
+[66] Applies to: npm:async@3.2.6
+------------------------------------------------------------------------------
+Copyright (c) 2010-2018 Caolan McMahon
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+
+------------------------------------------------------------------------------
+[67] Applies to: npm:asynckit@0.4.0
 ------------------------------------------------------------------------------
 The MIT License (MIT)
 
@@ -5018,7 +5212,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
 ------------------------------------------------------------------------------
-[63] Applies to: npm:atomically@1.7.0
+[68] Applies to: npm:atomically@1.7.0
 ------------------------------------------------------------------------------
 The MIT License (MIT)
 
@@ -5043,7 +5237,7 @@ FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
 DEALINGS IN THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[64] Applies to: npm:axios@1.18.1
+[69] Applies to: npm:axios@1.18.1
 ------------------------------------------------------------------------------
 # Copyright (c) 2014-present Matt Zabriskie & Collaborators
 
@@ -5054,7 +5248,7 @@ The above copyright notice and this permission notice shall be included in all c
 THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[65] Applies to: npm:bail@2.0.2, npm:ccount@2.0.1, npm:character-entities@2.0.2, npm:character-entities-html4@2.1.0, npm:character-entities-legacy@3.0.0, npm:character-reference-invalid@2.0.1, npm:mdast-util-to-string@4.0.0, npm:unist-util-find-after@5.0.0, npm:unist-util-position@5.0.0, npm:unist-util-visit@5.1.0
+[70] Applies to: npm:bail@2.0.2, npm:ccount@2.0.1, npm:character-entities@2.0.2, npm:character-entities-html4@2.1.0, npm:character-entities-legacy@3.0.0, npm:character-reference-invalid@2.0.1, npm:mdast-util-to-string@4.0.0, npm:unist-util-find-after@5.0.0, npm:unist-util-position@5.0.0, npm:unist-util-visit@5.1.0
 ------------------------------------------------------------------------------
 (The MIT License)
 
@@ -5080,7 +5274,7 @@ TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
 SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[66] Applies to: npm:balanced-match@1.0.2
+[71] Applies to: npm:balanced-match@1.0.2
 ------------------------------------------------------------------------------
 (MIT)
 
@@ -5105,7 +5299,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
 ------------------------------------------------------------------------------
-[67] Applies to: npm:base64-js@1.5.1
+[72] Applies to: npm:base64-js@1.5.1
 ------------------------------------------------------------------------------
 The MIT License (MIT)
 
@@ -5130,7 +5324,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[68] Applies to: npm:bcrypt-pbkdf@1.0.2
+[73] Applies to: npm:bcrypt-pbkdf@1.0.2
 ------------------------------------------------------------------------------
 The Blowfish portions are under the following license:
 
@@ -5200,7 +5394,7 @@ ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
 OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
 
 ------------------------------------------------------------------------------
-[69] Applies to: npm:better-sqlite3@12.11.1
+[74] Applies to: npm:better-sqlite3@12.11.1
 ------------------------------------------------------------------------------
 The MIT License (MIT)
 
@@ -5225,7 +5419,35 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
 ------------------------------------------------------------------------------
-[70] Applies to: npm:bignumber.js@9.3.1
+[75] Applies to: npm:big-integer@1.6.52, npm:robust-predicates@3.0.3, npm:tweetnacl@0.14.5
+------------------------------------------------------------------------------
+This is free and unencumbered software released into the public domain.
+
+Anyone is free to copy, modify, publish, use, compile, sell, or
+distribute this software, either in source code form or as a compiled
+binary, for any purpose, commercial or non-commercial, and by any
+means.
+
+In jurisdictions that recognize copyright laws, the author or authors
+of this software dedicate any and all copyright interest in the
+software to the public domain. We make this dedication for the benefit
+of the public at large and to the detriment of our heirs and
+successors. We intend this dedication to be an overt act of
+relinquishment in perpetuity of all present and future rights to this
+software under copyright law.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+IN NO EVENT SHALL THE AUTHORS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+OTHER DEALINGS IN THE SOFTWARE.
+
+For more information, please refer to <http://unlicense.org>
+
+------------------------------------------------------------------------------
+[76] Applies to: npm:bignumber.js@9.3.1
 ------------------------------------------------------------------------------
 The MIT License (MIT)
 =====================
@@ -5254,7 +5476,7 @@ FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
 OTHER DEALINGS IN THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[71] Applies to: npm:bindings@1.5.0
+[77] Applies to: npm:bindings@1.5.0
 ------------------------------------------------------------------------------
 (The MIT License)
 
@@ -5280,7 +5502,7 @@ TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
 SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[72] Applies to: npm:bl@4.1.0
+[78] Applies to: npm:bl@4.1.0
 ------------------------------------------------------------------------------
 The MIT License (MIT)
 =====================
@@ -5297,7 +5519,32 @@ The above copyright notice and this permission notice shall be included in all c
 THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[73] Applies to: npm:body-parser@2.3.0, npm:type-is@2.1.0
+[79] Applies to: npm:bluebird@3.4.7
+------------------------------------------------------------------------------
+The MIT License (MIT)
+
+Copyright (c) 2013-2015 Petka Antonov
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.  IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+
+------------------------------------------------------------------------------
+[80] Applies to: npm:body-parser@2.3.0, npm:type-is@2.1.0
 ------------------------------------------------------------------------------
 (The MIT License)
 
@@ -5324,7 +5571,7 @@ TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
 SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[74] Applies to: npm:brace-expansion@2.1.2
+[81] Applies to: npm:brace-expansion@1.1.16, npm:brace-expansion@2.1.2
 ------------------------------------------------------------------------------
 MIT License
 
@@ -5349,7 +5596,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
 ------------------------------------------------------------------------------
-[75] Applies to: npm:buffer@5.7.1
+[82] Applies to: npm:buffer@5.7.1
 ------------------------------------------------------------------------------
 The MIT License (MIT)
 
@@ -5374,7 +5621,30 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[76] Applies to: npm:buffer-equal-constant-time@1.0.1
+[83] Applies to: npm:buffer-crc32@0.2.13
+------------------------------------------------------------------------------
+The MIT License
+
+Copyright (c) 2013 Brian J. Brennan
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal in
+the Software without restriction, including without limitation the rights to use,
+copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the
+Software, and to permit persons to whom the Software is furnished to do so,
+subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED,
+INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR
+PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE
+FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+------------------------------------------------------------------------------
+[84] Applies to: npm:buffer-equal-constant-time@1.0.1
 ------------------------------------------------------------------------------
 Copyright (c) 2013, GoInstant Inc., a salesforce.com company
 All rights reserved.
@@ -5390,7 +5660,32 @@ Redistribution and use in source and binary forms, with or without modification,
 THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 ------------------------------------------------------------------------------
-[77] Applies to: npm:buildcheck@0.0.7, npm:cpu-features@0.0.10, npm:ssh2@1.17.0
+[85] Applies to: npm:buffer-indexof-polyfill@1.0.2
+------------------------------------------------------------------------------
+The MIT License (MIT)
+
+Copyright (c) 2015 Sarosia
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+
+------------------------------------------------------------------------------
+[86] Applies to: npm:buildcheck@0.0.7, npm:cpu-features@0.0.10, npm:ssh2@1.17.0
 ------------------------------------------------------------------------------
 Copyright Brian White. All rights reserved.
 
@@ -5413,7 +5708,7 @@ FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
 IN THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[78] Applies to: npm:byte-size@8.2.1
+[87] Applies to: npm:byte-size@8.2.1
 ------------------------------------------------------------------------------
 The MIT License (MIT)
 
@@ -5438,7 +5733,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
 ------------------------------------------------------------------------------
-[79] Applies to: npm:bytes@3.1.2
+[88] Applies to: npm:bytes@3.1.2
 ------------------------------------------------------------------------------
 (The MIT License)
 
@@ -5465,7 +5760,7 @@ TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
 SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[80] Applies to: npm:call-bind-apply-helpers@1.0.2, npm:call-bound@1.0.4, npm:es-define-property@1.0.1, npm:es-errors@1.3.0, npm:es-object-atoms@1.1.2, npm:side-channel-list@1.0.1, npm:side-channel-map@1.0.1
+[89] Applies to: npm:call-bind-apply-helpers@1.0.2, npm:call-bound@1.0.4, npm:es-define-property@1.0.1, npm:es-errors@1.3.0, npm:es-object-atoms@1.1.2, npm:side-channel-list@1.0.1, npm:side-channel-map@1.0.1
 ------------------------------------------------------------------------------
 MIT License
 
@@ -5490,7 +5785,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
 ------------------------------------------------------------------------------
-[81] Applies to: npm:charenc@0.0.2, npm:crypt@0.0.2
+[90] Applies to: npm:charenc@0.0.2, npm:crypt@0.0.2
 ------------------------------------------------------------------------------
 Copyright © 2011, Paul Vorbach. All rights reserved.
 Copyright © 2009, Jeff Mott. All rights reserved.
@@ -5521,7 +5816,7 @@ ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
 SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 ------------------------------------------------------------------------------
-[82] Applies to: npm:chownr@3.0.0, npm:package-json-from-dist@1.0.1, npm:yallist@5.0.0
+[91] Applies to: npm:chownr@3.0.0, npm:package-json-from-dist@1.0.1, npm:yallist@5.0.0
 ------------------------------------------------------------------------------
 All packages under `src/` are licensed according to the terms in
 their respective `LICENSE` or `LICENSE.md` files.
@@ -5588,7 +5883,7 @@ will be liable to anyone for any damages related to this
 software or this license, under any kind of legal claim.***
 
 ------------------------------------------------------------------------------
-[83] Applies to: npm:clsx@2.1.1
+[92] Applies to: npm:clsx@2.1.1
 ------------------------------------------------------------------------------
 MIT License
 
@@ -5601,7 +5896,7 @@ The above copyright notice and this permission notice shall be included in all c
 THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[84] Applies to: npm:cn-font-split@6.0.3
+[93] Applies to: npm:cn-font-split@6.0.3
 ------------------------------------------------------------------------------
 Apache License
                            Version 2.0, January 2004
@@ -5806,7 +6101,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 
 ------------------------------------------------------------------------------
-[85] Applies to: npm:color-convert@2.0.1
+[94] Applies to: npm:color-convert@2.0.1
 ------------------------------------------------------------------------------
 Copyright (c) 2011-2016 Heather Arthur <fayearthur@gmail.com>
 
@@ -5830,7 +6125,7 @@ OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
 WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[86] Applies to: npm:color-name@1.1.4
+[95] Applies to: npm:color-name@1.1.4
 ------------------------------------------------------------------------------
 The MIT License (MIT)
 Copyright (c) 2015 Dmitry Ivanov
@@ -5842,7 +6137,7 @@ The above copyright notice and this permission notice shall be included in all c
 THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[87] Applies to: npm:combined-stream@1.0.8, npm:delayed-stream@1.0.0
+[96] Applies to: npm:combined-stream@1.0.8, npm:delayed-stream@1.0.0
 ------------------------------------------------------------------------------
 Copyright (c) 2011 Debuggable Limited <felix@debuggable.com>
 
@@ -5865,7 +6160,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[88] Applies to: npm:comma-separated-tokens@2.0.3, npm:hast-util-is-element@3.0.0, npm:hast-util-parse-selector@4.0.0, npm:hast-util-whitespace@3.0.0, npm:is-alphabetical@2.0.1, npm:is-alphanumerical@2.0.1, npm:is-decimal@2.0.1, npm:is-hexadecimal@2.0.1, npm:mdast-util-to-hast@13.2.1, npm:rehype-slug@6.0.0, npm:space-separated-tokens@2.0.2, npm:unist-util-remove-position@5.0.0, npm:unist-util-stringify-position@4.0.0, npm:unist-util-visit-parents@6.0.2, npm:vfile-location@5.0.3, npm:web-namespaces@2.0.1, npm:zwitch@2.0.4
+[97] Applies to: npm:comma-separated-tokens@2.0.3, npm:hast-util-is-element@3.0.0, npm:hast-util-parse-selector@4.0.0, npm:hast-util-whitespace@3.0.0, npm:is-alphabetical@2.0.1, npm:is-alphanumerical@2.0.1, npm:is-decimal@2.0.1, npm:is-hexadecimal@2.0.1, npm:mdast-util-to-hast@13.2.1, npm:rehype-slug@6.0.0, npm:space-separated-tokens@2.0.2, npm:unist-util-remove-position@5.0.0, npm:unist-util-stringify-position@4.0.0, npm:unist-util-visit-parents@6.0.2, npm:vfile-location@5.0.3, npm:web-namespaces@2.0.1, npm:zwitch@2.0.4
 ------------------------------------------------------------------------------
 (The MIT License)
 
@@ -5891,7 +6186,7 @@ TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
 SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[89] Applies to: npm:commander@7.2.0, npm:commander@8.3.0
+[98] Applies to: npm:commander@7.2.0, npm:commander@8.3.0
 ------------------------------------------------------------------------------
 (The MIT License)
 
@@ -5917,7 +6212,55 @@ TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
 SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[90] Applies to: npm:content-disposition@1.1.0, npm:forwarded@0.2.0, npm:media-typer@1.1.0, npm:vary@1.1.2
+[99] Applies to: npm:compress-commons@4.1.2, npm:crc32-stream@4.0.3, npm:zip-stream@4.1.1
+------------------------------------------------------------------------------
+Copyright (c) 2014 Chris Talkington, contributors.
+
+Permission is hereby granted, free of charge, to any person
+obtaining a copy of this software and associated documentation
+files (the "Software"), to deal in the Software without
+restriction, including without limitation the rights to use,
+copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the
+Software is furnished to do so, subject to the following
+conditions:
+
+The above copyright notice and this permission notice shall be
+included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
+OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+OTHER DEALINGS IN THE SOFTWARE.
+
+------------------------------------------------------------------------------
+[100] Applies to: npm:concat-map@0.0.1, npm:github-from-package@0.0.0, npm:minimist@1.2.8
+------------------------------------------------------------------------------
+This software is released under the MIT license:
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of
+this software and associated documentation files (the "Software"), to deal in
+the Software without restriction, including without limitation the rights to
+use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+the Software, and to permit persons to whom the Software is furnished to do so,
+subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+------------------------------------------------------------------------------
+[101] Applies to: npm:content-disposition@1.1.0, npm:forwarded@0.2.0, npm:media-typer@1.1.0, npm:vary@1.1.2
 ------------------------------------------------------------------------------
 (The MIT License)
 
@@ -5943,7 +6286,7 @@ TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
 SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[91] Applies to: npm:content-type@1.0.5, npm:content-type@2.0.0
+[102] Applies to: npm:content-type@1.0.5, npm:content-type@2.0.0
 ------------------------------------------------------------------------------
 (The MIT License)
 
@@ -5969,7 +6312,7 @@ TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
 SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[92] Applies to: npm:cookie@0.7.2, npm:cookie@1.1.1
+[103] Applies to: npm:cookie@0.7.2, npm:cookie@1.1.1
 ------------------------------------------------------------------------------
 (The MIT License)
 
@@ -5996,7 +6339,7 @@ TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
 SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[93] Applies to: npm:cookie-signature@1.2.2
+[104] Applies to: npm:cookie-signature@1.2.2
 ------------------------------------------------------------------------------
 (The MIT License)
 
@@ -6022,7 +6365,7 @@ TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
 SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[94] Applies to: npm:core-util-is@1.0.3
+[105] Applies to: npm:core-util-is@1.0.3
 ------------------------------------------------------------------------------
 Copyright Node.js contributors. All rights reserved.
 
@@ -6045,7 +6388,7 @@ FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
 IN THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[95] Applies to: npm:cors@2.8.6
+[106] Applies to: npm:cors@2.8.6
 ------------------------------------------------------------------------------
 (The MIT License)
 
@@ -6071,7 +6414,7 @@ TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
 SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[96] Applies to: npm:cose-base@1.0.3, npm:cose-base@2.2.0
+[107] Applies to: npm:cose-base@1.0.3, npm:cose-base@2.2.0
 ------------------------------------------------------------------------------
 MIT License
 
@@ -6096,7 +6439,212 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
 ------------------------------------------------------------------------------
-[97] Applies to: npm:crelt@1.0.7
+[108] Applies to: npm:crc-32@1.2.2
+------------------------------------------------------------------------------
+Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "{}"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright (C) 2014-present   SheetJS LLC
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+
+------------------------------------------------------------------------------
+[109] Applies to: npm:crelt@1.0.7
 ------------------------------------------------------------------------------
 Copyright (C) 2020 by Marijn Haverbeke <marijn@haverbeke.berlin>
 
@@ -6119,7 +6667,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[98] Applies to: npm:cross-spawn@7.0.6
+[110] Applies to: npm:cross-spawn@7.0.6
 ------------------------------------------------------------------------------
 The MIT License (MIT)
 
@@ -6144,7 +6692,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[99] Applies to: npm:cytoscape@3.34.0
+[111] Applies to: npm:cytoscape@3.34.0
 ------------------------------------------------------------------------------
 Copyright (c) 2016-2026, The Cytoscape Consortium.
 
@@ -6200,7 +6748,7 @@ SOFTWARE.`;
 fs.writeFileSync(path.join(__dirname, 'LICENSE'), license);
 
 ------------------------------------------------------------------------------
-[100] Applies to: npm:cytoscape-cose-bilkent@4.1.0
+[112] Applies to: npm:cytoscape-cose-bilkent@4.1.0
 ------------------------------------------------------------------------------
 Copyright (c) 2016-2018, The Cytoscape Consortium.
 
@@ -6223,7 +6771,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
 ------------------------------------------------------------------------------
-[101] Applies to: npm:cytoscape-fcose@2.2.0
+[113] Applies to: npm:cytoscape-fcose@2.2.0
 ------------------------------------------------------------------------------
 Copyright (c) 2018 - present, iVis-at-Bilkent.
 
@@ -6246,7 +6794,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
 ------------------------------------------------------------------------------
-[102] Applies to: npm:d3@7.9.0, npm:d3-array@3.2.4
+[114] Applies to: npm:d3@7.9.0, npm:d3-array@3.2.4
 ------------------------------------------------------------------------------
 Copyright 2010-2023 Mike Bostock
 
@@ -6263,7 +6811,7 @@ TORTIOUS ACTION, ARISING OUT OF OR IN CONNECTION WITH THE USE OR PERFORMANCE OF
 THIS SOFTWARE.
 
 ------------------------------------------------------------------------------
-[103] Applies to: npm:d3-array@2.12.1
+[115] Applies to: npm:d3-array@2.12.1
 ------------------------------------------------------------------------------
 Copyright 2010-2020 Mike Bostock
 All rights reserved.
@@ -6294,7 +6842,7 @@ ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
 SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 ------------------------------------------------------------------------------
-[104] Applies to: npm:d3-axis@3.0.0, npm:d3-brush@3.0.0, npm:d3-chord@3.0.1, npm:d3-dispatch@3.0.1, npm:d3-drag@3.0.0, npm:d3-force@3.0.0, npm:d3-hierarchy@3.1.2, npm:d3-interpolate@3.0.1, npm:d3-polygon@3.0.1, npm:d3-quadtree@3.0.1, npm:d3-random@3.0.1, npm:d3-scale@4.0.2, npm:d3-selection@3.0.0, npm:d3-time-format@4.1.0, npm:d3-timer@3.0.1, npm:d3-transition@3.0.1, npm:d3-zoom@3.0.0
+[116] Applies to: npm:d3-axis@3.0.0, npm:d3-brush@3.0.0, npm:d3-chord@3.0.1, npm:d3-dispatch@3.0.1, npm:d3-drag@3.0.0, npm:d3-force@3.0.0, npm:d3-hierarchy@3.1.2, npm:d3-interpolate@3.0.1, npm:d3-polygon@3.0.1, npm:d3-quadtree@3.0.1, npm:d3-random@3.0.1, npm:d3-scale@4.0.2, npm:d3-selection@3.0.0, npm:d3-time-format@4.1.0, npm:d3-timer@3.0.1, npm:d3-transition@3.0.1, npm:d3-zoom@3.0.0
 ------------------------------------------------------------------------------
 Copyright 2010-2021 Mike Bostock
 
@@ -6311,7 +6859,7 @@ TORTIOUS ACTION, ARISING OUT OF OR IN CONNECTION WITH THE USE OR PERFORMANCE OF
 THIS SOFTWARE.
 
 ------------------------------------------------------------------------------
-[105] Applies to: npm:d3-color@3.1.0, npm:d3-shape@3.2.0, npm:d3-time@3.1.0
+[117] Applies to: npm:d3-color@3.1.0, npm:d3-shape@3.2.0, npm:d3-time@3.1.0
 ------------------------------------------------------------------------------
 Copyright 2010-2022 Mike Bostock
 
@@ -6328,7 +6876,7 @@ TORTIOUS ACTION, ARISING OUT OF OR IN CONNECTION WITH THE USE OR PERFORMANCE OF
 THIS SOFTWARE.
 
 ------------------------------------------------------------------------------
-[106] Applies to: npm:d3-contour@4.0.2
+[118] Applies to: npm:d3-contour@4.0.2
 ------------------------------------------------------------------------------
 Copyright 2012-2023 Mike Bostock
 
@@ -6345,7 +6893,7 @@ TORTIOUS ACTION, ARISING OUT OF OR IN CONNECTION WITH THE USE OR PERFORMANCE OF
 THIS SOFTWARE.
 
 ------------------------------------------------------------------------------
-[107] Applies to: npm:d3-delaunay@6.0.4
+[119] Applies to: npm:d3-delaunay@6.0.4
 ------------------------------------------------------------------------------
 Copyright 2018-2021 Observable, Inc.
 Copyright 2021 Mapbox
@@ -6363,7 +6911,7 @@ TORTIOUS ACTION, ARISING OUT OF OR IN CONNECTION WITH THE USE OR PERFORMANCE OF
 THIS SOFTWARE.
 
 ------------------------------------------------------------------------------
-[108] Applies to: npm:d3-dsv@3.0.1
+[120] Applies to: npm:d3-dsv@3.0.1
 ------------------------------------------------------------------------------
 Copyright 2013-2021 Mike Bostock
 
@@ -6380,7 +6928,7 @@ TORTIOUS ACTION, ARISING OUT OF OR IN CONNECTION WITH THE USE OR PERFORMANCE OF
 THIS SOFTWARE.
 
 ------------------------------------------------------------------------------
-[109] Applies to: npm:d3-ease@3.0.1
+[121] Applies to: npm:d3-ease@3.0.1
 ------------------------------------------------------------------------------
 Copyright 2010-2021 Mike Bostock
 Copyright 2001 Robert Penner
@@ -6412,7 +6960,7 @@ ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
 SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 ------------------------------------------------------------------------------
-[110] Applies to: npm:d3-fetch@3.0.1
+[122] Applies to: npm:d3-fetch@3.0.1
 ------------------------------------------------------------------------------
 Copyright 2016-2021 Mike Bostock
 
@@ -6429,7 +6977,7 @@ TORTIOUS ACTION, ARISING OUT OF OR IN CONNECTION WITH THE USE OR PERFORMANCE OF
 THIS SOFTWARE.
 
 ------------------------------------------------------------------------------
-[111] Applies to: npm:d3-format@3.1.2
+[123] Applies to: npm:d3-format@3.1.2
 ------------------------------------------------------------------------------
 Copyright 2010-2026 Mike Bostock
 
@@ -6446,7 +6994,7 @@ TORTIOUS ACTION, ARISING OUT OF OR IN CONNECTION WITH THE USE OR PERFORMANCE OF
 THIS SOFTWARE.
 
 ------------------------------------------------------------------------------
-[112] Applies to: npm:d3-geo@3.1.1
+[124] Applies to: npm:d3-geo@3.1.1
 ------------------------------------------------------------------------------
 Copyright 2010-2024 Mike Bostock
 
@@ -6484,7 +7032,7 @@ IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
 CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[113] Applies to: npm:d3-path@1.0.9
+[125] Applies to: npm:d3-path@1.0.9
 ------------------------------------------------------------------------------
 Copyright 2015-2016 Mike Bostock
 All rights reserved.
@@ -6515,7 +7063,7 @@ ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
 SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 ------------------------------------------------------------------------------
-[114] Applies to: npm:d3-path@3.1.0
+[126] Applies to: npm:d3-path@3.1.0
 ------------------------------------------------------------------------------
 Copyright 2015-2022 Mike Bostock
 
@@ -6532,7 +7080,7 @@ TORTIOUS ACTION, ARISING OUT OF OR IN CONNECTION WITH THE USE OR PERFORMANCE OF
 THIS SOFTWARE.
 
 ------------------------------------------------------------------------------
-[115] Applies to: npm:d3-sankey@0.12.3
+[127] Applies to: npm:d3-sankey@0.12.3
 ------------------------------------------------------------------------------
 Copyright 2015, Mike Bostock
 All rights reserved.
@@ -6563,7 +7111,7 @@ ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
 SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 ------------------------------------------------------------------------------
-[116] Applies to: npm:d3-scale-chromatic@3.1.0
+[128] Applies to: npm:d3-scale-chromatic@3.1.0
 ------------------------------------------------------------------------------
 Copyright 2010-2024 Mike Bostock
 
@@ -6595,7 +7143,7 @@ CONDITIONS OF ANY KIND, either express or implied. See the License for the
 specific language governing permissions and limitations under the License.
 
 ------------------------------------------------------------------------------
-[117] Applies to: npm:d3-shape@1.3.7
+[129] Applies to: npm:d3-shape@1.3.7
 ------------------------------------------------------------------------------
 Copyright 2010-2015 Mike Bostock
 All rights reserved.
@@ -6626,7 +7174,7 @@ ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
 SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 ------------------------------------------------------------------------------
-[118] Applies to: npm:dagre-d3-es@7.0.14
+[130] Applies to: npm:dagre-d3-es@7.0.14
 ------------------------------------------------------------------------------
 Original dagre-d3 copyright: Copyright (c) 2013 Chris Pettitt
 Original dagre copyright: Copyright (c) 2012-2014 Chris Pettitt
@@ -6653,7 +7201,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[119] Applies to: npm:dayjs@1.11.21
+[131] Applies to: npm:dayjs@1.11.21
 ------------------------------------------------------------------------------
 MIT License
 
@@ -6678,7 +7226,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
 ------------------------------------------------------------------------------
-[120] Applies to: npm:debug@2.6.9
+[132] Applies to: npm:debug@2.6.9
 ------------------------------------------------------------------------------
 (The MIT License)
 
@@ -6700,7 +7248,7 @@ WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN 
 SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[121] Applies to: npm:debug@4.4.3
+[133] Applies to: npm:debug@4.4.3
 ------------------------------------------------------------------------------
 (The MIT License)
 
@@ -6723,7 +7271,7 @@ WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN 
 SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[122] Applies to: npm:decamelize@1.2.0, npm:object-assign@4.1.1, npm:path-exists@3.0.0, npm:strip-json-comments@2.0.1
+[134] Applies to: npm:decamelize@1.2.0, npm:object-assign@4.1.1, npm:path-exists@3.0.0, npm:path-is-absolute@1.0.1, npm:strip-json-comments@2.0.1
 ------------------------------------------------------------------------------
 The MIT License (MIT)
 
@@ -6748,7 +7296,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[123] Applies to: npm:decode-named-character-reference@1.3.0, npm:hast-util-from-parse5@8.0.3, npm:hast-util-to-jsx-runtime@2.3.6, npm:hastscript@9.0.1, npm:lowlight@3.3.0, npm:markdown-table@3.0.4, npm:mdast-util-find-and-replace@3.0.2, npm:mdast-util-from-markdown@2.0.3, npm:mdast-util-gfm@3.1.0, npm:mdast-util-gfm-footnote@2.1.0, npm:mdast-util-to-markdown@2.1.2, npm:micromark@4.0.2, npm:micromark-core-commonmark@2.0.3, npm:micromark-extension-gfm-table@2.1.1, npm:micromark-factory-destination@2.0.1, npm:micromark-factory-label@2.0.1, npm:micromark-factory-space@2.0.1, npm:micromark-factory-title@2.0.1, npm:micromark-factory-whitespace@2.0.1, npm:micromark-util-character@2.1.1, npm:micromark-util-chunked@2.0.1, npm:micromark-util-classify-character@2.0.1, npm:micromark-util-combine-extensions@2.0.1, npm:micromark-util-decode-numeric-character-reference@2.0.2, npm:micromark-util-decode-string@2.0.1, npm:micromark-util-encode@2.0.1, npm:micromark-util-html-tag-name@2.0.1, npm:micromark-util-normalize-identifier@2.0.1, npm:micromark-util-resolve-all@2.0.1, npm:micromark-util-sanitize-uri@2.0.1, npm:micromark-util-subtokenize@2.1.0, npm:micromark-util-symbol@2.0.1, npm:micromark-util-types@2.0.2, npm:rehype-highlight@7.0.2, npm:remark-gfm@4.0.1, npm:remark-rehype@11.1.2, npm:vfile-message@4.0.3
+[135] Applies to: npm:decode-named-character-reference@1.3.0, npm:hast-util-from-parse5@8.0.3, npm:hast-util-to-jsx-runtime@2.3.6, npm:hastscript@9.0.1, npm:lowlight@3.3.0, npm:markdown-table@3.0.4, npm:mdast-util-find-and-replace@3.0.2, npm:mdast-util-from-markdown@2.0.3, npm:mdast-util-gfm@3.1.0, npm:mdast-util-gfm-footnote@2.1.0, npm:mdast-util-to-markdown@2.1.2, npm:micromark@4.0.2, npm:micromark-core-commonmark@2.0.3, npm:micromark-extension-gfm-table@2.1.1, npm:micromark-factory-destination@2.0.1, npm:micromark-factory-label@2.0.1, npm:micromark-factory-space@2.0.1, npm:micromark-factory-title@2.0.1, npm:micromark-factory-whitespace@2.0.1, npm:micromark-util-character@2.1.1, npm:micromark-util-chunked@2.0.1, npm:micromark-util-classify-character@2.0.1, npm:micromark-util-combine-extensions@2.0.1, npm:micromark-util-decode-numeric-character-reference@2.0.2, npm:micromark-util-decode-string@2.0.1, npm:micromark-util-encode@2.0.1, npm:micromark-util-html-tag-name@2.0.1, npm:micromark-util-normalize-identifier@2.0.1, npm:micromark-util-resolve-all@2.0.1, npm:micromark-util-sanitize-uri@2.0.1, npm:micromark-util-subtokenize@2.1.0, npm:micromark-util-symbol@2.0.1, npm:micromark-util-types@2.0.2, npm:rehype-highlight@7.0.2, npm:remark-gfm@4.0.1, npm:remark-rehype@11.1.2, npm:vfile-message@4.0.3
 ------------------------------------------------------------------------------
 (The MIT License)
 
@@ -6774,7 +7322,7 @@ TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
 SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[124] Applies to: npm:deep-extend@0.6.0
+[136] Applies to: npm:deep-extend@0.6.0
 ------------------------------------------------------------------------------
 The MIT License (MIT)
 
@@ -6798,7 +7346,7 @@ IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
 CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[125] Applies to: npm:delaunator@5.1.0
+[137] Applies to: npm:delaunator@5.1.0
 ------------------------------------------------------------------------------
 ISC License
 
@@ -6817,7 +7365,7 @@ TORTIOUS ACTION, ARISING OUT OF OR IN CONNECTION WITH THE USE OR PERFORMANCE OF
 THIS SOFTWARE.
 
 ------------------------------------------------------------------------------
-[126] Applies to: npm:depd@2.0.0
+[138] Applies to: npm:depd@2.0.0
 ------------------------------------------------------------------------------
 (The MIT License)
 
@@ -6843,7 +7391,7 @@ TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
 SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[127] Applies to: npm:dequal@2.0.3, npm:mri@1.2.0
+[139] Applies to: npm:dequal@2.0.3, npm:mri@1.2.0
 ------------------------------------------------------------------------------
 The MIT License (MIT)
 
@@ -6868,7 +7416,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[128] Applies to: npm:detect-libc@2.1.2
+[140] Applies to: npm:detect-libc@2.1.2
 ------------------------------------------------------------------------------
 Apache License
                            Version 2.0, January 2004
@@ -7073,7 +7621,7 @@ Apache License
    limitations under the License.
 
 ------------------------------------------------------------------------------
-[129] Applies to: npm:detect-node-es@1.1.0
+[141] Applies to: npm:detect-node-es@1.1.0
 ------------------------------------------------------------------------------
 MIT License
 
@@ -7098,7 +7646,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
 ------------------------------------------------------------------------------
-[130] Applies to: npm:devlop@1.1.0
+[142] Applies to: npm:devlop@1.1.0
 ------------------------------------------------------------------------------
 (The MIT License)
 
@@ -7124,7 +7672,7 @@ TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
 SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[131] Applies to: npm:diff@8.0.4
+[143] Applies to: npm:diff@8.0.4
 ------------------------------------------------------------------------------
 BSD 3-Clause License
 
@@ -7157,7 +7705,7 @@ OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 ------------------------------------------------------------------------------
-[132] Applies to: npm:dijkstrajs@1.0.3
+[144] Applies to: npm:dijkstrajs@1.0.3
 ------------------------------------------------------------------------------
 ```
 Dijkstra path-finding functions. Adapted from the Dijkstar Python project.
@@ -7180,7 +7728,7 @@ THE SOFTWARE.
 ```
 
 ------------------------------------------------------------------------------
-[133] Applies to: npm:dingtalk-stream@v2.1.5
+[145] Applies to: npm:dingtalk-stream@v2.1.5
 ------------------------------------------------------------------------------
 MIT License
 
@@ -7205,7 +7753,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
 ------------------------------------------------------------------------------
-[134] Applies to: npm:discord-api-types@0.38.50
+[146] Applies to: npm:discord-api-types@0.38.50
 ------------------------------------------------------------------------------
 MIT License
 
@@ -7230,7 +7778,32 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
 ------------------------------------------------------------------------------
-[135] Applies to: npm:dompurify@3.4.12
+[147] Applies to: npm:docx@9.7.1
+------------------------------------------------------------------------------
+The MIT License (MIT)
+
+Copyright (c) 2016 Dolan
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+
+------------------------------------------------------------------------------
+[148] Applies to: npm:dompurify@3.4.12
 ------------------------------------------------------------------------------
 Apache License
                            Version 2.0, January 2004
@@ -7809,7 +8382,7 @@ Exhibit B - "Incompatible With Secondary Licenses" Notice
   defined by the Mozilla Public License, v. 2.0.
 
 ------------------------------------------------------------------------------
-[136] Applies to: npm:dunder-proto@1.0.1, npm:math-intrinsics@1.1.0
+[149] Applies to: npm:dunder-proto@1.0.1, npm:math-intrinsics@1.1.0
 ------------------------------------------------------------------------------
 MIT License
 
@@ -7834,7 +8407,37 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
 ------------------------------------------------------------------------------
-[137] Applies to: npm:ecdsa-sig-formatter@1.0.11
+[150] Applies to: npm:duplexer2@0.1.4
+------------------------------------------------------------------------------
+Copyright (c) 2013, Deoxxa Development
+======================================
+All rights reserved.
+--------------------
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+1. Redistributions of source code must retain the above copyright
+   notice, this list of conditions and the following disclaimer.
+2. Redistributions in binary form must reproduce the above copyright
+   notice, this list of conditions and the following disclaimer in the
+   documentation and/or other materials provided with the distribution.
+3. Neither the name of Deoxxa Development nor the names of its contributors
+   may be used to endorse or promote products derived from this software
+   without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY DEOXXA DEVELOPMENT ''AS IS'' AND ANY
+EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL DEOXXA DEVELOPMENT BE LIABLE FOR ANY
+DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+(INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+------------------------------------------------------------------------------
+[151] Applies to: npm:ecdsa-sig-formatter@1.0.11
 ------------------------------------------------------------------------------
 Apache License
                            Version 2.0, January 2004
@@ -8039,7 +8642,7 @@ Apache License
    limitations under the License.
 
 ------------------------------------------------------------------------------
-[138] Applies to: npm:ee-first@1.1.1
+[152] Applies to: npm:ee-first@1.1.1
 ------------------------------------------------------------------------------
 The MIT License (MIT)
 
@@ -8064,7 +8667,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[139] Applies to: npm:electron-squirrel-startup@1.0.1
+[153] Applies to: npm:electron-squirrel-startup@1.0.1
 ------------------------------------------------------------------------------
 Apache License
 Version 2.0, January 2004
@@ -8269,7 +8872,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 
 ------------------------------------------------------------------------------
-[140] Applies to: npm:electron-window-state@5.0.3
+[154] Applies to: npm:electron-window-state@5.0.3
 ------------------------------------------------------------------------------
 The MIT License (MIT)
 
@@ -8295,7 +8898,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[141] Applies to: npm:emoji-regex@8.0.0, npm:emoji-regex@9.2.2, npm:punycode@2.3.1
+[155] Applies to: npm:emoji-regex@8.0.0, npm:emoji-regex@9.2.2, npm:punycode@2.3.1
 ------------------------------------------------------------------------------
 Copyright Mathias Bynens <https://mathiasbynens.be/>
 
@@ -8319,7 +8922,7 @@ OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
 WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[142] Applies to: npm:encodeurl@2.0.0
+[156] Applies to: npm:encodeurl@2.0.0
 ------------------------------------------------------------------------------
 (The MIT License)
 
@@ -8345,7 +8948,7 @@ TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
 SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[143] Applies to: npm:end-of-stream@1.4.5, npm:pump@3.0.4, npm:tar-fs@2.1.5, npm:tar-stream@2.2.0
+[157] Applies to: npm:end-of-stream@1.4.5, npm:pump@3.0.4, npm:tar-fs@2.1.5, npm:tar-stream@2.2.0
 ------------------------------------------------------------------------------
 The MIT License (MIT)
 
@@ -8370,7 +8973,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[144] Applies to: npm:entities@6.0.1
+[158] Applies to: npm:entities@6.0.1
 ------------------------------------------------------------------------------
 Copyright (c) Felix Böhm
 All rights reserved.
@@ -8385,7 +8988,7 @@ THIS IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRE
 EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 ------------------------------------------------------------------------------
-[145] Applies to: npm:es-set-tostringtag@2.1.0
+[159] Applies to: npm:es-set-tostringtag@2.1.0
 ------------------------------------------------------------------------------
 MIT License
 
@@ -8410,7 +9013,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
 ------------------------------------------------------------------------------
-[146] Applies to: npm:es-toolkit@1.49.0
+[160] Applies to: npm:es-toolkit@1.49.0
 ------------------------------------------------------------------------------
 MIT License
 
@@ -8435,7 +9038,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
 ------------------------------------------------------------------------------
-[147] Applies to: npm:escape-html@1.0.3
+[161] Applies to: npm:escape-html@1.0.3
 ------------------------------------------------------------------------------
 (The MIT License)
 
@@ -8463,7 +9066,7 @@ TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
 SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[148] Applies to: npm:esprima@4.0.1
+[162] Applies to: npm:esprima@4.0.1
 ------------------------------------------------------------------------------
 Copyright JS Foundation and other contributors, https://js.foundation/
 
@@ -8488,7 +9091,7 @@ ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
 THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 ------------------------------------------------------------------------------
-[149] Applies to: npm:estree-util-is-identifier-name@3.0.0, npm:hast-util-heading-rank@3.0.0, npm:mdast-util-gfm-autolink-literal@2.0.1, npm:mdast-util-gfm-strikethrough@2.0.0, npm:mdast-util-gfm-table@2.0.0, npm:mdast-util-gfm-task-list-item@2.0.0, npm:mdast-util-math@3.0.0, npm:mdast-util-mdx-expression@2.0.1, npm:mdast-util-mdx-jsx@3.2.0, npm:mdast-util-mdxjs-esm@2.0.1, npm:micromark-extension-gfm@3.0.0, npm:micromark-extension-gfm-autolink-literal@2.1.0, npm:micromark-extension-gfm-strikethrough@2.1.0, npm:micromark-extension-gfm-tagfilter@2.0.0, npm:micromark-extension-gfm-task-list-item@2.1.0, npm:micromark-extension-math@3.1.0
+[163] Applies to: npm:estree-util-is-identifier-name@3.0.0, npm:hast-util-heading-rank@3.0.0, npm:mdast-util-gfm-autolink-literal@2.0.1, npm:mdast-util-gfm-strikethrough@2.0.0, npm:mdast-util-gfm-table@2.0.0, npm:mdast-util-gfm-task-list-item@2.0.0, npm:mdast-util-math@3.0.0, npm:mdast-util-mdx-expression@2.0.1, npm:mdast-util-mdx-jsx@3.2.0, npm:mdast-util-mdxjs-esm@2.0.1, npm:micromark-extension-gfm@3.0.0, npm:micromark-extension-gfm-autolink-literal@2.1.0, npm:micromark-extension-gfm-strikethrough@2.1.0, npm:micromark-extension-gfm-tagfilter@2.0.0, npm:micromark-extension-gfm-task-list-item@2.1.0, npm:micromark-extension-math@3.1.0
 ------------------------------------------------------------------------------
 (The MIT License)
 
@@ -8514,7 +9117,7 @@ TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
 SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[150] Applies to: npm:etag@1.8.1, npm:proxy-addr@2.0.7
+[164] Applies to: npm:etag@1.8.1, npm:proxy-addr@2.0.7
 ------------------------------------------------------------------------------
 (The MIT License)
 
@@ -8540,7 +9143,7 @@ TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
 SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[151] Applies to: npm:eventemitter3@5.0.4
+[165] Applies to: npm:eventemitter3@5.0.4
 ------------------------------------------------------------------------------
 The MIT License (MIT)
 
@@ -8565,7 +9168,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
 ------------------------------------------------------------------------------
-[152] Applies to: npm:eventsource@3.0.7
+[166] Applies to: npm:eventsource@3.0.7
 ------------------------------------------------------------------------------
 The MIT License
 
@@ -8591,7 +9194,7 @@ OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
 WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[153] Applies to: npm:eventsource-parser@3.1.0
+[167] Applies to: npm:eventsource-parser@3.1.0
 ------------------------------------------------------------------------------
 MIT License
 
@@ -8616,7 +9219,32 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
 ------------------------------------------------------------------------------
-[154] Applies to: npm:expand-template@2.0.3
+[168] Applies to: npm:exceljs@4.4.0
+------------------------------------------------------------------------------
+The MIT License (MIT)
+
+Copyright (c) 2014-2019 Guyon Roche
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+
+------------------------------------------------------------------------------
+[169] Applies to: npm:expand-template@2.0.3
 ------------------------------------------------------------------------------
 The MIT License (MIT)
 
@@ -8641,7 +9269,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[155] Applies to: npm:express@5.2.1
+[170] Applies to: npm:express@5.2.1
 ------------------------------------------------------------------------------
 (The MIT License)
 
@@ -8669,7 +9297,7 @@ TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
 SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[156] Applies to: npm:express-rate-limit@8.5.2
+[171] Applies to: npm:express-rate-limit@8.5.2
 ------------------------------------------------------------------------------
 # MIT License
 
@@ -8693,7 +9321,7 @@ IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
 CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[157] Applies to: npm:extend@3.0.2
+[172] Applies to: npm:extend@3.0.2
 ------------------------------------------------------------------------------
 The MIT License (MIT)
 
@@ -8719,7 +9347,7 @@ OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
 WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[158] Applies to: npm:extend-shallow@2.0.1
+[173] Applies to: npm:extend-shallow@2.0.1
 ------------------------------------------------------------------------------
 The MIT License (MIT)
 
@@ -8744,7 +9372,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[159] Applies to: npm:fast-deep-equal@3.1.3, npm:json-schema-traverse@1.0.0
+[174] Applies to: npm:fast-deep-equal@3.1.3, npm:json-schema-traverse@1.0.0
 ------------------------------------------------------------------------------
 MIT License
 
@@ -8769,7 +9397,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
 ------------------------------------------------------------------------------
-[160] Applies to: npm:fast-equals@5.4.1
+[175] Applies to: npm:fast-equals@5.4.1
 ------------------------------------------------------------------------------
 MIT License
 
@@ -8794,7 +9422,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
 ------------------------------------------------------------------------------
-[161] Applies to: npm:fast-uri@3.1.4
+[176] Applies to: npm:fast-uri@3.1.4
 ------------------------------------------------------------------------------
 Copyright (c) 2011-2021, Gary Court until https://github.com/garycourt/uri-js/commit/a1acf730b4bba3f1097c9f52e7d9d3aba8cdcaae
 Copyright (c) 2021-present The Fastify team <https://github.com/fastify/fastify#team>
@@ -8828,7 +9456,7 @@ The complete list of contributors can be found at:
 - https://github.com/garycourt/uri-js/graphs/contributors
 
 ------------------------------------------------------------------------------
-[162] Applies to: npm:fetch-blob@3.2.0
+[177] Applies to: npm:fetch-blob@3.2.0
 ------------------------------------------------------------------------------
 MIT License
 
@@ -8853,7 +9481,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
 ------------------------------------------------------------------------------
-[163] Applies to: npm:file-uri-to-path@1.0.0
+[178] Applies to: npm:file-uri-to-path@1.0.0
 ------------------------------------------------------------------------------
 Copyright (c) 2014 Nathan Rajlich <nathan@tootallnate.net>
 
@@ -8877,7 +9505,7 @@ TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
 SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[164] Applies to: npm:finalhandler@2.1.1
+[179] Applies to: npm:finalhandler@2.1.1
 ------------------------------------------------------------------------------
 (The MIT License)
 
@@ -8903,7 +9531,7 @@ TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
 SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[165] Applies to: npm:follow-redirects@1.16.0
+[180] Applies to: npm:follow-redirects@1.16.0
 ------------------------------------------------------------------------------
 Copyright 2014–present Olivier Lalonde <olalonde@gmail.com>, James Talmage <james@talmage.io>, Ruben Verborgh
 
@@ -8925,7 +9553,7 @@ WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR
 IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[166] Applies to: npm:foreground-child@3.3.1
+[181] Applies to: npm:foreground-child@3.3.1
 ------------------------------------------------------------------------------
 The ISC License
 
@@ -8944,7 +9572,7 @@ ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF OR
 IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
 
 ------------------------------------------------------------------------------
-[167] Applies to: npm:form-data@4.0.6
+[182] Applies to: npm:form-data@4.0.6
 ------------------------------------------------------------------------------
 Copyright (c) 2012 Felix Geisendörfer (felix@debuggable.com) and contributors
 
@@ -8967,7 +9595,7 @@ Copyright (c) 2012 Felix Geisendörfer (felix@debuggable.com) and contributors
  THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[168] Applies to: npm:formdata-polyfill@4.0.10
+[183] Applies to: npm:formdata-polyfill@4.0.10
 ------------------------------------------------------------------------------
 MIT License
 
@@ -8992,7 +9620,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
 ------------------------------------------------------------------------------
-[169] Applies to: npm:fresh@2.0.0
+[184] Applies to: npm:fresh@2.0.0
 ------------------------------------------------------------------------------
 (The MIT License)
 
@@ -9019,7 +9647,7 @@ TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
 SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[170] Applies to: npm:fs-constants@1.0.0
+[185] Applies to: npm:fs-constants@1.0.0
 ------------------------------------------------------------------------------
 The MIT License (MIT)
 
@@ -9044,7 +9672,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[171] Applies to: npm:fs-extra@11.3.6
+[186] Applies to: npm:fs-extra@11.3.6
 ------------------------------------------------------------------------------
 (The MIT License)
 
@@ -9063,7 +9691,54 @@ OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHE
  ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[172] Applies to: npm:function-bind@1.1.2
+[187] Applies to: npm:fs.realpath@1.0.0
+------------------------------------------------------------------------------
+The ISC License
+
+Copyright (c) Isaac Z. Schlueter and Contributors
+
+Permission to use, copy, modify, and/or distribute this software for any
+purpose with or without fee is hereby granted, provided that the above
+copyright notice and this permission notice appear in all copies.
+
+THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
+ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF OR
+IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+
+----
+
+This library bundles a version of the `fs.realpath` and `fs.realpathSync`
+methods from Node.js v0.10 under the terms of the Node.js MIT license.
+
+Node's license follows, also included at the header of `old.js` which contains
+the licensed code:
+
+  Copyright Joyent, Inc. and other Node contributors.
+
+  Permission is hereby granted, free of charge, to any person obtaining a
+  copy of this software and associated documentation files (the "Software"),
+  to deal in the Software without restriction, including without limitation
+  the rights to use, copy, modify, merge, publish, distribute, sublicense,
+  and/or sell copies of the Software, and to permit persons to whom the
+  Software is furnished to do so, subject to the following conditions:
+
+  The above copyright notice and this permission notice shall be included in
+  all copies or substantial portions of the Software.
+
+  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+  FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+  DEALINGS IN THE SOFTWARE.
+
+------------------------------------------------------------------------------
+[188] Applies to: npm:function-bind@1.1.2
 ------------------------------------------------------------------------------
 Copyright (c) 2013 Raynos.
 
@@ -9086,7 +9761,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[173] Applies to: npm:get-caller-file@2.0.5
+[189] Applies to: npm:get-caller-file@2.0.5
 ------------------------------------------------------------------------------
 ISC License (ISC)
 Copyright 2018 Stefan Penner
@@ -9096,7 +9771,7 @@ Permission to use, copy, modify, and/or distribute this software for any purpose
 THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
 
 ------------------------------------------------------------------------------
-[174] Applies to: npm:get-intrinsic@1.3.0
+[190] Applies to: npm:get-intrinsic@1.3.0
 ------------------------------------------------------------------------------
 MIT License
 
@@ -9121,7 +9796,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
 ------------------------------------------------------------------------------
-[175] Applies to: npm:get-nonce@1.0.1
+[191] Applies to: npm:get-nonce@1.0.1
 ------------------------------------------------------------------------------
 MIT License
 
@@ -9146,7 +9821,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
 ------------------------------------------------------------------------------
-[176] Applies to: npm:get-proto@1.0.1
+[192] Applies to: npm:get-proto@1.0.1
 ------------------------------------------------------------------------------
 MIT License
 
@@ -9171,29 +9846,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
 ------------------------------------------------------------------------------
-[177] Applies to: npm:github-from-package@0.0.0, npm:minimist@1.2.8
-------------------------------------------------------------------------------
-This software is released under the MIT license:
-
-Permission is hereby granted, free of charge, to any person obtaining a copy of
-this software and associated documentation files (the "Software"), to deal in
-the Software without restriction, including without limitation the rights to
-use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
-the Software, and to permit persons to whom the Software is furnished to do so,
-subject to the following conditions:
-
-The above copyright notice and this permission notice shall be included in all
-copies or substantial portions of the Software.
-
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
-FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
-COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
-IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
-CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
-
-------------------------------------------------------------------------------
-[178] Applies to: npm:github-slugger@2.0.0
+[193] Applies to: npm:github-slugger@2.0.0
 ------------------------------------------------------------------------------
 Copyright (c) 2015, Dan Flettre <fletd01@yahoo.com>
 
@@ -9202,7 +9855,7 @@ Permission to use, copy, modify, and/or distribute this software for any purpose
 THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
 
 ------------------------------------------------------------------------------
-[179] Applies to: npm:glob@10.5.0
+[194] Applies to: npm:glob@10.5.0
 ------------------------------------------------------------------------------
 The ISC License
 
@@ -9221,7 +9874,32 @@ ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF OR
 IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
 
 ------------------------------------------------------------------------------
-[180] Applies to: npm:gopd@1.2.0
+[195] Applies to: npm:glob@7.2.3
+------------------------------------------------------------------------------
+The ISC License
+
+Copyright (c) Isaac Z. Schlueter and Contributors
+
+Permission to use, copy, modify, and/or distribute this software for any
+purpose with or without fee is hereby granted, provided that the above
+copyright notice and this permission notice appear in all copies.
+
+THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
+ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF OR
+IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+
+## Glob Logo
+
+Glob's logo created by Tanya Brassie <http://tanyabrassie.com/>, licensed
+under a Creative Commons Attribution-ShareAlike 4.0 International License
+https://creativecommons.org/licenses/by-sa/4.0/
+
+------------------------------------------------------------------------------
+[196] Applies to: npm:gopd@1.2.0
 ------------------------------------------------------------------------------
 MIT License
 
@@ -9246,7 +9924,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
 ------------------------------------------------------------------------------
-[181] Applies to: npm:graceful-fs@4.2.11
+[197] Applies to: npm:graceful-fs@4.2.11
 ------------------------------------------------------------------------------
 The ISC License
 
@@ -9265,7 +9943,7 @@ ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF OR
 IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
 
 ------------------------------------------------------------------------------
-[182] Applies to: npm:gray-matter@4.0.3
+[198] Applies to: npm:gray-matter@4.0.3, npm:normalize-path@3.0.0
 ------------------------------------------------------------------------------
 The MIT License (MIT)
 
@@ -9290,7 +9968,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[183] Applies to: npm:gtoken@8.0.0
+[199] Applies to: npm:gtoken@8.0.0
 ------------------------------------------------------------------------------
 The MIT License (MIT)
 
@@ -9315,7 +9993,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[184] Applies to: npm:hachure-fill@0.5.2
+[200] Applies to: npm:hachure-fill@0.5.2
 ------------------------------------------------------------------------------
 MIT License
 
@@ -9340,7 +10018,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
 ------------------------------------------------------------------------------
-[185] Applies to: npm:harmonyos-sans-sc-webfont-splitted@1.1.0
+[201] Applies to: npm:harmonyos-sans-sc-webfont-splitted@1.1.0
 ------------------------------------------------------------------------------
 This is free and unencumbered software released into the public domain.
 
@@ -9368,7 +10046,7 @@ OTHER DEALINGS IN THE SOFTWARE.
 For more information, please refer to <https://unlicense.org>
 
 ------------------------------------------------------------------------------
-[186] Applies to: npm:has-symbols@1.1.0
+[202] Applies to: npm:has-symbols@1.1.0
 ------------------------------------------------------------------------------
 MIT License
 
@@ -9393,7 +10071,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
 ------------------------------------------------------------------------------
-[187] Applies to: npm:has-tostringtag@1.0.2
+[203] Applies to: npm:has-tostringtag@1.0.2
 ------------------------------------------------------------------------------
 MIT License
 
@@ -9418,7 +10096,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
 ------------------------------------------------------------------------------
-[188] Applies to: npm:hasown@2.0.4
+[204] Applies to: npm:hasown@2.0.4
 ------------------------------------------------------------------------------
 MIT License
 
@@ -9443,7 +10121,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
 ------------------------------------------------------------------------------
-[189] Applies to: npm:hast-util-from-dom@5.0.1
+[205] Applies to: npm:hast-util-from-dom@5.0.1
 ------------------------------------------------------------------------------
 (ISC License)
 
@@ -9462,7 +10140,7 @@ TORTIOUS ACTION, ARISING OUT OF OR IN CONNECTION WITH THE USE OR PERFORMANCE OF
 THIS SOFTWARE.
 
 ------------------------------------------------------------------------------
-[190] Applies to: npm:hast-util-from-html@2.0.3
+[206] Applies to: npm:hast-util-from-html@2.0.3
 ------------------------------------------------------------------------------
 (The MIT License)
 
@@ -9488,7 +10166,7 @@ TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
 SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[191] Applies to: npm:hast-util-from-html-isomorphic@2.0.0
+[207] Applies to: npm:hast-util-from-html-isomorphic@2.0.0
 ------------------------------------------------------------------------------
 (The MIT License)
 
@@ -9514,7 +10192,7 @@ TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
 SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[192] Applies to: npm:hast-util-to-string@3.0.1, npm:html-url-attributes@3.0.1
+[208] Applies to: npm:hast-util-to-string@3.0.1, npm:html-url-attributes@3.0.1
 ------------------------------------------------------------------------------
 (The MIT License)
 
@@ -9539,7 +10217,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[193] Applies to: npm:hast-util-to-text@4.0.2
+[209] Applies to: npm:hast-util-to-text@4.0.2
 ------------------------------------------------------------------------------
 (The MIT License)
 
@@ -9565,7 +10243,7 @@ TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
 SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[194] Applies to: npm:highlight.js@11.11.1
+[210] Applies to: npm:highlight.js@11.11.1
 ------------------------------------------------------------------------------
 BSD 3-Clause License
 
@@ -9598,7 +10276,7 @@ OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 ------------------------------------------------------------------------------
-[195] Applies to: npm:hono@4.12.30
+[211] Applies to: npm:hono@4.12.30
 ------------------------------------------------------------------------------
 MIT License
 
@@ -9623,7 +10301,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
 ------------------------------------------------------------------------------
-[196] Applies to: npm:html-to-image@1.11.13
+[212] Applies to: npm:html-to-image@1.11.13
 ------------------------------------------------------------------------------
 MIT License
 
@@ -9648,7 +10326,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
 ------------------------------------------------------------------------------
-[197] Applies to: npm:http-errors@2.0.1
+[213] Applies to: npm:http-errors@2.0.1
 ------------------------------------------------------------------------------
 The MIT License (MIT)
 
@@ -9674,7 +10352,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[198] Applies to: npm:human-signals@1.1.1, npm:human-signals@2.1.0
+[214] Applies to: npm:human-signals@1.1.1, npm:human-signals@2.1.0
 ------------------------------------------------------------------------------
 Apache License
                            Version 2.0, January 2004
@@ -9879,7 +10557,7 @@ Apache License
    limitations under the License.
 
 ------------------------------------------------------------------------------
-[199] Applies to: npm:i18next@26.3.6
+[215] Applies to: npm:i18next@26.3.6
 ------------------------------------------------------------------------------
 The MIT License (MIT)
 
@@ -9904,7 +10582,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
 ------------------------------------------------------------------------------
-[200] Applies to: npm:iconv-lite@0.6.3, npm:iconv-lite@0.7.3
+[216] Applies to: npm:iconv-lite@0.6.3, npm:iconv-lite@0.7.3
 ------------------------------------------------------------------------------
 Copyright (c) 2011 Alexander Shtuchkin
 
@@ -9928,7 +10606,7 @@ OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
 WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[201] Applies to: npm:ieee754@1.2.1
+[217] Applies to: npm:ieee754@1.2.1
 ------------------------------------------------------------------------------
 Copyright 2008 Fair Oaks Labs, Inc.
 
@@ -9943,7 +10621,7 @@ Redistribution and use in source and binary forms, with or without modification,
 THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 ------------------------------------------------------------------------------
-[202] Applies to: npm:ignore@7.0.6
+[218] Applies to: npm:ignore@7.0.6
 ------------------------------------------------------------------------------
 Copyright (c) 2013 Kael Zhang <i@kael.me>, contributors
 http://kael.me/
@@ -9968,7 +10646,20 @@ OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
 WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[203] Applies to: npm:immediate@3.0.6
+[219] Applies to: npm:image-size@1.2.1
+------------------------------------------------------------------------------
+The MIT License (MIT)
+
+Copyright © 2013-Present Aditya Yadav, http://netroy.in
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the “Software”), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+------------------------------------------------------------------------------
+[220] Applies to: npm:immediate@3.0.6
 ------------------------------------------------------------------------------
 Copyright (c) 2012 Barnesandnoble.com, llc, Donavon West, Domenic Denicola, Brian Cavalier
 
@@ -9992,7 +10683,7 @@ OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
 WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[204] Applies to: npm:import-meta-resolve@4.2.0
+[221] Applies to: npm:import-meta-resolve@4.2.0
 ------------------------------------------------------------------------------
 (The MIT License)
 
@@ -10070,7 +10761,26 @@ IN THE SOFTWARE.
 """
 
 ------------------------------------------------------------------------------
-[205] Applies to: npm:inherits@2.0.4
+[222] Applies to: npm:inflight@1.0.6
+------------------------------------------------------------------------------
+The ISC License
+
+Copyright (c) Isaac Z. Schlueter
+
+Permission to use, copy, modify, and/or distribute this software for any
+purpose with or without fee is hereby granted, provided that the above
+copyright notice and this permission notice appear in all copies.
+
+THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
+ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF OR
+IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+
+------------------------------------------------------------------------------
+[223] Applies to: npm:inherits@2.0.4
 ------------------------------------------------------------------------------
 The ISC License
 
@@ -10089,7 +10799,7 @@ OTHER TORTIOUS ACTION, ARISING OUT OF OR IN CONNECTION WITH THE USE OR
 PERFORMANCE OF THIS SOFTWARE.
 
 ------------------------------------------------------------------------------
-[206] Applies to: npm:inline-style-parser@0.2.7
+[224] Applies to: npm:inline-style-parser@0.2.7
 ------------------------------------------------------------------------------
 (The MIT License)
 
@@ -10102,7 +10812,7 @@ The above copyright notice and this permission notice shall be included in all c
 THE SOFTWARE IS PROVIDED 'AS IS', WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[207] Applies to: npm:internmap@1.0.1, npm:internmap@2.0.3
+[225] Applies to: npm:internmap@1.0.1, npm:internmap@2.0.3
 ------------------------------------------------------------------------------
 Copyright 2021 Mike Bostock
 
@@ -10119,7 +10829,7 @@ TORTIOUS ACTION, ARISING OUT OF OR IN CONNECTION WITH THE USE OR PERFORMANCE OF
 THIS SOFTWARE.
 
 ------------------------------------------------------------------------------
-[208] Applies to: npm:ip-address@10.2.0
+[226] Applies to: npm:ip-address@10.2.0
 ------------------------------------------------------------------------------
 Copyright (C) 2011 by Beau Gunderson
 
@@ -10142,7 +10852,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[209] Applies to: npm:ipaddr.js@1.9.1, npm:ipaddr.js@2.4.0
+[227] Applies to: npm:ipaddr.js@1.9.1, npm:ipaddr.js@2.4.0
 ------------------------------------------------------------------------------
 Copyright (C) 2011-2017 whitequark <whitequark@whitequark.org>
 
@@ -10165,7 +10875,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[210] Applies to: npm:is-buffer@1.1.6, npm:safe-buffer@5.1.2, npm:safe-buffer@5.2.1
+[228] Applies to: npm:is-buffer@1.1.6, npm:safe-buffer@5.1.2, npm:safe-buffer@5.2.1
 ------------------------------------------------------------------------------
 The MIT License (MIT)
 
@@ -10190,7 +10900,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[211] Applies to: npm:is-extendable@0.1.1
+[229] Applies to: npm:is-extendable@0.1.1
 ------------------------------------------------------------------------------
 The MIT License (MIT)
 
@@ -10215,7 +10925,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[212] Applies to: npm:is-extglob@2.1.1
+[230] Applies to: npm:is-extglob@2.1.1
 ------------------------------------------------------------------------------
 The MIT License (MIT)
 
@@ -10240,7 +10950,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[213] Applies to: npm:is-glob@4.0.3, npm:kind-of@6.0.3
+[231] Applies to: npm:is-glob@4.0.3, npm:kind-of@6.0.3
 ------------------------------------------------------------------------------
 The MIT License (MIT)
 
@@ -10265,7 +10975,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[214] Applies to: npm:is-promise@2.2.2, npm:is-promise@4.0.0
+[232] Applies to: npm:is-promise@2.2.2, npm:is-promise@4.0.0
 ------------------------------------------------------------------------------
 Copyright (c) 2014 Forbes Lindesay
 
@@ -10288,7 +10998,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[215] Applies to: npm:jackspeak@3.4.3
+[233] Applies to: npm:jackspeak@3.4.3
 ------------------------------------------------------------------------------
 # Blue Oak Model License
 
@@ -10347,7 +11057,7 @@ will be liable to anyone for any damages related to this
 software or this license, under any kind of legal claim._**
 
 ------------------------------------------------------------------------------
-[216] Applies to: npm:jose@6.2.3
+[234] Applies to: npm:jose@6.2.3
 ------------------------------------------------------------------------------
 The MIT License (MIT)
 
@@ -10372,7 +11082,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
 ------------------------------------------------------------------------------
-[217] Applies to: npm:js-base64@3.9.1
+[235] Applies to: npm:js-base64@3.9.1
 ------------------------------------------------------------------------------
 Copyright (c) 2014, Dan Kogai
 All rights reserved.
@@ -10403,7 +11113,7 @@ OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 ------------------------------------------------------------------------------
-[218] Applies to: npm:js-yaml@3.15.0, npm:js-yaml@4.3.0
+[236] Applies to: npm:js-yaml@3.15.0, npm:js-yaml@4.3.0
 ------------------------------------------------------------------------------
 (The MIT License)
 
@@ -10428,7 +11138,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[219] Applies to: npm:json-bigint@1.0.0
+[237] Applies to: npm:json-bigint@1.0.0
 ------------------------------------------------------------------------------
 The MIT License (MIT)
 
@@ -10452,7 +11162,7 @@ IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
 CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[220] Applies to: npm:json-schema-to-ts@3.1.1, npm:ts-algebra@2.0.0
+[238] Applies to: npm:json-schema-to-ts@3.1.1, npm:ts-algebra@2.0.0
 ------------------------------------------------------------------------------
 MIT License
 
@@ -10477,7 +11187,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
 ------------------------------------------------------------------------------
-[221] Applies to: npm:json-schema-typed@7.0.3
+[239] Applies to: npm:json-schema-typed@7.0.3
 ------------------------------------------------------------------------------
 BSD-2-Clause License
 
@@ -10507,7 +11217,7 @@ ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 POSSIBILITY OF SUCH DAMAGE.
 
 ------------------------------------------------------------------------------
-[222] Applies to: npm:json-schema-typed@8.0.2
+[240] Applies to: npm:json-schema-typed@8.0.2
 ------------------------------------------------------------------------------
 BSD 2-Clause License
 
@@ -10568,7 +11278,7 @@ ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
 SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 ------------------------------------------------------------------------------
-[223] Applies to: npm:jsonfile@4.0.0, npm:jsonfile@6.2.1
+[241] Applies to: npm:jsonfile@4.0.0, npm:jsonfile@6.2.1
 ------------------------------------------------------------------------------
 (The MIT License)
 
@@ -10587,7 +11297,7 @@ OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHE
  ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[224] Applies to: npm:jszip@3.10.1
+[242] Applies to: npm:jszip@3.10.1
 ------------------------------------------------------------------------------
 JSZip is dual licensed. At your choice you may use it under the MIT license *or* the GPLv3
 license.
@@ -11242,7 +11952,7 @@ copy of the Program in return for a fee.
                      END OF TERMS AND CONDITIONS
 
 ------------------------------------------------------------------------------
-[225] Applies to: npm:jwa@2.0.1, npm:jws@4.0.1
+[243] Applies to: npm:jwa@2.0.1, npm:jws@4.0.1
 ------------------------------------------------------------------------------
 Copyright (c) 2013 Brian J. Brennan
 
@@ -11263,7 +11973,7 @@ FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TOR
 ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[226] Applies to: npm:katex@0.16.47
+[244] Applies to: npm:katex@0.16.47
 ------------------------------------------------------------------------------
 The MIT License (MIT)
 
@@ -11288,7 +11998,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
 ------------------------------------------------------------------------------
-[227] Applies to: npm:khroma@2.1.0
+[245] Applies to: npm:khroma@2.1.0
 ------------------------------------------------------------------------------
 The MIT License (MIT)
 
@@ -11313,7 +12023,7 @@ FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
 DEALINGS IN THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[228] Applies to: npm:layout-base@1.0.2, npm:layout-base@2.0.1
+[246] Applies to: npm:layout-base@1.0.2, npm:layout-base@2.0.1
 ------------------------------------------------------------------------------
 MIT License
 
@@ -11338,7 +12048,33 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
 ------------------------------------------------------------------------------
-[229] Applies to: npm:lie@3.3.0
+[247] Applies to: npm:lazystream@1.0.1
+------------------------------------------------------------------------------
+Copyright (c) 2013 J. Pommerening, contributors.
+
+Permission is hereby granted, free of charge, to any person
+obtaining a copy of this software and associated documentation
+files (the "Software"), to deal in the Software without
+restriction, including without limitation the rights to use,
+copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the
+Software is furnished to do so, subject to the following
+conditions:
+
+The above copyright notice and this permission notice shall be
+included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
+OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+OTHER DEALINGS IN THE SOFTWARE.
+
+------------------------------------------------------------------------------
+[248] Applies to: npm:lie@3.3.0
 ------------------------------------------------------------------------------
 #Copyright (c) 2014-2018 Calvin Metcalf, Jordan Harband
 
@@ -11349,7 +12085,16 @@ The above copyright notice and this permission notice shall be included in all c
 **THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.**
 
 ------------------------------------------------------------------------------
-[230] Applies to: npm:lodash@4.18.1, npm:lodash-es@4.18.1, npm:lodash.merge@4.6.2
+[249] Applies to: npm:listenercount@1.0.1
+------------------------------------------------------------------------------
+Copyright (c) MMXV jden <jason@denizac.org>
+
+Permission to use, copy, modify, and/or distribute this software for any purpose with or without fee is hereby granted, provided that the above copyright notice and this permission notice appear in all copies.
+
+THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+
+------------------------------------------------------------------------------
+[250] Applies to: npm:lodash@4.18.1, npm:lodash-es@4.18.1, npm:lodash.merge@4.6.2
 ------------------------------------------------------------------------------
 Copyright OpenJS Foundation and other contributors <https://openjsf.org/>
 
@@ -11400,33 +12145,7 @@ licenses; we recommend you read them, as their terms may differ from the
 terms above.
 
 ------------------------------------------------------------------------------
-[231] Applies to: npm:lodash.identity@3.0.0
-------------------------------------------------------------------------------
-Copyright 2012-2015 The Dojo Foundation <http://dojofoundation.org/>
-Based on Underscore.js 1.7.0, copyright 2009-2015 Jeremy Ashkenas,
-DocumentCloud and Investigative Reporters & Editors <http://underscorejs.org/>
-
-Permission is hereby granted, free of charge, to any person obtaining
-a copy of this software and associated documentation files (the
-"Software"), to deal in the Software without restriction, including
-without limitation the rights to use, copy, modify, merge, publish,
-distribute, sublicense, and/or sell copies of the Software, and to
-permit persons to whom the Software is furnished to do so, subject to
-the following conditions:
-
-The above copyright notice and this permission notice shall be
-included in all copies or substantial portions of the Software.
-
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
-EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
-MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
-NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
-LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
-OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
-WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
-
-------------------------------------------------------------------------------
-[232] Applies to: npm:lodash.pickby@4.6.0, npm:lodash.snakecase@4.1.1
+[251] Applies to: npm:lodash.defaults@4.2.0, npm:lodash.difference@4.5.0, npm:lodash.escaperegexp@4.1.2, npm:lodash.flatten@4.4.0, npm:lodash.groupby@4.6.0, npm:lodash.isplainobject@4.0.6, npm:lodash.pickby@4.6.0, npm:lodash.snakecase@4.1.1, npm:lodash.union@4.6.0, npm:lodash.uniq@4.5.0
 ------------------------------------------------------------------------------
 Copyright jQuery Foundation and other contributors <https://jquery.org/>
 
@@ -11477,7 +12196,136 @@ licenses; we recommend you read them, as their terms may differ from the
 terms above.
 
 ------------------------------------------------------------------------------
-[233] Applies to: npm:longest-streak@3.1.0, npm:stringify-entities@4.0.4, npm:trim-lines@3.0.1
+[252] Applies to: npm:lodash.identity@3.0.0
+------------------------------------------------------------------------------
+Copyright 2012-2015 The Dojo Foundation <http://dojofoundation.org/>
+Based on Underscore.js 1.7.0, copyright 2009-2015 Jeremy Ashkenas,
+DocumentCloud and Investigative Reporters & Editors <http://underscorejs.org/>
+
+Permission is hereby granted, free of charge, to any person obtaining
+a copy of this software and associated documentation files (the
+"Software"), to deal in the Software without restriction, including
+without limitation the rights to use, copy, modify, merge, publish,
+distribute, sublicense, and/or sell copies of the Software, and to
+permit persons to whom the Software is furnished to do so, subject to
+the following conditions:
+
+The above copyright notice and this permission notice shall be
+included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+------------------------------------------------------------------------------
+[253] Applies to: npm:lodash.isboolean@3.0.3, npm:lodash.isnil@4.0.0
+------------------------------------------------------------------------------
+Copyright 2012-2016 The Dojo Foundation <http://dojofoundation.org/>
+Based on Underscore.js, copyright 2009-2016 Jeremy Ashkenas,
+DocumentCloud and Investigative Reporters & Editors <http://underscorejs.org/>
+
+Permission is hereby granted, free of charge, to any person obtaining
+a copy of this software and associated documentation files (the
+"Software"), to deal in the Software without restriction, including
+without limitation the rights to use, copy, modify, merge, publish,
+distribute, sublicense, and/or sell copies of the Software, and to
+permit persons to whom the Software is furnished to do so, subject to
+the following conditions:
+
+The above copyright notice and this permission notice shall be
+included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+------------------------------------------------------------------------------
+[254] Applies to: npm:lodash.isequal@4.5.0, npm:lodash.isfunction@3.0.9
+------------------------------------------------------------------------------
+Copyright JS Foundation and other contributors <https://js.foundation/>
+
+Based on Underscore.js, copyright Jeremy Ashkenas,
+DocumentCloud and Investigative Reporters & Editors <http://underscorejs.org/>
+
+This software consists of voluntary contributions made by many
+individuals. For exact contribution history, see the revision history
+available at https://github.com/lodash/lodash
+
+The following license applies to all parts of this software except as
+documented below:
+
+====
+
+Permission is hereby granted, free of charge, to any person obtaining
+a copy of this software and associated documentation files (the
+"Software"), to deal in the Software without restriction, including
+without limitation the rights to use, copy, modify, merge, publish,
+distribute, sublicense, and/or sell copies of the Software, and to
+permit persons to whom the Software is furnished to do so, subject to
+the following conditions:
+
+The above copyright notice and this permission notice shall be
+included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+====
+
+Copyright and related rights for sample code are waived via CC0. Sample
+code is defined as all source code displayed within the prose of the
+documentation.
+
+CC0: http://creativecommons.org/publicdomain/zero/1.0/
+
+====
+
+Files located in the node_modules and vendor directories are externally
+maintained libraries used by this software which have their own
+licenses; we recommend you read them, as their terms may differ from the
+terms above.
+
+------------------------------------------------------------------------------
+[255] Applies to: npm:lodash.isundefined@3.0.1
+------------------------------------------------------------------------------
+Copyright 2012-2015 The Dojo Foundation <http://dojofoundation.org/>
+Based on Underscore.js, copyright 2009-2015 Jeremy Ashkenas,
+DocumentCloud and Investigative Reporters & Editors <http://underscorejs.org/>
+
+Permission is hereby granted, free of charge, to any person obtaining
+a copy of this software and associated documentation files (the
+"Software"), to deal in the Software without restriction, including
+without limitation the rights to use, copy, modify, merge, publish,
+distribute, sublicense, and/or sell copies of the Software, and to
+permit persons to whom the Software is furnished to do so, subject to
+the following conditions:
+
+The above copyright notice and this permission notice shall be
+included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+------------------------------------------------------------------------------
+[256] Applies to: npm:longest-streak@3.1.0, npm:stringify-entities@4.0.4, npm:trim-lines@3.0.1
 ------------------------------------------------------------------------------
 (The MIT License)
 
@@ -11503,7 +12351,7 @@ TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
 SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[234] Applies to: npm:loudness@0.4.2
+[257] Applies to: npm:loudness@0.4.2
 ------------------------------------------------------------------------------
 The MIT License (MIT)
 
@@ -11527,7 +12375,7 @@ IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
 CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[235] Applies to: npm:lru-cache@10.4.3
+[258] Applies to: npm:lru-cache@10.4.3
 ------------------------------------------------------------------------------
 The ISC License
 
@@ -11546,7 +12394,7 @@ ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF OR
 IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
 
 ------------------------------------------------------------------------------
-[236] Applies to: npm:lucide-react@0.468.0
+[259] Applies to: npm:lucide-react@0.468.0
 ------------------------------------------------------------------------------
 ISC License
 
@@ -11565,7 +12413,7 @@ ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
 OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
 
 ------------------------------------------------------------------------------
-[237] Applies to: npm:magic-bytes.js@1.13.0
+[260] Applies to: npm:magic-bytes.js@1.13.0
 ------------------------------------------------------------------------------
 MIT License
 
@@ -11590,7 +12438,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
 ------------------------------------------------------------------------------
-[238] Applies to: npm:marked@16.4.2
+[261] Applies to: npm:marked@16.4.2
 ------------------------------------------------------------------------------
 # License information
 
@@ -11638,7 +12486,7 @@ Redistribution and use in source and binary forms, with or without modification,
 This software is provided by the copyright holders and contributors “as is” and any express or implied warranties, including, but not limited to, the implied warranties of merchantability and fitness for a particular purpose are disclaimed. In no event shall the copyright owner or contributors be liable for any direct, indirect, incidental, special, exemplary, or consequential damages (including, but not limited to, procurement of substitute goods or services; loss of use, data, or profits; or business interruption) however caused and on any theory of liability, whether in contract, strict liability, or tort (including negligence or otherwise) arising in any way out of the use of this software, even if advised of the possibility of such damage.
 
 ------------------------------------------------------------------------------
-[239] Applies to: npm:md5@2.3.0
+[262] Applies to: npm:md5@2.3.0
 ------------------------------------------------------------------------------
 Copyright © 2011-2012, Paul Vorbach.
 Copyright © 2009, Jeff Mott.
@@ -11669,7 +12517,7 @@ ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
 SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 ------------------------------------------------------------------------------
-[240] Applies to: npm:mdast-util-phrasing@4.1.0
+[263] Applies to: npm:mdast-util-phrasing@4.1.0
 ------------------------------------------------------------------------------
 (The MIT License)
 
@@ -11696,7 +12544,7 @@ TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
 SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[241] Applies to: npm:mdast-util-to-markdown-cjk-friendly@1.0.0, npm:remark-cjk-friendly@2.3.1
+[264] Applies to: npm:mdast-util-to-markdown-cjk-friendly@1.0.0, npm:remark-cjk-friendly@2.3.1
 ------------------------------------------------------------------------------
 Copyright (c) 2025 Tatsunori Uchino <tats.u@live.jp>
 
@@ -11728,7 +12576,7 @@ TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
 SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[242] Applies to: npm:merge-descriptors@2.0.0
+[265] Applies to: npm:merge-descriptors@2.0.0
 ------------------------------------------------------------------------------
 MIT License
 
@@ -11743,7 +12591,7 @@ The above copyright notice and this permission notice shall be included in all c
 THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[243] Applies to: npm:merge-stream@2.0.0
+[266] Applies to: npm:merge-stream@2.0.0
 ------------------------------------------------------------------------------
 The MIT License (MIT)
 
@@ -11768,7 +12616,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[244] Applies to: npm:mermaid@11.16.0
+[267] Applies to: npm:mermaid@11.16.0
 ------------------------------------------------------------------------------
 The MIT License (MIT)
 
@@ -11793,7 +12641,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
 ------------------------------------------------------------------------------
-[245] Applies to: npm:micromark-extension-cjk-friendly@2.0.1
+[268] Applies to: npm:micromark-extension-cjk-friendly@2.0.1
 ------------------------------------------------------------------------------
 Copyright (c) 2025 Tatsunori Uchino <tats.u@live.jp>
 
@@ -11825,7 +12673,7 @@ TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
 SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[246] Applies to: npm:micromark-extension-cjk-friendly-util@3.0.1
+[269] Applies to: npm:micromark-extension-cjk-friendly-util@3.0.1
 ------------------------------------------------------------------------------
 Copyright (c) 2025 Tatsunori Uchino <tats.u@live.jp>
 
@@ -11857,7 +12705,7 @@ TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
 SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[247] Applies to: npm:micromark-extension-gfm-footnote@2.1.0
+[270] Applies to: npm:micromark-extension-gfm-footnote@2.1.0
 ------------------------------------------------------------------------------
 (The MIT License)
 
@@ -11883,7 +12731,7 @@ TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
 SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[248] Applies to: npm:mime-db@1.52.0, npm:mime-db@1.54.0
+[271] Applies to: npm:mime-db@1.52.0, npm:mime-db@1.54.0
 ------------------------------------------------------------------------------
 (The MIT License)
 
@@ -11910,7 +12758,24 @@ TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
 SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[249] Applies to: npm:minimatch@9.0.9, npm:rimraf@5.0.10
+[272] Applies to: npm:minimalistic-assert@1.0.1
+------------------------------------------------------------------------------
+Copyright 2015 Calvin Metcalf
+
+Permission to use, copy, modify, and/or distribute this software for any purpose
+with or without fee is hereby granted, provided that the above copyright notice
+and this permission notice appear in all copies.
+
+THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES WITH
+REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF MERCHANTABILITY AND
+FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY SPECIAL, DIRECT,
+INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES WHATSOEVER RESULTING FROM
+LOSS OF USE, DATA OR PROFITS, WHETHER IN AN ACTION OF CONTRACT, NEGLIGENCE
+OR OTHER TORTIOUS ACTION, ARISING OUT OF OR IN CONNECTION WITH THE USE OR
+PERFORMANCE OF THIS SOFTWARE.
+
+------------------------------------------------------------------------------
+[273] Applies to: npm:minimatch@5.1.9, npm:minimatch@9.0.9, npm:rimraf@5.0.10
 ------------------------------------------------------------------------------
 The ISC License
 
@@ -11929,7 +12794,7 @@ ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF OR
 IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
 
 ------------------------------------------------------------------------------
-[250] Applies to: npm:minipass@7.1.3, npm:path-scurry@1.11.1, npm:tar@7.5.22
+[274] Applies to: npm:minipass@7.1.3, npm:path-scurry@1.11.1, npm:sax@1.6.0, npm:tar@7.5.22
 ------------------------------------------------------------------------------
 # Blue Oak Model License
 
@@ -11988,7 +12853,7 @@ will be liable to anyone for any damages related to this
 software or this license, under any kind of legal claim.***
 
 ------------------------------------------------------------------------------
-[251] Applies to: npm:minizlib@3.1.0
+[275] Applies to: npm:minizlib@3.1.0
 ------------------------------------------------------------------------------
 Minizlib was created by Isaac Z. Schlueter.
 It is a derivative work of the Node.js project.
@@ -12018,7 +12883,7 @@ SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 """
 
 ------------------------------------------------------------------------------
-[252] Applies to: npm:mkdirp@0.5.6
+[276] Applies to: npm:mkdirp@0.5.6
 ------------------------------------------------------------------------------
 Copyright 2010 James Halliday (mail@substack.net)
 
@@ -12043,7 +12908,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[253] Applies to: npm:mkdirp-classic@0.5.3
+[277] Applies to: npm:mkdirp-classic@0.5.3
 ------------------------------------------------------------------------------
 The MIT License (MIT)
 
@@ -12068,7 +12933,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[254] Applies to: npm:ms@2.0.0
+[278] Applies to: npm:ms@2.0.0
 ------------------------------------------------------------------------------
 The MIT License (MIT)
 
@@ -12093,7 +12958,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
 ------------------------------------------------------------------------------
-[255] Applies to: npm:ms@2.1.3
+[279] Applies to: npm:ms@2.1.3
 ------------------------------------------------------------------------------
 The MIT License (MIT)
 
@@ -12118,7 +12983,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
 ------------------------------------------------------------------------------
-[256] Applies to: npm:nan@2.28.0
+[280] Applies to: npm:nan@2.28.0
 ------------------------------------------------------------------------------
 The MIT License (MIT)
 
@@ -12131,7 +12996,31 @@ The above copyright notice and this permission notice shall be included in all c
 THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[257] Applies to: npm:napi-build-utils@2.0.0
+[281] Applies to: npm:nanoid@5.1.16
+------------------------------------------------------------------------------
+The MIT License (MIT)
+
+Copyright 2017 Andrey Sitnik <andrey@sitnik.es>
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of
+this software and associated documentation files (the "Software"), to deal in
+the Software without restriction, including without limitation the rights to
+use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+the Software, and to permit persons to whom the Software is furnished to do so,
+subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+------------------------------------------------------------------------------
+[282] Applies to: npm:napi-build-utils@2.0.0
 ------------------------------------------------------------------------------
 MIT License
 
@@ -12156,7 +13045,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
 ------------------------------------------------------------------------------
-[258] Applies to: npm:negotiator@1.0.0
+[283] Applies to: npm:negotiator@1.0.0
 ------------------------------------------------------------------------------
 (The MIT License)
 
@@ -12184,7 +13073,7 @@ TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
 SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[259] Applies to: npm:node-abi@3.94.0
+[284] Applies to: npm:node-abi@3.94.0
 ------------------------------------------------------------------------------
 MIT License
 
@@ -12209,7 +13098,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
 ------------------------------------------------------------------------------
-[260] Applies to: npm:node-addon-api@7.1.1
+[285] Applies to: npm:node-addon-api@7.1.1
 ------------------------------------------------------------------------------
 The MIT License (MIT)
 
@@ -12222,7 +13111,7 @@ The above copyright notice and this permission notice shall be included in all c
 THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[261] Applies to: npm:node-domexception@1.0.0
+[286] Applies to: npm:node-domexception@1.0.0
 ------------------------------------------------------------------------------
 MIT License
 
@@ -12247,7 +13136,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
 ------------------------------------------------------------------------------
-[262] Applies to: npm:node-fetch@3.3.2
+[287] Applies to: npm:node-fetch@3.3.2
 ------------------------------------------------------------------------------
 The MIT License (MIT)
 
@@ -12272,7 +13161,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
 ------------------------------------------------------------------------------
-[263] Applies to: npm:node-machine-id@1.1.12
+[288] Applies to: npm:node-machine-id@1.1.12
 ------------------------------------------------------------------------------
 The MIT License (MIT)
 
@@ -12297,7 +13186,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
 ------------------------------------------------------------------------------
-[264] Applies to: npm:node-pty@1.1.0
+[289] Applies to: npm:node-pty@1.1.0
 ------------------------------------------------------------------------------
 Copyright (c) 2012-2015, Christopher Jeffrey (https://github.com/chjj/)
 
@@ -12370,7 +13259,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
 ------------------------------------------------------------------------------
-[265] Applies to: npm:object-inspect@1.13.4
+[290] Applies to: npm:object-inspect@1.13.4
 ------------------------------------------------------------------------------
 MIT License
 
@@ -12395,7 +13284,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
 ------------------------------------------------------------------------------
-[266] Applies to: npm:on-finished@2.4.1
+[291] Applies to: npm:on-finished@2.4.1
 ------------------------------------------------------------------------------
 (The MIT License)
 
@@ -12422,7 +13311,7 @@ TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
 SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[267] Applies to: npm:orderedmap@2.1.1, npm:w3c-keyname@2.2.8
+[292] Applies to: npm:orderedmap@2.1.1, npm:w3c-keyname@2.2.8
 ------------------------------------------------------------------------------
 Copyright (C) 2016 by Marijn Haverbeke <marijn@haverbeke.berlin> and others
 
@@ -12445,7 +13334,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[268] Applies to: npm:package-manager-detector@1.7.0
+[293] Applies to: npm:package-manager-detector@1.7.0
 ------------------------------------------------------------------------------
 MIT License
 
@@ -12470,7 +13359,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
 ------------------------------------------------------------------------------
-[269] Applies to: npm:pako@1.0.11
+[294] Applies to: npm:pako@1.0.11
 ------------------------------------------------------------------------------
 (The MIT License)
 
@@ -12495,7 +13384,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[270] Applies to: npm:parse-entities@4.0.2, npm:property-information@7.2.0
+[295] Applies to: npm:parse-entities@4.0.2, npm:property-information@7.2.0
 ------------------------------------------------------------------------------
 (The MIT License)
 
@@ -12521,7 +13410,7 @@ TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
 SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[271] Applies to: npm:parse5@7.3.0
+[296] Applies to: npm:parse5@7.3.0
 ------------------------------------------------------------------------------
 Copyright (c) 2013-2019 Ivan Nikulin (ifaaan@gmail.com, https://github.com/inikulin)
 
@@ -12544,7 +13433,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[272] Applies to: npm:parseurl@1.3.3
+[297] Applies to: npm:parseurl@1.3.3
 ------------------------------------------------------------------------------
 (The MIT License)
 
@@ -12571,7 +13460,7 @@ TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
 SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[273] Applies to: npm:path-data-parser@0.1.0, npm:points-on-curve@0.2.0
+[298] Applies to: npm:path-data-parser@0.1.0, npm:points-on-curve@0.2.0
 ------------------------------------------------------------------------------
 MIT License
 
@@ -12596,7 +13485,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
 ------------------------------------------------------------------------------
-[274] Applies to: npm:path-to-regexp@8.4.2
+[299] Applies to: npm:path-to-regexp@8.4.2
 ------------------------------------------------------------------------------
 The MIT License (MIT)
 
@@ -12621,7 +13510,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[275] Applies to: npm:pdfjs-dist@5.7.284
+[300] Applies to: npm:pdfjs-dist@5.7.284
 ------------------------------------------------------------------------------
 Apache License
                            Version 2.0, January 2004
@@ -12801,7 +13690,7 @@ Apache License
    END OF TERMS AND CONDITIONS
 
 ------------------------------------------------------------------------------
-[276] Applies to: npm:picomatch@4.0.5
+[301] Applies to: npm:picomatch@4.0.5
 ------------------------------------------------------------------------------
 The MIT License (MIT)
 
@@ -12826,7 +13715,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[277] Applies to: npm:pkce-challenge@5.0.1
+[302] Applies to: npm:pkce-challenge@5.0.1
 ------------------------------------------------------------------------------
 MIT License
 
@@ -12851,7 +13740,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
 ------------------------------------------------------------------------------
-[278] Applies to: npm:playwright-core@1.60.0
+[303] Applies to: npm:playwright-core@1.60.0
 ------------------------------------------------------------------------------
 Apache License
                            Version 2.0, January 2004
@@ -13057,7 +13946,7 @@ Apache License
    limitations under the License.
 
 ------------------------------------------------------------------------------
-[279] Applies to: npm:playwright-core@1.60.0 (NOTICE)
+[304] Applies to: npm:playwright-core@1.60.0 (NOTICE)
 ------------------------------------------------------------------------------
 NOTICE for npm:playwright-core@1.60.0:
 
@@ -13068,7 +13957,7 @@ This software contains code derived from the Puppeteer project (https://github.c
 available under the Apache 2.0 license (https://github.com/puppeteer/puppeteer/blob/master/LICENSE).
 
 ------------------------------------------------------------------------------
-[280] Applies to: npm:pngjs@5.0.0
+[305] Applies to: npm:pngjs@5.0.0
 ------------------------------------------------------------------------------
 pngjs2 original work Copyright (c) 2015 Luke Page & Original Contributors
 pngjs derived work Copyright (c) 2012 Kuba Niegowski
@@ -13092,7 +13981,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[281] Applies to: npm:points-on-path@0.2.1
+[306] Applies to: npm:points-on-path@0.2.1
 ------------------------------------------------------------------------------
 MIT License
 
@@ -13117,7 +14006,32 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
 ------------------------------------------------------------------------------
-[282] Applies to: npm:prebuild-install@7.1.3
+[307] Applies to: npm:pptxgenjs@4.0.1
+------------------------------------------------------------------------------
+The MIT License (MIT)
+
+Copyright (c) 2015-2022 Brent Ely
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+
+------------------------------------------------------------------------------
+[308] Applies to: npm:prebuild-install@7.1.3
 ------------------------------------------------------------------------------
 The MIT License (MIT)
 
@@ -13142,7 +14056,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[283] Applies to: npm:process-nextick-args@2.0.1
+[309] Applies to: npm:process-nextick-args@2.0.1
 ------------------------------------------------------------------------------
 # Copyright (c) 2015 Calvin Metcalf
 
@@ -13165,7 +14079,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.**
 
 ------------------------------------------------------------------------------
-[284] Applies to: npm:promise-worker-transferable@1.0.4
+[310] Applies to: npm:promise-worker-transferable@1.0.4
 ------------------------------------------------------------------------------
 Apache License
                           Version 2.0, January 2004
@@ -13370,7 +14284,7 @@ Apache License
   limitations under the License.
 
 ------------------------------------------------------------------------------
-[285] Applies to: npm:prosemirror-changeset@2.4.1
+[311] Applies to: npm:prosemirror-changeset@2.4.1
 ------------------------------------------------------------------------------
 Copyright (C) 2017 by Marijn Haverbeke <marijn@haverbeke.berlin> and others
 
@@ -13393,7 +14307,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[286] Applies to: npm:prosemirror-commands@1.7.1, npm:prosemirror-dropcursor@1.8.3, npm:prosemirror-gapcursor@1.4.1, npm:prosemirror-history@1.5.0, npm:prosemirror-inputrules@1.5.1, npm:prosemirror-keymap@1.2.3, npm:prosemirror-model@1.25.11, npm:prosemirror-schema-list@1.5.1, npm:prosemirror-state@1.4.4, npm:prosemirror-transform@1.12.0, npm:prosemirror-view@1.42.1
+[312] Applies to: npm:prosemirror-commands@1.7.1, npm:prosemirror-dropcursor@1.8.3, npm:prosemirror-gapcursor@1.4.1, npm:prosemirror-history@1.5.0, npm:prosemirror-inputrules@1.5.1, npm:prosemirror-keymap@1.2.3, npm:prosemirror-model@1.25.11, npm:prosemirror-schema-list@1.5.1, npm:prosemirror-state@1.4.4, npm:prosemirror-transform@1.12.0, npm:prosemirror-view@1.42.1
 ------------------------------------------------------------------------------
 Copyright (C) 2015-2017 by Marijn Haverbeke <marijn@haverbeke.berlin> and others
 
@@ -13416,7 +14330,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[287] Applies to: npm:prosemirror-tables@1.8.5
+[313] Applies to: npm:prosemirror-tables@1.8.5
 ------------------------------------------------------------------------------
 Copyright (C) 2015-2016 by Marijn Haverbeke <marijnh@gmail.com> and others
 
@@ -13439,7 +14353,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[288] Applies to: npm:protobufjs@7.6.5
+[314] Applies to: npm:protobufjs@7.6.5
 ------------------------------------------------------------------------------
 This license applies to all parts of protobuf.js except those files
 either explicitly including or referencing a different license or
@@ -13482,7 +14396,7 @@ standalone and requires a support library to be linked with it. This
 support library is itself covered by the above license.
 
 ------------------------------------------------------------------------------
-[289] Applies to: npm:proxy-from-env@2.1.0
+[315] Applies to: npm:proxy-from-env@2.1.0
 ------------------------------------------------------------------------------
 The MIT License
 
@@ -13506,7 +14420,7 @@ IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
 CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[290] Applies to: npm:qrcode@1.5.4
+[316] Applies to: npm:qrcode@1.5.4
 ------------------------------------------------------------------------------
 The MIT License (MIT)
 
@@ -13519,7 +14433,7 @@ The above copyright notice and this permission notice shall be included in all c
 THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[291] Applies to: npm:qs@6.15.3
+[317] Applies to: npm:qs@6.15.3
 ------------------------------------------------------------------------------
 BSD 3-Clause License
 
@@ -13552,7 +14466,19 @@ OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 ------------------------------------------------------------------------------
-[292] Applies to: npm:range-parser@1.3.0
+[318] Applies to: npm:queue@6.0.2
+------------------------------------------------------------------------------
+The MIT License (MIT)
+Copyright (c) 2014 Jesse Tane <jesse.tane@gmail.com>
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+------------------------------------------------------------------------------
+[319] Applies to: npm:range-parser@1.3.0
 ------------------------------------------------------------------------------
 (The MIT License)
 
@@ -13579,7 +14505,7 @@ TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
 SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[293] Applies to: npm:raw-body@3.0.2
+[320] Applies to: npm:raw-body@3.0.2
 ------------------------------------------------------------------------------
 The MIT License (MIT)
 
@@ -13605,7 +14531,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[294] Applies to: npm:rc@1.2.8
+[321] Applies to: npm:rc@1.2.8
 ------------------------------------------------------------------------------
 Apache License, Version 2.0
 
@@ -13676,7 +14602,7 @@ TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
 SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[295] Applies to: npm:react@19.2.3, npm:react-dom@19.2.3, npm:scheduler@0.27.0, npm:use-sync-external-store@1.6.0
+[322] Applies to: npm:react@19.2.3, npm:react-dom@19.2.3, npm:scheduler@0.27.0, npm:use-sync-external-store@1.6.0
 ------------------------------------------------------------------------------
 MIT License
 
@@ -13701,7 +14627,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
 ------------------------------------------------------------------------------
-[296] Applies to: npm:react-i18next@17.0.10
+[323] Applies to: npm:react-i18next@17.0.10
 ------------------------------------------------------------------------------
 The MIT License (MIT)
 
@@ -13726,7 +14652,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
 ------------------------------------------------------------------------------
-[297] Applies to: npm:react-markdown@10.1.0
+[324] Applies to: npm:react-markdown@10.1.0
 ------------------------------------------------------------------------------
 The MIT License (MIT)
 
@@ -13751,7 +14677,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
 ------------------------------------------------------------------------------
-[298] Applies to: npm:react-router@7.18.1, npm:react-router-dom@7.18.1
+[325] Applies to: npm:react-router@7.18.1, npm:react-router-dom@7.18.1
 ------------------------------------------------------------------------------
 MIT License
 
@@ -13778,7 +14704,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
 ------------------------------------------------------------------------------
-[299] Applies to: npm:readable-stream@2.3.8, npm:readable-stream@3.6.2, npm:string_decoder@1.1.1, npm:string_decoder@1.3.0
+[326] Applies to: npm:readable-stream@2.3.8, npm:readable-stream@3.6.2, npm:string_decoder@1.1.1, npm:string_decoder@1.3.0
 ------------------------------------------------------------------------------
 Node.js is licensed for use as follows:
 
@@ -13829,7 +14755,212 @@ IN THE SOFTWARE.
 """
 
 ------------------------------------------------------------------------------
-[300] Applies to: npm:remark-parse@11.0.0, npm:remark-stringify@11.0.0
+[327] Applies to: npm:readdir-glob@1.1.3
+------------------------------------------------------------------------------
+Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright 2020 Yann Armelin
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+
+------------------------------------------------------------------------------
+[328] Applies to: npm:remark-parse@11.0.0, npm:remark-stringify@11.0.0
 ------------------------------------------------------------------------------
 (The MIT License)
 
@@ -13854,7 +14985,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[301] Applies to: npm:require-directory@2.1.1
+[329] Applies to: npm:require-directory@2.1.1
 ------------------------------------------------------------------------------
 The MIT License (MIT)
 
@@ -13880,7 +15011,7 @@ TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
 SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[302] Applies to: npm:require-from-string@2.0.2
+[330] Applies to: npm:require-from-string@2.0.2
 ------------------------------------------------------------------------------
 The MIT License (MIT)
 
@@ -13905,7 +15036,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[303] Applies to: npm:require-main-filename@2.0.0, npm:set-blocking@2.0.0, npm:yargs-parser@18.1.3
+[331] Applies to: npm:require-main-filename@2.0.0, npm:set-blocking@2.0.0, npm:yargs-parser@18.1.3
 ------------------------------------------------------------------------------
 Copyright (c) 2016, Contributors
 
@@ -13923,35 +15054,7 @@ WHETHER IN AN ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION,
 ARISING OUT OF OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
 
 ------------------------------------------------------------------------------
-[304] Applies to: npm:robust-predicates@3.0.3, npm:tweetnacl@0.14.5
-------------------------------------------------------------------------------
-This is free and unencumbered software released into the public domain.
-
-Anyone is free to copy, modify, publish, use, compile, sell, or
-distribute this software, either in source code form or as a compiled
-binary, for any purpose, commercial or non-commercial, and by any
-means.
-
-In jurisdictions that recognize copyright laws, the author or authors
-of this software dedicate any and all copyright interest in the
-software to the public domain. We make this dedication for the benefit
-of the public at large and to the detriment of our heirs and
-successors. We intend this dedication to be an overt act of
-relinquishment in perpetuity of all present and future rights to this
-software under copyright law.
-
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
-EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
-MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
-IN NO EVENT SHALL THE AUTHORS BE LIABLE FOR ANY CLAIM, DAMAGES OR
-OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
-ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
-OTHER DEALINGS IN THE SOFTWARE.
-
-For more information, please refer to <http://unlicense.org>
-
-------------------------------------------------------------------------------
-[305] Applies to: npm:rope-sequence@1.3.4
+[332] Applies to: npm:rope-sequence@1.3.4
 ------------------------------------------------------------------------------
 Copyright (C) 2016 by Marijn Haverbeke <marijn@haverbeke.berlin>
 
@@ -13974,7 +15077,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[306] Applies to: npm:roughjs@4.6.6
+[333] Applies to: npm:roughjs@4.6.6
 ------------------------------------------------------------------------------
 MIT License
 
@@ -13999,7 +15102,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
 ------------------------------------------------------------------------------
-[307] Applies to: npm:router@2.2.0
+[334] Applies to: npm:router@2.2.0
 ------------------------------------------------------------------------------
 (The MIT License)
 
@@ -14026,7 +15129,7 @@ TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
 SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[308] Applies to: npm:rw@1.3.3
+[335] Applies to: npm:rw@1.3.3
 ------------------------------------------------------------------------------
 Copyright (c) 2014-2016, Michael Bostock
 All rights reserved.
@@ -14056,7 +15159,7 @@ NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE,
 EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 ------------------------------------------------------------------------------
-[309] Applies to: npm:safer-buffer@2.1.2
+[336] Applies to: npm:safer-buffer@2.1.2
 ------------------------------------------------------------------------------
 MIT License
 
@@ -14081,7 +15184,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
 ------------------------------------------------------------------------------
-[310] Applies to: npm:section-matter@1.0.0
+[337] Applies to: npm:section-matter@1.0.0
 ------------------------------------------------------------------------------
 The MIT License (MIT)
 
@@ -14106,7 +15209,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
 ------------------------------------------------------------------------------
-[311] Applies to: npm:send@1.2.1
+[338] Applies to: npm:send@1.2.1
 ------------------------------------------------------------------------------
 (The MIT License)
 
@@ -14133,7 +15236,7 @@ TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
 SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[312] Applies to: npm:serve-static@2.2.1
+[339] Applies to: npm:serve-static@2.2.1
 ------------------------------------------------------------------------------
 (The MIT License)
 
@@ -14162,7 +15265,7 @@ TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
 SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[313] Applies to: npm:set-cookie-parser@2.7.2
+[340] Applies to: npm:set-cookie-parser@2.7.2
 ------------------------------------------------------------------------------
 The MIT License (MIT)
 
@@ -14187,7 +15290,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[314] Applies to: npm:setimmediate@1.0.5
+[341] Applies to: npm:setimmediate@1.0.5
 ------------------------------------------------------------------------------
 Copyright (c) 2012 Barnesandnoble.com, llc, Donavon West, and Domenic Denicola
 
@@ -14211,7 +15314,7 @@ OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
 WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[315] Applies to: npm:setprototypeof@1.2.0
+[342] Applies to: npm:setprototypeof@1.2.0
 ------------------------------------------------------------------------------
 Copyright (c) 2015, Wes Todd
 
@@ -14228,7 +15331,7 @@ OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF OR IN
 CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
 
 ------------------------------------------------------------------------------
-[316] Applies to: npm:shebang-command@2.0.0
+[343] Applies to: npm:shebang-command@2.0.0
 ------------------------------------------------------------------------------
 MIT License
 
@@ -14241,7 +15344,7 @@ The above copyright notice and this permission notice shall be included in all c
 THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[317] Applies to: npm:side-channel@1.1.1, npm:side-channel-weakmap@1.0.2
+[344] Applies to: npm:side-channel@1.1.1, npm:side-channel-weakmap@1.0.2
 ------------------------------------------------------------------------------
 MIT License
 
@@ -14266,7 +15369,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
 ------------------------------------------------------------------------------
-[318] Applies to: npm:signal-exit@3.0.7
+[345] Applies to: npm:signal-exit@3.0.7
 ------------------------------------------------------------------------------
 The ISC License
 
@@ -14286,7 +15389,7 @@ WHETHER IN AN ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION,
 ARISING OUT OF OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
 
 ------------------------------------------------------------------------------
-[319] Applies to: npm:signal-exit@4.1.0
+[346] Applies to: npm:signal-exit@4.1.0
 ------------------------------------------------------------------------------
 The ISC License
 
@@ -14306,7 +15409,7 @@ WHETHER IN AN ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION,
 ARISING OUT OF OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
 
 ------------------------------------------------------------------------------
-[320] Applies to: npm:silk-wasm@3.7.1
+[347] Applies to: npm:silk-wasm@3.7.1
 ------------------------------------------------------------------------------
 MIT License
 
@@ -14331,7 +15434,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
 ------------------------------------------------------------------------------
-[321] Applies to: npm:simple-concat@1.0.1, npm:simple-get@4.0.1
+[348] Applies to: npm:simple-concat@1.0.1, npm:simple-get@4.0.1
 ------------------------------------------------------------------------------
 The MIT License (MIT)
 
@@ -14355,7 +15458,7 @@ IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
 CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[322] Applies to: npm:smol-toml@1.7.0
+[349] Applies to: npm:smol-toml@1.7.0
 ------------------------------------------------------------------------------
 Copyright (c) Squirrel Chat et al., All rights reserved.
 
@@ -14383,7 +15486,7 @@ OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 ------------------------------------------------------------------------------
-[323] Applies to: npm:sortablejs@1.15.7
+[350] Applies to: npm:sortablejs@1.15.7
 ------------------------------------------------------------------------------
 MIT License
 
@@ -14408,7 +15511,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
 ------------------------------------------------------------------------------
-[324] Applies to: npm:sprintf-js@1.0.3
+[351] Applies to: npm:sprintf-js@1.0.3
 ------------------------------------------------------------------------------
 Copyright (c) 2007-2014, Alexandru Marasteanu <hello [at) alexei (dot] ro>
 All rights reserved.
@@ -14436,7 +15539,7 @@ ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
 SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 ------------------------------------------------------------------------------
-[325] Applies to: npm:ssh-config@5.2.0
+[352] Applies to: npm:ssh-config@5.2.0
 ------------------------------------------------------------------------------
 MIT License
 
@@ -14461,7 +15564,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
 ------------------------------------------------------------------------------
-[326] Applies to: npm:statuses@2.0.2
+[353] Applies to: npm:statuses@2.0.2
 ------------------------------------------------------------------------------
 The MIT License (MIT)
 
@@ -14487,7 +15590,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[327] Applies to: npm:strip-bom-string@1.0.0
+[354] Applies to: npm:strip-bom-string@1.0.0
 ------------------------------------------------------------------------------
 The MIT License (MIT)
 
@@ -14512,7 +15615,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[328] Applies to: npm:style-mod@4.1.3
+[355] Applies to: npm:style-mod@4.1.3
 ------------------------------------------------------------------------------
 Copyright (C) 2018 by Marijn Haverbeke <marijn@haverbeke.berlin> and others
 
@@ -14535,7 +15638,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[329] Applies to: npm:style-to-js@1.1.21
+[356] Applies to: npm:style-to-js@1.1.21
 ------------------------------------------------------------------------------
 The MIT License (MIT)
 
@@ -14561,7 +15664,7 @@ OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
 WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[330] Applies to: npm:style-to-object@1.0.14
+[357] Applies to: npm:style-to-object@1.0.14
 ------------------------------------------------------------------------------
 The MIT License (MIT)
 
@@ -14587,7 +15690,7 @@ OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
 WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[331] Applies to: npm:stylis@4.4.0
+[358] Applies to: npm:stylis@4.4.0
 ------------------------------------------------------------------------------
 MIT License
 
@@ -14612,7 +15715,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
 ------------------------------------------------------------------------------
-[332] Applies to: npm:tailwind-merge@2.6.1
+[359] Applies to: npm:tailwind-merge@2.6.1
 ------------------------------------------------------------------------------
 MIT License
 
@@ -14637,7 +15740,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
 ------------------------------------------------------------------------------
-[333] Applies to: npm:tinyexec@1.2.4
+[360] Applies to: npm:tinyexec@1.2.4
 ------------------------------------------------------------------------------
 MIT License
 
@@ -14662,7 +15765,32 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
 ------------------------------------------------------------------------------
-[334] Applies to: npm:toidentifier@1.0.1
+[361] Applies to: npm:tmp@0.2.7
+------------------------------------------------------------------------------
+The MIT License (MIT)
+
+Copyright (c) 2014 KARASZI István
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+
+------------------------------------------------------------------------------
+[362] Applies to: npm:toidentifier@1.0.1
 ------------------------------------------------------------------------------
 MIT License
 
@@ -14687,7 +15815,35 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
 ------------------------------------------------------------------------------
-[335] Applies to: npm:trough@2.2.0
+[363] Applies to: npm:traverse@0.3.9
+------------------------------------------------------------------------------
+Copyright 2010 James Halliday (mail@substack.net)
+
+This project is free software released under the MIT/X11 license:
+http://www.opensource.org/licenses/mit-license.php
+
+Copyright 2010 James Halliday (mail@substack.net)
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+
+------------------------------------------------------------------------------
+[364] Applies to: npm:trough@2.2.0
 ------------------------------------------------------------------------------
 (The MIT License)
 
@@ -14712,7 +15868,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[336] Applies to: npm:ts-dedent@2.3.0
+[365] Applies to: npm:ts-dedent@2.3.0
 ------------------------------------------------------------------------------
 MIT License
 
@@ -14737,7 +15893,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
 ------------------------------------------------------------------------------
-[337] Applies to: npm:ts-mixer@6.0.4
+[366] Applies to: npm:ts-mixer@6.0.4
 ------------------------------------------------------------------------------
 MIT License
 
@@ -14762,7 +15918,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
 ------------------------------------------------------------------------------
-[338] Applies to: npm:tslib@2.8.1
+[367] Applies to: npm:tslib@2.8.1
 ------------------------------------------------------------------------------
 Copyright (c) Microsoft Corporation.
 
@@ -14778,7 +15934,7 @@ OTHER TORTIOUS ACTION, ARISING OUT OF OR IN CONNECTION WITH THE USE OR
 PERFORMANCE OF THIS SOFTWARE.
 
 ------------------------------------------------------------------------------
-[339] Applies to: npm:tslog@4.11.0
+[368] Applies to: npm:tslog@4.11.0
 ------------------------------------------------------------------------------
 MIT License
 
@@ -14803,7 +15959,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
 ------------------------------------------------------------------------------
-[340] Applies to: npm:tunnel-agent@0.6.0
+[369] Applies to: npm:tunnel-agent@0.6.0
 ------------------------------------------------------------------------------
 Apache License
 
@@ -14862,7 +16018,7 @@ If the Work includes a "NOTICE" text file as part of its distribution, then any 
 END OF TERMS AND CONDITIONS
 
 ------------------------------------------------------------------------------
-[341] Applies to: npm:type-fest@0.20.2
+[370] Applies to: npm:type-fest@0.20.2
 ------------------------------------------------------------------------------
 MIT License
 
@@ -14875,7 +16031,7 @@ The above copyright notice and this permission notice shall be included in all c
 THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[342] Applies to: npm:typebox@1.1.39
+[371] Applies to: npm:typebox@1.1.39
 ------------------------------------------------------------------------------
 TypeBox
 
@@ -14902,7 +16058,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[343] Applies to: npm:undici@6.27.0, npm:undici@8.7.0, npm:undici-types@7.24.6
+[372] Applies to: npm:undici@6.27.0, npm:undici@8.7.0, npm:undici-types@6.21.0, npm:undici-types@7.24.6
 ------------------------------------------------------------------------------
 MIT License
 
@@ -14927,7 +16083,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
 ------------------------------------------------------------------------------
-[344] Applies to: npm:unified@11.0.5, npm:vfile@6.0.3
+[373] Applies to: npm:unified@11.0.5, npm:vfile@6.0.3
 ------------------------------------------------------------------------------
 (The MIT License)
 
@@ -14952,7 +16108,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[345] Applies to: npm:unist-util-is@6.0.1
+[374] Applies to: npm:unist-util-is@6.0.1
 ------------------------------------------------------------------------------
 (The MIT license)
 
@@ -14978,7 +16134,7 @@ TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
 SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[346] Applies to: npm:universalify@2.0.1
+[375] Applies to: npm:universalify@2.0.1
 ------------------------------------------------------------------------------
 (The MIT License)
 
@@ -15002,7 +16158,7 @@ IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
 CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[347] Applies to: npm:unpipe@1.0.0
+[376] Applies to: npm:unpipe@1.0.0
 ------------------------------------------------------------------------------
 (The MIT License)
 
@@ -15028,7 +16184,36 @@ TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
 SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[348] Applies to: npm:uri-js@4.4.1
+[377] Applies to: npm:unzipper@0.10.14
+------------------------------------------------------------------------------
+Copyright (c) 2012 - 2013 Near Infinity Corporation
+
+Permission is hereby granted, free of charge, to any person obtaining
+a copy of this software and associated documentation files (the
+"Software"), to deal in the Software without restriction, including
+without limitation the rights to use, copy, modify, merge, publish,
+distribute, sublicense, and/or sell copies of the Software, and to
+permit persons to whom the Software is furnished to do so, subject to
+the following conditions:
+
+The above copyright notice and this permission notice shall be
+included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+---
+
+Commits in this fork are (c) Ziggy Jonsson (ziggy.jonsson.nyc@gmail.com)
+and fall under same licence structure as the original repo (MIT)
+
+------------------------------------------------------------------------------
+[378] Applies to: npm:uri-js@4.4.1
 ------------------------------------------------------------------------------
 Copyright 2011 Gary Court. All rights reserved.
 
@@ -15043,7 +16228,7 @@ THIS SOFTWARE IS PROVIDED BY GARY COURT "AS IS" AND ANY EXPRESS OR IMPLIED WARRA
 The views and conclusions contained in the software and documentation are those of the authors and should not be interpreted as representing official policies, either expressed or implied, of Gary Court.
 
 ------------------------------------------------------------------------------
-[349] Applies to: npm:url-template@2.0.8
+[379] Applies to: npm:url-template@2.0.8
 ------------------------------------------------------------------------------
 Copyright (c) 2012-2014, Bram Stein
 All rights reserved.
@@ -15072,7 +16257,7 @@ NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE,
 EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 ------------------------------------------------------------------------------
-[350] Applies to: npm:util-deprecate@1.0.2
+[380] Applies to: npm:util-deprecate@1.0.2
 ------------------------------------------------------------------------------
 (The MIT License)
 
@@ -15100,7 +16285,7 @@ FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
 OTHER DEALINGS IN THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[351] Applies to: npm:uuid@14.0.1
+[381] Applies to: npm:uuid@14.0.1, npm:uuid@8.3.2
 ------------------------------------------------------------------------------
 The MIT License (MIT)
 
@@ -15113,7 +16298,7 @@ The above copyright notice and this permission notice shall be included in all c
 THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[352] Applies to: npm:void-elements@3.1.0
+[382] Applies to: npm:void-elements@3.1.0
 ------------------------------------------------------------------------------
 (The MIT License)
 
@@ -15139,7 +16324,7 @@ TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
 SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[353] Applies to: npm:web-streams-polyfill@3.3.3
+[383] Applies to: npm:web-streams-polyfill@3.3.3
 ------------------------------------------------------------------------------
 The MIT License (MIT)
 
@@ -15165,7 +16350,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
 ------------------------------------------------------------------------------
-[354] Applies to: npm:which-module@2.0.1
+[384] Applies to: npm:which-module@2.0.1
 ------------------------------------------------------------------------------
 Copyright (c) 2016, Contributors
 
@@ -15182,7 +16367,7 @@ TORTIOUS ACTION, ARISING OUT OF OR IN CONNECTION WITH THE USE OR PERFORMANCE OF
 THIS SOFTWARE.
 
 ------------------------------------------------------------------------------
-[355] Applies to: npm:workerpool@9.1.1
+[385] Applies to: npm:workerpool@9.1.1
 ------------------------------------------------------------------------------
 Apache License
                            Version 2.0, January 2004
@@ -15387,7 +16572,7 @@ Apache License
    limitations under the License.
 
 ------------------------------------------------------------------------------
-[356] Applies to: npm:ws@8.21.1
+[386] Applies to: npm:ws@8.21.1
 ------------------------------------------------------------------------------
 Copyright (c) 2011 Einar Otto Stangvik <einaros@gmail.com>
 Copyright (c) 2013 Arnout Kazemier and contributors
@@ -15411,7 +16596,80 @@ IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
 CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[357] Applies to: npm:y18n@4.0.3
+[387] Applies to: npm:xml@1.0.1
+------------------------------------------------------------------------------
+(The MIT License)
+
+Copyright (c) 2011-2016 Dylan Greene <dylang@gmail.com>
+
+Permission is hereby granted, free of charge, to any person obtaining
+a copy of this software and associated documentation files (the
+'Software'), to deal in the Software without restriction, including
+without limitation the rights to use, copy, modify, merge, publish,
+distribute, sublicense, and/or sell copies of the Software, and to
+permit persons to whom the Software is furnished to do so, subject to
+the following conditions:
+
+The above copyright notice and this permission notice shall be
+included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED 'AS IS', WITHOUT WARRANTY OF ANY KIND,
+EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+------------------------------------------------------------------------------
+[388] Applies to: npm:xml-js@1.6.11
+------------------------------------------------------------------------------
+The MIT License (MIT)
+
+Copyright (c) 2016-2017 Yousuf Almarzooqi
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+
+------------------------------------------------------------------------------
+[389] Applies to: npm:xmlchars@2.2.0
+------------------------------------------------------------------------------
+Copyright Louis-Dominique Dubeau and contributors to xmlchars
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of
+this software and associated documentation files (the "Software"), to deal in
+the Software without restriction, including without limitation the rights to
+use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+the Software, and to permit persons to whom the Software is furnished to do so,
+subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+------------------------------------------------------------------------------
+[390] Applies to: npm:y18n@4.0.3
 ------------------------------------------------------------------------------
 Copyright (c) 2015, Contributors
 
@@ -15428,7 +16686,7 @@ TORTIOUS ACTION, ARISING OUT OF OR IN CONNECTION WITH THE USE OR PERFORMANCE OF
 THIS SOFTWARE.
 
 ------------------------------------------------------------------------------
-[358] Applies to: npm:yargs@15.4.1
+[391] Applies to: npm:yargs@15.4.1
 ------------------------------------------------------------------------------
 MIT License
 
@@ -15453,7 +16711,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[359] Applies to: npm:zod@4.3.6
+[392] Applies to: npm:zod@4.3.6
 ------------------------------------------------------------------------------
 MIT License
 
@@ -15478,7 +16736,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
 ------------------------------------------------------------------------------
-[360] Applies to: npm:zod-to-json-schema@3.25.2
+[393] Applies to: npm:zod-to-json-schema@3.25.2
 ------------------------------------------------------------------------------
 ISC License
 
@@ -15518,12 +16776,18 @@ Packages without a standalone license file (license per package.json):
 - npm:@sapphire/snowflake@3.5.5 (MIT)
 - npm:@wecom/aibot-node-sdk@1.0.7 (MIT)
 - npm:agent-base@6.0.2 (MIT)
+- npm:binary@0.3.0 (MIT)
+- npm:buffers@0.1.1 (MIT)
+- npm:chainsaw@0.1.0 (MIT)
 - npm:data-uri-to-buffer@4.0.1 (MIT)
 - npm:drizzle-orm@0.45.2 (Apache-2.0)
 - npm:eastasianwidth@0.2.0 (MIT)
+- npm:hash.js@1.1.7 (MIT)
 - npm:html-parse-stringify@3.0.1 (MIT)
+- npm:https@1.0.0 (ISC)
 - npm:https-proxy-agent@5.0.1 (MIT)
 - npm:isarray@1.0.0 (MIT)
 - npm:react-remove-scroll-bar@2.3.8 (MIT)
 - npm:rehype-katex@7.0.1 (MIT)
 - npm:remark-math@6.0.0 (MIT)
+- npm:saxes@5.0.1 (ISC)

--- a/docs/legal/notices/desktop-macos-restricted.txt
+++ b/docs/legal/notices/desktop-macos-restricted.txt
@@ -7,7 +7,7 @@ Cindy desktop application — macOS x64/arm64
 This file separately discloses components not distributed under open-source licenses.
 
 ------------------------------------------------------------------------------
-Claude Code CLI@2.1.219
+Claude Code CLI@2.1.259
 Category: proprietary
 License: LicenseRef-Anthropic-Commercial-Terms
 Source: https://www.anthropic.com/legal/commercial-terms

--- a/docs/legal/notices/desktop-macos.txt
+++ b/docs/legal/notices/desktop-macos.txt
@@ -259,7 +259,7 @@ Apache License
 Copyright (c) OpenAI
 
 ------------------------------------------------------------------------------
-pi coding agent (runtime-downloaded binary) 0.83.0
+pi coding agent (runtime-downloaded binary) 0.84.4
 License: MIT
 Source: https://github.com/earendil-works/pi
 ------------------------------------------------------------------------------
@@ -1107,12 +1107,16 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 
 ==============================================================================
-SECTION 2: npm packages (794 packages)
+SECTION 2: npm packages (865 packages)
 ==============================================================================
 
 - @antfu/install-pkg@1.1.0 — MIT — https://github.com/antfu/install-pkg
 - @anthropic-ai/sdk@0.91.1 — MIT — https://github.com/anthropics/anthropic-sdk-typescript
+- @babel/helper-string-parser@7.29.7 — MIT — https://github.com/babel/babel
+- @babel/helper-validator-identifier@7.29.7 — MIT — https://github.com/babel/babel
+- @babel/parser@7.29.7 — MIT — https://github.com/babel/babel
 - @babel/runtime@7.29.7 — MIT — https://github.com/babel/babel
+- @babel/types@7.29.7 — MIT — https://github.com/babel/babel
 - @braintree/sanitize-url@7.1.2 — MIT — https://github.com/braintree/sanitize-url
 - @chevrotain/types@11.1.2 — Apache-2.0 — https://github.com/Chevrotain/chevrotain
 - @chinese-fonts/font-contours@1.0.0 — ISC
@@ -1145,6 +1149,8 @@ SECTION 2: npm packages (794 packages)
 - @discordjs/rest@2.6.2 — Apache-2.0 — https://github.com/discordjs/discord.js
 - @discordjs/util@1.2.0 — Apache-2.0 — https://github.com/discordjs/discord.js
 - @discordjs/ws@1.2.3 — Apache-2.0 — https://github.com/discordjs/discord.js
+- @fast-csv/format@4.3.5 — MIT — https://github.com/C2FO/fast-csv
+- @fast-csv/parse@4.3.6 — MIT — https://github.com/C2FO/fast-csv
 - @floating-ui/core@1.8.0 — MIT — https://github.com/floating-ui/floating-ui
 - @floating-ui/dom@1.8.0 — MIT — https://github.com/floating-ui/floating-ui
 - @floating-ui/react-dom@2.1.9 — MIT — https://github.com/floating-ui/floating-ui
@@ -1307,6 +1313,8 @@ SECTION 2: npm packages (794 packages)
 - @types/katex@0.16.8 — MIT — https://github.com/DefinitelyTyped/DefinitelyTyped
 - @types/mdast@4.0.4 — MIT — https://github.com/DefinitelyTyped/DefinitelyTyped
 - @types/ms@2.1.0 — MIT — https://github.com/DefinitelyTyped/DefinitelyTyped
+- @types/node@14.18.63 — MIT — https://github.com/DefinitelyTyped/DefinitelyTyped
+- @types/node@22.20.1 — MIT — https://github.com/DefinitelyTyped/DefinitelyTyped
 - @types/node@25.9.5 — MIT — https://github.com/DefinitelyTyped/DefinitelyTyped
 - @types/trusted-types@2.0.7 — MIT — https://github.com/DefinitelyTyped/DefinitelyTyped
 - @types/unist@2.0.11 — MIT — https://github.com/DefinitelyTyped/DefinitelyTyped
@@ -1332,10 +1340,14 @@ SECTION 2: npm packages (794 packages)
 - ansi-regex@6.2.2 — MIT — https://github.com/chalk/ansi-regex
 - ansi-styles@4.3.0 — MIT — https://github.com/chalk/ansi-styles
 - ansi-styles@6.2.3 — MIT — https://github.com/chalk/ansi-styles
+- archiver@5.3.2 — MIT — https://github.com/archiverjs/node-archiver
+- archiver-utils@2.1.0 — MIT — https://github.com/archiverjs/archiver-utils
+- archiver-utils@3.0.4 — MIT — https://github.com/archiverjs/archiver-utils
 - argparse@1.0.10 — MIT — https://github.com/nodeca/argparse
 - argparse@2.0.1 — Python-2.0 — https://github.com/nodeca/argparse
 - aria-hidden@1.2.6 — MIT — https://github.com/theKashey/aria-hidden
 - asn1@0.2.6 — MIT — https://github.com/joyent/node-asn1
+- async@3.2.6 — MIT — https://github.com/caolan/async
 - asynckit@0.4.0 — MIT — https://github.com/alexindigo/asynckit
 - atomically@1.7.0 — MIT — https://github.com/fabiospampinato/atomically
 - axios@1.18.1 — MIT — https://github.com/axios/axios
@@ -1344,13 +1356,20 @@ SECTION 2: npm packages (794 packages)
 - base64-js@1.5.1 — MIT — https://github.com/beatgammit/base64-js
 - bcrypt-pbkdf@1.0.2 — BSD-3-Clause — https://github.com/joyent/node-bcrypt-pbkdf
 - better-sqlite3@12.11.1 — MIT — https://github.com/WiseLibs/better-sqlite3
+- big-integer@1.6.52 — Unlicense — https://github.com/peterolson/BigInteger.js
 - bignumber.js@9.3.1 — MIT — https://github.com/MikeMcl/bignumber.js
+- binary@0.3.0 — MIT — http://github.com/substack/node-binary
 - bindings@1.5.0 — MIT — https://github.com/TooTallNate/node-bindings
 - bl@4.1.0 — MIT — https://github.com/rvagg/bl
+- bluebird@3.4.7 — MIT — https://github.com/petkaantonov/bluebird
 - body-parser@2.3.0 — MIT — https://github.com/expressjs/body-parser
+- brace-expansion@1.1.16 — MIT — https://github.com/juliangruber/brace-expansion
 - brace-expansion@2.1.2 — MIT — https://github.com/juliangruber/brace-expansion
 - buffer@5.7.1 — MIT — https://github.com/feross/buffer
+- buffer-crc32@0.2.13 — MIT — https://github.com/brianloveswords/buffer-crc32
 - buffer-equal-constant-time@1.0.1 — BSD-3-Clause — https://github.com/goinstant/buffer-equal-constant-time
+- buffer-indexof-polyfill@1.0.2 — MIT — https://github.com/sarosia/buffer-indexof-polyfill
+- buffers@0.1.1 — MIT — http://github.com/substack/node-buffers
 - buildcheck@0.0.7 — MIT — http://github.com/mscdex/buildcheck
 - byte-size@8.2.1 — MIT — https://github.com/75lb/byte-size
 - bytes@3.1.2 — MIT — https://github.com/visionmedia/bytes.js
@@ -1358,6 +1377,7 @@ SECTION 2: npm packages (794 packages)
 - call-bound@1.0.4 — MIT — https://github.com/ljharb/call-bound
 - camelcase@5.3.1 — MIT — https://github.com/sindresorhus/camelcase
 - ccount@2.0.1 — MIT — https://github.com/wooorm/ccount
+- chainsaw@0.1.0 — MIT — http://github.com/substack/node-chainsaw
 - character-entities@2.0.2 — MIT — https://github.com/wooorm/character-entities
 - character-entities-html4@2.1.0 — MIT — https://github.com/wooorm/character-entities-html4
 - character-entities-legacy@3.0.0 — MIT — https://github.com/wooorm/character-entities-legacy
@@ -1374,6 +1394,8 @@ SECTION 2: npm packages (794 packages)
 - comma-separated-tokens@2.0.3 — MIT — https://github.com/wooorm/comma-separated-tokens
 - commander@7.2.0 — MIT — https://github.com/tj/commander.js
 - commander@8.3.0 — MIT — https://github.com/tj/commander.js
+- compress-commons@4.1.2 — MIT — https://github.com/archiverjs/node-compress-commons
+- concat-map@0.0.1 — MIT — https://github.com/substack/node-concat-map
 - conf@9.0.2 — MIT — https://github.com/sindresorhus/conf
 - content-disposition@1.1.0 — MIT — https://github.com/jshttp/content-disposition
 - content-type@1.0.5 — MIT — https://github.com/jshttp/content-type
@@ -1386,6 +1408,8 @@ SECTION 2: npm packages (794 packages)
 - cose-base@1.0.3 — MIT — https://github.com/iVis-at-Bilkent/cose-base
 - cose-base@2.2.0 — MIT — https://github.com/iVis-at-Bilkent/cose-base
 - cpu-features@0.0.10 — MIT — https://github.com/mscdex/cpu-features
+- crc-32@1.2.2 — Apache-2.0 — https://github.com/SheetJS/js-crc32
+- crc32-stream@4.0.3 — MIT — https://github.com/archiverjs/node-crc32-stream
 - crelt@1.0.7 — MIT — https://code.haverbeke.berlin/marijn/crelt
 - cross-spawn@7.0.6 — MIT — https://github.com/moxystudio/node-cross-spawn
 - crypt@0.0.2 — BSD-3-Clause — https://github.com/pvorb/node-crypt
@@ -1450,10 +1474,12 @@ SECTION 2: npm packages (794 packages)
 - dingtalk-stream@v2.1.5 — MIT — https://github.com/open-dingtalk/dingtalk-stream-sdk-nodejs
 - discord-api-types@0.38.50 — MIT — https://github.com/discordjs/discord-api-types
 - discord.js@14.27.0 — Apache-2.0 — https://github.com/discordjs/discord.js
+- docx@9.7.1 — MIT — https://github.com/dolanmiu/docx
 - dompurify@3.4.12 — (MPL-2.0 OR Apache-2.0) — https://github.com/cure53/DOMPurify
 - dot-prop@6.0.1 — MIT — https://github.com/sindresorhus/dot-prop
 - drizzle-orm@0.45.2 — Apache-2.0 — https://github.com/drizzle-team/drizzle-orm
 - dunder-proto@1.0.1 — MIT — https://github.com/es-shims/dunder-proto
+- duplexer2@0.1.4 — BSD-3-Clause — https://github.com/deoxxa/duplexer2
 - eastasianwidth@0.2.0 — MIT — https://github.com/komagata/eastasianwidth
 - ecdsa-sig-formatter@1.0.11 — Apache-2.0 — https://github.com/Brightspace/node-ecdsa-sig-formatter
 - ee-first@1.1.1 — MIT — https://github.com/jonathanong/ee-first
@@ -1479,6 +1505,7 @@ SECTION 2: npm packages (794 packages)
 - eventemitter3@5.0.4 — MIT — https://github.com/primus/eventemitter3
 - eventsource@3.0.7 — MIT — https://git@github.com/EventSource/eventsource
 - eventsource-parser@3.1.0 — MIT — https://github.com/rexxars/eventsource-parser
+- exceljs@4.4.0 — MIT — https://github.com/exceljs/exceljs
 - execa@4.1.0 — MIT — https://github.com/sindresorhus/execa
 - execa@5.1.1 — MIT — https://github.com/sindresorhus/execa
 - expand-template@2.0.3 — (MIT OR WTFPL) — https://github.com/ralphtheninja/expand-template
@@ -1486,6 +1513,7 @@ SECTION 2: npm packages (794 packages)
 - express-rate-limit@8.5.2 — MIT — https://github.com/express-rate-limit/express-rate-limit
 - extend@3.0.2 — MIT — https://github.com/justmoon/node-extend
 - extend-shallow@2.0.1 — MIT — https://github.com/jonschlinkert/extend-shallow
+- fast-csv@4.3.6 — MIT — https://github.com/C2FO/fast-csv
 - fast-deep-equal@3.1.3 — MIT — https://github.com/epoberezkin/fast-deep-equal
 - fast-equals@5.4.1 — MIT — https://github.com/planttheidea/fast-equals
 - fast-uri@3.1.4 — BSD-3-Clause — https://github.com/fastify/fast-uri
@@ -1503,6 +1531,8 @@ SECTION 2: npm packages (794 packages)
 - fresh@2.0.0 — MIT — https://github.com/jshttp/fresh
 - fs-constants@1.0.0 — MIT — https://github.com/mafintosh/fs-constants
 - fs-extra@11.3.6 — MIT — https://github.com/jprichardson/node-fs-extra
+- fs.realpath@1.0.0 — ISC — https://github.com/isaacs/fs.realpath
+- fstream@1.0.12 — ISC — https://github.com/npm/fstream
 - function-bind@1.1.2 — MIT — https://github.com/Raynos/function-bind
 - gaxios@7.1.3 — Apache-2.0 — https://github.com/googleapis/google-cloud-node-core
 - gaxios@7.2.0 — Apache-2.0 — https://github.com/googleapis/google-cloud-node
@@ -1518,6 +1548,7 @@ SECTION 2: npm packages (794 packages)
 - github-from-package@0.0.0 — MIT — https://github.com/substack/github-from-package
 - github-slugger@2.0.0 — ISC — https://github.com/Flet/github-slugger
 - glob@10.5.0 — ISC — https://github.com/isaacs/node-glob
+- glob@7.2.3 — ISC — https://github.com/isaacs/node-glob
 - google-auth-library@10.5.0 — Apache-2.0 — https://github.com/googleapis/google-auth-library-nodejs
 - google-auth-library@10.9.0 — Apache-2.0 — https://github.com/googleapis/google-cloud-node
 - google-logging-utils@1.1.3 — Apache-2.0 — https://github.com/googleapis/google-cloud-node-core
@@ -1530,6 +1561,7 @@ SECTION 2: npm packages (794 packages)
 - harmonyos-sans-sc-webfont-splitted@1.1.0 — Unlicense — https://github.com/SunsetMkt/HarmonyOS_Sans_SC_Webfont_Splitted
 - has-symbols@1.1.0 — MIT — https://github.com/inspect-js/has-symbols
 - has-tostringtag@1.0.2 — MIT — https://github.com/inspect-js/has-tostringtag
+- hash.js@1.1.7 — MIT — https://github.com/indutny/hash.js
 - hasown@2.0.4 — MIT — https://github.com/inspect-js/hasOwn
 - hast-util-from-dom@5.0.1 — ISC — https://github.com/syntax-tree/hast-util-from-dom
 - hast-util-from-html@2.0.3 — MIT — https://github.com/syntax-tree/hast-util-from-html
@@ -1549,6 +1581,7 @@ SECTION 2: npm packages (794 packages)
 - html-to-image@1.11.13 — MIT — https://github.com/bubkoo/html-to-image
 - html-url-attributes@3.0.1 — MIT — https://github.com/rehypejs/rehype-minify/tree/main/packages/html-url-attributes
 - http-errors@2.0.1 — MIT — https://github.com/jshttp/http-errors
+- https@1.0.0 — ISC
 - https-proxy-agent@5.0.1 — MIT — https://github.com/TooTallNate/node-https-proxy-agent
 - https-proxy-agent@7.0.6 — MIT — https://github.com/TooTallNate/proxy-agents
 - human-signals@1.1.1 — Apache-2.0 — https://github.com/ehmicky/human-signals
@@ -1558,8 +1591,10 @@ SECTION 2: npm packages (794 packages)
 - iconv-lite@0.7.3 — MIT — https://github.com/pillarjs/iconv-lite
 - ieee754@1.2.1 — BSD-3-Clause — https://github.com/feross/ieee754
 - ignore@7.0.6 — MIT — https://github.com/kaelzhang/node-ignore
+- image-size@1.2.1 — MIT — https://github.com/image-size/image-size
 - immediate@3.0.6 — MIT — https://github.com/calvinmetcalf/immediate
 - import-meta-resolve@4.2.0 — MIT — https://github.com/wooorm/import-meta-resolve
+- inflight@1.0.6 — ISC — https://github.com/npm/inflight
 - inherits@2.0.4 — ISC — https://github.com/isaacs/inherits
 - ini@1.3.8 — ISC — https://github.com/isaacs/ini
 - inline-style-parser@0.2.7 — MIT — https://github.com/remarkablemark/inline-style-parser
@@ -1605,8 +1640,10 @@ SECTION 2: npm packages (794 packages)
 - kind-of@6.0.3 — MIT — https://github.com/jonschlinkert/kind-of
 - layout-base@1.0.2 — MIT — https://github.com/iVis-at-Bilkent/layout-base
 - layout-base@2.0.1 — MIT — https://github.com/iVis-at-Bilkent/layout-base
+- lazystream@1.0.1 — MIT — https://github.com/jpommerening/node-lazystream
 - lcid@3.1.1 — MIT — https://github.com/sindresorhus/lcid
 - lie@3.3.0 — MIT — https://github.com/calvinmetcalf/lie
+- listenercount@1.0.1 — ISC — https://github.com/jden/node-listenercount
 - lit@3.3.3 — BSD-3-Clause — https://github.com/lit/lit
 - lit-element@4.2.2 — BSD-3-Clause — https://github.com/lit/lit
 - lit-html@3.3.3 — BSD-3-Clause — https://github.com/lit/lit
@@ -1614,10 +1651,23 @@ SECTION 2: npm packages (794 packages)
 - locate-path@5.0.0 — MIT — https://github.com/sindresorhus/locate-path
 - lodash@4.18.1 — MIT — https://github.com/lodash/lodash
 - lodash-es@4.18.1 — MIT — https://github.com/lodash/lodash
+- lodash.defaults@4.2.0 — MIT — https://github.com/lodash/lodash
+- lodash.difference@4.5.0 — MIT — https://github.com/lodash/lodash
+- lodash.escaperegexp@4.1.2 — MIT — https://github.com/lodash/lodash
+- lodash.flatten@4.4.0 — MIT — https://github.com/lodash/lodash
+- lodash.groupby@4.6.0 — MIT — https://github.com/lodash/lodash
 - lodash.identity@3.0.0 — MIT — https://github.com/lodash/lodash
+- lodash.isboolean@3.0.3 — MIT — https://github.com/lodash/lodash
+- lodash.isequal@4.5.0 — MIT — https://github.com/lodash/lodash
+- lodash.isfunction@3.0.9 — MIT — https://github.com/lodash/lodash
+- lodash.isnil@4.0.0 — MIT — https://github.com/lodash/lodash
+- lodash.isplainobject@4.0.6 — MIT — https://github.com/lodash/lodash
+- lodash.isundefined@3.0.1 — MIT — https://github.com/lodash/lodash
 - lodash.merge@4.6.2 — MIT — https://github.com/lodash/lodash
 - lodash.pickby@4.6.0 — MIT — https://github.com/lodash/lodash
 - lodash.snakecase@4.1.1 — MIT — https://github.com/lodash/lodash
+- lodash.union@4.6.0 — MIT — https://github.com/lodash/lodash
+- lodash.uniq@4.5.0 — MIT — https://github.com/lodash/lodash
 - long@5.3.2 — Apache-2.0 — https://github.com/dcodeIO/long.js
 - longest-streak@3.1.0 — MIT — https://github.com/wooorm/longest-streak
 - loudness@0.4.2 — MIT — https://github.com/LinusU/node-loudness
@@ -1689,6 +1739,9 @@ SECTION 2: npm packages (794 packages)
 - mimic-fn@2.1.0 — MIT — https://github.com/sindresorhus/mimic-fn
 - mimic-fn@3.1.0 — MIT — https://github.com/sindresorhus/mimic-fn
 - mimic-response@3.1.0 — MIT — https://github.com/sindresorhus/mimic-response
+- minimalistic-assert@1.0.1 — ISC — https://github.com/calvinmetcalf/minimalistic-assert
+- minimatch@3.1.5 — ISC — https://github.com/isaacs/minimatch
+- minimatch@5.1.9 — ISC — https://github.com/isaacs/minimatch
 - minimatch@9.0.9 — ISC — https://github.com/isaacs/minimatch
 - minimist@1.2.8 — MIT — https://github.com/minimistjs/minimist
 - minipass@7.1.3 — BlueOak-1.0.0 — https://github.com/isaacs/minipass
@@ -1699,6 +1752,7 @@ SECTION 2: npm packages (794 packages)
 - ms@2.0.0 — MIT — https://github.com/zeit/ms
 - ms@2.1.3 — MIT — https://github.com/vercel/ms
 - nan@2.28.0 — MIT — https://github.com/nodejs/nan
+- nanoid@5.1.16 — MIT — https://github.com/ai/nanoid
 - napi-build-utils@2.0.0 — MIT — https://github.com/inspiredware/napi-build-utils
 - negotiator@1.0.0 — MIT — https://github.com/jshttp/negotiator
 - node-abi@3.94.0 — MIT — https://github.com/electron/node-abi
@@ -1707,6 +1761,7 @@ SECTION 2: npm packages (794 packages)
 - node-fetch@3.3.2 — MIT — https://github.com/node-fetch/node-fetch
 - node-machine-id@1.1.12 — MIT — https://github.com/automation-stack/node-machine-id
 - node-pty@1.1.0 — MIT — https://github.com/microsoft/node-pty
+- normalize-path@3.0.0 — MIT — https://github.com/jonschlinkert/normalize-path
 - npm-run-path@4.0.1 — MIT — https://github.com/sindresorhus/npm-run-path
 - object-assign@4.1.1 — MIT — https://github.com/sindresorhus/object-assign
 - object-inspect@1.13.4 — MIT — https://github.com/inspect-js/object-inspect
@@ -1728,6 +1783,7 @@ SECTION 2: npm packages (794 packages)
 - path-data-parser@0.1.0 — MIT — https://github.com/pshihn/path-data-parser
 - path-exists@3.0.0 — MIT — https://github.com/sindresorhus/path-exists
 - path-exists@4.0.0 — MIT — https://github.com/sindresorhus/path-exists
+- path-is-absolute@1.0.1 — MIT — https://github.com/sindresorhus/path-is-absolute
 - path-key@3.1.1 — MIT — https://github.com/sindresorhus/path-key
 - path-scurry@1.11.1 — BlueOak-1.0.0 — https://github.com/isaacs/path-scurry
 - path-to-regexp@8.4.2 — MIT — https://github.com/pillarjs/path-to-regexp
@@ -1739,6 +1795,7 @@ SECTION 2: npm packages (794 packages)
 - pngjs@5.0.0 — MIT — https://github.com/lukeapage/pngjs
 - points-on-curve@0.2.0 — MIT — https://github.com/pshihn/bezier-points
 - points-on-path@0.2.1 — MIT — https://github.com/pshihn/points-on-path
+- pptxgenjs@4.0.1 — MIT — https://github.com/gitbrent/PptxGenJS
 - prebuild-install@7.1.3 — MIT — https://github.com/prebuild/prebuild-install
 - process-nextick-args@2.0.1 — MIT — https://github.com/calvinmetcalf/process-nextick-args
 - promise-worker-transferable@1.0.4 — Apache-2.0 — https://github.com/terikon/promise-worker-transferable
@@ -1763,6 +1820,7 @@ SECTION 2: npm packages (794 packages)
 - punycode@2.3.1 — MIT — https://github.com/mathiasbynens/punycode.js
 - qrcode@1.5.4 — MIT — https://github.com/soldair/node-qrcode
 - qs@6.15.3 — BSD-3-Clause — https://github.com/ljharb/qs
+- queue@6.0.2 — MIT — https://github.com/jessetane/queue
 - range-parser@1.3.0 — MIT — https://github.com/jshttp/range-parser
 - raw-body@3.0.2 — MIT — https://github.com/stream-utils/raw-body
 - rc@1.2.8 — (BSD-2-Clause OR MIT OR Apache-2.0) — https://github.com/dominictarr/rc
@@ -1777,6 +1835,7 @@ SECTION 2: npm packages (794 packages)
 - react-style-singleton@2.2.3 — MIT — https://github.com/theKashey/react-style-singleton
 - readable-stream@2.3.8 — MIT — https://github.com/nodejs/readable-stream
 - readable-stream@3.6.2 — MIT — https://github.com/nodejs/readable-stream
+- readdir-glob@1.1.3 — Apache-2.0 — https://github.com/Yqnn/node-readdir-glob
 - rehype-highlight@7.0.2 — MIT — https://github.com/rehypejs/rehype-highlight
 - rehype-katex@7.0.1 — MIT — https://github.com/remarkjs/remark-math/tree/main/packages/rehype-katex
 - rehype-slug@6.0.0 — MIT — https://github.com/rehypejs/rehype-slug
@@ -1789,6 +1848,7 @@ SECTION 2: npm packages (794 packages)
 - require-directory@2.1.1 — MIT — https://github.com/troygoode/node-require-directory
 - require-from-string@2.0.2 — MIT — https://github.com/floatdrop/require-from-string
 - require-main-filename@2.0.0 — ISC — https://github.com/yargs/require-main-filename
+- rimraf@2.6.3 — ISC — https://github.com/isaacs/rimraf
 - rimraf@5.0.10 — ISC — https://github.com/isaacs/rimraf
 - robust-predicates@3.0.3 — Unlicense — https://github.com/mourner/robust-predicates
 - rope-sequence@1.3.4 — MIT — https://github.com/marijnh/rope-sequence
@@ -1798,6 +1858,8 @@ SECTION 2: npm packages (794 packages)
 - safe-buffer@5.1.2 — MIT — https://github.com/feross/safe-buffer
 - safe-buffer@5.2.1 — MIT — https://github.com/feross/safe-buffer
 - safer-buffer@2.1.2 — MIT — https://github.com/ChALkeR/safer-buffer
+- sax@1.6.0 — BlueOak-1.0.0 — https://github.com/isaacs/sax-js
+- saxes@5.0.1 — ISC — https://github.com/lddubeau/saxes
 - scheduler@0.27.0 — MIT — https://github.com/facebook/react
 - section-matter@1.0.0 — MIT — https://github.com/jonschlinkert/section-matter
 - semver@6.3.1 — ISC — https://github.com/npm/node-semver
@@ -1848,7 +1910,9 @@ SECTION 2: npm packages (794 packages)
 - tar-fs@2.1.5 — MIT — https://github.com/mafintosh/tar-fs
 - tar-stream@2.2.0 — MIT — https://github.com/mafintosh/tar-stream
 - tinyexec@1.2.4 — MIT — https://github.com/tinylibs/tinyexec
+- tmp@0.2.7 — MIT — https://github.com/raszi/node-tmp
 - toidentifier@1.0.1 — MIT — https://github.com/component/toidentifier
+- traverse@0.3.9 — MIT — http://github.com/substack/js-traverse
 - trim-lines@3.0.1 — MIT — https://github.com/wooorm/trim-lines
 - trough@2.2.0 — MIT — https://github.com/wooorm/trough
 - ts-algebra@2.0.0 — MIT — https://github.com/ThomasAribart/ts-algebra
@@ -1863,6 +1927,7 @@ SECTION 2: npm packages (794 packages)
 - typebox@1.1.39 — MIT — https://github.com/sinclairzx81/typebox
 - undici@6.27.0 — MIT — https://github.com/nodejs/undici
 - undici@8.7.0 — MIT — https://github.com/nodejs/undici
+- undici-types@6.21.0 — MIT — https://github.com/nodejs/undici
 - undici-types@7.24.6 — MIT — https://github.com/nodejs/undici
 - unified@11.0.5 — MIT — https://github.com/unifiedjs/unified
 - unist-util-find-after@5.0.0 — MIT — https://github.com/syntax-tree/unist-util-find-after
@@ -1874,6 +1939,7 @@ SECTION 2: npm packages (794 packages)
 - unist-util-visit-parents@6.0.2 — MIT — https://github.com/syntax-tree/unist-util-visit-parents
 - universalify@2.0.1 — MIT — https://github.com/RyanZim/universalify
 - unpipe@1.0.0 — MIT — https://github.com/stream-utils/unpipe
+- unzipper@0.10.14 — MIT — https://github.com/ZJONSSON/node-unzipper
 - uri-js@4.4.1 — BSD-2-Clause — http://github.com/garycourt/uri-js
 - url-template@2.0.8 — LicenseRef-BSD-Variant — https://github.com/bramstein/url-template
 - use-callback-ref@1.3.3 — MIT — https://github.com/theKashey/use-callback-ref/
@@ -1881,6 +1947,7 @@ SECTION 2: npm packages (794 packages)
 - use-sync-external-store@1.6.0 — MIT — https://github.com/facebook/react
 - util-deprecate@1.0.2 — MIT — https://github.com/TooTallNate/util-deprecate
 - uuid@14.0.1 — MIT — https://github.com/uuidjs/uuid
+- uuid@8.3.2 — MIT — https://github.com/uuidjs/uuid
 - vary@1.1.2 — MIT — https://github.com/jshttp/vary
 - vfile@6.0.3 — MIT — https://github.com/vfile/vfile
 - vfile-location@5.0.3 — MIT — https://github.com/vfile/vfile-location
@@ -1897,10 +1964,14 @@ SECTION 2: npm packages (794 packages)
 - wrap-ansi@8.1.0 — MIT — https://github.com/chalk/wrap-ansi
 - wrappy@1.0.2 — ISC — https://github.com/npm/wrappy
 - ws@8.21.1 — MIT — https://github.com/websockets/ws
+- xml@1.0.1 — MIT — http://github.com/dylang/node-xml
+- xml-js@1.6.11 — MIT — https://github.com/nashwaan/xml-js
+- xmlchars@2.2.0 — MIT — https://github.com/lddubeau/xmlchars
 - y18n@4.0.3 — ISC — https://github.com/yargs/y18n
 - yallist@5.0.0 — BlueOak-1.0.0 — https://github.com/isaacs/yallist
 - yargs@15.4.1 — MIT — https://github.com/yargs/yargs
 - yargs-parser@18.1.3 — ISC — https://github.com/yargs/yargs-parser
+- zip-stream@4.1.1 — MIT — https://github.com/archiverjs/node-zip-stream
 - zod@4.3.6 — MIT — https://github.com/colinhacks/zod
 - zod-to-json-schema@3.25.2 — ISC — https://github.com/StefanTerdell/zod-to-json-schema
 - zwitch@2.0.4 — MIT — https://github.com/wooorm/zwitch
@@ -1949,7 +2020,7 @@ The above copyright notice and this permission notice shall be included in all c
 THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[3] Applies to: npm:@babel/runtime@7.29.7
+[3] Applies to: npm:@babel/helper-string-parser@7.29.7, npm:@babel/helper-validator-identifier@7.29.7, npm:@babel/runtime@7.29.7, npm:@babel/types@7.29.7
 ------------------------------------------------------------------------------
 MIT License
 
@@ -1975,7 +2046,30 @@ OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
 WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[4] Applies to: npm:@braintree/sanitize-url@7.1.2
+[4] Applies to: npm:@babel/parser@7.29.7
+------------------------------------------------------------------------------
+Copyright (C) 2012-2014 by various contributors (see AUTHORS)
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+
+------------------------------------------------------------------------------
+[5] Applies to: npm:@braintree/sanitize-url@7.1.2
 ------------------------------------------------------------------------------
 MIT License
 
@@ -2000,7 +2094,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
 ------------------------------------------------------------------------------
-[5] Applies to: npm:@chevrotain/types@11.1.2, npm:@google/model-viewer@4.3.1, npm:@pkgjs/parseargs@0.11.0, npm:gaxios@7.1.3, npm:gaxios@7.2.0, npm:gcp-metadata@8.1.2, npm:gcp-metadata@8.1.3, npm:google-auth-library@10.5.0, npm:google-auth-library@10.9.0, npm:google-logging-utils@1.1.3, npm:googleapis-common@8.0.2, npm:long@5.3.2
+[6] Applies to: npm:@chevrotain/types@11.1.2, npm:@google/model-viewer@4.3.1, npm:@pkgjs/parseargs@0.11.0, npm:gaxios@7.1.3, npm:gaxios@7.2.0, npm:gcp-metadata@8.1.2, npm:gcp-metadata@8.1.3, npm:google-auth-library@10.5.0, npm:google-auth-library@10.9.0, npm:google-logging-utils@1.1.3, npm:googleapis-common@8.0.2, npm:long@5.3.2
 ------------------------------------------------------------------------------
 Apache License
                            Version 2.0, January 2004
@@ -2205,7 +2299,7 @@ Apache License
    limitations under the License.
 
 ------------------------------------------------------------------------------
-[6] Applies to: npm:@codemirror/autocomplete@6.20.3, npm:@codemirror/commands@6.10.4, npm:@codemirror/lang-cpp@6.0.3, npm:@codemirror/lang-css@6.3.1, npm:@codemirror/lang-html@6.4.11, npm:@codemirror/lang-java@6.0.2, npm:@codemirror/lang-javascript@6.2.5, npm:@codemirror/lang-json@6.0.2, npm:@codemirror/lang-markdown@6.5.1, npm:@codemirror/lang-php@6.0.2, npm:@codemirror/lang-python@6.2.1, npm:@codemirror/lang-rust@6.0.2, npm:@codemirror/lang-sql@6.10.0, npm:@codemirror/lang-xml@6.1.0, npm:@codemirror/language@6.12.4, npm:@codemirror/legacy-modes@6.5.3, npm:@codemirror/lint@6.9.7, npm:@codemirror/search@6.7.1, npm:@codemirror/state@6.7.1, npm:@codemirror/view@6.43.6
+[7] Applies to: npm:@codemirror/autocomplete@6.20.3, npm:@codemirror/commands@6.10.4, npm:@codemirror/lang-cpp@6.0.3, npm:@codemirror/lang-css@6.3.1, npm:@codemirror/lang-html@6.4.11, npm:@codemirror/lang-java@6.0.2, npm:@codemirror/lang-javascript@6.2.5, npm:@codemirror/lang-json@6.0.2, npm:@codemirror/lang-markdown@6.5.1, npm:@codemirror/lang-php@6.0.2, npm:@codemirror/lang-python@6.2.1, npm:@codemirror/lang-rust@6.0.2, npm:@codemirror/lang-sql@6.10.0, npm:@codemirror/lang-xml@6.1.0, npm:@codemirror/language@6.12.4, npm:@codemirror/legacy-modes@6.5.3, npm:@codemirror/lint@6.9.7, npm:@codemirror/search@6.7.1, npm:@codemirror/state@6.7.1, npm:@codemirror/view@6.43.6
 ------------------------------------------------------------------------------
 MIT License
 
@@ -2230,7 +2324,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[7] Applies to: npm:@codemirror/lang-go@6.0.1, npm:@codemirror/lang-yaml@6.1.3
+[8] Applies to: npm:@codemirror/lang-go@6.0.1, npm:@codemirror/lang-yaml@6.1.3
 ------------------------------------------------------------------------------
 MIT License
 
@@ -2255,7 +2349,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[8] Applies to: npm:@discordjs/builders@1.14.1, npm:@discordjs/formatters@0.6.2
+[9] Applies to: npm:@discordjs/builders@1.14.1, npm:@discordjs/formatters@0.6.2
 ------------------------------------------------------------------------------
 Apache License
                            Version 2.0, January 2004
@@ -2450,7 +2544,7 @@ Apache License
    limitations under the License.
 
 ------------------------------------------------------------------------------
-[9] Applies to: npm:@discordjs/collection@1.5.3, npm:@discordjs/collection@2.1.1, npm:discord.js@14.27.0
+[10] Applies to: npm:@discordjs/collection@1.5.3, npm:@discordjs/collection@2.1.1, npm:discord.js@14.27.0
 ------------------------------------------------------------------------------
 Apache License
                            Version 2.0, January 2004
@@ -2645,7 +2739,7 @@ Apache License
    limitations under the License.
 
 ------------------------------------------------------------------------------
-[10] Applies to: npm:@discordjs/rest@2.6.2
+[11] Applies to: npm:@discordjs/rest@2.6.2
 ------------------------------------------------------------------------------
 Apache License
                            Version 2.0, January 2004
@@ -2841,7 +2935,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 
 ------------------------------------------------------------------------------
-[11] Applies to: npm:@discordjs/util@1.2.0
+[12] Applies to: npm:@discordjs/util@1.2.0
 ------------------------------------------------------------------------------
 Apache License
                            Version 2.0, January 2004
@@ -3035,7 +3129,7 @@ Apache License
    limitations under the License.
 
 ------------------------------------------------------------------------------
-[12] Applies to: npm:@discordjs/ws@1.2.3
+[13] Applies to: npm:@discordjs/ws@1.2.3
 ------------------------------------------------------------------------------
 Apache License
                            Version 2.0, January 2004
@@ -3230,7 +3324,32 @@ Apache License
    limitations under the License.
 
 ------------------------------------------------------------------------------
-[13] Applies to: npm:@floating-ui/core@1.8.0, npm:@floating-ui/dom@1.8.0, npm:@floating-ui/react-dom@2.1.9, npm:@floating-ui/utils@0.2.12
+[14] Applies to: npm:@fast-csv/format@4.3.5, npm:@fast-csv/parse@4.3.6, npm:fast-csv@4.3.6
+------------------------------------------------------------------------------
+The MIT License
+
+Copyright (c) 2011-2019 C2FO
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+
+------------------------------------------------------------------------------
+[15] Applies to: npm:@floating-ui/core@1.8.0, npm:@floating-ui/dom@1.8.0, npm:@floating-ui/react-dom@2.1.9, npm:@floating-ui/utils@0.2.12
 ------------------------------------------------------------------------------
 MIT License
 
@@ -3254,7 +3373,7 @@ IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
 CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[14] Applies to: npm:@fontsource-variable/inter@5.2.8
+[16] Applies to: npm:@fontsource-variable/inter@5.2.8
 ------------------------------------------------------------------------------
 Copyright 2016 The Inter Project Authors (https://github.com/rsms/inter) Inter-Italic[opsz,wght].ttf: Copyright 2016 The Inter Project Authors (https://github.com/rsms/inter)
 
@@ -3351,7 +3470,7 @@ FROM, OUT OF THE USE OR INABILITY TO USE THE FONT SOFTWARE OR FROM
 OTHER DEALINGS IN THE FONT SOFTWARE.
 
 ------------------------------------------------------------------------------
-[15] Applies to: npm:@fontsource-variable/jetbrains-mono@5.2.8
+[17] Applies to: npm:@fontsource-variable/jetbrains-mono@5.2.8
 ------------------------------------------------------------------------------
 Copyright 2020 The JetBrains Mono Project Authors (https://github.com/JetBrains/JetBrainsMono) JetBrainsMono-Italic[wght].ttf: Copyright 2020 The JetBrains Mono Project Authors (https://github.com/JetBrains/JetBrainsMono)
 
@@ -3448,7 +3567,7 @@ FROM, OUT OF THE USE OR INABILITY TO USE THE FONT SOFTWARE OR FROM
 OTHER DEALINGS IN THE FONT SOFTWARE.
 
 ------------------------------------------------------------------------------
-[16] Applies to: npm:@hono/node-server@1.19.14
+[18] Applies to: npm:@hono/node-server@1.19.14
 ------------------------------------------------------------------------------
 MIT License
 
@@ -3473,7 +3592,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
 ------------------------------------------------------------------------------
-[17] Applies to: npm:@iconify/types@2.0.0
+[19] Applies to: npm:@iconify/types@2.0.0
 ------------------------------------------------------------------------------
 MIT License
 
@@ -3498,7 +3617,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
 ------------------------------------------------------------------------------
-[18] Applies to: npm:@iconify/utils@3.1.4
+[20] Applies to: npm:@iconify/utils@3.1.4
 ------------------------------------------------------------------------------
 MIT License
 
@@ -3523,7 +3642,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
 ------------------------------------------------------------------------------
-[19] Applies to: npm:@img/colour@1.1.0
+[21] Applies to: npm:@img/colour@1.1.0
 ------------------------------------------------------------------------------
 # Licensing
 
@@ -3609,7 +3728,7 @@ The above copyright notice and this permission notice shall be included in all c
 THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[20] Applies to: npm:@img/sharp-darwin-arm64@0.34.5, npm:@img/sharp-darwin-arm64@0.35.3, npm:@img/sharp-darwin-x64@0.34.5, npm:@img/sharp-darwin-x64@0.35.3, npm:sharp@0.35.3
+[22] Applies to: npm:@img/sharp-darwin-arm64@0.34.5, npm:@img/sharp-darwin-arm64@0.35.3, npm:@img/sharp-darwin-x64@0.34.5, npm:@img/sharp-darwin-x64@0.35.3, npm:sharp@0.35.3
 ------------------------------------------------------------------------------
 Apache License
 Version 2.0, January 2004
@@ -3804,7 +3923,7 @@ third-party archives.
    limitations under the License.
 
 ------------------------------------------------------------------------------
-[21] Applies to: npm:@isaacs/cliui@8.0.2, npm:cliui@6.0.0
+[23] Applies to: npm:@isaacs/cliui@8.0.2, npm:cliui@6.0.0
 ------------------------------------------------------------------------------
 Copyright (c) 2015, Contributors
 
@@ -3822,7 +3941,7 @@ WHETHER IN AN ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION,
 ARISING OUT OF OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
 
 ------------------------------------------------------------------------------
-[22] Applies to: npm:@isaacs/fs-minipass@4.0.1, npm:chownr@1.1.4, npm:ini@1.3.8, npm:isexe@2.0.0, npm:once@1.4.0, npm:semver@6.3.1, npm:semver@7.8.5, npm:which@2.0.2, npm:wrappy@1.0.2
+[24] Applies to: npm:@isaacs/fs-minipass@4.0.1, npm:chownr@1.1.4, npm:fstream@1.0.12, npm:ini@1.3.8, npm:isexe@2.0.0, npm:minimatch@3.1.5, npm:once@1.4.0, npm:rimraf@2.6.3, npm:semver@6.3.1, npm:semver@7.8.5, npm:which@2.0.2, npm:wrappy@1.0.2
 ------------------------------------------------------------------------------
 The ISC License
 
@@ -3841,7 +3960,7 @@ ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF OR
 IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
 
 ------------------------------------------------------------------------------
-[23] Applies to: npm:@japont/unicode-range@1.0.0
+[25] Applies to: npm:@japont/unicode-range@1.0.0
 ------------------------------------------------------------------------------
 The MIT License (MIT)
 Copyright © 2018 3846masa
@@ -3865,7 +3984,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[24] Applies to: npm:@larksuiteoapi/node-sdk@1.71.1
+[26] Applies to: npm:@larksuiteoapi/node-sdk@1.71.1
 ------------------------------------------------------------------------------
 MIT License
 
@@ -3878,7 +3997,7 @@ The above copyright notice and this permission notice, shall be included in all 
 THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[25] Applies to: npm:@lezer/common@1.5.2, npm:@lezer/css@1.3.4, npm:@lezer/highlight@1.2.3, npm:@lezer/html@1.3.13, npm:@lezer/javascript@1.5.4, npm:@lezer/lr@1.4.10, npm:@lezer/php@1.0.5, npm:@lezer/rust@1.0.2, npm:@lezer/xml@1.0.6
+[27] Applies to: npm:@lezer/common@1.5.2, npm:@lezer/css@1.3.4, npm:@lezer/highlight@1.2.3, npm:@lezer/html@1.3.13, npm:@lezer/javascript@1.5.4, npm:@lezer/lr@1.4.10, npm:@lezer/php@1.0.5, npm:@lezer/rust@1.0.2, npm:@lezer/xml@1.0.6
 ------------------------------------------------------------------------------
 MIT License
 
@@ -3903,7 +4022,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[26] Applies to: npm:@lezer/cpp@1.1.6, npm:@lezer/go@1.0.1, npm:@lezer/java@1.1.3, npm:@lezer/markdown@1.7.2, npm:@lezer/python@1.1.19
+[28] Applies to: npm:@lezer/cpp@1.1.6, npm:@lezer/go@1.0.1, npm:@lezer/java@1.1.3, npm:@lezer/markdown@1.7.2, npm:@lezer/python@1.1.19
 ------------------------------------------------------------------------------
 MIT License
 
@@ -3928,7 +4047,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[27] Applies to: npm:@lezer/json@1.0.3
+[29] Applies to: npm:@lezer/json@1.0.3
 ------------------------------------------------------------------------------
 MIT License
 
@@ -3953,7 +4072,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[28] Applies to: npm:@lezer/yaml@1.0.4
+[30] Applies to: npm:@lezer/yaml@1.0.4
 ------------------------------------------------------------------------------
 MIT License
 
@@ -3978,7 +4097,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[29] Applies to: npm:@lit/reactive-element@2.1.2, npm:lit@3.3.3, npm:lit-element@4.2.2, npm:lit-html@3.3.3
+[31] Applies to: npm:@lit/reactive-element@2.1.2, npm:lit@3.3.3, npm:lit-element@4.2.2, npm:lit-html@3.3.3
 ------------------------------------------------------------------------------
 BSD 3-Clause License
 
@@ -4010,7 +4129,7 @@ OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 ------------------------------------------------------------------------------
-[30] Applies to: npm:@marijn/find-cluster-break@1.0.3
+[32] Applies to: npm:@marijn/find-cluster-break@1.0.3
 ------------------------------------------------------------------------------
 MIT License
 
@@ -4035,7 +4154,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[31] Applies to: npm:@mermaid-js/parser@1.2.0
+[33] Applies to: npm:@mermaid-js/parser@1.2.0
 ------------------------------------------------------------------------------
 The MIT License (MIT)
 
@@ -4060,7 +4179,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
 ------------------------------------------------------------------------------
-[32] Applies to: npm:@modelcontextprotocol/sdk@1.29.0
+[34] Applies to: npm:@modelcontextprotocol/sdk@1.29.0
 ------------------------------------------------------------------------------
 MIT License
 
@@ -4085,7 +4204,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
 ------------------------------------------------------------------------------
-[33] Applies to: npm:@monogrid/gainmap-js@3.4.0
+[35] Applies to: npm:@monogrid/gainmap-js@3.4.0
 ------------------------------------------------------------------------------
 MIT License
 
@@ -4110,7 +4229,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
 ------------------------------------------------------------------------------
-[34] Applies to: npm:@napi-rs/canvas@0.1.100
+[36] Applies to: npm:@napi-rs/canvas@0.1.100
 ------------------------------------------------------------------------------
 MIT License
 
@@ -4135,7 +4254,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
 ------------------------------------------------------------------------------
-[35] Applies to: npm:@noble/hashes@1.8.0
+[37] Applies to: npm:@noble/hashes@1.8.0
 ------------------------------------------------------------------------------
 The MIT License (MIT)
 
@@ -4160,7 +4279,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[36] Applies to: npm:@paralleldrive/cuid2@2.3.1
+[38] Applies to: npm:@paralleldrive/cuid2@2.3.1
 ------------------------------------------------------------------------------
 MIT License
 
@@ -4185,7 +4304,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
 ------------------------------------------------------------------------------
-[37] Applies to: npm:@parcel/watcher@2.5.6, npm:@parcel/watcher-darwin-arm64@2.5.6, npm:@parcel/watcher-darwin-x64@2.5.6
+[39] Applies to: npm:@parcel/watcher@2.5.6, npm:@parcel/watcher-darwin-arm64@2.5.6, npm:@parcel/watcher-darwin-x64@2.5.6
 ------------------------------------------------------------------------------
 MIT License
 
@@ -4210,7 +4329,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
 ------------------------------------------------------------------------------
-[38] Applies to: npm:@protobufjs/aspromise@1.1.2, npm:@protobufjs/base64@1.1.2, npm:@protobufjs/codegen@2.0.5, npm:@protobufjs/eventemitter@1.1.1, npm:@protobufjs/fetch@1.1.1, npm:@protobufjs/float@1.0.2, npm:@protobufjs/path@1.1.2, npm:@protobufjs/pool@1.1.0, npm:@protobufjs/utf8@1.1.2
+[40] Applies to: npm:@protobufjs/aspromise@1.1.2, npm:@protobufjs/base64@1.1.2, npm:@protobufjs/codegen@2.0.5, npm:@protobufjs/eventemitter@1.1.1, npm:@protobufjs/fetch@1.1.1, npm:@protobufjs/float@1.0.2, npm:@protobufjs/path@1.1.2, npm:@protobufjs/pool@1.1.0, npm:@protobufjs/utf8@1.1.2
 ------------------------------------------------------------------------------
 Copyright (c) 2016, Daniel Wirtz  All rights reserved.
 
@@ -4240,7 +4359,7 @@ THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
 OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 ------------------------------------------------------------------------------
-[39] Applies to: npm:@radix-ui/number@1.1.2, npm:@radix-ui/primitive@1.1.5, npm:@radix-ui/react-alert-dialog@1.1.19, npm:@radix-ui/react-arrow@1.1.11, npm:@radix-ui/react-collection@1.1.12, npm:@radix-ui/react-compose-refs@1.1.3, npm:@radix-ui/react-context@1.2.0, npm:@radix-ui/react-dialog@1.1.19, npm:@radix-ui/react-direction@1.1.2, npm:@radix-ui/react-dismissable-layer@1.1.15, npm:@radix-ui/react-dropdown-menu@2.1.20, npm:@radix-ui/react-focus-guards@1.1.4, npm:@radix-ui/react-focus-scope@1.1.12, npm:@radix-ui/react-id@1.1.2, npm:@radix-ui/react-menu@2.1.20, npm:@radix-ui/react-popover@1.1.19, npm:@radix-ui/react-popper@1.3.3, npm:@radix-ui/react-portal@1.1.13, npm:@radix-ui/react-presence@1.1.7, npm:@radix-ui/react-primitive@2.1.7, npm:@radix-ui/react-roving-focus@1.1.15, npm:@radix-ui/react-select@2.3.3, npm:@radix-ui/react-slider@1.4.3, npm:@radix-ui/react-slot@1.3.0, npm:@radix-ui/react-switch@1.3.3, npm:@radix-ui/react-tooltip@1.2.12, npm:@radix-ui/react-use-callback-ref@1.1.2, npm:@radix-ui/react-use-controllable-state@1.2.3, npm:@radix-ui/react-use-effect-event@0.0.3, npm:@radix-ui/react-use-is-hydrated@0.1.1, npm:@radix-ui/react-use-layout-effect@1.1.2, npm:@radix-ui/react-use-previous@1.1.2, npm:@radix-ui/react-use-rect@1.1.2, npm:@radix-ui/react-use-size@1.1.2, npm:@radix-ui/react-visually-hidden@1.2.7, npm:@radix-ui/rect@1.1.2
+[41] Applies to: npm:@radix-ui/number@1.1.2, npm:@radix-ui/primitive@1.1.5, npm:@radix-ui/react-alert-dialog@1.1.19, npm:@radix-ui/react-arrow@1.1.11, npm:@radix-ui/react-collection@1.1.12, npm:@radix-ui/react-compose-refs@1.1.3, npm:@radix-ui/react-context@1.2.0, npm:@radix-ui/react-dialog@1.1.19, npm:@radix-ui/react-direction@1.1.2, npm:@radix-ui/react-dismissable-layer@1.1.15, npm:@radix-ui/react-dropdown-menu@2.1.20, npm:@radix-ui/react-focus-guards@1.1.4, npm:@radix-ui/react-focus-scope@1.1.12, npm:@radix-ui/react-id@1.1.2, npm:@radix-ui/react-menu@2.1.20, npm:@radix-ui/react-popover@1.1.19, npm:@radix-ui/react-popper@1.3.3, npm:@radix-ui/react-portal@1.1.13, npm:@radix-ui/react-presence@1.1.7, npm:@radix-ui/react-primitive@2.1.7, npm:@radix-ui/react-roving-focus@1.1.15, npm:@radix-ui/react-select@2.3.3, npm:@radix-ui/react-slider@1.4.3, npm:@radix-ui/react-slot@1.3.0, npm:@radix-ui/react-switch@1.3.3, npm:@radix-ui/react-tooltip@1.2.12, npm:@radix-ui/react-use-callback-ref@1.1.2, npm:@radix-ui/react-use-controllable-state@1.2.3, npm:@radix-ui/react-use-effect-event@0.0.3, npm:@radix-ui/react-use-is-hydrated@0.1.1, npm:@radix-ui/react-use-layout-effect@1.1.2, npm:@radix-ui/react-use-previous@1.1.2, npm:@radix-ui/react-use-rect@1.1.2, npm:@radix-ui/react-use-size@1.1.2, npm:@radix-ui/react-visually-hidden@1.2.7, npm:@radix-ui/rect@1.1.2
 ------------------------------------------------------------------------------
 MIT License
 
@@ -4265,7 +4384,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
 ------------------------------------------------------------------------------
-[40] Applies to: npm:@replit/codemirror-lang-csharp@6.2.0
+[42] Applies to: npm:@replit/codemirror-lang-csharp@6.2.0
 ------------------------------------------------------------------------------
 MIT License
 
@@ -4290,7 +4409,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
 ------------------------------------------------------------------------------
-[41] Applies to: npm:@sapphire/shapeshift@4.0.0
+[43] Applies to: npm:@sapphire/shapeshift@4.0.0
 ------------------------------------------------------------------------------
 # The MIT License (MIT)
 
@@ -4318,7 +4437,7 @@ FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
 OTHER DEALINGS IN THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[42] Applies to: npm:@tanstack/react-virtual@3.14.6, npm:@tanstack/virtual-core@3.17.4
+[44] Applies to: npm:@tanstack/react-virtual@3.14.6, npm:@tanstack/virtual-core@3.17.4
 ------------------------------------------------------------------------------
 MIT License
 
@@ -4343,7 +4462,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
 ------------------------------------------------------------------------------
-[43] Applies to: npm:@tiptap/core@3.28.0, npm:@tiptap/extension-bubble-menu@3.28.0, npm:@tiptap/extension-document@3.28.0, npm:@tiptap/extension-floating-menu@3.28.0, npm:@tiptap/extension-hard-break@3.28.0, npm:@tiptap/extension-history@3.28.0, npm:@tiptap/extension-paragraph@3.28.0, npm:@tiptap/extension-placeholder@3.28.0, npm:@tiptap/extension-text@3.28.0, npm:@tiptap/pm@3.28.0, npm:@tiptap/react@3.28.0
+[45] Applies to: npm:@tiptap/core@3.28.0, npm:@tiptap/extension-bubble-menu@3.28.0, npm:@tiptap/extension-document@3.28.0, npm:@tiptap/extension-floating-menu@3.28.0, npm:@tiptap/extension-hard-break@3.28.0, npm:@tiptap/extension-history@3.28.0, npm:@tiptap/extension-paragraph@3.28.0, npm:@tiptap/extension-placeholder@3.28.0, npm:@tiptap/extension-text@3.28.0, npm:@tiptap/pm@3.28.0, npm:@tiptap/react@3.28.0
 ------------------------------------------------------------------------------
 MIT License
 
@@ -4368,7 +4487,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
 ------------------------------------------------------------------------------
-[44] Applies to: npm:@types/d3@7.4.3, npm:@types/d3-array@3.2.2, npm:@types/d3-axis@3.0.6, npm:@types/d3-brush@3.0.6, npm:@types/d3-chord@3.0.6, npm:@types/d3-color@3.1.3, npm:@types/d3-contour@3.0.6, npm:@types/d3-delaunay@6.0.4, npm:@types/d3-dispatch@3.0.7, npm:@types/d3-drag@3.0.7, npm:@types/d3-dsv@3.0.7, npm:@types/d3-ease@3.0.2, npm:@types/d3-fetch@3.0.7, npm:@types/d3-force@3.0.10, npm:@types/d3-format@3.0.4, npm:@types/d3-geo@3.1.0, npm:@types/d3-hierarchy@3.1.7, npm:@types/d3-interpolate@3.0.4, npm:@types/d3-path@3.1.1, npm:@types/d3-polygon@3.0.2, npm:@types/d3-quadtree@3.0.6, npm:@types/d3-random@3.0.4, npm:@types/d3-scale@4.0.9, npm:@types/d3-scale-chromatic@3.1.0, npm:@types/d3-selection@3.0.11, npm:@types/d3-shape@3.1.8, npm:@types/d3-time@3.0.4, npm:@types/d3-time-format@4.0.3, npm:@types/d3-timer@3.0.2, npm:@types/d3-transition@3.0.9, npm:@types/d3-zoom@3.0.8, npm:@types/debug@4.1.13, npm:@types/estree@1.0.9, npm:@types/estree-jsx@1.0.5, npm:@types/geojson@7946.0.16, npm:@types/hast@3.0.5, npm:@types/katex@0.16.8, npm:@types/mdast@4.0.4, npm:@types/ms@2.1.0, npm:@types/node@25.9.5, npm:@types/trusted-types@2.0.7, npm:@types/unist@2.0.11, npm:@types/unist@3.0.3, npm:@types/use-sync-external-store@0.0.6, npm:@types/ws@8.18.1
+[46] Applies to: npm:@types/d3@7.4.3, npm:@types/d3-array@3.2.2, npm:@types/d3-axis@3.0.6, npm:@types/d3-brush@3.0.6, npm:@types/d3-chord@3.0.6, npm:@types/d3-color@3.1.3, npm:@types/d3-contour@3.0.6, npm:@types/d3-delaunay@6.0.4, npm:@types/d3-dispatch@3.0.7, npm:@types/d3-drag@3.0.7, npm:@types/d3-dsv@3.0.7, npm:@types/d3-ease@3.0.2, npm:@types/d3-fetch@3.0.7, npm:@types/d3-force@3.0.10, npm:@types/d3-format@3.0.4, npm:@types/d3-geo@3.1.0, npm:@types/d3-hierarchy@3.1.7, npm:@types/d3-interpolate@3.0.4, npm:@types/d3-path@3.1.1, npm:@types/d3-polygon@3.0.2, npm:@types/d3-quadtree@3.0.6, npm:@types/d3-random@3.0.4, npm:@types/d3-scale@4.0.9, npm:@types/d3-scale-chromatic@3.1.0, npm:@types/d3-selection@3.0.11, npm:@types/d3-shape@3.1.8, npm:@types/d3-time@3.0.4, npm:@types/d3-time-format@4.0.3, npm:@types/d3-timer@3.0.2, npm:@types/d3-transition@3.0.9, npm:@types/d3-zoom@3.0.8, npm:@types/debug@4.1.13, npm:@types/estree@1.0.9, npm:@types/estree-jsx@1.0.5, npm:@types/geojson@7946.0.16, npm:@types/hast@3.0.5, npm:@types/katex@0.16.8, npm:@types/mdast@4.0.4, npm:@types/ms@2.1.0, npm:@types/node@14.18.63, npm:@types/node@22.20.1, npm:@types/node@25.9.5, npm:@types/trusted-types@2.0.7, npm:@types/unist@2.0.11, npm:@types/unist@3.0.3, npm:@types/use-sync-external-store@0.0.6, npm:@types/ws@8.18.1
 ------------------------------------------------------------------------------
 MIT License
 
@@ -4393,7 +4512,7 @@ MIT License
     SOFTWARE
 
 ------------------------------------------------------------------------------
-[45] Applies to: npm:@ungap/structured-clone@1.3.3
+[47] Applies to: npm:@ungap/structured-clone@1.3.3
 ------------------------------------------------------------------------------
 ISC License
 
@@ -4412,7 +4531,7 @@ OR OTHER TORTIOUS ACTION, ARISING OUT OF OR IN CONNECTION WITH THE USE OR
 PERFORMANCE OF THIS SOFTWARE.
 
 ------------------------------------------------------------------------------
-[46] Applies to: npm:@upsetjs/venn.js@2.0.0
+[48] Applies to: npm:@upsetjs/venn.js@2.0.0
 ------------------------------------------------------------------------------
 MIT License
 
@@ -4438,7 +4557,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
 ------------------------------------------------------------------------------
-[47] Applies to: npm:@vladfrangu/async_event_emitter@2.4.7
+[49] Applies to: npm:@vladfrangu/async_event_emitter@2.4.7
 ------------------------------------------------------------------------------
 # The MIT License (MIT)
 
@@ -4466,7 +4585,7 @@ FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
 OTHER DEALINGS IN THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[48] Applies to: npm:@xterm/addon-clipboard@0.1.0
+[50] Applies to: npm:@xterm/addon-clipboard@0.1.0
 ------------------------------------------------------------------------------
 Copyright (c) 2023, The xterm.js authors (https://github.com/xtermjs/xterm.js)
 
@@ -4489,7 +4608,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[49] Applies to: npm:@xterm/addon-fit@0.10.0
+[51] Applies to: npm:@xterm/addon-fit@0.10.0
 ------------------------------------------------------------------------------
 Copyright (c) 2019, The xterm.js authors (https://github.com/xtermjs/xterm.js)
 
@@ -4512,7 +4631,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[50] Applies to: npm:@xterm/addon-web-links@0.11.0
+[52] Applies to: npm:@xterm/addon-web-links@0.11.0
 ------------------------------------------------------------------------------
 Copyright (c) 2017, The xterm.js authors (https://github.com/xtermjs/xterm.js)
 
@@ -4535,7 +4654,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[51] Applies to: npm:@xterm/xterm@5.5.0
+[53] Applies to: npm:@xterm/xterm@5.5.0
 ------------------------------------------------------------------------------
 Copyright (c) 2017-2019, The xterm.js authors (https://github.com/xtermjs/xterm.js)
 Copyright (c) 2014-2016, SourceLair Private Company (https://www.sourcelair.com)
@@ -4560,7 +4679,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[52] Applies to: npm:accepts@2.0.0, npm:mime-types@2.1.35, npm:mime-types@3.0.2
+[54] Applies to: npm:accepts@2.0.0, npm:mime-types@2.1.35, npm:mime-types@3.0.2
 ------------------------------------------------------------------------------
 (The MIT License)
 
@@ -4587,7 +4706,7 @@ TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
 SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[53] Applies to: npm:agent-base@7.1.4, npm:https-proxy-agent@7.0.6
+[55] Applies to: npm:agent-base@7.1.4, npm:https-proxy-agent@7.0.6
 ------------------------------------------------------------------------------
 (The MIT License)
 
@@ -4613,7 +4732,7 @@ TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
 SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[54] Applies to: npm:ajv@7.2.4, npm:ajv@8.20.0
+[56] Applies to: npm:ajv@7.2.4, npm:ajv@8.20.0
 ------------------------------------------------------------------------------
 The MIT License (MIT)
 
@@ -4638,7 +4757,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
 ------------------------------------------------------------------------------
-[55] Applies to: npm:ajv-formats@1.6.1, npm:ajv-formats@3.0.1
+[57] Applies to: npm:ajv-formats@1.6.1, npm:ajv-formats@3.0.1
 ------------------------------------------------------------------------------
 MIT License
 
@@ -4663,7 +4782,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
 ------------------------------------------------------------------------------
-[56] Applies to: npm:ansi-regex@5.0.1, npm:ansi-styles@4.3.0, npm:camelcase@5.3.1, npm:env-paths@2.2.1, npm:find-up@3.0.0, npm:find-up@4.1.0, npm:is-fullwidth-code-point@3.0.0, npm:is-obj@2.0.0, npm:lcid@3.1.1, npm:locate-path@3.0.0, npm:locate-path@5.0.0, npm:make-dir@3.1.0, npm:mimic-fn@2.1.0, npm:mimic-fn@3.1.0, npm:npm-run-path@4.0.1, npm:p-limit@2.3.0, npm:p-locate@3.0.0, npm:p-locate@4.1.0, npm:p-try@2.2.0, npm:path-exists@4.0.0, npm:path-key@3.1.1, npm:pkg-up@3.1.0, npm:shebang-regex@3.0.0, npm:string-width@4.2.3, npm:strip-ansi@6.0.1, npm:strip-final-newline@2.0.0, npm:wrap-ansi@6.2.0
+[58] Applies to: npm:ansi-regex@5.0.1, npm:ansi-styles@4.3.0, npm:camelcase@5.3.1, npm:env-paths@2.2.1, npm:find-up@3.0.0, npm:find-up@4.1.0, npm:is-fullwidth-code-point@3.0.0, npm:is-obj@2.0.0, npm:lcid@3.1.1, npm:locate-path@3.0.0, npm:locate-path@5.0.0, npm:make-dir@3.1.0, npm:mimic-fn@2.1.0, npm:mimic-fn@3.1.0, npm:npm-run-path@4.0.1, npm:p-limit@2.3.0, npm:p-locate@3.0.0, npm:p-locate@4.1.0, npm:p-try@2.2.0, npm:path-exists@4.0.0, npm:path-key@3.1.1, npm:pkg-up@3.1.0, npm:shebang-regex@3.0.0, npm:string-width@4.2.3, npm:strip-ansi@6.0.1, npm:strip-final-newline@2.0.0, npm:wrap-ansi@6.2.0
 ------------------------------------------------------------------------------
 MIT License
 
@@ -4676,7 +4795,7 @@ The above copyright notice and this permission notice shall be included in all c
 THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[57] Applies to: npm:ansi-regex@6.2.2, npm:ansi-styles@6.2.3, npm:conf@9.0.2, npm:debounce-fn@4.0.0, npm:decompress-response@6.0.0, npm:default-shell@2.2.0, npm:dot-prop@6.0.1, npm:electron-store@7.0.3, npm:escape-string-regexp@5.0.0, npm:execa@4.1.0, npm:execa@5.1.1, npm:fix-path@5.0.0, npm:get-east-asian-width@1.6.0, npm:get-stream@5.2.0, npm:get-stream@6.0.1, npm:invert-kv@3.0.1, npm:is-plain-obj@4.1.0, npm:is-stream@2.0.1, npm:mimic-response@3.1.0, npm:onetime@5.1.2, npm:os-locale@6.0.2, npm:shell-env@4.0.3, npm:shell-path@3.1.0, npm:string-width@5.1.2, npm:strip-ansi@7.2.0, npm:wrap-ansi@7.0.0, npm:wrap-ansi@8.1.0
+[59] Applies to: npm:ansi-regex@6.2.2, npm:ansi-styles@6.2.3, npm:conf@9.0.2, npm:debounce-fn@4.0.0, npm:decompress-response@6.0.0, npm:default-shell@2.2.0, npm:dot-prop@6.0.1, npm:electron-store@7.0.3, npm:escape-string-regexp@5.0.0, npm:execa@4.1.0, npm:execa@5.1.1, npm:fix-path@5.0.0, npm:get-east-asian-width@1.6.0, npm:get-stream@5.2.0, npm:get-stream@6.0.1, npm:invert-kv@3.0.1, npm:is-plain-obj@4.1.0, npm:is-stream@2.0.1, npm:mimic-response@3.1.0, npm:onetime@5.1.2, npm:os-locale@6.0.2, npm:shell-env@4.0.3, npm:shell-path@3.1.0, npm:string-width@5.1.2, npm:strip-ansi@7.2.0, npm:wrap-ansi@7.0.0, npm:wrap-ansi@8.1.0
 ------------------------------------------------------------------------------
 MIT License
 
@@ -4689,7 +4808,59 @@ The above copyright notice and this permission notice shall be included in all c
 THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[58] Applies to: npm:argparse@1.0.10
+[60] Applies to: npm:archiver@5.3.2
+------------------------------------------------------------------------------
+Copyright (c) 2012-2014 Chris Talkington, contributors.
+
+Permission is hereby granted, free of charge, to any person
+obtaining a copy of this software and associated documentation
+files (the "Software"), to deal in the Software without
+restriction, including without limitation the rights to use,
+copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the
+Software is furnished to do so, subject to the following
+conditions:
+
+The above copyright notice and this permission notice shall be
+included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
+OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+OTHER DEALINGS IN THE SOFTWARE.
+
+------------------------------------------------------------------------------
+[61] Applies to: npm:archiver-utils@2.1.0, npm:archiver-utils@3.0.4
+------------------------------------------------------------------------------
+Copyright (c) 2015 Chris Talkington.
+
+Permission is hereby granted, free of charge, to any person
+obtaining a copy of this software and associated documentation
+files (the "Software"), to deal in the Software without
+restriction, including without limitation the rights to use,
+copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the
+Software is furnished to do so, subject to the following
+conditions:
+
+The above copyright notice and this permission notice shall be
+included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
+OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+OTHER DEALINGS IN THE SOFTWARE.
+
+------------------------------------------------------------------------------
+[62] Applies to: npm:argparse@1.0.10
 ------------------------------------------------------------------------------
 (The MIT License)
 
@@ -4714,7 +4885,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[59] Applies to: npm:argparse@2.0.1
+[63] Applies to: npm:argparse@2.0.1
 ------------------------------------------------------------------------------
 A. HISTORY OF THE SOFTWARE
 ==========================
@@ -4972,7 +5143,7 @@ ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT
 OF OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
 
 ------------------------------------------------------------------------------
-[60] Applies to: npm:aria-hidden@1.2.6, npm:react-remove-scroll@2.7.2, npm:react-style-singleton@2.2.3, npm:use-callback-ref@1.3.3, npm:use-sidecar@1.1.3
+[64] Applies to: npm:aria-hidden@1.2.6, npm:react-remove-scroll@2.7.2, npm:react-style-singleton@2.2.3, npm:use-callback-ref@1.3.3, npm:use-sidecar@1.1.3
 ------------------------------------------------------------------------------
 MIT License
 
@@ -4997,7 +5168,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
 ------------------------------------------------------------------------------
-[61] Applies to: npm:asn1@0.2.6
+[65] Applies to: npm:asn1@0.2.6
 ------------------------------------------------------------------------------
 Copyright (c) 2011 Mark Cavage, All rights reserved.
 
@@ -5020,7 +5191,30 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE
 
 ------------------------------------------------------------------------------
-[62] Applies to: npm:asynckit@0.4.0
+[66] Applies to: npm:async@3.2.6
+------------------------------------------------------------------------------
+Copyright (c) 2010-2018 Caolan McMahon
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+
+------------------------------------------------------------------------------
+[67] Applies to: npm:asynckit@0.4.0
 ------------------------------------------------------------------------------
 The MIT License (MIT)
 
@@ -5045,7 +5239,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
 ------------------------------------------------------------------------------
-[63] Applies to: npm:atomically@1.7.0
+[68] Applies to: npm:atomically@1.7.0
 ------------------------------------------------------------------------------
 The MIT License (MIT)
 
@@ -5070,7 +5264,7 @@ FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
 DEALINGS IN THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[64] Applies to: npm:axios@1.18.1
+[69] Applies to: npm:axios@1.18.1
 ------------------------------------------------------------------------------
 # Copyright (c) 2014-present Matt Zabriskie & Collaborators
 
@@ -5081,7 +5275,7 @@ The above copyright notice and this permission notice shall be included in all c
 THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[65] Applies to: npm:bail@2.0.2, npm:ccount@2.0.1, npm:character-entities@2.0.2, npm:character-entities-html4@2.1.0, npm:character-entities-legacy@3.0.0, npm:character-reference-invalid@2.0.1, npm:mdast-util-to-string@4.0.0, npm:unist-util-find-after@5.0.0, npm:unist-util-position@5.0.0, npm:unist-util-visit@5.1.0
+[70] Applies to: npm:bail@2.0.2, npm:ccount@2.0.1, npm:character-entities@2.0.2, npm:character-entities-html4@2.1.0, npm:character-entities-legacy@3.0.0, npm:character-reference-invalid@2.0.1, npm:mdast-util-to-string@4.0.0, npm:unist-util-find-after@5.0.0, npm:unist-util-position@5.0.0, npm:unist-util-visit@5.1.0
 ------------------------------------------------------------------------------
 (The MIT License)
 
@@ -5107,7 +5301,7 @@ TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
 SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[66] Applies to: npm:balanced-match@1.0.2
+[71] Applies to: npm:balanced-match@1.0.2
 ------------------------------------------------------------------------------
 (MIT)
 
@@ -5132,7 +5326,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
 ------------------------------------------------------------------------------
-[67] Applies to: npm:base64-js@1.5.1
+[72] Applies to: npm:base64-js@1.5.1
 ------------------------------------------------------------------------------
 The MIT License (MIT)
 
@@ -5157,7 +5351,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[68] Applies to: npm:bcrypt-pbkdf@1.0.2
+[73] Applies to: npm:bcrypt-pbkdf@1.0.2
 ------------------------------------------------------------------------------
 The Blowfish portions are under the following license:
 
@@ -5227,7 +5421,7 @@ ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
 OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
 
 ------------------------------------------------------------------------------
-[69] Applies to: npm:better-sqlite3@12.11.1
+[74] Applies to: npm:better-sqlite3@12.11.1
 ------------------------------------------------------------------------------
 The MIT License (MIT)
 
@@ -5252,7 +5446,35 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
 ------------------------------------------------------------------------------
-[70] Applies to: npm:bignumber.js@9.3.1
+[75] Applies to: npm:big-integer@1.6.52, npm:robust-predicates@3.0.3, npm:tweetnacl@0.14.5
+------------------------------------------------------------------------------
+This is free and unencumbered software released into the public domain.
+
+Anyone is free to copy, modify, publish, use, compile, sell, or
+distribute this software, either in source code form or as a compiled
+binary, for any purpose, commercial or non-commercial, and by any
+means.
+
+In jurisdictions that recognize copyright laws, the author or authors
+of this software dedicate any and all copyright interest in the
+software to the public domain. We make this dedication for the benefit
+of the public at large and to the detriment of our heirs and
+successors. We intend this dedication to be an overt act of
+relinquishment in perpetuity of all present and future rights to this
+software under copyright law.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+IN NO EVENT SHALL THE AUTHORS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+OTHER DEALINGS IN THE SOFTWARE.
+
+For more information, please refer to <http://unlicense.org>
+
+------------------------------------------------------------------------------
+[76] Applies to: npm:bignumber.js@9.3.1
 ------------------------------------------------------------------------------
 The MIT License (MIT)
 =====================
@@ -5281,7 +5503,7 @@ FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
 OTHER DEALINGS IN THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[71] Applies to: npm:bindings@1.5.0
+[77] Applies to: npm:bindings@1.5.0
 ------------------------------------------------------------------------------
 (The MIT License)
 
@@ -5307,7 +5529,7 @@ TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
 SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[72] Applies to: npm:bl@4.1.0
+[78] Applies to: npm:bl@4.1.0
 ------------------------------------------------------------------------------
 The MIT License (MIT)
 =====================
@@ -5324,7 +5546,32 @@ The above copyright notice and this permission notice shall be included in all c
 THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[73] Applies to: npm:body-parser@2.3.0, npm:type-is@2.1.0
+[79] Applies to: npm:bluebird@3.4.7
+------------------------------------------------------------------------------
+The MIT License (MIT)
+
+Copyright (c) 2013-2015 Petka Antonov
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.  IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+
+------------------------------------------------------------------------------
+[80] Applies to: npm:body-parser@2.3.0, npm:type-is@2.1.0
 ------------------------------------------------------------------------------
 (The MIT License)
 
@@ -5351,7 +5598,7 @@ TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
 SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[74] Applies to: npm:brace-expansion@2.1.2
+[81] Applies to: npm:brace-expansion@1.1.16, npm:brace-expansion@2.1.2
 ------------------------------------------------------------------------------
 MIT License
 
@@ -5376,7 +5623,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
 ------------------------------------------------------------------------------
-[75] Applies to: npm:buffer@5.7.1
+[82] Applies to: npm:buffer@5.7.1
 ------------------------------------------------------------------------------
 The MIT License (MIT)
 
@@ -5401,7 +5648,30 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[76] Applies to: npm:buffer-equal-constant-time@1.0.1
+[83] Applies to: npm:buffer-crc32@0.2.13
+------------------------------------------------------------------------------
+The MIT License
+
+Copyright (c) 2013 Brian J. Brennan
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal in
+the Software without restriction, including without limitation the rights to use,
+copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the
+Software, and to permit persons to whom the Software is furnished to do so,
+subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED,
+INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR
+PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE
+FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+------------------------------------------------------------------------------
+[84] Applies to: npm:buffer-equal-constant-time@1.0.1
 ------------------------------------------------------------------------------
 Copyright (c) 2013, GoInstant Inc., a salesforce.com company
 All rights reserved.
@@ -5417,7 +5687,32 @@ Redistribution and use in source and binary forms, with or without modification,
 THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 ------------------------------------------------------------------------------
-[77] Applies to: npm:buildcheck@0.0.7, npm:cpu-features@0.0.10, npm:ssh2@1.17.0
+[85] Applies to: npm:buffer-indexof-polyfill@1.0.2
+------------------------------------------------------------------------------
+The MIT License (MIT)
+
+Copyright (c) 2015 Sarosia
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+
+------------------------------------------------------------------------------
+[86] Applies to: npm:buildcheck@0.0.7, npm:cpu-features@0.0.10, npm:ssh2@1.17.0
 ------------------------------------------------------------------------------
 Copyright Brian White. All rights reserved.
 
@@ -5440,7 +5735,7 @@ FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
 IN THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[78] Applies to: npm:byte-size@8.2.1
+[87] Applies to: npm:byte-size@8.2.1
 ------------------------------------------------------------------------------
 The MIT License (MIT)
 
@@ -5465,7 +5760,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
 ------------------------------------------------------------------------------
-[79] Applies to: npm:bytes@3.1.2
+[88] Applies to: npm:bytes@3.1.2
 ------------------------------------------------------------------------------
 (The MIT License)
 
@@ -5492,7 +5787,7 @@ TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
 SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[80] Applies to: npm:call-bind-apply-helpers@1.0.2, npm:call-bound@1.0.4, npm:es-define-property@1.0.1, npm:es-errors@1.3.0, npm:es-object-atoms@1.1.2, npm:side-channel-list@1.0.1, npm:side-channel-map@1.0.1
+[89] Applies to: npm:call-bind-apply-helpers@1.0.2, npm:call-bound@1.0.4, npm:es-define-property@1.0.1, npm:es-errors@1.3.0, npm:es-object-atoms@1.1.2, npm:side-channel-list@1.0.1, npm:side-channel-map@1.0.1
 ------------------------------------------------------------------------------
 MIT License
 
@@ -5517,7 +5812,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
 ------------------------------------------------------------------------------
-[81] Applies to: npm:charenc@0.0.2, npm:crypt@0.0.2
+[90] Applies to: npm:charenc@0.0.2, npm:crypt@0.0.2
 ------------------------------------------------------------------------------
 Copyright © 2011, Paul Vorbach. All rights reserved.
 Copyright © 2009, Jeff Mott. All rights reserved.
@@ -5548,7 +5843,7 @@ ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
 SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 ------------------------------------------------------------------------------
-[82] Applies to: npm:chownr@3.0.0, npm:package-json-from-dist@1.0.1, npm:yallist@5.0.0
+[91] Applies to: npm:chownr@3.0.0, npm:package-json-from-dist@1.0.1, npm:yallist@5.0.0
 ------------------------------------------------------------------------------
 All packages under `src/` are licensed according to the terms in
 their respective `LICENSE` or `LICENSE.md` files.
@@ -5615,7 +5910,7 @@ will be liable to anyone for any damages related to this
 software or this license, under any kind of legal claim.***
 
 ------------------------------------------------------------------------------
-[83] Applies to: npm:clsx@2.1.1
+[92] Applies to: npm:clsx@2.1.1
 ------------------------------------------------------------------------------
 MIT License
 
@@ -5628,7 +5923,7 @@ The above copyright notice and this permission notice shall be included in all c
 THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[84] Applies to: npm:cn-font-split@6.0.3
+[93] Applies to: npm:cn-font-split@6.0.3
 ------------------------------------------------------------------------------
 Apache License
                            Version 2.0, January 2004
@@ -5833,7 +6128,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 
 ------------------------------------------------------------------------------
-[85] Applies to: npm:color-convert@2.0.1
+[94] Applies to: npm:color-convert@2.0.1
 ------------------------------------------------------------------------------
 Copyright (c) 2011-2016 Heather Arthur <fayearthur@gmail.com>
 
@@ -5857,7 +6152,7 @@ OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
 WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[86] Applies to: npm:color-name@1.1.4
+[95] Applies to: npm:color-name@1.1.4
 ------------------------------------------------------------------------------
 The MIT License (MIT)
 Copyright (c) 2015 Dmitry Ivanov
@@ -5869,7 +6164,7 @@ The above copyright notice and this permission notice shall be included in all c
 THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[87] Applies to: npm:combined-stream@1.0.8, npm:delayed-stream@1.0.0
+[96] Applies to: npm:combined-stream@1.0.8, npm:delayed-stream@1.0.0
 ------------------------------------------------------------------------------
 Copyright (c) 2011 Debuggable Limited <felix@debuggable.com>
 
@@ -5892,7 +6187,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[88] Applies to: npm:comma-separated-tokens@2.0.3, npm:hast-util-is-element@3.0.0, npm:hast-util-parse-selector@4.0.0, npm:hast-util-whitespace@3.0.0, npm:is-alphabetical@2.0.1, npm:is-alphanumerical@2.0.1, npm:is-decimal@2.0.1, npm:is-hexadecimal@2.0.1, npm:mdast-util-to-hast@13.2.1, npm:rehype-slug@6.0.0, npm:space-separated-tokens@2.0.2, npm:unist-util-remove-position@5.0.0, npm:unist-util-stringify-position@4.0.0, npm:unist-util-visit-parents@6.0.2, npm:vfile-location@5.0.3, npm:web-namespaces@2.0.1, npm:zwitch@2.0.4
+[97] Applies to: npm:comma-separated-tokens@2.0.3, npm:hast-util-is-element@3.0.0, npm:hast-util-parse-selector@4.0.0, npm:hast-util-whitespace@3.0.0, npm:is-alphabetical@2.0.1, npm:is-alphanumerical@2.0.1, npm:is-decimal@2.0.1, npm:is-hexadecimal@2.0.1, npm:mdast-util-to-hast@13.2.1, npm:rehype-slug@6.0.0, npm:space-separated-tokens@2.0.2, npm:unist-util-remove-position@5.0.0, npm:unist-util-stringify-position@4.0.0, npm:unist-util-visit-parents@6.0.2, npm:vfile-location@5.0.3, npm:web-namespaces@2.0.1, npm:zwitch@2.0.4
 ------------------------------------------------------------------------------
 (The MIT License)
 
@@ -5918,7 +6213,7 @@ TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
 SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[89] Applies to: npm:commander@7.2.0, npm:commander@8.3.0
+[98] Applies to: npm:commander@7.2.0, npm:commander@8.3.0
 ------------------------------------------------------------------------------
 (The MIT License)
 
@@ -5944,7 +6239,55 @@ TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
 SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[90] Applies to: npm:content-disposition@1.1.0, npm:forwarded@0.2.0, npm:media-typer@1.1.0, npm:vary@1.1.2
+[99] Applies to: npm:compress-commons@4.1.2, npm:crc32-stream@4.0.3, npm:zip-stream@4.1.1
+------------------------------------------------------------------------------
+Copyright (c) 2014 Chris Talkington, contributors.
+
+Permission is hereby granted, free of charge, to any person
+obtaining a copy of this software and associated documentation
+files (the "Software"), to deal in the Software without
+restriction, including without limitation the rights to use,
+copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the
+Software is furnished to do so, subject to the following
+conditions:
+
+The above copyright notice and this permission notice shall be
+included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
+OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+OTHER DEALINGS IN THE SOFTWARE.
+
+------------------------------------------------------------------------------
+[100] Applies to: npm:concat-map@0.0.1, npm:github-from-package@0.0.0, npm:minimist@1.2.8
+------------------------------------------------------------------------------
+This software is released under the MIT license:
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of
+this software and associated documentation files (the "Software"), to deal in
+the Software without restriction, including without limitation the rights to
+use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+the Software, and to permit persons to whom the Software is furnished to do so,
+subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+------------------------------------------------------------------------------
+[101] Applies to: npm:content-disposition@1.1.0, npm:forwarded@0.2.0, npm:media-typer@1.1.0, npm:vary@1.1.2
 ------------------------------------------------------------------------------
 (The MIT License)
 
@@ -5970,7 +6313,7 @@ TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
 SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[91] Applies to: npm:content-type@1.0.5, npm:content-type@2.0.0
+[102] Applies to: npm:content-type@1.0.5, npm:content-type@2.0.0
 ------------------------------------------------------------------------------
 (The MIT License)
 
@@ -5996,7 +6339,7 @@ TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
 SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[92] Applies to: npm:cookie@0.7.2, npm:cookie@1.1.1
+[103] Applies to: npm:cookie@0.7.2, npm:cookie@1.1.1
 ------------------------------------------------------------------------------
 (The MIT License)
 
@@ -6023,7 +6366,7 @@ TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
 SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[93] Applies to: npm:cookie-signature@1.2.2
+[104] Applies to: npm:cookie-signature@1.2.2
 ------------------------------------------------------------------------------
 (The MIT License)
 
@@ -6049,7 +6392,7 @@ TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
 SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[94] Applies to: npm:core-util-is@1.0.3
+[105] Applies to: npm:core-util-is@1.0.3
 ------------------------------------------------------------------------------
 Copyright Node.js contributors. All rights reserved.
 
@@ -6072,7 +6415,7 @@ FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
 IN THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[95] Applies to: npm:cors@2.8.6
+[106] Applies to: npm:cors@2.8.6
 ------------------------------------------------------------------------------
 (The MIT License)
 
@@ -6098,7 +6441,7 @@ TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
 SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[96] Applies to: npm:cose-base@1.0.3, npm:cose-base@2.2.0
+[107] Applies to: npm:cose-base@1.0.3, npm:cose-base@2.2.0
 ------------------------------------------------------------------------------
 MIT License
 
@@ -6123,7 +6466,212 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
 ------------------------------------------------------------------------------
-[97] Applies to: npm:crelt@1.0.7
+[108] Applies to: npm:crc-32@1.2.2
+------------------------------------------------------------------------------
+Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "{}"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright (C) 2014-present   SheetJS LLC
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+
+------------------------------------------------------------------------------
+[109] Applies to: npm:crelt@1.0.7
 ------------------------------------------------------------------------------
 Copyright (C) 2020 by Marijn Haverbeke <marijn@haverbeke.berlin>
 
@@ -6146,7 +6694,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[98] Applies to: npm:cross-spawn@7.0.6
+[110] Applies to: npm:cross-spawn@7.0.6
 ------------------------------------------------------------------------------
 The MIT License (MIT)
 
@@ -6171,7 +6719,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[99] Applies to: npm:cytoscape@3.34.0
+[111] Applies to: npm:cytoscape@3.34.0
 ------------------------------------------------------------------------------
 Copyright (c) 2016-2026, The Cytoscape Consortium.
 
@@ -6227,7 +6775,7 @@ SOFTWARE.`;
 fs.writeFileSync(path.join(__dirname, 'LICENSE'), license);
 
 ------------------------------------------------------------------------------
-[100] Applies to: npm:cytoscape-cose-bilkent@4.1.0
+[112] Applies to: npm:cytoscape-cose-bilkent@4.1.0
 ------------------------------------------------------------------------------
 Copyright (c) 2016-2018, The Cytoscape Consortium.
 
@@ -6250,7 +6798,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
 ------------------------------------------------------------------------------
-[101] Applies to: npm:cytoscape-fcose@2.2.0
+[113] Applies to: npm:cytoscape-fcose@2.2.0
 ------------------------------------------------------------------------------
 Copyright (c) 2018 - present, iVis-at-Bilkent.
 
@@ -6273,7 +6821,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
 ------------------------------------------------------------------------------
-[102] Applies to: npm:d3@7.9.0, npm:d3-array@3.2.4
+[114] Applies to: npm:d3@7.9.0, npm:d3-array@3.2.4
 ------------------------------------------------------------------------------
 Copyright 2010-2023 Mike Bostock
 
@@ -6290,7 +6838,7 @@ TORTIOUS ACTION, ARISING OUT OF OR IN CONNECTION WITH THE USE OR PERFORMANCE OF
 THIS SOFTWARE.
 
 ------------------------------------------------------------------------------
-[103] Applies to: npm:d3-array@2.12.1
+[115] Applies to: npm:d3-array@2.12.1
 ------------------------------------------------------------------------------
 Copyright 2010-2020 Mike Bostock
 All rights reserved.
@@ -6321,7 +6869,7 @@ ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
 SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 ------------------------------------------------------------------------------
-[104] Applies to: npm:d3-axis@3.0.0, npm:d3-brush@3.0.0, npm:d3-chord@3.0.1, npm:d3-dispatch@3.0.1, npm:d3-drag@3.0.0, npm:d3-force@3.0.0, npm:d3-hierarchy@3.1.2, npm:d3-interpolate@3.0.1, npm:d3-polygon@3.0.1, npm:d3-quadtree@3.0.1, npm:d3-random@3.0.1, npm:d3-scale@4.0.2, npm:d3-selection@3.0.0, npm:d3-time-format@4.1.0, npm:d3-timer@3.0.1, npm:d3-transition@3.0.1, npm:d3-zoom@3.0.0
+[116] Applies to: npm:d3-axis@3.0.0, npm:d3-brush@3.0.0, npm:d3-chord@3.0.1, npm:d3-dispatch@3.0.1, npm:d3-drag@3.0.0, npm:d3-force@3.0.0, npm:d3-hierarchy@3.1.2, npm:d3-interpolate@3.0.1, npm:d3-polygon@3.0.1, npm:d3-quadtree@3.0.1, npm:d3-random@3.0.1, npm:d3-scale@4.0.2, npm:d3-selection@3.0.0, npm:d3-time-format@4.1.0, npm:d3-timer@3.0.1, npm:d3-transition@3.0.1, npm:d3-zoom@3.0.0
 ------------------------------------------------------------------------------
 Copyright 2010-2021 Mike Bostock
 
@@ -6338,7 +6886,7 @@ TORTIOUS ACTION, ARISING OUT OF OR IN CONNECTION WITH THE USE OR PERFORMANCE OF
 THIS SOFTWARE.
 
 ------------------------------------------------------------------------------
-[105] Applies to: npm:d3-color@3.1.0, npm:d3-shape@3.2.0, npm:d3-time@3.1.0
+[117] Applies to: npm:d3-color@3.1.0, npm:d3-shape@3.2.0, npm:d3-time@3.1.0
 ------------------------------------------------------------------------------
 Copyright 2010-2022 Mike Bostock
 
@@ -6355,7 +6903,7 @@ TORTIOUS ACTION, ARISING OUT OF OR IN CONNECTION WITH THE USE OR PERFORMANCE OF
 THIS SOFTWARE.
 
 ------------------------------------------------------------------------------
-[106] Applies to: npm:d3-contour@4.0.2
+[118] Applies to: npm:d3-contour@4.0.2
 ------------------------------------------------------------------------------
 Copyright 2012-2023 Mike Bostock
 
@@ -6372,7 +6920,7 @@ TORTIOUS ACTION, ARISING OUT OF OR IN CONNECTION WITH THE USE OR PERFORMANCE OF
 THIS SOFTWARE.
 
 ------------------------------------------------------------------------------
-[107] Applies to: npm:d3-delaunay@6.0.4
+[119] Applies to: npm:d3-delaunay@6.0.4
 ------------------------------------------------------------------------------
 Copyright 2018-2021 Observable, Inc.
 Copyright 2021 Mapbox
@@ -6390,7 +6938,7 @@ TORTIOUS ACTION, ARISING OUT OF OR IN CONNECTION WITH THE USE OR PERFORMANCE OF
 THIS SOFTWARE.
 
 ------------------------------------------------------------------------------
-[108] Applies to: npm:d3-dsv@3.0.1
+[120] Applies to: npm:d3-dsv@3.0.1
 ------------------------------------------------------------------------------
 Copyright 2013-2021 Mike Bostock
 
@@ -6407,7 +6955,7 @@ TORTIOUS ACTION, ARISING OUT OF OR IN CONNECTION WITH THE USE OR PERFORMANCE OF
 THIS SOFTWARE.
 
 ------------------------------------------------------------------------------
-[109] Applies to: npm:d3-ease@3.0.1
+[121] Applies to: npm:d3-ease@3.0.1
 ------------------------------------------------------------------------------
 Copyright 2010-2021 Mike Bostock
 Copyright 2001 Robert Penner
@@ -6439,7 +6987,7 @@ ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
 SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 ------------------------------------------------------------------------------
-[110] Applies to: npm:d3-fetch@3.0.1
+[122] Applies to: npm:d3-fetch@3.0.1
 ------------------------------------------------------------------------------
 Copyright 2016-2021 Mike Bostock
 
@@ -6456,7 +7004,7 @@ TORTIOUS ACTION, ARISING OUT OF OR IN CONNECTION WITH THE USE OR PERFORMANCE OF
 THIS SOFTWARE.
 
 ------------------------------------------------------------------------------
-[111] Applies to: npm:d3-format@3.1.2
+[123] Applies to: npm:d3-format@3.1.2
 ------------------------------------------------------------------------------
 Copyright 2010-2026 Mike Bostock
 
@@ -6473,7 +7021,7 @@ TORTIOUS ACTION, ARISING OUT OF OR IN CONNECTION WITH THE USE OR PERFORMANCE OF
 THIS SOFTWARE.
 
 ------------------------------------------------------------------------------
-[112] Applies to: npm:d3-geo@3.1.1
+[124] Applies to: npm:d3-geo@3.1.1
 ------------------------------------------------------------------------------
 Copyright 2010-2024 Mike Bostock
 
@@ -6511,7 +7059,7 @@ IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
 CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[113] Applies to: npm:d3-path@1.0.9
+[125] Applies to: npm:d3-path@1.0.9
 ------------------------------------------------------------------------------
 Copyright 2015-2016 Mike Bostock
 All rights reserved.
@@ -6542,7 +7090,7 @@ ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
 SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 ------------------------------------------------------------------------------
-[114] Applies to: npm:d3-path@3.1.0
+[126] Applies to: npm:d3-path@3.1.0
 ------------------------------------------------------------------------------
 Copyright 2015-2022 Mike Bostock
 
@@ -6559,7 +7107,7 @@ TORTIOUS ACTION, ARISING OUT OF OR IN CONNECTION WITH THE USE OR PERFORMANCE OF
 THIS SOFTWARE.
 
 ------------------------------------------------------------------------------
-[115] Applies to: npm:d3-sankey@0.12.3
+[127] Applies to: npm:d3-sankey@0.12.3
 ------------------------------------------------------------------------------
 Copyright 2015, Mike Bostock
 All rights reserved.
@@ -6590,7 +7138,7 @@ ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
 SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 ------------------------------------------------------------------------------
-[116] Applies to: npm:d3-scale-chromatic@3.1.0
+[128] Applies to: npm:d3-scale-chromatic@3.1.0
 ------------------------------------------------------------------------------
 Copyright 2010-2024 Mike Bostock
 
@@ -6622,7 +7170,7 @@ CONDITIONS OF ANY KIND, either express or implied. See the License for the
 specific language governing permissions and limitations under the License.
 
 ------------------------------------------------------------------------------
-[117] Applies to: npm:d3-shape@1.3.7
+[129] Applies to: npm:d3-shape@1.3.7
 ------------------------------------------------------------------------------
 Copyright 2010-2015 Mike Bostock
 All rights reserved.
@@ -6653,7 +7201,7 @@ ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
 SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 ------------------------------------------------------------------------------
-[118] Applies to: npm:dagre-d3-es@7.0.14
+[130] Applies to: npm:dagre-d3-es@7.0.14
 ------------------------------------------------------------------------------
 Original dagre-d3 copyright: Copyright (c) 2013 Chris Pettitt
 Original dagre copyright: Copyright (c) 2012-2014 Chris Pettitt
@@ -6680,7 +7228,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[119] Applies to: npm:dayjs@1.11.21
+[131] Applies to: npm:dayjs@1.11.21
 ------------------------------------------------------------------------------
 MIT License
 
@@ -6705,7 +7253,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
 ------------------------------------------------------------------------------
-[120] Applies to: npm:debug@2.6.9
+[132] Applies to: npm:debug@2.6.9
 ------------------------------------------------------------------------------
 (The MIT License)
 
@@ -6727,7 +7275,7 @@ WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN 
 SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[121] Applies to: npm:debug@4.4.3
+[133] Applies to: npm:debug@4.4.3
 ------------------------------------------------------------------------------
 (The MIT License)
 
@@ -6750,7 +7298,7 @@ WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN 
 SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[122] Applies to: npm:decamelize@1.2.0, npm:object-assign@4.1.1, npm:path-exists@3.0.0, npm:strip-json-comments@2.0.1
+[134] Applies to: npm:decamelize@1.2.0, npm:object-assign@4.1.1, npm:path-exists@3.0.0, npm:path-is-absolute@1.0.1, npm:strip-json-comments@2.0.1
 ------------------------------------------------------------------------------
 The MIT License (MIT)
 
@@ -6775,7 +7323,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[123] Applies to: npm:decode-named-character-reference@1.3.0, npm:hast-util-from-parse5@8.0.3, npm:hast-util-to-jsx-runtime@2.3.6, npm:hastscript@9.0.1, npm:lowlight@3.3.0, npm:markdown-table@3.0.4, npm:mdast-util-find-and-replace@3.0.2, npm:mdast-util-from-markdown@2.0.3, npm:mdast-util-gfm@3.1.0, npm:mdast-util-gfm-footnote@2.1.0, npm:mdast-util-to-markdown@2.1.2, npm:micromark@4.0.2, npm:micromark-core-commonmark@2.0.3, npm:micromark-extension-gfm-table@2.1.1, npm:micromark-factory-destination@2.0.1, npm:micromark-factory-label@2.0.1, npm:micromark-factory-space@2.0.1, npm:micromark-factory-title@2.0.1, npm:micromark-factory-whitespace@2.0.1, npm:micromark-util-character@2.1.1, npm:micromark-util-chunked@2.0.1, npm:micromark-util-classify-character@2.0.1, npm:micromark-util-combine-extensions@2.0.1, npm:micromark-util-decode-numeric-character-reference@2.0.2, npm:micromark-util-decode-string@2.0.1, npm:micromark-util-encode@2.0.1, npm:micromark-util-html-tag-name@2.0.1, npm:micromark-util-normalize-identifier@2.0.1, npm:micromark-util-resolve-all@2.0.1, npm:micromark-util-sanitize-uri@2.0.1, npm:micromark-util-subtokenize@2.1.0, npm:micromark-util-symbol@2.0.1, npm:micromark-util-types@2.0.2, npm:rehype-highlight@7.0.2, npm:remark-gfm@4.0.1, npm:remark-rehype@11.1.2, npm:vfile-message@4.0.3
+[135] Applies to: npm:decode-named-character-reference@1.3.0, npm:hast-util-from-parse5@8.0.3, npm:hast-util-to-jsx-runtime@2.3.6, npm:hastscript@9.0.1, npm:lowlight@3.3.0, npm:markdown-table@3.0.4, npm:mdast-util-find-and-replace@3.0.2, npm:mdast-util-from-markdown@2.0.3, npm:mdast-util-gfm@3.1.0, npm:mdast-util-gfm-footnote@2.1.0, npm:mdast-util-to-markdown@2.1.2, npm:micromark@4.0.2, npm:micromark-core-commonmark@2.0.3, npm:micromark-extension-gfm-table@2.1.1, npm:micromark-factory-destination@2.0.1, npm:micromark-factory-label@2.0.1, npm:micromark-factory-space@2.0.1, npm:micromark-factory-title@2.0.1, npm:micromark-factory-whitespace@2.0.1, npm:micromark-util-character@2.1.1, npm:micromark-util-chunked@2.0.1, npm:micromark-util-classify-character@2.0.1, npm:micromark-util-combine-extensions@2.0.1, npm:micromark-util-decode-numeric-character-reference@2.0.2, npm:micromark-util-decode-string@2.0.1, npm:micromark-util-encode@2.0.1, npm:micromark-util-html-tag-name@2.0.1, npm:micromark-util-normalize-identifier@2.0.1, npm:micromark-util-resolve-all@2.0.1, npm:micromark-util-sanitize-uri@2.0.1, npm:micromark-util-subtokenize@2.1.0, npm:micromark-util-symbol@2.0.1, npm:micromark-util-types@2.0.2, npm:rehype-highlight@7.0.2, npm:remark-gfm@4.0.1, npm:remark-rehype@11.1.2, npm:vfile-message@4.0.3
 ------------------------------------------------------------------------------
 (The MIT License)
 
@@ -6801,7 +7349,7 @@ TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
 SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[124] Applies to: npm:deep-extend@0.6.0
+[136] Applies to: npm:deep-extend@0.6.0
 ------------------------------------------------------------------------------
 The MIT License (MIT)
 
@@ -6825,7 +7373,7 @@ IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
 CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[125] Applies to: npm:delaunator@5.1.0
+[137] Applies to: npm:delaunator@5.1.0
 ------------------------------------------------------------------------------
 ISC License
 
@@ -6844,7 +7392,7 @@ TORTIOUS ACTION, ARISING OUT OF OR IN CONNECTION WITH THE USE OR PERFORMANCE OF
 THIS SOFTWARE.
 
 ------------------------------------------------------------------------------
-[126] Applies to: npm:depd@2.0.0
+[138] Applies to: npm:depd@2.0.0
 ------------------------------------------------------------------------------
 (The MIT License)
 
@@ -6870,7 +7418,7 @@ TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
 SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[127] Applies to: npm:dequal@2.0.3, npm:mri@1.2.0
+[139] Applies to: npm:dequal@2.0.3, npm:mri@1.2.0
 ------------------------------------------------------------------------------
 The MIT License (MIT)
 
@@ -6895,7 +7443,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[128] Applies to: npm:detect-libc@2.1.2
+[140] Applies to: npm:detect-libc@2.1.2
 ------------------------------------------------------------------------------
 Apache License
                            Version 2.0, January 2004
@@ -7100,7 +7648,7 @@ Apache License
    limitations under the License.
 
 ------------------------------------------------------------------------------
-[129] Applies to: npm:detect-node-es@1.1.0
+[141] Applies to: npm:detect-node-es@1.1.0
 ------------------------------------------------------------------------------
 MIT License
 
@@ -7125,7 +7673,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
 ------------------------------------------------------------------------------
-[130] Applies to: npm:devlop@1.1.0
+[142] Applies to: npm:devlop@1.1.0
 ------------------------------------------------------------------------------
 (The MIT License)
 
@@ -7151,7 +7699,7 @@ TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
 SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[131] Applies to: npm:diff@8.0.4
+[143] Applies to: npm:diff@8.0.4
 ------------------------------------------------------------------------------
 BSD 3-Clause License
 
@@ -7184,7 +7732,7 @@ OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 ------------------------------------------------------------------------------
-[132] Applies to: npm:dijkstrajs@1.0.3
+[144] Applies to: npm:dijkstrajs@1.0.3
 ------------------------------------------------------------------------------
 ```
 Dijkstra path-finding functions. Adapted from the Dijkstar Python project.
@@ -7207,7 +7755,7 @@ THE SOFTWARE.
 ```
 
 ------------------------------------------------------------------------------
-[133] Applies to: npm:dingtalk-stream@v2.1.5
+[145] Applies to: npm:dingtalk-stream@v2.1.5
 ------------------------------------------------------------------------------
 MIT License
 
@@ -7232,7 +7780,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
 ------------------------------------------------------------------------------
-[134] Applies to: npm:discord-api-types@0.38.50
+[146] Applies to: npm:discord-api-types@0.38.50
 ------------------------------------------------------------------------------
 MIT License
 
@@ -7257,7 +7805,32 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
 ------------------------------------------------------------------------------
-[135] Applies to: npm:dompurify@3.4.12
+[147] Applies to: npm:docx@9.7.1
+------------------------------------------------------------------------------
+The MIT License (MIT)
+
+Copyright (c) 2016 Dolan
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+
+------------------------------------------------------------------------------
+[148] Applies to: npm:dompurify@3.4.12
 ------------------------------------------------------------------------------
 Apache License
                            Version 2.0, January 2004
@@ -7836,7 +8409,7 @@ Exhibit B - "Incompatible With Secondary Licenses" Notice
   defined by the Mozilla Public License, v. 2.0.
 
 ------------------------------------------------------------------------------
-[136] Applies to: npm:dunder-proto@1.0.1, npm:math-intrinsics@1.1.0
+[149] Applies to: npm:dunder-proto@1.0.1, npm:math-intrinsics@1.1.0
 ------------------------------------------------------------------------------
 MIT License
 
@@ -7861,7 +8434,37 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
 ------------------------------------------------------------------------------
-[137] Applies to: npm:ecdsa-sig-formatter@1.0.11
+[150] Applies to: npm:duplexer2@0.1.4
+------------------------------------------------------------------------------
+Copyright (c) 2013, Deoxxa Development
+======================================
+All rights reserved.
+--------------------
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+1. Redistributions of source code must retain the above copyright
+   notice, this list of conditions and the following disclaimer.
+2. Redistributions in binary form must reproduce the above copyright
+   notice, this list of conditions and the following disclaimer in the
+   documentation and/or other materials provided with the distribution.
+3. Neither the name of Deoxxa Development nor the names of its contributors
+   may be used to endorse or promote products derived from this software
+   without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY DEOXXA DEVELOPMENT ''AS IS'' AND ANY
+EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL DEOXXA DEVELOPMENT BE LIABLE FOR ANY
+DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+(INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+------------------------------------------------------------------------------
+[151] Applies to: npm:ecdsa-sig-formatter@1.0.11
 ------------------------------------------------------------------------------
 Apache License
                            Version 2.0, January 2004
@@ -8066,7 +8669,7 @@ Apache License
    limitations under the License.
 
 ------------------------------------------------------------------------------
-[138] Applies to: npm:ee-first@1.1.1
+[152] Applies to: npm:ee-first@1.1.1
 ------------------------------------------------------------------------------
 The MIT License (MIT)
 
@@ -8091,7 +8694,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[139] Applies to: npm:electron-squirrel-startup@1.0.1
+[153] Applies to: npm:electron-squirrel-startup@1.0.1
 ------------------------------------------------------------------------------
 Apache License
 Version 2.0, January 2004
@@ -8296,7 +8899,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 
 ------------------------------------------------------------------------------
-[140] Applies to: npm:electron-window-state@5.0.3
+[154] Applies to: npm:electron-window-state@5.0.3
 ------------------------------------------------------------------------------
 The MIT License (MIT)
 
@@ -8322,7 +8925,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[141] Applies to: npm:emoji-regex@8.0.0, npm:emoji-regex@9.2.2, npm:punycode@2.3.1
+[155] Applies to: npm:emoji-regex@8.0.0, npm:emoji-regex@9.2.2, npm:punycode@2.3.1
 ------------------------------------------------------------------------------
 Copyright Mathias Bynens <https://mathiasbynens.be/>
 
@@ -8346,7 +8949,7 @@ OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
 WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[142] Applies to: npm:encodeurl@2.0.0
+[156] Applies to: npm:encodeurl@2.0.0
 ------------------------------------------------------------------------------
 (The MIT License)
 
@@ -8372,7 +8975,7 @@ TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
 SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[143] Applies to: npm:end-of-stream@1.4.5, npm:pump@3.0.4, npm:tar-fs@2.1.5, npm:tar-stream@2.2.0
+[157] Applies to: npm:end-of-stream@1.4.5, npm:pump@3.0.4, npm:tar-fs@2.1.5, npm:tar-stream@2.2.0
 ------------------------------------------------------------------------------
 The MIT License (MIT)
 
@@ -8397,7 +9000,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[144] Applies to: npm:entities@6.0.1
+[158] Applies to: npm:entities@6.0.1
 ------------------------------------------------------------------------------
 Copyright (c) Felix Böhm
 All rights reserved.
@@ -8412,7 +9015,7 @@ THIS IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRE
 EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 ------------------------------------------------------------------------------
-[145] Applies to: npm:es-set-tostringtag@2.1.0
+[159] Applies to: npm:es-set-tostringtag@2.1.0
 ------------------------------------------------------------------------------
 MIT License
 
@@ -8437,7 +9040,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
 ------------------------------------------------------------------------------
-[146] Applies to: npm:es-toolkit@1.49.0
+[160] Applies to: npm:es-toolkit@1.49.0
 ------------------------------------------------------------------------------
 MIT License
 
@@ -8462,7 +9065,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
 ------------------------------------------------------------------------------
-[147] Applies to: npm:escape-html@1.0.3
+[161] Applies to: npm:escape-html@1.0.3
 ------------------------------------------------------------------------------
 (The MIT License)
 
@@ -8490,7 +9093,7 @@ TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
 SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[148] Applies to: npm:esprima@4.0.1
+[162] Applies to: npm:esprima@4.0.1
 ------------------------------------------------------------------------------
 Copyright JS Foundation and other contributors, https://js.foundation/
 
@@ -8515,7 +9118,7 @@ ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
 THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 ------------------------------------------------------------------------------
-[149] Applies to: npm:estree-util-is-identifier-name@3.0.0, npm:hast-util-heading-rank@3.0.0, npm:mdast-util-gfm-autolink-literal@2.0.1, npm:mdast-util-gfm-strikethrough@2.0.0, npm:mdast-util-gfm-table@2.0.0, npm:mdast-util-gfm-task-list-item@2.0.0, npm:mdast-util-math@3.0.0, npm:mdast-util-mdx-expression@2.0.1, npm:mdast-util-mdx-jsx@3.2.0, npm:mdast-util-mdxjs-esm@2.0.1, npm:micromark-extension-gfm@3.0.0, npm:micromark-extension-gfm-autolink-literal@2.1.0, npm:micromark-extension-gfm-strikethrough@2.1.0, npm:micromark-extension-gfm-tagfilter@2.0.0, npm:micromark-extension-gfm-task-list-item@2.1.0, npm:micromark-extension-math@3.1.0
+[163] Applies to: npm:estree-util-is-identifier-name@3.0.0, npm:hast-util-heading-rank@3.0.0, npm:mdast-util-gfm-autolink-literal@2.0.1, npm:mdast-util-gfm-strikethrough@2.0.0, npm:mdast-util-gfm-table@2.0.0, npm:mdast-util-gfm-task-list-item@2.0.0, npm:mdast-util-math@3.0.0, npm:mdast-util-mdx-expression@2.0.1, npm:mdast-util-mdx-jsx@3.2.0, npm:mdast-util-mdxjs-esm@2.0.1, npm:micromark-extension-gfm@3.0.0, npm:micromark-extension-gfm-autolink-literal@2.1.0, npm:micromark-extension-gfm-strikethrough@2.1.0, npm:micromark-extension-gfm-tagfilter@2.0.0, npm:micromark-extension-gfm-task-list-item@2.1.0, npm:micromark-extension-math@3.1.0
 ------------------------------------------------------------------------------
 (The MIT License)
 
@@ -8541,7 +9144,7 @@ TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
 SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[150] Applies to: npm:etag@1.8.1, npm:proxy-addr@2.0.7
+[164] Applies to: npm:etag@1.8.1, npm:proxy-addr@2.0.7
 ------------------------------------------------------------------------------
 (The MIT License)
 
@@ -8567,7 +9170,7 @@ TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
 SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[151] Applies to: npm:eventemitter3@5.0.4
+[165] Applies to: npm:eventemitter3@5.0.4
 ------------------------------------------------------------------------------
 The MIT License (MIT)
 
@@ -8592,7 +9195,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
 ------------------------------------------------------------------------------
-[152] Applies to: npm:eventsource@3.0.7
+[166] Applies to: npm:eventsource@3.0.7
 ------------------------------------------------------------------------------
 The MIT License
 
@@ -8618,7 +9221,7 @@ OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
 WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[153] Applies to: npm:eventsource-parser@3.1.0
+[167] Applies to: npm:eventsource-parser@3.1.0
 ------------------------------------------------------------------------------
 MIT License
 
@@ -8643,7 +9246,32 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
 ------------------------------------------------------------------------------
-[154] Applies to: npm:expand-template@2.0.3
+[168] Applies to: npm:exceljs@4.4.0
+------------------------------------------------------------------------------
+The MIT License (MIT)
+
+Copyright (c) 2014-2019 Guyon Roche
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+
+------------------------------------------------------------------------------
+[169] Applies to: npm:expand-template@2.0.3
 ------------------------------------------------------------------------------
 The MIT License (MIT)
 
@@ -8668,7 +9296,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[155] Applies to: npm:express@5.2.1
+[170] Applies to: npm:express@5.2.1
 ------------------------------------------------------------------------------
 (The MIT License)
 
@@ -8696,7 +9324,7 @@ TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
 SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[156] Applies to: npm:express-rate-limit@8.5.2
+[171] Applies to: npm:express-rate-limit@8.5.2
 ------------------------------------------------------------------------------
 # MIT License
 
@@ -8720,7 +9348,7 @@ IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
 CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[157] Applies to: npm:extend@3.0.2
+[172] Applies to: npm:extend@3.0.2
 ------------------------------------------------------------------------------
 The MIT License (MIT)
 
@@ -8746,7 +9374,7 @@ OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
 WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[158] Applies to: npm:extend-shallow@2.0.1
+[173] Applies to: npm:extend-shallow@2.0.1
 ------------------------------------------------------------------------------
 The MIT License (MIT)
 
@@ -8771,7 +9399,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[159] Applies to: npm:fast-deep-equal@3.1.3, npm:json-schema-traverse@1.0.0
+[174] Applies to: npm:fast-deep-equal@3.1.3, npm:json-schema-traverse@1.0.0
 ------------------------------------------------------------------------------
 MIT License
 
@@ -8796,7 +9424,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
 ------------------------------------------------------------------------------
-[160] Applies to: npm:fast-equals@5.4.1
+[175] Applies to: npm:fast-equals@5.4.1
 ------------------------------------------------------------------------------
 MIT License
 
@@ -8821,7 +9449,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
 ------------------------------------------------------------------------------
-[161] Applies to: npm:fast-uri@3.1.4
+[176] Applies to: npm:fast-uri@3.1.4
 ------------------------------------------------------------------------------
 Copyright (c) 2011-2021, Gary Court until https://github.com/garycourt/uri-js/commit/a1acf730b4bba3f1097c9f52e7d9d3aba8cdcaae
 Copyright (c) 2021-present The Fastify team <https://github.com/fastify/fastify#team>
@@ -8855,7 +9483,7 @@ The complete list of contributors can be found at:
 - https://github.com/garycourt/uri-js/graphs/contributors
 
 ------------------------------------------------------------------------------
-[162] Applies to: npm:fetch-blob@3.2.0
+[177] Applies to: npm:fetch-blob@3.2.0
 ------------------------------------------------------------------------------
 MIT License
 
@@ -8880,7 +9508,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
 ------------------------------------------------------------------------------
-[163] Applies to: npm:file-uri-to-path@1.0.0
+[178] Applies to: npm:file-uri-to-path@1.0.0
 ------------------------------------------------------------------------------
 Copyright (c) 2014 Nathan Rajlich <nathan@tootallnate.net>
 
@@ -8904,7 +9532,7 @@ TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
 SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[164] Applies to: npm:finalhandler@2.1.1
+[179] Applies to: npm:finalhandler@2.1.1
 ------------------------------------------------------------------------------
 (The MIT License)
 
@@ -8930,7 +9558,7 @@ TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
 SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[165] Applies to: npm:follow-redirects@1.16.0
+[180] Applies to: npm:follow-redirects@1.16.0
 ------------------------------------------------------------------------------
 Copyright 2014–present Olivier Lalonde <olalonde@gmail.com>, James Talmage <james@talmage.io>, Ruben Verborgh
 
@@ -8952,7 +9580,7 @@ WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR
 IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[166] Applies to: npm:foreground-child@3.3.1
+[181] Applies to: npm:foreground-child@3.3.1
 ------------------------------------------------------------------------------
 The ISC License
 
@@ -8971,7 +9599,7 @@ ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF OR
 IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
 
 ------------------------------------------------------------------------------
-[167] Applies to: npm:form-data@4.0.6
+[182] Applies to: npm:form-data@4.0.6
 ------------------------------------------------------------------------------
 Copyright (c) 2012 Felix Geisendörfer (felix@debuggable.com) and contributors
 
@@ -8994,7 +9622,7 @@ Copyright (c) 2012 Felix Geisendörfer (felix@debuggable.com) and contributors
  THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[168] Applies to: npm:formdata-polyfill@4.0.10
+[183] Applies to: npm:formdata-polyfill@4.0.10
 ------------------------------------------------------------------------------
 MIT License
 
@@ -9019,7 +9647,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
 ------------------------------------------------------------------------------
-[169] Applies to: npm:fresh@2.0.0
+[184] Applies to: npm:fresh@2.0.0
 ------------------------------------------------------------------------------
 (The MIT License)
 
@@ -9046,7 +9674,7 @@ TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
 SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[170] Applies to: npm:fs-constants@1.0.0
+[185] Applies to: npm:fs-constants@1.0.0
 ------------------------------------------------------------------------------
 The MIT License (MIT)
 
@@ -9071,7 +9699,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[171] Applies to: npm:fs-extra@11.3.6
+[186] Applies to: npm:fs-extra@11.3.6
 ------------------------------------------------------------------------------
 (The MIT License)
 
@@ -9090,7 +9718,54 @@ OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHE
  ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[172] Applies to: npm:function-bind@1.1.2
+[187] Applies to: npm:fs.realpath@1.0.0
+------------------------------------------------------------------------------
+The ISC License
+
+Copyright (c) Isaac Z. Schlueter and Contributors
+
+Permission to use, copy, modify, and/or distribute this software for any
+purpose with or without fee is hereby granted, provided that the above
+copyright notice and this permission notice appear in all copies.
+
+THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
+ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF OR
+IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+
+----
+
+This library bundles a version of the `fs.realpath` and `fs.realpathSync`
+methods from Node.js v0.10 under the terms of the Node.js MIT license.
+
+Node's license follows, also included at the header of `old.js` which contains
+the licensed code:
+
+  Copyright Joyent, Inc. and other Node contributors.
+
+  Permission is hereby granted, free of charge, to any person obtaining a
+  copy of this software and associated documentation files (the "Software"),
+  to deal in the Software without restriction, including without limitation
+  the rights to use, copy, modify, merge, publish, distribute, sublicense,
+  and/or sell copies of the Software, and to permit persons to whom the
+  Software is furnished to do so, subject to the following conditions:
+
+  The above copyright notice and this permission notice shall be included in
+  all copies or substantial portions of the Software.
+
+  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+  FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+  DEALINGS IN THE SOFTWARE.
+
+------------------------------------------------------------------------------
+[188] Applies to: npm:function-bind@1.1.2
 ------------------------------------------------------------------------------
 Copyright (c) 2013 Raynos.
 
@@ -9113,7 +9788,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[173] Applies to: npm:get-caller-file@2.0.5
+[189] Applies to: npm:get-caller-file@2.0.5
 ------------------------------------------------------------------------------
 ISC License (ISC)
 Copyright 2018 Stefan Penner
@@ -9123,7 +9798,7 @@ Permission to use, copy, modify, and/or distribute this software for any purpose
 THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
 
 ------------------------------------------------------------------------------
-[174] Applies to: npm:get-intrinsic@1.3.0
+[190] Applies to: npm:get-intrinsic@1.3.0
 ------------------------------------------------------------------------------
 MIT License
 
@@ -9148,7 +9823,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
 ------------------------------------------------------------------------------
-[175] Applies to: npm:get-nonce@1.0.1
+[191] Applies to: npm:get-nonce@1.0.1
 ------------------------------------------------------------------------------
 MIT License
 
@@ -9173,7 +9848,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
 ------------------------------------------------------------------------------
-[176] Applies to: npm:get-proto@1.0.1
+[192] Applies to: npm:get-proto@1.0.1
 ------------------------------------------------------------------------------
 MIT License
 
@@ -9198,29 +9873,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
 ------------------------------------------------------------------------------
-[177] Applies to: npm:github-from-package@0.0.0, npm:minimist@1.2.8
-------------------------------------------------------------------------------
-This software is released under the MIT license:
-
-Permission is hereby granted, free of charge, to any person obtaining a copy of
-this software and associated documentation files (the "Software"), to deal in
-the Software without restriction, including without limitation the rights to
-use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
-the Software, and to permit persons to whom the Software is furnished to do so,
-subject to the following conditions:
-
-The above copyright notice and this permission notice shall be included in all
-copies or substantial portions of the Software.
-
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
-FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
-COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
-IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
-CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
-
-------------------------------------------------------------------------------
-[178] Applies to: npm:github-slugger@2.0.0
+[193] Applies to: npm:github-slugger@2.0.0
 ------------------------------------------------------------------------------
 Copyright (c) 2015, Dan Flettre <fletd01@yahoo.com>
 
@@ -9229,7 +9882,7 @@ Permission to use, copy, modify, and/or distribute this software for any purpose
 THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
 
 ------------------------------------------------------------------------------
-[179] Applies to: npm:glob@10.5.0
+[194] Applies to: npm:glob@10.5.0
 ------------------------------------------------------------------------------
 The ISC License
 
@@ -9248,7 +9901,32 @@ ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF OR
 IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
 
 ------------------------------------------------------------------------------
-[180] Applies to: npm:gopd@1.2.0
+[195] Applies to: npm:glob@7.2.3
+------------------------------------------------------------------------------
+The ISC License
+
+Copyright (c) Isaac Z. Schlueter and Contributors
+
+Permission to use, copy, modify, and/or distribute this software for any
+purpose with or without fee is hereby granted, provided that the above
+copyright notice and this permission notice appear in all copies.
+
+THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
+ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF OR
+IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+
+## Glob Logo
+
+Glob's logo created by Tanya Brassie <http://tanyabrassie.com/>, licensed
+under a Creative Commons Attribution-ShareAlike 4.0 International License
+https://creativecommons.org/licenses/by-sa/4.0/
+
+------------------------------------------------------------------------------
+[196] Applies to: npm:gopd@1.2.0
 ------------------------------------------------------------------------------
 MIT License
 
@@ -9273,7 +9951,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
 ------------------------------------------------------------------------------
-[181] Applies to: npm:graceful-fs@4.2.11
+[197] Applies to: npm:graceful-fs@4.2.11
 ------------------------------------------------------------------------------
 The ISC License
 
@@ -9292,7 +9970,7 @@ ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF OR
 IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
 
 ------------------------------------------------------------------------------
-[182] Applies to: npm:gray-matter@4.0.3
+[198] Applies to: npm:gray-matter@4.0.3, npm:normalize-path@3.0.0
 ------------------------------------------------------------------------------
 The MIT License (MIT)
 
@@ -9317,7 +9995,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[183] Applies to: npm:gtoken@8.0.0
+[199] Applies to: npm:gtoken@8.0.0
 ------------------------------------------------------------------------------
 The MIT License (MIT)
 
@@ -9342,7 +10020,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[184] Applies to: npm:hachure-fill@0.5.2
+[200] Applies to: npm:hachure-fill@0.5.2
 ------------------------------------------------------------------------------
 MIT License
 
@@ -9367,7 +10045,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
 ------------------------------------------------------------------------------
-[185] Applies to: npm:harmonyos-sans-sc-webfont-splitted@1.1.0
+[201] Applies to: npm:harmonyos-sans-sc-webfont-splitted@1.1.0
 ------------------------------------------------------------------------------
 This is free and unencumbered software released into the public domain.
 
@@ -9395,7 +10073,7 @@ OTHER DEALINGS IN THE SOFTWARE.
 For more information, please refer to <https://unlicense.org>
 
 ------------------------------------------------------------------------------
-[186] Applies to: npm:has-symbols@1.1.0
+[202] Applies to: npm:has-symbols@1.1.0
 ------------------------------------------------------------------------------
 MIT License
 
@@ -9420,7 +10098,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
 ------------------------------------------------------------------------------
-[187] Applies to: npm:has-tostringtag@1.0.2
+[203] Applies to: npm:has-tostringtag@1.0.2
 ------------------------------------------------------------------------------
 MIT License
 
@@ -9445,7 +10123,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
 ------------------------------------------------------------------------------
-[188] Applies to: npm:hasown@2.0.4
+[204] Applies to: npm:hasown@2.0.4
 ------------------------------------------------------------------------------
 MIT License
 
@@ -9470,7 +10148,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
 ------------------------------------------------------------------------------
-[189] Applies to: npm:hast-util-from-dom@5.0.1
+[205] Applies to: npm:hast-util-from-dom@5.0.1
 ------------------------------------------------------------------------------
 (ISC License)
 
@@ -9489,7 +10167,7 @@ TORTIOUS ACTION, ARISING OUT OF OR IN CONNECTION WITH THE USE OR PERFORMANCE OF
 THIS SOFTWARE.
 
 ------------------------------------------------------------------------------
-[190] Applies to: npm:hast-util-from-html@2.0.3
+[206] Applies to: npm:hast-util-from-html@2.0.3
 ------------------------------------------------------------------------------
 (The MIT License)
 
@@ -9515,7 +10193,7 @@ TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
 SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[191] Applies to: npm:hast-util-from-html-isomorphic@2.0.0
+[207] Applies to: npm:hast-util-from-html-isomorphic@2.0.0
 ------------------------------------------------------------------------------
 (The MIT License)
 
@@ -9541,7 +10219,7 @@ TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
 SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[192] Applies to: npm:hast-util-to-string@3.0.1, npm:html-url-attributes@3.0.1
+[208] Applies to: npm:hast-util-to-string@3.0.1, npm:html-url-attributes@3.0.1
 ------------------------------------------------------------------------------
 (The MIT License)
 
@@ -9566,7 +10244,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[193] Applies to: npm:hast-util-to-text@4.0.2
+[209] Applies to: npm:hast-util-to-text@4.0.2
 ------------------------------------------------------------------------------
 (The MIT License)
 
@@ -9592,7 +10270,7 @@ TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
 SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[194] Applies to: npm:highlight.js@11.11.1
+[210] Applies to: npm:highlight.js@11.11.1
 ------------------------------------------------------------------------------
 BSD 3-Clause License
 
@@ -9625,7 +10303,7 @@ OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 ------------------------------------------------------------------------------
-[195] Applies to: npm:hono@4.12.30
+[211] Applies to: npm:hono@4.12.30
 ------------------------------------------------------------------------------
 MIT License
 
@@ -9650,7 +10328,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
 ------------------------------------------------------------------------------
-[196] Applies to: npm:html-to-image@1.11.13
+[212] Applies to: npm:html-to-image@1.11.13
 ------------------------------------------------------------------------------
 MIT License
 
@@ -9675,7 +10353,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
 ------------------------------------------------------------------------------
-[197] Applies to: npm:http-errors@2.0.1
+[213] Applies to: npm:http-errors@2.0.1
 ------------------------------------------------------------------------------
 The MIT License (MIT)
 
@@ -9701,7 +10379,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[198] Applies to: npm:human-signals@1.1.1, npm:human-signals@2.1.0
+[214] Applies to: npm:human-signals@1.1.1, npm:human-signals@2.1.0
 ------------------------------------------------------------------------------
 Apache License
                            Version 2.0, January 2004
@@ -9906,7 +10584,7 @@ Apache License
    limitations under the License.
 
 ------------------------------------------------------------------------------
-[199] Applies to: npm:i18next@26.3.6
+[215] Applies to: npm:i18next@26.3.6
 ------------------------------------------------------------------------------
 The MIT License (MIT)
 
@@ -9931,7 +10609,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
 ------------------------------------------------------------------------------
-[200] Applies to: npm:iconv-lite@0.6.3, npm:iconv-lite@0.7.3
+[216] Applies to: npm:iconv-lite@0.6.3, npm:iconv-lite@0.7.3
 ------------------------------------------------------------------------------
 Copyright (c) 2011 Alexander Shtuchkin
 
@@ -9955,7 +10633,7 @@ OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
 WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[201] Applies to: npm:ieee754@1.2.1
+[217] Applies to: npm:ieee754@1.2.1
 ------------------------------------------------------------------------------
 Copyright 2008 Fair Oaks Labs, Inc.
 
@@ -9970,7 +10648,7 @@ Redistribution and use in source and binary forms, with or without modification,
 THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 ------------------------------------------------------------------------------
-[202] Applies to: npm:ignore@7.0.6
+[218] Applies to: npm:ignore@7.0.6
 ------------------------------------------------------------------------------
 Copyright (c) 2013 Kael Zhang <i@kael.me>, contributors
 http://kael.me/
@@ -9995,7 +10673,20 @@ OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
 WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[203] Applies to: npm:immediate@3.0.6
+[219] Applies to: npm:image-size@1.2.1
+------------------------------------------------------------------------------
+The MIT License (MIT)
+
+Copyright © 2013-Present Aditya Yadav, http://netroy.in
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the “Software”), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+------------------------------------------------------------------------------
+[220] Applies to: npm:immediate@3.0.6
 ------------------------------------------------------------------------------
 Copyright (c) 2012 Barnesandnoble.com, llc, Donavon West, Domenic Denicola, Brian Cavalier
 
@@ -10019,7 +10710,7 @@ OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
 WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[204] Applies to: npm:import-meta-resolve@4.2.0
+[221] Applies to: npm:import-meta-resolve@4.2.0
 ------------------------------------------------------------------------------
 (The MIT License)
 
@@ -10097,7 +10788,26 @@ IN THE SOFTWARE.
 """
 
 ------------------------------------------------------------------------------
-[205] Applies to: npm:inherits@2.0.4
+[222] Applies to: npm:inflight@1.0.6
+------------------------------------------------------------------------------
+The ISC License
+
+Copyright (c) Isaac Z. Schlueter
+
+Permission to use, copy, modify, and/or distribute this software for any
+purpose with or without fee is hereby granted, provided that the above
+copyright notice and this permission notice appear in all copies.
+
+THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
+ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF OR
+IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+
+------------------------------------------------------------------------------
+[223] Applies to: npm:inherits@2.0.4
 ------------------------------------------------------------------------------
 The ISC License
 
@@ -10116,7 +10826,7 @@ OTHER TORTIOUS ACTION, ARISING OUT OF OR IN CONNECTION WITH THE USE OR
 PERFORMANCE OF THIS SOFTWARE.
 
 ------------------------------------------------------------------------------
-[206] Applies to: npm:inline-style-parser@0.2.7
+[224] Applies to: npm:inline-style-parser@0.2.7
 ------------------------------------------------------------------------------
 (The MIT License)
 
@@ -10129,7 +10839,7 @@ The above copyright notice and this permission notice shall be included in all c
 THE SOFTWARE IS PROVIDED 'AS IS', WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[207] Applies to: npm:internmap@1.0.1, npm:internmap@2.0.3
+[225] Applies to: npm:internmap@1.0.1, npm:internmap@2.0.3
 ------------------------------------------------------------------------------
 Copyright 2021 Mike Bostock
 
@@ -10146,7 +10856,7 @@ TORTIOUS ACTION, ARISING OUT OF OR IN CONNECTION WITH THE USE OR PERFORMANCE OF
 THIS SOFTWARE.
 
 ------------------------------------------------------------------------------
-[208] Applies to: npm:ip-address@10.2.0
+[226] Applies to: npm:ip-address@10.2.0
 ------------------------------------------------------------------------------
 Copyright (C) 2011 by Beau Gunderson
 
@@ -10169,7 +10879,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[209] Applies to: npm:ipaddr.js@1.9.1, npm:ipaddr.js@2.4.0
+[227] Applies to: npm:ipaddr.js@1.9.1, npm:ipaddr.js@2.4.0
 ------------------------------------------------------------------------------
 Copyright (C) 2011-2017 whitequark <whitequark@whitequark.org>
 
@@ -10192,7 +10902,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[210] Applies to: npm:is-buffer@1.1.6, npm:safe-buffer@5.1.2, npm:safe-buffer@5.2.1
+[228] Applies to: npm:is-buffer@1.1.6, npm:safe-buffer@5.1.2, npm:safe-buffer@5.2.1
 ------------------------------------------------------------------------------
 The MIT License (MIT)
 
@@ -10217,7 +10927,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[211] Applies to: npm:is-extendable@0.1.1
+[229] Applies to: npm:is-extendable@0.1.1
 ------------------------------------------------------------------------------
 The MIT License (MIT)
 
@@ -10242,7 +10952,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[212] Applies to: npm:is-extglob@2.1.1
+[230] Applies to: npm:is-extglob@2.1.1
 ------------------------------------------------------------------------------
 The MIT License (MIT)
 
@@ -10267,7 +10977,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[213] Applies to: npm:is-glob@4.0.3, npm:kind-of@6.0.3
+[231] Applies to: npm:is-glob@4.0.3, npm:kind-of@6.0.3
 ------------------------------------------------------------------------------
 The MIT License (MIT)
 
@@ -10292,7 +11002,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[214] Applies to: npm:is-promise@2.2.2, npm:is-promise@4.0.0
+[232] Applies to: npm:is-promise@2.2.2, npm:is-promise@4.0.0
 ------------------------------------------------------------------------------
 Copyright (c) 2014 Forbes Lindesay
 
@@ -10315,7 +11025,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[215] Applies to: npm:jackspeak@3.4.3
+[233] Applies to: npm:jackspeak@3.4.3
 ------------------------------------------------------------------------------
 # Blue Oak Model License
 
@@ -10374,7 +11084,7 @@ will be liable to anyone for any damages related to this
 software or this license, under any kind of legal claim._**
 
 ------------------------------------------------------------------------------
-[216] Applies to: npm:jose@6.2.3
+[234] Applies to: npm:jose@6.2.3
 ------------------------------------------------------------------------------
 The MIT License (MIT)
 
@@ -10399,7 +11109,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
 ------------------------------------------------------------------------------
-[217] Applies to: npm:js-base64@3.9.1
+[235] Applies to: npm:js-base64@3.9.1
 ------------------------------------------------------------------------------
 Copyright (c) 2014, Dan Kogai
 All rights reserved.
@@ -10430,7 +11140,7 @@ OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 ------------------------------------------------------------------------------
-[218] Applies to: npm:js-yaml@3.15.0, npm:js-yaml@4.3.0
+[236] Applies to: npm:js-yaml@3.15.0, npm:js-yaml@4.3.0
 ------------------------------------------------------------------------------
 (The MIT License)
 
@@ -10455,7 +11165,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[219] Applies to: npm:json-bigint@1.0.0
+[237] Applies to: npm:json-bigint@1.0.0
 ------------------------------------------------------------------------------
 The MIT License (MIT)
 
@@ -10479,7 +11189,7 @@ IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
 CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[220] Applies to: npm:json-schema-to-ts@3.1.1, npm:ts-algebra@2.0.0
+[238] Applies to: npm:json-schema-to-ts@3.1.1, npm:ts-algebra@2.0.0
 ------------------------------------------------------------------------------
 MIT License
 
@@ -10504,7 +11214,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
 ------------------------------------------------------------------------------
-[221] Applies to: npm:json-schema-typed@7.0.3
+[239] Applies to: npm:json-schema-typed@7.0.3
 ------------------------------------------------------------------------------
 BSD-2-Clause License
 
@@ -10534,7 +11244,7 @@ ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 POSSIBILITY OF SUCH DAMAGE.
 
 ------------------------------------------------------------------------------
-[222] Applies to: npm:json-schema-typed@8.0.2
+[240] Applies to: npm:json-schema-typed@8.0.2
 ------------------------------------------------------------------------------
 BSD 2-Clause License
 
@@ -10595,7 +11305,7 @@ ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
 SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 ------------------------------------------------------------------------------
-[223] Applies to: npm:jsonfile@4.0.0, npm:jsonfile@6.2.1
+[241] Applies to: npm:jsonfile@4.0.0, npm:jsonfile@6.2.1
 ------------------------------------------------------------------------------
 (The MIT License)
 
@@ -10614,7 +11324,7 @@ OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHE
  ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[224] Applies to: npm:jszip@3.10.1
+[242] Applies to: npm:jszip@3.10.1
 ------------------------------------------------------------------------------
 JSZip is dual licensed. At your choice you may use it under the MIT license *or* the GPLv3
 license.
@@ -11269,7 +11979,7 @@ copy of the Program in return for a fee.
                      END OF TERMS AND CONDITIONS
 
 ------------------------------------------------------------------------------
-[225] Applies to: npm:jwa@2.0.1, npm:jws@4.0.1
+[243] Applies to: npm:jwa@2.0.1, npm:jws@4.0.1
 ------------------------------------------------------------------------------
 Copyright (c) 2013 Brian J. Brennan
 
@@ -11290,7 +12000,7 @@ FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TOR
 ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[226] Applies to: npm:katex@0.16.47
+[244] Applies to: npm:katex@0.16.47
 ------------------------------------------------------------------------------
 The MIT License (MIT)
 
@@ -11315,7 +12025,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
 ------------------------------------------------------------------------------
-[227] Applies to: npm:khroma@2.1.0
+[245] Applies to: npm:khroma@2.1.0
 ------------------------------------------------------------------------------
 The MIT License (MIT)
 
@@ -11340,7 +12050,7 @@ FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
 DEALINGS IN THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[228] Applies to: npm:layout-base@1.0.2, npm:layout-base@2.0.1
+[246] Applies to: npm:layout-base@1.0.2, npm:layout-base@2.0.1
 ------------------------------------------------------------------------------
 MIT License
 
@@ -11365,7 +12075,33 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
 ------------------------------------------------------------------------------
-[229] Applies to: npm:lie@3.3.0
+[247] Applies to: npm:lazystream@1.0.1
+------------------------------------------------------------------------------
+Copyright (c) 2013 J. Pommerening, contributors.
+
+Permission is hereby granted, free of charge, to any person
+obtaining a copy of this software and associated documentation
+files (the "Software"), to deal in the Software without
+restriction, including without limitation the rights to use,
+copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the
+Software is furnished to do so, subject to the following
+conditions:
+
+The above copyright notice and this permission notice shall be
+included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
+OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+OTHER DEALINGS IN THE SOFTWARE.
+
+------------------------------------------------------------------------------
+[248] Applies to: npm:lie@3.3.0
 ------------------------------------------------------------------------------
 #Copyright (c) 2014-2018 Calvin Metcalf, Jordan Harband
 
@@ -11376,7 +12112,16 @@ The above copyright notice and this permission notice shall be included in all c
 **THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.**
 
 ------------------------------------------------------------------------------
-[230] Applies to: npm:lodash@4.18.1, npm:lodash-es@4.18.1, npm:lodash.merge@4.6.2
+[249] Applies to: npm:listenercount@1.0.1
+------------------------------------------------------------------------------
+Copyright (c) MMXV jden <jason@denizac.org>
+
+Permission to use, copy, modify, and/or distribute this software for any purpose with or without fee is hereby granted, provided that the above copyright notice and this permission notice appear in all copies.
+
+THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+
+------------------------------------------------------------------------------
+[250] Applies to: npm:lodash@4.18.1, npm:lodash-es@4.18.1, npm:lodash.merge@4.6.2
 ------------------------------------------------------------------------------
 Copyright OpenJS Foundation and other contributors <https://openjsf.org/>
 
@@ -11427,33 +12172,7 @@ licenses; we recommend you read them, as their terms may differ from the
 terms above.
 
 ------------------------------------------------------------------------------
-[231] Applies to: npm:lodash.identity@3.0.0
-------------------------------------------------------------------------------
-Copyright 2012-2015 The Dojo Foundation <http://dojofoundation.org/>
-Based on Underscore.js 1.7.0, copyright 2009-2015 Jeremy Ashkenas,
-DocumentCloud and Investigative Reporters & Editors <http://underscorejs.org/>
-
-Permission is hereby granted, free of charge, to any person obtaining
-a copy of this software and associated documentation files (the
-"Software"), to deal in the Software without restriction, including
-without limitation the rights to use, copy, modify, merge, publish,
-distribute, sublicense, and/or sell copies of the Software, and to
-permit persons to whom the Software is furnished to do so, subject to
-the following conditions:
-
-The above copyright notice and this permission notice shall be
-included in all copies or substantial portions of the Software.
-
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
-EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
-MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
-NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
-LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
-OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
-WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
-
-------------------------------------------------------------------------------
-[232] Applies to: npm:lodash.pickby@4.6.0, npm:lodash.snakecase@4.1.1
+[251] Applies to: npm:lodash.defaults@4.2.0, npm:lodash.difference@4.5.0, npm:lodash.escaperegexp@4.1.2, npm:lodash.flatten@4.4.0, npm:lodash.groupby@4.6.0, npm:lodash.isplainobject@4.0.6, npm:lodash.pickby@4.6.0, npm:lodash.snakecase@4.1.1, npm:lodash.union@4.6.0, npm:lodash.uniq@4.5.0
 ------------------------------------------------------------------------------
 Copyright jQuery Foundation and other contributors <https://jquery.org/>
 
@@ -11504,7 +12223,136 @@ licenses; we recommend you read them, as their terms may differ from the
 terms above.
 
 ------------------------------------------------------------------------------
-[233] Applies to: npm:longest-streak@3.1.0, npm:stringify-entities@4.0.4, npm:trim-lines@3.0.1
+[252] Applies to: npm:lodash.identity@3.0.0
+------------------------------------------------------------------------------
+Copyright 2012-2015 The Dojo Foundation <http://dojofoundation.org/>
+Based on Underscore.js 1.7.0, copyright 2009-2015 Jeremy Ashkenas,
+DocumentCloud and Investigative Reporters & Editors <http://underscorejs.org/>
+
+Permission is hereby granted, free of charge, to any person obtaining
+a copy of this software and associated documentation files (the
+"Software"), to deal in the Software without restriction, including
+without limitation the rights to use, copy, modify, merge, publish,
+distribute, sublicense, and/or sell copies of the Software, and to
+permit persons to whom the Software is furnished to do so, subject to
+the following conditions:
+
+The above copyright notice and this permission notice shall be
+included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+------------------------------------------------------------------------------
+[253] Applies to: npm:lodash.isboolean@3.0.3, npm:lodash.isnil@4.0.0
+------------------------------------------------------------------------------
+Copyright 2012-2016 The Dojo Foundation <http://dojofoundation.org/>
+Based on Underscore.js, copyright 2009-2016 Jeremy Ashkenas,
+DocumentCloud and Investigative Reporters & Editors <http://underscorejs.org/>
+
+Permission is hereby granted, free of charge, to any person obtaining
+a copy of this software and associated documentation files (the
+"Software"), to deal in the Software without restriction, including
+without limitation the rights to use, copy, modify, merge, publish,
+distribute, sublicense, and/or sell copies of the Software, and to
+permit persons to whom the Software is furnished to do so, subject to
+the following conditions:
+
+The above copyright notice and this permission notice shall be
+included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+------------------------------------------------------------------------------
+[254] Applies to: npm:lodash.isequal@4.5.0, npm:lodash.isfunction@3.0.9
+------------------------------------------------------------------------------
+Copyright JS Foundation and other contributors <https://js.foundation/>
+
+Based on Underscore.js, copyright Jeremy Ashkenas,
+DocumentCloud and Investigative Reporters & Editors <http://underscorejs.org/>
+
+This software consists of voluntary contributions made by many
+individuals. For exact contribution history, see the revision history
+available at https://github.com/lodash/lodash
+
+The following license applies to all parts of this software except as
+documented below:
+
+====
+
+Permission is hereby granted, free of charge, to any person obtaining
+a copy of this software and associated documentation files (the
+"Software"), to deal in the Software without restriction, including
+without limitation the rights to use, copy, modify, merge, publish,
+distribute, sublicense, and/or sell copies of the Software, and to
+permit persons to whom the Software is furnished to do so, subject to
+the following conditions:
+
+The above copyright notice and this permission notice shall be
+included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+====
+
+Copyright and related rights for sample code are waived via CC0. Sample
+code is defined as all source code displayed within the prose of the
+documentation.
+
+CC0: http://creativecommons.org/publicdomain/zero/1.0/
+
+====
+
+Files located in the node_modules and vendor directories are externally
+maintained libraries used by this software which have their own
+licenses; we recommend you read them, as their terms may differ from the
+terms above.
+
+------------------------------------------------------------------------------
+[255] Applies to: npm:lodash.isundefined@3.0.1
+------------------------------------------------------------------------------
+Copyright 2012-2015 The Dojo Foundation <http://dojofoundation.org/>
+Based on Underscore.js, copyright 2009-2015 Jeremy Ashkenas,
+DocumentCloud and Investigative Reporters & Editors <http://underscorejs.org/>
+
+Permission is hereby granted, free of charge, to any person obtaining
+a copy of this software and associated documentation files (the
+"Software"), to deal in the Software without restriction, including
+without limitation the rights to use, copy, modify, merge, publish,
+distribute, sublicense, and/or sell copies of the Software, and to
+permit persons to whom the Software is furnished to do so, subject to
+the following conditions:
+
+The above copyright notice and this permission notice shall be
+included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+------------------------------------------------------------------------------
+[256] Applies to: npm:longest-streak@3.1.0, npm:stringify-entities@4.0.4, npm:trim-lines@3.0.1
 ------------------------------------------------------------------------------
 (The MIT License)
 
@@ -11530,7 +12378,7 @@ TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
 SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[234] Applies to: npm:loudness@0.4.2
+[257] Applies to: npm:loudness@0.4.2
 ------------------------------------------------------------------------------
 The MIT License (MIT)
 
@@ -11554,7 +12402,7 @@ IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
 CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[235] Applies to: npm:lru-cache@10.4.3
+[258] Applies to: npm:lru-cache@10.4.3
 ------------------------------------------------------------------------------
 The ISC License
 
@@ -11573,7 +12421,7 @@ ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF OR
 IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
 
 ------------------------------------------------------------------------------
-[236] Applies to: npm:lucide-react@0.468.0
+[259] Applies to: npm:lucide-react@0.468.0
 ------------------------------------------------------------------------------
 ISC License
 
@@ -11592,7 +12440,7 @@ ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
 OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
 
 ------------------------------------------------------------------------------
-[237] Applies to: npm:magic-bytes.js@1.13.0
+[260] Applies to: npm:magic-bytes.js@1.13.0
 ------------------------------------------------------------------------------
 MIT License
 
@@ -11617,7 +12465,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
 ------------------------------------------------------------------------------
-[238] Applies to: npm:marked@16.4.2
+[261] Applies to: npm:marked@16.4.2
 ------------------------------------------------------------------------------
 # License information
 
@@ -11665,7 +12513,7 @@ Redistribution and use in source and binary forms, with or without modification,
 This software is provided by the copyright holders and contributors “as is” and any express or implied warranties, including, but not limited to, the implied warranties of merchantability and fitness for a particular purpose are disclaimed. In no event shall the copyright owner or contributors be liable for any direct, indirect, incidental, special, exemplary, or consequential damages (including, but not limited to, procurement of substitute goods or services; loss of use, data, or profits; or business interruption) however caused and on any theory of liability, whether in contract, strict liability, or tort (including negligence or otherwise) arising in any way out of the use of this software, even if advised of the possibility of such damage.
 
 ------------------------------------------------------------------------------
-[239] Applies to: npm:md5@2.3.0
+[262] Applies to: npm:md5@2.3.0
 ------------------------------------------------------------------------------
 Copyright © 2011-2012, Paul Vorbach.
 Copyright © 2009, Jeff Mott.
@@ -11696,7 +12544,7 @@ ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
 SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 ------------------------------------------------------------------------------
-[240] Applies to: npm:mdast-util-phrasing@4.1.0
+[263] Applies to: npm:mdast-util-phrasing@4.1.0
 ------------------------------------------------------------------------------
 (The MIT License)
 
@@ -11723,7 +12571,7 @@ TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
 SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[241] Applies to: npm:mdast-util-to-markdown-cjk-friendly@1.0.0, npm:remark-cjk-friendly@2.3.1
+[264] Applies to: npm:mdast-util-to-markdown-cjk-friendly@1.0.0, npm:remark-cjk-friendly@2.3.1
 ------------------------------------------------------------------------------
 Copyright (c) 2025 Tatsunori Uchino <tats.u@live.jp>
 
@@ -11755,7 +12603,7 @@ TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
 SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[242] Applies to: npm:merge-descriptors@2.0.0
+[265] Applies to: npm:merge-descriptors@2.0.0
 ------------------------------------------------------------------------------
 MIT License
 
@@ -11770,7 +12618,7 @@ The above copyright notice and this permission notice shall be included in all c
 THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[243] Applies to: npm:merge-stream@2.0.0
+[266] Applies to: npm:merge-stream@2.0.0
 ------------------------------------------------------------------------------
 The MIT License (MIT)
 
@@ -11795,7 +12643,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[244] Applies to: npm:mermaid@11.16.0
+[267] Applies to: npm:mermaid@11.16.0
 ------------------------------------------------------------------------------
 The MIT License (MIT)
 
@@ -11820,7 +12668,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
 ------------------------------------------------------------------------------
-[245] Applies to: npm:micromark-extension-cjk-friendly@2.0.1
+[268] Applies to: npm:micromark-extension-cjk-friendly@2.0.1
 ------------------------------------------------------------------------------
 Copyright (c) 2025 Tatsunori Uchino <tats.u@live.jp>
 
@@ -11852,7 +12700,7 @@ TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
 SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[246] Applies to: npm:micromark-extension-cjk-friendly-util@3.0.1
+[269] Applies to: npm:micromark-extension-cjk-friendly-util@3.0.1
 ------------------------------------------------------------------------------
 Copyright (c) 2025 Tatsunori Uchino <tats.u@live.jp>
 
@@ -11884,7 +12732,7 @@ TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
 SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[247] Applies to: npm:micromark-extension-gfm-footnote@2.1.0
+[270] Applies to: npm:micromark-extension-gfm-footnote@2.1.0
 ------------------------------------------------------------------------------
 (The MIT License)
 
@@ -11910,7 +12758,7 @@ TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
 SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[248] Applies to: npm:mime-db@1.52.0, npm:mime-db@1.54.0
+[271] Applies to: npm:mime-db@1.52.0, npm:mime-db@1.54.0
 ------------------------------------------------------------------------------
 (The MIT License)
 
@@ -11937,7 +12785,24 @@ TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
 SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[249] Applies to: npm:minimatch@9.0.9, npm:rimraf@5.0.10
+[272] Applies to: npm:minimalistic-assert@1.0.1
+------------------------------------------------------------------------------
+Copyright 2015 Calvin Metcalf
+
+Permission to use, copy, modify, and/or distribute this software for any purpose
+with or without fee is hereby granted, provided that the above copyright notice
+and this permission notice appear in all copies.
+
+THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES WITH
+REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF MERCHANTABILITY AND
+FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY SPECIAL, DIRECT,
+INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES WHATSOEVER RESULTING FROM
+LOSS OF USE, DATA OR PROFITS, WHETHER IN AN ACTION OF CONTRACT, NEGLIGENCE
+OR OTHER TORTIOUS ACTION, ARISING OUT OF OR IN CONNECTION WITH THE USE OR
+PERFORMANCE OF THIS SOFTWARE.
+
+------------------------------------------------------------------------------
+[273] Applies to: npm:minimatch@5.1.9, npm:minimatch@9.0.9, npm:rimraf@5.0.10
 ------------------------------------------------------------------------------
 The ISC License
 
@@ -11956,7 +12821,7 @@ ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF OR
 IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
 
 ------------------------------------------------------------------------------
-[250] Applies to: npm:minipass@7.1.3, npm:path-scurry@1.11.1, npm:tar@7.5.22
+[274] Applies to: npm:minipass@7.1.3, npm:path-scurry@1.11.1, npm:sax@1.6.0, npm:tar@7.5.22
 ------------------------------------------------------------------------------
 # Blue Oak Model License
 
@@ -12015,7 +12880,7 @@ will be liable to anyone for any damages related to this
 software or this license, under any kind of legal claim.***
 
 ------------------------------------------------------------------------------
-[251] Applies to: npm:minizlib@3.1.0
+[275] Applies to: npm:minizlib@3.1.0
 ------------------------------------------------------------------------------
 Minizlib was created by Isaac Z. Schlueter.
 It is a derivative work of the Node.js project.
@@ -12045,7 +12910,7 @@ SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 """
 
 ------------------------------------------------------------------------------
-[252] Applies to: npm:mkdirp@0.5.6
+[276] Applies to: npm:mkdirp@0.5.6
 ------------------------------------------------------------------------------
 Copyright 2010 James Halliday (mail@substack.net)
 
@@ -12070,7 +12935,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[253] Applies to: npm:mkdirp-classic@0.5.3
+[277] Applies to: npm:mkdirp-classic@0.5.3
 ------------------------------------------------------------------------------
 The MIT License (MIT)
 
@@ -12095,7 +12960,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[254] Applies to: npm:ms@2.0.0
+[278] Applies to: npm:ms@2.0.0
 ------------------------------------------------------------------------------
 The MIT License (MIT)
 
@@ -12120,7 +12985,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
 ------------------------------------------------------------------------------
-[255] Applies to: npm:ms@2.1.3
+[279] Applies to: npm:ms@2.1.3
 ------------------------------------------------------------------------------
 The MIT License (MIT)
 
@@ -12145,7 +13010,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
 ------------------------------------------------------------------------------
-[256] Applies to: npm:nan@2.28.0
+[280] Applies to: npm:nan@2.28.0
 ------------------------------------------------------------------------------
 The MIT License (MIT)
 
@@ -12158,7 +13023,31 @@ The above copyright notice and this permission notice shall be included in all c
 THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[257] Applies to: npm:napi-build-utils@2.0.0
+[281] Applies to: npm:nanoid@5.1.16
+------------------------------------------------------------------------------
+The MIT License (MIT)
+
+Copyright 2017 Andrey Sitnik <andrey@sitnik.es>
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of
+this software and associated documentation files (the "Software"), to deal in
+the Software without restriction, including without limitation the rights to
+use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+the Software, and to permit persons to whom the Software is furnished to do so,
+subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+------------------------------------------------------------------------------
+[282] Applies to: npm:napi-build-utils@2.0.0
 ------------------------------------------------------------------------------
 MIT License
 
@@ -12183,7 +13072,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
 ------------------------------------------------------------------------------
-[258] Applies to: npm:negotiator@1.0.0
+[283] Applies to: npm:negotiator@1.0.0
 ------------------------------------------------------------------------------
 (The MIT License)
 
@@ -12211,7 +13100,7 @@ TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
 SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[259] Applies to: npm:node-abi@3.94.0
+[284] Applies to: npm:node-abi@3.94.0
 ------------------------------------------------------------------------------
 MIT License
 
@@ -12236,7 +13125,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
 ------------------------------------------------------------------------------
-[260] Applies to: npm:node-addon-api@7.1.1
+[285] Applies to: npm:node-addon-api@7.1.1
 ------------------------------------------------------------------------------
 The MIT License (MIT)
 
@@ -12249,7 +13138,7 @@ The above copyright notice and this permission notice shall be included in all c
 THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[261] Applies to: npm:node-domexception@1.0.0
+[286] Applies to: npm:node-domexception@1.0.0
 ------------------------------------------------------------------------------
 MIT License
 
@@ -12274,7 +13163,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
 ------------------------------------------------------------------------------
-[262] Applies to: npm:node-fetch@3.3.2
+[287] Applies to: npm:node-fetch@3.3.2
 ------------------------------------------------------------------------------
 The MIT License (MIT)
 
@@ -12299,7 +13188,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
 ------------------------------------------------------------------------------
-[263] Applies to: npm:node-machine-id@1.1.12
+[288] Applies to: npm:node-machine-id@1.1.12
 ------------------------------------------------------------------------------
 The MIT License (MIT)
 
@@ -12324,7 +13213,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
 ------------------------------------------------------------------------------
-[264] Applies to: npm:node-pty@1.1.0
+[289] Applies to: npm:node-pty@1.1.0
 ------------------------------------------------------------------------------
 Copyright (c) 2012-2015, Christopher Jeffrey (https://github.com/chjj/)
 
@@ -12397,7 +13286,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
 ------------------------------------------------------------------------------
-[265] Applies to: npm:object-inspect@1.13.4
+[290] Applies to: npm:object-inspect@1.13.4
 ------------------------------------------------------------------------------
 MIT License
 
@@ -12422,7 +13311,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
 ------------------------------------------------------------------------------
-[266] Applies to: npm:on-finished@2.4.1
+[291] Applies to: npm:on-finished@2.4.1
 ------------------------------------------------------------------------------
 (The MIT License)
 
@@ -12449,7 +13338,7 @@ TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
 SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[267] Applies to: npm:orderedmap@2.1.1, npm:w3c-keyname@2.2.8
+[292] Applies to: npm:orderedmap@2.1.1, npm:w3c-keyname@2.2.8
 ------------------------------------------------------------------------------
 Copyright (C) 2016 by Marijn Haverbeke <marijn@haverbeke.berlin> and others
 
@@ -12472,7 +13361,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[268] Applies to: npm:package-manager-detector@1.7.0
+[293] Applies to: npm:package-manager-detector@1.7.0
 ------------------------------------------------------------------------------
 MIT License
 
@@ -12497,7 +13386,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
 ------------------------------------------------------------------------------
-[269] Applies to: npm:pako@1.0.11
+[294] Applies to: npm:pako@1.0.11
 ------------------------------------------------------------------------------
 (The MIT License)
 
@@ -12522,7 +13411,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[270] Applies to: npm:parse-entities@4.0.2, npm:property-information@7.2.0
+[295] Applies to: npm:parse-entities@4.0.2, npm:property-information@7.2.0
 ------------------------------------------------------------------------------
 (The MIT License)
 
@@ -12548,7 +13437,7 @@ TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
 SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[271] Applies to: npm:parse5@7.3.0
+[296] Applies to: npm:parse5@7.3.0
 ------------------------------------------------------------------------------
 Copyright (c) 2013-2019 Ivan Nikulin (ifaaan@gmail.com, https://github.com/inikulin)
 
@@ -12571,7 +13460,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[272] Applies to: npm:parseurl@1.3.3
+[297] Applies to: npm:parseurl@1.3.3
 ------------------------------------------------------------------------------
 (The MIT License)
 
@@ -12598,7 +13487,7 @@ TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
 SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[273] Applies to: npm:path-data-parser@0.1.0, npm:points-on-curve@0.2.0
+[298] Applies to: npm:path-data-parser@0.1.0, npm:points-on-curve@0.2.0
 ------------------------------------------------------------------------------
 MIT License
 
@@ -12623,7 +13512,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
 ------------------------------------------------------------------------------
-[274] Applies to: npm:path-to-regexp@8.4.2
+[299] Applies to: npm:path-to-regexp@8.4.2
 ------------------------------------------------------------------------------
 The MIT License (MIT)
 
@@ -12648,7 +13537,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[275] Applies to: npm:pdfjs-dist@5.7.284
+[300] Applies to: npm:pdfjs-dist@5.7.284
 ------------------------------------------------------------------------------
 Apache License
                            Version 2.0, January 2004
@@ -12828,7 +13717,7 @@ Apache License
    END OF TERMS AND CONDITIONS
 
 ------------------------------------------------------------------------------
-[276] Applies to: npm:picomatch@4.0.5
+[301] Applies to: npm:picomatch@4.0.5
 ------------------------------------------------------------------------------
 The MIT License (MIT)
 
@@ -12853,7 +13742,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[277] Applies to: npm:pkce-challenge@5.0.1
+[302] Applies to: npm:pkce-challenge@5.0.1
 ------------------------------------------------------------------------------
 MIT License
 
@@ -12878,7 +13767,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
 ------------------------------------------------------------------------------
-[278] Applies to: npm:playwright-core@1.60.0
+[303] Applies to: npm:playwright-core@1.60.0
 ------------------------------------------------------------------------------
 Apache License
                            Version 2.0, January 2004
@@ -13084,7 +13973,7 @@ Apache License
    limitations under the License.
 
 ------------------------------------------------------------------------------
-[279] Applies to: npm:playwright-core@1.60.0 (NOTICE)
+[304] Applies to: npm:playwright-core@1.60.0 (NOTICE)
 ------------------------------------------------------------------------------
 NOTICE for npm:playwright-core@1.60.0:
 
@@ -13095,7 +13984,7 @@ This software contains code derived from the Puppeteer project (https://github.c
 available under the Apache 2.0 license (https://github.com/puppeteer/puppeteer/blob/master/LICENSE).
 
 ------------------------------------------------------------------------------
-[280] Applies to: npm:pngjs@5.0.0
+[305] Applies to: npm:pngjs@5.0.0
 ------------------------------------------------------------------------------
 pngjs2 original work Copyright (c) 2015 Luke Page & Original Contributors
 pngjs derived work Copyright (c) 2012 Kuba Niegowski
@@ -13119,7 +14008,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[281] Applies to: npm:points-on-path@0.2.1
+[306] Applies to: npm:points-on-path@0.2.1
 ------------------------------------------------------------------------------
 MIT License
 
@@ -13144,7 +14033,32 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
 ------------------------------------------------------------------------------
-[282] Applies to: npm:prebuild-install@7.1.3
+[307] Applies to: npm:pptxgenjs@4.0.1
+------------------------------------------------------------------------------
+The MIT License (MIT)
+
+Copyright (c) 2015-2022 Brent Ely
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+
+------------------------------------------------------------------------------
+[308] Applies to: npm:prebuild-install@7.1.3
 ------------------------------------------------------------------------------
 The MIT License (MIT)
 
@@ -13169,7 +14083,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[283] Applies to: npm:process-nextick-args@2.0.1
+[309] Applies to: npm:process-nextick-args@2.0.1
 ------------------------------------------------------------------------------
 # Copyright (c) 2015 Calvin Metcalf
 
@@ -13192,7 +14106,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.**
 
 ------------------------------------------------------------------------------
-[284] Applies to: npm:promise-worker-transferable@1.0.4
+[310] Applies to: npm:promise-worker-transferable@1.0.4
 ------------------------------------------------------------------------------
 Apache License
                           Version 2.0, January 2004
@@ -13397,7 +14311,7 @@ Apache License
   limitations under the License.
 
 ------------------------------------------------------------------------------
-[285] Applies to: npm:prosemirror-changeset@2.4.1
+[311] Applies to: npm:prosemirror-changeset@2.4.1
 ------------------------------------------------------------------------------
 Copyright (C) 2017 by Marijn Haverbeke <marijn@haverbeke.berlin> and others
 
@@ -13420,7 +14334,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[286] Applies to: npm:prosemirror-commands@1.7.1, npm:prosemirror-dropcursor@1.8.3, npm:prosemirror-gapcursor@1.4.1, npm:prosemirror-history@1.5.0, npm:prosemirror-inputrules@1.5.1, npm:prosemirror-keymap@1.2.3, npm:prosemirror-model@1.25.11, npm:prosemirror-schema-list@1.5.1, npm:prosemirror-state@1.4.4, npm:prosemirror-transform@1.12.0, npm:prosemirror-view@1.42.1
+[312] Applies to: npm:prosemirror-commands@1.7.1, npm:prosemirror-dropcursor@1.8.3, npm:prosemirror-gapcursor@1.4.1, npm:prosemirror-history@1.5.0, npm:prosemirror-inputrules@1.5.1, npm:prosemirror-keymap@1.2.3, npm:prosemirror-model@1.25.11, npm:prosemirror-schema-list@1.5.1, npm:prosemirror-state@1.4.4, npm:prosemirror-transform@1.12.0, npm:prosemirror-view@1.42.1
 ------------------------------------------------------------------------------
 Copyright (C) 2015-2017 by Marijn Haverbeke <marijn@haverbeke.berlin> and others
 
@@ -13443,7 +14357,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[287] Applies to: npm:prosemirror-tables@1.8.5
+[313] Applies to: npm:prosemirror-tables@1.8.5
 ------------------------------------------------------------------------------
 Copyright (C) 2015-2016 by Marijn Haverbeke <marijnh@gmail.com> and others
 
@@ -13466,7 +14380,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[288] Applies to: npm:protobufjs@7.6.5
+[314] Applies to: npm:protobufjs@7.6.5
 ------------------------------------------------------------------------------
 This license applies to all parts of protobuf.js except those files
 either explicitly including or referencing a different license or
@@ -13509,7 +14423,7 @@ standalone and requires a support library to be linked with it. This
 support library is itself covered by the above license.
 
 ------------------------------------------------------------------------------
-[289] Applies to: npm:proxy-from-env@2.1.0
+[315] Applies to: npm:proxy-from-env@2.1.0
 ------------------------------------------------------------------------------
 The MIT License
 
@@ -13533,7 +14447,7 @@ IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
 CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[290] Applies to: npm:qrcode@1.5.4
+[316] Applies to: npm:qrcode@1.5.4
 ------------------------------------------------------------------------------
 The MIT License (MIT)
 
@@ -13546,7 +14460,7 @@ The above copyright notice and this permission notice shall be included in all c
 THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[291] Applies to: npm:qs@6.15.3
+[317] Applies to: npm:qs@6.15.3
 ------------------------------------------------------------------------------
 BSD 3-Clause License
 
@@ -13579,7 +14493,19 @@ OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 ------------------------------------------------------------------------------
-[292] Applies to: npm:range-parser@1.3.0
+[318] Applies to: npm:queue@6.0.2
+------------------------------------------------------------------------------
+The MIT License (MIT)
+Copyright (c) 2014 Jesse Tane <jesse.tane@gmail.com>
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+------------------------------------------------------------------------------
+[319] Applies to: npm:range-parser@1.3.0
 ------------------------------------------------------------------------------
 (The MIT License)
 
@@ -13606,7 +14532,7 @@ TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
 SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[293] Applies to: npm:raw-body@3.0.2
+[320] Applies to: npm:raw-body@3.0.2
 ------------------------------------------------------------------------------
 The MIT License (MIT)
 
@@ -13632,7 +14558,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[294] Applies to: npm:rc@1.2.8
+[321] Applies to: npm:rc@1.2.8
 ------------------------------------------------------------------------------
 Apache License, Version 2.0
 
@@ -13703,7 +14629,7 @@ TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
 SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[295] Applies to: npm:react@19.2.3, npm:react-dom@19.2.3, npm:scheduler@0.27.0, npm:use-sync-external-store@1.6.0
+[322] Applies to: npm:react@19.2.3, npm:react-dom@19.2.3, npm:scheduler@0.27.0, npm:use-sync-external-store@1.6.0
 ------------------------------------------------------------------------------
 MIT License
 
@@ -13728,7 +14654,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
 ------------------------------------------------------------------------------
-[296] Applies to: npm:react-i18next@17.0.10
+[323] Applies to: npm:react-i18next@17.0.10
 ------------------------------------------------------------------------------
 The MIT License (MIT)
 
@@ -13753,7 +14679,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
 ------------------------------------------------------------------------------
-[297] Applies to: npm:react-markdown@10.1.0
+[324] Applies to: npm:react-markdown@10.1.0
 ------------------------------------------------------------------------------
 The MIT License (MIT)
 
@@ -13778,7 +14704,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
 ------------------------------------------------------------------------------
-[298] Applies to: npm:react-router@7.18.1, npm:react-router-dom@7.18.1
+[325] Applies to: npm:react-router@7.18.1, npm:react-router-dom@7.18.1
 ------------------------------------------------------------------------------
 MIT License
 
@@ -13805,7 +14731,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
 ------------------------------------------------------------------------------
-[299] Applies to: npm:readable-stream@2.3.8, npm:readable-stream@3.6.2, npm:string_decoder@1.1.1, npm:string_decoder@1.3.0
+[326] Applies to: npm:readable-stream@2.3.8, npm:readable-stream@3.6.2, npm:string_decoder@1.1.1, npm:string_decoder@1.3.0
 ------------------------------------------------------------------------------
 Node.js is licensed for use as follows:
 
@@ -13856,7 +14782,212 @@ IN THE SOFTWARE.
 """
 
 ------------------------------------------------------------------------------
-[300] Applies to: npm:remark-parse@11.0.0, npm:remark-stringify@11.0.0
+[327] Applies to: npm:readdir-glob@1.1.3
+------------------------------------------------------------------------------
+Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright 2020 Yann Armelin
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+
+------------------------------------------------------------------------------
+[328] Applies to: npm:remark-parse@11.0.0, npm:remark-stringify@11.0.0
 ------------------------------------------------------------------------------
 (The MIT License)
 
@@ -13881,7 +15012,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[301] Applies to: npm:require-directory@2.1.1
+[329] Applies to: npm:require-directory@2.1.1
 ------------------------------------------------------------------------------
 The MIT License (MIT)
 
@@ -13907,7 +15038,7 @@ TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
 SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[302] Applies to: npm:require-from-string@2.0.2
+[330] Applies to: npm:require-from-string@2.0.2
 ------------------------------------------------------------------------------
 The MIT License (MIT)
 
@@ -13932,7 +15063,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[303] Applies to: npm:require-main-filename@2.0.0, npm:set-blocking@2.0.0, npm:yargs-parser@18.1.3
+[331] Applies to: npm:require-main-filename@2.0.0, npm:set-blocking@2.0.0, npm:yargs-parser@18.1.3
 ------------------------------------------------------------------------------
 Copyright (c) 2016, Contributors
 
@@ -13950,35 +15081,7 @@ WHETHER IN AN ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION,
 ARISING OUT OF OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
 
 ------------------------------------------------------------------------------
-[304] Applies to: npm:robust-predicates@3.0.3, npm:tweetnacl@0.14.5
-------------------------------------------------------------------------------
-This is free and unencumbered software released into the public domain.
-
-Anyone is free to copy, modify, publish, use, compile, sell, or
-distribute this software, either in source code form or as a compiled
-binary, for any purpose, commercial or non-commercial, and by any
-means.
-
-In jurisdictions that recognize copyright laws, the author or authors
-of this software dedicate any and all copyright interest in the
-software to the public domain. We make this dedication for the benefit
-of the public at large and to the detriment of our heirs and
-successors. We intend this dedication to be an overt act of
-relinquishment in perpetuity of all present and future rights to this
-software under copyright law.
-
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
-EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
-MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
-IN NO EVENT SHALL THE AUTHORS BE LIABLE FOR ANY CLAIM, DAMAGES OR
-OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
-ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
-OTHER DEALINGS IN THE SOFTWARE.
-
-For more information, please refer to <http://unlicense.org>
-
-------------------------------------------------------------------------------
-[305] Applies to: npm:rope-sequence@1.3.4
+[332] Applies to: npm:rope-sequence@1.3.4
 ------------------------------------------------------------------------------
 Copyright (C) 2016 by Marijn Haverbeke <marijn@haverbeke.berlin>
 
@@ -14001,7 +15104,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[306] Applies to: npm:roughjs@4.6.6
+[333] Applies to: npm:roughjs@4.6.6
 ------------------------------------------------------------------------------
 MIT License
 
@@ -14026,7 +15129,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
 ------------------------------------------------------------------------------
-[307] Applies to: npm:router@2.2.0
+[334] Applies to: npm:router@2.2.0
 ------------------------------------------------------------------------------
 (The MIT License)
 
@@ -14053,7 +15156,7 @@ TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
 SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[308] Applies to: npm:rw@1.3.3
+[335] Applies to: npm:rw@1.3.3
 ------------------------------------------------------------------------------
 Copyright (c) 2014-2016, Michael Bostock
 All rights reserved.
@@ -14083,7 +15186,7 @@ NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE,
 EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 ------------------------------------------------------------------------------
-[309] Applies to: npm:safer-buffer@2.1.2
+[336] Applies to: npm:safer-buffer@2.1.2
 ------------------------------------------------------------------------------
 MIT License
 
@@ -14108,7 +15211,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
 ------------------------------------------------------------------------------
-[310] Applies to: npm:section-matter@1.0.0
+[337] Applies to: npm:section-matter@1.0.0
 ------------------------------------------------------------------------------
 The MIT License (MIT)
 
@@ -14133,7 +15236,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
 ------------------------------------------------------------------------------
-[311] Applies to: npm:send@1.2.1
+[338] Applies to: npm:send@1.2.1
 ------------------------------------------------------------------------------
 (The MIT License)
 
@@ -14160,7 +15263,7 @@ TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
 SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[312] Applies to: npm:serve-static@2.2.1
+[339] Applies to: npm:serve-static@2.2.1
 ------------------------------------------------------------------------------
 (The MIT License)
 
@@ -14189,7 +15292,7 @@ TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
 SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[313] Applies to: npm:set-cookie-parser@2.7.2
+[340] Applies to: npm:set-cookie-parser@2.7.2
 ------------------------------------------------------------------------------
 The MIT License (MIT)
 
@@ -14214,7 +15317,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[314] Applies to: npm:setimmediate@1.0.5
+[341] Applies to: npm:setimmediate@1.0.5
 ------------------------------------------------------------------------------
 Copyright (c) 2012 Barnesandnoble.com, llc, Donavon West, and Domenic Denicola
 
@@ -14238,7 +15341,7 @@ OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
 WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[315] Applies to: npm:setprototypeof@1.2.0
+[342] Applies to: npm:setprototypeof@1.2.0
 ------------------------------------------------------------------------------
 Copyright (c) 2015, Wes Todd
 
@@ -14255,7 +15358,7 @@ OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF OR IN
 CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
 
 ------------------------------------------------------------------------------
-[316] Applies to: npm:shebang-command@2.0.0
+[343] Applies to: npm:shebang-command@2.0.0
 ------------------------------------------------------------------------------
 MIT License
 
@@ -14268,7 +15371,7 @@ The above copyright notice and this permission notice shall be included in all c
 THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[317] Applies to: npm:side-channel@1.1.1, npm:side-channel-weakmap@1.0.2
+[344] Applies to: npm:side-channel@1.1.1, npm:side-channel-weakmap@1.0.2
 ------------------------------------------------------------------------------
 MIT License
 
@@ -14293,7 +15396,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
 ------------------------------------------------------------------------------
-[318] Applies to: npm:signal-exit@3.0.7
+[345] Applies to: npm:signal-exit@3.0.7
 ------------------------------------------------------------------------------
 The ISC License
 
@@ -14313,7 +15416,7 @@ WHETHER IN AN ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION,
 ARISING OUT OF OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
 
 ------------------------------------------------------------------------------
-[319] Applies to: npm:signal-exit@4.1.0
+[346] Applies to: npm:signal-exit@4.1.0
 ------------------------------------------------------------------------------
 The ISC License
 
@@ -14333,7 +15436,7 @@ WHETHER IN AN ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION,
 ARISING OUT OF OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
 
 ------------------------------------------------------------------------------
-[320] Applies to: npm:silk-wasm@3.7.1
+[347] Applies to: npm:silk-wasm@3.7.1
 ------------------------------------------------------------------------------
 MIT License
 
@@ -14358,7 +15461,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
 ------------------------------------------------------------------------------
-[321] Applies to: npm:simple-concat@1.0.1, npm:simple-get@4.0.1
+[348] Applies to: npm:simple-concat@1.0.1, npm:simple-get@4.0.1
 ------------------------------------------------------------------------------
 The MIT License (MIT)
 
@@ -14382,7 +15485,7 @@ IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
 CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[322] Applies to: npm:smol-toml@1.7.0
+[349] Applies to: npm:smol-toml@1.7.0
 ------------------------------------------------------------------------------
 Copyright (c) Squirrel Chat et al., All rights reserved.
 
@@ -14410,7 +15513,7 @@ OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 ------------------------------------------------------------------------------
-[323] Applies to: npm:sortablejs@1.15.7
+[350] Applies to: npm:sortablejs@1.15.7
 ------------------------------------------------------------------------------
 MIT License
 
@@ -14435,7 +15538,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
 ------------------------------------------------------------------------------
-[324] Applies to: npm:sprintf-js@1.0.3
+[351] Applies to: npm:sprintf-js@1.0.3
 ------------------------------------------------------------------------------
 Copyright (c) 2007-2014, Alexandru Marasteanu <hello [at) alexei (dot] ro>
 All rights reserved.
@@ -14463,7 +15566,7 @@ ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
 SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 ------------------------------------------------------------------------------
-[325] Applies to: npm:ssh-config@5.2.0
+[352] Applies to: npm:ssh-config@5.2.0
 ------------------------------------------------------------------------------
 MIT License
 
@@ -14488,7 +15591,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
 ------------------------------------------------------------------------------
-[326] Applies to: npm:statuses@2.0.2
+[353] Applies to: npm:statuses@2.0.2
 ------------------------------------------------------------------------------
 The MIT License (MIT)
 
@@ -14514,7 +15617,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[327] Applies to: npm:strip-bom-string@1.0.0
+[354] Applies to: npm:strip-bom-string@1.0.0
 ------------------------------------------------------------------------------
 The MIT License (MIT)
 
@@ -14539,7 +15642,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[328] Applies to: npm:style-mod@4.1.3
+[355] Applies to: npm:style-mod@4.1.3
 ------------------------------------------------------------------------------
 Copyright (C) 2018 by Marijn Haverbeke <marijn@haverbeke.berlin> and others
 
@@ -14562,7 +15665,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[329] Applies to: npm:style-to-js@1.1.21
+[356] Applies to: npm:style-to-js@1.1.21
 ------------------------------------------------------------------------------
 The MIT License (MIT)
 
@@ -14588,7 +15691,7 @@ OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
 WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[330] Applies to: npm:style-to-object@1.0.14
+[357] Applies to: npm:style-to-object@1.0.14
 ------------------------------------------------------------------------------
 The MIT License (MIT)
 
@@ -14614,7 +15717,7 @@ OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
 WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[331] Applies to: npm:stylis@4.4.0
+[358] Applies to: npm:stylis@4.4.0
 ------------------------------------------------------------------------------
 MIT License
 
@@ -14639,7 +15742,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
 ------------------------------------------------------------------------------
-[332] Applies to: npm:tailwind-merge@2.6.1
+[359] Applies to: npm:tailwind-merge@2.6.1
 ------------------------------------------------------------------------------
 MIT License
 
@@ -14664,7 +15767,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
 ------------------------------------------------------------------------------
-[333] Applies to: npm:tinyexec@1.2.4
+[360] Applies to: npm:tinyexec@1.2.4
 ------------------------------------------------------------------------------
 MIT License
 
@@ -14689,7 +15792,32 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
 ------------------------------------------------------------------------------
-[334] Applies to: npm:toidentifier@1.0.1
+[361] Applies to: npm:tmp@0.2.7
+------------------------------------------------------------------------------
+The MIT License (MIT)
+
+Copyright (c) 2014 KARASZI István
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+
+------------------------------------------------------------------------------
+[362] Applies to: npm:toidentifier@1.0.1
 ------------------------------------------------------------------------------
 MIT License
 
@@ -14714,7 +15842,35 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
 ------------------------------------------------------------------------------
-[335] Applies to: npm:trough@2.2.0
+[363] Applies to: npm:traverse@0.3.9
+------------------------------------------------------------------------------
+Copyright 2010 James Halliday (mail@substack.net)
+
+This project is free software released under the MIT/X11 license:
+http://www.opensource.org/licenses/mit-license.php
+
+Copyright 2010 James Halliday (mail@substack.net)
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+
+------------------------------------------------------------------------------
+[364] Applies to: npm:trough@2.2.0
 ------------------------------------------------------------------------------
 (The MIT License)
 
@@ -14739,7 +15895,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[336] Applies to: npm:ts-dedent@2.3.0
+[365] Applies to: npm:ts-dedent@2.3.0
 ------------------------------------------------------------------------------
 MIT License
 
@@ -14764,7 +15920,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
 ------------------------------------------------------------------------------
-[337] Applies to: npm:ts-mixer@6.0.4
+[366] Applies to: npm:ts-mixer@6.0.4
 ------------------------------------------------------------------------------
 MIT License
 
@@ -14789,7 +15945,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
 ------------------------------------------------------------------------------
-[338] Applies to: npm:tslib@2.8.1
+[367] Applies to: npm:tslib@2.8.1
 ------------------------------------------------------------------------------
 Copyright (c) Microsoft Corporation.
 
@@ -14805,7 +15961,7 @@ OTHER TORTIOUS ACTION, ARISING OUT OF OR IN CONNECTION WITH THE USE OR
 PERFORMANCE OF THIS SOFTWARE.
 
 ------------------------------------------------------------------------------
-[339] Applies to: npm:tslog@4.11.0
+[368] Applies to: npm:tslog@4.11.0
 ------------------------------------------------------------------------------
 MIT License
 
@@ -14830,7 +15986,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
 ------------------------------------------------------------------------------
-[340] Applies to: npm:tunnel-agent@0.6.0
+[369] Applies to: npm:tunnel-agent@0.6.0
 ------------------------------------------------------------------------------
 Apache License
 
@@ -14889,7 +16045,7 @@ If the Work includes a "NOTICE" text file as part of its distribution, then any 
 END OF TERMS AND CONDITIONS
 
 ------------------------------------------------------------------------------
-[341] Applies to: npm:type-fest@0.20.2
+[370] Applies to: npm:type-fest@0.20.2
 ------------------------------------------------------------------------------
 MIT License
 
@@ -14902,7 +16058,7 @@ The above copyright notice and this permission notice shall be included in all c
 THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[342] Applies to: npm:typebox@1.1.39
+[371] Applies to: npm:typebox@1.1.39
 ------------------------------------------------------------------------------
 TypeBox
 
@@ -14929,7 +16085,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[343] Applies to: npm:undici@6.27.0, npm:undici@8.7.0, npm:undici-types@7.24.6
+[372] Applies to: npm:undici@6.27.0, npm:undici@8.7.0, npm:undici-types@6.21.0, npm:undici-types@7.24.6
 ------------------------------------------------------------------------------
 MIT License
 
@@ -14954,7 +16110,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
 ------------------------------------------------------------------------------
-[344] Applies to: npm:unified@11.0.5, npm:vfile@6.0.3
+[373] Applies to: npm:unified@11.0.5, npm:vfile@6.0.3
 ------------------------------------------------------------------------------
 (The MIT License)
 
@@ -14979,7 +16135,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[345] Applies to: npm:unist-util-is@6.0.1
+[374] Applies to: npm:unist-util-is@6.0.1
 ------------------------------------------------------------------------------
 (The MIT license)
 
@@ -15005,7 +16161,7 @@ TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
 SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[346] Applies to: npm:universalify@2.0.1
+[375] Applies to: npm:universalify@2.0.1
 ------------------------------------------------------------------------------
 (The MIT License)
 
@@ -15029,7 +16185,7 @@ IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
 CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[347] Applies to: npm:unpipe@1.0.0
+[376] Applies to: npm:unpipe@1.0.0
 ------------------------------------------------------------------------------
 (The MIT License)
 
@@ -15055,7 +16211,36 @@ TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
 SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[348] Applies to: npm:uri-js@4.4.1
+[377] Applies to: npm:unzipper@0.10.14
+------------------------------------------------------------------------------
+Copyright (c) 2012 - 2013 Near Infinity Corporation
+
+Permission is hereby granted, free of charge, to any person obtaining
+a copy of this software and associated documentation files (the
+"Software"), to deal in the Software without restriction, including
+without limitation the rights to use, copy, modify, merge, publish,
+distribute, sublicense, and/or sell copies of the Software, and to
+permit persons to whom the Software is furnished to do so, subject to
+the following conditions:
+
+The above copyright notice and this permission notice shall be
+included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+---
+
+Commits in this fork are (c) Ziggy Jonsson (ziggy.jonsson.nyc@gmail.com)
+and fall under same licence structure as the original repo (MIT)
+
+------------------------------------------------------------------------------
+[378] Applies to: npm:uri-js@4.4.1
 ------------------------------------------------------------------------------
 Copyright 2011 Gary Court. All rights reserved.
 
@@ -15070,7 +16255,7 @@ THIS SOFTWARE IS PROVIDED BY GARY COURT "AS IS" AND ANY EXPRESS OR IMPLIED WARRA
 The views and conclusions contained in the software and documentation are those of the authors and should not be interpreted as representing official policies, either expressed or implied, of Gary Court.
 
 ------------------------------------------------------------------------------
-[349] Applies to: npm:url-template@2.0.8
+[379] Applies to: npm:url-template@2.0.8
 ------------------------------------------------------------------------------
 Copyright (c) 2012-2014, Bram Stein
 All rights reserved.
@@ -15099,7 +16284,7 @@ NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE,
 EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 ------------------------------------------------------------------------------
-[350] Applies to: npm:util-deprecate@1.0.2
+[380] Applies to: npm:util-deprecate@1.0.2
 ------------------------------------------------------------------------------
 (The MIT License)
 
@@ -15127,7 +16312,7 @@ FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
 OTHER DEALINGS IN THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[351] Applies to: npm:uuid@14.0.1
+[381] Applies to: npm:uuid@14.0.1, npm:uuid@8.3.2
 ------------------------------------------------------------------------------
 The MIT License (MIT)
 
@@ -15140,7 +16325,7 @@ The above copyright notice and this permission notice shall be included in all c
 THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[352] Applies to: npm:void-elements@3.1.0
+[382] Applies to: npm:void-elements@3.1.0
 ------------------------------------------------------------------------------
 (The MIT License)
 
@@ -15166,7 +16351,7 @@ TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
 SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[353] Applies to: npm:web-streams-polyfill@3.3.3
+[383] Applies to: npm:web-streams-polyfill@3.3.3
 ------------------------------------------------------------------------------
 The MIT License (MIT)
 
@@ -15192,7 +16377,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
 ------------------------------------------------------------------------------
-[354] Applies to: npm:which-module@2.0.1
+[384] Applies to: npm:which-module@2.0.1
 ------------------------------------------------------------------------------
 Copyright (c) 2016, Contributors
 
@@ -15209,7 +16394,7 @@ TORTIOUS ACTION, ARISING OUT OF OR IN CONNECTION WITH THE USE OR PERFORMANCE OF
 THIS SOFTWARE.
 
 ------------------------------------------------------------------------------
-[355] Applies to: npm:workerpool@9.1.1
+[385] Applies to: npm:workerpool@9.1.1
 ------------------------------------------------------------------------------
 Apache License
                            Version 2.0, January 2004
@@ -15414,7 +16599,7 @@ Apache License
    limitations under the License.
 
 ------------------------------------------------------------------------------
-[356] Applies to: npm:ws@8.21.1
+[386] Applies to: npm:ws@8.21.1
 ------------------------------------------------------------------------------
 Copyright (c) 2011 Einar Otto Stangvik <einaros@gmail.com>
 Copyright (c) 2013 Arnout Kazemier and contributors
@@ -15438,7 +16623,80 @@ IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
 CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[357] Applies to: npm:y18n@4.0.3
+[387] Applies to: npm:xml@1.0.1
+------------------------------------------------------------------------------
+(The MIT License)
+
+Copyright (c) 2011-2016 Dylan Greene <dylang@gmail.com>
+
+Permission is hereby granted, free of charge, to any person obtaining
+a copy of this software and associated documentation files (the
+'Software'), to deal in the Software without restriction, including
+without limitation the rights to use, copy, modify, merge, publish,
+distribute, sublicense, and/or sell copies of the Software, and to
+permit persons to whom the Software is furnished to do so, subject to
+the following conditions:
+
+The above copyright notice and this permission notice shall be
+included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED 'AS IS', WITHOUT WARRANTY OF ANY KIND,
+EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+------------------------------------------------------------------------------
+[388] Applies to: npm:xml-js@1.6.11
+------------------------------------------------------------------------------
+The MIT License (MIT)
+
+Copyright (c) 2016-2017 Yousuf Almarzooqi
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+
+------------------------------------------------------------------------------
+[389] Applies to: npm:xmlchars@2.2.0
+------------------------------------------------------------------------------
+Copyright Louis-Dominique Dubeau and contributors to xmlchars
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of
+this software and associated documentation files (the "Software"), to deal in
+the Software without restriction, including without limitation the rights to
+use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+the Software, and to permit persons to whom the Software is furnished to do so,
+subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+------------------------------------------------------------------------------
+[390] Applies to: npm:y18n@4.0.3
 ------------------------------------------------------------------------------
 Copyright (c) 2015, Contributors
 
@@ -15455,7 +16713,7 @@ TORTIOUS ACTION, ARISING OUT OF OR IN CONNECTION WITH THE USE OR PERFORMANCE OF
 THIS SOFTWARE.
 
 ------------------------------------------------------------------------------
-[358] Applies to: npm:yargs@15.4.1
+[391] Applies to: npm:yargs@15.4.1
 ------------------------------------------------------------------------------
 MIT License
 
@@ -15480,7 +16738,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[359] Applies to: npm:zod@4.3.6
+[392] Applies to: npm:zod@4.3.6
 ------------------------------------------------------------------------------
 MIT License
 
@@ -15505,7 +16763,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
 ------------------------------------------------------------------------------
-[360] Applies to: npm:zod-to-json-schema@3.25.2
+[393] Applies to: npm:zod-to-json-schema@3.25.2
 ------------------------------------------------------------------------------
 ISC License
 
@@ -15545,12 +16803,18 @@ Packages without a standalone license file (license per package.json):
 - npm:@sapphire/snowflake@3.5.5 (MIT)
 - npm:@wecom/aibot-node-sdk@1.0.7 (MIT)
 - npm:agent-base@6.0.2 (MIT)
+- npm:binary@0.3.0 (MIT)
+- npm:buffers@0.1.1 (MIT)
+- npm:chainsaw@0.1.0 (MIT)
 - npm:data-uri-to-buffer@4.0.1 (MIT)
 - npm:drizzle-orm@0.45.2 (Apache-2.0)
 - npm:eastasianwidth@0.2.0 (MIT)
+- npm:hash.js@1.1.7 (MIT)
 - npm:html-parse-stringify@3.0.1 (MIT)
+- npm:https@1.0.0 (ISC)
 - npm:https-proxy-agent@5.0.1 (MIT)
 - npm:isarray@1.0.0 (MIT)
 - npm:react-remove-scroll-bar@2.3.8 (MIT)
 - npm:rehype-katex@7.0.1 (MIT)
 - npm:remark-math@6.0.0 (MIT)
+- npm:saxes@5.0.1 (ISC)

--- a/docs/legal/notices/desktop-win-restricted.txt
+++ b/docs/legal/notices/desktop-win-restricted.txt
@@ -7,7 +7,7 @@ Cindy desktop application — Windows x64
 This file separately discloses components not distributed under open-source licenses.
 
 ------------------------------------------------------------------------------
-Claude Code CLI@2.1.219
+Claude Code CLI@2.1.259
 Category: proprietary
 License: LicenseRef-Anthropic-Commercial-Terms
 Source: https://www.anthropic.com/legal/commercial-terms

--- a/docs/legal/notices/desktop-win.txt
+++ b/docs/legal/notices/desktop-win.txt
@@ -259,7 +259,7 @@ Apache License
 Copyright (c) OpenAI
 
 ------------------------------------------------------------------------------
-pi coding agent (runtime-downloaded binary) 0.83.0
+pi coding agent (runtime-downloaded binary) 0.84.4
 License: MIT
 Source: https://github.com/earendil-works/pi
 ------------------------------------------------------------------------------
@@ -3652,12 +3652,16 @@ necessary.  Here is a sample; alter the names:
 That's all there is to it!
 
 ==============================================================================
-SECTION 2: npm packages (785 packages)
+SECTION 2: npm packages (856 packages)
 ==============================================================================
 
 - @antfu/install-pkg@1.1.0 — MIT — https://github.com/antfu/install-pkg
 - @anthropic-ai/sdk@0.91.1 — MIT — https://github.com/anthropics/anthropic-sdk-typescript
+- @babel/helper-string-parser@7.29.7 — MIT — https://github.com/babel/babel
+- @babel/helper-validator-identifier@7.29.7 — MIT — https://github.com/babel/babel
+- @babel/parser@7.29.7 — MIT — https://github.com/babel/babel
 - @babel/runtime@7.29.7 — MIT — https://github.com/babel/babel
+- @babel/types@7.29.7 — MIT — https://github.com/babel/babel
 - @braintree/sanitize-url@7.1.2 — MIT — https://github.com/braintree/sanitize-url
 - @chevrotain/types@11.1.2 — Apache-2.0 — https://github.com/Chevrotain/chevrotain
 - @chinese-fonts/font-contours@1.0.0 — ISC
@@ -3690,6 +3694,8 @@ SECTION 2: npm packages (785 packages)
 - @discordjs/rest@2.6.2 — Apache-2.0 — https://github.com/discordjs/discord.js
 - @discordjs/util@1.2.0 — Apache-2.0 — https://github.com/discordjs/discord.js
 - @discordjs/ws@1.2.3 — Apache-2.0 — https://github.com/discordjs/discord.js
+- @fast-csv/format@4.3.5 — MIT — https://github.com/C2FO/fast-csv
+- @fast-csv/parse@4.3.6 — MIT — https://github.com/C2FO/fast-csv
 - @floating-ui/core@1.8.0 — MIT — https://github.com/floating-ui/floating-ui
 - @floating-ui/dom@1.8.0 — MIT — https://github.com/floating-ui/floating-ui
 - @floating-ui/react-dom@2.1.9 — MIT — https://github.com/floating-ui/floating-ui
@@ -3843,6 +3849,8 @@ SECTION 2: npm packages (785 packages)
 - @types/katex@0.16.8 — MIT — https://github.com/DefinitelyTyped/DefinitelyTyped
 - @types/mdast@4.0.4 — MIT — https://github.com/DefinitelyTyped/DefinitelyTyped
 - @types/ms@2.1.0 — MIT — https://github.com/DefinitelyTyped/DefinitelyTyped
+- @types/node@14.18.63 — MIT — https://github.com/DefinitelyTyped/DefinitelyTyped
+- @types/node@22.20.1 — MIT — https://github.com/DefinitelyTyped/DefinitelyTyped
 - @types/node@25.9.5 — MIT — https://github.com/DefinitelyTyped/DefinitelyTyped
 - @types/trusted-types@2.0.7 — MIT — https://github.com/DefinitelyTyped/DefinitelyTyped
 - @types/unist@2.0.11 — MIT — https://github.com/DefinitelyTyped/DefinitelyTyped
@@ -3868,10 +3876,14 @@ SECTION 2: npm packages (785 packages)
 - ansi-regex@6.2.2 — MIT — https://github.com/chalk/ansi-regex
 - ansi-styles@4.3.0 — MIT — https://github.com/chalk/ansi-styles
 - ansi-styles@6.2.3 — MIT — https://github.com/chalk/ansi-styles
+- archiver@5.3.2 — MIT — https://github.com/archiverjs/node-archiver
+- archiver-utils@2.1.0 — MIT — https://github.com/archiverjs/archiver-utils
+- archiver-utils@3.0.4 — MIT — https://github.com/archiverjs/archiver-utils
 - argparse@1.0.10 — MIT — https://github.com/nodeca/argparse
 - argparse@2.0.1 — Python-2.0 — https://github.com/nodeca/argparse
 - aria-hidden@1.2.6 — MIT — https://github.com/theKashey/aria-hidden
 - asn1@0.2.6 — MIT — https://github.com/joyent/node-asn1
+- async@3.2.6 — MIT — https://github.com/caolan/async
 - asynckit@0.4.0 — MIT — https://github.com/alexindigo/asynckit
 - atomically@1.7.0 — MIT — https://github.com/fabiospampinato/atomically
 - axios@1.18.1 — MIT — https://github.com/axios/axios
@@ -3880,13 +3892,20 @@ SECTION 2: npm packages (785 packages)
 - base64-js@1.5.1 — MIT — https://github.com/beatgammit/base64-js
 - bcrypt-pbkdf@1.0.2 — BSD-3-Clause — https://github.com/joyent/node-bcrypt-pbkdf
 - better-sqlite3@12.11.1 — MIT — https://github.com/WiseLibs/better-sqlite3
+- big-integer@1.6.52 — Unlicense — https://github.com/peterolson/BigInteger.js
 - bignumber.js@9.3.1 — MIT — https://github.com/MikeMcl/bignumber.js
+- binary@0.3.0 — MIT — http://github.com/substack/node-binary
 - bindings@1.5.0 — MIT — https://github.com/TooTallNate/node-bindings
 - bl@4.1.0 — MIT — https://github.com/rvagg/bl
+- bluebird@3.4.7 — MIT — https://github.com/petkaantonov/bluebird
 - body-parser@2.3.0 — MIT — https://github.com/expressjs/body-parser
+- brace-expansion@1.1.16 — MIT — https://github.com/juliangruber/brace-expansion
 - brace-expansion@2.1.2 — MIT — https://github.com/juliangruber/brace-expansion
 - buffer@5.7.1 — MIT — https://github.com/feross/buffer
+- buffer-crc32@0.2.13 — MIT — https://github.com/brianloveswords/buffer-crc32
 - buffer-equal-constant-time@1.0.1 — BSD-3-Clause — https://github.com/goinstant/buffer-equal-constant-time
+- buffer-indexof-polyfill@1.0.2 — MIT — https://github.com/sarosia/buffer-indexof-polyfill
+- buffers@0.1.1 — MIT — http://github.com/substack/node-buffers
 - buildcheck@0.0.7 — MIT — http://github.com/mscdex/buildcheck
 - byte-size@8.2.1 — MIT — https://github.com/75lb/byte-size
 - bytes@3.1.2 — MIT — https://github.com/visionmedia/bytes.js
@@ -3894,6 +3913,7 @@ SECTION 2: npm packages (785 packages)
 - call-bound@1.0.4 — MIT — https://github.com/ljharb/call-bound
 - camelcase@5.3.1 — MIT — https://github.com/sindresorhus/camelcase
 - ccount@2.0.1 — MIT — https://github.com/wooorm/ccount
+- chainsaw@0.1.0 — MIT — http://github.com/substack/node-chainsaw
 - character-entities@2.0.2 — MIT — https://github.com/wooorm/character-entities
 - character-entities-html4@2.1.0 — MIT — https://github.com/wooorm/character-entities-html4
 - character-entities-legacy@3.0.0 — MIT — https://github.com/wooorm/character-entities-legacy
@@ -3910,6 +3930,8 @@ SECTION 2: npm packages (785 packages)
 - comma-separated-tokens@2.0.3 — MIT — https://github.com/wooorm/comma-separated-tokens
 - commander@7.2.0 — MIT — https://github.com/tj/commander.js
 - commander@8.3.0 — MIT — https://github.com/tj/commander.js
+- compress-commons@4.1.2 — MIT — https://github.com/archiverjs/node-compress-commons
+- concat-map@0.0.1 — MIT — https://github.com/substack/node-concat-map
 - conf@9.0.2 — MIT — https://github.com/sindresorhus/conf
 - content-disposition@1.1.0 — MIT — https://github.com/jshttp/content-disposition
 - content-type@1.0.5 — MIT — https://github.com/jshttp/content-type
@@ -3922,6 +3944,8 @@ SECTION 2: npm packages (785 packages)
 - cose-base@1.0.3 — MIT — https://github.com/iVis-at-Bilkent/cose-base
 - cose-base@2.2.0 — MIT — https://github.com/iVis-at-Bilkent/cose-base
 - cpu-features@0.0.10 — MIT — https://github.com/mscdex/cpu-features
+- crc-32@1.2.2 — Apache-2.0 — https://github.com/SheetJS/js-crc32
+- crc32-stream@4.0.3 — MIT — https://github.com/archiverjs/node-crc32-stream
 - crelt@1.0.7 — MIT — https://code.haverbeke.berlin/marijn/crelt
 - cross-spawn@7.0.6 — MIT — https://github.com/moxystudio/node-cross-spawn
 - crypt@0.0.2 — BSD-3-Clause — https://github.com/pvorb/node-crypt
@@ -3986,10 +4010,12 @@ SECTION 2: npm packages (785 packages)
 - dingtalk-stream@v2.1.5 — MIT — https://github.com/open-dingtalk/dingtalk-stream-sdk-nodejs
 - discord-api-types@0.38.50 — MIT — https://github.com/discordjs/discord-api-types
 - discord.js@14.27.0 — Apache-2.0 — https://github.com/discordjs/discord.js
+- docx@9.7.1 — MIT — https://github.com/dolanmiu/docx
 - dompurify@3.4.12 — (MPL-2.0 OR Apache-2.0) — https://github.com/cure53/DOMPurify
 - dot-prop@6.0.1 — MIT — https://github.com/sindresorhus/dot-prop
 - drizzle-orm@0.45.2 — Apache-2.0 — https://github.com/drizzle-team/drizzle-orm
 - dunder-proto@1.0.1 — MIT — https://github.com/es-shims/dunder-proto
+- duplexer2@0.1.4 — BSD-3-Clause — https://github.com/deoxxa/duplexer2
 - eastasianwidth@0.2.0 — MIT — https://github.com/komagata/eastasianwidth
 - ecdsa-sig-formatter@1.0.11 — Apache-2.0 — https://github.com/Brightspace/node-ecdsa-sig-formatter
 - ee-first@1.1.1 — MIT — https://github.com/jonathanong/ee-first
@@ -4015,6 +4041,7 @@ SECTION 2: npm packages (785 packages)
 - eventemitter3@5.0.4 — MIT — https://github.com/primus/eventemitter3
 - eventsource@3.0.7 — MIT — https://git@github.com/EventSource/eventsource
 - eventsource-parser@3.1.0 — MIT — https://github.com/rexxars/eventsource-parser
+- exceljs@4.4.0 — MIT — https://github.com/exceljs/exceljs
 - execa@4.1.0 — MIT — https://github.com/sindresorhus/execa
 - execa@5.1.1 — MIT — https://github.com/sindresorhus/execa
 - expand-template@2.0.3 — (MIT OR WTFPL) — https://github.com/ralphtheninja/expand-template
@@ -4022,6 +4049,7 @@ SECTION 2: npm packages (785 packages)
 - express-rate-limit@8.5.2 — MIT — https://github.com/express-rate-limit/express-rate-limit
 - extend@3.0.2 — MIT — https://github.com/justmoon/node-extend
 - extend-shallow@2.0.1 — MIT — https://github.com/jonschlinkert/extend-shallow
+- fast-csv@4.3.6 — MIT — https://github.com/C2FO/fast-csv
 - fast-deep-equal@3.1.3 — MIT — https://github.com/epoberezkin/fast-deep-equal
 - fast-equals@5.4.1 — MIT — https://github.com/planttheidea/fast-equals
 - fast-uri@3.1.4 — BSD-3-Clause — https://github.com/fastify/fast-uri
@@ -4039,6 +4067,8 @@ SECTION 2: npm packages (785 packages)
 - fresh@2.0.0 — MIT — https://github.com/jshttp/fresh
 - fs-constants@1.0.0 — MIT — https://github.com/mafintosh/fs-constants
 - fs-extra@11.3.6 — MIT — https://github.com/jprichardson/node-fs-extra
+- fs.realpath@1.0.0 — ISC — https://github.com/isaacs/fs.realpath
+- fstream@1.0.12 — ISC — https://github.com/npm/fstream
 - function-bind@1.1.2 — MIT — https://github.com/Raynos/function-bind
 - gaxios@7.1.3 — Apache-2.0 — https://github.com/googleapis/google-cloud-node-core
 - gaxios@7.2.0 — Apache-2.0 — https://github.com/googleapis/google-cloud-node
@@ -4054,6 +4084,7 @@ SECTION 2: npm packages (785 packages)
 - github-from-package@0.0.0 — MIT — https://github.com/substack/github-from-package
 - github-slugger@2.0.0 — ISC — https://github.com/Flet/github-slugger
 - glob@10.5.0 — ISC — https://github.com/isaacs/node-glob
+- glob@7.2.3 — ISC — https://github.com/isaacs/node-glob
 - google-auth-library@10.5.0 — Apache-2.0 — https://github.com/googleapis/google-auth-library-nodejs
 - google-auth-library@10.9.0 — Apache-2.0 — https://github.com/googleapis/google-cloud-node
 - google-logging-utils@1.1.3 — Apache-2.0 — https://github.com/googleapis/google-cloud-node-core
@@ -4066,6 +4097,7 @@ SECTION 2: npm packages (785 packages)
 - harmonyos-sans-sc-webfont-splitted@1.1.0 — Unlicense — https://github.com/SunsetMkt/HarmonyOS_Sans_SC_Webfont_Splitted
 - has-symbols@1.1.0 — MIT — https://github.com/inspect-js/has-symbols
 - has-tostringtag@1.0.2 — MIT — https://github.com/inspect-js/has-tostringtag
+- hash.js@1.1.7 — MIT — https://github.com/indutny/hash.js
 - hasown@2.0.4 — MIT — https://github.com/inspect-js/hasOwn
 - hast-util-from-dom@5.0.1 — ISC — https://github.com/syntax-tree/hast-util-from-dom
 - hast-util-from-html@2.0.3 — MIT — https://github.com/syntax-tree/hast-util-from-html
@@ -4085,6 +4117,7 @@ SECTION 2: npm packages (785 packages)
 - html-to-image@1.11.13 — MIT — https://github.com/bubkoo/html-to-image
 - html-url-attributes@3.0.1 — MIT — https://github.com/rehypejs/rehype-minify/tree/main/packages/html-url-attributes
 - http-errors@2.0.1 — MIT — https://github.com/jshttp/http-errors
+- https@1.0.0 — ISC
 - https-proxy-agent@5.0.1 — MIT — https://github.com/TooTallNate/node-https-proxy-agent
 - https-proxy-agent@7.0.6 — MIT — https://github.com/TooTallNate/proxy-agents
 - human-signals@1.1.1 — Apache-2.0 — https://github.com/ehmicky/human-signals
@@ -4094,8 +4127,10 @@ SECTION 2: npm packages (785 packages)
 - iconv-lite@0.7.3 — MIT — https://github.com/pillarjs/iconv-lite
 - ieee754@1.2.1 — BSD-3-Clause — https://github.com/feross/ieee754
 - ignore@7.0.6 — MIT — https://github.com/kaelzhang/node-ignore
+- image-size@1.2.1 — MIT — https://github.com/image-size/image-size
 - immediate@3.0.6 — MIT — https://github.com/calvinmetcalf/immediate
 - import-meta-resolve@4.2.0 — MIT — https://github.com/wooorm/import-meta-resolve
+- inflight@1.0.6 — ISC — https://github.com/npm/inflight
 - inherits@2.0.4 — ISC — https://github.com/isaacs/inherits
 - ini@1.3.8 — ISC — https://github.com/isaacs/ini
 - inline-style-parser@0.2.7 — MIT — https://github.com/remarkablemark/inline-style-parser
@@ -4141,8 +4176,10 @@ SECTION 2: npm packages (785 packages)
 - kind-of@6.0.3 — MIT — https://github.com/jonschlinkert/kind-of
 - layout-base@1.0.2 — MIT — https://github.com/iVis-at-Bilkent/layout-base
 - layout-base@2.0.1 — MIT — https://github.com/iVis-at-Bilkent/layout-base
+- lazystream@1.0.1 — MIT — https://github.com/jpommerening/node-lazystream
 - lcid@3.1.1 — MIT — https://github.com/sindresorhus/lcid
 - lie@3.3.0 — MIT — https://github.com/calvinmetcalf/lie
+- listenercount@1.0.1 — ISC — https://github.com/jden/node-listenercount
 - lit@3.3.3 — BSD-3-Clause — https://github.com/lit/lit
 - lit-element@4.2.2 — BSD-3-Clause — https://github.com/lit/lit
 - lit-html@3.3.3 — BSD-3-Clause — https://github.com/lit/lit
@@ -4150,10 +4187,23 @@ SECTION 2: npm packages (785 packages)
 - locate-path@5.0.0 — MIT — https://github.com/sindresorhus/locate-path
 - lodash@4.18.1 — MIT — https://github.com/lodash/lodash
 - lodash-es@4.18.1 — MIT — https://github.com/lodash/lodash
+- lodash.defaults@4.2.0 — MIT — https://github.com/lodash/lodash
+- lodash.difference@4.5.0 — MIT — https://github.com/lodash/lodash
+- lodash.escaperegexp@4.1.2 — MIT — https://github.com/lodash/lodash
+- lodash.flatten@4.4.0 — MIT — https://github.com/lodash/lodash
+- lodash.groupby@4.6.0 — MIT — https://github.com/lodash/lodash
 - lodash.identity@3.0.0 — MIT — https://github.com/lodash/lodash
+- lodash.isboolean@3.0.3 — MIT — https://github.com/lodash/lodash
+- lodash.isequal@4.5.0 — MIT — https://github.com/lodash/lodash
+- lodash.isfunction@3.0.9 — MIT — https://github.com/lodash/lodash
+- lodash.isnil@4.0.0 — MIT — https://github.com/lodash/lodash
+- lodash.isplainobject@4.0.6 — MIT — https://github.com/lodash/lodash
+- lodash.isundefined@3.0.1 — MIT — https://github.com/lodash/lodash
 - lodash.merge@4.6.2 — MIT — https://github.com/lodash/lodash
 - lodash.pickby@4.6.0 — MIT — https://github.com/lodash/lodash
 - lodash.snakecase@4.1.1 — MIT — https://github.com/lodash/lodash
+- lodash.union@4.6.0 — MIT — https://github.com/lodash/lodash
+- lodash.uniq@4.5.0 — MIT — https://github.com/lodash/lodash
 - long@5.3.2 — Apache-2.0 — https://github.com/dcodeIO/long.js
 - longest-streak@3.1.0 — MIT — https://github.com/wooorm/longest-streak
 - loudness@0.4.2 — MIT — https://github.com/LinusU/node-loudness
@@ -4225,6 +4275,9 @@ SECTION 2: npm packages (785 packages)
 - mimic-fn@2.1.0 — MIT — https://github.com/sindresorhus/mimic-fn
 - mimic-fn@3.1.0 — MIT — https://github.com/sindresorhus/mimic-fn
 - mimic-response@3.1.0 — MIT — https://github.com/sindresorhus/mimic-response
+- minimalistic-assert@1.0.1 — ISC — https://github.com/calvinmetcalf/minimalistic-assert
+- minimatch@3.1.5 — ISC — https://github.com/isaacs/minimatch
+- minimatch@5.1.9 — ISC — https://github.com/isaacs/minimatch
 - minimatch@9.0.9 — ISC — https://github.com/isaacs/minimatch
 - minimist@1.2.8 — MIT — https://github.com/minimistjs/minimist
 - minipass@7.1.3 — BlueOak-1.0.0 — https://github.com/isaacs/minipass
@@ -4235,6 +4288,7 @@ SECTION 2: npm packages (785 packages)
 - ms@2.0.0 — MIT — https://github.com/zeit/ms
 - ms@2.1.3 — MIT — https://github.com/vercel/ms
 - nan@2.28.0 — MIT — https://github.com/nodejs/nan
+- nanoid@5.1.16 — MIT — https://github.com/ai/nanoid
 - napi-build-utils@2.0.0 — MIT — https://github.com/inspiredware/napi-build-utils
 - negotiator@1.0.0 — MIT — https://github.com/jshttp/negotiator
 - node-abi@3.94.0 — MIT — https://github.com/electron/node-abi
@@ -4243,6 +4297,7 @@ SECTION 2: npm packages (785 packages)
 - node-fetch@3.3.2 — MIT — https://github.com/node-fetch/node-fetch
 - node-machine-id@1.1.12 — MIT — https://github.com/automation-stack/node-machine-id
 - node-pty@1.1.0 — MIT — https://github.com/microsoft/node-pty
+- normalize-path@3.0.0 — MIT — https://github.com/jonschlinkert/normalize-path
 - npm-run-path@4.0.1 — MIT — https://github.com/sindresorhus/npm-run-path
 - object-assign@4.1.1 — MIT — https://github.com/sindresorhus/object-assign
 - object-inspect@1.13.4 — MIT — https://github.com/inspect-js/object-inspect
@@ -4264,6 +4319,7 @@ SECTION 2: npm packages (785 packages)
 - path-data-parser@0.1.0 — MIT — https://github.com/pshihn/path-data-parser
 - path-exists@3.0.0 — MIT — https://github.com/sindresorhus/path-exists
 - path-exists@4.0.0 — MIT — https://github.com/sindresorhus/path-exists
+- path-is-absolute@1.0.1 — MIT — https://github.com/sindresorhus/path-is-absolute
 - path-key@3.1.1 — MIT — https://github.com/sindresorhus/path-key
 - path-scurry@1.11.1 — BlueOak-1.0.0 — https://github.com/isaacs/path-scurry
 - path-to-regexp@8.4.2 — MIT — https://github.com/pillarjs/path-to-regexp
@@ -4275,6 +4331,7 @@ SECTION 2: npm packages (785 packages)
 - pngjs@5.0.0 — MIT — https://github.com/lukeapage/pngjs
 - points-on-curve@0.2.0 — MIT — https://github.com/pshihn/bezier-points
 - points-on-path@0.2.1 — MIT — https://github.com/pshihn/points-on-path
+- pptxgenjs@4.0.1 — MIT — https://github.com/gitbrent/PptxGenJS
 - prebuild-install@7.1.3 — MIT — https://github.com/prebuild/prebuild-install
 - process-nextick-args@2.0.1 — MIT — https://github.com/calvinmetcalf/process-nextick-args
 - promise-worker-transferable@1.0.4 — Apache-2.0 — https://github.com/terikon/promise-worker-transferable
@@ -4299,6 +4356,7 @@ SECTION 2: npm packages (785 packages)
 - punycode@2.3.1 — MIT — https://github.com/mathiasbynens/punycode.js
 - qrcode@1.5.4 — MIT — https://github.com/soldair/node-qrcode
 - qs@6.15.3 — BSD-3-Clause — https://github.com/ljharb/qs
+- queue@6.0.2 — MIT — https://github.com/jessetane/queue
 - range-parser@1.3.0 — MIT — https://github.com/jshttp/range-parser
 - raw-body@3.0.2 — MIT — https://github.com/stream-utils/raw-body
 - rc@1.2.8 — (BSD-2-Clause OR MIT OR Apache-2.0) — https://github.com/dominictarr/rc
@@ -4313,6 +4371,7 @@ SECTION 2: npm packages (785 packages)
 - react-style-singleton@2.2.3 — MIT — https://github.com/theKashey/react-style-singleton
 - readable-stream@2.3.8 — MIT — https://github.com/nodejs/readable-stream
 - readable-stream@3.6.2 — MIT — https://github.com/nodejs/readable-stream
+- readdir-glob@1.1.3 — Apache-2.0 — https://github.com/Yqnn/node-readdir-glob
 - rehype-highlight@7.0.2 — MIT — https://github.com/rehypejs/rehype-highlight
 - rehype-katex@7.0.1 — MIT — https://github.com/remarkjs/remark-math/tree/main/packages/rehype-katex
 - rehype-slug@6.0.0 — MIT — https://github.com/rehypejs/rehype-slug
@@ -4325,6 +4384,7 @@ SECTION 2: npm packages (785 packages)
 - require-directory@2.1.1 — MIT — https://github.com/troygoode/node-require-directory
 - require-from-string@2.0.2 — MIT — https://github.com/floatdrop/require-from-string
 - require-main-filename@2.0.0 — ISC — https://github.com/yargs/require-main-filename
+- rimraf@2.6.3 — ISC — https://github.com/isaacs/rimraf
 - rimraf@5.0.10 — ISC — https://github.com/isaacs/rimraf
 - robust-predicates@3.0.3 — Unlicense — https://github.com/mourner/robust-predicates
 - rope-sequence@1.3.4 — MIT — https://github.com/marijnh/rope-sequence
@@ -4334,6 +4394,8 @@ SECTION 2: npm packages (785 packages)
 - safe-buffer@5.1.2 — MIT — https://github.com/feross/safe-buffer
 - safe-buffer@5.2.1 — MIT — https://github.com/feross/safe-buffer
 - safer-buffer@2.1.2 — MIT — https://github.com/ChALkeR/safer-buffer
+- sax@1.6.0 — BlueOak-1.0.0 — https://github.com/isaacs/sax-js
+- saxes@5.0.1 — ISC — https://github.com/lddubeau/saxes
 - scheduler@0.27.0 — MIT — https://github.com/facebook/react
 - section-matter@1.0.0 — MIT — https://github.com/jonschlinkert/section-matter
 - semver@6.3.1 — ISC — https://github.com/npm/node-semver
@@ -4384,7 +4446,9 @@ SECTION 2: npm packages (785 packages)
 - tar-fs@2.1.5 — MIT — https://github.com/mafintosh/tar-fs
 - tar-stream@2.2.0 — MIT — https://github.com/mafintosh/tar-stream
 - tinyexec@1.2.4 — MIT — https://github.com/tinylibs/tinyexec
+- tmp@0.2.7 — MIT — https://github.com/raszi/node-tmp
 - toidentifier@1.0.1 — MIT — https://github.com/component/toidentifier
+- traverse@0.3.9 — MIT — http://github.com/substack/js-traverse
 - trim-lines@3.0.1 — MIT — https://github.com/wooorm/trim-lines
 - trough@2.2.0 — MIT — https://github.com/wooorm/trough
 - ts-algebra@2.0.0 — MIT — https://github.com/ThomasAribart/ts-algebra
@@ -4399,6 +4463,7 @@ SECTION 2: npm packages (785 packages)
 - typebox@1.1.39 — MIT — https://github.com/sinclairzx81/typebox
 - undici@6.27.0 — MIT — https://github.com/nodejs/undici
 - undici@8.7.0 — MIT — https://github.com/nodejs/undici
+- undici-types@6.21.0 — MIT — https://github.com/nodejs/undici
 - undici-types@7.24.6 — MIT — https://github.com/nodejs/undici
 - unified@11.0.5 — MIT — https://github.com/unifiedjs/unified
 - unist-util-find-after@5.0.0 — MIT — https://github.com/syntax-tree/unist-util-find-after
@@ -4410,6 +4475,7 @@ SECTION 2: npm packages (785 packages)
 - unist-util-visit-parents@6.0.2 — MIT — https://github.com/syntax-tree/unist-util-visit-parents
 - universalify@2.0.1 — MIT — https://github.com/RyanZim/universalify
 - unpipe@1.0.0 — MIT — https://github.com/stream-utils/unpipe
+- unzipper@0.10.14 — MIT — https://github.com/ZJONSSON/node-unzipper
 - uri-js@4.4.1 — BSD-2-Clause — http://github.com/garycourt/uri-js
 - url-template@2.0.8 — LicenseRef-BSD-Variant — https://github.com/bramstein/url-template
 - use-callback-ref@1.3.3 — MIT — https://github.com/theKashey/use-callback-ref/
@@ -4417,6 +4483,7 @@ SECTION 2: npm packages (785 packages)
 - use-sync-external-store@1.6.0 — MIT — https://github.com/facebook/react
 - util-deprecate@1.0.2 — MIT — https://github.com/TooTallNate/util-deprecate
 - uuid@14.0.1 — MIT — https://github.com/uuidjs/uuid
+- uuid@8.3.2 — MIT — https://github.com/uuidjs/uuid
 - vary@1.1.2 — MIT — https://github.com/jshttp/vary
 - vfile@6.0.3 — MIT — https://github.com/vfile/vfile
 - vfile-location@5.0.3 — MIT — https://github.com/vfile/vfile-location
@@ -4433,10 +4500,14 @@ SECTION 2: npm packages (785 packages)
 - wrap-ansi@8.1.0 — MIT — https://github.com/chalk/wrap-ansi
 - wrappy@1.0.2 — ISC — https://github.com/npm/wrappy
 - ws@8.21.1 — MIT — https://github.com/websockets/ws
+- xml@1.0.1 — MIT — http://github.com/dylang/node-xml
+- xml-js@1.6.11 — MIT — https://github.com/nashwaan/xml-js
+- xmlchars@2.2.0 — MIT — https://github.com/lddubeau/xmlchars
 - y18n@4.0.3 — ISC — https://github.com/yargs/y18n
 - yallist@5.0.0 — BlueOak-1.0.0 — https://github.com/isaacs/yallist
 - yargs@15.4.1 — MIT — https://github.com/yargs/yargs
 - yargs-parser@18.1.3 — ISC — https://github.com/yargs/yargs-parser
+- zip-stream@4.1.1 — MIT — https://github.com/archiverjs/node-zip-stream
 - zod@4.3.6 — MIT — https://github.com/colinhacks/zod
 - zod-to-json-schema@3.25.2 — ISC — https://github.com/StefanTerdell/zod-to-json-schema
 - zwitch@2.0.4 — MIT — https://github.com/wooorm/zwitch
@@ -25319,7 +25390,7 @@ The above copyright notice and this permission notice shall be included in all c
 THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[121] Applies to: npm:@babel/runtime@7.29.7
+[121] Applies to: npm:@babel/helper-string-parser@7.29.7, npm:@babel/helper-validator-identifier@7.29.7, npm:@babel/runtime@7.29.7, npm:@babel/types@7.29.7
 ------------------------------------------------------------------------------
 MIT License
 
@@ -25345,7 +25416,30 @@ OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
 WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[122] Applies to: npm:@braintree/sanitize-url@7.1.2
+[122] Applies to: npm:@babel/parser@7.29.7
+------------------------------------------------------------------------------
+Copyright (C) 2012-2014 by various contributors (see AUTHORS)
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+
+------------------------------------------------------------------------------
+[123] Applies to: npm:@braintree/sanitize-url@7.1.2
 ------------------------------------------------------------------------------
 MIT License
 
@@ -25370,7 +25464,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
 ------------------------------------------------------------------------------
-[123] Applies to: npm:@chevrotain/types@11.1.2, npm:@google/model-viewer@4.3.1, npm:@pkgjs/parseargs@0.11.0, npm:gaxios@7.1.3, npm:gaxios@7.2.0, npm:gcp-metadata@8.1.2, npm:gcp-metadata@8.1.3, npm:google-auth-library@10.5.0, npm:google-auth-library@10.9.0, npm:google-logging-utils@1.1.3, npm:googleapis-common@8.0.2, npm:long@5.3.2
+[124] Applies to: npm:@chevrotain/types@11.1.2, npm:@google/model-viewer@4.3.1, npm:@pkgjs/parseargs@0.11.0, npm:gaxios@7.1.3, npm:gaxios@7.2.0, npm:gcp-metadata@8.1.2, npm:gcp-metadata@8.1.3, npm:google-auth-library@10.5.0, npm:google-auth-library@10.9.0, npm:google-logging-utils@1.1.3, npm:googleapis-common@8.0.2, npm:long@5.3.2
 ------------------------------------------------------------------------------
 Apache License
                            Version 2.0, January 2004
@@ -25575,7 +25669,7 @@ Apache License
    limitations under the License.
 
 ------------------------------------------------------------------------------
-[124] Applies to: npm:@codemirror/autocomplete@6.20.3, npm:@codemirror/commands@6.10.4, npm:@codemirror/lang-cpp@6.0.3, npm:@codemirror/lang-css@6.3.1, npm:@codemirror/lang-html@6.4.11, npm:@codemirror/lang-java@6.0.2, npm:@codemirror/lang-javascript@6.2.5, npm:@codemirror/lang-json@6.0.2, npm:@codemirror/lang-markdown@6.5.1, npm:@codemirror/lang-php@6.0.2, npm:@codemirror/lang-python@6.2.1, npm:@codemirror/lang-rust@6.0.2, npm:@codemirror/lang-sql@6.10.0, npm:@codemirror/lang-xml@6.1.0, npm:@codemirror/language@6.12.4, npm:@codemirror/legacy-modes@6.5.3, npm:@codemirror/lint@6.9.7, npm:@codemirror/search@6.7.1, npm:@codemirror/state@6.7.1, npm:@codemirror/view@6.43.6
+[125] Applies to: npm:@codemirror/autocomplete@6.20.3, npm:@codemirror/commands@6.10.4, npm:@codemirror/lang-cpp@6.0.3, npm:@codemirror/lang-css@6.3.1, npm:@codemirror/lang-html@6.4.11, npm:@codemirror/lang-java@6.0.2, npm:@codemirror/lang-javascript@6.2.5, npm:@codemirror/lang-json@6.0.2, npm:@codemirror/lang-markdown@6.5.1, npm:@codemirror/lang-php@6.0.2, npm:@codemirror/lang-python@6.2.1, npm:@codemirror/lang-rust@6.0.2, npm:@codemirror/lang-sql@6.10.0, npm:@codemirror/lang-xml@6.1.0, npm:@codemirror/language@6.12.4, npm:@codemirror/legacy-modes@6.5.3, npm:@codemirror/lint@6.9.7, npm:@codemirror/search@6.7.1, npm:@codemirror/state@6.7.1, npm:@codemirror/view@6.43.6
 ------------------------------------------------------------------------------
 MIT License
 
@@ -25600,7 +25694,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[125] Applies to: npm:@codemirror/lang-go@6.0.1, npm:@codemirror/lang-yaml@6.1.3
+[126] Applies to: npm:@codemirror/lang-go@6.0.1, npm:@codemirror/lang-yaml@6.1.3
 ------------------------------------------------------------------------------
 MIT License
 
@@ -25625,7 +25719,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[126] Applies to: npm:@discordjs/builders@1.14.1, npm:@discordjs/formatters@0.6.2
+[127] Applies to: npm:@discordjs/builders@1.14.1, npm:@discordjs/formatters@0.6.2
 ------------------------------------------------------------------------------
 Apache License
                            Version 2.0, January 2004
@@ -25820,7 +25914,7 @@ Apache License
    limitations under the License.
 
 ------------------------------------------------------------------------------
-[127] Applies to: npm:@discordjs/collection@1.5.3, npm:@discordjs/collection@2.1.1, npm:discord.js@14.27.0
+[128] Applies to: npm:@discordjs/collection@1.5.3, npm:@discordjs/collection@2.1.1, npm:discord.js@14.27.0
 ------------------------------------------------------------------------------
 Apache License
                            Version 2.0, January 2004
@@ -26015,7 +26109,7 @@ Apache License
    limitations under the License.
 
 ------------------------------------------------------------------------------
-[128] Applies to: npm:@discordjs/rest@2.6.2
+[129] Applies to: npm:@discordjs/rest@2.6.2
 ------------------------------------------------------------------------------
 Apache License
                            Version 2.0, January 2004
@@ -26211,7 +26305,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 
 ------------------------------------------------------------------------------
-[129] Applies to: npm:@discordjs/util@1.2.0
+[130] Applies to: npm:@discordjs/util@1.2.0
 ------------------------------------------------------------------------------
 Apache License
                            Version 2.0, January 2004
@@ -26405,7 +26499,7 @@ Apache License
    limitations under the License.
 
 ------------------------------------------------------------------------------
-[130] Applies to: npm:@discordjs/ws@1.2.3
+[131] Applies to: npm:@discordjs/ws@1.2.3
 ------------------------------------------------------------------------------
 Apache License
                            Version 2.0, January 2004
@@ -26600,7 +26694,32 @@ Apache License
    limitations under the License.
 
 ------------------------------------------------------------------------------
-[131] Applies to: npm:@floating-ui/core@1.8.0, npm:@floating-ui/dom@1.8.0, npm:@floating-ui/react-dom@2.1.9, npm:@floating-ui/utils@0.2.12
+[132] Applies to: npm:@fast-csv/format@4.3.5, npm:@fast-csv/parse@4.3.6, npm:fast-csv@4.3.6
+------------------------------------------------------------------------------
+The MIT License
+
+Copyright (c) 2011-2019 C2FO
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+
+------------------------------------------------------------------------------
+[133] Applies to: npm:@floating-ui/core@1.8.0, npm:@floating-ui/dom@1.8.0, npm:@floating-ui/react-dom@2.1.9, npm:@floating-ui/utils@0.2.12
 ------------------------------------------------------------------------------
 MIT License
 
@@ -26624,7 +26743,7 @@ IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
 CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[132] Applies to: npm:@fontsource-variable/inter@5.2.8
+[134] Applies to: npm:@fontsource-variable/inter@5.2.8
 ------------------------------------------------------------------------------
 Copyright 2016 The Inter Project Authors (https://github.com/rsms/inter) Inter-Italic[opsz,wght].ttf: Copyright 2016 The Inter Project Authors (https://github.com/rsms/inter)
 
@@ -26721,7 +26840,7 @@ FROM, OUT OF THE USE OR INABILITY TO USE THE FONT SOFTWARE OR FROM
 OTHER DEALINGS IN THE FONT SOFTWARE.
 
 ------------------------------------------------------------------------------
-[133] Applies to: npm:@fontsource-variable/jetbrains-mono@5.2.8
+[135] Applies to: npm:@fontsource-variable/jetbrains-mono@5.2.8
 ------------------------------------------------------------------------------
 Copyright 2020 The JetBrains Mono Project Authors (https://github.com/JetBrains/JetBrainsMono) JetBrainsMono-Italic[wght].ttf: Copyright 2020 The JetBrains Mono Project Authors (https://github.com/JetBrains/JetBrainsMono)
 
@@ -26818,7 +26937,7 @@ FROM, OUT OF THE USE OR INABILITY TO USE THE FONT SOFTWARE OR FROM
 OTHER DEALINGS IN THE FONT SOFTWARE.
 
 ------------------------------------------------------------------------------
-[134] Applies to: npm:@hono/node-server@1.19.14
+[136] Applies to: npm:@hono/node-server@1.19.14
 ------------------------------------------------------------------------------
 MIT License
 
@@ -26843,7 +26962,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
 ------------------------------------------------------------------------------
-[135] Applies to: npm:@iconify/types@2.0.0
+[137] Applies to: npm:@iconify/types@2.0.0
 ------------------------------------------------------------------------------
 MIT License
 
@@ -26868,7 +26987,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
 ------------------------------------------------------------------------------
-[136] Applies to: npm:@iconify/utils@3.1.4
+[138] Applies to: npm:@iconify/utils@3.1.4
 ------------------------------------------------------------------------------
 MIT License
 
@@ -26893,7 +27012,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
 ------------------------------------------------------------------------------
-[137] Applies to: npm:@img/colour@1.1.0
+[139] Applies to: npm:@img/colour@1.1.0
 ------------------------------------------------------------------------------
 # Licensing
 
@@ -26979,7 +27098,7 @@ The above copyright notice and this permission notice shall be included in all c
 THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[138] Applies to: npm:@img/sharp-win32-x64@0.34.5, npm:@img/sharp-win32-x64@0.35.3, npm:sharp@0.35.3
+[140] Applies to: npm:@img/sharp-win32-x64@0.34.5, npm:@img/sharp-win32-x64@0.35.3, npm:sharp@0.35.3
 ------------------------------------------------------------------------------
 Apache License
 Version 2.0, January 2004
@@ -27174,7 +27293,7 @@ third-party archives.
    limitations under the License.
 
 ------------------------------------------------------------------------------
-[139] Applies to: npm:@isaacs/cliui@8.0.2, npm:cliui@6.0.0
+[141] Applies to: npm:@isaacs/cliui@8.0.2, npm:cliui@6.0.0
 ------------------------------------------------------------------------------
 Copyright (c) 2015, Contributors
 
@@ -27192,7 +27311,7 @@ WHETHER IN AN ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION,
 ARISING OUT OF OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
 
 ------------------------------------------------------------------------------
-[140] Applies to: npm:@isaacs/fs-minipass@4.0.1, npm:chownr@1.1.4, npm:ini@1.3.8, npm:isexe@2.0.0, npm:once@1.4.0, npm:semver@6.3.1, npm:semver@7.8.5, npm:which@2.0.2, npm:wrappy@1.0.2
+[142] Applies to: npm:@isaacs/fs-minipass@4.0.1, npm:chownr@1.1.4, npm:fstream@1.0.12, npm:ini@1.3.8, npm:isexe@2.0.0, npm:minimatch@3.1.5, npm:once@1.4.0, npm:rimraf@2.6.3, npm:semver@6.3.1, npm:semver@7.8.5, npm:which@2.0.2, npm:wrappy@1.0.2
 ------------------------------------------------------------------------------
 The ISC License
 
@@ -27211,7 +27330,7 @@ ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF OR
 IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
 
 ------------------------------------------------------------------------------
-[141] Applies to: npm:@japont/unicode-range@1.0.0
+[143] Applies to: npm:@japont/unicode-range@1.0.0
 ------------------------------------------------------------------------------
 The MIT License (MIT)
 Copyright © 2018 3846masa
@@ -27235,7 +27354,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[142] Applies to: npm:@larksuiteoapi/node-sdk@1.71.1
+[144] Applies to: npm:@larksuiteoapi/node-sdk@1.71.1
 ------------------------------------------------------------------------------
 MIT License
 
@@ -27248,7 +27367,7 @@ The above copyright notice and this permission notice, shall be included in all 
 THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[143] Applies to: npm:@lezer/common@1.5.2, npm:@lezer/css@1.3.4, npm:@lezer/highlight@1.2.3, npm:@lezer/html@1.3.13, npm:@lezer/javascript@1.5.4, npm:@lezer/lr@1.4.10, npm:@lezer/php@1.0.5, npm:@lezer/rust@1.0.2, npm:@lezer/xml@1.0.6
+[145] Applies to: npm:@lezer/common@1.5.2, npm:@lezer/css@1.3.4, npm:@lezer/highlight@1.2.3, npm:@lezer/html@1.3.13, npm:@lezer/javascript@1.5.4, npm:@lezer/lr@1.4.10, npm:@lezer/php@1.0.5, npm:@lezer/rust@1.0.2, npm:@lezer/xml@1.0.6
 ------------------------------------------------------------------------------
 MIT License
 
@@ -27273,7 +27392,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[144] Applies to: npm:@lezer/cpp@1.1.6, npm:@lezer/go@1.0.1, npm:@lezer/java@1.1.3, npm:@lezer/markdown@1.7.2, npm:@lezer/python@1.1.19
+[146] Applies to: npm:@lezer/cpp@1.1.6, npm:@lezer/go@1.0.1, npm:@lezer/java@1.1.3, npm:@lezer/markdown@1.7.2, npm:@lezer/python@1.1.19
 ------------------------------------------------------------------------------
 MIT License
 
@@ -27298,7 +27417,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[145] Applies to: npm:@lezer/json@1.0.3
+[147] Applies to: npm:@lezer/json@1.0.3
 ------------------------------------------------------------------------------
 MIT License
 
@@ -27323,7 +27442,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[146] Applies to: npm:@lezer/yaml@1.0.4
+[148] Applies to: npm:@lezer/yaml@1.0.4
 ------------------------------------------------------------------------------
 MIT License
 
@@ -27348,7 +27467,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[147] Applies to: npm:@lit/reactive-element@2.1.2, npm:lit@3.3.3, npm:lit-element@4.2.2, npm:lit-html@3.3.3
+[149] Applies to: npm:@lit/reactive-element@2.1.2, npm:lit@3.3.3, npm:lit-element@4.2.2, npm:lit-html@3.3.3
 ------------------------------------------------------------------------------
 BSD 3-Clause License
 
@@ -27380,7 +27499,7 @@ OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 ------------------------------------------------------------------------------
-[148] Applies to: npm:@marijn/find-cluster-break@1.0.3
+[150] Applies to: npm:@marijn/find-cluster-break@1.0.3
 ------------------------------------------------------------------------------
 MIT License
 
@@ -27405,7 +27524,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[149] Applies to: npm:@mermaid-js/parser@1.2.0
+[151] Applies to: npm:@mermaid-js/parser@1.2.0
 ------------------------------------------------------------------------------
 The MIT License (MIT)
 
@@ -27430,7 +27549,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
 ------------------------------------------------------------------------------
-[150] Applies to: npm:@modelcontextprotocol/sdk@1.29.0
+[152] Applies to: npm:@modelcontextprotocol/sdk@1.29.0
 ------------------------------------------------------------------------------
 MIT License
 
@@ -27455,7 +27574,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
 ------------------------------------------------------------------------------
-[151] Applies to: npm:@monogrid/gainmap-js@3.4.0
+[153] Applies to: npm:@monogrid/gainmap-js@3.4.0
 ------------------------------------------------------------------------------
 MIT License
 
@@ -27480,7 +27599,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
 ------------------------------------------------------------------------------
-[152] Applies to: npm:@napi-rs/canvas@0.1.100
+[154] Applies to: npm:@napi-rs/canvas@0.1.100
 ------------------------------------------------------------------------------
 MIT License
 
@@ -27505,7 +27624,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
 ------------------------------------------------------------------------------
-[153] Applies to: npm:@noble/hashes@1.8.0
+[155] Applies to: npm:@noble/hashes@1.8.0
 ------------------------------------------------------------------------------
 The MIT License (MIT)
 
@@ -27530,7 +27649,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[154] Applies to: npm:@paralleldrive/cuid2@2.3.1
+[156] Applies to: npm:@paralleldrive/cuid2@2.3.1
 ------------------------------------------------------------------------------
 MIT License
 
@@ -27555,7 +27674,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
 ------------------------------------------------------------------------------
-[155] Applies to: npm:@parcel/watcher@2.5.6, npm:@parcel/watcher-win32-x64@2.5.6
+[157] Applies to: npm:@parcel/watcher@2.5.6, npm:@parcel/watcher-win32-x64@2.5.6
 ------------------------------------------------------------------------------
 MIT License
 
@@ -27580,7 +27699,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
 ------------------------------------------------------------------------------
-[156] Applies to: npm:@protobufjs/aspromise@1.1.2, npm:@protobufjs/base64@1.1.2, npm:@protobufjs/codegen@2.0.5, npm:@protobufjs/eventemitter@1.1.1, npm:@protobufjs/fetch@1.1.1, npm:@protobufjs/float@1.0.2, npm:@protobufjs/path@1.1.2, npm:@protobufjs/pool@1.1.0, npm:@protobufjs/utf8@1.1.2
+[158] Applies to: npm:@protobufjs/aspromise@1.1.2, npm:@protobufjs/base64@1.1.2, npm:@protobufjs/codegen@2.0.5, npm:@protobufjs/eventemitter@1.1.1, npm:@protobufjs/fetch@1.1.1, npm:@protobufjs/float@1.0.2, npm:@protobufjs/path@1.1.2, npm:@protobufjs/pool@1.1.0, npm:@protobufjs/utf8@1.1.2
 ------------------------------------------------------------------------------
 Copyright (c) 2016, Daniel Wirtz  All rights reserved.
 
@@ -27610,7 +27729,7 @@ THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
 OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 ------------------------------------------------------------------------------
-[157] Applies to: npm:@radix-ui/number@1.1.2, npm:@radix-ui/primitive@1.1.5, npm:@radix-ui/react-alert-dialog@1.1.19, npm:@radix-ui/react-arrow@1.1.11, npm:@radix-ui/react-collection@1.1.12, npm:@radix-ui/react-compose-refs@1.1.3, npm:@radix-ui/react-context@1.2.0, npm:@radix-ui/react-dialog@1.1.19, npm:@radix-ui/react-direction@1.1.2, npm:@radix-ui/react-dismissable-layer@1.1.15, npm:@radix-ui/react-dropdown-menu@2.1.20, npm:@radix-ui/react-focus-guards@1.1.4, npm:@radix-ui/react-focus-scope@1.1.12, npm:@radix-ui/react-id@1.1.2, npm:@radix-ui/react-menu@2.1.20, npm:@radix-ui/react-popover@1.1.19, npm:@radix-ui/react-popper@1.3.3, npm:@radix-ui/react-portal@1.1.13, npm:@radix-ui/react-presence@1.1.7, npm:@radix-ui/react-primitive@2.1.7, npm:@radix-ui/react-roving-focus@1.1.15, npm:@radix-ui/react-select@2.3.3, npm:@radix-ui/react-slider@1.4.3, npm:@radix-ui/react-slot@1.3.0, npm:@radix-ui/react-switch@1.3.3, npm:@radix-ui/react-tooltip@1.2.12, npm:@radix-ui/react-use-callback-ref@1.1.2, npm:@radix-ui/react-use-controllable-state@1.2.3, npm:@radix-ui/react-use-effect-event@0.0.3, npm:@radix-ui/react-use-is-hydrated@0.1.1, npm:@radix-ui/react-use-layout-effect@1.1.2, npm:@radix-ui/react-use-previous@1.1.2, npm:@radix-ui/react-use-rect@1.1.2, npm:@radix-ui/react-use-size@1.1.2, npm:@radix-ui/react-visually-hidden@1.2.7, npm:@radix-ui/rect@1.1.2
+[159] Applies to: npm:@radix-ui/number@1.1.2, npm:@radix-ui/primitive@1.1.5, npm:@radix-ui/react-alert-dialog@1.1.19, npm:@radix-ui/react-arrow@1.1.11, npm:@radix-ui/react-collection@1.1.12, npm:@radix-ui/react-compose-refs@1.1.3, npm:@radix-ui/react-context@1.2.0, npm:@radix-ui/react-dialog@1.1.19, npm:@radix-ui/react-direction@1.1.2, npm:@radix-ui/react-dismissable-layer@1.1.15, npm:@radix-ui/react-dropdown-menu@2.1.20, npm:@radix-ui/react-focus-guards@1.1.4, npm:@radix-ui/react-focus-scope@1.1.12, npm:@radix-ui/react-id@1.1.2, npm:@radix-ui/react-menu@2.1.20, npm:@radix-ui/react-popover@1.1.19, npm:@radix-ui/react-popper@1.3.3, npm:@radix-ui/react-portal@1.1.13, npm:@radix-ui/react-presence@1.1.7, npm:@radix-ui/react-primitive@2.1.7, npm:@radix-ui/react-roving-focus@1.1.15, npm:@radix-ui/react-select@2.3.3, npm:@radix-ui/react-slider@1.4.3, npm:@radix-ui/react-slot@1.3.0, npm:@radix-ui/react-switch@1.3.3, npm:@radix-ui/react-tooltip@1.2.12, npm:@radix-ui/react-use-callback-ref@1.1.2, npm:@radix-ui/react-use-controllable-state@1.2.3, npm:@radix-ui/react-use-effect-event@0.0.3, npm:@radix-ui/react-use-is-hydrated@0.1.1, npm:@radix-ui/react-use-layout-effect@1.1.2, npm:@radix-ui/react-use-previous@1.1.2, npm:@radix-ui/react-use-rect@1.1.2, npm:@radix-ui/react-use-size@1.1.2, npm:@radix-ui/react-visually-hidden@1.2.7, npm:@radix-ui/rect@1.1.2
 ------------------------------------------------------------------------------
 MIT License
 
@@ -27635,7 +27754,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
 ------------------------------------------------------------------------------
-[158] Applies to: npm:@replit/codemirror-lang-csharp@6.2.0
+[160] Applies to: npm:@replit/codemirror-lang-csharp@6.2.0
 ------------------------------------------------------------------------------
 MIT License
 
@@ -27660,7 +27779,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
 ------------------------------------------------------------------------------
-[159] Applies to: npm:@sapphire/shapeshift@4.0.0
+[161] Applies to: npm:@sapphire/shapeshift@4.0.0
 ------------------------------------------------------------------------------
 # The MIT License (MIT)
 
@@ -27688,7 +27807,7 @@ FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
 OTHER DEALINGS IN THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[160] Applies to: npm:@tanstack/react-virtual@3.14.6, npm:@tanstack/virtual-core@3.17.4
+[162] Applies to: npm:@tanstack/react-virtual@3.14.6, npm:@tanstack/virtual-core@3.17.4
 ------------------------------------------------------------------------------
 MIT License
 
@@ -27713,7 +27832,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
 ------------------------------------------------------------------------------
-[161] Applies to: npm:@tiptap/core@3.28.0, npm:@tiptap/extension-bubble-menu@3.28.0, npm:@tiptap/extension-document@3.28.0, npm:@tiptap/extension-floating-menu@3.28.0, npm:@tiptap/extension-hard-break@3.28.0, npm:@tiptap/extension-history@3.28.0, npm:@tiptap/extension-paragraph@3.28.0, npm:@tiptap/extension-placeholder@3.28.0, npm:@tiptap/extension-text@3.28.0, npm:@tiptap/pm@3.28.0, npm:@tiptap/react@3.28.0
+[163] Applies to: npm:@tiptap/core@3.28.0, npm:@tiptap/extension-bubble-menu@3.28.0, npm:@tiptap/extension-document@3.28.0, npm:@tiptap/extension-floating-menu@3.28.0, npm:@tiptap/extension-hard-break@3.28.0, npm:@tiptap/extension-history@3.28.0, npm:@tiptap/extension-paragraph@3.28.0, npm:@tiptap/extension-placeholder@3.28.0, npm:@tiptap/extension-text@3.28.0, npm:@tiptap/pm@3.28.0, npm:@tiptap/react@3.28.0
 ------------------------------------------------------------------------------
 MIT License
 
@@ -27738,7 +27857,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
 ------------------------------------------------------------------------------
-[162] Applies to: npm:@types/d3@7.4.3, npm:@types/d3-array@3.2.2, npm:@types/d3-axis@3.0.6, npm:@types/d3-brush@3.0.6, npm:@types/d3-chord@3.0.6, npm:@types/d3-color@3.1.3, npm:@types/d3-contour@3.0.6, npm:@types/d3-delaunay@6.0.4, npm:@types/d3-dispatch@3.0.7, npm:@types/d3-drag@3.0.7, npm:@types/d3-dsv@3.0.7, npm:@types/d3-ease@3.0.2, npm:@types/d3-fetch@3.0.7, npm:@types/d3-force@3.0.10, npm:@types/d3-format@3.0.4, npm:@types/d3-geo@3.1.0, npm:@types/d3-hierarchy@3.1.7, npm:@types/d3-interpolate@3.0.4, npm:@types/d3-path@3.1.1, npm:@types/d3-polygon@3.0.2, npm:@types/d3-quadtree@3.0.6, npm:@types/d3-random@3.0.4, npm:@types/d3-scale@4.0.9, npm:@types/d3-scale-chromatic@3.1.0, npm:@types/d3-selection@3.0.11, npm:@types/d3-shape@3.1.8, npm:@types/d3-time@3.0.4, npm:@types/d3-time-format@4.0.3, npm:@types/d3-timer@3.0.2, npm:@types/d3-transition@3.0.9, npm:@types/d3-zoom@3.0.8, npm:@types/debug@4.1.13, npm:@types/estree@1.0.9, npm:@types/estree-jsx@1.0.5, npm:@types/geojson@7946.0.16, npm:@types/hast@3.0.5, npm:@types/katex@0.16.8, npm:@types/mdast@4.0.4, npm:@types/ms@2.1.0, npm:@types/node@25.9.5, npm:@types/trusted-types@2.0.7, npm:@types/unist@2.0.11, npm:@types/unist@3.0.3, npm:@types/use-sync-external-store@0.0.6, npm:@types/ws@8.18.1
+[164] Applies to: npm:@types/d3@7.4.3, npm:@types/d3-array@3.2.2, npm:@types/d3-axis@3.0.6, npm:@types/d3-brush@3.0.6, npm:@types/d3-chord@3.0.6, npm:@types/d3-color@3.1.3, npm:@types/d3-contour@3.0.6, npm:@types/d3-delaunay@6.0.4, npm:@types/d3-dispatch@3.0.7, npm:@types/d3-drag@3.0.7, npm:@types/d3-dsv@3.0.7, npm:@types/d3-ease@3.0.2, npm:@types/d3-fetch@3.0.7, npm:@types/d3-force@3.0.10, npm:@types/d3-format@3.0.4, npm:@types/d3-geo@3.1.0, npm:@types/d3-hierarchy@3.1.7, npm:@types/d3-interpolate@3.0.4, npm:@types/d3-path@3.1.1, npm:@types/d3-polygon@3.0.2, npm:@types/d3-quadtree@3.0.6, npm:@types/d3-random@3.0.4, npm:@types/d3-scale@4.0.9, npm:@types/d3-scale-chromatic@3.1.0, npm:@types/d3-selection@3.0.11, npm:@types/d3-shape@3.1.8, npm:@types/d3-time@3.0.4, npm:@types/d3-time-format@4.0.3, npm:@types/d3-timer@3.0.2, npm:@types/d3-transition@3.0.9, npm:@types/d3-zoom@3.0.8, npm:@types/debug@4.1.13, npm:@types/estree@1.0.9, npm:@types/estree-jsx@1.0.5, npm:@types/geojson@7946.0.16, npm:@types/hast@3.0.5, npm:@types/katex@0.16.8, npm:@types/mdast@4.0.4, npm:@types/ms@2.1.0, npm:@types/node@14.18.63, npm:@types/node@22.20.1, npm:@types/node@25.9.5, npm:@types/trusted-types@2.0.7, npm:@types/unist@2.0.11, npm:@types/unist@3.0.3, npm:@types/use-sync-external-store@0.0.6, npm:@types/ws@8.18.1
 ------------------------------------------------------------------------------
 MIT License
 
@@ -27763,7 +27882,7 @@ MIT License
     SOFTWARE
 
 ------------------------------------------------------------------------------
-[163] Applies to: npm:@ungap/structured-clone@1.3.3
+[165] Applies to: npm:@ungap/structured-clone@1.3.3
 ------------------------------------------------------------------------------
 ISC License
 
@@ -27782,7 +27901,7 @@ OR OTHER TORTIOUS ACTION, ARISING OUT OF OR IN CONNECTION WITH THE USE OR
 PERFORMANCE OF THIS SOFTWARE.
 
 ------------------------------------------------------------------------------
-[164] Applies to: npm:@upsetjs/venn.js@2.0.0
+[166] Applies to: npm:@upsetjs/venn.js@2.0.0
 ------------------------------------------------------------------------------
 MIT License
 
@@ -27808,7 +27927,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
 ------------------------------------------------------------------------------
-[165] Applies to: npm:@vladfrangu/async_event_emitter@2.4.7
+[167] Applies to: npm:@vladfrangu/async_event_emitter@2.4.7
 ------------------------------------------------------------------------------
 # The MIT License (MIT)
 
@@ -27836,7 +27955,7 @@ FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
 OTHER DEALINGS IN THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[166] Applies to: npm:@xterm/addon-clipboard@0.1.0
+[168] Applies to: npm:@xterm/addon-clipboard@0.1.0
 ------------------------------------------------------------------------------
 Copyright (c) 2023, The xterm.js authors (https://github.com/xtermjs/xterm.js)
 
@@ -27859,7 +27978,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[167] Applies to: npm:@xterm/addon-fit@0.10.0
+[169] Applies to: npm:@xterm/addon-fit@0.10.0
 ------------------------------------------------------------------------------
 Copyright (c) 2019, The xterm.js authors (https://github.com/xtermjs/xterm.js)
 
@@ -27882,7 +28001,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[168] Applies to: npm:@xterm/addon-web-links@0.11.0
+[170] Applies to: npm:@xterm/addon-web-links@0.11.0
 ------------------------------------------------------------------------------
 Copyright (c) 2017, The xterm.js authors (https://github.com/xtermjs/xterm.js)
 
@@ -27905,7 +28024,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[169] Applies to: npm:@xterm/xterm@5.5.0
+[171] Applies to: npm:@xterm/xterm@5.5.0
 ------------------------------------------------------------------------------
 Copyright (c) 2017-2019, The xterm.js authors (https://github.com/xtermjs/xterm.js)
 Copyright (c) 2014-2016, SourceLair Private Company (https://www.sourcelair.com)
@@ -27930,7 +28049,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[170] Applies to: npm:accepts@2.0.0, npm:mime-types@2.1.35, npm:mime-types@3.0.2
+[172] Applies to: npm:accepts@2.0.0, npm:mime-types@2.1.35, npm:mime-types@3.0.2
 ------------------------------------------------------------------------------
 (The MIT License)
 
@@ -27957,7 +28076,7 @@ TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
 SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[171] Applies to: npm:agent-base@7.1.4, npm:https-proxy-agent@7.0.6
+[173] Applies to: npm:agent-base@7.1.4, npm:https-proxy-agent@7.0.6
 ------------------------------------------------------------------------------
 (The MIT License)
 
@@ -27983,7 +28102,7 @@ TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
 SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[172] Applies to: npm:ajv@7.2.4, npm:ajv@8.20.0
+[174] Applies to: npm:ajv@7.2.4, npm:ajv@8.20.0
 ------------------------------------------------------------------------------
 The MIT License (MIT)
 
@@ -28008,7 +28127,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
 ------------------------------------------------------------------------------
-[173] Applies to: npm:ajv-formats@1.6.1, npm:ajv-formats@3.0.1
+[175] Applies to: npm:ajv-formats@1.6.1, npm:ajv-formats@3.0.1
 ------------------------------------------------------------------------------
 MIT License
 
@@ -28033,7 +28152,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
 ------------------------------------------------------------------------------
-[174] Applies to: npm:ansi-regex@5.0.1, npm:ansi-styles@4.3.0, npm:camelcase@5.3.1, npm:env-paths@2.2.1, npm:find-up@3.0.0, npm:find-up@4.1.0, npm:is-fullwidth-code-point@3.0.0, npm:is-obj@2.0.0, npm:lcid@3.1.1, npm:locate-path@3.0.0, npm:locate-path@5.0.0, npm:make-dir@3.1.0, npm:mimic-fn@2.1.0, npm:mimic-fn@3.1.0, npm:npm-run-path@4.0.1, npm:p-limit@2.3.0, npm:p-locate@3.0.0, npm:p-locate@4.1.0, npm:p-try@2.2.0, npm:path-exists@4.0.0, npm:path-key@3.1.1, npm:pkg-up@3.1.0, npm:shebang-regex@3.0.0, npm:string-width@4.2.3, npm:strip-ansi@6.0.1, npm:strip-final-newline@2.0.0, npm:wrap-ansi@6.2.0
+[176] Applies to: npm:ansi-regex@5.0.1, npm:ansi-styles@4.3.0, npm:camelcase@5.3.1, npm:env-paths@2.2.1, npm:find-up@3.0.0, npm:find-up@4.1.0, npm:is-fullwidth-code-point@3.0.0, npm:is-obj@2.0.0, npm:lcid@3.1.1, npm:locate-path@3.0.0, npm:locate-path@5.0.0, npm:make-dir@3.1.0, npm:mimic-fn@2.1.0, npm:mimic-fn@3.1.0, npm:npm-run-path@4.0.1, npm:p-limit@2.3.0, npm:p-locate@3.0.0, npm:p-locate@4.1.0, npm:p-try@2.2.0, npm:path-exists@4.0.0, npm:path-key@3.1.1, npm:pkg-up@3.1.0, npm:shebang-regex@3.0.0, npm:string-width@4.2.3, npm:strip-ansi@6.0.1, npm:strip-final-newline@2.0.0, npm:wrap-ansi@6.2.0
 ------------------------------------------------------------------------------
 MIT License
 
@@ -28046,7 +28165,7 @@ The above copyright notice and this permission notice shall be included in all c
 THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[175] Applies to: npm:ansi-regex@6.2.2, npm:ansi-styles@6.2.3, npm:conf@9.0.2, npm:debounce-fn@4.0.0, npm:decompress-response@6.0.0, npm:default-shell@2.2.0, npm:dot-prop@6.0.1, npm:electron-store@7.0.3, npm:escape-string-regexp@5.0.0, npm:execa@4.1.0, npm:execa@5.1.1, npm:fix-path@5.0.0, npm:get-east-asian-width@1.6.0, npm:get-stream@5.2.0, npm:get-stream@6.0.1, npm:invert-kv@3.0.1, npm:is-plain-obj@4.1.0, npm:is-stream@2.0.1, npm:mimic-response@3.1.0, npm:onetime@5.1.2, npm:os-locale@6.0.2, npm:shell-env@4.0.3, npm:shell-path@3.1.0, npm:string-width@5.1.2, npm:strip-ansi@7.2.0, npm:wrap-ansi@7.0.0, npm:wrap-ansi@8.1.0
+[177] Applies to: npm:ansi-regex@6.2.2, npm:ansi-styles@6.2.3, npm:conf@9.0.2, npm:debounce-fn@4.0.0, npm:decompress-response@6.0.0, npm:default-shell@2.2.0, npm:dot-prop@6.0.1, npm:electron-store@7.0.3, npm:escape-string-regexp@5.0.0, npm:execa@4.1.0, npm:execa@5.1.1, npm:fix-path@5.0.0, npm:get-east-asian-width@1.6.0, npm:get-stream@5.2.0, npm:get-stream@6.0.1, npm:invert-kv@3.0.1, npm:is-plain-obj@4.1.0, npm:is-stream@2.0.1, npm:mimic-response@3.1.0, npm:onetime@5.1.2, npm:os-locale@6.0.2, npm:shell-env@4.0.3, npm:shell-path@3.1.0, npm:string-width@5.1.2, npm:strip-ansi@7.2.0, npm:wrap-ansi@7.0.0, npm:wrap-ansi@8.1.0
 ------------------------------------------------------------------------------
 MIT License
 
@@ -28059,7 +28178,59 @@ The above copyright notice and this permission notice shall be included in all c
 THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[176] Applies to: npm:argparse@1.0.10
+[178] Applies to: npm:archiver@5.3.2
+------------------------------------------------------------------------------
+Copyright (c) 2012-2014 Chris Talkington, contributors.
+
+Permission is hereby granted, free of charge, to any person
+obtaining a copy of this software and associated documentation
+files (the "Software"), to deal in the Software without
+restriction, including without limitation the rights to use,
+copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the
+Software is furnished to do so, subject to the following
+conditions:
+
+The above copyright notice and this permission notice shall be
+included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
+OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+OTHER DEALINGS IN THE SOFTWARE.
+
+------------------------------------------------------------------------------
+[179] Applies to: npm:archiver-utils@2.1.0, npm:archiver-utils@3.0.4
+------------------------------------------------------------------------------
+Copyright (c) 2015 Chris Talkington.
+
+Permission is hereby granted, free of charge, to any person
+obtaining a copy of this software and associated documentation
+files (the "Software"), to deal in the Software without
+restriction, including without limitation the rights to use,
+copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the
+Software is furnished to do so, subject to the following
+conditions:
+
+The above copyright notice and this permission notice shall be
+included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
+OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+OTHER DEALINGS IN THE SOFTWARE.
+
+------------------------------------------------------------------------------
+[180] Applies to: npm:argparse@1.0.10
 ------------------------------------------------------------------------------
 (The MIT License)
 
@@ -28084,7 +28255,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[177] Applies to: npm:argparse@2.0.1
+[181] Applies to: npm:argparse@2.0.1
 ------------------------------------------------------------------------------
 A. HISTORY OF THE SOFTWARE
 ==========================
@@ -28342,7 +28513,7 @@ ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT
 OF OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
 
 ------------------------------------------------------------------------------
-[178] Applies to: npm:aria-hidden@1.2.6, npm:react-remove-scroll@2.7.2, npm:react-style-singleton@2.2.3, npm:use-callback-ref@1.3.3, npm:use-sidecar@1.1.3
+[182] Applies to: npm:aria-hidden@1.2.6, npm:react-remove-scroll@2.7.2, npm:react-style-singleton@2.2.3, npm:use-callback-ref@1.3.3, npm:use-sidecar@1.1.3
 ------------------------------------------------------------------------------
 MIT License
 
@@ -28367,7 +28538,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
 ------------------------------------------------------------------------------
-[179] Applies to: npm:asn1@0.2.6
+[183] Applies to: npm:asn1@0.2.6
 ------------------------------------------------------------------------------
 Copyright (c) 2011 Mark Cavage, All rights reserved.
 
@@ -28390,7 +28561,30 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE
 
 ------------------------------------------------------------------------------
-[180] Applies to: npm:asynckit@0.4.0
+[184] Applies to: npm:async@3.2.6
+------------------------------------------------------------------------------
+Copyright (c) 2010-2018 Caolan McMahon
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+
+------------------------------------------------------------------------------
+[185] Applies to: npm:asynckit@0.4.0
 ------------------------------------------------------------------------------
 The MIT License (MIT)
 
@@ -28415,7 +28609,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
 ------------------------------------------------------------------------------
-[181] Applies to: npm:atomically@1.7.0
+[186] Applies to: npm:atomically@1.7.0
 ------------------------------------------------------------------------------
 The MIT License (MIT)
 
@@ -28440,7 +28634,7 @@ FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
 DEALINGS IN THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[182] Applies to: npm:axios@1.18.1
+[187] Applies to: npm:axios@1.18.1
 ------------------------------------------------------------------------------
 # Copyright (c) 2014-present Matt Zabriskie & Collaborators
 
@@ -28451,7 +28645,7 @@ The above copyright notice and this permission notice shall be included in all c
 THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[183] Applies to: npm:bail@2.0.2, npm:ccount@2.0.1, npm:character-entities@2.0.2, npm:character-entities-html4@2.1.0, npm:character-entities-legacy@3.0.0, npm:character-reference-invalid@2.0.1, npm:mdast-util-to-string@4.0.0, npm:unist-util-find-after@5.0.0, npm:unist-util-position@5.0.0, npm:unist-util-visit@5.1.0
+[188] Applies to: npm:bail@2.0.2, npm:ccount@2.0.1, npm:character-entities@2.0.2, npm:character-entities-html4@2.1.0, npm:character-entities-legacy@3.0.0, npm:character-reference-invalid@2.0.1, npm:mdast-util-to-string@4.0.0, npm:unist-util-find-after@5.0.0, npm:unist-util-position@5.0.0, npm:unist-util-visit@5.1.0
 ------------------------------------------------------------------------------
 (The MIT License)
 
@@ -28477,7 +28671,7 @@ TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
 SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[184] Applies to: npm:balanced-match@1.0.2
+[189] Applies to: npm:balanced-match@1.0.2
 ------------------------------------------------------------------------------
 (MIT)
 
@@ -28502,7 +28696,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
 ------------------------------------------------------------------------------
-[185] Applies to: npm:base64-js@1.5.1
+[190] Applies to: npm:base64-js@1.5.1
 ------------------------------------------------------------------------------
 The MIT License (MIT)
 
@@ -28527,7 +28721,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[186] Applies to: npm:bcrypt-pbkdf@1.0.2
+[191] Applies to: npm:bcrypt-pbkdf@1.0.2
 ------------------------------------------------------------------------------
 The Blowfish portions are under the following license:
 
@@ -28597,7 +28791,7 @@ ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
 OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
 
 ------------------------------------------------------------------------------
-[187] Applies to: npm:better-sqlite3@12.11.1
+[192] Applies to: npm:better-sqlite3@12.11.1
 ------------------------------------------------------------------------------
 The MIT License (MIT)
 
@@ -28622,7 +28816,35 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
 ------------------------------------------------------------------------------
-[188] Applies to: npm:bignumber.js@9.3.1
+[193] Applies to: npm:big-integer@1.6.52, npm:robust-predicates@3.0.3, npm:tweetnacl@0.14.5
+------------------------------------------------------------------------------
+This is free and unencumbered software released into the public domain.
+
+Anyone is free to copy, modify, publish, use, compile, sell, or
+distribute this software, either in source code form or as a compiled
+binary, for any purpose, commercial or non-commercial, and by any
+means.
+
+In jurisdictions that recognize copyright laws, the author or authors
+of this software dedicate any and all copyright interest in the
+software to the public domain. We make this dedication for the benefit
+of the public at large and to the detriment of our heirs and
+successors. We intend this dedication to be an overt act of
+relinquishment in perpetuity of all present and future rights to this
+software under copyright law.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+IN NO EVENT SHALL THE AUTHORS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+OTHER DEALINGS IN THE SOFTWARE.
+
+For more information, please refer to <http://unlicense.org>
+
+------------------------------------------------------------------------------
+[194] Applies to: npm:bignumber.js@9.3.1
 ------------------------------------------------------------------------------
 The MIT License (MIT)
 =====================
@@ -28651,7 +28873,7 @@ FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
 OTHER DEALINGS IN THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[189] Applies to: npm:bindings@1.5.0
+[195] Applies to: npm:bindings@1.5.0
 ------------------------------------------------------------------------------
 (The MIT License)
 
@@ -28677,7 +28899,7 @@ TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
 SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[190] Applies to: npm:bl@4.1.0
+[196] Applies to: npm:bl@4.1.0
 ------------------------------------------------------------------------------
 The MIT License (MIT)
 =====================
@@ -28694,7 +28916,32 @@ The above copyright notice and this permission notice shall be included in all c
 THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[191] Applies to: npm:body-parser@2.3.0, npm:type-is@2.1.0
+[197] Applies to: npm:bluebird@3.4.7
+------------------------------------------------------------------------------
+The MIT License (MIT)
+
+Copyright (c) 2013-2015 Petka Antonov
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.  IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+
+------------------------------------------------------------------------------
+[198] Applies to: npm:body-parser@2.3.0, npm:type-is@2.1.0
 ------------------------------------------------------------------------------
 (The MIT License)
 
@@ -28721,7 +28968,7 @@ TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
 SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[192] Applies to: npm:brace-expansion@2.1.2
+[199] Applies to: npm:brace-expansion@1.1.16, npm:brace-expansion@2.1.2
 ------------------------------------------------------------------------------
 MIT License
 
@@ -28746,7 +28993,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
 ------------------------------------------------------------------------------
-[193] Applies to: npm:buffer@5.7.1
+[200] Applies to: npm:buffer@5.7.1
 ------------------------------------------------------------------------------
 The MIT License (MIT)
 
@@ -28771,7 +29018,30 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[194] Applies to: npm:buffer-equal-constant-time@1.0.1
+[201] Applies to: npm:buffer-crc32@0.2.13
+------------------------------------------------------------------------------
+The MIT License
+
+Copyright (c) 2013 Brian J. Brennan
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal in
+the Software without restriction, including without limitation the rights to use,
+copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the
+Software, and to permit persons to whom the Software is furnished to do so,
+subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED,
+INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR
+PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE
+FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+------------------------------------------------------------------------------
+[202] Applies to: npm:buffer-equal-constant-time@1.0.1
 ------------------------------------------------------------------------------
 Copyright (c) 2013, GoInstant Inc., a salesforce.com company
 All rights reserved.
@@ -28787,7 +29057,32 @@ Redistribution and use in source and binary forms, with or without modification,
 THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 ------------------------------------------------------------------------------
-[195] Applies to: npm:buildcheck@0.0.7, npm:cpu-features@0.0.10, npm:ssh2@1.17.0
+[203] Applies to: npm:buffer-indexof-polyfill@1.0.2
+------------------------------------------------------------------------------
+The MIT License (MIT)
+
+Copyright (c) 2015 Sarosia
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+
+------------------------------------------------------------------------------
+[204] Applies to: npm:buildcheck@0.0.7, npm:cpu-features@0.0.10, npm:ssh2@1.17.0
 ------------------------------------------------------------------------------
 Copyright Brian White. All rights reserved.
 
@@ -28810,7 +29105,7 @@ FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
 IN THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[196] Applies to: npm:byte-size@8.2.1
+[205] Applies to: npm:byte-size@8.2.1
 ------------------------------------------------------------------------------
 The MIT License (MIT)
 
@@ -28835,7 +29130,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
 ------------------------------------------------------------------------------
-[197] Applies to: npm:bytes@3.1.2
+[206] Applies to: npm:bytes@3.1.2
 ------------------------------------------------------------------------------
 (The MIT License)
 
@@ -28862,7 +29157,7 @@ TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
 SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[198] Applies to: npm:call-bind-apply-helpers@1.0.2, npm:call-bound@1.0.4, npm:es-define-property@1.0.1, npm:es-errors@1.3.0, npm:es-object-atoms@1.1.2, npm:side-channel-list@1.0.1, npm:side-channel-map@1.0.1
+[207] Applies to: npm:call-bind-apply-helpers@1.0.2, npm:call-bound@1.0.4, npm:es-define-property@1.0.1, npm:es-errors@1.3.0, npm:es-object-atoms@1.1.2, npm:side-channel-list@1.0.1, npm:side-channel-map@1.0.1
 ------------------------------------------------------------------------------
 MIT License
 
@@ -28887,7 +29182,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
 ------------------------------------------------------------------------------
-[199] Applies to: npm:charenc@0.0.2, npm:crypt@0.0.2
+[208] Applies to: npm:charenc@0.0.2, npm:crypt@0.0.2
 ------------------------------------------------------------------------------
 Copyright © 2011, Paul Vorbach. All rights reserved.
 Copyright © 2009, Jeff Mott. All rights reserved.
@@ -28918,7 +29213,7 @@ ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
 SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 ------------------------------------------------------------------------------
-[200] Applies to: npm:chownr@3.0.0, npm:package-json-from-dist@1.0.1, npm:yallist@5.0.0
+[209] Applies to: npm:chownr@3.0.0, npm:package-json-from-dist@1.0.1, npm:yallist@5.0.0
 ------------------------------------------------------------------------------
 All packages under `src/` are licensed according to the terms in
 their respective `LICENSE` or `LICENSE.md` files.
@@ -28985,7 +29280,7 @@ will be liable to anyone for any damages related to this
 software or this license, under any kind of legal claim.***
 
 ------------------------------------------------------------------------------
-[201] Applies to: npm:clsx@2.1.1
+[210] Applies to: npm:clsx@2.1.1
 ------------------------------------------------------------------------------
 MIT License
 
@@ -28998,7 +29293,7 @@ The above copyright notice and this permission notice shall be included in all c
 THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[202] Applies to: npm:cn-font-split@6.0.3
+[211] Applies to: npm:cn-font-split@6.0.3
 ------------------------------------------------------------------------------
 Apache License
                            Version 2.0, January 2004
@@ -29203,7 +29498,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 
 ------------------------------------------------------------------------------
-[203] Applies to: npm:color-convert@2.0.1
+[212] Applies to: npm:color-convert@2.0.1
 ------------------------------------------------------------------------------
 Copyright (c) 2011-2016 Heather Arthur <fayearthur@gmail.com>
 
@@ -29227,7 +29522,7 @@ OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
 WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[204] Applies to: npm:color-name@1.1.4
+[213] Applies to: npm:color-name@1.1.4
 ------------------------------------------------------------------------------
 The MIT License (MIT)
 Copyright (c) 2015 Dmitry Ivanov
@@ -29239,7 +29534,7 @@ The above copyright notice and this permission notice shall be included in all c
 THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[205] Applies to: npm:combined-stream@1.0.8, npm:delayed-stream@1.0.0
+[214] Applies to: npm:combined-stream@1.0.8, npm:delayed-stream@1.0.0
 ------------------------------------------------------------------------------
 Copyright (c) 2011 Debuggable Limited <felix@debuggable.com>
 
@@ -29262,7 +29557,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[206] Applies to: npm:comma-separated-tokens@2.0.3, npm:hast-util-is-element@3.0.0, npm:hast-util-parse-selector@4.0.0, npm:hast-util-whitespace@3.0.0, npm:is-alphabetical@2.0.1, npm:is-alphanumerical@2.0.1, npm:is-decimal@2.0.1, npm:is-hexadecimal@2.0.1, npm:mdast-util-to-hast@13.2.1, npm:rehype-slug@6.0.0, npm:space-separated-tokens@2.0.2, npm:unist-util-remove-position@5.0.0, npm:unist-util-stringify-position@4.0.0, npm:unist-util-visit-parents@6.0.2, npm:vfile-location@5.0.3, npm:web-namespaces@2.0.1, npm:zwitch@2.0.4
+[215] Applies to: npm:comma-separated-tokens@2.0.3, npm:hast-util-is-element@3.0.0, npm:hast-util-parse-selector@4.0.0, npm:hast-util-whitespace@3.0.0, npm:is-alphabetical@2.0.1, npm:is-alphanumerical@2.0.1, npm:is-decimal@2.0.1, npm:is-hexadecimal@2.0.1, npm:mdast-util-to-hast@13.2.1, npm:rehype-slug@6.0.0, npm:space-separated-tokens@2.0.2, npm:unist-util-remove-position@5.0.0, npm:unist-util-stringify-position@4.0.0, npm:unist-util-visit-parents@6.0.2, npm:vfile-location@5.0.3, npm:web-namespaces@2.0.1, npm:zwitch@2.0.4
 ------------------------------------------------------------------------------
 (The MIT License)
 
@@ -29288,7 +29583,7 @@ TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
 SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[207] Applies to: npm:commander@7.2.0, npm:commander@8.3.0
+[216] Applies to: npm:commander@7.2.0, npm:commander@8.3.0
 ------------------------------------------------------------------------------
 (The MIT License)
 
@@ -29314,7 +29609,55 @@ TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
 SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[208] Applies to: npm:content-disposition@1.1.0, npm:forwarded@0.2.0, npm:media-typer@1.1.0, npm:vary@1.1.2
+[217] Applies to: npm:compress-commons@4.1.2, npm:crc32-stream@4.0.3, npm:zip-stream@4.1.1
+------------------------------------------------------------------------------
+Copyright (c) 2014 Chris Talkington, contributors.
+
+Permission is hereby granted, free of charge, to any person
+obtaining a copy of this software and associated documentation
+files (the "Software"), to deal in the Software without
+restriction, including without limitation the rights to use,
+copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the
+Software is furnished to do so, subject to the following
+conditions:
+
+The above copyright notice and this permission notice shall be
+included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
+OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+OTHER DEALINGS IN THE SOFTWARE.
+
+------------------------------------------------------------------------------
+[218] Applies to: npm:concat-map@0.0.1, npm:github-from-package@0.0.0, npm:minimist@1.2.8
+------------------------------------------------------------------------------
+This software is released under the MIT license:
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of
+this software and associated documentation files (the "Software"), to deal in
+the Software without restriction, including without limitation the rights to
+use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+the Software, and to permit persons to whom the Software is furnished to do so,
+subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+------------------------------------------------------------------------------
+[219] Applies to: npm:content-disposition@1.1.0, npm:forwarded@0.2.0, npm:media-typer@1.1.0, npm:vary@1.1.2
 ------------------------------------------------------------------------------
 (The MIT License)
 
@@ -29340,7 +29683,7 @@ TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
 SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[209] Applies to: npm:content-type@1.0.5, npm:content-type@2.0.0
+[220] Applies to: npm:content-type@1.0.5, npm:content-type@2.0.0
 ------------------------------------------------------------------------------
 (The MIT License)
 
@@ -29366,7 +29709,7 @@ TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
 SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[210] Applies to: npm:cookie@0.7.2, npm:cookie@1.1.1
+[221] Applies to: npm:cookie@0.7.2, npm:cookie@1.1.1
 ------------------------------------------------------------------------------
 (The MIT License)
 
@@ -29393,7 +29736,7 @@ TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
 SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[211] Applies to: npm:cookie-signature@1.2.2
+[222] Applies to: npm:cookie-signature@1.2.2
 ------------------------------------------------------------------------------
 (The MIT License)
 
@@ -29419,7 +29762,7 @@ TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
 SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[212] Applies to: npm:core-util-is@1.0.3
+[223] Applies to: npm:core-util-is@1.0.3
 ------------------------------------------------------------------------------
 Copyright Node.js contributors. All rights reserved.
 
@@ -29442,7 +29785,7 @@ FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
 IN THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[213] Applies to: npm:cors@2.8.6
+[224] Applies to: npm:cors@2.8.6
 ------------------------------------------------------------------------------
 (The MIT License)
 
@@ -29468,7 +29811,7 @@ TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
 SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[214] Applies to: npm:cose-base@1.0.3, npm:cose-base@2.2.0
+[225] Applies to: npm:cose-base@1.0.3, npm:cose-base@2.2.0
 ------------------------------------------------------------------------------
 MIT License
 
@@ -29493,7 +29836,212 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
 ------------------------------------------------------------------------------
-[215] Applies to: npm:crelt@1.0.7
+[226] Applies to: npm:crc-32@1.2.2
+------------------------------------------------------------------------------
+Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "{}"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright (C) 2014-present   SheetJS LLC
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+
+------------------------------------------------------------------------------
+[227] Applies to: npm:crelt@1.0.7
 ------------------------------------------------------------------------------
 Copyright (C) 2020 by Marijn Haverbeke <marijn@haverbeke.berlin>
 
@@ -29516,7 +30064,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[216] Applies to: npm:cross-spawn@7.0.6
+[228] Applies to: npm:cross-spawn@7.0.6
 ------------------------------------------------------------------------------
 The MIT License (MIT)
 
@@ -29541,7 +30089,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[217] Applies to: npm:cytoscape@3.34.0
+[229] Applies to: npm:cytoscape@3.34.0
 ------------------------------------------------------------------------------
 Copyright (c) 2016-2026, The Cytoscape Consortium.
 
@@ -29597,7 +30145,7 @@ SOFTWARE.`;
 fs.writeFileSync(path.join(__dirname, 'LICENSE'), license);
 
 ------------------------------------------------------------------------------
-[218] Applies to: npm:cytoscape-cose-bilkent@4.1.0
+[230] Applies to: npm:cytoscape-cose-bilkent@4.1.0
 ------------------------------------------------------------------------------
 Copyright (c) 2016-2018, The Cytoscape Consortium.
 
@@ -29620,7 +30168,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
 ------------------------------------------------------------------------------
-[219] Applies to: npm:cytoscape-fcose@2.2.0
+[231] Applies to: npm:cytoscape-fcose@2.2.0
 ------------------------------------------------------------------------------
 Copyright (c) 2018 - present, iVis-at-Bilkent.
 
@@ -29643,7 +30191,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
 ------------------------------------------------------------------------------
-[220] Applies to: npm:d3@7.9.0, npm:d3-array@3.2.4
+[232] Applies to: npm:d3@7.9.0, npm:d3-array@3.2.4
 ------------------------------------------------------------------------------
 Copyright 2010-2023 Mike Bostock
 
@@ -29660,7 +30208,7 @@ TORTIOUS ACTION, ARISING OUT OF OR IN CONNECTION WITH THE USE OR PERFORMANCE OF
 THIS SOFTWARE.
 
 ------------------------------------------------------------------------------
-[221] Applies to: npm:d3-array@2.12.1
+[233] Applies to: npm:d3-array@2.12.1
 ------------------------------------------------------------------------------
 Copyright 2010-2020 Mike Bostock
 All rights reserved.
@@ -29691,7 +30239,7 @@ ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
 SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 ------------------------------------------------------------------------------
-[222] Applies to: npm:d3-axis@3.0.0, npm:d3-brush@3.0.0, npm:d3-chord@3.0.1, npm:d3-dispatch@3.0.1, npm:d3-drag@3.0.0, npm:d3-force@3.0.0, npm:d3-hierarchy@3.1.2, npm:d3-interpolate@3.0.1, npm:d3-polygon@3.0.1, npm:d3-quadtree@3.0.1, npm:d3-random@3.0.1, npm:d3-scale@4.0.2, npm:d3-selection@3.0.0, npm:d3-time-format@4.1.0, npm:d3-timer@3.0.1, npm:d3-transition@3.0.1, npm:d3-zoom@3.0.0
+[234] Applies to: npm:d3-axis@3.0.0, npm:d3-brush@3.0.0, npm:d3-chord@3.0.1, npm:d3-dispatch@3.0.1, npm:d3-drag@3.0.0, npm:d3-force@3.0.0, npm:d3-hierarchy@3.1.2, npm:d3-interpolate@3.0.1, npm:d3-polygon@3.0.1, npm:d3-quadtree@3.0.1, npm:d3-random@3.0.1, npm:d3-scale@4.0.2, npm:d3-selection@3.0.0, npm:d3-time-format@4.1.0, npm:d3-timer@3.0.1, npm:d3-transition@3.0.1, npm:d3-zoom@3.0.0
 ------------------------------------------------------------------------------
 Copyright 2010-2021 Mike Bostock
 
@@ -29708,7 +30256,7 @@ TORTIOUS ACTION, ARISING OUT OF OR IN CONNECTION WITH THE USE OR PERFORMANCE OF
 THIS SOFTWARE.
 
 ------------------------------------------------------------------------------
-[223] Applies to: npm:d3-color@3.1.0, npm:d3-shape@3.2.0, npm:d3-time@3.1.0
+[235] Applies to: npm:d3-color@3.1.0, npm:d3-shape@3.2.0, npm:d3-time@3.1.0
 ------------------------------------------------------------------------------
 Copyright 2010-2022 Mike Bostock
 
@@ -29725,7 +30273,7 @@ TORTIOUS ACTION, ARISING OUT OF OR IN CONNECTION WITH THE USE OR PERFORMANCE OF
 THIS SOFTWARE.
 
 ------------------------------------------------------------------------------
-[224] Applies to: npm:d3-contour@4.0.2
+[236] Applies to: npm:d3-contour@4.0.2
 ------------------------------------------------------------------------------
 Copyright 2012-2023 Mike Bostock
 
@@ -29742,7 +30290,7 @@ TORTIOUS ACTION, ARISING OUT OF OR IN CONNECTION WITH THE USE OR PERFORMANCE OF
 THIS SOFTWARE.
 
 ------------------------------------------------------------------------------
-[225] Applies to: npm:d3-delaunay@6.0.4
+[237] Applies to: npm:d3-delaunay@6.0.4
 ------------------------------------------------------------------------------
 Copyright 2018-2021 Observable, Inc.
 Copyright 2021 Mapbox
@@ -29760,7 +30308,7 @@ TORTIOUS ACTION, ARISING OUT OF OR IN CONNECTION WITH THE USE OR PERFORMANCE OF
 THIS SOFTWARE.
 
 ------------------------------------------------------------------------------
-[226] Applies to: npm:d3-dsv@3.0.1
+[238] Applies to: npm:d3-dsv@3.0.1
 ------------------------------------------------------------------------------
 Copyright 2013-2021 Mike Bostock
 
@@ -29777,7 +30325,7 @@ TORTIOUS ACTION, ARISING OUT OF OR IN CONNECTION WITH THE USE OR PERFORMANCE OF
 THIS SOFTWARE.
 
 ------------------------------------------------------------------------------
-[227] Applies to: npm:d3-ease@3.0.1
+[239] Applies to: npm:d3-ease@3.0.1
 ------------------------------------------------------------------------------
 Copyright 2010-2021 Mike Bostock
 Copyright 2001 Robert Penner
@@ -29809,7 +30357,7 @@ ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
 SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 ------------------------------------------------------------------------------
-[228] Applies to: npm:d3-fetch@3.0.1
+[240] Applies to: npm:d3-fetch@3.0.1
 ------------------------------------------------------------------------------
 Copyright 2016-2021 Mike Bostock
 
@@ -29826,7 +30374,7 @@ TORTIOUS ACTION, ARISING OUT OF OR IN CONNECTION WITH THE USE OR PERFORMANCE OF
 THIS SOFTWARE.
 
 ------------------------------------------------------------------------------
-[229] Applies to: npm:d3-format@3.1.2
+[241] Applies to: npm:d3-format@3.1.2
 ------------------------------------------------------------------------------
 Copyright 2010-2026 Mike Bostock
 
@@ -29843,7 +30391,7 @@ TORTIOUS ACTION, ARISING OUT OF OR IN CONNECTION WITH THE USE OR PERFORMANCE OF
 THIS SOFTWARE.
 
 ------------------------------------------------------------------------------
-[230] Applies to: npm:d3-geo@3.1.1
+[242] Applies to: npm:d3-geo@3.1.1
 ------------------------------------------------------------------------------
 Copyright 2010-2024 Mike Bostock
 
@@ -29881,7 +30429,7 @@ IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
 CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[231] Applies to: npm:d3-path@1.0.9
+[243] Applies to: npm:d3-path@1.0.9
 ------------------------------------------------------------------------------
 Copyright 2015-2016 Mike Bostock
 All rights reserved.
@@ -29912,7 +30460,7 @@ ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
 SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 ------------------------------------------------------------------------------
-[232] Applies to: npm:d3-path@3.1.0
+[244] Applies to: npm:d3-path@3.1.0
 ------------------------------------------------------------------------------
 Copyright 2015-2022 Mike Bostock
 
@@ -29929,7 +30477,7 @@ TORTIOUS ACTION, ARISING OUT OF OR IN CONNECTION WITH THE USE OR PERFORMANCE OF
 THIS SOFTWARE.
 
 ------------------------------------------------------------------------------
-[233] Applies to: npm:d3-sankey@0.12.3
+[245] Applies to: npm:d3-sankey@0.12.3
 ------------------------------------------------------------------------------
 Copyright 2015, Mike Bostock
 All rights reserved.
@@ -29960,7 +30508,7 @@ ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
 SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 ------------------------------------------------------------------------------
-[234] Applies to: npm:d3-scale-chromatic@3.1.0
+[246] Applies to: npm:d3-scale-chromatic@3.1.0
 ------------------------------------------------------------------------------
 Copyright 2010-2024 Mike Bostock
 
@@ -29992,7 +30540,7 @@ CONDITIONS OF ANY KIND, either express or implied. See the License for the
 specific language governing permissions and limitations under the License.
 
 ------------------------------------------------------------------------------
-[235] Applies to: npm:d3-shape@1.3.7
+[247] Applies to: npm:d3-shape@1.3.7
 ------------------------------------------------------------------------------
 Copyright 2010-2015 Mike Bostock
 All rights reserved.
@@ -30023,7 +30571,7 @@ ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
 SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 ------------------------------------------------------------------------------
-[236] Applies to: npm:dagre-d3-es@7.0.14
+[248] Applies to: npm:dagre-d3-es@7.0.14
 ------------------------------------------------------------------------------
 Original dagre-d3 copyright: Copyright (c) 2013 Chris Pettitt
 Original dagre copyright: Copyright (c) 2012-2014 Chris Pettitt
@@ -30050,7 +30598,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[237] Applies to: npm:dayjs@1.11.21
+[249] Applies to: npm:dayjs@1.11.21
 ------------------------------------------------------------------------------
 MIT License
 
@@ -30075,7 +30623,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
 ------------------------------------------------------------------------------
-[238] Applies to: npm:debug@2.6.9
+[250] Applies to: npm:debug@2.6.9
 ------------------------------------------------------------------------------
 (The MIT License)
 
@@ -30097,7 +30645,7 @@ WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN 
 SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[239] Applies to: npm:debug@4.4.3
+[251] Applies to: npm:debug@4.4.3
 ------------------------------------------------------------------------------
 (The MIT License)
 
@@ -30120,7 +30668,7 @@ WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN 
 SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[240] Applies to: npm:decamelize@1.2.0, npm:object-assign@4.1.1, npm:path-exists@3.0.0, npm:strip-json-comments@2.0.1
+[252] Applies to: npm:decamelize@1.2.0, npm:object-assign@4.1.1, npm:path-exists@3.0.0, npm:path-is-absolute@1.0.1, npm:strip-json-comments@2.0.1
 ------------------------------------------------------------------------------
 The MIT License (MIT)
 
@@ -30145,7 +30693,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[241] Applies to: npm:decode-named-character-reference@1.3.0, npm:hast-util-from-parse5@8.0.3, npm:hast-util-to-jsx-runtime@2.3.6, npm:hastscript@9.0.1, npm:lowlight@3.3.0, npm:markdown-table@3.0.4, npm:mdast-util-find-and-replace@3.0.2, npm:mdast-util-from-markdown@2.0.3, npm:mdast-util-gfm@3.1.0, npm:mdast-util-gfm-footnote@2.1.0, npm:mdast-util-to-markdown@2.1.2, npm:micromark@4.0.2, npm:micromark-core-commonmark@2.0.3, npm:micromark-extension-gfm-table@2.1.1, npm:micromark-factory-destination@2.0.1, npm:micromark-factory-label@2.0.1, npm:micromark-factory-space@2.0.1, npm:micromark-factory-title@2.0.1, npm:micromark-factory-whitespace@2.0.1, npm:micromark-util-character@2.1.1, npm:micromark-util-chunked@2.0.1, npm:micromark-util-classify-character@2.0.1, npm:micromark-util-combine-extensions@2.0.1, npm:micromark-util-decode-numeric-character-reference@2.0.2, npm:micromark-util-decode-string@2.0.1, npm:micromark-util-encode@2.0.1, npm:micromark-util-html-tag-name@2.0.1, npm:micromark-util-normalize-identifier@2.0.1, npm:micromark-util-resolve-all@2.0.1, npm:micromark-util-sanitize-uri@2.0.1, npm:micromark-util-subtokenize@2.1.0, npm:micromark-util-symbol@2.0.1, npm:micromark-util-types@2.0.2, npm:rehype-highlight@7.0.2, npm:remark-gfm@4.0.1, npm:remark-rehype@11.1.2, npm:vfile-message@4.0.3
+[253] Applies to: npm:decode-named-character-reference@1.3.0, npm:hast-util-from-parse5@8.0.3, npm:hast-util-to-jsx-runtime@2.3.6, npm:hastscript@9.0.1, npm:lowlight@3.3.0, npm:markdown-table@3.0.4, npm:mdast-util-find-and-replace@3.0.2, npm:mdast-util-from-markdown@2.0.3, npm:mdast-util-gfm@3.1.0, npm:mdast-util-gfm-footnote@2.1.0, npm:mdast-util-to-markdown@2.1.2, npm:micromark@4.0.2, npm:micromark-core-commonmark@2.0.3, npm:micromark-extension-gfm-table@2.1.1, npm:micromark-factory-destination@2.0.1, npm:micromark-factory-label@2.0.1, npm:micromark-factory-space@2.0.1, npm:micromark-factory-title@2.0.1, npm:micromark-factory-whitespace@2.0.1, npm:micromark-util-character@2.1.1, npm:micromark-util-chunked@2.0.1, npm:micromark-util-classify-character@2.0.1, npm:micromark-util-combine-extensions@2.0.1, npm:micromark-util-decode-numeric-character-reference@2.0.2, npm:micromark-util-decode-string@2.0.1, npm:micromark-util-encode@2.0.1, npm:micromark-util-html-tag-name@2.0.1, npm:micromark-util-normalize-identifier@2.0.1, npm:micromark-util-resolve-all@2.0.1, npm:micromark-util-sanitize-uri@2.0.1, npm:micromark-util-subtokenize@2.1.0, npm:micromark-util-symbol@2.0.1, npm:micromark-util-types@2.0.2, npm:rehype-highlight@7.0.2, npm:remark-gfm@4.0.1, npm:remark-rehype@11.1.2, npm:vfile-message@4.0.3
 ------------------------------------------------------------------------------
 (The MIT License)
 
@@ -30171,7 +30719,7 @@ TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
 SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[242] Applies to: npm:deep-extend@0.6.0
+[254] Applies to: npm:deep-extend@0.6.0
 ------------------------------------------------------------------------------
 The MIT License (MIT)
 
@@ -30195,7 +30743,7 @@ IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
 CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[243] Applies to: npm:delaunator@5.1.0
+[255] Applies to: npm:delaunator@5.1.0
 ------------------------------------------------------------------------------
 ISC License
 
@@ -30214,7 +30762,7 @@ TORTIOUS ACTION, ARISING OUT OF OR IN CONNECTION WITH THE USE OR PERFORMANCE OF
 THIS SOFTWARE.
 
 ------------------------------------------------------------------------------
-[244] Applies to: npm:depd@2.0.0
+[256] Applies to: npm:depd@2.0.0
 ------------------------------------------------------------------------------
 (The MIT License)
 
@@ -30240,7 +30788,7 @@ TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
 SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[245] Applies to: npm:dequal@2.0.3, npm:mri@1.2.0
+[257] Applies to: npm:dequal@2.0.3, npm:mri@1.2.0
 ------------------------------------------------------------------------------
 The MIT License (MIT)
 
@@ -30265,7 +30813,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[246] Applies to: npm:detect-libc@2.1.2
+[258] Applies to: npm:detect-libc@2.1.2
 ------------------------------------------------------------------------------
 Apache License
                            Version 2.0, January 2004
@@ -30470,7 +31018,7 @@ Apache License
    limitations under the License.
 
 ------------------------------------------------------------------------------
-[247] Applies to: npm:detect-node-es@1.1.0
+[259] Applies to: npm:detect-node-es@1.1.0
 ------------------------------------------------------------------------------
 MIT License
 
@@ -30495,7 +31043,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
 ------------------------------------------------------------------------------
-[248] Applies to: npm:devlop@1.1.0
+[260] Applies to: npm:devlop@1.1.0
 ------------------------------------------------------------------------------
 (The MIT License)
 
@@ -30521,7 +31069,7 @@ TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
 SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[249] Applies to: npm:diff@8.0.4
+[261] Applies to: npm:diff@8.0.4
 ------------------------------------------------------------------------------
 BSD 3-Clause License
 
@@ -30554,7 +31102,7 @@ OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 ------------------------------------------------------------------------------
-[250] Applies to: npm:dijkstrajs@1.0.3
+[262] Applies to: npm:dijkstrajs@1.0.3
 ------------------------------------------------------------------------------
 ```
 Dijkstra path-finding functions. Adapted from the Dijkstar Python project.
@@ -30577,7 +31125,7 @@ THE SOFTWARE.
 ```
 
 ------------------------------------------------------------------------------
-[251] Applies to: npm:dingtalk-stream@v2.1.5
+[263] Applies to: npm:dingtalk-stream@v2.1.5
 ------------------------------------------------------------------------------
 MIT License
 
@@ -30602,7 +31150,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
 ------------------------------------------------------------------------------
-[252] Applies to: npm:discord-api-types@0.38.50
+[264] Applies to: npm:discord-api-types@0.38.50
 ------------------------------------------------------------------------------
 MIT License
 
@@ -30627,7 +31175,32 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
 ------------------------------------------------------------------------------
-[253] Applies to: npm:dompurify@3.4.12
+[265] Applies to: npm:docx@9.7.1
+------------------------------------------------------------------------------
+The MIT License (MIT)
+
+Copyright (c) 2016 Dolan
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+
+------------------------------------------------------------------------------
+[266] Applies to: npm:dompurify@3.4.12
 ------------------------------------------------------------------------------
 Apache License
                            Version 2.0, January 2004
@@ -31206,7 +31779,7 @@ Exhibit B - "Incompatible With Secondary Licenses" Notice
   defined by the Mozilla Public License, v. 2.0.
 
 ------------------------------------------------------------------------------
-[254] Applies to: npm:dunder-proto@1.0.1, npm:math-intrinsics@1.1.0
+[267] Applies to: npm:dunder-proto@1.0.1, npm:math-intrinsics@1.1.0
 ------------------------------------------------------------------------------
 MIT License
 
@@ -31231,7 +31804,37 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
 ------------------------------------------------------------------------------
-[255] Applies to: npm:ecdsa-sig-formatter@1.0.11
+[268] Applies to: npm:duplexer2@0.1.4
+------------------------------------------------------------------------------
+Copyright (c) 2013, Deoxxa Development
+======================================
+All rights reserved.
+--------------------
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+1. Redistributions of source code must retain the above copyright
+   notice, this list of conditions and the following disclaimer.
+2. Redistributions in binary form must reproduce the above copyright
+   notice, this list of conditions and the following disclaimer in the
+   documentation and/or other materials provided with the distribution.
+3. Neither the name of Deoxxa Development nor the names of its contributors
+   may be used to endorse or promote products derived from this software
+   without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY DEOXXA DEVELOPMENT ''AS IS'' AND ANY
+EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL DEOXXA DEVELOPMENT BE LIABLE FOR ANY
+DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+(INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+------------------------------------------------------------------------------
+[269] Applies to: npm:ecdsa-sig-formatter@1.0.11
 ------------------------------------------------------------------------------
 Apache License
                            Version 2.0, January 2004
@@ -31436,7 +32039,7 @@ Apache License
    limitations under the License.
 
 ------------------------------------------------------------------------------
-[256] Applies to: npm:ee-first@1.1.1
+[270] Applies to: npm:ee-first@1.1.1
 ------------------------------------------------------------------------------
 The MIT License (MIT)
 
@@ -31461,7 +32064,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[257] Applies to: npm:electron-squirrel-startup@1.0.1
+[271] Applies to: npm:electron-squirrel-startup@1.0.1
 ------------------------------------------------------------------------------
 Apache License
 Version 2.0, January 2004
@@ -31666,7 +32269,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 
 ------------------------------------------------------------------------------
-[258] Applies to: npm:electron-window-state@5.0.3
+[272] Applies to: npm:electron-window-state@5.0.3
 ------------------------------------------------------------------------------
 The MIT License (MIT)
 
@@ -31692,7 +32295,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[259] Applies to: npm:emoji-regex@8.0.0, npm:emoji-regex@9.2.2, npm:punycode@2.3.1
+[273] Applies to: npm:emoji-regex@8.0.0, npm:emoji-regex@9.2.2, npm:punycode@2.3.1
 ------------------------------------------------------------------------------
 Copyright Mathias Bynens <https://mathiasbynens.be/>
 
@@ -31716,7 +32319,7 @@ OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
 WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[260] Applies to: npm:encodeurl@2.0.0
+[274] Applies to: npm:encodeurl@2.0.0
 ------------------------------------------------------------------------------
 (The MIT License)
 
@@ -31742,7 +32345,7 @@ TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
 SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[261] Applies to: npm:end-of-stream@1.4.5, npm:pump@3.0.4, npm:tar-fs@2.1.5, npm:tar-stream@2.2.0
+[275] Applies to: npm:end-of-stream@1.4.5, npm:pump@3.0.4, npm:tar-fs@2.1.5, npm:tar-stream@2.2.0
 ------------------------------------------------------------------------------
 The MIT License (MIT)
 
@@ -31767,7 +32370,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[262] Applies to: npm:entities@6.0.1
+[276] Applies to: npm:entities@6.0.1
 ------------------------------------------------------------------------------
 Copyright (c) Felix Böhm
 All rights reserved.
@@ -31782,7 +32385,7 @@ THIS IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRE
 EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 ------------------------------------------------------------------------------
-[263] Applies to: npm:es-set-tostringtag@2.1.0
+[277] Applies to: npm:es-set-tostringtag@2.1.0
 ------------------------------------------------------------------------------
 MIT License
 
@@ -31807,7 +32410,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
 ------------------------------------------------------------------------------
-[264] Applies to: npm:es-toolkit@1.49.0
+[278] Applies to: npm:es-toolkit@1.49.0
 ------------------------------------------------------------------------------
 MIT License
 
@@ -31832,7 +32435,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
 ------------------------------------------------------------------------------
-[265] Applies to: npm:escape-html@1.0.3
+[279] Applies to: npm:escape-html@1.0.3
 ------------------------------------------------------------------------------
 (The MIT License)
 
@@ -31860,7 +32463,7 @@ TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
 SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[266] Applies to: npm:esprima@4.0.1
+[280] Applies to: npm:esprima@4.0.1
 ------------------------------------------------------------------------------
 Copyright JS Foundation and other contributors, https://js.foundation/
 
@@ -31885,7 +32488,7 @@ ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
 THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 ------------------------------------------------------------------------------
-[267] Applies to: npm:estree-util-is-identifier-name@3.0.0, npm:hast-util-heading-rank@3.0.0, npm:mdast-util-gfm-autolink-literal@2.0.1, npm:mdast-util-gfm-strikethrough@2.0.0, npm:mdast-util-gfm-table@2.0.0, npm:mdast-util-gfm-task-list-item@2.0.0, npm:mdast-util-math@3.0.0, npm:mdast-util-mdx-expression@2.0.1, npm:mdast-util-mdx-jsx@3.2.0, npm:mdast-util-mdxjs-esm@2.0.1, npm:micromark-extension-gfm@3.0.0, npm:micromark-extension-gfm-autolink-literal@2.1.0, npm:micromark-extension-gfm-strikethrough@2.1.0, npm:micromark-extension-gfm-tagfilter@2.0.0, npm:micromark-extension-gfm-task-list-item@2.1.0, npm:micromark-extension-math@3.1.0
+[281] Applies to: npm:estree-util-is-identifier-name@3.0.0, npm:hast-util-heading-rank@3.0.0, npm:mdast-util-gfm-autolink-literal@2.0.1, npm:mdast-util-gfm-strikethrough@2.0.0, npm:mdast-util-gfm-table@2.0.0, npm:mdast-util-gfm-task-list-item@2.0.0, npm:mdast-util-math@3.0.0, npm:mdast-util-mdx-expression@2.0.1, npm:mdast-util-mdx-jsx@3.2.0, npm:mdast-util-mdxjs-esm@2.0.1, npm:micromark-extension-gfm@3.0.0, npm:micromark-extension-gfm-autolink-literal@2.1.0, npm:micromark-extension-gfm-strikethrough@2.1.0, npm:micromark-extension-gfm-tagfilter@2.0.0, npm:micromark-extension-gfm-task-list-item@2.1.0, npm:micromark-extension-math@3.1.0
 ------------------------------------------------------------------------------
 (The MIT License)
 
@@ -31911,7 +32514,7 @@ TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
 SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[268] Applies to: npm:etag@1.8.1, npm:proxy-addr@2.0.7
+[282] Applies to: npm:etag@1.8.1, npm:proxy-addr@2.0.7
 ------------------------------------------------------------------------------
 (The MIT License)
 
@@ -31937,7 +32540,7 @@ TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
 SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[269] Applies to: npm:eventemitter3@5.0.4
+[283] Applies to: npm:eventemitter3@5.0.4
 ------------------------------------------------------------------------------
 The MIT License (MIT)
 
@@ -31962,7 +32565,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
 ------------------------------------------------------------------------------
-[270] Applies to: npm:eventsource@3.0.7
+[284] Applies to: npm:eventsource@3.0.7
 ------------------------------------------------------------------------------
 The MIT License
 
@@ -31988,7 +32591,7 @@ OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
 WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[271] Applies to: npm:eventsource-parser@3.1.0
+[285] Applies to: npm:eventsource-parser@3.1.0
 ------------------------------------------------------------------------------
 MIT License
 
@@ -32013,7 +32616,32 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
 ------------------------------------------------------------------------------
-[272] Applies to: npm:expand-template@2.0.3
+[286] Applies to: npm:exceljs@4.4.0
+------------------------------------------------------------------------------
+The MIT License (MIT)
+
+Copyright (c) 2014-2019 Guyon Roche
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+
+------------------------------------------------------------------------------
+[287] Applies to: npm:expand-template@2.0.3
 ------------------------------------------------------------------------------
 The MIT License (MIT)
 
@@ -32038,7 +32666,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[273] Applies to: npm:express@5.2.1
+[288] Applies to: npm:express@5.2.1
 ------------------------------------------------------------------------------
 (The MIT License)
 
@@ -32066,7 +32694,7 @@ TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
 SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[274] Applies to: npm:express-rate-limit@8.5.2
+[289] Applies to: npm:express-rate-limit@8.5.2
 ------------------------------------------------------------------------------
 # MIT License
 
@@ -32090,7 +32718,7 @@ IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
 CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[275] Applies to: npm:extend@3.0.2
+[290] Applies to: npm:extend@3.0.2
 ------------------------------------------------------------------------------
 The MIT License (MIT)
 
@@ -32116,7 +32744,7 @@ OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
 WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[276] Applies to: npm:extend-shallow@2.0.1
+[291] Applies to: npm:extend-shallow@2.0.1
 ------------------------------------------------------------------------------
 The MIT License (MIT)
 
@@ -32141,7 +32769,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[277] Applies to: npm:fast-deep-equal@3.1.3, npm:json-schema-traverse@1.0.0
+[292] Applies to: npm:fast-deep-equal@3.1.3, npm:json-schema-traverse@1.0.0
 ------------------------------------------------------------------------------
 MIT License
 
@@ -32166,7 +32794,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
 ------------------------------------------------------------------------------
-[278] Applies to: npm:fast-equals@5.4.1
+[293] Applies to: npm:fast-equals@5.4.1
 ------------------------------------------------------------------------------
 MIT License
 
@@ -32191,7 +32819,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
 ------------------------------------------------------------------------------
-[279] Applies to: npm:fast-uri@3.1.4
+[294] Applies to: npm:fast-uri@3.1.4
 ------------------------------------------------------------------------------
 Copyright (c) 2011-2021, Gary Court until https://github.com/garycourt/uri-js/commit/a1acf730b4bba3f1097c9f52e7d9d3aba8cdcaae
 Copyright (c) 2021-present The Fastify team <https://github.com/fastify/fastify#team>
@@ -32225,7 +32853,7 @@ The complete list of contributors can be found at:
 - https://github.com/garycourt/uri-js/graphs/contributors
 
 ------------------------------------------------------------------------------
-[280] Applies to: npm:fetch-blob@3.2.0
+[295] Applies to: npm:fetch-blob@3.2.0
 ------------------------------------------------------------------------------
 MIT License
 
@@ -32250,7 +32878,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
 ------------------------------------------------------------------------------
-[281] Applies to: npm:file-uri-to-path@1.0.0
+[296] Applies to: npm:file-uri-to-path@1.0.0
 ------------------------------------------------------------------------------
 Copyright (c) 2014 Nathan Rajlich <nathan@tootallnate.net>
 
@@ -32274,7 +32902,7 @@ TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
 SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[282] Applies to: npm:finalhandler@2.1.1
+[297] Applies to: npm:finalhandler@2.1.1
 ------------------------------------------------------------------------------
 (The MIT License)
 
@@ -32300,7 +32928,7 @@ TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
 SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[283] Applies to: npm:follow-redirects@1.16.0
+[298] Applies to: npm:follow-redirects@1.16.0
 ------------------------------------------------------------------------------
 Copyright 2014–present Olivier Lalonde <olalonde@gmail.com>, James Talmage <james@talmage.io>, Ruben Verborgh
 
@@ -32322,7 +32950,7 @@ WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR
 IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[284] Applies to: npm:foreground-child@3.3.1
+[299] Applies to: npm:foreground-child@3.3.1
 ------------------------------------------------------------------------------
 The ISC License
 
@@ -32341,7 +32969,7 @@ ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF OR
 IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
 
 ------------------------------------------------------------------------------
-[285] Applies to: npm:form-data@4.0.6
+[300] Applies to: npm:form-data@4.0.6
 ------------------------------------------------------------------------------
 Copyright (c) 2012 Felix Geisendörfer (felix@debuggable.com) and contributors
 
@@ -32364,7 +32992,7 @@ Copyright (c) 2012 Felix Geisendörfer (felix@debuggable.com) and contributors
  THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[286] Applies to: npm:formdata-polyfill@4.0.10
+[301] Applies to: npm:formdata-polyfill@4.0.10
 ------------------------------------------------------------------------------
 MIT License
 
@@ -32389,7 +33017,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
 ------------------------------------------------------------------------------
-[287] Applies to: npm:fresh@2.0.0
+[302] Applies to: npm:fresh@2.0.0
 ------------------------------------------------------------------------------
 (The MIT License)
 
@@ -32416,7 +33044,7 @@ TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
 SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[288] Applies to: npm:fs-constants@1.0.0
+[303] Applies to: npm:fs-constants@1.0.0
 ------------------------------------------------------------------------------
 The MIT License (MIT)
 
@@ -32441,7 +33069,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[289] Applies to: npm:fs-extra@11.3.6
+[304] Applies to: npm:fs-extra@11.3.6
 ------------------------------------------------------------------------------
 (The MIT License)
 
@@ -32460,7 +33088,54 @@ OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHE
  ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[290] Applies to: npm:function-bind@1.1.2
+[305] Applies to: npm:fs.realpath@1.0.0
+------------------------------------------------------------------------------
+The ISC License
+
+Copyright (c) Isaac Z. Schlueter and Contributors
+
+Permission to use, copy, modify, and/or distribute this software for any
+purpose with or without fee is hereby granted, provided that the above
+copyright notice and this permission notice appear in all copies.
+
+THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
+ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF OR
+IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+
+----
+
+This library bundles a version of the `fs.realpath` and `fs.realpathSync`
+methods from Node.js v0.10 under the terms of the Node.js MIT license.
+
+Node's license follows, also included at the header of `old.js` which contains
+the licensed code:
+
+  Copyright Joyent, Inc. and other Node contributors.
+
+  Permission is hereby granted, free of charge, to any person obtaining a
+  copy of this software and associated documentation files (the "Software"),
+  to deal in the Software without restriction, including without limitation
+  the rights to use, copy, modify, merge, publish, distribute, sublicense,
+  and/or sell copies of the Software, and to permit persons to whom the
+  Software is furnished to do so, subject to the following conditions:
+
+  The above copyright notice and this permission notice shall be included in
+  all copies or substantial portions of the Software.
+
+  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+  FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+  DEALINGS IN THE SOFTWARE.
+
+------------------------------------------------------------------------------
+[306] Applies to: npm:function-bind@1.1.2
 ------------------------------------------------------------------------------
 Copyright (c) 2013 Raynos.
 
@@ -32483,7 +33158,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[291] Applies to: npm:get-caller-file@2.0.5
+[307] Applies to: npm:get-caller-file@2.0.5
 ------------------------------------------------------------------------------
 ISC License (ISC)
 Copyright 2018 Stefan Penner
@@ -32493,7 +33168,7 @@ Permission to use, copy, modify, and/or distribute this software for any purpose
 THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
 
 ------------------------------------------------------------------------------
-[292] Applies to: npm:get-intrinsic@1.3.0
+[308] Applies to: npm:get-intrinsic@1.3.0
 ------------------------------------------------------------------------------
 MIT License
 
@@ -32518,7 +33193,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
 ------------------------------------------------------------------------------
-[293] Applies to: npm:get-nonce@1.0.1
+[309] Applies to: npm:get-nonce@1.0.1
 ------------------------------------------------------------------------------
 MIT License
 
@@ -32543,7 +33218,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
 ------------------------------------------------------------------------------
-[294] Applies to: npm:get-proto@1.0.1
+[310] Applies to: npm:get-proto@1.0.1
 ------------------------------------------------------------------------------
 MIT License
 
@@ -32568,29 +33243,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
 ------------------------------------------------------------------------------
-[295] Applies to: npm:github-from-package@0.0.0, npm:minimist@1.2.8
-------------------------------------------------------------------------------
-This software is released under the MIT license:
-
-Permission is hereby granted, free of charge, to any person obtaining a copy of
-this software and associated documentation files (the "Software"), to deal in
-the Software without restriction, including without limitation the rights to
-use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
-the Software, and to permit persons to whom the Software is furnished to do so,
-subject to the following conditions:
-
-The above copyright notice and this permission notice shall be included in all
-copies or substantial portions of the Software.
-
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
-FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
-COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
-IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
-CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
-
-------------------------------------------------------------------------------
-[296] Applies to: npm:github-slugger@2.0.0
+[311] Applies to: npm:github-slugger@2.0.0
 ------------------------------------------------------------------------------
 Copyright (c) 2015, Dan Flettre <fletd01@yahoo.com>
 
@@ -32599,7 +33252,7 @@ Permission to use, copy, modify, and/or distribute this software for any purpose
 THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
 
 ------------------------------------------------------------------------------
-[297] Applies to: npm:glob@10.5.0
+[312] Applies to: npm:glob@10.5.0
 ------------------------------------------------------------------------------
 The ISC License
 
@@ -32618,7 +33271,32 @@ ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF OR
 IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
 
 ------------------------------------------------------------------------------
-[298] Applies to: npm:gopd@1.2.0
+[313] Applies to: npm:glob@7.2.3
+------------------------------------------------------------------------------
+The ISC License
+
+Copyright (c) Isaac Z. Schlueter and Contributors
+
+Permission to use, copy, modify, and/or distribute this software for any
+purpose with or without fee is hereby granted, provided that the above
+copyright notice and this permission notice appear in all copies.
+
+THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
+ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF OR
+IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+
+## Glob Logo
+
+Glob's logo created by Tanya Brassie <http://tanyabrassie.com/>, licensed
+under a Creative Commons Attribution-ShareAlike 4.0 International License
+https://creativecommons.org/licenses/by-sa/4.0/
+
+------------------------------------------------------------------------------
+[314] Applies to: npm:gopd@1.2.0
 ------------------------------------------------------------------------------
 MIT License
 
@@ -32643,7 +33321,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
 ------------------------------------------------------------------------------
-[299] Applies to: npm:graceful-fs@4.2.11
+[315] Applies to: npm:graceful-fs@4.2.11
 ------------------------------------------------------------------------------
 The ISC License
 
@@ -32662,7 +33340,7 @@ ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF OR
 IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
 
 ------------------------------------------------------------------------------
-[300] Applies to: npm:gray-matter@4.0.3
+[316] Applies to: npm:gray-matter@4.0.3, npm:normalize-path@3.0.0
 ------------------------------------------------------------------------------
 The MIT License (MIT)
 
@@ -32687,7 +33365,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[301] Applies to: npm:gtoken@8.0.0
+[317] Applies to: npm:gtoken@8.0.0
 ------------------------------------------------------------------------------
 The MIT License (MIT)
 
@@ -32712,7 +33390,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[302] Applies to: npm:hachure-fill@0.5.2
+[318] Applies to: npm:hachure-fill@0.5.2
 ------------------------------------------------------------------------------
 MIT License
 
@@ -32737,7 +33415,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
 ------------------------------------------------------------------------------
-[303] Applies to: npm:harmonyos-sans-sc-webfont-splitted@1.1.0
+[319] Applies to: npm:harmonyos-sans-sc-webfont-splitted@1.1.0
 ------------------------------------------------------------------------------
 This is free and unencumbered software released into the public domain.
 
@@ -32765,7 +33443,7 @@ OTHER DEALINGS IN THE SOFTWARE.
 For more information, please refer to <https://unlicense.org>
 
 ------------------------------------------------------------------------------
-[304] Applies to: npm:has-symbols@1.1.0
+[320] Applies to: npm:has-symbols@1.1.0
 ------------------------------------------------------------------------------
 MIT License
 
@@ -32790,7 +33468,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
 ------------------------------------------------------------------------------
-[305] Applies to: npm:has-tostringtag@1.0.2
+[321] Applies to: npm:has-tostringtag@1.0.2
 ------------------------------------------------------------------------------
 MIT License
 
@@ -32815,7 +33493,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
 ------------------------------------------------------------------------------
-[306] Applies to: npm:hasown@2.0.4
+[322] Applies to: npm:hasown@2.0.4
 ------------------------------------------------------------------------------
 MIT License
 
@@ -32840,7 +33518,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
 ------------------------------------------------------------------------------
-[307] Applies to: npm:hast-util-from-dom@5.0.1
+[323] Applies to: npm:hast-util-from-dom@5.0.1
 ------------------------------------------------------------------------------
 (ISC License)
 
@@ -32859,7 +33537,7 @@ TORTIOUS ACTION, ARISING OUT OF OR IN CONNECTION WITH THE USE OR PERFORMANCE OF
 THIS SOFTWARE.
 
 ------------------------------------------------------------------------------
-[308] Applies to: npm:hast-util-from-html@2.0.3
+[324] Applies to: npm:hast-util-from-html@2.0.3
 ------------------------------------------------------------------------------
 (The MIT License)
 
@@ -32885,7 +33563,7 @@ TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
 SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[309] Applies to: npm:hast-util-from-html-isomorphic@2.0.0
+[325] Applies to: npm:hast-util-from-html-isomorphic@2.0.0
 ------------------------------------------------------------------------------
 (The MIT License)
 
@@ -32911,7 +33589,7 @@ TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
 SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[310] Applies to: npm:hast-util-to-string@3.0.1, npm:html-url-attributes@3.0.1
+[326] Applies to: npm:hast-util-to-string@3.0.1, npm:html-url-attributes@3.0.1
 ------------------------------------------------------------------------------
 (The MIT License)
 
@@ -32936,7 +33614,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[311] Applies to: npm:hast-util-to-text@4.0.2
+[327] Applies to: npm:hast-util-to-text@4.0.2
 ------------------------------------------------------------------------------
 (The MIT License)
 
@@ -32962,7 +33640,7 @@ TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
 SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[312] Applies to: npm:highlight.js@11.11.1
+[328] Applies to: npm:highlight.js@11.11.1
 ------------------------------------------------------------------------------
 BSD 3-Clause License
 
@@ -32995,7 +33673,7 @@ OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 ------------------------------------------------------------------------------
-[313] Applies to: npm:hono@4.12.30
+[329] Applies to: npm:hono@4.12.30
 ------------------------------------------------------------------------------
 MIT License
 
@@ -33020,7 +33698,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
 ------------------------------------------------------------------------------
-[314] Applies to: npm:html-to-image@1.11.13
+[330] Applies to: npm:html-to-image@1.11.13
 ------------------------------------------------------------------------------
 MIT License
 
@@ -33045,7 +33723,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
 ------------------------------------------------------------------------------
-[315] Applies to: npm:http-errors@2.0.1
+[331] Applies to: npm:http-errors@2.0.1
 ------------------------------------------------------------------------------
 The MIT License (MIT)
 
@@ -33071,7 +33749,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[316] Applies to: npm:human-signals@1.1.1, npm:human-signals@2.1.0
+[332] Applies to: npm:human-signals@1.1.1, npm:human-signals@2.1.0
 ------------------------------------------------------------------------------
 Apache License
                            Version 2.0, January 2004
@@ -33276,7 +33954,7 @@ Apache License
    limitations under the License.
 
 ------------------------------------------------------------------------------
-[317] Applies to: npm:i18next@26.3.6
+[333] Applies to: npm:i18next@26.3.6
 ------------------------------------------------------------------------------
 The MIT License (MIT)
 
@@ -33301,7 +33979,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
 ------------------------------------------------------------------------------
-[318] Applies to: npm:iconv-lite@0.6.3, npm:iconv-lite@0.7.3
+[334] Applies to: npm:iconv-lite@0.6.3, npm:iconv-lite@0.7.3
 ------------------------------------------------------------------------------
 Copyright (c) 2011 Alexander Shtuchkin
 
@@ -33325,7 +34003,7 @@ OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
 WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[319] Applies to: npm:ieee754@1.2.1
+[335] Applies to: npm:ieee754@1.2.1
 ------------------------------------------------------------------------------
 Copyright 2008 Fair Oaks Labs, Inc.
 
@@ -33340,7 +34018,7 @@ Redistribution and use in source and binary forms, with or without modification,
 THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 ------------------------------------------------------------------------------
-[320] Applies to: npm:ignore@7.0.6
+[336] Applies to: npm:ignore@7.0.6
 ------------------------------------------------------------------------------
 Copyright (c) 2013 Kael Zhang <i@kael.me>, contributors
 http://kael.me/
@@ -33365,7 +34043,20 @@ OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
 WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[321] Applies to: npm:immediate@3.0.6
+[337] Applies to: npm:image-size@1.2.1
+------------------------------------------------------------------------------
+The MIT License (MIT)
+
+Copyright © 2013-Present Aditya Yadav, http://netroy.in
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the “Software”), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+------------------------------------------------------------------------------
+[338] Applies to: npm:immediate@3.0.6
 ------------------------------------------------------------------------------
 Copyright (c) 2012 Barnesandnoble.com, llc, Donavon West, Domenic Denicola, Brian Cavalier
 
@@ -33389,7 +34080,7 @@ OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
 WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[322] Applies to: npm:import-meta-resolve@4.2.0
+[339] Applies to: npm:import-meta-resolve@4.2.0
 ------------------------------------------------------------------------------
 (The MIT License)
 
@@ -33467,7 +34158,26 @@ IN THE SOFTWARE.
 """
 
 ------------------------------------------------------------------------------
-[323] Applies to: npm:inherits@2.0.4
+[340] Applies to: npm:inflight@1.0.6
+------------------------------------------------------------------------------
+The ISC License
+
+Copyright (c) Isaac Z. Schlueter
+
+Permission to use, copy, modify, and/or distribute this software for any
+purpose with or without fee is hereby granted, provided that the above
+copyright notice and this permission notice appear in all copies.
+
+THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
+ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF OR
+IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+
+------------------------------------------------------------------------------
+[341] Applies to: npm:inherits@2.0.4
 ------------------------------------------------------------------------------
 The ISC License
 
@@ -33486,7 +34196,7 @@ OTHER TORTIOUS ACTION, ARISING OUT OF OR IN CONNECTION WITH THE USE OR
 PERFORMANCE OF THIS SOFTWARE.
 
 ------------------------------------------------------------------------------
-[324] Applies to: npm:inline-style-parser@0.2.7
+[342] Applies to: npm:inline-style-parser@0.2.7
 ------------------------------------------------------------------------------
 (The MIT License)
 
@@ -33499,7 +34209,7 @@ The above copyright notice and this permission notice shall be included in all c
 THE SOFTWARE IS PROVIDED 'AS IS', WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[325] Applies to: npm:internmap@1.0.1, npm:internmap@2.0.3
+[343] Applies to: npm:internmap@1.0.1, npm:internmap@2.0.3
 ------------------------------------------------------------------------------
 Copyright 2021 Mike Bostock
 
@@ -33516,7 +34226,7 @@ TORTIOUS ACTION, ARISING OUT OF OR IN CONNECTION WITH THE USE OR PERFORMANCE OF
 THIS SOFTWARE.
 
 ------------------------------------------------------------------------------
-[326] Applies to: npm:ip-address@10.2.0
+[344] Applies to: npm:ip-address@10.2.0
 ------------------------------------------------------------------------------
 Copyright (C) 2011 by Beau Gunderson
 
@@ -33539,7 +34249,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[327] Applies to: npm:ipaddr.js@1.9.1, npm:ipaddr.js@2.4.0
+[345] Applies to: npm:ipaddr.js@1.9.1, npm:ipaddr.js@2.4.0
 ------------------------------------------------------------------------------
 Copyright (C) 2011-2017 whitequark <whitequark@whitequark.org>
 
@@ -33562,7 +34272,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[328] Applies to: npm:is-buffer@1.1.6, npm:safe-buffer@5.1.2, npm:safe-buffer@5.2.1
+[346] Applies to: npm:is-buffer@1.1.6, npm:safe-buffer@5.1.2, npm:safe-buffer@5.2.1
 ------------------------------------------------------------------------------
 The MIT License (MIT)
 
@@ -33587,7 +34297,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[329] Applies to: npm:is-extendable@0.1.1
+[347] Applies to: npm:is-extendable@0.1.1
 ------------------------------------------------------------------------------
 The MIT License (MIT)
 
@@ -33612,7 +34322,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[330] Applies to: npm:is-extglob@2.1.1
+[348] Applies to: npm:is-extglob@2.1.1
 ------------------------------------------------------------------------------
 The MIT License (MIT)
 
@@ -33637,7 +34347,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[331] Applies to: npm:is-glob@4.0.3, npm:kind-of@6.0.3
+[349] Applies to: npm:is-glob@4.0.3, npm:kind-of@6.0.3
 ------------------------------------------------------------------------------
 The MIT License (MIT)
 
@@ -33662,7 +34372,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[332] Applies to: npm:is-promise@2.2.2, npm:is-promise@4.0.0
+[350] Applies to: npm:is-promise@2.2.2, npm:is-promise@4.0.0
 ------------------------------------------------------------------------------
 Copyright (c) 2014 Forbes Lindesay
 
@@ -33685,7 +34395,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[333] Applies to: npm:jackspeak@3.4.3
+[351] Applies to: npm:jackspeak@3.4.3
 ------------------------------------------------------------------------------
 # Blue Oak Model License
 
@@ -33744,7 +34454,7 @@ will be liable to anyone for any damages related to this
 software or this license, under any kind of legal claim._**
 
 ------------------------------------------------------------------------------
-[334] Applies to: npm:jose@6.2.3
+[352] Applies to: npm:jose@6.2.3
 ------------------------------------------------------------------------------
 The MIT License (MIT)
 
@@ -33769,7 +34479,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
 ------------------------------------------------------------------------------
-[335] Applies to: npm:js-base64@3.9.1
+[353] Applies to: npm:js-base64@3.9.1
 ------------------------------------------------------------------------------
 Copyright (c) 2014, Dan Kogai
 All rights reserved.
@@ -33800,7 +34510,7 @@ OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 ------------------------------------------------------------------------------
-[336] Applies to: npm:js-yaml@3.15.0, npm:js-yaml@4.3.0
+[354] Applies to: npm:js-yaml@3.15.0, npm:js-yaml@4.3.0
 ------------------------------------------------------------------------------
 (The MIT License)
 
@@ -33825,7 +34535,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[337] Applies to: npm:json-bigint@1.0.0
+[355] Applies to: npm:json-bigint@1.0.0
 ------------------------------------------------------------------------------
 The MIT License (MIT)
 
@@ -33849,7 +34559,7 @@ IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
 CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[338] Applies to: npm:json-schema-to-ts@3.1.1, npm:ts-algebra@2.0.0
+[356] Applies to: npm:json-schema-to-ts@3.1.1, npm:ts-algebra@2.0.0
 ------------------------------------------------------------------------------
 MIT License
 
@@ -33874,7 +34584,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
 ------------------------------------------------------------------------------
-[339] Applies to: npm:json-schema-typed@7.0.3
+[357] Applies to: npm:json-schema-typed@7.0.3
 ------------------------------------------------------------------------------
 BSD-2-Clause License
 
@@ -33904,7 +34614,7 @@ ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 POSSIBILITY OF SUCH DAMAGE.
 
 ------------------------------------------------------------------------------
-[340] Applies to: npm:json-schema-typed@8.0.2
+[358] Applies to: npm:json-schema-typed@8.0.2
 ------------------------------------------------------------------------------
 BSD 2-Clause License
 
@@ -33965,7 +34675,7 @@ ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
 SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 ------------------------------------------------------------------------------
-[341] Applies to: npm:jsonfile@4.0.0, npm:jsonfile@6.2.1
+[359] Applies to: npm:jsonfile@4.0.0, npm:jsonfile@6.2.1
 ------------------------------------------------------------------------------
 (The MIT License)
 
@@ -33984,7 +34694,7 @@ OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHE
  ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[342] Applies to: npm:jszip@3.10.1
+[360] Applies to: npm:jszip@3.10.1
 ------------------------------------------------------------------------------
 JSZip is dual licensed. At your choice you may use it under the MIT license *or* the GPLv3
 license.
@@ -34639,7 +35349,7 @@ copy of the Program in return for a fee.
                      END OF TERMS AND CONDITIONS
 
 ------------------------------------------------------------------------------
-[343] Applies to: npm:jwa@2.0.1, npm:jws@4.0.1
+[361] Applies to: npm:jwa@2.0.1, npm:jws@4.0.1
 ------------------------------------------------------------------------------
 Copyright (c) 2013 Brian J. Brennan
 
@@ -34660,7 +35370,7 @@ FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TOR
 ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[344] Applies to: npm:katex@0.16.47
+[362] Applies to: npm:katex@0.16.47
 ------------------------------------------------------------------------------
 The MIT License (MIT)
 
@@ -34685,7 +35395,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
 ------------------------------------------------------------------------------
-[345] Applies to: npm:khroma@2.1.0
+[363] Applies to: npm:khroma@2.1.0
 ------------------------------------------------------------------------------
 The MIT License (MIT)
 
@@ -34710,7 +35420,7 @@ FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
 DEALINGS IN THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[346] Applies to: npm:layout-base@1.0.2, npm:layout-base@2.0.1
+[364] Applies to: npm:layout-base@1.0.2, npm:layout-base@2.0.1
 ------------------------------------------------------------------------------
 MIT License
 
@@ -34735,7 +35445,33 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
 ------------------------------------------------------------------------------
-[347] Applies to: npm:lie@3.3.0
+[365] Applies to: npm:lazystream@1.0.1
+------------------------------------------------------------------------------
+Copyright (c) 2013 J. Pommerening, contributors.
+
+Permission is hereby granted, free of charge, to any person
+obtaining a copy of this software and associated documentation
+files (the "Software"), to deal in the Software without
+restriction, including without limitation the rights to use,
+copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the
+Software is furnished to do so, subject to the following
+conditions:
+
+The above copyright notice and this permission notice shall be
+included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
+OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+OTHER DEALINGS IN THE SOFTWARE.
+
+------------------------------------------------------------------------------
+[366] Applies to: npm:lie@3.3.0
 ------------------------------------------------------------------------------
 #Copyright (c) 2014-2018 Calvin Metcalf, Jordan Harband
 
@@ -34746,7 +35482,16 @@ The above copyright notice and this permission notice shall be included in all c
 **THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.**
 
 ------------------------------------------------------------------------------
-[348] Applies to: npm:lodash@4.18.1, npm:lodash-es@4.18.1, npm:lodash.merge@4.6.2
+[367] Applies to: npm:listenercount@1.0.1
+------------------------------------------------------------------------------
+Copyright (c) MMXV jden <jason@denizac.org>
+
+Permission to use, copy, modify, and/or distribute this software for any purpose with or without fee is hereby granted, provided that the above copyright notice and this permission notice appear in all copies.
+
+THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+
+------------------------------------------------------------------------------
+[368] Applies to: npm:lodash@4.18.1, npm:lodash-es@4.18.1, npm:lodash.merge@4.6.2
 ------------------------------------------------------------------------------
 Copyright OpenJS Foundation and other contributors <https://openjsf.org/>
 
@@ -34797,33 +35542,7 @@ licenses; we recommend you read them, as their terms may differ from the
 terms above.
 
 ------------------------------------------------------------------------------
-[349] Applies to: npm:lodash.identity@3.0.0
-------------------------------------------------------------------------------
-Copyright 2012-2015 The Dojo Foundation <http://dojofoundation.org/>
-Based on Underscore.js 1.7.0, copyright 2009-2015 Jeremy Ashkenas,
-DocumentCloud and Investigative Reporters & Editors <http://underscorejs.org/>
-
-Permission is hereby granted, free of charge, to any person obtaining
-a copy of this software and associated documentation files (the
-"Software"), to deal in the Software without restriction, including
-without limitation the rights to use, copy, modify, merge, publish,
-distribute, sublicense, and/or sell copies of the Software, and to
-permit persons to whom the Software is furnished to do so, subject to
-the following conditions:
-
-The above copyright notice and this permission notice shall be
-included in all copies or substantial portions of the Software.
-
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
-EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
-MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
-NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
-LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
-OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
-WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
-
-------------------------------------------------------------------------------
-[350] Applies to: npm:lodash.pickby@4.6.0, npm:lodash.snakecase@4.1.1
+[369] Applies to: npm:lodash.defaults@4.2.0, npm:lodash.difference@4.5.0, npm:lodash.escaperegexp@4.1.2, npm:lodash.flatten@4.4.0, npm:lodash.groupby@4.6.0, npm:lodash.isplainobject@4.0.6, npm:lodash.pickby@4.6.0, npm:lodash.snakecase@4.1.1, npm:lodash.union@4.6.0, npm:lodash.uniq@4.5.0
 ------------------------------------------------------------------------------
 Copyright jQuery Foundation and other contributors <https://jquery.org/>
 
@@ -34874,7 +35593,136 @@ licenses; we recommend you read them, as their terms may differ from the
 terms above.
 
 ------------------------------------------------------------------------------
-[351] Applies to: npm:longest-streak@3.1.0, npm:stringify-entities@4.0.4, npm:trim-lines@3.0.1
+[370] Applies to: npm:lodash.identity@3.0.0
+------------------------------------------------------------------------------
+Copyright 2012-2015 The Dojo Foundation <http://dojofoundation.org/>
+Based on Underscore.js 1.7.0, copyright 2009-2015 Jeremy Ashkenas,
+DocumentCloud and Investigative Reporters & Editors <http://underscorejs.org/>
+
+Permission is hereby granted, free of charge, to any person obtaining
+a copy of this software and associated documentation files (the
+"Software"), to deal in the Software without restriction, including
+without limitation the rights to use, copy, modify, merge, publish,
+distribute, sublicense, and/or sell copies of the Software, and to
+permit persons to whom the Software is furnished to do so, subject to
+the following conditions:
+
+The above copyright notice and this permission notice shall be
+included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+------------------------------------------------------------------------------
+[371] Applies to: npm:lodash.isboolean@3.0.3, npm:lodash.isnil@4.0.0
+------------------------------------------------------------------------------
+Copyright 2012-2016 The Dojo Foundation <http://dojofoundation.org/>
+Based on Underscore.js, copyright 2009-2016 Jeremy Ashkenas,
+DocumentCloud and Investigative Reporters & Editors <http://underscorejs.org/>
+
+Permission is hereby granted, free of charge, to any person obtaining
+a copy of this software and associated documentation files (the
+"Software"), to deal in the Software without restriction, including
+without limitation the rights to use, copy, modify, merge, publish,
+distribute, sublicense, and/or sell copies of the Software, and to
+permit persons to whom the Software is furnished to do so, subject to
+the following conditions:
+
+The above copyright notice and this permission notice shall be
+included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+------------------------------------------------------------------------------
+[372] Applies to: npm:lodash.isequal@4.5.0, npm:lodash.isfunction@3.0.9
+------------------------------------------------------------------------------
+Copyright JS Foundation and other contributors <https://js.foundation/>
+
+Based on Underscore.js, copyright Jeremy Ashkenas,
+DocumentCloud and Investigative Reporters & Editors <http://underscorejs.org/>
+
+This software consists of voluntary contributions made by many
+individuals. For exact contribution history, see the revision history
+available at https://github.com/lodash/lodash
+
+The following license applies to all parts of this software except as
+documented below:
+
+====
+
+Permission is hereby granted, free of charge, to any person obtaining
+a copy of this software and associated documentation files (the
+"Software"), to deal in the Software without restriction, including
+without limitation the rights to use, copy, modify, merge, publish,
+distribute, sublicense, and/or sell copies of the Software, and to
+permit persons to whom the Software is furnished to do so, subject to
+the following conditions:
+
+The above copyright notice and this permission notice shall be
+included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+====
+
+Copyright and related rights for sample code are waived via CC0. Sample
+code is defined as all source code displayed within the prose of the
+documentation.
+
+CC0: http://creativecommons.org/publicdomain/zero/1.0/
+
+====
+
+Files located in the node_modules and vendor directories are externally
+maintained libraries used by this software which have their own
+licenses; we recommend you read them, as their terms may differ from the
+terms above.
+
+------------------------------------------------------------------------------
+[373] Applies to: npm:lodash.isundefined@3.0.1
+------------------------------------------------------------------------------
+Copyright 2012-2015 The Dojo Foundation <http://dojofoundation.org/>
+Based on Underscore.js, copyright 2009-2015 Jeremy Ashkenas,
+DocumentCloud and Investigative Reporters & Editors <http://underscorejs.org/>
+
+Permission is hereby granted, free of charge, to any person obtaining
+a copy of this software and associated documentation files (the
+"Software"), to deal in the Software without restriction, including
+without limitation the rights to use, copy, modify, merge, publish,
+distribute, sublicense, and/or sell copies of the Software, and to
+permit persons to whom the Software is furnished to do so, subject to
+the following conditions:
+
+The above copyright notice and this permission notice shall be
+included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+------------------------------------------------------------------------------
+[374] Applies to: npm:longest-streak@3.1.0, npm:stringify-entities@4.0.4, npm:trim-lines@3.0.1
 ------------------------------------------------------------------------------
 (The MIT License)
 
@@ -34900,7 +35748,7 @@ TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
 SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[352] Applies to: npm:loudness@0.4.2
+[375] Applies to: npm:loudness@0.4.2
 ------------------------------------------------------------------------------
 The MIT License (MIT)
 
@@ -34924,7 +35772,7 @@ IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
 CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[353] Applies to: npm:lru-cache@10.4.3
+[376] Applies to: npm:lru-cache@10.4.3
 ------------------------------------------------------------------------------
 The ISC License
 
@@ -34943,7 +35791,7 @@ ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF OR
 IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
 
 ------------------------------------------------------------------------------
-[354] Applies to: npm:lucide-react@0.468.0
+[377] Applies to: npm:lucide-react@0.468.0
 ------------------------------------------------------------------------------
 ISC License
 
@@ -34962,7 +35810,7 @@ ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
 OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
 
 ------------------------------------------------------------------------------
-[355] Applies to: npm:magic-bytes.js@1.13.0
+[378] Applies to: npm:magic-bytes.js@1.13.0
 ------------------------------------------------------------------------------
 MIT License
 
@@ -34987,7 +35835,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
 ------------------------------------------------------------------------------
-[356] Applies to: npm:marked@16.4.2
+[379] Applies to: npm:marked@16.4.2
 ------------------------------------------------------------------------------
 # License information
 
@@ -35035,7 +35883,7 @@ Redistribution and use in source and binary forms, with or without modification,
 This software is provided by the copyright holders and contributors “as is” and any express or implied warranties, including, but not limited to, the implied warranties of merchantability and fitness for a particular purpose are disclaimed. In no event shall the copyright owner or contributors be liable for any direct, indirect, incidental, special, exemplary, or consequential damages (including, but not limited to, procurement of substitute goods or services; loss of use, data, or profits; or business interruption) however caused and on any theory of liability, whether in contract, strict liability, or tort (including negligence or otherwise) arising in any way out of the use of this software, even if advised of the possibility of such damage.
 
 ------------------------------------------------------------------------------
-[357] Applies to: npm:md5@2.3.0
+[380] Applies to: npm:md5@2.3.0
 ------------------------------------------------------------------------------
 Copyright © 2011-2012, Paul Vorbach.
 Copyright © 2009, Jeff Mott.
@@ -35066,7 +35914,7 @@ ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
 SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 ------------------------------------------------------------------------------
-[358] Applies to: npm:mdast-util-phrasing@4.1.0
+[381] Applies to: npm:mdast-util-phrasing@4.1.0
 ------------------------------------------------------------------------------
 (The MIT License)
 
@@ -35093,7 +35941,7 @@ TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
 SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[359] Applies to: npm:mdast-util-to-markdown-cjk-friendly@1.0.0, npm:remark-cjk-friendly@2.3.1
+[382] Applies to: npm:mdast-util-to-markdown-cjk-friendly@1.0.0, npm:remark-cjk-friendly@2.3.1
 ------------------------------------------------------------------------------
 Copyright (c) 2025 Tatsunori Uchino <tats.u@live.jp>
 
@@ -35125,7 +35973,7 @@ TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
 SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[360] Applies to: npm:merge-descriptors@2.0.0
+[383] Applies to: npm:merge-descriptors@2.0.0
 ------------------------------------------------------------------------------
 MIT License
 
@@ -35140,7 +35988,7 @@ The above copyright notice and this permission notice shall be included in all c
 THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[361] Applies to: npm:merge-stream@2.0.0
+[384] Applies to: npm:merge-stream@2.0.0
 ------------------------------------------------------------------------------
 The MIT License (MIT)
 
@@ -35165,7 +36013,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[362] Applies to: npm:mermaid@11.16.0
+[385] Applies to: npm:mermaid@11.16.0
 ------------------------------------------------------------------------------
 The MIT License (MIT)
 
@@ -35190,7 +36038,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
 ------------------------------------------------------------------------------
-[363] Applies to: npm:micromark-extension-cjk-friendly@2.0.1
+[386] Applies to: npm:micromark-extension-cjk-friendly@2.0.1
 ------------------------------------------------------------------------------
 Copyright (c) 2025 Tatsunori Uchino <tats.u@live.jp>
 
@@ -35222,7 +36070,7 @@ TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
 SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[364] Applies to: npm:micromark-extension-cjk-friendly-util@3.0.1
+[387] Applies to: npm:micromark-extension-cjk-friendly-util@3.0.1
 ------------------------------------------------------------------------------
 Copyright (c) 2025 Tatsunori Uchino <tats.u@live.jp>
 
@@ -35254,7 +36102,7 @@ TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
 SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[365] Applies to: npm:micromark-extension-gfm-footnote@2.1.0
+[388] Applies to: npm:micromark-extension-gfm-footnote@2.1.0
 ------------------------------------------------------------------------------
 (The MIT License)
 
@@ -35280,7 +36128,7 @@ TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
 SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[366] Applies to: npm:mime-db@1.52.0, npm:mime-db@1.54.0
+[389] Applies to: npm:mime-db@1.52.0, npm:mime-db@1.54.0
 ------------------------------------------------------------------------------
 (The MIT License)
 
@@ -35307,7 +36155,24 @@ TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
 SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[367] Applies to: npm:minimatch@9.0.9, npm:rimraf@5.0.10
+[390] Applies to: npm:minimalistic-assert@1.0.1
+------------------------------------------------------------------------------
+Copyright 2015 Calvin Metcalf
+
+Permission to use, copy, modify, and/or distribute this software for any purpose
+with or without fee is hereby granted, provided that the above copyright notice
+and this permission notice appear in all copies.
+
+THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES WITH
+REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF MERCHANTABILITY AND
+FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY SPECIAL, DIRECT,
+INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES WHATSOEVER RESULTING FROM
+LOSS OF USE, DATA OR PROFITS, WHETHER IN AN ACTION OF CONTRACT, NEGLIGENCE
+OR OTHER TORTIOUS ACTION, ARISING OUT OF OR IN CONNECTION WITH THE USE OR
+PERFORMANCE OF THIS SOFTWARE.
+
+------------------------------------------------------------------------------
+[391] Applies to: npm:minimatch@5.1.9, npm:minimatch@9.0.9, npm:rimraf@5.0.10
 ------------------------------------------------------------------------------
 The ISC License
 
@@ -35326,7 +36191,7 @@ ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF OR
 IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
 
 ------------------------------------------------------------------------------
-[368] Applies to: npm:minipass@7.1.3, npm:path-scurry@1.11.1, npm:tar@7.5.22
+[392] Applies to: npm:minipass@7.1.3, npm:path-scurry@1.11.1, npm:sax@1.6.0, npm:tar@7.5.22
 ------------------------------------------------------------------------------
 # Blue Oak Model License
 
@@ -35385,7 +36250,7 @@ will be liable to anyone for any damages related to this
 software or this license, under any kind of legal claim.***
 
 ------------------------------------------------------------------------------
-[369] Applies to: npm:minizlib@3.1.0
+[393] Applies to: npm:minizlib@3.1.0
 ------------------------------------------------------------------------------
 Minizlib was created by Isaac Z. Schlueter.
 It is a derivative work of the Node.js project.
@@ -35415,7 +36280,7 @@ SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 """
 
 ------------------------------------------------------------------------------
-[370] Applies to: npm:mkdirp@0.5.6
+[394] Applies to: npm:mkdirp@0.5.6
 ------------------------------------------------------------------------------
 Copyright 2010 James Halliday (mail@substack.net)
 
@@ -35440,7 +36305,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[371] Applies to: npm:mkdirp-classic@0.5.3
+[395] Applies to: npm:mkdirp-classic@0.5.3
 ------------------------------------------------------------------------------
 The MIT License (MIT)
 
@@ -35465,7 +36330,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[372] Applies to: npm:ms@2.0.0
+[396] Applies to: npm:ms@2.0.0
 ------------------------------------------------------------------------------
 The MIT License (MIT)
 
@@ -35490,7 +36355,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
 ------------------------------------------------------------------------------
-[373] Applies to: npm:ms@2.1.3
+[397] Applies to: npm:ms@2.1.3
 ------------------------------------------------------------------------------
 The MIT License (MIT)
 
@@ -35515,7 +36380,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
 ------------------------------------------------------------------------------
-[374] Applies to: npm:nan@2.28.0
+[398] Applies to: npm:nan@2.28.0
 ------------------------------------------------------------------------------
 The MIT License (MIT)
 
@@ -35528,7 +36393,31 @@ The above copyright notice and this permission notice shall be included in all c
 THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[375] Applies to: npm:napi-build-utils@2.0.0
+[399] Applies to: npm:nanoid@5.1.16
+------------------------------------------------------------------------------
+The MIT License (MIT)
+
+Copyright 2017 Andrey Sitnik <andrey@sitnik.es>
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of
+this software and associated documentation files (the "Software"), to deal in
+the Software without restriction, including without limitation the rights to
+use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+the Software, and to permit persons to whom the Software is furnished to do so,
+subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+------------------------------------------------------------------------------
+[400] Applies to: npm:napi-build-utils@2.0.0
 ------------------------------------------------------------------------------
 MIT License
 
@@ -35553,7 +36442,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
 ------------------------------------------------------------------------------
-[376] Applies to: npm:negotiator@1.0.0
+[401] Applies to: npm:negotiator@1.0.0
 ------------------------------------------------------------------------------
 (The MIT License)
 
@@ -35581,7 +36470,7 @@ TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
 SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[377] Applies to: npm:node-abi@3.94.0
+[402] Applies to: npm:node-abi@3.94.0
 ------------------------------------------------------------------------------
 MIT License
 
@@ -35606,7 +36495,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
 ------------------------------------------------------------------------------
-[378] Applies to: npm:node-addon-api@7.1.1
+[403] Applies to: npm:node-addon-api@7.1.1
 ------------------------------------------------------------------------------
 The MIT License (MIT)
 
@@ -35619,7 +36508,7 @@ The above copyright notice and this permission notice shall be included in all c
 THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[379] Applies to: npm:node-domexception@1.0.0
+[404] Applies to: npm:node-domexception@1.0.0
 ------------------------------------------------------------------------------
 MIT License
 
@@ -35644,7 +36533,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
 ------------------------------------------------------------------------------
-[380] Applies to: npm:node-fetch@3.3.2
+[405] Applies to: npm:node-fetch@3.3.2
 ------------------------------------------------------------------------------
 The MIT License (MIT)
 
@@ -35669,7 +36558,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
 ------------------------------------------------------------------------------
-[381] Applies to: npm:node-machine-id@1.1.12
+[406] Applies to: npm:node-machine-id@1.1.12
 ------------------------------------------------------------------------------
 The MIT License (MIT)
 
@@ -35694,7 +36583,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
 ------------------------------------------------------------------------------
-[382] Applies to: npm:node-pty@1.1.0
+[407] Applies to: npm:node-pty@1.1.0
 ------------------------------------------------------------------------------
 Copyright (c) 2012-2015, Christopher Jeffrey (https://github.com/chjj/)
 
@@ -35767,7 +36656,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
 ------------------------------------------------------------------------------
-[383] Applies to: npm:object-inspect@1.13.4
+[408] Applies to: npm:object-inspect@1.13.4
 ------------------------------------------------------------------------------
 MIT License
 
@@ -35792,7 +36681,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
 ------------------------------------------------------------------------------
-[384] Applies to: npm:on-finished@2.4.1
+[409] Applies to: npm:on-finished@2.4.1
 ------------------------------------------------------------------------------
 (The MIT License)
 
@@ -35819,7 +36708,7 @@ TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
 SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[385] Applies to: npm:orderedmap@2.1.1, npm:w3c-keyname@2.2.8
+[410] Applies to: npm:orderedmap@2.1.1, npm:w3c-keyname@2.2.8
 ------------------------------------------------------------------------------
 Copyright (C) 2016 by Marijn Haverbeke <marijn@haverbeke.berlin> and others
 
@@ -35842,7 +36731,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[386] Applies to: npm:package-manager-detector@1.7.0
+[411] Applies to: npm:package-manager-detector@1.7.0
 ------------------------------------------------------------------------------
 MIT License
 
@@ -35867,7 +36756,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
 ------------------------------------------------------------------------------
-[387] Applies to: npm:pako@1.0.11
+[412] Applies to: npm:pako@1.0.11
 ------------------------------------------------------------------------------
 (The MIT License)
 
@@ -35892,7 +36781,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[388] Applies to: npm:parse-entities@4.0.2, npm:property-information@7.2.0
+[413] Applies to: npm:parse-entities@4.0.2, npm:property-information@7.2.0
 ------------------------------------------------------------------------------
 (The MIT License)
 
@@ -35918,7 +36807,7 @@ TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
 SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[389] Applies to: npm:parse5@7.3.0
+[414] Applies to: npm:parse5@7.3.0
 ------------------------------------------------------------------------------
 Copyright (c) 2013-2019 Ivan Nikulin (ifaaan@gmail.com, https://github.com/inikulin)
 
@@ -35941,7 +36830,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[390] Applies to: npm:parseurl@1.3.3
+[415] Applies to: npm:parseurl@1.3.3
 ------------------------------------------------------------------------------
 (The MIT License)
 
@@ -35968,7 +36857,7 @@ TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
 SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[391] Applies to: npm:path-data-parser@0.1.0, npm:points-on-curve@0.2.0
+[416] Applies to: npm:path-data-parser@0.1.0, npm:points-on-curve@0.2.0
 ------------------------------------------------------------------------------
 MIT License
 
@@ -35993,7 +36882,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
 ------------------------------------------------------------------------------
-[392] Applies to: npm:path-to-regexp@8.4.2
+[417] Applies to: npm:path-to-regexp@8.4.2
 ------------------------------------------------------------------------------
 The MIT License (MIT)
 
@@ -36018,7 +36907,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[393] Applies to: npm:pdfjs-dist@5.7.284
+[418] Applies to: npm:pdfjs-dist@5.7.284
 ------------------------------------------------------------------------------
 Apache License
                            Version 2.0, January 2004
@@ -36198,7 +37087,7 @@ Apache License
    END OF TERMS AND CONDITIONS
 
 ------------------------------------------------------------------------------
-[394] Applies to: npm:picomatch@4.0.5
+[419] Applies to: npm:picomatch@4.0.5
 ------------------------------------------------------------------------------
 The MIT License (MIT)
 
@@ -36223,7 +37112,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[395] Applies to: npm:pkce-challenge@5.0.1
+[420] Applies to: npm:pkce-challenge@5.0.1
 ------------------------------------------------------------------------------
 MIT License
 
@@ -36248,7 +37137,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
 ------------------------------------------------------------------------------
-[396] Applies to: npm:playwright-core@1.60.0
+[421] Applies to: npm:playwright-core@1.60.0
 ------------------------------------------------------------------------------
 Apache License
                            Version 2.0, January 2004
@@ -36454,7 +37343,7 @@ Apache License
    limitations under the License.
 
 ------------------------------------------------------------------------------
-[397] Applies to: npm:playwright-core@1.60.0 (NOTICE)
+[422] Applies to: npm:playwright-core@1.60.0 (NOTICE)
 ------------------------------------------------------------------------------
 NOTICE for npm:playwright-core@1.60.0:
 
@@ -36465,7 +37354,7 @@ This software contains code derived from the Puppeteer project (https://github.c
 available under the Apache 2.0 license (https://github.com/puppeteer/puppeteer/blob/master/LICENSE).
 
 ------------------------------------------------------------------------------
-[398] Applies to: npm:pngjs@5.0.0
+[423] Applies to: npm:pngjs@5.0.0
 ------------------------------------------------------------------------------
 pngjs2 original work Copyright (c) 2015 Luke Page & Original Contributors
 pngjs derived work Copyright (c) 2012 Kuba Niegowski
@@ -36489,7 +37378,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[399] Applies to: npm:points-on-path@0.2.1
+[424] Applies to: npm:points-on-path@0.2.1
 ------------------------------------------------------------------------------
 MIT License
 
@@ -36514,7 +37403,32 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
 ------------------------------------------------------------------------------
-[400] Applies to: npm:prebuild-install@7.1.3
+[425] Applies to: npm:pptxgenjs@4.0.1
+------------------------------------------------------------------------------
+The MIT License (MIT)
+
+Copyright (c) 2015-2022 Brent Ely
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+
+------------------------------------------------------------------------------
+[426] Applies to: npm:prebuild-install@7.1.3
 ------------------------------------------------------------------------------
 The MIT License (MIT)
 
@@ -36539,7 +37453,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[401] Applies to: npm:process-nextick-args@2.0.1
+[427] Applies to: npm:process-nextick-args@2.0.1
 ------------------------------------------------------------------------------
 # Copyright (c) 2015 Calvin Metcalf
 
@@ -36562,7 +37476,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.**
 
 ------------------------------------------------------------------------------
-[402] Applies to: npm:promise-worker-transferable@1.0.4
+[428] Applies to: npm:promise-worker-transferable@1.0.4
 ------------------------------------------------------------------------------
 Apache License
                           Version 2.0, January 2004
@@ -36767,7 +37681,7 @@ Apache License
   limitations under the License.
 
 ------------------------------------------------------------------------------
-[403] Applies to: npm:prosemirror-changeset@2.4.1
+[429] Applies to: npm:prosemirror-changeset@2.4.1
 ------------------------------------------------------------------------------
 Copyright (C) 2017 by Marijn Haverbeke <marijn@haverbeke.berlin> and others
 
@@ -36790,7 +37704,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[404] Applies to: npm:prosemirror-commands@1.7.1, npm:prosemirror-dropcursor@1.8.3, npm:prosemirror-gapcursor@1.4.1, npm:prosemirror-history@1.5.0, npm:prosemirror-inputrules@1.5.1, npm:prosemirror-keymap@1.2.3, npm:prosemirror-model@1.25.11, npm:prosemirror-schema-list@1.5.1, npm:prosemirror-state@1.4.4, npm:prosemirror-transform@1.12.0, npm:prosemirror-view@1.42.1
+[430] Applies to: npm:prosemirror-commands@1.7.1, npm:prosemirror-dropcursor@1.8.3, npm:prosemirror-gapcursor@1.4.1, npm:prosemirror-history@1.5.0, npm:prosemirror-inputrules@1.5.1, npm:prosemirror-keymap@1.2.3, npm:prosemirror-model@1.25.11, npm:prosemirror-schema-list@1.5.1, npm:prosemirror-state@1.4.4, npm:prosemirror-transform@1.12.0, npm:prosemirror-view@1.42.1
 ------------------------------------------------------------------------------
 Copyright (C) 2015-2017 by Marijn Haverbeke <marijn@haverbeke.berlin> and others
 
@@ -36813,7 +37727,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[405] Applies to: npm:prosemirror-tables@1.8.5
+[431] Applies to: npm:prosemirror-tables@1.8.5
 ------------------------------------------------------------------------------
 Copyright (C) 2015-2016 by Marijn Haverbeke <marijnh@gmail.com> and others
 
@@ -36836,7 +37750,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[406] Applies to: npm:protobufjs@7.6.5
+[432] Applies to: npm:protobufjs@7.6.5
 ------------------------------------------------------------------------------
 This license applies to all parts of protobuf.js except those files
 either explicitly including or referencing a different license or
@@ -36879,7 +37793,7 @@ standalone and requires a support library to be linked with it. This
 support library is itself covered by the above license.
 
 ------------------------------------------------------------------------------
-[407] Applies to: npm:proxy-from-env@2.1.0
+[433] Applies to: npm:proxy-from-env@2.1.0
 ------------------------------------------------------------------------------
 The MIT License
 
@@ -36903,7 +37817,7 @@ IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
 CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[408] Applies to: npm:qrcode@1.5.4
+[434] Applies to: npm:qrcode@1.5.4
 ------------------------------------------------------------------------------
 The MIT License (MIT)
 
@@ -36916,7 +37830,7 @@ The above copyright notice and this permission notice shall be included in all c
 THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[409] Applies to: npm:qs@6.15.3
+[435] Applies to: npm:qs@6.15.3
 ------------------------------------------------------------------------------
 BSD 3-Clause License
 
@@ -36949,7 +37863,19 @@ OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 ------------------------------------------------------------------------------
-[410] Applies to: npm:range-parser@1.3.0
+[436] Applies to: npm:queue@6.0.2
+------------------------------------------------------------------------------
+The MIT License (MIT)
+Copyright (c) 2014 Jesse Tane <jesse.tane@gmail.com>
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+------------------------------------------------------------------------------
+[437] Applies to: npm:range-parser@1.3.0
 ------------------------------------------------------------------------------
 (The MIT License)
 
@@ -36976,7 +37902,7 @@ TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
 SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[411] Applies to: npm:raw-body@3.0.2
+[438] Applies to: npm:raw-body@3.0.2
 ------------------------------------------------------------------------------
 The MIT License (MIT)
 
@@ -37002,7 +37928,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[412] Applies to: npm:rc@1.2.8
+[439] Applies to: npm:rc@1.2.8
 ------------------------------------------------------------------------------
 Apache License, Version 2.0
 
@@ -37073,7 +37999,7 @@ TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
 SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[413] Applies to: npm:react@19.2.3, npm:react-dom@19.2.3, npm:scheduler@0.27.0, npm:use-sync-external-store@1.6.0
+[440] Applies to: npm:react@19.2.3, npm:react-dom@19.2.3, npm:scheduler@0.27.0, npm:use-sync-external-store@1.6.0
 ------------------------------------------------------------------------------
 MIT License
 
@@ -37098,7 +38024,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
 ------------------------------------------------------------------------------
-[414] Applies to: npm:react-i18next@17.0.10
+[441] Applies to: npm:react-i18next@17.0.10
 ------------------------------------------------------------------------------
 The MIT License (MIT)
 
@@ -37123,7 +38049,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
 ------------------------------------------------------------------------------
-[415] Applies to: npm:react-markdown@10.1.0
+[442] Applies to: npm:react-markdown@10.1.0
 ------------------------------------------------------------------------------
 The MIT License (MIT)
 
@@ -37148,7 +38074,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
 ------------------------------------------------------------------------------
-[416] Applies to: npm:react-router@7.18.1, npm:react-router-dom@7.18.1
+[443] Applies to: npm:react-router@7.18.1, npm:react-router-dom@7.18.1
 ------------------------------------------------------------------------------
 MIT License
 
@@ -37175,7 +38101,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
 ------------------------------------------------------------------------------
-[417] Applies to: npm:readable-stream@2.3.8, npm:readable-stream@3.6.2, npm:string_decoder@1.1.1, npm:string_decoder@1.3.0
+[444] Applies to: npm:readable-stream@2.3.8, npm:readable-stream@3.6.2, npm:string_decoder@1.1.1, npm:string_decoder@1.3.0
 ------------------------------------------------------------------------------
 Node.js is licensed for use as follows:
 
@@ -37226,7 +38152,212 @@ IN THE SOFTWARE.
 """
 
 ------------------------------------------------------------------------------
-[418] Applies to: npm:remark-parse@11.0.0, npm:remark-stringify@11.0.0
+[445] Applies to: npm:readdir-glob@1.1.3
+------------------------------------------------------------------------------
+Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright 2020 Yann Armelin
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+
+------------------------------------------------------------------------------
+[446] Applies to: npm:remark-parse@11.0.0, npm:remark-stringify@11.0.0
 ------------------------------------------------------------------------------
 (The MIT License)
 
@@ -37251,7 +38382,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[419] Applies to: npm:require-directory@2.1.1
+[447] Applies to: npm:require-directory@2.1.1
 ------------------------------------------------------------------------------
 The MIT License (MIT)
 
@@ -37277,7 +38408,7 @@ TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
 SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[420] Applies to: npm:require-from-string@2.0.2
+[448] Applies to: npm:require-from-string@2.0.2
 ------------------------------------------------------------------------------
 The MIT License (MIT)
 
@@ -37302,7 +38433,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[421] Applies to: npm:require-main-filename@2.0.0, npm:set-blocking@2.0.0, npm:yargs-parser@18.1.3
+[449] Applies to: npm:require-main-filename@2.0.0, npm:set-blocking@2.0.0, npm:yargs-parser@18.1.3
 ------------------------------------------------------------------------------
 Copyright (c) 2016, Contributors
 
@@ -37320,35 +38451,7 @@ WHETHER IN AN ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION,
 ARISING OUT OF OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
 
 ------------------------------------------------------------------------------
-[422] Applies to: npm:robust-predicates@3.0.3, npm:tweetnacl@0.14.5
-------------------------------------------------------------------------------
-This is free and unencumbered software released into the public domain.
-
-Anyone is free to copy, modify, publish, use, compile, sell, or
-distribute this software, either in source code form or as a compiled
-binary, for any purpose, commercial or non-commercial, and by any
-means.
-
-In jurisdictions that recognize copyright laws, the author or authors
-of this software dedicate any and all copyright interest in the
-software to the public domain. We make this dedication for the benefit
-of the public at large and to the detriment of our heirs and
-successors. We intend this dedication to be an overt act of
-relinquishment in perpetuity of all present and future rights to this
-software under copyright law.
-
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
-EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
-MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
-IN NO EVENT SHALL THE AUTHORS BE LIABLE FOR ANY CLAIM, DAMAGES OR
-OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
-ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
-OTHER DEALINGS IN THE SOFTWARE.
-
-For more information, please refer to <http://unlicense.org>
-
-------------------------------------------------------------------------------
-[423] Applies to: npm:rope-sequence@1.3.4
+[450] Applies to: npm:rope-sequence@1.3.4
 ------------------------------------------------------------------------------
 Copyright (C) 2016 by Marijn Haverbeke <marijn@haverbeke.berlin>
 
@@ -37371,7 +38474,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[424] Applies to: npm:roughjs@4.6.6
+[451] Applies to: npm:roughjs@4.6.6
 ------------------------------------------------------------------------------
 MIT License
 
@@ -37396,7 +38499,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
 ------------------------------------------------------------------------------
-[425] Applies to: npm:router@2.2.0
+[452] Applies to: npm:router@2.2.0
 ------------------------------------------------------------------------------
 (The MIT License)
 
@@ -37423,7 +38526,7 @@ TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
 SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[426] Applies to: npm:rw@1.3.3
+[453] Applies to: npm:rw@1.3.3
 ------------------------------------------------------------------------------
 Copyright (c) 2014-2016, Michael Bostock
 All rights reserved.
@@ -37453,7 +38556,7 @@ NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE,
 EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 ------------------------------------------------------------------------------
-[427] Applies to: npm:safer-buffer@2.1.2
+[454] Applies to: npm:safer-buffer@2.1.2
 ------------------------------------------------------------------------------
 MIT License
 
@@ -37478,7 +38581,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
 ------------------------------------------------------------------------------
-[428] Applies to: npm:section-matter@1.0.0
+[455] Applies to: npm:section-matter@1.0.0
 ------------------------------------------------------------------------------
 The MIT License (MIT)
 
@@ -37503,7 +38606,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
 ------------------------------------------------------------------------------
-[429] Applies to: npm:send@1.2.1
+[456] Applies to: npm:send@1.2.1
 ------------------------------------------------------------------------------
 (The MIT License)
 
@@ -37530,7 +38633,7 @@ TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
 SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[430] Applies to: npm:serve-static@2.2.1
+[457] Applies to: npm:serve-static@2.2.1
 ------------------------------------------------------------------------------
 (The MIT License)
 
@@ -37559,7 +38662,7 @@ TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
 SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[431] Applies to: npm:set-cookie-parser@2.7.2
+[458] Applies to: npm:set-cookie-parser@2.7.2
 ------------------------------------------------------------------------------
 The MIT License (MIT)
 
@@ -37584,7 +38687,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[432] Applies to: npm:setimmediate@1.0.5
+[459] Applies to: npm:setimmediate@1.0.5
 ------------------------------------------------------------------------------
 Copyright (c) 2012 Barnesandnoble.com, llc, Donavon West, and Domenic Denicola
 
@@ -37608,7 +38711,7 @@ OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
 WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[433] Applies to: npm:setprototypeof@1.2.0
+[460] Applies to: npm:setprototypeof@1.2.0
 ------------------------------------------------------------------------------
 Copyright (c) 2015, Wes Todd
 
@@ -37625,7 +38728,7 @@ OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF OR IN
 CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
 
 ------------------------------------------------------------------------------
-[434] Applies to: npm:shebang-command@2.0.0
+[461] Applies to: npm:shebang-command@2.0.0
 ------------------------------------------------------------------------------
 MIT License
 
@@ -37638,7 +38741,7 @@ The above copyright notice and this permission notice shall be included in all c
 THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[435] Applies to: npm:side-channel@1.1.1, npm:side-channel-weakmap@1.0.2
+[462] Applies to: npm:side-channel@1.1.1, npm:side-channel-weakmap@1.0.2
 ------------------------------------------------------------------------------
 MIT License
 
@@ -37663,7 +38766,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
 ------------------------------------------------------------------------------
-[436] Applies to: npm:signal-exit@3.0.7
+[463] Applies to: npm:signal-exit@3.0.7
 ------------------------------------------------------------------------------
 The ISC License
 
@@ -37683,7 +38786,7 @@ WHETHER IN AN ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION,
 ARISING OUT OF OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
 
 ------------------------------------------------------------------------------
-[437] Applies to: npm:signal-exit@4.1.0
+[464] Applies to: npm:signal-exit@4.1.0
 ------------------------------------------------------------------------------
 The ISC License
 
@@ -37703,7 +38806,7 @@ WHETHER IN AN ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION,
 ARISING OUT OF OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
 
 ------------------------------------------------------------------------------
-[438] Applies to: npm:silk-wasm@3.7.1
+[465] Applies to: npm:silk-wasm@3.7.1
 ------------------------------------------------------------------------------
 MIT License
 
@@ -37728,7 +38831,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
 ------------------------------------------------------------------------------
-[439] Applies to: npm:simple-concat@1.0.1, npm:simple-get@4.0.1
+[466] Applies to: npm:simple-concat@1.0.1, npm:simple-get@4.0.1
 ------------------------------------------------------------------------------
 The MIT License (MIT)
 
@@ -37752,7 +38855,7 @@ IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
 CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[440] Applies to: npm:smol-toml@1.7.0
+[467] Applies to: npm:smol-toml@1.7.0
 ------------------------------------------------------------------------------
 Copyright (c) Squirrel Chat et al., All rights reserved.
 
@@ -37780,7 +38883,7 @@ OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 ------------------------------------------------------------------------------
-[441] Applies to: npm:sortablejs@1.15.7
+[468] Applies to: npm:sortablejs@1.15.7
 ------------------------------------------------------------------------------
 MIT License
 
@@ -37805,7 +38908,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
 ------------------------------------------------------------------------------
-[442] Applies to: npm:sprintf-js@1.0.3
+[469] Applies to: npm:sprintf-js@1.0.3
 ------------------------------------------------------------------------------
 Copyright (c) 2007-2014, Alexandru Marasteanu <hello [at) alexei (dot] ro>
 All rights reserved.
@@ -37833,7 +38936,7 @@ ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
 SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 ------------------------------------------------------------------------------
-[443] Applies to: npm:ssh-config@5.2.0
+[470] Applies to: npm:ssh-config@5.2.0
 ------------------------------------------------------------------------------
 MIT License
 
@@ -37858,7 +38961,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
 ------------------------------------------------------------------------------
-[444] Applies to: npm:statuses@2.0.2
+[471] Applies to: npm:statuses@2.0.2
 ------------------------------------------------------------------------------
 The MIT License (MIT)
 
@@ -37884,7 +38987,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[445] Applies to: npm:strip-bom-string@1.0.0
+[472] Applies to: npm:strip-bom-string@1.0.0
 ------------------------------------------------------------------------------
 The MIT License (MIT)
 
@@ -37909,7 +39012,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[446] Applies to: npm:style-mod@4.1.3
+[473] Applies to: npm:style-mod@4.1.3
 ------------------------------------------------------------------------------
 Copyright (C) 2018 by Marijn Haverbeke <marijn@haverbeke.berlin> and others
 
@@ -37932,7 +39035,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[447] Applies to: npm:style-to-js@1.1.21
+[474] Applies to: npm:style-to-js@1.1.21
 ------------------------------------------------------------------------------
 The MIT License (MIT)
 
@@ -37958,7 +39061,7 @@ OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
 WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[448] Applies to: npm:style-to-object@1.0.14
+[475] Applies to: npm:style-to-object@1.0.14
 ------------------------------------------------------------------------------
 The MIT License (MIT)
 
@@ -37984,7 +39087,7 @@ OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
 WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[449] Applies to: npm:stylis@4.4.0
+[476] Applies to: npm:stylis@4.4.0
 ------------------------------------------------------------------------------
 MIT License
 
@@ -38009,7 +39112,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
 ------------------------------------------------------------------------------
-[450] Applies to: npm:tailwind-merge@2.6.1
+[477] Applies to: npm:tailwind-merge@2.6.1
 ------------------------------------------------------------------------------
 MIT License
 
@@ -38034,7 +39137,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
 ------------------------------------------------------------------------------
-[451] Applies to: npm:tinyexec@1.2.4
+[478] Applies to: npm:tinyexec@1.2.4
 ------------------------------------------------------------------------------
 MIT License
 
@@ -38059,7 +39162,32 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
 ------------------------------------------------------------------------------
-[452] Applies to: npm:toidentifier@1.0.1
+[479] Applies to: npm:tmp@0.2.7
+------------------------------------------------------------------------------
+The MIT License (MIT)
+
+Copyright (c) 2014 KARASZI István
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+
+------------------------------------------------------------------------------
+[480] Applies to: npm:toidentifier@1.0.1
 ------------------------------------------------------------------------------
 MIT License
 
@@ -38084,7 +39212,35 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
 ------------------------------------------------------------------------------
-[453] Applies to: npm:trough@2.2.0
+[481] Applies to: npm:traverse@0.3.9
+------------------------------------------------------------------------------
+Copyright 2010 James Halliday (mail@substack.net)
+
+This project is free software released under the MIT/X11 license:
+http://www.opensource.org/licenses/mit-license.php
+
+Copyright 2010 James Halliday (mail@substack.net)
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+
+------------------------------------------------------------------------------
+[482] Applies to: npm:trough@2.2.0
 ------------------------------------------------------------------------------
 (The MIT License)
 
@@ -38109,7 +39265,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[454] Applies to: npm:ts-dedent@2.3.0
+[483] Applies to: npm:ts-dedent@2.3.0
 ------------------------------------------------------------------------------
 MIT License
 
@@ -38134,7 +39290,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
 ------------------------------------------------------------------------------
-[455] Applies to: npm:ts-mixer@6.0.4
+[484] Applies to: npm:ts-mixer@6.0.4
 ------------------------------------------------------------------------------
 MIT License
 
@@ -38159,7 +39315,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
 ------------------------------------------------------------------------------
-[456] Applies to: npm:tslib@2.8.1
+[485] Applies to: npm:tslib@2.8.1
 ------------------------------------------------------------------------------
 Copyright (c) Microsoft Corporation.
 
@@ -38175,7 +39331,7 @@ OTHER TORTIOUS ACTION, ARISING OUT OF OR IN CONNECTION WITH THE USE OR
 PERFORMANCE OF THIS SOFTWARE.
 
 ------------------------------------------------------------------------------
-[457] Applies to: npm:tslog@4.11.0
+[486] Applies to: npm:tslog@4.11.0
 ------------------------------------------------------------------------------
 MIT License
 
@@ -38200,7 +39356,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
 ------------------------------------------------------------------------------
-[458] Applies to: npm:tunnel-agent@0.6.0
+[487] Applies to: npm:tunnel-agent@0.6.0
 ------------------------------------------------------------------------------
 Apache License
 
@@ -38259,7 +39415,7 @@ If the Work includes a "NOTICE" text file as part of its distribution, then any 
 END OF TERMS AND CONDITIONS
 
 ------------------------------------------------------------------------------
-[459] Applies to: npm:type-fest@0.20.2
+[488] Applies to: npm:type-fest@0.20.2
 ------------------------------------------------------------------------------
 MIT License
 
@@ -38272,7 +39428,7 @@ The above copyright notice and this permission notice shall be included in all c
 THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[460] Applies to: npm:typebox@1.1.39
+[489] Applies to: npm:typebox@1.1.39
 ------------------------------------------------------------------------------
 TypeBox
 
@@ -38299,7 +39455,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[461] Applies to: npm:undici@6.27.0, npm:undici@8.7.0, npm:undici-types@7.24.6
+[490] Applies to: npm:undici@6.27.0, npm:undici@8.7.0, npm:undici-types@6.21.0, npm:undici-types@7.24.6
 ------------------------------------------------------------------------------
 MIT License
 
@@ -38324,7 +39480,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
 ------------------------------------------------------------------------------
-[462] Applies to: npm:unified@11.0.5, npm:vfile@6.0.3
+[491] Applies to: npm:unified@11.0.5, npm:vfile@6.0.3
 ------------------------------------------------------------------------------
 (The MIT License)
 
@@ -38349,7 +39505,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[463] Applies to: npm:unist-util-is@6.0.1
+[492] Applies to: npm:unist-util-is@6.0.1
 ------------------------------------------------------------------------------
 (The MIT license)
 
@@ -38375,7 +39531,7 @@ TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
 SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[464] Applies to: npm:universalify@2.0.1
+[493] Applies to: npm:universalify@2.0.1
 ------------------------------------------------------------------------------
 (The MIT License)
 
@@ -38399,7 +39555,7 @@ IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
 CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[465] Applies to: npm:unpipe@1.0.0
+[494] Applies to: npm:unpipe@1.0.0
 ------------------------------------------------------------------------------
 (The MIT License)
 
@@ -38425,7 +39581,36 @@ TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
 SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[466] Applies to: npm:uri-js@4.4.1
+[495] Applies to: npm:unzipper@0.10.14
+------------------------------------------------------------------------------
+Copyright (c) 2012 - 2013 Near Infinity Corporation
+
+Permission is hereby granted, free of charge, to any person obtaining
+a copy of this software and associated documentation files (the
+"Software"), to deal in the Software without restriction, including
+without limitation the rights to use, copy, modify, merge, publish,
+distribute, sublicense, and/or sell copies of the Software, and to
+permit persons to whom the Software is furnished to do so, subject to
+the following conditions:
+
+The above copyright notice and this permission notice shall be
+included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+---
+
+Commits in this fork are (c) Ziggy Jonsson (ziggy.jonsson.nyc@gmail.com)
+and fall under same licence structure as the original repo (MIT)
+
+------------------------------------------------------------------------------
+[496] Applies to: npm:uri-js@4.4.1
 ------------------------------------------------------------------------------
 Copyright 2011 Gary Court. All rights reserved.
 
@@ -38440,7 +39625,7 @@ THIS SOFTWARE IS PROVIDED BY GARY COURT "AS IS" AND ANY EXPRESS OR IMPLIED WARRA
 The views and conclusions contained in the software and documentation are those of the authors and should not be interpreted as representing official policies, either expressed or implied, of Gary Court.
 
 ------------------------------------------------------------------------------
-[467] Applies to: npm:url-template@2.0.8
+[497] Applies to: npm:url-template@2.0.8
 ------------------------------------------------------------------------------
 Copyright (c) 2012-2014, Bram Stein
 All rights reserved.
@@ -38469,7 +39654,7 @@ NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE,
 EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 ------------------------------------------------------------------------------
-[468] Applies to: npm:util-deprecate@1.0.2
+[498] Applies to: npm:util-deprecate@1.0.2
 ------------------------------------------------------------------------------
 (The MIT License)
 
@@ -38497,7 +39682,7 @@ FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
 OTHER DEALINGS IN THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[469] Applies to: npm:uuid@14.0.1
+[499] Applies to: npm:uuid@14.0.1, npm:uuid@8.3.2
 ------------------------------------------------------------------------------
 The MIT License (MIT)
 
@@ -38510,7 +39695,7 @@ The above copyright notice and this permission notice shall be included in all c
 THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[470] Applies to: npm:void-elements@3.1.0
+[500] Applies to: npm:void-elements@3.1.0
 ------------------------------------------------------------------------------
 (The MIT License)
 
@@ -38536,7 +39721,7 @@ TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
 SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[471] Applies to: npm:web-streams-polyfill@3.3.3
+[501] Applies to: npm:web-streams-polyfill@3.3.3
 ------------------------------------------------------------------------------
 The MIT License (MIT)
 
@@ -38562,7 +39747,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
 ------------------------------------------------------------------------------
-[472] Applies to: npm:which-module@2.0.1
+[502] Applies to: npm:which-module@2.0.1
 ------------------------------------------------------------------------------
 Copyright (c) 2016, Contributors
 
@@ -38579,7 +39764,7 @@ TORTIOUS ACTION, ARISING OUT OF OR IN CONNECTION WITH THE USE OR PERFORMANCE OF
 THIS SOFTWARE.
 
 ------------------------------------------------------------------------------
-[473] Applies to: npm:workerpool@9.1.1
+[503] Applies to: npm:workerpool@9.1.1
 ------------------------------------------------------------------------------
 Apache License
                            Version 2.0, January 2004
@@ -38784,7 +39969,7 @@ Apache License
    limitations under the License.
 
 ------------------------------------------------------------------------------
-[474] Applies to: npm:ws@8.21.1
+[504] Applies to: npm:ws@8.21.1
 ------------------------------------------------------------------------------
 Copyright (c) 2011 Einar Otto Stangvik <einaros@gmail.com>
 Copyright (c) 2013 Arnout Kazemier and contributors
@@ -38808,7 +39993,80 @@ IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
 CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[475] Applies to: npm:y18n@4.0.3
+[505] Applies to: npm:xml@1.0.1
+------------------------------------------------------------------------------
+(The MIT License)
+
+Copyright (c) 2011-2016 Dylan Greene <dylang@gmail.com>
+
+Permission is hereby granted, free of charge, to any person obtaining
+a copy of this software and associated documentation files (the
+'Software'), to deal in the Software without restriction, including
+without limitation the rights to use, copy, modify, merge, publish,
+distribute, sublicense, and/or sell copies of the Software, and to
+permit persons to whom the Software is furnished to do so, subject to
+the following conditions:
+
+The above copyright notice and this permission notice shall be
+included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED 'AS IS', WITHOUT WARRANTY OF ANY KIND,
+EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+------------------------------------------------------------------------------
+[506] Applies to: npm:xml-js@1.6.11
+------------------------------------------------------------------------------
+The MIT License (MIT)
+
+Copyright (c) 2016-2017 Yousuf Almarzooqi
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+
+------------------------------------------------------------------------------
+[507] Applies to: npm:xmlchars@2.2.0
+------------------------------------------------------------------------------
+Copyright Louis-Dominique Dubeau and contributors to xmlchars
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of
+this software and associated documentation files (the "Software"), to deal in
+the Software without restriction, including without limitation the rights to
+use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+the Software, and to permit persons to whom the Software is furnished to do so,
+subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+------------------------------------------------------------------------------
+[508] Applies to: npm:y18n@4.0.3
 ------------------------------------------------------------------------------
 Copyright (c) 2015, Contributors
 
@@ -38825,7 +40083,7 @@ TORTIOUS ACTION, ARISING OUT OF OR IN CONNECTION WITH THE USE OR PERFORMANCE OF
 THIS SOFTWARE.
 
 ------------------------------------------------------------------------------
-[476] Applies to: npm:yargs@15.4.1
+[509] Applies to: npm:yargs@15.4.1
 ------------------------------------------------------------------------------
 MIT License
 
@@ -38850,7 +40108,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[477] Applies to: npm:zod@4.3.6
+[510] Applies to: npm:zod@4.3.6
 ------------------------------------------------------------------------------
 MIT License
 
@@ -38875,7 +40133,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
 ------------------------------------------------------------------------------
-[478] Applies to: npm:zod-to-json-schema@3.25.2
+[511] Applies to: npm:zod-to-json-schema@3.25.2
 ------------------------------------------------------------------------------
 ISC License
 
@@ -38925,12 +40183,18 @@ Packages without a standalone license file (license per package.json):
 - npm:@sapphire/snowflake@3.5.5 (MIT)
 - npm:@wecom/aibot-node-sdk@1.0.7 (MIT)
 - npm:agent-base@6.0.2 (MIT)
+- npm:binary@0.3.0 (MIT)
+- npm:buffers@0.1.1 (MIT)
+- npm:chainsaw@0.1.0 (MIT)
 - npm:data-uri-to-buffer@4.0.1 (MIT)
 - npm:drizzle-orm@0.45.2 (Apache-2.0)
 - npm:eastasianwidth@0.2.0 (MIT)
+- npm:hash.js@1.1.7 (MIT)
 - npm:html-parse-stringify@3.0.1 (MIT)
+- npm:https@1.0.0 (ISC)
 - npm:https-proxy-agent@5.0.1 (MIT)
 - npm:isarray@1.0.0 (MIT)
 - npm:react-remove-scroll-bar@2.3.8 (MIT)
 - npm:rehype-katex@7.0.1 (MIT)
 - npm:remark-math@6.0.0 (MIT)
+- npm:saxes@5.0.1 (ISC)

--- a/docs/legal/notices/mobile-android.txt
+++ b/docs/legal/notices/mobile-android.txt
@@ -384,10 +384,9 @@ Apache License
    limitations under the License.
 
 ==============================================================================
-SECTION 2: npm packages (601 packages)
+SECTION 2: npm packages (610 packages)
 ==============================================================================
 
-- @adobe/css-tools@4.5.0 — MIT — https://github.com/adobe/css-tools
 - @babel/code-frame@7.29.7 — MIT — https://github.com/babel/babel
 - @babel/compat-data@7.29.7 — MIT — https://github.com/babel/babel
 - @babel/core@7.29.7 — MIT — https://github.com/babel/babel
@@ -457,42 +456,39 @@ SECTION 2: npm packages (601 packages)
 - @babel/template@7.29.7 — MIT — https://github.com/babel/babel
 - @babel/traverse@7.29.7 — MIT — https://github.com/babel/babel
 - @babel/types@7.29.7 — MIT — https://github.com/babel/babel
+- @egjs/hammerjs@2.0.17 — MIT — https://github.com/naver/hammer.js
 - @expo-google-fonts/material-symbols@0.4.40 — MIT AND Apache-2.0 — https://github.com/expo/google-fonts
-- @expo/cli@56.1.20 — MIT — https://github.com/expo/expo
+- @expo/cli@57.0.19 — MIT — https://github.com/expo/expo
 - @expo/code-signing-certificates@0.0.6 — MIT — https://github.com/expo/code-signing-certificates
-- @expo/config@56.0.12 — MIT — https://github.com/expo/expo
-- @expo/config-plugins@56.0.13 — MIT — https://github.com/expo/expo
-- @expo/config-types@56.0.7 — MIT — https://github.com/expo/expo
+- @expo/config@57.0.9 — MIT — https://github.com/expo/expo
+- @expo/config-plugins@57.0.9 — MIT — https://github.com/expo/expo
+- @expo/config-types@57.0.2 — MIT — https://github.com/expo/expo
 - @expo/devcert@1.2.1 — MIT — https://github.com/expo/devcert
-- @expo/devtools@56.0.2 — MIT — https://github.com/expo/expo
-- @expo/dom-webview@56.0.6 — MIT — https://github.com/expo/expo
-- @expo/env@2.3.1 — MIT — https://github.com/expo/expo
+- @expo/devtools@57.0.1 — MIT — https://github.com/expo/expo
+- @expo/dom-webview@57.0.1 — MIT — https://github.com/expo/expo
 - @expo/env@2.4.2 — MIT — https://github.com/expo/expo
-- @expo/expo-modules-macros-plugin@0.2.2 — MIT — https://github.com/expo/expo-modules-macros-plugin
-- @expo/fingerprint@0.19.8 — MIT — https://github.com/expo/expo
-- @expo/image-utils@0.10.3 — MIT — https://github.com/expo/expo
-- @expo/image-utils@0.10.4 — MIT — https://github.com/expo/expo
-- @expo/inline-modules@0.0.14 — MIT — https://github.com/expo/expo
-- @expo/json-file@10.2.0 — MIT — https://github.com/expo/expo
+- @expo/expo-modules-macros-plugin@0.6.1 — MIT — https://github.com/expo/expo-modules-macros-plugin
+- @expo/fingerprint@0.20.10 — MIT — https://github.com/expo/expo
+- @expo/image-utils@0.11.5 — MIT — https://github.com/expo/expo
+- @expo/inline-modules@0.1.7 — MIT — https://github.com/expo/expo
 - @expo/json-file@11.0.1 — MIT — https://github.com/expo/expo
-- @expo/local-build-cache-provider@56.0.10 — MIT — https://github.com/expo/expo
-- @expo/log-box@56.0.14 — MIT — https://github.com/expo/expo/tree/main/packages/@expo/log-box
-- @expo/metro@56.0.0 — MIT — https://github.com/expo/expo-metro
-- @expo/metro-config@56.0.17 — MIT — https://github.com/expo/expo
-- @expo/metro-file-map@56.0.3 — MIT — https://github.com/expo/expo
-- @expo/metro-runtime@56.0.17 — MIT — https://github.com/expo/expo
+- @expo/local-build-cache-provider@57.0.8 — MIT — https://github.com/expo/expo
+- @expo/log-box@57.0.4 — MIT — https://github.com/expo/expo/tree/main/packages/@expo/log-box
+- @expo/metro@56.0.2 — MIT — https://github.com/expo/expo-metro
+- @expo/metro-config@57.0.11 — MIT — https://github.com/expo/expo
+- @expo/metro-file-map@57.0.2 — MIT — https://github.com/expo/expo
+- @expo/metro-runtime@57.0.14 — MIT — https://github.com/expo/expo
 - @expo/osascript@2.7.1 — MIT — https://github.com/expo/expo
 - @expo/package-manager@1.13.1 — MIT — https://github.com/expo/expo
-- @expo/plist@0.7.0 — MIT — https://github.com/expo/expo
-- @expo/prebuild-config@56.0.20 — MIT — https://github.com/expo/expo
-- @expo/require-utils@56.1.5 — MIT — https://github.com/expo/expo
-- @expo/require-utils@56.1.6 — MIT — https://github.com/expo/expo
-- @expo/router-server@56.0.16 — MIT — https://github.com/expo/expo
-- @expo/schema-utils@56.0.2 — MIT — https://github.com/expo/expo
+- @expo/plist@0.8.1 — MIT — https://github.com/expo/expo
+- @expo/prebuild-config@57.0.15 — MIT — https://github.com/expo/expo
+- @expo/require-utils@57.0.5 — MIT — https://github.com/expo/expo
+- @expo/router-server@57.0.8 — MIT — https://github.com/expo/expo
+- @expo/schema-utils@57.0.2 — MIT — https://github.com/expo/expo
 - @expo/sdk-runtime-versions@1.0.0 — MIT
 - @expo/spawn-async@1.8.0 — MIT — https://github.com/expo/spawn-async
 - @expo/sudo-prompt@9.3.2 — MIT — https://github.com/expo/sudo-prompt
-- @expo/ui@56.0.22 — MIT — https://github.com/expo/expo
+- @expo/ui@57.0.14 — MIT — https://github.com/expo/expo
 - @expo/ws-tunnel@2.0.0 — MIT
 - @expo/xcpretty@4.4.4 — BSD-3-Clause — https://github.com/expo/expo-cli
 - @isaacs/ttlcache@1.4.1 — ISC — https://github.com/isaacs/ttlcache
@@ -530,21 +526,21 @@ SECTION 2: npm packages (601 packages)
 - @react-native-async-storage/async-storage@2.2.0 — MIT — https://github.com/react-native-async-storage/async-storage
 - @react-native-google-signin/google-signin@16.1.2 — MIT — https://github.com/react-native-google-signin/google-signin
 - @react-native-masked-view/masked-view@0.3.2 — MIT — https://github.com/react-native-masked-view/masked-view
-- @react-native/assets-registry@0.85.3 — MIT — https://github.com/facebook/react-native
-- @react-native/babel-plugin-codegen@0.85.3 — MIT — https://github.com/facebook/react-native
-- @react-native/codegen@0.85.3 — MIT — https://github.com/facebook/react-native
-- @react-native/community-cli-plugin@0.85.3 — MIT — https://github.com/facebook/react-native
-- @react-native/debugger-frontend@0.85.3 — BSD-3-Clause — https://github.com/facebook/react-native
-- @react-native/debugger-shell@0.85.3 — MIT — https://github.com/facebook/react-native
-- @react-native/dev-middleware@0.85.3 — MIT — https://github.com/facebook/react-native
-- @react-native/gradle-plugin@0.85.3 — MIT — https://github.com/facebook/react-native
-- @react-native/js-polyfills@0.85.3 — MIT — https://github.com/facebook/react-native
+- @react-native-menu/menu@2.0.0 — MIT — https://github.com/react-native-menu/menu
+- @react-native/assets-registry@0.86.3 — MIT — https://github.com/react/react-native
+- @react-native/babel-plugin-codegen@0.86.3 — MIT — https://github.com/react/react-native
+- @react-native/codegen@0.86.3 — MIT — https://github.com/react/react-native
+- @react-native/community-cli-plugin@0.86.3 — MIT — https://github.com/react/react-native
+- @react-native/debugger-frontend@0.86.3 — BSD-3-Clause — https://github.com/react/react-native
+- @react-native/debugger-shell@0.86.3 — MIT — https://github.com/react/react-native
+- @react-native/dev-middleware@0.86.3 — MIT — https://github.com/react/react-native
+- @react-native/gradle-plugin@0.86.3 — MIT — https://github.com/react/react-native
+- @react-native/js-polyfills@0.86.3 — MIT — https://github.com/react/react-native
 - @react-native/normalize-colors@0.74.89 — MIT — https://github.com/facebook/react-native
-- @react-native/normalize-colors@0.85.3 — MIT — https://github.com/facebook/react-native
-- @react-native/virtualized-lists@0.85.3 — MIT — https://github.com/facebook/react-native
+- @react-native/normalize-colors@0.86.3 — MIT — https://github.com/react/react-native
+- @react-native/virtualized-lists@0.86.3 — MIT — https://github.com/react/react-native
 - @sinclair/typebox@0.27.10 — MIT — https://github.com/sinclairzx81/typebox-legacy
-- @testing-library/jest-dom@6.9.1 — MIT — https://github.com/testing-library/jest-dom
-- @testing-library/user-event@14.6.1 — MIT — https://github.com/testing-library/user-event
+- @types/hammerjs@2.0.46 — MIT — https://github.com/DefinitelyTyped/DefinitelyTyped
 - @types/istanbul-lib-coverage@2.0.6 — MIT — https://github.com/DefinitelyTyped/DefinitelyTyped
 - @types/istanbul-lib-report@3.0.3 — MIT — https://github.com/DefinitelyTyped/DefinitelyTyped
 - @types/istanbul-reports@3.0.4 — MIT — https://github.com/DefinitelyTyped/DefinitelyTyped
@@ -562,7 +558,7 @@ SECTION 2: npm packages (601 packages)
 - accepts@2.0.0 — MIT — https://github.com/jshttp/accepts
 - acorn@8.17.0 — MIT — https://github.com/acornjs/acorn
 - agent-base@7.1.4 — MIT — https://github.com/TooTallNate/proxy-agents
-- agent-cli-detector@0.1.2 — MIT
+- agent-cli-detector@0.1.6 — MIT — https://github.com/expo/agent-cli-detector
 - anser@1.4.10 — MIT — https://github.com/IonicaBizau/anser
 - ansi-escapes@4.3.2 — MIT — https://github.com/sindresorhus/ansi-escapes
 - ansi-regex@4.1.1 — MIT — https://github.com/chalk/ansi-regex
@@ -574,16 +570,16 @@ SECTION 2: npm packages (601 packages)
 - arg@5.0.2 — MIT — https://github.com/vercel/arg
 - argparse@2.0.1 — Python-2.0 — https://github.com/nodeca/argparse
 - aria-hidden@1.2.6 — MIT — https://github.com/theKashey/aria-hidden
-- aria-query@5.3.2 — Apache-2.0 — https://github.com/A11yance/aria-query
 - asap@2.0.6 — MIT — https://github.com/kriskowal/asap
 - babel-plugin-polyfill-corejs2@0.4.17 — MIT — https://github.com/babel/babel-polyfills
 - babel-plugin-polyfill-corejs3@0.13.0 — MIT — https://github.com/babel/babel-polyfills
 - babel-plugin-polyfill-regenerator@0.6.8 — MIT — https://github.com/babel/babel-polyfills
 - babel-plugin-react-compiler@1.0.0 — MIT — https://github.com/facebook/react
 - babel-plugin-react-native-web@0.21.2 — MIT — https://github.com/necolas/react-native-web
-- babel-plugin-syntax-hermes-parser@0.33.3 — MIT — https://github.com/facebook/hermes
+- babel-plugin-syntax-hermes-parser@0.36.0 — MIT — https://github.com/facebook/hermes
+- babel-plugin-syntax-hermes-parser@0.36.1 — MIT — https://github.com/facebook/hermes
 - babel-plugin-transform-flow-enums@0.0.2 — MIT — https://github.com/facebook/flow
-- babel-preset-expo@56.0.17 — MIT — https://github.com/expo/expo
+- babel-preset-expo@57.0.9 — MIT — https://github.com/expo/expo
 - badgin@1.2.3 — MIT — https://github.com/jaulz/badgin
 - balanced-match@4.0.4 — MIT — https://github.com/juliangruber/balanced-match
 - base64-js@1.5.1 — MIT — https://github.com/beatgammit/base64-js
@@ -632,7 +628,6 @@ SECTION 2: npm packages (601 packages)
 - css-select@5.2.2 — BSD-2-Clause — https://github.com/fb55/css-select
 - css-tree@1.1.3 — MIT — https://github.com/csstree/csstree
 - css-what@6.2.2 — BSD-2-Clause — https://github.com/fb55/css-what
-- css.escape@1.5.1 — MIT — https://github.com/mathiasbynens/CSS.escape
 - csstype@3.2.3 — MIT — https://github.com/frenic/csstype
 - debug@2.6.9 — MIT — https://github.com/visionmedia/debug
 - debug@3.2.7 — MIT — https://github.com/visionmedia/debug
@@ -645,7 +640,6 @@ SECTION 2: npm packages (601 packages)
 - detect-libc@2.1.2 — Apache-2.0 — https://github.com/lovell/detect-libc
 - detect-node-es@1.1.0 — MIT — https://github.com/thekashey/detect-node
 - dnssd-advertise@1.1.6 — MIT — https://github.com/kitten/dnssd-advertise
-- dom-accessibility-api@0.6.3 — MIT — https://github.com/eps1lon/dom-accessibility-api
 - dom-serializer@2.0.0 — MIT — https://github.com/cheeriojs/dom-serializer
 - domelementtype@2.3.0 — BSD-2-Clause — https://github.com/fb55/domelementtype
 - domhandler@5.0.3 — BSD-2-Clause — https://github.com/fb55/domhandler
@@ -664,49 +658,48 @@ SECTION 2: npm packages (601 packages)
 - escape-string-regexp@4.0.0 — MIT — https://github.com/sindresorhus/escape-string-regexp
 - etag@1.8.1 — MIT — https://github.com/jshttp/etag
 - event-target-shim@5.0.1 — MIT — https://github.com/mysticatea/event-target-shim
-- expo@56.0.16 — MIT — https://github.com/expo/expo
-- expo-apple-authentication@56.0.4 — MIT — https://github.com/expo/expo
-- expo-application@56.0.3 — MIT — https://github.com/expo/expo
-- expo-asset@56.0.20 — MIT — https://github.com/expo/expo
-- expo-audio@56.0.12 — MIT — https://github.com/expo/expo
-- expo-auth-session@56.0.15 — MIT — https://github.com/expo/expo
-- expo-blur@56.0.4 — MIT — https://github.com/expo/expo
-- expo-build-properties@56.0.23 — MIT — https://github.com/expo/expo
-- expo-clipboard@56.0.4 — MIT — https://github.com/expo/expo
-- expo-constants@56.0.21 — MIT — https://github.com/expo/expo
-- expo-constants@56.0.22 — MIT — https://github.com/expo/expo
-- expo-crypto@56.0.4 — MIT — https://github.com/expo/expo
-- expo-document-picker@56.0.4 — MIT — https://github.com/expo/expo
-- expo-eas-client@56.0.1 — MIT — https://github.com/expo/expo
-- expo-file-system@56.0.8 — MIT — https://github.com/expo/expo
-- expo-font@56.0.7 — MIT — https://github.com/expo/expo
-- expo-glass-effect@56.0.4 — MIT — https://github.com/expo/expo
-- expo-image@56.0.11 — MIT — https://github.com/expo/expo
-- expo-image-loader@56.0.3 — MIT — https://github.com/expo/expo
-- expo-image-manipulator@56.0.22 — MIT — https://github.com/expo/expo
-- expo-image-picker@56.0.21 — MIT — https://github.com/expo/expo
-- expo-json-utils@56.0.0 — MIT — https://github.com/expo/expo
-- expo-keep-awake@56.0.3 — MIT — https://github.com/expo/expo
-- expo-linking@56.0.15 — MIT — https://github.com/expo/expo
-- expo-localization@56.0.6 — MIT — https://github.com/expo/expo
-- expo-manifests@56.0.4 — MIT — https://github.com/expo/expo
-- expo-media-library@56.0.9 — MIT — https://github.com/expo/expo
-- expo-modules-autolinking@56.0.20 — MIT — https://github.com/expo/expo
-- expo-modules-core@56.0.21 — MIT — https://github.com/expo/expo
-- expo-modules-jsi@56.0.12 — MIT — https://github.com/expo/expo
-- expo-notifications@56.0.22 — MIT — https://github.com/expo/expo
+- expo@57.0.17 — MIT — https://github.com/expo/expo
+- expo-apple-authentication@57.0.1 — MIT — https://github.com/expo/expo
+- expo-application@57.0.2 — MIT — https://github.com/expo/expo
+- expo-asset@57.0.15 — MIT — https://github.com/expo/expo
+- expo-audio@57.0.4 — MIT — https://github.com/expo/expo
+- expo-auth-session@57.0.10 — MIT — https://github.com/expo/expo
+- expo-blur@57.0.2 — MIT — https://github.com/expo/expo
+- expo-build-properties@57.0.15 — MIT — https://github.com/expo/expo
+- expo-clipboard@57.0.1 — MIT — https://github.com/expo/expo
+- expo-constants@57.0.15 — MIT — https://github.com/expo/expo
+- expo-crypto@57.0.2 — MIT — https://github.com/expo/expo
+- expo-document-picker@57.0.1 — MIT — https://github.com/expo/expo
+- expo-eas-client@57.0.2 — MIT — https://github.com/expo/expo
+- expo-file-system@57.0.6 — MIT — https://github.com/expo/expo
+- expo-font@57.0.1 — MIT — https://github.com/expo/expo
+- expo-glass-effect@57.0.1 — MIT — https://github.com/expo/expo
+- expo-image@57.0.3 — MIT — https://github.com/expo/expo
+- expo-image-loader@57.0.1 — MIT — https://github.com/expo/expo
+- expo-image-manipulator@57.0.14 — MIT — https://github.com/expo/expo
+- expo-image-picker@57.0.14 — MIT — https://github.com/expo/expo
+- expo-json-utils@57.0.1 — MIT — https://github.com/expo/expo
+- expo-keep-awake@57.0.1 — MIT — https://github.com/expo/expo
+- expo-linking@57.0.8 — MIT — https://github.com/expo/expo
+- expo-localization@57.0.1 — MIT — https://github.com/expo/expo
+- expo-manifests@57.0.1 — MIT — https://github.com/expo/expo
+- expo-media-library@57.0.4 — MIT — https://github.com/expo/expo
+- expo-modules-autolinking@57.0.12 — MIT — https://github.com/expo/expo
+- expo-modules-core@57.0.14 — MIT — https://github.com/expo/expo
+- expo-modules-jsi@57.0.6 — MIT — https://github.com/expo/expo
+- expo-notifications@57.0.15 — MIT — https://github.com/expo/expo
 - expo-paste-input@0.2.2 — MIT — https://github.com/arunabhverma/expo-paste-input
-- expo-router@56.2.15 — MIT — https://github.com/expo/expo
-- expo-secure-store@56.0.4 — MIT — https://github.com/expo/expo
-- expo-server@56.0.5 — MIT — https://github.com/expo/expo
-- expo-sharing@56.0.22 — MIT — https://github.com/expo/expo
-- expo-splash-screen@56.0.13 — MIT — https://github.com/expo/expo
-- expo-status-bar@56.0.4 — MIT — https://github.com/expo/expo
-- expo-structured-headers@56.0.0 — MIT — https://github.com/expo/expo
-- expo-symbols@56.0.6 — MIT — https://github.com/expo/expo
-- expo-updates@56.0.22 — MIT — https://github.com/expo/expo
-- expo-updates-interface@56.0.2 — MIT — https://github.com/expo/expo
-- expo-web-browser@56.0.5 — MIT — https://github.com/expo/expo
+- expo-router@57.0.17 — MIT — https://github.com/expo/expo
+- expo-secure-store@57.0.2 — MIT — https://github.com/expo/expo
+- expo-server@57.0.3 — MIT — https://github.com/expo/expo
+- expo-sharing@57.0.16 — MIT — https://github.com/expo/expo
+- expo-splash-screen@57.0.8 — MIT — https://github.com/expo/expo
+- expo-status-bar@57.0.1 — MIT — https://github.com/expo/expo
+- expo-structured-headers@57.0.0 — MIT — https://github.com/expo/expo
+- expo-symbols@57.0.2 — MIT — https://github.com/expo/expo
+- expo-updates@57.0.18 — MIT — https://github.com/expo/expo
+- expo-updates-interface@57.0.1 — MIT — https://github.com/expo/expo
+- expo-web-browser@57.0.2 — MIT — https://github.com/expo/expo
 - exponential-backoff@3.1.3 — Apache-2.0 — https://github.com/coveooss/exponential-backoff
 - fast-deep-equal@3.1.3 — MIT — https://github.com/epoberezkin/fast-deep-equal
 - fb-dotslash@0.5.8 — (MIT OR Apache-2.0) — https://github.com/facebook/dotslash
@@ -731,11 +724,14 @@ SECTION 2: npm packages (601 packages)
 - has-flag@3.0.0 — MIT — https://github.com/sindresorhus/has-flag
 - has-flag@4.0.0 — MIT — https://github.com/sindresorhus/has-flag
 - hasown@2.0.4 — MIT — https://github.com/inspect-js/hasOwn
-- hermes-compiler@250829098.0.10 — MIT — https://github.com/facebook/hermes
-- hermes-estree@0.33.3 — MIT — https://github.com/facebook/hermes
+- hermes-compiler@250829098.0.17 — MIT — https://github.com/facebook/hermes
 - hermes-estree@0.35.0 — MIT — https://github.com/facebook/hermes
-- hermes-parser@0.33.3 — MIT — https://github.com/facebook/hermes
+- hermes-estree@0.36.0 — MIT — https://github.com/facebook/hermes
+- hermes-estree@0.36.1 — MIT — https://github.com/facebook/hermes
 - hermes-parser@0.35.0 — MIT — https://github.com/facebook/hermes
+- hermes-parser@0.36.0 — MIT — https://github.com/facebook/hermes
+- hermes-parser@0.36.1 — MIT — https://github.com/facebook/hermes
+- hoist-non-react-statics@3.3.2 — BSD-3-Clause — https://github.com/mridgway/hoist-non-react-statics
 - hosted-git-info@7.0.2 — ISC — https://github.com/npm/hosted-git-info
 - html-parse-stringify@3.0.1 — MIT — https://github.com/henrikjoreteg/html-parse-stringify
 - http-errors@2.0.1 — MIT — https://github.com/jshttp/http-errors
@@ -744,7 +740,6 @@ SECTION 2: npm packages (601 packages)
 - i18next@26.3.6 — MIT — https://github.com/i18next/i18next
 - ignore@5.3.2 — MIT — https://github.com/kaelzhang/node-ignore
 - image-size@1.2.1 — MIT — https://github.com/image-size/image-size
-- indent-string@4.0.0 — MIT — https://github.com/sindresorhus/indent-string
 - inherits@2.0.4 — ISC — https://github.com/isaacs/inherits
 - inline-style-prefixer@7.0.1 — MIT — https://github.com/robinweser/inline-style-prefixer
 - invariant@2.2.4 — MIT — https://github.com/zertosh/invariant
@@ -787,19 +782,33 @@ SECTION 2: npm packages (601 packages)
 - merge-options@3.0.4 — MIT — https://github.com/schnittstabil/merge-options
 - merge-stream@2.0.0 — MIT — https://github.com/grncdr/merge-stream
 - metro@0.84.4 — MIT — https://github.com/facebook/metro
+- metro@0.84.5 — MIT — https://github.com/react/metro
 - metro-babel-transformer@0.84.4 — MIT — https://github.com/facebook/metro
+- metro-babel-transformer@0.84.5 — MIT — https://github.com/react/metro
 - metro-cache@0.84.4 — MIT — https://github.com/facebook/metro
+- metro-cache@0.84.5 — MIT — https://github.com/react/metro
 - metro-cache-key@0.84.4 — MIT — https://github.com/facebook/metro
+- metro-cache-key@0.84.5 — MIT — https://github.com/react/metro
 - metro-config@0.84.4 — MIT — https://github.com/facebook/metro
+- metro-config@0.84.5 — MIT — https://github.com/react/metro
 - metro-core@0.84.4 — MIT — https://github.com/facebook/metro
+- metro-core@0.84.5 — MIT — https://github.com/react/metro
 - metro-file-map@0.84.4 — MIT — https://github.com/facebook/metro
+- metro-file-map@0.84.5 — MIT — https://github.com/react/metro
 - metro-minify-terser@0.84.4 — MIT — https://github.com/facebook/metro
+- metro-minify-terser@0.84.5 — MIT — https://github.com/react/metro
 - metro-resolver@0.84.4 — MIT — https://github.com/facebook/metro
+- metro-resolver@0.84.5 — MIT — https://github.com/react/metro
 - metro-runtime@0.84.4 — MIT — https://github.com/facebook/metro
+- metro-runtime@0.84.5 — MIT — https://github.com/react/metro
 - metro-source-map@0.84.4 — MIT — https://github.com/facebook/metro
+- metro-source-map@0.84.5 — MIT — https://github.com/react/metro
 - metro-symbolicate@0.84.4 — MIT — https://github.com/facebook/metro
+- metro-symbolicate@0.84.5 — MIT — https://github.com/react/metro
 - metro-transform-plugins@0.84.4 — MIT — https://github.com/facebook/metro
+- metro-transform-plugins@0.84.5 — MIT — https://github.com/react/metro
 - metro-transform-worker@0.84.4 — MIT — https://github.com/facebook/metro
+- metro-transform-worker@0.84.5 — MIT — https://github.com/react/metro
 - micromatch@4.0.8 — MIT — https://github.com/micromatch/micromatch
 - mime@1.6.0 — MIT — https://github.com/broofa/node-mime
 - mime-db@1.52.0 — MIT — https://github.com/jshttp/mime-db
@@ -807,13 +816,12 @@ SECTION 2: npm packages (601 packages)
 - mime-types@2.1.35 — MIT — https://github.com/jshttp/mime-types
 - mime-types@3.0.2 — MIT — https://github.com/jshttp/mime-types
 - mimic-fn@1.2.0 — MIT — https://github.com/sindresorhus/mimic-fn
-- min-indent@1.0.1 — MIT — https://github.com/thejameskyle/min-indent
 - minimatch@10.2.5 — BlueOak-1.0.0 — https://github.com/isaacs/minimatch
 - minipass@7.1.3 — BlueOak-1.0.0 — https://github.com/isaacs/minipass
 - mkdirp@1.0.4 — MIT — https://github.com/isaacs/node-mkdirp
 - ms@2.0.0 — MIT — https://github.com/zeit/ms
 - ms@2.1.3 — MIT — https://github.com/vercel/ms
-- multitars@1.0.0 — MIT — https://github.com/kitten/multitars
+- multitars@1.0.2 — MIT — https://github.com/expo/multitars
 - nanoid@3.3.16 — MIT — https://github.com/ai/nanoid
 - negotiator@0.6.3 — MIT — https://github.com/jshttp/negotiator
 - negotiator@0.6.4 — MIT — https://github.com/jshttp/negotiator
@@ -826,6 +834,7 @@ SECTION 2: npm packages (601 packages)
 - nth-check@2.1.1 — BSD-2-Clause — https://github.com/fb55/nth-check
 - nullthrows@1.1.1 — MIT — https://github.com/zertosh/nullthrows
 - ob1@0.84.4 — MIT — https://github.com/facebook/metro
+- ob1@0.84.5 — MIT — https://github.com/react/metro
 - object-assign@4.1.1 — MIT — https://github.com/sindresorhus/object-assign
 - on-finished@2.3.0 — MIT — https://github.com/jshttp/on-finished
 - on-finished@2.4.1 — MIT — https://github.com/jshttp/on-finished
@@ -861,25 +870,25 @@ SECTION 2: npm packages (601 packages)
 - react-fast-compare@3.2.2 — MIT — https://github.com/FormidableLabs/react-fast-compare
 - react-freeze@1.0.4 — MIT — https://github.com/software-mansion/react-freeze
 - react-i18next@17.0.10 — MIT — https://github.com/i18next/react-i18next
+- react-is@16.13.1 — MIT — https://github.com/facebook/react
 - react-is@18.3.1 — MIT — https://github.com/facebook/react
 - react-is@19.2.7 — MIT — https://github.com/facebook/react
-- react-native@0.85.3 — MIT — https://github.com/facebook/react-native
+- react-native@0.86.3 — MIT — https://github.com/react/react-native
 - react-native-drawer-layout@4.2.7 — MIT — https://github.com/react-navigation/react-navigation
-- react-native-gesture-handler@3.0.2 — MIT — https://github.com/software-mansion/react-native-gesture-handler
+- react-native-gesture-handler@2.32.0 — MIT — https://github.com/software-mansion/react-native-gesture-handler
 - react-native-is-edge-to-edge@1.3.1 — MIT — https://github.com/zoontek/react-native-edge-to-edge
-- react-native-reanimated@4.3.1 — MIT — https://github.com/software-mansion/react-native-reanimated
+- react-native-reanimated@4.5.1 — MIT — https://github.com/software-mansion/react-native-reanimated
 - react-native-safe-area-context@5.7.0 — MIT — https://github.com/AppAndFlow/react-native-safe-area-context
-- react-native-screens@4.25.2 — MIT — https://github.com/software-mansion/react-native-screens
+- react-native-screens@4.26.2 — MIT — https://github.com/software-mansion/react-native-screens
 - react-native-svg@15.15.4 — MIT — https://github.com/react-native-community/react-native-svg
 - react-native-uitextview@2.2.0 — MIT — https://github.com/bluesky-social/react-native-uitextview
 - react-native-web@0.21.2 — MIT — https://github.com/necolas/react-native-web
 - react-native-webview@13.16.1 — MIT — https://github.com/react-native-webview/react-native-webview
-- react-native-worklets@0.8.3 — MIT — https://github.com/software-mansion/react-native-reanimated
+- react-native-worklets@0.10.1 — MIT — https://github.com/software-mansion/react-native-reanimated
 - react-refresh@0.14.2 — MIT — https://github.com/facebook/react
 - react-remove-scroll@2.7.2 — MIT — https://github.com/theKashey/react-remove-scroll
 - react-remove-scroll-bar@2.3.8 — MIT — https://github.com/theKashey/react-remove-scroll-bar
 - react-style-singleton@2.2.3 — MIT — https://github.com/theKashey/react-style-singleton
-- redent@3.0.0 — MIT — https://github.com/sindresorhus/redent
 - regenerate@1.4.2 — MIT — https://github.com/mathiasbynens/regenerate
 - regenerate-unicode-properties@10.2.2 — MIT — https://github.com/mathiasbynens/regenerate-unicode-properties
 - regenerator-runtime@0.13.11 — MIT — https://github.com/facebook/regenerator/tree/main/packages/runtime
@@ -893,6 +902,7 @@ SECTION 2: npm packages (601 packages)
 - restore-cursor@2.0.0 — MIT — https://github.com/sindresorhus/restore-cursor
 - rtl-detect@1.1.2 — BSD-3-Clause — https://github.com/shadiabuhilal/rtl-detect
 - safe-buffer@5.2.1 — MIT — https://github.com/feross/safe-buffer
+- sandbox-cli-detector@0.2.0 — MIT — https://github.com/davidmokos/sandbox-cli-detector
 - sax@1.6.0 — BlueOak-1.0.0 — https://github.com/isaacs/sax-js
 - scheduler@0.27.0 — MIT — https://github.com/facebook/react
 - semver@6.3.1 — ISC — https://github.com/npm/node-semver
@@ -928,7 +938,6 @@ SECTION 2: npm packages (601 packages)
 - string-width@4.2.3 — MIT — https://github.com/sindresorhus/string-width
 - strip-ansi@5.2.0 — MIT — https://github.com/chalk/strip-ansi
 - strip-ansi@6.0.1 — MIT — https://github.com/chalk/strip-ansi
-- strip-indent@3.0.0 — MIT — https://github.com/sindresorhus/strip-indent
 - structured-headers@0.4.1 — MIT — https://github.com/evert/structured-header
 - styleq@0.1.3 — MIT — https://github.com/necolas/styleq
 - supports-color@5.5.0 — MIT — https://github.com/chalk/supports-color
@@ -997,21 +1006,7 @@ SECTION 3: Package license texts
 包元数据声明的 SPDX 标识为准(见前述 package sections)。
 
 ------------------------------------------------------------------------------
-[1] Applies to: npm:@adobe/css-tools@4.5.0
-------------------------------------------------------------------------------
-(The MIT License)
-
-Copyright (c) 2012 TJ Holowaychuk <tj@vision-media.ca>
-Copyright (c) 2022 Jean-Philippe Zolesio <holblin@gmail.com>
-
-Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the 'Software'), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
-
-The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
-
-THE SOFTWARE IS PROVIDED 'AS IS', WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
-
-------------------------------------------------------------------------------
-[2] Applies to: npm:@babel/code-frame@7.29.7, npm:@babel/compat-data@7.29.7, npm:@babel/core@7.29.7, npm:@babel/generator@7.29.7, npm:@babel/helper-annotate-as-pure@7.29.7, npm:@babel/helper-compilation-targets@7.29.7, npm:@babel/helper-create-class-features-plugin@7.29.7, npm:@babel/helper-create-regexp-features-plugin@7.29.7, npm:@babel/helper-globals@7.29.7, npm:@babel/helper-member-expression-to-functions@7.29.7, npm:@babel/helper-module-imports@7.29.7, npm:@babel/helper-module-transforms@7.29.7, npm:@babel/helper-optimise-call-expression@7.29.7, npm:@babel/helper-plugin-utils@7.29.7, npm:@babel/helper-remap-async-to-generator@7.29.7, npm:@babel/helper-replace-supers@7.29.7, npm:@babel/helper-skip-transparent-expression-wrappers@7.29.7, npm:@babel/helper-string-parser@7.29.7, npm:@babel/helper-validator-identifier@7.29.7, npm:@babel/helper-validator-option@7.29.7, npm:@babel/helper-wrap-function@7.29.7, npm:@babel/plugin-proposal-decorators@7.29.7, npm:@babel/plugin-proposal-export-default-from@7.29.7, npm:@babel/plugin-syntax-decorators@7.29.7, npm:@babel/plugin-syntax-dynamic-import@7.8.3, npm:@babel/plugin-syntax-export-default-from@7.29.7, npm:@babel/plugin-syntax-flow@7.29.7, npm:@babel/plugin-syntax-jsx@7.29.7, npm:@babel/plugin-syntax-nullish-coalescing-operator@7.8.3, npm:@babel/plugin-syntax-optional-chaining@7.8.3, npm:@babel/plugin-syntax-typescript@7.29.7, npm:@babel/plugin-transform-arrow-functions@7.29.7, npm:@babel/plugin-transform-async-generator-functions@7.29.7, npm:@babel/plugin-transform-async-to-generator@7.29.7, npm:@babel/plugin-transform-block-scoping@7.29.7, npm:@babel/plugin-transform-class-properties@7.29.7, npm:@babel/plugin-transform-class-static-block@7.29.7, npm:@babel/plugin-transform-classes@7.29.7, npm:@babel/plugin-transform-destructuring@7.29.7, npm:@babel/plugin-transform-export-namespace-from@7.29.7, npm:@babel/plugin-transform-flow-strip-types@7.29.7, npm:@babel/plugin-transform-for-of@7.29.7, npm:@babel/plugin-transform-logical-assignment-operators@7.29.7, npm:@babel/plugin-transform-modules-commonjs@7.29.7, npm:@babel/plugin-transform-named-capturing-groups-regex@7.29.7, npm:@babel/plugin-transform-nullish-coalescing-operator@7.29.7, npm:@babel/plugin-transform-object-rest-spread@7.29.7, npm:@babel/plugin-transform-optional-catch-binding@7.29.7, npm:@babel/plugin-transform-optional-chaining@7.29.7, npm:@babel/plugin-transform-parameters@7.29.7, npm:@babel/plugin-transform-private-methods@7.29.7, npm:@babel/plugin-transform-private-property-in-object@7.29.7, npm:@babel/plugin-transform-react-display-name@7.29.7, npm:@babel/plugin-transform-react-jsx@7.29.7, npm:@babel/plugin-transform-react-jsx-development@7.29.7, npm:@babel/plugin-transform-react-pure-annotations@7.29.7, npm:@babel/plugin-transform-runtime@7.29.7, npm:@babel/plugin-transform-shorthand-properties@7.29.7, npm:@babel/plugin-transform-template-literals@7.29.7, npm:@babel/plugin-transform-typescript@7.29.7, npm:@babel/plugin-transform-unicode-regex@7.29.7, npm:@babel/preset-typescript@7.29.7, npm:@babel/runtime@7.29.7, npm:@babel/template@7.29.7, npm:@babel/traverse@7.29.7, npm:@babel/types@7.29.7
+[1] Applies to: npm:@babel/code-frame@7.29.7, npm:@babel/compat-data@7.29.7, npm:@babel/core@7.29.7, npm:@babel/generator@7.29.7, npm:@babel/helper-annotate-as-pure@7.29.7, npm:@babel/helper-compilation-targets@7.29.7, npm:@babel/helper-create-class-features-plugin@7.29.7, npm:@babel/helper-create-regexp-features-plugin@7.29.7, npm:@babel/helper-globals@7.29.7, npm:@babel/helper-member-expression-to-functions@7.29.7, npm:@babel/helper-module-imports@7.29.7, npm:@babel/helper-module-transforms@7.29.7, npm:@babel/helper-optimise-call-expression@7.29.7, npm:@babel/helper-plugin-utils@7.29.7, npm:@babel/helper-remap-async-to-generator@7.29.7, npm:@babel/helper-replace-supers@7.29.7, npm:@babel/helper-skip-transparent-expression-wrappers@7.29.7, npm:@babel/helper-string-parser@7.29.7, npm:@babel/helper-validator-identifier@7.29.7, npm:@babel/helper-validator-option@7.29.7, npm:@babel/helper-wrap-function@7.29.7, npm:@babel/plugin-proposal-decorators@7.29.7, npm:@babel/plugin-proposal-export-default-from@7.29.7, npm:@babel/plugin-syntax-decorators@7.29.7, npm:@babel/plugin-syntax-dynamic-import@7.8.3, npm:@babel/plugin-syntax-export-default-from@7.29.7, npm:@babel/plugin-syntax-flow@7.29.7, npm:@babel/plugin-syntax-jsx@7.29.7, npm:@babel/plugin-syntax-nullish-coalescing-operator@7.8.3, npm:@babel/plugin-syntax-optional-chaining@7.8.3, npm:@babel/plugin-syntax-typescript@7.29.7, npm:@babel/plugin-transform-arrow-functions@7.29.7, npm:@babel/plugin-transform-async-generator-functions@7.29.7, npm:@babel/plugin-transform-async-to-generator@7.29.7, npm:@babel/plugin-transform-block-scoping@7.29.7, npm:@babel/plugin-transform-class-properties@7.29.7, npm:@babel/plugin-transform-class-static-block@7.29.7, npm:@babel/plugin-transform-classes@7.29.7, npm:@babel/plugin-transform-destructuring@7.29.7, npm:@babel/plugin-transform-export-namespace-from@7.29.7, npm:@babel/plugin-transform-flow-strip-types@7.29.7, npm:@babel/plugin-transform-for-of@7.29.7, npm:@babel/plugin-transform-logical-assignment-operators@7.29.7, npm:@babel/plugin-transform-modules-commonjs@7.29.7, npm:@babel/plugin-transform-named-capturing-groups-regex@7.29.7, npm:@babel/plugin-transform-nullish-coalescing-operator@7.29.7, npm:@babel/plugin-transform-object-rest-spread@7.29.7, npm:@babel/plugin-transform-optional-catch-binding@7.29.7, npm:@babel/plugin-transform-optional-chaining@7.29.7, npm:@babel/plugin-transform-parameters@7.29.7, npm:@babel/plugin-transform-private-methods@7.29.7, npm:@babel/plugin-transform-private-property-in-object@7.29.7, npm:@babel/plugin-transform-react-display-name@7.29.7, npm:@babel/plugin-transform-react-jsx@7.29.7, npm:@babel/plugin-transform-react-jsx-development@7.29.7, npm:@babel/plugin-transform-react-pure-annotations@7.29.7, npm:@babel/plugin-transform-runtime@7.29.7, npm:@babel/plugin-transform-shorthand-properties@7.29.7, npm:@babel/plugin-transform-template-literals@7.29.7, npm:@babel/plugin-transform-typescript@7.29.7, npm:@babel/plugin-transform-unicode-regex@7.29.7, npm:@babel/preset-typescript@7.29.7, npm:@babel/runtime@7.29.7, npm:@babel/template@7.29.7, npm:@babel/traverse@7.29.7, npm:@babel/types@7.29.7
 ------------------------------------------------------------------------------
 MIT License
 
@@ -1037,7 +1032,7 @@ OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
 WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[3] Applies to: npm:@babel/helper-define-polyfill-provider@0.6.8, npm:babel-plugin-polyfill-corejs2@0.4.17, npm:babel-plugin-polyfill-corejs3@0.13.0, npm:babel-plugin-polyfill-regenerator@0.6.8
+[2] Applies to: npm:@babel/helper-define-polyfill-provider@0.6.8, npm:babel-plugin-polyfill-corejs2@0.4.17, npm:babel-plugin-polyfill-corejs3@0.13.0, npm:babel-plugin-polyfill-regenerator@0.6.8
 ------------------------------------------------------------------------------
 MIT License
 
@@ -1063,7 +1058,7 @@ OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
 WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[4] Applies to: npm:@babel/helpers@7.29.7
+[3] Applies to: npm:@babel/helpers@7.29.7
 ------------------------------------------------------------------------------
 MIT License
 
@@ -1090,9 +1085,35 @@ OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
 WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[5] Applies to: npm:@babel/parser@7.29.7
+[4] Applies to: npm:@babel/parser@7.29.7
 ------------------------------------------------------------------------------
 Copyright (C) 2012-2014 by various contributors (see AUTHORS)
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+
+------------------------------------------------------------------------------
+[5] Applies to: npm:@egjs/hammerjs@2.0.17
+------------------------------------------------------------------------------
+The MIT License (MIT)
+
+Copyright (c) 2018-present NAVER Corp.
+Copyright (C) 2011-2017 by Jorik Tangelder (Eight Media)
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal
@@ -1138,7 +1159,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
 ------------------------------------------------------------------------------
-[7] Applies to: npm:@expo/cli@56.1.20, npm:@expo/config@56.0.12, npm:@expo/config-plugins@56.0.13, npm:@expo/devtools@56.0.2, npm:@expo/dom-webview@56.0.6, npm:@expo/expo-modules-macros-plugin@0.2.2, npm:@expo/fingerprint@0.19.8, npm:@expo/image-utils@0.10.3, npm:@expo/image-utils@0.10.4, npm:@expo/inline-modules@0.0.14, npm:@expo/json-file@10.2.0, npm:@expo/json-file@11.0.1, npm:@expo/local-build-cache-provider@56.0.10, npm:@expo/log-box@56.0.14, npm:@expo/metro-config@56.0.17, npm:@expo/metro-file-map@56.0.3, npm:@expo/metro-runtime@56.0.17, npm:@expo/osascript@2.7.1, npm:@expo/package-manager@1.13.1, npm:@expo/plist@0.7.0, npm:@expo/prebuild-config@56.0.20, npm:@expo/router-server@56.0.16, npm:babel-preset-expo@56.0.17, npm:expo@56.0.16, npm:expo-apple-authentication@56.0.4, npm:expo-application@56.0.3, npm:expo-asset@56.0.20, npm:expo-audio@56.0.12, npm:expo-auth-session@56.0.15, npm:expo-blur@56.0.4, npm:expo-build-properties@56.0.23, npm:expo-clipboard@56.0.4, npm:expo-constants@56.0.21, npm:expo-constants@56.0.22, npm:expo-crypto@56.0.4, npm:expo-document-picker@56.0.4, npm:expo-eas-client@56.0.1, npm:expo-file-system@56.0.8, npm:expo-font@56.0.7, npm:expo-glass-effect@56.0.4, npm:expo-image@56.0.11, npm:expo-image-loader@56.0.3, npm:expo-image-manipulator@56.0.22, npm:expo-image-picker@56.0.21, npm:expo-keep-awake@56.0.3, npm:expo-linking@56.0.15, npm:expo-localization@56.0.6, npm:expo-manifests@56.0.4, npm:expo-media-library@56.0.9, npm:expo-modules-autolinking@56.0.20, npm:expo-modules-core@56.0.21, npm:expo-modules-jsi@56.0.12, npm:expo-notifications@56.0.22, npm:expo-secure-store@56.0.4, npm:expo-server@56.0.5, npm:expo-sharing@56.0.22, npm:expo-splash-screen@56.0.13, npm:expo-status-bar@56.0.4, npm:expo-symbols@56.0.6, npm:expo-updates-interface@56.0.2, npm:expo-web-browser@56.0.5
+[7] Applies to: npm:@expo/cli@57.0.19, npm:@expo/config@57.0.9, npm:@expo/config-plugins@57.0.9, npm:@expo/devtools@57.0.1, npm:@expo/dom-webview@57.0.1, npm:@expo/expo-modules-macros-plugin@0.6.1, npm:@expo/fingerprint@0.20.10, npm:@expo/image-utils@0.11.5, npm:@expo/inline-modules@0.1.7, npm:@expo/json-file@11.0.1, npm:@expo/local-build-cache-provider@57.0.8, npm:@expo/log-box@57.0.4, npm:@expo/metro-config@57.0.11, npm:@expo/metro-file-map@57.0.2, npm:@expo/metro-runtime@57.0.14, npm:@expo/osascript@2.7.1, npm:@expo/package-manager@1.13.1, npm:@expo/plist@0.8.1, npm:@expo/prebuild-config@57.0.15, npm:@expo/router-server@57.0.8, npm:babel-preset-expo@57.0.9, npm:expo@57.0.17, npm:expo-apple-authentication@57.0.1, npm:expo-application@57.0.2, npm:expo-asset@57.0.15, npm:expo-audio@57.0.4, npm:expo-auth-session@57.0.10, npm:expo-blur@57.0.2, npm:expo-build-properties@57.0.15, npm:expo-clipboard@57.0.1, npm:expo-constants@57.0.15, npm:expo-crypto@57.0.2, npm:expo-document-picker@57.0.1, npm:expo-eas-client@57.0.2, npm:expo-file-system@57.0.6, npm:expo-font@57.0.1, npm:expo-glass-effect@57.0.1, npm:expo-image@57.0.3, npm:expo-image-loader@57.0.1, npm:expo-image-manipulator@57.0.14, npm:expo-image-picker@57.0.14, npm:expo-json-utils@57.0.1, npm:expo-keep-awake@57.0.1, npm:expo-linking@57.0.8, npm:expo-localization@57.0.1, npm:expo-manifests@57.0.1, npm:expo-media-library@57.0.4, npm:expo-modules-autolinking@57.0.12, npm:expo-modules-core@57.0.14, npm:expo-modules-jsi@57.0.6, npm:expo-notifications@57.0.15, npm:expo-secure-store@57.0.2, npm:expo-server@57.0.3, npm:expo-sharing@57.0.16, npm:expo-splash-screen@57.0.8, npm:expo-status-bar@57.0.1, npm:expo-symbols@57.0.2, npm:expo-updates-interface@57.0.1, npm:expo-web-browser@57.0.2
 ------------------------------------------------------------------------------
 The MIT License (MIT)
 
@@ -1163,7 +1184,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
 ------------------------------------------------------------------------------
-[8] Applies to: npm:@expo/code-signing-certificates@0.0.6, npm:@expo/config-types@56.0.7
+[8] Applies to: npm:@expo/code-signing-certificates@0.0.6, npm:@expo/config-types@57.0.2
 ------------------------------------------------------------------------------
 The MIT License (MIT)
 
@@ -1188,7 +1209,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
 ------------------------------------------------------------------------------
-[9] Applies to: npm:@expo/env@2.3.1, npm:@expo/env@2.4.2
+[9] Applies to: npm:@expo/env@2.4.2
 ------------------------------------------------------------------------------
 The MIT License (MIT)
 
@@ -1213,7 +1234,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
 ------------------------------------------------------------------------------
-[10] Applies to: npm:@expo/metro@56.0.0
+[10] Applies to: npm:@expo/metro@56.0.2
 ------------------------------------------------------------------------------
 MIT License
 
@@ -1239,7 +1260,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
 ------------------------------------------------------------------------------
-[11] Applies to: npm:@expo/require-utils@56.1.5, npm:@expo/require-utils@56.1.6, npm:@expo/schema-utils@56.0.2
+[11] Applies to: npm:@expo/require-utils@57.0.5, npm:@expo/schema-utils@57.0.2
 ------------------------------------------------------------------------------
 The MIT License (MIT)
 
@@ -1333,7 +1354,7 @@ ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF OR
 IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
 
 ------------------------------------------------------------------------------
-[15] Applies to: npm:@jest/schemas@29.6.3, npm:@jest/types@29.6.3, npm:babel-plugin-syntax-hermes-parser@0.33.3, npm:hermes-estree@0.33.3, npm:hermes-estree@0.35.0, npm:hermes-parser@0.33.3, npm:hermes-parser@0.35.0, npm:jest-get-type@29.6.3, npm:jest-util@29.7.0, npm:jest-validate@29.7.0, npm:jest-worker@29.7.0, npm:pretty-format@29.7.0, npm:react@19.2.3, npm:react-dom@19.2.3, npm:react-is@19.2.7, npm:react-native@0.85.3, npm:scheduler@0.27.0, npm:use-sync-external-store@1.6.0
+[15] Applies to: npm:@jest/schemas@29.6.3, npm:@jest/types@29.6.3, npm:babel-plugin-syntax-hermes-parser@0.36.0, npm:babel-plugin-syntax-hermes-parser@0.36.1, npm:hermes-estree@0.35.0, npm:hermes-estree@0.36.0, npm:hermes-estree@0.36.1, npm:hermes-parser@0.35.0, npm:hermes-parser@0.36.0, npm:hermes-parser@0.36.1, npm:jest-get-type@29.6.3, npm:jest-util@29.7.0, npm:jest-validate@29.7.0, npm:jest-worker@29.7.0, npm:pretty-format@29.7.0, npm:react@19.2.3, npm:react-dom@19.2.3, npm:react-is@19.2.7, npm:react-native@0.86.3, npm:scheduler@0.27.0, npm:use-sync-external-store@1.6.0
 ------------------------------------------------------------------------------
 MIT License
 
@@ -1529,7 +1550,32 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
 ------------------------------------------------------------------------------
-[23] Applies to: npm:@sinclair/typebox@0.27.10
+[23] Applies to: npm:@react-native-menu/menu@2.0.0
+------------------------------------------------------------------------------
+MIT License
+
+Copyright (c) 2020 Jesse Katsumata
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+
+------------------------------------------------------------------------------
+[24] Applies to: npm:@sinclair/typebox@0.27.10
 ------------------------------------------------------------------------------
 TypeBox: JSON Schema Type Builder with Static Type Resolution for TypeScript
 
@@ -1556,55 +1602,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[24] Applies to: npm:@testing-library/jest-dom@6.9.1
-------------------------------------------------------------------------------
-The MIT License (MIT)
-Copyright (c) 2017 Kent C. Dodds
-
-Permission is hereby granted, free of charge, to any person obtaining a copy
-of this software and associated documentation files (the "Software"), to deal
-in the Software without restriction, including without limitation the rights
-to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-copies of the Software, and to permit persons to whom the Software is
-furnished to do so, subject to the following conditions:
-
-The above copyright notice and this permission notice shall be included in all
-copies or substantial portions of the Software.
-
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
-SOFTWARE.
-
-------------------------------------------------------------------------------
-[25] Applies to: npm:@testing-library/user-event@14.6.1
-------------------------------------------------------------------------------
-The MIT License (MIT)
-Copyright (c) 2020 Giorgio Polvara
-
-Permission is hereby granted, free of charge, to any person obtaining a copy
-of this software and associated documentation files (the "Software"), to deal
-in the Software without restriction, including without limitation the rights
-to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-copies of the Software, and to permit persons to whom the Software is
-furnished to do so, subject to the following conditions:
-
-The above copyright notice and this permission notice shall be included in all
-copies or substantial portions of the Software.
-
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
-SOFTWARE.
-
-------------------------------------------------------------------------------
-[26] Applies to: npm:@types/istanbul-lib-coverage@2.0.6, npm:@types/istanbul-lib-report@3.0.3, npm:@types/istanbul-reports@3.0.4, npm:@types/node@25.9.5, npm:@types/pako@2.0.4, npm:@types/react@19.2.17, npm:@types/react-test-renderer@19.1.0, npm:@types/yargs@17.0.35, npm:@types/yargs-parser@21.0.3
+[25] Applies to: npm:@types/hammerjs@2.0.46, npm:@types/istanbul-lib-coverage@2.0.6, npm:@types/istanbul-lib-report@3.0.3, npm:@types/istanbul-reports@3.0.4, npm:@types/node@25.9.5, npm:@types/pako@2.0.4, npm:@types/react@19.2.17, npm:@types/react-test-renderer@19.1.0, npm:@types/yargs@17.0.35, npm:@types/yargs-parser@21.0.3
 ------------------------------------------------------------------------------
 MIT License
 
@@ -1629,7 +1627,7 @@ MIT License
     SOFTWARE
 
 ------------------------------------------------------------------------------
-[27] Applies to: npm:@ungap/structured-clone@1.3.3
+[26] Applies to: npm:@ungap/structured-clone@1.3.3
 ------------------------------------------------------------------------------
 ISC License
 
@@ -1648,7 +1646,7 @@ OR OTHER TORTIOUS ACTION, ARISING OUT OF OR IN CONNECTION WITH THE USE OR
 PERFORMANCE OF THIS SOFTWARE.
 
 ------------------------------------------------------------------------------
-[28] Applies to: npm:@xmldom/xmldom@0.8.13, npm:@xmldom/xmldom@0.9.10
+[27] Applies to: npm:@xmldom/xmldom@0.8.13, npm:@xmldom/xmldom@0.9.10
 ------------------------------------------------------------------------------
 Copyright 2019 - present Christopher J. Brody and other contributors, as listed in: https://github.com/xmldom/xmldom/graphs/contributors
 Copyright 2012 - 2017 @jindw <jindw@xidea.org> and other contributors, as listed in: https://github.com/jindw/xmldom/graphs/contributors
@@ -1660,7 +1658,7 @@ The above copyright notice and this permission notice shall be included in all c
 THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[29] Applies to: npm:abort-controller@3.0.0
+[28] Applies to: npm:abort-controller@3.0.0
 ------------------------------------------------------------------------------
 MIT License
 
@@ -1685,7 +1683,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
 ------------------------------------------------------------------------------
-[30] Applies to: npm:accepts@1.3.8, npm:accepts@2.0.0, npm:mime-types@2.1.35, npm:mime-types@3.0.2
+[29] Applies to: npm:accepts@1.3.8, npm:accepts@2.0.0, npm:mime-types@2.1.35, npm:mime-types@3.0.2
 ------------------------------------------------------------------------------
 (The MIT License)
 
@@ -1712,7 +1710,7 @@ TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
 SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[31] Applies to: npm:acorn@8.17.0
+[30] Applies to: npm:acorn@8.17.0
 ------------------------------------------------------------------------------
 MIT License
 
@@ -1737,7 +1735,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[32] Applies to: npm:agent-base@7.1.4, npm:https-proxy-agent@7.0.6
+[31] Applies to: npm:agent-base@7.1.4, npm:https-proxy-agent@7.0.6
 ------------------------------------------------------------------------------
 (The MIT License)
 
@@ -1763,7 +1761,7 @@ TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
 SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[33] Applies to: npm:agent-cli-detector@0.1.2
+[32] Applies to: npm:agent-cli-detector@0.1.6, npm:sandbox-cli-detector@0.2.0
 ------------------------------------------------------------------------------
 MIT License
 
@@ -1788,7 +1786,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
 ------------------------------------------------------------------------------
-[34] Applies to: npm:anser@1.4.10
+[33] Applies to: npm:anser@1.4.10
 ------------------------------------------------------------------------------
 The MIT License (MIT)
 
@@ -1813,7 +1811,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
 ------------------------------------------------------------------------------
-[35] Applies to: npm:ansi-escapes@4.3.2, npm:camelcase@6.3.0, npm:cli-spinners@2.9.2, npm:escape-string-regexp@4.0.0, npm:is-docker@2.2.1, npm:open@7.4.2, npm:supports-color@8.1.1, npm:wrap-ansi@7.0.0
+[34] Applies to: npm:ansi-escapes@4.3.2, npm:camelcase@6.3.0, npm:cli-spinners@2.9.2, npm:escape-string-regexp@4.0.0, npm:is-docker@2.2.1, npm:open@7.4.2, npm:supports-color@8.1.1, npm:wrap-ansi@7.0.0
 ------------------------------------------------------------------------------
 MIT License
 
@@ -1826,7 +1824,7 @@ The above copyright notice and this permission notice shall be included in all c
 THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[36] Applies to: npm:ansi-regex@4.1.1, npm:ansi-regex@5.0.1, npm:ansi-styles@3.2.1, npm:ansi-styles@4.3.0, npm:ansi-styles@5.2.0, npm:chalk@2.4.2, npm:chalk@4.1.2, npm:has-flag@3.0.0, npm:has-flag@4.0.0, npm:indent-string@4.0.0, npm:is-fullwidth-code-point@3.0.0, npm:is-plain-obj@2.1.0, npm:is-wsl@2.2.0, npm:leven@3.1.0, npm:log-symbols@2.2.0, npm:mimic-fn@1.2.0, npm:ora@3.4.0, npm:path-key@3.1.1, npm:redent@3.0.0, npm:resolve-from@5.0.0, npm:shebang-regex@3.0.0, npm:split-on-first@1.1.0, npm:string-width@4.2.3, npm:strip-ansi@5.2.0, npm:strip-ansi@6.0.1, npm:strip-indent@3.0.0, npm:supports-color@5.5.0, npm:supports-color@7.2.0, npm:terminal-link@2.1.1, npm:type-fest@0.7.1
+[35] Applies to: npm:ansi-regex@4.1.1, npm:ansi-regex@5.0.1, npm:ansi-styles@3.2.1, npm:ansi-styles@4.3.0, npm:ansi-styles@5.2.0, npm:chalk@2.4.2, npm:chalk@4.1.2, npm:has-flag@3.0.0, npm:has-flag@4.0.0, npm:is-fullwidth-code-point@3.0.0, npm:is-plain-obj@2.1.0, npm:is-wsl@2.2.0, npm:leven@3.1.0, npm:log-symbols@2.2.0, npm:mimic-fn@1.2.0, npm:ora@3.4.0, npm:path-key@3.1.1, npm:resolve-from@5.0.0, npm:shebang-regex@3.0.0, npm:split-on-first@1.1.0, npm:string-width@4.2.3, npm:strip-ansi@5.2.0, npm:strip-ansi@6.0.1, npm:supports-color@5.5.0, npm:supports-color@7.2.0, npm:terminal-link@2.1.1, npm:type-fest@0.7.1
 ------------------------------------------------------------------------------
 MIT License
 
@@ -1839,7 +1837,7 @@ The above copyright notice and this permission notice shall be included in all c
 THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[37] Applies to: npm:arg@4.1.3
+[36] Applies to: npm:arg@4.1.3
 ------------------------------------------------------------------------------
 MIT License
 
@@ -1864,7 +1862,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
 ------------------------------------------------------------------------------
-[38] Applies to: npm:arg@5.0.2
+[37] Applies to: npm:arg@5.0.2
 ------------------------------------------------------------------------------
 The MIT License (MIT)
 
@@ -1889,7 +1887,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
 ------------------------------------------------------------------------------
-[39] Applies to: npm:argparse@2.0.1
+[38] Applies to: npm:argparse@2.0.1
 ------------------------------------------------------------------------------
 A. HISTORY OF THE SOFTWARE
 ==========================
@@ -2147,7 +2145,7 @@ ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT
 OF OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
 
 ------------------------------------------------------------------------------
-[40] Applies to: npm:aria-hidden@1.2.6, npm:react-remove-scroll@2.7.2, npm:react-style-singleton@2.2.3, npm:use-callback-ref@1.3.3, npm:use-sidecar@1.1.3
+[39] Applies to: npm:aria-hidden@1.2.6, npm:react-remove-scroll@2.7.2, npm:react-style-singleton@2.2.3, npm:use-callback-ref@1.3.3, npm:use-sidecar@1.1.3
 ------------------------------------------------------------------------------
 MIT License
 
@@ -2172,212 +2170,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
 ------------------------------------------------------------------------------
-[41] Applies to: npm:aria-query@5.3.2
-------------------------------------------------------------------------------
-Apache License
-Version 2.0, January 2004
-http://www.apache.org/licenses/
-
-TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
-
-1. Definitions.
-
-"License" shall mean the terms and conditions for use, reproduction,
-and distribution as defined by Sections 1 through 9 of this document.
-
-"Licensor" shall mean the copyright owner or entity authorized by
-the copyright owner that is granting the License.
-
-"Legal Entity" shall mean the union of the acting entity and all
-other entities that control, are controlled by, or are under common
-control with that entity. For the purposes of this definition,
-"control" means (i) the power, direct or indirect, to cause the
-direction or management of such entity, whether by contract or
-otherwise, or (ii) ownership of fifty percent (50%) or more of the
-outstanding shares, or (iii) beneficial ownership of such entity.
-
-"You" (or "Your") shall mean an individual or Legal Entity
-exercising permissions granted by this License.
-
-"Source" form shall mean the preferred form for making modifications,
-including but not limited to software source code, documentation
-source, and configuration files.
-
-"Object" form shall mean any form resulting from mechanical
-transformation or translation of a Source form, including but
-not limited to compiled object code, generated documentation,
-and conversions to other media types.
-
-"Work" shall mean the work of authorship, whether in Source or
-Object form, made available under the License, as indicated by a
-copyright notice that is included in or attached to the work
-(an example is provided in the Appendix below).
-
-"Derivative Works" shall mean any work, whether in Source or Object
-form, that is based on (or derived from) the Work and for which the
-editorial revisions, annotations, elaborations, or other modifications
-represent, as a whole, an original work of authorship. For the purposes
-of this License, Derivative Works shall not include works that remain
-separable from, or merely link (or bind by name) to the interfaces of,
-the Work and Derivative Works thereof.
-
-"Contribution" shall mean any work of authorship, including
-the original version of the Work and any modifications or additions
-to that Work or Derivative Works thereof, that is intentionally
-submitted to Licensor for inclusion in the Work by the copyright owner
-or by an individual or Legal Entity authorized to submit on behalf of
-the copyright owner. For the purposes of this definition, "submitted"
-means any form of electronic, verbal, or written communication sent
-to the Licensor or its representatives, including but not limited to
-communication on electronic mailing lists, source code control systems,
-and issue tracking systems that are managed by, or on behalf of, the
-Licensor for the purpose of discussing and improving the Work, but
-excluding communication that is conspicuously marked or otherwise
-designated in writing by the copyright owner as "Not a Contribution."
-
-"Contributor" shall mean Licensor and any individual or Legal Entity
-on behalf of whom a Contribution has been received by Licensor and
-subsequently incorporated within the Work.
-
-2. Grant of Copyright License. Subject to the terms and conditions of
-this License, each Contributor hereby grants to You a perpetual,
-worldwide, non-exclusive, no-charge, royalty-free, irrevocable
-copyright license to reproduce, prepare Derivative Works of,
-publicly display, publicly perform, sublicense, and distribute the
-Work and such Derivative Works in Source or Object form.
-
-3. Grant of Patent License. Subject to the terms and conditions of
-this License, each Contributor hereby grants to You a perpetual,
-worldwide, non-exclusive, no-charge, royalty-free, irrevocable
-(except as stated in this section) patent license to make, have made,
-use, offer to sell, sell, import, and otherwise transfer the Work,
-where such license applies only to those patent claims licensable
-by such Contributor that are necessarily infringed by their
-Contribution(s) alone or by combination of their Contribution(s)
-with the Work to which such Contribution(s) was submitted. If You
-institute patent litigation against any entity (including a
-cross-claim or counterclaim in a lawsuit) alleging that the Work
-or a Contribution incorporated within the Work constitutes direct
-or contributory patent infringement, then any patent licenses
-granted to You under this License for that Work shall terminate
-as of the date such litigation is filed.
-
-4. Redistribution. You may reproduce and distribute copies of the
-Work or Derivative Works thereof in any medium, with or without
-modifications, and in Source or Object form, provided that You
-meet the following conditions:
-
-(a) You must give any other recipients of the Work or
-Derivative Works a copy of this License; and
-
-(b) You must cause any modified files to carry prominent notices
-stating that You changed the files; and
-
-(c) You must retain, in the Source form of any Derivative Works
-that You distribute, all copyright, patent, trademark, and
-attribution notices from the Source form of the Work,
-excluding those notices that do not pertain to any part of
-the Derivative Works; and
-
-(d) If the Work includes a "NOTICE" text file as part of its
-distribution, then any Derivative Works that You distribute must
-include a readable copy of the attribution notices contained
-within such NOTICE file, excluding those notices that do not
-pertain to any part of the Derivative Works, in at least one
-of the following places: within a NOTICE text file distributed
-as part of the Derivative Works; within the Source form or
-documentation, if provided along with the Derivative Works; or,
-within a display generated by the Derivative Works, if and
-wherever such third-party notices normally appear. The contents
-of the NOTICE file are for informational purposes only and
-do not modify the License. You may add Your own attribution
-notices within Derivative Works that You distribute, alongside
-or as an addendum to the NOTICE text from the Work, provided
-that such additional attribution notices cannot be construed
-as modifying the License.
-
-You may add Your own copyright statement to Your modifications and
-may provide additional or different license terms and conditions
-for use, reproduction, or distribution of Your modifications, or
-for any such Derivative Works as a whole, provided Your use,
-reproduction, and distribution of the Work otherwise complies with
-the conditions stated in this License.
-
-5. Submission of Contributions. Unless You explicitly state otherwise,
-any Contribution intentionally submitted for inclusion in the Work
-by You to the Licensor shall be under the terms and conditions of
-this License, without any additional terms or conditions.
-Notwithstanding the above, nothing herein shall supersede or modify
-the terms of any separate license agreement you may have executed
-with Licensor regarding such Contributions.
-
-6. Trademarks. This License does not grant permission to use the trade
-names, trademarks, service marks, or product names of the Licensor,
-except as required for reasonable and customary use in describing the
-origin of the Work and reproducing the content of the NOTICE file.
-
-7. Disclaimer of Warranty. Unless required by applicable law or
-agreed to in writing, Licensor provides the Work (and each
-Contributor provides its Contributions) on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
-implied, including, without limitation, any warranties or conditions
-of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
-PARTICULAR PURPOSE. You are solely responsible for determining the
-appropriateness of using or redistributing the Work and assume any
-risks associated with Your exercise of permissions under this License.
-
-8. Limitation of Liability. In no event and under no legal theory,
-whether in tort (including negligence), contract, or otherwise,
-unless required by applicable law (such as deliberate and grossly
-negligent acts) or agreed to in writing, shall any Contributor be
-liable to You for damages, including any direct, indirect, special,
-incidental, or consequential damages of any character arising as a
-result of this License or out of the use or inability to use the
-Work (including but not limited to damages for loss of goodwill,
-work stoppage, computer failure or malfunction, or any and all
-other commercial damages or losses), even if such Contributor
-has been advised of the possibility of such damages.
-
-9. Accepting Warranty or Additional Liability. While redistributing
-the Work or Derivative Works thereof, You may choose to offer,
-and charge a fee for, acceptance of support, warranty, indemnity,
-or other liability obligations and/or rights consistent with this
-License. However, in accepting such obligations, You may act only
-on Your own behalf and on Your sole responsibility, not on behalf
-of any other Contributor, and only if You agree to indemnify,
-defend, and hold each Contributor harmless for any liability
-incurred by, or claims asserted against, such Contributor by reason
-of your accepting any such warranty or additional liability.
-
-END OF TERMS AND CONDITIONS
-
-APPENDIX: How to apply the Apache License to your work.
-
-To apply the Apache License to your work, attach the following
-boilerplate notice, with the fields enclosed by brackets "{}"
-replaced with your own identifying information. (Don't include
-the brackets!)  The text should be enclosed in the appropriate
-comment syntax for the file format. We also recommend that a
-file or class name and description of purpose be included on the
-same "printed page" as the copyright notice for easier
-identification within third-party archives.
-
-Copyright 2020 A11yance
-
-Licensed under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License.
-You may obtain a copy of the License at
-
-http://www.apache.org/licenses/LICENSE-2.0
-
-Unless required by applicable law or agreed to in writing, software
-distributed under the License is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-See the License for the specific language governing permissions and
-limitations under the License.
-
-------------------------------------------------------------------------------
-[42] Applies to: npm:asap@2.0.6
+[40] Applies to: npm:asap@2.0.6
 ------------------------------------------------------------------------------
 Copyright 2009–2014 Contributors. All rights reserved.
 
@@ -2400,7 +2193,7 @@ FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
 IN THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[43] Applies to: npm:babel-plugin-react-native-web@0.21.2
+[41] Applies to: npm:babel-plugin-react-native-web@0.21.2
 ------------------------------------------------------------------------------
 MIT License
 
@@ -2425,7 +2218,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
 ------------------------------------------------------------------------------
-[44] Applies to: npm:babel-plugin-transform-flow-enums@0.0.2, npm:flow-enums-runtime@0.0.6, npm:react-is@18.3.1, npm:react-refresh@0.14.2
+[42] Applies to: npm:babel-plugin-transform-flow-enums@0.0.2, npm:flow-enums-runtime@0.0.6, npm:react-is@16.13.1, npm:react-is@18.3.1, npm:react-refresh@0.14.2
 ------------------------------------------------------------------------------
 MIT License
 
@@ -2450,7 +2243,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
 ------------------------------------------------------------------------------
-[45] Applies to: npm:balanced-match@4.0.4
+[43] Applies to: npm:balanced-match@4.0.4
 ------------------------------------------------------------------------------
 (MIT)
 
@@ -2477,7 +2270,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
 ------------------------------------------------------------------------------
-[46] Applies to: npm:base64-js@1.5.1
+[44] Applies to: npm:base64-js@1.5.1
 ------------------------------------------------------------------------------
 The MIT License (MIT)
 
@@ -2502,7 +2295,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[47] Applies to: npm:baseline-browser-mapping@2.10.43, npm:xcode@3.0.1
+[45] Applies to: npm:baseline-browser-mapping@2.10.43, npm:xcode@3.0.1
 ------------------------------------------------------------------------------
 Apache License
                            Version 2.0, January 2004
@@ -2707,7 +2500,7 @@ Apache License
    limitations under the License.
 
 ------------------------------------------------------------------------------
-[48] Applies to: npm:big-integer@1.6.52
+[46] Applies to: npm:big-integer@1.6.52
 ------------------------------------------------------------------------------
 This is free and unencumbered software released into the public domain.
 
@@ -2735,7 +2528,7 @@ OTHER DEALINGS IN THE SOFTWARE.
 For more information, please refer to <http://unlicense.org>
 
 ------------------------------------------------------------------------------
-[49] Applies to: npm:bplist-creator@0.1.0
+[47] Applies to: npm:bplist-creator@0.1.0
 ------------------------------------------------------------------------------
 (The MIT License)
 
@@ -2757,7 +2550,7 @@ WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN 
 OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[50] Applies to: npm:brace-expansion@5.0.8
+[48] Applies to: npm:brace-expansion@5.0.8
 ------------------------------------------------------------------------------
 MIT License
 
@@ -2784,7 +2577,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
 ------------------------------------------------------------------------------
-[51] Applies to: npm:braces@3.0.3, npm:fill-range@7.1.1, npm:is-number@7.0.0, npm:micromatch@4.0.8
+[49] Applies to: npm:braces@3.0.3, npm:fill-range@7.1.1, npm:is-number@7.0.0, npm:micromatch@4.0.8
 ------------------------------------------------------------------------------
 The MIT License (MIT)
 
@@ -2809,7 +2602,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[52] Applies to: npm:browserslist@4.28.6
+[50] Applies to: npm:browserslist@4.28.6
 ------------------------------------------------------------------------------
 The MIT License (MIT)
 
@@ -2833,7 +2626,7 @@ IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
 CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[53] Applies to: npm:buffer-from@1.1.2
+[51] Applies to: npm:buffer-from@1.1.2
 ------------------------------------------------------------------------------
 MIT License
 
@@ -2858,7 +2651,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
 ------------------------------------------------------------------------------
-[54] Applies to: npm:bytes@3.1.2
+[52] Applies to: npm:bytes@3.1.2
 ------------------------------------------------------------------------------
 (The MIT License)
 
@@ -2885,7 +2678,7 @@ TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
 SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[55] Applies to: npm:caniuse-lite@1.0.30001805
+[53] Applies to: npm:caniuse-lite@1.0.30001805
 ------------------------------------------------------------------------------
 Attribution 4.0 International
 
@@ -3284,7 +3077,7 @@ public licenses.
 Creative Commons may be contacted at creativecommons.org.
 
 ------------------------------------------------------------------------------
-[56] Applies to: npm:chrome-launcher@0.15.2, npm:chromium-edge-launcher@0.3.0, npm:lighthouse-logger@1.4.2
+[54] Applies to: npm:chrome-launcher@0.15.2, npm:chromium-edge-launcher@0.3.0, npm:lighthouse-logger@1.4.2
 ------------------------------------------------------------------------------
 Apache License
                            Version 2.0, January 2004
@@ -3489,7 +3282,7 @@ Apache License
    limitations under the License.
 
 ------------------------------------------------------------------------------
-[57] Applies to: npm:ci-info@2.0.0
+[55] Applies to: npm:ci-info@2.0.0
 ------------------------------------------------------------------------------
 The MIT License (MIT)
 
@@ -3514,7 +3307,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
 ------------------------------------------------------------------------------
-[58] Applies to: npm:ci-info@3.9.0
+[56] Applies to: npm:ci-info@3.9.0
 ------------------------------------------------------------------------------
 The MIT License (MIT)
 
@@ -3539,7 +3332,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
 ------------------------------------------------------------------------------
-[59] Applies to: npm:cli-cursor@2.1.0, npm:escape-string-regexp@1.0.5, npm:filter-obj@1.1.0, npm:object-assign@4.1.1, npm:onetime@2.0.1, npm:restore-cursor@2.0.0, npm:serialize-error@2.1.0
+[57] Applies to: npm:cli-cursor@2.1.0, npm:escape-string-regexp@1.0.5, npm:filter-obj@1.1.0, npm:object-assign@4.1.1, npm:onetime@2.0.1, npm:restore-cursor@2.0.0, npm:serialize-error@2.1.0
 ------------------------------------------------------------------------------
 The MIT License (MIT)
 
@@ -3564,7 +3357,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[60] Applies to: npm:cliui@8.0.1
+[58] Applies to: npm:cliui@8.0.1
 ------------------------------------------------------------------------------
 Copyright (c) 2015, Contributors
 
@@ -3582,7 +3375,7 @@ WHETHER IN AN ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION,
 ARISING OUT OF OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
 
 ------------------------------------------------------------------------------
-[61] Applies to: npm:clone@1.0.4
+[59] Applies to: npm:clone@1.0.4
 ------------------------------------------------------------------------------
 Copyright © 2011-2015 Paul Vorbach <paul@vorba.ch>
 
@@ -3604,7 +3397,7 @@ IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, OUT OF OR IN CONNECTION WITH THE
 SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[62] Applies to: npm:color@4.2.3
+[60] Applies to: npm:color@4.2.3
 ------------------------------------------------------------------------------
 Copyright (c) 2012 Heather Arthur
 
@@ -3628,7 +3421,7 @@ OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
 WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[63] Applies to: npm:color-convert@1.9.3, npm:color-convert@2.0.1
+[61] Applies to: npm:color-convert@1.9.3, npm:color-convert@2.0.1
 ------------------------------------------------------------------------------
 Copyright (c) 2011-2016 Heather Arthur <fayearthur@gmail.com>
 
@@ -3652,7 +3445,7 @@ OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
 WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[64] Applies to: npm:color-name@1.1.3, npm:color-name@1.1.4
+[62] Applies to: npm:color-name@1.1.3, npm:color-name@1.1.4
 ------------------------------------------------------------------------------
 The MIT License (MIT)
 Copyright (c) 2015 Dmitry Ivanov
@@ -3664,7 +3457,7 @@ The above copyright notice and this permission notice shall be included in all c
 THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[65] Applies to: npm:color-string@1.9.1
+[63] Applies to: npm:color-string@1.9.1
 ------------------------------------------------------------------------------
 Copyright (c) 2011 Heather Arthur <fayearthur@gmail.com>
 
@@ -3688,7 +3481,7 @@ OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
 WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[66] Applies to: npm:commander@12.1.0, npm:commander@2.20.3, npm:commander@7.2.0
+[64] Applies to: npm:commander@12.1.0, npm:commander@2.20.3, npm:commander@7.2.0
 ------------------------------------------------------------------------------
 (The MIT License)
 
@@ -3714,7 +3507,7 @@ TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
 SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[67] Applies to: npm:compressible@2.0.18
+[65] Applies to: npm:compressible@2.0.18
 ------------------------------------------------------------------------------
 (The MIT License)
 
@@ -3742,7 +3535,7 @@ TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
 SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[68] Applies to: npm:compression@1.8.1
+[66] Applies to: npm:compression@1.8.1
 ------------------------------------------------------------------------------
 (The MIT License)
 
@@ -3769,7 +3562,7 @@ TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
 SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[69] Applies to: npm:connect@3.7.0
+[67] Applies to: npm:connect@3.7.0
 ------------------------------------------------------------------------------
 (The MIT License)
 
@@ -3798,7 +3591,7 @@ TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
 SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[70] Applies to: npm:convert-source-map@2.0.0
+[68] Applies to: npm:convert-source-map@2.0.0
 ------------------------------------------------------------------------------
 Copyright 2013 Thorsten Lorenz.
 All rights reserved.
@@ -3825,7 +3618,7 @@ FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
 OTHER DEALINGS IN THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[71] Applies to: npm:core-js-compat@3.49.0
+[69] Applies to: npm:core-js-compat@3.49.0
 ------------------------------------------------------------------------------
 Copyright (c) 2013–2025 Denis Pushkarev (zloirock.ru)
 Copyright (c) 2025–2026 CoreJS Company (core-js.io)
@@ -3849,7 +3642,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[72] Applies to: npm:cross-fetch@3.2.0
+[70] Applies to: npm:cross-fetch@3.2.0
 ------------------------------------------------------------------------------
 The MIT License (MIT)
 
@@ -3874,7 +3667,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
 ------------------------------------------------------------------------------
-[73] Applies to: npm:cross-spawn@7.0.6
+[71] Applies to: npm:cross-spawn@7.0.6
 ------------------------------------------------------------------------------
 The MIT License (MIT)
 
@@ -3899,7 +3692,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[74] Applies to: npm:css-in-js-utils@3.1.0
+[72] Applies to: npm:css-in-js-utils@3.1.0
 ------------------------------------------------------------------------------
 MIT License
 
@@ -3924,7 +3717,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
 ------------------------------------------------------------------------------
-[75] Applies to: npm:css-select@5.2.2, npm:css-what@6.2.2, npm:domelementtype@2.3.0, npm:domhandler@5.0.3, npm:domutils@3.2.2, npm:entities@4.5.0, npm:nth-check@2.1.1
+[73] Applies to: npm:css-select@5.2.2, npm:css-what@6.2.2, npm:domelementtype@2.3.0, npm:domhandler@5.0.3, npm:domutils@3.2.2, npm:entities@4.5.0, npm:nth-check@2.1.1
 ------------------------------------------------------------------------------
 Copyright (c) Felix Böhm
 All rights reserved.
@@ -3939,7 +3732,7 @@ THIS IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRE
 EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 ------------------------------------------------------------------------------
-[76] Applies to: npm:css-tree@1.1.3
+[74] Applies to: npm:css-tree@1.1.3
 ------------------------------------------------------------------------------
 Copyright (C) 2016-2019 by Roman Dvornov
 
@@ -3962,31 +3755,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[77] Applies to: npm:css.escape@1.5.1, npm:emoji-regex@8.0.0, npm:jsesc@3.1.0, npm:regenerate@1.4.2, npm:regenerate-unicode-properties@10.2.2, npm:regexpu-core@6.4.0, npm:unicode-canonical-property-names-ecmascript@2.0.1, npm:unicode-match-property-ecmascript@2.0.0, npm:unicode-match-property-value-ecmascript@2.2.1, npm:unicode-property-aliases-ecmascript@2.2.0
-------------------------------------------------------------------------------
-Copyright Mathias Bynens <https://mathiasbynens.be/>
-
-Permission is hereby granted, free of charge, to any person obtaining
-a copy of this software and associated documentation files (the
-"Software"), to deal in the Software without restriction, including
-without limitation the rights to use, copy, modify, merge, publish,
-distribute, sublicense, and/or sell copies of the Software, and to
-permit persons to whom the Software is furnished to do so, subject to
-the following conditions:
-
-The above copyright notice and this permission notice shall be
-included in all copies or substantial portions of the Software.
-
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
-EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
-MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
-NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
-LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
-OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
-WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
-
-------------------------------------------------------------------------------
-[78] Applies to: npm:csstype@3.2.3
+[75] Applies to: npm:csstype@3.2.3
 ------------------------------------------------------------------------------
 Copyright (c) 2017-2018 Fredrik Nicol
 
@@ -4009,7 +3778,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
 ------------------------------------------------------------------------------
-[79] Applies to: npm:debug@2.6.9, npm:debug@3.2.7
+[76] Applies to: npm:debug@2.6.9, npm:debug@3.2.7
 ------------------------------------------------------------------------------
 (The MIT License)
 
@@ -4031,7 +3800,7 @@ WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN 
 SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[80] Applies to: npm:debug@4.4.3
+[77] Applies to: npm:debug@4.4.3
 ------------------------------------------------------------------------------
 (The MIT License)
 
@@ -4054,7 +3823,7 @@ WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN 
 SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[81] Applies to: npm:decode-uri-component@0.2.2
+[78] Applies to: npm:decode-uri-component@0.2.2
 ------------------------------------------------------------------------------
 The MIT License (MIT)
 
@@ -4067,7 +3836,7 @@ The above copyright notice and this permission notice shall be included in all c
 THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[82] Applies to: npm:deepmerge@4.3.1
+[79] Applies to: npm:deepmerge@4.3.1
 ------------------------------------------------------------------------------
 The MIT License (MIT)
 
@@ -4092,7 +3861,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[83] Applies to: npm:defaults@1.0.4
+[80] Applies to: npm:defaults@1.0.4
 ------------------------------------------------------------------------------
 The MIT License (MIT)
 
@@ -4118,7 +3887,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[84] Applies to: npm:depd@2.0.0
+[81] Applies to: npm:depd@2.0.0
 ------------------------------------------------------------------------------
 (The MIT License)
 
@@ -4144,7 +3913,7 @@ TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
 SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[85] Applies to: npm:destroy@1.2.0
+[82] Applies to: npm:destroy@1.2.0
 ------------------------------------------------------------------------------
 The MIT License (MIT)
 
@@ -4170,7 +3939,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[86] Applies to: npm:detect-libc@2.1.2
+[83] Applies to: npm:detect-libc@2.1.2
 ------------------------------------------------------------------------------
 Apache License
                            Version 2.0, January 2004
@@ -4375,7 +4144,7 @@ Apache License
    limitations under the License.
 
 ------------------------------------------------------------------------------
-[87] Applies to: npm:detect-node-es@1.1.0
+[84] Applies to: npm:detect-node-es@1.1.0
 ------------------------------------------------------------------------------
 MIT License
 
@@ -4400,7 +4169,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
 ------------------------------------------------------------------------------
-[88] Applies to: npm:dnssd-advertise@1.1.6, npm:multitars@1.0.0, npm:toqr@0.1.1
+[85] Applies to: npm:dnssd-advertise@1.1.6, npm:multitars@1.0.2, npm:toqr@0.1.1
 ------------------------------------------------------------------------------
 MIT License
 
@@ -4426,32 +4195,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
 ------------------------------------------------------------------------------
-[89] Applies to: npm:dom-accessibility-api@0.6.3
-------------------------------------------------------------------------------
-MIT License
-
-Copyright (c) 2020 Sebastian Silbermann
-
-Permission is hereby granted, free of charge, to any person obtaining a copy
-of this software and associated documentation files (the "Software"), to deal
-in the Software without restriction, including without limitation the rights
-to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-copies of the Software, and to permit persons to whom the Software is
-furnished to do so, subject to the following conditions:
-
-The above copyright notice and this permission notice shall be included in all
-copies or substantial portions of the Software.
-
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
-SOFTWARE.
-
-------------------------------------------------------------------------------
-[90] Applies to: npm:dom-serializer@2.0.0
+[86] Applies to: npm:dom-serializer@2.0.0
 ------------------------------------------------------------------------------
 License
 
@@ -4466,7 +4210,7 @@ The above copyright notice and this permission notice shall be included in all c
 THE SOFTWARE IS PROVIDED 'AS IS', WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[91] Applies to: npm:ee-first@1.1.1
+[87] Applies to: npm:ee-first@1.1.1
 ------------------------------------------------------------------------------
 The MIT License (MIT)
 
@@ -4491,7 +4235,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[92] Applies to: npm:electron-to-chromium@1.5.392
+[88] Applies to: npm:electron-to-chromium@1.5.392
 ------------------------------------------------------------------------------
 Copyright 2018 Kilian Valkhof
 
@@ -4500,7 +4244,31 @@ Permission to use, copy, modify, and/or distribute this software for any purpose
 THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
 
 ------------------------------------------------------------------------------
-[93] Applies to: npm:encodeurl@1.0.2, npm:encodeurl@2.0.0
+[89] Applies to: npm:emoji-regex@8.0.0, npm:jsesc@3.1.0, npm:regenerate@1.4.2, npm:regenerate-unicode-properties@10.2.2, npm:regexpu-core@6.4.0, npm:unicode-canonical-property-names-ecmascript@2.0.1, npm:unicode-match-property-ecmascript@2.0.0, npm:unicode-match-property-value-ecmascript@2.2.1, npm:unicode-property-aliases-ecmascript@2.2.0
+------------------------------------------------------------------------------
+Copyright Mathias Bynens <https://mathiasbynens.be/>
+
+Permission is hereby granted, free of charge, to any person obtaining
+a copy of this software and associated documentation files (the
+"Software"), to deal in the Software without restriction, including
+without limitation the rights to use, copy, modify, merge, publish,
+distribute, sublicense, and/or sell copies of the Software, and to
+permit persons to whom the Software is furnished to do so, subject to
+the following conditions:
+
+The above copyright notice and this permission notice shall be
+included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+------------------------------------------------------------------------------
+[90] Applies to: npm:encodeurl@1.0.2, npm:encodeurl@2.0.0
 ------------------------------------------------------------------------------
 (The MIT License)
 
@@ -4526,7 +4294,7 @@ TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
 SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[94] Applies to: npm:error-stack-parser@2.1.4, npm:stackframe@1.3.4
+[91] Applies to: npm:error-stack-parser@2.1.4, npm:stackframe@1.3.4
 ------------------------------------------------------------------------------
 Copyright (c) 2017 Eric Wendelin and other contributors
 
@@ -4549,7 +4317,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
 ------------------------------------------------------------------------------
-[95] Applies to: npm:es-errors@1.3.0
+[92] Applies to: npm:es-errors@1.3.0
 ------------------------------------------------------------------------------
 MIT License
 
@@ -4574,7 +4342,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
 ------------------------------------------------------------------------------
-[96] Applies to: npm:escalade@3.2.0
+[93] Applies to: npm:escalade@3.2.0
 ------------------------------------------------------------------------------
 MIT License
 
@@ -4587,7 +4355,7 @@ The above copyright notice and this permission notice shall be included in all c
 THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[97] Applies to: npm:escape-html@1.0.3
+[94] Applies to: npm:escape-html@1.0.3
 ------------------------------------------------------------------------------
 (The MIT License)
 
@@ -4615,7 +4383,7 @@ TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
 SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[98] Applies to: npm:etag@1.8.1
+[95] Applies to: npm:etag@1.8.1
 ------------------------------------------------------------------------------
 (The MIT License)
 
@@ -4641,7 +4409,7 @@ TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
 SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[99] Applies to: npm:event-target-shim@5.0.1
+[96] Applies to: npm:event-target-shim@5.0.1
 ------------------------------------------------------------------------------
 The MIT License (MIT)
 
@@ -4666,7 +4434,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
 ------------------------------------------------------------------------------
-[100] Applies to: npm:expo-paste-input@0.2.2
+[97] Applies to: npm:expo-paste-input@0.2.2
 ------------------------------------------------------------------------------
 MIT License
 
@@ -4691,7 +4459,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
 ------------------------------------------------------------------------------
-[101] Applies to: npm:exponential-backoff@3.1.3
+[98] Applies to: npm:exponential-backoff@3.1.3
 ------------------------------------------------------------------------------
 Apache License
                            Version 2.0, January 2004
@@ -4896,7 +4664,7 @@ Apache License
    limitations under the License.
 
 ------------------------------------------------------------------------------
-[102] Applies to: npm:fast-deep-equal@3.1.3
+[99] Applies to: npm:fast-deep-equal@3.1.3
 ------------------------------------------------------------------------------
 MIT License
 
@@ -4921,7 +4689,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
 ------------------------------------------------------------------------------
-[103] Applies to: npm:fbjs@3.0.5, npm:fbjs-css-vars@1.0.2, npm:invariant@2.2.4
+[100] Applies to: npm:fbjs@3.0.5, npm:fbjs-css-vars@1.0.2, npm:invariant@2.2.4
 ------------------------------------------------------------------------------
 MIT License
 
@@ -4946,7 +4714,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
 ------------------------------------------------------------------------------
-[104] Applies to: npm:fdir@6.5.0
+[101] Applies to: npm:fdir@6.5.0
 ------------------------------------------------------------------------------
 Copyright 2023 Abdullah Atta
 
@@ -4957,7 +4725,7 @@ The above copyright notice and this permission notice shall be included in all c
 THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[105] Applies to: npm:fetch-nodeshim@0.4.10
+[102] Applies to: npm:fetch-nodeshim@0.4.10
 ------------------------------------------------------------------------------
 MIT License
 
@@ -4986,7 +4754,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
 ------------------------------------------------------------------------------
-[106] Applies to: npm:finalhandler@1.1.2
+[103] Applies to: npm:finalhandler@1.1.2
 ------------------------------------------------------------------------------
 (The MIT License)
 
@@ -5012,7 +4780,7 @@ TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
 SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[107] Applies to: npm:fontfaceobserver@2.3.0
+[104] Applies to: npm:fontfaceobserver@2.3.0
 ------------------------------------------------------------------------------
 Copyright (c) 2014 - Bram Stein
 
@@ -5037,7 +4805,7 @@ ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
 SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 ------------------------------------------------------------------------------
-[108] Applies to: npm:fresh@0.5.2
+[105] Applies to: npm:fresh@0.5.2
 ------------------------------------------------------------------------------
 (The MIT License)
 
@@ -5064,7 +4832,7 @@ TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
 SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[109] Applies to: npm:function-bind@1.1.2
+[106] Applies to: npm:function-bind@1.1.2
 ------------------------------------------------------------------------------
 Copyright (c) 2013 Raynos.
 
@@ -5087,7 +4855,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[110] Applies to: npm:gensync@1.0.0-beta.2
+[107] Applies to: npm:gensync@1.0.0-beta.2
 ------------------------------------------------------------------------------
 Copyright 2018 Logan Smyth <loganfsmyth@gmail.com>
 
@@ -5098,7 +4866,7 @@ The above copyright notice and this permission notice shall be included in all c
 THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[111] Applies to: npm:get-caller-file@2.0.5
+[108] Applies to: npm:get-caller-file@2.0.5
 ------------------------------------------------------------------------------
 ISC License (ISC)
 Copyright 2018 Stefan Penner
@@ -5108,7 +4876,7 @@ Permission to use, copy, modify, and/or distribute this software for any purpose
 THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
 
 ------------------------------------------------------------------------------
-[112] Applies to: npm:get-nonce@1.0.1
+[109] Applies to: npm:get-nonce@1.0.1
 ------------------------------------------------------------------------------
 MIT License
 
@@ -5133,7 +4901,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
 ------------------------------------------------------------------------------
-[113] Applies to: npm:getenv@2.0.0
+[110] Applies to: npm:getenv@2.0.0
 ------------------------------------------------------------------------------
 The MIT License (MIT)
 Copyright (c) 2012-2019 Christoph Tavan <dev@tavan.de>
@@ -5157,7 +4925,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
 ------------------------------------------------------------------------------
-[114] Applies to: npm:glob@13.0.6
+[111] Applies to: npm:glob@13.0.6
 ------------------------------------------------------------------------------
 All packages under `src/` are licensed according to the terms in
 their respective `LICENSE` or `LICENSE.md` files.
@@ -5224,7 +4992,7 @@ will be liable to anyone for any damages related to this
 software or this license, under any kind of legal claim.***
 
 ------------------------------------------------------------------------------
-[115] Applies to: npm:graceful-fs@4.2.11
+[112] Applies to: npm:graceful-fs@4.2.11
 ------------------------------------------------------------------------------
 The ISC License
 
@@ -5243,7 +5011,7 @@ ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF OR
 IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
 
 ------------------------------------------------------------------------------
-[116] Applies to: npm:hasown@2.0.4
+[113] Applies to: npm:hasown@2.0.4
 ------------------------------------------------------------------------------
 MIT License
 
@@ -5268,7 +5036,40 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
 ------------------------------------------------------------------------------
-[117] Applies to: npm:hosted-git-info@7.0.2
+[114] Applies to: npm:hoist-non-react-statics@3.3.2
+------------------------------------------------------------------------------
+Software License Agreement (BSD License)
+========================================
+
+Copyright (c) 2015, Yahoo! Inc. All rights reserved.
+----------------------------------------------------
+
+Redistribution and use of this software in source and binary forms, with or
+without modification, are permitted provided that the following conditions are
+met:
+
+  * Redistributions of source code must retain the above copyright notice, this
+    list of conditions and the following disclaimer.
+  * Redistributions in binary form must reproduce the above copyright notice,
+    this list of conditions and the following disclaimer in the documentation
+    and/or other materials provided with the distribution.
+  * Neither the name of Yahoo! Inc. nor the names of YUI's contributors may be
+    used to endorse or promote products derived from this software without
+    specific prior written permission of Yahoo! Inc.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+(INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+------------------------------------------------------------------------------
+[115] Applies to: npm:hosted-git-info@7.0.2
 ------------------------------------------------------------------------------
 Copyright (c) 2015, Rebecca Turner
 
@@ -5285,7 +5086,7 @@ OTHER TORTIOUS ACTION, ARISING OUT OF OR IN CONNECTION WITH THE USE OR
 PERFORMANCE OF THIS SOFTWARE.
 
 ------------------------------------------------------------------------------
-[118] Applies to: npm:http-errors@2.0.1
+[116] Applies to: npm:http-errors@2.0.1
 ------------------------------------------------------------------------------
 The MIT License (MIT)
 
@@ -5311,7 +5112,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[119] Applies to: npm:hyphenate-style-name@1.1.0
+[117] Applies to: npm:hyphenate-style-name@1.1.0
 ------------------------------------------------------------------------------
 BSD 3-Clause License
 
@@ -5344,7 +5145,7 @@ OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 ------------------------------------------------------------------------------
-[120] Applies to: npm:i18next@26.3.6
+[118] Applies to: npm:i18next@26.3.6
 ------------------------------------------------------------------------------
 The MIT License (MIT)
 
@@ -5369,7 +5170,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
 ------------------------------------------------------------------------------
-[121] Applies to: npm:ignore@5.3.2
+[119] Applies to: npm:ignore@5.3.2
 ------------------------------------------------------------------------------
 Copyright (c) 2013 Kael Zhang <i@kael.me>, contributors
 http://kael.me/
@@ -5394,7 +5195,7 @@ OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
 WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[122] Applies to: npm:image-size@1.2.1
+[120] Applies to: npm:image-size@1.2.1
 ------------------------------------------------------------------------------
 The MIT License (MIT)
 
@@ -5407,7 +5208,7 @@ The above copyright notice and this permission notice shall be included in all c
 THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[123] Applies to: npm:inherits@2.0.4
+[121] Applies to: npm:inherits@2.0.4
 ------------------------------------------------------------------------------
 The ISC License
 
@@ -5426,7 +5227,7 @@ OTHER TORTIOUS ACTION, ARISING OUT OF OR IN CONNECTION WITH THE USE OR
 PERFORMANCE OF THIS SOFTWARE.
 
 ------------------------------------------------------------------------------
-[124] Applies to: npm:inline-style-prefixer@7.0.1
+[122] Applies to: npm:inline-style-prefixer@7.0.1
 ------------------------------------------------------------------------------
 The MIT License (MIT)
 
@@ -5451,7 +5252,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
 ------------------------------------------------------------------------------
-[125] Applies to: npm:is-arrayish@0.3.4
+[123] Applies to: npm:is-arrayish@0.3.4
 ------------------------------------------------------------------------------
 The MIT License (MIT)
 
@@ -5476,7 +5277,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[126] Applies to: npm:is-core-module@2.16.2
+[124] Applies to: npm:is-core-module@2.16.2
 ------------------------------------------------------------------------------
 The MIT License (MIT)
 
@@ -5500,7 +5301,7 @@ IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
 CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[127] Applies to: npm:isexe@2.0.0, npm:lru-cache@5.1.1, npm:semver@6.3.1, npm:semver@7.8.5, npm:which@2.0.2, npm:yallist@3.1.1
+[125] Applies to: npm:isexe@2.0.0, npm:lru-cache@5.1.1, npm:semver@6.3.1, npm:semver@7.8.5, npm:which@2.0.2, npm:yallist@3.1.1
 ------------------------------------------------------------------------------
 The ISC License
 
@@ -5519,7 +5320,7 @@ ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF OR
 IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
 
 ------------------------------------------------------------------------------
-[128] Applies to: npm:js-tokens@4.0.0
+[126] Applies to: npm:js-tokens@4.0.0
 ------------------------------------------------------------------------------
 The MIT License (MIT)
 
@@ -5544,7 +5345,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[129] Applies to: npm:js-yaml@4.3.0
+[127] Applies to: npm:js-yaml@4.3.0
 ------------------------------------------------------------------------------
 (The MIT License)
 
@@ -5569,7 +5370,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[130] Applies to: npm:jsc-safe-url@0.2.4
+[128] Applies to: npm:jsc-safe-url@0.2.4
 ------------------------------------------------------------------------------
 Zero-Clause BSD
 =============
@@ -5586,7 +5387,7 @@ AN ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT
 OF OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
 
 ------------------------------------------------------------------------------
-[131] Applies to: npm:json5@2.2.3
+[129] Applies to: npm:json5@2.2.3
 ------------------------------------------------------------------------------
 MIT License
 
@@ -5613,7 +5414,7 @@ SOFTWARE.
 [others]: https://github.com/json5/json5/contributors
 
 ------------------------------------------------------------------------------
-[132] Applies to: npm:kleur@3.0.3
+[130] Applies to: npm:kleur@3.0.3
 ------------------------------------------------------------------------------
 The MIT License (MIT)
 
@@ -5638,7 +5439,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[133] Applies to: npm:lan-network@0.2.1
+[131] Applies to: npm:lan-network@0.2.1
 ------------------------------------------------------------------------------
 MIT License
 
@@ -5663,7 +5464,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
 ------------------------------------------------------------------------------
-[134] Applies to: npm:lightningcss@1.32.0
+[132] Applies to: npm:lightningcss@1.32.0
 ------------------------------------------------------------------------------
 Mozilla Public License Version 2.0
 ==================================
@@ -6040,7 +5841,7 @@ This Source Code Form is "Incompatible With Secondary Licenses", as
 defined by the Mozilla Public License, v. 2.0.
 
 ------------------------------------------------------------------------------
-[135] Applies to: npm:lodash.debounce@4.0.8, npm:lodash.throttle@4.1.1
+[133] Applies to: npm:lodash.debounce@4.0.8, npm:lodash.throttle@4.1.1
 ------------------------------------------------------------------------------
 Copyright jQuery Foundation and other contributors <https://jquery.org/>
 
@@ -6091,7 +5892,7 @@ licenses; we recommend you read them, as their terms may differ from the
 terms above.
 
 ------------------------------------------------------------------------------
-[136] Applies to: npm:loose-envify@1.4.0
+[134] Applies to: npm:loose-envify@1.4.0
 ------------------------------------------------------------------------------
 The MIT License (MIT)
 
@@ -6116,7 +5917,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[137] Applies to: npm:lru-cache@10.4.3
+[135] Applies to: npm:lru-cache@10.4.3
 ------------------------------------------------------------------------------
 The ISC License
 
@@ -6135,7 +5936,7 @@ ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF OR
 IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
 
 ------------------------------------------------------------------------------
-[138] Applies to: npm:lru-cache@11.5.2, npm:minipass@7.1.3, npm:path-scurry@2.0.2, npm:sax@1.6.0
+[136] Applies to: npm:lru-cache@11.5.2, npm:minipass@7.1.3, npm:path-scurry@2.0.2, npm:sax@1.6.0
 ------------------------------------------------------------------------------
 # Blue Oak Model License
 
@@ -6194,7 +5995,7 @@ will be liable to anyone for any damages related to this
 software or this license, under any kind of legal claim.***
 
 ------------------------------------------------------------------------------
-[139] Applies to: npm:lucide-react-native@0.468.0
+[137] Applies to: npm:lucide-react-native@0.468.0
 ------------------------------------------------------------------------------
 ISC License
 
@@ -6213,7 +6014,7 @@ ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
 OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
 
 ------------------------------------------------------------------------------
-[140] Applies to: npm:makeerror@1.0.12, npm:tmpl@1.0.5
+[138] Applies to: npm:makeerror@1.0.12, npm:tmpl@1.0.5
 ------------------------------------------------------------------------------
 BSD License
 
@@ -6245,7 +6046,7 @@ ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
 SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 ------------------------------------------------------------------------------
-[141] Applies to: npm:marky@1.3.0
+[139] Applies to: npm:marky@1.3.0
 ------------------------------------------------------------------------------
 Apache License
 Version 2.0, January 2004
@@ -6457,7 +6258,7 @@ APPENDIX: How to apply the Apache License to your work
         permissions and limitations under the License.
 
 ------------------------------------------------------------------------------
-[142] Applies to: npm:mdn-data@2.0.14
+[140] Applies to: npm:mdn-data@2.0.14
 ------------------------------------------------------------------------------
 CC0 1.0 Universal
 
@@ -6577,7 +6378,7 @@ For more information, please see
 <http://creativecommons.org/publicdomain/zero/1.0/>
 
 ------------------------------------------------------------------------------
-[143] Applies to: npm:memoize-one@5.2.1, npm:memoize-one@6.0.0
+[141] Applies to: npm:memoize-one@5.2.1, npm:memoize-one@6.0.0
 ------------------------------------------------------------------------------
 MIT License
 
@@ -6602,7 +6403,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
 ------------------------------------------------------------------------------
-[144] Applies to: npm:merge-options@3.0.4
+[142] Applies to: npm:merge-options@3.0.4
 ------------------------------------------------------------------------------
 The MIT License (MIT)
 
@@ -6627,7 +6428,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
 ------------------------------------------------------------------------------
-[145] Applies to: npm:merge-stream@2.0.0
+[143] Applies to: npm:merge-stream@2.0.0
 ------------------------------------------------------------------------------
 The MIT License (MIT)
 
@@ -6652,7 +6453,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[146] Applies to: npm:mime@1.6.0
+[144] Applies to: npm:mime@1.6.0
 ------------------------------------------------------------------------------
 The MIT License (MIT)
 
@@ -6677,7 +6478,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[147] Applies to: npm:mime-db@1.52.0, npm:mime-db@1.54.0
+[145] Applies to: npm:mime-db@1.52.0, npm:mime-db@1.54.0
 ------------------------------------------------------------------------------
 (The MIT License)
 
@@ -6704,32 +6505,7 @@ TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
 SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[148] Applies to: npm:min-indent@1.0.1
-------------------------------------------------------------------------------
-The MIT License (MIT)
-
-Copyright (c) Sindre Sorhus <sindresorhus@gmail.com> (sindresorhus.com), James Kyle <me@thejameskyle.com> (thejameskyle.com)
-
-Permission is hereby granted, free of charge, to any person obtaining a copy
-of this software and associated documentation files (the "Software"), to deal
-in the Software without restriction, including without limitation the rights
-to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-copies of the Software, and to permit persons to whom the Software is
-furnished to do so, subject to the following conditions:
-
-The above copyright notice and this permission notice shall be included in
-all copies or substantial portions of the Software.
-
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
-THE SOFTWARE.
-
-------------------------------------------------------------------------------
-[149] Applies to: npm:minimatch@10.2.5
+[146] Applies to: npm:minimatch@10.2.5
 ------------------------------------------------------------------------------
 # Blue Oak Model License
 
@@ -6788,7 +6564,7 @@ will be liable to anyone for any damages related to this
 software or this license, under any kind of legal claim._**
 
 ------------------------------------------------------------------------------
-[150] Applies to: npm:mkdirp@1.0.4
+[147] Applies to: npm:mkdirp@1.0.4
 ------------------------------------------------------------------------------
 Copyright James Halliday (mail@substack.net) and Isaac Z. Schlueter (i@izs.me)
 
@@ -6813,7 +6589,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[151] Applies to: npm:ms@2.0.0
+[148] Applies to: npm:ms@2.0.0
 ------------------------------------------------------------------------------
 The MIT License (MIT)
 
@@ -6838,7 +6614,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
 ------------------------------------------------------------------------------
-[152] Applies to: npm:ms@2.1.3
+[149] Applies to: npm:ms@2.1.3
 ------------------------------------------------------------------------------
 The MIT License (MIT)
 
@@ -6863,7 +6639,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
 ------------------------------------------------------------------------------
-[153] Applies to: npm:nanoid@3.3.16
+[150] Applies to: npm:nanoid@3.3.16
 ------------------------------------------------------------------------------
 The MIT License (MIT)
 
@@ -6887,7 +6663,7 @@ IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
 CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[154] Applies to: npm:negotiator@0.6.3, npm:negotiator@0.6.4, npm:negotiator@1.0.0
+[151] Applies to: npm:negotiator@0.6.3, npm:negotiator@0.6.4, npm:negotiator@1.0.0
 ------------------------------------------------------------------------------
 (The MIT License)
 
@@ -6915,7 +6691,7 @@ TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
 SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[155] Applies to: npm:node-fetch@2.7.0
+[152] Applies to: npm:node-fetch@2.7.0
 ------------------------------------------------------------------------------
 The MIT License (MIT)
 
@@ -6940,7 +6716,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
 ------------------------------------------------------------------------------
-[156] Applies to: npm:node-forge@1.4.0
+[153] Applies to: npm:node-forge@1.4.0
 ------------------------------------------------------------------------------
 You may use the Forge project under the terms of either the BSD License or the
 GNU General Public License (GPL) Version 2.
@@ -7274,7 +7050,7 @@ PROGRAMS), EVEN IF SUCH HOLDER OR OTHER PARTY HAS BEEN ADVISED OF THE
 POSSIBILITY OF SUCH DAMAGES.
 
 ------------------------------------------------------------------------------
-[157] Applies to: npm:node-int64@0.4.0
+[154] Applies to: npm:node-int64@0.4.0
 ------------------------------------------------------------------------------
 Copyright (c) 2014 Robert Kieffer
 
@@ -7297,7 +7073,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[158] Applies to: npm:node-releases@2.0.51
+[155] Applies to: npm:node-releases@2.0.51
 ------------------------------------------------------------------------------
 The MIT License
 
@@ -7322,7 +7098,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[159] Applies to: npm:npm-package-arg@11.0.3
+[156] Applies to: npm:npm-package-arg@11.0.3
 ------------------------------------------------------------------------------
 The ISC License
 
@@ -7341,7 +7117,7 @@ ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF OR
 IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
 
 ------------------------------------------------------------------------------
-[160] Applies to: npm:nullthrows@1.1.1
+[157] Applies to: npm:nullthrows@1.1.1
 ------------------------------------------------------------------------------
 The MIT License (MIT)
 Copyright (c) 2016 Andres Suarez
@@ -7353,7 +7129,7 @@ The above copyright notice and this permission notice shall be included in all c
 THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[161] Applies to: npm:on-finished@2.3.0, npm:on-finished@2.4.1
+[158] Applies to: npm:on-finished@2.3.0, npm:on-finished@2.4.1
 ------------------------------------------------------------------------------
 (The MIT License)
 
@@ -7380,7 +7156,7 @@ TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
 SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[162] Applies to: npm:on-headers@1.1.0
+[159] Applies to: npm:on-headers@1.1.0
 ------------------------------------------------------------------------------
 (The MIT License)
 
@@ -7406,7 +7182,7 @@ TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
 SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[163] Applies to: npm:pako@2.2.0
+[160] Applies to: npm:pako@2.2.0
 ------------------------------------------------------------------------------
 (The MIT License)
 
@@ -7431,7 +7207,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[164] Applies to: npm:parse-png@2.1.0, npm:shebang-command@2.0.0
+[161] Applies to: npm:parse-png@2.1.0, npm:shebang-command@2.0.0
 ------------------------------------------------------------------------------
 MIT License
 
@@ -7444,7 +7220,7 @@ The above copyright notice and this permission notice shall be included in all c
 THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[165] Applies to: npm:parseurl@1.3.3
+[162] Applies to: npm:parseurl@1.3.3
 ------------------------------------------------------------------------------
 (The MIT License)
 
@@ -7471,7 +7247,7 @@ TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
 SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[166] Applies to: npm:path-parse@1.0.7
+[163] Applies to: npm:path-parse@1.0.7
 ------------------------------------------------------------------------------
 The MIT License (MIT)
 
@@ -7496,7 +7272,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
 ------------------------------------------------------------------------------
-[167] Applies to: npm:picocolors@1.1.1
+[164] Applies to: npm:picocolors@1.1.1
 ------------------------------------------------------------------------------
 ISC License
 
@@ -7515,7 +7291,7 @@ ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
 OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
 
 ------------------------------------------------------------------------------
-[168] Applies to: npm:picomatch@2.3.2, npm:picomatch@4.0.5
+[165] Applies to: npm:picomatch@2.3.2, npm:picomatch@4.0.5
 ------------------------------------------------------------------------------
 The MIT License (MIT)
 
@@ -7540,7 +7316,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[169] Applies to: npm:plist@3.1.1
+[166] Applies to: npm:plist@3.1.1
 ------------------------------------------------------------------------------
 (The MIT License)
 
@@ -7568,7 +7344,7 @@ FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
 OTHER DEALINGS IN THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[170] Applies to: npm:pngjs@3.4.0
+[167] Applies to: npm:pngjs@3.4.0
 ------------------------------------------------------------------------------
 pngjs2 original work Copyright (c) 2015 Luke Page & Original Contributors
 pngjs derived work Copyright (c) 2012 Kuba Niegowski
@@ -7592,7 +7368,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[171] Applies to: npm:postcss@8.5.19
+[168] Applies to: npm:postcss@8.5.19
 ------------------------------------------------------------------------------
 The MIT License (MIT)
 
@@ -7616,7 +7392,7 @@ IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
 CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[172] Applies to: npm:postcss-value-parser@4.2.0
+[169] Applies to: npm:postcss-value-parser@4.2.0
 ------------------------------------------------------------------------------
 Copyright (c) Bogdan Chadkin <trysound@yandex.ru>
 
@@ -7642,7 +7418,7 @@ FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
 OTHER DEALINGS IN THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[173] Applies to: npm:proc-log@4.2.0
+[170] Applies to: npm:proc-log@4.2.0
 ------------------------------------------------------------------------------
 The ISC License
 
@@ -7661,7 +7437,7 @@ ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF OR
 IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
 
 ------------------------------------------------------------------------------
-[174] Applies to: npm:progress@2.0.3
+[171] Applies to: npm:progress@2.0.3
 ------------------------------------------------------------------------------
 (The MIT License)
 
@@ -7687,7 +7463,7 @@ TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
 SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[175] Applies to: npm:promise@7.3.1, npm:promise@8.3.0
+[172] Applies to: npm:promise@7.3.1, npm:promise@8.3.0
 ------------------------------------------------------------------------------
 Copyright (c) 2014 Forbes Lindesay
 
@@ -7710,7 +7486,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[176] Applies to: npm:prompts@2.4.2, npm:sisteransi@1.0.5
+[173] Applies to: npm:prompts@2.4.2, npm:sisteransi@1.0.5
 ------------------------------------------------------------------------------
 MIT License
 
@@ -7735,7 +7511,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
 ------------------------------------------------------------------------------
-[177] Applies to: npm:query-string@7.1.3
+[174] Applies to: npm:query-string@7.1.3
 ------------------------------------------------------------------------------
 MIT License
 
@@ -7748,7 +7524,7 @@ The above copyright notice and this permission notice shall be included in all c
 THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[178] Applies to: npm:queue@6.0.2
+[175] Applies to: npm:queue@6.0.2
 ------------------------------------------------------------------------------
 The MIT License (MIT)
 Copyright (c) 2014 Jesse Tane <jesse.tane@gmail.com>
@@ -7760,7 +7536,7 @@ The above copyright notice and this permission notice shall be included in all c
 THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[179] Applies to: npm:range-parser@1.2.1
+[176] Applies to: npm:range-parser@1.2.1
 ------------------------------------------------------------------------------
 (The MIT License)
 
@@ -7787,7 +7563,7 @@ TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
 SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[180] Applies to: npm:react-fast-compare@3.2.2
+[177] Applies to: npm:react-fast-compare@3.2.2
 ------------------------------------------------------------------------------
 MIT License
 
@@ -7813,7 +7589,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
 ------------------------------------------------------------------------------
-[181] Applies to: npm:react-freeze@1.0.4
+[178] Applies to: npm:react-freeze@1.0.4
 ------------------------------------------------------------------------------
 The MIT License (MIT)
 
@@ -7838,7 +7614,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
 ------------------------------------------------------------------------------
-[182] Applies to: npm:react-i18next@17.0.10
+[179] Applies to: npm:react-i18next@17.0.10
 ------------------------------------------------------------------------------
 The MIT License (MIT)
 
@@ -7863,7 +7639,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
 ------------------------------------------------------------------------------
-[183] Applies to: npm:react-native-drawer-layout@4.2.7
+[180] Applies to: npm:react-native-drawer-layout@4.2.7
 ------------------------------------------------------------------------------
 MIT License
 
@@ -7888,7 +7664,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
 ------------------------------------------------------------------------------
-[184] Applies to: npm:react-native-gesture-handler@3.0.2, npm:react-native-reanimated@4.3.1
+[181] Applies to: npm:react-native-gesture-handler@2.32.0, npm:react-native-reanimated@4.5.1
 ------------------------------------------------------------------------------
 The MIT License (MIT)
 
@@ -7913,7 +7689,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
 ------------------------------------------------------------------------------
-[185] Applies to: npm:react-native-is-edge-to-edge@1.3.1
+[182] Applies to: npm:react-native-is-edge-to-edge@1.3.1
 ------------------------------------------------------------------------------
 MIT License
 
@@ -7938,7 +7714,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
 ------------------------------------------------------------------------------
-[186] Applies to: npm:react-native-safe-area-context@5.7.0
+[183] Applies to: npm:react-native-safe-area-context@5.7.0
 ------------------------------------------------------------------------------
 MIT License
 
@@ -7963,7 +7739,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
 ------------------------------------------------------------------------------
-[187] Applies to: npm:react-native-screens@4.25.2
+[184] Applies to: npm:react-native-screens@4.26.2
 ------------------------------------------------------------------------------
 The MIT License (MIT)
 
@@ -7988,7 +7764,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
 ------------------------------------------------------------------------------
-[188] Applies to: npm:react-native-svg@15.15.4
+[185] Applies to: npm:react-native-svg@15.15.4
 ------------------------------------------------------------------------------
 The MIT License (MIT)
 
@@ -8013,7 +7789,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
 ------------------------------------------------------------------------------
-[189] Applies to: npm:react-native-uitextview@2.2.0
+[186] Applies to: npm:react-native-uitextview@2.2.0
 ------------------------------------------------------------------------------
 MIT License
 
@@ -8037,7 +7813,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
 ------------------------------------------------------------------------------
-[190] Applies to: npm:react-native-web@0.21.2
+[187] Applies to: npm:react-native-web@0.21.2
 ------------------------------------------------------------------------------
 MIT License
 
@@ -8063,7 +7839,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
 ------------------------------------------------------------------------------
-[191] Applies to: npm:react-native-worklets@0.8.3
+[188] Applies to: npm:react-native-worklets@0.10.1
 ------------------------------------------------------------------------------
 MIT License
 
@@ -8087,7 +7863,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
 ------------------------------------------------------------------------------
-[192] Applies to: npm:regenerator-runtime@0.13.11
+[189] Applies to: npm:regenerator-runtime@0.13.11
 ------------------------------------------------------------------------------
 MIT License
 
@@ -8112,7 +7888,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
 ------------------------------------------------------------------------------
-[193] Applies to: npm:regjsgen@0.8.0
+[190] Applies to: npm:regjsgen@0.8.0
 ------------------------------------------------------------------------------
 The MIT License (MIT)
 
@@ -8138,7 +7914,7 @@ OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
 WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[194] Applies to: npm:regjsparser@0.13.2
+[191] Applies to: npm:regjsparser@0.13.2
 ------------------------------------------------------------------------------
 Copyright (c) Julian Viereck and Contributors, All Rights Reserved.
 
@@ -8163,7 +7939,7 @@ ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
 THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 ------------------------------------------------------------------------------
-[195] Applies to: npm:require-directory@2.1.1
+[192] Applies to: npm:require-directory@2.1.1
 ------------------------------------------------------------------------------
 The MIT License (MIT)
 
@@ -8189,7 +7965,7 @@ TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
 SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[196] Applies to: npm:resolve@1.22.12
+[193] Applies to: npm:resolve@1.22.12
 ------------------------------------------------------------------------------
 MIT License
 
@@ -8214,7 +7990,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
 ------------------------------------------------------------------------------
-[197] Applies to: npm:resolve-workspace-root@2.0.1
+[194] Applies to: npm:resolve-workspace-root@2.0.1
 ------------------------------------------------------------------------------
 # The MIT License (MIT)
 
@@ -8239,7 +8015,7 @@ Copyright (c) 2024-present Cedric van Putten <me@cedric.dev>
 > THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[198] Applies to: npm:rtl-detect@1.1.2
+[195] Applies to: npm:rtl-detect@1.1.2
 ------------------------------------------------------------------------------
 Copyright 2015 Yahoo Inc.
 All rights reserved.
@@ -8270,7 +8046,7 @@ ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
 SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 ------------------------------------------------------------------------------
-[199] Applies to: npm:safe-buffer@5.2.1
+[196] Applies to: npm:safe-buffer@5.2.1
 ------------------------------------------------------------------------------
 The MIT License (MIT)
 
@@ -8295,7 +8071,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[200] Applies to: npm:send@0.19.2
+[197] Applies to: npm:send@0.19.2
 ------------------------------------------------------------------------------
 (The MIT License)
 
@@ -8322,7 +8098,7 @@ TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
 SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[201] Applies to: npm:serve-static@1.16.3
+[198] Applies to: npm:serve-static@1.16.3
 ------------------------------------------------------------------------------
 (The MIT License)
 
@@ -8351,7 +8127,7 @@ TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
 SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[202] Applies to: npm:setimmediate@1.0.5
+[199] Applies to: npm:setimmediate@1.0.5
 ------------------------------------------------------------------------------
 Copyright (c) 2012 Barnesandnoble.com, llc, Donavon West, and Domenic Denicola
 
@@ -8375,7 +8151,7 @@ OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
 WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[203] Applies to: npm:setprototypeof@1.2.0
+[200] Applies to: npm:setprototypeof@1.2.0
 ------------------------------------------------------------------------------
 Copyright (c) 2015, Wes Todd
 
@@ -8392,7 +8168,7 @@ OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF OR IN
 CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
 
 ------------------------------------------------------------------------------
-[204] Applies to: npm:sf-symbols-typescript@2.2.0
+[201] Applies to: npm:sf-symbols-typescript@2.2.0
 ------------------------------------------------------------------------------
 MIT License
 
@@ -8417,7 +8193,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
 ------------------------------------------------------------------------------
-[205] Applies to: npm:shallowequal@1.1.0
+[202] Applies to: npm:shallowequal@1.1.0
 ------------------------------------------------------------------------------
 MIT License
 
@@ -8442,7 +8218,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
 ------------------------------------------------------------------------------
-[206] Applies to: npm:shell-quote@1.10.0
+[203] Applies to: npm:shell-quote@1.10.0
 ------------------------------------------------------------------------------
 The MIT License
 
@@ -8470,7 +8246,7 @@ TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
 SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[207] Applies to: npm:signal-exit@3.0.7
+[204] Applies to: npm:signal-exit@3.0.7
 ------------------------------------------------------------------------------
 The ISC License
 
@@ -8490,7 +8266,7 @@ WHETHER IN AN ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION,
 ARISING OUT OF OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
 
 ------------------------------------------------------------------------------
-[208] Applies to: npm:simple-plist@1.3.1
+[205] Applies to: npm:simple-plist@1.3.1
 ------------------------------------------------------------------------------
 The MIT License (MIT)
 
@@ -8514,7 +8290,7 @@ IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
 CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[209] Applies to: npm:simple-swizzle@0.2.4
+[206] Applies to: npm:simple-swizzle@0.2.4
 ------------------------------------------------------------------------------
 The MIT License (MIT)
 
@@ -8539,7 +8315,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[210] Applies to: npm:slugify@1.6.9
+[207] Applies to: npm:slugify@1.6.9
 ------------------------------------------------------------------------------
 The MIT License (MIT)
 
@@ -8564,7 +8340,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
 ------------------------------------------------------------------------------
-[211] Applies to: npm:source-map@0.5.7, npm:source-map@0.6.1, npm:source-map-js@1.2.1
+[208] Applies to: npm:source-map@0.5.7, npm:source-map@0.6.1, npm:source-map-js@1.2.1
 ------------------------------------------------------------------------------
 Copyright (c) 2009-2011, Mozilla Foundation and contributors
 All rights reserved.
@@ -8595,7 +8371,7 @@ OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 ------------------------------------------------------------------------------
-[212] Applies to: npm:source-map-support@0.5.21
+[209] Applies to: npm:source-map-support@0.5.21
 ------------------------------------------------------------------------------
 The MIT License (MIT)
 
@@ -8620,7 +8396,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
 ------------------------------------------------------------------------------
-[213] Applies to: npm:stacktrace-parser@0.1.11
+[210] Applies to: npm:stacktrace-parser@0.1.11
 ------------------------------------------------------------------------------
 MIT License
 
@@ -8645,7 +8421,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
 ------------------------------------------------------------------------------
-[214] Applies to: npm:statuses@1.5.0, npm:statuses@2.0.2
+[211] Applies to: npm:statuses@1.5.0, npm:statuses@2.0.2
 ------------------------------------------------------------------------------
 The MIT License (MIT)
 
@@ -8671,7 +8447,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[215] Applies to: npm:stream-buffers@2.2.0
+[212] Applies to: npm:stream-buffers@2.2.0
 ------------------------------------------------------------------------------
 This is free and unencumbered software released into the public domain.
 
@@ -8699,7 +8475,7 @@ OTHER DEALINGS IN THE SOFTWARE.
 For more information, please refer to <http://unlicense.org/>
 
 ------------------------------------------------------------------------------
-[216] Applies to: npm:strict-uri-encode@2.0.0
+[213] Applies to: npm:strict-uri-encode@2.0.0
 ------------------------------------------------------------------------------
 The MIT License (MIT)
 
@@ -8724,7 +8500,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[217] Applies to: npm:styleq@0.1.3
+[214] Applies to: npm:styleq@0.1.3
 ------------------------------------------------------------------------------
 MIT License
 
@@ -8749,7 +8525,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
 ------------------------------------------------------------------------------
-[218] Applies to: npm:supports-hyperlinks@2.3.0
+[215] Applies to: npm:supports-hyperlinks@2.3.0
 ------------------------------------------------------------------------------
 MIT License
 
@@ -8762,7 +8538,7 @@ The above copyright notice and this permission notice shall be included in all c
 THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[219] Applies to: npm:supports-preserve-symlinks-flag@1.0.0
+[216] Applies to: npm:supports-preserve-symlinks-flag@1.0.0
 ------------------------------------------------------------------------------
 MIT License
 
@@ -8787,7 +8563,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
 ------------------------------------------------------------------------------
-[220] Applies to: npm:terser@5.49.0
+[217] Applies to: npm:terser@5.49.0
 ------------------------------------------------------------------------------
 Copyright 2012-2018 (c) Mihai Bazon <mihai.bazon@gmail.com>
 
@@ -8818,7 +8594,7 @@ THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
 SUCH DAMAGE.
 
 ------------------------------------------------------------------------------
-[221] Applies to: npm:throat@5.0.0
+[218] Applies to: npm:throat@5.0.0
 ------------------------------------------------------------------------------
 Copyright (c) 2013 Forbes Lindesay
 
@@ -8841,7 +8617,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[222] Applies to: npm:tinyglobby@0.2.17
+[219] Applies to: npm:tinyglobby@0.2.17
 ------------------------------------------------------------------------------
 MIT License
 
@@ -8866,7 +8642,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
 ------------------------------------------------------------------------------
-[223] Applies to: npm:to-regex-range@5.0.1
+[220] Applies to: npm:to-regex-range@5.0.1
 ------------------------------------------------------------------------------
 The MIT License (MIT)
 
@@ -8891,7 +8667,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[224] Applies to: npm:toidentifier@1.0.1
+[221] Applies to: npm:toidentifier@1.0.1
 ------------------------------------------------------------------------------
 MIT License
 
@@ -8916,7 +8692,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
 ------------------------------------------------------------------------------
-[225] Applies to: npm:tslib@2.8.1
+[222] Applies to: npm:tslib@2.8.1
 ------------------------------------------------------------------------------
 Copyright (c) Microsoft Corporation.
 
@@ -8932,7 +8708,7 @@ OTHER TORTIOUS ACTION, ARISING OUT OF OR IN CONNECTION WITH THE USE OR
 PERFORMANCE OF THIS SOFTWARE.
 
 ------------------------------------------------------------------------------
-[226] Applies to: npm:type-fest@0.21.3
+[223] Applies to: npm:type-fest@0.21.3
 ------------------------------------------------------------------------------
 MIT License
 
@@ -8945,7 +8721,7 @@ The above copyright notice and this permission notice shall be included in all c
 THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[227] Applies to: npm:ua-parser-js@1.0.41
+[224] Applies to: npm:ua-parser-js@1.0.41
 ------------------------------------------------------------------------------
 MIT License
 
@@ -8970,7 +8746,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
 ------------------------------------------------------------------------------
-[228] Applies to: npm:undici-types@7.24.6
+[225] Applies to: npm:undici-types@7.24.6
 ------------------------------------------------------------------------------
 MIT License
 
@@ -8995,7 +8771,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
 ------------------------------------------------------------------------------
-[229] Applies to: npm:unpipe@1.0.0
+[226] Applies to: npm:unpipe@1.0.0
 ------------------------------------------------------------------------------
 (The MIT License)
 
@@ -9021,7 +8797,7 @@ TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
 SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[230] Applies to: npm:update-browserslist-db@1.2.3
+[227] Applies to: npm:update-browserslist-db@1.2.3
 ------------------------------------------------------------------------------
 The MIT License (MIT)
 
@@ -9045,7 +8821,7 @@ IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
 CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[231] Applies to: npm:use-latest-callback@0.2.6
+[228] Applies to: npm:use-latest-callback@0.2.6
 ------------------------------------------------------------------------------
 MIT License
 
@@ -9070,7 +8846,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
 ------------------------------------------------------------------------------
-[232] Applies to: npm:utils-merge@1.0.1
+[229] Applies to: npm:utils-merge@1.0.1
 ------------------------------------------------------------------------------
 The MIT License (MIT)
 
@@ -9094,7 +8870,7 @@ IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
 CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[233] Applies to: npm:uuid@7.0.3
+[230] Applies to: npm:uuid@7.0.3
 ------------------------------------------------------------------------------
 The MIT License (MIT)
 
@@ -9119,7 +8895,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
 ------------------------------------------------------------------------------
-[234] Applies to: npm:validate-npm-package-name@5.0.1
+[231] Applies to: npm:validate-npm-package-name@5.0.1
 ------------------------------------------------------------------------------
 Copyright (c) 2015, npm, Inc
 
@@ -9129,7 +8905,7 @@ Permission to use, copy, modify, and/or distribute this software for any purpose
 THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
 
 ------------------------------------------------------------------------------
-[235] Applies to: npm:vary@1.1.2
+[232] Applies to: npm:vary@1.1.2
 ------------------------------------------------------------------------------
 (The MIT License)
 
@@ -9155,7 +8931,7 @@ TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
 SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[236] Applies to: npm:vaul@1.1.2
+[233] Applies to: npm:vaul@1.1.2
 ------------------------------------------------------------------------------
 MIT License
 
@@ -9168,7 +8944,7 @@ The above copyright notice and this permission notice shall be included in all c
 THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[237] Applies to: npm:vlq@1.0.1
+[234] Applies to: npm:vlq@1.0.1
 ------------------------------------------------------------------------------
 Copyright (c) 2017 [these people](https://github.com/Rich-Harris/vlq/graphs/contributors)
 
@@ -9179,7 +8955,7 @@ The above copyright notice and this permission notice shall be included in all c
 THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[238] Applies to: npm:void-elements@3.1.0
+[235] Applies to: npm:void-elements@3.1.0
 ------------------------------------------------------------------------------
 (The MIT License)
 
@@ -9205,7 +8981,7 @@ TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
 SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[239] Applies to: npm:walker@1.0.8
+[236] Applies to: npm:walker@1.0.8
 ------------------------------------------------------------------------------
 Copyright 2013 Naitik Shah
 
@@ -9222,7 +8998,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 
 ------------------------------------------------------------------------------
-[240] Applies to: npm:warn-once@0.1.1
+[237] Applies to: npm:warn-once@0.1.1
 ------------------------------------------------------------------------------
 MIT License
 
@@ -9247,7 +9023,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
 ------------------------------------------------------------------------------
-[241] Applies to: npm:wcwidth@1.0.1
+[238] Applies to: npm:wcwidth@1.0.1
 ------------------------------------------------------------------------------
 wcwidth.js: JavaScript Portng of Markus Kuhn's wcwidth() Implementation
 =======================================================================
@@ -9280,7 +9056,7 @@ ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 POSSIBILITY OF SUCH DAMAGE.
 
 ------------------------------------------------------------------------------
-[242] Applies to: npm:webidl-conversions@3.0.1
+[239] Applies to: npm:webidl-conversions@3.0.1
 ------------------------------------------------------------------------------
 # The BSD 2-Clause License
 
@@ -9296,7 +9072,7 @@ Redistribution and use in source and binary forms, with or without modification,
 THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 ------------------------------------------------------------------------------
-[243] Applies to: npm:whatwg-fetch@3.6.20
+[240] Applies to: npm:whatwg-fetch@3.6.20
 ------------------------------------------------------------------------------
 Copyright (c) 2014-2023 GitHub, Inc.
 
@@ -9320,7 +9096,7 @@ OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
 WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[244] Applies to: npm:whatwg-url@5.0.0
+[241] Applies to: npm:whatwg-url@5.0.0
 ------------------------------------------------------------------------------
 The MIT License (MIT)
 
@@ -9345,7 +9121,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[245] Applies to: npm:whatwg-url-minimum@0.1.2
+[242] Applies to: npm:whatwg-url-minimum@0.1.2
 ------------------------------------------------------------------------------
 MIT License
 
@@ -9372,7 +9148,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
 ------------------------------------------------------------------------------
-[246] Applies to: npm:ws@7.5.12
+[243] Applies to: npm:ws@7.5.12
 ------------------------------------------------------------------------------
 The MIT License (MIT)
 
@@ -9397,7 +9173,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
 ------------------------------------------------------------------------------
-[247] Applies to: npm:ws@8.21.1
+[244] Applies to: npm:ws@8.21.1
 ------------------------------------------------------------------------------
 Copyright (c) 2011 Einar Otto Stangvik <einaros@gmail.com>
 Copyright (c) 2013 Arnout Kazemier and contributors
@@ -9421,7 +9197,7 @@ IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
 CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[248] Applies to: npm:xcode@3.0.1 (NOTICE)
+[245] Applies to: npm:xcode@3.0.1 (NOTICE)
 ------------------------------------------------------------------------------
 NOTICE for npm:xcode@3.0.1:
 
@@ -9432,7 +9208,7 @@ This product includes software developed at
 The Apache Software Foundation (http://www.apache.org/).
 
 ------------------------------------------------------------------------------
-[249] Applies to: npm:xml2js@0.6.0
+[246] Applies to: npm:xml2js@0.6.0
 ------------------------------------------------------------------------------
 Copyright 2010, 2011, 2012, 2013. All rights reserved.
 
@@ -9455,7 +9231,7 @@ FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
 IN THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[250] Applies to: npm:xmlbuilder@11.0.1, npm:xmlbuilder@15.1.1
+[247] Applies to: npm:xmlbuilder@11.0.1, npm:xmlbuilder@15.1.1
 ------------------------------------------------------------------------------
 The MIT License (MIT)
 
@@ -9480,7 +9256,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[251] Applies to: npm:y18n@5.0.8
+[248] Applies to: npm:y18n@5.0.8
 ------------------------------------------------------------------------------
 Copyright (c) 2015, Contributors
 
@@ -9497,7 +9273,7 @@ TORTIOUS ACTION, ARISING OUT OF OR IN CONNECTION WITH THE USE OR PERFORMANCE OF
 THIS SOFTWARE.
 
 ------------------------------------------------------------------------------
-[252] Applies to: npm:yaml@2.9.0
+[249] Applies to: npm:yaml@2.9.0
 ------------------------------------------------------------------------------
 Copyright Eemeli Aro <eemeli@gmail.com>
 
@@ -9514,7 +9290,7 @@ TORTIOUS ACTION, ARISING OUT OF OR IN CONNECTION WITH THE USE OR PERFORMANCE OF
 THIS SOFTWARE.
 
 ------------------------------------------------------------------------------
-[253] Applies to: npm:yargs@17.7.3
+[250] Applies to: npm:yargs@17.7.3
 ------------------------------------------------------------------------------
 MIT License
 
@@ -9539,7 +9315,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[254] Applies to: npm:yargs-parser@21.1.1
+[251] Applies to: npm:yargs-parser@21.1.1
 ------------------------------------------------------------------------------
 Copyright (c) 2016, Contributors
 
@@ -9557,7 +9333,7 @@ WHETHER IN AN ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION,
 ARISING OUT OF OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
 
 ------------------------------------------------------------------------------
-[255] Applies to: npm:zod@4.3.6
+[252] Applies to: npm:zod@4.3.6
 ------------------------------------------------------------------------------
 MIT License
 
@@ -9586,21 +9362,21 @@ Packages without a standalone license file (license per package.json):
 ------------------------------------------------------------------------------
 - npm:@expo/devcert@1.2.1 (MIT)
 - npm:@expo/sdk-runtime-versions@1.0.0 (MIT)
-- npm:@expo/ui@56.0.22 (MIT)
+- npm:@expo/ui@57.0.14 (MIT)
 - npm:@expo/ws-tunnel@2.0.0 (MIT)
 - npm:@expo/xcpretty@4.4.4 (BSD-3-Clause)
-- npm:@react-native/assets-registry@0.85.3 (MIT)
-- npm:@react-native/babel-plugin-codegen@0.85.3 (MIT)
-- npm:@react-native/codegen@0.85.3 (MIT)
-- npm:@react-native/community-cli-plugin@0.85.3 (MIT)
-- npm:@react-native/debugger-frontend@0.85.3 (BSD-3-Clause)
-- npm:@react-native/debugger-shell@0.85.3 (MIT)
-- npm:@react-native/dev-middleware@0.85.3 (MIT)
-- npm:@react-native/gradle-plugin@0.85.3 (MIT)
-- npm:@react-native/js-polyfills@0.85.3 (MIT)
+- npm:@react-native/assets-registry@0.86.3 (MIT)
+- npm:@react-native/babel-plugin-codegen@0.86.3 (MIT)
+- npm:@react-native/codegen@0.86.3 (MIT)
+- npm:@react-native/community-cli-plugin@0.86.3 (MIT)
+- npm:@react-native/debugger-frontend@0.86.3 (BSD-3-Clause)
+- npm:@react-native/debugger-shell@0.86.3 (MIT)
+- npm:@react-native/dev-middleware@0.86.3 (MIT)
+- npm:@react-native/gradle-plugin@0.86.3 (MIT)
+- npm:@react-native/js-polyfills@0.86.3 (MIT)
 - npm:@react-native/normalize-colors@0.74.89 (MIT)
-- npm:@react-native/normalize-colors@0.85.3 (MIT)
-- npm:@react-native/virtualized-lists@0.85.3 (MIT)
+- npm:@react-native/normalize-colors@0.86.3 (MIT)
+- npm:@react-native/virtualized-lists@0.86.3 (MIT)
 - npm:babel-plugin-react-compiler@1.0.0 (MIT)
 - npm:badgin@1.2.3 (MIT)
 - npm:boolbase@1.0.0 (ISC)
@@ -9608,30 +9384,44 @@ Packages without a standalone license file (license per package.json):
 - npm:bplist-parser@0.3.2 (MIT)
 - npm:bser@2.1.1 (Apache-2.0)
 - npm:client-only@0.0.1 (MIT)
-- npm:expo-json-utils@56.0.0 (MIT)
-- npm:expo-router@56.2.15 (MIT)
-- npm:expo-structured-headers@56.0.0 (MIT)
-- npm:expo-updates@56.0.22 (MIT)
+- npm:expo-router@57.0.17 (MIT)
+- npm:expo-structured-headers@57.0.0 (MIT)
+- npm:expo-updates@57.0.18 (MIT)
 - npm:fb-dotslash@0.5.8 ((MIT OR Apache-2.0))
 - npm:fb-watchman@2.0.2 (Apache-2.0)
-- npm:hermes-compiler@250829098.0.10 (MIT)
+- npm:hermes-compiler@250829098.0.17 (MIT)
 - npm:html-parse-stringify@3.0.1 (MIT)
 - npm:jimp-compact@0.16.1 (MIT)
 - npm:metro@0.84.4 (MIT)
+- npm:metro@0.84.5 (MIT)
 - npm:metro-babel-transformer@0.84.4 (MIT)
+- npm:metro-babel-transformer@0.84.5 (MIT)
 - npm:metro-cache@0.84.4 (MIT)
+- npm:metro-cache@0.84.5 (MIT)
 - npm:metro-cache-key@0.84.4 (MIT)
+- npm:metro-cache-key@0.84.5 (MIT)
 - npm:metro-config@0.84.4 (MIT)
+- npm:metro-config@0.84.5 (MIT)
 - npm:metro-core@0.84.4 (MIT)
+- npm:metro-core@0.84.5 (MIT)
 - npm:metro-file-map@0.84.4 (MIT)
+- npm:metro-file-map@0.84.5 (MIT)
 - npm:metro-minify-terser@0.84.4 (MIT)
+- npm:metro-minify-terser@0.84.5 (MIT)
 - npm:metro-resolver@0.84.4 (MIT)
+- npm:metro-resolver@0.84.5 (MIT)
 - npm:metro-runtime@0.84.4 (MIT)
+- npm:metro-runtime@0.84.5 (MIT)
 - npm:metro-source-map@0.84.4 (MIT)
+- npm:metro-source-map@0.84.5 (MIT)
 - npm:metro-symbolicate@0.84.4 (MIT)
+- npm:metro-symbolicate@0.84.5 (MIT)
 - npm:metro-transform-plugins@0.84.4 (MIT)
+- npm:metro-transform-plugins@0.84.5 (MIT)
 - npm:metro-transform-worker@0.84.4 (MIT)
+- npm:metro-transform-worker@0.84.5 (MIT)
 - npm:ob1@0.84.4 (MIT)
+- npm:ob1@0.84.5 (MIT)
 - npm:react-devtools-core@6.1.5 (MIT)
 - npm:react-remove-scroll-bar@2.3.8 (MIT)
 - npm:server-only@0.0.1 (MIT)

--- a/docs/legal/notices/mobile-ios.txt
+++ b/docs/legal/notices/mobile-ios.txt
@@ -202,10 +202,9 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 
 ==============================================================================
-SECTION 2: npm packages (601 packages)
+SECTION 2: npm packages (610 packages)
 ==============================================================================
 
-- @adobe/css-tools@4.5.0 — MIT — https://github.com/adobe/css-tools
 - @babel/code-frame@7.29.7 — MIT — https://github.com/babel/babel
 - @babel/compat-data@7.29.7 — MIT — https://github.com/babel/babel
 - @babel/core@7.29.7 — MIT — https://github.com/babel/babel
@@ -275,42 +274,39 @@ SECTION 2: npm packages (601 packages)
 - @babel/template@7.29.7 — MIT — https://github.com/babel/babel
 - @babel/traverse@7.29.7 — MIT — https://github.com/babel/babel
 - @babel/types@7.29.7 — MIT — https://github.com/babel/babel
+- @egjs/hammerjs@2.0.17 — MIT — https://github.com/naver/hammer.js
 - @expo-google-fonts/material-symbols@0.4.40 — MIT AND Apache-2.0 — https://github.com/expo/google-fonts
-- @expo/cli@56.1.20 — MIT — https://github.com/expo/expo
+- @expo/cli@57.0.19 — MIT — https://github.com/expo/expo
 - @expo/code-signing-certificates@0.0.6 — MIT — https://github.com/expo/code-signing-certificates
-- @expo/config@56.0.12 — MIT — https://github.com/expo/expo
-- @expo/config-plugins@56.0.13 — MIT — https://github.com/expo/expo
-- @expo/config-types@56.0.7 — MIT — https://github.com/expo/expo
+- @expo/config@57.0.9 — MIT — https://github.com/expo/expo
+- @expo/config-plugins@57.0.9 — MIT — https://github.com/expo/expo
+- @expo/config-types@57.0.2 — MIT — https://github.com/expo/expo
 - @expo/devcert@1.2.1 — MIT — https://github.com/expo/devcert
-- @expo/devtools@56.0.2 — MIT — https://github.com/expo/expo
-- @expo/dom-webview@56.0.6 — MIT — https://github.com/expo/expo
-- @expo/env@2.3.1 — MIT — https://github.com/expo/expo
+- @expo/devtools@57.0.1 — MIT — https://github.com/expo/expo
+- @expo/dom-webview@57.0.1 — MIT — https://github.com/expo/expo
 - @expo/env@2.4.2 — MIT — https://github.com/expo/expo
-- @expo/expo-modules-macros-plugin@0.2.2 — MIT — https://github.com/expo/expo-modules-macros-plugin
-- @expo/fingerprint@0.19.8 — MIT — https://github.com/expo/expo
-- @expo/image-utils@0.10.3 — MIT — https://github.com/expo/expo
-- @expo/image-utils@0.10.4 — MIT — https://github.com/expo/expo
-- @expo/inline-modules@0.0.14 — MIT — https://github.com/expo/expo
-- @expo/json-file@10.2.0 — MIT — https://github.com/expo/expo
+- @expo/expo-modules-macros-plugin@0.6.1 — MIT — https://github.com/expo/expo-modules-macros-plugin
+- @expo/fingerprint@0.20.10 — MIT — https://github.com/expo/expo
+- @expo/image-utils@0.11.5 — MIT — https://github.com/expo/expo
+- @expo/inline-modules@0.1.7 — MIT — https://github.com/expo/expo
 - @expo/json-file@11.0.1 — MIT — https://github.com/expo/expo
-- @expo/local-build-cache-provider@56.0.10 — MIT — https://github.com/expo/expo
-- @expo/log-box@56.0.14 — MIT — https://github.com/expo/expo/tree/main/packages/@expo/log-box
-- @expo/metro@56.0.0 — MIT — https://github.com/expo/expo-metro
-- @expo/metro-config@56.0.17 — MIT — https://github.com/expo/expo
-- @expo/metro-file-map@56.0.3 — MIT — https://github.com/expo/expo
-- @expo/metro-runtime@56.0.17 — MIT — https://github.com/expo/expo
+- @expo/local-build-cache-provider@57.0.8 — MIT — https://github.com/expo/expo
+- @expo/log-box@57.0.4 — MIT — https://github.com/expo/expo/tree/main/packages/@expo/log-box
+- @expo/metro@56.0.2 — MIT — https://github.com/expo/expo-metro
+- @expo/metro-config@57.0.11 — MIT — https://github.com/expo/expo
+- @expo/metro-file-map@57.0.2 — MIT — https://github.com/expo/expo
+- @expo/metro-runtime@57.0.14 — MIT — https://github.com/expo/expo
 - @expo/osascript@2.7.1 — MIT — https://github.com/expo/expo
 - @expo/package-manager@1.13.1 — MIT — https://github.com/expo/expo
-- @expo/plist@0.7.0 — MIT — https://github.com/expo/expo
-- @expo/prebuild-config@56.0.20 — MIT — https://github.com/expo/expo
-- @expo/require-utils@56.1.5 — MIT — https://github.com/expo/expo
-- @expo/require-utils@56.1.6 — MIT — https://github.com/expo/expo
-- @expo/router-server@56.0.16 — MIT — https://github.com/expo/expo
-- @expo/schema-utils@56.0.2 — MIT — https://github.com/expo/expo
+- @expo/plist@0.8.1 — MIT — https://github.com/expo/expo
+- @expo/prebuild-config@57.0.15 — MIT — https://github.com/expo/expo
+- @expo/require-utils@57.0.5 — MIT — https://github.com/expo/expo
+- @expo/router-server@57.0.8 — MIT — https://github.com/expo/expo
+- @expo/schema-utils@57.0.2 — MIT — https://github.com/expo/expo
 - @expo/sdk-runtime-versions@1.0.0 — MIT
 - @expo/spawn-async@1.8.0 — MIT — https://github.com/expo/spawn-async
 - @expo/sudo-prompt@9.3.2 — MIT — https://github.com/expo/sudo-prompt
-- @expo/ui@56.0.22 — MIT — https://github.com/expo/expo
+- @expo/ui@57.0.14 — MIT — https://github.com/expo/expo
 - @expo/ws-tunnel@2.0.0 — MIT
 - @expo/xcpretty@4.4.4 — BSD-3-Clause — https://github.com/expo/expo-cli
 - @isaacs/ttlcache@1.4.1 — ISC — https://github.com/isaacs/ttlcache
@@ -348,21 +344,21 @@ SECTION 2: npm packages (601 packages)
 - @react-native-async-storage/async-storage@2.2.0 — MIT — https://github.com/react-native-async-storage/async-storage
 - @react-native-google-signin/google-signin@16.1.2 — MIT — https://github.com/react-native-google-signin/google-signin
 - @react-native-masked-view/masked-view@0.3.2 — MIT — https://github.com/react-native-masked-view/masked-view
-- @react-native/assets-registry@0.85.3 — MIT — https://github.com/facebook/react-native
-- @react-native/babel-plugin-codegen@0.85.3 — MIT — https://github.com/facebook/react-native
-- @react-native/codegen@0.85.3 — MIT — https://github.com/facebook/react-native
-- @react-native/community-cli-plugin@0.85.3 — MIT — https://github.com/facebook/react-native
-- @react-native/debugger-frontend@0.85.3 — BSD-3-Clause — https://github.com/facebook/react-native
-- @react-native/debugger-shell@0.85.3 — MIT — https://github.com/facebook/react-native
-- @react-native/dev-middleware@0.85.3 — MIT — https://github.com/facebook/react-native
-- @react-native/gradle-plugin@0.85.3 — MIT — https://github.com/facebook/react-native
-- @react-native/js-polyfills@0.85.3 — MIT — https://github.com/facebook/react-native
+- @react-native-menu/menu@2.0.0 — MIT — https://github.com/react-native-menu/menu
+- @react-native/assets-registry@0.86.3 — MIT — https://github.com/react/react-native
+- @react-native/babel-plugin-codegen@0.86.3 — MIT — https://github.com/react/react-native
+- @react-native/codegen@0.86.3 — MIT — https://github.com/react/react-native
+- @react-native/community-cli-plugin@0.86.3 — MIT — https://github.com/react/react-native
+- @react-native/debugger-frontend@0.86.3 — BSD-3-Clause — https://github.com/react/react-native
+- @react-native/debugger-shell@0.86.3 — MIT — https://github.com/react/react-native
+- @react-native/dev-middleware@0.86.3 — MIT — https://github.com/react/react-native
+- @react-native/gradle-plugin@0.86.3 — MIT — https://github.com/react/react-native
+- @react-native/js-polyfills@0.86.3 — MIT — https://github.com/react/react-native
 - @react-native/normalize-colors@0.74.89 — MIT — https://github.com/facebook/react-native
-- @react-native/normalize-colors@0.85.3 — MIT — https://github.com/facebook/react-native
-- @react-native/virtualized-lists@0.85.3 — MIT — https://github.com/facebook/react-native
+- @react-native/normalize-colors@0.86.3 — MIT — https://github.com/react/react-native
+- @react-native/virtualized-lists@0.86.3 — MIT — https://github.com/react/react-native
 - @sinclair/typebox@0.27.10 — MIT — https://github.com/sinclairzx81/typebox-legacy
-- @testing-library/jest-dom@6.9.1 — MIT — https://github.com/testing-library/jest-dom
-- @testing-library/user-event@14.6.1 — MIT — https://github.com/testing-library/user-event
+- @types/hammerjs@2.0.46 — MIT — https://github.com/DefinitelyTyped/DefinitelyTyped
 - @types/istanbul-lib-coverage@2.0.6 — MIT — https://github.com/DefinitelyTyped/DefinitelyTyped
 - @types/istanbul-lib-report@3.0.3 — MIT — https://github.com/DefinitelyTyped/DefinitelyTyped
 - @types/istanbul-reports@3.0.4 — MIT — https://github.com/DefinitelyTyped/DefinitelyTyped
@@ -380,7 +376,7 @@ SECTION 2: npm packages (601 packages)
 - accepts@2.0.0 — MIT — https://github.com/jshttp/accepts
 - acorn@8.17.0 — MIT — https://github.com/acornjs/acorn
 - agent-base@7.1.4 — MIT — https://github.com/TooTallNate/proxy-agents
-- agent-cli-detector@0.1.2 — MIT
+- agent-cli-detector@0.1.6 — MIT — https://github.com/expo/agent-cli-detector
 - anser@1.4.10 — MIT — https://github.com/IonicaBizau/anser
 - ansi-escapes@4.3.2 — MIT — https://github.com/sindresorhus/ansi-escapes
 - ansi-regex@4.1.1 — MIT — https://github.com/chalk/ansi-regex
@@ -392,16 +388,16 @@ SECTION 2: npm packages (601 packages)
 - arg@5.0.2 — MIT — https://github.com/vercel/arg
 - argparse@2.0.1 — Python-2.0 — https://github.com/nodeca/argparse
 - aria-hidden@1.2.6 — MIT — https://github.com/theKashey/aria-hidden
-- aria-query@5.3.2 — Apache-2.0 — https://github.com/A11yance/aria-query
 - asap@2.0.6 — MIT — https://github.com/kriskowal/asap
 - babel-plugin-polyfill-corejs2@0.4.17 — MIT — https://github.com/babel/babel-polyfills
 - babel-plugin-polyfill-corejs3@0.13.0 — MIT — https://github.com/babel/babel-polyfills
 - babel-plugin-polyfill-regenerator@0.6.8 — MIT — https://github.com/babel/babel-polyfills
 - babel-plugin-react-compiler@1.0.0 — MIT — https://github.com/facebook/react
 - babel-plugin-react-native-web@0.21.2 — MIT — https://github.com/necolas/react-native-web
-- babel-plugin-syntax-hermes-parser@0.33.3 — MIT — https://github.com/facebook/hermes
+- babel-plugin-syntax-hermes-parser@0.36.0 — MIT — https://github.com/facebook/hermes
+- babel-plugin-syntax-hermes-parser@0.36.1 — MIT — https://github.com/facebook/hermes
 - babel-plugin-transform-flow-enums@0.0.2 — MIT — https://github.com/facebook/flow
-- babel-preset-expo@56.0.17 — MIT — https://github.com/expo/expo
+- babel-preset-expo@57.0.9 — MIT — https://github.com/expo/expo
 - badgin@1.2.3 — MIT — https://github.com/jaulz/badgin
 - balanced-match@4.0.4 — MIT — https://github.com/juliangruber/balanced-match
 - base64-js@1.5.1 — MIT — https://github.com/beatgammit/base64-js
@@ -450,7 +446,6 @@ SECTION 2: npm packages (601 packages)
 - css-select@5.2.2 — BSD-2-Clause — https://github.com/fb55/css-select
 - css-tree@1.1.3 — MIT — https://github.com/csstree/csstree
 - css-what@6.2.2 — BSD-2-Clause — https://github.com/fb55/css-what
-- css.escape@1.5.1 — MIT — https://github.com/mathiasbynens/CSS.escape
 - csstype@3.2.3 — MIT — https://github.com/frenic/csstype
 - debug@2.6.9 — MIT — https://github.com/visionmedia/debug
 - debug@3.2.7 — MIT — https://github.com/visionmedia/debug
@@ -463,7 +458,6 @@ SECTION 2: npm packages (601 packages)
 - detect-libc@2.1.2 — Apache-2.0 — https://github.com/lovell/detect-libc
 - detect-node-es@1.1.0 — MIT — https://github.com/thekashey/detect-node
 - dnssd-advertise@1.1.6 — MIT — https://github.com/kitten/dnssd-advertise
-- dom-accessibility-api@0.6.3 — MIT — https://github.com/eps1lon/dom-accessibility-api
 - dom-serializer@2.0.0 — MIT — https://github.com/cheeriojs/dom-serializer
 - domelementtype@2.3.0 — BSD-2-Clause — https://github.com/fb55/domelementtype
 - domhandler@5.0.3 — BSD-2-Clause — https://github.com/fb55/domhandler
@@ -482,49 +476,48 @@ SECTION 2: npm packages (601 packages)
 - escape-string-regexp@4.0.0 — MIT — https://github.com/sindresorhus/escape-string-regexp
 - etag@1.8.1 — MIT — https://github.com/jshttp/etag
 - event-target-shim@5.0.1 — MIT — https://github.com/mysticatea/event-target-shim
-- expo@56.0.16 — MIT — https://github.com/expo/expo
-- expo-apple-authentication@56.0.4 — MIT — https://github.com/expo/expo
-- expo-application@56.0.3 — MIT — https://github.com/expo/expo
-- expo-asset@56.0.20 — MIT — https://github.com/expo/expo
-- expo-audio@56.0.12 — MIT — https://github.com/expo/expo
-- expo-auth-session@56.0.15 — MIT — https://github.com/expo/expo
-- expo-blur@56.0.4 — MIT — https://github.com/expo/expo
-- expo-build-properties@56.0.23 — MIT — https://github.com/expo/expo
-- expo-clipboard@56.0.4 — MIT — https://github.com/expo/expo
-- expo-constants@56.0.21 — MIT — https://github.com/expo/expo
-- expo-constants@56.0.22 — MIT — https://github.com/expo/expo
-- expo-crypto@56.0.4 — MIT — https://github.com/expo/expo
-- expo-document-picker@56.0.4 — MIT — https://github.com/expo/expo
-- expo-eas-client@56.0.1 — MIT — https://github.com/expo/expo
-- expo-file-system@56.0.8 — MIT — https://github.com/expo/expo
-- expo-font@56.0.7 — MIT — https://github.com/expo/expo
-- expo-glass-effect@56.0.4 — MIT — https://github.com/expo/expo
-- expo-image@56.0.11 — MIT — https://github.com/expo/expo
-- expo-image-loader@56.0.3 — MIT — https://github.com/expo/expo
-- expo-image-manipulator@56.0.22 — MIT — https://github.com/expo/expo
-- expo-image-picker@56.0.21 — MIT — https://github.com/expo/expo
-- expo-json-utils@56.0.0 — MIT — https://github.com/expo/expo
-- expo-keep-awake@56.0.3 — MIT — https://github.com/expo/expo
-- expo-linking@56.0.15 — MIT — https://github.com/expo/expo
-- expo-localization@56.0.6 — MIT — https://github.com/expo/expo
-- expo-manifests@56.0.4 — MIT — https://github.com/expo/expo
-- expo-media-library@56.0.9 — MIT — https://github.com/expo/expo
-- expo-modules-autolinking@56.0.20 — MIT — https://github.com/expo/expo
-- expo-modules-core@56.0.21 — MIT — https://github.com/expo/expo
-- expo-modules-jsi@56.0.12 — MIT — https://github.com/expo/expo
-- expo-notifications@56.0.22 — MIT — https://github.com/expo/expo
+- expo@57.0.17 — MIT — https://github.com/expo/expo
+- expo-apple-authentication@57.0.1 — MIT — https://github.com/expo/expo
+- expo-application@57.0.2 — MIT — https://github.com/expo/expo
+- expo-asset@57.0.15 — MIT — https://github.com/expo/expo
+- expo-audio@57.0.4 — MIT — https://github.com/expo/expo
+- expo-auth-session@57.0.10 — MIT — https://github.com/expo/expo
+- expo-blur@57.0.2 — MIT — https://github.com/expo/expo
+- expo-build-properties@57.0.15 — MIT — https://github.com/expo/expo
+- expo-clipboard@57.0.1 — MIT — https://github.com/expo/expo
+- expo-constants@57.0.15 — MIT — https://github.com/expo/expo
+- expo-crypto@57.0.2 — MIT — https://github.com/expo/expo
+- expo-document-picker@57.0.1 — MIT — https://github.com/expo/expo
+- expo-eas-client@57.0.2 — MIT — https://github.com/expo/expo
+- expo-file-system@57.0.6 — MIT — https://github.com/expo/expo
+- expo-font@57.0.1 — MIT — https://github.com/expo/expo
+- expo-glass-effect@57.0.1 — MIT — https://github.com/expo/expo
+- expo-image@57.0.3 — MIT — https://github.com/expo/expo
+- expo-image-loader@57.0.1 — MIT — https://github.com/expo/expo
+- expo-image-manipulator@57.0.14 — MIT — https://github.com/expo/expo
+- expo-image-picker@57.0.14 — MIT — https://github.com/expo/expo
+- expo-json-utils@57.0.1 — MIT — https://github.com/expo/expo
+- expo-keep-awake@57.0.1 — MIT — https://github.com/expo/expo
+- expo-linking@57.0.8 — MIT — https://github.com/expo/expo
+- expo-localization@57.0.1 — MIT — https://github.com/expo/expo
+- expo-manifests@57.0.1 — MIT — https://github.com/expo/expo
+- expo-media-library@57.0.4 — MIT — https://github.com/expo/expo
+- expo-modules-autolinking@57.0.12 — MIT — https://github.com/expo/expo
+- expo-modules-core@57.0.14 — MIT — https://github.com/expo/expo
+- expo-modules-jsi@57.0.6 — MIT — https://github.com/expo/expo
+- expo-notifications@57.0.15 — MIT — https://github.com/expo/expo
 - expo-paste-input@0.2.2 — MIT — https://github.com/arunabhverma/expo-paste-input
-- expo-router@56.2.15 — MIT — https://github.com/expo/expo
-- expo-secure-store@56.0.4 — MIT — https://github.com/expo/expo
-- expo-server@56.0.5 — MIT — https://github.com/expo/expo
-- expo-sharing@56.0.22 — MIT — https://github.com/expo/expo
-- expo-splash-screen@56.0.13 — MIT — https://github.com/expo/expo
-- expo-status-bar@56.0.4 — MIT — https://github.com/expo/expo
-- expo-structured-headers@56.0.0 — MIT — https://github.com/expo/expo
-- expo-symbols@56.0.6 — MIT — https://github.com/expo/expo
-- expo-updates@56.0.22 — MIT — https://github.com/expo/expo
-- expo-updates-interface@56.0.2 — MIT — https://github.com/expo/expo
-- expo-web-browser@56.0.5 — MIT — https://github.com/expo/expo
+- expo-router@57.0.17 — MIT — https://github.com/expo/expo
+- expo-secure-store@57.0.2 — MIT — https://github.com/expo/expo
+- expo-server@57.0.3 — MIT — https://github.com/expo/expo
+- expo-sharing@57.0.16 — MIT — https://github.com/expo/expo
+- expo-splash-screen@57.0.8 — MIT — https://github.com/expo/expo
+- expo-status-bar@57.0.1 — MIT — https://github.com/expo/expo
+- expo-structured-headers@57.0.0 — MIT — https://github.com/expo/expo
+- expo-symbols@57.0.2 — MIT — https://github.com/expo/expo
+- expo-updates@57.0.18 — MIT — https://github.com/expo/expo
+- expo-updates-interface@57.0.1 — MIT — https://github.com/expo/expo
+- expo-web-browser@57.0.2 — MIT — https://github.com/expo/expo
 - exponential-backoff@3.1.3 — Apache-2.0 — https://github.com/coveooss/exponential-backoff
 - fast-deep-equal@3.1.3 — MIT — https://github.com/epoberezkin/fast-deep-equal
 - fb-dotslash@0.5.8 — (MIT OR Apache-2.0) — https://github.com/facebook/dotslash
@@ -549,11 +542,14 @@ SECTION 2: npm packages (601 packages)
 - has-flag@3.0.0 — MIT — https://github.com/sindresorhus/has-flag
 - has-flag@4.0.0 — MIT — https://github.com/sindresorhus/has-flag
 - hasown@2.0.4 — MIT — https://github.com/inspect-js/hasOwn
-- hermes-compiler@250829098.0.10 — MIT — https://github.com/facebook/hermes
-- hermes-estree@0.33.3 — MIT — https://github.com/facebook/hermes
+- hermes-compiler@250829098.0.17 — MIT — https://github.com/facebook/hermes
 - hermes-estree@0.35.0 — MIT — https://github.com/facebook/hermes
-- hermes-parser@0.33.3 — MIT — https://github.com/facebook/hermes
+- hermes-estree@0.36.0 — MIT — https://github.com/facebook/hermes
+- hermes-estree@0.36.1 — MIT — https://github.com/facebook/hermes
 - hermes-parser@0.35.0 — MIT — https://github.com/facebook/hermes
+- hermes-parser@0.36.0 — MIT — https://github.com/facebook/hermes
+- hermes-parser@0.36.1 — MIT — https://github.com/facebook/hermes
+- hoist-non-react-statics@3.3.2 — BSD-3-Clause — https://github.com/mridgway/hoist-non-react-statics
 - hosted-git-info@7.0.2 — ISC — https://github.com/npm/hosted-git-info
 - html-parse-stringify@3.0.1 — MIT — https://github.com/henrikjoreteg/html-parse-stringify
 - http-errors@2.0.1 — MIT — https://github.com/jshttp/http-errors
@@ -562,7 +558,6 @@ SECTION 2: npm packages (601 packages)
 - i18next@26.3.6 — MIT — https://github.com/i18next/i18next
 - ignore@5.3.2 — MIT — https://github.com/kaelzhang/node-ignore
 - image-size@1.2.1 — MIT — https://github.com/image-size/image-size
-- indent-string@4.0.0 — MIT — https://github.com/sindresorhus/indent-string
 - inherits@2.0.4 — ISC — https://github.com/isaacs/inherits
 - inline-style-prefixer@7.0.1 — MIT — https://github.com/robinweser/inline-style-prefixer
 - invariant@2.2.4 — MIT — https://github.com/zertosh/invariant
@@ -605,19 +600,33 @@ SECTION 2: npm packages (601 packages)
 - merge-options@3.0.4 — MIT — https://github.com/schnittstabil/merge-options
 - merge-stream@2.0.0 — MIT — https://github.com/grncdr/merge-stream
 - metro@0.84.4 — MIT — https://github.com/facebook/metro
+- metro@0.84.5 — MIT — https://github.com/react/metro
 - metro-babel-transformer@0.84.4 — MIT — https://github.com/facebook/metro
+- metro-babel-transformer@0.84.5 — MIT — https://github.com/react/metro
 - metro-cache@0.84.4 — MIT — https://github.com/facebook/metro
+- metro-cache@0.84.5 — MIT — https://github.com/react/metro
 - metro-cache-key@0.84.4 — MIT — https://github.com/facebook/metro
+- metro-cache-key@0.84.5 — MIT — https://github.com/react/metro
 - metro-config@0.84.4 — MIT — https://github.com/facebook/metro
+- metro-config@0.84.5 — MIT — https://github.com/react/metro
 - metro-core@0.84.4 — MIT — https://github.com/facebook/metro
+- metro-core@0.84.5 — MIT — https://github.com/react/metro
 - metro-file-map@0.84.4 — MIT — https://github.com/facebook/metro
+- metro-file-map@0.84.5 — MIT — https://github.com/react/metro
 - metro-minify-terser@0.84.4 — MIT — https://github.com/facebook/metro
+- metro-minify-terser@0.84.5 — MIT — https://github.com/react/metro
 - metro-resolver@0.84.4 — MIT — https://github.com/facebook/metro
+- metro-resolver@0.84.5 — MIT — https://github.com/react/metro
 - metro-runtime@0.84.4 — MIT — https://github.com/facebook/metro
+- metro-runtime@0.84.5 — MIT — https://github.com/react/metro
 - metro-source-map@0.84.4 — MIT — https://github.com/facebook/metro
+- metro-source-map@0.84.5 — MIT — https://github.com/react/metro
 - metro-symbolicate@0.84.4 — MIT — https://github.com/facebook/metro
+- metro-symbolicate@0.84.5 — MIT — https://github.com/react/metro
 - metro-transform-plugins@0.84.4 — MIT — https://github.com/facebook/metro
+- metro-transform-plugins@0.84.5 — MIT — https://github.com/react/metro
 - metro-transform-worker@0.84.4 — MIT — https://github.com/facebook/metro
+- metro-transform-worker@0.84.5 — MIT — https://github.com/react/metro
 - micromatch@4.0.8 — MIT — https://github.com/micromatch/micromatch
 - mime@1.6.0 — MIT — https://github.com/broofa/node-mime
 - mime-db@1.52.0 — MIT — https://github.com/jshttp/mime-db
@@ -625,13 +634,12 @@ SECTION 2: npm packages (601 packages)
 - mime-types@2.1.35 — MIT — https://github.com/jshttp/mime-types
 - mime-types@3.0.2 — MIT — https://github.com/jshttp/mime-types
 - mimic-fn@1.2.0 — MIT — https://github.com/sindresorhus/mimic-fn
-- min-indent@1.0.1 — MIT — https://github.com/thejameskyle/min-indent
 - minimatch@10.2.5 — BlueOak-1.0.0 — https://github.com/isaacs/minimatch
 - minipass@7.1.3 — BlueOak-1.0.0 — https://github.com/isaacs/minipass
 - mkdirp@1.0.4 — MIT — https://github.com/isaacs/node-mkdirp
 - ms@2.0.0 — MIT — https://github.com/zeit/ms
 - ms@2.1.3 — MIT — https://github.com/vercel/ms
-- multitars@1.0.0 — MIT — https://github.com/kitten/multitars
+- multitars@1.0.2 — MIT — https://github.com/expo/multitars
 - nanoid@3.3.16 — MIT — https://github.com/ai/nanoid
 - negotiator@0.6.3 — MIT — https://github.com/jshttp/negotiator
 - negotiator@0.6.4 — MIT — https://github.com/jshttp/negotiator
@@ -644,6 +652,7 @@ SECTION 2: npm packages (601 packages)
 - nth-check@2.1.1 — BSD-2-Clause — https://github.com/fb55/nth-check
 - nullthrows@1.1.1 — MIT — https://github.com/zertosh/nullthrows
 - ob1@0.84.4 — MIT — https://github.com/facebook/metro
+- ob1@0.84.5 — MIT — https://github.com/react/metro
 - object-assign@4.1.1 — MIT — https://github.com/sindresorhus/object-assign
 - on-finished@2.3.0 — MIT — https://github.com/jshttp/on-finished
 - on-finished@2.4.1 — MIT — https://github.com/jshttp/on-finished
@@ -679,25 +688,25 @@ SECTION 2: npm packages (601 packages)
 - react-fast-compare@3.2.2 — MIT — https://github.com/FormidableLabs/react-fast-compare
 - react-freeze@1.0.4 — MIT — https://github.com/software-mansion/react-freeze
 - react-i18next@17.0.10 — MIT — https://github.com/i18next/react-i18next
+- react-is@16.13.1 — MIT — https://github.com/facebook/react
 - react-is@18.3.1 — MIT — https://github.com/facebook/react
 - react-is@19.2.7 — MIT — https://github.com/facebook/react
-- react-native@0.85.3 — MIT — https://github.com/facebook/react-native
+- react-native@0.86.3 — MIT — https://github.com/react/react-native
 - react-native-drawer-layout@4.2.7 — MIT — https://github.com/react-navigation/react-navigation
-- react-native-gesture-handler@3.0.2 — MIT — https://github.com/software-mansion/react-native-gesture-handler
+- react-native-gesture-handler@2.32.0 — MIT — https://github.com/software-mansion/react-native-gesture-handler
 - react-native-is-edge-to-edge@1.3.1 — MIT — https://github.com/zoontek/react-native-edge-to-edge
-- react-native-reanimated@4.3.1 — MIT — https://github.com/software-mansion/react-native-reanimated
+- react-native-reanimated@4.5.1 — MIT — https://github.com/software-mansion/react-native-reanimated
 - react-native-safe-area-context@5.7.0 — MIT — https://github.com/AppAndFlow/react-native-safe-area-context
-- react-native-screens@4.25.2 — MIT — https://github.com/software-mansion/react-native-screens
+- react-native-screens@4.26.2 — MIT — https://github.com/software-mansion/react-native-screens
 - react-native-svg@15.15.4 — MIT — https://github.com/react-native-community/react-native-svg
 - react-native-uitextview@2.2.0 — MIT — https://github.com/bluesky-social/react-native-uitextview
 - react-native-web@0.21.2 — MIT — https://github.com/necolas/react-native-web
 - react-native-webview@13.16.1 — MIT — https://github.com/react-native-webview/react-native-webview
-- react-native-worklets@0.8.3 — MIT — https://github.com/software-mansion/react-native-reanimated
+- react-native-worklets@0.10.1 — MIT — https://github.com/software-mansion/react-native-reanimated
 - react-refresh@0.14.2 — MIT — https://github.com/facebook/react
 - react-remove-scroll@2.7.2 — MIT — https://github.com/theKashey/react-remove-scroll
 - react-remove-scroll-bar@2.3.8 — MIT — https://github.com/theKashey/react-remove-scroll-bar
 - react-style-singleton@2.2.3 — MIT — https://github.com/theKashey/react-style-singleton
-- redent@3.0.0 — MIT — https://github.com/sindresorhus/redent
 - regenerate@1.4.2 — MIT — https://github.com/mathiasbynens/regenerate
 - regenerate-unicode-properties@10.2.2 — MIT — https://github.com/mathiasbynens/regenerate-unicode-properties
 - regenerator-runtime@0.13.11 — MIT — https://github.com/facebook/regenerator/tree/main/packages/runtime
@@ -711,6 +720,7 @@ SECTION 2: npm packages (601 packages)
 - restore-cursor@2.0.0 — MIT — https://github.com/sindresorhus/restore-cursor
 - rtl-detect@1.1.2 — BSD-3-Clause — https://github.com/shadiabuhilal/rtl-detect
 - safe-buffer@5.2.1 — MIT — https://github.com/feross/safe-buffer
+- sandbox-cli-detector@0.2.0 — MIT — https://github.com/davidmokos/sandbox-cli-detector
 - sax@1.6.0 — BlueOak-1.0.0 — https://github.com/isaacs/sax-js
 - scheduler@0.27.0 — MIT — https://github.com/facebook/react
 - semver@6.3.1 — ISC — https://github.com/npm/node-semver
@@ -746,7 +756,6 @@ SECTION 2: npm packages (601 packages)
 - string-width@4.2.3 — MIT — https://github.com/sindresorhus/string-width
 - strip-ansi@5.2.0 — MIT — https://github.com/chalk/strip-ansi
 - strip-ansi@6.0.1 — MIT — https://github.com/chalk/strip-ansi
-- strip-indent@3.0.0 — MIT — https://github.com/sindresorhus/strip-indent
 - structured-headers@0.4.1 — MIT — https://github.com/evert/structured-header
 - styleq@0.1.3 — MIT — https://github.com/necolas/styleq
 - supports-color@5.5.0 — MIT — https://github.com/chalk/supports-color
@@ -815,21 +824,7 @@ SECTION 3: Package license texts
 包元数据声明的 SPDX 标识为准(见前述 package sections)。
 
 ------------------------------------------------------------------------------
-[1] Applies to: npm:@adobe/css-tools@4.5.0
-------------------------------------------------------------------------------
-(The MIT License)
-
-Copyright (c) 2012 TJ Holowaychuk <tj@vision-media.ca>
-Copyright (c) 2022 Jean-Philippe Zolesio <holblin@gmail.com>
-
-Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the 'Software'), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
-
-The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
-
-THE SOFTWARE IS PROVIDED 'AS IS', WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
-
-------------------------------------------------------------------------------
-[2] Applies to: npm:@babel/code-frame@7.29.7, npm:@babel/compat-data@7.29.7, npm:@babel/core@7.29.7, npm:@babel/generator@7.29.7, npm:@babel/helper-annotate-as-pure@7.29.7, npm:@babel/helper-compilation-targets@7.29.7, npm:@babel/helper-create-class-features-plugin@7.29.7, npm:@babel/helper-create-regexp-features-plugin@7.29.7, npm:@babel/helper-globals@7.29.7, npm:@babel/helper-member-expression-to-functions@7.29.7, npm:@babel/helper-module-imports@7.29.7, npm:@babel/helper-module-transforms@7.29.7, npm:@babel/helper-optimise-call-expression@7.29.7, npm:@babel/helper-plugin-utils@7.29.7, npm:@babel/helper-remap-async-to-generator@7.29.7, npm:@babel/helper-replace-supers@7.29.7, npm:@babel/helper-skip-transparent-expression-wrappers@7.29.7, npm:@babel/helper-string-parser@7.29.7, npm:@babel/helper-validator-identifier@7.29.7, npm:@babel/helper-validator-option@7.29.7, npm:@babel/helper-wrap-function@7.29.7, npm:@babel/plugin-proposal-decorators@7.29.7, npm:@babel/plugin-proposal-export-default-from@7.29.7, npm:@babel/plugin-syntax-decorators@7.29.7, npm:@babel/plugin-syntax-dynamic-import@7.8.3, npm:@babel/plugin-syntax-export-default-from@7.29.7, npm:@babel/plugin-syntax-flow@7.29.7, npm:@babel/plugin-syntax-jsx@7.29.7, npm:@babel/plugin-syntax-nullish-coalescing-operator@7.8.3, npm:@babel/plugin-syntax-optional-chaining@7.8.3, npm:@babel/plugin-syntax-typescript@7.29.7, npm:@babel/plugin-transform-arrow-functions@7.29.7, npm:@babel/plugin-transform-async-generator-functions@7.29.7, npm:@babel/plugin-transform-async-to-generator@7.29.7, npm:@babel/plugin-transform-block-scoping@7.29.7, npm:@babel/plugin-transform-class-properties@7.29.7, npm:@babel/plugin-transform-class-static-block@7.29.7, npm:@babel/plugin-transform-classes@7.29.7, npm:@babel/plugin-transform-destructuring@7.29.7, npm:@babel/plugin-transform-export-namespace-from@7.29.7, npm:@babel/plugin-transform-flow-strip-types@7.29.7, npm:@babel/plugin-transform-for-of@7.29.7, npm:@babel/plugin-transform-logical-assignment-operators@7.29.7, npm:@babel/plugin-transform-modules-commonjs@7.29.7, npm:@babel/plugin-transform-named-capturing-groups-regex@7.29.7, npm:@babel/plugin-transform-nullish-coalescing-operator@7.29.7, npm:@babel/plugin-transform-object-rest-spread@7.29.7, npm:@babel/plugin-transform-optional-catch-binding@7.29.7, npm:@babel/plugin-transform-optional-chaining@7.29.7, npm:@babel/plugin-transform-parameters@7.29.7, npm:@babel/plugin-transform-private-methods@7.29.7, npm:@babel/plugin-transform-private-property-in-object@7.29.7, npm:@babel/plugin-transform-react-display-name@7.29.7, npm:@babel/plugin-transform-react-jsx@7.29.7, npm:@babel/plugin-transform-react-jsx-development@7.29.7, npm:@babel/plugin-transform-react-pure-annotations@7.29.7, npm:@babel/plugin-transform-runtime@7.29.7, npm:@babel/plugin-transform-shorthand-properties@7.29.7, npm:@babel/plugin-transform-template-literals@7.29.7, npm:@babel/plugin-transform-typescript@7.29.7, npm:@babel/plugin-transform-unicode-regex@7.29.7, npm:@babel/preset-typescript@7.29.7, npm:@babel/runtime@7.29.7, npm:@babel/template@7.29.7, npm:@babel/traverse@7.29.7, npm:@babel/types@7.29.7
+[1] Applies to: npm:@babel/code-frame@7.29.7, npm:@babel/compat-data@7.29.7, npm:@babel/core@7.29.7, npm:@babel/generator@7.29.7, npm:@babel/helper-annotate-as-pure@7.29.7, npm:@babel/helper-compilation-targets@7.29.7, npm:@babel/helper-create-class-features-plugin@7.29.7, npm:@babel/helper-create-regexp-features-plugin@7.29.7, npm:@babel/helper-globals@7.29.7, npm:@babel/helper-member-expression-to-functions@7.29.7, npm:@babel/helper-module-imports@7.29.7, npm:@babel/helper-module-transforms@7.29.7, npm:@babel/helper-optimise-call-expression@7.29.7, npm:@babel/helper-plugin-utils@7.29.7, npm:@babel/helper-remap-async-to-generator@7.29.7, npm:@babel/helper-replace-supers@7.29.7, npm:@babel/helper-skip-transparent-expression-wrappers@7.29.7, npm:@babel/helper-string-parser@7.29.7, npm:@babel/helper-validator-identifier@7.29.7, npm:@babel/helper-validator-option@7.29.7, npm:@babel/helper-wrap-function@7.29.7, npm:@babel/plugin-proposal-decorators@7.29.7, npm:@babel/plugin-proposal-export-default-from@7.29.7, npm:@babel/plugin-syntax-decorators@7.29.7, npm:@babel/plugin-syntax-dynamic-import@7.8.3, npm:@babel/plugin-syntax-export-default-from@7.29.7, npm:@babel/plugin-syntax-flow@7.29.7, npm:@babel/plugin-syntax-jsx@7.29.7, npm:@babel/plugin-syntax-nullish-coalescing-operator@7.8.3, npm:@babel/plugin-syntax-optional-chaining@7.8.3, npm:@babel/plugin-syntax-typescript@7.29.7, npm:@babel/plugin-transform-arrow-functions@7.29.7, npm:@babel/plugin-transform-async-generator-functions@7.29.7, npm:@babel/plugin-transform-async-to-generator@7.29.7, npm:@babel/plugin-transform-block-scoping@7.29.7, npm:@babel/plugin-transform-class-properties@7.29.7, npm:@babel/plugin-transform-class-static-block@7.29.7, npm:@babel/plugin-transform-classes@7.29.7, npm:@babel/plugin-transform-destructuring@7.29.7, npm:@babel/plugin-transform-export-namespace-from@7.29.7, npm:@babel/plugin-transform-flow-strip-types@7.29.7, npm:@babel/plugin-transform-for-of@7.29.7, npm:@babel/plugin-transform-logical-assignment-operators@7.29.7, npm:@babel/plugin-transform-modules-commonjs@7.29.7, npm:@babel/plugin-transform-named-capturing-groups-regex@7.29.7, npm:@babel/plugin-transform-nullish-coalescing-operator@7.29.7, npm:@babel/plugin-transform-object-rest-spread@7.29.7, npm:@babel/plugin-transform-optional-catch-binding@7.29.7, npm:@babel/plugin-transform-optional-chaining@7.29.7, npm:@babel/plugin-transform-parameters@7.29.7, npm:@babel/plugin-transform-private-methods@7.29.7, npm:@babel/plugin-transform-private-property-in-object@7.29.7, npm:@babel/plugin-transform-react-display-name@7.29.7, npm:@babel/plugin-transform-react-jsx@7.29.7, npm:@babel/plugin-transform-react-jsx-development@7.29.7, npm:@babel/plugin-transform-react-pure-annotations@7.29.7, npm:@babel/plugin-transform-runtime@7.29.7, npm:@babel/plugin-transform-shorthand-properties@7.29.7, npm:@babel/plugin-transform-template-literals@7.29.7, npm:@babel/plugin-transform-typescript@7.29.7, npm:@babel/plugin-transform-unicode-regex@7.29.7, npm:@babel/preset-typescript@7.29.7, npm:@babel/runtime@7.29.7, npm:@babel/template@7.29.7, npm:@babel/traverse@7.29.7, npm:@babel/types@7.29.7
 ------------------------------------------------------------------------------
 MIT License
 
@@ -855,7 +850,7 @@ OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
 WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[3] Applies to: npm:@babel/helper-define-polyfill-provider@0.6.8, npm:babel-plugin-polyfill-corejs2@0.4.17, npm:babel-plugin-polyfill-corejs3@0.13.0, npm:babel-plugin-polyfill-regenerator@0.6.8
+[2] Applies to: npm:@babel/helper-define-polyfill-provider@0.6.8, npm:babel-plugin-polyfill-corejs2@0.4.17, npm:babel-plugin-polyfill-corejs3@0.13.0, npm:babel-plugin-polyfill-regenerator@0.6.8
 ------------------------------------------------------------------------------
 MIT License
 
@@ -881,7 +876,7 @@ OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
 WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[4] Applies to: npm:@babel/helpers@7.29.7
+[3] Applies to: npm:@babel/helpers@7.29.7
 ------------------------------------------------------------------------------
 MIT License
 
@@ -908,9 +903,35 @@ OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
 WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[5] Applies to: npm:@babel/parser@7.29.7
+[4] Applies to: npm:@babel/parser@7.29.7
 ------------------------------------------------------------------------------
 Copyright (C) 2012-2014 by various contributors (see AUTHORS)
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+
+------------------------------------------------------------------------------
+[5] Applies to: npm:@egjs/hammerjs@2.0.17
+------------------------------------------------------------------------------
+The MIT License (MIT)
+
+Copyright (c) 2018-present NAVER Corp.
+Copyright (C) 2011-2017 by Jorik Tangelder (Eight Media)
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal
@@ -956,7 +977,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
 ------------------------------------------------------------------------------
-[7] Applies to: npm:@expo/cli@56.1.20, npm:@expo/config@56.0.12, npm:@expo/config-plugins@56.0.13, npm:@expo/devtools@56.0.2, npm:@expo/dom-webview@56.0.6, npm:@expo/expo-modules-macros-plugin@0.2.2, npm:@expo/fingerprint@0.19.8, npm:@expo/image-utils@0.10.3, npm:@expo/image-utils@0.10.4, npm:@expo/inline-modules@0.0.14, npm:@expo/json-file@10.2.0, npm:@expo/json-file@11.0.1, npm:@expo/local-build-cache-provider@56.0.10, npm:@expo/log-box@56.0.14, npm:@expo/metro-config@56.0.17, npm:@expo/metro-file-map@56.0.3, npm:@expo/metro-runtime@56.0.17, npm:@expo/osascript@2.7.1, npm:@expo/package-manager@1.13.1, npm:@expo/plist@0.7.0, npm:@expo/prebuild-config@56.0.20, npm:@expo/router-server@56.0.16, npm:babel-preset-expo@56.0.17, npm:expo@56.0.16, npm:expo-apple-authentication@56.0.4, npm:expo-application@56.0.3, npm:expo-asset@56.0.20, npm:expo-audio@56.0.12, npm:expo-auth-session@56.0.15, npm:expo-blur@56.0.4, npm:expo-build-properties@56.0.23, npm:expo-clipboard@56.0.4, npm:expo-constants@56.0.21, npm:expo-constants@56.0.22, npm:expo-crypto@56.0.4, npm:expo-document-picker@56.0.4, npm:expo-eas-client@56.0.1, npm:expo-file-system@56.0.8, npm:expo-font@56.0.7, npm:expo-glass-effect@56.0.4, npm:expo-image@56.0.11, npm:expo-image-loader@56.0.3, npm:expo-image-manipulator@56.0.22, npm:expo-image-picker@56.0.21, npm:expo-keep-awake@56.0.3, npm:expo-linking@56.0.15, npm:expo-localization@56.0.6, npm:expo-manifests@56.0.4, npm:expo-media-library@56.0.9, npm:expo-modules-autolinking@56.0.20, npm:expo-modules-core@56.0.21, npm:expo-modules-jsi@56.0.12, npm:expo-notifications@56.0.22, npm:expo-secure-store@56.0.4, npm:expo-server@56.0.5, npm:expo-sharing@56.0.22, npm:expo-splash-screen@56.0.13, npm:expo-status-bar@56.0.4, npm:expo-symbols@56.0.6, npm:expo-updates-interface@56.0.2, npm:expo-web-browser@56.0.5
+[7] Applies to: npm:@expo/cli@57.0.19, npm:@expo/config@57.0.9, npm:@expo/config-plugins@57.0.9, npm:@expo/devtools@57.0.1, npm:@expo/dom-webview@57.0.1, npm:@expo/expo-modules-macros-plugin@0.6.1, npm:@expo/fingerprint@0.20.10, npm:@expo/image-utils@0.11.5, npm:@expo/inline-modules@0.1.7, npm:@expo/json-file@11.0.1, npm:@expo/local-build-cache-provider@57.0.8, npm:@expo/log-box@57.0.4, npm:@expo/metro-config@57.0.11, npm:@expo/metro-file-map@57.0.2, npm:@expo/metro-runtime@57.0.14, npm:@expo/osascript@2.7.1, npm:@expo/package-manager@1.13.1, npm:@expo/plist@0.8.1, npm:@expo/prebuild-config@57.0.15, npm:@expo/router-server@57.0.8, npm:babel-preset-expo@57.0.9, npm:expo@57.0.17, npm:expo-apple-authentication@57.0.1, npm:expo-application@57.0.2, npm:expo-asset@57.0.15, npm:expo-audio@57.0.4, npm:expo-auth-session@57.0.10, npm:expo-blur@57.0.2, npm:expo-build-properties@57.0.15, npm:expo-clipboard@57.0.1, npm:expo-constants@57.0.15, npm:expo-crypto@57.0.2, npm:expo-document-picker@57.0.1, npm:expo-eas-client@57.0.2, npm:expo-file-system@57.0.6, npm:expo-font@57.0.1, npm:expo-glass-effect@57.0.1, npm:expo-image@57.0.3, npm:expo-image-loader@57.0.1, npm:expo-image-manipulator@57.0.14, npm:expo-image-picker@57.0.14, npm:expo-json-utils@57.0.1, npm:expo-keep-awake@57.0.1, npm:expo-linking@57.0.8, npm:expo-localization@57.0.1, npm:expo-manifests@57.0.1, npm:expo-media-library@57.0.4, npm:expo-modules-autolinking@57.0.12, npm:expo-modules-core@57.0.14, npm:expo-modules-jsi@57.0.6, npm:expo-notifications@57.0.15, npm:expo-secure-store@57.0.2, npm:expo-server@57.0.3, npm:expo-sharing@57.0.16, npm:expo-splash-screen@57.0.8, npm:expo-status-bar@57.0.1, npm:expo-symbols@57.0.2, npm:expo-updates-interface@57.0.1, npm:expo-web-browser@57.0.2
 ------------------------------------------------------------------------------
 The MIT License (MIT)
 
@@ -981,7 +1002,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
 ------------------------------------------------------------------------------
-[8] Applies to: npm:@expo/code-signing-certificates@0.0.6, npm:@expo/config-types@56.0.7
+[8] Applies to: npm:@expo/code-signing-certificates@0.0.6, npm:@expo/config-types@57.0.2
 ------------------------------------------------------------------------------
 The MIT License (MIT)
 
@@ -1006,7 +1027,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
 ------------------------------------------------------------------------------
-[9] Applies to: npm:@expo/env@2.3.1, npm:@expo/env@2.4.2
+[9] Applies to: npm:@expo/env@2.4.2
 ------------------------------------------------------------------------------
 The MIT License (MIT)
 
@@ -1031,7 +1052,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
 ------------------------------------------------------------------------------
-[10] Applies to: npm:@expo/metro@56.0.0
+[10] Applies to: npm:@expo/metro@56.0.2
 ------------------------------------------------------------------------------
 MIT License
 
@@ -1057,7 +1078,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
 ------------------------------------------------------------------------------
-[11] Applies to: npm:@expo/require-utils@56.1.5, npm:@expo/require-utils@56.1.6, npm:@expo/schema-utils@56.0.2
+[11] Applies to: npm:@expo/require-utils@57.0.5, npm:@expo/schema-utils@57.0.2
 ------------------------------------------------------------------------------
 The MIT License (MIT)
 
@@ -1151,7 +1172,7 @@ ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF OR
 IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
 
 ------------------------------------------------------------------------------
-[15] Applies to: npm:@jest/schemas@29.6.3, npm:@jest/types@29.6.3, npm:babel-plugin-syntax-hermes-parser@0.33.3, npm:hermes-estree@0.33.3, npm:hermes-estree@0.35.0, npm:hermes-parser@0.33.3, npm:hermes-parser@0.35.0, npm:jest-get-type@29.6.3, npm:jest-util@29.7.0, npm:jest-validate@29.7.0, npm:jest-worker@29.7.0, npm:pretty-format@29.7.0, npm:react@19.2.3, npm:react-dom@19.2.3, npm:react-is@19.2.7, npm:react-native@0.85.3, npm:scheduler@0.27.0, npm:use-sync-external-store@1.6.0
+[15] Applies to: npm:@jest/schemas@29.6.3, npm:@jest/types@29.6.3, npm:babel-plugin-syntax-hermes-parser@0.36.0, npm:babel-plugin-syntax-hermes-parser@0.36.1, npm:hermes-estree@0.35.0, npm:hermes-estree@0.36.0, npm:hermes-estree@0.36.1, npm:hermes-parser@0.35.0, npm:hermes-parser@0.36.0, npm:hermes-parser@0.36.1, npm:jest-get-type@29.6.3, npm:jest-util@29.7.0, npm:jest-validate@29.7.0, npm:jest-worker@29.7.0, npm:pretty-format@29.7.0, npm:react@19.2.3, npm:react-dom@19.2.3, npm:react-is@19.2.7, npm:react-native@0.86.3, npm:scheduler@0.27.0, npm:use-sync-external-store@1.6.0
 ------------------------------------------------------------------------------
 MIT License
 
@@ -1347,7 +1368,32 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
 ------------------------------------------------------------------------------
-[23] Applies to: npm:@sinclair/typebox@0.27.10
+[23] Applies to: npm:@react-native-menu/menu@2.0.0
+------------------------------------------------------------------------------
+MIT License
+
+Copyright (c) 2020 Jesse Katsumata
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+
+------------------------------------------------------------------------------
+[24] Applies to: npm:@sinclair/typebox@0.27.10
 ------------------------------------------------------------------------------
 TypeBox: JSON Schema Type Builder with Static Type Resolution for TypeScript
 
@@ -1374,55 +1420,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[24] Applies to: npm:@testing-library/jest-dom@6.9.1
-------------------------------------------------------------------------------
-The MIT License (MIT)
-Copyright (c) 2017 Kent C. Dodds
-
-Permission is hereby granted, free of charge, to any person obtaining a copy
-of this software and associated documentation files (the "Software"), to deal
-in the Software without restriction, including without limitation the rights
-to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-copies of the Software, and to permit persons to whom the Software is
-furnished to do so, subject to the following conditions:
-
-The above copyright notice and this permission notice shall be included in all
-copies or substantial portions of the Software.
-
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
-SOFTWARE.
-
-------------------------------------------------------------------------------
-[25] Applies to: npm:@testing-library/user-event@14.6.1
-------------------------------------------------------------------------------
-The MIT License (MIT)
-Copyright (c) 2020 Giorgio Polvara
-
-Permission is hereby granted, free of charge, to any person obtaining a copy
-of this software and associated documentation files (the "Software"), to deal
-in the Software without restriction, including without limitation the rights
-to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-copies of the Software, and to permit persons to whom the Software is
-furnished to do so, subject to the following conditions:
-
-The above copyright notice and this permission notice shall be included in all
-copies or substantial portions of the Software.
-
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
-SOFTWARE.
-
-------------------------------------------------------------------------------
-[26] Applies to: npm:@types/istanbul-lib-coverage@2.0.6, npm:@types/istanbul-lib-report@3.0.3, npm:@types/istanbul-reports@3.0.4, npm:@types/node@25.9.5, npm:@types/pako@2.0.4, npm:@types/react@19.2.17, npm:@types/react-test-renderer@19.1.0, npm:@types/yargs@17.0.35, npm:@types/yargs-parser@21.0.3
+[25] Applies to: npm:@types/hammerjs@2.0.46, npm:@types/istanbul-lib-coverage@2.0.6, npm:@types/istanbul-lib-report@3.0.3, npm:@types/istanbul-reports@3.0.4, npm:@types/node@25.9.5, npm:@types/pako@2.0.4, npm:@types/react@19.2.17, npm:@types/react-test-renderer@19.1.0, npm:@types/yargs@17.0.35, npm:@types/yargs-parser@21.0.3
 ------------------------------------------------------------------------------
 MIT License
 
@@ -1447,7 +1445,7 @@ MIT License
     SOFTWARE
 
 ------------------------------------------------------------------------------
-[27] Applies to: npm:@ungap/structured-clone@1.3.3
+[26] Applies to: npm:@ungap/structured-clone@1.3.3
 ------------------------------------------------------------------------------
 ISC License
 
@@ -1466,7 +1464,7 @@ OR OTHER TORTIOUS ACTION, ARISING OUT OF OR IN CONNECTION WITH THE USE OR
 PERFORMANCE OF THIS SOFTWARE.
 
 ------------------------------------------------------------------------------
-[28] Applies to: npm:@xmldom/xmldom@0.8.13, npm:@xmldom/xmldom@0.9.10
+[27] Applies to: npm:@xmldom/xmldom@0.8.13, npm:@xmldom/xmldom@0.9.10
 ------------------------------------------------------------------------------
 Copyright 2019 - present Christopher J. Brody and other contributors, as listed in: https://github.com/xmldom/xmldom/graphs/contributors
 Copyright 2012 - 2017 @jindw <jindw@xidea.org> and other contributors, as listed in: https://github.com/jindw/xmldom/graphs/contributors
@@ -1478,7 +1476,7 @@ The above copyright notice and this permission notice shall be included in all c
 THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[29] Applies to: npm:abort-controller@3.0.0
+[28] Applies to: npm:abort-controller@3.0.0
 ------------------------------------------------------------------------------
 MIT License
 
@@ -1503,7 +1501,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
 ------------------------------------------------------------------------------
-[30] Applies to: npm:accepts@1.3.8, npm:accepts@2.0.0, npm:mime-types@2.1.35, npm:mime-types@3.0.2
+[29] Applies to: npm:accepts@1.3.8, npm:accepts@2.0.0, npm:mime-types@2.1.35, npm:mime-types@3.0.2
 ------------------------------------------------------------------------------
 (The MIT License)
 
@@ -1530,7 +1528,7 @@ TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
 SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[31] Applies to: npm:acorn@8.17.0
+[30] Applies to: npm:acorn@8.17.0
 ------------------------------------------------------------------------------
 MIT License
 
@@ -1555,7 +1553,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[32] Applies to: npm:agent-base@7.1.4, npm:https-proxy-agent@7.0.6
+[31] Applies to: npm:agent-base@7.1.4, npm:https-proxy-agent@7.0.6
 ------------------------------------------------------------------------------
 (The MIT License)
 
@@ -1581,7 +1579,7 @@ TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
 SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[33] Applies to: npm:agent-cli-detector@0.1.2
+[32] Applies to: npm:agent-cli-detector@0.1.6, npm:sandbox-cli-detector@0.2.0
 ------------------------------------------------------------------------------
 MIT License
 
@@ -1606,7 +1604,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
 ------------------------------------------------------------------------------
-[34] Applies to: npm:anser@1.4.10
+[33] Applies to: npm:anser@1.4.10
 ------------------------------------------------------------------------------
 The MIT License (MIT)
 
@@ -1631,7 +1629,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
 ------------------------------------------------------------------------------
-[35] Applies to: npm:ansi-escapes@4.3.2, npm:camelcase@6.3.0, npm:cli-spinners@2.9.2, npm:escape-string-regexp@4.0.0, npm:is-docker@2.2.1, npm:open@7.4.2, npm:supports-color@8.1.1, npm:wrap-ansi@7.0.0
+[34] Applies to: npm:ansi-escapes@4.3.2, npm:camelcase@6.3.0, npm:cli-spinners@2.9.2, npm:escape-string-regexp@4.0.0, npm:is-docker@2.2.1, npm:open@7.4.2, npm:supports-color@8.1.1, npm:wrap-ansi@7.0.0
 ------------------------------------------------------------------------------
 MIT License
 
@@ -1644,7 +1642,7 @@ The above copyright notice and this permission notice shall be included in all c
 THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[36] Applies to: npm:ansi-regex@4.1.1, npm:ansi-regex@5.0.1, npm:ansi-styles@3.2.1, npm:ansi-styles@4.3.0, npm:ansi-styles@5.2.0, npm:chalk@2.4.2, npm:chalk@4.1.2, npm:has-flag@3.0.0, npm:has-flag@4.0.0, npm:indent-string@4.0.0, npm:is-fullwidth-code-point@3.0.0, npm:is-plain-obj@2.1.0, npm:is-wsl@2.2.0, npm:leven@3.1.0, npm:log-symbols@2.2.0, npm:mimic-fn@1.2.0, npm:ora@3.4.0, npm:path-key@3.1.1, npm:redent@3.0.0, npm:resolve-from@5.0.0, npm:shebang-regex@3.0.0, npm:split-on-first@1.1.0, npm:string-width@4.2.3, npm:strip-ansi@5.2.0, npm:strip-ansi@6.0.1, npm:strip-indent@3.0.0, npm:supports-color@5.5.0, npm:supports-color@7.2.0, npm:terminal-link@2.1.1, npm:type-fest@0.7.1
+[35] Applies to: npm:ansi-regex@4.1.1, npm:ansi-regex@5.0.1, npm:ansi-styles@3.2.1, npm:ansi-styles@4.3.0, npm:ansi-styles@5.2.0, npm:chalk@2.4.2, npm:chalk@4.1.2, npm:has-flag@3.0.0, npm:has-flag@4.0.0, npm:is-fullwidth-code-point@3.0.0, npm:is-plain-obj@2.1.0, npm:is-wsl@2.2.0, npm:leven@3.1.0, npm:log-symbols@2.2.0, npm:mimic-fn@1.2.0, npm:ora@3.4.0, npm:path-key@3.1.1, npm:resolve-from@5.0.0, npm:shebang-regex@3.0.0, npm:split-on-first@1.1.0, npm:string-width@4.2.3, npm:strip-ansi@5.2.0, npm:strip-ansi@6.0.1, npm:supports-color@5.5.0, npm:supports-color@7.2.0, npm:terminal-link@2.1.1, npm:type-fest@0.7.1
 ------------------------------------------------------------------------------
 MIT License
 
@@ -1657,7 +1655,7 @@ The above copyright notice and this permission notice shall be included in all c
 THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[37] Applies to: npm:arg@4.1.3
+[36] Applies to: npm:arg@4.1.3
 ------------------------------------------------------------------------------
 MIT License
 
@@ -1682,7 +1680,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
 ------------------------------------------------------------------------------
-[38] Applies to: npm:arg@5.0.2
+[37] Applies to: npm:arg@5.0.2
 ------------------------------------------------------------------------------
 The MIT License (MIT)
 
@@ -1707,7 +1705,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
 ------------------------------------------------------------------------------
-[39] Applies to: npm:argparse@2.0.1
+[38] Applies to: npm:argparse@2.0.1
 ------------------------------------------------------------------------------
 A. HISTORY OF THE SOFTWARE
 ==========================
@@ -1965,7 +1963,7 @@ ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT
 OF OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
 
 ------------------------------------------------------------------------------
-[40] Applies to: npm:aria-hidden@1.2.6, npm:react-remove-scroll@2.7.2, npm:react-style-singleton@2.2.3, npm:use-callback-ref@1.3.3, npm:use-sidecar@1.1.3
+[39] Applies to: npm:aria-hidden@1.2.6, npm:react-remove-scroll@2.7.2, npm:react-style-singleton@2.2.3, npm:use-callback-ref@1.3.3, npm:use-sidecar@1.1.3
 ------------------------------------------------------------------------------
 MIT License
 
@@ -1990,212 +1988,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
 ------------------------------------------------------------------------------
-[41] Applies to: npm:aria-query@5.3.2
-------------------------------------------------------------------------------
-Apache License
-Version 2.0, January 2004
-http://www.apache.org/licenses/
-
-TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
-
-1. Definitions.
-
-"License" shall mean the terms and conditions for use, reproduction,
-and distribution as defined by Sections 1 through 9 of this document.
-
-"Licensor" shall mean the copyright owner or entity authorized by
-the copyright owner that is granting the License.
-
-"Legal Entity" shall mean the union of the acting entity and all
-other entities that control, are controlled by, or are under common
-control with that entity. For the purposes of this definition,
-"control" means (i) the power, direct or indirect, to cause the
-direction or management of such entity, whether by contract or
-otherwise, or (ii) ownership of fifty percent (50%) or more of the
-outstanding shares, or (iii) beneficial ownership of such entity.
-
-"You" (or "Your") shall mean an individual or Legal Entity
-exercising permissions granted by this License.
-
-"Source" form shall mean the preferred form for making modifications,
-including but not limited to software source code, documentation
-source, and configuration files.
-
-"Object" form shall mean any form resulting from mechanical
-transformation or translation of a Source form, including but
-not limited to compiled object code, generated documentation,
-and conversions to other media types.
-
-"Work" shall mean the work of authorship, whether in Source or
-Object form, made available under the License, as indicated by a
-copyright notice that is included in or attached to the work
-(an example is provided in the Appendix below).
-
-"Derivative Works" shall mean any work, whether in Source or Object
-form, that is based on (or derived from) the Work and for which the
-editorial revisions, annotations, elaborations, or other modifications
-represent, as a whole, an original work of authorship. For the purposes
-of this License, Derivative Works shall not include works that remain
-separable from, or merely link (or bind by name) to the interfaces of,
-the Work and Derivative Works thereof.
-
-"Contribution" shall mean any work of authorship, including
-the original version of the Work and any modifications or additions
-to that Work or Derivative Works thereof, that is intentionally
-submitted to Licensor for inclusion in the Work by the copyright owner
-or by an individual or Legal Entity authorized to submit on behalf of
-the copyright owner. For the purposes of this definition, "submitted"
-means any form of electronic, verbal, or written communication sent
-to the Licensor or its representatives, including but not limited to
-communication on electronic mailing lists, source code control systems,
-and issue tracking systems that are managed by, or on behalf of, the
-Licensor for the purpose of discussing and improving the Work, but
-excluding communication that is conspicuously marked or otherwise
-designated in writing by the copyright owner as "Not a Contribution."
-
-"Contributor" shall mean Licensor and any individual or Legal Entity
-on behalf of whom a Contribution has been received by Licensor and
-subsequently incorporated within the Work.
-
-2. Grant of Copyright License. Subject to the terms and conditions of
-this License, each Contributor hereby grants to You a perpetual,
-worldwide, non-exclusive, no-charge, royalty-free, irrevocable
-copyright license to reproduce, prepare Derivative Works of,
-publicly display, publicly perform, sublicense, and distribute the
-Work and such Derivative Works in Source or Object form.
-
-3. Grant of Patent License. Subject to the terms and conditions of
-this License, each Contributor hereby grants to You a perpetual,
-worldwide, non-exclusive, no-charge, royalty-free, irrevocable
-(except as stated in this section) patent license to make, have made,
-use, offer to sell, sell, import, and otherwise transfer the Work,
-where such license applies only to those patent claims licensable
-by such Contributor that are necessarily infringed by their
-Contribution(s) alone or by combination of their Contribution(s)
-with the Work to which such Contribution(s) was submitted. If You
-institute patent litigation against any entity (including a
-cross-claim or counterclaim in a lawsuit) alleging that the Work
-or a Contribution incorporated within the Work constitutes direct
-or contributory patent infringement, then any patent licenses
-granted to You under this License for that Work shall terminate
-as of the date such litigation is filed.
-
-4. Redistribution. You may reproduce and distribute copies of the
-Work or Derivative Works thereof in any medium, with or without
-modifications, and in Source or Object form, provided that You
-meet the following conditions:
-
-(a) You must give any other recipients of the Work or
-Derivative Works a copy of this License; and
-
-(b) You must cause any modified files to carry prominent notices
-stating that You changed the files; and
-
-(c) You must retain, in the Source form of any Derivative Works
-that You distribute, all copyright, patent, trademark, and
-attribution notices from the Source form of the Work,
-excluding those notices that do not pertain to any part of
-the Derivative Works; and
-
-(d) If the Work includes a "NOTICE" text file as part of its
-distribution, then any Derivative Works that You distribute must
-include a readable copy of the attribution notices contained
-within such NOTICE file, excluding those notices that do not
-pertain to any part of the Derivative Works, in at least one
-of the following places: within a NOTICE text file distributed
-as part of the Derivative Works; within the Source form or
-documentation, if provided along with the Derivative Works; or,
-within a display generated by the Derivative Works, if and
-wherever such third-party notices normally appear. The contents
-of the NOTICE file are for informational purposes only and
-do not modify the License. You may add Your own attribution
-notices within Derivative Works that You distribute, alongside
-or as an addendum to the NOTICE text from the Work, provided
-that such additional attribution notices cannot be construed
-as modifying the License.
-
-You may add Your own copyright statement to Your modifications and
-may provide additional or different license terms and conditions
-for use, reproduction, or distribution of Your modifications, or
-for any such Derivative Works as a whole, provided Your use,
-reproduction, and distribution of the Work otherwise complies with
-the conditions stated in this License.
-
-5. Submission of Contributions. Unless You explicitly state otherwise,
-any Contribution intentionally submitted for inclusion in the Work
-by You to the Licensor shall be under the terms and conditions of
-this License, without any additional terms or conditions.
-Notwithstanding the above, nothing herein shall supersede or modify
-the terms of any separate license agreement you may have executed
-with Licensor regarding such Contributions.
-
-6. Trademarks. This License does not grant permission to use the trade
-names, trademarks, service marks, or product names of the Licensor,
-except as required for reasonable and customary use in describing the
-origin of the Work and reproducing the content of the NOTICE file.
-
-7. Disclaimer of Warranty. Unless required by applicable law or
-agreed to in writing, Licensor provides the Work (and each
-Contributor provides its Contributions) on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
-implied, including, without limitation, any warranties or conditions
-of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
-PARTICULAR PURPOSE. You are solely responsible for determining the
-appropriateness of using or redistributing the Work and assume any
-risks associated with Your exercise of permissions under this License.
-
-8. Limitation of Liability. In no event and under no legal theory,
-whether in tort (including negligence), contract, or otherwise,
-unless required by applicable law (such as deliberate and grossly
-negligent acts) or agreed to in writing, shall any Contributor be
-liable to You for damages, including any direct, indirect, special,
-incidental, or consequential damages of any character arising as a
-result of this License or out of the use or inability to use the
-Work (including but not limited to damages for loss of goodwill,
-work stoppage, computer failure or malfunction, or any and all
-other commercial damages or losses), even if such Contributor
-has been advised of the possibility of such damages.
-
-9. Accepting Warranty or Additional Liability. While redistributing
-the Work or Derivative Works thereof, You may choose to offer,
-and charge a fee for, acceptance of support, warranty, indemnity,
-or other liability obligations and/or rights consistent with this
-License. However, in accepting such obligations, You may act only
-on Your own behalf and on Your sole responsibility, not on behalf
-of any other Contributor, and only if You agree to indemnify,
-defend, and hold each Contributor harmless for any liability
-incurred by, or claims asserted against, such Contributor by reason
-of your accepting any such warranty or additional liability.
-
-END OF TERMS AND CONDITIONS
-
-APPENDIX: How to apply the Apache License to your work.
-
-To apply the Apache License to your work, attach the following
-boilerplate notice, with the fields enclosed by brackets "{}"
-replaced with your own identifying information. (Don't include
-the brackets!)  The text should be enclosed in the appropriate
-comment syntax for the file format. We also recommend that a
-file or class name and description of purpose be included on the
-same "printed page" as the copyright notice for easier
-identification within third-party archives.
-
-Copyright 2020 A11yance
-
-Licensed under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License.
-You may obtain a copy of the License at
-
-http://www.apache.org/licenses/LICENSE-2.0
-
-Unless required by applicable law or agreed to in writing, software
-distributed under the License is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-See the License for the specific language governing permissions and
-limitations under the License.
-
-------------------------------------------------------------------------------
-[42] Applies to: npm:asap@2.0.6
+[40] Applies to: npm:asap@2.0.6
 ------------------------------------------------------------------------------
 Copyright 2009–2014 Contributors. All rights reserved.
 
@@ -2218,7 +2011,7 @@ FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
 IN THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[43] Applies to: npm:babel-plugin-react-native-web@0.21.2
+[41] Applies to: npm:babel-plugin-react-native-web@0.21.2
 ------------------------------------------------------------------------------
 MIT License
 
@@ -2243,7 +2036,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
 ------------------------------------------------------------------------------
-[44] Applies to: npm:babel-plugin-transform-flow-enums@0.0.2, npm:flow-enums-runtime@0.0.6, npm:react-is@18.3.1, npm:react-refresh@0.14.2
+[42] Applies to: npm:babel-plugin-transform-flow-enums@0.0.2, npm:flow-enums-runtime@0.0.6, npm:react-is@16.13.1, npm:react-is@18.3.1, npm:react-refresh@0.14.2
 ------------------------------------------------------------------------------
 MIT License
 
@@ -2268,7 +2061,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
 ------------------------------------------------------------------------------
-[45] Applies to: npm:balanced-match@4.0.4
+[43] Applies to: npm:balanced-match@4.0.4
 ------------------------------------------------------------------------------
 (MIT)
 
@@ -2295,7 +2088,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
 ------------------------------------------------------------------------------
-[46] Applies to: npm:base64-js@1.5.1
+[44] Applies to: npm:base64-js@1.5.1
 ------------------------------------------------------------------------------
 The MIT License (MIT)
 
@@ -2320,7 +2113,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[47] Applies to: npm:baseline-browser-mapping@2.10.43, npm:xcode@3.0.1
+[45] Applies to: npm:baseline-browser-mapping@2.10.43, npm:xcode@3.0.1
 ------------------------------------------------------------------------------
 Apache License
                            Version 2.0, January 2004
@@ -2525,7 +2318,7 @@ Apache License
    limitations under the License.
 
 ------------------------------------------------------------------------------
-[48] Applies to: npm:big-integer@1.6.52
+[46] Applies to: npm:big-integer@1.6.52
 ------------------------------------------------------------------------------
 This is free and unencumbered software released into the public domain.
 
@@ -2553,7 +2346,7 @@ OTHER DEALINGS IN THE SOFTWARE.
 For more information, please refer to <http://unlicense.org>
 
 ------------------------------------------------------------------------------
-[49] Applies to: npm:bplist-creator@0.1.0
+[47] Applies to: npm:bplist-creator@0.1.0
 ------------------------------------------------------------------------------
 (The MIT License)
 
@@ -2575,7 +2368,7 @@ WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN 
 OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[50] Applies to: npm:brace-expansion@5.0.8
+[48] Applies to: npm:brace-expansion@5.0.8
 ------------------------------------------------------------------------------
 MIT License
 
@@ -2602,7 +2395,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
 ------------------------------------------------------------------------------
-[51] Applies to: npm:braces@3.0.3, npm:fill-range@7.1.1, npm:is-number@7.0.0, npm:micromatch@4.0.8
+[49] Applies to: npm:braces@3.0.3, npm:fill-range@7.1.1, npm:is-number@7.0.0, npm:micromatch@4.0.8
 ------------------------------------------------------------------------------
 The MIT License (MIT)
 
@@ -2627,7 +2420,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[52] Applies to: npm:browserslist@4.28.6
+[50] Applies to: npm:browserslist@4.28.6
 ------------------------------------------------------------------------------
 The MIT License (MIT)
 
@@ -2651,7 +2444,7 @@ IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
 CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[53] Applies to: npm:buffer-from@1.1.2
+[51] Applies to: npm:buffer-from@1.1.2
 ------------------------------------------------------------------------------
 MIT License
 
@@ -2676,7 +2469,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
 ------------------------------------------------------------------------------
-[54] Applies to: npm:bytes@3.1.2
+[52] Applies to: npm:bytes@3.1.2
 ------------------------------------------------------------------------------
 (The MIT License)
 
@@ -2703,7 +2496,7 @@ TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
 SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[55] Applies to: npm:caniuse-lite@1.0.30001805
+[53] Applies to: npm:caniuse-lite@1.0.30001805
 ------------------------------------------------------------------------------
 Attribution 4.0 International
 
@@ -3102,7 +2895,7 @@ public licenses.
 Creative Commons may be contacted at creativecommons.org.
 
 ------------------------------------------------------------------------------
-[56] Applies to: npm:chrome-launcher@0.15.2, npm:chromium-edge-launcher@0.3.0, npm:lighthouse-logger@1.4.2
+[54] Applies to: npm:chrome-launcher@0.15.2, npm:chromium-edge-launcher@0.3.0, npm:lighthouse-logger@1.4.2
 ------------------------------------------------------------------------------
 Apache License
                            Version 2.0, January 2004
@@ -3307,7 +3100,7 @@ Apache License
    limitations under the License.
 
 ------------------------------------------------------------------------------
-[57] Applies to: npm:ci-info@2.0.0
+[55] Applies to: npm:ci-info@2.0.0
 ------------------------------------------------------------------------------
 The MIT License (MIT)
 
@@ -3332,7 +3125,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
 ------------------------------------------------------------------------------
-[58] Applies to: npm:ci-info@3.9.0
+[56] Applies to: npm:ci-info@3.9.0
 ------------------------------------------------------------------------------
 The MIT License (MIT)
 
@@ -3357,7 +3150,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
 ------------------------------------------------------------------------------
-[59] Applies to: npm:cli-cursor@2.1.0, npm:escape-string-regexp@1.0.5, npm:filter-obj@1.1.0, npm:object-assign@4.1.1, npm:onetime@2.0.1, npm:restore-cursor@2.0.0, npm:serialize-error@2.1.0
+[57] Applies to: npm:cli-cursor@2.1.0, npm:escape-string-regexp@1.0.5, npm:filter-obj@1.1.0, npm:object-assign@4.1.1, npm:onetime@2.0.1, npm:restore-cursor@2.0.0, npm:serialize-error@2.1.0
 ------------------------------------------------------------------------------
 The MIT License (MIT)
 
@@ -3382,7 +3175,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[60] Applies to: npm:cliui@8.0.1
+[58] Applies to: npm:cliui@8.0.1
 ------------------------------------------------------------------------------
 Copyright (c) 2015, Contributors
 
@@ -3400,7 +3193,7 @@ WHETHER IN AN ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION,
 ARISING OUT OF OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
 
 ------------------------------------------------------------------------------
-[61] Applies to: npm:clone@1.0.4
+[59] Applies to: npm:clone@1.0.4
 ------------------------------------------------------------------------------
 Copyright © 2011-2015 Paul Vorbach <paul@vorba.ch>
 
@@ -3422,7 +3215,7 @@ IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, OUT OF OR IN CONNECTION WITH THE
 SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[62] Applies to: npm:color@4.2.3
+[60] Applies to: npm:color@4.2.3
 ------------------------------------------------------------------------------
 Copyright (c) 2012 Heather Arthur
 
@@ -3446,7 +3239,7 @@ OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
 WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[63] Applies to: npm:color-convert@1.9.3, npm:color-convert@2.0.1
+[61] Applies to: npm:color-convert@1.9.3, npm:color-convert@2.0.1
 ------------------------------------------------------------------------------
 Copyright (c) 2011-2016 Heather Arthur <fayearthur@gmail.com>
 
@@ -3470,7 +3263,7 @@ OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
 WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[64] Applies to: npm:color-name@1.1.3, npm:color-name@1.1.4
+[62] Applies to: npm:color-name@1.1.3, npm:color-name@1.1.4
 ------------------------------------------------------------------------------
 The MIT License (MIT)
 Copyright (c) 2015 Dmitry Ivanov
@@ -3482,7 +3275,7 @@ The above copyright notice and this permission notice shall be included in all c
 THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[65] Applies to: npm:color-string@1.9.1
+[63] Applies to: npm:color-string@1.9.1
 ------------------------------------------------------------------------------
 Copyright (c) 2011 Heather Arthur <fayearthur@gmail.com>
 
@@ -3506,7 +3299,7 @@ OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
 WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[66] Applies to: npm:commander@12.1.0, npm:commander@2.20.3, npm:commander@7.2.0
+[64] Applies to: npm:commander@12.1.0, npm:commander@2.20.3, npm:commander@7.2.0
 ------------------------------------------------------------------------------
 (The MIT License)
 
@@ -3532,7 +3325,7 @@ TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
 SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[67] Applies to: npm:compressible@2.0.18
+[65] Applies to: npm:compressible@2.0.18
 ------------------------------------------------------------------------------
 (The MIT License)
 
@@ -3560,7 +3353,7 @@ TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
 SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[68] Applies to: npm:compression@1.8.1
+[66] Applies to: npm:compression@1.8.1
 ------------------------------------------------------------------------------
 (The MIT License)
 
@@ -3587,7 +3380,7 @@ TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
 SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[69] Applies to: npm:connect@3.7.0
+[67] Applies to: npm:connect@3.7.0
 ------------------------------------------------------------------------------
 (The MIT License)
 
@@ -3616,7 +3409,7 @@ TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
 SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[70] Applies to: npm:convert-source-map@2.0.0
+[68] Applies to: npm:convert-source-map@2.0.0
 ------------------------------------------------------------------------------
 Copyright 2013 Thorsten Lorenz.
 All rights reserved.
@@ -3643,7 +3436,7 @@ FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
 OTHER DEALINGS IN THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[71] Applies to: npm:core-js-compat@3.49.0
+[69] Applies to: npm:core-js-compat@3.49.0
 ------------------------------------------------------------------------------
 Copyright (c) 2013–2025 Denis Pushkarev (zloirock.ru)
 Copyright (c) 2025–2026 CoreJS Company (core-js.io)
@@ -3667,7 +3460,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[72] Applies to: npm:cross-fetch@3.2.0
+[70] Applies to: npm:cross-fetch@3.2.0
 ------------------------------------------------------------------------------
 The MIT License (MIT)
 
@@ -3692,7 +3485,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
 ------------------------------------------------------------------------------
-[73] Applies to: npm:cross-spawn@7.0.6
+[71] Applies to: npm:cross-spawn@7.0.6
 ------------------------------------------------------------------------------
 The MIT License (MIT)
 
@@ -3717,7 +3510,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[74] Applies to: npm:css-in-js-utils@3.1.0
+[72] Applies to: npm:css-in-js-utils@3.1.0
 ------------------------------------------------------------------------------
 MIT License
 
@@ -3742,7 +3535,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
 ------------------------------------------------------------------------------
-[75] Applies to: npm:css-select@5.2.2, npm:css-what@6.2.2, npm:domelementtype@2.3.0, npm:domhandler@5.0.3, npm:domutils@3.2.2, npm:entities@4.5.0, npm:nth-check@2.1.1
+[73] Applies to: npm:css-select@5.2.2, npm:css-what@6.2.2, npm:domelementtype@2.3.0, npm:domhandler@5.0.3, npm:domutils@3.2.2, npm:entities@4.5.0, npm:nth-check@2.1.1
 ------------------------------------------------------------------------------
 Copyright (c) Felix Böhm
 All rights reserved.
@@ -3757,7 +3550,7 @@ THIS IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRE
 EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 ------------------------------------------------------------------------------
-[76] Applies to: npm:css-tree@1.1.3
+[74] Applies to: npm:css-tree@1.1.3
 ------------------------------------------------------------------------------
 Copyright (C) 2016-2019 by Roman Dvornov
 
@@ -3780,31 +3573,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[77] Applies to: npm:css.escape@1.5.1, npm:emoji-regex@8.0.0, npm:jsesc@3.1.0, npm:regenerate@1.4.2, npm:regenerate-unicode-properties@10.2.2, npm:regexpu-core@6.4.0, npm:unicode-canonical-property-names-ecmascript@2.0.1, npm:unicode-match-property-ecmascript@2.0.0, npm:unicode-match-property-value-ecmascript@2.2.1, npm:unicode-property-aliases-ecmascript@2.2.0
-------------------------------------------------------------------------------
-Copyright Mathias Bynens <https://mathiasbynens.be/>
-
-Permission is hereby granted, free of charge, to any person obtaining
-a copy of this software and associated documentation files (the
-"Software"), to deal in the Software without restriction, including
-without limitation the rights to use, copy, modify, merge, publish,
-distribute, sublicense, and/or sell copies of the Software, and to
-permit persons to whom the Software is furnished to do so, subject to
-the following conditions:
-
-The above copyright notice and this permission notice shall be
-included in all copies or substantial portions of the Software.
-
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
-EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
-MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
-NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
-LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
-OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
-WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
-
-------------------------------------------------------------------------------
-[78] Applies to: npm:csstype@3.2.3
+[75] Applies to: npm:csstype@3.2.3
 ------------------------------------------------------------------------------
 Copyright (c) 2017-2018 Fredrik Nicol
 
@@ -3827,7 +3596,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
 ------------------------------------------------------------------------------
-[79] Applies to: npm:debug@2.6.9, npm:debug@3.2.7
+[76] Applies to: npm:debug@2.6.9, npm:debug@3.2.7
 ------------------------------------------------------------------------------
 (The MIT License)
 
@@ -3849,7 +3618,7 @@ WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN 
 SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[80] Applies to: npm:debug@4.4.3
+[77] Applies to: npm:debug@4.4.3
 ------------------------------------------------------------------------------
 (The MIT License)
 
@@ -3872,7 +3641,7 @@ WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN 
 SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[81] Applies to: npm:decode-uri-component@0.2.2
+[78] Applies to: npm:decode-uri-component@0.2.2
 ------------------------------------------------------------------------------
 The MIT License (MIT)
 
@@ -3885,7 +3654,7 @@ The above copyright notice and this permission notice shall be included in all c
 THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[82] Applies to: npm:deepmerge@4.3.1
+[79] Applies to: npm:deepmerge@4.3.1
 ------------------------------------------------------------------------------
 The MIT License (MIT)
 
@@ -3910,7 +3679,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[83] Applies to: npm:defaults@1.0.4
+[80] Applies to: npm:defaults@1.0.4
 ------------------------------------------------------------------------------
 The MIT License (MIT)
 
@@ -3936,7 +3705,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[84] Applies to: npm:depd@2.0.0
+[81] Applies to: npm:depd@2.0.0
 ------------------------------------------------------------------------------
 (The MIT License)
 
@@ -3962,7 +3731,7 @@ TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
 SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[85] Applies to: npm:destroy@1.2.0
+[82] Applies to: npm:destroy@1.2.0
 ------------------------------------------------------------------------------
 The MIT License (MIT)
 
@@ -3988,7 +3757,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[86] Applies to: npm:detect-libc@2.1.2
+[83] Applies to: npm:detect-libc@2.1.2
 ------------------------------------------------------------------------------
 Apache License
                            Version 2.0, January 2004
@@ -4193,7 +3962,7 @@ Apache License
    limitations under the License.
 
 ------------------------------------------------------------------------------
-[87] Applies to: npm:detect-node-es@1.1.0
+[84] Applies to: npm:detect-node-es@1.1.0
 ------------------------------------------------------------------------------
 MIT License
 
@@ -4218,7 +3987,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
 ------------------------------------------------------------------------------
-[88] Applies to: npm:dnssd-advertise@1.1.6, npm:multitars@1.0.0, npm:toqr@0.1.1
+[85] Applies to: npm:dnssd-advertise@1.1.6, npm:multitars@1.0.2, npm:toqr@0.1.1
 ------------------------------------------------------------------------------
 MIT License
 
@@ -4244,32 +4013,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
 ------------------------------------------------------------------------------
-[89] Applies to: npm:dom-accessibility-api@0.6.3
-------------------------------------------------------------------------------
-MIT License
-
-Copyright (c) 2020 Sebastian Silbermann
-
-Permission is hereby granted, free of charge, to any person obtaining a copy
-of this software and associated documentation files (the "Software"), to deal
-in the Software without restriction, including without limitation the rights
-to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-copies of the Software, and to permit persons to whom the Software is
-furnished to do so, subject to the following conditions:
-
-The above copyright notice and this permission notice shall be included in all
-copies or substantial portions of the Software.
-
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
-SOFTWARE.
-
-------------------------------------------------------------------------------
-[90] Applies to: npm:dom-serializer@2.0.0
+[86] Applies to: npm:dom-serializer@2.0.0
 ------------------------------------------------------------------------------
 License
 
@@ -4284,7 +4028,7 @@ The above copyright notice and this permission notice shall be included in all c
 THE SOFTWARE IS PROVIDED 'AS IS', WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[91] Applies to: npm:ee-first@1.1.1
+[87] Applies to: npm:ee-first@1.1.1
 ------------------------------------------------------------------------------
 The MIT License (MIT)
 
@@ -4309,7 +4053,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[92] Applies to: npm:electron-to-chromium@1.5.392
+[88] Applies to: npm:electron-to-chromium@1.5.392
 ------------------------------------------------------------------------------
 Copyright 2018 Kilian Valkhof
 
@@ -4318,7 +4062,31 @@ Permission to use, copy, modify, and/or distribute this software for any purpose
 THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
 
 ------------------------------------------------------------------------------
-[93] Applies to: npm:encodeurl@1.0.2, npm:encodeurl@2.0.0
+[89] Applies to: npm:emoji-regex@8.0.0, npm:jsesc@3.1.0, npm:regenerate@1.4.2, npm:regenerate-unicode-properties@10.2.2, npm:regexpu-core@6.4.0, npm:unicode-canonical-property-names-ecmascript@2.0.1, npm:unicode-match-property-ecmascript@2.0.0, npm:unicode-match-property-value-ecmascript@2.2.1, npm:unicode-property-aliases-ecmascript@2.2.0
+------------------------------------------------------------------------------
+Copyright Mathias Bynens <https://mathiasbynens.be/>
+
+Permission is hereby granted, free of charge, to any person obtaining
+a copy of this software and associated documentation files (the
+"Software"), to deal in the Software without restriction, including
+without limitation the rights to use, copy, modify, merge, publish,
+distribute, sublicense, and/or sell copies of the Software, and to
+permit persons to whom the Software is furnished to do so, subject to
+the following conditions:
+
+The above copyright notice and this permission notice shall be
+included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+------------------------------------------------------------------------------
+[90] Applies to: npm:encodeurl@1.0.2, npm:encodeurl@2.0.0
 ------------------------------------------------------------------------------
 (The MIT License)
 
@@ -4344,7 +4112,7 @@ TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
 SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[94] Applies to: npm:error-stack-parser@2.1.4, npm:stackframe@1.3.4
+[91] Applies to: npm:error-stack-parser@2.1.4, npm:stackframe@1.3.4
 ------------------------------------------------------------------------------
 Copyright (c) 2017 Eric Wendelin and other contributors
 
@@ -4367,7 +4135,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
 ------------------------------------------------------------------------------
-[95] Applies to: npm:es-errors@1.3.0
+[92] Applies to: npm:es-errors@1.3.0
 ------------------------------------------------------------------------------
 MIT License
 
@@ -4392,7 +4160,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
 ------------------------------------------------------------------------------
-[96] Applies to: npm:escalade@3.2.0
+[93] Applies to: npm:escalade@3.2.0
 ------------------------------------------------------------------------------
 MIT License
 
@@ -4405,7 +4173,7 @@ The above copyright notice and this permission notice shall be included in all c
 THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[97] Applies to: npm:escape-html@1.0.3
+[94] Applies to: npm:escape-html@1.0.3
 ------------------------------------------------------------------------------
 (The MIT License)
 
@@ -4433,7 +4201,7 @@ TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
 SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[98] Applies to: npm:etag@1.8.1
+[95] Applies to: npm:etag@1.8.1
 ------------------------------------------------------------------------------
 (The MIT License)
 
@@ -4459,7 +4227,7 @@ TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
 SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[99] Applies to: npm:event-target-shim@5.0.1
+[96] Applies to: npm:event-target-shim@5.0.1
 ------------------------------------------------------------------------------
 The MIT License (MIT)
 
@@ -4484,7 +4252,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
 ------------------------------------------------------------------------------
-[100] Applies to: npm:expo-paste-input@0.2.2
+[97] Applies to: npm:expo-paste-input@0.2.2
 ------------------------------------------------------------------------------
 MIT License
 
@@ -4509,7 +4277,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
 ------------------------------------------------------------------------------
-[101] Applies to: npm:exponential-backoff@3.1.3
+[98] Applies to: npm:exponential-backoff@3.1.3
 ------------------------------------------------------------------------------
 Apache License
                            Version 2.0, January 2004
@@ -4714,7 +4482,7 @@ Apache License
    limitations under the License.
 
 ------------------------------------------------------------------------------
-[102] Applies to: npm:fast-deep-equal@3.1.3
+[99] Applies to: npm:fast-deep-equal@3.1.3
 ------------------------------------------------------------------------------
 MIT License
 
@@ -4739,7 +4507,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
 ------------------------------------------------------------------------------
-[103] Applies to: npm:fbjs@3.0.5, npm:fbjs-css-vars@1.0.2, npm:invariant@2.2.4
+[100] Applies to: npm:fbjs@3.0.5, npm:fbjs-css-vars@1.0.2, npm:invariant@2.2.4
 ------------------------------------------------------------------------------
 MIT License
 
@@ -4764,7 +4532,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
 ------------------------------------------------------------------------------
-[104] Applies to: npm:fdir@6.5.0
+[101] Applies to: npm:fdir@6.5.0
 ------------------------------------------------------------------------------
 Copyright 2023 Abdullah Atta
 
@@ -4775,7 +4543,7 @@ The above copyright notice and this permission notice shall be included in all c
 THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[105] Applies to: npm:fetch-nodeshim@0.4.10
+[102] Applies to: npm:fetch-nodeshim@0.4.10
 ------------------------------------------------------------------------------
 MIT License
 
@@ -4804,7 +4572,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
 ------------------------------------------------------------------------------
-[106] Applies to: npm:finalhandler@1.1.2
+[103] Applies to: npm:finalhandler@1.1.2
 ------------------------------------------------------------------------------
 (The MIT License)
 
@@ -4830,7 +4598,7 @@ TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
 SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[107] Applies to: npm:fontfaceobserver@2.3.0
+[104] Applies to: npm:fontfaceobserver@2.3.0
 ------------------------------------------------------------------------------
 Copyright (c) 2014 - Bram Stein
 
@@ -4855,7 +4623,7 @@ ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
 SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 ------------------------------------------------------------------------------
-[108] Applies to: npm:fresh@0.5.2
+[105] Applies to: npm:fresh@0.5.2
 ------------------------------------------------------------------------------
 (The MIT License)
 
@@ -4882,7 +4650,7 @@ TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
 SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[109] Applies to: npm:function-bind@1.1.2
+[106] Applies to: npm:function-bind@1.1.2
 ------------------------------------------------------------------------------
 Copyright (c) 2013 Raynos.
 
@@ -4905,7 +4673,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[110] Applies to: npm:gensync@1.0.0-beta.2
+[107] Applies to: npm:gensync@1.0.0-beta.2
 ------------------------------------------------------------------------------
 Copyright 2018 Logan Smyth <loganfsmyth@gmail.com>
 
@@ -4916,7 +4684,7 @@ The above copyright notice and this permission notice shall be included in all c
 THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[111] Applies to: npm:get-caller-file@2.0.5
+[108] Applies to: npm:get-caller-file@2.0.5
 ------------------------------------------------------------------------------
 ISC License (ISC)
 Copyright 2018 Stefan Penner
@@ -4926,7 +4694,7 @@ Permission to use, copy, modify, and/or distribute this software for any purpose
 THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
 
 ------------------------------------------------------------------------------
-[112] Applies to: npm:get-nonce@1.0.1
+[109] Applies to: npm:get-nonce@1.0.1
 ------------------------------------------------------------------------------
 MIT License
 
@@ -4951,7 +4719,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
 ------------------------------------------------------------------------------
-[113] Applies to: npm:getenv@2.0.0
+[110] Applies to: npm:getenv@2.0.0
 ------------------------------------------------------------------------------
 The MIT License (MIT)
 Copyright (c) 2012-2019 Christoph Tavan <dev@tavan.de>
@@ -4975,7 +4743,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
 ------------------------------------------------------------------------------
-[114] Applies to: npm:glob@13.0.6
+[111] Applies to: npm:glob@13.0.6
 ------------------------------------------------------------------------------
 All packages under `src/` are licensed according to the terms in
 their respective `LICENSE` or `LICENSE.md` files.
@@ -5042,7 +4810,7 @@ will be liable to anyone for any damages related to this
 software or this license, under any kind of legal claim.***
 
 ------------------------------------------------------------------------------
-[115] Applies to: npm:graceful-fs@4.2.11
+[112] Applies to: npm:graceful-fs@4.2.11
 ------------------------------------------------------------------------------
 The ISC License
 
@@ -5061,7 +4829,7 @@ ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF OR
 IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
 
 ------------------------------------------------------------------------------
-[116] Applies to: npm:hasown@2.0.4
+[113] Applies to: npm:hasown@2.0.4
 ------------------------------------------------------------------------------
 MIT License
 
@@ -5086,7 +4854,40 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
 ------------------------------------------------------------------------------
-[117] Applies to: npm:hosted-git-info@7.0.2
+[114] Applies to: npm:hoist-non-react-statics@3.3.2
+------------------------------------------------------------------------------
+Software License Agreement (BSD License)
+========================================
+
+Copyright (c) 2015, Yahoo! Inc. All rights reserved.
+----------------------------------------------------
+
+Redistribution and use of this software in source and binary forms, with or
+without modification, are permitted provided that the following conditions are
+met:
+
+  * Redistributions of source code must retain the above copyright notice, this
+    list of conditions and the following disclaimer.
+  * Redistributions in binary form must reproduce the above copyright notice,
+    this list of conditions and the following disclaimer in the documentation
+    and/or other materials provided with the distribution.
+  * Neither the name of Yahoo! Inc. nor the names of YUI's contributors may be
+    used to endorse or promote products derived from this software without
+    specific prior written permission of Yahoo! Inc.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+(INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+------------------------------------------------------------------------------
+[115] Applies to: npm:hosted-git-info@7.0.2
 ------------------------------------------------------------------------------
 Copyright (c) 2015, Rebecca Turner
 
@@ -5103,7 +4904,7 @@ OTHER TORTIOUS ACTION, ARISING OUT OF OR IN CONNECTION WITH THE USE OR
 PERFORMANCE OF THIS SOFTWARE.
 
 ------------------------------------------------------------------------------
-[118] Applies to: npm:http-errors@2.0.1
+[116] Applies to: npm:http-errors@2.0.1
 ------------------------------------------------------------------------------
 The MIT License (MIT)
 
@@ -5129,7 +4930,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[119] Applies to: npm:hyphenate-style-name@1.1.0
+[117] Applies to: npm:hyphenate-style-name@1.1.0
 ------------------------------------------------------------------------------
 BSD 3-Clause License
 
@@ -5162,7 +4963,7 @@ OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 ------------------------------------------------------------------------------
-[120] Applies to: npm:i18next@26.3.6
+[118] Applies to: npm:i18next@26.3.6
 ------------------------------------------------------------------------------
 The MIT License (MIT)
 
@@ -5187,7 +4988,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
 ------------------------------------------------------------------------------
-[121] Applies to: npm:ignore@5.3.2
+[119] Applies to: npm:ignore@5.3.2
 ------------------------------------------------------------------------------
 Copyright (c) 2013 Kael Zhang <i@kael.me>, contributors
 http://kael.me/
@@ -5212,7 +5013,7 @@ OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
 WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[122] Applies to: npm:image-size@1.2.1
+[120] Applies to: npm:image-size@1.2.1
 ------------------------------------------------------------------------------
 The MIT License (MIT)
 
@@ -5225,7 +5026,7 @@ The above copyright notice and this permission notice shall be included in all c
 THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[123] Applies to: npm:inherits@2.0.4
+[121] Applies to: npm:inherits@2.0.4
 ------------------------------------------------------------------------------
 The ISC License
 
@@ -5244,7 +5045,7 @@ OTHER TORTIOUS ACTION, ARISING OUT OF OR IN CONNECTION WITH THE USE OR
 PERFORMANCE OF THIS SOFTWARE.
 
 ------------------------------------------------------------------------------
-[124] Applies to: npm:inline-style-prefixer@7.0.1
+[122] Applies to: npm:inline-style-prefixer@7.0.1
 ------------------------------------------------------------------------------
 The MIT License (MIT)
 
@@ -5269,7 +5070,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
 ------------------------------------------------------------------------------
-[125] Applies to: npm:is-arrayish@0.3.4
+[123] Applies to: npm:is-arrayish@0.3.4
 ------------------------------------------------------------------------------
 The MIT License (MIT)
 
@@ -5294,7 +5095,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[126] Applies to: npm:is-core-module@2.16.2
+[124] Applies to: npm:is-core-module@2.16.2
 ------------------------------------------------------------------------------
 The MIT License (MIT)
 
@@ -5318,7 +5119,7 @@ IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
 CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[127] Applies to: npm:isexe@2.0.0, npm:lru-cache@5.1.1, npm:semver@6.3.1, npm:semver@7.8.5, npm:which@2.0.2, npm:yallist@3.1.1
+[125] Applies to: npm:isexe@2.0.0, npm:lru-cache@5.1.1, npm:semver@6.3.1, npm:semver@7.8.5, npm:which@2.0.2, npm:yallist@3.1.1
 ------------------------------------------------------------------------------
 The ISC License
 
@@ -5337,7 +5138,7 @@ ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF OR
 IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
 
 ------------------------------------------------------------------------------
-[128] Applies to: npm:js-tokens@4.0.0
+[126] Applies to: npm:js-tokens@4.0.0
 ------------------------------------------------------------------------------
 The MIT License (MIT)
 
@@ -5362,7 +5163,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[129] Applies to: npm:js-yaml@4.3.0
+[127] Applies to: npm:js-yaml@4.3.0
 ------------------------------------------------------------------------------
 (The MIT License)
 
@@ -5387,7 +5188,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[130] Applies to: npm:jsc-safe-url@0.2.4
+[128] Applies to: npm:jsc-safe-url@0.2.4
 ------------------------------------------------------------------------------
 Zero-Clause BSD
 =============
@@ -5404,7 +5205,7 @@ AN ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT
 OF OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
 
 ------------------------------------------------------------------------------
-[131] Applies to: npm:json5@2.2.3
+[129] Applies to: npm:json5@2.2.3
 ------------------------------------------------------------------------------
 MIT License
 
@@ -5431,7 +5232,7 @@ SOFTWARE.
 [others]: https://github.com/json5/json5/contributors
 
 ------------------------------------------------------------------------------
-[132] Applies to: npm:kleur@3.0.3
+[130] Applies to: npm:kleur@3.0.3
 ------------------------------------------------------------------------------
 The MIT License (MIT)
 
@@ -5456,7 +5257,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[133] Applies to: npm:lan-network@0.2.1
+[131] Applies to: npm:lan-network@0.2.1
 ------------------------------------------------------------------------------
 MIT License
 
@@ -5481,7 +5282,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
 ------------------------------------------------------------------------------
-[134] Applies to: npm:lightningcss@1.32.0
+[132] Applies to: npm:lightningcss@1.32.0
 ------------------------------------------------------------------------------
 Mozilla Public License Version 2.0
 ==================================
@@ -5858,7 +5659,7 @@ This Source Code Form is "Incompatible With Secondary Licenses", as
 defined by the Mozilla Public License, v. 2.0.
 
 ------------------------------------------------------------------------------
-[135] Applies to: npm:lodash.debounce@4.0.8, npm:lodash.throttle@4.1.1
+[133] Applies to: npm:lodash.debounce@4.0.8, npm:lodash.throttle@4.1.1
 ------------------------------------------------------------------------------
 Copyright jQuery Foundation and other contributors <https://jquery.org/>
 
@@ -5909,7 +5710,7 @@ licenses; we recommend you read them, as their terms may differ from the
 terms above.
 
 ------------------------------------------------------------------------------
-[136] Applies to: npm:loose-envify@1.4.0
+[134] Applies to: npm:loose-envify@1.4.0
 ------------------------------------------------------------------------------
 The MIT License (MIT)
 
@@ -5934,7 +5735,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[137] Applies to: npm:lru-cache@10.4.3
+[135] Applies to: npm:lru-cache@10.4.3
 ------------------------------------------------------------------------------
 The ISC License
 
@@ -5953,7 +5754,7 @@ ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF OR
 IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
 
 ------------------------------------------------------------------------------
-[138] Applies to: npm:lru-cache@11.5.2, npm:minipass@7.1.3, npm:path-scurry@2.0.2, npm:sax@1.6.0
+[136] Applies to: npm:lru-cache@11.5.2, npm:minipass@7.1.3, npm:path-scurry@2.0.2, npm:sax@1.6.0
 ------------------------------------------------------------------------------
 # Blue Oak Model License
 
@@ -6012,7 +5813,7 @@ will be liable to anyone for any damages related to this
 software or this license, under any kind of legal claim.***
 
 ------------------------------------------------------------------------------
-[139] Applies to: npm:lucide-react-native@0.468.0
+[137] Applies to: npm:lucide-react-native@0.468.0
 ------------------------------------------------------------------------------
 ISC License
 
@@ -6031,7 +5832,7 @@ ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
 OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
 
 ------------------------------------------------------------------------------
-[140] Applies to: npm:makeerror@1.0.12, npm:tmpl@1.0.5
+[138] Applies to: npm:makeerror@1.0.12, npm:tmpl@1.0.5
 ------------------------------------------------------------------------------
 BSD License
 
@@ -6063,7 +5864,7 @@ ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
 SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 ------------------------------------------------------------------------------
-[141] Applies to: npm:marky@1.3.0
+[139] Applies to: npm:marky@1.3.0
 ------------------------------------------------------------------------------
 Apache License
 Version 2.0, January 2004
@@ -6275,7 +6076,7 @@ APPENDIX: How to apply the Apache License to your work
         permissions and limitations under the License.
 
 ------------------------------------------------------------------------------
-[142] Applies to: npm:mdn-data@2.0.14
+[140] Applies to: npm:mdn-data@2.0.14
 ------------------------------------------------------------------------------
 CC0 1.0 Universal
 
@@ -6395,7 +6196,7 @@ For more information, please see
 <http://creativecommons.org/publicdomain/zero/1.0/>
 
 ------------------------------------------------------------------------------
-[143] Applies to: npm:memoize-one@5.2.1, npm:memoize-one@6.0.0
+[141] Applies to: npm:memoize-one@5.2.1, npm:memoize-one@6.0.0
 ------------------------------------------------------------------------------
 MIT License
 
@@ -6420,7 +6221,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
 ------------------------------------------------------------------------------
-[144] Applies to: npm:merge-options@3.0.4
+[142] Applies to: npm:merge-options@3.0.4
 ------------------------------------------------------------------------------
 The MIT License (MIT)
 
@@ -6445,7 +6246,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
 ------------------------------------------------------------------------------
-[145] Applies to: npm:merge-stream@2.0.0
+[143] Applies to: npm:merge-stream@2.0.0
 ------------------------------------------------------------------------------
 The MIT License (MIT)
 
@@ -6470,7 +6271,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[146] Applies to: npm:mime@1.6.0
+[144] Applies to: npm:mime@1.6.0
 ------------------------------------------------------------------------------
 The MIT License (MIT)
 
@@ -6495,7 +6296,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[147] Applies to: npm:mime-db@1.52.0, npm:mime-db@1.54.0
+[145] Applies to: npm:mime-db@1.52.0, npm:mime-db@1.54.0
 ------------------------------------------------------------------------------
 (The MIT License)
 
@@ -6522,32 +6323,7 @@ TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
 SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[148] Applies to: npm:min-indent@1.0.1
-------------------------------------------------------------------------------
-The MIT License (MIT)
-
-Copyright (c) Sindre Sorhus <sindresorhus@gmail.com> (sindresorhus.com), James Kyle <me@thejameskyle.com> (thejameskyle.com)
-
-Permission is hereby granted, free of charge, to any person obtaining a copy
-of this software and associated documentation files (the "Software"), to deal
-in the Software without restriction, including without limitation the rights
-to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-copies of the Software, and to permit persons to whom the Software is
-furnished to do so, subject to the following conditions:
-
-The above copyright notice and this permission notice shall be included in
-all copies or substantial portions of the Software.
-
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
-THE SOFTWARE.
-
-------------------------------------------------------------------------------
-[149] Applies to: npm:minimatch@10.2.5
+[146] Applies to: npm:minimatch@10.2.5
 ------------------------------------------------------------------------------
 # Blue Oak Model License
 
@@ -6606,7 +6382,7 @@ will be liable to anyone for any damages related to this
 software or this license, under any kind of legal claim._**
 
 ------------------------------------------------------------------------------
-[150] Applies to: npm:mkdirp@1.0.4
+[147] Applies to: npm:mkdirp@1.0.4
 ------------------------------------------------------------------------------
 Copyright James Halliday (mail@substack.net) and Isaac Z. Schlueter (i@izs.me)
 
@@ -6631,7 +6407,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[151] Applies to: npm:ms@2.0.0
+[148] Applies to: npm:ms@2.0.0
 ------------------------------------------------------------------------------
 The MIT License (MIT)
 
@@ -6656,7 +6432,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
 ------------------------------------------------------------------------------
-[152] Applies to: npm:ms@2.1.3
+[149] Applies to: npm:ms@2.1.3
 ------------------------------------------------------------------------------
 The MIT License (MIT)
 
@@ -6681,7 +6457,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
 ------------------------------------------------------------------------------
-[153] Applies to: npm:nanoid@3.3.16
+[150] Applies to: npm:nanoid@3.3.16
 ------------------------------------------------------------------------------
 The MIT License (MIT)
 
@@ -6705,7 +6481,7 @@ IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
 CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[154] Applies to: npm:negotiator@0.6.3, npm:negotiator@0.6.4, npm:negotiator@1.0.0
+[151] Applies to: npm:negotiator@0.6.3, npm:negotiator@0.6.4, npm:negotiator@1.0.0
 ------------------------------------------------------------------------------
 (The MIT License)
 
@@ -6733,7 +6509,7 @@ TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
 SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[155] Applies to: npm:node-fetch@2.7.0
+[152] Applies to: npm:node-fetch@2.7.0
 ------------------------------------------------------------------------------
 The MIT License (MIT)
 
@@ -6758,7 +6534,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
 ------------------------------------------------------------------------------
-[156] Applies to: npm:node-forge@1.4.0
+[153] Applies to: npm:node-forge@1.4.0
 ------------------------------------------------------------------------------
 You may use the Forge project under the terms of either the BSD License or the
 GNU General Public License (GPL) Version 2.
@@ -7092,7 +6868,7 @@ PROGRAMS), EVEN IF SUCH HOLDER OR OTHER PARTY HAS BEEN ADVISED OF THE
 POSSIBILITY OF SUCH DAMAGES.
 
 ------------------------------------------------------------------------------
-[157] Applies to: npm:node-int64@0.4.0
+[154] Applies to: npm:node-int64@0.4.0
 ------------------------------------------------------------------------------
 Copyright (c) 2014 Robert Kieffer
 
@@ -7115,7 +6891,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[158] Applies to: npm:node-releases@2.0.51
+[155] Applies to: npm:node-releases@2.0.51
 ------------------------------------------------------------------------------
 The MIT License
 
@@ -7140,7 +6916,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[159] Applies to: npm:npm-package-arg@11.0.3
+[156] Applies to: npm:npm-package-arg@11.0.3
 ------------------------------------------------------------------------------
 The ISC License
 
@@ -7159,7 +6935,7 @@ ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF OR
 IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
 
 ------------------------------------------------------------------------------
-[160] Applies to: npm:nullthrows@1.1.1
+[157] Applies to: npm:nullthrows@1.1.1
 ------------------------------------------------------------------------------
 The MIT License (MIT)
 Copyright (c) 2016 Andres Suarez
@@ -7171,7 +6947,7 @@ The above copyright notice and this permission notice shall be included in all c
 THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[161] Applies to: npm:on-finished@2.3.0, npm:on-finished@2.4.1
+[158] Applies to: npm:on-finished@2.3.0, npm:on-finished@2.4.1
 ------------------------------------------------------------------------------
 (The MIT License)
 
@@ -7198,7 +6974,7 @@ TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
 SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[162] Applies to: npm:on-headers@1.1.0
+[159] Applies to: npm:on-headers@1.1.0
 ------------------------------------------------------------------------------
 (The MIT License)
 
@@ -7224,7 +7000,7 @@ TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
 SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[163] Applies to: npm:pako@2.2.0
+[160] Applies to: npm:pako@2.2.0
 ------------------------------------------------------------------------------
 (The MIT License)
 
@@ -7249,7 +7025,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[164] Applies to: npm:parse-png@2.1.0, npm:shebang-command@2.0.0
+[161] Applies to: npm:parse-png@2.1.0, npm:shebang-command@2.0.0
 ------------------------------------------------------------------------------
 MIT License
 
@@ -7262,7 +7038,7 @@ The above copyright notice and this permission notice shall be included in all c
 THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[165] Applies to: npm:parseurl@1.3.3
+[162] Applies to: npm:parseurl@1.3.3
 ------------------------------------------------------------------------------
 (The MIT License)
 
@@ -7289,7 +7065,7 @@ TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
 SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[166] Applies to: npm:path-parse@1.0.7
+[163] Applies to: npm:path-parse@1.0.7
 ------------------------------------------------------------------------------
 The MIT License (MIT)
 
@@ -7314,7 +7090,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
 ------------------------------------------------------------------------------
-[167] Applies to: npm:picocolors@1.1.1
+[164] Applies to: npm:picocolors@1.1.1
 ------------------------------------------------------------------------------
 ISC License
 
@@ -7333,7 +7109,7 @@ ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
 OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
 
 ------------------------------------------------------------------------------
-[168] Applies to: npm:picomatch@2.3.2, npm:picomatch@4.0.5
+[165] Applies to: npm:picomatch@2.3.2, npm:picomatch@4.0.5
 ------------------------------------------------------------------------------
 The MIT License (MIT)
 
@@ -7358,7 +7134,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[169] Applies to: npm:plist@3.1.1
+[166] Applies to: npm:plist@3.1.1
 ------------------------------------------------------------------------------
 (The MIT License)
 
@@ -7386,7 +7162,7 @@ FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
 OTHER DEALINGS IN THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[170] Applies to: npm:pngjs@3.4.0
+[167] Applies to: npm:pngjs@3.4.0
 ------------------------------------------------------------------------------
 pngjs2 original work Copyright (c) 2015 Luke Page & Original Contributors
 pngjs derived work Copyright (c) 2012 Kuba Niegowski
@@ -7410,7 +7186,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[171] Applies to: npm:postcss@8.5.19
+[168] Applies to: npm:postcss@8.5.19
 ------------------------------------------------------------------------------
 The MIT License (MIT)
 
@@ -7434,7 +7210,7 @@ IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
 CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[172] Applies to: npm:postcss-value-parser@4.2.0
+[169] Applies to: npm:postcss-value-parser@4.2.0
 ------------------------------------------------------------------------------
 Copyright (c) Bogdan Chadkin <trysound@yandex.ru>
 
@@ -7460,7 +7236,7 @@ FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
 OTHER DEALINGS IN THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[173] Applies to: npm:proc-log@4.2.0
+[170] Applies to: npm:proc-log@4.2.0
 ------------------------------------------------------------------------------
 The ISC License
 
@@ -7479,7 +7255,7 @@ ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF OR
 IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
 
 ------------------------------------------------------------------------------
-[174] Applies to: npm:progress@2.0.3
+[171] Applies to: npm:progress@2.0.3
 ------------------------------------------------------------------------------
 (The MIT License)
 
@@ -7505,7 +7281,7 @@ TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
 SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[175] Applies to: npm:promise@7.3.1, npm:promise@8.3.0
+[172] Applies to: npm:promise@7.3.1, npm:promise@8.3.0
 ------------------------------------------------------------------------------
 Copyright (c) 2014 Forbes Lindesay
 
@@ -7528,7 +7304,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[176] Applies to: npm:prompts@2.4.2, npm:sisteransi@1.0.5
+[173] Applies to: npm:prompts@2.4.2, npm:sisteransi@1.0.5
 ------------------------------------------------------------------------------
 MIT License
 
@@ -7553,7 +7329,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
 ------------------------------------------------------------------------------
-[177] Applies to: npm:query-string@7.1.3
+[174] Applies to: npm:query-string@7.1.3
 ------------------------------------------------------------------------------
 MIT License
 
@@ -7566,7 +7342,7 @@ The above copyright notice and this permission notice shall be included in all c
 THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[178] Applies to: npm:queue@6.0.2
+[175] Applies to: npm:queue@6.0.2
 ------------------------------------------------------------------------------
 The MIT License (MIT)
 Copyright (c) 2014 Jesse Tane <jesse.tane@gmail.com>
@@ -7578,7 +7354,7 @@ The above copyright notice and this permission notice shall be included in all c
 THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[179] Applies to: npm:range-parser@1.2.1
+[176] Applies to: npm:range-parser@1.2.1
 ------------------------------------------------------------------------------
 (The MIT License)
 
@@ -7605,7 +7381,7 @@ TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
 SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[180] Applies to: npm:react-fast-compare@3.2.2
+[177] Applies to: npm:react-fast-compare@3.2.2
 ------------------------------------------------------------------------------
 MIT License
 
@@ -7631,7 +7407,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
 ------------------------------------------------------------------------------
-[181] Applies to: npm:react-freeze@1.0.4
+[178] Applies to: npm:react-freeze@1.0.4
 ------------------------------------------------------------------------------
 The MIT License (MIT)
 
@@ -7656,7 +7432,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
 ------------------------------------------------------------------------------
-[182] Applies to: npm:react-i18next@17.0.10
+[179] Applies to: npm:react-i18next@17.0.10
 ------------------------------------------------------------------------------
 The MIT License (MIT)
 
@@ -7681,7 +7457,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
 ------------------------------------------------------------------------------
-[183] Applies to: npm:react-native-drawer-layout@4.2.7
+[180] Applies to: npm:react-native-drawer-layout@4.2.7
 ------------------------------------------------------------------------------
 MIT License
 
@@ -7706,7 +7482,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
 ------------------------------------------------------------------------------
-[184] Applies to: npm:react-native-gesture-handler@3.0.2, npm:react-native-reanimated@4.3.1
+[181] Applies to: npm:react-native-gesture-handler@2.32.0, npm:react-native-reanimated@4.5.1
 ------------------------------------------------------------------------------
 The MIT License (MIT)
 
@@ -7731,7 +7507,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
 ------------------------------------------------------------------------------
-[185] Applies to: npm:react-native-is-edge-to-edge@1.3.1
+[182] Applies to: npm:react-native-is-edge-to-edge@1.3.1
 ------------------------------------------------------------------------------
 MIT License
 
@@ -7756,7 +7532,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
 ------------------------------------------------------------------------------
-[186] Applies to: npm:react-native-safe-area-context@5.7.0
+[183] Applies to: npm:react-native-safe-area-context@5.7.0
 ------------------------------------------------------------------------------
 MIT License
 
@@ -7781,7 +7557,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
 ------------------------------------------------------------------------------
-[187] Applies to: npm:react-native-screens@4.25.2
+[184] Applies to: npm:react-native-screens@4.26.2
 ------------------------------------------------------------------------------
 The MIT License (MIT)
 
@@ -7806,7 +7582,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
 ------------------------------------------------------------------------------
-[188] Applies to: npm:react-native-svg@15.15.4
+[185] Applies to: npm:react-native-svg@15.15.4
 ------------------------------------------------------------------------------
 The MIT License (MIT)
 
@@ -7831,7 +7607,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
 ------------------------------------------------------------------------------
-[189] Applies to: npm:react-native-uitextview@2.2.0
+[186] Applies to: npm:react-native-uitextview@2.2.0
 ------------------------------------------------------------------------------
 MIT License
 
@@ -7855,7 +7631,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
 ------------------------------------------------------------------------------
-[190] Applies to: npm:react-native-web@0.21.2
+[187] Applies to: npm:react-native-web@0.21.2
 ------------------------------------------------------------------------------
 MIT License
 
@@ -7881,7 +7657,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
 ------------------------------------------------------------------------------
-[191] Applies to: npm:react-native-worklets@0.8.3
+[188] Applies to: npm:react-native-worklets@0.10.1
 ------------------------------------------------------------------------------
 MIT License
 
@@ -7905,7 +7681,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
 ------------------------------------------------------------------------------
-[192] Applies to: npm:regenerator-runtime@0.13.11
+[189] Applies to: npm:regenerator-runtime@0.13.11
 ------------------------------------------------------------------------------
 MIT License
 
@@ -7930,7 +7706,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
 ------------------------------------------------------------------------------
-[193] Applies to: npm:regjsgen@0.8.0
+[190] Applies to: npm:regjsgen@0.8.0
 ------------------------------------------------------------------------------
 The MIT License (MIT)
 
@@ -7956,7 +7732,7 @@ OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
 WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[194] Applies to: npm:regjsparser@0.13.2
+[191] Applies to: npm:regjsparser@0.13.2
 ------------------------------------------------------------------------------
 Copyright (c) Julian Viereck and Contributors, All Rights Reserved.
 
@@ -7981,7 +7757,7 @@ ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
 THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 ------------------------------------------------------------------------------
-[195] Applies to: npm:require-directory@2.1.1
+[192] Applies to: npm:require-directory@2.1.1
 ------------------------------------------------------------------------------
 The MIT License (MIT)
 
@@ -8007,7 +7783,7 @@ TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
 SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[196] Applies to: npm:resolve@1.22.12
+[193] Applies to: npm:resolve@1.22.12
 ------------------------------------------------------------------------------
 MIT License
 
@@ -8032,7 +7808,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
 ------------------------------------------------------------------------------
-[197] Applies to: npm:resolve-workspace-root@2.0.1
+[194] Applies to: npm:resolve-workspace-root@2.0.1
 ------------------------------------------------------------------------------
 # The MIT License (MIT)
 
@@ -8057,7 +7833,7 @@ Copyright (c) 2024-present Cedric van Putten <me@cedric.dev>
 > THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[198] Applies to: npm:rtl-detect@1.1.2
+[195] Applies to: npm:rtl-detect@1.1.2
 ------------------------------------------------------------------------------
 Copyright 2015 Yahoo Inc.
 All rights reserved.
@@ -8088,7 +7864,7 @@ ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
 SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 ------------------------------------------------------------------------------
-[199] Applies to: npm:safe-buffer@5.2.1
+[196] Applies to: npm:safe-buffer@5.2.1
 ------------------------------------------------------------------------------
 The MIT License (MIT)
 
@@ -8113,7 +7889,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[200] Applies to: npm:send@0.19.2
+[197] Applies to: npm:send@0.19.2
 ------------------------------------------------------------------------------
 (The MIT License)
 
@@ -8140,7 +7916,7 @@ TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
 SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[201] Applies to: npm:serve-static@1.16.3
+[198] Applies to: npm:serve-static@1.16.3
 ------------------------------------------------------------------------------
 (The MIT License)
 
@@ -8169,7 +7945,7 @@ TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
 SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[202] Applies to: npm:setimmediate@1.0.5
+[199] Applies to: npm:setimmediate@1.0.5
 ------------------------------------------------------------------------------
 Copyright (c) 2012 Barnesandnoble.com, llc, Donavon West, and Domenic Denicola
 
@@ -8193,7 +7969,7 @@ OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
 WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[203] Applies to: npm:setprototypeof@1.2.0
+[200] Applies to: npm:setprototypeof@1.2.0
 ------------------------------------------------------------------------------
 Copyright (c) 2015, Wes Todd
 
@@ -8210,7 +7986,7 @@ OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF OR IN
 CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
 
 ------------------------------------------------------------------------------
-[204] Applies to: npm:sf-symbols-typescript@2.2.0
+[201] Applies to: npm:sf-symbols-typescript@2.2.0
 ------------------------------------------------------------------------------
 MIT License
 
@@ -8235,7 +8011,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
 ------------------------------------------------------------------------------
-[205] Applies to: npm:shallowequal@1.1.0
+[202] Applies to: npm:shallowequal@1.1.0
 ------------------------------------------------------------------------------
 MIT License
 
@@ -8260,7 +8036,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
 ------------------------------------------------------------------------------
-[206] Applies to: npm:shell-quote@1.10.0
+[203] Applies to: npm:shell-quote@1.10.0
 ------------------------------------------------------------------------------
 The MIT License
 
@@ -8288,7 +8064,7 @@ TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
 SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[207] Applies to: npm:signal-exit@3.0.7
+[204] Applies to: npm:signal-exit@3.0.7
 ------------------------------------------------------------------------------
 The ISC License
 
@@ -8308,7 +8084,7 @@ WHETHER IN AN ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION,
 ARISING OUT OF OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
 
 ------------------------------------------------------------------------------
-[208] Applies to: npm:simple-plist@1.3.1
+[205] Applies to: npm:simple-plist@1.3.1
 ------------------------------------------------------------------------------
 The MIT License (MIT)
 
@@ -8332,7 +8108,7 @@ IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
 CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[209] Applies to: npm:simple-swizzle@0.2.4
+[206] Applies to: npm:simple-swizzle@0.2.4
 ------------------------------------------------------------------------------
 The MIT License (MIT)
 
@@ -8357,7 +8133,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[210] Applies to: npm:slugify@1.6.9
+[207] Applies to: npm:slugify@1.6.9
 ------------------------------------------------------------------------------
 The MIT License (MIT)
 
@@ -8382,7 +8158,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
 ------------------------------------------------------------------------------
-[211] Applies to: npm:source-map@0.5.7, npm:source-map@0.6.1, npm:source-map-js@1.2.1
+[208] Applies to: npm:source-map@0.5.7, npm:source-map@0.6.1, npm:source-map-js@1.2.1
 ------------------------------------------------------------------------------
 Copyright (c) 2009-2011, Mozilla Foundation and contributors
 All rights reserved.
@@ -8413,7 +8189,7 @@ OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 ------------------------------------------------------------------------------
-[212] Applies to: npm:source-map-support@0.5.21
+[209] Applies to: npm:source-map-support@0.5.21
 ------------------------------------------------------------------------------
 The MIT License (MIT)
 
@@ -8438,7 +8214,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
 ------------------------------------------------------------------------------
-[213] Applies to: npm:stacktrace-parser@0.1.11
+[210] Applies to: npm:stacktrace-parser@0.1.11
 ------------------------------------------------------------------------------
 MIT License
 
@@ -8463,7 +8239,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
 ------------------------------------------------------------------------------
-[214] Applies to: npm:statuses@1.5.0, npm:statuses@2.0.2
+[211] Applies to: npm:statuses@1.5.0, npm:statuses@2.0.2
 ------------------------------------------------------------------------------
 The MIT License (MIT)
 
@@ -8489,7 +8265,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[215] Applies to: npm:stream-buffers@2.2.0
+[212] Applies to: npm:stream-buffers@2.2.0
 ------------------------------------------------------------------------------
 This is free and unencumbered software released into the public domain.
 
@@ -8517,7 +8293,7 @@ OTHER DEALINGS IN THE SOFTWARE.
 For more information, please refer to <http://unlicense.org/>
 
 ------------------------------------------------------------------------------
-[216] Applies to: npm:strict-uri-encode@2.0.0
+[213] Applies to: npm:strict-uri-encode@2.0.0
 ------------------------------------------------------------------------------
 The MIT License (MIT)
 
@@ -8542,7 +8318,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[217] Applies to: npm:styleq@0.1.3
+[214] Applies to: npm:styleq@0.1.3
 ------------------------------------------------------------------------------
 MIT License
 
@@ -8567,7 +8343,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
 ------------------------------------------------------------------------------
-[218] Applies to: npm:supports-hyperlinks@2.3.0
+[215] Applies to: npm:supports-hyperlinks@2.3.0
 ------------------------------------------------------------------------------
 MIT License
 
@@ -8580,7 +8356,7 @@ The above copyright notice and this permission notice shall be included in all c
 THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[219] Applies to: npm:supports-preserve-symlinks-flag@1.0.0
+[216] Applies to: npm:supports-preserve-symlinks-flag@1.0.0
 ------------------------------------------------------------------------------
 MIT License
 
@@ -8605,7 +8381,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
 ------------------------------------------------------------------------------
-[220] Applies to: npm:terser@5.49.0
+[217] Applies to: npm:terser@5.49.0
 ------------------------------------------------------------------------------
 Copyright 2012-2018 (c) Mihai Bazon <mihai.bazon@gmail.com>
 
@@ -8636,7 +8412,7 @@ THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
 SUCH DAMAGE.
 
 ------------------------------------------------------------------------------
-[221] Applies to: npm:throat@5.0.0
+[218] Applies to: npm:throat@5.0.0
 ------------------------------------------------------------------------------
 Copyright (c) 2013 Forbes Lindesay
 
@@ -8659,7 +8435,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[222] Applies to: npm:tinyglobby@0.2.17
+[219] Applies to: npm:tinyglobby@0.2.17
 ------------------------------------------------------------------------------
 MIT License
 
@@ -8684,7 +8460,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
 ------------------------------------------------------------------------------
-[223] Applies to: npm:to-regex-range@5.0.1
+[220] Applies to: npm:to-regex-range@5.0.1
 ------------------------------------------------------------------------------
 The MIT License (MIT)
 
@@ -8709,7 +8485,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[224] Applies to: npm:toidentifier@1.0.1
+[221] Applies to: npm:toidentifier@1.0.1
 ------------------------------------------------------------------------------
 MIT License
 
@@ -8734,7 +8510,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
 ------------------------------------------------------------------------------
-[225] Applies to: npm:tslib@2.8.1
+[222] Applies to: npm:tslib@2.8.1
 ------------------------------------------------------------------------------
 Copyright (c) Microsoft Corporation.
 
@@ -8750,7 +8526,7 @@ OTHER TORTIOUS ACTION, ARISING OUT OF OR IN CONNECTION WITH THE USE OR
 PERFORMANCE OF THIS SOFTWARE.
 
 ------------------------------------------------------------------------------
-[226] Applies to: npm:type-fest@0.21.3
+[223] Applies to: npm:type-fest@0.21.3
 ------------------------------------------------------------------------------
 MIT License
 
@@ -8763,7 +8539,7 @@ The above copyright notice and this permission notice shall be included in all c
 THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[227] Applies to: npm:ua-parser-js@1.0.41
+[224] Applies to: npm:ua-parser-js@1.0.41
 ------------------------------------------------------------------------------
 MIT License
 
@@ -8788,7 +8564,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
 ------------------------------------------------------------------------------
-[228] Applies to: npm:undici-types@7.24.6
+[225] Applies to: npm:undici-types@7.24.6
 ------------------------------------------------------------------------------
 MIT License
 
@@ -8813,7 +8589,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
 ------------------------------------------------------------------------------
-[229] Applies to: npm:unpipe@1.0.0
+[226] Applies to: npm:unpipe@1.0.0
 ------------------------------------------------------------------------------
 (The MIT License)
 
@@ -8839,7 +8615,7 @@ TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
 SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[230] Applies to: npm:update-browserslist-db@1.2.3
+[227] Applies to: npm:update-browserslist-db@1.2.3
 ------------------------------------------------------------------------------
 The MIT License (MIT)
 
@@ -8863,7 +8639,7 @@ IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
 CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[231] Applies to: npm:use-latest-callback@0.2.6
+[228] Applies to: npm:use-latest-callback@0.2.6
 ------------------------------------------------------------------------------
 MIT License
 
@@ -8888,7 +8664,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
 ------------------------------------------------------------------------------
-[232] Applies to: npm:utils-merge@1.0.1
+[229] Applies to: npm:utils-merge@1.0.1
 ------------------------------------------------------------------------------
 The MIT License (MIT)
 
@@ -8912,7 +8688,7 @@ IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
 CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[233] Applies to: npm:uuid@7.0.3
+[230] Applies to: npm:uuid@7.0.3
 ------------------------------------------------------------------------------
 The MIT License (MIT)
 
@@ -8937,7 +8713,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
 ------------------------------------------------------------------------------
-[234] Applies to: npm:validate-npm-package-name@5.0.1
+[231] Applies to: npm:validate-npm-package-name@5.0.1
 ------------------------------------------------------------------------------
 Copyright (c) 2015, npm, Inc
 
@@ -8947,7 +8723,7 @@ Permission to use, copy, modify, and/or distribute this software for any purpose
 THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
 
 ------------------------------------------------------------------------------
-[235] Applies to: npm:vary@1.1.2
+[232] Applies to: npm:vary@1.1.2
 ------------------------------------------------------------------------------
 (The MIT License)
 
@@ -8973,7 +8749,7 @@ TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
 SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[236] Applies to: npm:vaul@1.1.2
+[233] Applies to: npm:vaul@1.1.2
 ------------------------------------------------------------------------------
 MIT License
 
@@ -8986,7 +8762,7 @@ The above copyright notice and this permission notice shall be included in all c
 THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[237] Applies to: npm:vlq@1.0.1
+[234] Applies to: npm:vlq@1.0.1
 ------------------------------------------------------------------------------
 Copyright (c) 2017 [these people](https://github.com/Rich-Harris/vlq/graphs/contributors)
 
@@ -8997,7 +8773,7 @@ The above copyright notice and this permission notice shall be included in all c
 THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[238] Applies to: npm:void-elements@3.1.0
+[235] Applies to: npm:void-elements@3.1.0
 ------------------------------------------------------------------------------
 (The MIT License)
 
@@ -9023,7 +8799,7 @@ TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
 SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[239] Applies to: npm:walker@1.0.8
+[236] Applies to: npm:walker@1.0.8
 ------------------------------------------------------------------------------
 Copyright 2013 Naitik Shah
 
@@ -9040,7 +8816,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 
 ------------------------------------------------------------------------------
-[240] Applies to: npm:warn-once@0.1.1
+[237] Applies to: npm:warn-once@0.1.1
 ------------------------------------------------------------------------------
 MIT License
 
@@ -9065,7 +8841,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
 ------------------------------------------------------------------------------
-[241] Applies to: npm:wcwidth@1.0.1
+[238] Applies to: npm:wcwidth@1.0.1
 ------------------------------------------------------------------------------
 wcwidth.js: JavaScript Portng of Markus Kuhn's wcwidth() Implementation
 =======================================================================
@@ -9098,7 +8874,7 @@ ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 POSSIBILITY OF SUCH DAMAGE.
 
 ------------------------------------------------------------------------------
-[242] Applies to: npm:webidl-conversions@3.0.1
+[239] Applies to: npm:webidl-conversions@3.0.1
 ------------------------------------------------------------------------------
 # The BSD 2-Clause License
 
@@ -9114,7 +8890,7 @@ Redistribution and use in source and binary forms, with or without modification,
 THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 ------------------------------------------------------------------------------
-[243] Applies to: npm:whatwg-fetch@3.6.20
+[240] Applies to: npm:whatwg-fetch@3.6.20
 ------------------------------------------------------------------------------
 Copyright (c) 2014-2023 GitHub, Inc.
 
@@ -9138,7 +8914,7 @@ OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
 WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[244] Applies to: npm:whatwg-url@5.0.0
+[241] Applies to: npm:whatwg-url@5.0.0
 ------------------------------------------------------------------------------
 The MIT License (MIT)
 
@@ -9163,7 +8939,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[245] Applies to: npm:whatwg-url-minimum@0.1.2
+[242] Applies to: npm:whatwg-url-minimum@0.1.2
 ------------------------------------------------------------------------------
 MIT License
 
@@ -9190,7 +8966,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
 ------------------------------------------------------------------------------
-[246] Applies to: npm:ws@7.5.12
+[243] Applies to: npm:ws@7.5.12
 ------------------------------------------------------------------------------
 The MIT License (MIT)
 
@@ -9215,7 +8991,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
 ------------------------------------------------------------------------------
-[247] Applies to: npm:ws@8.21.1
+[244] Applies to: npm:ws@8.21.1
 ------------------------------------------------------------------------------
 Copyright (c) 2011 Einar Otto Stangvik <einaros@gmail.com>
 Copyright (c) 2013 Arnout Kazemier and contributors
@@ -9239,7 +9015,7 @@ IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
 CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[248] Applies to: npm:xcode@3.0.1 (NOTICE)
+[245] Applies to: npm:xcode@3.0.1 (NOTICE)
 ------------------------------------------------------------------------------
 NOTICE for npm:xcode@3.0.1:
 
@@ -9250,7 +9026,7 @@ This product includes software developed at
 The Apache Software Foundation (http://www.apache.org/).
 
 ------------------------------------------------------------------------------
-[249] Applies to: npm:xml2js@0.6.0
+[246] Applies to: npm:xml2js@0.6.0
 ------------------------------------------------------------------------------
 Copyright 2010, 2011, 2012, 2013. All rights reserved.
 
@@ -9273,7 +9049,7 @@ FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
 IN THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[250] Applies to: npm:xmlbuilder@11.0.1, npm:xmlbuilder@15.1.1
+[247] Applies to: npm:xmlbuilder@11.0.1, npm:xmlbuilder@15.1.1
 ------------------------------------------------------------------------------
 The MIT License (MIT)
 
@@ -9298,7 +9074,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[251] Applies to: npm:y18n@5.0.8
+[248] Applies to: npm:y18n@5.0.8
 ------------------------------------------------------------------------------
 Copyright (c) 2015, Contributors
 
@@ -9315,7 +9091,7 @@ TORTIOUS ACTION, ARISING OUT OF OR IN CONNECTION WITH THE USE OR PERFORMANCE OF
 THIS SOFTWARE.
 
 ------------------------------------------------------------------------------
-[252] Applies to: npm:yaml@2.9.0
+[249] Applies to: npm:yaml@2.9.0
 ------------------------------------------------------------------------------
 Copyright Eemeli Aro <eemeli@gmail.com>
 
@@ -9332,7 +9108,7 @@ TORTIOUS ACTION, ARISING OUT OF OR IN CONNECTION WITH THE USE OR PERFORMANCE OF
 THIS SOFTWARE.
 
 ------------------------------------------------------------------------------
-[253] Applies to: npm:yargs@17.7.3
+[250] Applies to: npm:yargs@17.7.3
 ------------------------------------------------------------------------------
 MIT License
 
@@ -9357,7 +9133,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 
 ------------------------------------------------------------------------------
-[254] Applies to: npm:yargs-parser@21.1.1
+[251] Applies to: npm:yargs-parser@21.1.1
 ------------------------------------------------------------------------------
 Copyright (c) 2016, Contributors
 
@@ -9375,7 +9151,7 @@ WHETHER IN AN ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION,
 ARISING OUT OF OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
 
 ------------------------------------------------------------------------------
-[255] Applies to: npm:zod@4.3.6
+[252] Applies to: npm:zod@4.3.6
 ------------------------------------------------------------------------------
 MIT License
 
@@ -9404,21 +9180,21 @@ Packages without a standalone license file (license per package.json):
 ------------------------------------------------------------------------------
 - npm:@expo/devcert@1.2.1 (MIT)
 - npm:@expo/sdk-runtime-versions@1.0.0 (MIT)
-- npm:@expo/ui@56.0.22 (MIT)
+- npm:@expo/ui@57.0.14 (MIT)
 - npm:@expo/ws-tunnel@2.0.0 (MIT)
 - npm:@expo/xcpretty@4.4.4 (BSD-3-Clause)
-- npm:@react-native/assets-registry@0.85.3 (MIT)
-- npm:@react-native/babel-plugin-codegen@0.85.3 (MIT)
-- npm:@react-native/codegen@0.85.3 (MIT)
-- npm:@react-native/community-cli-plugin@0.85.3 (MIT)
-- npm:@react-native/debugger-frontend@0.85.3 (BSD-3-Clause)
-- npm:@react-native/debugger-shell@0.85.3 (MIT)
-- npm:@react-native/dev-middleware@0.85.3 (MIT)
-- npm:@react-native/gradle-plugin@0.85.3 (MIT)
-- npm:@react-native/js-polyfills@0.85.3 (MIT)
+- npm:@react-native/assets-registry@0.86.3 (MIT)
+- npm:@react-native/babel-plugin-codegen@0.86.3 (MIT)
+- npm:@react-native/codegen@0.86.3 (MIT)
+- npm:@react-native/community-cli-plugin@0.86.3 (MIT)
+- npm:@react-native/debugger-frontend@0.86.3 (BSD-3-Clause)
+- npm:@react-native/debugger-shell@0.86.3 (MIT)
+- npm:@react-native/dev-middleware@0.86.3 (MIT)
+- npm:@react-native/gradle-plugin@0.86.3 (MIT)
+- npm:@react-native/js-polyfills@0.86.3 (MIT)
 - npm:@react-native/normalize-colors@0.74.89 (MIT)
-- npm:@react-native/normalize-colors@0.85.3 (MIT)
-- npm:@react-native/virtualized-lists@0.85.3 (MIT)
+- npm:@react-native/normalize-colors@0.86.3 (MIT)
+- npm:@react-native/virtualized-lists@0.86.3 (MIT)
 - npm:babel-plugin-react-compiler@1.0.0 (MIT)
 - npm:badgin@1.2.3 (MIT)
 - npm:boolbase@1.0.0 (ISC)
@@ -9426,30 +9202,44 @@ Packages without a standalone license file (license per package.json):
 - npm:bplist-parser@0.3.2 (MIT)
 - npm:bser@2.1.1 (Apache-2.0)
 - npm:client-only@0.0.1 (MIT)
-- npm:expo-json-utils@56.0.0 (MIT)
-- npm:expo-router@56.2.15 (MIT)
-- npm:expo-structured-headers@56.0.0 (MIT)
-- npm:expo-updates@56.0.22 (MIT)
+- npm:expo-router@57.0.17 (MIT)
+- npm:expo-structured-headers@57.0.0 (MIT)
+- npm:expo-updates@57.0.18 (MIT)
 - npm:fb-dotslash@0.5.8 ((MIT OR Apache-2.0))
 - npm:fb-watchman@2.0.2 (Apache-2.0)
-- npm:hermes-compiler@250829098.0.10 (MIT)
+- npm:hermes-compiler@250829098.0.17 (MIT)
 - npm:html-parse-stringify@3.0.1 (MIT)
 - npm:jimp-compact@0.16.1 (MIT)
 - npm:metro@0.84.4 (MIT)
+- npm:metro@0.84.5 (MIT)
 - npm:metro-babel-transformer@0.84.4 (MIT)
+- npm:metro-babel-transformer@0.84.5 (MIT)
 - npm:metro-cache@0.84.4 (MIT)
+- npm:metro-cache@0.84.5 (MIT)
 - npm:metro-cache-key@0.84.4 (MIT)
+- npm:metro-cache-key@0.84.5 (MIT)
 - npm:metro-config@0.84.4 (MIT)
+- npm:metro-config@0.84.5 (MIT)
 - npm:metro-core@0.84.4 (MIT)
+- npm:metro-core@0.84.5 (MIT)
 - npm:metro-file-map@0.84.4 (MIT)
+- npm:metro-file-map@0.84.5 (MIT)
 - npm:metro-minify-terser@0.84.4 (MIT)
+- npm:metro-minify-terser@0.84.5 (MIT)
 - npm:metro-resolver@0.84.4 (MIT)
+- npm:metro-resolver@0.84.5 (MIT)
 - npm:metro-runtime@0.84.4 (MIT)
+- npm:metro-runtime@0.84.5 (MIT)
 - npm:metro-source-map@0.84.4 (MIT)
+- npm:metro-source-map@0.84.5 (MIT)
 - npm:metro-symbolicate@0.84.4 (MIT)
+- npm:metro-symbolicate@0.84.5 (MIT)
 - npm:metro-transform-plugins@0.84.4 (MIT)
+- npm:metro-transform-plugins@0.84.5 (MIT)
 - npm:metro-transform-worker@0.84.4 (MIT)
+- npm:metro-transform-worker@0.84.5 (MIT)
 - npm:ob1@0.84.4 (MIT)
+- npm:ob1@0.84.5 (MIT)
 - npm:react-devtools-core@6.1.5 (MIT)
 - npm:react-remove-scroll-bar@2.3.8 (MIT)
 - npm:server-only@0.0.1 (MIT)

--- a/docs/legal/notices/sbom/desktop-linux.spdx.json
+++ b/docs/legal/notices/sbom/desktop-linux.spdx.json
@@ -3,9 +3,9 @@
   "dataLicense": "CC0-1.0",
   "SPDXID": "SPDXRef-DOCUMENT",
   "name": "cindy-desktop-linux",
-  "documentNamespace": "https://cindy.app/spdx/desktop-linux/474608a0d72ac80973f3c0c12f44d0db8d19d9d87f818662dd586a576c911ca9",
+  "documentNamespace": "https://cindy.app/spdx/desktop-linux/f50b1ffaaabe7683b25bbab0193449d1f3d86142ed23fe302c3dc623fe260c5f",
   "creationInfo": {
-    "created": "2026-08-14T10:29:27Z",
+    "created": "2026-09-02T19:21:04Z",
     "creators": [
       "Tool: scripts/generate-third-party-notices.mjs"
     ]
@@ -103,8 +103,8 @@
     },
     {
       "name": "pi coding agent (runtime-downloaded binary)",
-      "SPDXID": "SPDXRef-Package-04c1add3e48a9e5c",
-      "versionInfo": "0.83.0",
+      "SPDXID": "SPDXRef-Package-a3cbdbce86e6fdc7",
+      "versionInfo": "0.84.4",
       "downloadLocation": "https://github.com/earendil-works/pi",
       "filesAnalyzed": false,
       "licenseConcluded": "MIT",
@@ -196,6 +196,57 @@
       ]
     },
     {
+      "name": "@babel/helper-string-parser",
+      "SPDXID": "SPDXRef-Package-2d6a4b723df29496",
+      "versionInfo": "7.29.7",
+      "downloadLocation": "https://github.com/babel/babel",
+      "filesAnalyzed": false,
+      "licenseConcluded": "MIT",
+      "licenseDeclared": "MIT",
+      "copyrightText": "NOASSERTION",
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceType": "purl",
+          "referenceLocator": "pkg:npm/%40babel/helper-string-parser@7.29.7"
+        }
+      ]
+    },
+    {
+      "name": "@babel/helper-validator-identifier",
+      "SPDXID": "SPDXRef-Package-d10d1f341d4abfa8",
+      "versionInfo": "7.29.7",
+      "downloadLocation": "https://github.com/babel/babel",
+      "filesAnalyzed": false,
+      "licenseConcluded": "MIT",
+      "licenseDeclared": "MIT",
+      "copyrightText": "NOASSERTION",
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceType": "purl",
+          "referenceLocator": "pkg:npm/%40babel/helper-validator-identifier@7.29.7"
+        }
+      ]
+    },
+    {
+      "name": "@babel/parser",
+      "SPDXID": "SPDXRef-Package-bae6a338f33d9a1c",
+      "versionInfo": "7.29.7",
+      "downloadLocation": "https://github.com/babel/babel",
+      "filesAnalyzed": false,
+      "licenseConcluded": "MIT",
+      "licenseDeclared": "MIT",
+      "copyrightText": "NOASSERTION",
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceType": "purl",
+          "referenceLocator": "pkg:npm/%40babel/parser@7.29.7"
+        }
+      ]
+    },
+    {
       "name": "@babel/runtime",
       "SPDXID": "SPDXRef-Package-edf04d45834b4fbf",
       "versionInfo": "7.29.7",
@@ -209,6 +260,23 @@
           "referenceCategory": "PACKAGE-MANAGER",
           "referenceType": "purl",
           "referenceLocator": "pkg:npm/%40babel/runtime@7.29.7"
+        }
+      ]
+    },
+    {
+      "name": "@babel/types",
+      "SPDXID": "SPDXRef-Package-3adbc0856a9bda85",
+      "versionInfo": "7.29.7",
+      "downloadLocation": "https://github.com/babel/babel",
+      "filesAnalyzed": false,
+      "licenseConcluded": "MIT",
+      "licenseDeclared": "MIT",
+      "copyrightText": "NOASSERTION",
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceType": "purl",
+          "referenceLocator": "pkg:npm/%40babel/types@7.29.7"
         }
       ]
     },
@@ -753,6 +821,40 @@
           "referenceCategory": "PACKAGE-MANAGER",
           "referenceType": "purl",
           "referenceLocator": "pkg:npm/%40discordjs/ws@1.2.3"
+        }
+      ]
+    },
+    {
+      "name": "@fast-csv/format",
+      "SPDXID": "SPDXRef-Package-ef09030156acbe49",
+      "versionInfo": "4.3.5",
+      "downloadLocation": "https://github.com/C2FO/fast-csv",
+      "filesAnalyzed": false,
+      "licenseConcluded": "MIT",
+      "licenseDeclared": "MIT",
+      "copyrightText": "NOASSERTION",
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceType": "purl",
+          "referenceLocator": "pkg:npm/%40fast-csv/format@4.3.5"
+        }
+      ]
+    },
+    {
+      "name": "@fast-csv/parse",
+      "SPDXID": "SPDXRef-Package-f4baae4686e02f0a",
+      "versionInfo": "4.3.6",
+      "downloadLocation": "https://github.com/C2FO/fast-csv",
+      "filesAnalyzed": false,
+      "licenseConcluded": "MIT",
+      "licenseDeclared": "MIT",
+      "copyrightText": "NOASSERTION",
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceType": "purl",
+          "referenceLocator": "pkg:npm/%40fast-csv/parse@4.3.6"
         }
       ]
     },
@@ -3512,6 +3614,40 @@
     },
     {
       "name": "@types/node",
+      "SPDXID": "SPDXRef-Package-c6b0b3ef4062e7b5",
+      "versionInfo": "14.18.63",
+      "downloadLocation": "https://github.com/DefinitelyTyped/DefinitelyTyped",
+      "filesAnalyzed": false,
+      "licenseConcluded": "MIT",
+      "licenseDeclared": "MIT",
+      "copyrightText": "NOASSERTION",
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceType": "purl",
+          "referenceLocator": "pkg:npm/%40types/node@14.18.63"
+        }
+      ]
+    },
+    {
+      "name": "@types/node",
+      "SPDXID": "SPDXRef-Package-006d2bce93d8f1dd",
+      "versionInfo": "22.20.1",
+      "downloadLocation": "https://github.com/DefinitelyTyped/DefinitelyTyped",
+      "filesAnalyzed": false,
+      "licenseConcluded": "MIT",
+      "licenseDeclared": "MIT",
+      "copyrightText": "NOASSERTION",
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceType": "purl",
+          "referenceLocator": "pkg:npm/%40types/node@22.20.1"
+        }
+      ]
+    },
+    {
+      "name": "@types/node",
       "SPDXID": "SPDXRef-Package-b02ebf6599a4715f",
       "versionInfo": "25.9.5",
       "downloadLocation": "https://github.com/DefinitelyTyped/DefinitelyTyped",
@@ -3936,6 +4072,57 @@
       ]
     },
     {
+      "name": "archiver",
+      "SPDXID": "SPDXRef-Package-9135483032251fea",
+      "versionInfo": "5.3.2",
+      "downloadLocation": "https://github.com/archiverjs/node-archiver",
+      "filesAnalyzed": false,
+      "licenseConcluded": "MIT",
+      "licenseDeclared": "MIT",
+      "copyrightText": "NOASSERTION",
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceType": "purl",
+          "referenceLocator": "pkg:npm/archiver@5.3.2"
+        }
+      ]
+    },
+    {
+      "name": "archiver-utils",
+      "SPDXID": "SPDXRef-Package-e4af001b994a14f4",
+      "versionInfo": "2.1.0",
+      "downloadLocation": "https://github.com/archiverjs/archiver-utils",
+      "filesAnalyzed": false,
+      "licenseConcluded": "MIT",
+      "licenseDeclared": "MIT",
+      "copyrightText": "NOASSERTION",
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceType": "purl",
+          "referenceLocator": "pkg:npm/archiver-utils@2.1.0"
+        }
+      ]
+    },
+    {
+      "name": "archiver-utils",
+      "SPDXID": "SPDXRef-Package-f7b326a32927cbed",
+      "versionInfo": "3.0.4",
+      "downloadLocation": "https://github.com/archiverjs/archiver-utils",
+      "filesAnalyzed": false,
+      "licenseConcluded": "MIT",
+      "licenseDeclared": "MIT",
+      "copyrightText": "NOASSERTION",
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceType": "purl",
+          "referenceLocator": "pkg:npm/archiver-utils@3.0.4"
+        }
+      ]
+    },
+    {
       "name": "argparse",
       "SPDXID": "SPDXRef-Package-1b8ff3f05bffff87",
       "versionInfo": "1.0.10",
@@ -4000,6 +4187,23 @@
           "referenceCategory": "PACKAGE-MANAGER",
           "referenceType": "purl",
           "referenceLocator": "pkg:npm/asn1@0.2.6"
+        }
+      ]
+    },
+    {
+      "name": "async",
+      "SPDXID": "SPDXRef-Package-1faad319f76b179f",
+      "versionInfo": "3.2.6",
+      "downloadLocation": "https://github.com/caolan/async",
+      "filesAnalyzed": false,
+      "licenseConcluded": "MIT",
+      "licenseDeclared": "MIT",
+      "copyrightText": "NOASSERTION",
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceType": "purl",
+          "referenceLocator": "pkg:npm/async@3.2.6"
         }
       ]
     },
@@ -4140,6 +4344,23 @@
       ]
     },
     {
+      "name": "big-integer",
+      "SPDXID": "SPDXRef-Package-d4c964d5752fd254",
+      "versionInfo": "1.6.52",
+      "downloadLocation": "https://github.com/peterolson/BigInteger.js",
+      "filesAnalyzed": false,
+      "licenseConcluded": "Unlicense",
+      "licenseDeclared": "Unlicense",
+      "copyrightText": "NOASSERTION",
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceType": "purl",
+          "referenceLocator": "pkg:npm/big-integer@1.6.52"
+        }
+      ]
+    },
+    {
       "name": "bignumber.js",
       "SPDXID": "SPDXRef-Package-e6bcaebbcb046dc4",
       "versionInfo": "9.3.1",
@@ -4153,6 +4374,23 @@
           "referenceCategory": "PACKAGE-MANAGER",
           "referenceType": "purl",
           "referenceLocator": "pkg:npm/bignumber.js@9.3.1"
+        }
+      ]
+    },
+    {
+      "name": "binary",
+      "SPDXID": "SPDXRef-Package-169094cbdc1389db",
+      "versionInfo": "0.3.0",
+      "downloadLocation": "http://github.com/substack/node-binary",
+      "filesAnalyzed": false,
+      "licenseConcluded": "MIT",
+      "licenseDeclared": "MIT",
+      "copyrightText": "NOASSERTION",
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceType": "purl",
+          "referenceLocator": "pkg:npm/binary@0.3.0"
         }
       ]
     },
@@ -4191,6 +4429,23 @@
       ]
     },
     {
+      "name": "bluebird",
+      "SPDXID": "SPDXRef-Package-281d2b6b5950a4ba",
+      "versionInfo": "3.4.7",
+      "downloadLocation": "https://github.com/petkaantonov/bluebird",
+      "filesAnalyzed": false,
+      "licenseConcluded": "MIT",
+      "licenseDeclared": "MIT",
+      "copyrightText": "NOASSERTION",
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceType": "purl",
+          "referenceLocator": "pkg:npm/bluebird@3.4.7"
+        }
+      ]
+    },
+    {
       "name": "body-parser",
       "SPDXID": "SPDXRef-Package-603bfb1d8a6cd096",
       "versionInfo": "2.3.0",
@@ -4204,6 +4459,23 @@
           "referenceCategory": "PACKAGE-MANAGER",
           "referenceType": "purl",
           "referenceLocator": "pkg:npm/body-parser@2.3.0"
+        }
+      ]
+    },
+    {
+      "name": "brace-expansion",
+      "SPDXID": "SPDXRef-Package-3a4b46a93421a532",
+      "versionInfo": "1.1.16",
+      "downloadLocation": "https://github.com/juliangruber/brace-expansion",
+      "filesAnalyzed": false,
+      "licenseConcluded": "MIT",
+      "licenseDeclared": "MIT",
+      "copyrightText": "NOASSERTION",
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceType": "purl",
+          "referenceLocator": "pkg:npm/brace-expansion@1.1.16"
         }
       ]
     },
@@ -4242,6 +4514,23 @@
       ]
     },
     {
+      "name": "buffer-crc32",
+      "SPDXID": "SPDXRef-Package-3f07b92fa45ba611",
+      "versionInfo": "0.2.13",
+      "downloadLocation": "https://github.com/brianloveswords/buffer-crc32",
+      "filesAnalyzed": false,
+      "licenseConcluded": "MIT",
+      "licenseDeclared": "MIT",
+      "copyrightText": "NOASSERTION",
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceType": "purl",
+          "referenceLocator": "pkg:npm/buffer-crc32@0.2.13"
+        }
+      ]
+    },
+    {
       "name": "buffer-equal-constant-time",
       "SPDXID": "SPDXRef-Package-2f4ce0cccb4ed6f4",
       "versionInfo": "1.0.1",
@@ -4255,6 +4544,40 @@
           "referenceCategory": "PACKAGE-MANAGER",
           "referenceType": "purl",
           "referenceLocator": "pkg:npm/buffer-equal-constant-time@1.0.1"
+        }
+      ]
+    },
+    {
+      "name": "buffer-indexof-polyfill",
+      "SPDXID": "SPDXRef-Package-62eb5a03ebf03674",
+      "versionInfo": "1.0.2",
+      "downloadLocation": "https://github.com/sarosia/buffer-indexof-polyfill",
+      "filesAnalyzed": false,
+      "licenseConcluded": "MIT",
+      "licenseDeclared": "MIT",
+      "copyrightText": "NOASSERTION",
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceType": "purl",
+          "referenceLocator": "pkg:npm/buffer-indexof-polyfill@1.0.2"
+        }
+      ]
+    },
+    {
+      "name": "buffers",
+      "SPDXID": "SPDXRef-Package-8e3f307fa2ee1e16",
+      "versionInfo": "0.1.1",
+      "downloadLocation": "http://github.com/substack/node-buffers",
+      "filesAnalyzed": false,
+      "licenseConcluded": "MIT",
+      "licenseDeclared": "MIT",
+      "copyrightText": "NOASSERTION",
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceType": "purl",
+          "referenceLocator": "pkg:npm/buffers@0.1.1"
         }
       ]
     },
@@ -4374,6 +4697,23 @@
           "referenceCategory": "PACKAGE-MANAGER",
           "referenceType": "purl",
           "referenceLocator": "pkg:npm/ccount@2.0.1"
+        }
+      ]
+    },
+    {
+      "name": "chainsaw",
+      "SPDXID": "SPDXRef-Package-b114758f8c10a13e",
+      "versionInfo": "0.1.0",
+      "downloadLocation": "http://github.com/substack/node-chainsaw",
+      "filesAnalyzed": false,
+      "licenseConcluded": "MIT",
+      "licenseDeclared": "MIT",
+      "copyrightText": "NOASSERTION",
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceType": "purl",
+          "referenceLocator": "pkg:npm/chainsaw@0.1.0"
         }
       ]
     },
@@ -4650,6 +4990,40 @@
       ]
     },
     {
+      "name": "compress-commons",
+      "SPDXID": "SPDXRef-Package-e77e224d03910af4",
+      "versionInfo": "4.1.2",
+      "downloadLocation": "https://github.com/archiverjs/node-compress-commons",
+      "filesAnalyzed": false,
+      "licenseConcluded": "MIT",
+      "licenseDeclared": "MIT",
+      "copyrightText": "NOASSERTION",
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceType": "purl",
+          "referenceLocator": "pkg:npm/compress-commons@4.1.2"
+        }
+      ]
+    },
+    {
+      "name": "concat-map",
+      "SPDXID": "SPDXRef-Package-446fb7e0d413f4e8",
+      "versionInfo": "0.0.1",
+      "downloadLocation": "https://github.com/substack/node-concat-map",
+      "filesAnalyzed": false,
+      "licenseConcluded": "MIT",
+      "licenseDeclared": "MIT",
+      "copyrightText": "NOASSERTION",
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceType": "purl",
+          "referenceLocator": "pkg:npm/concat-map@0.0.1"
+        }
+      ]
+    },
+    {
       "name": "conf",
       "SPDXID": "SPDXRef-Package-4b508a608e7c9c35",
       "versionInfo": "9.0.2",
@@ -4850,6 +5224,40 @@
           "referenceCategory": "PACKAGE-MANAGER",
           "referenceType": "purl",
           "referenceLocator": "pkg:npm/cpu-features@0.0.10"
+        }
+      ]
+    },
+    {
+      "name": "crc-32",
+      "SPDXID": "SPDXRef-Package-7b769d3a0b61c741",
+      "versionInfo": "1.2.2",
+      "downloadLocation": "https://github.com/SheetJS/js-crc32",
+      "filesAnalyzed": false,
+      "licenseConcluded": "Apache-2.0",
+      "licenseDeclared": "Apache-2.0",
+      "copyrightText": "NOASSERTION",
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceType": "purl",
+          "referenceLocator": "pkg:npm/crc-32@1.2.2"
+        }
+      ]
+    },
+    {
+      "name": "crc32-stream",
+      "SPDXID": "SPDXRef-Package-3bd6e89d41e1b16e",
+      "versionInfo": "4.0.3",
+      "downloadLocation": "https://github.com/archiverjs/node-crc32-stream",
+      "filesAnalyzed": false,
+      "licenseConcluded": "MIT",
+      "licenseDeclared": "MIT",
+      "copyrightText": "NOASSERTION",
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceType": "purl",
+          "referenceLocator": "pkg:npm/crc32-stream@4.0.3"
         }
       ]
     },
@@ -5942,6 +6350,23 @@
       ]
     },
     {
+      "name": "docx",
+      "SPDXID": "SPDXRef-Package-5fcae62518b2d23a",
+      "versionInfo": "9.7.1",
+      "downloadLocation": "https://github.com/dolanmiu/docx",
+      "filesAnalyzed": false,
+      "licenseConcluded": "MIT",
+      "licenseDeclared": "MIT",
+      "copyrightText": "NOASSERTION",
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceType": "purl",
+          "referenceLocator": "pkg:npm/docx@9.7.1"
+        }
+      ]
+    },
+    {
       "name": "dompurify",
       "SPDXID": "SPDXRef-Package-fe4205b186c43bb8",
       "versionInfo": "3.4.12",
@@ -6006,6 +6431,23 @@
           "referenceCategory": "PACKAGE-MANAGER",
           "referenceType": "purl",
           "referenceLocator": "pkg:npm/dunder-proto@1.0.1"
+        }
+      ]
+    },
+    {
+      "name": "duplexer2",
+      "SPDXID": "SPDXRef-Package-5203e1981b9684d9",
+      "versionInfo": "0.1.4",
+      "downloadLocation": "https://github.com/deoxxa/duplexer2",
+      "filesAnalyzed": false,
+      "licenseConcluded": "BSD-3-Clause",
+      "licenseDeclared": "BSD-3-Clause",
+      "copyrightText": "NOASSERTION",
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceType": "purl",
+          "referenceLocator": "pkg:npm/duplexer2@0.1.4"
         }
       ]
     },
@@ -6435,6 +6877,23 @@
       ]
     },
     {
+      "name": "exceljs",
+      "SPDXID": "SPDXRef-Package-a037ed657533f4f1",
+      "versionInfo": "4.4.0",
+      "downloadLocation": "https://github.com/exceljs/exceljs",
+      "filesAnalyzed": false,
+      "licenseConcluded": "MIT",
+      "licenseDeclared": "MIT",
+      "copyrightText": "NOASSERTION",
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceType": "purl",
+          "referenceLocator": "pkg:npm/exceljs@4.4.0"
+        }
+      ]
+    },
+    {
       "name": "execa",
       "SPDXID": "SPDXRef-Package-95a792ac9cb6ef2b",
       "versionInfo": "4.1.0",
@@ -6550,6 +7009,23 @@
           "referenceCategory": "PACKAGE-MANAGER",
           "referenceType": "purl",
           "referenceLocator": "pkg:npm/extend-shallow@2.0.1"
+        }
+      ]
+    },
+    {
+      "name": "fast-csv",
+      "SPDXID": "SPDXRef-Package-c7b893d84403ff14",
+      "versionInfo": "4.3.6",
+      "downloadLocation": "https://github.com/C2FO/fast-csv",
+      "filesAnalyzed": false,
+      "licenseConcluded": "MIT",
+      "licenseDeclared": "MIT",
+      "copyrightText": "NOASSERTION",
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceType": "purl",
+          "referenceLocator": "pkg:npm/fast-csv@4.3.6"
         }
       ]
     },
@@ -6843,6 +7319,40 @@
       ]
     },
     {
+      "name": "fs.realpath",
+      "SPDXID": "SPDXRef-Package-066c98d78f779398",
+      "versionInfo": "1.0.0",
+      "downloadLocation": "https://github.com/isaacs/fs.realpath",
+      "filesAnalyzed": false,
+      "licenseConcluded": "ISC",
+      "licenseDeclared": "ISC",
+      "copyrightText": "NOASSERTION",
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceType": "purl",
+          "referenceLocator": "pkg:npm/fs.realpath@1.0.0"
+        }
+      ]
+    },
+    {
+      "name": "fstream",
+      "SPDXID": "SPDXRef-Package-8c228885d01e65b0",
+      "versionInfo": "1.0.12",
+      "downloadLocation": "https://github.com/npm/fstream",
+      "filesAnalyzed": false,
+      "licenseConcluded": "ISC",
+      "licenseDeclared": "ISC",
+      "copyrightText": "NOASSERTION",
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceType": "purl",
+          "referenceLocator": "pkg:npm/fstream@1.0.12"
+        }
+      ]
+    },
+    {
       "name": "function-bind",
       "SPDXID": "SPDXRef-Package-efff64b24eff87e8",
       "versionInfo": "1.1.2",
@@ -7098,6 +7608,23 @@
       ]
     },
     {
+      "name": "glob",
+      "SPDXID": "SPDXRef-Package-8702ad5f91114f8f",
+      "versionInfo": "7.2.3",
+      "downloadLocation": "https://github.com/isaacs/node-glob",
+      "filesAnalyzed": false,
+      "licenseConcluded": "ISC",
+      "licenseDeclared": "ISC",
+      "copyrightText": "NOASSERTION",
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceType": "purl",
+          "referenceLocator": "pkg:npm/glob@7.2.3"
+        }
+      ]
+    },
+    {
       "name": "google-auth-library",
       "SPDXID": "SPDXRef-Package-ca014b881c253ebc",
       "versionInfo": "10.5.0",
@@ -7298,6 +7825,23 @@
           "referenceCategory": "PACKAGE-MANAGER",
           "referenceType": "purl",
           "referenceLocator": "pkg:npm/has-tostringtag@1.0.2"
+        }
+      ]
+    },
+    {
+      "name": "hash.js",
+      "SPDXID": "SPDXRef-Package-0fe3a8dd2852340e",
+      "versionInfo": "1.1.7",
+      "downloadLocation": "https://github.com/indutny/hash.js",
+      "filesAnalyzed": false,
+      "licenseConcluded": "MIT",
+      "licenseDeclared": "MIT",
+      "copyrightText": "NOASSERTION",
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceType": "purl",
+          "referenceLocator": "pkg:npm/hash.js@1.1.7"
         }
       ]
     },
@@ -7625,6 +8169,23 @@
       ]
     },
     {
+      "name": "https",
+      "SPDXID": "SPDXRef-Package-a6138fed56d8e05e",
+      "versionInfo": "1.0.0",
+      "downloadLocation": "NOASSERTION",
+      "filesAnalyzed": false,
+      "licenseConcluded": "ISC",
+      "licenseDeclared": "ISC",
+      "copyrightText": "NOASSERTION",
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceType": "purl",
+          "referenceLocator": "pkg:npm/https@1.0.0"
+        }
+      ]
+    },
+    {
       "name": "https-proxy-agent",
       "SPDXID": "SPDXRef-Package-ca16958c815c8380",
       "versionInfo": "5.0.1",
@@ -7778,6 +8339,23 @@
       ]
     },
     {
+      "name": "image-size",
+      "SPDXID": "SPDXRef-Package-41bbec0dae5bac67",
+      "versionInfo": "1.2.1",
+      "downloadLocation": "https://github.com/image-size/image-size",
+      "filesAnalyzed": false,
+      "licenseConcluded": "MIT",
+      "licenseDeclared": "MIT",
+      "copyrightText": "NOASSERTION",
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceType": "purl",
+          "referenceLocator": "pkg:npm/image-size@1.2.1"
+        }
+      ]
+    },
+    {
       "name": "immediate",
       "SPDXID": "SPDXRef-Package-1bf8b3e308414474",
       "versionInfo": "3.0.6",
@@ -7808,6 +8386,23 @@
           "referenceCategory": "PACKAGE-MANAGER",
           "referenceType": "purl",
           "referenceLocator": "pkg:npm/import-meta-resolve@4.2.0"
+        }
+      ]
+    },
+    {
+      "name": "inflight",
+      "SPDXID": "SPDXRef-Package-93b34ac704832584",
+      "versionInfo": "1.0.6",
+      "downloadLocation": "https://github.com/npm/inflight",
+      "filesAnalyzed": false,
+      "licenseConcluded": "ISC",
+      "licenseDeclared": "ISC",
+      "copyrightText": "NOASSERTION",
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceType": "purl",
+          "referenceLocator": "pkg:npm/inflight@1.0.6"
         }
       ]
     },
@@ -8577,6 +9172,23 @@
       ]
     },
     {
+      "name": "lazystream",
+      "SPDXID": "SPDXRef-Package-85cab3d3fea075b9",
+      "versionInfo": "1.0.1",
+      "downloadLocation": "https://github.com/jpommerening/node-lazystream",
+      "filesAnalyzed": false,
+      "licenseConcluded": "MIT",
+      "licenseDeclared": "MIT",
+      "copyrightText": "NOASSERTION",
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceType": "purl",
+          "referenceLocator": "pkg:npm/lazystream@1.0.1"
+        }
+      ]
+    },
+    {
       "name": "lcid",
       "SPDXID": "SPDXRef-Package-dc65c95b58f6df34",
       "versionInfo": "3.1.1",
@@ -8607,6 +9219,23 @@
           "referenceCategory": "PACKAGE-MANAGER",
           "referenceType": "purl",
           "referenceLocator": "pkg:npm/lie@3.3.0"
+        }
+      ]
+    },
+    {
+      "name": "listenercount",
+      "SPDXID": "SPDXRef-Package-a12a1c81551b29a0",
+      "versionInfo": "1.0.1",
+      "downloadLocation": "https://github.com/jden/node-listenercount",
+      "filesAnalyzed": false,
+      "licenseConcluded": "ISC",
+      "licenseDeclared": "ISC",
+      "copyrightText": "NOASSERTION",
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceType": "purl",
+          "referenceLocator": "pkg:npm/listenercount@1.0.1"
         }
       ]
     },
@@ -8730,6 +9359,91 @@
       ]
     },
     {
+      "name": "lodash.defaults",
+      "SPDXID": "SPDXRef-Package-a3a0c53acb8c1dcc",
+      "versionInfo": "4.2.0",
+      "downloadLocation": "https://github.com/lodash/lodash",
+      "filesAnalyzed": false,
+      "licenseConcluded": "MIT",
+      "licenseDeclared": "MIT",
+      "copyrightText": "NOASSERTION",
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceType": "purl",
+          "referenceLocator": "pkg:npm/lodash.defaults@4.2.0"
+        }
+      ]
+    },
+    {
+      "name": "lodash.difference",
+      "SPDXID": "SPDXRef-Package-0264c095c57bc5cf",
+      "versionInfo": "4.5.0",
+      "downloadLocation": "https://github.com/lodash/lodash",
+      "filesAnalyzed": false,
+      "licenseConcluded": "MIT",
+      "licenseDeclared": "MIT",
+      "copyrightText": "NOASSERTION",
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceType": "purl",
+          "referenceLocator": "pkg:npm/lodash.difference@4.5.0"
+        }
+      ]
+    },
+    {
+      "name": "lodash.escaperegexp",
+      "SPDXID": "SPDXRef-Package-de4b3a9e90ea9774",
+      "versionInfo": "4.1.2",
+      "downloadLocation": "https://github.com/lodash/lodash",
+      "filesAnalyzed": false,
+      "licenseConcluded": "MIT",
+      "licenseDeclared": "MIT",
+      "copyrightText": "NOASSERTION",
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceType": "purl",
+          "referenceLocator": "pkg:npm/lodash.escaperegexp@4.1.2"
+        }
+      ]
+    },
+    {
+      "name": "lodash.flatten",
+      "SPDXID": "SPDXRef-Package-0729f90dee660e49",
+      "versionInfo": "4.4.0",
+      "downloadLocation": "https://github.com/lodash/lodash",
+      "filesAnalyzed": false,
+      "licenseConcluded": "MIT",
+      "licenseDeclared": "MIT",
+      "copyrightText": "NOASSERTION",
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceType": "purl",
+          "referenceLocator": "pkg:npm/lodash.flatten@4.4.0"
+        }
+      ]
+    },
+    {
+      "name": "lodash.groupby",
+      "SPDXID": "SPDXRef-Package-ff4c49b4828c9e19",
+      "versionInfo": "4.6.0",
+      "downloadLocation": "https://github.com/lodash/lodash",
+      "filesAnalyzed": false,
+      "licenseConcluded": "MIT",
+      "licenseDeclared": "MIT",
+      "copyrightText": "NOASSERTION",
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceType": "purl",
+          "referenceLocator": "pkg:npm/lodash.groupby@4.6.0"
+        }
+      ]
+    },
+    {
       "name": "lodash.identity",
       "SPDXID": "SPDXRef-Package-a1ca8608b85fb076",
       "versionInfo": "3.0.0",
@@ -8743,6 +9457,108 @@
           "referenceCategory": "PACKAGE-MANAGER",
           "referenceType": "purl",
           "referenceLocator": "pkg:npm/lodash.identity@3.0.0"
+        }
+      ]
+    },
+    {
+      "name": "lodash.isboolean",
+      "SPDXID": "SPDXRef-Package-db45f10bd3ef5fb5",
+      "versionInfo": "3.0.3",
+      "downloadLocation": "https://github.com/lodash/lodash",
+      "filesAnalyzed": false,
+      "licenseConcluded": "MIT",
+      "licenseDeclared": "MIT",
+      "copyrightText": "NOASSERTION",
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceType": "purl",
+          "referenceLocator": "pkg:npm/lodash.isboolean@3.0.3"
+        }
+      ]
+    },
+    {
+      "name": "lodash.isequal",
+      "SPDXID": "SPDXRef-Package-4fbfd070c92eb053",
+      "versionInfo": "4.5.0",
+      "downloadLocation": "https://github.com/lodash/lodash",
+      "filesAnalyzed": false,
+      "licenseConcluded": "MIT",
+      "licenseDeclared": "MIT",
+      "copyrightText": "NOASSERTION",
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceType": "purl",
+          "referenceLocator": "pkg:npm/lodash.isequal@4.5.0"
+        }
+      ]
+    },
+    {
+      "name": "lodash.isfunction",
+      "SPDXID": "SPDXRef-Package-48d573eae5c4cd81",
+      "versionInfo": "3.0.9",
+      "downloadLocation": "https://github.com/lodash/lodash",
+      "filesAnalyzed": false,
+      "licenseConcluded": "MIT",
+      "licenseDeclared": "MIT",
+      "copyrightText": "NOASSERTION",
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceType": "purl",
+          "referenceLocator": "pkg:npm/lodash.isfunction@3.0.9"
+        }
+      ]
+    },
+    {
+      "name": "lodash.isnil",
+      "SPDXID": "SPDXRef-Package-45270f7cf55ec688",
+      "versionInfo": "4.0.0",
+      "downloadLocation": "https://github.com/lodash/lodash",
+      "filesAnalyzed": false,
+      "licenseConcluded": "MIT",
+      "licenseDeclared": "MIT",
+      "copyrightText": "NOASSERTION",
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceType": "purl",
+          "referenceLocator": "pkg:npm/lodash.isnil@4.0.0"
+        }
+      ]
+    },
+    {
+      "name": "lodash.isplainobject",
+      "SPDXID": "SPDXRef-Package-715a4dee5083b138",
+      "versionInfo": "4.0.6",
+      "downloadLocation": "https://github.com/lodash/lodash",
+      "filesAnalyzed": false,
+      "licenseConcluded": "MIT",
+      "licenseDeclared": "MIT",
+      "copyrightText": "NOASSERTION",
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceType": "purl",
+          "referenceLocator": "pkg:npm/lodash.isplainobject@4.0.6"
+        }
+      ]
+    },
+    {
+      "name": "lodash.isundefined",
+      "SPDXID": "SPDXRef-Package-395eddedb8745a8f",
+      "versionInfo": "3.0.1",
+      "downloadLocation": "https://github.com/lodash/lodash",
+      "filesAnalyzed": false,
+      "licenseConcluded": "MIT",
+      "licenseDeclared": "MIT",
+      "copyrightText": "NOASSERTION",
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceType": "purl",
+          "referenceLocator": "pkg:npm/lodash.isundefined@3.0.1"
         }
       ]
     },
@@ -8794,6 +9610,40 @@
           "referenceCategory": "PACKAGE-MANAGER",
           "referenceType": "purl",
           "referenceLocator": "pkg:npm/lodash.snakecase@4.1.1"
+        }
+      ]
+    },
+    {
+      "name": "lodash.union",
+      "SPDXID": "SPDXRef-Package-57a1e9a5e166604b",
+      "versionInfo": "4.6.0",
+      "downloadLocation": "https://github.com/lodash/lodash",
+      "filesAnalyzed": false,
+      "licenseConcluded": "MIT",
+      "licenseDeclared": "MIT",
+      "copyrightText": "NOASSERTION",
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceType": "purl",
+          "referenceLocator": "pkg:npm/lodash.union@4.6.0"
+        }
+      ]
+    },
+    {
+      "name": "lodash.uniq",
+      "SPDXID": "SPDXRef-Package-ce721e649dfb1e5c",
+      "versionInfo": "4.5.0",
+      "downloadLocation": "https://github.com/lodash/lodash",
+      "filesAnalyzed": false,
+      "licenseConcluded": "MIT",
+      "licenseDeclared": "MIT",
+      "copyrightText": "NOASSERTION",
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceType": "purl",
+          "referenceLocator": "pkg:npm/lodash.uniq@4.5.0"
         }
       ]
     },
@@ -10005,6 +10855,57 @@
       ]
     },
     {
+      "name": "minimalistic-assert",
+      "SPDXID": "SPDXRef-Package-588f964b04a1a148",
+      "versionInfo": "1.0.1",
+      "downloadLocation": "https://github.com/calvinmetcalf/minimalistic-assert",
+      "filesAnalyzed": false,
+      "licenseConcluded": "ISC",
+      "licenseDeclared": "ISC",
+      "copyrightText": "NOASSERTION",
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceType": "purl",
+          "referenceLocator": "pkg:npm/minimalistic-assert@1.0.1"
+        }
+      ]
+    },
+    {
+      "name": "minimatch",
+      "SPDXID": "SPDXRef-Package-40d05b19a4e7d885",
+      "versionInfo": "3.1.5",
+      "downloadLocation": "https://github.com/isaacs/minimatch",
+      "filesAnalyzed": false,
+      "licenseConcluded": "ISC",
+      "licenseDeclared": "ISC",
+      "copyrightText": "NOASSERTION",
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceType": "purl",
+          "referenceLocator": "pkg:npm/minimatch@3.1.5"
+        }
+      ]
+    },
+    {
+      "name": "minimatch",
+      "SPDXID": "SPDXRef-Package-9b652aa8c82e5af7",
+      "versionInfo": "5.1.9",
+      "downloadLocation": "https://github.com/isaacs/minimatch",
+      "filesAnalyzed": false,
+      "licenseConcluded": "ISC",
+      "licenseDeclared": "ISC",
+      "copyrightText": "NOASSERTION",
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceType": "purl",
+          "referenceLocator": "pkg:npm/minimatch@5.1.9"
+        }
+      ]
+    },
+    {
       "name": "minimatch",
       "SPDXID": "SPDXRef-Package-9a47e0282c0c109e",
       "versionInfo": "9.0.9",
@@ -10175,6 +11076,23 @@
       ]
     },
     {
+      "name": "nanoid",
+      "SPDXID": "SPDXRef-Package-351e1526e0c140ae",
+      "versionInfo": "5.1.16",
+      "downloadLocation": "https://github.com/ai/nanoid",
+      "filesAnalyzed": false,
+      "licenseConcluded": "MIT",
+      "licenseDeclared": "MIT",
+      "copyrightText": "NOASSERTION",
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceType": "purl",
+          "referenceLocator": "pkg:npm/nanoid@5.1.16"
+        }
+      ]
+    },
+    {
       "name": "napi-build-utils",
       "SPDXID": "SPDXRef-Package-ee090ad491ba86cf",
       "versionInfo": "2.0.0",
@@ -10307,6 +11225,23 @@
           "referenceCategory": "PACKAGE-MANAGER",
           "referenceType": "purl",
           "referenceLocator": "pkg:npm/node-pty@1.1.0"
+        }
+      ]
+    },
+    {
+      "name": "normalize-path",
+      "SPDXID": "SPDXRef-Package-e6a9afc20b6a5b4f",
+      "versionInfo": "3.0.0",
+      "downloadLocation": "https://github.com/jonschlinkert/normalize-path",
+      "filesAnalyzed": false,
+      "licenseConcluded": "MIT",
+      "licenseDeclared": "MIT",
+      "copyrightText": "NOASSERTION",
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceType": "purl",
+          "referenceLocator": "pkg:npm/normalize-path@3.0.0"
         }
       ]
     },
@@ -10668,6 +11603,23 @@
       ]
     },
     {
+      "name": "path-is-absolute",
+      "SPDXID": "SPDXRef-Package-79f253dbdc64eb00",
+      "versionInfo": "1.0.1",
+      "downloadLocation": "https://github.com/sindresorhus/path-is-absolute",
+      "filesAnalyzed": false,
+      "licenseConcluded": "MIT",
+      "licenseDeclared": "MIT",
+      "copyrightText": "NOASSERTION",
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceType": "purl",
+          "referenceLocator": "pkg:npm/path-is-absolute@1.0.1"
+        }
+      ]
+    },
+    {
       "name": "path-key",
       "SPDXID": "SPDXRef-Package-fdd7a87411d74d56",
       "versionInfo": "3.1.1",
@@ -10851,6 +11803,23 @@
           "referenceCategory": "PACKAGE-MANAGER",
           "referenceType": "purl",
           "referenceLocator": "pkg:npm/points-on-path@0.2.1"
+        }
+      ]
+    },
+    {
+      "name": "pptxgenjs",
+      "SPDXID": "SPDXRef-Package-8406d74ee701100f",
+      "versionInfo": "4.0.1",
+      "downloadLocation": "https://github.com/gitbrent/PptxGenJS",
+      "filesAnalyzed": false,
+      "licenseConcluded": "MIT",
+      "licenseDeclared": "MIT",
+      "copyrightText": "NOASSERTION",
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceType": "purl",
+          "referenceLocator": "pkg:npm/pptxgenjs@4.0.1"
         }
       ]
     },
@@ -11263,6 +12232,23 @@
       ]
     },
     {
+      "name": "queue",
+      "SPDXID": "SPDXRef-Package-c8b1e190ece36b5b",
+      "versionInfo": "6.0.2",
+      "downloadLocation": "https://github.com/jessetane/queue",
+      "filesAnalyzed": false,
+      "licenseConcluded": "MIT",
+      "licenseDeclared": "MIT",
+      "copyrightText": "NOASSERTION",
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceType": "purl",
+          "referenceLocator": "pkg:npm/queue@6.0.2"
+        }
+      ]
+    },
+    {
       "name": "range-parser",
       "SPDXID": "SPDXRef-Package-c99f309bb22fcd34",
       "versionInfo": "1.3.0",
@@ -11501,6 +12487,23 @@
       ]
     },
     {
+      "name": "readdir-glob",
+      "SPDXID": "SPDXRef-Package-8c907a9e46ec42ff",
+      "versionInfo": "1.1.3",
+      "downloadLocation": "https://github.com/Yqnn/node-readdir-glob",
+      "filesAnalyzed": false,
+      "licenseConcluded": "Apache-2.0",
+      "licenseDeclared": "Apache-2.0",
+      "copyrightText": "NOASSERTION",
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceType": "purl",
+          "referenceLocator": "pkg:npm/readdir-glob@1.1.3"
+        }
+      ]
+    },
+    {
       "name": "rehype-highlight",
       "SPDXID": "SPDXRef-Package-046eb40b35cfc8f2",
       "versionInfo": "7.0.2",
@@ -11706,6 +12709,23 @@
     },
     {
       "name": "rimraf",
+      "SPDXID": "SPDXRef-Package-1b50db6d94db0196",
+      "versionInfo": "2.6.3",
+      "downloadLocation": "https://github.com/isaacs/rimraf",
+      "filesAnalyzed": false,
+      "licenseConcluded": "ISC",
+      "licenseDeclared": "ISC",
+      "copyrightText": "NOASSERTION",
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceType": "purl",
+          "referenceLocator": "pkg:npm/rimraf@2.6.3"
+        }
+      ]
+    },
+    {
+      "name": "rimraf",
       "SPDXID": "SPDXRef-Package-7fd5189f1498eda2",
       "versionInfo": "5.0.10",
       "downloadLocation": "https://github.com/isaacs/rimraf",
@@ -11854,6 +12874,40 @@
           "referenceCategory": "PACKAGE-MANAGER",
           "referenceType": "purl",
           "referenceLocator": "pkg:npm/safer-buffer@2.1.2"
+        }
+      ]
+    },
+    {
+      "name": "sax",
+      "SPDXID": "SPDXRef-Package-6d51ff5f61437558",
+      "versionInfo": "1.6.0",
+      "downloadLocation": "https://github.com/isaacs/sax-js",
+      "filesAnalyzed": false,
+      "licenseConcluded": "BlueOak-1.0.0",
+      "licenseDeclared": "BlueOak-1.0.0",
+      "copyrightText": "NOASSERTION",
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceType": "purl",
+          "referenceLocator": "pkg:npm/sax@1.6.0"
+        }
+      ]
+    },
+    {
+      "name": "saxes",
+      "SPDXID": "SPDXRef-Package-95cdee6f7d557d13",
+      "versionInfo": "5.0.1",
+      "downloadLocation": "https://github.com/lddubeau/saxes",
+      "filesAnalyzed": false,
+      "licenseConcluded": "ISC",
+      "licenseDeclared": "ISC",
+      "copyrightText": "NOASSERTION",
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceType": "purl",
+          "referenceLocator": "pkg:npm/saxes@5.0.1"
         }
       ]
     },
@@ -12708,6 +13762,23 @@
       ]
     },
     {
+      "name": "tmp",
+      "SPDXID": "SPDXRef-Package-b335f2d01d3ed9cf",
+      "versionInfo": "0.2.7",
+      "downloadLocation": "https://github.com/raszi/node-tmp",
+      "filesAnalyzed": false,
+      "licenseConcluded": "MIT",
+      "licenseDeclared": "MIT",
+      "copyrightText": "NOASSERTION",
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceType": "purl",
+          "referenceLocator": "pkg:npm/tmp@0.2.7"
+        }
+      ]
+    },
+    {
       "name": "toidentifier",
       "SPDXID": "SPDXRef-Package-c834291cf2535d86",
       "versionInfo": "1.0.1",
@@ -12721,6 +13792,23 @@
           "referenceCategory": "PACKAGE-MANAGER",
           "referenceType": "purl",
           "referenceLocator": "pkg:npm/toidentifier@1.0.1"
+        }
+      ]
+    },
+    {
+      "name": "traverse",
+      "SPDXID": "SPDXRef-Package-a141076283aa9950",
+      "versionInfo": "0.3.9",
+      "downloadLocation": "http://github.com/substack/js-traverse",
+      "filesAnalyzed": false,
+      "licenseConcluded": "MIT",
+      "licenseDeclared": "MIT",
+      "copyrightText": "NOASSERTION",
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceType": "purl",
+          "referenceLocator": "pkg:npm/traverse@0.3.9"
         }
       ]
     },
@@ -12964,6 +14052,23 @@
     },
     {
       "name": "undici-types",
+      "SPDXID": "SPDXRef-Package-a3e23d7a1173dbbf",
+      "versionInfo": "6.21.0",
+      "downloadLocation": "https://github.com/nodejs/undici",
+      "filesAnalyzed": false,
+      "licenseConcluded": "MIT",
+      "licenseDeclared": "MIT",
+      "copyrightText": "NOASSERTION",
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceType": "purl",
+          "referenceLocator": "pkg:npm/undici-types@6.21.0"
+        }
+      ]
+    },
+    {
+      "name": "undici-types",
       "SPDXID": "SPDXRef-Package-a85d345236e133c0",
       "versionInfo": "7.24.6",
       "downloadLocation": "https://github.com/nodejs/undici",
@@ -13150,6 +14255,23 @@
       ]
     },
     {
+      "name": "unzipper",
+      "SPDXID": "SPDXRef-Package-0691de763eddddc8",
+      "versionInfo": "0.10.14",
+      "downloadLocation": "https://github.com/ZJONSSON/node-unzipper",
+      "filesAnalyzed": false,
+      "licenseConcluded": "MIT",
+      "licenseDeclared": "MIT",
+      "copyrightText": "NOASSERTION",
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceType": "purl",
+          "referenceLocator": "pkg:npm/unzipper@0.10.14"
+        }
+      ]
+    },
+    {
       "name": "uri-js",
       "SPDXID": "SPDXRef-Package-86b9d1cd1856870a",
       "versionInfo": "4.4.1",
@@ -13265,6 +14387,23 @@
           "referenceCategory": "PACKAGE-MANAGER",
           "referenceType": "purl",
           "referenceLocator": "pkg:npm/uuid@14.0.1"
+        }
+      ]
+    },
+    {
+      "name": "uuid",
+      "SPDXID": "SPDXRef-Package-781eb11958365689",
+      "versionInfo": "8.3.2",
+      "downloadLocation": "https://github.com/uuidjs/uuid",
+      "filesAnalyzed": false,
+      "licenseConcluded": "MIT",
+      "licenseDeclared": "MIT",
+      "copyrightText": "NOASSERTION",
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceType": "purl",
+          "referenceLocator": "pkg:npm/uuid@8.3.2"
         }
       ]
     },
@@ -13541,6 +14680,57 @@
       ]
     },
     {
+      "name": "xml",
+      "SPDXID": "SPDXRef-Package-952c31231ba66670",
+      "versionInfo": "1.0.1",
+      "downloadLocation": "http://github.com/dylang/node-xml",
+      "filesAnalyzed": false,
+      "licenseConcluded": "MIT",
+      "licenseDeclared": "MIT",
+      "copyrightText": "NOASSERTION",
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceType": "purl",
+          "referenceLocator": "pkg:npm/xml@1.0.1"
+        }
+      ]
+    },
+    {
+      "name": "xml-js",
+      "SPDXID": "SPDXRef-Package-db9ebd25cef24c8f",
+      "versionInfo": "1.6.11",
+      "downloadLocation": "https://github.com/nashwaan/xml-js",
+      "filesAnalyzed": false,
+      "licenseConcluded": "MIT",
+      "licenseDeclared": "MIT",
+      "copyrightText": "NOASSERTION",
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceType": "purl",
+          "referenceLocator": "pkg:npm/xml-js@1.6.11"
+        }
+      ]
+    },
+    {
+      "name": "xmlchars",
+      "SPDXID": "SPDXRef-Package-bd49bc058ac56fd1",
+      "versionInfo": "2.2.0",
+      "downloadLocation": "https://github.com/lddubeau/xmlchars",
+      "filesAnalyzed": false,
+      "licenseConcluded": "MIT",
+      "licenseDeclared": "MIT",
+      "copyrightText": "NOASSERTION",
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceType": "purl",
+          "referenceLocator": "pkg:npm/xmlchars@2.2.0"
+        }
+      ]
+    },
+    {
       "name": "y18n",
       "SPDXID": "SPDXRef-Package-8e532c67f7b65656",
       "versionInfo": "4.0.3",
@@ -13605,6 +14795,23 @@
           "referenceCategory": "PACKAGE-MANAGER",
           "referenceType": "purl",
           "referenceLocator": "pkg:npm/yargs-parser@18.1.3"
+        }
+      ]
+    },
+    {
+      "name": "zip-stream",
+      "SPDXID": "SPDXRef-Package-83f742740c720c8e",
+      "versionInfo": "4.1.1",
+      "downloadLocation": "https://github.com/archiverjs/node-zip-stream",
+      "filesAnalyzed": false,
+      "licenseConcluded": "MIT",
+      "licenseDeclared": "MIT",
+      "copyrightText": "NOASSERTION",
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceType": "purl",
+          "referenceLocator": "pkg:npm/zip-stream@4.1.1"
         }
       ]
     },
@@ -13709,7 +14916,7 @@
     {
       "spdxElementId": "SPDXRef-DOCUMENT",
       "relationshipType": "DESCRIBES",
-      "relatedSpdxElement": "SPDXRef-Package-04c1add3e48a9e5c"
+      "relatedSpdxElement": "SPDXRef-Package-a3cbdbce86e6fdc7"
     },
     {
       "spdxElementId": "SPDXRef-DOCUMENT",
@@ -13749,7 +14956,27 @@
     {
       "spdxElementId": "SPDXRef-DOCUMENT",
       "relationshipType": "DESCRIBES",
+      "relatedSpdxElement": "SPDXRef-Package-2d6a4b723df29496"
+    },
+    {
+      "spdxElementId": "SPDXRef-DOCUMENT",
+      "relationshipType": "DESCRIBES",
+      "relatedSpdxElement": "SPDXRef-Package-d10d1f341d4abfa8"
+    },
+    {
+      "spdxElementId": "SPDXRef-DOCUMENT",
+      "relationshipType": "DESCRIBES",
+      "relatedSpdxElement": "SPDXRef-Package-bae6a338f33d9a1c"
+    },
+    {
+      "spdxElementId": "SPDXRef-DOCUMENT",
+      "relationshipType": "DESCRIBES",
       "relatedSpdxElement": "SPDXRef-Package-edf04d45834b4fbf"
+    },
+    {
+      "spdxElementId": "SPDXRef-DOCUMENT",
+      "relationshipType": "DESCRIBES",
+      "relatedSpdxElement": "SPDXRef-Package-3adbc0856a9bda85"
     },
     {
       "spdxElementId": "SPDXRef-DOCUMENT",
@@ -13910,6 +15137,16 @@
       "spdxElementId": "SPDXRef-DOCUMENT",
       "relationshipType": "DESCRIBES",
       "relatedSpdxElement": "SPDXRef-Package-53aca7cadbe88e59"
+    },
+    {
+      "spdxElementId": "SPDXRef-DOCUMENT",
+      "relationshipType": "DESCRIBES",
+      "relatedSpdxElement": "SPDXRef-Package-ef09030156acbe49"
+    },
+    {
+      "spdxElementId": "SPDXRef-DOCUMENT",
+      "relationshipType": "DESCRIBES",
+      "relatedSpdxElement": "SPDXRef-Package-f4baae4686e02f0a"
     },
     {
       "spdxElementId": "SPDXRef-DOCUMENT",
@@ -14724,6 +15961,16 @@
     {
       "spdxElementId": "SPDXRef-DOCUMENT",
       "relationshipType": "DESCRIBES",
+      "relatedSpdxElement": "SPDXRef-Package-c6b0b3ef4062e7b5"
+    },
+    {
+      "spdxElementId": "SPDXRef-DOCUMENT",
+      "relationshipType": "DESCRIBES",
+      "relatedSpdxElement": "SPDXRef-Package-006d2bce93d8f1dd"
+    },
+    {
+      "spdxElementId": "SPDXRef-DOCUMENT",
+      "relationshipType": "DESCRIBES",
       "relatedSpdxElement": "SPDXRef-Package-b02ebf6599a4715f"
     },
     {
@@ -14849,6 +16096,21 @@
     {
       "spdxElementId": "SPDXRef-DOCUMENT",
       "relationshipType": "DESCRIBES",
+      "relatedSpdxElement": "SPDXRef-Package-9135483032251fea"
+    },
+    {
+      "spdxElementId": "SPDXRef-DOCUMENT",
+      "relationshipType": "DESCRIBES",
+      "relatedSpdxElement": "SPDXRef-Package-e4af001b994a14f4"
+    },
+    {
+      "spdxElementId": "SPDXRef-DOCUMENT",
+      "relationshipType": "DESCRIBES",
+      "relatedSpdxElement": "SPDXRef-Package-f7b326a32927cbed"
+    },
+    {
+      "spdxElementId": "SPDXRef-DOCUMENT",
+      "relationshipType": "DESCRIBES",
       "relatedSpdxElement": "SPDXRef-Package-1b8ff3f05bffff87"
     },
     {
@@ -14865,6 +16127,11 @@
       "spdxElementId": "SPDXRef-DOCUMENT",
       "relationshipType": "DESCRIBES",
       "relatedSpdxElement": "SPDXRef-Package-11e344538943bbf2"
+    },
+    {
+      "spdxElementId": "SPDXRef-DOCUMENT",
+      "relationshipType": "DESCRIBES",
+      "relatedSpdxElement": "SPDXRef-Package-1faad319f76b179f"
     },
     {
       "spdxElementId": "SPDXRef-DOCUMENT",
@@ -14909,7 +16176,17 @@
     {
       "spdxElementId": "SPDXRef-DOCUMENT",
       "relationshipType": "DESCRIBES",
+      "relatedSpdxElement": "SPDXRef-Package-d4c964d5752fd254"
+    },
+    {
+      "spdxElementId": "SPDXRef-DOCUMENT",
+      "relationshipType": "DESCRIBES",
       "relatedSpdxElement": "SPDXRef-Package-e6bcaebbcb046dc4"
+    },
+    {
+      "spdxElementId": "SPDXRef-DOCUMENT",
+      "relationshipType": "DESCRIBES",
+      "relatedSpdxElement": "SPDXRef-Package-169094cbdc1389db"
     },
     {
       "spdxElementId": "SPDXRef-DOCUMENT",
@@ -14924,7 +16201,17 @@
     {
       "spdxElementId": "SPDXRef-DOCUMENT",
       "relationshipType": "DESCRIBES",
+      "relatedSpdxElement": "SPDXRef-Package-281d2b6b5950a4ba"
+    },
+    {
+      "spdxElementId": "SPDXRef-DOCUMENT",
+      "relationshipType": "DESCRIBES",
       "relatedSpdxElement": "SPDXRef-Package-603bfb1d8a6cd096"
+    },
+    {
+      "spdxElementId": "SPDXRef-DOCUMENT",
+      "relationshipType": "DESCRIBES",
+      "relatedSpdxElement": "SPDXRef-Package-3a4b46a93421a532"
     },
     {
       "spdxElementId": "SPDXRef-DOCUMENT",
@@ -14939,7 +16226,22 @@
     {
       "spdxElementId": "SPDXRef-DOCUMENT",
       "relationshipType": "DESCRIBES",
+      "relatedSpdxElement": "SPDXRef-Package-3f07b92fa45ba611"
+    },
+    {
+      "spdxElementId": "SPDXRef-DOCUMENT",
+      "relationshipType": "DESCRIBES",
       "relatedSpdxElement": "SPDXRef-Package-2f4ce0cccb4ed6f4"
+    },
+    {
+      "spdxElementId": "SPDXRef-DOCUMENT",
+      "relationshipType": "DESCRIBES",
+      "relatedSpdxElement": "SPDXRef-Package-62eb5a03ebf03674"
+    },
+    {
+      "spdxElementId": "SPDXRef-DOCUMENT",
+      "relationshipType": "DESCRIBES",
+      "relatedSpdxElement": "SPDXRef-Package-8e3f307fa2ee1e16"
     },
     {
       "spdxElementId": "SPDXRef-DOCUMENT",
@@ -14975,6 +16277,11 @@
       "spdxElementId": "SPDXRef-DOCUMENT",
       "relationshipType": "DESCRIBES",
       "relatedSpdxElement": "SPDXRef-Package-8454f0e154fad702"
+    },
+    {
+      "spdxElementId": "SPDXRef-DOCUMENT",
+      "relationshipType": "DESCRIBES",
+      "relatedSpdxElement": "SPDXRef-Package-b114758f8c10a13e"
     },
     {
       "spdxElementId": "SPDXRef-DOCUMENT",
@@ -15059,6 +16366,16 @@
     {
       "spdxElementId": "SPDXRef-DOCUMENT",
       "relationshipType": "DESCRIBES",
+      "relatedSpdxElement": "SPDXRef-Package-e77e224d03910af4"
+    },
+    {
+      "spdxElementId": "SPDXRef-DOCUMENT",
+      "relationshipType": "DESCRIBES",
+      "relatedSpdxElement": "SPDXRef-Package-446fb7e0d413f4e8"
+    },
+    {
+      "spdxElementId": "SPDXRef-DOCUMENT",
+      "relationshipType": "DESCRIBES",
       "relatedSpdxElement": "SPDXRef-Package-4b508a608e7c9c35"
     },
     {
@@ -15115,6 +16432,16 @@
       "spdxElementId": "SPDXRef-DOCUMENT",
       "relationshipType": "DESCRIBES",
       "relatedSpdxElement": "SPDXRef-Package-b6c9c76e33815fb2"
+    },
+    {
+      "spdxElementId": "SPDXRef-DOCUMENT",
+      "relationshipType": "DESCRIBES",
+      "relatedSpdxElement": "SPDXRef-Package-7b769d3a0b61c741"
+    },
+    {
+      "spdxElementId": "SPDXRef-DOCUMENT",
+      "relationshipType": "DESCRIBES",
+      "relatedSpdxElement": "SPDXRef-Package-3bd6e89d41e1b16e"
     },
     {
       "spdxElementId": "SPDXRef-DOCUMENT",
@@ -15439,6 +16766,11 @@
     {
       "spdxElementId": "SPDXRef-DOCUMENT",
       "relationshipType": "DESCRIBES",
+      "relatedSpdxElement": "SPDXRef-Package-5fcae62518b2d23a"
+    },
+    {
+      "spdxElementId": "SPDXRef-DOCUMENT",
+      "relationshipType": "DESCRIBES",
       "relatedSpdxElement": "SPDXRef-Package-fe4205b186c43bb8"
     },
     {
@@ -15455,6 +16787,11 @@
       "spdxElementId": "SPDXRef-DOCUMENT",
       "relationshipType": "DESCRIBES",
       "relatedSpdxElement": "SPDXRef-Package-591da600a357596a"
+    },
+    {
+      "spdxElementId": "SPDXRef-DOCUMENT",
+      "relationshipType": "DESCRIBES",
+      "relatedSpdxElement": "SPDXRef-Package-5203e1981b9684d9"
     },
     {
       "spdxElementId": "SPDXRef-DOCUMENT",
@@ -15584,6 +16921,11 @@
     {
       "spdxElementId": "SPDXRef-DOCUMENT",
       "relationshipType": "DESCRIBES",
+      "relatedSpdxElement": "SPDXRef-Package-a037ed657533f4f1"
+    },
+    {
+      "spdxElementId": "SPDXRef-DOCUMENT",
+      "relationshipType": "DESCRIBES",
       "relatedSpdxElement": "SPDXRef-Package-95a792ac9cb6ef2b"
     },
     {
@@ -15615,6 +16957,11 @@
       "spdxElementId": "SPDXRef-DOCUMENT",
       "relationshipType": "DESCRIBES",
       "relatedSpdxElement": "SPDXRef-Package-89a61fe97490415f"
+    },
+    {
+      "spdxElementId": "SPDXRef-DOCUMENT",
+      "relationshipType": "DESCRIBES",
+      "relatedSpdxElement": "SPDXRef-Package-c7b893d84403ff14"
     },
     {
       "spdxElementId": "SPDXRef-DOCUMENT",
@@ -15704,6 +17051,16 @@
     {
       "spdxElementId": "SPDXRef-DOCUMENT",
       "relationshipType": "DESCRIBES",
+      "relatedSpdxElement": "SPDXRef-Package-066c98d78f779398"
+    },
+    {
+      "spdxElementId": "SPDXRef-DOCUMENT",
+      "relationshipType": "DESCRIBES",
+      "relatedSpdxElement": "SPDXRef-Package-8c228885d01e65b0"
+    },
+    {
+      "spdxElementId": "SPDXRef-DOCUMENT",
+      "relationshipType": "DESCRIBES",
       "relatedSpdxElement": "SPDXRef-Package-efff64b24eff87e8"
     },
     {
@@ -15779,6 +17136,11 @@
     {
       "spdxElementId": "SPDXRef-DOCUMENT",
       "relationshipType": "DESCRIBES",
+      "relatedSpdxElement": "SPDXRef-Package-8702ad5f91114f8f"
+    },
+    {
+      "spdxElementId": "SPDXRef-DOCUMENT",
+      "relationshipType": "DESCRIBES",
       "relatedSpdxElement": "SPDXRef-Package-ca014b881c253ebc"
     },
     {
@@ -15835,6 +17197,11 @@
       "spdxElementId": "SPDXRef-DOCUMENT",
       "relationshipType": "DESCRIBES",
       "relatedSpdxElement": "SPDXRef-Package-f1710245eb206d86"
+    },
+    {
+      "spdxElementId": "SPDXRef-DOCUMENT",
+      "relationshipType": "DESCRIBES",
+      "relatedSpdxElement": "SPDXRef-Package-0fe3a8dd2852340e"
     },
     {
       "spdxElementId": "SPDXRef-DOCUMENT",
@@ -15934,6 +17301,11 @@
     {
       "spdxElementId": "SPDXRef-DOCUMENT",
       "relationshipType": "DESCRIBES",
+      "relatedSpdxElement": "SPDXRef-Package-a6138fed56d8e05e"
+    },
+    {
+      "spdxElementId": "SPDXRef-DOCUMENT",
+      "relationshipType": "DESCRIBES",
       "relatedSpdxElement": "SPDXRef-Package-ca16958c815c8380"
     },
     {
@@ -15979,12 +17351,22 @@
     {
       "spdxElementId": "SPDXRef-DOCUMENT",
       "relationshipType": "DESCRIBES",
+      "relatedSpdxElement": "SPDXRef-Package-41bbec0dae5bac67"
+    },
+    {
+      "spdxElementId": "SPDXRef-DOCUMENT",
+      "relationshipType": "DESCRIBES",
       "relatedSpdxElement": "SPDXRef-Package-1bf8b3e308414474"
     },
     {
       "spdxElementId": "SPDXRef-DOCUMENT",
       "relationshipType": "DESCRIBES",
       "relatedSpdxElement": "SPDXRef-Package-0ed4bf4ae6371945"
+    },
+    {
+      "spdxElementId": "SPDXRef-DOCUMENT",
+      "relationshipType": "DESCRIBES",
+      "relatedSpdxElement": "SPDXRef-Package-93b34ac704832584"
     },
     {
       "spdxElementId": "SPDXRef-DOCUMENT",
@@ -16214,12 +17596,22 @@
     {
       "spdxElementId": "SPDXRef-DOCUMENT",
       "relationshipType": "DESCRIBES",
+      "relatedSpdxElement": "SPDXRef-Package-85cab3d3fea075b9"
+    },
+    {
+      "spdxElementId": "SPDXRef-DOCUMENT",
+      "relationshipType": "DESCRIBES",
       "relatedSpdxElement": "SPDXRef-Package-dc65c95b58f6df34"
     },
     {
       "spdxElementId": "SPDXRef-DOCUMENT",
       "relationshipType": "DESCRIBES",
       "relatedSpdxElement": "SPDXRef-Package-aaecb0d5f9d49a47"
+    },
+    {
+      "spdxElementId": "SPDXRef-DOCUMENT",
+      "relationshipType": "DESCRIBES",
+      "relatedSpdxElement": "SPDXRef-Package-a12a1c81551b29a0"
     },
     {
       "spdxElementId": "SPDXRef-DOCUMENT",
@@ -16259,7 +17651,62 @@
     {
       "spdxElementId": "SPDXRef-DOCUMENT",
       "relationshipType": "DESCRIBES",
+      "relatedSpdxElement": "SPDXRef-Package-a3a0c53acb8c1dcc"
+    },
+    {
+      "spdxElementId": "SPDXRef-DOCUMENT",
+      "relationshipType": "DESCRIBES",
+      "relatedSpdxElement": "SPDXRef-Package-0264c095c57bc5cf"
+    },
+    {
+      "spdxElementId": "SPDXRef-DOCUMENT",
+      "relationshipType": "DESCRIBES",
+      "relatedSpdxElement": "SPDXRef-Package-de4b3a9e90ea9774"
+    },
+    {
+      "spdxElementId": "SPDXRef-DOCUMENT",
+      "relationshipType": "DESCRIBES",
+      "relatedSpdxElement": "SPDXRef-Package-0729f90dee660e49"
+    },
+    {
+      "spdxElementId": "SPDXRef-DOCUMENT",
+      "relationshipType": "DESCRIBES",
+      "relatedSpdxElement": "SPDXRef-Package-ff4c49b4828c9e19"
+    },
+    {
+      "spdxElementId": "SPDXRef-DOCUMENT",
+      "relationshipType": "DESCRIBES",
       "relatedSpdxElement": "SPDXRef-Package-a1ca8608b85fb076"
+    },
+    {
+      "spdxElementId": "SPDXRef-DOCUMENT",
+      "relationshipType": "DESCRIBES",
+      "relatedSpdxElement": "SPDXRef-Package-db45f10bd3ef5fb5"
+    },
+    {
+      "spdxElementId": "SPDXRef-DOCUMENT",
+      "relationshipType": "DESCRIBES",
+      "relatedSpdxElement": "SPDXRef-Package-4fbfd070c92eb053"
+    },
+    {
+      "spdxElementId": "SPDXRef-DOCUMENT",
+      "relationshipType": "DESCRIBES",
+      "relatedSpdxElement": "SPDXRef-Package-48d573eae5c4cd81"
+    },
+    {
+      "spdxElementId": "SPDXRef-DOCUMENT",
+      "relationshipType": "DESCRIBES",
+      "relatedSpdxElement": "SPDXRef-Package-45270f7cf55ec688"
+    },
+    {
+      "spdxElementId": "SPDXRef-DOCUMENT",
+      "relationshipType": "DESCRIBES",
+      "relatedSpdxElement": "SPDXRef-Package-715a4dee5083b138"
+    },
+    {
+      "spdxElementId": "SPDXRef-DOCUMENT",
+      "relationshipType": "DESCRIBES",
+      "relatedSpdxElement": "SPDXRef-Package-395eddedb8745a8f"
     },
     {
       "spdxElementId": "SPDXRef-DOCUMENT",
@@ -16275,6 +17722,16 @@
       "spdxElementId": "SPDXRef-DOCUMENT",
       "relationshipType": "DESCRIBES",
       "relatedSpdxElement": "SPDXRef-Package-a6e12dc74e4896ce"
+    },
+    {
+      "spdxElementId": "SPDXRef-DOCUMENT",
+      "relationshipType": "DESCRIBES",
+      "relatedSpdxElement": "SPDXRef-Package-57a1e9a5e166604b"
+    },
+    {
+      "spdxElementId": "SPDXRef-DOCUMENT",
+      "relationshipType": "DESCRIBES",
+      "relatedSpdxElement": "SPDXRef-Package-ce721e649dfb1e5c"
     },
     {
       "spdxElementId": "SPDXRef-DOCUMENT",
@@ -16634,6 +18091,21 @@
     {
       "spdxElementId": "SPDXRef-DOCUMENT",
       "relationshipType": "DESCRIBES",
+      "relatedSpdxElement": "SPDXRef-Package-588f964b04a1a148"
+    },
+    {
+      "spdxElementId": "SPDXRef-DOCUMENT",
+      "relationshipType": "DESCRIBES",
+      "relatedSpdxElement": "SPDXRef-Package-40d05b19a4e7d885"
+    },
+    {
+      "spdxElementId": "SPDXRef-DOCUMENT",
+      "relationshipType": "DESCRIBES",
+      "relatedSpdxElement": "SPDXRef-Package-9b652aa8c82e5af7"
+    },
+    {
+      "spdxElementId": "SPDXRef-DOCUMENT",
+      "relationshipType": "DESCRIBES",
       "relatedSpdxElement": "SPDXRef-Package-9a47e0282c0c109e"
     },
     {
@@ -16684,6 +18156,11 @@
     {
       "spdxElementId": "SPDXRef-DOCUMENT",
       "relationshipType": "DESCRIBES",
+      "relatedSpdxElement": "SPDXRef-Package-351e1526e0c140ae"
+    },
+    {
+      "spdxElementId": "SPDXRef-DOCUMENT",
+      "relationshipType": "DESCRIBES",
       "relatedSpdxElement": "SPDXRef-Package-ee090ad491ba86cf"
     },
     {
@@ -16720,6 +18197,11 @@
       "spdxElementId": "SPDXRef-DOCUMENT",
       "relationshipType": "DESCRIBES",
       "relatedSpdxElement": "SPDXRef-Package-4a60f58708d5b311"
+    },
+    {
+      "spdxElementId": "SPDXRef-DOCUMENT",
+      "relationshipType": "DESCRIBES",
+      "relatedSpdxElement": "SPDXRef-Package-e6a9afc20b6a5b4f"
     },
     {
       "spdxElementId": "SPDXRef-DOCUMENT",
@@ -16829,6 +18311,11 @@
     {
       "spdxElementId": "SPDXRef-DOCUMENT",
       "relationshipType": "DESCRIBES",
+      "relatedSpdxElement": "SPDXRef-Package-79f253dbdc64eb00"
+    },
+    {
+      "spdxElementId": "SPDXRef-DOCUMENT",
+      "relationshipType": "DESCRIBES",
       "relatedSpdxElement": "SPDXRef-Package-fdd7a87411d74d56"
     },
     {
@@ -16880,6 +18367,11 @@
       "spdxElementId": "SPDXRef-DOCUMENT",
       "relationshipType": "DESCRIBES",
       "relatedSpdxElement": "SPDXRef-Package-357a328a448d93cd"
+    },
+    {
+      "spdxElementId": "SPDXRef-DOCUMENT",
+      "relationshipType": "DESCRIBES",
+      "relatedSpdxElement": "SPDXRef-Package-8406d74ee701100f"
     },
     {
       "spdxElementId": "SPDXRef-DOCUMENT",
@@ -17004,6 +18496,11 @@
     {
       "spdxElementId": "SPDXRef-DOCUMENT",
       "relationshipType": "DESCRIBES",
+      "relatedSpdxElement": "SPDXRef-Package-c8b1e190ece36b5b"
+    },
+    {
+      "spdxElementId": "SPDXRef-DOCUMENT",
+      "relationshipType": "DESCRIBES",
       "relatedSpdxElement": "SPDXRef-Package-c99f309bb22fcd34"
     },
     {
@@ -17074,6 +18571,11 @@
     {
       "spdxElementId": "SPDXRef-DOCUMENT",
       "relationshipType": "DESCRIBES",
+      "relatedSpdxElement": "SPDXRef-Package-8c907a9e46ec42ff"
+    },
+    {
+      "spdxElementId": "SPDXRef-DOCUMENT",
+      "relationshipType": "DESCRIBES",
       "relatedSpdxElement": "SPDXRef-Package-046eb40b35cfc8f2"
     },
     {
@@ -17134,6 +18636,11 @@
     {
       "spdxElementId": "SPDXRef-DOCUMENT",
       "relationshipType": "DESCRIBES",
+      "relatedSpdxElement": "SPDXRef-Package-1b50db6d94db0196"
+    },
+    {
+      "spdxElementId": "SPDXRef-DOCUMENT",
+      "relationshipType": "DESCRIBES",
       "relatedSpdxElement": "SPDXRef-Package-7fd5189f1498eda2"
     },
     {
@@ -17175,6 +18682,16 @@
       "spdxElementId": "SPDXRef-DOCUMENT",
       "relationshipType": "DESCRIBES",
       "relatedSpdxElement": "SPDXRef-Package-5941030fc7f193de"
+    },
+    {
+      "spdxElementId": "SPDXRef-DOCUMENT",
+      "relationshipType": "DESCRIBES",
+      "relatedSpdxElement": "SPDXRef-Package-6d51ff5f61437558"
+    },
+    {
+      "spdxElementId": "SPDXRef-DOCUMENT",
+      "relationshipType": "DESCRIBES",
+      "relatedSpdxElement": "SPDXRef-Package-95cdee6f7d557d13"
     },
     {
       "spdxElementId": "SPDXRef-DOCUMENT",
@@ -17429,7 +18946,17 @@
     {
       "spdxElementId": "SPDXRef-DOCUMENT",
       "relationshipType": "DESCRIBES",
+      "relatedSpdxElement": "SPDXRef-Package-b335f2d01d3ed9cf"
+    },
+    {
+      "spdxElementId": "SPDXRef-DOCUMENT",
+      "relationshipType": "DESCRIBES",
       "relatedSpdxElement": "SPDXRef-Package-c834291cf2535d86"
+    },
+    {
+      "spdxElementId": "SPDXRef-DOCUMENT",
+      "relationshipType": "DESCRIBES",
+      "relatedSpdxElement": "SPDXRef-Package-a141076283aa9950"
     },
     {
       "spdxElementId": "SPDXRef-DOCUMENT",
@@ -17504,6 +19031,11 @@
     {
       "spdxElementId": "SPDXRef-DOCUMENT",
       "relationshipType": "DESCRIBES",
+      "relatedSpdxElement": "SPDXRef-Package-a3e23d7a1173dbbf"
+    },
+    {
+      "spdxElementId": "SPDXRef-DOCUMENT",
+      "relationshipType": "DESCRIBES",
       "relatedSpdxElement": "SPDXRef-Package-a85d345236e133c0"
     },
     {
@@ -17559,6 +19091,11 @@
     {
       "spdxElementId": "SPDXRef-DOCUMENT",
       "relationshipType": "DESCRIBES",
+      "relatedSpdxElement": "SPDXRef-Package-0691de763eddddc8"
+    },
+    {
+      "spdxElementId": "SPDXRef-DOCUMENT",
+      "relationshipType": "DESCRIBES",
       "relatedSpdxElement": "SPDXRef-Package-86b9d1cd1856870a"
     },
     {
@@ -17590,6 +19127,11 @@
       "spdxElementId": "SPDXRef-DOCUMENT",
       "relationshipType": "DESCRIBES",
       "relatedSpdxElement": "SPDXRef-Package-0ba81ad163d7682e"
+    },
+    {
+      "spdxElementId": "SPDXRef-DOCUMENT",
+      "relationshipType": "DESCRIBES",
+      "relatedSpdxElement": "SPDXRef-Package-781eb11958365689"
     },
     {
       "spdxElementId": "SPDXRef-DOCUMENT",
@@ -17674,6 +19216,21 @@
     {
       "spdxElementId": "SPDXRef-DOCUMENT",
       "relationshipType": "DESCRIBES",
+      "relatedSpdxElement": "SPDXRef-Package-952c31231ba66670"
+    },
+    {
+      "spdxElementId": "SPDXRef-DOCUMENT",
+      "relationshipType": "DESCRIBES",
+      "relatedSpdxElement": "SPDXRef-Package-db9ebd25cef24c8f"
+    },
+    {
+      "spdxElementId": "SPDXRef-DOCUMENT",
+      "relationshipType": "DESCRIBES",
+      "relatedSpdxElement": "SPDXRef-Package-bd49bc058ac56fd1"
+    },
+    {
+      "spdxElementId": "SPDXRef-DOCUMENT",
+      "relationshipType": "DESCRIBES",
       "relatedSpdxElement": "SPDXRef-Package-8e532c67f7b65656"
     },
     {
@@ -17690,6 +19247,11 @@
       "spdxElementId": "SPDXRef-DOCUMENT",
       "relationshipType": "DESCRIBES",
       "relatedSpdxElement": "SPDXRef-Package-0d53ff1f3e7f8816"
+    },
+    {
+      "spdxElementId": "SPDXRef-DOCUMENT",
+      "relationshipType": "DESCRIBES",
+      "relatedSpdxElement": "SPDXRef-Package-83f742740c720c8e"
     },
     {
       "spdxElementId": "SPDXRef-DOCUMENT",

--- a/docs/legal/notices/sbom/desktop-macos.spdx.json
+++ b/docs/legal/notices/sbom/desktop-macos.spdx.json
@@ -3,9 +3,9 @@
   "dataLicense": "CC0-1.0",
   "SPDXID": "SPDXRef-DOCUMENT",
   "name": "cindy-desktop-macos",
-  "documentNamespace": "https://cindy.app/spdx/desktop-macos/71046b3dc5cf9074da16a9c27fed04b8c046b20ddc8f62e4b43d8126c029ea09",
+  "documentNamespace": "https://cindy.app/spdx/desktop-macos/7a188fd38c636b249f8ca6c8e292a748e66535e389b72d172b7b74e1cbd3975e",
   "creationInfo": {
-    "created": "2026-08-14T10:29:27Z",
+    "created": "2026-09-02T19:21:04Z",
     "creators": [
       "Tool: scripts/generate-third-party-notices.mjs"
     ]
@@ -113,8 +113,8 @@
     },
     {
       "name": "pi coding agent (runtime-downloaded binary)",
-      "SPDXID": "SPDXRef-Package-04c1add3e48a9e5c",
-      "versionInfo": "0.83.0",
+      "SPDXID": "SPDXRef-Package-a3cbdbce86e6fdc7",
+      "versionInfo": "0.84.4",
       "downloadLocation": "https://github.com/earendil-works/pi",
       "filesAnalyzed": false,
       "licenseConcluded": "MIT",
@@ -206,6 +206,57 @@
       ]
     },
     {
+      "name": "@babel/helper-string-parser",
+      "SPDXID": "SPDXRef-Package-2d6a4b723df29496",
+      "versionInfo": "7.29.7",
+      "downloadLocation": "https://github.com/babel/babel",
+      "filesAnalyzed": false,
+      "licenseConcluded": "MIT",
+      "licenseDeclared": "MIT",
+      "copyrightText": "NOASSERTION",
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceType": "purl",
+          "referenceLocator": "pkg:npm/%40babel/helper-string-parser@7.29.7"
+        }
+      ]
+    },
+    {
+      "name": "@babel/helper-validator-identifier",
+      "SPDXID": "SPDXRef-Package-d10d1f341d4abfa8",
+      "versionInfo": "7.29.7",
+      "downloadLocation": "https://github.com/babel/babel",
+      "filesAnalyzed": false,
+      "licenseConcluded": "MIT",
+      "licenseDeclared": "MIT",
+      "copyrightText": "NOASSERTION",
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceType": "purl",
+          "referenceLocator": "pkg:npm/%40babel/helper-validator-identifier@7.29.7"
+        }
+      ]
+    },
+    {
+      "name": "@babel/parser",
+      "SPDXID": "SPDXRef-Package-bae6a338f33d9a1c",
+      "versionInfo": "7.29.7",
+      "downloadLocation": "https://github.com/babel/babel",
+      "filesAnalyzed": false,
+      "licenseConcluded": "MIT",
+      "licenseDeclared": "MIT",
+      "copyrightText": "NOASSERTION",
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceType": "purl",
+          "referenceLocator": "pkg:npm/%40babel/parser@7.29.7"
+        }
+      ]
+    },
+    {
       "name": "@babel/runtime",
       "SPDXID": "SPDXRef-Package-edf04d45834b4fbf",
       "versionInfo": "7.29.7",
@@ -219,6 +270,23 @@
           "referenceCategory": "PACKAGE-MANAGER",
           "referenceType": "purl",
           "referenceLocator": "pkg:npm/%40babel/runtime@7.29.7"
+        }
+      ]
+    },
+    {
+      "name": "@babel/types",
+      "SPDXID": "SPDXRef-Package-3adbc0856a9bda85",
+      "versionInfo": "7.29.7",
+      "downloadLocation": "https://github.com/babel/babel",
+      "filesAnalyzed": false,
+      "licenseConcluded": "MIT",
+      "licenseDeclared": "MIT",
+      "copyrightText": "NOASSERTION",
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceType": "purl",
+          "referenceLocator": "pkg:npm/%40babel/types@7.29.7"
         }
       ]
     },
@@ -763,6 +831,40 @@
           "referenceCategory": "PACKAGE-MANAGER",
           "referenceType": "purl",
           "referenceLocator": "pkg:npm/%40discordjs/ws@1.2.3"
+        }
+      ]
+    },
+    {
+      "name": "@fast-csv/format",
+      "SPDXID": "SPDXRef-Package-ef09030156acbe49",
+      "versionInfo": "4.3.5",
+      "downloadLocation": "https://github.com/C2FO/fast-csv",
+      "filesAnalyzed": false,
+      "licenseConcluded": "MIT",
+      "licenseDeclared": "MIT",
+      "copyrightText": "NOASSERTION",
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceType": "purl",
+          "referenceLocator": "pkg:npm/%40fast-csv/format@4.3.5"
+        }
+      ]
+    },
+    {
+      "name": "@fast-csv/parse",
+      "SPDXID": "SPDXRef-Package-f4baae4686e02f0a",
+      "versionInfo": "4.3.6",
+      "downloadLocation": "https://github.com/C2FO/fast-csv",
+      "filesAnalyzed": false,
+      "licenseConcluded": "MIT",
+      "licenseDeclared": "MIT",
+      "copyrightText": "NOASSERTION",
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceType": "purl",
+          "referenceLocator": "pkg:npm/%40fast-csv/parse@4.3.6"
         }
       ]
     },
@@ -3522,6 +3624,40 @@
     },
     {
       "name": "@types/node",
+      "SPDXID": "SPDXRef-Package-c6b0b3ef4062e7b5",
+      "versionInfo": "14.18.63",
+      "downloadLocation": "https://github.com/DefinitelyTyped/DefinitelyTyped",
+      "filesAnalyzed": false,
+      "licenseConcluded": "MIT",
+      "licenseDeclared": "MIT",
+      "copyrightText": "NOASSERTION",
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceType": "purl",
+          "referenceLocator": "pkg:npm/%40types/node@14.18.63"
+        }
+      ]
+    },
+    {
+      "name": "@types/node",
+      "SPDXID": "SPDXRef-Package-006d2bce93d8f1dd",
+      "versionInfo": "22.20.1",
+      "downloadLocation": "https://github.com/DefinitelyTyped/DefinitelyTyped",
+      "filesAnalyzed": false,
+      "licenseConcluded": "MIT",
+      "licenseDeclared": "MIT",
+      "copyrightText": "NOASSERTION",
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceType": "purl",
+          "referenceLocator": "pkg:npm/%40types/node@22.20.1"
+        }
+      ]
+    },
+    {
+      "name": "@types/node",
       "SPDXID": "SPDXRef-Package-b02ebf6599a4715f",
       "versionInfo": "25.9.5",
       "downloadLocation": "https://github.com/DefinitelyTyped/DefinitelyTyped",
@@ -3946,6 +4082,57 @@
       ]
     },
     {
+      "name": "archiver",
+      "SPDXID": "SPDXRef-Package-9135483032251fea",
+      "versionInfo": "5.3.2",
+      "downloadLocation": "https://github.com/archiverjs/node-archiver",
+      "filesAnalyzed": false,
+      "licenseConcluded": "MIT",
+      "licenseDeclared": "MIT",
+      "copyrightText": "NOASSERTION",
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceType": "purl",
+          "referenceLocator": "pkg:npm/archiver@5.3.2"
+        }
+      ]
+    },
+    {
+      "name": "archiver-utils",
+      "SPDXID": "SPDXRef-Package-e4af001b994a14f4",
+      "versionInfo": "2.1.0",
+      "downloadLocation": "https://github.com/archiverjs/archiver-utils",
+      "filesAnalyzed": false,
+      "licenseConcluded": "MIT",
+      "licenseDeclared": "MIT",
+      "copyrightText": "NOASSERTION",
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceType": "purl",
+          "referenceLocator": "pkg:npm/archiver-utils@2.1.0"
+        }
+      ]
+    },
+    {
+      "name": "archiver-utils",
+      "SPDXID": "SPDXRef-Package-f7b326a32927cbed",
+      "versionInfo": "3.0.4",
+      "downloadLocation": "https://github.com/archiverjs/archiver-utils",
+      "filesAnalyzed": false,
+      "licenseConcluded": "MIT",
+      "licenseDeclared": "MIT",
+      "copyrightText": "NOASSERTION",
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceType": "purl",
+          "referenceLocator": "pkg:npm/archiver-utils@3.0.4"
+        }
+      ]
+    },
+    {
       "name": "argparse",
       "SPDXID": "SPDXRef-Package-1b8ff3f05bffff87",
       "versionInfo": "1.0.10",
@@ -4010,6 +4197,23 @@
           "referenceCategory": "PACKAGE-MANAGER",
           "referenceType": "purl",
           "referenceLocator": "pkg:npm/asn1@0.2.6"
+        }
+      ]
+    },
+    {
+      "name": "async",
+      "SPDXID": "SPDXRef-Package-1faad319f76b179f",
+      "versionInfo": "3.2.6",
+      "downloadLocation": "https://github.com/caolan/async",
+      "filesAnalyzed": false,
+      "licenseConcluded": "MIT",
+      "licenseDeclared": "MIT",
+      "copyrightText": "NOASSERTION",
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceType": "purl",
+          "referenceLocator": "pkg:npm/async@3.2.6"
         }
       ]
     },
@@ -4150,6 +4354,23 @@
       ]
     },
     {
+      "name": "big-integer",
+      "SPDXID": "SPDXRef-Package-d4c964d5752fd254",
+      "versionInfo": "1.6.52",
+      "downloadLocation": "https://github.com/peterolson/BigInteger.js",
+      "filesAnalyzed": false,
+      "licenseConcluded": "Unlicense",
+      "licenseDeclared": "Unlicense",
+      "copyrightText": "NOASSERTION",
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceType": "purl",
+          "referenceLocator": "pkg:npm/big-integer@1.6.52"
+        }
+      ]
+    },
+    {
       "name": "bignumber.js",
       "SPDXID": "SPDXRef-Package-e6bcaebbcb046dc4",
       "versionInfo": "9.3.1",
@@ -4163,6 +4384,23 @@
           "referenceCategory": "PACKAGE-MANAGER",
           "referenceType": "purl",
           "referenceLocator": "pkg:npm/bignumber.js@9.3.1"
+        }
+      ]
+    },
+    {
+      "name": "binary",
+      "SPDXID": "SPDXRef-Package-169094cbdc1389db",
+      "versionInfo": "0.3.0",
+      "downloadLocation": "http://github.com/substack/node-binary",
+      "filesAnalyzed": false,
+      "licenseConcluded": "MIT",
+      "licenseDeclared": "MIT",
+      "copyrightText": "NOASSERTION",
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceType": "purl",
+          "referenceLocator": "pkg:npm/binary@0.3.0"
         }
       ]
     },
@@ -4201,6 +4439,23 @@
       ]
     },
     {
+      "name": "bluebird",
+      "SPDXID": "SPDXRef-Package-281d2b6b5950a4ba",
+      "versionInfo": "3.4.7",
+      "downloadLocation": "https://github.com/petkaantonov/bluebird",
+      "filesAnalyzed": false,
+      "licenseConcluded": "MIT",
+      "licenseDeclared": "MIT",
+      "copyrightText": "NOASSERTION",
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceType": "purl",
+          "referenceLocator": "pkg:npm/bluebird@3.4.7"
+        }
+      ]
+    },
+    {
       "name": "body-parser",
       "SPDXID": "SPDXRef-Package-603bfb1d8a6cd096",
       "versionInfo": "2.3.0",
@@ -4214,6 +4469,23 @@
           "referenceCategory": "PACKAGE-MANAGER",
           "referenceType": "purl",
           "referenceLocator": "pkg:npm/body-parser@2.3.0"
+        }
+      ]
+    },
+    {
+      "name": "brace-expansion",
+      "SPDXID": "SPDXRef-Package-3a4b46a93421a532",
+      "versionInfo": "1.1.16",
+      "downloadLocation": "https://github.com/juliangruber/brace-expansion",
+      "filesAnalyzed": false,
+      "licenseConcluded": "MIT",
+      "licenseDeclared": "MIT",
+      "copyrightText": "NOASSERTION",
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceType": "purl",
+          "referenceLocator": "pkg:npm/brace-expansion@1.1.16"
         }
       ]
     },
@@ -4252,6 +4524,23 @@
       ]
     },
     {
+      "name": "buffer-crc32",
+      "SPDXID": "SPDXRef-Package-3f07b92fa45ba611",
+      "versionInfo": "0.2.13",
+      "downloadLocation": "https://github.com/brianloveswords/buffer-crc32",
+      "filesAnalyzed": false,
+      "licenseConcluded": "MIT",
+      "licenseDeclared": "MIT",
+      "copyrightText": "NOASSERTION",
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceType": "purl",
+          "referenceLocator": "pkg:npm/buffer-crc32@0.2.13"
+        }
+      ]
+    },
+    {
       "name": "buffer-equal-constant-time",
       "SPDXID": "SPDXRef-Package-2f4ce0cccb4ed6f4",
       "versionInfo": "1.0.1",
@@ -4265,6 +4554,40 @@
           "referenceCategory": "PACKAGE-MANAGER",
           "referenceType": "purl",
           "referenceLocator": "pkg:npm/buffer-equal-constant-time@1.0.1"
+        }
+      ]
+    },
+    {
+      "name": "buffer-indexof-polyfill",
+      "SPDXID": "SPDXRef-Package-62eb5a03ebf03674",
+      "versionInfo": "1.0.2",
+      "downloadLocation": "https://github.com/sarosia/buffer-indexof-polyfill",
+      "filesAnalyzed": false,
+      "licenseConcluded": "MIT",
+      "licenseDeclared": "MIT",
+      "copyrightText": "NOASSERTION",
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceType": "purl",
+          "referenceLocator": "pkg:npm/buffer-indexof-polyfill@1.0.2"
+        }
+      ]
+    },
+    {
+      "name": "buffers",
+      "SPDXID": "SPDXRef-Package-8e3f307fa2ee1e16",
+      "versionInfo": "0.1.1",
+      "downloadLocation": "http://github.com/substack/node-buffers",
+      "filesAnalyzed": false,
+      "licenseConcluded": "MIT",
+      "licenseDeclared": "MIT",
+      "copyrightText": "NOASSERTION",
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceType": "purl",
+          "referenceLocator": "pkg:npm/buffers@0.1.1"
         }
       ]
     },
@@ -4384,6 +4707,23 @@
           "referenceCategory": "PACKAGE-MANAGER",
           "referenceType": "purl",
           "referenceLocator": "pkg:npm/ccount@2.0.1"
+        }
+      ]
+    },
+    {
+      "name": "chainsaw",
+      "SPDXID": "SPDXRef-Package-b114758f8c10a13e",
+      "versionInfo": "0.1.0",
+      "downloadLocation": "http://github.com/substack/node-chainsaw",
+      "filesAnalyzed": false,
+      "licenseConcluded": "MIT",
+      "licenseDeclared": "MIT",
+      "copyrightText": "NOASSERTION",
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceType": "purl",
+          "referenceLocator": "pkg:npm/chainsaw@0.1.0"
         }
       ]
     },
@@ -4660,6 +5000,40 @@
       ]
     },
     {
+      "name": "compress-commons",
+      "SPDXID": "SPDXRef-Package-e77e224d03910af4",
+      "versionInfo": "4.1.2",
+      "downloadLocation": "https://github.com/archiverjs/node-compress-commons",
+      "filesAnalyzed": false,
+      "licenseConcluded": "MIT",
+      "licenseDeclared": "MIT",
+      "copyrightText": "NOASSERTION",
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceType": "purl",
+          "referenceLocator": "pkg:npm/compress-commons@4.1.2"
+        }
+      ]
+    },
+    {
+      "name": "concat-map",
+      "SPDXID": "SPDXRef-Package-446fb7e0d413f4e8",
+      "versionInfo": "0.0.1",
+      "downloadLocation": "https://github.com/substack/node-concat-map",
+      "filesAnalyzed": false,
+      "licenseConcluded": "MIT",
+      "licenseDeclared": "MIT",
+      "copyrightText": "NOASSERTION",
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceType": "purl",
+          "referenceLocator": "pkg:npm/concat-map@0.0.1"
+        }
+      ]
+    },
+    {
       "name": "conf",
       "SPDXID": "SPDXRef-Package-4b508a608e7c9c35",
       "versionInfo": "9.0.2",
@@ -4860,6 +5234,40 @@
           "referenceCategory": "PACKAGE-MANAGER",
           "referenceType": "purl",
           "referenceLocator": "pkg:npm/cpu-features@0.0.10"
+        }
+      ]
+    },
+    {
+      "name": "crc-32",
+      "SPDXID": "SPDXRef-Package-7b769d3a0b61c741",
+      "versionInfo": "1.2.2",
+      "downloadLocation": "https://github.com/SheetJS/js-crc32",
+      "filesAnalyzed": false,
+      "licenseConcluded": "Apache-2.0",
+      "licenseDeclared": "Apache-2.0",
+      "copyrightText": "NOASSERTION",
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceType": "purl",
+          "referenceLocator": "pkg:npm/crc-32@1.2.2"
+        }
+      ]
+    },
+    {
+      "name": "crc32-stream",
+      "SPDXID": "SPDXRef-Package-3bd6e89d41e1b16e",
+      "versionInfo": "4.0.3",
+      "downloadLocation": "https://github.com/archiverjs/node-crc32-stream",
+      "filesAnalyzed": false,
+      "licenseConcluded": "MIT",
+      "licenseDeclared": "MIT",
+      "copyrightText": "NOASSERTION",
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceType": "purl",
+          "referenceLocator": "pkg:npm/crc32-stream@4.0.3"
         }
       ]
     },
@@ -5952,6 +6360,23 @@
       ]
     },
     {
+      "name": "docx",
+      "SPDXID": "SPDXRef-Package-5fcae62518b2d23a",
+      "versionInfo": "9.7.1",
+      "downloadLocation": "https://github.com/dolanmiu/docx",
+      "filesAnalyzed": false,
+      "licenseConcluded": "MIT",
+      "licenseDeclared": "MIT",
+      "copyrightText": "NOASSERTION",
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceType": "purl",
+          "referenceLocator": "pkg:npm/docx@9.7.1"
+        }
+      ]
+    },
+    {
       "name": "dompurify",
       "SPDXID": "SPDXRef-Package-fe4205b186c43bb8",
       "versionInfo": "3.4.12",
@@ -6016,6 +6441,23 @@
           "referenceCategory": "PACKAGE-MANAGER",
           "referenceType": "purl",
           "referenceLocator": "pkg:npm/dunder-proto@1.0.1"
+        }
+      ]
+    },
+    {
+      "name": "duplexer2",
+      "SPDXID": "SPDXRef-Package-5203e1981b9684d9",
+      "versionInfo": "0.1.4",
+      "downloadLocation": "https://github.com/deoxxa/duplexer2",
+      "filesAnalyzed": false,
+      "licenseConcluded": "BSD-3-Clause",
+      "licenseDeclared": "BSD-3-Clause",
+      "copyrightText": "NOASSERTION",
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceType": "purl",
+          "referenceLocator": "pkg:npm/duplexer2@0.1.4"
         }
       ]
     },
@@ -6445,6 +6887,23 @@
       ]
     },
     {
+      "name": "exceljs",
+      "SPDXID": "SPDXRef-Package-a037ed657533f4f1",
+      "versionInfo": "4.4.0",
+      "downloadLocation": "https://github.com/exceljs/exceljs",
+      "filesAnalyzed": false,
+      "licenseConcluded": "MIT",
+      "licenseDeclared": "MIT",
+      "copyrightText": "NOASSERTION",
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceType": "purl",
+          "referenceLocator": "pkg:npm/exceljs@4.4.0"
+        }
+      ]
+    },
+    {
       "name": "execa",
       "SPDXID": "SPDXRef-Package-95a792ac9cb6ef2b",
       "versionInfo": "4.1.0",
@@ -6560,6 +7019,23 @@
           "referenceCategory": "PACKAGE-MANAGER",
           "referenceType": "purl",
           "referenceLocator": "pkg:npm/extend-shallow@2.0.1"
+        }
+      ]
+    },
+    {
+      "name": "fast-csv",
+      "SPDXID": "SPDXRef-Package-c7b893d84403ff14",
+      "versionInfo": "4.3.6",
+      "downloadLocation": "https://github.com/C2FO/fast-csv",
+      "filesAnalyzed": false,
+      "licenseConcluded": "MIT",
+      "licenseDeclared": "MIT",
+      "copyrightText": "NOASSERTION",
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceType": "purl",
+          "referenceLocator": "pkg:npm/fast-csv@4.3.6"
         }
       ]
     },
@@ -6853,6 +7329,40 @@
       ]
     },
     {
+      "name": "fs.realpath",
+      "SPDXID": "SPDXRef-Package-066c98d78f779398",
+      "versionInfo": "1.0.0",
+      "downloadLocation": "https://github.com/isaacs/fs.realpath",
+      "filesAnalyzed": false,
+      "licenseConcluded": "ISC",
+      "licenseDeclared": "ISC",
+      "copyrightText": "NOASSERTION",
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceType": "purl",
+          "referenceLocator": "pkg:npm/fs.realpath@1.0.0"
+        }
+      ]
+    },
+    {
+      "name": "fstream",
+      "SPDXID": "SPDXRef-Package-8c228885d01e65b0",
+      "versionInfo": "1.0.12",
+      "downloadLocation": "https://github.com/npm/fstream",
+      "filesAnalyzed": false,
+      "licenseConcluded": "ISC",
+      "licenseDeclared": "ISC",
+      "copyrightText": "NOASSERTION",
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceType": "purl",
+          "referenceLocator": "pkg:npm/fstream@1.0.12"
+        }
+      ]
+    },
+    {
       "name": "function-bind",
       "SPDXID": "SPDXRef-Package-efff64b24eff87e8",
       "versionInfo": "1.1.2",
@@ -7108,6 +7618,23 @@
       ]
     },
     {
+      "name": "glob",
+      "SPDXID": "SPDXRef-Package-8702ad5f91114f8f",
+      "versionInfo": "7.2.3",
+      "downloadLocation": "https://github.com/isaacs/node-glob",
+      "filesAnalyzed": false,
+      "licenseConcluded": "ISC",
+      "licenseDeclared": "ISC",
+      "copyrightText": "NOASSERTION",
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceType": "purl",
+          "referenceLocator": "pkg:npm/glob@7.2.3"
+        }
+      ]
+    },
+    {
       "name": "google-auth-library",
       "SPDXID": "SPDXRef-Package-ca014b881c253ebc",
       "versionInfo": "10.5.0",
@@ -7308,6 +7835,23 @@
           "referenceCategory": "PACKAGE-MANAGER",
           "referenceType": "purl",
           "referenceLocator": "pkg:npm/has-tostringtag@1.0.2"
+        }
+      ]
+    },
+    {
+      "name": "hash.js",
+      "SPDXID": "SPDXRef-Package-0fe3a8dd2852340e",
+      "versionInfo": "1.1.7",
+      "downloadLocation": "https://github.com/indutny/hash.js",
+      "filesAnalyzed": false,
+      "licenseConcluded": "MIT",
+      "licenseDeclared": "MIT",
+      "copyrightText": "NOASSERTION",
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceType": "purl",
+          "referenceLocator": "pkg:npm/hash.js@1.1.7"
         }
       ]
     },
@@ -7635,6 +8179,23 @@
       ]
     },
     {
+      "name": "https",
+      "SPDXID": "SPDXRef-Package-a6138fed56d8e05e",
+      "versionInfo": "1.0.0",
+      "downloadLocation": "NOASSERTION",
+      "filesAnalyzed": false,
+      "licenseConcluded": "ISC",
+      "licenseDeclared": "ISC",
+      "copyrightText": "NOASSERTION",
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceType": "purl",
+          "referenceLocator": "pkg:npm/https@1.0.0"
+        }
+      ]
+    },
+    {
       "name": "https-proxy-agent",
       "SPDXID": "SPDXRef-Package-ca16958c815c8380",
       "versionInfo": "5.0.1",
@@ -7788,6 +8349,23 @@
       ]
     },
     {
+      "name": "image-size",
+      "SPDXID": "SPDXRef-Package-41bbec0dae5bac67",
+      "versionInfo": "1.2.1",
+      "downloadLocation": "https://github.com/image-size/image-size",
+      "filesAnalyzed": false,
+      "licenseConcluded": "MIT",
+      "licenseDeclared": "MIT",
+      "copyrightText": "NOASSERTION",
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceType": "purl",
+          "referenceLocator": "pkg:npm/image-size@1.2.1"
+        }
+      ]
+    },
+    {
       "name": "immediate",
       "SPDXID": "SPDXRef-Package-1bf8b3e308414474",
       "versionInfo": "3.0.6",
@@ -7818,6 +8396,23 @@
           "referenceCategory": "PACKAGE-MANAGER",
           "referenceType": "purl",
           "referenceLocator": "pkg:npm/import-meta-resolve@4.2.0"
+        }
+      ]
+    },
+    {
+      "name": "inflight",
+      "SPDXID": "SPDXRef-Package-93b34ac704832584",
+      "versionInfo": "1.0.6",
+      "downloadLocation": "https://github.com/npm/inflight",
+      "filesAnalyzed": false,
+      "licenseConcluded": "ISC",
+      "licenseDeclared": "ISC",
+      "copyrightText": "NOASSERTION",
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceType": "purl",
+          "referenceLocator": "pkg:npm/inflight@1.0.6"
         }
       ]
     },
@@ -8587,6 +9182,23 @@
       ]
     },
     {
+      "name": "lazystream",
+      "SPDXID": "SPDXRef-Package-85cab3d3fea075b9",
+      "versionInfo": "1.0.1",
+      "downloadLocation": "https://github.com/jpommerening/node-lazystream",
+      "filesAnalyzed": false,
+      "licenseConcluded": "MIT",
+      "licenseDeclared": "MIT",
+      "copyrightText": "NOASSERTION",
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceType": "purl",
+          "referenceLocator": "pkg:npm/lazystream@1.0.1"
+        }
+      ]
+    },
+    {
       "name": "lcid",
       "SPDXID": "SPDXRef-Package-dc65c95b58f6df34",
       "versionInfo": "3.1.1",
@@ -8617,6 +9229,23 @@
           "referenceCategory": "PACKAGE-MANAGER",
           "referenceType": "purl",
           "referenceLocator": "pkg:npm/lie@3.3.0"
+        }
+      ]
+    },
+    {
+      "name": "listenercount",
+      "SPDXID": "SPDXRef-Package-a12a1c81551b29a0",
+      "versionInfo": "1.0.1",
+      "downloadLocation": "https://github.com/jden/node-listenercount",
+      "filesAnalyzed": false,
+      "licenseConcluded": "ISC",
+      "licenseDeclared": "ISC",
+      "copyrightText": "NOASSERTION",
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceType": "purl",
+          "referenceLocator": "pkg:npm/listenercount@1.0.1"
         }
       ]
     },
@@ -8740,6 +9369,91 @@
       ]
     },
     {
+      "name": "lodash.defaults",
+      "SPDXID": "SPDXRef-Package-a3a0c53acb8c1dcc",
+      "versionInfo": "4.2.0",
+      "downloadLocation": "https://github.com/lodash/lodash",
+      "filesAnalyzed": false,
+      "licenseConcluded": "MIT",
+      "licenseDeclared": "MIT",
+      "copyrightText": "NOASSERTION",
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceType": "purl",
+          "referenceLocator": "pkg:npm/lodash.defaults@4.2.0"
+        }
+      ]
+    },
+    {
+      "name": "lodash.difference",
+      "SPDXID": "SPDXRef-Package-0264c095c57bc5cf",
+      "versionInfo": "4.5.0",
+      "downloadLocation": "https://github.com/lodash/lodash",
+      "filesAnalyzed": false,
+      "licenseConcluded": "MIT",
+      "licenseDeclared": "MIT",
+      "copyrightText": "NOASSERTION",
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceType": "purl",
+          "referenceLocator": "pkg:npm/lodash.difference@4.5.0"
+        }
+      ]
+    },
+    {
+      "name": "lodash.escaperegexp",
+      "SPDXID": "SPDXRef-Package-de4b3a9e90ea9774",
+      "versionInfo": "4.1.2",
+      "downloadLocation": "https://github.com/lodash/lodash",
+      "filesAnalyzed": false,
+      "licenseConcluded": "MIT",
+      "licenseDeclared": "MIT",
+      "copyrightText": "NOASSERTION",
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceType": "purl",
+          "referenceLocator": "pkg:npm/lodash.escaperegexp@4.1.2"
+        }
+      ]
+    },
+    {
+      "name": "lodash.flatten",
+      "SPDXID": "SPDXRef-Package-0729f90dee660e49",
+      "versionInfo": "4.4.0",
+      "downloadLocation": "https://github.com/lodash/lodash",
+      "filesAnalyzed": false,
+      "licenseConcluded": "MIT",
+      "licenseDeclared": "MIT",
+      "copyrightText": "NOASSERTION",
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceType": "purl",
+          "referenceLocator": "pkg:npm/lodash.flatten@4.4.0"
+        }
+      ]
+    },
+    {
+      "name": "lodash.groupby",
+      "SPDXID": "SPDXRef-Package-ff4c49b4828c9e19",
+      "versionInfo": "4.6.0",
+      "downloadLocation": "https://github.com/lodash/lodash",
+      "filesAnalyzed": false,
+      "licenseConcluded": "MIT",
+      "licenseDeclared": "MIT",
+      "copyrightText": "NOASSERTION",
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceType": "purl",
+          "referenceLocator": "pkg:npm/lodash.groupby@4.6.0"
+        }
+      ]
+    },
+    {
       "name": "lodash.identity",
       "SPDXID": "SPDXRef-Package-a1ca8608b85fb076",
       "versionInfo": "3.0.0",
@@ -8753,6 +9467,108 @@
           "referenceCategory": "PACKAGE-MANAGER",
           "referenceType": "purl",
           "referenceLocator": "pkg:npm/lodash.identity@3.0.0"
+        }
+      ]
+    },
+    {
+      "name": "lodash.isboolean",
+      "SPDXID": "SPDXRef-Package-db45f10bd3ef5fb5",
+      "versionInfo": "3.0.3",
+      "downloadLocation": "https://github.com/lodash/lodash",
+      "filesAnalyzed": false,
+      "licenseConcluded": "MIT",
+      "licenseDeclared": "MIT",
+      "copyrightText": "NOASSERTION",
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceType": "purl",
+          "referenceLocator": "pkg:npm/lodash.isboolean@3.0.3"
+        }
+      ]
+    },
+    {
+      "name": "lodash.isequal",
+      "SPDXID": "SPDXRef-Package-4fbfd070c92eb053",
+      "versionInfo": "4.5.0",
+      "downloadLocation": "https://github.com/lodash/lodash",
+      "filesAnalyzed": false,
+      "licenseConcluded": "MIT",
+      "licenseDeclared": "MIT",
+      "copyrightText": "NOASSERTION",
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceType": "purl",
+          "referenceLocator": "pkg:npm/lodash.isequal@4.5.0"
+        }
+      ]
+    },
+    {
+      "name": "lodash.isfunction",
+      "SPDXID": "SPDXRef-Package-48d573eae5c4cd81",
+      "versionInfo": "3.0.9",
+      "downloadLocation": "https://github.com/lodash/lodash",
+      "filesAnalyzed": false,
+      "licenseConcluded": "MIT",
+      "licenseDeclared": "MIT",
+      "copyrightText": "NOASSERTION",
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceType": "purl",
+          "referenceLocator": "pkg:npm/lodash.isfunction@3.0.9"
+        }
+      ]
+    },
+    {
+      "name": "lodash.isnil",
+      "SPDXID": "SPDXRef-Package-45270f7cf55ec688",
+      "versionInfo": "4.0.0",
+      "downloadLocation": "https://github.com/lodash/lodash",
+      "filesAnalyzed": false,
+      "licenseConcluded": "MIT",
+      "licenseDeclared": "MIT",
+      "copyrightText": "NOASSERTION",
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceType": "purl",
+          "referenceLocator": "pkg:npm/lodash.isnil@4.0.0"
+        }
+      ]
+    },
+    {
+      "name": "lodash.isplainobject",
+      "SPDXID": "SPDXRef-Package-715a4dee5083b138",
+      "versionInfo": "4.0.6",
+      "downloadLocation": "https://github.com/lodash/lodash",
+      "filesAnalyzed": false,
+      "licenseConcluded": "MIT",
+      "licenseDeclared": "MIT",
+      "copyrightText": "NOASSERTION",
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceType": "purl",
+          "referenceLocator": "pkg:npm/lodash.isplainobject@4.0.6"
+        }
+      ]
+    },
+    {
+      "name": "lodash.isundefined",
+      "SPDXID": "SPDXRef-Package-395eddedb8745a8f",
+      "versionInfo": "3.0.1",
+      "downloadLocation": "https://github.com/lodash/lodash",
+      "filesAnalyzed": false,
+      "licenseConcluded": "MIT",
+      "licenseDeclared": "MIT",
+      "copyrightText": "NOASSERTION",
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceType": "purl",
+          "referenceLocator": "pkg:npm/lodash.isundefined@3.0.1"
         }
       ]
     },
@@ -8804,6 +9620,40 @@
           "referenceCategory": "PACKAGE-MANAGER",
           "referenceType": "purl",
           "referenceLocator": "pkg:npm/lodash.snakecase@4.1.1"
+        }
+      ]
+    },
+    {
+      "name": "lodash.union",
+      "SPDXID": "SPDXRef-Package-57a1e9a5e166604b",
+      "versionInfo": "4.6.0",
+      "downloadLocation": "https://github.com/lodash/lodash",
+      "filesAnalyzed": false,
+      "licenseConcluded": "MIT",
+      "licenseDeclared": "MIT",
+      "copyrightText": "NOASSERTION",
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceType": "purl",
+          "referenceLocator": "pkg:npm/lodash.union@4.6.0"
+        }
+      ]
+    },
+    {
+      "name": "lodash.uniq",
+      "SPDXID": "SPDXRef-Package-ce721e649dfb1e5c",
+      "versionInfo": "4.5.0",
+      "downloadLocation": "https://github.com/lodash/lodash",
+      "filesAnalyzed": false,
+      "licenseConcluded": "MIT",
+      "licenseDeclared": "MIT",
+      "copyrightText": "NOASSERTION",
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceType": "purl",
+          "referenceLocator": "pkg:npm/lodash.uniq@4.5.0"
         }
       ]
     },
@@ -10015,6 +10865,57 @@
       ]
     },
     {
+      "name": "minimalistic-assert",
+      "SPDXID": "SPDXRef-Package-588f964b04a1a148",
+      "versionInfo": "1.0.1",
+      "downloadLocation": "https://github.com/calvinmetcalf/minimalistic-assert",
+      "filesAnalyzed": false,
+      "licenseConcluded": "ISC",
+      "licenseDeclared": "ISC",
+      "copyrightText": "NOASSERTION",
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceType": "purl",
+          "referenceLocator": "pkg:npm/minimalistic-assert@1.0.1"
+        }
+      ]
+    },
+    {
+      "name": "minimatch",
+      "SPDXID": "SPDXRef-Package-40d05b19a4e7d885",
+      "versionInfo": "3.1.5",
+      "downloadLocation": "https://github.com/isaacs/minimatch",
+      "filesAnalyzed": false,
+      "licenseConcluded": "ISC",
+      "licenseDeclared": "ISC",
+      "copyrightText": "NOASSERTION",
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceType": "purl",
+          "referenceLocator": "pkg:npm/minimatch@3.1.5"
+        }
+      ]
+    },
+    {
+      "name": "minimatch",
+      "SPDXID": "SPDXRef-Package-9b652aa8c82e5af7",
+      "versionInfo": "5.1.9",
+      "downloadLocation": "https://github.com/isaacs/minimatch",
+      "filesAnalyzed": false,
+      "licenseConcluded": "ISC",
+      "licenseDeclared": "ISC",
+      "copyrightText": "NOASSERTION",
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceType": "purl",
+          "referenceLocator": "pkg:npm/minimatch@5.1.9"
+        }
+      ]
+    },
+    {
       "name": "minimatch",
       "SPDXID": "SPDXRef-Package-9a47e0282c0c109e",
       "versionInfo": "9.0.9",
@@ -10185,6 +11086,23 @@
       ]
     },
     {
+      "name": "nanoid",
+      "SPDXID": "SPDXRef-Package-351e1526e0c140ae",
+      "versionInfo": "5.1.16",
+      "downloadLocation": "https://github.com/ai/nanoid",
+      "filesAnalyzed": false,
+      "licenseConcluded": "MIT",
+      "licenseDeclared": "MIT",
+      "copyrightText": "NOASSERTION",
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceType": "purl",
+          "referenceLocator": "pkg:npm/nanoid@5.1.16"
+        }
+      ]
+    },
+    {
       "name": "napi-build-utils",
       "SPDXID": "SPDXRef-Package-ee090ad491ba86cf",
       "versionInfo": "2.0.0",
@@ -10317,6 +11235,23 @@
           "referenceCategory": "PACKAGE-MANAGER",
           "referenceType": "purl",
           "referenceLocator": "pkg:npm/node-pty@1.1.0"
+        }
+      ]
+    },
+    {
+      "name": "normalize-path",
+      "SPDXID": "SPDXRef-Package-e6a9afc20b6a5b4f",
+      "versionInfo": "3.0.0",
+      "downloadLocation": "https://github.com/jonschlinkert/normalize-path",
+      "filesAnalyzed": false,
+      "licenseConcluded": "MIT",
+      "licenseDeclared": "MIT",
+      "copyrightText": "NOASSERTION",
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceType": "purl",
+          "referenceLocator": "pkg:npm/normalize-path@3.0.0"
         }
       ]
     },
@@ -10678,6 +11613,23 @@
       ]
     },
     {
+      "name": "path-is-absolute",
+      "SPDXID": "SPDXRef-Package-79f253dbdc64eb00",
+      "versionInfo": "1.0.1",
+      "downloadLocation": "https://github.com/sindresorhus/path-is-absolute",
+      "filesAnalyzed": false,
+      "licenseConcluded": "MIT",
+      "licenseDeclared": "MIT",
+      "copyrightText": "NOASSERTION",
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceType": "purl",
+          "referenceLocator": "pkg:npm/path-is-absolute@1.0.1"
+        }
+      ]
+    },
+    {
       "name": "path-key",
       "SPDXID": "SPDXRef-Package-fdd7a87411d74d56",
       "versionInfo": "3.1.1",
@@ -10861,6 +11813,23 @@
           "referenceCategory": "PACKAGE-MANAGER",
           "referenceType": "purl",
           "referenceLocator": "pkg:npm/points-on-path@0.2.1"
+        }
+      ]
+    },
+    {
+      "name": "pptxgenjs",
+      "SPDXID": "SPDXRef-Package-8406d74ee701100f",
+      "versionInfo": "4.0.1",
+      "downloadLocation": "https://github.com/gitbrent/PptxGenJS",
+      "filesAnalyzed": false,
+      "licenseConcluded": "MIT",
+      "licenseDeclared": "MIT",
+      "copyrightText": "NOASSERTION",
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceType": "purl",
+          "referenceLocator": "pkg:npm/pptxgenjs@4.0.1"
         }
       ]
     },
@@ -11273,6 +12242,23 @@
       ]
     },
     {
+      "name": "queue",
+      "SPDXID": "SPDXRef-Package-c8b1e190ece36b5b",
+      "versionInfo": "6.0.2",
+      "downloadLocation": "https://github.com/jessetane/queue",
+      "filesAnalyzed": false,
+      "licenseConcluded": "MIT",
+      "licenseDeclared": "MIT",
+      "copyrightText": "NOASSERTION",
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceType": "purl",
+          "referenceLocator": "pkg:npm/queue@6.0.2"
+        }
+      ]
+    },
+    {
       "name": "range-parser",
       "SPDXID": "SPDXRef-Package-c99f309bb22fcd34",
       "versionInfo": "1.3.0",
@@ -11511,6 +12497,23 @@
       ]
     },
     {
+      "name": "readdir-glob",
+      "SPDXID": "SPDXRef-Package-8c907a9e46ec42ff",
+      "versionInfo": "1.1.3",
+      "downloadLocation": "https://github.com/Yqnn/node-readdir-glob",
+      "filesAnalyzed": false,
+      "licenseConcluded": "Apache-2.0",
+      "licenseDeclared": "Apache-2.0",
+      "copyrightText": "NOASSERTION",
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceType": "purl",
+          "referenceLocator": "pkg:npm/readdir-glob@1.1.3"
+        }
+      ]
+    },
+    {
       "name": "rehype-highlight",
       "SPDXID": "SPDXRef-Package-046eb40b35cfc8f2",
       "versionInfo": "7.0.2",
@@ -11716,6 +12719,23 @@
     },
     {
       "name": "rimraf",
+      "SPDXID": "SPDXRef-Package-1b50db6d94db0196",
+      "versionInfo": "2.6.3",
+      "downloadLocation": "https://github.com/isaacs/rimraf",
+      "filesAnalyzed": false,
+      "licenseConcluded": "ISC",
+      "licenseDeclared": "ISC",
+      "copyrightText": "NOASSERTION",
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceType": "purl",
+          "referenceLocator": "pkg:npm/rimraf@2.6.3"
+        }
+      ]
+    },
+    {
+      "name": "rimraf",
       "SPDXID": "SPDXRef-Package-7fd5189f1498eda2",
       "versionInfo": "5.0.10",
       "downloadLocation": "https://github.com/isaacs/rimraf",
@@ -11864,6 +12884,40 @@
           "referenceCategory": "PACKAGE-MANAGER",
           "referenceType": "purl",
           "referenceLocator": "pkg:npm/safer-buffer@2.1.2"
+        }
+      ]
+    },
+    {
+      "name": "sax",
+      "SPDXID": "SPDXRef-Package-6d51ff5f61437558",
+      "versionInfo": "1.6.0",
+      "downloadLocation": "https://github.com/isaacs/sax-js",
+      "filesAnalyzed": false,
+      "licenseConcluded": "BlueOak-1.0.0",
+      "licenseDeclared": "BlueOak-1.0.0",
+      "copyrightText": "NOASSERTION",
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceType": "purl",
+          "referenceLocator": "pkg:npm/sax@1.6.0"
+        }
+      ]
+    },
+    {
+      "name": "saxes",
+      "SPDXID": "SPDXRef-Package-95cdee6f7d557d13",
+      "versionInfo": "5.0.1",
+      "downloadLocation": "https://github.com/lddubeau/saxes",
+      "filesAnalyzed": false,
+      "licenseConcluded": "ISC",
+      "licenseDeclared": "ISC",
+      "copyrightText": "NOASSERTION",
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceType": "purl",
+          "referenceLocator": "pkg:npm/saxes@5.0.1"
         }
       ]
     },
@@ -12718,6 +13772,23 @@
       ]
     },
     {
+      "name": "tmp",
+      "SPDXID": "SPDXRef-Package-b335f2d01d3ed9cf",
+      "versionInfo": "0.2.7",
+      "downloadLocation": "https://github.com/raszi/node-tmp",
+      "filesAnalyzed": false,
+      "licenseConcluded": "MIT",
+      "licenseDeclared": "MIT",
+      "copyrightText": "NOASSERTION",
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceType": "purl",
+          "referenceLocator": "pkg:npm/tmp@0.2.7"
+        }
+      ]
+    },
+    {
       "name": "toidentifier",
       "SPDXID": "SPDXRef-Package-c834291cf2535d86",
       "versionInfo": "1.0.1",
@@ -12731,6 +13802,23 @@
           "referenceCategory": "PACKAGE-MANAGER",
           "referenceType": "purl",
           "referenceLocator": "pkg:npm/toidentifier@1.0.1"
+        }
+      ]
+    },
+    {
+      "name": "traverse",
+      "SPDXID": "SPDXRef-Package-a141076283aa9950",
+      "versionInfo": "0.3.9",
+      "downloadLocation": "http://github.com/substack/js-traverse",
+      "filesAnalyzed": false,
+      "licenseConcluded": "MIT",
+      "licenseDeclared": "MIT",
+      "copyrightText": "NOASSERTION",
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceType": "purl",
+          "referenceLocator": "pkg:npm/traverse@0.3.9"
         }
       ]
     },
@@ -12974,6 +14062,23 @@
     },
     {
       "name": "undici-types",
+      "SPDXID": "SPDXRef-Package-a3e23d7a1173dbbf",
+      "versionInfo": "6.21.0",
+      "downloadLocation": "https://github.com/nodejs/undici",
+      "filesAnalyzed": false,
+      "licenseConcluded": "MIT",
+      "licenseDeclared": "MIT",
+      "copyrightText": "NOASSERTION",
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceType": "purl",
+          "referenceLocator": "pkg:npm/undici-types@6.21.0"
+        }
+      ]
+    },
+    {
+      "name": "undici-types",
       "SPDXID": "SPDXRef-Package-a85d345236e133c0",
       "versionInfo": "7.24.6",
       "downloadLocation": "https://github.com/nodejs/undici",
@@ -13160,6 +14265,23 @@
       ]
     },
     {
+      "name": "unzipper",
+      "SPDXID": "SPDXRef-Package-0691de763eddddc8",
+      "versionInfo": "0.10.14",
+      "downloadLocation": "https://github.com/ZJONSSON/node-unzipper",
+      "filesAnalyzed": false,
+      "licenseConcluded": "MIT",
+      "licenseDeclared": "MIT",
+      "copyrightText": "NOASSERTION",
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceType": "purl",
+          "referenceLocator": "pkg:npm/unzipper@0.10.14"
+        }
+      ]
+    },
+    {
       "name": "uri-js",
       "SPDXID": "SPDXRef-Package-86b9d1cd1856870a",
       "versionInfo": "4.4.1",
@@ -13275,6 +14397,23 @@
           "referenceCategory": "PACKAGE-MANAGER",
           "referenceType": "purl",
           "referenceLocator": "pkg:npm/uuid@14.0.1"
+        }
+      ]
+    },
+    {
+      "name": "uuid",
+      "SPDXID": "SPDXRef-Package-781eb11958365689",
+      "versionInfo": "8.3.2",
+      "downloadLocation": "https://github.com/uuidjs/uuid",
+      "filesAnalyzed": false,
+      "licenseConcluded": "MIT",
+      "licenseDeclared": "MIT",
+      "copyrightText": "NOASSERTION",
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceType": "purl",
+          "referenceLocator": "pkg:npm/uuid@8.3.2"
         }
       ]
     },
@@ -13551,6 +14690,57 @@
       ]
     },
     {
+      "name": "xml",
+      "SPDXID": "SPDXRef-Package-952c31231ba66670",
+      "versionInfo": "1.0.1",
+      "downloadLocation": "http://github.com/dylang/node-xml",
+      "filesAnalyzed": false,
+      "licenseConcluded": "MIT",
+      "licenseDeclared": "MIT",
+      "copyrightText": "NOASSERTION",
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceType": "purl",
+          "referenceLocator": "pkg:npm/xml@1.0.1"
+        }
+      ]
+    },
+    {
+      "name": "xml-js",
+      "SPDXID": "SPDXRef-Package-db9ebd25cef24c8f",
+      "versionInfo": "1.6.11",
+      "downloadLocation": "https://github.com/nashwaan/xml-js",
+      "filesAnalyzed": false,
+      "licenseConcluded": "MIT",
+      "licenseDeclared": "MIT",
+      "copyrightText": "NOASSERTION",
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceType": "purl",
+          "referenceLocator": "pkg:npm/xml-js@1.6.11"
+        }
+      ]
+    },
+    {
+      "name": "xmlchars",
+      "SPDXID": "SPDXRef-Package-bd49bc058ac56fd1",
+      "versionInfo": "2.2.0",
+      "downloadLocation": "https://github.com/lddubeau/xmlchars",
+      "filesAnalyzed": false,
+      "licenseConcluded": "MIT",
+      "licenseDeclared": "MIT",
+      "copyrightText": "NOASSERTION",
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceType": "purl",
+          "referenceLocator": "pkg:npm/xmlchars@2.2.0"
+        }
+      ]
+    },
+    {
       "name": "y18n",
       "SPDXID": "SPDXRef-Package-8e532c67f7b65656",
       "versionInfo": "4.0.3",
@@ -13615,6 +14805,23 @@
           "referenceCategory": "PACKAGE-MANAGER",
           "referenceType": "purl",
           "referenceLocator": "pkg:npm/yargs-parser@18.1.3"
+        }
+      ]
+    },
+    {
+      "name": "zip-stream",
+      "SPDXID": "SPDXRef-Package-83f742740c720c8e",
+      "versionInfo": "4.1.1",
+      "downloadLocation": "https://github.com/archiverjs/node-zip-stream",
+      "filesAnalyzed": false,
+      "licenseConcluded": "MIT",
+      "licenseDeclared": "MIT",
+      "copyrightText": "NOASSERTION",
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceType": "purl",
+          "referenceLocator": "pkg:npm/zip-stream@4.1.1"
         }
       ]
     },
@@ -13724,7 +14931,7 @@
     {
       "spdxElementId": "SPDXRef-DOCUMENT",
       "relationshipType": "DESCRIBES",
-      "relatedSpdxElement": "SPDXRef-Package-04c1add3e48a9e5c"
+      "relatedSpdxElement": "SPDXRef-Package-a3cbdbce86e6fdc7"
     },
     {
       "spdxElementId": "SPDXRef-DOCUMENT",
@@ -13764,7 +14971,27 @@
     {
       "spdxElementId": "SPDXRef-DOCUMENT",
       "relationshipType": "DESCRIBES",
+      "relatedSpdxElement": "SPDXRef-Package-2d6a4b723df29496"
+    },
+    {
+      "spdxElementId": "SPDXRef-DOCUMENT",
+      "relationshipType": "DESCRIBES",
+      "relatedSpdxElement": "SPDXRef-Package-d10d1f341d4abfa8"
+    },
+    {
+      "spdxElementId": "SPDXRef-DOCUMENT",
+      "relationshipType": "DESCRIBES",
+      "relatedSpdxElement": "SPDXRef-Package-bae6a338f33d9a1c"
+    },
+    {
+      "spdxElementId": "SPDXRef-DOCUMENT",
+      "relationshipType": "DESCRIBES",
       "relatedSpdxElement": "SPDXRef-Package-edf04d45834b4fbf"
+    },
+    {
+      "spdxElementId": "SPDXRef-DOCUMENT",
+      "relationshipType": "DESCRIBES",
+      "relatedSpdxElement": "SPDXRef-Package-3adbc0856a9bda85"
     },
     {
       "spdxElementId": "SPDXRef-DOCUMENT",
@@ -13925,6 +15152,16 @@
       "spdxElementId": "SPDXRef-DOCUMENT",
       "relationshipType": "DESCRIBES",
       "relatedSpdxElement": "SPDXRef-Package-53aca7cadbe88e59"
+    },
+    {
+      "spdxElementId": "SPDXRef-DOCUMENT",
+      "relationshipType": "DESCRIBES",
+      "relatedSpdxElement": "SPDXRef-Package-ef09030156acbe49"
+    },
+    {
+      "spdxElementId": "SPDXRef-DOCUMENT",
+      "relationshipType": "DESCRIBES",
+      "relatedSpdxElement": "SPDXRef-Package-f4baae4686e02f0a"
     },
     {
       "spdxElementId": "SPDXRef-DOCUMENT",
@@ -14739,6 +15976,16 @@
     {
       "spdxElementId": "SPDXRef-DOCUMENT",
       "relationshipType": "DESCRIBES",
+      "relatedSpdxElement": "SPDXRef-Package-c6b0b3ef4062e7b5"
+    },
+    {
+      "spdxElementId": "SPDXRef-DOCUMENT",
+      "relationshipType": "DESCRIBES",
+      "relatedSpdxElement": "SPDXRef-Package-006d2bce93d8f1dd"
+    },
+    {
+      "spdxElementId": "SPDXRef-DOCUMENT",
+      "relationshipType": "DESCRIBES",
       "relatedSpdxElement": "SPDXRef-Package-b02ebf6599a4715f"
     },
     {
@@ -14864,6 +16111,21 @@
     {
       "spdxElementId": "SPDXRef-DOCUMENT",
       "relationshipType": "DESCRIBES",
+      "relatedSpdxElement": "SPDXRef-Package-9135483032251fea"
+    },
+    {
+      "spdxElementId": "SPDXRef-DOCUMENT",
+      "relationshipType": "DESCRIBES",
+      "relatedSpdxElement": "SPDXRef-Package-e4af001b994a14f4"
+    },
+    {
+      "spdxElementId": "SPDXRef-DOCUMENT",
+      "relationshipType": "DESCRIBES",
+      "relatedSpdxElement": "SPDXRef-Package-f7b326a32927cbed"
+    },
+    {
+      "spdxElementId": "SPDXRef-DOCUMENT",
+      "relationshipType": "DESCRIBES",
       "relatedSpdxElement": "SPDXRef-Package-1b8ff3f05bffff87"
     },
     {
@@ -14880,6 +16142,11 @@
       "spdxElementId": "SPDXRef-DOCUMENT",
       "relationshipType": "DESCRIBES",
       "relatedSpdxElement": "SPDXRef-Package-11e344538943bbf2"
+    },
+    {
+      "spdxElementId": "SPDXRef-DOCUMENT",
+      "relationshipType": "DESCRIBES",
+      "relatedSpdxElement": "SPDXRef-Package-1faad319f76b179f"
     },
     {
       "spdxElementId": "SPDXRef-DOCUMENT",
@@ -14924,7 +16191,17 @@
     {
       "spdxElementId": "SPDXRef-DOCUMENT",
       "relationshipType": "DESCRIBES",
+      "relatedSpdxElement": "SPDXRef-Package-d4c964d5752fd254"
+    },
+    {
+      "spdxElementId": "SPDXRef-DOCUMENT",
+      "relationshipType": "DESCRIBES",
       "relatedSpdxElement": "SPDXRef-Package-e6bcaebbcb046dc4"
+    },
+    {
+      "spdxElementId": "SPDXRef-DOCUMENT",
+      "relationshipType": "DESCRIBES",
+      "relatedSpdxElement": "SPDXRef-Package-169094cbdc1389db"
     },
     {
       "spdxElementId": "SPDXRef-DOCUMENT",
@@ -14939,7 +16216,17 @@
     {
       "spdxElementId": "SPDXRef-DOCUMENT",
       "relationshipType": "DESCRIBES",
+      "relatedSpdxElement": "SPDXRef-Package-281d2b6b5950a4ba"
+    },
+    {
+      "spdxElementId": "SPDXRef-DOCUMENT",
+      "relationshipType": "DESCRIBES",
       "relatedSpdxElement": "SPDXRef-Package-603bfb1d8a6cd096"
+    },
+    {
+      "spdxElementId": "SPDXRef-DOCUMENT",
+      "relationshipType": "DESCRIBES",
+      "relatedSpdxElement": "SPDXRef-Package-3a4b46a93421a532"
     },
     {
       "spdxElementId": "SPDXRef-DOCUMENT",
@@ -14954,7 +16241,22 @@
     {
       "spdxElementId": "SPDXRef-DOCUMENT",
       "relationshipType": "DESCRIBES",
+      "relatedSpdxElement": "SPDXRef-Package-3f07b92fa45ba611"
+    },
+    {
+      "spdxElementId": "SPDXRef-DOCUMENT",
+      "relationshipType": "DESCRIBES",
       "relatedSpdxElement": "SPDXRef-Package-2f4ce0cccb4ed6f4"
+    },
+    {
+      "spdxElementId": "SPDXRef-DOCUMENT",
+      "relationshipType": "DESCRIBES",
+      "relatedSpdxElement": "SPDXRef-Package-62eb5a03ebf03674"
+    },
+    {
+      "spdxElementId": "SPDXRef-DOCUMENT",
+      "relationshipType": "DESCRIBES",
+      "relatedSpdxElement": "SPDXRef-Package-8e3f307fa2ee1e16"
     },
     {
       "spdxElementId": "SPDXRef-DOCUMENT",
@@ -14990,6 +16292,11 @@
       "spdxElementId": "SPDXRef-DOCUMENT",
       "relationshipType": "DESCRIBES",
       "relatedSpdxElement": "SPDXRef-Package-8454f0e154fad702"
+    },
+    {
+      "spdxElementId": "SPDXRef-DOCUMENT",
+      "relationshipType": "DESCRIBES",
+      "relatedSpdxElement": "SPDXRef-Package-b114758f8c10a13e"
     },
     {
       "spdxElementId": "SPDXRef-DOCUMENT",
@@ -15074,6 +16381,16 @@
     {
       "spdxElementId": "SPDXRef-DOCUMENT",
       "relationshipType": "DESCRIBES",
+      "relatedSpdxElement": "SPDXRef-Package-e77e224d03910af4"
+    },
+    {
+      "spdxElementId": "SPDXRef-DOCUMENT",
+      "relationshipType": "DESCRIBES",
+      "relatedSpdxElement": "SPDXRef-Package-446fb7e0d413f4e8"
+    },
+    {
+      "spdxElementId": "SPDXRef-DOCUMENT",
+      "relationshipType": "DESCRIBES",
       "relatedSpdxElement": "SPDXRef-Package-4b508a608e7c9c35"
     },
     {
@@ -15130,6 +16447,16 @@
       "spdxElementId": "SPDXRef-DOCUMENT",
       "relationshipType": "DESCRIBES",
       "relatedSpdxElement": "SPDXRef-Package-b6c9c76e33815fb2"
+    },
+    {
+      "spdxElementId": "SPDXRef-DOCUMENT",
+      "relationshipType": "DESCRIBES",
+      "relatedSpdxElement": "SPDXRef-Package-7b769d3a0b61c741"
+    },
+    {
+      "spdxElementId": "SPDXRef-DOCUMENT",
+      "relationshipType": "DESCRIBES",
+      "relatedSpdxElement": "SPDXRef-Package-3bd6e89d41e1b16e"
     },
     {
       "spdxElementId": "SPDXRef-DOCUMENT",
@@ -15454,6 +16781,11 @@
     {
       "spdxElementId": "SPDXRef-DOCUMENT",
       "relationshipType": "DESCRIBES",
+      "relatedSpdxElement": "SPDXRef-Package-5fcae62518b2d23a"
+    },
+    {
+      "spdxElementId": "SPDXRef-DOCUMENT",
+      "relationshipType": "DESCRIBES",
       "relatedSpdxElement": "SPDXRef-Package-fe4205b186c43bb8"
     },
     {
@@ -15470,6 +16802,11 @@
       "spdxElementId": "SPDXRef-DOCUMENT",
       "relationshipType": "DESCRIBES",
       "relatedSpdxElement": "SPDXRef-Package-591da600a357596a"
+    },
+    {
+      "spdxElementId": "SPDXRef-DOCUMENT",
+      "relationshipType": "DESCRIBES",
+      "relatedSpdxElement": "SPDXRef-Package-5203e1981b9684d9"
     },
     {
       "spdxElementId": "SPDXRef-DOCUMENT",
@@ -15599,6 +16936,11 @@
     {
       "spdxElementId": "SPDXRef-DOCUMENT",
       "relationshipType": "DESCRIBES",
+      "relatedSpdxElement": "SPDXRef-Package-a037ed657533f4f1"
+    },
+    {
+      "spdxElementId": "SPDXRef-DOCUMENT",
+      "relationshipType": "DESCRIBES",
       "relatedSpdxElement": "SPDXRef-Package-95a792ac9cb6ef2b"
     },
     {
@@ -15630,6 +16972,11 @@
       "spdxElementId": "SPDXRef-DOCUMENT",
       "relationshipType": "DESCRIBES",
       "relatedSpdxElement": "SPDXRef-Package-89a61fe97490415f"
+    },
+    {
+      "spdxElementId": "SPDXRef-DOCUMENT",
+      "relationshipType": "DESCRIBES",
+      "relatedSpdxElement": "SPDXRef-Package-c7b893d84403ff14"
     },
     {
       "spdxElementId": "SPDXRef-DOCUMENT",
@@ -15719,6 +17066,16 @@
     {
       "spdxElementId": "SPDXRef-DOCUMENT",
       "relationshipType": "DESCRIBES",
+      "relatedSpdxElement": "SPDXRef-Package-066c98d78f779398"
+    },
+    {
+      "spdxElementId": "SPDXRef-DOCUMENT",
+      "relationshipType": "DESCRIBES",
+      "relatedSpdxElement": "SPDXRef-Package-8c228885d01e65b0"
+    },
+    {
+      "spdxElementId": "SPDXRef-DOCUMENT",
+      "relationshipType": "DESCRIBES",
       "relatedSpdxElement": "SPDXRef-Package-efff64b24eff87e8"
     },
     {
@@ -15794,6 +17151,11 @@
     {
       "spdxElementId": "SPDXRef-DOCUMENT",
       "relationshipType": "DESCRIBES",
+      "relatedSpdxElement": "SPDXRef-Package-8702ad5f91114f8f"
+    },
+    {
+      "spdxElementId": "SPDXRef-DOCUMENT",
+      "relationshipType": "DESCRIBES",
       "relatedSpdxElement": "SPDXRef-Package-ca014b881c253ebc"
     },
     {
@@ -15850,6 +17212,11 @@
       "spdxElementId": "SPDXRef-DOCUMENT",
       "relationshipType": "DESCRIBES",
       "relatedSpdxElement": "SPDXRef-Package-f1710245eb206d86"
+    },
+    {
+      "spdxElementId": "SPDXRef-DOCUMENT",
+      "relationshipType": "DESCRIBES",
+      "relatedSpdxElement": "SPDXRef-Package-0fe3a8dd2852340e"
     },
     {
       "spdxElementId": "SPDXRef-DOCUMENT",
@@ -15949,6 +17316,11 @@
     {
       "spdxElementId": "SPDXRef-DOCUMENT",
       "relationshipType": "DESCRIBES",
+      "relatedSpdxElement": "SPDXRef-Package-a6138fed56d8e05e"
+    },
+    {
+      "spdxElementId": "SPDXRef-DOCUMENT",
+      "relationshipType": "DESCRIBES",
       "relatedSpdxElement": "SPDXRef-Package-ca16958c815c8380"
     },
     {
@@ -15994,12 +17366,22 @@
     {
       "spdxElementId": "SPDXRef-DOCUMENT",
       "relationshipType": "DESCRIBES",
+      "relatedSpdxElement": "SPDXRef-Package-41bbec0dae5bac67"
+    },
+    {
+      "spdxElementId": "SPDXRef-DOCUMENT",
+      "relationshipType": "DESCRIBES",
       "relatedSpdxElement": "SPDXRef-Package-1bf8b3e308414474"
     },
     {
       "spdxElementId": "SPDXRef-DOCUMENT",
       "relationshipType": "DESCRIBES",
       "relatedSpdxElement": "SPDXRef-Package-0ed4bf4ae6371945"
+    },
+    {
+      "spdxElementId": "SPDXRef-DOCUMENT",
+      "relationshipType": "DESCRIBES",
+      "relatedSpdxElement": "SPDXRef-Package-93b34ac704832584"
     },
     {
       "spdxElementId": "SPDXRef-DOCUMENT",
@@ -16229,12 +17611,22 @@
     {
       "spdxElementId": "SPDXRef-DOCUMENT",
       "relationshipType": "DESCRIBES",
+      "relatedSpdxElement": "SPDXRef-Package-85cab3d3fea075b9"
+    },
+    {
+      "spdxElementId": "SPDXRef-DOCUMENT",
+      "relationshipType": "DESCRIBES",
       "relatedSpdxElement": "SPDXRef-Package-dc65c95b58f6df34"
     },
     {
       "spdxElementId": "SPDXRef-DOCUMENT",
       "relationshipType": "DESCRIBES",
       "relatedSpdxElement": "SPDXRef-Package-aaecb0d5f9d49a47"
+    },
+    {
+      "spdxElementId": "SPDXRef-DOCUMENT",
+      "relationshipType": "DESCRIBES",
+      "relatedSpdxElement": "SPDXRef-Package-a12a1c81551b29a0"
     },
     {
       "spdxElementId": "SPDXRef-DOCUMENT",
@@ -16274,7 +17666,62 @@
     {
       "spdxElementId": "SPDXRef-DOCUMENT",
       "relationshipType": "DESCRIBES",
+      "relatedSpdxElement": "SPDXRef-Package-a3a0c53acb8c1dcc"
+    },
+    {
+      "spdxElementId": "SPDXRef-DOCUMENT",
+      "relationshipType": "DESCRIBES",
+      "relatedSpdxElement": "SPDXRef-Package-0264c095c57bc5cf"
+    },
+    {
+      "spdxElementId": "SPDXRef-DOCUMENT",
+      "relationshipType": "DESCRIBES",
+      "relatedSpdxElement": "SPDXRef-Package-de4b3a9e90ea9774"
+    },
+    {
+      "spdxElementId": "SPDXRef-DOCUMENT",
+      "relationshipType": "DESCRIBES",
+      "relatedSpdxElement": "SPDXRef-Package-0729f90dee660e49"
+    },
+    {
+      "spdxElementId": "SPDXRef-DOCUMENT",
+      "relationshipType": "DESCRIBES",
+      "relatedSpdxElement": "SPDXRef-Package-ff4c49b4828c9e19"
+    },
+    {
+      "spdxElementId": "SPDXRef-DOCUMENT",
+      "relationshipType": "DESCRIBES",
       "relatedSpdxElement": "SPDXRef-Package-a1ca8608b85fb076"
+    },
+    {
+      "spdxElementId": "SPDXRef-DOCUMENT",
+      "relationshipType": "DESCRIBES",
+      "relatedSpdxElement": "SPDXRef-Package-db45f10bd3ef5fb5"
+    },
+    {
+      "spdxElementId": "SPDXRef-DOCUMENT",
+      "relationshipType": "DESCRIBES",
+      "relatedSpdxElement": "SPDXRef-Package-4fbfd070c92eb053"
+    },
+    {
+      "spdxElementId": "SPDXRef-DOCUMENT",
+      "relationshipType": "DESCRIBES",
+      "relatedSpdxElement": "SPDXRef-Package-48d573eae5c4cd81"
+    },
+    {
+      "spdxElementId": "SPDXRef-DOCUMENT",
+      "relationshipType": "DESCRIBES",
+      "relatedSpdxElement": "SPDXRef-Package-45270f7cf55ec688"
+    },
+    {
+      "spdxElementId": "SPDXRef-DOCUMENT",
+      "relationshipType": "DESCRIBES",
+      "relatedSpdxElement": "SPDXRef-Package-715a4dee5083b138"
+    },
+    {
+      "spdxElementId": "SPDXRef-DOCUMENT",
+      "relationshipType": "DESCRIBES",
+      "relatedSpdxElement": "SPDXRef-Package-395eddedb8745a8f"
     },
     {
       "spdxElementId": "SPDXRef-DOCUMENT",
@@ -16290,6 +17737,16 @@
       "spdxElementId": "SPDXRef-DOCUMENT",
       "relationshipType": "DESCRIBES",
       "relatedSpdxElement": "SPDXRef-Package-a6e12dc74e4896ce"
+    },
+    {
+      "spdxElementId": "SPDXRef-DOCUMENT",
+      "relationshipType": "DESCRIBES",
+      "relatedSpdxElement": "SPDXRef-Package-57a1e9a5e166604b"
+    },
+    {
+      "spdxElementId": "SPDXRef-DOCUMENT",
+      "relationshipType": "DESCRIBES",
+      "relatedSpdxElement": "SPDXRef-Package-ce721e649dfb1e5c"
     },
     {
       "spdxElementId": "SPDXRef-DOCUMENT",
@@ -16649,6 +18106,21 @@
     {
       "spdxElementId": "SPDXRef-DOCUMENT",
       "relationshipType": "DESCRIBES",
+      "relatedSpdxElement": "SPDXRef-Package-588f964b04a1a148"
+    },
+    {
+      "spdxElementId": "SPDXRef-DOCUMENT",
+      "relationshipType": "DESCRIBES",
+      "relatedSpdxElement": "SPDXRef-Package-40d05b19a4e7d885"
+    },
+    {
+      "spdxElementId": "SPDXRef-DOCUMENT",
+      "relationshipType": "DESCRIBES",
+      "relatedSpdxElement": "SPDXRef-Package-9b652aa8c82e5af7"
+    },
+    {
+      "spdxElementId": "SPDXRef-DOCUMENT",
+      "relationshipType": "DESCRIBES",
       "relatedSpdxElement": "SPDXRef-Package-9a47e0282c0c109e"
     },
     {
@@ -16699,6 +18171,11 @@
     {
       "spdxElementId": "SPDXRef-DOCUMENT",
       "relationshipType": "DESCRIBES",
+      "relatedSpdxElement": "SPDXRef-Package-351e1526e0c140ae"
+    },
+    {
+      "spdxElementId": "SPDXRef-DOCUMENT",
+      "relationshipType": "DESCRIBES",
       "relatedSpdxElement": "SPDXRef-Package-ee090ad491ba86cf"
     },
     {
@@ -16735,6 +18212,11 @@
       "spdxElementId": "SPDXRef-DOCUMENT",
       "relationshipType": "DESCRIBES",
       "relatedSpdxElement": "SPDXRef-Package-4a60f58708d5b311"
+    },
+    {
+      "spdxElementId": "SPDXRef-DOCUMENT",
+      "relationshipType": "DESCRIBES",
+      "relatedSpdxElement": "SPDXRef-Package-e6a9afc20b6a5b4f"
     },
     {
       "spdxElementId": "SPDXRef-DOCUMENT",
@@ -16844,6 +18326,11 @@
     {
       "spdxElementId": "SPDXRef-DOCUMENT",
       "relationshipType": "DESCRIBES",
+      "relatedSpdxElement": "SPDXRef-Package-79f253dbdc64eb00"
+    },
+    {
+      "spdxElementId": "SPDXRef-DOCUMENT",
+      "relationshipType": "DESCRIBES",
       "relatedSpdxElement": "SPDXRef-Package-fdd7a87411d74d56"
     },
     {
@@ -16895,6 +18382,11 @@
       "spdxElementId": "SPDXRef-DOCUMENT",
       "relationshipType": "DESCRIBES",
       "relatedSpdxElement": "SPDXRef-Package-357a328a448d93cd"
+    },
+    {
+      "spdxElementId": "SPDXRef-DOCUMENT",
+      "relationshipType": "DESCRIBES",
+      "relatedSpdxElement": "SPDXRef-Package-8406d74ee701100f"
     },
     {
       "spdxElementId": "SPDXRef-DOCUMENT",
@@ -17019,6 +18511,11 @@
     {
       "spdxElementId": "SPDXRef-DOCUMENT",
       "relationshipType": "DESCRIBES",
+      "relatedSpdxElement": "SPDXRef-Package-c8b1e190ece36b5b"
+    },
+    {
+      "spdxElementId": "SPDXRef-DOCUMENT",
+      "relationshipType": "DESCRIBES",
       "relatedSpdxElement": "SPDXRef-Package-c99f309bb22fcd34"
     },
     {
@@ -17089,6 +18586,11 @@
     {
       "spdxElementId": "SPDXRef-DOCUMENT",
       "relationshipType": "DESCRIBES",
+      "relatedSpdxElement": "SPDXRef-Package-8c907a9e46ec42ff"
+    },
+    {
+      "spdxElementId": "SPDXRef-DOCUMENT",
+      "relationshipType": "DESCRIBES",
       "relatedSpdxElement": "SPDXRef-Package-046eb40b35cfc8f2"
     },
     {
@@ -17149,6 +18651,11 @@
     {
       "spdxElementId": "SPDXRef-DOCUMENT",
       "relationshipType": "DESCRIBES",
+      "relatedSpdxElement": "SPDXRef-Package-1b50db6d94db0196"
+    },
+    {
+      "spdxElementId": "SPDXRef-DOCUMENT",
+      "relationshipType": "DESCRIBES",
       "relatedSpdxElement": "SPDXRef-Package-7fd5189f1498eda2"
     },
     {
@@ -17190,6 +18697,16 @@
       "spdxElementId": "SPDXRef-DOCUMENT",
       "relationshipType": "DESCRIBES",
       "relatedSpdxElement": "SPDXRef-Package-5941030fc7f193de"
+    },
+    {
+      "spdxElementId": "SPDXRef-DOCUMENT",
+      "relationshipType": "DESCRIBES",
+      "relatedSpdxElement": "SPDXRef-Package-6d51ff5f61437558"
+    },
+    {
+      "spdxElementId": "SPDXRef-DOCUMENT",
+      "relationshipType": "DESCRIBES",
+      "relatedSpdxElement": "SPDXRef-Package-95cdee6f7d557d13"
     },
     {
       "spdxElementId": "SPDXRef-DOCUMENT",
@@ -17444,7 +18961,17 @@
     {
       "spdxElementId": "SPDXRef-DOCUMENT",
       "relationshipType": "DESCRIBES",
+      "relatedSpdxElement": "SPDXRef-Package-b335f2d01d3ed9cf"
+    },
+    {
+      "spdxElementId": "SPDXRef-DOCUMENT",
+      "relationshipType": "DESCRIBES",
       "relatedSpdxElement": "SPDXRef-Package-c834291cf2535d86"
+    },
+    {
+      "spdxElementId": "SPDXRef-DOCUMENT",
+      "relationshipType": "DESCRIBES",
+      "relatedSpdxElement": "SPDXRef-Package-a141076283aa9950"
     },
     {
       "spdxElementId": "SPDXRef-DOCUMENT",
@@ -17519,6 +19046,11 @@
     {
       "spdxElementId": "SPDXRef-DOCUMENT",
       "relationshipType": "DESCRIBES",
+      "relatedSpdxElement": "SPDXRef-Package-a3e23d7a1173dbbf"
+    },
+    {
+      "spdxElementId": "SPDXRef-DOCUMENT",
+      "relationshipType": "DESCRIBES",
       "relatedSpdxElement": "SPDXRef-Package-a85d345236e133c0"
     },
     {
@@ -17574,6 +19106,11 @@
     {
       "spdxElementId": "SPDXRef-DOCUMENT",
       "relationshipType": "DESCRIBES",
+      "relatedSpdxElement": "SPDXRef-Package-0691de763eddddc8"
+    },
+    {
+      "spdxElementId": "SPDXRef-DOCUMENT",
+      "relationshipType": "DESCRIBES",
       "relatedSpdxElement": "SPDXRef-Package-86b9d1cd1856870a"
     },
     {
@@ -17605,6 +19142,11 @@
       "spdxElementId": "SPDXRef-DOCUMENT",
       "relationshipType": "DESCRIBES",
       "relatedSpdxElement": "SPDXRef-Package-0ba81ad163d7682e"
+    },
+    {
+      "spdxElementId": "SPDXRef-DOCUMENT",
+      "relationshipType": "DESCRIBES",
+      "relatedSpdxElement": "SPDXRef-Package-781eb11958365689"
     },
     {
       "spdxElementId": "SPDXRef-DOCUMENT",
@@ -17689,6 +19231,21 @@
     {
       "spdxElementId": "SPDXRef-DOCUMENT",
       "relationshipType": "DESCRIBES",
+      "relatedSpdxElement": "SPDXRef-Package-952c31231ba66670"
+    },
+    {
+      "spdxElementId": "SPDXRef-DOCUMENT",
+      "relationshipType": "DESCRIBES",
+      "relatedSpdxElement": "SPDXRef-Package-db9ebd25cef24c8f"
+    },
+    {
+      "spdxElementId": "SPDXRef-DOCUMENT",
+      "relationshipType": "DESCRIBES",
+      "relatedSpdxElement": "SPDXRef-Package-bd49bc058ac56fd1"
+    },
+    {
+      "spdxElementId": "SPDXRef-DOCUMENT",
+      "relationshipType": "DESCRIBES",
       "relatedSpdxElement": "SPDXRef-Package-8e532c67f7b65656"
     },
     {
@@ -17705,6 +19262,11 @@
       "spdxElementId": "SPDXRef-DOCUMENT",
       "relationshipType": "DESCRIBES",
       "relatedSpdxElement": "SPDXRef-Package-0d53ff1f3e7f8816"
+    },
+    {
+      "spdxElementId": "SPDXRef-DOCUMENT",
+      "relationshipType": "DESCRIBES",
+      "relatedSpdxElement": "SPDXRef-Package-83f742740c720c8e"
     },
     {
       "spdxElementId": "SPDXRef-DOCUMENT",

--- a/docs/legal/notices/sbom/desktop-win.spdx.json
+++ b/docs/legal/notices/sbom/desktop-win.spdx.json
@@ -3,9 +3,9 @@
   "dataLicense": "CC0-1.0",
   "SPDXID": "SPDXRef-DOCUMENT",
   "name": "cindy-desktop-win",
-  "documentNamespace": "https://cindy.app/spdx/desktop-win/1be344db12c8580ca201f06bafbcbbe814d8770eb6125c34cc23a1742b1a628a",
+  "documentNamespace": "https://cindy.app/spdx/desktop-win/ac14fb1f2d54c0846455923676ea186d8e1cce596d7a5f691364eebf835e0868",
   "creationInfo": {
-    "created": "2026-08-14T10:29:27Z",
+    "created": "2026-09-02T19:21:04Z",
     "creators": [
       "Tool: scripts/generate-third-party-notices.mjs"
     ]
@@ -103,8 +103,8 @@
     },
     {
       "name": "pi coding agent (runtime-downloaded binary)",
-      "SPDXID": "SPDXRef-Package-04c1add3e48a9e5c",
-      "versionInfo": "0.83.0",
+      "SPDXID": "SPDXRef-Package-a3cbdbce86e6fdc7",
+      "versionInfo": "0.84.4",
       "downloadLocation": "https://github.com/earendil-works/pi",
       "filesAnalyzed": false,
       "licenseConcluded": "MIT",
@@ -4718,6 +4718,57 @@
       ]
     },
     {
+      "name": "@babel/helper-string-parser",
+      "SPDXID": "SPDXRef-Package-2d6a4b723df29496",
+      "versionInfo": "7.29.7",
+      "downloadLocation": "https://github.com/babel/babel",
+      "filesAnalyzed": false,
+      "licenseConcluded": "MIT",
+      "licenseDeclared": "MIT",
+      "copyrightText": "NOASSERTION",
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceType": "purl",
+          "referenceLocator": "pkg:npm/%40babel/helper-string-parser@7.29.7"
+        }
+      ]
+    },
+    {
+      "name": "@babel/helper-validator-identifier",
+      "SPDXID": "SPDXRef-Package-d10d1f341d4abfa8",
+      "versionInfo": "7.29.7",
+      "downloadLocation": "https://github.com/babel/babel",
+      "filesAnalyzed": false,
+      "licenseConcluded": "MIT",
+      "licenseDeclared": "MIT",
+      "copyrightText": "NOASSERTION",
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceType": "purl",
+          "referenceLocator": "pkg:npm/%40babel/helper-validator-identifier@7.29.7"
+        }
+      ]
+    },
+    {
+      "name": "@babel/parser",
+      "SPDXID": "SPDXRef-Package-bae6a338f33d9a1c",
+      "versionInfo": "7.29.7",
+      "downloadLocation": "https://github.com/babel/babel",
+      "filesAnalyzed": false,
+      "licenseConcluded": "MIT",
+      "licenseDeclared": "MIT",
+      "copyrightText": "NOASSERTION",
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceType": "purl",
+          "referenceLocator": "pkg:npm/%40babel/parser@7.29.7"
+        }
+      ]
+    },
+    {
       "name": "@babel/runtime",
       "SPDXID": "SPDXRef-Package-edf04d45834b4fbf",
       "versionInfo": "7.29.7",
@@ -4731,6 +4782,23 @@
           "referenceCategory": "PACKAGE-MANAGER",
           "referenceType": "purl",
           "referenceLocator": "pkg:npm/%40babel/runtime@7.29.7"
+        }
+      ]
+    },
+    {
+      "name": "@babel/types",
+      "SPDXID": "SPDXRef-Package-3adbc0856a9bda85",
+      "versionInfo": "7.29.7",
+      "downloadLocation": "https://github.com/babel/babel",
+      "filesAnalyzed": false,
+      "licenseConcluded": "MIT",
+      "licenseDeclared": "MIT",
+      "copyrightText": "NOASSERTION",
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceType": "purl",
+          "referenceLocator": "pkg:npm/%40babel/types@7.29.7"
         }
       ]
     },
@@ -5275,6 +5343,40 @@
           "referenceCategory": "PACKAGE-MANAGER",
           "referenceType": "purl",
           "referenceLocator": "pkg:npm/%40discordjs/ws@1.2.3"
+        }
+      ]
+    },
+    {
+      "name": "@fast-csv/format",
+      "SPDXID": "SPDXRef-Package-ef09030156acbe49",
+      "versionInfo": "4.3.5",
+      "downloadLocation": "https://github.com/C2FO/fast-csv",
+      "filesAnalyzed": false,
+      "licenseConcluded": "MIT",
+      "licenseDeclared": "MIT",
+      "copyrightText": "NOASSERTION",
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceType": "purl",
+          "referenceLocator": "pkg:npm/%40fast-csv/format@4.3.5"
+        }
+      ]
+    },
+    {
+      "name": "@fast-csv/parse",
+      "SPDXID": "SPDXRef-Package-f4baae4686e02f0a",
+      "versionInfo": "4.3.6",
+      "downloadLocation": "https://github.com/C2FO/fast-csv",
+      "filesAnalyzed": false,
+      "licenseConcluded": "MIT",
+      "licenseDeclared": "MIT",
+      "copyrightText": "NOASSERTION",
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceType": "purl",
+          "referenceLocator": "pkg:npm/%40fast-csv/parse@4.3.6"
         }
       ]
     },
@@ -7881,6 +7983,40 @@
     },
     {
       "name": "@types/node",
+      "SPDXID": "SPDXRef-Package-c6b0b3ef4062e7b5",
+      "versionInfo": "14.18.63",
+      "downloadLocation": "https://github.com/DefinitelyTyped/DefinitelyTyped",
+      "filesAnalyzed": false,
+      "licenseConcluded": "MIT",
+      "licenseDeclared": "MIT",
+      "copyrightText": "NOASSERTION",
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceType": "purl",
+          "referenceLocator": "pkg:npm/%40types/node@14.18.63"
+        }
+      ]
+    },
+    {
+      "name": "@types/node",
+      "SPDXID": "SPDXRef-Package-006d2bce93d8f1dd",
+      "versionInfo": "22.20.1",
+      "downloadLocation": "https://github.com/DefinitelyTyped/DefinitelyTyped",
+      "filesAnalyzed": false,
+      "licenseConcluded": "MIT",
+      "licenseDeclared": "MIT",
+      "copyrightText": "NOASSERTION",
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceType": "purl",
+          "referenceLocator": "pkg:npm/%40types/node@22.20.1"
+        }
+      ]
+    },
+    {
+      "name": "@types/node",
       "SPDXID": "SPDXRef-Package-b02ebf6599a4715f",
       "versionInfo": "25.9.5",
       "downloadLocation": "https://github.com/DefinitelyTyped/DefinitelyTyped",
@@ -8305,6 +8441,57 @@
       ]
     },
     {
+      "name": "archiver",
+      "SPDXID": "SPDXRef-Package-9135483032251fea",
+      "versionInfo": "5.3.2",
+      "downloadLocation": "https://github.com/archiverjs/node-archiver",
+      "filesAnalyzed": false,
+      "licenseConcluded": "MIT",
+      "licenseDeclared": "MIT",
+      "copyrightText": "NOASSERTION",
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceType": "purl",
+          "referenceLocator": "pkg:npm/archiver@5.3.2"
+        }
+      ]
+    },
+    {
+      "name": "archiver-utils",
+      "SPDXID": "SPDXRef-Package-e4af001b994a14f4",
+      "versionInfo": "2.1.0",
+      "downloadLocation": "https://github.com/archiverjs/archiver-utils",
+      "filesAnalyzed": false,
+      "licenseConcluded": "MIT",
+      "licenseDeclared": "MIT",
+      "copyrightText": "NOASSERTION",
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceType": "purl",
+          "referenceLocator": "pkg:npm/archiver-utils@2.1.0"
+        }
+      ]
+    },
+    {
+      "name": "archiver-utils",
+      "SPDXID": "SPDXRef-Package-f7b326a32927cbed",
+      "versionInfo": "3.0.4",
+      "downloadLocation": "https://github.com/archiverjs/archiver-utils",
+      "filesAnalyzed": false,
+      "licenseConcluded": "MIT",
+      "licenseDeclared": "MIT",
+      "copyrightText": "NOASSERTION",
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceType": "purl",
+          "referenceLocator": "pkg:npm/archiver-utils@3.0.4"
+        }
+      ]
+    },
+    {
       "name": "argparse",
       "SPDXID": "SPDXRef-Package-1b8ff3f05bffff87",
       "versionInfo": "1.0.10",
@@ -8369,6 +8556,23 @@
           "referenceCategory": "PACKAGE-MANAGER",
           "referenceType": "purl",
           "referenceLocator": "pkg:npm/asn1@0.2.6"
+        }
+      ]
+    },
+    {
+      "name": "async",
+      "SPDXID": "SPDXRef-Package-1faad319f76b179f",
+      "versionInfo": "3.2.6",
+      "downloadLocation": "https://github.com/caolan/async",
+      "filesAnalyzed": false,
+      "licenseConcluded": "MIT",
+      "licenseDeclared": "MIT",
+      "copyrightText": "NOASSERTION",
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceType": "purl",
+          "referenceLocator": "pkg:npm/async@3.2.6"
         }
       ]
     },
@@ -8509,6 +8713,23 @@
       ]
     },
     {
+      "name": "big-integer",
+      "SPDXID": "SPDXRef-Package-d4c964d5752fd254",
+      "versionInfo": "1.6.52",
+      "downloadLocation": "https://github.com/peterolson/BigInteger.js",
+      "filesAnalyzed": false,
+      "licenseConcluded": "Unlicense",
+      "licenseDeclared": "Unlicense",
+      "copyrightText": "NOASSERTION",
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceType": "purl",
+          "referenceLocator": "pkg:npm/big-integer@1.6.52"
+        }
+      ]
+    },
+    {
       "name": "bignumber.js",
       "SPDXID": "SPDXRef-Package-e6bcaebbcb046dc4",
       "versionInfo": "9.3.1",
@@ -8522,6 +8743,23 @@
           "referenceCategory": "PACKAGE-MANAGER",
           "referenceType": "purl",
           "referenceLocator": "pkg:npm/bignumber.js@9.3.1"
+        }
+      ]
+    },
+    {
+      "name": "binary",
+      "SPDXID": "SPDXRef-Package-169094cbdc1389db",
+      "versionInfo": "0.3.0",
+      "downloadLocation": "http://github.com/substack/node-binary",
+      "filesAnalyzed": false,
+      "licenseConcluded": "MIT",
+      "licenseDeclared": "MIT",
+      "copyrightText": "NOASSERTION",
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceType": "purl",
+          "referenceLocator": "pkg:npm/binary@0.3.0"
         }
       ]
     },
@@ -8560,6 +8798,23 @@
       ]
     },
     {
+      "name": "bluebird",
+      "SPDXID": "SPDXRef-Package-281d2b6b5950a4ba",
+      "versionInfo": "3.4.7",
+      "downloadLocation": "https://github.com/petkaantonov/bluebird",
+      "filesAnalyzed": false,
+      "licenseConcluded": "MIT",
+      "licenseDeclared": "MIT",
+      "copyrightText": "NOASSERTION",
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceType": "purl",
+          "referenceLocator": "pkg:npm/bluebird@3.4.7"
+        }
+      ]
+    },
+    {
       "name": "body-parser",
       "SPDXID": "SPDXRef-Package-603bfb1d8a6cd096",
       "versionInfo": "2.3.0",
@@ -8573,6 +8828,23 @@
           "referenceCategory": "PACKAGE-MANAGER",
           "referenceType": "purl",
           "referenceLocator": "pkg:npm/body-parser@2.3.0"
+        }
+      ]
+    },
+    {
+      "name": "brace-expansion",
+      "SPDXID": "SPDXRef-Package-3a4b46a93421a532",
+      "versionInfo": "1.1.16",
+      "downloadLocation": "https://github.com/juliangruber/brace-expansion",
+      "filesAnalyzed": false,
+      "licenseConcluded": "MIT",
+      "licenseDeclared": "MIT",
+      "copyrightText": "NOASSERTION",
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceType": "purl",
+          "referenceLocator": "pkg:npm/brace-expansion@1.1.16"
         }
       ]
     },
@@ -8611,6 +8883,23 @@
       ]
     },
     {
+      "name": "buffer-crc32",
+      "SPDXID": "SPDXRef-Package-3f07b92fa45ba611",
+      "versionInfo": "0.2.13",
+      "downloadLocation": "https://github.com/brianloveswords/buffer-crc32",
+      "filesAnalyzed": false,
+      "licenseConcluded": "MIT",
+      "licenseDeclared": "MIT",
+      "copyrightText": "NOASSERTION",
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceType": "purl",
+          "referenceLocator": "pkg:npm/buffer-crc32@0.2.13"
+        }
+      ]
+    },
+    {
       "name": "buffer-equal-constant-time",
       "SPDXID": "SPDXRef-Package-2f4ce0cccb4ed6f4",
       "versionInfo": "1.0.1",
@@ -8624,6 +8913,40 @@
           "referenceCategory": "PACKAGE-MANAGER",
           "referenceType": "purl",
           "referenceLocator": "pkg:npm/buffer-equal-constant-time@1.0.1"
+        }
+      ]
+    },
+    {
+      "name": "buffer-indexof-polyfill",
+      "SPDXID": "SPDXRef-Package-62eb5a03ebf03674",
+      "versionInfo": "1.0.2",
+      "downloadLocation": "https://github.com/sarosia/buffer-indexof-polyfill",
+      "filesAnalyzed": false,
+      "licenseConcluded": "MIT",
+      "licenseDeclared": "MIT",
+      "copyrightText": "NOASSERTION",
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceType": "purl",
+          "referenceLocator": "pkg:npm/buffer-indexof-polyfill@1.0.2"
+        }
+      ]
+    },
+    {
+      "name": "buffers",
+      "SPDXID": "SPDXRef-Package-8e3f307fa2ee1e16",
+      "versionInfo": "0.1.1",
+      "downloadLocation": "http://github.com/substack/node-buffers",
+      "filesAnalyzed": false,
+      "licenseConcluded": "MIT",
+      "licenseDeclared": "MIT",
+      "copyrightText": "NOASSERTION",
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceType": "purl",
+          "referenceLocator": "pkg:npm/buffers@0.1.1"
         }
       ]
     },
@@ -8743,6 +9066,23 @@
           "referenceCategory": "PACKAGE-MANAGER",
           "referenceType": "purl",
           "referenceLocator": "pkg:npm/ccount@2.0.1"
+        }
+      ]
+    },
+    {
+      "name": "chainsaw",
+      "SPDXID": "SPDXRef-Package-b114758f8c10a13e",
+      "versionInfo": "0.1.0",
+      "downloadLocation": "http://github.com/substack/node-chainsaw",
+      "filesAnalyzed": false,
+      "licenseConcluded": "MIT",
+      "licenseDeclared": "MIT",
+      "copyrightText": "NOASSERTION",
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceType": "purl",
+          "referenceLocator": "pkg:npm/chainsaw@0.1.0"
         }
       ]
     },
@@ -9019,6 +9359,40 @@
       ]
     },
     {
+      "name": "compress-commons",
+      "SPDXID": "SPDXRef-Package-e77e224d03910af4",
+      "versionInfo": "4.1.2",
+      "downloadLocation": "https://github.com/archiverjs/node-compress-commons",
+      "filesAnalyzed": false,
+      "licenseConcluded": "MIT",
+      "licenseDeclared": "MIT",
+      "copyrightText": "NOASSERTION",
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceType": "purl",
+          "referenceLocator": "pkg:npm/compress-commons@4.1.2"
+        }
+      ]
+    },
+    {
+      "name": "concat-map",
+      "SPDXID": "SPDXRef-Package-446fb7e0d413f4e8",
+      "versionInfo": "0.0.1",
+      "downloadLocation": "https://github.com/substack/node-concat-map",
+      "filesAnalyzed": false,
+      "licenseConcluded": "MIT",
+      "licenseDeclared": "MIT",
+      "copyrightText": "NOASSERTION",
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceType": "purl",
+          "referenceLocator": "pkg:npm/concat-map@0.0.1"
+        }
+      ]
+    },
+    {
       "name": "conf",
       "SPDXID": "SPDXRef-Package-4b508a608e7c9c35",
       "versionInfo": "9.0.2",
@@ -9219,6 +9593,40 @@
           "referenceCategory": "PACKAGE-MANAGER",
           "referenceType": "purl",
           "referenceLocator": "pkg:npm/cpu-features@0.0.10"
+        }
+      ]
+    },
+    {
+      "name": "crc-32",
+      "SPDXID": "SPDXRef-Package-7b769d3a0b61c741",
+      "versionInfo": "1.2.2",
+      "downloadLocation": "https://github.com/SheetJS/js-crc32",
+      "filesAnalyzed": false,
+      "licenseConcluded": "Apache-2.0",
+      "licenseDeclared": "Apache-2.0",
+      "copyrightText": "NOASSERTION",
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceType": "purl",
+          "referenceLocator": "pkg:npm/crc-32@1.2.2"
+        }
+      ]
+    },
+    {
+      "name": "crc32-stream",
+      "SPDXID": "SPDXRef-Package-3bd6e89d41e1b16e",
+      "versionInfo": "4.0.3",
+      "downloadLocation": "https://github.com/archiverjs/node-crc32-stream",
+      "filesAnalyzed": false,
+      "licenseConcluded": "MIT",
+      "licenseDeclared": "MIT",
+      "copyrightText": "NOASSERTION",
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceType": "purl",
+          "referenceLocator": "pkg:npm/crc32-stream@4.0.3"
         }
       ]
     },
@@ -10311,6 +10719,23 @@
       ]
     },
     {
+      "name": "docx",
+      "SPDXID": "SPDXRef-Package-5fcae62518b2d23a",
+      "versionInfo": "9.7.1",
+      "downloadLocation": "https://github.com/dolanmiu/docx",
+      "filesAnalyzed": false,
+      "licenseConcluded": "MIT",
+      "licenseDeclared": "MIT",
+      "copyrightText": "NOASSERTION",
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceType": "purl",
+          "referenceLocator": "pkg:npm/docx@9.7.1"
+        }
+      ]
+    },
+    {
       "name": "dompurify",
       "SPDXID": "SPDXRef-Package-fe4205b186c43bb8",
       "versionInfo": "3.4.12",
@@ -10375,6 +10800,23 @@
           "referenceCategory": "PACKAGE-MANAGER",
           "referenceType": "purl",
           "referenceLocator": "pkg:npm/dunder-proto@1.0.1"
+        }
+      ]
+    },
+    {
+      "name": "duplexer2",
+      "SPDXID": "SPDXRef-Package-5203e1981b9684d9",
+      "versionInfo": "0.1.4",
+      "downloadLocation": "https://github.com/deoxxa/duplexer2",
+      "filesAnalyzed": false,
+      "licenseConcluded": "BSD-3-Clause",
+      "licenseDeclared": "BSD-3-Clause",
+      "copyrightText": "NOASSERTION",
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceType": "purl",
+          "referenceLocator": "pkg:npm/duplexer2@0.1.4"
         }
       ]
     },
@@ -10804,6 +11246,23 @@
       ]
     },
     {
+      "name": "exceljs",
+      "SPDXID": "SPDXRef-Package-a037ed657533f4f1",
+      "versionInfo": "4.4.0",
+      "downloadLocation": "https://github.com/exceljs/exceljs",
+      "filesAnalyzed": false,
+      "licenseConcluded": "MIT",
+      "licenseDeclared": "MIT",
+      "copyrightText": "NOASSERTION",
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceType": "purl",
+          "referenceLocator": "pkg:npm/exceljs@4.4.0"
+        }
+      ]
+    },
+    {
       "name": "execa",
       "SPDXID": "SPDXRef-Package-95a792ac9cb6ef2b",
       "versionInfo": "4.1.0",
@@ -10919,6 +11378,23 @@
           "referenceCategory": "PACKAGE-MANAGER",
           "referenceType": "purl",
           "referenceLocator": "pkg:npm/extend-shallow@2.0.1"
+        }
+      ]
+    },
+    {
+      "name": "fast-csv",
+      "SPDXID": "SPDXRef-Package-c7b893d84403ff14",
+      "versionInfo": "4.3.6",
+      "downloadLocation": "https://github.com/C2FO/fast-csv",
+      "filesAnalyzed": false,
+      "licenseConcluded": "MIT",
+      "licenseDeclared": "MIT",
+      "copyrightText": "NOASSERTION",
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceType": "purl",
+          "referenceLocator": "pkg:npm/fast-csv@4.3.6"
         }
       ]
     },
@@ -11212,6 +11688,40 @@
       ]
     },
     {
+      "name": "fs.realpath",
+      "SPDXID": "SPDXRef-Package-066c98d78f779398",
+      "versionInfo": "1.0.0",
+      "downloadLocation": "https://github.com/isaacs/fs.realpath",
+      "filesAnalyzed": false,
+      "licenseConcluded": "ISC",
+      "licenseDeclared": "ISC",
+      "copyrightText": "NOASSERTION",
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceType": "purl",
+          "referenceLocator": "pkg:npm/fs.realpath@1.0.0"
+        }
+      ]
+    },
+    {
+      "name": "fstream",
+      "SPDXID": "SPDXRef-Package-8c228885d01e65b0",
+      "versionInfo": "1.0.12",
+      "downloadLocation": "https://github.com/npm/fstream",
+      "filesAnalyzed": false,
+      "licenseConcluded": "ISC",
+      "licenseDeclared": "ISC",
+      "copyrightText": "NOASSERTION",
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceType": "purl",
+          "referenceLocator": "pkg:npm/fstream@1.0.12"
+        }
+      ]
+    },
+    {
       "name": "function-bind",
       "SPDXID": "SPDXRef-Package-efff64b24eff87e8",
       "versionInfo": "1.1.2",
@@ -11467,6 +11977,23 @@
       ]
     },
     {
+      "name": "glob",
+      "SPDXID": "SPDXRef-Package-8702ad5f91114f8f",
+      "versionInfo": "7.2.3",
+      "downloadLocation": "https://github.com/isaacs/node-glob",
+      "filesAnalyzed": false,
+      "licenseConcluded": "ISC",
+      "licenseDeclared": "ISC",
+      "copyrightText": "NOASSERTION",
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceType": "purl",
+          "referenceLocator": "pkg:npm/glob@7.2.3"
+        }
+      ]
+    },
+    {
       "name": "google-auth-library",
       "SPDXID": "SPDXRef-Package-ca014b881c253ebc",
       "versionInfo": "10.5.0",
@@ -11667,6 +12194,23 @@
           "referenceCategory": "PACKAGE-MANAGER",
           "referenceType": "purl",
           "referenceLocator": "pkg:npm/has-tostringtag@1.0.2"
+        }
+      ]
+    },
+    {
+      "name": "hash.js",
+      "SPDXID": "SPDXRef-Package-0fe3a8dd2852340e",
+      "versionInfo": "1.1.7",
+      "downloadLocation": "https://github.com/indutny/hash.js",
+      "filesAnalyzed": false,
+      "licenseConcluded": "MIT",
+      "licenseDeclared": "MIT",
+      "copyrightText": "NOASSERTION",
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceType": "purl",
+          "referenceLocator": "pkg:npm/hash.js@1.1.7"
         }
       ]
     },
@@ -11994,6 +12538,23 @@
       ]
     },
     {
+      "name": "https",
+      "SPDXID": "SPDXRef-Package-a6138fed56d8e05e",
+      "versionInfo": "1.0.0",
+      "downloadLocation": "NOASSERTION",
+      "filesAnalyzed": false,
+      "licenseConcluded": "ISC",
+      "licenseDeclared": "ISC",
+      "copyrightText": "NOASSERTION",
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceType": "purl",
+          "referenceLocator": "pkg:npm/https@1.0.0"
+        }
+      ]
+    },
+    {
       "name": "https-proxy-agent",
       "SPDXID": "SPDXRef-Package-ca16958c815c8380",
       "versionInfo": "5.0.1",
@@ -12147,6 +12708,23 @@
       ]
     },
     {
+      "name": "image-size",
+      "SPDXID": "SPDXRef-Package-41bbec0dae5bac67",
+      "versionInfo": "1.2.1",
+      "downloadLocation": "https://github.com/image-size/image-size",
+      "filesAnalyzed": false,
+      "licenseConcluded": "MIT",
+      "licenseDeclared": "MIT",
+      "copyrightText": "NOASSERTION",
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceType": "purl",
+          "referenceLocator": "pkg:npm/image-size@1.2.1"
+        }
+      ]
+    },
+    {
       "name": "immediate",
       "SPDXID": "SPDXRef-Package-1bf8b3e308414474",
       "versionInfo": "3.0.6",
@@ -12177,6 +12755,23 @@
           "referenceCategory": "PACKAGE-MANAGER",
           "referenceType": "purl",
           "referenceLocator": "pkg:npm/import-meta-resolve@4.2.0"
+        }
+      ]
+    },
+    {
+      "name": "inflight",
+      "SPDXID": "SPDXRef-Package-93b34ac704832584",
+      "versionInfo": "1.0.6",
+      "downloadLocation": "https://github.com/npm/inflight",
+      "filesAnalyzed": false,
+      "licenseConcluded": "ISC",
+      "licenseDeclared": "ISC",
+      "copyrightText": "NOASSERTION",
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceType": "purl",
+          "referenceLocator": "pkg:npm/inflight@1.0.6"
         }
       ]
     },
@@ -12946,6 +13541,23 @@
       ]
     },
     {
+      "name": "lazystream",
+      "SPDXID": "SPDXRef-Package-85cab3d3fea075b9",
+      "versionInfo": "1.0.1",
+      "downloadLocation": "https://github.com/jpommerening/node-lazystream",
+      "filesAnalyzed": false,
+      "licenseConcluded": "MIT",
+      "licenseDeclared": "MIT",
+      "copyrightText": "NOASSERTION",
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceType": "purl",
+          "referenceLocator": "pkg:npm/lazystream@1.0.1"
+        }
+      ]
+    },
+    {
       "name": "lcid",
       "SPDXID": "SPDXRef-Package-dc65c95b58f6df34",
       "versionInfo": "3.1.1",
@@ -12976,6 +13588,23 @@
           "referenceCategory": "PACKAGE-MANAGER",
           "referenceType": "purl",
           "referenceLocator": "pkg:npm/lie@3.3.0"
+        }
+      ]
+    },
+    {
+      "name": "listenercount",
+      "SPDXID": "SPDXRef-Package-a12a1c81551b29a0",
+      "versionInfo": "1.0.1",
+      "downloadLocation": "https://github.com/jden/node-listenercount",
+      "filesAnalyzed": false,
+      "licenseConcluded": "ISC",
+      "licenseDeclared": "ISC",
+      "copyrightText": "NOASSERTION",
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceType": "purl",
+          "referenceLocator": "pkg:npm/listenercount@1.0.1"
         }
       ]
     },
@@ -13099,6 +13728,91 @@
       ]
     },
     {
+      "name": "lodash.defaults",
+      "SPDXID": "SPDXRef-Package-a3a0c53acb8c1dcc",
+      "versionInfo": "4.2.0",
+      "downloadLocation": "https://github.com/lodash/lodash",
+      "filesAnalyzed": false,
+      "licenseConcluded": "MIT",
+      "licenseDeclared": "MIT",
+      "copyrightText": "NOASSERTION",
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceType": "purl",
+          "referenceLocator": "pkg:npm/lodash.defaults@4.2.0"
+        }
+      ]
+    },
+    {
+      "name": "lodash.difference",
+      "SPDXID": "SPDXRef-Package-0264c095c57bc5cf",
+      "versionInfo": "4.5.0",
+      "downloadLocation": "https://github.com/lodash/lodash",
+      "filesAnalyzed": false,
+      "licenseConcluded": "MIT",
+      "licenseDeclared": "MIT",
+      "copyrightText": "NOASSERTION",
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceType": "purl",
+          "referenceLocator": "pkg:npm/lodash.difference@4.5.0"
+        }
+      ]
+    },
+    {
+      "name": "lodash.escaperegexp",
+      "SPDXID": "SPDXRef-Package-de4b3a9e90ea9774",
+      "versionInfo": "4.1.2",
+      "downloadLocation": "https://github.com/lodash/lodash",
+      "filesAnalyzed": false,
+      "licenseConcluded": "MIT",
+      "licenseDeclared": "MIT",
+      "copyrightText": "NOASSERTION",
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceType": "purl",
+          "referenceLocator": "pkg:npm/lodash.escaperegexp@4.1.2"
+        }
+      ]
+    },
+    {
+      "name": "lodash.flatten",
+      "SPDXID": "SPDXRef-Package-0729f90dee660e49",
+      "versionInfo": "4.4.0",
+      "downloadLocation": "https://github.com/lodash/lodash",
+      "filesAnalyzed": false,
+      "licenseConcluded": "MIT",
+      "licenseDeclared": "MIT",
+      "copyrightText": "NOASSERTION",
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceType": "purl",
+          "referenceLocator": "pkg:npm/lodash.flatten@4.4.0"
+        }
+      ]
+    },
+    {
+      "name": "lodash.groupby",
+      "SPDXID": "SPDXRef-Package-ff4c49b4828c9e19",
+      "versionInfo": "4.6.0",
+      "downloadLocation": "https://github.com/lodash/lodash",
+      "filesAnalyzed": false,
+      "licenseConcluded": "MIT",
+      "licenseDeclared": "MIT",
+      "copyrightText": "NOASSERTION",
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceType": "purl",
+          "referenceLocator": "pkg:npm/lodash.groupby@4.6.0"
+        }
+      ]
+    },
+    {
       "name": "lodash.identity",
       "SPDXID": "SPDXRef-Package-a1ca8608b85fb076",
       "versionInfo": "3.0.0",
@@ -13112,6 +13826,108 @@
           "referenceCategory": "PACKAGE-MANAGER",
           "referenceType": "purl",
           "referenceLocator": "pkg:npm/lodash.identity@3.0.0"
+        }
+      ]
+    },
+    {
+      "name": "lodash.isboolean",
+      "SPDXID": "SPDXRef-Package-db45f10bd3ef5fb5",
+      "versionInfo": "3.0.3",
+      "downloadLocation": "https://github.com/lodash/lodash",
+      "filesAnalyzed": false,
+      "licenseConcluded": "MIT",
+      "licenseDeclared": "MIT",
+      "copyrightText": "NOASSERTION",
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceType": "purl",
+          "referenceLocator": "pkg:npm/lodash.isboolean@3.0.3"
+        }
+      ]
+    },
+    {
+      "name": "lodash.isequal",
+      "SPDXID": "SPDXRef-Package-4fbfd070c92eb053",
+      "versionInfo": "4.5.0",
+      "downloadLocation": "https://github.com/lodash/lodash",
+      "filesAnalyzed": false,
+      "licenseConcluded": "MIT",
+      "licenseDeclared": "MIT",
+      "copyrightText": "NOASSERTION",
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceType": "purl",
+          "referenceLocator": "pkg:npm/lodash.isequal@4.5.0"
+        }
+      ]
+    },
+    {
+      "name": "lodash.isfunction",
+      "SPDXID": "SPDXRef-Package-48d573eae5c4cd81",
+      "versionInfo": "3.0.9",
+      "downloadLocation": "https://github.com/lodash/lodash",
+      "filesAnalyzed": false,
+      "licenseConcluded": "MIT",
+      "licenseDeclared": "MIT",
+      "copyrightText": "NOASSERTION",
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceType": "purl",
+          "referenceLocator": "pkg:npm/lodash.isfunction@3.0.9"
+        }
+      ]
+    },
+    {
+      "name": "lodash.isnil",
+      "SPDXID": "SPDXRef-Package-45270f7cf55ec688",
+      "versionInfo": "4.0.0",
+      "downloadLocation": "https://github.com/lodash/lodash",
+      "filesAnalyzed": false,
+      "licenseConcluded": "MIT",
+      "licenseDeclared": "MIT",
+      "copyrightText": "NOASSERTION",
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceType": "purl",
+          "referenceLocator": "pkg:npm/lodash.isnil@4.0.0"
+        }
+      ]
+    },
+    {
+      "name": "lodash.isplainobject",
+      "SPDXID": "SPDXRef-Package-715a4dee5083b138",
+      "versionInfo": "4.0.6",
+      "downloadLocation": "https://github.com/lodash/lodash",
+      "filesAnalyzed": false,
+      "licenseConcluded": "MIT",
+      "licenseDeclared": "MIT",
+      "copyrightText": "NOASSERTION",
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceType": "purl",
+          "referenceLocator": "pkg:npm/lodash.isplainobject@4.0.6"
+        }
+      ]
+    },
+    {
+      "name": "lodash.isundefined",
+      "SPDXID": "SPDXRef-Package-395eddedb8745a8f",
+      "versionInfo": "3.0.1",
+      "downloadLocation": "https://github.com/lodash/lodash",
+      "filesAnalyzed": false,
+      "licenseConcluded": "MIT",
+      "licenseDeclared": "MIT",
+      "copyrightText": "NOASSERTION",
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceType": "purl",
+          "referenceLocator": "pkg:npm/lodash.isundefined@3.0.1"
         }
       ]
     },
@@ -13163,6 +13979,40 @@
           "referenceCategory": "PACKAGE-MANAGER",
           "referenceType": "purl",
           "referenceLocator": "pkg:npm/lodash.snakecase@4.1.1"
+        }
+      ]
+    },
+    {
+      "name": "lodash.union",
+      "SPDXID": "SPDXRef-Package-57a1e9a5e166604b",
+      "versionInfo": "4.6.0",
+      "downloadLocation": "https://github.com/lodash/lodash",
+      "filesAnalyzed": false,
+      "licenseConcluded": "MIT",
+      "licenseDeclared": "MIT",
+      "copyrightText": "NOASSERTION",
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceType": "purl",
+          "referenceLocator": "pkg:npm/lodash.union@4.6.0"
+        }
+      ]
+    },
+    {
+      "name": "lodash.uniq",
+      "SPDXID": "SPDXRef-Package-ce721e649dfb1e5c",
+      "versionInfo": "4.5.0",
+      "downloadLocation": "https://github.com/lodash/lodash",
+      "filesAnalyzed": false,
+      "licenseConcluded": "MIT",
+      "licenseDeclared": "MIT",
+      "copyrightText": "NOASSERTION",
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceType": "purl",
+          "referenceLocator": "pkg:npm/lodash.uniq@4.5.0"
         }
       ]
     },
@@ -14374,6 +15224,57 @@
       ]
     },
     {
+      "name": "minimalistic-assert",
+      "SPDXID": "SPDXRef-Package-588f964b04a1a148",
+      "versionInfo": "1.0.1",
+      "downloadLocation": "https://github.com/calvinmetcalf/minimalistic-assert",
+      "filesAnalyzed": false,
+      "licenseConcluded": "ISC",
+      "licenseDeclared": "ISC",
+      "copyrightText": "NOASSERTION",
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceType": "purl",
+          "referenceLocator": "pkg:npm/minimalistic-assert@1.0.1"
+        }
+      ]
+    },
+    {
+      "name": "minimatch",
+      "SPDXID": "SPDXRef-Package-40d05b19a4e7d885",
+      "versionInfo": "3.1.5",
+      "downloadLocation": "https://github.com/isaacs/minimatch",
+      "filesAnalyzed": false,
+      "licenseConcluded": "ISC",
+      "licenseDeclared": "ISC",
+      "copyrightText": "NOASSERTION",
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceType": "purl",
+          "referenceLocator": "pkg:npm/minimatch@3.1.5"
+        }
+      ]
+    },
+    {
+      "name": "minimatch",
+      "SPDXID": "SPDXRef-Package-9b652aa8c82e5af7",
+      "versionInfo": "5.1.9",
+      "downloadLocation": "https://github.com/isaacs/minimatch",
+      "filesAnalyzed": false,
+      "licenseConcluded": "ISC",
+      "licenseDeclared": "ISC",
+      "copyrightText": "NOASSERTION",
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceType": "purl",
+          "referenceLocator": "pkg:npm/minimatch@5.1.9"
+        }
+      ]
+    },
+    {
       "name": "minimatch",
       "SPDXID": "SPDXRef-Package-9a47e0282c0c109e",
       "versionInfo": "9.0.9",
@@ -14544,6 +15445,23 @@
       ]
     },
     {
+      "name": "nanoid",
+      "SPDXID": "SPDXRef-Package-351e1526e0c140ae",
+      "versionInfo": "5.1.16",
+      "downloadLocation": "https://github.com/ai/nanoid",
+      "filesAnalyzed": false,
+      "licenseConcluded": "MIT",
+      "licenseDeclared": "MIT",
+      "copyrightText": "NOASSERTION",
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceType": "purl",
+          "referenceLocator": "pkg:npm/nanoid@5.1.16"
+        }
+      ]
+    },
+    {
       "name": "napi-build-utils",
       "SPDXID": "SPDXRef-Package-ee090ad491ba86cf",
       "versionInfo": "2.0.0",
@@ -14676,6 +15594,23 @@
           "referenceCategory": "PACKAGE-MANAGER",
           "referenceType": "purl",
           "referenceLocator": "pkg:npm/node-pty@1.1.0"
+        }
+      ]
+    },
+    {
+      "name": "normalize-path",
+      "SPDXID": "SPDXRef-Package-e6a9afc20b6a5b4f",
+      "versionInfo": "3.0.0",
+      "downloadLocation": "https://github.com/jonschlinkert/normalize-path",
+      "filesAnalyzed": false,
+      "licenseConcluded": "MIT",
+      "licenseDeclared": "MIT",
+      "copyrightText": "NOASSERTION",
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceType": "purl",
+          "referenceLocator": "pkg:npm/normalize-path@3.0.0"
         }
       ]
     },
@@ -15037,6 +15972,23 @@
       ]
     },
     {
+      "name": "path-is-absolute",
+      "SPDXID": "SPDXRef-Package-79f253dbdc64eb00",
+      "versionInfo": "1.0.1",
+      "downloadLocation": "https://github.com/sindresorhus/path-is-absolute",
+      "filesAnalyzed": false,
+      "licenseConcluded": "MIT",
+      "licenseDeclared": "MIT",
+      "copyrightText": "NOASSERTION",
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceType": "purl",
+          "referenceLocator": "pkg:npm/path-is-absolute@1.0.1"
+        }
+      ]
+    },
+    {
       "name": "path-key",
       "SPDXID": "SPDXRef-Package-fdd7a87411d74d56",
       "versionInfo": "3.1.1",
@@ -15220,6 +16172,23 @@
           "referenceCategory": "PACKAGE-MANAGER",
           "referenceType": "purl",
           "referenceLocator": "pkg:npm/points-on-path@0.2.1"
+        }
+      ]
+    },
+    {
+      "name": "pptxgenjs",
+      "SPDXID": "SPDXRef-Package-8406d74ee701100f",
+      "versionInfo": "4.0.1",
+      "downloadLocation": "https://github.com/gitbrent/PptxGenJS",
+      "filesAnalyzed": false,
+      "licenseConcluded": "MIT",
+      "licenseDeclared": "MIT",
+      "copyrightText": "NOASSERTION",
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceType": "purl",
+          "referenceLocator": "pkg:npm/pptxgenjs@4.0.1"
         }
       ]
     },
@@ -15632,6 +16601,23 @@
       ]
     },
     {
+      "name": "queue",
+      "SPDXID": "SPDXRef-Package-c8b1e190ece36b5b",
+      "versionInfo": "6.0.2",
+      "downloadLocation": "https://github.com/jessetane/queue",
+      "filesAnalyzed": false,
+      "licenseConcluded": "MIT",
+      "licenseDeclared": "MIT",
+      "copyrightText": "NOASSERTION",
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceType": "purl",
+          "referenceLocator": "pkg:npm/queue@6.0.2"
+        }
+      ]
+    },
+    {
       "name": "range-parser",
       "SPDXID": "SPDXRef-Package-c99f309bb22fcd34",
       "versionInfo": "1.3.0",
@@ -15870,6 +16856,23 @@
       ]
     },
     {
+      "name": "readdir-glob",
+      "SPDXID": "SPDXRef-Package-8c907a9e46ec42ff",
+      "versionInfo": "1.1.3",
+      "downloadLocation": "https://github.com/Yqnn/node-readdir-glob",
+      "filesAnalyzed": false,
+      "licenseConcluded": "Apache-2.0",
+      "licenseDeclared": "Apache-2.0",
+      "copyrightText": "NOASSERTION",
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceType": "purl",
+          "referenceLocator": "pkg:npm/readdir-glob@1.1.3"
+        }
+      ]
+    },
+    {
       "name": "rehype-highlight",
       "SPDXID": "SPDXRef-Package-046eb40b35cfc8f2",
       "versionInfo": "7.0.2",
@@ -16075,6 +17078,23 @@
     },
     {
       "name": "rimraf",
+      "SPDXID": "SPDXRef-Package-1b50db6d94db0196",
+      "versionInfo": "2.6.3",
+      "downloadLocation": "https://github.com/isaacs/rimraf",
+      "filesAnalyzed": false,
+      "licenseConcluded": "ISC",
+      "licenseDeclared": "ISC",
+      "copyrightText": "NOASSERTION",
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceType": "purl",
+          "referenceLocator": "pkg:npm/rimraf@2.6.3"
+        }
+      ]
+    },
+    {
+      "name": "rimraf",
       "SPDXID": "SPDXRef-Package-7fd5189f1498eda2",
       "versionInfo": "5.0.10",
       "downloadLocation": "https://github.com/isaacs/rimraf",
@@ -16223,6 +17243,40 @@
           "referenceCategory": "PACKAGE-MANAGER",
           "referenceType": "purl",
           "referenceLocator": "pkg:npm/safer-buffer@2.1.2"
+        }
+      ]
+    },
+    {
+      "name": "sax",
+      "SPDXID": "SPDXRef-Package-6d51ff5f61437558",
+      "versionInfo": "1.6.0",
+      "downloadLocation": "https://github.com/isaacs/sax-js",
+      "filesAnalyzed": false,
+      "licenseConcluded": "BlueOak-1.0.0",
+      "licenseDeclared": "BlueOak-1.0.0",
+      "copyrightText": "NOASSERTION",
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceType": "purl",
+          "referenceLocator": "pkg:npm/sax@1.6.0"
+        }
+      ]
+    },
+    {
+      "name": "saxes",
+      "SPDXID": "SPDXRef-Package-95cdee6f7d557d13",
+      "versionInfo": "5.0.1",
+      "downloadLocation": "https://github.com/lddubeau/saxes",
+      "filesAnalyzed": false,
+      "licenseConcluded": "ISC",
+      "licenseDeclared": "ISC",
+      "copyrightText": "NOASSERTION",
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceType": "purl",
+          "referenceLocator": "pkg:npm/saxes@5.0.1"
         }
       ]
     },
@@ -17077,6 +18131,23 @@
       ]
     },
     {
+      "name": "tmp",
+      "SPDXID": "SPDXRef-Package-b335f2d01d3ed9cf",
+      "versionInfo": "0.2.7",
+      "downloadLocation": "https://github.com/raszi/node-tmp",
+      "filesAnalyzed": false,
+      "licenseConcluded": "MIT",
+      "licenseDeclared": "MIT",
+      "copyrightText": "NOASSERTION",
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceType": "purl",
+          "referenceLocator": "pkg:npm/tmp@0.2.7"
+        }
+      ]
+    },
+    {
       "name": "toidentifier",
       "SPDXID": "SPDXRef-Package-c834291cf2535d86",
       "versionInfo": "1.0.1",
@@ -17090,6 +18161,23 @@
           "referenceCategory": "PACKAGE-MANAGER",
           "referenceType": "purl",
           "referenceLocator": "pkg:npm/toidentifier@1.0.1"
+        }
+      ]
+    },
+    {
+      "name": "traverse",
+      "SPDXID": "SPDXRef-Package-a141076283aa9950",
+      "versionInfo": "0.3.9",
+      "downloadLocation": "http://github.com/substack/js-traverse",
+      "filesAnalyzed": false,
+      "licenseConcluded": "MIT",
+      "licenseDeclared": "MIT",
+      "copyrightText": "NOASSERTION",
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceType": "purl",
+          "referenceLocator": "pkg:npm/traverse@0.3.9"
         }
       ]
     },
@@ -17333,6 +18421,23 @@
     },
     {
       "name": "undici-types",
+      "SPDXID": "SPDXRef-Package-a3e23d7a1173dbbf",
+      "versionInfo": "6.21.0",
+      "downloadLocation": "https://github.com/nodejs/undici",
+      "filesAnalyzed": false,
+      "licenseConcluded": "MIT",
+      "licenseDeclared": "MIT",
+      "copyrightText": "NOASSERTION",
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceType": "purl",
+          "referenceLocator": "pkg:npm/undici-types@6.21.0"
+        }
+      ]
+    },
+    {
+      "name": "undici-types",
       "SPDXID": "SPDXRef-Package-a85d345236e133c0",
       "versionInfo": "7.24.6",
       "downloadLocation": "https://github.com/nodejs/undici",
@@ -17519,6 +18624,23 @@
       ]
     },
     {
+      "name": "unzipper",
+      "SPDXID": "SPDXRef-Package-0691de763eddddc8",
+      "versionInfo": "0.10.14",
+      "downloadLocation": "https://github.com/ZJONSSON/node-unzipper",
+      "filesAnalyzed": false,
+      "licenseConcluded": "MIT",
+      "licenseDeclared": "MIT",
+      "copyrightText": "NOASSERTION",
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceType": "purl",
+          "referenceLocator": "pkg:npm/unzipper@0.10.14"
+        }
+      ]
+    },
+    {
       "name": "uri-js",
       "SPDXID": "SPDXRef-Package-86b9d1cd1856870a",
       "versionInfo": "4.4.1",
@@ -17634,6 +18756,23 @@
           "referenceCategory": "PACKAGE-MANAGER",
           "referenceType": "purl",
           "referenceLocator": "pkg:npm/uuid@14.0.1"
+        }
+      ]
+    },
+    {
+      "name": "uuid",
+      "SPDXID": "SPDXRef-Package-781eb11958365689",
+      "versionInfo": "8.3.2",
+      "downloadLocation": "https://github.com/uuidjs/uuid",
+      "filesAnalyzed": false,
+      "licenseConcluded": "MIT",
+      "licenseDeclared": "MIT",
+      "copyrightText": "NOASSERTION",
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceType": "purl",
+          "referenceLocator": "pkg:npm/uuid@8.3.2"
         }
       ]
     },
@@ -17910,6 +19049,57 @@
       ]
     },
     {
+      "name": "xml",
+      "SPDXID": "SPDXRef-Package-952c31231ba66670",
+      "versionInfo": "1.0.1",
+      "downloadLocation": "http://github.com/dylang/node-xml",
+      "filesAnalyzed": false,
+      "licenseConcluded": "MIT",
+      "licenseDeclared": "MIT",
+      "copyrightText": "NOASSERTION",
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceType": "purl",
+          "referenceLocator": "pkg:npm/xml@1.0.1"
+        }
+      ]
+    },
+    {
+      "name": "xml-js",
+      "SPDXID": "SPDXRef-Package-db9ebd25cef24c8f",
+      "versionInfo": "1.6.11",
+      "downloadLocation": "https://github.com/nashwaan/xml-js",
+      "filesAnalyzed": false,
+      "licenseConcluded": "MIT",
+      "licenseDeclared": "MIT",
+      "copyrightText": "NOASSERTION",
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceType": "purl",
+          "referenceLocator": "pkg:npm/xml-js@1.6.11"
+        }
+      ]
+    },
+    {
+      "name": "xmlchars",
+      "SPDXID": "SPDXRef-Package-bd49bc058ac56fd1",
+      "versionInfo": "2.2.0",
+      "downloadLocation": "https://github.com/lddubeau/xmlchars",
+      "filesAnalyzed": false,
+      "licenseConcluded": "MIT",
+      "licenseDeclared": "MIT",
+      "copyrightText": "NOASSERTION",
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceType": "purl",
+          "referenceLocator": "pkg:npm/xmlchars@2.2.0"
+        }
+      ]
+    },
+    {
       "name": "y18n",
       "SPDXID": "SPDXRef-Package-8e532c67f7b65656",
       "versionInfo": "4.0.3",
@@ -17974,6 +19164,23 @@
           "referenceCategory": "PACKAGE-MANAGER",
           "referenceType": "purl",
           "referenceLocator": "pkg:npm/yargs-parser@18.1.3"
+        }
+      ]
+    },
+    {
+      "name": "zip-stream",
+      "SPDXID": "SPDXRef-Package-83f742740c720c8e",
+      "versionInfo": "4.1.1",
+      "downloadLocation": "https://github.com/archiverjs/node-zip-stream",
+      "filesAnalyzed": false,
+      "licenseConcluded": "MIT",
+      "licenseDeclared": "MIT",
+      "copyrightText": "NOASSERTION",
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceType": "purl",
+          "referenceLocator": "pkg:npm/zip-stream@4.1.1"
         }
       ]
     },
@@ -18078,7 +19285,7 @@
     {
       "spdxElementId": "SPDXRef-DOCUMENT",
       "relationshipType": "DESCRIBES",
-      "relatedSpdxElement": "SPDXRef-Package-04c1add3e48a9e5c"
+      "relatedSpdxElement": "SPDXRef-Package-a3cbdbce86e6fdc7"
     },
     {
       "spdxElementId": "SPDXRef-DOCUMENT",
@@ -19448,7 +20655,27 @@
     {
       "spdxElementId": "SPDXRef-DOCUMENT",
       "relationshipType": "DESCRIBES",
+      "relatedSpdxElement": "SPDXRef-Package-2d6a4b723df29496"
+    },
+    {
+      "spdxElementId": "SPDXRef-DOCUMENT",
+      "relationshipType": "DESCRIBES",
+      "relatedSpdxElement": "SPDXRef-Package-d10d1f341d4abfa8"
+    },
+    {
+      "spdxElementId": "SPDXRef-DOCUMENT",
+      "relationshipType": "DESCRIBES",
+      "relatedSpdxElement": "SPDXRef-Package-bae6a338f33d9a1c"
+    },
+    {
+      "spdxElementId": "SPDXRef-DOCUMENT",
+      "relationshipType": "DESCRIBES",
       "relatedSpdxElement": "SPDXRef-Package-edf04d45834b4fbf"
+    },
+    {
+      "spdxElementId": "SPDXRef-DOCUMENT",
+      "relationshipType": "DESCRIBES",
+      "relatedSpdxElement": "SPDXRef-Package-3adbc0856a9bda85"
     },
     {
       "spdxElementId": "SPDXRef-DOCUMENT",
@@ -19609,6 +20836,16 @@
       "spdxElementId": "SPDXRef-DOCUMENT",
       "relationshipType": "DESCRIBES",
       "relatedSpdxElement": "SPDXRef-Package-53aca7cadbe88e59"
+    },
+    {
+      "spdxElementId": "SPDXRef-DOCUMENT",
+      "relationshipType": "DESCRIBES",
+      "relatedSpdxElement": "SPDXRef-Package-ef09030156acbe49"
+    },
+    {
+      "spdxElementId": "SPDXRef-DOCUMENT",
+      "relationshipType": "DESCRIBES",
+      "relatedSpdxElement": "SPDXRef-Package-f4baae4686e02f0a"
     },
     {
       "spdxElementId": "SPDXRef-DOCUMENT",
@@ -20378,6 +21615,16 @@
     {
       "spdxElementId": "SPDXRef-DOCUMENT",
       "relationshipType": "DESCRIBES",
+      "relatedSpdxElement": "SPDXRef-Package-c6b0b3ef4062e7b5"
+    },
+    {
+      "spdxElementId": "SPDXRef-DOCUMENT",
+      "relationshipType": "DESCRIBES",
+      "relatedSpdxElement": "SPDXRef-Package-006d2bce93d8f1dd"
+    },
+    {
+      "spdxElementId": "SPDXRef-DOCUMENT",
+      "relationshipType": "DESCRIBES",
       "relatedSpdxElement": "SPDXRef-Package-b02ebf6599a4715f"
     },
     {
@@ -20503,6 +21750,21 @@
     {
       "spdxElementId": "SPDXRef-DOCUMENT",
       "relationshipType": "DESCRIBES",
+      "relatedSpdxElement": "SPDXRef-Package-9135483032251fea"
+    },
+    {
+      "spdxElementId": "SPDXRef-DOCUMENT",
+      "relationshipType": "DESCRIBES",
+      "relatedSpdxElement": "SPDXRef-Package-e4af001b994a14f4"
+    },
+    {
+      "spdxElementId": "SPDXRef-DOCUMENT",
+      "relationshipType": "DESCRIBES",
+      "relatedSpdxElement": "SPDXRef-Package-f7b326a32927cbed"
+    },
+    {
+      "spdxElementId": "SPDXRef-DOCUMENT",
+      "relationshipType": "DESCRIBES",
       "relatedSpdxElement": "SPDXRef-Package-1b8ff3f05bffff87"
     },
     {
@@ -20519,6 +21781,11 @@
       "spdxElementId": "SPDXRef-DOCUMENT",
       "relationshipType": "DESCRIBES",
       "relatedSpdxElement": "SPDXRef-Package-11e344538943bbf2"
+    },
+    {
+      "spdxElementId": "SPDXRef-DOCUMENT",
+      "relationshipType": "DESCRIBES",
+      "relatedSpdxElement": "SPDXRef-Package-1faad319f76b179f"
     },
     {
       "spdxElementId": "SPDXRef-DOCUMENT",
@@ -20563,7 +21830,17 @@
     {
       "spdxElementId": "SPDXRef-DOCUMENT",
       "relationshipType": "DESCRIBES",
+      "relatedSpdxElement": "SPDXRef-Package-d4c964d5752fd254"
+    },
+    {
+      "spdxElementId": "SPDXRef-DOCUMENT",
+      "relationshipType": "DESCRIBES",
       "relatedSpdxElement": "SPDXRef-Package-e6bcaebbcb046dc4"
+    },
+    {
+      "spdxElementId": "SPDXRef-DOCUMENT",
+      "relationshipType": "DESCRIBES",
+      "relatedSpdxElement": "SPDXRef-Package-169094cbdc1389db"
     },
     {
       "spdxElementId": "SPDXRef-DOCUMENT",
@@ -20578,7 +21855,17 @@
     {
       "spdxElementId": "SPDXRef-DOCUMENT",
       "relationshipType": "DESCRIBES",
+      "relatedSpdxElement": "SPDXRef-Package-281d2b6b5950a4ba"
+    },
+    {
+      "spdxElementId": "SPDXRef-DOCUMENT",
+      "relationshipType": "DESCRIBES",
       "relatedSpdxElement": "SPDXRef-Package-603bfb1d8a6cd096"
+    },
+    {
+      "spdxElementId": "SPDXRef-DOCUMENT",
+      "relationshipType": "DESCRIBES",
+      "relatedSpdxElement": "SPDXRef-Package-3a4b46a93421a532"
     },
     {
       "spdxElementId": "SPDXRef-DOCUMENT",
@@ -20593,7 +21880,22 @@
     {
       "spdxElementId": "SPDXRef-DOCUMENT",
       "relationshipType": "DESCRIBES",
+      "relatedSpdxElement": "SPDXRef-Package-3f07b92fa45ba611"
+    },
+    {
+      "spdxElementId": "SPDXRef-DOCUMENT",
+      "relationshipType": "DESCRIBES",
       "relatedSpdxElement": "SPDXRef-Package-2f4ce0cccb4ed6f4"
+    },
+    {
+      "spdxElementId": "SPDXRef-DOCUMENT",
+      "relationshipType": "DESCRIBES",
+      "relatedSpdxElement": "SPDXRef-Package-62eb5a03ebf03674"
+    },
+    {
+      "spdxElementId": "SPDXRef-DOCUMENT",
+      "relationshipType": "DESCRIBES",
+      "relatedSpdxElement": "SPDXRef-Package-8e3f307fa2ee1e16"
     },
     {
       "spdxElementId": "SPDXRef-DOCUMENT",
@@ -20629,6 +21931,11 @@
       "spdxElementId": "SPDXRef-DOCUMENT",
       "relationshipType": "DESCRIBES",
       "relatedSpdxElement": "SPDXRef-Package-8454f0e154fad702"
+    },
+    {
+      "spdxElementId": "SPDXRef-DOCUMENT",
+      "relationshipType": "DESCRIBES",
+      "relatedSpdxElement": "SPDXRef-Package-b114758f8c10a13e"
     },
     {
       "spdxElementId": "SPDXRef-DOCUMENT",
@@ -20713,6 +22020,16 @@
     {
       "spdxElementId": "SPDXRef-DOCUMENT",
       "relationshipType": "DESCRIBES",
+      "relatedSpdxElement": "SPDXRef-Package-e77e224d03910af4"
+    },
+    {
+      "spdxElementId": "SPDXRef-DOCUMENT",
+      "relationshipType": "DESCRIBES",
+      "relatedSpdxElement": "SPDXRef-Package-446fb7e0d413f4e8"
+    },
+    {
+      "spdxElementId": "SPDXRef-DOCUMENT",
+      "relationshipType": "DESCRIBES",
       "relatedSpdxElement": "SPDXRef-Package-4b508a608e7c9c35"
     },
     {
@@ -20769,6 +22086,16 @@
       "spdxElementId": "SPDXRef-DOCUMENT",
       "relationshipType": "DESCRIBES",
       "relatedSpdxElement": "SPDXRef-Package-b6c9c76e33815fb2"
+    },
+    {
+      "spdxElementId": "SPDXRef-DOCUMENT",
+      "relationshipType": "DESCRIBES",
+      "relatedSpdxElement": "SPDXRef-Package-7b769d3a0b61c741"
+    },
+    {
+      "spdxElementId": "SPDXRef-DOCUMENT",
+      "relationshipType": "DESCRIBES",
+      "relatedSpdxElement": "SPDXRef-Package-3bd6e89d41e1b16e"
     },
     {
       "spdxElementId": "SPDXRef-DOCUMENT",
@@ -21093,6 +22420,11 @@
     {
       "spdxElementId": "SPDXRef-DOCUMENT",
       "relationshipType": "DESCRIBES",
+      "relatedSpdxElement": "SPDXRef-Package-5fcae62518b2d23a"
+    },
+    {
+      "spdxElementId": "SPDXRef-DOCUMENT",
+      "relationshipType": "DESCRIBES",
       "relatedSpdxElement": "SPDXRef-Package-fe4205b186c43bb8"
     },
     {
@@ -21109,6 +22441,11 @@
       "spdxElementId": "SPDXRef-DOCUMENT",
       "relationshipType": "DESCRIBES",
       "relatedSpdxElement": "SPDXRef-Package-591da600a357596a"
+    },
+    {
+      "spdxElementId": "SPDXRef-DOCUMENT",
+      "relationshipType": "DESCRIBES",
+      "relatedSpdxElement": "SPDXRef-Package-5203e1981b9684d9"
     },
     {
       "spdxElementId": "SPDXRef-DOCUMENT",
@@ -21238,6 +22575,11 @@
     {
       "spdxElementId": "SPDXRef-DOCUMENT",
       "relationshipType": "DESCRIBES",
+      "relatedSpdxElement": "SPDXRef-Package-a037ed657533f4f1"
+    },
+    {
+      "spdxElementId": "SPDXRef-DOCUMENT",
+      "relationshipType": "DESCRIBES",
       "relatedSpdxElement": "SPDXRef-Package-95a792ac9cb6ef2b"
     },
     {
@@ -21269,6 +22611,11 @@
       "spdxElementId": "SPDXRef-DOCUMENT",
       "relationshipType": "DESCRIBES",
       "relatedSpdxElement": "SPDXRef-Package-89a61fe97490415f"
+    },
+    {
+      "spdxElementId": "SPDXRef-DOCUMENT",
+      "relationshipType": "DESCRIBES",
+      "relatedSpdxElement": "SPDXRef-Package-c7b893d84403ff14"
     },
     {
       "spdxElementId": "SPDXRef-DOCUMENT",
@@ -21358,6 +22705,16 @@
     {
       "spdxElementId": "SPDXRef-DOCUMENT",
       "relationshipType": "DESCRIBES",
+      "relatedSpdxElement": "SPDXRef-Package-066c98d78f779398"
+    },
+    {
+      "spdxElementId": "SPDXRef-DOCUMENT",
+      "relationshipType": "DESCRIBES",
+      "relatedSpdxElement": "SPDXRef-Package-8c228885d01e65b0"
+    },
+    {
+      "spdxElementId": "SPDXRef-DOCUMENT",
+      "relationshipType": "DESCRIBES",
       "relatedSpdxElement": "SPDXRef-Package-efff64b24eff87e8"
     },
     {
@@ -21433,6 +22790,11 @@
     {
       "spdxElementId": "SPDXRef-DOCUMENT",
       "relationshipType": "DESCRIBES",
+      "relatedSpdxElement": "SPDXRef-Package-8702ad5f91114f8f"
+    },
+    {
+      "spdxElementId": "SPDXRef-DOCUMENT",
+      "relationshipType": "DESCRIBES",
       "relatedSpdxElement": "SPDXRef-Package-ca014b881c253ebc"
     },
     {
@@ -21489,6 +22851,11 @@
       "spdxElementId": "SPDXRef-DOCUMENT",
       "relationshipType": "DESCRIBES",
       "relatedSpdxElement": "SPDXRef-Package-f1710245eb206d86"
+    },
+    {
+      "spdxElementId": "SPDXRef-DOCUMENT",
+      "relationshipType": "DESCRIBES",
+      "relatedSpdxElement": "SPDXRef-Package-0fe3a8dd2852340e"
     },
     {
       "spdxElementId": "SPDXRef-DOCUMENT",
@@ -21588,6 +22955,11 @@
     {
       "spdxElementId": "SPDXRef-DOCUMENT",
       "relationshipType": "DESCRIBES",
+      "relatedSpdxElement": "SPDXRef-Package-a6138fed56d8e05e"
+    },
+    {
+      "spdxElementId": "SPDXRef-DOCUMENT",
+      "relationshipType": "DESCRIBES",
       "relatedSpdxElement": "SPDXRef-Package-ca16958c815c8380"
     },
     {
@@ -21633,12 +23005,22 @@
     {
       "spdxElementId": "SPDXRef-DOCUMENT",
       "relationshipType": "DESCRIBES",
+      "relatedSpdxElement": "SPDXRef-Package-41bbec0dae5bac67"
+    },
+    {
+      "spdxElementId": "SPDXRef-DOCUMENT",
+      "relationshipType": "DESCRIBES",
       "relatedSpdxElement": "SPDXRef-Package-1bf8b3e308414474"
     },
     {
       "spdxElementId": "SPDXRef-DOCUMENT",
       "relationshipType": "DESCRIBES",
       "relatedSpdxElement": "SPDXRef-Package-0ed4bf4ae6371945"
+    },
+    {
+      "spdxElementId": "SPDXRef-DOCUMENT",
+      "relationshipType": "DESCRIBES",
+      "relatedSpdxElement": "SPDXRef-Package-93b34ac704832584"
     },
     {
       "spdxElementId": "SPDXRef-DOCUMENT",
@@ -21868,12 +23250,22 @@
     {
       "spdxElementId": "SPDXRef-DOCUMENT",
       "relationshipType": "DESCRIBES",
+      "relatedSpdxElement": "SPDXRef-Package-85cab3d3fea075b9"
+    },
+    {
+      "spdxElementId": "SPDXRef-DOCUMENT",
+      "relationshipType": "DESCRIBES",
       "relatedSpdxElement": "SPDXRef-Package-dc65c95b58f6df34"
     },
     {
       "spdxElementId": "SPDXRef-DOCUMENT",
       "relationshipType": "DESCRIBES",
       "relatedSpdxElement": "SPDXRef-Package-aaecb0d5f9d49a47"
+    },
+    {
+      "spdxElementId": "SPDXRef-DOCUMENT",
+      "relationshipType": "DESCRIBES",
+      "relatedSpdxElement": "SPDXRef-Package-a12a1c81551b29a0"
     },
     {
       "spdxElementId": "SPDXRef-DOCUMENT",
@@ -21913,7 +23305,62 @@
     {
       "spdxElementId": "SPDXRef-DOCUMENT",
       "relationshipType": "DESCRIBES",
+      "relatedSpdxElement": "SPDXRef-Package-a3a0c53acb8c1dcc"
+    },
+    {
+      "spdxElementId": "SPDXRef-DOCUMENT",
+      "relationshipType": "DESCRIBES",
+      "relatedSpdxElement": "SPDXRef-Package-0264c095c57bc5cf"
+    },
+    {
+      "spdxElementId": "SPDXRef-DOCUMENT",
+      "relationshipType": "DESCRIBES",
+      "relatedSpdxElement": "SPDXRef-Package-de4b3a9e90ea9774"
+    },
+    {
+      "spdxElementId": "SPDXRef-DOCUMENT",
+      "relationshipType": "DESCRIBES",
+      "relatedSpdxElement": "SPDXRef-Package-0729f90dee660e49"
+    },
+    {
+      "spdxElementId": "SPDXRef-DOCUMENT",
+      "relationshipType": "DESCRIBES",
+      "relatedSpdxElement": "SPDXRef-Package-ff4c49b4828c9e19"
+    },
+    {
+      "spdxElementId": "SPDXRef-DOCUMENT",
+      "relationshipType": "DESCRIBES",
       "relatedSpdxElement": "SPDXRef-Package-a1ca8608b85fb076"
+    },
+    {
+      "spdxElementId": "SPDXRef-DOCUMENT",
+      "relationshipType": "DESCRIBES",
+      "relatedSpdxElement": "SPDXRef-Package-db45f10bd3ef5fb5"
+    },
+    {
+      "spdxElementId": "SPDXRef-DOCUMENT",
+      "relationshipType": "DESCRIBES",
+      "relatedSpdxElement": "SPDXRef-Package-4fbfd070c92eb053"
+    },
+    {
+      "spdxElementId": "SPDXRef-DOCUMENT",
+      "relationshipType": "DESCRIBES",
+      "relatedSpdxElement": "SPDXRef-Package-48d573eae5c4cd81"
+    },
+    {
+      "spdxElementId": "SPDXRef-DOCUMENT",
+      "relationshipType": "DESCRIBES",
+      "relatedSpdxElement": "SPDXRef-Package-45270f7cf55ec688"
+    },
+    {
+      "spdxElementId": "SPDXRef-DOCUMENT",
+      "relationshipType": "DESCRIBES",
+      "relatedSpdxElement": "SPDXRef-Package-715a4dee5083b138"
+    },
+    {
+      "spdxElementId": "SPDXRef-DOCUMENT",
+      "relationshipType": "DESCRIBES",
+      "relatedSpdxElement": "SPDXRef-Package-395eddedb8745a8f"
     },
     {
       "spdxElementId": "SPDXRef-DOCUMENT",
@@ -21929,6 +23376,16 @@
       "spdxElementId": "SPDXRef-DOCUMENT",
       "relationshipType": "DESCRIBES",
       "relatedSpdxElement": "SPDXRef-Package-a6e12dc74e4896ce"
+    },
+    {
+      "spdxElementId": "SPDXRef-DOCUMENT",
+      "relationshipType": "DESCRIBES",
+      "relatedSpdxElement": "SPDXRef-Package-57a1e9a5e166604b"
+    },
+    {
+      "spdxElementId": "SPDXRef-DOCUMENT",
+      "relationshipType": "DESCRIBES",
+      "relatedSpdxElement": "SPDXRef-Package-ce721e649dfb1e5c"
     },
     {
       "spdxElementId": "SPDXRef-DOCUMENT",
@@ -22288,6 +23745,21 @@
     {
       "spdxElementId": "SPDXRef-DOCUMENT",
       "relationshipType": "DESCRIBES",
+      "relatedSpdxElement": "SPDXRef-Package-588f964b04a1a148"
+    },
+    {
+      "spdxElementId": "SPDXRef-DOCUMENT",
+      "relationshipType": "DESCRIBES",
+      "relatedSpdxElement": "SPDXRef-Package-40d05b19a4e7d885"
+    },
+    {
+      "spdxElementId": "SPDXRef-DOCUMENT",
+      "relationshipType": "DESCRIBES",
+      "relatedSpdxElement": "SPDXRef-Package-9b652aa8c82e5af7"
+    },
+    {
+      "spdxElementId": "SPDXRef-DOCUMENT",
+      "relationshipType": "DESCRIBES",
       "relatedSpdxElement": "SPDXRef-Package-9a47e0282c0c109e"
     },
     {
@@ -22338,6 +23810,11 @@
     {
       "spdxElementId": "SPDXRef-DOCUMENT",
       "relationshipType": "DESCRIBES",
+      "relatedSpdxElement": "SPDXRef-Package-351e1526e0c140ae"
+    },
+    {
+      "spdxElementId": "SPDXRef-DOCUMENT",
+      "relationshipType": "DESCRIBES",
       "relatedSpdxElement": "SPDXRef-Package-ee090ad491ba86cf"
     },
     {
@@ -22374,6 +23851,11 @@
       "spdxElementId": "SPDXRef-DOCUMENT",
       "relationshipType": "DESCRIBES",
       "relatedSpdxElement": "SPDXRef-Package-4a60f58708d5b311"
+    },
+    {
+      "spdxElementId": "SPDXRef-DOCUMENT",
+      "relationshipType": "DESCRIBES",
+      "relatedSpdxElement": "SPDXRef-Package-e6a9afc20b6a5b4f"
     },
     {
       "spdxElementId": "SPDXRef-DOCUMENT",
@@ -22483,6 +23965,11 @@
     {
       "spdxElementId": "SPDXRef-DOCUMENT",
       "relationshipType": "DESCRIBES",
+      "relatedSpdxElement": "SPDXRef-Package-79f253dbdc64eb00"
+    },
+    {
+      "spdxElementId": "SPDXRef-DOCUMENT",
+      "relationshipType": "DESCRIBES",
       "relatedSpdxElement": "SPDXRef-Package-fdd7a87411d74d56"
     },
     {
@@ -22534,6 +24021,11 @@
       "spdxElementId": "SPDXRef-DOCUMENT",
       "relationshipType": "DESCRIBES",
       "relatedSpdxElement": "SPDXRef-Package-357a328a448d93cd"
+    },
+    {
+      "spdxElementId": "SPDXRef-DOCUMENT",
+      "relationshipType": "DESCRIBES",
+      "relatedSpdxElement": "SPDXRef-Package-8406d74ee701100f"
     },
     {
       "spdxElementId": "SPDXRef-DOCUMENT",
@@ -22658,6 +24150,11 @@
     {
       "spdxElementId": "SPDXRef-DOCUMENT",
       "relationshipType": "DESCRIBES",
+      "relatedSpdxElement": "SPDXRef-Package-c8b1e190ece36b5b"
+    },
+    {
+      "spdxElementId": "SPDXRef-DOCUMENT",
+      "relationshipType": "DESCRIBES",
       "relatedSpdxElement": "SPDXRef-Package-c99f309bb22fcd34"
     },
     {
@@ -22728,6 +24225,11 @@
     {
       "spdxElementId": "SPDXRef-DOCUMENT",
       "relationshipType": "DESCRIBES",
+      "relatedSpdxElement": "SPDXRef-Package-8c907a9e46ec42ff"
+    },
+    {
+      "spdxElementId": "SPDXRef-DOCUMENT",
+      "relationshipType": "DESCRIBES",
       "relatedSpdxElement": "SPDXRef-Package-046eb40b35cfc8f2"
     },
     {
@@ -22788,6 +24290,11 @@
     {
       "spdxElementId": "SPDXRef-DOCUMENT",
       "relationshipType": "DESCRIBES",
+      "relatedSpdxElement": "SPDXRef-Package-1b50db6d94db0196"
+    },
+    {
+      "spdxElementId": "SPDXRef-DOCUMENT",
+      "relationshipType": "DESCRIBES",
       "relatedSpdxElement": "SPDXRef-Package-7fd5189f1498eda2"
     },
     {
@@ -22829,6 +24336,16 @@
       "spdxElementId": "SPDXRef-DOCUMENT",
       "relationshipType": "DESCRIBES",
       "relatedSpdxElement": "SPDXRef-Package-5941030fc7f193de"
+    },
+    {
+      "spdxElementId": "SPDXRef-DOCUMENT",
+      "relationshipType": "DESCRIBES",
+      "relatedSpdxElement": "SPDXRef-Package-6d51ff5f61437558"
+    },
+    {
+      "spdxElementId": "SPDXRef-DOCUMENT",
+      "relationshipType": "DESCRIBES",
+      "relatedSpdxElement": "SPDXRef-Package-95cdee6f7d557d13"
     },
     {
       "spdxElementId": "SPDXRef-DOCUMENT",
@@ -23083,7 +24600,17 @@
     {
       "spdxElementId": "SPDXRef-DOCUMENT",
       "relationshipType": "DESCRIBES",
+      "relatedSpdxElement": "SPDXRef-Package-b335f2d01d3ed9cf"
+    },
+    {
+      "spdxElementId": "SPDXRef-DOCUMENT",
+      "relationshipType": "DESCRIBES",
       "relatedSpdxElement": "SPDXRef-Package-c834291cf2535d86"
+    },
+    {
+      "spdxElementId": "SPDXRef-DOCUMENT",
+      "relationshipType": "DESCRIBES",
+      "relatedSpdxElement": "SPDXRef-Package-a141076283aa9950"
     },
     {
       "spdxElementId": "SPDXRef-DOCUMENT",
@@ -23158,6 +24685,11 @@
     {
       "spdxElementId": "SPDXRef-DOCUMENT",
       "relationshipType": "DESCRIBES",
+      "relatedSpdxElement": "SPDXRef-Package-a3e23d7a1173dbbf"
+    },
+    {
+      "spdxElementId": "SPDXRef-DOCUMENT",
+      "relationshipType": "DESCRIBES",
       "relatedSpdxElement": "SPDXRef-Package-a85d345236e133c0"
     },
     {
@@ -23213,6 +24745,11 @@
     {
       "spdxElementId": "SPDXRef-DOCUMENT",
       "relationshipType": "DESCRIBES",
+      "relatedSpdxElement": "SPDXRef-Package-0691de763eddddc8"
+    },
+    {
+      "spdxElementId": "SPDXRef-DOCUMENT",
+      "relationshipType": "DESCRIBES",
       "relatedSpdxElement": "SPDXRef-Package-86b9d1cd1856870a"
     },
     {
@@ -23244,6 +24781,11 @@
       "spdxElementId": "SPDXRef-DOCUMENT",
       "relationshipType": "DESCRIBES",
       "relatedSpdxElement": "SPDXRef-Package-0ba81ad163d7682e"
+    },
+    {
+      "spdxElementId": "SPDXRef-DOCUMENT",
+      "relationshipType": "DESCRIBES",
+      "relatedSpdxElement": "SPDXRef-Package-781eb11958365689"
     },
     {
       "spdxElementId": "SPDXRef-DOCUMENT",
@@ -23328,6 +24870,21 @@
     {
       "spdxElementId": "SPDXRef-DOCUMENT",
       "relationshipType": "DESCRIBES",
+      "relatedSpdxElement": "SPDXRef-Package-952c31231ba66670"
+    },
+    {
+      "spdxElementId": "SPDXRef-DOCUMENT",
+      "relationshipType": "DESCRIBES",
+      "relatedSpdxElement": "SPDXRef-Package-db9ebd25cef24c8f"
+    },
+    {
+      "spdxElementId": "SPDXRef-DOCUMENT",
+      "relationshipType": "DESCRIBES",
+      "relatedSpdxElement": "SPDXRef-Package-bd49bc058ac56fd1"
+    },
+    {
+      "spdxElementId": "SPDXRef-DOCUMENT",
+      "relationshipType": "DESCRIBES",
       "relatedSpdxElement": "SPDXRef-Package-8e532c67f7b65656"
     },
     {
@@ -23344,6 +24901,11 @@
       "spdxElementId": "SPDXRef-DOCUMENT",
       "relationshipType": "DESCRIBES",
       "relatedSpdxElement": "SPDXRef-Package-0d53ff1f3e7f8816"
+    },
+    {
+      "spdxElementId": "SPDXRef-DOCUMENT",
+      "relationshipType": "DESCRIBES",
+      "relatedSpdxElement": "SPDXRef-Package-83f742740c720c8e"
     },
     {
       "spdxElementId": "SPDXRef-DOCUMENT",

--- a/docs/legal/notices/sbom/mobile-android.spdx.json
+++ b/docs/legal/notices/sbom/mobile-android.spdx.json
@@ -3,9 +3,9 @@
   "dataLicense": "CC0-1.0",
   "SPDXID": "SPDXRef-DOCUMENT",
   "name": "cindy-mobile-android",
-  "documentNamespace": "https://cindy.app/spdx/mobile-android/05efd357f74ac207a075699dbbd457afe65ed99fd574ee594be1d4bb651dc49a",
+  "documentNamespace": "https://cindy.app/spdx/mobile-android/279afe096f67e06278533b0141e4ec9be3d49bf89bbd4ecc0eebb430433efbb9",
   "creationInfo": {
-    "created": "2026-08-14T10:29:27Z",
+    "created": "2026-09-02T19:21:04Z",
     "creators": [
       "Tool: scripts/generate-third-party-notices.mjs"
     ]
@@ -50,23 +50,6 @@
       "licenseConcluded": "MIT",
       "licenseDeclared": "MIT",
       "copyrightText": "NOASSERTION"
-    },
-    {
-      "name": "@adobe/css-tools",
-      "SPDXID": "SPDXRef-Package-10a5c5df7c6ba052",
-      "versionInfo": "4.5.0",
-      "downloadLocation": "https://github.com/adobe/css-tools",
-      "filesAnalyzed": false,
-      "licenseConcluded": "MIT",
-      "licenseDeclared": "MIT",
-      "copyrightText": "NOASSERTION",
-      "externalRefs": [
-        {
-          "referenceCategory": "PACKAGE-MANAGER",
-          "referenceType": "purl",
-          "referenceLocator": "pkg:npm/%40adobe/css-tools@4.5.0"
-        }
-      ]
     },
     {
       "name": "@babel/code-frame",
@@ -1242,6 +1225,23 @@
       ]
     },
     {
+      "name": "@egjs/hammerjs",
+      "SPDXID": "SPDXRef-Package-cf26df301845f4cf",
+      "versionInfo": "2.0.17",
+      "downloadLocation": "https://github.com/naver/hammer.js",
+      "filesAnalyzed": false,
+      "licenseConcluded": "MIT",
+      "licenseDeclared": "MIT",
+      "copyrightText": "NOASSERTION",
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceType": "purl",
+          "referenceLocator": "pkg:npm/%40egjs/hammerjs@2.0.17"
+        }
+      ]
+    },
+    {
       "name": "@expo-google-fonts/material-symbols",
       "SPDXID": "SPDXRef-Package-396b2918563c1afc",
       "versionInfo": "0.4.40",
@@ -1260,8 +1260,8 @@
     },
     {
       "name": "@expo/cli",
-      "SPDXID": "SPDXRef-Package-6ac0bb956200fdf5",
-      "versionInfo": "56.1.20",
+      "SPDXID": "SPDXRef-Package-20e7a8f375c2feb7",
+      "versionInfo": "57.0.19",
       "downloadLocation": "https://github.com/expo/expo",
       "filesAnalyzed": false,
       "licenseConcluded": "MIT",
@@ -1271,7 +1271,7 @@
         {
           "referenceCategory": "PACKAGE-MANAGER",
           "referenceType": "purl",
-          "referenceLocator": "pkg:npm/%40expo/cli@56.1.20"
+          "referenceLocator": "pkg:npm/%40expo/cli@57.0.19"
         }
       ]
     },
@@ -1294,8 +1294,8 @@
     },
     {
       "name": "@expo/config",
-      "SPDXID": "SPDXRef-Package-dcc374c8c02d514d",
-      "versionInfo": "56.0.12",
+      "SPDXID": "SPDXRef-Package-1496420660ddf99b",
+      "versionInfo": "57.0.9",
       "downloadLocation": "https://github.com/expo/expo",
       "filesAnalyzed": false,
       "licenseConcluded": "MIT",
@@ -1305,14 +1305,14 @@
         {
           "referenceCategory": "PACKAGE-MANAGER",
           "referenceType": "purl",
-          "referenceLocator": "pkg:npm/%40expo/config@56.0.12"
+          "referenceLocator": "pkg:npm/%40expo/config@57.0.9"
         }
       ]
     },
     {
       "name": "@expo/config-plugins",
-      "SPDXID": "SPDXRef-Package-cf8f2de11ad0cb5b",
-      "versionInfo": "56.0.13",
+      "SPDXID": "SPDXRef-Package-5b62941641563ebf",
+      "versionInfo": "57.0.9",
       "downloadLocation": "https://github.com/expo/expo",
       "filesAnalyzed": false,
       "licenseConcluded": "MIT",
@@ -1322,14 +1322,14 @@
         {
           "referenceCategory": "PACKAGE-MANAGER",
           "referenceType": "purl",
-          "referenceLocator": "pkg:npm/%40expo/config-plugins@56.0.13"
+          "referenceLocator": "pkg:npm/%40expo/config-plugins@57.0.9"
         }
       ]
     },
     {
       "name": "@expo/config-types",
-      "SPDXID": "SPDXRef-Package-cdeb690c56a84829",
-      "versionInfo": "56.0.7",
+      "SPDXID": "SPDXRef-Package-772be2704d1edaac",
+      "versionInfo": "57.0.2",
       "downloadLocation": "https://github.com/expo/expo",
       "filesAnalyzed": false,
       "licenseConcluded": "MIT",
@@ -1339,7 +1339,7 @@
         {
           "referenceCategory": "PACKAGE-MANAGER",
           "referenceType": "purl",
-          "referenceLocator": "pkg:npm/%40expo/config-types@56.0.7"
+          "referenceLocator": "pkg:npm/%40expo/config-types@57.0.2"
         }
       ]
     },
@@ -1362,8 +1362,8 @@
     },
     {
       "name": "@expo/devtools",
-      "SPDXID": "SPDXRef-Package-43316c9d32c89096",
-      "versionInfo": "56.0.2",
+      "SPDXID": "SPDXRef-Package-13b0840247977fd4",
+      "versionInfo": "57.0.1",
       "downloadLocation": "https://github.com/expo/expo",
       "filesAnalyzed": false,
       "licenseConcluded": "MIT",
@@ -1373,14 +1373,14 @@
         {
           "referenceCategory": "PACKAGE-MANAGER",
           "referenceType": "purl",
-          "referenceLocator": "pkg:npm/%40expo/devtools@56.0.2"
+          "referenceLocator": "pkg:npm/%40expo/devtools@57.0.1"
         }
       ]
     },
     {
       "name": "@expo/dom-webview",
-      "SPDXID": "SPDXRef-Package-617dd995820cbb4d",
-      "versionInfo": "56.0.6",
+      "SPDXID": "SPDXRef-Package-4747d19862c6c2b8",
+      "versionInfo": "57.0.1",
       "downloadLocation": "https://github.com/expo/expo",
       "filesAnalyzed": false,
       "licenseConcluded": "MIT",
@@ -1390,24 +1390,7 @@
         {
           "referenceCategory": "PACKAGE-MANAGER",
           "referenceType": "purl",
-          "referenceLocator": "pkg:npm/%40expo/dom-webview@56.0.6"
-        }
-      ]
-    },
-    {
-      "name": "@expo/env",
-      "SPDXID": "SPDXRef-Package-af1d891ecc9c652c",
-      "versionInfo": "2.3.1",
-      "downloadLocation": "https://github.com/expo/expo",
-      "filesAnalyzed": false,
-      "licenseConcluded": "MIT",
-      "licenseDeclared": "MIT",
-      "copyrightText": "NOASSERTION",
-      "externalRefs": [
-        {
-          "referenceCategory": "PACKAGE-MANAGER",
-          "referenceType": "purl",
-          "referenceLocator": "pkg:npm/%40expo/env@2.3.1"
+          "referenceLocator": "pkg:npm/%40expo/dom-webview@57.0.1"
         }
       ]
     },
@@ -1430,8 +1413,8 @@
     },
     {
       "name": "@expo/expo-modules-macros-plugin",
-      "SPDXID": "SPDXRef-Package-f7064e795090188d",
-      "versionInfo": "0.2.2",
+      "SPDXID": "SPDXRef-Package-a9b72b527dd55c2c",
+      "versionInfo": "0.6.1",
       "downloadLocation": "https://github.com/expo/expo-modules-macros-plugin",
       "filesAnalyzed": false,
       "licenseConcluded": "MIT",
@@ -1441,14 +1424,14 @@
         {
           "referenceCategory": "PACKAGE-MANAGER",
           "referenceType": "purl",
-          "referenceLocator": "pkg:npm/%40expo/expo-modules-macros-plugin@0.2.2"
+          "referenceLocator": "pkg:npm/%40expo/expo-modules-macros-plugin@0.6.1"
         }
       ]
     },
     {
       "name": "@expo/fingerprint",
-      "SPDXID": "SPDXRef-Package-5dd3cf74bac21b26",
-      "versionInfo": "0.19.8",
+      "SPDXID": "SPDXRef-Package-cf2499e732152ff1",
+      "versionInfo": "0.20.10",
       "downloadLocation": "https://github.com/expo/expo",
       "filesAnalyzed": false,
       "licenseConcluded": "MIT",
@@ -1458,14 +1441,14 @@
         {
           "referenceCategory": "PACKAGE-MANAGER",
           "referenceType": "purl",
-          "referenceLocator": "pkg:npm/%40expo/fingerprint@0.19.8"
+          "referenceLocator": "pkg:npm/%40expo/fingerprint@0.20.10"
         }
       ]
     },
     {
       "name": "@expo/image-utils",
-      "SPDXID": "SPDXRef-Package-24cf3edefeb8ede5",
-      "versionInfo": "0.10.3",
+      "SPDXID": "SPDXRef-Package-11cb55c38fa93cd7",
+      "versionInfo": "0.11.5",
       "downloadLocation": "https://github.com/expo/expo",
       "filesAnalyzed": false,
       "licenseConcluded": "MIT",
@@ -1475,31 +1458,14 @@
         {
           "referenceCategory": "PACKAGE-MANAGER",
           "referenceType": "purl",
-          "referenceLocator": "pkg:npm/%40expo/image-utils@0.10.3"
-        }
-      ]
-    },
-    {
-      "name": "@expo/image-utils",
-      "SPDXID": "SPDXRef-Package-52847b30294715dd",
-      "versionInfo": "0.10.4",
-      "downloadLocation": "https://github.com/expo/expo",
-      "filesAnalyzed": false,
-      "licenseConcluded": "MIT",
-      "licenseDeclared": "MIT",
-      "copyrightText": "NOASSERTION",
-      "externalRefs": [
-        {
-          "referenceCategory": "PACKAGE-MANAGER",
-          "referenceType": "purl",
-          "referenceLocator": "pkg:npm/%40expo/image-utils@0.10.4"
+          "referenceLocator": "pkg:npm/%40expo/image-utils@0.11.5"
         }
       ]
     },
     {
       "name": "@expo/inline-modules",
-      "SPDXID": "SPDXRef-Package-43d80c1b2da0e96a",
-      "versionInfo": "0.0.14",
+      "SPDXID": "SPDXRef-Package-20bcb76ccf8f4986",
+      "versionInfo": "0.1.7",
       "downloadLocation": "https://github.com/expo/expo",
       "filesAnalyzed": false,
       "licenseConcluded": "MIT",
@@ -1509,24 +1475,7 @@
         {
           "referenceCategory": "PACKAGE-MANAGER",
           "referenceType": "purl",
-          "referenceLocator": "pkg:npm/%40expo/inline-modules@0.0.14"
-        }
-      ]
-    },
-    {
-      "name": "@expo/json-file",
-      "SPDXID": "SPDXRef-Package-dca50474e69f294b",
-      "versionInfo": "10.2.0",
-      "downloadLocation": "https://github.com/expo/expo",
-      "filesAnalyzed": false,
-      "licenseConcluded": "MIT",
-      "licenseDeclared": "MIT",
-      "copyrightText": "NOASSERTION",
-      "externalRefs": [
-        {
-          "referenceCategory": "PACKAGE-MANAGER",
-          "referenceType": "purl",
-          "referenceLocator": "pkg:npm/%40expo/json-file@10.2.0"
+          "referenceLocator": "pkg:npm/%40expo/inline-modules@0.1.7"
         }
       ]
     },
@@ -1549,8 +1498,8 @@
     },
     {
       "name": "@expo/local-build-cache-provider",
-      "SPDXID": "SPDXRef-Package-91e14c6d4bc9e3b1",
-      "versionInfo": "56.0.10",
+      "SPDXID": "SPDXRef-Package-7161e8a7d78e0b5d",
+      "versionInfo": "57.0.8",
       "downloadLocation": "https://github.com/expo/expo",
       "filesAnalyzed": false,
       "licenseConcluded": "MIT",
@@ -1560,14 +1509,14 @@
         {
           "referenceCategory": "PACKAGE-MANAGER",
           "referenceType": "purl",
-          "referenceLocator": "pkg:npm/%40expo/local-build-cache-provider@56.0.10"
+          "referenceLocator": "pkg:npm/%40expo/local-build-cache-provider@57.0.8"
         }
       ]
     },
     {
       "name": "@expo/log-box",
-      "SPDXID": "SPDXRef-Package-18f232e2f8bcfc8d",
-      "versionInfo": "56.0.14",
+      "SPDXID": "SPDXRef-Package-4ab6622b68b7ad20",
+      "versionInfo": "57.0.4",
       "downloadLocation": "https://github.com/expo/expo/tree/main/packages/@expo/log-box",
       "filesAnalyzed": false,
       "licenseConcluded": "MIT",
@@ -1577,14 +1526,14 @@
         {
           "referenceCategory": "PACKAGE-MANAGER",
           "referenceType": "purl",
-          "referenceLocator": "pkg:npm/%40expo/log-box@56.0.14"
+          "referenceLocator": "pkg:npm/%40expo/log-box@57.0.4"
         }
       ]
     },
     {
       "name": "@expo/metro",
-      "SPDXID": "SPDXRef-Package-87d75a8a36e3a905",
-      "versionInfo": "56.0.0",
+      "SPDXID": "SPDXRef-Package-f555a00e5e60bd38",
+      "versionInfo": "56.0.2",
       "downloadLocation": "https://github.com/expo/expo-metro",
       "filesAnalyzed": false,
       "licenseConcluded": "MIT",
@@ -1594,14 +1543,14 @@
         {
           "referenceCategory": "PACKAGE-MANAGER",
           "referenceType": "purl",
-          "referenceLocator": "pkg:npm/%40expo/metro@56.0.0"
+          "referenceLocator": "pkg:npm/%40expo/metro@56.0.2"
         }
       ]
     },
     {
       "name": "@expo/metro-config",
-      "SPDXID": "SPDXRef-Package-fdc1aa5e69b581c1",
-      "versionInfo": "56.0.17",
+      "SPDXID": "SPDXRef-Package-7ba1e9724ad8c5a0",
+      "versionInfo": "57.0.11",
       "downloadLocation": "https://github.com/expo/expo",
       "filesAnalyzed": false,
       "licenseConcluded": "MIT",
@@ -1611,14 +1560,14 @@
         {
           "referenceCategory": "PACKAGE-MANAGER",
           "referenceType": "purl",
-          "referenceLocator": "pkg:npm/%40expo/metro-config@56.0.17"
+          "referenceLocator": "pkg:npm/%40expo/metro-config@57.0.11"
         }
       ]
     },
     {
       "name": "@expo/metro-file-map",
-      "SPDXID": "SPDXRef-Package-2499d3555c55bdd8",
-      "versionInfo": "56.0.3",
+      "SPDXID": "SPDXRef-Package-9613d6cca786e5b8",
+      "versionInfo": "57.0.2",
       "downloadLocation": "https://github.com/expo/expo",
       "filesAnalyzed": false,
       "licenseConcluded": "MIT",
@@ -1628,14 +1577,14 @@
         {
           "referenceCategory": "PACKAGE-MANAGER",
           "referenceType": "purl",
-          "referenceLocator": "pkg:npm/%40expo/metro-file-map@56.0.3"
+          "referenceLocator": "pkg:npm/%40expo/metro-file-map@57.0.2"
         }
       ]
     },
     {
       "name": "@expo/metro-runtime",
-      "SPDXID": "SPDXRef-Package-9ce7cf04e77ca4a6",
-      "versionInfo": "56.0.17",
+      "SPDXID": "SPDXRef-Package-ea9b1f8b52305c58",
+      "versionInfo": "57.0.14",
       "downloadLocation": "https://github.com/expo/expo",
       "filesAnalyzed": false,
       "licenseConcluded": "MIT",
@@ -1645,7 +1594,7 @@
         {
           "referenceCategory": "PACKAGE-MANAGER",
           "referenceType": "purl",
-          "referenceLocator": "pkg:npm/%40expo/metro-runtime@56.0.17"
+          "referenceLocator": "pkg:npm/%40expo/metro-runtime@57.0.14"
         }
       ]
     },
@@ -1685,8 +1634,8 @@
     },
     {
       "name": "@expo/plist",
-      "SPDXID": "SPDXRef-Package-c954ec0010947377",
-      "versionInfo": "0.7.0",
+      "SPDXID": "SPDXRef-Package-dab0f600a6aac3a5",
+      "versionInfo": "0.8.1",
       "downloadLocation": "https://github.com/expo/expo",
       "filesAnalyzed": false,
       "licenseConcluded": "MIT",
@@ -1696,14 +1645,14 @@
         {
           "referenceCategory": "PACKAGE-MANAGER",
           "referenceType": "purl",
-          "referenceLocator": "pkg:npm/%40expo/plist@0.7.0"
+          "referenceLocator": "pkg:npm/%40expo/plist@0.8.1"
         }
       ]
     },
     {
       "name": "@expo/prebuild-config",
-      "SPDXID": "SPDXRef-Package-db0a8a179287852b",
-      "versionInfo": "56.0.20",
+      "SPDXID": "SPDXRef-Package-828ab691dacd318f",
+      "versionInfo": "57.0.15",
       "downloadLocation": "https://github.com/expo/expo",
       "filesAnalyzed": false,
       "licenseConcluded": "MIT",
@@ -1713,14 +1662,14 @@
         {
           "referenceCategory": "PACKAGE-MANAGER",
           "referenceType": "purl",
-          "referenceLocator": "pkg:npm/%40expo/prebuild-config@56.0.20"
+          "referenceLocator": "pkg:npm/%40expo/prebuild-config@57.0.15"
         }
       ]
     },
     {
       "name": "@expo/require-utils",
-      "SPDXID": "SPDXRef-Package-4c47aeaa005e858a",
-      "versionInfo": "56.1.5",
+      "SPDXID": "SPDXRef-Package-7ef22c29797e4d3d",
+      "versionInfo": "57.0.5",
       "downloadLocation": "https://github.com/expo/expo",
       "filesAnalyzed": false,
       "licenseConcluded": "MIT",
@@ -1730,31 +1679,14 @@
         {
           "referenceCategory": "PACKAGE-MANAGER",
           "referenceType": "purl",
-          "referenceLocator": "pkg:npm/%40expo/require-utils@56.1.5"
-        }
-      ]
-    },
-    {
-      "name": "@expo/require-utils",
-      "SPDXID": "SPDXRef-Package-a4143b2eec52de2b",
-      "versionInfo": "56.1.6",
-      "downloadLocation": "https://github.com/expo/expo",
-      "filesAnalyzed": false,
-      "licenseConcluded": "MIT",
-      "licenseDeclared": "MIT",
-      "copyrightText": "NOASSERTION",
-      "externalRefs": [
-        {
-          "referenceCategory": "PACKAGE-MANAGER",
-          "referenceType": "purl",
-          "referenceLocator": "pkg:npm/%40expo/require-utils@56.1.6"
+          "referenceLocator": "pkg:npm/%40expo/require-utils@57.0.5"
         }
       ]
     },
     {
       "name": "@expo/router-server",
-      "SPDXID": "SPDXRef-Package-b1d9220809aa7a64",
-      "versionInfo": "56.0.16",
+      "SPDXID": "SPDXRef-Package-952f3858313b4378",
+      "versionInfo": "57.0.8",
       "downloadLocation": "https://github.com/expo/expo",
       "filesAnalyzed": false,
       "licenseConcluded": "MIT",
@@ -1764,14 +1696,14 @@
         {
           "referenceCategory": "PACKAGE-MANAGER",
           "referenceType": "purl",
-          "referenceLocator": "pkg:npm/%40expo/router-server@56.0.16"
+          "referenceLocator": "pkg:npm/%40expo/router-server@57.0.8"
         }
       ]
     },
     {
       "name": "@expo/schema-utils",
-      "SPDXID": "SPDXRef-Package-c0bac98925b4634a",
-      "versionInfo": "56.0.2",
+      "SPDXID": "SPDXRef-Package-98e94fcbd54437ff",
+      "versionInfo": "57.0.2",
       "downloadLocation": "https://github.com/expo/expo",
       "filesAnalyzed": false,
       "licenseConcluded": "MIT",
@@ -1781,7 +1713,7 @@
         {
           "referenceCategory": "PACKAGE-MANAGER",
           "referenceType": "purl",
-          "referenceLocator": "pkg:npm/%40expo/schema-utils@56.0.2"
+          "referenceLocator": "pkg:npm/%40expo/schema-utils@57.0.2"
         }
       ]
     },
@@ -1838,8 +1770,8 @@
     },
     {
       "name": "@expo/ui",
-      "SPDXID": "SPDXRef-Package-87d88e47cacb464b",
-      "versionInfo": "56.0.22",
+      "SPDXID": "SPDXRef-Package-0acdbde3f99d7b83",
+      "versionInfo": "57.0.14",
       "downloadLocation": "https://github.com/expo/expo",
       "filesAnalyzed": false,
       "licenseConcluded": "MIT",
@@ -1849,7 +1781,7 @@
         {
           "referenceCategory": "PACKAGE-MANAGER",
           "referenceType": "purl",
-          "referenceLocator": "pkg:npm/%40expo/ui@56.0.22"
+          "referenceLocator": "pkg:npm/%40expo/ui@57.0.14"
         }
       ]
     },
@@ -2483,10 +2415,10 @@
       ]
     },
     {
-      "name": "@react-native/assets-registry",
-      "SPDXID": "SPDXRef-Package-697edb2f6789d2bf",
-      "versionInfo": "0.85.3",
-      "downloadLocation": "https://github.com/facebook/react-native",
+      "name": "@react-native-menu/menu",
+      "SPDXID": "SPDXRef-Package-21e2f3b9e698d433",
+      "versionInfo": "2.0.0",
+      "downloadLocation": "https://github.com/react-native-menu/menu",
       "filesAnalyzed": false,
       "licenseConcluded": "MIT",
       "licenseDeclared": "MIT",
@@ -2495,15 +2427,32 @@
         {
           "referenceCategory": "PACKAGE-MANAGER",
           "referenceType": "purl",
-          "referenceLocator": "pkg:npm/%40react-native/assets-registry@0.85.3"
+          "referenceLocator": "pkg:npm/%40react-native-menu/menu@2.0.0"
+        }
+      ]
+    },
+    {
+      "name": "@react-native/assets-registry",
+      "SPDXID": "SPDXRef-Package-7679de1ca6bac3dc",
+      "versionInfo": "0.86.3",
+      "downloadLocation": "https://github.com/react/react-native",
+      "filesAnalyzed": false,
+      "licenseConcluded": "MIT",
+      "licenseDeclared": "MIT",
+      "copyrightText": "NOASSERTION",
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceType": "purl",
+          "referenceLocator": "pkg:npm/%40react-native/assets-registry@0.86.3"
         }
       ]
     },
     {
       "name": "@react-native/babel-plugin-codegen",
-      "SPDXID": "SPDXRef-Package-39bee8b40a187d72",
-      "versionInfo": "0.85.3",
-      "downloadLocation": "https://github.com/facebook/react-native",
+      "SPDXID": "SPDXRef-Package-434137ef60694065",
+      "versionInfo": "0.86.3",
+      "downloadLocation": "https://github.com/react/react-native",
       "filesAnalyzed": false,
       "licenseConcluded": "MIT",
       "licenseDeclared": "MIT",
@@ -2512,15 +2461,15 @@
         {
           "referenceCategory": "PACKAGE-MANAGER",
           "referenceType": "purl",
-          "referenceLocator": "pkg:npm/%40react-native/babel-plugin-codegen@0.85.3"
+          "referenceLocator": "pkg:npm/%40react-native/babel-plugin-codegen@0.86.3"
         }
       ]
     },
     {
       "name": "@react-native/codegen",
-      "SPDXID": "SPDXRef-Package-319a60e34cc90e53",
-      "versionInfo": "0.85.3",
-      "downloadLocation": "https://github.com/facebook/react-native",
+      "SPDXID": "SPDXRef-Package-ea25b6a034786450",
+      "versionInfo": "0.86.3",
+      "downloadLocation": "https://github.com/react/react-native",
       "filesAnalyzed": false,
       "licenseConcluded": "MIT",
       "licenseDeclared": "MIT",
@@ -2529,15 +2478,15 @@
         {
           "referenceCategory": "PACKAGE-MANAGER",
           "referenceType": "purl",
-          "referenceLocator": "pkg:npm/%40react-native/codegen@0.85.3"
+          "referenceLocator": "pkg:npm/%40react-native/codegen@0.86.3"
         }
       ]
     },
     {
       "name": "@react-native/community-cli-plugin",
-      "SPDXID": "SPDXRef-Package-2246cebc8611d4a9",
-      "versionInfo": "0.85.3",
-      "downloadLocation": "https://github.com/facebook/react-native",
+      "SPDXID": "SPDXRef-Package-007d6833d0beec2b",
+      "versionInfo": "0.86.3",
+      "downloadLocation": "https://github.com/react/react-native",
       "filesAnalyzed": false,
       "licenseConcluded": "MIT",
       "licenseDeclared": "MIT",
@@ -2546,15 +2495,15 @@
         {
           "referenceCategory": "PACKAGE-MANAGER",
           "referenceType": "purl",
-          "referenceLocator": "pkg:npm/%40react-native/community-cli-plugin@0.85.3"
+          "referenceLocator": "pkg:npm/%40react-native/community-cli-plugin@0.86.3"
         }
       ]
     },
     {
       "name": "@react-native/debugger-frontend",
-      "SPDXID": "SPDXRef-Package-73c5e62980816f3b",
-      "versionInfo": "0.85.3",
-      "downloadLocation": "https://github.com/facebook/react-native",
+      "SPDXID": "SPDXRef-Package-0377a46cabd76d85",
+      "versionInfo": "0.86.3",
+      "downloadLocation": "https://github.com/react/react-native",
       "filesAnalyzed": false,
       "licenseConcluded": "BSD-3-Clause",
       "licenseDeclared": "BSD-3-Clause",
@@ -2563,15 +2512,15 @@
         {
           "referenceCategory": "PACKAGE-MANAGER",
           "referenceType": "purl",
-          "referenceLocator": "pkg:npm/%40react-native/debugger-frontend@0.85.3"
+          "referenceLocator": "pkg:npm/%40react-native/debugger-frontend@0.86.3"
         }
       ]
     },
     {
       "name": "@react-native/debugger-shell",
-      "SPDXID": "SPDXRef-Package-90829fd85682cb54",
-      "versionInfo": "0.85.3",
-      "downloadLocation": "https://github.com/facebook/react-native",
+      "SPDXID": "SPDXRef-Package-b2c43839a201485c",
+      "versionInfo": "0.86.3",
+      "downloadLocation": "https://github.com/react/react-native",
       "filesAnalyzed": false,
       "licenseConcluded": "MIT",
       "licenseDeclared": "MIT",
@@ -2580,15 +2529,15 @@
         {
           "referenceCategory": "PACKAGE-MANAGER",
           "referenceType": "purl",
-          "referenceLocator": "pkg:npm/%40react-native/debugger-shell@0.85.3"
+          "referenceLocator": "pkg:npm/%40react-native/debugger-shell@0.86.3"
         }
       ]
     },
     {
       "name": "@react-native/dev-middleware",
-      "SPDXID": "SPDXRef-Package-b07732d9e61953dc",
-      "versionInfo": "0.85.3",
-      "downloadLocation": "https://github.com/facebook/react-native",
+      "SPDXID": "SPDXRef-Package-11f24d26ef45da66",
+      "versionInfo": "0.86.3",
+      "downloadLocation": "https://github.com/react/react-native",
       "filesAnalyzed": false,
       "licenseConcluded": "MIT",
       "licenseDeclared": "MIT",
@@ -2597,15 +2546,15 @@
         {
           "referenceCategory": "PACKAGE-MANAGER",
           "referenceType": "purl",
-          "referenceLocator": "pkg:npm/%40react-native/dev-middleware@0.85.3"
+          "referenceLocator": "pkg:npm/%40react-native/dev-middleware@0.86.3"
         }
       ]
     },
     {
       "name": "@react-native/gradle-plugin",
-      "SPDXID": "SPDXRef-Package-2bc8ec6514dca871",
-      "versionInfo": "0.85.3",
-      "downloadLocation": "https://github.com/facebook/react-native",
+      "SPDXID": "SPDXRef-Package-e472e20c90af8fe4",
+      "versionInfo": "0.86.3",
+      "downloadLocation": "https://github.com/react/react-native",
       "filesAnalyzed": false,
       "licenseConcluded": "MIT",
       "licenseDeclared": "MIT",
@@ -2614,15 +2563,15 @@
         {
           "referenceCategory": "PACKAGE-MANAGER",
           "referenceType": "purl",
-          "referenceLocator": "pkg:npm/%40react-native/gradle-plugin@0.85.3"
+          "referenceLocator": "pkg:npm/%40react-native/gradle-plugin@0.86.3"
         }
       ]
     },
     {
       "name": "@react-native/js-polyfills",
-      "SPDXID": "SPDXRef-Package-f790a5dd2c1b424e",
-      "versionInfo": "0.85.3",
-      "downloadLocation": "https://github.com/facebook/react-native",
+      "SPDXID": "SPDXRef-Package-fc0492cb2625a29f",
+      "versionInfo": "0.86.3",
+      "downloadLocation": "https://github.com/react/react-native",
       "filesAnalyzed": false,
       "licenseConcluded": "MIT",
       "licenseDeclared": "MIT",
@@ -2631,7 +2580,7 @@
         {
           "referenceCategory": "PACKAGE-MANAGER",
           "referenceType": "purl",
-          "referenceLocator": "pkg:npm/%40react-native/js-polyfills@0.85.3"
+          "referenceLocator": "pkg:npm/%40react-native/js-polyfills@0.86.3"
         }
       ]
     },
@@ -2654,9 +2603,9 @@
     },
     {
       "name": "@react-native/normalize-colors",
-      "SPDXID": "SPDXRef-Package-0b5a844e5407336a",
-      "versionInfo": "0.85.3",
-      "downloadLocation": "https://github.com/facebook/react-native",
+      "SPDXID": "SPDXRef-Package-48ec3746ca63e32d",
+      "versionInfo": "0.86.3",
+      "downloadLocation": "https://github.com/react/react-native",
       "filesAnalyzed": false,
       "licenseConcluded": "MIT",
       "licenseDeclared": "MIT",
@@ -2665,15 +2614,15 @@
         {
           "referenceCategory": "PACKAGE-MANAGER",
           "referenceType": "purl",
-          "referenceLocator": "pkg:npm/%40react-native/normalize-colors@0.85.3"
+          "referenceLocator": "pkg:npm/%40react-native/normalize-colors@0.86.3"
         }
       ]
     },
     {
       "name": "@react-native/virtualized-lists",
-      "SPDXID": "SPDXRef-Package-29f40625ff887dce",
-      "versionInfo": "0.85.3",
-      "downloadLocation": "https://github.com/facebook/react-native",
+      "SPDXID": "SPDXRef-Package-48adfa4b57db12d0",
+      "versionInfo": "0.86.3",
+      "downloadLocation": "https://github.com/react/react-native",
       "filesAnalyzed": false,
       "licenseConcluded": "MIT",
       "licenseDeclared": "MIT",
@@ -2682,7 +2631,7 @@
         {
           "referenceCategory": "PACKAGE-MANAGER",
           "referenceType": "purl",
-          "referenceLocator": "pkg:npm/%40react-native/virtualized-lists@0.85.3"
+          "referenceLocator": "pkg:npm/%40react-native/virtualized-lists@0.86.3"
         }
       ]
     },
@@ -2704,10 +2653,10 @@
       ]
     },
     {
-      "name": "@testing-library/jest-dom",
-      "SPDXID": "SPDXRef-Package-e6cc8a080e50374e",
-      "versionInfo": "6.9.1",
-      "downloadLocation": "https://github.com/testing-library/jest-dom",
+      "name": "@types/hammerjs",
+      "SPDXID": "SPDXRef-Package-d80edd77c266fce4",
+      "versionInfo": "2.0.46",
+      "downloadLocation": "https://github.com/DefinitelyTyped/DefinitelyTyped",
       "filesAnalyzed": false,
       "licenseConcluded": "MIT",
       "licenseDeclared": "MIT",
@@ -2716,24 +2665,7 @@
         {
           "referenceCategory": "PACKAGE-MANAGER",
           "referenceType": "purl",
-          "referenceLocator": "pkg:npm/%40testing-library/jest-dom@6.9.1"
-        }
-      ]
-    },
-    {
-      "name": "@testing-library/user-event",
-      "SPDXID": "SPDXRef-Package-58f40d3f2ac7f037",
-      "versionInfo": "14.6.1",
-      "downloadLocation": "https://github.com/testing-library/user-event",
-      "filesAnalyzed": false,
-      "licenseConcluded": "MIT",
-      "licenseDeclared": "MIT",
-      "copyrightText": "NOASSERTION",
-      "externalRefs": [
-        {
-          "referenceCategory": "PACKAGE-MANAGER",
-          "referenceType": "purl",
-          "referenceLocator": "pkg:npm/%40testing-library/user-event@14.6.1"
+          "referenceLocator": "pkg:npm/%40types/hammerjs@2.0.46"
         }
       ]
     },
@@ -3028,9 +2960,9 @@
     },
     {
       "name": "agent-cli-detector",
-      "SPDXID": "SPDXRef-Package-225d9eba44f2c070",
-      "versionInfo": "0.1.2",
-      "downloadLocation": "NOASSERTION",
+      "SPDXID": "SPDXRef-Package-941d66f44d7533af",
+      "versionInfo": "0.1.6",
+      "downloadLocation": "https://github.com/expo/agent-cli-detector",
       "filesAnalyzed": false,
       "licenseConcluded": "MIT",
       "licenseDeclared": "MIT",
@@ -3039,7 +2971,7 @@
         {
           "referenceCategory": "PACKAGE-MANAGER",
           "referenceType": "purl",
-          "referenceLocator": "pkg:npm/agent-cli-detector@0.1.2"
+          "referenceLocator": "pkg:npm/agent-cli-detector@0.1.6"
         }
       ]
     },
@@ -3231,23 +3163,6 @@
       ]
     },
     {
-      "name": "aria-query",
-      "SPDXID": "SPDXRef-Package-93e30f698184db06",
-      "versionInfo": "5.3.2",
-      "downloadLocation": "https://github.com/A11yance/aria-query",
-      "filesAnalyzed": false,
-      "licenseConcluded": "Apache-2.0",
-      "licenseDeclared": "Apache-2.0",
-      "copyrightText": "NOASSERTION",
-      "externalRefs": [
-        {
-          "referenceCategory": "PACKAGE-MANAGER",
-          "referenceType": "purl",
-          "referenceLocator": "pkg:npm/aria-query@5.3.2"
-        }
-      ]
-    },
-    {
       "name": "asap",
       "SPDXID": "SPDXRef-Package-2a5f02a5b88d90c7",
       "versionInfo": "2.0.6",
@@ -3351,8 +3266,8 @@
     },
     {
       "name": "babel-plugin-syntax-hermes-parser",
-      "SPDXID": "SPDXRef-Package-bdd394dd76daf688",
-      "versionInfo": "0.33.3",
+      "SPDXID": "SPDXRef-Package-001e09a3c95a0f4c",
+      "versionInfo": "0.36.0",
       "downloadLocation": "https://github.com/facebook/hermes",
       "filesAnalyzed": false,
       "licenseConcluded": "MIT",
@@ -3362,7 +3277,24 @@
         {
           "referenceCategory": "PACKAGE-MANAGER",
           "referenceType": "purl",
-          "referenceLocator": "pkg:npm/babel-plugin-syntax-hermes-parser@0.33.3"
+          "referenceLocator": "pkg:npm/babel-plugin-syntax-hermes-parser@0.36.0"
+        }
+      ]
+    },
+    {
+      "name": "babel-plugin-syntax-hermes-parser",
+      "SPDXID": "SPDXRef-Package-4bb46f134eb78acd",
+      "versionInfo": "0.36.1",
+      "downloadLocation": "https://github.com/facebook/hermes",
+      "filesAnalyzed": false,
+      "licenseConcluded": "MIT",
+      "licenseDeclared": "MIT",
+      "copyrightText": "NOASSERTION",
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceType": "purl",
+          "referenceLocator": "pkg:npm/babel-plugin-syntax-hermes-parser@0.36.1"
         }
       ]
     },
@@ -3385,8 +3317,8 @@
     },
     {
       "name": "babel-preset-expo",
-      "SPDXID": "SPDXRef-Package-2d518b389f6bb837",
-      "versionInfo": "56.0.17",
+      "SPDXID": "SPDXRef-Package-a5b27d8080aa66fa",
+      "versionInfo": "57.0.9",
       "downloadLocation": "https://github.com/expo/expo",
       "filesAnalyzed": false,
       "licenseConcluded": "MIT",
@@ -3396,7 +3328,7 @@
         {
           "referenceCategory": "PACKAGE-MANAGER",
           "referenceType": "purl",
-          "referenceLocator": "pkg:npm/babel-preset-expo@56.0.17"
+          "referenceLocator": "pkg:npm/babel-preset-expo@57.0.9"
         }
       ]
     },
@@ -4217,23 +4149,6 @@
       ]
     },
     {
-      "name": "css.escape",
-      "SPDXID": "SPDXRef-Package-12f921da792516fb",
-      "versionInfo": "1.5.1",
-      "downloadLocation": "https://github.com/mathiasbynens/CSS.escape",
-      "filesAnalyzed": false,
-      "licenseConcluded": "MIT",
-      "licenseDeclared": "MIT",
-      "copyrightText": "NOASSERTION",
-      "externalRefs": [
-        {
-          "referenceCategory": "PACKAGE-MANAGER",
-          "referenceType": "purl",
-          "referenceLocator": "pkg:npm/css.escape@1.5.1"
-        }
-      ]
-    },
-    {
       "name": "csstype",
       "SPDXID": "SPDXRef-Package-b05903de4c965507",
       "versionInfo": "3.2.3",
@@ -4434,23 +4349,6 @@
           "referenceCategory": "PACKAGE-MANAGER",
           "referenceType": "purl",
           "referenceLocator": "pkg:npm/dnssd-advertise@1.1.6"
-        }
-      ]
-    },
-    {
-      "name": "dom-accessibility-api",
-      "SPDXID": "SPDXRef-Package-1c3a0e559d0f9ecd",
-      "versionInfo": "0.6.3",
-      "downloadLocation": "https://github.com/eps1lon/dom-accessibility-api",
-      "filesAnalyzed": false,
-      "licenseConcluded": "MIT",
-      "licenseDeclared": "MIT",
-      "copyrightText": "NOASSERTION",
-      "externalRefs": [
-        {
-          "referenceCategory": "PACKAGE-MANAGER",
-          "referenceType": "purl",
-          "referenceLocator": "pkg:npm/dom-accessibility-api@0.6.3"
         }
       ]
     },
@@ -4762,8 +4660,8 @@
     },
     {
       "name": "expo",
-      "SPDXID": "SPDXRef-Package-f904a8f640516fd4",
-      "versionInfo": "56.0.16",
+      "SPDXID": "SPDXRef-Package-a21f8aa8ea316bba",
+      "versionInfo": "57.0.17",
       "downloadLocation": "https://github.com/expo/expo",
       "filesAnalyzed": false,
       "licenseConcluded": "MIT",
@@ -4773,14 +4671,14 @@
         {
           "referenceCategory": "PACKAGE-MANAGER",
           "referenceType": "purl",
-          "referenceLocator": "pkg:npm/expo@56.0.16"
+          "referenceLocator": "pkg:npm/expo@57.0.17"
         }
       ]
     },
     {
       "name": "expo-apple-authentication",
-      "SPDXID": "SPDXRef-Package-49bdb2df683d4c2b",
-      "versionInfo": "56.0.4",
+      "SPDXID": "SPDXRef-Package-d3e78dcf1fe1fd7f",
+      "versionInfo": "57.0.1",
       "downloadLocation": "https://github.com/expo/expo",
       "filesAnalyzed": false,
       "licenseConcluded": "MIT",
@@ -4790,14 +4688,14 @@
         {
           "referenceCategory": "PACKAGE-MANAGER",
           "referenceType": "purl",
-          "referenceLocator": "pkg:npm/expo-apple-authentication@56.0.4"
+          "referenceLocator": "pkg:npm/expo-apple-authentication@57.0.1"
         }
       ]
     },
     {
       "name": "expo-application",
-      "SPDXID": "SPDXRef-Package-c0652dfd8ad23fd0",
-      "versionInfo": "56.0.3",
+      "SPDXID": "SPDXRef-Package-96bd055d8952a64a",
+      "versionInfo": "57.0.2",
       "downloadLocation": "https://github.com/expo/expo",
       "filesAnalyzed": false,
       "licenseConcluded": "MIT",
@@ -4807,14 +4705,14 @@
         {
           "referenceCategory": "PACKAGE-MANAGER",
           "referenceType": "purl",
-          "referenceLocator": "pkg:npm/expo-application@56.0.3"
+          "referenceLocator": "pkg:npm/expo-application@57.0.2"
         }
       ]
     },
     {
       "name": "expo-asset",
-      "SPDXID": "SPDXRef-Package-5244d65f73050017",
-      "versionInfo": "56.0.20",
+      "SPDXID": "SPDXRef-Package-eb081b986ec50ba8",
+      "versionInfo": "57.0.15",
       "downloadLocation": "https://github.com/expo/expo",
       "filesAnalyzed": false,
       "licenseConcluded": "MIT",
@@ -4824,14 +4722,14 @@
         {
           "referenceCategory": "PACKAGE-MANAGER",
           "referenceType": "purl",
-          "referenceLocator": "pkg:npm/expo-asset@56.0.20"
+          "referenceLocator": "pkg:npm/expo-asset@57.0.15"
         }
       ]
     },
     {
       "name": "expo-audio",
-      "SPDXID": "SPDXRef-Package-de023797d4f6beb3",
-      "versionInfo": "56.0.12",
+      "SPDXID": "SPDXRef-Package-33d1161b33e80a74",
+      "versionInfo": "57.0.4",
       "downloadLocation": "https://github.com/expo/expo",
       "filesAnalyzed": false,
       "licenseConcluded": "MIT",
@@ -4841,14 +4739,14 @@
         {
           "referenceCategory": "PACKAGE-MANAGER",
           "referenceType": "purl",
-          "referenceLocator": "pkg:npm/expo-audio@56.0.12"
+          "referenceLocator": "pkg:npm/expo-audio@57.0.4"
         }
       ]
     },
     {
       "name": "expo-auth-session",
-      "SPDXID": "SPDXRef-Package-617b233816b65cd3",
-      "versionInfo": "56.0.15",
+      "SPDXID": "SPDXRef-Package-16721e986d3b9518",
+      "versionInfo": "57.0.10",
       "downloadLocation": "https://github.com/expo/expo",
       "filesAnalyzed": false,
       "licenseConcluded": "MIT",
@@ -4858,14 +4756,14 @@
         {
           "referenceCategory": "PACKAGE-MANAGER",
           "referenceType": "purl",
-          "referenceLocator": "pkg:npm/expo-auth-session@56.0.15"
+          "referenceLocator": "pkg:npm/expo-auth-session@57.0.10"
         }
       ]
     },
     {
       "name": "expo-blur",
-      "SPDXID": "SPDXRef-Package-1f337586ebdeb8f6",
-      "versionInfo": "56.0.4",
+      "SPDXID": "SPDXRef-Package-212df03adf8ed7fe",
+      "versionInfo": "57.0.2",
       "downloadLocation": "https://github.com/expo/expo",
       "filesAnalyzed": false,
       "licenseConcluded": "MIT",
@@ -4875,14 +4773,14 @@
         {
           "referenceCategory": "PACKAGE-MANAGER",
           "referenceType": "purl",
-          "referenceLocator": "pkg:npm/expo-blur@56.0.4"
+          "referenceLocator": "pkg:npm/expo-blur@57.0.2"
         }
       ]
     },
     {
       "name": "expo-build-properties",
-      "SPDXID": "SPDXRef-Package-4509b3d6d2ad2247",
-      "versionInfo": "56.0.23",
+      "SPDXID": "SPDXRef-Package-db974288258db9d5",
+      "versionInfo": "57.0.15",
       "downloadLocation": "https://github.com/expo/expo",
       "filesAnalyzed": false,
       "licenseConcluded": "MIT",
@@ -4892,14 +4790,14 @@
         {
           "referenceCategory": "PACKAGE-MANAGER",
           "referenceType": "purl",
-          "referenceLocator": "pkg:npm/expo-build-properties@56.0.23"
+          "referenceLocator": "pkg:npm/expo-build-properties@57.0.15"
         }
       ]
     },
     {
       "name": "expo-clipboard",
-      "SPDXID": "SPDXRef-Package-ae73538e6490c31d",
-      "versionInfo": "56.0.4",
+      "SPDXID": "SPDXRef-Package-aa4802bc4df9e75d",
+      "versionInfo": "57.0.1",
       "downloadLocation": "https://github.com/expo/expo",
       "filesAnalyzed": false,
       "licenseConcluded": "MIT",
@@ -4909,14 +4807,14 @@
         {
           "referenceCategory": "PACKAGE-MANAGER",
           "referenceType": "purl",
-          "referenceLocator": "pkg:npm/expo-clipboard@56.0.4"
+          "referenceLocator": "pkg:npm/expo-clipboard@57.0.1"
         }
       ]
     },
     {
       "name": "expo-constants",
-      "SPDXID": "SPDXRef-Package-2f57860ffb00e84a",
-      "versionInfo": "56.0.21",
+      "SPDXID": "SPDXRef-Package-178ca4d8f21ab312",
+      "versionInfo": "57.0.15",
       "downloadLocation": "https://github.com/expo/expo",
       "filesAnalyzed": false,
       "licenseConcluded": "MIT",
@@ -4926,31 +4824,14 @@
         {
           "referenceCategory": "PACKAGE-MANAGER",
           "referenceType": "purl",
-          "referenceLocator": "pkg:npm/expo-constants@56.0.21"
-        }
-      ]
-    },
-    {
-      "name": "expo-constants",
-      "SPDXID": "SPDXRef-Package-c24f51763a027a0c",
-      "versionInfo": "56.0.22",
-      "downloadLocation": "https://github.com/expo/expo",
-      "filesAnalyzed": false,
-      "licenseConcluded": "MIT",
-      "licenseDeclared": "MIT",
-      "copyrightText": "NOASSERTION",
-      "externalRefs": [
-        {
-          "referenceCategory": "PACKAGE-MANAGER",
-          "referenceType": "purl",
-          "referenceLocator": "pkg:npm/expo-constants@56.0.22"
+          "referenceLocator": "pkg:npm/expo-constants@57.0.15"
         }
       ]
     },
     {
       "name": "expo-crypto",
-      "SPDXID": "SPDXRef-Package-c6f45a0d6c4e5cd4",
-      "versionInfo": "56.0.4",
+      "SPDXID": "SPDXRef-Package-437ab5e1d8c16256",
+      "versionInfo": "57.0.2",
       "downloadLocation": "https://github.com/expo/expo",
       "filesAnalyzed": false,
       "licenseConcluded": "MIT",
@@ -4960,14 +4841,14 @@
         {
           "referenceCategory": "PACKAGE-MANAGER",
           "referenceType": "purl",
-          "referenceLocator": "pkg:npm/expo-crypto@56.0.4"
+          "referenceLocator": "pkg:npm/expo-crypto@57.0.2"
         }
       ]
     },
     {
       "name": "expo-document-picker",
-      "SPDXID": "SPDXRef-Package-33a951a400f7df59",
-      "versionInfo": "56.0.4",
+      "SPDXID": "SPDXRef-Package-a5bbd96cc10aa769",
+      "versionInfo": "57.0.1",
       "downloadLocation": "https://github.com/expo/expo",
       "filesAnalyzed": false,
       "licenseConcluded": "MIT",
@@ -4977,14 +4858,14 @@
         {
           "referenceCategory": "PACKAGE-MANAGER",
           "referenceType": "purl",
-          "referenceLocator": "pkg:npm/expo-document-picker@56.0.4"
+          "referenceLocator": "pkg:npm/expo-document-picker@57.0.1"
         }
       ]
     },
     {
       "name": "expo-eas-client",
-      "SPDXID": "SPDXRef-Package-eefa29432c981aa8",
-      "versionInfo": "56.0.1",
+      "SPDXID": "SPDXRef-Package-7db55d7e21b6e61b",
+      "versionInfo": "57.0.2",
       "downloadLocation": "https://github.com/expo/expo",
       "filesAnalyzed": false,
       "licenseConcluded": "MIT",
@@ -4994,14 +4875,14 @@
         {
           "referenceCategory": "PACKAGE-MANAGER",
           "referenceType": "purl",
-          "referenceLocator": "pkg:npm/expo-eas-client@56.0.1"
+          "referenceLocator": "pkg:npm/expo-eas-client@57.0.2"
         }
       ]
     },
     {
       "name": "expo-file-system",
-      "SPDXID": "SPDXRef-Package-7f4954546c75f805",
-      "versionInfo": "56.0.8",
+      "SPDXID": "SPDXRef-Package-3afcf9f00a2e8de5",
+      "versionInfo": "57.0.6",
       "downloadLocation": "https://github.com/expo/expo",
       "filesAnalyzed": false,
       "licenseConcluded": "MIT",
@@ -5011,14 +4892,14 @@
         {
           "referenceCategory": "PACKAGE-MANAGER",
           "referenceType": "purl",
-          "referenceLocator": "pkg:npm/expo-file-system@56.0.8"
+          "referenceLocator": "pkg:npm/expo-file-system@57.0.6"
         }
       ]
     },
     {
       "name": "expo-font",
-      "SPDXID": "SPDXRef-Package-589614dc8525ab1d",
-      "versionInfo": "56.0.7",
+      "SPDXID": "SPDXRef-Package-ca53585bedabf1bf",
+      "versionInfo": "57.0.1",
       "downloadLocation": "https://github.com/expo/expo",
       "filesAnalyzed": false,
       "licenseConcluded": "MIT",
@@ -5028,14 +4909,14 @@
         {
           "referenceCategory": "PACKAGE-MANAGER",
           "referenceType": "purl",
-          "referenceLocator": "pkg:npm/expo-font@56.0.7"
+          "referenceLocator": "pkg:npm/expo-font@57.0.1"
         }
       ]
     },
     {
       "name": "expo-glass-effect",
-      "SPDXID": "SPDXRef-Package-c93981ba4220ef5d",
-      "versionInfo": "56.0.4",
+      "SPDXID": "SPDXRef-Package-c383b71921578672",
+      "versionInfo": "57.0.1",
       "downloadLocation": "https://github.com/expo/expo",
       "filesAnalyzed": false,
       "licenseConcluded": "MIT",
@@ -5045,14 +4926,14 @@
         {
           "referenceCategory": "PACKAGE-MANAGER",
           "referenceType": "purl",
-          "referenceLocator": "pkg:npm/expo-glass-effect@56.0.4"
+          "referenceLocator": "pkg:npm/expo-glass-effect@57.0.1"
         }
       ]
     },
     {
       "name": "expo-image",
-      "SPDXID": "SPDXRef-Package-c395b610c9c83108",
-      "versionInfo": "56.0.11",
+      "SPDXID": "SPDXRef-Package-abb4296acc136edf",
+      "versionInfo": "57.0.3",
       "downloadLocation": "https://github.com/expo/expo",
       "filesAnalyzed": false,
       "licenseConcluded": "MIT",
@@ -5062,14 +4943,14 @@
         {
           "referenceCategory": "PACKAGE-MANAGER",
           "referenceType": "purl",
-          "referenceLocator": "pkg:npm/expo-image@56.0.11"
+          "referenceLocator": "pkg:npm/expo-image@57.0.3"
         }
       ]
     },
     {
       "name": "expo-image-loader",
-      "SPDXID": "SPDXRef-Package-b4a626d8163a8d58",
-      "versionInfo": "56.0.3",
+      "SPDXID": "SPDXRef-Package-1d7cbf079bfa1c79",
+      "versionInfo": "57.0.1",
       "downloadLocation": "https://github.com/expo/expo",
       "filesAnalyzed": false,
       "licenseConcluded": "MIT",
@@ -5079,14 +4960,14 @@
         {
           "referenceCategory": "PACKAGE-MANAGER",
           "referenceType": "purl",
-          "referenceLocator": "pkg:npm/expo-image-loader@56.0.3"
+          "referenceLocator": "pkg:npm/expo-image-loader@57.0.1"
         }
       ]
     },
     {
       "name": "expo-image-manipulator",
-      "SPDXID": "SPDXRef-Package-d32bd72eb825a363",
-      "versionInfo": "56.0.22",
+      "SPDXID": "SPDXRef-Package-fb9a2dea2b853b2e",
+      "versionInfo": "57.0.14",
       "downloadLocation": "https://github.com/expo/expo",
       "filesAnalyzed": false,
       "licenseConcluded": "MIT",
@@ -5096,14 +4977,14 @@
         {
           "referenceCategory": "PACKAGE-MANAGER",
           "referenceType": "purl",
-          "referenceLocator": "pkg:npm/expo-image-manipulator@56.0.22"
+          "referenceLocator": "pkg:npm/expo-image-manipulator@57.0.14"
         }
       ]
     },
     {
       "name": "expo-image-picker",
-      "SPDXID": "SPDXRef-Package-80cdba93d16a6db7",
-      "versionInfo": "56.0.21",
+      "SPDXID": "SPDXRef-Package-effb76fd2f135e9e",
+      "versionInfo": "57.0.14",
       "downloadLocation": "https://github.com/expo/expo",
       "filesAnalyzed": false,
       "licenseConcluded": "MIT",
@@ -5113,14 +4994,14 @@
         {
           "referenceCategory": "PACKAGE-MANAGER",
           "referenceType": "purl",
-          "referenceLocator": "pkg:npm/expo-image-picker@56.0.21"
+          "referenceLocator": "pkg:npm/expo-image-picker@57.0.14"
         }
       ]
     },
     {
       "name": "expo-json-utils",
-      "SPDXID": "SPDXRef-Package-d311c09601e952de",
-      "versionInfo": "56.0.0",
+      "SPDXID": "SPDXRef-Package-2fa8052f5f4080b3",
+      "versionInfo": "57.0.1",
       "downloadLocation": "https://github.com/expo/expo",
       "filesAnalyzed": false,
       "licenseConcluded": "MIT",
@@ -5130,14 +5011,14 @@
         {
           "referenceCategory": "PACKAGE-MANAGER",
           "referenceType": "purl",
-          "referenceLocator": "pkg:npm/expo-json-utils@56.0.0"
+          "referenceLocator": "pkg:npm/expo-json-utils@57.0.1"
         }
       ]
     },
     {
       "name": "expo-keep-awake",
-      "SPDXID": "SPDXRef-Package-138291e1c127cad9",
-      "versionInfo": "56.0.3",
+      "SPDXID": "SPDXRef-Package-e5bcaadc6e015d5e",
+      "versionInfo": "57.0.1",
       "downloadLocation": "https://github.com/expo/expo",
       "filesAnalyzed": false,
       "licenseConcluded": "MIT",
@@ -5147,14 +5028,14 @@
         {
           "referenceCategory": "PACKAGE-MANAGER",
           "referenceType": "purl",
-          "referenceLocator": "pkg:npm/expo-keep-awake@56.0.3"
+          "referenceLocator": "pkg:npm/expo-keep-awake@57.0.1"
         }
       ]
     },
     {
       "name": "expo-linking",
-      "SPDXID": "SPDXRef-Package-489f92d8a30a359c",
-      "versionInfo": "56.0.15",
+      "SPDXID": "SPDXRef-Package-f4802688e73e0a32",
+      "versionInfo": "57.0.8",
       "downloadLocation": "https://github.com/expo/expo",
       "filesAnalyzed": false,
       "licenseConcluded": "MIT",
@@ -5164,14 +5045,14 @@
         {
           "referenceCategory": "PACKAGE-MANAGER",
           "referenceType": "purl",
-          "referenceLocator": "pkg:npm/expo-linking@56.0.15"
+          "referenceLocator": "pkg:npm/expo-linking@57.0.8"
         }
       ]
     },
     {
       "name": "expo-localization",
-      "SPDXID": "SPDXRef-Package-415b21fcb52049d8",
-      "versionInfo": "56.0.6",
+      "SPDXID": "SPDXRef-Package-26b461b3f5de381c",
+      "versionInfo": "57.0.1",
       "downloadLocation": "https://github.com/expo/expo",
       "filesAnalyzed": false,
       "licenseConcluded": "MIT",
@@ -5181,14 +5062,14 @@
         {
           "referenceCategory": "PACKAGE-MANAGER",
           "referenceType": "purl",
-          "referenceLocator": "pkg:npm/expo-localization@56.0.6"
+          "referenceLocator": "pkg:npm/expo-localization@57.0.1"
         }
       ]
     },
     {
       "name": "expo-manifests",
-      "SPDXID": "SPDXRef-Package-ad9182d6194767d9",
-      "versionInfo": "56.0.4",
+      "SPDXID": "SPDXRef-Package-337b5c07192674f9",
+      "versionInfo": "57.0.1",
       "downloadLocation": "https://github.com/expo/expo",
       "filesAnalyzed": false,
       "licenseConcluded": "MIT",
@@ -5198,14 +5079,14 @@
         {
           "referenceCategory": "PACKAGE-MANAGER",
           "referenceType": "purl",
-          "referenceLocator": "pkg:npm/expo-manifests@56.0.4"
+          "referenceLocator": "pkg:npm/expo-manifests@57.0.1"
         }
       ]
     },
     {
       "name": "expo-media-library",
-      "SPDXID": "SPDXRef-Package-955b483a28991e94",
-      "versionInfo": "56.0.9",
+      "SPDXID": "SPDXRef-Package-7be8250e4e585882",
+      "versionInfo": "57.0.4",
       "downloadLocation": "https://github.com/expo/expo",
       "filesAnalyzed": false,
       "licenseConcluded": "MIT",
@@ -5215,14 +5096,14 @@
         {
           "referenceCategory": "PACKAGE-MANAGER",
           "referenceType": "purl",
-          "referenceLocator": "pkg:npm/expo-media-library@56.0.9"
+          "referenceLocator": "pkg:npm/expo-media-library@57.0.4"
         }
       ]
     },
     {
       "name": "expo-modules-autolinking",
-      "SPDXID": "SPDXRef-Package-ac1d86a216028819",
-      "versionInfo": "56.0.20",
+      "SPDXID": "SPDXRef-Package-f35e90f38d6ead79",
+      "versionInfo": "57.0.12",
       "downloadLocation": "https://github.com/expo/expo",
       "filesAnalyzed": false,
       "licenseConcluded": "MIT",
@@ -5232,14 +5113,14 @@
         {
           "referenceCategory": "PACKAGE-MANAGER",
           "referenceType": "purl",
-          "referenceLocator": "pkg:npm/expo-modules-autolinking@56.0.20"
+          "referenceLocator": "pkg:npm/expo-modules-autolinking@57.0.12"
         }
       ]
     },
     {
       "name": "expo-modules-core",
-      "SPDXID": "SPDXRef-Package-6416decb6cf4e38f",
-      "versionInfo": "56.0.21",
+      "SPDXID": "SPDXRef-Package-b3b6449f3773b175",
+      "versionInfo": "57.0.14",
       "downloadLocation": "https://github.com/expo/expo",
       "filesAnalyzed": false,
       "licenseConcluded": "MIT",
@@ -5249,14 +5130,14 @@
         {
           "referenceCategory": "PACKAGE-MANAGER",
           "referenceType": "purl",
-          "referenceLocator": "pkg:npm/expo-modules-core@56.0.21"
+          "referenceLocator": "pkg:npm/expo-modules-core@57.0.14"
         }
       ]
     },
     {
       "name": "expo-modules-jsi",
-      "SPDXID": "SPDXRef-Package-598de26019281869",
-      "versionInfo": "56.0.12",
+      "SPDXID": "SPDXRef-Package-bf533b3e2ed3f7f5",
+      "versionInfo": "57.0.6",
       "downloadLocation": "https://github.com/expo/expo",
       "filesAnalyzed": false,
       "licenseConcluded": "MIT",
@@ -5266,14 +5147,14 @@
         {
           "referenceCategory": "PACKAGE-MANAGER",
           "referenceType": "purl",
-          "referenceLocator": "pkg:npm/expo-modules-jsi@56.0.12"
+          "referenceLocator": "pkg:npm/expo-modules-jsi@57.0.6"
         }
       ]
     },
     {
       "name": "expo-notifications",
-      "SPDXID": "SPDXRef-Package-4a45e7754a1432e1",
-      "versionInfo": "56.0.22",
+      "SPDXID": "SPDXRef-Package-3747d33027ed5d3f",
+      "versionInfo": "57.0.15",
       "downloadLocation": "https://github.com/expo/expo",
       "filesAnalyzed": false,
       "licenseConcluded": "MIT",
@@ -5283,7 +5164,7 @@
         {
           "referenceCategory": "PACKAGE-MANAGER",
           "referenceType": "purl",
-          "referenceLocator": "pkg:npm/expo-notifications@56.0.22"
+          "referenceLocator": "pkg:npm/expo-notifications@57.0.15"
         }
       ]
     },
@@ -5306,8 +5187,8 @@
     },
     {
       "name": "expo-router",
-      "SPDXID": "SPDXRef-Package-1d313b59691b3815",
-      "versionInfo": "56.2.15",
+      "SPDXID": "SPDXRef-Package-351d6a4e6ee6dd69",
+      "versionInfo": "57.0.17",
       "downloadLocation": "https://github.com/expo/expo",
       "filesAnalyzed": false,
       "licenseConcluded": "MIT",
@@ -5317,14 +5198,14 @@
         {
           "referenceCategory": "PACKAGE-MANAGER",
           "referenceType": "purl",
-          "referenceLocator": "pkg:npm/expo-router@56.2.15"
+          "referenceLocator": "pkg:npm/expo-router@57.0.17"
         }
       ]
     },
     {
       "name": "expo-secure-store",
-      "SPDXID": "SPDXRef-Package-4943becc52f7c846",
-      "versionInfo": "56.0.4",
+      "SPDXID": "SPDXRef-Package-9d90dc6c6c4be0bb",
+      "versionInfo": "57.0.2",
       "downloadLocation": "https://github.com/expo/expo",
       "filesAnalyzed": false,
       "licenseConcluded": "MIT",
@@ -5334,14 +5215,14 @@
         {
           "referenceCategory": "PACKAGE-MANAGER",
           "referenceType": "purl",
-          "referenceLocator": "pkg:npm/expo-secure-store@56.0.4"
+          "referenceLocator": "pkg:npm/expo-secure-store@57.0.2"
         }
       ]
     },
     {
       "name": "expo-server",
-      "SPDXID": "SPDXRef-Package-d311b4ab7ff5b00d",
-      "versionInfo": "56.0.5",
+      "SPDXID": "SPDXRef-Package-b4cc7f026fce021b",
+      "versionInfo": "57.0.3",
       "downloadLocation": "https://github.com/expo/expo",
       "filesAnalyzed": false,
       "licenseConcluded": "MIT",
@@ -5351,14 +5232,14 @@
         {
           "referenceCategory": "PACKAGE-MANAGER",
           "referenceType": "purl",
-          "referenceLocator": "pkg:npm/expo-server@56.0.5"
+          "referenceLocator": "pkg:npm/expo-server@57.0.3"
         }
       ]
     },
     {
       "name": "expo-sharing",
-      "SPDXID": "SPDXRef-Package-a76d5fff827e3e52",
-      "versionInfo": "56.0.22",
+      "SPDXID": "SPDXRef-Package-93ef7f8f2d646cf4",
+      "versionInfo": "57.0.16",
       "downloadLocation": "https://github.com/expo/expo",
       "filesAnalyzed": false,
       "licenseConcluded": "MIT",
@@ -5368,14 +5249,14 @@
         {
           "referenceCategory": "PACKAGE-MANAGER",
           "referenceType": "purl",
-          "referenceLocator": "pkg:npm/expo-sharing@56.0.22"
+          "referenceLocator": "pkg:npm/expo-sharing@57.0.16"
         }
       ]
     },
     {
       "name": "expo-splash-screen",
-      "SPDXID": "SPDXRef-Package-e2848901cb956a1c",
-      "versionInfo": "56.0.13",
+      "SPDXID": "SPDXRef-Package-4d6601a85cd39faa",
+      "versionInfo": "57.0.8",
       "downloadLocation": "https://github.com/expo/expo",
       "filesAnalyzed": false,
       "licenseConcluded": "MIT",
@@ -5385,14 +5266,14 @@
         {
           "referenceCategory": "PACKAGE-MANAGER",
           "referenceType": "purl",
-          "referenceLocator": "pkg:npm/expo-splash-screen@56.0.13"
+          "referenceLocator": "pkg:npm/expo-splash-screen@57.0.8"
         }
       ]
     },
     {
       "name": "expo-status-bar",
-      "SPDXID": "SPDXRef-Package-671c72dd56bb579e",
-      "versionInfo": "56.0.4",
+      "SPDXID": "SPDXRef-Package-69cfe19a4ed17459",
+      "versionInfo": "57.0.1",
       "downloadLocation": "https://github.com/expo/expo",
       "filesAnalyzed": false,
       "licenseConcluded": "MIT",
@@ -5402,14 +5283,14 @@
         {
           "referenceCategory": "PACKAGE-MANAGER",
           "referenceType": "purl",
-          "referenceLocator": "pkg:npm/expo-status-bar@56.0.4"
+          "referenceLocator": "pkg:npm/expo-status-bar@57.0.1"
         }
       ]
     },
     {
       "name": "expo-structured-headers",
-      "SPDXID": "SPDXRef-Package-e1f9f99d647772da",
-      "versionInfo": "56.0.0",
+      "SPDXID": "SPDXRef-Package-aa96b5fa5570dbff",
+      "versionInfo": "57.0.0",
       "downloadLocation": "https://github.com/expo/expo",
       "filesAnalyzed": false,
       "licenseConcluded": "MIT",
@@ -5419,14 +5300,14 @@
         {
           "referenceCategory": "PACKAGE-MANAGER",
           "referenceType": "purl",
-          "referenceLocator": "pkg:npm/expo-structured-headers@56.0.0"
+          "referenceLocator": "pkg:npm/expo-structured-headers@57.0.0"
         }
       ]
     },
     {
       "name": "expo-symbols",
-      "SPDXID": "SPDXRef-Package-abf2a80389832b3e",
-      "versionInfo": "56.0.6",
+      "SPDXID": "SPDXRef-Package-2acfd2fd0fd3ba5f",
+      "versionInfo": "57.0.2",
       "downloadLocation": "https://github.com/expo/expo",
       "filesAnalyzed": false,
       "licenseConcluded": "MIT",
@@ -5436,14 +5317,14 @@
         {
           "referenceCategory": "PACKAGE-MANAGER",
           "referenceType": "purl",
-          "referenceLocator": "pkg:npm/expo-symbols@56.0.6"
+          "referenceLocator": "pkg:npm/expo-symbols@57.0.2"
         }
       ]
     },
     {
       "name": "expo-updates",
-      "SPDXID": "SPDXRef-Package-bcd7977e03f59a7e",
-      "versionInfo": "56.0.22",
+      "SPDXID": "SPDXRef-Package-39ccab59fc625cd2",
+      "versionInfo": "57.0.18",
       "downloadLocation": "https://github.com/expo/expo",
       "filesAnalyzed": false,
       "licenseConcluded": "MIT",
@@ -5453,14 +5334,14 @@
         {
           "referenceCategory": "PACKAGE-MANAGER",
           "referenceType": "purl",
-          "referenceLocator": "pkg:npm/expo-updates@56.0.22"
+          "referenceLocator": "pkg:npm/expo-updates@57.0.18"
         }
       ]
     },
     {
       "name": "expo-updates-interface",
-      "SPDXID": "SPDXRef-Package-69891146ffd2ac4e",
-      "versionInfo": "56.0.2",
+      "SPDXID": "SPDXRef-Package-8b849016e1749034",
+      "versionInfo": "57.0.1",
       "downloadLocation": "https://github.com/expo/expo",
       "filesAnalyzed": false,
       "licenseConcluded": "MIT",
@@ -5470,14 +5351,14 @@
         {
           "referenceCategory": "PACKAGE-MANAGER",
           "referenceType": "purl",
-          "referenceLocator": "pkg:npm/expo-updates-interface@56.0.2"
+          "referenceLocator": "pkg:npm/expo-updates-interface@57.0.1"
         }
       ]
     },
     {
       "name": "expo-web-browser",
-      "SPDXID": "SPDXRef-Package-cd5fdc34ff05ecda",
-      "versionInfo": "56.0.5",
+      "SPDXID": "SPDXRef-Package-d7af0c7232fa828c",
+      "versionInfo": "57.0.2",
       "downloadLocation": "https://github.com/expo/expo",
       "filesAnalyzed": false,
       "licenseConcluded": "MIT",
@@ -5487,7 +5368,7 @@
         {
           "referenceCategory": "PACKAGE-MANAGER",
           "referenceType": "purl",
-          "referenceLocator": "pkg:npm/expo-web-browser@56.0.5"
+          "referenceLocator": "pkg:npm/expo-web-browser@57.0.2"
         }
       ]
     },
@@ -5901,8 +5782,8 @@
     },
     {
       "name": "hermes-compiler",
-      "SPDXID": "SPDXRef-Package-c2badcb682cdf5ce",
-      "versionInfo": "250829098.0.10",
+      "SPDXID": "SPDXRef-Package-3f43a0a8eb764204",
+      "versionInfo": "250829098.0.17",
       "downloadLocation": "https://github.com/facebook/hermes",
       "filesAnalyzed": false,
       "licenseConcluded": "MIT",
@@ -5912,24 +5793,7 @@
         {
           "referenceCategory": "PACKAGE-MANAGER",
           "referenceType": "purl",
-          "referenceLocator": "pkg:npm/hermes-compiler@250829098.0.10"
-        }
-      ]
-    },
-    {
-      "name": "hermes-estree",
-      "SPDXID": "SPDXRef-Package-7bb0f392884b6c7b",
-      "versionInfo": "0.33.3",
-      "downloadLocation": "https://github.com/facebook/hermes",
-      "filesAnalyzed": false,
-      "licenseConcluded": "MIT",
-      "licenseDeclared": "MIT",
-      "copyrightText": "NOASSERTION",
-      "externalRefs": [
-        {
-          "referenceCategory": "PACKAGE-MANAGER",
-          "referenceType": "purl",
-          "referenceLocator": "pkg:npm/hermes-estree@0.33.3"
+          "referenceLocator": "pkg:npm/hermes-compiler@250829098.0.17"
         }
       ]
     },
@@ -5951,9 +5815,9 @@
       ]
     },
     {
-      "name": "hermes-parser",
-      "SPDXID": "SPDXRef-Package-fcf18dec3c39a179",
-      "versionInfo": "0.33.3",
+      "name": "hermes-estree",
+      "SPDXID": "SPDXRef-Package-7f10269e26834f74",
+      "versionInfo": "0.36.0",
       "downloadLocation": "https://github.com/facebook/hermes",
       "filesAnalyzed": false,
       "licenseConcluded": "MIT",
@@ -5963,7 +5827,24 @@
         {
           "referenceCategory": "PACKAGE-MANAGER",
           "referenceType": "purl",
-          "referenceLocator": "pkg:npm/hermes-parser@0.33.3"
+          "referenceLocator": "pkg:npm/hermes-estree@0.36.0"
+        }
+      ]
+    },
+    {
+      "name": "hermes-estree",
+      "SPDXID": "SPDXRef-Package-d2400efb14a646cc",
+      "versionInfo": "0.36.1",
+      "downloadLocation": "https://github.com/facebook/hermes",
+      "filesAnalyzed": false,
+      "licenseConcluded": "MIT",
+      "licenseDeclared": "MIT",
+      "copyrightText": "NOASSERTION",
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceType": "purl",
+          "referenceLocator": "pkg:npm/hermes-estree@0.36.1"
         }
       ]
     },
@@ -5981,6 +5862,57 @@
           "referenceCategory": "PACKAGE-MANAGER",
           "referenceType": "purl",
           "referenceLocator": "pkg:npm/hermes-parser@0.35.0"
+        }
+      ]
+    },
+    {
+      "name": "hermes-parser",
+      "SPDXID": "SPDXRef-Package-0c381b6f09221886",
+      "versionInfo": "0.36.0",
+      "downloadLocation": "https://github.com/facebook/hermes",
+      "filesAnalyzed": false,
+      "licenseConcluded": "MIT",
+      "licenseDeclared": "MIT",
+      "copyrightText": "NOASSERTION",
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceType": "purl",
+          "referenceLocator": "pkg:npm/hermes-parser@0.36.0"
+        }
+      ]
+    },
+    {
+      "name": "hermes-parser",
+      "SPDXID": "SPDXRef-Package-04a516c568f52201",
+      "versionInfo": "0.36.1",
+      "downloadLocation": "https://github.com/facebook/hermes",
+      "filesAnalyzed": false,
+      "licenseConcluded": "MIT",
+      "licenseDeclared": "MIT",
+      "copyrightText": "NOASSERTION",
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceType": "purl",
+          "referenceLocator": "pkg:npm/hermes-parser@0.36.1"
+        }
+      ]
+    },
+    {
+      "name": "hoist-non-react-statics",
+      "SPDXID": "SPDXRef-Package-48959bb6d78ea484",
+      "versionInfo": "3.3.2",
+      "downloadLocation": "https://github.com/mridgway/hoist-non-react-statics",
+      "filesAnalyzed": false,
+      "licenseConcluded": "BSD-3-Clause",
+      "licenseDeclared": "BSD-3-Clause",
+      "copyrightText": "NOASSERTION",
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceType": "purl",
+          "referenceLocator": "pkg:npm/hoist-non-react-statics@3.3.2"
         }
       ]
     },
@@ -6117,23 +6049,6 @@
           "referenceCategory": "PACKAGE-MANAGER",
           "referenceType": "purl",
           "referenceLocator": "pkg:npm/image-size@1.2.1"
-        }
-      ]
-    },
-    {
-      "name": "indent-string",
-      "SPDXID": "SPDXRef-Package-e4c04eafeff49de8",
-      "versionInfo": "4.0.0",
-      "downloadLocation": "https://github.com/sindresorhus/indent-string",
-      "filesAnalyzed": false,
-      "licenseConcluded": "MIT",
-      "licenseDeclared": "MIT",
-      "copyrightText": "NOASSERTION",
-      "externalRefs": [
-        {
-          "referenceCategory": "PACKAGE-MANAGER",
-          "referenceType": "purl",
-          "referenceLocator": "pkg:npm/indent-string@4.0.0"
         }
       ]
     },
@@ -6852,6 +6767,23 @@
       ]
     },
     {
+      "name": "metro",
+      "SPDXID": "SPDXRef-Package-7c676065cfd964ce",
+      "versionInfo": "0.84.5",
+      "downloadLocation": "https://github.com/react/metro",
+      "filesAnalyzed": false,
+      "licenseConcluded": "MIT",
+      "licenseDeclared": "MIT",
+      "copyrightText": "NOASSERTION",
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceType": "purl",
+          "referenceLocator": "pkg:npm/metro@0.84.5"
+        }
+      ]
+    },
+    {
       "name": "metro-babel-transformer",
       "SPDXID": "SPDXRef-Package-5b883337a485e777",
       "versionInfo": "0.84.4",
@@ -6865,6 +6797,23 @@
           "referenceCategory": "PACKAGE-MANAGER",
           "referenceType": "purl",
           "referenceLocator": "pkg:npm/metro-babel-transformer@0.84.4"
+        }
+      ]
+    },
+    {
+      "name": "metro-babel-transformer",
+      "SPDXID": "SPDXRef-Package-3acb47578d0e1af3",
+      "versionInfo": "0.84.5",
+      "downloadLocation": "https://github.com/react/metro",
+      "filesAnalyzed": false,
+      "licenseConcluded": "MIT",
+      "licenseDeclared": "MIT",
+      "copyrightText": "NOASSERTION",
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceType": "purl",
+          "referenceLocator": "pkg:npm/metro-babel-transformer@0.84.5"
         }
       ]
     },
@@ -6886,6 +6835,23 @@
       ]
     },
     {
+      "name": "metro-cache",
+      "SPDXID": "SPDXRef-Package-2345f39952349568",
+      "versionInfo": "0.84.5",
+      "downloadLocation": "https://github.com/react/metro",
+      "filesAnalyzed": false,
+      "licenseConcluded": "MIT",
+      "licenseDeclared": "MIT",
+      "copyrightText": "NOASSERTION",
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceType": "purl",
+          "referenceLocator": "pkg:npm/metro-cache@0.84.5"
+        }
+      ]
+    },
+    {
       "name": "metro-cache-key",
       "SPDXID": "SPDXRef-Package-9cfa9e8a7af46d4c",
       "versionInfo": "0.84.4",
@@ -6899,6 +6865,23 @@
           "referenceCategory": "PACKAGE-MANAGER",
           "referenceType": "purl",
           "referenceLocator": "pkg:npm/metro-cache-key@0.84.4"
+        }
+      ]
+    },
+    {
+      "name": "metro-cache-key",
+      "SPDXID": "SPDXRef-Package-bb90f134a888e80f",
+      "versionInfo": "0.84.5",
+      "downloadLocation": "https://github.com/react/metro",
+      "filesAnalyzed": false,
+      "licenseConcluded": "MIT",
+      "licenseDeclared": "MIT",
+      "copyrightText": "NOASSERTION",
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceType": "purl",
+          "referenceLocator": "pkg:npm/metro-cache-key@0.84.5"
         }
       ]
     },
@@ -6920,6 +6903,23 @@
       ]
     },
     {
+      "name": "metro-config",
+      "SPDXID": "SPDXRef-Package-4e0b399ea417d4b3",
+      "versionInfo": "0.84.5",
+      "downloadLocation": "https://github.com/react/metro",
+      "filesAnalyzed": false,
+      "licenseConcluded": "MIT",
+      "licenseDeclared": "MIT",
+      "copyrightText": "NOASSERTION",
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceType": "purl",
+          "referenceLocator": "pkg:npm/metro-config@0.84.5"
+        }
+      ]
+    },
+    {
       "name": "metro-core",
       "SPDXID": "SPDXRef-Package-a35101b99db7bfa8",
       "versionInfo": "0.84.4",
@@ -6933,6 +6933,23 @@
           "referenceCategory": "PACKAGE-MANAGER",
           "referenceType": "purl",
           "referenceLocator": "pkg:npm/metro-core@0.84.4"
+        }
+      ]
+    },
+    {
+      "name": "metro-core",
+      "SPDXID": "SPDXRef-Package-ab9b3717f29cebf8",
+      "versionInfo": "0.84.5",
+      "downloadLocation": "https://github.com/react/metro",
+      "filesAnalyzed": false,
+      "licenseConcluded": "MIT",
+      "licenseDeclared": "MIT",
+      "copyrightText": "NOASSERTION",
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceType": "purl",
+          "referenceLocator": "pkg:npm/metro-core@0.84.5"
         }
       ]
     },
@@ -6954,6 +6971,23 @@
       ]
     },
     {
+      "name": "metro-file-map",
+      "SPDXID": "SPDXRef-Package-cb89d27f053a8229",
+      "versionInfo": "0.84.5",
+      "downloadLocation": "https://github.com/react/metro",
+      "filesAnalyzed": false,
+      "licenseConcluded": "MIT",
+      "licenseDeclared": "MIT",
+      "copyrightText": "NOASSERTION",
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceType": "purl",
+          "referenceLocator": "pkg:npm/metro-file-map@0.84.5"
+        }
+      ]
+    },
+    {
       "name": "metro-minify-terser",
       "SPDXID": "SPDXRef-Package-c169b0b8613d59b6",
       "versionInfo": "0.84.4",
@@ -6967,6 +7001,23 @@
           "referenceCategory": "PACKAGE-MANAGER",
           "referenceType": "purl",
           "referenceLocator": "pkg:npm/metro-minify-terser@0.84.4"
+        }
+      ]
+    },
+    {
+      "name": "metro-minify-terser",
+      "SPDXID": "SPDXRef-Package-70598be7904735a1",
+      "versionInfo": "0.84.5",
+      "downloadLocation": "https://github.com/react/metro",
+      "filesAnalyzed": false,
+      "licenseConcluded": "MIT",
+      "licenseDeclared": "MIT",
+      "copyrightText": "NOASSERTION",
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceType": "purl",
+          "referenceLocator": "pkg:npm/metro-minify-terser@0.84.5"
         }
       ]
     },
@@ -6988,6 +7039,23 @@
       ]
     },
     {
+      "name": "metro-resolver",
+      "SPDXID": "SPDXRef-Package-98d6596180be67e1",
+      "versionInfo": "0.84.5",
+      "downloadLocation": "https://github.com/react/metro",
+      "filesAnalyzed": false,
+      "licenseConcluded": "MIT",
+      "licenseDeclared": "MIT",
+      "copyrightText": "NOASSERTION",
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceType": "purl",
+          "referenceLocator": "pkg:npm/metro-resolver@0.84.5"
+        }
+      ]
+    },
+    {
       "name": "metro-runtime",
       "SPDXID": "SPDXRef-Package-5a666c014661c95e",
       "versionInfo": "0.84.4",
@@ -7001,6 +7069,23 @@
           "referenceCategory": "PACKAGE-MANAGER",
           "referenceType": "purl",
           "referenceLocator": "pkg:npm/metro-runtime@0.84.4"
+        }
+      ]
+    },
+    {
+      "name": "metro-runtime",
+      "SPDXID": "SPDXRef-Package-cffe6b9120ab6939",
+      "versionInfo": "0.84.5",
+      "downloadLocation": "https://github.com/react/metro",
+      "filesAnalyzed": false,
+      "licenseConcluded": "MIT",
+      "licenseDeclared": "MIT",
+      "copyrightText": "NOASSERTION",
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceType": "purl",
+          "referenceLocator": "pkg:npm/metro-runtime@0.84.5"
         }
       ]
     },
@@ -7022,6 +7107,23 @@
       ]
     },
     {
+      "name": "metro-source-map",
+      "SPDXID": "SPDXRef-Package-6aa71406fb83e2b1",
+      "versionInfo": "0.84.5",
+      "downloadLocation": "https://github.com/react/metro",
+      "filesAnalyzed": false,
+      "licenseConcluded": "MIT",
+      "licenseDeclared": "MIT",
+      "copyrightText": "NOASSERTION",
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceType": "purl",
+          "referenceLocator": "pkg:npm/metro-source-map@0.84.5"
+        }
+      ]
+    },
+    {
       "name": "metro-symbolicate",
       "SPDXID": "SPDXRef-Package-3757547c4c1d5336",
       "versionInfo": "0.84.4",
@@ -7035,6 +7137,23 @@
           "referenceCategory": "PACKAGE-MANAGER",
           "referenceType": "purl",
           "referenceLocator": "pkg:npm/metro-symbolicate@0.84.4"
+        }
+      ]
+    },
+    {
+      "name": "metro-symbolicate",
+      "SPDXID": "SPDXRef-Package-ed7d37aa788ec99a",
+      "versionInfo": "0.84.5",
+      "downloadLocation": "https://github.com/react/metro",
+      "filesAnalyzed": false,
+      "licenseConcluded": "MIT",
+      "licenseDeclared": "MIT",
+      "copyrightText": "NOASSERTION",
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceType": "purl",
+          "referenceLocator": "pkg:npm/metro-symbolicate@0.84.5"
         }
       ]
     },
@@ -7056,6 +7175,23 @@
       ]
     },
     {
+      "name": "metro-transform-plugins",
+      "SPDXID": "SPDXRef-Package-499b1df7a096af9a",
+      "versionInfo": "0.84.5",
+      "downloadLocation": "https://github.com/react/metro",
+      "filesAnalyzed": false,
+      "licenseConcluded": "MIT",
+      "licenseDeclared": "MIT",
+      "copyrightText": "NOASSERTION",
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceType": "purl",
+          "referenceLocator": "pkg:npm/metro-transform-plugins@0.84.5"
+        }
+      ]
+    },
+    {
       "name": "metro-transform-worker",
       "SPDXID": "SPDXRef-Package-f9387ad05dce7961",
       "versionInfo": "0.84.4",
@@ -7069,6 +7205,23 @@
           "referenceCategory": "PACKAGE-MANAGER",
           "referenceType": "purl",
           "referenceLocator": "pkg:npm/metro-transform-worker@0.84.4"
+        }
+      ]
+    },
+    {
+      "name": "metro-transform-worker",
+      "SPDXID": "SPDXRef-Package-eb8a00819286064c",
+      "versionInfo": "0.84.5",
+      "downloadLocation": "https://github.com/react/metro",
+      "filesAnalyzed": false,
+      "licenseConcluded": "MIT",
+      "licenseDeclared": "MIT",
+      "copyrightText": "NOASSERTION",
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceType": "purl",
+          "referenceLocator": "pkg:npm/metro-transform-worker@0.84.5"
         }
       ]
     },
@@ -7192,23 +7345,6 @@
       ]
     },
     {
-      "name": "min-indent",
-      "SPDXID": "SPDXRef-Package-d630fdbec9080dbb",
-      "versionInfo": "1.0.1",
-      "downloadLocation": "https://github.com/thejameskyle/min-indent",
-      "filesAnalyzed": false,
-      "licenseConcluded": "MIT",
-      "licenseDeclared": "MIT",
-      "copyrightText": "NOASSERTION",
-      "externalRefs": [
-        {
-          "referenceCategory": "PACKAGE-MANAGER",
-          "referenceType": "purl",
-          "referenceLocator": "pkg:npm/min-indent@1.0.1"
-        }
-      ]
-    },
-    {
       "name": "minimatch",
       "SPDXID": "SPDXRef-Package-37b2e23b08106590",
       "versionInfo": "10.2.5",
@@ -7295,9 +7431,9 @@
     },
     {
       "name": "multitars",
-      "SPDXID": "SPDXRef-Package-2ed7bbd69b3885e6",
-      "versionInfo": "1.0.0",
-      "downloadLocation": "https://github.com/kitten/multitars",
+      "SPDXID": "SPDXRef-Package-1327b46b9d227040",
+      "versionInfo": "1.0.2",
+      "downloadLocation": "https://github.com/expo/multitars",
       "filesAnalyzed": false,
       "licenseConcluded": "MIT",
       "licenseDeclared": "MIT",
@@ -7306,7 +7442,7 @@
         {
           "referenceCategory": "PACKAGE-MANAGER",
           "referenceType": "purl",
-          "referenceLocator": "pkg:npm/multitars@1.0.0"
+          "referenceLocator": "pkg:npm/multitars@1.0.2"
         }
       ]
     },
@@ -7511,6 +7647,23 @@
           "referenceCategory": "PACKAGE-MANAGER",
           "referenceType": "purl",
           "referenceLocator": "pkg:npm/ob1@0.84.4"
+        }
+      ]
+    },
+    {
+      "name": "ob1",
+      "SPDXID": "SPDXRef-Package-65907f15f40ad75b",
+      "versionInfo": "0.84.5",
+      "downloadLocation": "https://github.com/react/metro",
+      "filesAnalyzed": false,
+      "licenseConcluded": "MIT",
+      "licenseDeclared": "MIT",
+      "copyrightText": "NOASSERTION",
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceType": "purl",
+          "referenceLocator": "pkg:npm/ob1@0.84.5"
         }
       ]
     },
@@ -8111,6 +8264,23 @@
     },
     {
       "name": "react-is",
+      "SPDXID": "SPDXRef-Package-6a89229fd526bb86",
+      "versionInfo": "16.13.1",
+      "downloadLocation": "https://github.com/facebook/react",
+      "filesAnalyzed": false,
+      "licenseConcluded": "MIT",
+      "licenseDeclared": "MIT",
+      "copyrightText": "NOASSERTION",
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceType": "purl",
+          "referenceLocator": "pkg:npm/react-is@16.13.1"
+        }
+      ]
+    },
+    {
+      "name": "react-is",
       "SPDXID": "SPDXRef-Package-3f6a332a26930af4",
       "versionInfo": "18.3.1",
       "downloadLocation": "https://github.com/facebook/react",
@@ -8145,9 +8315,9 @@
     },
     {
       "name": "react-native",
-      "SPDXID": "SPDXRef-Package-320b48b78f68ec78",
-      "versionInfo": "0.85.3",
-      "downloadLocation": "https://github.com/facebook/react-native",
+      "SPDXID": "SPDXRef-Package-d09e24f5425789d2",
+      "versionInfo": "0.86.3",
+      "downloadLocation": "https://github.com/react/react-native",
       "filesAnalyzed": false,
       "licenseConcluded": "MIT",
       "licenseDeclared": "MIT",
@@ -8156,7 +8326,7 @@
         {
           "referenceCategory": "PACKAGE-MANAGER",
           "referenceType": "purl",
-          "referenceLocator": "pkg:npm/react-native@0.85.3"
+          "referenceLocator": "pkg:npm/react-native@0.86.3"
         }
       ]
     },
@@ -8179,8 +8349,8 @@
     },
     {
       "name": "react-native-gesture-handler",
-      "SPDXID": "SPDXRef-Package-33e808bf5cec693e",
-      "versionInfo": "3.0.2",
+      "SPDXID": "SPDXRef-Package-ff00236a86b22e8e",
+      "versionInfo": "2.32.0",
       "downloadLocation": "https://github.com/software-mansion/react-native-gesture-handler",
       "filesAnalyzed": false,
       "licenseConcluded": "MIT",
@@ -8190,7 +8360,7 @@
         {
           "referenceCategory": "PACKAGE-MANAGER",
           "referenceType": "purl",
-          "referenceLocator": "pkg:npm/react-native-gesture-handler@3.0.2"
+          "referenceLocator": "pkg:npm/react-native-gesture-handler@2.32.0"
         }
       ]
     },
@@ -8213,8 +8383,8 @@
     },
     {
       "name": "react-native-reanimated",
-      "SPDXID": "SPDXRef-Package-a9bb914e4ffcb526",
-      "versionInfo": "4.3.1",
+      "SPDXID": "SPDXRef-Package-b7b0ad22ed49b61b",
+      "versionInfo": "4.5.1",
       "downloadLocation": "https://github.com/software-mansion/react-native-reanimated",
       "filesAnalyzed": false,
       "licenseConcluded": "MIT",
@@ -8224,7 +8394,7 @@
         {
           "referenceCategory": "PACKAGE-MANAGER",
           "referenceType": "purl",
-          "referenceLocator": "pkg:npm/react-native-reanimated@4.3.1"
+          "referenceLocator": "pkg:npm/react-native-reanimated@4.5.1"
         }
       ]
     },
@@ -8247,8 +8417,8 @@
     },
     {
       "name": "react-native-screens",
-      "SPDXID": "SPDXRef-Package-583495f14e006813",
-      "versionInfo": "4.25.2",
+      "SPDXID": "SPDXRef-Package-b6497d544417df00",
+      "versionInfo": "4.26.2",
       "downloadLocation": "https://github.com/software-mansion/react-native-screens",
       "filesAnalyzed": false,
       "licenseConcluded": "MIT",
@@ -8258,7 +8428,7 @@
         {
           "referenceCategory": "PACKAGE-MANAGER",
           "referenceType": "purl",
-          "referenceLocator": "pkg:npm/react-native-screens@4.25.2"
+          "referenceLocator": "pkg:npm/react-native-screens@4.26.2"
         }
       ]
     },
@@ -8332,8 +8502,8 @@
     },
     {
       "name": "react-native-worklets",
-      "SPDXID": "SPDXRef-Package-2729ad6f5e015637",
-      "versionInfo": "0.8.3",
+      "SPDXID": "SPDXRef-Package-48fbbad74c6fdd9c",
+      "versionInfo": "0.10.1",
       "downloadLocation": "https://github.com/software-mansion/react-native-reanimated",
       "filesAnalyzed": false,
       "licenseConcluded": "MIT",
@@ -8343,7 +8513,7 @@
         {
           "referenceCategory": "PACKAGE-MANAGER",
           "referenceType": "purl",
-          "referenceLocator": "pkg:npm/react-native-worklets@0.8.3"
+          "referenceLocator": "pkg:npm/react-native-worklets@0.10.1"
         }
       ]
     },
@@ -8412,23 +8582,6 @@
           "referenceCategory": "PACKAGE-MANAGER",
           "referenceType": "purl",
           "referenceLocator": "pkg:npm/react-style-singleton@2.2.3"
-        }
-      ]
-    },
-    {
-      "name": "redent",
-      "SPDXID": "SPDXRef-Package-9b7210a64fc715b8",
-      "versionInfo": "3.0.0",
-      "downloadLocation": "https://github.com/sindresorhus/redent",
-      "filesAnalyzed": false,
-      "licenseConcluded": "MIT",
-      "licenseDeclared": "MIT",
-      "copyrightText": "NOASSERTION",
-      "externalRefs": [
-        {
-          "referenceCategory": "PACKAGE-MANAGER",
-          "referenceType": "purl",
-          "referenceLocator": "pkg:npm/redent@3.0.0"
         }
       ]
     },
@@ -8650,6 +8803,23 @@
           "referenceCategory": "PACKAGE-MANAGER",
           "referenceType": "purl",
           "referenceLocator": "pkg:npm/safe-buffer@5.2.1"
+        }
+      ]
+    },
+    {
+      "name": "sandbox-cli-detector",
+      "SPDXID": "SPDXRef-Package-bde20ab5886a590d",
+      "versionInfo": "0.2.0",
+      "downloadLocation": "https://github.com/davidmokos/sandbox-cli-detector",
+      "filesAnalyzed": false,
+      "licenseConcluded": "MIT",
+      "licenseDeclared": "MIT",
+      "copyrightText": "NOASSERTION",
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceType": "purl",
+          "referenceLocator": "pkg:npm/sandbox-cli-detector@0.2.0"
         }
       ]
     },
@@ -9245,23 +9415,6 @@
           "referenceCategory": "PACKAGE-MANAGER",
           "referenceType": "purl",
           "referenceLocator": "pkg:npm/strip-ansi@6.0.1"
-        }
-      ]
-    },
-    {
-      "name": "strip-indent",
-      "SPDXID": "SPDXRef-Package-6b434451ae9a68d6",
-      "versionInfo": "3.0.0",
-      "downloadLocation": "https://github.com/sindresorhus/strip-indent",
-      "filesAnalyzed": false,
-      "licenseConcluded": "MIT",
-      "licenseDeclared": "MIT",
-      "copyrightText": "NOASSERTION",
-      "externalRefs": [
-        {
-          "referenceCategory": "PACKAGE-MANAGER",
-          "referenceType": "purl",
-          "referenceLocator": "pkg:npm/strip-indent@3.0.0"
         }
       ]
     },
@@ -10293,11 +10446,6 @@
     {
       "spdxElementId": "SPDXRef-DOCUMENT",
       "relationshipType": "DESCRIBES",
-      "relatedSpdxElement": "SPDXRef-Package-10a5c5df7c6ba052"
-    },
-    {
-      "spdxElementId": "SPDXRef-DOCUMENT",
-      "relationshipType": "DESCRIBES",
       "relatedSpdxElement": "SPDXRef-Package-59e6d9f0e83e9c3b"
     },
     {
@@ -10643,12 +10791,17 @@
     {
       "spdxElementId": "SPDXRef-DOCUMENT",
       "relationshipType": "DESCRIBES",
+      "relatedSpdxElement": "SPDXRef-Package-cf26df301845f4cf"
+    },
+    {
+      "spdxElementId": "SPDXRef-DOCUMENT",
+      "relationshipType": "DESCRIBES",
       "relatedSpdxElement": "SPDXRef-Package-396b2918563c1afc"
     },
     {
       "spdxElementId": "SPDXRef-DOCUMENT",
       "relationshipType": "DESCRIBES",
-      "relatedSpdxElement": "SPDXRef-Package-6ac0bb956200fdf5"
+      "relatedSpdxElement": "SPDXRef-Package-20e7a8f375c2feb7"
     },
     {
       "spdxElementId": "SPDXRef-DOCUMENT",
@@ -10658,17 +10811,17 @@
     {
       "spdxElementId": "SPDXRef-DOCUMENT",
       "relationshipType": "DESCRIBES",
-      "relatedSpdxElement": "SPDXRef-Package-dcc374c8c02d514d"
+      "relatedSpdxElement": "SPDXRef-Package-1496420660ddf99b"
     },
     {
       "spdxElementId": "SPDXRef-DOCUMENT",
       "relationshipType": "DESCRIBES",
-      "relatedSpdxElement": "SPDXRef-Package-cf8f2de11ad0cb5b"
+      "relatedSpdxElement": "SPDXRef-Package-5b62941641563ebf"
     },
     {
       "spdxElementId": "SPDXRef-DOCUMENT",
       "relationshipType": "DESCRIBES",
-      "relatedSpdxElement": "SPDXRef-Package-cdeb690c56a84829"
+      "relatedSpdxElement": "SPDXRef-Package-772be2704d1edaac"
     },
     {
       "spdxElementId": "SPDXRef-DOCUMENT",
@@ -10678,17 +10831,12 @@
     {
       "spdxElementId": "SPDXRef-DOCUMENT",
       "relationshipType": "DESCRIBES",
-      "relatedSpdxElement": "SPDXRef-Package-43316c9d32c89096"
+      "relatedSpdxElement": "SPDXRef-Package-13b0840247977fd4"
     },
     {
       "spdxElementId": "SPDXRef-DOCUMENT",
       "relationshipType": "DESCRIBES",
-      "relatedSpdxElement": "SPDXRef-Package-617dd995820cbb4d"
-    },
-    {
-      "spdxElementId": "SPDXRef-DOCUMENT",
-      "relationshipType": "DESCRIBES",
-      "relatedSpdxElement": "SPDXRef-Package-af1d891ecc9c652c"
+      "relatedSpdxElement": "SPDXRef-Package-4747d19862c6c2b8"
     },
     {
       "spdxElementId": "SPDXRef-DOCUMENT",
@@ -10698,32 +10846,22 @@
     {
       "spdxElementId": "SPDXRef-DOCUMENT",
       "relationshipType": "DESCRIBES",
-      "relatedSpdxElement": "SPDXRef-Package-f7064e795090188d"
+      "relatedSpdxElement": "SPDXRef-Package-a9b72b527dd55c2c"
     },
     {
       "spdxElementId": "SPDXRef-DOCUMENT",
       "relationshipType": "DESCRIBES",
-      "relatedSpdxElement": "SPDXRef-Package-5dd3cf74bac21b26"
+      "relatedSpdxElement": "SPDXRef-Package-cf2499e732152ff1"
     },
     {
       "spdxElementId": "SPDXRef-DOCUMENT",
       "relationshipType": "DESCRIBES",
-      "relatedSpdxElement": "SPDXRef-Package-24cf3edefeb8ede5"
+      "relatedSpdxElement": "SPDXRef-Package-11cb55c38fa93cd7"
     },
     {
       "spdxElementId": "SPDXRef-DOCUMENT",
       "relationshipType": "DESCRIBES",
-      "relatedSpdxElement": "SPDXRef-Package-52847b30294715dd"
-    },
-    {
-      "spdxElementId": "SPDXRef-DOCUMENT",
-      "relationshipType": "DESCRIBES",
-      "relatedSpdxElement": "SPDXRef-Package-43d80c1b2da0e96a"
-    },
-    {
-      "spdxElementId": "SPDXRef-DOCUMENT",
-      "relationshipType": "DESCRIBES",
-      "relatedSpdxElement": "SPDXRef-Package-dca50474e69f294b"
+      "relatedSpdxElement": "SPDXRef-Package-20bcb76ccf8f4986"
     },
     {
       "spdxElementId": "SPDXRef-DOCUMENT",
@@ -10733,32 +10871,32 @@
     {
       "spdxElementId": "SPDXRef-DOCUMENT",
       "relationshipType": "DESCRIBES",
-      "relatedSpdxElement": "SPDXRef-Package-91e14c6d4bc9e3b1"
+      "relatedSpdxElement": "SPDXRef-Package-7161e8a7d78e0b5d"
     },
     {
       "spdxElementId": "SPDXRef-DOCUMENT",
       "relationshipType": "DESCRIBES",
-      "relatedSpdxElement": "SPDXRef-Package-18f232e2f8bcfc8d"
+      "relatedSpdxElement": "SPDXRef-Package-4ab6622b68b7ad20"
     },
     {
       "spdxElementId": "SPDXRef-DOCUMENT",
       "relationshipType": "DESCRIBES",
-      "relatedSpdxElement": "SPDXRef-Package-87d75a8a36e3a905"
+      "relatedSpdxElement": "SPDXRef-Package-f555a00e5e60bd38"
     },
     {
       "spdxElementId": "SPDXRef-DOCUMENT",
       "relationshipType": "DESCRIBES",
-      "relatedSpdxElement": "SPDXRef-Package-fdc1aa5e69b581c1"
+      "relatedSpdxElement": "SPDXRef-Package-7ba1e9724ad8c5a0"
     },
     {
       "spdxElementId": "SPDXRef-DOCUMENT",
       "relationshipType": "DESCRIBES",
-      "relatedSpdxElement": "SPDXRef-Package-2499d3555c55bdd8"
+      "relatedSpdxElement": "SPDXRef-Package-9613d6cca786e5b8"
     },
     {
       "spdxElementId": "SPDXRef-DOCUMENT",
       "relationshipType": "DESCRIBES",
-      "relatedSpdxElement": "SPDXRef-Package-9ce7cf04e77ca4a6"
+      "relatedSpdxElement": "SPDXRef-Package-ea9b1f8b52305c58"
     },
     {
       "spdxElementId": "SPDXRef-DOCUMENT",
@@ -10773,32 +10911,27 @@
     {
       "spdxElementId": "SPDXRef-DOCUMENT",
       "relationshipType": "DESCRIBES",
-      "relatedSpdxElement": "SPDXRef-Package-c954ec0010947377"
+      "relatedSpdxElement": "SPDXRef-Package-dab0f600a6aac3a5"
     },
     {
       "spdxElementId": "SPDXRef-DOCUMENT",
       "relationshipType": "DESCRIBES",
-      "relatedSpdxElement": "SPDXRef-Package-db0a8a179287852b"
+      "relatedSpdxElement": "SPDXRef-Package-828ab691dacd318f"
     },
     {
       "spdxElementId": "SPDXRef-DOCUMENT",
       "relationshipType": "DESCRIBES",
-      "relatedSpdxElement": "SPDXRef-Package-4c47aeaa005e858a"
+      "relatedSpdxElement": "SPDXRef-Package-7ef22c29797e4d3d"
     },
     {
       "spdxElementId": "SPDXRef-DOCUMENT",
       "relationshipType": "DESCRIBES",
-      "relatedSpdxElement": "SPDXRef-Package-a4143b2eec52de2b"
+      "relatedSpdxElement": "SPDXRef-Package-952f3858313b4378"
     },
     {
       "spdxElementId": "SPDXRef-DOCUMENT",
       "relationshipType": "DESCRIBES",
-      "relatedSpdxElement": "SPDXRef-Package-b1d9220809aa7a64"
-    },
-    {
-      "spdxElementId": "SPDXRef-DOCUMENT",
-      "relationshipType": "DESCRIBES",
-      "relatedSpdxElement": "SPDXRef-Package-c0bac98925b4634a"
+      "relatedSpdxElement": "SPDXRef-Package-98e94fcbd54437ff"
     },
     {
       "spdxElementId": "SPDXRef-DOCUMENT",
@@ -10818,7 +10951,7 @@
     {
       "spdxElementId": "SPDXRef-DOCUMENT",
       "relationshipType": "DESCRIBES",
-      "relatedSpdxElement": "SPDXRef-Package-87d88e47cacb464b"
+      "relatedSpdxElement": "SPDXRef-Package-0acdbde3f99d7b83"
     },
     {
       "spdxElementId": "SPDXRef-DOCUMENT",
@@ -11008,47 +11141,52 @@
     {
       "spdxElementId": "SPDXRef-DOCUMENT",
       "relationshipType": "DESCRIBES",
-      "relatedSpdxElement": "SPDXRef-Package-697edb2f6789d2bf"
+      "relatedSpdxElement": "SPDXRef-Package-21e2f3b9e698d433"
     },
     {
       "spdxElementId": "SPDXRef-DOCUMENT",
       "relationshipType": "DESCRIBES",
-      "relatedSpdxElement": "SPDXRef-Package-39bee8b40a187d72"
+      "relatedSpdxElement": "SPDXRef-Package-7679de1ca6bac3dc"
     },
     {
       "spdxElementId": "SPDXRef-DOCUMENT",
       "relationshipType": "DESCRIBES",
-      "relatedSpdxElement": "SPDXRef-Package-319a60e34cc90e53"
+      "relatedSpdxElement": "SPDXRef-Package-434137ef60694065"
     },
     {
       "spdxElementId": "SPDXRef-DOCUMENT",
       "relationshipType": "DESCRIBES",
-      "relatedSpdxElement": "SPDXRef-Package-2246cebc8611d4a9"
+      "relatedSpdxElement": "SPDXRef-Package-ea25b6a034786450"
     },
     {
       "spdxElementId": "SPDXRef-DOCUMENT",
       "relationshipType": "DESCRIBES",
-      "relatedSpdxElement": "SPDXRef-Package-73c5e62980816f3b"
+      "relatedSpdxElement": "SPDXRef-Package-007d6833d0beec2b"
     },
     {
       "spdxElementId": "SPDXRef-DOCUMENT",
       "relationshipType": "DESCRIBES",
-      "relatedSpdxElement": "SPDXRef-Package-90829fd85682cb54"
+      "relatedSpdxElement": "SPDXRef-Package-0377a46cabd76d85"
     },
     {
       "spdxElementId": "SPDXRef-DOCUMENT",
       "relationshipType": "DESCRIBES",
-      "relatedSpdxElement": "SPDXRef-Package-b07732d9e61953dc"
+      "relatedSpdxElement": "SPDXRef-Package-b2c43839a201485c"
     },
     {
       "spdxElementId": "SPDXRef-DOCUMENT",
       "relationshipType": "DESCRIBES",
-      "relatedSpdxElement": "SPDXRef-Package-2bc8ec6514dca871"
+      "relatedSpdxElement": "SPDXRef-Package-11f24d26ef45da66"
     },
     {
       "spdxElementId": "SPDXRef-DOCUMENT",
       "relationshipType": "DESCRIBES",
-      "relatedSpdxElement": "SPDXRef-Package-f790a5dd2c1b424e"
+      "relatedSpdxElement": "SPDXRef-Package-e472e20c90af8fe4"
+    },
+    {
+      "spdxElementId": "SPDXRef-DOCUMENT",
+      "relationshipType": "DESCRIBES",
+      "relatedSpdxElement": "SPDXRef-Package-fc0492cb2625a29f"
     },
     {
       "spdxElementId": "SPDXRef-DOCUMENT",
@@ -11058,12 +11196,12 @@
     {
       "spdxElementId": "SPDXRef-DOCUMENT",
       "relationshipType": "DESCRIBES",
-      "relatedSpdxElement": "SPDXRef-Package-0b5a844e5407336a"
+      "relatedSpdxElement": "SPDXRef-Package-48ec3746ca63e32d"
     },
     {
       "spdxElementId": "SPDXRef-DOCUMENT",
       "relationshipType": "DESCRIBES",
-      "relatedSpdxElement": "SPDXRef-Package-29f40625ff887dce"
+      "relatedSpdxElement": "SPDXRef-Package-48adfa4b57db12d0"
     },
     {
       "spdxElementId": "SPDXRef-DOCUMENT",
@@ -11073,12 +11211,7 @@
     {
       "spdxElementId": "SPDXRef-DOCUMENT",
       "relationshipType": "DESCRIBES",
-      "relatedSpdxElement": "SPDXRef-Package-e6cc8a080e50374e"
-    },
-    {
-      "spdxElementId": "SPDXRef-DOCUMENT",
-      "relationshipType": "DESCRIBES",
-      "relatedSpdxElement": "SPDXRef-Package-58f40d3f2ac7f037"
+      "relatedSpdxElement": "SPDXRef-Package-d80edd77c266fce4"
     },
     {
       "spdxElementId": "SPDXRef-DOCUMENT",
@@ -11168,7 +11301,7 @@
     {
       "spdxElementId": "SPDXRef-DOCUMENT",
       "relationshipType": "DESCRIBES",
-      "relatedSpdxElement": "SPDXRef-Package-225d9eba44f2c070"
+      "relatedSpdxElement": "SPDXRef-Package-941d66f44d7533af"
     },
     {
       "spdxElementId": "SPDXRef-DOCUMENT",
@@ -11228,11 +11361,6 @@
     {
       "spdxElementId": "SPDXRef-DOCUMENT",
       "relationshipType": "DESCRIBES",
-      "relatedSpdxElement": "SPDXRef-Package-93e30f698184db06"
-    },
-    {
-      "spdxElementId": "SPDXRef-DOCUMENT",
-      "relationshipType": "DESCRIBES",
       "relatedSpdxElement": "SPDXRef-Package-2a5f02a5b88d90c7"
     },
     {
@@ -11263,7 +11391,12 @@
     {
       "spdxElementId": "SPDXRef-DOCUMENT",
       "relationshipType": "DESCRIBES",
-      "relatedSpdxElement": "SPDXRef-Package-bdd394dd76daf688"
+      "relatedSpdxElement": "SPDXRef-Package-001e09a3c95a0f4c"
+    },
+    {
+      "spdxElementId": "SPDXRef-DOCUMENT",
+      "relationshipType": "DESCRIBES",
+      "relatedSpdxElement": "SPDXRef-Package-4bb46f134eb78acd"
     },
     {
       "spdxElementId": "SPDXRef-DOCUMENT",
@@ -11273,7 +11406,7 @@
     {
       "spdxElementId": "SPDXRef-DOCUMENT",
       "relationshipType": "DESCRIBES",
-      "relatedSpdxElement": "SPDXRef-Package-2d518b389f6bb837"
+      "relatedSpdxElement": "SPDXRef-Package-a5b27d8080aa66fa"
     },
     {
       "spdxElementId": "SPDXRef-DOCUMENT",
@@ -11518,11 +11651,6 @@
     {
       "spdxElementId": "SPDXRef-DOCUMENT",
       "relationshipType": "DESCRIBES",
-      "relatedSpdxElement": "SPDXRef-Package-12f921da792516fb"
-    },
-    {
-      "spdxElementId": "SPDXRef-DOCUMENT",
-      "relationshipType": "DESCRIBES",
       "relatedSpdxElement": "SPDXRef-Package-b05903de4c965507"
     },
     {
@@ -11579,11 +11707,6 @@
       "spdxElementId": "SPDXRef-DOCUMENT",
       "relationshipType": "DESCRIBES",
       "relatedSpdxElement": "SPDXRef-Package-dd3933b705c729c5"
-    },
-    {
-      "spdxElementId": "SPDXRef-DOCUMENT",
-      "relationshipType": "DESCRIBES",
-      "relatedSpdxElement": "SPDXRef-Package-1c3a0e559d0f9ecd"
     },
     {
       "spdxElementId": "SPDXRef-DOCUMENT",
@@ -11678,157 +11801,152 @@
     {
       "spdxElementId": "SPDXRef-DOCUMENT",
       "relationshipType": "DESCRIBES",
-      "relatedSpdxElement": "SPDXRef-Package-f904a8f640516fd4"
+      "relatedSpdxElement": "SPDXRef-Package-a21f8aa8ea316bba"
     },
     {
       "spdxElementId": "SPDXRef-DOCUMENT",
       "relationshipType": "DESCRIBES",
-      "relatedSpdxElement": "SPDXRef-Package-49bdb2df683d4c2b"
+      "relatedSpdxElement": "SPDXRef-Package-d3e78dcf1fe1fd7f"
     },
     {
       "spdxElementId": "SPDXRef-DOCUMENT",
       "relationshipType": "DESCRIBES",
-      "relatedSpdxElement": "SPDXRef-Package-c0652dfd8ad23fd0"
+      "relatedSpdxElement": "SPDXRef-Package-96bd055d8952a64a"
     },
     {
       "spdxElementId": "SPDXRef-DOCUMENT",
       "relationshipType": "DESCRIBES",
-      "relatedSpdxElement": "SPDXRef-Package-5244d65f73050017"
+      "relatedSpdxElement": "SPDXRef-Package-eb081b986ec50ba8"
     },
     {
       "spdxElementId": "SPDXRef-DOCUMENT",
       "relationshipType": "DESCRIBES",
-      "relatedSpdxElement": "SPDXRef-Package-de023797d4f6beb3"
+      "relatedSpdxElement": "SPDXRef-Package-33d1161b33e80a74"
     },
     {
       "spdxElementId": "SPDXRef-DOCUMENT",
       "relationshipType": "DESCRIBES",
-      "relatedSpdxElement": "SPDXRef-Package-617b233816b65cd3"
+      "relatedSpdxElement": "SPDXRef-Package-16721e986d3b9518"
     },
     {
       "spdxElementId": "SPDXRef-DOCUMENT",
       "relationshipType": "DESCRIBES",
-      "relatedSpdxElement": "SPDXRef-Package-1f337586ebdeb8f6"
+      "relatedSpdxElement": "SPDXRef-Package-212df03adf8ed7fe"
     },
     {
       "spdxElementId": "SPDXRef-DOCUMENT",
       "relationshipType": "DESCRIBES",
-      "relatedSpdxElement": "SPDXRef-Package-4509b3d6d2ad2247"
+      "relatedSpdxElement": "SPDXRef-Package-db974288258db9d5"
     },
     {
       "spdxElementId": "SPDXRef-DOCUMENT",
       "relationshipType": "DESCRIBES",
-      "relatedSpdxElement": "SPDXRef-Package-ae73538e6490c31d"
+      "relatedSpdxElement": "SPDXRef-Package-aa4802bc4df9e75d"
     },
     {
       "spdxElementId": "SPDXRef-DOCUMENT",
       "relationshipType": "DESCRIBES",
-      "relatedSpdxElement": "SPDXRef-Package-2f57860ffb00e84a"
+      "relatedSpdxElement": "SPDXRef-Package-178ca4d8f21ab312"
     },
     {
       "spdxElementId": "SPDXRef-DOCUMENT",
       "relationshipType": "DESCRIBES",
-      "relatedSpdxElement": "SPDXRef-Package-c24f51763a027a0c"
+      "relatedSpdxElement": "SPDXRef-Package-437ab5e1d8c16256"
     },
     {
       "spdxElementId": "SPDXRef-DOCUMENT",
       "relationshipType": "DESCRIBES",
-      "relatedSpdxElement": "SPDXRef-Package-c6f45a0d6c4e5cd4"
+      "relatedSpdxElement": "SPDXRef-Package-a5bbd96cc10aa769"
     },
     {
       "spdxElementId": "SPDXRef-DOCUMENT",
       "relationshipType": "DESCRIBES",
-      "relatedSpdxElement": "SPDXRef-Package-33a951a400f7df59"
+      "relatedSpdxElement": "SPDXRef-Package-7db55d7e21b6e61b"
     },
     {
       "spdxElementId": "SPDXRef-DOCUMENT",
       "relationshipType": "DESCRIBES",
-      "relatedSpdxElement": "SPDXRef-Package-eefa29432c981aa8"
+      "relatedSpdxElement": "SPDXRef-Package-3afcf9f00a2e8de5"
     },
     {
       "spdxElementId": "SPDXRef-DOCUMENT",
       "relationshipType": "DESCRIBES",
-      "relatedSpdxElement": "SPDXRef-Package-7f4954546c75f805"
+      "relatedSpdxElement": "SPDXRef-Package-ca53585bedabf1bf"
     },
     {
       "spdxElementId": "SPDXRef-DOCUMENT",
       "relationshipType": "DESCRIBES",
-      "relatedSpdxElement": "SPDXRef-Package-589614dc8525ab1d"
+      "relatedSpdxElement": "SPDXRef-Package-c383b71921578672"
     },
     {
       "spdxElementId": "SPDXRef-DOCUMENT",
       "relationshipType": "DESCRIBES",
-      "relatedSpdxElement": "SPDXRef-Package-c93981ba4220ef5d"
+      "relatedSpdxElement": "SPDXRef-Package-abb4296acc136edf"
     },
     {
       "spdxElementId": "SPDXRef-DOCUMENT",
       "relationshipType": "DESCRIBES",
-      "relatedSpdxElement": "SPDXRef-Package-c395b610c9c83108"
+      "relatedSpdxElement": "SPDXRef-Package-1d7cbf079bfa1c79"
     },
     {
       "spdxElementId": "SPDXRef-DOCUMENT",
       "relationshipType": "DESCRIBES",
-      "relatedSpdxElement": "SPDXRef-Package-b4a626d8163a8d58"
+      "relatedSpdxElement": "SPDXRef-Package-fb9a2dea2b853b2e"
     },
     {
       "spdxElementId": "SPDXRef-DOCUMENT",
       "relationshipType": "DESCRIBES",
-      "relatedSpdxElement": "SPDXRef-Package-d32bd72eb825a363"
+      "relatedSpdxElement": "SPDXRef-Package-effb76fd2f135e9e"
     },
     {
       "spdxElementId": "SPDXRef-DOCUMENT",
       "relationshipType": "DESCRIBES",
-      "relatedSpdxElement": "SPDXRef-Package-80cdba93d16a6db7"
+      "relatedSpdxElement": "SPDXRef-Package-2fa8052f5f4080b3"
     },
     {
       "spdxElementId": "SPDXRef-DOCUMENT",
       "relationshipType": "DESCRIBES",
-      "relatedSpdxElement": "SPDXRef-Package-d311c09601e952de"
+      "relatedSpdxElement": "SPDXRef-Package-e5bcaadc6e015d5e"
     },
     {
       "spdxElementId": "SPDXRef-DOCUMENT",
       "relationshipType": "DESCRIBES",
-      "relatedSpdxElement": "SPDXRef-Package-138291e1c127cad9"
+      "relatedSpdxElement": "SPDXRef-Package-f4802688e73e0a32"
     },
     {
       "spdxElementId": "SPDXRef-DOCUMENT",
       "relationshipType": "DESCRIBES",
-      "relatedSpdxElement": "SPDXRef-Package-489f92d8a30a359c"
+      "relatedSpdxElement": "SPDXRef-Package-26b461b3f5de381c"
     },
     {
       "spdxElementId": "SPDXRef-DOCUMENT",
       "relationshipType": "DESCRIBES",
-      "relatedSpdxElement": "SPDXRef-Package-415b21fcb52049d8"
+      "relatedSpdxElement": "SPDXRef-Package-337b5c07192674f9"
     },
     {
       "spdxElementId": "SPDXRef-DOCUMENT",
       "relationshipType": "DESCRIBES",
-      "relatedSpdxElement": "SPDXRef-Package-ad9182d6194767d9"
+      "relatedSpdxElement": "SPDXRef-Package-7be8250e4e585882"
     },
     {
       "spdxElementId": "SPDXRef-DOCUMENT",
       "relationshipType": "DESCRIBES",
-      "relatedSpdxElement": "SPDXRef-Package-955b483a28991e94"
+      "relatedSpdxElement": "SPDXRef-Package-f35e90f38d6ead79"
     },
     {
       "spdxElementId": "SPDXRef-DOCUMENT",
       "relationshipType": "DESCRIBES",
-      "relatedSpdxElement": "SPDXRef-Package-ac1d86a216028819"
+      "relatedSpdxElement": "SPDXRef-Package-b3b6449f3773b175"
     },
     {
       "spdxElementId": "SPDXRef-DOCUMENT",
       "relationshipType": "DESCRIBES",
-      "relatedSpdxElement": "SPDXRef-Package-6416decb6cf4e38f"
+      "relatedSpdxElement": "SPDXRef-Package-bf533b3e2ed3f7f5"
     },
     {
       "spdxElementId": "SPDXRef-DOCUMENT",
       "relationshipType": "DESCRIBES",
-      "relatedSpdxElement": "SPDXRef-Package-598de26019281869"
-    },
-    {
-      "spdxElementId": "SPDXRef-DOCUMENT",
-      "relationshipType": "DESCRIBES",
-      "relatedSpdxElement": "SPDXRef-Package-4a45e7754a1432e1"
+      "relatedSpdxElement": "SPDXRef-Package-3747d33027ed5d3f"
     },
     {
       "spdxElementId": "SPDXRef-DOCUMENT",
@@ -11838,57 +11956,57 @@
     {
       "spdxElementId": "SPDXRef-DOCUMENT",
       "relationshipType": "DESCRIBES",
-      "relatedSpdxElement": "SPDXRef-Package-1d313b59691b3815"
+      "relatedSpdxElement": "SPDXRef-Package-351d6a4e6ee6dd69"
     },
     {
       "spdxElementId": "SPDXRef-DOCUMENT",
       "relationshipType": "DESCRIBES",
-      "relatedSpdxElement": "SPDXRef-Package-4943becc52f7c846"
+      "relatedSpdxElement": "SPDXRef-Package-9d90dc6c6c4be0bb"
     },
     {
       "spdxElementId": "SPDXRef-DOCUMENT",
       "relationshipType": "DESCRIBES",
-      "relatedSpdxElement": "SPDXRef-Package-d311b4ab7ff5b00d"
+      "relatedSpdxElement": "SPDXRef-Package-b4cc7f026fce021b"
     },
     {
       "spdxElementId": "SPDXRef-DOCUMENT",
       "relationshipType": "DESCRIBES",
-      "relatedSpdxElement": "SPDXRef-Package-a76d5fff827e3e52"
+      "relatedSpdxElement": "SPDXRef-Package-93ef7f8f2d646cf4"
     },
     {
       "spdxElementId": "SPDXRef-DOCUMENT",
       "relationshipType": "DESCRIBES",
-      "relatedSpdxElement": "SPDXRef-Package-e2848901cb956a1c"
+      "relatedSpdxElement": "SPDXRef-Package-4d6601a85cd39faa"
     },
     {
       "spdxElementId": "SPDXRef-DOCUMENT",
       "relationshipType": "DESCRIBES",
-      "relatedSpdxElement": "SPDXRef-Package-671c72dd56bb579e"
+      "relatedSpdxElement": "SPDXRef-Package-69cfe19a4ed17459"
     },
     {
       "spdxElementId": "SPDXRef-DOCUMENT",
       "relationshipType": "DESCRIBES",
-      "relatedSpdxElement": "SPDXRef-Package-e1f9f99d647772da"
+      "relatedSpdxElement": "SPDXRef-Package-aa96b5fa5570dbff"
     },
     {
       "spdxElementId": "SPDXRef-DOCUMENT",
       "relationshipType": "DESCRIBES",
-      "relatedSpdxElement": "SPDXRef-Package-abf2a80389832b3e"
+      "relatedSpdxElement": "SPDXRef-Package-2acfd2fd0fd3ba5f"
     },
     {
       "spdxElementId": "SPDXRef-DOCUMENT",
       "relationshipType": "DESCRIBES",
-      "relatedSpdxElement": "SPDXRef-Package-bcd7977e03f59a7e"
+      "relatedSpdxElement": "SPDXRef-Package-39ccab59fc625cd2"
     },
     {
       "spdxElementId": "SPDXRef-DOCUMENT",
       "relationshipType": "DESCRIBES",
-      "relatedSpdxElement": "SPDXRef-Package-69891146ffd2ac4e"
+      "relatedSpdxElement": "SPDXRef-Package-8b849016e1749034"
     },
     {
       "spdxElementId": "SPDXRef-DOCUMENT",
       "relationshipType": "DESCRIBES",
-      "relatedSpdxElement": "SPDXRef-Package-cd5fdc34ff05ecda"
+      "relatedSpdxElement": "SPDXRef-Package-d7af0c7232fa828c"
     },
     {
       "spdxElementId": "SPDXRef-DOCUMENT",
@@ -12013,12 +12131,7 @@
     {
       "spdxElementId": "SPDXRef-DOCUMENT",
       "relationshipType": "DESCRIBES",
-      "relatedSpdxElement": "SPDXRef-Package-c2badcb682cdf5ce"
-    },
-    {
-      "spdxElementId": "SPDXRef-DOCUMENT",
-      "relationshipType": "DESCRIBES",
-      "relatedSpdxElement": "SPDXRef-Package-7bb0f392884b6c7b"
+      "relatedSpdxElement": "SPDXRef-Package-3f43a0a8eb764204"
     },
     {
       "spdxElementId": "SPDXRef-DOCUMENT",
@@ -12028,12 +12141,32 @@
     {
       "spdxElementId": "SPDXRef-DOCUMENT",
       "relationshipType": "DESCRIBES",
-      "relatedSpdxElement": "SPDXRef-Package-fcf18dec3c39a179"
+      "relatedSpdxElement": "SPDXRef-Package-7f10269e26834f74"
+    },
+    {
+      "spdxElementId": "SPDXRef-DOCUMENT",
+      "relationshipType": "DESCRIBES",
+      "relatedSpdxElement": "SPDXRef-Package-d2400efb14a646cc"
     },
     {
       "spdxElementId": "SPDXRef-DOCUMENT",
       "relationshipType": "DESCRIBES",
       "relatedSpdxElement": "SPDXRef-Package-535c12cfb084b0a7"
+    },
+    {
+      "spdxElementId": "SPDXRef-DOCUMENT",
+      "relationshipType": "DESCRIBES",
+      "relatedSpdxElement": "SPDXRef-Package-0c381b6f09221886"
+    },
+    {
+      "spdxElementId": "SPDXRef-DOCUMENT",
+      "relationshipType": "DESCRIBES",
+      "relatedSpdxElement": "SPDXRef-Package-04a516c568f52201"
+    },
+    {
+      "spdxElementId": "SPDXRef-DOCUMENT",
+      "relationshipType": "DESCRIBES",
+      "relatedSpdxElement": "SPDXRef-Package-48959bb6d78ea484"
     },
     {
       "spdxElementId": "SPDXRef-DOCUMENT",
@@ -12074,11 +12207,6 @@
       "spdxElementId": "SPDXRef-DOCUMENT",
       "relationshipType": "DESCRIBES",
       "relatedSpdxElement": "SPDXRef-Package-41bbec0dae5bac67"
-    },
-    {
-      "spdxElementId": "SPDXRef-DOCUMENT",
-      "relationshipType": "DESCRIBES",
-      "relatedSpdxElement": "SPDXRef-Package-e4c04eafeff49de8"
     },
     {
       "spdxElementId": "SPDXRef-DOCUMENT",
@@ -12293,7 +12421,17 @@
     {
       "spdxElementId": "SPDXRef-DOCUMENT",
       "relationshipType": "DESCRIBES",
+      "relatedSpdxElement": "SPDXRef-Package-7c676065cfd964ce"
+    },
+    {
+      "spdxElementId": "SPDXRef-DOCUMENT",
+      "relationshipType": "DESCRIBES",
       "relatedSpdxElement": "SPDXRef-Package-5b883337a485e777"
+    },
+    {
+      "spdxElementId": "SPDXRef-DOCUMENT",
+      "relationshipType": "DESCRIBES",
+      "relatedSpdxElement": "SPDXRef-Package-3acb47578d0e1af3"
     },
     {
       "spdxElementId": "SPDXRef-DOCUMENT",
@@ -12303,7 +12441,17 @@
     {
       "spdxElementId": "SPDXRef-DOCUMENT",
       "relationshipType": "DESCRIBES",
+      "relatedSpdxElement": "SPDXRef-Package-2345f39952349568"
+    },
+    {
+      "spdxElementId": "SPDXRef-DOCUMENT",
+      "relationshipType": "DESCRIBES",
       "relatedSpdxElement": "SPDXRef-Package-9cfa9e8a7af46d4c"
+    },
+    {
+      "spdxElementId": "SPDXRef-DOCUMENT",
+      "relationshipType": "DESCRIBES",
+      "relatedSpdxElement": "SPDXRef-Package-bb90f134a888e80f"
     },
     {
       "spdxElementId": "SPDXRef-DOCUMENT",
@@ -12313,7 +12461,17 @@
     {
       "spdxElementId": "SPDXRef-DOCUMENT",
       "relationshipType": "DESCRIBES",
+      "relatedSpdxElement": "SPDXRef-Package-4e0b399ea417d4b3"
+    },
+    {
+      "spdxElementId": "SPDXRef-DOCUMENT",
+      "relationshipType": "DESCRIBES",
       "relatedSpdxElement": "SPDXRef-Package-a35101b99db7bfa8"
+    },
+    {
+      "spdxElementId": "SPDXRef-DOCUMENT",
+      "relationshipType": "DESCRIBES",
+      "relatedSpdxElement": "SPDXRef-Package-ab9b3717f29cebf8"
     },
     {
       "spdxElementId": "SPDXRef-DOCUMENT",
@@ -12323,7 +12481,17 @@
     {
       "spdxElementId": "SPDXRef-DOCUMENT",
       "relationshipType": "DESCRIBES",
+      "relatedSpdxElement": "SPDXRef-Package-cb89d27f053a8229"
+    },
+    {
+      "spdxElementId": "SPDXRef-DOCUMENT",
+      "relationshipType": "DESCRIBES",
       "relatedSpdxElement": "SPDXRef-Package-c169b0b8613d59b6"
+    },
+    {
+      "spdxElementId": "SPDXRef-DOCUMENT",
+      "relationshipType": "DESCRIBES",
+      "relatedSpdxElement": "SPDXRef-Package-70598be7904735a1"
     },
     {
       "spdxElementId": "SPDXRef-DOCUMENT",
@@ -12333,7 +12501,17 @@
     {
       "spdxElementId": "SPDXRef-DOCUMENT",
       "relationshipType": "DESCRIBES",
+      "relatedSpdxElement": "SPDXRef-Package-98d6596180be67e1"
+    },
+    {
+      "spdxElementId": "SPDXRef-DOCUMENT",
+      "relationshipType": "DESCRIBES",
       "relatedSpdxElement": "SPDXRef-Package-5a666c014661c95e"
+    },
+    {
+      "spdxElementId": "SPDXRef-DOCUMENT",
+      "relationshipType": "DESCRIBES",
+      "relatedSpdxElement": "SPDXRef-Package-cffe6b9120ab6939"
     },
     {
       "spdxElementId": "SPDXRef-DOCUMENT",
@@ -12343,7 +12521,17 @@
     {
       "spdxElementId": "SPDXRef-DOCUMENT",
       "relationshipType": "DESCRIBES",
+      "relatedSpdxElement": "SPDXRef-Package-6aa71406fb83e2b1"
+    },
+    {
+      "spdxElementId": "SPDXRef-DOCUMENT",
+      "relationshipType": "DESCRIBES",
       "relatedSpdxElement": "SPDXRef-Package-3757547c4c1d5336"
+    },
+    {
+      "spdxElementId": "SPDXRef-DOCUMENT",
+      "relationshipType": "DESCRIBES",
+      "relatedSpdxElement": "SPDXRef-Package-ed7d37aa788ec99a"
     },
     {
       "spdxElementId": "SPDXRef-DOCUMENT",
@@ -12353,7 +12541,17 @@
     {
       "spdxElementId": "SPDXRef-DOCUMENT",
       "relationshipType": "DESCRIBES",
+      "relatedSpdxElement": "SPDXRef-Package-499b1df7a096af9a"
+    },
+    {
+      "spdxElementId": "SPDXRef-DOCUMENT",
+      "relationshipType": "DESCRIBES",
       "relatedSpdxElement": "SPDXRef-Package-f9387ad05dce7961"
+    },
+    {
+      "spdxElementId": "SPDXRef-DOCUMENT",
+      "relationshipType": "DESCRIBES",
+      "relatedSpdxElement": "SPDXRef-Package-eb8a00819286064c"
     },
     {
       "spdxElementId": "SPDXRef-DOCUMENT",
@@ -12393,11 +12591,6 @@
     {
       "spdxElementId": "SPDXRef-DOCUMENT",
       "relationshipType": "DESCRIBES",
-      "relatedSpdxElement": "SPDXRef-Package-d630fdbec9080dbb"
-    },
-    {
-      "spdxElementId": "SPDXRef-DOCUMENT",
-      "relationshipType": "DESCRIBES",
       "relatedSpdxElement": "SPDXRef-Package-37b2e23b08106590"
     },
     {
@@ -12423,7 +12616,7 @@
     {
       "spdxElementId": "SPDXRef-DOCUMENT",
       "relationshipType": "DESCRIBES",
-      "relatedSpdxElement": "SPDXRef-Package-2ed7bbd69b3885e6"
+      "relatedSpdxElement": "SPDXRef-Package-1327b46b9d227040"
     },
     {
       "spdxElementId": "SPDXRef-DOCUMENT",
@@ -12484,6 +12677,11 @@
       "spdxElementId": "SPDXRef-DOCUMENT",
       "relationshipType": "DESCRIBES",
       "relatedSpdxElement": "SPDXRef-Package-32e4716c960d2e4f"
+    },
+    {
+      "spdxElementId": "SPDXRef-DOCUMENT",
+      "relationshipType": "DESCRIBES",
+      "relatedSpdxElement": "SPDXRef-Package-65907f15f40ad75b"
     },
     {
       "spdxElementId": "SPDXRef-DOCUMENT",
@@ -12663,6 +12861,11 @@
     {
       "spdxElementId": "SPDXRef-DOCUMENT",
       "relationshipType": "DESCRIBES",
+      "relatedSpdxElement": "SPDXRef-Package-6a89229fd526bb86"
+    },
+    {
+      "spdxElementId": "SPDXRef-DOCUMENT",
+      "relationshipType": "DESCRIBES",
       "relatedSpdxElement": "SPDXRef-Package-3f6a332a26930af4"
     },
     {
@@ -12673,7 +12876,7 @@
     {
       "spdxElementId": "SPDXRef-DOCUMENT",
       "relationshipType": "DESCRIBES",
-      "relatedSpdxElement": "SPDXRef-Package-320b48b78f68ec78"
+      "relatedSpdxElement": "SPDXRef-Package-d09e24f5425789d2"
     },
     {
       "spdxElementId": "SPDXRef-DOCUMENT",
@@ -12683,7 +12886,7 @@
     {
       "spdxElementId": "SPDXRef-DOCUMENT",
       "relationshipType": "DESCRIBES",
-      "relatedSpdxElement": "SPDXRef-Package-33e808bf5cec693e"
+      "relatedSpdxElement": "SPDXRef-Package-ff00236a86b22e8e"
     },
     {
       "spdxElementId": "SPDXRef-DOCUMENT",
@@ -12693,7 +12896,7 @@
     {
       "spdxElementId": "SPDXRef-DOCUMENT",
       "relationshipType": "DESCRIBES",
-      "relatedSpdxElement": "SPDXRef-Package-a9bb914e4ffcb526"
+      "relatedSpdxElement": "SPDXRef-Package-b7b0ad22ed49b61b"
     },
     {
       "spdxElementId": "SPDXRef-DOCUMENT",
@@ -12703,7 +12906,7 @@
     {
       "spdxElementId": "SPDXRef-DOCUMENT",
       "relationshipType": "DESCRIBES",
-      "relatedSpdxElement": "SPDXRef-Package-583495f14e006813"
+      "relatedSpdxElement": "SPDXRef-Package-b6497d544417df00"
     },
     {
       "spdxElementId": "SPDXRef-DOCUMENT",
@@ -12728,7 +12931,7 @@
     {
       "spdxElementId": "SPDXRef-DOCUMENT",
       "relationshipType": "DESCRIBES",
-      "relatedSpdxElement": "SPDXRef-Package-2729ad6f5e015637"
+      "relatedSpdxElement": "SPDXRef-Package-48fbbad74c6fdd9c"
     },
     {
       "spdxElementId": "SPDXRef-DOCUMENT",
@@ -12749,11 +12952,6 @@
       "spdxElementId": "SPDXRef-DOCUMENT",
       "relationshipType": "DESCRIBES",
       "relatedSpdxElement": "SPDXRef-Package-59285e73b61f5d17"
-    },
-    {
-      "spdxElementId": "SPDXRef-DOCUMENT",
-      "relationshipType": "DESCRIBES",
-      "relatedSpdxElement": "SPDXRef-Package-9b7210a64fc715b8"
     },
     {
       "spdxElementId": "SPDXRef-DOCUMENT",
@@ -12819,6 +13017,11 @@
       "spdxElementId": "SPDXRef-DOCUMENT",
       "relationshipType": "DESCRIBES",
       "relatedSpdxElement": "SPDXRef-Package-1708d3e03e05ca06"
+    },
+    {
+      "spdxElementId": "SPDXRef-DOCUMENT",
+      "relationshipType": "DESCRIBES",
+      "relatedSpdxElement": "SPDXRef-Package-bde20ab5886a590d"
     },
     {
       "spdxElementId": "SPDXRef-DOCUMENT",
@@ -12994,11 +13197,6 @@
       "spdxElementId": "SPDXRef-DOCUMENT",
       "relationshipType": "DESCRIBES",
       "relatedSpdxElement": "SPDXRef-Package-1f771006a623836a"
-    },
-    {
-      "spdxElementId": "SPDXRef-DOCUMENT",
-      "relationshipType": "DESCRIBES",
-      "relatedSpdxElement": "SPDXRef-Package-6b434451ae9a68d6"
     },
     {
       "spdxElementId": "SPDXRef-DOCUMENT",

--- a/docs/legal/notices/sbom/mobile-ios.spdx.json
+++ b/docs/legal/notices/sbom/mobile-ios.spdx.json
@@ -3,9 +3,9 @@
   "dataLicense": "CC0-1.0",
   "SPDXID": "SPDXRef-DOCUMENT",
   "name": "cindy-mobile-ios",
-  "documentNamespace": "https://cindy.app/spdx/mobile-ios/9cae3d29bee1df233432e6dd0978265ea2d61b380b2e50bf92a64c3516a1cccf",
+  "documentNamespace": "https://cindy.app/spdx/mobile-ios/22e8580cec32cb0ffd93f0776e3026b788adb70104d5a79b699faf275a748230",
   "creationInfo": {
-    "created": "2026-08-14T10:29:27Z",
+    "created": "2026-09-02T19:21:04Z",
     "creators": [
       "Tool: scripts/generate-third-party-notices.mjs"
     ]
@@ -50,23 +50,6 @@
       "licenseConcluded": "MIT",
       "licenseDeclared": "MIT",
       "copyrightText": "NOASSERTION"
-    },
-    {
-      "name": "@adobe/css-tools",
-      "SPDXID": "SPDXRef-Package-10a5c5df7c6ba052",
-      "versionInfo": "4.5.0",
-      "downloadLocation": "https://github.com/adobe/css-tools",
-      "filesAnalyzed": false,
-      "licenseConcluded": "MIT",
-      "licenseDeclared": "MIT",
-      "copyrightText": "NOASSERTION",
-      "externalRefs": [
-        {
-          "referenceCategory": "PACKAGE-MANAGER",
-          "referenceType": "purl",
-          "referenceLocator": "pkg:npm/%40adobe/css-tools@4.5.0"
-        }
-      ]
     },
     {
       "name": "@babel/code-frame",
@@ -1242,6 +1225,23 @@
       ]
     },
     {
+      "name": "@egjs/hammerjs",
+      "SPDXID": "SPDXRef-Package-cf26df301845f4cf",
+      "versionInfo": "2.0.17",
+      "downloadLocation": "https://github.com/naver/hammer.js",
+      "filesAnalyzed": false,
+      "licenseConcluded": "MIT",
+      "licenseDeclared": "MIT",
+      "copyrightText": "NOASSERTION",
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceType": "purl",
+          "referenceLocator": "pkg:npm/%40egjs/hammerjs@2.0.17"
+        }
+      ]
+    },
+    {
       "name": "@expo-google-fonts/material-symbols",
       "SPDXID": "SPDXRef-Package-396b2918563c1afc",
       "versionInfo": "0.4.40",
@@ -1260,8 +1260,8 @@
     },
     {
       "name": "@expo/cli",
-      "SPDXID": "SPDXRef-Package-6ac0bb956200fdf5",
-      "versionInfo": "56.1.20",
+      "SPDXID": "SPDXRef-Package-20e7a8f375c2feb7",
+      "versionInfo": "57.0.19",
       "downloadLocation": "https://github.com/expo/expo",
       "filesAnalyzed": false,
       "licenseConcluded": "MIT",
@@ -1271,7 +1271,7 @@
         {
           "referenceCategory": "PACKAGE-MANAGER",
           "referenceType": "purl",
-          "referenceLocator": "pkg:npm/%40expo/cli@56.1.20"
+          "referenceLocator": "pkg:npm/%40expo/cli@57.0.19"
         }
       ]
     },
@@ -1294,8 +1294,8 @@
     },
     {
       "name": "@expo/config",
-      "SPDXID": "SPDXRef-Package-dcc374c8c02d514d",
-      "versionInfo": "56.0.12",
+      "SPDXID": "SPDXRef-Package-1496420660ddf99b",
+      "versionInfo": "57.0.9",
       "downloadLocation": "https://github.com/expo/expo",
       "filesAnalyzed": false,
       "licenseConcluded": "MIT",
@@ -1305,14 +1305,14 @@
         {
           "referenceCategory": "PACKAGE-MANAGER",
           "referenceType": "purl",
-          "referenceLocator": "pkg:npm/%40expo/config@56.0.12"
+          "referenceLocator": "pkg:npm/%40expo/config@57.0.9"
         }
       ]
     },
     {
       "name": "@expo/config-plugins",
-      "SPDXID": "SPDXRef-Package-cf8f2de11ad0cb5b",
-      "versionInfo": "56.0.13",
+      "SPDXID": "SPDXRef-Package-5b62941641563ebf",
+      "versionInfo": "57.0.9",
       "downloadLocation": "https://github.com/expo/expo",
       "filesAnalyzed": false,
       "licenseConcluded": "MIT",
@@ -1322,14 +1322,14 @@
         {
           "referenceCategory": "PACKAGE-MANAGER",
           "referenceType": "purl",
-          "referenceLocator": "pkg:npm/%40expo/config-plugins@56.0.13"
+          "referenceLocator": "pkg:npm/%40expo/config-plugins@57.0.9"
         }
       ]
     },
     {
       "name": "@expo/config-types",
-      "SPDXID": "SPDXRef-Package-cdeb690c56a84829",
-      "versionInfo": "56.0.7",
+      "SPDXID": "SPDXRef-Package-772be2704d1edaac",
+      "versionInfo": "57.0.2",
       "downloadLocation": "https://github.com/expo/expo",
       "filesAnalyzed": false,
       "licenseConcluded": "MIT",
@@ -1339,7 +1339,7 @@
         {
           "referenceCategory": "PACKAGE-MANAGER",
           "referenceType": "purl",
-          "referenceLocator": "pkg:npm/%40expo/config-types@56.0.7"
+          "referenceLocator": "pkg:npm/%40expo/config-types@57.0.2"
         }
       ]
     },
@@ -1362,8 +1362,8 @@
     },
     {
       "name": "@expo/devtools",
-      "SPDXID": "SPDXRef-Package-43316c9d32c89096",
-      "versionInfo": "56.0.2",
+      "SPDXID": "SPDXRef-Package-13b0840247977fd4",
+      "versionInfo": "57.0.1",
       "downloadLocation": "https://github.com/expo/expo",
       "filesAnalyzed": false,
       "licenseConcluded": "MIT",
@@ -1373,14 +1373,14 @@
         {
           "referenceCategory": "PACKAGE-MANAGER",
           "referenceType": "purl",
-          "referenceLocator": "pkg:npm/%40expo/devtools@56.0.2"
+          "referenceLocator": "pkg:npm/%40expo/devtools@57.0.1"
         }
       ]
     },
     {
       "name": "@expo/dom-webview",
-      "SPDXID": "SPDXRef-Package-617dd995820cbb4d",
-      "versionInfo": "56.0.6",
+      "SPDXID": "SPDXRef-Package-4747d19862c6c2b8",
+      "versionInfo": "57.0.1",
       "downloadLocation": "https://github.com/expo/expo",
       "filesAnalyzed": false,
       "licenseConcluded": "MIT",
@@ -1390,24 +1390,7 @@
         {
           "referenceCategory": "PACKAGE-MANAGER",
           "referenceType": "purl",
-          "referenceLocator": "pkg:npm/%40expo/dom-webview@56.0.6"
-        }
-      ]
-    },
-    {
-      "name": "@expo/env",
-      "SPDXID": "SPDXRef-Package-af1d891ecc9c652c",
-      "versionInfo": "2.3.1",
-      "downloadLocation": "https://github.com/expo/expo",
-      "filesAnalyzed": false,
-      "licenseConcluded": "MIT",
-      "licenseDeclared": "MIT",
-      "copyrightText": "NOASSERTION",
-      "externalRefs": [
-        {
-          "referenceCategory": "PACKAGE-MANAGER",
-          "referenceType": "purl",
-          "referenceLocator": "pkg:npm/%40expo/env@2.3.1"
+          "referenceLocator": "pkg:npm/%40expo/dom-webview@57.0.1"
         }
       ]
     },
@@ -1430,8 +1413,8 @@
     },
     {
       "name": "@expo/expo-modules-macros-plugin",
-      "SPDXID": "SPDXRef-Package-f7064e795090188d",
-      "versionInfo": "0.2.2",
+      "SPDXID": "SPDXRef-Package-a9b72b527dd55c2c",
+      "versionInfo": "0.6.1",
       "downloadLocation": "https://github.com/expo/expo-modules-macros-plugin",
       "filesAnalyzed": false,
       "licenseConcluded": "MIT",
@@ -1441,14 +1424,14 @@
         {
           "referenceCategory": "PACKAGE-MANAGER",
           "referenceType": "purl",
-          "referenceLocator": "pkg:npm/%40expo/expo-modules-macros-plugin@0.2.2"
+          "referenceLocator": "pkg:npm/%40expo/expo-modules-macros-plugin@0.6.1"
         }
       ]
     },
     {
       "name": "@expo/fingerprint",
-      "SPDXID": "SPDXRef-Package-5dd3cf74bac21b26",
-      "versionInfo": "0.19.8",
+      "SPDXID": "SPDXRef-Package-cf2499e732152ff1",
+      "versionInfo": "0.20.10",
       "downloadLocation": "https://github.com/expo/expo",
       "filesAnalyzed": false,
       "licenseConcluded": "MIT",
@@ -1458,14 +1441,14 @@
         {
           "referenceCategory": "PACKAGE-MANAGER",
           "referenceType": "purl",
-          "referenceLocator": "pkg:npm/%40expo/fingerprint@0.19.8"
+          "referenceLocator": "pkg:npm/%40expo/fingerprint@0.20.10"
         }
       ]
     },
     {
       "name": "@expo/image-utils",
-      "SPDXID": "SPDXRef-Package-24cf3edefeb8ede5",
-      "versionInfo": "0.10.3",
+      "SPDXID": "SPDXRef-Package-11cb55c38fa93cd7",
+      "versionInfo": "0.11.5",
       "downloadLocation": "https://github.com/expo/expo",
       "filesAnalyzed": false,
       "licenseConcluded": "MIT",
@@ -1475,31 +1458,14 @@
         {
           "referenceCategory": "PACKAGE-MANAGER",
           "referenceType": "purl",
-          "referenceLocator": "pkg:npm/%40expo/image-utils@0.10.3"
-        }
-      ]
-    },
-    {
-      "name": "@expo/image-utils",
-      "SPDXID": "SPDXRef-Package-52847b30294715dd",
-      "versionInfo": "0.10.4",
-      "downloadLocation": "https://github.com/expo/expo",
-      "filesAnalyzed": false,
-      "licenseConcluded": "MIT",
-      "licenseDeclared": "MIT",
-      "copyrightText": "NOASSERTION",
-      "externalRefs": [
-        {
-          "referenceCategory": "PACKAGE-MANAGER",
-          "referenceType": "purl",
-          "referenceLocator": "pkg:npm/%40expo/image-utils@0.10.4"
+          "referenceLocator": "pkg:npm/%40expo/image-utils@0.11.5"
         }
       ]
     },
     {
       "name": "@expo/inline-modules",
-      "SPDXID": "SPDXRef-Package-43d80c1b2da0e96a",
-      "versionInfo": "0.0.14",
+      "SPDXID": "SPDXRef-Package-20bcb76ccf8f4986",
+      "versionInfo": "0.1.7",
       "downloadLocation": "https://github.com/expo/expo",
       "filesAnalyzed": false,
       "licenseConcluded": "MIT",
@@ -1509,24 +1475,7 @@
         {
           "referenceCategory": "PACKAGE-MANAGER",
           "referenceType": "purl",
-          "referenceLocator": "pkg:npm/%40expo/inline-modules@0.0.14"
-        }
-      ]
-    },
-    {
-      "name": "@expo/json-file",
-      "SPDXID": "SPDXRef-Package-dca50474e69f294b",
-      "versionInfo": "10.2.0",
-      "downloadLocation": "https://github.com/expo/expo",
-      "filesAnalyzed": false,
-      "licenseConcluded": "MIT",
-      "licenseDeclared": "MIT",
-      "copyrightText": "NOASSERTION",
-      "externalRefs": [
-        {
-          "referenceCategory": "PACKAGE-MANAGER",
-          "referenceType": "purl",
-          "referenceLocator": "pkg:npm/%40expo/json-file@10.2.0"
+          "referenceLocator": "pkg:npm/%40expo/inline-modules@0.1.7"
         }
       ]
     },
@@ -1549,8 +1498,8 @@
     },
     {
       "name": "@expo/local-build-cache-provider",
-      "SPDXID": "SPDXRef-Package-91e14c6d4bc9e3b1",
-      "versionInfo": "56.0.10",
+      "SPDXID": "SPDXRef-Package-7161e8a7d78e0b5d",
+      "versionInfo": "57.0.8",
       "downloadLocation": "https://github.com/expo/expo",
       "filesAnalyzed": false,
       "licenseConcluded": "MIT",
@@ -1560,14 +1509,14 @@
         {
           "referenceCategory": "PACKAGE-MANAGER",
           "referenceType": "purl",
-          "referenceLocator": "pkg:npm/%40expo/local-build-cache-provider@56.0.10"
+          "referenceLocator": "pkg:npm/%40expo/local-build-cache-provider@57.0.8"
         }
       ]
     },
     {
       "name": "@expo/log-box",
-      "SPDXID": "SPDXRef-Package-18f232e2f8bcfc8d",
-      "versionInfo": "56.0.14",
+      "SPDXID": "SPDXRef-Package-4ab6622b68b7ad20",
+      "versionInfo": "57.0.4",
       "downloadLocation": "https://github.com/expo/expo/tree/main/packages/@expo/log-box",
       "filesAnalyzed": false,
       "licenseConcluded": "MIT",
@@ -1577,14 +1526,14 @@
         {
           "referenceCategory": "PACKAGE-MANAGER",
           "referenceType": "purl",
-          "referenceLocator": "pkg:npm/%40expo/log-box@56.0.14"
+          "referenceLocator": "pkg:npm/%40expo/log-box@57.0.4"
         }
       ]
     },
     {
       "name": "@expo/metro",
-      "SPDXID": "SPDXRef-Package-87d75a8a36e3a905",
-      "versionInfo": "56.0.0",
+      "SPDXID": "SPDXRef-Package-f555a00e5e60bd38",
+      "versionInfo": "56.0.2",
       "downloadLocation": "https://github.com/expo/expo-metro",
       "filesAnalyzed": false,
       "licenseConcluded": "MIT",
@@ -1594,14 +1543,14 @@
         {
           "referenceCategory": "PACKAGE-MANAGER",
           "referenceType": "purl",
-          "referenceLocator": "pkg:npm/%40expo/metro@56.0.0"
+          "referenceLocator": "pkg:npm/%40expo/metro@56.0.2"
         }
       ]
     },
     {
       "name": "@expo/metro-config",
-      "SPDXID": "SPDXRef-Package-fdc1aa5e69b581c1",
-      "versionInfo": "56.0.17",
+      "SPDXID": "SPDXRef-Package-7ba1e9724ad8c5a0",
+      "versionInfo": "57.0.11",
       "downloadLocation": "https://github.com/expo/expo",
       "filesAnalyzed": false,
       "licenseConcluded": "MIT",
@@ -1611,14 +1560,14 @@
         {
           "referenceCategory": "PACKAGE-MANAGER",
           "referenceType": "purl",
-          "referenceLocator": "pkg:npm/%40expo/metro-config@56.0.17"
+          "referenceLocator": "pkg:npm/%40expo/metro-config@57.0.11"
         }
       ]
     },
     {
       "name": "@expo/metro-file-map",
-      "SPDXID": "SPDXRef-Package-2499d3555c55bdd8",
-      "versionInfo": "56.0.3",
+      "SPDXID": "SPDXRef-Package-9613d6cca786e5b8",
+      "versionInfo": "57.0.2",
       "downloadLocation": "https://github.com/expo/expo",
       "filesAnalyzed": false,
       "licenseConcluded": "MIT",
@@ -1628,14 +1577,14 @@
         {
           "referenceCategory": "PACKAGE-MANAGER",
           "referenceType": "purl",
-          "referenceLocator": "pkg:npm/%40expo/metro-file-map@56.0.3"
+          "referenceLocator": "pkg:npm/%40expo/metro-file-map@57.0.2"
         }
       ]
     },
     {
       "name": "@expo/metro-runtime",
-      "SPDXID": "SPDXRef-Package-9ce7cf04e77ca4a6",
-      "versionInfo": "56.0.17",
+      "SPDXID": "SPDXRef-Package-ea9b1f8b52305c58",
+      "versionInfo": "57.0.14",
       "downloadLocation": "https://github.com/expo/expo",
       "filesAnalyzed": false,
       "licenseConcluded": "MIT",
@@ -1645,7 +1594,7 @@
         {
           "referenceCategory": "PACKAGE-MANAGER",
           "referenceType": "purl",
-          "referenceLocator": "pkg:npm/%40expo/metro-runtime@56.0.17"
+          "referenceLocator": "pkg:npm/%40expo/metro-runtime@57.0.14"
         }
       ]
     },
@@ -1685,8 +1634,8 @@
     },
     {
       "name": "@expo/plist",
-      "SPDXID": "SPDXRef-Package-c954ec0010947377",
-      "versionInfo": "0.7.0",
+      "SPDXID": "SPDXRef-Package-dab0f600a6aac3a5",
+      "versionInfo": "0.8.1",
       "downloadLocation": "https://github.com/expo/expo",
       "filesAnalyzed": false,
       "licenseConcluded": "MIT",
@@ -1696,14 +1645,14 @@
         {
           "referenceCategory": "PACKAGE-MANAGER",
           "referenceType": "purl",
-          "referenceLocator": "pkg:npm/%40expo/plist@0.7.0"
+          "referenceLocator": "pkg:npm/%40expo/plist@0.8.1"
         }
       ]
     },
     {
       "name": "@expo/prebuild-config",
-      "SPDXID": "SPDXRef-Package-db0a8a179287852b",
-      "versionInfo": "56.0.20",
+      "SPDXID": "SPDXRef-Package-828ab691dacd318f",
+      "versionInfo": "57.0.15",
       "downloadLocation": "https://github.com/expo/expo",
       "filesAnalyzed": false,
       "licenseConcluded": "MIT",
@@ -1713,14 +1662,14 @@
         {
           "referenceCategory": "PACKAGE-MANAGER",
           "referenceType": "purl",
-          "referenceLocator": "pkg:npm/%40expo/prebuild-config@56.0.20"
+          "referenceLocator": "pkg:npm/%40expo/prebuild-config@57.0.15"
         }
       ]
     },
     {
       "name": "@expo/require-utils",
-      "SPDXID": "SPDXRef-Package-4c47aeaa005e858a",
-      "versionInfo": "56.1.5",
+      "SPDXID": "SPDXRef-Package-7ef22c29797e4d3d",
+      "versionInfo": "57.0.5",
       "downloadLocation": "https://github.com/expo/expo",
       "filesAnalyzed": false,
       "licenseConcluded": "MIT",
@@ -1730,31 +1679,14 @@
         {
           "referenceCategory": "PACKAGE-MANAGER",
           "referenceType": "purl",
-          "referenceLocator": "pkg:npm/%40expo/require-utils@56.1.5"
-        }
-      ]
-    },
-    {
-      "name": "@expo/require-utils",
-      "SPDXID": "SPDXRef-Package-a4143b2eec52de2b",
-      "versionInfo": "56.1.6",
-      "downloadLocation": "https://github.com/expo/expo",
-      "filesAnalyzed": false,
-      "licenseConcluded": "MIT",
-      "licenseDeclared": "MIT",
-      "copyrightText": "NOASSERTION",
-      "externalRefs": [
-        {
-          "referenceCategory": "PACKAGE-MANAGER",
-          "referenceType": "purl",
-          "referenceLocator": "pkg:npm/%40expo/require-utils@56.1.6"
+          "referenceLocator": "pkg:npm/%40expo/require-utils@57.0.5"
         }
       ]
     },
     {
       "name": "@expo/router-server",
-      "SPDXID": "SPDXRef-Package-b1d9220809aa7a64",
-      "versionInfo": "56.0.16",
+      "SPDXID": "SPDXRef-Package-952f3858313b4378",
+      "versionInfo": "57.0.8",
       "downloadLocation": "https://github.com/expo/expo",
       "filesAnalyzed": false,
       "licenseConcluded": "MIT",
@@ -1764,14 +1696,14 @@
         {
           "referenceCategory": "PACKAGE-MANAGER",
           "referenceType": "purl",
-          "referenceLocator": "pkg:npm/%40expo/router-server@56.0.16"
+          "referenceLocator": "pkg:npm/%40expo/router-server@57.0.8"
         }
       ]
     },
     {
       "name": "@expo/schema-utils",
-      "SPDXID": "SPDXRef-Package-c0bac98925b4634a",
-      "versionInfo": "56.0.2",
+      "SPDXID": "SPDXRef-Package-98e94fcbd54437ff",
+      "versionInfo": "57.0.2",
       "downloadLocation": "https://github.com/expo/expo",
       "filesAnalyzed": false,
       "licenseConcluded": "MIT",
@@ -1781,7 +1713,7 @@
         {
           "referenceCategory": "PACKAGE-MANAGER",
           "referenceType": "purl",
-          "referenceLocator": "pkg:npm/%40expo/schema-utils@56.0.2"
+          "referenceLocator": "pkg:npm/%40expo/schema-utils@57.0.2"
         }
       ]
     },
@@ -1838,8 +1770,8 @@
     },
     {
       "name": "@expo/ui",
-      "SPDXID": "SPDXRef-Package-87d88e47cacb464b",
-      "versionInfo": "56.0.22",
+      "SPDXID": "SPDXRef-Package-0acdbde3f99d7b83",
+      "versionInfo": "57.0.14",
       "downloadLocation": "https://github.com/expo/expo",
       "filesAnalyzed": false,
       "licenseConcluded": "MIT",
@@ -1849,7 +1781,7 @@
         {
           "referenceCategory": "PACKAGE-MANAGER",
           "referenceType": "purl",
-          "referenceLocator": "pkg:npm/%40expo/ui@56.0.22"
+          "referenceLocator": "pkg:npm/%40expo/ui@57.0.14"
         }
       ]
     },
@@ -2483,10 +2415,10 @@
       ]
     },
     {
-      "name": "@react-native/assets-registry",
-      "SPDXID": "SPDXRef-Package-697edb2f6789d2bf",
-      "versionInfo": "0.85.3",
-      "downloadLocation": "https://github.com/facebook/react-native",
+      "name": "@react-native-menu/menu",
+      "SPDXID": "SPDXRef-Package-21e2f3b9e698d433",
+      "versionInfo": "2.0.0",
+      "downloadLocation": "https://github.com/react-native-menu/menu",
       "filesAnalyzed": false,
       "licenseConcluded": "MIT",
       "licenseDeclared": "MIT",
@@ -2495,15 +2427,32 @@
         {
           "referenceCategory": "PACKAGE-MANAGER",
           "referenceType": "purl",
-          "referenceLocator": "pkg:npm/%40react-native/assets-registry@0.85.3"
+          "referenceLocator": "pkg:npm/%40react-native-menu/menu@2.0.0"
+        }
+      ]
+    },
+    {
+      "name": "@react-native/assets-registry",
+      "SPDXID": "SPDXRef-Package-7679de1ca6bac3dc",
+      "versionInfo": "0.86.3",
+      "downloadLocation": "https://github.com/react/react-native",
+      "filesAnalyzed": false,
+      "licenseConcluded": "MIT",
+      "licenseDeclared": "MIT",
+      "copyrightText": "NOASSERTION",
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceType": "purl",
+          "referenceLocator": "pkg:npm/%40react-native/assets-registry@0.86.3"
         }
       ]
     },
     {
       "name": "@react-native/babel-plugin-codegen",
-      "SPDXID": "SPDXRef-Package-39bee8b40a187d72",
-      "versionInfo": "0.85.3",
-      "downloadLocation": "https://github.com/facebook/react-native",
+      "SPDXID": "SPDXRef-Package-434137ef60694065",
+      "versionInfo": "0.86.3",
+      "downloadLocation": "https://github.com/react/react-native",
       "filesAnalyzed": false,
       "licenseConcluded": "MIT",
       "licenseDeclared": "MIT",
@@ -2512,15 +2461,15 @@
         {
           "referenceCategory": "PACKAGE-MANAGER",
           "referenceType": "purl",
-          "referenceLocator": "pkg:npm/%40react-native/babel-plugin-codegen@0.85.3"
+          "referenceLocator": "pkg:npm/%40react-native/babel-plugin-codegen@0.86.3"
         }
       ]
     },
     {
       "name": "@react-native/codegen",
-      "SPDXID": "SPDXRef-Package-319a60e34cc90e53",
-      "versionInfo": "0.85.3",
-      "downloadLocation": "https://github.com/facebook/react-native",
+      "SPDXID": "SPDXRef-Package-ea25b6a034786450",
+      "versionInfo": "0.86.3",
+      "downloadLocation": "https://github.com/react/react-native",
       "filesAnalyzed": false,
       "licenseConcluded": "MIT",
       "licenseDeclared": "MIT",
@@ -2529,15 +2478,15 @@
         {
           "referenceCategory": "PACKAGE-MANAGER",
           "referenceType": "purl",
-          "referenceLocator": "pkg:npm/%40react-native/codegen@0.85.3"
+          "referenceLocator": "pkg:npm/%40react-native/codegen@0.86.3"
         }
       ]
     },
     {
       "name": "@react-native/community-cli-plugin",
-      "SPDXID": "SPDXRef-Package-2246cebc8611d4a9",
-      "versionInfo": "0.85.3",
-      "downloadLocation": "https://github.com/facebook/react-native",
+      "SPDXID": "SPDXRef-Package-007d6833d0beec2b",
+      "versionInfo": "0.86.3",
+      "downloadLocation": "https://github.com/react/react-native",
       "filesAnalyzed": false,
       "licenseConcluded": "MIT",
       "licenseDeclared": "MIT",
@@ -2546,15 +2495,15 @@
         {
           "referenceCategory": "PACKAGE-MANAGER",
           "referenceType": "purl",
-          "referenceLocator": "pkg:npm/%40react-native/community-cli-plugin@0.85.3"
+          "referenceLocator": "pkg:npm/%40react-native/community-cli-plugin@0.86.3"
         }
       ]
     },
     {
       "name": "@react-native/debugger-frontend",
-      "SPDXID": "SPDXRef-Package-73c5e62980816f3b",
-      "versionInfo": "0.85.3",
-      "downloadLocation": "https://github.com/facebook/react-native",
+      "SPDXID": "SPDXRef-Package-0377a46cabd76d85",
+      "versionInfo": "0.86.3",
+      "downloadLocation": "https://github.com/react/react-native",
       "filesAnalyzed": false,
       "licenseConcluded": "BSD-3-Clause",
       "licenseDeclared": "BSD-3-Clause",
@@ -2563,15 +2512,15 @@
         {
           "referenceCategory": "PACKAGE-MANAGER",
           "referenceType": "purl",
-          "referenceLocator": "pkg:npm/%40react-native/debugger-frontend@0.85.3"
+          "referenceLocator": "pkg:npm/%40react-native/debugger-frontend@0.86.3"
         }
       ]
     },
     {
       "name": "@react-native/debugger-shell",
-      "SPDXID": "SPDXRef-Package-90829fd85682cb54",
-      "versionInfo": "0.85.3",
-      "downloadLocation": "https://github.com/facebook/react-native",
+      "SPDXID": "SPDXRef-Package-b2c43839a201485c",
+      "versionInfo": "0.86.3",
+      "downloadLocation": "https://github.com/react/react-native",
       "filesAnalyzed": false,
       "licenseConcluded": "MIT",
       "licenseDeclared": "MIT",
@@ -2580,15 +2529,15 @@
         {
           "referenceCategory": "PACKAGE-MANAGER",
           "referenceType": "purl",
-          "referenceLocator": "pkg:npm/%40react-native/debugger-shell@0.85.3"
+          "referenceLocator": "pkg:npm/%40react-native/debugger-shell@0.86.3"
         }
       ]
     },
     {
       "name": "@react-native/dev-middleware",
-      "SPDXID": "SPDXRef-Package-b07732d9e61953dc",
-      "versionInfo": "0.85.3",
-      "downloadLocation": "https://github.com/facebook/react-native",
+      "SPDXID": "SPDXRef-Package-11f24d26ef45da66",
+      "versionInfo": "0.86.3",
+      "downloadLocation": "https://github.com/react/react-native",
       "filesAnalyzed": false,
       "licenseConcluded": "MIT",
       "licenseDeclared": "MIT",
@@ -2597,15 +2546,15 @@
         {
           "referenceCategory": "PACKAGE-MANAGER",
           "referenceType": "purl",
-          "referenceLocator": "pkg:npm/%40react-native/dev-middleware@0.85.3"
+          "referenceLocator": "pkg:npm/%40react-native/dev-middleware@0.86.3"
         }
       ]
     },
     {
       "name": "@react-native/gradle-plugin",
-      "SPDXID": "SPDXRef-Package-2bc8ec6514dca871",
-      "versionInfo": "0.85.3",
-      "downloadLocation": "https://github.com/facebook/react-native",
+      "SPDXID": "SPDXRef-Package-e472e20c90af8fe4",
+      "versionInfo": "0.86.3",
+      "downloadLocation": "https://github.com/react/react-native",
       "filesAnalyzed": false,
       "licenseConcluded": "MIT",
       "licenseDeclared": "MIT",
@@ -2614,15 +2563,15 @@
         {
           "referenceCategory": "PACKAGE-MANAGER",
           "referenceType": "purl",
-          "referenceLocator": "pkg:npm/%40react-native/gradle-plugin@0.85.3"
+          "referenceLocator": "pkg:npm/%40react-native/gradle-plugin@0.86.3"
         }
       ]
     },
     {
       "name": "@react-native/js-polyfills",
-      "SPDXID": "SPDXRef-Package-f790a5dd2c1b424e",
-      "versionInfo": "0.85.3",
-      "downloadLocation": "https://github.com/facebook/react-native",
+      "SPDXID": "SPDXRef-Package-fc0492cb2625a29f",
+      "versionInfo": "0.86.3",
+      "downloadLocation": "https://github.com/react/react-native",
       "filesAnalyzed": false,
       "licenseConcluded": "MIT",
       "licenseDeclared": "MIT",
@@ -2631,7 +2580,7 @@
         {
           "referenceCategory": "PACKAGE-MANAGER",
           "referenceType": "purl",
-          "referenceLocator": "pkg:npm/%40react-native/js-polyfills@0.85.3"
+          "referenceLocator": "pkg:npm/%40react-native/js-polyfills@0.86.3"
         }
       ]
     },
@@ -2654,9 +2603,9 @@
     },
     {
       "name": "@react-native/normalize-colors",
-      "SPDXID": "SPDXRef-Package-0b5a844e5407336a",
-      "versionInfo": "0.85.3",
-      "downloadLocation": "https://github.com/facebook/react-native",
+      "SPDXID": "SPDXRef-Package-48ec3746ca63e32d",
+      "versionInfo": "0.86.3",
+      "downloadLocation": "https://github.com/react/react-native",
       "filesAnalyzed": false,
       "licenseConcluded": "MIT",
       "licenseDeclared": "MIT",
@@ -2665,15 +2614,15 @@
         {
           "referenceCategory": "PACKAGE-MANAGER",
           "referenceType": "purl",
-          "referenceLocator": "pkg:npm/%40react-native/normalize-colors@0.85.3"
+          "referenceLocator": "pkg:npm/%40react-native/normalize-colors@0.86.3"
         }
       ]
     },
     {
       "name": "@react-native/virtualized-lists",
-      "SPDXID": "SPDXRef-Package-29f40625ff887dce",
-      "versionInfo": "0.85.3",
-      "downloadLocation": "https://github.com/facebook/react-native",
+      "SPDXID": "SPDXRef-Package-48adfa4b57db12d0",
+      "versionInfo": "0.86.3",
+      "downloadLocation": "https://github.com/react/react-native",
       "filesAnalyzed": false,
       "licenseConcluded": "MIT",
       "licenseDeclared": "MIT",
@@ -2682,7 +2631,7 @@
         {
           "referenceCategory": "PACKAGE-MANAGER",
           "referenceType": "purl",
-          "referenceLocator": "pkg:npm/%40react-native/virtualized-lists@0.85.3"
+          "referenceLocator": "pkg:npm/%40react-native/virtualized-lists@0.86.3"
         }
       ]
     },
@@ -2704,10 +2653,10 @@
       ]
     },
     {
-      "name": "@testing-library/jest-dom",
-      "SPDXID": "SPDXRef-Package-e6cc8a080e50374e",
-      "versionInfo": "6.9.1",
-      "downloadLocation": "https://github.com/testing-library/jest-dom",
+      "name": "@types/hammerjs",
+      "SPDXID": "SPDXRef-Package-d80edd77c266fce4",
+      "versionInfo": "2.0.46",
+      "downloadLocation": "https://github.com/DefinitelyTyped/DefinitelyTyped",
       "filesAnalyzed": false,
       "licenseConcluded": "MIT",
       "licenseDeclared": "MIT",
@@ -2716,24 +2665,7 @@
         {
           "referenceCategory": "PACKAGE-MANAGER",
           "referenceType": "purl",
-          "referenceLocator": "pkg:npm/%40testing-library/jest-dom@6.9.1"
-        }
-      ]
-    },
-    {
-      "name": "@testing-library/user-event",
-      "SPDXID": "SPDXRef-Package-58f40d3f2ac7f037",
-      "versionInfo": "14.6.1",
-      "downloadLocation": "https://github.com/testing-library/user-event",
-      "filesAnalyzed": false,
-      "licenseConcluded": "MIT",
-      "licenseDeclared": "MIT",
-      "copyrightText": "NOASSERTION",
-      "externalRefs": [
-        {
-          "referenceCategory": "PACKAGE-MANAGER",
-          "referenceType": "purl",
-          "referenceLocator": "pkg:npm/%40testing-library/user-event@14.6.1"
+          "referenceLocator": "pkg:npm/%40types/hammerjs@2.0.46"
         }
       ]
     },
@@ -3028,9 +2960,9 @@
     },
     {
       "name": "agent-cli-detector",
-      "SPDXID": "SPDXRef-Package-225d9eba44f2c070",
-      "versionInfo": "0.1.2",
-      "downloadLocation": "NOASSERTION",
+      "SPDXID": "SPDXRef-Package-941d66f44d7533af",
+      "versionInfo": "0.1.6",
+      "downloadLocation": "https://github.com/expo/agent-cli-detector",
       "filesAnalyzed": false,
       "licenseConcluded": "MIT",
       "licenseDeclared": "MIT",
@@ -3039,7 +2971,7 @@
         {
           "referenceCategory": "PACKAGE-MANAGER",
           "referenceType": "purl",
-          "referenceLocator": "pkg:npm/agent-cli-detector@0.1.2"
+          "referenceLocator": "pkg:npm/agent-cli-detector@0.1.6"
         }
       ]
     },
@@ -3231,23 +3163,6 @@
       ]
     },
     {
-      "name": "aria-query",
-      "SPDXID": "SPDXRef-Package-93e30f698184db06",
-      "versionInfo": "5.3.2",
-      "downloadLocation": "https://github.com/A11yance/aria-query",
-      "filesAnalyzed": false,
-      "licenseConcluded": "Apache-2.0",
-      "licenseDeclared": "Apache-2.0",
-      "copyrightText": "NOASSERTION",
-      "externalRefs": [
-        {
-          "referenceCategory": "PACKAGE-MANAGER",
-          "referenceType": "purl",
-          "referenceLocator": "pkg:npm/aria-query@5.3.2"
-        }
-      ]
-    },
-    {
       "name": "asap",
       "SPDXID": "SPDXRef-Package-2a5f02a5b88d90c7",
       "versionInfo": "2.0.6",
@@ -3351,8 +3266,8 @@
     },
     {
       "name": "babel-plugin-syntax-hermes-parser",
-      "SPDXID": "SPDXRef-Package-bdd394dd76daf688",
-      "versionInfo": "0.33.3",
+      "SPDXID": "SPDXRef-Package-001e09a3c95a0f4c",
+      "versionInfo": "0.36.0",
       "downloadLocation": "https://github.com/facebook/hermes",
       "filesAnalyzed": false,
       "licenseConcluded": "MIT",
@@ -3362,7 +3277,24 @@
         {
           "referenceCategory": "PACKAGE-MANAGER",
           "referenceType": "purl",
-          "referenceLocator": "pkg:npm/babel-plugin-syntax-hermes-parser@0.33.3"
+          "referenceLocator": "pkg:npm/babel-plugin-syntax-hermes-parser@0.36.0"
+        }
+      ]
+    },
+    {
+      "name": "babel-plugin-syntax-hermes-parser",
+      "SPDXID": "SPDXRef-Package-4bb46f134eb78acd",
+      "versionInfo": "0.36.1",
+      "downloadLocation": "https://github.com/facebook/hermes",
+      "filesAnalyzed": false,
+      "licenseConcluded": "MIT",
+      "licenseDeclared": "MIT",
+      "copyrightText": "NOASSERTION",
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceType": "purl",
+          "referenceLocator": "pkg:npm/babel-plugin-syntax-hermes-parser@0.36.1"
         }
       ]
     },
@@ -3385,8 +3317,8 @@
     },
     {
       "name": "babel-preset-expo",
-      "SPDXID": "SPDXRef-Package-2d518b389f6bb837",
-      "versionInfo": "56.0.17",
+      "SPDXID": "SPDXRef-Package-a5b27d8080aa66fa",
+      "versionInfo": "57.0.9",
       "downloadLocation": "https://github.com/expo/expo",
       "filesAnalyzed": false,
       "licenseConcluded": "MIT",
@@ -3396,7 +3328,7 @@
         {
           "referenceCategory": "PACKAGE-MANAGER",
           "referenceType": "purl",
-          "referenceLocator": "pkg:npm/babel-preset-expo@56.0.17"
+          "referenceLocator": "pkg:npm/babel-preset-expo@57.0.9"
         }
       ]
     },
@@ -4217,23 +4149,6 @@
       ]
     },
     {
-      "name": "css.escape",
-      "SPDXID": "SPDXRef-Package-12f921da792516fb",
-      "versionInfo": "1.5.1",
-      "downloadLocation": "https://github.com/mathiasbynens/CSS.escape",
-      "filesAnalyzed": false,
-      "licenseConcluded": "MIT",
-      "licenseDeclared": "MIT",
-      "copyrightText": "NOASSERTION",
-      "externalRefs": [
-        {
-          "referenceCategory": "PACKAGE-MANAGER",
-          "referenceType": "purl",
-          "referenceLocator": "pkg:npm/css.escape@1.5.1"
-        }
-      ]
-    },
-    {
       "name": "csstype",
       "SPDXID": "SPDXRef-Package-b05903de4c965507",
       "versionInfo": "3.2.3",
@@ -4434,23 +4349,6 @@
           "referenceCategory": "PACKAGE-MANAGER",
           "referenceType": "purl",
           "referenceLocator": "pkg:npm/dnssd-advertise@1.1.6"
-        }
-      ]
-    },
-    {
-      "name": "dom-accessibility-api",
-      "SPDXID": "SPDXRef-Package-1c3a0e559d0f9ecd",
-      "versionInfo": "0.6.3",
-      "downloadLocation": "https://github.com/eps1lon/dom-accessibility-api",
-      "filesAnalyzed": false,
-      "licenseConcluded": "MIT",
-      "licenseDeclared": "MIT",
-      "copyrightText": "NOASSERTION",
-      "externalRefs": [
-        {
-          "referenceCategory": "PACKAGE-MANAGER",
-          "referenceType": "purl",
-          "referenceLocator": "pkg:npm/dom-accessibility-api@0.6.3"
         }
       ]
     },
@@ -4762,8 +4660,8 @@
     },
     {
       "name": "expo",
-      "SPDXID": "SPDXRef-Package-f904a8f640516fd4",
-      "versionInfo": "56.0.16",
+      "SPDXID": "SPDXRef-Package-a21f8aa8ea316bba",
+      "versionInfo": "57.0.17",
       "downloadLocation": "https://github.com/expo/expo",
       "filesAnalyzed": false,
       "licenseConcluded": "MIT",
@@ -4773,14 +4671,14 @@
         {
           "referenceCategory": "PACKAGE-MANAGER",
           "referenceType": "purl",
-          "referenceLocator": "pkg:npm/expo@56.0.16"
+          "referenceLocator": "pkg:npm/expo@57.0.17"
         }
       ]
     },
     {
       "name": "expo-apple-authentication",
-      "SPDXID": "SPDXRef-Package-49bdb2df683d4c2b",
-      "versionInfo": "56.0.4",
+      "SPDXID": "SPDXRef-Package-d3e78dcf1fe1fd7f",
+      "versionInfo": "57.0.1",
       "downloadLocation": "https://github.com/expo/expo",
       "filesAnalyzed": false,
       "licenseConcluded": "MIT",
@@ -4790,14 +4688,14 @@
         {
           "referenceCategory": "PACKAGE-MANAGER",
           "referenceType": "purl",
-          "referenceLocator": "pkg:npm/expo-apple-authentication@56.0.4"
+          "referenceLocator": "pkg:npm/expo-apple-authentication@57.0.1"
         }
       ]
     },
     {
       "name": "expo-application",
-      "SPDXID": "SPDXRef-Package-c0652dfd8ad23fd0",
-      "versionInfo": "56.0.3",
+      "SPDXID": "SPDXRef-Package-96bd055d8952a64a",
+      "versionInfo": "57.0.2",
       "downloadLocation": "https://github.com/expo/expo",
       "filesAnalyzed": false,
       "licenseConcluded": "MIT",
@@ -4807,14 +4705,14 @@
         {
           "referenceCategory": "PACKAGE-MANAGER",
           "referenceType": "purl",
-          "referenceLocator": "pkg:npm/expo-application@56.0.3"
+          "referenceLocator": "pkg:npm/expo-application@57.0.2"
         }
       ]
     },
     {
       "name": "expo-asset",
-      "SPDXID": "SPDXRef-Package-5244d65f73050017",
-      "versionInfo": "56.0.20",
+      "SPDXID": "SPDXRef-Package-eb081b986ec50ba8",
+      "versionInfo": "57.0.15",
       "downloadLocation": "https://github.com/expo/expo",
       "filesAnalyzed": false,
       "licenseConcluded": "MIT",
@@ -4824,14 +4722,14 @@
         {
           "referenceCategory": "PACKAGE-MANAGER",
           "referenceType": "purl",
-          "referenceLocator": "pkg:npm/expo-asset@56.0.20"
+          "referenceLocator": "pkg:npm/expo-asset@57.0.15"
         }
       ]
     },
     {
       "name": "expo-audio",
-      "SPDXID": "SPDXRef-Package-de023797d4f6beb3",
-      "versionInfo": "56.0.12",
+      "SPDXID": "SPDXRef-Package-33d1161b33e80a74",
+      "versionInfo": "57.0.4",
       "downloadLocation": "https://github.com/expo/expo",
       "filesAnalyzed": false,
       "licenseConcluded": "MIT",
@@ -4841,14 +4739,14 @@
         {
           "referenceCategory": "PACKAGE-MANAGER",
           "referenceType": "purl",
-          "referenceLocator": "pkg:npm/expo-audio@56.0.12"
+          "referenceLocator": "pkg:npm/expo-audio@57.0.4"
         }
       ]
     },
     {
       "name": "expo-auth-session",
-      "SPDXID": "SPDXRef-Package-617b233816b65cd3",
-      "versionInfo": "56.0.15",
+      "SPDXID": "SPDXRef-Package-16721e986d3b9518",
+      "versionInfo": "57.0.10",
       "downloadLocation": "https://github.com/expo/expo",
       "filesAnalyzed": false,
       "licenseConcluded": "MIT",
@@ -4858,14 +4756,14 @@
         {
           "referenceCategory": "PACKAGE-MANAGER",
           "referenceType": "purl",
-          "referenceLocator": "pkg:npm/expo-auth-session@56.0.15"
+          "referenceLocator": "pkg:npm/expo-auth-session@57.0.10"
         }
       ]
     },
     {
       "name": "expo-blur",
-      "SPDXID": "SPDXRef-Package-1f337586ebdeb8f6",
-      "versionInfo": "56.0.4",
+      "SPDXID": "SPDXRef-Package-212df03adf8ed7fe",
+      "versionInfo": "57.0.2",
       "downloadLocation": "https://github.com/expo/expo",
       "filesAnalyzed": false,
       "licenseConcluded": "MIT",
@@ -4875,14 +4773,14 @@
         {
           "referenceCategory": "PACKAGE-MANAGER",
           "referenceType": "purl",
-          "referenceLocator": "pkg:npm/expo-blur@56.0.4"
+          "referenceLocator": "pkg:npm/expo-blur@57.0.2"
         }
       ]
     },
     {
       "name": "expo-build-properties",
-      "SPDXID": "SPDXRef-Package-4509b3d6d2ad2247",
-      "versionInfo": "56.0.23",
+      "SPDXID": "SPDXRef-Package-db974288258db9d5",
+      "versionInfo": "57.0.15",
       "downloadLocation": "https://github.com/expo/expo",
       "filesAnalyzed": false,
       "licenseConcluded": "MIT",
@@ -4892,14 +4790,14 @@
         {
           "referenceCategory": "PACKAGE-MANAGER",
           "referenceType": "purl",
-          "referenceLocator": "pkg:npm/expo-build-properties@56.0.23"
+          "referenceLocator": "pkg:npm/expo-build-properties@57.0.15"
         }
       ]
     },
     {
       "name": "expo-clipboard",
-      "SPDXID": "SPDXRef-Package-ae73538e6490c31d",
-      "versionInfo": "56.0.4",
+      "SPDXID": "SPDXRef-Package-aa4802bc4df9e75d",
+      "versionInfo": "57.0.1",
       "downloadLocation": "https://github.com/expo/expo",
       "filesAnalyzed": false,
       "licenseConcluded": "MIT",
@@ -4909,14 +4807,14 @@
         {
           "referenceCategory": "PACKAGE-MANAGER",
           "referenceType": "purl",
-          "referenceLocator": "pkg:npm/expo-clipboard@56.0.4"
+          "referenceLocator": "pkg:npm/expo-clipboard@57.0.1"
         }
       ]
     },
     {
       "name": "expo-constants",
-      "SPDXID": "SPDXRef-Package-2f57860ffb00e84a",
-      "versionInfo": "56.0.21",
+      "SPDXID": "SPDXRef-Package-178ca4d8f21ab312",
+      "versionInfo": "57.0.15",
       "downloadLocation": "https://github.com/expo/expo",
       "filesAnalyzed": false,
       "licenseConcluded": "MIT",
@@ -4926,31 +4824,14 @@
         {
           "referenceCategory": "PACKAGE-MANAGER",
           "referenceType": "purl",
-          "referenceLocator": "pkg:npm/expo-constants@56.0.21"
-        }
-      ]
-    },
-    {
-      "name": "expo-constants",
-      "SPDXID": "SPDXRef-Package-c24f51763a027a0c",
-      "versionInfo": "56.0.22",
-      "downloadLocation": "https://github.com/expo/expo",
-      "filesAnalyzed": false,
-      "licenseConcluded": "MIT",
-      "licenseDeclared": "MIT",
-      "copyrightText": "NOASSERTION",
-      "externalRefs": [
-        {
-          "referenceCategory": "PACKAGE-MANAGER",
-          "referenceType": "purl",
-          "referenceLocator": "pkg:npm/expo-constants@56.0.22"
+          "referenceLocator": "pkg:npm/expo-constants@57.0.15"
         }
       ]
     },
     {
       "name": "expo-crypto",
-      "SPDXID": "SPDXRef-Package-c6f45a0d6c4e5cd4",
-      "versionInfo": "56.0.4",
+      "SPDXID": "SPDXRef-Package-437ab5e1d8c16256",
+      "versionInfo": "57.0.2",
       "downloadLocation": "https://github.com/expo/expo",
       "filesAnalyzed": false,
       "licenseConcluded": "MIT",
@@ -4960,14 +4841,14 @@
         {
           "referenceCategory": "PACKAGE-MANAGER",
           "referenceType": "purl",
-          "referenceLocator": "pkg:npm/expo-crypto@56.0.4"
+          "referenceLocator": "pkg:npm/expo-crypto@57.0.2"
         }
       ]
     },
     {
       "name": "expo-document-picker",
-      "SPDXID": "SPDXRef-Package-33a951a400f7df59",
-      "versionInfo": "56.0.4",
+      "SPDXID": "SPDXRef-Package-a5bbd96cc10aa769",
+      "versionInfo": "57.0.1",
       "downloadLocation": "https://github.com/expo/expo",
       "filesAnalyzed": false,
       "licenseConcluded": "MIT",
@@ -4977,14 +4858,14 @@
         {
           "referenceCategory": "PACKAGE-MANAGER",
           "referenceType": "purl",
-          "referenceLocator": "pkg:npm/expo-document-picker@56.0.4"
+          "referenceLocator": "pkg:npm/expo-document-picker@57.0.1"
         }
       ]
     },
     {
       "name": "expo-eas-client",
-      "SPDXID": "SPDXRef-Package-eefa29432c981aa8",
-      "versionInfo": "56.0.1",
+      "SPDXID": "SPDXRef-Package-7db55d7e21b6e61b",
+      "versionInfo": "57.0.2",
       "downloadLocation": "https://github.com/expo/expo",
       "filesAnalyzed": false,
       "licenseConcluded": "MIT",
@@ -4994,14 +4875,14 @@
         {
           "referenceCategory": "PACKAGE-MANAGER",
           "referenceType": "purl",
-          "referenceLocator": "pkg:npm/expo-eas-client@56.0.1"
+          "referenceLocator": "pkg:npm/expo-eas-client@57.0.2"
         }
       ]
     },
     {
       "name": "expo-file-system",
-      "SPDXID": "SPDXRef-Package-7f4954546c75f805",
-      "versionInfo": "56.0.8",
+      "SPDXID": "SPDXRef-Package-3afcf9f00a2e8de5",
+      "versionInfo": "57.0.6",
       "downloadLocation": "https://github.com/expo/expo",
       "filesAnalyzed": false,
       "licenseConcluded": "MIT",
@@ -5011,14 +4892,14 @@
         {
           "referenceCategory": "PACKAGE-MANAGER",
           "referenceType": "purl",
-          "referenceLocator": "pkg:npm/expo-file-system@56.0.8"
+          "referenceLocator": "pkg:npm/expo-file-system@57.0.6"
         }
       ]
     },
     {
       "name": "expo-font",
-      "SPDXID": "SPDXRef-Package-589614dc8525ab1d",
-      "versionInfo": "56.0.7",
+      "SPDXID": "SPDXRef-Package-ca53585bedabf1bf",
+      "versionInfo": "57.0.1",
       "downloadLocation": "https://github.com/expo/expo",
       "filesAnalyzed": false,
       "licenseConcluded": "MIT",
@@ -5028,14 +4909,14 @@
         {
           "referenceCategory": "PACKAGE-MANAGER",
           "referenceType": "purl",
-          "referenceLocator": "pkg:npm/expo-font@56.0.7"
+          "referenceLocator": "pkg:npm/expo-font@57.0.1"
         }
       ]
     },
     {
       "name": "expo-glass-effect",
-      "SPDXID": "SPDXRef-Package-c93981ba4220ef5d",
-      "versionInfo": "56.0.4",
+      "SPDXID": "SPDXRef-Package-c383b71921578672",
+      "versionInfo": "57.0.1",
       "downloadLocation": "https://github.com/expo/expo",
       "filesAnalyzed": false,
       "licenseConcluded": "MIT",
@@ -5045,14 +4926,14 @@
         {
           "referenceCategory": "PACKAGE-MANAGER",
           "referenceType": "purl",
-          "referenceLocator": "pkg:npm/expo-glass-effect@56.0.4"
+          "referenceLocator": "pkg:npm/expo-glass-effect@57.0.1"
         }
       ]
     },
     {
       "name": "expo-image",
-      "SPDXID": "SPDXRef-Package-c395b610c9c83108",
-      "versionInfo": "56.0.11",
+      "SPDXID": "SPDXRef-Package-abb4296acc136edf",
+      "versionInfo": "57.0.3",
       "downloadLocation": "https://github.com/expo/expo",
       "filesAnalyzed": false,
       "licenseConcluded": "MIT",
@@ -5062,14 +4943,14 @@
         {
           "referenceCategory": "PACKAGE-MANAGER",
           "referenceType": "purl",
-          "referenceLocator": "pkg:npm/expo-image@56.0.11"
+          "referenceLocator": "pkg:npm/expo-image@57.0.3"
         }
       ]
     },
     {
       "name": "expo-image-loader",
-      "SPDXID": "SPDXRef-Package-b4a626d8163a8d58",
-      "versionInfo": "56.0.3",
+      "SPDXID": "SPDXRef-Package-1d7cbf079bfa1c79",
+      "versionInfo": "57.0.1",
       "downloadLocation": "https://github.com/expo/expo",
       "filesAnalyzed": false,
       "licenseConcluded": "MIT",
@@ -5079,14 +4960,14 @@
         {
           "referenceCategory": "PACKAGE-MANAGER",
           "referenceType": "purl",
-          "referenceLocator": "pkg:npm/expo-image-loader@56.0.3"
+          "referenceLocator": "pkg:npm/expo-image-loader@57.0.1"
         }
       ]
     },
     {
       "name": "expo-image-manipulator",
-      "SPDXID": "SPDXRef-Package-d32bd72eb825a363",
-      "versionInfo": "56.0.22",
+      "SPDXID": "SPDXRef-Package-fb9a2dea2b853b2e",
+      "versionInfo": "57.0.14",
       "downloadLocation": "https://github.com/expo/expo",
       "filesAnalyzed": false,
       "licenseConcluded": "MIT",
@@ -5096,14 +4977,14 @@
         {
           "referenceCategory": "PACKAGE-MANAGER",
           "referenceType": "purl",
-          "referenceLocator": "pkg:npm/expo-image-manipulator@56.0.22"
+          "referenceLocator": "pkg:npm/expo-image-manipulator@57.0.14"
         }
       ]
     },
     {
       "name": "expo-image-picker",
-      "SPDXID": "SPDXRef-Package-80cdba93d16a6db7",
-      "versionInfo": "56.0.21",
+      "SPDXID": "SPDXRef-Package-effb76fd2f135e9e",
+      "versionInfo": "57.0.14",
       "downloadLocation": "https://github.com/expo/expo",
       "filesAnalyzed": false,
       "licenseConcluded": "MIT",
@@ -5113,14 +4994,14 @@
         {
           "referenceCategory": "PACKAGE-MANAGER",
           "referenceType": "purl",
-          "referenceLocator": "pkg:npm/expo-image-picker@56.0.21"
+          "referenceLocator": "pkg:npm/expo-image-picker@57.0.14"
         }
       ]
     },
     {
       "name": "expo-json-utils",
-      "SPDXID": "SPDXRef-Package-d311c09601e952de",
-      "versionInfo": "56.0.0",
+      "SPDXID": "SPDXRef-Package-2fa8052f5f4080b3",
+      "versionInfo": "57.0.1",
       "downloadLocation": "https://github.com/expo/expo",
       "filesAnalyzed": false,
       "licenseConcluded": "MIT",
@@ -5130,14 +5011,14 @@
         {
           "referenceCategory": "PACKAGE-MANAGER",
           "referenceType": "purl",
-          "referenceLocator": "pkg:npm/expo-json-utils@56.0.0"
+          "referenceLocator": "pkg:npm/expo-json-utils@57.0.1"
         }
       ]
     },
     {
       "name": "expo-keep-awake",
-      "SPDXID": "SPDXRef-Package-138291e1c127cad9",
-      "versionInfo": "56.0.3",
+      "SPDXID": "SPDXRef-Package-e5bcaadc6e015d5e",
+      "versionInfo": "57.0.1",
       "downloadLocation": "https://github.com/expo/expo",
       "filesAnalyzed": false,
       "licenseConcluded": "MIT",
@@ -5147,14 +5028,14 @@
         {
           "referenceCategory": "PACKAGE-MANAGER",
           "referenceType": "purl",
-          "referenceLocator": "pkg:npm/expo-keep-awake@56.0.3"
+          "referenceLocator": "pkg:npm/expo-keep-awake@57.0.1"
         }
       ]
     },
     {
       "name": "expo-linking",
-      "SPDXID": "SPDXRef-Package-489f92d8a30a359c",
-      "versionInfo": "56.0.15",
+      "SPDXID": "SPDXRef-Package-f4802688e73e0a32",
+      "versionInfo": "57.0.8",
       "downloadLocation": "https://github.com/expo/expo",
       "filesAnalyzed": false,
       "licenseConcluded": "MIT",
@@ -5164,14 +5045,14 @@
         {
           "referenceCategory": "PACKAGE-MANAGER",
           "referenceType": "purl",
-          "referenceLocator": "pkg:npm/expo-linking@56.0.15"
+          "referenceLocator": "pkg:npm/expo-linking@57.0.8"
         }
       ]
     },
     {
       "name": "expo-localization",
-      "SPDXID": "SPDXRef-Package-415b21fcb52049d8",
-      "versionInfo": "56.0.6",
+      "SPDXID": "SPDXRef-Package-26b461b3f5de381c",
+      "versionInfo": "57.0.1",
       "downloadLocation": "https://github.com/expo/expo",
       "filesAnalyzed": false,
       "licenseConcluded": "MIT",
@@ -5181,14 +5062,14 @@
         {
           "referenceCategory": "PACKAGE-MANAGER",
           "referenceType": "purl",
-          "referenceLocator": "pkg:npm/expo-localization@56.0.6"
+          "referenceLocator": "pkg:npm/expo-localization@57.0.1"
         }
       ]
     },
     {
       "name": "expo-manifests",
-      "SPDXID": "SPDXRef-Package-ad9182d6194767d9",
-      "versionInfo": "56.0.4",
+      "SPDXID": "SPDXRef-Package-337b5c07192674f9",
+      "versionInfo": "57.0.1",
       "downloadLocation": "https://github.com/expo/expo",
       "filesAnalyzed": false,
       "licenseConcluded": "MIT",
@@ -5198,14 +5079,14 @@
         {
           "referenceCategory": "PACKAGE-MANAGER",
           "referenceType": "purl",
-          "referenceLocator": "pkg:npm/expo-manifests@56.0.4"
+          "referenceLocator": "pkg:npm/expo-manifests@57.0.1"
         }
       ]
     },
     {
       "name": "expo-media-library",
-      "SPDXID": "SPDXRef-Package-955b483a28991e94",
-      "versionInfo": "56.0.9",
+      "SPDXID": "SPDXRef-Package-7be8250e4e585882",
+      "versionInfo": "57.0.4",
       "downloadLocation": "https://github.com/expo/expo",
       "filesAnalyzed": false,
       "licenseConcluded": "MIT",
@@ -5215,14 +5096,14 @@
         {
           "referenceCategory": "PACKAGE-MANAGER",
           "referenceType": "purl",
-          "referenceLocator": "pkg:npm/expo-media-library@56.0.9"
+          "referenceLocator": "pkg:npm/expo-media-library@57.0.4"
         }
       ]
     },
     {
       "name": "expo-modules-autolinking",
-      "SPDXID": "SPDXRef-Package-ac1d86a216028819",
-      "versionInfo": "56.0.20",
+      "SPDXID": "SPDXRef-Package-f35e90f38d6ead79",
+      "versionInfo": "57.0.12",
       "downloadLocation": "https://github.com/expo/expo",
       "filesAnalyzed": false,
       "licenseConcluded": "MIT",
@@ -5232,14 +5113,14 @@
         {
           "referenceCategory": "PACKAGE-MANAGER",
           "referenceType": "purl",
-          "referenceLocator": "pkg:npm/expo-modules-autolinking@56.0.20"
+          "referenceLocator": "pkg:npm/expo-modules-autolinking@57.0.12"
         }
       ]
     },
     {
       "name": "expo-modules-core",
-      "SPDXID": "SPDXRef-Package-6416decb6cf4e38f",
-      "versionInfo": "56.0.21",
+      "SPDXID": "SPDXRef-Package-b3b6449f3773b175",
+      "versionInfo": "57.0.14",
       "downloadLocation": "https://github.com/expo/expo",
       "filesAnalyzed": false,
       "licenseConcluded": "MIT",
@@ -5249,14 +5130,14 @@
         {
           "referenceCategory": "PACKAGE-MANAGER",
           "referenceType": "purl",
-          "referenceLocator": "pkg:npm/expo-modules-core@56.0.21"
+          "referenceLocator": "pkg:npm/expo-modules-core@57.0.14"
         }
       ]
     },
     {
       "name": "expo-modules-jsi",
-      "SPDXID": "SPDXRef-Package-598de26019281869",
-      "versionInfo": "56.0.12",
+      "SPDXID": "SPDXRef-Package-bf533b3e2ed3f7f5",
+      "versionInfo": "57.0.6",
       "downloadLocation": "https://github.com/expo/expo",
       "filesAnalyzed": false,
       "licenseConcluded": "MIT",
@@ -5266,14 +5147,14 @@
         {
           "referenceCategory": "PACKAGE-MANAGER",
           "referenceType": "purl",
-          "referenceLocator": "pkg:npm/expo-modules-jsi@56.0.12"
+          "referenceLocator": "pkg:npm/expo-modules-jsi@57.0.6"
         }
       ]
     },
     {
       "name": "expo-notifications",
-      "SPDXID": "SPDXRef-Package-4a45e7754a1432e1",
-      "versionInfo": "56.0.22",
+      "SPDXID": "SPDXRef-Package-3747d33027ed5d3f",
+      "versionInfo": "57.0.15",
       "downloadLocation": "https://github.com/expo/expo",
       "filesAnalyzed": false,
       "licenseConcluded": "MIT",
@@ -5283,7 +5164,7 @@
         {
           "referenceCategory": "PACKAGE-MANAGER",
           "referenceType": "purl",
-          "referenceLocator": "pkg:npm/expo-notifications@56.0.22"
+          "referenceLocator": "pkg:npm/expo-notifications@57.0.15"
         }
       ]
     },
@@ -5306,8 +5187,8 @@
     },
     {
       "name": "expo-router",
-      "SPDXID": "SPDXRef-Package-1d313b59691b3815",
-      "versionInfo": "56.2.15",
+      "SPDXID": "SPDXRef-Package-351d6a4e6ee6dd69",
+      "versionInfo": "57.0.17",
       "downloadLocation": "https://github.com/expo/expo",
       "filesAnalyzed": false,
       "licenseConcluded": "MIT",
@@ -5317,14 +5198,14 @@
         {
           "referenceCategory": "PACKAGE-MANAGER",
           "referenceType": "purl",
-          "referenceLocator": "pkg:npm/expo-router@56.2.15"
+          "referenceLocator": "pkg:npm/expo-router@57.0.17"
         }
       ]
     },
     {
       "name": "expo-secure-store",
-      "SPDXID": "SPDXRef-Package-4943becc52f7c846",
-      "versionInfo": "56.0.4",
+      "SPDXID": "SPDXRef-Package-9d90dc6c6c4be0bb",
+      "versionInfo": "57.0.2",
       "downloadLocation": "https://github.com/expo/expo",
       "filesAnalyzed": false,
       "licenseConcluded": "MIT",
@@ -5334,14 +5215,14 @@
         {
           "referenceCategory": "PACKAGE-MANAGER",
           "referenceType": "purl",
-          "referenceLocator": "pkg:npm/expo-secure-store@56.0.4"
+          "referenceLocator": "pkg:npm/expo-secure-store@57.0.2"
         }
       ]
     },
     {
       "name": "expo-server",
-      "SPDXID": "SPDXRef-Package-d311b4ab7ff5b00d",
-      "versionInfo": "56.0.5",
+      "SPDXID": "SPDXRef-Package-b4cc7f026fce021b",
+      "versionInfo": "57.0.3",
       "downloadLocation": "https://github.com/expo/expo",
       "filesAnalyzed": false,
       "licenseConcluded": "MIT",
@@ -5351,14 +5232,14 @@
         {
           "referenceCategory": "PACKAGE-MANAGER",
           "referenceType": "purl",
-          "referenceLocator": "pkg:npm/expo-server@56.0.5"
+          "referenceLocator": "pkg:npm/expo-server@57.0.3"
         }
       ]
     },
     {
       "name": "expo-sharing",
-      "SPDXID": "SPDXRef-Package-a76d5fff827e3e52",
-      "versionInfo": "56.0.22",
+      "SPDXID": "SPDXRef-Package-93ef7f8f2d646cf4",
+      "versionInfo": "57.0.16",
       "downloadLocation": "https://github.com/expo/expo",
       "filesAnalyzed": false,
       "licenseConcluded": "MIT",
@@ -5368,14 +5249,14 @@
         {
           "referenceCategory": "PACKAGE-MANAGER",
           "referenceType": "purl",
-          "referenceLocator": "pkg:npm/expo-sharing@56.0.22"
+          "referenceLocator": "pkg:npm/expo-sharing@57.0.16"
         }
       ]
     },
     {
       "name": "expo-splash-screen",
-      "SPDXID": "SPDXRef-Package-e2848901cb956a1c",
-      "versionInfo": "56.0.13",
+      "SPDXID": "SPDXRef-Package-4d6601a85cd39faa",
+      "versionInfo": "57.0.8",
       "downloadLocation": "https://github.com/expo/expo",
       "filesAnalyzed": false,
       "licenseConcluded": "MIT",
@@ -5385,14 +5266,14 @@
         {
           "referenceCategory": "PACKAGE-MANAGER",
           "referenceType": "purl",
-          "referenceLocator": "pkg:npm/expo-splash-screen@56.0.13"
+          "referenceLocator": "pkg:npm/expo-splash-screen@57.0.8"
         }
       ]
     },
     {
       "name": "expo-status-bar",
-      "SPDXID": "SPDXRef-Package-671c72dd56bb579e",
-      "versionInfo": "56.0.4",
+      "SPDXID": "SPDXRef-Package-69cfe19a4ed17459",
+      "versionInfo": "57.0.1",
       "downloadLocation": "https://github.com/expo/expo",
       "filesAnalyzed": false,
       "licenseConcluded": "MIT",
@@ -5402,14 +5283,14 @@
         {
           "referenceCategory": "PACKAGE-MANAGER",
           "referenceType": "purl",
-          "referenceLocator": "pkg:npm/expo-status-bar@56.0.4"
+          "referenceLocator": "pkg:npm/expo-status-bar@57.0.1"
         }
       ]
     },
     {
       "name": "expo-structured-headers",
-      "SPDXID": "SPDXRef-Package-e1f9f99d647772da",
-      "versionInfo": "56.0.0",
+      "SPDXID": "SPDXRef-Package-aa96b5fa5570dbff",
+      "versionInfo": "57.0.0",
       "downloadLocation": "https://github.com/expo/expo",
       "filesAnalyzed": false,
       "licenseConcluded": "MIT",
@@ -5419,14 +5300,14 @@
         {
           "referenceCategory": "PACKAGE-MANAGER",
           "referenceType": "purl",
-          "referenceLocator": "pkg:npm/expo-structured-headers@56.0.0"
+          "referenceLocator": "pkg:npm/expo-structured-headers@57.0.0"
         }
       ]
     },
     {
       "name": "expo-symbols",
-      "SPDXID": "SPDXRef-Package-abf2a80389832b3e",
-      "versionInfo": "56.0.6",
+      "SPDXID": "SPDXRef-Package-2acfd2fd0fd3ba5f",
+      "versionInfo": "57.0.2",
       "downloadLocation": "https://github.com/expo/expo",
       "filesAnalyzed": false,
       "licenseConcluded": "MIT",
@@ -5436,14 +5317,14 @@
         {
           "referenceCategory": "PACKAGE-MANAGER",
           "referenceType": "purl",
-          "referenceLocator": "pkg:npm/expo-symbols@56.0.6"
+          "referenceLocator": "pkg:npm/expo-symbols@57.0.2"
         }
       ]
     },
     {
       "name": "expo-updates",
-      "SPDXID": "SPDXRef-Package-bcd7977e03f59a7e",
-      "versionInfo": "56.0.22",
+      "SPDXID": "SPDXRef-Package-39ccab59fc625cd2",
+      "versionInfo": "57.0.18",
       "downloadLocation": "https://github.com/expo/expo",
       "filesAnalyzed": false,
       "licenseConcluded": "MIT",
@@ -5453,14 +5334,14 @@
         {
           "referenceCategory": "PACKAGE-MANAGER",
           "referenceType": "purl",
-          "referenceLocator": "pkg:npm/expo-updates@56.0.22"
+          "referenceLocator": "pkg:npm/expo-updates@57.0.18"
         }
       ]
     },
     {
       "name": "expo-updates-interface",
-      "SPDXID": "SPDXRef-Package-69891146ffd2ac4e",
-      "versionInfo": "56.0.2",
+      "SPDXID": "SPDXRef-Package-8b849016e1749034",
+      "versionInfo": "57.0.1",
       "downloadLocation": "https://github.com/expo/expo",
       "filesAnalyzed": false,
       "licenseConcluded": "MIT",
@@ -5470,14 +5351,14 @@
         {
           "referenceCategory": "PACKAGE-MANAGER",
           "referenceType": "purl",
-          "referenceLocator": "pkg:npm/expo-updates-interface@56.0.2"
+          "referenceLocator": "pkg:npm/expo-updates-interface@57.0.1"
         }
       ]
     },
     {
       "name": "expo-web-browser",
-      "SPDXID": "SPDXRef-Package-cd5fdc34ff05ecda",
-      "versionInfo": "56.0.5",
+      "SPDXID": "SPDXRef-Package-d7af0c7232fa828c",
+      "versionInfo": "57.0.2",
       "downloadLocation": "https://github.com/expo/expo",
       "filesAnalyzed": false,
       "licenseConcluded": "MIT",
@@ -5487,7 +5368,7 @@
         {
           "referenceCategory": "PACKAGE-MANAGER",
           "referenceType": "purl",
-          "referenceLocator": "pkg:npm/expo-web-browser@56.0.5"
+          "referenceLocator": "pkg:npm/expo-web-browser@57.0.2"
         }
       ]
     },
@@ -5901,8 +5782,8 @@
     },
     {
       "name": "hermes-compiler",
-      "SPDXID": "SPDXRef-Package-c2badcb682cdf5ce",
-      "versionInfo": "250829098.0.10",
+      "SPDXID": "SPDXRef-Package-3f43a0a8eb764204",
+      "versionInfo": "250829098.0.17",
       "downloadLocation": "https://github.com/facebook/hermes",
       "filesAnalyzed": false,
       "licenseConcluded": "MIT",
@@ -5912,24 +5793,7 @@
         {
           "referenceCategory": "PACKAGE-MANAGER",
           "referenceType": "purl",
-          "referenceLocator": "pkg:npm/hermes-compiler@250829098.0.10"
-        }
-      ]
-    },
-    {
-      "name": "hermes-estree",
-      "SPDXID": "SPDXRef-Package-7bb0f392884b6c7b",
-      "versionInfo": "0.33.3",
-      "downloadLocation": "https://github.com/facebook/hermes",
-      "filesAnalyzed": false,
-      "licenseConcluded": "MIT",
-      "licenseDeclared": "MIT",
-      "copyrightText": "NOASSERTION",
-      "externalRefs": [
-        {
-          "referenceCategory": "PACKAGE-MANAGER",
-          "referenceType": "purl",
-          "referenceLocator": "pkg:npm/hermes-estree@0.33.3"
+          "referenceLocator": "pkg:npm/hermes-compiler@250829098.0.17"
         }
       ]
     },
@@ -5951,9 +5815,9 @@
       ]
     },
     {
-      "name": "hermes-parser",
-      "SPDXID": "SPDXRef-Package-fcf18dec3c39a179",
-      "versionInfo": "0.33.3",
+      "name": "hermes-estree",
+      "SPDXID": "SPDXRef-Package-7f10269e26834f74",
+      "versionInfo": "0.36.0",
       "downloadLocation": "https://github.com/facebook/hermes",
       "filesAnalyzed": false,
       "licenseConcluded": "MIT",
@@ -5963,7 +5827,24 @@
         {
           "referenceCategory": "PACKAGE-MANAGER",
           "referenceType": "purl",
-          "referenceLocator": "pkg:npm/hermes-parser@0.33.3"
+          "referenceLocator": "pkg:npm/hermes-estree@0.36.0"
+        }
+      ]
+    },
+    {
+      "name": "hermes-estree",
+      "SPDXID": "SPDXRef-Package-d2400efb14a646cc",
+      "versionInfo": "0.36.1",
+      "downloadLocation": "https://github.com/facebook/hermes",
+      "filesAnalyzed": false,
+      "licenseConcluded": "MIT",
+      "licenseDeclared": "MIT",
+      "copyrightText": "NOASSERTION",
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceType": "purl",
+          "referenceLocator": "pkg:npm/hermes-estree@0.36.1"
         }
       ]
     },
@@ -5981,6 +5862,57 @@
           "referenceCategory": "PACKAGE-MANAGER",
           "referenceType": "purl",
           "referenceLocator": "pkg:npm/hermes-parser@0.35.0"
+        }
+      ]
+    },
+    {
+      "name": "hermes-parser",
+      "SPDXID": "SPDXRef-Package-0c381b6f09221886",
+      "versionInfo": "0.36.0",
+      "downloadLocation": "https://github.com/facebook/hermes",
+      "filesAnalyzed": false,
+      "licenseConcluded": "MIT",
+      "licenseDeclared": "MIT",
+      "copyrightText": "NOASSERTION",
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceType": "purl",
+          "referenceLocator": "pkg:npm/hermes-parser@0.36.0"
+        }
+      ]
+    },
+    {
+      "name": "hermes-parser",
+      "SPDXID": "SPDXRef-Package-04a516c568f52201",
+      "versionInfo": "0.36.1",
+      "downloadLocation": "https://github.com/facebook/hermes",
+      "filesAnalyzed": false,
+      "licenseConcluded": "MIT",
+      "licenseDeclared": "MIT",
+      "copyrightText": "NOASSERTION",
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceType": "purl",
+          "referenceLocator": "pkg:npm/hermes-parser@0.36.1"
+        }
+      ]
+    },
+    {
+      "name": "hoist-non-react-statics",
+      "SPDXID": "SPDXRef-Package-48959bb6d78ea484",
+      "versionInfo": "3.3.2",
+      "downloadLocation": "https://github.com/mridgway/hoist-non-react-statics",
+      "filesAnalyzed": false,
+      "licenseConcluded": "BSD-3-Clause",
+      "licenseDeclared": "BSD-3-Clause",
+      "copyrightText": "NOASSERTION",
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceType": "purl",
+          "referenceLocator": "pkg:npm/hoist-non-react-statics@3.3.2"
         }
       ]
     },
@@ -6117,23 +6049,6 @@
           "referenceCategory": "PACKAGE-MANAGER",
           "referenceType": "purl",
           "referenceLocator": "pkg:npm/image-size@1.2.1"
-        }
-      ]
-    },
-    {
-      "name": "indent-string",
-      "SPDXID": "SPDXRef-Package-e4c04eafeff49de8",
-      "versionInfo": "4.0.0",
-      "downloadLocation": "https://github.com/sindresorhus/indent-string",
-      "filesAnalyzed": false,
-      "licenseConcluded": "MIT",
-      "licenseDeclared": "MIT",
-      "copyrightText": "NOASSERTION",
-      "externalRefs": [
-        {
-          "referenceCategory": "PACKAGE-MANAGER",
-          "referenceType": "purl",
-          "referenceLocator": "pkg:npm/indent-string@4.0.0"
         }
       ]
     },
@@ -6852,6 +6767,23 @@
       ]
     },
     {
+      "name": "metro",
+      "SPDXID": "SPDXRef-Package-7c676065cfd964ce",
+      "versionInfo": "0.84.5",
+      "downloadLocation": "https://github.com/react/metro",
+      "filesAnalyzed": false,
+      "licenseConcluded": "MIT",
+      "licenseDeclared": "MIT",
+      "copyrightText": "NOASSERTION",
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceType": "purl",
+          "referenceLocator": "pkg:npm/metro@0.84.5"
+        }
+      ]
+    },
+    {
       "name": "metro-babel-transformer",
       "SPDXID": "SPDXRef-Package-5b883337a485e777",
       "versionInfo": "0.84.4",
@@ -6865,6 +6797,23 @@
           "referenceCategory": "PACKAGE-MANAGER",
           "referenceType": "purl",
           "referenceLocator": "pkg:npm/metro-babel-transformer@0.84.4"
+        }
+      ]
+    },
+    {
+      "name": "metro-babel-transformer",
+      "SPDXID": "SPDXRef-Package-3acb47578d0e1af3",
+      "versionInfo": "0.84.5",
+      "downloadLocation": "https://github.com/react/metro",
+      "filesAnalyzed": false,
+      "licenseConcluded": "MIT",
+      "licenseDeclared": "MIT",
+      "copyrightText": "NOASSERTION",
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceType": "purl",
+          "referenceLocator": "pkg:npm/metro-babel-transformer@0.84.5"
         }
       ]
     },
@@ -6886,6 +6835,23 @@
       ]
     },
     {
+      "name": "metro-cache",
+      "SPDXID": "SPDXRef-Package-2345f39952349568",
+      "versionInfo": "0.84.5",
+      "downloadLocation": "https://github.com/react/metro",
+      "filesAnalyzed": false,
+      "licenseConcluded": "MIT",
+      "licenseDeclared": "MIT",
+      "copyrightText": "NOASSERTION",
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceType": "purl",
+          "referenceLocator": "pkg:npm/metro-cache@0.84.5"
+        }
+      ]
+    },
+    {
       "name": "metro-cache-key",
       "SPDXID": "SPDXRef-Package-9cfa9e8a7af46d4c",
       "versionInfo": "0.84.4",
@@ -6899,6 +6865,23 @@
           "referenceCategory": "PACKAGE-MANAGER",
           "referenceType": "purl",
           "referenceLocator": "pkg:npm/metro-cache-key@0.84.4"
+        }
+      ]
+    },
+    {
+      "name": "metro-cache-key",
+      "SPDXID": "SPDXRef-Package-bb90f134a888e80f",
+      "versionInfo": "0.84.5",
+      "downloadLocation": "https://github.com/react/metro",
+      "filesAnalyzed": false,
+      "licenseConcluded": "MIT",
+      "licenseDeclared": "MIT",
+      "copyrightText": "NOASSERTION",
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceType": "purl",
+          "referenceLocator": "pkg:npm/metro-cache-key@0.84.5"
         }
       ]
     },
@@ -6920,6 +6903,23 @@
       ]
     },
     {
+      "name": "metro-config",
+      "SPDXID": "SPDXRef-Package-4e0b399ea417d4b3",
+      "versionInfo": "0.84.5",
+      "downloadLocation": "https://github.com/react/metro",
+      "filesAnalyzed": false,
+      "licenseConcluded": "MIT",
+      "licenseDeclared": "MIT",
+      "copyrightText": "NOASSERTION",
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceType": "purl",
+          "referenceLocator": "pkg:npm/metro-config@0.84.5"
+        }
+      ]
+    },
+    {
       "name": "metro-core",
       "SPDXID": "SPDXRef-Package-a35101b99db7bfa8",
       "versionInfo": "0.84.4",
@@ -6933,6 +6933,23 @@
           "referenceCategory": "PACKAGE-MANAGER",
           "referenceType": "purl",
           "referenceLocator": "pkg:npm/metro-core@0.84.4"
+        }
+      ]
+    },
+    {
+      "name": "metro-core",
+      "SPDXID": "SPDXRef-Package-ab9b3717f29cebf8",
+      "versionInfo": "0.84.5",
+      "downloadLocation": "https://github.com/react/metro",
+      "filesAnalyzed": false,
+      "licenseConcluded": "MIT",
+      "licenseDeclared": "MIT",
+      "copyrightText": "NOASSERTION",
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceType": "purl",
+          "referenceLocator": "pkg:npm/metro-core@0.84.5"
         }
       ]
     },
@@ -6954,6 +6971,23 @@
       ]
     },
     {
+      "name": "metro-file-map",
+      "SPDXID": "SPDXRef-Package-cb89d27f053a8229",
+      "versionInfo": "0.84.5",
+      "downloadLocation": "https://github.com/react/metro",
+      "filesAnalyzed": false,
+      "licenseConcluded": "MIT",
+      "licenseDeclared": "MIT",
+      "copyrightText": "NOASSERTION",
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceType": "purl",
+          "referenceLocator": "pkg:npm/metro-file-map@0.84.5"
+        }
+      ]
+    },
+    {
       "name": "metro-minify-terser",
       "SPDXID": "SPDXRef-Package-c169b0b8613d59b6",
       "versionInfo": "0.84.4",
@@ -6967,6 +7001,23 @@
           "referenceCategory": "PACKAGE-MANAGER",
           "referenceType": "purl",
           "referenceLocator": "pkg:npm/metro-minify-terser@0.84.4"
+        }
+      ]
+    },
+    {
+      "name": "metro-minify-terser",
+      "SPDXID": "SPDXRef-Package-70598be7904735a1",
+      "versionInfo": "0.84.5",
+      "downloadLocation": "https://github.com/react/metro",
+      "filesAnalyzed": false,
+      "licenseConcluded": "MIT",
+      "licenseDeclared": "MIT",
+      "copyrightText": "NOASSERTION",
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceType": "purl",
+          "referenceLocator": "pkg:npm/metro-minify-terser@0.84.5"
         }
       ]
     },
@@ -6988,6 +7039,23 @@
       ]
     },
     {
+      "name": "metro-resolver",
+      "SPDXID": "SPDXRef-Package-98d6596180be67e1",
+      "versionInfo": "0.84.5",
+      "downloadLocation": "https://github.com/react/metro",
+      "filesAnalyzed": false,
+      "licenseConcluded": "MIT",
+      "licenseDeclared": "MIT",
+      "copyrightText": "NOASSERTION",
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceType": "purl",
+          "referenceLocator": "pkg:npm/metro-resolver@0.84.5"
+        }
+      ]
+    },
+    {
       "name": "metro-runtime",
       "SPDXID": "SPDXRef-Package-5a666c014661c95e",
       "versionInfo": "0.84.4",
@@ -7001,6 +7069,23 @@
           "referenceCategory": "PACKAGE-MANAGER",
           "referenceType": "purl",
           "referenceLocator": "pkg:npm/metro-runtime@0.84.4"
+        }
+      ]
+    },
+    {
+      "name": "metro-runtime",
+      "SPDXID": "SPDXRef-Package-cffe6b9120ab6939",
+      "versionInfo": "0.84.5",
+      "downloadLocation": "https://github.com/react/metro",
+      "filesAnalyzed": false,
+      "licenseConcluded": "MIT",
+      "licenseDeclared": "MIT",
+      "copyrightText": "NOASSERTION",
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceType": "purl",
+          "referenceLocator": "pkg:npm/metro-runtime@0.84.5"
         }
       ]
     },
@@ -7022,6 +7107,23 @@
       ]
     },
     {
+      "name": "metro-source-map",
+      "SPDXID": "SPDXRef-Package-6aa71406fb83e2b1",
+      "versionInfo": "0.84.5",
+      "downloadLocation": "https://github.com/react/metro",
+      "filesAnalyzed": false,
+      "licenseConcluded": "MIT",
+      "licenseDeclared": "MIT",
+      "copyrightText": "NOASSERTION",
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceType": "purl",
+          "referenceLocator": "pkg:npm/metro-source-map@0.84.5"
+        }
+      ]
+    },
+    {
       "name": "metro-symbolicate",
       "SPDXID": "SPDXRef-Package-3757547c4c1d5336",
       "versionInfo": "0.84.4",
@@ -7035,6 +7137,23 @@
           "referenceCategory": "PACKAGE-MANAGER",
           "referenceType": "purl",
           "referenceLocator": "pkg:npm/metro-symbolicate@0.84.4"
+        }
+      ]
+    },
+    {
+      "name": "metro-symbolicate",
+      "SPDXID": "SPDXRef-Package-ed7d37aa788ec99a",
+      "versionInfo": "0.84.5",
+      "downloadLocation": "https://github.com/react/metro",
+      "filesAnalyzed": false,
+      "licenseConcluded": "MIT",
+      "licenseDeclared": "MIT",
+      "copyrightText": "NOASSERTION",
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceType": "purl",
+          "referenceLocator": "pkg:npm/metro-symbolicate@0.84.5"
         }
       ]
     },
@@ -7056,6 +7175,23 @@
       ]
     },
     {
+      "name": "metro-transform-plugins",
+      "SPDXID": "SPDXRef-Package-499b1df7a096af9a",
+      "versionInfo": "0.84.5",
+      "downloadLocation": "https://github.com/react/metro",
+      "filesAnalyzed": false,
+      "licenseConcluded": "MIT",
+      "licenseDeclared": "MIT",
+      "copyrightText": "NOASSERTION",
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceType": "purl",
+          "referenceLocator": "pkg:npm/metro-transform-plugins@0.84.5"
+        }
+      ]
+    },
+    {
       "name": "metro-transform-worker",
       "SPDXID": "SPDXRef-Package-f9387ad05dce7961",
       "versionInfo": "0.84.4",
@@ -7069,6 +7205,23 @@
           "referenceCategory": "PACKAGE-MANAGER",
           "referenceType": "purl",
           "referenceLocator": "pkg:npm/metro-transform-worker@0.84.4"
+        }
+      ]
+    },
+    {
+      "name": "metro-transform-worker",
+      "SPDXID": "SPDXRef-Package-eb8a00819286064c",
+      "versionInfo": "0.84.5",
+      "downloadLocation": "https://github.com/react/metro",
+      "filesAnalyzed": false,
+      "licenseConcluded": "MIT",
+      "licenseDeclared": "MIT",
+      "copyrightText": "NOASSERTION",
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceType": "purl",
+          "referenceLocator": "pkg:npm/metro-transform-worker@0.84.5"
         }
       ]
     },
@@ -7192,23 +7345,6 @@
       ]
     },
     {
-      "name": "min-indent",
-      "SPDXID": "SPDXRef-Package-d630fdbec9080dbb",
-      "versionInfo": "1.0.1",
-      "downloadLocation": "https://github.com/thejameskyle/min-indent",
-      "filesAnalyzed": false,
-      "licenseConcluded": "MIT",
-      "licenseDeclared": "MIT",
-      "copyrightText": "NOASSERTION",
-      "externalRefs": [
-        {
-          "referenceCategory": "PACKAGE-MANAGER",
-          "referenceType": "purl",
-          "referenceLocator": "pkg:npm/min-indent@1.0.1"
-        }
-      ]
-    },
-    {
       "name": "minimatch",
       "SPDXID": "SPDXRef-Package-37b2e23b08106590",
       "versionInfo": "10.2.5",
@@ -7295,9 +7431,9 @@
     },
     {
       "name": "multitars",
-      "SPDXID": "SPDXRef-Package-2ed7bbd69b3885e6",
-      "versionInfo": "1.0.0",
-      "downloadLocation": "https://github.com/kitten/multitars",
+      "SPDXID": "SPDXRef-Package-1327b46b9d227040",
+      "versionInfo": "1.0.2",
+      "downloadLocation": "https://github.com/expo/multitars",
       "filesAnalyzed": false,
       "licenseConcluded": "MIT",
       "licenseDeclared": "MIT",
@@ -7306,7 +7442,7 @@
         {
           "referenceCategory": "PACKAGE-MANAGER",
           "referenceType": "purl",
-          "referenceLocator": "pkg:npm/multitars@1.0.0"
+          "referenceLocator": "pkg:npm/multitars@1.0.2"
         }
       ]
     },
@@ -7511,6 +7647,23 @@
           "referenceCategory": "PACKAGE-MANAGER",
           "referenceType": "purl",
           "referenceLocator": "pkg:npm/ob1@0.84.4"
+        }
+      ]
+    },
+    {
+      "name": "ob1",
+      "SPDXID": "SPDXRef-Package-65907f15f40ad75b",
+      "versionInfo": "0.84.5",
+      "downloadLocation": "https://github.com/react/metro",
+      "filesAnalyzed": false,
+      "licenseConcluded": "MIT",
+      "licenseDeclared": "MIT",
+      "copyrightText": "NOASSERTION",
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceType": "purl",
+          "referenceLocator": "pkg:npm/ob1@0.84.5"
         }
       ]
     },
@@ -8111,6 +8264,23 @@
     },
     {
       "name": "react-is",
+      "SPDXID": "SPDXRef-Package-6a89229fd526bb86",
+      "versionInfo": "16.13.1",
+      "downloadLocation": "https://github.com/facebook/react",
+      "filesAnalyzed": false,
+      "licenseConcluded": "MIT",
+      "licenseDeclared": "MIT",
+      "copyrightText": "NOASSERTION",
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceType": "purl",
+          "referenceLocator": "pkg:npm/react-is@16.13.1"
+        }
+      ]
+    },
+    {
+      "name": "react-is",
       "SPDXID": "SPDXRef-Package-3f6a332a26930af4",
       "versionInfo": "18.3.1",
       "downloadLocation": "https://github.com/facebook/react",
@@ -8145,9 +8315,9 @@
     },
     {
       "name": "react-native",
-      "SPDXID": "SPDXRef-Package-320b48b78f68ec78",
-      "versionInfo": "0.85.3",
-      "downloadLocation": "https://github.com/facebook/react-native",
+      "SPDXID": "SPDXRef-Package-d09e24f5425789d2",
+      "versionInfo": "0.86.3",
+      "downloadLocation": "https://github.com/react/react-native",
       "filesAnalyzed": false,
       "licenseConcluded": "MIT",
       "licenseDeclared": "MIT",
@@ -8156,7 +8326,7 @@
         {
           "referenceCategory": "PACKAGE-MANAGER",
           "referenceType": "purl",
-          "referenceLocator": "pkg:npm/react-native@0.85.3"
+          "referenceLocator": "pkg:npm/react-native@0.86.3"
         }
       ]
     },
@@ -8179,8 +8349,8 @@
     },
     {
       "name": "react-native-gesture-handler",
-      "SPDXID": "SPDXRef-Package-33e808bf5cec693e",
-      "versionInfo": "3.0.2",
+      "SPDXID": "SPDXRef-Package-ff00236a86b22e8e",
+      "versionInfo": "2.32.0",
       "downloadLocation": "https://github.com/software-mansion/react-native-gesture-handler",
       "filesAnalyzed": false,
       "licenseConcluded": "MIT",
@@ -8190,7 +8360,7 @@
         {
           "referenceCategory": "PACKAGE-MANAGER",
           "referenceType": "purl",
-          "referenceLocator": "pkg:npm/react-native-gesture-handler@3.0.2"
+          "referenceLocator": "pkg:npm/react-native-gesture-handler@2.32.0"
         }
       ]
     },
@@ -8213,8 +8383,8 @@
     },
     {
       "name": "react-native-reanimated",
-      "SPDXID": "SPDXRef-Package-a9bb914e4ffcb526",
-      "versionInfo": "4.3.1",
+      "SPDXID": "SPDXRef-Package-b7b0ad22ed49b61b",
+      "versionInfo": "4.5.1",
       "downloadLocation": "https://github.com/software-mansion/react-native-reanimated",
       "filesAnalyzed": false,
       "licenseConcluded": "MIT",
@@ -8224,7 +8394,7 @@
         {
           "referenceCategory": "PACKAGE-MANAGER",
           "referenceType": "purl",
-          "referenceLocator": "pkg:npm/react-native-reanimated@4.3.1"
+          "referenceLocator": "pkg:npm/react-native-reanimated@4.5.1"
         }
       ]
     },
@@ -8247,8 +8417,8 @@
     },
     {
       "name": "react-native-screens",
-      "SPDXID": "SPDXRef-Package-583495f14e006813",
-      "versionInfo": "4.25.2",
+      "SPDXID": "SPDXRef-Package-b6497d544417df00",
+      "versionInfo": "4.26.2",
       "downloadLocation": "https://github.com/software-mansion/react-native-screens",
       "filesAnalyzed": false,
       "licenseConcluded": "MIT",
@@ -8258,7 +8428,7 @@
         {
           "referenceCategory": "PACKAGE-MANAGER",
           "referenceType": "purl",
-          "referenceLocator": "pkg:npm/react-native-screens@4.25.2"
+          "referenceLocator": "pkg:npm/react-native-screens@4.26.2"
         }
       ]
     },
@@ -8332,8 +8502,8 @@
     },
     {
       "name": "react-native-worklets",
-      "SPDXID": "SPDXRef-Package-2729ad6f5e015637",
-      "versionInfo": "0.8.3",
+      "SPDXID": "SPDXRef-Package-48fbbad74c6fdd9c",
+      "versionInfo": "0.10.1",
       "downloadLocation": "https://github.com/software-mansion/react-native-reanimated",
       "filesAnalyzed": false,
       "licenseConcluded": "MIT",
@@ -8343,7 +8513,7 @@
         {
           "referenceCategory": "PACKAGE-MANAGER",
           "referenceType": "purl",
-          "referenceLocator": "pkg:npm/react-native-worklets@0.8.3"
+          "referenceLocator": "pkg:npm/react-native-worklets@0.10.1"
         }
       ]
     },
@@ -8412,23 +8582,6 @@
           "referenceCategory": "PACKAGE-MANAGER",
           "referenceType": "purl",
           "referenceLocator": "pkg:npm/react-style-singleton@2.2.3"
-        }
-      ]
-    },
-    {
-      "name": "redent",
-      "SPDXID": "SPDXRef-Package-9b7210a64fc715b8",
-      "versionInfo": "3.0.0",
-      "downloadLocation": "https://github.com/sindresorhus/redent",
-      "filesAnalyzed": false,
-      "licenseConcluded": "MIT",
-      "licenseDeclared": "MIT",
-      "copyrightText": "NOASSERTION",
-      "externalRefs": [
-        {
-          "referenceCategory": "PACKAGE-MANAGER",
-          "referenceType": "purl",
-          "referenceLocator": "pkg:npm/redent@3.0.0"
         }
       ]
     },
@@ -8650,6 +8803,23 @@
           "referenceCategory": "PACKAGE-MANAGER",
           "referenceType": "purl",
           "referenceLocator": "pkg:npm/safe-buffer@5.2.1"
+        }
+      ]
+    },
+    {
+      "name": "sandbox-cli-detector",
+      "SPDXID": "SPDXRef-Package-bde20ab5886a590d",
+      "versionInfo": "0.2.0",
+      "downloadLocation": "https://github.com/davidmokos/sandbox-cli-detector",
+      "filesAnalyzed": false,
+      "licenseConcluded": "MIT",
+      "licenseDeclared": "MIT",
+      "copyrightText": "NOASSERTION",
+      "externalRefs": [
+        {
+          "referenceCategory": "PACKAGE-MANAGER",
+          "referenceType": "purl",
+          "referenceLocator": "pkg:npm/sandbox-cli-detector@0.2.0"
         }
       ]
     },
@@ -9245,23 +9415,6 @@
           "referenceCategory": "PACKAGE-MANAGER",
           "referenceType": "purl",
           "referenceLocator": "pkg:npm/strip-ansi@6.0.1"
-        }
-      ]
-    },
-    {
-      "name": "strip-indent",
-      "SPDXID": "SPDXRef-Package-6b434451ae9a68d6",
-      "versionInfo": "3.0.0",
-      "downloadLocation": "https://github.com/sindresorhus/strip-indent",
-      "filesAnalyzed": false,
-      "licenseConcluded": "MIT",
-      "licenseDeclared": "MIT",
-      "copyrightText": "NOASSERTION",
-      "externalRefs": [
-        {
-          "referenceCategory": "PACKAGE-MANAGER",
-          "referenceType": "purl",
-          "referenceLocator": "pkg:npm/strip-indent@3.0.0"
         }
       ]
     },
@@ -10293,11 +10446,6 @@
     {
       "spdxElementId": "SPDXRef-DOCUMENT",
       "relationshipType": "DESCRIBES",
-      "relatedSpdxElement": "SPDXRef-Package-10a5c5df7c6ba052"
-    },
-    {
-      "spdxElementId": "SPDXRef-DOCUMENT",
-      "relationshipType": "DESCRIBES",
       "relatedSpdxElement": "SPDXRef-Package-59e6d9f0e83e9c3b"
     },
     {
@@ -10643,12 +10791,17 @@
     {
       "spdxElementId": "SPDXRef-DOCUMENT",
       "relationshipType": "DESCRIBES",
+      "relatedSpdxElement": "SPDXRef-Package-cf26df301845f4cf"
+    },
+    {
+      "spdxElementId": "SPDXRef-DOCUMENT",
+      "relationshipType": "DESCRIBES",
       "relatedSpdxElement": "SPDXRef-Package-396b2918563c1afc"
     },
     {
       "spdxElementId": "SPDXRef-DOCUMENT",
       "relationshipType": "DESCRIBES",
-      "relatedSpdxElement": "SPDXRef-Package-6ac0bb956200fdf5"
+      "relatedSpdxElement": "SPDXRef-Package-20e7a8f375c2feb7"
     },
     {
       "spdxElementId": "SPDXRef-DOCUMENT",
@@ -10658,17 +10811,17 @@
     {
       "spdxElementId": "SPDXRef-DOCUMENT",
       "relationshipType": "DESCRIBES",
-      "relatedSpdxElement": "SPDXRef-Package-dcc374c8c02d514d"
+      "relatedSpdxElement": "SPDXRef-Package-1496420660ddf99b"
     },
     {
       "spdxElementId": "SPDXRef-DOCUMENT",
       "relationshipType": "DESCRIBES",
-      "relatedSpdxElement": "SPDXRef-Package-cf8f2de11ad0cb5b"
+      "relatedSpdxElement": "SPDXRef-Package-5b62941641563ebf"
     },
     {
       "spdxElementId": "SPDXRef-DOCUMENT",
       "relationshipType": "DESCRIBES",
-      "relatedSpdxElement": "SPDXRef-Package-cdeb690c56a84829"
+      "relatedSpdxElement": "SPDXRef-Package-772be2704d1edaac"
     },
     {
       "spdxElementId": "SPDXRef-DOCUMENT",
@@ -10678,17 +10831,12 @@
     {
       "spdxElementId": "SPDXRef-DOCUMENT",
       "relationshipType": "DESCRIBES",
-      "relatedSpdxElement": "SPDXRef-Package-43316c9d32c89096"
+      "relatedSpdxElement": "SPDXRef-Package-13b0840247977fd4"
     },
     {
       "spdxElementId": "SPDXRef-DOCUMENT",
       "relationshipType": "DESCRIBES",
-      "relatedSpdxElement": "SPDXRef-Package-617dd995820cbb4d"
-    },
-    {
-      "spdxElementId": "SPDXRef-DOCUMENT",
-      "relationshipType": "DESCRIBES",
-      "relatedSpdxElement": "SPDXRef-Package-af1d891ecc9c652c"
+      "relatedSpdxElement": "SPDXRef-Package-4747d19862c6c2b8"
     },
     {
       "spdxElementId": "SPDXRef-DOCUMENT",
@@ -10698,32 +10846,22 @@
     {
       "spdxElementId": "SPDXRef-DOCUMENT",
       "relationshipType": "DESCRIBES",
-      "relatedSpdxElement": "SPDXRef-Package-f7064e795090188d"
+      "relatedSpdxElement": "SPDXRef-Package-a9b72b527dd55c2c"
     },
     {
       "spdxElementId": "SPDXRef-DOCUMENT",
       "relationshipType": "DESCRIBES",
-      "relatedSpdxElement": "SPDXRef-Package-5dd3cf74bac21b26"
+      "relatedSpdxElement": "SPDXRef-Package-cf2499e732152ff1"
     },
     {
       "spdxElementId": "SPDXRef-DOCUMENT",
       "relationshipType": "DESCRIBES",
-      "relatedSpdxElement": "SPDXRef-Package-24cf3edefeb8ede5"
+      "relatedSpdxElement": "SPDXRef-Package-11cb55c38fa93cd7"
     },
     {
       "spdxElementId": "SPDXRef-DOCUMENT",
       "relationshipType": "DESCRIBES",
-      "relatedSpdxElement": "SPDXRef-Package-52847b30294715dd"
-    },
-    {
-      "spdxElementId": "SPDXRef-DOCUMENT",
-      "relationshipType": "DESCRIBES",
-      "relatedSpdxElement": "SPDXRef-Package-43d80c1b2da0e96a"
-    },
-    {
-      "spdxElementId": "SPDXRef-DOCUMENT",
-      "relationshipType": "DESCRIBES",
-      "relatedSpdxElement": "SPDXRef-Package-dca50474e69f294b"
+      "relatedSpdxElement": "SPDXRef-Package-20bcb76ccf8f4986"
     },
     {
       "spdxElementId": "SPDXRef-DOCUMENT",
@@ -10733,32 +10871,32 @@
     {
       "spdxElementId": "SPDXRef-DOCUMENT",
       "relationshipType": "DESCRIBES",
-      "relatedSpdxElement": "SPDXRef-Package-91e14c6d4bc9e3b1"
+      "relatedSpdxElement": "SPDXRef-Package-7161e8a7d78e0b5d"
     },
     {
       "spdxElementId": "SPDXRef-DOCUMENT",
       "relationshipType": "DESCRIBES",
-      "relatedSpdxElement": "SPDXRef-Package-18f232e2f8bcfc8d"
+      "relatedSpdxElement": "SPDXRef-Package-4ab6622b68b7ad20"
     },
     {
       "spdxElementId": "SPDXRef-DOCUMENT",
       "relationshipType": "DESCRIBES",
-      "relatedSpdxElement": "SPDXRef-Package-87d75a8a36e3a905"
+      "relatedSpdxElement": "SPDXRef-Package-f555a00e5e60bd38"
     },
     {
       "spdxElementId": "SPDXRef-DOCUMENT",
       "relationshipType": "DESCRIBES",
-      "relatedSpdxElement": "SPDXRef-Package-fdc1aa5e69b581c1"
+      "relatedSpdxElement": "SPDXRef-Package-7ba1e9724ad8c5a0"
     },
     {
       "spdxElementId": "SPDXRef-DOCUMENT",
       "relationshipType": "DESCRIBES",
-      "relatedSpdxElement": "SPDXRef-Package-2499d3555c55bdd8"
+      "relatedSpdxElement": "SPDXRef-Package-9613d6cca786e5b8"
     },
     {
       "spdxElementId": "SPDXRef-DOCUMENT",
       "relationshipType": "DESCRIBES",
-      "relatedSpdxElement": "SPDXRef-Package-9ce7cf04e77ca4a6"
+      "relatedSpdxElement": "SPDXRef-Package-ea9b1f8b52305c58"
     },
     {
       "spdxElementId": "SPDXRef-DOCUMENT",
@@ -10773,32 +10911,27 @@
     {
       "spdxElementId": "SPDXRef-DOCUMENT",
       "relationshipType": "DESCRIBES",
-      "relatedSpdxElement": "SPDXRef-Package-c954ec0010947377"
+      "relatedSpdxElement": "SPDXRef-Package-dab0f600a6aac3a5"
     },
     {
       "spdxElementId": "SPDXRef-DOCUMENT",
       "relationshipType": "DESCRIBES",
-      "relatedSpdxElement": "SPDXRef-Package-db0a8a179287852b"
+      "relatedSpdxElement": "SPDXRef-Package-828ab691dacd318f"
     },
     {
       "spdxElementId": "SPDXRef-DOCUMENT",
       "relationshipType": "DESCRIBES",
-      "relatedSpdxElement": "SPDXRef-Package-4c47aeaa005e858a"
+      "relatedSpdxElement": "SPDXRef-Package-7ef22c29797e4d3d"
     },
     {
       "spdxElementId": "SPDXRef-DOCUMENT",
       "relationshipType": "DESCRIBES",
-      "relatedSpdxElement": "SPDXRef-Package-a4143b2eec52de2b"
+      "relatedSpdxElement": "SPDXRef-Package-952f3858313b4378"
     },
     {
       "spdxElementId": "SPDXRef-DOCUMENT",
       "relationshipType": "DESCRIBES",
-      "relatedSpdxElement": "SPDXRef-Package-b1d9220809aa7a64"
-    },
-    {
-      "spdxElementId": "SPDXRef-DOCUMENT",
-      "relationshipType": "DESCRIBES",
-      "relatedSpdxElement": "SPDXRef-Package-c0bac98925b4634a"
+      "relatedSpdxElement": "SPDXRef-Package-98e94fcbd54437ff"
     },
     {
       "spdxElementId": "SPDXRef-DOCUMENT",
@@ -10818,7 +10951,7 @@
     {
       "spdxElementId": "SPDXRef-DOCUMENT",
       "relationshipType": "DESCRIBES",
-      "relatedSpdxElement": "SPDXRef-Package-87d88e47cacb464b"
+      "relatedSpdxElement": "SPDXRef-Package-0acdbde3f99d7b83"
     },
     {
       "spdxElementId": "SPDXRef-DOCUMENT",
@@ -11008,47 +11141,52 @@
     {
       "spdxElementId": "SPDXRef-DOCUMENT",
       "relationshipType": "DESCRIBES",
-      "relatedSpdxElement": "SPDXRef-Package-697edb2f6789d2bf"
+      "relatedSpdxElement": "SPDXRef-Package-21e2f3b9e698d433"
     },
     {
       "spdxElementId": "SPDXRef-DOCUMENT",
       "relationshipType": "DESCRIBES",
-      "relatedSpdxElement": "SPDXRef-Package-39bee8b40a187d72"
+      "relatedSpdxElement": "SPDXRef-Package-7679de1ca6bac3dc"
     },
     {
       "spdxElementId": "SPDXRef-DOCUMENT",
       "relationshipType": "DESCRIBES",
-      "relatedSpdxElement": "SPDXRef-Package-319a60e34cc90e53"
+      "relatedSpdxElement": "SPDXRef-Package-434137ef60694065"
     },
     {
       "spdxElementId": "SPDXRef-DOCUMENT",
       "relationshipType": "DESCRIBES",
-      "relatedSpdxElement": "SPDXRef-Package-2246cebc8611d4a9"
+      "relatedSpdxElement": "SPDXRef-Package-ea25b6a034786450"
     },
     {
       "spdxElementId": "SPDXRef-DOCUMENT",
       "relationshipType": "DESCRIBES",
-      "relatedSpdxElement": "SPDXRef-Package-73c5e62980816f3b"
+      "relatedSpdxElement": "SPDXRef-Package-007d6833d0beec2b"
     },
     {
       "spdxElementId": "SPDXRef-DOCUMENT",
       "relationshipType": "DESCRIBES",
-      "relatedSpdxElement": "SPDXRef-Package-90829fd85682cb54"
+      "relatedSpdxElement": "SPDXRef-Package-0377a46cabd76d85"
     },
     {
       "spdxElementId": "SPDXRef-DOCUMENT",
       "relationshipType": "DESCRIBES",
-      "relatedSpdxElement": "SPDXRef-Package-b07732d9e61953dc"
+      "relatedSpdxElement": "SPDXRef-Package-b2c43839a201485c"
     },
     {
       "spdxElementId": "SPDXRef-DOCUMENT",
       "relationshipType": "DESCRIBES",
-      "relatedSpdxElement": "SPDXRef-Package-2bc8ec6514dca871"
+      "relatedSpdxElement": "SPDXRef-Package-11f24d26ef45da66"
     },
     {
       "spdxElementId": "SPDXRef-DOCUMENT",
       "relationshipType": "DESCRIBES",
-      "relatedSpdxElement": "SPDXRef-Package-f790a5dd2c1b424e"
+      "relatedSpdxElement": "SPDXRef-Package-e472e20c90af8fe4"
+    },
+    {
+      "spdxElementId": "SPDXRef-DOCUMENT",
+      "relationshipType": "DESCRIBES",
+      "relatedSpdxElement": "SPDXRef-Package-fc0492cb2625a29f"
     },
     {
       "spdxElementId": "SPDXRef-DOCUMENT",
@@ -11058,12 +11196,12 @@
     {
       "spdxElementId": "SPDXRef-DOCUMENT",
       "relationshipType": "DESCRIBES",
-      "relatedSpdxElement": "SPDXRef-Package-0b5a844e5407336a"
+      "relatedSpdxElement": "SPDXRef-Package-48ec3746ca63e32d"
     },
     {
       "spdxElementId": "SPDXRef-DOCUMENT",
       "relationshipType": "DESCRIBES",
-      "relatedSpdxElement": "SPDXRef-Package-29f40625ff887dce"
+      "relatedSpdxElement": "SPDXRef-Package-48adfa4b57db12d0"
     },
     {
       "spdxElementId": "SPDXRef-DOCUMENT",
@@ -11073,12 +11211,7 @@
     {
       "spdxElementId": "SPDXRef-DOCUMENT",
       "relationshipType": "DESCRIBES",
-      "relatedSpdxElement": "SPDXRef-Package-e6cc8a080e50374e"
-    },
-    {
-      "spdxElementId": "SPDXRef-DOCUMENT",
-      "relationshipType": "DESCRIBES",
-      "relatedSpdxElement": "SPDXRef-Package-58f40d3f2ac7f037"
+      "relatedSpdxElement": "SPDXRef-Package-d80edd77c266fce4"
     },
     {
       "spdxElementId": "SPDXRef-DOCUMENT",
@@ -11168,7 +11301,7 @@
     {
       "spdxElementId": "SPDXRef-DOCUMENT",
       "relationshipType": "DESCRIBES",
-      "relatedSpdxElement": "SPDXRef-Package-225d9eba44f2c070"
+      "relatedSpdxElement": "SPDXRef-Package-941d66f44d7533af"
     },
     {
       "spdxElementId": "SPDXRef-DOCUMENT",
@@ -11228,11 +11361,6 @@
     {
       "spdxElementId": "SPDXRef-DOCUMENT",
       "relationshipType": "DESCRIBES",
-      "relatedSpdxElement": "SPDXRef-Package-93e30f698184db06"
-    },
-    {
-      "spdxElementId": "SPDXRef-DOCUMENT",
-      "relationshipType": "DESCRIBES",
       "relatedSpdxElement": "SPDXRef-Package-2a5f02a5b88d90c7"
     },
     {
@@ -11263,7 +11391,12 @@
     {
       "spdxElementId": "SPDXRef-DOCUMENT",
       "relationshipType": "DESCRIBES",
-      "relatedSpdxElement": "SPDXRef-Package-bdd394dd76daf688"
+      "relatedSpdxElement": "SPDXRef-Package-001e09a3c95a0f4c"
+    },
+    {
+      "spdxElementId": "SPDXRef-DOCUMENT",
+      "relationshipType": "DESCRIBES",
+      "relatedSpdxElement": "SPDXRef-Package-4bb46f134eb78acd"
     },
     {
       "spdxElementId": "SPDXRef-DOCUMENT",
@@ -11273,7 +11406,7 @@
     {
       "spdxElementId": "SPDXRef-DOCUMENT",
       "relationshipType": "DESCRIBES",
-      "relatedSpdxElement": "SPDXRef-Package-2d518b389f6bb837"
+      "relatedSpdxElement": "SPDXRef-Package-a5b27d8080aa66fa"
     },
     {
       "spdxElementId": "SPDXRef-DOCUMENT",
@@ -11518,11 +11651,6 @@
     {
       "spdxElementId": "SPDXRef-DOCUMENT",
       "relationshipType": "DESCRIBES",
-      "relatedSpdxElement": "SPDXRef-Package-12f921da792516fb"
-    },
-    {
-      "spdxElementId": "SPDXRef-DOCUMENT",
-      "relationshipType": "DESCRIBES",
       "relatedSpdxElement": "SPDXRef-Package-b05903de4c965507"
     },
     {
@@ -11579,11 +11707,6 @@
       "spdxElementId": "SPDXRef-DOCUMENT",
       "relationshipType": "DESCRIBES",
       "relatedSpdxElement": "SPDXRef-Package-dd3933b705c729c5"
-    },
-    {
-      "spdxElementId": "SPDXRef-DOCUMENT",
-      "relationshipType": "DESCRIBES",
-      "relatedSpdxElement": "SPDXRef-Package-1c3a0e559d0f9ecd"
     },
     {
       "spdxElementId": "SPDXRef-DOCUMENT",
@@ -11678,157 +11801,152 @@
     {
       "spdxElementId": "SPDXRef-DOCUMENT",
       "relationshipType": "DESCRIBES",
-      "relatedSpdxElement": "SPDXRef-Package-f904a8f640516fd4"
+      "relatedSpdxElement": "SPDXRef-Package-a21f8aa8ea316bba"
     },
     {
       "spdxElementId": "SPDXRef-DOCUMENT",
       "relationshipType": "DESCRIBES",
-      "relatedSpdxElement": "SPDXRef-Package-49bdb2df683d4c2b"
+      "relatedSpdxElement": "SPDXRef-Package-d3e78dcf1fe1fd7f"
     },
     {
       "spdxElementId": "SPDXRef-DOCUMENT",
       "relationshipType": "DESCRIBES",
-      "relatedSpdxElement": "SPDXRef-Package-c0652dfd8ad23fd0"
+      "relatedSpdxElement": "SPDXRef-Package-96bd055d8952a64a"
     },
     {
       "spdxElementId": "SPDXRef-DOCUMENT",
       "relationshipType": "DESCRIBES",
-      "relatedSpdxElement": "SPDXRef-Package-5244d65f73050017"
+      "relatedSpdxElement": "SPDXRef-Package-eb081b986ec50ba8"
     },
     {
       "spdxElementId": "SPDXRef-DOCUMENT",
       "relationshipType": "DESCRIBES",
-      "relatedSpdxElement": "SPDXRef-Package-de023797d4f6beb3"
+      "relatedSpdxElement": "SPDXRef-Package-33d1161b33e80a74"
     },
     {
       "spdxElementId": "SPDXRef-DOCUMENT",
       "relationshipType": "DESCRIBES",
-      "relatedSpdxElement": "SPDXRef-Package-617b233816b65cd3"
+      "relatedSpdxElement": "SPDXRef-Package-16721e986d3b9518"
     },
     {
       "spdxElementId": "SPDXRef-DOCUMENT",
       "relationshipType": "DESCRIBES",
-      "relatedSpdxElement": "SPDXRef-Package-1f337586ebdeb8f6"
+      "relatedSpdxElement": "SPDXRef-Package-212df03adf8ed7fe"
     },
     {
       "spdxElementId": "SPDXRef-DOCUMENT",
       "relationshipType": "DESCRIBES",
-      "relatedSpdxElement": "SPDXRef-Package-4509b3d6d2ad2247"
+      "relatedSpdxElement": "SPDXRef-Package-db974288258db9d5"
     },
     {
       "spdxElementId": "SPDXRef-DOCUMENT",
       "relationshipType": "DESCRIBES",
-      "relatedSpdxElement": "SPDXRef-Package-ae73538e6490c31d"
+      "relatedSpdxElement": "SPDXRef-Package-aa4802bc4df9e75d"
     },
     {
       "spdxElementId": "SPDXRef-DOCUMENT",
       "relationshipType": "DESCRIBES",
-      "relatedSpdxElement": "SPDXRef-Package-2f57860ffb00e84a"
+      "relatedSpdxElement": "SPDXRef-Package-178ca4d8f21ab312"
     },
     {
       "spdxElementId": "SPDXRef-DOCUMENT",
       "relationshipType": "DESCRIBES",
-      "relatedSpdxElement": "SPDXRef-Package-c24f51763a027a0c"
+      "relatedSpdxElement": "SPDXRef-Package-437ab5e1d8c16256"
     },
     {
       "spdxElementId": "SPDXRef-DOCUMENT",
       "relationshipType": "DESCRIBES",
-      "relatedSpdxElement": "SPDXRef-Package-c6f45a0d6c4e5cd4"
+      "relatedSpdxElement": "SPDXRef-Package-a5bbd96cc10aa769"
     },
     {
       "spdxElementId": "SPDXRef-DOCUMENT",
       "relationshipType": "DESCRIBES",
-      "relatedSpdxElement": "SPDXRef-Package-33a951a400f7df59"
+      "relatedSpdxElement": "SPDXRef-Package-7db55d7e21b6e61b"
     },
     {
       "spdxElementId": "SPDXRef-DOCUMENT",
       "relationshipType": "DESCRIBES",
-      "relatedSpdxElement": "SPDXRef-Package-eefa29432c981aa8"
+      "relatedSpdxElement": "SPDXRef-Package-3afcf9f00a2e8de5"
     },
     {
       "spdxElementId": "SPDXRef-DOCUMENT",
       "relationshipType": "DESCRIBES",
-      "relatedSpdxElement": "SPDXRef-Package-7f4954546c75f805"
+      "relatedSpdxElement": "SPDXRef-Package-ca53585bedabf1bf"
     },
     {
       "spdxElementId": "SPDXRef-DOCUMENT",
       "relationshipType": "DESCRIBES",
-      "relatedSpdxElement": "SPDXRef-Package-589614dc8525ab1d"
+      "relatedSpdxElement": "SPDXRef-Package-c383b71921578672"
     },
     {
       "spdxElementId": "SPDXRef-DOCUMENT",
       "relationshipType": "DESCRIBES",
-      "relatedSpdxElement": "SPDXRef-Package-c93981ba4220ef5d"
+      "relatedSpdxElement": "SPDXRef-Package-abb4296acc136edf"
     },
     {
       "spdxElementId": "SPDXRef-DOCUMENT",
       "relationshipType": "DESCRIBES",
-      "relatedSpdxElement": "SPDXRef-Package-c395b610c9c83108"
+      "relatedSpdxElement": "SPDXRef-Package-1d7cbf079bfa1c79"
     },
     {
       "spdxElementId": "SPDXRef-DOCUMENT",
       "relationshipType": "DESCRIBES",
-      "relatedSpdxElement": "SPDXRef-Package-b4a626d8163a8d58"
+      "relatedSpdxElement": "SPDXRef-Package-fb9a2dea2b853b2e"
     },
     {
       "spdxElementId": "SPDXRef-DOCUMENT",
       "relationshipType": "DESCRIBES",
-      "relatedSpdxElement": "SPDXRef-Package-d32bd72eb825a363"
+      "relatedSpdxElement": "SPDXRef-Package-effb76fd2f135e9e"
     },
     {
       "spdxElementId": "SPDXRef-DOCUMENT",
       "relationshipType": "DESCRIBES",
-      "relatedSpdxElement": "SPDXRef-Package-80cdba93d16a6db7"
+      "relatedSpdxElement": "SPDXRef-Package-2fa8052f5f4080b3"
     },
     {
       "spdxElementId": "SPDXRef-DOCUMENT",
       "relationshipType": "DESCRIBES",
-      "relatedSpdxElement": "SPDXRef-Package-d311c09601e952de"
+      "relatedSpdxElement": "SPDXRef-Package-e5bcaadc6e015d5e"
     },
     {
       "spdxElementId": "SPDXRef-DOCUMENT",
       "relationshipType": "DESCRIBES",
-      "relatedSpdxElement": "SPDXRef-Package-138291e1c127cad9"
+      "relatedSpdxElement": "SPDXRef-Package-f4802688e73e0a32"
     },
     {
       "spdxElementId": "SPDXRef-DOCUMENT",
       "relationshipType": "DESCRIBES",
-      "relatedSpdxElement": "SPDXRef-Package-489f92d8a30a359c"
+      "relatedSpdxElement": "SPDXRef-Package-26b461b3f5de381c"
     },
     {
       "spdxElementId": "SPDXRef-DOCUMENT",
       "relationshipType": "DESCRIBES",
-      "relatedSpdxElement": "SPDXRef-Package-415b21fcb52049d8"
+      "relatedSpdxElement": "SPDXRef-Package-337b5c07192674f9"
     },
     {
       "spdxElementId": "SPDXRef-DOCUMENT",
       "relationshipType": "DESCRIBES",
-      "relatedSpdxElement": "SPDXRef-Package-ad9182d6194767d9"
+      "relatedSpdxElement": "SPDXRef-Package-7be8250e4e585882"
     },
     {
       "spdxElementId": "SPDXRef-DOCUMENT",
       "relationshipType": "DESCRIBES",
-      "relatedSpdxElement": "SPDXRef-Package-955b483a28991e94"
+      "relatedSpdxElement": "SPDXRef-Package-f35e90f38d6ead79"
     },
     {
       "spdxElementId": "SPDXRef-DOCUMENT",
       "relationshipType": "DESCRIBES",
-      "relatedSpdxElement": "SPDXRef-Package-ac1d86a216028819"
+      "relatedSpdxElement": "SPDXRef-Package-b3b6449f3773b175"
     },
     {
       "spdxElementId": "SPDXRef-DOCUMENT",
       "relationshipType": "DESCRIBES",
-      "relatedSpdxElement": "SPDXRef-Package-6416decb6cf4e38f"
+      "relatedSpdxElement": "SPDXRef-Package-bf533b3e2ed3f7f5"
     },
     {
       "spdxElementId": "SPDXRef-DOCUMENT",
       "relationshipType": "DESCRIBES",
-      "relatedSpdxElement": "SPDXRef-Package-598de26019281869"
-    },
-    {
-      "spdxElementId": "SPDXRef-DOCUMENT",
-      "relationshipType": "DESCRIBES",
-      "relatedSpdxElement": "SPDXRef-Package-4a45e7754a1432e1"
+      "relatedSpdxElement": "SPDXRef-Package-3747d33027ed5d3f"
     },
     {
       "spdxElementId": "SPDXRef-DOCUMENT",
@@ -11838,57 +11956,57 @@
     {
       "spdxElementId": "SPDXRef-DOCUMENT",
       "relationshipType": "DESCRIBES",
-      "relatedSpdxElement": "SPDXRef-Package-1d313b59691b3815"
+      "relatedSpdxElement": "SPDXRef-Package-351d6a4e6ee6dd69"
     },
     {
       "spdxElementId": "SPDXRef-DOCUMENT",
       "relationshipType": "DESCRIBES",
-      "relatedSpdxElement": "SPDXRef-Package-4943becc52f7c846"
+      "relatedSpdxElement": "SPDXRef-Package-9d90dc6c6c4be0bb"
     },
     {
       "spdxElementId": "SPDXRef-DOCUMENT",
       "relationshipType": "DESCRIBES",
-      "relatedSpdxElement": "SPDXRef-Package-d311b4ab7ff5b00d"
+      "relatedSpdxElement": "SPDXRef-Package-b4cc7f026fce021b"
     },
     {
       "spdxElementId": "SPDXRef-DOCUMENT",
       "relationshipType": "DESCRIBES",
-      "relatedSpdxElement": "SPDXRef-Package-a76d5fff827e3e52"
+      "relatedSpdxElement": "SPDXRef-Package-93ef7f8f2d646cf4"
     },
     {
       "spdxElementId": "SPDXRef-DOCUMENT",
       "relationshipType": "DESCRIBES",
-      "relatedSpdxElement": "SPDXRef-Package-e2848901cb956a1c"
+      "relatedSpdxElement": "SPDXRef-Package-4d6601a85cd39faa"
     },
     {
       "spdxElementId": "SPDXRef-DOCUMENT",
       "relationshipType": "DESCRIBES",
-      "relatedSpdxElement": "SPDXRef-Package-671c72dd56bb579e"
+      "relatedSpdxElement": "SPDXRef-Package-69cfe19a4ed17459"
     },
     {
       "spdxElementId": "SPDXRef-DOCUMENT",
       "relationshipType": "DESCRIBES",
-      "relatedSpdxElement": "SPDXRef-Package-e1f9f99d647772da"
+      "relatedSpdxElement": "SPDXRef-Package-aa96b5fa5570dbff"
     },
     {
       "spdxElementId": "SPDXRef-DOCUMENT",
       "relationshipType": "DESCRIBES",
-      "relatedSpdxElement": "SPDXRef-Package-abf2a80389832b3e"
+      "relatedSpdxElement": "SPDXRef-Package-2acfd2fd0fd3ba5f"
     },
     {
       "spdxElementId": "SPDXRef-DOCUMENT",
       "relationshipType": "DESCRIBES",
-      "relatedSpdxElement": "SPDXRef-Package-bcd7977e03f59a7e"
+      "relatedSpdxElement": "SPDXRef-Package-39ccab59fc625cd2"
     },
     {
       "spdxElementId": "SPDXRef-DOCUMENT",
       "relationshipType": "DESCRIBES",
-      "relatedSpdxElement": "SPDXRef-Package-69891146ffd2ac4e"
+      "relatedSpdxElement": "SPDXRef-Package-8b849016e1749034"
     },
     {
       "spdxElementId": "SPDXRef-DOCUMENT",
       "relationshipType": "DESCRIBES",
-      "relatedSpdxElement": "SPDXRef-Package-cd5fdc34ff05ecda"
+      "relatedSpdxElement": "SPDXRef-Package-d7af0c7232fa828c"
     },
     {
       "spdxElementId": "SPDXRef-DOCUMENT",
@@ -12013,12 +12131,7 @@
     {
       "spdxElementId": "SPDXRef-DOCUMENT",
       "relationshipType": "DESCRIBES",
-      "relatedSpdxElement": "SPDXRef-Package-c2badcb682cdf5ce"
-    },
-    {
-      "spdxElementId": "SPDXRef-DOCUMENT",
-      "relationshipType": "DESCRIBES",
-      "relatedSpdxElement": "SPDXRef-Package-7bb0f392884b6c7b"
+      "relatedSpdxElement": "SPDXRef-Package-3f43a0a8eb764204"
     },
     {
       "spdxElementId": "SPDXRef-DOCUMENT",
@@ -12028,12 +12141,32 @@
     {
       "spdxElementId": "SPDXRef-DOCUMENT",
       "relationshipType": "DESCRIBES",
-      "relatedSpdxElement": "SPDXRef-Package-fcf18dec3c39a179"
+      "relatedSpdxElement": "SPDXRef-Package-7f10269e26834f74"
+    },
+    {
+      "spdxElementId": "SPDXRef-DOCUMENT",
+      "relationshipType": "DESCRIBES",
+      "relatedSpdxElement": "SPDXRef-Package-d2400efb14a646cc"
     },
     {
       "spdxElementId": "SPDXRef-DOCUMENT",
       "relationshipType": "DESCRIBES",
       "relatedSpdxElement": "SPDXRef-Package-535c12cfb084b0a7"
+    },
+    {
+      "spdxElementId": "SPDXRef-DOCUMENT",
+      "relationshipType": "DESCRIBES",
+      "relatedSpdxElement": "SPDXRef-Package-0c381b6f09221886"
+    },
+    {
+      "spdxElementId": "SPDXRef-DOCUMENT",
+      "relationshipType": "DESCRIBES",
+      "relatedSpdxElement": "SPDXRef-Package-04a516c568f52201"
+    },
+    {
+      "spdxElementId": "SPDXRef-DOCUMENT",
+      "relationshipType": "DESCRIBES",
+      "relatedSpdxElement": "SPDXRef-Package-48959bb6d78ea484"
     },
     {
       "spdxElementId": "SPDXRef-DOCUMENT",
@@ -12074,11 +12207,6 @@
       "spdxElementId": "SPDXRef-DOCUMENT",
       "relationshipType": "DESCRIBES",
       "relatedSpdxElement": "SPDXRef-Package-41bbec0dae5bac67"
-    },
-    {
-      "spdxElementId": "SPDXRef-DOCUMENT",
-      "relationshipType": "DESCRIBES",
-      "relatedSpdxElement": "SPDXRef-Package-e4c04eafeff49de8"
     },
     {
       "spdxElementId": "SPDXRef-DOCUMENT",
@@ -12293,7 +12421,17 @@
     {
       "spdxElementId": "SPDXRef-DOCUMENT",
       "relationshipType": "DESCRIBES",
+      "relatedSpdxElement": "SPDXRef-Package-7c676065cfd964ce"
+    },
+    {
+      "spdxElementId": "SPDXRef-DOCUMENT",
+      "relationshipType": "DESCRIBES",
       "relatedSpdxElement": "SPDXRef-Package-5b883337a485e777"
+    },
+    {
+      "spdxElementId": "SPDXRef-DOCUMENT",
+      "relationshipType": "DESCRIBES",
+      "relatedSpdxElement": "SPDXRef-Package-3acb47578d0e1af3"
     },
     {
       "spdxElementId": "SPDXRef-DOCUMENT",
@@ -12303,7 +12441,17 @@
     {
       "spdxElementId": "SPDXRef-DOCUMENT",
       "relationshipType": "DESCRIBES",
+      "relatedSpdxElement": "SPDXRef-Package-2345f39952349568"
+    },
+    {
+      "spdxElementId": "SPDXRef-DOCUMENT",
+      "relationshipType": "DESCRIBES",
       "relatedSpdxElement": "SPDXRef-Package-9cfa9e8a7af46d4c"
+    },
+    {
+      "spdxElementId": "SPDXRef-DOCUMENT",
+      "relationshipType": "DESCRIBES",
+      "relatedSpdxElement": "SPDXRef-Package-bb90f134a888e80f"
     },
     {
       "spdxElementId": "SPDXRef-DOCUMENT",
@@ -12313,7 +12461,17 @@
     {
       "spdxElementId": "SPDXRef-DOCUMENT",
       "relationshipType": "DESCRIBES",
+      "relatedSpdxElement": "SPDXRef-Package-4e0b399ea417d4b3"
+    },
+    {
+      "spdxElementId": "SPDXRef-DOCUMENT",
+      "relationshipType": "DESCRIBES",
       "relatedSpdxElement": "SPDXRef-Package-a35101b99db7bfa8"
+    },
+    {
+      "spdxElementId": "SPDXRef-DOCUMENT",
+      "relationshipType": "DESCRIBES",
+      "relatedSpdxElement": "SPDXRef-Package-ab9b3717f29cebf8"
     },
     {
       "spdxElementId": "SPDXRef-DOCUMENT",
@@ -12323,7 +12481,17 @@
     {
       "spdxElementId": "SPDXRef-DOCUMENT",
       "relationshipType": "DESCRIBES",
+      "relatedSpdxElement": "SPDXRef-Package-cb89d27f053a8229"
+    },
+    {
+      "spdxElementId": "SPDXRef-DOCUMENT",
+      "relationshipType": "DESCRIBES",
       "relatedSpdxElement": "SPDXRef-Package-c169b0b8613d59b6"
+    },
+    {
+      "spdxElementId": "SPDXRef-DOCUMENT",
+      "relationshipType": "DESCRIBES",
+      "relatedSpdxElement": "SPDXRef-Package-70598be7904735a1"
     },
     {
       "spdxElementId": "SPDXRef-DOCUMENT",
@@ -12333,7 +12501,17 @@
     {
       "spdxElementId": "SPDXRef-DOCUMENT",
       "relationshipType": "DESCRIBES",
+      "relatedSpdxElement": "SPDXRef-Package-98d6596180be67e1"
+    },
+    {
+      "spdxElementId": "SPDXRef-DOCUMENT",
+      "relationshipType": "DESCRIBES",
       "relatedSpdxElement": "SPDXRef-Package-5a666c014661c95e"
+    },
+    {
+      "spdxElementId": "SPDXRef-DOCUMENT",
+      "relationshipType": "DESCRIBES",
+      "relatedSpdxElement": "SPDXRef-Package-cffe6b9120ab6939"
     },
     {
       "spdxElementId": "SPDXRef-DOCUMENT",
@@ -12343,7 +12521,17 @@
     {
       "spdxElementId": "SPDXRef-DOCUMENT",
       "relationshipType": "DESCRIBES",
+      "relatedSpdxElement": "SPDXRef-Package-6aa71406fb83e2b1"
+    },
+    {
+      "spdxElementId": "SPDXRef-DOCUMENT",
+      "relationshipType": "DESCRIBES",
       "relatedSpdxElement": "SPDXRef-Package-3757547c4c1d5336"
+    },
+    {
+      "spdxElementId": "SPDXRef-DOCUMENT",
+      "relationshipType": "DESCRIBES",
+      "relatedSpdxElement": "SPDXRef-Package-ed7d37aa788ec99a"
     },
     {
       "spdxElementId": "SPDXRef-DOCUMENT",
@@ -12353,7 +12541,17 @@
     {
       "spdxElementId": "SPDXRef-DOCUMENT",
       "relationshipType": "DESCRIBES",
+      "relatedSpdxElement": "SPDXRef-Package-499b1df7a096af9a"
+    },
+    {
+      "spdxElementId": "SPDXRef-DOCUMENT",
+      "relationshipType": "DESCRIBES",
       "relatedSpdxElement": "SPDXRef-Package-f9387ad05dce7961"
+    },
+    {
+      "spdxElementId": "SPDXRef-DOCUMENT",
+      "relationshipType": "DESCRIBES",
+      "relatedSpdxElement": "SPDXRef-Package-eb8a00819286064c"
     },
     {
       "spdxElementId": "SPDXRef-DOCUMENT",
@@ -12393,11 +12591,6 @@
     {
       "spdxElementId": "SPDXRef-DOCUMENT",
       "relationshipType": "DESCRIBES",
-      "relatedSpdxElement": "SPDXRef-Package-d630fdbec9080dbb"
-    },
-    {
-      "spdxElementId": "SPDXRef-DOCUMENT",
-      "relationshipType": "DESCRIBES",
       "relatedSpdxElement": "SPDXRef-Package-37b2e23b08106590"
     },
     {
@@ -12423,7 +12616,7 @@
     {
       "spdxElementId": "SPDXRef-DOCUMENT",
       "relationshipType": "DESCRIBES",
-      "relatedSpdxElement": "SPDXRef-Package-2ed7bbd69b3885e6"
+      "relatedSpdxElement": "SPDXRef-Package-1327b46b9d227040"
     },
     {
       "spdxElementId": "SPDXRef-DOCUMENT",
@@ -12484,6 +12677,11 @@
       "spdxElementId": "SPDXRef-DOCUMENT",
       "relationshipType": "DESCRIBES",
       "relatedSpdxElement": "SPDXRef-Package-32e4716c960d2e4f"
+    },
+    {
+      "spdxElementId": "SPDXRef-DOCUMENT",
+      "relationshipType": "DESCRIBES",
+      "relatedSpdxElement": "SPDXRef-Package-65907f15f40ad75b"
     },
     {
       "spdxElementId": "SPDXRef-DOCUMENT",
@@ -12663,6 +12861,11 @@
     {
       "spdxElementId": "SPDXRef-DOCUMENT",
       "relationshipType": "DESCRIBES",
+      "relatedSpdxElement": "SPDXRef-Package-6a89229fd526bb86"
+    },
+    {
+      "spdxElementId": "SPDXRef-DOCUMENT",
+      "relationshipType": "DESCRIBES",
       "relatedSpdxElement": "SPDXRef-Package-3f6a332a26930af4"
     },
     {
@@ -12673,7 +12876,7 @@
     {
       "spdxElementId": "SPDXRef-DOCUMENT",
       "relationshipType": "DESCRIBES",
-      "relatedSpdxElement": "SPDXRef-Package-320b48b78f68ec78"
+      "relatedSpdxElement": "SPDXRef-Package-d09e24f5425789d2"
     },
     {
       "spdxElementId": "SPDXRef-DOCUMENT",
@@ -12683,7 +12886,7 @@
     {
       "spdxElementId": "SPDXRef-DOCUMENT",
       "relationshipType": "DESCRIBES",
-      "relatedSpdxElement": "SPDXRef-Package-33e808bf5cec693e"
+      "relatedSpdxElement": "SPDXRef-Package-ff00236a86b22e8e"
     },
     {
       "spdxElementId": "SPDXRef-DOCUMENT",
@@ -12693,7 +12896,7 @@
     {
       "spdxElementId": "SPDXRef-DOCUMENT",
       "relationshipType": "DESCRIBES",
-      "relatedSpdxElement": "SPDXRef-Package-a9bb914e4ffcb526"
+      "relatedSpdxElement": "SPDXRef-Package-b7b0ad22ed49b61b"
     },
     {
       "spdxElementId": "SPDXRef-DOCUMENT",
@@ -12703,7 +12906,7 @@
     {
       "spdxElementId": "SPDXRef-DOCUMENT",
       "relationshipType": "DESCRIBES",
-      "relatedSpdxElement": "SPDXRef-Package-583495f14e006813"
+      "relatedSpdxElement": "SPDXRef-Package-b6497d544417df00"
     },
     {
       "spdxElementId": "SPDXRef-DOCUMENT",
@@ -12728,7 +12931,7 @@
     {
       "spdxElementId": "SPDXRef-DOCUMENT",
       "relationshipType": "DESCRIBES",
-      "relatedSpdxElement": "SPDXRef-Package-2729ad6f5e015637"
+      "relatedSpdxElement": "SPDXRef-Package-48fbbad74c6fdd9c"
     },
     {
       "spdxElementId": "SPDXRef-DOCUMENT",
@@ -12749,11 +12952,6 @@
       "spdxElementId": "SPDXRef-DOCUMENT",
       "relationshipType": "DESCRIBES",
       "relatedSpdxElement": "SPDXRef-Package-59285e73b61f5d17"
-    },
-    {
-      "spdxElementId": "SPDXRef-DOCUMENT",
-      "relationshipType": "DESCRIBES",
-      "relatedSpdxElement": "SPDXRef-Package-9b7210a64fc715b8"
     },
     {
       "spdxElementId": "SPDXRef-DOCUMENT",
@@ -12819,6 +13017,11 @@
       "spdxElementId": "SPDXRef-DOCUMENT",
       "relationshipType": "DESCRIBES",
       "relatedSpdxElement": "SPDXRef-Package-1708d3e03e05ca06"
+    },
+    {
+      "spdxElementId": "SPDXRef-DOCUMENT",
+      "relationshipType": "DESCRIBES",
+      "relatedSpdxElement": "SPDXRef-Package-bde20ab5886a590d"
     },
     {
       "spdxElementId": "SPDXRef-DOCUMENT",
@@ -12994,11 +13197,6 @@
       "spdxElementId": "SPDXRef-DOCUMENT",
       "relationshipType": "DESCRIBES",
       "relatedSpdxElement": "SPDXRef-Package-1f771006a623836a"
-    },
-    {
-      "spdxElementId": "SPDXRef-DOCUMENT",
-      "relationshipType": "DESCRIBES",
-      "relatedSpdxElement": "SPDXRef-Package-6b434451ae9a68d6"
     },
     {
       "spdxElementId": "SPDXRef-DOCUMENT",

--- a/scripts/generate-third-party-notices.mjs
+++ b/scripts/generate-third-party-notices.mjs
@@ -61,6 +61,15 @@ function discoverWorkspaceDirs() {
 const PACKAGE_POLICIES = {
   // https://github.com/fabiospampinato/khroma (仓库内 LICENSE 为 MIT,npm 包漏带字段)
   khroma: { license: "MIT", url: "https://github.com/fabiospampinato/khroma" },
+  // 以下三个 substack 旧包经 exceljs → unzipper → binary 进入 desktop 闭包,
+  // 上游仓库已随作者删号下线,包内元数据缺失或写作 "MIT/X11"(非法 SPDX 表达)。
+  // buffers@0.1.1 包内无 license 字段:上游仓库后续 commit(1b745ee)补声明 MIT,
+  // Debian node-buffers/0.1.1-5 copyright 与 ClearlyDefined 均审定为 Expat/MIT。
+  buffers: { license: "MIT", url: "https://github.com/substack/node-buffers" },
+  // package.json 声明 "MIT/X11",归一为 MIT。
+  chainsaw: { license: "MIT", url: "https://github.com/substack/node-chainsaw" },
+  // 包内 LICENSE 文件明示 MIT/X11,归一为 MIT。
+  traverse: { license: "MIT", url: "https://github.com/substack/js-traverse" },
   // 明确选择双许可证中的宽松分支,避免声明口径含糊。
   jszip: { license: "MIT" },
   "node-forge": { license: "BSD-3-Clause" },
@@ -1354,6 +1363,7 @@ function assertTrackedBinariesRegistered() {
   const registeredPrefixes = [
     "apps/android-platform-tools-bin/",
     "apps/desktop/native/sqlite-vec/",
+    "apps/desktop/resources/cindy-updater-runtime/",
     "apps/mobile/assets/fonts/JetBrainsMono-",
   ];
   const files = execFileSync("git", ["ls-files", "-z"], {

--- a/scripts/generate-third-party-notices.mjs
+++ b/scripts/generate-third-party-notices.mjs
@@ -63,13 +63,27 @@ const PACKAGE_POLICIES = {
   khroma: { license: "MIT", url: "https://github.com/fabiospampinato/khroma" },
   // 以下三个 substack 旧包经 exceljs → unzipper → binary 进入 desktop 闭包,
   // 上游仓库已随作者删号下线,包内元数据缺失或写作 "MIT/X11"(非法 SPDX 表达)。
+  // 人工核验结论只对 verifiedVersion 生效:版本升级后 override 自动失效,
+  // license audit 会重新报错,强制重走核验而不是静默沿用旧结论。
   // buffers@0.1.1 包内无 license 字段:上游仓库后续 commit(1b745ee)补声明 MIT,
   // Debian node-buffers/0.1.1-5 copyright 与 ClearlyDefined 均审定为 Expat/MIT。
-  buffers: { license: "MIT", url: "https://github.com/substack/node-buffers" },
+  buffers: {
+    license: "MIT",
+    url: "https://github.com/substack/node-buffers",
+    verifiedVersion: "0.1.1",
+  },
   // package.json 声明 "MIT/X11",归一为 MIT。
-  chainsaw: { license: "MIT", url: "https://github.com/substack/node-chainsaw" },
+  chainsaw: {
+    license: "MIT",
+    url: "https://github.com/substack/node-chainsaw",
+    verifiedVersion: "0.1.0",
+  },
   // 包内 LICENSE 文件明示 MIT/X11,归一为 MIT。
-  traverse: { license: "MIT", url: "https://github.com/substack/js-traverse" },
+  traverse: {
+    license: "MIT",
+    url: "https://github.com/substack/js-traverse",
+    verifiedVersion: "0.3.9",
+  },
   // 明确选择双许可证中的宽松分支,避免声明口径含糊。
   jszip: { license: "MIT" },
   "node-forge": { license: "BSD-3-Clause" },
@@ -344,7 +358,13 @@ function collectClosure(entryDirs, target) {
         );
       }
 
-      const policy = PACKAGE_POLICIES[depJson.name];
+      // 带 verifiedVersion 的 override 只对核验过的那个版本生效;版本变化后
+      // 回落到包自身元数据,让 license audit 重新把关。
+      const rawPolicy = PACKAGE_POLICIES[depJson.name];
+      const policy =
+        rawPolicy?.verifiedVersion && rawPolicy.verifiedVersion !== depJson.version
+          ? undefined
+          : rawPolicy;
       if (policy?.category) {
         excluded.set(key, {
           ecosystem: "npm",
@@ -1363,9 +1383,14 @@ function assertTrackedBinariesRegistered() {
   const registeredPrefixes = [
     "apps/android-platform-tools-bin/",
     "apps/desktop/native/sqlite-vec/",
-    "apps/desktop/resources/cindy-updater-runtime/",
     "apps/mobile/assets/fonts/JetBrainsMono-",
   ];
+  // Windows updater 内置 VC++ Runtime 按精确文件登记(披露条目见
+  // restrictedManualEntries):目录内新增其它二进制时这里会重新拦下要求补披露。
+  const registeredFiles = new Set([
+    "apps/desktop/resources/cindy-updater-runtime/vcruntime140.dll",
+    "apps/desktop/resources/cindy-updater-runtime/vcruntime140_1.dll",
+  ]);
   const files = execFileSync("git", ["ls-files", "-z"], {
     cwd: REPO_ROOT,
     encoding: "utf8",
@@ -1376,6 +1401,7 @@ function assertTrackedBinariesRegistered() {
   const unregistered = files.filter(
     (file) =>
       binaryExtensions.has(path.extname(file).toLowerCase()) &&
+      !registeredFiles.has(file) &&
       !registeredPrefixes.some((prefix) => file.startsWith(prefix)),
   );
   if (unregistered.length) {


### PR DESCRIPTION
## 这次改了什么

### 摘要

Fable 5.1 上线后需要 Claude Code ≥ 2.1.251,ec4bd863 已把 `tools/claude/latest.json` pin 升到 2.1.259,但配套的第三方声明没有跟上——legal notices 里披露的仍是 `Claude Code CLI@2.1.219`。尝试重新生成时发现 `scripts/generate-third-party-notices.mjs` 在 main 上已经跑不起来,本 PR 修掉生成器的两处登记缺口,并重新生成全部 notices 与 SBOM。

具体三件事:

1. **生成器登记白名单补 `apps/desktop/resources/cindy-updater-runtime/`**:#3697 为 Windows 更新器内置了 `vcruntime140*.dll` 并写好了 restricted 披露条目,但没把目录加进 `assertTrackedBinariesRegistered` 的白名单,此后生成器一启动就抛 `tracked binary assets need license registration`。
2. **`PACKAGE_POLICIES` 补录 `buffers` / `chainsaw` / `traverse`**:exceljs → unzipper → binary 把这三个 substack 旧包带进 desktop 生产闭包,包内 license 元数据缺失或写作非法 SPDX 表达 `MIT/X11`,license audit 直接失败。归一为 MIT 的依据:`traverse` 包内 LICENSE 明示 MIT/X11;`chainsaw` package.json 声明 MIT/X11;`buffers@0.1.1` 无任何声明,但上游仓库后续 commit(1b745ee)补了 `"license": "MIT"`,Debian `node-buffers/0.1.1-5` copyright 审定 Expat,ClearlyDefined 亦 declared MIT(上游仓库已随作者删号下线,依据写在代码注释里)。
3. **重新生成全部 notices / SBOM**:Claude Code CLI 披露追平 2.1.259;同时补齐 main 上早已落地但未再生成的依赖漂移(Expo 56→57、pi 0.83.0→0.84.4、exceljs / fast-csv 等新增,desktop npm 包 794→865)。生成文件的大 diff 全部来自生成器输出,无手工编辑。

### 变更类型

- [x] `fix` 缺陷修复
- [ ] `feat` 新功能
- [ ] `refactor` / `perf` 重构或性能优化
- [ ] `docs` / `test` / `chore` 文档、测试或工程维护
- [ ] 其他:

### 范围

- 关联 Issue / 需求:ec4bd863(claude code 升级 2.1.259)的配套收尾;#3697 的登记遗漏
- 本 PR 包含:生成器两处登记修复(`scripts/generate-third-party-notices.mjs`,+10 行)+ 重新生成的 12 份 notices 与 5 份 SPDX SBOM
- 明确不包含:`tools/claude/latest.json`(main 已升级);CDN manifest 发布(服务端动作,见下方「影响与回滚」)
- 用户可见变化:随包分发的 `apps/desktop/resources/THIRD-PARTY-*.txt` 披露内容更新;无功能变化
- 是否存在 breaking change:无

### UI 变化

不涉及。

- 引用的设计规范:不涉及

## 怎么验证的

### 自动验证

```text
node scripts/generate-third-party-notices.mjs
结果:exit 0,restricted/proprietary components: 5(修复前在 main 上直接抛错)

node --test scripts/__tests__/third-party-notices.test.mjs
结果:tests 8 / pass 8 / fail 0(含平台作用域、SPDX 结构与许可表达式校验)
```

### 手工验证

- 逐段核对 restricted 4 份文件 diff:仅 `Claude Code CLI@2.1.219 → 2.1.259` 一行变化
- 抽查开源清单 diff:全部为依赖追平(Expo 57、pi 0.84.4、exceljs 链新增),无条目异常消失
- `pnpm why buffers chainsaw traverse` 确认三个包的引入链;pnpm-lock 确认各只有一个版本(`@babel/traverse` 为不同包名,不受 override 影响)
- 环境:macOS arm64,pnpm 10.33.2,cargo 1.98.0(生成器的 cargo closure 依赖)

### 未执行的验证

- 未在 Windows / Linux 宿主上复跑生成器(仓库测试已覆盖平台作用域断言,且本机无对应环境)
- 未跑全仓测试(改动不触及运行时代码路径)

## 风险

### 风险分类

- [x] 无已知风险
- [ ] 其他:

### 影响与回滚

- 影响范围:仅 legal notices / SBOM 文本与生成器登记表;不触及任何运行时代码
- 回滚 / 降级方式:revert 本 commit 即可
- 备注:用户侧要真正用上 Fable 5.1,还需把 CDN manifest(stable / beta / canary)里的 `claudeCode` 资产发布到 2.1.259——今天 14:30 前后实测三个渠道仍指向 2.1.219,这是发布侧动作,本 PR 无法覆盖

### 提交前检查

- [x] 已 review 完整 diff(手写部分 +10 行逐行过;生成部分抽查构成)
- [x] 每个 commit 都带 DCO 签名(`git commit -s`,见 [DCO](../DCO))
- [ ] UI 改动已在「UI 变化」注明引用的设计规范章节(不涉及 UI 则跳过)
- [x] 未提交凭证、令牌或授权文件
- [x] 已补充必要文档
- [x] 已确认测试结果或说明未执行原因
