### PR TITLE
fix(pi): 使用独立原生模型目录

### DIFF
--- a/apps/desktop/src/main/maker-host/__tests__/activeCatalogDiscovery.test.ts
+++ b/apps/desktop/src/main/maker-host/__tests__/activeCatalogDiscovery.test.ts
@@ -95,15 +95,28 @@ describe('active-catalog discovered augment', () => {
     setDiscoveredProviderMediaModels('xai', null);
   });
 
-  it('新 discovered id 同时进入 openai.codex 与 Claude/Pi bridge', () => {
+  it('Codex discovery 只进入 Codex 与 Claude bridge，不改写 Pi 名单', () => {
     setActiveCatalog(BUNDLED_CATALOG);
     setDiscoveredCodexModels([fake('gpt-5.7')]);
     expect(openaiIds('codex')).toContain('gpt-5.7');
     expect(openaiIds('claude-code')).toContain('chatgpt/gpt-5.7');
-    expect(openaiIds('pi')).toContain('chatgpt/gpt-5.7');
+    expect(openaiIds('pi')).not.toContain('chatgpt/gpt-5.7');
   });
 
-  it('applies a daily PI protocol annotation only after OpenAI discovery proves the model exists', () => {
+  it('旧服务端缺少或下发空 Pi 数组时仍保留客户端原生名单', () => {
+    const expected = openaiIds('pi');
+    const omitted = bundledWithoutRegistry();
+    delete omitted.providers.find((provider) => provider.id === 'openai')!.models.pi;
+    setActiveCatalog(omitted, { authorityCatalog: omitted });
+    expect(openaiIds('pi')).toEqual(expected);
+
+    const empty = bundledWithoutRegistry();
+    empty.providers.find((provider) => provider.id === 'openai')!.models.pi = [];
+    setActiveCatalog(empty, { authorityCatalog: empty });
+    expect(openaiIds('pi')).toEqual(expected);
+  });
+
+  it('明确的服务端 Pi 条目直接叠加本地目录，不依赖 Codex discovery', () => {
     const catalog = bundledWithoutRegistry();
     const openai = catalog.providers.find((provider) => provider.id === 'openai')!;
     openai.models.pi = [
@@ -112,15 +125,15 @@ describe('active-catalog discovered augment', () => {
         piApi: 'openai-responses',
       },
     ];
-    setActiveCatalog(catalog);
-
-    expect(openaiIds('pi')).not.toContain('chatgpt/gpt-5.7');
-
-    setDiscoveredCodexModels([fake('gpt-5.7')]);
+    setActiveCatalog(catalog, { authorityCatalog: catalog });
     const projected = getActiveCatalog()
       .providers.find((provider) => provider.id === 'openai')
       ?.models.pi?.find((candidate) => candidate.id === 'chatgpt/gpt-5.7');
-    expect(projected).toMatchObject({ piApi: 'openai-responses' });
+    expect(projected).toMatchObject({
+      id: 'chatgpt/gpt-5.7',
+      piApi: 'openai-responses',
+      contextWindow: 400_000,
+    });
   });
 
   it('SuperGrok fallback keeps namespaced roots but projects bare Pi ids', () => {
@@ -128,7 +141,9 @@ describe('active-catalog discovered augment', () => {
     const xai = getActiveCatalog().providers.find((provider) => provider.id === 'xai');
     expect(xai?.agents).toContain('pi');
     expect(xai?.routing.pi?.upstream).toBe('https://api.x.ai/v1');
-    expect(xai?.models.pi?.find((model) => model.id === 'grok-4.6')?.piApi).toBe('openai-responses');
+    expect(xai?.models.pi?.find((model) => model.id === 'grok-4.6')?.piApi).toBe(
+      'openai-responses',
+    );
     expect(xai?.models.pi?.map((model) => model.id)).toEqual([
       'grok-4.3',
       'grok-4.5',
@@ -159,7 +174,12 @@ describe('active-catalog discovered augment', () => {
       'xai/grok-4.6',
     ]);
     expect(xai?.models.codex?.map((model) => model.id)).toEqual(['xai/grok-4.5', 'xai/grok-4.6']);
-    expect(xai?.models.pi?.map((model) => model.id)).toEqual(['grok-4.5', 'grok-4.6']);
+    expect(xai?.models.pi?.map((model) => model.id)).toEqual([
+      'grok-4.3',
+      'grok-4.5',
+      'grok-4.6',
+      'grok-build-0.1',
+    ]);
     expect(xai?.models.pi?.find((model) => model.id === 'grok-4.6')).toMatchObject({
       contextWindow: 500_000,
       supportsImageInput: true,
@@ -201,8 +221,8 @@ describe('active-catalog discovered augment', () => {
       defaultEffort: 'low',
     });
     expect(xai?.models.pi?.find((model) => model.id === 'grok-4.5')).toMatchObject({
-      efforts: ['low'],
-      defaultEffort: 'low',
+      efforts: ['low', 'medium', 'high'],
+      defaultEffort: 'medium',
     });
     expect(xai?.models.pi?.find((model) => model.id === 'grok-4.6')).toMatchObject({
       efforts: ['low', 'medium', 'high', 'xhigh'],
@@ -225,7 +245,7 @@ describe('active-catalog discovered augment', () => {
     });
     expect(xai?.models.pi?.find((model) => model.id === 'grok-4.5')).toMatchObject({
       efforts: ['low', 'medium', 'high'],
-      defaultEffort: 'high',
+      defaultEffort: 'medium',
     });
   });
 
@@ -242,7 +262,7 @@ describe('active-catalog discovered augment', () => {
     });
     expect(xai?.models.pi?.find((model) => model.id === 'grok-4.5')).toMatchObject({
       efforts: ['low', 'medium', 'high'],
-      defaultEffort: 'low',
+      defaultEffort: 'medium',
     });
     expect(xai?.models.pi?.find((model) => model.id === 'grok-4.6')).toMatchObject({
       efforts: ['low', 'medium', 'high', 'xhigh'],
@@ -250,13 +270,18 @@ describe('active-catalog discovered augment', () => {
     });
   });
 
-  it('xAI successful empty snapshot stays empty and does not leak static membership', () => {
+  it('xAI account discovery can clear Claude/Codex without clearing independent Pi membership', () => {
     setActiveCatalog(BUNDLED_CATALOG);
     setXaiDiscoveredModels([]);
     const xai = getActiveCatalog().providers.find((provider) => provider.id === 'xai');
     expect(xai?.models['claude-code']).toEqual([]);
     expect(xai?.models.codex).toEqual([]);
-    expect(xai?.models.pi).toEqual([]);
+    expect(xai?.models.pi?.map((model) => model.id)).toEqual([
+      'grok-4.3',
+      'grok-4.5',
+      'grok-4.6',
+      'grok-build-0.1',
+    ]);
   });
 
   it('xAI 媒体发现按官方存在性收敛，静态同 id 保持 first-wins', () => {
@@ -346,10 +371,11 @@ describe('active-catalog discovered augment', () => {
 
   it('动态清单契约:注册表快照即清单本身(bundled 零静态,快照全量呈现)', () => {
     setActiveCatalog(bundledWithoutRegistry());
+    const piBeforeDiscovery = openaiIds('pi');
     setDiscoveredCodexModels([fake('gpt-5.7', 17), fake('gpt-5.5', 20)]);
     expect(openaiIds('codex')).toEqual(['gpt-5.7', 'gpt-5.5']);
     expect(openaiIds('claude-code')).toEqual(['chatgpt/gpt-5.7', 'chatgpt/gpt-5.5']);
-    expect(openaiIds('pi')).toEqual(['chatgpt/gpt-5.7', 'chatgpt/gpt-5.5']);
+    expect(openaiIds('pi')).toEqual(piBeforeDiscovery);
     // 动态快照决定存在性，且明确返回的运行时能力高于 registry 基线。
     const openai = getActiveCatalog().providers.find((p) => p.id === 'openai');
     expect((openai?.models.codex ?? []).find((m) => m.id === 'gpt-5.5')?.contextWindow).toBe(
@@ -473,7 +499,11 @@ describe('anthropic 发现条目的 modelRegistry 元数据基线', () => {
         supportsFastMode: false,
       })),
     );
-    expect(anthropicList('pi')).toEqual(anthropicList('claude-code'));
+    expect(anthropicList('pi').map((model) => model.id)).toEqual(
+      BUNDLED_CATALOG.providers
+        .find((provider) => provider.id === 'anthropic')
+        ?.models.pi?.map((model) => model.id),
+    );
     expect(
       Object.fromEntries(
         [

--- a/apps/desktop/src/main/maker-host/__tests__/catalogDerivedModels.test.ts
+++ b/apps/desktop/src/main/maker-host/__tests__/catalogDerivedModels.test.ts
@@ -483,7 +483,7 @@ describe('deriveAvailableModels — dynamic-first catalog contract', () => {
     expect(provider!.models['claude-code']!.some((entry) => entry.id === retired.id)).toBe(true);
   });
 
-  it('纯 Registry retired 不进入公开清单,但可按统一投影重建 Pi 续跑描述符', () => {
+  it('纯 Registry retired 不会被重建成 Pi 续跑描述符', () => {
     const catalog = structuredClone(BUNDLED_CATALOG);
     catalog.modelRegistry = {
       schemaVersion: 1,
@@ -524,18 +524,11 @@ describe('deriveAvailableModels — dynamic-first catalog contract', () => {
       'openai',
       'chatgpt/gpt-retired',
       { localOverrides },
-    )).toMatchObject({
-      id: 'chatgpt/gpt-retired',
-      displayName: 'GPT Retired',
-      contextWindow: 444_000,
-      maxOutputTokens: 96_000,
-      efforts: ['minimal', 'medium', 'high'],
-      defaultEffort: 'high',
-    });
+    )).toBeNull();
     expect(resolvePiRuntimeModelDescriptor(catalog, 'anthropic', 'chatgpt/gpt-retired')).toBeNull();
   });
 
-  it('retired Pi fallback 按 addition 后 patch 的最终层顺序重建 root', () => {
+  it('本地 Codex addition/patch 也不能重建 retired Pi fallback', () => {
     const catalog = structuredClone(BUNDLED_CATALOG);
     catalog.modelRegistry = {
       schemaVersion: 1,
@@ -575,15 +568,10 @@ describe('deriveAvailableModels — dynamic-first catalog contract', () => {
       'openai',
       'chatgpt/gpt-local-revival',
       { localOverrides },
-    )).toMatchObject({
-      displayName: 'Local addition',
-      contextWindow: 600_000,
-      efforts: ['minimal', 'medium', 'high'],
-      defaultEffort: 'high',
-    });
+    )).toBeNull();
   });
 
-  it('retired OpenAI context profile 按 alias id 与 entry baseline 重建 Pi 私有描述符', () => {
+  it('retired OpenAI context profile 不会跨 harness 重建 Pi 私有描述符', () => {
     const catalog = structuredClone(BUNDLED_CATALOG);
     catalog.modelRegistry = {
       schemaVersion: 1,
@@ -613,14 +601,7 @@ describe('deriveAvailableModels — dynamic-first catalog contract', () => {
 
     expect(
       resolvePiRuntimeModelDescriptor(catalog, 'openai', 'chatgpt/gpt-5.6-sol[1m]'),
-    ).toMatchObject({
-      id: 'chatgpt/gpt-5.6-sol[1m]',
-      displayName: 'GPT-5.6-Sol (1M · Higher usage)',
-      contextWindow: 1_000_000,
-      maxOutputTokens: 128_000,
-      efforts: ['minimal', 'low', 'medium', 'high', 'xhigh'],
-      defaultEffort: 'medium',
-    });
+    ).toBeNull();
   });
 
   it('runtime refresh replaces both agent model lists in place so existing sessions keep the live reference', () => {

--- a/apps/desktop/src/main/maker-host/__tests__/modelPlane.test.ts
+++ b/apps/desktop/src/main/maker-host/__tests__/modelPlane.test.ts
@@ -1,7 +1,7 @@
 /**
  * modelPlane.test.ts —— 模型平面收敛(2026-08-02)的 invariant 矩阵:
  * registry presence 实体化 / 生命周期(retired tombstone + keepSelected 豁免)/
- * 表驱动投影(bridge membership 门控、Pi 恒定派生)/ 本地 override(local 永远
+ * 表驱动投影(bridge membership 门控、Pi 独立目录)/ 本地 override(local 永远
  * 最高、addition 复活 retired、perAgent 单点修、dormant patch)/ XD 不可伪造。
  * 全部走真实 active-catalog computeMerged 管线,不 mock 合并逻辑。
  */
@@ -95,7 +95,7 @@ afterEach(() => {
 });
 
 describe('registry presence 实体化', () => {
-  it('a loaded legacy Catalog keeps its own xAI fallback membership instead of importing Pi members', () => {
+  it('a loaded legacy Catalog cannot replace the local Pi membership baseline', () => {
     const expected = BUNDLED_CATALOG.providers.find((provider) => provider.id === 'xai');
     if (!expected) throw new Error('bundled catalog missing xai');
     const generatedCatalog = structuredClone(BUNDLED_CATALOG);
@@ -107,12 +107,10 @@ describe('registry presence 实体化', () => {
     setActiveCatalog(generatedCatalog);
     expect(models('xai', 'claude-code')).toEqual(expected.models['claude-code']);
     expect(models('xai', 'codex')).toEqual(expected.models.codex);
-    expect(models('xai', 'pi').map((model) => model.id)).toEqual(
-      expected.models['claude-code']?.map((model) => model.id.slice('xai/'.length)),
-    );
+    expect(models('xai', 'pi')).toEqual(expected.models.pi);
   });
 
-  it('远端宣告 GPT-6(status+能力自洽)→ 免发现进入 codex root,并自动派生 claude/pi bridge', () => {
+  it('远端 Registry 宣告 GPT-6 只进入 Codex/Claude，不会自动加入 Pi', () => {
     setActiveCatalog(baseCatalog([gpt6Entry()]));
     const codex = models('openai', 'codex').find((m) => m.id === 'gpt-6');
     expect(codex).toMatchObject({
@@ -125,7 +123,7 @@ describe('registry presence 实体化', () => {
       status: 'active',
     });
     expect(models('openai', 'claude-code').map((m) => m.id)).toContain('chatgpt/gpt-6');
-    expect(models('openai', 'pi').map((m) => m.id)).toContain('chatgpt/gpt-6');
+    expect(models('openai', 'pi').map((m) => m.id)).not.toContain('chatgpt/gpt-6');
   });
 
   it('公共 Registry 的 newSessionDefault 不进入 CatalogModel；默认只信区域门控后的 /models', () => {
@@ -136,10 +134,9 @@ describe('registry presence 实体化', () => {
     const pi = models('openai', 'pi').find((m) => m.id === 'chatgpt/gpt-6');
     expect(codex).toBeDefined();
     expect(claude).toBeDefined();
-    expect(pi).toBeDefined();
+    expect(pi).toBeUndefined();
     expect('newSessionDefault' in codex!).toBe(false);
     expect('newSessionDefault' in claude!).toBe(false);
-    expect('newSessionDefault' in pi!).toBe(false);
   });
 
   it('bridge 在投影后应用目标端 perAgent,随后再执行 effort 硬约束', () => {
@@ -170,23 +167,16 @@ describe('registry presence 实体化', () => {
       efforts: ['low', 'medium'],
       defaultEffort: 'medium',
     });
-    // Pi 没有 wire perAgent，但仍是独立消费端：使用 entry 基线，再执行 bridge 硬约束。
-    expect(models('openai', 'pi').find((m) => m.id === 'chatgpt/gpt-6')).toMatchObject({
-      contextWindow: 1_000_000,
-      efforts: ['low', 'medium', 'high', 'xhigh'],
-      defaultEffort: 'xhigh',
-    });
+    expect(models('openai', 'pi').find((m) => m.id === 'chatgpt/gpt-6')).toBeUndefined();
 
     setLocalCatalogOverrides(
       overridesOf({ patches: { 'openai:gpt-6': { base: { contextWindow: 123_000 } } } }),
     );
     expect(models('openai', 'codex').find((m) => m.id === 'gpt-6')?.contextWindow).toBe(123_000);
-    expect(models('openai', 'pi').find((m) => m.id === 'chatgpt/gpt-6')?.contextWindow).toBe(
-      123_000,
-    );
+    expect(models('openai', 'pi').find((m) => m.id === 'chatgpt/gpt-6')).toBeUndefined();
   });
 
-  it('同一 OpenAI modelId 的长上下文 entry 只生成 Claude/Pi 独立选择', () => {
+  it('同一 OpenAI modelId 的长上下文 Registry entry 只生成 Claude 独立选择', () => {
     setActiveCatalog(
       baseCatalog([
         gpt6Entry({ contextWindow: 272_000 }),
@@ -202,32 +192,29 @@ describe('registry presence 实体化', () => {
     expect(models('openai', 'codex').filter((m) => m.id.startsWith('gpt-6'))).toMatchObject([
       { id: 'gpt-6', contextWindow: 272_000 },
     ]);
-    for (const agent of ['claude-code', 'pi'] as const) {
-      expect(
-        models('openai', agent)
-          .filter((m) => m.id.startsWith('chatgpt/gpt-6'))
-          .map((m) => ({ id: m.id, name: m.name, contextWindow: m.contextWindow })),
-      ).toEqual([
-        { id: 'chatgpt/gpt-6', name: 'GPT-6', contextWindow: 272_000 },
-        {
-          id: 'chatgpt/gpt-6[1m]',
-          name: 'GPT-6 (1M · 高消耗)',
-          contextWindow: 1_000_000,
-        },
-      ]);
-    }
+    expect(
+      models('openai', 'claude-code')
+        .filter((m) => m.id.startsWith('chatgpt/gpt-6'))
+        .map((m) => ({ id: m.id, name: m.name, contextWindow: m.contextWindow })),
+    ).toEqual([
+      { id: 'chatgpt/gpt-6', name: 'GPT-6', contextWindow: 272_000 },
+      {
+        id: 'chatgpt/gpt-6[1m]',
+        name: 'GPT-6 (1M · 高消耗)',
+        contextWindow: 1_000_000,
+      },
+    ]);
+    expect(models('openai', 'pi').some((m) => m.id.startsWith('chatgpt/gpt-6'))).toBe(false);
     setLocalCatalogOverrides(
       overridesOf({
         patches: { 'openai:gpt-6[1m]': { base: { contextWindow: 900_000 } } },
       }),
     );
-    expect(
-      models('openai', 'pi').find((m) => m.id === 'chatgpt/gpt-6[1m]')?.contextWindow,
-    ).toBe(900_000);
+    expect(models('openai', 'pi').find((m) => m.id === 'chatgpt/gpt-6[1m]')).toBeUndefined();
     expect(getModelPlaneWarnings()).toEqual([]);
   });
 
-  it('没有 Registry entry 时 Pi 保留 Codex discovery 的既有字段', () => {
+  it('没有 Registry entry 时 Codex discovery 也不会产生 Pi 条目', () => {
     setActiveCatalog(baseCatalog());
     setDiscoveredCodexModels([
       {
@@ -239,11 +226,7 @@ describe('registry presence 实体化', () => {
       },
     ]);
 
-    expect(models('openai', 'pi').find((m) => m.id === 'chatgpt/gpt-discovered')).toMatchObject({
-      contextWindow: 272_000,
-      efforts: ['high'],
-      defaultEffort: 'high',
-    });
+    expect(models('openai', 'pi').find((m) => m.id === 'chatgpt/gpt-discovered')).toBeUndefined();
   });
 
   it('status 缺失 = metadata-only,不长实体;retired = tombstone,不长实体', () => {
@@ -332,7 +315,7 @@ describe('registry presence 实体化', () => {
     });
   });
 
-  it('membership 门控 bridge:route.agents 不含 claude-code → claude bridge 无、pi 恒定有', () => {
+  it('membership 门控 bridge 不会影响独立 Pi 名单', () => {
     setActiveCatalog(
       baseCatalog([
         gpt6Entry({ routes: [{ providerId: 'openai', modelId: 'gpt-6', agents: ['codex'] }] }),
@@ -340,7 +323,7 @@ describe('registry presence 实体化', () => {
     );
     expect(models('openai', 'codex').map((m) => m.id)).toContain('gpt-6');
     expect(models('openai', 'claude-code').map((m) => m.id)).not.toContain('chatgpt/gpt-6');
-    expect(models('openai', 'pi').map((m) => m.id)).toContain('chatgpt/gpt-6');
+    expect(models('openai', 'pi').map((m) => m.id)).not.toContain('chatgpt/gpt-6');
   });
 
   it('status 缺失只做 metadata overlay,不能用 membership 缩减 discovery 投影', () => {
@@ -378,7 +361,7 @@ describe('registry presence 实体化', () => {
     ]);
   });
 
-  it('anthropic membership 门控 codex bridge(fast=false 硬约束);pi 恒定镜像 root', () => {
+  it('anthropic membership 只门控 Codex bridge，Pi 保持本地原生名单', () => {
     setActiveCatalog(
       baseCatalog([
         {
@@ -395,7 +378,9 @@ describe('registry presence 实体化', () => {
     );
     expect(models('anthropic', 'claude-code').map((m) => m.id)).toEqual(['claude-next']);
     expect(models('anthropic', 'codex')).toEqual([]);
-    expect(models('anthropic', 'pi').map((m) => m.id)).toEqual(['claude-next']);
+    expect(models('anthropic', 'pi')).toEqual(
+      BUNDLED_CATALOG.providers.find((provider) => provider.id === 'anthropic')?.models.pi,
+    );
   });
 
   it('anthropic codex bridge 应用 perAgent.codex 后仍强制 fast=false', () => {
@@ -500,10 +485,12 @@ describe('retired tombstone 与 discovery 回补', () => {
     defaultEffort: 'high',
   };
 
-  it('无 discovery 实体时仍可按 root/bridge/Pi 投影图查询 Registry tombstone', () => {
+  it('Registry tombstone 只作用于自己的 root/bridge，不扩散到 Pi', () => {
     const registry = retiredRegistry().modelRegistry;
     expect(isRegistryTombstoneForConsumer(registry, 'openai', 'gpt-dead', 'codex')).toBe(true);
-    expect(isRegistryTombstoneForConsumer(registry, 'openai', 'chatgpt/gpt-dead', 'pi')).toBe(true);
+    expect(isRegistryTombstoneForConsumer(registry, 'openai', 'chatgpt/gpt-dead', 'pi')).toBe(
+      false,
+    );
     // route.agents 未授权 Claude bridge，不能把 root tombstone 扩成不存在的消费端。
     expect(
       isRegistryTombstoneForConsumer(registry, 'openai', 'chatgpt/gpt-dead', 'claude-code'),
@@ -518,16 +505,11 @@ describe('retired tombstone 与 discovery 回补', () => {
         routes: [{ providerId: 'openai', modelId: 'gpt-6', agents: ['claude-code'] }],
       }),
     ]).modelRegistry;
+    expect(isRegistryTombstoneForConsumer(withAlias, 'openai', 'chatgpt/gpt-6[1m]', 'pi')).toBe(
+      false,
+    );
     expect(
-      isRegistryTombstoneForConsumer(withAlias, 'openai', 'chatgpt/gpt-6[1m]', 'pi'),
-    ).toBe(true);
-    expect(
-      isRegistryTombstoneForConsumer(
-        withAlias,
-        'openai',
-        'chatgpt/gpt-6[1m]',
-        'claude-code',
-      ),
+      isRegistryTombstoneForConsumer(withAlias, 'openai', 'chatgpt/gpt-6[1m]', 'claude-code'),
     ).toBe(true);
     expect(isRegistryTombstoneForConsumer(withAlias, 'openai', 'chatgpt/gpt-6', 'pi')).toBe(false);
     expect(
@@ -540,17 +522,12 @@ describe('retired tombstone 与 discovery 回补', () => {
     setDiscoveredCodexModels([discoveredDead]);
     const entry = models('openai', 'codex').find((m) => m.id === 'gpt-dead');
     expect(entry?.status).toBe('retired');
-    expect(models('openai', 'pi').find((m) => m.id === 'chatgpt/gpt-dead')).toMatchObject({
-      contextWindow: 300_000,
-      status: 'retired',
-    });
+    expect(models('openai', 'pi').find((m) => m.id === 'chatgpt/gpt-dead')).toBeUndefined();
 
     setLocalCatalogOverrides(
       overridesOf({ patches: { 'openai:gpt-dead': { base: { contextWindow: 123_000 } } } }),
     );
-    expect(
-      models('openai', 'pi').find((m) => m.id === 'chatgpt/gpt-dead')?.contextWindow,
-    ).toBe(123_000);
+    expect(models('openai', 'pi').find((m) => m.id === 'chatgpt/gpt-dead')).toBeUndefined();
 
     const views = buildRegistry(getActiveCatalog(), { openai: true });
     const withoutSelection = deriveModelList({ providers: views, agent: 'codex' });
@@ -592,11 +569,7 @@ describe('retired tombstone 与 discovery 回补', () => {
       name: 'Dead Model Revived',
       status: 'active',
     });
-    expect(models('openai', 'pi').find((m) => m.id === 'chatgpt/gpt-dead')).toMatchObject({
-      name: 'Dead Model Revived',
-      status: 'active',
-      contextWindow: 100_000,
-    });
+    expect(models('openai', 'pi').find((m) => m.id === 'chatgpt/gpt-dead')).toBeUndefined();
   });
 });
 
@@ -674,9 +647,7 @@ describe('本地 override(local 永远最高)', () => {
     });
     const claude = models('xai', 'claude-code').find((m) => m.id === 'xai/grok-test');
     expect(claude).toMatchObject({ efforts: ['low', 'medium', 'high', 'xhigh'] });
-    expect(models('xai', 'pi').find((m) => m.id === 'grok-test')).toMatchObject({
-      efforts: ['low', 'medium', 'high', 'xhigh'],
-    });
+    expect(models('xai', 'pi').find((m) => m.id === 'grok-test')).toBeUndefined();
     expect(models('xai', 'pi').some((m) => m.id === 'grok-pi-only-fixture')).toBe(false);
   });
 
@@ -736,7 +707,7 @@ describe('本地 override(local 永远最高)', () => {
     expect(entry?.group).toBeUndefined();
   });
 
-  it('本地 membership 与 registry 同义:可关闭/重开 bridge,Pi 仍由 root 恒定派生', () => {
+  it('本地 membership 可关闭/重开 bridge，但不会改变 Pi', () => {
     setActiveCatalog(
       baseCatalog([
         gpt6Entry({ routes: [{ providerId: 'openai', modelId: 'gpt-6', agents: ['codex'] }] }),
@@ -758,7 +729,7 @@ describe('本地 override(local 永远最高)', () => {
       }),
     );
     expect(models('openai', 'claude-code').map((m) => m.id)).not.toContain('chatgpt/gpt-6');
-    expect(models('openai', 'pi').map((m) => m.id)).toContain('chatgpt/gpt-6');
+    expect(models('openai', 'pi').map((m) => m.id)).not.toContain('chatgpt/gpt-6');
 
     setLocalCatalogOverrides(
       overridesOf({

--- a/apps/desktop/src/main/maker-host/__tests__/piNativeProviders.test.ts
+++ b/apps/desktop/src/main/maker-host/__tests__/piNativeProviders.test.ts
@@ -286,6 +286,83 @@ describe('buildPiNativeProvidersFromConfigs', () => {
     });
   });
 
+  it('同源本地 Pi 元数据补齐能力，但不覆盖下发文件的上下文', () => {
+    const bundled = new Map([
+      [
+        'bundled-provider',
+        new Map([
+          [
+            'server-model',
+            piBundledModel('server-model', 'openai-completions', {
+              baseUrl: 'https://api.example/v1',
+              contextWindow: 272_000,
+              maxTokens: 128_000,
+              input: ['text', 'image'],
+            }),
+          ],
+        ]),
+      ],
+    ]);
+    const { providers } = buildPiNativeProvidersFromConfigs(
+      [
+        {
+          id: 'server-models',
+          name: 'Server Models',
+          auth: { method: 'none' },
+          runtimes: {
+            pi: piRuntime({
+              baseUrl: 'https://api.example/v1',
+              wireProtocol: 'openai-chat',
+              models: [{ id: 'server-model', name: 'Server Model', contextWindow: 64_000 }],
+            }),
+          },
+        },
+      ],
+      () => null,
+      undefined,
+      bundled,
+    );
+
+    expect(providers[0]?.models[0]).toMatchObject({
+      id: 'server-model',
+      contextWindow: 64_000,
+      maxTokens: 128_000,
+      input: ['text', 'image'],
+      reasoning: true,
+    });
+  });
+
+  it('下发协议与本地 Pi 元数据冲突时不借用本地能力', () => {
+    const bundled = new Map([
+      [
+        'bundled-provider',
+        new Map([['server-model', piBundledModel('server-model', 'anthropic-messages')]]),
+      ],
+    ]);
+    const { providers } = buildPiNativeProvidersFromConfigs(
+      [
+        {
+          id: 'server-models',
+          name: 'Server Models',
+          auth: { method: 'none' },
+          runtimes: {
+            pi: piRuntime({
+              wireProtocol: 'openai-responses',
+              models: [{ id: 'server-model', name: 'Server Model' }],
+            }),
+          },
+        },
+      ],
+      () => null,
+      undefined,
+      bundled,
+    );
+
+    expect(providers[0]?.models[0]).toMatchObject({ id: 'server-model', name: 'Server Model' });
+    expect(providers[0]?.models[0]).not.toHaveProperty('reasoning');
+    expect(providers[0]?.models[0]).not.toHaveProperty('input');
+  });
+
   it('defaults unknown custom Chat Completions models to system role (#3832)', () => {
     const { providers } = buildPiNativeProvidersFromConfigs(
       [

--- a/apps/desktop/src/main/maker-host/__tests__/piNativeProviders.test.ts
+++ b/apps/desktop/src/main/maker-host/__tests__/piNativeProviders.test.ts
@@ -332,6 +332,54 @@ describe('buildPiNativeProvidersFromConfigs', () => {
     });
   });
 
+  it('同 origin 的 bundled 元数据不能把用户代理路径改回原生路径', () => {
+    const bundled = new Map([
+      [
+        'bundled-provider',
+        new Map([
+          [
+            'server-model',
+            piBundledModel('server-model', 'openai-completions', {
+              baseUrl: 'https://api.example/native/v1',
+              contextWindow: 272_000,
+              maxTokens: 128_000,
+            }),
+          ],
+        ]),
+      ],
+    ]);
+    const { providers } = buildPiNativeProvidersFromConfigs(
+      [
+        {
+          id: 'proxied-models',
+          name: 'Proxied Models',
+          auth: { method: 'none' },
+          runtimes: {
+            pi: piRuntime({
+              baseUrl: 'https://api.example/user-proxy/v1',
+              wireProtocol: 'openai-chat',
+              models: [{ id: 'server-model', name: 'Server Model' }],
+            }),
+          },
+        },
+      ],
+      () => null,
+      undefined,
+      bundled,
+    );
+
+    expect(providers[0]).toMatchObject({
+      baseUrl: 'https://api.example/user-proxy/v1',
+      api: 'openai-completions',
+    });
+    expect(providers[0]?.models[0]).toMatchObject({
+      id: 'server-model',
+      contextWindow: 272_000,
+      maxTokens: 128_000,
+    });
+    expect(providers[0]?.models[0]).not.toHaveProperty('baseUrl');
+  });
+
   it('下发协议与本地 Pi 元数据冲突时不借用本地能力', () => {
     const bundled = new Map([
       [
@@ -1625,7 +1673,7 @@ describe('buildPiNativeProvidersFromConfigs', () => {
     ).toThrow('Unsupported PI wire protocol: future-protocol');
   });
 
-  it('uses same-origin PI bundled protocol knowledge when no endpoint default is configured', () => {
+  it('uses same-origin PI bundled protocol knowledge without borrowing its endpoint path', () => {
     const bundled = new Map([
       [
         'zai',
@@ -1680,16 +1728,15 @@ describe('buildPiNativeProvidersFromConfigs', () => {
     );
 
     expect(providers[0]).toMatchObject({
+      baseUrl: 'https://open.bigmodel.cn/api/anthropic',
       api: 'openai-completions',
       models: [
-        {
-          id: 'glm-5.2',
-          baseUrl: 'https://open.bigmodel.cn/api/coding/paas/v4',
-        },
+        { id: 'glm-5.2' },
         { id: 'glm-5.3', api: 'anthropic-messages' },
       ],
     });
     expect(providers[0]?.models[0]?.api).toBeUndefined();
+    expect(providers[0]?.models[0]).not.toHaveProperty('baseUrl');
   });
 
   it('does not infer ambiguous duplicate model ids from PI bundled providers', () => {

--- a/apps/desktop/src/main/maker-host/__tests__/piNativeProviders.test.ts
+++ b/apps/desktop/src/main/maker-host/__tests__/piNativeProviders.test.ts
@@ -884,6 +884,38 @@ describe('buildPiNativeProvidersFromConfigs', () => {
     });
   });
 
+  it('preserves Pi native wire values when the catalog overlays OpenAI effort membership', () => {
+    const catalog = JSON.parse(JSON.stringify(BUNDLED_CATALOG)) as Catalog;
+    const openai = catalog.providers.find((provider) => provider.id === 'openai')!;
+    openai.models.pi = [
+      {
+        id: 'chatgpt/gpt-5.6-sol',
+        name: 'GPT-5.6 Sol',
+        contextWindow: 272_000,
+        efforts: ['minimal', 'xhigh', 'max'],
+        defaultEffort: 'xhigh',
+      },
+    ];
+    const bundled = piBundledModel('gpt-5.6-sol', 'openai-codex-responses', {
+      thinkingLevelMap: { minimal: 'low', xhigh: 'xhigh', max: 'max' },
+    });
+
+    const model = buildPiSubscriptionNativeProviders(
+      catalog,
+      'http://127.0.0.1:4567/',
+      new Map([['openai-codex', new Map([[bundled.id, bundled]])]]),
+    ).providers.find((candidate) => candidate.id === 'openai-codex')?.models[0];
+
+    expect(model?.thinkingLevelMap).toEqual({
+      minimal: 'low',
+      low: null,
+      medium: null,
+      high: null,
+      xhigh: 'xhigh',
+      max: 'max',
+    });
+  });
+
   it('keeps a retired OpenAI profile private to its native subscription resume', () => {
     const catalog = JSON.parse(JSON.stringify(BUNDLED_CATALOG)) as Catalog;
     const openai = catalog.providers.find((provider) => provider.id === 'openai')!;

--- a/apps/desktop/src/main/maker-host/active-catalog.ts
+++ b/apps/desktop/src/main/maker-host/active-catalog.ts
@@ -52,7 +52,6 @@ import {
 import {
   applyLocalConsumerOverrides,
   applyLocalOverridesToRoot,
-  applyLocalOverridesToRootModel,
   hasLocalAddition,
   EMPTY_MODEL_CATALOG_OVERRIDES,
   resolveLocalBridgeExclusions,
@@ -106,7 +105,7 @@ const discoveredByProvider = new Map<string, Partial<Record<AgentKind, CatalogMo
  *
  * `null` = 当前 owner 尚无成功账号快照，允许公共 Catalog / bundled 只作为启动救急；
  * `[]` = 上游明确返回空清单，仍是权威结果。成员保存为 canonical `xai/grok-*`，
- * Claude/Codex 原样消费，Pi 在投影时去掉 `xai/`。
+ * 只供 Claude/Codex 消费；Pi 使用自己的本地目录。
  */
 export interface XaiDiscoveredModel {
   id: string;
@@ -551,14 +550,12 @@ function applyMediaDiscovery(
  * defaultEnabled 等 runtime 能力。这样旧远端目录里曾固化的本地化后缀也不会继续泄漏。
  *
  * claude-code bridge 受 registry membership 门控(route.agents 不含 claude-code 的
- * 模型经 `claudeExcluded` 排除);Pi 恒定从 codex root 派生、不受门控——投影拓扑
- * 见 model-plane/modelPlanePolicy.ts。
+ * 模型经 `claudeExcluded` 排除)。Pi 不在这里派生，而是由自己的本地目录装配。
  */
-function projectCodexModelsToBridges(
+function projectCodexModelsToClaudeBridge(
   p: Provider,
   claudeExcluded: ReadonlySet<string> = new Set(),
   prepareClaudeModel: (model: CatalogModel) => CatalogModel = (model) => model,
-  preparePiModel: (model: CatalogModel) => CatalogModel = (model) => model,
 ): Provider {
   const codex = p.models.codex ?? [];
   const canonical = new Map(codex.map((model) => [model.id, model]));
@@ -576,16 +573,10 @@ function projectCodexModelsToBridges(
     ? { ...p, models: { ...p.models, 'claude-code': alignedExisting } }
     : p;
   const claudeSource = codex.filter((model) => !claudeExcluded.has(model.id));
-  const withClaude = augmentModels(
+  return augmentModels(
     withAligned,
     'claude-code',
     claudeSource.map((model) => toChatgptBridgeModel(prepareClaudeModel(model))),
-    true,
-  );
-  return augmentModels(
-    withClaude,
-    'pi',
-    codex.map((model) => toChatgptBridgeModel(preparePiModel(model))),
     true,
   );
 }
@@ -763,16 +754,9 @@ function assembleAuthoritativeRoot(
 function xaiCatalogModelById(
   provider: Provider,
   id: string,
-  agent: AgentKind,
+  agent: RootAgentKind,
 ): CatalogModel | undefined {
   const bundled = BUNDLED_CATALOG.providers.find((entry) => entry.id === 'xai');
-  if (agent === 'pi') {
-    const bare = id.startsWith('xai/') ? id.slice('xai/'.length) : id;
-    return (
-      provider.models.pi?.find((model) => model.id === bare) ??
-      bundled?.models.pi?.find((model) => model.id === bare)
-    );
-  }
   return (
     provider.models[agent]?.find((model) => model.id === id) ??
     bundled?.models[agent]?.find((model) => model.id === id)
@@ -785,9 +769,7 @@ function materializeXaiAccountModels(
   discovered: readonly XaiDiscoveredModel[],
 ): CatalogModel[] {
   return discovered.map((entry, index) => {
-    const catalogModel =
-      xaiCatalogModelById(provider, entry.id, agent) ??
-      xaiCatalogModelById(provider, entry.id, 'pi');
+    const catalogModel = xaiCatalogModelById(provider, entry.id, agent);
     const registry = modelRegistryMetaFields('xai', agent, entry.id);
     const { efforts, defaultEffort } = resolveXaiAccountCapabilities(
       entry,
@@ -833,41 +815,52 @@ function materializeXaiAccountModels(
 }
 
 function bundledXaiFallbackMembers(provider: Provider): XaiDiscoveredModel[] {
-  return (provider.models.pi ?? []).map((model) => ({
-    id: model.id.startsWith('xai/') ? model.id : `xai/${model.id}`,
+  return (provider.models['claude-code'] ?? []).map((model) => ({
+    id: model.id,
   }));
 }
 
-function projectXaiPiModel(provider: Provider, model: CatalogModel): CatalogModel {
-  const bareId = model.id.startsWith('xai/') ? model.id.slice('xai/'.length) : model.id;
-  const piMetadata = xaiCatalogModelById(provider, model.id, 'pi');
-  return {
-    ...model,
-    ...piMetadata,
-    id: bareId,
-    name: model.name,
-    description: model.description,
-    group: model.group,
-    sortOrder: model.sortOrder,
-    contextWindow: model.contextWindow,
-    ...(model.contextWindowVerified !== undefined
-      ? { contextWindowVerified: model.contextWindowVerified }
-      : {}),
-    ...(model.maxOutput !== undefined ? { maxOutput: model.maxOutput } : {}),
-    // Official Pi effort maps stay authoritative, including explicit empty lists.
-    // CC/Codex root efforts must not leak into the Pi projection.
-    status: model.status,
-    defaultEnabled: model.defaultEnabled,
-  };
-}
-
-/** 把 provider 的全部 per-agent 模型清单清零(保留身份卡);已为空则原样返回。 */
+/** 动态供应商只清空 Codex/Claude；Pi 本地目录不能跟着清空再从其它 harness 重建。 */
 function withEmptyModels(p: Provider): Provider {
   const entries = Object.entries(p.models) as [AgentKind, CatalogModel[]][];
-  if (entries.every(([, list]) => list.length === 0)) return p;
+  if (entries.every(([agent, list]) => agent === 'pi' || list.length === 0)) return p;
   const models: Provider['models'] = {};
-  for (const [agent] of entries) models[agent] = [];
+  for (const [agent, list] of entries) models[agent] = agent === 'pi' ? list : [];
   return { ...p, models };
+}
+
+function normalizePiModelId(providerId: string, modelId: string): string {
+  if (providerId === 'openai' && !modelId.startsWith(CHATGPT_MODEL_PREFIX)) {
+    return `${CHATGPT_MODEL_PREFIX}${modelId}`;
+  }
+  if (providerId === 'xai' && modelId.startsWith('xai/')) return modelId.slice('xai/'.length);
+  return modelId;
+}
+
+/**
+ * 本地 Pi 原生目录是基线；服务端/本地覆盖文件只叠加明确给出的 Pi 条目。
+ * 缺字段或空数组不会清掉本地名单，所以旧服务端文件可直接与新客户端共存。
+ */
+function mergeIndependentPiModels(providerId: string): CatalogModel[] {
+  const bundled =
+    BUNDLED_CATALOG.providers.find((provider) => provider.id === providerId)?.models.pi ?? [];
+  const explicit = piGatewayAuthorityCatalog?.providers.find(
+    (provider) => provider.id === providerId,
+  )?.models.pi;
+  const merged = bundled.map((model) => ({ ...model }));
+  if (!explicit || explicit.length === 0) return merged;
+  const indexes = new Map(merged.map((model, index) => [model.id, index]));
+  for (const remote of explicit) {
+    const id = normalizePiModelId(providerId, remote.id);
+    const index = indexes.get(id);
+    if (index === undefined) {
+      indexes.set(id, merged.length);
+      merged.push({ ...remote, id });
+    } else {
+      merged[index] = { ...merged[index]!, ...remote, id };
+    }
+  }
+  return merged;
 }
 
 function projectXdGatewayMediaModels(
@@ -937,38 +930,6 @@ function computeMerged(): Catalog {
           baseUnverifiedXdMediaKinds,
         )
       : projectUnverifiedCatalogFallbackForBuildRegion(source, CURRENT_CINDY_REGION);
-  // Dynamic OpenAI/Anthropic roots are rebuilt from discovery/registry below,
-  // but the daily OSS catalog may carry sparse PI protocol annotations. Keep
-  // only that metadata and apply it after existence has been independently
-  // proven; these entries never create a selectable model by themselves.
-  const piApiByProvider = new Map<string, Map<string, NonNullable<CatalogModel['piApi']>>>();
-  for (const provider of b.providers) {
-    const annotationSources = [
-      ...(provider.models.pi ?? []),
-      ...(provider.id === 'xai' ? (provider.models['claude-code'] ?? []) : []),
-    ];
-    for (const model of annotationSources) {
-      if (!model.piApi) continue;
-      const byModel = piApiByProvider.get(provider.id) ?? new Map();
-      byModel.set(model.id, model.piApi);
-      if (provider.id === 'openai' && model.id.startsWith(CHATGPT_MODEL_PREFIX)) {
-        byModel.set(model.id.slice(CHATGPT_MODEL_PREFIX.length), model.piApi);
-      }
-      piApiByProvider.set(provider.id, byModel);
-    }
-  }
-  const applyPiApiAnnotations = (providerId: string, models: CatalogModel[]): CatalogModel[] => {
-    const annotations = piApiByProvider.get(providerId);
-    if (!annotations || annotations.size === 0) return models;
-    return models.map((model) => {
-      const rawId =
-        providerId === 'openai' && model.id.startsWith(CHATGPT_MODEL_PREFIX)
-          ? model.id.slice(CHATGPT_MODEL_PREFIX.length)
-          : model.id;
-      const piApi = annotations.get(model.id) ?? annotations.get(rawId);
-      return piApi && model.piApi !== piApi ? { ...model, piApi } : model;
-    });
-  };
   // registry 消费计划(实体化/overlay/retired/bridge 门控)一次算好;单 route 的
   // 作者错误隔离进 warnings,由刷新路径读走打日志,不拖垮其余条目。
   const plan = planRegistryRoots(b.modelRegistry);
@@ -999,8 +960,7 @@ function computeMerged(): Catalog {
   );
   if (normalized.some((p, index) => p !== providers[index])) providers = normalized;
 
-  // 同一份规范快照先进入 Codex root;bridge/Pi 投影移到 root 装配(registry 实体化 +
-  // 本地 override)之后统一做——派生端永远从最终 root 重算,不再维护两份名单。
+  // 规范 discovery 只进入 Codex root；Claude bridge 从最终 root 重算，Pi 另读自己的目录。
   const withCodexDiscovery = providers.map((p) =>
     p.id === 'openai' ? augmentModels(p, 'codex', discoveredCodex, true) : p,
   );
@@ -1040,7 +1000,7 @@ function computeMerged(): Catalog {
   }
   // ── root 装配 + 投影(2026-08-02 模型平面收敛,拓扑见 model-plane/modelPlanePolicy.ts)。
   // 每个 allowlist 供应商:registry presence 实体化/overlay + retired 标记 → 本地
-  // override(local 永远最高)→ 派生端(bridge/Pi)从最终 root 统一重算。
+  // override(local 永远最高)→ wire bridge 从最终 root 统一重算；Pi 不参与。
   // 优先级:local addition/patch > registry 显式字段 > discovery 显式值 > 静态兜底。
   // 注:anthropic 的 discovery 快照非空时整表以它为基线(登录态权威);registry
   // 实体化条目在未登录时也保持 presence——能否选中由连接态门控,presence ≠ entitlement。
@@ -1065,43 +1025,22 @@ function computeMerged(): Catalog {
           localOverrides,
           plan.warnings,
         );
-      const preparePiModel = (model: CatalogModel): CatalogModel =>
-        applyLocalOverridesToRootModel(
-          'openai',
-          'codex',
-          applyRegistryConsumerOverlay(model, 'openai', 'pi', model.id, plan),
-          localOverrides,
-          plan.warnings,
-        );
-      const projected = projectCodexModelsToBridges(
-        withRoot,
-        excluded,
-        prepareClaudeModel,
-        preparePiModel,
-      );
+      const projected = projectCodexModelsToClaudeBridge(withRoot, excluded, prepareClaudeModel);
       const appendConsumerAdditions = (
-        agent: 'claude-code' | 'pi',
+        agent: 'claude-code',
         models: CatalogModel[],
       ): CatalogModel[] => {
         const additions = (plan.consumerAdditions.get(consumerPlanKey('openai', agent)) ?? []).map(
           (model) =>
             toChatgptBridgeModel(
-              agent === 'pi'
-                ? applyLocalOverridesToRootModel(
-                    'openai',
-                    'codex',
-                    model,
-                    localOverrides,
-                    plan.warnings,
-                  )
-                : applyLocalConsumerOverrides(
-                    'openai',
-                    'claude-code',
-                    model.id,
-                    model,
-                    localOverrides,
-                    plan.warnings,
-                  ),
+              applyLocalConsumerOverrides(
+                'openai',
+                'claude-code',
+                model.id,
+                model,
+                localOverrides,
+                plan.warnings,
+              ),
             ),
         );
         if (additions.length === 0) return models;
@@ -1116,10 +1055,7 @@ function computeMerged(): Catalog {
             'claude-code',
             projected.models['claude-code'] ?? [],
           ),
-          pi: applyPiApiAnnotations(
-            'openai',
-            appendConsumerAdditions('pi', projected.models.pi ?? []),
-          ),
+          pi: mergeIndependentPiModels('openai'),
         },
       };
     }
@@ -1135,7 +1071,7 @@ function computeMerged(): Catalog {
         remoteExcluded,
         localOverrides,
       );
-      // codex bridge 受 membership 门控且 fast=false(硬约束);Pi 恒定镜像 root。
+      // codex bridge 受 membership 门控且 fast=false(硬约束)；Pi 不镜像 Claude root。
       const codexBridge = root
         .filter((m) => !excluded.has(m.id))
         .map((model) =>
@@ -1155,17 +1091,16 @@ function computeMerged(): Catalog {
           ...p.models,
           'claude-code': root,
           codex: codexBridge,
-          pi: applyPiApiAnnotations('anthropic', root),
+          pi: mergeIndependentPiModels('anthropic'),
         },
       };
     }
     if (p.id === 'xai') {
       const useAccountMembership = xaiDiscoveredModels !== null;
       const accountModels = xaiDiscoveredModels ?? [];
-      // The bundled-only fallback uses Pi's official list as its membership seed because it is
-      // the freshest packaged xAI list (and currently carries Grok 4.6). A loaded server Catalog
-      // remains the preceding fallback and keeps its own legacy static membership for old server
-      // compatibility. Any successful account snapshot, including [], overrides both.
+      // The bundled-only fallback uses the packaged Claude/Codex list as its own membership seed.
+      // A loaded server Catalog keeps its legacy static membership for old server compatibility;
+      // Pi's separate local list is assembled below and never participates in this choice.
       const authoritativeMembers = useAccountMembership
         ? accountModels
         : b === BUNDLED_CATALOG || p === bundledXai
@@ -1195,14 +1130,7 @@ function computeMerged(): Catalog {
         delete rest.piApi;
         return rest;
       };
-      const piProjected = applyPiApiAnnotations(
-        'xai',
-        claudeAccountRoot.map((model) => projectXaiPiModel(p, model)),
-      );
-      // Pi 投影会写回静态 official map;非 4.6 的 discovery 显式档位/默认值仍须压过它。
-      const piModels = useAccountMembership
-        ? preserveNonGrok46DiscoveryEfforts(piProjected, accountModels)
-        : piProjected;
+      const piModels = mergeIndependentPiModels('xai');
       return {
         ...p,
         agents: p.agents.includes('pi') ? p.agents : [...p.agents, 'pi' as AgentKind],

--- a/apps/desktop/src/main/maker-host/catalog-to-descriptors.ts
+++ b/apps/desktop/src/main/maker-host/catalog-to-descriptors.ts
@@ -28,12 +28,7 @@ import {
   type AgentKind,
 } from '@cindy/model-providers';
 import type { ModelDescriptor } from '@cindy/maker-core';
-import { resolveRetiredRegistryModelForPi } from './model-plane/modelPlanePolicy.js';
-import {
-  applyLocalOverridesToRetiredRootModel,
-  EMPTY_MODEL_CATALOG_OVERRIDES,
-  type ModelCatalogOverrides,
-} from './model-plane/localCatalogOverrides.js';
+import type { ModelCatalogOverrides } from './model-plane/localCatalogOverrides.js';
 
 /** Maker 能力读取面的最小形状；保留数组引用以让已创建 Session 同步看到新目录。 */
 interface ModelCapabilitiesTarget {
@@ -185,15 +180,15 @@ export function deriveAvailableModels(catalog: Catalog, agent: AgentKind): Model
 
 /**
  * 解析 Pi 当前持久化选择所需的运行时描述符,不参与公开模型清单或新路由准入。
- * 优先使用完整目录中的实际来源实体(允许 disabled/retired 供续跑);纯 Registry retired
- * 没有目录实体时,再按统一 model-plane policy 从其完整能力字段重建 Pi 投影。
+ * 只使用 Pi 自己目录中的实际来源实体(允许 disabled/retired 供续跑)。缺少 Pi 条目时
+ * 不从 Registry/Codex/Claude 重建，避免其它 harness 的成员关系污染 Pi。
  * `cindy` 是内置 gateway 的复合路由：按内置 provider 顺序解析，明确排除同 id user/BYOM。
  */
 export function resolvePiRuntimeModelDescriptor(
   catalog: Catalog,
   providerId: string | null | undefined,
   modelId: string,
-  options: { localOverrides?: ModelCatalogOverrides } = {},
+  _options: { localOverrides?: ModelCatalogOverrides } = {},
 ): ModelDescriptor | null {
   const providers =
     providerId === 'cindy'
@@ -213,18 +208,6 @@ export function resolvePiRuntimeModelDescriptor(
     }
   }
 
-  for (const provider of providers) {
-    const retired = resolveRetiredRegistryModelForPi(catalog.modelRegistry, provider.id, modelId, {
-      prepareRootModel: ({ providerId: matchedProviderId, rootAgent, model }) =>
-        applyLocalOverridesToRetiredRootModel(
-          matchedProviderId,
-          rootAgent,
-          model,
-          options.localOverrides ?? EMPTY_MODEL_CATALOG_OVERRIDES,
-        ),
-    });
-    if (retired) return toDescriptor(retired, 'pi');
-  }
   return null;
 }
 

--- a/apps/desktop/src/main/maker-host/model-plane/localCatalogOverrides.ts
+++ b/apps/desktop/src/main/maker-host/model-plane/localCatalogOverrides.ts
@@ -417,54 +417,6 @@ export function applyLocalOverridesToRoot(
 }
 
 /**
- * 对单个已存在 root 模型重放本地最终层。完整 addition 整条替换，patch 随后逐字段覆盖；
- * Pi 在切换到 Registry entry baseline 后用它恢复与最终 root 相同的 local > remote 优先级。
- */
-export function applyLocalOverridesToRootModel(
-  providerId: string,
-  agent: RootAgentKind,
-  model: CatalogModel,
-  overrides: ModelCatalogOverrides,
-  warnings: ModelPlaneWarning[] = [],
-): CatalogModel {
-  const key = `${providerId}:${model.id}`;
-  let out = model;
-  const addition = overrides.additions[key];
-  if (addition && entryRootAgents(addition, providerId).includes(agent)) {
-    out = additionModelFor(model.id, addition, agent) ?? out;
-  }
-  const patch = overrides.patches[key];
-  if (!patch || !entryRootAgents(patch, providerId).includes(agent)) return out;
-  const patched = overlayFields(out, effectiveFields(patch, agent));
-  if (typeof patched !== 'string') return patched;
-  warnings.push({
-    source: 'local',
-    providerId,
-    agent,
-    modelId: model.id,
-    reason: patched,
-  });
-  return out;
-}
-
-/**
- * 对 Registry retired root 重放与 active-catalog 相同的最终层顺序。
- * 完整 addition 可显式复活；仅有 patch 时无论其 status 写什么都重新压回 tombstone。
- */
-export function applyLocalOverridesToRetiredRootModel(
-  providerId: string,
-  agent: RootAgentKind,
-  model: CatalogModel,
-  overrides: ModelCatalogOverrides,
-  warnings: ModelPlaneWarning[] = [],
-): CatalogModel {
-  const overlaid = applyLocalOverridesToRootModel(providerId, agent, model, overrides, warnings);
-  return hasLocalAddition(overrides, providerId, model.id, agent)
-    ? overlaid
-    : { ...overlaid, status: 'retired' };
-}
-
-/**
  * root 投影到 bridge 后，应用目标消费端的本地 perAgent/base patch。顺序仍是
  * addition → patch；bridge 的 ID/effort/fast 硬约束由 active-catalog 最后收口。
  */

--- a/apps/desktop/src/main/maker-host/model-plane/modelPlanePolicy.ts
+++ b/apps/desktop/src/main/maker-host/model-plane/modelPlanePolicy.ts
@@ -4,18 +4,18 @@
  * 三件事严格分离(2026-08-02 架构收敛定案,协议侧契约见本仓
  * modelRegistryCanonical.ts 的「Presence, entitlement, and sale availability」):
  *  - roots:该供应商的 canonical 实体列表落在哪些 agent。实体化 / discovery /
- *    本地 override 只作用于 root;派生端(bridge / Pi)永远重算,禁止直写。
+ *    本地 override 只作用于 root；wire bridge 从 root 重算，Pi 不进入这张投影图。
  *  - membership:registry route.agents 声明「允许出现在哪些消费端」,不是 root
  *    清单——root ∩ membership 决定实体化落点,非 root 的 membership 只授权投影
  *    可达(如 anthropic route 含 codex = 允许进 codex bridge)。
  *  - transforms:投影期的 ID/能力变换(chatgpt/ 前缀、effort 封顶、fast=false),
  *    硬约束最后收口。共享变换与拓扑都集中在本模块,目录装配和续跑描述符不得各写一套。
  *
- * Pi 不在 wire enum(protocol MODEL_ACCESS_AGENTS 只有 claude-code/codex),
- * 恒定由客户端投影派生,route 永远无法点名 pi:
- *  - openai:  codex root → claude-code bridge(membership 门控) + pi bridge(恒定);
- *  - anthropic: claude-code root → codex bridge(membership 门控,fast=false) + pi 镜像(恒定);
- *  - xai:    claude-code/codex 双 root(perAgent 各自应用),pi 镜像 claude-code root(恒定);
+ * Pi 不在 wire enum(protocol MODEL_ACCESS_AGENTS 只有 claude-code/codex)，也不从这两个
+ * harness 复制。Pi 的成员与能力由客户端 Pi 原生目录和明确的 Pi 覆盖单独装配。
+ *  - openai:  codex root → claude-code bridge(membership 门控);
+ *  - anthropic: claude-code root → codex bridge(membership 门控,fast=false);
+ *  - xai:    claude-code/codex 双 root(perAgent 各自应用);
  *  - xd:     roots=∅ —— 存在性/元数据只来自 Gateway /models,registry 与本地
  *            override 永远不能凭空制造 XD 可售模型。
  */
@@ -36,8 +36,6 @@ export type RootAgentKind = 'claude-code' | 'codex';
 export interface BuiltinModelPlanePolicy {
   /** canonical 实体列表所在 agent。 */
   roots: readonly RootAgentKind[];
-  /** Pi 恒定投影使用的 canonical root;Pi 不进入 wire membership。 */
-  piRoot: RootAgentKind;
   /**
    * membership 门控的派生端:root 模型是否进入该 bridge 由 registry route.agents
    * 是否包含该 agent 决定;registry 没登记的模型(纯 discovery)不受门控,维持
@@ -48,42 +46,11 @@ export interface BuiltinModelPlanePolicy {
 
 /** 实体化 allowlist:只有这三家允许由 registry presence 长出可选实体。 */
 export const MODEL_PLANE_POLICIES: ReadonlyMap<string, BuiltinModelPlanePolicy> = new Map([
-  ['openai', { roots: ['codex'], piRoot: 'codex', membershipGatedBridges: ['claude-code'] }],
-  [
-    'anthropic',
-    { roots: ['claude-code'], piRoot: 'claude-code', membershipGatedBridges: ['codex'] },
-  ],
-  ['xai', { roots: ['claude-code', 'codex'], piRoot: 'claude-code', membershipGatedBridges: [] }],
+  ['openai', { roots: ['codex'], membershipGatedBridges: ['claude-code'] }],
+  ['anthropic', { roots: ['claude-code'], membershipGatedBridges: ['codex'] }],
+  ['xai', { roots: ['claude-code', 'codex'], membershipGatedBridges: [] }],
   // xd 有意不在表内:Gateway 独占存在性(见文件头)。
 ]);
-
-function piRegistryMatch(
-  registry: ModelRegistry,
-  providerId: string,
-  piModelId: string,
-): { entry: ModelRegistryEntry; rootModelId: string } | null {
-  const policy = MODEL_PLANE_POLICIES.get(providerId);
-  if (!policy) return null;
-  const rootModelId = canonicalRegistryEntryModelId(providerId, piModelId);
-  if (!rootModelId) return null;
-
-  const exactEntry = registry.models.find((entry) => entry.id === `${providerId}/${rootModelId}`);
-  if (exactEntry) {
-    const exactRoute = exactEntry.routes.find((route) => route.providerId === providerId);
-    if (exactRoute) {
-      const isConsumerAlias = exactRoute.modelId !== rootModelId;
-      const piReachable =
-        exactRoute.agents.includes(policy.piRoot) ||
-        (providerId === 'openai' &&
-          isConsumerAlias &&
-          exactRoute.agents.includes('claude-code'));
-      if (piReachable) return { entry: exactEntry, rootModelId };
-    }
-  }
-
-  const matched = findModelRegistryRoute(registry, providerId, rootModelId, policy.piRoot);
-  return matched ? { entry: matched.entry, rootModelId } : null;
-}
 
 function canonicalRegistryEntryModelId(providerId: string, consumerModelId: string): string | null {
   const modelId = consumerModelId.trim();
@@ -98,8 +65,7 @@ function canonicalRegistryEntryModelId(providerId: string, consumerModelId: stri
  * Registry tombstone lookup for a concrete client consumer. This mirrors the same root/bridge
  * graph used by materialization without requiring a CatalogModel entity: retired routes are
  * intentionally absent from the assembled provider list, but legacy controllers may still name
- * one explicitly. Pi maps to its canonical source root because it is client-projected and never
- * appears in the wire agent enum.
+ * one explicitly. Pi is independent from the Registry graph and is never tombstoned here.
  */
 export function isRegistryTombstoneForConsumer(
   registry: ModelRegistry | null | undefined,
@@ -110,9 +76,7 @@ export function isRegistryTombstoneForConsumer(
   const policy = MODEL_PLANE_POLICIES.get(providerId);
   if (!registry || !policy) return false;
 
-  if (agent === 'pi') {
-    return piRegistryMatch(registry, providerId, modelId)?.entry.status === 'retired';
-  }
+  if (agent === 'pi') return false;
   const registryAgent =
     policy.roots.includes(agent) || policy.membershipGatedBridges.includes(agent) ? agent : null;
   if (!registryAgent) return false;
@@ -126,8 +90,7 @@ export function isRegistryTombstoneForConsumer(
       (entry) => entry.id === `${providerId}/${canonicalModelId}`,
     );
     const exactRoute = exactEntry?.routes.find(
-      (route) =>
-        route.providerId === providerId && route.agents.includes(registryAgent),
+      (route) => route.providerId === providerId && route.agents.includes(registryAgent),
     );
     if (exactEntry && exactRoute) return exactEntry.status === 'retired';
   }
@@ -148,13 +111,13 @@ const VALID_EFFORTS: ReadonlySet<string> = new Set([
 ]);
 type Effort = CatalogModel['efforts'][number];
 
-/** Claude/Pi 的 OpenAI bridge 默认收起的旧型号;与既有目录行为保持一致。 */
+/** Claude 的 OpenAI bridge 默认收起的旧型号;与既有目录行为保持一致。 */
 const BRIDGE_DEFAULT_HIDDEN_SLUGS: ReadonlySet<string> = new Set(['gpt-5.4', 'gpt-5.4-mini']);
 
 /** anthropic-responses bridge 不会兑现的 GPT 思考档,投影时必须在客户端硬封顶。 */
 const CLAUDE_BRIDGE_UNSUPPORTED_EFFORTS: ReadonlySet<Effort> = new Set(['max', 'ultra']);
 
-/** OpenAI Codex root → Claude/Pi bridge;目录装配与 retired 续跑共同复用。 */
+/** OpenAI Codex root → Claude bridge。 */
 export function toChatgptBridgeModel(model: CatalogModel): CatalogModel {
   const bridgeEfforts = model.efforts.filter(
     (effort) => !CLAUDE_BRIDGE_UNSUPPORTED_EFFORTS.has(effort),
@@ -173,17 +136,6 @@ export function toChatgptBridgeModel(model: CatalogModel): CatalogModel {
       : {}),
     ...(BRIDGE_DEFAULT_HIDDEN_SLUGS.has(model.id) ? { defaultEnabled: false } : {}),
   };
-}
-
-/** canonical root → Pi;Pi 始终从 policy 指定 root 派生,永不读取 wire agent membership。 */
-export function projectRootModelToPi(
-  providerId: string,
-  rootAgent: RootAgentKind,
-  model: CatalogModel,
-): CatalogModel | null {
-  const policy = MODEL_PLANE_POLICIES.get(providerId);
-  if (!policy || policy.piRoot !== rootAgent) return null;
-  return providerId === 'openai' ? toChatgptBridgeModel(model) : model;
 }
 
 /** 单 root 的 registry 消费计划:先算好,合并期零决策。 */
@@ -209,14 +161,14 @@ export interface ModelPlaneWarning {
 export interface ModelPlaneRegistryPlan {
   /** key = `${providerId}:${rootAgent}`。 */
   roots: Map<string, RootRegistryPlan>;
-  /** key = `${providerId}:${consumer}`；wire bridge 用 perAgent，Pi 用 entry 基线。 */
+  /** key = `${providerId}:${consumer}`；wire bridge 使用目标端 perAgent。 */
   consumers: Map<string, Map<string, Partial<CatalogModel>>>;
   /**
    * key = `${providerId}:${consumer}`；同一上游 modelId 的显式消费端变体。
    *
    * 这类条目用不同 canonical entry id 表达独立选择，但 route.modelId 仍保持厂商官方
    * model id。旧客户端会因没有 canonical root 而安全忽略；理解该语义的新客户端只在
-   * route 明确授权的 bridge 与 Pi 投影中物化，不污染 canonical root（尤其不改 Codex）。
+   * route 明确授权的 bridge 中物化，不污染 canonical root（尤其不改 Codex）。
    */
   consumerAdditions: Map<string, CatalogModel[]>;
   warnings: ModelPlaneWarning[];
@@ -345,13 +297,11 @@ export function planRegistryRoots(registry: ModelRegistry | undefined): ModelPla
         ? entry.id.slice(canonicalPrefix.length)
         : null;
       const isConsumerAlias =
-        consumerAliasId !== null &&
-        consumerAliasId.length > 0 &&
-        consumerAliasId !== route.modelId;
+        consumerAliasId !== null && consumerAliasId.length > 0 && consumerAliasId !== route.modelId;
 
       // OpenAI 的包月长上下文是同一官方 modelId 的显式 opt-in。Registry 用不同 entry id
       // 建立独立选择，route.modelId 仍写官方裸 id；route 只点名 claude-code，因此不能为了
-      // 物化它而把 Codex root 一起抬高。Pi 继续按产品约定从同一 entry 基线投影。
+      // 物化它而把 Codex root 一起抬高。Pi 不参与 Registry consumer projection。
       if (
         route.providerId === 'openai' &&
         memberRoots.length === 0 &&
@@ -359,37 +309,32 @@ export function planRegistryRoots(registry: ModelRegistry | undefined): ModelPla
         routeAgents.includes('claude-code')
       ) {
         if (status === null) continue;
-        for (const consumer of ['claude-code', 'pi'] as const) {
-          const fields = effectiveRouteFields(
-            entry,
-            consumer === 'claude-code' ? 'claude-code' : undefined,
-          );
-          if (fields.validationError) {
-            plan.warnings.push({
-              source: 'registry',
-              providerId: route.providerId,
-              agent: policy.piRoot,
-              modelId: consumerAliasId,
-              reason: `${consumer} consumer alias ${fields.validationError}`,
-            });
-            continue;
-          }
-          const materialized = toMaterializedModel(consumerAliasId, fields, status);
-          if (typeof materialized === 'string') {
-            plan.warnings.push({
-              source: 'registry',
-              providerId: route.providerId,
-              agent: policy.piRoot,
-              modelId: consumerAliasId,
-              reason: `${consumer} consumer alias ${materialized}`,
-            });
-            continue;
-          }
-          const key = consumerPlanKey(route.providerId, consumer);
-          const additions = plan.consumerAdditions.get(key) ?? [];
-          additions.push(materialized);
-          plan.consumerAdditions.set(key, additions);
+        const fields = effectiveRouteFields(entry, 'claude-code');
+        if (fields.validationError) {
+          plan.warnings.push({
+            source: 'registry',
+            providerId: route.providerId,
+            agent: 'claude-code',
+            modelId: consumerAliasId,
+            reason: `claude-code consumer alias ${fields.validationError}`,
+          });
+          continue;
         }
+        const materialized = toMaterializedModel(consumerAliasId, fields, status);
+        if (typeof materialized === 'string') {
+          plan.warnings.push({
+            source: 'registry',
+            providerId: route.providerId,
+            agent: 'claude-code',
+            modelId: consumerAliasId,
+            reason: `claude-code consumer alias ${materialized}`,
+          });
+          continue;
+        }
+        const key = consumerPlanKey(route.providerId, 'claude-code');
+        const additions = plan.consumerAdditions.get(key) ?? [];
+        additions.push(materialized);
+        plan.consumerAdditions.set(key, additions);
         continue;
       }
       // 有 lifecycle presence、却没有 canonical root 的 route 无法产生任何实体或
@@ -458,28 +403,6 @@ export function planRegistryRoots(registry: ModelRegistry | undefined): ModelPla
         rootPlan.additions.push(materialized);
       }
       if (!acceptedRoot) continue;
-      // Pi 不在 wire perAgent enum 中，但它仍是 Registry 的独立消费端。它必须从
-      // entry 基线投影，不能继承 piRoot 上的 Codex/Claude 专属覆盖。
-      if (memberRoots.includes(policy.piRoot)) {
-        const fields = effectiveRouteFields(entry);
-        if (fields.validationError) {
-          plan.warnings.push({
-            source: 'registry',
-            providerId: route.providerId,
-            agent: policy.piRoot,
-            modelId: route.modelId,
-            reason: `pi baseline ${fields.validationError}`,
-          });
-        } else {
-          const key = consumerPlanKey(route.providerId, 'pi');
-          let overlays = plan.consumers.get(key);
-          if (!overlays) {
-            overlays = new Map();
-            plan.consumers.set(key, overlays);
-          }
-          overlays.set(route.modelId, toOverlay(fields, status));
-        }
-      }
       // 目标 bridge 的 effective fields = entry base + perAgent[bridge]。metadata-only
       // 仍可 overlay 已存在的 discovery bridge，但不能在下面改变投影拓扑。
       for (const bridgeAgent of policy.membershipGatedBridges) {
@@ -619,42 +542,6 @@ function toMaterializedModel(
         ? { defaultEnabled: fields.defaultEnabled }
         : {}),
   };
-}
-
-/**
- * 为已持久化 Pi 会话重建 retired 模型的运行时描述实体。
- *
- * 这不是可选目录实体化:调用方只可把结果补进当前会话私有的 models.json;公开
- * availableModels / 新路由准入仍过滤 retired。这样纯 Registry 模型在退役并重启后
- * 仍能按旧选择续跑,同时保持 MODEL_REGISTRY.md 的“不得新实体化”契约。
- */
-export function resolveRetiredRegistryModelForPi(
-  registry: ModelRegistry | null | undefined,
-  providerId: string,
-  piModelId: string,
-  options: {
-    prepareRootModel?: (params: {
-      providerId: string;
-      rootAgent: RootAgentKind;
-      model: CatalogModel;
-    }) => CatalogModel;
-  } = {},
-): CatalogModel | null {
-  const policy = MODEL_PLANE_POLICIES.get(providerId);
-  if (!registry || !policy) return null;
-  const matched = piRegistryMatch(registry, providerId, piModelId);
-  if (!matched || matched.entry.status !== 'retired') return null;
-  const fields = effectiveRouteFields(matched.entry);
-  if (fields.validationError) return null;
-  const root = toMaterializedModel(matched.rootModelId, fields, 'active');
-  if (typeof root === 'string') return null;
-  const retiredRoot = { ...root, status: 'retired' as const };
-  const preparedRoot = options.prepareRootModel?.({
-    providerId,
-    rootAgent: policy.piRoot,
-    model: retiredRoot,
-  }) ?? retiredRoot;
-  return projectRootModelToPi(providerId, policy.piRoot, preparedRoot);
 }
 
 /**

--- a/apps/desktop/src/main/maker-host/pi-host.ts
+++ b/apps/desktop/src/main/maker-host/pi-host.ts
@@ -503,6 +503,23 @@ function catalogCostForPiNative(cost: {
 }
 
 /**
+ * CatalogModel 只保存 Cindy 可选择的 effort 档位，Pi 原生目录还可能把档位映射到
+ * 另一条 wire 值（例如 minimal -> low）。叠加服务端能力时保留同源 bundled 映射；
+ * 服务端新增的档位没有原生映射才按同名值发送。
+ */
+function catalogThinkingLevelMap(
+  efforts: readonly string[],
+  bundled: PiNativeModelSpec['thinkingLevelMap'] | undefined,
+): NonNullable<PiNativeModelSpec['thinkingLevelMap']> {
+  return Object.fromEntries(
+    PI_REASONING_EFFORTS.map((effort) => [
+      effort,
+      efforts.includes(effort) ? (bundled?.[effort] ?? effort) : null,
+    ]),
+  );
+}
+
+/**
  * Overlay Cindy's host-managed subscription endpoints onto PI's bundled
  * provider catalog. Registry metadata is authoritative for OpenAI subscription
  * models; the version-matched PI binary remains authoritative for native API and
@@ -656,11 +673,9 @@ export function buildPiSubscriptionNativeProviders(
             maxTokens: model.maxOutput ?? bundledModel.maxTokens,
             reasoning: model.efforts.length > 0,
             input,
-            thinkingLevelMap: Object.fromEntries(
-              PI_REASONING_EFFORTS.map((effort) => [
-                effort,
-                model.efforts.includes(effort) ? effort : null,
-              ]),
+            thinkingLevelMap: catalogThinkingLevelMap(
+              model.efforts,
+              bundledModel.thinkingLevelMap,
             ),
             ...(cost ? { cost: { ...cost } } : {}),
             ...(bundledModel.headers ? { headers: { ...bundledModel.headers } } : {}),

--- a/apps/desktop/src/main/maker-host/pi-host.ts
+++ b/apps/desktop/src/main/maker-host/pi-host.ts
@@ -1324,12 +1324,11 @@ export function buildPiNativeProvidersFromConfigs(
         const explicitRouteApi = explicitRoute
           ? wireProtocolToPiApi(explicitRoute.wireProtocol)
           : undefined;
+        // bundled/official rows may lend protocol-compatible capabilities, but never routing.
+        // A same-origin URL is not the same endpoint: replacing /proxy/v1 with /v1 can bypass
+        // the user's proxy. Only the model's own explicit route may create a model-level baseUrl.
         const modelBaseUrl =
-          explicitRouteApi === modelApi
-            ? explicitRoute?.baseUrl
-            : bundledModel?.api === modelApi
-              ? bundledModel.baseUrl
-              : undefined;
+          m.route && explicitRouteApi === modelApi ? explicitRoute?.baseUrl : undefined;
         const spec = {
           id: m.id,
           ...(m.piApi || modelApi !== providerApi ? { api: modelApi } : {}),

--- a/apps/desktop/src/main/maker-host/pi-host.ts
+++ b/apps/desktop/src/main/maker-host/pi-host.ts
@@ -1232,11 +1232,14 @@ export function buildPiNativeProvidersFromConfigs(
     // strictly same-origin PI bundled knowledge, then an explicitly matched official
     // PI catalog. Missing protocol is not Chat: one unresolved model makes the whole
     // provider unusable so PI cannot silently send it to a guessed endpoint shape.
-    const bundledModels = rt.models.map((model) =>
-      !model.piApi && !runtimeApi
-        ? resolvePiBundledModelById(bundledModelsByProvider, model.id, rt.baseUrl)
-        : undefined,
-    );
+    const bundledModels = rt.models.map((model) => {
+      // 显式 runtime 协议决定端点形状，但不应阻止同源 Pi 目录补齐图片、输出上限等能力。
+      // 只有 per-model piApi 明确改写协议时才不借用；协议冲突也必须隔离。
+      if (model.piApi) return undefined;
+      const bundled = resolvePiBundledModelById(bundledModelsByProvider, model.id, rt.baseUrl);
+      if (!bundled || !runtimeApi || bundled.api === runtimeApi) return bundled;
+      return undefined;
+    });
     const official =
       rt.piCatalogProviderId &&
       officialPiRouteMatches(rt.piCatalogProviderId, rt.baseUrl, rt.wireProtocol)
@@ -1317,7 +1320,8 @@ export function buildPiNativeProvidersFromConfigs(
           ...(m.piApi || modelApi !== providerApi ? { api: modelApi } : {}),
           ...(modelBaseUrl && modelBaseUrl !== rt.baseUrl ? { baseUrl: modelBaseUrl } : {}),
           name: bundledModel?.name ?? m.name,
-          contextWindow: bundledModel?.contextWindow ?? m.contextWindow,
+          // 下发文件明确写出的上下文优先；本地 Pi 目录只补缺失值。
+          contextWindow: m.contextWindow ?? bundledModel?.contextWindow,
           ...(bundledModel?.maxTokens ? { maxTokens: bundledModel.maxTokens } : {}),
           ...(bundledModel?.input
             ? { input: [...bundledModel.input] }

--- a/apps/desktop/src/main/maker-host/title-one-shot.ts
+++ b/apps/desktop/src/main/maker-host/title-one-shot.ts
@@ -149,8 +149,17 @@ function trimTrailingSlash(s: string): string {
   return s.replace(/\/+$/, '');
 }
 
-/** 在 provider 的所有 agent 模型清单里查某 model id 的目录条目(用于取 efforts)。 */
-function findCatalogModel(provider: Provider, modelId: string) {
+/** 标题请求固定走供应商自己的原生通道，不能被其它 harness 的同名模型遮住状态。 */
+function titleCatalogAgent(providerId: string): 'claude-code' | 'codex' | null {
+  if (providerId === 'anthropic') return 'claude-code';
+  if (providerId === 'openai') return 'codex';
+  return null;
+}
+
+/** 在标题请求实际使用的 agent 清单里查模型；XD 动态模型仍跨清单查找。 */
+function findTitleCatalogModel(provider: Provider, modelId: string) {
+  const titleAgent = titleCatalogAgent(provider.id);
+  if (titleAgent) return (provider.models[titleAgent] ?? []).find((model) => model.id === modelId);
   for (const agent of provider.agents) {
     const hit = (provider.models[agent] ?? []).find((m) => m.id === modelId);
     if (hit) return hit;
@@ -229,7 +238,7 @@ export function buildTitleTarget(providerId: string): TitleTarget | null {
     case 'anthropic': {
       if (!provider.titleModel) return null;
       const model = provider.titleModel;
-      const effort = lowestEffort(findCatalogModel(provider, model)?.efforts ?? []);
+      const effort = lowestEffort(findTitleCatalogModel(provider, model)?.efforts ?? []);
       const routing = provider.routing['claude-code'];
       return routing
         ? { providerId, model, effort, wire: 'anthropic-messages', upstream: routing.upstream }
@@ -238,7 +247,7 @@ export function buildTitleTarget(providerId: string): TitleTarget | null {
     case 'openai': {
       if (!provider.titleModel) return null;
       const model = provider.titleModel;
-      const effort = lowestEffort(findCatalogModel(provider, model)?.efforts ?? []);
+      const effort = lowestEffort(findTitleCatalogModel(provider, model)?.efforts ?? []);
       const routing = provider.routing['codex'];
       return routing
         ? { providerId, model, effort, wire: 'codex-responses', upstream: routing.upstream }
@@ -538,13 +547,13 @@ log.debug('title oneShot skipped: no title target', {
     });
     return { status };
   }
-  // 标题模型这份拷贝被用户停用 → 跳过(回落启发式起名)。rail 条目带 buildRegistry
-  // 烘焙的 disabled 标志。查找必须跨该供应商的**所有 agent** 清单(findCatalogModel,
-  // 与 buildTitleTarget 解析 titleModel 的口径一致):cc 会话经 OpenAI 路由时,标题模型
-  // gpt-5.4-mini 挂在 codex 清单下,只查会话 agent 会漏掉停用标志(PR #744 review
-  // 第十一轮)。目录里完全找不到该模型时不额外拦。
+  // 标题模型这份拷贝被用户停用 → 跳过(回落启发式起名)。查标题请求实际使用的原生
+  // agent 清单，而不是会话 agent 或全部清单：OpenAI 标题走 codex，Anthropic 标题走
+  // claude-code；否则 Pi 的独立同名条目会遮住原生通道的 retired 状态。
   const railProvider = rail.find((p) => p.id === providerId);
-  const titleCatalogModel = railProvider ? findCatalogModel(railProvider, target.model) : undefined;
+  const titleCatalogModel = railProvider
+    ? findTitleCatalogModel(railProvider, target.model)
+    : undefined;
   const initialUnavailableReason = titleCatalogModel
     ? titleRouteUnavailableReason(titleCatalogModel, railProvider?.source === 'user')
     : null;
@@ -580,15 +589,19 @@ log.debug('title oneShot skipped: no title target', {
     const currentCatalog = getActiveCatalog();
     const currentProvider = currentCatalog.providers.find((provider) => provider.id === providerId);
     const currentModel = currentProvider
-      ? findCatalogModel(currentProvider, target.model)
+      ? findTitleCatalogModel(currentProvider, target.model)
       : undefined;
     if (currentModel) {
       return titleRouteUnavailableReason(currentModel, currentProvider?.source === 'user');
     }
     // retired 且没有 discovery/local addition 时不会出现在 provider.models；仍要从
     // Registry tombstone 本身识别，不能把“未实体化”误当成“没有限制”。
-    return findModelRegistryRoute(currentCatalog.modelRegistry, providerId, target.model)?.entry
-      .status === 'retired'
+    return findModelRegistryRoute(
+      currentCatalog.modelRegistry,
+      providerId,
+      target.model,
+      titleCatalogAgent(providerId) ?? undefined,
+    )?.entry.status === 'retired'
       ? 'retired'
       : null;
   };

--- a/docs/product-rules/model-selector-unified.md
+++ b/docs/product-rules/model-selector-unified.md
@@ -93,7 +93,8 @@
 
 - 候选引擎 = 该模型在最终 catalog 中出现的所有 `(provider, agent)` 组合(`Provider.models: Record<AgentKind, CatalogModel[]>`),经现有可见/准入/区域/SSH 过滤后。
 - 推荐引擎 = 模型**生效来源** provider 的主 root(`MODEL_PLANE_POLICIES`:openai→codex、anthropic→claude-code;xd 按 gateway `perAgent`/membership;user provider 按其 runtime)。同名多来源时先 `effectiveSourceIdForModel` 解析生效来源再推导——**禁止读拍平去重后的列表**(registry.ts 明示)。
-- Pi 恒为候选(客户端投影,wire enum 无 pi,维持现状)。
+- Pi 的候选成员来自客户端随包的 Pi 原生目录与明确的 Pi 覆盖，不能从
+  Claude Code/Codex 的发现清单或 Registry 投影；wire enum 仍不增加 pi。
 - **原生底座(排序用,与推荐引擎分离)只标确有主场的,可空**(Chris 2026-08-13 裁决):
   anthropic→cc、openai→codex、折扣条目→codex;**多 root 全能模型(xai 系)与判不出家族的
   BYOM 一律 null = 无主场**——任何引擎视图都不降级,只有「主场明确在别处」的行才降到

--- a/packages/model-providers/catalog/pi-model-catalog.json
+++ b/packages/model-providers/catalog/pi-model-catalog.json
@@ -1,6 +1,398 @@
 {
-  "generatedAt": "2026-09-01T09:09:09.000Z",
+  "generatedAt": "2026-09-03T10:41:11.000Z",
   "providers": {
+    "anthropic": [
+      {
+        "id": "claude-fable-5",
+        "name": "Claude Fable 5",
+        "api": "anthropic-messages",
+        "provider": "anthropic",
+        "baseUrl": "https://api.anthropic.com",
+        "reasoning": true,
+        "input": [
+          "text",
+          "image"
+        ],
+        "cost": {
+          "input": 10,
+          "output": 50,
+          "cacheRead": 1,
+          "cacheWrite": 12.5
+        },
+        "contextWindow": 1000000,
+        "maxTokens": 128000,
+        "thinkingLevelMap": {
+          "off": null,
+          "xhigh": "xhigh",
+          "max": "max"
+        },
+        "compat": {
+          "forceAdaptiveThinking": true,
+          "supportsStrictTools": true,
+          "allowedFallbackModels": [
+            {
+              "provider": "anthropic",
+              "model": "claude-opus-4-8",
+              "cost": {
+                "input": 5,
+                "output": 25,
+                "cacheRead": 0.5,
+                "cacheWrite": 6.25
+              }
+            },
+            {
+              "provider": "anthropic",
+              "model": "claude-opus-5",
+              "cost": {
+                "input": 5,
+                "output": 25,
+                "cacheRead": 0.5,
+                "cacheWrite": 6.25
+              }
+            }
+          ]
+        }
+      },
+      {
+        "id": "claude-fable-5-1",
+        "name": "Claude Fable 5.1",
+        "api": "anthropic-messages",
+        "provider": "anthropic",
+        "baseUrl": "https://api.anthropic.com",
+        "reasoning": true,
+        "input": [
+          "text",
+          "image"
+        ],
+        "cost": {
+          "input": 10,
+          "output": 50,
+          "cacheRead": 0.25,
+          "cacheWrite": 12.5
+        },
+        "contextWindow": 1000000,
+        "maxTokens": 128000,
+        "compat": {
+          "supportsMidConvoEffort": true,
+          "forceAdaptiveThinking": true,
+          "supportsStrictTools": true
+        },
+        "thinkingLevelMap": {
+          "off": null,
+          "xhigh": "xhigh",
+          "max": "max"
+        }
+      },
+      {
+        "id": "claude-haiku-4-5",
+        "name": "Claude Haiku 4.5 (latest)",
+        "api": "anthropic-messages",
+        "provider": "anthropic",
+        "baseUrl": "https://api.anthropic.com",
+        "reasoning": true,
+        "input": [
+          "text",
+          "image"
+        ],
+        "cost": {
+          "input": 1,
+          "output": 5,
+          "cacheRead": 0.1,
+          "cacheWrite": 1.25
+        },
+        "contextWindow": 200000,
+        "maxTokens": 64000,
+        "compat": {
+          "supportsStrictTools": true
+        }
+      },
+      {
+        "id": "claude-haiku-4-5-20251001",
+        "name": "Claude Haiku 4.5",
+        "api": "anthropic-messages",
+        "provider": "anthropic",
+        "baseUrl": "https://api.anthropic.com",
+        "reasoning": true,
+        "input": [
+          "text",
+          "image"
+        ],
+        "cost": {
+          "input": 1,
+          "output": 5,
+          "cacheRead": 0.1,
+          "cacheWrite": 1.25
+        },
+        "contextWindow": 200000,
+        "maxTokens": 64000,
+        "compat": {
+          "supportsStrictTools": true
+        }
+      },
+      {
+        "id": "claude-opus-4-5",
+        "name": "Claude Opus 4.5 (latest)",
+        "api": "anthropic-messages",
+        "provider": "anthropic",
+        "baseUrl": "https://api.anthropic.com",
+        "reasoning": true,
+        "input": [
+          "text",
+          "image"
+        ],
+        "cost": {
+          "input": 5,
+          "output": 25,
+          "cacheRead": 0.5,
+          "cacheWrite": 6.25
+        },
+        "contextWindow": 200000,
+        "maxTokens": 64000,
+        "compat": {
+          "supportsStrictTools": true
+        }
+      },
+      {
+        "id": "claude-opus-4-5-20251101",
+        "name": "Claude Opus 4.5",
+        "api": "anthropic-messages",
+        "provider": "anthropic",
+        "baseUrl": "https://api.anthropic.com",
+        "reasoning": true,
+        "input": [
+          "text",
+          "image"
+        ],
+        "cost": {
+          "input": 5,
+          "output": 25,
+          "cacheRead": 0.5,
+          "cacheWrite": 6.25
+        },
+        "contextWindow": 200000,
+        "maxTokens": 64000,
+        "compat": {
+          "supportsStrictTools": true
+        }
+      },
+      {
+        "id": "claude-opus-4-6",
+        "name": "Claude Opus 4.6",
+        "api": "anthropic-messages",
+        "provider": "anthropic",
+        "baseUrl": "https://api.anthropic.com",
+        "reasoning": true,
+        "input": [
+          "text",
+          "image"
+        ],
+        "cost": {
+          "input": 5,
+          "output": 25,
+          "cacheRead": 0.5,
+          "cacheWrite": 6.25
+        },
+        "contextWindow": 1000000,
+        "maxTokens": 128000,
+        "thinkingLevelMap": {
+          "max": "max"
+        },
+        "compat": {
+          "forceAdaptiveThinking": true,
+          "supportsStrictTools": true
+        }
+      },
+      {
+        "id": "claude-opus-4-7",
+        "name": "Claude Opus 4.7",
+        "api": "anthropic-messages",
+        "provider": "anthropic",
+        "baseUrl": "https://api.anthropic.com",
+        "reasoning": true,
+        "input": [
+          "text",
+          "image"
+        ],
+        "cost": {
+          "input": 5,
+          "output": 25,
+          "cacheRead": 0.5,
+          "cacheWrite": 6.25
+        },
+        "contextWindow": 1000000,
+        "maxTokens": 128000,
+        "thinkingLevelMap": {
+          "xhigh": "xhigh",
+          "max": "max"
+        },
+        "compat": {
+          "forceAdaptiveThinking": true,
+          "supportsTemperature": false,
+          "supportsStrictTools": true
+        }
+      },
+      {
+        "id": "claude-opus-4-8",
+        "name": "Claude Opus 4.8",
+        "api": "anthropic-messages",
+        "provider": "anthropic",
+        "baseUrl": "https://api.anthropic.com",
+        "reasoning": true,
+        "input": [
+          "text",
+          "image"
+        ],
+        "cost": {
+          "input": 5,
+          "output": 25,
+          "cacheRead": 0.5,
+          "cacheWrite": 6.25
+        },
+        "contextWindow": 1000000,
+        "maxTokens": 128000,
+        "thinkingLevelMap": {
+          "xhigh": "xhigh",
+          "max": "max"
+        },
+        "compat": {
+          "forceAdaptiveThinking": true,
+          "supportsTemperature": false,
+          "supportsStrictTools": true
+        }
+      },
+      {
+        "id": "claude-opus-5",
+        "name": "Claude Opus 5",
+        "api": "anthropic-messages",
+        "provider": "anthropic",
+        "baseUrl": "https://api.anthropic.com",
+        "reasoning": true,
+        "input": [
+          "text",
+          "image"
+        ],
+        "cost": {
+          "input": 5,
+          "output": 25,
+          "cacheRead": 0.5,
+          "cacheWrite": 6.25
+        },
+        "contextWindow": 1000000,
+        "maxTokens": 128000,
+        "compat": {
+          "supportsMidConvoEffort": true,
+          "forceAdaptiveThinking": true,
+          "supportsTemperature": false,
+          "supportsStrictTools": true
+        },
+        "thinkingLevelMap": {
+          "off": null,
+          "xhigh": "xhigh",
+          "max": "max"
+        }
+      },
+      {
+        "id": "claude-sonnet-4-5",
+        "name": "Claude Sonnet 4.5 (latest)",
+        "api": "anthropic-messages",
+        "provider": "anthropic",
+        "baseUrl": "https://api.anthropic.com",
+        "reasoning": true,
+        "input": [
+          "text",
+          "image"
+        ],
+        "cost": {
+          "input": 3,
+          "output": 15,
+          "cacheRead": 0.3,
+          "cacheWrite": 3.75
+        },
+        "contextWindow": 1000000,
+        "maxTokens": 64000,
+        "compat": {
+          "supportsStrictTools": true
+        }
+      },
+      {
+        "id": "claude-sonnet-4-5-20250929",
+        "name": "Claude Sonnet 4.5",
+        "api": "anthropic-messages",
+        "provider": "anthropic",
+        "baseUrl": "https://api.anthropic.com",
+        "reasoning": true,
+        "input": [
+          "text",
+          "image"
+        ],
+        "cost": {
+          "input": 3,
+          "output": 15,
+          "cacheRead": 0.3,
+          "cacheWrite": 3.75
+        },
+        "contextWindow": 1000000,
+        "maxTokens": 64000,
+        "compat": {
+          "supportsStrictTools": true
+        }
+      },
+      {
+        "id": "claude-sonnet-4-6",
+        "name": "Claude Sonnet 4.6",
+        "api": "anthropic-messages",
+        "provider": "anthropic",
+        "baseUrl": "https://api.anthropic.com",
+        "reasoning": true,
+        "input": [
+          "text",
+          "image"
+        ],
+        "cost": {
+          "input": 3,
+          "output": 15,
+          "cacheRead": 0.3,
+          "cacheWrite": 3.75
+        },
+        "contextWindow": 1000000,
+        "maxTokens": 128000,
+        "thinkingLevelMap": {
+          "max": "max"
+        },
+        "compat": {
+          "forceAdaptiveThinking": true,
+          "supportsStrictTools": true
+        }
+      },
+      {
+        "id": "claude-sonnet-5",
+        "name": "Claude Sonnet 5",
+        "api": "anthropic-messages",
+        "provider": "anthropic",
+        "baseUrl": "https://api.anthropic.com",
+        "reasoning": true,
+        "input": [
+          "text",
+          "image"
+        ],
+        "cost": {
+          "input": 2,
+          "output": 10,
+          "cacheRead": 0.2,
+          "cacheWrite": 2.5
+        },
+        "contextWindow": 1000000,
+        "maxTokens": 128000,
+        "thinkingLevelMap": {
+          "xhigh": "xhigh",
+          "max": "max"
+        },
+        "compat": {
+          "forceAdaptiveThinking": true,
+          "supportsStrictTools": true
+        }
+      }
+    ],
     "deepseek": [
       {
         "id": "deepseek-v4-flash",
@@ -925,6 +1317,253 @@
         }
       }
     ],
+    "openai-codex": [
+      {
+        "id": "gpt-5.3-codex-spark",
+        "name": "GPT-5.3 Codex Spark",
+        "api": "openai-codex-responses",
+        "provider": "openai-codex",
+        "baseUrl": "https://chatgpt.com/backend-api",
+        "reasoning": true,
+        "input": [
+          "text"
+        ],
+        "cost": {
+          "input": 1.75,
+          "output": 14,
+          "cacheRead": 0.175,
+          "cacheWrite": 0
+        },
+        "contextWindow": 128000,
+        "maxTokens": 128000,
+        "thinkingLevelMap": {
+          "xhigh": "xhigh",
+          "minimal": "low"
+        },
+        "compat": {
+          "supportsOpenAIGrammarTools": true
+        }
+      },
+      {
+        "id": "gpt-5.4",
+        "name": "GPT-5.4",
+        "api": "openai-codex-responses",
+        "provider": "openai-codex",
+        "baseUrl": "https://chatgpt.com/backend-api",
+        "reasoning": true,
+        "input": [
+          "text",
+          "image"
+        ],
+        "cost": {
+          "input": 2.5,
+          "output": 15,
+          "cacheRead": 0.25,
+          "cacheWrite": 0,
+          "tiers": [
+            {
+              "inputTokensAbove": 272000,
+              "input": 5,
+              "output": 22.5,
+              "cacheRead": 0.5,
+              "cacheWrite": 0
+            }
+          ]
+        },
+        "contextWindow": 272000,
+        "maxTokens": 128000,
+        "thinkingLevelMap": {
+          "xhigh": "xhigh",
+          "minimal": "low"
+        },
+        "compat": {
+          "supportsOpenAIGrammarTools": true,
+          "supportsToolSearch": true
+        }
+      },
+      {
+        "id": "gpt-5.4-mini",
+        "name": "GPT-5.4 mini",
+        "api": "openai-codex-responses",
+        "provider": "openai-codex",
+        "baseUrl": "https://chatgpt.com/backend-api",
+        "reasoning": true,
+        "input": [
+          "text",
+          "image"
+        ],
+        "cost": {
+          "input": 0.75,
+          "output": 4.5,
+          "cacheRead": 0.075,
+          "cacheWrite": 0
+        },
+        "contextWindow": 272000,
+        "maxTokens": 128000,
+        "thinkingLevelMap": {
+          "xhigh": "xhigh",
+          "minimal": "low"
+        },
+        "compat": {
+          "supportsOpenAIGrammarTools": true,
+          "supportsToolSearch": true
+        }
+      },
+      {
+        "id": "gpt-5.5",
+        "name": "GPT-5.5",
+        "api": "openai-codex-responses",
+        "provider": "openai-codex",
+        "baseUrl": "https://chatgpt.com/backend-api",
+        "reasoning": true,
+        "input": [
+          "text",
+          "image"
+        ],
+        "cost": {
+          "input": 5,
+          "output": 30,
+          "cacheRead": 0.5,
+          "cacheWrite": 0,
+          "tiers": [
+            {
+              "inputTokensAbove": 272000,
+              "input": 10,
+              "output": 45,
+              "cacheRead": 1,
+              "cacheWrite": 0
+            }
+          ]
+        },
+        "contextWindow": 272000,
+        "maxTokens": 128000,
+        "thinkingLevelMap": {
+          "xhigh": "xhigh",
+          "minimal": "low"
+        },
+        "compat": {
+          "supportsOpenAIGrammarTools": true,
+          "supportsToolSearch": true
+        }
+      },
+      {
+        "id": "gpt-5.6-luna",
+        "name": "GPT-5.6 Luna",
+        "api": "openai-codex-responses",
+        "provider": "openai-codex",
+        "baseUrl": "https://chatgpt.com/backend-api",
+        "reasoning": true,
+        "input": [
+          "text",
+          "image"
+        ],
+        "cost": {
+          "input": 0.2,
+          "output": 1.2,
+          "cacheRead": 0.02,
+          "cacheWrite": 0.25,
+          "tiers": [
+            {
+              "inputTokensAbove": 272000,
+              "input": 0.4,
+              "output": 1.8,
+              "cacheRead": 0.04,
+              "cacheWrite": 0.5
+            }
+          ]
+        },
+        "contextWindow": 272000,
+        "maxTokens": 128000,
+        "thinkingLevelMap": {
+          "xhigh": "xhigh",
+          "max": "max",
+          "minimal": "low"
+        },
+        "compat": {
+          "supportsOpenAIGrammarTools": true,
+          "supportsAdditionalTools": true,
+          "supportsToolSearch": true
+        }
+      },
+      {
+        "id": "gpt-5.6-sol",
+        "name": "GPT-5.6 Sol",
+        "api": "openai-codex-responses",
+        "provider": "openai-codex",
+        "baseUrl": "https://chatgpt.com/backend-api",
+        "reasoning": true,
+        "input": [
+          "text",
+          "image"
+        ],
+        "cost": {
+          "input": 5,
+          "output": 30,
+          "cacheRead": 0.5,
+          "cacheWrite": 6.25,
+          "tiers": [
+            {
+              "inputTokensAbove": 272000,
+              "input": 10,
+              "output": 45,
+              "cacheRead": 1,
+              "cacheWrite": 12.5
+            }
+          ]
+        },
+        "contextWindow": 272000,
+        "maxTokens": 128000,
+        "thinkingLevelMap": {
+          "xhigh": "xhigh",
+          "max": "max",
+          "minimal": "low"
+        },
+        "compat": {
+          "supportsOpenAIGrammarTools": true,
+          "supportsAdditionalTools": true,
+          "supportsToolSearch": true
+        }
+      },
+      {
+        "id": "gpt-5.6-terra",
+        "name": "GPT-5.6 Terra",
+        "api": "openai-codex-responses",
+        "provider": "openai-codex",
+        "baseUrl": "https://chatgpt.com/backend-api",
+        "reasoning": true,
+        "input": [
+          "text",
+          "image"
+        ],
+        "cost": {
+          "input": 2,
+          "output": 12,
+          "cacheRead": 0.2,
+          "cacheWrite": 2.5,
+          "tiers": [
+            {
+              "inputTokensAbove": 272000,
+              "input": 4,
+              "output": 18,
+              "cacheRead": 0.4,
+              "cacheWrite": 5
+            }
+          ]
+        },
+        "contextWindow": 272000,
+        "maxTokens": 128000,
+        "thinkingLevelMap": {
+          "xhigh": "xhigh",
+          "max": "max",
+          "minimal": "low"
+        },
+        "compat": {
+          "supportsOpenAIGrammarTools": true,
+          "supportsAdditionalTools": true,
+          "supportsToolSearch": true
+        }
+      }
+    ],
     "qwen-token-plan-cn": [
       {
         "id": "MiniMax-M2.5",
@@ -989,6 +1628,7 @@
           "supportsReasoningEffort": true
         },
         "thinkingLevelMap": {
+          "off": null,
           "minimal": null,
           "low": null,
           "medium": null,
@@ -1022,6 +1662,7 @@
           "supportsReasoningEffort": true
         },
         "thinkingLevelMap": {
+          "off": null,
           "minimal": null,
           "low": null,
           "medium": null,
@@ -1055,6 +1696,7 @@
           "supportsReasoningEffort": true
         },
         "thinkingLevelMap": {
+          "off": null,
           "minimal": null,
           "low": null,
           "medium": null,
@@ -1088,6 +1730,7 @@
           "supportsReasoningEffort": true
         },
         "thinkingLevelMap": {
+          "off": null,
           "minimal": null,
           "low": null,
           "medium": null,
@@ -1187,6 +1830,7 @@
           "supportsReasoningEffort": true
         },
         "thinkingLevelMap": {
+          "off": null,
           "minimal": null,
           "low": null,
           "medium": null,
@@ -1401,12 +2045,13 @@
           "supportsReasoningEffort": true
         },
         "thinkingLevelMap": {
+          "off": null,
           "minimal": null,
-          "low": null,
-          "medium": null,
-          "high": "high",
-          "xhigh": null,
-          "max": "max"
+          "low": "low",
+          "medium": "medium",
+          "high": null,
+          "xhigh": "xhigh",
+          "max": null
         },
         "reasoning": true,
         "input": [
@@ -1435,6 +2080,7 @@
           "supportsReasoningEffort": true
         },
         "thinkingLevelMap": {
+          "off": null,
           "minimal": null,
           "low": "low",
           "medium": "medium",

--- a/packages/model-providers/catalog/providers.json
+++ b/packages/model-providers/catalog/providers.json
@@ -1396,10 +1396,11 @@
               "supportsImageInput": true,
               "reasoning": true,
               "reasoningEfforts": [
-                "high",
-                "max"
+                "low",
+                "medium",
+                "xhigh"
               ],
-              "reasoningDefaultEffort": "high"
+              "reasoningDefaultEffort": "medium"
             },
             {
               "id": "qwen3.8-max",
@@ -1730,10 +1731,11 @@
               "supportsImageInput": true,
               "reasoning": true,
               "reasoningEfforts": [
-                "high",
-                "max"
+                "low",
+                "medium",
+                "xhigh"
               ],
-              "reasoningDefaultEffort": "high"
+              "reasoningDefaultEffort": "medium"
             },
             {
               "id": "qwen3.8-max",

--- a/packages/model-providers/src/__tests__/catalog.test.ts
+++ b/packages/model-providers/src/__tests__/catalog.test.ts
@@ -2,8 +2,8 @@
  * 目录校验 + 内置供应商契约(2026-07-19 模型列表统一重构后的新契约)。
  *
  * **清单来源唯一化**——
- *   - anthropic / openai / xd 是动态清单供应商:bundled 目录只有身份卡,models 恒为空,
- *     清单运行时由 host 注入(SDK 发现 / codex 注册表 / 网关下发);
+ *   - anthropic / openai 的 Claude/Codex 清单动态注入，Pi 使用随包原生目录；
+ *   - xd 是动态清单供应商:bundled 目录只有身份卡,models 恒为空;
  *   - xai 的静态段是离线 fallback/元数据层；登录后的成员由账号发现决定;
  *   - presets 是自定义供应商模板,随目录 OSS 热更。
  *
@@ -23,7 +23,7 @@ import {
 } from '../registry.js';
 import type { AgentKind, Catalog, CatalogModel } from '../types.js';
 
-/** 动态清单供应商(bundled 零模型,运行时注入)。 */
+/** Claude/Codex 动态清单供应商；Anthropic/OpenAI 的 Pi 目录是独立静态快照。 */
 const DYNAMIC_PROVIDER_IDS = ['anthropic', 'openai', 'xd'] as const;
 
 /** xAI 随包 fallback 元数据清单。 */
@@ -130,13 +130,33 @@ describe('bundled catalog validity (dynamic-first contract)', () => {
     expect(BUNDLED_CATALOG.providers.every((p) => p.source === 'builtin')).toBe(true);
   });
 
-  it('dynamic providers ship ZERO static models (list is runtime-injected, no fallback)', () => {
+  it('dynamic providers keep Claude/Codex empty while Pi ships its independent native baseline', () => {
     for (const id of DYNAMIC_PROVIDER_IDS) {
       const p = provider(id);
       for (const agent of p.agents) {
-        expect(p.models[agent], `${id} models[${agent}] must exist (empty array)`).toEqual([]);
+        if (agent === 'pi' && (id === 'anthropic' || id === 'openai')) {
+          expect(p.models.pi?.length, `${id} must ship Pi native models`).toBeGreaterThan(0);
+        } else {
+          expect(p.models[agent], `${id} models[${agent}] must exist (empty array)`).toEqual([]);
+        }
       }
     }
+  });
+
+  it('ships only Pi-native subscription models and does not invent GPT-6 from Registry', () => {
+    expect(provider('openai').models.pi?.map((model) => model.id)).toEqual([
+      'chatgpt/gpt-5.3-codex-spark',
+      'chatgpt/gpt-5.4',
+      'chatgpt/gpt-5.4-mini',
+      'chatgpt/gpt-5.5',
+      'chatgpt/gpt-5.6-luna',
+      'chatgpt/gpt-5.6-sol',
+      'chatgpt/gpt-5.6-terra',
+    ]);
+    expect(
+      provider('openai').models.pi?.some((model) => model.id.startsWith('chatgpt/gpt-6')),
+    ).toBe(false);
+    expect(provider('anthropic').models.pi).toHaveLength(14);
   });
 
   it('xai ships a static fallback list and Pi official metadata', () => {

--- a/packages/model-providers/src/__tests__/unifiedSelection.test.ts
+++ b/packages/model-providers/src/__tests__/unifiedSelection.test.ts
@@ -515,7 +515,7 @@ describe('recommendedAgentForModel', () => {
     expect(recommendedAgentForModel(bridgeOnly, 'openai', 'gpt-legacy')).toBe('claude-code');
   });
 
-  it('xai 双 root → claude-code(piRoot 也是 cc)', () => {
+  it('xai 双 root 推荐 claude-code', () => {
     expect(recommendedAgentForModel(providers, 'xai', 'grok-4.5')).toBe('claude-code');
     expect(recommendedAgentForModel(providers, 'xai', 'xai/grok-4.5')).toBe('claude-code');
   });

--- a/packages/model-providers/src/builtin.ts
+++ b/packages/model-providers/src/builtin.ts
@@ -2,15 +2,14 @@
  * builtin.ts —— 内置供应商身份卡(TS 常量)+ bundled 目录组装。
  *
  * 2026-07-19 模型列表统一重构定案:**清单来源唯一化**——
- *   - anthropic:清单来自 Agent SDK(会话 init 捕获)+ 登录时 HTTP `/v1/models`,
- *     由 host 注入(active-catalog setAnthropicDiscoveredModels);本文件只有身份卡,零模型。
- *   - openai:清单来自 codex 模型注册表(models_cache.json,codex-model-discovery 派生),
- *     经 active-catalog 注入 codex 并投影 claude-code bridge;本文件零模型。
+ *   - anthropic:Claude/Codex 清单来自 Agent SDK(会话 init 捕获)+ 登录时 HTTP `/v1/models`,
+ *     由 host 注入；Pi 清单来自随客户端发布的 Pi 原生目录快照。
+ *   - openai:Codex 清单来自 models_cache.json，经 active-catalog 注入并投影 Claude bridge；
+ *     Pi 清单来自随客户端发布的 Pi 原生目录快照，不经过 Codex 投影。
  *   - xd(Cindy AI 网关):清单来自 model-access-server GET /models(网关权威,
  *     元数据由服务端 modelRegistry 下发);本文件零模型。
- *   - xai:SuperGrok 订阅 OAuth 没有任何列模型通道(官方未提供),清单是唯一
- *     必须静态维护的——活在 `catalog/providers.json`(仓内正本 = OSS 发布物 = dev 直读),
- *     此处从 json 引入作 bundled 兜底。
+ *   - xai:Claude/Codex 静态清单活在 `catalog/providers.json`；Pi 同样只读 Pi 原生目录，
+ *     两边不互相复制成员关系。
  *
  * 身份卡(id / auth / access / routing / titleModel)是随代码走的事实:
  * 改它们必然伴随发版(SDK 集成 / 翻译桥 / 网关协议都是代码),所以写死在这里,
@@ -25,6 +24,7 @@ import catalogJson from '../catalog/providers.json' with { type: 'json' };
 import modelRegistryJson from '../catalog/model-registry.json' with { type: 'json' };
 
 import type { ModelRegistry } from './modelAccessBean.js';
+import { piNativeCatalogModels } from './piNativeCatalog.js';
 import type { Catalog, CatalogModel, Provider } from './types.js';
 
 /** 仓内 v2 目录文件(xai 清单 + presets;同一文件发布到 OSS `cfg/providers.json`)。 */
@@ -75,8 +75,21 @@ const withoutPiApi = (model: CatalogModel): CatalogModel => {
 };
 const xaiClaudeModels = xaiFromCatalog.models['claude-code'] ?? [];
 const xaiCodexModels = xaiFromCatalog.models.codex ?? [];
+const xaiPiOverrides = new Map((xaiFromCatalog.models.pi ?? []).map((model) => [model.id, model]));
+const xaiPiModels = piNativeCatalogModels('xai', { group: 'grok' }).map((model) => ({
+  ...model,
+  ...xaiPiOverrides.get(model.id),
+  id: model.id,
+}));
+const anthropicPiModels = piNativeCatalogModels('anthropic', {
+  group: 'anthropic',
+});
+const openAiPiModels = piNativeCatalogModels('openai-codex', {
+  idPrefix: 'chatgpt/',
+  group: 'gpt',
+});
 
-/** xAI 静态清单同时供 Claude bridge、Codex 与 Pi bridge 使用。 */
+/** xAI 的 Claude/Codex 静态根；Pi 清单来自独立的 Pi 原生快照。 */
 const XAI_PROVIDER: Provider = {
   ...xaiFromCatalog,
   agents: xaiFromCatalog.agents.includes('pi')
@@ -90,13 +103,11 @@ const XAI_PROVIDER: Provider = {
     ...xaiFromCatalog.models,
     'claude-code': xaiClaudeModels.map(withoutPiApi),
     codex: xaiCodexModels.map(withoutPiApi),
-    // providers.json 的 piApi 只属于 Pi；源文件仍与 xAI 静态根同表维护，
-    // bundled 投影在这里拆开，避免协议注解污染 Claude/Codex 快照契约。
-    pi: xaiFromCatalog.models.pi ?? xaiClaudeModels,
+    pi: xaiPiModels,
   },
 };
 
-/** Anthropic(Claude.ai 订阅 OAuth)。模型清单运行时动态注入,此处恒为空。 */
+/** Anthropic(Claude.ai 订阅 OAuth)。Claude/Codex 动态发现，Pi 使用独立原生快照。 */
 const ANTHROPIC_PROVIDER: Provider = {
   id: 'anthropic',
   name: 'Anthropic',
@@ -133,10 +144,10 @@ const ANTHROPIC_PROVIDER: Provider = {
       headerDelete: ['x-api-key'],
     },
   },
-  models: { 'claude-code': [], codex: [], pi: [] },
+  models: { 'claude-code': [], codex: [], pi: anthropicPiModels },
 };
 
-/** OpenAI(ChatGPT 订阅 OAuth)。模型清单来自 codex 注册表,此处恒为空。 */
+/** OpenAI(ChatGPT 订阅 OAuth)。Codex/Claude 动态发现，Pi 使用独立原生快照。 */
 const OPENAI_PROVIDER: Provider = {
   id: 'openai',
   name: 'OpenAI',
@@ -175,7 +186,7 @@ const OPENAI_PROVIDER: Provider = {
       modelPrefixes: ['chatgpt/'],
     },
   },
-  models: { codex: [], 'claude-code': [], pi: [] },
+  models: { codex: [], 'claude-code': [], pi: openAiPiModels },
 };
 
 /** XD / Cindy AI 网关(账号体系托管 key)。模型清单来自网关实时下发,此处恒为空。 */

--- a/packages/model-providers/src/catalog.ts
+++ b/packages/model-providers/src/catalog.ts
@@ -364,11 +364,13 @@ function validateProvider(p: Provider): void {
   }
   // 约束：若声明了 titleModel（标题 oneShot 用的最经济模型），它必须存在于本供应商任一
   // agent 的模型清单里 —— 防把不存在 / 拼错的 id 配进去导致运行时静默起不出标题。
-  // 豁免:动态清单供应商(全部 models 数组为空,清单运行时注入——2026-07-19 统一重构后
-  // 的 anthropic/openai/xd)无静态清单可校验,titleModel 指向的是运行时会出现的 id。
+  // 豁免:Claude/Codex 动态清单供应商在这两个 harness 下都为空时无静态清单可校验；
+  // 独立的 Pi 原生名单不应把它误判为静态 root，也不要求沿用同一 model id 命名空间。
   if (p.titleModel !== undefined) {
     assert(typeof p.titleModel === 'string' && p.titleModel.length > 0, `provider '${p.id}' titleModel must be a non-empty string`);
-    const hasStaticModels = p.agents.some((agent) => (p.models[agent] ?? []).length > 0);
+    const hasStaticModels = p.agents.some(
+      (agent) => agent !== 'pi' && (p.models[agent] ?? []).length > 0,
+    );
     if (hasStaticModels) {
       const known = p.agents.some((agent) => (p.models[agent] ?? []).some((m) => m.id === p.titleModel));
       assert(known, `provider '${p.id}' titleModel '${p.titleModel}' not found in any agent's models`);

--- a/packages/model-providers/src/piNativeCatalog.ts
+++ b/packages/model-providers/src/piNativeCatalog.ts
@@ -1,0 +1,89 @@
+import piModelCatalogJson from '../catalog/pi-model-catalog.json' with { type: 'json' };
+
+import { PI_REASONING_EFFORTS } from './types.js';
+import type { CatalogModel, Effort, ModelCost, PiModelApi } from './types.js';
+
+interface PiCatalogRow {
+  id: string;
+  name?: string;
+  api?: string;
+  provider: string;
+  contextWindow: number;
+  maxTokens?: number;
+  input?: string[];
+  reasoning?: boolean;
+  thinkingLevelMap?: Partial<Record<string, string | null>> | null;
+  cost?: ModelCost;
+}
+
+const PI_CATALOG = piModelCatalogJson as unknown as {
+  generatedAt: string;
+  providers: Record<string, PiCatalogRow[]>;
+};
+
+function catalogEfforts(row: PiCatalogRow): Effort[] {
+  if (!row.reasoning || !row.thinkingLevelMap) return [];
+  return PI_REASONING_EFFORTS.filter((effort) => row.thinkingLevelMap?.[effort] != null);
+}
+
+function defaultEffort(efforts: readonly Effort[]): Effort | null {
+  if (efforts.length === 0) return null;
+  for (const effort of ['medium', 'high', 'low', 'xhigh', 'max', 'minimal'] as const) {
+    if (efforts.includes(effort)) return effort;
+  }
+  return efforts[0] ?? null;
+}
+
+function portablePiApi(api: string | undefined): PiModelApi | undefined {
+  switch (api) {
+    case 'anthropic-messages':
+    case 'openai-responses':
+    case 'openai-completions':
+    case 'google-generative-ai':
+      return api;
+    default:
+      return undefined;
+  }
+}
+
+/**
+ * Convert Pi's pinned native catalog into Cindy's Pi-only membership list.
+ *
+ * The OpenAI subscription route keeps Cindy's `chatgpt/` identity prefix, while its native
+ * `openai-codex-responses` transport remains in the raw snapshot for pi-host to materialize.
+ */
+export function piNativeCatalogModels(
+  piProviderId: string,
+  options: { idPrefix?: string; group?: string } = {},
+): CatalogModel[] {
+  const rows = PI_CATALOG.providers[piProviderId];
+  if (!rows) {
+    throw new Error(`[model-providers] Pi catalog missing provider '${piProviderId}'`);
+  }
+  return rows.map((row, index) => {
+    if (
+      row.provider !== piProviderId ||
+      !Number.isFinite(row.contextWindow) ||
+      row.contextWindow <= 0
+    ) {
+      throw new Error(`[model-providers] invalid Pi catalog row '${piProviderId}/${row.id}'`);
+    }
+    const efforts = catalogEfforts(row);
+    const piApi = portablePiApi(row.api);
+    return {
+      id: `${options.idPrefix ?? ''}${row.id}`,
+      name: row.name ?? row.id,
+      ...(options.group ? { group: options.group } : {}),
+      sortOrder: index,
+      contextWindow: row.contextWindow,
+      contextWindowVerified: true,
+      ...(Number.isFinite(row.maxTokens) && row.maxTokens! > 0 ? { maxOutput: row.maxTokens } : {}),
+      efforts,
+      defaultEffort: defaultEffort(efforts),
+      status: 'active',
+      ...(row.input?.includes('image') ? { supportsImageInput: true } : {}),
+      ...(row.cost ? { cost: row.cost } : {}),
+      ...(piApi ? { piApi } : {}),
+    };
+  });
+}

--- a/tools/pi/sync-model-catalog.mjs
+++ b/tools/pi/sync-model-catalog.mjs
@@ -31,6 +31,10 @@ const PRESET_PROVIDER_MAP = {
 
 const PROVIDER_IDS = [...new Set([
   ...Object.values(PRESET_PROVIDER_MAP).map(({ providerId }) => providerId),
+  // Subscription providers are native Pi sources. Their membership and capabilities must not
+  // be copied from Cindy's separately discovered Claude Code or Codex catalogs.
+  'anthropic',
+  'openai-codex',
   'xai',
 ])].sort();
 


### PR DESCRIPTION
## 这次改了什么

### 摘要

让 Pi 使用随客户端发布的原生模型目录，并只叠加服务端明确提供的 Pi 配置。Codex、Claude Code、Registry 和 xAI 账号发现不再自动增删或改写 Pi 模型，因此服务端新增 GPT-6 但未提供 Pi 配置时，GPT-6 不会误入 Pi。旧服务端缺少 Pi 字段或下发空数组时，客户端仍保留完整本地 Pi 目录。

### 变更类型

- [ ] `feat` 新功能
- [x] `fix` 缺陷修复
- [ ] `refactor` / `perf` 重构或性能优化
- [ ] `docs` / `test` / `chore` 文档、测试或工程维护
- [ ] 其他：

### 范围

- 关联 Issue / 需求：Pi 模型目录必须独立，不能从其它 harness 映射；兼容旧服务端目录。
- 本 PR 包含：Pi 原生目录快照、客户端装配与叠加规则、旧服务端兼容、同源能力补齐、回归测试与产品规则更新。
- 明确不包含：服务端目录结构变更；把 Pi 官方全部供应商的 1337 个模型整体加入内置供应商；任何 UI 改版。
- 用户可见变化：Pi 只显示 Pi 原生目录及明确的 Pi 叠加项；当前 Pi 官方 OpenAI 清单没有 GPT-6，因此 GPT-6 不会出现在 Pi。
- 是否存在 breaking change：无。旧服务端缺失或清空 Pi 数组时回落客户端本地目录。

### UI 变化

不涉及。

- 引用的设计规范：不涉及：未修改 UI、视觉或交互代码。

## 怎么验证的

### 自动验证

```text
pnpm test:unit:related
结果：PASS；desktop、mobile、model-providers 相关单测全部通过。

pnpm --filter desktop typecheck
结果：PASS。

pnpm --filter @cindy/model-providers build
pnpm --filter @cindy/model-providers test
结果：PASS；20 个测试文件、685 个测试通过。

pnpm --dir apps/desktop exec vitest run src/main/maker-host/__tests__/titleOneShot.test.ts src/main/maker-host/__tests__/activeCatalogDiscovery.test.ts src/main/maker-host/__tests__/catalogDerivedModels.test.ts src/main/maker-host/__tests__/modelPlane.test.ts src/main/maker-host/__tests__/piNativeProviders.test.ts --pool=threads --maxWorkers=1
结果：PASS；5 个测试文件、189 个测试通过，2 个按平台跳过。
```

### 手工验证

运行 Pi 官方目录同步，确认 14 个本项目相关供应商共 98 个模型；OpenAI Pi 原生清单为 7 个 GPT-5.3～5.6 模型，不含 GPT-6。逐文件审阅最终 diff，并核对目录改动来源。

### 未执行的验证

未启动完整桌面应用做 UI 手工冒烟：本 PR 不改 UI，目录装配、运行时协议和旧服务端组合均已有针对性单测并通过全客户端相关回归。

## 风险

### 风险分类

- [ ] 无已知风险
- [ ] SQLite / migration
- [ ] system prompt
- [x] 协议兼容
- [ ] 权限 / 安全 / 用户数据
- [ ] 存量插件兼容（批准状态 / 指纹 / manifest 校验 / 安装布局 / 包格式）
- [ ] 原生层 / fingerprint / OTA
- [ ] 跨平台差异
- [x] 其他：模型目录成员与能力来源调整

### 影响与回滚

- 影响范围：客户端内置 Anthropic、OpenAI、xAI 的 Pi 模型成员与能力，以及自定义 Pi 配置和本地 Pi 元数据的合并顺序。
- 回滚 / 降级方式：回退本提交即可恢复旧投影逻辑；服务端无需同步改结构。旧服务端下发继续兼容，本地目录保证 Pi 基线不被缺失字段或空数组清除。

### 提交前检查

- [x] 已 review 完整 diff
- [x] 每个 commit 都带 DCO 签名（`git commit -s`，见 [DCO](../DCO)）
- [ ] UI 改动已在「UI 变化」注明引用的设计规范章节（不涉及 UI 则跳过）
- [x] 未提交凭证、令牌或授权文件
- [x] 已补充必要文档
- [x] 已确认测试结果或说明未执行原因
