### PR TITLE
fix(mobile): 修复 iOS HDR 截图发送失败

### DIFF
--- a/dependency-patches/README.md
+++ b/dependency-patches/README.md
@@ -10,6 +10,7 @@
 
 | 依赖 | 用途 |
 | --- | --- |
+| `expo-image-manipulator@57.0.14` | 修复 iOS HDR / 10-bit HEIC 图片在方向归一化时因原生 `CGContext` 参数不兼容而抛出 `ERR_IMAGE_CONTEXT_LOST`；正常方向直接复用原图，其余方向交给 `UIGraphicsImageRenderer`。同类问题与真机验证见 [`tloncorp/tlon-apps#5951`](https://github.com/tloncorp/tlon-apps/pull/5951)，待 Expo 上游提供等价修复后移除。 |
 | `expo-paste-input@0.2.2` | 优化移动端粘贴图片的处理时序，将耗时的解码、压缩和写盘移出 UI 线程，并补充加载中与失败事件。 |
 | `harmonyos-sans-sc-webfont-splitted` | 移除依赖按语言全局覆盖 `font-family` 的规则，由 Cindy 自己决定界面字体。 |
 | `react-native@0.85.3` | 回移 Yoga 对 `display: none` 与 `display: contents` 测量过程的布局状态修复，避免 Fabric 布局阶段因错误的 owner 关系触发断言崩溃（上游 `6fa330693fba313a2fe1121545c1efd558b60983`、`2546ce4d8219050fcd1bf432c7c830c9fd70c9af`）。移动端 iOS 通过 `expo-build-properties` 的 `buildReactNativeFromSource` 编译该补丁，不能改回预编译 RN Core。 |

--- a/dependency-patches/expo-image-manipulator@57.0.14.patch
+++ b/dependency-patches/expo-image-manipulator@57.0.14.patch
@@ -1,0 +1,79 @@
+diff --git a/ios/Transformers/ImageFixOrientationTransformer.swift b/ios/Transformers/ImageFixOrientationTransformer.swift
+index c3e3b66eb6b5b0ef75431c96bf292d4fae004606..9e9e6503a09771896936c4d823dd28e9d03b51df 100644
+--- a/ios/Transformers/ImageFixOrientationTransformer.swift
++++ b/ios/Transformers/ImageFixOrientationTransformer.swift
+@@ -6,70 +6,12 @@
+  */
+ internal struct ImageFixOrientationTransformer: ImageTransformer {
+   func transform(image: UIImage) async throws -> UIImage {
+-    guard let cgImage = image.cgImage else {
+-      throw ImageNotFoundException()
+-    }
+-    guard var colorSpace = cgImage.colorSpace else {
+-      // That should never happen as `colorSpace` is empty only when the image is a mask.
+-      throw ImageColorSpaceNotFoundException()
+-    }
+-    if !colorSpace.supportsOutput {
+-      colorSpace = CGColorSpaceCreateDeviceRGB()
+-    }
+-
+-    var transform = CGAffineTransform.identity
+-
+-    switch image.imageOrientation {
+-    case .down, .downMirrored:
+-      transform = transform.translatedBy(x: image.size.width, y: image.size.height)
+-      transform = transform.rotated(by: Double.pi)
+-    case .left, .leftMirrored:
+-      transform = transform.translatedBy(x: image.size.width, y: 0)
+-      transform = transform.rotated(by: Double.pi / 2)
+-    case .right, .rightMirrored:
+-      transform = transform.translatedBy(x: 0, y: image.size.height)
+-      transform = transform.rotated(by: -Double.pi / 2)
+-    default:
+-      break
+-    }
+-
+-    switch image.imageOrientation {
+-    case .upMirrored, .downMirrored:
+-      transform = transform.translatedBy(x: image.size.width, y: 0)
+-      transform = transform.scaledBy(x: -1, y: 1)
+-    case .leftMirrored, .rightMirrored:
+-      transform = transform.translatedBy(x: image.size.height, y: 0)
+-      transform = transform.scaledBy(x: -1, y: 1)
+-    default:
+-      break
+-    }
+-
+-    let context = CGContext(
+-      data: nil,
+-      width: Int(image.size.width),
+-      height: Int(image.size.height),
+-      bitsPerComponent: cgImage.bitsPerComponent,
+-      bytesPerRow: 0,
+-      space: colorSpace,
+-      bitmapInfo: CGImageAlphaInfo.premultipliedLast.rawValue
+-    )
+-
+-    guard let context = context else {
+-      throw ImageContextLostException()
+-    }
+-
+-    context.concatenate(transform)
+-
+-    switch image.imageOrientation {
+-    case .left, .leftMirrored, .right, .rightMirrored:
+-      context.draw(cgImage, in: CGRect(x: 0, y: 0, width: image.size.height, height: image.size.width))
+-    default:
+-      context.draw(cgImage, in: CGRect(x: 0, y: 0, width: image.size.width, height: image.size.height))
++    if image.imageOrientation == .up {
++      return image
+     }
+
+-    guard let newCGImage = context.makeImage() else {
+-      throw ImageDrawingFailedException()
++    return drawInNewContext(size: image.size) { _ in
++      image.draw(in: CGRect(origin: .zero, size: image.size))
+     }
+-    return UIImage(cgImage: newCGImage)
+   }
+ }

--- a/dependency-patches/expo-image-manipulator@57.0.14.patch
+++ b/dependency-patches/expo-image-manipulator@57.0.14.patch
@@ -68,7 +68,7 @@ index c3e3b66eb6b5b0ef75431c96bf292d4fae004606..9e9e6503a09771896936c4d823dd28e9
 +    if image.imageOrientation == .up {
 +      return image
      }
-
+ 
 -    guard let newCGImage = context.makeImage() else {
 -      throw ImageDrawingFailedException()
 +    return drawInNewContext(size: image.size) { _ in

--- a/package.json
+++ b/package.json
@@ -63,6 +63,7 @@
       "react-native@0.85.3": "dependency-patches/react-native@0.85.3.patch",
       "react-native-uitextview@2.2.0": "dependency-patches/react-native-uitextview@2.2.0.patch",
       "react-native-webview@13.16.1": "dependency-patches/react-native-webview@13.16.1.patch",
+      "expo-image-manipulator@57.0.14": "dependency-patches/expo-image-manipulator@57.0.14.patch",
       "expo-paste-input@0.2.2": "dependency-patches/expo-paste-input@0.2.2.patch"
     },
     "allowUnusedPatches": true

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -19,6 +19,9 @@ overrides:
   builder-util-runtime: ^9.7.0
 
 patchedDependencies:
+  expo-image-manipulator@57.0.14:
+    hash: 78594ca2235bdbbee2665f37b86d4e1e892733c4f9bd38fa7085338b90486e2b
+    path: dependency-patches/expo-image-manipulator@57.0.14.patch
   expo-paste-input@0.2.2:
     hash: 53be555646735a171c1624f074ef30e5ca897a7b8893724bc2d0d51682f769d8
     path: dependency-patches/expo-paste-input@0.2.2.patch
@@ -658,7 +661,7 @@ importers:
         version: 57.0.3(expo@57.0.17)(react-native-web@0.21.2(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(react-native@0.86.3(@babel/core@7.29.7)(@react-native/metro-config@0.86.3(@babel/core@7.29.7))(@types/react@19.2.17)(react@19.2.3))(react@19.2.3)
       expo-image-manipulator:
         specifier: ~57.0.14
-        version: 57.0.14(expo@57.0.17)
+        version: 57.0.14(patch_hash=78594ca2235bdbbee2665f37b86d4e1e892733c4f9bd38fa7085338b90486e2b)(expo@57.0.17)
       expo-image-picker:
         specifier: ^57.0.14
         version: 57.0.14(expo@57.0.17)
@@ -16857,7 +16860,7 @@ snapshots:
     dependencies:
       expo: 57.0.17(@babel/core@7.29.7)(@expo/dom-webview@57.0.1)(@expo/metro-runtime@57.0.14)(expo-router@57.0.17)(react-dom@19.2.3(react@19.2.3))(react-native-web@0.21.2(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(react-native-webview@13.16.1(patch_hash=4f76ca2497d14d136ef6ff35060f4c35b57319a3edf53fa334b82771a9405c16)(react-native@0.86.3(@babel/core@7.29.7)(@react-native/metro-config@0.86.3(@babel/core@7.29.7))(@types/react@19.2.17)(react@19.2.3))(react@19.2.3))(react-native-worklets@0.10.1(@babel/core@7.29.7)(@react-native/metro-config@0.86.3(@babel/core@7.29.7))(react-native@0.86.3(@babel/core@7.29.7)(@react-native/metro-config@0.86.3(@babel/core@7.29.7))(@types/react@19.2.17)(react@19.2.3))(react@19.2.3))(react-native@0.86.3(@babel/core@7.29.7)(@react-native/metro-config@0.86.3(@babel/core@7.29.7))(@types/react@19.2.17)(react@19.2.3))(react@19.2.3)(typescript@6.0.3)
 
-  expo-image-manipulator@57.0.14(expo@57.0.17):
+  expo-image-manipulator@57.0.14(patch_hash=78594ca2235bdbbee2665f37b86d4e1e892733c4f9bd38fa7085338b90486e2b)(expo@57.0.17):
     dependencies:
       expo: 57.0.17(@babel/core@7.29.7)(@expo/dom-webview@57.0.1)(@expo/metro-runtime@57.0.14)(expo-router@57.0.17)(react-dom@19.2.3(react@19.2.3))(react-native-web@0.21.2(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(react-native-webview@13.16.1(patch_hash=4f76ca2497d14d136ef6ff35060f4c35b57319a3edf53fa334b82771a9405c16)(react-native@0.86.3(@babel/core@7.29.7)(@react-native/metro-config@0.86.3(@babel/core@7.29.7))(@types/react@19.2.17)(react@19.2.3))(react@19.2.3))(react-native-worklets@0.10.1(@babel/core@7.29.7)(@react-native/metro-config@0.86.3(@babel/core@7.29.7))(react-native@0.86.3(@babel/core@7.29.7)(@react-native/metro-config@0.86.3(@babel/core@7.29.7))(@types/react@19.2.17)(react@19.2.3))(react@19.2.3))(react-native@0.86.3(@babel/core@7.29.7)(@react-native/metro-config@0.86.3(@babel/core@7.29.7))(@types/react@19.2.17)(react@19.2.3))(react@19.2.3)(typescript@6.0.3)
       expo-image-loader: 57.0.1(expo@57.0.17)


### PR DESCRIPTION
## 这次改了什么

### 摘要

修复 iOS 手机截图在方向归一化时处理 HDR / 10-bit HEIC 失败，导致图片发送报错 `ERR_IMAGE_CONTEXT_LOST` 的问题。补丁参考了 Expo 同类修复路径：正常方向直接复用原图，其他方向使用系统 `UIGraphicsImageRenderer` 绘制。

### 变更类型

- [x] `fix` 缺陷修复
- [ ] `feat` 新功能
- [ ] `refactor` / `perf` 重构或性能优化
- [ ] `docs` / `test` / `chore` 文档、测试或工程维护
- [ ] 其他：

### 范围

- 关联 Issue / 需求：#3889
- 本 PR 包含：`expo-image-manipulator@57.0.14` 的 iOS 原生补丁、patch 登记和 lockfile 更新。
- 明确不包含：服务端改动、Android 原生逻辑、UI 调整及图片业务流程改造。
- 用户可见变化：兼容受影响机型的手机截图发送；正常图片处理路径不变。
- 是否存在 breaking change：无

### UI 变化

不涉及：仅修改 Mobile 依赖的 iOS 原生图片方向归一化实现，没有界面、布局、样式、交互或文案变化。

- 引用的设计规范：不涉及 UI。

## 怎么验证的

### 自动验证

```text
pnpm install --frozen-lockfile
git apply --check（补丁可应用到原始 npm 包）
pnpm --filter mobile run --if-present typecheck
pnpm --filter mobile test:scope
pnpm test:unit:related（因 package.json / pnpm-lock.yaml 改动退回全量单测）
```

结果：以上命令全部通过；Desktop、Mobile、maker-core 及要求的 workspace 单测均通过。

### 手工验证

未执行：当前环境为 Windows，无法编译 iOS Swift；尚未在 iOS 26 HDR / SDR 真机上回归。

### 未执行的验证

- 未执行 macOS iOS 构建及 iOS 26 HDR / SDR 真机验证，原因是当前环境为 Windows。

## 风险

### 风险分类

- [ ] 无已知风险
- [ ] SQLite / migration
- [ ] system prompt
- [ ] 协议兼容
- [ ] 权限 / 安全 / 用户数据
- [ ] 存量插件兼容（批准状态 / 指纹 / manifest 校验 / 安装布局 / 包格式）
- [x] 原生层 / fingerprint / OTA
- [x] 跨平台差异
- [ ] 其他：

### 影响与回滚

- 影响范围：iOS 原生依赖补丁会改变 iOS runtime fingerprint；旧装机无法接收该新指纹及其后续 OTA，需安装包含本补丁的新冷更包。Android fingerprint 不变，Android 逻辑不受影响。
- 回滚 / 降级方式：随 iOS 冷更包发布；如真机回归发现问题，可移除该 patch 登记并恢复原始依赖实现后重新构建冷更包。
- 冷更建议：随下一次 iOS 冷更发布，并在发布前完成 HDR / SDR 真机验证；在指定把关人明确确认前保持 Draft。

### 提交前检查

- [x] 已 review 完整 diff
- [x] 每个 commit 都带 DCO 签名（`git commit -s`，见 [DCO](../DCO)）
- [x] UI 改动已在「UI 变化」注明引用的设计规范章节（不涉及 UI 则跳过）
- [x] 未提交凭证、令牌或授权文件
- [x] 已补充必要文档
- [x] 已确认测试结果或说明未执行原因