### PR TITLE
feat(desktop): 支持成对符号包裹选中文本

### DIFF
--- a/apps/desktop/src/renderer/__tests__/listComposerTextarea.test.tsx
+++ b/apps/desktop/src/renderer/__tests__/listComposerTextarea.test.tsx
@@ -29,6 +29,40 @@ function setup(opts: { value: string; caret: number; maxLength?: number }) {
 }
 
 describe('ListComposerTextarea 键盘契约', () => {
+  it('输入左符号时包裹并保留非空选区', () => {
+    const { el, onKeyDown } = setup({ value: 'before abc after', caret: 0 });
+    el.setSelectionRange(7, 10);
+
+    fireEvent.keyDown(el, { key: '(' });
+
+    expect(el.value).toBe('before (abc) after');
+    expect(el.selectionStart).toBe(8);
+    expect(el.selectionEnd).toBe(11);
+    expect(onKeyDown).not.toHaveBeenCalled();
+  });
+
+  it('IME 组字时不介入成对符号输入', () => {
+    const { el, onKeyDown } = setup({ value: 'abc', caret: 0 });
+    el.setSelectionRange(0, 3);
+
+    fireEvent.keyDown(el, { key: '(', isComposing: true });
+
+    expect(el.value).toBe('abc');
+    expect(onKeyDown).toHaveBeenCalledOnce();
+  });
+
+  it('包裹会超过 maxLength 时消费输入且保留原选区', () => {
+    const { el, onKeyDown } = setup({ value: 'abc', caret: 0, maxLength: 4 });
+    el.setSelectionRange(0, 3);
+
+    fireEvent.keyDown(el, { key: '"' });
+
+    expect(el.value).toBe('abc');
+    expect(el.selectionStart).toBe(0);
+    expect(el.selectionEnd).toBe(3);
+    expect(onKeyDown).not.toHaveBeenCalled();
+  });
+
   it('Alt+Enter 在非列表行:插换行并消费,不下沉到消费方(不误发送)', () => {
     const { el, onKeyDown } = setup({ value: 'hello', caret: 5 });
     fireEvent.keyDown(el, { key: 'Enter', altKey: true });

--- a/apps/desktop/src/renderer/__tests__/windowsSelectionReplacement.test.ts
+++ b/apps/desktop/src/renderer/__tests__/windowsSelectionReplacement.test.ts
@@ -4,6 +4,7 @@ import { EditorState, TextSelection, type Transaction } from '@tiptap/pm/state';
 import type { EditorProps, EditorView } from '@tiptap/pm/view';
 
 import { handleWindowsSelectedTextInput } from '../components/new-chat/WindowsSelectionReplacement';
+import { handlePairedSelectionInput } from '../components/new-chat/SelectionPairing';
 
 const schema = new Schema({
   nodes: {
@@ -72,6 +73,18 @@ function inputEvent(data: string, inputType = 'insertText') {
 }
 
 describe('Windows chat composer selection replacement', () => {
+  it('lets the shared text-input rule wrap a selected range', () => {
+    const initial = selectedPrefixState('hardBreak');
+    const { view, getState } = makeView(initial, false, handlePairedSelectionInput);
+    const event = inputEvent('(');
+
+    expect(handleWindowsSelectedTextInput(view, event)).toBe(true);
+
+    expect(documentText(getState())).toBe('(GPT5.5)啊啊啊啊\n');
+    expect(getState().selection.from).toBe(2);
+    expect(getState().selection.to).toBe(8);
+  });
+
   it.each(['hardBreak', 'emptyParagraph'] as const)(
     'replaces a selected prefix before a trailing %s and leaves the caret after the new text',
     (trailingKind) => {

--- a/apps/desktop/src/renderer/components/markdown/CodeMirrorSelectionPairing.ts
+++ b/apps/desktop/src/renderer/components/markdown/CodeMirrorSelectionPairing.ts
@@ -1,0 +1,32 @@
+import { EditorSelection } from '@codemirror/state';
+import { EditorView } from '@codemirror/view';
+
+import { closingSymbolFor } from '@/lib/pairedSelection';
+
+/** CodeMirror input boundary for wrapping one non-empty primary selection. */
+export function handleCodeMirrorPairedSelection(
+  view: EditorView,
+  from: number,
+  to: number,
+  input: string,
+): boolean {
+  const close = closingSymbolFor(input);
+  if (close === null || from === to || view.composing || view.state.selection.ranges.length !== 1) {
+    return false;
+  }
+
+  view.dispatch({
+    changes: [
+      { from, insert: input },
+      { from: to, insert: close },
+    ],
+    selection: EditorSelection.range(from + input.length, to + input.length),
+    userEvent: 'input.type',
+  });
+  return true;
+}
+
+/** Shared extension used by plain-text, Markdown, and code-file editor modes. */
+export const codeMirrorSelectionPairing = EditorView.inputHandler.of(
+  handleCodeMirrorPairedSelection,
+);

--- a/apps/desktop/src/renderer/components/markdown/PlaintextEditor.tsx
+++ b/apps/desktop/src/renderer/components/markdown/PlaintextEditor.tsx
@@ -70,6 +70,7 @@ import {
   markdownDarkEditorTheme,
 } from './codemirrorGithubTheme';
 import { getCodeMirrorLanguage } from './codemirrorLanguages';
+import { codeMirrorSelectionPairing } from './CodeMirrorSelectionPairing';
 import {
   clamp,
   findMarkdownTableAtLine,
@@ -1192,6 +1193,7 @@ export const PlaintextEditor = forwardRef<PlaintextEditorHandle, PlaintextEditor
       //   - code chrome → 始终挂 lineNumbers gutter,即使 parser 缺失。
       const extensions = [
         history(),
+        codeMirrorSelectionPairing,
         keymap.of([indentWithTab, ...defaultKeymap, ...historyKeymap]),
         ...(initialConfig.skipWrap ? [] : [EditorView.lineWrapping]),
         ...(initialConfig.useCodeChrome ? [lineNumbers()] : []),

--- a/apps/desktop/src/renderer/components/markdown/__tests__/CodeMirrorSelectionPairing.test.ts
+++ b/apps/desktop/src/renderer/components/markdown/__tests__/CodeMirrorSelectionPairing.test.ts
@@ -1,0 +1,45 @@
+// @vitest-environment jsdom
+
+import { EditorState, EditorSelection } from '@codemirror/state';
+import { EditorView } from '@codemirror/view';
+import { afterEach, describe, expect, it } from 'vitest';
+
+import { handleCodeMirrorPairedSelection } from '../CodeMirrorSelectionPairing';
+
+let view: EditorView | null = null;
+
+afterEach(() => {
+  view?.destroy();
+  view = null;
+});
+
+function createView(doc: string, from: number, to: number): EditorView {
+  view = new EditorView({
+    parent: document.body,
+    state: EditorState.create({
+      doc,
+      selection: EditorSelection.range(from, to),
+    }),
+  });
+  return view;
+}
+
+describe('CodeMirror selection pairing', () => {
+  it('wraps the selection in one undoable input transaction', () => {
+    const editor = createView('before abc after', 7, 10);
+
+    expect(handleCodeMirrorPairedSelection(editor, 7, 10, '[')).toBe(true);
+
+    expect(editor.state.doc.toString()).toBe('before [abc] after');
+    expect(editor.state.selection.main.from).toBe(8);
+    expect(editor.state.selection.main.to).toBe(11);
+  });
+
+  it('leaves a collapsed selection and unsupported input to CodeMirror', () => {
+    const editor = createView('abc', 1, 1);
+
+    expect(handleCodeMirrorPairedSelection(editor, 1, 1, '(')).toBe(false);
+    expect(handleCodeMirrorPairedSelection(editor, 0, 1, 'x')).toBe(false);
+    expect(editor.state.doc.toString()).toBe('abc');
+  });
+});

--- a/apps/desktop/src/renderer/components/new-chat/ChatInput.tsx
+++ b/apps/desktop/src/renderer/components/new-chat/ChatInput.tsx
@@ -45,6 +45,7 @@ import {
   promoteTrailingPlainListParagraph,
 } from './ComposerListNodes';
 import { WindowsSelectionReplacement } from './WindowsSelectionReplacement';
+import { SelectionPairing } from './SelectionPairing';
 import { EmptyDocSelectionGuard } from './EmptyDocSelectionGuard';
 import {
   hasFocusMovedToInteractiveElement,
@@ -2086,6 +2087,7 @@ export function ChatInput({
       MentionChipNode,
       ComposerQuoteNode,
       PastedTextChipNode,
+      SelectionPairing,
       WindowsSelectionReplacement.configure({
         enabled: window.electronAPI.platform === 'win32',
       }),

--- a/apps/desktop/src/renderer/components/new-chat/ListComposerTextarea.tsx
+++ b/apps/desktop/src/renderer/components/new-chat/ListComposerTextarea.tsx
@@ -5,6 +5,7 @@ import {
   computeTextareaContinuation,
   type TextareaListEdit,
 } from '@/lib/composerListTextarea';
+import { computePairedSelectionEdit, type PairedSelectionEdit } from '@/lib/pairedSelection';
 
 /**
  * ListComposerTextarea —— 原生 `<textarea>` 的直替换包装,统一附带 composer
@@ -54,6 +55,18 @@ function applyEdit(el: HTMLTextAreaElement, edit: TextareaListEdit): void {
   el.setSelectionRange(edit.caret, edit.caret);
 }
 
+function applyPairedSelectionEdit(
+  el: HTMLTextAreaElement,
+  edit: PairedSelectionEdit,
+  direction: 'forward' | 'backward' | 'none',
+): void {
+  const setter = Object.getOwnPropertyDescriptor(HTMLTextAreaElement.prototype, 'value')?.set;
+  if (setter) setter.call(el, edit.value);
+  else el.value = edit.value;
+  el.dispatchEvent(new Event('input', { bubbles: true }));
+  el.setSelectionRange(edit.selectionStart, edit.selectionEnd, direction);
+}
+
 export const ListComposerTextarea = forwardRef<HTMLTextAreaElement, ListComposerTextareaProps>(
   function ListComposerTextarea({ onKeyDown, className, ...rest }, ref) {
     const handleKeyDown = (event: KeyboardEvent<HTMLTextAreaElement>) => {
@@ -64,6 +77,16 @@ export const ListComposerTextarea = forwardRef<HTMLTextAreaElement, ListComposer
       // 仍显式守卫(类型为 number | null)以满足 strictNullChecks 并让意图清晰。
       if (!event.nativeEvent.isComposing && selStart !== null && selEnd !== null) {
         const noHardMods = !event.metaKey && !event.ctrlKey;
+        const pairedEdit = noHardMods
+          ? computePairedSelectionEdit(el.value, selStart, selEnd, event.key)
+          : null;
+        if (pairedEdit) {
+          event.preventDefault();
+          if (withinMaxLength(el, pairedEdit.value)) {
+            applyPairedSelectionEdit(el, pairedEdit, el.selectionDirection);
+          }
+          return;
+        }
         // Shift/Alt+Enter — 列表接续 / 空项退出。
         if (event.key === 'Enter' && (event.shiftKey || event.altKey) && noHardMods) {
           const edit = computeTextareaContinuation(el.value, selStart, selEnd);

--- a/apps/desktop/src/renderer/components/new-chat/SelectionPairing.ts
+++ b/apps/desktop/src/renderer/components/new-chat/SelectionPairing.ts
@@ -1,0 +1,45 @@
+import { Extension } from '@tiptap/core';
+import { Plugin, TextSelection } from '@tiptap/pm/state';
+import type { EditorView } from '@tiptap/pm/view';
+
+import { closingSymbolFor } from '@/lib/pairedSelection';
+
+/** Wrap a ProseMirror selection without flattening inline structured nodes. */
+export function handlePairedSelectionInput(
+  view: EditorView,
+  from: number,
+  to: number,
+  input: string,
+): boolean {
+  const close = closingSymbolFor(input);
+  if (
+    close === null ||
+    from === to ||
+    view.composing ||
+    !(view.state.selection instanceof TextSelection)
+  ) {
+    return false;
+  }
+
+  const transaction = view.state.tr.insertText(close, to).insertText(input, from);
+  transaction.setSelection(
+    TextSelection.create(transaction.doc, from + input.length, to + input.length),
+  );
+  view.dispatch(transaction.scrollIntoView());
+  return true;
+}
+
+/** Tiptap input rule for VS Code-style wrapping of selected composer content. */
+export const SelectionPairing = Extension.create({
+  name: 'selectionPairing',
+
+  addProseMirrorPlugins() {
+    return [
+      new Plugin({
+        props: {
+          handleTextInput: handlePairedSelectionInput,
+        },
+      }),
+    ];
+  },
+});

--- a/apps/desktop/src/renderer/lib/__tests__/pairedSelection.test.ts
+++ b/apps/desktop/src/renderer/lib/__tests__/pairedSelection.test.ts
@@ -1,0 +1,32 @@
+import { describe, expect, it } from 'vitest';
+
+import { closingSymbolFor, computePairedSelectionEdit } from '../pairedSelection';
+
+describe('paired selection', () => {
+  it.each([
+    ['"', '"'],
+    ["'", "'"],
+    ['(', ')'],
+    ['[', ']'],
+    ['{', '}'],
+    ['<', '>'],
+  ])('maps %s to %s', (open, close) => {
+    expect(closingSymbolFor(open)).toBe(close);
+  });
+
+  it('wraps a multiline selection and keeps its contents selected', () => {
+    expect(computePairedSelectionEdit('before\na\nb\nafter', 7, 10, '(')).toEqual({
+      value: 'before\n(a\nb)\nafter',
+      selectionStart: 8,
+      selectionEnd: 11,
+    });
+  });
+
+  it.each(['x', ')', ''])('ignores unsupported input %j', (input) => {
+    expect(computePairedSelectionEdit('abc', 0, 3, input)).toBeNull();
+  });
+
+  it('ignores a collapsed selection', () => {
+    expect(computePairedSelectionEdit('abc', 1, 1, '"')).toBeNull();
+  });
+});

--- a/apps/desktop/src/renderer/lib/pairedSelection.ts
+++ b/apps/desktop/src/renderer/lib/pairedSelection.ts
@@ -1,0 +1,47 @@
+/** Symbols that wrap a non-empty text selection when their opening key is typed. */
+const SELECTION_PAIRS = {
+  '"': '"',
+  "'": "'",
+  '(': ')',
+  '[': ']',
+  '{': '}',
+  '<': '>',
+} as const;
+
+export interface PairedSelectionEdit {
+  value: string;
+  selectionStart: number;
+  selectionEnd: number;
+}
+
+/** Return the closing symbol for a supported single-character opening input. */
+export function closingSymbolFor(input: string): string | null {
+  return Object.prototype.hasOwnProperty.call(SELECTION_PAIRS, input)
+    ? SELECTION_PAIRS[input as keyof typeof SELECTION_PAIRS]
+    : null;
+}
+
+/**
+ * Compute a selection-preserving edit for native text controls. The selected
+ * text remains selected inside the new pair, matching VS Code's interaction.
+ */
+export function computePairedSelectionEdit(
+  value: string,
+  selectionStart: number,
+  selectionEnd: number,
+  input: string,
+): PairedSelectionEdit | null {
+  const close = closingSymbolFor(input);
+  if (close === null || selectionStart === selectionEnd) return null;
+
+  return {
+    value:
+      value.slice(0, selectionStart) +
+      input +
+      value.slice(selectionStart, selectionEnd) +
+      close +
+      value.slice(selectionEnd),
+    selectionStart: selectionStart + input.length,
+    selectionEnd: selectionEnd + input.length,
+  };
+}


### PR DESCRIPTION
## 这次改了什么

### 摘要

在 Cindy 的主要文本编辑入口中加入类似 VS Code 的选区包裹行为：选中文本后输入双引号、单引号、圆括号、方括号、花括号或尖括号的左符号，会保留原文并在两侧插入配对符号，原内容继续保持选中。

### 变更类型

- [x] `feat` 新功能
- [ ] `fix` 缺陷修复
- [ ] `refactor` / `perf` 重构或性能优化
- [ ] `docs` / `test` / `chore` 文档、测试或工程维护
- [ ] 其他：

### 范围

- 关联 Issue / 需求：Closes #3899
- 本 PR 包含：共享配对规则；主聊天 Tiptap/ProseMirror 输入框；共享 textarea（含消息编辑等入口）；纯文本、Markdown 和代码文件的 CodeMirror 编辑器；IME、maxlength、选区与 Windows beforeinput 回归测试。
- 明确不包含：空选区自动补齐、输入右符号跳过、配置开关、未复用上述编辑器基座的第三方/vendor 编辑器。
- 用户可见变化：选中内容后输入 `"`、`'`、`(`、`[`、`{`、`<` 时，内容被对应符号包裹而非覆盖。
- 是否存在 breaking change：无。

### UI 变化

- 引用的设计规范：`docs/design-rules/DESIGN.md` §4 Inputs。本改动只调整既有编辑器的文本输入交互，不新增或改变视觉、布局、颜色、文案与主题样式；Light/Dark 均复用现有界面。

## 怎么验证的

### 自动验证

```text
pnpm test:unit:related
结果：通过（apps/desktop，10 个相关文件）

pnpm --filter desktop run typecheck
结果：通过

pnpm --filter desktop exec vitest run src/renderer/lib/__tests__/pairedSelection.test.ts src/renderer/components/markdown/__tests__/CodeMirrorSelectionPairing.test.ts src/renderer/__tests__/windowsSelectionReplacement.test.ts
结果：通过（3 files，22 tests）

pnpm check:dco -- --base origin/main
结果：通过（1 commit）
```

### 手工验证

未执行：当前独立 worktree 不属于运行中 Desktop dev 实例，无法在不影响宿主 checkout 的情况下做实机输入验证。

### 未执行的验证

- 未在 macOS/Linux 实机验证；实现使用各编辑器的跨平台事务/input API，并显式避开 IME composing。
- 未做视觉截图：没有视觉变化。

## 风险

### 风险分类

- [ ] 无已知风险
- [ ] SQLite / migration
- [ ] system prompt
- [ ] 协议兼容
- [ ] 权限 / 安全 / 用户数据
- [ ] 存量插件兼容（批准状态 / 指纹 / manifest 校验 / 安装布局 / 包格式）
- [ ] 原生层 / fingerprint / OTA
- [x] 跨平台差异
- [x] 其他：编辑器输入法与选区事务

### 影响与回滚

- 影响范围：Desktop 主聊天输入、复用 ListComposerTextarea 的原生 textarea，以及 PlaintextEditor 的 plain/Markdown/code 三种模式。
- 回滚 / 降级方式：移除三个编辑器适配扩展及共享配对规则即可恢复原生选区覆盖行为。IME 组字、空选区、快捷键修饰输入、CodeMirror 多选区和不支持字符均保持原编辑器处理路径。

### 提交前检查

- [x] 已 review 完整 diff
- [x] 每个 commit 都带 DCO 签名（`git commit -s`，见 [DCO](../DCO)）
- [x] UI 改动已在「UI 变化」注明引用的设计规范章节（不涉及 UI 则跳过）
- [x] 未提交凭证、令牌或授权文件
- [x] 已补充必要文档（本改动无需额外文档）
- [x] 已确认测试结果或说明未执行原因

