### PR TITLE
fix(desktop): 自动弹出的更新横幅在任务再次运行时收回

### DIFF
--- a/apps/desktop/src/renderer/__tests__/updateBannerBusyDefer.test.tsx
+++ b/apps/desktop/src/renderer/__tests__/updateBannerBusyDefer.test.tsx
@@ -106,6 +106,15 @@ describe('update banner dismiss store', () => {
     deferUpdateBannerBecauseBusy('ready', '1.0.0');
     expect(getUpdateBannerDismissState()).toBe(first);
   });
+
+  it('does not let a busy defer hide a banner the user reopened', () => {
+    deferUpdateBannerBecauseBusy('ready', '1.0.0');
+    restoreUpdateBanner();
+    expect(getUpdateBannerDismissState().pinnedByUser).toBe(true);
+    deferUpdateBannerBecauseBusy('ready', '1.0.0');
+    expect(getUpdateBannerDismissState().dismissed).toBe(false);
+    expect(getUpdateBannerDismissState().pinnedByUser).toBe(true);
+  });
 });
 
 describe('UpdateBanner busy defer', () => {
@@ -216,6 +225,53 @@ describe('UpdateBanner busy defer', () => {
       await Promise.resolve();
     });
     expect(getUpdateBannerDismissState().reason).toBe('busy');
+    expect(screen.queryByRole('button', { name: EXPANDED })).toBeNull();
+
+    busy = false;
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(UPDATE_BANNER_BUSY_POLL_MS);
+    });
+    expect(screen.getByRole('button', { name: EXPANDED })).toBeTruthy();
+    expect(getUpdateBannerDismissState().dismissed).toBe(false);
+  });
+
+  it('hides the expanded banner again if a later poll sees activity', async () => {
+    vi.useFakeTimers();
+    let busy = false;
+    anyActivityBlockingRelaunch.mockImplementation(() => Promise.resolve(busy));
+    render(<UpdateBanner isCollapsed={false} />);
+
+    await act(async () => {
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+    expect(screen.getByRole('button', { name: EXPANDED })).toBeTruthy();
+
+    busy = true;
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(UPDATE_BANNER_BUSY_POLL_MS);
+    });
+    expect(screen.queryByRole('button', { name: EXPANDED })).toBeNull();
+    expect(getUpdateBannerDismissState().reason).toBe('busy');
+    expect(getUpdateBannerDismissState().pinnedByUser).toBe(false);
+  });
+
+  it('pops the expanded banner again after a later busy defer goes idle', async () => {
+    vi.useFakeTimers();
+    let busy = false;
+    anyActivityBlockingRelaunch.mockImplementation(() => Promise.resolve(busy));
+    render(<UpdateBanner isCollapsed={false} />);
+
+    await act(async () => {
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+    expect(screen.getByRole('button', { name: EXPANDED })).toBeTruthy();
+
+    busy = true;
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(UPDATE_BANNER_BUSY_POLL_MS);
+    });
     expect(screen.queryByRole('button', { name: EXPANDED })).toBeNull();
 
     busy = false;

--- a/apps/desktop/src/renderer/__tests__/updateBannerBusyDefer.test.tsx
+++ b/apps/desktop/src/renderer/__tests__/updateBannerBusyDefer.test.tsx
@@ -115,6 +115,17 @@ describe('update banner dismiss store', () => {
     expect(getUpdateBannerDismissState().dismissed).toBe(false);
     expect(getUpdateBannerDismissState().pinnedByUser).toBe(true);
   });
+
+  it('does not keep a user pin when a newer update becomes ready', () => {
+    deferUpdateBannerBecauseBusy('ready', '1.0.0');
+    restoreUpdateBanner();
+    expect(getUpdateBannerDismissState().pinnedByUser).toBe(true);
+
+    deferUpdateBannerBecauseBusy('ready', '2.0.0');
+    expect(getUpdateBannerDismissState().reason).toBe('busy');
+    expect(getUpdateBannerDismissState().dismissedVersion).toBe('2.0.0');
+    expect(getUpdateBannerDismissState().pinnedByUser).toBe(false);
+  });
 });
 
 describe('UpdateBanner busy defer', () => {
@@ -280,5 +291,48 @@ describe('UpdateBanner busy defer', () => {
     });
     expect(screen.getByRole('button', { name: EXPANDED })).toBeTruthy();
     expect(getUpdateBannerDismissState().dismissed).toBe(false);
+  });
+
+  it('probes a newer update after the previous one was user-pinned', async () => {
+    anyActivityBlockingRelaunch.mockResolvedValue(true);
+    const { rerender } = render(<UpdateBanner isCollapsed={false} />);
+    await waitFor(() => expect(getUpdateBannerDismissState().reason).toBe('busy'));
+
+    act(() => {
+      restoreUpdateBanner();
+    });
+    rerender(<UpdateBanner isCollapsed={false} />);
+    expect(await screen.findByRole('button', { name: EXPANDED })).toBeTruthy();
+    expect(getUpdateBannerDismissState().pinnedByUser).toBe(true);
+
+    anyActivityBlockingRelaunch.mockResolvedValue(false);
+    updateStatus.current = { status: 'ready', version: '2.0.0', errorCode: null };
+    rerender(<UpdateBanner isCollapsed={false} />);
+
+    expect(await screen.findByRole('button', { name: EXPANDED })).toBeTruthy();
+    await waitFor(() => {
+      expect(getUpdateBannerDismissState().pinnedByUser).toBe(false);
+      expect(getUpdateBannerDismissState().decidedVersion).toBe('2.0.0');
+    });
+  });
+
+  it('hides a newer update when it arrives busy after a previous pin', async () => {
+    anyActivityBlockingRelaunch.mockResolvedValue(true);
+    const { rerender } = render(<UpdateBanner isCollapsed={false} />);
+    await waitFor(() => expect(getUpdateBannerDismissState().reason).toBe('busy'));
+
+    act(() => {
+      restoreUpdateBanner();
+    });
+    rerender(<UpdateBanner isCollapsed={false} />);
+    expect(await screen.findByRole('button', { name: EXPANDED })).toBeTruthy();
+
+    updateStatus.current = { status: 'ready', version: '2.0.0', errorCode: null };
+    rerender(<UpdateBanner isCollapsed={false} />);
+
+    await waitFor(() => expect(getUpdateBannerDismissState().reason).toBe('busy'));
+    expect(screen.queryByRole('button', { name: EXPANDED })).toBeNull();
+    expect(getUpdateBannerDismissState().pinnedByUser).toBe(false);
+    expect(getUpdateBannerDismissState().dismissedVersion).toBe('2.0.0');
   });
 });

