### PR TITLE
fix(model-providers): 自定义模型缺省上下文窗口按 Registry 命中回填

### DIFF
--- a/packages/model-providers/catalog/model-registry.json
+++ b/packages/model-providers/catalog/model-registry.json
@@ -1557,6 +1557,30 @@
       ]
     },
     {
+      "id": "z-ai/glm-5.3",
+      "name": "GLM-5.3",
+      "group": "china",
+      "description": "Zhipu GLM-5.3 agentic coding model; 1M context",
+      "contextWindow": 1000000,
+      "efforts": ["minimal", "low", "high", "max"],
+      "defaultEffort": "high",
+      "sortOrder": 43.5,
+      "supportsFastMode": false,
+      "perAgent": {
+        "claude-code": {
+          "efforts": ["low", "high", "max"],
+          "defaultEffort": "high"
+        }
+      },
+      "routes": [
+        {
+          "providerId": "xd",
+          "modelId": "z-ai/glm-5.3",
+          "agents": ["claude-code", "codex"]
+        }
+      ]
+    },
+    {
       "id": "deepseek/deepseek-v4-pro",
       "name": "DeepSeek V4 Pro",
       "group": "china",

--- a/packages/model-providers/src/__tests__/user-provider.test.ts
+++ b/packages/model-providers/src/__tests__/user-provider.test.ts
@@ -5,7 +5,8 @@
  *   - source='user'、auth.method 与 access 元数据匹配；
  *   - 只为**已配置的 runtime** 生成 api-key-header 路由 + per-agent 模型清单（各自 baseUrl/models）；
  *   - **API key 绝不出现在产出的 Provider 里**（密钥在 host resolve 时按 (id,agent) 注入）；
- *   - 模型补保守默认（contextWindow / 无 effort / group=custom:<id> / defaultEnabled）。
+ *   - 模型补保守默认（contextWindow / 无 effort / group=custom:<id> / defaultEnabled）；
+ *     contextWindow 缺省时若模型 ID 唯一命中 Registry 条目则回填 Registry 窗口。
  */
 
 import { describe, it, expect } from "vitest";
@@ -613,6 +614,161 @@ it('strips xd/ prefix to match registry effort metadata (entry.id ≠ custom id)
     });
     expect(p.models.codex?.[0]).toMatchObject({
       contextWindow: DEFAULT_CUSTOM_CONTEXT_WINDOW,
+      contextWindowVerified: true,
+      contextWindowExplicit: true,
+    });
+  });
+
+  it("backfills a Registry context window when the bare model id matches a namespaced entry", () => {
+    // #3883:自定义供应商填官方端点 + 裸模型 id "glm-5.3"(Registry 条目为
+    // "z-ai/glm-5.3")——过去一律 200K 保守默认,1M 模型被当 200K 用。
+    const p = buildUserProvider(
+      {
+        id: "glm",
+        name: "智谱 GLM",
+        runtimes: {
+          "claude-code": {
+            baseUrl: "https://open.bigmodel.cn/api/anthropic",
+            models: [
+              { id: "glm-5.3", name: "GLM-5.3" },
+              { id: "z-ai/glm-5.2", name: "GLM-5.2" },
+            ],
+          },
+        },
+      },
+      { modelRegistry: BUNDLED_CATALOG.modelRegistry },
+    );
+    expect(p.models["claude-code"]?.[0]).toMatchObject({
+      id: "glm-5.3",
+      contextWindow: 1_000_000,
+      contextWindowVerified: true,
+    });
+    expect(p.models["claude-code"]?.[0]?.contextWindowExplicit).toBeUndefined();
+    // 命名空间形态的自定义 id 也算精确命中(entry.id === modelId)。
+    expect(p.models["claude-code"]?.[1]).toMatchObject({
+      id: "z-ai/glm-5.2",
+      contextWindow: 1_000_000,
+      contextWindowVerified: true,
+    });
+  });
+
+  it("respects per-agent Registry windows for the same model id", () => {
+    // openai/gpt-5.5:claude-code 1.05M / codex 272K —— 同一模型在不同 agent 下的
+    // 窗口不同,回填必须按 agent 取 perAgent 覆盖,不能拿顶层值一刀切。
+    const p = buildUserProvider(
+      {
+        id: "relay",
+        name: "Relay",
+        runtimes: {
+          "claude-code": {
+            baseUrl: "https://relay.example/anthropic",
+            models: [{ id: "gpt-5.5", name: "GPT-5.5" }],
+          },
+          codex: {
+            baseUrl: "https://relay.example/v1",
+            models: [{ id: "gpt-5.5", name: "GPT-5.5" }],
+          },
+        },
+      },
+      { modelRegistry: BUNDLED_CATALOG.modelRegistry },
+    );
+    expect(p.models["claude-code"]?.[0]?.contextWindow).toBe(1_050_000);
+    expect(p.models.codex?.[0]?.contextWindow).toBe(272_000);
+  });
+
+  it("backfills after stripping a gateway prefix from the custom model id", () => {
+    const p = buildUserProvider(
+      {
+        id: "relay",
+        name: "Relay",
+        runtimes: {
+          codex: {
+            baseUrl: "https://relay.example/v1",
+            models: [{ id: "xd/gpt-5.5", name: "GPT-5.5" }],
+          },
+        },
+      },
+      { modelRegistry: BUNDLED_CATALOG.modelRegistry },
+    );
+    expect(p.models.codex?.[0]?.contextWindow).toBe(272_000);
+  });
+
+  it("keeps the conservative default when the registry match is ambiguous or windowless", () => {
+    const registry = structuredClone(BUNDLED_CATALOG.modelRegistry);
+    if (!registry) throw new Error("missing bundled model registry");
+    const base = registry.models.find((entry) => entry.id === "z-ai/glm-5.2");
+    if (!base) throw new Error("missing z-ai/glm-5.2 registry entry");
+    // 两个命名空间不同的条目,去前缀后同名 "glm-x" 但窗口不一致 → 冲突,不回填。
+    const conflictingA = structuredClone(base);
+    conflictingA.id = "vendor-a/glm-x";
+    conflictingA.routes = [
+      { providerId: "vendor-a", modelId: "glm-x", agents: ["claude-code", "codex"] },
+    ];
+    conflictingA.contextWindow = 128_000;
+    const conflictingB = structuredClone(base);
+    conflictingB.id = "vendor-b/glm-x";
+    conflictingB.routes = [
+      { providerId: "vendor-b", modelId: "glm-x", agents: ["claude-code", "codex"] },
+    ];
+    conflictingB.contextWindow = 200_000;
+    const windowless = structuredClone(base);
+    windowless.id = "bare/glm-windowless";
+    windowless.routes = [
+      {
+        providerId: "bare",
+        modelId: "glm-windowless",
+        agents: ["claude-code", "codex"],
+      },
+    ];
+    delete windowless.contextWindow;
+    registry.models.push(conflictingA, conflictingB, windowless);
+
+    const p = buildUserProvider(
+      {
+        id: "relay",
+        name: "Relay",
+        runtimes: {
+          codex: {
+            baseUrl: "https://relay.example/v1",
+            models: [
+              { id: "glm-x", name: "GLM X" }, // 两个条目后缀同名但窗口冲突
+              { id: "glm-windowless", name: "GLM Windowless" }, // 唯一命中但未声明窗口
+              { id: "totally-unknown", name: "Unknown" }, // 无命中
+            ],
+          },
+        },
+      },
+      { modelRegistry: registry },
+    );
+    expect(
+      p.models.codex?.map((m) => [
+        m.id,
+        m.contextWindow,
+        m.contextWindowVerified ?? null,
+      ]),
+    ).toEqual([
+      ["glm-x", DEFAULT_CUSTOM_CONTEXT_WINDOW, null],
+      ["glm-windowless", DEFAULT_CUSTOM_CONTEXT_WINDOW, null],
+      ["totally-unknown", DEFAULT_CUSTOM_CONTEXT_WINDOW, null],
+    ]);
+  });
+
+  it("prefers an explicit contextWindow over the Registry backfill", () => {
+    const p = buildUserProvider(
+      {
+        id: "relay",
+        name: "Relay",
+        runtimes: {
+          "claude-code": {
+            baseUrl: "https://relay.example/anthropic",
+            models: [{ id: "glm-5.3", name: "GLM-5.3", contextWindow: 300_000 }],
+          },
+        },
+      },
+      { modelRegistry: BUNDLED_CATALOG.modelRegistry },
+    );
+    expect(p.models["claude-code"]?.[0]).toMatchObject({
+      contextWindow: 300_000,
       contextWindowVerified: true,
       contextWindowExplicit: true,
     });

--- a/packages/model-providers/src/user-provider.ts
+++ b/packages/model-providers/src/user-provider.ts
@@ -8,7 +8,8 @@
  *   - 每个用户选中的 agent 生成一份与鉴权形态匹配的路由（upstream = baseUrl，带用户自定义
  *     headers）；**API key 不在此注入**——它存 safeStorage，由 host 在路由 resolve 时按
  *     `provider_key_<id>` 读出并写进鉴权头，绝不进 catalog（防经 listProviders 泄漏给 renderer）。
- *   - 用户模型可携带预设确认的 contextWindow；缺省时补保守默认，effort 使用 runtime 默认。
+ *   - 用户模型可携带预设确认的 contextWindow；缺省时若模型 ID 能唯一命中 Registry 条目
+ *     则回填 Registry 窗口，仍未命中才补 200K 保守默认；effort 使用 runtime 默认。
  */
 
 import type {
@@ -154,6 +155,66 @@ function registryEffortMetadata(
   return consensusRegistryEffortMetadata(fallbackMatches, agent);
 }
 
+/** 取 id 去掉最后一层命名空间后的形态("z-ai/glm-5.2" → "glm-5.2";无 "/" 原样返回)。 */
+function suffixAfterNamespace(id: string): string {
+  const idx = id.lastIndexOf("/");
+  return idx >= 0 ? id.slice(idx + 1) : id;
+}
+
+/**
+ * 自定义模型缺省上下文窗口的 Registry 回填。与 `registryEffortMetadata` 同款两阶段:
+ *   - Stage 1 精确命中(entry.id / route.modelId 原样等于模型 ID);
+ *   - Stage 2 仅在精确无命中时,用去掉网关前缀(openai/xd/chatgpt)的形态,或与
+ *     Registry 命名空间条目 id 的去前缀形态(自定义 "glm-5.3" ↔ 条目 "z-ai/glm-5.3")
+ *     兜底匹配。
+ * 命中的、面向当前 agent 的条目在窗口上全部一致(perAgent 覆盖优先)才采用;
+ * 匹配不到、有条目未声明窗口或多方冲突时返回 undefined,由调用方落 200K 保守默认
+ * —— Registry 窗口是产品目录写定的真实上限,错误回填比不填更糟(见 #3883)。
+ * 两阶段必须分开:如 "gpt-5.5" 精确命中 openai/gpt-5.5,若混入后缀兜底还会捎上
+ * 折扣档 xd/codex-gpt-5.5(窗口不同),把本可回填的 1.05M 冲突成保守默认。
+ */
+function registryContextWindow(
+  registry: ModelRegistry | null | undefined,
+  modelId: string,
+  agent: AgentKind,
+): number | undefined {
+  if (agent === "pi" || !registry) return undefined;
+  const matchesEntry = (entry: ModelRegistry["models"][number], candidates: Set<string>) =>
+    entry.routes.some(
+      (route) =>
+        route.agents.includes(agent) &&
+        [...candidates].some(
+          (candidate) => entry.id === candidate || route.modelId === candidate,
+        ),
+    );
+  let matches = registry.models.filter((entry) =>
+    matchesEntry(entry, new Set([modelId])),
+  );
+  if (matches.length === 0) {
+    // Stage 2 — 网关前缀剥离 + 命名空间条目去前缀兜底。
+    const candidates = new Set<string>([modelId]);
+    for (const prefix of ['openai/', 'xd/', 'chatgpt/']) {
+      if (modelId.startsWith(prefix)) candidates.add(modelId.slice(prefix.length));
+    }
+    matches = registry.models.filter(
+      (entry) =>
+        matchesEntry(entry, candidates) ||
+        candidates.has(suffixAfterNamespace(entry.id)),
+    );
+  }
+  const uniqueEntries = [
+    ...new Map(matches.map((entry) => [entry.id, entry])).values(),
+  ];
+  if (uniqueEntries.length === 0) return undefined;
+  const windows = uniqueEntries.map(
+    (entry) => entry.perAgent?.[agent]?.contextWindow ?? entry.contextWindow,
+  );
+  if (windows.some((window) => window === undefined)) return undefined;
+  return windows.every((window) => window === windows[0])
+    ? windows[0]
+    : undefined;
+}
+
 /**
  * Fast mode is a Codex service-tier capability, so a user provider may inherit it only when the
  * configured model id exactly matches a Registry route for Codex. Prefix fallback is intentionally
@@ -211,6 +272,11 @@ function toCatalogModel(
     m.id,
     agent,
   );
+  // 用户显式填写优先;缺省才尝试 Registry 回填(命中即产品目录写定的真实上限)。
+  const registryWindow =
+    m.contextWindow === undefined
+      ? registryContextWindow(modelRegistry, m.id, agent)
+      : undefined;
   const effectiveEfforts = registryEfforts?.efforts ?? efforts;
   const defaultEffort =
     registryEfforts?.defaultEffort ??
@@ -226,10 +292,14 @@ function toCatalogModel(
     name: m.name,
     ...(agent === "pi" && m.piApi ? { piApi: m.piApi } : {}),
     ...(m.route ? { route: { ...m.route } } : {}),
-    contextWindow: m.contextWindow ?? DEFAULT_CUSTOM_CONTEXT_WINDOW,
-    // 用户自己填了才算显式声明;走 DEFAULT_CUSTOM_CONTEXT_WINDOW 兜底的不标记 ——
-    // 那是「仅用于展示」的保守默认,不能拿去收敛运行期上报的窗口。
-    ...(m.contextWindow !== undefined ? { contextWindowVerified: true } : {}),
+    contextWindow:
+      m.contextWindow ?? registryWindow ?? DEFAULT_CUSTOM_CONTEXT_WINDOW,
+    // 用户填写或 Registry 命中都属于「显式声明的真实上限」(产品目录写定),
+    // 可供 resolveVerifiedContextWindow 收敛运行期上报的窗口;纯 200K 兜底的
+    // 不标记 —— 那是「仅用于展示」的保守默认。
+    ...(m.contextWindow !== undefined || registryWindow !== undefined
+      ? { contextWindowVerified: true }
+      : {}),
     // 显式配置的窗口打标:编辑表单回转配置时必须与「缺省物化成的默认值」可区分,
     // 哪怕用户显式填的恰好等于当前默认(未来默认升级后显式值要原样保留)。
     ...(m.contextWindow !== undefined ? { contextWindowExplicit: true } : {}),


### PR DESCRIPTION
# fix(model-providers): 自定义模型缺省上下文窗口按 Registry 命中回填

Closes #3883

## 问题

自定义供应商的模型此前一律物化 200K 保守默认 `contextWindow`。用户走官方端点 + 裸模型 id(如智谱官方 Anthropic 兼容端点 + `glm-5.3`)时,模型实际可用 1M 上下文,却先被 200K 兜底压住:

- 模型选择器里显示 20 万;
- claude-code 侧的 `[1m]` 后缀开关随物化窗口(< 1e6)被剥离,1M 形同虚设;
- 用户必须逐模型手填「上下文(tokens)」才能解锁,且不知道要填多少。

## 方案

`buildUserProvider` 物化模型元数据时,缺省 `contextWindow` 改为按 Model Registry 回填:

1. **用户显式填写优先**(行为不变);
2. **缺省时回填 Registry 窗口**(perAgent 覆盖优先,如 gpt-5.5 在 claude-code 下 1.05M、codex 下 272K);
3. **仍未命中才落 200K 保守默认**(行为不变)。

匹配沿用既有 `registryEffortMetadata` 的两阶段结构:

- **Stage 1 精确命中**:`entry.id` / `route.modelId` 原样等于模型 ID;
- **Stage 2 兜底**(仅精确无命中时):网关前缀剥离(`openai/` `xd/` `chatgpt/`)+ 命名空间条目去前缀(自定义 `glm-5.3` ↔ 条目 `z-ai/glm-5.3`)。

两阶段必须分开:`gpt-5.5` 精确命中 `openai/gpt-5.5`,若混入后缀兜底还会捎上折扣档 `xd/codex-gpt-5.5`(272K),把本可回填的 1.05M 冲突成保守默认。

**保守性**:匹配不到、命中条目未声明窗口、或多方窗口冲突时,一律保持 200K 不回填——Registry 窗口是产品目录写定的真实上限,错误回填(高估导致会话中后段 400)比不填(仅浪费可用窗口)更糟。

**配套语义**:

- 用户填写或 Registry 命中均标记 `contextWindowVerified: true`(显式声明的真实上限,可供 `resolveVerifiedContextWindow` 收敛运行期上报的窗口);纯 200K 兜底不标记(仅用于展示的保守默认)。
- `contextWindowExplicit` 仍只在用户显式填写时置位——编辑表单回转配置时继续区分「显式值」与「回填/默认值」,未来默认升级后显式值原样保留。

**数据**:catalog/model-registry.json 补登 `z-ai/glm-5.3`(contextWindow 1M,xd 路由 claude-code/codex,perAgent claude-code efforts),形态对齐既有 `z-ai/glm-5.2` 条目。

## 效果(以 #3883 场景为例)

| 场景 | 改前 | 改后 |
| --- | --- | --- |
| 自定义 `glm-5.3` + 官方端点,未填窗口 | 200K(`[1m]` 被剥离) | **1M**(Registry 回填) |
| 自定义 `gpt-5.5`,claude-code / codex | 200K | 1.05M / 272K(perAgent) |
| 用户显式填 300K | 300K | 300K(不变,显式优先) |
| 未登记模型(如 `glm-5.3-flash`) | 200K | 200K(保守默认不变) |
| 同名多条目窗口冲突 | 200K | 200K(冲突不回填) |

## 测试

- `src/__tests__/user-provider.test.ts` 新增 5 例:裸 id / 命名空间 id 命中回填、perAgent 分 agent 窗口、网关前缀剥离命中、冲突与未声明窗口保持保守默认、显式填写压过 Registry 回填;
- `packages/model-providers` 全量 689 例通过,`tsc --noEmit` 通过。
