### PR TITLE
fix(scheduler): 定时任务路由拒绝按原因分类,exclusive Grok 缺来源不再误报「设置里停用」

### DIFF
--- a/apps/desktop/src/main/maker-host/__tests__/model-route-guard.test.ts
+++ b/apps/desktop/src/main/maker-host/__tests__/model-route-guard.test.ts
@@ -11,6 +11,7 @@ import { buildRegistry, type Catalog, type CatalogModel, type Provider } from '@
 
 import {
   checkModelRoute,
+  describeModelRouteRejection,
   materializeExclusiveProviderRoute,
   pickEnabledFallbackModel,
   resolveCurrentSetModelProviderId,
@@ -19,6 +20,26 @@ import {
   resolveSetModelGuardProviderId,
   shouldApplyExclusiveProviderReroute,
 } from '../model-route-guard.js';
+
+describe('describeModelRouteRejection', () => {
+  it('exclusive-source-unavailable 说清缺 SuperGrok/自定义源,不再冒充「设置里停用」(#3884)', () => {
+    const text = describeModelRouteRejection('exclusive-source-unavailable', 'grok-4.6', null);
+    expect(text).toContain('requires SuperGrok (xAI) or an explicitly selected custom source');
+    expect(text).not.toContain('disabled in settings');
+  });
+
+  it('其余 reason 保持既有措辞', () => {
+    expect(describeModelRouteRejection('model-disabled', 'm', null)).toBe(
+      'model "m" is disabled in settings',
+    );
+    expect(describeModelRouteRejection('explicit-source-disabled', 'm', 'p')).toBe(
+      'provider "p" is disabled for model "m" in settings',
+    );
+    expect(describeModelRouteRejection('capability-model', 'm', null)).toContain('not an agent chat model');
+    expect(describeModelRouteRejection('model-retired', 'm', null)).toContain('retired from the catalog');
+    expect(describeModelRouteRejection('payment-required', 'm', null)).toContain('requires paid access');
+  });
+});
 
 function model(id: string, extra: Partial<CatalogModel> = {}): CatalogModel {
   return { id, name: id, contextWindow: 200_000, efforts: [], defaultEffort: null, ...extra };

--- a/apps/desktop/src/main/maker-host/model-route-guard.ts
+++ b/apps/desktop/src/main/maker-host/model-route-guard.ts
@@ -69,12 +69,15 @@ export type ModelRouteRejectReason = Extract<ModelRouteVerdict, { kind: 'reject'
  * exclusive grok 未登录 SuperGrok 时用户被引导去设置里找一个并不存在的停用开关(#3884)。
  */
 export function describeModelRouteRejection(
-  // runner 的 checkModelRoute 依赖契约把 reason 放宽为 string(测试桩友好);未知值落 default。
-  reason: ModelRouteRejectReason | string,
+  reason: ModelRouteRejectReason,
   model: string,
   providerId: string | null | undefined,
 ): string {
+  // 穷尽 switch,不设 default:新增 reason 时编译器逼着补文案,不会静默落回
+  // 「disabled in settings」这条本次要消除的误分类。
   switch (reason) {
+    case 'model-disabled':
+      return `model "${model}" is disabled in settings`;
     case 'explicit-source-disabled':
       return `provider "${providerId ?? ''}" is disabled for model "${model}" in settings`;
     case 'capability-model':
@@ -85,10 +88,9 @@ export function describeModelRouteRejection(
       return `model "${model}" requires paid access`;
     case 'exclusive-source-unavailable':
       return `model "${model}" requires SuperGrok (xAI) or an explicitly selected custom source; the default gateway cannot serve it`;
-    case 'model-disabled':
-    default:
-      return `model "${model}" is disabled in settings`;
   }
+  const unreachable: never = reason;
+  return `model "${model}" is unavailable (${String(unreachable)})`;
 }
 
 export type ExclusiveProviderRoute =

--- a/apps/desktop/src/main/maker-host/model-route-guard.ts
+++ b/apps/desktop/src/main/maker-host/model-route-guard.ts
@@ -61,6 +61,36 @@ export type ModelRouteVerdict =
         | 'exclusive-source-unavailable';
     };
 
+export type ModelRouteRejectReason = Extract<ModelRouteVerdict, { kind: 'reject' }>['reason'];
+
+/**
+ * 路由拒绝原因 → 一句可行动的说明。会话切模(register)与定时任务触发(runner)共用,
+ * 两个入口不得各自维护一份措辞:定时任务此前把所有 reason 都写成「disabled in settings」,
+ * exclusive grok 未登录 SuperGrok 时用户被引导去设置里找一个并不存在的停用开关(#3884)。
+ */
+export function describeModelRouteRejection(
+  // runner 的 checkModelRoute 依赖契约把 reason 放宽为 string(测试桩友好);未知值落 default。
+  reason: ModelRouteRejectReason | string,
+  model: string,
+  providerId: string | null | undefined,
+): string {
+  switch (reason) {
+    case 'explicit-source-disabled':
+      return `provider "${providerId ?? ''}" is disabled for model "${model}" in settings`;
+    case 'capability-model':
+      return `model "${model}" is not an agent chat model`;
+    case 'model-retired':
+      return `model "${model}" has been retired from the catalog`;
+    case 'payment-required':
+      return `model "${model}" requires paid access`;
+    case 'exclusive-source-unavailable':
+      return `model "${model}" requires SuperGrok (xAI) or an explicitly selected custom source; the default gateway cannot serve it`;
+    case 'model-disabled':
+    default:
+      return `model "${model}" is disabled in settings`;
+  }
+}
+
 export type ExclusiveProviderRoute =
   | { kind: 'keep' }
   | { kind: 'pin'; providerId: string }

--- a/apps/desktop/src/main/maker-ipc/register.ts
+++ b/apps/desktop/src/main/maker-ipc/register.ts
@@ -897,6 +897,7 @@ import {
 } from '../maker-host/model-disable-store.js';
 import { readProviderOrder, setProviderOrder } from '../maker-host/provider-order-store.js';
 import {
+  describeModelRouteRejection,
   resolveCurrentSetModelProviderId,
   resolveExclusiveSetModelReroute,
   resolveSetModelGuardProviderId,
@@ -8003,17 +8004,7 @@ export function registerMakerIpc(maker: Maker, options: RegisterMakerIpcOptions)
     if (verdict.kind === 'reject') {
       throwIpcError(
         'INVALID_PARAMS',
-        verdict.reason === 'explicit-source-disabled'
-          ? `provider "${providerId}" is disabled for model "${model}" in settings`
-          : verdict.reason === 'capability-model'
-            ? `model "${model}" is not an agent chat model`
-            : verdict.reason === 'model-retired'
-              ? `model "${model}" has been retired from the catalog`
-              : verdict.reason === 'payment-required'
-                ? `model "${model}" requires paid access`
-                : verdict.reason === 'exclusive-source-unavailable'
-                  ? `model "${model}" requires SuperGrok (xAI) and cannot use the default gateway`
-                  : `model "${model}" is disabled in settings`,
+        describeModelRouteRejection(verdict.reason, model, providerId),
       );
     }
     return verdict.kind === 'reroute' ? verdict.providerId : undefined;

--- a/apps/desktop/src/main/scheduler-host/__tests__/runnerQueuedDispatch.test.ts
+++ b/apps/desktop/src/main/scheduler-host/__tests__/runnerQueuedDispatch.test.ts
@@ -1487,6 +1487,36 @@ describe('MakerScheduleRunner queued dispatch (busy bound session)', () => {
     expect(harness.setEffort).not.toHaveBeenCalled(); // 终检在 effort 下发之前拦截
   });
 
+  it('exclusive grok 无 SuperGrok 且未钉自定义源时,失败原因说清缺来源而不是「设置里停用」(#3884)', async () => {
+    const harness = createSessionHarness(async () => ({ accepted: true }));
+    harness.setModel.mockRejectedValue(new Error('switchModel rejected'));
+    const queue = createQueueHarness({ busy: true });
+    const checkModelRoute = vi.fn(
+      async (_agent: string, model: string, _providerId: string | null) =>
+        model === 'claude-opus-4-6'
+          ? ({ kind: 'reject', reason: 'exclusive-source-unavailable' } as const)
+          : ({ kind: 'pass' } as const),
+    );
+    const { runner } = createRunnerHarness(harness.session, queue.deps, {
+      availableModels: [
+        { id: 'claude-opus-4-6', efforts: ['low', 'medium', 'high'], defaultEffort: 'high' },
+        { id: 'claude-opus-4-8', efforts: ['low', 'medium', 'high'], defaultEffort: 'high' },
+      ],
+      checkModelRoute,
+    });
+
+    const firePromise = runner.fire(
+      heartbeatSchedule({ model: 'claude-opus-4-8' }),
+      createFireContext(),
+    );
+    await vi.waitFor(() => expect(queue.enqueueCalls.length).toBe(1));
+    await queue.accept();
+
+    await expect(firePromise).rejects.toThrow(/requires SuperGrok \(xAI\) or an explicitly selected custom source/);
+    await expect(firePromise).rejects.not.toThrow(/disabled in settings/);
+    await expect(firePromise).rejects.toThrow(/\(exclusive-source-unavailable\)/);
+  });
+
   it('clamps follow-session queued effort to the drifted live model, not the stale baseline (PR #479 review)', async () => {
     // follow-session:schedule 无显式 model(沿用会话模型)但覆盖 effort=max。排队等待期间用户
     // 把会话切到只到 xhigh 的模型 → 本轮不 setModel、turn 跑在 live.model。effort 必须按 live.model

--- a/apps/desktop/src/main/scheduler-host/runner.ts
+++ b/apps/desktop/src/main/scheduler-host/runner.ts
@@ -42,6 +42,7 @@ import type {
   TurnContinuationState,
 } from '@cindy/maker-core';
 import { clampEffortToSupported } from '@cindy/model-providers';
+import { describeModelRouteRejection } from '../maker-host/model-route-guard.js';
 import { shouldApplyExclusiveProviderRerouteLive } from '../maker-host/model-route-guard-live.js';
 import { SCHEDULER_RUN_ID_VENDOR_OPTION } from '@cindy/maker-scheduler';
 import type {
@@ -869,7 +870,7 @@ export class MakerScheduleRunner implements ScheduleRunner {
       const verdict = await this.deps.checkModelRoute(effectiveAgentKind, model, createProviderId);
       if (verdict.kind === 'reject') {
         throw new Error(
-          `schedule route unavailable: model "${model}" is disabled in settings (${verdict.reason})`,
+          `schedule route unavailable: ${describeModelRouteRejection(verdict.reason, model, createProviderId)} (${verdict.reason})`,
         );
       }
       if (verdict.kind === 'reroute' && shouldApplyExclusiveProviderRerouteLive(createProviderId)) {
@@ -1362,7 +1363,7 @@ export class MakerScheduleRunner implements ScheduleRunner {
         );
         if (verdict.kind === 'reject') {
           throw new Error(
-            `schedule route unavailable: model "${runtimeModel}" is disabled in settings (${verdict.reason}, revalidated before dispatch)`,
+            `schedule route unavailable: ${describeModelRouteRejection(verdict.reason, runtimeModel, dispatchProviderId)} (${verdict.reason}, revalidated before dispatch)`,
           );
         }
         if (verdict.kind === 'reroute' && shouldApplyExclusiveProviderRerouteLive(dispatchProviderId)) {
@@ -2145,7 +2146,7 @@ export class MakerScheduleRunner implements ScheduleRunner {
       const verdict = await this.deps.checkModelRoute(live.agentKind, targetModel, routeProviderId);
       if (verdict.kind === 'reject') {
         throw new QueuedRouteDisabledError(
-          `schedule route unavailable: model "${targetModel}" is disabled in settings (${verdict.reason})`,
+          `schedule route unavailable: ${describeModelRouteRejection(verdict.reason, targetModel, routeProviderId)} (${verdict.reason})`,
         );
       }
       if (verdict.kind === 'reroute' && shouldApplyExclusiveProviderRerouteLive(routeProviderId)) {
@@ -2210,7 +2211,7 @@ export class MakerScheduleRunner implements ScheduleRunner {
         );
         if (retained.kind === 'reject') {
           throw new QueuedRouteDisabledError(
-            `schedule route unavailable: current session route (model "${live.model}") is disabled in settings (${retained.reason})`,
+            `schedule route unavailable: current session route: ${describeModelRouteRejection(retained.reason, live.model, currentProviderId)} (${retained.reason})`,
           );
         }
       }
@@ -2277,7 +2278,7 @@ export class MakerScheduleRunner implements ScheduleRunner {
       );
       if (actual.kind === 'reject') {
         throw new QueuedRouteDisabledError(
-          `schedule route unavailable: runtime model "${runtimeModel}" is disabled in settings (${actual.reason})`,
+          `schedule route unavailable: runtime route: ${describeModelRouteRejection(actual.reason, runtimeModel, applyProviderId ?? currentProviderId)} (${actual.reason})`,
         );
       }
     }

--- a/apps/desktop/src/main/scheduler-host/runner.ts
+++ b/apps/desktop/src/main/scheduler-host/runner.ts
@@ -42,7 +42,10 @@ import type {
   TurnContinuationState,
 } from '@cindy/maker-core';
 import { clampEffortToSupported } from '@cindy/model-providers';
-import { describeModelRouteRejection } from '../maker-host/model-route-guard.js';
+import {
+  describeModelRouteRejection,
+  type ModelRouteRejectReason,
+} from '../maker-host/model-route-guard.js';
 import { shouldApplyExclusiveProviderRerouteLive } from '../maker-host/model-route-guard-live.js';
 import { SCHEDULER_RUN_ID_VENDOR_OPTION } from '@cindy/maker-scheduler';
 import type {
@@ -254,7 +257,10 @@ export interface MakerScheduleRunnerDeps {
     model: string,
     providerId: string | null,
   ) => Promise<
-    { kind: 'pass' } | { kind: 'reroute'; providerId: string } | { kind: 'reject'; reason: string }
+    | { kind: 'pass' }
+    | { kind: 'reroute'; providerId: string }
+    // reason 用 model-route-guard 的严格联合:文案映射穷尽 switch,新增原因编译期就暴露。
+    | { kind: 'reject'; reason: ModelRouteRejectReason }
   >;
   /**
    * 某 (来源, 模型, agent) 拷贝的能力(efforts / Fast)。effort 与 Fast 支持都是


### PR DESCRIPTION
## 这次改了什么

### 摘要

fix #3884 的 main 侧切片:定时任务触发时的路由拒绝原因分类。

`scheduler-host/runner.ts` 五处路由拒绝(首检、派发前复检、排队目标裁决、当前会话路由裁决、运行时终检)不论 `verdict.reason` 为何,一律写成 `model "x" is disabled in settings (<reason>)`。当模型是 exclusive Grok(裸 `grok-*`)、本机未登录 SuperGrok、任务又没钉自定义源时,reason 是 `exclusive-source-unavailable`,用户却被引导去设置里找一个并不存在的「停用开关」——这是 issue 报告的第 3 点。同仓 `maker-ipc/register.ts` 的会话切模路径早已对各 reason 分别给出语义(含 exclusive 的 SuperGrok 提示),两个入口各维护一份措辞导致漂移。

改动:在 `maker-host/model-route-guard.ts`(verdict reason 的定义处)抽出 `describeModelRouteRejection(reason, model, providerId)`,register 与 runner 共用;`exclusive-source-unavailable` 统一为可行动文案「requires SuperGrok (xAI) or an explicitly selected custom source; the default gateway cannot serve it」,其余 reason 措辞不变。**不放宽 exclusive Grok 路由规则**(与 #2898 一致,issue 内维护者助手分析亦不建议)。

### 变更类型

- [x] `fix` 缺陷修复

### 范围

- 关联 Issue / 需求:#3884(main 侧错误分类切片;renderer 侧「改引擎后 providerId 被清空」的精确位置已在 issue 评论给出,属产品语义决策,本 PR 不动 renderer)
- 本 PR 包含:`model-route-guard.ts` 新增共享映射函数;`register.ts` 改用共享函数(消除重复三元链);`runner.ts` 五处拒绝路径接入;guard 单测 2 例、runner 回归 1 例
- 明确不包含:scheduler 表单 providerId 持久化(renderer)、Codex 与 Claude Code 默认源补全差异(既有设计)、exclusive Grok 改道规则
- 用户可见变化:定时任务因 exclusive Grok 缺来源失败时,run 历史/错误文案说清「需要 SuperGrok 或为任务选择自定义源」,不再误报「设置里停用」;会话切模的 exclusive 文案同步为同一句
- 是否存在 breaking change:无(错误字符串前缀 `schedule route unavailable:` 与 `(<reason>)` 后缀保留;`model-disabled` 等既有措辞不变)

### UI 变化

不涉及:main 进程错误文案与共享纯函数,无 UI 代码。

## 怎么验证的

### 自动验证

```text
pnpm vitest run model-route-guard.test.ts runnerQueuedDispatch.test.ts sessionRuntimeControlWiring.test.ts → 133 passed
反证:stash 掉 runner.ts 后,新增 runner 用例(exclusive-source-unavailable 终检)失败;恢复后通过
pnpm test:unit:related → PASS(apps/desktop unit)
pnpm --filter desktop run --if-present typecheck → 通过(exit 0)
```

### 手动验证

未做实机(需自定义 Grok 源 + 未登录 SuperGrok 环境);错误分类由纯函数与 runner 回归覆盖。

## 风险与回滚

- 风险:低——纯文案分类,不改路由裁决与 verdict 生成;`reason` 参数按 runner 依赖契约放宽为 `string`,未知值落 default(与旧行为一致)。
- 回滚:revert 单 commit。
