### PR TITLE
fix(mobile): 系统相册/相机选图的 HEIC/HEIF 就位时转 JPEG,补齐 picker 入口缺失的格式归一

### DIFF
--- a/apps/mobile/src/__tests__/mobileImageAttachment.test.ts
+++ b/apps/mobile/src/__tests__/mobileImageAttachment.test.ts
@@ -81,6 +81,8 @@ describe('buildMobileImageAttachmentCandidate · HEIC / HEIF 归一(#3889)', () 
       uri: 'file:///tmp/converted.jpg',
       name: 'IMG_0001.jpg',
       mimeType: 'image/jpeg',
+      // 转码后 size 必须归 0:管线据此 stat 真实大小,否则沿用原 HEIC 字节数会撞大小校验。
+      size: 0,
     });
     expect(convertToJpeg).toHaveBeenCalledWith('file:///tmp/IMG_0001.HEIF');
   });
@@ -96,6 +98,7 @@ describe('buildMobileImageAttachmentCandidate · HEIC / HEIF 归一(#3889)', () 
       uri: 'file:///tmp/shot.jpg',
       name: 'screenshot.jpg',
       mimeType: 'image/jpeg',
+      size: 0,
     });
   });
 

--- a/apps/mobile/src/__tests__/mobileImageAttachment.test.ts
+++ b/apps/mobile/src/__tests__/mobileImageAttachment.test.ts
@@ -1,9 +1,10 @@
-import { beforeAll, describe, expect, it } from 'vitest';
+import { beforeAll, describe, expect, it, vi } from 'vitest';
 import { i18n } from '@/i18n';
 import { MOBILE_MAX_ATTACHMENT_BYTES } from '@/session/attachments';
 import {
   assertMobileImageSize,
   buildMobileImageAttachmentCandidate,
+  needsJpegConversion,
 } from '@/session/mobileImageAttachment';
 
 // 文案已 i18n 化;固定 zh-CN 让字面量断言与语言环境解耦(全局 mock 默认 en-US)。
