### PR TITLE
fix(claude-code): 让 Cindy 模型目录可用于 Claude 子代理

### DIFF
--- a/packages/maker-core/src/agents/claude-code/__tests__/env-builder.test.ts
+++ b/packages/maker-core/src/agents/claude-code/__tests__/env-builder.test.ts
@@ -326,6 +326,17 @@ describe('buildClaudeEnv', () => {
     expect(env.CLAUDE_AUTOCOMPACT_PCT_OVERRIDE).toBe('80');
   });
 
+  it('matches a catalog model when the active SDK wire id carries [1m]', async () => {
+    process.env.CLAUDE_CODE_MAX_CONTEXT_TOKENS = '1000';
+
+    const env = await buildClaudeEnv(createAuthAdapter(), {}, {
+      activeModel: 'z-ai/glm-5.3[1m]',
+      modelContextWindows: [{ id: 'z-ai/glm-5.3', contextWindow: 1_000_000 }],
+    });
+
+    expect(env.CLAUDE_CODE_MAX_CONTEXT_TOKENS).toBe('1000000');
+  });
+
   it('does not set a context window when the selected model is provider-unrouted', async () => {
     process.env.CLAUDE_CODE_MAX_CONTEXT_TOKENS = '1000';
     process.env.CLAUDE_AUTOCOMPACT_PCT_OVERRIDE = '30';

--- a/packages/maker-core/src/agents/claude-code/__tests__/mcp-approval-policy.test.ts
+++ b/packages/maker-core/src/agents/claude-code/__tests__/mcp-approval-policy.test.ts
@@ -207,6 +207,7 @@ async function startSession(
     turnChangeCapture?: AgentDeps['turnChangeCapture'];
     getMcpToolApprovalPresentation?: AgentDeps['getMcpToolApprovalPresentation'];
     resolveClaudeSubagentModelAccess?: AgentDeps['resolveClaudeSubagentModelAccess'];
+    resolveVerifiedContextWindow?: AgentDeps['resolveVerifiedContextWindow'];
     availableModels?: NonNullable<AgentDeps['capabilityAdditions']>['availableModels'];
     model?: string;
   },
@@ -227,6 +228,7 @@ async function startSession(
   deps.turnChangeCapture = options?.turnChangeCapture;
   deps.getMcpToolApprovalPresentation = options?.getMcpToolApprovalPresentation;
   deps.resolveClaudeSubagentModelAccess = options?.resolveClaudeSubagentModelAccess;
+  deps.resolveVerifiedContextWindow = options?.resolveVerifiedContextWindow;
   deps.capabilityAdditions = options?.availableModels
     ? { availableModels: options.availableModels }
     : undefined;
@@ -466,6 +468,85 @@ describe('ClaudeCodeAgent canUseTool honors the host MCP approval policy', () =>
         },
       },
     });
