### PR TITLE
fix(pi): preserve explicit catalog reasoning levels

### DIFF
--- a/apps/desktop/src/main/maker-host/__tests__/catalogDerivedModels.test.ts
+++ b/apps/desktop/src/main/maker-host/__tests__/catalogDerivedModels.test.ts
@@ -104,6 +104,34 @@ function injectedCatalog(): Catalog {
 }
 
 describe('deriveAvailableModels — dynamic-first catalog contract', () => {
+  it('keeps explicit GPT-6 Pi effort capabilities in the picker and runtime descriptor', () => {
+    const catalog = structuredClone(BUNDLED_CATALOG);
+    const efforts = ['low', 'medium', 'high', 'xhigh', 'max'] as const;
+    catalog.providers.find((provider) => provider.id === 'openai')!.models.pi = [
+      model('chatgpt/gpt-6-astra', {
+        contextWindow: 272_000,
+        maxOutput: 128_000,
+        efforts: [...efforts],
+        defaultEffort: 'medium',
+        reasoning: true,
+        reasoningEfforts: [...efforts],
+        reasoningDefaultEffort: 'medium',
+        supportsImageInput: true,
+      }),
+    ];
+    const expected = {
+      contextWindow: 272_000,
+      maxOutputTokens: 128_000,
+      efforts: [...efforts],
+      defaultEffort: 'medium',
+      supportsImageInput: true,
+    };
+    expect(deriveAvailableModels(catalog, 'pi').find((entry) => entry.id === 'chatgpt/gpt-6-astra'))
+      .toMatchObject(expected);
+    expect(resolvePiRuntimeModelDescriptor(catalog, 'openai', 'chatgpt/gpt-6-astra'))
+      .toMatchObject(expected);
+  });
+
   it('publishes Pi effort controls only when the official catalog has an explicit thinking map', () => {
     const pi = deriveAvailableModels(BUNDLED_CATALOG, 'pi');
     expect(pi.find((m) => m.id === 'grok-4.3')?.efforts).toEqual([

--- a/apps/desktop/src/main/maker-host/__tests__/catalogDerivedModels.test.ts
+++ b/apps/desktop/src/main/maker-host/__tests__/catalogDerivedModels.test.ts
@@ -132,6 +132,30 @@ describe('deriveAvailableModels — dynamic-first catalog contract', () => {
       .toMatchObject(expected);
   });
 
+  it.each([
+    ['missing fields', {}],
+    ['null efforts', { reasoningEfforts: null, reasoningDefaultEffort: 'medium' }],
+    ['string efforts', { reasoningEfforts: 'medium', reasoningDefaultEffort: 'medium' }],
+    ['empty efforts', { reasoningEfforts: [], reasoningDefaultEffort: 'medium' }],
+    ['invalid effort', { reasoningEfforts: ['medium', 'ultra'], reasoningDefaultEffort: 'medium' }],
+    ['non-string effort', { reasoningEfforts: ['medium', null], reasoningDefaultEffort: 'medium' }],
+    ['missing default', { reasoningEfforts: ['medium'] }],
+    ['null default', { reasoningEfforts: ['medium'], reasoningDefaultEffort: null }],
+    ['default outside efforts', { reasoningEfforts: ['low'], reasoningDefaultEffort: 'medium' }],
+  ])('keeps legacy Pi minimal compatibility for %s in both descriptors', (_label, fields) => {
+    const catalog = structuredClone(BUNDLED_CATALOG);
+    // Remote JSON can violate the static CatalogModel type at runtime.
+    const entry = {
+      ...model('legacy-reasoner', { efforts: ['low', 'medium', 'high'], defaultEffort: 'medium' }),
+      ...fields,
+    } as unknown as CatalogModel;
+    catalog.providers.find((provider) => provider.id === 'openai')!.models.pi = [entry];
+    const expected = { efforts: ['minimal', 'low', 'medium', 'high'], defaultEffort: 'medium' };
+    expect(deriveAvailableModels(catalog, 'pi').find((m) => m.id === entry.id))
+      .toMatchObject(expected);
+    expect(resolvePiRuntimeModelDescriptor(catalog, 'openai', entry.id)).toMatchObject(expected);
+  });
+
   it('publishes Pi effort controls only when the official catalog has an explicit thinking map', () => {
     const pi = deriveAvailableModels(BUNDLED_CATALOG, 'pi');
     expect(pi.find((m) => m.id === 'grok-4.3')?.efforts).toEqual([

--- a/apps/desktop/src/main/maker-host/catalog-to-descriptors.ts
+++ b/apps/desktop/src/main/maker-host/catalog-to-descriptors.ts
@@ -54,13 +54,12 @@ function toDescriptor(
   agent: AgentKind,
   options: DescriptorProjectionOptions = {},
 ): ModelDescriptor {
-  // Pi runtime 原生接受 minimal thinking level。目录里的同一模型常从 CC/Codex
-  // 投影而来而未声明该档；只要模型有 reasoning 档，就把 Pi 的最小档补在最前。
-  // BYOM 的 efforts 则是用户显式声明的协议能力，必须原样保留，不能对外宣称一个
-  // models.json 会禁用的档位。
+  // 仅为缺少明确 Pi 能力字段的旧目录保留 minimal 兼容补档。独立 Pi 目录的
+  // reasoningEfforts 与 BYOM 声明都是协议能力，不能额外公布 models.json 禁用的档位。
   const efforts =
     agent === 'pi' &&
     options.preserveExplicitPiEfforts !== true &&
+    m.reasoningEfforts === undefined &&
     m.efforts.length > 0 &&
     !m.efforts.includes('minimal')
       ? (['minimal', ...m.efforts] as const)

--- a/apps/desktop/src/main/maker-host/catalog-to-descriptors.ts
+++ b/apps/desktop/src/main/maker-host/catalog-to-descriptors.ts
@@ -21,6 +21,7 @@
  */
 
 import {
+  PI_REASONING_EFFORTS,
   isAgentSelectableModel,
   isModelSelectableForNewRoute,
   type Catalog,
@@ -48,18 +49,29 @@ interface SeenModelProjection {
   includesUserProvider: boolean;
 }
 
+function hasValidPiReasoningCapabilities(m: CatalogModel): boolean {
+  const efforts = m.reasoningEfforts;
+  return (
+    Array.isArray(efforts) &&
+    efforts.length > 0 &&
+    efforts.every((effort) => PI_REASONING_EFFORTS.includes(effort)) &&
+    typeof m.reasoningDefaultEffort === 'string' &&
+    efforts.includes(m.reasoningDefaultEffort)
+  );
+}
+
 /** CatalogModel → ModelDescriptor。仅透传 ModelDescriptor 需要的字段；可选字段缺省时不写键。 */
 function toDescriptor(
   m: CatalogModel,
   agent: AgentKind,
   options: DescriptorProjectionOptions = {},
 ): ModelDescriptor {
-  // 仅为缺少明确 Pi 能力字段的旧目录保留 minimal 兼容补档。独立 Pi 目录的
+  // 缺少或格式错误的 Pi 能力字段继续走旧目录 minimal 兼容补档。合法独立 Pi 目录的
   // reasoningEfforts 与 BYOM 声明都是协议能力，不能额外公布 models.json 禁用的档位。
   const efforts =
     agent === 'pi' &&
     options.preserveExplicitPiEfforts !== true &&
-    m.reasoningEfforts === undefined &&
+    !hasValidPiReasoningCapabilities(m) &&
     m.efforts.length > 0 &&
     !m.efforts.includes('minimal')
       ? (['minimal', ...m.efforts] as const)

--- a/packages/model-providers/src/types.ts
+++ b/packages/model-providers/src/types.ts
@@ -333,6 +333,10 @@ export interface CatalogModel {
   maxOutput?: number;
   /** 支持的 effort 档；空数组 = 不支持切换（如 Haiku / 部分 provider-managed 模型）。 */
   efforts: Effort[];
+  /** 独立 Pi 远端目录的显式能力；缺席时保留旧目录兼容行为。 */
+  reasoning?: boolean;
+  reasoningEfforts?: PiReasoningEffort[];
+  reasoningDefaultEffort?: PiReasoningEffort;
   /**
    * Model-specific effort 显示名覆盖（= maker-core ModelDescriptor.effortDisplayNames）。
    * 缺省时回退统一档名词表(桌面 i18n `effortLevels.*` / 手机 MOBILE_EFFORT_LABELS)→


### PR DESCRIPTION
## 这次改了什么

### 摘要

GPT-6 Astra 的独立 Pi 目录明确只有 low/medium/high/xhigh/max，桌面端却会自动补出 minimal，导致选择器和运行时描述符宣称 Pi models.json 禁用的档位。只有 reasoningEfforts 为合法非空 Pi 档位数组、且 reasoningDefaultEffort 属于该数组时，Pi 条目才保留目录声明的 efforts；缺失或格式错误的字段继续走旧目录 minimal 兼容补档，BYOM 行为保持不变。

### 变更类型

- [ ] feat：N/A
- [x] fix 缺陷修复
- [ ] refactor / perf：N/A
- [x] test 回归测试
- [ ] 其他：N/A

### 范围

- 关联需求：GPT-6 全 harness 配置复核，配套 https://github.com/xindong/cindy-server/pull/581。
- 本 PR 包含：Pi 描述符补档条件、既有远端 reasoning 字段的可选 TypeScript 声明和 picker/runtime 双入口回归用例。
- 明确不包含：修改目录、升级 Pi 二进制、调整默认窗口、权限、协议 schema 或其它 harness。
- 用户可见变化：服务端明确声明 GPT-6 五档后，Pi 不再显示 unsupported minimal。
- 是否存在 breaking change：无。

### UI 变化

- 引用的设计规范：不涉及视觉、布局或文案；仅纠正模型能力数据，不修改 UI 组件。

## 怎么验证的

### 自动验证

- `pnpm test:unit:related -- --no-lock --workspace-concurrency=1`：PASS（完整相关范围，按请求与其他任务并行运行）。
- `pnpm --filter desktop run --if-present typecheck`：PASS。
- `pnpm --filter desktop exec vitest run src/main/maker-host/__tests__/catalogDerivedModels.test.ts`：40 passed；覆盖合法 GPT-6 五档、9 类缺失/错误 reasoning 字段，以及原有 BYOM 行为。
- 用真实服务端 #581 数据经过 parse/merge/active-catalog/descriptor 验证 GPT-6：Claude Code 272K/四档；Codex 272K/六档含 ultra；Pi 272K/五档，默认 medium，图片支持。

首次批量运行中 `ghostOauthFlow.test.ts` 的端口复用用例偶发失败；无代码变更的定向复跑 41/41 通过，随后完整相关门禁复跑通过。

### 手工验证

本机 Pi 0.84.4 隔离配置 + 假凭证 RPC `get_available_models` 确认 GPT-6 动态 addition 的原生 adapter 为 openai-codex-responses、272K/128K、text/image，minimal/off 为 null，五档映射完整。

### 未执行的验证

未调用真实推理端点，未启动 Electron GUI；Windows 交由 CI，变更为无平台分支的纯数据转换。

## 风险

### 风险分类

- [ ] 无已知风险：存在旧客户端需升级的限制，见下。
- [ ] SQLite / migration：N/A
- [ ] system prompt：N/A
- [ ] 协议兼容：N/A，未改 wire shape
- [ ] 权限 / 安全 / 用户数据：N/A
- [ ] 存量插件兼容：N/A
- [ ] 原生层 / fingerprint / OTA：N/A
- [ ] 跨平台差异：N/A，纯逻辑
- [x] 其他：仅影响带合法显式 Pi reasoningEfforts 和对应默认档的描述符补档行为；格式错误时保留旧目录兼容。

### 影响与回滚

- 影响范围：Pi 模型能力对外投影；服务端目录修正可以先部署，移除错误 minimal 需要发布该客户端版本。用户已有有效档位与默认选择不变。
- 回滚 / 降级方式：revert 本提交恢复旧补档逻辑；无数据迁移。存量插件影响：无。

### 提交前检查

- [x] 已 review 完整 diff
- [x] 每个 commit 都带 DCO 签名
- [x] UI 变化已注明不涉及视觉代码
- [x] 未提交凭证、令牌或授权文件
- [x] 必要行为与边界已在 PR 说明，N/A：无新增配置文档
- [x] 已确认测试结果并说明未执行验证
