### PR TITLE
fix(desktop): 非 macOS 上 iOS Simulator 入口报 UNSUPPORTED_PLATFORM 而非误导性的 DEVICE_BUSY

### DIFF
--- a/apps/desktop/src/main/mcp-integrations/__tests__/ios-simulator-unsupported-platform.test.ts
+++ b/apps/desktop/src/main/mcp-integrations/__tests__/ios-simulator-unsupported-platform.test.ts
@@ -1,0 +1,98 @@
+/**
+ * #3914: on non-macOS the module singleton must not try to own the Darwin
+ * ownership registry (its writer lease is never granted there), otherwise the
+ * Host reports DEVICE_BUSY before the runtime can report UNSUPPORTED_PLATFORM
+ * — and no reboot can clear a lease that was never taken.
+ *
+ * Lives in its own file: the default Host is a module singleton whose disposal
+ * is one-way, so it cannot share a module instance with the darwin suites.
+ */
+import { existsSync, mkdtempSync, readdirSync, rmSync } from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { app } from 'electron';
+import { afterAll, beforeAll, describe, expect, it, vi } from 'vitest';
+
+import { IOSSimulatorOwnershipRegistryFile } from '@cindy/ios-simulator-runtime';
+
+// Same owner-boundary override as ios-simulator.test.ts: these cases exercise
+// platform gating, not owner transitions.
+vi.mock('../../appSessionState.js', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../../appSessionState.js')>();
+  return { ...actual, isAppSessionBoundaryPending: () => false };
+});
+
+import { disposeIOSSimulatorHost, initializeIOSSimulatorHost } from '../ios-simulator';
+
+const originalPlatform = Object.getOwnPropertyDescriptor(process, 'platform');
+
+function setPlatform(value: NodeJS.Platform): void {
+  Object.defineProperty(process, 'platform', { value, configurable: true });
+}
+
+function localSession(id: string) {
+  return { id, workDir: `/tmp/${id}`, remoteHostId: null };
+}
+
+describe('iOS Simulator host on a non-macOS platform (#3914)', () => {
+  beforeAll(() => {
+    setPlatform('win32');
+  });
+
+  afterAll(async () => {
+    await disposeIOSSimulatorHost();
+    if (originalPlatform) Object.defineProperty(process, 'platform', originalPlatform);
+  });
+
+  it('reports UNSUPPORTED_PLATFORM without touching the ownership registry or its lock', async () => {
+    const acquireWriter = vi.spyOn(IOSSimulatorOwnershipRegistryFile.prototype, 'acquireWriterSync');
+    // Point the profile at a fresh directory: the non-macOS Host may still resolve
+    // userData for unrelated cache roots (WDA archive cache), but it must never
+    // materialise the Darwin ownership registry, its writer lock, device grants or
+    // interrupted-create evidence there.
+    const root = mkdtempSync(path.join(os.tmpdir(), 'cindy-ios-sim-win32-'));
+    const getPath = vi.spyOn(app, 'getPath').mockReturnValue(root);
+    try {
+      const host = initializeIOSSimulatorHost({
+        getSession: async (id) => localSession(id),
+      });
+
+      const environment = await host.callTool('check_environment', {}, {
+        sessionId: 'win-session',
+        origin: 'user',
+      });
+      expect(environment).toMatchObject({
+        ok: true,
+        data: {
+          supported: false,
+          ready: false,
+          issue: 'UNSUPPORTED_PLATFORM',
+          error: 'iOS Simulator is available only for local macOS sessions.',
+        },
+      });
+      expect(JSON.stringify(environment)).not.toContain('Another Cindy process');
+
+      const tools = await host.describeTools('win-session');
+      expect(tools.ready).toBe(false);
+      expect(tools.tools.check_environment).toMatchObject({ state: 'available' });
+      expect(tools.tools.list_simulator_devices).toMatchObject({
+        state: 'unavailable',
+        reasonCode: 'UNSUPPORTED_PLATFORM',
+      });
+
+      // The Darwin-only registry must stay untouched: no writer lease attempt and
+      // no registry / lock / grants / evidence files under the profile.
+      expect(acquireWriter).not.toHaveBeenCalled();
+      const profileDir = path.join(root, 'ios-simulator');
+      const materialised = existsSync(profileDir) ? readdirSync(profileDir) : [];
+      expect(materialised).not.toContain('ownership-registry.json');
+      expect(materialised).not.toContain('ownership-registry.json.writer.lock');
+      expect(materialised).not.toContain('device-grants.json');
+      expect(materialised).not.toContain('pending-create-evidence.json');
+    } finally {
+      acquireWriter.mockRestore();
+      getPath.mockRestore();
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+});

--- a/apps/desktop/src/main/mcp-integrations/ios-simulator.ts
+++ b/apps/desktop/src/main/mcp-integrations/ios-simulator.ts
@@ -7364,11 +7364,17 @@ async function readPassiveIOSSimulatorPluginStatus(
   }
 }
 
+/** Test seams for the module singleton; production callers pass nothing. */
+export interface IOSSimulatorHostInitializeOptions {
+  getSession?: IOSSimulatorHostOptions['getSession'];
+}
+
 function installDefaultIOSSimulatorHost(
   lifecycle: IOSSimulatorSimctlLifecycle,
   persistedActor: ReturnType<typeof createDefaultActor>,
-  registry: IOSSimulatorOwnershipRegistryFile,
-  pendingCreateEvidence: IOSSimulatorPendingCreateEvidenceStore,
+  grantStore: IOSSimulatorDeviceGrantStore,
+  pendingCreateEvidence: IOSSimulatorPendingCreateEvidenceStore | null,
+  seams: IOSSimulatorHostInitializeOptions = {},
 ): IOSSimulatorHost {
   if (defaultIOSSimulatorRuntime) {
     persistedActor.release();
@@ -7384,9 +7390,10 @@ function installDefaultIOSSimulatorHost(
     const host = createIOSSimulatorHost({
       lifecycle,
       actor: persistedActor.actor,
-      grantStore: createRegistryBackedIOSSimulatorDeviceGrantStore(registry),
+      grantStore,
       canReconcilePendingCreates: persistedActor.canReconcilePendingCreates,
-      pendingCreateEvidence,
+      ...(pendingCreateEvidence ? { pendingCreateEvidence } : {}),
+      ...(seams.getSession ? { getSession: seams.getSession } : {}),
       driverManager: createDefaultDriverManager(),
     });
     configureIOSSimulatorRendererAccessRevocationObserver((grants) => {
@@ -7418,17 +7425,50 @@ function installDefaultIOSSimulatorHost(
  * Simulator must not prevent the instance that actually needs it from taking
  * ownership.
  */
-export function initializeIOSSimulatorHost(): IOSSimulatorHost {
+export function initializeIOSSimulatorHost(
+  options: IOSSimulatorHostInitializeOptions = {},
+): IOSSimulatorHost {
   if (defaultIOSSimulatorRuntime) return defaultIOSSimulatorRuntime.host;
   if (defaultIOSSimulatorRuntimeClosing) {
     throw new Error('The iOS Simulator host is shutting down.');
+  }
+
+  if (process.platform !== 'darwin') {
+    // Apple Simulator is macOS-only. The profile ownership registry only exists
+    // for Darwin (its writer lease is an O_EXLOCK kernel lock and
+    // acquireDarwinWriterLease() returns null elsewhere), so a registry-backed
+    // actor would report DEVICE_BUSY ("another Cindy process…") before the
+    // runtime ever gets to say UNSUPPORTED_PLATFORM — and no reboot can clear a
+    // lease that was never taken (#3914). Install an in-memory Host that never
+    // touches the registry, lock, grants or interrupted-create evidence so
+    // every entry (tool catalog, check_environment, doctor, instance queries)
+    // surfaces the real platform issue through runtime.inspect().
+    const lifecycle = createIOSSimulatorSimctlLifecycle();
+    return installDefaultIOSSimulatorHost(
+      lifecycle,
+      {
+        actor: createInMemoryActor(lifecycle),
+        flush: async () => {},
+        release: () => {},
+        canReconcilePendingCreates: () => false,
+      },
+      new IOSSimulatorDeviceGrantStore(),
+      null,
+      options,
+    );
   }
 
   const registry = createDefaultOwnershipRegistry();
   const pendingCreateEvidence = createDefaultPendingCreateEvidence(registry);
   const lifecycle = createProfileScopedIOSSimulatorLifecycle(registry, pendingCreateEvidence);
   const persistedActor = createDefaultActor(lifecycle, registry);
-  return installDefaultIOSSimulatorHost(lifecycle, persistedActor, registry, pendingCreateEvidence);
+  return installDefaultIOSSimulatorHost(
+    lifecycle,
+    persistedActor,
+    createRegistryBackedIOSSimulatorDeviceGrantStore(registry),
+    pendingCreateEvidence,
+    options,
+  );
 }
 
 function currentIOSSimulatorHost(): IOSSimulatorHost | null {
@@ -7618,7 +7658,7 @@ export async function reconcilePersistedIOSSimulatorOwnership(
     const host = installDefaultIOSSimulatorHost(
       lifecycle,
       persistedActor,
-      registry,
+      createRegistryBackedIOSSimulatorDeviceGrantStore(registry),
       pendingCreateEvidence,
     );
     registryTransferred = true;
@@ -7688,7 +7728,7 @@ export function cleanupIOSSimulatorRemovedSession(sessionId: string): Promise<vo
     const host = installDefaultIOSSimulatorHost(
       lifecycle,
       persistedActor,
-      registry,
+      createRegistryBackedIOSSimulatorDeviceGrantStore(registry),
       pendingCreateEvidence,
     );
     registryTransferred = true;


### PR DESCRIPTION
## 这次改了什么

### 摘要

修复 #3914:Windows(及任何非 macOS)上,内嵌 iOS Simulator 的所有入口都报「Another Cindy process is managing iOS Simulator ownership for this profile」(`DEVICE_BUSY`),重启也无法恢复。

根因(与 issue 内维护者助手分析一致,已逐行核实):`initializeIOSSimulatorHost()` 在做任何平台判断之前就构造 profile ownership registry 并走 `createDefaultActor()`;后者调用 `registry.acquireWriterSync()`,而 `packages/ios-simulator-runtime` 的 `acquireDarwinWriterLease()` 对非 Darwin **恒返 null**(writer lease 是 `O_EXLOCK` 内核锁,只在 macOS 存在)→ `isWriter` 永远为 false → 直接抛 `DEVICE_BUSY`。运行时 `inspect()` 明明会返回 `UNSUPPORTED_PLATFORM`("Apple iOS Simulator is only available on macOS."),但根本走不到;进程树里只有一个 Cindy、重启无效,都是这条路径的必然结果——不存在可过期的 lease。

修复(收敛为平台分流,不放宽 ownership):
- `initializeIOSSimulatorHost()` 在非 macOS 早分流:安装一个**内存 Host**(`createInMemoryActor` + 内存 `IOSSimulatorDeviceGrantStore`、无 pending-create evidence、`canReconcilePendingCreates: () => false`),完全不构造 ownership registry、不尝试 writer lease、不读写 registry / lock / grants / evidence 文件。所有入口(tool catalog、`check_environment`、`doctor`、instance 查询)由此经 `runtime.inspect()` 自然报 `UNSUPPORTED_PLATFORM`,再由既有公共映射转成「iOS Simulator is available only for local macOS sessions.」。
- `installDefaultIOSSimulatorHost()` 改为接收 `grantStore`(而非 `registry`),三处 macOS 调用点(冷启动初始化、启动期 ownership 恢复、会话删除清理)改传 `createRegistryBackedIOSSimulatorDeviceGrantStore(registry)`——macOS 的单 writer 保护、重启恢复、`DEVICE_BUSY` 语义**逐字节不变**。
- 顺带给 `initializeIOSSimulatorHost` 加了与 `reconcilePersistedIOSSimulatorOwnership` 同款的测试 seam(`getSession`),仅测试使用,生产调用方不传。

### 变更类型

- [x] `fix` 缺陷修复

### 范围

- 关联 Issue / 需求:Fixes #3914
- 本 PR 包含:`ios-simulator.ts` 非 macOS 早分流 + 安装函数参数收口(+47/−7);新增独立测试文件 `ios-simulator-unsupported-platform.test.ts`(单例是一次性 dispose 的模块级对象,不能与 darwin 套件共用模块实例,故单独成文件)
- 明确不包含:新增跨平台 iOS Simulator 支持;放宽/重置 ownership 或 lease;Windows 侧的外部 Simulator fallback(仓内 fallback 是 macOS 上的 WDA/MJPEG 路线);`packages/ios-simulator-runtime` 未改动
- 用户可见变化:Windows/Linux 上 iOS Simulator 相关工具与状态改为明确的「仅 macOS 本地会话可用」提示,不再是误导性的「另一个 Cindy 进程占用」
- 是否存在 breaking change:无

### UI 变化

- 不涉及:main 进程 MCP 集成与 Host 装配,无界面、交互、文案改动(公共提示文案复用既有 `UNSUPPORTED_PLATFORM` 映射)。
- 引用的设计规范:不涉及:main 进程平台分流与 Host 装配,无视觉、交互、文案变化。

## 怎么验证的

### 自动验证

```text
pnpm vitest run ios-simulator-unsupported-platform.test.ts ios-simulator.test.ts → 2 files, 149 passed
  新增用例(process.platform 桩为 win32,userData 指向临时目录):
    check_environment → ok:true, data.issue=UNSUPPORTED_PLATFORM, supported=false, ready=false,
      error="iOS Simulator is available only for local macOS sessions.",响应不含 "Another Cindy process";
    describeTools → list_simulator_devices reasonCode=UNSUPPORTED_PLATFORM;
    IOSSimulatorOwnershipRegistryFile.prototype.acquireWriterSync 未被调用;
    临时 profile 下不存在 ownership-registry.json / .writer.lock / device-grants.json / pending-create-evidence.json
  既有 darwin 套件(148 例,含 ownership 竞争 / 启动恢复 / 会话删除清理)不变
反证(变异法):把非 macOS 分流条件短路后重跑新用例 → 新用例以 issue 原始错误失败(IOSSimulatorInstanceError DEVICE_BUSY「Another Cindy process is managing iOS Simulator ownership for this profile.」),恢复后通过——即在 macOS 上用平台桩复现并锁定了 Windows 的失败形态
pnpm --filter desktop run --if-present typecheck → 通过(exit 0)
pnpm test:unit:related → PASS(apps/desktop unit 33.3s)
```

### 手动验证

未做 Windows 实机(无 Windows 设备)。本 PR 消除的是代码层可证明的顺序缺口(lease 恒空 → 先报 DEVICE_BUSY 后才可能报平台),新用例在 macOS 上通过 `process.platform` 桩复现了 issue 的失败形态并验证修复;Windows 真机验收(tool catalog / check_environment / doctor 提示、不生成 lock 文件)请 QA 在包含本 PR 的构建上补做。

## 风险与回滚

- 风险:低。仅在 `process.platform !== 'darwin'` 时改变行为(从"必然 DEVICE_BUSY"到"UNSUPPORTED_PLATFORM");macOS 路径只是把 grant store 的构造从安装函数内部挪到调用点,语义不变,148 例既有回归全过。
- 回滚:revert 单 commit。
