### PR TITLE
fix(desktop): 前置检查跳过/失败文案改人话，跳过历史默认折叠

### DIFF
--- a/apps/desktop/src/main/scheduler-host/__tests__/preRunHook.test.ts
+++ b/apps/desktop/src/main/scheduler-host/__tests__/preRunHook.test.ts
@@ -10,7 +10,9 @@
 import { describe, expect, it } from 'vitest';
 
 import {
+  buildSkipResultText,
   executePreRunHook,
+  formatPreRunHookFailure,
   resolvePreRunHookTimeoutMs,
   type PreRunHookStdinPayload,
 } from '../pre-run-hook';
@@ -91,7 +93,7 @@ describe('executePreRunHook', () => {
 
   it('stdout / stderr 分别捕获', async () => {
     const result = await executePreRunHook({
-      command: 'node -e "console.log(\'to-out\');console.error(\'to-err\');process.exit(0)"',
+      command: "node -e \"console.log('to-out');console.error('to-err');process.exit(0)\"",
       stdinPayload: payload,
     });
     expect(result.stdout).toContain('to-out');
@@ -160,6 +162,55 @@ describe('executePreRunHook', () => {
     // 树杀 + 1s 强制 settle 兜底:远小于 60s 超时即返回
     expect(Date.now() - startedAt).toBeLessThan(10_000);
   }, 15_000);
+});
+
+describe('formatPreRunHookFailure', () => {
+  it('失败摘要是人话，不含 pre-run hook', () => {
+    expect(
+      formatPreRunHookFailure({
+        status: 'failed',
+        decision: 'block',
+        exitCode: 1,
+        durationMs: 10,
+        stdout: '',
+        stderr: '',
+        stdoutTruncated: false,
+        stderrTruncated: false,
+        timedOut: false,
+        aborted: false,
+      }),
+    ).toBe('前置检查失败（exit 1）');
+  });
+});
+
+describe('buildSkipResultText', () => {
+  const hook = {
+    status: 'skipped' as const,
+    decision: 'skip' as const,
+    exitCode: 2,
+    durationMs: 125,
+    stdout: '',
+    stderr: '',
+    stdoutTruncated: false,
+    stderrTruncated: false,
+    timedOut: false,
+    aborted: false,
+  };
+
+  it('有 stdout 时用人话全文，不加机器前缀', () => {
+    const text = buildSkipResultText({
+      ...hook,
+      stdout: 'Worktree 跟上轮一致，没清。\n',
+    });
+    expect(text).toBe('Worktree 跟上轮一致，没清。');
+    expect(text).not.toContain('pre-run hook exit');
+  });
+
+  it('空 stdout 时仍给一行人话', () => {
+    const text = buildSkipResultText(hook);
+    expect(text).toContain('本轮跳过');
+    expect(text).not.toContain('pre-run hook exit');
+  });
 });
 
 describe('resolvePreRunHookTimeoutMs(无默认超时)', () => {

--- a/apps/desktop/src/main/scheduler-host/pre-run-hook.ts
+++ b/apps/desktop/src/main/scheduler-host/pre-run-hook.ts
@@ -85,14 +85,9 @@ export type PreRunHookResult = PreRunHookRunResult;
 
 /** 构造 skipped run 的历史摘要，不创建会话或写入消息。 */
 export function buildSkipResultText(hook: PreRunHookResult): string {
-  const head = `pre-run hook exit ${hook.exitCode ?? '?'} — ${hook.durationMs}ms`;
   const out = hook.stdout.trim();
-  return out ? `${head} — ${firstLine(out)}` : head;
-}
-
-function firstLine(text: string): string {
-  const line = text.split(/\r?\n/, 1)[0] ?? '';
-  return line.length > 200 ? `${line.slice(0, 200)}…` : line;
+  if (out) return out;
+  return `本轮跳过（exit ${hook.exitCode ?? '?'}，${hook.durationMs}ms）`;
 }
 
 /** 显式配置的正数才启用超时;未传 / 非法 / ≤0 → undefined(不限时)。 */
@@ -167,9 +162,9 @@ export async function executePreRunHook(input: PreRunHookInput): Promise<PreRunH
         error:
           partial.spawnError ??
           (timedOut
-            ? `pre-run hook timed out after ${timeoutMs ?? 0}ms`
+            ? `前置检查超时（${timeoutMs ?? 0}ms）`
             : !aborted && exitCode === null
-              ? 'pre-run hook exited without a valid result'
+              ? '前置检查没有正常结束'
               : undefined),
       });
     };
@@ -248,7 +243,7 @@ export async function executePreRunHook(input: PreRunHookInput): Promise<PreRunH
 
 /** 给 run 错误、通知和日志共用的前置检查失败摘要。 */
 export function formatPreRunHookFailure(result: PreRunHookResult): string {
-  if (result.status === 'timed_out') return result.error ?? 'pre-run hook timed out';
-  if (result.error) return `pre-run hook failed: ${result.error}`;
-  return `pre-run hook failed with exit code ${result.exitCode ?? 'unknown'}`;
+  if (result.status === 'timed_out') return result.error ?? '前置检查超时';
+  if (result.error) return `前置检查失败：${result.error}`;
+  return `前置检查失败（exit ${result.exitCode ?? 'unknown'}）`;
 }

--- a/apps/desktop/src/renderer/features/scheduler/components/RunHistoryCard.tsx
+++ b/apps/desktop/src/renderer/features/scheduler/components/RunHistoryCard.tsx
@@ -67,9 +67,13 @@ function StatusChip({ status }: { status: RunStatus }) {
 }
 
 /** 单轮前置检查摘要与完整诊断。异常/跳过默认展开，通过默认折叠。 */
-function PreRunHookResultDetails({ result }: { result: NonNullable<ScheduleRun['preRunHookResult']> }) {
+function PreRunHookResultDetails({
+  result,
+}: {
+  result: NonNullable<ScheduleRun['preRunHookResult']>;
+}) {
   const { t } = useTranslation();
-  const defaultOpen = result.status !== 'passed';
+  const defaultOpen = result.status !== 'passed' && result.status !== 'skipped';
   const outputSections = [
     { key: 'stdout', value: result.stdout, truncated: result.stdoutTruncated },
     { key: 'stderr', value: result.stderr, truncated: result.stderrTruncated },
@@ -136,13 +140,7 @@ interface Props {
   sessionReference?: SessionReference;
 }
 
-export function RunHistoryCard({
-  run,
-  agentKind,
-  onDelete,
-  onRestart,
-  sessionReference,
-}: Props) {
+export function RunHistoryCard({ run, agentKind, onDelete, onRestart, sessionReference }: Props) {
   const { t } = useTranslation();
   const navigate = useNavigate();
   const isLegacySessionRun = run.id.startsWith(LEGACY_SESSION_RUN_ID_PREFIX);

--- a/apps/desktop/src/renderer/features/scheduler/components/__tests__/RunHistoryCard.test.tsx
+++ b/apps/desktop/src/renderer/features/scheduler/components/__tests__/RunHistoryCard.test.tsx
@@ -105,6 +105,32 @@ describe('RunHistoryCard 前置检查结果', () => {
     expect(screen.getByText('captured stderr')).toBeTruthy();
     expect(screen.getByText(/scheduler\.runs\.preRun\.truncated/)).toBeTruthy();
   });
+
+  it('跳过结果默认折叠，避免空转把 hook 全文糊在卡上', () => {
+    const { container } = renderRun({
+      id: 'run-skipped',
+      scheduleId: 'schedule-1',
+      firedAt: 1,
+      finishedAt: 11,
+      status: 'skipped',
+      readAt: 11,
+      resultText: 'Worktree 跟上轮一致，没清。',
+      preRunHookResult: {
+        status: 'skipped',
+        decision: 'skip',
+        exitCode: 2,
+        durationMs: 125,
+        stdout: 'Worktree 跟上轮一致，没清。',
+        stderr: '',
+        stdoutTruncated: false,
+        stderrTruncated: false,
+        timedOut: false,
+        aborted: false,
+      },
+    });
+
+    expect(container.querySelector('details')?.open).toBe(false);
+  });
 });
 
 describe('RunHistoryCard 费用展示', () => {


### PR DESCRIPTION
## 这次改了什么

### 摘要

定时任务空转时，运行历史会把 `pre-run hook exit 2 — 125ms` 这类机器句糊在卡片上，跳过结果还默认展开。前置检查的跳过摘要改成脚本自己的人话全文；失败/超时改成「前置检查失败/超时」。跳过详情默认折叠，失败仍展开。

### 变更类型

- [x] `fix` 缺陷修复

### 范围

- 关联 Issue / 需求：无
- 本 PR 包含：`buildSkipResultText` / `formatPreRunHookFailure` 人话摘要；`RunHistoryCard` 对 skipped 默认折叠
- 明确不包含：前置检查协议、调度执行路径、脚本能力
- 用户可见变化：调度运行历史上，跳过轮次不再默认展开 hook 详情，摘要不再出现 `pre-run hook exit`
- 是否存在 breaking change：无

### UI 变化

- 引用的设计规范：不涉及：只改 `RunHistoryCard` 里 skipped 详情的默认展开，以及历史摘要字符串；无新布局、无新组件、无新文案 token。

## 怎么验证的

### 自动验证

```text
pnpm --filter desktop exec vitest run src/main/scheduler-host/__tests__/preRunHook.test.ts src/renderer/features/scheduler/components/__tests__/RunHistoryCard.test.tsx
结果：29 passed

pnpm --filter desktop run typecheck
结果：通过
```

`pnpm test:unit:related` 还扫到无关的 `updateService.test.ts` 一条 5s 超时；单独重跑该用例通过，与本次 4 个文件无关。

### 手工验证

不涉及。

### 未执行的验证

未跑完整 `pnpm test:unit`（related 被无关超时打断；已用定点单测 + typecheck 覆盖本次改动）。

## 风险

### 风险分类

- [x] 其他：调度运行历史文案/折叠态

### 影响与回滚

只影响前置检查跳过/失败时用户看见的摘要和详情默认展开。回滚本 PR 即可。