### PR TITLE
fix(desktop): 显示器变化后恢复主窗口最大化状态

### DIFF
--- a/apps/desktop/src/main/__tests__/mainWindowMaximizeRecovery.test.ts
+++ b/apps/desktop/src/main/__tests__/mainWindowMaximizeRecovery.test.ts
@@ -548,6 +548,17 @@ describe('installMainWindowNativeRestoreIntent', () => {
         modifiers: [],
       },
     );
+    expect(() =>
+      windows.webContentsListeners.get('before-input-event')?.(
+        {},
+        {
+          type: 'keyDown',
+          key: 'a',
+          meta: false,
+          isAutoRepeat: false,
+        },
+      ),
+    ).not.toThrow();
     windows.webContentsListeners.get('before-input-event')?.(
       {},
       {

--- a/apps/desktop/src/main/__tests__/mainWindowMaximizeRecovery.test.ts
+++ b/apps/desktop/src/main/__tests__/mainWindowMaximizeRecovery.test.ts
@@ -244,7 +244,7 @@ describe('installMainWindowMaximizeRecovery', () => {
     h.runTimers();
     h.advance(1_000);
     h.osUnmaximize();
-    h.recovery.notifyUserUnmaximizeIntent();
+    h.recovery.notifyUserUnmaximizeIntent('after-unmaximize');
     h.runTimers();
 
     expect(h.win.maximize).not.toHaveBeenCalled();
@@ -252,6 +252,20 @@ describe('installMainWindowMaximizeRecovery', () => {
     h.fireDisplay();
     h.runTimers();
     expect(h.win.maximize).not.toHaveBeenCalled();
+  });
+
+  it('does not pair a late title-bar intent with an earlier OS unmaximize', () => {
+    const h = createHarness();
+    h.state.maximized = true;
+
+    h.fireDisplay();
+    h.runTimers();
+    h.advance(1_000);
+    h.osUnmaximize();
+    h.recovery.notifyUserUnmaximizeIntent('before-unmaximize');
+    h.runTimers();
+
+    expect(h.win.maximize).toHaveBeenCalledOnce();
   });
 
   it('disarms after the user unmaximizes away from any display change', () => {

--- a/apps/desktop/src/main/__tests__/mainWindowMaximizeRecovery.test.ts
+++ b/apps/desktop/src/main/__tests__/mainWindowMaximizeRecovery.test.ts
@@ -2,8 +2,10 @@ import { describe, expect, it, vi } from 'vitest';
 
 import {
   installMainWindowMaximizeRecovery,
+  installMainWindowNativeRestoreIntent,
   readPersistedWindowMaximized,
   type DisplayChangeEvent,
+  type MaximizeRecoveryNativeWindow,
 } from '../mainWindowMaximizeRecovery';
 
 describe('readPersistedWindowMaximized', () => {
@@ -288,5 +290,136 @@ describe('installMainWindowMaximizeRecovery', () => {
     again.dispose();
     again.runTimers();
     expect(again.win.maximize).not.toHaveBeenCalled();
+  });
+});
+
+describe('installMainWindowNativeRestoreIntent', () => {
+  function createNativeHarness() {
+    type Listener = (...args: unknown[]) => void;
+    const windowListeners = new Map<string, Listener>();
+    const webContentsListeners = new Map<string, Listener>();
+    const removeListener = vi.fn((event: string) => windowListeners.delete(event));
+    const removeWebContentsListener = vi.fn((event: string) => webContentsListeners.delete(event));
+    const win = {
+      isDestroyed: () => false,
+      isVisible: () => true,
+      isMaximized: () => true,
+      isMinimized: () => false,
+      isFullScreen: () => false,
+      maximize: vi.fn(),
+      on: vi.fn((event: string, listener: Listener) => windowListeners.set(event, listener)),
+      removeListener,
+      webContents: {
+        on: vi.fn((event: string, listener: Listener) => webContentsListeners.set(event, listener)),
+        removeListener: removeWebContentsListener,
+      },
+    } as unknown as MaximizeRecoveryNativeWindow;
+    return {
+      win,
+      windowListeners,
+      webContentsListeners,
+      removeListener,
+      removeWebContentsListener,
+    };
+  }
+
+  it('marks Windows native restore gestures before unmaximize', () => {
+    const h = createNativeHarness();
+    const notify = vi.fn();
+    const dispose = installMainWindowNativeRestoreIntent(h.win, notify, 'win32');
+
+    h.windowListeners.get('will-move')?.();
+    h.windowListeners.get('will-resize')?.();
+    h.webContentsListeners.get('before-mouse-event')?.(
+      {},
+      {
+        type: 'mouseDown',
+        button: 'left',
+        clickCount: 2,
+        y: 24,
+      },
+    );
+    h.webContentsListeners.get('before-input-event')?.(
+      {},
+      {
+        type: 'keyDown',
+        key: 'ArrowDown',
+        meta: true,
+        isAutoRepeat: false,
+        modifiers: ['meta'],
+      },
+    );
+
+    expect(notify).toHaveBeenCalledTimes(4);
+
+    dispose();
+    expect(h.removeListener).toHaveBeenCalledWith('will-move', expect.any(Function));
+    expect(h.removeListener).toHaveBeenCalledWith('will-resize', expect.any(Function));
+    expect(h.removeWebContentsListener).toHaveBeenCalledWith(
+      'before-mouse-event',
+      expect.any(Function),
+    );
+    expect(h.removeWebContentsListener).toHaveBeenCalledWith(
+      'before-input-event',
+      expect.any(Function),
+    );
+    expect(h.windowListeners.size).toBe(0);
+    expect(h.webContentsListeners.size).toBe(0);
+  });
+
+  it('ignores unrelated input and non-Windows platforms', () => {
+    const h = createNativeHarness();
+    const notify = vi.fn();
+    const dispose = installMainWindowNativeRestoreIntent(h.win, notify, 'darwin');
+
+    expect(h.windowListeners.size).toBe(0);
+    expect(h.webContentsListeners.size).toBe(0);
+
+    dispose();
+    expect(notify).not.toHaveBeenCalled();
+
+    const windows = createNativeHarness();
+    const windowsNotify = vi.fn();
+    installMainWindowNativeRestoreIntent(windows.win, windowsNotify, 'win32');
+    windows.webContentsListeners.get('before-mouse-event')?.(
+      {},
+      {
+        type: 'mouseDown',
+        button: 'right',
+        clickCount: 2,
+        y: 24,
+      },
+    );
+    windows.webContentsListeners.get('before-mouse-event')?.(
+      {},
+      {
+        type: 'mouseDown',
+        button: 'left',
+        clickCount: 2,
+        y: 60,
+      },
+    );
+    windows.webContentsListeners.get('before-input-event')?.(
+      {},
+      {
+        type: 'keyDown',
+        key: 'ArrowDown',
+        meta: false,
+        isAutoRepeat: false,
+        modifiers: [],
+      },
+    );
+    windows.webContentsListeners.get('before-input-event')?.(
+      {},
+      {
+        type: 'keyDown',
+        key: 'ArrowDown',
+        meta: true,
+        isAutoRepeat: true,
+        modifiers: ['meta'],
+      },
+    );
+
+    expect(windowsNotify).not.toHaveBeenCalled();
   });
 });

--- a/apps/desktop/src/main/__tests__/mainWindowMaximizeRecovery.test.ts
+++ b/apps/desktop/src/main/__tests__/mainWindowMaximizeRecovery.test.ts
@@ -88,7 +88,7 @@ function createHarness(options: { armed?: boolean } = {}) {
     windowListeners.get('unmaximize')?.();
   };
   const userUnmaximize = (): void => {
-    recovery.notifyUserUnmaximize();
+    recovery.notifyUserUnmaximizeIntent();
     state.maximized = false;
     windowListeners.get('unmaximize')?.();
   };
@@ -211,6 +211,40 @@ describe('installMainWindowMaximizeRecovery', () => {
 
     h.fireDisplay();
     h.userUnmaximize();
+    h.runTimers();
+
+    expect(h.win.maximize).not.toHaveBeenCalled();
+
+    h.fireDisplay();
+    h.runTimers();
+    expect(h.win.maximize).not.toHaveBeenCalled();
+  });
+
+  it('keeps recovery armed when a native restore intent is not followed by unmaximize', () => {
+    const h = createHarness();
+    h.state.maximized = true;
+
+    h.fireDisplay();
+    h.runTimers();
+    expect(h.win.maximize).not.toHaveBeenCalled();
+
+    h.recovery.notifyUserUnmaximizeIntent();
+    h.advance(600);
+    h.osUnmaximize();
+    h.runTimers();
+
+    expect(h.win.maximize).toHaveBeenCalledOnce();
+  });
+
+  it('cancels a late OS re-apply when native restore intent follows unmaximize', () => {
+    const h = createHarness();
+    h.state.maximized = true;
+
+    h.fireDisplay();
+    h.runTimers();
+    h.advance(1_000);
+    h.osUnmaximize();
+    h.recovery.notifyUserUnmaximizeIntent();
     h.runTimers();
 
     expect(h.win.maximize).not.toHaveBeenCalled();

--- a/apps/desktop/src/main/__tests__/mainWindowMaximizeRecovery.test.ts
+++ b/apps/desktop/src/main/__tests__/mainWindowMaximizeRecovery.test.ts
@@ -297,6 +297,21 @@ describe('installMainWindowMaximizeRecovery', () => {
     expect(h.win.maximize).toHaveBeenCalledOnce();
   });
 
+  it('keeps a native intent created during a display burst across later events', () => {
+    const h = createHarness();
+    h.state.maximized = true;
+
+    h.fireDisplay();
+    h.advance(100);
+    h.recovery.notifyUserUnmaximizeIntent();
+    h.advance(100);
+    h.fireDisplay();
+    h.osUnmaximize();
+    h.runTimers();
+
+    expect(h.win.maximize).not.toHaveBeenCalled();
+  });
+
   it('disarms after the user unmaximizes away from any display change', () => {
     const h = createHarness();
     h.state.maximized = true;

--- a/apps/desktop/src/main/__tests__/mainWindowMaximizeRecovery.test.ts
+++ b/apps/desktop/src/main/__tests__/mainWindowMaximizeRecovery.test.ts
@@ -312,6 +312,21 @@ describe('installMainWindowMaximizeRecovery', () => {
     expect(h.win.maximize).not.toHaveBeenCalled();
   });
 
+  it('expires a native intent before a later display burst', () => {
+    const h = createHarness();
+    h.state.maximized = true;
+
+    h.fireDisplay();
+    h.advance(2_500);
+    h.recovery.notifyUserUnmaximizeIntent();
+    h.advance(100);
+    h.fireDisplay();
+    h.osUnmaximize();
+    h.runTimers();
+
+    expect(h.win.maximize).toHaveBeenCalledOnce();
+  });
+
   it('disarms after the user unmaximizes away from any display change', () => {
     const h = createHarness();
     h.state.maximized = true;

--- a/apps/desktop/src/main/__tests__/mainWindowMaximizeRecovery.test.ts
+++ b/apps/desktop/src/main/__tests__/mainWindowMaximizeRecovery.test.ts
@@ -110,6 +110,10 @@ function createHarness(options: { armed?: boolean } = {}) {
     state.minimized = false;
     windowListeners.get('restore')?.();
   };
+  const leaveFullscreen = (): void => {
+    state.fullscreen = false;
+    windowListeners.get('leave-full-screen')?.();
+  };
 
   return {
     state,
@@ -126,6 +130,7 @@ function createHarness(options: { armed?: boolean } = {}) {
     userUnmaximize,
     showWindow,
     restoreWindow,
+    leaveFullscreen,
     windowListeners,
     screenListeners,
   };
@@ -314,6 +319,23 @@ describe('installMainWindowMaximizeRecovery', () => {
     expect(h.win.maximize).toHaveBeenCalledOnce();
   });
 
+  it('retries after leaving fullscreen when a display recovery was pending', () => {
+    const h = createHarness();
+    h.state.maximized = true;
+    h.state.fullscreen = true;
+
+    h.fireDisplay();
+    h.runTimers();
+    h.osUnmaximize();
+    h.runTimers();
+    expect(h.win.maximize).not.toHaveBeenCalled();
+
+    h.leaveFullscreen();
+    h.runTimers();
+
+    expect(h.win.maximize).toHaveBeenCalledOnce();
+  });
+
   it('re-arms when the user maximizes again', () => {
     const h = createHarness({ armed: false });
 
@@ -337,6 +359,7 @@ describe('installMainWindowMaximizeRecovery', () => {
     expect(h.win.removeListener).toHaveBeenCalledWith('unmaximize', expect.any(Function));
     expect(h.win.removeListener).toHaveBeenCalledWith('show', expect.any(Function));
     expect(h.win.removeListener).toHaveBeenCalledWith('restore', expect.any(Function));
+    expect(h.win.removeListener).toHaveBeenCalledWith('leave-full-screen', expect.any(Function));
     expect(h.screenListeners.size).toBe(0);
 
     h.fireDisplay();

--- a/apps/desktop/src/main/__tests__/mainWindowMaximizeRecovery.test.ts
+++ b/apps/desktop/src/main/__tests__/mainWindowMaximizeRecovery.test.ts
@@ -54,7 +54,7 @@ function createHarness(options: { armed?: boolean } = {}) {
   };
   const log = { info: vi.fn() };
 
-  const dispose = installMainWindowMaximizeRecovery(win, screen, {
+  const recovery = installMainWindowMaximizeRecovery(win, screen, {
     armed: options.armed ?? true,
     log,
     now: () => nowMs,
@@ -85,8 +85,28 @@ function createHarness(options: { armed?: boolean } = {}) {
     state.maximized = false;
     windowListeners.get('unmaximize')?.();
   };
+  const userUnmaximize = (): void => {
+    recovery.notifyUserUnmaximize();
+    state.maximized = false;
+    windowListeners.get('unmaximize')?.();
+  };
 
-  return { state, win, screen, log, timers, dispose, runTimers, advance, fireDisplay, osUnmaximize, windowListeners, screenListeners };
+  return {
+    state,
+    win,
+    screen,
+    log,
+    timers,
+    recovery,
+    dispose: recovery.dispose,
+    runTimers,
+    advance,
+    fireDisplay,
+    osUnmaximize,
+    userUnmaximize,
+    windowListeners,
+    screenListeners,
+  };
 }
 
 describe('installMainWindowMaximizeRecovery', () => {
@@ -156,6 +176,21 @@ describe('installMainWindowMaximizeRecovery', () => {
     h.osUnmaximize();
     h.runTimers();
     expect(h.win.maximize).toHaveBeenCalledTimes(2);
+  });
+
+  it('honors an explicit user restore during the display-change grace window', () => {
+    const h = createHarness();
+    h.state.maximized = true;
+
+    h.fireDisplay();
+    h.userUnmaximize();
+    h.runTimers();
+
+    expect(h.win.maximize).not.toHaveBeenCalled();
+
+    h.fireDisplay();
+    h.runTimers();
+    expect(h.win.maximize).not.toHaveBeenCalled();
   });
 
   it('disarms after the user unmaximizes away from any display change', () => {

--- a/apps/desktop/src/main/__tests__/mainWindowMaximizeRecovery.test.ts
+++ b/apps/desktop/src/main/__tests__/mainWindowMaximizeRecovery.test.ts
@@ -1,0 +1,208 @@
+import { describe, expect, it, vi } from 'vitest';
+
+import {
+  installMainWindowMaximizeRecovery,
+  readPersistedWindowMaximized,
+  type DisplayChangeEvent,
+} from '../mainWindowMaximizeRecovery';
+
+describe('readPersistedWindowMaximized', () => {
+  it('reads the flag from the raw window-state file', () => {
+    const read = vi.fn(() => JSON.stringify({ width: 1280, height: 812, isMaximized: true }));
+    expect(readPersistedWindowMaximized('state.json', read)).toBe(true);
+    expect(read).toHaveBeenCalledWith('state.json', 'utf8');
+  });
+
+  it('is false for a windowed, malformed or missing file', () => {
+    expect(readPersistedWindowMaximized('x', () => JSON.stringify({ isMaximized: false }))).toBe(false);
+    expect(readPersistedWindowMaximized('x', () => JSON.stringify({ isMaximized: 'yes' }))).toBe(false);
+    expect(readPersistedWindowMaximized('x', () => '[]')).toBe(false);
+    expect(readPersistedWindowMaximized('x', () => 'not json')).toBe(false);
+    expect(
+      readPersistedWindowMaximized('x', () => {
+        throw new Error('ENOENT');
+      }),
+    ).toBe(false);
+  });
+});
+
+type Timer = { callback: () => void; ms: number; cleared: boolean };
+
+function createHarness(options: { armed?: boolean } = {}) {
+  let nowMs = 0;
+  const timers: Timer[] = [];
+  const windowListeners = new Map<string, () => void>();
+  const screenListeners = new Map<string, () => void>();
+  const state = { visible: true, maximized: false, minimized: false, fullscreen: false, destroyed: false };
+
+  const win = {
+    isDestroyed: () => state.destroyed,
+    isVisible: () => state.visible,
+    isMaximized: () => state.maximized,
+    isMinimized: () => state.minimized,
+    isFullScreen: () => state.fullscreen,
+    maximize: vi.fn(() => {
+      state.maximized = true;
+      windowListeners.get('maximize')?.();
+    }),
+    on: vi.fn((event: string, listener: () => void) => windowListeners.set(event, listener)),
+    removeListener: vi.fn((event: string) => windowListeners.delete(event)),
+  };
+  const screen = {
+    on: vi.fn((event: string, listener: () => void) => screenListeners.set(event, listener)),
+    removeListener: vi.fn((event: string) => screenListeners.delete(event)),
+  };
+  const log = { info: vi.fn() };
+
+  const dispose = installMainWindowMaximizeRecovery(win, screen, {
+    armed: options.armed ?? true,
+    log,
+    now: () => nowMs,
+    setTimer: (callback, ms) => {
+      const timer: Timer = { callback, ms, cleared: false };
+      timers.push(timer);
+      return timer;
+    },
+    clearTimer: (handle) => {
+      (handle as Timer).cleared = true;
+    },
+    settleMs: 300,
+    graceMs: 2_000,
+  });
+
+  const runTimers = (): void => {
+    for (const timer of timers.splice(0)) {
+      if (!timer.cleared) timer.callback();
+    }
+  };
+  const advance = (ms: number): void => {
+    nowMs += ms;
+  };
+  const fireDisplay = (event: DisplayChangeEvent = 'display-metrics-changed'): void => {
+    screenListeners.get(event)?.();
+  };
+  const osUnmaximize = (): void => {
+    state.maximized = false;
+    windowListeners.get('unmaximize')?.();
+  };
+
+  return { state, win, screen, log, timers, dispose, runTimers, advance, fireDisplay, osUnmaximize, windowListeners, screenListeners };
+}
+
+describe('installMainWindowMaximizeRecovery', () => {
+  it('re-maximizes a windowed main window after the display settles', () => {
+    const h = createHarness();
+
+    h.fireDisplay('display-added');
+    expect(h.win.maximize).not.toHaveBeenCalled();
+    expect(h.timers.at(-1)?.ms).toBe(300);
+
+    h.runTimers();
+    expect(h.win.maximize).toHaveBeenCalledOnce();
+    expect(h.log.info).toHaveBeenCalledWith('re-applying maximized state after display change');
+  });
+
+  it('coalesces a burst of display events into a single re-apply', () => {
+    const h = createHarness();
+
+    h.fireDisplay('display-removed');
+    h.fireDisplay('display-added');
+    h.fireDisplay('display-metrics-changed');
+    h.runTimers();
+
+    expect(h.win.maximize).toHaveBeenCalledOnce();
+  });
+
+  it('does nothing while the window is already maximized', () => {
+    const h = createHarness();
+    h.state.maximized = true;
+
+    h.fireDisplay();
+    h.runTimers();
+
+    expect(h.win.maximize).not.toHaveBeenCalled();
+  });
+
+  it.each([
+    ['hidden', { visible: false }],
+    ['minimized', { minimized: true }],
+    ['fullscreen', { fullscreen: true }],
+    ['destroyed', { destroyed: true }],
+  ])('leaves a %s window alone', (_label, patch) => {
+    const h = createHarness();
+    Object.assign(h.state, patch);
+
+    h.fireDisplay();
+    h.runTimers();
+
+    expect(h.win.maximize).not.toHaveBeenCalled();
+  });
+
+  it('keeps recovery armed when the OS unmaximizes right around a display change', () => {
+    const h = createHarness();
+    h.state.maximized = true;
+
+    // Unmaximize first (Windows re-layout), display event shortly after.
+    h.osUnmaximize();
+    h.advance(500);
+    h.fireDisplay();
+    h.runTimers();
+    expect(h.win.maximize).toHaveBeenCalledOnce();
+
+    // Display event first, unmaximize inside the grace window.
+    h.advance(10_000);
+    h.fireDisplay();
+    h.advance(1_000);
+    h.osUnmaximize();
+    h.runTimers();
+    expect(h.win.maximize).toHaveBeenCalledTimes(2);
+  });
+
+  it('disarms after the user unmaximizes away from any display change', () => {
+    const h = createHarness();
+    h.state.maximized = true;
+
+    h.advance(60_000);
+    h.osUnmaximize();
+    h.advance(2_000);
+    h.runTimers();
+
+    h.fireDisplay();
+    h.runTimers();
+    expect(h.win.maximize).not.toHaveBeenCalled();
+  });
+
+  it('re-arms when the user maximizes again', () => {
+    const h = createHarness({ armed: false });
+
+    h.fireDisplay();
+    h.runTimers();
+    expect(h.win.maximize).not.toHaveBeenCalled();
+
+    h.windowListeners.get('maximize')?.();
+    h.state.maximized = false;
+    h.fireDisplay();
+    h.runTimers();
+    expect(h.win.maximize).toHaveBeenCalledOnce();
+  });
+
+  it('tears down its listeners on close and on dispose', () => {
+    const h = createHarness();
+    h.windowListeners.get('closed')?.();
+
+    expect(h.screen.removeListener).toHaveBeenCalledTimes(3);
+    expect(h.win.removeListener).toHaveBeenCalledWith('maximize', expect.any(Function));
+    expect(h.win.removeListener).toHaveBeenCalledWith('unmaximize', expect.any(Function));
+    expect(h.screenListeners.size).toBe(0);
+
+    h.fireDisplay();
+    h.runTimers();
+    expect(h.win.maximize).not.toHaveBeenCalled();
+
+    const again = createHarness();
+    again.fireDisplay();
+    again.dispose();
+    again.runTimers();
+    expect(again.win.maximize).not.toHaveBeenCalled();
+  });
+});

--- a/apps/desktop/src/main/__tests__/mainWindowMaximizeRecovery.test.ts
+++ b/apps/desktop/src/main/__tests__/mainWindowMaximizeRecovery.test.ts
@@ -283,6 +283,20 @@ describe('installMainWindowMaximizeRecovery', () => {
     expect(h.win.maximize).toHaveBeenCalledOnce();
   });
 
+  it('does not let a pre-display native intent confirm the display re-layout', () => {
+    const h = createHarness();
+    h.state.maximized = true;
+
+    h.recovery.notifyUserUnmaximizeIntent();
+    h.advance(100);
+    h.fireDisplay();
+    h.runTimers();
+    h.osUnmaximize();
+    h.runTimers();
+
+    expect(h.win.maximize).toHaveBeenCalledOnce();
+  });
+
   it('disarms after the user unmaximizes away from any display change', () => {
     const h = createHarness();
     h.state.maximized = true;

--- a/apps/desktop/src/main/__tests__/mainWindowMaximizeRecovery.test.ts
+++ b/apps/desktop/src/main/__tests__/mainWindowMaximizeRecovery.test.ts
@@ -90,6 +90,14 @@ function createHarness(options: { armed?: boolean } = {}) {
     state.maximized = false;
     windowListeners.get('unmaximize')?.();
   };
+  const showWindow = (): void => {
+    state.visible = true;
+    windowListeners.get('show')?.();
+  };
+  const restoreWindow = (): void => {
+    state.minimized = false;
+    windowListeners.get('restore')?.();
+  };
 
   return {
     state,
@@ -104,6 +112,8 @@ function createHarness(options: { armed?: boolean } = {}) {
     fireDisplay,
     osUnmaximize,
     userUnmaximize,
+    showWindow,
+    restoreWindow,
     windowListeners,
     screenListeners,
   };
@@ -178,6 +188,21 @@ describe('installMainWindowMaximizeRecovery', () => {
     expect(h.win.maximize).toHaveBeenCalledTimes(2);
   });
 
+  it('retries when the OS unmaximizes after the first settle timer', () => {
+    const h = createHarness();
+    h.state.maximized = true;
+
+    h.fireDisplay();
+    h.runTimers();
+    expect(h.win.maximize).not.toHaveBeenCalled();
+
+    h.advance(1_000);
+    h.osUnmaximize();
+    h.runTimers();
+
+    expect(h.win.maximize).toHaveBeenCalledOnce();
+  });
+
   it('honors an explicit user restore during the display-change grace window', () => {
     const h = createHarness();
     h.state.maximized = true;
@@ -207,6 +232,28 @@ describe('installMainWindowMaximizeRecovery', () => {
     expect(h.win.maximize).not.toHaveBeenCalled();
   });
 
+  it.each([
+    ['hidden', { visible: false }, 'showWindow'],
+    ['minimized', { minimized: true }, 'restoreWindow'],
+  ])('retries after a %s window becomes available', (_label, patch, makeAvailable) => {
+    const h = createHarness();
+    h.state.maximized = true;
+    Object.assign(h.state, patch);
+
+    h.fireDisplay();
+    h.runTimers();
+    expect(h.win.maximize).not.toHaveBeenCalled();
+
+    h.osUnmaximize();
+    h.runTimers();
+    h.state.maximized = false;
+    if (makeAvailable === 'showWindow') h.showWindow();
+    else h.restoreWindow();
+    h.runTimers();
+
+    expect(h.win.maximize).toHaveBeenCalledOnce();
+  });
+
   it('re-arms when the user maximizes again', () => {
     const h = createHarness({ armed: false });
 
@@ -228,6 +275,8 @@ describe('installMainWindowMaximizeRecovery', () => {
     expect(h.screen.removeListener).toHaveBeenCalledTimes(3);
     expect(h.win.removeListener).toHaveBeenCalledWith('maximize', expect.any(Function));
     expect(h.win.removeListener).toHaveBeenCalledWith('unmaximize', expect.any(Function));
+    expect(h.win.removeListener).toHaveBeenCalledWith('show', expect.any(Function));
+    expect(h.win.removeListener).toHaveBeenCalledWith('restore', expect.any(Function));
     expect(h.screenListeners.size).toBe(0);
 
     h.fireDisplay();

--- a/apps/desktop/src/main/__tests__/mainWindowMaximizeRecovery.test.ts
+++ b/apps/desktop/src/main/__tests__/mainWindowMaximizeRecovery.test.ts
@@ -16,8 +16,12 @@ describe('readPersistedWindowMaximized', () => {
   });
 
   it('is false for a windowed, malformed or missing file', () => {
-    expect(readPersistedWindowMaximized('x', () => JSON.stringify({ isMaximized: false }))).toBe(false);
-    expect(readPersistedWindowMaximized('x', () => JSON.stringify({ isMaximized: 'yes' }))).toBe(false);
+    expect(readPersistedWindowMaximized('x', () => JSON.stringify({ isMaximized: false }))).toBe(
+      false,
+    );
+    expect(readPersistedWindowMaximized('x', () => JSON.stringify({ isMaximized: 'yes' }))).toBe(
+      false,
+    );
     expect(readPersistedWindowMaximized('x', () => '[]')).toBe(false);
     expect(readPersistedWindowMaximized('x', () => 'not json')).toBe(false);
     expect(
@@ -35,7 +39,13 @@ function createHarness(options: { armed?: boolean } = {}) {
   const timers: Timer[] = [];
   const windowListeners = new Map<string, () => void>();
   const screenListeners = new Map<string, () => void>();
-  const state = { visible: true, maximized: false, minimized: false, fullscreen: false, destroyed: false };
+  const state = {
+    visible: true,
+    maximized: false,
+    minimized: false,
+    fullscreen: false,
+    destroyed: false,
+  };
 
   const win = {
     isDestroyed: () => state.destroyed,
@@ -346,8 +356,10 @@ describe('installMainWindowNativeRestoreIntent', () => {
     type Listener = (...args: unknown[]) => void;
     const windowListeners = new Map<string, Listener>();
     const webContentsListeners = new Map<string, Listener>();
+    const windowMessageListeners = new Map<number, (wParam: Buffer, lParam: Buffer) => void>();
     const removeListener = vi.fn((event: string) => windowListeners.delete(event));
     const removeWebContentsListener = vi.fn((event: string) => webContentsListeners.delete(event));
+    const unhookWindowMessage = vi.fn((message: number) => windowMessageListeners.delete(message));
     const win = {
       isDestroyed: () => false,
       isVisible: () => true,
@@ -357,6 +369,11 @@ describe('installMainWindowNativeRestoreIntent', () => {
       maximize: vi.fn(),
       on: vi.fn((event: string, listener: Listener) => windowListeners.set(event, listener)),
       removeListener,
+      hookWindowMessage: vi.fn(
+        (message: number, listener: (wParam: Buffer, lParam: Buffer) => void) =>
+          windowMessageListeners.set(message, listener),
+      ),
+      unhookWindowMessage,
       webContents: {
         on: vi.fn((event: string, listener: Listener) => webContentsListeners.set(event, listener)),
         removeListener: removeWebContentsListener,
@@ -366,8 +383,10 @@ describe('installMainWindowNativeRestoreIntent', () => {
       win,
       windowListeners,
       webContentsListeners,
+      windowMessageListeners,
       removeListener,
       removeWebContentsListener,
+      unhookWindowMessage,
     };
   }
 
@@ -397,8 +416,11 @@ describe('installMainWindowNativeRestoreIntent', () => {
         modifiers: ['meta'],
       },
     );
+    const restoreCommand = Buffer.alloc(8);
+    restoreCommand.writeUInt32LE(0xf120, 0);
+    h.windowMessageListeners.get(0x0112)?.(restoreCommand, Buffer.alloc(8));
 
-    expect(notify).toHaveBeenCalledTimes(4);
+    expect(notify).toHaveBeenCalledTimes(5);
 
     dispose();
     expect(h.removeListener).toHaveBeenCalledWith('will-move', expect.any(Function));
@@ -411,8 +433,10 @@ describe('installMainWindowNativeRestoreIntent', () => {
       'before-input-event',
       expect.any(Function),
     );
+    expect(h.unhookWindowMessage).toHaveBeenCalledWith(0x0112);
     expect(h.windowListeners.size).toBe(0);
     expect(h.webContentsListeners.size).toBe(0);
+    expect(h.windowMessageListeners.size).toBe(0);
   });
 
   it('ignores unrelated input and non-Windows platforms', () => {
@@ -467,6 +491,9 @@ describe('installMainWindowNativeRestoreIntent', () => {
         modifiers: ['meta'],
       },
     );
+    const minimizeCommand = Buffer.alloc(8);
+    minimizeCommand.writeUInt32LE(0xf020, 0);
+    windows.windowMessageListeners.get(0x0112)?.(minimizeCommand, Buffer.alloc(8));
 
     expect(windowsNotify).not.toHaveBeenCalled();
   });

--- a/apps/desktop/src/main/bootstrap-electron.ts
+++ b/apps/desktop/src/main/bootstrap-electron.ts
@@ -3717,21 +3717,26 @@ const createWindow = () => {
   // state to disk on `close`. Must run before any user resize event fires.
   mainWindowState.manage(mainWindow);
   if (shouldRestoreMaximized && !mainWindow.isMaximized()) mainWindow.maximize();
-  const maximizeRecovery = installMainWindowMaximizeRecovery(mainWindow, screen, {
-    armed: shouldRestoreMaximized,
-    log: createSchedulerLogger('main-window-maximize-recovery'),
-  });
-  mainWindowMaximizeRecoveryController = maximizeRecovery;
-  const removeNativeRestoreIntent = installMainWindowNativeRestoreIntent(
-    mainWindow,
-    maximizeRecovery.notifyUserUnmaximize,
-  );
-  mainWindow.once('closed', () => {
-    removeNativeRestoreIntent();
-    if (mainWindowMaximizeRecoveryController === maximizeRecovery) {
-      mainWindowMaximizeRecoveryController = null;
-    }
-  });
+  // Windows can transiently unmaximize during display/DPI re-layout. macOS
+  // owns its native Zoom behavior, so do not install the Windows recovery
+  // state machine there.
+  if (process.platform === 'win32') {
+    const maximizeRecovery = installMainWindowMaximizeRecovery(mainWindow, screen, {
+      armed: shouldRestoreMaximized,
+      log: createSchedulerLogger('main-window-maximize-recovery'),
+    });
+    mainWindowMaximizeRecoveryController = maximizeRecovery;
+    const removeNativeRestoreIntent = installMainWindowNativeRestoreIntent(
+      mainWindow,
+      maximizeRecovery.notifyUserUnmaximizeIntent,
+    );
+    mainWindow.once('closed', () => {
+      removeNativeRestoreIntent();
+      if (mainWindowMaximizeRecoveryController === maximizeRecovery) {
+        mainWindowMaximizeRecoveryController = null;
+      }
+    });
+  }
 
   // dev-only:F12 切换 DevTools 的兜底通道。走 before-input-event 在 main 侧
   // 拦截,按键根本不进 renderer —— 不受页面内快捷键系统 / 输入焦点 / 菜单
@@ -4740,7 +4745,7 @@ const registerIpcHandlers = () => {
     if (!win) return;
     if (win.isMaximized()) {
       if (win === mainWindowRef) {
-        mainWindowMaximizeRecoveryController?.notifyUserUnmaximize();
+        mainWindowMaximizeRecoveryController?.notifyUserUnmaximizeIntent();
       }
       win.unmaximize();
     } else {

--- a/apps/desktop/src/main/bootstrap-electron.ts
+++ b/apps/desktop/src/main/bootstrap-electron.ts
@@ -57,6 +57,7 @@ import {
 import {
   installMainWindowMaximizeRecovery,
   readPersistedWindowMaximized,
+  type MainWindowMaximizeRecoveryController,
 } from './mainWindowMaximizeRecovery';
 import { prewarmMacComputerPermissionGuideHelper } from './computer-permission-guide/MacComputerPermissionGuideNativeHost.js';
 import { handleOpenChatGPTApp } from './chatgpt-app.js';
@@ -2940,6 +2941,7 @@ function isPathAllowed(filePath: string): boolean {
 // BrowserWindow，[0] 拿到它再 .focus() 等于啥也没干，用户视觉上以为
 // "双击启动不了"。
 let mainWindowRef: BrowserWindow | null = null;
+let mainWindowMaximizeRecoveryController: MainWindowMaximizeRecoveryController | null = null;
 // 端点清单阻断门:ready 流程走到正常 createWindow() 前置 true。在此之前
 // second-instance / activate 一律不许建窗——阻断循环(错误框重试)期间用户
 // 双击图标 / 点 Dock 若能建窗,preload 的模块级 sendSync 会因 handler 未注册
@@ -3714,9 +3716,15 @@ const createWindow = () => {
   // state to disk on `close`. Must run before any user resize event fires.
   mainWindowState.manage(mainWindow);
   if (shouldRestoreMaximized && !mainWindow.isMaximized()) mainWindow.maximize();
-  installMainWindowMaximizeRecovery(mainWindow, screen, {
+  const maximizeRecovery = installMainWindowMaximizeRecovery(mainWindow, screen, {
     armed: shouldRestoreMaximized,
     log: createSchedulerLogger('main-window-maximize-recovery'),
+  });
+  mainWindowMaximizeRecoveryController = maximizeRecovery;
+  mainWindow.once('closed', () => {
+    if (mainWindowMaximizeRecoveryController === maximizeRecovery) {
+      mainWindowMaximizeRecoveryController = null;
+    }
   });
 
   // dev-only:F12 切换 DevTools 的兜底通道。走 before-input-event 在 main 侧
@@ -4725,6 +4733,9 @@ const registerIpcHandlers = () => {
     const win = BrowserWindow.fromWebContents(event.sender) ?? mainWindowRef;
     if (!win) return;
     if (win.isMaximized()) {
+      if (win === mainWindowRef) {
+        mainWindowMaximizeRecoveryController?.notifyUserUnmaximize();
+      }
       win.unmaximize();
     } else {
       win.maximize();

--- a/apps/desktop/src/main/bootstrap-electron.ts
+++ b/apps/desktop/src/main/bootstrap-electron.ts
@@ -56,6 +56,7 @@ import {
 } from './mainWindowFullscreenStartup';
 import {
   installMainWindowMaximizeRecovery,
+  installMainWindowNativeRestoreIntent,
   readPersistedWindowMaximized,
   type MainWindowMaximizeRecoveryController,
 } from './mainWindowMaximizeRecovery';
@@ -3721,7 +3722,12 @@ const createWindow = () => {
     log: createSchedulerLogger('main-window-maximize-recovery'),
   });
   mainWindowMaximizeRecoveryController = maximizeRecovery;
+  const removeNativeRestoreIntent = installMainWindowNativeRestoreIntent(
+    mainWindow,
+    maximizeRecovery.notifyUserUnmaximize,
+  );
   mainWindow.once('closed', () => {
+    removeNativeRestoreIntent();
     if (mainWindowMaximizeRecoveryController === maximizeRecovery) {
       mainWindowMaximizeRecoveryController = null;
     }

--- a/apps/desktop/src/main/bootstrap-electron.ts
+++ b/apps/desktop/src/main/bootstrap-electron.ts
@@ -54,6 +54,10 @@ import {
   readWindowFullscreenState,
   showMainWindowAndRestoreFullscreen,
 } from './mainWindowFullscreenStartup';
+import {
+  installMainWindowMaximizeRecovery,
+  readPersistedWindowMaximized,
+} from './mainWindowMaximizeRecovery';
 import { prewarmMacComputerPermissionGuideHelper } from './computer-permission-guide/MacComputerPermissionGuideNativeHost.js';
 import { handleOpenChatGPTApp } from './chatgpt-app.js';
 import {
@@ -3567,7 +3571,15 @@ const createWindow = () => {
   // 改用顶层 import 而不是运行时 require —— Vite 才能 bundle 进 main 产物，
   // 否则 packaged app 因 pnpm hoisted 布局 + electron-packager 只扫
   // apps/desktop/node_modules 而拿不到这个包，运行时报 Cannot find module。
+  const mainWindowStateFile = 'window-state.json';
+  // Read the flag before the keeper validates bounds: it discards `isMaximized`
+  // along with off-screen bounds, which is exactly the lid-closed / monitor-asleep
+  // relaunch case where we still want to come back maximized.
+  const persistedMaximized = readPersistedWindowMaximized(
+    path.join(app.getPath('userData'), mainWindowStateFile),
+  );
   const mainWindowState = windowStateKeeper({
+    file: mainWindowStateFile,
     defaultWidth: 1280,
     defaultHeight: 800,
     // Applying fullscreen while a hidden macOS window is still starting can
@@ -3575,6 +3587,8 @@ const createWindow = () => {
     fullScreen: process.platform !== 'darwin',
   });
   const shouldRestoreMacFullscreen = process.platform === 'darwin' && mainWindowState.isFullScreen;
+  const shouldRestoreMaximized =
+    !shouldRestoreMacFullscreen && (persistedMaximized || Boolean(mainWindowState.isMaximized));
 
   const mainWindow = new BrowserWindow({
     x: mainWindowState.x,
@@ -3699,6 +3713,11 @@ const createWindow = () => {
   // Wire resize / move / maximize / fullscreen listeners that persist the
   // state to disk on `close`. Must run before any user resize event fires.
   mainWindowState.manage(mainWindow);
+  if (shouldRestoreMaximized && !mainWindow.isMaximized()) mainWindow.maximize();
+  installMainWindowMaximizeRecovery(mainWindow, screen, {
+    armed: shouldRestoreMaximized,
+    log: createSchedulerLogger('main-window-maximize-recovery'),
+  });
 
   // dev-only:F12 切换 DevTools 的兜底通道。走 before-input-event 在 main 侧
   // 拦截,按键根本不进 renderer —— 不受页面内快捷键系统 / 输入焦点 / 菜单

--- a/apps/desktop/src/main/mainWindowMaximizeRecovery.ts
+++ b/apps/desktop/src/main/mainWindowMaximizeRecovery.ts
@@ -35,7 +35,8 @@ const DISPLAY_CHANGE_EVENTS: readonly DisplayChangeEvent[] = [
   'display-metrics-changed',
 ];
 
-type WindowStateEvent = 'maximize' | 'unmaximize' | 'closed' | 'show' | 'restore';
+type WindowStateEvent =
+  'maximize' | 'unmaximize' | 'closed' | 'show' | 'restore' | 'will-move' | 'will-resize';
 
 export interface MaximizeRecoveryWindow {
   isDestroyed(): boolean;
@@ -51,6 +52,95 @@ export interface MaximizeRecoveryWindow {
 export interface MaximizeRecoveryScreen {
   on(event: DisplayChangeEvent, listener: () => void): unknown;
   removeListener(event: DisplayChangeEvent, listener: () => void): unknown;
+}
+
+interface MaximizeRecoveryInput {
+  type: string;
+  key: string;
+  meta: boolean;
+  isAutoRepeat: boolean;
+  modifiers: string[];
+}
+
+interface MaximizeRecoveryMouseInput {
+  type: string;
+  button?: string;
+  clickCount?: number;
+  y: number;
+}
+
+export interface MaximizeRecoveryNativeWindow extends MaximizeRecoveryWindow {
+  webContents: {
+    on(
+      event: 'before-input-event',
+      listener: (event: unknown, input: MaximizeRecoveryInput) => void,
+    ): unknown;
+    removeListener(
+      event: 'before-input-event',
+      listener: (event: unknown, input: MaximizeRecoveryInput) => void,
+    ): unknown;
+    on(
+      event: 'before-mouse-event',
+      listener: (event: unknown, mouse: MaximizeRecoveryMouseInput) => void,
+    ): unknown;
+    removeListener(
+      event: 'before-mouse-event',
+      listener: (event: unknown, mouse: MaximizeRecoveryMouseInput) => void,
+    ): unknown;
+  };
+}
+
+/**
+ * Marks restore gestures that do not go through Cindy's custom window-control IPC.
+ * Electron exposes manual movement/resizing separately from programmatic bounds
+ * changes, while the frameless title bar's double-click and Win+Down arrive via
+ * webContents input events. These signals precede the native `unmaximize`
+ * transition on Windows, so the recovery controller can preserve the user's choice.
+ */
+export function installMainWindowNativeRestoreIntent(
+  win: MaximizeRecoveryNativeWindow,
+  notifyUserUnmaximize: () => void,
+  platform: NodeJS.Platform = process.platform,
+): () => void {
+  if (platform !== 'win32') return () => {};
+
+  const onWillMove = (): void => notifyUserUnmaximize();
+  const onWillResize = (): void => notifyUserUnmaximize();
+  const onBeforeMouseEvent = (_event: unknown, mouse: MaximizeRecoveryMouseInput): void => {
+    if (
+      mouse.type === 'mouseDown' &&
+      mouse.button === 'left' &&
+      mouse.clickCount === 2 &&
+      mouse.y >= 0 &&
+      mouse.y <= 46
+    ) {
+      notifyUserUnmaximize();
+    }
+  };
+  const onBeforeInputEvent = (_event: unknown, input: MaximizeRecoveryInput): void => {
+    const hasWindowsModifier =
+      input.meta || input.modifiers.includes('meta') || input.modifiers.includes('command');
+    if (
+      input.type === 'keyDown' &&
+      !input.isAutoRepeat &&
+      input.key === 'ArrowDown' &&
+      hasWindowsModifier
+    ) {
+      notifyUserUnmaximize();
+    }
+  };
+
+  win.on('will-move', onWillMove);
+  win.on('will-resize', onWillResize);
+  win.webContents.on('before-mouse-event', onBeforeMouseEvent);
+  win.webContents.on('before-input-event', onBeforeInputEvent);
+
+  return (): void => {
+    win.removeListener('will-move', onWillMove);
+    win.removeListener('will-resize', onWillResize);
+    win.webContents.removeListener('before-mouse-event', onBeforeMouseEvent);
+    win.webContents.removeListener('before-input-event', onBeforeInputEvent);
+  };
 }
 
 export interface MaximizeRecoveryOptions {

--- a/apps/desktop/src/main/mainWindowMaximizeRecovery.ts
+++ b/apps/desktop/src/main/mainWindowMaximizeRecovery.ts
@@ -69,6 +69,8 @@ interface MaximizeRecoveryMouseInput {
   y: number;
 }
 
+type MaximizeRecoveryUserIntentSource = 'before-unmaximize' | 'after-unmaximize';
+
 export interface MaximizeRecoveryNativeWindow extends MaximizeRecoveryWindow {
   webContents: {
     on(
@@ -99,13 +101,15 @@ export interface MaximizeRecoveryNativeWindow extends MaximizeRecoveryWindow {
  */
 export function installMainWindowNativeRestoreIntent(
   win: MaximizeRecoveryNativeWindow,
-  notifyUserUnmaximizeIntent: () => void,
+  notifyUserUnmaximizeIntent: (source?: MaximizeRecoveryUserIntentSource) => void,
   platform: NodeJS.Platform = process.platform,
 ): () => void {
   if (platform !== 'win32') return () => {};
 
-  const onWillMove = (): void => notifyUserUnmaximizeIntent();
-  const onWillResize = (): void => notifyUserUnmaximizeIntent();
+  const onWillMove = (): void =>
+    notifyUserUnmaximizeIntent(win.isMaximized() ? 'before-unmaximize' : 'after-unmaximize');
+  const onWillResize = (): void =>
+    notifyUserUnmaximizeIntent(win.isMaximized() ? 'before-unmaximize' : 'after-unmaximize');
   const onBeforeMouseEvent = (_event: unknown, mouse: MaximizeRecoveryMouseInput): void => {
     if (
       mouse.type === 'mouseDown' &&
@@ -114,7 +118,7 @@ export function installMainWindowNativeRestoreIntent(
       mouse.y >= 0 &&
       mouse.y <= 46
     ) {
-      notifyUserUnmaximizeIntent();
+      notifyUserUnmaximizeIntent('before-unmaximize');
     }
   };
   const onBeforeInputEvent = (_event: unknown, input: MaximizeRecoveryInput): void => {
@@ -126,7 +130,7 @@ export function installMainWindowNativeRestoreIntent(
       input.key === 'ArrowDown' &&
       hasWindowsModifier
     ) {
-      notifyUserUnmaximizeIntent();
+      notifyUserUnmaximizeIntent('before-unmaximize');
     }
   };
 
@@ -165,7 +169,7 @@ export interface MainWindowMaximizeRecoveryController {
   /** Stop listening for display and window state changes. */
   dispose(): void;
   /** Record a possible user restore; it only disarms once unmaximize is observed. */
-  notifyUserUnmaximizeIntent(): void;
+  notifyUserUnmaximizeIntent(source?: MaximizeRecoveryUserIntentSource): void;
 }
 
 /**
@@ -213,18 +217,33 @@ export function installMainWindowMaximizeRecovery(
     clearDisarm();
   };
 
-  const notifyUserUnmaximizeIntent = (): void => {
+  const notifyUserUnmaximizeIntent = (
+    source: MaximizeRecoveryUserIntentSource = 'before-unmaximize',
+  ): void => {
     if (disposed) return;
     const at = now();
-    // Manual move/resize can be reported immediately after `unmaximize`. Pair
-    // either event order, but never disarm for an input signal by itself.
+    if (source === 'after-unmaximize') {
+      // Manual move/resize can be reported immediately after `unmaximize`.
+      // Only these concrete native transitions may confirm a late signal;
+      // title-bar clicks and key events must never pair with an older OS event.
+      if (
+        lastUnmaximizeAtMs !== null &&
+        at - lastUnmaximizeAtMs >= 0 &&
+        at - lastUnmaximizeAtMs <= userIntentMs &&
+        !win.isMaximized()
+      ) {
+        disarmForConfirmedUserUnmaximize();
+      }
+      return;
+    }
+    if (!win.isMaximized()) return;
     if (
       lastUnmaximizeAtMs !== null &&
       at - lastUnmaximizeAtMs >= 0 &&
-      at - lastUnmaximizeAtMs <= userIntentMs &&
-      !win.isMaximized()
+      at - lastUnmaximizeAtMs <= userIntentMs
     ) {
-      disarmForConfirmedUserUnmaximize();
+      // A click or key event that arrives after an OS transition is not proof
+      // that it caused that transition, so do not retain it as pending intent.
       return;
     }
     pendingUserUnmaximizeAtMs = at;

--- a/apps/desktop/src/main/mainWindowMaximizeRecovery.ts
+++ b/apps/desktop/src/main/mainWindowMaximizeRecovery.ts
@@ -99,13 +99,13 @@ export interface MaximizeRecoveryNativeWindow extends MaximizeRecoveryWindow {
  */
 export function installMainWindowNativeRestoreIntent(
   win: MaximizeRecoveryNativeWindow,
-  notifyUserUnmaximize: () => void,
+  notifyUserUnmaximizeIntent: () => void,
   platform: NodeJS.Platform = process.platform,
 ): () => void {
   if (platform !== 'win32') return () => {};
 
-  const onWillMove = (): void => notifyUserUnmaximize();
-  const onWillResize = (): void => notifyUserUnmaximize();
+  const onWillMove = (): void => notifyUserUnmaximizeIntent();
+  const onWillResize = (): void => notifyUserUnmaximizeIntent();
   const onBeforeMouseEvent = (_event: unknown, mouse: MaximizeRecoveryMouseInput): void => {
     if (
       mouse.type === 'mouseDown' &&
@@ -114,7 +114,7 @@ export function installMainWindowNativeRestoreIntent(
       mouse.y >= 0 &&
       mouse.y <= 46
     ) {
-      notifyUserUnmaximize();
+      notifyUserUnmaximizeIntent();
     }
   };
   const onBeforeInputEvent = (_event: unknown, input: MaximizeRecoveryInput): void => {
@@ -126,7 +126,7 @@ export function installMainWindowNativeRestoreIntent(
       input.key === 'ArrowDown' &&
       hasWindowsModifier
     ) {
-      notifyUserUnmaximize();
+      notifyUserUnmaximizeIntent();
     }
   };
 
@@ -157,13 +157,15 @@ export interface MaximizeRecoveryOptions {
    * keeps recovery armed; anything further away is treated as the user's choice.
    */
   graceMs?: number;
+  /** How long a native input signal may be paired with an actual unmaximize. */
+  userIntentMs?: number;
 }
 
 export interface MainWindowMaximizeRecoveryController {
   /** Stop listening for display and window state changes. */
   dispose(): void;
-  /** Mark the next unmaximize as an explicit user request, not OS re-layout. */
-  notifyUserUnmaximize(): void;
+  /** Record a possible user restore; it only disarms once unmaximize is observed. */
+  notifyUserUnmaximizeIntent(): void;
 }
 
 /**
@@ -181,10 +183,13 @@ export function installMainWindowMaximizeRecovery(
   const clearTimer = options.clearTimer ?? ((handle) => clearTimeout(handle as NodeJS.Timeout));
   const settleMs = options.settleMs ?? 300;
   const graceMs = options.graceMs ?? 2_000;
+  const userIntentMs = options.userIntentMs ?? 500;
 
   let armed = options.armed;
   let disposed = false;
   let pendingRecovery = false;
+  let pendingUserUnmaximizeAtMs: number | null = null;
+  let lastUnmaximizeAtMs: number | null = null;
   let lastDisplayChangeAtMs: number | null = null;
   let reapplyTimer: unknown = null;
   let disarmTimer: unknown = null;
@@ -198,16 +203,31 @@ export function installMainWindowMaximizeRecovery(
     disarmTimer = null;
   };
 
-  const notifyUserUnmaximize = (): void => {
-    if (disposed) return;
-    // The renderer's custom title-bar control is an explicit user choice. Clear
-    // any recovery work before Electron emits `unmaximize`, so a click during
-    // the display-change grace window cannot be mistaken for OS re-layout.
+  const disarmForConfirmedUserUnmaximize = (): void => {
     armed = false;
     pendingRecovery = false;
+    pendingUserUnmaximizeAtMs = null;
+    lastUnmaximizeAtMs = null;
     lastDisplayChangeAtMs = null;
     clearReapply();
     clearDisarm();
+  };
+
+  const notifyUserUnmaximizeIntent = (): void => {
+    if (disposed) return;
+    const at = now();
+    // Manual move/resize can be reported immediately after `unmaximize`. Pair
+    // either event order, but never disarm for an input signal by itself.
+    if (
+      lastUnmaximizeAtMs !== null &&
+      at - lastUnmaximizeAtMs >= 0 &&
+      at - lastUnmaximizeAtMs <= userIntentMs &&
+      !win.isMaximized()
+    ) {
+      disarmForConfirmedUserUnmaximize();
+      return;
+    }
+    pendingUserUnmaximizeAtMs = at;
   };
 
   const dispose = (): void => {
@@ -264,11 +284,23 @@ export function installMainWindowMaximizeRecovery(
     clearDisarm();
     armed = true;
     pendingRecovery = false;
+    pendingUserUnmaximizeAtMs = null;
+    lastUnmaximizeAtMs = null;
   };
 
   const onUnmaximize = (): void => {
     if (disposed || !armed) return;
     const at = now();
+    lastUnmaximizeAtMs = at;
+    if (
+      pendingUserUnmaximizeAtMs !== null &&
+      at - pendingUserUnmaximizeAtMs >= 0 &&
+      at - pendingUserUnmaximizeAtMs <= userIntentMs
+    ) {
+      disarmForConfirmedUserUnmaximize();
+      return;
+    }
+    pendingUserUnmaximizeAtMs = null;
     if (lastDisplayChangeAtMs !== null && at - lastDisplayChangeAtMs <= graceMs) {
       // Windows can emit the OS unmaximize after the first settle timer has
       // already observed a still-maximized window. Keep the recovery request
@@ -294,5 +326,5 @@ export function installMainWindowMaximizeRecovery(
   win.on('show', onWindowAvailable);
   win.on('restore', onWindowAvailable);
   win.on('closed', dispose);
-  return { dispose, notifyUserUnmaximize };
+  return { dispose, notifyUserUnmaximizeIntent };
 }

--- a/apps/desktop/src/main/mainWindowMaximizeRecovery.ts
+++ b/apps/desktop/src/main/mainWindowMaximizeRecovery.ts
@@ -71,7 +71,13 @@ interface MaximizeRecoveryMouseInput {
 
 type MaximizeRecoveryUserIntentSource = 'before-unmaximize' | 'after-unmaximize';
 
+const WM_SYSCOMMAND = 0x0112;
+const SC_RESTORE = 0xf120;
+const SYSTEM_COMMAND_MASK = 0xfff0;
+
 export interface MaximizeRecoveryNativeWindow extends MaximizeRecoveryWindow {
+  hookWindowMessage(message: number, callback: (wParam: Buffer, lParam: Buffer) => void): void;
+  unhookWindowMessage(message: number): void;
   webContents: {
     on(
       event: 'before-input-event',
@@ -110,6 +116,11 @@ export function installMainWindowNativeRestoreIntent(
     notifyUserUnmaximizeIntent(win.isMaximized() ? 'before-unmaximize' : 'after-unmaximize');
   const onWillResize = (): void =>
     notifyUserUnmaximizeIntent(win.isMaximized() ? 'before-unmaximize' : 'after-unmaximize');
+  const onSystemCommand = (wParam: Buffer): void => {
+    if (wParam.byteLength >= 4 && (wParam.readUInt32LE(0) & SYSTEM_COMMAND_MASK) === SC_RESTORE) {
+      notifyUserUnmaximizeIntent('before-unmaximize');
+    }
+  };
   const onBeforeMouseEvent = (_event: unknown, mouse: MaximizeRecoveryMouseInput): void => {
     if (
       mouse.type === 'mouseDown' &&
@@ -136,12 +147,14 @@ export function installMainWindowNativeRestoreIntent(
 
   win.on('will-move', onWillMove);
   win.on('will-resize', onWillResize);
+  win.hookWindowMessage(WM_SYSCOMMAND, onSystemCommand);
   win.webContents.on('before-mouse-event', onBeforeMouseEvent);
   win.webContents.on('before-input-event', onBeforeInputEvent);
 
   return (): void => {
     win.removeListener('will-move', onWillMove);
     win.removeListener('will-resize', onWillResize);
+    win.unhookWindowMessage(WM_SYSCOMMAND);
     win.webContents.removeListener('before-mouse-event', onBeforeMouseEvent);
     win.webContents.removeListener('before-input-event', onBeforeInputEvent);
   };

--- a/apps/desktop/src/main/mainWindowMaximizeRecovery.ts
+++ b/apps/desktop/src/main/mainWindowMaximizeRecovery.ts
@@ -69,6 +69,13 @@ export interface MaximizeRecoveryOptions {
   graceMs?: number;
 }
 
+export interface MainWindowMaximizeRecoveryController {
+  /** Stop listening for display and window state changes. */
+  dispose(): void;
+  /** Mark the next unmaximize as an explicit user request, not OS re-layout. */
+  notifyUserUnmaximize(): void;
+}
+
 /**
  * Keeps the main window maximized across display topology / DPI changes while
  * the user's last choice was "maximized"; the user's own maximize / unmaximize
@@ -78,7 +85,7 @@ export function installMainWindowMaximizeRecovery(
   win: MaximizeRecoveryWindow,
   screen: MaximizeRecoveryScreen,
   options: MaximizeRecoveryOptions,
-): () => void {
+): MainWindowMaximizeRecoveryController {
   const now = options.now ?? Date.now;
   const setTimer = options.setTimer ?? ((callback, ms) => setTimeout(callback, ms));
   const clearTimer = options.clearTimer ?? ((handle) => clearTimeout(handle as NodeJS.Timeout));
@@ -98,6 +105,17 @@ export function installMainWindowMaximizeRecovery(
   const clearDisarm = (): void => {
     if (disarmTimer !== null) clearTimer(disarmTimer);
     disarmTimer = null;
+  };
+
+  const notifyUserUnmaximize = (): void => {
+    if (disposed) return;
+    // The renderer's custom title-bar control is an explicit user choice. Clear
+    // any recovery work before Electron emits `unmaximize`, so a click during
+    // the display-change grace window cannot be mistaken for OS re-layout.
+    armed = false;
+    lastDisplayChangeAtMs = null;
+    clearReapply();
+    clearDisarm();
   };
 
   const dispose = (): void => {
@@ -156,5 +174,5 @@ export function installMainWindowMaximizeRecovery(
   win.on('maximize', onMaximize);
   win.on('unmaximize', onUnmaximize);
   win.on('closed', dispose);
-  return dispose;
+  return { dispose, notifyUserUnmaximize };
 }

--- a/apps/desktop/src/main/mainWindowMaximizeRecovery.ts
+++ b/apps/desktop/src/main/mainWindowMaximizeRecovery.ts
@@ -309,6 +309,9 @@ export function installMainWindowMaximizeRecovery(
     lastDisplayChangeAtMs = now();
     // An unmaximize immediately before this change belongs to the OS re-layout.
     clearDisarm();
+    // A native restore signal from the previous display generation must not
+    // confirm the OS unmaximize caused by this new display re-layout.
+    pendingUserUnmaximizeAtMs = null;
     if (!armed) return;
     pendingRecovery = true;
     scheduleReapply();

--- a/apps/desktop/src/main/mainWindowMaximizeRecovery.ts
+++ b/apps/desktop/src/main/mainWindowMaximizeRecovery.ts
@@ -315,7 +315,9 @@ export function installMainWindowMaximizeRecovery(
     // notifications cannot discard the same user gesture before unmaximize.
     if (
       pendingUserUnmaximizeAtMs !== null &&
-      (lastDisplayChangeAtMs === null || pendingUserUnmaximizeAtMs < lastDisplayChangeAtMs)
+      (lastDisplayChangeAtMs === null ||
+        pendingUserUnmaximizeAtMs < lastDisplayChangeAtMs ||
+        at - lastDisplayChangeAtMs > graceMs)
     ) {
       pendingUserUnmaximizeAtMs = null;
     }

--- a/apps/desktop/src/main/mainWindowMaximizeRecovery.ts
+++ b/apps/desktop/src/main/mainWindowMaximizeRecovery.ts
@@ -36,7 +36,14 @@ const DISPLAY_CHANGE_EVENTS: readonly DisplayChangeEvent[] = [
 ];
 
 type WindowStateEvent =
-  'maximize' | 'unmaximize' | 'closed' | 'show' | 'restore' | 'will-move' | 'will-resize';
+  | 'maximize'
+  | 'unmaximize'
+  | 'closed'
+  | 'show'
+  | 'restore'
+  | 'leave-full-screen'
+  | 'will-move'
+  | 'will-resize';
 
 export interface MaximizeRecoveryWindow {
   isDestroyed(): boolean;
@@ -272,6 +279,7 @@ export function installMainWindowMaximizeRecovery(
     win.removeListener('unmaximize', onUnmaximize);
     win.removeListener('show', onWindowAvailable);
     win.removeListener('restore', onWindowAvailable);
+    win.removeListener('leave-full-screen', onWindowAvailable);
     win.removeListener('closed', dispose);
   };
 
@@ -357,6 +365,7 @@ export function installMainWindowMaximizeRecovery(
   win.on('unmaximize', onUnmaximize);
   win.on('show', onWindowAvailable);
   win.on('restore', onWindowAvailable);
+  win.on('leave-full-screen', onWindowAvailable);
   win.on('closed', dispose);
   return { dispose, notifyUserUnmaximizeIntent };
 }

--- a/apps/desktop/src/main/mainWindowMaximizeRecovery.ts
+++ b/apps/desktop/src/main/mainWindowMaximizeRecovery.ts
@@ -66,7 +66,7 @@ interface MaximizeRecoveryInput {
   key: string;
   meta: boolean;
   isAutoRepeat: boolean;
-  modifiers: string[];
+  modifiers?: string[];
 }
 
 interface MaximizeRecoveryMouseInput {
@@ -141,7 +141,9 @@ export function installMainWindowNativeRestoreIntent(
   };
   const onBeforeInputEvent = (_event: unknown, input: MaximizeRecoveryInput): void => {
     const hasWindowsModifier =
-      input.meta || input.modifiers.includes('meta') || input.modifiers.includes('command');
+      input.meta ||
+      input.modifiers?.includes('meta') === true ||
+      input.modifiers?.includes('command') === true;
     if (
       input.type === 'keyDown' &&
       !input.isAutoRepeat &&

--- a/apps/desktop/src/main/mainWindowMaximizeRecovery.ts
+++ b/apps/desktop/src/main/mainWindowMaximizeRecovery.ts
@@ -1,0 +1,160 @@
+import fs from 'node:fs';
+
+/**
+ * electron-window-state drops `isMaximized` together with the saved bounds
+ * whenever the saved rectangle is not inside any currently attached display.
+ * That happens on Windows when the app is relaunched (e.g. idle auto-update)
+ * while the laptop lid is closed or the monitor is asleep: the only display
+ * Windows reports is a placeholder that neither contains the saved bounds nor
+ * has the real scale factor, so the window comes back small and rendered at 1x.
+ *
+ * Read the persisted flag from the raw file so the caller can maximize
+ * regardless of that bounds validation.
+ */
+export function readPersistedWindowMaximized(
+  filePath: string,
+  readFileSync: (path: string, encoding: 'utf8') => string = fs.readFileSync,
+): boolean {
+  try {
+    const parsed: unknown = JSON.parse(readFileSync(filePath, 'utf8'));
+    return (
+      typeof parsed === 'object' &&
+      parsed !== null &&
+      (parsed as { isMaximized?: unknown }).isMaximized === true
+    );
+  } catch {
+    return false;
+  }
+}
+
+export type DisplayChangeEvent = 'display-added' | 'display-removed' | 'display-metrics-changed';
+
+const DISPLAY_CHANGE_EVENTS: readonly DisplayChangeEvent[] = [
+  'display-added',
+  'display-removed',
+  'display-metrics-changed',
+];
+
+type WindowStateEvent = 'maximize' | 'unmaximize' | 'closed';
+
+export interface MaximizeRecoveryWindow {
+  isDestroyed(): boolean;
+  isVisible(): boolean;
+  isMaximized(): boolean;
+  isMinimized(): boolean;
+  isFullScreen(): boolean;
+  maximize(): void;
+  on(event: WindowStateEvent, listener: () => void): unknown;
+  removeListener(event: WindowStateEvent, listener: () => void): unknown;
+}
+
+export interface MaximizeRecoveryScreen {
+  on(event: DisplayChangeEvent, listener: () => void): unknown;
+  removeListener(event: DisplayChangeEvent, listener: () => void): unknown;
+}
+
+export interface MaximizeRecoveryOptions {
+  /** Whether the window should currently be kept maximized (persisted state). */
+  armed: boolean;
+  log?: { info: (...args: unknown[]) => void };
+  now?: () => number;
+  setTimer?: (callback: () => void, ms: number) => unknown;
+  clearTimer?: (handle: unknown) => void;
+  /** Delay before re-applying maximize, so the OS finishes its own re-layout first. */
+  settleMs?: number;
+  /**
+   * An `unmaximize` this close to a display change is attributed to the OS and
+   * keeps recovery armed; anything further away is treated as the user's choice.
+   */
+  graceMs?: number;
+}
+
+/**
+ * Keeps the main window maximized across display topology / DPI changes while
+ * the user's last choice was "maximized"; the user's own maximize / unmaximize
+ * re-arms / disarms it. Returns a disposer; also tears down on window close.
+ */
+export function installMainWindowMaximizeRecovery(
+  win: MaximizeRecoveryWindow,
+  screen: MaximizeRecoveryScreen,
+  options: MaximizeRecoveryOptions,
+): () => void {
+  const now = options.now ?? Date.now;
+  const setTimer = options.setTimer ?? ((callback, ms) => setTimeout(callback, ms));
+  const clearTimer = options.clearTimer ?? ((handle) => clearTimeout(handle as NodeJS.Timeout));
+  const settleMs = options.settleMs ?? 300;
+  const graceMs = options.graceMs ?? 2_000;
+
+  let armed = options.armed;
+  let disposed = false;
+  let lastDisplayChangeAtMs: number | null = null;
+  let reapplyTimer: unknown = null;
+  let disarmTimer: unknown = null;
+
+  const clearReapply = (): void => {
+    if (reapplyTimer !== null) clearTimer(reapplyTimer);
+    reapplyTimer = null;
+  };
+  const clearDisarm = (): void => {
+    if (disarmTimer !== null) clearTimer(disarmTimer);
+    disarmTimer = null;
+  };
+
+  const dispose = (): void => {
+    if (disposed) return;
+    disposed = true;
+    clearReapply();
+    clearDisarm();
+    for (const event of DISPLAY_CHANGE_EVENTS) screen.removeListener(event, onDisplayChange);
+    win.removeListener('maximize', onMaximize);
+    win.removeListener('unmaximize', onUnmaximize);
+    win.removeListener('closed', dispose);
+  };
+
+  const reapply = (): void => {
+    reapplyTimer = null;
+    if (disposed || !armed || win.isDestroyed()) return;
+    // A hidden window (closed to tray) must not be surfaced, and a minimized
+    // or fullscreen one reflects a deliberate state we should not override.
+    if (!win.isVisible() || win.isMinimized() || win.isFullScreen() || win.isMaximized()) return;
+    options.log?.info('re-applying maximized state after display change');
+    win.maximize();
+  };
+
+  const onDisplayChange = (): void => {
+    if (disposed) return;
+    lastDisplayChangeAtMs = now();
+    // An unmaximize immediately before this change belongs to the OS re-layout.
+    clearDisarm();
+    if (!armed) return;
+    clearReapply();
+    reapplyTimer = setTimer(reapply, settleMs);
+  };
+
+  const onMaximize = (): void => {
+    if (disposed) return;
+    clearDisarm();
+    armed = true;
+  };
+
+  const onUnmaximize = (): void => {
+    if (disposed || !armed) return;
+    const at = now();
+    if (lastDisplayChangeAtMs !== null && at - lastDisplayChangeAtMs <= graceMs) return;
+    // Decide after the grace period: a display change arriving right after
+    // means the OS restored the window, not the user.
+    clearDisarm();
+    disarmTimer = setTimer(() => {
+      disarmTimer = null;
+      if (disposed) return;
+      if (lastDisplayChangeAtMs !== null && lastDisplayChangeAtMs >= at) return;
+      armed = false;
+    }, graceMs);
+  };
+
+  for (const event of DISPLAY_CHANGE_EVENTS) screen.on(event, onDisplayChange);
+  win.on('maximize', onMaximize);
+  win.on('unmaximize', onUnmaximize);
+  win.on('closed', dispose);
+  return dispose;
+}

--- a/apps/desktop/src/main/mainWindowMaximizeRecovery.ts
+++ b/apps/desktop/src/main/mainWindowMaximizeRecovery.ts
@@ -35,7 +35,7 @@ const DISPLAY_CHANGE_EVENTS: readonly DisplayChangeEvent[] = [
   'display-metrics-changed',
 ];
 
-type WindowStateEvent = 'maximize' | 'unmaximize' | 'closed';
+type WindowStateEvent = 'maximize' | 'unmaximize' | 'closed' | 'show' | 'restore';
 
 export interface MaximizeRecoveryWindow {
   isDestroyed(): boolean;
@@ -94,6 +94,7 @@ export function installMainWindowMaximizeRecovery(
 
   let armed = options.armed;
   let disposed = false;
+  let pendingRecovery = false;
   let lastDisplayChangeAtMs: number | null = null;
   let reapplyTimer: unknown = null;
   let disarmTimer: unknown = null;
@@ -113,6 +114,7 @@ export function installMainWindowMaximizeRecovery(
     // any recovery work before Electron emits `unmaximize`, so a click during
     // the display-change grace window cannot be mistaken for OS re-layout.
     armed = false;
+    pendingRecovery = false;
     lastDisplayChangeAtMs = null;
     clearReapply();
     clearDisarm();
@@ -126,6 +128,8 @@ export function installMainWindowMaximizeRecovery(
     for (const event of DISPLAY_CHANGE_EVENTS) screen.removeListener(event, onDisplayChange);
     win.removeListener('maximize', onMaximize);
     win.removeListener('unmaximize', onUnmaximize);
+    win.removeListener('show', onWindowAvailable);
+    win.removeListener('restore', onWindowAvailable);
     win.removeListener('closed', dispose);
   };
 
@@ -134,9 +138,20 @@ export function installMainWindowMaximizeRecovery(
     if (disposed || !armed || win.isDestroyed()) return;
     // A hidden window (closed to tray) must not be surfaced, and a minimized
     // or fullscreen one reflects a deliberate state we should not override.
-    if (!win.isVisible() || win.isMinimized() || win.isFullScreen() || win.isMaximized()) return;
+    if (!win.isVisible() || win.isMinimized() || win.isFullScreen()) return;
+    if (win.isMaximized()) {
+      pendingRecovery = false;
+      return;
+    }
+    pendingRecovery = false;
     options.log?.info('re-applying maximized state after display change');
     win.maximize();
+  };
+
+  const scheduleReapply = (): void => {
+    if (disposed || !armed) return;
+    clearReapply();
+    reapplyTimer = setTimer(reapply, settleMs);
   };
 
   const onDisplayChange = (): void => {
@@ -145,20 +160,33 @@ export function installMainWindowMaximizeRecovery(
     // An unmaximize immediately before this change belongs to the OS re-layout.
     clearDisarm();
     if (!armed) return;
-    clearReapply();
-    reapplyTimer = setTimer(reapply, settleMs);
+    pendingRecovery = true;
+    scheduleReapply();
+  };
+
+  const onWindowAvailable = (): void => {
+    if (disposed || !armed || !pendingRecovery) return;
+    scheduleReapply();
   };
 
   const onMaximize = (): void => {
     if (disposed) return;
     clearDisarm();
     armed = true;
+    pendingRecovery = false;
   };
 
   const onUnmaximize = (): void => {
     if (disposed || !armed) return;
     const at = now();
-    if (lastDisplayChangeAtMs !== null && at - lastDisplayChangeAtMs <= graceMs) return;
+    if (lastDisplayChangeAtMs !== null && at - lastDisplayChangeAtMs <= graceMs) {
+      // Windows can emit the OS unmaximize after the first settle timer has
+      // already observed a still-maximized window. Keep the recovery request
+      // alive and retry after this late transition.
+      pendingRecovery = true;
+      scheduleReapply();
+      return;
+    }
     // Decide after the grace period: a display change arriving right after
     // means the OS restored the window, not the user.
     clearDisarm();
@@ -173,6 +201,8 @@ export function installMainWindowMaximizeRecovery(
   for (const event of DISPLAY_CHANGE_EVENTS) screen.on(event, onDisplayChange);
   win.on('maximize', onMaximize);
   win.on('unmaximize', onUnmaximize);
+  win.on('show', onWindowAvailable);
+  win.on('restore', onWindowAvailable);
   win.on('closed', dispose);
   return { dispose, notifyUserUnmaximize };
 }

--- a/apps/desktop/src/main/mainWindowMaximizeRecovery.ts
+++ b/apps/desktop/src/main/mainWindowMaximizeRecovery.ts
@@ -306,12 +306,20 @@ export function installMainWindowMaximizeRecovery(
 
   const onDisplayChange = (): void => {
     if (disposed) return;
-    lastDisplayChangeAtMs = now();
+    const at = now();
     // An unmaximize immediately before this change belongs to the OS re-layout.
     clearDisarm();
-    // A native restore signal from the previous display generation must not
-    // confirm the OS unmaximize caused by this new display re-layout.
-    pendingUserUnmaximizeAtMs = null;
+    // A native restore signal from before the current display generation must
+    // not confirm the OS unmaximize caused by this new display re-layout. Keep
+    // signals created after the last display event so a burst of display/DPI
+    // notifications cannot discard the same user gesture before unmaximize.
+    if (
+      pendingUserUnmaximizeAtMs !== null &&
+      (lastDisplayChangeAtMs === null || pendingUserUnmaximizeAtMs < lastDisplayChangeAtMs)
+    ) {
+      pendingUserUnmaximizeAtMs = null;
+    }
+    lastDisplayChangeAtMs = at;
     if (!armed) return;
     pendingRecovery = true;
     scheduleReapply();


### PR DESCRIPTION
## 这次改了什么

### 摘要

Windows 上在合盖 / 显示器休眠期间重新拉起 Cindy（典型场景是「空闲时自动应用更新」触发的重启）时，主窗口会变成左上角一个 1280×800、按 1x 渲染的小窗，字和窗口都非常小，显示器恢复后也不会跟着重新缩放。

根因：那一刻 Windows 只报一块 96 DPI 的占位显示器，`electron-window-state` 发现保存的矩形不在任何显示器范围内就回退默认尺寸，并且把 `isMaximized` 一起丢掉；窗口按占位显示器的缩放建出来后，真实显示器回来时没有任何逻辑把它重新套回最大化。

修复（不碰更新器链路）：

- 建窗前直接读 `window-state.json` 里的 `isMaximized`，不依赖 `electron-window-state` 的边界校验；上次记录是最大化就无条件 `maximize()`。
- 新增 `mainWindowMaximizeRecovery.ts`：监听 `screen` 的 `display-added` / `display-removed` / `display-metrics-changed`，显示器恢复后延迟 300ms 重新套一次最大化（跳过隐藏 / 最小化 / 全屏 / 已最大化的窗口）；窗口暂不可见时保留 pending 恢复，待 `show` / `restore` 后再尝试。用户通过标题栏明确取消最大化（包括显示器事件后的 grace window 内）后停止接管；Windows 原生拖动/缩放、无边框标题栏双击、Win+↓ 及系统菜单/任务栏缩略图还原都记录候选意图，双击/键盘只接受还原前的配对，拖动/缩放允许在 500ms 内配对晚到的 `unmaximize`，均需实际还原才标记为用户取消；全屏期间保留的 pending 恢复会在退出全屏后重新调度；显示器事件按事件代次隔离原生还原候选：使上一代旧候选失效，同时保留当前显示器事件序列中已产生的真实用户意图；超过 2 秒突发边界后不再继承候选；键盘输入按 Electron 字段安全读取，不依赖缺失的 `modifiers`；再次最大化则重新接管，窗口关闭时自动卸载监听。
- macOS 恢复原生全屏的既有路径不变（全屏优先，不叠加最大化）。

### 变更类型

- [x] `fix` 缺陷修复

### 范围

- 关联 Issue / 需求：无（本机复现，见下方验证）
- 本 PR 包含：主窗口最大化状态恢复 + 显示器变化后的重新套用
- 明确不包含：更新器 / 空闲自动重启策略、副窗口（右侧栏、插件面板）的窗口状态
- 用户可见变化：合盖 / 黑屏期间重启后，主窗口回到最大化且按正确 DPI 渲染
- 是否存在 breaking change：无

### UI 变化

不涉及：只改主进程窗口状态恢复逻辑，无视觉 / 交互 / 文案变化。

- 引用的设计规范：不涉及

## 怎么验证的

### 自动验证

```text
pnpm test:unit:related
结果：PASS apps/desktop unit（related 3 文件，含新增 26 个用例）

pnpm --filter desktop run --if-present typecheck
结果：通过

pnpm check:dco
结果：DCO check passed: 12 commits signed off
```

新增 `apps/desktop/src/main/__tests__/mainWindowMaximizeRecovery.test.ts` 覆盖：读取持久化标记的正常 / 异常文件；显示器事件后延迟重新最大化并合并抖动；隐藏 / 最小化 / 全屏 / 已销毁窗口不动；OS 在显示器变化前后触发的 unmaximize 不视为用户操作；用户主动取消（含 grace window 内的标题栏还原）后停止、再次最大化后恢复接管；晚到 OS 还原与 hidden/minimized 窗口重新可见也有回归覆盖；原生还原入口（will-move / will-resize / before-mouse-event / before-input-event / WM_SYSCOMMAND）及退出全屏重试、跨显示器事件的过期候选隔离、同代意图保留、突发边界、键盘输入字段防御与关闭清理也有回归覆盖。

### 手工验证

根因定位在本机（Windows 11，2560×1600 @150%）：0.1.72 空闲自动更新在 15:24 触发，更新前 `window-state.json` 为 `isMaximized: true`，更新后窗口为 (0,0) 1280×800 物理像素 @1x，与 `electron-window-state` 回退默认值一致。修复后的运行时行为未在打包版本上实测（worktree 内无法重启宿主），待验证。

### 未执行的验证

- 未在 macOS 上实测（显示器变更恢复控制器仅在 Windows 安装；macOS 原生 Zoom / 全屏路径不改）。
- 未在 Windows 上做真实的合盖 → 重启 → 开盖验证，需要装包后复现。

## 风险

### 风险分类

- [x] 跨平台差异

### 影响与回滚

- 影响范围：仅主窗口创建与显示器事件处理；上次不是最大化的用户行为完全不变。
- 回滚 / 降级方式：revert 本 PR 即��，无数据格式变化（只读 `window-state.json`，写入仍由 `electron-window-state` 负责）。
- 已分别考虑 macOS / Windows：Windows 是目标场景；macOS 不安装该恢复控制器，原生 Zoom / 全屏恢复路径不改。

### 提交前检查

- [x] 已 review 完整 diff
- [x] 每个 commit 都带 DCO 签名（`git commit -s`，见 [DCO](../DCO)）
- [x] UI 改动已在「UI 变化」注明引用的设计规范章节（不涉及 UI 则跳过）
- [x] 未提交凭证、令牌或授权文件
- [x] 已补充必要文档
- [x] 已确认测试结果或说明未执行原因
