### PR TITLE
fix(model-providers): enable Fast for custom GPT-5.6 Sol

### DIFF
--- a/packages/model-providers/src/__tests__/user-provider.test.ts
+++ b/packages/model-providers/src/__tests__/user-provider.test.ts
@@ -223,6 +223,40 @@ describe("buildUserProvider (per-runtime)", () => {
     });
   });
 
+  it("inherits Registry Fast support only for an exact Codex route model id", () => {
+    const provider = buildUserProvider(
+      {
+        id: "fast-relay",
+        name: "Fast Relay",
+        runtimes: {
+          codex: {
+            baseUrl: "https://relay.example/v1",
+            models: [
+              { id: "gpt-5.6-sol", name: "GPT-5.6-Sol" },
+              { id: "openai/gpt-5.6-sol", name: "Prefixed GPT-5.6-Sol" },
+              { id: "unregistered-model", name: "Unregistered" },
+            ],
+          },
+          "claude-code": {
+            baseUrl: "https://relay.example/anthropic",
+            models: [{ id: "gpt-5.6-sol", name: "GPT-5.6-Sol" }],
+          },
+        },
+      },
+      { modelRegistry: BUNDLED_CATALOG.modelRegistry },
+    );
+
+    expect(provider.models.codex?.[0]).toMatchObject({
+      id: "gpt-5.6-sol",
+      supportsFastMode: true,
+    });
+    expect(provider.models.codex?.[1]?.supportsFastMode).toBeUndefined();
+    expect(provider.models.codex?.[2]?.supportsFastMode).toBeUndefined();
+    expect(
+      provider.models["claude-code"]?.[0]?.supportsFastMode,
+    ).toBeUndefined();
+  });
+
 it('strips xd/ prefix to match registry effort metadata (entry.id ≠ custom id)', () => {
     const p = buildUserProvider(
       {

--- a/packages/model-providers/src/user-provider.ts
+++ b/packages/model-providers/src/user-provider.ts
@@ -154,6 +154,34 @@ function registryEffortMetadata(
   return consensusRegistryEffortMetadata(fallbackMatches, agent);
 }
 
+/**
+ * Fast mode is a Codex service-tier capability, so a user provider may inherit it only when the
+ * configured model id exactly matches a Registry route for Codex. Prefix fallback is intentionally
+ * excluded: aliases can point at gateways with different billing or service-tier behavior.
+ */
+function registrySupportsFastMode(
+  registry: ModelRegistry | null | undefined,
+  modelId: string,
+  agent: AgentKind,
+): boolean {
+  if (agent !== "codex" || !registry) return false;
+
+  const matches = registry.models.filter((entry) =>
+    entry.routes.some(
+      (route) =>
+        route.agents.includes(agent) && route.modelId === modelId,
+    ),
+  );
+  return (
+    matches.length > 0 &&
+    matches.every(
+      (entry) =>
+        (entry.perAgent?.[agent]?.supportsFastMode ??
+          entry.supportsFastMode) === true,
+    )
+  );
+}
+
 /** 固定 agent 顺序：保证派生出的 provider.agents / routing / models 顺序稳定。 */
 const AGENT_ORDER: readonly AgentKind[] = ["claude-code", "codex", "pi"];
 
@@ -178,6 +206,11 @@ function toCatalogModel(
     m.reasoning !== undefined
       ? undefined
       : registryEffortMetadata(modelRegistry, m.id, agent);
+  const supportsFastMode = registrySupportsFastMode(
+    modelRegistry,
+    m.id,
+    agent,
+  );
   const effectiveEfforts = registryEfforts?.efforts ?? efforts;
   const defaultEffort =
     registryEfforts?.defaultEffort ??
@@ -209,6 +242,7 @@ function toCatalogModel(
     // 图片能力必须由用户/预设明确确认；缺省不猜，防止 Pi 静默把截图降级成占位文本。
     ...(m.supportsImageInput === true ? { supportsImageInput: true } : {}),
     ...(m.thinkingToggle === true ? { thinkingToggle: true } : {}),
+    ...(supportsFastMode ? { supportsFastMode: true } : {}),
   };
 }
 


### PR DESCRIPTION
## 这次改了什么

### 摘要

自定义供应商模型此前只继承 Registry 的 reasoning effort，导致精确配置为 `gpt-5.6-sol` 时缺少 `supportsFastMode`，Cindy 因而隐藏 Fast 开关。

本次让自定义供应商的 Codex 模型在精确匹配 Registry route model ID、且所有匹配条目都确认支持时继承 Fast 能力。前缀别名、未知模型、Claude Code 和 Pi 继续保持关闭，避免对第三方兼容端点作宽泛推断。

### 变更类型

- [ ] `feat` 新功能
- [x] `fix` 缺陷修复
- [ ] `refactor` / `perf` 重构或性能优化
- [ ] `docs` / `test` / `chore` 文档、测试或工程维护
- [ ] 其他

### 范围

- 关联 Issue / 需求：自定义模型供应商下的 `gpt-5.6-sol` 无法开启 Fast
- 本 PR 包含：自定义 Provider 的 Fast 能力投影与回归测试
- 明确不包含：网关侧 Fast 策略、上游账号配置、其他模型别名的 Fast 推断
- 用户可见变化：自定义供应商中的精确 `gpt-5.6-sol` 可显示并使用 Fast 开关
- 是否存在 breaking change：无

### UI 变化

未修改 UI 组件、样式或文案；仅修复已有 Fast 开关依赖的模型能力元数据。

- 引用的设计规范：不涉及

## 怎么验证的

### 自动验证

```text
pnpm --filter @cindy/model-providers test
结果：通过，20 个测试文件、684 项测试

pnpm --filter @cindy/model-providers run --if-present typecheck
结果：通过；该 package 无独立 typecheck script，按仓库规则跳过

pnpm --filter @cindy/model-providers run build
结果：通过，tsc --noEmit

pnpm test:unit:related
结果：通过；apps/desktop unit、apps/mobile unit、packages/model-providers related 全部通过

pnpm check:dco
结果：通过，1 个 commit 已签名

git diff --check origin/main...HEAD
结果：通过
```

### 手工验证

未执行打包后的 Desktop 实机验证；本次能力投影由单测覆盖。

### 未执行的验证

未执行完整打包与安装验证，改动不涉及构建或安装链路。

补充：在本地 `origin/main` 尚未对齐官方主干时，related runner 曾误退回全量；其中上游现有 Windows Pi symlink fixture 用例失败。对齐官方 `main` 后，正式的 related 门禁已完整通过。

## 风险

### 风险分类

- [ ] 无已知风险
- [ ] SQLite / migration
- [ ] system prompt
- [ ] 协议兼容
- [ ] 权限 / 安全 / 用户数据
- [ ] 存量插件兼容（批准状态 / 指纹 / manifest 校验 / 安装布局 / 包格式）
- [ ] 原生层 / fingerprint / OTA
- [ ] 跨平台差异
- [x] 其他：第三方 Responses 端点可能不接受 `service_tier`，但只有用户主动开启 Fast 后才会发送

### 影响与回滚

- 影响范围：仅自定义供应商、Codex runtime、精确模型 ID `gpt-5.6-sol`
- 回滚 / 降级方式：回退本提交即可恢复原有保守门控

### 提交前检查

- [x] 已 review 完整 diff
- [x] 每个 commit 都带 DCO 签名（`git commit -s`）
- [x] UI 改动：不涉及
- [x] 未提交凭证、令牌或授权文件
- [x] 已补充必要测试
- [x] 已确认测试结果并说明未执行项