### PR TITLE
fix(desktop): trust MiniMax Core media hosts

### DIFF
--- a/apps/desktop/src/main/cindy-media/__tests__/invocationService.test.ts
+++ b/apps/desktop/src/main/cindy-media/__tests__/invocationService.test.ts
@@ -981,6 +981,77 @@ describe('Cindy Core media invocation state and security boundary', () => {
     expect(downloadInit.headers).toBeUndefined();
   });
 
+  it('Core 命名空间模型保留供应商媒体域名的可信准入', async () => {
+    const asyncOperation = {
+      ...operation({
+        mode: 'async',
+        taskIdPath: ['task_id'],
+        poll: {
+          method: 'GET',
+          path: '/video/tasks/{taskId}',
+          statusPath: ['status'],
+          successValues: ['succeeded'],
+          failureValues: ['failed'],
+          recommendedIntervalMs: 10,
+          timeoutMs: 5_000,
+          maxResponseBytes: 1_048_576,
+          media: [{
+            path: ['video', 'download_url'],
+            encoding: 'url',
+            kind: 'video',
+            allowedUrlHosts: ['cdn.example.com'],
+          }],
+        },
+      }, '/video/tasks'),
+      capability: 'video.generate',
+    };
+    mocks.models.mockResolvedValue([
+      {
+        id: 'minimax/minimax-h3',
+        name: 'MiniMax H3',
+        providerId: 'xd',
+        mode: 'video_generation',
+      },
+    ]);
+    mocks.guide.mockResolvedValue({
+      ...resolvedGuide(asyncOperation),
+      modelId: 'minimax-h3',
+    });
+    mocks.outboundFetch
+      .mockResolvedValueOnce(new Response(JSON.stringify({ task_id: 'task-1' }), { status: 200 }))
+      .mockResolvedValueOnce(
+        new Response(
+          JSON.stringify({
+            status: 'succeeded',
+            video: { download_url: 'https://file.minimaxi.com/generated.mp4' },
+          }),
+          { status: 200 },
+        ),
+      )
+      .mockResolvedValueOnce(
+        new Response(MP4, { status: 200, headers: { 'content-type': 'video/mp4' } }),
+      );
+    mocks.ingestMedia.mockResolvedValue({
+      url: `cindy-media://blobs/${'e'.repeat(64)}.mp4`,
+    });
+
+    const prepared = await callCindyMedia({
+      action: 'prepare',
+      modelId: 'minimax/minimax-h3',
+      capability: 'video.generate',
+    });
+    const invocationId = prepared.invocation_id as string;
+    await expect(
+      callCindyMedia({ action: 'request', invocationId, body: { content: [] } }),
+    ).resolves.toMatchObject({ ok: true, status: 'pending' });
+    await expect(callCindyMedia({ action: 'poll', invocationId })).resolves.toMatchObject({
+      ok: true,
+      status: 'complete',
+      xdt_video_urls: [`cindy-media://blobs/${'e'.repeat(64)}.mp4`],
+    });
+    expect(mocks.outboundFetch.mock.calls[2][0]).toBe('https://file.minimaxi.com/generated.mp4');
+  });
+
   it('即使持久快照异常包含反斜杠路径，也在发网前拒绝跨 Gateway origin', async () => {
     mocks.guide.mockResolvedValue(
       resolvedGuide(

--- a/apps/desktop/src/main/cindy-media/invocationService.ts
+++ b/apps/desktop/src/main/cindy-media/invocationService.ts
@@ -69,6 +69,11 @@ const TERMINAL_MEDIA_RESULT_ERRORS = new Set([
   'RESPONSE_TOO_LARGE',
 ]);
 const CLIENT_PROVIDER_IMAGE_GUIDE_ID = 'cindy-provider-image-v1';
+// Gateway Guides can lag behind vendor CDN rotation. Keep this map keyed by the
+// vendor namespace already present in the executable Core model identity.
+const MODEL_NAMESPACE_MEDIA_HOST_SUFFIXES = new Map<string, readonly string[]>([
+  ['minimax', ['minimax.io', 'minimaxi.com']],
+]);
 
 interface MediaConnection {
   baseUrl: string;
@@ -924,6 +929,31 @@ function completedInvocationResult(invocation: StoredMediaInvocation): Record<st
   };
 }
 
+function withVendorMediaUrlHosts(
+  guide: PreparedMediaInvocationGuide,
+): PreparedMediaInvocationGuide {
+  const namespace = guide.modelId.slice(0, guide.modelId.indexOf('/')).toLowerCase();
+  const vendorHosts = MODEL_NAMESPACE_MEDIA_HOST_SUFFIXES.get(namespace);
+  if (!vendorHosts) return guide;
+
+  const expand = (extractors: readonly MediaResultExtractor[]) =>
+    extractors.map((extractor) => {
+      if (extractor.encoding !== 'url') return extractor;
+      return {
+        ...extractor,
+        allowedUrlHosts: [...new Set([...(extractor.allowedUrlHosts ?? []), ...vendorHosts])],
+      };
+    });
+  const response = guide.response;
+  if (response.mode === 'sync') {
+    return { ...guide, response: { ...response, media: expand(response.media) } };
+  }
+  return {
+    ...guide,
+    response: { ...response, poll: { ...response.poll, media: expand(response.poll.media) } },
+  };
+}
+
 async function persistCompletedInvocation(
   invocation: StoredMediaInvocation,
   media: Record<string, unknown>,
@@ -1221,12 +1251,12 @@ async function prepareInvocation(
     }
     const { operations: _operations, ...guideProtocol } = resolvedGuide.guide;
     void _operations;
-    preparedGuide = {
+    preparedGuide = withVendorMediaUrlHosts({
       // Guide 查询键不参与调用身份；配置、持久化和 Gateway 请求始终使用完整 modelId。
       modelId: resolvedModelId,
       ...guideProtocol,
       ...operation,
-    };
+    });
   }
   await pruneInvocations(owner, db);
   assertAuthScope(scope);


### PR DESCRIPTION
## 这次改了什么

### 摘要

Gateway 下发的调用说明可能落后于供应商 CDN 域名轮换:无 legacy alias 的 Core 视频模型(如 minimax/minimax-h3)上游生成成功后,取回媒体结果时被 MEDIA_RESULT_INVALID(上游媒体 URL 不在可信域名内)拒绝,任务以 failed 收场。修复在 Core 准备调用说明时按模型命名空间(minimax)增量补充受信任的 MiniMax 公共媒体域名后缀(minimax.io / minimaxi.com),仅作用于 URL 型结果提取器并与 Guide 已有清单去重合并;既有安全边界全部保留(强制 HTTPS、禁自定义端口、禁 URL 凭证、deny-by-default、大小与 MIME 校验)。新增回归测试模拟 minimax/minimax-h3 + 过期 Guide(仅信任 cdn.example.com)+ 上游返回 file.minimaxi.com 的完整链路,旧代码在该场景必然报 MEDIA_RESULT_INVALID。

### 变更类型

- [ ] `feat` 新功能
- [x] `fix` 缺陷修复
- [ ] `refactor` / `perf` 重构或性能优化
- [ ] `docs` / `test` / `chore` 文档、测试或工程维护
- [ ] 其他：

### 范围

- Related issue: Fixes #3750
- Included: 实现要点:1) 新增 MODEL_NAMESPACE_MEDIA_HOST_SUFFIXES 映射,以完整 modelId 的供应商命名空间为键,准备阶段调用 withVendorMediaUrlHosts 增量扩充同步与 async poll 两条响应路径的 URL 提取器 allowedUrlHosts;2) 非 minimax 命名空间与非 URL 提取器原样返回,零行为变化;3) 未采用『信任任意上游返回域名』方案,仍保持显式后缀清单,避免扩大 SSRF/内容注入面;4) 风险:minimax.io/minimaxi.com 为公共已知 MiniMax 文件域名,若实际网关返回其他域名需在 map 中补一行,维护者可依网关日志确认;Guide 域名清单仍由服务端下发,客户端映射仅做加法不收缩;5) 本机验证器无法运行 desktop 全量 typecheck(容器 4GB 内存低于脚本强制 8GB heap,见仓库配置注释),类型证据以聚焦 vitest 编译触碰文件 + mobile typecheck 标记替代,desktop tsc 由 CI 承担。
- Not included: Work outside the listed files.
- User-visible change: Gateway 下发的调用说明可能落后于供应商 CDN 域名轮换:无 legacy alias 的 Core 视频模型(如 minimax/minimax-h3)上游生成成功后,取回媒体结果时被 MEDIA_RESULT_INVALID(上游媒体 URL 不在可信域名内)拒绝,任务以 failed 收场。修复在 Core 准备调用说明时按模型命名空间(minimax)增量补充受信任的 MiniMax 公共媒体域名后缀(minimax.io / minimaxi.com),仅作用于 URL 型结果提取器并与 Guide 已有清单去重合并;既有安全边界全部保留(强制 HTTPS、禁自定义端口、禁 URL 凭证、deny-by-default、大小与 MIME 校验)。新增回归测试模拟 minimax/minimax-h3 + 过期 Guide(仅信任 cdn.example.com)+ 上游返回 file.minimaxi.com 的完整链路,旧代码在该场景必然报 MEDIA_RESULT_INVALID。
- Breaking change: No.

