### PR TITLE
fix(mobile): 移除设置中的被控权限说明

### DIFF
--- a/apps/mobile/src/i18n/locales/en/settings.json
+++ b/apps/mobile/src/i18n/locales/en/settings.json
@@ -58,9 +58,6 @@
     "deviceName": "Device Name",
     "deviceNameDetail": "This name appears in the authorization list on your computer.",
     "platform": "Platform",
-    "remoteControl": "Remote Control",
-    "remoteControlValue": "Managed on desktop",
-    "remoteControlDetail": "This phone acts only as a controller. Granting, revoking, and restoring control permissions is done in desktop settings.",
     "editAccessibility": "Edit {{label}}"
   },
   "relay": {

--- a/apps/mobile/src/i18n/locales/ja/settings.json
+++ b/apps/mobile/src/i18n/locales/ja/settings.json
@@ -58,9 +58,6 @@
     "deviceName": "デバイス名",
     "deviceNameDetail": "パソコン側の承認リストにこの名前が表示されます。",
     "platform": "プラットフォーム",
-    "remoteControl": "リモート制御権限",
-    "remoteControlValue": "パソコン側で管理",
-    "remoteControlDetail": "このスマートフォンは操作する側としてのみ動作します。被操作の許可・取り消し・復元はパソコン側の設定で行います。",
     "editAccessibility": "{{label}}を変更"
   },
   "relay": {

--- a/apps/mobile/src/i18n/locales/ko/settings.json
+++ b/apps/mobile/src/i18n/locales/ko/settings.json
@@ -58,9 +58,6 @@
     "deviceName": "기기 이름",
     "deviceNameDetail": "컴퓨터의 승인 목록에 이 이름이 표시됩니다.",
     "platform": "플랫폼",
-    "remoteControl": "원격 제어 권한",
-    "remoteControlValue": "데스크톱에서 관리",
-    "remoteControlDetail": "이 휴대폰은 제어하는 쪽으로만 동작합니다. 피제어 허용·철회·복원은 데스크톱 설정에서 진행합니다.",
     "editAccessibility": "{{label}} 수정"
   },
   "relay": {

--- a/apps/mobile/src/i18n/locales/zh-CN/settings.json
+++ b/apps/mobile/src/i18n/locales/zh-CN/settings.json
@@ -58,9 +58,6 @@
     "deviceName": "设备名称",
     "deviceNameDetail": "电脑端授权列表会显示这个名称。",
     "platform": "平台",
-    "remoteControl": "被控权限",
-    "remoteControlValue": "电脑端管理",
-    "remoteControlDetail": "手机只作为控制端。允许被控、撤销和恢复权限仍在电脑端设置里完成。",
     "editAccessibility": "修改{{label}}"
   },
   "relay": {

--- a/apps/mobile/src/i18n/locales/zh-TW/settings.json
+++ b/apps/mobile/src/i18n/locales/zh-TW/settings.json
@@ -58,9 +58,6 @@
     "deviceName": "裝置名稱",
     "deviceNameDetail": "電腦端授權列表會顯示這個名稱。",
     "platform": "平臺",
-    "remoteControl": "被控權限",
-    "remoteControlValue": "電腦端管理",
-    "remoteControlDetail": "手機只作為控制端。允許被控、撤銷和恢復權限仍在電腦端設定裡完成。",
     "editAccessibility": "修改{{label}}"
   },
   "relay": {

--- a/apps/mobile/src/settings/mobileSettings.ts
+++ b/apps/mobile/src/settings/mobileSettings.ts
@@ -87,12 +87,6 @@ export function buildMobileSettingsOverview(input: MobileSettingsOverviewInput):
             label: i18n.t('settings.about.platform'),
             value: platformLabel(input.platform),
           },
-          {
-            id: 'about.remoteControl',
-            label: i18n.t('settings.about.remoteControl'),
-            value: i18n.t('settings.about.remoteControlValue'),
-            detail: i18n.t('settings.about.remoteControlDetail'),
-          },
         ]),
       },
       {


### PR DESCRIPTION
## 这次改了什么

### 摘要

手机版设置的「关于这台手机」原本展示「被控权限 / 电脑端管理」及解释文字。移除整条说明，减少手机用户无需关注的信息。

### 变更类型

- [x] `fix` 缺陷修复

### 范围

- 关联 Issue / 需求：手机版设置不再展示被控权限。
- 本 PR 包含：删除设置展示模型中的 `about.remoteControl` 行，并清理五种语言中对应的三个未使用翻译键。
- 明确不包含：桌面端权限管理、授权逻辑、持久配置和原生配置变更。
- 用户可见变化：所有语言的手机版设置均不再出现该项及其说明。
- 是否存在 breaking change：无。

### UI 变化

手机版「关于这台手机」保留设备名称与平台，移除被控权限整行。未提供实机截图。

- 引用的设计规范：`docs/design-rules/DESIGN.md` §1 减法原则，移除不需要呈现的信息；§10 Light / Dark，直接从共用展示模型删除该行，两种模式均适用，没有新增颜色或样式。

## 怎么验证的

### 自动验证

```text
pnpm test:unit:related
结果：PASS apps/mobile unit

pnpm --filter mobile run --if-present typecheck
结果：通过

git diff --check
结果：通过

pnpm check:i18n
pnpm check:i18n-glossary
结果：通过（现有非阻断翻译告警）
```

### 手工验证

已检查完整 diff 和设置页面消费路径：页面遍历 aboutSection.rows，删除模型行后不会保留占位行。

### 未执行的验证

未启动手机 App，Light / Dark 实机目检未执行；本次为单行展示删除，已完成相关单测和类型检查。
验证分支：`dash/hide-mobile-controlled-permissions`；worktree：`cindy-hide-mobile-controlled-permissions`。未启动 Metro，无 Metro 归属及 `__DEV__` build label 证据。

## 风险

### 风险分类

- [x] 无已知风险

### 影响与回滚

- 影响范围：手机版设置说明行；权限实际行为保持不变，不改变 runtime fingerprint。
- 回滚 / 降级方式：恢复被删除的展示行和对应翻译键。

### 提交前检查

- [x] 已 review 完整 diff
- [x] 每个 commit 都带 DCO 签名（`git commit -s`）
- [x] UI 改动已在「UI 变化」注明引用的设计规范章节
- [x] 未提交凭证、令牌或授权文件
- [x] 已补充必要文档（本次无需更新文档）
- [x] 已确认测试结果或说明未执行原因