+    await handle.close();
+  });
+
+  it('falls back to the catalog when verified route context is unavailable', async () => {
+    const { handle, hooks } = await startSession(undefined, {
+      permissionMode: 'bypassPermissions',
+      resolveClaudeSubagentModelAccess: async () => ({ status: 'allowed' }),
+      resolveVerifiedContextWindow: () => null,
+      availableModels: [{
+        id: 'z-ai/glm-5.3',
+        displayName: 'GLM-5.3',
+        contextWindow: 1_000_000,
+        efforts: ['high'],
+        defaultEffort: 'high',
+      }],
+    });
+    const preToolUse = hooks?.PreToolUse?.find((entry) => entry.matcher === 'Agent')?.hooks[0];
+    if (!preToolUse) throw new Error('expected subagent model access hook');
+
+    await expect(preToolUse({
+      hook_event_name: 'PreToolUse',
+      tool_name: 'Agent',
+      tool_input: { model: 'z-ai/glm-5.3' },
+    })).resolves.toMatchObject({
+      hookSpecificOutput: { updatedInput: { model: 'z-ai/glm-5.3[1m]' } },
+    });
+    await handle.close();
+  });
+
+  it('falls back to the catalog when verified route context throws', async () => {
+    const { handle, hooks } = await startSession(undefined, {
+      permissionMode: 'bypassPermissions',
+      resolveClaudeSubagentModelAccess: async () => ({ status: 'allowed' }),
+      resolveVerifiedContextWindow: (_providerId, modelId) => {
+        if (modelId === 'z-ai/glm-5.3') throw new Error('route unavailable');
+        return null;
+      },
+      availableModels: [{
+        id: 'z-ai/glm-5.3',
+        displayName: 'GLM-5.3',
+        contextWindow: 1_000_000,
+        efforts: ['high'],
+        defaultEffort: 'high',
+      }],
+    });
+    const preToolUse = hooks?.PreToolUse?.find((entry) => entry.matcher === 'Agent')?.hooks[0];
+    if (!preToolUse) throw new Error('expected subagent model access hook');
+
+    await expect(preToolUse({
+      hook_event_name: 'PreToolUse',
+      tool_name: 'Agent',
+      tool_input: { model: 'z-ai/glm-5.3' },
+    })).resolves.toMatchObject({
+      hookSpecificOutput: { updatedInput: { model: 'z-ai/glm-5.3[1m]' } },
+    });
+    await handle.close();
+  });
+
+  it('does not invent a context window when route and catalog metadata are invalid', async () => {
+    const { handle, hooks } = await startSession(undefined, {
+      permissionMode: 'bypassPermissions',
+      resolveClaudeSubagentModelAccess: async () => ({ status: 'allowed' }),
+      resolveVerifiedContextWindow: () => Number.NaN,
+      availableModels: [{
+        id: 'z-ai/glm-5.3',
+        displayName: 'GLM-5.3',
+        contextWindow: 0,
+        efforts: ['high'],
+        defaultEffort: 'high',
+      }],
+    });
+    const preToolUse = hooks?.PreToolUse?.find((entry) => entry.matcher === 'Agent')?.hooks[0];
+    if (!preToolUse) throw new Error('expected subagent model access hook');
+
+    await expect(preToolUse({
+      hook_event_name: 'PreToolUse',
+      tool_name: 'Agent',
+      tool_input: { model: 'z-ai/glm-5.3' },
+    })).resolves.toEqual({ continue: true });
     await handle.close();
   });
 

