### PR TITLE
fix(mobile): 修复回退面板被顶部栏遮挡

### DIFF
--- a/apps/mobile/app/sessions/[sessionId].tsx
+++ b/apps/mobile/app/sessions/[sessionId].tsx
@@ -9006,6 +9006,7 @@ export default function SessionScreen() {
                 onCancel={() => setRewindState({ kind: 'idle' })}
                 onConfirm={() => void confirmRewind()}
                 state={rewindState}
+                bottomOverlayHeight={bottomOverlayHeight}
                 topOverlayHeight={topOverlayHeight}
               />
 

--- a/apps/mobile/app/sessions/[sessionId].tsx
+++ b/apps/mobile/app/sessions/[sessionId].tsx
@@ -9006,6 +9006,7 @@ export default function SessionScreen() {
                 onCancel={() => setRewindState({ kind: 'idle' })}
                 onConfirm={() => void confirmRewind()}
                 state={rewindState}
+                topOverlayHeight={topOverlayHeight}
               />
 
               {sessionOperationLayout.messageHistoryMode === 'collapsed' ? (

--- a/apps/mobile/src/__tests__/rewindPreviewLayout.test.ts
+++ b/apps/mobile/src/__tests__/rewindPreviewLayout.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest';
-import { buildRewindPreviewLayout } from '@/session/rewindPreviewLayout';
+import { buildRewindPreviewLayout, rewindPreviewMaxHeight } from '@/session/rewindPreviewLayout';
 
 describe('rewindPreviewLayout', () => {
   it('compacts file rows on iPhone SE width', () => {
@@ -44,5 +44,21 @@ describe('rewindPreviewLayout', () => {
       containerPadding: 16,
       visibleFileCount: 3,
     });
+  });
+
+  it('reserves space for fixed overlays on a short viewport', () => {
+    expect(rewindPreviewMaxHeight({
+      bottomOverlayHeight: 92,
+      screenHeight: 320,
+      topOverlayHeight: 58,
+    })).toBe(154);
+  });
+
+  it('does not produce a negative panel height when overlays consume the viewport', () => {
+    expect(rewindPreviewMaxHeight({
+      bottomOverlayHeight: 220,
+      screenHeight: 320,
+      topOverlayHeight: 120,
+    })).toBe(0);
   });
 });

--- a/apps/mobile/src/session/RewindPreviewPanel.tsx
+++ b/apps/mobile/src/session/RewindPreviewPanel.tsx
@@ -16,6 +16,7 @@ import { radius, spacing, typeScale } from '@/theme/tokens';
 interface RewindPreviewPanelProps {
   state: RewindPreviewState;
   committing?: boolean;
+  topOverlayHeight?: number;
   onCancel(): void;
   onConfirm(): void;
 }
@@ -23,6 +24,7 @@ interface RewindPreviewPanelProps {
 export function RewindPreviewPanel({
   state,
   committing,
+  topOverlayHeight = 0,
   onCancel,
   onConfirm,
 }: RewindPreviewPanelProps) {
@@ -47,6 +49,7 @@ export function RewindPreviewPanel({
         styles.container,
         {
           marginHorizontal: layout.containerMarginHorizontal,
+          marginTop: Math.max(spacing.sm, topOverlayHeight + spacing.sm),
           padding: layout.containerPadding,
         },
       ]}

--- a/apps/mobile/src/session/RewindPreviewPanel.tsx
+++ b/apps/mobile/src/session/RewindPreviewPanel.tsx
@@ -1,5 +1,6 @@
 import {
   ActivityIndicator,
+  ScrollView,
   StyleSheet,
   View,
   useWindowDimensions,
@@ -9,7 +10,7 @@ import type { TFunction } from 'i18next';
 import { Text } from '@/components/AppText';
 import { MainWindowActionGroup } from '@/components/MobilePrimitives';
 import type { RewindPreviewState } from '@/session/rewindPreview';
-import { buildRewindPreviewLayout } from '@/session/rewindPreviewLayout';
+import { buildRewindPreviewLayout, rewindPreviewMaxHeight } from '@/session/rewindPreviewLayout';
 import { fontWeight, lineHeight, useTheme, useThemedStyles, type ThemeColors } from '@/theme';
 import { radius, spacing, typeScale } from '@/theme/tokens';
 
@@ -17,6 +18,7 @@ interface RewindPreviewPanelProps {
   state: RewindPreviewState;
   committing?: boolean;
   topOverlayHeight?: number;
+  bottomOverlayHeight?: number;
   onCancel(): void;
   onConfirm(): void;
 }
@@ -25,13 +27,14 @@ export function RewindPreviewPanel({
   state,
   committing,
   topOverlayHeight = 0,
+  bottomOverlayHeight = 0,
   onCancel,
   onConfirm,
 }: RewindPreviewPanelProps) {
   const styles = useThemedStyles(makeStyles);
   const { colors } = useTheme();
   const { t } = useTranslation();
-  const { width: screenWidth } = useWindowDimensions();
+  const { height: screenHeight, width: screenWidth } = useWindowDimensions();
   if (state.kind === 'idle') return null;
 
   const canConfirm = state.kind === 'default' || state.kind === 'empty';
@@ -42,12 +45,18 @@ export function RewindPreviewPanel({
     fileCount,
     screenWidth,
   });
+  const maxHeight = rewindPreviewMaxHeight({
+    bottomOverlayHeight,
+    screenHeight,
+    topOverlayHeight,
+  });
 
   return (
     <View
       style={[
         styles.container,
         {
+          maxHeight,
           marginHorizontal: layout.containerMarginHorizontal,
           marginTop: Math.max(spacing.sm, topOverlayHeight + spacing.sm),
           padding: layout.containerPadding,
@@ -55,62 +64,68 @@ export function RewindPreviewPanel({
       ]}
       testID="rewind.panel"
     >
-      <View style={styles.header}>
-        <View style={styles.headerText}>
-          <Text style={styles.title}>{title}</Text>
-          {detail ? <Text style={styles.detail}>{detail}</Text> : null}
+      <ScrollView
+        contentContainerStyle={styles.scrollContent}
+        nestedScrollEnabled
+        showsVerticalScrollIndicator
+        style={styles.scroll}
+      >
+        <View style={styles.header}>
+          <View style={styles.headerText}>
+            <Text style={styles.title}>{title}</Text>
+            {detail ? <Text style={styles.detail}>{detail}</Text> : null}
+          </View>
+          {state.kind === 'loading' ? <ActivityIndicator color={colors.textSecondary} /> : null}
         </View>
-        {state.kind === 'loading' ? <ActivityIndicator color={colors.textSecondary} /> : null}
-      </View>
 
-      {state.kind === 'default' ? (
-        <View style={styles.fileList}>
-          {state.filesChanged.slice(0, layout.visibleFileCount).map((file) => (
-            <Text
-              key={file}
-              numberOfLines={1}
-              selectable
-              style={[styles.filePath, { minHeight: layout.fileRowMinHeight }]}
-            >
-              {file}
+        {state.kind === 'default' ? (
+          <View style={styles.fileList}>
+            {state.filesChanged.slice(0, layout.visibleFileCount).map((file) => (
+              <Text
+                key={file}
+                numberOfLines={1}
+                selectable
+                style={[styles.filePath, { minHeight: layout.fileRowMinHeight }]}
+              >
+                {file}
+              </Text>
+            ))}
+            {state.filesChanged.length > layout.visibleFileCount ? (
+              <Text style={styles.moreFiles}>{t('interaction.rewind.moreFiles', { count: state.filesChanged.length - layout.visibleFileCount })}</Text>
+            ) : null}
+            <Text style={styles.stats}>
+              {t('interaction.rewind.stats', { count: state.filesChanged.length, insertions: state.insertions, deletions: state.deletions })}
             </Text>
-          ))}
-          {state.filesChanged.length > layout.visibleFileCount ? (
-            <Text style={styles.moreFiles}>{t('interaction.rewind.moreFiles', { count: state.filesChanged.length - layout.visibleFileCount })}</Text>
-          ) : null}
-          <Text style={styles.stats}>
-            {t('interaction.rewind.stats', { count: state.filesChanged.length, insertions: state.insertions, deletions: state.deletions })}
-          </Text>
-        </View>
-      ) : null}
+          </View>
+        ) : null}
 
-      {state.kind === 'empty' && state.note ? (
-        <Text selectable style={styles.note}>{state.note}</Text>
-      ) : null}
+        {state.kind === 'empty' && state.note ? (
+          <Text selectable style={styles.note}>{state.note}</Text>
+        ) : null}
 
-      {state.kind === 'error' ? (
-        <Text selectable style={styles.errorText}>{state.errorText}</Text>
-      ) : null}
-
-      {state.kind !== 'loading' ? (
-        <MainWindowActionGroup
-          cancelAction={{
-            accessibilityLabel: state.kind === 'error' ? t('interaction.rewind.gotIt') : t('interaction.rewind.cancelAccessibility'),
-            label: state.kind === 'error' ? t('interaction.rewind.gotIt') : t('interaction.rewind.cancel'),
-            onPress: onCancel,
-            testID: state.kind === 'error' ? 'rewind.dismissButton' : 'rewind.cancelButton',
-          }}
-          primaryActions={canConfirm ? [{
-            accessibilityLabel: t('interaction.rewind.confirm'),
-            disabled: committing,
-            label: committing ? t('interaction.rewind.confirming') : t('interaction.rewind.confirm'),
-            onPress: onConfirm,
-            testID: 'rewind.confirmButton',
-            tone: 'primary',
-          }] : []}
-          testID="rewind.actions"
-        />
-      ) : null}
+        {state.kind === 'error' ? (
+          <Text selectable style={styles.errorText}>{state.errorText}</Text>
+        ) : null}
+        {state.kind !== 'loading' ? (
+          <MainWindowActionGroup
+            cancelAction={{
+              accessibilityLabel: state.kind === 'error' ? t('interaction.rewind.gotIt') : t('interaction.rewind.cancelAccessibility'),
+              label: state.kind === 'error' ? t('interaction.rewind.gotIt') : t('interaction.rewind.cancel'),
+              onPress: onCancel,
+              testID: state.kind === 'error' ? 'rewind.dismissButton' : 'rewind.cancelButton',
+            }}
+            primaryActions={canConfirm ? [{
+              accessibilityLabel: t('interaction.rewind.confirm'),
+              disabled: committing,
+              label: committing ? t('interaction.rewind.confirming') : t('interaction.rewind.confirm'),
+              onPress: onConfirm,
+              testID: 'rewind.confirmButton',
+              tone: 'primary',
+            }] : []}
+            testID="rewind.actions"
+          />
+        ) : null}
+      </ScrollView>
     </View>
   );
 }
@@ -138,8 +153,11 @@ const makeStyles = (colors: ThemeColors) => StyleSheet.create({
     gap: spacing.md,
     marginHorizontal: spacing.md,
     marginTop: spacing.sm,
+    overflow: 'hidden',
     padding: spacing.md,
   },
+  scroll: { flexShrink: 1, minHeight: 0 },
+  scrollContent: { gap: spacing.md },
   header: { alignItems: 'center', flexDirection: 'row', gap: spacing.md },
   headerText: { flex: 1, minWidth: 0 },
   title: { color: colors.textPrimary, fontSize: typeScale.body, fontWeight: fontWeight.medium },

--- a/apps/mobile/src/session/rewindPreviewLayout.ts
+++ b/apps/mobile/src/session/rewindPreviewLayout.ts
@@ -11,12 +11,20 @@ export interface RewindPreviewLayout {
   visibleFileCount: number;
 }
 
+export interface RewindPreviewViewportInput {
+  screenHeight: number;
+  topOverlayHeight?: number;
+  bottomOverlayHeight?: number;
+}
+
 const DEFAULT_SCREEN_WIDTH = 390;
+const DEFAULT_SCREEN_HEIGHT = 844;
 const COMPACT_WIDTH = 360;
 const STANDARD_SPACE = 16;
 const COMPACT_SPACE = 12;
 const STANDARD_VISIBLE_FILES = 6;
 const COMPACT_VISIBLE_FILES = 4;
+const PANEL_EDGE_GAP = 8;
 
 /** 回退预览面板布局:compact 只由屏宽决定(操作区已收敛到 MainWindowActionGroup,不再输出按钮尺寸)。 */
 export function buildRewindPreviewLayout(input: RewindPreviewLayoutInput): RewindPreviewLayout {
@@ -34,6 +42,14 @@ export function buildRewindPreviewLayout(input: RewindPreviewLayoutInput): Rewin
   };
 }
 
+/** Keeps the rewind panel inside the space between the fixed top and bottom overlays. */
+export function rewindPreviewMaxHeight(input: RewindPreviewViewportInput): number {
+  const screenHeight = normalizeDimension(input.screenHeight, DEFAULT_SCREEN_HEIGHT);
+  const topOverlayHeight = normalizeInset(input.topOverlayHeight);
+  const bottomOverlayHeight = normalizeInset(input.bottomOverlayHeight);
+  return Math.max(0, screenHeight - topOverlayHeight - bottomOverlayHeight - PANEL_EDGE_GAP * 2);
+}
+
 function normalizeCount(value: number): number {
   if (!Number.isFinite(value) || value <= 0) return 0;
   return Math.floor(value);
@@ -41,4 +57,8 @@ function normalizeCount(value: number): number {
 
 function normalizeDimension(value: number, fallback: number): number {
   return Number.isFinite(value) && value > 0 ? value : fallback;
+}
+
+function normalizeInset(value: number | undefined): number {
+  return typeof value === 'number' && Number.isFinite(value) && value > 0 ? value : 0;
 }


### PR DESCRIPTION
## 这次改了什么

### 摘要

修复 Android 手机会话页打开回退确认面板时被顶部会话栏遮挡的问题。面板现在会根据顶部覆盖层高度自动下移，标题、说明和操作按钮都保持在可视区域内。

### 变更类型

- [x] `fix` 缺陷修复
- [ ] `feat` 新功能
- [ ] `refactor` / `perf` 重构或性能优化
- [ ] `docs` / `test` / `chore` 文档、测试或工程维护
- [ ] 其他：

### 范围

- 关联 Issue / 需求：无
- 本 PR 包含：移动端回退预览面板的顶部间距适配。
- 明确不包含：回退业务协议、桌面端逻辑和原生配置。
- 用户可见变化：回退面板不再被顶部会话栏覆盖。
- 是否存在 breaking change：无

### UI 变化

- 平台：Android CN 模拟器。
- 变化：回退确认面板按顶部覆盖层高度留出间距，保留现有按钮和颜色语义。
- 引用的设计规范：`docs/design-rules/DESIGN.md` §4 Dialog & Modal、§5 Layout Principles（8px 间距体系与容器布局）、§10 Light / Dark Dual-Mode Delivery Gate。
- 深色模式沿用现有 themed 样式；本次仅调整布局，没有新增颜色或模式分支。

## 怎么验证的

### 自动验证

~~~text
pnpm test:unit:related
结果：PASS apps/mobile unit（相关测试通过）

pnpm --filter mobile run --if-present typecheck
结果：通过

pnpm --filter mobile exec vitest run src/__tests__/rewindPreviewLayout.test.ts
结果：4/4 通过

pnpm check:dco
结果：通过，提交 668a6d690 带 Signed-off-by。
~~~

### 手工验证

- 工作区：`D:/XDCindy/cindy/.cindy-worktrees/trusty-goldberg`，分支 `cindy/trusty-goldberg`。
- 启动证据：`pnpm mobile:sim:start:cn -- --no-emulator` 报告 `region=cn`、Metro `8081`，源码为 `cindy/trusty-goldberg@7ac1c4da7+4562267825`。
- 在 CN Android 模拟器 `com.xd.cindycn` 的真实登录会话中打开回退面板，用户验收通过。

### 未执行的验证

- Android 深色模式未单独目检。
- `pnpm mobile:sim:rebuild -- --region=cn` 在 Windows 环境调用 iOS 专用 `xcrun` 未执行成功；已使用 `pnpm --filter mobile android` 完成 Android 构建并安装验证。

## 风险

### 风险分类

- [x] 无已知风险
- [ ] SQLite / migration
- [ ] system prompt
- [ ] 协议兼容
- [ ] 权限 / 安全 / 用户数据
- [ ] 存量插件兼容（批准状态 / 指纹 / manifest 校验 / 安装布局 / 包格式）
- [ ] 原生层 / fingerprint / OTA
- [ ] 跨平台差异
- [ ] 其他：

### 影响与回滚

- 影响范围：仅移动端会话回退预览面板的纵向布局。
- 回滚 / 降级方式：回退本 PR 的两个移动端文件即可。

### 提交前检查

- [x] 已 review 完整 diff
- [x] 每个 commit 都带 DCO 签名
- [x] UI 改动已在 UI 变化注明设计规范
- [x] 未提交凭证、令牌或授权文件
- [x] 已确认测试结果或说明未执行原因


## 界面效果证据

- **CN Android 实机（1080×2400）**：回退面板位于会话顶部栏下方，沿用现有浅色/深色语义样式。
- **短视口回归（1080×900）**：面板高度扣除顶部栏和底部输入区；文件内容与操作区在面板内滚动，确认和取消按钮不会被底部输入区截断。
- **可复现 HTML 示意**：下面的自包含页面复现最终布局的短视口约束，滚动后可以到达两个操作按钮。

~~~html
<!doctype html>
<meta name="viewport" content="width=device-width,initial-scale=1">
<style>
  * { box-sizing: border-box; }
  body { margin: 0; background: #eef0f2; color: #383c42; font: 16px system-ui, sans-serif; }
  .viewport { height: 320px; overflow: hidden; border: 1px solid #b5b9bf; }
  .topbar { height: 58px; display: flex; align-items: center; padding: 0 16px; background: #fff; font-weight: 600; }
  .panel { max-height: 238px; margin: 8px 12px; overflow: auto; border: 1px solid #9da2a8; border-radius: 16px; padding: 12px; background: #fff; }
  .content { display: flex; flex-direction: column; gap: 12px; }
  .file { padding: 8px; border-radius: 8px; background: #eef0f2; white-space: nowrap; overflow: hidden; text-overflow: ellipsis; }
  .actions { display: grid; gap: 8px; }
  button { min-height: 44px; border: 1px solid #c4c8cd; border-radius: 24px; background: #fff; font: inherit; }
  .confirm { border-color: #383c42; background: #383c42; color: #fff; }
</style>
<div class="viewport">
  <div class="topbar">Session header</div>
  <section class="panel" aria-label="Rewind preview">
    <div class="content">
      <div><strong>Rewind preview</strong><br><small>Review the files before confirming.</small></div>
      <div class="file">apps/mobile/src/session/RewindPreviewPanel.tsx</div>
      <div class="file">apps/mobile/src/session/rewindPreviewLayout.ts</div>
      <div class="file">apps/mobile/app/sessions/[sessionId].tsx</div>
      <div class="file">another/changed/file.ts</div>
      <div class="file">more/changed/file.ts</div>
      <div class="file">sixth/changed/file.ts</div>
      <div class="actions">
        <button class="confirm">Confirm rewind</button>
        <button>Cancel</button>
      </div>
    </div>
  </section>
</div>
~~~

