### PR TITLE
fix(mobile): 加载更早消息不再抖动/空白，iOS 历史 prepend 交回原生原子锚定

### DIFF
--- a/apps/mobile/src/__tests__/messageHistoryAnchor.test.ts
+++ b/apps/mobile/src/__tests__/messageHistoryAnchor.test.ts
@@ -2,6 +2,8 @@ import { describe, expect, it } from 'vitest';
 import {
   captureMobileHistoryAnchor,
   isMobileHistoryAnchorSettled,
+  mobileHistoryAnchorCorrectionStatus,
+  mobileHistoryPrependUsesAppOwnedAnchor,
   mobileHistoryTopOffsetAdjustment,
   resolveMobileHistoryAnchorOffset,
 } from '@/session/messageHistoryAnchor';
@@ -14,6 +16,35 @@ import { buildMobileMessageRenderItems } from '@/session/messageRenderModel';
 import type { RemoteMessage } from '@/session/types';
 
 describe('messageHistoryAnchor', () => {
+  it('uses native prepend anchoring on iOS and app-owned anchoring only on Android', () => {
+    expect(mobileHistoryPrependUsesAppOwnedAnchor('ios')).toBe(false);
+    expect(mobileHistoryPrependUsesAppOwnedAnchor('android')).toBe(true);
+    expect(mobileHistoryPrependUsesAppOwnedAnchor('web')).toBe(false);
+  });
+
+  it('waits for the native viewport instead of trusting LegendList optimistic scroll state', () => {
+    const correction = {
+      requestedAfterNativeScrollSequence: 12,
+      targetOffset: 11_330,
+    };
+
+    // LegendList.getState().scroll may already equal 11_330 here, but no new native onScroll has
+    // acknowledged it yet. The transaction must stay locked instead of re-enabling MVCP early.
+    expect(mobileHistoryAnchorCorrectionStatus(correction, {
+      nativeOffset: 8_000,
+      nativeScrollSequence: 12,
+    }, 2)).toBe('waiting');
+    // A residual native event at the old coordinate is not the command acknowledgment either.
+    expect(mobileHistoryAnchorCorrectionStatus(correction, {
+      nativeOffset: 8_000,
+      nativeScrollSequence: 13,
+    }, 2)).toBe('missed');
+    expect(mobileHistoryAnchorCorrectionStatus(correction, {
+      nativeOffset: 11_329,
+      nativeScrollSequence: 14,
+    }, 2)).toBe('acknowledged');
+  });
+
   it('captures the first visible row in LegendList coordinates', () => {
     const anchor = captureMobileHistoryAnchor({
       data: [{ key: 'm1' }, { key: 'm2' }, { key: 'm3' }],

--- a/apps/mobile/src/__tests__/messageListVirtualization.test.ts
+++ b/apps/mobile/src/__tests__/messageListVirtualization.test.ts
@@ -4,9 +4,9 @@ import { describe, expect, it } from 'vitest';
 
 // 消息列表容器契约:LegendList(替代 FlatList —— 滚动 mount 卡顿的实测解,见 listperf profiling:
 // windowSize=21 的大挂载树 p95≈167ms/jank46,换 LegendList 小预渲窗口后 p95≈20ms/jank4)。
-// 关键 prop 不可回退:估高 + 小 drawDistance(挂载集小)+ 尺寸锚定 + 应用层 prepend 事务。
+// 关键 prop 不可回退:估高 + 小 drawDistance(挂载集小)+ iOS 原生 / Android 应用层 prepend 锚定。
 describe('mobile message list container', () => {
-  it('uses LegendList virtualization with app-owned history anchoring', () => {
+  it('uses LegendList virtualization with platform-scoped history anchoring', () => {
     const source = readFileSync(resolve(process.cwd(), 'src/session/MessageRenderer.tsx'), 'utf8');
     const perfHarness = readFileSync(resolve(process.cwd(), 'app/listperf.tsx'), 'utf8');
 
@@ -41,6 +41,8 @@ describe('mobile message list container', () => {
     expect(listSource).toContain('maintainVisibleContentPosition={historyPrependNativeMvcpDisabled');
     expect(listSource).toContain('? false');
     expect(listSource).toContain(': { data: true, size: true }}');
+    expect(source).toContain('mobileHistoryPrependUsesAppOwnedAnchor(');
+    expect(source).toContain('MOBILE_HISTORY_PREPEND_USES_APP_OWNED_ANCHOR');
     expect(source).toContain('captureMobileHistoryAnchor(');
     expect(source).toContain('resolveMobileMessageHistoryAnchorOffset(');
     expect(source).toContain('getCurrentHistoryTopOffsetAdjustment()');
@@ -127,15 +129,34 @@ describe('mobile message list container', () => {
     expect(source).toContain('MOBILE_HISTORY_ANCHOR_VERIFY_MAX_FRAMES');
     expect(source).toContain('MOBILE_HISTORY_ANCHOR_VERIFY_MAX_MS');
     expect(source).toContain('Date.now() < currentTransaction.verifyDeadlineAt');
-    expect(source).toContain('Complex pages can keep refining estimates beyond the retry window');
-    expect(source).toContain('if (finalTarget !== null) scrollToOffsetProgrammatically(finalTarget, false);');
+    expect(source).toContain('mobileHistoryAnchorCorrectionStatus(pendingCorrection');
+    expect(source).toContain('nativeScrollEventSequenceRef.current += 1');
+    expect(source).toContain('const currentOffset = scrollMetricsRef.current.offsetY;');
+    expect(source).not.toContain('const currentOffset = listState.scroll;');
+    expect(source).not.toContain('if (finalTarget !== null) scrollToOffsetProgrammatically(finalTarget, false);');
     expect(source).toContain('const restoreHistoryAnchorOnce = useCallback');
     expect(source).toContain('restoreHistoryAnchorOnce(transaction.generation)');
     expect(source).toContain('transaction.userControlledAfterCommit = true');
+    expect(source).toContain('transaction.userControlledDuringRequest = true');
+    expect(source).toContain('if (transaction.userControlledDuringRequest) {');
+    // 手势接管只在手指/惯性真正持有视口时扣住事务:否则「提交前手势已结束 + 该页无坐标进展」
+    // 会永久扣住事务,native MVCP 整段关掉。提交分支必须显式重新武装 handoff,
+    // 手势早已结束时才有路径回到锚点校验并收口。
+    const maybeFinishStart = source.indexOf('const maybeFinishHistoryPrependTransaction = useCallback');
+    const maybeFinishEnd = source.indexOf('const handoffHistoryPrependToUser', maybeFinishStart);
+    const maybeFinishSource = source.slice(maybeFinishStart, maybeFinishEnd);
+    expect(maybeFinishSource).toContain('transaction.userHandoffPending');
+    expect(maybeFinishSource).toContain('isDraggingRef.current');
+    expect(maybeFinishSource).toContain('isMomentumScrollingRef.current');
+    expect(maybeFinishSource).toContain('historyTouchStartYRef.current !== null');
+    expect(source).toContain('transaction.userHandoffPending = true;');
+    expect(source).toContain('currentTransaction.userHandoffPending = false;');
     // 直接拖动结束前不发请求，避免远端页在手指仍控制 ScrollView 时落地。
     expect(source).toContain('queuedLoadEarlierRef.current = true');
     expect(source).toContain('setHistoryPrependNativeMvcpDisabled(true)');
-    expect(source).toContain('if (!historyPrependNativeMvcpDisabledRef.current)');
+    expect(source).toMatch(
+      /MOBILE_HISTORY_PREPEND_USES_APP_OWNED_ANCHOR\s+&& !historyPrependNativeMvcpDisabledRef\.current/,
+    );
     expect(source).toContain('if (!historyPrependNativeMvcpDisabled) return;');
     expect(source).toContain('flushQueuedLoadEarlier();');
     expect(source).toContain('isMomentumScrollingRef.current');

--- a/apps/mobile/src/__tests__/messageListVirtualization.test.ts
+++ b/apps/mobile/src/__tests__/messageListVirtualization.test.ts
@@ -137,8 +137,17 @@ describe('mobile message list container', () => {
     expect(source).toContain('const restoreHistoryAnchorOnce = useCallback');
     expect(source).toContain('restoreHistoryAnchorOnce(transaction.generation)');
     expect(source).toContain('transaction.userControlledAfterCommit = true');
-    expect(source).toContain('transaction.userControlledDuringRequest = true');
+    expect(source).toContain('if (viewportTakenOver) transaction.userControlledDuringRequest = true;');
     expect(source).toContain('if (transaction.userControlledDuringRequest) {');
+    // 轻点不是接管视口:touch-start 只代表手指按住 ScrollView。若把它当接管,会取消
+    // regroup-only 续拉标记,新页仅展开顶部折叠 Worked for 时用户就被留在顶部干等。
+    const touchStartStart = source.indexOf('const handleHistoryTouchStart = useCallback');
+    const touchStartEnd = source.indexOf('const maybeTriggerHistoryTouch', touchStartStart);
+    const touchStartSource = source.slice(touchStartStart, touchStartEnd);
+    expect(touchStartSource).toContain('handoffHistoryPrependToUser(false)');
+    const triggerTouchStart = source.indexOf('const maybeTriggerHistoryTouch = useCallback');
+    const triggerTouchEnd = source.indexOf('const handleHistoryTouchMove', triggerTouchStart);
+    expect(source.slice(triggerTouchStart, triggerTouchEnd)).toContain('handoffHistoryPrependToUser();');
     // 手势接管只在手指/惯性真正持有视口时扣住事务:否则「提交前手势已结束 + 该页无坐标进展」
     // 会永久扣住事务,native MVCP 整段关掉。提交分支必须显式重新武装 handoff,
     // 手势早已结束时才有路径回到锚点校验并收口。

--- a/apps/mobile/src/session/MessageRenderer.tsx
+++ b/apps/mobile/src/session/MessageRenderer.tsx
@@ -340,9 +340,12 @@ import {
 import {
   captureMobileHistoryAnchor,
   isMobileHistoryAnchorSettled,
+  mobileHistoryAnchorCorrectionStatus,
+  mobileHistoryPrependUsesAppOwnedAnchor,
   mobileHistoryTopOffsetAdjustment,
   resolveMobileHistoryAnchorOffset,
   type MobileHistoryAnchor,
+  type MobileHistoryAnchorPendingCorrection,
   type MobileHistoryAnchorResolveState,
 } from '@/session/messageHistoryAnchor';
 import {
@@ -405,6 +408,9 @@ const MOBILE_MESSAGE_ESTIMATED_ITEM_SIZE = 100;
 const MOBILE_HISTORY_ANCHOR_VERIFY_MAX_FRAMES = 180;
 const MOBILE_HISTORY_ANCHOR_VERIFY_MAX_MS = 3000;
 const MOBILE_HISTORY_ANCHOR_STABLE_FRAMES = 2;
+const MOBILE_HISTORY_PREPEND_USES_APP_OWNED_ANCHOR = mobileHistoryPrependUsesAppOwnedAnchor(
+  Platform.OS,
+);
 const MOBILE_SCROLL_HISTORY_EVALUATION_INTERVAL_MS = 64;
 const ANDROID_SELECTABLE_TEXT_RUN_MAX_BLOCKS = 12;
 const ANDROID_SELECTABLE_TEXT_RUN_MAX_UTF16_LENGTH = 1800;
@@ -445,11 +451,14 @@ interface MobileHistoryPrependTransaction {
   continueAfterRegroup: boolean;
   generation: number;
   pageCommitted: boolean;
+  pendingCorrection: MobileHistoryAnchorPendingCorrection | null;
   promiseSettled: boolean;
   startItems: readonly MobileMessageRenderItem[];
   startProgressKey: string | null;
   userInitiated: boolean;
   userControlledAfterCommit: boolean;
+  userControlledDuringRequest: boolean;
+  userHandoffPending: boolean;
   verifyDeadlineAt: number;
 }
 // 「跳到底部」浮标直径:比 composer 里的语音按钮(28)大一档但不压过它,Telegram 同款层级感。
@@ -778,16 +787,15 @@ export function MessageRenderer({
   const readingOlderRef = useRef(false);
   // 每次补页分配 generation：旧会话 / 旧请求的异步 settle 不得清掉新请求的抑制态。
   const readingOlderRequestGenerationRef = useRef(0);
-  // data-change anchoring is app-owned instead of delegated to Android MVCP. The transaction
-  // keeps the old visible row pinned until the new page, layout, and non-animated correction all
-  // settle; this removes the frame where cells move before native contentOffset catches up.
+  // Android data-change anchoring is app-owned; iOS keeps LegendList/RN's atomic native MVCP.
+  // The shared transaction also suppresses follow-to-end until the page commit has settled.
   const historyPrependTransactionRef = useRef<MobileHistoryPrependTransaction | null>(null);
   const historyAnchorVerifyFrameRef = useRef<number | null>(null);
   const queuedLoadEarlierRef = useRef(false);
   const queuedLoadEarlierFlushFrameRef = useRef<number | null>(null);
-  // Keep native MVCP for ordinary data/size changes, but turn it fully off before starting a
-  // history request. LegendList maps either `data` or `size` to the same RN ScrollView prop, so
-  // `{ data:false, size:true }` would still race the app-owned prepend correction on Android.
+  // On Android, keep native MVCP for ordinary data/size changes but turn it fully off before a
+  // history request. LegendList maps either flag to the same RN ScrollView prop, so leaving size on
+  // would still race the app-owned correction. iOS never flips this state.
   const [historyPrependNativeMvcpDisabled, setHistoryPrependNativeMvcpDisabled] = useState(false);
   const historyPrependNativeMvcpDisabledRef = useRef(historyPrependNativeMvcpDisabled);
   historyPrependNativeMvcpDisabledRef.current = historyPrependNativeMvcpDisabled;
@@ -803,6 +811,9 @@ export function MessageRenderer({
   const programmaticScrollSettleAtRef = useRef(0);
   const previousFollowLatestRequestKeyRef = useRef(followLatestRequestKey);
   const previousItemKeysRef = useRef<readonly string[]>([]);
+  // LegendList updates getState().scroll optimistically before an imperative native scroll lands.
+  // This sequence advances only from ScrollView onScroll and is the ack source for Android prepend.
+  const nativeScrollEventSequenceRef = useRef(0);
   const scrollMetricsRef = useRef<MessageScrollMetrics>({
     contentHeight: 0,
     offsetY: 0,
@@ -894,6 +905,7 @@ export function MessageRenderer({
     }
     previousItemKeysRef.current = [];
     firstVisibleIndexRef.current = 0;
+    nativeScrollEventSequenceRef.current = 0;
     scrollMetricsRef.current = { contentHeight: 0, offsetY: 0, viewportHeight: 0 };
     followEndPinStateRef.current = createMobileFollowEndPinState();
     initialAnchorDoneRef.current = false;
@@ -1022,12 +1034,20 @@ export function MessageRenderer({
     });
   }, []);
 
-  const captureCurrentHistoryAnchor = useCallback((): MobileHistoryAnchor | null => {
+  const captureCurrentHistoryAnchor = useCallback((useNativeViewport = false): MobileHistoryAnchor | null => {
     const listState = listRef.current?.getState();
+    const nativeMetrics = scrollMetricsRef.current;
+    const canUseNativeViewport = useNativeViewport && nativeMetrics.viewportHeight > 0;
     return listState
       ? captureMobileHistoryAnchor(
         {
           ...listState,
+          // A pending LegendList command can move `scroll` and the cached visible range before
+          // Android's ScrollView follows. Once a finger owns the viewport, derive the anchor from
+          // the last native offset and force the position lookup to ignore that optimistic range.
+          ...(canUseNativeViewport
+            ? { scroll: nativeMetrics.offsetY, start: -1 }
+            : {}),
           topOffsetAdjustment: getCurrentHistoryTopOffsetAdjustment(),
         },
         (item) => (item as MobileMessageRenderItem).key,
@@ -1045,7 +1065,7 @@ export function MessageRenderer({
     }
     regroupedHistoryContinuationRef.current = transaction.continueAfterRegroup
       && transaction.userInitiated
-      && !transaction.userControlledAfterCommit;
+      && !transaction.userControlledDuringRequest;
     historyPrependTransactionRef.current = null;
     readingOlderRef.current = false;
     setHistoryPrependNativeMvcpDisabled(false);
@@ -1056,6 +1076,18 @@ export function MessageRenderer({
     const transaction = historyPrependTransactionRef.current;
     if (!transaction || transaction.generation !== generation) return;
     if (loadingEarlierRef.current || !transaction.promiseSettled) return;
+    // A committed page still needs its anchor correction acknowledged; that case is covered by
+    // `anchorStable` below. Only hold the handoff open while the finger or momentum still owns the
+    // viewport, otherwise a page that resolves with no coordinate change could never release the
+    // transaction and native MVCP would stay off for the rest of the session.
+    if (
+      transaction.userHandoffPending
+      && (
+        isDraggingRef.current
+        || isMomentumScrollingRef.current
+        || historyTouchStartYRef.current !== null
+      )
+    ) return;
     if (transaction.pageCommitted && !transaction.anchorStable) return;
     finishHistoryPrependTransaction(generation);
   }, [finishHistoryPrependTransaction]);
@@ -1063,17 +1095,23 @@ export function MessageRenderer({
   const handoffHistoryPrependToUser = useCallback(() => {
     const transaction = historyPrependTransactionRef.current;
     if (!transaction) return;
-    const currentAnchor = captureCurrentHistoryAnchor();
+    transaction.userControlledDuringRequest = true;
+    if (!MOBILE_HISTORY_PREPEND_USES_APP_OWNED_ANCHOR) return;
+    transaction.userHandoffPending = true;
+    const currentAnchor = captureCurrentHistoryAnchor(true);
     if (currentAnchor) transaction.anchor = currentAnchor;
     if (!transaction.pageCommitted) return;
     transaction.userControlledAfterCommit = true;
-    transaction.anchorStable = true;
+    transaction.anchorStable = false;
+    // An imperative scroll already handed to native cannot be cancelled reliably. Stop the JS
+    // verifier from adding more commands while the finger/momentum owns the viewport, keep MVCP
+    // disabled, and reconcile from native metrics after that gesture ends.
+    transaction.pendingCorrection = null;
     if (historyAnchorVerifyFrameRef.current !== null) {
       cancelAnimationFrame(historyAnchorVerifyFrameRef.current);
       historyAnchorVerifyFrameRef.current = null;
     }
-    maybeFinishHistoryPrependTransaction(transaction.generation);
-  }, [captureCurrentHistoryAnchor, maybeFinishHistoryPrependTransaction]);
+  }, [captureCurrentHistoryAnchor]);
 
   const cancelHistoryPrependTransaction = useCallback(() => {
     readingOlderRequestGenerationRef.current += 1;
@@ -1093,6 +1131,7 @@ export function MessageRenderer({
   }, []);
 
   const scheduleHistoryAnchorRestore = useCallback((generation: number) => {
+    if (!MOBILE_HISTORY_PREPEND_USES_APP_OWNED_ANCHOR) return;
     const transaction = historyPrependTransactionRef.current;
     if (
       !transaction
@@ -1132,34 +1171,69 @@ export function MessageRenderer({
         : null;
 
       if (targetOffset !== null && listState) {
-        const currentOffset = listState.scroll;
-        const settled = isMobileHistoryAnchorSettled(
-          currentOffset,
-          targetOffset,
-          previousTargetOffset,
-          MOBILE_ANCHOR_VERIFY_TOLERANCE,
-        );
-        // Only the anchor row's resolved position matters here. A running session can keep
-        // growing below the reader while history is settling; treating every tail size change as
-        // anchor instability keeps this verifier alive for the full retry bound and needlessly
-        // churns cells/GC. If a layout change above the anchor matters, targetOffset changes and
-        // the two-frame stability check resets on its own.
-        const nextStableFrames = settled ? stableFrames + 1 : 0;
-        if (Math.abs(currentOffset - targetOffset) > MOBILE_ANCHOR_VERIFY_TOLERANCE) {
-          scrollToOffsetProgrammatically(targetOffset, false);
-        }
-        if (nextStableFrames >= MOBILE_HISTORY_ANCHOR_STABLE_FRAMES) {
-          historyAnchorVerifyFrameRef.current = null;
-          currentTransaction.anchorStable = true;
-          maybeFinishHistoryPrependTransaction(generation);
-          return;
-        }
-        if (withinDeadline && attempts < MOBILE_HISTORY_ANCHOR_VERIFY_MAX_FRAMES) {
-          historyAnchorVerifyFrameRef.current = requestAnimationFrame(() => {
+        // LegendList moves getState().scroll to an imperative target before the native ScrollView
+        // receives it. Using that optimistic value here used to self-confirm the correction in two
+        // frames, release MVCP, and leave Android briefly rendering the target cell window at the
+        // old physical offset. Only onScroll-backed metrics can prove the viewport actually moved.
+        const currentOffset = scrollMetricsRef.current.offsetY;
+        const pendingCorrection = currentTransaction.pendingCorrection;
+        const correctionStatus = pendingCorrection
+          ? mobileHistoryAnchorCorrectionStatus(pendingCorrection, {
+              nativeOffset: currentOffset,
+              nativeScrollSequence: nativeScrollEventSequenceRef.current,
+            }, MOBILE_ANCHOR_VERIFY_TOLERANCE)
+          : null;
+        const waitingForNativeCorrection = correctionStatus === 'waiting'
+          && Math.abs(currentOffset - targetOffset) > MOBILE_ANCHOR_VERIFY_TOLERANCE;
+        if (waitingForNativeCorrection) {
+          // Keep one command in flight while no later native event has arrived. Once a later event
+          // misses, the branch below clears this command and retries the latest resolved target at
+          // most once per native event, rather than replacing the command on every animation frame.
+          if (withinDeadline && attempts < MOBILE_HISTORY_ANCHOR_VERIFY_MAX_FRAMES) {
+            historyAnchorVerifyFrameRef.current = requestAnimationFrame(() => {
+              historyAnchorVerifyFrameRef.current = null;
+              step(attempts + 1, 0, targetOffset);
+            });
+            return;
+          }
+        } else {
+          if (pendingCorrection) currentTransaction.pendingCorrection = null;
+          const settled = isMobileHistoryAnchorSettled(
+            currentOffset,
+            targetOffset,
+            previousTargetOffset,
+            MOBILE_ANCHOR_VERIFY_TOLERANCE,
+          );
+          // Only the anchor row's resolved position matters here. A running session can keep
+          // growing below the reader while history is settling; treating every tail size change as
+          // anchor instability keeps this verifier alive for the full retry bound and needlessly
+          // churns cells/GC. If a layout change above the anchor matters, targetOffset changes and
+          // the two-frame stability check resets on its own.
+          const nextStableFrames = settled ? stableFrames + 1 : 0;
+          if (
+            Math.abs(currentOffset - targetOffset) > MOBILE_ANCHOR_VERIFY_TOLERANCE
+            && withinDeadline
+            && attempts < MOBILE_HISTORY_ANCHOR_VERIFY_MAX_FRAMES
+          ) {
+            currentTransaction.pendingCorrection = {
+              requestedAfterNativeScrollSequence: nativeScrollEventSequenceRef.current,
+              targetOffset,
+            };
+            scrollToOffsetProgrammatically(targetOffset, false);
+          }
+          if (nextStableFrames >= MOBILE_HISTORY_ANCHOR_STABLE_FRAMES) {
             historyAnchorVerifyFrameRef.current = null;
-            step(attempts + 1, nextStableFrames, targetOffset);
-          });
-          return;
+            currentTransaction.anchorStable = true;
+            maybeFinishHistoryPrependTransaction(generation);
+            return;
+          }
+          if (withinDeadline && attempts < MOBILE_HISTORY_ANCHOR_VERIFY_MAX_FRAMES) {
+            historyAnchorVerifyFrameRef.current = requestAnimationFrame(() => {
+              historyAnchorVerifyFrameRef.current = null;
+              step(attempts + 1, nextStableFrames, targetOffset);
+            });
+            return;
+          }
         }
       } else if (withinDeadline && attempts < MOBILE_HISTORY_ANCHOR_VERIFY_MAX_FRAMES) {
         historyAnchorVerifyFrameRef.current = requestAnimationFrame(() => {
@@ -1169,47 +1243,12 @@ export function MessageRenderer({
         return;
       }
 
-      if (targetOffset !== null && listState) {
-        // Complex pages can keep refining estimates beyond the retry window even though the anchor
-        // key remains valid. End with two bounded, non-animated corrections instead of warning and
-        // re-enabling native MVCP against a stale offset. The history-intent guard keeps these
-        // resulting scroll events from being mistaken for a user return to the latest edge.
-        scrollToOffsetProgrammatically(targetOffset, false);
-        historyAnchorVerifyFrameRef.current = requestAnimationFrame(() => {
-          const finalTransaction = historyPrependTransactionRef.current;
-          if (
-            !finalTransaction
-            || finalTransaction.generation !== generation
-            || finalTransaction.userControlledAfterCommit
-          ) return;
-          const finalState = listRef.current?.getState();
-          const finalTarget = finalTransaction.anchor && finalState
-            ? resolveMobileMessageHistoryAnchorOffset(
-              finalTransaction.anchor,
-              finalState,
-              getCurrentHistoryTopOffsetAdjustment(),
-            )
-            : null;
-          if (finalTarget !== null) scrollToOffsetProgrammatically(finalTarget, false);
-          historyAnchorVerifyFrameRef.current = requestAnimationFrame(() => {
-            historyAnchorVerifyFrameRef.current = null;
-            const settledTransaction = historyPrependTransactionRef.current;
-            if (
-              !settledTransaction
-              || settledTransaction.generation !== generation
-              || settledTransaction.userControlledAfterCommit
-            ) return;
-            settledTransaction.anchorStable = true;
-            maybeFinishHistoryPrependTransaction(generation);
-          });
-        });
-        return;
-      }
-
-      // The key should survive a prepend. Keep an actually unresolved page bounded so malformed
-      // host data cannot lock history browsing forever; follow-to-latest remains disabled.
-      console.warn('[message-list] history prepend anchor could not be resolved before the retry bound');
+      // Do not fire unacknowledged "final" scrolls and immediately re-enable native MVCP. That old
+      // fallback raced its still-pending imperative command and amplified the visible bounce. Keep
+      // the transaction bounded, warn once, and leave the reader detached from follow-to-latest.
+      console.warn('[message-list] history prepend anchor did not settle before the retry bound');
       historyAnchorVerifyFrameRef.current = null;
+      currentTransaction.pendingCorrection = null;
       currentTransaction.anchorStable = true;
       maybeFinishHistoryPrependTransaction(generation);
     };
@@ -1226,6 +1265,7 @@ export function MessageRenderer({
   ]);
 
   const restoreHistoryAnchorOnce = useCallback((generation: number) => {
+    if (!MOBILE_HISTORY_PREPEND_USES_APP_OWNED_ANCHOR) return;
     const transaction = historyPrependTransactionRef.current;
     if (
       !transaction
@@ -1242,12 +1282,50 @@ export function MessageRenderer({
       : null;
     if (
       targetOffset !== null
-      && listState
-      && Math.abs(listState.scroll - targetOffset) > MOBILE_ANCHOR_VERIFY_TOLERANCE
+      && Math.abs(scrollMetricsRef.current.offsetY - targetOffset) > MOBILE_ANCHOR_VERIFY_TOLERANCE
     ) {
       scrollToOffsetProgrammatically(targetOffset, false);
     }
   }, [getCurrentHistoryTopOffsetAdjustment, scrollToOffsetProgrammatically]);
+
+  const scheduleHistoryPrependUserHandoffSettle = useCallback(() => {
+    if (!MOBILE_HISTORY_PREPEND_USES_APP_OWNED_ANCHOR) return;
+    const transaction = historyPrependTransactionRef.current;
+    if (!transaction || !transaction.userHandoffPending) return;
+    if (historyAnchorVerifyFrameRef.current !== null) return;
+    const generation = transaction.generation;
+    // onScrollEndDrag can be followed by onMomentumScrollBegin. Defer one frame so momentum gets
+    // ownership before deciding whether it is safe to resume imperative anchor verification.
+    historyAnchorVerifyFrameRef.current = requestAnimationFrame(() => {
+      historyAnchorVerifyFrameRef.current = null;
+      const currentTransaction = historyPrependTransactionRef.current;
+      if (
+        !currentTransaction
+        || currentTransaction.generation !== generation
+        || isDraggingRef.current
+        || isMomentumScrollingRef.current
+        || historyTouchStartYRef.current !== null
+      ) return;
+
+      if (currentTransaction.pageCommitted) {
+        currentTransaction.userHandoffPending = false;
+        currentTransaction.userControlledAfterCommit = false;
+        currentTransaction.pendingCorrection = null;
+        currentTransaction.verifyDeadlineAt = 0;
+        scheduleHistoryAnchorRestore(generation);
+        return;
+      }
+      if (currentTransaction.promiseSettled && !loadingEarlierRef.current) {
+        // A failed, empty, or duplicate page changed no coordinates. Waiting until the gesture
+        // ended still guarantees that an older in-flight correction cannot race MVCP re-enable.
+        currentTransaction.userHandoffPending = false;
+        currentTransaction.userControlledAfterCommit = false;
+        currentTransaction.pendingCorrection = null;
+        currentTransaction.anchorStable = true;
+        maybeFinishHistoryPrependTransaction(generation);
+      }
+    });
+  }, [maybeFinishHistoryPrependTransaction, scheduleHistoryAnchorRestore]);
 
   // 贴底跟随的落底校验/补滚环:两条手动补滚路径——「跳到最新」(followLatestRequestKey)
   // 与 handleContentSize 的贴底追赶——都只发一次命令式 scrollToEnd,不校验是否真的到达内容
@@ -1378,6 +1456,26 @@ export function MessageRenderer({
           transaction.startItems,
           listDataRef.current,
         );
+      if (!MOBILE_HISTORY_PREPEND_USES_APP_OWNED_ANCHOR) {
+        // iOS keeps LegendList/RN MVCP enabled for the data commit. Do not follow its atomic native
+        // correction with an application scroll; only retain the transaction's follow-to-end guard.
+        transaction.anchorStable = true;
+        maybeFinishHistoryPrependTransaction(transaction.generation);
+        return;
+      }
+      if (transaction.userControlledDuringRequest) {
+        // A second gesture can begin while the remote page is in flight. Keep native MVCP disabled
+        // and issue no app scroll while the finger/momentum owns the viewport. Gesture-end resumes
+        // verification from the latest native-captured anchor and waits for its native ack.
+        transaction.userControlledAfterCommit = true;
+        transaction.anchorStable = false;
+        transaction.pendingCorrection = null;
+        // Re-arm the handoff explicitly: the gesture that took over may already have ended, in
+        // which case the scheduled settle below is the only path back to anchor verification.
+        transaction.userHandoffPending = true;
+        scheduleHistoryPrependUserHandoffSettle();
+        return;
+      }
       scheduleHistoryAnchorRestore(transaction.generation);
       maybeFinishHistoryPrependTransaction(transaction.generation);
       return;
@@ -1395,6 +1493,7 @@ export function MessageRenderer({
     loadingEarlier,
     maybeFinishHistoryPrependTransaction,
     scheduleHistoryAnchorRestore,
+    scheduleHistoryPrependUserHandoffSettle,
   ]);
   // 只认行身份（追加 / 换行 / 重排）。流式改内容会换 items 引用，但不能续安静窗。
   useEffect(() => {
@@ -1757,7 +1856,7 @@ export function MessageRenderer({
     const generation = readingOlderRequestGenerationRef.current + 1;
     readingOlderRequestGenerationRef.current = generation;
     const listState = listRef.current?.getState();
-    const anchor = listState
+    const anchor = MOBILE_HISTORY_PREPEND_USES_APP_OWNED_ANCHOR && listState
       ? captureMobileHistoryAnchor(
         {
           ...listState,
@@ -1769,15 +1868,18 @@ export function MessageRenderer({
       : null;
     historyPrependTransactionRef.current = {
       anchor,
-      anchorStable: false,
+      anchorStable: !MOBILE_HISTORY_PREPEND_USES_APP_OWNED_ANCHOR,
       continueAfterRegroup: false,
       generation,
       pageCommitted: false,
+      pendingCorrection: null,
       promiseSettled: false,
       startItems: listDataRef.current,
       startProgressKey: historyProgressKey,
       userInitiated: userScrollForOlderRef.current,
       userControlledAfterCommit: false,
+      userControlledDuringRequest: false,
+      userHandoffPending: false,
       verifyDeadlineAt: 0,
     };
     readingOlderRef.current = true;
@@ -1815,9 +1917,13 @@ export function MessageRenderer({
       || isMomentumScrollingRef.current
       || historyTouchStartYRef.current !== null
     ) return;
-    // The request must not start until a committed render has removed RN's native MVCP prop.
-    // Otherwise a fast local/relay response can prepend before the prop update reaches Android.
-    if (!historyPrependNativeMvcpDisabledRef.current) {
+    // Android must not start until a committed render removes RN's native MVCP prop. Otherwise a
+    // fast local/relay response can prepend before that prop update lands. iOS keeps native MVCP
+    // throughout and can start immediately once the user's gesture is no longer active.
+    if (
+      MOBILE_HISTORY_PREPEND_USES_APP_OWNED_ANCHOR
+      && !historyPrependNativeMvcpDisabledRef.current
+    ) {
       setHistoryPrependNativeMvcpDisabled(true);
       return;
     }
@@ -1967,6 +2073,7 @@ export function MessageRenderer({
   // (readingOlderRef)期间禁止方向性恢复——load-earlier prepend 的 mVCP 补偿会产生
   // 程序化向下增量,短会话里会被误判成「用户滑回底部」。
   const handleScroll = useCallback((event: NativeSyntheticEvent<NativeScrollEvent>) => {
+    nativeScrollEventSequenceRef.current += 1;
     const metrics = {
       contentHeight: event.nativeEvent.contentSize.height,
       offsetY: event.nativeEvent.contentOffset.y,
@@ -2048,7 +2155,8 @@ export function MessageRenderer({
     isMomentumScrollingRef.current = false;
     historyTouchStartYRef.current = event.nativeEvent.pageY;
     historyTouchTriggeredRef.current = false;
-  }, []);
+    handoffHistoryPrependToUser();
+  }, [handoffHistoryPrependToUser]);
 
   const maybeTriggerHistoryTouch = useCallback((pageY: number) => {
     const startY = historyTouchStartYRef.current;
@@ -2074,14 +2182,20 @@ export function MessageRenderer({
     maybeTriggerHistoryTouch(event.nativeEvent.pageY);
     historyTouchStartYRef.current = null;
     historyTouchTriggeredRef.current = false;
+    scheduleHistoryPrependUserHandoffSettle();
     scheduleQueuedLoadEarlierFlush();
-  }, [maybeTriggerHistoryTouch, scheduleQueuedLoadEarlierFlush]);
+  }, [
+    maybeTriggerHistoryTouch,
+    scheduleHistoryPrependUserHandoffSettle,
+    scheduleQueuedLoadEarlierFlush,
+  ]);
 
   const handleHistoryTouchCancel = useCallback(() => {
     historyTouchStartYRef.current = null;
     historyTouchTriggeredRef.current = false;
+    scheduleHistoryPrependUserHandoffSettle();
     scheduleQueuedLoadEarlierFlush();
-  }, [scheduleQueuedLoadEarlierFlush]);
+  }, [scheduleHistoryPrependUserHandoffSettle, scheduleQueuedLoadEarlierFlush]);
 
   // 用户开始拖动 → 标记「上翻意图」,放行自动加载更早(onScrollBeginDrag 仅用户手势触发,
   // 程序化 scrollToEnd 不会触发,故不会误置);同时记录拖动起点 offset,供
@@ -2115,8 +2229,13 @@ export function MessageRenderer({
     dragStartOffsetYRef.current = null;
     refreshPreviousUserTarget();
     // Wait one frame so Android can report whether this drag transitioned into momentum.
+    scheduleHistoryPrependUserHandoffSettle();
     scheduleQueuedLoadEarlierFlush();
-  }, [refreshPreviousUserTarget, scheduleQueuedLoadEarlierFlush]);
+  }, [
+    refreshPreviousUserTarget,
+    scheduleHistoryPrependUserHandoffSettle,
+    scheduleQueuedLoadEarlierFlush,
+  ]);
 
   const handleMomentumScrollBegin = useCallback(() => {
     isMomentumScrollingRef.current = true;
@@ -2125,8 +2244,13 @@ export function MessageRenderer({
   const handleMomentumScrollEnd = useCallback(() => {
     isMomentumScrollingRef.current = false;
     refreshPreviousUserTarget();
+    scheduleHistoryPrependUserHandoffSettle();
     scheduleQueuedLoadEarlierFlush();
-  }, [refreshPreviousUserTarget, scheduleQueuedLoadEarlierFlush]);
+  }, [
+    refreshPreviousUserTarget,
+    scheduleHistoryPrependUserHandoffSettle,
+    scheduleQueuedLoadEarlierFlush,
+  ]);
 
   const handleStartReached = useCallback(() => {
     attemptAutoLoadEarlier();
@@ -2503,9 +2627,9 @@ export function MessageRenderer({
         // 二分实锤,3.3.2 / 3.3.3 均复现)。
         alignItemsAtEnd
         maintainScrollAtEnd={false}
-        // Ordinary updates keep LegendList's native data/size anchoring. Manual history prepends
-        // disable the whole prop before the request starts because RN exposes one native switch:
-        // leaving either flag on would race the app-owned key/offset correction on Android.
+        // iOS always uses LegendList/RN's atomic data/size anchoring. Android history prepends
+        // temporarily disable the whole prop because RN exposes one native switch: leaving either
+        // flag on would race the app-owned key/offset correction there.
         maintainVisibleContentPosition={historyPrependNativeMvcpDisabled
           ? false
           : { data: true, size: true }}

--- a/apps/mobile/src/session/MessageRenderer.tsx
+++ b/apps/mobile/src/session/MessageRenderer.tsx
@@ -1092,10 +1092,14 @@ export function MessageRenderer({
     finishHistoryPrependTransaction(generation);
   }, [finishHistoryPrependTransaction]);
 
-  const handoffHistoryPrependToUser = useCallback(() => {
+  // `viewportTakenOver` separates «a finger is on the ScrollView» from «the reader actually moved
+  // the viewport». Both must stop imperative corrections, but only the latter may cancel the
+  // regroup-only continuation: a bare tap moves nothing, and treating it as a takeover strands the
+  // reader at the top when a page merely expanded the collapsed first work group.
+  const handoffHistoryPrependToUser = useCallback((viewportTakenOver = true) => {
     const transaction = historyPrependTransactionRef.current;
     if (!transaction) return;
-    transaction.userControlledDuringRequest = true;
+    if (viewportTakenOver) transaction.userControlledDuringRequest = true;
     if (!MOBILE_HISTORY_PREPEND_USES_APP_OWNED_ANCHOR) return;
     transaction.userHandoffPending = true;
     const currentAnchor = captureCurrentHistoryAnchor(true);
@@ -2155,7 +2159,9 @@ export function MessageRenderer({
     isMomentumScrollingRef.current = false;
     historyTouchStartYRef.current = event.nativeEvent.pageY;
     historyTouchTriggeredRef.current = false;
-    handoffHistoryPrependToUser();
+    // Touch-start only means the finger holds the ScrollView; it is not a viewport takeover yet.
+    // maybeTriggerHistoryTouch / onScrollBeginDrag report the real move once it clears the dead zone.
+    handoffHistoryPrependToUser(false);
   }, [handoffHistoryPrependToUser]);
 
   const maybeTriggerHistoryTouch = useCallback((pageY: number) => {

--- a/apps/mobile/src/session/messageHistoryAnchor.ts
+++ b/apps/mobile/src/session/messageHistoryAnchor.ts
@@ -35,6 +35,14 @@ export interface MobileHistoryAnchorResolveState {
   topOffsetAdjustment?: number;
 }
 
+export interface MobileHistoryAnchorPendingCorrection {
+  /** Native scroll-event sequence observed immediately before issuing the correction. */
+  requestedAfterNativeScrollSequence: number;
+  targetOffset: number;
+}
+
+export type MobileHistoryAnchorCorrectionStatus = 'acknowledged' | 'missed' | 'waiting';
+
 export interface MobileHistoryTopOffsetState {
   contentLength: number;
   data: readonly unknown[];
@@ -46,6 +54,38 @@ export interface MobileHistoryTopOffsetState {
 const MAX_MOBILE_HISTORY_ANCHOR_CANDIDATES = 8;
 const MAX_MOBILE_HISTORY_ANCHOR_POSITION_PROBES = 24;
 const MOBILE_HISTORY_SHORT_LIST_TOLERANCE = 2;
+
+/**
+ * Android needs the app-owned prepend transaction because its native MVCP can commit the new cell
+ * coordinates before the ScrollView offset. iOS keeps the native path, which applies the data and
+ * offset change atomically and must not be followed by imperative app scrolls.
+ */
+export function mobileHistoryPrependUsesAppOwnedAnchor(platformOS: string): boolean {
+  return platformOS === 'android';
+}
+
+/**
+ * Distinguish LegendList's optimistic internal scroll bookkeeping from a native ScrollView ack.
+ * `LegendList.getState().scroll` moves to the requested offset before the native command lands, so
+ * only a later `onScroll` sequence can prove that the physical viewport caught up.
+ */
+export function mobileHistoryAnchorCorrectionStatus(
+  correction: MobileHistoryAnchorPendingCorrection,
+  state: {
+    nativeOffset: number;
+    nativeScrollSequence: number;
+  },
+  tolerance: number,
+): MobileHistoryAnchorCorrectionStatus {
+  if (state.nativeScrollSequence <= correction.requestedAfterNativeScrollSequence) {
+    return 'waiting';
+  }
+  return Number.isFinite(state.nativeOffset)
+    && Number.isFinite(correction.targetOffset)
+    && Math.abs(state.nativeOffset - correction.targetOffset) <= Math.max(0, tolerance)
+    ? 'acknowledged'
+    : 'missed';
+}
 
 /**
  * Translate LegendList's data-relative item positions into its raw ScrollView coordinates.


### PR DESCRIPTION
## 这次改了什么

### 摘要

加载更早消息落地后，消息流会突然刷新抖动、甚至整屏空白。这是 #3629 引入的回归：它把 prepend 防跳从**常开的 native `maintainVisibleContentPosition`** 改成「历史请求期间整个关掉 + app 侧命令式 `scrollToOffset` 补位」，而这套 workaround 的理由通篇是 Android 的，代码里却**没有任何 `Platform.OS` 分支**，于是 iOS 上本来原子的原生锚定也被换成了晚一帧的 app 补位。本 PR 按平台分流：iOS 交回原生原子锚定，Android 保留 app 事务但改用真实原生回执。

### 变更类型

- [ ] `feat` 新功能
- [x] `fix` 缺陷修复
- [ ] `refactor` / `perf` 重构或性能优化
- [ ] `docs` / `test` / `chore` 文档、测试或工程维护
- [ ] 其他：

### 范围

- 关联 Issue / 需求：回归自 #3629（`574dae9f4` 引入 + `0110985c1` 放大）
- 本 PR 包含：
  - **按平台分流**：新增 `mobileHistoryPrependUsesAppOwnedAnchor()`，只有 Android 走 app 侧 prepend 事务。这是 `574dae9f4` 缺失的那一句。
  - **iOS 交回 native 原子锚定**：不捕锚点、不关 MVCP prop（恒为 `{data:true, size:true}`）、提交点直接收口，`scheduleHistoryAnchorRestore` / `restoreHistoryAnchorOnce` / `scheduleHistoryPrependUserHandoffSettle` 三个函数入口短路，app 不再发任何补位滚动。事务本身保留 —— 它还承担 prepend 期间禁止贴底跟随，这部分双端都要。
  - **Android 改用真实原生回执**：新增 `nativeScrollEventSequenceRef`（只在原生 `onScroll` 自增）与 `mobileHistoryAnchorCorrectionStatus()` 三态判定（`waiting` 不重发不计稳定 / `missed` 按最新目标重发一次 / `acknowledged` 计帧）；到位判据从 `LegendList.getState().scroll` 换成 `scrollMetricsRef` 的原生 `offsetY`。原来那个是乐观值——命令还没到原生就已经等于目标，两帧就自我确认并提前重开 MVCP。现在一个原生事件最多补一发。
  - **删掉重试窗末尾那两发未确认滚动**：超时只 `warn` + 有界收手，不再与在飞的命令对打。
  - 另修两处会**永久扣住事务**的边界：手势接管的扣留改为只在手指/惯性真正持有视口时生效（否则「提交前手势已结束 + 该页无坐标进展」会让 `readingOlder` 不解、native MVCP 整段关掉）；提交分支显式重新武装 `userHandoffPending`，手势早已结束时才有路径回到锚点校验。
- 明确不包含：不 revert #3629（它的内存修复要保留）；不改分页接口、device-link payload、IPC allowlist、原生依赖、原生配置或 runtime fingerprint；不动 `docs/dev-rules/mobile-development.md`（根因里的「缺双端验证门槛」规则洞另开 PR）。
- 用户可见变化：加载更早消息时消息流不再抖动/闪空白，阅读位置保持不动。其余交互、文案、入口不变。
- 是否存在 breaking change：无

### UI 变化

不涉及。

- 引用的设计规范：不涉及：本次只改滚动锚定与 prepend 事务的时序逻辑，没有新增或修改任何颜色、间距、层级、组件、动效或文案，Light / Dark 两种模式的样式代码路径均未触碰。

## 怎么验证的

### 自动验证

```text
pnpm --filter mobile run typecheck
结果：通过

pnpm test:unit:related
结果：通过（apps/mobile、apps/desktop、packages/maker-core、packages/lizi-mcps、packages/orca-workflow 全 PASS）

pnpm --filter mobile run test
结果：通过（343 test files / 4169 tests）

pnpm --filter mobile run test:scope
结果：通过（mobile-scope-guard passed）

git diff --check
结果：通过

pnpm check:dco
结果：通过（origin/main..HEAD 共 1 个 commit 已签名）
```

新增测试：
- `messageHistoryAnchor.test.ts` +2 个 `it`：平台归属（`ios→false / android→true / web→false`）、乐观值 vs 原生回执三态。
- `messageListVirtualization.test.ts`：容器契约断言更新，并补 `not.toContain` **反向断言**钉住 `const currentOffset = listState.scroll;` 和末尾兜底那行两个坏写法。`574dae9f4` 当年正是把能挡住这次回归的断言（`maintainVisibleContentPosition={{ data: true, size: true }}`）替换成了断言新行为，所以这次特意用反向断言防回潮。

### 手工验证

不涉及。

### 未执行的验证

**没有做设备目检（iOS 与 Android 都没有）。** 需要显式指出这一条的分量：#3629 之所以把 iOS 打坏，直接原因就是它的手工验证只覆盖了「Android 模拟器 + CN 包 `com.xd.cindycn`」，而 PR 却声明了双端用户可见行为。本 PR 修的是同一个坑，却同样没有实机证据，所以这里如实写明：

- 本机没有 booted iOS simulator、未安装 Maestro、`apps/mobile` 也没有 ios 原生工程（managed workflow），跑不了 `pnpm --filter mobile test:e2e:local:ios`；装 Maestro 属于改环境，未擅自执行。
- 因此**「加载更早消息时消息流不动」这条最终判据是代码级 + 时间线级推断，不是目击**：依据是 `git log -S` 确认 `{data:true,size:true}` 从开源首提到 2026-08-30 一直常开、`574dae9f4` 才改成请求期间关闭，以及 main 上锚定事务区间 `Platform.OS` 零出现。
- 落地后请在真机各跑一次「上翻加载更早消息 ×3 页」：iOS 验第 ①②刀，Android 验第 ③④刀。若 Android 仍有残留抖动，那是 app 事务本身的问题，与本 PR 的平台分流无关，另开 issue 跟。

## 风险

### 风险分类

- [ ] 无已知风险
- [ ] SQLite / migration
- [ ] system prompt
- [ ] 协议兼容
- [ ] 权限 / 安全 / 用户数据
- [ ] 存量插件兼容（批准状态 / 指纹 / manifest 校验 / 安装布局 / 包格式）
- [ ] 原生层 / fingerprint / OTA
- [x] 跨平台差异
- [ ] 其他：

### 影响与回滚

- 影响范围：只影响 `apps/mobile` 会话详情消息列表的「加载更早消息」路径。iOS 行为等价回到 `574dae9f4` 之前（native MVCP 常开、app 不插手）；Android 继续走 app 事务，只是到位判据与重试收尾改了。其余滚动路径（冷开锚定、贴底跟随、跳到最新）未改。
- 跨平台差异说明：这是**有意**引入的平台分支，且是修正 —— `574dae9f4` 的 workaround 本就只对 Android 成立（其注释原文：`This is the atomic point missing from Android native MVCP`），把它套到 iOS 才是 bug。分支点集中在 `mobileHistoryPrependUsesAppOwnedAnchor()` 一个纯函数，有单测覆盖。
- 回滚 / 降级方式：`git revert` 本 PR 即可，回到当前 main 行为，无数据/协议/持久化残留。不触发 runtime fingerprint，不需要冷更，存量装机可走热更。

### 提交前检查

- [x] 已 review 完整 diff
- [x] 每个 commit 都带 DCO 签名（`git commit -s`）
- [x] UI 改动已在「UI 变化」注明引用的设计规范章节（不涉及 UI 则跳过）
- [x] 未提交凭证、令牌或授权文件
- [x] 已补充必要文档（本次为行为修复，规则文档缺口另开 PR）
- [x] 已确认测试结果或说明未执行原因