--- a/packages/maker-core/src/agents/claude-code/__tests__/mcp-approval-policy.test.ts
+++ b/packages/maker-core/src/agents/claude-code/__tests__/mcp-approval-policy.test.ts
@@ -207,6 +207,8 @@ async function startSession(
     turnChangeCapture?: AgentDeps['turnChangeCapture'];
     getMcpToolApprovalPresentation?: AgentDeps['getMcpToolApprovalPresentation'];
     resolveClaudeSubagentModelAccess?: AgentDeps['resolveClaudeSubagentModelAccess'];
+    availableModels?: NonNullable<AgentDeps['capabilityAdditions']>['availableModels'];
+    model?: string;
   },
 ) {
   const configDir = await makeTempDir();
@@ -225,20 +227,24 @@ async function startSession(
   deps.turnChangeCapture = options?.turnChangeCapture;
   deps.getMcpToolApprovalPresentation = options?.getMcpToolApprovalPresentation;
   deps.resolveClaudeSubagentModelAccess = options?.resolveClaudeSubagentModelAccess;
+  deps.capabilityAdditions = options?.availableModels
+    ? { availableModels: options.availableModels }
+    : undefined;
   const agent = new ClaudeCodeAgent(deps);
   const handle = await agent.startSession({
     sessionId: 'session-mcp-policy',
-    model: 'claude-opus-4-6',
+    model: options?.model ?? 'claude-opus-4-6',
     workingDir,
     permissionMode: options?.permissionMode ?? 'default',
   });
   const queryOptions = sdkMock.query.mock.calls.at(-1)?.[0]?.options as
     | {
         canUseTool?: CanUseToolFn;
-        hooks?: Record<
+      hooks?: Record<
           string,
           Array<{ hooks: Array<(input: unknown) => Promise<unknown>> }>
         >;
+        env?: Record<string, string>;
       }
     | undefined;
   if (!queryOptions?.canUseTool) throw new Error('expected sdk query canUseTool');
@@ -260,6 +266,7 @@ async function startSession(
     handle,
     canUseTool: queryOptions.canUseTool,
     hooks: queryOptions.hooks,
+    env: queryOptions.env,
     seen,
     workingDir,
   };
@@ -385,7 +392,7 @@ describe('ClaudeCodeAgent canUseTool honors the host MCP approval policy', () =>
       permissionMode: 'bypassPermissions',
       resolveClaudeSubagentModelAccess: async () => ({ status: 'denied' }),
     });
-    const preToolUse = hooks?.PreToolUse?.[0]?.hooks[0];
+    const preToolUse = hooks?.PreToolUse?.find((entry) => entry.matcher === 'Agent')?.hooks[0];
     if (!preToolUse) throw new Error('expected subagent model access hook');
 
     await expect(preToolUse({
@@ -398,6 +405,83 @@ describe('ClaudeCodeAgent canUseTool honors the host MCP approval policy', () =>
         permissionDecisionReason: expect.stringContaining('sonnet'),
       },
     });
+    await handle.close();
+  });
+
+  it('rewrites a catalog 1M Agent model at the real session hook boundary', async () => {
+    const { handle, hooks } = await startSession(undefined, {
+      permissionMode: 'bypassPermissions',
+      resolveClaudeSubagentModelAccess: async () => ({ status: 'allowed' }),
+      availableModels: [{
+        id: 'z-ai/glm-5.3',
+        displayName: 'GLM-5.3',
+        contextWindow: 1_000_000,
+        efforts: ['high'],
+        defaultEffort: 'high',
+      }],
+    });
+    const preToolUse = hooks?.PreToolUse?.find((entry) => entry.matcher === 'Agent')?.hooks[0];
+    if (!preToolUse) throw new Error('expected subagent model access hook');
+
+    await expect(preToolUse({
+      hook_event_name: 'PreToolUse',
+      tool_name: 'Agent',
+      tool_input: { model: 'z-ai/glm-5.3', run_in_background: true },
+    })).resolves.toMatchObject({
+      hookSpecificOutput: {
+        updatedInput: {
+          model: 'z-ai/glm-5.3[1m]',
+          run_in_background: true,
+        },
+      },
+    });
+    await handle.close();
+  });
+
+  it('keeps a catalog 272K Agent model on its bare wire id', async () => {
+    const { handle, hooks } = await startSession(undefined, {
+      permissionMode: 'bypassPermissions',
+      resolveClaudeSubagentModelAccess: async () => ({ status: 'allowed' }),
+      availableModels: [{
+        id: 'codex/gpt-5.6-sol',
+        displayName: 'GPT-5.6 Sol',
+        contextWindow: 272_000,
+        efforts: ['high'],
+        defaultEffort: 'high',
+      }],
+    });
+    const preToolUse = hooks?.PreToolUse?.find((entry) => entry.matcher === 'Agent')?.hooks[0];
+    if (!preToolUse) throw new Error('expected subagent model access hook');
+
+    await expect(preToolUse({
+      hook_event_name: 'PreToolUse',
+      tool_name: 'Agent',
+      tool_input: { model: 'codex/gpt-5.6-sol[1m]', run_in_background: true },
+    })).resolves.toMatchObject({
+      continue: true,
+      hookSpecificOutput: {
+        updatedInput: {
+          model: 'codex/gpt-5.6-sol',
+          run_in_background: true,
+        },
+      },
+    });
+    await handle.close();
+  });
+
+  it('injects the selected catalog model window into the real Claude Code session env', async () => {
+    const { handle, env } = await startSession(undefined, {
+      model: 'z-ai/glm-5.3',
+      availableModels: [{
+        id: 'z-ai/glm-5.3',
+        displayName: 'GLM-5.3',
+        contextWindow: 1_000_000,
+        efforts: ['high'],
+        defaultEffort: 'high',
+      }],
+    });
+
+    expect(env?.CLAUDE_CODE_MAX_CONTEXT_TOKENS).toBe('1000000');
     await handle.close();
   });
 

