### PR TITLE
fix(computer): 修复窗口观测失败被误报成功

### DIFF
--- a/packages/lizi-mcps/src/computer/server.ts
+++ b/packages/lizi-mcps/src/computer/server.ts
@@ -376,6 +376,22 @@ export function createComputerMcpServer(
         parsedArgs,
         callContext,
       );
+      if (
+        name === 'get_window_state' &&
+        isUnavailableWindowObservation(data, parsedData.capture_mode)
+      ) {
+        invalidateWindowSnapshot(name, parsedData, sessionId);
+        return textResult(
+          {
+            ok: false,
+            tool: name,
+            errorCode: 'CUA_UNAVAILABLE',
+            hint: 'The requested window observation failed. Do not reuse earlier snapshot IDs, element indices or coordinates. Check status/check_permissions and refresh list_windows for the target; after the window or capture state recovers, call get_window_state again. Repeated capture failure requires recovery before further actions.',
+            data,
+          },
+          true,
+        );
+      }
       const snapshotId = recordWindowSnapshot(name as ComputerMcpToolName, parsedData, data, sessionId);
       return textResult({
         ok: true,
@@ -384,6 +400,7 @@ export function createComputerMcpServer(
         data,
       });
     } catch (err) {
+      invalidateWindowSnapshot(name, parsedData, sessionId);
       return textResult(
         {
           ok: false,
@@ -392,6 +409,20 @@ export function createComputerMcpServer(
         },
         true,
       );
+    }
+  }
+
+  function invalidateWindowSnapshot(
+    name: string,
+    args: Record<string, unknown>,
+    sessionId: string | undefined,
+  ): void {
+    if (
+      name === 'get_window_state' &&
+      typeof args.pid === 'number' &&
+      typeof args.window_id === 'number'
+    ) {
+      snapshotTracker.invalidate(sessionId, args.pid, args.window_id);
     }
   }
 
@@ -957,6 +988,31 @@ export function createComputerMcpServer(
   }
 
   return server;
