### PR TITLE
fix(models): 对齐 Server 模型目录与客户端兜底

### DIFF
--- a/apps/desktop/src/main/maker-host/__tests__/activeCatalogDiscovery.test.ts
+++ b/apps/desktop/src/main/maker-host/__tests__/activeCatalogDiscovery.test.ts
@@ -152,7 +152,7 @@ describe('active-catalog discovered augment', () => {
     ]);
     expect(xai?.models.pi).not.toEqual(xai?.models['claude-code']);
     expect(xai?.models['claude-code']?.find((model) => model.id === 'xai/grok-4.6')).toMatchObject({
-      efforts: ['low', 'medium', 'high'],
+      efforts: ['low', 'medium', 'high', 'xhigh'],
       defaultEffort: 'high',
     });
     expect(xai?.models.pi?.find((model) => model.id === 'grok-4.6')).toMatchObject({
@@ -187,7 +187,7 @@ describe('active-catalog discovered augment', () => {
       defaultEffort: 'high',
     });
     expect(xai?.models['claude-code']?.find((model) => model.id === 'xai/grok-4.6')).toMatchObject({
-      efforts: ['low', 'medium', 'high'],
+      efforts: ['low', 'medium', 'high', 'xhigh'],
       defaultEffort: 'high',
     });
   });
@@ -198,9 +198,9 @@ describe('active-catalog discovered augment', () => {
       { id: 'xai/grok-4.6', efforts: ['low', 'medium', 'high'], defaultEffort: 'medium' },
     ]);
     const xai = getActiveCatalog().providers.find((provider) => provider.id === 'xai');