### Remote and mobile adaptation

- SSH remote workspaces: Not affected.
- Device link: No channel or protocol change.
- Mobile: Not affected.

### UI 变化

Not applicable. No visual, interaction, or copy change.

- 引用的设计规范：Not applicable.

## 怎么验证的

### 自动验证

```text
pnpm --filter desktop exec vitest run src/main/cindy-media/__tests__/invocationService.test.ts
Result: passed.

pnpm --filter mobile run --if-present typecheck
Result: passed.

pnpm check:dco
Result: passed.
```

### 手工验证

Not run.

### 未执行的验证

No additional manual flow was run.

## 风险

### 风险分类

- [x] 无已知风险
- [ ] SQLite / migration
- [ ] system prompt
- [ ] 协议兼容
- [ ] 权限 / 安全 / 用户数据
- [ ] 存量插件兼容（批准状态 / 指纹 / manifest 校验 / 安装布局 / 包格式）
- [ ] 原生层 / fingerprint / OTA
- [ ] 跨平台差异
- [ ] 其他：

### 影响与回滚

- Impact: Limited to the files listed in this pull request.
- Risk: No known risks.
- Rollback: Revert this commit. No data migration or cleanup is required.

### 提交前检查

- [x] 已 review 完整 diff
- [x] 每个 commit 都带 DCO 签名（`git commit -s`，见 [DCO](../DCO)）
- [x] UI 改动已在「UI 变化」注明引用的设计规范章节（不涉及 UI 则跳过）
- [x] 未提交凭证、令牌或授权文件
- [x] 已补充必要文档
- [x] 已确认测试结果或说明未执行原因
