### PR TITLE
perf(desktop): 优化灵动岛流式文本处理

### DIFF
--- a/apps/desktop/src/main/agent-island/__tests__/activityTextStream.test.ts
+++ b/apps/desktop/src/main/agent-island/__tests__/activityTextStream.test.ts
@@ -153,4 +153,23 @@ describe('Agent Island activity text stream', () => {
     expect(metrics.jsonParseCodeUnits).toBe(payload.length);
     expect(measuredWork).toBeLessThanOrEqual(payload.length * 3 + 300);
   });
+
+  it('compacts tiny deltas while an incomplete structured stream is retained', () => {
+    const stream = createActivityTextStreamState();
+    const prefix = '{"content":"';
+    const deltaCount = 100_000;
+    appendActivityTextStream(stream, prefix);
+
+    for (let index = 0; index < deltaCount; index += 1) {
+      appendActivityTextStream(stream, 'x');
+    }
+
+    const retainedText = `${prefix}${'x'.repeat(deltaCount)}`;
+    expect(stream.mode).toBe('structured');
+    expect(stream.rawChunks.join('')).toBe(retainedText);
+    expect(stream.rawPreview).toBe(legacyNormalizeActivityText(retainedText));
+    expect(stream.rawChunks.length).toBeLessThanOrEqual(
+      Math.ceil(Math.log2(retainedText.length)) + 1,
+    );
+  });
 });

