### PR TITLE
perf(mobile): 轻量化已完成工具输入驻留

### DIFF
--- a/apps/mobile/app/sessions/[sessionId].tsx
+++ b/apps/mobile/app/sessions/[sessionId].tsx
@@ -462,6 +462,11 @@ import {
   shouldKeepOlderMessagesAffordance,
 } from '@/session/messagePaging';
 import {
+  fetchMobileToolInputDetail,
+  type MobileToolInputDetail,
+  type MobileToolInputProjection,
+} from '@/session/messageToolPayloadProjection';
+import {
   HISTORY_BACKFILL_MAX_GAPS_PER_VISIT,
   HISTORY_GAP_MAX_CONSIDERED_PER_VISIT,
   HISTORY_GAP_PROBE_LIMIT,
@@ -5002,6 +5007,16 @@ export default function SessionScreen() {
       setLoadingEarlier(false);
     }
   }, [abandonInFlightBackfill, deviceId, hasOlderMessages, isScheduleDetail, loadingEarlier, maker, oldestLoadedMessageCursor, sessionId]);
+
+  const loadToolInput = useCallback(async (
+    ref: MobileToolInputProjection,
+  ): Promise<MobileToolInputDetail> => {
+    if (!deviceId) throw new Error('tool input device is unavailable');
+    return fetchMobileToolInputDetail(
+      ref,
+      (messageId, options) => maker.aroundMessages(sessionId, messageId, options),
+    );
+  }, [deviceId, maker, sessionId]);
 
   /**
    * 历史窗口空洞的自动补齐(见 `historyWindowGap.ts` 的文件头)。
@@ -9544,6 +9559,7 @@ export default function SessionScreen() {
                     onDeleteMessage={collaborationReadOnlyReason ? undefined : deleteMessage}
                     onForkMessage={collaborationReadOnlyReason ? undefined : forkAtMessage}
                     onLoadEarlier={loadEarlierMessages}
+                    onLoadToolInput={loadToolInput}
                     onOpenForkOrigin={forkOrigin ? openForkOrigin : undefined}
                     onBlockingOverlayChange={handleMessageBlockingOverlayChange}
                     onOpenSessionLink={openSessionLink}

--- a/apps/mobile/src/__tests__/messageNormalize.test.ts
+++ b/apps/mobile/src/__tests__/messageNormalize.test.ts
@@ -7,6 +7,10 @@ import {
 import { composerDocumentFromSerializedMessage } from '@/session/composerDocument';
 import { buildMobileMessageCopyText } from '@/session/messageActions';
 import { normalizeRemoteMessages } from '@/session/messageNormalize';
+import {
+  MOBILE_TOOL_INPUT_PROJECTION_THRESHOLD_BYTES,
+  projectLargeSettledToolInputs,
+} from '@/session/messageToolPayloadProjection';
 import type { RemoteMessage } from '@/session/types';
 
 function message(patch: Partial<RemoteMessage> & Pick<RemoteMessage, 'id' | 'role' | 'content'>): RemoteMessage {
@@ -23,6 +27,41 @@ function message(patch: Partial<RemoteMessage> & Pick<RemoteMessage, 'id' | 'rol
 describe('normalizeRemoteMessages', () => {
   beforeAll(async () => {
     await i18n.changeLanguage('zh-CN');
+  });
+
+  it('renders a projected large tool input from its bounded summary and keeps its result', () => {
+    const projected = projectLargeSettledToolInputs([
+      message({
+        id: 'large-tool',
+        role: 'tool_use',
+        toolUseId: 'toolu-large',
+        content: {
+          input: { payload: 'x'.repeat(MOBILE_TOOL_INPUT_PROJECTION_THRESHOLD_BYTES + 1) },
+          toolName: 'WebFetch',
+          toolUseId: 'toolu-large',
+        },
+      }),
+      message({
+        id: 'large-result',
+        role: 'tool_result',
+        toolUseId: 'toolu-large',
+        content: 'finished',
+        createdAt: '2026-01-01T00:00:01.000Z',
+      }),
+    ]);
+
+    const [item] = normalizeRemoteMessages(projected);
+    expect(item).toMatchObject({
+      kind: 'tool',
+      label: 'WebFetch',
+      secondaryBody: 'finished',
+      toolSettled: true,
+      toolInputProjection: {
+        projected: true,
+        toolUseMessageId: 'large-tool',
+      },
+    });
+    expect(item.body.length).toBeLessThanOrEqual(480);
   });
 
   it('projects a persisted agent task terminal state from tool_use metadata', () => {

--- a/apps/mobile/src/__tests__/messageToolPayloadProjection.test.ts
+++ b/apps/mobile/src/__tests__/messageToolPayloadProjection.test.ts
@@ -1,0 +1,222 @@
+import { describe, expect, it, vi } from 'vitest';
+import {
+  buildMobileToolInputDetail,
+  fetchMobileToolInputDetail,
+  MOBILE_TOOL_INPUT_PROJECTION_THRESHOLD_BYTES,
+  projectLargeSettledToolInputs,
+} from '@/session/messageToolPayloadProjection';
+import type { RemoteMessage } from '@/session/types';
+
+function message(
+  id: string,
+  role: RemoteMessage['role'],
+  content: unknown,
+  toolUseId: string | null,
+  patch: Partial<RemoteMessage> = {},
+): RemoteMessage {
+  return {
+    id,
+    clientId: id,
+    sessionId: 'session-1',
+    role,
+    content,
+    toolUseId,
+    agentMeta: null,
+    createdAt: `2026-01-01T00:00:0${id.endsWith('result') ? '2' : '1'}.000Z`,
+    ...patch,
+  };
+}
+
+function toolPair(
+  toolName: string,
+  input: unknown,
+  patch: Partial<RemoteMessage> = {},
+): RemoteMessage[] {
+  return [
+    message('tool-use', 'tool_use', { input, toolName, toolUseId: 'toolu-1' }, 'toolu-1', patch),
+    message('tool-result', 'tool_result', 'ok', 'toolu-1'),
+  ];
+}
+
+describe('projectLargeSettledToolInputs', () => {
+  it('projects a persisted ordinary tool only after its exact result arrives', () => {
+    const input = { payload: 'x'.repeat(MOBILE_TOOL_INPUT_PROJECTION_THRESHOLD_BYTES + 1) };
+    const projected = projectLargeSettledToolInputs(toolPair('WebFetch', input));
+
+    expect(projected[0]).toMatchObject({
+      content: {
+        input: null,
+        mobilePayloadProjected: true,
+        toolName: 'WebFetch',
+        toolUseId: 'toolu-1',
+      },
+      mobileToolInputProjection: {
+        projected: true,
+        toolName: 'WebFetch',
+        toolUseId: 'toolu-1',
+        toolUseMessageId: 'tool-use',
+        version: 1,
+      },
+    });
+    expect(projected[0].mobileToolInputProjection).not.toHaveProperty('originalBytes');
+    expect(projected[1].content).toBe('ok');
+  });
+
+  it('keeps small, unsettled, unpersisted, or remotely truncated inputs intact', () => {
+    const largeInput = { payload: 'x'.repeat(MOBILE_TOOL_INPUT_PROJECTION_THRESHOLD_BYTES + 1) };
+    const small = toolPair('WebFetch', { payload: 'small' });
+    const unsettled = toolPair('WebFetch', largeInput).slice(0, 1);
+    const unpersisted = toolPair('WebFetch', largeInput, { id: '' });
+    const truncated = toolPair('WebFetch', largeInput, {
+      agentMeta: { remoteContentTruncated: true },
+    });
+
+    for (const rows of [small, unsettled, unpersisted, truncated]) {
+      expect(projectLargeSettledToolInputs(rows)[0].mobileToolInputProjection).toBeUndefined();
+    }
+  });
+
+  it('requires exact toolUseId pairing instead of adjacent result guessing', () => {
+    const rows = toolPair('WebFetch', {
+      payload: 'x'.repeat(MOBILE_TOOL_INPUT_PROJECTION_THRESHOLD_BYTES + 1),
+    });
+    rows[1] = { ...rows[1], toolUseId: 'another-tool' };
+
+    expect(projectLargeSettledToolInputs(rows)[0].mobileToolInputProjection).toBeUndefined();
+  });
+
+  it.each([
+    ['Agent', { prompt: 'x' }],
+    ['update_plan', { plan: [{ status: 'in_progress', step: 'x' }] }],
+    ['send_to_worker', { message: 'x', target_session_id: 'worker-1' }],
+    ['Edit', { file_path: '/repo/a.ts', old_string: 'a', new_string: 'b' }],
+  ])('preserves structural %s tool inputs', (toolName, seedInput) => {
+    const input = { ...seedInput, padding: 'x'.repeat(MOBILE_TOOL_INPUT_PROJECTION_THRESHOLD_BYTES + 1) };
+    expect(projectLargeSettledToolInputs(toolPair(toolName, input))[0].mobileToolInputProjection)
+      .toBeUndefined();
+  });
+
+  it('counts UTF-8 bytes instead of UTF-16 code units', () => {
+    const input = '界'.repeat(Math.ceil(MOBILE_TOOL_INPUT_PROJECTION_THRESHOLD_BYTES / 3) + 1);
+    const projected = projectLargeSettledToolInputs(toolPair('WebFetch', input));
+
+    expect(input.length).toBeLessThan(MOBILE_TOOL_INPUT_PROJECTION_THRESHOLD_BYTES);
+    expect(projected[0].mobileToolInputProjection).toBeDefined();
+  });
+
+  it('includes JSON syntax and escaping while applying the byte threshold', () => {
+    const syntaxBytes = '{"payload":""}'.length;
+    const exact = { payload: 'x'.repeat(MOBILE_TOOL_INPUT_PROJECTION_THRESHOLD_BYTES - syntaxBytes) };
+    const over = { payload: 'x'.repeat(MOBILE_TOOL_INPUT_PROJECTION_THRESHOLD_BYTES - syntaxBytes + 1) };
+
+    expect(projectLargeSettledToolInputs(toolPair('WebFetch', exact))[0]
+      .mobileToolInputProjection).toBeUndefined();
+    expect(projectLargeSettledToolInputs(toolPair('WebFetch', over))[0]
+      .mobileToolInputProjection).toBeDefined();
+  });
+
+  it('stops inspecting a large input as soon as the threshold is crossed', () => {
+    let latePropertyRead = false;
+    const input = {
+      payload: 'x'.repeat(MOBILE_TOOL_INPUT_PROJECTION_THRESHOLD_BYTES + 1),
+      get unreadTail() {
+        latePropertyRead = true;
+        return 'not reached';
+      },
+    };
+    const stringify = vi.spyOn(JSON, 'stringify');
+
+    try {
+      expect(projectLargeSettledToolInputs(toolPair('WebFetch', input))[0]
+        .mobileToolInputProjection).toBeDefined();
+      expect(latePropertyRead).toBe(false);
+      expect(stringify).not.toHaveBeenCalled();
+    } finally {
+      stringify.mockRestore();
+    }
+  });
+
+  it('is idempotent for an already projected row', () => {
+    const first = projectLargeSettledToolInputs(toolPair('WebFetch', {
+      payload: 'x'.repeat(MOBILE_TOOL_INPUT_PROJECTION_THRESHOLD_BYTES + 1),
+    }));
+    const second = projectLargeSettledToolInputs(first);
+
+    expect(second[0]).toBe(first[0]);
+  });
+
+  it('does not inspect the same settled small input again on later normalizations', () => {
+    let inspectionCount = 0;
+    const rows = toolPair('WebFetch', {
+      get payload() {
+        inspectionCount += 1;
+        return 'small';
+      },
+    });
+
+    expect(projectLargeSettledToolInputs(rows)[0].mobileToolInputProjection).toBeUndefined();
+    expect(projectLargeSettledToolInputs(rows)[0].mobileToolInputProjection).toBeUndefined();
+    expect(inspectionCount).toBe(1);
+  });
+});
+
+describe('buildMobileToolInputDetail', () => {
+  it('restores the full input from the exact authoritative tool row', () => {
+    const fullInput = {
+      nested: { value: 'x'.repeat(MOBILE_TOOL_INPUT_PROJECTION_THRESHOLD_BYTES + 1) },
+    };
+    const rows = toolPair('WebFetch', fullInput);
+    const projected = projectLargeSettledToolInputs(rows);
+    const ref = projected[0].mobileToolInputProjection!;
+
+    const detail = buildMobileToolInputDetail(rows, ref);
+    expect(detail?.toolName).toBe('WebFetch');
+    expect(detail?.body).toBe(JSON.stringify(fullInput, null, 2));
+    expect(detail?.body.length).toBeGreaterThan(MOBILE_TOOL_INPUT_PROJECTION_THRESHOLD_BYTES);
+  });
+
+  it('rejects missing, mismatched, truncated, or still-projected rows', () => {
+    const original = toolPair('WebFetch', {
+      payload: 'x'.repeat(MOBILE_TOOL_INPUT_PROJECTION_THRESHOLD_BYTES + 1),
+    });
+    const projected = projectLargeSettledToolInputs(original);
+    const ref = projected[0].mobileToolInputProjection!;
+
+    expect(buildMobileToolInputDetail([], ref)).toBeNull();
+    expect(buildMobileToolInputDetail([
+      { ...original[0], content: { input: {}, toolName: 'Other', toolUseId: 'toolu-1' } },
+    ], ref)).toBeNull();
+    expect(buildMobileToolInputDetail([
+      { ...original[0], agentMeta: { remoteContentTruncated: true } },
+    ], ref)).toBeNull();
+    expect(buildMobileToolInputDetail(projected, ref)).toBeNull();
+  });
+});
+
+describe('fetchMobileToolInputDetail', () => {
+  it('requests only the authoritative tool row and returns its full input', async () => {
+    const rows = toolPair('WebFetch', {
+      payload: 'x'.repeat(MOBILE_TOOL_INPUT_PROJECTION_THRESHOLD_BYTES + 1),
+    });
+    const ref = projectLargeSettledToolInputs(rows)[0].mobileToolInputProjection!;
+    const calls: Array<{ messageId: string; radius: number }> = [];
+
+    const detail = await fetchMobileToolInputDetail(ref, async (messageId, options) => {
+      calls.push({ messageId, radius: options.radius });
+      return rows;
+    });
+
+    expect(calls).toEqual([{ messageId: 'tool-use', radius: 0 }]);
+    expect(detail.body.length).toBeGreaterThan(MOBILE_TOOL_INPUT_PROJECTION_THRESHOLD_BYTES);
+  });
+
+  it('rejects when the authoritative row cannot restore the projected input', async () => {
+    const rows = toolPair('WebFetch', {
+      payload: 'x'.repeat(MOBILE_TOOL_INPUT_PROJECTION_THRESHOLD_BYTES + 1),
+    });
+    const ref = projectLargeSettledToolInputs(rows)[0].mobileToolInputProjection!;
+
+    await expect(fetchMobileToolInputDetail(ref, async () => [])).rejects
+      .toThrow('tool input is unavailable');
+  });
+});

--- a/apps/mobile/src/__tests__/remoteSessionStore.test.ts
+++ b/apps/mobile/src/__tests__/remoteSessionStore.test.ts
@@ -1,6 +1,7 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { MAKER_EVENT_BATCH_CHANNEL } from '@cindy/device-link';
 import { clampLiveRowCreatedAt } from '@/session/messagePaging';
+import { MOBILE_TOOL_INPUT_PROJECTION_THRESHOLD_BYTES } from '@/session/messageToolPayloadProjection';
 import { remoteSessionStore, sessionPendingWrites } from '@/session/remoteSessionStore';
 import type { InputProjection, PendingInteraction, RemoteMessage, RemoteSession } from '@/session/types';
 
@@ -133,6 +134,36 @@ function pending(kind: string, requestId?: string, persistId?: string): PendingI
 
 describe('remoteSessionStore', () => {
   beforeEach(() => remoteSessionStore.clear());
+
+  it('releases a large persisted tool input when the matching result is appended', () => {
+    remoteSessionStore.setMessages('s1', [{
+      ...message('tool-use', 's1'),
+      role: 'tool_use',
+      toolUseId: 'toolu-1',
+      content: {
+        input: { payload: 'x'.repeat(MOBILE_TOOL_INPUT_PROJECTION_THRESHOLD_BYTES + 1) },
+        toolName: 'WebFetch',
+        toolUseId: 'toolu-1',
+      },
+    }]);
+    expect(remoteSessionStore.getMessages('s1')[0].mobileToolInputProjection).toBeUndefined();
+
+    remoteSessionStore.appendMessage('s1', {
+      ...message('tool-result', 's1'),
+      role: 'tool_result',
+      toolUseId: 'toolu-1',
+      content: 'finished',
+      createdAt: '2026-01-01T00:00:01.000Z',
+    });
+
+    expect(remoteSessionStore.getMessages('s1')[0]).toMatchObject({
+      content: { input: null, mobilePayloadProjected: true },
+      mobileToolInputProjection: {
+        projected: true,
+        toolUseMessageId: 'tool-use',
+      },
+    });
+  });
 
   it('normalizes same-timestamp messages by host rowid', () => {
     const createdAt = '2026-01-01T00:00:00.000Z';

--- a/apps/mobile/src/i18n/locales/en/message.json
+++ b/apps/mobile/src/i18n/locales/en/message.json
@@ -116,6 +116,10 @@
     "controlFork": "Fork session",
     "markdownDocAriaLabel": "Message body",
     "toolOutputTitle": "{{label}} output",
+    "toolInputTitle": "{{label}} input",
+    "viewToolInput": "View full input",
+    "loadingToolInput": "Loading full input",
+    "retryToolInput": "Couldn't load input. Retry",
     "toolResultCompacted": "Full tool output was released (original size {{size}})",
     "mermaidEmpty": "Empty Mermaid diagram.",
     "diffEditCount": "{{n}} edits"

--- a/apps/mobile/src/i18n/locales/ja/message.json
+++ b/apps/mobile/src/i18n/locales/ja/message.json
@@ -116,6 +116,10 @@
     "controlFork": "セッションを分岐",
     "markdownDocAriaLabel": "メッセージ本文",
     "toolOutputTitle": "{{label}} の出力",
+    "toolInputTitle": "{{label}} の入力",
+    "viewToolInput": "完全な入力を表示",
+    "loadingToolInput": "完全な入力を読み込み中",
+    "retryToolInput": "入力を読み込めませんでした。再試行",
     "toolResultCompacted": "Full tool output was released (original size {{size}})",
     "mermaidEmpty": "空の Mermaid 図。",
     "diffEditCount": "{{n}} 件の編集"

--- a/apps/mobile/src/i18n/locales/ko/message.json
+++ b/apps/mobile/src/i18n/locales/ko/message.json
@@ -116,6 +116,10 @@
     "controlFork": "세션 분기",
     "markdownDocAriaLabel": "메시지 본문",
     "toolOutputTitle": "{{label}} 출력",
+    "toolInputTitle": "{{label}} 입력",
+    "viewToolInput": "전체 입력 보기",
+    "loadingToolInput": "전체 입력 불러오는 중",
+    "retryToolInput": "입력을 불러오지 못했습니다. 다시 시도",
     "toolResultCompacted": "Full tool output was released (original size {{size}})",
     "mermaidEmpty": "빈 Mermaid 다이어그램.",
     "diffEditCount": "{{n}}개 편집"

--- a/apps/mobile/src/i18n/locales/zh-CN/message.json
+++ b/apps/mobile/src/i18n/locales/zh-CN/message.json
@@ -116,6 +116,10 @@
     "controlFork": "分叉任务",
     "markdownDocAriaLabel": "消息正文",
     "toolOutputTitle": "{{label}} 输出",
+    "toolInputTitle": "{{label}} 输入",
+    "viewToolInput": "查看完整输入",
+    "loadingToolInput": "正在读取完整输入",
+    "retryToolInput": "读取失败，重试",
     "toolResultCompacted": "Full tool output was released (original size {{size}})",
     "mermaidEmpty": "空 Mermaid 图表。",
     "diffEditCount": "{{n}} 处编辑"

--- a/apps/mobile/src/i18n/locales/zh-TW/message.json
+++ b/apps/mobile/src/i18n/locales/zh-TW/message.json
@@ -116,6 +116,10 @@
     "controlFork": "分叉任務",
     "markdownDocAriaLabel": "訊息正文",
     "toolOutputTitle": "{{label}} 輸出",
+    "toolInputTitle": "{{label}} 輸入",
+    "viewToolInput": "查看完整輸入",
+    "loadingToolInput": "正在讀取完整輸入",
+    "retryToolInput": "讀取失敗，重試",
     "toolResultCompacted": "Full tool output was released (original size {{size}})",
     "mermaidEmpty": "空 Mermaid 圖表。",
     "diffEditCount": "{{n}} 處編輯"

--- a/apps/mobile/src/session/MessageRenderer.tsx
+++ b/apps/mobile/src/session/MessageRenderer.tsx
@@ -118,12 +118,17 @@ import type {
   NormalizedToolDiff,
   NormalizedToolMedia,
 } from '@/session/messageNormalize';
+import type {
+  MobileToolInputDetail,
+  MobileToolInputProjection,
+} from '@/session/messageToolPayloadProjection';
 import {
   buildAttachmentPayload,
   buildDiffPayload,
   buildFilePayload,
   buildMediaPayload,
   buildMermaidPayload,
+  buildTextPayload,
   buildToolResultPayload,
   formatDiffPayloadView,
   payloadMediaKindLabel,
@@ -589,6 +594,7 @@ interface MessageActions {
   onLoadEarlier?: () => void | Promise<void>;
   onOpenForkOrigin?: () => void;
   onOpenPayload?: (payload: MessagePayload) => void;
+  onLoadToolInput?: (ref: MobileToolInputProjection) => Promise<MobileToolInputDetail>;
   onBlockingOverlayChange?: (blocked: boolean) => void;
   onMessageActionSheetOpenChange?: (clientId: string, open: boolean) => void;
   /** 正文里会话深链 chip(xdt-maker://session/…)点击回调,app 内跳转。 */
