### PR TITLE
feat(desktop): use current Codex CLI account

### DIFF
--- a/apps/desktop/src/main/maker-host/__tests__/codexAuthBindingClaim.test.ts
+++ b/apps/desktop/src/main/maker-host/__tests__/codexAuthBindingClaim.test.ts
@@ -193,6 +193,115 @@ describe('codex OAuth binding auto-claim on reconcile', () => {
     expect(fs.existsSync(bindingFile)).toBe(false);
   });
 
+  it('explicitly adopts the current Codex CLI OAuth account after a durable disconnect', async () => {
+    const { codexHome, systemAuth, localAuth, bindingFile } = fixture();
+    fs.mkdirSync(codexHome, { recursive: true });
+    fs.copyFileSync(systemAuth, localAuth);
+    const {
+      CODEX_USER_DISCONNECT_REASON,
+      readInvalidatedSystemCodexAuthMarker,
+      writeInvalidatedSystemCodexAuthMarker,
+    } = await import('../codex-auth-invalidation.js');
+    expect(
+      writeInvalidatedSystemCodexAuthMarker(
+        codexHome,
+        systemAuth,
+        CODEX_USER_DISCONNECT_REASON,
+        localAuth,
+      ),
+    ).toBe(true);
+    h.dataOwnerId = 'owner-a';
+    writeStableProjectionOwner('owner-a');
+    const { DesktopCodexAuthAdapter } = await import('../auth-adapters.js');
+    const adapter = new DesktopCodexAuthAdapter();
+    const refreshed = vi.fn();
+    adapter.setOnLoginSuccess(refreshed);
+
+    await expect(adapter.getState()).resolves.toMatchObject({ authenticated: false });
+    await expect(adapter.triggerLogin({ mode: 'local-cli' })).resolves.toMatchObject({
+      authenticated: true,
+      authSource: 'oauth',
+      identity: 'dev@example.test',
+      credentialScope: 'system-shared',
+    });
+
+    expect(readInvalidatedSystemCodexAuthMarker(codexHome)).toBeNull();
+    expect(fs.statSync(localAuth, { bigint: true }).ino).toBe(
+      fs.statSync(systemAuth, { bigint: true }).ino,
+    );
+    expect(readBindingFile(bindingFile)).toMatchObject({
+      openai: 'owner-a',
+      sources: { openai: 'native-harness-inherited' },
+      sharedSystemCredential: { openai: 'owner-a' },
+    });
+    expect(refreshed).toHaveBeenCalledOnce();
+  });
+
+  it('does not roll an adopted binding into a new owner when the session switches mid-flight', async () => {
+    const { codexHome, systemAuth, localAuth, bindingFile } = fixture();
+    fs.mkdirSync(codexHome, { recursive: true });
+    fs.copyFileSync(systemAuth, localAuth);
+    const { CODEX_USER_DISCONNECT_REASON, writeInvalidatedSystemCodexAuthMarker } =
+      await import('../codex-auth-invalidation.js');
+    expect(
+      writeInvalidatedSystemCodexAuthMarker(
+        codexHome,
+        systemAuth,
+        CODEX_USER_DISCONNECT_REASON,
+        localAuth,
+      ),
+    ).toBe(true);
+    h.dataOwnerId = 'owner-a';
+    writeStableProjectionOwner('owner-a');
+    const { DesktopCodexAuthAdapter } = await import('../auth-adapters.js');
+    const adapter = new DesktopCodexAuthAdapter();
+    let finishRead!: (state: { authenticated: true; authSource: 'oauth' }) => void;
+    Object.defineProperty(adapter, 'readState', {
+      configurable: true,
+      value: vi.fn(
+        () =>
+          new Promise((resolve) => {
+            finishRead = resolve;
+          }),
+      ),
+    });
+
+    const adoption = adapter.triggerLogin({ mode: 'local-cli' });
+    await vi.waitFor(() => expect(readBindingFile(bindingFile)).toMatchObject({ openai: 'owner-a' }));
+    h.dataOwnerId = 'owner-b';
+    finishRead({ authenticated: true, authSource: 'oauth' });
+
+    await expect(adoption).resolves.toEqual({
+      authenticated: false,
+      errorReason: 'auth_mutation_superseded',
+    });
+    expect(readBindingFile(bindingFile)).toMatchObject({
+      openai: 'owner-a',
+      sharedSystemCredential: { openai: 'owner-a' },
+    });
+    expect(readBindingFile(bindingFile)).not.toHaveProperty('revoked.openai');
+  });
+
+  it.each([
+    ['missing', null, 'codex_cli_oauth_missing'],
+    ['malformed', '{not-json', 'codex_cli_auth_parse_failed'],
+    ['API-key-only', JSON.stringify({ OPENAI_API_KEY: 'placeholder' }), 'codex_cli_oauth_missing'],
+  ])('rejects a %s Codex CLI auth file without binding it', async (_case, contents, reason) => {
+    const { systemAuth, bindingFile } = fixture();
+    if (contents === null) fs.rmSync(systemAuth, { force: true });
+    else fs.writeFileSync(systemAuth, contents);
+    h.dataOwnerId = 'owner-a';
+    writeStableProjectionOwner('owner-a');
+    const { DesktopCodexAuthAdapter } = await import('../auth-adapters.js');
+    const adapter = new DesktopCodexAuthAdapter();
+
+    await expect(adapter.triggerLogin({ mode: 'local-cli' })).resolves.toEqual({
+      authenticated: false,
+      errorReason: reason,
+    });
+    expect(fs.existsSync(bindingFile)).toBe(false);
+  });
+
   it('drops the claim when the app session switches owners during an in-flight reconcile', async () => {
     // review P1:claim 只允许写给「reconcile 发起时」的会话;在途期间切换账号必须放弃,
     // 绝不把 A 时代发起的认领写到 B 名下。B 自己的下一次 reconcile 会按 B 的规则重试。

--- a/apps/desktop/src/main/maker-host/__tests__/nativeProviderAuthBinding.test.ts
+++ b/apps/desktop/src/main/maker-host/__tests__/nativeProviderAuthBinding.test.ts
@@ -818,6 +818,18 @@ describe('凭证来路(selfAuthorized)—— 显式授权 vs 自动继承', () =
     expect(getNativeProviderAuthSource('openai')).toBe('native-harness-inherited');
   });
 
+  it('用户显式选择系统 CLI 时清除撤销边界但仍保留继承来路', () => {
+    unbindNativeProviderAuth('openai', { revoked: true });
+
+    bindNativeProviderAuth('openai', { inheritedSystem: true });
+
+    expect(isNativeProviderAuthBound('openai')).toBe(true);
+    expect(isNativeProviderAuthRevoked('openai')).toBe(false);
+    expect(isNativeProviderAuthSelfAuthorized('openai')).toBe(false);
+    expect(isNativeProviderAuthSharedSystemCredential('openai')).toBe(true);
+    expect(getNativeProviderAuthSource('openai')).toBe('native-harness-inherited');
+  });
+
   it('来路按 provider 分别记账,不互相串味', () => {
     bindNativeProviderAuth('anthropic');
     expect(claimDetectedNativeProviderAuth('openai', () => true)).toBe(true);

--- a/apps/desktop/src/main/maker-host/auth-adapters.ts
+++ b/apps/desktop/src/main/maker-host/auth-adapters.ts
@@ -68,6 +68,7 @@ import {
   resolveCodexLoginCleanupPreflight,
   resolveCodexLoginExitState,
   terminateCodexLoginProcess,
+  type CodexLoginMode,
 } from './codex-auth-state.js';
 import {
   CODEX_GATEWAY_ENV_KEY,
@@ -175,6 +176,49 @@ async function readCodexAccountId(authPath: string): Promise<string | null> {
   return null;
 }
 
+/** 读取任意 Codex auth 文件；只返回可展示状态，token 永不离开 Main。 */
+async function readCodexAuthFileState(authPath: string): Promise<AuthState> {
+  try {
+    const raw = await fsp.readFile(authPath, 'utf-8');
+    const obj = JSON.parse(raw) as {
+      account?: { email?: unknown };
+      expires_at?: unknown;
+      tokens?: { access_token?: unknown; id_token?: unknown };
+    };
+    const idTokenClaims =
+      typeof obj.tokens?.id_token === 'string'
+        ? readChatgptIdTokenClaims(obj.tokens.id_token)
+        : null;
+    const identity =
+      typeof obj.account?.email === 'string'
+        ? obj.account.email
+        : typeof idTokenClaims?.email === 'string'
+          ? idTokenClaims.email
+          : (codexAccountIdFromAuthJson(raw) ?? undefined);
+    const expiresAt = typeof obj.expires_at === 'number' ? obj.expires_at : undefined;
+    const hasOAuthToken =
+      typeof obj.tokens?.access_token === 'string' && obj.tokens.access_token.length > 0;
+    return hasOAuthToken
+      ? { authenticated: true, identity, expiresAt, authSource: 'oauth' }
+      : { authenticated: true, identity, expiresAt };
+  } catch (error) {
+    return {
+      authenticated: false,
+      errorReason:
+        (error as NodeJS.ErrnoException | null)?.code === 'ENOENT'
+          ? 'no_oauth'
+          : 'auth_parse_failed',
+    };
+  }
+}
+
+/** Main-only probe used by settings; returns metadata only, never credential contents or paths. */
+export async function hasSystemCodexOAuthLogin(): Promise<boolean> {
+  const authPath = getSystemCodexAuthPath();
+  const state = requireCodexOAuthLoginState(await readCodexAuthFileState(authPath));
+  return state.authenticated && (await readCodexAccountId(authPath)) !== null;
+}
+
 function codexAccountIdFromAuthJson(raw: string): string | null {
   try {
     const obj = JSON.parse(raw) as { tokens?: { account_id?: unknown; id_token?: unknown } };
@@ -216,6 +260,7 @@ function readCodexRecoveryCredentialProof(
 
 interface ChatgptIdTokenClaims {
   chatgpt_account_id?: unknown;
+  email?: unknown;
   sub?: unknown;
   'https://api.openai.com/auth'?: { chatgpt_account_id?: unknown };
 }
@@ -1688,45 +1733,25 @@ export class DesktopCodexAuthAdapter implements AuthAdapter {
     if (shouldSuppressLocalCodexAuth(this.codexHome, authPath)) {
       return { authenticated: false };
     }
-    try {
-      const raw = await fsp.readFile(authPath, 'utf-8');
-      const obj = JSON.parse(raw) as {
-        account?: { email?: unknown };
-        expires_at?: unknown;
-        tokens?: { access_token?: unknown };
-      };
-      const identity = typeof obj.account?.email === 'string' ? obj.account.email : undefined;
-      const expiresAt = typeof obj.expires_at === 'number' ? obj.expires_at : undefined;
-      // authSource='oauth' 必须与 spawn fallback 的判定同源(hasCodexOAuthLogin =
-      // auth.json 含 access_token,见下方 getAccessToken 的字段路径)。`codex login
-      // --api-key` 产生的 auth.json 没有 tokens —— 若仅凭"能解析"就标 oauth,
-      // maker-core 会把隐式会话归一成 oauth-bearer,而 spawn fallback 实际走
-      // gateway key,共享 host 被登记错形态 → 后续显式 oauth 会话静默复用网关
-      // key 进程(review P1)。tokens 缺失时不标 authSource,归一化解析不出
-      // 即回退保守的"重建"语义,登录门禁(authenticated)不受影响。
-      const hasOAuthToken =
-        typeof obj.tokens?.access_token === 'string' && obj.tokens.access_token.length > 0;
-      return hasOAuthToken
-        ? { authenticated: true, identity, expiresAt, authSource: 'oauth' }
-        : { authenticated: true, identity, expiresAt };
-    } catch {
-      // JSON.parse 失败 / IO 错 → 降级为未登录 + errorReason, 不抛
-      return { authenticated: false, errorReason: 'auth_parse_failed' };
-    }
+    // authSource='oauth' 必须与 spawn fallback 的判定同源(access_token)。API-key-only
+    // auth.json 仍算可解析，但不会被误标成 ChatGPT OAuth。
+    return readCodexAuthFileState(authPath);
   }
 
   triggerLogin(opts?: AuthLoginOptions): Promise<AuthState> {
-    if (this.devOAuthWritesBlocked()) {
+    const mode = opts?.mode ?? 'browser';
+    // 复用当前 Codex CLI 只把 Cindy 自己的 auth 入口重新链接到系统文件，不启动 OAuth、
+    // 不改写系统 token；开发版的只读继承策略因此允许这条显式恢复路径。
+    if (mode !== 'local-cli' && this.devOAuthWritesBlocked()) {
       return Promise.resolve({
         authenticated: false,
         errorReason: 'dev_oauth_write_blocked',
         oauthWritesBlocked: true,
       });
     }
-    this.warnDevOAuthWriteOverride('login');
+    if (mode !== 'local-cli') this.warnDevOAuthWriteOverride('login');
     this.devReadOnlyDetached = false;
     this.memoryOnlyInvalidatedSystemCredential = null;
-    const mode = opts?.mode ?? 'browser';
     if (this.pendingLogin) {
       if (this.pendingLogin.mode === mode && !this.pendingLogin.cancelled) {
         if (opts?.onProgress && !this.pendingLogin.progressListeners.has(opts.onProgress)) {
@@ -1814,6 +1839,13 @@ export class DesktopCodexAuthAdapter implements AuthAdapter {
     if (this.loginAborted || isCancelled()) {
       return { authenticated: false, errorReason: 'login_cancelled' };
     }
+    if (opts?.mode === 'local-cli') {
+      // 隔离 OAuth 沙箱的目的就是不触碰真实本机登录，不能让一个 UI 动作绕回 ~/.codex。
+      if (!app.isPackaged && process.env.XDT_ISOLATED_AUTH === '1') {
+        return { authenticated: false, errorReason: 'local_cli_blocked_in_isolated_auth' };
+      }
+      return this.adoptSystemCodexLogin(isCancelled);
+    }
     if (!app.isPackaged && process.env.XDT_ISOLATED_AUTH === '1' && !this.isolatedAuthSanitized) {
       // This tracked login is itself the owner of the pending-login gate. After its logout barrier
       // has settled, allow only its trusted isolated-auth cleanup through that gate; ordinary
@@ -1859,7 +1891,7 @@ export class DesktopCodexAuthAdapter implements AuthAdapter {
 
     // spawn codex login。POSIX 建独立进程组，取消/超时时连同回调 server 一起收割。
     return new Promise<AuthState>((resolve) => {
-      const mode: AgentLoginMode = opts?.mode ?? 'browser';
+      const mode: CodexLoginMode = opts?.mode === 'device-code' ? 'device-code' : 'browser';
       const proc = spawn(binaryPath, codexLoginArgs(mode), {
         shell: false,
         env: { ...process.env, CODEX_HOME: this.codexHome },
@@ -1936,6 +1968,147 @@ export class DesktopCodexAuthAdapter implements AuthAdapter {
         complete({ authenticated: false, errorReason: `spawn_error:${err.message}` });
       });
     });
+  }
+
+  /**
+   * 用户显式选择当前 Codex CLI 账号。与自动 reconcile 的关键差异是：该动作可以解除
+   * durable user_disconnect / provider revoked 边界；但仍只建立共享链接，绝不复制 token。
+   */
+  private async adoptSystemCodexLogin(isCancelled: () => boolean): Promise<AuthState> {
+    const sessionAtStart = getActiveAppSession();
+    if (!sessionAtStart.dataOwnerId || isAppSessionBoundaryPending()) {
+      return { authenticated: false, errorReason: 'auth_session_unavailable' };
+    }
+    const sessionIsCurrent = (): boolean => {
+      const current = getActiveAppSession();
+      return (
+        !isAppSessionBoundaryPending() &&
+        current.dataOwnerId === sessionAtStart.dataOwnerId &&
+        current.generation === sessionAtStart.generation
+      );
+    };
+    const rollbackLinkedAuth = async (): Promise<void> => {
+      try {
+        await this.disconnectCodexOAuth();
+      } catch (error) {
+        // disconnect 已先建立进程内 fail-closed 状态；绑定锁等收尾失败不能让 IPC reject。
+        log.warn('failed to finish Codex CLI adoption rollback', {
+          error: error instanceof Error ? error.message : String(error),
+        });
+      }
+    };
+    const cancelledState = async (linked: boolean): Promise<AuthState> => {
+      if (linked) await rollbackLinkedAuth();
+      return { authenticated: false, errorReason: 'login_cancelled' };
+    };
+
+    const systemAuth = getSystemCodexAuthPath();
+    const systemState = requireCodexOAuthLoginState(await readCodexAuthFileState(systemAuth));
+    if (!systemState.authenticated) {
+      return {
+        authenticated: false,
+        errorReason:
+          systemState.errorReason === 'auth_parse_failed'
+            ? 'codex_cli_auth_parse_failed'
+            : 'codex_cli_oauth_missing',
+      };
+    }
+    const systemAccountId = await readCodexAccountId(systemAuth);
+    if (!systemAccountId) {
+      return { authenticated: false, errorReason: 'codex_cli_account_unavailable' };
+    }
+    if (isCancelled()) return cancelledState(false);
+    if (!sessionIsCurrent()) {
+      return { authenticated: false, errorReason: 'auth_mutation_superseded' };
+    }
+
+    const localAuth = path.join(this.codexHome, 'auth.json');
+    await fsp.mkdir(this.codexHome, { recursive: true }).catch(() => undefined);
+    const relink = await relinkSharedCodexAuth(systemAuth, localAuth);
+    const topology = await inspectCodexAuthLink(systemAuth, localAuth);
+    if (!topology.healthy) {
+      credPathLog.warn('explicit Codex CLI auth link failed', {
+        kind: relink.kind,
+        error: relink.error?.message,
+      });
+      return { authenticated: false, errorReason: 'codex_cli_link_failed' };
+    }
+    if (!sessionIsCurrent()) {
+      return { authenticated: false, errorReason: 'auth_mutation_superseded' };
+    }
+    if (isCancelled()) return cancelledState(true);
+
+    // 重读链接后的入口：CLI 可能在两次 await 之间原子换号或退出。只有眼前这份文件仍是
+    // 可识别 OAuth 才解除登出边界，避免把 malformed/API-key-only 文件绑定给当前 owner。
+    const linkedState = requireCodexOAuthLoginState(await readCodexAuthFileState(localAuth));
+    const linkedAccountId = await readCodexAccountId(localAuth);
+    const finalTopology = await inspectCodexAuthLink(systemAuth, localAuth);
+    if (!linkedState.authenticated || !linkedAccountId) {
+      await cancelledState(true);
+      return { authenticated: false, errorReason: 'codex_cli_oauth_missing' };
+    }
+    if (linkedAccountId !== systemAccountId || !finalTopology.healthy) {
+      await cancelledState(true);
+      return { authenticated: false, errorReason: 'codex_cli_account_changed' };
+    }
+    if (!sessionIsCurrent()) {
+      return { authenticated: false, errorReason: 'auth_mutation_superseded' };
+    }
+    if (isCancelled()) return cancelledState(true);
+
+    if (!clearInvalidatedSystemCodexAuthMarker(this.codexHome)) {
+      await rollbackLinkedAuth();
+      return { authenticated: false, errorReason: 'codex_cli_disconnect_boundary_clear_failed' };
+    }
+    try {
+      // 这是用户明确选择外部 CLI 账号，不是 Cindy 新发 OAuth；清 revoked 但保留 inherited
+      // provenance，后续“沿用本机订阅”文案和共享凭证保护才能继续准确工作。
+      bindNativeProviderAuth('openai', { inheritedSystem: true });
+    } catch (error) {
+      await rollbackLinkedAuth();
+      log.warn('failed to bind explicitly selected Codex CLI credential', {
+        error: error instanceof Error ? error.message : String(error),
+      });
+      return { authenticated: false, errorReason: 'codex_cli_binding_failed' };
+    }
+
+    this.devReadOnlyDetached = false;
+    this.oauthInvalidatedReason = null;
+    this.oauthInvalidatedCredentialScope = undefined;
+    this.oauthRecoveryRequiredReason = null;
+    this.oauthRecoveryCredentialScope = undefined;
+    this.memoryOnlyInvalidatedSystemCredential = null;
+    this.suppressSystemCodexReconcile = false;
+    this.lastKnownCodexCredentialScope = 'system-shared';
+
+    if (!sessionIsCurrent()) {
+      return { authenticated: false, errorReason: 'auth_mutation_superseded' };
+    }
+    if (isCancelled()) return cancelledState(true);
+    const state = requireCodexOAuthLoginState(
+      await this.readState({ skipReconcile: true, credentialMode: 'oauth-bearer' }),
+    );
+    if (!sessionIsCurrent()) {
+      return { authenticated: false, errorReason: 'auth_mutation_superseded' };
+    }
+    if (!state.authenticated) {
+      await rollbackLinkedAuth();
+      return state;
+    }
+    if (this.onLoginSuccess) {
+      try {
+        await this.onLoginSuccess();
+      } catch (error) {
+        log.warn('onLoginSuccess threw after Codex CLI adoption', {
+          error: error instanceof Error ? error.message : String(error),
+        });
+      }
+    }
+    if (!sessionIsCurrent()) {
+      return { authenticated: false, errorReason: 'auth_mutation_superseded' };
+    }
+    if (isCancelled()) return cancelledState(true);
+    return state;
   }
 
   private async finishSuccessfulCodexLogin(

--- a/apps/desktop/src/main/maker-host/nativeProviderAuthBinding.ts
+++ b/apps/desktop/src/main/maker-host/nativeProviderAuthBinding.ts
@@ -469,10 +469,14 @@ export function isNativeProviderAuthRevoked(provider: NativeProviderId): boolean
   return Boolean(read.ok && read.bindings.revoked && provider in read.bindings.revoked);
 }
 
-/** Bind newly completed native OAuth to the current data owner. */
+/**
+ * Bind a user-confirmed native OAuth credential to the current data owner.
+ * `inheritedSystem` is reserved for an explicit "use this computer's CLI account" action: it
+ * clears a prior disconnect just like fresh authorization, but preserves inherited provenance.
+ */
 export function bindNativeProviderAuth(
   provider: NativeProviderId,
-  opts?: { instanceIsolated?: boolean },
+  opts?: { instanceIsolated?: boolean; inheritedSystem?: boolean },
 ): void {
   const owner = getActiveAppSession().dataOwnerId;
   if (!owner) throw new Error('cannot bind native provider auth without an active data owner');
@@ -481,23 +485,28 @@ export function bindNativeProviderAuth(
     if (read.ok) {
       const bindings = read.bindings;
       const sharedSystemCredential = sharedSystemCredentialOwners(bindings);
-      delete sharedSystemCredential[provider];
+      if (opts?.inheritedSystem) sharedSystemCredential[provider] = owner;
+      else delete sharedSystemCredential[provider];
       const instanceIsolatedCredential = instanceIsolatedCredentialOwners(bindings);
       if (opts?.instanceIsolated) instanceIsolatedCredential[provider] = owner;
       else delete instanceIsolatedCredential[provider];
-      // 显式授权 = 用户重新表达了「我要连它」，撤销标记就此作废。
+      // 用户再次明确表达「我要连它」，无论重新 OAuth 还是选用当前 CLI，撤销标记都作废。
       if (bindings.revoked && provider in bindings.revoked) {
         const revoked = { ...bindings.revoked };
         delete revoked[provider];
         bindings.revoked = revoked;
       }
-      // 记下「这是用户自己在 Cindy 里授权的」——继承类文案据此不再对它成立。
+      const selfAuthorized = { ...bindings.selfAuthorized };
+      if (opts?.inheritedSystem) delete selfAuthorized[provider];
+      else selfAuthorized[provider] = owner;
       writeBindings({
         ...bindings,
-        selfAuthorized: { ...bindings.selfAuthorized, [provider]: owner },
+        selfAuthorized,
         sources: {
           ...bindings.sources,
-          [provider]: 'explicit-provider-oauth',
+          [provider]: opts?.inheritedSystem
+            ? 'native-harness-inherited'
+            : 'explicit-provider-oauth',
         },
         sharedSystemCredential,
         instanceIsolatedCredential,
@@ -519,7 +528,8 @@ export function bindNativeProviderAuth(
     // 授权即可恢复。
     const salvaged = read.reason === 'badRevoked' ? read.bindings : {};
     const sharedSystemCredential = sharedSystemCredentialOwners(salvaged);
-    delete sharedSystemCredential[provider];
+    if (opts?.inheritedSystem) sharedSystemCredential[provider] = owner;
+    else delete sharedSystemCredential[provider];
     const instanceIsolatedCredential = instanceIsolatedCredentialOwners(salvaged);
     if (opts?.instanceIsolated) instanceIsolatedCredential[provider] = owner;
     else delete instanceIsolatedCredential[provider];
@@ -527,13 +537,18 @@ export function bindNativeProviderAuth(
     for (const other of NATIVE_PROVIDER_IDS) {
       if (other !== provider) suppressed[other] = owner;
     }
+    const selfAuthorized = { ...salvaged.selfAuthorized };
+    if (opts?.inheritedSystem) delete selfAuthorized[provider];
+    else selfAuthorized[provider] = owner;
     writeBindings({
       ...salvaged,
       revoked: suppressed,
-      selfAuthorized: { ...salvaged.selfAuthorized, [provider]: owner },
+      selfAuthorized,
       sources: {
         ...salvaged.sources,
-        [provider]: 'explicit-provider-oauth',
+        [provider]: opts?.inheritedSystem
+          ? 'native-harness-inherited'
+          : 'explicit-provider-oauth',
       },
       sharedSystemCredential,
       instanceIsolatedCredential,

--- a/apps/desktop/src/main/maker-ipc/__tests__/localCliDetect.test.ts
+++ b/apps/desktop/src/main/maker-ipc/__tests__/localCliDetect.test.ts
@@ -15,6 +15,7 @@ function depsWith(
   files: string[],
   claudeLogin = false,
   shared: (cli: string) => boolean = () => true,
+  codexOAuthLogin = true,
 ): LocalCliScanDeps {
   const dirSet = new Set(dirs.map((d) => join(HOME, d)));
   const fileSet = new Set(files.map((f) => join(HOME, f)));
@@ -23,6 +24,7 @@ function depsWith(
     isDirectory: async (p) => dirSet.has(p),
     isFile: async (p) => fileSet.has(p),
     hasClaudeLogin: () => claudeLogin,
+    hasCodexOAuthLogin: async () => codexOAuthLogin,
     isCredentialSharedWithCindy: (cli) => shared(cli),
   };
 }
@@ -62,10 +64,21 @@ describe('scanLocalCliAuth', () => {
     expect(codex).toMatchObject({ installed: false, loggedIn: false });
   });
 
-  it('codex 已安装已登录', async () => {
+  it('codex 已安装且通过 ChatGPT OAuth 登录', async () => {
     const r = await scanLocalCliAuth(depsWith(['.codex'], [join('.codex', 'auth.json')], false));
     const codex = r.find((d) => d.cli === 'codex-cli');
-    expect(codex).toMatchObject({ installed: true, loggedIn: true });
+    expect(codex).toMatchObject({ installed: true, loggedIn: true, oauthLoggedIn: true });
+  });
+
+  it('codex 只有 API key auth 时不显示 OAuth 复用入口', async () => {
+    const r = await scanLocalCliAuth(
+      depsWith(['.codex'], [join('.codex', 'auth.json')], false, () => true, false),
+    );
+    expect(r.find((d) => d.cli === 'codex-cli')).toMatchObject({
+      installed: true,
+      loggedIn: true,
+      oauthLoggedIn: false,
+    });
   });
 
   it('文件探测抛错向上传播(生产 deps 在 stat 层吞错,handler 再降级空数组)', async () => {
@@ -76,6 +89,7 @@ describe('scanLocalCliAuth', () => {
         throw new Error('EACCES');
       },
       hasClaudeLogin: () => false,
+      hasCodexOAuthLogin: async () => false,
       isCredentialSharedWithCindy: () => true,
     };
     await expect(scanLocalCliAuth(deps)).rejects.toThrow('EACCES');

--- a/apps/desktop/src/main/maker-ipc/authHandlers.ts
+++ b/apps/desktop/src/main/maker-ipc/authHandlers.ts
@@ -19,7 +19,11 @@ export type MakerIpcBroadcast = (channel: string, payload: unknown) => void;
 
 /** IPC 允许的 agent 种类；运行时枚举校验不能靠 TypeScript 强转替代。 */
 const AGENT_KINDS = ['claude-code', 'codex', 'pi'] as const satisfies readonly AgentKind[];
-const AGENT_LOGIN_MODES = ['browser', 'device-code'] as const satisfies readonly AgentLoginMode[];
+const AGENT_LOGIN_MODES = [
+  'browser',
+  'device-code',
+  'local-cli',
+] as const satisfies readonly AgentLoginMode[];
 const MAX_LOGIN_PROGRESS_CHARS = 16_384;
 const LOGIN_OWNER_ID_PATTERN = /^[A-Za-z0-9._:-]{1,128}$/;
 const ANSI_SEQUENCE = new RegExp(
@@ -560,8 +564,8 @@ function requireLoginOptions(
 ): { mode: AgentLoginMode; ownerId?: string } {
   const options = value === undefined ? {} : requireObject(value, 'options');
   const mode = optionalEnum(options.mode, AGENT_LOGIN_MODES, 'login mode') ?? 'browser';
-  if (agentKind !== 'codex' && mode === 'device-code') {
-    throwIpcError('INVALID_PARAMS', 'device-code login is only supported by codex');
+  if (agentKind !== 'codex' && mode !== 'browser') {
+    throwIpcError('INVALID_PARAMS', `${mode} login is only supported by codex`);
   }
   const ownerId = requireLoginOwnerId(options.ownerId);
   if (agentKind !== 'codex' && ownerId) {

--- a/apps/desktop/src/main/maker-ipc/localCliDetect.ts
+++ b/apps/desktop/src/main/maker-ipc/localCliDetect.ts
@@ -2,9 +2,9 @@
  * localCliDetect(main)—— 本机 agent CLI 安装 / 登录态扫描的实现。
  *
  * 纯函数 + 注入 fs 依赖(规则 14:handler body 可脱 Electron 单测)。
- * 只做存在性 stat(目录用 isDirectory、文件用 isFile,防同名文件顶替误报——
- * 见 memory: 存在性探测用 stat 而非 access),**绝不读取凭证内容**(规则 23)。
- * 任一条目探测失败按「未安装」处理(fail-quiet:检测建议是增强,不是功能依赖)。
+ * 基础状态只做存在性 stat(目录用 isDirectory、文件用 isFile,防同名文件顶替误报)。
+ * Codex 额外通过 Main-only auth helper 判断文件是否为 OAuth；renderer 只收到布尔元数据，
+ * token 和路径不跨 IPC。任一条目探测失败均 fail-quiet（检测建议只是增强）。
  */
 
 import { homedir } from 'node:os';
@@ -12,7 +12,10 @@ import { join } from 'node:path';
 import { stat } from 'node:fs/promises';
 
 import { hasClaudeAiOAuth } from '../maker-host/claude-credentials-store.js';
-import { isCodexAuthInheritedFromSystemCli } from '../maker-host/auth-adapters.js';
+import {
+  hasSystemCodexOAuthLogin,
+  isCodexAuthInheritedFromSystemCli,
+} from '../maker-host/auth-adapters.js';
 import { isNativeProviderAuthSelfAuthorized } from '../maker-host/nativeProviderAuthBinding.js';
 import {
   LOCAL_CLI_DETECT_MAP,
@@ -31,6 +34,8 @@ export interface LocalCliScanDeps {
    * 生产 = hasClaudeAiOAuth();只返 boolean,不暴露凭证内容(规则 23)。
    */
   hasClaudeLogin(): boolean;
+  /** Codex CLI auth.json 是否包含可识别的 ChatGPT OAuth 账号。只返回布尔元数据。 */
+  hasCodexOAuthLogin(): Promise<boolean>;
   /**
    * Cindy 用的凭证是否确实就是这份本机凭证(填 `LocalCliDetection.sharedWithCindy`)。
    * 只在该 CLI 已登录时被调用;判据按 CLI 分派,见 createLocalCliScanDeps。
@@ -59,6 +64,13 @@ export function createLocalCliScanDeps(): LocalCliScanDeps {
     hasClaudeLogin: () => {
       try {
         return hasClaudeAiOAuth();
+      } catch {
+        return false;
+      }
+    },
+    hasCodexOAuthLogin: async () => {
+      try {
+        return await hasSystemCodexOAuthLogin();
       } catch {
         return false;
       }
@@ -106,6 +118,8 @@ export async function scanLocalCliAuth(deps: LocalCliScanDeps): Promise<LocalCli
     } else if (dirExists && entry.credentialFileSegments) {
       loggedIn = await deps.isFile(join(deps.homeDir, ...entry.credentialFileSegments));
     }
+    const oauthLoggedIn =
+      entry.cli === 'claude-cli' ? loggedIn : loggedIn ? await deps.hasCodexOAuthLogin() : false;
     // 未登录时不必探测共用性(也无从谈起);已登录才问「Cindy 用的是不是这一份」。
     const sharedWithCindy = loggedIn ? deps.isCredentialSharedWithCindy(entry.cli) : false;
     results.push({
@@ -113,6 +127,7 @@ export async function scanLocalCliAuth(deps: LocalCliScanDeps): Promise<LocalCli
       providerId: entry.providerId,
       installed,
       loggedIn,
+      oauthLoggedIn,
       sharedWithCindy,
     });
   }

--- a/apps/desktop/src/preload/preload.ts
+++ b/apps/desktop/src/preload/preload.ts
@@ -6793,7 +6793,7 @@ contextBridge.exposeInMainWorld('electronAPI', {
         ipcRenderer.invoke('maker:auth:get-state', agentKind),
       triggerLogin: (
         agentKind: 'claude-code' | 'codex' | 'pi',
-        options?: { mode?: 'browser' | 'device-code'; ownerId?: string },
+        options?: { mode?: 'browser' | 'device-code' | 'local-cli'; ownerId?: string },
       ): Promise<unknown> => ipcRenderer.invoke('maker:auth:trigger-login', agentKind, options),
       cancelLogin: (
         agentKind: 'claude-code' | 'codex' | 'pi',

--- a/apps/desktop/src/renderer/__tests__/inheritedSubscriptionNotice.test.tsx
+++ b/apps/desktop/src/renderer/__tests__/inheritedSubscriptionNotice.test.tsx
@@ -75,6 +75,7 @@ function detection(providerId: string, over: Partial<LocalCliDetection> = {}): L
     providerId,
     installed: true,
     loggedIn: true,
+    oauthLoggedIn: true,
     // 默认「确实是同一份凭证」；不共用的场景由用例显式覆写（见 sharedWithCindy 用例）。
     sharedWithCindy: true,
     ...over,

--- a/apps/desktop/src/renderer/components/settings/ProvidersSection.tsx
+++ b/apps/desktop/src/renderer/components/settings/ProvidersSection.tsx
@@ -142,18 +142,22 @@ function providerIcon(p: ProviderView, size: number): ReactNode {
 // 通用小件(与重构前一致)
 // ---------------------------------------------------------------------------
 
-function ConnectedPill() {
+function ConnectedPill({ identity }: { identity?: string } = {}) {
   const { t } = useTranslation();
   return (
     <span
-      className="flex h-[22px] shrink-0 items-center gap-1 rounded-full px-2.5 text-11 font-medium"
+      className="flex h-[22px] max-w-64 shrink-0 items-center gap-1 rounded-full px-2.5 text-11 font-medium"
       style={{
         backgroundColor: 'var(--settings-btn-secondary-bg)',
         color: 'var(--settings-section-desc)',
       }}
     >
-      <Check size={12} strokeWidth={2.5} />
-      {t('settings.providers.pill.connected')}
+      <Check size={12} className="shrink-0" strokeWidth={2.5} />
+      <span className="truncate">
+        {identity
+          ? `${t('settings.providers.pill.connected')} · ${identity}`
+          : t('settings.providers.pill.connected')}
+      </span>
     </span>
   );
 }
@@ -562,7 +566,15 @@ function AnthropicHeader({
 // OpenAI —— OAuth(ChatGPT 订阅 / Codex),复用 useCodexAuth()。
 // ---------------------------------------------------------------------------
 
-function OpenAiHeader({ provider, onChanged }: { provider?: ProviderView; onChanged: () => void }) {
+function OpenAiHeader({
+  provider,
+  onChanged,
+  codexCliLoggedIn,
+}: {
+  provider?: ProviderView;
+  onChanged: () => void;
+  codexCliLoggedIn: boolean;
+}) {
   const { t } = useTranslation();
   const { confirm } = useConfirmDialog();
   const {
@@ -623,6 +635,15 @@ function OpenAiHeader({ provider, onChanged }: { provider?: ProviderView; onChan
     }
   }, [triggerLogin, onChanged, t]);
 
+  const handleUseCodexCli = useCallback(async () => {
+    const outcome = await triggerLogin('local-cli');
+    if (outcome === 'authenticated') {
+      onChanged();
+    } else if (outcome === 'failed' || outcome === 'unverified') {
+      toast.error(t('settings.connections.codex.toast.cliConnectFailed'));
+    }
+  }, [onChanged, t, triggerLogin]);
+
   const handleRecovery = useCallback(async () => {
     if (recoveryCheck === 'checking' || loggingIn) return;
     if (recoveryCheck === 'failed') {
@@ -646,7 +667,7 @@ function OpenAiHeader({ provider, onChanged }: { provider?: ProviderView; onChan
 
   const trailing = connected ? (
     <div className="flex shrink-0 items-center gap-2.5">
-      <ConnectedPill />
+      <ConnectedPill identity={state.kind === 'authenticated' ? state.identity : undefined} />
       <PillButton
         label={t('settings.providers.button.disconnect')}
         onClick={() => void handleLogout()}
@@ -674,20 +695,29 @@ function OpenAiHeader({ provider, onChanged }: { provider?: ProviderView; onChan
       />
     </div>
   ) : (
-    <PillButton
-      label={
-        oauthWritesBlocked
-          ? t('chatgptAuthRecovery.devReadOnly')
-          : loggingIn
-            ? t('settings.providers.openai.cancelConnect')
-            : t('settings.providers.openai.connect')
-      }
-      disabled={oauthWritesBlocked}
-      onClick={() => {
-        if (loggingIn) void cancelLogin();
-        else void handleLogin();
-      }}
-    />
+    <div className="flex shrink-0 flex-wrap items-center justify-end gap-2.5">
+      <PillButton
+        label={
+          oauthWritesBlocked
+            ? t('chatgptAuthRecovery.devReadOnly')
+            : loggingIn
+              ? t('settings.providers.openai.cancelConnect')
+              : t('settings.providers.openai.connect')
+        }
+        disabled={oauthWritesBlocked}
+        onClick={() => {
+          if (loggingIn) void cancelLogin();
+          else void handleLogin();
+        }}
+      />
+      {codexCliLoggedIn &&
+        (state.kind === 'unauthenticated' || state.kind === 'error') && (
+          <PillButton
+            label={t('settings.providers.openai.useCodexCli')}
+            onClick={() => void handleUseCodexCli()}
+          />
+        )}
+    </div>
   );
 
   return (
@@ -2353,7 +2383,17 @@ export function ProvidersSection() {
   const renderDetailHeader = (p: ProviderView): ReactNode => {
     if (p.id === 'xd') return <XdGatewayHeader provider={p} onChanged={refetch} />;
     if (p.id === 'anthropic') return <AnthropicHeader provider={p} onChanged={refetch} />;
-    if (p.id === 'openai') return <OpenAiHeader provider={p} onChanged={refetch} />;
+    if (p.id === 'openai') {
+      return (
+        <OpenAiHeader
+          provider={p}
+          onChanged={refetch}
+          codexCliLoggedIn={detections.some(
+            (d) => d.providerId === 'openai' && d.installed && d.oauthLoggedIn,
+          )}
+        />
+      );
+    }
     if (p.id === 'xai') return <XaiHeader provider={p} onChanged={refetch} />;
     if (
       p.source === 'builtin' &&

--- a/apps/desktop/src/renderer/hooks/__tests__/useCodexAuth.test.ts
+++ b/apps/desktop/src/renderer/hooks/__tests__/useCodexAuth.test.ts
@@ -86,7 +86,7 @@ function loginProgressListener(auth: ReturnType<typeof installAuthApi>) {
       (payload: {
         agentKind: string;
         phase: string;
-        mode?: 'browser' | 'device-code';
+        mode?: 'browser' | 'device-code' | 'local-cli';
         detail?: string;
         verificationUrl?: string;
         userCode?: string;
@@ -287,6 +287,34 @@ describe('useCodexAuth lifecycle', () => {
       oauthWritesBlocked: true,
     });
     expect(auth.triggerLogin).not.toHaveBeenCalled();
+  });
+
+  it('allows explicit local CLI adoption under the dev OAuth write policy', async () => {
+    const auth = installAuthApi(async () => undefined);
+    auth.getState.mockResolvedValueOnce({ authenticated: false, oauthWritesBlocked: true });
+    auth.triggerLogin.mockResolvedValue({
+      authenticated: true,
+      identity: 'cli@example.test',
+      authSource: 'oauth',
+      credentialScope: 'system-shared',
+      oauthWritesBlocked: true,
+    });
+    const { result } = renderHook(() => useCodexAuth());
+
+    await waitFor(() => expect(result.current.state.kind).toBe('unauthenticated'));
+    await act(async () => {
+      await expect(result.current.triggerLogin('local-cli')).resolves.toBe('authenticated');
+    });
+
+    expect(auth.triggerLogin).toHaveBeenCalledWith('codex', {
+      mode: 'local-cli',
+      ownerId: expect.any(String),
+    });
+    expect(result.current.state).toMatchObject({
+      kind: 'authenticated',
+      identity: 'cli@example.test',
+      credentialScope: 'system-shared',
+    });
   });
 
   it('restores reconnect-required from a persisted OAuth invalidation', async () => {

--- a/apps/desktop/src/renderer/hooks/codexAuthLogin.ts
+++ b/apps/desktop/src/renderer/hooks/codexAuthLogin.ts
@@ -26,8 +26,10 @@ export type CodexLoginResult = {
 
 type CodexLoginStartedListener = () => void;
 
+export type CodexLoginMode = 'browser' | 'device-code' | 'local-cli';
+
 type PendingCodexLogin = {
-  mode: 'browser' | 'device-code';
+  mode: CodexLoginMode;
   ownerId: string;
   promise: Promise<CodexLoginResult>;
 };
@@ -90,13 +92,10 @@ export function onCodexLoginStarted(listener: CodexLoginStartedListener): () => 
   return () => loginStartedListeners.delete(listener);
 }
 
-function invokeCodexLogin(
-  mode: 'browser' | 'device-code',
-  ownerId: string,
-): Promise<CodexLoginResult> {
+function invokeCodexLogin(mode: CodexLoginMode, ownerId: string): Promise<CodexLoginResult> {
   return window.electronAPI.maker.auth.triggerLogin(
     'codex',
-    mode === 'device-code' ? { mode, ownerId } : { ownerId },
+    mode === 'browser' ? { ownerId } : { mode, ownerId },
   );
 }
 
@@ -106,7 +105,7 @@ function invokeCodexLogin(
  * main adapter 也会复用正在运行的 CLI 登录，但在 renderer 先合并可以避免设置页、
  * 会话横幅等入口重复发 IPC，并避免同一结果重复执行 main handler 的刷新与广播收尾。
  */
-function getOrStartCodexLogin(mode: 'browser' | 'device-code' = 'browser'): PendingCodexLogin {
+function getOrStartCodexLogin(mode: CodexLoginMode = 'browser'): PendingCodexLogin {
   if (pendingCodexLogin) {
     if (pendingCodexLogin.mode === mode) return pendingCodexLogin;
 
@@ -145,9 +144,7 @@ function getOrStartCodexLogin(mode: 'browser' | 'device-code' = 'browser'): Pend
   return pendingCodexLogin;
 }
 
-export function triggerCodexLoginOnce(
-  mode: 'browser' | 'device-code' = 'browser',
-): Promise<CodexLoginResult> {
+export function triggerCodexLoginOnce(mode: CodexLoginMode = 'browser'): Promise<CodexLoginResult> {
   return getOrStartCodexLogin(mode).promise;
 }
 
@@ -157,7 +154,7 @@ export function triggerCodexLoginOnce(
  * 同一 renderer 内多个显式入口会复用一个登录 promise；组件卸载时只有最后一个 owner
  * 才能取消它。lease 绑定具体 promise，因此旧模式的 cleanup 不会误杀已排队的新模式。
  */
-export function acquireCodexLogin(mode: 'browser' | 'device-code' = 'browser'): CodexLoginLease {
+export function acquireCodexLogin(mode: CodexLoginMode = 'browser'): CodexLoginLease {
   const pending = getOrStartCodexLogin(mode);
   const { ownerId, promise } = pending;
   let ownership = loginOwnership.get(promise);

--- a/apps/desktop/src/renderer/hooks/useCodexAuth.ts
+++ b/apps/desktop/src/renderer/hooks/useCodexAuth.ts
@@ -15,6 +15,7 @@ import {
   invalidatePendingCodexLogin,
   onCodexLoginStarted,
   type CodexLoginLease,
+  type CodexLoginMode,
   type CodexLoginResult,
   type CodexCredentialDiagnostics,
 } from './codexAuthLogin';
@@ -25,7 +26,7 @@ export type CodexUiState = (
   | { kind: 'unauthenticated' }
   | {
       kind: 'login-pending';
-      mode: 'browser' | 'device-code';
+      mode: CodexLoginMode;
       deviceCode?: { verificationUrl: string; userCode: string };
     }
   | {
@@ -73,7 +74,7 @@ type CodexAuthMachineEvent =
   | { type: 'state-changed'; result: CodexLoginResult }
   | {
       type: 'login-pending';
-      mode: 'browser' | 'device-code';
+      mode: CodexLoginMode;
       deviceCode?: { verificationUrl: string; userCode: string };
     }
   | { type: 'login-progress-error'; message: string }
@@ -433,9 +434,7 @@ export function verifyCodexAuthRecovery(
  *
  * 观察型 useCodexAuth 实例不会获得 lease，因此卸载时不会取消别的窗口发起的登录。
  */
-export function useOwnedCodexLogin(): (
-  mode?: 'browser' | 'device-code',
-) => Promise<CodexLoginResult> {
+export function useOwnedCodexLogin(): (mode?: CodexLoginMode) => Promise<CodexLoginResult> {
   const leasesRef = useRef(new Set<CodexLoginLease>());
   const mountedRef = useRef(true);
 
@@ -450,7 +449,7 @@ export function useOwnedCodexLogin(): (
     };
   }, []);
 
-  return useCallback((mode: 'browser' | 'device-code' = 'browser') => {
+  return useCallback((mode: CodexLoginMode = 'browser') => {
     if (!mountedRef.current) {
       return Promise.resolve({
         authenticated: false,
@@ -717,7 +716,12 @@ export function useCodexAuth(options?: {
       } else if (progress.phase === 'login-pending') {
         transition({
           type: 'login-pending',
-          mode: progress.mode === 'device-code' ? 'device-code' : 'browser',
+          mode:
+            progress.mode === 'device-code'
+              ? 'device-code'
+              : progress.mode === 'local-cli'
+                ? 'local-cli'
+                : 'browser',
         });
       } else if (progress.phase === 'login-error') {
         transition({ type: 'login-progress-error', message: progress.detail ?? 'unknown' });
@@ -777,10 +781,10 @@ export function useCodexAuth(options?: {
   }, [enabled, machine.ui.kind, refresh]);
 
   const triggerLogin = useCallback(
-    async (mode: 'browser' | 'device-code' = 'browser'): Promise<CodexLoginOutcome> => {
+    async (mode: CodexLoginMode = 'browser'): Promise<CodexLoginOutcome> => {
       const observerEpoch = observerEpochRef.current;
       if (!isObserverActive(observerEpoch)) return 'cancelled';
-      if (machineRef.current.ui.oauthWritesBlocked) return 'blocked';
+      if (mode !== 'local-cli' && machineRef.current.ui.oauthWritesBlocked) return 'blocked';
       transition({ type: 'login-pending', mode });
       try {
         const result = await triggerOwnedLogin(mode);

--- a/apps/desktop/src/renderer/i18n/locales/en/common.json
+++ b/apps/desktop/src/renderer/i18n/locales/en/common.json
@@ -1315,6 +1315,7 @@
         "toast": {
           "loggedOut": "ChatGPT account disconnected",
           "loginFailed": "Couldn’t connect ChatGPT. Try again",
+          "cliConnectFailed": "Couldn’t use the Codex CLI account. Make sure the CLI is signed in with ChatGPT and try again",
           "logoutFailed": "Couldn’t disconnect ChatGPT. Try again",
           "binaryMissing": "Codex component is unavailable, please restart the app"
         },
@@ -1427,7 +1428,8 @@
         "subtitle": "Connect one ChatGPT account for both Codex and Claude",
         "modelLabel": "GPT models",
         "reconnectRequired": "Reconnect Needed",
-        "connect": "Connect ChatGPT",
+        "connect": "Sign In to ChatGPT",
+        "useCodexCli": "Use Current Codex CLI Account",
         "reconnect": "Reconnect ChatGPT",
         "cancelConnect": "Cancel Connection"
       },

--- a/apps/desktop/src/renderer/i18n/locales/ja/common.json
+++ b/apps/desktop/src/renderer/i18n/locales/ja/common.json
@@ -1315,6 +1315,7 @@
         "toast": {
           "loggedOut": "ChatGPT アカウントを切断しました",
           "loginFailed": "ChatGPT に接続できませんでした。再試行してください",
+          "cliConnectFailed": "Codex CLI アカウントを使用できませんでした。CLI が ChatGPT にログイン済みか確認して再試行してください",
           "logoutFailed": "ChatGPT を切断できませんでした。再試行してください",
           "binaryMissing": "Codex コンポーネントが利用できません。アプリを再起動してください"
         },
@@ -1427,7 +1428,8 @@
         "subtitle": "1 つの ChatGPT アカウントを Codex と Claude の両方で使用",
         "modelLabel": "GPT モデル",
         "reconnectRequired": "再接続が必要",
-        "connect": "ChatGPT に接続",
+        "connect": "ChatGPT にログイン",
+        "useCodexCli": "現在の Codex CLI アカウントを使用",
         "reconnect": "ChatGPT に再接続",
         "cancelConnect": "接続をキャンセル"
       },

--- a/apps/desktop/src/renderer/i18n/locales/ko/common.json
+++ b/apps/desktop/src/renderer/i18n/locales/ko/common.json
@@ -1315,6 +1315,7 @@
         "toast": {
           "loggedOut": "ChatGPT 계정 연결이 해제되었습니다",
           "loginFailed": "ChatGPT에 연결하지 못했습니다. 다시 시도해 주세요",
+          "cliConnectFailed": "Codex CLI 계정을 사용할 수 없습니다. CLI가 ChatGPT에 로그인되어 있는지 확인한 후 다시 시도해 주세요",
           "logoutFailed": "ChatGPT 연결을 해제하지 못했습니다. 다시 시도해 주세요",
           "binaryMissing": "Codex 구성 요소를 사용할 수 없습니다. 앱을 다시 시작하세요"
         },
@@ -1427,7 +1428,8 @@
         "subtitle": "하나의 ChatGPT 계정을 Codex와 Claude에서 함께 사용",
         "modelLabel": "GPT 모델",
         "reconnectRequired": "다시 연결 필요",
-        "connect": "ChatGPT 연결",
+        "connect": "ChatGPT 로그인",
+        "useCodexCli": "현재 Codex CLI 계정 사용",
         "reconnect": "ChatGPT 다시 연결",
         "cancelConnect": "연결 취소"
       },

--- a/apps/desktop/src/renderer/i18n/locales/zh-CN/common.json
+++ b/apps/desktop/src/renderer/i18n/locales/zh-CN/common.json
@@ -1315,6 +1315,7 @@
         "toast": {
           "loggedOut": "ChatGPT 账号已断开",
           "loginFailed": "无法连接 ChatGPT，请重试",
+          "cliConnectFailed": "无法使用 Codex CLI 账号，请确认 CLI 已通过 ChatGPT 登录后重试",
           "logoutFailed": "无法断开 ChatGPT，请重试",
           "binaryMissing": "Codex 组件不可用，请重启应用"
         },
@@ -1427,7 +1428,8 @@
         "subtitle": "连接一个 ChatGPT 账号，同时用于 Codex 和 Claude",
         "modelLabel": "GPT 模型",
         "reconnectRequired": "需要重新连接",
-        "connect": "连接 ChatGPT",
+        "connect": "登录 ChatGPT",
+        "useCodexCli": "使用当前 Codex CLI 账号",
         "reconnect": "重新连接 ChatGPT",
         "cancelConnect": "取消连接"
       },

--- a/apps/desktop/src/renderer/i18n/locales/zh-TW/common.json
+++ b/apps/desktop/src/renderer/i18n/locales/zh-TW/common.json
@@ -1315,6 +1315,7 @@
         "toast": {
           "loggedOut": "ChatGPT 帳號已斷開",
           "loginFailed": "無法連線 ChatGPT，請重試",
+          "cliConnectFailed": "無法使用 Codex CLI 帳號，請確認 CLI 已透過 ChatGPT 登入後再試一次",
           "logoutFailed": "無法斷開 ChatGPT，請重試",
           "binaryMissing": "Codex 元件不可用，請重啟應用"
         },
@@ -1427,7 +1428,8 @@
         "subtitle": "連線一個 ChatGPT 帳號，同時用於 Codex 和 Claude",
         "modelLabel": "GPT 模型",
         "reconnectRequired": "需要重新連線",
-        "connect": "連線 ChatGPT",
+        "connect": "登入 ChatGPT",
+        "useCodexCli": "使用目前的 Codex CLI 帳號",
         "reconnect": "重新連線 ChatGPT",
         "cancelConnect": "取消連線"
       },

--- a/apps/desktop/src/renderer/vite-env.d.ts
+++ b/apps/desktop/src/renderer/vite-env.d.ts
@@ -6051,7 +6051,7 @@ interface ElectronAPI {
       getState: (agentKind: 'claude-code' | 'codex' | 'pi') => Promise<CodexAuthState>;
       triggerLogin: (
         agentKind: 'claude-code' | 'codex' | 'pi',
-        options?: { mode?: 'browser' | 'device-code'; ownerId?: string },
+        options?: { mode?: 'browser' | 'device-code' | 'local-cli'; ownerId?: string },
       ) => Promise<CodexAuthState>;
       cancelLogin: (
         agentKind: 'claude-code' | 'codex' | 'pi',
@@ -6065,7 +6065,7 @@ interface ElectronAPI {
         cb: (p: {
           agentKind: 'claude-code' | 'codex' | 'pi';
           phase: string;
-          mode?: 'browser' | 'device-code';
+          mode?: 'browser' | 'device-code' | 'local-cli';
           detail?: string;
           verificationUrl?: string;
           userCode?: string;

--- a/apps/desktop/src/shared/localCliDetect.ts
+++ b/apps/desktop/src/shared/localCliDetect.ts
@@ -39,8 +39,13 @@ export interface LocalCliDetection {
   providerId: string;
   /** 配置目录存在(~/.claude / ~/.codex)。 */
   installed: boolean;
-  /** 登录态凭证文件存在(只 stat 不读)。 */
+  /** 登录态凭证存在；仅表示 CLI 有某种认证配置。 */
   loggedIn: boolean;
+  /**
+   * 是否检测到可供 ChatGPT 登录复用的 OAuth 凭证。Main 只暴露此布尔元数据，
+   * 不向 renderer 传递 token 或凭证路径。
+   */
+  oauthLoggedIn: boolean;
   /**
    * Cindy 当前用的凭证**确实就是这一份本机凭证**(而不是各自登录了不同账号)。
    *

--- a/packages/maker-core/src/interfaces/auth-adapter.ts
+++ b/packages/maker-core/src/interfaces/auth-adapter.ts
@@ -9,7 +9,7 @@
 import type { AuthState } from '../types/common.js';
 
 export type AgentCredentialMode = 'gateway-key' | 'oauth-bearer' | 'provider-oauth';
-export type AgentLoginMode = 'browser' | 'device-code';
+export type AgentLoginMode = 'browser' | 'device-code' | 'local-cli';
 
 export interface AuthLoginOptions {
   mode?: AgentLoginMode;


### PR DESCRIPTION
## Summary

- add an explicit **Use current Codex CLI account** action for the built-in OpenAI provider when Cindy is disconnected and a valid local Codex OAuth login is detected
- reuse Cindy's existing shared `auth.json` link topology instead of copying OAuth tokens, preserving Codex CLI token rotation and Cindy-only logout semantics
- validate OAuth/account metadata, owner generation, cancellation, and final link topology before clearing the durable disconnect boundary
- preserve inherited native-provider provenance and refresh provider/model state through the existing post-login flow
- expose only non-sensitive CLI account metadata to the renderer and add copy for all five locales

## Behavior

After a user explicitly disconnects ChatGPT in Cindy, the system Codex CLI remains logged in. If that CLI login is a valid ChatGPT OAuth account, Settings shows an explicit action to adopt it again without opening a browser. API-key-only or malformed Codex auth files do not expose the action.

`reconnect-required` recovery behavior is unchanged.

## Testing

- `pnpm --filter desktop typecheck`
- `pnpm --filter desktop exec vitest run src/main/maker-host/__tests__/codexAuthBindingClaim.test.ts src/main/maker-host/__tests__/nativeProviderAuthBinding.test.ts src/main/maker-host/__tests__/codexAuthLoginConcurrency.test.ts src/main/maker-ipc/__tests__/localCliDetect.test.ts src/renderer/hooks/__tests__/useCodexAuth.test.ts src/renderer/__tests__/inheritedSubscriptionNotice.test.tsx` — 152 tests passed
- manual Windows desktop smoke test with an independent Cindy profile:
  - existing Codex CLI ChatGPT login detected
  - Cindy disconnect did not log out Codex CLI
  - explicit CLI adoption opened no browser
  - account/model state refreshed and Codex conversation worked
  - adoption persisted across restart
  - subsequent Cindy logout left Codex CLI logged in
