### PR TITLE
refactor(maker): 拆分任务绑定与事件生命周期

### DIFF
--- a/apps/desktop/src/main/__tests__/interruptedContinuationContract.test.ts
+++ b/apps/desktop/src/main/__tests__/interruptedContinuationContract.test.ts
@@ -7,6 +7,18 @@ const registerSource = readFileSync(
   resolve(__dirname, '..', 'maker-ipc', 'register.ts'),
   'utf8',
 ).replace(/\r\n?/g, '\n');
+// Retain local characterization guards at the production stages they describe.
+// Cross-stage delivery and recovery timing run in sessionEventPipeline.test.ts.
+const eventSource = [
+  'sessionEventPreparation',
+  'sessionEventStream',
+  'sessionEventDelivery',
+  'sessionEventTerminal',
+]
+  .map((name) => readFileSync(resolve(__dirname, '..', 'maker-ipc', name + '.ts'), 'utf8'))
+  .join('\n')
+  .replace(/\r\n?/g, '\n')
+  .replaceAll('deps.', '');
 const coordinatorSource = readFileSync(
   resolve(__dirname, '..', 'maker-ipc', 'agent-input-coordinator.ts'),
   'utf8',
@@ -90,7 +102,7 @@ describe('interrupted continuation enqueue contract', () => {
     expect(scheduleHook).toMatch(/\(attempt\)\s*=>\s*\{\s*return\s*\(async/);
     expect(scheduleHook).not.toMatch(/void\s*\(async\s*\(\)\s*=>/);
 
-    expect(registerSource).toMatch(/getAutoResumeDeferredOwner\(session\.id\)/);
+    expect(eventSource).toMatch(/getAutoResumeDeferredOwner\(session\.id\)/);
     const ownerDiscardedStart = registerSource.indexOf('onResumableTurnErrorDiscarded:');
     const ownerDiscardedEnd = registerSource.indexOf('onResumableTurnError:', ownerDiscardedStart);
     expect(registerSource.slice(ownerDiscardedStart, ownerDiscardedEnd)).toMatch(
@@ -184,40 +196,25 @@ describe('interrupted continuation enqueue contract', () => {
   });
 
   it('retires an interrupted attempt owner after both done and terminal error settlement', () => {
-    const doneStart = registerSource.indexOf('const doneAttemptToken = event.turnAttemptToken;');
-    const doneEnd = registerSource.indexOf('const isSilentStopDone', doneStart);
+    const doneStart = eventSource.indexOf('const doneAttemptToken = event.turnAttemptToken;');
+    const doneEnd = eventSource.indexOf('const isSilentStopDone', doneStart);
     expect(doneStart).toBeGreaterThan(-1);
     expect(doneEnd).toBeGreaterThan(doneStart);
-    expect(registerSource.slice(doneStart, doneEnd)).toMatch(
+    expect(eventSource.slice(doneStart, doneEnd)).toMatch(
       /autoResumeBookkeeping\.settleOutcome\(session\.id, doneAttemptToken, 'failed'\);\s*interruptedTurnAutoResumeGuard\.noteAttemptSettled\(session\.id, doneAttemptToken\);/,
     );
 
-    const errorStart = registerSource.indexOf('const failedAttemptToken = event.turnAttemptToken;');
-    const errorEnd = registerSource.indexOf('// 终止型 error 可能没有后续 status/done', errorStart);
+    const errorStart = eventSource.indexOf('const failedAttemptToken = event.turnAttemptToken;');
+    const errorEnd = eventSource.indexOf('// 终止型 error 可能没有后续 status/done', errorStart);
     expect(errorStart).toBeGreaterThan(-1);
     expect(errorEnd).toBeGreaterThan(errorStart);
-    expect(registerSource.slice(errorStart, errorEnd)).toMatch(
+    expect(eventSource.slice(errorStart, errorEnd)).toMatch(
       /autoResumeBookkeeping\.settleOutcome\(session\.id, failedAttemptToken, 'failed'\);\s*interruptedTurnAutoResumeGuard\.noteAttemptSettled\(session\.id, failedAttemptToken\);/,
     );
   });
 
-  it('keeps background substantive events out of interrupted-turn progress bookkeeping', () => {
-    const progressStart = registerSource.indexOf(
-      "if (event.turnScope !== 'background' && isSubstantiveProgressEvent(event))",
-    );
-    expect(progressStart).toBeGreaterThan(-1);
-    const progressEnd = registerSource.indexOf(
-      "\n      }\n      if (event.type === 'text')",
-      progressStart,
-    );
-    expect(progressEnd).toBeGreaterThan(progressStart);
-    const progressBlock = registerSource.slice(progressStart, progressEnd);
-    expect(progressBlock).toContain('interruptedTurnAutoResumeGuard.noteProgress(');
-    expect(registerSource.indexOf('onToolUseEvent(', progressEnd)).toBeGreaterThan(progressEnd);
-    expect(
-      registerSource.indexOf('broadcastToAllWindows(MAKER_PUSH.EVENT', progressEnd),
-    ).toBeGreaterThan(progressEnd);
-  });
+  // Foreground/background progress ordering runs through the production pipeline
+  // in sessionEventPipeline.test.ts.
 
   it('advertises interval null-clear support for mobile wire compatibility', () => {
     expect(registerSource).toMatch(/supportsScheduleIntervalNullClear:\s*true/);
@@ -298,36 +295,35 @@ describe('interrupted continuation enqueue contract', () => {
   });
 
   it('defers Orca worker terminal while auto-resume owns the failure, and finalizes on surface', () => {
-    const persistStart = registerSource.indexOf('const autoResumeSuppressesPersist =');
-    const persistEnd = registerSource.indexOf('const overflowClaim =', persistStart);
+    const persistStart = eventSource.indexOf('const autoResumeSuppressesPersist =');
+    const persistEnd = eventSource.indexOf('const overflowClaim =', persistStart);
     expect(persistStart).toBeGreaterThan(-1);
     expect(persistEnd).toBeGreaterThan(persistStart);
-    const persistBlock = registerSource.slice(persistStart, persistEnd);
-    expect(persistBlock).toMatch(/isAutoResumePending\(session\.id\) === true/);
-    expect(persistBlock).toMatch(/isAutoResumeDeferred\(session\.id\) === true/);
-    expect(registerSource).toMatch(/let deferredOrcaWorkerTerminal = false/);
+    const persistBlock = eventSource.slice(persistStart, persistEnd);
+    expect(persistBlock).toContain('isSessionErrorSuppressed(');
+    expect(eventSource).toMatch(/let deferredOrcaWorkerTerminal = false/);
 
-    const stashStart = registerSource.indexOf('if (autoResumeSuppressesPersist) {');
-    const stashEnd = registerSource.indexOf(
+    const stashStart = eventSource.indexOf('if (autoResumeSuppressesPersist) {');
+    const stashEnd = eventSource.indexOf(
       "} else if (event.type === 'error' && isTerminalTurnErrorEvent(event)) {",
       stashStart,
     );
     expect(stashStart).toBeGreaterThan(-1);
     expect(stashEnd).toBeGreaterThan(stashStart);
-    const stashBlock = registerSource.slice(stashStart, stashEnd);
+    const stashBlock = eventSource.slice(stashStart, stashEnd);
     expect(stashBlock).toMatch(/autoResumeBookkeeping\.stashSuppressedError\(/);
     expect(stashBlock).toMatch(
       /deferredOrcaWorkerTerminal = autoResumeBookkeeping\.stashOrcaSuppressedTerminal\(/,
     );
     expect(stashBlock).toMatch(/capture:\s*workerTerminalCapture/);
 
-    const terminalStart = registerSource.indexOf(
+    const terminalStart = eventSource.indexOf(
       '// Worker turn 结束后交给 OrcaTeamService 处理 DB status、广播与 auto-bridge。',
     );
-    const terminalEnd = registerSource.indexOf('if (pendingContextSnapshot)', terminalStart);
+    const terminalEnd = eventSource.indexOf('return { turnAssistantPersistId }', terminalStart);
     expect(terminalStart).toBeGreaterThan(-1);
     expect(terminalEnd).toBeGreaterThan(terminalStart);
-    const terminalBlock = registerSource.slice(terminalStart, terminalEnd);
+    const terminalBlock = eventSource.slice(terminalStart, terminalEnd);
     expect(terminalBlock).toMatch(/shouldSkipOrcaWorkerTerminal\(\{/);
     expect(terminalBlock).toMatch(/stashedThisErrorEvent:\s*deferredOrcaWorkerTerminal/);
     expect(terminalBlock).toMatch(/isPairedFailedTurnDone/);
@@ -342,18 +338,18 @@ describe('interrupted continuation enqueue contract', () => {
     expect(terminalBlock).toMatch(/isAutoResumeDeferred:/);
     expect(terminalBlock).toMatch(/handleWorkerTerminalTurn\(/);
 
-    expect(registerSource).toMatch(
+    expect(eventSource).toMatch(
       /noteFailedTurnCompletionTail\(\s*session\.id,\s*event\.sessionTurnGeneration/,
     );
-    const noteTailStart = registerSource.indexOf(
+    const noteTailStart = eventSource.indexOf(
       'autoResumeBookkeeping.noteFailedTurnCompletionTail(',
     );
     expect(noteTailStart).toBeGreaterThan(-1);
-    const persistIdIf = registerSource.lastIndexOf('if (turnAssistantPersistId)', noteTailStart);
-    const persistIdIfEnd = registerSource.indexOf('}', persistIdIf);
+    const persistIdIf = eventSource.lastIndexOf('if (turnAssistantPersistId)', noteTailStart);
+    const persistIdIfEnd = eventSource.indexOf('}', persistIdIf);
     expect(persistIdIf).toBeGreaterThan(-1);
     expect(noteTailStart).toBeGreaterThan(persistIdIfEnd);
-    expect(registerSource.slice(persistIdIf, persistIdIfEnd)).not.toMatch(
+    expect(eventSource.slice(persistIdIf, persistIdIfEnd)).not.toMatch(
       /noteFailedTurnCompletionTail/,
     );
 
@@ -378,7 +374,7 @@ describe('interrupted continuation enqueue contract', () => {
     expect(automaticEnqueueHook).not.toMatch(/clearFailedTurnCompletionTail/);
     expect(automaticEnqueueHook).not.toMatch(/consumeFailedTurnCompletionTail/);
 
-    expect(registerSource).toMatch(
+    expect(eventSource).toMatch(
       /if \(typeof event\.turnAttemptToken === 'number'\) \{\s*autoResumeBookkeeping\.clearFailedTurnCompletionTail\(session\.id\);/,
     );
 

--- a/apps/desktop/src/main/__tests__/makerEventHotPathOrdering.test.ts
+++ b/apps/desktop/src/main/__tests__/makerEventHotPathOrdering.test.ts
@@ -1,9 +1,9 @@
 /**
  * makerEventHotPathOrdering.test.ts
  * ---------------------------------------------------------------------------
- * maker:event 是每个 agent 事件都会经过的 main→renderer hot path。这里用源码
- * 契约守住顺序：先把事件广播给 renderer，再做 usage/context 这类同步 SQLite
- * 或额外广播 side effect，避免 turn 结束时把 final/done 送达延后。
+ * Remaining production wiring and pricing characterization guards. Event ordering,
+ * failure ownership and provider admission run as behavioral tests in
+ * maker-ipc/__tests__/sessionEventPipeline.test.ts.
  */
 
 import { readFileSync } from 'node:fs';
@@ -12,6 +12,7 @@ import { describe, expect, it } from 'vitest';
 
 const sourcePath = resolve(__dirname, '..', 'maker-ipc', 'register.ts');
 const source = readFileSync(sourcePath, 'utf8').replace(/\r\n?/g, '\n');
+const registerSource = source;
 const usageSourcePath = resolve(__dirname, '..', 'maker-ipc', 'usage.ts');
 const usageSource = readFileSync(usageSourcePath, 'utf8').replace(/\r\n?/g, '\n');
 const hookControlSourcePath = resolve(__dirname, '..', 'hook-control', 'ipc.ts');
@@ -27,6 +28,8 @@ describe('maker:event hot path ordering', () => {
       source.indexOf('function redactEventForRenderer'),
       source.indexOf('\nfunction ', source.indexOf('function redactEventForRenderer') + 1),
     );
+    expect(redactor).toContain('delete rendererEvent.sessionTurnGeneration;');
+    expect(redactor).toContain('delete rendererEvent.sessionInstanceId;');
     for (const key of [
       'subagentObservation',
       'returnedResult',
@@ -40,17 +43,19 @@ describe('maker:event hot path ordering', () => {
   it('rewires a replacement Session instance that retains the same business id', () => {
     const wireSessionSource = extractWireSessionSource();
 
-    expect(source).toContain(
-      'const wiredSessionsById = new Map<string, WiredSessionRegistration>();',
+    // Instance ownership and teardown failures are exercised by
+    // sessionBindingLifecycle.test.ts; retain the production adapter wiring guard.
+    expect(wireSessionSource).toContain(
+      'const registration = sessionBindings.beginBinding(session);',
     );
-    expect(wireSessionSource).toContain('if (existing?.session === session)');
-    expect(wireSessionSource).toContain('for (const dispose of existing.disposers) dispose();');
-    expect(wireSessionSource).toContain('existing.session.setInteractionListener(null);');
+    expect(wireSessionSource).toContain('if (!registration) return;');
     expect(wireSessionSource).toMatch(
       /registration\.disposers\.push\(\s*session\.onEvent\(\(event: AgentEvent\) => \{/,
     );
-    expect(wireSessionSource).toMatch(
-      /registration\.disposers\.push\(\s*session\.onStatusChange\(\(status\) => \{/,
+    expectOrder(
+      wireSessionSource,
+      'sessionBindings.attachStatusListener(registration);',
+      'installDesktopInteractionListener(session);',
     );
     // #1286:拆线(实例替换 / 会话关闭)必须给插件补 did-turn-end,否则订阅方的
     // 「AI 在忙」外层状态永久卡在 working,除重启没有自愈手段。同一个 disposer 里
@@ -61,143 +66,70 @@ describe('maker:event hot path ordering', () => {
       wireSessionSource.lastIndexOf('registration.disposers.push(', tapDisposerIndex),
     ).toBeGreaterThanOrEqual(0);
     expect(wireSessionSource).toContain('installInteractionLifecycleObserver(session, null);');
-  });
-
-  it('runs the paid-model fence in the shared Session lifecycle boundary', () => {
-    const wireSessionSource = extractWireSessionSource();
-    const observerStart = wireSessionSource.indexOf('session.setTurnLifecycleObserver({');
-    const observerEnd = wireSessionSource.indexOf('\n  });', observerStart);
-    const observerSource = wireSessionSource.slice(observerStart, observerEnd);
-
-    expect(observerStart).toBeGreaterThanOrEqual(0);
-    expect(observerEnd).toBeGreaterThan(observerStart);
-    expect(observerSource).toContain('await verdictForModelRoute(');
-    expect(observerSource).toContain(
-      "if (verdict.kind === 'reroute' && verdict.reason === 'payment-required')",
-    );
-    expect(observerSource).toContain("verdict.reason === 'payment-required'");
-    expectOrder(
-      observerSource,
-      'await verdictForModelRoute(',
-      'sessionTurnLeaseTracker.markTurnStarted(',
-    );
-    expectOrder(
-      observerSource,
-      "if (verdict.kind === 'reroute' && verdict.reason === 'payment-required')",
-      'sessionTurnLeaseTracker.markTurnStarted(',
-    );
-  });
-
-  it('rejects a fenced leftover terminal before register-side turn effects', () => {
-    expect(source).toContain('delete rendererEvent.sessionTurnGeneration');
-    expect(source).toContain('delete rendererEvent.sessionInstanceId');
-    const wireSessionSource = extractWireSessionSource();
     expectOrder(
       wireSessionSource,
-      'isFencedStaleSessionTerminal(session.id, event)',
+      'if (isFencedStaleSessionTerminal(session.id, event)) return;',
       'ghostSessionTap.handleEvent(',
     );
-    expectOrder(
-      wireSessionSource,
-      'isFencedStaleSessionTerminal(session.id, event)',
-      'consumeClaudeOpusPlanMismatch(',
-    );
-    expectOrder(
-      wireSessionSource,
-      'isFencedStaleSessionTerminal(session.id, event)',
-      'finalizeTurnChangeSet(',
-    );
-    expectOrder(
-      wireSessionSource,
-      'isFencedStaleSessionTerminal(session.id, event)',
-      'shouldMarkTurnStatusIdleAfterBroadcast = true',
-    );
   });
 
-  it('broadcasts EVENT before usage/context/island/idle side effects', () => {
-    const wireSessionSource = extractWireSessionSource();
-
-    const broadcastIndex = wireSessionSource.indexOf('broadcastToAllWindows(MAKER_PUSH.EVENT');
-    expect(broadcastIndex).toBeGreaterThanOrEqual(0);
-
-    for (const sideEffect of [
-      'recordSessionContextSnapshot(',
-      'recordCodexAccountUsageSnapshot(',
-      'recordTurnSpend(',
-      'recordSessionTurnSpend(',
-      'recordCodexTurnUsage(',
-      'handleAgentIslandEventAfterBroadcast(',
-      'sessionTurnActivityTracker.scheduleIdleAfterStatusBroadcast(',
-      'sessionTurnActivityTracker.scheduleIdleAfterTerminalBroadcast(',
+  it('keeps the remaining runtime close adapter in its original domain order', () => {
+    const start = source.indexOf('function cleanupClosedSessionRuntime(');
+    const end = source.indexOf('\n}\n', start);
+    expect(start).toBeGreaterThan(-1);
+    const body = source.slice(start, end);
+    let previous = -1;
+    for (const call of [
+      'pendingCredentialSwitchHolder?.onSessionClosed(',
+      'deferredCodexRestartHolder?.onSessionSettled(',
+      'agentInputCoordinatorHolder?.onExternalTurnSettled(',
+      'refreshRemoteCodexMcpOnTurnSettledHolder?.(',
+      'gitSnapshotCoordinator?.onSessionClosed(',
+      'clearOrcaMcpHydrated(',
+      'knownNonOrcaSessionIds.delete(',
+      'lastReportedCostUsdBySession.delete(',
+      'lastReportedModelUsageBySession.delete(',
+      'turnModelPromiseBySession.delete(',
+      'turnPiFastModeBySession.delete(',
+      'productTurnWallClockTracker.clear(',
+      'productTurnUsageTargetTracker.clear(',
+      'claudeOutputLagTimingGuard.clear(',
+      'clearClaudeSessionBackgroundActivity(',
+      'clearSessionPersistState(',
+      'clearSubagentObservationRewindState(',
+      'handleAgentIslandSessionClosedAfterCleanup(',
     ]) {
-      const indices = [...wireSessionSource.matchAll(new RegExp(escapeRegExp(sideEffect), 'g'))]
-        .map((match) => match.index)
-        .filter((index): index is number => typeof index === 'number');
-      expect(indices.length, `${sideEffect} should be present`).toBeGreaterThan(0);
-      expect(
-        indices.every((index) => index > broadcastIndex),
-        `${sideEffect} must be after EVENT broadcast`,
-      ).toBe(true);
+      const index = body.indexOf(call);
+      expect(index, call).toBeGreaterThan(previous);
+      previous = index;
     }
-    expect(wireSessionSource.slice(0, broadcastIndex)).not.toContain(
-      'handleAgentEvent(sessionMetaForIsland',
-    );
   });
+  // runs the paid-model fence in the shared Session lifecycle boundary: covered by the executable sessionEventPipeline tests.
 
-  it('tracks Claude wall clock across continuation segments and only consumes it at product completion', () => {
-    const wireSessionSource = extractWireSessionSource();
+  // rejects a fenced leftover terminal before register-side turn effects: covered by the executable sessionEventPipeline tests.
 
-    expect(wireSessionSource).toContain(
-      'const startedProductTurn = productTurnWallClockTracker.start(session.id);',
+  // broadcasts EVENT before usage/context/island/idle side effects: covered by the executable sessionEventPipeline tests.
+
+  // tracks Claude wall clock across continuation segments and only consumes it at product completion: covered by the executable sessionEventPipeline tests.
+  it('preserves the product clock before a silent-stop continuation can emit running', () => {
+    const start = source.indexOf('async function handleSilentStopTurnEnd(');
+    const continuation = source.slice(start, source.indexOf('\nfunction ', start + 1));
+    expectOrder(
+      continuation,
+      'productTurnWallClockTracker.preserveForContinuation(session.id);',
+      'const sendResult = await session.send(',
     );
-    expect(wireSessionSource).toContain(
-      'if (startedProductTurn) productTurnUsageTargetTracker.clear(session.id);',
-    );
-    expect(source).toMatch(
-      /decision\.action === 'resume'[\s\S]*?productTurnWallClockTracker\.preserveForContinuation\(session\.id\);[\s\S]*?await session\.send\(/,
-    );
-    expect(wireSessionSource).toMatch(
-      /event\.source === 'claude-code'\s*&&\s*!isContinuationBoundary\s*&&\s*!isSilentStopDone[\s\S]*?productTurnWallClockTracker\.finish\(session\.id\)/,
-    );
-    expect(wireSessionSource).toContain(
-      'const claudeTurnDurationMs =\n          completedTurnWallClockMs ??',
-    );
-    expect(wireSessionSource.match(/claudeTurnDurationMs,/g)).toHaveLength(3);
   });
 
   it('uses the assistant API message id as Vertex output-lag evidence', () => {
-    const wireSessionSource = extractWireSessionSource();
+    const wireSessionSource = readEventModule('sessionClaudeTurnUsage');
 
     expect(wireSessionSource).toContain('assistant_message_id?: unknown;');
     expect(wireSessionSource).toContain("typeof doneData?.assistant_message_id === 'string'");
     expect(wireSessionSource).toContain('? doneData.assistant_message_id');
     expect(wireSessionSource).toContain('doneData?.is_error !== true');
   });
-
-  it('wakes deferred Goal resumes from the shared product-terminal idle boundary', () => {
-    const wireSessionSource = extractWireSessionSource();
-    const broadcastIndex = wireSessionSource.indexOf('broadcastToAllWindows(MAKER_PUSH.EVENT');
-    const terminalIdleStart = wireSessionSource.indexOf(
-      'if (shouldMarkTurnTerminalIdleAfterBroadcast) {',
-      broadcastIndex,
-    );
-    const terminalIdleEnd = wireSessionSource.indexOf(
-      '} else if (shouldMarkTurnStatusIdleAfterBroadcast) {',
-      terminalIdleStart,
-    );
-    const terminalIdleBlock = wireSessionSource.slice(terminalIdleStart, terminalIdleEnd);
-
-    expect(terminalIdleStart).toBeGreaterThan(broadcastIndex);
-    expect(terminalIdleEnd).toBeGreaterThan(terminalIdleStart);
-    expectOrder(
-      terminalIdleBlock,
-      'sessionTurnActivityTracker.scheduleIdleAfterTerminalBroadcast(session.id);',
-      'notifyGoalIdleAfterTurnSettled(session.id);',
-    );
-    expect([
-      ...terminalIdleBlock.matchAll(/notifyGoalIdleAfterTurnSettled\(session\.id\);/g),
-    ]).toHaveLength(1);
-  });
+  // wakes deferred Goal resumes from the shared product-terminal idle boundary: covered by the executable sessionEventPipeline tests.
 
   it('wakes deferred Goal resumes after direct-abort and authoritative-idle reconciliation', () => {
     const observerHelperStart = source.indexOf('function notifyGoalIdleAfterTurnSettled(');
@@ -272,45 +204,12 @@ describe('maker:event hot path ordering', () => {
     expect(coordinatorSource).toContain("if (lookup.status === 'missing') return false;");
     expect(coordinatorSource).toContain("return lookup.status === 'found';");
   });
+  // does not latch product-turn bookkeeping on background status events: covered by the executable sessionEventPipeline tests.
 
-  it('does not latch product-turn bookkeeping on background status events', () => {
-    const statusStart = source.indexOf("if (event.type === 'status') {");
-    const statusEnd = source.indexOf("if (event.type === 'done')", statusStart);
-    const statusSource = source.slice(statusStart, statusEnd);
-    expect(statusStart).toBeGreaterThanOrEqual(0);
-    expect(statusEnd).toBeGreaterThan(statusStart);
-    expect(statusSource).toContain("data.isRunning === true && event.turnScope !== 'background'");
-    expect(statusSource).toContain("event.turnScope !== 'background'");
-    expect(statusSource).toContain(
-      'sessionTurnActivityTracker.setSessionInTurn(session.id, data.isRunning)',
-    );
-  });
-
-  it('persists a terminal Codex plan before clearing its turn-owned lookup maps', () => {
-    const wireSessionSource = extractWireSessionSource();
-    const persistIndex = wireSessionSource.indexOf('persistCodexPlanOnDone(');
-    const barrierIndex = wireSessionSource.indexOf(
-      'markTurnEndedAfterPersistDrain(session.id);',
-      persistIndex,
-    );
-    const resetIndex = wireSessionSource.indexOf(
-      'resetTurnPersistState(session.id);',
-      barrierIndex,
-    );
-
-    expect(persistIndex).toBeGreaterThanOrEqual(0);
-    expect(barrierIndex).toBeGreaterThan(persistIndex);
-    expect(resetIndex).toBeGreaterThan(barrierIndex);
-    expect(wireSessionSource.slice(persistIndex - 800, persistIndex)).toContain(
-      'isContinuationBoundary',
-    );
-    expect(wireSessionSource.slice(persistIndex - 500, persistIndex)).toContain(
-      '!isContinuationBoundary',
-    );
-  });
+  // persists a terminal Codex plan before clearing its turn-owned lookup maps: covered by the executable sessionEventPipeline tests.
 
   it('defers remote auth island errors until the renderer reports retry failure', () => {
-    const wireSessionSource = extractWireSessionSource();
+    const wireSessionSource = readEventModule('sessionEventPreparation');
     const deferredHandler = source.match(
       /ipcMain\.handle\(\s*MAKER_INVOKE\.PERSIST_TURN_ERROR_DEFERRED,[\s\S]*?\n\s*\}\);/,
     )?.[0];
@@ -339,6 +238,7 @@ describe('maker:event hot path ordering', () => {
   });
 
   it('keeps auto-resume-owned terminal errors out of Agent Island until they are final', () => {
+    const source = registerSource + readEventModule('sessionEventTerminal');
     const handler = source.match(
       /function handleAgentIslandEventAfterBroadcast\([\s\S]*?\n}\n\nfunction surfaceSuppressedAutoResumeErrorInAgentIsland/,
     )?.[0];
@@ -405,92 +305,14 @@ describe('maker:event hot path ordering', () => {
       'hasSuppressedError: autoResumeBookkeeping.hasSuppressedError(session.id)',
     );
   });
+  // only status/done/error paths request idle restore: covered by the executable sessionEventPipeline tests.
 
-  it('only status/done/error paths request idle restore', () => {
-    const wireSessionSource = extractWireSessionSource();
-    const statusIdleAssignments = [
-      ...wireSessionSource.matchAll(/shouldMarkTurnStatusIdleAfterBroadcast = true;/g),
-    ]
-      .map((match) => match.index)
-      .filter((index): index is number => typeof index === 'number');
-    const terminalIdleAssignments = [
-      ...wireSessionSource.matchAll(/shouldMarkTurnTerminalIdleAfterBroadcast = true;/g),
-    ]
-      .map((match) => match.index)
-      .filter((index): index is number => typeof index === 'number');
+  // does not persist remote Codex account snapshots into local account usage: covered by the executable sessionEventPipeline tests.
 
-    expect(statusIdleAssignments).toHaveLength(1);
-    expect(terminalIdleAssignments).toHaveLength(2);
-
-    // 回看窗口要盖住赋值点与所属 if 条件之间的声明/注释(done 分支里 silent-stop
-    // 的 isSilentStopDone 判定 + 设计注释就有 ~500 字符),太窄会把仍在正确分支内的
-    // 赋值误判成"脱离 done 路径"。
-    const CONTEXT_LOOKBACK = 1_400;
-    const statusContexts = statusIdleAssignments.map((index) =>
-      wireSessionSource.slice(
-        Math.max(0, index - CONTEXT_LOOKBACK),
-        index + 'shouldMarkTurnStatusIdleAfterBroadcast = true;'.length,
-      ),
-    );
-    const terminalContexts = terminalIdleAssignments.map((index) =>
-      wireSessionSource.slice(
-        Math.max(0, index - CONTEXT_LOOKBACK),
-        index + 'shouldMarkTurnTerminalIdleAfterBroadcast = true;'.length,
-      ),
-    );
-
-    expect(statusContexts.some((context) => context.includes('data.isRunning === false'))).toBe(
-      true,
-    );
-    expect(terminalContexts.some((context) => context.includes("event.type === 'done'"))).toBe(
-      true,
-    );
-    expect(
-      terminalContexts.some((context) => context.includes('isTerminalTurnErrorEvent(event)')),
-    ).toBe(true);
-    expect([...statusContexts, ...terminalContexts].join('\n')).not.toContain(
-      "event.type === 'error'",
-    );
-    // Keep a direct structural guard too: each terminal idle assignment must
-    // remain inside its corresponding done/error branch.
-    expect(
-      wireSessionSource.lastIndexOf("if (event.type === 'done') {", terminalIdleAssignments[0]),
-    ).toBeGreaterThanOrEqual(0);
-    expect(
-      wireSessionSource.lastIndexOf(
-        'if (isTerminalTurnErrorEvent(event)) {',
-        terminalIdleAssignments[1],
-      ),
-    ).toBeGreaterThanOrEqual(0);
-  });
-
-  it('does not persist remote Codex account snapshots into local account usage', () => {
-    const wireSessionSource = extractWireSessionSource();
-    expect(wireSessionSource).toContain(
-      "event.type === 'account_usage' && event.source === 'codex' && !session.remoteHostId",
-    );
-  });
-
-  it('fires git snapshots only from post-broadcast product-terminal done events', () => {
-    const wireSessionSource = extractWireSessionSource();
-    const broadcastIndex = wireSessionSource.indexOf('broadcastToAllWindows(MAKER_PUSH.EVENT');
-    const snapshotIndex = wireSessionSource.indexOf(
-      'void gitSnapshotCoordinator?.onTurnEnd(session.id);',
-    );
-    const doneBlockIndex = wireSessionSource.indexOf(
-      "if (event.type === 'done' && !isContinuationBoundary) {",
-      broadcastIndex,
-    );
-    const beforeBroadcast = wireSessionSource.slice(0, broadcastIndex);
-
-    expect(snapshotIndex).toBeGreaterThan(broadcastIndex);
-    expect(beforeBroadcast).not.toContain('gitSnapshotCoordinator?.onTurnEnd');
-    expect(doneBlockIndex).toBeGreaterThanOrEqual(0);
-    expect(snapshotIndex).toBeGreaterThan(doneBlockIndex);
-  });
+  // fires git snapshots only from post-broadcast product-terminal done events: covered by the executable sessionEventPipeline tests.
 
   it('uses status turn-start snapshots only as a fallback when no baseline is pending', () => {
-    const wireSessionSource = extractWireSessionSource();
+    const wireSessionSource = readEventModule('sessionEventPreparation');
     const turnStartIndex = wireSessionSource.indexOf(
       'gitSnapshotCoordinator?.onTurnStart(session.id);',
     );
@@ -502,90 +324,11 @@ describe('maker:event hot path ordering', () => {
     expect(pendingCheckIndex).toBeGreaterThanOrEqual(0);
     expect(pendingCheckIndex).toBeLessThan(turnStartIndex);
   });
+  // clears pending git snapshot baselines only after terminal error broadcast: covered by the executable sessionEventPipeline tests.
 
-  it('clears pending git snapshot baselines only after terminal error broadcast', () => {
-    const wireSessionSource = extractWireSessionSource();
-    const broadcastIndex = wireSessionSource.indexOf('broadcastToAllWindows(MAKER_PUSH.EVENT');
-    const abortIndex = wireSessionSource.indexOf(
-      'gitSnapshotCoordinator?.onTurnAbort(session.id);',
-    );
-    const beforeBroadcast = wireSessionSource.slice(0, broadcastIndex);
-    const abortContext = wireSessionSource.slice(Math.max(0, abortIndex - 140), abortIndex + 80);
+  // writes one durable Assistant boundary for both success and terminal error: covered by the executable sessionEventPipeline tests.
 
-    expect(abortIndex).toBeGreaterThan(broadcastIndex);
-    expect(beforeBroadcast).not.toContain('gitSnapshotCoordinator?.onTurnAbort');
-    expect(abortContext).toContain('isTerminalTurnErrorEvent(event)');
-  });
-
-  it('writes one durable Assistant boundary for both success and terminal error', () => {
-    const wireSessionSource = extractWireSessionSource();
-    const boundaryStart = wireSessionSource.indexOf(
-      'let turnAssistantPersistId: string | undefined;',
-    );
-    const boundaryEnd = wireSessionSource.indexOf(
-      'const autoResumeSuppressesPersist',
-      boundaryStart,
-    );
-    const boundaryBlock = wireSessionSource.slice(boundaryStart, boundaryEnd);
-
-    expect(boundaryStart).toBeGreaterThanOrEqual(0);
-    expect(boundaryEnd).toBeGreaterThan(boundaryStart);
-    expectOrder(
-      boundaryBlock,
-      'flushAssistantBlock(session.id, eventAgentMeta);',
-      'consumeLastAssistantPersistId(session.id);',
-    );
-    expectOrder(
-      boundaryBlock,
-      'consumeLastAssistantPersistId(session.id);',
-      'consumeLastTopLevelAssistantPersistId(session.id);',
-    );
-    expectOrder(
-      boundaryBlock,
-      'consumeLastTopLevelAssistantPersistId(session.id);',
-      'flushOrphanToolResults(session.id, eventAgentMeta);',
-    );
-    expect(boundaryBlock).toContain("event.type === 'done'");
-    expect(boundaryBlock).toContain("event.source !== 'codex'");
-    expect(boundaryBlock).toContain('isSuccessfulCodexDoneEventData(event.data)');
-    expect(boundaryBlock).toContain('markAssistantTurnCompleted(');
-    expect(boundaryBlock).toContain('nativeForkAnchor ? { nativeForkAnchor } : undefined');
-    expect(boundaryBlock).toContain(
-      'markAssistantTurnFailed(session.id, turnBoundaryAssistantPersistId)',
-    );
-    expect(boundaryBlock).toContain('pendingFailedTurnAssistantPersistId.get(session.id)');
-    expect(boundaryBlock).toContain('isPairedFailedTurnDone = true');
-    expect(boundaryBlock).toContain('autoResumeBookkeeping.noteFailedTurnCompletionTail(');
-    expect(boundaryBlock).toContain('event.sessionTurnGeneration');
-    expectOrder(
-      boundaryBlock,
-      'isPairedFailedTurnDone = true',
-      'else if (!isPairedFailedTurnDone)',
-    );
-    expectOrder(
-      boundaryBlock,
-      'isSuccessfulCodexDoneEventData(event.data)',
-      'markAssistantTurnFailed(session.id, turnBoundaryAssistantPersistId)',
-    );
-  });
-
-  it('reserves terminal error persistId before EVENT broadcast and writes after', () => {
-    const wireSessionSource = extractWireSessionSource();
-    expectOrder(
-      wireSessionSource,
-      'persistId = reserveTurnErrorPersistId(',
-      'broadcastToAllWindows(MAKER_PUSH.EVENT',
-    );
-    expectOrder(wireSessionSource, 'broadcastToAllWindows(MAKER_PUSH.EVENT', 'onTurnErrorEvent(');
-    expect(wireSessionSource).toContain('const autoResumeWouldSuppressPersist');
-    const persistBoundaryStart = wireSessionSource.indexOf(
-      'let turnAssistantPersistId: string | undefined;',
-    );
-    expect(persistBoundaryStart).toBeGreaterThanOrEqual(0);
-    expect(
-      wireSessionSource.indexOf('const autoResumeSuppressesPersist', persistBoundaryStart),
-    ).toBeGreaterThan(persistBoundaryStart);
-  });
+  // reserves terminal error persistId before EVENT broadcast and writes after: covered by the executable sessionEventPipeline tests.
 
   it('rejects stale Agent Island interactions before renderer delivery', () => {
     const interactionListenerSource = extractInstallDesktopInteractionListenerSource();
@@ -621,45 +364,38 @@ describe('maker:event hot path ordering', () => {
   });
 
   it('clears git snapshot coordinator state when sessions close', () => {
-    const wireSessionSource = extractWireSessionSource();
-    const closedBlock = wireSessionSource.slice(
-      wireSessionSource.indexOf("if (status === 'closed') {"),
-    );
+    const closedBlock = extractSessionCloseAdaptersSource();
 
     expect(closedBlock).toContain('gitSnapshotCoordinator?.onSessionClosed(session.id);');
     expectOrder(
       closedBlock,
-      'agentInputCoordinatorHolder?.onSessionClosed(session.id, {',
+      'agentInputCoordinatorHolder?.onSessionClosed(session.id, options);',
       'gitSnapshotCoordinator?.onSessionClosed(session.id);',
     );
   });
 
   it('preserves coordinator input boundary inside the rehydrate suppression window (#1930)', () => {
-    const wireSessionSource = extractWireSessionSource();
-    const closedBlock = wireSessionSource.slice(
-      wireSessionSource.indexOf("if (status === 'closed') {"),
-    );
+    const closedBlock = extractSessionCloseAdaptersSource();
 
     // rehydrate / 凭证切换 close-rebuild 期间同一逻辑会话进程内重建:窗口内
     // onSessionClosed 传 preserveInputBoundary(true)保留 input boundary(不 abort
     // 驱动本次重建的 signal → #1930),但**其余清理必须照常执行**(不能整体跳过
     // onSessionClosed,否则 rebuild 失败/close 后不 rebuild 时 coordinator 残留)。
-    expect(closedBlock).toContain('agentInputCoordinatorHolder?.onSessionClosed(session.id, {');
     expect(closedBlock).toContain(
-      'preserveInputBoundary: rehydrateCloseSuppression.isSuppressed(session.id),',
+      'agentInputCoordinatorHolder?.onSessionClosed(session.id, options);',
+    );
+    expect(closedBlock).toContain(
+      'shouldPreserveInputBoundary: () => rehydrateCloseSuppression.isSuppressed(session.id),',
     );
     expectOrder(
       closedBlock,
-      'agentInputCoordinatorHolder?.onSessionClosed(session.id, {',
+      'agentInputCoordinatorHolder?.onSessionClosed(session.id, options);',
       'gitSnapshotCoordinator?.onSessionClosed(session.id);',
     );
   });
 
   it('preserves only a waiting Codex reconnect-stall retry across its exact provider rebuild', () => {
-    const wireSessionSource = extractWireSessionSource();
-    const closedBlock = wireSessionSource.slice(
-      wireSessionSource.indexOf("if (status === 'closed') {"),
-    );
+    const closedBlock = extractSessionCloseAdaptersSource();
 
     expect(source).toContain(
       'const pendingCodexReconnectStalledRebuilds = new WeakMap<Session, number>();',
@@ -680,16 +416,12 @@ describe('maker:event hot path ordering', () => {
     expect(closedBlock).toContain(
       'shouldPreserveSessionRuntimeFallbackAutoResume(session, closeReason)',
     );
-    expect(closedBlock).toContain('if (preserveAutoResumeIntent) {');
+    expect(closedBlock).toContain('runSessionCloseCleanup(context.preserveAutoResumeIntent, {');
     expect(closedBlock).toContain('autoResumeBookkeeping.teardown(session.id);');
-    expect(closedBlock).toContain('preserveAutoResumeIntent,');
   });
 
   it('clears Agent Island after mandatory closed-session cleanup', () => {
-    const wireSessionSource = extractWireSessionSource();
-    const closedBlock = wireSessionSource.slice(
-      wireSessionSource.indexOf("if (status === 'closed') {"),
-    );
+    const closedBlock = extractSessionCloseAdaptersSource();
     const closeSessionHandler = source.match(
       /ipcMain\.handle\(MAKER_INVOKE\.CLOSE_SESSION,[\s\S]*?\n {2}\}\);/,
     )?.[0];
@@ -699,7 +431,7 @@ describe('maker:event hot path ordering', () => {
     );
     expectOrder(
       closedBlock,
-      "cleanupPendingInteractionsForSession(session.id, 'session_closed');",
+      "cleanupPendingInteractionsForSession(session.id, 'session_closed')",
       "handleAgentIslandSessionClosedAfterCleanup(session.id, 'process-closed');",
     );
     expect(source).toContain(
@@ -904,7 +636,7 @@ describe('maker:event hot path ordering', () => {
 
     expect(stableLookupStart).toBeGreaterThanOrEqual(0);
     expect(stableLookupEnd).toBeGreaterThan(stableLookupStart);
-    expect(stableLookupSource).toContain('wiredSessionsById.get(sessionId)?.session');
+    expect(stableLookupSource).toContain('sessionBindings.getSession(sessionId)');
     expectOrder(
       stableLookupSource,
       "if (wired) return { status: 'found', session: wired };",
@@ -956,10 +688,8 @@ describe('maker:event hot path ordering', () => {
     const helperStart = source.indexOf('const readDirectAbortTurnId =');
     const helperEnd = source.indexOf('\n\n  const inputCoordinator:', helperStart);
     const helperSource = source.slice(helperStart, helperEnd);
-    const wireSessionSource = extractWireSessionSource();
-    const closedBlock = wireSessionSource.slice(
-      wireSessionSource.indexOf("if (status === 'closed') {"),
-    );
+    const wireSessionSource = readEventModule('sessionEventPreparation');
+    const closedBlock = extractSessionCloseAdaptersSource();
 
     expect(source).toContain(
       'const sessionTurnBoundaryGenerationById = new Map<string, number>();',
@@ -973,9 +703,7 @@ describe('maker:event hot path ordering', () => {
     expect(closeBoundarySource).toContain(
       'currentSessionTurnBoundaryGeneration(sessionId) !== boundary.generation',
     );
-    expect(helperSource).toContain(
-      'wiredSessionsById.get(sessionId)?.session !== boundary.session',
-    );
+    expect(helperSource).toContain('sessionBindings.getSession(sessionId) !== boundary.session');
     expect(helperSource).toContain(
       'currentSessionTurnBoundaryGeneration(sessionId) !== boundary.generation',
     );
@@ -999,24 +727,21 @@ describe('maker:event hot path ordering', () => {
     expectOrder(
       closedBlock,
       'sessionTurnActivityTracker.deleteSession(session.id);',
-      'if (closedDirectAbortBoundary) {',
+      'notifyGoalIdle: () => notifyGoalIdleAfterTurnSettled(session.id)',
     );
-    expect(closedBlock).toContain('notifyGoalIdleAfterTurnSettled(session.id);');
-    expect(closedBlock.indexOf('notifyGoalIdleAfterTurnSettled(session.id);')).toBeGreaterThan(
-      closedBlock.indexOf('sessionTurnBoundaryGenerationById.delete(session.id);'),
+    expect(closedBlock).toContain(
+      'finalizeSessionClose(context.closedDirectAbortBoundary !== null, {',
     );
+    expect(
+      closedBlock.indexOf('notifyGoalIdle: () => notifyGoalIdleAfterTurnSettled(session.id)'),
+    ).toBeGreaterThan(closedBlock.indexOf('sessionTurnBoundaryGenerationById.delete(session.id);'));
   });
 
   it('cancels deferred Goal resumes when non-abort session teardown supersedes them', () => {
-    const wireSessionSource = extractWireSessionSource();
-    const replacementStart = wireSessionSource.indexOf('if (existing) {');
-    const replacementEnd = wireSessionSource.indexOf(
-      '\n  }\n  advanceSessionTurnBoundaryGeneration',
-      replacementStart,
-    );
-    const replacementBlock = wireSessionSource.slice(replacementStart, replacementEnd);
-    const closedStart = wireSessionSource.indexOf("if (status === 'closed') {");
-    const closedBlock = wireSessionSource.slice(closedStart);
+    const replacementStart = source.indexOf('beforeReplace: (session: WiredSession) => {');
+    const replacementEnd = source.indexOf('onBind: (session: WiredSession) => {', replacementStart);
+    const replacementBlock = source.slice(replacementStart, replacementEnd);
+    const closedBlock = extractSessionCloseAdaptersSource();
 
     expect(source).toContain('let goalDeferredResumeCancelObserver:');
     expect(source).toContain('export function setGoalDeferredResumeCancelObserver(');
@@ -1031,14 +756,16 @@ describe('maker:event hot path ordering', () => {
       'cancelDirectAbortReconciliation(session.id);',
       'goalDeferredResumeCancelObserver?.(session.id);',
     );
-    expect(closedStart).toBeGreaterThanOrEqual(0);
-    expect(closedBlock).toMatch(
-      /if \(closedDirectAbortBoundary\) \{[\s\S]*notifyGoalIdleAfterTurnSettled\(session\.id\);[\s\S]*\} else \{[\s\S]*goalDeferredResumeCancelObserver\?\.\(session\.id\);/,
+    expect(closedBlock).toContain(
+      'finalizeSessionClose(context.closedDirectAbortBoundary !== null, {',
+    );
+    expect(closedBlock).toContain(
+      'cancelGoalResume: () => goalDeferredResumeCancelObserver?.(session.id),',
     );
   });
 
   it('keeps Codex subscription value out of real session cost totals', () => {
-    const wireSessionSource = extractWireSessionSource();
+    const wireSessionSource = readEventModule('sessionCodexTurnUsage');
     const codexDoneIndex = wireSessionSource.indexOf(
       "event.type === 'done' && event.source === 'codex'",
     );
@@ -1052,8 +779,10 @@ describe('maker:event hot path ordering', () => {
     expect(codexDoneSource).toContain(
       'const codexAuthInjection = isRemoteCodexSession ? null : getCodexProxyAuthInjection();',
     );
-    expect(wireSessionSource).toContain('!turnModelPromiseBySession.has(session.id)');
-    expect(wireSessionSource).toContain(
+    expect(readEventModule('sessionEventPreparation')).toContain(
+      '!turnModelPromiseBySession.has(session.id)',
+    );
+    expect(readEventModule('sessionEventPreparation')).toContain(
       'turnModelPromiseBySession.set(session.id, readSessionModelForUsage(session.id));',
     );
     expect(codexDoneSource).toMatch(
@@ -1146,18 +875,12 @@ describe('maker:event hot path ordering', () => {
   });
 
   it('claude-code 费用按完整请求段定价，累计 cost 首帧只建基线', () => {
-    const wireSessionSource = extractWireSessionSource();
+    const wireSessionSource = readEventModule('sessionClaudeTurnUsage');
     const claudeDoneIndex = wireSessionSource.indexOf(
       "event.type === 'done' && event.source === 'claude-code'",
     );
-    const codexDoneIndex = wireSessionSource.indexOf(
-      "event.type === 'done' && event.source === 'codex'",
-    );
     expect(claudeDoneIndex).toBeGreaterThanOrEqual(0);
-    expect(codexDoneIndex).toBeGreaterThan(claudeDoneIndex);
-
-    // 仅取 claude-code 块 (到 codex 块前)。
-    const claudeDoneSource = wireSessionSource.slice(claudeDoneIndex, codexDoneIndex);
+    const claudeDoneSource = wireSessionSource.slice(claudeDoneIndex);
     // 主路径:按真实 provider / billing route 取价，所有 sink 共用区域金额结果。
     expect(claudeDoneSource).toContain('const billingRoute: BillingRoute = session.remoteHostId');
     expect(claudeDoneSource).toContain("billingRoute === 'xd-gateway'");
@@ -1216,7 +939,7 @@ describe('maker:event hot path ordering', () => {
   });
 
   it('pi subscription turns estimate value from the shared reference-price helper', () => {
-    const wireSessionSource = extractWireSessionSource();
+    const wireSessionSource = readEventModule('sessionPiTurnUsage');
     const piDoneIndex = wireSessionSource.indexOf("event.type === 'done' && event.source === 'pi'");
     expect(piDoneIndex).toBeGreaterThanOrEqual(0);
     const piDoneSource = wireSessionSource.slice(piDoneIndex);
@@ -1263,6 +986,15 @@ describe('maker:event hot path ordering', () => {
   });
 });
 
+/** Checks the production adapters; close ordering itself is tested by executing the service. */
+function extractSessionCloseAdaptersSource(): string {
+  const start = source.indexOf('captureCloseContext: (session: WiredSession) => {');
+  const end = source.indexOf('export function wireSessionToIpc', start);
+  expect(start).toBeGreaterThanOrEqual(0);
+  expect(end).toBeGreaterThan(start);
+  return source.slice(start, end);
+}
+
 function extractWireSessionSource(): string {
   const wireSessionSource = source.match(
     /export function wireSessionToIpc\([\s\S]*?export const wireSessionToIpcExternal = wireSessionToIpc;/,
@@ -1285,14 +1017,17 @@ function extractInstallDesktopInteractionListenerSource(): string {
   return listenerSource;
 }
 
-function escapeRegExp(value: string): string {
-  return value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
-}
-
 function expectOrder(sourceBlock: string, firstNeedle: string, secondNeedle: string): void {
   const first = sourceBlock.indexOf(firstNeedle);
   const second = sourceBlock.indexOf(secondNeedle);
   expect(first).toBeGreaterThanOrEqual(0);
   expect(second).toBeGreaterThanOrEqual(0);
   expect(first).toBeLessThan(second);
+}
+
+/** Existing domain guards ignore only the injected service qualifier. */
+function readEventModule(name: string): string {
+  return readFileSync(resolve(__dirname, '..', 'maker-ipc', name + '.ts'), 'utf8')
+    .replace(/\r\n?/g, '\n')
+    .replaceAll('deps.', '');
 }

--- a/apps/desktop/src/main/__tests__/makerSendToSessionOrdering.test.ts
+++ b/apps/desktop/src/main/__tests__/makerSendToSessionOrdering.test.ts
@@ -127,7 +127,7 @@ describe('sendToSession ordering', () => {
     );
 
     expect(policyGuardBlock).toContain(
-      "const liveWorkspaceKind = (lead as { workspaceKind?: unknown } | undefined)?.workspaceKind;",
+      'const liveWorkspaceKind = (lead as { workspaceKind?: unknown } | undefined)?.workspaceKind;',
     );
     expect(policyGuardBlock).toContain(
       "typeof leadRow?.workingDir === 'string' ? leadRow.workingDir : lead?.workDir;",
@@ -433,7 +433,9 @@ describe('sendToSession ordering', () => {
       'await gitSnapshotCoordinator.onTurnStart(session.id);',
     );
     expect(countOccurrences(block, 'sendUserMessageWithAwaitedGitBaseline(')).toBe(3);
-    expect(block).not.toContain('const sendResult = await session.send({ type: \'user\', content: message }, {');
+    expect(block).not.toContain(
+      "const sendResult = await session.send({ type: 'user', content: message }, {",
+    );
     expect(block).not.toContain('const sendResult = await live.send(');
   });
 
@@ -654,7 +656,9 @@ describe('sendToSession ordering', () => {
     expect(promptPreviewBlock).toContain('try {');
     expect(promptPreviewBlock).toContain('getAgentIslandService()');
     expect(promptPreviewBlock).toContain('service.handleUserPrompt');
-    expect(promptPreviewBlock).toContain('log.warn(\'Agent Island prompt preview update failed after user message persistence\'');
+    expect(promptPreviewBlock).toContain(
+      "log.warn('Agent Island prompt preview update failed after user message persistence'",
+    );
     expect(promptPreviewBlock).toContain('clientId: options.clientId');
     expect(promptPreviewBlock).toContain('error: error instanceof Error ? error.message : String(error)');
   });
@@ -786,40 +790,7 @@ describe('sendToSession ordering', () => {
     expect(terminalBlock).not.toContain('listWorkersByLead');
     expect(terminalBlock).not.toContain('dispatchInterAgentMessage');
   });
-
-  it('serializes worker terminal handling behind in-flight turn-start status updates', () => {
-    const wireSessionSource = extractWireSessionSource();
-    const terminalBlock = extractWorkerTerminalHandlerSource();
-    const captureIndex = wireSessionSource.indexOf(
-      'orcaTeamServiceForEvents?.captureWorkerTerminalTurn(session.id)',
-    );
-    const broadcastIndex = wireSessionSource.indexOf('broadcastToAllWindows(MAKER_PUSH.EVENT');
-    const drainIndex = wireSessionSource.indexOf(
-      'agentInputCoordinatorHolder?.onExternalTurnSettled(session.id);',
-    );
-    const waitIndex = wireSessionSource.indexOf(
-      'await workerTurnStartSequencer.waitForStart(session.id);',
-    );
-    const terminalIndex = wireSessionSource.indexOf(
-      'await orcaTeamServiceForEvents?.handleWorkerTerminalTurn({',
-    );
-
-    expect(source).toContain(
-      'const workerTurnStartSequencer = createWorkerTurnStartSequencer(log);',
-    );
-    expect(source).toContain('workerTurnStartSequencer.start(session.id, async () => {');
-    expect(source).toContain(
-      'await orcaTeamServiceForEvents?.handleWorkerTurnStarted(session.id);',
-    );
-    expect(terminalBlock).toContain('await workerTurnStartSequencer.waitForStart(session.id);');
-    expect(terminalBlock).toContain('capture: workerTerminalCapture,');
-    expect(captureIndex).toBeGreaterThanOrEqual(0);
-    expect(broadcastIndex).toBeGreaterThanOrEqual(0);
-    expect(drainIndex).toBeGreaterThan(broadcastIndex);
-    expect(drainIndex).toBeGreaterThan(captureIndex);
-    expect(waitIndex).toBeGreaterThan(broadcastIndex);
-    expect(terminalIndex).toBeGreaterThan(waitIndex);
-  });
+  // serializes worker terminal handling behind in-flight turn-start status updates: covered by the executable sessionEventPipeline tests.
 
   it('keeps terminal skip and manual interrupt behavior inside OrcaTeamService', () => {
     const serviceTerminalBlock = extractOrcaTeamServiceHandleWorkerTerminalTurnSource();
@@ -1127,20 +1098,10 @@ function extractDispatchOrEnqueueOrcaInterAgentMessageSource(): string {
 }
 
 function extractWorkerTerminalHandlerSource(): string {
-  const block = source.match(
-    /Worker turn 结束后[\s\S]*?await orcaTeamServiceForEvents\?\.handleWorkerTerminalTurn\(\{[\s\S]*?\n {10}\}\);/,
-  )?.[0];
-  expect(block).toBeTruthy();
-  if (!block) throw new Error('worker terminal handler source block not found');
-  return block;
-}
-
-function extractWireSessionSource(): string {
-  return extractBetween(
-    source,
-    'export function wireSessionToIpc',
-    'ipcMain.handle(MAKER_INVOKE.LIST_AVAILABLE_AGENTS',
-  );
+  return readFileSync(
+    resolve(__dirname, '..', 'maker-ipc', 'sessionEventTerminal.ts'),
+    'utf8',
+  ).replaceAll('deps.', '');
 }
 
 function extractBetween(

--- a/apps/desktop/src/main/__tests__/sessionRuntimeControlWiring.test.ts
+++ b/apps/desktop/src/main/__tests__/sessionRuntimeControlWiring.test.ts
@@ -785,8 +785,8 @@ describe('session runtime control wiring', () => {
   it('retains runtime state across process closes and clears it at task lifecycle boundaries', () => {
     const closeBoundary = handlerBody(
       registerSource,
-      "if (status === 'closed') {",
-      'const closedDirectAbortBoundary',
+      'const sessionBindings = createSessionBindingLifecycle',
+      'export function wireSessionToIpc',
     );
     const terminalCleanup = handlerBody(
       registerSource,
@@ -922,21 +922,8 @@ describe('session runtime control wiring', () => {
     expect(registerSource).toContain('runtimePending: control.pending');
     expect(registerSource).toContain("effort: effective.effort ?? '',");
   });
+  // persists Pi runtime-verified windows without catalog replacement: covered by the executable sessionEventPipeline tests.
 
-  it('persists Pi runtime-verified windows without catalog replacement', () => {
-    const snapshotStart = registerSource.indexOf('if (pendingContextSnapshot) {');
-    const snapshotEnd = registerSource.indexOf(
-      'if (pendingCodexAccountUsageSnapshot)',
-      snapshotStart,
-    );
-    const snapshot = registerSource.slice(snapshotStart, snapshotEnd);
-
-    expect(snapshot).toContain("session.agentKind === 'pi'");
-    expect(snapshot).toContain('piRuntimeWindow ?? verifiedWindow');
-    expect(snapshot.indexOf('pendingContextSnapshot.contextWindow')).toBeLessThan(
-      snapshot.indexOf('lookupVerifiedContextWindow('),
-    );
-  });
 
   it('counts fallback eligibility across the whole interrupted-turn episode', () => {
     expect(registerSource).toContain(

--- a/apps/desktop/src/main/__tests__/sessionTaskSummary.test.ts
+++ b/apps/desktop/src/main/__tests__/sessionTaskSummary.test.ts
@@ -241,7 +241,7 @@ describe('sessionListPreviewPatch', () => {
 describe('turn-done list preview refresh', () => {
   it('回合结束后先刷新列表预览,再按需生成置顶摘要', () => {
     const registerSource = readFileSync(
-      resolve(__dirname, '..', 'maker-ipc', 'register.ts'),
+      resolve(__dirname, '..', 'maker-ipc', 'sessionEventTerminal.ts'),
       'utf8',
     );
     const summarySource = readFileSync(resolve(__dirname, '..', 'sessionTaskSummary.ts'), 'utf8');

--- a/apps/desktop/src/main/maker-ipc/__tests__/promptPredictionStopLedger.test.ts
+++ b/apps/desktop/src/main/maker-ipc/__tests__/promptPredictionStopLedger.test.ts
@@ -10,6 +10,10 @@ import {
 } from '../promptPredictionStopLedger.js';
 
 const REGISTER_SOURCE = readFileSync(new URL('../register.ts', import.meta.url), 'utf8');
+const PREPARATION_SOURCE = readFileSync(
+  new URL('../sessionEventPreparation.ts', import.meta.url),
+  'utf8',
+);
 
 beforeEach(() => {
   resetPromptPredictionStopLedgerForTests();
@@ -26,10 +30,13 @@ describe('prompt prediction explicit Stop ledger', () => {
 
   it('INPUT_STOP 在 abort 前记账，中央 turn-start 边界负责清除', () => {
     const stopHandlerAt = REGISTER_SOURCE.indexOf('ipcMain.handle(MAKER_INVOKE.INPUT_STOP');
-    const noteAt = REGISTER_SOURCE.indexOf('notePromptPredictionSessionStopped(sid);', stopHandlerAt);
+    const noteAt = REGISTER_SOURCE.indexOf(
+      'notePromptPredictionSessionStopped(sid);',
+      stopHandlerAt,
+    );
     const abortAt = REGISTER_SOURCE.indexOf('inputCoordinator.stop(', stopHandlerAt);
-    const clearAt = REGISTER_SOURCE.indexOf('clearPromptPredictionSessionStopped(session.id);');
-    const turnStartAt = REGISTER_SOURCE.indexOf('markSessionTurnStarted(session.id);', clearAt);
+    const clearAt = PREPARATION_SOURCE.indexOf('clearPromptPredictionSessionStopped(session.id);');
+    const turnStartAt = PREPARATION_SOURCE.indexOf('markSessionTurnStarted(session.id);', clearAt);
 
     expect(stopHandlerAt).toBeGreaterThanOrEqual(0);
     expect(noteAt).toBeGreaterThan(stopHandlerAt);

--- a/apps/desktop/src/main/maker-ipc/__tests__/sessionBindingLifecycle.test.ts
+++ b/apps/desktop/src/main/maker-ipc/__tests__/sessionBindingLifecycle.test.ts
@@ -1,0 +1,531 @@
+import {
+  Session,
+  type AgentEvent,
+  type AgentSessionHandle,
+  type SessionStatusListener,
+} from '@cindy/maker-core';
+import { describe, expect, it, vi } from 'vitest';
+
+import {
+  createSessionBindingLifecycle,
+  finalizeSessionClose,
+  runSessionCloseCleanup,
+  type SessionBindingLifecycleDeps,
+  type SessionCloseCleanupActions,
+} from '../sessionBindingLifecycle.js';
+import {
+  AgentInputCoordinator,
+  type AgentInputCoordinatorDeps,
+} from '../agent-input-coordinator.js';
+import { createRehydrateCloseSuppression } from '../../maker-host/rehydrateCloseSuppression.js';
+import type { AgentInputQueuedMessage } from '../../../shared/agentInputQueue.js';
+
+vi.mock('../../localDb/ipc/messages.js', () => ({ createMessage: vi.fn(async () => ({})) }));
+vi.mock('../../localDb/ipc/sessions.js', () => ({ touchUserSendInDb: vi.fn(async () => {}) }));
+vi.mock('../../logger.js', () => ({
+  createLogger: () => ({ debug: vi.fn(), info: vi.fn(), warn: vi.fn(), error: vi.fn() }),
+}));
+
+function deferred() {
+  let resolve!: () => void;
+  const promise = new Promise<void>((done) => {
+    resolve = done;
+  });
+  return { promise, resolve };
+}
+
+/** Retains captured callbacks so tests can deliver a stale transport notification explicitly. */
+class TestSession {
+  readonly statuses = new Set<SessionStatusListener>();
+  readonly events = new Set<(value: string) => void>();
+  readonly setInteractionListener = vi.fn<Session['setInteractionListener']>();
+  constructor(readonly id = 'task') {}
+  onStatusChange(listener: SessionStatusListener) {
+    this.statuses.add(listener);
+    return () => {
+      this.statuses.delete(listener);
+    };
+  }
+  onEvent(listener: (value: string) => void) {
+    this.events.add(listener);
+    return () => {
+      this.events.delete(listener);
+    };
+  }
+  emitStatus(status: Parameters<SessionStatusListener>[0]) {
+    for (const listener of this.statuses) listener(status);
+  }
+  emitEvent(value: string) {
+    for (const listener of this.events) listener(value);
+  }
+}
+
+function harness<S extends Pick<Session, 'id' | 'onStatusChange' | 'setInteractionListener'>>() {
+  const order: string[] = [];
+  const context = { settlesDirectAbort: false, preserveAutoResumeIntent: false };
+  const actions = {
+    cleanupInteractions: vi.fn(() => {
+      order.push('interactions');
+    }),
+    preserveAutoResume: vi.fn(() => {
+      order.push('preserve-retry');
+    }),
+    resetAutoResume: vi.fn(() => {
+      order.push('reset-retry');
+    }),
+    shouldPreserveInputBoundary: vi.fn(() => false),
+    closeInputCoordinator: vi.fn<SessionCloseCleanupActions['closeInputCoordinator']>(() => {
+      order.push('coordinator');
+    }),
+    cleanupRuntimeState: vi.fn(() => {
+      order.push('runtime');
+    }),
+  };
+  const finalActions = {
+    clearTurnState: vi.fn(() => {
+      order.push('idle');
+    }),
+    notifyGoalIdle: vi.fn(() => {
+      order.push('goal-idle');
+    }),
+    cancelGoalResume: vi.fn(() => {
+      order.push('cancel-goal');
+    }),
+  };
+  const deps = {
+    log: { warn: vi.fn() },
+    restoreInteractionListener: vi.fn<(session: S) => void>(() => {
+      order.push('restore-interaction');
+    }),
+    beforeReplace: vi.fn<(session: S) => void>(() => {
+      order.push('replace');
+    }),
+    onBind: vi.fn<(session: S) => void>(() => {
+      order.push('bind');
+    }),
+    broadcastStatus: vi.fn<SessionBindingLifecycleDeps<S, typeof context>['broadcastStatus']>(
+      () => {
+        order.push('status');
+      },
+    ),
+    captureCloseContext: vi.fn<(session: S) => typeof context>(() => {
+      order.push('capture');
+      return { ...context };
+    }),
+    cleanupClosedSession: vi.fn((_session: S, captured: typeof context) => {
+      runSessionCloseCleanup(captured.preserveAutoResumeIntent, actions);
+    }),
+    beforeCloseTeardown: vi.fn<(session: S) => void>(() => {
+      order.push('unregister');
+      context.settlesDirectAbort = false;
+    }),
+    finalizeClosedSession: vi.fn((_session: S, captured: typeof context) => {
+      finalizeSessionClose(captured.settlesDirectAbort, finalActions);
+    }),
+  } satisfies SessionBindingLifecycleDeps<S, typeof context>;
+  const lifecycle = createSessionBindingLifecycle<S, typeof context>(deps);
+  function bind(
+    session: S,
+    dispose = () => {
+      order.push('dispose');
+    },
+  ) {
+    const registration = lifecycle.beginBinding(session);
+    if (registration) {
+      registration.disposers.push(dispose);
+      lifecycle.attachStatusListener(registration);
+    }
+    return registration;
+  }
+  return { lifecycle, deps, bind, actions, finalActions, context, order };
+}
+
+describe('Desktop Session binding lifecycle', () => {
+  it('deduplicates the same instance and detaches the old instance before publishing its replacement', () => {
+    const h = harness<TestSession>();
+    const old = new TestSession();
+    const next = new TestSession();
+    const seen: string[] = [];
+    const disposeTap = vi.fn(() => {
+      expect(h.lifecycle.getSession(old.id)).toBe(old);
+      h.order.push('tap-end');
+    });
+    const registration = h.lifecycle.beginBinding(old)!;
+    registration.disposers.push(
+      disposeTap,
+      old.onEvent((value) => seen.push(value)),
+    );
+    h.lifecycle.attachStatusListener(registration);
+    const staleStatus = [...old.statuses][0];
+    expect(h.lifecycle.beginBinding(old)).toBeNull();
+    expect(old.statuses.size).toBe(1);
+    old.emitEvent('once');
+    expect(seen).toEqual(['once']);
+    expect(h.deps.restoreInteractionListener).toHaveBeenCalledOnce();
+
+    h.order.length = 0;
+    h.bind(next);
+    expect(h.order).toEqual(['replace', 'tap-end', 'bind']);
+    expect(disposeTap).toHaveBeenCalledOnce();
+    expect(old.setInteractionListener).toHaveBeenCalledWith(null);
+    expect(old.events.size).toBe(0);
+    expect(old.statuses.size).toBe(0);
+    staleStatus('closed');
+    old.emitEvent('stale');
+    expect(seen).toEqual(['once']);
+    expect(h.deps.cleanupClosedSession).not.toHaveBeenCalled();
+    expect(h.lifecycle.getSession(old.id)).toBe(next);
+    next.emitStatus('active');
+    expect(h.deps.broadcastStatus).toHaveBeenCalledWith(next, 'active');
+  });
+
+  it('keeps unrelated task registrations and teardown independent', () => {
+    const h = harness<TestSession>();
+    const first = new TestSession('first');
+    const second = new TestSession('second');
+    h.bind(first);
+    h.bind(second);
+    first.emitStatus('closed');
+    expect(h.lifecycle.getSession(first.id)).toBeUndefined();
+    expect(h.lifecycle.getSession(second.id)).toBe(second);
+    expect(second.statuses.size).toBe(1);
+    second.emitStatus('active');
+    expect(h.deps.broadcastStatus).toHaveBeenLastCalledWith(second, 'active');
+  });
+
+  it.each([false, true])(
+    'captures direct-abort ownership before teardown and reconciles idle first (owner=%s)',
+    (ownsAbort) => {
+      const h = harness<TestSession>();
+      const session = new TestSession();
+      h.context.settlesDirectAbort = ownsAbort;
+      h.bind(session, () => {
+        expect(h.lifecycle.getSession(session.id)).toBeUndefined();
+        h.order.push('dispose');
+      });
+      const staleStatus = [...session.statuses][0];
+      h.order.length = 0;
+      session.emitStatus('closed');
+      expect(h.order).toEqual([
+        'status',
+        'capture',
+        'interactions',
+        'reset-retry',
+        'coordinator',
+        'runtime',
+        'unregister',
+        'dispose',
+        'idle',
+        ownsAbort ? 'goal-idle' : 'cancel-goal',
+      ]);
+      expect(h.context.settlesDirectAbort).toBe(false);
+      expect(h.lifecycle.getSession(session.id)).toBeUndefined();
+      expect(session.statuses.size).toBe(0);
+      staleStatus('closed');
+      expect(h.deps.cleanupClosedSession).toHaveBeenCalledOnce();
+    },
+  );
+
+  it.each(['broadcast', 'cleanup', 'disposer', 'interaction'] as const)(
+    'still unregisters and clears busy when %s fails',
+    (failure) => {
+      const h = harness<TestSession>();
+      const session = new TestSession();
+      const fail = () => {
+        throw new Error(failure);
+      };
+      const afterFailedDisposer = vi.fn();
+      const registration = h.bind(session, failure === 'disposer' ? fail : vi.fn())!;
+      registration.disposers.push(afterFailedDisposer);
+      if (failure === 'broadcast') h.deps.broadcastStatus.mockImplementation(fail);
+      if (failure === 'cleanup') h.actions.cleanupInteractions.mockImplementation(fail);
+      if (failure === 'interaction') session.setInteractionListener.mockImplementation(fail);
+      expect(() => session.emitStatus('closed')).not.toThrow();
+      expect(h.lifecycle.getSession(session.id)).toBeUndefined();
+      expect(afterFailedDisposer).toHaveBeenCalledOnce();
+      expect(h.finalActions.clearTurnState).toHaveBeenCalledOnce();
+      expect(h.finalActions.cancelGoalResume).toHaveBeenCalledOnce();
+      expect(h.deps.log.warn).toHaveBeenCalledWith(
+        expect.any(String),
+        expect.objectContaining({ error: failure }),
+      );
+      // Preserve the existing product-cleanup failure boundary; it is not a
+      // per-action retry engine. Only the mandatory teardown is guaranteed.
+      if (failure === 'cleanup') expect(h.actions.cleanupRuntimeState).not.toHaveBeenCalled();
+    },
+  );
+
+  it('does not publish a replacement when an old disposer fails', () => {
+    const h = harness<TestSession>();
+    const old = new TestSession();
+    h.bind(old, () => {
+      throw new Error('detach failed');
+    });
+    expect(() => h.bind(new TestSession())).toThrow('detach failed');
+    expect(h.lifecycle.getSession(old.id)).toBe(old);
+    expect(h.deps.onBind).toHaveBeenCalledOnce();
+  });
+
+  it('allows an already accepted old event write to finish after replacement', async () => {
+    const h = harness<TestSession>();
+    const old = new TestSession();
+    const next = new TestSession();
+    const write = deferred();
+    const persisted: string[] = [];
+    const pending: Promise<void>[] = [];
+    const registration = h.bind(old)!;
+    registration.disposers.push(
+      old.onEvent((value) => {
+        pending.push(
+          write.promise.then(() => {
+            persisted.push(value);
+          }),
+        );
+      }),
+    );
+    old.emitEvent('old-assistant-row');
+    h.bind(next);
+    old.emitEvent('must-not-start-another-write');
+    write.resolve();
+    await Promise.all(pending);
+    expect(persisted).toEqual(['old-assistant-row']);
+    expect(h.lifecycle.getSession(next.id)).toBe(next);
+  });
+});
+
+describe('close/rebuild input policy', () => {
+  it.each([
+    [false, false],
+    [true, false],
+    [false, true],
+    [true, true],
+  ])(
+    'keeps input preservation (%s) independent from retry preservation (%s)',
+    async (preserveInput, preserveRetry) => {
+      const h = harness<TestSession>();
+      const session = new TestSession();
+      const coordinator = new AgentInputCoordinator({
+        sendToAgent: vi.fn(),
+        steerToAgent: vi.fn(),
+        abortSession: vi.fn(),
+        isTurnRunning: () => false,
+        hasPendingInteraction: () => false,
+        getAgentKind: () => 'codex',
+        getSdkSessionId: async () => undefined,
+        emitProjection: vi.fn(),
+      });
+      const input = coordinator.getInputAbortSignal(session.id);
+      const preparation = deferred();
+      const nextDispatch = preparation.promise.then(() => !input.aborted);
+      h.actions.shouldPreserveInputBoundary.mockReturnValue(preserveInput);
+      h.context.preserveAutoResumeIntent = preserveRetry;
+      h.actions.closeInputCoordinator.mockImplementation((options) =>
+        coordinator.onSessionClosed(session.id, options),
+      );
+      h.bind(session);
+      session.emitStatus('closed');
+      const replacement = new TestSession();
+      h.bind(replacement);
+      preparation.resolve();
+      expect(await nextDispatch).toBe(preserveInput);
+      expect(h.actions.closeInputCoordinator).toHaveBeenCalledWith({
+        preserveInputBoundary: preserveInput,
+        preserveAutoResumeIntent: preserveRetry,
+      });
+      expect(h.actions.resetAutoResume).toHaveBeenCalledTimes(preserveRetry ? 0 : 1);
+      expect(h.actions.preserveAutoResume).toHaveBeenCalledTimes(preserveRetry ? 1 : 0);
+      expect(h.actions.cleanupRuntimeState).toHaveBeenCalledOnce();
+      expect(h.lifecycle.getSession(session.id)).toBe(replacement);
+    },
+  );
+});
+
+describe('binding with the real maker-core Session', () => {
+  function realSession() {
+    const closeStarted = deferred();
+    const closeFinished = deferred();
+    const eventReady = deferred();
+    const logger = {
+      trace: vi.fn(),
+      debug: vi.fn(),
+      info: vi.fn(),
+      warn: vi.fn(),
+      error: vi.fn(),
+      fatal: vi.fn(),
+      child: () => logger,
+    };
+    const handle = {
+      id: 'provider-thread',
+      agentKind: 'codex',
+      model: 'test-model',
+      send: vi.fn(async () => {}),
+      setInteractionResolver: vi.fn(),
+      close: vi.fn(async () => {
+        closeStarted.resolve();
+        await closeFinished.promise;
+      }),
+      async *events() {
+        await eventReady.promise;
+        yield { type: 'text', data: 'late provider output', source: 'codex' } as AgentEvent;
+        await closeFinished.promise;
+      },
+    } as unknown as AgentSessionHandle;
+    const session = new Session({
+      id: 'task',
+      agentKind: 'codex',
+      workDir: process.cwd(),
+      handle,
+      capabilities: {} as never,
+      logger,
+      turnStallMs: 0,
+    });
+    return { session, handle, closeStarted, closeFinished, eventReady };
+  }
+
+  it.each([true, false])(
+    'dispatches queued input across a real close/rebuild only when suppressed (%s)',
+    async (preserve) => {
+      const h = harness<Session>();
+      const old = realSession(),
+        next = realSession();
+      const preparation = deferred(),
+        entered = deferred(),
+        dispatched = deferred();
+      const suppression = createRehydrateCloseSuppression({ debug: vi.fn(), warn: vi.fn() });
+      let signal: AbortSignal | undefined;
+      const sendToAgent = vi.fn<AgentInputCoordinatorDeps['sendToAgent']>(
+        async (_sid, message, _opts, sendOpts) => {
+          signal = sendOpts.signal;
+          entered.resolve();
+          await preparation.promise;
+          const text = typeof message === 'string' ? message : message.content;
+          if (typeof text !== 'string') throw new Error('This fixture sends text only');
+          const result = await h.lifecycle
+            .getSession('task')!
+            .send(text, { signal: sendOpts.signal });
+          dispatched.resolve();
+          if (result.accepted === false)
+            return {
+              kind: 'session-dispatch',
+              source: 'lifecycle-test',
+              dispatched: false,
+              reason: 'cancelled-before-dispatch',
+              message: 'cancelled',
+              context: 'lifecycle-test',
+            };
+          return {
+            kind: 'session-dispatch' as const,
+            source: 'lifecycle-test',
+            dispatched: true,
+          };
+        },
+      );
+      const coordinator = new AgentInputCoordinator({
+        sendToAgent,
+        steerToAgent: vi.fn(),
+        abortSession: vi.fn(),
+        isTurnRunning: () => false,
+        hasPendingInteraction: () => false,
+        getAgentKind: () => 'codex',
+        getSdkSessionId: async () => undefined,
+        emitProjection: vi.fn(),
+      });
+      h.actions.shouldPreserveInputBoundary.mockImplementation(() =>
+        suppression.isSuppressed('task'),
+      );
+      h.actions.closeInputCoordinator.mockImplementation((options) =>
+        coordinator.onSessionClosed('task', options),
+      );
+      h.bind(old.session);
+      const item = (id: string): AgentInputQueuedMessage => ({
+        clientId: id,
+        text: id,
+        persistedContent: id,
+        model: 'test-model',
+        effort: 'medium',
+        permissionMode: 'default',
+        workingDir: '/unused',
+        chatMessage: {
+          clientId: id,
+          role: 'user',
+          content: id,
+          isStreaming: false,
+          createdAt: '2026-09-05T00:00:00.000Z',
+        },
+        createOpts: {
+          agentKind: 'codex',
+          workingDir: '/unused',
+          model: 'test-model',
+          effort: 'medium',
+          permissionMode: 'default',
+          userPrompt: '',
+          makerMemoryEnabled: false,
+          displayReasoning: 'summarized',
+        },
+      });
+      const queued = coordinator.enqueue('task', item('first'));
+      await entered.promise;
+      old.closeFinished.resolve();
+      const rebuild = async () => {
+        await old.session.close();
+        h.bind(next.session);
+      };
+      if (preserve) await suppression.withSuppressed('task', rebuild);
+      else await rebuild();
+      expect(signal?.aborted).toBe(!preserve);
+      preparation.resolve();
+      await dispatched.promise;
+      await queued;
+      expect(old.handle.send).not.toHaveBeenCalled();
+      expect(next.handle.send).toHaveBeenCalledTimes(preserve ? 1 : 0);
+      // Close cleared the old active input: a later user input remains dispatchable.
+      for (let i = 0; i < 20; i++) await Promise.resolve();
+      await coordinator.enqueue('task', item('second'));
+      for (let i = 0; i < 20; i++) await Promise.resolve();
+      expect(next.handle.send).toHaveBeenCalledTimes(preserve ? 2 : 1);
+      expect(suppression.isSuppressed('task')).toBe(false);
+      next.closeFinished.resolve();
+      await next.session.close();
+      suppression.resetForTest();
+    },
+  );
+
+  it('rejects send during provider close and ignores late output while closing exactly once', async () => {
+    const h = harness<Session>();
+    const r = realSession();
+    const seen = vi.fn();
+    const registration = h.bind(r.session)!;
+    registration.disposers.push(r.session.onEvent(seen));
+    const closing = r.session.close();
+    await r.closeStarted.promise;
+    await expect(r.session.send('new input')).rejects.toThrow('closing');
+    expect(r.handle.send).not.toHaveBeenCalled();
+    r.eventReady.resolve();
+    await Promise.resolve();
+    expect(h.lifecycle.getSession(r.session.id)).toBe(r.session);
+    const repeatedClose = r.session.close();
+    r.closeFinished.resolve();
+    await Promise.all([closing, repeatedClose]);
+    expect(seen).not.toHaveBeenCalled();
+    expect(r.handle.close).toHaveBeenCalledOnce();
+    expect(h.lifecycle.getSession(r.session.id)).toBeUndefined();
+    expect(h.finalActions.clearTurnState).toHaveBeenCalledOnce();
+  });
+
+  it('retains the binding on provider close failure and tears down after a successful retry', async () => {
+    const h = harness<Session>();
+    const r = realSession();
+    vi.mocked(r.handle.close).mockRejectedValueOnce(new Error('transport still alive'));
+    h.bind(r.session);
+    await expect(r.session.close()).rejects.toThrow('transport still alive');
+    expect(r.session.getStatus()).toBe('error');
+    expect(h.lifecycle.getSession(r.session.id)).toBe(r.session);
+    expect(h.deps.cleanupClosedSession).not.toHaveBeenCalled();
+    const closing = r.session.close();
+    r.closeFinished.resolve();
+    await closing;
+    expect(r.session.getStatus()).toBe('closed');
+    expect(h.deps.cleanupClosedSession).toHaveBeenCalledOnce();
+    expect(h.lifecycle.getSession(r.session.id)).toBeUndefined();
+  });
+});

--- a/apps/desktop/src/main/maker-ipc/__tests__/sessionEventPipeline.test.ts
+++ b/apps/desktop/src/main/maker-ipc/__tests__/sessionEventPipeline.test.ts
@@ -1,0 +1,1009 @@
+import { Session, type AgentEvent, type AgentSessionHandle } from '@cindy/maker-core';
+import { beforeEach, afterEach, describe, expect, it, vi } from 'vitest';
+import { handleSessionEvent, type SessionEventDependencies } from '../sessionEventPipeline.js';
+import { installSessionTurnObserver } from '../sessionTurnObserver.js';
+import { createSessionBindingLifecycle } from '../sessionBindingLifecycle.js';
+import { SessionTurnActivityTracker } from '../sessionTurnActivityTracker.js';
+import { ProductTurnWallClockTracker, ProductTurnUsageTargetTracker } from '../turnWallClock.js';
+import { ClaudeOutputLagTimingGuard } from '../../usage/modelUsageDelta.js';
+import { createWorkerTurnStartSequencer } from '../workerTurnStartSequencer.js';
+
+const effects = vi.hoisted(() => {
+  const calls: string[] = [];
+  const fns = new Map<string, ReturnType<typeof vi.fn>>();
+  function fn(name: string) {
+    if (!fns.has(name))
+      fns.set(
+        name,
+        vi.fn(() => {
+          calls.push(name);
+        }),
+      );
+    return fns.get(name)!;
+  }
+  return { calls, fns, fn };
+});
+vi.mock('../../logger.js', () => ({
+  createLogger: () => ({ debug: vi.fn(), info: vi.fn(), warn: vi.fn(), error: vi.fn() }),
+}));
+vi.mock('../../maker-host/auth-adapters.js', () => ({
+  readClaudeApiKey: effects.fn('readClaudeApiKey'),
+}));
+vi.mock('../../sessionSpendBroadcaster.js', () => ({
+  recordSessionTurnSpend: effects.fn('recordSessionTurnSpend'),
+  recordSessionTurnTokens: effects.fn('recordSessionTurnTokens'),
+  recordSessionContextSnapshot: effects.fn('recordSessionContextSnapshot'),
+}));
+vi.mock('../../turnCostBroadcaster.js', () => ({
+  recordSchedulerTurnCost: effects.fn('recordSchedulerTurnCost'),
+  recordTurnUsageOnMessage: effects.fn('recordTurnUsageOnMessage'),
+  codexUsageToTokens: effects.fn('codexUsageToTokens'),
+  piUsageToTokens: effects.fn('piUsageToTokens'),
+}));
+vi.mock('../../modelMismatchBroadcaster.js', () => ({
+  recordModelMismatchOnMessage: effects.fn('recordModelMismatchOnMessage'),
+}));
+vi.mock('../../usage/claudeAccountUsage.js', () => ({
+  triggerClaudeAccountUsageRefresh: effects.fn('triggerClaudeAccountUsageRefresh'),
+}));
+vi.mock('../../usage/modelPricing.js', () => ({
+  getGatewayModelPricing: effects.fn('getGatewayModelPricing'),
+  isModelPricingRefreshInFlight: effects.fn('isModelPricingRefreshInFlight'),
+  getGatewayAccountCurrency: effects.fn('getGatewayAccountCurrency'),
+  getGatewayModelPricingForModel: effects.fn('getGatewayModelPricingForModel'),
+  getModelPriceQuote: effects.fn('getModelPriceQuote'),
+}));
+vi.mock('../../usage/referenceModelPricing.js', () => ({
+  readModelPriceOverridesSnapshot: effects.fn('readModelPriceOverridesSnapshot'),
+  getClaudeSubscriptionValuePrice: effects.fn('getClaudeSubscriptionValuePrice'),
+  getCodexSubscriptionValuePrice: effects.fn('getCodexSubscriptionValuePrice'),
+  getReferenceModelPricing: effects.fn('getReferenceModelPricing'),
+  getCodexProviderSubscriptionValuePrice: effects.fn('getCodexProviderSubscriptionValuePrice'),
+  getSubscriptionDirectValuePrice: effects.fn('getSubscriptionDirectValuePrice'),
+}));
+vi.mock('../../usage/ledgerCurrency.js', () => ({
+  currentLedgerCurrency: effects.fn('currentLedgerCurrency'),
+}));
+vi.mock('../usage.js', () => ({
+  triggerClaudeSubscriptionUsageRefresh: effects.fn('triggerClaudeSubscriptionUsageRefresh'),
+  triggerCodexAccountUsageRefresh: effects.fn('triggerCodexAccountUsageRefresh'),
+  triggerXaiSubscriptionUsageRefresh: effects.fn('triggerXaiSubscriptionUsageRefresh'),
+}));
+vi.mock('../../usageBroadcaster.js', () => ({
+  rebroadcastTodaySpend: effects.fn('rebroadcastTodaySpend'),
+  recordModelTurnUsage: effects.fn('recordModelTurnUsage'),
+  recordTurnSpend: effects.fn('recordTurnSpend'),
+  rebroadcastCodexTodayUsage: effects.fn('rebroadcastCodexTodayUsage'),
+  recordCodexTurnUsage: effects.fn('recordCodexTurnUsage'),
+  recordCodexAccountUsageSnapshot: effects.fn('recordCodexAccountUsageSnapshot'),
+}));
+vi.mock('../schedule.js', () => ({
+  broadcastSchedulerChanged: effects.fn('broadcastSchedulerChanged'),
+}));
+vi.mock('../../maker-host/session-provider-store.js', () => ({
+  getSessionProvider: effects.fn('getSessionProvider'),
+}));
+vi.mock('../../maker-host/active-catalog.js', () => ({
+  getActiveCatalog: effects.fn('getActiveCatalog'),
+}));
+vi.mock('../../maker-host/claude-session-route-registry.js', () => ({
+  readClaudeSessionRoute: effects.fn('readClaudeSessionRoute'),
+}));
+vi.mock('../../maker-host/codex-proxy-host.js', () => ({
+  getCodexProxyAuthInjection: effects.fn('getCodexProxyAuthInjection'),
+}));
+vi.mock('../../maker-host/provider-route.js', () => ({
+  isUserProviderSession: effects.fn('isUserProviderSession'),
+}));
+vi.mock('../../messagePersistBroadcaster.js', () => ({
+  reserveTurnErrorPersistId: effects.fn('reserveTurnErrorPersistId'),
+  backgroundTurnPredatesSessionClear: effects.fn('backgroundTurnPredatesSessionClear'),
+  noteAgentMeta: effects.fn('noteAgentMeta'),
+  noteTurnStarted: effects.fn('noteTurnStarted'),
+  enqueueDurableWrite: effects.fn('enqueueDurableWrite'),
+  flushAssistantBlock: effects.fn('flushAssistantBlock'),
+  onAssistantTextEvent: effects.fn('onAssistantTextEvent'),
+  onAgentTaskUpdateEvent: effects.fn('onAgentTaskUpdateEvent'),
+  onThinkingEvent: effects.fn('onThinkingEvent'),
+  onToolResultEvent: effects.fn('onToolResultEvent'),
+  onToolResultFullEvent: effects.fn('onToolResultFullEvent'),
+  onToolUseEvent: effects.fn('onToolUseEvent'),
+  consumeLastAssistantPersistId: effects.fn('consumeLastAssistantPersistId'),
+  consumeLastTopLevelAssistantPersistId: effects.fn('consumeLastTopLevelAssistantPersistId'),
+  drainPersistQueue: effects.fn('drainPersistQueue'),
+  flushOrphanToolResults: effects.fn('flushOrphanToolResults'),
+  isSuccessfulCodexDoneEventData: effects.fn('isSuccessfulCodexDoneEventData'),
+  markAssistantTurnCompleted: effects.fn('markAssistantTurnCompleted'),
+  markAssistantTurnFailed: effects.fn('markAssistantTurnFailed'),
+  clearCodexPlanRowsForSession: effects.fn('clearCodexPlanRowsForSession'),
+  persistCodexPlanOnDone: effects.fn('persistCodexPlanOnDone'),
+  persistCodexPlanOnTerminalError: effects.fn('persistCodexPlanOnTerminalError'),
+  preserveTurnPersistStateForBackground: effects.fn('preserveTurnPersistStateForBackground'),
+  onTurnErrorEvent: effects.fn('onTurnErrorEvent'),
+  releaseReservedTurnErrorPersistId: effects.fn('releaseReservedTurnErrorPersistId'),
+  resetTurnPersistState: effects.fn('resetTurnPersistState'),
+  saveTurnStartedAtForDeferred: effects.fn('saveTurnStartedAtForDeferred'),
+}));
+vi.mock('../../maker-host/claude-session-background-activity.js', () => ({
+  noteClaudeSessionTurnState: effects.fn('noteClaudeSessionTurnState'),
+}));
+vi.mock('../../subagentObservationRewindFence.js', () => ({
+  noteSubagentObservationTurnStarted: effects.fn('noteSubagentObservationTurnStarted'),
+  captureSubagentObservationGeneration: effects.fn('captureSubagentObservationGeneration'),
+  enqueueSubagentObservationWrite: effects.fn('enqueueSubagentObservationWrite'),
+}));
+vi.mock('../../localDb/ipc/sessions.js', () => ({
+  persistSessionFields: effects.fn('persistSessionFields'),
+}));
+vi.mock('../../localDb/sessionActiveTurn.js', () => ({
+  markSessionTurnStarted: effects.fn('markSessionTurnStarted'),
+}));
+vi.mock('../../remote-ssh/index.js', () => ({
+  isCcMgrUpgradeInFlight: effects.fn('isCcMgrUpgradeInFlight'),
+}));
+vi.mock('../promptPredictionStopLedger.js', () => ({
+  clearPromptPredictionSessionStopped: effects.fn('clearPromptPredictionSessionStopped'),
+}));
+vi.mock('../../turn-change-set/store.js', () => ({
+  finalizeTurnChangeSet: effects.fn('finalizeTurnChangeSet'),
+}));
+vi.mock('../../maker-host/session-effort-store.js', () => ({
+  getSessionFastMode: effects.fn('getSessionFastMode'),
+}));
+vi.mock('../../maker-host/claude-gateway-error-observer.js', () => ({
+  consumeClaudeOpusPlanMismatch: effects.fn('consumeClaudeOpusPlanMismatch'),
+}));
+vi.mock('../../maker-host/catalog-to-descriptors.js', () => ({
+  resolveVerifiedContextWindow: effects.fn('resolveVerifiedContextWindow'),
+}));
+vi.mock('../../localDb/subagentRuns.js', () => ({
+  persistSubagentTaskUpdate: effects.fn('persistSubagentTaskUpdate'),
+}));
+vi.mock('../../localDb/ipc/subagentRuns.js', () => ({
+  broadcastSubagentRunsChanged: effects.fn('broadcastSubagentRunsChanged'),
+}));
+vi.mock('../../sessionTaskSummary.js', () => ({
+  maybeGenerateSessionTaskSummary: effects.fn('maybeGenerateSessionTaskSummary'),
+  refreshSessionListPreview: effects.fn('refreshSessionListPreview'),
+}));
+vi.mock('../../cindy-brain/index.js', () => ({
+  hasEnabledGhostAssistantHook: effects.fn('hasEnabledGhostAssistantHook'),
+  runGhostAssistantReplyHook: effects.fn('runGhostAssistantReplyHook'),
+}));
+vi.mock('../../cindy-brain/subscriptionGateway.js', () => ({
+  withGhostAssistantHookModel: effects.fn('withGhostAssistantHookModel'),
+}));
+vi.mock('../../maker-host/model-route-guard-live.js', () => ({
+  verdictForModelRoute: effects.fn('verdictForModelRoute'),
+}));
+
+function deferred<T = void>() {
+  let resolve!: (value: T) => void;
+  const promise = new Promise<T>((done) => {
+    resolve = done;
+  });
+  return { promise, resolve };
+}
+
+async function microtasks() {
+  for (let i = 0; i < 20; i++) await Promise.resolve();
+}
+
+function event(
+  type: AgentEvent['type'],
+  data: unknown = {},
+  extra: Partial<AgentEvent> = {},
+): AgentEvent {
+  return { type, source: 'codex', data, ...extra } as AgentEvent;
+}
+
+function harness() {
+  const log = {
+    trace: vi.fn(),
+    debug: vi.fn(),
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+    fatal: vi.fn(),
+    child: () => log,
+  };
+  const ended = deferred();
+  const handle = {
+    id: 'provider',
+    agentKind: 'codex',
+    model: 'test-model',
+    send: vi.fn(async () => {}),
+    close: vi.fn(async () => {
+      ended.resolve();
+    }),
+    setInteractionResolver: vi.fn(),
+    async *events() {
+      await ended.promise;
+      yield* [] as AgentEvent[];
+    },
+  } as unknown as AgentSessionHandle;
+  const session = new Session({
+    id: 'task',
+    agentKind: 'codex',
+    workDir: '/unused',
+    handle,
+    capabilities: {} as never,
+    logger: log,
+    turnStallMs: 0,
+  });
+  const activity = new SessionTurnActivityTracker();
+  const deps = {
+    log,
+    isFencedStaleSessionTerminal: vi.fn(() => false),
+    redactEventForRenderer: vi.fn((value: AgentEvent) => ({ ...value, data: { redacted: true } })),
+    interruptedTurnAutoResumeGuard: {
+      noteAttemptEvent: vi.fn(),
+      noteTurnStarted: vi.fn(),
+      noteAttemptSettled: vi.fn(),
+      noteProgress: vi.fn(() => true),
+    },
+    handleAgentIslandInteractionDismissed: vi.fn(),
+    clearPendingInteraction: vi.fn(() => null),
+    defaultDecisionForPending: vi.fn(),
+    persistInteractionDecision: vi.fn(),
+    broadcastToAllWindows: effects.fn('broadcast'),
+    broadcastCodexImageAsToolResult: vi.fn(async () => {}),
+    autoResumeBookkeeping: {
+      discardReplacementProvenByProviderEvent: vi.fn(),
+      clearFailedTurnCompletionTail: vi.fn(),
+      settleOutcome: vi.fn(),
+      noteFailedTurnCompletionTail: vi.fn(),
+      stashSuppressedError: vi.fn(),
+      stashOrcaSuppressedTerminal: vi.fn(() => true),
+      consumeFailedTurnCompletionTail: vi.fn(() => false),
+      hasSuppressedError: vi.fn(() => false),
+    },
+    pendingFailedTurnAssistantPersistId: new Map<string, string>(),
+    silentStopAutoResumeGuard: { noteTurnStarted: vi.fn() },
+    sessionTurnActivityTracker: activity,
+    productTurnWallClockTracker: new ProductTurnWallClockTracker(),
+    productTurnUsageTargetTracker: new ProductTurnUsageTargetTracker(),
+    advanceSessionTurnBoundaryGeneration: vi.fn(() => 1),
+    gitSnapshotCoordinator: {
+      hasPendingTurnStart: vi.fn(() => false),
+      onTurnStart: effects.fn('git-start'),
+      onTurnEnd: effects.fn('git-end'),
+      onTurnAbort: effects.fn('git-abort'),
+    },
+    workerTurnStartSequencer: createWorkerTurnStartSequencer(log),
+    orcaTeamServiceForEvents: {
+      handleWorkerTurnStarted: effects.fn('worker-start'),
+      captureWorkerText: vi.fn(),
+      captureWorkerTerminalTurn: vi.fn(() => ({ owner: 'old-turn' })),
+      handleWorkerTerminalTurn: effects.fn('worker-terminal'),
+    },
+    turnModelPromiseBySession: new Map<string, Promise<string>>(),
+    readSessionModelForUsage: vi.fn(async () => 'test-model'),
+    turnPiFastModeBySession: new Map<string, boolean>(),
+    silentStopTurnLeaseGate: { turnLeaseIdForEvent: vi.fn(() => 'instance:1') },
+    agentInputCoordinatorHolder: {
+      onTurnEvent: vi.fn(),
+      noteSuppressedTerminalError: vi.fn(),
+      onExternalTurnSettled: vi.fn(),
+      isAutoResumePending: vi.fn(() => false),
+      isAutoResumeDeferred: vi.fn(() => false),
+      getAutoResumeAttemptToken: vi.fn(() => 5),
+      getAutoResumeDeferredOwner: vi.fn(() => null),
+    },
+    handleSilentStopTurnEnd: vi.fn(async () => {}),
+    isRemoteAuthRetryErrorEvent: vi.fn(() => false),
+    isGatewayProxyTokenRecoveryErrorEvent: vi.fn(() => false),
+    overflowSuppressedBroadcasts: new Map(),
+    handleAgentIslandEventAfterBroadcast: effects.fn('island'),
+    notifyGoalIdleAfterTurnSettled: vi.fn(() => {
+      expect(activity.isSessionInTurn('task')).toBe(false);
+      effects.calls.push('goal');
+    }),
+    settlePendingCredentialSwitch: effects.fn('credentials'),
+    settlePendingSessionRuntimeControlHolder: effects.fn('runtime'),
+    deferredCodexRestartHolder: null,
+    refreshRemoteCodexMcpOnTurnSettledHolder: null,
+    markTurnEndedAfterPersistDrain: effects.fn('turn-drain'),
+    contextOverflowRolloverHolder: null,
+    lastReportedModelUsageBySession: new Map(),
+    claudeOutputLagTimingGuard: new ClaudeOutputLagTimingGuard(),
+    lastReportedCostUsdBySession: new Map<string, number>(),
+    unpricedSubscriptionValueMarker: () => ({
+      amount: 0,
+      currency: 'USD',
+      approximate: true,
+      kind: 'value-estimate',
+      estimateReasons: ['subscription-value'],
+    }),
+  };
+  // External services are reduced to their public event-facing methods. Session,
+  // activity, wall clock, usage target and worker sequencing above are real.
+  const dependencies = deps as unknown as SessionEventDependencies;
+  const emit = (value: AgentEvent) => handleSessionEvent(dependencies, session, value);
+  return {
+    deps,
+    dependencies,
+    activity,
+    session,
+    handle,
+    emit,
+    dispose: async () => {
+      activity.deleteSession('task');
+      await session.close();
+    },
+  };
+}
+
+beforeEach(() => {
+  vi.useFakeTimers();
+  for (const [name, fn] of effects.fns)
+    fn.mockReset().mockImplementation(() => {
+      effects.calls.push(name);
+    });
+  effects.calls.length = 0;
+  for (const name of [
+    'drainPersistQueue',
+    'recordModelTurnUsage',
+    'recordTurnUsageOnMessage',
+    'recordSchedulerTurnCost',
+    'persistSessionFields',
+    'getGatewayModelPricingForModel',
+  ])
+    effects.fn(name).mockResolvedValue(undefined);
+  effects.fn('getActiveCatalog').mockReturnValue({ providers: [] });
+  effects.fn('currentLedgerCurrency').mockReturnValue('USD');
+  effects.fn('reserveTurnErrorPersistId').mockImplementation(() => {
+    effects.calls.push('reserve');
+    return 'error-row';
+  });
+  effects.fn('onAssistantTextEvent').mockReturnValue('assistant-row');
+  effects.fn('onToolUseEvent').mockReturnValue('tool-row');
+  effects.fn('isSuccessfulCodexDoneEventData').mockReturnValue(true);
+  effects.fn('verdictForModelRoute').mockResolvedValue({ kind: 'pass' });
+});
+afterEach(() => {
+  vi.clearAllTimers();
+  vi.useRealTimers();
+});
+
+function ordered(...names: string[]) {
+  let previous = -1;
+  for (const name of names) {
+    const index = effects.calls.indexOf(name);
+    expect(index, name).toBeGreaterThan(previous);
+    previous = index;
+  }
+}
+
+describe('production Session event pipeline', () => {
+  it('keeps continuation segments running, then seals the final product boundary', async () => {
+    const h = harness();
+    vi.setSystemTime(1000);
+    h.emit(event('status', { isRunning: true }, { source: 'claude-code' }));
+    effects.fn('consumeLastAssistantPersistId').mockReturnValueOnce('segment-row');
+    vi.setSystemTime(3000);
+    h.emit(event('done', {}, { source: 'claude-code', turnContinuationId: 0 }));
+    expect(h.activity.isSessionInTurn('task')).toBe(true);
+    expect(h.deps.notifyGoalIdleAfterTurnSettled).not.toHaveBeenCalled();
+    expect(effects.fn('turn-drain')).not.toHaveBeenCalled();
+    expect(h.deps.gitSnapshotCoordinator.onTurnEnd).not.toHaveBeenCalled();
+    expect(effects.fn('clearCodexPlanRowsForSession')).not.toHaveBeenCalled();
+    expect(effects.fn('resetTurnPersistState')).toHaveBeenCalledOnce();
+    await microtasks();
+    expect(h.deps.orcaTeamServiceForEvents.handleWorkerTerminalTurn).not.toHaveBeenCalled();
+    effects.fn('recordTurnUsageOnMessage').mockClear();
+    vi.setSystemTime(5000);
+    h.emit(event('done', { total_cost_usd: 0, duration_ms: 20 }, { source: 'claude-code' }));
+    expect(h.activity.isSessionInTurn('task')).toBe(false);
+    expect(h.deps.notifyGoalIdleAfterTurnSettled).toHaveBeenCalledOnce();
+    await microtasks();
+    expect(effects.fn('recordTurnUsageOnMessage')).toHaveBeenCalledWith({
+      sessionId: 'task',
+      clientId: 'segment-row',
+      turnUsageDetails: expect.objectContaining({ turnDurationMs: 4000 }),
+    });
+    await h.dispose();
+  });
+
+  it('keeps the silent-stop decision window running and rejects an unowned late terminal', async () => {
+    const h = harness();
+    h.emit(event('done', { silentStop: true }));
+    expect(h.activity.isSessionInTurn('task')).toBe(true);
+    expect(h.deps.notifyGoalIdleAfterTurnSettled).not.toHaveBeenCalled();
+    await vi.advanceTimersByTimeAsync(1500);
+    expect(h.deps.handleSilentStopTurnEnd).toHaveBeenCalledOnce();
+    h.deps.silentStopTurnLeaseGate.turnLeaseIdForEvent.mockReturnValue(undefined as never);
+    effects.fn('broadcast').mockClear();
+    h.emit(event('done', { silentStop: true }));
+    expect(effects.fn('broadcast')).not.toHaveBeenCalled();
+    await h.dispose();
+  });
+
+  it('records context after status delivery and preserves Pi runtime context windows', async () => {
+    const h = harness();
+    Object.defineProperty(h.session, 'agentKind', { value: 'pi' });
+    effects.fn('resolveVerifiedContextWindow').mockReturnValue(99999);
+    h.emit(
+      event(
+        'status',
+        { isRunning: false, status: 'Done', contextTokens: 50, contextWindow: 12345 },
+        { source: 'pi' },
+      ),
+    );
+    ordered('broadcast', 'recordSessionContextSnapshot');
+    expect(effects.fn('recordSessionContextSnapshot')).toHaveBeenCalledWith('task', 50, 12345);
+    await h.dispose();
+  });
+
+  it('prefers the verified context window for a non-Pi session', async () => {
+    const h = harness();
+    effects.fn('resolveVerifiedContextWindow').mockReturnValue(99999);
+    h.emit(
+      event(
+        'status',
+        { isRunning: false, status: 'Done', contextTokens: 50, contextWindow: 12345 },
+        { source: 'claude-code' },
+      ),
+    );
+    expect(effects.fn('recordSessionContextSnapshot')).toHaveBeenCalledWith('task', 50, 99999);
+    await h.dispose();
+  });
+
+  it('keeps a retryable error running without resetting persistence', async () => {
+    const h = harness();
+    h.activity.setSessionInTurn('task', true);
+    h.emit(event('error', { message: 'retrying', isTerminal: false }));
+    expect(h.activity.isSessionInTurn('task')).toBe(true);
+    expect(h.deps.notifyGoalIdleAfterTurnSettled).not.toHaveBeenCalled();
+    expect(effects.fn('resetTurnPersistState')).not.toHaveBeenCalled();
+    expect(effects.fn('turn-drain')).not.toHaveBeenCalled();
+    expect(h.deps.gitSnapshotCoordinator.onTurnAbort).not.toHaveBeenCalled();
+    expect(effects.fn('broadcast')).toHaveBeenCalledOnce();
+    await h.dispose();
+  });
+
+  it('reserves the live error identity before delivery, then seals and persists before drain/reset', async () => {
+    const h = harness();
+    h.activity.setSessionInTurn('task', true);
+    effects.fn('consumeLastAssistantPersistId').mockReturnValue('assistant-row');
+    effects.fn('consumeLastTopLevelAssistantPersistId').mockReturnValue('assistant-row');
+    h.emit(event('error', { message: 'provider secret', reason: 'sdk_crash' }));
+    ordered(
+      'reserve',
+      'broadcast',
+      'island',
+      'goal',
+      'credentials',
+      'runtime',
+      'git-abort',
+      'flushAssistantBlock',
+      'flushOrphanToolResults',
+      'markAssistantTurnFailed',
+      'onTurnErrorEvent',
+      'persistCodexPlanOnTerminalError',
+      'turn-drain',
+      'clearCodexPlanRowsForSession',
+      'preserveTurnPersistStateForBackground',
+      'resetTurnPersistState',
+    );
+    expect(effects.fn('broadcast')).toHaveBeenCalledWith(
+      'maker:event',
+      expect.objectContaining({
+        event: expect.objectContaining({ data: { redacted: true } }),
+        persistId: 'error-row',
+      }),
+    );
+    expect(effects.fn('onTurnErrorEvent')).toHaveBeenCalledWith(
+      'task',
+      { message: 'provider secret', reason: 'sdk_crash' },
+      null,
+      'error-row',
+    );
+    await h.dispose();
+  });
+
+  it.each([true, false])(
+    'rechecks recovery after delivery changes pending to %s',
+    async (pendingAfter) => {
+      const h = harness();
+      h.deps.agentInputCoordinatorHolder.isAutoResumePending.mockReturnValue(!pendingAfter);
+      h.deps.broadcastToAllWindows.mockImplementation(() => {
+        h.deps.agentInputCoordinatorHolder.isAutoResumePending.mockReturnValue(pendingAfter);
+      });
+      h.emit(event('error', { message: 'failed', reason: 'sdk_crash' }));
+      expect(effects.fn('reserveTurnErrorPersistId')).toHaveBeenCalledTimes(pendingAfter ? 1 : 0);
+      expect(effects.fn('onTurnErrorEvent')).toHaveBeenCalledTimes(pendingAfter ? 0 : 1);
+      expect(effects.fn('releaseReservedTurnErrorPersistId')).toHaveBeenCalledTimes(
+        pendingAfter ? 1 : 0,
+      );
+      expect(h.deps.autoResumeBookkeeping.stashSuppressedError).toHaveBeenCalledTimes(
+        pendingAfter ? 1 : 0,
+      );
+      await h.dispose();
+    },
+  );
+
+  it('keeps deferred error and its paired done out of Orca terminal handling and preserves the failure seal', async () => {
+    const h = harness();
+    h.deps.agentInputCoordinatorHolder.isAutoResumeDeferred.mockReturnValue(true);
+    effects.fn('consumeLastAssistantPersistId').mockReturnValueOnce('failed-row');
+    effects.fn('consumeLastTopLevelAssistantPersistId').mockReturnValue('failed-row');
+    h.emit(event('error', { reason: 'sdk_crash' }, { sessionTurnGeneration: 4 }));
+    h.deps.autoResumeBookkeeping.consumeFailedTurnCompletionTail.mockReturnValue(true);
+    h.emit(event('done', {}, { sessionTurnGeneration: 4 }));
+    await microtasks();
+    expect(effects.fn('markAssistantTurnFailed')).toHaveBeenCalledOnce();
+    expect(effects.fn('markAssistantTurnCompleted')).not.toHaveBeenCalled();
+    expect(h.deps.autoResumeBookkeeping.stashOrcaSuppressedTerminal).toHaveBeenCalledOnce();
+    expect(h.deps.orcaTeamServiceForEvents.handleWorkerTerminalTurn).not.toHaveBeenCalled();
+    await h.dispose();
+  });
+
+  it.each(['failed', 'interrupted'])(
+    'seals a Codex %s done without a preceding error as failed',
+    async (status) => {
+      const h = harness();
+      effects.fn('isSuccessfulCodexDoneEventData').mockReturnValue(false);
+      effects.fn('consumeLastTopLevelAssistantPersistId').mockReturnValueOnce('failed-row');
+      h.emit(event('done', { raw: { id: 'turn', status } }));
+      expect(effects.fn('isSuccessfulCodexDoneEventData')).toHaveBeenCalledWith({
+        raw: { id: 'turn', status },
+      });
+      expect(effects.fn('markAssistantTurnFailed')).toHaveBeenCalledWith('task', 'failed-row');
+      expect(effects.fn('markAssistantTurnCompleted')).not.toHaveBeenCalled();
+      await h.dispose();
+    },
+  );
+
+  it('passes the native fork anchor to the successful assistant seal after flushing tools', async () => {
+    const h = harness();
+    const nativeForkAnchor = {
+      agentKind: 'codex',
+      sdkSessionId: 'thread',
+      kind: 'turn',
+      id: 'turn',
+    };
+    effects.fn('consumeLastTopLevelAssistantPersistId').mockReturnValueOnce('completed-row');
+    h.emit({ ...event('done'), agentMeta: { nativeForkAnchor } } as AgentEvent);
+    expect(effects.fn('markAssistantTurnCompleted')).toHaveBeenCalledWith('task', 'completed-row', {
+      nativeForkAnchor,
+    });
+    expect(effects.fn('markAssistantTurnFailed')).not.toHaveBeenCalled();
+    ordered('flushOrphanToolResults', 'markAssistantTurnCompleted', 'resetTurnPersistState');
+    await h.dispose();
+  });
+
+  it.each([true, false])(
+    'carries remote-auth recovery classification through persistence (%s)',
+    async (retry) => {
+      const h = harness();
+      h.deps.isRemoteAuthRetryErrorEvent.mockReturnValue(retry);
+      h.emit(event('error', { message: 'auth expired', reason: 'sdk_crash' }));
+      expect(effects.fn('reserveTurnErrorPersistId')).toHaveBeenCalledTimes(retry ? 0 : 1);
+      expect(effects.fn('onTurnErrorEvent')).toHaveBeenCalledTimes(retry ? 0 : 1);
+      expect(effects.fn('saveTurnStartedAtForDeferred')).toHaveBeenCalledTimes(retry ? 1 : 0);
+      if (retry) ordered('saveTurnStartedAtForDeferred', 'resetTurnPersistState');
+      await h.dispose();
+    },
+  );
+
+  it.each([true, false])(
+    'only counts foreground substantive output as retry progress (%s)',
+    async (background) => {
+      const h = harness();
+      effects.fn('onToolUseEvent').mockImplementation(() => {
+        effects.calls.push('tool');
+        return 'tool-row';
+      });
+      h.deps.interruptedTurnAutoResumeGuard.noteProgress.mockImplementation(() => {
+        effects.calls.push('progress');
+        return true;
+      });
+      h.emit(
+        event(
+          'tool_use',
+          { toolUseId: 'tool', toolName: 'read' },
+          background ? { turnScope: 'background' } : {},
+        ),
+      );
+      expect(h.deps.interruptedTurnAutoResumeGuard.noteProgress).toHaveBeenCalledTimes(
+        background ? 0 : 1,
+      );
+      if (!background) ordered('progress', 'tool', 'broadcast');
+      await h.dispose();
+    },
+  );
+
+  it('flushes assistant before foreground tool use, without flushing the current turn for background tools', async () => {
+    const h = harness();
+    effects.fn('onToolUseEvent').mockImplementation(() => {
+      effects.calls.push('tool');
+      return 'tool-row';
+    });
+    h.emit(event('text', { text: 'hello' }));
+    effects.calls.length = 0;
+    h.emit(event('tool_use', { toolUseId: 'tool', toolName: 'read' }));
+    ordered('flushAssistantBlock', 'tool', 'broadcast');
+    effects.fn('flushAssistantBlock').mockClear();
+    h.emit(event('tool_use', { toolUseId: 'background' }, { turnScope: 'background' }));
+    expect(effects.fn('flushAssistantBlock')).not.toHaveBeenCalled();
+    expect(effects.fn('broadcast')).toHaveBeenLastCalledWith(
+      'maker:event',
+      expect.objectContaining({ persistId: 'tool-row' }),
+    );
+    await h.dispose();
+  });
+
+  it.each(['stale', 'cleared-background', 'turn-diff'] as const)(
+    'drops %s before downstream state and delivery',
+    async (kind) => {
+      const h = harness();
+      if (kind === 'stale') h.deps.isFencedStaleSessionTerminal.mockReturnValue(true);
+      if (kind === 'cleared-background')
+        effects.fn('backgroundTurnPredatesSessionClear').mockReturnValue(true);
+      h.emit(
+        kind === 'turn-diff'
+          ? event('turn_diff')
+          : event(
+              'done',
+              {},
+              kind === 'cleared-background'
+                ? { turnScope: 'background', backgroundTurnStartedAt: 1 }
+                : {},
+            ),
+      );
+      expect(effects.fn('broadcast')).not.toHaveBeenCalled();
+      expect(h.deps.agentInputCoordinatorHolder.onTurnEvent).not.toHaveBeenCalled();
+      expect(effects.fn('flushAssistantBlock')).not.toHaveBeenCalled();
+      await h.dispose();
+    },
+  );
+
+  it('broadcasts background status without starting or settling the product turn', async () => {
+    const h = harness();
+    h.emit(event('status', { isRunning: true }, { turnScope: 'background' }));
+    h.emit(event('status', { isRunning: false }, { turnScope: 'background' }));
+    expect(h.activity.isSessionInTurn('task')).toBe(false);
+    expect(effects.fn('noteTurnStarted')).not.toHaveBeenCalled();
+    expect(effects.fn('turn-drain')).not.toHaveBeenCalled();
+    expect(effects.fn('broadcast')).toHaveBeenCalledTimes(2);
+    await h.dispose();
+  });
+
+  it('waits for accepted persistence and worker start while returning synchronously', async () => {
+    const h = harness(),
+      writes = deferred(),
+      start = deferred();
+    effects.fn('drainPersistQueue').mockReturnValue(writes.promise);
+    h.deps.orcaTeamServiceForEvents.handleWorkerTurnStarted.mockReturnValue(start.promise);
+    h.emit(event('status', { isRunning: true }));
+    effects.calls.length = 0;
+    expect(h.emit(event('done'))).toBeUndefined();
+    ordered(
+      'broadcast',
+      'island',
+      'goal',
+      'git-end',
+      'flushAssistantBlock',
+      'persistCodexPlanOnDone',
+      'turn-drain',
+      'resetTurnPersistState',
+    );
+    expect(effects.fn('refreshSessionListPreview')).not.toHaveBeenCalled();
+    expect(h.deps.orcaTeamServiceForEvents.handleWorkerTerminalTurn).not.toHaveBeenCalled();
+    h.deps.orcaTeamServiceForEvents.captureWorkerTerminalTurn.mockReturnValue({
+      owner: 'new-turn',
+    });
+    start.resolve();
+    writes.resolve();
+    await microtasks();
+    expect(h.deps.orcaTeamServiceForEvents.handleWorkerTerminalTurn).toHaveBeenCalledWith(
+      expect.objectContaining({ capture: { owner: 'old-turn' } }),
+    );
+    expect(effects.fn('refreshSessionListPreview')).toHaveBeenCalledOnce();
+    expect(effects.fn('maybeGenerateSessionTaskSummary')).toHaveBeenCalledWith('task', {
+      force: true,
+    });
+    await h.dispose();
+  });
+
+  it.each([null, 'ssh-host'])(
+    'only records local Codex account snapshots (remote=%s)',
+    async (remoteHostId) => {
+      const h = harness();
+      Object.defineProperty(h.session, 'remoteHostId', { value: remoteHostId });
+      h.emit(event('account_usage', { remaining: 42 }));
+      expect(effects.fn('recordCodexAccountUsageSnapshot')).toHaveBeenCalledTimes(
+        remoteHostId ? 0 : 1,
+      );
+      if (!remoteHostId) ordered('broadcast', 'recordCodexAccountUsageSnapshot');
+      await h.dispose();
+    },
+  );
+});
+
+describe('provider turn observer on real Session.send', () => {
+  function observerDeps() {
+    return {
+      log: { debug: vi.fn() },
+      providerTurnLeaseId: (id: string, turn: number) => `${id}:${turn}`,
+      silentStopTurnLeaseGate: {
+        supersede: vi.fn(),
+        supersedeOwnedBy: vi.fn(),
+        schedule: vi.fn(() => true),
+      },
+      sessionTurnLeaseTracker: {
+        markTurnStarted: vi.fn(async () => {
+          effects.calls.push('lease-start');
+        }),
+        markTurnEnded: vi.fn(async () => {}),
+      },
+    };
+  }
+  it.each(['reject', 'reroute'] as const)(
+    'stops a paid-model %s before lease and provider dispatch',
+    async (kind) => {
+      const h = harness(),
+        deps = observerDeps();
+      effects
+        .fn('verdictForModelRoute')
+        .mockResolvedValue({ kind, reason: 'payment-required', providerId: 'other' });
+      const dispose = installSessionTurnObserver(deps, h.session);
+      await expect(h.session.send('test')).rejects.toThrow(
+        kind === 'reject' ? 'requires paid access' : 'must switch',
+      );
+      expect(deps.sessionTurnLeaseTracker.markTurnStarted).not.toHaveBeenCalled();
+      expect(h.handle.send).not.toHaveBeenCalled();
+      dispose();
+      await h.dispose();
+    },
+  );
+  it('waits for permission and lease before dispatch, and tears down the owned lease', async () => {
+    const h = harness(),
+      deps = observerDeps(),
+      permission = deferred();
+    effects.fn('verdictForModelRoute').mockImplementation(async () => {
+      await permission.promise;
+      effects.calls.push('permission');
+      return { kind: 'pass' };
+    });
+    vi.mocked(h.handle.send).mockImplementation(async () => {
+      effects.calls.push('provider-send');
+    });
+    const dispose = installSessionTurnObserver(deps, h.session);
+    const sending = h.session.send('test');
+    await microtasks();
+    expect(h.handle.send).not.toHaveBeenCalled();
+    permission.resolve();
+    await sending;
+    ordered('permission', 'lease-start', 'provider-send');
+    dispose();
+    expect(deps.silentStopTurnLeaseGate.supersedeOwnedBy).toHaveBeenCalledWith(
+      'task',
+      `${h.session.instanceId}:`,
+    );
+    await h.dispose();
+  });
+  it('leaves remote provider admission and leases to the remote host', async () => {
+    const h = harness(),
+      deps = observerDeps();
+    Object.defineProperty(h.session, 'remoteHostId', { value: 'ssh-host' });
+    const dispose = installSessionTurnObserver(deps, h.session);
+    await h.session.send('remote');
+    expect(effects.fn('verdictForModelRoute')).not.toHaveBeenCalled();
+    expect(deps.sessionTurnLeaseTracker.markTurnStarted).not.toHaveBeenCalled();
+    expect(h.handle.send).toHaveBeenCalledOnce();
+    dispose();
+    await h.dispose();
+  });
+});
+
+describe('usage through the production event pipeline', () => {
+  const tokens = { inputTokens: 100, outputTokens: 20, cacheReadTokens: 10, cacheCreateTokens: 0 };
+  const segment = { ...tokens, model: 'test-model', priceVariant: 'standard' };
+  function usage(source: 'codex' | 'pi') {
+    return source === 'codex'
+      ? { promptTokens: 100, completionTokens: 20, cachedTokens: 10, segments: [segment] }
+      : { ...tokens, segments: [segment], segmentsComplete: true };
+  }
+  function pricing(subscription: boolean) {
+    const quote = {
+      providerId: subscription ? 'openai' : 'xd',
+      modelId: 'test-model',
+      currency: 'USD',
+      source: subscription ? 'subscription-reference' : 'gateway',
+      approximate: subscription,
+      inputPerMtok: 1,
+      outputPerMtok: 2,
+      cacheReadPerMtok: 0.1,
+    };
+    effects.fn('getSessionProvider').mockReturnValue(subscription ? 'openai' : 'xd');
+    effects
+      .fn('getCodexProxyAuthInjection')
+      .mockReturnValue(subscription ? 'oauth-bearer' : 'env-key');
+    effects.fn('getGatewayModelPricingForModel').mockResolvedValue({ xd: { 'test-model': quote } });
+    effects.fn('getModelPriceQuote').mockReturnValue(quote);
+    const referenceQuote = {
+      ...quote,
+      providerId: 'openai',
+      source: 'subscription-reference',
+      approximate: true,
+    };
+    for (const name of [
+      'getSubscriptionDirectValuePrice',
+      'getCodexProviderSubscriptionValuePrice',
+    ])
+      effects.fn(name).mockReturnValue(referenceQuote);
+    effects
+      .fn('getReferenceModelPricing')
+      .mockReturnValue({ openai: { 'test-model': referenceQuote } });
+    effects.fn('codexUsageToTokens').mockReturnValue(tokens);
+    effects.fn('piUsageToTokens').mockReturnValue(tokens);
+    effects.fn('consumeLastAssistantPersistId').mockReturnValue('assistant-row');
+  }
+
+  it.each([
+    ['codex', false],
+    ['codex', true],
+    ['pi', false],
+    ['pi', true],
+  ] as const)(
+    '%s attributes %s subscription pricing without changing token facts',
+    async (source, subscription) => {
+      const h = harness();
+      pricing(subscription);
+      h.emit(event('done', { usage: usage(source) }, { source }));
+      await microtasks();
+      expect(effects.fn('recordSessionTurnTokens')).toHaveBeenCalledWith('task', 130);
+      expect(effects.fn('recordModelTurnUsage')).toHaveBeenCalledWith(
+        expect.objectContaining({
+          inputTokensDelta: 100,
+          outputTokensDelta: 20,
+          cacheReadTokensDelta: 10,
+        }),
+      );
+      expect(effects.fn('recordSchedulerTurnCost')).toHaveBeenCalledWith(
+        expect.objectContaining({
+          clientId: 'assistant-row',
+          money: expect.objectContaining({ kind: subscription ? 'value-estimate' : 'actual-cost' }),
+        }),
+      );
+      expect(effects.fn('recordTurnSpend')).toHaveBeenCalledTimes(subscription ? 0 : 1);
+      expect(effects.fn('recordSessionTurnSpend')).toHaveBeenCalledTimes(subscription ? 0 : 1);
+      ordered('broadcast', 'recordSessionTurnTokens');
+      await h.dispose();
+    },
+  );
+
+  it.each(['codex', 'claude-code'] as const)(
+    'keeps remote %s usage out of local gateway charges',
+    async (source) => {
+      const h = harness();
+      pricing(false);
+      Object.defineProperty(h.session, 'remoteHostId', { value: 'ssh-host' });
+      h.deps.lastReportedCostUsdBySession.set('task', 10);
+      h.emit(
+        event(
+          'done',
+          source === 'codex'
+            ? { usage: usage('codex') }
+            : {
+                total_cost_usd: 12,
+                duration_ms: 100,
+                usage: { input_tokens: 100, output_tokens: 20 },
+              },
+          { source },
+        ),
+      );
+      await microtasks();
+      expect(effects.fn('recordTurnSpend')).not.toHaveBeenCalled();
+      expect(effects.fn('recordSessionTurnSpend')).not.toHaveBeenCalled();
+      expect(effects.fn('recordSchedulerTurnCost')).not.toHaveBeenCalledWith(
+        expect.objectContaining({ money: expect.objectContaining({ kind: 'actual-cost' }) }),
+      );
+      if (source === 'codex')
+        expect(effects.fn('recordModelTurnUsage')).toHaveBeenCalledWith(
+          expect.objectContaining({ inputTokensDelta: 100 }),
+        );
+      else
+        expect(effects.fn('recordTurnUsageOnMessage')).toHaveBeenCalledWith(
+          expect.objectContaining({
+            clientId: 'assistant-row',
+            turnUsageDetails: expect.objectContaining({ turnDurationMs: 100 }),
+          }),
+        );
+      await h.dispose();
+    },
+  );
+
+  it.each(['codex', 'pi'] as const)(
+    'retains %s token facts when pricing rejects',
+    async (source) => {
+      const h = harness();
+      pricing(false);
+      effects.fn('getGatewayModelPricingForModel').mockRejectedValue(new Error('offline'));
+      h.emit(event('done', { usage: usage(source) }, { source }));
+      await microtasks();
+      expect(effects.fn('recordTurnSpend')).not.toHaveBeenCalled();
+      expect(effects.fn('recordTurnUsageOnMessage')).toHaveBeenCalledWith(
+        expect.objectContaining({
+          clientId: 'assistant-row',
+          turnUsageDetails: expect.objectContaining({ inputTokens: 100, outputTokens: 20 }),
+        }),
+      );
+      expect(effects.fn('recordModelTurnUsage')).toHaveBeenCalledWith(
+        expect.objectContaining({ inputTokensDelta: 100, outputTokensDelta: 20 }),
+      );
+      await h.dispose();
+    },
+  );
+
+  it('keeps accepted old-turn accounting after replacement and does not block delivery on model lookup', async () => {
+    const h = harness(),
+      replacement = harness(),
+      model = deferred<string>();
+    pricing(false);
+    const lifecycle = createSessionBindingLifecycle<Session, null>({
+      log: h.deps.log,
+      restoreInteractionListener: vi.fn(),
+      beforeReplace: vi.fn(),
+      onBind: vi.fn(),
+      broadcastStatus: vi.fn(),
+      captureCloseContext: () => null,
+      cleanupClosedSession: vi.fn(),
+      beforeCloseTeardown: vi.fn(),
+      finalizeClosedSession: vi.fn(),
+    });
+    const registration = lifecycle.beginBinding(h.session)!;
+    registration.disposers.push(h.session.onEvent(h.emit));
+    lifecycle.attachStatusListener(registration);
+    h.deps.turnModelPromiseBySession.set('task', model.promise);
+    h.emit(event('done', { usage: usage('codex') }));
+    expect(effects.fn('broadcast')).toHaveBeenCalledOnce();
+    expect(effects.fn('recordSchedulerTurnCost')).not.toHaveBeenCalled();
+    lifecycle.beginBinding(replacement.session);
+    effects.fn('consumeLastAssistantPersistId').mockReturnValue('new-row');
+    model.resolve('test-model');
+    await microtasks();
+    expect(effects.fn('recordSchedulerTurnCost')).toHaveBeenCalledWith(
+      expect.objectContaining({ clientId: 'assistant-row' }),
+    );
+    expect(lifecycle.getSession('task')).toBe(replacement.session);
+    await h.dispose();
+    await replacement.dispose();
+  });
+
+  it('uses only the Claude cumulative delta after establishing a baseline', async () => {
+    const h = harness();
+    effects.fn('getSessionProvider').mockReturnValue('custom-api');
+    effects
+      .fn('getActiveCatalog')
+      .mockReturnValue({ providers: [{ id: 'custom-api', access: { kind: 'api' } }] });
+    effects.fn('getGatewayAccountCurrency').mockResolvedValue('USD');
+    effects.fn('consumeLastAssistantPersistId').mockReturnValue('assistant-row');
+    h.emit(
+      event(
+        'done',
+        { total_cost_usd: 100, usage: { input_tokens: 5000 } },
+        { source: 'claude-code' },
+      ),
+    );
+    await microtasks();
+    expect(effects.fn('recordTurnSpend')).not.toHaveBeenCalled();
+    h.emit(
+      event(
+        'done',
+        { total_cost_usd: 102, usage: { input_tokens: 6000 } },
+        { source: 'claude-code' },
+      ),
+    );
+    await microtasks();
+    expect(effects.fn('recordTurnSpend')).toHaveBeenCalledWith(
+      expect.objectContaining({ amount: 2, kind: 'actual-cost' }),
+    );
+    expect(effects.fn('recordSchedulerTurnCost')).toHaveBeenCalledWith(
+      expect.objectContaining({ money: expect.objectContaining({ amount: 2 }) }),
+    );
+    await h.dispose();
+  });
+});

--- a/apps/desktop/src/main/maker-ipc/register.ts
+++ b/apps/desktop/src/main/maker-ipc/register.ts
@@ -71,9 +71,7 @@ import { upsertRecentWorkdir } from '../localDb/ipc/recentWorkdirs.js';
 import type { AgentMeta, Session as RendererSession } from '../../renderer/lib/ccAgent.types';
 import {
   deriveAutoTitleSeed,
-  getAgentFacingText,
   normalizeAgentInputClearBoundaryMs,
-  parseAgentInputToolLoopDetails,
   serializeSessionReferencePayload,
   type AgentInputClearBoundaryOpts,
   type AgentInputCreateOpts,
@@ -83,7 +81,7 @@ import {
 } from '../../shared/agentInputQueue.js';
 import { getManagedWorktreeBasePath } from '../../shared/managedWorktreePaths.js';
 import { normalizeWorkingDirForProjectSettings } from '../../shared/workingDir.js';
-import { buildTurnUsageDetails } from '../../shared/turnUsageDetails.js';
+
 import {
   buildDeferredRuntimeSelectionProfile,
   nextDeferredModelWindowRetry,
@@ -138,10 +136,7 @@ import {
   getActiveCodexBridgeServerNames,
   shutdownCodexEnvironment,
 } from '../mcp-integrations/codexEnvironment.js';
-import {
-  invalidatePiEnvironment,
-  shutdownPiEnvironment,
-} from '../mcp-integrations/piEnvironment.js';
+import { invalidatePiEnvironment } from '../mcp-integrations/piEnvironment.js';
 import { REMOTE_MEMORY_SERVER_NAME } from '../mcp-integrations/codexHttpBridge.js';
 import { getRemoteMcpBridgeToken } from '../mcp-integrations/remoteMcpBridgeToken.js';
 import {
@@ -178,6 +173,11 @@ import {
   createSessionControlService,
   sessionQueueOriginForDispatcher,
 } from './sessionControlService.js';
+import {
+  createSessionBindingLifecycle,
+  finalizeSessionClose,
+  runSessionCloseCleanup,
+} from './sessionBindingLifecycle.js';
 import { readCanonicalSessionActivity } from './sessionActivityProjection.js';
 import {
   listAtBrowserTabs,
@@ -283,14 +283,9 @@ import {
   releaseReviewSourceLease,
   tryAcquireReviewSourceLease,
 } from '../reviewer/reviewSourceLease.js';
-import { persistSubagentTaskUpdate } from '../localDb/subagentRuns.js';
+
 import { broadcastSubagentRunsChanged } from '../localDb/ipc/subagentRuns.js';
-import {
-  captureSubagentObservationGeneration,
-  clearSubagentObservationRewindState,
-  enqueueSubagentObservationWrite,
-  noteSubagentObservationTurnStarted,
-} from '../subagentObservationRewindFence.js';
+import { clearSubagentObservationRewindState } from '../subagentObservationRewindFence.js';
 import {
   applyAgentSwitchToSessionRow,
   applyAgentSwitchResumeFallbackAtomically,
@@ -306,10 +301,7 @@ import {
 } from '../localDb/ipc/sessions.js';
 import { persistableSessionEffort } from '../localDb/mapper.js';
 // sidebar-card-mode: turn-done 后刷新列表预览,并按需生成置顶卡片摘要
-import {
-  maybeGenerateSessionTaskSummary,
-  refreshSessionListPreview,
-} from '../sessionTaskSummary.js';
+
 import {
   addOrUpdateWorker,
   archiveSingleWorkerSession,
@@ -354,10 +346,7 @@ import {
   getRemoteCcTurnSettledHandler,
   getRemoteCcStaleQuery,
 } from '../maker-host/remote-session-start-ensure.js';
-import {
-  getCodexProxyAuthInjection,
-  getCodexProxyAuthInjectionState,
-} from '../maker-host/codex-proxy-host.js';
+import { getCodexProxyAuthInjectionState } from '../maker-host/codex-proxy-host.js';
 import {
   readCollaborationSettings,
   readCollaborationSettingsState,
@@ -426,7 +415,6 @@ import {
   getRecoveryContextSnapshot,
   markSessionTurnEnded,
   markSessionTurnEndedAfterBarrier,
-  markSessionTurnStarted,
 } from '../localDb/sessionActiveTurn.js';
 import {
   assertDesktopSendDispatched,
@@ -442,7 +430,6 @@ import {
   listVisibleActiveSessionIds,
 } from '../maker-host/session-storage.js';
 import {
-  backgroundTurnPredatesSessionClear,
   clearSessionPersistState,
   consumeLastAssistantPersistId,
   consumeLastTopLevelAssistantPersistId,
@@ -452,30 +439,15 @@ import {
   flushOrphanToolResults,
   getLastAssistantTranscriptUuid,
   getSessionDbAgentKind,
-  isSuccessfulCodexDoneEventData,
-  markAssistantTurnCompleted,
   markAssistantTurnFailed,
-  noteAgentMeta,
   noteSessionAgentKind,
   noteSessionClearBoundary,
-  noteTurnStarted,
-  onAssistantTextEvent,
-  onAgentTaskUpdateEvent,
   onInteractionMessage,
   onInteractionResolved,
   clearCodexPlanRowsForSession,
-  persistCodexPlanOnDone,
-  persistCodexPlanOnTerminalError,
-  onThinkingEvent,
-  onToolResultEvent,
-  onToolResultFullEvent,
-  onToolUseEvent,
-  preserveTurnPersistStateForBackground,
   sealAssistantBlockForLateFinal,
   markAutoResumeOutcome,
   onTurnErrorEvent,
-  releaseReservedTurnErrorPersistId,
-  reserveTurnErrorPersistId,
   prepareSyntheticToolEventForBroadcast,
   resetTurnPersistState,
   saveTurnStartedAtForDeferred,
@@ -494,77 +466,20 @@ import {
   ensureRemoteAgentInstalledOrInstall,
   ensureRemoteHostReady,
   getRemoteSshPool,
-  isCcMgrUpgradeInFlight,
   broadcastSilentInstallStatus,
 } from '../remote-ssh/index.js';
-import {
-  recordSessionContextSnapshot,
-  recordSessionTurnSpend,
-  recordSessionTurnTokens,
-} from '../sessionSpendBroadcaster.js';
-import {
-  codexUsageToTokens,
-  piUsageToTokens,
-  recordSchedulerTurnCost,
-  recordTurnCostOnMessage,
-  recordTurnUsageOnMessage,
-} from '../turnCostBroadcaster.js';
-import { recordModelMismatchOnMessage } from '../modelMismatchBroadcaster.js';
-import { detectClaudeModelMismatch } from '../../shared/modelMismatch.js';
-import { triggerClaudeAccountUsageRefresh } from '../usage/claudeAccountUsage.js';
-import {
-  getGatewayAccountCurrency,
-  getGatewayModelPricingForModel,
-  getModelPriceQuote,
-} from '../usage/modelPricing.js';
-import {
-  broadcastReferenceModelPricing,
-  getCodexProviderSubscriptionValuePrice,
-  getReferenceModelPricing,
-  getSubscriptionDirectValuePrice,
-} from '../usage/referenceModelPricing.js';
+import { recordSessionContextSnapshot } from '../sessionSpendBroadcaster.js';
+
+import { broadcastReferenceModelPricing } from '../usage/referenceModelPricing.js';
 import {
   clearModelPriceOverride,
   stageProviderModelPriceOverridesClear,
   readModelPriceOverrideView,
   setModelPriceOverride,
 } from '../usage/modelPriceOverrideStore.js';
-import {
-  ClaudeOutputLagTimingGuard,
-  computeModelUsageDeltas,
-  type ModelUsageCumulative,
-  type ModelUsageDeltaEntry,
-} from '../usage/modelUsageDelta.js';
-import {
-  claudeSubscriptionUsageModelKey,
-  codexApiUsageModelKey,
-  codexSubscriptionUsageModelKey,
-  getSubscriptionValuePriceFor,
-  piSubscriptionUsageModelKey,
-} from '../usage/usageHistory.js';
-import {
-  billingRouteForExplicitProvider,
-  buildClaudeTurnUsageDetails,
-  computePriceQuoteTurnMoney,
-  isAnthropicModel,
-  normalizeTurnUsageSegments,
-  normalizeModelIdForPricing,
-  resolveTurnCost,
-  resolveClaudeTurnCostSinks,
-  sumTurnUsageSegments,
-  type BillingRoute,
-} from '../usage/turnCostCalculator.js';
-import {
-  CHATGPT_MODEL_PREFIX,
-  XAI_MODEL_PREFIX,
-  isExclusiveXaiModelId,
-  isSubscriptionDirectRoute,
-} from '../../shared/subscriptionModels.js';
-import {
-  addRegionalMoney,
-  usdToLedgerCurrency,
-  type RegionalMoney,
-} from '../../shared/regionalMoney.js';
+import { ClaudeOutputLagTimingGuard, type ModelUsageCumulative } from '../usage/modelUsageDelta.js';
+
+import { type RegionalMoney } from '../../shared/regionalMoney.js';
 import { currentLedgerCurrency } from '../usage/ledgerCurrency.js';
 import {
   mergePiPackageCommands,
@@ -588,20 +503,7 @@ import {
   issuePiPackageMutationGrant,
   piPackageMutationNeedsGrant,
 } from '../maker-host/pi-package-mutation-grant.js';
-import { CURRENT_CINDY_REGION } from '../../shared/brandRegion.js';
-import {
-  triggerClaudeSubscriptionUsageRefresh,
-  triggerCodexAccountUsageRefresh,
-  triggerXaiSubscriptionUsageRefresh,
-} from './usage.js';
-import {
-  rebroadcastCodexTodayUsage,
-  rebroadcastTodaySpend,
-  recordCodexAccountUsageSnapshot,
-  recordCodexTurnUsage,
-  recordModelTurnUsage,
-  recordTurnSpend,
-} from '../usageBroadcaster.js';
+
 import { requireEnum, requireObject, throwIpcError } from '../utils/ipcValidate.js';
 import { isIpcError } from '../../shared/ipc-errors.js';
 import {
@@ -611,10 +513,7 @@ import {
 import { dbToMakerAgentKind, makerToDbAgentKind } from '../../shared/agentKindConversion.js';
 import { readWorkflowProgressForSession } from '../workflow-progress/reader.js';
 import { AgentInputCoordinator } from './agent-input-coordinator.js';
-import {
-  clearPromptPredictionSessionStopped,
-  notePromptPredictionSessionStopped,
-} from './promptPredictionStopLedger.js';
+import { notePromptPredictionSessionStopped } from './promptPredictionStopLedger.js';
 import {
   estimateReferenceTokens,
   MAX_REFERENCE_MESSAGES,
@@ -630,7 +529,7 @@ import type { CollabDispatchOutcome } from './collabSendOutcome.js';
 import { runAcceptedCallback } from './acceptedCallbackRunner.js';
 import { createElectronIpcHandlerRegistry } from './electronIpcRegistry.js';
 import { refreshCodexMcpEnvironment } from './codexMcpRefresh.js';
-import { broadcastSchedulerChanged } from './schedule.js';
+
 import {
   excludeDirectoryGrantConflictsWithSlots,
   extraDirsForRuntime,
@@ -711,7 +610,6 @@ import {
   normalizeUserMessage,
   materializeDirectSendOssAttachments,
   materializeQueuedOssAttachmentsDeferred,
-  materializeQueuedOssAttachments,
 } from './normalizeAttachments.js';
 import { QueuedAttachmentOwnershipRegistry } from './queuedAttachmentOwnership.js';
 import { AGENT_ISLAND_DISPLAY_CONFIG } from '../agent-island/displayConfig.js';
@@ -784,13 +682,10 @@ import {
 } from './agentHandoff.js';
 import {
   createContextOverflowRollover,
-  isContextOverflowErrorData,
-  isOversizedHistoryErrorData,
   isPiPromptRpcTimeoutError,
   lookupVerifiedContextWindow,
   persistedUserContentToWireMessage,
   type ModelWindowSwitchPreparationResult,
-  shouldRebuildPiNativeSession,
 } from './contextOverflowRollover.js';
 import {
   classifyCodexHistoryOversized,
@@ -840,7 +735,6 @@ import { testProviderConnection } from '../maker-host/provider-diagnostics.js';
 import { fetchProviderModels } from '../maker-host/provider-model-fetch.js';
 import {
   beginProviderRouteMutation,
-  isUserProviderSession,
   setPendingCredentialSwitchReader,
 } from '../maker-host/provider-route.js';
 import {
@@ -922,8 +816,7 @@ import {
   noteClaudeSessionTurnState,
   setClaudeBackgroundActivityBroadcaster,
 } from '../maker-host/claude-session-background-activity.js';
-import { readClaudeSessionRoute } from '../maker-host/claude-session-route-registry.js';
-import { consumeClaudeOpusPlanMismatch } from '../maker-host/claude-gateway-error-observer.js';
+
 import { setLiveCcSessionBridge } from '../maker-host/claude-transcript-relocation.js';
 import {
   CredentialModeSwitchBusyError,
@@ -1056,7 +949,6 @@ import {
 import { readSilentStopAutoResumeSettings } from '../maker-host/silent-stop-auto-resume-store.js';
 import {
   AutoResumeBookkeeping,
-  shouldSkipOrcaWorkerTerminal,
   type SuppressedTurnError,
   type SuppressedTurnErrorOwner,
 } from './autoResumeBookkeeping.js';
@@ -1064,18 +956,15 @@ import {
   InterruptedTurnAutoResumeGuard,
   isAutoResumeUserMessage,
   isInterruptedTurnError,
-  isSubstantiveProgressEvent,
   type InterruptedTurnErrorSignals,
 } from './interruptedTurnAutoResume.js';
 import { readInterruptedTurnAutoResumeSettings } from '../maker-host/interrupted-turn-auto-resume-store.js';
-import { isSuccessfulAssistantReplyDoneData } from '../cindy-brain/assistantReplyHook.js';
+
 import {
   broadcastGhostMessageBlocked,
   broadcastGhostMessageRewritten,
   createGhostSessionTap,
   getGhostFsSlot,
-  hasEnabledGhostAssistantHook,
-  runGhostAssistantReplyHook,
   hasEnabledUserMessageHookGhost,
   screenGhostUserMessage,
   setGhostAgentTurnRunner,
@@ -1095,7 +984,6 @@ import {
 import { isGhostPickedDir } from '../cindy-brain/pickGrantsStore.js';
 import {
   resolveGhostUserHookModel,
-  withGhostAssistantHookModel,
   withGhostUserHookModel,
 } from '../cindy-brain/subscriptionGateway.js';
 import { createGhostErrandRunner } from './ghostErrandRunner.js';
@@ -1106,6 +994,8 @@ import {
 } from '../localDb/ipc/pluginWorkspaceSessions.js';
 import { normalizeWorkingDirForStorage } from '../../shared/workingDir.js';
 import { openMainWindowSession } from '../deepLink.js';
+import { handleSessionEvent, type SessionEventDependencies } from './sessionEventPipeline.js';
+import { installSessionTurnObserver } from './sessionTurnObserver.js';
 
 const log = createLogger('maker-ipc');
 
@@ -1151,8 +1041,6 @@ const interruptedTurnAutoResumeGuard = new InterruptedTurnAutoResumeGuard({
 });
 let settlePendingSessionRuntimeControlHolder: ((sessionId: string, reason: string) => void) | null =
   null;
-let broadcastSessionRuntimeProjectionHolder:
-  ((sessionId: string, baselineOverride?: SessionRuntimeProfile) => Promise<void>) | null = null;
 
 function projectSessionRuntimeControl(
   sessionId: string,
@@ -2681,20 +2569,6 @@ export function takePendingInteractionsForSession(sessionId: string): Array<{
 
 type WiredSession = NonNullable<ReturnType<Maker['getSession']>>;
 
-interface WiredSessionRegistration {
-  session: WiredSession;
-  disposers: Array<() => void>;
-}
-
-/**
- * 记录已经 wire 过 IPC 转发的 session 实例，避免 lazy-create 路径或多个调用方
- * (renderer IPC handler / scheduler runner / feishu 接管 / future MCP server) 重复挂 listener。
- *
- * deferred agent switch 会保留业务 id 但替换 Session 实例；此时必须解绑旧实例并完整
- * wire 新实例，不能只按 id 去重。
- */
-const wiredSessionsById = new Map<string, WiredSessionRegistration>();
-
 /**
  * Monotonic logical-turn generation used by direct abort reconciliation.
  * Session ids survive owner-boundary replacement, so the Session object alone
@@ -3584,7 +3458,7 @@ function surfaceSuppressedAutoResumeErrorInAgentIsland(
   try {
     const service = getAgentIslandService();
     if (!service) return;
-    const wired = wiredSessionsById.get(sessionId)?.session;
+    const wired = sessionBindings.getSession(sessionId);
     const meta = wired ? sessionMetaForIsland(wired) : { sessionId };
     service.handleAgentEvent(
       meta,
@@ -4164,94 +4038,252 @@ function isFencedStaleSessionTerminal(sessionId: string, event: AgentEvent): boo
   );
 }
 
-export function wireSessionToIpc(session: ReturnType<Maker['getSession']>): void {
-  if (!session) return;
-  const existing = wiredSessionsById.get(session.id);
-  if (existing?.session === session) {
-    installDesktopInteractionListener(session);
-    return;
-  }
-  if (existing) {
-    // A runtime replacement invalidates any delayed direct-abort callback that
-    // still belongs to the old Session instance.
+interface WiredSessionCloseContext {
+  closeReason: ReturnType<typeof getWiredSessionCloseReason>;
+  closedDirectAbortBoundary: DirectAbortReconcileBoundary | null;
+  preserveAutoResumeIntent: boolean;
+}
+
+/** Desktop adapters for the instance-owned binding and synchronous close lifecycle. */
+const sessionBindings = createSessionBindingLifecycle<WiredSession, WiredSessionCloseContext>({
+  log,
+  restoreInteractionListener: installDesktopInteractionListener,
+  beforeReplace: (session: WiredSession) => {
+    // Invalidate delayed callbacks before publishing the replacement instance.
     cancelDirectAbortReconciliation(session.id);
     goalDeferredResumeCancelObserver?.(session.id);
-    for (const dispose of existing.disposers) dispose();
-    existing.session.setInteractionListener(null);
-  }
-  advanceSessionTurnBoundaryGeneration(session.id);
-  const registration: WiredSessionRegistration = { session, disposers: [] };
-  wiredSessionsById.set(session.id, registration);
+  },
+  onBind: (session: WiredSession) => {
+    advanceSessionTurnBoundaryGeneration(session.id);
+  },
+  broadcastStatus: (session: WiredSession, status) => {
+    broadcastToAllWindows(MAKER_PUSH.STATUS_CHANGED, { sessionId: session.id, status });
+  },
+  captureCloseContext: (session: WiredSession) => {
+    const closeReason = getWiredSessionCloseReason(session);
+    const closedDirectAbortBoundary = getDirectAbortBoundaryForClosingSession(session.id, session);
+    const preserveAutoResumeIntent =
+      shouldPreserveCodexReconnectStalledAutoResume(session, closeReason) ||
+      shouldPreserveSessionRuntimeFallbackAutoResume(session, closeReason);
+    pendingCodexReconnectStalledRebuilds.delete(session);
+    return { closeReason, closedDirectAbortBoundary, preserveAutoResumeIntent };
+  },
+  cleanupClosedSession: (session: WiredSession, context) => {
+    runSessionCloseCleanup(context.preserveAutoResumeIntent, {
+      cleanupInteractions: () => cleanupPendingInteractionsForSession(session.id, 'session_closed'),
+      preserveAutoResume: () => {
+        log.info('preserving scheduled Codex reconnect-stall auto-resume across provider rebuild', {
+          sessionId: session.id,
+          attemptToken: agentInputCoordinatorHolder?.getAutoResumeAttemptToken(session.id),
+          closeReason: context.closeReason,
+        });
+      },
+      resetAutoResume: () => {
+        // Cancelling both the timer and its bookkeeping prevents a closed task
+        // from being resurrected or attaching recovery to a replacement runtime.
+        interruptedTurnAutoResumeGuard.noteSessionReset(session.id);
+        autoResumeBookkeeping.teardown(session.id);
+      },
+      // Read at the coordinator boundary, as before: only a close/rebuild window
+      // preserves the signal currently driving that rebuild, not the old queue.
+      shouldPreserveInputBoundary: () => rehydrateCloseSuppression.isSuppressed(session.id),
+      closeInputCoordinator: (options) => {
+        agentInputCoordinatorHolder?.onSessionClosed(session.id, options);
+      },
+      cleanupRuntimeState: () => cleanupClosedSessionRuntime(session),
+    });
+  },
+  beforeCloseTeardown: (session: WiredSession) => {
+    cancelDirectAbortReconciliation(session.id);
+    pendingFailedTurnAssistantPersistId.delete(session.id);
+  },
+  finalizeClosedSession: (session: WiredSession, context) => {
+    finalizeSessionClose(context.closedDirectAbortBoundary !== null, {
+      clearTurnState: () => {
+        sessionTurnActivityTracker.deleteSession(session.id);
+        sessionTurnBoundaryGenerationById.delete(session.id);
+        markSessionTurnEnded(session.id);
+      },
+      notifyGoalIdle: () => notifyGoalIdleAfterTurnSettled(session.id),
+      cancelGoalResume: () => goalDeferredResumeCancelObserver?.(session.id),
+    });
+  },
+});
 
-  session.setTurnLifecycleObserver({
-    beforeProviderStart: async (turnGeneration) => {
-      if (session.remoteHostId) return;
-      // 每条本地 Session.send 都经过这一个 Main-owned 边界，包括 renderer、IM、
-      // Goal、Learn、Hook 与 Scheduler。付费权限不能只挂在普通 IPC 发送事务上。
-      const model = session.model;
-      if (model) {
-        const verdict = await verdictForModelRoute(
-          session.agentKind,
-          model,
-          getSessionProvider(session.id),
-        );
-        // beforeProviderStart 已经进入 Session 内部，无法再安全重建跨凭证形态的
-        // runtime。付费 reroute 不能当作 pass，否则 null-provider 仍会落到已锁定
-        // 的 XD 默认来源。普通停用/能力/独占 reroute 属于既有 best-effort 轴，
-        // 运行中会话按 model-route-guard 契约不在这里打断。
-        if (verdict.kind === 'reroute' && verdict.reason === 'payment-required') {
-          throwIpcError(
-            'INVALID_PARAMS',
-            `model "${model}" must switch to provider "${verdict.providerId}" before sending`,
-          );
-        }
-        if (verdict.kind === 'reject' && verdict.reason === 'payment-required') {
-          throwIpcError('PERMISSION_DENIED', `model "${model}" requires paid access`);
-        }
-      }
-      silentStopTurnLeaseGate.supersede(session.id);
-      // Keep Review's exact-instance liveness listener lazy. PID-only turn
-      // leases remain fail-closed until this process actually starts Review.
-      await sessionTurnLeaseTracker.markTurnStarted(
-        session.id,
-        providerTurnLeaseId(session.instanceId, turnGeneration),
-      );
-    },
-    onUndispatched: async (turnGeneration) => {
-      if (session.remoteHostId) return;
-      await sessionTurnLeaseTracker.markTurnEnded(
-        session.id,
-        providerTurnLeaseId(session.instanceId, turnGeneration),
-      );
-    },
-    onTerminal: ({ turnGeneration, event, isCurrentGeneration }) => {
-      if (session.remoteHostId) return;
-      const turnLeaseId = providerTurnLeaseId(session.instanceId, turnGeneration);
-      const isSilentStop =
-        event.type === 'done' &&
-        (event.data as { silentStop?: unknown } | null | undefined)?.silentStop === true;
-      if (isSilentStop && isCurrentGeneration) {
-        // The provider turn ended, but the product turn remains occupied while
-        // the bounded auto-resume decision runs. Its exact lease is either
-        // replaced by the next provider generation or released by settle.
-        const scheduled = silentStopTurnLeaseGate.schedule(session.id, event, turnLeaseId);
-        if (!scheduled) {
-          log.debug('ignored duplicate silent-stop terminal for the current turn', {
-            sessionId: session.id,
-            turnLeaseId,
-          });
-        }
-        return;
-      }
-      if (isCurrentGeneration) silentStopTurnLeaseGate.supersede(session.id);
-      void sessionTurnLeaseTracker.markTurnEnded(session.id, turnLeaseId);
-    },
-  });
-  registration.disposers.push(() => {
-    session.setTurnLifecycleObserver(null);
-    silentStopTurnLeaseGate.supersedeOwnedBy(session.id, `${session.instanceId}:`);
-    void sessionTurnLeaseTracker.markTurnEnded(session.id);
-  });
+/** Remaining domain cleanup stays in its original order, after input coordination. */
+function cleanupClosedSessionRuntime(session: WiredSession): void {
+  // 会话关闭:兑现延迟凭证切换(直接写 route),并唤醒被它挡住的等待者。
+  pendingCredentialSwitchHolder?.onSessionClosed(session.id);
+  deferredCodexRestartHolder?.onSessionSettled();
+  agentInputCoordinatorHolder?.onExternalTurnSettled(session.id);
+  refreshRemoteCodexMcpOnTurnSettledHolder?.(session.id);
+  gitSnapshotCoordinator?.onSessionClosed(session.id);
+  clearOrcaMcpHydrated(session.id);
+  knownNonOrcaSessionIds.delete(session.id);
+  lastReportedCostUsdBySession.delete(session.id);
+  lastReportedModelUsageBySession.delete(session.id);
+  turnModelPromiseBySession.delete(session.id);
+  turnPiFastModeBySession.delete(session.id);
+  productTurnWallClockTracker.clear(session.id);
+  productTurnUsageTargetTracker.clear(session.id);
+  claudeOutputLagTimingGuard.clear(session.id);
+  // 后台活动检测:会话进程已关闭(closeSession / 删除),清账并广播横幅熄灭。
+  clearClaudeSessionBackgroundActivity(session.id);
+  clearSessionPersistState(session.id);
+  const subagentRewindStateCleared = clearSubagentObservationRewindState(session.id);
+  if (!subagentRewindStateCleared) {
+    log.warn('session close deferred active Subagent Rewind cleanup', {
+      sessionId: session.id,
+    });
+  }
+  // 进程关闭 ≠ 通知作废:临时会话调度(非 heartbeat / 非 persistentSession)在 run
+  // 终态后立刻 closeSession,此刻完成卡片刚在灵动岛上弹出来。硬删条目会让它当场
+  // 消失,所以这条路径保留仍在展示的卡片,由 dwell 到期或用户 ack 收掉。
+  handleAgentIslandSessionClosedAfterCleanup(session.id, 'process-closed');
+}
+
+// Keep holder reads live, including reads after an awaited pricing/persistence
+// operation. Capturing these services when wiring a Session would freeze the
+// pre-initialization or previous runtime value for later events.
+const sessionEventDependencies: SessionEventDependencies = {
+  get isFencedStaleSessionTerminal() {
+    return isFencedStaleSessionTerminal;
+  },
+  get log() {
+    return log;
+  },
+  get interruptedTurnAutoResumeGuard() {
+    return interruptedTurnAutoResumeGuard;
+  },
+  get redactEventForRenderer() {
+    return redactEventForRenderer;
+  },
+  get handleAgentIslandInteractionDismissed() {
+    return handleAgentIslandInteractionDismissed;
+  },
+  get clearPendingInteraction() {
+    return clearPendingInteraction;
+  },
+  get defaultDecisionForPending() {
+    return defaultDecisionForPending;
+  },
+  get persistInteractionDecision() {
+    return persistInteractionDecision;
+  },
+  get broadcastToAllWindows() {
+    return broadcastToAllWindows;
+  },
+  get broadcastCodexImageAsToolResult() {
+    return broadcastCodexImageAsToolResult;
+  },
+  get autoResumeBookkeeping() {
+    return autoResumeBookkeeping;
+  },
+  get pendingFailedTurnAssistantPersistId() {
+    return pendingFailedTurnAssistantPersistId;
+  },
+  get silentStopAutoResumeGuard() {
+    return silentStopAutoResumeGuard;
+  },
+  get sessionTurnActivityTracker() {
+    return sessionTurnActivityTracker;
+  },
+  get productTurnWallClockTracker() {
+    return productTurnWallClockTracker;
+  },
+  get productTurnUsageTargetTracker() {
+    return productTurnUsageTargetTracker;
+  },
+  get advanceSessionTurnBoundaryGeneration() {
+    return advanceSessionTurnBoundaryGeneration;
+  },
+  get gitSnapshotCoordinator() {
+    return gitSnapshotCoordinator;
+  },
+  get workerTurnStartSequencer() {
+    return workerTurnStartSequencer;
+  },
+  get orcaTeamServiceForEvents() {
+    return orcaTeamServiceForEvents;
+  },
+  get turnModelPromiseBySession() {
+    return turnModelPromiseBySession;
+  },
+  get readSessionModelForUsage() {
+    return readSessionModelForUsage;
+  },
+  get turnPiFastModeBySession() {
+    return turnPiFastModeBySession;
+  },
+  get silentStopTurnLeaseGate() {
+    return silentStopTurnLeaseGate;
+  },
+  get agentInputCoordinatorHolder() {
+    return agentInputCoordinatorHolder;
+  },
+  get handleSilentStopTurnEnd() {
+    return handleSilentStopTurnEnd;
+  },
+  get isRemoteAuthRetryErrorEvent() {
+    return isRemoteAuthRetryErrorEvent;
+  },
+  get isGatewayProxyTokenRecoveryErrorEvent() {
+    return isGatewayProxyTokenRecoveryErrorEvent;
+  },
+  get overflowSuppressedBroadcasts() {
+    return overflowSuppressedBroadcasts;
+  },
+  get handleAgentIslandEventAfterBroadcast() {
+    return handleAgentIslandEventAfterBroadcast;
+  },
+  get notifyGoalIdleAfterTurnSettled() {
+    return notifyGoalIdleAfterTurnSettled;
+  },
+  get settlePendingCredentialSwitch() {
+    return settlePendingCredentialSwitch;
+  },
+  get settlePendingSessionRuntimeControlHolder() {
+    return settlePendingSessionRuntimeControlHolder;
+  },
+  get deferredCodexRestartHolder() {
+    return deferredCodexRestartHolder;
+  },
+  get refreshRemoteCodexMcpOnTurnSettledHolder() {
+    return refreshRemoteCodexMcpOnTurnSettledHolder;
+  },
+  get markTurnEndedAfterPersistDrain() {
+    return markTurnEndedAfterPersistDrain;
+  },
+  get contextOverflowRolloverHolder() {
+    return contextOverflowRolloverHolder;
+  },
+  get lastReportedModelUsageBySession() {
+    return lastReportedModelUsageBySession;
+  },
+  get claudeOutputLagTimingGuard() {
+    return claudeOutputLagTimingGuard;
+  },
+  get lastReportedCostUsdBySession() {
+    return lastReportedCostUsdBySession;
+  },
+  get unpricedSubscriptionValueMarker() {
+    return unpricedSubscriptionValueMarker;
+  },
+};
+
+const sessionTurnObserverDependencies = {
+  silentStopTurnLeaseGate,
+  sessionTurnLeaseTracker,
+  providerTurnLeaseId,
+  log,
+};
+
+export function wireSessionToIpc(session: ReturnType<Maker['getSession']>): void {
+  if (!session) return;
+  const registration = sessionBindings.beginBinding(session);
+  if (!registration) return;
+
+  registration.disposers.push(installSessionTurnObserver(sessionTurnObserverDependencies, session));
 
   // session-agent-switch:登记本会话当前引擎,broadcaster / user 行落库据此逐行
   // stamp messages.agent_kind(切换后历史行的 agent_meta 必须按写入时引擎解析)。
@@ -4282,2013 +4314,10 @@ export function wireSessionToIpc(session: ReturnType<Maker['getSession']>): void
   // 让 renderer chat store 不必扫所有 vendor-raw 找它。
   registration.disposers.push(
     session.onEvent((event: AgentEvent) => {
-      // Exact patches are main-owned durable data. They have a dedicated summary push and
-      // on-demand detail IPC; forwarding the raw diff through maker:event would duplicate a
-      // potentially multi-megabyte payload to every renderer and device-link controller.
-      if (event.type === 'turn_diff') return;
-      if (
-        event.turnScope === 'background' &&
-        Object.prototype.hasOwnProperty.call(event, 'backgroundTurnStartedAt') &&
-        backgroundTurnPredatesSessionClear(session.id, event.backgroundTurnStartedAt)
-      ) {
-        return;
-      }
-      if (isFencedStaleSessionTerminal(session.id, event)) {
-        log.debug('ignored stale terminal after leftover turn reclaim', {
-          sessionId: session.id,
-          eventType: event.type,
-          sessionTurnGeneration: event.sessionTurnGeneration ?? null,
-          sessionInstanceId: event.sessionInstanceId ?? null,
-        });
-        return;
-      }
-      // 自动续跑的 pending 不能只靠 status(isRunning=true) 清理：Pi/Claude 的
-      // terminal-only 路径可能首个事件就是 error。Session 已把 host-owned token
-      // 盖到事件上，首个匹配 token 的事件即视为 provider accepted。
-      if (typeof event.turnAttemptToken === 'number') {
-        interruptedTurnAutoResumeGuard.noteAttemptEvent(session.id, event.turnAttemptToken);
-      }
-      let attributedEvent = event;
-      if (event.type === 'error' && isTerminalTurnErrorEvent(event)) {
-        const reason =
-          !session.remoteHostId && session.agentKind === 'claude-code'
-            ? consumeClaudeOpusPlanMismatch(session.id)
-            : null;
-        if (reason) {
-          const eventData =
-            event.data && typeof event.data === 'object' && !Array.isArray(event.data)
-              ? (event.data as Record<string, unknown>)
-              : {};
-          attributedEvent = { ...event, data: { ...eventData, reason } };
-          log.warn('Claude Opus plan error normalized for renderer', {
-            sessionId: session.id,
-            model: session.model,
-            reason,
-          });
-        }
-      }
-      const broadcastEvent = redactEventForRenderer(attributedEvent);
-      if (event.type === 'interaction_dismissed') {
-        const data = event.data as { requestId?: unknown; reason?: unknown };
-        if (typeof data.requestId === 'string') {
-          handleAgentIslandInteractionDismissed(session.id, data.requestId);
-          const entry = clearPendingInteraction(data.requestId);
-          if (entry) {
-            const decision = defaultDecisionForPending(
-              entry.kind,
-              typeof data.reason === 'string' ? data.reason : 'dismissed',
-            );
-            entry.resolve(decision);
-            persistInteractionDecision(
-              session.id,
-              entry.persistId,
-              entry.kind,
-              entry.request,
-              decision,
-            );
-          }
-        }
-        broadcastToAllWindows(MAKER_PUSH.INTERACTION_DISMISSED, {
-          sessionId: session.id,
-          ...(event.data as object),
-        });
-        return;
-      }
-      if (event.type === 'image' && event.source === 'codex') {
-        void broadcastCodexImageAsToolResult(session.id, event);
-        return;
-      }
-      if (event.type === 'plan_mode_changed') {
-        // agent 自行切换计划模式(典型: 计划批准后自动退出)。main 是持久化收口点:
-        // 复用 persistSessionFields 回写 sessions.plan_mode_enabled 并广播
-        // sessions:patched, 本机窗口与 device-link 控制端镜像同步收敛。
-        const data = event.data as { enabled?: unknown };
-        if (typeof data?.enabled === 'boolean') {
-          void persistSessionFields(session.id, { planModeEnabled: data.enabled }).catch((err) => {
-            log.warn('persist plan_mode_changed failed', {
-              sessionId: session.id,
-              error: err instanceof Error ? err.message : String(err),
-            });
-          });
-        }
-        return;
-      }
-      // turn 结束的 status event (isRunning=false + status='Done') 携带 endSnapshot。
-      // contextTokens / contextWindow 的持久化统一在 main 端做，避免多 window 竞写；
-      // 但不能挡在 EVENT broadcast 前面，否则 final/done 已到 main 后还会被同步 SQLite
-      // 和 usage 广播拖住。这里先记录待写快照，广播后再执行。
-      // Claude / Codex 同形 (usageTracker.snapshot() 两边都给 contextTokens / contextWindow),
-      // 不按 source 分支 —— 之前漏接 codex 导致重启后圆环归零。
-      let pendingContextSnapshot: { contextTokens: number; contextWindow: number } | null = null;
-      let pendingCodexAccountUsageSnapshot: unknown | null = null;
-      let shouldMarkTurnStatusIdleAfterBroadcast = false;
-      let shouldMarkTurnTerminalIdleAfterBroadcast = false;
-      let completedTurnWallClockMs: number | undefined;
-      const isContinuationBoundary = isTurnContinuationBoundaryEvent(event);
-      // 探针:continuation 边界命中会跳过 status idle / ended 写 / tracker idle,
-      // 若 claim 悬挂会导致 UI 永久「正在生成」。区分「claim 悬挂」与「done 未到达」。
-      if (isContinuationBoundary && (event.type === 'done' || event.type === 'status')) {
-        log.debug('turn continuation boundary event skipped from turn-finalize', {
-          sessionId: session.id,
-          eventType: event.type,
-          turnContinuationId: event.turnContinuationId,
-        });
-      }
-      if (event.type === 'account_usage' && event.source === 'codex' && !session.remoteHostId) {
-        pendingCodexAccountUsageSnapshot = event.data;
-      }
-      if (event.type === 'status') {
-        const data = event.data as {
-          isRunning?: boolean;
-          status?: string;
-          contextTokens?: number;
-          contextWindow?: number;
-        };
-        // Idle compact / late background work may still send isRunning for UI
-        // copy. It must not latch the product turn tracker or idle bookkeeping.
-        if (data.isRunning === true && event.turnScope !== 'background') {
-          // replacement 已进入 vendor 后，running 是新 attempt 的权威起点。不要依赖
-          // sendToAgent 返回后的 onDispatched 回调：provider 可同步发事件并先清 activeTurn。
-          autoResumeBookkeeping.discardReplacementProvenByProviderEvent(session.id);
-          // 新 turn 启动: 上一轮未配对的失败记账交接 id 已无归属, 丢弃防错配。
-          pendingFailedTurnAssistantPersistId.delete(session.id);
-          // Tokenless status(true) can be a delayed tail of the failed turn.
-          // Only a token-bearing running event proves a new attempt started.
-          if (typeof event.turnAttemptToken === 'number') {
-            autoResumeBookkeeping.clearFailedTurnCompletionTail(session.id);
-          }
-          // 记录 turn 开始时刻，供 onTurnErrorEvent 判断 error 是否属于 /clear 之前的旧 turn。
-          noteTurnStarted(session.id, event.turnAttemptToken);
-          noteSubagentObservationTurnStarted(session.id);
-          // silent-stop 守卫:新 turn 开始 → 清 pendingResume + 记录时刻(陈旧判定)。
-          silentStopAutoResumeGuard.noteTurnStarted(session.id);
-          interruptedTurnAutoResumeGuard.noteTurnStarted(session.id, {
-            // A tokenless status(true) can be a delayed tail from the failed turn. It
-            // must not consume the pending token of the next scheduled auto-resume.
-            clearPending: typeof event.turnAttemptToken === 'number',
-          });
-          const wasInTurn = sessionTurnActivityTracker.isSessionInTurn(session.id);
-          if (!wasInTurn && event.source === 'claude-code') {
-            const startedProductTurn = productTurnWallClockTracker.start(session.id);
-            if (startedProductTurn) productTurnUsageTargetTracker.clear(session.id);
-          }
-          sessionTurnActivityTracker.setSessionInTurn(session.id, data.isRunning);
-          if (!wasInTurn) advanceSessionTurnBoundaryGeneration(session.id);
-          // 后台活动检测:turn 开始 → 该会话的 API 流量回归主线,后台横幅熄灭。
-          noteClaudeSessionTurnState(session.id, true);
-          if (!wasInTurn) {
-            if (!gitSnapshotCoordinator?.hasPendingTurnStart(session.id)) {
-              void gitSnapshotCoordinator?.onTurnStart(session.id);
-            }
-            workerTurnStartSequencer.start(session.id, async () => {
-              await orcaTeamServiceForEvents?.handleWorkerTurnStarted(session.id);
-            });
-            // interrupted-turn-resume:记录 turn 启动时刻,与正常收尾时刻配对做
-            // 「疑似中断」纯读判定(设计总述见 localDb/sessionActiveTurn.ts 文件头)。
-            // SSH remote 会话同样记录:session 行在本地 DB、事件流走本进程,只是
-            // agent 跑在远端;device-link 被控会话不进本进程 maker-core,天然不经过。
-            clearPromptPredictionSessionStopped(session.id);
-            markSessionTurnStarted(session.id);
-          }
-          if (
-            (event.source === 'claude-code' || event.source === 'codex' || event.source === 'pi') &&
-            !turnModelPromiseBySession.has(session.id)
-          ) {
-            turnModelPromiseBySession.set(session.id, readSessionModelForUsage(session.id));
-          }
-          if (event.source === 'pi' && !turnPiFastModeBySession.has(session.id)) {
-            turnPiFastModeBySession.set(session.id, getSessionFastMode(session.id));
-          }
-        } else if (
-          data.isRunning === false &&
-          !isContinuationBoundary &&
-          event.turnScope !== 'background'
-        ) {
-          shouldMarkTurnStatusIdleAfterBroadcast = true;
-        }
-        if (
-          data.isRunning === false &&
-          data.status === 'Done' &&
-          typeof data.contextTokens === 'number'
-        ) {
-          pendingContextSnapshot = {
-            contextTokens: data.contextTokens,
-            contextWindow: data.contextWindow ?? 0,
-          };
-        }
-      }
-      if (event.type === 'done') {
-        const doneAttemptToken = event.turnAttemptToken;
-        if (typeof doneAttemptToken === 'number' && !isContinuationBoundary) {
-          autoResumeBookkeeping.settleOutcome(session.id, doneAttemptToken, 'failed');
-          interruptedTurnAutoResumeGuard.noteAttemptSettled(session.id, doneAttemptToken);
-        }
-        const rawTurn = (event.data as { raw?: { id?: unknown; status?: unknown } } | null)?.raw;
-        const carriesSilentStop =
-          (event.data as { silentStop?: boolean } | null | undefined)?.silentStop === true;
-        const silentStopTurnLeaseId = carriesSilentStop
-          ? silentStopTurnLeaseGate.turnLeaseIdForEvent(event)
-          : undefined;
-        if (carriesSilentStop && !silentStopTurnLeaseId) {
-          log.debug('ignored stale silent-stop terminal from an older turn', {
-            sessionId: session.id,
-          });
-          return;
-        }
-        const isSilentStopDone = carriesSilentStop;
-        if (event.source === 'claude-code' && !isContinuationBoundary && !isSilentStopDone) {
-          completedTurnWallClockMs = productTurnWallClockTracker.finish(session.id);
-        }
-        if (!isContinuationBoundary && !isSilentStopDone) {
-          shouldMarkTurnTerminalIdleAfterBroadcast = true;
-        }
-        if (!isContinuationBoundary && !isSilentStopDone) {
-          finalizeTurnChangeSet(
-            session.id,
-            typeof rawTurn?.id === 'string' ? rawTurn.id : null,
-            rawTurn && rawTurn.status !== 'completed' ? 'partial' : 'complete',
-          );
-        }
-        // turn 正常收尾但一路没有实质产出时,上一条重连记录同样不能停在"结果未回填":
-        // 成功路径已在产出事件里 settle 成 succeeded(此处 no-op),走到这里就是没产出。
-        // silent-stop done:自动续跑会在 1.5s 后启动新 turn(或弹耗尽横幅),
-        // 不标 idle/不触发 goal idle/不通知 coordinator done——避免 renderer
-        // 在 500ms 完成去抖窗口内显示假完成通知,下一个 turn 开始后又跳回 running。
-        if (isContinuationBoundary) {
-          // A claimed done only closes the current SDK segment. It must not enter
-          // silent-stop recovery or settle the auto-resume attempt; the later
-          // unclaimed product terminal owns those side effects.
-        } else if (!isSilentStopDone) {
-          // 兜底: 有些 vendor 的 done 不必先发 status:isRunning=false。
-          // 但 idle 恢复不能挡在 EVENT broadcast 前，否则隐藏窗口可能在 done
-          // 还没进入 renderer 时就重新被 Chromium 节流。
-          agentInputCoordinatorHolder?.onTurnEvent(session.id, 'done', undefined, undefined, {
-            sessionTurnGeneration: event.sessionTurnGeneration,
-            sessionInstanceId: event.sessionInstanceId,
-          });
-        } else {
-          // silent-stop 自动续跑:translator 判定本 turn 被上游空内容消息静默收尾时在
-          // done.data 附加 silentStop 标记(见 maker-core translator)。延迟一拍再决策,
-          // 让本次 turn-end 的落库/收口先走完,也给"用户恰好自己发了消息"留出让位窗口
-          //(守卫内部还有 doneAt 陈旧判定,双保险,绝不插队)。
-          // 回拨 in-turn 状态:translator 在 done 之前推了 status(isRunning=false),
-          // 那条事件已经把 tracker 标成 idle。恢复 in-turn 让 renderer 在 1.5s 决策
-          // 窗口内不触发 500ms 完成去抖的假通知。settleSilentStopDone / 新 turn 的
-          // noteTurnStarted 会再正确设置最终状态。
-          sessionTurnActivityTracker.setSessionInTurn(session.id, true);
-          // 后台活动检测:silent-stop 决策窗内逻辑 turn 仍在继续,同步回拨。
-          noteClaudeSessionTurnState(session.id, true);
-          const silentStopDoneAt = Date.now();
-          const silentStopTurnOrigin = event.turnOrigin;
-          setTimeout(() => {
-            void handleSilentStopTurnEnd(
-              session,
-              silentStopDoneAt,
-              silentStopTurnLeaseId!,
-              silentStopTurnOrigin,
-            );
-          }, 1_500);
-        }
-      }
-      // 提前声明在终止型 error 块与 done/terminal 边界块两处均需使用的持久化条件标志。
-      let isPlannedUpgradeClose = false;
-      let isRemoteAuthRetry = false;
-      let isGatewayProxyTokenRecovery = false;
-      if (isTerminalTurnErrorEvent(event)) {
-        finalizeTurnChangeSet(session.id, null, 'partial');
-        // **任何**终态失败都先把上一条重连记录钉成失败 —— 不管这次错误本身是否值得自愈。
-        // 只在"命中白名单、准备再接管"时才 settle 的话,非白名单的终态(认证 / 计费 /
-        // invalid-request)会让记录悬空,随后一个无关 turn 的首个产出事件就把它标成
-        // 「已重新连接」(codex P1)。
-        const failedAttemptToken = event.turnAttemptToken;
-        if (typeof failedAttemptToken === 'number') {
-          autoResumeBookkeeping.settleOutcome(session.id, failedAttemptToken, 'failed');
-          interruptedTurnAutoResumeGuard.noteAttemptSettled(session.id, failedAttemptToken);
-        }
-        // 终止型 error 可能没有后续 status/done（SDK/event loop crash 等），需要在
-        // EVENT broadcast 后结束逻辑 turn，并保留 terminal grace 给 renderer 收尾；
-        // 可重试 error 保持 running。
-        shouldMarkTurnTerminalIdleAfterBroadcast = true;
-        if (event.source === 'claude-code' || event.source === 'codex' || event.source === 'pi') {
-          turnModelPromiseBySession.delete(session.id);
-          if (event.source === 'pi') turnPiFastModeBySession.delete(session.id);
-        }
-        const errData =
-          attributedEvent.type === 'error'
-            ? (attributedEvent.data as
-                | {
-                    message?: unknown;
-                    reason?: unknown;
-                    sdkError?: unknown;
-                    errorStatus?: unknown;
-                    toolLoop?: unknown;
-                  }
-                | undefined)
-            : undefined;
-        // Terminal error details cross the coordinator/device-link boundary as untrusted data.
-        // Keep only the bounded tool-loop shape; never let a provider-controlled object become
-        // live projection state or renderer interpolation.
-        const toolLoop = parseAgentInputToolLoopDetails(errData?.toolLoop);
-        // 计划内 cc-mgr 升级窗口的 daemon 关闭(reason='remote_daemon_closed')是
-        // 预期噪音: renderer 事件路径按同语义静默 banner, 这里同样不给 coordinator
-        // 记 error —— 否则 paired-done 保留会让升级后的 projection 复现
-        // [REMOTE_DAEMON_CLOSED] banner。范围与 renderer 一致**按 session**(仅
-        // banner-clicker):同 host 其它会话的中断照真实失败浮现;窗口外的 daemon
-        // 死亡同样不受影响(保留 + 通知)。
-        isPlannedUpgradeClose =
-          errData?.reason === 'remote_daemon_closed' && isCcMgrUpgradeInFlight(session.id);
-        // Legacy CC/XD 远程 auth 错误跳过持久化：renderer 会静默 auto-retry（makerChatStore 在 reducer
-        // 前拦截、关闭旧会话、重发消息，不显示 ErrorBanner）；若 main 已落库，retry 成功后
-        // 重开会话会看到虚假错误卡。判定与 renderer 的 isAuthError 保持一致，覆盖
-        // sdkError === 'authentication_failed' 以及 message 命中 authentication_error /
-        // invalid api key / 401 的情形。本地会话（无 remoteHostId）无 auto-retry，不跳过。
-        isRemoteAuthRetry = isRemoteAuthRetryErrorEvent(session, event);
-        isGatewayProxyTokenRecovery = isGatewayProxyTokenRecoveryErrorEvent(session.id, event);
-        if (isPlannedUpgradeClose) {
-          agentInputCoordinatorHolder?.noteSuppressedTerminalError(session.id, {
-            generation: event.sessionTurnGeneration,
-            reason: 'remote_daemon_closed',
-            instanceId: event.sessionInstanceId ?? session.instanceId,
-          });
-        } else {
-          agentInputCoordinatorHolder?.onTurnEvent(
-            session.id,
-            'error',
-            typeof broadcastEvent.data === 'object' &&
-              broadcastEvent.data !== null &&
-              typeof (broadcastEvent.data as { message?: unknown }).message === 'string'
-              ? (broadcastEvent.data as { message: string }).message
-              : undefined,
-            // 结构化信号:自动续跑的判据靠它们收紧(见 isInterruptedTurnError),不靠文本猜。
-            {
-              ...(typeof errData?.sdkError === 'string' ? { sdkError: errData.sdkError } : {}),
-              ...(typeof errData?.reason === 'string' ? { reason: errData.reason } : {}),
-              ...(typeof errData?.errorStatus === 'number'
-                ? { errorStatus: errData.errorStatus }
-                : {}),
-              ...(toolLoop ? { toolLoop } : {}),
-            },
-            {
-              sessionTurnGeneration: event.sessionTurnGeneration,
-              sessionInstanceId: event.sessionInstanceId,
-            },
-          );
-        }
-      }
-      // F1-a Phase 2: assistant 文本持久化收口 main 单点(根除多窗各落一份的重复)。
-      // 在 onEvent 同步路径只做 O(1):为在飞 assistant 分配 / 复用 persistId、累积全文,
-      // 把 persistId 盖进广播 payload 让 renderer 在途气泡用同一 id;真正落库走模块内
-      // 异步队列、不在此同步执行(规则19 热路径)。终止型 error 同样在广播前预留 persistId
-      // (O(1) createId,不 flush、不写库),让 live 横幅与事后 error 行绑定同一 id。
-      const eventAgentMeta = (event as { agentMeta?: AgentMeta | null }).agentMeta ?? null;
-      // 跟踪会话最近一次非空 agentMeta(镜像 renderer state.lastAgentMeta),给 interaction
-      // 边界 flush 当兜底锚点,保 agent_meta 不丢(rewind/fork)。
-      if (eventAgentMeta && event.turnScope !== 'background')
-        noteAgentMeta(session.id, eventAgentMeta);
-      let persistId: string | undefined;
-      // tool_result 家族:main 解析出的权威内容,盖进 payload 让 renderer 即时显示
-      // (Option C:内容重排状态机只在 main 一份,与落库同源同值)。
-      let resolvedContent: string | undefined;
-      // 中断自愈的额度判据是「是否在推进」:模型产出了实质内容(文本 / 工具调用)就把
-      // 连续失败计数归零；人工介入周期的硬总上限不归零，保证始终有限。
-      // 刻意只认这两类事件:thinking / status / 空消息都不算产出;guard 侧是 O(1)、
-      // 无 IO、无日志,放在热路径安全。
-      // 晚到 background 事件仍需广播和持久化,但不能给当前中断回合充值。
-      if (event.turnScope !== 'background' && isSubstantiveProgressEvent(event)) {
-        const progressAttemptToken = event.turnAttemptToken;
-        const accepted = interruptedTurnAutoResumeGuard.noteProgress(
-          session.id,
-          progressAttemptToken ?? undefined,
-        );
-        // 同一个信号也是「上一次重连真的成功了」的唯一证据；旧 attempt 的迟到事件
-        // token 不匹配时不会结算当前新 attempt。
-        if (accepted && typeof progressAttemptToken === 'number') {
-          autoResumeBookkeeping.settleOutcome(session.id, progressAttemptToken, 'succeeded');
-        }
-      }
-      if (event.type === 'text') {
-        const td = event.data as { text?: unknown; isFinal?: unknown } | null;
-        if (typeof td?.text === 'string') {
-          orcaTeamServiceForEvents?.captureWorkerText(session.id, td.text, {
-            isFinal: td.isFinal === true,
-          });
-        }
-        persistId = onAssistantTextEvent(
-          session.id,
-          event.data as {
-            text?: unknown;
-            isFinal?: unknown;
-            isFullText?: unknown;
-            agentMessageId?: unknown;
-          },
-          eventAgentMeta,
-        );
-      } else if (event.type === 'tool_use') {
-        // tool_use 边界:先 flush 在飞 assistant(保证 assistant 行先于其 tool_use 入队
-        // 落库),再落 tool_use 本身,拿回 persistId 盖进 payload。两者都只入队、不阻塞。
-        if (event.turnScope !== 'background') flushAssistantBlock(session.id, eventAgentMeta);
-        persistId = onToolUseEvent(
-          session.id,
-          event.data as { toolUseId?: unknown; toolName?: unknown; input?: unknown },
-          eventAgentMeta,
-          event.turnScope === 'background' ? 'background' : 'turn',
-          event.backgroundTurnStartedAt,
-          event.turnAttemptToken,
-        );
-      } else if (event.type === 'tool_result') {
-        const r = onToolResultEvent(
-          session.id,
-          event.data as { summary?: unknown; toolUseIds?: unknown },
-          eventAgentMeta,
-          event.turnScope === 'background' ? 'background' : 'turn',
-        );
-        persistId = r?.persistId;
-        resolvedContent = r?.content;
-      } else if (event.type === 'tool_result_full') {
-        const r = onToolResultFullEvent(
-          session.id,
-          event.data as { toolUseId?: unknown; fullText?: unknown; isError?: unknown },
-          eventAgentMeta,
-          event.turnScope === 'background' ? 'background' : 'turn',
-        );
-        persistId = r?.persistId;
-        resolvedContent = r?.content;
-      } else if (event.type === 'thinking') {
-        // thinking final/redacted 落库收口 main;clientId=blockId(renderer 同源),无需
-        // persistId 回传。start/delta 不落库。
-        onThinkingEvent(
-          session.id,
-          event.data as {
-            stage?: unknown;
-            blockId?: unknown;
-            text?: unknown;
-            durationMs?: unknown;
-          },
-          eventAgentMeta,
-        );
-      }
-      if (event.type === 'agent_task_update') {
-        onAgentTaskUpdateEvent(session.id, event.data);
-        // Subagent workspace is an observer only: normalize the existing
-        // harness event into Cindy's durable record on the same FIFO as chat
-        // messages. No launch/control path or provider payload is modified.
-        const source =
-          event.source === 'claude-code' || event.source === 'codex' || event.source === 'pi'
-            ? event.source
-            : undefined;
-        const observedAt = Date.now();
-        const generationStamp = captureSubagentObservationGeneration({
-          sessionId: session.id,
-          data: event.data,
-          source,
-        });
-        if (generationStamp)
-          void enqueueSubagentObservationWrite({
-            sessionId: session.id,
-            stamp: generationStamp,
-            enqueue: () =>
-              enqueueDurableWrite(`subagent_update:${session.id}`, async (ownerScope) => {
-                const persisted = await persistSubagentTaskUpdate(
-                  session.id,
-                  event.data,
-                  source,
-                  observedAt,
-                );
-                if (persisted) {
-                  broadcastSubagentRunsChanged({ sessionId: session.id, ...persisted }, ownerScope);
-                }
-                return persisted;
-              }),
-          }).catch((error) => {
-            log.warn('Subagent workspace persistence failed', {
-              sessionId: session.id,
-              error: error instanceof Error ? error.message : String(error),
-            });
-          });
-      }
-      // 先 broadcast 保 UI 实时性,再 flush(flush 只入队、不阻塞)。
-      // Keep the raw event for main-side coordination/persistence, but only
-      // cross renderer/device-link boundaries with the redacted copy.
-      // Capture Orca terminal ownership before the tracker wakes queue drain.
-      // The replacement input may be accepted while the async persistence and
-      // turn-start barriers below yield; that later turn must not inherit this
-      // terminal event or lose the lead_interrupt marker before it is observed.
-      const workerTerminalCapture =
-        !isContinuationBoundary && (event.type === 'done' || isTerminalTurnErrorEvent(event))
-          ? orcaTeamServiceForEvents?.captureWorkerTerminalTurn(session.id)
-          : undefined;
-      // 与下方 autoResumeSuppressesPersist 同判据,但必须在广播前就算出来:
-      // 热路径测试以 `const autoResumeSuppressesPersist` 为 flush 边界,不能把那条
-      // const 提前。预留 persistId 只看这份,真正写库仍走广播后的那份。
-      const autoResumeWouldSuppressPersist =
-        event.type === 'error' &&
-        (agentInputCoordinatorHolder?.isAutoResumePending(session.id) === true ||
-          agentInputCoordinatorHolder?.isAutoResumeDeferred(session.id) === true);
-      const suppressOverflowBroadcast =
-        !session.remoteHostId &&
-        event.type === 'error' &&
-        isTerminalTurnErrorEvent(event) &&
-        (isContextOverflowErrorData(event.data) || isOversizedHistoryErrorData(event.data));
-      if (
-        event.type === 'error' &&
-        isTerminalTurnErrorEvent(event) &&
-        !isPlannedUpgradeClose &&
-        !isRemoteAuthRetry &&
-        !isGatewayProxyTokenRecovery &&
-        !autoResumeWouldSuppressPersist &&
-        !suppressOverflowBroadcast
-      ) {
-        persistId = reserveTurnErrorPersistId(
-          session.id,
-          attributedEvent.data as {
-            message?: unknown;
-            reason?: unknown;
-            sdkError?: unknown;
-          } | null,
-          eventAgentMeta,
-        );
-      }
-      if (suppressOverflowBroadcast) {
-        overflowSuppressedBroadcasts.set(session.id, {
-          sessionId: session.id,
-          event: broadcastEvent,
-          persistId,
-          resolvedContent,
-        });
-      } else {
-        broadcastToAllWindows(MAKER_PUSH.EVENT, {
-          sessionId: session.id,
-          event: broadcastEvent,
-          persistId,
-          resolvedContent,
-        });
-        handleAgentIslandEventAfterBroadcast(session, broadcastEvent);
-      }
-      if (shouldMarkTurnTerminalIdleAfterBroadcast) {
-        sessionTurnActivityTracker.scheduleIdleAfterTerminalBroadcast(session.id);
-        // #9 idle 兜底:正常 done、终止型 error（含 abort）统一在 tracker 已置 idle 后
-        // 唤醒 Goal controller。无 goal / 非 active / 已取消的 deferred Resume 均为 no-op。
-        notifyGoalIdleAfterTurnSettled(session.id);
-        // 后台活动检测:done / 终止型 error = 逻辑 turn 结束,记录结束时刻。
-        // 此后若该会话进程仍有 API 流量(后台子 agent),record 路径会点亮横幅。
-        noteClaudeSessionTurnState(session.id, false);
-        // turn 收尾打标(last_turn_ended_at)不在此处:done / terminal error 的本 turn
-        // 持久化(assistant flush / orphan tool_result / error 行)在下方 flush 块才
-        // 入队,统一在那之后走 markTurnEndedAfterPersistDrain(见该 helper 注释)。
-        // turn 边界(done / 终止型 error):必须在 tracker 标 idle **之后**再兑现本会话的
-        // 延迟凭证切换、唤醒被本会话挡住的等待者 —— vendor 可能不发前置 status:false,
-        // 提前唤醒会让 apply/重试读到 isSessionInTurn=true 而空转,退化到 10s 兜底
-        // (review P2 2026-07-04)。apply 内部串行 + 幂等,fire-and-forget 安全;
-        // planned upgrade close 等场景多唤一次也只是 no-op。
-        settlePendingCredentialSwitch(session.id, `event:${event.type}`);
-        settlePendingSessionRuntimeControlHolder?.(session.id, `event:${event.type}`);
-        deferredCodexRestartHolder?.onSessionSettled();
-        agentInputCoordinatorHolder?.onExternalTurnSettled(session.id);
-        refreshRemoteCodexMcpOnTurnSettledHolder?.(session.id);
-      } else if (shouldMarkTurnStatusIdleAfterBroadcast) {
-        sessionTurnActivityTracker.scheduleIdleAfterStatusBroadcast(session.id);
-        // status:isRunning=false 即逻辑 turn 结束(可重试 error 不发这个信号)。
-        markTurnEndedAfterPersistDrain(session.id);
-        noteClaudeSessionTurnState(session.id, false);
-      }
-      if (event.type === 'done' && !isContinuationBoundary) {
-        void gitSnapshotCoordinator?.onTurnEnd(session.id);
-      }
-      if (isTerminalTurnErrorEvent(event)) {
-        gitSnapshotCoordinator?.onTurnAbort(session.id);
-      }
-      // done / 终止型 error 持久化边界:把在飞 assistant 落库(与 text isFinal 互斥幂等)。
-      // tool_use 边界的 flush 已在上面 broadcast 前做(需先于 tool_use 落库);
-      // ask_user / plan_review / permission 不走 onEvent(走 interaction listener),
-      // 它们的 flush 在 setInteractionListener 里。
-      //
-      // 可重试 error 仍属于同一 turn，不能 reset lastAgentMeta / tool_result 配对状态；
-      // 否则未来出现 turn 中途的非终止型 error 时会打断后续 tool_result 关联。
-      // 本 turn 最后一条 assistant 的 persistId(挂 per-turn 费用 / turn 边界用)。terminal
-      // error 同样 consume，写失败 seal 后再按需交接给 paired done；纯 tool 轮为 undefined。
-      let turnAssistantPersistId: string | undefined;
-      let turnBoundaryAssistantPersistId: string | undefined;
-      let isPairedFailedTurnDone = false;
-      if (event.type === 'done' || isTerminalTurnErrorEvent(event)) {
-        flushAssistantBlock(session.id, eventAgentMeta);
-        turnAssistantPersistId = consumeLastAssistantPersistId(session.id);
-        turnBoundaryAssistantPersistId = consumeLastTopLevelAssistantPersistId(session.id);
-        if (isTerminalTurnErrorEvent(event) && event.type !== 'done') {
-          // 失败 turn: 记账发生在稍后的配对 done(usage 在那条事件上), 把这里
-          // consume 到的 persistId 交接过去(见 pendingFailedTurnAssistantPersistId)。
-          if (turnAssistantPersistId) {
-            pendingFailedTurnAssistantPersistId.set(session.id, turnAssistantPersistId);
-          }
-          // persistId 只覆盖有 assistant 行的失败轮。零输出 / 纯 tool 轮没有 id，
-          // 用户接手还会 flush 掉 suppressed entry 并清 pending。这条 tail 活过
-          // flush，按失败轮 generation 配对；不同代的 done 不得当成这条尾巴。
-          if (!isContinuationBoundary && typeof event.sessionTurnGeneration === 'number') {
-            autoResumeBookkeeping.noteFailedTurnCompletionTail(
-              session.id,
-              event.sessionTurnGeneration,
-            );
-          }
-        } else {
-          // done: 优先本事件 consume 的 id, 失败 turn 场景回收交接的 id;
-          // 无论用没用到都清掉, 防残留错配下一轮。
-          const pendingFailedPersistId = pendingFailedTurnAssistantPersistId.get(session.id);
-          if (!turnAssistantPersistId && pendingFailedPersistId) {
-            turnAssistantPersistId = pendingFailedPersistId;
-            isPairedFailedTurnDone = true;
-          }
-          pendingFailedTurnAssistantPersistId.delete(session.id);
-        }
-        if (event.type === 'done' && event.source === 'claude-code') {
-          if (isContinuationBoundary) {
-            productTurnUsageTargetTracker.remember(session.id, turnAssistantPersistId);
-          } else {
-            turnAssistantPersistId = productTurnUsageTargetTracker.finish(
-              session.id,
-              turnAssistantPersistId,
-            );
-          }
-        }
-        flushOrphanToolResults(session.id, eventAgentMeta);
-        if (turnBoundaryAssistantPersistId) {
-          // 在同一 durable FIFO 内先盖 turn seal、再复用 local-db:messages:created 广播
-          // 更新后的完整行。失败轮的 paired done 只复用 id 做 usage 记账，不能把
-          // terminal error 已写的 false seal 覆盖成 true、让施工播报重新进入标题素材。
-          // Codex 的 interrupted / failed 同样以 done 收尾；即使没有配套 error，也必须
-          // 写 false，避免历史计划兼容逻辑把用户主动停止的半截计划推成全部完成。
-          const isSuccessfulDone =
-            event.type === 'done' &&
-            (event.source !== 'codex' || isSuccessfulCodexDoneEventData(event.data));
-          if (!isSuccessfulDone) {
-            void markAssistantTurnFailed(session.id, turnBoundaryAssistantPersistId);
-          } else if (!isPairedFailedTurnDone) {
-            const nativeForkAnchor = eventAgentMeta?.nativeForkAnchor;
-            void markAssistantTurnCompleted(
-              session.id,
-              turnBoundaryAssistantPersistId,
-              nativeForkAnchor ? { nativeForkAnchor } : undefined,
-            );
-          }
-        }
-        // error 行在 flushOrphanToolResults 之后入队,保证 orphan tool_result 排在
-        // error 行之前(历史时间线:tool 输出 → 错误卡,而非错误卡插到 tool 输出之前)。
-        // 自愈接管中 → 压住 error 行:成功续跑时历史里只留一条「已自动继续」分隔条,
-        // 救不回来时由 AutoResumeBookkeeping.finalizeSuppressedError 补落。判据取 coordinator 的实时
-        // 接管态(而非 host 自己的 map):退避期间用户若自己发了消息,接管态已被清,那之后
-        // 新 turn 的失败必须照常落库。
-        //
-        // 还有一种时序:terminal error 早于用户气泡落库完成到达时,接管决策要推迟到
-        // settlePendingTerminalEventAfterPersist 才能做(recovery 留不留得住是前提)。那时
-        // error 行早就落库了、压不回去,接管成功后历史里会同时留下错误卡与重连行(codex P1)。
-        // 所以决策未定时也一并压住(isAutoResumeDeferred),由 coordinator 在三个「最终没接管」
-        // 的出口回调 onResumableTurnErrorDiscarded 让它补落。
-        const workerTerminalDoneData = event.data as {
-          result?: unknown;
-          message?: unknown;
-          sdkError?: unknown;
-          reason?: unknown;
-          error?: { message?: unknown };
-        } | null;
-        const workerTerminalFinalText =
-          typeof workerTerminalDoneData?.result === 'string' &&
-          workerTerminalDoneData.result.length > 0
-            ? workerTerminalDoneData.result
-            : '';
-        const workerTerminalDiagnostic = isTerminalTurnErrorEvent(event)
-          ? [
-              workerTerminalDoneData?.message,
-              workerTerminalDoneData?.sdkError,
-              workerTerminalDoneData?.reason,
-              workerTerminalDoneData?.error?.message,
-            ].find((value): value is string => typeof value === 'string' && value.trim().length > 0)
-          : undefined;
-        const autoResumeSuppressesPersist =
-          event.type === 'error' &&
-          (agentInputCoordinatorHolder?.isAutoResumePending(session.id) === true ||
-            agentInputCoordinatorHolder?.isAutoResumeDeferred(session.id) === true);
-        // Only skip handleWorkerTerminalTurn after the Orca payload is actually
-        // hanging on the suppressed-error owner. stashOrca 失败必须立刻收口，
-        // 否则 worker 会永远停在 running。
-        let deferredOrcaWorkerTerminal = false;
-        const overflowClaim =
-          event.type === 'error' &&
-          !session.remoteHostId &&
-          isTerminalTurnErrorEvent(event) &&
-          !isPlannedUpgradeClose &&
-          !isRemoteAuthRetry &&
-          !isGatewayProxyTokenRecovery &&
-          !autoResumeSuppressesPersist &&
-          (isContextOverflowErrorData(attributedEvent.data) ||
-            isOversizedHistoryErrorData(attributedEvent.data))
-            ? (contextOverflowRolloverHolder?.claim(session.id) ?? 'idle')
-            : 'idle';
-        if (overflowClaim === 'claimed') {
-          const overflowErrorData = attributedEvent.data;
-          const surfaceOverflowFailure = (): void => {
-            const overflowErrorPayload = overflowErrorData as {
-              message?: unknown;
-              reason?: unknown;
-              sdkError?: unknown;
-            } | null;
-            const overflowPersistId = reserveTurnErrorPersistId(
-              session.id,
-              overflowErrorPayload,
-              eventAgentMeta,
-            );
-            const stashed = overflowSuppressedBroadcasts.get(session.id);
-            overflowSuppressedBroadcasts.delete(session.id);
-            if (stashed) {
-              broadcastToAllWindows(MAKER_PUSH.EVENT, {
-                ...stashed,
-                persistId: overflowPersistId ?? stashed.persistId,
-              });
-              handleAgentIslandEventAfterBroadcast(session, stashed.event);
-            }
-            onTurnErrorEvent(session.id, overflowErrorPayload, eventAgentMeta, overflowPersistId);
-          };
-          void contextOverflowRolloverHolder
-            ?.tryRecover(session.id, overflowErrorData)
-            .then((recovered) => {
-              if (recovered) {
-                overflowSuppressedBroadcasts.delete(session.id);
-                return;
-              }
-              surfaceOverflowFailure();
-            })
-            .catch((error) => {
-              log.warn('context overflow rollover rejected', {
-                sessionId: session.id,
-                error: error instanceof Error ? error.message : String(error),
-              });
-              surfaceOverflowFailure();
-            });
-        } else if (overflowClaim === 'in-flight') {
-          // 同一 turn 的重复终态 error：继续压住，避免污染历史。
-          if (persistId) releaseReservedTurnErrorPersistId(session.id, persistId);
-        } else if (
-          event.type === 'error' &&
-          !isPlannedUpgradeClose &&
-          !isRemoteAuthRetry &&
-          !isGatewayProxyTokenRecovery &&
-          !autoResumeSuppressesPersist
-        ) {
-          onTurnErrorEvent(
-            session.id,
-            attributedEvent.data as {
-              message?: unknown;
-              reason?: unknown;
-              sdkError?: unknown;
-            } | null,
-            eventAgentMeta,
-            persistId,
-          );
-        } else if (persistId) {
-          releaseReservedTurnErrorPersistId(session.id, persistId);
-        }
-        // 压住的错误详情必须在这里存一份:决策推迟场景下 onResumableTurnError 还没被调用过
-        // (它自己那份 set 发生在接管成立时),不存就无从补落。同 clientId 内容,覆盖无害。
-        if (autoResumeSuppressesPersist) {
-          autoResumeBookkeeping.stashSuppressedError(
-            session.id,
-            attributedEvent.data,
-            agentInputCoordinatorHolder?.getAutoResumeAttemptToken(session.id) ?? null,
-            agentInputCoordinatorHolder?.getAutoResumeDeferredOwner(session.id) ?? null,
-          );
-          // Orca terminal 与 error 行共用同一条 owner：L2 不 bridge / 不标 error，
-          // L3 surface 时用这份 capture 恰好一次收口。
-          if (isTerminalTurnErrorEvent(event)) {
-            deferredOrcaWorkerTerminal = autoResumeBookkeeping.stashOrcaSuppressedTerminal(
-              session.id,
-              {
-                status: 'error',
-                finalText: workerTerminalFinalText,
-                diagnostic: workerTerminalDiagnostic,
-                capture: workerTerminalCapture,
-              },
-            );
-          }
-        } else if (event.type === 'error' && isTerminalTurnErrorEvent(event)) {
-          // replacement 可在 sendToAgent 返回前同步失败并让 coordinator 的 activeTurn
-          // 失效；这个新终态已经取代旧中断，按 dispatch phase 直接清旧 owner。
-          autoResumeBookkeeping.discardReplacementProvenByProviderEvent(session.id);
-        }
-        // deferred 路径保存 turn 开始时刻:isRemoteAuthRetry 时 onTurnErrorEvent 被跳过，
-        // renderer 会稍后调 persistTurnErrorDeferred IPC。在 resetTurnPersistState 清掉
-        // _turnStartedAtBySession 之前保存一份，让 deferred 路径能正确做 /clear 竞态 cap。
-        // 自愈压住 error 行时同理:补落发生在 resetTurnPersistState 之后(退避 3–20 秒,
-        // 或决策推迟的那一小段),不先存一份会让 /clear 竞态 cap 判错。
-        if (
-          event.type === 'error' &&
-          (isRemoteAuthRetry || isGatewayProxyTokenRecovery || autoResumeSuppressesPersist)
-        ) {
-          saveTurnStartedAtForDeferred(session.id);
-        }
-        // turn 收尾打标:本 turn 已知持久化(assistant flush / orphan tool_result /
-        // error 行)已全部入队,在此统一定格并等排空后写。done 与 terminal error
-        // 同一规则(planned upgrade close / remote auth retry 分支无 error 行,
-        // drain 同样无害)。
-        // A claim-bearing done seals this SDK segment, but the product turn is
-        // still running and may emit another continuation segment. Reset the
-        // per-SDK-turn persistence maps while deferring the logical turn marker.
-        // 没有 done 的终态 error(Codex 在 terminal error 后显式压掉迟到的
-        // turnCompleted,persistCodexPlanOnDone 永远不会跑到):本 turn 的计划行
-        // 既没有章也没有 turnCompleted:false,面板会把全勾完的失败计划当旧数据
-        // 兜底退场。在这里补失败印记——只盖 turn 存活标记,不动步骤状态。
-        if (
-          !isContinuationBoundary &&
-          event.source === 'codex' &&
-          event.type !== 'done' &&
-          isTerminalTurnErrorEvent(event)
-        ) {
-          const errorTurnId =
-            typeof (event.data as { raw?: { id?: unknown } } | null | undefined)?.raw?.id ===
-            'string'
-              ? ((event.data as { raw?: { id?: unknown } }).raw!.id as string)
-              : null;
-          persistCodexPlanOnTerminalError(session.id, errorTurnId);
-        }
-        if (!isContinuationBoundary && event.source === 'codex' && event.type === 'done') {
-          // Renderer applies this terminal snapshot immediately. Persist the
-          // same state before sealing the persist queue and clearing the
-          // turn-owned lookup maps. The drain barrier below must include this
-          // write, otherwise app exit can still leave an in-progress plan.
-          persistCodexPlanOnDone(
-            session.id,
-            event.data as
-              { plan?: unknown; raw?: { id?: unknown; status?: unknown } } | null | undefined,
-          );
-        }
-        if (!isContinuationBoundary) {
-          markTurnEndedAfterPersistDrain(session.id);
-          // 逻辑 turn 结束:跨段存活的计划行引用到此回收(continuation boundary
-          // 上必须保留,否则最终 done 找不到计划行 → 无章无失败印记 → 胶囊永久
-          // 钉住,review P1-1)。
-          clearCodexPlanRowsForSession(session.id);
-        }
-        preserveTurnPersistStateForBackground(session.id);
-        resetTurnPersistState(session.id);
-        // sidebar-card-mode: 摘要触发挪到本轮 assistant 块 flush 入队之后(原先在
-        // done 早段、flush 之前触发,流式轮次会读到上一轮文本)。只在正常 done 触发。
-        // codex review:flushAssistantBlock 仅把 assistant insert 入队 writeChain、未落库,
-        // latestMessageText 立刻读库可能读到本轮 assistant 写入之前的旧状态;先 await
-        // drainPersistQueue() 等持久化队列排空,确立"读在写后"的边界,再起摘要。
-        if (event.type === 'done' && !isContinuationBoundary) {
-          void (async () => {
-            await drainPersistQueue();
-            // 列表预览与置顶卡片摘要解耦:无论置顶区是不是卡片、这条有没有置顶,
-            // 都要把最近一条可见消息立刻写回 session.preview。摘要生成失败也不能
-            // 让侧栏停在进入本轮前的旧句子。
-            await refreshSessionListPreview(session.id);
-            // force:turn-done 是权威刷新点(本轮 assistant 已落库),必须以最新内容覆盖
-            // 任何 pin 触发 / 上一轮残留的摘要——绕过 in-flight 早返与 20s 节流
-            // (codex review:pin during running turn 会让卡片停在部分/旧摘要)。
-            await maybeGenerateSessionTaskSummary(session.id, { force: true });
-          })();
-        }
-        // will-assistant-message 出口钩子(先定案 → 一拍后替换):仅 done(非终止
-        // error)、有真实回复文本 + 已落库的 assistant persistId + 有启用的出口钩子
-        // 意识时,派一个独立异步续跑跑裁决并原地更新那条消息(rewrite 换文本 /
-        // render 换自绘卡)。同步守卫 hasEnabledGhostAssistantHook 保证无此类意识时
-        // 不 schedule —— 与今天行为逐字节一致,零额外开销(规则 10 不碰热路径)。
-        if (
-          event.type === 'done' &&
-          !isContinuationBoundary &&
-          !isPairedFailedTurnDone &&
-          !isTerminalTurnErrorEvent(event) &&
-          isSuccessfulAssistantReplyDoneData(event.data) &&
-          turnAssistantPersistId
-        ) {
-          const doneResult = (event.data as { result?: unknown } | null)?.result;
-          const replyText = typeof doneResult === 'string' ? doneResult : '';
-          if (replyText.length > 0 && hasEnabledGhostAssistantHook()) {
-            const turnModel =
-              turnModelPromiseBySession.get(session.id) ??
-              Promise.resolve(session.model || 'unknown');
-            const assistantPersistId = turnAssistantPersistId;
-            withGhostAssistantHookModel(turnModel, () => {
-              runGhostAssistantReplyHook(session.id, assistantPersistId, replyText);
-            });
-          }
-        }
-        // Worker turn 结束后交给 OrcaTeamService 处理 DB status、广播与 auto-bridge。
-        // L2（auto-resume 仍拥有这次失败）不得在这里收口：否则 Lead 会先收到「异常终止」，
-        // 而聊天里还在显示自动重试。Codex/Claude 失败轮随后的 unclaimed done 同样不是
-        // 产品终态。L3 由 AutoResumeBookkeeping 的 surface 路径补调。
-        const isFailedTurnCompletionTail =
-          event.type === 'done' &&
-          !isContinuationBoundary &&
-          autoResumeBookkeeping.consumeFailedTurnCompletionTail(
-            session.id,
-            event.sessionTurnGeneration,
-          );
-        if (
-          !shouldSkipOrcaWorkerTerminal({
-            isContinuationBoundary,
-            stashedThisErrorEvent: deferredOrcaWorkerTerminal,
-            eventType: event.type,
-            isPairedFailedTurnDone,
-            isFailedTurnCompletionTail,
-            hasSuppressedError: autoResumeBookkeeping.hasSuppressedError(session.id),
-            isAutoResumePending:
-              agentInputCoordinatorHolder?.isAutoResumePending(session.id) === true,
-            isAutoResumeDeferred:
-              agentInputCoordinatorHolder?.isAutoResumeDeferred(session.id) === true,
-          })
-        ) {
-          void (async () => {
-            try {
-              await workerTurnStartSequencer.waitForStart(session.id);
-              await orcaTeamServiceForEvents?.handleWorkerTerminalTurn({
-                sessionId: session.id,
-                status: isTerminalTurnErrorEvent(event) ? 'error' : 'done',
-                finalText: workerTerminalFinalText,
-                diagnostic: workerTerminalDiagnostic,
-                capture: workerTerminalCapture,
-              });
-            } catch {
-              /* non-fatal */
-            }
-          })();
-        }
-      }
-      if (pendingContextSnapshot) {
-        const piRuntimeWindow =
-          session.agentKind === 'pi' &&
-          Number.isFinite(pendingContextSnapshot.contextWindow) &&
-          pendingContextSnapshot.contextWindow > 0
-            ? pendingContextSnapshot.contextWindow
-            : null;
-        const verifiedWindow = lookupVerifiedContextWindow(
-          (agentKind, modelId, providerId) =>
-            resolveVerifiedContextWindow(
-              getActiveCatalog(),
-              dbToMakerAgentKind(agentKind),
-              providerId,
-              modelId,
-            ),
-          session.model,
-          getSessionProvider(session.id),
-          session.agentKind,
-        );
-        recordSessionContextSnapshot(
-          session.id,
-          pendingContextSnapshot.contextTokens,
-          piRuntimeWindow ?? verifiedWindow ?? pendingContextSnapshot.contextWindow,
-        );
-      }
-      if (pendingCodexAccountUsageSnapshot) {
-        recordCodexAccountUsageSnapshot(pendingCodexAccountUsageSnapshot);
-      }
-      // 每 turn 结束累加 daily_spend 表 + 广播给 renderer 右下角"今日 $X.XX" chip。
-      // 这些统计 side effect 必须在 EVENT broadcast 之后，避免同步 SQLite 或额外
-      // usage 广播延后 final/done 送达。
-      //
-      // 本轮费用 = HYBRID 定价: Anthropic 模型信任 SDK 自报 cost (OAuth 下=0、API 下=真实、
-      // cache-correct), 非 Anthropic provider 模型 (gpt-5.5 等) 用远端 gateway 价 × token
-      // 重算 —— 修 SDK 把它们按 Anthropic 价错算 (~2.5x) 的 bug。逐模型解析后四个 sink
-      // (今日 / session / per-message / 按模型) 同源同值。
-      // 守卫: index.ts:388 stream_end fallback / codex done 不带 total_cost_usd, typeof 检查会跳过。
-      if (event.type === 'done' && event.source === 'claude-code') {
-        const modelPromise =
-          turnModelPromiseBySession.get(session.id) ?? readSessionModelForUsage(session.id);
-        turnModelPromiseBySession.delete(session.id);
-        const doneData = event.data as
-          | {
-              total_cost_usd?: unknown;
-              duration_ms?: unknown;
-              duration_api_ms?: unknown;
-              usage?: {
-                input_tokens?: number;
-                output_tokens?: number;
-                cache_read_input_tokens?: number;
-                cache_creation_input_tokens?: number;
-              };
-              modelUsage?: Record<string, unknown>;
-              usageSegments?: unknown;
-              usageSegmentsComplete?: unknown;
-              modelUsageCumulativeStartsAtZero?: unknown;
-              assistant_message_id?: unknown;
-              is_error?: unknown;
-            }
-          | undefined;
-        const cumulative = doneData?.total_cost_usd;
-        const modelUsage = doneData?.modelUsage;
-        // Missing request boundaries are an explicit pricing failure, including
-        // older remote payloads. Flat aggregate arithmetic may look safe, but
-        // the request's Fast/Batch variant is also unknown.
-        const claudeUsageSegments = normalizeTurnUsageSegments(doneData?.usageSegments);
-        const claudeUsageSegmentsComplete =
-          doneData?.usageSegmentsComplete === true && (claudeUsageSegments?.length ?? 0) > 0;
-        const claudeTurnDurationMs =
-          completedTurnWallClockMs ??
-          (typeof doneData?.duration_ms === 'number' ? doneData.duration_ms : undefined);
-        let modelUsageDeltas: ModelUsageDeltaEntry[] | undefined;
-        if (modelUsage && typeof modelUsage === 'object') {
-          const observedByModel = claudeUsageSegmentsComplete
-            ? (() => {
-                const grouped = new Map<string, ReturnType<typeof sumTurnUsageSegments>>();
-                for (const segment of claudeUsageSegments ?? []) {
-                  const model = normalizeModelIdForPricing(segment.model);
-                  const previous = grouped.get(model) ?? {
-                    inputTokens: 0,
-                    outputTokens: 0,
-                    cacheReadTokens: 0,
-                    cacheCreateTokens: 0,
-                  };
-                  grouped.set(model, {
-                    inputTokens: previous.inputTokens + segment.inputTokens,
-                    outputTokens: previous.outputTokens + segment.outputTokens,
-                    cacheReadTokens: previous.cacheReadTokens + segment.cacheReadTokens,
-                    cacheCreateTokens: previous.cacheCreateTokens + segment.cacheCreateTokens,
-                  });
-                }
-                return grouped;
-              })()
-            : undefined;
-          const { next, deltas } = computeModelUsageDeltas(
-            lastReportedModelUsageBySession.get(session.id),
-            modelUsage,
-            observedByModel,
-            {
-              cumulativeStartsAtZero: doneData?.modelUsageCumulativeStartsAtZero === true,
-            },
-          );
-          lastReportedModelUsageBySession.set(session.id, next);
-          modelUsageDeltas = deltas;
-        }
-        const outputLagTiming = claudeOutputLagTimingGuard.evaluate(
-          session.id,
-          modelUsageDeltas ?? [],
-          !isContinuationBoundary,
-          typeof doneData?.assistant_message_id === 'string'
-            ? doneData.assistant_message_id
-            : undefined,
-          doneData?.is_error !== true,
-        );
-        const claudeGenerationDurationMs = outputLagTiming.suppressTiming
-          ? undefined
-          : typeof doneData?.duration_api_ms === 'number'
-            ? doneData.duration_api_ms
-            : undefined;
-        // total_cost_usd 累计基线: 主路径不靠它算钱, 但仍跟住, 以便万一某轮缺 modelUsage
-        // 走兜底时累计差才准。先取"更新前"基线给兜底用, 再写入本轮累计。
-        const prevReportedCost = lastReportedCostUsdBySession.get(session.id);
-        if (typeof cumulative === 'number' && cumulative >= 0) {
-          lastReportedCostUsdBySession.set(session.id, cumulative);
-        }
-        // 模型降级检测:所选模型(turn start 快照)整轮缺席于实际 modelUsage delta →
-        // 判定主线被上游静默替换(如 fable-5 高负载被路由到 opus-4-8),把标记挂到本轮
-        // 收尾 assistant 的 agent_meta 上(AssistantMessage 渲染降级提示行)。
-        // fire-and-forget,与记账 sink 互不阻塞;判定纯函数见 shared/modelMismatch.ts。
-        if (modelUsageDeltas && outputLagTiming.detected) {
-          // 上游在 done 时点还没结算本轮输出(实测 Vertex),这一轮的费用会偏低、下一轮偏高。
-          // 总量不丢,只是归属错位;不做纠正的理由见 usage/modelUsageDelta 文件头。
-          log.warn(
-            `turn output likely lagging upstream settlement (session=${session.id}): ` +
-              modelUsageDeltas
-                .map(
-                  (d) =>
-                    `${d.model} out=${d.outputTokensDelta} in=${d.inputTokensDelta} ` +
-                    `cacheRead=${d.cacheReadTokensDelta} cacheCreate=${d.cacheCreateTokensDelta}`,
-                )
-                .join('; '),
-          );
-        }
-        if (turnAssistantPersistId && modelUsageDeltas && modelUsageDeltas.length > 0) {
-          const mismatchClientId = turnAssistantPersistId;
-          const actualEntries = modelUsageDeltas.map((d) => ({
-            model: d.model,
-            outputTokens: d.outputTokensDelta,
-          }));
-          void modelPromise
-            .then((selectedModel) => {
-              const mismatch = detectClaudeModelMismatch(selectedModel, actualEntries);
-              if (mismatch) {
-                return recordModelMismatchOnMessage({
-                  sessionId: session.id,
-                  clientId: mismatchClientId,
-                  mismatch,
-                });
-              }
-            })
-            .catch(() => {
-              /* 模型解析失败:跳过降级检测,非致命 */
-            });
-        }
-        if (
-          (modelUsageDeltas && modelUsageDeltas.length > 0) ||
-          (claudeUsageSegments?.length ?? 0) > 0
-        ) {
-          // 主路径: 逐模型 HYBRID 定价 (Anthropic→SDK, 非 Anthropic→gateway), 四个 sink
-          // 由同一份解析结果驱动。价格表走 main 端内存 + 磁盘缓存, stale 快返并后台刷新。
-          const deltas = modelUsageDeltas ?? [];
-          void (async () => {
-            const sessionProviderForBilling = getSessionProvider(session.id);
-            const observedClaudeRoute =
-              sessionProviderForBilling == null ? readClaudeSessionRoute(session.id) : null;
-            const explicitProviderBillingRoute = billingRouteForExplicitProvider(
-              sessionProviderForBilling,
-              sessionProviderForBilling
-                ? getActiveCatalog().providers.find(
-                    (provider) => provider.id === sessionProviderForBilling,
-                  )?.access?.kind
-                : null,
-            );
-            const isClaudeSubscriptionSession =
-              !session.remoteHostId &&
-              (sessionProviderForBilling === 'anthropic' ||
-                (sessionProviderForBilling == null &&
-                  (observedClaudeRoute != null
-                    ? observedClaudeRoute === 'subscription'
-                    : !readClaudeApiKey())));
-            const billingRoute: BillingRoute = session.remoteHostId
-              ? 'unknown'
-              : isClaudeSubscriptionSession
-                ? 'subscription'
-                : (explicitProviderBillingRoute ??
-                  (observedClaudeRoute === 'gateway' ? 'xd-gateway' : 'unknown'));
-            const pricing =
-              billingRoute === 'xd-gateway'
-                ? await getGatewayModelPricingForModel()
-                : getReferenceModelPricing();
-            const { turnMoney, estimatedTurnMoney, perModel } = resolveClaudeTurnCostSinks(
-              deltas,
-              pricing,
-              { providerId: sessionProviderForBilling, billingRoute, region: CURRENT_CINDY_REGION },
-              claudeUsageSegments,
-              claudeUsageSegmentsComplete,
-            );
-            const resolvedUsageDeltas: ModelUsageDeltaEntry[] = perModel.map((item) => ({
-              model: item.model,
-              costUsdDelta: item.money?.kind === 'actual-cost' ? item.money.amount : 0,
-              inputTokensDelta: item.deltas.inputTokens,
-              outputTokensDelta: item.deltas.outputTokens,
-              cacheReadTokensDelta: item.deltas.cacheReadTokens,
-              cacheCreateTokensDelta: item.deltas.cacheCreateTokens,
-            }));
-            // 按模型记账 (首页仪表盘"按模型拆分"): 保留 provider/SKU 前缀，
-            // `codex/` 等预算路由必须精确命中自己的报价，不能回落到裸模型的另一折扣。
-            // 订阅轮打 #billing=subscription 标记(Claude 订阅:Anthropic 模型 + cost=0),
-            // 或 bridge 订阅轮(chatgpt// xai/ 前缀,source==='subscription');两类均需触发
-            // rebroadcastTodaySpend 刷新首页仪表盘。
-            const modelUsageWrites: Promise<unknown>[] = [];
-            const subscriptionTurnEstimates: RegionalMoney[] = [];
-            let hasSubscriptionValueRow = false;
-            for (const m of perModel) {
-              const isClaudeSubscriptionValueRow =
-                isClaudeSubscriptionSession && !m.money && isAnthropicModel(m.model);
-              const isBridgeSubscriptionRow =
-                m.source === 'subscription' && isSubscriptionDirectRoute(m.model);
-              const subscriptionEstimate =
-                isClaudeSubscriptionValueRow || isBridgeSubscriptionRow
-                  ? computePriceQuoteTurnMoney(
-                      m.deltas,
-                      getSubscriptionValuePriceFor('claude-code', m.model, pricing),
-                      currentLedgerCurrency(),
-                      m.segments,
-                    )
-                  : null;
-              if (subscriptionEstimate?.amount) {
-                subscriptionTurnEstimates.push(subscriptionEstimate);
-              }
-              if (isClaudeSubscriptionValueRow || isBridgeSubscriptionRow)
-                hasSubscriptionValueRow = true;
-              const modelRowMoney =
-                m.money?.kind === 'actual-cost'
-                  ? m.money
-                  : isClaudeSubscriptionValueRow || isBridgeSubscriptionRow
-                    ? (subscriptionEstimate ?? unpricedSubscriptionValueMarker())
-                    : null;
-              modelUsageWrites.push(
-                recordModelTurnUsage({
-                  agentKind: 'claude-code',
-                  model:
-                    isClaudeSubscriptionValueRow || isBridgeSubscriptionRow
-                      ? claudeSubscriptionUsageModelKey(m.model)
-                      : m.model,
-                  // The subscription suffix lets the existing schema reconstruct this amount as
-                  // value-estimate, keeping it out of daily_spend and actual API totals.
-                  money: modelRowMoney,
-                  inputTokensDelta: m.deltas.inputTokens,
-                  outputTokensDelta: m.deltas.outputTokens,
-                  cacheReadTokensDelta: m.deltas.cacheReadTokens,
-                  cacheCreateTokensDelta: m.deltas.cacheCreateTokens,
-                }),
-              );
-            }
-            // 无真实费用、但产生订阅价值或 provider 参考估值的轮次不走
-            // recordTurnSpend。等模型行落库后重广播今日 spend 快照,通知已打开的首页
-            // 仪表盘刷新(对齐 codex 订阅轮的 rebroadcastCodexTodayUsage)。
-            if ((hasSubscriptionValueRow || estimatedTurnMoney) && !turnMoney) {
-              void Promise.allSettled(modelUsageWrites).then(() => rebroadcastTodaySpend());
-            }
-            if (turnMoney && turnMoney.amount > 0) {
-              // 保留 #216 的 token/cache 明细随费用落库 (MessageActionBar tooltip)。
-              // deltas 非空 → buildClaudeTurnUsageDetails 用 deltas 里的 model, fallbackModel 不取用。
-              // 传 perModel → 落「按模型成本明细」(含 subagent 跑的模型, 如 Haiku)。
-              const turnUsageDetails = buildClaudeTurnUsageDetails(
-                doneData?.usage,
-                resolvedUsageDeltas,
-                'unknown',
-                perModel,
-                claudeGenerationDurationMs,
-                claudeTurnDurationMs,
-              );
-              recordTurnSpend(turnMoney);
-              recordSessionTurnSpend(session.id, turnMoney);
-              // per-message 维度优先挂 assistant；纯 tool turn 则按 scheduler runId 直接归因。
-              const changedScheduleId = await recordSchedulerTurnCost({
-                sessionId: session.id,
-                clientId: turnAssistantPersistId,
-                money: turnMoney,
-                turnUsageDetails,
-                turnOrigin: event.turnOrigin,
-              });
-              if (changedScheduleId) broadcastSchedulerChanged(changedScheduleId);
-            } else if (turnAssistantPersistId) {
-              // 无真实计费轮的「本轮价值」估算,挂到消息(isEstimate:true,chip 的
-              // "本会话价值"由 useSessionEstimatedValue 汇总),不进 daily_spend /
-              // sessions.total_cost_usd(那些是真实账单)。provider 参考价与两类订阅估值
-              // 可叠加(如 Claude 订阅主会话 + bridge 订阅子 agent):
-              //   - provider-api 参考价:远程目录中的公开参考价,不是供应商真实账单;
-              //   - bridge 订阅模型(chatgpt/ / xai/,source==='subscription'):静态参考价折算;
-              //   - Claude 订阅会话(显式选 Anthropic,SDK 自报 cost=0):Anthropic 牌价折算
-              //     (纯 Anthropic 轮 pricing 为 null → 家族牌价兜底表,不为估值发起网络请求)。
-              // 混合轮(真实计费 > 0)走上面的真实分支,订阅部分不另挂估算 —— 一条消息只有一个
-              // cost 字段,真实计费优先;订阅 token 明细仍在 turnUsageDetails.perModelCost 里。
-              const estimatedValues: RegionalMoney[] = estimatedTurnMoney
-                ? [estimatedTurnMoney]
-                : [];
-              estimatedValues.push(...subscriptionTurnEstimates);
-              const turnEstimatedValue =
-                estimatedValues.length > 0 ? addRegionalMoney(estimatedValues) : null;
-              const turnUsageDetails = buildClaudeTurnUsageDetails(
-                doneData?.usage,
-                resolvedUsageDeltas,
-                'unknown',
-                perModel,
-                claudeGenerationDurationMs,
-                claudeTurnDurationMs,
-              );
-              if (turnEstimatedValue && turnEstimatedValue.amount > 0) {
-                const changedScheduleId = await recordSchedulerTurnCost({
-                  sessionId: session.id,
-                  clientId: turnAssistantPersistId,
-                  money: turnEstimatedValue,
-                  turnUsageDetails,
-                  turnOrigin: event.turnOrigin,
-                });
-                if (changedScheduleId) broadcastSchedulerChanged(changedScheduleId);
-              } else {
-                // 真实计费与订阅估值都拿不到(典型:网关目录整体不下发价格、模型不在价表)
-                // —— 钱没有,但 token 明细是算好的,落下来让 UI 退回显示本轮 token。
-                await recordTurnUsageOnMessage({
-                  sessionId: session.id,
-                  clientId: turnAssistantPersistId,
-                  turnUsageDetails,
-                });
-              }
-            }
-          })();
-        } else if (typeof cumulative === 'number' && cumulative >= 0) {
-          // 窄兜底: 罕见地 done 只带 total_cost_usd、没 modelUsage / request segments ——
-          // 拆不了 daily_model_usage, 只在已有累计基线后用 cost delta 记总额。
-          // The first cumulative snapshot after restart/reattach may contain
-          // the whole provider process lifetime. With neither modelUsage nor
-          // request segments, only establish the baseline.
-          const rawDelta =
-            prevReportedCost === undefined ? 0 : Math.max(0, cumulative - prevReportedCost);
-          void (async () => {
-            let resolvedModel = 'unknown';
-            try {
-              const model = await modelPromise;
-              resolvedModel = model;
-            } catch {
-              /* non-fatal: 保留 SDK 原始 cost */
-            }
-            // `doneData.usage` can be the same process-lifetime cumulative snapshot as
-            // `total_cost_usd`. Without model deltas or request segments it is not a reliable
-            // per-turn token fact, so retain only model/timing metadata in this fallback.
-            const turnUsageDetails = buildClaudeTurnUsageDetails(
-              undefined,
-              undefined,
-              resolvedModel,
-              undefined,
-              claudeGenerationDurationMs,
-              claudeTurnDurationMs,
-            );
-            // 本分支有三个"记不了钱"的出口(本轮 cost 未增长 / 订阅直连 / 非明确
-            // provider-api 路由)。只保留可证明的模型与时长；进程累计 usage 不能冒充本轮 token。
-            const recordUsageOnly = async () => {
-              if (!turnAssistantPersistId) return;
-              await recordTurnUsageOnMessage({
-                sessionId: session.id,
-                clientId: turnAssistantPersistId,
-                turnUsageDetails,
-              });
-            };
-            if (rawDelta <= 0) {
-              await recordUsageOnly();
-              return;
-            }
-            const providerId = getSessionProvider(session.id);
-            const observedRoute = providerId == null ? readClaudeSessionRoute(session.id) : null;
-            const explicitProviderRoute = billingRouteForExplicitProvider(
-              providerId,
-              providerId
-                ? getActiveCatalog().providers.find((provider) => provider.id === providerId)
-                    ?.access?.kind
-                : null,
-            );
-            const route: BillingRoute = session.remoteHostId
-              ? 'unknown'
-              : providerId === 'anthropic' || observedRoute === 'subscription'
-                ? 'subscription'
-                : (explicitProviderRoute ??
-                  (observedRoute === 'gateway' ? 'xd-gateway' : 'unknown'));
-            // 订阅直连轮(chatgpt/ / xai/)走窄兜底时: 真实计费恒 0, 不写 daily_spend /
-            // sessions.total_cost_usd(与主路径 resolveTurnCost 的 subscription gate 同口径,
-            // 避免把订阅 SDK 自报 cost 误记进计费)。但显式 provider-api 是权威路由:
-            // 自定义 API 供应商可能供应带订阅前缀的模型 id,不能按前缀把真实费用判掉。
-            if (route !== 'provider-api' && isSubscriptionDirectRoute(resolvedModel)) {
-              await recordUsageOnly();
-              return;
-            }
-            // A cumulative SDK dollar value is authoritative only for an
-            // explicitly selected provider API. Remote/unknown routing cannot
-            // be attributed to this local account and must stay usage-only.
-            if (route !== 'provider-api') {
-              await recordUsageOnly();
-              return;
-            }
-            const ledgerCurrency = (await getGatewayAccountCurrency()) ?? currentLedgerCurrency();
-            const money = usdToLedgerCurrency(rawDelta, ledgerCurrency);
-            recordTurnSpend(money);
-            recordSessionTurnSpend(session.id, money);
-            const changedScheduleId = await recordSchedulerTurnCost({
-              sessionId: session.id,
-              clientId: turnAssistantPersistId,
-              money,
-              turnUsageDetails,
-              turnOrigin: event.turnOrigin,
-            });
-            if (changedScheduleId) broadcastSchedulerChanged(changedScheduleId);
-          })();
-        }
-        // 与 spend 记账并列的另一个 turn-done side-effect: 刷新 Claude 账号月度配额
-        // (LiteLLM /v2/user/info)。fire-and-forget, 模块内 2s 超时 + 10s 节流。
-        // 故意放在 cumulative 块外面: spend 走 turn delta, 配额走 HTTP API, 两件事独立;
-        // 但仍在 done && claude-code 的 if 内, 不要每个事件都打一次。
-        void triggerClaudeAccountUsageRefresh();
-        // chatgpt/ 订阅轮: 额外触发 ChatGPT wham 额度刷新(与 codex 同一 ChatGPT 账户),让底部
-        // chip 的订阅额度实时更新 —— bridge 轮不产生 codex account_usage 事件,须主动触发。
-        void modelPromise
-          .then((m) => {
-            if (m && m.startsWith(CHATGPT_MODEL_PREFIX)) triggerCodexAccountUsageRefresh();
-            if (m && isExclusiveXaiModelId(m)) triggerXaiSubscriptionUsageRefresh();
-          })
-          .catch(() => {
-            /* 模型解析失败: 跳过, 非致命 */
-          });
-        // Claude 订阅账号余量 (oauth/usage 端点) 同理 turn-done 触发一次 —— 节流 (180s) /
-        // 429 退避 / 未连订阅 no-op 都在 reader 内部; turn 内的实时刷新由 proxy 旁路读
-        // unified headers 兜住, 这里只负责把 scoped 分模型窗口等端点独有数据拉新。
-        triggerClaudeSubscriptionUsageRefresh();
-      }
-      // Codex done 事件: 记 today token 累计 (替代老 registerCodexIpc 里的 recordCodexTurnUsage 接入点)。
-      // codex/index.ts 在 turn.completed 时把 SDK usage 翻成 camelCase 塞进 done.data.usage, 这里直接转给 broadcaster。
-      // Codex SDK 不报 cost, 所以走 token 量(codex chip 显示 "本 session N token"), 跟 Claude 的 $ chip 是两条管道。
-      if (event.type === 'done' && event.source === 'codex') {
-        // 本会话显式选定的供应商('xd' / 'openai' / null=默认)。退役全局 authMode 后,
-        // 「是否走订阅(不计网关费)」改由 spawn 注入 + 该会话是否显式选了 XD 网关决定。
-        const sessionProvider = getSessionProvider(session.id);
-        const isRemoteCodexSession = Boolean(session.remoteHostId);
-        const isCustomProviderRoute = !isRemoteCodexSession && isUserProviderSession(session.id);
-        const codexAuthInjection = isRemoteCodexSession ? null : getCodexProxyAuthInjection();
-        const modelPromise =
-          turnModelPromiseBySession.get(session.id) ?? readSessionModelForUsage(session.id);
-        turnModelPromiseBySession.delete(session.id);
-        const usage = (event.data as { usage?: unknown } | undefined)?.usage;
-        if (usage) recordCodexTurnUsage(usage);
-        // 按模型记账: codex done.data.usage 是 **per-turn 增量语义** (maker-core
-        // codexDoneUsage 契约: promptTokens=本 turn 未命中输入, completionTokens=完整输出
-        // (reasoningTokens 只是其中的诊断子集), cachedTokens=命中缓存;
-        // 整 turn 没收到 tokenUsage/updated 时全 0。
-        // 直接入库, 不做 delta 化 —— 历史上 promptTokens 曾是 contextTokens 快照、这里
-        // 做过 per-session delta 化, 语义改为 per-turn 后那套逻辑会把后小于前的 turn 记 0。
-        if (usage && typeof usage === 'object') {
-          const u = usage as {
-            promptTokens?: number;
-            completionTokens?: number;
-            reasoningTokens?: number;
-            cachedTokens?: number;
-            segments?: unknown;
-            durationMs?: number;
-            turnDurationMs?: number;
-          };
-          const promptTokens = Number(u.promptTokens) || 0;
-          const completionTokens = Number(u.completionTokens) || 0;
-          const cachedTokens = Number(u.cachedTokens) || 0;
-          const codexUsageSegments = normalizeTurnUsageSegments(u.segments);
-          const codexSegmentTotals = sumTurnUsageSegments(codexUsageSegments);
-          const codexSegmentsReliable =
-            codexUsageSegments.length > 0 &&
-            codexSegmentTotals.inputTokens === promptTokens &&
-            codexSegmentTotals.outputTokens === completionTokens &&
-            codexSegmentTotals.cacheReadTokens === cachedTokens;
-          void recordSessionTurnTokens(session.id, promptTokens + completionTokens + cachedTokens);
-          // 先落 daily_model_usage token 行, 再等价格表补 API cost。首页 usage push 会在
-          // ~2s 后刷新, 不能让冷价格表 / 离线 fetch 把模型 token 行延后到刷新之后。
-          // 后续 cost-only 增量不会重复累计 token。
-          void (async () => {
-            let pricingModel = 'unknown';
-            let turnModel = 'unknown';
-            try {
-              turnModel = await modelPromise;
-              // 只剥上下文后缀，保留 provider/SKU 前缀；`codex/gpt-*` 与裸
-              // `gpt-*` 是不同售价和折扣，不能互相回落。
-              pricingModel = normalizeModelIdForPricing(turnModel);
-            } catch {
-              // 模型读取失败时仍记录 token, 聚合 UI 会归到 unknown。
-            }
-            const isCodexBudgetRoute =
-              (sessionProvider == null || sessionProvider === 'xd') &&
-              pricingModel.startsWith('codex/');
-            const isCodexXaiProviderRoute =
-              (sessionProvider == null || sessionProvider === 'xai') &&
-              isExclusiveXaiModelId(pricingModel);
-            const isCodexOpenAiProviderRoute =
-              sessionProvider == null || sessionProvider === 'openai';
-            const hasGatewayKey = Boolean(readClaudeApiKey());
-            const hasEffectiveGatewayRoute =
-              !isRemoteCodexSession &&
-              !isCustomProviderRoute &&
-              (codexAuthInjection === 'env-key' ||
-                isCodexBudgetRoute ||
-                (sessionProvider === 'xd' && hasGatewayKey));
-            // 显式来源的订阅判定以目录 access.kind 为权威(内置 anthropic 的 Claude.ai
-            // 订阅同样是订阅价值,不能只认 OpenAI/xAI);目录缺 access 的旧快照仍靠下面
-            // 的 openai oauth 分支兜底。
-            const sessionProviderAccessKind = sessionProvider
-              ? getActiveCatalog().providers.find((provider) => provider.id === sessionProvider)
-                  ?.access?.kind
-              : null;
-            const isCodexSubscriptionAccessRoute =
-              !isRemoteCodexSession &&
-              sessionProvider != null &&
-              sessionProvider !== 'xd' &&
-              sessionProviderAccessKind === 'subscription' &&
-              !hasEffectiveGatewayRoute;
-            const isSubscriptionValue =
-              isRemoteCodexSession ||
-              isCodexXaiProviderRoute ||
-              isCodexSubscriptionAccessRoute ||
-              (isCodexOpenAiProviderRoute &&
-                codexAuthInjection === 'oauth-bearer' &&
-                !hasEffectiveGatewayRoute);
-            const usesReferencePriceEstimate =
-              !isSubscriptionValue &&
-              !isRemoteCodexSession &&
-              !hasEffectiveGatewayRoute &&
-              Boolean(sessionProvider && sessionProvider !== 'xd');
-            const modelUsageKey = isSubscriptionValue
-              ? codexSubscriptionUsageModelKey(pricingModel)
-              : codexApiUsageModelKey(pricingModel);
-            await recordModelTurnUsage({
-              agentKind: 'codex',
-              model: modelUsageKey,
-              money: isSubscriptionValue ? unpricedSubscriptionValueMarker() : undefined,
-              inputTokensDelta: promptTokens,
-              outputTokensDelta: completionTokens,
-              cacheReadTokensDelta: cachedTokens,
-              cacheCreateTokensDelta: 0,
-            }).finally(() => rebroadcastCodexTodayUsage());
-
-            // Codex SDK 不报 $, 用价格表折算。普通模型 + oauth(订阅)显示为 token 价值;api 模式和 codex/
-            // 折扣模型走 gateway API, 显示为 API cost。远端 Codex 由远端 daemon
-            // 路由,本机不知道远端 OAuth/API 事实,因此只显示 token 价值,不写本地
-            // gateway cost。只有真实本地 API cost 写入 sessions.total_cost_usd,
-            // 避免 scheduler 的 Cost 汇总混入订阅价值或远端账号消耗。
-            // fire-and-forget 不阻塞事件循环;价格表走 main 端内存 + 磁盘缓存,
-            // stale 快返并后台刷新,
-            // 拉不到 / 模型无条目 → 只落 token 明细,UI 退回显示本轮 token。
-            // 明细在 try 外构造:它只依赖上面已拿到的 token 数,价格请求抛错时也要能落。
-            const turnUsageDetails = buildTurnUsageDetails({
-              inputTokens: promptTokens,
-              outputTokens: completionTokens,
-              cacheReadTokens: cachedTokens,
-              cacheCreateTokens: 0,
-              model: turnModel,
-              durationMs: u.durationMs,
-              turnDurationMs: u.turnDurationMs,
-            });
-            const recordCodexUsageOnly = async () => {
-              if (!turnAssistantPersistId) return;
-              await recordTurnUsageOnMessage({
-                sessionId: session.id,
-                clientId: turnAssistantPersistId,
-                turnUsageDetails,
-              });
-            };
-            try {
-              const pricing = isSubscriptionValue
-                ? getReferenceModelPricing()
-                : hasEffectiveGatewayRoute
-                  ? await getGatewayModelPricingForModel()
-                  : usesReferencePriceEstimate
-                    ? getReferenceModelPricing()
-                    : null;
-              // 订阅估值按显式来源取各自的日期定价路由:内置 anthropic 走 Anthropic
-              // registry 参考价(含 codex 侧价格覆盖),默认/openai 保持 OpenAI 价表。
-              const subscriptionValueProviderId =
-                isCodexSubscriptionAccessRoute && sessionProvider != null
-                  ? sessionProvider
-                  : 'openai';
-              const price = isCodexXaiProviderRoute
-                ? getSubscriptionDirectValuePrice(pricingModel, 'codex', pricing)
-                : isSubscriptionValue
-                  ? getCodexProviderSubscriptionValuePrice(
-                      subscriptionValueProviderId,
-                      pricingModel,
-                      pricing,
-                    )
-                  : hasEffectiveGatewayRoute
-                    ? getModelPriceQuote(pricing, 'xd', pricingModel)
-                    : usesReferencePriceEstimate
-                      ? getModelPriceQuote(pricing, sessionProvider, pricingModel, 'codex')
-                      : undefined;
-              const money = computePriceQuoteTurnMoney(
-                codexUsageToTokens(u),
-                price ?? undefined,
-                currentLedgerCurrency(),
-                u.segments !== undefined && codexSegmentsReliable ? codexUsageSegments : [],
-              );
-              // Only Gateway sale prices are actual API spend. Third-party/user reference quotes
-              // are value estimates and daily_model_usage cannot preserve RegionalMoney.kind, so
-              // writing them into #billing=api would later reconstruct an estimate as actual cost.
-              if (money && (isSubscriptionValue || price?.source === 'gateway')) {
-                await recordModelTurnUsage({
-                  agentKind: 'codex',
-                  model: modelUsageKey,
-                  money,
-                  inputTokensDelta: 0,
-                  outputTokensDelta: 0,
-                  cacheReadTokensDelta: 0,
-                  cacheCreateTokensDelta: 0,
-                });
-              }
-              if (money && money.amount > 0) {
-                const isActualApiCost = !isSubscriptionValue && price?.source === 'gateway';
-                if (isActualApiCost) {
-                  void recordTurnSpend(money);
-                  void recordSessionTurnSpend(session.id, money);
-                }
-                const changedScheduleId = await recordSchedulerTurnCost({
-                  sessionId: session.id,
-                  clientId: turnAssistantPersistId,
-                  money,
-                  turnUsageDetails,
-                  turnOrigin: event.turnOrigin,
-                });
-                if (changedScheduleId) broadcastSchedulerChanged(changedScheduleId);
-              } else {
-                await recordCodexUsageOnly();
-              }
-            } catch {
-              // token row 已在价格请求前落库;价格失败只影响 API cost / message cost。
-              // 消息那一格仍要有事实可看:补落一次 token 明细。patch 是 agent_meta merge、
-              // 写的又是同一份明细,所以与上面成功分支重复执行也是幂等的(自身失败只 warn)。
-              await recordCodexUsageOnly();
-            }
-          })();
-        }
-        // 走 gateway/API 口径(同一把 XD key 的 LiteLLM 计费)的 codex turn,done 后刷新账号配额
-        // (与 cc 同口径, chip 显示 daily/monthly/key cost)。命中:会话显式选了 XD 网关、无 OAuth
-        // token 的 env-key fallback、或 codex/ 预算模型。普通 oauth 订阅没有 $ 配额,不刷。
-        void modelPromise
-          .then((model) => {
-            const hasGatewayKey = Boolean(readClaudeApiKey());
-            if (!isRemoteCodexSession && isExclusiveXaiModelId(model)) {
-              triggerXaiSubscriptionUsageRefresh();
-              return;
-            }
-            if (
-              !isRemoteCodexSession &&
-              !isCustomProviderRoute &&
-              !isExclusiveXaiModelId(model) &&
-              (codexAuthInjection === 'env-key' ||
-                model.startsWith('codex/') ||
-                (sessionProvider === 'xd' && hasGatewayKey))
-            ) {
-              void triggerClaudeAccountUsageRefresh();
-            }
-          })
-          .catch(() => {
-            if (sessionProvider === 'xd' && readClaudeApiKey()) {
-              void triggerClaudeAccountUsageRefresh();
-            }
-          });
-      }
-      // Pi done 事件同样携带 per-turn token/cache 明细。Pi 复用 Cindy 的 provider
-      // 路由，因此计费形态必须看 session provider，而不是把它当成一个新的计费方：
-      //   openai / anthropic / xai → 用户订阅，显示剩余窗口 + 本对话价值；
-      //   xd / 默认网关            → 实际 gateway cost。
-      // usage 事实无论价格是否可解析都持久化，保证新模型也能看到 cache 命中明细。
-      if (event.type === 'done' && event.source === 'pi') {
-        const sessionProvider = getSessionProvider(session.id);
-        // New Pi payloads carry the tariff on every request segment. Keep the
-        // turn-start snapshot only as a compatibility fallback for older or
-        // incomplete payloads that have no explicit priceVariant.
-        const piPriceVariant =
-          (turnPiFastModeBySession.get(session.id) ?? getSessionFastMode(session.id))
-            ? 'priority'
-            : 'standard';
-        turnPiFastModeBySession.delete(session.id);
-        const modelPromise =
-          turnModelPromiseBySession.get(session.id) ?? readSessionModelForUsage(session.id);
-        turnModelPromiseBySession.delete(session.id);
-        const rawUsage = (event.data as { usage?: unknown } | undefined)?.usage;
-        if (rawUsage && typeof rawUsage === 'object') {
-          const tokens = piUsageToTokens(
-            rawUsage as {
-              inputTokens?: number;
-              outputTokens?: number;
-              cacheReadTokens?: number;
-              cacheCreationTokens?: number;
-            },
-          );
-          const piUsageSegments = normalizeTurnUsageSegments(
-            (rawUsage as { segments?: unknown }).segments,
-          ).map((segment) => ({
-            ...segment,
-            // Parent requests use this session's bridge preference. Delegated
-            // child requests have an independent process and are standard
-            // unless their own payload explicitly reports another variant.
-            priceVariant:
-              segment.priceVariant ?? (segment.id?.startsWith('pi:') ? piPriceVariant : 'standard'),
-          }));
-          const piSegmentTotals = sumTurnUsageSegments(piUsageSegments);
-          const piSegmentsReliable =
-            (rawUsage as { segmentsComplete?: unknown }).segmentsComplete === true &&
-            piUsageSegments.length > 0 &&
-            piSegmentTotals.inputTokens === tokens.inputTokens &&
-            piSegmentTotals.outputTokens === tokens.outputTokens &&
-            piSegmentTotals.cacheReadTokens === tokens.cacheReadTokens &&
-            piSegmentTotals.cacheCreateTokens === tokens.cacheCreateTokens;
-          const totalTokens =
-            tokens.inputTokens +
-            tokens.outputTokens +
-            tokens.cacheReadTokens +
-            tokens.cacheCreateTokens;
-          void recordSessionTurnTokens(session.id, totalTokens);
-          void (async () => {
-            let turnModel = 'unknown';
-            try {
-              turnModel = await modelPromise;
-            } catch {
-              // 模型读取失败仍持久化 token/cache，模型显示为 unknown。
-            }
-            const pricingModel = normalizeModelIdForPricing(turnModel);
-            const isCustomProviderRoute = isUserProviderSession(session.id);
-            const effectiveProvider =
-              sessionProvider ??
-              (pricingModel.startsWith(CHATGPT_MODEL_PREFIX)
-                ? 'openai'
-                : pricingModel.startsWith(XAI_MODEL_PREFIX)
-                  ? 'xai'
-                  : null);
-            const isSubscriptionValue =
-              effectiveProvider === 'openai' ||
-              effectiveProvider === 'anthropic' ||
-              effectiveProvider === 'xai' ||
-              (!isCustomProviderRoute && isSubscriptionDirectRoute(pricingModel));
-            const billingRoute: BillingRoute = isCustomProviderRoute
-              ? 'provider-api'
-              : isSubscriptionValue
-                ? 'subscription'
-                : 'xd-gateway';
-            const effectiveSegments = piSegmentsReliable ? piUsageSegments : [];
-            const groupedSegments = new Map<
-              string,
-              { segments: typeof effectiveSegments; tokens: typeof tokens; sdkCostUsd: number }
-            >();
-            for (const segment of effectiveSegments) {
-              const model = normalizeModelIdForPricing(segment.model ?? turnModel);
-              const group = groupedSegments.get(model) ?? {
-                segments: [],
-                tokens: {
-                  inputTokens: 0,
-                  outputTokens: 0,
-                  cacheReadTokens: 0,
-                  cacheCreateTokens: 0,
-                },
-                sdkCostUsd: 0,
-              };
-              group.segments.push(segment);
-              group.tokens.inputTokens += segment.inputTokens;
-              group.tokens.outputTokens += segment.outputTokens;
-              group.tokens.cacheReadTokens += segment.cacheReadTokens;
-              group.tokens.cacheCreateTokens += segment.cacheCreateTokens;
-              group.sdkCostUsd += segment.costUsd ?? 0;
-              groupedSegments.set(model, group);
-            }
-            // An explicitly incomplete segment payload must not be collapsed
-            // into one synthetic request for pricing. Keep the aggregate token
-            // fact under the selected model while leaving money unavailable.
-            if (groupedSegments.size === 0) {
-              groupedSegments.set(pricingModel, { segments: [], tokens, sdkCostUsd: 0 });
-            }
-
-            const durationMs =
-              typeof (rawUsage as { durationMs?: unknown }).durationMs === 'number'
-                ? (rawUsage as { durationMs: number }).durationMs
-                : undefined;
-            const turnDurationMs =
-              typeof (rawUsage as { turnDurationMs?: unknown }).turnDurationMs === 'number'
-                ? (rawUsage as { turnDurationMs: number }).turnDurationMs
-                : undefined;
-            const usageOnlyDetails = buildTurnUsageDetails({
-              ...tokens,
-              model: groupedSegments.size === 1 ? [...groupedSegments.keys()][0] : undefined,
-              models: [...groupedSegments.keys()],
-              durationMs,
-              turnDurationMs,
-            });
-
-            try {
-              const pricing =
-                billingRoute === 'xd-gateway'
-                  ? await getGatewayModelPricingForModel()
-                  : getReferenceModelPricing();
-              const actualMonies: RegionalMoney[] = [];
-              const estimatedMonies: RegionalMoney[] = [];
-              const perModelCost: Array<{ model: string; money: RegionalMoney }> = [];
-              const modelWrites: Promise<unknown>[] = [];
-              for (const [model, group] of groupedSegments) {
-                // Missing/incomplete request boundaries are explicitly unpriceable. A provider-
-                // reported request cost may still win in resolveTurnCost; token × quote must not
-                // collapse the whole turn into one synthetic long-context request.
-                const pricingSegments = piSegmentsReliable ? group.segments : [];
-                let money: RegionalMoney | null = null;
-                if (billingRoute === 'subscription') {
-                  const quote = getSubscriptionValuePriceFor('pi', model, pricing);
-                  money = computePriceQuoteTurnMoney(
-                    group.tokens,
-                    quote ?? undefined,
-                    currentLedgerCurrency(),
-                    pricingSegments,
-                  );
-                } else {
-                  money = resolveTurnCost({
-                    rawModel: model,
-                    tokens: group.tokens,
-                    // Pi computes usage.cost from its local model catalog. For
-                    // BYOM/provider-api routes that is a reference estimate,
-                    // not a provider invoice. Let the provider quote path mark
-                    // it as value-estimate instead of recording it as actual.
-                    sdkCostDelta: billingRoute === 'provider-api' ? undefined : group.sdkCostUsd,
-                    pricing,
-                    context: {
-                      providerId: sessionProvider,
-                      billingRoute,
-                      region: CURRENT_CINDY_REGION,
-                    },
-                    segments: pricingSegments,
-                  }).money;
-                }
-                if (money?.amount) {
-                  perModelCost.push({ model, money });
-                  (money.kind === 'actual-cost' ? actualMonies : estimatedMonies).push(money);
-                }
-                const modelUsageKey = isSubscriptionValue
-                  ? piSubscriptionUsageModelKey(model)
-                  : model;
-                const modelRowMoney =
-                  money?.kind === 'actual-cost'
-                    ? money
-                    : isSubscriptionValue
-                      ? (money ?? unpricedSubscriptionValueMarker())
-                      : null;
-                modelWrites.push(
-                  recordModelTurnUsage({
-                    agentKind: 'pi',
-                    model: modelUsageKey,
-                    // daily_model_usage has no money-kind column. Subscription
-                    // rows recover value-estimate from their suffix; other
-                    // reference estimates must stay message-only or they would
-                    // be reconstructed later as actual spend.
-                    money: modelRowMoney,
-                    inputTokensDelta: group.tokens.inputTokens,
-                    outputTokensDelta: group.tokens.outputTokens,
-                    cacheReadTokensDelta: group.tokens.cacheReadTokens,
-                    cacheCreateTokensDelta: group.tokens.cacheCreateTokens,
-                  }),
-                );
-              }
-              await Promise.allSettled(modelWrites);
-              void rebroadcastTodaySpend();
-              const actualMoney = actualMonies.length > 0 ? addRegionalMoney(actualMonies) : null;
-              const estimatedMoney =
-                estimatedMonies.length > 0 ? addRegionalMoney(estimatedMonies) : null;
-              const messageMoney = actualMoney ?? estimatedMoney;
-              const turnUsageDetails = buildTurnUsageDetails({
-                ...tokens,
-                model: groupedSegments.size === 1 ? [...groupedSegments.keys()][0] : undefined,
-                models: [...groupedSegments.keys()],
-                perModelCost,
-                durationMs,
-                turnDurationMs,
-              });
-              if (actualMoney) {
-                void recordTurnSpend(actualMoney);
-                void recordSessionTurnSpend(session.id, actualMoney);
-              }
-              if (messageMoney) {
-                const changedScheduleId = await recordSchedulerTurnCost({
-                  sessionId: session.id,
-                  clientId: turnAssistantPersistId,
-                  money: messageMoney,
-                  turnUsageDetails,
-                  turnOrigin: event.turnOrigin,
-                });
-                if (changedScheduleId) broadcastSchedulerChanged(changedScheduleId);
-              } else if (turnAssistantPersistId && turnUsageDetails) {
-                await recordTurnUsageOnMessage({
-                  sessionId: session.id,
-                  clientId: turnAssistantPersistId,
-                  turnUsageDetails,
-                });
-              }
-            } catch {
-              // Price/catalog failure must not lose token/cache facts.
-              const writes = [...groupedSegments].map(([model, group]) =>
-                recordModelTurnUsage({
-                  agentKind: 'pi',
-                  model: isSubscriptionValue ? piSubscriptionUsageModelKey(model) : model,
-                  money: isSubscriptionValue ? unpricedSubscriptionValueMarker() : undefined,
-                  inputTokensDelta: group.tokens.inputTokens,
-                  outputTokensDelta: group.tokens.outputTokens,
-                  cacheReadTokensDelta: group.tokens.cacheReadTokens,
-                  cacheCreateTokensDelta: group.tokens.cacheCreateTokens,
-                }),
-              );
-              await Promise.allSettled(writes);
-              void rebroadcastTodaySpend();
-              if (turnAssistantPersistId && usageOnlyDetails) {
-                await recordTurnUsageOnMessage({
-                  sessionId: session.id,
-                  clientId: turnAssistantPersistId,
-                  turnUsageDetails: usageOnlyDetails,
-                });
-              }
-            }
-
-            if (effectiveProvider === 'openai') {
-              triggerCodexAccountUsageRefresh();
-            } else if (effectiveProvider === 'anthropic') {
-              triggerClaudeSubscriptionUsageRefresh();
-            } else if (effectiveProvider === 'xai') {
-              triggerXaiSubscriptionUsageRefresh();
-            } else if (effectiveProvider === 'xd' || effectiveProvider == null) {
-              void triggerClaudeAccountUsageRefresh();
-            }
-          })();
-        }
-      }
+      handleSessionEvent(sessionEventDependencies, session, event);
     }),
   );
-  registration.disposers.push(
-    session.onStatusChange((status) => {
-      if (wiredSessionsById.get(session.id)?.session !== session) return;
-      // The local window broadcast is best-effort, but keep this guard here as
-      // well because status callbacks are a lifecycle boundary: a third-party
-      // bridge must not be able to skip session cleanup by throwing.
-      try {
-        broadcastToAllWindows(MAKER_PUSH.STATUS_CHANGED, { sessionId: session.id, status });
-      } catch (err) {
-        log.warn('session status broadcast failed', {
-          sessionId: session.id,
-          status,
-          error: err instanceof Error ? err.message : String(err),
-        });
-      }
-      if (status === 'closed') {
-        const closeReason = getWiredSessionCloseReason(session);
-        const closedDirectAbortBoundary = getDirectAbortBoundaryForClosingSession(
-          session.id,
-          session,
-        );
-        const preserveAutoResumeIntent =
-          shouldPreserveCodexReconnectStalledAutoResume(session, closeReason) ||
-          shouldPreserveSessionRuntimeFallbackAutoResume(session, closeReason);
-        pendingCodexReconnectStalledRebuilds.delete(session);
-        try {
-          cleanupPendingInteractionsForSession(session.id, 'session_closed');
-          if (preserveAutoResumeIntent) {
-            log.info(
-              'preserving scheduled Codex reconnect-stall auto-resume across provider rebuild',
-              {
-                sessionId: session.id,
-                attemptToken: agentInputCoordinatorHolder?.getAutoResumeAttemptToken(session.id),
-                closeReason,
-              },
-            );
-          } else {
-            // 会话关闭同样是"终止":退避窗口有 3–20 秒,期间会话可能被独立关掉(切 agent、
-            // 远端断开、宿主回收)。只清 coordinator 不够 —— 排期中的定时器与悬空的重连记录
-            // 都还活着,前者会到点往已关闭的会话补发消息(coordinator 关闭路径保留 recovery,
-            // 补发会把用户关掉的会话重新拉起来),后者会把结果错绑到下一个会话实例(codex P1)。
-            interruptedTurnAutoResumeGuard.noteSessionReset(session.id);
-            autoResumeBookkeeping.teardown(session.id);
-          }
-          // rehydrate / 凭证切换 close-rebuild 窗口:同一逻辑会话进程内重建,
-          // 协调器状态应连续。窗口内保留 input boundary(不 abort,避免取消
-          // 驱动本次重建的 signal → #1930 cancelled-before-dispatch),但
-          // **其余清理必须照常执行**(activeTurn / steer / queue 状态不能残留,
-          // 否则 rebuild 失败或 close 后不 rebuild 时 coordinator 残留旧状态
-          // 阻塞后续发送)。其余清理(凭证切换 / git snapshot / Orca hydration
-          // 标记 / wiring teardown)照常。
-          agentInputCoordinatorHolder?.onSessionClosed(session.id, {
-            preserveInputBoundary: rehydrateCloseSuppression.isSuppressed(session.id),
-            preserveAutoResumeIntent,
-          });
-          // 会话关闭:兑现延迟凭证切换(直接写 route),并唤醒被它挡住的等待者。
-          pendingCredentialSwitchHolder?.onSessionClosed(session.id);
-          deferredCodexRestartHolder?.onSessionSettled();
-          agentInputCoordinatorHolder?.onExternalTurnSettled(session.id);
-          refreshRemoteCodexMcpOnTurnSettledHolder?.(session.id);
-          gitSnapshotCoordinator?.onSessionClosed(session.id);
-          clearOrcaMcpHydrated(session.id);
-          knownNonOrcaSessionIds.delete(session.id);
-          lastReportedCostUsdBySession.delete(session.id);
-          lastReportedModelUsageBySession.delete(session.id);
-          turnModelPromiseBySession.delete(session.id);
-          turnPiFastModeBySession.delete(session.id);
-          productTurnWallClockTracker.clear(session.id);
-          productTurnUsageTargetTracker.clear(session.id);
-          claudeOutputLagTimingGuard.clear(session.id);
-          // 后台活动检测:会话进程已关闭(closeSession / 删除),清账并广播横幅熄灭。
-          clearClaudeSessionBackgroundActivity(session.id);
-          clearSessionPersistState(session.id);
-          const subagentRewindStateCleared = clearSubagentObservationRewindState(session.id);
-          if (!subagentRewindStateCleared) {
-            log.warn('session close deferred active Subagent Rewind cleanup', {
-              sessionId: session.id,
-            });
-          }
-          // 进程关闭 ≠ 通知作废:临时会话调度(非 heartbeat / 非 persistentSession)在 run
-          // 终态后立刻 closeSession,此刻完成卡片刚在灵动岛上弹出来。硬删条目会让它当场
-          // 消失,所以这条路径保留仍在展示的卡片,由 dwell 到期或用户 ack 收掉。
-          handleAgentIslandSessionClosedAfterCleanup(session.id, 'process-closed');
-        } catch (err) {
-          log.warn('session close cleanup failed; forcing idle reconciliation', {
-            sessionId: session.id,
-            error: err instanceof Error ? err.message : String(err),
-          });
-        } finally {
-          // Wiring teardown is independent of the best-effort product cleanup
-          // above. A single disposer or listener error must not leave a closed
-          // session reachable from the in-memory routing map.
-          cancelDirectAbortReconciliation(session.id);
-          pendingFailedTurnAssistantPersistId.delete(session.id);
-          wiredSessionsById.delete(session.id);
-          for (const dispose of registration.disposers) {
-            try {
-              dispose();
-            } catch (err) {
-              log.warn('session disposer failed during close teardown', {
-                sessionId: session.id,
-                error: err instanceof Error ? err.message : String(err),
-              });
-            }
-          }
-          try {
-            session.setInteractionListener(null);
-          } catch (err) {
-            log.warn('session interaction listener teardown failed', {
-              sessionId: session.id,
-              error: err instanceof Error ? err.message : String(err),
-            });
-          }
-          // This must run even when an owner-boundary-sensitive cleanup above
-          // rejects. A closed Session cannot keep the desktop turn boundary busy.
-          sessionTurnActivityTracker.deleteSession(session.id);
-          sessionTurnBoundaryGenerationById.delete(session.id);
-          markSessionTurnEnded(session.id);
-          if (closedDirectAbortBoundary) {
-            // Provider close is authoritative that this exact abort-owned turn
-            // is idle. Its reconciliation chain was cancelled by teardown, so
-            // preserve the shared terminal wake-up before the intent is orphaned.
-            notifyGoalIdleAfterTurnSettled(session.id);
-          } else {
-            // A close that did not settle this exact abort generation supersedes
-            // any Resume intent keyed by the reusable session id. Cancel it and
-            // its retry timer so a later Session instance cannot revive the Goal.
-            goalDeferredResumeCancelObserver?.(session.id);
-          }
-        }
-      }
-    }),
-  );
+  sessionBindings.attachStatusListener(registration);
 
   // 注入 interaction listener (permission/ask/plan 三合一,renderer 按 kind 弹不同 UI)
   installDesktopInteractionListener(session);
@@ -6406,7 +4435,6 @@ export function registerMakerIpc(maker: Maker, options: RegisterMakerIpcOptions)
       projectSessionRuntimeControl(sessionId, baseline) as Record<string, unknown>,
     );
   };
-  broadcastSessionRuntimeProjectionHolder = broadcastSessionRuntimeProjection;
   setSessionRuntimeProjector((session) =>
     projectSessionRuntimeControl(session.id, {
       agentKind: dbToMakerAgentKind(session.agentKind),
@@ -7719,7 +5747,7 @@ export function registerMakerIpc(maker: Maker, options: RegisterMakerIpcOptions)
   });
 
   // ── Session 生命周期 ────────────────────────────────────────────────────
-  // wiredSessionsById + lastReportedCostUsdBySession + sessionTurnActivityTracker 都在模块顶层,
+  // sessionBindings + lastReportedCostUsdBySession + sessionTurnActivityTracker 都在模块顶层,
   // 让 scheduler runner / feishu 接管 / future MCP 等绕过 IPC 的调用方也能复用同一份 wire 逻辑。
 
   type CreateOpts = MakerSessionCreateOpts;
@@ -13161,7 +11189,7 @@ export function registerMakerIpc(maker: Maker, options: RegisterMakerIpcOptions)
     { status: 'found'; session: WiredSession } | { status: 'missing' } | { status: 'unavailable' };
 
   const lookupStableSessionForTurnBoundary = (sessionId: string): StableSessionLookup => {
-    const wired = wiredSessionsById.get(sessionId)?.session;
+    const wired = sessionBindings.getSession(sessionId);
     if (wired) return { status: 'found', session: wired };
     try {
       const sess = maker.getSession(sessionId);
@@ -13349,7 +11377,7 @@ export function registerMakerIpc(maker: Maker, options: RegisterMakerIpcOptions)
     boundary: DirectAbortReconcileBoundary,
   ): boolean => {
     if (directAbortReconcileBoundaries.get(sessionId) !== boundary) return false;
-    if (wiredSessionsById.get(sessionId)?.session !== boundary.session) return false;
+    if (sessionBindings.getSession(sessionId) !== boundary.session) return false;
     if (currentSessionTurnBoundaryGeneration(sessionId) !== boundary.generation) return false;
 
     // Codex exposes a provider turn id. Compare only when both sides have an

--- a/apps/desktop/src/main/maker-ipc/sessionBindingLifecycle.ts
+++ b/apps/desktop/src/main/maker-ipc/sessionBindingLifecycle.ts
@@ -1,0 +1,153 @@
+import type { Session, SessionStatus } from '@cindy/maker-core';
+
+type BindingSession = Pick<Session, 'id' | 'onStatusChange' | 'setInteractionListener'>;
+
+/** Resources belong to a Session instance, even when its business id is reused. */
+export interface SessionBindingRegistration<S extends BindingSession> {
+  readonly session: S;
+  readonly disposers: Array<() => void>;
+}
+
+export interface SessionBindingLifecycleDeps<S extends BindingSession, CloseContext> {
+  log: { warn(message: string, context: Record<string, unknown>): void };
+  restoreInteractionListener(session: S): void;
+  beforeReplace(session: S): void;
+  onBind(session: S): void;
+  broadcastStatus(session: S, status: SessionStatus): void;
+  captureCloseContext(session: S): CloseContext;
+  cleanupClosedSession(session: S, context: CloseContext): void;
+  beforeCloseTeardown(session: S): void;
+  finalizeClosedSession(session: S, context: CloseContext): void;
+}
+
+/**
+ * Owns Desktop's exact-instance registration and synchronous close boundary.
+ * Event/turn observers are installed between beginBinding and attachStatusListener,
+ * preserving their existing registration order. Their accepted asynchronous work
+ * (message persistence, usage accounting) is not cancelled by this registry.
+ */
+export function createSessionBindingLifecycle<S extends BindingSession, CloseContext>(
+  deps: SessionBindingLifecycleDeps<S, CloseContext>,
+) {
+  const bindings = new Map<string, SessionBindingRegistration<S>>();
+
+  function beginBinding(session: S): SessionBindingRegistration<S> | null {
+    const existing = bindings.get(session.id);
+    if (existing?.session === session) {
+      deps.restoreInteractionListener(session);
+      return null;
+    }
+    if (existing) {
+      deps.beforeReplace(existing.session);
+      // Replacement remains fail-fast: do not install a new instance when an
+      // old resource failed to detach. Close below has a different contract.
+      for (const dispose of existing.disposers) dispose();
+      existing.session.setInteractionListener(null);
+    }
+    deps.onBind(session);
+    const registration: SessionBindingRegistration<S> = { session, disposers: [] };
+    bindings.set(session.id, registration);
+    return registration;
+  }
+
+  function attachStatusListener(registration: SessionBindingRegistration<S>): void {
+    const { session } = registration;
+    registration.disposers.push(
+      session.onStatusChange((status) => {
+        if (bindings.get(session.id)?.session !== session) return;
+        try {
+          deps.broadcastStatus(session, status);
+        } catch (err) {
+          deps.log.warn('session status broadcast failed', {
+            sessionId: session.id,
+            status,
+            error: err instanceof Error ? err.message : String(err),
+          });
+        }
+        if (status !== 'closed') return;
+
+        // Capture abort/recovery ownership before any cleanup removes it.
+        const context = deps.captureCloseContext(session);
+        try {
+          deps.cleanupClosedSession(session, context);
+        } catch (err) {
+          deps.log.warn('session close cleanup failed; forcing idle reconciliation', {
+            sessionId: session.id,
+            error: err instanceof Error ? err.message : String(err),
+          });
+        } finally {
+          // Product cleanup is best-effort. Unregister before calling disposers
+          // so a late status callback cannot enter the close boundary again.
+          deps.beforeCloseTeardown(session);
+          bindings.delete(session.id);
+          for (const dispose of registration.disposers) {
+            try {
+              dispose();
+            } catch (err) {
+              deps.log.warn('session disposer failed during close teardown', {
+                sessionId: session.id,
+                error: err instanceof Error ? err.message : String(err),
+              });
+            }
+          }
+          try {
+            session.setInteractionListener(null);
+          } catch (err) {
+            deps.log.warn('session interaction listener teardown failed', {
+              sessionId: session.id,
+              error: err instanceof Error ? err.message : String(err),
+            });
+          }
+          deps.finalizeClosedSession(session, context);
+        }
+      }),
+    );
+  }
+
+  return {
+    beginBinding,
+    attachStatusListener,
+    getSession: (sessionId: string): S | undefined => bindings.get(sessionId)?.session,
+  };
+}
+
+export interface SessionCloseCleanupActions {
+  cleanupInteractions(): void;
+  preserveAutoResume(): void;
+  resetAutoResume(): void;
+  shouldPreserveInputBoundary(): boolean;
+  closeInputCoordinator(options: {
+    preserveInputBoundary: boolean;
+    preserveAutoResumeIntent: boolean;
+  }): void;
+  cleanupRuntimeState(): void;
+}
+
+/** A runtime rebuild may preserve input/recovery, but never skips runtime cleanup. */
+export function runSessionCloseCleanup(
+  preserveAutoResumeIntent: boolean,
+  actions: SessionCloseCleanupActions,
+): void {
+  actions.cleanupInteractions();
+  if (preserveAutoResumeIntent) actions.preserveAutoResume();
+  else actions.resetAutoResume();
+  actions.closeInputCoordinator({
+    preserveInputBoundary: actions.shouldPreserveInputBoundary(),
+    preserveAutoResumeIntent,
+  });
+  actions.cleanupRuntimeState();
+}
+
+/** Only the captured direct-abort owner can wake a Goal after close proves idle. */
+export function finalizeSessionClose(
+  settlesDirectAbort: boolean,
+  actions: {
+    clearTurnState(): void;
+    notifyGoalIdle(): void;
+    cancelGoalResume(): void;
+  },
+): void {
+  actions.clearTurnState();
+  if (settlesDirectAbort) actions.notifyGoalIdle();
+  else actions.cancelGoalResume();
+}

--- a/apps/desktop/src/main/maker-ipc/sessionClaudeTurnUsage.ts
+++ b/apps/desktop/src/main/maker-ipc/sessionClaudeTurnUsage.ts
@@ -1,0 +1,494 @@
+import type { AgentEvent, Session } from '@cindy/maker-core';
+
+import { createLogger } from '../logger.js';
+import { readClaudeApiKey } from '../maker-host/auth-adapters.js';
+import { recordSessionTurnSpend } from '../sessionSpendBroadcaster.js';
+import { recordSchedulerTurnCost, recordTurnUsageOnMessage } from '../turnCostBroadcaster.js';
+import { recordModelMismatchOnMessage } from '../modelMismatchBroadcaster.js';
+import { detectClaudeModelMismatch } from '../../shared/modelMismatch.js';
+import { triggerClaudeAccountUsageRefresh } from '../usage/claudeAccountUsage.js';
+import {
+  getGatewayAccountCurrency,
+  getGatewayModelPricingForModel,
+} from '../usage/modelPricing.js';
+import { getReferenceModelPricing } from '../usage/referenceModelPricing.js';
+import {
+  ClaudeOutputLagTimingGuard,
+  computeModelUsageDeltas,
+  type ModelUsageCumulative,
+  type ModelUsageDeltaEntry,
+} from '../usage/modelUsageDelta.js';
+import {
+  claudeSubscriptionUsageModelKey,
+  getSubscriptionValuePriceFor,
+} from '../usage/usageHistory.js';
+import {
+  billingRouteForExplicitProvider,
+  buildClaudeTurnUsageDetails,
+  computePriceQuoteTurnMoney,
+  isAnthropicModel,
+  normalizeTurnUsageSegments,
+  normalizeModelIdForPricing,
+  resolveClaudeTurnCostSinks,
+  sumTurnUsageSegments,
+  type BillingRoute,
+} from '../usage/turnCostCalculator.js';
+import {
+  CHATGPT_MODEL_PREFIX,
+  isExclusiveXaiModelId,
+  isSubscriptionDirectRoute,
+} from '../../shared/subscriptionModels.js';
+import {
+  addRegionalMoney,
+  usdToLedgerCurrency,
+  type RegionalMoney,
+} from '../../shared/regionalMoney.js';
+import { currentLedgerCurrency } from '../usage/ledgerCurrency.js';
+import { CURRENT_CINDY_REGION } from '../../shared/brandRegion.js';
+import {
+  triggerClaudeSubscriptionUsageRefresh,
+  triggerCodexAccountUsageRefresh,
+  triggerXaiSubscriptionUsageRefresh,
+} from './usage.js';
+import {
+  rebroadcastTodaySpend,
+  recordModelTurnUsage,
+  recordTurnSpend,
+} from '../usageBroadcaster.js';
+import { broadcastSchedulerChanged } from './schedule.js';
+import { getSessionProvider } from '../maker-host/session-provider-store.js';
+import { getActiveCatalog } from '../maker-host/active-catalog.js';
+import { readClaudeSessionRoute } from '../maker-host/claude-session-route-registry.js';
+
+export interface RecordSessionClaudeTurnUsageDeps {
+  readonly turnModelPromiseBySession: Map<string, Promise<string>>;
+  readonly readSessionModelForUsage: (sessionId: string) => Promise<string>;
+  readonly lastReportedModelUsageBySession: Map<string, Map<string, ModelUsageCumulative>>;
+  readonly claudeOutputLagTimingGuard: Pick<ClaudeOutputLagTimingGuard, 'evaluate'>;
+  readonly lastReportedCostUsdBySession: Map<string, number>;
+  readonly log: Pick<ReturnType<typeof createLogger>, 'warn'>;
+  readonly unpricedSubscriptionValueMarker: () => RegionalMoney;
+}
+
+export function recordSessionClaudeTurnUsage(
+  deps: RecordSessionClaudeTurnUsageDeps,
+  session: Session,
+  event: AgentEvent,
+  turnAssistantPersistId: string | undefined,
+  completedTurnWallClockMs: number | undefined,
+  isContinuationBoundary: boolean,
+) {
+  // 每 turn 结束累加 daily_spend 表 + 广播给 renderer 右下角"今日 $X.XX" chip。
+  // 这些统计 side effect 必须在 EVENT broadcast 之后，避免同步 SQLite 或额外
+  // usage 广播延后 final/done 送达。
+  //
+  // 本轮费用 = HYBRID 定价: Anthropic 模型信任 SDK 自报 cost (OAuth 下=0、API 下=真实、
+  // cache-correct), 非 Anthropic provider 模型 (gpt-5.5 等) 用远端 gateway 价 × token
+  // 重算 —— 修 SDK 把它们按 Anthropic 价错算 (~2.5x) 的 bug。逐模型解析后四个 sink
+  // (今日 / session / per-message / 按模型) 同源同值。
+  // 守卫: index.ts:388 stream_end fallback / codex done 不带 total_cost_usd, typeof 检查会跳过。
+  if (event.type === 'done' && event.source === 'claude-code') {
+    const modelPromise =
+      deps.turnModelPromiseBySession.get(session.id) ?? deps.readSessionModelForUsage(session.id);
+    deps.turnModelPromiseBySession.delete(session.id);
+    const doneData = event.data as
+      | {
+          total_cost_usd?: unknown;
+          duration_ms?: unknown;
+          duration_api_ms?: unknown;
+          usage?: {
+            input_tokens?: number;
+            output_tokens?: number;
+            cache_read_input_tokens?: number;
+            cache_creation_input_tokens?: number;
+          };
+          modelUsage?: Record<string, unknown>;
+          usageSegments?: unknown;
+          usageSegmentsComplete?: unknown;
+          modelUsageCumulativeStartsAtZero?: unknown;
+          assistant_message_id?: unknown;
+          is_error?: unknown;
+        }
+      | undefined;
+    const cumulative = doneData?.total_cost_usd;
+    const modelUsage = doneData?.modelUsage;
+    // Missing request boundaries are an explicit pricing failure, including
+    // older remote payloads. Flat aggregate arithmetic may look safe, but
+    // the request's Fast/Batch variant is also unknown.
+    const claudeUsageSegments = normalizeTurnUsageSegments(doneData?.usageSegments);
+    const claudeUsageSegmentsComplete =
+      doneData?.usageSegmentsComplete === true && (claudeUsageSegments?.length ?? 0) > 0;
+    const claudeTurnDurationMs =
+      completedTurnWallClockMs ??
+      (typeof doneData?.duration_ms === 'number' ? doneData.duration_ms : undefined);
+    let modelUsageDeltas: ModelUsageDeltaEntry[] | undefined;
+    if (modelUsage && typeof modelUsage === 'object') {
+      const observedByModel = claudeUsageSegmentsComplete
+        ? (() => {
+            const grouped = new Map<string, ReturnType<typeof sumTurnUsageSegments>>();
+            for (const segment of claudeUsageSegments ?? []) {
+              const model = normalizeModelIdForPricing(segment.model);
+              const previous = grouped.get(model) ?? {
+                inputTokens: 0,
+                outputTokens: 0,
+                cacheReadTokens: 0,
+                cacheCreateTokens: 0,
+              };
+              grouped.set(model, {
+                inputTokens: previous.inputTokens + segment.inputTokens,
+                outputTokens: previous.outputTokens + segment.outputTokens,
+                cacheReadTokens: previous.cacheReadTokens + segment.cacheReadTokens,
+                cacheCreateTokens: previous.cacheCreateTokens + segment.cacheCreateTokens,
+              });
+            }
+            return grouped;
+          })()
+        : undefined;
+      const { next, deltas } = computeModelUsageDeltas(
+        deps.lastReportedModelUsageBySession.get(session.id),
+        modelUsage,
+        observedByModel,
+        {
+          cumulativeStartsAtZero: doneData?.modelUsageCumulativeStartsAtZero === true,
+        },
+      );
+      deps.lastReportedModelUsageBySession.set(session.id, next);
+      modelUsageDeltas = deltas;
+    }
+    const outputLagTiming = deps.claudeOutputLagTimingGuard.evaluate(
+      session.id,
+      modelUsageDeltas ?? [],
+      !isContinuationBoundary,
+      typeof doneData?.assistant_message_id === 'string'
+        ? doneData.assistant_message_id
+        : undefined,
+      doneData?.is_error !== true,
+    );
+    const claudeGenerationDurationMs = outputLagTiming.suppressTiming
+      ? undefined
+      : typeof doneData?.duration_api_ms === 'number'
+        ? doneData.duration_api_ms
+        : undefined;
+    // total_cost_usd 累计基线: 主路径不靠它算钱, 但仍跟住, 以便万一某轮缺 modelUsage
+    // 走兜底时累计差才准。先取"更新前"基线给兜底用, 再写入本轮累计。
+    const prevReportedCost = deps.lastReportedCostUsdBySession.get(session.id);
+    if (typeof cumulative === 'number' && cumulative >= 0) {
+      deps.lastReportedCostUsdBySession.set(session.id, cumulative);
+    }
+    // 模型降级检测:所选模型(turn start 快照)整轮缺席于实际 modelUsage delta →
+    // 判定主线被上游静默替换(如 fable-5 高负载被路由到 opus-4-8),把标记挂到本轮
+    // 收尾 assistant 的 agent_meta 上(AssistantMessage 渲染降级提示行)。
+    // fire-and-forget,与记账 sink 互不阻塞;判定纯函数见 shared/modelMismatch.ts。
+    if (modelUsageDeltas && outputLagTiming.detected) {
+      // 上游在 done 时点还没结算本轮输出(实测 Vertex),这一轮的费用会偏低、下一轮偏高。
+      // 总量不丢,只是归属错位;不做纠正的理由见 usage/modelUsageDelta 文件头。
+      deps.log.warn(
+        `turn output likely lagging upstream settlement (session=${session.id}): ` +
+          modelUsageDeltas
+            .map(
+              (d) =>
+                `${d.model} out=${d.outputTokensDelta} in=${d.inputTokensDelta} ` +
+                `cacheRead=${d.cacheReadTokensDelta} cacheCreate=${d.cacheCreateTokensDelta}`,
+            )
+            .join('; '),
+      );
+    }
+    if (turnAssistantPersistId && modelUsageDeltas && modelUsageDeltas.length > 0) {
+      const mismatchClientId = turnAssistantPersistId;
+      const actualEntries = modelUsageDeltas.map((d) => ({
+        model: d.model,
+        outputTokens: d.outputTokensDelta,
+      }));
+      void modelPromise
+        .then((selectedModel) => {
+          const mismatch = detectClaudeModelMismatch(selectedModel, actualEntries);
+          if (mismatch) {
+            return recordModelMismatchOnMessage({
+              sessionId: session.id,
+              clientId: mismatchClientId,
+              mismatch,
+            });
+          }
+        })
+        .catch(() => {
+          /* 模型解析失败:跳过降级检测,非致命 */
+        });
+    }
+    if (
+      (modelUsageDeltas && modelUsageDeltas.length > 0) ||
+      (claudeUsageSegments?.length ?? 0) > 0
+    ) {
+      // 主路径: 逐模型 HYBRID 定价 (Anthropic→SDK, 非 Anthropic→gateway), 四个 sink
+      // 由同一份解析结果驱动。价格表走 main 端内存 + 磁盘缓存, stale 快返并后台刷新。
+      const deltas = modelUsageDeltas ?? [];
+      void (async () => {
+        const sessionProviderForBilling = getSessionProvider(session.id);
+        const observedClaudeRoute =
+          sessionProviderForBilling == null ? readClaudeSessionRoute(session.id) : null;
+        const explicitProviderBillingRoute = billingRouteForExplicitProvider(
+          sessionProviderForBilling,
+          sessionProviderForBilling
+            ? getActiveCatalog().providers.find(
+                (provider) => provider.id === sessionProviderForBilling,
+              )?.access?.kind
+            : null,
+        );
+        const isClaudeSubscriptionSession =
+          !session.remoteHostId &&
+          (sessionProviderForBilling === 'anthropic' ||
+            (sessionProviderForBilling == null &&
+              (observedClaudeRoute != null
+                ? observedClaudeRoute === 'subscription'
+                : !readClaudeApiKey())));
+        const billingRoute: BillingRoute = session.remoteHostId
+          ? 'unknown'
+          : isClaudeSubscriptionSession
+            ? 'subscription'
+            : (explicitProviderBillingRoute ??
+              (observedClaudeRoute === 'gateway' ? 'xd-gateway' : 'unknown'));
+        const pricing =
+          billingRoute === 'xd-gateway'
+            ? await getGatewayModelPricingForModel()
+            : getReferenceModelPricing();
+        const { turnMoney, estimatedTurnMoney, perModel } = resolveClaudeTurnCostSinks(
+          deltas,
+          pricing,
+          { providerId: sessionProviderForBilling, billingRoute, region: CURRENT_CINDY_REGION },
+          claudeUsageSegments,
+          claudeUsageSegmentsComplete,
+        );
+        const resolvedUsageDeltas: ModelUsageDeltaEntry[] = perModel.map((item) => ({
+          model: item.model,
+          costUsdDelta: item.money?.kind === 'actual-cost' ? item.money.amount : 0,
+          inputTokensDelta: item.deltas.inputTokens,
+          outputTokensDelta: item.deltas.outputTokens,
+          cacheReadTokensDelta: item.deltas.cacheReadTokens,
+          cacheCreateTokensDelta: item.deltas.cacheCreateTokens,
+        }));
+        // 按模型记账 (首页仪表盘"按模型拆分"): 保留 provider/SKU 前缀，
+        // `codex/` 等预算路由必须精确命中自己的报价，不能回落到裸模型的另一折扣。
+        // 订阅轮打 #billing=subscription 标记(Claude 订阅:Anthropic 模型 + cost=0),
+        // 或 bridge 订阅轮(chatgpt// xai/ 前缀,source==='subscription');两类均需触发
+        // rebroadcastTodaySpend 刷新首页仪表盘。
+        const modelUsageWrites: Promise<unknown>[] = [];
+        const subscriptionTurnEstimates: RegionalMoney[] = [];
+        let hasSubscriptionValueRow = false;
+        for (const m of perModel) {
+          const isClaudeSubscriptionValueRow =
+            isClaudeSubscriptionSession && !m.money && isAnthropicModel(m.model);
+          const isBridgeSubscriptionRow =
+            m.source === 'subscription' && isSubscriptionDirectRoute(m.model);
+          const subscriptionEstimate =
+            isClaudeSubscriptionValueRow || isBridgeSubscriptionRow
+              ? computePriceQuoteTurnMoney(
+                  m.deltas,
+                  getSubscriptionValuePriceFor('claude-code', m.model, pricing),
+                  currentLedgerCurrency(),
+                  m.segments,
+                )
+              : null;
+          if (subscriptionEstimate?.amount) {
+            subscriptionTurnEstimates.push(subscriptionEstimate);
+          }
+          if (isClaudeSubscriptionValueRow || isBridgeSubscriptionRow)
+            hasSubscriptionValueRow = true;
+          const modelRowMoney =
+            m.money?.kind === 'actual-cost'
+              ? m.money
+              : isClaudeSubscriptionValueRow || isBridgeSubscriptionRow
+                ? (subscriptionEstimate ?? deps.unpricedSubscriptionValueMarker())
+                : null;
+          modelUsageWrites.push(
+            recordModelTurnUsage({
+              agentKind: 'claude-code',
+              model:
+                isClaudeSubscriptionValueRow || isBridgeSubscriptionRow
+                  ? claudeSubscriptionUsageModelKey(m.model)
+                  : m.model,
+              // The subscription suffix lets the existing schema reconstruct this amount as
+              // value-estimate, keeping it out of daily_spend and actual API totals.
+              money: modelRowMoney,
+              inputTokensDelta: m.deltas.inputTokens,
+              outputTokensDelta: m.deltas.outputTokens,
+              cacheReadTokensDelta: m.deltas.cacheReadTokens,
+              cacheCreateTokensDelta: m.deltas.cacheCreateTokens,
+            }),
+          );
+        }
+        // 无真实费用、但产生订阅价值或 provider 参考估值的轮次不走
+        // recordTurnSpend。等模型行落库后重广播今日 spend 快照,通知已打开的首页
+        // 仪表盘刷新(对齐 codex 订阅轮的 rebroadcastCodexTodayUsage)。
+        if ((hasSubscriptionValueRow || estimatedTurnMoney) && !turnMoney) {
+          void Promise.allSettled(modelUsageWrites).then(() => rebroadcastTodaySpend());
+        }
+        if (turnMoney && turnMoney.amount > 0) {
+          // 保留 #216 的 token/cache 明细随费用落库 (MessageActionBar tooltip)。
+          // deltas 非空 → buildClaudeTurnUsageDetails 用 deltas 里的 model, fallbackModel 不取用。
+          // 传 perModel → 落「按模型成本明细」(含 subagent 跑的模型, 如 Haiku)。
+          const turnUsageDetails = buildClaudeTurnUsageDetails(
+            doneData?.usage,
+            resolvedUsageDeltas,
+            'unknown',
+            perModel,
+            claudeGenerationDurationMs,
+            claudeTurnDurationMs,
+          );
+          recordTurnSpend(turnMoney);
+          recordSessionTurnSpend(session.id, turnMoney);
+          // per-message 维度优先挂 assistant；纯 tool turn 则按 scheduler runId 直接归因。
+          const changedScheduleId = await recordSchedulerTurnCost({
+            sessionId: session.id,
+            clientId: turnAssistantPersistId,
+            money: turnMoney,
+            turnUsageDetails,
+            turnOrigin: event.turnOrigin,
+          });
+          if (changedScheduleId) broadcastSchedulerChanged(changedScheduleId);
+        } else if (turnAssistantPersistId) {
+          // 无真实计费轮的「本轮价值」估算,挂到消息(isEstimate:true,chip 的
+          // "本会话价值"由 useSessionEstimatedValue 汇总),不进 daily_spend /
+          // sessions.total_cost_usd(那些是真实账单)。provider 参考价与两类订阅估值
+          // 可叠加(如 Claude 订阅主会话 + bridge 订阅子 agent):
+          //   - provider-api 参考价:远程目录中的公开参考价,不是供应商真实账单;
+          //   - bridge 订阅模型(chatgpt/ / xai/,source==='subscription'):静态参考价折算;
+          //   - Claude 订阅会话(显式选 Anthropic,SDK 自报 cost=0):Anthropic 牌价折算
+          //     (纯 Anthropic 轮 pricing 为 null → 家族牌价兜底表,不为估值发起网络请求)。
+          // 混合轮(真实计费 > 0)走上面的真实分支,订阅部分不另挂估算 —— 一条消息只有一个
+          // cost 字段,真实计费优先;订阅 token 明细仍在 turnUsageDetails.perModelCost 里。
+          const estimatedValues: RegionalMoney[] = estimatedTurnMoney ? [estimatedTurnMoney] : [];
+          estimatedValues.push(...subscriptionTurnEstimates);
+          const turnEstimatedValue =
+            estimatedValues.length > 0 ? addRegionalMoney(estimatedValues) : null;
+          const turnUsageDetails = buildClaudeTurnUsageDetails(
+            doneData?.usage,
+            resolvedUsageDeltas,
+            'unknown',
+            perModel,
+            claudeGenerationDurationMs,
+            claudeTurnDurationMs,
+          );
+          if (turnEstimatedValue && turnEstimatedValue.amount > 0) {
+            const changedScheduleId = await recordSchedulerTurnCost({
+              sessionId: session.id,
+              clientId: turnAssistantPersistId,
+              money: turnEstimatedValue,
+              turnUsageDetails,
+              turnOrigin: event.turnOrigin,
+            });
+            if (changedScheduleId) broadcastSchedulerChanged(changedScheduleId);
+          } else {
+            // 真实计费与订阅估值都拿不到(典型:网关目录整体不下发价格、模型不在价表)
+            // —— 钱没有,但 token 明细是算好的,落下来让 UI 退回显示本轮 token。
+            await recordTurnUsageOnMessage({
+              sessionId: session.id,
+              clientId: turnAssistantPersistId,
+              turnUsageDetails,
+            });
+          }
+        }
+      })();
+    } else if (typeof cumulative === 'number' && cumulative >= 0) {
+      // 窄兜底: 罕见地 done 只带 total_cost_usd、没 modelUsage / request segments ——
+      // 拆不了 daily_model_usage, 只在已有累计基线后用 cost delta 记总额。
+      // The first cumulative snapshot after restart/reattach may contain
+      // the whole provider process lifetime. With neither modelUsage nor
+      // request segments, only establish the baseline.
+      const rawDelta =
+        prevReportedCost === undefined ? 0 : Math.max(0, cumulative - prevReportedCost);
+      void (async () => {
+        let resolvedModel = 'unknown';
+        try {
+          const model = await modelPromise;
+          resolvedModel = model;
+        } catch {
+          /* non-fatal: 保留 SDK 原始 cost */
+        }
+        // `doneData.usage` can be the same process-lifetime cumulative snapshot as
+        // `total_cost_usd`. Without model deltas or request segments it is not a reliable
+        // per-turn token fact, so retain only model/timing metadata in this fallback.
+        const turnUsageDetails = buildClaudeTurnUsageDetails(
+          undefined,
+          undefined,
+          resolvedModel,
+          undefined,
+          claudeGenerationDurationMs,
+          claudeTurnDurationMs,
+        );
+        // 本分支有三个"记不了钱"的出口(本轮 cost 未增长 / 订阅直连 / 非明确
+        // provider-api 路由)。只保留可证明的模型与时长；进程累计 usage 不能冒充本轮 token。
+        const recordUsageOnly = async () => {
+          if (!turnAssistantPersistId) return;
+          await recordTurnUsageOnMessage({
+            sessionId: session.id,
+            clientId: turnAssistantPersistId,
+            turnUsageDetails,
+          });
+        };
+        if (rawDelta <= 0) {
+          await recordUsageOnly();
+          return;
+        }
+        const providerId = getSessionProvider(session.id);
+        const observedRoute = providerId == null ? readClaudeSessionRoute(session.id) : null;
+        const explicitProviderRoute = billingRouteForExplicitProvider(
+          providerId,
+          providerId
+            ? getActiveCatalog().providers.find((provider) => provider.id === providerId)?.access
+                ?.kind
+            : null,
+        );
+        const route: BillingRoute = session.remoteHostId
+          ? 'unknown'
+          : providerId === 'anthropic' || observedRoute === 'subscription'
+            ? 'subscription'
+            : (explicitProviderRoute ?? (observedRoute === 'gateway' ? 'xd-gateway' : 'unknown'));
+        // 订阅直连轮(chatgpt/ / xai/)走窄兜底时: 真实计费恒 0, 不写 daily_spend /
+        // sessions.total_cost_usd(与主路径 resolveTurnCost 的 subscription gate 同口径,
+        // 避免把订阅 SDK 自报 cost 误记进计费)。但显式 provider-api 是权威路由:
+        // 自定义 API 供应商可能供应带订阅前缀的模型 id,不能按前缀把真实费用判掉。
+        if (route !== 'provider-api' && isSubscriptionDirectRoute(resolvedModel)) {
+          await recordUsageOnly();
+          return;
+        }
+        // A cumulative SDK dollar value is authoritative only for an
+        // explicitly selected provider API. Remote/unknown routing cannot
+        // be attributed to this local account and must stay usage-only.
+        if (route !== 'provider-api') {
+          await recordUsageOnly();
+          return;
+        }
+        const ledgerCurrency = (await getGatewayAccountCurrency()) ?? currentLedgerCurrency();
+        const money = usdToLedgerCurrency(rawDelta, ledgerCurrency);
+        recordTurnSpend(money);
+        recordSessionTurnSpend(session.id, money);
+        const changedScheduleId = await recordSchedulerTurnCost({
+          sessionId: session.id,
+          clientId: turnAssistantPersistId,
+          money,
+          turnUsageDetails,
+          turnOrigin: event.turnOrigin,
+        });
+        if (changedScheduleId) broadcastSchedulerChanged(changedScheduleId);
+      })();
+    }
+    // 与 spend 记账并列的另一个 turn-done side-effect: 刷新 Claude 账号月度配额
+    // (LiteLLM /v2/user/info)。fire-and-forget, 模块内 2s 超时 + 10s 节流。
+    // 故意放在 cumulative 块外面: spend 走 turn delta, 配额走 HTTP API, 两件事独立;
+    // 但仍在 done && claude-code 的 if 内, 不要每个事件都打一次。
+    void triggerClaudeAccountUsageRefresh();
+    // chatgpt/ 订阅轮: 额外触发 ChatGPT wham 额度刷新(与 codex 同一 ChatGPT 账户),让底部
+    // chip 的订阅额度实时更新 —— bridge 轮不产生 codex account_usage 事件,须主动触发。
+    void modelPromise
+      .then((m) => {
+        if (m && m.startsWith(CHATGPT_MODEL_PREFIX)) triggerCodexAccountUsageRefresh();
+        if (m && isExclusiveXaiModelId(m)) triggerXaiSubscriptionUsageRefresh();
+      })
+      .catch(() => {
+        /* 模型解析失败: 跳过, 非致命 */
+      });
+    // Claude 订阅账号余量 (oauth/usage 端点) 同理 turn-done 触发一次 —— 节流 (180s) /
+    // 429 退避 / 未连订阅 no-op 都在 reader 内部; turn 内的实时刷新由 proxy 旁路读
+    // unified headers 兜住, 这里只负责把 scoped 分模型窗口等端点独有数据拉新。
+    triggerClaudeSubscriptionUsageRefresh();
+  }
+}

--- a/apps/desktop/src/main/maker-ipc/sessionCodexTurnUsage.ts
+++ b/apps/desktop/src/main/maker-ipc/sessionCodexTurnUsage.ts
@@ -1,0 +1,285 @@
+import type { AgentEvent, Session } from '@cindy/maker-core';
+
+import { buildTurnUsageDetails } from '../../shared/turnUsageDetails.js';
+
+import { readClaudeApiKey } from '../maker-host/auth-adapters.js';
+import { getCodexProxyAuthInjection } from '../maker-host/codex-proxy-host.js';
+import { recordSessionTurnSpend, recordSessionTurnTokens } from '../sessionSpendBroadcaster.js';
+import {
+  codexUsageToTokens,
+  recordSchedulerTurnCost,
+  recordTurnUsageOnMessage,
+} from '../turnCostBroadcaster.js';
+import { triggerClaudeAccountUsageRefresh } from '../usage/claudeAccountUsage.js';
+import { getGatewayModelPricingForModel, getModelPriceQuote } from '../usage/modelPricing.js';
+import {
+  getCodexProviderSubscriptionValuePrice,
+  getReferenceModelPricing,
+  getSubscriptionDirectValuePrice,
+} from '../usage/referenceModelPricing.js';
+import { codexApiUsageModelKey, codexSubscriptionUsageModelKey } from '../usage/usageHistory.js';
+import {
+  computePriceQuoteTurnMoney,
+  normalizeTurnUsageSegments,
+  normalizeModelIdForPricing,
+  sumTurnUsageSegments,
+} from '../usage/turnCostCalculator.js';
+import { isExclusiveXaiModelId } from '../../shared/subscriptionModels.js';
+import { type RegionalMoney } from '../../shared/regionalMoney.js';
+import { currentLedgerCurrency } from '../usage/ledgerCurrency.js';
+import { triggerXaiSubscriptionUsageRefresh } from './usage.js';
+import {
+  rebroadcastCodexTodayUsage,
+  recordCodexTurnUsage,
+  recordModelTurnUsage,
+  recordTurnSpend,
+} from '../usageBroadcaster.js';
+import { broadcastSchedulerChanged } from './schedule.js';
+import { getSessionProvider } from '../maker-host/session-provider-store.js';
+import { getActiveCatalog } from '../maker-host/active-catalog.js';
+import { isUserProviderSession } from '../maker-host/provider-route.js';
+
+export interface RecordSessionCodexTurnUsageDeps {
+  readonly turnModelPromiseBySession: Map<string, Promise<string>>;
+  readonly readSessionModelForUsage: (sessionId: string) => Promise<string>;
+  readonly unpricedSubscriptionValueMarker: () => RegionalMoney;
+}
+
+export function recordSessionCodexTurnUsage(
+  deps: RecordSessionCodexTurnUsageDeps,
+  session: Session,
+  event: AgentEvent,
+  turnAssistantPersistId: string | undefined,
+) {
+  // Codex done 事件: 记 today token 累计 (替代老 registerCodexIpc 里的 recordCodexTurnUsage 接入点)。
+  // codex/index.ts 在 turn.completed 时把 SDK usage 翻成 camelCase 塞进 done.data.usage, 这里直接转给 broadcaster。
+  // Codex SDK 不报 cost, 所以走 token 量(codex chip 显示 "本 session N token"), 跟 Claude 的 $ chip 是两条管道。
+  if (event.type === 'done' && event.source === 'codex') {
+    // 本会话显式选定的供应商('xd' / 'openai' / null=默认)。退役全局 authMode 后,
+    // 「是否走订阅(不计网关费)」改由 spawn 注入 + 该会话是否显式选了 XD 网关决定。
+    const sessionProvider = getSessionProvider(session.id);
+    const isRemoteCodexSession = Boolean(session.remoteHostId);
+    const isCustomProviderRoute = !isRemoteCodexSession && isUserProviderSession(session.id);
+    const codexAuthInjection = isRemoteCodexSession ? null : getCodexProxyAuthInjection();
+    const modelPromise =
+      deps.turnModelPromiseBySession.get(session.id) ?? deps.readSessionModelForUsage(session.id);
+    deps.turnModelPromiseBySession.delete(session.id);
+    const usage = (event.data as { usage?: unknown } | undefined)?.usage;
+    if (usage) recordCodexTurnUsage(usage);
+    // 按模型记账: codex done.data.usage 是 **per-turn 增量语义** (maker-core
+    // codexDoneUsage 契约: promptTokens=本 turn 未命中输入, completionTokens=完整输出
+    // (reasoningTokens 只是其中的诊断子集), cachedTokens=命中缓存;
+    // 整 turn 没收到 tokenUsage/updated 时全 0。
+    // 直接入库, 不做 delta 化 —— 历史上 promptTokens 曾是 contextTokens 快照、这里
+    // 做过 per-session delta 化, 语义改为 per-turn 后那套逻辑会把后小于前的 turn 记 0。
+    if (usage && typeof usage === 'object') {
+      const u = usage as {
+        promptTokens?: number;
+        completionTokens?: number;
+        reasoningTokens?: number;
+        cachedTokens?: number;
+        segments?: unknown;
+        durationMs?: number;
+        turnDurationMs?: number;
+      };
+      const promptTokens = Number(u.promptTokens) || 0;
+      const completionTokens = Number(u.completionTokens) || 0;
+      const cachedTokens = Number(u.cachedTokens) || 0;
+      const codexUsageSegments = normalizeTurnUsageSegments(u.segments);
+      const codexSegmentTotals = sumTurnUsageSegments(codexUsageSegments);
+      const codexSegmentsReliable =
+        codexUsageSegments.length > 0 &&
+        codexSegmentTotals.inputTokens === promptTokens &&
+        codexSegmentTotals.outputTokens === completionTokens &&
+        codexSegmentTotals.cacheReadTokens === cachedTokens;
+      void recordSessionTurnTokens(session.id, promptTokens + completionTokens + cachedTokens);
+      // 先落 daily_model_usage token 行, 再等价格表补 API cost。首页 usage push 会在
+      // ~2s 后刷新, 不能让冷价格表 / 离线 fetch 把模型 token 行延后到刷新之后。
+      // 后续 cost-only 增量不会重复累计 token。
+      void (async () => {
+        let pricingModel = 'unknown';
+        let turnModel = 'unknown';
+        try {
+          turnModel = await modelPromise;
+          // 只剥上下文后缀，保留 provider/SKU 前缀；`codex/gpt-*` 与裸
+          // `gpt-*` 是不同售价和折扣，不能互相回落。
+          pricingModel = normalizeModelIdForPricing(turnModel);
+        } catch {
+          // 模型读取失败时仍记录 token, 聚合 UI 会归到 unknown。
+        }
+        const isCodexBudgetRoute =
+          (sessionProvider == null || sessionProvider === 'xd') &&
+          pricingModel.startsWith('codex/');
+        const isCodexXaiProviderRoute =
+          (sessionProvider == null || sessionProvider === 'xai') &&
+          isExclusiveXaiModelId(pricingModel);
+        const isCodexOpenAiProviderRoute = sessionProvider == null || sessionProvider === 'openai';
+        const hasGatewayKey = Boolean(readClaudeApiKey());
+        const hasEffectiveGatewayRoute =
+          !isRemoteCodexSession &&
+          !isCustomProviderRoute &&
+          (codexAuthInjection === 'env-key' ||
+            isCodexBudgetRoute ||
+            (sessionProvider === 'xd' && hasGatewayKey));
+        // 显式来源的订阅判定以目录 access.kind 为权威(内置 anthropic 的 Claude.ai
+        // 订阅同样是订阅价值,不能只认 OpenAI/xAI);目录缺 access 的旧快照仍靠下面
+        // 的 openai oauth 分支兜底。
+        const sessionProviderAccessKind = sessionProvider
+          ? getActiveCatalog().providers.find((provider) => provider.id === sessionProvider)?.access
+              ?.kind
+          : null;
+        const isCodexSubscriptionAccessRoute =
+          !isRemoteCodexSession &&
+          sessionProvider != null &&
+          sessionProvider !== 'xd' &&
+          sessionProviderAccessKind === 'subscription' &&
+          !hasEffectiveGatewayRoute;
+        const isSubscriptionValue =
+          isRemoteCodexSession ||
+          isCodexXaiProviderRoute ||
+          isCodexSubscriptionAccessRoute ||
+          (isCodexOpenAiProviderRoute &&
+            codexAuthInjection === 'oauth-bearer' &&
+            !hasEffectiveGatewayRoute);
+        const usesReferencePriceEstimate =
+          !isSubscriptionValue &&
+          !isRemoteCodexSession &&
+          !hasEffectiveGatewayRoute &&
+          Boolean(sessionProvider && sessionProvider !== 'xd');
+        const modelUsageKey = isSubscriptionValue
+          ? codexSubscriptionUsageModelKey(pricingModel)
+          : codexApiUsageModelKey(pricingModel);
+        await recordModelTurnUsage({
+          agentKind: 'codex',
+          model: modelUsageKey,
+          money: isSubscriptionValue ? deps.unpricedSubscriptionValueMarker() : undefined,
+          inputTokensDelta: promptTokens,
+          outputTokensDelta: completionTokens,
+          cacheReadTokensDelta: cachedTokens,
+          cacheCreateTokensDelta: 0,
+        }).finally(() => rebroadcastCodexTodayUsage());
+
+        // Codex SDK 不报 $, 用价格表折算。普通模型 + oauth(订阅)显示为 token 价值;api 模式和 codex/
+        // 折扣模型走 gateway API, 显示为 API cost。远端 Codex 由远端 daemon
+        // 路由,本机不知道远端 OAuth/API 事实,因此只显示 token 价值,不写本地
+        // gateway cost。只有真实本地 API cost 写入 sessions.total_cost_usd,
+        // 避免 scheduler 的 Cost 汇总混入订阅价值或远端账号消耗。
+        // fire-and-forget 不阻塞事件循环;价格表走 main 端内存 + 磁盘缓存,
+        // stale 快返并后台刷新,
+        // 拉不到 / 模型无条目 → 只落 token 明细,UI 退回显示本轮 token。
+        // 明细在 try 外构造:它只依赖上面已拿到的 token 数,价格请求抛错时也要能落。
+        const turnUsageDetails = buildTurnUsageDetails({
+          inputTokens: promptTokens,
+          outputTokens: completionTokens,
+          cacheReadTokens: cachedTokens,
+          cacheCreateTokens: 0,
+          model: turnModel,
+          durationMs: u.durationMs,
+          turnDurationMs: u.turnDurationMs,
+        });
+        const recordCodexUsageOnly = async () => {
+          if (!turnAssistantPersistId) return;
+          await recordTurnUsageOnMessage({
+            sessionId: session.id,
+            clientId: turnAssistantPersistId,
+            turnUsageDetails,
+          });
+        };
+        try {
+          const pricing = isSubscriptionValue
+            ? getReferenceModelPricing()
+            : hasEffectiveGatewayRoute
+              ? await getGatewayModelPricingForModel()
+              : usesReferencePriceEstimate
+                ? getReferenceModelPricing()
+                : null;
+          // 订阅估值按显式来源取各自的日期定价路由:内置 anthropic 走 Anthropic
+          // registry 参考价(含 codex 侧价格覆盖),默认/openai 保持 OpenAI 价表。
+          const subscriptionValueProviderId =
+            isCodexSubscriptionAccessRoute && sessionProvider != null ? sessionProvider : 'openai';
+          const price = isCodexXaiProviderRoute
+            ? getSubscriptionDirectValuePrice(pricingModel, 'codex', pricing)
+            : isSubscriptionValue
+              ? getCodexProviderSubscriptionValuePrice(
+                  subscriptionValueProviderId,
+                  pricingModel,
+                  pricing,
+                )
+              : hasEffectiveGatewayRoute
+                ? getModelPriceQuote(pricing, 'xd', pricingModel)
+                : usesReferencePriceEstimate
+                  ? getModelPriceQuote(pricing, sessionProvider, pricingModel, 'codex')
+                  : undefined;
+          const money = computePriceQuoteTurnMoney(
+            codexUsageToTokens(u),
+            price ?? undefined,
+            currentLedgerCurrency(),
+            u.segments !== undefined && codexSegmentsReliable ? codexUsageSegments : [],
+          );
+          // Only Gateway sale prices are actual API spend. Third-party/user reference quotes
+          // are value estimates and daily_model_usage cannot preserve RegionalMoney.kind, so
+          // writing them into #billing=api would later reconstruct an estimate as actual cost.
+          if (money && (isSubscriptionValue || price?.source === 'gateway')) {
+            await recordModelTurnUsage({
+              agentKind: 'codex',
+              model: modelUsageKey,
+              money,
+              inputTokensDelta: 0,
+              outputTokensDelta: 0,
+              cacheReadTokensDelta: 0,
+              cacheCreateTokensDelta: 0,
+            });
+          }
+          if (money && money.amount > 0) {
+            const isActualApiCost = !isSubscriptionValue && price?.source === 'gateway';
+            if (isActualApiCost) {
+              void recordTurnSpend(money);
+              void recordSessionTurnSpend(session.id, money);
+            }
+            const changedScheduleId = await recordSchedulerTurnCost({
+              sessionId: session.id,
+              clientId: turnAssistantPersistId,
+              money,
+              turnUsageDetails,
+              turnOrigin: event.turnOrigin,
+            });
+            if (changedScheduleId) broadcastSchedulerChanged(changedScheduleId);
+          } else {
+            await recordCodexUsageOnly();
+          }
+        } catch {
+          // token row 已在价格请求前落库;价格失败只影响 API cost / message cost。
+          // 消息那一格仍要有事实可看:补落一次 token 明细。patch 是 agent_meta merge、
+          // 写的又是同一份明细,所以与上面成功分支重复执行也是幂等的(自身失败只 warn)。
+          await recordCodexUsageOnly();
+        }
+      })();
+    }
+    // 走 gateway/API 口径(同一把 XD key 的 LiteLLM 计费)的 codex turn,done 后刷新账号配额
+    // (与 cc 同口径, chip 显示 daily/monthly/key cost)。命中:会话显式选了 XD 网关、无 OAuth
+    // token 的 env-key fallback、或 codex/ 预算模型。普通 oauth 订阅没有 $ 配额,不刷。
+    void modelPromise
+      .then((model) => {
+        const hasGatewayKey = Boolean(readClaudeApiKey());
+        if (!isRemoteCodexSession && isExclusiveXaiModelId(model)) {
+          triggerXaiSubscriptionUsageRefresh();
+          return;
+        }
+        if (
+          !isRemoteCodexSession &&
+          !isCustomProviderRoute &&
+          !isExclusiveXaiModelId(model) &&
+          (codexAuthInjection === 'env-key' ||
+            model.startsWith('codex/') ||
+            (sessionProvider === 'xd' && hasGatewayKey))
+        ) {
+          void triggerClaudeAccountUsageRefresh();
+        }
+      })
+      .catch(() => {
+        if (sessionProvider === 'xd' && readClaudeApiKey()) {
+          void triggerClaudeAccountUsageRefresh();
+        }
+      });
+  }
+}

--- a/apps/desktop/src/main/maker-ipc/sessionErrorSuppression.ts
+++ b/apps/desktop/src/main/maker-ipc/sessionErrorSuppression.ts
@@ -1,0 +1,15 @@
+import type { AgentEvent } from '@cindy/maker-core';
+import type { AgentInputCoordinator } from './agent-input-coordinator.js';
+
+/** Read at each boundary: delivery/idle callbacks may change recovery ownership. */
+export function isSessionErrorSuppressed(
+  coordinator: Pick<AgentInputCoordinator, 'isAutoResumePending' | 'isAutoResumeDeferred'> | null,
+  sessionId: string,
+  event: AgentEvent,
+): boolean {
+  return (
+    event.type === 'error' &&
+    (coordinator?.isAutoResumePending(sessionId) === true ||
+      coordinator?.isAutoResumeDeferred(sessionId) === true)
+  );
+}

--- a/apps/desktop/src/main/maker-ipc/sessionEventDelivery.ts
+++ b/apps/desktop/src/main/maker-ipc/sessionEventDelivery.ts
@@ -1,0 +1,170 @@
+import type { AgentEvent, Session } from '@cindy/maker-core';
+
+import type { GitSnapshotCoordinator } from '../git-snapshot/gitSnapshotCoordinator.js';
+import { reserveTurnErrorPersistId } from '../messagePersistBroadcaster.js';
+import { AgentInputCoordinator } from './agent-input-coordinator.js';
+import { MAKER_PUSH } from './channels.js';
+import { type OrcaTeamService } from './orcaTeamService.js';
+import {
+  isContextOverflowErrorData,
+  isOversizedHistoryErrorData,
+} from './contextOverflowRollover.js';
+import { noteClaudeSessionTurnState } from '../maker-host/claude-session-background-activity.js';
+import { DeferredCodexRestartService } from './deferredCodexRestart.js';
+import {
+  isTerminalTurnErrorEvent,
+  SessionTurnActivityTracker,
+} from './sessionTurnActivityTracker.js';
+import type { PreparedSessionEvent } from './sessionEventPreparation.js';
+import type { SessionStreamResult } from './sessionEventStream.js';
+import { isSessionErrorSuppressed } from './sessionErrorSuppression.js';
+export interface DeliverSessionEventDeps {
+  readonly orcaTeamServiceForEvents: Pick<OrcaTeamService, 'captureWorkerTerminalTurn'> | null;
+  readonly agentInputCoordinatorHolder: Pick<
+    AgentInputCoordinator,
+    'onExternalTurnSettled' | 'isAutoResumePending' | 'isAutoResumeDeferred'
+  > | null;
+  readonly overflowSuppressedBroadcasts: Map<
+    string,
+    { sessionId: string; event: AgentEvent; persistId?: string; resolvedContent?: unknown }
+  >;
+  readonly broadcastToAllWindows: (channel: string, payload: unknown) => void;
+  readonly handleAgentIslandEventAfterBroadcast: (
+    session: {
+      id: string;
+      agentKind?: unknown;
+      workDir?: unknown;
+      workspaceKind?: unknown;
+      remoteHostId?: unknown;
+    },
+    event: AgentEvent,
+  ) => void;
+  readonly sessionTurnActivityTracker: Pick<
+    SessionTurnActivityTracker,
+    'scheduleIdleAfterTerminalBroadcast' | 'scheduleIdleAfterStatusBroadcast'
+  >;
+  readonly notifyGoalIdleAfterTurnSettled: (sessionId: string) => void;
+  readonly settlePendingCredentialSwitch: (sessionId: string, source: string) => void;
+  readonly settlePendingSessionRuntimeControlHolder:
+    ((sessionId: string, reason: string) => void) | null;
+  readonly deferredCodexRestartHolder: Pick<DeferredCodexRestartService, 'onSessionSettled'> | null;
+  readonly refreshRemoteCodexMcpOnTurnSettledHolder: ((sessionId: string) => void) | null;
+  readonly markTurnEndedAfterPersistDrain: (sessionId: string) => void;
+  readonly gitSnapshotCoordinator: Pick<GitSnapshotCoordinator, 'onTurnEnd' | 'onTurnAbort'> | null;
+}
+
+export function deliverSessionEvent(
+  deps: DeliverSessionEventDeps,
+  session: Session,
+  prepared: PreparedSessionEvent,
+  stream: SessionStreamResult,
+) {
+  const {
+    event,
+    attributedEvent,
+    broadcastEvent,
+    eventAgentMeta,
+    shouldMarkTurnStatusIdleAfterBroadcast,
+    shouldMarkTurnTerminalIdleAfterBroadcast,
+    isContinuationBoundary,
+    isPlannedUpgradeClose,
+    isRemoteAuthRetry,
+    isGatewayProxyTokenRecovery,
+  } = prepared;
+  let { persistId } = stream;
+  const { resolvedContent } = stream;
+  // 先 broadcast 保 UI 实时性,再 flush(flush 只入队、不阻塞)。
+  // Keep the raw event for main-side coordination/persistence, but only
+  // cross renderer/device-link boundaries with the redacted copy.
+  // Capture Orca terminal ownership before the tracker wakes queue drain.
+  // The replacement input may be accepted while the async persistence and
+  // turn-start barriers below yield; that later turn must not inherit this
+  // terminal event or lose the lead_interrupt marker before it is observed.
+  const workerTerminalCapture =
+    !isContinuationBoundary && (event.type === 'done' || isTerminalTurnErrorEvent(event))
+      ? deps.orcaTeamServiceForEvents?.captureWorkerTerminalTurn(session.id)
+      : undefined;
+  // Reserve against the current recovery owner. Terminal persistence reads
+  // again after delivery and idle callbacks, which may change that owner.
+  const autoResumeWouldSuppressPersist = isSessionErrorSuppressed(
+    deps.agentInputCoordinatorHolder,
+    session.id,
+    event,
+  );
+  const suppressOverflowBroadcast =
+    !session.remoteHostId &&
+    event.type === 'error' &&
+    isTerminalTurnErrorEvent(event) &&
+    (isContextOverflowErrorData(event.data) || isOversizedHistoryErrorData(event.data));
+  if (
+    event.type === 'error' &&
+    isTerminalTurnErrorEvent(event) &&
+    !isPlannedUpgradeClose &&
+    !isRemoteAuthRetry &&
+    !isGatewayProxyTokenRecovery &&
+    !autoResumeWouldSuppressPersist &&
+    !suppressOverflowBroadcast
+  ) {
+    persistId = reserveTurnErrorPersistId(
+      session.id,
+      attributedEvent.data as {
+        message?: unknown;
+        reason?: unknown;
+        sdkError?: unknown;
+      } | null,
+      eventAgentMeta,
+    );
+  }
+  if (suppressOverflowBroadcast) {
+    deps.overflowSuppressedBroadcasts.set(session.id, {
+      sessionId: session.id,
+      event: broadcastEvent,
+      persistId,
+      resolvedContent,
+    });
+  } else {
+    deps.broadcastToAllWindows(MAKER_PUSH.EVENT, {
+      sessionId: session.id,
+      event: broadcastEvent,
+      persistId,
+      resolvedContent,
+    });
+    deps.handleAgentIslandEventAfterBroadcast(session, broadcastEvent);
+  }
+  if (shouldMarkTurnTerminalIdleAfterBroadcast) {
+    deps.sessionTurnActivityTracker.scheduleIdleAfterTerminalBroadcast(session.id);
+    // #9 idle 兜底:正常 done、终止型 error（含 abort）统一在 tracker 已置 idle 后
+    // 唤醒 Goal controller。无 goal / 非 active / 已取消的 deferred Resume 均为 no-op。
+    deps.notifyGoalIdleAfterTurnSettled(session.id);
+    // 后台活动检测:done / 终止型 error = 逻辑 turn 结束,记录结束时刻。
+    // 此后若该会话进程仍有 API 流量(后台子 agent),record 路径会点亮横幅。
+    noteClaudeSessionTurnState(session.id, false);
+    // turn 收尾打标(last_turn_ended_at)不在此处:done / terminal error 的本 turn
+    // 持久化(assistant flush / orphan tool_result / error 行)在下方 flush 块才
+    // 入队,统一在那之后走 markTurnEndedAfterPersistDrain(见该 helper 注释)。
+    // turn 边界(done / 终止型 error):必须在 tracker 标 idle **之后**再兑现本会话的
+    // 延迟凭证切换、唤醒被本会话挡住的等待者 —— vendor 可能不发前置 status:false,
+    // 提前唤醒会让 apply/重试读到 isSessionInTurn=true 而空转,退化到 10s 兜底
+    // (review P2 2026-07-04)。apply 内部串行 + 幂等,fire-and-forget 安全;
+    // planned upgrade close 等场景多唤一次也只是 no-op。
+    deps.settlePendingCredentialSwitch(session.id, `event:${event.type}`);
+    deps.settlePendingSessionRuntimeControlHolder?.(session.id, `event:${event.type}`);
+    deps.deferredCodexRestartHolder?.onSessionSettled();
+    deps.agentInputCoordinatorHolder?.onExternalTurnSettled(session.id);
+    deps.refreshRemoteCodexMcpOnTurnSettledHolder?.(session.id);
+  } else if (shouldMarkTurnStatusIdleAfterBroadcast) {
+    deps.sessionTurnActivityTracker.scheduleIdleAfterStatusBroadcast(session.id);
+    // status:isRunning=false 即逻辑 turn 结束(可重试 error 不发这个信号)。
+    deps.markTurnEndedAfterPersistDrain(session.id);
+    noteClaudeSessionTurnState(session.id, false);
+  }
+  if (event.type === 'done' && !isContinuationBoundary) {
+    void deps.gitSnapshotCoordinator?.onTurnEnd(session.id);
+  }
+  if (isTerminalTurnErrorEvent(event)) {
+    deps.gitSnapshotCoordinator?.onTurnAbort(session.id);
+  }
+  return { persistId, workerTerminalCapture };
+}
+
+export type SessionDeliveryResult = ReturnType<typeof deliverSessionEvent>;

--- a/apps/desktop/src/main/maker-ipc/sessionEventPipeline.ts
+++ b/apps/desktop/src/main/maker-ipc/sessionEventPipeline.ts
@@ -1,0 +1,56 @@
+import type { AgentEvent, Session } from '@cindy/maker-core';
+import { prepareSessionEvent, type PrepareSessionEventDeps } from './sessionEventPreparation.js';
+import {
+  persistSessionStreamEvent,
+  type PersistSessionStreamEventDeps,
+} from './sessionEventStream.js';
+import { deliverSessionEvent, type DeliverSessionEventDeps } from './sessionEventDelivery.js';
+import {
+  finishSessionTerminalEvent,
+  type FinishSessionTerminalEventDeps,
+} from './sessionEventTerminal.js';
+import { recordSessionEventSnapshots } from './sessionEventSnapshots.js';
+import {
+  recordSessionClaudeTurnUsage,
+  type RecordSessionClaudeTurnUsageDeps,
+} from './sessionClaudeTurnUsage.js';
+import {
+  recordSessionCodexTurnUsage,
+  type RecordSessionCodexTurnUsageDeps,
+} from './sessionCodexTurnUsage.js';
+import {
+  recordSessionPiTurnUsage,
+  type RecordSessionPiTurnUsageDeps,
+} from './sessionPiTurnUsage.js';
+
+export type SessionEventDependencies = PrepareSessionEventDeps &
+  PersistSessionStreamEventDeps &
+  DeliverSessionEventDeps &
+  FinishSessionTerminalEventDeps &
+  RecordSessionClaudeTurnUsageDeps &
+  RecordSessionCodexTurnUsageDeps &
+  RecordSessionPiTurnUsageDeps;
+
+/** Synchronous delivery boundary. Accepted asynchronous writes retain their original turn. */
+export function handleSessionEvent(
+  deps: SessionEventDependencies,
+  session: Session,
+  event: AgentEvent,
+): void {
+  const prepared = prepareSessionEvent(deps, session, event);
+  if (!prepared) return;
+  const stream = persistSessionStreamEvent(deps, session, prepared);
+  const delivery = deliverSessionEvent(deps, session, prepared, stream);
+  const terminal = finishSessionTerminalEvent(deps, session, prepared, delivery);
+  recordSessionEventSnapshots(session, prepared);
+  recordSessionClaudeTurnUsage(
+    deps,
+    session,
+    event,
+    terminal.turnAssistantPersistId,
+    prepared.completedTurnWallClockMs,
+    prepared.isContinuationBoundary,
+  );
+  recordSessionCodexTurnUsage(deps, session, event, terminal.turnAssistantPersistId);
+  recordSessionPiTurnUsage(deps, session, event, terminal.turnAssistantPersistId);
+}

--- a/apps/desktop/src/main/maker-ipc/sessionEventPreparation.ts
+++ b/apps/desktop/src/main/maker-ipc/sessionEventPreparation.ts
@@ -1,0 +1,523 @@
+import type {
+  AgentEvent,
+  InteractionDecision,
+  InteractionRequest,
+  SendOrigin,
+  Session,
+} from '@cindy/maker-core';
+
+import { isTurnContinuationBoundaryEvent } from '@cindy/maker-shared/turn-continuation';
+
+import type { AgentMeta } from '../../renderer/lib/ccAgent.types';
+import { parseAgentInputToolLoopDetails } from '../../shared/agentInputQueue.js';
+import { noteSubagentObservationTurnStarted } from '../subagentObservationRewindFence.js';
+import { persistSessionFields } from '../localDb/ipc/sessions.js';
+
+import { createLogger } from '../logger.js';
+import type { GitSnapshotCoordinator } from '../git-snapshot/gitSnapshotCoordinator.js';
+import { markSessionTurnStarted } from '../localDb/sessionActiveTurn.js';
+import {
+  backgroundTurnPredatesSessionClear,
+  noteAgentMeta,
+  noteTurnStarted,
+} from '../messagePersistBroadcaster.js';
+import { isCcMgrUpgradeInFlight } from '../remote-ssh/index.js';
+import { AgentInputCoordinator } from './agent-input-coordinator.js';
+import { clearPromptPredictionSessionStopped } from './promptPredictionStopLedger.js';
+import { MAKER_PUSH } from './channels.js';
+import { finalizeTurnChangeSet } from '../turn-change-set/store.js';
+import { type OrcaTeamService } from './orcaTeamService.js';
+import { getSessionFastMode } from '../maker-host/session-effort-store.js';
+import { noteClaudeSessionTurnState } from '../maker-host/claude-session-background-activity.js';
+import { consumeClaudeOpusPlanMismatch } from '../maker-host/claude-gateway-error-observer.js';
+import {
+  isTerminalTurnErrorEvent,
+  SessionTurnActivityTracker,
+} from './sessionTurnActivityTracker.js';
+import { SilentStopTurnLeaseGate } from './sessionTurnLease.js';
+import { ProductTurnUsageTargetTracker, ProductTurnWallClockTracker } from './turnWallClock.js';
+import { createWorkerTurnStartSequencer } from './workerTurnStartSequencer.js';
+import { SilentStopAutoResumeGuard } from './silentStopAutoResume.js';
+import { AutoResumeBookkeeping } from './autoResumeBookkeeping.js';
+import {
+  InterruptedTurnAutoResumeGuard,
+  isSubstantiveProgressEvent,
+} from './interruptedTurnAutoResume.js';
+
+interface DismissedInteraction {
+  kind: InteractionRequest['kind'];
+  resolve: (decision: InteractionDecision) => void;
+  request: InteractionRequest;
+  persistId?: string;
+}
+
+export interface PrepareSessionEventDeps {
+  readonly isFencedStaleSessionTerminal: (sessionId: string, event: AgentEvent) => boolean;
+  readonly log: Pick<ReturnType<typeof createLogger>, 'debug' | 'warn'>;
+  readonly interruptedTurnAutoResumeGuard: Pick<
+    InterruptedTurnAutoResumeGuard,
+    'noteAttemptEvent' | 'noteTurnStarted' | 'noteAttemptSettled' | 'noteProgress'
+  >;
+  readonly redactEventForRenderer: (event: AgentEvent) => AgentEvent;
+  readonly handleAgentIslandInteractionDismissed: (sessionId: string, requestId: string) => void;
+  readonly clearPendingInteraction: (requestId: string) => DismissedInteraction | null;
+  readonly defaultDecisionForPending: (
+    kind: InteractionRequest['kind'],
+    reason: string,
+  ) => InteractionDecision;
+  readonly persistInteractionDecision: (
+    sessionId: string,
+    persistId: string | undefined,
+    kind: InteractionRequest['kind'],
+    request: InteractionRequest,
+    decision: InteractionDecision | Record<string, unknown>,
+  ) => void;
+  readonly broadcastToAllWindows: (channel: string, payload: unknown) => void;
+  readonly broadcastCodexImageAsToolResult: (sessionId: string, event: AgentEvent) => Promise<void>;
+  readonly autoResumeBookkeeping: Pick<
+    AutoResumeBookkeeping,
+    'discardReplacementProvenByProviderEvent' | 'clearFailedTurnCompletionTail' | 'settleOutcome'
+  >;
+  readonly pendingFailedTurnAssistantPersistId: Map<string, string>;
+  readonly silentStopAutoResumeGuard: Pick<SilentStopAutoResumeGuard, 'noteTurnStarted'>;
+  readonly sessionTurnActivityTracker: Pick<
+    SessionTurnActivityTracker,
+    'isSessionInTurn' | 'setSessionInTurn'
+  >;
+  readonly productTurnWallClockTracker: Pick<ProductTurnWallClockTracker, 'start' | 'finish'>;
+  readonly productTurnUsageTargetTracker: Pick<ProductTurnUsageTargetTracker, 'clear'>;
+  readonly advanceSessionTurnBoundaryGeneration: (sessionId: string) => number;
+  readonly gitSnapshotCoordinator: Pick<
+    GitSnapshotCoordinator,
+    'hasPendingTurnStart' | 'onTurnStart'
+  > | null;
+  readonly workerTurnStartSequencer: Pick<
+    ReturnType<typeof createWorkerTurnStartSequencer>,
+    'start'
+  >;
+  readonly orcaTeamServiceForEvents: Pick<OrcaTeamService, 'handleWorkerTurnStarted'> | null;
+  readonly turnModelPromiseBySession: Map<string, Promise<string>>;
+  readonly readSessionModelForUsage: (sessionId: string) => Promise<string>;
+  readonly turnPiFastModeBySession: Map<string, boolean>;
+  readonly silentStopTurnLeaseGate: Pick<SilentStopTurnLeaseGate, 'turnLeaseIdForEvent'>;
+  readonly agentInputCoordinatorHolder: Pick<
+    AgentInputCoordinator,
+    'onTurnEvent' | 'noteSuppressedTerminalError'
+  > | null;
+  readonly handleSilentStopTurnEnd: (
+    session: Session,
+    doneAt: number,
+    turnLeaseId: string,
+    turnOrigin?: SendOrigin,
+  ) => Promise<void>;
+  readonly isRemoteAuthRetryErrorEvent: (
+    session: { agentKind?: unknown; remoteHostId?: unknown },
+    event: AgentEvent,
+  ) => boolean;
+  readonly isGatewayProxyTokenRecoveryErrorEvent: (sessionId: string, event: AgentEvent) => boolean;
+}
+
+export function prepareSessionEvent(
+  deps: PrepareSessionEventDeps,
+  session: Session,
+  event: AgentEvent,
+) {
+  // Exact patches are main-owned durable data. They have a dedicated summary push and
+  // on-demand detail IPC; forwarding the raw diff through maker:event would duplicate a
+  // potentially multi-megabyte payload to every renderer and device-link controller.
+  if (event.type === 'turn_diff') return;
+  if (
+    event.turnScope === 'background' &&
+    Object.prototype.hasOwnProperty.call(event, 'backgroundTurnStartedAt') &&
+    backgroundTurnPredatesSessionClear(session.id, event.backgroundTurnStartedAt)
+  ) {
+    return;
+  }
+  if (deps.isFencedStaleSessionTerminal(session.id, event)) {
+    deps.log.debug('ignored stale terminal after leftover turn reclaim', {
+      sessionId: session.id,
+      eventType: event.type,
+      sessionTurnGeneration: event.sessionTurnGeneration ?? null,
+      sessionInstanceId: event.sessionInstanceId ?? null,
+    });
+    return;
+  }
+  // 自动续跑的 pending 不能只靠 status(isRunning=true) 清理：Pi/Claude 的
+  // terminal-only 路径可能首个事件就是 error。Session 已把 host-owned token
+  // 盖到事件上，首个匹配 token 的事件即视为 provider accepted。
+  if (typeof event.turnAttemptToken === 'number') {
+    deps.interruptedTurnAutoResumeGuard.noteAttemptEvent(session.id, event.turnAttemptToken);
+  }
+  let attributedEvent = event;
+  if (event.type === 'error' && isTerminalTurnErrorEvent(event)) {
+    const reason =
+      !session.remoteHostId && session.agentKind === 'claude-code'
+        ? consumeClaudeOpusPlanMismatch(session.id)
+        : null;
+    if (reason) {
+      const eventData =
+        event.data && typeof event.data === 'object' && !Array.isArray(event.data)
+          ? (event.data as Record<string, unknown>)
+          : {};
+      attributedEvent = { ...event, data: { ...eventData, reason } };
+      deps.log.warn('Claude Opus plan error normalized for renderer', {
+        sessionId: session.id,
+        model: session.model,
+        reason,
+      });
+    }
+  }
+  const broadcastEvent = deps.redactEventForRenderer(attributedEvent);
+  if (event.type === 'interaction_dismissed') {
+    const data = event.data as { requestId?: unknown; reason?: unknown };
+    if (typeof data.requestId === 'string') {
+      deps.handleAgentIslandInteractionDismissed(session.id, data.requestId);
+      const entry = deps.clearPendingInteraction(data.requestId);
+      if (entry) {
+        const decision = deps.defaultDecisionForPending(
+          entry.kind,
+          typeof data.reason === 'string' ? data.reason : 'dismissed',
+        );
+        entry.resolve(decision);
+        deps.persistInteractionDecision(
+          session.id,
+          entry.persistId,
+          entry.kind,
+          entry.request,
+          decision,
+        );
+      }
+    }
+    deps.broadcastToAllWindows(MAKER_PUSH.INTERACTION_DISMISSED, {
+      sessionId: session.id,
+      ...(event.data as object),
+    });
+    return;
+  }
+  if (event.type === 'image' && event.source === 'codex') {
+    void deps.broadcastCodexImageAsToolResult(session.id, event);
+    return;
+  }
+  if (event.type === 'plan_mode_changed') {
+    // agent 自行切换计划模式(典型: 计划批准后自动退出)。main 是持久化收口点:
+    // 复用 persistSessionFields 回写 sessions.plan_mode_enabled 并广播
+    // sessions:patched, 本机窗口与 device-link 控制端镜像同步收敛。
+    const data = event.data as { enabled?: unknown };
+    if (typeof data?.enabled === 'boolean') {
+      void persistSessionFields(session.id, { planModeEnabled: data.enabled }).catch((err) => {
+        deps.log.warn('persist plan_mode_changed failed', {
+          sessionId: session.id,
+          error: err instanceof Error ? err.message : String(err),
+        });
+      });
+    }
+    return;
+  }
+  // turn 结束的 status event (isRunning=false + status='Done') 携带 endSnapshot。
+  // contextTokens / contextWindow 的持久化统一在 main 端做，避免多 window 竞写；
+  // 但不能挡在 EVENT broadcast 前面，否则 final/done 已到 main 后还会被同步 SQLite
+  // 和 usage 广播拖住。这里先记录待写快照，广播后再执行。
+  // Claude / Codex 同形 (usageTracker.snapshot() 两边都给 contextTokens / contextWindow),
+  // 不按 source 分支 —— 之前漏接 codex 导致重启后圆环归零。
+  let pendingContextSnapshot: { contextTokens: number; contextWindow: number } | null = null;
+  let pendingCodexAccountUsageSnapshot: unknown | null = null;
+  let shouldMarkTurnStatusIdleAfterBroadcast = false;
+  let shouldMarkTurnTerminalIdleAfterBroadcast = false;
+  let completedTurnWallClockMs: number | undefined;
+  const isContinuationBoundary = isTurnContinuationBoundaryEvent(event);
+  // 探针:continuation 边界命中会跳过 status idle / ended 写 / tracker idle,
+  // 若 claim 悬挂会导致 UI 永久「正在生成」。区分「claim 悬挂」与「done 未到达」。
+  if (isContinuationBoundary && (event.type === 'done' || event.type === 'status')) {
+    deps.log.debug('turn continuation boundary event skipped from turn-finalize', {
+      sessionId: session.id,
+      eventType: event.type,
+      turnContinuationId: event.turnContinuationId,
+    });
+  }
+  if (event.type === 'account_usage' && event.source === 'codex' && !session.remoteHostId) {
+    pendingCodexAccountUsageSnapshot = event.data;
+  }
+  if (event.type === 'status') {
+    const data = event.data as {
+      isRunning?: boolean;
+      status?: string;
+      contextTokens?: number;
+      contextWindow?: number;
+    };
+    // Idle compact / late background work may still send isRunning for UI
+    // copy. It must not latch the product turn tracker or idle bookkeeping.
+    if (data.isRunning === true && event.turnScope !== 'background') {
+      // replacement 已进入 vendor 后，running 是新 attempt 的权威起点。不要依赖
+      // sendToAgent 返回后的 onDispatched 回调：provider 可同步发事件并先清 activeTurn。
+      deps.autoResumeBookkeeping.discardReplacementProvenByProviderEvent(session.id);
+      // 新 turn 启动: 上一轮未配对的失败记账交接 id 已无归属, 丢弃防错配。
+      deps.pendingFailedTurnAssistantPersistId.delete(session.id);
+      // Tokenless status(true) can be a delayed tail of the failed turn.
+      // Only a token-bearing running event proves a new attempt started.
+      if (typeof event.turnAttemptToken === 'number') {
+        deps.autoResumeBookkeeping.clearFailedTurnCompletionTail(session.id);
+      }
+      // 记录 turn 开始时刻，供 onTurnErrorEvent 判断 error 是否属于 /clear 之前的旧 turn。
+      noteTurnStarted(session.id, event.turnAttemptToken);
+      noteSubagentObservationTurnStarted(session.id);
+      // silent-stop 守卫:新 turn 开始 → 清 pendingResume + 记录时刻(陈旧判定)。
+      deps.silentStopAutoResumeGuard.noteTurnStarted(session.id);
+      deps.interruptedTurnAutoResumeGuard.noteTurnStarted(session.id, {
+        // A tokenless status(true) can be a delayed tail from the failed turn. It
+        // must not consume the pending token of the next scheduled auto-resume.
+        clearPending: typeof event.turnAttemptToken === 'number',
+      });
+      const wasInTurn = deps.sessionTurnActivityTracker.isSessionInTurn(session.id);
+      if (!wasInTurn && event.source === 'claude-code') {
+        const startedProductTurn = deps.productTurnWallClockTracker.start(session.id);
+        if (startedProductTurn) deps.productTurnUsageTargetTracker.clear(session.id);
+      }
+      deps.sessionTurnActivityTracker.setSessionInTurn(session.id, data.isRunning);
+      if (!wasInTurn) deps.advanceSessionTurnBoundaryGeneration(session.id);
+      // 后台活动检测:turn 开始 → 该会话的 API 流量回归主线,后台横幅熄灭。
+      noteClaudeSessionTurnState(session.id, true);
+      if (!wasInTurn) {
+        if (!deps.gitSnapshotCoordinator?.hasPendingTurnStart(session.id)) {
+          void deps.gitSnapshotCoordinator?.onTurnStart(session.id);
+        }
+        deps.workerTurnStartSequencer.start(session.id, async () => {
+          await deps.orcaTeamServiceForEvents?.handleWorkerTurnStarted(session.id);
+        });
+        // interrupted-turn-resume:记录 turn 启动时刻,与正常收尾时刻配对做
+        // 「疑似中断」纯读判定(设计总述见 localDb/sessionActiveTurn.ts 文件头)。
+        // SSH remote 会话同样记录:session 行在本地 DB、事件流走本进程,只是
+        // agent 跑在远端;device-link 被控会话不进本进程 maker-core,天然不经过。
+        clearPromptPredictionSessionStopped(session.id);
+        markSessionTurnStarted(session.id);
+      }
+      if (
+        (event.source === 'claude-code' || event.source === 'codex' || event.source === 'pi') &&
+        !deps.turnModelPromiseBySession.has(session.id)
+      ) {
+        deps.turnModelPromiseBySession.set(session.id, deps.readSessionModelForUsage(session.id));
+      }
+      if (event.source === 'pi' && !deps.turnPiFastModeBySession.has(session.id)) {
+        deps.turnPiFastModeBySession.set(session.id, getSessionFastMode(session.id));
+      }
+    } else if (
+      data.isRunning === false &&
+      !isContinuationBoundary &&
+      event.turnScope !== 'background'
+    ) {
+      shouldMarkTurnStatusIdleAfterBroadcast = true;
+    }
+    if (
+      data.isRunning === false &&
+      data.status === 'Done' &&
+      typeof data.contextTokens === 'number'
+    ) {
+      pendingContextSnapshot = {
+        contextTokens: data.contextTokens,
+        contextWindow: data.contextWindow ?? 0,
+      };
+    }
+  }
+  if (event.type === 'done') {
+    const doneAttemptToken = event.turnAttemptToken;
+    if (typeof doneAttemptToken === 'number' && !isContinuationBoundary) {
+      deps.autoResumeBookkeeping.settleOutcome(session.id, doneAttemptToken, 'failed');
+      deps.interruptedTurnAutoResumeGuard.noteAttemptSettled(session.id, doneAttemptToken);
+    }
+    const rawTurn = (event.data as { raw?: { id?: unknown; status?: unknown } } | null)?.raw;
+    const carriesSilentStop =
+      (event.data as { silentStop?: boolean } | null | undefined)?.silentStop === true;
+    const silentStopTurnLeaseId = carriesSilentStop
+      ? deps.silentStopTurnLeaseGate.turnLeaseIdForEvent(event)
+      : undefined;
+    if (carriesSilentStop && !silentStopTurnLeaseId) {
+      deps.log.debug('ignored stale silent-stop terminal from an older turn', {
+        sessionId: session.id,
+      });
+      return;
+    }
+    const isSilentStopDone = carriesSilentStop;
+    if (event.source === 'claude-code' && !isContinuationBoundary && !isSilentStopDone) {
+      completedTurnWallClockMs = deps.productTurnWallClockTracker.finish(session.id);
+    }
+    if (!isContinuationBoundary && !isSilentStopDone) {
+      shouldMarkTurnTerminalIdleAfterBroadcast = true;
+    }
+    if (!isContinuationBoundary && !isSilentStopDone) {
+      finalizeTurnChangeSet(
+        session.id,
+        typeof rawTurn?.id === 'string' ? rawTurn.id : null,
+        rawTurn && rawTurn.status !== 'completed' ? 'partial' : 'complete',
+      );
+    }
+    // turn 正常收尾但一路没有实质产出时,上一条重连记录同样不能停在"结果未回填":
+    // 成功路径已在产出事件里 settle 成 succeeded(此处 no-op),走到这里就是没产出。
+    // silent-stop done:自动续跑会在 1.5s 后启动新 turn(或弹耗尽横幅),
+    // 不标 idle/不触发 goal idle/不通知 coordinator done——避免 renderer
+    // 在 500ms 完成去抖窗口内显示假完成通知,下一个 turn 开始后又跳回 running。
+    if (isContinuationBoundary) {
+      // A claimed done only closes the current SDK segment. It must not enter
+      // silent-stop recovery or settle the auto-resume attempt; the later
+      // unclaimed product terminal owns those side effects.
+    } else if (!isSilentStopDone) {
+      // 兜底: 有些 vendor 的 done 不必先发 status:isRunning=false。
+      // 但 idle 恢复不能挡在 EVENT broadcast 前，否则隐藏窗口可能在 done
+      // 还没进入 renderer 时就重新被 Chromium 节流。
+      deps.agentInputCoordinatorHolder?.onTurnEvent(session.id, 'done', undefined, undefined, {
+        sessionTurnGeneration: event.sessionTurnGeneration,
+        sessionInstanceId: event.sessionInstanceId,
+      });
+    } else {
+      // silent-stop 自动续跑:translator 判定本 turn 被上游空内容消息静默收尾时在
+      // done.data 附加 silentStop 标记(见 maker-core translator)。延迟一拍再决策,
+      // 让本次 turn-end 的落库/收口先走完,也给"用户恰好自己发了消息"留出让位窗口
+      //(守卫内部还有 doneAt 陈旧判定,双保险,绝不插队)。
+      // 回拨 in-turn 状态:translator 在 done 之前推了 status(isRunning=false),
+      // 那条事件已经把 tracker 标成 idle。恢复 in-turn 让 renderer 在 1.5s 决策
+      // 窗口内不触发 500ms 完成去抖的假通知。settleSilentStopDone / 新 turn 的
+      // noteTurnStarted 会再正确设置最终状态。
+      deps.sessionTurnActivityTracker.setSessionInTurn(session.id, true);
+      // 后台活动检测:silent-stop 决策窗内逻辑 turn 仍在继续,同步回拨。
+      noteClaudeSessionTurnState(session.id, true);
+      const silentStopDoneAt = Date.now();
+      const silentStopTurnOrigin = event.turnOrigin;
+      setTimeout(() => {
+        void deps.handleSilentStopTurnEnd(
+          session,
+          silentStopDoneAt,
+          silentStopTurnLeaseId!,
+          silentStopTurnOrigin,
+        );
+      }, 1_500);
+    }
+  }
+  // 提前声明在终止型 error 块与 done/terminal 边界块两处均需使用的持久化条件标志。
+  let isPlannedUpgradeClose = false;
+  let isRemoteAuthRetry = false;
+  let isGatewayProxyTokenRecovery = false;
+  if (isTerminalTurnErrorEvent(event)) {
+    finalizeTurnChangeSet(session.id, null, 'partial');
+    // **任何**终态失败都先把上一条重连记录钉成失败 —— 不管这次错误本身是否值得自愈。
+    // 只在"命中白名单、准备再接管"时才 settle 的话,非白名单的终态(认证 / 计费 /
+    // invalid-request)会让记录悬空,随后一个无关 turn 的首个产出事件就把它标成
+    // 「已重新连接」(codex P1)。
+    const failedAttemptToken = event.turnAttemptToken;
+    if (typeof failedAttemptToken === 'number') {
+      deps.autoResumeBookkeeping.settleOutcome(session.id, failedAttemptToken, 'failed');
+      deps.interruptedTurnAutoResumeGuard.noteAttemptSettled(session.id, failedAttemptToken);
+    }
+    // 终止型 error 可能没有后续 status/done（SDK/event loop crash 等），需要在
+    // EVENT broadcast 后结束逻辑 turn，并保留 terminal grace 给 renderer 收尾；
+    // 可重试 error 保持 running。
+    shouldMarkTurnTerminalIdleAfterBroadcast = true;
+    if (event.source === 'claude-code' || event.source === 'codex' || event.source === 'pi') {
+      deps.turnModelPromiseBySession.delete(session.id);
+      if (event.source === 'pi') deps.turnPiFastModeBySession.delete(session.id);
+    }
+    const errData =
+      attributedEvent.type === 'error'
+        ? (attributedEvent.data as
+            | {
+                message?: unknown;
+                reason?: unknown;
+                sdkError?: unknown;
+                errorStatus?: unknown;
+                toolLoop?: unknown;
+              }
+            | undefined)
+        : undefined;
+    // Terminal error details cross the coordinator/device-link boundary as untrusted data.
+    // Keep only the bounded tool-loop shape; never let a provider-controlled object become
+    // live projection state or renderer interpolation.
+    const toolLoop = parseAgentInputToolLoopDetails(errData?.toolLoop);
+    // 计划内 cc-mgr 升级窗口的 daemon 关闭(reason='remote_daemon_closed')是
+    // 预期噪音: renderer 事件路径按同语义静默 banner, 这里同样不给 coordinator
+    // 记 error —— 否则 paired-done 保留会让升级后的 projection 复现
+    // [REMOTE_DAEMON_CLOSED] banner。范围与 renderer 一致**按 session**(仅
+    // banner-clicker):同 host 其它会话的中断照真实失败浮现;窗口外的 daemon
+    // 死亡同样不受影响(保留 + 通知)。
+    isPlannedUpgradeClose =
+      errData?.reason === 'remote_daemon_closed' && isCcMgrUpgradeInFlight(session.id);
+    // Legacy CC/XD 远程 auth 错误跳过持久化：renderer 会静默 auto-retry（makerChatStore 在 reducer
+    // 前拦截、关闭旧会话、重发消息，不显示 ErrorBanner）；若 main 已落库，retry 成功后
+    // 重开会话会看到虚假错误卡。判定与 renderer 的 isAuthError 保持一致，覆盖
+    // sdkError === 'authentication_failed' 以及 message 命中 authentication_error /
+    // invalid api key / 401 的情形。本地会话（无 remoteHostId）无 auto-retry，不跳过。
+    isRemoteAuthRetry = deps.isRemoteAuthRetryErrorEvent(session, event);
+    isGatewayProxyTokenRecovery = deps.isGatewayProxyTokenRecoveryErrorEvent(session.id, event);
+    if (isPlannedUpgradeClose) {
+      deps.agentInputCoordinatorHolder?.noteSuppressedTerminalError(session.id, {
+        generation: event.sessionTurnGeneration,
+        reason: 'remote_daemon_closed',
+        instanceId: event.sessionInstanceId ?? session.instanceId,
+      });
+    } else {
+      deps.agentInputCoordinatorHolder?.onTurnEvent(
+        session.id,
+        'error',
+        typeof broadcastEvent.data === 'object' &&
+          broadcastEvent.data !== null &&
+          typeof (broadcastEvent.data as { message?: unknown }).message === 'string'
+          ? (broadcastEvent.data as { message: string }).message
+          : undefined,
+        // 结构化信号:自动续跑的判据靠它们收紧(见 isInterruptedTurnError),不靠文本猜。
+        {
+          ...(typeof errData?.sdkError === 'string' ? { sdkError: errData.sdkError } : {}),
+          ...(typeof errData?.reason === 'string' ? { reason: errData.reason } : {}),
+          ...(typeof errData?.errorStatus === 'number' ? { errorStatus: errData.errorStatus } : {}),
+          ...(toolLoop ? { toolLoop } : {}),
+        },
+        {
+          sessionTurnGeneration: event.sessionTurnGeneration,
+          sessionInstanceId: event.sessionInstanceId,
+        },
+      );
+    }
+  }
+  // F1-a Phase 2: assistant 文本持久化收口 main 单点(根除多窗各落一份的重复)。
+  // 在 onEvent 同步路径只做 O(1):为在飞 assistant 分配 / 复用 persistId、累积全文,
+  // 把 persistId 盖进广播 payload 让 renderer 在途气泡用同一 id;真正落库走模块内
+  // 异步队列、不在此同步执行(规则19 热路径)。终止型 error 同样在广播前预留 persistId
+  // (O(1) createId,不 flush、不写库),让 live 横幅与事后 error 行绑定同一 id。
+  const eventAgentMeta = (event as { agentMeta?: AgentMeta | null }).agentMeta ?? null;
+  // 跟踪会话最近一次非空 agentMeta(镜像 renderer state.lastAgentMeta),给 interaction
+  // 边界 flush 当兜底锚点,保 agent_meta 不丢(rewind/fork)。
+  if (eventAgentMeta && event.turnScope !== 'background') noteAgentMeta(session.id, eventAgentMeta);
+
+  // tool_result 家族:main 解析出的权威内容,盖进 payload 让 renderer 即时显示
+  // (Option C:内容重排状态机只在 main 一份,与落库同源同值)。
+
+  // 中断自愈的额度判据是「是否在推进」:模型产出了实质内容(文本 / 工具调用)就把
+  // 连续失败计数归零；人工介入周期的硬总上限不归零，保证始终有限。
+  // 刻意只认这两类事件:thinking / status / 空消息都不算产出;guard 侧是 O(1)、
+  // 无 IO、无日志,放在热路径安全。
+  // 晚到 background 事件仍需广播和持久化,但不能给当前中断回合充值。
+  if (event.turnScope !== 'background' && isSubstantiveProgressEvent(event)) {
+    const progressAttemptToken = event.turnAttemptToken;
+    const accepted = deps.interruptedTurnAutoResumeGuard.noteProgress(
+      session.id,
+      progressAttemptToken ?? undefined,
+    );
+    // 同一个信号也是「上一次重连真的成功了」的唯一证据；旧 attempt 的迟到事件
+    // token 不匹配时不会结算当前新 attempt。
+    if (accepted && typeof progressAttemptToken === 'number') {
+      deps.autoResumeBookkeeping.settleOutcome(session.id, progressAttemptToken, 'succeeded');
+    }
+  }
+  return {
+    event,
+    attributedEvent,
+    broadcastEvent,
+    eventAgentMeta,
+    pendingContextSnapshot,
+    pendingCodexAccountUsageSnapshot,
+    shouldMarkTurnStatusIdleAfterBroadcast,
+    shouldMarkTurnTerminalIdleAfterBroadcast,
+    completedTurnWallClockMs,
+    isContinuationBoundary,
+    isPlannedUpgradeClose,
+    isRemoteAuthRetry,
+    isGatewayProxyTokenRecovery,
+  };
+}
+
+export type PreparedSessionEvent = NonNullable<ReturnType<typeof prepareSessionEvent>>;

--- a/apps/desktop/src/main/maker-ipc/sessionEventSnapshots.ts
+++ b/apps/desktop/src/main/maker-ipc/sessionEventSnapshots.ts
@@ -1,0 +1,40 @@
+import type { Session } from '@cindy/maker-core';
+import { recordSessionContextSnapshot } from '../sessionSpendBroadcaster.js';
+import { recordCodexAccountUsageSnapshot } from '../usageBroadcaster.js';
+import { dbToMakerAgentKind } from '../../shared/agentKindConversion.js';
+import { lookupVerifiedContextWindow } from './contextOverflowRollover.js';
+import { getSessionProvider } from '../maker-host/session-provider-store.js';
+import { getActiveCatalog } from '../maker-host/active-catalog.js';
+import { resolveVerifiedContextWindow } from '../maker-host/catalog-to-descriptors.js';
+import type { PreparedSessionEvent } from './sessionEventPreparation.js';
+export function recordSessionEventSnapshots(session: Session, prepared: PreparedSessionEvent) {
+  const { pendingContextSnapshot, pendingCodexAccountUsageSnapshot } = prepared;
+  if (pendingContextSnapshot) {
+    const piRuntimeWindow =
+      session.agentKind === 'pi' &&
+      Number.isFinite(pendingContextSnapshot.contextWindow) &&
+      pendingContextSnapshot.contextWindow > 0
+        ? pendingContextSnapshot.contextWindow
+        : null;
+    const verifiedWindow = lookupVerifiedContextWindow(
+      (agentKind, modelId, providerId) =>
+        resolveVerifiedContextWindow(
+          getActiveCatalog(),
+          dbToMakerAgentKind(agentKind),
+          providerId,
+          modelId,
+        ),
+      session.model,
+      getSessionProvider(session.id),
+      session.agentKind,
+    );
+    recordSessionContextSnapshot(
+      session.id,
+      pendingContextSnapshot.contextTokens,
+      piRuntimeWindow ?? verifiedWindow ?? pendingContextSnapshot.contextWindow,
+    );
+  }
+  if (pendingCodexAccountUsageSnapshot) {
+    recordCodexAccountUsageSnapshot(pendingCodexAccountUsageSnapshot);
+  }
+}

--- a/apps/desktop/src/main/maker-ipc/sessionEventStream.ts
+++ b/apps/desktop/src/main/maker-ipc/sessionEventStream.ts
@@ -1,0 +1,138 @@
+import type { Session } from '@cindy/maker-core';
+import { persistSubagentTaskUpdate } from '../localDb/subagentRuns.js';
+import { broadcastSubagentRunsChanged } from '../localDb/ipc/subagentRuns.js';
+import {
+  captureSubagentObservationGeneration,
+  enqueueSubagentObservationWrite,
+} from '../subagentObservationRewindFence.js';
+
+import { createLogger } from '../logger.js';
+import {
+  enqueueDurableWrite,
+  flushAssistantBlock,
+  onAssistantTextEvent,
+  onAgentTaskUpdateEvent,
+  onThinkingEvent,
+  onToolResultEvent,
+  onToolResultFullEvent,
+  onToolUseEvent,
+} from '../messagePersistBroadcaster.js';
+import { type OrcaTeamService } from './orcaTeamService.js';
+import type { PreparedSessionEvent } from './sessionEventPreparation.js';
+export interface PersistSessionStreamEventDeps {
+  readonly orcaTeamServiceForEvents: Pick<OrcaTeamService, 'captureWorkerText'> | null;
+  readonly log: Pick<ReturnType<typeof createLogger>, 'warn'>;
+}
+
+export function persistSessionStreamEvent(
+  deps: PersistSessionStreamEventDeps,
+  session: Session,
+  prepared: PreparedSessionEvent,
+) {
+  const { event, eventAgentMeta } = prepared;
+  let persistId: string | undefined;
+  let resolvedContent: string | undefined;
+  if (event.type === 'text') {
+    const td = event.data as { text?: unknown; isFinal?: unknown } | null;
+    if (typeof td?.text === 'string') {
+      deps.orcaTeamServiceForEvents?.captureWorkerText(session.id, td.text, {
+        isFinal: td.isFinal === true,
+      });
+    }
+    persistId = onAssistantTextEvent(
+      session.id,
+      event.data as {
+        text?: unknown;
+        isFinal?: unknown;
+        isFullText?: unknown;
+        agentMessageId?: unknown;
+      },
+      eventAgentMeta,
+    );
+  } else if (event.type === 'tool_use') {
+    // tool_use 边界:先 flush 在飞 assistant(保证 assistant 行先于其 tool_use 入队
+    // 落库),再落 tool_use 本身,拿回 persistId 盖进 payload。两者都只入队、不阻塞。
+    if (event.turnScope !== 'background') flushAssistantBlock(session.id, eventAgentMeta);
+    persistId = onToolUseEvent(
+      session.id,
+      event.data as { toolUseId?: unknown; toolName?: unknown; input?: unknown },
+      eventAgentMeta,
+      event.turnScope === 'background' ? 'background' : 'turn',
+      event.backgroundTurnStartedAt,
+      event.turnAttemptToken,
+    );
+  } else if (event.type === 'tool_result') {
+    const r = onToolResultEvent(
+      session.id,
+      event.data as { summary?: unknown; toolUseIds?: unknown },
+      eventAgentMeta,
+      event.turnScope === 'background' ? 'background' : 'turn',
+    );
+    persistId = r?.persistId;
+    resolvedContent = r?.content;
+  } else if (event.type === 'tool_result_full') {
+    const r = onToolResultFullEvent(
+      session.id,
+      event.data as { toolUseId?: unknown; fullText?: unknown; isError?: unknown },
+      eventAgentMeta,
+      event.turnScope === 'background' ? 'background' : 'turn',
+    );
+    persistId = r?.persistId;
+    resolvedContent = r?.content;
+  } else if (event.type === 'thinking') {
+    // thinking final/redacted 落库收口 main;clientId=blockId(renderer 同源),无需
+    // persistId 回传。start/delta 不落库。
+    onThinkingEvent(
+      session.id,
+      event.data as {
+        stage?: unknown;
+        blockId?: unknown;
+        text?: unknown;
+        durationMs?: unknown;
+      },
+      eventAgentMeta,
+    );
+  }
+  if (event.type === 'agent_task_update') {
+    onAgentTaskUpdateEvent(session.id, event.data);
+    // Subagent workspace is an observer only: normalize the existing
+    // harness event into Cindy's durable record on the same FIFO as chat
+    // messages. No launch/control path or provider payload is modified.
+    const source =
+      event.source === 'claude-code' || event.source === 'codex' || event.source === 'pi'
+        ? event.source
+        : undefined;
+    const observedAt = Date.now();
+    const generationStamp = captureSubagentObservationGeneration({
+      sessionId: session.id,
+      data: event.data,
+      source,
+    });
+    if (generationStamp)
+      void enqueueSubagentObservationWrite({
+        sessionId: session.id,
+        stamp: generationStamp,
+        enqueue: () =>
+          enqueueDurableWrite(`subagent_update:${session.id}`, async (ownerScope) => {
+            const persisted = await persistSubagentTaskUpdate(
+              session.id,
+              event.data,
+              source,
+              observedAt,
+            );
+            if (persisted) {
+              broadcastSubagentRunsChanged({ sessionId: session.id, ...persisted }, ownerScope);
+            }
+            return persisted;
+          }),
+      }).catch((error) => {
+        deps.log.warn('Subagent workspace persistence failed', {
+          sessionId: session.id,
+          error: error instanceof Error ? error.message : String(error),
+        });
+      });
+  }
+  return { persistId, resolvedContent };
+}
+
+export type SessionStreamResult = ReturnType<typeof persistSessionStreamEvent>;

--- a/apps/desktop/src/main/maker-ipc/sessionEventTerminal.ts
+++ b/apps/desktop/src/main/maker-ipc/sessionEventTerminal.ts
@@ -1,0 +1,467 @@
+import type { AgentEvent, Session } from '@cindy/maker-core';
+
+// sidebar-card-mode: turn-done 后刷新列表预览,并按需生成置顶卡片摘要
+import {
+  maybeGenerateSessionTaskSummary,
+  refreshSessionListPreview,
+} from '../sessionTaskSummary.js';
+
+import { createLogger } from '../logger.js';
+import {
+  consumeLastAssistantPersistId,
+  consumeLastTopLevelAssistantPersistId,
+  drainPersistQueue,
+  flushAssistantBlock,
+  flushOrphanToolResults,
+  isSuccessfulCodexDoneEventData,
+  markAssistantTurnCompleted,
+  markAssistantTurnFailed,
+  clearCodexPlanRowsForSession,
+  persistCodexPlanOnDone,
+  persistCodexPlanOnTerminalError,
+  preserveTurnPersistStateForBackground,
+  onTurnErrorEvent,
+  releaseReservedTurnErrorPersistId,
+  reserveTurnErrorPersistId,
+  resetTurnPersistState,
+  saveTurnStartedAtForDeferred,
+} from '../messagePersistBroadcaster.js';
+import { AgentInputCoordinator } from './agent-input-coordinator.js';
+import { MAKER_PUSH } from './channels.js';
+import { type OrcaTeamService } from './orcaTeamService.js';
+import {
+  createContextOverflowRollover,
+  isContextOverflowErrorData,
+  isOversizedHistoryErrorData,
+} from './contextOverflowRollover.js';
+import { isTerminalTurnErrorEvent } from './sessionTurnActivityTracker.js';
+import { ProductTurnUsageTargetTracker } from './turnWallClock.js';
+import { createWorkerTurnStartSequencer } from './workerTurnStartSequencer.js';
+import { AutoResumeBookkeeping, shouldSkipOrcaWorkerTerminal } from './autoResumeBookkeeping.js';
+import { isSuccessfulAssistantReplyDoneData } from '../cindy-brain/assistantReplyHook.js';
+import { hasEnabledGhostAssistantHook, runGhostAssistantReplyHook } from '../cindy-brain/index.js';
+import { withGhostAssistantHookModel } from '../cindy-brain/subscriptionGateway.js';
+import type { PreparedSessionEvent } from './sessionEventPreparation.js';
+import type { SessionDeliveryResult } from './sessionEventDelivery.js';
+import { isSessionErrorSuppressed } from './sessionErrorSuppression.js';
+export interface FinishSessionTerminalEventDeps {
+  readonly pendingFailedTurnAssistantPersistId: Map<string, string>;
+  readonly autoResumeBookkeeping: Pick<
+    AutoResumeBookkeeping,
+    | 'noteFailedTurnCompletionTail'
+    | 'stashSuppressedError'
+    | 'stashOrcaSuppressedTerminal'
+    | 'discardReplacementProvenByProviderEvent'
+    | 'consumeFailedTurnCompletionTail'
+    | 'hasSuppressedError'
+  >;
+  readonly productTurnUsageTargetTracker: Pick<
+    ProductTurnUsageTargetTracker,
+    'remember' | 'finish'
+  >;
+  readonly agentInputCoordinatorHolder: Pick<
+    AgentInputCoordinator,
+    | 'getAutoResumeAttemptToken'
+    | 'getAutoResumeDeferredOwner'
+    | 'isAutoResumePending'
+    | 'isAutoResumeDeferred'
+  > | null;
+  readonly contextOverflowRolloverHolder: Pick<
+    ReturnType<typeof createContextOverflowRollover>,
+    'claim' | 'tryRecover'
+  > | null;
+  readonly overflowSuppressedBroadcasts: Map<
+    string,
+    { sessionId: string; event: AgentEvent; persistId?: string; resolvedContent?: unknown }
+  >;
+  readonly broadcastToAllWindows: (channel: string, payload: unknown) => void;
+  readonly handleAgentIslandEventAfterBroadcast: (
+    session: {
+      id: string;
+      agentKind?: unknown;
+      workDir?: unknown;
+      workspaceKind?: unknown;
+      remoteHostId?: unknown;
+    },
+    event: AgentEvent,
+  ) => void;
+  readonly log: Pick<ReturnType<typeof createLogger>, 'warn'>;
+  readonly markTurnEndedAfterPersistDrain: (sessionId: string) => void;
+  readonly turnModelPromiseBySession: Map<string, Promise<string>>;
+  readonly workerTurnStartSequencer: Pick<
+    ReturnType<typeof createWorkerTurnStartSequencer>,
+    'waitForStart'
+  >;
+  readonly orcaTeamServiceForEvents: Pick<OrcaTeamService, 'handleWorkerTerminalTurn'> | null;
+}
+
+export function finishSessionTerminalEvent(
+  deps: FinishSessionTerminalEventDeps,
+  session: Session,
+  prepared: PreparedSessionEvent,
+  delivery: SessionDeliveryResult,
+) {
+  const {
+    event,
+    attributedEvent,
+    eventAgentMeta,
+    isContinuationBoundary,
+    isPlannedUpgradeClose,
+    isRemoteAuthRetry,
+    isGatewayProxyTokenRecovery,
+  } = prepared;
+  const { persistId, workerTerminalCapture } = delivery;
+  // done / 终止型 error 持久化边界:把在飞 assistant 落库(与 text isFinal 互斥幂等)。
+  // tool_use 边界的 flush 已在上面 broadcast 前做(需先于 tool_use 落库);
+  // ask_user / plan_review / permission 不走 onEvent(走 interaction listener),
+  // 它们的 flush 在 setInteractionListener 里。
+  //
+  // 可重试 error 仍属于同一 turn，不能 reset lastAgentMeta / tool_result 配对状态；
+  // 否则未来出现 turn 中途的非终止型 error 时会打断后续 tool_result 关联。
+  // 本 turn 最后一条 assistant 的 persistId(挂 per-turn 费用 / turn 边界用)。terminal
+  // error 同样 consume，写失败 seal 后再按需交接给 paired done；纯 tool 轮为 undefined。
+  let turnAssistantPersistId: string | undefined;
+  let turnBoundaryAssistantPersistId: string | undefined;
+  let isPairedFailedTurnDone = false;
+  if (event.type === 'done' || isTerminalTurnErrorEvent(event)) {
+    flushAssistantBlock(session.id, eventAgentMeta);
+    turnAssistantPersistId = consumeLastAssistantPersistId(session.id);
+    turnBoundaryAssistantPersistId = consumeLastTopLevelAssistantPersistId(session.id);
+    if (isTerminalTurnErrorEvent(event) && event.type !== 'done') {
+      // 失败 turn: 记账发生在稍后的配对 done(usage 在那条事件上), 把这里
+      // consume 到的 persistId 交接过去(见 pendingFailedTurnAssistantPersistId)。
+      if (turnAssistantPersistId) {
+        deps.pendingFailedTurnAssistantPersistId.set(session.id, turnAssistantPersistId);
+      }
+      // persistId 只覆盖有 assistant 行的失败轮。零输出 / 纯 tool 轮没有 id，
+      // 用户接手还会 flush 掉 suppressed entry 并清 pending。这条 tail 活过
+      // flush，按失败轮 generation 配对；不同代的 done 不得当成这条尾巴。
+      if (!isContinuationBoundary && typeof event.sessionTurnGeneration === 'number') {
+        deps.autoResumeBookkeeping.noteFailedTurnCompletionTail(
+          session.id,
+          event.sessionTurnGeneration,
+        );
+      }
+    } else {
+      // done: 优先本事件 consume 的 id, 失败 turn 场景回收交接的 id;
+      // 无论用没用到都清掉, 防残留错配下一轮。
+      const pendingFailedPersistId = deps.pendingFailedTurnAssistantPersistId.get(session.id);
+      if (!turnAssistantPersistId && pendingFailedPersistId) {
+        turnAssistantPersistId = pendingFailedPersistId;
+        isPairedFailedTurnDone = true;
+      }
+      deps.pendingFailedTurnAssistantPersistId.delete(session.id);
+    }
+    if (event.type === 'done' && event.source === 'claude-code') {
+      if (isContinuationBoundary) {
+        deps.productTurnUsageTargetTracker.remember(session.id, turnAssistantPersistId);
+      } else {
+        turnAssistantPersistId = deps.productTurnUsageTargetTracker.finish(
+          session.id,
+          turnAssistantPersistId,
+        );
+      }
+    }
+    flushOrphanToolResults(session.id, eventAgentMeta);
+    if (turnBoundaryAssistantPersistId) {
+      // 在同一 durable FIFO 内先盖 turn seal、再复用 local-db:messages:created 广播
+      // 更新后的完整行。失败轮的 paired done 只复用 id 做 usage 记账，不能把
+      // terminal error 已写的 false seal 覆盖成 true、让施工播报重新进入标题素材。
+      // Codex 的 interrupted / failed 同样以 done 收尾；即使没有配套 error，也必须
+      // 写 false，避免历史计划兼容逻辑把用户主动停止的半截计划推成全部完成。
+      const isSuccessfulDone =
+        event.type === 'done' &&
+        (event.source !== 'codex' || isSuccessfulCodexDoneEventData(event.data));
+      if (!isSuccessfulDone) {
+        void markAssistantTurnFailed(session.id, turnBoundaryAssistantPersistId);
+      } else if (!isPairedFailedTurnDone) {
+        const nativeForkAnchor = eventAgentMeta?.nativeForkAnchor;
+        void markAssistantTurnCompleted(
+          session.id,
+          turnBoundaryAssistantPersistId,
+          nativeForkAnchor ? { nativeForkAnchor } : undefined,
+        );
+      }
+    }
+    // error 行在 flushOrphanToolResults 之后入队,保证 orphan tool_result 排在
+    // error 行之前(历史时间线:tool 输出 → 错误卡,而非错误卡插到 tool 输出之前)。
+    // 自愈接管中 → 压住 error 行:成功续跑时历史里只留一条「已自动继续」分隔条,
+    // 救不回来时由 AutoResumeBookkeeping.finalizeSuppressedError 补落。判据取 coordinator 的实时
+    // 接管态(而非 host 自己的 map):退避期间用户若自己发了消息,接管态已被清,那之后
+    // 新 turn 的失败必须照常落库。
+    //
+    // 还有一种时序:terminal error 早于用户气泡落库完成到达时,接管决策要推迟到
+    // settlePendingTerminalEventAfterPersist 才能做(recovery 留不留得住是前提)。那时
+    // error 行早就落库了、压不回去,接管成功后历史里会同时留下错误卡与重连行(codex P1)。
+    // 所以决策未定时也一并压住(isAutoResumeDeferred),由 coordinator 在三个「最终没接管」
+    // 的出口回调 onResumableTurnErrorDiscarded 让它补落。
+    const workerTerminalDoneData = event.data as {
+      result?: unknown;
+      message?: unknown;
+      sdkError?: unknown;
+      reason?: unknown;
+      error?: { message?: unknown };
+    } | null;
+    const workerTerminalFinalText =
+      typeof workerTerminalDoneData?.result === 'string' && workerTerminalDoneData.result.length > 0
+        ? workerTerminalDoneData.result
+        : '';
+    const workerTerminalDiagnostic = isTerminalTurnErrorEvent(event)
+      ? [
+          workerTerminalDoneData?.message,
+          workerTerminalDoneData?.sdkError,
+          workerTerminalDoneData?.reason,
+          workerTerminalDoneData?.error?.message,
+        ].find((value): value is string => typeof value === 'string' && value.trim().length > 0)
+      : undefined;
+    const autoResumeSuppressesPersist = isSessionErrorSuppressed(
+      deps.agentInputCoordinatorHolder,
+      session.id,
+      event,
+    );
+    // Only skip handleWorkerTerminalTurn after the Orca payload is actually
+    // hanging on the suppressed-error owner. stashOrca 失败必须立刻收口，
+    // 否则 worker 会永远停在 running。
+    let deferredOrcaWorkerTerminal = false;
+    const overflowClaim =
+      event.type === 'error' &&
+      !session.remoteHostId &&
+      isTerminalTurnErrorEvent(event) &&
+      !isPlannedUpgradeClose &&
+      !isRemoteAuthRetry &&
+      !isGatewayProxyTokenRecovery &&
+      !autoResumeSuppressesPersist &&
+      (isContextOverflowErrorData(attributedEvent.data) ||
+        isOversizedHistoryErrorData(attributedEvent.data))
+        ? (deps.contextOverflowRolloverHolder?.claim(session.id) ?? 'idle')
+        : 'idle';
+    if (overflowClaim === 'claimed') {
+      const overflowErrorData = attributedEvent.data;
+      const surfaceOverflowFailure = (): void => {
+        const overflowErrorPayload = overflowErrorData as {
+          message?: unknown;
+          reason?: unknown;
+          sdkError?: unknown;
+        } | null;
+        const overflowPersistId = reserveTurnErrorPersistId(
+          session.id,
+          overflowErrorPayload,
+          eventAgentMeta,
+        );
+        const stashed = deps.overflowSuppressedBroadcasts.get(session.id);
+        deps.overflowSuppressedBroadcasts.delete(session.id);
+        if (stashed) {
+          deps.broadcastToAllWindows(MAKER_PUSH.EVENT, {
+            ...stashed,
+            persistId: overflowPersistId ?? stashed.persistId,
+          });
+          deps.handleAgentIslandEventAfterBroadcast(session, stashed.event);
+        }
+        onTurnErrorEvent(session.id, overflowErrorPayload, eventAgentMeta, overflowPersistId);
+      };
+      void deps.contextOverflowRolloverHolder
+        ?.tryRecover(session.id, overflowErrorData)
+        .then((recovered) => {
+          if (recovered) {
+            deps.overflowSuppressedBroadcasts.delete(session.id);
+            return;
+          }
+          surfaceOverflowFailure();
+        })
+        .catch((error) => {
+          deps.log.warn('context overflow rollover rejected', {
+            sessionId: session.id,
+            error: error instanceof Error ? error.message : String(error),
+          });
+          surfaceOverflowFailure();
+        });
+    } else if (overflowClaim === 'in-flight') {
+      // 同一 turn 的重复终态 error：继续压住，避免污染历史。
+      if (persistId) releaseReservedTurnErrorPersistId(session.id, persistId);
+    } else if (
+      event.type === 'error' &&
+      !isPlannedUpgradeClose &&
+      !isRemoteAuthRetry &&
+      !isGatewayProxyTokenRecovery &&
+      !autoResumeSuppressesPersist
+    ) {
+      onTurnErrorEvent(
+        session.id,
+        attributedEvent.data as {
+          message?: unknown;
+          reason?: unknown;
+          sdkError?: unknown;
+        } | null,
+        eventAgentMeta,
+        persistId,
+      );
+    } else if (persistId) {
+      releaseReservedTurnErrorPersistId(session.id, persistId);
+    }
+    // 压住的错误详情必须在这里存一份:决策推迟场景下 onResumableTurnError 还没被调用过
+    // (它自己那份 set 发生在接管成立时),不存就无从补落。同 clientId 内容,覆盖无害。
+    if (autoResumeSuppressesPersist) {
+      deps.autoResumeBookkeeping.stashSuppressedError(
+        session.id,
+        attributedEvent.data,
+        deps.agentInputCoordinatorHolder?.getAutoResumeAttemptToken(session.id) ?? null,
+        deps.agentInputCoordinatorHolder?.getAutoResumeDeferredOwner(session.id) ?? null,
+      );
+      // Orca terminal 与 error 行共用同一条 owner：L2 不 bridge / 不标 error，
+      // L3 surface 时用这份 capture 恰好一次收口。
+      if (isTerminalTurnErrorEvent(event)) {
+        deferredOrcaWorkerTerminal = deps.autoResumeBookkeeping.stashOrcaSuppressedTerminal(
+          session.id,
+          {
+            status: 'error',
+            finalText: workerTerminalFinalText,
+            diagnostic: workerTerminalDiagnostic,
+            capture: workerTerminalCapture,
+          },
+        );
+      }
+    } else if (event.type === 'error' && isTerminalTurnErrorEvent(event)) {
+      // replacement 可在 sendToAgent 返回前同步失败并让 coordinator 的 activeTurn
+      // 失效；这个新终态已经取代旧中断，按 dispatch phase 直接清旧 owner。
+      deps.autoResumeBookkeeping.discardReplacementProvenByProviderEvent(session.id);
+    }
+    // deferred 路径保存 turn 开始时刻:isRemoteAuthRetry 时 onTurnErrorEvent 被跳过，
+    // renderer 会稍后调 persistTurnErrorDeferred IPC。在 resetTurnPersistState 清掉
+    // _turnStartedAtBySession 之前保存一份，让 deferred 路径能正确做 /clear 竞态 cap。
+    // 自愈压住 error 行时同理:补落发生在 resetTurnPersistState 之后(退避 3–20 秒,
+    // 或决策推迟的那一小段),不先存一份会让 /clear 竞态 cap 判错。
+    if (
+      event.type === 'error' &&
+      (isRemoteAuthRetry || isGatewayProxyTokenRecovery || autoResumeSuppressesPersist)
+    ) {
+      saveTurnStartedAtForDeferred(session.id);
+    }
+    // turn 收尾打标:本 turn 已知持久化(assistant flush / orphan tool_result /
+    // error 行)已全部入队,在此统一定格并等排空后写。done 与 terminal error
+    // 同一规则(planned upgrade close / remote auth retry 分支无 error 行,
+    // drain 同样无害)。
+    // A claim-bearing done seals this SDK segment, but the product turn is
+    // still running and may emit another continuation segment. Reset the
+    // per-SDK-turn persistence maps while deferring the logical turn marker.
+    // 没有 done 的终态 error(Codex 在 terminal error 后显式压掉迟到的
+    // turnCompleted,persistCodexPlanOnDone 永远不会跑到):本 turn 的计划行
+    // 既没有章也没有 turnCompleted:false,面板会把全勾完的失败计划当旧数据
+    // 兜底退场。在这里补失败印记——只盖 turn 存活标记,不动步骤状态。
+    if (
+      !isContinuationBoundary &&
+      event.source === 'codex' &&
+      event.type !== 'done' &&
+      isTerminalTurnErrorEvent(event)
+    ) {
+      const errorTurnId =
+        typeof (event.data as { raw?: { id?: unknown } } | null | undefined)?.raw?.id === 'string'
+          ? ((event.data as { raw?: { id?: unknown } }).raw!.id as string)
+          : null;
+      persistCodexPlanOnTerminalError(session.id, errorTurnId);
+    }
+    if (!isContinuationBoundary && event.source === 'codex' && event.type === 'done') {
+      // Renderer applies this terminal snapshot immediately. Persist the
+      // same state before sealing the persist queue and clearing the
+      // turn-owned lookup maps. The drain barrier below must include this
+      // write, otherwise app exit can still leave an in-progress plan.
+      persistCodexPlanOnDone(
+        session.id,
+        event.data as
+          { plan?: unknown; raw?: { id?: unknown; status?: unknown } } | null | undefined,
+      );
+    }
+    if (!isContinuationBoundary) {
+      deps.markTurnEndedAfterPersistDrain(session.id);
+      // 逻辑 turn 结束:跨段存活的计划行引用到此回收(continuation boundary
+      // 上必须保留,否则最终 done 找不到计划行 → 无章无失败印记 → 胶囊永久
+      // 钉住,review P1-1)。
+      clearCodexPlanRowsForSession(session.id);
+    }
+    preserveTurnPersistStateForBackground(session.id);
+    resetTurnPersistState(session.id);
+    // sidebar-card-mode: 摘要触发挪到本轮 assistant 块 flush 入队之后(原先在
+    // done 早段、flush 之前触发,流式轮次会读到上一轮文本)。只在正常 done 触发。
+    // codex review:flushAssistantBlock 仅把 assistant insert 入队 writeChain、未落库,
+    // latestMessageText 立刻读库可能读到本轮 assistant 写入之前的旧状态;先 await
+    // drainPersistQueue() 等持久化队列排空,确立"读在写后"的边界,再起摘要。
+    if (event.type === 'done' && !isContinuationBoundary) {
+      void (async () => {
+        await drainPersistQueue();
+        // 列表预览与置顶卡片摘要解耦:无论置顶区是不是卡片、这条有没有置顶,
+        // 都要把最近一条可见消息立刻写回 session.preview。摘要生成失败也不能
+        // 让侧栏停在进入本轮前的旧句子。
+        await refreshSessionListPreview(session.id);
+        // force:turn-done 是权威刷新点(本轮 assistant 已落库),必须以最新内容覆盖
+        // 任何 pin 触发 / 上一轮残留的摘要——绕过 in-flight 早返与 20s 节流
+        // (codex review:pin during running turn 会让卡片停在部分/旧摘要)。
+        await maybeGenerateSessionTaskSummary(session.id, { force: true });
+      })();
+    }
+    // will-assistant-message 出口钩子(先定案 → 一拍后替换):仅 done(非终止
+    // error)、有真实回复文本 + 已落库的 assistant persistId + 有启用的出口钩子
+    // 意识时,派一个独立异步续跑跑裁决并原地更新那条消息(rewrite 换文本 /
+    // render 换自绘卡)。同步守卫 hasEnabledGhostAssistantHook 保证无此类意识时
+    // 不 schedule —— 与今天行为逐字节一致,零额外开销(规则 10 不碰热路径)。
+    if (
+      event.type === 'done' &&
+      !isContinuationBoundary &&
+      !isPairedFailedTurnDone &&
+      !isTerminalTurnErrorEvent(event) &&
+      isSuccessfulAssistantReplyDoneData(event.data) &&
+      turnAssistantPersistId
+    ) {
+      const doneResult = (event.data as { result?: unknown } | null)?.result;
+      const replyText = typeof doneResult === 'string' ? doneResult : '';
+      if (replyText.length > 0 && hasEnabledGhostAssistantHook()) {
+        const turnModel =
+          deps.turnModelPromiseBySession.get(session.id) ??
+          Promise.resolve(session.model || 'unknown');
+        const assistantPersistId = turnAssistantPersistId;
+        withGhostAssistantHookModel(turnModel, () => {
+          runGhostAssistantReplyHook(session.id, assistantPersistId, replyText);
+        });
+      }
+    }
+    // Worker turn 结束后交给 OrcaTeamService 处理 DB status、广播与 auto-bridge。
+    // L2（auto-resume 仍拥有这次失败）不得在这里收口：否则 Lead 会先收到「异常终止」，
+    // 而聊天里还在显示自动重试。Codex/Claude 失败轮随后的 unclaimed done 同样不是
+    // 产品终态。L3 由 AutoResumeBookkeeping 的 surface 路径补调。
+    const isFailedTurnCompletionTail =
+      event.type === 'done' &&
+      !isContinuationBoundary &&
+      deps.autoResumeBookkeeping.consumeFailedTurnCompletionTail(
+        session.id,
+        event.sessionTurnGeneration,
+      );
+    if (
+      !shouldSkipOrcaWorkerTerminal({
+        isContinuationBoundary,
+        stashedThisErrorEvent: deferredOrcaWorkerTerminal,
+        eventType: event.type,
+        isPairedFailedTurnDone,
+        isFailedTurnCompletionTail,
+        hasSuppressedError: deps.autoResumeBookkeeping.hasSuppressedError(session.id),
+        isAutoResumePending:
+          deps.agentInputCoordinatorHolder?.isAutoResumePending(session.id) === true,
+        isAutoResumeDeferred:
+          deps.agentInputCoordinatorHolder?.isAutoResumeDeferred(session.id) === true,
+      })
+    ) {
+      void (async () => {
+        try {
+          await deps.workerTurnStartSequencer.waitForStart(session.id);
+          await deps.orcaTeamServiceForEvents?.handleWorkerTerminalTurn({
+            sessionId: session.id,
+            status: isTerminalTurnErrorEvent(event) ? 'error' : 'done',
+            finalText: workerTerminalFinalText,
+            diagnostic: workerTerminalDiagnostic,
+            capture: workerTerminalCapture,
+          });
+        } catch {
+          /* non-fatal */
+        }
+      })();
+    }
+  }
+  return { turnAssistantPersistId };
+}

--- a/apps/desktop/src/main/maker-ipc/sessionPiTurnUsage.ts
+++ b/apps/desktop/src/main/maker-ipc/sessionPiTurnUsage.ts
@@ -1,0 +1,325 @@
+import type { AgentEvent, Session } from '@cindy/maker-core';
+
+import { buildTurnUsageDetails } from '../../shared/turnUsageDetails.js';
+import { recordSessionTurnSpend, recordSessionTurnTokens } from '../sessionSpendBroadcaster.js';
+import {
+  piUsageToTokens,
+  recordSchedulerTurnCost,
+  recordTurnUsageOnMessage,
+} from '../turnCostBroadcaster.js';
+import { triggerClaudeAccountUsageRefresh } from '../usage/claudeAccountUsage.js';
+import { getGatewayModelPricingForModel } from '../usage/modelPricing.js';
+import { getReferenceModelPricing } from '../usage/referenceModelPricing.js';
+import {
+  getSubscriptionValuePriceFor,
+  piSubscriptionUsageModelKey,
+} from '../usage/usageHistory.js';
+import {
+  computePriceQuoteTurnMoney,
+  normalizeTurnUsageSegments,
+  normalizeModelIdForPricing,
+  resolveTurnCost,
+  sumTurnUsageSegments,
+  type BillingRoute,
+} from '../usage/turnCostCalculator.js';
+import {
+  CHATGPT_MODEL_PREFIX,
+  XAI_MODEL_PREFIX,
+  isSubscriptionDirectRoute,
+} from '../../shared/subscriptionModels.js';
+import { addRegionalMoney, type RegionalMoney } from '../../shared/regionalMoney.js';
+import { currentLedgerCurrency } from '../usage/ledgerCurrency.js';
+import { CURRENT_CINDY_REGION } from '../../shared/brandRegion.js';
+import {
+  triggerClaudeSubscriptionUsageRefresh,
+  triggerCodexAccountUsageRefresh,
+  triggerXaiSubscriptionUsageRefresh,
+} from './usage.js';
+import {
+  rebroadcastTodaySpend,
+  recordModelTurnUsage,
+  recordTurnSpend,
+} from '../usageBroadcaster.js';
+import { broadcastSchedulerChanged } from './schedule.js';
+import { getSessionProvider } from '../maker-host/session-provider-store.js';
+import { isUserProviderSession } from '../maker-host/provider-route.js';
+import { getSessionFastMode } from '../maker-host/session-effort-store.js';
+
+export interface RecordSessionPiTurnUsageDeps {
+  readonly turnPiFastModeBySession: Map<string, boolean>;
+  readonly turnModelPromiseBySession: Map<string, Promise<string>>;
+  readonly readSessionModelForUsage: (sessionId: string) => Promise<string>;
+  readonly unpricedSubscriptionValueMarker: () => RegionalMoney;
+}
+
+export function recordSessionPiTurnUsage(
+  deps: RecordSessionPiTurnUsageDeps,
+  session: Session,
+  event: AgentEvent,
+  turnAssistantPersistId: string | undefined,
+) {
+  // Pi done 事件同样携带 per-turn token/cache 明细。Pi 复用 Cindy 的 provider
+  // 路由，因此计费形态必须看 session provider，而不是把它当成一个新的计费方：
+  //   openai / anthropic / xai → 用户订阅，显示剩余窗口 + 本对话价值；
+  //   xd / 默认网关            → 实际 gateway cost。
+  // usage 事实无论价格是否可解析都持久化，保证新模型也能看到 cache 命中明细。
+  if (event.type === 'done' && event.source === 'pi') {
+    const sessionProvider = getSessionProvider(session.id);
+    // New Pi payloads carry the tariff on every request segment. Keep the
+    // turn-start snapshot only as a compatibility fallback for older or
+    // incomplete payloads that have no explicit priceVariant.
+    const piPriceVariant =
+      (deps.turnPiFastModeBySession.get(session.id) ?? getSessionFastMode(session.id))
+        ? 'priority'
+        : 'standard';
+    deps.turnPiFastModeBySession.delete(session.id);
+    const modelPromise =
+      deps.turnModelPromiseBySession.get(session.id) ?? deps.readSessionModelForUsage(session.id);
+    deps.turnModelPromiseBySession.delete(session.id);
+    const rawUsage = (event.data as { usage?: unknown } | undefined)?.usage;
+    if (rawUsage && typeof rawUsage === 'object') {
+      const tokens = piUsageToTokens(
+        rawUsage as {
+          inputTokens?: number;
+          outputTokens?: number;
+          cacheReadTokens?: number;
+          cacheCreationTokens?: number;
+        },
+      );
+      const piUsageSegments = normalizeTurnUsageSegments(
+        (rawUsage as { segments?: unknown }).segments,
+      ).map((segment) => ({
+        ...segment,
+        // Parent requests use this session's bridge preference. Delegated
+        // child requests have an independent process and are standard
+        // unless their own payload explicitly reports another variant.
+        priceVariant:
+          segment.priceVariant ?? (segment.id?.startsWith('pi:') ? piPriceVariant : 'standard'),
+      }));
+      const piSegmentTotals = sumTurnUsageSegments(piUsageSegments);
+      const piSegmentsReliable =
+        (rawUsage as { segmentsComplete?: unknown }).segmentsComplete === true &&
+        piUsageSegments.length > 0 &&
+        piSegmentTotals.inputTokens === tokens.inputTokens &&
+        piSegmentTotals.outputTokens === tokens.outputTokens &&
+        piSegmentTotals.cacheReadTokens === tokens.cacheReadTokens &&
+        piSegmentTotals.cacheCreateTokens === tokens.cacheCreateTokens;
+      const totalTokens =
+        tokens.inputTokens +
+        tokens.outputTokens +
+        tokens.cacheReadTokens +
+        tokens.cacheCreateTokens;
+      void recordSessionTurnTokens(session.id, totalTokens);
+      void (async () => {
+        let turnModel = 'unknown';
+        try {
+          turnModel = await modelPromise;
+        } catch {
+          // 模型读取失败仍持久化 token/cache，模型显示为 unknown。
+        }
+        const pricingModel = normalizeModelIdForPricing(turnModel);
+        const isCustomProviderRoute = isUserProviderSession(session.id);
+        const effectiveProvider =
+          sessionProvider ??
+          (pricingModel.startsWith(CHATGPT_MODEL_PREFIX)
+            ? 'openai'
+            : pricingModel.startsWith(XAI_MODEL_PREFIX)
+              ? 'xai'
+              : null);
+        const isSubscriptionValue =
+          effectiveProvider === 'openai' ||
+          effectiveProvider === 'anthropic' ||
+          effectiveProvider === 'xai' ||
+          (!isCustomProviderRoute && isSubscriptionDirectRoute(pricingModel));
+        const billingRoute: BillingRoute = isCustomProviderRoute
+          ? 'provider-api'
+          : isSubscriptionValue
+            ? 'subscription'
+            : 'xd-gateway';
+        const effectiveSegments = piSegmentsReliable ? piUsageSegments : [];
+        const groupedSegments = new Map<
+          string,
+          { segments: typeof effectiveSegments; tokens: typeof tokens; sdkCostUsd: number }
+        >();
+        for (const segment of effectiveSegments) {
+          const model = normalizeModelIdForPricing(segment.model ?? turnModel);
+          const group = groupedSegments.get(model) ?? {
+            segments: [],
+            tokens: {
+              inputTokens: 0,
+              outputTokens: 0,
+              cacheReadTokens: 0,
+              cacheCreateTokens: 0,
+            },
+            sdkCostUsd: 0,
+          };
+          group.segments.push(segment);
+          group.tokens.inputTokens += segment.inputTokens;
+          group.tokens.outputTokens += segment.outputTokens;
+          group.tokens.cacheReadTokens += segment.cacheReadTokens;
+          group.tokens.cacheCreateTokens += segment.cacheCreateTokens;
+          group.sdkCostUsd += segment.costUsd ?? 0;
+          groupedSegments.set(model, group);
+        }
+        // An explicitly incomplete segment payload must not be collapsed
+        // into one synthetic request for pricing. Keep the aggregate token
+        // fact under the selected model while leaving money unavailable.
+        if (groupedSegments.size === 0) {
+          groupedSegments.set(pricingModel, { segments: [], tokens, sdkCostUsd: 0 });
+        }
+
+        const durationMs =
+          typeof (rawUsage as { durationMs?: unknown }).durationMs === 'number'
+            ? (rawUsage as { durationMs: number }).durationMs
+            : undefined;
+        const turnDurationMs =
+          typeof (rawUsage as { turnDurationMs?: unknown }).turnDurationMs === 'number'
+            ? (rawUsage as { turnDurationMs: number }).turnDurationMs
+            : undefined;
+        const usageOnlyDetails = buildTurnUsageDetails({
+          ...tokens,
+          model: groupedSegments.size === 1 ? [...groupedSegments.keys()][0] : undefined,
+          models: [...groupedSegments.keys()],
+          durationMs,
+          turnDurationMs,
+        });
+
+        try {
+          const pricing =
+            billingRoute === 'xd-gateway'
+              ? await getGatewayModelPricingForModel()
+              : getReferenceModelPricing();
+          const actualMonies: RegionalMoney[] = [];
+          const estimatedMonies: RegionalMoney[] = [];
+          const perModelCost: Array<{ model: string; money: RegionalMoney }> = [];
+          const modelWrites: Promise<unknown>[] = [];
+          for (const [model, group] of groupedSegments) {
+            // Missing/incomplete request boundaries are explicitly unpriceable. A provider-
+            // reported request cost may still win in resolveTurnCost; token × quote must not
+            // collapse the whole turn into one synthetic long-context request.
+            const pricingSegments = piSegmentsReliable ? group.segments : [];
+            let money: RegionalMoney | null = null;
+            if (billingRoute === 'subscription') {
+              const quote = getSubscriptionValuePriceFor('pi', model, pricing);
+              money = computePriceQuoteTurnMoney(
+                group.tokens,
+                quote ?? undefined,
+                currentLedgerCurrency(),
+                pricingSegments,
+              );
+            } else {
+              money = resolveTurnCost({
+                rawModel: model,
+                tokens: group.tokens,
+                // Pi computes usage.cost from its local model catalog. For
+                // BYOM/provider-api routes that is a reference estimate,
+                // not a provider invoice. Let the provider quote path mark
+                // it as value-estimate instead of recording it as actual.
+                sdkCostDelta: billingRoute === 'provider-api' ? undefined : group.sdkCostUsd,
+                pricing,
+                context: {
+                  providerId: sessionProvider,
+                  billingRoute,
+                  region: CURRENT_CINDY_REGION,
+                },
+                segments: pricingSegments,
+              }).money;
+            }
+            if (money?.amount) {
+              perModelCost.push({ model, money });
+              (money.kind === 'actual-cost' ? actualMonies : estimatedMonies).push(money);
+            }
+            const modelUsageKey = isSubscriptionValue ? piSubscriptionUsageModelKey(model) : model;
+            const modelRowMoney =
+              money?.kind === 'actual-cost'
+                ? money
+                : isSubscriptionValue
+                  ? (money ?? deps.unpricedSubscriptionValueMarker())
+                  : null;
+            modelWrites.push(
+              recordModelTurnUsage({
+                agentKind: 'pi',
+                model: modelUsageKey,
+                // daily_model_usage has no money-kind column. Subscription
+                // rows recover value-estimate from their suffix; other
+                // reference estimates must stay message-only or they would
+                // be reconstructed later as actual spend.
+                money: modelRowMoney,
+                inputTokensDelta: group.tokens.inputTokens,
+                outputTokensDelta: group.tokens.outputTokens,
+                cacheReadTokensDelta: group.tokens.cacheReadTokens,
+                cacheCreateTokensDelta: group.tokens.cacheCreateTokens,
+              }),
+            );
+          }
+          await Promise.allSettled(modelWrites);
+          void rebroadcastTodaySpend();
+          const actualMoney = actualMonies.length > 0 ? addRegionalMoney(actualMonies) : null;
+          const estimatedMoney =
+            estimatedMonies.length > 0 ? addRegionalMoney(estimatedMonies) : null;
+          const messageMoney = actualMoney ?? estimatedMoney;
+          const turnUsageDetails = buildTurnUsageDetails({
+            ...tokens,
+            model: groupedSegments.size === 1 ? [...groupedSegments.keys()][0] : undefined,
+            models: [...groupedSegments.keys()],
+            perModelCost,
+            durationMs,
+            turnDurationMs,
+          });
+          if (actualMoney) {
+            void recordTurnSpend(actualMoney);
+            void recordSessionTurnSpend(session.id, actualMoney);
+          }
+          if (messageMoney) {
+            const changedScheduleId = await recordSchedulerTurnCost({
+              sessionId: session.id,
+              clientId: turnAssistantPersistId,
+              money: messageMoney,
+              turnUsageDetails,
+              turnOrigin: event.turnOrigin,
+            });
+            if (changedScheduleId) broadcastSchedulerChanged(changedScheduleId);
+          } else if (turnAssistantPersistId && turnUsageDetails) {
+            await recordTurnUsageOnMessage({
+              sessionId: session.id,
+              clientId: turnAssistantPersistId,
+              turnUsageDetails,
+            });
+          }
+        } catch {
+          // Price/catalog failure must not lose token/cache facts.
+          const writes = [...groupedSegments].map(([model, group]) =>
+            recordModelTurnUsage({
+              agentKind: 'pi',
+              model: isSubscriptionValue ? piSubscriptionUsageModelKey(model) : model,
+              money: isSubscriptionValue ? deps.unpricedSubscriptionValueMarker() : undefined,
+              inputTokensDelta: group.tokens.inputTokens,
+              outputTokensDelta: group.tokens.outputTokens,
+              cacheReadTokensDelta: group.tokens.cacheReadTokens,
+              cacheCreateTokensDelta: group.tokens.cacheCreateTokens,
+            }),
+          );
+          await Promise.allSettled(writes);
+          void rebroadcastTodaySpend();
+          if (turnAssistantPersistId && usageOnlyDetails) {
+            await recordTurnUsageOnMessage({
+              sessionId: session.id,
+              clientId: turnAssistantPersistId,
+              turnUsageDetails: usageOnlyDetails,
+            });
+          }
+        }
+
+        if (effectiveProvider === 'openai') {
+          triggerCodexAccountUsageRefresh();
+        } else if (effectiveProvider === 'anthropic') {
+          triggerClaudeSubscriptionUsageRefresh();
+        } else if (effectiveProvider === 'xai') {
+          triggerXaiSubscriptionUsageRefresh();
+        } else if (effectiveProvider === 'xd' || effectiveProvider == null) {
+          void triggerClaudeAccountUsageRefresh();
+        }
+      })();
+    }
+  }
+}

--- a/apps/desktop/src/main/maker-ipc/sessionTurnObserver.ts
+++ b/apps/desktop/src/main/maker-ipc/sessionTurnObserver.ts
@@ -1,0 +1,91 @@
+import type { Session } from '@cindy/maker-core';
+import { createLogger } from '../logger.js';
+import { throwIpcError } from '../utils/ipcValidate.js';
+import { getSessionProvider } from '../maker-host/session-provider-store.js';
+import { verdictForModelRoute } from '../maker-host/model-route-guard-live.js';
+import { SilentStopTurnLeaseGate, SessionTurnLeaseTracker } from './sessionTurnLease.js';
+
+export interface InstallSessionTurnObserverDeps {
+  readonly silentStopTurnLeaseGate: Pick<
+    SilentStopTurnLeaseGate,
+    'supersede' | 'schedule' | 'supersedeOwnedBy'
+  >;
+  readonly sessionTurnLeaseTracker: Pick<
+    SessionTurnLeaseTracker,
+    'markTurnStarted' | 'markTurnEnded'
+  >;
+  readonly providerTurnLeaseId: (sessionInstanceId: string, turnGeneration: number) => string;
+  readonly log: Pick<ReturnType<typeof createLogger>, 'debug'>;
+}
+
+export function installSessionTurnObserver(deps: InstallSessionTurnObserverDeps, session: Session) {
+  session.setTurnLifecycleObserver({
+    beforeProviderStart: async (turnGeneration) => {
+      if (session.remoteHostId) return;
+      // 每条本地 Session.send 都经过这一个 Main-owned 边界，包括 renderer、IM、
+      // Goal、Learn、Hook 与 Scheduler。付费权限不能只挂在普通 IPC 发送事务上。
+      const model = session.model;
+      if (model) {
+        const verdict = await verdictForModelRoute(
+          session.agentKind,
+          model,
+          getSessionProvider(session.id),
+        );
+        // beforeProviderStart 已经进入 Session 内部，无法再安全重建跨凭证形态的
+        // runtime。付费 reroute 不能当作 pass，否则 null-provider 仍会落到已锁定
+        // 的 XD 默认来源。普通停用/能力/独占 reroute 属于既有 best-effort 轴，
+        // 运行中会话按 model-route-guard 契约不在这里打断。
+        if (verdict.kind === 'reroute' && verdict.reason === 'payment-required') {
+          throwIpcError(
+            'INVALID_PARAMS',
+            `model "${model}" must switch to provider "${verdict.providerId}" before sending`,
+          );
+        }
+        if (verdict.kind === 'reject' && verdict.reason === 'payment-required') {
+          throwIpcError('PERMISSION_DENIED', `model "${model}" requires paid access`);
+        }
+      }
+      deps.silentStopTurnLeaseGate.supersede(session.id);
+      // Keep Review's exact-instance liveness listener lazy. PID-only turn
+      // leases remain fail-closed until this process actually starts Review.
+      await deps.sessionTurnLeaseTracker.markTurnStarted(
+        session.id,
+        deps.providerTurnLeaseId(session.instanceId, turnGeneration),
+      );
+    },
+    onUndispatched: async (turnGeneration) => {
+      if (session.remoteHostId) return;
+      await deps.sessionTurnLeaseTracker.markTurnEnded(
+        session.id,
+        deps.providerTurnLeaseId(session.instanceId, turnGeneration),
+      );
+    },
+    onTerminal: ({ turnGeneration, event, isCurrentGeneration }) => {
+      if (session.remoteHostId) return;
+      const turnLeaseId = deps.providerTurnLeaseId(session.instanceId, turnGeneration);
+      const isSilentStop =
+        event.type === 'done' &&
+        (event.data as { silentStop?: unknown } | null | undefined)?.silentStop === true;
+      if (isSilentStop && isCurrentGeneration) {
+        // The provider turn ended, but the product turn remains occupied while
+        // the bounded auto-resume decision runs. Its exact lease is either
+        // replaced by the next provider generation or released by settle.
+        const scheduled = deps.silentStopTurnLeaseGate.schedule(session.id, event, turnLeaseId);
+        if (!scheduled) {
+          deps.log.debug('ignored duplicate silent-stop terminal for the current turn', {
+            sessionId: session.id,
+            turnLeaseId,
+          });
+        }
+        return;
+      }
+      if (isCurrentGeneration) deps.silentStopTurnLeaseGate.supersede(session.id);
+      void deps.sessionTurnLeaseTracker.markTurnEnded(session.id, turnLeaseId);
+    },
+  });
+  return () => {
+    session.setTurnLifecycleObserver(null);
+    deps.silentStopTurnLeaseGate.supersedeOwnedBy(session.id, `${session.instanceId}:`);
+    void deps.sessionTurnLeaseTracker.markTurnEnded(session.id);
+  };
+}


### PR DESCRIPTION
## 这次改了什么

### 摘要

任务实例替换、关闭、事件广播和用量结算原来集中在约 1.85 万行的 `register.ts`，关键时序难以独立执行测试。本次按现有边界抽出绑定生命周期和同步事件流水线，`register.ts` 减少约 2,000 行，并用可控的异步行为测试保护旧实例迟到、关闭与发送交错等场景。

### 变更类型

- [x] `refactor` / `perf` 重构或性能优化
- [x] `docs` / `test` / `chore` 文档、测试或工程维护

### 范围

- 关联 Issue / 需求：任务生命周期拆分与竞态回归覆盖。
- 本 PR 包含：绑定/解绑与关闭收口、provider 启动观察器、事件准备/流式持久化/广播/终态收口/快照，以及 Claude、Codex、Pi 用量结算模块；移除原文件的 6 个未使用声明。
- 明确不包含：新的锁、重试或恢复状态机；数据库 migration、协议、权限规则和 UI 变化。
- 用户可见变化：预期无；保持实例隔离、轮次边界与恢复语义。
- 是否存在 breaking change：无。

### UI 变化

不涉及。

- 引用的设计规范：不涉及。

## 怎么验证的

### 自动验证

- `pnpm test:unit`（经本地统一门禁脚本执行）：通过，28 个工作区通过；根测试 502 通过、1 跳过。
- `pnpm test:unit:related`：通过。
- `pnpm --filter desktop run typecheck`：通过。
- `pnpm test:guard`：通过。
- `pnpm --filter desktop exec vitest run src/main/localDb/__tests__/sessionActiveTurn.test.ts`：24 个真实 SQLite 边界用例通过，覆盖保序、关闭与落库交错、owner 隔离。
- 在 desktop 包内对本次全部改动文件执行 ESLint：通过。
- 新增 56 个生命周期/事件流水线用例：包含真实 Session 和输入队列的关闭/重建交错、旧实例回调迟到、清理失败、续跑跨段时长与消息归属、失败后配对 done、可重试错误、远端认证恢复标记、Orca 终态等待、延迟记账、上下文窗口优先级和三引擎计价分支。
- 原有源码接线断言迁移到所属模块；跨阶段时序改为执行真实流水线。全量测试曾发现模块导入顺序导致的循环依赖初始化失败，已修复，恢复模块加载回归和隔离启动均通过。

### 手工验证

macOS arm64、Global、按 worktree 隔离且调度被动的 Desktop 成功构建和启动。启动返回 `DESKTOP_DEV_VERDICT=ready`，`pnpm desktop:whoami --all` 返回 `Desktop source: MATCH`；实际 main 页面加载完成，preload 和 Maker IPC 可用。

Fable 5.1 已在 Orca 协同中完成两轮独立复核，逐段对照原实现并核对规范化后的 token diff，未发现阻断提交的问题或 P0/P1。首轮提出的整理建议与覆盖缺口已处理，第二轮独立补跑 8 个相关测试文件、206 个用例全部通过。

### 未执行的验证

隔离 profile 尚未登录，真实模型收发/停止/关闭后恢复尚未验证。未在 Windows GUI、真实 SSH 主机或配对手机上运行完整链路；这些边界已有自动化覆盖，不能等同于端到端实测。Windows 单测以本 PR 的 CI 结果为准。

## 风险

### 风险分类

- [x] 其他：高频异步生命周期与记账接线重构。

### 影响与回滚

- 影响范围：Desktop 本地和远端任务事件消费。状态仍属于原来的 Session 实例/轮次与服务，未新增跨路径状态。服务 holder 使用 getter，保留 await 前后的实时读取语义。
- 保留的不变量：旧实例解绑；关闭前捕获直接中止/恢复归属；同步 EVENT 先于 idle/结算；消息写入先于 drain/reset；成功与失败 seal 不互相覆盖；续跑计时与费用归属不跨轮；provider 启动前执行付费权限校验；渲染器不暴露内部实例/轮次标记。
- 回滚 / 降级方式：回退本 PR 的代码提交即可，不涉及数据格式迁移。

### 提交前检查

- [x] 已 review 完整 diff
- [x] 每个 commit 都带 DCO 签名（`git commit -s`）
- [x] UI 改动已在「UI 变化」注明引用的设计规范章节（不涉及 UI）
- [x] 未提交凭证、令牌或授权文件
- [x] 已补充必要文档（模块边界与时序注释）
- [x] 已确认测试结果或说明未执行原因