--- a/apps/desktop/src/renderer/hooks/useDeferUpdateBannerWhileBusy.ts
+++ b/apps/desktop/src/renderer/hooks/useDeferUpdateBannerWhileBusy.ts
@@ -3,22 +3,23 @@ import { useEffect, useRef } from 'react';
 import {
   deferUpdateBannerBecauseBusy,
   getUpdateBannerDismissState,
-  isUpdateBannerDecidedFor,
   markUpdateBannerAutoShown,
   useUpdateBannerDismiss,
 } from '@/hooks/useUpdateBannerDismiss';
 
 /**
- * 更新就绪后完整 banner 自动弹出前,先问「有没有任务在跑」。
+ * 更新就绪后完整 banner 要不要占侧栏,先问「有没有任务在跑」。
  *
  * 判定复用「立即重启」二次确认的同一条 IPC(anyActivityBlockingRelaunch),renderer
  * 不枚举活动来源。有任务(或探针失败,fail closed)→ 只留头像行火焰入口;全部停下
- * 后再弹出。用户点 X 关掉的不在这条自动恢复里。
+ * 后再弹出。系统自己弹出的,后来又 busy 同样收回去;用户点 X 关掉的不自动恢复;
+ * 用户点火焰唤回的钉住,busy 不再藏。
  *
  * 这条 IPC 是为点击「立即重启」设计的一次性探针(含 PI 目录同步扫描),不是廉价订阅。
- * 要知道「任务何时停」必须再问同一条定义,但不能把它当成 2s 热循环,也不另做活动缓存
- * 或事件总线。首次立刻问一次以免闪横幅;busy 之后才续询,间隔见
- * UPDATE_BANNER_BUSY_POLL_MS;轮询带 silent,避免把延后展示打成「manual relaunch」INFO。
+ * 要知道「任务何时停 / 后来又没停」必须再问同一条定义,但不能把它当成 2s 热循环,
+ * 也不另做活动缓存或事件总线。首次立刻问一次以免闪横幅;之后按
+ * UPDATE_BANNER_BUSY_POLL_MS 续询(busy 等停下,已弹出等又 busy)。用户关掉或钉住后
+ * 停询。轮询带 silent,避免把延后展示打成「manual relaunch」INFO。
  *
  * 返回值:当前这个版本还没做出弹出/让路决定时为 true,调用方据此先不渲染 banner,
  * 避免「闪一下完整横幅再收成火焰」。
@@ -61,16 +62,13 @@ export function useDeferUpdateBannerWhileBusy(
       if (read().reason === 'busy') {
         read().deferBecauseBusy(status, versionOrNull);
       } else {
-        read().restore();
+        read().restore({ pin: false });
         read().clearAutoDecision();
       }
     }
 
     const snap = getUpdateBannerDismissState();
-    const shouldProbe =
-      (!snap.dismissed && !isUpdateBannerDecidedFor(versionOrNull))
-      || (snap.dismissed && snap.reason === 'busy');
-    if (!shouldProbe) return;
+    if (snap.reason === 'user' || snap.pinnedByUser) return;
 
     let cancelled = false;
     let timer: ReturnType<typeof setTimeout> | null = null;
@@ -88,17 +86,16 @@ export function useDeferUpdateBannerWhileBusy(
       // 探针落地时必须读模块现态,不能读 render 快照:restore / dismiss 可能已经
       // 发生、但这次 render 还没跟上。
       const latest = getUpdateBannerDismissState();
-      if (latest.reason === 'user') return;
+      if (latest.reason === 'user' || latest.pinnedByUser) return;
 
       if (busy) {
-        // 用户已经点火焰把 banner 唤回来了:这是明确要看,不要再藏回去。
-        if (!latest.dismissed && isUpdateBannerDecidedFor(versionOrNull)) return;
         deferUpdateBannerBecauseBusy(status, versionOrNull);
         schedulePoll();
         return;
       }
 
       markUpdateBannerAutoShown(versionOrNull);
+      schedulePoll();
     };
 
     void run();
@@ -107,7 +104,7 @@ export function useDeferUpdateBannerWhileBusy(
       cancelled = true;
       if (timer !== null) clearTimeout(timer);
     };
-  }, [status, versionOrNull, dismissApi.dismissed, dismissApi.reason]);
+  }, [status, versionOrNull, dismissApi.dismissed, dismissApi.reason, dismissApi.pinnedByUser]);
 
   return hideUntilDecided;
 }

--- a/apps/desktop/src/renderer/hooks/useDeferUpdateBannerWhileBusy.ts
+++ b/apps/desktop/src/renderer/hooks/useDeferUpdateBannerWhileBusy.ts
@@ -3,6 +3,7 @@ import { useEffect, useRef } from 'react';
 import {
   deferUpdateBannerBecauseBusy,
   getUpdateBannerDismissState,
+  isUpdateBannerPinnedFor,
   markUpdateBannerAutoShown,
   useUpdateBannerDismiss,
 } from '@/hooks/useUpdateBannerDismiss';
@@ -13,7 +14,7 @@ import {
  * 判定复用「立即重启」二次确认的同一条 IPC(anyActivityBlockingRelaunch),renderer
  * 不枚举活动来源。有任务(或探针失败,fail closed)→ 只留头像行火焰入口;全部停下
  * 后再弹出。系统自己弹出的,后来又 busy 同样收回去;用户点 X 关掉的不自动恢复;
- * 用户点火焰唤回的钉住,busy 不再藏。
+ * 用户点火焰唤回的钉住当前这一版,busy 不再藏。待装版本变了,钉住作废并重新探针。
  *
  * 这条 IPC 是为点击「立即重启」设计的一次性探针(含 PI 目录同步扫描),不是廉价订阅。
  * 要知道「任务何时停 / 后来又没停」必须再问同一条定义,但不能把它当成 2s 热循环,
@@ -68,7 +69,7 @@ export function useDeferUpdateBannerWhileBusy(
     }
 
     const snap = getUpdateBannerDismissState();
-    if (snap.reason === 'user' || snap.pinnedByUser) return;
+    if (snap.reason === 'user' || isUpdateBannerPinnedFor(versionOrNull)) return;
 
     let cancelled = false;
     let timer: ReturnType<typeof setTimeout> | null = null;
@@ -86,7 +87,7 @@ export function useDeferUpdateBannerWhileBusy(
       // 探针落地时必须读模块现态,不能读 render 快照:restore / dismiss 可能已经
       // 发生、但这次 render 还没跟上。
       const latest = getUpdateBannerDismissState();
-      if (latest.reason === 'user' || latest.pinnedByUser) return;
+      if (latest.reason === 'user' || isUpdateBannerPinnedFor(versionOrNull)) return;
 
       if (busy) {
         deferUpdateBannerBecauseBusy(status, versionOrNull);

--- a/apps/desktop/src/renderer/hooks/useUpdateBannerDismiss.ts
+++ b/apps/desktop/src/renderer/hooks/useUpdateBannerDismiss.ts
@@ -20,7 +20,8 @@ import { useSyncExternalStore } from 'react';
  *   时,不会因为「版本和之前 dismiss 时一样」而误 restore。
  * - **decidedVersion**:已经对某个待装版本做过「弹出 / 让路」决定。用来避免
  *   remount 时再闪一次探针空窗。系统自己弹出的横幅,后来又 busy 时仍会收回去。
- * - **pinnedByUser**:用户点火焰把横幅唤回来。这是明确要看,busy 探针不要再藏。
+ * - **pinnedByUser**:用户点火焰把横幅唤回来。只对 decidedVersion 那一版生效:
+ *   这是明确要看,busy 探针不要再藏。待装版本变了就把钉住作废,重新探针。
  * - 模块级 singleton store(useSyncExternalStore),让 UpdateBanner 与
  *   UserInfoSection 无需 context / prop-drill 就能共享同一状态。
  */