--- a/packages/maker-core/src/agents/claude-code/__tests__/subagent-model-access.test.ts
+++ b/packages/maker-core/src/agents/claude-code/__tests__/subagent-model-access.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it, vi } from 'vitest';
 
 import {
   buildClaudeSubagentModelGuardHooks,
+  claudeSubagentModelWithContextWindow,
   effectiveClaudeSubagentModel,
 } from '../subagent-model-access.js';
 
@@ -18,6 +19,76 @@ function agentInput(model?: string) {
 }
 
 describe('Claude subagent model access guard', () => {
+  it('normalizes the 1M suffix from the resolved model capability', () => {
+    expect(claudeSubagentModelWithContextWindow('z-ai/glm-5.3', 1_000_000))
+      .toBe('z-ai/glm-5.3[1m]');
+    expect(claudeSubagentModelWithContextWindow('z-ai/glm-5.3[1m]', 272_000))
+      .toBe('z-ai/glm-5.3');
+    expect(claudeSubagentModelWithContextWindow('unknown/model', undefined))
+      .toBe('unknown/model');
+  });
+
+  it('rewrites an explicit Agent model before Claude Code resolves its context window', async () => {
+    const hook = buildClaudeSubagentModelGuardHooks(
+      async () => ({ status: 'allowed' as const }),
+      undefined,
+      undefined,
+      (model) => model === 'z-ai/glm-5.3' ? 1_000_000 : undefined,
+    ).PreToolUse?.[0]?.hooks[0];
+    if (!hook) throw new Error('expected subagent model guard');
+
+    await expect(hook(
+      agentInput('z-ai/glm-5.3'),
+      undefined,
+      { signal: new AbortController().signal },
+    )).resolves.toMatchObject({
+      hookSpecificOutput: {
+        updatedInput: { model: 'z-ai/glm-5.3[1m]' },
+      },
+    });
+  });
+
+  it('does not rewrite unknown models or non-Agent tools', async () => {
+    const hook = buildClaudeSubagentModelGuardHooks(
+      async () => ({ status: 'allowed' as const }),
+      undefined,
+      undefined,
+      () => undefined,
+    ).PreToolUse?.[0]?.hooks[0];
+    if (!hook) throw new Error('expected subagent model guard');
+
+    await expect(hook(
+      agentInput('unknown/model'),
+      undefined,
+      { signal: new AbortController().signal },
+    )).resolves.toEqual({ continue: true });
+    await expect(hook(
+      { ...agentInput('z-ai/glm-5.3'), tool_name: 'Read' },
+      undefined,
+      { signal: new AbortController().signal },
+    )).resolves.toEqual({ continue: true });
+  });
+
+  it('can rewrite context metadata even when account access preflight is not installed', async () => {
+    const hook = buildClaudeSubagentModelGuardHooks(
+      undefined,
+      undefined,
+      undefined,
+      (model) => model === 'z-ai/glm-5.3' ? 1_000_000 : undefined,
+    ).PreToolUse?.[0]?.hooks[0];
+    if (!hook) throw new Error('expected context-only subagent guard');
+
+    await expect(hook(
+      agentInput('z-ai/glm-5.3'),
+      undefined,
+      { signal: new AbortController().signal },
+    )).resolves.toMatchObject({
+      hookSpecificOutput: {
+        updatedInput: { model: 'z-ai/glm-5.3[1m]' },
+      },
+    });
+  });
+
   it('denies only an authoritative denial before Full access can bypass canUseTool', async () => {
     const resolveAccess = vi.fn(async () => ({ status: 'denied' as const }));
     const hook = buildClaudeSubagentModelGuardHooks(resolveAccess)

--- a/packages/maker-core/src/agents/claude-code/env-builder.ts
+++ b/packages/maker-core/src/agents/claude-code/env-builder.ts
@@ -406,7 +406,11 @@ export async function buildClaudeEnv(
 
   const activeContextWindow = options.modelContextWindows?.find(
     (model) => model.id === options.activeModel,
-  )?.contextWindow;
+  )?.contextWindow
+    ?? options.modelContextWindows?.find(
+      (model) => model.id.replace(/\[1m\]$/i, '')
+        === options.activeModel?.replace(/\[1m\]$/i, ''),
+    )?.contextWindow;
   if (
     activeContextWindow !== undefined
     && Number.isFinite(activeContextWindow)

--- a/packages/maker-core/src/agents/claude-code/index.ts
+++ b/packages/maker-core/src/agents/claude-code/index.ts
@@ -1293,9 +1293,11 @@ export class ClaudeCodeAgent extends BaseAgent {
       if (resolveVerified) {
         try {
           const verified = resolveVerified(opts.providerId ?? null, normalized);
-          return typeof verified === 'number' && verified > 0 ? verified : undefined;
+          if (typeof verified === 'number' && Number.isFinite(verified) && verified > 0) {
+            return verified;
+          }
         } catch {
-          return undefined;
+          // Fall back to catalog metadata when route verification is unavailable.
         }
       }
       const descriptor = this.capabilities.availableModels.find(

--- a/packages/maker-core/src/agents/claude-code/index.ts
+++ b/packages/maker-core/src/agents/claude-code/index.ts
@@ -48,6 +48,8 @@ import {
 } from './subagent-model-default.js';
 import {
   buildClaudeSubagentModelGuardHooks,
+  claudeSubagentModelWithContextWindow,
+  normalizeClaudeSubagentModel,
 } from './subagent-model-access.js';
 import Anthropic, { APIError } from '@anthropic-ai/sdk';
 
@@ -1209,7 +1211,7 @@ export class ClaudeCodeAgent extends BaseAgent {
     const env = await buildClaudeEnv(this.deps.auth, this.deps.runtimeConfig, {
       credentialMode,
       sessionProviderId: opts.providerId ?? null,
-      activeModel: opts.model,
+      activeModel: sdkModel,
       modelContextWindows,
       smallFastModel,
       // 先按「不设」建好 env(顺带删掉可能从 process.env 继承来的残留),真正的判定在下面
@@ -1275,8 +1277,6 @@ export class ClaudeCodeAgent extends BaseAgent {
         });
       }
     }
-    // 判定落到 env(唯一写入点,见 env-builder.applySubagentModelEnv)。
-    applySubagentModelEnv(env, subagentDefault.envSubagentModel ?? null);
     // 每次 Agent/Task 调用都重新读取 host 的当前账号与路由事实。静态 capabilities
     // 只负责展示，不参与 deny；账号切换时 resolver 会立即看到新快照或 unknown。
     const resolveSubagentModelAccess = this.deps.resolveClaudeSubagentModelAccess
@@ -1287,6 +1287,35 @@ export class ClaudeCodeAgent extends BaseAgent {
           model,
         })
       : undefined;
+    const resolveSubagentModelContextWindow = (model: string): number | undefined => {
+      const normalized = normalizeClaudeSubagentModel(model);
+      const resolveVerified = this.deps.resolveVerifiedContextWindow;
+      if (resolveVerified) {
+        try {
+          const verified = resolveVerified(opts.providerId ?? null, normalized);
+          return typeof verified === 'number' && verified > 0 ? verified : undefined;
+        } catch {
+          return undefined;
+        }
+      }
+      const descriptor = this.capabilities.availableModels.find(
+        (item) => normalizeClaudeSubagentModel(item.id) === normalized,
+      );
+      return descriptor && Number.isFinite(descriptor.contextWindow) && descriptor.contextWindow > 0
+        ? descriptor.contextWindow
+        : undefined;
+    };
+    // Claude Code only recognizes the 1M wire suffix for native context-window
+    // accounting. Normalize the process-level default too; explicit Agent/Task
+    // calls are normalized by the PreToolUse hook below.
+    const wireSubagentDefault = subagentDefault.envSubagentModel
+      ? claudeSubagentModelWithContextWindow(
+        subagentDefault.envSubagentModel,
+        resolveSubagentModelContextWindow(subagentDefault.envSubagentModel),
+      )
+      : null;
+    // 判定落到 env(唯一写入点,见 env-builder.applySubagentModelEnv)。
+    applySubagentModelEnv(env, wireSubagentDefault);
     // 远端单独一份 env:用 'remote' 模式从空字典起(不继承 desktop OS env),否则
     // Windows HOME=C:\Users\Lizi 之类污染远端 cc CLI 的 ~ 展开(session/memory
     // 落怪路径)。详见 env-builder.ts buildClaudeEnv 文档。
@@ -1295,11 +1324,11 @@ export class ClaudeCodeAgent extends BaseAgent {
           credentialMode,
           sessionProviderId: opts.providerId ?? null,
           mode: 'remote',
-          activeModel: opts.model,
+          activeModel: sdkModel,
           modelContextWindows,
           smallFastModel,
           // 远端不做本地扫描(见上),这里的值就是路由感知后的设置值 —— 保持 env 强制覆盖语义。
-          subagentModel: subagentDefault.envSubagentModel ?? null,
+          subagentModel: wireSubagentDefault,
         })
       : null;
     // 远端 route 覆盖(route 解析见上方 credentialMode 前的 remoteRoute):
@@ -1667,15 +1696,6 @@ export class ClaudeCodeAgent extends BaseAgent {
     const localClaudeHooks = reviewMode
       ? { PreToolUse: [{ hooks: [reviewReadOnlyHook] }] }
       : mergeClaudeHookSets(
-          // 账号/模型准入是执行前提，不是用户工具权限。放在 PreToolUse，确保
-          // Full access 也无法绕过。
-          buildClaudeSubagentModelGuardHooks(
-            resolveSubagentModelAccess,
-            subagentDefault.envSubagentModel,
-            (model) => {
-              log.warn('subagent model denied by account access preflight', { model });
-            },
-          ),
           buildClaudeLocalToolGuardHooks(
             this.deps.capabilityRouting,
             () => activeCapabilitySelectionText,
@@ -1696,6 +1716,16 @@ export class ClaudeCodeAgent extends BaseAgent {
           // Keep the existing local routing/capture hooks first: callers and tests
           // rely on their observable order. The exact-match Orca provenance guard
           // still runs for send_to_lead after those hooks and denies descendants.
+          // 账号/模型准入是执行前提，不是用户工具权限。仍放在 PreToolUse，确保
+          // Full access 也无法绕过；它排在既有捕获/路由 hook 后，不改变既有顺序。
+          buildClaudeSubagentModelGuardHooks(
+            resolveSubagentModelAccess,
+            wireSubagentDefault ?? undefined,
+            (model) => {
+              log.warn('subagent model denied by account access preflight', { model });
+            },
+            resolveSubagentModelContextWindow,
+          ),
           buildClaudeOrcaCallerProvenanceHooks(),
           buildClaudeAskUserQuestionCallerProvenanceHooks(),
           this.deps.claudeHooks,

--- a/packages/maker-core/src/agents/claude-code/subagent-model-access.ts
+++ b/packages/maker-core/src/agents/claude-code/subagent-model-access.ts
@@ -17,11 +17,33 @@ export type ResolveClaudeSubagentModelAccess = (
   model: string,
 ) => ClaudeSubagentModelAccessResult | Promise<ClaudeSubagentModelAccessResult>;
 
+export type ResolveClaudeSubagentModelContextWindow = (
+  model: string,
+) => number | undefined;
+
 export function normalizeClaudeSubagentModel(model: string): string {
   const normalized = model.trim().toLowerCase();
   return normalized.endsWith('[1m]')
     ? normalized.slice(0, -'[1m]'.length)
     : normalized;
+}
+
+/** Add or remove Claude Code's explicit 1M context wire suffix for a known model. */
+export function claudeSubagentModelWithContextWindow(
+  model: string,
+  contextWindow: number | undefined,
+): string {
+  const trimmed = model.trim();
+  if (
+    !trimmed
+    || typeof contextWindow !== 'number'
+    || !Number.isFinite(contextWindow)
+    || contextWindow <= 0
+  ) {
+    return trimmed;
+  }
+  const bare = trimmed.replace(/\[1m\]$/i, '');
+  return contextWindow >= 1_000_000 ? `${bare}[1m]` : bare;
 }
 
 /**
@@ -56,33 +78,73 @@ export function buildClaudeSubagentModelGuardHooks(
   resolveAccess: ResolveClaudeSubagentModelAccess | undefined,
   forcedModel?: string,
   onDeny?: (model: string) => void,
+  resolveContextWindow?: ResolveClaudeSubagentModelContextWindow,
 ): Partial<Record<HookEvent, HookCallbackMatcher[]>> {
-  if (!resolveAccess) return {};
+  if (!resolveAccess && !resolveContextWindow) return {};
 
   const guard: HookCallback = async (input) => {
     if (input.hook_event_name !== 'PreToolUse') return { continue: true };
     const pre = input as PreToolUseHookInput;
     const model = effectiveClaudeSubagentModel(forcedModel, pre.tool_name, pre.tool_input);
-    if (!model) return { continue: true };
-
-    let access: ClaudeSubagentModelAccessResult;
-    try {
-      access = await resolveAccess(model);
-    } catch {
-      return { continue: true };
+    const toolInput = typeof pre.tool_input === 'object' && pre.tool_input !== null
+      ? pre.tool_input as Record<string, unknown>
+      : undefined;
+    const requestedModel = typeof toolInput?.model === 'string' ? toolInput.model : undefined;
+    const modelToRewrite = requestedModel ?? forcedModel;
+    let wireModel: string | undefined;
+    if (modelToRewrite && resolveContextWindow) {
+      try {
+        wireModel = claudeSubagentModelWithContextWindow(
+          modelToRewrite,
+          resolveContextWindow(normalizeClaudeSubagentModel(modelToRewrite)),
+        );
+      } catch {
+        // Context metadata is advisory; an unavailable live resolver must not
+        // block an otherwise valid Agent/Task invocation.
+        wireModel = undefined;
+      }
     }
-    if (access.status !== 'denied') return { continue: true };
+    const updatedInput = requestedModel && wireModel && wireModel !== requestedModel
+      ? { ...toolInput, model: wireModel }
+      : undefined;
+    const continueWithUpdatedInput = updatedInput
+      ? {
+          continue: true as const,
+          hookSpecificOutput: {
+            hookEventName: 'PreToolUse' as const,
+            updatedInput,
+          },
+        }
+      : { continue: true as const };
 
-    onDeny?.(model);
-    return {
-      continue: true,
-      hookSpecificOutput: {
-        hookEventName: 'PreToolUse',
-        permissionDecision: 'deny',
-        permissionDecisionReason: claudeSubagentModelDenialReason(model, access.reason),
-      },
-    };
+    if (!model) return continueWithUpdatedInput;
+
+    if (resolveAccess) {
+      let access: ClaudeSubagentModelAccessResult;
+      try {
+        access = await resolveAccess(model);
+      } catch {
+        return continueWithUpdatedInput;
+      }
+      if (access.status === 'denied') {
+        onDeny?.(model);
+        return {
+          continue: true,
+          hookSpecificOutput: {
+            hookEventName: 'PreToolUse',
+            permissionDecision: 'deny',
+            permissionDecisionReason: claudeSubagentModelDenialReason(model, access.reason),
+          },
+        };
+      }
+    }
+    return continueWithUpdatedInput;
   };
 
-  return { PreToolUse: [{ hooks: [guard] }] };
+  return {
+    PreToolUse: [
+      { matcher: 'Agent', hooks: [guard] },
+      { matcher: 'Task', hooks: [guard] },
+    ],
+  };
 }


### PR DESCRIPTION
## 这次改了什么

### 摘要

让 Claude Code 的 Agent/Task 子代理直接使用 Cindy 模型目录中的模型，并按目录提供的上下文窗口生成 Claude Code 能识别的 wire model：上下文窗口达到 1M 的模型加 `[1m]`，其他已知模型保持裸模型 ID；未知模型不改写。这样 Fable 5.1 作为 Claude Code 父会话时，可以把 Cindy AI 中支持 Claude Code 的模型交给子代理执行。

### 变更类型

- [ ] `feat` 新功能
- [x] `fix` 缺陷修复
- [ ] `refactor` / `perf` 重构或性能优化
- [ ] `docs` / `test` / `chore` 文档、测试或工程维护
- [ ] 其他：

### 范围

- 关联 Issue / 需求：无
- 本 PR 包含：maker-core Claude Code 会话环境、Agent/Task PreToolUse 模型改写、上下文窗口匹配及对应单测
- 明确不包含：修改 Claude Code 二进制、用户 `.claude/agents` 文件、Pi/Codex/其他 harness、账号权限判定和默认模型选择语义
- 用户可见变化：Claude Code 子代理可使用 Cindy 模型目录；1M 模型使用 `[1m]` 上下文标记，272K 等非 1M 模型不会被误标成 1M
- 是否存在 breaking change：无

## UI 变化

- 引用的设计规范：不涉及：仅修改 maker-core Claude Code runtime/env/hooks 与测试，无 UI、布局、样式或文案变化。

## 怎么验证的

### 自动验证

```text
pnpm test:unit:related
结果：通过。Desktop、lizi-mcps、maker-core、orca-workflow 相关测试均通过。

pnpm --filter @cindy/maker-core run --if-present typecheck
结果：通过。

pnpm test:unit
结果：workspace 其他单元测试通过；maker-core 首次运行因新 worktree 缺少 bundled ripgrep 失败，执行 pnpm install:ripgrep 后独立重跑 maker-core 全套通过：125 个测试文件通过、3 个跳过，3707 个测试通过、78 个跳过。

pnpm check:dco
结果：通过，1 个 commit 均带 Signed-off-by。

pnpm --filter @cindy/maker-core lint
结果：未通过仓库现有基线问题（107 个既有 lint 问题）；本次改动未引入新的 lint 规则例外。
```

### 手工验证

在隔离的正式 Claude Code 2.1.247 CLI 进程上验证同一未知 GLM 模型的两种 wire ID：裸 ID 的 `modelUsage.contextWindow` 为 200000，带 `[1m]` 的 wire ID 为 1000000。未启动 dev，也未触碰当前正式会话。

### 未执行的验证

无。正式版 UI 入口回归不适用，本 PR 不含 UI 改动。

## 风险

### 风险分类

- [ ] 无已知风险
- [ ] SQLite / migration
- [ ] system prompt
- [ ] 协议兼容
- [x] 权限 / 安全 / 用户数据
- [ ] 存量插件兼容（批准状态 / 指纹 / manifest 校验 / 安装布局 / 包格式）
- [ ] 原生层 / fingerprint / OTA
- [ ] 跨平台差异
- [ ] 其他：

### 影响与回滚

- 影响范围：Claude Code Agent/Task 子代理模型输入和 Claude 会话上下文环境。现有模型访问拒绝逻辑保持不变；未知模型保持不变；既有 hook 顺序保持不变。
- 回滚 / 降级方式：revert 本 PR commit；不涉及数据迁移、凭证或用户文件变更。

### 提交前检查

- [x] 已 review 完整 diff
- [x] 每个 commit 都带 DCO 签名（`git commit -s`，见 [DCO](../DCO)）
- [x] UI 改动已在「UI 变化」注明引用的设计规范章节（不涉及 UI）
- [x] 未提交凭证、令牌或授权文件
- [x] 已补充必要文档
- [x] 已确认测试结果或说明未执行原因
