### PR TITLE
feat(desktop): 显示上下文窗口紧凑单位

### DIFF
--- a/apps/desktop/src/renderer/components/settings/CustomProviderDialog.tsx
+++ b/apps/desktop/src/renderer/components/settings/CustomProviderDialog.tsx
@@ -96,6 +96,7 @@ import {
 } from '@/lib/customProviderRuntimeFill';
 
 import {
+  formatContextWindow,
   isProviderRequestPath,
   PI_REASONING_EFFORTS,
   presetDisplayName,
@@ -305,6 +306,18 @@ function isCommittableWindowText(text: string): boolean {
   if (!/^[0-9]+(?:[,_ ][0-9]+)*$/.test(trimmed)) return false;
   const parsed = BigInt(trimmed.replace(/[,_ ]/g, ''));
   return parsed > 0n && parsed <= BigInt(Number.MAX_SAFE_INTEGER);
+}
+
+/** Compact context-window label shown inside the existing token-count input. */
+function compactContextWindowLabel(draft: string | undefined, contextWindow?: number): string | null {
+  if (draft !== undefined) {
+    if (!isCommittableWindowText(draft) || !draft.trim()) return null;
+    const value = Number(BigInt(draft.trim().replace(/[,_ ]/g, '')));
+    return Number.isSafeInteger(value) && value > 0 ? formatContextWindow(value) : null;
+  }
+  return contextWindow != null && Number.isSafeInteger(contextWindow) && contextWindow > 0
+    ? formatContextWindow(contextWindow)
+    : null;
 }
 
 /**
@@ -2547,6 +2560,20 @@ export function CustomProviderDialog({
                           placeholder={t(
                             'settings.providers.custom.fields.modelContextWindowPlaceholder',
                           )}
+                          trailing={(() => {
+                            const label = compactContextWindowLabel(
+                              windowDrafts[`${activeTab}:${i}`],
+                              m.contextWindow,
+                            );
+                            return label ? (
+                              <span
+                                aria-hidden="true"
+                                className="pointer-events-none absolute right-3 top-1/2 -translate-y-1/2 text-11 font-medium tabular-nums text-[var(--text-tertiary)]"
+                              >
+                                {label}
+                              </span>
+                            ) : null;
+                          })()}
                         />
                       </div>
                       <button


### PR DESCRIPTION
## 这次改了什么？

### 摘要

自定义供应商编辑窗口的模型配置中，用户输入较长的上下文窗口 token 数后，输入框右侧同步显示紧凑单位，例如 252K、1M，减少手动数位的负担。显示复用现有模型选择器的格式化规则，并保持原有数字输入与校验行为。

### 变更类型

- [x] feat 新功能
- [ ] fix 缺陷修复
- [ ] refactor / perf 重构或性能优化
- [ ] docs / test / chore 文档、测试或工程维护
- [ ] 其他

### 范围

- 关联 Issue / 需求：用户反馈自定义供应商模型上下文窗口数字过长，难以快速识别数量级。
- 本 PR 包含：Desktop 自定义供应商编辑窗口的上下文窗口紧凑单位展示。
- 明确不包含：数据格式、保存逻辑、上下文窗口计算逻辑和对话框宽度调整。
- 用户可见变化：输入上下文窗口 token 数时，右侧显示对应的 K/M 紧凑表示。
- 是否存在 breaking change：无。

### UI 变化

上下文窗口输入框在现有宽度内增加右侧辅助显示，空值和非法草稿不显示；输入框宽度、对话框宽度及模型行整体布局保持不变。Light 与 Dark 模式均使用语义 token。

- 引用的设计规范：`docs/design-rules/DESIGN.md` §4（输入控件与 pill 几何）、§10（主题 token 与双模式）。

## 怎么验证的？

### 自动验证

```text
pnpm test:unit:related
结果：通过（apps/desktop）

pnpm --filter desktop run --if-present typecheck
结果：通过

pnpm --filter desktop exec eslint src/renderer/components/settings/CustomProviderDialog.tsx
结果：通过
```

### 手动验证

已在 worktree 隔离沙盒中启动 Desktop dev 实例（sandbox：serene-mendel-ded2c7，状态：ready），用于验收自定义供应商编辑窗口。

### 未执行的验证

无。

## 风险

### 风险分类

- [x] 无已知风险
- [ ] SQLite / migration
- [ ] system prompt
- [ ] 协议兼容
- [ ] 权限 / 安全 / 用户数据
- [ ] 存量插件兼容
- [ ] 原生层 / fingerprint / OTA
- [ ] 跨平台差异
- [ ] 其他

### 影响与回滚

仅影响 Desktop 设置界面的展示；回滚该提交即可恢复原有输入框显示。

### 提交前检查

- [x] 已 review 完整 diff
- [x] commit 带 DCO Signed-off-by
- [x] UI 变更已引用设计规范
- [x] 未提交凭证、令牌或授权文件

### 手工验证

已在 worktree 隔离沙盒中启动 Desktop dev 实例（sandbox：serene-mendel-ded2c7，状态：ready），用于验收自定义供应商编辑窗口。