### PR TITLE
fix(device-link): 修复设备状态未知时订阅恢复停止

### DIFF
--- a/apps/desktop/src/main/__tests__/deviceLinkVoiceCredentialBootstrap.test.ts
+++ b/apps/desktop/src/main/__tests__/deviceLinkVoiceCredentialBootstrap.test.ts
@@ -44,15 +44,18 @@ describe('mobile voice credential sync desktop bootstrap path', () => {
 
     expect(deviceLinkHost).toContain('const available = snap.online && snap.remoteControlEnabled;');
     // `!== true` 而非 `=== false`:断线时 availability 视图整体清空,重连后首帧
-    // presence(wasAvailable=undefined)同样必须触发重放——它是 DEVICE_OFFLINE
-    // 永久放弃后的唯一恢复事件(#1520 review P1)。
+    // presence(wasAvailable=undefined)同样必须触发重放,接续 DEVICE_OFFLINE
+    // 结束的恢复轮次(#1520 review P1)。
     expect(deviceLinkHost).toContain('if (available && wasAvailable !== true)');
     expect(deviceLinkHost).toContain('replayActiveSubscriptions(`presence-online:${snap.deviceId.slice(0, 8)}`, snap.deviceId);');
     expect(deviceLinkHost).toContain('createSubscriptionReplayScheduler({');
     // Preserve unknown after reconnect; only explicit unavailability stops retries.
     expect(deviceLinkHost).toContain(
-      'getPresenceAvailability: (deviceId) => presenceAvailableByDevice.get(deviceId),',
+      'getPresenceAvailability: (deviceId) => presenceAvailableByDevice.get(deviceId)',
     );
+    expect(deviceLinkHost).toContain('?? (presenceOnlineByDevice.get(deviceId) === false ? false : undefined)');
+    expect(deviceLinkHost).toContain("replayActiveSubscriptions('directory-online', deviceId);");
+    expect(deviceLinkHost).toContain('isPermanentSubscriptionReplayError(error, presenceAvailableByDevice.get(deviceId))');
   });
 
   it('每个 relay 连接代上线时从设备目录补齐展示名与已在线桌面', () => {

--- a/apps/desktop/src/main/__tests__/deviceLinkVoiceCredentialBootstrap.test.ts
+++ b/apps/desktop/src/main/__tests__/deviceLinkVoiceCredentialBootstrap.test.ts
@@ -49,6 +49,10 @@ describe('mobile voice credential sync desktop bootstrap path', () => {
     expect(deviceLinkHost).toContain('if (available && wasAvailable !== true)');
     expect(deviceLinkHost).toContain('replayActiveSubscriptions(`presence-online:${snap.deviceId.slice(0, 8)}`, snap.deviceId);');
     expect(deviceLinkHost).toContain('createSubscriptionReplayScheduler({');
+    // Preserve unknown after reconnect; only explicit unavailability stops retries.
+    expect(deviceLinkHost).toContain(
+      'getPresenceAvailability: (deviceId) => presenceAvailableByDevice.get(deviceId),',
+    );
   });
 
   it('每个 relay 连接代上线时从设备目录补齐展示名与已在线桌面', () => {

--- a/apps/desktop/src/main/device-link/__tests__/subscriptionReplayScheduler.test.ts
+++ b/apps/desktop/src/main/device-link/__tests__/subscriptionReplayScheduler.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it, vi } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 import { createSubscriptionReplayScheduler } from '../subscriptionReplayScheduler';
 
@@ -13,6 +13,115 @@ function deferred<T>() {
 }
 
 describe('subscription replay scheduler', () => {
+  describe('recovery before presence arrives', () => {
+    const deviceId = 'device-a';
+    let presence: Map<string, boolean>;
+    let relayOnline: boolean;
+    let unresponsive: boolean;
+    let tornDown: boolean;
+    let refs: Array<{ deviceId: string; topics: string[] }>;
+    let remoteSubscribe: ReturnType<typeof vi.fn<(id: string, topics: string[]) => Promise<unknown>>>;
+    let scheduler: ReturnType<typeof createSubscriptionReplayScheduler>;
+
+    beforeEach(() => {
+      vi.useFakeTimers();
+      presence = new Map();
+      relayOnline = true;
+      unresponsive = false;
+      tornDown = false;
+      refs = [{ deviceId, topics: ['session:one'] }];
+      remoteSubscribe = vi.fn<(id: string, topics: string[]) => Promise<unknown>>()
+        .mockRejectedValue(new Error('temporary'));
+      scheduler = createSubscriptionReplayScheduler({
+        snapshotSubscriptions: (id) => refs.filter((ref) => !id || ref.deviceId === id),
+        remoteSubscribe,
+        isLinkTornDown: () => tornDown,
+        isRelayOnline: () => relayOnline,
+        isDeviceUnresponsive: () => unresponsive,
+        getPresenceAvailability: (id) => presence.get(id),
+        isPermanentError: (error) => String(error).includes('ACCESS_REVOKED'),
+        log: { debug: vi.fn(), warn: vi.fn() },
+      });
+    });
+
+    afterEach(() => {
+      scheduler.teardown();
+      vi.useRealTimers();
+    });
+
+    it('recovers after reconnect without a presence event or replaying a healthy peer', async () => {
+      presence.set(deviceId, true);
+      presence.clear(); // The old connection verdict is invalidated on disconnect.
+      refs.push({ deviceId: 'device-b', topics: ['sessions'] });
+      const healthy = deferred<unknown>();
+      let attempts = 0;
+      remoteSubscribe.mockImplementation((id) => {
+        if (id === 'device-b') return healthy.promise;
+        return ++attempts === 1 ? Promise.reject(new Error('temporary')) : Promise.resolve();
+      });
+
+      scheduler.replay('ws-online');
+      await vi.advanceTimersByTimeAsync(2_999);
+      expect(remoteSubscribe).toHaveBeenCalledTimes(2);
+      refs[0].topics = ['session:one', 'session:two'];
+      await vi.advanceTimersByTimeAsync(1);
+      expect(remoteSubscribe).toHaveBeenCalledTimes(3);
+      expect(remoteSubscribe).toHaveBeenLastCalledWith(deviceId, ['session:one', 'session:two']);
+      healthy.resolve(undefined);
+      await vi.advanceTimersByTimeAsync(60_000);
+      expect(remoteSubscribe.mock.calls.filter(([id]) => id === 'device-b')).toHaveLength(1);
+      expect(remoteSubscribe).toHaveBeenCalledTimes(3);
+    });
+
+    it('keeps exponential backoff capped at 30 seconds while presence stays unknown', async () => {
+      scheduler.replay('ws-online');
+      let attempts = 1;
+      for (const delay of [3_000, 6_000, 12_000, 24_000, 30_000, 30_000]) {
+        await vi.advanceTimersByTimeAsync(delay - 1);
+        expect(remoteSubscribe).toHaveBeenCalledTimes(attempts);
+        await vi.advanceTimersByTimeAsync(1);
+        expect(remoteSubscribe).toHaveBeenCalledTimes(++attempts);
+      }
+    });
+
+    it('stops on explicit unavailability and resumes on the next online trigger', async () => {
+      scheduler.replay('ws-online');
+      await vi.advanceTimersByTimeAsync(0);
+      presence.set(deviceId, false);
+      await vi.advanceTimersByTimeAsync(60_000);
+      expect(remoteSubscribe).toHaveBeenCalledTimes(1);
+
+      presence.set(deviceId, true);
+      remoteSubscribe.mockResolvedValue(undefined);
+      scheduler.replay('presence-online', deviceId);
+      await vi.advanceTimersByTimeAsync(60_000);
+      expect(remoteSubscribe).toHaveBeenCalledTimes(2);
+    });
+
+    it.each(['relay-offline', 'torn-down', 'unresponsive', 'unsubscribed', 'cancel', 'teardown'])(
+      'does not retry unknown presence after %s', async (gate) => {
+        scheduler.replay('ws-online');
+        await vi.advanceTimersByTimeAsync(0);
+        if (gate === 'relay-offline') relayOnline = false;
+        if (gate === 'torn-down') tornDown = true;
+        if (gate === 'unresponsive') unresponsive = true;
+        if (gate === 'unsubscribed') refs = [];
+        if (gate === 'cancel') scheduler.cancel(deviceId);
+        if (gate === 'teardown') scheduler.teardown();
+        await vi.advanceTimersByTimeAsync(60_000);
+        expect(remoteSubscribe).toHaveBeenCalledTimes(1);
+      },
+    );
+
+    it('stops when an unknown peer retry receives a permanent rejection', async () => {
+      remoteSubscribe.mockRejectedValueOnce(new Error('temporary'))
+        .mockRejectedValue(new Error('[ACCESS_REVOKED] denied'));
+      scheduler.replay('ws-online');
+      await vi.advanceTimersByTimeAsync(60_000);
+      expect(remoteSubscribe).toHaveBeenCalledTimes(2);
+    });
+  });
+
   it('coalesces ws/presence triggers and replays the latest snapshot after settle', async () => {
     const deviceId = 'device-a';
     let refs = [{ deviceId, topics: ['session:one'] }];
@@ -30,7 +139,7 @@ describe('subscription replay scheduler', () => {
       isLinkTornDown: () => false,
       isRelayOnline: () => true,
       isDeviceUnresponsive: () => false,
-      isPresenceAvailable: () => true,
+      getPresenceAvailability: () => true,
       isPermanentError: () => false,
       log: { debug: vi.fn(), warn: vi.fn() },
     });
@@ -62,7 +171,7 @@ describe('subscription replay scheduler', () => {
       isLinkTornDown: () => false,
       isRelayOnline: () => true,
       isDeviceUnresponsive: () => false,
-      isPresenceAvailable: () => true,
+      getPresenceAvailability: () => true,
       isPermanentError: () => false,
       log: { debug: vi.fn(), warn: vi.fn() },
     });
@@ -96,7 +205,7 @@ describe('subscription replay scheduler', () => {
         isLinkTornDown: () => false,
         isRelayOnline: () => true,
         isDeviceUnresponsive: () => false,
-        isPresenceAvailable: () => true,
+        getPresenceAvailability: () => true,
         isPermanentError: () => false,
         log: { debug: vi.fn(), warn: vi.fn() },
         retryBaseMs: 10,

--- a/apps/desktop/src/main/device-link/__tests__/subscriptionReplayScheduler.test.ts
+++ b/apps/desktop/src/main/device-link/__tests__/subscriptionReplayScheduler.test.ts
@@ -158,16 +158,19 @@ describe('subscription replay scheduler', () => {
       expect(presence.has(deviceId)).toBe(false);
     });
 
-    it('preserves online presence when an earlier subscribe rejects offline', async () => {
-      const first = deferred<unknown>();
-      remoteSubscribe.mockReturnValueOnce(first.promise).mockResolvedValue(undefined);
-      scheduler.replay('ws-online');
-      presence.set(deviceId, true);
-      first.reject(new DeviceLinkError('DEVICE_OFFLINE', 'late response'));
-      await vi.advanceTimersByTimeAsync(3_000);
-      expect(remoteSubscribe).toHaveBeenCalledTimes(2);
-      expect(presence.get(deviceId)).toBe(true);
-    });
+    it.each(['before request', 'while request pending'])(
+      'preserves the existing policy when presence becomes true %s', async (when) => {
+        const first = deferred<unknown>();
+        remoteSubscribe.mockReturnValueOnce(first.promise).mockResolvedValue(undefined);
+        if (when === 'before request') presence.set(deviceId, true);
+        scheduler.replay('ws-online');
+        if (when === 'while request pending') presence.set(deviceId, true);
+        first.reject(new DeviceLinkError('DEVICE_OFFLINE', 'route offline without a presence update'));
+        await vi.advanceTimersByTimeAsync(3_000);
+        expect(remoteSubscribe).toHaveBeenCalledTimes(2);
+        expect(presence.get(deviceId)).toBe(true);
+      },
+    );
 
     it('does not lose an online trigger queued before the offline response settles', async () => {
       const first = deferred<unknown>();

--- a/apps/desktop/src/main/device-link/__tests__/subscriptionReplayScheduler.test.ts
+++ b/apps/desktop/src/main/device-link/__tests__/subscriptionReplayScheduler.test.ts
@@ -1,6 +1,8 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
-import { createSubscriptionReplayScheduler } from '../subscriptionReplayScheduler';
+import { DeviceLinkError } from '@cindy/device-link';
+
+import { createSubscriptionReplayScheduler, isPermanentSubscriptionReplayError } from '../subscriptionReplayScheduler';
 
 function deferred<T>() {
   let resolve!: (value: T) => void;
@@ -16,6 +18,7 @@ describe('subscription replay scheduler', () => {
   describe('recovery before presence arrives', () => {
     const deviceId = 'device-a';
     let presence: Map<string, boolean>;
+    let directoryOnline: Map<string, boolean>;
     let relayOnline: boolean;
     let unresponsive: boolean;
     let tornDown: boolean;
@@ -26,6 +29,7 @@ describe('subscription replay scheduler', () => {
     beforeEach(() => {
       vi.useFakeTimers();
       presence = new Map();
+      directoryOnline = new Map();
       relayOnline = true;
       unresponsive = false;
       tornDown = false;
@@ -38,8 +42,9 @@ describe('subscription replay scheduler', () => {
         isLinkTornDown: () => tornDown,
         isRelayOnline: () => relayOnline,
         isDeviceUnresponsive: () => unresponsive,
-        getPresenceAvailability: (id) => presence.get(id),
-        isPermanentError: (error) => String(error).includes('ACCESS_REVOKED'),
+        getPresenceAvailability: (id) => presence.get(id)
+          ?? (directoryOnline.get(id) === false ? false : undefined),
+        isPermanentError: (error, id) => isPermanentSubscriptionReplayError(error, presence.get(id)),
         log: { debug: vi.fn(), warn: vi.fn() },
       });
     });
@@ -119,6 +124,61 @@ describe('subscription replay scheduler', () => {
       scheduler.replay('ws-online');
       await vi.advanceTimersByTimeAsync(60_000);
       expect(remoteSubscribe).toHaveBeenCalledTimes(2);
+    });
+
+    it.each([
+      new Error('[DEVICE_OFFLINE] offline'),
+      new DeviceLinkError('DEVICE_OFFLINE', 'offline'),
+    ])('stops unknown recovery on explicit offline response %s and resumes on directory online', async (error) => {
+      remoteSubscribe.mockRejectedValue(error);
+      scheduler.replay('ws-online');
+      await vi.advanceTimersByTimeAsync(120_000);
+      expect(remoteSubscribe).toHaveBeenCalledTimes(1);
+      expect(vi.getTimerCount()).toBe(0);
+      expect(presence.has(deviceId)).toBe(false);
+
+      directoryOnline.set(deviceId, true);
+      remoteSubscribe.mockResolvedValue(undefined);
+      scheduler.replay('directory-online', deviceId);
+      await vi.advanceTimersByTimeAsync(60_000);
+      expect(remoteSubscribe).toHaveBeenCalledTimes(2);
+    });
+
+    it('stops on directory offline and retries again after the directory reports online', async () => {
+      scheduler.replay('ws-online');
+      await vi.advanceTimersByTimeAsync(0);
+      directoryOnline.set(deviceId, false);
+      await vi.advanceTimersByTimeAsync(120_000);
+      expect(remoteSubscribe).toHaveBeenCalledTimes(1);
+
+      directoryOnline.set(deviceId, true);
+      scheduler.replay('directory-online', deviceId);
+      await vi.advanceTimersByTimeAsync(3_000);
+      expect(remoteSubscribe).toHaveBeenCalledTimes(3);
+      expect(presence.has(deviceId)).toBe(false);
+    });
+
+    it('preserves online presence when an earlier subscribe rejects offline', async () => {
+      const first = deferred<unknown>();
+      remoteSubscribe.mockReturnValueOnce(first.promise).mockResolvedValue(undefined);
+      scheduler.replay('ws-online');
+      presence.set(deviceId, true);
+      first.reject(new DeviceLinkError('DEVICE_OFFLINE', 'late response'));
+      await vi.advanceTimersByTimeAsync(3_000);
+      expect(remoteSubscribe).toHaveBeenCalledTimes(2);
+      expect(presence.get(deviceId)).toBe(true);
+    });
+
+    it('does not lose an online trigger queued before the offline response settles', async () => {
+      const first = deferred<unknown>();
+      remoteSubscribe.mockReturnValueOnce(first.promise).mockResolvedValue(undefined);
+      scheduler.replay('ws-online');
+      directoryOnline.set(deviceId, true);
+      scheduler.replay('directory-online', deviceId);
+      first.reject(new DeviceLinkError('DEVICE_OFFLINE', 'late response'));
+      await vi.advanceTimersByTimeAsync(120_000);
+      expect(remoteSubscribe).toHaveBeenCalledTimes(2);
+      expect(vi.getTimerCount()).toBe(0);
     });
   });
 

--- a/apps/desktop/src/main/device-link/index.ts
+++ b/apps/desktop/src/main/device-link/index.ts
@@ -1275,7 +1275,7 @@ const PERMANENT_SUBSCRIPTION_REPLAY_CODES: ReadonlySet<string> = new Set([
   // DEVICE_OFFLINE 刻意不在列(MOBILE-PARITY-CHECKLIST §2 归瞬态):presence
   // 滞后窗口内 subscribe 可能先吃到 DEVICE_OFFLINE,归永久会在「presence 仍
   // available」期间放弃收敛;归瞬态则退避循环续跑,presence 补到 offline 时由
-  // 重试前置门(presenceAvailableByDevice !== true)自然终止,设备回归再由
+  // 重试前置门(presenceAvailableByDevice === false)自然终止,设备回归再由
   // presence 翻转重放接棒——两个终止/恢复信号都已存在,无泄漏风险(review P2)。
 ]);
 
@@ -1292,7 +1292,7 @@ const subscriptionReplayScheduler = createSubscriptionReplayScheduler({
   isLinkTornDown: () => linkTornDown,
   isRelayOnline: () => client?.getStatus() === 'online',
   isDeviceUnresponsive: (deviceId) => responsivenessTracker?.isUnresponsive(deviceId) ?? false,
-  isPresenceAvailable: (deviceId) => presenceAvailableByDevice.get(deviceId) === true,
+  getPresenceAvailability: (deviceId) => presenceAvailableByDevice.get(deviceId),
   isPermanentError: isPermanentSubscriptionReplayError,
   log: {
     debug: (message) => log.debug(message),

--- a/apps/desktop/src/main/device-link/index.ts
+++ b/apps/desktop/src/main/device-link/index.ts
@@ -128,7 +128,7 @@ import {
   buildSessionNotifyPayload,
   type MobileSessionEventKind,
 } from './mobileNotify';
-import { createSubscriptionReplayScheduler } from './subscriptionReplayScheduler';
+import { createSubscriptionReplayScheduler, isPermanentSubscriptionReplayError } from './subscriptionReplayScheduler';
 import { getSessionNotificationBody } from '../sessionNotificationCopy';
 import { getClientEndpoint } from '../clientEndpointsService';
 import {
@@ -268,6 +268,7 @@ export function applyControllerPresenceListSnapshot(
     onPeerBecameOnline: (deviceId, platform) => {
       if (isMobilePlatform(platform)) handleMobilePeerOnline(deviceId);
       else handleDesktopPeerOnline(deviceId);
+      replayActiveSubscriptions('directory-online', deviceId);
     },
   });
 }
@@ -1259,41 +1260,15 @@ function replayActiveSubscriptions(reason: string, deviceId?: string): void {
   subscriptionReplayScheduler.replay(reason, deviceId);
 }
 
-/**
- * 订阅重放的永久失败判据:这些码代表「重试同一动作不可能改变结果」的终态
- * (协议不符 / 对端明确拒绝 / 授权被收回 / 本机 fail-closed 门),各自有独立的
- * 恢复事件,不归退避循环管。DeviceLinkError.code 优先,兜底解析 message 里的
- * [CODE] 编码(本机门禁抛的是普通 Error)。
- */
-const PERMANENT_SUBSCRIPTION_REPLAY_CODES: ReadonlySet<string> = new Set([
-  'VERSION_MISMATCH',
-  'REMOTE_DISABLED',
-  'ACCESS_REVOKED',
-  'CHANNEL_NOT_ALLOWED',
-  'DEVICE_LINK_CONTROL_DISABLED',
-  'DEVICE_LINK_STANDBY',
-  // DEVICE_OFFLINE 刻意不在列(MOBILE-PARITY-CHECKLIST §2 归瞬态):presence
-  // 滞后窗口内 subscribe 可能先吃到 DEVICE_OFFLINE,归永久会在「presence 仍
-  // available」期间放弃收敛;归瞬态则退避循环续跑,presence 补到 offline 时由
-  // 重试前置门(presenceAvailableByDevice === false)自然终止,设备回归再由
-  // presence 翻转重放接棒——两个终止/恢复信号都已存在,无泄漏风险(review P2)。
-]);
-
-function isPermanentSubscriptionReplayError(err: unknown): boolean {
-  if (err instanceof DeviceLinkError) return PERMANENT_SUBSCRIPTION_REPLAY_CODES.has(err.code);
-  const message = err instanceof Error ? err.message : String(err);
-  const code = /\[([A-Z_]+)\]/.exec(message)?.[1];
-  return code !== undefined && PERMANENT_SUBSCRIPTION_REPLAY_CODES.has(code);
-}
-
 const subscriptionReplayScheduler = createSubscriptionReplayScheduler({
   snapshotSubscriptions,
   remoteSubscribe,
   isLinkTornDown: () => linkTornDown,
   isRelayOnline: () => client?.getStatus() === 'online',
   isDeviceUnresponsive: (deviceId) => responsivenessTracker?.isUnresponsive(deviceId) ?? false,
-  getPresenceAvailability: (deviceId) => presenceAvailableByDevice.get(deviceId),
-  isPermanentError: isPermanentSubscriptionReplayError,
+  getPresenceAvailability: (deviceId) => presenceAvailableByDevice.get(deviceId)
+    ?? (presenceOnlineByDevice.get(deviceId) === false ? false : undefined),
+  isPermanentError: (error, deviceId) => isPermanentSubscriptionReplayError(error, presenceAvailableByDevice.get(deviceId)),
   log: {
     debug: (message) => log.debug(message),
     warn: (message) => log.warn(message),

--- a/apps/desktop/src/main/device-link/subscriptionReplayScheduler.ts
+++ b/apps/desktop/src/main/device-link/subscriptionReplayScheduler.ts
@@ -13,9 +13,10 @@ const PERMANENT_SUBSCRIPTION_REPLAY_CODES: ReadonlySet<string> = new Set([
 export function isPermanentSubscriptionReplayError(err: unknown, available: boolean | undefined): boolean {
   const message = err instanceof Error ? err.message : String(err);
   const code = err instanceof DeviceLinkError ? err.code : /\[([A-Z_]+)\]/.exec(message)?.[1];
-  // An offline response ends unknown-state recovery. Preserve the existing
-  // transient handling when a newer online presence contradicts the response.
-  // Never persist a route error into presence: late errors must not overwrite it.
+  // Bound the newly enabled unknown-state recovery on an explicit offline result.
+  // For known-available peers, preserve the pre-existing transient policy. This
+  // cached boolean does not establish event ordering; it may itself be stale.
+  // Route/presence reconciliation is outside this unknown-state recovery fix.
   return code !== undefined && (
     PERMANENT_SUBSCRIPTION_REPLAY_CODES.has(code)
     || (code === 'DEVICE_OFFLINE' && available !== true)

--- a/apps/desktop/src/main/device-link/subscriptionReplayScheduler.ts
+++ b/apps/desktop/src/main/device-link/subscriptionReplayScheduler.ts
@@ -1,3 +1,27 @@
+import { DeviceLinkError } from '@cindy/device-link';
+
+const PERMANENT_SUBSCRIPTION_REPLAY_CODES: ReadonlySet<string> = new Set([
+  'VERSION_MISMATCH',
+  'REMOTE_DISABLED',
+  'ACCESS_REVOKED',
+  'CHANNEL_NOT_ALLOWED',
+  'DEVICE_LINK_CONTROL_DISABLED',
+  'DEVICE_LINK_STANDBY',
+]);
+
+/** Terminal for this replay; later online/reconnect triggers can start another. */
+export function isPermanentSubscriptionReplayError(err: unknown, available: boolean | undefined): boolean {
+  const message = err instanceof Error ? err.message : String(err);
+  const code = err instanceof DeviceLinkError ? err.code : /\[([A-Z_]+)\]/.exec(message)?.[1];
+  // An offline response ends unknown-state recovery. Preserve the existing
+  // transient handling when a newer online presence contradicts the response.
+  // Never persist a route error into presence: late errors must not overwrite it.
+  return code !== undefined && (
+    PERMANENT_SUBSCRIPTION_REPLAY_CODES.has(code)
+    || (code === 'DEVICE_OFFLINE' && available !== true)
+  );
+}
+
 export type SubscriptionReplayRef = {
   deviceId: string;
   topics: string[];
@@ -19,7 +43,7 @@ type SubscriptionReplaySchedulerOptions = {
   isDeviceUnresponsive: (deviceId: string) => boolean;
   /** undefined means this relay generation has not observed the peer yet. */
   getPresenceAvailability: (deviceId: string) => boolean | undefined;
-  isPermanentError: (error: unknown) => boolean;
+  isPermanentError: (error: unknown, deviceId: string) => boolean;
   log: {
     debug(message: string): void;
     warn(message: string): void;
@@ -74,7 +98,7 @@ export function createSubscriptionReplayScheduler(
     inFlight.set(deviceId, requestToken);
     void options.remoteSubscribe(deviceId, topics).catch((error: unknown) => {
       if (currentGeneration(deviceId) !== gen) return;
-      if (options.isPermanentError(error)) {
+      if (options.isPermanentError(error, deviceId)) {
         options.log.warn(
           `device-link replay subscriptions failed (${reason}) for ${deviceId.slice(0, 8)}, permanent, giving up: ${String(error)}`,
         );

--- a/apps/desktop/src/main/device-link/subscriptionReplayScheduler.ts
+++ b/apps/desktop/src/main/device-link/subscriptionReplayScheduler.ts
@@ -17,7 +17,8 @@ type SubscriptionReplaySchedulerOptions = {
   isLinkTornDown: () => boolean;
   isRelayOnline: () => boolean;
   isDeviceUnresponsive: (deviceId: string) => boolean;
-  isPresenceAvailable: (deviceId: string) => boolean;
+  /** undefined means this relay generation has not observed the peer yet. */
+  getPresenceAvailability: (deviceId: string) => boolean | undefined;
   isPermanentError: (error: unknown) => boolean;
   log: {
     debug(message: string): void;
@@ -89,7 +90,9 @@ export function createSubscriptionReplayScheduler(
         if (currentGeneration(deviceId) !== gen) return;
         if (options.isLinkTornDown() || !options.isRelayOnline()) return;
         if (options.isDeviceUnresponsive(deviceId)) return;
-        if (!options.isPresenceAvailable(deviceId)) return;
+        // Presence is incremental and resets on reconnect. Unknown must keep the
+        // existing backoff alive; only an explicit offline/disabled verdict stops it.
+        if (options.getPresenceAvailability(deviceId) === false) return;
         const current = options
           .snapshotSubscriptions(deviceId)
           .find((ref) => ref.deviceId === deviceId);


### PR DESCRIPTION
## 这次改了什么

### 摘要

桌面端重连 relay 后会清空设备在线状态；如果首次恢复订阅遇到瞬态错误，原重试门把“状态未知”也当作“不可用”，导致订阅恢复在没有后续 presence 事件时停止。

现在保留 presence 三态：未知时沿用既有 3 秒起步、30 秒封顶的指数退避；明确离线或关闭被控时暂停。未知状态收到 DEVICE_OFFLINE，或尚无实时 presence 时设备目录明确返回离线，也会结束本轮恢复；后续 presence / 目录上线边沿或 relay 重连可以重新触发。每次重试仍只针对失败设备，并读取最新订阅集合；取消、停机、熔断和既有授权检查继续生效。

已知可用（true）时遇到 DEVICE_OFFLINE 仍沿用主干的瞬态退避策略。本 PR 不依据缓存布尔值判断 route 与 presence 的先后顺序，也不解决主干已有的两者失配问题；此限制与修复“未知状态误停”分开说明，不能把 true 描述成“较新的在线事件”。

### 变更类型

- [ ] `feat` 新功能
- [x] `fix` 缺陷修复
- [ ] `refactor` / `perf` 重构或性能优化
- [ ] `docs` / `test` / `chore` 文档、测试或工程维护
- [ ] 其他：

### 范围

- 关联 Issue / 需求：远程连接逻辑排查发现的订阅恢复空档。
- 本 PR 包含：Desktop presence 三态接线、订阅重试的停止和恢复判据、16 个新增行为回归及接线断言。
- 明确不包含：服务端、wire protocol、IPC allowlist、Mobile outbox、UI、网络切换监听、新重试机制，以及已知在线状态下 route/presence 的顺序协调。
- 用户可见变化：桌面远程控制时，重连后的首次订阅失败可继续自动恢复，不再依赖下一次设备在线通知。
- 是否存在 breaking change：无；仅 Desktop 本地编排变化，旧对端继续使用现有 subscribe 协议。

### UI 变化

- 引用的设计规范：不涉及；没有界面、布局、样式或文案修改。

## 怎么验证的

### 自动验证

```text
pnpm test:unit:related
结果：通过，Desktop 相关单测通过。

bash /Users/dash/Code/XD/dash/Skills/git/scripts/run-unit-gate.sh /Users/dash/Code/Cindy/cindy-fix-device-link-subscription-retry
结果：全量单测通过，GATE_EXIT=0。

pnpm --filter desktop run --if-present typecheck
结果：通过。

pnpm --filter desktop exec vitest run src/main/device-link/__tests__/subscriptionReplayScheduler.test.ts src/main/__tests__/deviceLinkVoiceCredentialBootstrap.test.ts src/main/device-link/__tests__/linkRecovery.test.ts src/main/device-link/__tests__/transportTimeoutReopen.test.ts
结果：4 文件 / 43 测试通过。

pnpm --filter @cindy/device-link exec vitest run src/__tests__/client.test.ts -t '≥2 控制端共享同一被控端'
结果：选定的双控制端隔离测试 1/1 通过；其余 172 项未在此定向命令运行。

git diff --check
结果：通过。

pnpm check:dco
结果：通过，全部提交已签名。
```

初始恢复测试在旧判据下有 3 个失败。当前调度器 19/19 通过，覆盖未知状态无事件恢复、3/6/12/24/30 秒退避与封顶、明确离线后再上线、最新订阅集合、单设备恢复不重复请求健康设备，以及取消/停机/熔断/退订/永久异常停止。离线回归还覆盖结构化和编码 DEVICE_OFFLINE、目录 offline→online、已知在线状态沿用原重试策略，以及错误收尾前排队的在线触发不丢失。

调度器、Desktop 接线和目录状态测试：3 文件 / 38 测试通过。运行时修复提交 3079eb70a 通过相关单测、Desktop typecheck 与统一全量门禁；其后的注释及测试场景澄清重新通过相关单测、Desktop typecheck 和上述 38 项测试，运行时代码未变，沿用该次全量门禁结果。

额外从主干 59bf3eaa 读取原调度器及原错误分类函数并以内存定时器执行：presence 已为 true 后收到 DEVICE_OFFLINE，首个 3000ms 定时器仍触发第二次订阅，确认该策略在本 PR 前已存在。

### 恢复边界检查点

不变量：新放开的未知状态恢复必须继续处理真正的瞬态错误，并在收到明确离线结果时停止；不改变已知在线状态的原有重试策略。presence 与目录各自由现有宿主视图维护，调度器只管理本设备的在途、退避、代次和待重放请求，不向在线视图写入 route 错误。

| 状态 / 事件 | 处理 |
| --- | --- |
| unknown + 非终态失败 / 超时 | 原指数退避，重读最新订阅 |
| unknown + DEVICE_OFFLINE | 结束当前恢复，等后续有效恢复触发 |
| 明确不可用 / 目录明确离线且无实时 presence | 暂停定时重试 |
| known true + DEVICE_OFFLINE | 保持主干原有退避；不声称已解决顺序协调 |
| 在线触发先于请求 resolve / reject | 现有 pending rerun 在收尾后重放 |
| 在线触发晚于请求收尾 | 现有 replay 入口开启新轮次 |
| cancel / teardown / 旧代迟到结果 | 现有代次与 request token 阻止旧请求清理新轮次 |

### 手工验证

完成代码路径自审及独立只读复审，未发现本次引入的阻断问题。

### 未执行的验证

未启动 Desktop/Mobile 实机或真实 relay 弱网演练；本次通过注入依赖和假时钟验证恢复时序，未将其视为实机验证。

## 风险

### 风险分类

- [ ] 无已知风险
- [ ] SQLite / migration
- [ ] system prompt
- [ ] 协议兼容
- [ ] 权限 / 安全 / 用户数据
- [ ] 存量插件兼容（批准状态 / 指纹 / manifest 校验 / 安装布局 / 包格式）
- [ ] 原生层 / fingerprint / OTA
- [ ] 跨平台差异
- [x] 其他：设备状态未知期间继续订阅恢复

### 影响与回滚

- 影响范围：Desktop 控制端的订阅重放。真正未知期间的瞬态失败继续低频重试，复用原有退避和单飞；未知时明确离线、presence 不可用、无订阅、取消或停机仍终止。route 错误不持久化到 presence；目录上线只触发该设备已有订阅的重放。已知 true 但 route 已离线且无新 presence 的主干已有持续退避仍存在，本 PR 不以新增状态机制改动该策略。远端授权仍由既有 dispatch 检查。
- 回滚 / 降级方式：回退本 PR 即恢复旧判据，无数据迁移或版本联动。

故障半径三问：

1. 触发层级：单设备 subscribe 瞬态失败，且本连接代尚未获得该设备的 presence。
2. 动作层级：只继续该设备既有订阅重试，不新增共享 relay teardown、全量重放或连接级恢复。
3. 多 peer 验证：新增 A 未知且失败、B 在途且健康时只重试 A 的回归；另实际运行共享被控端的两个控制端用例，一端停止 ACK 后仅复位该 peer，另一端 link、在途结果和后续请求保持正常。

远程与手机版适配：

- SSH：不修改 workdir、文件访问或 agent 执行位置。
- IPC / wire：不新增 channel、topic、字段或消息种类。
- Mobile：此次缺口位于 Desktop 控制端的调度器；Mobile 使用独立恢复调度，本 PR 不要求手机同步升级。

### 提交前检查

- [x] 已 review 完整 diff
- [x] 每个 commit 都带 DCO 签名（`git commit -s`，见 [DCO](../DCO)）
- [x] UI 改动已在「UI 变化」注明不涉及及理由
- [x] 未提交凭证、令牌或授权文件
- [x] 已补充必要说明：代码注释及 PR 中的恢复边界，无新增用户配置
- [x] 已确认测试结果或说明未执行原因