@@ -631,6 +637,7 @@ export function MessageRenderer({
   onForkMessage,
   onDeleteMessage,
   onLoadEarlier,
+  onLoadToolInput,
   onOpenForkOrigin,
   onBlockingOverlayChange,
   onOpenSessionLink,
@@ -1481,6 +1488,7 @@ export function MessageRenderer({
     onEnterShareSelection,
     onShareableMessageViewChange: handleShareableMessageViewChange,
     onOpenPayload: setPayload,
+    onLoadToolInput,
     onMessageActionSheetOpenChange: handleMessageActionSheetOpenChange,
     onResolveRemoteMedia,
     // 待发送气泡(pending_send 项)的展开态与队列操作:漏了这一项 actions.pendingSend 就是
@@ -1511,6 +1519,7 @@ export function MessageRenderer({
     onDeleteMessage,
     onForkMessage,
     onOpenForkOrigin,
+    onLoadToolInput,
     onOpenSessionLink,
     onPreviewRewind,
     onEnterShareSelection,
@@ -3718,11 +3727,75 @@ function ToolActionRow({
           {row.detail || tool.body ? (
             <Text style={styles.toolRowDetailText}>{row.detail ?? tool.body}</Text>
           ) : null}
+          {tool.toolInputProjection ? (
+            <ProjectedToolInputButton
+              key={tool.toolInputProjection.toolUseMessageId}
+              actions={actions}
+              projection={tool.toolInputProjection}
+            />
+          ) : null}
           {tool.diff ? <DiffPreview diff={tool.diff} layout={contentLayout} onOpen={actions.onOpenPayload} /> : null}
           {tool.secondaryBody ? <ToolResultPreview layout={contentLayout} tool={tool} onOpen={actions.onOpenPayload} /> : null}
         </View>
       ) : null}
     </View>
+  );
+}
+
+function ProjectedToolInputButton({
+  actions,
+  projection,
+}: {
+  actions: MessageActions;
+  projection: MobileToolInputProjection;
+}) {
+  const { colors } = useTheme();
+  const { t } = useTranslation();
+  const styles = useThemedStyles(makeStyles);
+  const [status, setStatus] = useState<'error' | 'idle' | 'loading'>('idle');
+  const requestSeqRef = useRef(0);
+
+  useEffect(() => () => {
+    requestSeqRef.current += 1;
+  }, []);
+
+  const openFullInput = useCallback(() => {
+    if (!actions.onLoadToolInput || !actions.onOpenPayload || status === 'loading') return;
+    const requestSeq = requestSeqRef.current + 1;
+    requestSeqRef.current = requestSeq;
+    setStatus('loading');
+    void actions.onLoadToolInput(projection).then((detail) => {
+      if (requestSeqRef.current !== requestSeq) return;
+      setStatus('idle');
+      actions.onOpenPayload?.(buildTextPayload(
+        t('message.renderer.toolInputTitle', { label: detail.toolName }),
+        detail.body,
+      ));
+    }).catch(() => {
+      if (requestSeqRef.current === requestSeq) setStatus('error');
+    });
+  }, [actions, projection, status, t]);
+
+  const label = status === 'loading'
+    ? t('message.renderer.loadingToolInput')
+    : status === 'error'
+      ? t('message.renderer.retryToolInput')
+      : t('message.renderer.viewToolInput');
+  return (
+    <MessageContentOpenButton
+      accessibilityLabel={label}
+      disabled={status === 'loading'}
+      onPress={openFullInput}
+      style={styles.toolInputPreview}
+      testID="message.toolInputPayloadButton"
+    >
+      <View style={styles.toolInputActionRow}>
+        {status === 'loading' ? (
+          <CompactActivityIndicator color={colors.textTertiary} size={iconSize.sm} />
+        ) : null}
+        <Text style={styles.toolInputActionText}>{label}</Text>
+      </View>
+    </MessageContentOpenButton>
   );
 }
 
@@ -8345,6 +8418,25 @@ const makeStyles = (colors: ThemeColors) => StyleSheet.create({
   toolRowDetailText: {
     color: colors.textSecondary,
     fontSize: typeScale.footnote,
+    lineHeight: lineHeight.caption,
+  },
+  toolInputPreview: {
+    backgroundColor: colors.chatCodeSurface,
+    borderColor: colors.chatCodeBorder,
+    borderRadius: radius.container,
+    borderWidth: StyleSheet.hairlineWidth,
+  },
+  toolInputActionRow: {
+    alignItems: 'center',
+    flexDirection: 'row',
+    gap: spacing.sm,
+    minHeight: MESSAGE_CONTROL_TOUCH_SIZE,
+    paddingHorizontal: spacing.sm,
+  },
+  toolInputActionText: {
+    color: colors.textTertiary,
+    fontSize: typeScale.caption,
+    fontWeight: fontWeight.medium,
     lineHeight: lineHeight.caption,
   },
   toolName: {

--- a/apps/mobile/src/session/messageNormalize.ts
+++ b/apps/mobile/src/session/messageNormalize.ts
@@ -51,6 +51,7 @@ import {
   localizeToolLoopError,
   parseMobileToolLoopErrorDetails,
 } from '@/session/toolLoopErrorI18n';
+import type { MobileToolInputProjection } from '@/session/messageToolPayloadProjection';
 
 export type NormalizedRemoteMessageKind =
   | 'user'
@@ -108,6 +109,8 @@ export interface NormalizedRemoteMessage {
   orcaCard?: OrcaCollabCard;
   /** tool 消息专用:tool_result 是否已到达(含被隐藏的 orca 空结果),驱动工具行 running/done 状态。 */
   toolSettled?: boolean;
+  /** Large settled tool input is fetched only when the user asks to view it. */
+  toolInputProjection?: MobileToolInputProjection;
   /** Durable Agent/Task terminal lifecycle restored from tool_use metadata. */
   agentTaskStatus?: AgentTaskTerminalStatus;
   /** assistant 专用:是否本轮收尾正文(操作行只挂在收尾正文上,对齐桌面 #456);由 messageRenderModel 标注。 */
@@ -195,6 +198,7 @@ export function normalizeRemoteMessages(messages: readonly RemoteMessage[]): Nor
 
     if (message.role === 'tool_use') {
       const tool = parseToolUse(message);
+      const toolInputProjection = message.mobileToolInputProjection;
       const agentTaskStatus = normalizeAgentTaskTerminalStatus(
         message.agentMeta?.agentTaskStatus,
       );
@@ -232,6 +236,7 @@ export function normalizeRemoteMessages(messages: readonly RemoteMessage[]): Nor
         // 结束时刻(配对 tool_result 落库时间)驱动渲染层的历史空洞判定,详见共享类型上的说明。
         settledAt: toolResultPairing.resultCreatedAtFor(message, tool),
         toolSettled: toolResultPairing.hasResultFor(message, tool),
+        ...(toolInputProjection ? { toolInputProjection } : {}),
         ...(agentTaskStatus ? { agentTaskStatus } : {}),
       });
       continue;
@@ -500,6 +505,16 @@ function parseToolUse(message: RemoteMessage): ToolUsePayload {
   const cached = toolUsePayloadByMessage.get(message);
   if (cached) return cached;
   const sharedTool = parseMessageToolUse(message);
+  const projection = message.mobileToolInputProjection;
+  if (projection) {
+    const payload = {
+      ...sharedTool,
+      toolName: projection.toolName,
+      summary: projection.summary,
+    };
+    toolUsePayloadByMessage.set(message, payload);
+    return payload;
+  }
   const { toolName, input } = sharedTool;
   const summary = toolName ? formatToolUseSummary(toolName, input) : contentToPreview(message.content);
   const diff = buildToolDiff(toolName, input);

--- a/apps/mobile/src/session/messageRenderReconcile.ts
+++ b/apps/mobile/src/session/messageRenderReconcile.ts
@@ -227,5 +227,6 @@ function remoteMessageEqual(previous: RemoteMessage, next: RemoteMessage): boole
     && previous.systemCardType === next.systemCardType
     && deepValueEqual(previous.content, next.content)
     && deepValueEqual(previous.agentMeta, next.agentMeta)
+    && deepValueEqual(previous.mobileToolInputProjection, next.mobileToolInputProjection)
     && deepValueEqual(previous.systemCardData, next.systemCardData);
 }

--- a/apps/mobile/src/session/messageToolPayloadProjection.ts
+++ b/apps/mobile/src/session/messageToolPayloadProjection.ts
@@ -1,0 +1,258 @@
+import { isAgentTaskToolName } from '@cindy/maker-shared/agent-task';
+import {
+  isAgentPlanToolName,
+} from '@cindy/maker-shared/message-render';
+import { parseMessageToolUse } from '@cindy/maker-shared/message-normalize';
+import {
+  buildPayloadToolDiff,
+  formatPayloadToolUseSummary,
+} from '@/session/messagePayload';
+import { classifyOrcaDispatchTool } from '@/session/orcaCollab';
+import type { RemoteMessage } from '@/session/types';
+
+export const MOBILE_TOOL_INPUT_PROJECTION_THRESHOLD_BYTES = 32 * 1024;
+
+const TOOL_SUMMARY_MAX_CHARS = 480;
+
+// Normalization can revisit the same immutable rows during pagination and refreshes.
+// Remember only that a settled row was evaluated; WeakSet neither retains the row nor
+// keeps any payload bytes alive.
+const evaluatedSettledToolInputs = new WeakSet<RemoteMessage>();
+
+export interface MobileToolInputProjection {
+  projected: true;
+  summary: string;
+  toolName: string;
+  toolUseId: string;
+  toolUseMessageId: string;
+  version: 1;
+}
+
+export interface MobileToolInputDetail {
+  body: string;
+  toolName: string;
+}
+
+export type MobileToolInputAroundLoader = (
+  messageId: string,
+  options: { radius: 0 },
+) => Promise<readonly RemoteMessage[]>;
+
+/**
+ * Release only large, persisted tool inputs after their exact result has arrived.
+ * Tool results are already bounded by the remote transport, while structural tools
+ * need their original input to build Agent, plan, Todo, Orca, and diff render models.
+ */
+export function projectLargeSettledToolInputs(
+  messages: readonly RemoteMessage[],
+): RemoteMessage[] {
+  const settledToolUseIds = new Set<string>();
+  for (const message of messages) {
+    if (message.role !== 'tool_result') continue;
+    const toolUseId = readToolUseId(message);
+    if (toolUseId) settledToolUseIds.add(toolUseId);
+  }
+  if (settledToolUseIds.size === 0) return [...messages];
+
+  return messages.map((message) => {
+    if (
+      message.role !== 'tool_use'
+      || message.mobileToolInputProjection
+      || !message.id
+      || message.agentMeta?.remoteContentTruncated === true
+    ) return message;
+
+    const tool = parseMessageToolUse(message);
+    if (
+      !tool.toolUseId
+      || !settledToolUseIds.has(tool.toolUseId)
+    ) return message;
+    if (evaluatedSettledToolInputs.has(message)) return message;
+    evaluatedSettledToolInputs.add(message);
+    if (!toolInputCanBeProjected(tool.toolName, tool.input)) return message;
+
+    if (!toolInputExceedsProjectionThreshold(tool.input)) return message;
+
+    const summary = limitText(
+      formatPayloadToolUseSummary(tool.toolName, tool.input),
+      TOOL_SUMMARY_MAX_CHARS,
+    );
+    const projection: MobileToolInputProjection = {
+      projected: true,
+      summary,
+      toolName: tool.toolName,
+      toolUseId: tool.toolUseId,
+      toolUseMessageId: message.id,
+      version: 1,
+    };
+    return {
+      ...message,
+      content: {
+        input: null,
+        mobilePayloadProjected: true,
+        toolName: tool.toolName,
+        toolUseId: tool.toolUseId,
+      },
+      mobileToolInputProjection: projection,
+    };
+  });
+}
+
+/** Build the one expanded detail directly from a radius-0 authoritative read. */
+export function buildMobileToolInputDetail(
+  messages: readonly RemoteMessage[],
+  ref: MobileToolInputProjection,
+): MobileToolInputDetail | null {
+  const message = messages.find((candidate) => (
+    candidate.role === 'tool_use' && candidate.id === ref.toolUseMessageId
+  ));
+  if (
+    !message
+    || message.agentMeta?.remoteContentTruncated === true
+    || message.mobileToolInputProjection
+  ) return null;
+
+  const tool = parseMessageToolUse(message);
+  if (tool.toolUseId !== ref.toolUseId || tool.toolName !== ref.toolName) return null;
+  const body = formatFullToolInput(tool.input);
+  return body ? { body, toolName: tool.toolName } : null;
+}
+
+export async function fetchMobileToolInputDetail(
+  ref: MobileToolInputProjection,
+  loadAround: MobileToolInputAroundLoader,
+): Promise<MobileToolInputDetail> {
+  const rows = await loadAround(ref.toolUseMessageId, { radius: 0 });
+  const detail = buildMobileToolInputDetail(rows, ref);
+  if (!detail) throw new Error('tool input is unavailable');
+  return detail;
+}
+
+function toolInputCanBeProjected(toolName: string, input: unknown): boolean {
+  if (!toolName) return false;
+  if (toolName === 'AskUserQuestion' || toolName === 'ExitPlanMode') return false;
+  if (isAgentTaskToolName(toolName) || isAgentPlanToolName(toolName)) return false;
+  if (classifyOrcaDispatchTool(toolName) !== null) return false;
+  return buildPayloadToolDiff(toolName, input) === undefined;
+}
+
+function readToolUseId(message: RemoteMessage): string | null {
+  if (message.toolUseId) return message.toolUseId;
+  if (!message.content || typeof message.content !== 'object' || Array.isArray(message.content)) {
+    return null;
+  }
+  const toolUseId = (message.content as Record<string, unknown>).toolUseId;
+  return typeof toolUseId === 'string' && toolUseId.length > 0 ? toolUseId : null;
+}
+
+interface JsonByteBudget {
+  ancestors: Set<object>;
+  remaining: number;
+}
+
+/** Count decoded JSON until 32 KiB is crossed, without building its full string. */
+function toolInputExceedsProjectionThreshold(input: unknown): boolean {
+  const budget: JsonByteBudget = {
+    ancestors: new Set(),
+    remaining: MOBILE_TOOL_INPUT_PROJECTION_THRESHOLD_BYTES,
+  };
+  return typeof input === 'string'
+    ? consumeUtf8(budget, input, false)
+    : measureJsonValue(budget, input) === true;
+}
+
+/** `true` means over budget; `null` means this is not a decoded JSON value. */
+function measureJsonValue(budget: JsonByteBudget, value: unknown): boolean | null {
+  if (value === null) return consumeAscii(budget, 4);
+  if (typeof value === 'string') return consumeUtf8(budget, value, true);
+  if (typeof value === 'boolean') return consumeAscii(budget, value ? 4 : 5);
+  if (typeof value === 'number') {
+    return consumeAscii(budget, Number.isFinite(value) ? String(value).length : 4);
+  }
+  if (typeof value !== 'object' || budget.ancestors.has(value)) return null;
+
+  if (!Array.isArray(value)) {
+    try {
+      const prototype = Object.getPrototypeOf(value);
+      if (prototype !== Object.prototype && prototype !== null) return null;
+    } catch {
+      return null;
+    }
+  }
+
+  budget.ancestors.add(value);
+  try {
+    if (Array.isArray(value)) {
+      if (consumeAscii(budget, 1)) return true;
+      for (let index = 0; index < value.length; index += 1) {
+        if (index > 0 && consumeAscii(budget, 1)) return true;
+        const measured = measureJsonValue(budget, value[index]);
+        if (measured === true) return true;
+        if (measured === null && consumeAscii(budget, 4)) return true;
+      }
+      return consumeAscii(budget, 1);
+    }
+
+    let written = 0;
+    if (consumeAscii(budget, 1)) return true;
+    for (const key of Object.keys(value)) {
+      const property = (value as Record<string, unknown>)[key];
+      if (property === undefined || typeof property === 'function' || typeof property === 'symbol') {
+        continue;
+      }
+      if (written > 0 && consumeAscii(budget, 1)) return true;
+      if (consumeUtf8(budget, key, true) || consumeAscii(budget, 1)) return true;
+      const measured = measureJsonValue(budget, property);
+      if (measured === null) return null;
+      if (measured) return true;
+      written += 1;
+    }
+    return consumeAscii(budget, 1);
+  } catch {
+    return null;
+  } finally {
+    budget.ancestors.delete(value);
+  }
+}
+
+function consumeAscii(budget: JsonByteBudget, bytes: number): boolean {
+  budget.remaining -= bytes;
+  return budget.remaining < 0;
+}
+
+function consumeUtf8(budget: JsonByteBudget, value: string, jsonQuoted: boolean): boolean {
+  if (jsonQuoted && consumeAscii(budget, 1)) return true;
+  for (let index = 0; index < value.length; index += 1) {
+    const code = value.charCodeAt(index);
+    let bytes: number;
+    if (jsonQuoted && (code === 0x22 || code === 0x5c || code === 0x08 || code === 0x09
+      || code === 0x0a || code === 0x0c || code === 0x0d)) bytes = 2;
+    else if (jsonQuoted && code <= 0x1f) bytes = 6;
+    else if (code <= 0x7f) bytes = 1;
+    else if (code <= 0x7ff) bytes = 2;
+    else if (code >= 0xd800 && code <= 0xdbff) {
+      const next = value.charCodeAt(index + 1);
+      if (next >= 0xdc00 && next <= 0xdfff) {
+        bytes = 4;
+        index += 1;
+      } else bytes = jsonQuoted ? 6 : 3;
+    } else if (jsonQuoted && code >= 0xdc00 && code <= 0xdfff) bytes = 6;
+    else bytes = 3;
+    if (consumeAscii(budget, bytes)) return true;
+  }
+  return jsonQuoted ? consumeAscii(budget, 1) : false;
+}
+
+function formatFullToolInput(input: unknown): string {
+  if (typeof input === 'string') return input;
+  try {
+    return JSON.stringify(input, null, 2) ?? '';
+  } catch {
+    return String(input ?? '');
+  }
+}
+
+function limitText(value: string, maxChars: number): string {
+  if (value.length <= maxChars) return value;
+  return `${value.slice(0, Math.max(0, maxChars - 1))}…`;
+}

--- a/apps/mobile/src/session/remoteSessionStore.ts
+++ b/apps/mobile/src/session/remoteSessionStore.ts
@@ -63,6 +63,7 @@ import type { MobileSystemCardType } from '@/session/systemCard';
 import type { InputProjection, PendingInteraction, RemoteMessage, RemoteSession } from '@/session/types';
 import { clampLiveRowCreatedAt, compareMessageOrder, MESSAGE_PAGE_SIZE } from '@/session/messagePaging';
 import { normalizeRemoteMoney } from '@/session/remoteMoney';
+import { projectLargeSettledToolInputs } from '@/session/messageToolPayloadProjection';
 
 interface DeviceShard {
   deviceId: string;
@@ -1572,7 +1573,7 @@ function preserveSessionRuntimeFields(
 }
 
 function normalizeMessages(list: readonly RemoteMessage[]): RemoteMessage[] {
-  return [...list].sort(compareMessageOrder);
+  return projectLargeSettledToolInputs([...list].sort(compareMessageOrder));
 }
 
 function messageKey(message: RemoteMessage): string {

--- a/apps/mobile/src/session/types.ts
+++ b/apps/mobile/src/session/types.ts
@@ -2,6 +2,7 @@ import type { MobileSessionAgentSwitchIntent } from '@cindy/maker-shared/device-
 import type { AgentInputReference } from '@cindy/maker-shared/agent-input-projection';
 import type { RemoteMoney } from '@/session/remoteMoney';
 import type { MobileToolLoopErrorDetails } from '@/session/toolLoopErrorI18n';
+import type { MobileToolInputProjection } from '@/session/messageToolPayloadProjection';
 
 export type RemoteSessionStatus = 'active' | 'archived' | 'deleted';
 export type RemoteMessageRole =
@@ -114,6 +115,8 @@ export interface RemoteMessage {
   toolUseId: string | null;
   agentMeta: Record<string, unknown> | null;
   createdAt: string;
+  /** Large settled tool input released from the transcript mirror and recoverable by message id. */
+  mobileToolInputProjection?: MobileToolInputProjection;
   systemCardData?: Record<string, unknown>;
   systemCardType?: 'help' | 'context' | 'cost' | 'pwd' | 'status' | 'compact' | 'cmd' | 'goal-complete' | 'goal-resumed' | 'auto-resume' | 'learn' | 'agent-switch';
 }


### PR DESCRIPTION
## 这次改了什么

### 摘要

Mobile 长历史会把已经完成的普通工具输入全文长期保留在 JS Store 中。单个输入很大、历史里数量很多时，这些已经不再参与实时执行的 payload 会显著抬高驻留内存。

本 PR 只保留一层轻量投影：当普通工具输入超过 32KiB，且已经有精确匹配的 `tool_result` 时，Store 只保留最多 480 字符的摘要和工具身份；用户点“查看完整输入”时，再通过已有的 `messages:around(radius: 0)` 精确补取该条输入，全文只在当前弹层驻留，关闭后释放。

此前实验版用完整 `JSON.stringify` 判断大小并保存 `originalBytes`，极端批量加载时曾让 `seedMs` 上升 57.3%。最终实现改为有界 UTF-8 JSON 计数，跨过 32KiB 立即停止，并删除 `originalBytes`；最新同批 A/B 中 `seedMs` 从 1216.66ms 降至 1136.86ms（-6.6%），该回归已消除。

### 变更类型

- [ ] `feat` 新功能
- [ ] `fix` 缺陷修复
- [x] `refactor` / `perf` 重构或性能优化
- [ ] `docs` / `test` / `chore` 文档、测试或工程维护
- [ ] 其他：

### 范围

- 关联 Issue / 需求：Mobile 长任务工具 payload 内存治理第二批。
- 本 PR 包含：超过 32KiB 的已完成普通工具输入轻量投影；有界 UTF-8 JSON 大小判断；精确按需补取；加载、失败重试与五语文案；配对、阈值、结构工具排除、幂等、早停、恢复与 Store 集成测试。
- 明确不包含：历史分段驻留、历史补偿层、全局 payload LRU、工具结果投影、新 IPC、新 Device Link 协议或恢复策略。Agent、计划/Todo、Orca、diff 等结构工具输入保持原样。
- 用户可见变化：被投影的大型已完成普通工具行新增“查看完整输入”；小输入、运行中工具和结构工具的展示与交互不变。
- 是否存在 breaking change：无。投影只存在于 Mobile 内存镜像，不改变持久化或跨端 wire format。

### UI 变化

- 大型已完成普通工具行新增轻量查看入口，并覆盖 idle、loading、error/retry 状态；复用现有 payload 弹层，不改变消息气泡背景和布局规则。
- 引用的设计规范：`docs/design-rules/DESIGN.md` §10 Light / Dark Dual-Mode Delivery Gate；`apps/mobile/docs/mobile-design-guide.md` §1 视觉哲学、§2 颜色 token、§5 间距/圆角/触控。实现复用 `MessageContentOpenButton`，颜色全部走主题语义 token，圆角、间距、字号和 44pt 触控高度沿用既有 token。

## 怎么验证的

### 自动验证

```text
pnpm test:unit:related
结果：通过

pnpm --filter mobile run --if-present typecheck
结果：通过

pnpm --filter mobile exec vitest run src/__tests__/messageToolPayloadProjection.test.ts src/__tests__/messageNormalize.test.ts src/__tests__/remoteSessionStore.test.ts --pool=threads --maxWorkers=4
结果：通过，293/293

pnpm check:i18n-glossary
结果：通过，无新增术语违规

git diff --check
结果：通过

pnpm check:dco
结果：通过，1/1 commit 已签名
```

### 手工验证

在同一台 `cindy-api36` Android 模拟器上，对基线 `04dac2438` 与本 PR 各做 3 轮冷启动正式采样，取中位数。场景为 2002 行真实历史、100 个已完成 `WebFetch` 输入（每个 96KiB）和 250 次 40ms 间隔流式增量，使用正式 `remoteSessionStore + MessageRenderer + LegendList`。每轮强停应用后冷启动，并在界面就绪后清零 `gfxinfo`。

| 指标（3 轮中位数） | 基线 | 本 PR | 变化 |
|---|---:|---:|---:|
| `seedMs` | 1216.66ms | 1136.86ms | -6.6% |
| READY Store 驻留 | 19.89MiB | 1.17MiB | -94.1% |
| READY 总 PSS | 814.54MiB | 773.85MiB | -40.69MiB |
| 流式结束总 PSS | 860.28MiB | 815.54MiB | -44.74MiB |
| 初始 React commits | 18 | 17 | -5.6% |
| 初始 React 总耗时 | 488.59ms | 448.61ms | -8.2% |
| 初始 React P95 | 162.013ms | 129.545ms | -20.0% |
| 流式 React commits | 517 | 507 | -1.9% |
| 流式 React 总耗时 | 1859.21ms | 1850.96ms | -0.4% |
| 流式 React P95 | 11.885ms | 11.636ms | -2.1% |
| 进程 CPU | 85.27% | 85.73% | +0.46pp |
| Janky frames | 243 | 249 | +6 |
| Janky 比例 | 33.65% | 37.67% | +4.02pp |
| Android 帧 P95 | 65ms | 69ms | +4ms |

结论：`seedMs` 回归已消除，Store 驻留下降 94.1%，系统总 PSS 保留约 41–45MiB 收益。CPU 基本持平；Janky 的点估计略差，未观察到明确改善，因此本 PR 的价值是降低极端长历史的内存压力，不宣称流畅度收益。

正式采样在 `cindy/peaceful-darwin` worktree 与独立基线 worktree 中分别运行；临时 `__DEV__` 性能路由用于确认测试组和 Metro 归属，未进入提交，采样后已删除，Metro 已停止。

按需查看路径验证了精确 `toolUseId` / 消息 ID 配对、radius 0 补取、加载态、失败重试和弹层关闭后的局部释放。浅色模式随正式 A/B 页面检查；深色模式未单独做本轮实机目检，代码使用现有主题 token 覆盖。

### 未执行的验证

- 未运行全仓 `pnpm test:unit`：按仓库门禁使用 `pnpm test:unit:related`，完整单测由 CI 执行。
- 未在 iOS 真机/模拟器复测：改动不涉及原生层，正式性能结论限定为 Android 模拟器。
- 未单独进行 Dark 模式实机目检：新增样式全部复用主题语义 token，已如实保留该验证边界。

## 风险

### 风险分类

- [ ] 无已知风险
- [ ] SQLite / migration
- [ ] system prompt
- [ ] 协议兼容
- [ ] 权限 / 安全 / 用户数据
- [ ] 存量插件兼容（批准状态 / 指纹 / manifest 校验 / 安装布局 / 包格式）
- [ ] 原生层 / fingerprint / OTA
- [x] 跨平台差异
- [x] 其他：大型工具输入按需补取依赖被控端仍可返回对应消息；失败时保留重试入口。

### 影响与回滚

- 影响范围：仅 Mobile 内存镜像中超过 32KiB、已有精确结果配对且可恢复的普通工具输入。不可恢复、远端已截断、未持久化、运行中和结构工具输入不会投影。
- 回滚 / 降级方式：回退本提交即可恢复始终驻留全文的旧行为；运行时补取失败不会丢失当前摘要或结果，只显示可重试状态。
- 远程与手机版适配：会话数据不读取本机 `fs`，全文通过已有远程消息通道获取；无新增 IPC、push、allowlist 或 wire protocol；Mobile 入口和交互已在本 PR 内完成。未改 Device Link 重试、超时或断链恢复，故障半径三问不适用。
- 冷更判断：不涉及 `app.json`、`app.config.js`、`eas.json`、`apps/mobile/package.json`、lockfile、`plugins/`、`modules/` 或原生依赖，不改变 runtime fingerprint，不触发冷更。
- 跨平台说明：内存和 Janky 数据仅代表 Android 模拟器；iOS 未做性能外推。

### 提交前检查

- [x] 已 review 完整 diff
- [x] 每个 commit 都带 DCO 签名（`git commit -s`，见 [DCO](../DCO)）
- [x] UI 改动已在“UI 变化”注明引用的设计规范章节
- [x] 未提交凭证、令牌或授权文件
- [x] 已补充必要文档（本次无需新增独立文档，行为与边界由测试和 PR 描述记录）
- [x] 已确认测试结果或说明未执行原因