@@ -104,7 +105,7 @@ export function dismissUpdateBanner(currentStatus: string, currentVersion: strin
  */
 export function deferUpdateBannerBecauseBusy(currentStatus: string, currentVersion: string | null) {
   if (state.dismissed && state.reason === 'user') return;
-  if (state.pinnedByUser) return;
+  if (isUpdateBannerPinnedFor(currentVersion)) return;
   if (sameBusyDefer(currentStatus, currentVersion)) return;
   state = {
     dismissed: true,
@@ -119,7 +120,7 @@ export function deferUpdateBannerBecauseBusy(currentStatus: string, currentVersi
 
 export function markUpdateBannerAutoShown(currentVersion: string | null) {
   if (state.dismissed && state.reason === 'user') return;
-  if (state.pinnedByUser) return;
+  if (isUpdateBannerPinnedFor(currentVersion)) return;
   const decidedVersion = updateBannerDecisionVersion(currentVersion);
   if (
     !state.dismissed
@@ -159,6 +160,11 @@ export function clearUpdateBannerAutoDecision() {
 
 export function isUpdateBannerDecidedFor(currentVersion: string | null): boolean {
   return state.decidedVersion === updateBannerDecisionVersion(currentVersion);
+}
+
+/** 用户钉住的是当前这个待装版本,不是上一版留下的钉。 */
+export function isUpdateBannerPinnedFor(currentVersion: string | null): boolean {
+  return state.pinnedByUser && isUpdateBannerDecidedFor(currentVersion);
 }
 
 /**

--- a/apps/desktop/src/renderer/hooks/useUpdateBannerDismiss.ts
+++ b/apps/desktop/src/renderer/hooks/useUpdateBannerDismiss.ts
@@ -19,7 +19,8 @@ import { useSyncExternalStore } from 'react';
  *   /settings 往返后 remount、useUpdateStatus() 经历 idle→ready 的初始水合
  *   时,不会因为「版本和之前 dismiss 时一样」而误 restore。
  * - **decidedVersion**:已经对某个待装版本做过「弹出 / 让路」决定。用来避免
- *   remount 时再闪一次探针空窗,也避免用户点火焰唤回之后又被 busy 探针藏回去。
+ *   remount 时再闪一次探针空窗。系统自己弹出的横幅,后来又 busy 时仍会收回去。
+ * - **pinnedByUser**:用户点火焰把横幅唤回来。这是明确要看,busy 探针不要再藏。
  * - 模块级 singleton store(useSyncExternalStore),让 UpdateBanner 与
  *   UserInfoSection 无需 context / prop-drill 就能共享同一状态。
  */
@@ -32,6 +33,7 @@ interface DismissState {
   dismissedStatus: string | null;
   dismissedVersion: string | null;
   decidedVersion: string | null;
+  pinnedByUser: boolean;
 }
 
 const UNVERSIONED = '<none>';
@@ -40,13 +42,16 @@ export function updateBannerDecisionVersion(version: string | null): string {
   return version ?? UNVERSIONED;
 }
 
-let state: DismissState = {
+const INITIAL_STATE: DismissState = {
   dismissed: false,
   reason: null,
   dismissedStatus: null,
   dismissedVersion: null,
   decidedVersion: null,
+  pinnedByUser: false,
 };
+
+let state: DismissState = { ...INITIAL_STATE };
 const listeners = new Set<() => void>();
 
 function emit() {
@@ -88,15 +93,18 @@ export function dismissUpdateBanner(currentStatus: string, currentVersion: strin
     dismissedStatus: currentStatus,
     dismissedVersion: currentVersion,
     decidedVersion: state.decidedVersion,
+    pinnedByUser: false,
   };
   emit();
 }
 
 /**
- * 有任务在跑:不要弹出完整 banner,只留火焰入口。已经是用户关掉的,不要覆盖。
+ * 有任务在跑:不要弹出完整 banner,只留火焰入口。已经是用户关掉的,或用户点火焰
+ * 钉住要看的,不要覆盖。
  */
 export function deferUpdateBannerBecauseBusy(currentStatus: string, currentVersion: string | null) {
   if (state.dismissed && state.reason === 'user') return;
+  if (state.pinnedByUser) return;
   if (sameBusyDefer(currentStatus, currentVersion)) return;
   state = {
     dismissed: true,
@@ -104,25 +112,33 @@ export function deferUpdateBannerBecauseBusy(currentStatus: string, currentVersi
     dismissedStatus: currentStatus,
     dismissedVersion: currentVersion,
     decidedVersion: updateBannerDecisionVersion(currentVersion),
+    pinnedByUser: false,
   };
   emit();
 }
 
 export function markUpdateBannerAutoShown(currentVersion: string | null) {
   if (state.dismissed && state.reason === 'user') return;
+  if (state.pinnedByUser) return;
   const decidedVersion = updateBannerDecisionVersion(currentVersion);
-  if (!state.dismissed && state.reason === null && state.decidedVersion === decidedVersion) return;
+  if (
+    !state.dismissed
+    && state.reason === null
+    && state.decidedVersion === decidedVersion
+    && !state.pinnedByUser
+  ) return;
   state = {
     dismissed: false,
     reason: null,
     dismissedStatus: null,
     dismissedVersion: null,
     decidedVersion,
+    pinnedByUser: false,
   };
   emit();
 }
 
-export function restoreUpdateBanner() {
+export function restoreUpdateBanner(opts?: { pin?: boolean }) {
   if (!state.dismissed) return;
   state = {
     dismissed: false,
@@ -130,6 +146,7 @@ export function restoreUpdateBanner() {
     dismissedStatus: null,
     dismissedVersion: null,
     decidedVersion: state.decidedVersion,
+    pinnedByUser: opts?.pin !== false,
   };
   emit();
 }
@@ -161,13 +178,7 @@ export function isNewUpdateAfterDismiss(currentStatus: string, currentVersion: s
 }
 
 export function resetUpdateBannerDismissStoreForTests() {
-  state = {
-    dismissed: false,
-    reason: null,
-    dismissedStatus: null,
-    dismissedVersion: null,
-    decidedVersion: null,
-  };
+  state = { ...INITIAL_STATE };
   emit();
 }
 
@@ -178,6 +189,7 @@ export function useUpdateBannerDismiss() {
     reason: snap.reason,
     dismiss: dismissUpdateBanner,
     restore: restoreUpdateBanner,
+    pinnedByUser: snap.pinnedByUser,
     deferBecauseBusy: deferUpdateBannerBecauseBusy,
     markAutoShown: markUpdateBannerAutoShown,
     clearAutoDecision: clearUpdateBannerAutoDecision,


### PR DESCRIPTION
## 这次改了什么

### 摘要

Desktop 更新就绪后，完整横幅如果是系统自己弹出来的，后来又有任务在跑，会收回最小化入口（侧栏火焰）；任务全部停下后再弹出。用户点 X 关掉的仍不自动回来；用户点火焰唤回来的会钉住，busy 不再藏。

「有任务在跑」仍复用「立即重启」二次确认的同一条探针，不另做活动缓存或事件总线。只改提醒展示时机，不改 cindy-updater 安装/替换。展示时机此前已与 owner 确认。

### 变更类型

- [x] `fix` 缺陷修复
- [ ] `feat` 新功能
- [ ] `refactor` / `perf` 重构或性能优化
- [ ] `docs` / `test` / `chore` 文档、测试或工程维护
- [ ] 其他：

### 范围

- 关联 Issue / 需求：延续 #3615。自动弹出后若再开任务，完整横幅应让路。
- 本 PR 包含：自动弹出后继续 15s 静默探针；busy 时收回；idle 再弹出；`pinnedByUser` 区分火焰唤回与系统弹出。
- 明确不包含：更新器下载/安装/替换；Mobile；新 UI；活动事件总线。
- 用户可见变化：干活时完整更新横幅会收成火焰；停下来再展开。点火焰看过的这次不收回。
- 是否存在 breaking change：无

### UI 变化

- 引用的设计规范：不涉及：只改完整横幅何时出现/收回，沿用现有 UpdateBanner 与火焰入口，无新组件、样式或文案。

## 怎么验证的

### 自动验证

```text
cd /Users/dash/Code/Cindy/cindy-hide-update-banner-when-busy-again
pnpm test:unit:related
结果：PASS apps/desktop unit (15.3s)

pnpm --filter desktop run --if-present typecheck
结果：通过

pnpm check:dco
结果：1 commit signed off
```

### 手工验证

未在实机点更新横幅走一轮 busy/idle。当前安装的 0.1.72 不含本提交。

### 未执行的验证

实机：更新就绪 → 横幅弹出 → 开任务应收成火焰 → 停任务应再弹出；点火焰钉住后 busy 不收。Light/Dark 无样式改动，未做双模式目检。

## 风险

### 风险分类

- [x] 无已知风险
- [ ] SQLite / migration
- [ ] system prompt
- [ ] 协议兼容
- [ ] 权限 / 安全 / 用户数据
- [ ] 存量插件兼容（批准状态 / 指纹 / manifest 校验 / 安装布局 / 包格式）
- [ ] 原生层 / fingerprint / OTA
- [ ] 跨平台差异
- [ ] 其他：

### 影响与回滚

- 影响范围：Desktop 侧栏更新横幅的自动展示时机。安装/重启路径不变。
- 回滚 / 降级方式：revert 本 PR。存量插件影响：无。

### 提交前检查

- [x] 已 review 完整 diff
- [x] 每个 commit 都带 DCO 签名（`git commit -s`，见 [DCO](../DCO)）
- [x] UI 改动已在「UI 变化」注明引用的设计规范章节（不涉及 UI 则跳过）
- [x] 未提交凭证、令牌或授权文件
- [x] 已补充必要文档
- [x] 已确认测试结果或说明未执行原因