@@ -54,5 +55,61 @@ describe('mobileImageAttachment', () => {
     expect(() => buildMobileImageAttachmentCandidate({ uri: '' }, 0)).toThrow('没有读取到可上传的图片');
     expect(() => assertMobileImageSize(0)).toThrow('图片为空');
     expect(() => assertMobileImageSize(MOBILE_MAX_ATTACHMENT_BYTES + 1)).toThrow('图片超过');
+  });
+});
+
+describe('buildMobileImageAttachmentCandidate · HEIC / HEIF 归一(#3889)', () => {
+  it('白名单格式(png / jpg / webp)不带 resolve 钩子,候选形状不变', () => {
+    for (const [fileName, mimeType] of [['a.png', 'image/png'], ['b.JPG', null], ['c.webp', 'image/webp']] as const) {
+      const candidate = buildMobileImageAttachmentCandidate({ uri: `file:///tmp/${fileName}`, fileName, mimeType }, 0);
+      expect(candidate).not.toHaveProperty('resolve');
+    }
+  });
+
+  it('文件名为 .heic / .HEIF 时带 resolve:预览仍用原始 uri,就位时转 JPEG 并改名', async () => {
+    const convertToJpeg = vi.fn().mockResolvedValue('file:///tmp/converted.jpg');
+    const candidate = buildMobileImageAttachmentCandidate({
+      uri: 'file:///tmp/IMG_0001.HEIF',
+      fileName: 'IMG_0001.HEIF',
+      fileSize: 321,
+      mimeType: null,
+    }, 0, { convertToJpeg });
+    // 入队当帧:原始 uri / 名字不动,托盘预览用得上。
+    expect(candidate).toMatchObject({ uri: 'file:///tmp/IMG_0001.HEIF', name: 'IMG_0001.HEIF', size: 321 });
+    expect(convertToJpeg).not.toHaveBeenCalled();
+    await expect(candidate.resolve!()).resolves.toEqual({
+      uri: 'file:///tmp/converted.jpg',
+      name: 'IMG_0001.jpg',
+      mimeType: 'image/jpeg',
+    });
+    expect(convertToJpeg).toHaveBeenCalledWith('file:///tmp/IMG_0001.HEIF');
+  });
+
+  it('MIME 明示 image/heic 即使文件名扩展名像白名单也转 JPEG(MIME 为准)', async () => {
+    const convertToJpeg = vi.fn().mockResolvedValue('file:///tmp/shot.jpg');
+    const candidate = buildMobileImageAttachmentCandidate({
+      uri: 'file:///tmp/screenshot.png',
+      fileName: 'screenshot.png',
+      mimeType: 'image/heic',
+    }, 3, { convertToJpeg });
+    await expect(candidate.resolve!()).resolves.toEqual({
+      uri: 'file:///tmp/shot.jpg',
+      name: 'screenshot.jpg',
+      mimeType: 'image/jpeg',
+    });
+  });
+
+  it('未知扩展名(如 .tiff)同样归一;无扩展名但 MIME 为 jpeg 的 ph:// 资产不转', () => {
+    expect(buildMobileImageAttachmentCandidate({ uri: 'file:///tmp/x.tiff', fileName: 'x.tiff', mimeType: 'image/tiff' }, 0))
+      .toHaveProperty('resolve');
+    expect(buildMobileImageAttachmentCandidate({ uri: 'ph://asset-no-ext', mimeType: 'image/jpeg' }, 0))
+      .not.toHaveProperty('resolve');
+  });
+
+  it('needsJpegConversion 判定与粘贴链路口径一致', () => {
+    expect(needsJpegConversion('a.heic', null)).toBe(true);
+    expect(needsJpegConversion('a.jpg', 'image/heif')).toBe(true);
+    expect(needsJpegConversion('a.jpg', 'image/jpeg')).toBe(false);
+    expect(needsJpegConversion('a.GIF', undefined)).toBe(false);
   });
 });

--- a/apps/mobile/src/session/mobileImageAttachment.ts
+++ b/apps/mobile/src/session/mobileImageAttachment.ts
@@ -19,7 +19,7 @@ export type MobileImageAttachmentCandidate = MobileAttachmentUploadCandidate & {
    * 仅 HEIC / HEIF 等非白名单格式带此钩子:任务开跑时就地转 JPEG(#3889)。
    * 托盘预览仍用原始 uri;返回字段由上传管线覆盖到 candidate 上。
    */
-  resolve?: () => Promise<{ uri: string; name: string; mimeType: string }>;
+  resolve?: () => Promise<{ uri: string; name: string; mimeType: string; size: number }>;
 };
 
 /** JPEG 转换器(可注入,单测用假实现避免触碰原生模块)。 */
@@ -68,6 +68,10 @@ export function buildMobileImageAttachmentCandidate(
       uri: await convert(uri),
       name: replaceImageFileExt(name, 'jpg'),
       mimeType: 'image/jpeg',
+      // 转码后字节数已变:置 0 让管线 stat 转换产物的真实大小。沿用 picker 给的原
+      // HEIC 字节数会在 uploadMobileAttachmentFromFile 的大小一致性校验处被拒
+      //(Attachment size changed),恰好卡死本次要修的小图场景(review P1)。
+      size: 0,
     }),
   };
 }

--- a/apps/mobile/src/session/mobileImageAttachment.ts
+++ b/apps/mobile/src/session/mobileImageAttachment.ts
@@ -15,18 +15,40 @@ export type MobileImageAttachmentCandidate = MobileAttachmentUploadCandidate & {
   uri: string;
   width?: number | null;
   height?: number | null;
+  /**
+   * 仅 HEIC / HEIF 等非白名单格式带此钩子:任务开跑时就地转 JPEG(#3889)。
+   * 托盘预览仍用原始 uri;返回字段由上传管线覆盖到 candidate 上。
+   */
+  resolve?: () => Promise<{ uri: string; name: string; mimeType: string }>;
 };
