### PR TITLE
fix(mobile): 兼容 Android WebView 85 的任务输入框

### DIFF
--- a/apps/mobile/src/__tests__/composerRichInputHtml.test.ts
+++ b/apps/mobile/src/__tests__/composerRichInputHtml.test.ts
@@ -62,29 +62,116 @@ describe('mobile composer rich input HTML', () => {
         textSecondary: '#333',
       },
     });
-    const script = legacyHtml.match(/<script>([\s\S]*?)<\/script>/)?.[1];
+    const script = legacyHtml.match(/<script>([\s\S]*?)<\/script>/i)?.[1];
     expect(script).toBeTruthy();
 
     const messages: unknown[] = [];
     const listeners = new Map<string, (...args: unknown[]) => void>();
-    const children: unknown[] = [{}];
+    type StubNode = {
+      classList?: { contains(value: string): boolean };
+      className?: string;
+      contentEditable?: string;
+      dataset?: Record<string, string>;
+      readonly nextSibling: StubNode | null;
+      nodeType: number;
+      nodeValue?: string;
+      parentNode: StubParent | null;
+      remove(): void;
+      setAttribute?: () => void;
+      tabIndex?: number;
+      tagName?: string;
+      textContent?: string;
+    };
+    type StubParent = {
+      appendChild(node: StubNode | StubParent): StubNode | StubParent;
+      childNodes: StubNode[];
+      insertBefore(node: StubNode, reference: StubNode | null): StubNode;
+    };
+    type StubRange = {
+      collapse(): void;
+      deleteContents(): void;
+      insertNode(node: StubNode | StubParent): void;
+      selectNodeContents(): void;
+      setStart(node: StubNode, offset: number): void;
+      setStartAfter(node: StubNode): void;
+      startNode: StubNode | null;
+      startOffset: number;
+    };
+    const detach = (node: StubNode) => {
+      const parent = node.parentNode;
+      const index = parent?.childNodes.indexOf(node) ?? -1;
+      if (parent && index >= 0) parent.childNodes.splice(index, 1);
+      node.parentNode = null;
+    };
+    const insertBefore = (
+      parent: StubParent,
+      node: StubNode,
+      reference: StubNode | null,
+    ) => {
+      detach(node);
+      const index = reference ? parent.childNodes.indexOf(reference) : -1;
+      if (index >= 0) parent.childNodes.splice(index, 0, node);
+      else parent.childNodes.push(node);
+      node.parentNode = parent;
+      return node;
+    };
+    const createNode = (nodeType: number, nodeValue?: string): StubNode => {
+      const node: StubNode = {
+        get nextSibling() {
+          const parent = node.parentNode;
+          const index = parent?.childNodes.indexOf(node) ?? -1;
+          return parent && index >= 0 ? parent.childNodes[index + 1] || null : null;
+        },
+        nodeType,
+        nodeValue,
+        parentNode: null,
+        remove() {
+          detach(node);
+        },
+      };
+      return node;
+    };
+    const createFragment = (): StubParent => {
+      const fragment: StubParent = {
+        appendChild(node) {
+          if (!('nodeType' in node)) throw new Error('Nested fragments are not supported');
+          return insertBefore(fragment, node, null);
+        },
+        childNodes: [],
+        insertBefore(node, reference) {
+          return insertBefore(fragment, node, reference);
+        },
+      };
+      return fragment;
+    };
+    const children: StubNode[] = [];
     const root = {
       addEventListener(type: string, listener: (...args: unknown[]) => void) {
         listeners.set(type, listener);
       },
-      appendChild(node: { childNodes?: unknown[] }) {
-        children.push(...(node.childNodes || []));
+      appendChild(node: StubNode | StubParent) {
+        if ('nodeType' in node) return insertBefore(root, node, null);
+        [...node.childNodes].forEach((child) => insertBefore(root, child, null));
         return node;
       },
       childNodes: children,
       contentEditable: 'false',
+      contains(node: unknown) {
+        return children.includes(node as StubNode);
+      },
       dataset: {} as Record<string, string>,
       get firstChild() {
         return children[0] || null;
       },
-      removeChild(node: unknown) {
-        const index = children.indexOf(node);
-        if (index >= 0) children.splice(index, 1);
+      focus() {},
+      insertBefore(node: StubNode, reference: StubNode | null) {
+        return insertBefore(root, node, reference);
+      },
+      get lastChild() {
+        return children[children.length - 1] || null;
+      },
+      removeChild(node: StubNode) {
+        detach(node);
         return node;
       },
       scrollHeight: 0,
@@ -95,19 +182,77 @@ describe('mobile composer rich input HTML', () => {
         setProperty() {},
       },
     };
-    const documentStub = {
-      createDocumentFragment() {
-        const fragmentChildren: unknown[] = [];
-        return {
-          appendChild(node: unknown) {
-            fragmentChildren.push(node);
-            return node;
-          },
-          childNodes: fragmentChildren,
-        };
+    const staleNode = createNode(1);
+    staleNode.parentNode = root;
+    children.push(staleNode);
+    let activeRange: StubRange | null = null;
+    const createRange = (): StubRange => ({
+      collapse() {},
+      deleteContents() {},
+      insertNode(node) {
+        const reference = this.startNode?.nextSibling || null;
+        if ('nodeType' in node) root.insertBefore(node, reference);
+        else [...node.childNodes].forEach((child) => root.insertBefore(child, reference));
       },
+      selectNodeContents() {},
+      setStart(node, offset) {
+        this.startNode = node;
+        this.startOffset = offset;
+      },
+      setStartAfter(node) {
+        this.startNode = node;
+        this.startOffset = 1;
+      },
+      startNode: null,
+      startOffset: 0,
+    });
+    const selection = {
+      anchorNode: null as StubNode | null,
+      anchorOffset: 0,
+      addRange(range: StubRange) {
+        activeRange = range;
+        this.anchorNode = range.startNode;
+        this.anchorOffset = range.startOffset;
+      },
+      getRangeAt() {
+        if (!activeRange) throw new Error('No active range');
+        return activeRange;
+      },
+      get rangeCount() {
+        return activeRange ? 1 : 0;
+      },
+      removeAllRanges() {
+        activeRange = null;
+        this.anchorNode = null;
+        this.anchorOffset = 0;
+      },
+    };
+    const documentStub = {
+      createComment(value: string) {
+        return createNode(8, value);
+      },
+      createDocumentFragment() {
+        return createFragment();
+      },
+      createElement(tagName: string) {
+        const element = createNode(1);
+        element.className = '';
+        element.classList = {
+          contains(value: string) {
+            return element.className?.split(/\s+/).includes(value) === true;
+          },
+        };
+        element.contentEditable = '';
+        element.dataset = {};
+        element.setAttribute = () => {};
+        element.tabIndex = 0;
+        element.tagName = tagName.toUpperCase();
+        element.textContent = '';
+        return element;
+      },
+      createRange,
       createTextNode(value: string) {
-        return { nodeType: 3, nodeValue: value };
+        return createNode(3, value);
       },
       documentElement: {
         style: {
@@ -118,11 +263,18 @@ describe('mobile composer rich input HTML', () => {
         return root;
       },
     };
-    const windowStub = {
+    const windowStub: {
+      ReactNativeWebView: { postMessage(payload: string): void };
+      cindyComposer?: { commitPaste(requestId: string, nodes: unknown[]): void };
+      getSelection(): typeof selection;
+    } = {
       ReactNativeWebView: {
         postMessage(payload: string) {
           messages.push(JSON.parse(payload));
         },
+      },
+      getSelection() {
+        return selection;
       },
     };
 
@@ -137,13 +289,50 @@ describe('mobile composer rich input HTML', () => {
         window: windowStub,
       },
     );
-    expect(children).toEqual([{ nodeType: 3, nodeValue: 'hello' }]);
+    expect(children).toHaveLength(1);
+    expect(children[0]).toMatchObject({ nodeType: 3, nodeValue: 'hello' });
     expect(messages).toContainEqual({ type: 'ready' });
-    (children[0] as { nodeValue: string }).nodeValue = 'hello world';
+    children[0].nodeValue = 'hello world';
     listeners.get('input')?.();
     expect(messages).toContainEqual({
       type: 'change',
       document: { version: 1, nodes: [{ type: 'text', text: 'hello world' }] },
+    });
+
+    const pasteRange = createRange();
+    pasteRange.setStart(children[0], String(children[0].nodeValue).length);
+    selection.addRange(pasteRange);
+    listeners.get('paste')?.({
+      clipboardData: {
+        getData: () => ' pasted',
+        items: [],
+      },
+      preventDefault() {},
+    });
+    expect(messages).toContainEqual({
+      type: 'paste-text-request',
+      requestId: '1',
+      text: ' pasted',
+    });
+    windowStub.cindyComposer?.commitPaste('1', [
+      { type: 'text', text: ' pasted' },
+      { type: 'pasted-text', text: 'full pasted text', display: 'Pasted text' },
+    ]);
+    expect(children).toHaveLength(4);
+    expect(children[1]).toMatchObject({ nodeType: 3, nodeValue: ' pasted' });
+    expect(children[2]).toMatchObject({ className: 'atom', nodeType: 1 });
+    expect(children[3]).toMatchObject({ nodeType: 3, nodeValue: '\u200B' });
+    expect(selection.anchorNode).toBe(children[3]);
+    expect(selection.anchorOffset).toBe(1);
+    expect(messages).toContainEqual({
+      type: 'change',
+      document: {
+        version: 1,
+        nodes: [
+          { type: 'text', text: 'hello world pasted' },
+          { type: 'pasted-text', text: 'full pasted text', display: 'Pasted text' },
+        ],
+      },
     });
     expect(legacyHtml).not.toContain('replaceChildren');
     expect(legacyHtml).not.toContain('.flatMap(');

--- a/apps/mobile/src/__tests__/composerRichInputHtml.test.ts
+++ b/apps/mobile/src/__tests__/composerRichInputHtml.test.ts
@@ -1,5 +1,6 @@
 import { readFileSync } from 'node:fs';
 import { resolve } from 'node:path';
+import { runInNewContext } from 'node:vm';
 import { describe, expect, it } from 'vitest';
 import { buildComposerRichInputHtml } from '@/session/composerRichInputHtml';
 import { parseComposerWebMessage } from '@/session/composerRichInputProtocol';
@@ -41,6 +42,111 @@ describe('mobile composer rich input HTML', () => {
     expect(html).toContain('setConfig(value)');
     expect(html).toContain("style.setProperty('--chip', config.theme.chip)");
     expect(html).not.toContain('https://');
+  });
+
+  it('initializes on the Android WebView 85 API baseline', () => {
+    const legacyHtml = buildComposerRichInputHtml({
+      accessibilityLabel: '输入消息',
+      document: { version: 1, nodes: [{ type: 'text', text: 'hello' }] },
+      editable: true,
+      maxHeight: 264,
+      platform: 'android',
+      placeholder: '发送消息',
+      theme: {
+        background: '#eee',
+        border: '#aaa',
+        chip: '#ddd',
+        focus: '#555',
+        placeholder: '#777',
+        text: '#111',
+        textSecondary: '#333',
+      },
+    });
+    const script = legacyHtml.match(/<script>([\s\S]*?)<\/script>/)?.[1];
+    expect(script).toBeTruthy();
+
+    const messages: unknown[] = [];
+    const listeners = new Map<string, (...args: unknown[]) => void>();
+    const children: unknown[] = [{}];
+    const root = {
+      addEventListener(type: string, listener: (...args: unknown[]) => void) {
+        listeners.set(type, listener);
+      },
+      appendChild(node: { childNodes?: unknown[] }) {
+        children.push(...(node.childNodes || []));
+        return node;
+      },
+      childNodes: children,
+      contentEditable: 'false',
+      dataset: {} as Record<string, string>,
+      get firstChild() {
+        return children[0] || null;
+      },
+      removeChild(node: unknown) {
+        const index = children.indexOf(node);
+        if (index >= 0) children.splice(index, 1);
+        return node;
+      },
+      scrollHeight: 0,
+      setAttribute() {},
+      style: {
+        paddingBottom: '',
+        paddingTop: '',
+        setProperty() {},
+      },
+    };
+    const documentStub = {
+      createDocumentFragment() {
+        const fragmentChildren: unknown[] = [];
+        return {
+          appendChild(node: unknown) {
+            fragmentChildren.push(node);
+            return node;
+          },
+          childNodes: fragmentChildren,
+        };
+      },
+      createTextNode(value: string) {
+        return { nodeType: 3, nodeValue: value };
+      },
+      documentElement: {
+        style: {
+          setProperty() {},
+        },
+      },
+      getElementById() {
+        return root;
+      },
+    };
+    const windowStub = {
+      ReactNativeWebView: {
+        postMessage(payload: string) {
+          messages.push(JSON.parse(payload));
+        },
+      },
+    };
+
+    runInNewContext(
+      `Array.prototype.flatMap = undefined;\n${script}`,
+      {
+        document: documentStub,
+        Node: { ELEMENT_NODE: 1, TEXT_NODE: 3 },
+        ResizeObserver: class {
+          observe() {}
+        },
+        window: windowStub,
+      },
+    );
+    expect(children).toEqual([{ nodeType: 3, nodeValue: 'hello' }]);
+    expect(messages).toContainEqual({ type: 'ready' });
+    (children[0] as { nodeValue: string }).nodeValue = 'hello world';
+    listeners.get('input')?.();
+    expect(messages).toContainEqual({
+      type: 'change',
+      document: { version: 1, nodes: [{ type: 'text', text: 'hello world' }] },
+    });
+    expect(legacyHtml).not.toContain('replaceChildren');
+    expect(legacyHtml).not.toContain('.flatMap(');
   });
 
   it('uses the shared compact pill geometry for atoms and slash decorations', () => {

--- a/apps/mobile/src/session/composerRichInputHtml.ts
+++ b/apps/mobile/src/session/composerRichInputHtml.ts
@@ -173,9 +173,20 @@ export function buildComposerRichInputHtml(config: ComposerRichInputConfig): str
     const element = makeNode(node);
     return node.type === 'text' ? [element] : [element, makeCaretAnchor()];
   };
+  const flattenDomNodes = (nodes) => {
+    const elements = [];
+    (nodes || []).forEach((node) => {
+      makeDomNodes(node).forEach((element) => elements.push(element));
+    });
+    return elements;
+  };
   const render = (documentValue, focusAfter) => {
     applying = true;
-    root.replaceChildren(...(documentValue.nodes || []).flatMap(makeDomNodes));
+    // Android WebView 85 lacks the modern child-replacement API; use legacy DOM primitives.
+    const fragment = document.createDocumentFragment();
+    flattenDomNodes(documentValue.nodes).forEach((node) => fragment.appendChild(node));
+    while (root.firstChild) root.removeChild(root.firstChild);
+    root.appendChild(fragment);
     applying = false;
     lastSignature = JSON.stringify(readDocument());
     reportHeight();
@@ -298,7 +309,7 @@ export function buildComposerRichInputHtml(config: ComposerRichInputConfig): str
     pasteMarkers.delete(requestId);
     const marker = pending && pending.marker;
     if (!marker || !marker.parentNode) return;
-    const inserted = (Array.isArray(nodes) ? nodes : []).flatMap(makeDomNodes);
+    const inserted = flattenDomNodes(Array.isArray(nodes) ? nodes : []);
     inserted.forEach((node) => marker.parentNode.insertBefore(node, marker));
     const selection = window.getSelection();
     const trailing = pending && pending.anchor;


### PR DESCRIPTION
## 这次改了什么

### 摘要

修复 #3890：Mobile 富文本输入框初始化时不再依赖旧版 Android WebView 不支持的 `replaceChildren`，并移除同一路径对 `Array.prototype.flatMap` 的依赖。这样在 0.1.72、0.1.73 所涉及的旧 WebView 环境中，初始化脚本不会因缺少 API 提前中断，输入内容后可以恢复既有的发送按钮状态。

### 变更类型

- [ ] `feat` 新功能
- [x] `fix` 缺陷修复
- [ ] `refactor` / `perf` 重构或性能优化
- [ ] `docs` / `test` / `chore` 文档、测试或工程维护
- [ ] 其他：

### 范围

- 关联 Issue / 需求：#3890
- 本 PR 包含：用兼容写法替换富文本输入框的子节点，并补充模拟旧 WebView 缺少相关 API 的执行级回归测试。
- 明确不包含：不修改发送按钮显示规则、原生依赖、原生配置、样式、布局或 UI 文案。
- 用户可见变化：旧版 Android WebView 中，任务输入框输入内容后能正常显示并启用发送按钮。
- 是否存在 breaking change：无。

### UI 变化

不涉及新增视觉、布局或文案变化；本次只恢复旧 WebView 上原本应有的输入与发送按钮交互。引用 `docs/design-rules/DESIGN.md` 的双模式交付门槛：未修改颜色、主题 token 或样式，Light / Dark 继续复用既有实现。

- 引用的设计规范：`docs/design-rules/DESIGN.md`「双模式交付门槛」。

## 怎么验证的

### 自动验证

```text
pnpm --filter mobile exec vitest run src/__tests__/composerRichInputHtml.test.ts
结果：通过，11 tests passed。

pnpm --filter mobile run --if-present typecheck
结果：通过。

pnpm test:unit:related
结果：通过，apps/mobile passed。

pnpm check:dco
结果：通过，1 commit signed off。

git diff --check origin/main...HEAD
结果：通过。
```

### 手工验证

- 分支 / worktree：`cindy/radiant-fermi`，提交 `f4139b7aa`。
- Metro 归属证据：控制台输出 `source=cindy/radiant-fermi@f4139b7aa`，并在当前提交上重新完成 Android bundle。
- 环境：`cindy-api36` AVD，Android 16 / API 36，WebView 133，CN development client `com.xd.cindycn`，Light 模式。
- 操作与结果：在已有任务中输入 `test`，UI Automator 检测到 `session.sendButton` 的 `enabled=true`、`clickable=true`；清空文本后发送按钮消失，`session.voiceButton` 恢复。为避免污染真实任务，未点击发送。

### 未执行的验证

- 未在 Mi 10 或 WebView 85 真机上验证：当前 AVD 的 WebView 为 133，不能直接降到 85；旧版差异由 VM 执行级测试覆盖，该测试显式移除 `replaceChildren` 与 `flatMap` 后验证初始化、`ready` 和输入后的 `change` 消息。
- 未实机目检 Dark 模式：本次没有样式或主题改动。
- `pnpm mobile:sim:whoami -- --region=cn` 未通过：Windows / Node 24 环境报 `spawnSync pnpm ENOENT`；改由 Metro 的 source 输出和当前提交 fresh bundle 确认归属。

## 风险

### 风险分类

- [ ] 无已知风险
- [ ] SQLite / migration
- [ ] system prompt
- [ ] 协议兼容
- [ ] 权限 / 安全 / 用户数据
- [ ] 存量插件兼容（批准状态 / 指纹 / manifest 校验 / 安装布局 / 包格式）
- [ ] 原生层 / fingerprint / OTA
- [x] 跨平台差异
- [ ] 其他：

### 影响与回滚

- 影响范围：仅 Mobile WebView 内富文本输入框的 HTML 初始化与 DOM 节点展开。新写法使用基础 DOM API，性能影响可忽略，不改变发送逻辑；Desktop、服务端和原生层不受影响。本次没有修改 Mobile 原生配置、原生依赖或 runtime fingerprint，不触发冷更。
- 回滚 / 降级方式：回退提交 `f4139b7aa` 即可恢复原实现。

### 提交前检查

- [x] 已 review 完整 diff
- [x] 每个 commit 都带 DCO 签名（`git commit -s`，见 [DCO](../DCO)）
- [x] UI 改动已在「UI 变化」注明引用的设计规范章节（本次无视觉、布局或文案变化）
- [x] 未提交凭证、令牌或授权文件
- [x] 已补充必要文档（本次为最小兼容性修复，无需新增产品文档）
- [x] 已确认测试结果或说明未执行原因