### PR TITLE
fix(mobile): 分享聊天长图时保留粘贴和正文图片

### DIFF
--- a/apps/mobile/app/sessions/[sessionId].tsx
+++ b/apps/mobile/app/sessions/[sessionId].tsx
@@ -5636,12 +5636,13 @@ export default function SessionScreen() {
   }, [sessionId]);
   const cancelShareSelection = useCallback(() => {
     shareOperationSeqRef.current += 1;
+    shareImages.cancel();
     setConversationShareBusy(false);
     setShareSelectionTriggeredByScreenshot(false);
     shareSelectionStore.exit();
-  }, []);
+  }, [shareImages.cancel]);
   const exportConversationSharePng = useCallback(async () => {
-    const messages = await shareImages.ready;
+    const messages = await shareImages.prepare();
     if (messages.length === 0) throw new Error('conversation share selection changed');
     const nativeShareAssetsReady = Boolean(
       nativeConversationShareAvailable
@@ -5673,7 +5674,7 @@ export default function SessionScreen() {
     const svg = conversationShareSvgRef.current;
     if (!svg) throw new Error('conversation share svg renderer is unavailable');
     return svg.exportPng();
-  }, [shareImages.ready, allShareableIds, conversationShareColors, mode, shareCharacterSrc, shareLogoSrc, windowDimensions.width]);
+  }, [shareImages.prepare, allShareableIds, conversationShareColors, mode, shareCharacterSrc, shareLogoSrc, windowDimensions.width]);
   const shareSelectedConversation = useCallback(async () => {
     if (
       conversationShareBusy

--- a/apps/mobile/app/sessions/[sessionId].tsx
+++ b/apps/mobile/app/sessions/[sessionId].tsx
@@ -136,6 +136,7 @@ import {
   collectConversationShareBlockIds,
   collectConversationShareMessages,
 } from '@/session/conversationShareMessages';
+import { useConversationShareImages } from '@/session/useConversationShareImages';
 import {
   isFoldableBlockExpanded,
   useFoldableExpandedBlocksSnapshot,
@@ -5623,30 +5624,11 @@ export default function SessionScreen() {
     textTertiary: colors.textTertiary,
     dark: mode === 'dark',
   }), [colors, mode]);
-  const conversationShareHtml = useMemo(() => {
-    if (
-      !nativeConversationShareAvailable
-      || !shareSelectionActive
-      || selectedShareMessages.length === 0
-    ) return '';
-    return buildConversationShareHtml({
-      allShareableIds,
-      characterSrc: shareCharacterSrc ?? undefined,
-      colors: conversationShareColors,
-      contentWidth: windowDimensions.width,
-      logoSrc: shareLogoModeRef.current === mode ? shareLogoSrc ?? undefined : undefined,
-      selectedMessages: selectedShareMessages,
-    });
-  }, [
-    allShareableIds,
-    conversationShareColors,
-    mode,
-    selectedShareMessages,
-    shareCharacterSrc,
-    shareLogoSrc,
-    shareSelectionActive,
-    windowDimensions.width,
-  ]);
+  const shareImages = useConversationShareImages(selectedShareMessages, resolveRemoteMedia, {
+    workdir: currentSession?.workingDir ?? undefined,
+    remoteHostId: currentSession?.remoteHostId ?? undefined,
+    sessionId,
+  });
   const enterShareSelection = useCallback((clientId: string) => {
     Keyboard.dismiss();
     setShareSelectionTriggeredByScreenshot(false);
@@ -5659,16 +5641,25 @@ export default function SessionScreen() {
     shareSelectionStore.exit();
   }, []);
   const exportConversationSharePng = useCallback(async () => {
+    const messages = await shareImages.ready;
+    if (messages.length === 0) throw new Error('conversation share selection changed');
     const nativeShareAssetsReady = Boolean(
       nativeConversationShareAvailable
       && shareCharacterSrc
       && shareLogoSrc
       && shareLogoModeRef.current === mode,
     );
-    if (conversationShareHtml && nativeShareAssetsReady) {
+    if (nativeShareAssetsReady) {
       try {
         const nativeBase64 = await renderConversationShareHtmlToPng({
-          html: conversationShareHtml,
+          html: buildConversationShareHtml({
+            allShareableIds,
+            characterSrc: shareCharacterSrc ?? undefined,
+            colors: conversationShareColors,
+            contentWidth: windowDimensions.width,
+            logoSrc: shareLogoSrc ?? undefined,
+            selectedMessages: messages,
+          }),
           width: windowDimensions.width,
         });
         if (nativeBase64) {
@@ -5682,7 +5673,7 @@ export default function SessionScreen() {
     const svg = conversationShareSvgRef.current;
     if (!svg) throw new Error('conversation share svg renderer is unavailable');
     return svg.exportPng();
-  }, [conversationShareHtml, mode, shareCharacterSrc, shareLogoSrc, windowDimensions.width]);
+  }, [shareImages.ready, allShareableIds, conversationShareColors, mode, shareCharacterSrc, shareLogoSrc, windowDimensions.width]);
   const shareSelectedConversation = useCallback(async () => {
     if (
       conversationShareBusy
@@ -9415,9 +9406,10 @@ export default function SessionScreen() {
       </ComposerKeyboardAvoidingView>
       {shareSelectionActive && selectedShareMessages.length > 0 ? (
         <ConversationShareSvg
+          key={`${shareImages.revision}-${mode}`}
           allShareableIds={allShareableIds}
           colors={conversationShareColors}
-          messages={selectedShareMessages}
+          messages={shareImages.messages}
           ref={conversationShareSvgRef}
           width={windowDimensions.width}
         />

--- a/apps/mobile/src/__tests__/ConversationShareSvgExport.test.tsx
+++ b/apps/mobile/src/__tests__/ConversationShareSvgExport.test.tsx
@@ -1,0 +1,390 @@
+// @vitest-environment jsdom
+import Module, { createRequire } from "node:module";
+import { act, createRef, StrictMode } from "react";
+import { createRoot, type Root } from "react-dom/client";
+import {
+  afterAll,
+  afterEach,
+  beforeAll,
+  beforeEach,
+  describe,
+  expect,
+  it,
+  vi,
+} from "vitest";
+import type { ConversationShareSvgHandle } from "@/session/ConversationShareSvg";
+import type { ConversationShareMessage } from "@/session/conversationShareWebViewHtml";
+import { lightColors, darkColors } from "@/theme/tokens";
+
+const native = vi.hoisted(() => ({
+  os: "ios",
+  nextId: 0,
+  svgLoads: new Map<number, () => void>(),
+  imageLoads: new Map<string, () => void>(),
+  imageErrors: new Map<string, () => void>(),
+  barrier: undefined as (() => void) | undefined,
+  queryCache: vi.fn(),
+  capture: vi.fn(),
+}));
+vi.mock("@/theme", () => ({ typeScale: { body: 15 } }));
+vi.mock("react-native", async () => {
+  const { createElement, useLayoutEffect } = await import("react");
+  const uri = (source: string | { uri: string }) =>
+    typeof source === "string" ? source : source.uri;
+  const Image = Object.assign(
+    ({
+      source,
+      onLoad,
+      onError,
+    }: {
+      source: string | { uri: string };
+      onLoad: () => void;
+      onError: () => void;
+    }) => {
+      native.imageLoads.set(uri(source), onLoad);
+      native.imageErrors.set(uri(source), onError);
+      return createElement("span", { "data-probe": uri(source) });
+    },
+    {
+      resolveAssetSource: (source: string | { uri: string }) => ({
+        uri: uri(source),
+        width: 100,
+        height: 20,
+      }),
+      queryCache: native.queryCache,
+    },
+  );
+  return {
+    Image,
+    Platform: {
+      get OS() {
+        return native.os;
+      },
+    },
+    StyleSheet: { create: (s: unknown) => s },
+    View: ({
+      children,
+      onLayout,
+    }: {
+      children?: import("react").ReactNode;
+      onLayout?: () => void;
+    }) => {
+      useLayoutEffect(() => {
+        if (!onLayout) return;
+        native.barrier = onLayout;
+        return () => {
+          native.barrier = undefined;
+        };
+      }, [onLayout]);
+      return createElement(
+        "div",
+        { "data-barrier": onLayout ? "true" : undefined },
+        children,
+      );
+    },
+  };
+});
+vi.mock("react-native-svg", async () => {
+  const { createElement, forwardRef, useImperativeHandle, useState } =
+    await import("react");
+  const element = ({ children }: { children?: import("react").ReactNode }) =>
+    createElement("span", null, children);
+  return {
+    default: forwardRef(
+      ({ children }: { children?: import("react").ReactNode }, ref) => {
+        useImperativeHandle(ref, () => ({ toDataURL: native.capture }), []);
+        return createElement("section", { "data-svg": "true" }, children);
+      },
+    ),
+    ClipPath: element,
+    Defs: element,
+    Rect: element,
+    Text: element,
+    TSpan: element,
+    Image: ({
+      href,
+      onLoad,
+    }: {
+      href: string | { uri: string };
+      onLoad: () => void;
+    }) => {
+      const [id] = useState(() => ++native.nextId);
+      native.svgLoads.set(id, onLoad);
+      return createElement("span", {
+        "data-svg-image": id,
+        "data-uri": typeof href === "string" ? href : href.uri,
+      });
+    },
+  };
+});
+
+let ConversationShareSvg: typeof import("@/session/ConversationShareSvg").ConversationShareSvg;
+const require = createRequire(import.meta.url);
+const oldJpg = require.extensions[".jpg"];
+const oldPng = require.extensions[".png"];
+const nodeModule = Module as unknown as {
+  _resolveFilename(request: string, ...args: unknown[]): string;
+};
+const resolveFilename = nodeModule._resolveFilename;
+beforeAll(async () => {
+  // Metro's static require assets are opaque identifiers; native decoding is
+  // driven explicitly below. Do not replace the component or layout builder.
+  require.extensions[".jpg"] = require.extensions[".png"] = (module, file) => {
+    module.exports = file;
+  };
+  // Metro also resolves an unsuffixed asset to its checked-in density variant.
+  nodeModule._resolveFilename = function (request, ...args) {
+    return resolveFilename.call(
+      this,
+      request.replace(
+        /^(\.\.\/\.\.\/assets\/login\/login-wordmark(?:-dark)?)\.png$/,
+        "$1@2x.png",
+      ),
+      ...args,
+    );
+  };
+  ({ ConversationShareSvg } = await import("@/session/ConversationShareSvg"));
+});
+afterAll(() => {
+  nodeModule._resolveFilename = resolveFilename;
+  if (oldJpg) require.extensions[".jpg"] = oldJpg;
+  else delete require.extensions[".jpg"];
+  if (oldPng) require.extensions[".png"] = oldPng;
+  else delete require.extensions[".png"];
+});
+
+const good = "data:image/png;base64,Z29vZA==";
+const bad = "data:image/png;base64,YmFk";
+const message: ConversationShareMessage = {
+  clientId: "m",
+  kind: "assistant",
+  attachments: [
+    { kind: "image", uri: "cindy-media://bad", name: "broken attachment" },
+  ],
+  body: "before ![broken inline](cindy-media://bad) middle ![good](cindy-media://good) after ![repeat](cindy-media://good)",
+  images: new Map([
+    ["cindy-media://good", { uri: good, width: 40, height: 20 }],
+    ["cindy-media://bad", { uri: bad, width: 40, height: 20 }],
+  ]),
+};
+let root: Root;
+let host: HTMLDivElement;
+let ref: ReturnType<typeof createRef<ConversationShareSvgHandle>>;
+beforeEach(() => {
+  Object.assign(globalThis, { IS_REACT_ACT_ENVIRONMENT: true });
+  vi.useFakeTimers({ toFake: ["setTimeout", "clearTimeout"] });
+  native.os = "ios";
+  native.svgLoads.clear();
+  native.imageLoads.clear();
+  native.imageErrors.clear();
+  native.capture
+    .mockReset()
+    .mockImplementation((done: (s: string) => void) => done("png"));
+  native.queryCache
+    .mockReset()
+    .mockImplementation(async (uris: string[]) =>
+      Object.fromEntries(uris.map((uri) => [uri, "memory"])),
+    );
+  native.barrier = undefined;
+  host = document.createElement("div");
+  root = createRoot(host);
+  ref = createRef();
+});
+afterEach(async () => {
+  await act(async () => root.unmount());
+  expect(vi.getTimerCount()).toBe(0);
+  vi.useRealTimers();
+});
+function render(width = 390, dark = false) {
+  const colors = dark ? darkColors : lightColors;
+  root.render(
+    <StrictMode>
+      <ConversationShareSvg
+        ref={ref}
+        messages={[message]}
+        allShareableIds={["m"]}
+        colors={{
+          ...colors,
+          dark,
+          background: colors.surface,
+          codeSurface: colors.chatCodeSurface,
+          inlineCode: colors.chatInlineCodeText,
+          syntax: {
+            comment: colors.syntaxComment,
+            function: colors.syntaxFunction,
+            keyword: colors.syntaxKeyword,
+            number: colors.syntaxNumber,
+            property: colors.syntaxProperty,
+            string: colors.syntaxString,
+          },
+        }}
+        width={width}
+      />
+    </StrictMode>,
+  );
+}
+function svgNodes(uri?: string) {
+  return Array.from(
+    host.querySelectorAll<HTMLElement>("[data-svg-image]"),
+  ).filter((node) => !uri || node.dataset.uri === uri);
+}
+function loadSvgExcept(excluded?: string) {
+  for (const node of svgNodes())
+    if (node.dataset.uri !== excluded)
+      native.svgLoads.get(Number(node.dataset.svgImage))!();
+}
+async function start() {
+  let result!: Promise<string>;
+  await act(async () => {
+    result = ref.current!.exportPng();
+  });
+  return { result };
+}
+
+describe("SVG export lifecycle", () => {
+  it.each([false, true])(
+    "waits for each cold iOS occurrence, then captures once after native layout (dark=%s)",
+    async (dark) => {
+      await act(async () => render(390, dark));
+      const { result } = await start();
+      const last = svgNodes(good).at(-1)!;
+      await act(async () => {
+        for (const node of svgNodes())
+          if (node !== last)
+            native.svgLoads.get(Number(node.dataset.svgImage))!();
+      });
+      expect(native.barrier).toBeUndefined();
+      await act(async () =>
+        native.svgLoads.get(Number(last.dataset.svgImage))!(),
+      );
+      expect(native.capture).not.toHaveBeenCalled();
+      await act(async () => {
+        native.barrier!();
+        native.barrier!();
+      });
+      await expect(result).resolves.toBe("png");
+      expect(native.capture).toHaveBeenCalledTimes(1);
+      expect(svgNodes(good)).toHaveLength(2);
+      expect(svgNodes(bad)).toHaveLength(2);
+    },
+  );
+
+  it("freezes timeout fallback before capture, preserving normal occurrences and ignoring late loads", async () => {
+    await act(async () => render());
+    const goodNodes = svgNodes(good);
+    const lateLoads = svgNodes(bad).map((node) =>
+      native.svgLoads.get(Number(node.dataset.svgImage))!,
+    );
+    const { result } = await start();
+    await act(async () => loadSvgExcept(bad));
+    await act(async () => vi.advanceTimersByTimeAsync(15_000));
+    expect(native.capture).not.toHaveBeenCalled();
+    expect(svgNodes(bad)).toHaveLength(0);
+    expect(svgNodes(good)).toEqual(goodNodes);
+    expect(host.textContent).toContain("broken attachment");
+    expect(host.textContent).toContain("broken inline");
+    expect(host.textContent).not.toContain("cindy-media://bad");
+    await act(async () => {
+      lateLoads.forEach((load) => load());
+      render(420);
+    });
+    expect(svgNodes(bad)).toHaveLength(0);
+    expect(svgNodes(good)).toEqual(goodNodes);
+    await act(async () => native.barrier!());
+    await expect(result).resolves.toBe("png");
+  });
+
+  it.each(["error", "disk", "empty-cache", "query-error"])(
+    "handles Android cache hits with no SVG event and %s for a damaged image",
+    async (failure) => {
+      native.os = "android";
+      native.queryCache.mockImplementation(async ([uri]: string[]) => {
+        if (uri === bad && failure === "query-error")
+          throw new Error("cache unavailable");
+        if (uri === bad && failure === "empty-cache") return {};
+        return { [uri!]: uri === bad ? "disk" : "memory" };
+      });
+      await act(async () => render());
+      const { result } = await start();
+      await act(async () => {
+        for (const [uri, load] of native.imageLoads) {
+          if (uri === bad && failure === "error")
+            native.imageErrors.get(uri)!();
+          else load();
+        }
+      });
+      expect(svgNodes(good)).toHaveLength(2);
+      expect(svgNodes(bad)).toHaveLength(0);
+      expect(host.textContent).toContain("broken inline");
+      // Bundled resource names are not queryable via Android's URI-only cache API.
+      expect(
+        native.queryCache.mock.calls.every(([uris]) =>
+          uris[0].startsWith("data:"),
+        ),
+      ).toBe(true);
+      expect(native.capture).not.toHaveBeenCalled();
+      await act(async () => native.barrier!());
+      await expect(result).resolves.toBe("png");
+    },
+  );
+
+  it("rejects a missing footer within the deadline instead of capturing an incomplete footer", async () => {
+    await act(async () => render());
+    const { result } = await start();
+    const rejected = expect(result).rejects.toThrow("footer is unavailable");
+    await act(async () => {
+      for (const node of [...svgNodes(good), ...svgNodes(bad)])
+        native.svgLoads.get(Number(node.dataset.svgImage))!();
+      await vi.advanceTimersByTimeAsync(15_000);
+    });
+    await rejected;
+    expect(native.capture).not.toHaveBeenCalled();
+  });
+
+  it.each(["decoding", "layout", "capturing"])(
+    "cancels on unmount during %s and ignores late native events",
+    async (stage) => {
+      native.capture.mockImplementation(() => {});
+      await act(async () => render());
+      const { result } = await start();
+      const rejected = expect(result).rejects.toThrow("cancelled");
+      if (stage !== "decoding") await act(async () => loadSvgExcept());
+      const lateLayout = native.barrier;
+      if (stage === "capturing") await act(async () => native.barrier!());
+      const lateCapture = native.capture.mock.calls[0]?.[0];
+      await act(async () => root.render(null));
+      await rejected;
+      await act(async () => {
+        native.svgLoads.forEach((load) => load());
+        lateLayout?.();
+        lateCapture?.("late png");
+      });
+      expect(native.capture).toHaveBeenCalledTimes(
+        stage === "capturing" ? 1 : 0,
+      );
+    },
+  );
+
+  it.each(["throw", "empty", "no-callback", "no-layout"])(
+    "bounds capture failure: %s",
+    async (failure) => {
+      native.capture.mockImplementation((done: (s: string) => void) => {
+        if (failure === "throw") throw new Error("capture failed");
+        if (failure === "empty") done("");
+      });
+      await act(async () => render());
+      const { result } = await start();
+      const rejected = expect(result).rejects.toThrow(
+        failure === "throw"
+          ? "capture failed"
+          : failure === "empty"
+            ? "empty"
+            : "timed out",
+      );
+      await act(async () => loadSvgExcept());
+      if (failure !== "no-layout") await act(async () => native.barrier!());
+      await act(async () => vi.advanceTimersByTimeAsync(20_000));
+      await rejected;
+    },
+  );
+});

--- a/apps/mobile/src/__tests__/conversationShareImages.test.ts
+++ b/apps/mobile/src/__tests__/conversationShareImages.test.ts
@@ -1,0 +1,151 @@
+import { describe, expect, it, vi } from "vitest";
+import { prepareConversationShareImages } from "@/session/conversationShareImages";
+import { projectConversationShareMessage } from "@/session/conversationShareProjection";
+import { buildConversationShareHtml } from "@/session/conversationShareWebViewHtml";
+import { buildConversationShareSvgLayout } from "@/session/conversationShareSvgLayout";
+import { lightColors, darkColors } from "@/theme/tokens";
+
+const image = {
+  uri: "data:image/png;base64,aGVsbG8=",
+  width: 640,
+  height: 480,
+};
+
+describe("conversation share images", () => {
+  it.each([lightColors, darkColors])(
+    "embeds pasted and inline images in both exporters without source URLs",
+    async (theme) => {
+      const source = "cindy-media://asset/pasted";
+      const inline = "https://example.com/image.png?signature=private";
+      const projected = projectConversationShareMessage("user", {
+        kind: "user",
+        body: `Picture: ![inline](${inline})`,
+        attachments: [
+          { kind: "image", name: "pasted.png", uri: source, previewable: true },
+        ],
+      })!;
+      const load = vi.fn(async () => image);
+      const messages = await prepareConversationShareImages([projected], load);
+      const colors = {
+        background: theme.surface,
+        border: theme.border,
+        codeSurface: theme.chatCodeSurface,
+        inlineCode: theme.chatInlineCodeText,
+        surfaceChip: theme.surfaceChip,
+        surfaceElevated: theme.surfaceElevated,
+        textPrimary: theme.textPrimary,
+        textSecondary: theme.textSecondary,
+        textTertiary: theme.textTertiary,
+        syntax: {},
+      };
+      const html = buildConversationShareHtml({
+        selectedMessages: messages,
+        allShareableIds: ["user"],
+        colors,
+        contentWidth: 390,
+      });
+      expect(html.split(`src="${image.uri}"`)).toHaveLength(3);
+      expect(html).not.toContain(source);
+      expect(html).not.toContain(inline);
+      expect(html).toContain("img-src data:");
+      const svg = buildConversationShareSvgLayout({
+        messages,
+        allShareableIds: ["user"],
+        colors,
+        width: 390,
+      });
+      expect(svg.images).toHaveLength(2);
+      for (const rendered of svg.images) {
+        expect(rendered.uri).toBe(image.uri);
+        expect(rendered.width / rendered.height).toBeCloseTo(4 / 3);
+        expect(rendered.x + rendered.width).toBeLessThanOrEqual(390);
+        expect(rendered.y + rendered.height).toBeLessThan(svg.footerY);
+      }
+    },
+  );
+
+  it("reuses attachment bytes, skips code and hidden chip contents, and preserves failures", async () => {
+    const load = vi.fn(async (url: string) => {
+      if (url.includes("missing")) throw new Error("offline");
+      return image;
+    });
+    const messages = await prepareConversationShareImages(
+      [
+        {
+          clientId: "u",
+          kind: "user",
+          body: "![hidden](https://hidden.test/image.png)",
+          bodyParts: [
+            { kind: "quote", label: "![quote](https://quote.test/a.png)" },
+            {
+              kind: "text",
+              text: "```md\n![code](https://code.test/a.png)\n```",
+            },
+          ],
+          attachments: [
+            { kind: "image", name: "one", uri: "cindy-media://same" },
+            { kind: "image", name: "two", uri: "cindy-media://same" },
+            { kind: "image", name: "missing", uri: "cindy-media://missing" },
+            { kind: "file", name: "file", uri: "file:///private/file" },
+          ],
+        },
+      ],
+      load,
+    );
+    expect(load.mock.calls.map(([url]) => url)).toEqual([
+      "cindy-media://same",
+      "cindy-media://missing",
+    ]);
+    expect(messages[0]?.images?.size).toBe(1);
+    expect(messages[0]?.attachments?.[2]?.name).toBe("missing");
+  });
+
+  it("routes relative and forged SSH image URLs using the current trusted session", async () => {
+    const load = vi.fn(async () => image);
+    await prepareConversationShareImages(
+      [
+        {
+          clientId: "m",
+          kind: "assistant",
+          body: "![relative](./pic.png)\n![forged](xdt-file://open?path=%2Fwork%2Fpic.png&sessionId=other&remoteHostId=evil)",
+        },
+      ],
+      load,
+      { workdir: "/work", remoteHostId: "host", sessionId: "session" },
+    );
+    for (const [url] of load.mock.calls as unknown as [string][]) {
+      const parsed = new URL(url);
+      expect(parsed.protocol).toBe("xdt-file:");
+      expect(parsed.searchParams.get("sessionId")).toBe("session");
+      expect(parsed.searchParams.get("remoteHostId")).toBe("host");
+      expect(parsed.searchParams.get("v")).toBe("m");
+    }
+    expect(load).toHaveBeenCalled();
+  });
+
+  it("stops reading remaining images when selection is cancelled", async () => {
+    let active = true;
+    const load = vi.fn(async () => {
+      active = false;
+      return image;
+    });
+    const result = await prepareConversationShareImages(
+      [
+        {
+          clientId: "u",
+          kind: "user",
+          body: "",
+          attachments: [
+            { kind: "image", name: "one", uri: "cindy-media://one" },
+            { kind: "image", name: "two", uri: "cindy-media://two" },
+          ],
+        },
+      ],
+      load,
+      {},
+      () => active,
+    );
+    expect(load).toHaveBeenCalledTimes(1);
+    expect(result).toEqual([]);
+  });
+});

--- a/apps/mobile/src/__tests__/conversationShareImages.test.ts
+++ b/apps/mobile/src/__tests__/conversationShareImages.test.ts
@@ -12,6 +12,46 @@ const image = {
 };
 
 describe("conversation share images", () => {
+  it("charges every attachment and Markdown occurrence even when bytes are reused across messages", async () => {
+    const largeImage = {
+      ...image,
+      uri: "data:image/png;base64," + "A".repeat(6 * 1024 * 1024),
+    };
+    const source = "cindy-media://repeated";
+    const load = vi.fn(async () => largeImage);
+    const repeated = {
+      clientId: "one",
+      kind: "user" as const,
+      body: `![body](${source})`,
+      secondaryBody: `![secondary](${source})`,
+      attachments: [{ kind: "image" as const, name: "paste", uri: source }],
+    };
+    const messages = await prepareConversationShareImages(
+      [repeated, { ...repeated, clientId: "two" }],
+      load,
+    );
+    expect(messages[0]?.images?.get(source)).toBe(largeImage);
+    expect(messages[1]?.images?.size).toBe(0);
+    expect(load).toHaveBeenCalledTimes(1);
+    load.mockClear();
+    const tooMany = await prepareConversationShareImages(
+      [
+        {
+          ...repeated,
+          attachments: Array.from(
+            { length: 4 },
+            () => repeated.attachments[0]!,
+          ),
+        },
+        { ...repeated, clientId: "later" },
+      ],
+      load,
+    );
+    expect(tooMany[0]?.images?.size).toBe(0);
+    expect(tooMany[1]?.images?.get(source)).toBe(largeImage);
+    expect(load).toHaveBeenCalledTimes(2);
+  });
+
   it.each([lightColors, darkColors])(
     "embeds pasted and inline images in both exporters without source URLs",
     async (theme) => {

--- a/apps/mobile/src/__tests__/conversationShareImages.test.ts
+++ b/apps/mobile/src/__tests__/conversationShareImages.test.ts
@@ -12,6 +12,90 @@ const image = {
 };
 
 describe("conversation share images", () => {
+  it("lets free workers advance across messages while the first source is stalled", async () => {
+    const finishes = new Map<string, (value: typeof image | null) => void>();
+    let active = 0;
+    let peak = 0;
+    const load = vi.fn((url: string) => {
+      peak = Math.max(peak, ++active);
+      return new Promise<typeof image | null>((resolve) =>
+        finishes.set(url, resolve),
+      ).finally(() => {
+        active--;
+      });
+    });
+    const messages = Array.from({ length: 6 }, (_, i) => ({
+      clientId: String(i),
+      kind: "user" as const,
+      body: "",
+      attachments: [
+        { kind: "image" as const, name: String(i), uri: `cindy-media://${i}` },
+      ],
+    }));
+    const pending = prepareConversationShareImages(messages, load);
+    expect(load).toHaveBeenCalledTimes(3);
+    for (let i = 1; i < 6; i++) {
+      await vi.waitFor(() =>
+        expect(finishes.has(`cindy-media://${i}`)).toBe(true),
+      );
+      finishes.get(`cindy-media://${i}`)!(image);
+    }
+    finishes.get("cindy-media://0")!(null);
+    const result = await pending;
+    expect(peak).toBe(3);
+    expect(load).toHaveBeenCalledTimes(6);
+    expect(result.map((m) => m.clientId)).toEqual(
+      messages.map((m) => m.clientId),
+    );
+    expect(result.map((m) => m.images!.size)).toEqual([0, 1, 1, 1, 1, 1]);
+  });
+
+  it("admits ready sources within both occurrence budgets and discards cancelled late loads", async () => {
+    for (const cancel of [false, true]) {
+      let active = true;
+      const finishes = new Map<string, (value: typeof image) => void>();
+      const load = vi.fn(
+        (url: string) =>
+          new Promise<typeof image>((done) => finishes.set(url, done)),
+      );
+      const urls = ["first", "second", "third", "queued"];
+      const pending = prepareConversationShareImages(
+        [
+          {
+            clientId: "m",
+            kind: "user",
+            body: "",
+            attachments: urls.flatMap((url) =>
+              Array.from({ length: 2 }, () => ({
+                kind: "image" as const,
+                name: url,
+                uri: url,
+              })),
+            ),
+          },
+        ],
+        load,
+        {},
+        () => active,
+      );
+      expect(load).toHaveBeenCalledTimes(3);
+      if (cancel) active = false;
+      const large = {
+        ...image,
+        width: 2000,
+        height: 2000,
+        uri: "data:image/png;base64," + "A".repeat(10 * 1024 * 1024),
+      };
+      finishes.get("second")!(large);
+      finishes.get("third")!(large);
+      finishes.get("first")!(large);
+      const result = await pending;
+      expect(load).toHaveBeenCalledTimes(3);
+      if (cancel) expect(result).toEqual([]);
+      else expect([...result[0]!.images!.keys()]).toEqual(["second"]);
+    }
+  });
+
   it("rejects compressed images above the single-image pixel limit without spending the batch budget", async () => {
     const load = vi.fn(async (url: string) => ({
       ...image,
@@ -40,9 +124,6 @@ describe("conversation share images", () => {
     ]);
     expect(messages[0]!.body).toBe("keep text");
     expect(messages[0]!.attachments).toHaveLength(4);
-    expect(load.mock.calls.map(([url]) => url)).not.toContain(
-      "cindy-media://three",
-    );
   });
 
   it("charges decoded pixels for repeated sources across attachments, structured/secondary text and messages", async () => {
@@ -114,7 +195,7 @@ describe("conversation share images", () => {
     );
     expect(tooMany[0]?.images?.size).toBe(0);
     expect(tooMany[1]?.images?.get(source)).toBe(largeImage);
-    expect(load).toHaveBeenCalledTimes(2);
+    expect(load).toHaveBeenCalledTimes(1);
   });
 
   it.each([lightColors, darkColors])(
@@ -170,9 +251,9 @@ describe("conversation share images", () => {
   );
 
   it("reuses attachment bytes, skips code and hidden chip contents, and preserves failures", async () => {
-    const load = vi.fn(async (url: string) => {
+    const load = vi.fn((url: string) => {
       if (url.includes("missing")) throw new Error("offline");
-      return image;
+      return Promise.resolve(image);
     });
     const messages = await prepareConversationShareImages(
       [

--- a/apps/mobile/src/__tests__/conversationShareImages.test.ts
+++ b/apps/mobile/src/__tests__/conversationShareImages.test.ts
@@ -12,6 +12,71 @@ const image = {
 };
 
 describe("conversation share images", () => {
+  it("rejects compressed images above the single-image pixel limit without spending the batch budget", async () => {
+    const load = vi.fn(async (url: string) => ({
+      ...image,
+      width: url.endsWith("huge") ? 100_000 : 2_000,
+      height: url.endsWith("huge") ? 100_000 : 2_000,
+    }));
+    const messages = await prepareConversationShareImages(
+      [
+        {
+          clientId: "m",
+          kind: "user",
+          body: "keep text",
+          attachments: [
+            { kind: "image", name: "huge", uri: "cindy-media://huge" },
+            { kind: "image", name: "one", uri: "cindy-media://one" },
+            { kind: "image", name: "two", uri: "cindy-media://two" },
+            { kind: "image", name: "over batch", uri: "cindy-media://three" },
+          ],
+        },
+      ],
+      load,
+    );
+    expect([...messages[0]!.images!.keys()]).toEqual([
+      "cindy-media://one",
+      "cindy-media://two",
+    ]);
+    expect(messages[0]!.body).toBe("keep text");
+    expect(messages[0]!.attachments).toHaveLength(4);
+    expect(load.mock.calls.map(([url]) => url)).not.toContain(
+      "cindy-media://three",
+    );
+  });
+
+  it("charges decoded pixels for repeated sources across attachments, structured/secondary text and messages", async () => {
+    const url = "cindy-media://same";
+    const load = vi.fn(async () => ({ ...image, width: 2_000, height: 1_000 }));
+    const message = {
+      clientId: "first",
+      kind: "user" as const,
+      body: "ignored",
+      attachments: [{ kind: "image" as const, name: "paste", uri: url }],
+      bodyParts: [{ kind: "text" as const, text: `![body](${url})` }],
+      secondaryBody: `![secondary](${url})`,
+    };
+    const result = await prepareConversationShareImages(
+      [
+        message,
+        { ...message, clientId: "over" },
+        { clientId: "last", kind: "assistant", body: `![last](${url})` },
+      ],
+      load,
+    );
+    expect(result.map((m) => m.images!.size)).toEqual([1, 0, 1]);
+    expect(load).toHaveBeenCalledTimes(1);
+    // A rejected oversized occurrence group must not poison a later smaller group.
+    const retry = await prepareConversationShareImages(
+      [
+        { ...message, secondaryBody: `![a](${url})![b](${url})![c](${url})` },
+        { ...message, clientId: "later" },
+      ],
+      load,
+    );
+    expect(retry.map((m) => m.images!.size)).toEqual([0, 1]);
+  });
+
   it("charges every attachment and Markdown occurrence even when bytes are reused across messages", async () => {
     const largeImage = {
       ...image,

--- a/apps/mobile/src/__tests__/conversationShareProjection.test.ts
+++ b/apps/mobile/src/__tests__/conversationShareProjection.test.ts
@@ -45,7 +45,7 @@ describe('projectConversationShareMessage', () => {
     );
   });
 
-  it('按气泡顺序保留图片和文件名，不把附件字节或来源带入导出', () => {
+  it('保留图片读取地址和附件顺序，但不带入普通文件的本机路径', () => {
     const projected = projectConversationShareMessage('attachments', {
       attachments: [
         {
@@ -72,12 +72,10 @@ describe('projectConversationShareMessage', () => {
     });
 
     expect(projected?.attachments).toEqual([
-      { kind: 'image', name: 'inline.png' },
-      { kind: 'image', name: 'remote.png' },
+      { kind: 'image', name: 'inline.png', uri: 'data:image/png;base64,AA==' },
+      { kind: 'image', name: 'remote.png', uri: 'https://example.com/private.png' },
       { kind: 'file', name: 'notes.md' },
     ]);
-    expect(JSON.stringify(projected)).not.toContain('example.com');
     expect(JSON.stringify(projected)).not.toContain('/private/project');
-    expect(JSON.stringify(projected)).not.toContain('data:image');
   });
 });

--- a/apps/mobile/src/__tests__/conversationShareSvg.test.ts
+++ b/apps/mobile/src/__tests__/conversationShareSvg.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it } from "vitest";
+import { redactSensitiveText } from "@cindy/maker-shared/error-redaction";
 
 import { i18n } from "@/i18n";
 import { createConversationShareFooterAssetGate } from "@/session/conversationShareAssetGate";
@@ -29,6 +30,48 @@ const colors = {
 };
 
 describe("ConversationShareSvg", () => {
+  it.each([
+    ["password: ", "private-secret"],
+    ["pass", "word: private-secret"],
+    ["password: private-", "secret"],
+    ["Authorization: Basic ", "private-secret"],
+    ["sk-abcd", "12345678"],
+    ["password: ", "`private-secret`"],
+    ["password: ", "**private-secret**"],
+    ["password:\n\n", "private-secret"],
+    ["token: [REDACTED]\npassword: ", "private-secret"],
+  ])("redacts across an image between %s and %s", (before, after) => {
+    const url = "cindy-media://same";
+    const image = {
+      uri: "data:image/png;base64,aGVsbG8=",
+      width: 40,
+      height: 20,
+    };
+    const layout = buildConversationShareSvgLayout({
+      allShareableIds: ["m"],
+      colors,
+      width: 390,
+      messages: [
+        {
+          clientId: "m",
+          kind: "assistant",
+          body: `${before}![one](${url})![two](${url})${after}`,
+          images: new Map([[url, image]]),
+        },
+      ],
+    });
+    const text = layout.bubbles
+      .flatMap((bubble) => bubble.textBlocks.flatMap((block) => block.lines))
+      .join("");
+    const visible = (before + after).replace(/[`*]/g, "");
+    expect(text.replace(/\s/g, "")).toBe(
+      redactSensitiveText(visible).replace(/\s/g, ""),
+    );
+    expect(layout.images).toHaveLength(2);
+    expect(layout.images[0]!.y).toBeLessThan(layout.images[1]!.y);
+    expect(text).not.toContain("private-secret");
+  });
+
   it.each(["user", "assistant"] as const)(
     "preserves repeated image positions inside a %s bubble, including an attachment with the same source",
     (kind) => {

--- a/apps/mobile/src/__tests__/conversationShareSvg.test.ts
+++ b/apps/mobile/src/__tests__/conversationShareSvg.test.ts
@@ -29,6 +29,95 @@ const colors = {
 };
 
 describe("ConversationShareSvg", () => {
+  it.each(["user", "assistant"] as const)(
+    "preserves repeated image positions inside a %s bubble, including an attachment with the same source",
+    (kind) => {
+      const url = "cindy-media://same";
+      const image = {
+        uri: "data:image/png;base64,aGVsbG8=",
+        width: 40,
+        height: 20,
+      };
+      const layout = buildConversationShareSvgLayout({
+        allShareableIds: ["m"],
+        colors,
+        width: 390,
+        messages: [
+          {
+            clientId: "m",
+            kind,
+            attachments: [{ kind: "image", name: "attachment", uri: url }],
+            body: `before ![first](${url}) middle ![second](${url}) after`,
+            images: new Map([[url, image]]),
+          },
+        ],
+      });
+      expect(layout.images).toHaveLength(3);
+      const bubble = layout.bubbles[0]!;
+      const text = bubble.textBlocks;
+      expect(text.map((block) => block.lines.join(""))).toEqual([
+        "before",
+        "middle",
+        "after",
+      ]);
+      expect(layout.images[0]!.y + layout.images[0]!.height).toBeLessThan(
+        bubble.y,
+      );
+      expect(text[0]!.y).toBeLessThan(layout.images[1]!.y);
+      expect(layout.images[1]!.y + layout.images[1]!.height).toBeLessThan(
+        text[1]!.y,
+      );
+      expect(text[1]!.y).toBeLessThan(layout.images[2]!.y);
+      expect(layout.images[2]!.y + layout.images[2]!.height).toBeLessThan(
+        text[2]!.y,
+      );
+      expect(layout.images[2]!.y + layout.images[2]!.height).toBeLessThan(
+        bubble.y + bubble.height,
+      );
+    },
+  );
+
+  it("traverses structured text, table cells, and secondary body without parsing code or chip labels as images", () => {
+    const url = "cindy-media://same";
+    const image = {
+      uri: "data:image/png;base64,aGVsbG8=",
+      width: 40,
+      height: 20,
+    };
+    const layout = buildConversationShareSvgLayout({
+      allShareableIds: ["m"],
+      colors,
+      width: 390,
+      messages: [
+        {
+          clientId: "m",
+          kind: "assistant",
+          body: "ignored",
+          images: new Map([[url, image]]),
+          bodyParts: [
+            { kind: "quote", label: `![chip](${url})` },
+            {
+              kind: "text",
+              text: `> quote ![quote image](${url})\n\n- item ![list image](${url})\n\n| header ![head](${url}) | next |\n| --- | --- |\n| ![cell](${url}) | last |\n\n\`\`\`md\n![code](${url})\n\`\`\``,
+            },
+          ],
+          secondaryBody: `secondary ![last](${url}) end`,
+        },
+      ],
+    });
+    expect(layout.images).toHaveLength(5);
+    expect(layout.images.map((image) => image.y)).toEqual(
+      layout.images.map((image) => image.y).sort((a, b) => a - b),
+    );
+    const text = layout.bubbles
+      .flatMap((bubble) => bubble.textBlocks.flatMap((block) => block.lines))
+      .join("\n");
+    expect(text).toContain("![chip]");
+    expect(text).toContain("![code]");
+    expect(text).not.toContain("quote image");
+    expect(text).toContain("secondary");
+  });
+
   it("wraps Chinese and Latin text within the available width", () => {
     expect(
       wrapSvgText("这是很长的一段中文消息", 60, 15).length,

--- a/apps/mobile/src/__tests__/conversationShareSvg.test.ts
+++ b/apps/mobile/src/__tests__/conversationShareSvg.test.ts
@@ -2,7 +2,7 @@ import { describe, expect, it } from "vitest";
 import { redactSensitiveText } from "@cindy/maker-shared/error-redaction";
 
 import { i18n } from "@/i18n";
-import { createConversationShareFooterAssetGate } from "@/session/conversationShareAssetGate";
+import { createConversationShareAssetGate } from "@/session/conversationShareAssetGate";
 import {
   buildConversationShareSvgLayout,
   conversationShareSvgRenderSize,
@@ -331,9 +331,9 @@ describe("ConversationShareSvg", () => {
   });
 
   it("waits for both footer assets before allowing export", async () => {
-    const gate = createConversationShareFooterAssetGate();
+    const gate = createConversationShareAssetGate(["character", "logo"]);
     let ready = false;
-    const wait = gate.waitUntilReady().then(() => {
+    const wait = gate.waitUntilSettled().then(() => {
       ready = true;
     });
 

--- a/apps/mobile/src/__tests__/conversationShareSvg.test.ts
+++ b/apps/mobile/src/__tests__/conversationShareSvg.test.ts
@@ -30,6 +30,75 @@ const colors = {
 };
 
 describe("ConversationShareSvg", () => {
+  it.each(["user", "assistant"] as const)(
+    "preserves mixed attachment order through every image fallback combination for %s",
+    (kind) => {
+      for (let ready = 0; ready < 8; ready++) {
+        const urls = ["first", "second", "third"];
+        const images = new Map(
+          urls.flatMap((url, index) =>
+            ready & (1 << index)
+              ? [
+                  [
+                    url,
+                    {
+                      uri: `data:image/png;base64,${url}`,
+                      width: 40,
+                      height: 20,
+                    },
+                  ] as const,
+                ]
+              : [],
+          ),
+        );
+        const layout = buildConversationShareSvgLayout({
+          allShareableIds: ["m"],
+          colors,
+          width: 390,
+          messages: [
+            {
+              clientId: "m",
+              kind,
+              automationOriginLabel: "automation",
+              body: "body",
+              attachments: [
+                { kind: "image", name: "first", uri: "first" },
+                { kind: "file", name: "document" },
+                { kind: "image", name: "second", uri: "second" },
+                { kind: "image", name: "third", uri: "third" },
+              ],
+              images,
+            },
+          ],
+        });
+        const visible = [
+          ...layout.images.map((image) => ({
+            y: image.y,
+            text: image.uri.split(",")[1],
+          })),
+          ...layout.bubbles.map((bubble) => ({
+            y: bubble.y,
+            text: bubble.textBlocks
+              .flatMap((block) => block.lines)
+              .join(" ")
+              .replace(/^[▧▤] /, ""),
+          })),
+        ].sort((a, b) => a.y - b.y);
+        expect(visible.map((item) => item.text)).toEqual([
+          "automation",
+          "first",
+          "document",
+          "second",
+          "third",
+          "body",
+        ]);
+        for (let i = 1; i < visible.length; i++) {
+          expect(visible[i]!.y).toBeGreaterThan(visible[i - 1]!.y);
+        }
+      }
+    },
+  );
+
   it.each([0, 1, 2])(
     "keeps attribution above all content with %i decoded attachments",
     (decodedCount) => {
@@ -80,7 +149,7 @@ describe("ConversationShareSvg", () => {
           expect(item.y).toBeGreaterThan(attributionBottom);
         }
         const content = layout.bubbles.slice(2, -1);
-        expect(content).toHaveLength(decodedCount < 2 || body ? 1 : 0);
+        expect(content).toHaveLength(2 - decodedCount + (body ? 1 : 0));
         expect(
           content
             .flatMap((bubble) => bubble.textBlocks)

--- a/apps/mobile/src/__tests__/conversationShareSvg.test.ts
+++ b/apps/mobile/src/__tests__/conversationShareSvg.test.ts
@@ -30,6 +30,71 @@ const colors = {
 };
 
 describe("ConversationShareSvg", () => {
+  it.each([0, 1, 2])(
+    "keeps attribution above all content with %i decoded attachments",
+    (decodedCount) => {
+      for (const body of ["", "message body"]) {
+        const image = {
+          uri: "data:image/png;base64,aGVsbG8=",
+          width: 40,
+          height: 20,
+        };
+        const urls = ["cindy-media://first", "cindy-media://second"];
+        const label = "Sent by automation: ".repeat(8);
+        const layout = buildConversationShareSvgLayout({
+          allShareableIds: ["previous", "skipped", "m", "next"],
+          colors,
+          width: 390,
+          messages: [
+            { clientId: "previous", kind: "assistant", body: "previous" },
+            {
+              clientId: "m",
+              kind: "user",
+              automationOriginLabel: label,
+              attachments: urls.map((uri) => ({
+                kind: "image",
+                name: "attachment",
+                uri,
+              })),
+              images: new Map(
+                urls.slice(0, decodedCount).map((uri) => [uri, image]),
+              ),
+              body,
+            },
+            { clientId: "next", kind: "assistant", body: "next" },
+          ],
+        });
+        const attribution = layout.bubbles[1]!;
+        expect(attribution.fill).toBeUndefined();
+        expect(attribution.stroke).toBeUndefined();
+        expect(attribution.textBlocks).toHaveLength(1);
+        expect(attribution.textBlocks[0]!.lines.length).toBeGreaterThan(1);
+        expect(attribution.textBlocks[0]!.lines.join(" ")).toContain(
+          "Sent by automation:",
+        );
+        expect(attribution.textBlocks[0]!.color).toBe(colors.textTertiary);
+        expect(layout.gaps[0]!.y).toBeLessThan(attribution.y);
+        expect(layout.images).toHaveLength(decodedCount);
+        const attributionBottom = attribution.y + attribution.height;
+        for (const item of [...layout.images, ...layout.bubbles.slice(2)]) {
+          expect(item.y).toBeGreaterThan(attributionBottom);
+        }
+        const content = layout.bubbles.slice(2, -1);
+        expect(content).toHaveLength(decodedCount < 2 || body ? 1 : 0);
+        expect(
+          content
+            .flatMap((bubble) => bubble.textBlocks)
+            .some((block) =>
+              block.lines.join(" ").includes("Sent by automation:"),
+            ),
+        ).toBe(false);
+        expect(layout.bubbles.at(-1)!.y).toBeGreaterThan(
+          layout.images.at(-1)?.y ?? attributionBottom,
+        );
+      }
+    },
+  );
+
   it.each([
     ["password: ", "private-secret"],
     ["pass", "word: private-secret"],
@@ -227,9 +292,9 @@ describe("ConversationShareSvg", () => {
       ],
       width: 390,
     });
-    const renderedText =
-      layout.bubbles[0]?.textBlocks.flatMap((block) => block.lines).join(" ") ??
-      "";
+    const renderedText = layout.bubbles
+      .flatMap((bubble) => bubble.textBlocks.flatMap((block) => block.lines))
+      .join(" ");
     expect(renderedText).not.toContain("sk-12345678");
     expect(renderedText).toContain("[REDACTED]");
   });

--- a/apps/mobile/src/__tests__/conversationShareWebViewHtml.test.ts
+++ b/apps/mobile/src/__tests__/conversationShareWebViewHtml.test.ts
@@ -241,7 +241,7 @@ describe('buildConversationShareHtml 富内容导出', () => {
       'if (!nativeConversationShareAvailable || !shareSelectionActive) return undefined;',
     );
     expect(sessionSource).toContain(
-      'const messages = await shareImages.ready;',
+      'const messages = await shareImages.prepare();',
     );
     expect(sessionSource).toContain(
       'nativeConversationShareAvailable\n      && shareCharacterSrc',

--- a/apps/mobile/src/__tests__/conversationShareWebViewHtml.test.ts
+++ b/apps/mobile/src/__tests__/conversationShareWebViewHtml.test.ts
@@ -88,6 +88,27 @@ describe('buildConversationShareHtml 富内容导出', () => {
     },
   );
 
+  it.each(['body', 'bodyParts', 'secondaryBody'] as const)(
+    '%s 中图片语法受到脱敏影响时由 SVG 保留图片或替代文字',
+    (field) => {
+      const url = 'https://example.com/p.png';
+      const body = `password: private![preview](${url})`;
+      for (const prepared of [false, true]) {
+        const message = {
+          clientId: 'm', kind: 'assistant' as const, body: '',
+          ...(field === 'bodyParts' ? { bodyParts: [{ kind: 'text' as const, text: body }] } : { [field]: body }),
+          images: new Map(prepared ? [[url, { uri: 'data:image/png;base64,aGVsbG8=', width: 40, height: 20 }]] : []),
+        };
+        const options = { allShareableIds: ['m'], colors, contentWidth: 390, selectedMessages: [message] };
+        expect(() => buildConversationShareHtml(options)).toThrow('conversation-share-image-requires-svg');
+        const svg = buildConversationShareSvgLayout({ ...options, width: 390, messages: [message] });
+        expect(svg.images).toHaveLength(prepared ? 1 : 0);
+        expect(JSON.stringify(svg)).not.toContain('private');
+        expect(JSON.stringify(svg)).not.toContain(url);
+      }
+    },
+  );
+
   it('只按选中内容嵌入对应的富内容运行时', () => {
     const plainHtml = buildConversationShareHtml({
       allShareableIds: ['plain'],

--- a/apps/mobile/src/__tests__/conversationShareWebViewHtml.test.ts
+++ b/apps/mobile/src/__tests__/conversationShareWebViewHtml.test.ts
@@ -7,6 +7,7 @@ import {
   type ConversationShareWebViewColors,
 } from '@/session/conversationShareWebViewHtml';
 import { i18n } from '@/i18n';
+import { buildConversationShareSvgLayout } from '@/session/conversationShareSvgLayout';
 
 const colors: ConversationShareWebViewColors = {
   background: '#ffffff',
@@ -50,6 +51,43 @@ function buildRichConversationHtml(): string {
 }
 
 describe('buildConversationShareHtml 富内容导出', () => {
+  it('继续脱敏跨行内格式和段落拆开的凭证', () => {
+    const html = buildConversationShareHtml({
+      allShareableIds: ['secret'], colors, contentWidth: 390,
+      selectedMessages: [{ clientId: 'secret', kind: 'assistant', body: 'password: `private-code-secret`\n\nAuthorization: Basic **private-strong-secret**\n\npassword:\n\nprivate-paragraph-secret' }],
+    });
+    expect(html).not.toContain('private-');
+    expect(html).toContain('[REDACTED]');
+  });
+
+  it.each(['token', 'access_token', 'api_key'])(
+    '带 %s 的已准备图片使用 SVG 备用成图，保留图片和脱敏文字',
+    (parameter) => {
+      const url = `https://example.com/pic.png?${parameter}=private-image-secret`;
+      const uri = 'data:image/png;base64,aGVsbG8=';
+      const picture = `![picture](${url})`;
+      const options = {
+        allShareableIds: ['plain', 'parts'], colors, contentWidth: 390,
+        selectedMessages: [
+          { clientId: 'plain', kind: 'assistant' as const, body: picture, images: new Map([[url, { uri, width: 40, height: 20 }]]) },
+          {
+            clientId: 'parts', kind: 'user' as const, body: '',
+            bodyParts: [{ kind: 'text' as const, text: `| image |\n| --- |\n| ${picture} |` }],
+            secondaryBody: `${picture}\n\npassword=private-text-secret\n\n[link](https://example.com/?token=private-link-secret)\n\n\`\`\`text\npassword=private-code-secret\n\`\`\``,
+            images: new Map([[url, { uri, width: 40, height: 20 }]]),
+          },
+        ],
+      };
+      expect(() => buildConversationShareHtml(options)).toThrow('conversation-share-image-requires-svg');
+      const svg = buildConversationShareSvgLayout({ ...options, width: 390, messages: options.selectedMessages });
+      expect(svg.images).toHaveLength(3);
+      expect(svg.images.every((image) => image.uri === uri)).toBe(true);
+      expect(JSON.stringify(svg)).not.toContain('private-');
+      expect(JSON.stringify(svg)).not.toContain(url);
+      expect(JSON.stringify(svg)).toContain('[REDACTED]');
+    },
+  );
+
   it('只按选中内容嵌入对应的富内容运行时', () => {
     const plainHtml = buildConversationShareHtml({
       allShareableIds: ['plain'],

--- a/apps/mobile/src/__tests__/conversationShareWebViewHtml.test.ts
+++ b/apps/mobile/src/__tests__/conversationShareWebViewHtml.test.ts
@@ -146,7 +146,8 @@ describe('buildConversationShareHtml 富内容导出', () => {
       }],
     });
 
-    expect(html).toContain(`alt="${i18n.t('message.renderer.imageFallbackTitle')}"`);
+    expect(html).toContain(`<span class="xdt-image-chip">${i18n.t('message.renderer.imageFallbackTitle')}</span>`);
+    expect(html).not.toContain('https://example.com/image.png');
   });
 
   it('限制原生与降级 renderer 的完整源尺寸，并安全保留已分享 PNG', () => {
@@ -202,7 +203,7 @@ describe('buildConversationShareHtml 富内容导出', () => {
       'if (!nativeConversationShareAvailable || !shareSelectionActive) return undefined;',
     );
     expect(sessionSource).toContain(
-      '!nativeConversationShareAvailable\n      || !shareSelectionActive',
+      'const messages = await shareImages.ready;',
     );
     expect(sessionSource).toContain(
       'nativeConversationShareAvailable\n      && shareCharacterSrc',
@@ -381,7 +382,7 @@ describe('buildConversationShareHtml 富内容导出', () => {
     expect(html).toContain('/review');
     expect(html).not.toContain('share-inline-chip-icon" aria-hidden="true">/</span>');
     expect(html).toContain('preview.png');
-    expect(html).not.toContain('share-attachment-image');
+    expect(html).not.toContain('<img class="share-attachment-image"');
     expect(html).toContain('remote.png');
     expect(html).toContain('notes.md');
     expect(html).not.toContain('visible fallback');

--- a/apps/mobile/src/__tests__/conversationShareWebViewHtml.test.ts
+++ b/apps/mobile/src/__tests__/conversationShareWebViewHtml.test.ts
@@ -305,9 +305,9 @@ describe('buildConversationShareHtml 富内容导出', () => {
     expect(svgSource).toContain('const SHARE_LOGO_HEIGHT = 18;');
     expect(svgSource).toContain('const SHARE_LOCKUP_GAP = 6;');
     expect(svgSource).toContain('rx={6}');
-    expect(svgSource).toContain('footerAssetGate.waitUntilReady()');
-    expect(svgSource).toContain('footerAssetGate.markReady("character")');
-    expect(svgSource).toContain('footerAssetGate.markReady("logo")');
+    expect(svgSource).toContain('assetGate.waitUntilSettled()');
+    expect(svgSource).toContain('assetGate.markReady("character")');
+    expect(svgSource).toContain('assetGate.markReady("logo")');
     expect(html).toContain('width: 22px;');
     expect(html).toContain('height: 18px;');
     expect(html).toContain('gap: 6px;');

--- a/apps/mobile/src/__tests__/useConversationShareImages.test.ts
+++ b/apps/mobile/src/__tests__/useConversationShareImages.test.ts
@@ -23,10 +23,7 @@ vi.mock("expo-file-system", () => ({
 }));
 vi.mock("@/session/sentAttachmentThumbStore", () => ({
   useSentAttachmentThumbsVersion: () => thumbs.version,
-  applySentAttachmentThumbOverlay: (item: { uri: string }) => {
-    const uri = thumbs.entries.get(item.uri);
-    return uri ? { ...item, uri, previewable: true } : item;
-  },
+  getSentAttachmentThumbUri: (uri: string) => thumbs.entries.get(uri) ?? null,
 }));
 vi.mock("@/session/remoteMediaDiskCacheExpo", () => ({
   downloadRemoteMediaAsDataUri: vi.fn(),
@@ -72,10 +69,17 @@ afterEach(async () => {
 });
 
 describe("share image readiness", () => {
-  it.each(["cindy-oss-attach://upload/paste", "xdt-oss-attach://upload/paste"])(
+  it.each([
+    "cindy-oss-attach://upload/paste",
+    "xdt-oss-attach://upload/paste",
+    "cindy-media://blobs/paste",
+    "xdt-image://paste",
+  ])(
     "refreshes %s when its existing upload thumbnail becomes available",
     async (uri) => {
-      const resolve = vi.fn<ResolveRemoteMediaFn>();
+      const resolve = vi.fn<ResolveRemoteMediaFn>(async () => {
+        throw new Error("desktop offline");
+      });
       const messages: ConversationShareMessage[] = [
         {
           ...source,
@@ -94,6 +98,7 @@ describe("share image readiness", () => {
       const oldReady = current.ready;
       expect((await oldReady)[0]?.images?.size).toBe(0);
       expect(thumbs.reads).not.toHaveBeenCalled();
+      resolve.mockClear();
       thumbs.entries.set(uri, "file:///app/sent-attachment-thumbs/paste.png");
       thumbs.version++;
       await act(async () => root.render(render()));
@@ -106,6 +111,22 @@ describe("share image readiness", () => {
       expect(resolve).not.toHaveBeenCalled();
     },
   );
+
+  it("falls back to the controlled resolver if a registered thumbnail cannot be read", async () => {
+    thumbs.entries.set(
+      "cindy-media://paste",
+      "file:///app/sent-attachment-thumbs/paste.png",
+    );
+    thumbs.reads.mockRejectedValueOnce(new Error("file removed"));
+    const resolve = vi.fn<ResolveRemoteMediaFn>(async () => media);
+    await act(async () =>
+      root.render(createElement(Probe, { messages: [source], resolve })),
+    );
+    expect(
+      (await current.ready)[0]?.images?.get("cindy-media://paste")?.uri,
+    ).toBe(media.url);
+    expect(resolve).toHaveBeenCalledTimes(1);
+  });
 
   it("keeps text and completed images when another image times out, ignoring its late result", async () => {
     vi.useFakeTimers({ toFake: ["setTimeout", "clearTimeout"] });

--- a/apps/mobile/src/__tests__/useConversationShareImages.test.ts
+++ b/apps/mobile/src/__tests__/useConversationShareImages.test.ts
@@ -46,10 +46,71 @@ const media = {
 };
 afterEach(async () => {
   await act(async () => root.unmount());
+  vi.useRealTimers();
   root = createRoot(container);
 });
 
 describe("share image readiness", () => {
+  it("keeps text and completed images when another image times out, ignoring its late result", async () => {
+    vi.useFakeTimers({ toFake: ["setTimeout", "clearTimeout"] });
+    let finish!: (value: typeof media) => void;
+    const resolve = vi.fn<ResolveRemoteMediaFn>(async ({ url }) => {
+      if (url === "cindy-media://paste") return media;
+      return new Promise((done) => {
+        finish = done;
+      });
+    });
+    await act(async () =>
+      root.render(
+        createElement(Probe, {
+          messages: [
+            {
+              ...source,
+              body: "keep this text",
+              attachments: [
+                ...source.attachments!,
+                {
+                  kind: "image",
+                  name: "slow image",
+                  uri: "cindy-media://slow",
+                },
+                {
+                  kind: "image",
+                  name: "remaining image",
+                  uri: "cindy-media://remaining",
+                },
+              ],
+            },
+            {
+              clientId: "next",
+              kind: "assistant",
+              body: "keep the next message",
+            },
+          ],
+          resolve,
+        }),
+      ),
+    );
+    const ready = current.ready;
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(20_000);
+    });
+    const result = await ready;
+    expect(result.map((message) => message.body)).toEqual([
+      "keep this text",
+      "keep the next message",
+    ]);
+    expect(result[0]?.images?.size).toBe(1);
+    expect(result[0]?.images?.get("cindy-media://paste")?.uri).toBe(media.url);
+    expect(result[0]?.attachments?.[1]?.name).toBe("slow image");
+    expect(resolve).toHaveBeenCalledTimes(2);
+    await act(async () =>
+      finish({ ...media, url: "data:image/png;base64,bGF0ZQ==" }),
+    );
+    expect(current.messages).toBe(result);
+    expect(result[0]?.images?.size).toBe(1);
+  });
+
   it("survives StrictMode and unrelated rerenders while a remote image loads", async () => {
     let finish!: (value: typeof media) => void;
     const pending = new Promise<typeof media>((done) => {

--- a/apps/mobile/src/__tests__/useConversationShareImages.test.ts
+++ b/apps/mobile/src/__tests__/useConversationShareImages.test.ts
@@ -5,6 +5,7 @@ import { afterEach, describe, expect, it, vi } from "vitest";
 import { useConversationShareImages } from "@/session/useConversationShareImages";
 import type { ConversationShareMessage } from "@/session/conversationShareWebViewHtml";
 import type { ResolveRemoteMediaFn } from "@/session/remoteMedia";
+import { downloadRemoteMediaAsDataUri } from "@/session/remoteMediaDiskCacheExpo";
 
 vi.mock("react-native", () => ({
   Image: { getSize: vi.fn(async () => ({ width: 40, height: 20 })) },
@@ -69,10 +70,55 @@ afterEach(async () => {
   vi.useRealTimers();
   thumbs.entries.clear();
   thumbs.reads.mockClear();
+  vi.mocked(downloadRemoteMediaAsDataUri).mockReset();
   root = createRoot(container);
 });
 
 describe("share image readiness", () => {
+  it("keeps direct HTTP images as placeholders without starting a download", async () => {
+    const resolve = vi.fn<ResolveRemoteMediaFn>();
+    const url = "https://example.com/unbounded.png";
+    await act(async () =>
+      root.render(
+        createElement(Probe, {
+          messages: [
+            {
+              ...source,
+              body: `![preview](${url})`,
+              attachments: [{ kind: "image", name: "remote", uri: url }],
+            },
+          ],
+          resolve,
+        }),
+      ),
+    );
+    await startShare();
+    expect((await ready)[0]?.images?.size).toBe(0);
+    expect(resolve).not.toHaveBeenCalled();
+    expect(downloadRemoteMediaAsDataUri).not.toHaveBeenCalled();
+  });
+
+  it.each([5, 0, -1, NaN, Infinity, 8 * 1024 * 1024 + 1])(
+    "downloads controlled images only with a valid known size (%s)",
+    async (size) => {
+      const url = "https://example.com/controlled.png";
+      const resolve = vi.fn<ResolveRemoteMediaFn>(async () => ({
+        ...media,
+        size,
+        url,
+      }));
+      vi.mocked(downloadRemoteMediaAsDataUri).mockResolvedValue(media.url);
+      await act(async () =>
+        root.render(createElement(Probe, { messages: [source], resolve })),
+      );
+      await startShare();
+      expect((await ready)[0]?.images?.size).toBe(size === 5 ? 1 : 0);
+      expect(downloadRemoteMediaAsDataUri).toHaveBeenCalledTimes(
+        size === 5 ? 1 : 0,
+      );
+    },
+  );
+
   it.each([
     "cindy-oss-attach://upload/paste",
     "xdt-oss-attach://upload/paste",
@@ -189,10 +235,11 @@ describe("share image readiness", () => {
     expect(result[0]?.attachments?.[1]?.name).toBe("slow image");
     expect(resolve).toHaveBeenCalledTimes(2);
     await act(async () =>
-      finish({ ...media, url: "data:image/png;base64,bGF0ZQ==" }),
+      finish({ ...media, url: "https://example.com/late.png" }),
     );
     expect(current.messages).toBe(result);
     expect(result[0]?.images?.size).toBe(1);
+    expect(downloadRemoteMediaAsDataUri).not.toHaveBeenCalled();
   });
 
   it("survives StrictMode and unrelated rerenders while a remote image loads", async () => {
@@ -247,7 +294,8 @@ describe("share image readiness", () => {
       ),
     );
     expect(await oldReady).toEqual([]);
-    await act(async () => finish(media));
+    await act(async () => finish({ ...media, url: "https://example.com/cancelled.png" }));
+    expect(downloadRemoteMediaAsDataUri).not.toHaveBeenCalled();
     await startShare();
     expect((await ready).map((message) => message.clientId)).toEqual(["next"]);
     expect(current.messages[0]?.images?.size).toBe(0);

--- a/apps/mobile/src/__tests__/useConversationShareImages.test.ts
+++ b/apps/mobile/src/__tests__/useConversationShareImages.test.ts
@@ -11,7 +11,6 @@ vi.mock("react-native", () => ({
 }));
 const thumbs = vi.hoisted(() => ({
   entries: new Map<string, string>(),
-  version: 0,
   reads: vi.fn(async () => "aGVsbG8="),
 }));
 vi.mock("expo-file-system", () => ({
@@ -22,7 +21,7 @@ vi.mock("expo-file-system", () => ({
   },
 }));
 vi.mock("@/session/sentAttachmentThumbStore", () => ({
-  useSentAttachmentThumbsVersion: () => thumbs.version,
+  ensureSentAttachmentThumbsHydrated: vi.fn(async () => undefined),
   getSentAttachmentThumbUri: (uri: string) => thumbs.entries.get(uri) ?? null,
 }));
 vi.mock("@/session/remoteMediaDiskCacheExpo", () => ({
@@ -33,6 +32,12 @@ Object.assign(globalThis, { IS_REACT_ACT_ENVIRONMENT: true });
 const container = document.createElement("div");
 let root = createRoot(container);
 let current!: ReturnType<typeof useConversationShareImages>;
+let ready!: Promise<readonly ConversationShareMessage[]>;
+async function startShare() {
+  await act(async () => {
+    ready = current.prepare();
+  });
+}
 function Probe({
   messages,
   resolve,
@@ -63,7 +68,6 @@ afterEach(async () => {
   await act(async () => root.unmount());
   vi.useRealTimers();
   thumbs.entries.clear();
-  thumbs.version = 0;
   thumbs.reads.mockClear();
   root = createRoot(container);
 });
@@ -75,7 +79,7 @@ describe("share image readiness", () => {
     "cindy-media://blobs/paste",
     "xdt-image://paste",
   ])(
-    "refreshes %s when its existing upload thumbnail becomes available",
+    "reads the latest %s thumbnail on each share without background preparation",
     async (uri) => {
       const resolve = vi.fn<ResolveRemoteMediaFn>(async () => {
         throw new Error("desktop offline");
@@ -95,15 +99,17 @@ describe("share image readiness", () => {
       ];
       const render = () => createElement(Probe, { messages, resolve });
       await act(async () => root.render(render()));
-      const oldReady = current.ready;
+      expect(resolve).not.toHaveBeenCalled();
+      await startShare();
+      const oldReady = ready;
       expect((await oldReady)[0]?.images?.size).toBe(0);
       expect(thumbs.reads).not.toHaveBeenCalled();
       resolve.mockClear();
       thumbs.entries.set(uri, "file:///app/sent-attachment-thumbs/paste.png");
-      thumbs.version++;
       await act(async () => root.render(render()));
-      expect(current.ready).not.toBe(oldReady);
-      const result = await current.ready;
+      await startShare();
+      expect(ready).not.toBe(oldReady);
+      const result = await ready;
       expect(result[0]?.images?.get(uri)?.uri).toBe(media.url);
       expect(result[0]?.images?.size).toBe(1);
       expect(result[0]?.attachments?.[0]?.uri).toBe(uri);
@@ -122,9 +128,10 @@ describe("share image readiness", () => {
     await act(async () =>
       root.render(createElement(Probe, { messages: [source], resolve })),
     );
-    expect(
-      (await current.ready)[0]?.images?.get("cindy-media://paste")?.uri,
-    ).toBe(media.url);
+    await startShare();
+    expect((await ready)[0]?.images?.get("cindy-media://paste")?.uri).toBe(
+      media.url,
+    );
     expect(resolve).toHaveBeenCalledTimes(1);
   });
 
@@ -168,7 +175,7 @@ describe("share image readiness", () => {
         }),
       ),
     );
-    const ready = current.ready;
+    await startShare();
     await act(async () => {
       await vi.advanceTimersByTimeAsync(20_000);
     });
@@ -209,9 +216,8 @@ describe("share image readiness", () => {
         }),
       );
     await act(async () => root.render(render()));
-    const ready = current.ready;
+    await startShare();
     await act(async () => root.render(render()));
-    expect(current.ready).toBe(ready);
     await act(async () => finish(media));
     expect((await ready)[0]?.images?.get("cindy-media://paste")?.uri).toBe(
       media.url,
@@ -230,7 +236,8 @@ describe("share image readiness", () => {
     await act(async () =>
       root.render(createElement(Probe, { messages: [source], resolve })),
     );
-    const oldReady = current.ready;
+    await startShare();
+    const oldReady = ready;
     await act(async () =>
       root.render(
         createElement(Probe, {
@@ -241,9 +248,52 @@ describe("share image readiness", () => {
     );
     expect(await oldReady).toEqual([]);
     await act(async () => finish(media));
-    expect((await current.ready).map((message) => message.clientId)).toEqual([
-      "next",
-    ]);
+    await startShare();
+    expect((await ready).map((message) => message.clientId)).toEqual(["next"]);
     expect(current.messages[0]?.images?.size).toBe(0);
+  });
+
+  it("retains the clicked snapshot through streaming and thumbnail updates", async () => {
+    let finish!: (value: typeof media) => void;
+    const resolve = vi.fn<ResolveRemoteMediaFn>(
+      () =>
+        new Promise((done) => {
+          finish = done;
+        }),
+    );
+    await act(async () =>
+      root.render(
+        createElement(Probe, {
+          messages: [{ ...source, body: "clicked text" }],
+          resolve,
+        }),
+      ),
+    );
+    await startShare();
+    const clickedReady = ready;
+    thumbs.entries.set(
+      "cindy-media://paste",
+      "file:///app/sent-attachment-thumbs/new.png",
+    );
+    await act(async () =>
+      root.render(
+        createElement(Probe, {
+          messages: [{ ...source, body: "later streamed text" }],
+          resolve,
+        }),
+      ),
+    );
+    await act(async () => finish(media));
+    const snapshot = await clickedReady;
+    expect(snapshot[0]?.body).toBe("clicked text");
+    expect(snapshot[0]?.images?.get("cindy-media://paste")?.uri).toBe(
+      media.url,
+    );
+    expect(current.messages).toBe(snapshot);
+    expect(resolve).toHaveBeenCalledTimes(1);
+    expect(thumbs.reads).not.toHaveBeenCalled();
+    await startShare();
+    expect((await ready)[0]?.body).toBe("later streamed text");
+    expect(thumbs.reads).toHaveBeenCalledTimes(1);
   });
 });

--- a/apps/mobile/src/__tests__/useConversationShareImages.test.ts
+++ b/apps/mobile/src/__tests__/useConversationShareImages.test.ts
@@ -1,0 +1,111 @@
+// @vitest-environment jsdom
+import { act, createElement, StrictMode } from "react";
+import { createRoot } from "react-dom/client";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { useConversationShareImages } from "@/session/useConversationShareImages";
+import type { ConversationShareMessage } from "@/session/conversationShareWebViewHtml";
+import type { ResolveRemoteMediaFn } from "@/session/remoteMedia";
+
+vi.mock("react-native", () => ({
+  Image: { getSize: vi.fn(async () => ({ width: 40, height: 20 })) },
+}));
+vi.mock("expo-file-system", () => ({ File: class {} }));
+vi.mock("@/session/remoteMediaDiskCacheExpo", () => ({
+  downloadRemoteMediaAsDataUri: vi.fn(),
+}));
+
+Object.assign(globalThis, { IS_REACT_ACT_ENVIRONMENT: true });
+const container = document.createElement("div");
+let root = createRoot(container);
+let current!: ReturnType<typeof useConversationShareImages>;
+function Probe({
+  messages,
+  resolve,
+}: {
+  messages: ConversationShareMessage[];
+  resolve: ResolveRemoteMediaFn;
+}) {
+  current = useConversationShareImages(messages, resolve, {
+    sessionId: "session",
+  });
+  return null;
+}
+const source: ConversationShareMessage = {
+  clientId: "user",
+  kind: "user",
+  body: "",
+  attachments: [{ kind: "image", name: "paste", uri: "cindy-media://paste" }],
+};
+const media = {
+  url: "data:image/png;base64,aGVsbG8=",
+  mimeType: "image/png",
+  size: 5,
+  ossKey: "",
+  expiresAt: "",
+  previewable: true,
+};
+afterEach(async () => {
+  await act(async () => root.unmount());
+  root = createRoot(container);
+});
+
+describe("share image readiness", () => {
+  it("survives StrictMode and unrelated rerenders while a remote image loads", async () => {
+    let finish!: (value: typeof media) => void;
+    const pending = new Promise<typeof media>((done) => {
+      finish = done;
+    });
+    const resolve = vi.fn(() => pending);
+    const render = () =>
+      createElement(
+        StrictMode,
+        null,
+        createElement(Probe, {
+          messages: [
+            {
+              ...source,
+              attachments: source.attachments?.map((a) => ({ ...a })),
+            },
+          ],
+          resolve,
+        }),
+      );
+    await act(async () => root.render(render()));
+    const ready = current.ready;
+    await act(async () => root.render(render()));
+    expect(current.ready).toBe(ready);
+    await act(async () => finish(media));
+    expect((await ready)[0]?.images?.get("cindy-media://paste")?.uri).toBe(
+      media.url,
+    );
+    expect(current.messages).toHaveLength(1);
+  });
+
+  it("cancels the previous selection and ignores its late image result", async () => {
+    let finish!: (value: typeof media) => void;
+    const resolve = vi.fn(
+      () =>
+        new Promise<typeof media>((done) => {
+          finish = done;
+        }),
+    );
+    await act(async () =>
+      root.render(createElement(Probe, { messages: [source], resolve })),
+    );
+    const oldReady = current.ready;
+    await act(async () =>
+      root.render(
+        createElement(Probe, {
+          messages: [{ clientId: "next", kind: "assistant", body: "next" }],
+          resolve,
+        }),
+      ),
+    );
+    expect(await oldReady).toEqual([]);
+    await act(async () => finish(media));
+    expect((await current.ready).map((message) => message.clientId)).toEqual([
+      "next",
+    ]);
+    expect(current.messages[0]?.images?.size).toBe(0);
+  });
+});

--- a/apps/mobile/src/__tests__/useConversationShareImages.test.ts
+++ b/apps/mobile/src/__tests__/useConversationShareImages.test.ts
@@ -9,7 +9,25 @@ import type { ResolveRemoteMediaFn } from "@/session/remoteMedia";
 vi.mock("react-native", () => ({
   Image: { getSize: vi.fn(async () => ({ width: 40, height: 20 })) },
 }));
-vi.mock("expo-file-system", () => ({ File: class {} }));
+const thumbs = vi.hoisted(() => ({
+  entries: new Map<string, string>(),
+  version: 0,
+  reads: vi.fn(async () => "aGVsbG8="),
+}));
+vi.mock("expo-file-system", () => ({
+  File: class {
+    exists = true;
+    size = 5;
+    base64 = thumbs.reads;
+  },
+}));
+vi.mock("@/session/sentAttachmentThumbStore", () => ({
+  useSentAttachmentThumbsVersion: () => thumbs.version,
+  applySentAttachmentThumbOverlay: (item: { uri: string }) => {
+    const uri = thumbs.entries.get(item.uri);
+    return uri ? { ...item, uri, previewable: true } : item;
+  },
+}));
 vi.mock("@/session/remoteMediaDiskCacheExpo", () => ({
   downloadRemoteMediaAsDataUri: vi.fn(),
 }));
@@ -47,10 +65,48 @@ const media = {
 afterEach(async () => {
   await act(async () => root.unmount());
   vi.useRealTimers();
+  thumbs.entries.clear();
+  thumbs.version = 0;
+  thumbs.reads.mockClear();
   root = createRoot(container);
 });
 
 describe("share image readiness", () => {
+  it.each(["cindy-oss-attach://upload/paste", "xdt-oss-attach://upload/paste"])(
+    "refreshes %s when its existing upload thumbnail becomes available",
+    async (uri) => {
+      const resolve = vi.fn<ResolveRemoteMediaFn>();
+      const messages: ConversationShareMessage[] = [
+        {
+          ...source,
+          attachments: [
+            { kind: "image", name: "paste", uri },
+            {
+              kind: "image",
+              name: "untrusted",
+              uri: "file:///private/image.png",
+            },
+          ],
+        },
+      ];
+      const render = () => createElement(Probe, { messages, resolve });
+      await act(async () => root.render(render()));
+      const oldReady = current.ready;
+      expect((await oldReady)[0]?.images?.size).toBe(0);
+      expect(thumbs.reads).not.toHaveBeenCalled();
+      thumbs.entries.set(uri, "file:///app/sent-attachment-thumbs/paste.png");
+      thumbs.version++;
+      await act(async () => root.render(render()));
+      expect(current.ready).not.toBe(oldReady);
+      const result = await current.ready;
+      expect(result[0]?.images?.get(uri)?.uri).toBe(media.url);
+      expect(result[0]?.images?.size).toBe(1);
+      expect(result[0]?.attachments?.[0]?.uri).toBe(uri);
+      expect(thumbs.reads).toHaveBeenCalledTimes(1);
+      expect(resolve).not.toHaveBeenCalled();
+    },
+  );
+
   it("keeps text and completed images when another image times out, ignoring its late result", async () => {
     vi.useFakeTimers({ toFake: ["setTimeout", "clearTimeout"] });
     let finish!: (value: typeof media) => void;

--- a/apps/mobile/src/__tests__/useConversationShareImages.test.ts
+++ b/apps/mobile/src/__tests__/useConversationShareImages.test.ts
@@ -269,66 +269,98 @@ describe("share image readiness", () => {
     expect(resolve).toHaveBeenCalledTimes(1);
   });
 
-  it("keeps text and completed images when another image times out, ignoring its late result", async () => {
-    vi.useFakeTimers({ toFake: ["setTimeout", "clearTimeout"] });
-    let finish!: (value: typeof media) => void;
-    const resolve = vi.fn<ResolveRemoteMediaFn>(async ({ url }) => {
-      if (url === "cindy-media://paste") return media;
-      return new Promise((done) => {
-        finish = done;
+  it.each([false, true])(
+    "keeps later local images across messages when a remote source stalls (reverse=%s)",
+    async (reverse) => {
+      vi.useFakeTimers({ toFake: ["setTimeout", "clearTimeout"] });
+      thumbs.entries.set(
+        "cindy-media://remaining",
+        "file:///app/remaining.png",
+      );
+      thumbs.entries.set("cindy-media://next", "file:///app/next.png");
+      let finish!: (value: typeof media) => void;
+      const resolve = vi.fn<ResolveRemoteMediaFn>(async ({ url }) => {
+        if (url === "cindy-media://paste") return media;
+        return new Promise((done) => {
+          finish = done;
+        });
       });
-    });
-    await act(async () =>
-      root.render(
-        createElement(Probe, {
-          messages: [
-            {
-              ...source,
-              body: "keep this text",
-              attachments: [
-                ...source.attachments!,
-                {
-                  kind: "image",
-                  name: "slow image",
-                  uri: "cindy-media://slow",
-                },
-                {
-                  kind: "image",
-                  name: "remaining image",
-                  uri: "cindy-media://remaining",
-                },
-              ],
-            },
-            {
-              clientId: "next",
-              kind: "assistant",
-              body: "keep the next message",
-            },
-          ],
-          resolve,
-        }),
-      ),
-    );
-    await startShare();
-    await act(async () => {
-      await vi.advanceTimersByTimeAsync(20_000);
-    });
-    const result = await ready;
-    expect(result.map((message) => message.body)).toEqual([
-      "keep this text",
-      "keep the next message",
-    ]);
-    expect(result[0]?.images?.size).toBe(1);
-    expect(result[0]?.images?.get("cindy-media://paste")?.uri).toBe(media.url);
-    expect(result[0]?.attachments?.[1]?.name).toBe("slow image");
-    expect(resolve).toHaveBeenCalledTimes(2);
-    await act(async () =>
-      finish({ ...media, url: "https://example.com/late.png" }),
-    );
-    expect(current.messages).toBe(result);
-    expect(result[0]?.images?.size).toBe(1);
-    expect(downloadRemoteMediaAsDataUri).not.toHaveBeenCalled();
-  });
+      await act(async () =>
+        root.render(
+          createElement(Probe, {
+            messages: [
+              {
+                ...source,
+                body: "keep this text",
+                attachments: (reverse
+                  ? [
+                      {
+                        kind: "image",
+                        name: "slow image",
+                        uri: "cindy-media://slow",
+                      },
+                      {
+                        kind: "image",
+                        name: "remaining image",
+                        uri: "cindy-media://remaining",
+                      },
+                      ...source.attachments!,
+                    ]
+                  : [
+                      ...source.attachments!,
+                      {
+                        kind: "image" as const,
+                        name: "slow image",
+                        uri: "cindy-media://slow",
+                      },
+                      {
+                        kind: "image" as const,
+                        name: "remaining image",
+                        uri: "cindy-media://remaining",
+                      },
+                    ]) as ConversationShareMessage["attachments"],
+              },
+              {
+                clientId: "next",
+                kind: "assistant",
+                body: "keep the next message",
+                attachments: [
+                  { kind: "image", name: "next", uri: "cindy-media://next" },
+                ],
+              },
+            ],
+            resolve,
+          }),
+        ),
+      );
+      await startShare();
+      await act(async () => {
+        await vi.advanceTimersByTimeAsync(20_000);
+      });
+      const result = await ready;
+      expect(result.map((message) => message.body)).toEqual([
+        "keep this text",
+        "keep the next message",
+      ]);
+      expect(result[0]?.images?.size).toBe(2);
+      expect(result[1]?.images?.size).toBe(1);
+      expect(result[0]?.images?.get("cindy-media://paste")?.uri).toBe(
+        media.url,
+      );
+      expect(
+        result[0]?.attachments?.find(
+          (attachment) => attachment.uri === "cindy-media://slow",
+        )?.name,
+      ).toBe("slow image");
+      expect(resolve).toHaveBeenCalledTimes(2);
+      await act(async () =>
+        finish({ ...media, url: "https://example.com/late.png" }),
+      );
+      expect(current.messages).toBe(result);
+      expect(result[0]?.images?.size).toBe(2);
+      expect(downloadRemoteMediaAsDataUri).not.toHaveBeenCalled();
+    },
+  );
 
   it("survives StrictMode and unrelated rerenders while a remote image loads", async () => {
     let finish!: (value: typeof media) => void;

--- a/apps/mobile/src/__tests__/useConversationShareImages.test.ts
+++ b/apps/mobile/src/__tests__/useConversationShareImages.test.ts
@@ -6,6 +6,7 @@ import { useConversationShareImages } from "@/session/useConversationShareImages
 import type { ConversationShareMessage } from "@/session/conversationShareWebViewHtml";
 import type { ResolveRemoteMediaFn } from "@/session/remoteMedia";
 import { downloadRemoteMediaAsDataUri } from "@/session/remoteMediaDiskCacheExpo";
+import { createRemoteMediaResolveQueue } from "@/session/remoteMediaResolveQueue";
 
 vi.mock("react-native", () => ({
   Image: { getSize: vi.fn(async () => ({ width: 40, height: 20 })) },
@@ -42,12 +43,14 @@ async function startShare() {
 function Probe({
   messages,
   resolve,
+  sessionId = "session",
 }: {
   messages: ConversationShareMessage[];
   resolve: ResolveRemoteMediaFn;
+  sessionId?: string;
 }) {
   current = useConversationShareImages(messages, resolve, {
-    sessionId: "session",
+    sessionId,
   });
   return null;
 }
@@ -75,6 +78,91 @@ afterEach(async () => {
 });
 
 describe("share image readiness", () => {
+  it.each(["timeout", "cancel", "selection", "session", "unmount"])(
+    "removes queued media work on %s before a free slot can start it",
+    async (event) => {
+      vi.useFakeTimers({ toFake: ["setTimeout", "clearTimeout"] });
+      let finish!: (value: typeof media) => void;
+      const fetch = vi.fn(
+        () =>
+          new Promise<typeof media>((done) => {
+            finish = done;
+          }),
+      );
+      const queue = createRemoteMediaResolveQueue(
+        { resolve: fetch },
+        { maxConcurrent: 1 },
+      );
+      const busy = queue.request({ kind: "image", url: "cindy-media://busy" });
+      const resolve: ResolveRemoteMediaFn = (request, opts) =>
+        queue.request(request, opts);
+      await act(async () =>
+        root.render(createElement(Probe, { messages: [source], resolve })),
+      );
+      await startShare();
+      expect(queue.stats()).toEqual({ inFlight: 1, queued: 1 });
+      await act(async () => {
+        if (event === "timeout") await vi.advanceTimersByTimeAsync(20_000);
+        if (event === "cancel") current.cancel();
+        if (event === "selection")
+          root.render(createElement(Probe, { messages: [], resolve }));
+        if (event === "session")
+          root.render(
+            createElement(Probe, {
+              messages: [source],
+              resolve,
+              sessionId: "next",
+            }),
+          );
+        if (event === "unmount") root.render(null);
+      });
+      expect(queue.stats().queued).toBe(0);
+      expect((await ready).length).toBe(event === "timeout" ? 1 : 0);
+      await act(async () => {
+        finish(media);
+        await busy;
+      });
+      expect(fetch).toHaveBeenCalledTimes(1);
+      expect(queue.stats()).toEqual({ inFlight: 0, queued: 0 });
+    },
+  );
+
+  it("cancels only the share waiter while a shared queued consumer still completes", async () => {
+    let finish!: (value: typeof media) => void;
+    const fetch = vi.fn(async ({ url }: { url: string }) =>
+      url.endsWith("busy")
+        ? new Promise<typeof media>((done) => {
+            finish = done;
+          })
+        : media,
+    );
+    const queue = createRemoteMediaResolveQueue(
+      { resolve: fetch },
+      { maxConcurrent: 1 },
+    );
+    const busy = queue.request({ kind: "image", url: "cindy-media://busy" });
+    const resolve: ResolveRemoteMediaFn = (request, opts) =>
+      queue.request(request, opts);
+    await act(async () =>
+      root.render(createElement(Probe, { messages: [source], resolve })),
+    );
+    await startShare();
+    const other = queue.request({
+      kind: "image",
+      url: "cindy-media://paste",
+      thumbnail: true,
+    });
+    await act(async () => current.cancel());
+    expect(await ready).toEqual([]);
+    expect(queue.stats().queued).toBe(1);
+    await act(async () => {
+      finish(media);
+      await busy;
+      await other;
+    });
+    expect(fetch).toHaveBeenCalledTimes(2);
+  });
+
   it("keeps direct HTTP images as placeholders without starting a download", async () => {
     const resolve = vi.fn<ResolveRemoteMediaFn>();
     const url = "https://example.com/unbounded.png";
@@ -294,7 +382,9 @@ describe("share image readiness", () => {
       ),
     );
     expect(await oldReady).toEqual([]);
-    await act(async () => finish({ ...media, url: "https://example.com/cancelled.png" }));
+    await act(async () =>
+      finish({ ...media, url: "https://example.com/cancelled.png" }),
+    );
     expect(downloadRemoteMediaAsDataUri).not.toHaveBeenCalled();
     await startShare();
     expect((await ready).map((message) => message.clientId)).toEqual(["next"]);

--- a/apps/mobile/src/session/ConversationShareSvg.tsx
+++ b/apps/mobile/src/session/ConversationShareSvg.tsx
@@ -1,4 +1,4 @@
-import { forwardRef, useImperativeHandle, useMemo, useRef } from "react";
+import { forwardRef, useImperativeHandle, useMemo, useRef, useState } from "react";
 import { Image as NativeImage, StyleSheet, View } from "react-native";
 import Svg, {
   ClipPath,
@@ -67,9 +67,10 @@ export const ConversationShareSvg = forwardRef<
     [layout],
   );
   const logoAsset = colors.dark ? shareLogoDarkAsset : shareLogoLightAsset;
-  const footerAssetGate = useMemo(
-    () => createConversationShareFooterAssetGate(),
-    [logoAsset],
+  // The screen keys this component by prepared snapshot + theme. Retain the
+  // decoded-image latch through layout-only changes (e.g. rotating the phone).
+  const [footerAssetGate] = useState(
+    () => createConversationShareFooterAssetGate(layout.images.map((_, index) => `image-${index}`)),
   );
   const logoSource = NativeImage.resolveAssetSource(logoAsset);
   const logoWidth = (SHARE_LOGO_HEIGHT * logoSource.width) / logoSource.height;
@@ -147,6 +148,18 @@ export const ConversationShareSvg = forwardRef<
         />
         {!renderSize.sourceTooLarge ? (
           <>
+            {layout.images.map((image, index) => (
+              <SvgImage
+                key={`image-${index}`}
+                href={{ uri: image.uri }}
+                x={image.x}
+                y={image.y}
+                width={image.width}
+                height={image.height}
+                preserveAspectRatio="xMidYMid meet"
+                onLoad={() => footerAssetGate.markReady(`image-${index}`)}
+              />
+            ))}
             {layout.bubbles.map((bubble, bubbleIndex) => (
               <SvgBubbleView bubble={bubble} key={`bubble-${bubbleIndex}`} />
             ))}

--- a/apps/mobile/src/session/ConversationShareSvg.tsx
+++ b/apps/mobile/src/session/ConversationShareSvg.tsx
@@ -1,4 +1,10 @@
-import { forwardRef, useImperativeHandle, useMemo, useRef, useState } from "react";
+import {
+  forwardRef,
+  useImperativeHandle,
+  useMemo,
+  useRef,
+  useState,
+} from "react";
 import { Image as NativeImage, StyleSheet, View } from "react-native";
 import Svg, {
   ClipPath,
@@ -69,8 +75,10 @@ export const ConversationShareSvg = forwardRef<
   const logoAsset = colors.dark ? shareLogoDarkAsset : shareLogoLightAsset;
   // The screen keys this component by prepared snapshot + theme. Retain the
   // decoded-image latch through layout-only changes (e.g. rotating the phone).
-  const [footerAssetGate] = useState(
-    () => createConversationShareFooterAssetGate(layout.images.map((_, index) => `image-${index}`)),
+  const [footerAssetGate] = useState(() =>
+    createConversationShareFooterAssetGate(
+      layout.images.map((_, index) => `image-${index}`),
+    ),
   );
   const logoSource = NativeImage.resolveAssetSource(logoAsset);
   const logoWidth = (SHARE_LOGO_HEIGHT * logoSource.width) / logoSource.height;
@@ -148,6 +156,9 @@ export const ConversationShareSvg = forwardRef<
         />
         {!renderSize.sourceTooLarge ? (
           <>
+            {layout.bubbles.map((bubble, bubbleIndex) => (
+              <SvgBubbleView bubble={bubble} key={`bubble-${bubbleIndex}`} />
+            ))}
             {layout.images.map((image, index) => (
               <SvgImage
                 key={`image-${index}`}
@@ -159,9 +170,6 @@ export const ConversationShareSvg = forwardRef<
                 preserveAspectRatio="xMidYMid meet"
                 onLoad={() => footerAssetGate.markReady(`image-${index}`)}
               />
-            ))}
-            {layout.bubbles.map((bubble, bubbleIndex) => (
-              <SvgBubbleView bubble={bubble} key={`bubble-${bubbleIndex}`} />
             ))}
             {layout.gaps.map((gap, gapIndex) => (
               <SvgText

--- a/apps/mobile/src/session/ConversationShareSvg.tsx
+++ b/apps/mobile/src/session/ConversationShareSvg.tsx
@@ -1,11 +1,12 @@
 import {
   forwardRef,
+  useEffect,
   useImperativeHandle,
   useMemo,
   useRef,
   useState,
 } from "react";
-import { Image as NativeImage, StyleSheet, View } from "react-native";
+import { Image as NativeImage, Platform, StyleSheet, View } from "react-native";
 import Svg, {
   ClipPath,
   Defs,
@@ -19,7 +20,7 @@ import type {
   ConversationShareMessage,
   ConversationShareWebViewColors,
 } from "@/session/conversationShareWebViewHtml";
-import { createConversationShareFooterAssetGate } from "@/session/conversationShareAssetGate";
+import { createConversationShareAssetGate } from "@/session/conversationShareAssetGate";
 import {
   buildConversationShareSvgLayout,
   conversationShareSvgRenderSize,
@@ -41,6 +42,8 @@ const SHARE_CHARACTER_SIZE = 22;
 const SHARE_LOGO_HEIGHT = 18;
 const SHARE_LOCKUP_GAP = 6;
 const SHARE_EXPORT_TIMEOUT_MS = 20_000;
+// Leave time within the existing export deadline for fallback layout + capture.
+const SHARE_DECODE_TIMEOUT_MS = 15_000;
 // Export-card geometry: this is a 1px bubble border in the SVG coordinate
 // system, not a Lucide icon stroke (whose thinnest token is intentionally 1.75).
 const SHARE_BUBBLE_STROKE_WIDTH = 1;
@@ -58,28 +61,78 @@ export const ConversationShareSvg = forwardRef<
   ref,
 ) {
   const svgRef = useRef<Svg | null>(null);
+  const [imageKeysByUri] = useState(() => {
+    const original = buildConversationShareSvgLayout({
+      allShareableIds,
+      colors,
+      messages,
+      width,
+    });
+    const keys = new Map<string, string[]>();
+    original.images.forEach((image, index) => {
+      const occurrences = keys.get(image.uri) ?? [];
+      occurrences.push(`image-${index}`);
+      keys.set(image.uri, occurrences);
+    });
+    return keys;
+  });
+  const [assetGate] = useState(() =>
+    createConversationShareAssetGate([
+      "character",
+      "logo",
+      ...Array.from(imageKeysByUri.values()).flat(),
+    ]),
+  );
+  const [readyAssets, setReadyAssets] = useState<ReadonlySet<string> | null>(
+    null,
+  );
+  const captureMessages = useMemo(
+    () =>
+      readyAssets
+        ? messages.map((message) => ({
+            ...message,
+            images: new Map(
+              Array.from(message.images ?? []).filter(([, image]) =>
+                imageKeysByUri
+                  .get(image.uri)
+                  ?.every((key) => readyAssets.has(key)),
+              ),
+            ),
+          }))
+        : messages,
+    [imageKeysByUri, messages, readyAssets],
+  );
   const layout = useMemo(
     () =>
       buildConversationShareSvgLayout({
         allShareableIds,
         colors,
-        messages,
+        messages: captureMessages,
         width,
       }),
-    [allShareableIds, colors, messages, width],
+    [allShareableIds, colors, captureMessages, width],
   );
+  // Removing a failed URI must not remount already decoded SVG occurrences.
+  const keyedImages = useMemo(() => {
+    const occurrences = new Map<string, number>();
+    return layout.images.map((image) => {
+      const occurrence = occurrences.get(image.uri) ?? 0;
+      occurrences.set(image.uri, occurrence + 1);
+      return { ...image, key: imageKeysByUri.get(image.uri)![occurrence]! };
+    });
+  }, [imageKeysByUri, layout.images]);
   const renderSize = useMemo(
     () => conversationShareSvgRenderSize(layout),
     [layout],
   );
   const logoAsset = colors.dark ? shareLogoDarkAsset : shareLogoLightAsset;
-  // The screen keys this component by prepared snapshot + theme. Retain the
-  // decoded-image latch through layout-only changes (e.g. rotating the phone).
-  const [footerAssetGate] = useState(() =>
-    createConversationShareFooterAssetGate(
-      layout.images.map((_, index) => `image-${index}`),
-    ),
-  );
+  // The screen keys this component by prepared snapshot + theme.
+  const exportJob = useRef<{
+    promise: Promise<string>;
+    cancel(): void;
+    capture(sourceTooLarge: boolean): void;
+  } | null>(null);
+  useEffect(() => () => exportJob.current?.cancel(), []);
   const logoSource = NativeImage.resolveAssetSource(logoAsset);
   const logoWidth = (SHARE_LOGO_HEIGHT * logoSource.width) / logoSource.height;
   const lockupWidth = SHARE_CHARACTER_SIZE + SHARE_LOCKUP_GAP + logoWidth;
@@ -89,48 +142,80 @@ export const ConversationShareSvg = forwardRef<
     ref,
     () => ({
       exportPng() {
+        if (exportJob.current) return exportJob.current.promise;
         if (renderSize.sourceTooLarge) {
           return Promise.reject(
             new Error("conversation share content is too large"),
           );
         }
-        return new Promise<string>((resolve, reject) => {
-          let settled = false;
-          const fail = (error: Error) => {
-            if (settled) return;
-            settled = true;
+        let capture = (_sourceTooLarge: boolean) => {};
+        let cancel = () => {};
+        const promise = new Promise<string>((resolve, reject) => {
+          let phase: "decoding" | "layout" | "capturing" | "settled" =
+            "decoding";
+          const finish = (error?: Error, base64?: string) => {
+            if (phase === "settled") return;
+            phase = "settled";
             clearTimeout(timer);
-            reject(error);
+            clearTimeout(decodeTimer);
+            assetGate.finish();
+            if (error) reject(error);
+            else resolve(base64!);
           };
           const timer = setTimeout(() => {
-            fail(new Error("conversation share svg export timed out"));
+            finish(new Error("conversation share svg export timed out"));
           }, SHARE_EXPORT_TIMEOUT_MS);
-          void footerAssetGate.waitUntilReady().then(() => {
-            if (settled) return;
+          const prepareCapture = () => {
+            if (phase !== "decoding") return;
+            phase = "layout";
+            clearTimeout(decodeTimer);
+            const ready = assetGate.finish();
+            if (!ready.has("character") || !ready.has("logo")) {
+              finish(new Error("conversation share footer is unavailable"));
+              return;
+            }
+            setReadyAssets(ready);
+          };
+          const decodeTimer = setTimeout(
+            prepareCapture,
+            SHARE_DECODE_TIMEOUT_MS,
+          );
+          void assetGate.waitUntilSettled().then(prepareCapture);
+          cancel = () =>
+            finish(new Error("conversation share svg export cancelled"));
+          capture = (sourceTooLarge) => {
+            if (phase !== "layout") return;
+            phase = "capturing";
+            if (sourceTooLarge) {
+              finish(new Error("conversation share content is too large"));
+              return;
+            }
             const svg = svgRef.current;
             if (!svg) {
-              fail(new Error("conversation share svg renderer is unavailable"));
+              finish(
+                new Error("conversation share svg renderer is unavailable"),
+              );
               return;
             }
             try {
               svg.toDataURL((base64) => {
-                if (settled) return;
+                if (phase === "settled") return;
                 if (!base64) {
-                  fail(new Error("conversation share svg export was empty"));
+                  finish(new Error("conversation share svg export was empty"));
                   return;
                 }
-                settled = true;
-                clearTimeout(timer);
-                resolve(base64);
+                finish(undefined, base64);
               });
             } catch (error) {
-              fail(error instanceof Error ? error : new Error(String(error)));
+              finish(error instanceof Error ? error : new Error(String(error)));
             }
-          });
+          };
         });
+        exportJob.current = { promise, cancel, capture };
+        return promise;
       },
     }),
-    [footerAssetGate, renderSize.sourceTooLarge],
+    [assetGate, renderSize.sourceTooLarge],
   );
 
   return (
@@ -143,6 +228,52 @@ export const ConversationShareSvg = forwardRef<
         { height: renderSize.height, width: renderSize.width },
       ]}
     >
+      {Platform.OS === "android" && !renderSize.sourceTooLarge
+        ? [
+            { source: shareCharacterAsset, keys: ["character"] },
+            { source: logoAsset, keys: ["logo"] },
+            ...Array.from(imageKeysByUri, ([uri, keys]) => ({
+              source: { uri },
+              keys,
+            })),
+          ].map(({ source, keys }) => (
+            <NativeImage
+              key={keys[0]}
+              source={source}
+              resizeMethod="none"
+              fadeDuration={0}
+              style={styles.decodeProbe}
+              onLoad={() => {
+                // Bundled footer bitmaps are held by this mounted view.
+                // Release Android may resolve them to resource names, which the
+                // URI-only queryCache API cannot look up as native res:/ IDs.
+                if (keys[0] === "character" || keys[0] === "logo") {
+                  keys.forEach(assetGate.markReady);
+                  return;
+                }
+                // Android SVG cache hits do not emit onLoad. This mounted Image
+                // holds the same unresized Fresco bitmap; encoded/disk cache alone
+                // is insufficient, including when Fresco refuses a large bitmap.
+                const uri = NativeImage.resolveAssetSource(source).uri;
+                const cached = NativeImage.queryCache?.([uri]);
+                if (!cached) {
+                  keys.forEach(assetGate.markFailed);
+                  return;
+                }
+                void cached.then(
+                  (cache) => {
+                    const mark = cache[uri]?.includes("memory")
+                      ? assetGate.markReady
+                      : assetGate.markFailed;
+                    keys.forEach(mark);
+                  },
+                  () => keys.forEach(assetGate.markFailed),
+                );
+              }}
+              onError={() => keys.forEach(assetGate.markFailed)}
+            />
+          ))
+        : null}
       <Svg
         height={renderSize.height}
         ref={svgRef}
@@ -159,16 +290,18 @@ export const ConversationShareSvg = forwardRef<
             {layout.bubbles.map((bubble, bubbleIndex) => (
               <SvgBubbleView bubble={bubble} key={`bubble-${bubbleIndex}`} />
             ))}
-            {layout.images.map((image, index) => (
+            {keyedImages.map((image) => (
               <SvgImage
-                key={`image-${index}`}
+                key={image.key}
                 href={{ uri: image.uri }}
                 x={image.x}
                 y={image.y}
                 width={image.width}
                 height={image.height}
                 preserveAspectRatio="xMidYMid meet"
-                onLoad={() => footerAssetGate.markReady(`image-${index}`)}
+                onLoad={() => {
+                  if (Platform.OS !== "android") assetGate.markReady(image.key);
+                }}
               />
             ))}
             {layout.gaps.map((gap, gapIndex) => (
@@ -201,7 +334,9 @@ export const ConversationShareSvg = forwardRef<
               height={SHARE_CHARACTER_SIZE}
               href={shareCharacterAsset}
               key={`conversation-share-character-${colors.dark ? "dark" : "light"}`}
-              onLoad={() => footerAssetGate.markReady("character")}
+              onLoad={() => {
+                if (Platform.OS !== "android") assetGate.markReady("character");
+              }}
               preserveAspectRatio="xMidYMid slice"
               width={SHARE_CHARACTER_SIZE}
               x={lockupX}
@@ -211,7 +346,9 @@ export const ConversationShareSvg = forwardRef<
               height={SHARE_LOGO_HEIGHT}
               href={logoAsset}
               key={`conversation-share-logo-${colors.dark ? "dark" : "light"}`}
-              onLoad={() => footerAssetGate.markReady("logo")}
+              onLoad={() => {
+                if (Platform.OS !== "android") assetGate.markReady("logo");
+              }}
               preserveAspectRatio="xMinYMid meet"
               width={logoWidth}
               x={lockupX + SHARE_CHARACTER_SIZE + SHARE_LOCKUP_GAP}
@@ -222,6 +359,15 @@ export const ConversationShareSvg = forwardRef<
           </>
         ) : null}
       </Svg>
+      {readyAssets ? (
+        // A newly mounted native layout event is the commit barrier: capture
+        // must see the fallback SVG, even when its outer size did not change.
+        <View
+          collapsable={false}
+          onLayout={() => exportJob.current?.capture(renderSize.sourceTooLarge)}
+          style={styles.decodeProbe}
+        />
+      ) : null}
     </View>
   );
 });
@@ -266,6 +412,7 @@ function SvgBubbleView({ bubble }: { bubble: ConversationShareSvgBubble }) {
 }
 
 const styles = StyleSheet.create({
+  decodeProbe: { position: "absolute", width: 1, height: 1 },
   hidden: {
     left: 0,
     opacity: 0,

--- a/apps/mobile/src/session/conversationShareAssetGate.ts
+++ b/apps/mobile/src/session/conversationShareAssetGate.ts
@@ -1,7 +1,7 @@
 export type ConversationShareFooterAsset = "character" | "logo";
 
 export interface ConversationShareFooterAssetGate {
-  markReady(asset: ConversationShareFooterAsset): void;
+  markReady(asset: string): void;
   waitUntilReady(): Promise<void>;
 }
 
@@ -10,8 +10,10 @@ export interface ConversationShareFooterAssetGate {
  * readiness latch separate from React so export can wait for both assets and
  * the ordering/duplicate-load behavior stays unit-testable.
  */
-export function createConversationShareFooterAssetGate(): ConversationShareFooterAssetGate {
-  const pending = new Set<ConversationShareFooterAsset>(["character", "logo"]);
+export function createConversationShareFooterAssetGate(
+  imageKeys: readonly string[] = [],
+): ConversationShareFooterAssetGate {
+  const pending = new Set<string>(["character", "logo", ...imageKeys]);
   let resolveReady = () => {};
   const ready = new Promise<void>((resolve) => {
     resolveReady = resolve;

--- a/apps/mobile/src/session/conversationShareAssetGate.ts
+++ b/apps/mobile/src/session/conversationShareAssetGate.ts
@@ -1,30 +1,39 @@
-export type ConversationShareFooterAsset = "character" | "logo";
-
-export interface ConversationShareFooterAssetGate {
+export interface ConversationShareAssetGate {
   markReady(asset: string): void;
-  waitUntilReady(): Promise<void>;
+  markFailed(asset: string): void;
+  waitUntilSettled(): Promise<void>;
+  finish(): ReadonlySet<string>;
 }
 
 /**
- * The SVG footer contains two independently decoded bundled images. Keep the
- * readiness latch separate from React so export can wait for both assets and
- * the ordering/duplicate-load behavior stays unit-testable.
+ * One prepared export owns this latch. The first result for each asset wins;
+ * finish freezes the successful subset, including when the decode deadline
+ * expires. Late native callbacks cannot change the capture layout.
  */
-export function createConversationShareFooterAssetGate(
-  imageKeys: readonly string[] = [],
-): ConversationShareFooterAssetGate {
-  const pending = new Set<string>(["character", "logo", ...imageKeys]);
-  let resolveReady = () => {};
-  const ready = new Promise<void>((resolve) => {
-    resolveReady = resolve;
+export function createConversationShareAssetGate(
+  keys: readonly string[],
+): ConversationShareAssetGate {
+  const pending = new Set(keys);
+  const ready = new Set<string>();
+  let finished = false;
+  let resolveSettled = () => {};
+  const settled = new Promise<void>((resolve) => {
+    resolveSettled = resolve;
   });
+  const mark = (asset: string, success: boolean) => {
+    if (finished || !pending.delete(asset)) return;
+    if (success) ready.add(asset);
+    if (pending.size === 0) resolveSettled();
+  };
+  if (pending.size === 0) resolveSettled();
 
   return {
-    markReady(asset) {
-      pending.delete(asset);
-      if (pending.size === 0) resolveReady();
-    },
-    waitUntilReady() {
+    markReady: (asset) => mark(asset, true),
+    markFailed: (asset) => mark(asset, false),
+    waitUntilSettled: () => settled,
+    finish() {
+      finished = true;
+      resolveSettled();
       return ready;
     },
   };

--- a/apps/mobile/src/session/conversationShareImages.ts
+++ b/apps/mobile/src/session/conversationShareImages.ts
@@ -26,10 +26,16 @@ export async function prepareConversationShareImages(
   let remainingCharacters = 32 * 1024 * 1024;
   for (const message of messages) {
     if (!isActive()) return [];
-    const sources = new Map<string, string>();
+    const sources = new Map<string, { url: string; occurrences: number }>();
+    const addSource = (source: string, url: string) => {
+      sources.set(source, {
+        url,
+        occurrences: (sources.get(source)?.occurrences ?? 0) + 1,
+      });
+    };
     for (const attachment of message.attachments ?? []) {
       if (attachment.kind === "image" && attachment.uri) {
-        sources.set(attachment.uri, attachment.uri);
+        addSource(attachment.uri, attachment.uri);
       }
     }
     const texts = message.bodyParts
@@ -47,32 +53,36 @@ export async function prepareConversationShareImages(
           context.remoteHostId,
           context.sessionId,
         );
-        if (url) sources.set(image.url, url);
+        if (url) addSource(image.url, url);
       }
     }
     const images = new Map<string, ConversationShareImage>();
-    for (const [source, url] of sources) {
+    for (const [source, { url, occurrences }] of sources) {
       if (!isActive()) return [];
+      let image = loaded.get(url);
       if (!loaded.has(url)) {
         const candidate =
           remainingCharacters > 0 ? await load(url).catch(() => null) : null;
-        const image =
+        image =
           candidate && candidate.uri.length <= remainingCharacters
             ? candidate
             : null;
-        if (image) remainingCharacters -= image.uri.length;
-        loaded.set(url, image);
+        if (!image) loaded.set(url, null);
       }
-      const image = loaded.get(url);
       if (
         image &&
         image.uri.startsWith("data:image/") &&
         Number.isFinite(image.width) &&
         Number.isFinite(image.height) &&
         image.width > 0 &&
-        image.height > 0
+        image.height > 0 &&
+        image.uri.length * occurrences <= remainingCharacters
       ) {
+        // Retain bytes only once they fit an output occurrence budget.
+        loaded.set(url, image);
         images.set(source, image);
+        // Byte reuse saves reads, but each rendered occurrence embeds a URI.
+        remainingCharacters -= image.uri.length * occurrences;
       }
     }
     result.push({ ...message, images });

--- a/apps/mobile/src/session/conversationShareImages.ts
+++ b/apps/mobile/src/session/conversationShareImages.ts
@@ -1,0 +1,81 @@
+import {
+  collectMobileMarkdownImages,
+  mobileMarkdownImageUrlForWorkdir,
+} from "@/session/messageMarkdown";
+import type {
+  ConversationShareImage,
+  ConversationShareMessage,
+} from "@/session/conversationShareWebViewHtml";
+
+export interface ConversationShareImageContext {
+  workdir?: string;
+  remoteHostId?: string;
+  sessionId?: string;
+}
+
+/** Prepare selected, visible content only; source URLs never enter the export document. */
+export async function prepareConversationShareImages(
+  messages: readonly ConversationShareMessage[],
+  load: (url: string) => Promise<ConversationShareImage | null>,
+  context: ConversationShareImageContext = {},
+  isActive: () => boolean = () => true,
+): Promise<ConversationShareMessage[]> {
+  const result: ConversationShareMessage[] = [];
+  // Per-export reuse, with sequential reads to bound simultaneous decoded images.
+  const loaded = new Map<string, ConversationShareImage | null>();
+  let remainingCharacters = 32 * 1024 * 1024;
+  for (const message of messages) {
+    if (!isActive()) return [];
+    const sources = new Map<string, string>();
+    for (const attachment of message.attachments ?? []) {
+      if (attachment.kind === "image" && attachment.uri) {
+        sources.set(attachment.uri, attachment.uri);
+      }
+    }
+    const texts = message.bodyParts
+      ? message.bodyParts.flatMap((part) =>
+          part.kind === "text" ? [part.text] : [],
+        )
+      : [message.body];
+    if (message.secondaryBody) texts.push(message.secondaryBody);
+    for (const text of texts) {
+      for (const image of collectMobileMarkdownImages(text)) {
+        const url = mobileMarkdownImageUrlForWorkdir(
+          image.url,
+          context.workdir,
+          message.clientId,
+          context.remoteHostId,
+          context.sessionId,
+        );
+        if (url) sources.set(image.url, url);
+      }
+    }
+    const images = new Map<string, ConversationShareImage>();
+    for (const [source, url] of sources) {
+      if (!isActive()) return [];
+      if (!loaded.has(url)) {
+        const candidate =
+          remainingCharacters > 0 ? await load(url).catch(() => null) : null;
+        const image =
+          candidate && candidate.uri.length <= remainingCharacters
+            ? candidate
+            : null;
+        if (image) remainingCharacters -= image.uri.length;
+        loaded.set(url, image);
+      }
+      const image = loaded.get(url);
+      if (
+        image &&
+        image.uri.startsWith("data:image/") &&
+        Number.isFinite(image.width) &&
+        Number.isFinite(image.height) &&
+        image.width > 0 &&
+        image.height > 0
+      ) {
+        images.set(source, image);
+      }
+    }
+    result.push({ ...message, images });
+  }
+  return result;
+}

--- a/apps/mobile/src/session/conversationShareImages.ts
+++ b/apps/mobile/src/session/conversationShareImages.ts
@@ -13,6 +13,11 @@ export interface ConversationShareImageContext {
   sessionId?: string;
 }
 
+// Compressed bytes do not bound native bitmap memory. Charge every rendered
+// occurrence before either HTML or SVG can mount it (RGBA: 16 / 32 MB).
+const MAX_IMAGE_PIXELS = 4_000_000;
+const MAX_EXPORT_IMAGE_PIXELS = 8_000_000;
+
 /** Prepare selected, visible content only; source URLs never enter the export document. */
 export async function prepareConversationShareImages(
   messages: readonly ConversationShareMessage[],
@@ -21,9 +26,10 @@ export async function prepareConversationShareImages(
   isActive: () => boolean = () => true,
 ): Promise<ConversationShareMessage[]> {
   const result: ConversationShareMessage[] = [];
-  // Per-export reuse, with sequential reads to bound simultaneous decoded images.
+  // Per-export byte reuse. Native renderers mount only the budgeted result.
   const loaded = new Map<string, ConversationShareImage | null>();
   let remainingCharacters = 32 * 1024 * 1024;
+  let remainingPixels = MAX_EXPORT_IMAGE_PIXELS;
   for (const message of messages) {
     if (!isActive()) return [];
     const sources = new Map<string, { url: string; occurrences: number }>();
@@ -62,13 +68,18 @@ export async function prepareConversationShareImages(
       let image = loaded.get(url);
       if (!loaded.has(url)) {
         const candidate =
-          remainingCharacters > 0 ? await load(url).catch(() => null) : null;
+          remainingCharacters > 0 && remainingPixels > 0
+            ? await load(url).catch(() => null)
+            : null;
         image =
           candidate && candidate.uri.length <= remainingCharacters
             ? candidate
             : null;
         if (!image) loaded.set(url, null);
       }
+      const pixels = image
+        ? Math.ceil(image.width) * Math.ceil(image.height)
+        : 0;
       if (
         image &&
         image.uri.startsWith("data:image/") &&
@@ -76,6 +87,8 @@ export async function prepareConversationShareImages(
         Number.isFinite(image.height) &&
         image.width > 0 &&
         image.height > 0 &&
+        pixels <= MAX_IMAGE_PIXELS &&
+        pixels * occurrences <= remainingPixels &&
         image.uri.length * occurrences <= remainingCharacters
       ) {
         // Retain bytes only once they fit an output occurrence budget.
@@ -83,6 +96,7 @@ export async function prepareConversationShareImages(
         images.set(source, image);
         // Byte reuse saves reads, but each rendered occurrence embeds a URI.
         remainingCharacters -= image.uri.length * occurrences;
+        remainingPixels -= pixels * occurrences;
       }
     }
     result.push({ ...message, images });

--- a/apps/mobile/src/session/conversationShareImages.ts
+++ b/apps/mobile/src/session/conversationShareImages.ts
@@ -17,6 +17,7 @@ export interface ConversationShareImageContext {
 // occurrence before either HTML or SVG can mount it (RGBA: 16 / 32 MB).
 const MAX_IMAGE_PIXELS = 4_000_000;
 const MAX_EXPORT_IMAGE_PIXELS = 8_000_000;
+const IMAGE_PREPARATION_CONCURRENCY = 3;
 
 /** Prepare selected, visible content only; source URLs never enter the export document. */
 export async function prepareConversationShareImages(
@@ -26,8 +27,16 @@ export async function prepareConversationShareImages(
   isActive: () => boolean = () => true,
 ): Promise<ConversationShareMessage[]> {
   const result: ConversationShareMessage[] = [];
-  // Per-export byte reuse. Native renderers mount only the budgeted result.
-  const loaded = new Map<string, ConversationShareImage | null>();
+  // Group references before starting IO so a stalled source cannot prevent
+  // independent sources in later messages from reaching a free worker.
+  const requests = new Map<
+    string,
+    Array<{
+      source: string;
+      occurrences: number;
+      images: Map<string, ConversationShareImage>;
+    }>
+  >();
   let remainingCharacters = 32 * 1024 * 1024;
   let remainingPixels = MAX_EXPORT_IMAGE_PIXELS;
   for (const message of messages) {
@@ -64,19 +73,25 @@ export async function prepareConversationShareImages(
     }
     const images = new Map<string, ConversationShareImage>();
     for (const [source, { url, occurrences }] of sources) {
-      if (!isActive()) return [];
-      let image = loaded.get(url);
-      if (!loaded.has(url)) {
-        const candidate =
-          remainingCharacters > 0 && remainingPixels > 0
-            ? await load(url).catch(() => null)
-            : null;
-        image =
-          candidate && candidate.uri.length <= remainingCharacters
-            ? candidate
-            : null;
-        if (!image) loaded.set(url, null);
+      const references = requests.get(url) ?? [];
+      references.push({ source, occurrences, images });
+      requests.set(url, references);
+    }
+    result.push({ ...message, images });
+  }
+  const pending = requests.entries();
+  const worker = async () => {
+    while (isActive() && remainingCharacters > 0 && remainingPixels > 0) {
+      const next = pending.next();
+      if (next.done) return;
+      const [url, references] = next.value;
+      let image: ConversationShareImage | null;
+      try {
+        image = await load(url);
+      } catch {
+        continue;
       }
+      if (!isActive()) return;
       const pixels = image
         ? Math.ceil(image.width) * Math.ceil(image.height)
         : 0;
@@ -87,19 +102,29 @@ export async function prepareConversationShareImages(
         Number.isFinite(image.height) &&
         image.width > 0 &&
         image.height > 0 &&
-        pixels <= MAX_IMAGE_PIXELS &&
-        pixels * occurrences <= remainingPixels &&
-        image.uri.length * occurrences <= remainingCharacters
+        pixels <= MAX_IMAGE_PIXELS
       ) {
-        // Retain bytes only once they fit an output occurrence budget.
-        loaded.set(url, image);
-        images.set(source, image);
-        // Byte reuse saves reads, but each rendered occurrence embeds a URI.
-        remainingCharacters -= image.uri.length * occurrences;
-        remainingPixels -= pixels * occurrences;
+        // Admission is synchronous: completed sources share one budget owner.
+        // No unbounded completed-image buffer; rejected candidates are released.
+        // Readiness decides admission, while render order stays in the messages.
+        for (const { source, occurrences, images } of references) {
+          if (
+            pixels * occurrences <= remainingPixels &&
+            image.uri.length * occurrences <= remainingCharacters
+          ) {
+            images.set(source, image);
+            remainingCharacters -= image.uri.length * occurrences;
+            remainingPixels -= pixels * occurrences;
+          }
+        }
       }
     }
-    result.push({ ...message, images });
-  }
-  return result;
+  };
+  await Promise.all(
+    Array.from(
+      { length: Math.min(IMAGE_PREPARATION_CONCURRENCY, requests.size) },
+      worker,
+    ),
+  );
+  return isActive() ? result : [];
 }

--- a/apps/mobile/src/session/conversationShareProjection.ts
+++ b/apps/mobile/src/session/conversationShareProjection.ts
@@ -141,8 +141,9 @@ function projectAttachments(
 ): ConversationShareAttachment[] {
   const { imageAttachments, fileAttachments } =
     partitionMessageAttachments(attachments);
-  return [...imageAttachments, ...fileAttachments].map(({ kind, name }) => ({
+  return [...imageAttachments, ...fileAttachments].map(({ kind, name, uri }) => ({
     kind,
     name,
+    ...(kind === 'image' && uri ? { uri } : {}),
   }));
 }

--- a/apps/mobile/src/session/conversationShareSvgLayout.ts
+++ b/apps/mobile/src/session/conversationShareSvgLayout.ts
@@ -258,11 +258,38 @@ function conversationShareBodyParts(
     }
   } else markdown(message.body);
   if (message.secondaryBody) markdown(message.secondaryBody);
-  return parts.flatMap<ShareBodyPart>((part) => {
+  const fullText = parts
+    .map((part) => ("text" in part ? part.text : ""))
+    .join("");
+  const redacted = redactSensitiveText(fullText);
+  let safeParts = parts;
+  if (redacted !== fullText) {
+    safeParts = [];
+    let sourceOffset = 0;
+    let safeOffset = 0;
+    for (const part of parts) {
+      if ("text" in part) {
+        sourceOffset += part.text.length;
+        continue;
+      }
+      // A secret can span an image. Position images against redacted prefixes,
+      // but take ALL output text from the fully redacted message, never a prefix.
+      const prefix = redactSensitiveText(fullText.slice(0, sourceOffset));
+      let boundary = 0;
+      while (
+        boundary < prefix.length &&
+        prefix[boundary] === redacted[boundary]
+      )
+        boundary++;
+      boundary = Math.max(safeOffset, boundary);
+      safeParts.push({ text: redacted.slice(safeOffset, boundary) }, part);
+      safeOffset = boundary;
+    }
+    safeParts.push({ text: redacted.slice(safeOffset) });
+  }
+  return safeParts.flatMap<ShareBodyPart>((part) => {
     if ("image" in part) return [part];
-    const text = redactSensitiveText(part.text)
-      .replace(/\n{3,}/g, "\n\n")
-      .trim();
+    const text = part.text.replace(/\n{3,}/g, "\n\n").trim();
     return text ? [{ text }] : [];
   });
 }

--- a/apps/mobile/src/session/conversationShareSvgLayout.ts
+++ b/apps/mobile/src/session/conversationShareSvgLayout.ts
@@ -8,6 +8,7 @@ import {
 } from "@/session/messageMarkdown";
 import type {
   ConversationShareMessage,
+  ConversationShareImage,
   ConversationShareWebViewColors,
 } from "@/session/conversationShareWebViewHtml";
 
@@ -40,6 +41,7 @@ export interface ConversationShareSvgBubble {
 }
 
 export interface ConversationShareSvgLayout {
+  images: Array<{ uri: string; x: number; y: number; width: number; height: number }>;
   bubbles: ConversationShareSvgBubble[];
   footerY: number;
   gaps: Array<{ color: string; y: number }>;
@@ -80,6 +82,7 @@ export function buildConversationShareSvgLayout({
   const canvasWidth = Math.max(280, Math.round(width));
   const contentWidth = canvasWidth - PADDING * 2;
   const bubbles: ConversationShareSvgBubble[] = [];
+  const images: ConversationShareSvgLayout['images'] = [];
   const gaps: Array<{ color: string; y: number }> = [];
   const messageIndex = new Map(allShareableIds.map((id, index) => [id, index]));
   let previousIndex: number | null = null;
@@ -100,6 +103,28 @@ export function buildConversationShareSvgLayout({
     const bubbleX = user ? canvasWidth - PADDING - bubbleWidth : PADDING;
     const horizontalPadding = user ? 12 : 0;
     const textWidth = bubbleWidth - horizontalPadding * 2;
+    const appendImage = (image: ConversationShareImage) => {
+      const scale = Math.min(1, bubbleWidth / image.width, 320 / image.height);
+      const imageWidth = image.width * scale;
+      const imageHeight = image.height * scale;
+      images.push({
+        uri: image.uri,
+        width: imageWidth,
+        height: imageHeight,
+        x: user ? canvasWidth - PADDING - imageWidth : PADDING,
+        y: cursorY,
+      });
+      cursorY += imageHeight + MESSAGE_GAP;
+    };
+    const attachmentSources = new Set<string>();
+    for (const attachment of message.attachments ?? []) {
+      const image = attachment.kind === 'image' && attachment.uri
+        ? message.images?.get(attachment.uri) : undefined;
+      if (image && attachment.uri) {
+        appendImage(image);
+        attachmentSources.add(attachment.uri);
+      }
+    }
     const blocks: Array<{
       color: string;
       fontSize: number;
@@ -116,6 +141,7 @@ export function buildConversationShareSvgLayout({
       });
     }
     for (const attachment of message.attachments ?? []) {
+      if (attachment.kind === 'image' && attachment.uri && message.images?.has(attachment.uri)) continue;
       blocks.push({
         color: colors.textSecondary,
         fontSize: META_FONT_SIZE,
@@ -149,7 +175,7 @@ export function buildConversationShareSvgLayout({
     }
     if (blocks.length > 0) innerY -= 5;
     const bubbleHeight = Math.max(user ? 44 : 30, innerY + (user ? 12 : 4));
-    bubbles.push({
+    if (blocks.length > 0) bubbles.push({
       fill: user ? colors.surfaceElevated : undefined,
       height: bubbleHeight,
       stroke: user ? colors.textSecondary : undefined,
@@ -158,13 +184,17 @@ export function buildConversationShareSvgLayout({
       x: bubbleX,
       y: cursorY,
     });
-    cursorY += bubbleHeight + MESSAGE_GAP;
+    if (blocks.length > 0) cursorY += bubbleHeight + MESSAGE_GAP;
+    for (const [source, image] of message.images ?? []) {
+      if (!attachmentSources.has(source)) appendImage(image);
+    }
     previousIndex = currentIndex;
   }
 
   const footerY = cursorY + 36;
   return {
     bubbles,
+    images,
     footerY,
     gaps,
     height: footerY + 22 + PADDING,

--- a/apps/mobile/src/session/conversationShareSvgLayout.ts
+++ b/apps/mobile/src/session/conversationShareSvgLayout.ts
@@ -41,7 +41,13 @@ export interface ConversationShareSvgBubble {
 }
 
 export interface ConversationShareSvgLayout {
-  images: Array<{ uri: string; x: number; y: number; width: number; height: number }>;
+  images: Array<{
+    uri: string;
+    x: number;
+    y: number;
+    width: number;
+    height: number;
+  }>;
   bubbles: ConversationShareSvgBubble[];
   footerY: number;
   gaps: Array<{ color: string; y: number }>;
@@ -82,7 +88,7 @@ export function buildConversationShareSvgLayout({
   const canvasWidth = Math.max(280, Math.round(width));
   const contentWidth = canvasWidth - PADDING * 2;
   const bubbles: ConversationShareSvgBubble[] = [];
-  const images: ConversationShareSvgLayout['images'] = [];
+  const images: ConversationShareSvgLayout["images"] = [];
   const gaps: Array<{ color: string; y: number }> = [];
   const messageIndex = new Map(allShareableIds.map((id, index) => [id, index]));
   let previousIndex: number | null = null;
@@ -116,21 +122,24 @@ export function buildConversationShareSvgLayout({
       });
       cursorY += imageHeight + MESSAGE_GAP;
     };
-    const attachmentSources = new Set<string>();
     for (const attachment of message.attachments ?? []) {
-      const image = attachment.kind === 'image' && attachment.uri
-        ? message.images?.get(attachment.uri) : undefined;
+      const image =
+        attachment.kind === "image" && attachment.uri
+          ? message.images?.get(attachment.uri)
+          : undefined;
       if (image && attachment.uri) {
         appendImage(image);
-        attachmentSources.add(attachment.uri);
       }
     }
-    const blocks: Array<{
-      color: string;
-      fontSize: number;
-      lineHeight: number;
-      text: string;
-    }> = [];
+    const blocks: Array<
+      | { image: ConversationShareImage }
+      | {
+          color: string;
+          fontSize: number;
+          lineHeight: number;
+          text: string;
+        }
+    > = [];
 
     if (message.automationOriginLabel) {
       blocks.push({
@@ -141,7 +150,12 @@ export function buildConversationShareSvgLayout({
       });
     }
     for (const attachment of message.attachments ?? []) {
-      if (attachment.kind === 'image' && attachment.uri && message.images?.has(attachment.uri)) continue;
+      if (
+        attachment.kind === "image" &&
+        attachment.uri &&
+        message.images?.has(attachment.uri)
+      )
+        continue;
       blocks.push({
         color: colors.textSecondary,
         fontSize: META_FONT_SIZE,
@@ -149,19 +163,37 @@ export function buildConversationShareSvgLayout({
         text: `${attachment.kind === "image" ? "▧" : "▤"} ${redactSensitiveText(attachment.name).trim()}`,
       });
     }
-    const body = plainConversationShareText(message);
-    if (body) {
-      blocks.push({
-        color: colors.textPrimary,
-        fontSize: TEXT_FONT_SIZE,
-        lineHeight: TEXT_LINE_HEIGHT,
-        text: body,
-      });
+    for (const part of conversationShareBodyParts(message)) {
+      if ("image" in part) blocks.push(part);
+      else
+        blocks.push({
+          color: colors.textPrimary,
+          fontSize: TEXT_FONT_SIZE,
+          lineHeight: TEXT_LINE_HEIGHT,
+          text: part.text,
+        });
     }
 
     const textBlocks: ConversationShareSvgTextBlock[] = [];
     let innerY = user ? 12 : 4;
     for (const block of blocks) {
+      if ("image" in block) {
+        const scale = Math.min(
+          1,
+          textWidth / block.image.width,
+          320 / block.image.height,
+        );
+        const height = block.image.height * scale;
+        images.push({
+          uri: block.image.uri,
+          width: block.image.width * scale,
+          height,
+          x: bubbleX + horizontalPadding,
+          y: cursorY + innerY,
+        });
+        innerY += height + 5;
+        continue;
+      }
       const lines = wrapSvgText(block.text, textWidth, block.fontSize);
       textBlocks.push({
         color: block.color,
@@ -175,19 +207,17 @@ export function buildConversationShareSvgLayout({
     }
     if (blocks.length > 0) innerY -= 5;
     const bubbleHeight = Math.max(user ? 44 : 30, innerY + (user ? 12 : 4));
-    if (blocks.length > 0) bubbles.push({
-      fill: user ? colors.surfaceElevated : undefined,
-      height: bubbleHeight,
-      stroke: user ? colors.textSecondary : undefined,
-      textBlocks,
-      width: bubbleWidth,
-      x: bubbleX,
-      y: cursorY,
-    });
+    if (blocks.length > 0)
+      bubbles.push({
+        fill: user ? colors.surfaceElevated : undefined,
+        height: bubbleHeight,
+        stroke: user ? colors.textSecondary : undefined,
+        textBlocks,
+        width: bubbleWidth,
+        x: bubbleX,
+        y: cursorY,
+      });
     if (blocks.length > 0) cursorY += bubbleHeight + MESSAGE_GAP;
-    for (const [source, image] of message.images ?? []) {
-      if (!attachmentSources.has(source)) appendImage(image);
-    }
     previousIndex = currentIndex;
   }
 
@@ -202,36 +232,60 @@ export function buildConversationShareSvgLayout({
   };
 }
 
-function plainConversationShareText(message: ConversationShareMessage): string {
-  const parts = message.bodyParts
-    ? message.bodyParts
-        .map((part) => (part.kind === "text" ? part.text : part.label))
-        .join("\n")
-    : message.body;
-  const combined = [parts, message.secondaryBody].filter(Boolean).join("\n");
-  return redactSensitiveText(plainMarkdownText(combined));
+type ShareBodyPart = { text: string } | { image: ConversationShareImage };
+
+/** Traverse occurrences, using the source map only to look up decoded bytes. */
+function conversationShareBodyParts(
+  message: ConversationShareMessage,
+): ShareBodyPart[] {
+  const parts: ShareBodyPart[] = [];
+  const append = (part: ShareBodyPart) => {
+    const last = parts[parts.length - 1];
+    if ("text" in part && last && "text" in last) last.text += part.text;
+    else parts.push(part);
+  };
+  const markdown = (text: string) => {
+    for (const block of parseMobileMarkdown(text)) {
+      for (const part of markdownBlockParts(block, message.images))
+        append(part);
+      append({ text: "\n" });
+    }
+  };
+  if (message.bodyParts) {
+    for (const part of message.bodyParts) {
+      if (part.kind === "text") markdown(part.text);
+      else append({ text: `${part.label}\n` });
+    }
+  } else markdown(message.body);
+  if (message.secondaryBody) markdown(message.secondaryBody);
+  return parts.flatMap<ShareBodyPart>((part) => {
+    if ("image" in part) return [part];
+    const text = redactSensitiveText(part.text)
+      .replace(/\n{3,}/g, "\n\n")
+      .trim();
+    return text ? [{ text }] : [];
+  });
 }
 
-function plainMarkdownText(markdown: string): string {
-  const blocks = parseMobileMarkdown(markdown);
-  return blocks
-    .map(plainMarkdownBlockText)
-    .filter(Boolean)
-    .join("\n")
-    .replace(/\n{3,}/g, "\n\n")
-    .trim();
-}
-
-function plainMarkdownBlockText(block: MobileMarkdownBlock): string {
+function markdownBlockParts(
+  block: MobileMarkdownBlock,
+  images: ConversationShareMessage["images"],
+): ShareBodyPart[] {
   switch (block.type) {
     case "paragraph":
     case "heading":
-      return plainMarkdownInlineText(block.inlines);
+      return markdownInlineParts(block.inlines, images);
     case "blockquote":
-      return plainMarkdownInlineText(block.inlines)
-        .split("\n")
-        .map((line) => `> ${line}`)
-        .join("\n");
+      return markdownInlineParts(block.inlines, images).map((part) =>
+        "text" in part
+          ? {
+              text: part.text
+                .split("\n")
+                .map((line) => `> ${line}`)
+                .join("\n"),
+            }
+          : part,
+      );
     case "list_item": {
       const taskMarker =
         typeof block.checked === "boolean"
@@ -244,26 +298,40 @@ function plainMarkdownBlockText(block: MobileMarkdownBlock): string {
           ? `${block.marker} ${taskMarker}`
           : taskMarker
         : block.marker;
-      return `${marker} ${plainMarkdownInlineText(block.inlines)}`;
+      return [
+        { text: `${marker} ` },
+        ...markdownInlineParts(block.inlines, images),
+      ];
     }
     case "table": {
       const rows = [block.header, ...block.rows.map((row) => row.cells)];
-      return rows
-        .map((cells) => cells.map(plainMarkdownInlineText).join(" | "))
-        .join("\n");
+      return rows.flatMap((cells, rowIndex) => [
+        ...(rowIndex ? [{ text: "\n" }] : []),
+        ...cells.flatMap((inlines, cellIndex) => [
+          ...(cellIndex ? [{ text: " | " }] : []),
+          ...markdownInlineParts(inlines, images),
+        ]),
+      ]);
     }
     case "code":
     case "math":
     case "mermaid":
-      return block.text;
+      return [{ text: block.text }];
   }
 }
 
-function plainMarkdownInlineText(
+function markdownInlineParts(
   inlines: readonly MobileMarkdownInline[],
-): string {
-  return inlines
-    .map((inline) => {
+  images: ConversationShareMessage["images"],
+): ShareBodyPart[] {
+  const parts: ShareBodyPart[] = [];
+  for (const inline of inlines) {
+    const image = inline.type === "image" ? images?.get(inline.url) : undefined;
+    if (image) {
+      parts.push({ image });
+      continue;
+    }
+    const text = (() => {
       if (inline.type === "image") {
         return (
           inline.alt.trim() || i18n.t("message.renderer.imageFallbackTitle")
@@ -273,8 +341,12 @@ function plainMarkdownInlineText(
         return `~~${inline.text}~~`;
       }
       return inline.text;
-    })
-    .join("");
+    })();
+    const last = parts[parts.length - 1];
+    if (last && "text" in last) last.text += text;
+    else parts.push({ text });
+  }
+  return parts;
 }
 
 export function wrapSvgText(

--- a/apps/mobile/src/session/conversationShareSvgLayout.ts
+++ b/apps/mobile/src/session/conversationShareSvgLayout.ts
@@ -109,11 +109,9 @@ export function buildConversationShareSvgLayout({
     const bubbleX = user ? canvasWidth - PADDING - bubbleWidth : PADDING;
     const horizontalPadding = user ? 12 : 0;
     const textWidth = bubbleWidth - horizontalPadding * 2;
-    // Attribution belongs to the whole message, above attachments and outside
-    // the content bubble, including when failed images fall back to text.
-    if (message.automationOriginLabel) {
+    const appendMetadata = (text: string, color: string, gap: number) => {
       const lines = wrapSvgText(
-        redactSensitiveText(message.automationOriginLabel).trim(),
+        redactSensitiveText(text).trim(),
         bubbleWidth,
         META_FONT_SIZE,
       );
@@ -125,7 +123,7 @@ export function buildConversationShareSvgLayout({
         y: cursorY,
         textBlocks: [
           {
-            color: colors.textTertiary,
+            color,
             fontSize: META_FONT_SIZE,
             lineHeight: META_LINE_HEIGHT,
             lines,
@@ -134,7 +132,12 @@ export function buildConversationShareSvgLayout({
           },
         ],
       });
-      cursorY += height + 4;
+      cursorY += height + gap;
+    };
+    // One ordered traversal owns attribution, attachments, then body. Failed
+    // images replace their own occurrence rather than moving into the bubble.
+    if (message.automationOriginLabel) {
+      appendMetadata(message.automationOriginLabel, colors.textTertiary, 4);
     }
     const appendImage = (image: ConversationShareImage) => {
       const scale = Math.min(1, bubbleWidth / image.width, 320 / image.height);
@@ -156,6 +159,12 @@ export function buildConversationShareSvgLayout({
           : undefined;
       if (image && attachment.uri) {
         appendImage(image);
+      } else {
+        appendMetadata(
+          `${attachment.kind === "image" ? "▧" : "▤"} ${attachment.name}`,
+          colors.textSecondary,
+          MESSAGE_GAP,
+        );
       }
     }
     const blocks: Array<
@@ -168,20 +177,6 @@ export function buildConversationShareSvgLayout({
         }
     > = [];
 
-    for (const attachment of message.attachments ?? []) {
-      if (
-        attachment.kind === "image" &&
-        attachment.uri &&
-        message.images?.has(attachment.uri)
-      )
-        continue;
-      blocks.push({
-        color: colors.textSecondary,
-        fontSize: META_FONT_SIZE,
-        lineHeight: META_LINE_HEIGHT,
-        text: `${attachment.kind === "image" ? "▧" : "▤"} ${redactSensitiveText(attachment.name).trim()}`,
-      });
-    }
     for (const part of conversationShareBodyParts(message)) {
       if ("image" in part) blocks.push(part);
       else

--- a/apps/mobile/src/session/conversationShareSvgLayout.ts
+++ b/apps/mobile/src/session/conversationShareSvgLayout.ts
@@ -109,6 +109,33 @@ export function buildConversationShareSvgLayout({
     const bubbleX = user ? canvasWidth - PADDING - bubbleWidth : PADDING;
     const horizontalPadding = user ? 12 : 0;
     const textWidth = bubbleWidth - horizontalPadding * 2;
+    // Attribution belongs to the whole message, above attachments and outside
+    // the content bubble, including when failed images fall back to text.
+    if (message.automationOriginLabel) {
+      const lines = wrapSvgText(
+        redactSensitiveText(message.automationOriginLabel).trim(),
+        bubbleWidth,
+        META_FONT_SIZE,
+      );
+      const height = lines.length * META_LINE_HEIGHT;
+      bubbles.push({
+        height,
+        width: bubbleWidth,
+        x: bubbleX,
+        y: cursorY,
+        textBlocks: [
+          {
+            color: colors.textTertiary,
+            fontSize: META_FONT_SIZE,
+            lineHeight: META_LINE_HEIGHT,
+            lines,
+            x: bubbleX,
+            y: cursorY + META_FONT_SIZE,
+          },
+        ],
+      });
+      cursorY += height + 4;
+    }
     const appendImage = (image: ConversationShareImage) => {
       const scale = Math.min(1, bubbleWidth / image.width, 320 / image.height);
       const imageWidth = image.width * scale;
@@ -141,14 +168,6 @@ export function buildConversationShareSvgLayout({
         }
     > = [];
 
-    if (message.automationOriginLabel) {
-      blocks.push({
-        color: colors.textTertiary,
-        fontSize: META_FONT_SIZE,
-        lineHeight: META_LINE_HEIGHT,
-        text: redactSensitiveText(message.automationOriginLabel).trim(),
-      });
-    }
     for (const attachment of message.attachments ?? []) {
       if (
         attachment.kind === "image" &&

--- a/apps/mobile/src/session/conversationShareWebViewHtml.ts
+++ b/apps/mobile/src/session/conversationShareWebViewHtml.ts
@@ -17,11 +17,20 @@ export interface ConversationShareMessage {
   body: string;
   bodyParts?: readonly ConversationShareBodyPart[];
   secondaryBody?: string;
+  /** Export-only decoded images, keyed by attachment/Markdown source. */
+  images?: ReadonlyMap<string, ConversationShareImage>;
+}
+
+export interface ConversationShareImage {
+  uri: string;
+  width: number;
+  height: number;
 }
 
 export interface ConversationShareAttachment {
   kind: "image" | "file";
   name: string;
+  uri?: string;
 }
 
 export type ConversationShareBodyPart =
@@ -124,6 +133,7 @@ function buildMessageHtml(
   message: ConversationShareMessage,
   markdownOptions: SelectableMarkdownHtmlOptions,
 ): string {
+  markdownOptions = { ...markdownOptions, imageSources: message.images ?? new Map() };
   const body = redactSensitiveText(message.body).trim();
   const secondaryBody = message.secondaryBody
     ? redactSensitiveText(message.secondaryBody).trim()
@@ -136,7 +146,7 @@ function buildMessageHtml(
   const secondaryHtml = secondaryBody
     ? buildSelectableMarkdownFragmentHtml(secondaryBody, markdownOptions)
     : "";
-  const attachmentsHtml = buildAttachmentsHtml(message.attachments ?? []);
+  const attachmentsHtml = buildAttachmentsHtml(message.attachments ?? [], message.images);
   const bubbleHtml = bodyHtml || secondaryHtml
     ? [
         `<div class="share-bubble share-bubble-${message.kind}">`,
@@ -182,10 +192,16 @@ function buildBodyPartsHtml(
 
 function buildAttachmentsHtml(
   attachments: readonly ConversationShareAttachment[],
+  images?: ConversationShareMessage['images'],
 ): string {
   if (attachments.length === 0) return "";
   const items = attachments.map((attachment) => {
     const name = redactSensitiveText(attachment.name).trim();
+    const image = attachment.kind === "image" && attachment.uri
+      ? images?.get(attachment.uri) : undefined;
+    if (image?.uri.startsWith('data:image/')) {
+      return `<img class="share-attachment-image" src="${escapeAttribute(image.uri)}" alt="${escapeAttribute(name)}">`;
+    }
     return `<div class="share-attachment-chip share-attachment-chip-${attachment.kind}"><span class="share-attachment-icon" aria-hidden="true"></span><span class="share-attachment-label">${escapeHtml(name)}</span></div>`;
   });
   return `<div class="share-attachments">${items.join("")}</div>`;
@@ -275,6 +291,13 @@ function buildConversationShareCss({
     }
     .share-message-user .share-attachments { align-items: flex-end; }
     .share-message-assistant .share-attachments { align-items: flex-start; }
+    .share-attachment-image {
+      display: block;
+      max-width: 100%;
+      max-height: 320px;
+      object-fit: contain;
+      border-radius: 12px;
+    }
     .share-attachment-chip {
       box-sizing: border-box;
       display: flex;

--- a/apps/mobile/src/session/conversationShareWebViewHtml.ts
+++ b/apps/mobile/src/session/conversationShareWebViewHtml.ts
@@ -134,6 +134,14 @@ function buildMessageHtml(
   markdownOptions: SelectableMarkdownHtmlOptions,
 ): string {
   markdownOptions = { ...markdownOptions, imageSources: message.images ?? new Map() };
+  // Raw-text redaction can consume signed URLs and Markdown delimiters. Use
+  // the existing SVG fallback (which looks up images before redacting text)
+  // rather than weakening redaction across inline code/emphasis boundaries.
+  for (const source of message.images?.keys() ?? []) {
+    if (redactSensitiveText(source) !== source) {
+      throw new Error('conversation-share-image-requires-svg');
+    }
+  }
   const body = redactSensitiveText(message.body).trim();
   const secondaryBody = message.secondaryBody
     ? redactSensitiveText(message.secondaryBody).trim()

--- a/apps/mobile/src/session/conversationShareWebViewHtml.ts
+++ b/apps/mobile/src/session/conversationShareWebViewHtml.ts
@@ -7,6 +7,7 @@ import {
   type SelectableMarkdownHtmlOptions,
 } from "@/session/selectableMarkdownHtml";
 import { buildMessageContentLayout } from "@/session/messageContentLayout";
+import { collectMobileMarkdownImages } from "@/session/messageMarkdown";
 import { lineHeight, typeScale } from "@/theme/tokens";
 
 export interface ConversationShareMessage {
@@ -134,13 +135,18 @@ function buildMessageHtml(
   markdownOptions: SelectableMarkdownHtmlOptions,
 ): string {
   markdownOptions = { ...markdownOptions, imageSources: message.images ?? new Map() };
-  // Raw-text redaction can consume signed URLs and Markdown delimiters. Use
-  // the existing SVG fallback (which looks up images before redacting text)
-  // rather than weakening redaction across inline code/emphasis boundaries.
-  for (const source of message.images?.keys() ?? []) {
-    if (redactSensitiveText(source) !== source) {
-      throw new Error('conversation-share-image-requires-svg');
-    }
+  const texts = message.bodyParts
+    ? message.bodyParts.flatMap((part) => part.kind === "text" ? [part.text] : [])
+    : [message.body];
+  if (message.secondaryBody) texts.push(message.secondaryBody);
+  // Redaction can consume image delimiters as well as URLs. Let the existing
+  // SVG path own all image-bearing text that needs redaction, even when image
+  // preparation failed; never parse damaged Markdown or expose its source URL.
+  if (
+    texts.some((text) => redactSensitiveText(text) !== text) &&
+    texts.some((text) => collectMobileMarkdownImages(text).length > 0)
+  ) {
+    throw new Error('conversation-share-image-requires-svg');
   }
   const body = redactSensitiveText(message.body).trim();
   const secondaryBody = message.secondaryBody

--- a/apps/mobile/src/session/selectableMarkdownHtml.ts
+++ b/apps/mobile/src/session/selectableMarkdownHtml.ts
@@ -19,6 +19,8 @@ import { i18n } from '@/i18n';
  * 只保留「markdown → 完整 HTML 文档」这一条能力。
  */
 export interface SelectableMarkdownHtmlOptions {
+  /** When supplied, export only these embedded images; never expose source URLs. */
+  imageSources?: ReadonlyMap<string, { uri: string }>;
   bodyGap?: number;
   borderColor?: string;
   chipColor?: string;
@@ -54,6 +56,7 @@ export interface SelectableMarkdownHtmlOptions {
 
 /** renderBlocks/renderInline 的渲染上下文(目前只有会话 chip 标题 map)。 */
 interface RenderContext {
+  imageSources?: SelectableMarkdownHtmlOptions['imageSources'];
   sessionLinkTitles?: Readonly<Record<string, string>>;
 }
 
@@ -82,7 +85,7 @@ export function buildSelectableMarkdownHtml(
     '</head>',
     '<body>',
     `<main id="xdt-content" role="article" aria-label="${escapeAttribute(i18n.t('message.renderer.markdownDocAriaLabel'))}">`,
-    renderBlocks(blocks, { sessionLinkTitles: options.sessionLinkTitles }),
+    renderBlocks(blocks, { sessionLinkTitles: options.sessionLinkTitles, imageSources: options.imageSources }),
     '</main>',
     hasMath ? buildMathRuntimeScript() : '',
     buildTargetLineScript(options.targetLine),
@@ -96,6 +99,7 @@ export function buildSelectableMarkdownFragmentHtml(
   options: SelectableMarkdownHtmlOptions = {},
 ): string {
   return renderBlocks(parseMobileMarkdown(markdown), {
+    imageSources: options.imageSources,
     sessionLinkTitles: options.sessionLinkTitles,
   });
 }
@@ -512,6 +516,13 @@ function renderInline(inline: MobileMarkdownInline, ctx: RenderContext = {}): st
       // 关闭),加载失败保持斜体源码。
       return `<span class="xdt-math-inline" data-latex="${escapeAttribute(inline.text)}"><em>${escapeHtml(inline.text)}</em></span>`;
     case 'image': {
+      if (ctx.imageSources) {
+        const image = ctx.imageSources.get(inline.url);
+        const alt = inline.alt || i18n.t('message.renderer.imageFallbackTitle');
+        return image?.uri.startsWith('data:image/')
+          ? `<img src="${escapeAttribute(image.uri)}" alt="${escapeAttribute(alt)}">`
+          : `<span class="xdt-image-chip">${escapeHtml(alt)}</span>`;
+      }
       // xdt 系非直连图:WebView 无法解析 xdt-image:// 等内部 scheme,渲染占位 chip,
       // 点击经 data-xdt-src 上报后由 ImageLightbox 走 remote-media resolver 取图。
       if (!isMobileMarkdownImageDirectUrl(inline.url)) {

--- a/apps/mobile/src/session/useConversationShareImages.ts
+++ b/apps/mobile/src/session/useConversationShareImages.ts
@@ -86,13 +86,23 @@ export function useConversationShareImages(
   useEffect(() => {
     let active = true;
     activeJob.current = job;
+    let timedOut = false;
+    let finishImageWait!: (image: null) => void;
+    const imageDeadline = new Promise<null>((done) => {
+      finishImageWait = done;
+    });
     const timer = setTimeout(() => {
-      active = false;
-      job.finish([]);
+      timedOut = true;
+      finishImageWait(null);
     }, 20_000);
     void prepareConversationShareImages(
       sourceMessages,
-      (url) => loadShareImage(url, resolve),
+      // Keep completed images and all message text when the shared deadline
+      // expires. Remaining images become placeholders without starting more IO.
+      (url) =>
+        timedOut
+          ? Promise.resolve(null)
+          : Promise.race([loadShareImage(url, resolve), imageDeadline]),
       { workdir, remoteHostId, sessionId },
       () => active,
     )
@@ -103,11 +113,17 @@ export function useConversationShareImages(
       })
       .catch(() => {
         clearTimeout(timer);
-        if (active) job.finish([]);
+        if (active)
+          setPrepared({
+            job,
+            messages: sourceMessages,
+            revision: ++revision.current,
+          });
       });
     return () => {
       active = false;
       clearTimeout(timer);
+      finishImageWait(null);
       activeJob.current = null;
       // StrictMode immediately replays this effect with the same job.
       queueMicrotask(() => {

--- a/apps/mobile/src/session/useConversationShareImages.ts
+++ b/apps/mobile/src/session/useConversationShareImages.ts
@@ -1,4 +1,4 @@
-import { useEffect, useMemo, useRef, useState } from "react";
+import { useCallback, useEffect, useRef, useState } from "react";
 import { Image } from "react-native";
 import { File } from "expo-file-system";
 import {
@@ -17,7 +17,7 @@ import { downloadRemoteMediaAsDataUri } from "@/session/remoteMediaDiskCacheExpo
 import { imageMimeFromUrl } from "@/session/remoteMediaDiskCache";
 import {
   getSentAttachmentThumbUri,
-  useSentAttachmentThumbsVersion,
+  ensureSentAttachmentThumbsHydrated,
 } from "@/session/sentAttachmentThumbStore";
 
 const MAX_IMAGE_BYTES = 8 * 1024 * 1024;
@@ -37,6 +37,7 @@ async function loadShareImage(
   resolve: ResolveRemoteMediaFn,
 ): Promise<ConversationShareImage | null> {
   // The existing store owns both OSS and desktop-media upload thumbnails.
+  await ensureSentAttachmentThumbsHydrated();
   const localThumb = getSentAttachmentThumbUri(url);
   let uri = localThumb
     ? ((await readShareImageFile(
@@ -74,34 +75,35 @@ async function loadShareImage(
   return { uri, width: size.width, height: size.height };
 }
 
-/** Resolve readiness after React commits the prepared SVG, including selection changes. */
+interface ShareImageJob {
+  sourceMessages: readonly ConversationShareMessage[];
+  resolve: ResolveRemoteMediaFn;
+  context: ConversationShareImageContext;
+  finish: (messages: readonly ConversationShareMessage[]) => void;
+}
+
+/** Prepare one click-time snapshot; live message updates cannot replace it. */
 export function useConversationShareImages(
   messages: readonly ConversationShareMessage[],
   resolve: ResolveRemoteMediaFn,
   { workdir, remoteHostId, sessionId }: ConversationShareImageContext,
 ) {
-  const thumbsVersion = useSentAttachmentThumbsVersion();
-  // Unselected streaming messages recreate the projection array too. Keep the
-  // selected content stable so they cannot cancel an in-flight image export.
-  const sourceKey = JSON.stringify(messages);
-  const sourceMessages = useMemo(
-    () => JSON.parse(sourceKey) as ConversationShareMessage[],
-    [sourceKey],
-  );
-  const job = useMemo(() => {
-    let finish!: (messages: readonly ConversationShareMessage[]) => void;
-    const ready = new Promise<readonly ConversationShareMessage[]>((done) => {
-      finish = done;
+  const [job, setJob] = useState<ShareImageJob | null>(null);
+  const prepare = useCallback(() => {
+    return new Promise<readonly ConversationShareMessage[]>((finish) => {
+      setJob({
+        sourceMessages: messages,
+        resolve,
+        context: { workdir, remoteHostId, sessionId },
+        finish,
+      });
     });
-    return { ready, finish };
-  }, [
-    sourceMessages,
-    resolve,
-    workdir,
-    remoteHostId,
-    sessionId,
-    thumbsVersion,
-  ]);
+  }, [messages, resolve, workdir, remoteHostId, sessionId]);
+  const cancel = useCallback(() => setJob(null), []);
+  const selectionKey = JSON.stringify(
+    messages.map((message) => message.clientId),
+  );
+  useEffect(cancel, [cancel, selectionKey, sessionId]);
   const revision = useRef(0);
   const activeJob = useRef<typeof job | null>(null);
   const [prepared, setPrepared] = useState<{
@@ -110,6 +112,8 @@ export function useConversationShareImages(
     revision: number;
   } | null>(null);
   useEffect(() => {
+    if (!job) return;
+    const { sourceMessages, resolve, context } = job;
     let active = true;
     activeJob.current = job;
     let timedOut = false;
@@ -129,7 +133,7 @@ export function useConversationShareImages(
         timedOut
           ? Promise.resolve(null)
           : Promise.race([loadShareImage(url, resolve), imageDeadline]),
-      { workdir, remoteHostId, sessionId },
+      context,
       () => active,
     )
       .then((result) => {
@@ -156,12 +160,13 @@ export function useConversationShareImages(
         if (activeJob.current !== job) job.finish([]);
       });
     };
-  }, [job, sourceMessages, resolve, workdir, remoteHostId, sessionId]);
+  }, [job]);
   useEffect(() => {
-    if (prepared?.job === job) job.finish(prepared.messages);
+    if (job && prepared?.job === job) job.finish(prepared.messages);
   }, [job, prepared]);
   return {
-    ready: job.ready,
+    prepare,
+    cancel,
     messages: prepared?.job === job ? prepared.messages : [],
     revision: prepared?.job === job ? prepared.revision : 0,
   };

--- a/apps/mobile/src/session/useConversationShareImages.ts
+++ b/apps/mobile/src/session/useConversationShareImages.ts
@@ -1,0 +1,126 @@
+import { useEffect, useMemo, useRef, useState } from "react";
+import { Image } from "react-native";
+import { File } from "expo-file-system";
+import {
+  prepareConversationShareImages,
+  type ConversationShareImageContext,
+} from "@/session/conversationShareImages";
+import type {
+  ConversationShareImage,
+  ConversationShareMessage,
+} from "@/session/conversationShareWebViewHtml";
+import {
+  isDesktopLocalMediaUrl,
+  type ResolveRemoteMediaFn,
+} from "@/session/remoteMedia";
+import { downloadRemoteMediaAsDataUri } from "@/session/remoteMediaDiskCacheExpo";
+import { imageMimeFromUrl } from "@/session/remoteMediaDiskCache";
+
+const MAX_IMAGE_BYTES = 8 * 1024 * 1024;
+
+async function loadShareImage(
+  url: string,
+  resolve: ResolveRemoteMediaFn,
+): Promise<ConversationShareImage | null> {
+  let uri = url;
+  let mimeType = imageMimeFromUrl(url) ?? "image/jpeg";
+  if (isDesktopLocalMediaUrl(url)) {
+    const media = await resolve({
+      kind: "image",
+      url,
+      previewable: true,
+      thumbnail: true,
+    });
+    if (!media.mimeType.startsWith("image/") || media.size > MAX_IMAGE_BYTES)
+      return null;
+    uri = media.url;
+    mimeType = media.mimeType;
+  }
+  if (uri.startsWith("file://") && isDesktopLocalMediaUrl(url)) {
+    // Only resolver-owned phone cache files may be read locally.
+    const file = new File(uri);
+    if (!file.exists || file.size <= 0 || file.size > MAX_IMAGE_BYTES)
+      return null;
+    uri = `data:${mimeType};base64,${await file.base64()}`;
+  } else if (/^https?:\/\//i.test(uri)) {
+    uri =
+      (await downloadRemoteMediaAsDataUri(uri, mimeType, MAX_IMAGE_BYTES)) ??
+      "";
+  }
+  if (
+    !uri.startsWith("data:image/") ||
+    uri.length > (MAX_IMAGE_BYTES * 4) / 3 + 128
+  )
+    return null;
+  const size = await Image.getSize(uri);
+  return { uri, width: size.width, height: size.height };
+}
+
+/** Resolve readiness after React commits the prepared SVG, including selection changes. */
+export function useConversationShareImages(
+  messages: readonly ConversationShareMessage[],
+  resolve: ResolveRemoteMediaFn,
+  { workdir, remoteHostId, sessionId }: ConversationShareImageContext,
+) {
+  // Unselected streaming messages recreate the projection array too. Keep the
+  // selected content stable so they cannot cancel an in-flight image export.
+  const sourceKey = JSON.stringify(messages);
+  const sourceMessages = useMemo(
+    () => JSON.parse(sourceKey) as ConversationShareMessage[],
+    [sourceKey],
+  );
+  const job = useMemo(() => {
+    let finish!: (messages: readonly ConversationShareMessage[]) => void;
+    const ready = new Promise<readonly ConversationShareMessage[]>((done) => {
+      finish = done;
+    });
+    return { ready, finish };
+  }, [sourceMessages, resolve, workdir, remoteHostId, sessionId]);
+  const revision = useRef(0);
+  const activeJob = useRef<typeof job | null>(null);
+  const [prepared, setPrepared] = useState<{
+    job: typeof job;
+    messages: readonly ConversationShareMessage[];
+    revision: number;
+  } | null>(null);
+  useEffect(() => {
+    let active = true;
+    activeJob.current = job;
+    const timer = setTimeout(() => {
+      active = false;
+      job.finish([]);
+    }, 20_000);
+    void prepareConversationShareImages(
+      sourceMessages,
+      (url) => loadShareImage(url, resolve),
+      { workdir, remoteHostId, sessionId },
+      () => active,
+    )
+      .then((result) => {
+        clearTimeout(timer);
+        if (active)
+          setPrepared({ job, messages: result, revision: ++revision.current });
+      })
+      .catch(() => {
+        clearTimeout(timer);
+        if (active) job.finish([]);
+      });
+    return () => {
+      active = false;
+      clearTimeout(timer);
+      activeJob.current = null;
+      // StrictMode immediately replays this effect with the same job.
+      queueMicrotask(() => {
+        if (activeJob.current !== job) job.finish([]);
+      });
+    };
+  }, [job, sourceMessages, resolve, workdir, remoteHostId, sessionId]);
+  useEffect(() => {
+    if (prepared?.job === job) job.finish(prepared.messages);
+  }, [job, prepared]);
+  return {
+    ready: job.ready,
+    messages: prepared?.job === job ? prepared.messages : [],
+    revision: prepared?.job === job ? prepared.revision : 0,
+  };
+}

--- a/apps/mobile/src/session/useConversationShareImages.ts
+++ b/apps/mobile/src/session/useConversationShareImages.ts
@@ -15,6 +15,10 @@ import {
 } from "@/session/remoteMedia";
 import { downloadRemoteMediaAsDataUri } from "@/session/remoteMediaDiskCacheExpo";
 import { imageMimeFromUrl } from "@/session/remoteMediaDiskCache";
+import {
+  applySentAttachmentThumbOverlay,
+  useSentAttachmentThumbsVersion,
+} from "@/session/sentAttachmentThumbStore";
 
 const MAX_IMAGE_BYTES = 8 * 1024 * 1024;
 
@@ -22,8 +26,14 @@ async function loadShareImage(
   url: string,
   resolve: ResolveRemoteMediaFn,
 ): Promise<ConversationShareImage | null> {
-  let uri = url;
-  let mimeType = imageMimeFromUrl(url) ?? "image/jpeg";
+  const overlay = applySentAttachmentThumbOverlay({
+    kind: "image",
+    uri: url,
+    previewable: false,
+  });
+  const hasLocalThumb = overlay.uri !== url;
+  let uri = overlay.uri;
+  let mimeType = imageMimeFromUrl(uri) ?? "image/jpeg";
   if (isDesktopLocalMediaUrl(url)) {
     const media = await resolve({
       kind: "image",
@@ -36,8 +46,11 @@ async function loadShareImage(
     uri = media.url;
     mimeType = media.mimeType;
   }
-  if (uri.startsWith("file://") && isDesktopLocalMediaUrl(url)) {
-    // Only resolver-owned phone cache files may be read locally.
+  if (
+    uri.startsWith("file://") &&
+    (hasLocalThumb || isDesktopLocalMediaUrl(url))
+  ) {
+    // Only existing upload-thumb or resolver-owned phone files may be read locally.
     const file = new File(uri);
     if (!file.exists || file.size <= 0 || file.size > MAX_IMAGE_BYTES)
       return null;
@@ -62,6 +75,7 @@ export function useConversationShareImages(
   resolve: ResolveRemoteMediaFn,
   { workdir, remoteHostId, sessionId }: ConversationShareImageContext,
 ) {
+  const thumbsVersion = useSentAttachmentThumbsVersion();
   // Unselected streaming messages recreate the projection array too. Keep the
   // selected content stable so they cannot cancel an in-flight image export.
   const sourceKey = JSON.stringify(messages);
@@ -75,7 +89,14 @@ export function useConversationShareImages(
       finish = done;
     });
     return { ready, finish };
-  }, [sourceMessages, resolve, workdir, remoteHostId, sessionId]);
+  }, [
+    sourceMessages,
+    resolve,
+    workdir,
+    remoteHostId,
+    sessionId,
+    thumbsVersion,
+  ]);
   const revision = useRef(0);
   const activeJob = useRef<typeof job | null>(null);
   const [prepared, setPrepared] = useState<{

--- a/apps/mobile/src/session/useConversationShareImages.ts
+++ b/apps/mobile/src/session/useConversationShareImages.ts
@@ -35,9 +35,11 @@ async function readShareImageFile(
 async function loadShareImage(
   url: string,
   resolve: ResolveRemoteMediaFn,
+  canRead: () => boolean,
 ): Promise<ConversationShareImage | null> {
   // The existing store owns both OSS and desktop-media upload thumbnails.
   await ensureSentAttachmentThumbsHydrated();
+  if (!canRead()) return null;
   const localThumb = getSentAttachmentThumbUri(url);
   let uri = localThumb
     ? ((await readShareImageFile(
@@ -45,6 +47,7 @@ async function loadShareImage(
         imageMimeFromUrl(localThumb) ?? "image/jpeg",
       ).catch(() => null)) ?? url)
     : url;
+  if (!canRead()) return null;
   let mimeType = imageMimeFromUrl(uri) ?? "image/jpeg";
   if (uri === url && isDesktopLocalMediaUrl(url)) {
     const media = await resolve({
@@ -53,20 +56,30 @@ async function loadShareImage(
       previewable: true,
       thumbnail: true,
     });
-    if (!media.mimeType.startsWith("image/") || media.size > MAX_IMAGE_BYTES)
+    if (
+      !canRead() ||
+      !media.mimeType.startsWith("image/") ||
+      !Number.isFinite(media.size) ||
+      media.size <= 0 ||
+      media.size > MAX_IMAGE_BYTES
+    )
       return null;
     uri = media.url;
     mimeType = media.mimeType;
+    // Only download objects whose size the controlled desktop resolver knows.
+    // Arbitrary HTTP sources have no trusted pre-transfer bound: keep alt text.
+    if (/^https?:\/\//i.test(uri)) {
+      uri =
+        (await downloadRemoteMediaAsDataUri(uri, mimeType, MAX_IMAGE_BYTES)) ??
+        "";
+    }
   }
   if (uri.startsWith("file://") && isDesktopLocalMediaUrl(url)) {
     // Other local files must come from the controlled media resolver.
     uri = (await readShareImageFile(uri, mimeType)) ?? "";
-  } else if (/^https?:\/\//i.test(uri)) {
-    uri =
-      (await downloadRemoteMediaAsDataUri(uri, mimeType, MAX_IMAGE_BYTES)) ??
-      "";
   }
   if (
+    !canRead() ||
     !uri.startsWith("data:image/") ||
     uri.length > (MAX_IMAGE_BYTES * 4) / 3 + 128
   )
@@ -132,7 +145,10 @@ export function useConversationShareImages(
       (url) =>
         timedOut
           ? Promise.resolve(null)
-          : Promise.race([loadShareImage(url, resolve), imageDeadline]),
+          : Promise.race([
+              loadShareImage(url, resolve, () => active && !timedOut),
+              imageDeadline,
+            ]),
       context,
       () => active,
     )

--- a/apps/mobile/src/session/useConversationShareImages.ts
+++ b/apps/mobile/src/session/useConversationShareImages.ts
@@ -16,25 +16,36 @@ import {
 import { downloadRemoteMediaAsDataUri } from "@/session/remoteMediaDiskCacheExpo";
 import { imageMimeFromUrl } from "@/session/remoteMediaDiskCache";
 import {
-  applySentAttachmentThumbOverlay,
+  getSentAttachmentThumbUri,
   useSentAttachmentThumbsVersion,
 } from "@/session/sentAttachmentThumbStore";
 
 const MAX_IMAGE_BYTES = 8 * 1024 * 1024;
 
+async function readShareImageFile(
+  uri: string,
+  mimeType: string,
+): Promise<string | null> {
+  const file = new File(uri);
+  if (!file.exists || file.size <= 0 || file.size > MAX_IMAGE_BYTES)
+    return null;
+  return `data:${mimeType};base64,${await file.base64()}`;
+}
+
 async function loadShareImage(
   url: string,
   resolve: ResolveRemoteMediaFn,
 ): Promise<ConversationShareImage | null> {
-  const overlay = applySentAttachmentThumbOverlay({
-    kind: "image",
-    uri: url,
-    previewable: false,
-  });
-  const hasLocalThumb = overlay.uri !== url;
-  let uri = overlay.uri;
+  // The existing store owns both OSS and desktop-media upload thumbnails.
+  const localThumb = getSentAttachmentThumbUri(url);
+  let uri = localThumb
+    ? ((await readShareImageFile(
+        localThumb,
+        imageMimeFromUrl(localThumb) ?? "image/jpeg",
+      ).catch(() => null)) ?? url)
+    : url;
   let mimeType = imageMimeFromUrl(uri) ?? "image/jpeg";
-  if (isDesktopLocalMediaUrl(url)) {
+  if (uri === url && isDesktopLocalMediaUrl(url)) {
     const media = await resolve({
       kind: "image",
       url,
@@ -46,15 +57,9 @@ async function loadShareImage(
     uri = media.url;
     mimeType = media.mimeType;
   }
-  if (
-    uri.startsWith("file://") &&
-    (hasLocalThumb || isDesktopLocalMediaUrl(url))
-  ) {
-    // Only existing upload-thumb or resolver-owned phone files may be read locally.
-    const file = new File(uri);
-    if (!file.exists || file.size <= 0 || file.size > MAX_IMAGE_BYTES)
-      return null;
-    uri = `data:${mimeType};base64,${await file.base64()}`;
+  if (uri.startsWith("file://") && isDesktopLocalMediaUrl(url)) {
+    // Other local files must come from the controlled media resolver.
+    uri = (await readShareImageFile(uri, mimeType)) ?? "";
   } else if (/^https?:\/\//i.test(uri)) {
     uri =
       (await downloadRemoteMediaAsDataUri(uri, mimeType, MAX_IMAGE_BYTES)) ??

--- a/apps/mobile/src/session/useConversationShareImages.ts
+++ b/apps/mobile/src/session/useConversationShareImages.ts
@@ -36,6 +36,7 @@ async function loadShareImage(
   url: string,
   resolve: ResolveRemoteMediaFn,
   canRead: () => boolean,
+  signal: AbortSignal,
 ): Promise<ConversationShareImage | null> {
   // The existing store owns both OSS and desktop-media upload thumbnails.
   await ensureSentAttachmentThumbsHydrated();
@@ -50,12 +51,15 @@ async function loadShareImage(
   if (!canRead()) return null;
   let mimeType = imageMimeFromUrl(uri) ?? "image/jpeg";
   if (uri === url && isDesktopLocalMediaUrl(url)) {
-    const media = await resolve({
-      kind: "image",
-      url,
-      previewable: true,
-      thumbnail: true,
-    });
+    const media = await resolve(
+      {
+        kind: "image",
+        url,
+        previewable: true,
+        thumbnail: true,
+      },
+      { signal },
+    );
     if (
       !canRead() ||
       !media.mimeType.startsWith("image/") ||
@@ -127,6 +131,9 @@ export function useConversationShareImages(
   useEffect(() => {
     if (!job) return;
     const { sourceMessages, resolve, context } = job;
+    // The existing media queue removes this export's still-queued waiter.
+    // Effect-local ownership also gives StrictMode replays a fresh signal.
+    const controller = new AbortController();
     let active = true;
     activeJob.current = job;
     let timedOut = false;
@@ -136,6 +143,7 @@ export function useConversationShareImages(
     });
     const timer = setTimeout(() => {
       timedOut = true;
+      controller.abort();
       finishImageWait(null);
     }, 20_000);
     void prepareConversationShareImages(
@@ -146,7 +154,12 @@ export function useConversationShareImages(
         timedOut
           ? Promise.resolve(null)
           : Promise.race([
-              loadShareImage(url, resolve, () => active && !timedOut),
+              loadShareImage(
+                url,
+                resolve,
+                () => active && !timedOut,
+                controller.signal,
+              ),
               imageDeadline,
             ]),
       context,
@@ -168,6 +181,7 @@ export function useConversationShareImages(
       });
     return () => {
       active = false;
+      controller.abort();
       clearTimeout(timer);
       finishImageWait(null);
       activeJob.current = null;


### PR DESCRIPTION
## 这次改了什么

### 摘要

手机版分享聊天长图时，粘贴图片原先只剩附件名称，正文图片也会变成占位文字。现在保留图片来源，复用当前设备的媒体读取通道准备内嵌图片，并在 iOS HTML 成图和 SVG 备用成图中保留图片顺序与重复次数。读取或解码失败的图片保留名称或替代文字，其他已完成图片继续导出。

桌面分享已包含图片内嵌流程，本次排查未发现相同的字段丢失问题，未改桌面代码。

### 变更类型

- [x] `fix` 缺陷修复

### 范围

- 关联 Issue / 需求：手机版分享内容看不到粘贴图片的反馈。
- 本 PR 包含：图片附件、正文图片、两条手机成图路径，以及选区变化/流式刷新期间的图片准备。
- 明确不包含：桌面普通聊天和 `.xdtshare` 文件格式改动；没有本地缩略图且大小未知的公网直链图片不新增下载。
- 用户可见变化：分享长图包含成功读取并就绪的图片；失败图片显示名称或替代文字。
- 是否存在 breaking change：无。

### UI 变化

- 引用的设计规范：`docs/design-rules/DESIGN.md` §10 双模式交付、§15.7 分享页脚。图片按比例限制尺寸，复用已有语义主题色、缺图文字与页脚布局。
- 未上传实机截图；Light/Dark 有自动测试，不代表实机目检通过。

## 怎么验证的

### 自动验证

```text
pnpm test:unit:related
结果：通过（mobile 相关测试）。

pnpm --filter mobile run --if-present typecheck
结果：通过。

pnpm --filter desktop exec vitest run src/renderer/__tests__/shareConversationImage.test.ts
结果：前期排查时 26 项通过；本轮没有桌面改动，未重复运行。
```

回归覆盖正文图片顺序与重复次数、附件同源、表格和次要正文、部分准备超时、上传缩略图映射、受控文件读取、按图片出现次数扣预算、源 URL 不进入分享文档、跨图片边界脱敏、StrictMode、点击快照与取消后的迟到结果。

新增组件级测试使用真实 SVG 组件及布局构建器，模拟原生事件：逐个 iOS 图片就绪、双模式、Android 缓存命中但无 SVG onLoad、解码失败/仅磁盘缓存/缓存查询失败、截止后迟到回调、降级布局提交前不捕获、旋转不重挂正常图片、卸载取消、缺失页脚、空 PNG/同步异常/无捕获回调。

### 图片导出不变量与收敛检查

- 图片准备最多 3 路：先按规范化 URL 汇总各消息的原始来源及出现次数，每个 URL 只取一次；空闲 worker 持续处理后续来源，不等待前一张慢图。所有预算扣减在完成回调内同步执行，跨 URL 按就绪先后分配，同一 URL 内按消息顺序分配；图片在导出中的顺序仍由原消息决定。只保留预算允许的结果，不另存未获准图片或增加持久缓存/重试。
- 准备生命周期沿用一次点击的 effect、AbortController 和 20 秒截止：单图成功则按预算接纳，单图异常仅跳过该来源；超时令未完成读取降级并保留已完成结果；取消后不再派发新来源，也不接纳迟到结果。最多 3 张图同时处于现有 8 MiB 单图受控读取流程；输出仍受原 32 MiB 字符/800 万像素预算限制，该输出预算不代表含在途读取的峰值内存。三路都卡住时，后续来源仍可能等到共同截止时间。
- 新回归覆盖慢远程图在前/在后、后续附件及下一条消息的本地缩略图、并发上限与空闲槽位继续派发、乱序完成不超预算、取消后的迟到读取、同源一次取件与每次出现计费。本轮 related 单测 129 项通过，mobile typecheck 通过。

- 附件顺序由同一次遍历和唯一纵向游标决定：成功图片、失败图片名称、普通文件都在原来的位置输出，然后才排正文。来源和附件文字共用已有无边框文本块，不再先排成功图片、再把失败项塞进正文。测试枚举三张图片的全部 8 种成功/失败组合及夹入文件，分别覆盖用户和助手消息。

- 来源归属不变量：自动化标注始终位于本条消息的全部附件与正文之前、正文气泡之外。纯布局函数独占纵向游标；成功、部分失败、全部失败的图片准备结果共用同一标注入口，降级重排不改变归属顺序。复用现有无边框文本块，没有增加导出状态或机制。回归交叉覆盖 0/1/2 张图片就绪、有/无正文、多行标注、选区断点和前后相邻消息。

- 图片准备仅由每次点击建立的 job 持有内容与取件上下文；正文/缩略图刷新不改当前快照。选区/会话切换作废旧操作，页面原有序号继续阻止失活操作发起系统分享。
- 单图受控读取上限 8 MiB、整次内嵌字符预算 32 MiB；解码前另外限制单张 400 万像素、整次 800 万像素。附件、正文、次要正文及跨消息的每次出现都扣预算，超额组不占用后续额度；该像素预算不代表整个导出的峰值内存。只接受已有本地缩略图或受控 resolver；未知大小直链不下载。
- 图片准备 effect 独占 AbortController，接入现有媒体队列的 signal；20 秒截止及 cleanup 均 abort，移除本次仍在排队的 waiter，保留其他消费者与已起飞请求。原有 active/deadline 判据继续阻止迟到结果启动后续下载，StrictMode 重放使用新 signal。
- SVG 完整可见文本统一脱敏后再切片，绝不拼回原始片段。HTML 中含 Markdown 图片的正文只要需要脱敏，就统一转已有 SVG，避免改写图片语法后泄漏源地址。
- SVG 单次导出由一个 phase 管理：`decoding → layout → capturing → settled`。15 秒解码截止冻结已就绪集合，其余正文图片使用既有缺图投影重新排版；整个 SVG 导出仍受 20 秒截止约束。
- `assetGate` 是解码结果的唯一写入者；每个图片实例首个结果生效，冻结后忽略迟到事件。保留正常 SVG 实例的 key；新增原生 layout 事件确认降级布局提交后才捕获。所有成功/失败/取消共用一次结算及定时器清理。
- iOS 使用每个 SVG 图片的 onLoad；当前依赖没有 SVG onError，因此无事件时由截止时间收敛。Android SVG 缓存命中不发 onLoad，改用挂载的原生 Image 解码探针；正文 data URI 还需查到 bitmap memory cache，磁盘缓存不能放行。没有新增原生依赖、持久缓存或后台重试。

| 事件 | 解码中 | 等待布局/捕获中 | 已结算 |
| --- | --- | --- | --- |
| 图片成功/失败 | 首个结果记入 gate，全部结束后固定布局 | 忽略迟到结果 | 忽略 |
| 15 秒截止 | 保留就绪正文图片，其余替代文字；页脚未就绪则报错 | 无额外动作 | 无额外动作 |
| 原生布局提交 | 不捕获 | 固定布局仅捕获一次；过大布局报错 | 忽略 |
| PNG 成功/空值/异常 | 不适用 | 成功返回，空值或异常失败 | 忽略重复回调 |
| 20 秒截止/卸载 | 失败或取消，清理定时器 | 失败或取消，清理定时器 | 无额外动作 |

补充回归覆盖高压缩比超大图、重复图片的单张/批次像素预算，以及真实媒体队列在超时、显式取消、选区变化、会话变化、卸载后不再启动过期取件；同源其他消费者继续完成。

### 手工验证

只读核对手机普通消息图片、桌面 DOM 分享链路及已安装 React Native / react-native-svg 的平台解码行为；未启动客户端进行实机操作。

### 未执行的验证

未运行 iOS/Android 实机系统分享及 Light/Dark 实机目检；没有启动 Metro，因而没有 Metro 归属或 __DEV__ build label 证据。工作分支 `dash/fix-share-pasted-images`，worktree `cindy-fix-share-pasted-images`。新提交的完整 CI 与自动 review 以 PR 最新结果为准。

## 风险

### 风险分类

- [x] 跨平台差异

### 影响与回滚

- 影响范围：手机聊天长图。Android 使用 SVG；iOS 原生 HTML 不可用/失败或正文图片需要脱敏时使用 SVG，其富文本排版沿用备用路径的近似呈现。
- 手机版仅 JS/TS 改动，没有修改原生配置、依赖或模块，不改变 runtime fingerprint。
- SSH/设备互联复用现有 workdir/session/host 规范化、媒体 resolver 和缩略图，不改变协议或文件权限。
- 20 秒准备截止不等于网络层取消：已启动的受控小对象下载仍由既有下载器完成并清理；失活后的迟到 resolver 不能再启动下载。
- 原生边界：Android 页脚资源可能为不可由 queryCache 查询的资源名，使用挂载 Image 的解码回调；Fresco 内存缓存拒收情况下页脚完整性尚未实机验证。正文 memory 查询按 URI，不能证明所有极端内存压力下的原生绘制结果；本 PR 不改原生缓存实现。
- 回滚 / 降级方式：回退本 PR；失败正文图片沿用名称/替代文字。无需数据迁移。

### 提交前检查

- [x] 已 review 完整 diff
- [x] 每个 commit 都带 DCO 签名（`git commit -s`）
- [x] UI 改动已注明设计规范
- [x] 未提交凭证、令牌或授权文件
- [x] 已补充必要文档（本说明）
- [x] 已确认测试结果并说明未执行原因