+
+/** JPEG 转换器(可注入,单测用假实现避免触碰原生模块)。 */
+export type MobileImageJpegConverter = (uri: string) => Promise<string>;
+
+export interface BuildMobileImageAttachmentCandidateDeps {
+  convertToJpeg?: MobileImageJpegConverter;
+}
+
+/**
+ * 附件白名单与下游模型图像接口都只认这四种(与 attachments.ts 的
+ * SUPPORTED_IMAGE_EXTS、pastedImageAttachment 的 WHITELISTED_IMAGE_EXTS 同口径)。
+ */
+const WHITELISTED_IMAGE_EXTS = new Set(['.jpeg', '.jpg', '.png', '.gif', '.webp']);
+const HEIC_MIME_TYPES = new Set(['image/heic', 'image/heif', 'image/heic-sequence', 'image/heif-sequence']);
+/** 与 useContextSheetMediaAssets / pastedImageAttachment 同口径:0.9 视觉无损,体积可控。 */
+const IMAGE_JPEG_COMPRESS = 0.9;
 
 export function buildMobileImageAttachmentCandidate(
   asset: MobileImagePickerAssetLike,
   index: number,
+  deps: BuildMobileImageAttachmentCandidateDeps = {},
 ): MobileImageAttachmentCandidate {
   const uri = asset.uri?.trim();
   if (!uri) throw new Error(i18n.t('composer.upload.noImageRead'));
   const mimeType = normalizeImageMimeType(asset.mimeType, uri);
   const name = normalizeImageFileName(asset.fileName, uri, mimeType, index);
   const size = Number(asset.fileSize ?? 0);
-  return {
+  const candidate: MobileImageAttachmentCandidate = {
     uri,
     name,
     size: Number.isFinite(size) && size > 0 ? size : 0,
@@ -34,6 +56,46 @@ export function buildMobileImageAttachmentCandidate(
     width: asset.width,
     height: asset.height,
   };
+  if (!needsJpegConversion(name, mimeType)) return candidate;
+  // 系统 Photos picker / 相机可能直接交出 HEIC / HEIF(iOS 原生格式):MIME 原样
+  // 放行、文件名保留 .heic,而 preprocess 只在大图 / 超长边时才顺带 JPEG 重编码,
+  // 小图会原样直传进只认 jpeg/png/gif/webp 的下游,表现为「截图发送失败」(#3889)。
+  // 与相册 ph:// 链路、粘贴链路同一口径:在就位钩子里就地转 JPEG。
+  const convert = deps.convertToJpeg ?? convertMobileImageToJpegNative;
+  return {
+    ...candidate,
+    resolve: async () => ({
+      uri: await convert(uri),
+      name: replaceImageFileExt(name, 'jpg'),
+      mimeType: 'image/jpeg',
+    }),
+  };
+}
+
+/** 文件名扩展名不在白名单、或 MIME 明示 HEIC / HEIF → 需转 JPEG 才能进上传管线。 */
+export function needsJpegConversion(name: string, mimeType: string | null | undefined): boolean {
+  const mime = mimeType?.trim().toLowerCase() ?? '';
+  if (HEIC_MIME_TYPES.has(mime)) return true;
+  return !WHITELISTED_IMAGE_EXTS.has(extractRemoteFileExt(name));
+}
+
+/**
+ * 默认 JPEG 转换:expo-image-manipulator 动态 import,保证本模块在 vitest(node)
+ * 下可导入;测试路径经 deps.convertToJpeg 注入。粘贴链路复用同一实现。
+ */
+export async function convertMobileImageToJpegNative(uri: string): Promise<string> {
+  const { ImageManipulator, SaveFormat } = await import('expo-image-manipulator');
+  const context = ImageManipulator.manipulate(uri);
+  const image = await context.renderAsync();
+  try {
+    const saved = await image.saveAsync({ compress: IMAGE_JPEG_COMPRESS, format: SaveFormat.JPEG });
+    return saved.uri;
+  } finally {
+    // render 结果持有 native GPU 纹理,不显式 release 会在 GC 前持续占用
+    //(与 useContextSheetMediaAssets / mobileImagePreprocess 同模式)。
+    image.release();
+    context.release();
+  }
 }
 
 export function assertMobileImageSize(size: number): void {
@@ -67,6 +129,12 @@ function normalizeImageFileName(
   const uriName = basenameFromUri(uri);
   if (uriName && extractRemoteFileExt(uriName)) return uriName;
   return `mobile-image-${index + 1}.${extForImageMimeType(mimeType)}`;
+}
+
+function replaceImageFileExt(name: string, targetExt: string): string {
+  const ext = extractRemoteFileExt(name);
+  const base = ext ? name.slice(0, name.length - ext.length) : name;
+  return `${base}.${targetExt}`;
 }
 
 function basenameFromUri(uri: string): string {

--- a/apps/mobile/src/session/pastedImageAttachment.ts
+++ b/apps/mobile/src/session/pastedImageAttachment.ts
@@ -8,9 +8,8 @@
  * 就地转 JPEG,避免在链路下游变成不可用附件(同 Context 面板相册链路的处理)。
  */
 import { extractRemoteFileExt } from '@/session/attachments';
+import { convertMobileImageToJpegNative } from '@/session/mobileImageAttachment';
 
-/** 与 useContextSheetMediaAssets 同口径:iOS 原生格式,白名单与下游模型接口都不收。 */
-const PASTED_JPEG_COMPRESS = 0.9;
 export const COMPOSER_PASTED_IMAGE_FILE_PREFIX = 'cindy-composer-paste-';
 
 const WHITELISTED_IMAGE_EXTS = ['jpg', 'jpeg', 'png', 'gif', 'webp'] as const;
@@ -83,20 +82,12 @@ export async function resolvePastedImageAsset(
       mimeType: mimeTypeForPastedImageExt(classified.ext),
     };
   }
-  const convert = deps.convertToJpeg ?? convertToJpegNative;
+  const convert = deps.convertToJpeg ?? convertMobileImageToJpegNative;
   return {
     uri: await convert(uri),
     fileName: buildPastedImageFileName(index, 'jpg'),
     mimeType: 'image/jpeg',
   };
-}
-
-/** 默认 JPEG 转换:同 resolveContextSheetMediaAssetForUpload 的 HEIC 处理方式。 */
-async function convertToJpegNative(uri: string): Promise<string> {
-  const { ImageManipulator, SaveFormat } = await import('expo-image-manipulator');
-  const image = await ImageManipulator.manipulate(uri).renderAsync();
-  const saved = await image.saveAsync({ compress: PASTED_JPEG_COMPRESS, format: SaveFormat.JPEG });
-  return saved.uri;
 }
 
 function basenameFromUri(uri: string): string {


### PR DESCRIPTION
## 这次改了什么

### 摘要

修复 #3889 的仓内确定性缺口:**系统 Photos picker / 相机入口是唯一没有 HEIC/HEIF 归一的图片入口**。

现状对照(均在 `apps/mobile/src/session/`):
- 相册 ph:// 路径 `useContextSheetMediaAssets.ts` 显式把 HEIC/HEIF 转 JPEG,注释写明「附件白名单与下游模型图像接口都只认 jpeg/png/gif/webp,直接放行 HEIC 会在链路下游变成不可用附件」;
- 粘贴路径 `pastedImageAttachment.ts` 对非白名单扩展名(HEIC/HEIF/TIFF/无扩展名)就地转 JPEG;
- **picker 路径** `useMobileLocalAttachments.addImages` → `buildMobileImageAttachmentCandidate`:`normalizeImageMimeType` 对 `image/heic` 原样放行、文件名保留 `.heic`;`planMobileImageUploadPreprocess` 只在「大图或长边 > 2048」时顺带 JPEG 重编码,且预处理失败静默回退原图——小图 / 重编码失败的 HEIC 会原样直传进只认四种格式的下游。这与 issue 现象吻合:拍照(大图,必被重编码)能发,截屏不行,隔空投送到别的 iPhone 也不行(同一文件)。

修复:在 `buildMobileImageAttachmentCandidate` 对需转换的候选(MIME 明示 heic/heif,或文件名扩展名不在白名单)挂上传管线既有的 **`resolve` 就位钩子**,任务开跑时转 JPEG 并改名 / 改 MIME;托盘预览仍用原始 uri(与相册 / 粘贴路径同一模式)。白名单图**不新增任何字段**,行为逐字节不变。JPEG 转换器抽为共享导出 `convertMobileImageToJpegNative`,粘贴路径改为复用(删除其 4 行私有重复实现)。

### 变更类型

- [x] `fix` 缺陷修复

### 范围

- 关联 Issue / 需求:Fixes #3889
- 本 PR 包含:`mobileImageAttachment.ts`(HEIC 判定 + resolve 钩子 + 共享转换器)、`pastedImageAttachment.ts`(复用共享转换器)、`mobileImageAttachment.test.ts`(+5 用例)
- 明确不包含:原生配置 / 依赖 / config plugin(**不触及 runtime fingerprint,不触发冷更**);预处理的「失败回退原图」语义(转换后已是 JPEG,回退不再产生不可用格式);expo-image-picker 的 `preferredAssetRepresentationMode` 选项(留作后续,若真机证明 picker 总能交出 JPEG 则本修复只是防御层)
- 用户可见变化:从系统相册 / 相机选中的 HEIC/HEIF 图片可正常发送
- 是否存在 breaking change:无

### UI 变化

- 不涉及:附件上传管线(apps/mobile/src/session),无界面 / 交互 / 文案改动;check:pr-design-basis 按路径命中 UI 目录,故按模板补齐本小节。
- 引用的设计规范:不涉及:附件上传管线纯逻辑改动,无视觉、交互、文案变化。

## 怎么验证的

### 自动验证

```text
pnpm vitest run mobileImageAttachment / pastedImageAttachment / mobileLocalAttachmentUpload → 3 files, 62 passed
反证(变异法):把转换判定短路成永不转换后重跑 mobileImageAttachment.test.ts → 3 个新增用例失败,恢复后全过
pnpm --filter mobile run --if-present typecheck → 通过(exit 0)
pnpm test:unit:related → PASS(apps/mobile unit)
```

新增用例覆盖:白名单 png/jpg/webp 不带 resolve、`.HEIF` 文件名 → resolve 转 JPEG 并改名、MIME `image/heic` 优先于扩展名、`.tiff` 归一 / 无扩展名 ph:// + jpeg MIME 不转、`needsJpegConversion` 判定与粘贴链路口径一致。

### 手动验证

未做 iPhone 17 / iOS 26 真机验证(无设备)。如实说明:本 PR 消除的是代码层可证明的缺口(picker 路径缺少其他两条入口都有的归一);issue 中截屏失败的**具体触发格式**(PNG / HDR HEIF)仍需 QA 按分析矩阵确认——若失败截屏原本就是 PNG,则本修复不覆盖该案,需另查 PNG 路径。已在 issue 请提报人回报失败文件的原始格式。

## 风险与回滚

- 风险:低。仅对「MIME 为 heic/heif 或扩展名非白名单」的候选新增就位转换;转换失败会以任务失败(可重试)呈现,而不是静默送出下游必拒的格式。
- 回滚:revert 单 commit。