-    // Claude/Codex 静态梯子留给 #2601；Pi 目录已带官方 xhigh。
+    // Server Registry 和独立 Pi 目录均声明 xhigh，不被旧 discovery 降档。
     expect(xai?.models['claude-code']?.find((model) => model.id === 'xai/grok-4.6')).toMatchObject({
-      efforts: ['low', 'medium', 'high'],
+      efforts: ['low', 'medium', 'high', 'xhigh'],
       defaultEffort: 'high',
     });
     expect(xai?.models.pi?.find((model) => model.id === 'grok-4.6')).toMatchObject({
@@ -492,6 +492,8 @@ describe('anthropic 发现条目的 modelRegistry 元数据基线', () => {
       ['claude-sonnet-4-6', 'Sonnet 4.6'],
       ['claude-sonnet-4-5', 'Sonnet 4.5'],
       ['claude-haiku-4-5', 'Haiku 4.5'],
+      ['claude-fable-5-1', 'Fable 5.1'],
+      ['claude-mythos-5', 'Mythos 5'],
     ]);
     expect(anthropicList('codex')).toEqual(
       anthropicList('claude-code').map((model) => ({

--- a/apps/desktop/src/main/maker-host/__tests__/codexProxyHost.test.ts
+++ b/apps/desktop/src/main/maker-host/__tests__/codexProxyHost.test.ts
@@ -4474,6 +4474,7 @@ describe('codex proxy host', () => {
   });
 
   it.each([
+    'moonshot/kimi-k3',
     'moonshotai/kimi-k3',
     'deepseek/deepseek-v4-pro',
     'deepseek/deepseek-v4-flash',

--- a/apps/desktop/src/main/maker-host/__tests__/modelPlane.test.ts
+++ b/apps/desktop/src/main/maker-host/__tests__/modelPlane.test.ts
@@ -180,6 +180,62 @@ describe('registry presence 实体化', () => {
     expect(models('openai', 'pi').find((m) => m.id === 'chatgpt/gpt-6')).toBeUndefined();
   });
 
+  it('bundled GPT-5.4 Mini preserves Claude Fast=false without a Claude default override', () => {
+    setActiveCatalog(BUNDLED_CATALOG);
+    expect(models('openai', 'codex').find((m) => m.id === 'gpt-5.4-mini')).toMatchObject({
+      supportsFastMode: true,
+      defaultEffort: 'medium',
+    });
+    expect(models('openai', 'claude-code').find((m) => m.id === 'chatgpt/gpt-5.4-mini')).toMatchObject({
+      supportsFastMode: false,
+      efforts: ['low', 'medium', 'high', 'xhigh'],
+      defaultEffort: 'medium',
+    });
+    expect(getModelPlaneWarnings().filter((warning) => warning.modelId === 'gpt-5.4-mini')).toEqual([]);
+  });
+
+  it.each([
+    { efforts: ['low', 'medium'], expectedDefault: 'medium' },
+    { efforts: ['low', 'high'], expectedDefault: 'high' },
+    { efforts: ['low'], expectedDefault: 'low' },
+    { efforts: [], expectedDefault: null },
+  ])('bridge overlays independent fields and reconciles omitted defaults: $efforts', ({ efforts, expectedDefault }) => {
+    setActiveCatalog(baseCatalog([gpt6Entry({
+      defaultEffort: undefined,
+      supportsFastMode: true,
+      perAgent: {
+        codex: { defaultEffort: 'medium' },
+        'claude-code': { efforts, contextWindow: 123_000, supportsFastMode: false },
+      },
+    })]));
+    expect(models('openai', 'claude-code').find((m) => m.id === 'chatgpt/gpt-6')).toMatchObject({
+      contextWindow: 123_000,
+      supportsFastMode: false,
+      efforts,
+      defaultEffort: expectedDefault,
+    });
+    expect(models('openai', 'codex').find((m) => m.id === 'gpt-6')).toMatchObject({
+      contextWindow: 400_000,
+      supportsFastMode: true,
+      defaultEffort: 'medium',
+    });
+  });
+
+  it('missing defaults still cannot materialize new roots or standalone consumer aliases', () => {
+    setActiveCatalog(baseCatalog([
+      gpt6Entry({ defaultEffort: undefined }),
+      gpt6Entry({
+        id: 'openai/gpt-6[1m]',
+        defaultEffort: undefined,
+        routes: [{ providerId: 'openai', modelId: 'gpt-6', agents: ['claude-code'] }],
+      }),
+    ]));
+    expect(models('openai', 'codex')).toEqual([]);
+    expect(models('openai', 'claude-code')).toEqual([]);
+    expect(getModelPlaneWarnings()).toHaveLength(2);
+    expect(getModelPlaneWarnings().every((warning) => warning.reason.includes('defaultEffort'))).toBe(true);
+  });
+
   it('bridge preserves max and ultra when declared by the target consumer', () => {
     setActiveCatalog(baseCatalog([gpt6Entry({
       efforts: ['low', 'medium', 'high', 'xhigh', 'max', 'ultra'],

--- a/apps/desktop/src/main/maker-host/__tests__/modelPlane.test.ts
+++ b/apps/desktop/src/main/maker-host/__tests__/modelPlane.test.ts
@@ -98,15 +98,19 @@ describe('registry presence 实体化', () => {
   it('a loaded legacy Catalog cannot replace the local Pi membership baseline', () => {
     const expected = BUNDLED_CATALOG.providers.find((provider) => provider.id === 'xai');
     if (!expected) throw new Error('bundled catalog missing xai');
-    const generatedCatalog = structuredClone(BUNDLED_CATALOG);
+    // Root models consume Registry; Pi retains its independent native baseline.
+    const generatedCatalog = baseCatalog([grokEntry()]);
     const generatedXai = generatedCatalog.providers.find((provider) => provider.id === 'xai');
     if (!generatedXai) throw new Error('generated fixture missing xai');
     generatedXai.models['claude-code'] = [];
     generatedXai.models.codex = [];
     generatedXai.models.pi = [];
     setActiveCatalog(generatedCatalog);
-    expect(models('xai', 'claude-code')).toEqual(expected.models['claude-code']);
-    expect(models('xai', 'codex')).toEqual(expected.models.codex);
+    for (const agent of ['claude-code', 'codex'] as const) {
+      expect(models('xai', agent)).toEqual([
+        expect.objectContaining({ id: 'xai/grok-test', contextWindow: 500_000 }),
+      ]);
+    }
     expect(models('xai', 'pi')).toEqual(expected.models.pi);
   });
 

--- a/apps/desktop/src/main/maker-host/__tests__/providerCatalogRealmReload.test.ts
+++ b/apps/desktop/src/main/maker-host/__tests__/providerCatalogRealmReload.test.ts
@@ -444,6 +444,7 @@ describe('provider catalog realm reload', () => {
       (entry) => entry.id === 'openai/gpt-5.6-sol',
     );
     if (!currentEntry) throw new Error('expected gpt-5.6-sol Registry entry');
+    current.modelRegistry!.models = [currentEntry];
     currentEntry.perAgent = { ...currentEntry.perAgent, codex: { efforts: ['high'] } };
     setActiveCatalog(current);
 
@@ -464,6 +465,7 @@ describe('provider catalog realm reload', () => {
       (entry) => entry.id === 'openai/gpt-5.6-sol',
     );
     if (!nextEntry) throw new Error('expected gpt-5.6-sol Registry entry');
+    next.modelRegistry!.models = [nextEntry];
     nextEntry.perAgent = {
       ...nextEntry.perAgent,
       codex: { efforts: ['high', 'max', 'ultra'], defaultEffort: 'ultra' },
@@ -496,6 +498,7 @@ describe('provider catalog realm reload', () => {
       (candidate) => candidate.id === 'openai/gpt-5.6-sol',
     );
     if (!entry) throw new Error('expected gpt-5.6-sol Registry entry');
+    current.modelRegistry!.models = [entry];
     entry.perAgent = {
       ...entry.perAgent,
       codex: { efforts: ['minimal', 'max'], defaultEffort: 'max' },

--- a/apps/desktop/src/main/maker-host/codex-proxy-host.ts
+++ b/apps/desktop/src/main/maker-host/codex-proxy-host.ts
@@ -1794,6 +1794,7 @@ function sanitizeByteDanceSeedTools(body: Record<string, unknown>): Record<strin
 }
 
 const STRICT_GATEWAY_TOOL_HISTORY_MODELS = new Set([
+  'moonshot/kimi-k3',
   'moonshotai/kimi-k3',
   'deepseek/deepseek-v4-pro',
   'deepseek/deepseek-v4-flash',

--- a/apps/desktop/src/main/maker-host/model-plane/modelPlanePolicy.ts
+++ b/apps/desktop/src/main/maker-host/model-plane/modelPlanePolicy.ts
@@ -403,20 +403,8 @@ export function planRegistryRoots(registry: ModelRegistry | undefined): ModelPla
           });
           continue;
         }
-        if (
-          fields.efforts !== undefined &&
-          fields.efforts.length > 0 &&
-          (fields.defaultEffort == null || !fields.efforts.includes(fields.defaultEffort))
-        ) {
-          plan.warnings.push({
-            source: 'registry',
-            providerId: route.providerId,
-            agent: bridgeAgent,
-            modelId: route.modelId,
-            reason: 'bridge consumer has efforts but no self-consistent defaultEffort',
-          });
-          continue;
-        }
+        // 已存在的 root 投影允许缺省默认档；合并时按 root overlay 的同一规则收敛。
+        // 不可套用新实体的完整性门禁，连带丢掉 Fast 等独立的显式字段。
         const key = consumerPlanKey(route.providerId, bridgeAgent);
         let overlays = plan.consumers.get(key);
         if (!overlays) {
@@ -457,7 +445,27 @@ export function applyRegistryConsumerOverlay(
 ): CatalogModel {
   const overlay = plan.consumers.get(consumerPlanKey(providerId, consumer))?.get(rootModelId);
   if (!overlay) return model;
-  return { ...model, ...overlay };
+  return applyExistingRegistryOverlay(model, overlay);
+}
+
+/** 已存在实体的字段覆盖：保留有效默认档，能力变化时复用既有确定性回退。 */
+function applyExistingRegistryOverlay(
+  model: CatalogModel,
+  overlay: Partial<CatalogModel>,
+): CatalogModel {
+  const overlaid = { ...model, ...overlay };
+  // 新实体仍由 toMaterializedModel 要求显式自洽；这里只处理已有 root/bridge。
+  if (overlay.efforts !== undefined) {
+    const { efforts, defaultEffort } = overlaid;
+    if (efforts.length === 0) return { ...overlaid, defaultEffort: null };
+    if (defaultEffort === null || !efforts.includes(defaultEffort)) {
+      return {
+        ...overlaid,
+        defaultEffort: efforts.includes('high') ? 'high' : efforts[efforts.length - 1]!,
+      };
+    }
+  }
+  return overlaid;
 }
 
 /** registry 显式字段 → 已存在条目的 overlay(在场即胜出,不在场不触碰)。 */
@@ -542,20 +550,7 @@ export function applyRootRegistryPlan(
   const existingIds = new Set(models.map((m) => m.id));
   const out = models.map((m) => {
     const overlay = rootPlan.overlays.get(m.id);
-    let overlaid = overlay ? { ...m, ...overlay } : m;
-    // 只有已有 discovery/静态证据的条目允许确定性修复缺失默认档。纯远端新实体
-    // 仍由 toMaterializedModel 严格要求显式自洽，不在这里猜。
-    if (overlay?.efforts !== undefined) {
-      const efforts = overlaid.efforts;
-      const defaultEffort = overlaid.defaultEffort;
-      if (efforts.length === 0) overlaid = { ...overlaid, defaultEffort: null };
-      else if (defaultEffort === null || !efforts.includes(defaultEffort)) {
-        overlaid = {
-          ...overlaid,
-          defaultEffort: efforts.includes('high') ? 'high' : efforts[efforts.length - 1]!,
-        };
-      }
-    }
+    const overlaid = overlay ? applyExistingRegistryOverlay(m, overlay) : m;
     return rootPlan.retired.has(m.id) ? { ...overlaid, status: 'retired' as const } : overlaid;
   });
   for (const addition of rootPlan.additions) {

--- a/apps/desktop/src/main/usage/__tests__/modelPricing.test.ts
+++ b/apps/desktop/src/main/usage/__tests__/modelPricing.test.ts
@@ -541,8 +541,8 @@ describe('reference pricing helpers', () => {
       outputPerMtok: 10,
     });
     expect(getClaudeSubscriptionValuePrice('claude-sonnet-5', null, '2026-09-01')).toMatchObject({
-      inputPerMtok: 3,
-      outputPerMtok: 15,
+      inputPerMtok: 2,
+      outputPerMtok: 10,
     });
     expect(getClaudeSubscriptionValuePrice('claude-sonnet-5', null, '2026-06-29')).toBeUndefined();
     expect(getClaudeSubscriptionValuePrice('sonnet', null, '2026-03-01')).toMatchObject({
@@ -660,15 +660,15 @@ describe('reference pricing helpers', () => {
     ).toMatchObject({ providerId: 'anthropic', inputPerMtok: 2, outputPerMtok: 10 });
     expect(
       getCodexProviderSubscriptionValuePrice('anthropic', 'claude-sonnet-5', null, '2026-09-01'),
-    ).toMatchObject({ inputPerMtok: 3, outputPerMtok: 15 });
+    ).toMatchObject({ inputPerMtok: 2, outputPerMtok: 10 });
   });
 
   it('re-merges sparse price overrides against the reference effective at the queried date', () => {
     const registry = getActiveCatalog().modelRegistry;
     const target = {
-      providerId: 'anthropic',
-      agent: 'claude-code',
-      modelId: 'claude-sonnet-5',
+      providerId: 'openai',
+      agent: 'codex',
+      modelId: 'gpt-5.6-sol',
     } as const;
     const currentReference = providerReferencePriceQuote(
       target.providerId,
@@ -692,20 +692,20 @@ describe('reference pricing helpers', () => {
       );
       const pricing = applyModelPriceOverrides({}, registry);
       expect(
-        getClaudeSubscriptionValuePrice('claude-sonnet-5', pricing, '2026-08-31'),
-      ).toMatchObject({ source: 'user-override', inputPerMtok: 2.5, outputPerMtok: 10 });
+        getCodexSubscriptionValuePrice('gpt-5.6-sol', pricing, '2026-08-20'),
+      ).toMatchObject({ source: 'user-override', inputPerMtok: 2.5, outputPerMtok: 30 });
       expect(
-        getClaudeSubscriptionValuePrice('claude-sonnet-5', pricing, '2026-09-01'),
-      ).toMatchObject({ source: 'user-override', inputPerMtok: 2.5, outputPerMtok: 15 });
-      expect(getClaudeSubscriptionValuePrice('claude-sonnet-5', pricing)).toMatchObject({
+        getCodexSubscriptionValuePrice('gpt-5.6-sol', pricing, '2026-08-21'),
+      ).toMatchObject({ source: 'user-override', inputPerMtok: 2.5, outputPerMtok: 20 });
+      expect(getCodexSubscriptionValuePrice('gpt-5.6-sol', pricing)).toMatchObject({
         source: 'user-override',
         inputPerMtok: 2.5,
       });
       // 批量路径:传入一次性快照时结果一致,不逐行重读覆盖文件。
       const snapshot = readModelPriceOverridesSnapshot();
       expect(
-        getClaudeSubscriptionValuePrice('claude-sonnet-5', pricing, '2026-08-31', snapshot),
-      ).toMatchObject({ source: 'user-override', inputPerMtok: 2.5, outputPerMtok: 10 });
+        getCodexSubscriptionValuePrice('gpt-5.6-sol', pricing, '2026-08-20', snapshot),
+      ).toMatchObject({ source: 'user-override', inputPerMtok: 2.5, outputPerMtok: 30 });
     } finally {
       clearModelPriceOverride(target);
     }

--- a/docs/dev-rules/model-catalog-maintenance.md
+++ b/docs/dev-rules/model-catalog-maintenance.md
@@ -9,13 +9,13 @@
 
 ## 1. 先找数据归属
 
-| 内容 | 应维护的位置 | 客户端职责 |
-| --- | --- | --- |
+| 内容                                                             | 应维护的位置                                                                                                               | 客户端职责                                                                                   |
+| ---------------------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------- | -------------------------------------------------------------------------------------------- |
 | 统一模型目录中的名称、窗口、最大输出、推理档位、参考价及默认标记 | `cindy-server` 的 `model-access-server/catalog/providers.json`；若部署配置了 `MODEL_CATALOG_URL`，还需核对那份远程完整快照 | 同步 `packages/model-providers/catalog/model-registry.json` 作为内置兜底，正确消费实际下发值 |
-| Gateway 的实际可用性、路由能力与实价 | Gateway／Server 对应控制面 | 保留实际路由与价格来源，不用 registry 参考价覆盖 Gateway 实价 |
-| 请求协议、SDK 字段兼容、能力透传与 token 计量 | 本仓对应 harness／bridge／host | 根据具体通道能力适配，测试最终请求与用量 |
-| Pi 原生模型元数据 | Pi 上游与本仓 `tools/pi/sync-model-catalog.mjs`、`catalog/pi-model-catalog.json` | 保留上游原生字段，区分公共 API 与订阅协议，遵守 `pi-harness.md` |
-| 旧任务的上下文占比 | 客户端历史读取与展示路径 | 正确区分历史快照、当前目录与运行数据；不能用显示特判掩盖源目录错误 |
+| Gateway 的实际可用性、路由能力与实价                             | Gateway／Server 对应控制面                                                                                                 | 保留实际路由与价格来源，不用 registry 参考价覆盖 Gateway 实价                                |
+| 请求协议、SDK 字段兼容、能力透传与 token 计量                    | 本仓对应 harness／bridge／host                                                                                             | 根据具体通道能力适配，测试最终请求与用量                                                     |
+| Pi 原生模型元数据                                                | Pi 上游与本仓 `tools/pi/sync-model-catalog.mjs`、`catalog/pi-model-catalog.json`                                           | 保留上游原生字段，区分公共 API 与订阅协议，遵守 `pi-harness.md`                              |
+| 旧任务的上下文占比                                               | 客户端历史读取与展示路径                                                                                                   | 正确区分历史快照、当前目录与运行数据；不能用显示特判掩盖源目录错误                           |
 
 同一模型在公共 API、订阅、Gateway，以及不同 Agent 下的能力可能不同。先列出实际
 `provider + agent + model` 路由，再判断哪些字段共用、哪些需要 `perAgent` 或独立条目。
@@ -55,6 +55,38 @@
 5. **按运行结果验收**：确认部署后公共接口已返回目标条目，客户端实际接受目标 revision，
    再验证选择模型、请求参数和新旧任务显示。只跑本地 fixture、只成功启动登录页、或
    只通过 CI 时，明确记录尚未完成的运行验收，不宣称线上支持已闭环。
+
+### 同步内置兜底时的具体操作
+
+先完成 Server 的目录修正，再把其 `modelRegistry` 整体同步到
+`packages/model-providers/catalog/model-registry.json`，保留相同的 `updatedAt` 和内容。
+在客户端仓执行以下命令，参数指向已经审阅的 Server worktree 快照：
+
+```sh
+node --input-type=module - /path/to/cindy-server/model-access-server/catalog/providers.json <<'JS'
+import { readFileSync, writeFileSync } from 'node:fs';
+const { modelRegistry } = JSON.parse(readFileSync(process.argv[2], 'utf8'));
+if (!modelRegistry?.updatedAt || !Array.isArray(modelRegistry.models)) {
+  throw new Error('Server snapshot has no modelRegistry');
+}
+writeFileSync('packages/model-providers/catalog/model-registry.json',
+  JSON.stringify(modelRegistry, null, 2) + '\n');
+JS
+```
+
+不要把 Server 的整份 `providers.json` 覆盖到客户端：其中 providers、presets 与 Pi
+运行时配置各有消费契约。同步后核对两份 registry 的解析结果完全相等，并检查原有
+直连 route 和历史价区间是否丢失。默认模型选择器及用户显式设置不随同步迁移；若离线
+兜底中的默认档与当前 Server 已发布值不同，应在交付说明中逐项披露对齐结果。
+
+2026-09-05 对齐发现的典型差异包括：OpenAI 订阅与 XD 路由窗口混用、Sonnet 5 已取消
+的涨价仍留在旧兜底、Opus Fast 缓存价缺项、Grok 长输入分档过时，以及 DeepSeek
+直连参考价 route 缺失。此类修正先落 Server，再同步兜底，不能再维护两份独立数字。
+既有 GPT-5.x 公共 API 长输入参考价仍用于历史／显式长窗口估值，不表示订阅默认窗口
+应扩大；Astra 当前订阅参考价只覆盖 272K，超出仍返回未知。未核实的历史价格不补猜。
+
+Pi 的原生目录和请求兼容仍留在客户端。删除临时补项前，必须验证随包 Pi 已原生支持
+相同模型、协议及参数；仅 Server 新增了该模型，不足以证明可以删除兼容代码。
 
 ## 4. 上下文显示错误的排查顺序
 

--- a/packages/model-providers/catalog/model-registry.json
+++ b/packages/model-providers/catalog/model-registry.json
@@ -1,6 +1,6 @@
 {
-  "schemaVersion": 1,
-  "updatedAt": "2026-09-04T21:38:48.000Z",
+  "schemaVersion": 2,
+  "updatedAt": "2026-09-05T05:54:12.833Z",
   "models": [
     {
       "id": "openai/gpt-5.6-sol",
@@ -8,19 +8,16 @@
       "status": "active",
       "group": "gpt",
       "description": "GPT-5.6-Sol for coding tasks",
-      "contextWindow": 1050000,
+      "contextWindow": 272000,
       "maxOutputTokens": 128000,
       "efforts": ["low", "medium", "high", "xhigh", "max"],
-      "defaultEffort": "high",
+      "defaultEffort": "medium",
       "sortOrder": 18,
       "supportsFastMode": true,
       "perAgent": {
-        "claude-code": {
-          "supportsFastMode": false
-        },
         "codex": {
-          "contextWindow": 372000,
-          "efforts": ["low", "medium", "high", "xhigh", "max", "ultra"]
+          "efforts": ["low", "medium", "high", "xhigh", "max", "ultra"],
+          "defaultEffort": "medium"
         }
       },
       "routes": [
@@ -38,6 +35,7 @@
               "cacheWritePerMtok": 6.25,
               "maxInputTokens": 272001,
               "effectiveFrom": "2026-07-09",
+              "effectiveUntil": "2026-08-21",
               "source": {
                 "kind": "provider-official",
                 "url": "https://developers.openai.com/api/docs/models/gpt-5.6-sol",
@@ -53,14 +51,154 @@
               "cacheWritePerMtok": 12.5,
               "minInputTokens": 272001,
               "effectiveFrom": "2026-07-09",
+              "effectiveUntil": "2026-08-21",
               "source": {
                 "kind": "provider-official",
                 "url": "https://developers.openai.com/api/docs/models/gpt-5.6-sol",
                 "verifiedAt": "2026-08-01"
               }
+            },
+            {
+              "currency": "USD",
+              "variant": "standard",
+              "inputPerMtok": 4,
+              "outputPerMtok": 20,
+              "cacheReadPerMtok": 0.4,
+              "cacheWritePerMtok": 5,
+              "maxInputTokens": 272001,
+              "effectiveFrom": "2026-08-21",
+              "source": {
+                "kind": "provider-official",
+                "url": "https://developers.openai.com/api/docs/models/gpt-5.6-sol",
+                "verifiedAt": "2026-08-28"
+              }
+            },
+            {
+              "currency": "USD",
+              "variant": "standard",
+              "inputPerMtok": 8,
+              "outputPerMtok": 30,
+              "cacheReadPerMtok": 0.8,
+              "cacheWritePerMtok": 10,
+              "minInputTokens": 272001,
+              "effectiveFrom": "2026-08-21",
+              "source": {
+                "kind": "provider-official",
+                "url": "https://developers.openai.com/api/docs/models/gpt-5.6-sol",
+                "verifiedAt": "2026-08-28"
+              }
             }
           ]
+        }
+      ]
+    },
+    {
+      "id": "openai/gpt-5.6-sol[1m]",
+      "name": "GPT-5.6-Sol (1M · Higher usage)",
+      "status": "active",
+      "group": "gpt",
+      "description": "Explicit 1M context opt-in; inputs above 272K use higher long-context rates for the entire request",
+      "contextWindow": 1000000,
+      "maxOutputTokens": 128000,
+      "efforts": ["low", "medium", "high", "xhigh"],
+      "defaultEffort": "medium",
+      "sortOrder": 18,
+      "supportsFastMode": true,
+      "routes": [
+        {
+          "providerId": "openai",
+          "modelId": "gpt-5.6-sol",
+          "agents": ["claude-code"],
+          "referencePrices": [
+            {
+              "currency": "USD",
+              "variant": "standard",
+              "inputPerMtok": 5,
+              "outputPerMtok": 30,
+              "cacheReadPerMtok": 0.5,
+              "cacheWritePerMtok": 6.25,
+              "maxInputTokens": 272001,
+              "effectiveFrom": "2026-07-09",
+              "effectiveUntil": "2026-08-21",
+              "source": {
+                "kind": "provider-official",
+                "url": "https://developers.openai.com/api/docs/models/gpt-5.6-sol",
+                "verifiedAt": "2026-08-01"
+              }
+            },
+            {
+              "currency": "USD",
+              "variant": "standard",
+              "inputPerMtok": 10,
+              "outputPerMtok": 45,
+              "cacheReadPerMtok": 1,
+              "cacheWritePerMtok": 12.5,
+              "minInputTokens": 272001,
+              "effectiveFrom": "2026-07-09",
+              "effectiveUntil": "2026-08-21",
+              "source": {
+                "kind": "provider-official",
+                "url": "https://developers.openai.com/api/docs/models/gpt-5.6-sol",
+                "verifiedAt": "2026-08-01"
+              }
+            },
+            {
+              "currency": "USD",
+              "variant": "standard",
+              "inputPerMtok": 4,
+              "outputPerMtok": 20,
+              "cacheReadPerMtok": 0.4,
+              "cacheWritePerMtok": 5,
+              "maxInputTokens": 272001,
+              "effectiveFrom": "2026-08-21",
+              "source": {
+                "kind": "provider-official",
+                "url": "https://developers.openai.com/api/docs/models/gpt-5.6-sol",
+                "verifiedAt": "2026-08-28"
+              }
+            },
+            {
+              "currency": "USD",
+              "variant": "standard",
+              "inputPerMtok": 8,
+              "outputPerMtok": 30,
+              "cacheReadPerMtok": 0.8,
+              "cacheWritePerMtok": 10,
+              "minInputTokens": 272001,
+              "effectiveFrom": "2026-08-21",
+              "source": {
+                "kind": "provider-official",
+                "url": "https://developers.openai.com/api/docs/models/gpt-5.6-sol",
+                "verifiedAt": "2026-08-28"
+              }
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "xd/gpt-5.6-sol",
+      "name": "GPT-5.6-Sol",
+      "status": "active",
+      "group": "gpt",
+      "description": "GPT-5.6-Sol for coding tasks",
+      "contextWindow": 1050000,
+      "maxOutputTokens": 128000,
+      "efforts": ["low", "medium", "high", "xhigh", "max"],
+      "defaultEffort": "medium",
+      "sortOrder": 18,
+      "supportsFastMode": true,
+      "perAgent": {
+        "claude-code": {
+          "supportsFastMode": false
         },
+        "codex": {
+          "contextWindow": 272000,
+          "efforts": ["low", "medium", "high", "xhigh", "max", "ultra"],
+          "defaultEffort": "medium"
+        }
+      },
+      "routes": [
         {
           "providerId": "xd",
           "modelId": "gpt-5.6-sol",
@@ -74,19 +212,16 @@
       "status": "active",
       "group": "gpt",
       "description": "GPT-5.6-Terra for coding tasks",
-      "contextWindow": 1050000,
+      "contextWindow": 272000,
       "maxOutputTokens": 128000,
       "efforts": ["low", "medium", "high", "xhigh", "max"],
-      "defaultEffort": "high",
+      "defaultEffort": "medium",
       "sortOrder": 19,
       "supportsFastMode": true,
       "perAgent": {
-        "claude-code": {
-          "supportsFastMode": false
-        },
         "codex": {
-          "contextWindow": 372000,
-          "efforts": ["low", "medium", "high", "xhigh", "max", "ultra"]
+          "efforts": ["low", "medium", "high", "xhigh", "max", "ultra"],
+          "defaultEffort": "medium"
         }
       },
       "routes": [
@@ -104,10 +239,11 @@
               "cacheWritePerMtok": 3.125,
               "maxInputTokens": 272001,
               "effectiveFrom": "2026-07-09",
+              "effectiveUntil": "2026-07-30",
               "source": {
                 "kind": "provider-official",
                 "url": "https://developers.openai.com/api/docs/models/gpt-5.6-terra",
-                "verifiedAt": "2026-08-01"
+                "verifiedAt": "2026-08-07"
               }
             },
             {
@@ -119,14 +255,70 @@
               "cacheWritePerMtok": 6.25,
               "minInputTokens": 272001,
               "effectiveFrom": "2026-07-09",
+              "effectiveUntil": "2026-07-30",
               "source": {
                 "kind": "provider-official",
                 "url": "https://developers.openai.com/api/docs/models/gpt-5.6-terra",
-                "verifiedAt": "2026-08-01"
+                "verifiedAt": "2026-08-07"
+              }
+            },
+            {
+              "currency": "USD",
+              "variant": "standard",
+              "inputPerMtok": 2,
+              "outputPerMtok": 12,
+              "cacheReadPerMtok": 0.2,
+              "cacheWritePerMtok": 2.5,
+              "maxInputTokens": 272001,
+              "effectiveFrom": "2026-07-30",
+              "source": {
+                "kind": "provider-official",
+                "url": "https://developers.openai.com/api/docs/models/gpt-5.6-terra",
+                "verifiedAt": "2026-08-07"
+              }
+            },
+            {
+              "currency": "USD",
+              "variant": "standard",
+              "inputPerMtok": 4,
+              "outputPerMtok": 18,
+              "cacheReadPerMtok": 0.4,
+              "cacheWritePerMtok": 5,
+              "minInputTokens": 272001,
+              "effectiveFrom": "2026-07-30",
+              "source": {
+                "kind": "provider-official",
+                "url": "https://developers.openai.com/api/docs/models/gpt-5.6-terra",
+                "verifiedAt": "2026-08-07"
               }
             }
           ]
+        }
+      ]
+    },
+    {
+      "id": "xd/gpt-5.6-terra",
+      "name": "GPT-5.6-Terra",
+      "status": "active",
+      "group": "gpt",
+      "description": "GPT-5.6-Terra for coding tasks",
+      "contextWindow": 1050000,
+      "maxOutputTokens": 128000,
+      "efforts": ["low", "medium", "high", "xhigh", "max"],
+      "defaultEffort": "medium",
+      "sortOrder": 19,
+      "supportsFastMode": true,
+      "perAgent": {
+        "claude-code": {
+          "supportsFastMode": false
         },
+        "codex": {
+          "contextWindow": 272000,
+          "efforts": ["low", "medium", "high", "xhigh", "max", "ultra"],
+          "defaultEffort": "medium"
+        }
+      },
+      "routes": [
         {
           "providerId": "xd",
           "modelId": "gpt-5.6-terra",
@@ -139,10 +331,10 @@
       "name": "GPT-5.6-Luna",
       "status": "active",
       "group": "gpt",
-      "contextWindow": 1050000,
+      "contextWindow": 272000,
       "maxOutputTokens": 128000,
       "efforts": ["low", "medium", "high", "xhigh", "max"],
-      "defaultEffort": "high",
+      "defaultEffort": "medium",
       "sortOrder": 17,
       "routes": [
         {
@@ -159,10 +351,11 @@
               "cacheWritePerMtok": 1.25,
               "maxInputTokens": 272001,
               "effectiveFrom": "2026-07-09",
+              "effectiveUntil": "2026-07-30",
               "source": {
                 "kind": "provider-official",
                 "url": "https://developers.openai.com/api/docs/models/gpt-5.6-luna",
-                "verifiedAt": "2026-08-01"
+                "verifiedAt": "2026-08-07"
               }
             },
             {
@@ -174,14 +367,63 @@
               "cacheWritePerMtok": 2.5,
               "minInputTokens": 272001,
               "effectiveFrom": "2026-07-09",
+              "effectiveUntil": "2026-07-30",
               "source": {
                 "kind": "provider-official",
                 "url": "https://developers.openai.com/api/docs/models/gpt-5.6-luna",
-                "verifiedAt": "2026-08-01"
+                "verifiedAt": "2026-08-07"
+              }
+            },
+            {
+              "currency": "USD",
+              "variant": "standard",
+              "inputPerMtok": 0.2,
+              "outputPerMtok": 1.2,
+              "cacheReadPerMtok": 0.02,
+              "cacheWritePerMtok": 0.25,
+              "maxInputTokens": 272001,
+              "effectiveFrom": "2026-07-30",
+              "source": {
+                "kind": "provider-official",
+                "url": "https://developers.openai.com/api/docs/models/gpt-5.6-luna",
+                "verifiedAt": "2026-08-07"
+              }
+            },
+            {
+              "currency": "USD",
+              "variant": "standard",
+              "inputPerMtok": 0.4,
+              "outputPerMtok": 1.8,
+              "cacheReadPerMtok": 0.04,
+              "cacheWritePerMtok": 0.5,
+              "minInputTokens": 272001,
+              "effectiveFrom": "2026-07-30",
+              "source": {
+                "kind": "provider-official",
+                "url": "https://developers.openai.com/api/docs/models/gpt-5.6-luna",
+                "verifiedAt": "2026-08-07"
               }
             }
           ]
-        },
+        }
+      ]
+    },
+    {
+      "id": "xd/gpt-5.6-luna",
+      "name": "GPT-5.6-Luna",
+      "status": "active",
+      "group": "gpt",
+      "contextWindow": 1050000,
+      "maxOutputTokens": 128000,
+      "efforts": ["low", "medium", "high", "xhigh", "max"],
+      "defaultEffort": "medium",
+      "sortOrder": 17,
+      "perAgent": {
+        "codex": {
+          "contextWindow": 272000
+        }
+      },
+      "routes": [
         {
           "providerId": "xd",
           "modelId": "gpt-5.6-luna",
@@ -195,18 +437,14 @@
       "status": "active",
       "group": "gpt",
       "description": "OpenAI Codex (GPT-5.5) for coding tasks",
-      "contextWindow": 1050000,
+      "contextWindow": 272000,
       "maxOutputTokens": 128000,
       "efforts": ["low", "medium", "high", "xhigh"],
-      "defaultEffort": "high",
+      "defaultEffort": "medium",
       "sortOrder": 20,
       "supportsFastMode": true,
       "defaultEnabled": false,
       "perAgent": {
-        "claude-code": {
-          "contextWindow": 1050000,
-          "supportsFastMode": false
-        },
         "codex": {
           "contextWindow": 272000
         }
@@ -246,7 +484,31 @@
               }
             }
           ]
+        }
+      ]
+    },
+    {
+      "id": "xd/gpt-5.5",
+      "name": "GPT-5.5",
+      "status": "active",
+      "group": "gpt",
+      "description": "GPT-5.5 for coding tasks",
+      "contextWindow": 1050000,
+      "maxOutputTokens": 128000,
+      "efforts": ["low", "medium", "high", "xhigh"],
+      "defaultEffort": "medium",
+      "sortOrder": 20,
+      "supportsFastMode": true,
+      "defaultEnabled": false,
+      "perAgent": {
+        "claude-code": {
+          "supportsFastMode": false
         },
+        "codex": {
+          "contextWindow": 272000
+        }
+      },
+      "routes": [
         {
           "providerId": "xd",
           "modelId": "gpt-5.5",
@@ -260,16 +522,16 @@
       "status": "active",
       "group": "gpt",
       "description": "OpenAI Codex (GPT-5.4) for coding tasks",
-      "contextWindow": 1050000,
+      "contextWindow": 272000,
       "maxOutputTokens": 128000,
       "efforts": ["low", "medium", "high", "xhigh"],
-      "defaultEffort": "high",
       "sortOrder": 21,
       "supportsFastMode": true,
       "defaultEnabled": false,
       "perAgent": {
-        "claude-code": {
-          "supportsFastMode": false
+        "codex": {
+          "contextWindow": 272000,
+          "defaultEffort": "medium"
         }
       },
       "routes": [
@@ -307,7 +569,31 @@
               }
             }
           ]
+        }
+      ]
+    },
+    {
+      "id": "xd/gpt-5.4",
+      "name": "GPT-5.4",
+      "status": "active",
+      "group": "gpt",
+      "description": "GPT-5.4 for coding tasks",
+      "contextWindow": 1050000,
+      "maxOutputTokens": 128000,
+      "efforts": ["low", "medium", "high", "xhigh"],
+      "sortOrder": 21,
+      "supportsFastMode": true,
+      "defaultEnabled": false,
+      "perAgent": {
+        "claude-code": {
+          "supportsFastMode": false
         },
+        "codex": {
+          "contextWindow": 272000,
+          "defaultEffort": "medium"
+        }
+      },
+      "routes": [
         {
           "providerId": "xd",
           "modelId": "gpt-5.4",
@@ -321,16 +607,19 @@
       "status": "active",
       "group": "gpt",
       "description": "Faster, lighter Codex variant — speed-optimized for quick edits",
-      "contextWindow": 400000,
+      "contextWindow": 272000,
       "maxOutputTokens": 128000,
       "efforts": ["low", "medium", "high", "xhigh"],
-      "defaultEffort": "high",
       "sortOrder": 22,
       "supportsFastMode": true,
       "defaultEnabled": false,
       "perAgent": {
         "claude-code": {
           "supportsFastMode": false
+        },
+        "codex": {
+          "contextWindow": 272000,
+          "defaultEffort": "medium"
         }
       },
       "routes": [
@@ -353,10 +642,163 @@
               }
             }
           ]
+        }
+      ]
+    },
+    {
+      "id": "xd/gpt-5.4-mini",
+      "name": "GPT-5.4-Mini",
+      "status": "active",
+      "group": "gpt",
+      "description": "GPT-5.4-Mini for coding tasks",
+      "contextWindow": 400000,
+      "maxOutputTokens": 128000,
+      "efforts": ["low", "medium", "high", "xhigh"],
+      "sortOrder": 22,
+      "supportsFastMode": true,
+      "defaultEnabled": false,
+      "perAgent": {
+        "claude-code": {
+          "supportsFastMode": false
         },
+        "codex": {
+          "contextWindow": 272000,
+          "defaultEffort": "medium"
+        }
+      },
+      "routes": [
         {
           "providerId": "xd",
           "modelId": "gpt-5.4-mini",
+          "agents": ["claude-code", "codex"]
+        }
+      ]
+    },
+    {
+      "id": "openai/gpt-5.4-pro",
+      "name": "GPT-5.4 Pro",
+      "status": "active",
+      "group": "gpt",
+      "description": "OpenAI GPT-5.4 Pro for demanding reasoning tasks",
+      "contextWindow": 1050000,
+      "maxOutputTokens": 128000,
+      "sortOrder": 23,
+      "defaultEnabled": false,
+      "routes": [
+        {
+          "providerId": "openai",
+          "modelId": "gpt-5.4-pro",
+          "agents": ["claude-code", "codex"]
+        }
+      ]
+    },
+    {
+      "id": "openai/gpt-5.5-pro",
+      "name": "GPT-5.5 Pro",
+      "status": "active",
+      "group": "gpt",
+      "description": "OpenAI GPT-5.5 Pro for precise, high-quality reasoning",
+      "contextWindow": 1050000,
+      "maxOutputTokens": 128000,
+      "sortOrder": 24,
+      "defaultEnabled": false,
+      "routes": [
+        {
+          "providerId": "openai",
+          "modelId": "gpt-5.5-pro",
+          "agents": ["claude-code", "codex"]
+        }
+      ]
+    },
+    {
+      "id": "openai/gpt-5.6-cyber",
+      "name": "GPT-5.6 Cyber",
+      "status": "active",
+      "group": "gpt",
+      "description": "OpenAI cyber security reasoning model; access requires approval",
+      "contextWindow": 400000,
+      "maxOutputTokens": 128000,
+      "sortOrder": 25,
+      "defaultEnabled": false,
+      "routes": [
+        {
+          "providerId": "openai",
+          "modelId": "gpt-5.6-cyber",
+          "agents": ["claude-code", "codex"]
+        }
+      ]
+    },
+    {
+      "id": "openai/gpt-6-astra",
+      "name": "GPT-6 Astra",
+      "status": "active",
+      "group": "gpt",
+      "description": "OpenAI GPT-6 Astra for complex reasoning, coding, computer use, research, and document creation",
+      "contextWindow": 272000,
+      "maxOutputTokens": 128000,
+      "efforts": ["low", "medium", "high", "xhigh", "max"],
+      "defaultEffort": "medium",
+      "perAgent": {
+        "codex": {
+          "efforts": ["low", "medium", "high", "xhigh", "max", "ultra"],
+          "defaultEffort": "medium"
+        }
+      },
+      "routes": [
+        {
+          "providerId": "openai",
+          "modelId": "gpt-6-astra",
+          "agents": ["claude-code", "codex"],
+          "referencePrices": [
+            {
+              "currency": "USD",
+              "variant": "standard",
+              "inputPerMtok": 10,
+              "outputPerMtok": 50,
+              "cacheReadPerMtok": 1,
+              "cacheWritePerMtok": 12.5,
+              "maxInputTokens": 272001,
+              "effectiveFrom": "2026-09-04",
+              "source": {
+                "kind": "provider-official",
+                "url": "https://developers.openai.com/api/docs/models/gpt-6-astra",
+                "verifiedAt": "2026-09-05"
+              }
+            },
+            {
+              "currency": "USD",
+              "variant": "fast",
+              "inputPerMtok": 20,
+              "outputPerMtok": 100,
+              "cacheReadPerMtok": 2,
+              "cacheWritePerMtok": 25,
+              "maxInputTokens": 272001,
+              "effectiveFrom": "2026-09-04",
+              "source": {
+                "kind": "provider-official",
+                "url": "https://developers.openai.com/api/docs/models/gpt-6-astra",
+                "verifiedAt": "2026-09-05"
+              }
+            }
+          ]
+        }
+      ],
+      "supportsFastMode": true
+    },
+    {
+      "id": "anthropic/claude-fable-5-1",
+      "name": "Fable 5.1",
+      "status": "active",
+      "group": "anthropic",
+      "description": "Claude Fable 5.1 for long-running agentic coding and research",
+      "contextWindow": 1000000,
+      "maxOutputTokens": 128000,
+      "efforts": ["low", "medium", "high", "xhigh", "max"],
+      "defaultEffort": "high",
+      "routes": [
+        {
+          "providerId": "anthropic",
+          "modelId": "claude-fable-5-1",
           "agents": ["claude-code", "codex"]
         }
       ]
@@ -410,6 +852,8 @@
       "group": "anthropic",
       "contextWindow": 1000000,
       "maxOutputTokens": 128000,
+      "efforts": ["low", "medium", "high", "xhigh", "max"],
+      "defaultEffort": "high",
       "routes": [
         {
           "providerId": "anthropic",
@@ -473,11 +917,14 @@
               "variant": "fast",
               "inputPerMtok": 10,
               "outputPerMtok": 50,
+              "cacheReadPerMtok": 1,
+              "cacheWritePerMtok": 12.5,
+              "cacheWrite1hPerMtok": 20,
               "effectiveFrom": "2026-07-24",
               "source": {
                 "kind": "provider-official",
                 "url": "https://platform.claude.com/docs/en/about-claude/pricing",
-                "verifiedAt": "2026-07-31"
+                "verifiedAt": "2026-08-02"
               }
             }
           ]
@@ -527,11 +974,14 @@
               "variant": "fast",
               "inputPerMtok": 10,
               "outputPerMtok": 50,
+              "cacheReadPerMtok": 1,
+              "cacheWritePerMtok": 12.5,
+              "cacheWrite1hPerMtok": 20,
               "effectiveFrom": "2026-05-28",
               "source": {
                 "kind": "provider-official",
                 "url": "https://platform.claude.com/docs/en/about-claude/pricing",
-                "verifiedAt": "2026-07-31"
+                "verifiedAt": "2026-08-02"
               }
             }
           ]
@@ -699,26 +1149,10 @@
               "cacheWritePerMtok": 2.5,
               "cacheWrite1hPerMtok": 4,
               "effectiveFrom": "2026-06-30",
-              "effectiveUntil": "2026-09-01",
               "source": {
                 "kind": "provider-official",
                 "url": "https://platform.claude.com/docs/en/about-claude/pricing",
-                "verifiedAt": "2026-07-31"
-              }
-            },
-            {
-              "currency": "USD",
-              "variant": "standard",
-              "inputPerMtok": 3,
-              "outputPerMtok": 15,
-              "cacheReadPerMtok": 0.3,
-              "cacheWritePerMtok": 3.75,
-              "cacheWrite1hPerMtok": 6,
-              "effectiveFrom": "2026-09-01",
-              "source": {
-                "kind": "provider-official",
-                "url": "https://platform.claude.com/docs/en/about-claude/pricing",
-                "verifiedAt": "2026-07-31"
+                "verifiedAt": "2026-08-12"
               }
             }
           ]
@@ -862,9 +1296,9 @@
       "name": "Grok 4.6",
       "status": "active",
       "group": "grok",
-      "description": "xAI Grok 4.6 旗舰,编码/agent 任务,500k 上下文(SuperGrok 订阅直连)",
+      "description": "xAI Grok 4.6 新旗舰,编码/agent 任务最强,500k 上下文(SuperGrok 订阅直连)",
       "contextWindow": 500000,
-      "efforts": ["low", "medium", "high"],
+      "efforts": ["low", "medium", "high", "xhigh"],
       "defaultEffort": "high",
       "sortOrder": 48,
       "routes": [
@@ -879,11 +1313,26 @@
               "inputPerMtok": 2,
               "outputPerMtok": 6,
               "cacheReadPerMtok": 0.5,
+              "maxInputTokens": 200000,
               "effectiveFrom": "2026-08-12",
               "source": {
                 "kind": "provider-official",
                 "url": "https://docs.x.ai/developers/pricing",
-                "verifiedAt": "2026-08-17"
+                "verifiedAt": "2026-08-13"
+              }
+            },
+            {
+              "currency": "USD",
+              "variant": "standard",
+              "inputPerMtok": 4,
+              "outputPerMtok": 12,
+              "cacheReadPerMtok": 1,
+              "minInputTokens": 200000,
+              "effectiveFrom": "2026-08-12",
+              "source": {
+                "kind": "provider-official",
+                "url": "https://docs.x.ai/developers/pricing",
+                "verifiedAt": "2026-08-13"
               }
             }
           ]
@@ -895,7 +1344,7 @@
       "name": "Grok 4.5",
       "status": "active",
       "group": "grok",
-      "description": "xAI Grok 4.5,编码/agent 任务,500k 上下文(SuperGrok 订阅直连)",
+      "description": "xAI Grok 4.5 新旗舰,编码/agent 任务最强,500k 上下文(SuperGrok 订阅直连)",
       "contextWindow": 500000,
       "efforts": ["low", "medium", "high"],
       "defaultEffort": "high",
@@ -1046,7 +1495,8 @@
       "group": "grok",
       "description": "xAI Grok 4.20 multi-agent model,1M 上下文(SuperGrok 订阅直连)",
       "contextWindow": 1000000,
-      "efforts": [],
+      "efforts": ["low", "medium", "high", "xhigh"],
+      "defaultEffort": "low",
       "sortOrder": 52,
       "defaultEnabled": false,
       "routes": [
@@ -1194,11 +1644,6 @@
       "defaultEffort": "high",
       "sortOrder": 98,
       "defaultEnabled": false,
-      "perAgent": {
-        "codex": {
-          "efforts": ["low", "medium", "high"]
-        }
-      },
       "routes": [
         {
           "providerId": "xai",
@@ -1286,13 +1731,27 @@
       ]
     },
     {
+      "id": "xd/codex-gpt-5.6-luna",
+      "name": "GPT-5.6-Luna",
+      "group": "gpt-budget",
+      "sortOrder": 7,
+      "routes": [
+        {
+          "providerId": "xd",
+          "modelId": "codex/gpt-5.6-luna",
+          "agents": ["claude-code", "codex"]
+        }
+      ]
+    },
+    {
       "id": "xd/codex-gpt-5.6-sol",
       "name": "GPT-5.6-Sol",
       "group": "gpt-budget",
       "description": "GPT-5.6-Sol for coding tasks",
       "contextWindow": 372000,
-      "efforts": ["low", "medium", "high", "xhigh"],
-      "defaultEffort": "high",
+      "maxOutputTokens": 128000,
+      "efforts": ["low", "medium", "high", "xhigh", "max"],
+      "defaultEffort": "medium",
       "sortOrder": 8,
       "supportsFastMode": true,
       "perAgent": {
@@ -1300,7 +1759,9 @@
           "supportsFastMode": false
         },
         "codex": {
-          "efforts": ["low", "medium", "high", "xhigh", "max", "ultra"]
+          "contextWindow": 272000,
+          "efforts": ["low", "medium", "high", "xhigh", "max", "ultra"],
+          "defaultEffort": "medium"
         }
       },
       "routes": [
@@ -1317,8 +1778,9 @@
       "group": "gpt-budget",
       "description": "GPT-5.6-Terra for coding tasks",
       "contextWindow": 372000,
-      "efforts": ["low", "medium", "high", "xhigh"],
-      "defaultEffort": "high",
+      "maxOutputTokens": 128000,
+      "efforts": ["low", "medium", "high", "xhigh", "max"],
+      "defaultEffort": "medium",
       "sortOrder": 9,
       "supportsFastMode": true,
       "perAgent": {
@@ -1326,7 +1788,9 @@
           "supportsFastMode": false
         },
         "codex": {
-          "efforts": ["low", "medium", "high", "xhigh", "max", "ultra"]
+          "contextWindow": 272000,
+          "efforts": ["low", "medium", "high", "xhigh", "max", "ultra"],
+          "defaultEffort": "medium"
         }
       },
       "routes": [
@@ -1343,8 +1807,9 @@
       "group": "gpt-budget",
       "description": "GPT-5.5 for coding tasks",
       "contextWindow": 272000,
+      "maxOutputTokens": 128000,
       "efforts": ["low", "medium", "high", "xhigh"],
-      "defaultEffort": "high",
+      "defaultEffort": "medium",
       "sortOrder": 10,
       "supportsFastMode": true,
       "defaultEnabled": false,
@@ -1367,8 +1832,9 @@
       "group": "gpt-budget",
       "description": "GPT-5.4 for coding tasks",
       "contextWindow": 272000,
+      "maxOutputTokens": 128000,
       "efforts": ["low", "medium", "high", "xhigh"],
-      "defaultEffort": "high",
+      "defaultEffort": "medium",
       "sortOrder": 11,
       "supportsFastMode": true,
       "defaultEnabled": false,
@@ -1386,13 +1852,116 @@
       ]
     },
     {
+      "id": "google/gemini-3.7-flash",
+      "name": "Gemini 3.7 Flash",
+      "status": "active",
+      "group": "google",
+      "description": "Google Gemini 3.7 Flash — agentic workflows and multimodal reasoning",
+      "contextWindow": 1000000,
+      "maxOutputTokens": 65536,
+      "efforts": ["low", "medium", "high"],
+      "defaultEffort": "medium",
+      "sortOrder": 28,
+      "supportsFastMode": false,
+      "routes": [
+        {
+          "providerId": "xd",
+          "modelId": "gemini-3.7-flash",
+          "agents": ["claude-code"],
+          "referencePrices": [
+            {
+              "currency": "USD",
+              "variant": "standard",
+              "inputPerMtok": 0.75,
+              "outputPerMtok": 3.75,
+              "cacheReadPerMtok": 0.075,
+              "cacheWrite1hPerMtok": 0.5,
+              "effectiveFrom": "2026-08-13",
+              "effectiveUntil": "2027-01-01",
+              "source": {
+                "kind": "provider-official",
+                "url": "https://ai.google.dev/gemini-api/docs/pricing",
+                "verifiedAt": "2026-08-13"
+              }
+            },
+            {
+              "currency": "USD",
+              "variant": "standard",
+              "inputPerMtok": 1.5,
+              "outputPerMtok": 7.5,
+              "cacheReadPerMtok": 0.15,
+              "cacheWrite1hPerMtok": 1,
+              "effectiveFrom": "2027-01-01",
+              "source": {
+                "kind": "provider-official",
+                "url": "https://ai.google.dev/gemini-api/docs/pricing",
+                "verifiedAt": "2026-08-13"
+              }
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "google/gemini-3.6-flash",
+      "name": "Gemini 3.6 Flash",
+      "status": "active",
+      "group": "google",
+      "description": "Google Gemini 3.6 Flash — frontier intelligence optimized for speed and cost",
+      "contextWindow": 1000000,
+      "maxOutputTokens": 65536,
+      "efforts": ["minimal", "low", "medium", "high"],
+      "defaultEffort": "medium",
+      "sortOrder": 29,
+      "supportsFastMode": false,
+      "routes": [
+        {
+          "providerId": "xd",
+          "modelId": "gemini-3.6-flash",
+          "agents": ["claude-code"],
+          "referencePrices": [
+            {
+              "currency": "USD",
+              "variant": "standard",
+              "inputPerMtok": 0.75,
+              "outputPerMtok": 3.75,
+              "cacheReadPerMtok": 0.075,
+              "cacheWrite1hPerMtok": 0.5,
+              "effectiveFrom": "2026-07-21",
+              "effectiveUntil": "2027-01-01",
+              "source": {
+                "kind": "provider-official",
+                "url": "https://ai.google.dev/gemini-api/docs/pricing",
+                "verifiedAt": "2026-08-13"
+              }
+            },
+            {
+              "currency": "USD",
+              "variant": "standard",
+              "inputPerMtok": 1.5,
+              "outputPerMtok": 7.5,
+              "cacheReadPerMtok": 0.15,
+              "cacheWrite1hPerMtok": 1,
+              "effectiveFrom": "2027-01-01",
+              "source": {
+                "kind": "provider-official",
+                "url": "https://ai.google.dev/gemini-api/docs/pricing",
+                "verifiedAt": "2026-08-13"
+              }
+            }
+          ]
+        }
+      ]
+    },
+    {
       "id": "google/gemini-3.5-flash",
       "name": "Gemini 3.5 Flash",
       "group": "google",
       "description": "Google Gemini 3.5 Flash — upgraded Flash with stronger reasoning",
       "contextWindow": 1000000,
-      "efforts": ["low", "medium", "high"],
-      "defaultEffort": "high",
+      "maxOutputTokens": 65536,
+      "efforts": ["minimal", "low", "medium", "high"],
+      "defaultEffort": "medium",
       "sortOrder": 30,
       "supportsFastMode": false,
       "routes": [
@@ -1409,6 +1978,7 @@
       "group": "google",
       "description": "Google Gemini 3.1 Pro Preview — deepest reasoning, multimodal",
       "contextWindow": 1000000,
+      "maxOutputTokens": 65536,
       "efforts": ["low", "medium", "high"],
       "defaultEffort": "high",
       "sortOrder": 31,
@@ -1428,7 +1998,8 @@
       "group": "google",
       "description": "Google Gemini 3 Flash Preview — fast multimodal reasoning",
       "contextWindow": 1000000,
-      "efforts": ["low", "medium", "high"],
+      "maxOutputTokens": 65536,
+      "efforts": ["minimal", "low", "medium", "high"],
       "defaultEffort": "high",
       "sortOrder": 32,
       "supportsFastMode": false,
@@ -1442,10 +2013,49 @@
       ]
     },
     {
+      "id": "google/gemini-3.5-flash-lite",
+      "name": "Gemini 3.5 Flash-Lite",
+      "status": "active",
+      "group": "google",
+      "description": "Google Gemini 3.5 Flash-Lite — cost-efficient multimodal model for high-volume workloads",
+      "contextWindow": 1000000,
+      "maxOutputTokens": 65536,
+      "efforts": ["minimal", "low", "medium", "high"],
+      "defaultEffort": "minimal",
+      "sortOrder": 33,
+      "supportsFastMode": false,
+      "routes": [
+        {
+          "providerId": "xd",
+          "modelId": "gemini-3.5-flash-lite",
+          "agents": ["claude-code"]
+        }
+      ]
+    },
+    {
+      "id": "google/gemini-3.1-flash-lite",
+      "name": "Gemini 3.1 Flash-Lite",
+      "status": "active",
+      "group": "google",
+      "description": "Google Gemini 3.1 Flash-Lite — efficient multimodal model for large-scale tasks",
+      "contextWindow": 1000000,
+      "maxOutputTokens": 65536,
+      "sortOrder": 34,
+      "supportsFastMode": false,
+      "routes": [
+        {
+          "providerId": "xd",
+          "modelId": "gemini-3.1-flash-lite",
+          "agents": ["claude-code"]
+        }
+      ]
+    },
+    {
       "id": "bytedance-seed/seed-2.1-pro",
       "name": "Seed 2.1 Pro",
       "group": "china",
       "contextWindow": 256000,
+      "maxOutputTokens": 256000,
       "efforts": ["minimal", "low", "medium", "high"],
       "defaultEffort": "minimal",
       "supportsFastMode": false,
@@ -1464,8 +2074,26 @@
       ]
     },
     {
+      "id": "qwen/qwen3.8-max",
+      "name": "Qwen 3.8 Max",
+      "group": "china",
+      "contextWindow": 983616,
+      "maxOutputTokens": 131072,
+      "efforts": ["low", "high", "xhigh"],
+      "defaultEffort": "xhigh",
+      "supportsFastMode": false,
+      "routes": [
+        {
+          "providerId": "xd",
+          "modelId": "qwen/qwen3.8-max",
+          "agents": ["claude-code", "codex"]
+        }
+      ]
+    },
+    {
       "id": "qwen/qwen3.8-max-preview",
       "name": "Qwen 3.8 Max Preview",
+      "status": "retired",
       "group": "china",
       "contextWindow": 983616,
       "efforts": ["low", "high", "xhigh"],
@@ -1485,6 +2113,7 @@
       "group": "china",
       "description": "Qwen 3.7 Max agentic coding model; thinking is provider-managed",
       "contextWindow": 992000,
+      "maxOutputTokens": 65536,
       "efforts": [],
       "sortOrder": 40,
       "supportsFastMode": false,
@@ -1492,6 +2121,52 @@
         {
           "providerId": "xd",
           "modelId": "qwen/qwen3.7-max",
+          "agents": ["claude-code", "codex"]
+        }
+      ]
+    },
+    {
+      "id": "moonshotai/kimi-k2.7-code",
+      "name": "Kimi K2.7 Code",
+      "status": "active",
+      "group": "china",
+      "description": "Moonshot Kimi K2.7 Code agentic coding model",
+      "contextWindow": 262144,
+      "efforts": [],
+      "sortOrder": 107,
+      "defaultEnabled": false,
+      "routes": [
+        {
+          "providerId": "moonshot-kimi-cn",
+          "modelId": "kimi-k2.7-code",
+          "agents": ["claude-code", "codex"]
+        },
+        {
+          "providerId": "moonshot-kimi-global",
+          "modelId": "kimi-k2.7-code",
+          "agents": ["claude-code", "codex"]
+        }
+      ]
+    },
+    {
+      "id": "moonshotai/kimi-k2.7-code-highspeed",
+      "name": "Kimi K2.7 Code Highspeed",
+      "status": "active",
+      "group": "china",
+      "description": "Moonshot Kimi K2.7 Code high-speed API variant",
+      "contextWindow": 262144,
+      "efforts": [],
+      "sortOrder": 108,
+      "defaultEnabled": false,
+      "routes": [
+        {
+          "providerId": "moonshot-kimi-cn",
+          "modelId": "kimi-k2.7-code-highspeed",
+          "agents": ["claude-code", "codex"]
+        },
+        {
+          "providerId": "moonshot-kimi-global",
+          "modelId": "kimi-k2.7-code-highspeed",
           "agents": ["claude-code", "codex"]
         }
       ]
@@ -1519,7 +2194,8 @@
       "name": "GLM-5.1",
       "group": "china",
       "description": "Zhipu GLM-5.1 agentic coding model; thinking is provider-managed",
-      "contextWindow": 202752,
+      "contextWindow": 200000,
+      "maxOutputTokens": 131072,
       "efforts": [],
       "sortOrder": 42,
       "supportsFastMode": false,
@@ -1538,6 +2214,7 @@
       "group": "china",
       "description": "Zhipu GLM-5.2 agentic coding model; 1M context",
       "contextWindow": 1000000,
+      "maxOutputTokens": 131072,
       "efforts": ["minimal", "high", "max"],
       "defaultEffort": "max",
       "sortOrder": 43,
@@ -1557,20 +2234,93 @@
       ]
     },
     {
-      "id": "deepseek/deepseek-v4-pro",
-      "name": "DeepSeek V4 Pro",
+      "id": "z-ai/glm-5.3",
+      "name": "GLM-5.3",
+      "status": "active",
       "group": "china",
-      "description": "DeepSeek V4 Pro reasoning model; only high/max effective (low/medium→high, xhigh→max)",
-      "contextWindow": 1048576,
-      "efforts": ["high", "max"],
-      "defaultEffort": "high",
+      "description": "Zhipu GLM-5.3 agentic coding model; 1M context",
+      "contextWindow": 1000000,
+      "maxOutputTokens": 131072,
+      "efforts": ["low", "high", "max"],
+      "defaultEffort": "max",
       "sortOrder": 44,
       "supportsFastMode": false,
       "routes": [
         {
           "providerId": "xd",
-          "modelId": "deepseek/deepseek-v4-pro",
+          "modelId": "z-ai/glm-5.3",
           "agents": ["claude-code", "codex"]
+        }
+      ]
+    },
+    {
+      "id": "z-ai/glm-5.3-flash",
+      "name": "GLM-5.3-Flash",
+      "status": "active",
+      "group": "china",
+      "description": "Zhipu GLM-5.3-Flash native multimodal coding model; 1M context",
+      "contextWindow": 1000000,
+      "maxOutputTokens": 131072,
+      "routes": [
+        {
+          "providerId": "zhipu-glm-cn",
+          "modelId": "glm-5.3-flash",
+          "agents": ["claude-code", "codex"]
+        },
+        {
+          "providerId": "zhipu-glm-global",
+          "modelId": "glm-5.3-flash",
+          "agents": ["claude-code", "codex"]
+        }
+      ]
+    },
+    {
+      "id": "xd/z-ai-glm-5.3-flash",
+      "name": "GLM-5.3-Flash",
+      "status": "active",
+      "group": "china",
+      "description": "Zhipu GLM-5.3-Flash native multimodal coding model; 1M context",
+      "contextWindow": 1000000,
+      "maxOutputTokens": 131072,
+      "routes": [
+        {
+          "providerId": "xd",
+          "modelId": "z-ai/glm-5.3-flash",
+          "agents": ["claude-code", "codex"]
+        }
+      ]
+    },
+    {
+      "id": "deepseek/deepseek-v4-pro",
+      "name": "DeepSeek V4 Pro",
+      "group": "china",
+      "description": "DeepSeek V4 Pro reasoning model; only high/max effective (low/medium→high, xhigh→max)",
+      "contextWindow": 1048576,
+      "maxOutputTokens": 384000,
+      "efforts": ["high", "max"],
+      "defaultEffort": "high",
+      "sortOrder": 45,
+      "supportsFastMode": false,
+      "routes": [
+        {
+          "providerId": "xd",
+          "modelId": "deepseek/deepseek-v4-pro",
+          "agents": ["claude-code", "codex"],
+          "referencePrices": [
+            {
+              "currency": "USD",
+              "variant": "standard",
+              "inputPerMtok": 1.32,
+              "outputPerMtok": 3.96,
+              "cacheReadPerMtok": 0.044,
+              "effectiveFrom": "2026-08-16",
+              "source": {
+                "kind": "provider-official",
+                "url": "https://api-docs.deepseek.com/quick_start/pricing",
+                "verifiedAt": "2026-08-16"
+              }
+            }
+          ]
         },
         {
           "providerId": "deepseek",
@@ -1588,6 +2338,20 @@
                 "kind": "provider-official",
                 "url": "https://api-docs.deepseek.com/quick_start/pricing",
                 "verifiedAt": "2026-08-05"
+              },
+              "effectiveUntil": "2026-08-16"
+            },
+            {
+              "currency": "USD",
+              "variant": "standard",
+              "inputPerMtok": 1.32,
+              "outputPerMtok": 3.96,
+              "cacheReadPerMtok": 0.044,
+              "effectiveFrom": "2026-08-16",
+              "source": {
+                "kind": "provider-official",
+                "url": "https://api-docs.deepseek.com/quick_start/pricing",
+                "verifiedAt": "2026-08-16"
               }
             }
           ]
@@ -1598,17 +2362,33 @@
       "id": "deepseek/deepseek-v4-flash",
       "name": "DeepSeek V4 Flash",
       "group": "china",
-      "description": "DeepSeek V4 Flash efficiency-optimized MoE; only high/max effective",
+      "description": "DeepSeek V4 Flash efficiency-optimized MoE; supports low/high/max effort",
       "contextWindow": 1048576,
-      "efforts": ["high", "max"],
+      "maxOutputTokens": 384000,
+      "efforts": ["low", "high", "max"],
       "defaultEffort": "high",
-      "sortOrder": 45,
+      "sortOrder": 46,
       "supportsFastMode": false,
       "routes": [
         {
           "providerId": "xd",
           "modelId": "deepseek/deepseek-v4-flash",
-          "agents": ["claude-code", "codex"]
+          "agents": ["claude-code", "codex"],
+          "referencePrices": [
+            {
+              "currency": "USD",
+              "variant": "standard",
+              "inputPerMtok": 0.44,
+              "outputPerMtok": 1.32,
+              "cacheReadPerMtok": 0.014,
+              "effectiveFrom": "2026-08-16",
+              "source": {
+                "kind": "provider-official",
+                "url": "https://api-docs.deepseek.com/quick_start/pricing",
+                "verifiedAt": "2026-08-16"
+              }
+            }
+          ]
         },
         {
           "providerId": "deepseek",
@@ -1626,6 +2406,20 @@
                 "kind": "provider-official",
                 "url": "https://api-docs.deepseek.com/quick_start/pricing",
                 "verifiedAt": "2026-08-05"
+              },
+              "effectiveUntil": "2026-08-16"
+            },
+            {
+              "currency": "USD",
+              "variant": "standard",
+              "inputPerMtok": 0.44,
+              "outputPerMtok": 1.32,
+              "cacheReadPerMtok": 0.014,
+              "effectiveFrom": "2026-08-16",
+              "source": {
+                "kind": "provider-official",
+                "url": "https://api-docs.deepseek.com/quick_start/pricing",
+                "verifiedAt": "2026-08-16"
               }
             }
           ]
@@ -1641,7 +2435,6 @@
       "contextWindow": 400000,
       "maxOutputTokens": 128000,
       "efforts": ["low", "medium", "high", "xhigh"],
-      "defaultEffort": "high",
       "sortOrder": 101,
       "defaultEnabled": false,
       "routes": [
@@ -1676,6 +2469,9 @@
       "id": "xd/codex-gpt-5.4-mini",
       "name": "GPT-5.4-Mini",
       "group": "gpt-budget",
+      "contextWindow": 272000,
+      "efforts": ["low", "medium", "high", "xhigh"],
+      "defaultEffort": "medium",
       "sortOrder": 103,
       "defaultEnabled": false,
       "routes": [
@@ -1684,13 +2480,183 @@
           "modelId": "codex/gpt-5.4-mini",
           "agents": ["claude-code", "codex"]
         }
+      ],
+      "maxOutputTokens": 128000
+    },
+    {
+      "id": "minimax/minimax-m3",
+      "name": "MiniMax M3",
+      "status": "active",
+      "group": "china",
+      "contextWindow": 1000000,
+      "sortOrder": 114,
+      "defaultEnabled": false,
+      "routes": [
+        {
+          "providerId": "minimax-cn",
+          "modelId": "MiniMax-M3",
+          "agents": ["claude-code", "codex"]
+        },
+        {
+          "providerId": "minimax-global",
+          "modelId": "MiniMax-M3",
+          "agents": ["claude-code", "codex"]
+        }
+      ]
+    },
+    {
+      "id": "minimax/minimax-m2.7",
+      "name": "MiniMax M2.7",
+      "status": "active",
+      "group": "china",
+      "contextWindow": 204800,
+      "sortOrder": 111,
+      "defaultEnabled": false,
+      "routes": [
+        {
+          "providerId": "minimax-cn",
+          "modelId": "MiniMax-M2.7",
+          "agents": ["claude-code", "codex"]
+        },
+        {
+          "providerId": "minimax-global",
+          "modelId": "MiniMax-M2.7",
+          "agents": ["claude-code", "codex"]
+        }
+      ]
+    },
+    {
+      "id": "minimax/minimax-m2.7-highspeed",
+      "name": "MiniMax M2.7 Highspeed",
+      "status": "active",
+      "group": "china",
+      "contextWindow": 204800,
+      "sortOrder": 112,
+      "defaultEnabled": false,
+      "routes": [
+        {
+          "providerId": "minimax-cn",
+          "modelId": "MiniMax-M2.7-highspeed",
+          "agents": ["claude-code", "codex"]
+        },
+        {
+          "providerId": "minimax-global",
+          "modelId": "MiniMax-M2.7-highspeed",
+          "agents": ["claude-code", "codex"]
+        }
+      ]
+    },
+    {
+      "id": "minimax/minimax-m2.5",
+      "name": "MiniMax M2.5",
+      "status": "active",
+      "group": "china",
+      "contextWindow": 204800,
+      "sortOrder": 116,
+      "defaultEnabled": false,
+      "routes": [
+        {
+          "providerId": "minimax-cn",
+          "modelId": "MiniMax-M2.5",
+          "agents": ["claude-code", "codex"]
+        },
+        {
+          "providerId": "minimax-global",
+          "modelId": "MiniMax-M2.5",
+          "agents": ["claude-code", "codex"]
+        }
+      ]
+    },
+    {
+      "id": "minimax/minimax-m2.5-highspeed",
+      "name": "MiniMax M2.5 Highspeed",
+      "status": "active",
+      "group": "china",
+      "contextWindow": 204800,
+      "sortOrder": 117,
+      "defaultEnabled": false,
+      "routes": [
+        {
+          "providerId": "minimax-cn",
+          "modelId": "MiniMax-M2.5-highspeed",
+          "agents": ["claude-code", "codex"]
+        },
+        {
+          "providerId": "minimax-global",
+          "modelId": "MiniMax-M2.5-highspeed",
+          "agents": ["claude-code", "codex"]
+        }
+      ]
+    },
+    {
+      "id": "minimax/minimax-m2.1",
+      "name": "MiniMax M2.1",
+      "status": "active",
+      "group": "china",
+      "contextWindow": 204800,
+      "sortOrder": 118,
+      "defaultEnabled": false,
+      "routes": [
+        {
+          "providerId": "minimax-cn",
+          "modelId": "MiniMax-M2.1",
+          "agents": ["claude-code", "codex"]
+        },
+        {
+          "providerId": "minimax-global",
+          "modelId": "MiniMax-M2.1",
+          "agents": ["claude-code", "codex"]
+        }
+      ]
+    },
+    {
+      "id": "minimax/minimax-m2.1-highspeed",
+      "name": "MiniMax M2.1 Highspeed",
+      "status": "active",
+      "group": "china",
+      "contextWindow": 204800,
+      "sortOrder": 119,
+      "defaultEnabled": false,
+      "routes": [
+        {
+          "providerId": "minimax-cn",
+          "modelId": "MiniMax-M2.1-highspeed",
+          "agents": ["claude-code", "codex"]
+        },
+        {
+          "providerId": "minimax-global",
+          "modelId": "MiniMax-M2.1-highspeed",
+          "agents": ["claude-code", "codex"]
+        }
+      ]
+    },
+    {
+      "id": "minimax/minimax-m2",
+      "name": "MiniMax M2",
+      "status": "active",
+      "group": "china",
+      "contextWindow": 204800,
+      "sortOrder": 120,
+      "defaultEnabled": false,
+      "routes": [
+        {
+          "providerId": "minimax-cn",
+          "modelId": "MiniMax-M2",
+          "agents": ["claude-code", "codex"]
+        },
+        {
+          "providerId": "minimax-global",
+          "modelId": "MiniMax-M2",
+          "agents": ["claude-code", "codex"]
+        }
       ]
     },
     {
       "id": "moonshotai/kimi-k3",
       "name": "Kimi K3",
       "group": "china",
-      "contextWindow": 1000000,
+      "contextWindow": 1048576,
+      "maxOutputTokens": 1048576,
       "efforts": ["low", "high", "max"],
       "defaultEffort": "max",
       "sortOrder": 41,
@@ -1698,7 +2664,17 @@
       "routes": [
         {
           "providerId": "xd",
-          "modelId": "moonshotai/kimi-k3",
+          "modelId": "moonshot/kimi-k3",
+          "agents": ["claude-code", "codex"]
+        },
+        {
+          "providerId": "moonshot-kimi-cn",
+          "modelId": "kimi-k3",
+          "agents": ["claude-code", "codex"]
+        },
+        {
+          "providerId": "moonshot-kimi-global",
+          "modelId": "kimi-k3",
           "agents": ["claude-code", "codex"]
         }
       ]
@@ -1707,6 +2683,10 @@
       "id": "qwen/qwen3.6-plus",
       "name": "Qwen 3.6 Plus",
       "group": "china",
+      "description": "Qwen 3.6 Plus with provider-managed thinking",
+      "contextWindow": 1048576,
+      "maxOutputTokens": 65536,
+      "efforts": [],
       "sortOrder": 105,
       "defaultEnabled": false,
       "routes": [
@@ -1714,6 +2694,124 @@
           "providerId": "xd",
           "modelId": "qwen/qwen3.6-plus",
           "agents": ["claude-code"]
+        }
+      ]
+    },
+    {
+      "id": "qwen/qwen3.6-plus-api",
+      "name": "Qwen 3.6 Plus API",
+      "status": "active",
+      "group": "china",
+      "contextWindow": 991808,
+      "maxOutputTokens": 65536,
+      "sortOrder": 113,
+      "defaultEnabled": false,
+      "routes": [
+        {
+          "providerId": "aliyun-model-studio-cn",
+          "modelId": "qwen3.6-plus",
+          "agents": ["claude-code", "codex"]
+        },
+        {
+          "providerId": "aliyun-model-studio-global",
+          "modelId": "qwen3.6-plus",
+          "agents": ["claude-code", "codex"]
+        }
+      ]
+    },
+    {
+      "id": "qwen/qwen3.7-flash",
+      "name": "Qwen 3.7 Flash",
+      "status": "active",
+      "group": "china",
+      "description": "Alibaba Qwen 3.7 Flash text model with provider-managed thinking",
+      "contextWindow": 991808,
+      "maxOutputTokens": 65536,
+      "efforts": [],
+      "sortOrder": 115,
+      "defaultEnabled": false,
+      "routes": [
+        {
+          "providerId": "aliyun-model-studio-cn",
+          "modelId": "qwen3.7-flash",
+          "agents": ["claude-code", "codex"]
+        },
+        {
+          "providerId": "aliyun-model-studio-global",
+          "modelId": "qwen3.7-flash",
+          "agents": ["claude-code", "codex"]
+        }
+      ]
+    },
+    {
+      "id": "qwen/qwen3.8-flash",
+      "name": "Qwen 3.8 Flash",
+      "status": "active",
+      "group": "china",
+      "description": "Alibaba Qwen 3.8 Flash multimodal model with provider-managed thinking",
+      "contextWindow": 991808,
+      "maxOutputTokens": 131072,
+      "efforts": [],
+      "sortOrder": 121,
+      "defaultEnabled": false,
+      "routes": [
+        {
+          "providerId": "aliyun-model-studio-cn",
+          "modelId": "qwen3.8-flash",
+          "agents": ["claude-code", "codex"]
+        },
+        {
+          "providerId": "aliyun-model-studio-global",
+          "modelId": "qwen3.8-flash",
+          "agents": ["claude-code", "codex"]
+        }
+      ]
+    },
+    {
+      "id": "qwen/qwen3.7-plus",
+      "name": "Qwen 3.7 Plus",
+      "status": "active",
+      "group": "china",
+      "description": "Alibaba Qwen 3.7 Plus text model with provider-managed thinking",
+      "contextWindow": 991808,
+      "maxOutputTokens": 65536,
+      "efforts": [],
+      "sortOrder": 109,
+      "defaultEnabled": false,
+      "routes": [
+        {
+          "providerId": "aliyun-model-studio-cn",
+          "modelId": "qwen3.7-plus",
+          "agents": ["claude-code", "codex"]
+        },
+        {
+          "providerId": "aliyun-model-studio-global",
+          "modelId": "qwen3.7-plus",
+          "agents": ["claude-code", "codex"]
+        }
+      ]
+    },
+    {
+      "id": "qwen/qwen3.6-flash",
+      "name": "Qwen 3.6 Flash",
+      "status": "active",
+      "group": "china",
+      "description": "Alibaba Qwen 3.6 Flash text model with provider-managed thinking",
+      "contextWindow": 991808,
+      "maxOutputTokens": 65536,
+      "efforts": [],
+      "sortOrder": 110,
+      "defaultEnabled": false,
+      "routes": [
+        {
+          "providerId": "aliyun-model-studio-cn",
+          "modelId": "qwen3.6-flash",
+          "agents": ["claude-code", "codex"]
+        },
+        {
+          "providerId": "aliyun-model-studio-global",
+          "modelId": "qwen3.6-flash",
+          "agents": ["claude-code", "codex"]
         }
       ]
     },
@@ -1729,91 +2827,8 @@
           "modelId": "codex/gpt-5.5:auto",
           "agents": ["claude-code", "codex"]
         }
-      ]
-    },
-    {
-      "id": "openai/gpt-6-astra",
-      "name": "GPT-6 Astra",
-      "status": "active",
-      "group": "gpt",
-      "contextWindow": 1050000,
-      "maxOutputTokens": 128000,
-      "efforts": [
-        "low",
-        "medium",
-        "high",
-        "xhigh",
-        "max"
       ],
-      "defaultEffort": "medium",
-      "sortOrder": 22,
-      "supportsFastMode": true,
-      "perAgent": {
-        "claude-code": {
-          "contextWindow": 272000,
-          "efforts": [
-            "low",
-            "medium",
-            "high",
-            "xhigh",
-            "max",
-            "ultra"
-          ]
-        },
-        "codex": {
-          "contextWindow": 272000,
-          "efforts": [
-            "low",
-            "medium",
-            "high",
-            "xhigh",
-            "max",
-            "ultra"
-          ]
-        }
-      },
-      "routes": [
-        {
-          "providerId": "openai",
-          "modelId": "gpt-6-astra",
-          "agents": [
-            "claude-code",
-            "codex"
-          ],
-          "referencePrices": [
-            {
-              "currency": "USD",
-              "variant": "standard",
-              "inputPerMtok": 10,
-              "outputPerMtok": 50,
-              "cacheReadPerMtok": 1,
-              "cacheWritePerMtok": 12.5,
-              "maxInputTokens": 272001,
-              "effectiveFrom": "2026-09-04",
-              "source": {
-                "kind": "provider-official",
-                "url": "https://developers.openai.com/api/docs/models/gpt-6-astra",
-                "verifiedAt": "2026-09-04"
-              }
-            },
-            {
-              "currency": "USD",
-              "variant": "fast",
-              "inputPerMtok": 20,
-              "outputPerMtok": 100,
-              "cacheReadPerMtok": 2,
-              "cacheWritePerMtok": 25,
-              "maxInputTokens": 272001,
-              "effectiveFrom": "2026-09-04",
-              "source": {
-                "kind": "provider-official",
-                "url": "https://developers.openai.com/api/docs/models/gpt-6-astra",
-                "verifiedAt": "2026-09-04"
-              }
-            }
-          ]
-        }
-      ]
+      "maxOutputTokens": 128000
     }
   ]
 }

--- a/packages/model-providers/src/__tests__/catalog.test.ts
+++ b/packages/model-providers/src/__tests__/catalog.test.ts
@@ -106,18 +106,25 @@ describe('bundled catalog validity (dynamic-first contract)', () => {
     const registry = BUNDLED_CATALOG.modelRegistry;
     expect(registry).toBeDefined();
     for (const entry of registry!.models) {
-      const efforts = entry.efforts ?? [];
-      if (efforts.length === 0) continue;
-      expect(entry.defaultEffort, entry.id).toBeTruthy();
-      expect(efforts, entry.id).toContain(entry.defaultEffort);
+      for (const agent of new Set(entry.routes.flatMap((route) => route.agents))) {
+        const override = entry.perAgent?.[agent];
+        const efforts = override?.efforts ?? entry.efforts ?? [];
+        const defaultEffort = override?.defaultEffort ?? entry.defaultEffort;
+        if (efforts.length === 0) continue;
+        // Disabled legacy entries may rely on discovery for a default, but must
+        // never declare a default that the target engine does not support.
+        if (entry.defaultEnabled === false && defaultEffort === undefined) continue;
+        expect(defaultEffort, `${entry.id}/${agent}`).toBeTruthy();
+        expect(efforts, `${entry.id}/${agent}`).toContain(defaultEffort);
+      }
     }
     expect(registryEntryForRoute('openai', 'gpt-5.6-luna')).toMatchObject({
       efforts: ['low', 'medium', 'high', 'xhigh', 'max'],
-      defaultEffort: 'high',
+      defaultEffort: 'medium',
     });
     expect(registryEntryForRoute('openai', 'gpt-5.4-nano')).toMatchObject({
       efforts: ['low', 'medium', 'high', 'xhigh'],
-      defaultEffort: 'high',
+      defaultEnabled: false,
     });
     // Corrections must forward-fix: same updatedAt + different content is a
     // conflict, so cached clients would keep the entries without defaultEffort.
@@ -315,7 +322,7 @@ describe('bundled catalog validity (dynamic-first contract)', () => {
   it('ships Codex support metadata for the current XD gateway model set', () => {
     const expected = {
       'qwen/qwen3.7-max': 'Qwen 3.7 Max',
-      'moonshotai/kimi-k3': 'Kimi K3',
+      'moonshot/kimi-k3': 'Kimi K3',
       'z-ai/glm-5.2': 'GLM-5.2',
       'deepseek/deepseek-v4-pro': 'DeepSeek V4 Pro',
       'deepseek/deepseek-v4-flash': 'DeepSeek V4 Flash',
@@ -342,7 +349,7 @@ describe('bundled catalog validity (dynamic-first contract)', () => {
         },
       },
     });
-    expect(registryEntryForRoute('xd', 'moonshotai/kimi-k3')).toMatchObject({
+    expect(registryEntryForRoute('xd', 'moonshot/kimi-k3')).toMatchObject({
       efforts: ['low', 'high', 'max'],
       defaultEffort: 'max',
       supportsFastMode: false,
@@ -365,14 +372,14 @@ describe('bundled catalog validity (dynamic-first contract)', () => {
     });
     for (const id of ['deepseek/deepseek-v4-pro', 'deepseek/deepseek-v4-flash']) {
       expect(registryEntryForRoute('xd', id), id).toMatchObject({
-        efforts: ['high', 'max'],
+        efforts: id.endsWith('-flash') ? ['low', 'high', 'max'] : ['high', 'max'],
         defaultEffort: 'high',
         supportsFastMode: false,
       });
     }
     for (const id of [
       'bytedance-seed/seed-2.1-pro',
-      'moonshotai/kimi-k3',
+      'moonshot/kimi-k3',
       'qwen/qwen3.8-max-preview',
     ]) {
       expect(registryEntryForRoute('xd', id), id).not.toHaveProperty('description');

--- a/packages/model-providers/src/__tests__/modelRegistry.test.ts
+++ b/packages/model-providers/src/__tests__/modelRegistry.test.ts
@@ -13,20 +13,41 @@ describe("model registry", () => {
   it.each([
     { variant: "standard" as const, inputPerMtok: 10, cacheWritePerMtok: 12.5 },
     { variant: "fast" as const, inputPerMtok: 20, cacheWritePerMtok: 25 },
-  ])("Astra $variant prices are available on the verified UTC day", ({ variant, inputPerMtok, cacheWritePerMtok }) => {
-    // September 5 in Auckland is still September 4 UTC: pricing uses the UTC day.
-    const options = { at: new Date("2026-09-04T21:00:00Z"), variant, inputTokens: 272_000 };
-    expect(resolveModelReferencePrice(registry, "openai", "gpt-6-astra", options)?.price)
-      .toMatchObject({ inputPerMtok, cacheWritePerMtok });
-    expect(resolveModelReferencePrice(registry, "openai", "gpt-6-astra", {
-      ...options, inputTokens: 272_001,
-    })).toBeUndefined();
-  });
+  ])(
+    "Astra $variant prices are available on the verified UTC day",
+    ({ variant, inputPerMtok, cacheWritePerMtok }) => {
+      // The observation starts at UTC midnight, regardless of the local calendar day.
+      const options = {
+        at: new Date("2026-09-04T00:00:00Z"),
+        variant,
+        inputTokens: 272_000,
+      };
+      expect(
+        resolveModelReferencePrice(registry, "openai", "gpt-6-astra", {
+          ...options,
+          at: new Date("2026-09-03T23:59:59Z"),
+        }),
+      ).toBeUndefined();
+      expect(
+        resolveModelReferencePrice(registry, "openai", "gpt-6-astra", options)
+          ?.price,
+      ).toMatchObject({ inputPerMtok, cacheWritePerMtok });
+      expect(
+        resolveModelReferencePrice(registry, "openai", "gpt-6-astra", {
+          ...options,
+          inputTokens: 272_001,
+        }),
+      ).toBeUndefined();
+    },
+  );
 
   it("compares revision instants with normalized timestamps before checking content", () => {
     if (!registry) throw new Error("missing bundled registry");
     const current = { ...registry, updatedAt: "2026-08-02T02:00:00.000Z" };
-    const equivalent = { ...registry, updatedAt: "2026-08-02T10:00:00.000+08:00" };
+    const equivalent = {
+      ...registry,
+      updatedAt: "2026-08-02T10:00:00.000+08:00",
+    };
 
     expect(compareModelRegistryRevisions(equivalent, current)).toBe("same");
     expect(
@@ -47,9 +68,12 @@ describe("model registry", () => {
         current,
       ),
     ).toBe("newer");
-    expect(compareModelRegistryRevisions({ ...registry, updatedAt: "invalid" }, current)).toBe(
-      "invalid-incoming",
-    );
+    expect(
+      compareModelRegistryRevisions(
+        { ...registry, updatedAt: "invalid" },
+        current,
+      ),
+    ).toBe("invalid-incoming");
   });
 
   it("resolves exact provider/runtime routes without claiming availability", () => {
@@ -85,41 +109,47 @@ describe("model registry", () => {
   });
 
   it("normalizes the ChatGPT bridge id and selects OpenAI long-context bands", () => {
-    // 2026-08-16 随上游目录收敛:XD 网关不再拆独立条目,而是作为 `openai/*` 条目的
-    // 额外 route;窗口等元数据**以服务端目录快照为准**(本地不再维护拆分值,快照
-    // 08-14 起两条路由同为 372K)。这里只锁「同一条目、双路由可解析」的结构。
+    // Subscription and gateway windows belong to distinct server-owned routes.
     expect(
       findModelRegistryRoute(registry, "openai", "gpt-5.6-sol", "codex"),
     ).toMatchObject({
       entry: {
-        contextWindow: 1_050_000,
+        contextWindow: 272_000,
         maxOutputTokens: 128_000,
-        perAgent: { codex: { contextWindow: 372_000 } },
       },
     });
     expect(
       findModelRegistryRoute(registry, "xd", "gpt-5.6-sol", "codex"),
     ).toMatchObject({
-      entry: { id: "openai/gpt-5.6-sol", perAgent: { codex: { contextWindow: 372_000 } } },
+      entry: {
+        id: "xd/gpt-5.6-sol",
+        contextWindow: 1_050_000,
+        perAgent: { codex: { contextWindow: 272_000 } },
+      },
     });
     expect(
       resolveModelReferencePrice(registry, "openai", "chatgpt/gpt-5.6-sol", {
         agent: "claude-code",
         inputTokens: 272_000,
       })?.price,
-    ).toMatchObject({ inputPerMtok: 5, outputPerMtok: 30 });
+    ).toMatchObject({ inputPerMtok: 4, outputPerMtok: 20 });
     expect(
-      resolveModelReferencePrice(registry, "openai", "chatgpt/gpt-5.6-sol[1m]", {
-        agent: "claude-code",
-        inputTokens: 272_001,
-      })?.price,
-    ).toMatchObject({ inputPerMtok: 10, outputPerMtok: 45 });
+      resolveModelReferencePrice(
+        registry,
+        "openai",
+        "chatgpt/gpt-5.6-sol[1m]",
+        {
+          agent: "claude-code",
+          inputTokens: 272_001,
+        },
+      )?.price,
+    ).toMatchObject({ inputPerMtok: 8, outputPerMtok: 30 });
     expect(
       resolveModelReferencePrice(registry, "openai", "gpt-5.6-sol", {
         agent: "codex",
         inputTokens: 272_001,
       })?.price,
-    ).toMatchObject({ inputPerMtok: 10, outputPerMtok: 45 });
+    ).toMatchObject({ inputPerMtok: 8, outputPerMtok: 30 });
     expect(
       resolveModelReferencePrice(registry, "openai", "gpt-5.4-nano", {
         agent: "codex",
@@ -132,12 +162,20 @@ describe("model registry", () => {
       resolveModelReferencePrice(registry, "xai", "xai/grok-4.6", {
         inputTokens: 199_999,
       })?.price,
-    ).toMatchObject({ inputPerMtok: 2, outputPerMtok: 6, cacheReadPerMtok: 0.5 });
+    ).toMatchObject({
+      inputPerMtok: 2,
+      outputPerMtok: 6,
+      cacheReadPerMtok: 0.5,
+    });
     expect(
       resolveModelReferencePrice(registry, "xai", "xai/grok-4.6", {
         inputTokens: 200_000,
       })?.price,
-    ).toMatchObject({ inputPerMtok: 2, outputPerMtok: 6, cacheReadPerMtok: 0.5 });
+    ).toMatchObject({
+      inputPerMtok: 4,
+      outputPerMtok: 12,
+      cacheReadPerMtok: 1,
+    });
     expect(
       resolveModelReferencePrice(registry, "xai", "xai/grok-4.5", {
         inputTokens: 199_999,
@@ -171,14 +209,18 @@ describe("model registry", () => {
       resolveModelReferencePrice(registry, "anthropic", "claude-sonnet-5", {
         at: "2026-09-01",
       })?.price,
-    ).toMatchObject({ inputPerMtok: 3, outputPerMtok: 15 });
+    ).toMatchObject({ inputPerMtok: 2, outputPerMtok: 10 });
   });
 
   it("resolves DeepSeek BYOK cache-hit pricing for both runtimes", () => {
     for (const [modelId, expected] of [
       [
         "deepseek-v4-pro",
-        { inputPerMtok: 0.435, outputPerMtok: 0.87, cacheReadPerMtok: 0.003625 },
+        {
+          inputPerMtok: 0.435,
+          outputPerMtok: 0.87,
+          cacheReadPerMtok: 0.003625,
+        },
       ],
       [
         "deepseek-v4-flash",
@@ -197,6 +239,61 @@ describe("model registry", () => {
           at: "2026-08-05",
         })?.price,
       ).toMatchObject(expected);
+    }
+  });
+
+  it.each([
+    ["deepseek-v4-pro", 0.435, 1.32, 3.96, 0.044],
+    ["deepseek-v4-flash", 0.14, 0.44, 1.32, 0.014],
+  ] as const)(
+    "preserves %s direct historical prices at the peak-reference transition",
+    (modelId, oldInput, inputPerMtok, outputPerMtok, cacheReadPerMtok) => {
+      for (const agent of ["claude-code", "codex"] as const) {
+        expect(
+          resolveModelReferencePrice(registry, "deepseek", modelId, {
+            agent,
+            at: "2026-08-15",
+          })?.price.inputPerMtok,
+        ).toBe(oldInput);
+        expect(
+          resolveModelReferencePrice(registry, "deepseek", modelId, {
+            agent,
+            at: "2026-08-16",
+          })?.price,
+        ).toMatchObject({ inputPerMtok, outputPerMtok, cacheReadPerMtok });
+      }
+    },
+  );
+
+  it.each(["claude-opus-5", "claude-opus-4-8"])(
+    "includes %s Fast cache prices independently of standard prices",
+    (modelId) => {
+      expect(
+        resolveModelReferencePrice(registry, "anthropic", modelId, {
+          at: "2026-09-05",
+          variant: "fast",
+        })?.price,
+      ).toMatchObject({
+        inputPerMtok: 10,
+        outputPerMtok: 50,
+        cacheReadPerMtok: 1,
+        cacheWritePerMtok: 12.5,
+        cacheWrite1hPerMtok: 20,
+      });
+    },
+  );
+
+  it("keeps Sol historical prices when selecting the later reduced reference rate", () => {
+    for (const [at, inputPerMtok, outputPerMtok] of [
+      ["2026-08-20", 5, 30],
+      ["2026-08-21", 4, 20],
+    ] as const) {
+      expect(
+        resolveModelReferencePrice(registry, "openai", "gpt-5.6-sol", {
+          at,
+          inputTokens: 272_000,
+        })?.price,
+      ).toMatchObject({ inputPerMtok, outputPerMtok });
     }
   });
 

--- a/packages/model-providers/src/__tests__/modelRegistryConsistency.test.ts
+++ b/packages/model-providers/src/__tests__/modelRegistryConsistency.test.ts
@@ -42,7 +42,9 @@ function bandGroups(route: ModelRegistryRoute): ModelReferencePrice[][] {
     else groups.set(key, [price]);
   }
   return Array.from(groups.values()).map((group) =>
-    group.slice().sort((a, b) => (a.minInputTokens ?? 0) - (b.minInputTokens ?? 0)),
+    group
+      .slice()
+      .sort((a, b) => (a.minInputTokens ?? 0) - (b.minInputTokens ?? 0)),
   );
 }
 
@@ -50,12 +52,21 @@ describe("model registry data consistency", () => {
   it("window / output declarations are positive and mutually sane", () => {
     for (const entry of registry.models) {
       if (entry.contextWindow !== undefined) {
-        expect(entry.contextWindow, `${entry.id} contextWindow`).toBeGreaterThan(0);
+        expect(
+          entry.contextWindow,
+          `${entry.id} contextWindow`,
+        ).toBeGreaterThan(0);
       }
       if (entry.maxOutputTokens !== undefined) {
-        expect(entry.maxOutputTokens, `${entry.id} maxOutputTokens`).toBeGreaterThan(0);
+        expect(
+          entry.maxOutputTokens,
+          `${entry.id} maxOutputTokens`,
+        ).toBeGreaterThan(0);
       }
-      if (entry.contextWindow !== undefined && entry.maxOutputTokens !== undefined) {
+      if (
+        entry.contextWindow !== undefined &&
+        entry.maxOutputTokens !== undefined
+      ) {
         expect(
           entry.maxOutputTokens,
           `${entry.id}: maxOutputTokens exceeds contextWindow`,
@@ -83,7 +94,10 @@ describe("model registry data consistency", () => {
         for (const group of bandGroups(route)) {
           const label = `${entry.id} @ ${route.providerId}`;
           // 第一条必须从 0 起 —— 否则低输入段无价可循
-          expect(group[0]!.minInputTokens ?? 0, `${label}: first band must start at 0`).toBe(0);
+          expect(
+            group[0]!.minInputTokens ?? 0,
+            `${label}: first band must start at 0`,
+          ).toBe(0);
           for (let i = 1; i < group.length; i += 1) {
             const prev = group[i - 1]!;
             const cur = group[i]!;
@@ -99,15 +113,35 @@ describe("model registry data consistency", () => {
     }
   });
 
-  it("every tier boundary is reachable by at least one agent's declared window", () => {
-    // band 起点 ≥ 该路由所有 agent 的声明窗口 = 这条价档永不可达,
-    // 说明窗口或价档必有一边写错(#1429 的窗口下调修正会先撞到这里)。
+  it("tier boundaries fit declared windows except documented API reference bands", () => {
+    // These existing Server prices also value historical/explicit long-window
+    // usage. Their public API bands must not enlarge today's subscription window.
+    const subscriptionApiReferences = new Set([
+      "openai/gpt-5.6-sol",
+      "openai/gpt-5.6-terra",
+      "openai/gpt-5.6-luna",
+      "openai/gpt-5.5",
+      "openai/gpt-5.4",
+    ]);
     for (const entry of registry.models) {
       for (const route of entry.routes) {
         for (const group of bandGroups(route)) {
           for (const band of group) {
             const lo = band.minInputTokens ?? 0;
             if (lo === 0) continue;
+            if (
+              subscriptionApiReferences.has(entry.id) &&
+              route.providerId === "openai"
+            ) {
+              expect(lo, entry.id).toBe(272_001);
+              for (const agent of route.agents) {
+                expect(
+                  effectiveWindow(entry, agent),
+                  `${entry.id}/${agent}`,
+                ).toBe(272_000);
+              }
+              continue;
+            }
             const reachable = route.agents.some((agent) => {
               const window = effectiveWindow(entry, agent);
               return window === undefined || window > lo;

--- a/packages/model-providers/src/__tests__/user-provider.test.ts
+++ b/packages/model-providers/src/__tests__/user-provider.test.ts
@@ -293,12 +293,12 @@ describe("buildUserProvider (per-runtime)", () => {
       expect.objectContaining({
         id: "gpt-5.6-sol",
         efforts: ["low", "medium", "high", "xhigh", "max", "ultra"],
-        defaultEffort: "high",
+        defaultEffort: "medium",
       }),
       expect.objectContaining({
         id: "chatgpt/gpt-5.6-sol",
         efforts: ["low", "medium", "high", "xhigh", "max", "ultra"],
-        defaultEffort: "high",
+        defaultEffort: "medium",
       }),
       expect.objectContaining({
         id: "unregistered-model",
@@ -368,7 +368,7 @@ it('strips xd/ prefix to match registry effort metadata (entry.id ≠ custom id)
     expect(p.models.codex?.[0]).toMatchObject({
       id: 'xd/codex/gpt-5.6-sol',
       efforts: expect.arrayContaining(['ultra']),
-      defaultEffort: 'high',
+      defaultEffort: 'medium',
     });
   });
 
@@ -390,7 +390,7 @@ it('strips xd/ prefix to match registry effort metadata (entry.id ≠ custom id)
     expect(p.models.codex?.[0]).toMatchObject({
       id: 'xd/gpt-5.6-sol',
       efforts: expect.arrayContaining(['ultra']),
-      defaultEffort: 'high',
+      defaultEffort: 'medium',
     });
   });
 
@@ -413,7 +413,7 @@ it('strips xd/ prefix to match registry effort metadata (entry.id ≠ custom id)
     expect(p.models.codex?.[0]).toMatchObject({
       id: 'openai/gpt-5.6-sol',
       efforts: expect.arrayContaining(['ultra']),
-      defaultEffort: 'high',
+      defaultEffort: 'medium',
     });
   });
 
@@ -469,7 +469,7 @@ it('strips xd/ prefix to match registry effort metadata (entry.id ≠ custom id)
 
       expect(provider.models.codex?.[0]).toMatchObject({
         efforts: ["low", "medium", "high", "xhigh", "max", "ultra"],
-        defaultEffort: "high",
+        defaultEffort: "medium",
       });
     },
   );
@@ -508,7 +508,7 @@ it('strips xd/ prefix to match registry effort metadata (entry.id ≠ custom id)
 
       expect(provider.models.codex?.[0]).toMatchObject({
         efforts: ["low", "medium", "high", "xhigh", "max", "ultra"],
-        defaultEffort: "high",
+        defaultEffort: "medium",
       });
     },
   );
@@ -560,6 +560,7 @@ it('strips xd/ prefix to match registry effort metadata (entry.id ≠ custom id)
       (entry) => entry.id === "openai/gpt-5.6-sol",
     );
     if (!baseEntry) throw new Error("missing gpt-5.6-sol registry entry");
+    registry.models = [baseEntry];
     baseEntry.perAgent = {
       ...baseEntry.perAgent,
       codex: { efforts: ["minimal", "max"], defaultEffort: "high" },


### PR DESCRIPTION
## 这次改了什么

### 摘要

客户端内置 registry 停留在 47 个条目，与 Server 已发布的窗口、价格和档位有差异；服务器刷新失败或离线时会出现不同结果。将 Server 配套修正后的完整 82 条 registry 同步为客户端兜底，保留同一 revision 和内容，并补充今后的单一来源维护步骤。同步修正两处消费兼容：Kimi 新旧 wire ID 都走既有历史归一化；Claude bridge 不因省略默认档而丢弃显式 Fast 等字段。

### 变更类型

- [x] `fix` 缺陷修复
- [x] `docs` / `test` / `chore` 文档、测试或工程维护
- [ ] `feat` 新功能
- [ ] `refactor` / `perf` 重构或性能优化
- [ ] 其他：无

### 范围

- 关联 Issue / 需求：#3938 后续；配套 Server 数据补全在 xindong/cindy-server#586。
- 本 PR 包含：同步 `modelRegistry` 完整快照（新增 35、更新 34、未删除条目），窗口/价档/缓存/历史参考价和路由回归，以及 Server → Client 同步操作文档。revision 为 `2026-09-05T05:54:12.833Z`，与 Server 配套 PR 解析内容完全相等。
- 明确不包含：providers/presets、Pi 原生目录、SDK 版本或跨端 wire schema 改动；#3938 已合并的 context 显示和 usage 代码继续使用，无新增状态或合并机制。
- 用户可见变化：离线或回落内置目录时，GPT-5.x 订阅窗口与 XD route 分开，Sol/Terra/Luna 参考价更新，Sonnet 5 取消的涨价不再应用，Opus Fast 缓存价及 Grok 长输入分档补齐；包含 Server 已发布的其余模型元数据。新增目录条目不等于自动启用或获得服务权限。
- 默认模型选择器、用户已选模型和显式推理档不变。旧离线兜底默认档对齐 Server：Sol/Terra/Luna/5.5 及既有 XD Codex 对应条目、Gemini 3.5 Flash 等 high→medium；GPT-5.4/mini 的 Codex 默认 medium，CC 不再声明默认；5.4-nano 不再声明默认；Mythos 5、Grok multi-agent、XD Codex 5.4-mini 分别补 Server 已有的 high、low、medium。均未修改 Server 现行策略。
- 是否存在 breaking change：无，沿用既有 registry schema 和刷新协议。

### UI 变化

不涉及布局、交互或 UI 文案代码；选择器和参考估值消费同步后的目录数据。

- 引用的设计规范：不涉及。

## 怎么验证的

### 自动验证

```text
pnpm test:unit:related
PASS：Desktop、Mobile、model-providers、test:runner
pnpm --filter @cindy/model-providers test
PASS：704 tests
pnpm --filter @cindy/model-providers build
PASS：tsc --noEmit
pnpm --filter desktop run --if-present typecheck
PASS：0 errors
```

本轮已同步 main 到 `c43335b8f`，经 git skill `run-unit-gate.sh` 跑根 `pnpm test:unit`：GATE_EXIT=0，所有可运行 workspace 通过；Desktop typecheck 复跑退出 0。

本轮完整相关门禁和整合后根全量门禁均通过；最终 HEAD `7f8aa8faf`。

本轮兼容回归：`modelPlane.test.ts` + `codexProxyHost.test.ts` 共 248 项通过；Desktop typecheck 退出 0。

### 手工验证

两仓 JSON 解析后完全相等；Server 只改变 Astra 和两个 DeepSeek 条目，其他 Server 默认值及顶层 catalog 分区不变。review 完整 diff，`git diff --check` 通过。

### 未执行的验证

未部署 Server、未启动登录后桌面交互或移动端 Metro/实机验收，未实发模型 API；不以单元测试代替线上验收。此 PR 不改变 mobile 原生指纹。

## 风险

### 风险分类

- [x] 其他：模型目录数据与参考估值覆盖范围
- [ ] 无已知风险
- [ ] SQLite / migration
- [ ] system prompt
- [x] 协议兼容
- [ ] 权限 / 安全 / 用户数据
- [ ] 存量插件兼容
- [ ] 原生层 / fingerprint / OTA
- [ ] 跨平台差异

### 影响与回滚

- 影响范围：内置 registry 兜底与使用它的目录、参考价消费者，以及 Codex 网关历史兼容名单和 Claude bridge 字段投影。正常联网仍由现有 updatedAt 规则选择较新的完整快照，不是字段级合并，也不是无条件 Server 优先。
- 客户端兼容：Kimi 同时保留 `moonshot/kimi-k3` 与旧 `moonshotai/kimi-k3` 的历史处理。已有 root/bridge 共用原有默认档自洽规则，保留有效默认；纯远端新实体仍要求完整能力，用户显式 override 仍最后应用。没有新增状态或运行机制；回退客户端代码会恢复这两处兼容缺口，回滚目录数据仍须遵守 revision 规则。
- 配套发布：Server PR #586 补齐 Astra 标准/Fast/缓存参考价和 DeepSeek 直连历史价；发布源若配置 MODEL_CATALOG_URL，也需同步完整快照。客户端兜底不能代替 Server 发布。
- 边界：Astra 订阅估值仅覆盖 ≤272K，以上未知；既有 GPT-5.x 长输入参考价保留给历史/显式长窗口估值，不放大订阅默认窗口。DeepSeek 保留峰值参考价口径，不计实际分时账单。Gateway 实际售价不被参考价覆盖。
- 回滚 / 降级方式：更正目录需要在 Server 与客户端同步更高 revision；不要复用同 revision 修改内容或仅回退旧时间戳。用户显式覆盖保持优先。

### 提交前检查

- [x] 已 review 完整 diff
- [x] 每个 commit 都带 DCO 签名
- [x] UI 改动已注明设计依据：N/A，无 UI 代码变更
- [x] 未提交凭证、令牌或授权文件
- [x] 已补充必要文档
- [x] 已确认测试结果或说明未执行原因