--- a/apps/desktop/src/main/agent-island/__tests__/activityTextStream.test.ts
+++ b/apps/desktop/src/main/agent-island/__tests__/activityTextStream.test.ts
@@ -1,0 +1,156 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  AGENT_ISLAND_ACTIVITY_TEXT_MAX_LENGTH,
+  appendActivityTextStream,
+  createActivityTextStreamState,
+  type ActivityTextStreamMetrics,
+} from '../activityTextStream.js';
+
+function createMetrics(): ActivityTextStreamMetrics {
+  return {
+    classificationCodeUnits: 0,
+    normalizationCodeUnits: 0,
+    jsonSyntaxCodeUnits: 0,
+    jsonParseCodeUnits: 0,
+  };
+}
+
+function expectEveryStreamingStepToMatchLegacyNormalization(chunks: string[]): void {
+  const stream = createActivityTextStreamState();
+  let accumulated = '';
+
+  for (const chunk of chunks) {
+    accumulated += chunk;
+    expect(appendActivityTextStream(stream, chunk)).toBe(legacyNormalizeActivityText(accumulated));
+  }
+}
+
+function legacyNormalizeActivityText(text: string): string {
+  return legacyExtractActivityDisplayText(text)
+    .split('\n')
+    .map((line) => line.trim())
+    .filter(Boolean)
+    .join(' ')
+    .replace(/\s+/g, ' ')
+    .slice(0, AGENT_ISLAND_ACTIVITY_TEXT_MAX_LENGTH)
+    .trim();
+}
+
+function legacyExtractActivityDisplayText(rawText: string): string {
+  const trimmed = rawText.trim();
+  if (!trimmed || !/^[{[]/.test(trimmed)) return rawText;
+
+  try {
+    return legacyExtractTextFromStructuredContent(JSON.parse(trimmed) as unknown) ?? rawText;
+  } catch {
+    return rawText;
+  }
+}
+
+function legacyExtractTextFromStructuredContent(value: unknown): string | null {
+  if (typeof value === 'string') return value.trim() || null;
+  if (Array.isArray(value)) {
+    const parts = value
+      .map(legacyExtractTextFromStructuredContent)
+      .filter((part): part is string => Boolean(part));
+    return parts.length > 0 ? parts.join(' ') : null;
+  }
+  if (!value || typeof value !== 'object') return null;
+
+  const record = value as Record<string, unknown>;
+  for (const key of ['text', 'message', 'prompt']) {
+    const text = record[key];
+    if (typeof text === 'string' && text.trim()) return text.trim();
+  }
+
+  const content = record.content;
+  if (typeof content === 'string' && content.trim()) return content.trim();
+  return legacyExtractTextFromStructuredContent(content);
+}
+
+describe('Agent Island activity text stream', () => {
+  it('preserves the existing display text across whitespace, markdown, emoji, and the 280-code-unit boundary', () => {
+    expectEveryStreamingStepToMatchLegacyNormalization([
+      '\n  ',
+      'I will **inspect**',
+      '\t  the logs',
+      '\r\n\r\n',
+      'before editing. ',
+      'x'.repeat(240),
+      '\ud83d',
+      '\ude00',
+      ' invisible suffix',
+    ]);
+  });
+
+  it('keeps showing partial JSON verbatim, then switches to its extracted text when it becomes valid', () => {
+    expectEveryStreamingStepToMatchLegacyNormalization([
+      '  {',
+      '"content":[{"text":"first line\\nsecond line with } and ["},',
+      '{"message":"quoted \\"value\\""}]',
+      '}',
+      '  ',
+    ]);
+  });
+
+  it('falls back to the exact raw preview when completed structured text receives trailing content', () => {
+    expectEveryStreamingStepToMatchLegacyNormalization([
+      '{"text":"display text"}',
+      '   ',
+      'trailing content',
+      ' and more',
+    ]);
+  });
+
+  it('preserves raw fallback behavior for invalid or non-text structured values', () => {
+    expectEveryStreamingStepToMatchLegacyNormalization(['{"text":', '123}']);
+    expectEveryStreamingStepToMatchLegacyNormalization(['[{"unknown":true}', ',42]']);
+    expectEveryStreamingStepToMatchLegacyNormalization(['{"text":"unfinished}', ' still a string']);
+  });
+
+  it('bounds ordinary streaming work after the visible prefix instead of rescanning cumulative text', () => {
+    const stream = createActivityTextStreamState();
+    const metrics = createMetrics();
+    const chunk = 'abcdefghij';
+    const chunkCount = 32_000;
+    let legacyCumulativeScanCodeUnits = 0;
+
+    for (let index = 1; index <= chunkCount; index += 1) {
+      appendActivityTextStream(stream, chunk, metrics);
+      legacyCumulativeScanCodeUnits += index * chunk.length;
+    }
+
+    const optimizedScanCodeUnits =
+      metrics.classificationCodeUnits +
+      metrics.normalizationCodeUnits +
+      metrics.jsonSyntaxCodeUnits +
+      metrics.jsonParseCodeUnits;
+    expect(stream.rawPreview).toBe('abcdefghij'.repeat(28));
+    expect(stream.rawChunks).toHaveLength(0);
+    expect(optimizedScanCodeUnits).toBeLessThanOrEqual(AGENT_ISLAND_ACTIVITY_TEXT_MAX_LENGTH + 1);
+    expect(legacyCumulativeScanCodeUnits).toBeGreaterThan(optimizedScanCodeUnits * 1_000_000);
+  });
+
+  it('scans a long structured stream linearly and parses it only once', () => {
+    const stream = createActivityTextStreamState();
+    const metrics = createMetrics();
+    const payload = JSON.stringify({ content: `start ${'x'.repeat(100_000)} end` });
+    const chunkSize = 10;
+
+    for (let offset = 0; offset < payload.length; offset += chunkSize) {
+      appendActivityTextStream(stream, payload.slice(offset, offset + chunkSize), metrics);
+    }
+
+    const measuredWork =
+      metrics.classificationCodeUnits +
+      metrics.normalizationCodeUnits +
+      metrics.jsonSyntaxCodeUnits +
+      metrics.jsonParseCodeUnits;
+    expect(stream.mode).toBe('structured-extracted');
+    expect(stream.rawChunks).toHaveLength(0);
+    expect(stream.structuredDisplayText).toBe(legacyNormalizeActivityText(payload));
+    expect(metrics.jsonParseCodeUnits).toBe(payload.length);
+    expect(measuredWork).toBeLessThanOrEqual(payload.length * 3 + 300);
+  });
+});

--- a/apps/desktop/src/main/agent-island/__tests__/state.test.ts
+++ b/apps/desktop/src/main/agent-island/__tests__/state.test.ts
@@ -397,7 +397,10 @@ describe('Agent Island display state', () => {
       },
     }, start + 200);
     expect(state.sessions.get('s1')).toMatchObject({
-      assistantStreamRawText: '我会先',
+      assistantStream: {
+        mode: 'plain',
+        rawPreview: '我会先',
+      },
       reconnectStatus: '（1/5）正在重连…',
     });
     expect(buildAgentIslandDisplayState(state, start + 200).sessions[0]).toMatchObject({
@@ -446,7 +449,10 @@ describe('Agent Island display state', () => {
       running: true,
       phase: 'running',
       assistantStreamLineId: null,
-      assistantStreamRawText: '',
+      assistantStream: {
+        mode: 'pending',
+        rawPreview: '',
+      },
     });
     expect(session?.activityLines.map((line) => `${line.kind}:${line.text}`)).toEqual([
       'user:run tests',
@@ -454,21 +460,29 @@ describe('Agent Island display state', () => {
     ]);
   });
 
-  it('keeps whitespace-only assistant deltas in the raw stream accumulator', () => {
+  it('keeps whitespace-only assistant deltas pending for the next visible delta', () => {
     const state = createAgentIslandState();
     const start = 1_000;
 
     applyAgentIslandUserPrompt(state, { sessionId: 's1', title: 'Task', agentKind: 'codex' }, 'run tests', start);
     applyAgentIslandEvent(state, { sessionId: 's1' }, textDeltaEvent('\n'), start + 100);
 
-    expect(state.sessions.get('s1')?.assistantStreamRawText).toBe('\n');
+    expect(state.sessions.get('s1')?.assistantStream).toMatchObject({
+      mode: 'pending',
+      rawChunks: ['\n'],
+      rawPreview: '',
+    });
     expect(state.sessions.get('s1')?.activityLines.map((line) => `${line.kind}:${line.text}`)).toEqual([
       'user:run tests',
     ]);
 
     applyAgentIslandEvent(state, { sessionId: 's1' }, textDeltaEvent('我会继续处理'), start + 200);
 
-    expect(state.sessions.get('s1')?.assistantStreamRawText).toBe('\n我会继续处理');
+    expect(state.sessions.get('s1')?.assistantStream).toMatchObject({
+      mode: 'plain',
+      rawChunks: [],
+      rawPreview: '我会继续处理',
+    });
     expect(state.sessions.get('s1')?.activityLines.map((line) => `${line.kind}:${line.text}`)).toEqual([
       'user:run tests',
       'assistant:我会继续处理',

--- a/apps/desktop/src/main/agent-island/activityTextStream.ts
+++ b/apps/desktop/src/main/agent-island/activityTextStream.ts
@@ -64,7 +64,7 @@ export function appendActivityTextStream(
   }
 
   if (state.mode === 'pending') {
-    state.rawChunks.push(chunk);
+    appendRetainedRawChunk(state, chunk);
     const firstContentIndex = firstNonWhitespaceIndex(chunk, metrics);
     if (firstContentIndex < 0) return rawPreviewText(state);
 
@@ -80,7 +80,7 @@ export function appendActivityTextStream(
       return rawPreviewText(state);
     }
   } else {
-    state.rawChunks.push(chunk);
+    appendRetainedRawChunk(state, chunk);
     if (!scanStructuredChunk(state, chunk, 0, metrics)) {
       return rawPreviewText(state);
     }
@@ -107,6 +107,23 @@ export function appendActivityTextStream(
 
   switchToPlain(state);
   return rawPreviewText(state);
+}
+
+function appendRetainedRawChunk(state: ActivityTextStreamState, chunk: string): void {
+  if (!chunk) return;
+  state.rawChunks.push(chunk);
+
+  // Keep older chunks geometrically larger than newer ones. This preserves the
+  // exact JSON input and ordering while preventing one retained string object
+  // per tiny delta when a structured stream stays incomplete for a long time.
+  while (state.rawChunks.length >= 2) {
+    const newest = state.rawChunks.at(-1) ?? '';
+    const previous = state.rawChunks.at(-2) ?? '';
+    if (previous.length > newest.length * 2) return;
+    state.rawChunks.pop();
+    state.rawChunks.pop();
+    state.rawChunks.push(previous + newest);
+  }
 }
 
 export function normalizeActivityText(text: string): string {

--- a/apps/desktop/src/main/agent-island/activityTextStream.ts
+++ b/apps/desktop/src/main/agent-island/activityTextStream.ts
@@ -1,0 +1,267 @@
+export const AGENT_ISLAND_ACTIVITY_TEXT_MAX_LENGTH = 280;
+
+type ActivityTextStreamMode = 'pending' | 'plain' | 'structured' | 'structured-extracted';
+
+export interface ActivityTextStreamState {
+  mode: ActivityTextStreamMode;
+  rawChunks: string[];
+  rawPreview: string;
+  rawPreviewHasPendingWhitespace: boolean;
+  jsonClosingStack: Array<'}' | ']'>;
+  jsonInString: boolean;
+  jsonEscapePending: boolean;
+  structuredDisplayText: string;
+}
+
+/** Deterministic work counters used by the performance regression test. */
+export interface ActivityTextStreamMetrics {
+  classificationCodeUnits: number;
+  normalizationCodeUnits: number;
+  jsonSyntaxCodeUnits: number;
+  jsonParseCodeUnits: number;
+}
+
+export function createActivityTextStreamState(): ActivityTextStreamState {
+  return {
+    mode: 'pending',
+    rawChunks: [],
+    rawPreview: '',
+    rawPreviewHasPendingWhitespace: false,
+    jsonClosingStack: [],
+    jsonInString: false,
+    jsonEscapePending: false,
+    structuredDisplayText: '',
+  };
+}
+
+export function cloneActivityTextStreamState(
+  state: ActivityTextStreamState,
+): ActivityTextStreamState {
+  return {
+    ...state,
+    rawChunks: [...state.rawChunks],
+    jsonClosingStack: [...state.jsonClosingStack],
+  };
+}
+
+export function appendActivityTextStream(
+  state: ActivityTextStreamState,
+  chunk: string,
+  metrics?: ActivityTextStreamMetrics,
+): string {
+  appendRawPreview(state, chunk, metrics);
+
+  if (state.mode === 'plain') {
+    return rawPreviewText(state);
+  }
+
+  if (state.mode === 'structured-extracted') {
+    if (firstNonWhitespaceIndex(chunk, metrics) < 0) {
+      return state.structuredDisplayText;
+    }
+    switchToPlain(state);
+    return rawPreviewText(state);
+  }
+
+  if (state.mode === 'pending') {
+    state.rawChunks.push(chunk);
+    const firstContentIndex = firstNonWhitespaceIndex(chunk, metrics);
+    if (firstContentIndex < 0) return rawPreviewText(state);
+
+    const firstContent = chunk[firstContentIndex];
+    if (firstContent !== '{' && firstContent !== '[') {
+      switchToPlain(state);
+      return rawPreviewText(state);
+    }
+
+    state.mode = 'structured';
+    state.jsonClosingStack.push(firstContent === '{' ? '}' : ']');
+    if (!scanStructuredChunk(state, chunk, firstContentIndex + 1, metrics)) {
+      return rawPreviewText(state);
+    }
+  } else {
+    state.rawChunks.push(chunk);
+    if (!scanStructuredChunk(state, chunk, 0, metrics)) {
+      return rawPreviewText(state);
+    }
+  }
+
+  if (state.jsonClosingStack.length > 0) return rawPreviewText(state);
+
+  const rawText = state.rawChunks.join('');
+  if (metrics) metrics.jsonParseCodeUnits += rawText.length;
+  try {
+    const parsed = JSON.parse(rawText.trim()) as unknown;
+    const extracted = extractTextFromStructuredContent(parsed);
+    if (extracted) {
+      state.mode = 'structured-extracted';
+      if (metrics) metrics.normalizationCodeUnits += extracted.length;
+      state.structuredDisplayText = normalizePlainActivityText(extracted);
+      releaseStructuredParserState(state);
+      return state.structuredDisplayText;
+    }
+  } catch {
+    // Once the outer object/array has closed, a parse failure cannot be repaired
+    // by appending another delta. Keep showing the existing raw-text fallback.
+  }
+
+  switchToPlain(state);
+  return rawPreviewText(state);
+}
+
+export function normalizeActivityText(text: string): string {
+  return normalizePlainActivityText(extractActivityDisplayText(text));
+}
+
+function appendRawPreview(
+  state: ActivityTextStreamState,
+  chunk: string,
+  metrics?: ActivityTextStreamMetrics,
+): void {
+  if (state.rawPreview.length >= AGENT_ISLAND_ACTIVITY_TEXT_MAX_LENGTH) return;
+
+  for (let index = 0; index < chunk.length; index += 1) {
+    if (metrics) metrics.normalizationCodeUnits += 1;
+    const codeUnit = chunk[index] ?? '';
+    if (/\s/.test(codeUnit)) {
+      if (state.rawPreview) state.rawPreviewHasPendingWhitespace = true;
+      continue;
+    }
+
+    if (state.rawPreviewHasPendingWhitespace) {
+      state.rawPreview += ' ';
+      state.rawPreviewHasPendingWhitespace = false;
+      if (state.rawPreview.length >= AGENT_ISLAND_ACTIVITY_TEXT_MAX_LENGTH) return;
+    }
+
+    state.rawPreview += codeUnit;
+    if (state.rawPreview.length >= AGENT_ISLAND_ACTIVITY_TEXT_MAX_LENGTH) return;
+  }
+}
+
+function firstNonWhitespaceIndex(value: string, metrics?: ActivityTextStreamMetrics): number {
+  for (let index = 0; index < value.length; index += 1) {
+    if (metrics) metrics.classificationCodeUnits += 1;
+    if (!/\s/.test(value[index] ?? '')) return index;
+  }
+  return -1;
+}
+
+function scanStructuredChunk(
+  state: ActivityTextStreamState,
+  chunk: string,
+  startIndex: number,
+  metrics?: ActivityTextStreamMetrics,
+): boolean {
+  for (let index = startIndex; index < chunk.length; index += 1) {
+    if (metrics) metrics.jsonSyntaxCodeUnits += 1;
+    const codeUnit = chunk[index] ?? '';
+
+    if (state.jsonClosingStack.length === 0) {
+      if (!/\s/.test(codeUnit)) {
+        switchToPlain(state);
+        return false;
+      }
+      continue;
+    }
+
+    if (state.jsonInString) {
+      if (state.jsonEscapePending) {
+        state.jsonEscapePending = false;
+      } else if (codeUnit === '\\') {
+        state.jsonEscapePending = true;
+      } else if (codeUnit === '"') {
+        state.jsonInString = false;
+      }
+      continue;
+    }
+
+    if (codeUnit === '"') {
+      state.jsonInString = true;
+      continue;
+    }
+    if (codeUnit === '{') {
+      state.jsonClosingStack.push('}');
+      continue;
+    }
+    if (codeUnit === '[') {
+      state.jsonClosingStack.push(']');
+      continue;
+    }
+    if (codeUnit !== '}' && codeUnit !== ']') continue;
+
+    if (state.jsonClosingStack.at(-1) !== codeUnit) {
+      switchToPlain(state);
+      return false;
+    }
+    state.jsonClosingStack.pop();
+  }
+  return true;
+}
+
+function switchToPlain(state: ActivityTextStreamState): void {
+  state.mode = 'plain';
+  state.structuredDisplayText = '';
+  releaseStructuredParserState(state);
+}
+
+function releaseStructuredParserState(state: ActivityTextStreamState): void {
+  state.rawChunks = [];
+  state.jsonClosingStack = [];
+  state.jsonInString = false;
+  state.jsonEscapePending = false;
+}
+
+function rawPreviewText(state: ActivityTextStreamState): string {
+  return state.rawPreview.trim();
+}
+
+function normalizePlainActivityText(text: string): string {
+  return text
+    .split('\n')
+    .map((line) => line.trim())
+    .filter(Boolean)
+    .join(' ')
+    .replace(/\s+/g, ' ')
+    .slice(0, AGENT_ISLAND_ACTIVITY_TEXT_MAX_LENGTH)
+    .trim();
+}
+
+function extractActivityDisplayText(rawText: string): string {
+  const trimmed = rawText.trim();
+  if (!trimmed || !/^[{[]/.test(trimmed)) return rawText;
+
+  try {
+    const parsed = JSON.parse(trimmed) as unknown;
+    return extractTextFromStructuredContent(parsed) ?? rawText;
+  } catch {
+    return rawText;
+  }
+}
+
+function extractTextFromStructuredContent(value: unknown): string | null {
+  if (typeof value === 'string') return value.trim() || null;
+
+  if (Array.isArray(value)) {
+    const parts = value
+      .map(extractTextFromStructuredContent)
+      .filter((part): part is string => Boolean(part));
+    return parts.length > 0 ? parts.join(' ') : null;
+  }
+
+  const record = asRecord(value);
+  if (!record) return null;
+
+  for (const key of ['text', 'message', 'prompt']) {
+    const text = record[key];
+    if (typeof text === 'string' && text.trim()) return text.trim();
+  }
+
+  const content = record.content;
+  if (typeof content === 'string' && content.trim()) return content.trim();
+  return extractTextFromStructuredContent(content);
+}
+
+function asRecord(value: unknown): Record<string, unknown> | null {
+  return value && typeof value === 'object' ? (value as Record<string, unknown>) : null;
+}

--- a/apps/desktop/src/main/agent-island/state.ts
+++ b/apps/desktop/src/main/agent-island/state.ts
@@ -10,6 +10,13 @@ import { LIVE_TASK_PRIORITY, liveTaskPriorityRank } from '../../shared/liveTaskP
 import { stripTrailingPathSeparators } from '../../shared/pathText';
 
 import { formatIslandToolDetail } from './toolDetail.js';
+import {
+  appendActivityTextStream,
+  cloneActivityTextStreamState,
+  createActivityTextStreamState,
+  normalizeActivityText,
+  type ActivityTextStreamState,
+} from './activityTextStream.js';
 
 import {
   createDefaultAgentIslandDisplayConfig,
@@ -58,7 +65,6 @@ export const AGENT_ISLAND_UNREAD_TRANSIENT_TTL_MS = 4 * 60 * 60 * 1_000;
 const AGENT_ISLAND_COMPACT_CURRENT_MIN_DWELL_MS = 1_200;
 const AGENT_ISLAND_MEASURED_HEIGHT_MAX = 2_000;
 const AGENT_ISLAND_ACTIVITY_MAX_LINES = 3;
-const AGENT_ISLAND_ACTIVITY_TEXT_MAX_LENGTH = 280;
 const AGENT_ISLAND_COMPACT_TITLE_MAX_LENGTH = 28;
 const AGENT_ISLAND_COMPACT_DETAIL_MAX_LENGTH = 120;
 
@@ -137,7 +143,7 @@ interface AgentIslandSessionState {
   activityLines: AgentIslandActivityLine[];
   activitySeq: number;
   assistantStreamLineId: string | null;
-  assistantStreamRawText: string;
+  assistantStream: ActivityTextStreamState;
   messagePreview: {
     line: AgentIslandActivityLine;
     until: number;
@@ -2171,7 +2177,7 @@ function getOrCreateSession(
     activityLines: [],
     activitySeq: 0,
     assistantStreamLineId: null,
-    assistantStreamRawText: '',
+    assistantStream: createActivityTextStreamState(),
     messagePreview: null,
     messagePreviewQueue: [],
     startedAt: now,
@@ -2190,6 +2196,7 @@ function cloneSession(session: AgentIslandSessionState): AgentIslandSessionState
     pendingInteractionDetails: new Map(session.pendingInteractionDetails),
     pendingPermissionCanAllowForSession: new Map(session.pendingPermissionCanAllowForSession),
     activityLines: session.activityLines.map((line) => ({ ...line })),
+    assistantStream: cloneActivityTextStreamState(session.assistantStream),
     messagePreview: session.messagePreview
       ? {
           line: { ...session.messagePreview.line },
@@ -2516,15 +2523,12 @@ function applyAssistantTextLine(
   rawText: string,
   isFinal: boolean,
 ): AgentIslandActivityLine | null {
-  const nextRawText = isFinal
-    ? rawText
-    : `${session.assistantStreamRawText}${rawText}`;
-  const text = normalizeActivityText(nextRawText);
+  const text = isFinal
+    ? normalizeActivityText(rawText)
+    : appendActivityTextStream(session.assistantStream, rawText);
   if (!text) {
     if (isFinal) {
       clearAssistantStream(session);
-    } else {
-      session.assistantStreamRawText = nextRawText;
     }
     return null;
   }
@@ -2542,8 +2546,6 @@ function applyAssistantTextLine(
       replaceMessagePreviewLine(session, line);
       if (isFinal) {
         clearAssistantStream(session);
-      } else {
-        session.assistantStreamRawText = nextRawText;
       }
       return line;
     }
@@ -2555,7 +2557,6 @@ function applyAssistantTextLine(
     clearAssistantStream(session);
   } else {
     session.assistantStreamLineId = line.id;
-    session.assistantStreamRawText = nextRawText;
   }
   return line;
 }
@@ -2571,7 +2572,7 @@ function replaceMessagePreviewLine(session: AgentIslandSessionState, line: Agent
 
 function clearAssistantStream(session: AgentIslandSessionState): void {
   session.assistantStreamLineId = null;
-  session.assistantStreamRawText = '';
+  session.assistantStream = createActivityTextStreamState();
 }
 
 function enqueueMessagePreview(
@@ -2599,17 +2600,6 @@ function assistantTextFromEvent(event: AgentEvent): string | null {
   return typeof data?.text === 'string' ? data.text : null;
 }
 
-function normalizeActivityText(text: string): string {
-  return extractActivityDisplayText(text)
-    .split('\n')
-    .map((line) => line.trim())
-    .filter(Boolean)
-    .join(' ')
-    .replace(/\s+/g, ' ')
-    .slice(0, AGENT_ISLAND_ACTIVITY_TEXT_MAX_LENGTH)
-    .trim();
-}
-
 function normalizeInlineText(text: string): string {
   return text
     .trim()
@@ -2627,41 +2617,6 @@ function truncateInlineText(text: string, maxLength: number): string {
   const chars = Array.from(normalized);
   if (chars.length <= maxLength) return normalized;
   return `${chars.slice(0, Math.max(0, maxLength - 3)).join('')}...`;
-}
-
-function extractActivityDisplayText(rawText: string): string {
-  const trimmed = rawText.trim();
-  if (!trimmed || !/^[{[]/.test(trimmed)) return rawText;
-
-  try {
-    const parsed = JSON.parse(trimmed) as unknown;
-    return extractTextFromStructuredContent(parsed) ?? rawText;
-  } catch {
-    return rawText;
-  }
-}
-
-function extractTextFromStructuredContent(value: unknown): string | null {
-  if (typeof value === 'string') return value.trim() || null;
-
-  if (Array.isArray(value)) {
-    const parts = value
-      .map(extractTextFromStructuredContent)
-      .filter((part): part is string => Boolean(part));
-    return parts.length > 0 ? parts.join(' ') : null;
-  }
-
-  const record = asRecord(value);
-  if (!record) return null;
-
-  for (const key of ['text', 'message', 'prompt']) {
-    const text = record[key];
-    if (typeof text === 'string' && text.trim()) return text.trim();
-  }
-
-  const content = record.content;
-  if (typeof content === 'string' && content.trim()) return content.trim();
-  return extractTextFromStructuredContent(content);
 }
 
 function projectNameFromWorkingDir(workingDir: string | null | undefined, workspaceKind?: string | null): string | null {


### PR DESCRIPTION
## 这次改了什么

### 摘要

Agent Island 原先会在每个 assistant text delta 到达时重新拼接并规范化累计全文，长回复会让 Electron Main 侧工作量接近 O(n²)。本 PR 改为有界增量处理：普通文本只维护可见的前 280 个 UTF-16 code unit；结构化 JSON 分片增量判断闭合，并只在闭合时解析一次。

展示语义保持不变：空白折叠、Markdown、emoji 边界、分片 JSON 未闭合时显示原文、闭合后提取文本、final 全量替换、重连续接和消息预览队列均有回归覆盖。

### 变更类型

- [ ] `feat` 新功能
- [ ] `fix` 缺陷修复
- [x] `refactor` / `perf` 重构或性能优化
- [ ] `docs` / `test` / `chore` 文档、测试或工程维护
- [ ] 其他：

### 范围

- 关联 Issue / 需求：无
- 本 PR 包含：Agent Island assistant 流式文本增量规范化、结构化 JSON 增量扫描、展示等价回归和确定性性能测试
- 明确不包含：Renderer、灵动岛布局、样式、动画、发布节奏，以及其它 Main/Renderer 性能热点
- 用户可见变化：长任务持续输出时减少 Main 线程计算压力；灵动岛展示内容和状态行为不变
- 是否存在 breaking change：无

### UI 变化

不涉及：仅替换 Electron Main 内 Agent Island 文本状态的内部计算方式，没有修改 UI、视觉、交互或文案。

- 引用的设计规范：不涉及

## 怎么验证的

### 自动验证

```text
pnpm --filter desktop test -- src/main/agent-island/__tests__/activityTextStream.test.ts src/main/agent-island/__tests__/state.test.ts
结果：通过，2 个测试文件、127 条测试全部通过

pnpm test:unit:related
结果：通过，apps/desktop related unit tests 全部通过

pnpm --filter desktop run --if-present typecheck
结果：通过

pnpm --filter desktop exec eslint src/main/agent-island/activityTextStream.ts src/main/agent-island/__tests__/activityTextStream.test.ts
结果：通过

pnpm check:dco
结果：通过，1 个提交带有效 Signed-off-by
```

性能回归使用确定性工作量断言而非墙钟阈值：32,000 个 10 字符普通分片下，旧算法累计正文扫描量为 5,120,160,000，新路径的正文扫描量不超过 281；长结构化 JSON 保持线性扫描并只解析一次。

### 手工验证

Subagent 独立审查为 clean；普通文本和嵌套 JSON 随机分片逐步与旧算法对照，未发现展示差异。

### 未执行的验证

未执行 Electron 实机视觉目检：本 PR 不修改 UI，展示内容与状态行为由旧算法 oracle 和 Agent Island 状态测试覆盖。

## 风险

### 风险分类

- [ ] 无已知风险
- [ ] SQLite / migration
- [ ] system prompt
- [ ] 协议兼容
- [ ] 权限 / 安全 / 用户数据
- [ ] 存量插件兼容（批准状态 / 指纹 / manifest 校验 / 安装布局 / 包格式）
- [ ] 原生层 / fingerprint / OTA
- [ ] 跨平台差异
- [x] 其他：Agent Island 流式文本状态机兼容风险，已用独立旧算法 oracle、随机差分和现有状态测试覆盖

### 影响与回滚

- 影响范围：Electron Main 内 Agent Island assistant 活动文本预览；远端 session activity snapshot 复用同一状态结果
- 回滚 / 降级方式：回滚本 PR，恢复累计全文规范化路径；不涉及 schema、协议或用户数据迁移

### 提交前检查

- [x] 已 review 完整 diff
- [x] 每个 commit 都带 DCO 签名（`git commit -s`，见 [DCO](../DCO)）
- [x] UI 改动已在「UI 变化」注明引用的设计规范章节（不涉及 UI 则跳过）
- [x] 未提交凭证、令牌或授权文件
- [x] 已补充必要文档
- [x] 已确认测试结果或说明未执行原因