### PR TITLE
fix(desktop): preserve pasted paths in logs

### DIFF
--- a/apps/desktop/src/renderer/__tests__/pastePipeline.test.ts
+++ b/apps/desktop/src/renderer/__tests__/pastePipeline.test.ts
@@ -158,16 +158,30 @@ describe('segmentPastedContent — deep links', () => {
 });
 
 describe('segmentPastedContent — path candidates', () => {
-  it('emits path segments only for absolute paths inside the workingDir', () => {
+  it('keeps paths embedded in prose as literal text', () => {
     const inPath = `${WORKDIR}/apps/desktop/src/main.ts`;
     expect(
       segmentPastedContent(`报错在 ${inPath} 附近,系统文件 /etc/hosts 无关`, {
         workingDir: WORKDIR,
       }),
-    ).toEqual([
-      { kind: 'text', text: '报错在 ' },
+    ).toBeNull();
+  });
+
+  it('keeps multiline terminal output containing a Windows workspace path unchanged', () => {
+    const script = 'C:\\Code\\XDMaker\\scripts\\build.sh';
+    const output = `running build\n/bin/bash: ${script}: No such file or directory\nexit 127`;
+    expect(segmentPastedContent(output, { workingDir: WIN_WORKDIR })).toBeNull();
+  });
+
+  it('emits a path segment when the entire paste is one workspace path', () => {
+    const inPath = `${WORKDIR}/apps/desktop/src/main.ts`;
+    expect(segmentPastedContent(inPath, { workingDir: WORKDIR })).toEqual([
       { kind: 'path', path: inPath },
-      { kind: 'text', text: ' 附近,系统文件 /etc/hosts 无关' },
+    ]);
+    expect(segmentPastedContent(`  ${inPath}\n`, { workingDir: WORKDIR })).toEqual([
+      { kind: 'text', text: '  ' },
+      { kind: 'path', path: inPath },
+      { kind: 'text', text: '\n' },
     ]);
   });
 
@@ -181,54 +195,38 @@ describe('segmentPastedContent — path candidates', () => {
     expect(segmentPastedContent(`cd ${WORKDIR}/`, { workingDir: WORKDIR })).toBeNull();
   });
 
-  it('emits dir candidates without the trailing separator (review P2)', () => {
+  it('does not upgrade a path used as part of a shell command', () => {
     const dir = `${WORKDIR}/apps/desktop`;
-    expect(segmentPastedContent(`cd ${dir}/`, { workingDir: WORKDIR })).toEqual([
-      { kind: 'text', text: 'cd ' },
-      { kind: 'path', path: dir },
-      { kind: 'text', text: '/' },
-    ]);
+    expect(segmentPastedContent(`cd ${dir}/`, { workingDir: WORKDIR })).toBeNull();
   });
 
-  it('strips :line / :line:col suffixes from candidates', () => {
+  it('keeps a path with diagnostic suffix and prose as literal text', () => {
     const p = `${WORKDIR}/src/index.ts`;
-    expect(segmentPastedContent(`${p}:12:5 报错`, { workingDir: WORKDIR })).toEqual([
-      { kind: 'path', path: p },
-      { kind: 'text', text: ':12:5 报错' },
-    ]);
+    expect(segmentPastedContent(`${p}:12:5 报错`, { workingDir: WORKDIR })).toBeNull();
   });
 
   it('recognizes paths with CJK dir / file names (review P2)', () => {
     const cjkPath = `${WORKDIR}/文档/需求说明.md`;
-    expect(segmentPastedContent(`看 ${cjkPath} 这份`, { workingDir: WORKDIR })).toEqual([
-      { kind: 'text', text: '看 ' },
+    expect(segmentPastedContent(cjkPath, { workingDir: WORKDIR })).toEqual([
       { kind: 'path', path: cjkPath },
-      { kind: 'text', text: ' 这份' },
     ]);
     // 全角标点终止路径(， 全角逗号不吞进候选;ASCII 逗号是合法路径
     // 字符,紧贴场景按文档注释走「吞入候选 → stat miss 安全降级」)
-    expect(segmentPastedContent(`${cjkPath}，另外`, { workingDir: WORKDIR })).toEqual([
-      { kind: 'path', path: cjkPath },
-      { kind: 'text', text: '，另外' },
-    ]);
+    expect(segmentPastedContent(`${cjkPath}，另外`, { workingDir: WORKDIR })).toBeNull();
   });
 
   it('matches Windows paths case-insensitively against the workingDir', () => {
     const winPath = 'c:\\code\\xdmaker\\Apps\\main.ts';
-    expect(segmentPastedContent(`见 ${winPath} 一行`, { workingDir: WIN_WORKDIR })).toEqual([
-      { kind: 'text', text: '见 ' },
+    expect(segmentPastedContent(winPath, { workingDir: WIN_WORKDIR })).toEqual([
       { kind: 'path', path: winPath },
-      { kind: 'text', text: ' 一行' },
     ]);
   });
 
   it('matches Windows slash-form paths against a backslash workingDir (review P2)', () => {
     // Git Bash / Node 输出常用 C:/... 斜杠形态,workdir 存的是 C:\... 反斜杠形态。
     const slashPath = 'C:/Code/XDMaker/src/a.ts';
-    expect(segmentPastedContent(`见 ${slashPath} 一行`, { workingDir: WIN_WORKDIR })).toEqual([
-      { kind: 'text', text: '见 ' },
+    expect(segmentPastedContent(slashPath, { workingDir: WIN_WORKDIR })).toEqual([
       { kind: 'path', path: slashPath },
-      { kind: 'text', text: ' 一行' },
     ]);
     expect(toWorkdirRelativePath(slashPath, WIN_WORKDIR)).toBe('src/a.ts');
   });
@@ -237,14 +235,13 @@ describe('segmentPastedContent — path candidates', () => {
     expect(segmentPastedContent('/some/other/root/file.ts', { workingDir: WORKDIR })).toBeNull();
   });
 
-  it('scans paths inside the leftover text segments around deep links', () => {
+  it('keeps paths literal while still converting deep links in the same paste', () => {
     const p = `${WORKDIR}/README.md`;
     expect(
       segmentPastedContent(`${SESSION_URL} 里改了 ${p}`, { workingDir: WORKDIR }),
     ).toEqual([
       { kind: 'session', href: SESSION_URL, label: null },
-      { kind: 'text', text: ' 里改了 ' },
-      { kind: 'path', path: p },
+      { kind: 'text', text: ` 里改了 ${p}` },
     ]);
   });
 });

--- a/apps/desktop/src/renderer/__tests__/pastePipeline.test.ts
+++ b/apps/desktop/src/renderer/__tests__/pastePipeline.test.ts
@@ -185,6 +185,29 @@ describe('segmentPastedContent — path candidates', () => {
     ]);
   });
 
+  it.each([
+    [WORKDIR, `${WORKDIR}/apps/desktop`, '/'],
+    [WORKDIR, `${WORKDIR}/apps/desktop`, '///'],
+    [WIN_WORKDIR, 'C:\\Code\\XDMaker\\apps', '\\'],
+    [WIN_WORKDIR, 'C:\\Code\\XDMaker\\apps', '\\\\'],
+    [WIN_WORKDIR, 'c:/code/xdmaker/apps', '/'],
+  ])('recognizes standalone directory paths for %s: %s%s', (workingDir, dir, suffix) => {
+    expect(segmentPastedContent(`${dir}${suffix}`, { workingDir })).toEqual([
+      { kind: 'path', path: dir },
+    ]);
+    expect(segmentPastedContent(` \t${dir}${suffix}\r\n`, { workingDir })).toEqual([
+      { kind: 'text', text: ' \t' },
+      { kind: 'path', path: dir },
+      { kind: 'text', text: '\r\n' },
+    ]);
+    expect(segmentPastedContent(`${workingDir}${suffix}`, { workingDir })).toBeNull();
+    expect(segmentPastedContent(`cd ${dir}${suffix}`, { workingDir })).toBeNull();
+  });
+
+  it.each(['/:12', ':12/', '/)', ')/', '/,', ',/'])('keeps directory diagnostic suffix %s literal', (suffix) => {
+    expect(segmentPastedContent(`${WORKDIR}/apps${suffix}`, { workingDir: WORKDIR })).toBeNull();
+  });
+
   it('does not treat the workingDir itself as a path segment', () => {
     expect(segmentPastedContent(`目录是 ${WORKDIR} 本体`, { workingDir: WORKDIR })).toBeNull();
   });

--- a/apps/desktop/src/renderer/components/new-chat/ChatInput.tsx
+++ b/apps/desktop/src/renderer/components/new-chat/ChatInput.tsx
@@ -2269,10 +2269,11 @@ export function ChatInput({
           return true;
         }
 
-        // 2. 深链 / 路径混排 → text / session / project / path 分段:
+        // 2. 深链 / 独立路径 → text / session / project / path 分段:
         //    session、project 即时成 chip(session 裸链接先短 ID 占位,标题
-        //    异步原地补齐——sessionLinkPaste.ts);path 段先落纯文本,stat
-        //    确认存在后原地升级为 @chip(pathPaste.ts)。
+        //    异步原地补齐——sessionLinkPaste.ts);整段粘贴仅为一个工作区
+        //    绝对路径时,path 段先落纯文本,stat 确认存在后原地升级
+        //    为 @chip(pathPaste.ts);日志或叙述中的路径保持字面原文。
         const segments = text
           ? segmentPastedContent(text, { workingDir: workingDirRef.current })
           : null;

--- a/apps/desktop/src/renderer/components/new-chat/pastePipeline.ts
+++ b/apps/desktop/src/renderer/components/new-chat/pastePipeline.ts
@@ -4,8 +4,9 @@
  * ChatInput.handlePaste 对剪贴板文本按以下优先级走管线,命中即停:
  *   1. 长文本(isLongPasteText)→ 整段折叠为 PastedTextChip(长 log 里的
  *      深链 / 路径不再逐个 chip 化——那是噪音不是引用);
- *   2. 深链 / 路径混排(segmentPastedContent)→ text / session / project /
- *      path 分段:session、project 即时成 chip;path 段先落纯文本,由
+ *   2. 深链 / 独立路径(segmentPastedContent)→ text / session / project /
+ *      path 分段:session、project 即时成 chip;仅整段粘贴是一个路径时,
+ *      path 段先落纯文本,由
  *      pathPaste.ts 异步 stat 确认后原地升级(见该文件头注释);
  *   3. 都不命中 → null,调用方 fall through 到默认粘贴。
  *
@@ -155,7 +156,9 @@ export function toWorkdirRelativePath(candidate: string, workingDir: string): st
 /**
  * 把粘贴文本切成 text / session / project / path 段。没有任何可变换目标时
  * 返回 null(调用方走默认粘贴)。深链的 markdown 形式(`[标题](深链)`)
- * 优先于裸形式;路径候选在剩余 text 段上做第二遍扫描。
+ * 优先于裸形式;路径只在整段粘贴除首尾空白外是单个工作区内
+ * 绝对路径时识别。这样粘贴单个路径仍是明确的文件引用操作,终端日志、
+ * 错误信息与普通叙述中的字面路径则保持原样。
  */
 export function segmentPastedContent(
   text: string,
@@ -164,8 +167,7 @@ export function segmentPastedContent(
   const deepLinkSegments = segmentDeepLinks(text);
   const workingDir = options.workingDir?.trim() || null;
 
-  let segments: PastedContentSegment[] = deepLinkSegments ?? [{ kind: 'text', text }];
-  let matchedAny = deepLinkSegments != null;
+  if (deepLinkSegments) return deepLinkSegments;
 
   // 快速早退:文本里连 workdir 前缀都没有就不做逐段路径扫描。Windows 路径
   // 大小写不敏感且 `\` / `/` 两种分隔符形态并存(Git Bash / Node 输出斜杠
@@ -177,25 +179,14 @@ export function segmentPastedContent(
         (winLike ? workingDir.toLowerCase().replace(/\\/g, '/') : workingDir).replace(/[\\/]+$/, ''),
       )
     : false;
-  if (workingDir && containsWorkdir) {
-    const withPaths: PastedContentSegment[] = [];
-    for (const seg of segments) {
-      if (seg.kind !== 'text') {
-        withPaths.push(seg);
-        continue;
-      }
-      const pathSegs = segmentPathCandidates(seg.text, workingDir);
-      if (pathSegs) {
-        matchedAny = true;
-        withPaths.push(...pathSegs);
-      } else {
-        withPaths.push(seg);
-      }
-    }
-    segments = withPaths;
-  }
-
-  return matchedAny ? segments : null;
+  if (!workingDir || !containsWorkdir) return null;
+  const pathSegments = segmentPathCandidates(text, workingDir);
+  if (!pathSegments) return null;
+  const paths = pathSegments.filter((seg) => seg.kind === 'path');
+  const hasOnlySurroundingWhitespace = pathSegments.every(
+    (seg) => seg.kind === 'path' || (seg.kind === 'text' && seg.text.trim().length === 0),
+  );
+  return paths.length === 1 && hasOnlySurroundingWhitespace ? pathSegments : null;
 }
 
 /** 深链(session + project,裸 / markdown 两形态)分段;无命中 → null。 */

--- a/apps/desktop/src/renderer/components/new-chat/pastePipeline.ts
+++ b/apps/desktop/src/renderer/components/new-chat/pastePipeline.ts
@@ -274,6 +274,9 @@ function segmentPathCandidates(
     segments.push({ kind: 'path', path: trimmed });
     matchedAny = true;
     cursor = m.index + trimmed.length;
+    // 尾分隔符属于目录路径,不应作为非空白文本阻止独立路径识别。
+    // 只消费紧随路径的分隔符,诊断后缀和标点仍保留为文本。
+    cursor += /^[\\/]+/.exec(text.slice(cursor))?.[0].length ?? 0;
     PATH_CANDIDATE_RE.lastIndex = cursor;
   }
   if (!matchedAny) return null;


### PR DESCRIPTION
## 这次改了什么

### 摘要

收窄输入框的粘贴路径自动引用行为：只有整段粘贴除首尾空白外仅包含一个工作区内绝对路径时，才继续确认文件并升级为引用。终端日志、错误信息和普通叙述中混入的绝对路径保持字面原文，避免发送给模型时静默变成 `@相对路径`。

### 变更类型

- [x] `fix` 缺陷修复

### 范围

- 关联 Issue / 需求：Fixes #3846
- 本 PR 包含：粘贴路径识别边界调整；Windows 多行终端输出、混合文本、独立路径和深链混排回归测试；修复 Greptile 指出的目录尾分隔符识别问题，补充 Windows/POSIX、连续分隔符、周围空白及诊断后缀回归测试
- 明确不包含：文件引用的 `stat`、序列化和显式 `@`/拖拽入口改动
- 用户可见变化：日志和普通文本中的路径原样发送；单独粘贴路径仍生成文件引用
- 是否存在 breaking change：无

### UI 变化

- 引用的设计规范：不涉及：未修改视觉、布局、样式或 UI 文案，仅修正既有输入框的粘贴语义

## 怎么验证的

### 自动验证

```text
pnpm --filter desktop exec vitest run src/renderer/__tests__/pastePipeline.test.ts
结果：通过，44 tests

pnpm --filter desktop run --if-present typecheck
结果：通过

pnpm test:unit:related
结果：通过，apps/desktop related unit tests

pnpm check:dco -- --base origin/main --head HEAD
结果：通过，2 commits signed off
```

验证说明：修复提交接到 PR 来源基线后，已确认完整代码树与通过上述测试的版本一致；DCO 在最终提交上重新检查通过。

### 手工验证

不涉及：本次用纯函数回归测试覆盖 Issue 中的 Windows 终端输出输入形态。

### 未执行的验证

未启动 Desktop 做 GUI 手工验证；改动位于纯粘贴分段函数，已由定向与 related 单测覆盖。

## 风险

### 风险分类

- [x] 其他：输入框粘贴路径识别边界变化

### 影响与回滚

- 影响范围：Desktop 输入框中自动识别工作区绝对路径的粘贴流程
- 回滚 / 降级方式：回退本提交即可恢复混合文本内路径自动升级；不涉及持久化格式或数据迁移

### 提交前检查

- [x] 已 review 完整 diff
- [x] 每个 commit 都带 DCO 签名
- [x] UI 改动已在「UI 变化」注明不涉及视觉变化
- [x] 未提交凭证、令牌或授权文件
- [x] 已补充必要测试
- [x] 已确认测试结果