### PR TITLE
fix(mobile): 新建任务沿用上次项目或对话选择

### DIFF
--- a/apps/mobile/app/sessions/new.tsx
+++ b/apps/mobile/app/sessions/new.tsx
@@ -482,7 +482,7 @@ export default function NewRemoteSessionScreen() {
   const [draft, setDraft] = useState<NewSessionDraft>({
     ...DEFAULT_NEW_SESSION_DRAFT,
     firstMessage: visualInitialDraft ?? DEFAULT_NEW_SESSION_DRAFT.firstMessage,
-    // 默认进入「对话」(无项目),对齐桌面;只有从项目入口带了 workingDir 才默认项目模式。
+    // 无记忆时默认对话；偏好加载后恢复上次选择，显式项目入口优先。
     workspaceKind: initialWorkingDir ? 'project' : 'dialogue',
     workingDir: initialWorkingDir ?? '',
   });
@@ -605,10 +605,13 @@ export default function NewRemoteSessionScreen() {
   useEffect(() => {
     const stashed = drainStashedNewSessionDraft();
     if (!stashed) return;
+    // 返回编辑沿用草稿的工作区，不能被随后加载的全局默认覆盖。
+    userTouchedWorkspaceRef.current = true;
     setDraft(stashed.draft);
     setAttachments([...stashed.attachments]);
     if (stashed.notice) setAttachmentError(stashed.notice);
     if (stashed.deviceId) {
+      userTouchedDeviceRef.current = true;
       setSelectedDeviceId(stashed.deviceId);
       setSelectedDeviceName(stashed.deviceName || stashed.deviceId);
     }
@@ -688,6 +691,7 @@ export default function NewRemoteSessionScreen() {
   // 权限记忆只在偏好加载后恢复一次(之后由用户选择 / 切 agent 驱动),防止重复覆盖。
   const appliedPermissionMemoryRef = useRef(false);
   const userTouchedDeviceRef = useRef(false);
+  const userTouchedWorkspaceRef = useRef(false);
   const firstMessageRef = useRef(draft.firstMessage);
   const firstMessageInputRef = useRef<NativeTextInput>(null);
   const voiceDraftScrollRef = useRef<ScrollView>(null);
@@ -827,7 +831,14 @@ export default function NewRemoteSessionScreen() {
     setNewSessionPreferencesLoaded(false);
     void readNewSessionPreferences()
       .then((preferences) => {
-        if (!cancelled) setNewSessionPreferences(preferences);
+        if (cancelled) return;
+        setNewSessionPreferences(preferences);
+        const workspaceKind = preferences.workspaceKind;
+        if (!initialWorkingDir && workspaceKind) {
+          setDraft((current) => userTouchedWorkspaceRef.current
+            ? current
+            : { ...current, workspaceKind });
+        }
       })
       .finally(() => {
         if (!cancelled) setNewSessionPreferencesLoaded(true);
@@ -2136,6 +2147,8 @@ export default function NewRemoteSessionScreen() {
   }, [patchDraft]);
 
   const selectDialogueWorkspace = useCallback(() => {
+    userTouchedWorkspaceRef.current = true;
+    void saveNewSessionPreferences({ workspaceKind: 'dialogue' });
     patchDraft({ workspaceKind: 'dialogue', workingDir: '' });
     setWorkspacePickerOpen(false);
     setBrowseOpen(false);
@@ -2143,6 +2156,8 @@ export default function NewRemoteSessionScreen() {
   }, [patchDraft]);
 
   const selectRecentProject = useCallback((workingDir: string) => {
+    userTouchedWorkspaceRef.current = true;
+    void saveNewSessionPreferences({ workspaceKind: 'project' });
     patchDraft({ workspaceKind: 'project', workingDir });
     setWorkspacePickerOpen(false);
     setBrowseOpen(false);
@@ -2150,6 +2165,8 @@ export default function NewRemoteSessionScreen() {
   }, [patchDraft]);
 
   const openProjectBrowse = useCallback(() => {
+    userTouchedWorkspaceRef.current = true;
+    void saveNewSessionPreferences({ workspaceKind: 'project' });
     patchDraft({ workspaceKind: 'project' });
     setWorkspacePickerOpen(false);
     setBrowseOpen(true);
@@ -3667,6 +3684,9 @@ export default function NewRemoteSessionScreen() {
 
   useEffect(() => {
     if (!selectedDeviceId || draft.workspaceKind !== 'project' || draft.workingDir.trim()) return;
+    // 恢复项目模式后，等默认设备同步完成再选目录，避免借用上一台电脑的路径。
+    if (!newSessionPreferencesLoaded) return;
+    if (!userTouchedDeviceRef.current && selectedDeviceId !== preferredDefaultDevice?.deviceId) return;
 
     const key = `${selectedDeviceId}:${initialWorkingDir ?? ''}`;
     if (initialWorkspaceKeyRef.current === key) return;
@@ -3688,6 +3708,8 @@ export default function NewRemoteSessionScreen() {
     loadBrowsePath,
     recentWorkspaces,
     selectWorkingDir,
+    newSessionPreferencesLoaded,
+    preferredDefaultDevice?.deviceId,
   ]);
 
   const selectSlashCommand = useCallback((command: MobileSlashCommand) => {
@@ -4075,6 +4097,7 @@ export default function NewRemoteSessionScreen() {
       if (!ensureDeviceAlive()) return;
       void saveNewSessionPreferences({
         agentKind: effectiveDraft.agentKind,
+        workspaceKind: effectiveDraft.workspaceKind,
         device: {
           deviceId: selectedDeviceId,
           name: selectedDeviceName || selectedDeviceId,
@@ -4828,6 +4851,7 @@ export default function NewRemoteSessionScreen() {
       }
       void saveNewSessionPreferences({
         agentKind: draft.agentKind,
+        workspaceKind: draft.workspaceKind,
         device: {
           deviceId: selectedDeviceId,
           name: selectedDeviceName || selectedDeviceId,

--- a/apps/mobile/src/__tests__/newSessionPreferenceStore.test.ts
+++ b/apps/mobile/src/__tests__/newSessionPreferenceStore.test.ts
@@ -38,6 +38,7 @@ describe('newSessionPreferenceStore', () => {
     await expect(readNewSessionPreferences()).resolves.toEqual({
       agentKind: 'codex',
       device: { deviceId: 'devA', name: 'Mac A' },
+      workspaceKind: null,
       permissionModeByAgent: {},
     });
     expect(JSON.parse(store.get(__testing.storageKey) ?? '{}')).toEqual({
@@ -63,6 +64,7 @@ describe('newSessionPreferenceStore', () => {
     await expect(readNewSessionPreferences()).resolves.toEqual({
       agentKind: null,
       device: { deviceId: 'devB', name: 'devB' },
+      workspaceKind: null,
       permissionModeByAgent: {},
     });
 
@@ -70,6 +72,7 @@ describe('newSessionPreferenceStore', () => {
     await expect(readNewSessionPreferences()).resolves.toEqual({
       agentKind: null,
       device: null,
+      workspaceKind: null,
       permissionModeByAgent: {},
     });
 
@@ -79,6 +82,7 @@ describe('newSessionPreferenceStore', () => {
     await expect(readNewSessionPreferences()).resolves.toEqual({
       agentKind: null,
       device: { deviceId: 'devC', name: 'devC' },
+      workspaceKind: null,
       permissionModeByAgent: {},
     });
   });
@@ -104,6 +108,7 @@ describe('newSessionPreferenceStore', () => {
     await expect(readNewSessionPreferences()).resolves.toEqual({
       agentKind: null,
       device: null,
+      workspaceKind: null,
       permissionModeByAgent: { 'claude-code': 'bypassPermissions', codex: 'ask' },
     });
 
@@ -114,7 +119,62 @@ describe('newSessionPreferenceStore', () => {
     await expect(readNewSessionPreferences()).resolves.toEqual({
       agentKind: null,
       device: null,
+      workspaceKind: null,
       permissionModeByAgent: { codex: 'auto' },
     });
+  });
+
+  it('remembers either workspace mode across reloads without losing other preferences', async () => {
+    const { readNewSessionPreferences, saveNewSessionPreferences } =
+      await import('@/session/newSessionPreferenceStore');
+
+    await Promise.all([
+      saveNewSessionPreferences({ workspaceKind: 'project' }),
+      saveNewSessionPreferences({ device: { deviceId: 'devA', name: 'Mac A' } }),
+      saveNewSessionPreferences({ agentKind: 'codex' }),
+    ]);
+    expect(await readNewSessionPreferences()).toMatchObject({
+      workspaceKind: 'project',
+      device: { deviceId: 'devA', name: 'Mac A' },
+      agentKind: 'codex',
+    });
+
+    await Promise.all([
+      saveNewSessionPreferences({ workspaceKind: 'project' }),
+      saveNewSessionPreferences({ workspaceKind: 'dialogue' }),
+      saveNewSessionPreferences({ permissionModeForAgent: { agentKind: 'codex', mode: 'ask' } }),
+    ]);
+    expect(await readNewSessionPreferences()).toMatchObject({
+      workspaceKind: 'dialogue',
+      agentKind: 'codex',
+      permissionModeByAgent: { codex: 'ask' },
+    });
+  });
+
+  it('ignores an unknown workspace mode in old or invalid storage', async () => {
+    const { __testing, readNewSessionPreferences } =
+      await import('@/session/newSessionPreferenceStore');
+    store.set(__testing.storageKey, JSON.stringify({ workspaceKind: 'unknown', agentKind: 'codex' }));
+    expect(await readNewSessionPreferences()).toMatchObject({ workspaceKind: null, agentKind: 'codex' });
+  });
+
+  it('restores the latest choice when the page reopens before saving finishes', async () => {
+    const { readNewSessionPreferences, saveNewSessionPreferences } =
+      await import('@/session/newSessionPreferenceStore');
+    const saving = saveNewSessionPreferences({ workspaceKind: 'project' });
+    const reopened = readNewSessionPreferences();
+    expect(await reopened).toMatchObject({ workspaceKind: 'project' });
+    await saving;
+  });
+
+  it('clears pending selections without letting them restore cleared preferences', async () => {
+    const { clearNewSessionPreferences, readNewSessionPreferences, saveNewSessionPreferences } =
+      await import('@/session/newSessionPreferenceStore');
+    await Promise.all([
+      saveNewSessionPreferences({ workspaceKind: 'project' }),
+      clearNewSessionPreferences(),
+    ]);
+    expect(await readNewSessionPreferences()).toMatchObject({ workspaceKind: null });
+    expect(store.size).toBe(0);
   });
 });

--- a/apps/mobile/src/__tests__/newSessionWorkspaceEffects.test.tsx
+++ b/apps/mobile/src/__tests__/newSessionWorkspaceEffects.test.tsx
@@ -1,0 +1,201 @@
+// @vitest-environment jsdom
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+import { act, createElement, useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import { createRoot, type Root } from 'react-dom/client';
+import ts from 'typescript';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import {
+  DEFAULT_NEW_SESSION_DRAFT,
+  buildRecentWorkspaceOptions,
+  pickInitialNewSessionWorkspace,
+  pickNewSessionDefaultDevice,
+  type NewSessionDraft,
+  type NewSessionStoredPreferences,
+  type NewSessionWorkspaceKind,
+} from '@/session/newSession';
+
+// Mount the page's actual workspace hooks in source order, without loading its unrelated
+// voice/media/native UI. Extract AST statements, not copies of the guards under test.
+const source = ts.createSourceFile('new.tsx', readFileSync(
+  resolve(process.cwd(), 'app/sessions/new.tsx'), 'utf8',
+), ts.ScriptTarget.Latest, true, ts.ScriptKind.TSX);
+const page = source.statements.find((node): node is ts.FunctionDeclaration =>
+  ts.isFunctionDeclaration(node) && node.name?.text === 'NewRemoteSessionScreen');
+if (!page?.body) throw new Error('NewRemoteSessionScreen not found');
+const declarations = new Set([
+  'selectedDeviceId', 'selectedDeviceName', 'newSessionPreferences', 'newSessionPreferencesLoaded',
+  'preferredDefaultDevice', 'recentWorkspaces', 'draft', 'initialWorkspaceKeyRef',
+  'appliedDefaultDeviceKeyRef', 'userTouchedDeviceRef', 'userTouchedWorkspaceRef',
+  'patchDraft', 'selectWorkingDir', 'selectDialogueWorkspace', 'selectRecentProject', 'openProjectBrowse',
+]);
+const effectMarkers = new Set([
+  'drainStashedNewSessionDraft', 'readNewSessionPreferences',
+  'appliedDefaultDeviceKeyRef', 'pickInitialNewSessionWorkspace',
+]);
+function identifiers(node: ts.Node): Set<string> {
+  const names = new Set<string>();
+  function visit(child: ts.Node) {
+    if (ts.isIdentifier(child)) names.add(child.text);
+    ts.forEachChild(child, visit);
+  }
+  visit(node);
+  return names;
+}
+const selected = page.body.statements.filter((statement) => {
+  if (ts.isVariableStatement(statement)) {
+    const names = statement.declarationList.declarations.flatMap((declaration) =>
+      [...identifiers(declaration.name)]);
+    return names.some((name) => declarations.has(name));
+  }
+  if (!ts.isExpressionStatement(statement) || !ts.isCallExpression(statement.expression)
+    || statement.expression.expression.getText(source) !== 'useEffect') return false;
+  return [...identifiers(statement)].some((name) => effectMarkers.has(name));
+});
+// Fail visibly if a refactor moves/removes a hook; never silently stop exercising it.
+for (const name of [...declarations, ...effectMarkers]) {
+  const matches = selected.filter((node) => ts.isVariableStatement(node)
+    ? node.declarationList.declarations.some((declaration) => identifiers(declaration.name).has(name))
+    : !declarations.has(name) && identifiers(node).has(name));
+  if (matches.length !== 1) throw new Error(`Expected one workspace statement for ${name}`);
+}
+
+interface WorkspaceState {
+  draft: NewSessionDraft;
+  selectedDeviceId: string;
+  newSessionPreferencesLoaded: boolean;
+  selectDialogueWorkspace(): void;
+  selectRecentProject(path: string): void;
+  openProjectBrowse(): void;
+}
+const bindingNames = [
+  'useState', 'useRef', 'useMemo', 'useEffect', 'useCallback', 'DEFAULT_NEW_SESSION_DRAFT',
+  'pickNewSessionDefaultDevice', 'buildRecentWorkspaceOptions', 'pickInitialNewSessionWorkspace',
+  'routeDeviceId', 'routeDeviceName', 'routeDeviceFallback', 'routeDeviceExplicit', 'deviceOptions',
+  'initialWorkingDir', 'visualInitialDraft', 'sessions', 'readNewSessionPreferences',
+  'saveNewSessionPreferences', 'drainStashedNewSessionDraft', 'loadBrowsePath', 'setDevicePickerOpen',
+  'setAttachments', 'setAttachmentError', 'setBrowseOpen', 'setBrowseError',
+  'setShowHiddenDirectories', 'setWorkspacePickerOpen',
+];
+const compiled = ts.transpileModule(`function usePageWorkspace(bindings) {
+  const { ${bindingNames.join(', ')} } = bindings;
+  ${selected.map((statement) => statement.getText(source)).join('\n')}
+  return { draft, selectedDeviceId, newSessionPreferencesLoaded,
+    selectDialogueWorkspace, selectRecentProject, openProjectBrowse };
+}`, { compilerOptions: { target: ts.ScriptTarget.ES2022 } }).outputText;
+const usePageWorkspace = new Function(`${compiled}; return usePageWorkspace;`)() as
+  (bindings: Record<string, unknown>) => WorkspaceState;
+
+Object.assign(globalThis, { IS_REACT_ACT_ENVIRONMENT: true });
+let root: Root | undefined;
+afterEach(() => { act(() => root?.unmount()); root = undefined; });
+
+function mountWorkspace(options: { initialWorkingDir?: string; restoredKind?: NewSessionWorkspaceKind } = {}) {
+  let resolveRead!: (value: NewSessionStoredPreferences) => void;
+  const pendingRead = new Promise<NewSessionStoredPreferences>((resolve) => { resolveRead = resolve; });
+  const deviceOptions = [{ deviceId: 'a', name: 'A' }, { deviceId: 'b', name: 'B' }];
+  const initialWorkingDir = options.initialWorkingDir ?? null;
+  const bindings = {
+    useState, useRef, useMemo, useEffect, useCallback, DEFAULT_NEW_SESSION_DRAFT,
+    pickNewSessionDefaultDevice, buildRecentWorkspaceOptions,
+    pickInitialNewSessionWorkspace: vi.fn(pickInitialNewSessionWorkspace),
+    routeDeviceId: 'a', routeDeviceName: 'A', routeDeviceFallback: deviceOptions[0],
+    routeDeviceExplicit: !!initialWorkingDir, deviceOptions, initialWorkingDir, visualInitialDraft: null,
+    sessions: deviceOptions.map(({ deviceId }) => ({
+      deviceLinkDeviceId: deviceId, workingDir: `/projects/${deviceId}`, workspaceKind: 'project',
+      status: 'active', updatedAt: '2026-09-01T00:00:00Z',
+    })),
+    readNewSessionPreferences: vi.fn(() => pendingRead),
+    saveNewSessionPreferences: vi.fn(async () => {}),
+    drainStashedNewSessionDraft: vi.fn(() => options.restoredKind ? {
+      draft: { ...DEFAULT_NEW_SESSION_DRAFT, workspaceKind: options.restoredKind,
+        workingDir: options.restoredKind === 'project' ? '/restored/project' : '' },
+      attachments: [], deviceId: 'a', deviceName: 'A',
+    } : null),
+    loadBrowsePath: vi.fn(async () => {}), setDevicePickerOpen: vi.fn(),
+    setAttachments: vi.fn(), setAttachmentError: vi.fn(), setBrowseOpen: vi.fn(),
+    setBrowseError: vi.fn(), setShowHiddenDirectories: vi.fn(), setWorkspacePickerOpen: vi.fn(),
+  };
+  let current!: WorkspaceState;
+  const commits: Array<{ device: string; kind: NewSessionWorkspaceKind; path: string }> = [];
+  function Harness() {
+    current = usePageWorkspace(bindings);
+    useEffect(() => {
+      commits.push({ device: current.selectedDeviceId, kind: current.draft.workspaceKind,
+        path: current.draft.workingDir });
+    });
+    return null;
+  }
+  root = createRoot(document.createElement('div'));
+  act(() => root!.render(createElement(Harness)));
+  return {
+    bindings, commits, get current() { return current; },
+    async resolvePreferences(kind: NewSessionWorkspaceKind | null, deviceId = 'a') {
+      await act(async () => {
+        resolveRead({ workspaceKind: kind, device: { deviceId, name: deviceId },
+          agentKind: null, permissionModeByAgent: {} });
+        await pendingRead;
+      });
+    },
+  };
+}
+
+describe('new session workspace page effects', () => {
+  it('keeps an explicit project entry when a different preference arrives late', async () => {
+    const page = mountWorkspace({ initialWorkingDir: '/explicit/project' });
+    await page.resolvePreferences('dialogue', 'b');
+    expect(page.current.draft).toMatchObject({ workspaceKind: 'project', workingDir: '/explicit/project' });
+    expect(page.current.selectedDeviceId).toBe('a');
+    expect(page.bindings.loadBrowsePath).not.toHaveBeenCalled();
+  });
+
+  it.each(['project', 'dialogue'] as const)('preserves a restored %s draft over a late default', async (kind) => {
+    const page = mountWorkspace({ restoredKind: kind });
+    await page.resolvePreferences(kind === 'project' ? 'dialogue' : 'project', 'b');
+    expect(page.current.draft).toMatchObject({ workspaceKind: kind,
+      workingDir: kind === 'project' ? '/restored/project' : '' });
+    expect(page.current.selectedDeviceId).toBe('a');
+    expect(page.bindings.pickInitialNewSessionWorkspace).not.toHaveBeenCalled();
+  });
+
+  it.each(['project', 'dialogue'] as const)('preserves a manual %s choice made during the read', async (kind) => {
+    const page = mountWorkspace();
+    act(() => kind === 'project'
+      ? page.current.selectRecentProject('/manual/project')
+      : page.current.selectDialogueWorkspace());
+    await page.resolvePreferences(kind === 'project' ? 'dialogue' : 'project');
+    expect(page.current.draft).toMatchObject({ workspaceKind: kind,
+      workingDir: kind === 'project' ? '/manual/project' : '' });
+    expect(page.bindings.saveNewSessionPreferences).toHaveBeenCalledWith({ workspaceKind: kind });
+  });
+
+  it('keeps an explicitly opened project browser open after a late dialogue preference', async () => {
+    const page = mountWorkspace();
+    act(() => page.current.openProjectBrowse());
+    await page.resolvePreferences('dialogue');
+    expect(page.current.draft).toMatchObject({ workspaceKind: 'project', workingDir: '' });
+    expect(page.bindings.setBrowseOpen).toHaveBeenLastCalledWith(true);
+    expect(page.bindings.loadBrowsePath).toHaveBeenCalledExactlyOnceWith('~');
+  });
+
+  it('waits for the remembered device before choosing a project, including intermediate commits', async () => {
+    const page = mountWorkspace();
+    expect(page.current.newSessionPreferencesLoaded).toBe(false);
+    expect(page.bindings.pickInitialNewSessionWorkspace).not.toHaveBeenCalled();
+    await page.resolvePreferences('project', 'b');
+    expect(page.current.selectedDeviceId).toBe('b');
+    expect(page.current.draft.workingDir).toBe('/projects/b');
+    expect(page.bindings.pickInitialNewSessionWorkspace).toHaveBeenCalledTimes(1);
+    expect(page.commits.filter(({ path }) => path)).toEqual([
+      { device: 'b', kind: 'project', path: '/projects/b' },
+    ]);
+    expect(page.bindings.loadBrowsePath).not.toHaveBeenCalled();
+  });
+
+  it('keeps the existing default when storage has no remembered mode', async () => {
+    const page = mountWorkspace();
+    await page.resolvePreferences(null);
+    expect(page.current.draft).toMatchObject({ workspaceKind: 'dialogue', workingDir: '' });
+    expect(page.bindings.pickInitialNewSessionWorkspace).not.toHaveBeenCalled();
+  });
+});

--- a/apps/mobile/src/session/newSession.ts
+++ b/apps/mobile/src/session/newSession.ts
@@ -76,6 +76,8 @@ export interface NewSessionDeviceOption {
 export interface NewSessionStoredPreferences {
   agentKind: NewSessionAgentKind | null;
   device: NewSessionDeviceOption | null;
+  /** 上次显式选择的项目/对话模式；null 表示尚未选择，沿用入口默认。 */
+  workspaceKind: NewSessionWorkspaceKind | null;
   /**
    * 每个 agent 上次在新建页显式选过的权限档(对齐桌面 lastByVendor 的权限记忆语义);
    * 没选过 = 缺失,回落该 agent 的安全种子默认。'plan' 不入记忆(计划模式是独立开关)。

--- a/apps/mobile/src/session/newSessionPreferenceStore.ts
+++ b/apps/mobile/src/session/newSessionPreferenceStore.ts
@@ -4,6 +4,7 @@ import {
   type NewSessionAgentKind,
   type NewSessionDeviceOption,
   type NewSessionStoredPreferences,
+  type NewSessionWorkspaceKind,
 } from '@/session/newSession';
 
 const STORAGE_KEY = 'xdt-maker.mobile.new-session.preferences.v1';
@@ -11,11 +12,18 @@ const STORAGE_KEY = 'xdt-maker.mobile.new-session.preferences.v1';
 export interface NewSessionPreferencePatch {
   agentKind?: NewSessionAgentKind;
   device?: NewSessionDeviceOption;
+  workspaceKind?: NewSessionWorkspaceKind;
   /** 记住某 agent 在新建页选的权限档(单键合并进 permissionModeByAgent;'plan' 被忽略)。 */
   permissionModeForAgent?: { agentKind: NewSessionAgentKind; mode: string };
 }
 
 export async function readNewSessionPreferences(): Promise<NewSessionStoredPreferences> {
+  // 刚选完就重新打开新建页时，也要看到已提交但尚未落盘的选择。
+  await writeChain;
+  return loadNewSessionPreferences();
+}
+
+async function loadNewSessionPreferences(): Promise<NewSessionStoredPreferences> {
   const raw = await AsyncStorage.getItem(STORAGE_KEY).catch(() => null);
   if (!raw) return emptyPreferences();
   try {
@@ -25,11 +33,21 @@ export async function readNewSessionPreferences(): Promise<NewSessionStoredPrefe
   }
 }
 
-export async function saveNewSessionPreferences(patch: NewSessionPreferencePatch): Promise<void> {
-  const current = await readNewSessionPreferences();
+// 与首页偏好存储一致：连续选择不同字段时，读改写必须按操作顺序执行。
+let writeChain: Promise<void> = Promise.resolve();
+
+export function saveNewSessionPreferences(patch: NewSessionPreferencePatch): Promise<void> {
+  const next = writeChain.then(() => writeNewSessionPreferences(patch));
+  writeChain = next.catch(() => undefined);
+  return next;
+}
+
+async function writeNewSessionPreferences(patch: NewSessionPreferencePatch): Promise<void> {
+  const current = await loadNewSessionPreferences();
   const permissionPatch = patch.permissionModeForAgent;
   const next: NewSessionStoredPreferences = {
     agentKind: patch.agentKind ?? current.agentKind,
+    workspaceKind: patch.workspaceKind ?? current.workspaceKind,
     device: patch.device
       ? normalizeDeviceOption(patch.device)
       : current.device,
@@ -41,13 +59,16 @@ export async function saveNewSessionPreferences(patch: NewSessionPreferencePatch
   await AsyncStorage.setItem(STORAGE_KEY, JSON.stringify(serializePreferences(next))).catch(() => undefined);
 }
 
-export async function clearNewSessionPreferences(): Promise<void> {
-  await AsyncStorage.removeItem(STORAGE_KEY).catch(() => undefined);
+export function clearNewSessionPreferences(): Promise<void> {
+  const next = writeChain.then(() => AsyncStorage.removeItem(STORAGE_KEY));
+  writeChain = next.catch(() => undefined);
+  return writeChain;
 }
 
 function emptyPreferences(): NewSessionStoredPreferences {
   return {
     agentKind: null,
+    workspaceKind: null,
     device: null,
     permissionModeByAgent: {},
   };
@@ -78,6 +99,9 @@ function normalizeStoredPreferences(value: unknown): NewSessionStoredPreferences
   const deviceName = readString(record.deviceName);
   return {
     agentKind: normalizeNewSessionAgentKind(record.agentKind),
+    workspaceKind: record.workspaceKind === 'project' || record.workspaceKind === 'dialogue'
+      ? record.workspaceKind
+      : null,
     device: deviceId
       ? { deviceId, name: deviceName || deviceId }
       : null,
@@ -102,6 +126,7 @@ function serializePreferences(
   );
   return {
     ...(preferences.agentKind ? { agentKind: preferences.agentKind } : {}),
+    ...(preferences.workspaceKind ? { workspaceKind: preferences.workspaceKind } : {}),
     ...(preferences.device
       ? {
           deviceId: preferences.device.deviceId,


### PR DESCRIPTION
## 这次改了什么

### 摘要

手机版新建任务原先在未指定项目路径时总是进入“对话”。现在记住上次选择的“项目／对话”模式，重新打开时恢复；从具体项目进入、创建失败后返回编辑的草稿优先保留自身选择。

### 变更类型

- [ ] `feat` 新功能
- [x] `fix` 缺陷修复
- [ ] `refactor` / `perf` 重构或性能优化
- [ ] `docs` / `test` / `chore` 文档、测试或工程维护
- [ ] 其他：

### 范围

- 关联 Issue / 需求：用户要求手机版新建时默认跟随上次的项目／对话选择。
- 本 PR 包含：沿用现有 AsyncStorage 偏好记录模式；选择与创建入口保存；异步恢复尊重当前选择和恢复草稿；连续写入按顺序合并，清除后不被在途写入恢复。
- 明确不包含：记住具体项目目录、新增设置开关、修改桌面端或远端协议、原生依赖及配置。
- 用户可见变化：上次选项目则下次进入项目模式，上次选对话则进入对话模式；没有记录的用户保留现有默认。项目目录仍沿用所选设备的既有最近项目逻辑。
- 是否存在 breaking change：无。新增字段可缺省，旧数据仍可读取。

### UI 变化

- 引用的设计规范：`docs/design-rules/DESIGN.md` §8（手机沿用现有界面）、§10（Light / Dark 同样行为）、§14.2（保持弹层焦点及关闭交互）。复用原选择器，修改默认选择行为，不新增样式、颜色或文案。未附实机截图。

<details>
<summary>工作区选择器局部 HTML 预览（Light / Dark，项目 / 对话）</summary>

依据 HEAD `4881496` 的现有选择器 JSX、样式和主题 token 制作，展示恢复后的选中状态；面板展开用于说明勾选位置，不表示页面会自动打开选择器。**这是静态局部预览，不是实机／模拟器运行证据，也不替代异步行为测试。**示例目录为虚构数据。

```html
<!doctype html>
<html lang="zh-CN"><meta charset="utf-8"><meta name="viewport" content="width=device-width,initial-scale=1">
<title>PR #3963 工作区选中状态预览</title>
<style>
*{box-sizing:border-box}body{margin:0;padding:20px;font:16px/1.5 system-ui,sans-serif;background:#fff;color:#262626}main{max-width:780px;margin:auto}h1{font-size:20px;font-weight:500}h2{font-size:14px;font-weight:500;margin:0 0 8px}p{font-size:13px;margin:8px 0 20px}.grid{display:grid;grid-template-columns:repeat(auto-fit,minmax(min(100%,300px),1fr));gap:16px}
.light{--surface:#EDEDED;--elevated:#F8F8F8;--border:#C6C9CE;--primary:#3C3F43;--secondary:#8C8E94;--tertiary:#686B72}.dark{--surface:#2A2828;--elevated:#312F2F;--border:#434343;--primary:#D4D4D4;--secondary:#6F6F6F;--tertiary:#BFC1C4}
.sample{background:var(--surface);color:var(--primary);padding:16px;border-radius:12px}.sample p{color:var(--tertiary)}.panel{padding:4px;border:.5px solid var(--border);border-radius:12px;background:var(--elevated);margin-bottom:4px}.row{display:flex;align-items:center;gap:8px;min-height:44px;padding:0 8px;font-size:16px;font-weight:500;border-radius:9999px}.row span{flex:1;min-width:0}.row svg{width:20px;height:20px;flex:none;color:var(--secondary)}.row svg:last-child:not(:first-child){width:18px;height:18px;color:var(--primary);stroke-width:2}.project{min-height:48px;padding:4px 8px;border-radius:12px}small{display:block;font-size:12px;font-weight:400;color:var(--tertiary);margin-top:1px}hr{border:0;border-top:.5px solid var(--border);margin:4px 8px}.trigger{display:flex;align-items:center;gap:12px;min-height:42px;color:var(--tertiary);font-weight:500;line-height:22px}.trigger svg{width:18px;height:18px}.trigger svg:last-child{width:14px;height:14px}
</style><main>
<h1>工作区选择器：恢复后状态</h1>
<p>PR #3963 · HEAD 4881496。此页是依据现有 JSX、样式和主题 token 制作的局部静态 HTML 预览，不是 App 运行截图；没有执行偏好读写或原生交互。示例目录为虚构数据，不表示跨设备记住具体目录。</p>
<div class="grid"><section class="sample light">
<h2>Light · 上次选择对话</h2>
<p>重新打开后：对话。下方展示用户展开选择器后的状态。</p>
<div class="panel" aria-label="工作区选项静态预览">
<div class="row"><svg aria-hidden="true" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><path d="M21 11.5a8.4 8.4 0 0 1-.9 3.8 8.5 8.5 0 0 1-7.6 4.7 8.4 8.4 0 0 1-3.8-.9L3 21l1.9-5.7a8.4 8.4 0 0 1-.9-3.8 8.5 8.5 0 0 1 4.7-7.6 8.4 8.4 0 0 1 3.8-.9h.5a8.5 8.5 0 0 1 8 8v.5Z"/></svg><span>对话</span><svg aria-hidden="true" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><path d="m20 6-11 11-5-5"/></svg></div>
<hr><div class="row project"><svg aria-hidden="true" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><path d="M20 20H4a2 2 0 0 1-2-2V6a2 2 0 0 1 2-2h5l2 3h9a2 2 0 0 1 2 2v9a2 2 0 0 1-2 2Z"/></svg><span>project-a<small>/demo/project-a</small></span></div>
<hr><div class="row"><svg aria-hidden="true" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><path d="M20 20H4a2 2 0 0 1-2-2V6a2 2 0 0 1 2-2h5l2 3h9a2 2 0 0 1 2 2v9a2 2 0 0 1-2 2Zm-8-10v6m-3-3h6"/></svg><span>选择其他项目文件夹</span></div>
</div>
<div class="trigger"><svg aria-hidden="true" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><path d="M21 11.5a8.4 8.4 0 0 1-.9 3.8 8.5 8.5 0 0 1-7.6 4.7 8.4 8.4 0 0 1-3.8-.9L3 21l1.9-5.7a8.4 8.4 0 0 1-.9-3.8 8.5 8.5 0 0 1 4.7-7.6 8.4 8.4 0 0 1 3.8-.9h.5a8.5 8.5 0 0 1 8 8v.5Z"/></svg><span>对话</span><svg aria-hidden="true" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><path d="m7 9 5-5 5 5m-10 6 5 5 5-5"/></svg></div>
</section>
<section class="sample light">
<h2>Light · 上次选择项目</h2>
<p>重新打开后：project-a。下方展示用户展开选择器后的状态。</p>
<div class="panel" aria-label="工作区选项静态预览">
<div class="row"><svg aria-hidden="true" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><path d="M21 11.5a8.4 8.4 0 0 1-.9 3.8 8.5 8.5 0 0 1-7.6 4.7 8.4 8.4 0 0 1-3.8-.9L3 21l1.9-5.7a8.4 8.4 0 0 1-.9-3.8 8.5 8.5 0 0 1 4.7-7.6 8.4 8.4 0 0 1 3.8-.9h.5a8.5 8.5 0 0 1 8 8v.5Z"/></svg><span>对话</span></div>
<hr><div class="row project"><svg aria-hidden="true" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><path d="M20 20H4a2 2 0 0 1-2-2V6a2 2 0 0 1 2-2h5l2 3h9a2 2 0 0 1 2 2v9a2 2 0 0 1-2 2Z"/></svg><span>project-a<small>/demo/project-a</small></span><svg aria-hidden="true" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><path d="m20 6-11 11-5-5"/></svg></div>
<hr><div class="row"><svg aria-hidden="true" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><path d="M20 20H4a2 2 0 0 1-2-2V6a2 2 0 0 1 2-2h5l2 3h9a2 2 0 0 1 2 2v9a2 2 0 0 1-2 2Zm-8-10v6m-3-3h6"/></svg><span>选择其他项目文件夹</span></div>
</div>
<div class="trigger"><svg aria-hidden="true" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><path d="M20 20H4a2 2 0 0 1-2-2V6a2 2 0 0 1 2-2h5l2 3h9a2 2 0 0 1 2 2v9a2 2 0 0 1-2 2Z"/></svg><span>project-a</span><svg aria-hidden="true" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><path d="m7 9 5-5 5 5m-10 6 5 5 5-5"/></svg></div>
</section>
<section class="sample dark">
<h2>Dark · 上次选择对话</h2>
<p>重新打开后：对话。下方展示用户展开选择器后的状态。</p>
<div class="panel" aria-label="工作区选项静态预览">
<div class="row"><svg aria-hidden="true" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><path d="M21 11.5a8.4 8.4 0 0 1-.9 3.8 8.5 8.5 0 0 1-7.6 4.7 8.4 8.4 0 0 1-3.8-.9L3 21l1.9-5.7a8.4 8.4 0 0 1-.9-3.8 8.5 8.5 0 0 1 4.7-7.6 8.4 8.4 0 0 1 3.8-.9h.5a8.5 8.5 0 0 1 8 8v.5Z"/></svg><span>对话</span><svg aria-hidden="true" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><path d="m20 6-11 11-5-5"/></svg></div>
<hr><div class="row project"><svg aria-hidden="true" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><path d="M20 20H4a2 2 0 0 1-2-2V6a2 2 0 0 1 2-2h5l2 3h9a2 2 0 0 1 2 2v9a2 2 0 0 1-2 2Z"/></svg><span>project-a<small>/demo/project-a</small></span></div>
<hr><div class="row"><svg aria-hidden="true" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><path d="M20 20H4a2 2 0 0 1-2-2V6a2 2 0 0 1 2-2h5l2 3h9a2 2 0 0 1 2 2v9a2 2 0 0 1-2 2Zm-8-10v6m-3-3h6"/></svg><span>选择其他项目文件夹</span></div>
</div>
<div class="trigger"><svg aria-hidden="true" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><path d="M21 11.5a8.4 8.4 0 0 1-.9 3.8 8.5 8.5 0 0 1-7.6 4.7 8.4 8.4 0 0 1-3.8-.9L3 21l1.9-5.7a8.4 8.4 0 0 1-.9-3.8 8.5 8.5 0 0 1 4.7-7.6 8.4 8.4 0 0 1 3.8-.9h.5a8.5 8.5 0 0 1 8 8v.5Z"/></svg><span>对话</span><svg aria-hidden="true" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><path d="m7 9 5-5 5 5m-10 6 5 5 5-5"/></svg></div>
</section>
<section class="sample dark">
<h2>Dark · 上次选择项目</h2>
<p>重新打开后：project-a。下方展示用户展开选择器后的状态。</p>
<div class="panel" aria-label="工作区选项静态预览">
<div class="row"><svg aria-hidden="true" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><path d="M21 11.5a8.4 8.4 0 0 1-.9 3.8 8.5 8.5 0 0 1-7.6 4.7 8.4 8.4 0 0 1-3.8-.9L3 21l1.9-5.7a8.4 8.4 0 0 1-.9-3.8 8.5 8.5 0 0 1 4.7-7.6 8.4 8.4 0 0 1 3.8-.9h.5a8.5 8.5 0 0 1 8 8v.5Z"/></svg><span>对话</span></div>
<hr><div class="row project"><svg aria-hidden="true" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><path d="M20 20H4a2 2 0 0 1-2-2V6a2 2 0 0 1 2-2h5l2 3h9a2 2 0 0 1 2 2v9a2 2 0 0 1-2 2Z"/></svg><span>project-a<small>/demo/project-a</small></span><svg aria-hidden="true" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><path d="m20 6-11 11-5-5"/></svg></div>
<hr><div class="row"><svg aria-hidden="true" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><path d="M20 20H4a2 2 0 0 1-2-2V6a2 2 0 0 1 2-2h5l2 3h9a2 2 0 0 1 2 2v9a2 2 0 0 1-2 2Zm-8-10v6m-3-3h6"/></svg><span>选择其他项目文件夹</span></div>
</div>
<div class="trigger"><svg aria-hidden="true" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><path d="M20 20H4a2 2 0 0 1-2-2V6a2 2 0 0 1 2-2h5l2 3h9a2 2 0 0 1 2 2v9a2 2 0 0 1-2 2Z"/></svg><span>project-a</span><svg aria-hidden="true" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><path d="m7 9 5-5 5 5m-10 6 5 5 5-5"/></svg></div>
</section></div>
<p>记忆仅恢复项目／对话模式；项目目录沿用所选设备的最近项目。具体项目入口、返回编辑草稿和本次手选优先。无记录时保持原默认；没有可用最近项目时沿用现有目录浏览流程。此预览只展示已有最近项目的场景。</p>
<p>样式来源：apps/mobile/app/sessions/new.tsx 的 workspacePickerPanel、workspaceOptionRow、workspaceProjectRow、selectorRow；颜色来源：apps/mobile/src/theme/tokens.ts。iOS / Android、Light / Dark 的实际 App 渲染均未验证。</p>
</main></html>
```

</details>

## 怎么验证的

### 自动验证

```text
pnpm --filter mobile exec vitest run src/__tests__/newSessionPreferenceStore.test.ts src/__tests__/newSession.test.ts
结果：135 项通过。

pnpm --filter mobile exec vitest run src/__tests__/newSessionWorkspaceEffects.test.tsx
结果：8 项页面 hooks 时序测试通过；延迟读取覆盖显式项目、返回编辑、手选和默认设备切换。测试按 AST 提取页面原始 hooks/callbacks 并用 React 挂载，未复制恢复判据。移除优先级及设备守卫的变异验证触发 7 项预期失败，恢复源码后关联门禁通过。

pnpm test:unit:related
结果：Mobile 关联单测通过。

pnpm --filter mobile run --if-present typecheck
结果：通过。

git diff --check
结果：通过。

node apps/mobile/scripts/ci-fingerprint.mjs compute --output <report>
结果：在同一工作区、相同依赖下分别计算 HEAD 基线及改动结果，iOS / Android 指纹一致。
```

### 手工验证

已审查完整 diff 和恢复顺序；未启动手机 App。

### 未执行的验证

未做 iOS / Android 实机或模拟器验证，Light / Dark 均未目检。验证分支为 `dash/mobile-remember-new-session-target`，工作区为 `cindy-mobile-remember-new-session-target`；本次未启动 Metro，因此无 Metro 归属或 `__DEV__` build label 证据。全量 CI 由 PR 检查执行。

## 风险

### 风险分类

- [ ] 无已知风险
- [ ] SQLite / migration
- [ ] system prompt
- [ ] 协议兼容
- [ ] 权限 / 安全 / 用户数据
- [ ] 存量插件兼容（批准状态 / 指纹 / manifest 校验 / 安装布局 / 包格式）
- [ ] 原生层 / fingerprint / OTA
- [ ] 跨平台差异
- [x] 其他：本地默认选择的异步恢复与偏好写入顺序。

### 影响与回滚

- 影响范围：仅 Mobile 新建任务的项目／对话模式及现有新建偏好存储。隐藏偏好只记录选择；无字段表示未自定义。现有清除偏好函数会移除此字段并恢复入口默认。
- 适配：SSH 不涉及；设备互联仍沿用既有创建通道，恢复项目模式等待默认设备同步后再选目录；Mobile iOS / Android 共用此逻辑。存量插件影响：无。
- 回滚 / 降级方式：回滚本 PR 后恢复原入口默认，旧版本忽略新增字段；本地存储不可用时沿用无记录默认，不阻断新建页。

### 提交前检查

- [x] 已 review 完整 diff
- [x] 每个 commit 都带 DCO 签名（`git commit -s`，见 [DCO](../DCO)）
- [x] UI 改动已在「UI 变化」注明引用的设计规范章节（不涉及 UI 则跳过）
- [x] 未提交凭证、令牌或授权文件
- [x] 已补充必要文档（本 PR 描述说明默认、兼容及回滚；无需新增独立文档）
- [x] 已确认测试结果或说明未执行原因