+}
+
+/** Only explicit driver failure signals override legacy/partial observation success. */
+function isUnavailableWindowObservation(
+  data: unknown,
+  captureMode: unknown,
+): boolean {
+  if (!data || typeof data !== 'object' || Array.isArray(data)) return false;
+  const state = data as Record<string, unknown>;
+  if (state.ok === false || state.isError === true) return true;
+  const screenshotFailed =
+    state.screenshot_frame_valid === false ||
+    (state.screenshot_error !== undefined && state.screenshot_error !== null);
+  const hasElements =
+    Array.isArray(state.elements) && state.elements.length > 0;
+  const hasTree =
+    typeof state.tree_markdown === 'string' &&
+    state.tree_markdown.trim().length > 0;
+  const axUnavailable = state.degraded === true && !hasElements && !hasTree;
+  // A screenshot explicitly requested by vision/SOM cannot be replaced by an AX tree.
+  // Conversely, a valid vision-only result may have no AX surface or input route.
+  if (captureMode === 'vision' || captureMode === 'som')
+    return screenshotFailed;
+  if (captureMode === 'ax') return axUnavailable;
+  return screenshotFailed && axUnavailable;
 }
 
 function readDriverSnapshotId(data: unknown): string | null {

--- a/packages/lizi-mcps/src/computer/snapshot-tracker.ts
+++ b/packages/lizi-mcps/src/computer/snapshot-tracker.ts
@@ -84,6 +84,15 @@ export class WindowSnapshotTracker {
     return id;
   }
 
+  /** A failed observation invalidates earlier IDs and aliases without issuing a usable ID. */
+  invalidate(
+    sessionId: string | undefined,
+    pid: number,
+    windowId: number,
+  ): void {
+    this.latestByWindow.delete(this.windowKey(sessionId ?? '', pid, windowId));
+  }
+
   /** Register a host/driver snapshot id as an alias for the MCP-level guard id. */
   registerAlias(snapshotId: string, alias: string): void {
     const meta = this.metaById.get(snapshotId);

--- a/packages/lizi-mcps/src/computer/snapshotGuard.test.ts
+++ b/packages/lizi-mcps/src/computer/snapshotGuard.test.ts
@@ -31,6 +31,7 @@ async function makeHarness(deps: ComputerMcpDeps, options?: Parameters<typeof cr
     textPayload(await client.callTool({ name: 'call_tool', arguments: { name, args } }));
   return {
     call,
+    client,
     cleanup: async () => {
       await client.close();
       await server.close();
@@ -298,8 +299,182 @@ describe('computer snapshot guard', () => {
     const h = await makeHarness(deps, { sessionId: 'sess-1' });
 
     const observed = await h.call('get_window_state', { pid: 100, window_id: 1 });
-    expect(observed.ok).toBe(true);
+    expect(observed.ok).toBe(false);
+    expect(observed.errorCode).toBe('CUA_UNAVAILABLE');
     expect(observed).not.toHaveProperty('snapshot_id');
     await h.cleanup();
   });
+  const failedCapture = {
+    degraded: true,
+    degraded_reason: 'ax_window_unresolved',
+    elements: [],
+    tree_markdown: '',
+    screenshot_frame_valid: false,
+    screenshot_error: {
+      code: 'px_capture_unavailable',
+      reason: 'ScreenCaptureKit and shell capture failed',
+    },
+    background_input: {
+      routes: [{ route: 'accessibility', status: 'refused' }],
+    },
+  };
+
+  it.each(['returned failure', 'thrown failure'])(
+    'invalidates only the failed window and recovers after a fresh observation: %s',
+    async (failure) => {
+      let fail = false;
+      const callTool = vi.fn(async (name: string) => {
+        if (name === 'get_window_state') {
+          if (fail) {
+            if (failure === 'thrown failure') throw new Error('window gone');
+            return failedCapture;
+          }
+          return { elements: [{ element_token: 'driver-first:0' }] };
+        }
+        return { ok: true };
+      });
+      let sessionId = 's1';
+      const h = await makeHarness(
+        { getStatus: vi.fn(), callTool },
+        {
+          getSessionContext: () => ({
+            sessionId,
+            workingDir: '',
+            agentKind: 'codex',
+          }),
+        },
+      );
+      try {
+        const first = await h.call('get_window_state', {
+          pid: 100,
+          window_id: 1,
+        });
+        const otherWindow = await h.call('get_window_state', {
+          pid: 100,
+          window_id: 2,
+        });
+        sessionId = 's2';
+        const otherSession = await h.call('get_window_state', {
+          pid: 100,
+          window_id: 1,
+        });
+        sessionId = 's1';
+        fail = true;
+        const result = await h.client.callTool({
+          name: 'call_tool',
+          arguments: {
+            name: 'get_window_state',
+            args: { pid: 100, window_id: 1, capture_mode: 'vision' },
+          },
+        });
+        expect(result.isError).toBe(true);
+        const payload = textPayload(result);
+        expect(payload.ok).toBe(false);
+        expect(payload).not.toHaveProperty('snapshot_id');
+        if (failure === 'returned failure')
+          expect(payload.data).toEqual(failedCapture);
+        const dispatchCount = callTool.mock.calls.length;
+        for (const snapshot_id of [first.snapshot_id, 'driver-first']) {
+          expect(
+            await h.call('click', {
+              pid: 100,
+              window_id: 1,
+              element_index: 0,
+              snapshot_id,
+            }),
+          ).toMatchObject({ ok: false, errorCode: 'STALE_SNAPSHOT' });
+        }
+        expect(callTool).toHaveBeenCalledTimes(dispatchCount);
+        expect(
+          await h.call('click', {
+            pid: 100,
+            window_id: 2,
+            element_index: 0,
+            snapshot_id: otherWindow.snapshot_id,
+          }),
+        ).toMatchObject({ ok: true });
+        sessionId = 's2';
+        expect(
+          await h.call('click', {
+            pid: 100,
+            window_id: 1,
+            element_index: 0,
+            snapshot_id: otherSession.snapshot_id,
+          }),
+        ).toMatchObject({ ok: true });
+        sessionId = 's1';
+        fail = false;
+        const recovered = await h.call('get_window_state', {
+          pid: 100,
+          window_id: 1,
+        });
+        expect(
+          await h.call('click', {
+            pid: 100,
+            window_id: 1,
+            element_index: 0,
+            snapshot_id: recovered.snapshot_id,
+          }),
+        ).toMatchObject({ ok: true });
+      } finally {
+        await h.cleanup();
+      }
+    },
+  );
+
+  it.each([
+    { mode: undefined, state: failedCapture, ok: false },
+    {
+      mode: 'vision',
+      state: { ...failedCapture, elements: [{ index: 0 }] },
+      ok: false,
+    },
+    { mode: 'som', state: failedCapture, ok: false },
+    {
+      mode: 'ax',
+      state: { degraded: true, elements: [], tree_markdown: '' },
+      ok: false,
+    },
+    {
+      mode: 'ax',
+      state: { ...failedCapture, elements: [{ index: 0 }] },
+      ok: true,
+    },
+    {
+      mode: undefined,
+      state: { ...failedCapture, tree_markdown: 'Button: Save' },
+      ok: true,
+    },
+    {
+      mode: 'vision',
+      state: {
+        degraded: true,
+        elements: [],
+        screenshot_frame_valid: true,
+        screenshot_file_path: 'state.png',
+      },
+      ok: true,
+    },
+    { mode: undefined, state: { elements: [] }, ok: true },
+  ])(
+    'respects requested observation mode: $mode / ok=$ok',
+    async ({ mode, state, ok }) => {
+      const callTool = vi.fn(async () => state);
+      const h = await makeHarness({ getStatus: vi.fn(), callTool });
+      try {
+        const observed = await h.call('get_window_state', {
+          pid: 100,
+          window_id: 1,
+          capture_mode: mode,
+        });
+        expect(observed.ok).toBe(ok);
+        expect(Boolean(observed.snapshot_id)).toBe(ok);
+        expect(observed.data).toEqual(state);
+        // A failed observation is reported once; the wrapper never replays it or restarts the driver.
+        expect(callTool).toHaveBeenCalledTimes(1);
+      } finally {
+        await h.cleanup();
+      }
+    },
+  );
 });


### PR DESCRIPTION
## 这次改了什么

### 摘要

修复 Computer Use 窗口观测失败仍被 MCP 包装为成功的问题。driver 返回截图不可用、AX 降级且无内容时，包装层现在明确返回错误并保留原始诊断；同时失效该窗口之前的快照，避免后续动作继续使用失效的元素索引或坐标。

按请求的 capture mode 判断失败，保留有效的纯视觉、AX 部分结果及旧版返回值兼容性。不新增自动重试。

### 变更类型

- [ ] `feat` 新功能
- [x] `fix` 缺陷修复
- [ ] `refactor` / `perf` 重构或性能优化
- [ ] `docs` / `test` / `chore` 文档、测试或工程维护
- [ ] 其他：

### 范围

- 关联 Issue / 需求：Computer Use 使用体验巡检发现的窗口观测失败。
- 本 PR 包含：`get_window_state` 失败分类、MCP `isError` 与 `CUA_UNAVAILABLE`、原始诊断透传、返回失败及抛异常时的窗口快照失效、恢复与隔离回归测试。
- 明确不包含：driver 升级、系统权限变更、daemon 自动启动或重启、截图重试、调度配置修改。
- 用户可见变化：Agent 能看到真实失败及恢复建议，不再收到不可用观测的成功包装；旧快照与 driver 别名失效，重新成功观测后恢复使用。
- 是否存在 breaking change：不改输入 schema；纠正失败返回的 `ok`/`isError`，成功与可用部分结果保持兼容。不能以本修复推断底层截图失败已解决；被动 status 的 daemon 状态也不足以证明截图失败原因。

### UI 变化

不涉及；仅修改工具结果与内存快照跟踪。

- 引用的设计规范：不涉及。

## 怎么验证的

### 自动验证

```text
pnpm --filter @cindy/mcps exec vitest run src/computer/snapshotGuard.test.ts src/computer/computerMcpServer.test.ts
结果：2 个文件、75 个测试通过。

pnpm test:unit:related
结果：通过；执行了 Desktop 单测和 lizi-mcps 关联测试。

pnpm --filter @cindy/mcps run --if-present typecheck
结果：退出 0；该包没有 typecheck script，按仓库规则跳过。

git diff --check
结果：通过。
```

额外执行 `pnpm --filter @cindy/mcps exec tsc --noEmit`：未通过，存在 9 条基线类型错误，均在 `sessionControlTools.test.ts` 与 `submitGithubIssueTool.test.ts`。通过 TypeScript compiler API 将本 PR 三个文件替换为基线版本后，在同一依赖环境复核得到相同 9 条错误；改动文件没有类型诊断。不将这一额外检查表述为通过。

回归测试经内存 MCP transport 覆盖真实失败形态：`degraded=true`、空 AX、`screenshot_frame_valid=false`、`px_capture_unavailable`。验证 MCP 错误位、原始诊断、无新快照、旧 ID/别名拒绝、其他窗口及其他 session 不受影响、恢复后可继续动作，以及 capture mode 兼容矩阵。

### 手工验证

已自审完整 diff，并完成独立代码复核。未启动或重启用户 Desktop，未操作系统权限。

### 未执行的验证

未做真实 macOS 截图故障恢复及 Windows 实机验证；此次以 MCP 回归测试验证包装层行为，不声称修复 OS/driver 捕获失败根因。

## 风险

### 风险分类

- [ ] 无已知风险
- [ ] SQLite / migration
- [ ] system prompt
- [x] 协议兼容
- [ ] 权限 / 安全 / 用户数据
- [ ] 存量插件兼容（批准状态 / 指纹 / manifest 校验 / 安装布局 / 包格式）
- [ ] 原生层 / fingerprint / OTA
- [ ] 跨平台差异
- [x] 其他：窗口观测错误与快照失效语义

### 影响与回滚

- 影响范围：`lizi_computer` 的 `get_window_state` 返回结果及该 session/窗口的内存快照。未更改 driver wire schema、权限门禁或持久数据；无平台专属分支。显式 vision/som 请求不能以 AX 结果替代失败截图；默认模式允许仍可用的 AX 结果。
- 回滚 / 降级方式：回退本 PR 即可，无 migration 或用户配置恢复步骤。已有成功结果、旧版空返回和有效部分结果有兼容测试。

### 提交前检查

- [x] 已 review 完整 diff
- [x] 每个 commit 都带 DCO 签名（`git commit -s`，见 [DCO](../DCO)）
- [x] UI 改动已在「UI 变化」注明引用的设计规范章节（不涉及 UI 则跳过）
- [x] 未提交凭证、令牌或授权文件
- [x] 已补充必要文档（行为及恢复边界记录于本 PR；无新增配置）
- [x] 已确认测试结果或说明未执行原因
