### PR TITLE
fix(mobile): 流式输出时让自动滚底避让手势

### DIFF
--- a/apps/mobile/src/__tests__/messageFollowGesture.test.ts
+++ b/apps/mobile/src/__tests__/messageFollowGesture.test.ts
@@ -124,19 +124,19 @@ describe('streaming follow yields to the reader', () => {
     },
   );
 
-  it('resumes a dead-zone drag without letting its native acknowledgement unpin follow', () => {
+  it.each([1196, 1194])('preserves a dead-zone drag through a trailing offset of %i after large growth', (trailingOffset) => {
     const h = harness();
     h.handleScrollBeginDrag(h.scrollEvent(1200));
     h.handleScroll(h.scrollEvent(1196));
-    h.handleContentSize(400, 2100);
+    h.handleContentSize(400, 2500);
     h.handleScrollEndDrag();
     // The trailing native event may arrive before the release verifier's first frame.
-    h.handleScroll(h.scrollEvent(1196));
+    h.handleScroll(h.scrollEvent(trailingOffset));
     settle();
     expect(h.scrollToEnd).toHaveBeenCalledTimes(1);
-    h.handleScroll(h.scrollEvent(1300));
+    h.handleScroll(h.scrollEvent(1700));
     expect(h.state.nearBottomRef.current).toBe(true);
-    h.handleContentSize(400, 2140);
+    h.handleContentSize(400, 2540);
     expect(h.scrollToEnd).toHaveBeenCalledTimes(2);
   });
 
@@ -155,6 +155,35 @@ describe('streaming follow yields to the reader', () => {
     h.handleMomentumScrollEnd();
     settle();
     expect(h.scrollToEnd).toHaveBeenCalledTimes(1);
+  });
+
+  it('keeps the drag dead zone authoritative when the tail grows beyond the distance threshold', () => {
+    const h = harness();
+    h.handleScrollBeginDrag(h.scrollEvent(1200));
+    h.handleScroll(h.scrollEvent(1196));
+    h.handleContentSize(400, 2500);
+    h.handleScroll(h.scrollEvent(1194));
+    expect(h.state.nearBottomRef.current).toBe(true);
+    expect(h.scrollToEnd).not.toHaveBeenCalled();
+    h.handleScroll(h.scrollEvent(1190));
+    expect(h.state.nearBottomRef.current).toBe(false);
+    h.handleScrollEndDrag();
+    settle();
+    expect(h.scrollToEnd).not.toHaveBeenCalled();
+  });
+
+  it('still unpins a real momentum fling after a short drag', () => {
+    const h = harness();
+    h.handleScrollBeginDrag(h.scrollEvent(1200));
+    h.handleScroll(h.scrollEvent(1196));
+    h.handleScrollEndDrag();
+    h.handleMomentumScrollBegin();
+    h.handleScroll(h.scrollEvent(900));
+    expect(h.state.nearBottomRef.current).toBe(false);
+    h.handleContentSize(400, 2500);
+    h.handleMomentumScrollEnd();
+    settle();
+    expect(h.scrollToEnd).not.toHaveBeenCalled();
   });
 
   it('blocks a previously scheduled circuit recovery while the finger owns the viewport', () => {

--- a/apps/mobile/src/__tests__/messageFollowGesture.test.ts
+++ b/apps/mobile/src/__tests__/messageFollowGesture.test.ts
@@ -94,6 +94,70 @@ beforeEach(() => {
 afterEach(() => { vi.useRealTimers(); vi.unstubAllGlobals(); vi.restoreAllMocks(); });
 
 describe('streaming follow yields to the reader', () => {
+  it.each([1196, 1180].flatMap((offset) => [false, true].map((lateEnd) => ({ offset, lateEnd }))))(
+    'releases a cancelled drag at $offset with a late end event: $lateEnd', ({ offset, lateEnd }) => {
+      const h = harness();
+      h.handleHistoryTouchStart(touch());
+      h.handleScrollBeginDrag(h.scrollEvent(1200));
+      h.handleScroll(h.scrollEvent(offset));
+      h.handleContentSize(400, 2500);
+      h.handleHistoryTouchCancel();
+      h.handleHistoryTouchCancel();
+      if (lateEnd) h.handleScrollEndDrag(h.scrollEvent(offset));
+      settle();
+      expect(h.state.nearBottomRef.current).toBe(offset === 1196);
+      expect(h.scrollToEnd).toHaveBeenCalledTimes(offset === 1196 ? 1 : 0);
+      expect(h.state.isDraggingRef.current).toBe(false);
+      expect(h.state.dragStartOffsetYRef.current).toBeNull();
+    },
+  );
+
+  it('allows native scrolling to take ownership after Android cancels the JS touch', () => {
+    const h = harness();
+    h.handleHistoryTouchStart(touch());
+    h.handleHistoryTouchCancel();
+    h.handleScrollBeginDrag(h.scrollEvent(1200));
+    h.handleContentSize(400, 2500);
+    settle();
+    expect(h.scrollToEnd).not.toHaveBeenCalled();
+    h.handleScroll(h.scrollEvent(1180));
+    h.handleScrollEndDrag();
+    settle();
+    expect(h.state.nearBottomRef.current).toBe(false);
+    expect(h.scrollToEnd).not.toHaveBeenCalled();
+  });
+
+  it('waits for independently reported momentum after cancelling a touch', () => {
+    const h = harness();
+    h.handleHistoryTouchStart(touch());
+    h.handleScrollBeginDrag(h.scrollEvent(1200));
+    h.handleMomentumScrollBegin();
+    h.handleHistoryTouchCancel();
+    h.handleContentSize(400, 2500);
+    settle();
+    expect(h.scrollToEnd).not.toHaveBeenCalled();
+    h.handleMomentumScrollEnd();
+    settle();
+    expect(h.scrollToEnd).toHaveBeenCalledTimes(1);
+  });
+
+  it('keeps an active drag when another finger touches the list', () => {
+    const h = harness();
+    h.handleHistoryTouchStart(touch());
+    h.handleScrollBeginDrag(h.scrollEvent(1200));
+    h.handleScroll(h.scrollEvent(1196));
+    h.handleHistoryTouchStart(touch());
+    h.handleContentSize(400, 2500);
+    settle();
+    expect(h.scrollToEnd).not.toHaveBeenCalled();
+    h.handleScroll(h.scrollEvent(1180));
+    h.handleHistoryTouchEnd(touch());
+    h.handleScrollEndDrag();
+    settle();
+    expect(h.state.nearBottomRef.current).toBe(false);
+    expect(h.scrollToEnd).not.toHaveBeenCalled();
+  });
+
   it.each([false, true])('preserves an explicit animated jump when touchEnd precedes onPress: %s', (releaseFirst) => {
     const h = harness();
     h.state.nearBottomRef.current = false;

--- a/apps/mobile/src/__tests__/messageFollowGesture.test.ts
+++ b/apps/mobile/src/__tests__/messageFollowGesture.test.ts
@@ -89,6 +89,41 @@ beforeEach(() => {
 afterEach(() => { vi.useRealTimers(); vi.unstubAllGlobals(); vi.restoreAllMocks(); });
 
 describe('streaming follow yields to the reader', () => {
+  it.each([false, true])('preserves an explicit animated jump when touchEnd precedes onPress: %s', (releaseFirst) => {
+    const h = harness();
+    h.state.nearBottomRef.current = false;
+    h.state.scrollMetricsRef.current.offsetY = 300;
+    // Native animation has not landed yet; command dispatch does not acknowledge its offset.
+    h.scrollToEnd.mockImplementation(() => {});
+    h.handleHistoryTouchStart(touch());
+    if (releaseFirst) h.handleHistoryTouchEnd(touch());
+    h.scrollToBottom();
+    expect(h.scrollToEnd).toHaveBeenCalledExactlyOnceWith({ animated: true });
+    if (!releaseFirst) h.handleHistoryTouchEnd(touch());
+    h.handleContentSize(400, 2200);
+    const remaining = h.state.programmaticScrollSettleAtRef.current - Date.now();
+    vi.advanceTimersByTime(remaining - 1);
+    // Releasing the button and receiving new content must not truncate the animation.
+    expect(h.scrollToEnd).toHaveBeenCalledExactlyOnceWith({ animated: true });
+    h.handleScroll(h.scrollEvent(1400));
+    settle();
+    expect(h.scrollToEnd).toHaveBeenCalledExactlyOnceWith({ animated: true });
+  });
+
+  it('lets a new upward drag interrupt verification after an explicit animated jump', () => {
+    const h = harness();
+    h.scrollToBottom();
+    h.handleHistoryTouchStart(touch());
+    h.handleScrollBeginDrag(h.scrollEvent(1200));
+    h.handleScroll(h.scrollEvent(1180));
+    h.handleContentSize(400, 2200);
+    h.handleHistoryTouchEnd(touch(420));
+    h.handleScrollEndDrag();
+    settle();
+    expect(h.state.nearBottomRef.current).toBe(false);
+    expect(h.scrollToEnd).toHaveBeenCalledExactlyOnceWith({ animated: true });
+  });
+
   it('allows an upward drag to unpin while content grows before the first scroll event', () => {
     const h = harness();
     h.handleHistoryTouchStart(touch());

--- a/apps/mobile/src/__tests__/messageFollowGesture.test.ts
+++ b/apps/mobile/src/__tests__/messageFollowGesture.test.ts
@@ -15,6 +15,7 @@ const renderer = source.statements.find((node): node is ts.FunctionDeclaration =
 const callbackNames = [
   'markProgrammaticScroll', 'clearProgrammaticScroll', 'markMobileMvcpSettle',
   'isUserControllingScroll', 'scrollToEndProgrammatically', 'runStickToLatestVerify',
+  'scrollToOffsetProgrammatically', 'scrollToIndexProgrammatically',
   'scrollToBottom', 'handleScroll', 'handleHistoryTouchStart', 'maybeTriggerHistoryTouch',
   'handleHistoryTouchMove', 'handleHistoryTouchEnd', 'handleHistoryTouchCancel',
   'handleScrollBeginDrag', 'handleScrollEndDrag', 'handleMomentumScrollBegin',
@@ -60,7 +61,9 @@ function harness() {
     metrics.offsetY = metrics.contentHeight - metrics.viewportHeight;
   });
   const environment = {
-    ...scrollModel, ...state, listRef: ref({ scrollToEnd }), bottomOverlayHeight: undefined,
+    ...scrollModel, ...state,
+    listRef: ref({ scrollToEnd, scrollToOffset: vi.fn(), scrollToIndex: vi.fn() }),
+    bottomOverlayHeight: undefined,
     useCallback: (callback: unknown) => callback,
     attemptAutoLoadEarlier: vi.fn(), handoffHistoryPrependToUser: vi.fn(),
     scheduleHistoryPrependUserHandoffSettle: vi.fn(), scheduleQueuedLoadEarlierFlush: vi.fn(),
@@ -94,21 +97,26 @@ beforeEach(() => {
 afterEach(() => { vi.useRealTimers(); vi.unstubAllGlobals(); vi.restoreAllMocks(); });
 
 describe('streaming follow yields to the reader', () => {
-  it.each([1196, 1180].flatMap((offset) => [false, true].map((lateEnd) => ({ offset, lateEnd }))))(
-    'releases a cancelled drag at $offset with a late end event: $lateEnd', ({ offset, lateEnd }) => {
+  it.each([1196, 1180].flatMap((offset) => ['missing', 'before-verify', 'after-verify'].map((end) => ({ offset, end }))))(
+    'releases a cancelled drag at $offset with end event $end', ({ offset, end }) => {
       const h = harness();
       h.handleHistoryTouchStart(touch());
       h.handleScrollBeginDrag(h.scrollEvent(1200));
-      h.handleScroll(h.scrollEvent(lateEnd ? 1196 : offset));
+      h.handleScroll(h.scrollEvent(end === 'missing' ? offset : 1196));
       h.handleContentSize(400, 2500);
       h.handleHistoryTouchCancel();
       h.handleHistoryTouchCancel();
-      if (lateEnd) h.handleScrollEndDrag(h.scrollEvent(offset));
+      if (end === 'after-verify') {
+        settle();
+        expect(h.scrollToEnd).toHaveBeenCalledTimes(1);
+        h.scrollToEnd.mockClear();
+      }
+      if (end !== 'missing') h.handleScrollEndDrag(h.scrollEvent(offset));
       settle();
       expect(h.state.nearBottomRef.current).toBe(offset === 1196);
       expect(h.scrollToEnd).toHaveBeenCalledTimes(offset === 1196 ? 1 : 0);
       expect(h.state.isDraggingRef.current).toBe(false);
-      if (lateEnd) expect(h.state.dragStartOffsetYRef.current).toBeNull();
+      if (end !== 'missing') expect(h.state.dragStartOffsetYRef.current).toBeNull();
     },
   );
 
@@ -139,15 +147,27 @@ describe('streaming follow yields to the reader', () => {
     expect(h.scrollToEnd).not.toHaveBeenCalled();
   });
 
-  it('discards the cancelled drag sample when an explicit scroll takes over', () => {
+  it.each(['end', 'index'])('discards the cancelled drag sample when explicit %s takes over', (target) => {
     const h = harness();
     h.handleScrollBeginDrag(h.scrollEvent(1200));
     h.handleScroll(h.scrollEvent(1196));
     h.handleHistoryTouchCancel();
-    h.scrollToBottom();
+    if (target === 'end') h.scrollToBottom();
+    else h.scrollToIndexProgrammatically(10, 0.45);
     h.handleScrollEndDrag(h.scrollEvent(1180));
     expect(h.state.nearBottomRef.current).toBe(true);
-    expect(h.scrollToEnd).toHaveBeenCalledExactlyOnceWith({ animated: true });
+    if (target === 'end') expect(h.scrollToEnd).toHaveBeenCalledExactlyOnceWith({ animated: true });
+  });
+
+  it('keeps the cancelled drag sample through automatic offset compensation', () => {
+    const h = harness();
+    h.handleScrollBeginDrag(h.scrollEvent(1200));
+    h.handleHistoryTouchCancel();
+    h.scrollToOffsetProgrammatically(900, false);
+    h.handleScroll(h.scrollEvent(900));
+    expect(h.state.nearBottomRef.current).toBe(true);
+    h.handleScrollEndDrag(h.scrollEvent(1180));
+    expect(h.state.nearBottomRef.current).toBe(false);
   });
 
   it('can return to the bottom in the final drag sample after cancellation', () => {

--- a/apps/mobile/src/__tests__/messageFollowGesture.test.ts
+++ b/apps/mobile/src/__tests__/messageFollowGesture.test.ts
@@ -99,7 +99,7 @@ describe('streaming follow yields to the reader', () => {
       const h = harness();
       h.handleHistoryTouchStart(touch());
       h.handleScrollBeginDrag(h.scrollEvent(1200));
-      h.handleScroll(h.scrollEvent(offset));
+      h.handleScroll(h.scrollEvent(lateEnd ? 1196 : offset));
       h.handleContentSize(400, 2500);
       h.handleHistoryTouchCancel();
       h.handleHistoryTouchCancel();
@@ -108,9 +108,59 @@ describe('streaming follow yields to the reader', () => {
       expect(h.state.nearBottomRef.current).toBe(offset === 1196);
       expect(h.scrollToEnd).toHaveBeenCalledTimes(offset === 1196 ? 1 : 0);
       expect(h.state.isDraggingRef.current).toBe(false);
-      expect(h.state.dragStartOffsetYRef.current).toBeNull();
+      if (lateEnd) expect(h.state.dragStartOffsetYRef.current).toBeNull();
     },
   );
+
+  it('consumes a late final sample even after a no-op cancellation verification', () => {
+    const h = harness();
+    h.handleScrollBeginDrag(h.scrollEvent(1200));
+    h.handleHistoryTouchCancel();
+    settle();
+    expect(h.scrollToEnd).not.toHaveBeenCalled();
+    h.handleScrollEndDrag(h.scrollEvent(1180));
+    h.handleContentSize(400, 2500);
+    settle();
+    expect(h.state.nearBottomRef.current).toBe(false);
+    expect(h.scrollToEnd).not.toHaveBeenCalled();
+  });
+
+  it('ignores layout corrections after cancel but consumes the final drag sample', () => {
+    const h = harness();
+    h.handleScrollBeginDrag(h.scrollEvent(1200));
+    h.handleScroll(h.scrollEvent(1196));
+    h.handleContentSize(400, 2500);
+    h.handleHistoryTouchCancel();
+    h.handleScroll(h.scrollEvent(900));
+    expect(h.state.nearBottomRef.current).toBe(true);
+    h.handleScrollEndDrag(h.scrollEvent(1180));
+    settle();
+    expect(h.state.nearBottomRef.current).toBe(false);
+    expect(h.scrollToEnd).not.toHaveBeenCalled();
+  });
+
+  it('discards the cancelled drag sample when an explicit scroll takes over', () => {
+    const h = harness();
+    h.handleScrollBeginDrag(h.scrollEvent(1200));
+    h.handleScroll(h.scrollEvent(1196));
+    h.handleHistoryTouchCancel();
+    h.scrollToBottom();
+    h.handleScrollEndDrag(h.scrollEvent(1180));
+    expect(h.state.nearBottomRef.current).toBe(true);
+    expect(h.scrollToEnd).toHaveBeenCalledExactlyOnceWith({ animated: true });
+  });
+
+  it('can return to the bottom in the final drag sample after cancellation', () => {
+    const h = harness();
+    h.handleScrollBeginDrag(h.scrollEvent(1200));
+    h.handleScroll(h.scrollEvent(1180));
+    h.handleHistoryTouchCancel();
+    h.handleScrollEndDrag(h.scrollEvent(1200));
+    expect(h.state.nearBottomRef.current).toBe(true);
+    h.handleContentSize(400, 2500);
+    settle();
+    expect(h.scrollToEnd).toHaveBeenCalledTimes(1);
+  });
 
   it('allows native scrolling to take ownership after Android cancels the JS touch', () => {
     const h = harness();

--- a/apps/mobile/src/__tests__/messageFollowGesture.test.ts
+++ b/apps/mobile/src/__tests__/messageFollowGesture.test.ts
@@ -159,7 +159,7 @@ describe('streaming follow yields to the reader', () => {
     },
   );
 
-  it.each([1196, 1194])('preserves a dead-zone drag through a trailing offset of %i after large growth', (trailingOffset) => {
+  it.each([1196, 1194, 1192, 1190])('applies the cumulative drag threshold to a trailing offset of %i after large growth', (trailingOffset) => {
     const h = harness();
     h.handleScrollBeginDrag(h.scrollEvent(1200));
     h.handleScroll(h.scrollEvent(1196));
@@ -167,12 +167,82 @@ describe('streaming follow yields to the reader', () => {
     h.handleScrollEndDrag();
     // The trailing native event may arrive before the release verifier's first frame.
     h.handleScroll(h.scrollEvent(trailingOffset));
+    expect(h.state.nearBottomRef.current).toBe(trailingOffset >= 1192);
     settle();
+    if (trailingOffset < 1192) {
+      expect(h.scrollToEnd).not.toHaveBeenCalled();
+      return;
+    }
     expect(h.scrollToEnd).toHaveBeenCalledTimes(1);
     h.handleScroll(h.scrollEvent(1700));
     expect(h.state.nearBottomRef.current).toBe(true);
     h.handleContentSize(400, 2540);
     expect(h.scrollToEnd).toHaveBeenCalledTimes(2);
+  });
+
+  it.each([false, true])('unpins a trailing drag across momentum-start ordering: %s', (momentumFirst) => {
+    const h = harness();
+    h.handleHistoryTouchStart(touch());
+    h.handleScrollBeginDrag(h.scrollEvent(1200));
+    h.handleScroll(h.scrollEvent(1196));
+    h.handleHistoryTouchEnd(touch());
+    h.handleScrollEndDrag();
+    if (momentumFirst) h.handleMomentumScrollBegin();
+    h.handleScroll(h.scrollEvent(1190));
+    if (!momentumFirst) h.handleMomentumScrollBegin();
+    h.handleMomentumScrollEnd();
+    h.handleContentSize(400, 2500);
+    settle();
+    expect(h.state.nearBottomRef.current).toBe(false);
+    expect(h.scrollToEnd).not.toHaveBeenCalled();
+  });
+
+  it('retires a completed drag after a no-op release verification', () => {
+    const h = harness();
+    h.handleScrollBeginDrag(h.scrollEvent(1200));
+    h.handleScroll(h.scrollEvent(1200));
+    h.handleScrollEndDrag();
+    settle();
+    expect(h.scrollToEnd).not.toHaveBeenCalled();
+    h.handleScroll(h.scrollEvent(1190));
+    h.handleContentSize(400, 2500);
+    settle();
+    expect(h.state.nearBottomRef.current).toBe(true);
+    expect(h.scrollToEnd).toHaveBeenCalledTimes(1);
+  });
+
+  it('can unpin again after returning to the bottom within the same drag', () => {
+    const h = harness();
+    h.handleScrollBeginDrag(h.scrollEvent(1200));
+    h.handleScroll(h.scrollEvent(1180));
+    expect(h.state.nearBottomRef.current).toBe(false);
+    h.handleScroll(h.scrollEvent(1200));
+    expect(h.state.nearBottomRef.current).toBe(true);
+    h.handleScroll(h.scrollEvent(1180));
+    expect(h.state.nearBottomRef.current).toBe(false);
+  });
+
+  it('forgets the previous drag when an explicit command owns native scroll events', () => {
+    const h = harness();
+    h.handleScrollBeginDrag(h.scrollEvent(1200));
+    h.handleScroll(h.scrollEvent(1196));
+    h.handleScrollEndDrag();
+    h.scrollToBottom();
+    h.handleScroll(h.scrollEvent(1190));
+    expect(h.state.nearBottomRef.current).toBe(true);
+  });
+
+  it('measures a new drag from its own starting offset', () => {
+    const h = harness();
+    h.handleScrollBeginDrag(h.scrollEvent(1200));
+    h.handleScroll(h.scrollEvent(1196));
+    h.handleScrollEndDrag();
+    h.handleHistoryTouchStart(touch());
+    h.handleScrollBeginDrag(h.scrollEvent(1196));
+    h.handleScroll(h.scrollEvent(1190));
+    expect(h.state.nearBottomRef.current).toBe(true);
+    h.handleScroll(h.scrollEvent(1186));
+    expect(h.state.nearBottomRef.current).toBe(false);
   });
 
   it('pauses already queued verification and waits for momentum to end before catching up', () => {

--- a/apps/mobile/src/__tests__/messageFollowGesture.test.ts
+++ b/apps/mobile/src/__tests__/messageFollowGesture.test.ts
@@ -1,0 +1,184 @@
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+import ts from 'typescript';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import * as scrollModel from '@/session/messageScroll';
+
+// Execute the production callbacks without mounting Markdown/media/native views. Unlike source
+// assertions, this harness interleaves touch, native scroll, content-size, timers and frame delivery.
+const source = ts.createSourceFile('MessageRenderer.tsx', readFileSync(
+  resolve(process.cwd(), 'src/session/MessageRenderer.tsx'), 'utf8',
+), ts.ScriptTarget.Latest, true, ts.ScriptKind.TSX);
+const renderer = source.statements.find((node): node is ts.FunctionDeclaration => (
+  ts.isFunctionDeclaration(node) && node.name?.text === 'MessageRenderer'
+));
+const callbackNames = [
+  'markProgrammaticScroll', 'clearProgrammaticScroll', 'markMobileMvcpSettle',
+  'isUserControllingScroll', 'scrollToEndProgrammatically', 'runStickToLatestVerify',
+  'scrollToBottom', 'handleScroll', 'handleHistoryTouchStart', 'maybeTriggerHistoryTouch',
+  'handleHistoryTouchMove', 'handleHistoryTouchEnd', 'handleHistoryTouchCancel',
+  'handleScrollBeginDrag', 'handleScrollEndDrag', 'handleMomentumScrollBegin',
+  'handleMomentumScrollEnd', 'handleContentSize',
+] as const;
+type CallbackName = typeof callbackNames[number];
+const declarations = renderer!.body!.statements.filter((node) => (
+  ts.isVariableStatement(node) && node.declarationList.declarations.some((declaration) => (
+    ts.isIdentifier(declaration.name) && callbackNames.includes(declaration.name.text as CallbackName)
+  ))
+));
+const constants = source.statements.filter((node) => (
+  ts.isVariableStatement(node) && node.declarationList.declarations.some((declaration) => (
+    ts.isIdentifier(declaration.name) && /^MOBILE_PROGRAMMATIC_.*_MS$/.test(declaration.name.text)
+  ))
+));
+const compiled = ts.transpileModule([
+  ...constants.map((node) => node.getText(source)),
+  ...declarations.map((node) => node.getText(source)),
+  `return { ${callbackNames.join(', ')} };`,
+].join('\n'), { compilerOptions: { target: ts.ScriptTarget.ES2022 } }).outputText;
+
+function harness() {
+  const ref = <T>(current: T) => ({ current });
+  const state = {
+    nearBottomRef: ref(true), readingOlderRef: ref(false),
+    isDraggingRef: ref(false), isMomentumScrollingRef: ref(false),
+    historyTouchStartYRef: ref<number | null>(null), historyTouchTriggeredRef: ref(false),
+    dragStartOffsetYRef: ref<number | null>(null), userScrollForOlderRef: ref(false),
+    lastAutoLoadEarlierKeyRef: ref<string | null>(null),
+    programmaticScrollGenerationRef: ref(0), programmaticScrollTimerRef: ref<unknown>(null),
+    programmaticScrollInFlightRef: ref(false), programmaticAnimatedScrollInFlightRef: ref(false),
+    programmaticScrollSettleAtRef: ref(0), mvcpSettleAtRef: ref(0),
+    followVerifyGenerationRef: ref(0), followVerifyFrameRef: ref<unknown>(null),
+    followVerifyTimerRef: ref<unknown>(null), followEndPinRecoveryTimerRef: ref<unknown>(null),
+    followEndPinStateRef: ref(scrollModel.createMobileFollowEndPinState()),
+    historyPrependTransactionRef: ref(null), nativeScrollEventSequenceRef: ref(0),
+    shareSelectionActiveRef: ref(false),
+    scrollMetricsRef: ref({ contentHeight: 2000, offsetY: 1200, viewportHeight: 800 }),
+  };
+  const scrollToEnd = vi.fn(() => {
+    const metrics = state.scrollMetricsRef.current;
+    metrics.offsetY = metrics.contentHeight - metrics.viewportHeight;
+  });
+  const environment = {
+    ...scrollModel, ...state, listRef: ref({ scrollToEnd }), bottomOverlayHeight: undefined,
+    useCallback: (callback: unknown) => callback,
+    attemptAutoLoadEarlier: vi.fn(), handoffHistoryPrependToUser: vi.fn(),
+    scheduleHistoryPrependUserHandoffSettle: vi.fn(), scheduleQueuedLoadEarlierFlush: vi.fn(),
+    refreshPreviousUserTarget: vi.fn(), scheduleStickyShareCheck: vi.fn(),
+    scheduleHistoryAnchorRestore: vi.fn(), restoreHistoryAnchorOnce: vi.fn(),
+    cancelHistoryPrependTransaction: vi.fn(),
+    setIsAwayFromBottom: vi.fn(), setHasNewMessages: vi.fn(), setPreviousUserTarget: vi.fn(),
+  };
+  const callbacks = new Function(...Object.keys(environment), compiled)(
+    ...Object.values(environment),
+  ) as Record<CallbackName, (...args: unknown[]) => void>;
+  const scrollEvent = (offsetY: number) => ({ nativeEvent: {
+    contentSize: { height: state.scrollMetricsRef.current.contentHeight },
+    contentOffset: { y: offsetY }, layoutMeasurement: { height: 800 },
+  } });
+  return { ...callbacks, state, scrollToEnd, scrollEvent };
+}
+const touch = (pageY = 400) => ({ nativeEvent: { pageY } });
+const settle = () => vi.advanceTimersByTime(4000);
+
+beforeEach(() => {
+  vi.useFakeTimers();
+  vi.stubGlobal('requestAnimationFrame', (callback: () => void) => setTimeout(callback, 16));
+  vi.stubGlobal('cancelAnimationFrame', (timer: ReturnType<typeof setTimeout>) => clearTimeout(timer));
+});
+afterEach(() => { vi.useRealTimers(); vi.unstubAllGlobals(); vi.restoreAllMocks(); });
+
+describe('streaming follow yields to the reader', () => {
+  it('allows an upward drag to unpin while content grows before the first scroll event', () => {
+    const h = harness();
+    h.handleHistoryTouchStart(touch());
+    h.handleContentSize(400, 2040);
+    h.handleScrollBeginDrag(h.scrollEvent(1200));
+    h.handleContentSize(400, 2080);
+    expect(h.scrollToEnd).not.toHaveBeenCalled();
+    h.handleScroll(h.scrollEvent(1180));
+    expect(h.state.nearBottomRef.current).toBe(false);
+    h.handleHistoryTouchEnd(touch(420));
+    h.handleScrollEndDrag();
+    h.handleMomentumScrollBegin();
+    h.handleContentSize(400, 2200);
+    h.handleMomentumScrollEnd();
+    settle();
+    h.handleContentSize(400, 2240);
+    expect(h.scrollToEnd).not.toHaveBeenCalled();
+    h.scrollToBottom();
+    expect(h.scrollToEnd).toHaveBeenLastCalledWith({ animated: true });
+  });
+
+  it.each(['handleHistoryTouchEnd', 'handleHistoryTouchCancel'] as const)(
+    'catches up after %s when output ended during a stationary touch', (release) => {
+      const h = harness();
+      h.handleHistoryTouchStart(touch());
+      h.handleContentSize(400, 2300);
+      settle();
+      expect(h.scrollToEnd).not.toHaveBeenCalled();
+      h[release](touch());
+      settle();
+      expect(h.scrollToEnd).toHaveBeenCalledTimes(1);
+      expect(h.state.scrollMetricsRef.current.offsetY).toBe(1500);
+    },
+  );
+
+  it('resumes a dead-zone drag without letting its native acknowledgement unpin follow', () => {
+    const h = harness();
+    h.handleScrollBeginDrag(h.scrollEvent(1200));
+    h.handleScroll(h.scrollEvent(1196));
+    h.handleContentSize(400, 2100);
+    h.handleScrollEndDrag();
+    // The trailing native event may arrive before the release verifier's first frame.
+    h.handleScroll(h.scrollEvent(1196));
+    settle();
+    expect(h.scrollToEnd).toHaveBeenCalledTimes(1);
+    h.handleScroll(h.scrollEvent(1300));
+    expect(h.state.nearBottomRef.current).toBe(true);
+    h.handleContentSize(400, 2140);
+    expect(h.scrollToEnd).toHaveBeenCalledTimes(2);
+  });
+
+  it('pauses already queued verification and waits for momentum to end before catching up', () => {
+    const h = harness();
+    h.state.scrollMetricsRef.current.contentHeight = 2200;
+    h.runStickToLatestVerify();
+    h.handleHistoryTouchStart(touch());
+    settle();
+    expect(h.scrollToEnd).not.toHaveBeenCalled();
+    h.handleHistoryTouchEnd(touch());
+    h.handleMomentumScrollBegin();
+    h.handleContentSize(400, 2300);
+    settle();
+    expect(h.scrollToEnd).not.toHaveBeenCalled();
+    h.handleMomentumScrollEnd();
+    settle();
+    expect(h.scrollToEnd).toHaveBeenCalledTimes(1);
+  });
+
+  it('blocks a previously scheduled circuit recovery while the finger owns the viewport', () => {
+    const h = harness();
+    vi.spyOn(console, 'warn').mockImplementation(() => {});
+    for (let i = 0; i < 12; i++) h.handleContentSize(400, i % 2 ? 2100 : 2200);
+    expect(h.state.followEndPinRecoveryTimerRef.current).not.toBeNull();
+    h.scrollToEnd.mockClear();
+    h.handleHistoryTouchStart(touch());
+    settle();
+    expect(h.scrollToEnd).not.toHaveBeenCalled();
+    h.handleHistoryTouchEnd(touch());
+    settle();
+    expect(h.state.scrollMetricsRef.current.offsetY).toBe(1300);
+  });
+
+  it('does not resume tail follow while a history page owns the anchor', () => {
+    const h = harness();
+    h.state.readingOlderRef.current = true;
+    h.state.nearBottomRef.current = false;
+    h.handleHistoryTouchStart(touch());
+    h.handleContentSize(400, 2500);
+    h.handleHistoryTouchEnd(touch());
+    settle();
+    expect(h.scrollToEnd).not.toHaveBeenCalled();
+  });
+});

--- a/apps/mobile/src/__tests__/messageFollowGesture.test.ts
+++ b/apps/mobile/src/__tests__/messageFollowGesture.test.ts
@@ -76,7 +76,12 @@ function harness() {
     contentSize: { height: state.scrollMetricsRef.current.contentHeight },
     contentOffset: { y: offsetY }, layoutMeasurement: { height: 800 },
   } });
-  return { ...callbacks, state, scrollToEnd, scrollEvent };
+  return {
+    ...callbacks, state, scrollToEnd, scrollEvent,
+    handleScrollEndDrag: (event = scrollEvent(state.scrollMetricsRef.current.offsetY)) => (
+      callbacks.handleScrollEndDrag(event)
+    ),
+  };
 }
 const touch = (pageY = 400) => ({ nativeEvent: { pageY } });
 const settle = () => vi.advanceTimersByTime(4000);
@@ -164,8 +169,8 @@ describe('streaming follow yields to the reader', () => {
     h.handleScrollBeginDrag(h.scrollEvent(1200));
     h.handleScroll(h.scrollEvent(1196));
     h.handleContentSize(400, 2500);
-    h.handleScrollEndDrag();
-    // The trailing native event may arrive before the release verifier's first frame.
+    h.handleScrollEndDrag(h.scrollEvent(trailingOffset));
+    // End-drag carries the final offset even when the matching onScroll is delivered later.
     h.handleScroll(h.scrollEvent(trailingOffset));
     expect(h.state.nearBottomRef.current).toBe(trailingOffset >= 1192);
     settle();
@@ -186,7 +191,7 @@ describe('streaming follow yields to the reader', () => {
     h.handleScrollBeginDrag(h.scrollEvent(1200));
     h.handleScroll(h.scrollEvent(1196));
     h.handleHistoryTouchEnd(touch());
-    h.handleScrollEndDrag();
+    h.handleScrollEndDrag(h.scrollEvent(1190));
     if (momentumFirst) h.handleMomentumScrollBegin();
     h.handleScroll(h.scrollEvent(1190));
     if (!momentumFirst) h.handleMomentumScrollBegin();
@@ -209,6 +214,20 @@ describe('streaming follow yields to the reader', () => {
     settle();
     expect(h.state.nearBottomRef.current).toBe(true);
     expect(h.scrollToEnd).toHaveBeenCalledTimes(1);
+  });
+
+  it.each([1180, 900])('preserves a short drag through a post-release layout correction to %i', (offset) => {
+    const h = harness();
+    h.handleScrollBeginDrag(h.scrollEvent(1200));
+    h.handleScroll(h.scrollEvent(1196));
+    h.handleContentSize(400, 2500);
+    h.handleScrollEndDrag(h.scrollEvent(1196));
+    // MVCP may correct the visible anchor before the release verifier runs.
+    h.handleScroll(h.scrollEvent(offset));
+    expect(h.state.nearBottomRef.current).toBe(true);
+    settle();
+    expect(h.scrollToEnd).toHaveBeenCalledExactlyOnceWith({ animated: false });
+    expect(h.state.scrollMetricsRef.current.offsetY).toBe(1700);
   });
 
   it('can unpin again after returning to the bottom within the same drag', () => {

--- a/apps/mobile/src/__tests__/messageListVirtualization.test.ts
+++ b/apps/mobile/src/__tests__/messageListVirtualization.test.ts
@@ -295,6 +295,7 @@ describe('mobile message list container', () => {
     expect(effectEnd).toBeGreaterThan(effectStart);
     expect(clearHistoryIntentAt).toBeGreaterThan(-1);
     expect(verifyAt).toBeGreaterThan(clearHistoryIntentAt);
+    expect(effectSource).toContain("scrollToEndProgrammatically(true, 'explicit');");
   });
 
   it('verifies a manual jump-to-latest after issuing the animated scroll', () => {
@@ -302,7 +303,7 @@ describe('mobile message list container', () => {
     const callbackStart = source.indexOf('const scrollToBottom = useCallback');
     const callbackEnd = source.indexOf('const jumpToPreviousUserMessage', callbackStart);
     const callbackSource = source.slice(callbackStart, callbackEnd);
-    const scrollAt = callbackSource.indexOf('scrollToEndProgrammatically(true);');
+    const scrollAt = callbackSource.indexOf("scrollToEndProgrammatically(true, 'explicit');");
     const verifyAt = callbackSource.indexOf('runStickToLatestVerify();');
 
     expect(callbackStart).toBeGreaterThan(-1);

--- a/apps/mobile/src/__tests__/messageListVirtualization.test.ts
+++ b/apps/mobile/src/__tests__/messageListVirtualization.test.ts
@@ -207,7 +207,7 @@ describe('mobile message list container', () => {
     )).toContain('return;');
     expect(scrollSource).toContain('shouldPreserveMobileHistoryBrowseIntent({');
     expect(scrollSource).toContain('historyBrowseIntent: userScrollForOlderRef.current');
-    expect(scrollSource).toContain('userControllingScroll: isDraggingRef.current');
+    expect(scrollSource).toContain('userControllingScroll: isDragSample');
     // 深链 / 搜索定位本身就是明确的历史浏览意图,后续近顶自动补页无需再拖一下。
     const focusEffectStart = source.indexOf('// 深链/搜索:滚到指定消息');
     const focusEffectEnd = source.indexOf('// 新消息红点', focusEffectStart);

--- a/apps/mobile/src/session/MessageRenderer.tsx
+++ b/apps/mobile/src/session/MessageRenderer.tsx
@@ -816,7 +816,7 @@ export function MessageRenderer({
   const previousFollowLatestRequestKeyRef = useRef(followLatestRequestKey);
   const previousItemKeysRef = useRef<readonly string[]>([]);
   // LegendList updates getState().scroll optimistically before an imperative native scroll lands.
-  // This sequence advances only from ScrollView onScroll and is the ack source for Android prepend.
+  // Only native ScrollView scroll/end-drag samples advance this ack source for Android prepend.
   const nativeScrollEventSequenceRef = useRef(0);
   const scrollMetricsRef = useRef<MessageScrollMetrics>({
     contentHeight: 0,
@@ -975,8 +975,6 @@ export function MessageRenderer({
   // 可能打断进行中的捏合/拖动手势(rule 7)。
   const closePayload = useCallback(() => setPayload(null), []);
   const markProgrammaticScroll = useCallback((animated: boolean) => {
-    // Native events from this command no longer belong to the preceding drag.
-    dragStartOffsetYRef.current = null;
     const generation = programmaticScrollGenerationRef.current + 1;
     const settleMs = animated
       ? MOBILE_PROGRAMMATIC_ANIMATED_SCROLL_SETTLE_MS
@@ -1196,7 +1194,7 @@ export function MessageRenderer({
         // LegendList moves getState().scroll to an imperative target before the native ScrollView
         // receives it. Using that optimistic value here used to self-confirm the correction in two
         // frames, release MVCP, and leave Android briefly rendering the target cell window at the
-        // old physical offset. Only onScroll-backed metrics can prove the viewport actually moved.
+        // old physical offset. Only native scroll/end-drag metrics prove the viewport actually moved.
         const currentOffset = scrollMetricsRef.current.offsetY;
         const pendingCorrection = currentTransaction.pendingCorrection;
         const correctionStatus = pendingCorrection
@@ -1388,7 +1386,6 @@ export function MessageRenderer({
         waitRounds,
       });
       if (action === 'settled' || action === 'give-up') {
-        dragStartOffsetYRef.current = null;
         followVerifyFrameRef.current = null;
         return;
       }
@@ -2127,11 +2124,10 @@ export function MessageRenderer({
     }
     const wasNearBottom = nearBottomRef.current;
     const scrollDelta = metrics.offsetY - previousOffsetY;
-    const hasDragOrigin = dragStartOffsetYRef.current !== null;
     if (
       nearBottomRef.current
       && shouldUnpinMobileFollowOnDrag({
-        dragging: hasDragOrigin,
+        dragging: isDraggingRef.current,
         dragStartOffsetY: dragStartOffsetYRef.current,
         metrics,
       })
@@ -2147,13 +2143,10 @@ export function MessageRenderer({
           || isMomentumScrollingRef.current
           || historyTouchStartYRef.current !== null,
       });
-      // The same cumulative dead zone owns both dragging and its trailing native events.
-      // A queued verifier alone is not evidence of user intent. Keep the drag origin until
-      // verification finishes or a new gesture/programmatic command takes ownership.
-      const preserveFollowIntent = nearBottomRef.current && (
-        historyTouchStartYRef.current !== null
-        || (!isMomentumScrollingRef.current && hasDragOrigin)
-      );
+      // Dragging (including end-drag's final native metrics) owns the cumulative dead zone.
+      // Outside a drag, layout/MVCP corrections cannot prove user intent. Preserve follow;
+      // actual momentum retains the existing direction/distance fallback.
+      const preserveFollowIntent = nearBottomRef.current && !isMomentumScrollingRef.current;
       const nearBottom = preserveHistoryBrowseIntent
         ? false
         : preserveFollowIntent || resolveMobileNearBottomOnScroll({
@@ -2192,7 +2185,6 @@ export function MessageRenderer({
     // Android may omit momentum-end when a new finger stops a fling. The new touch owns the
     // ScrollView now, so the old momentum flag must not keep a queued history request suspended.
     isMomentumScrollingRef.current = false;
-    dragStartOffsetYRef.current = null;
     historyTouchStartYRef.current = event.nativeEvent.pageY;
     historyTouchTriggeredRef.current = false;
     clearProgrammaticScroll();
@@ -2268,16 +2260,19 @@ export function MessageRenderer({
     // 「失败后停在顶部再拖一下重试」的信号会整体丢失(review P2)。
   }, [attemptAutoLoadEarlier, clearProgrammaticScroll, handoffHistoryPrependToUser]);
 
-  // 手指离开后保留本次起点：最后一帧 onScroll 可能晚于 endDrag / momentumBegin。
-  // 由既有补滚校验收尾或下一次手势/程序化滚动接管时清理。
-  const handleScrollEndDrag = useCallback(() => {
+  // 原生 endDrag 自带最终位置，不依赖最后一帧 onScroll 的投递顺序。
+  // 先结算本次拖动再清理起点，避免把后续 MVCP 布局校正误判成用户上翻。
+  const handleScrollEndDrag = useCallback((event: NativeSyntheticEvent<NativeScrollEvent>) => {
+    handleScroll(event);
     isDraggingRef.current = false;
+    dragStartOffsetYRef.current = null;
     refreshPreviousUserTarget();
     // Wait one frame so Android can report whether this drag transitioned into momentum.
     scheduleHistoryPrependUserHandoffSettle();
     scheduleQueuedLoadEarlierFlush();
     runStickToLatestVerify();
   }, [
+    handleScroll,
     refreshPreviousUserTarget,
     runStickToLatestVerify,
     scheduleHistoryPrependUserHandoffSettle,

--- a/apps/mobile/src/session/MessageRenderer.tsx
+++ b/apps/mobile/src/session/MessageRenderer.tsx
@@ -975,6 +975,8 @@ export function MessageRenderer({
   // 可能打断进行中的捏合/拖动手势(rule 7)。
   const closePayload = useCallback(() => setPayload(null), []);
   const markProgrammaticScroll = useCallback((animated: boolean) => {
+    // Native events from this command no longer belong to the preceding drag.
+    dragStartOffsetYRef.current = null;
     const generation = programmaticScrollGenerationRef.current + 1;
     const settleMs = animated
       ? MOBILE_PROGRAMMATIC_ANIMATED_SCROLL_SETTLE_MS
@@ -1386,6 +1388,7 @@ export function MessageRenderer({
         waitRounds,
       });
       if (action === 'settled' || action === 'give-up') {
+        dragStartOffsetYRef.current = null;
         followVerifyFrameRef.current = null;
         return;
       }
@@ -2124,10 +2127,11 @@ export function MessageRenderer({
     }
     const wasNearBottom = nearBottomRef.current;
     const scrollDelta = metrics.offsetY - previousOffsetY;
+    const hasDragOrigin = dragStartOffsetYRef.current !== null;
     if (
       nearBottomRef.current
       && shouldUnpinMobileFollowOnDrag({
-        dragging: isDraggingRef.current,
+        dragging: hasDragOrigin,
         dragStartOffsetY: dragStartOffsetYRef.current,
         metrics,
       })
@@ -2143,16 +2147,12 @@ export function MessageRenderer({
           || isMomentumScrollingRef.current
           || historyTouchStartYRef.current !== null,
       });
-      // The explicit drag dead zone above owns unpinning while a finger is down. After release,
-      // keep that intent until the existing verifier catches up with growth during the gesture;
-      // a tiny trailing native delta must not become an unpin merely because the tail grew far
-      // away. Momentum still uses the direction/distance fallback to recognize a real fling.
+      // The same cumulative dead zone owns both dragging and its trailing native events.
+      // A queued verifier alone is not evidence of user intent. Keep the drag origin until
+      // verification finishes or a new gesture/programmatic command takes ownership.
       const preserveFollowIntent = nearBottomRef.current && (
-        isDraggingRef.current
-        || historyTouchStartYRef.current !== null
-        || (!isMomentumScrollingRef.current && (
-          followVerifyFrameRef.current !== null || followVerifyTimerRef.current !== null
-        ))
+        historyTouchStartYRef.current !== null
+        || (!isMomentumScrollingRef.current && hasDragOrigin)
       );
       const nearBottom = preserveHistoryBrowseIntent
         ? false
@@ -2192,6 +2192,7 @@ export function MessageRenderer({
     // Android may omit momentum-end when a new finger stops a fling. The new touch owns the
     // ScrollView now, so the old momentum flag must not keep a queued history request suspended.
     isMomentumScrollingRef.current = false;
+    dragStartOffsetYRef.current = null;
     historyTouchStartYRef.current = event.nativeEvent.pageY;
     historyTouchTriggeredRef.current = false;
     clearProgrammaticScroll();
@@ -2267,11 +2268,10 @@ export function MessageRenderer({
     // 「失败后停在顶部再拖一下重试」的信号会整体丢失(review P2)。
   }, [attemptAutoLoadEarlier, clearProgrammaticScroll, handoffHistoryPrependToUser]);
 
-  // 拖动结束(手指离开,可能进入惯性滚动)→ 关闭拖动追踪。惯性阶段的上滑不需要再判
-  // 解除:上滑手势的拖动段必然已越过死区完成解除;下滑回底的恢复由 scroll 方向判定接手。
+  // 手指离开后保留本次起点：最后一帧 onScroll 可能晚于 endDrag / momentumBegin。
+  // 由既有补滚校验收尾或下一次手势/程序化滚动接管时清理。
   const handleScrollEndDrag = useCallback(() => {
     isDraggingRef.current = false;
-    dragStartOffsetYRef.current = null;
     refreshPreviousUserTarget();
     // Wait one frame so Android can report whether this drag transitioned into momentum.
     scheduleHistoryPrependUserHandoffSettle();

--- a/apps/mobile/src/session/MessageRenderer.tsx
+++ b/apps/mobile/src/session/MessageRenderer.tsx
@@ -2228,6 +2228,10 @@ export function MessageRenderer({
   ]);
 
   const handleHistoryTouchCancel = useCallback(() => {
+    // An interrupted drag may never emit endDrag. Android's normal native takeover emits
+    // touchCancel before beginDrag, so that subsequent beginDrag establishes its own ownership.
+    isDraggingRef.current = false;
+    dragStartOffsetYRef.current = null;
     historyTouchStartYRef.current = null;
     historyTouchTriggeredRef.current = false;
     scheduleHistoryPrependUserHandoffSettle();

--- a/apps/mobile/src/session/MessageRenderer.tsx
+++ b/apps/mobile/src/session/MessageRenderer.tsx
@@ -975,7 +975,6 @@ export function MessageRenderer({
   // 可能打断进行中的捏合/拖动手势(rule 7)。
   const closePayload = useCallback(() => setPayload(null), []);
   const markProgrammaticScroll = useCallback((animated: boolean) => {
-    dragStartOffsetYRef.current = null;
     const generation = programmaticScrollGenerationRef.current + 1;
     const settleMs = animated
       ? MOBILE_PROGRAMMATIC_ANIMATED_SCROLL_SETTLE_MS
@@ -1027,6 +1026,9 @@ export function MessageRenderer({
     // Automatic growth/recovery/anchor retries yield to gestures. Explicit jump/send actions
     // own their scroll even if onPress arrives before the ancestor's touchEnd clears the finger.
     if (intent === 'follow' && isUserControllingScroll()) return;
+    // Only a new explicit destination supersedes a pending final drag sample. Automatic
+    // follow and offset compensation must leave that sample available to endDrag.
+    if (intent === 'explicit') dragStartOffsetYRef.current = null;
     markProgrammaticScroll(animated);
     void listRef.current?.scrollToEnd({ animated });
   }, [isUserControllingScroll, markProgrammaticScroll]);
@@ -1037,6 +1039,7 @@ export function MessageRenderer({
   }, [markProgrammaticScroll]);
 
   const scrollToIndexProgrammatically = useCallback((index: number, viewPosition: number) => {
+    dragStartOffsetYRef.current = null;
     markProgrammaticScroll(true);
     void listRef.current?.scrollToIndex({ animated: true, index, viewPosition });
   }, [markProgrammaticScroll]);

--- a/apps/mobile/src/session/MessageRenderer.tsx
+++ b/apps/mobile/src/session/MessageRenderer.tsx
@@ -2140,9 +2140,20 @@ export function MessageRenderer({
           || isMomentumScrollingRef.current
           || historyTouchStartYRef.current !== null,
       });
+      // The explicit drag dead zone above owns unpinning while a finger is down. After release,
+      // keep that intent until the existing verifier catches up with growth during the gesture;
+      // a tiny trailing native delta must not become an unpin merely because the tail grew far
+      // away. Momentum still uses the direction/distance fallback to recognize a real fling.
+      const preserveFollowIntent = nearBottomRef.current && (
+        isDraggingRef.current
+        || historyTouchStartYRef.current !== null
+        || (!isMomentumScrollingRef.current && (
+          followVerifyFrameRef.current !== null || followVerifyTimerRef.current !== null
+        ))
+      );
       const nearBottom = preserveHistoryBrowseIntent
         ? false
-        : resolveMobileNearBottomOnScroll({
+        : preserveFollowIntent || resolveMobileNearBottomOnScroll({
           wasNearBottom: nearBottomRef.current,
           metrics,
           programmaticScrollInFlight: programmaticScrollInFlightRef.current,

--- a/apps/mobile/src/session/MessageRenderer.tsx
+++ b/apps/mobile/src/session/MessageRenderer.tsx
@@ -1013,10 +1013,19 @@ export function MessageRenderer({
     );
   }, []);
 
+  const isUserControllingScroll = useCallback(() => (
+    historyTouchStartYRef.current !== null
+    || isDraggingRef.current
+    || isMomentumScrollingRef.current
+  ), []);
+
   const scrollToEndProgrammatically = useCallback((animated: boolean) => {
+    // Guard the command itself: content growth, delayed recovery and anchor retries must all
+    // yield before the first upward scroll event has had a chance to unpin follow.
+    if (isUserControllingScroll()) return;
     markProgrammaticScroll(animated);
     void listRef.current?.scrollToEnd({ animated });
-  }, [markProgrammaticScroll]);
+  }, [isUserControllingScroll, markProgrammaticScroll]);
 
   const scrollToOffsetProgrammatically = useCallback((offset: number, animated: boolean) => {
     markProgrammaticScroll(animated);
@@ -1354,6 +1363,12 @@ export function MessageRenderer({
     }
     const step = (attempts: number, waitRounds: number) => {
       if (followVerifyGenerationRef.current !== generation) return;
+      // Release handlers restart this bounded verifier, including when the stream ends while
+      // a finger is held still. Do not poll or issue corrections during a gesture.
+      if (isUserControllingScroll()) {
+        followVerifyFrameRef.current = null;
+        return;
+      }
       // 贴底跟随意图只认 nearBottomRef:死区内轻触 / 小幅拖动并没有真实解除贴底,
       // 不能让 userScrollForOlderRef 这根“允许加载历史”的手势记录把校验永久关掉。
       // 真正上移超过死区时 shouldUnpinMobileFollowOnDrag 会把 nearBottomRef 翻 false,
@@ -1407,7 +1422,7 @@ export function MessageRenderer({
     } else {
       start();
     }
-  }, [scrollToEndProgrammatically]);
+  }, [isUserControllingScroll, scrollToEndProgrammatically]);
 
   // DEV-only:把列表控制器 + 滚动 metrics 暴露给性能 harness(临时,profiling/回归测量用)。
   useEffect(() => {
@@ -2118,7 +2133,9 @@ export function MessageRenderer({
       setIsAwayFromBottom(true);
     } else {
       const preserveHistoryBrowseIntent = shouldPreserveMobileHistoryBrowseIntent({
-        historyBrowseIntent: userScrollForOlderRef.current,
+        // Only preserve an actual unpin. A dead-zone drag also enables pagination, but its
+        // final native event must not turn a temporary follow suspension into an unpin.
+        historyBrowseIntent: userScrollForOlderRef.current && !nearBottomRef.current,
         userControllingScroll: isDraggingRef.current
           || isMomentumScrollingRef.current
           || historyTouchStartYRef.current !== null,
@@ -2163,10 +2180,11 @@ export function MessageRenderer({
     isMomentumScrollingRef.current = false;
     historyTouchStartYRef.current = event.nativeEvent.pageY;
     historyTouchTriggeredRef.current = false;
+    clearProgrammaticScroll();
     // Touch-start only means the finger holds the ScrollView; it is not a viewport takeover yet.
     // maybeTriggerHistoryTouch / onScrollBeginDrag report the real move once it clears the dead zone.
     handoffHistoryPrependToUser(false);
-  }, [handoffHistoryPrependToUser]);
+  }, [clearProgrammaticScroll, handoffHistoryPrependToUser]);
 
   const maybeTriggerHistoryTouch = useCallback((pageY: number) => {
     const startY = historyTouchStartYRef.current;
@@ -2194,8 +2212,10 @@ export function MessageRenderer({
     historyTouchTriggeredRef.current = false;
     scheduleHistoryPrependUserHandoffSettle();
     scheduleQueuedLoadEarlierFlush();
+    runStickToLatestVerify();
   }, [
     maybeTriggerHistoryTouch,
+    runStickToLatestVerify,
     scheduleHistoryPrependUserHandoffSettle,
     scheduleQueuedLoadEarlierFlush,
   ]);
@@ -2205,7 +2225,8 @@ export function MessageRenderer({
     historyTouchTriggeredRef.current = false;
     scheduleHistoryPrependUserHandoffSettle();
     scheduleQueuedLoadEarlierFlush();
-  }, [scheduleHistoryPrependUserHandoffSettle, scheduleQueuedLoadEarlierFlush]);
+    runStickToLatestVerify();
+  }, [runStickToLatestVerify, scheduleHistoryPrependUserHandoffSettle, scheduleQueuedLoadEarlierFlush]);
 
   // 用户开始拖动 → 标记「上翻意图」,放行自动加载更早(onScrollBeginDrag 仅用户手势触发,
   // 程序化 scrollToEnd 不会触发,故不会误置);同时记录拖动起点 offset,供
@@ -2230,7 +2251,7 @@ export function MessageRenderer({
     // 翻完 refs 立即补一次电平评估:列表已顶死时(Android 无 bounce 尤甚)这次拖动不产生
     // offset 变化,不会有 onScroll / onStartReached,ref 写入也不驱动 effect——没有这一刀,
     // 「失败后停在顶部再拖一下重试」的信号会整体丢失(review P2)。
-  }, [attemptAutoLoadEarlier, handoffHistoryPrependToUser]);
+  }, [attemptAutoLoadEarlier, clearProgrammaticScroll, handoffHistoryPrependToUser]);
 
   // 拖动结束(手指离开,可能进入惯性滚动)→ 关闭拖动追踪。惯性阶段的上滑不需要再判
   // 解除:上滑手势的拖动段必然已越过死区完成解除;下滑回底的恢复由 scroll 方向判定接手。
@@ -2241,8 +2262,10 @@ export function MessageRenderer({
     // Wait one frame so Android can report whether this drag transitioned into momentum.
     scheduleHistoryPrependUserHandoffSettle();
     scheduleQueuedLoadEarlierFlush();
+    runStickToLatestVerify();
   }, [
     refreshPreviousUserTarget,
+    runStickToLatestVerify,
     scheduleHistoryPrependUserHandoffSettle,
     scheduleQueuedLoadEarlierFlush,
   ]);
@@ -2256,8 +2279,10 @@ export function MessageRenderer({
     refreshPreviousUserTarget();
     scheduleHistoryPrependUserHandoffSettle();
     scheduleQueuedLoadEarlierFlush();
+    runStickToLatestVerify();
   }, [
     refreshPreviousUserTarget,
+    runStickToLatestVerify,
     scheduleHistoryPrependUserHandoffSettle,
     scheduleQueuedLoadEarlierFlush,
   ]);
@@ -2322,6 +2347,7 @@ export function MessageRenderer({
       }
       return;
     }
+    if (isUserControllingScroll()) return;
     if (nearBottomRef.current && viewportHeight > 0 && height > viewportHeight) {
       // Animated jump/send follow owns the viewport until its settle window closes. Content
       // growth during that animation only reschedules the verifier; a false-animated pin here
@@ -2366,6 +2392,7 @@ export function MessageRenderer({
       }
     }
   }, [
+    isUserControllingScroll,
     markMobileMvcpSettle,
     restoreHistoryAnchorOnce,
     runStickToLatestVerify,

--- a/apps/mobile/src/session/MessageRenderer.tsx
+++ b/apps/mobile/src/session/MessageRenderer.tsx
@@ -1019,10 +1019,13 @@ export function MessageRenderer({
     || isMomentumScrollingRef.current
   ), []);
 
-  const scrollToEndProgrammatically = useCallback((animated: boolean) => {
-    // Guard the command itself: content growth, delayed recovery and anchor retries must all
-    // yield before the first upward scroll event has had a chance to unpin follow.
-    if (isUserControllingScroll()) return;
+  const scrollToEndProgrammatically = useCallback((
+    animated: boolean,
+    intent: 'follow' | 'explicit' = 'follow',
+  ) => {
+    // Automatic growth/recovery/anchor retries yield to gestures. Explicit jump/send actions
+    // own their scroll even if onPress arrives before the ancestor's touchEnd clears the finger.
+    if (intent === 'follow' && isUserControllingScroll()) return;
     markProgrammaticScroll(animated);
     void listRef.current?.scrollToEnd({ animated });
   }, [isUserControllingScroll, markProgrammaticScroll]);
@@ -1812,7 +1815,7 @@ export function MessageRenderer({
     setIsAwayFromBottom(false);
     setHasNewMessages(false);
     setPreviousUserTarget(null);
-    scrollToEndProgrammatically(true);
+    scrollToEndProgrammatically(true, 'explicit');
     runStickToLatestVerify();
   }, [cancelHistoryPrependTransaction, runStickToLatestVerify, scrollToEndProgrammatically]);
 
@@ -1854,7 +1857,7 @@ export function MessageRenderer({
     }
     setHasNewMessages(false);
     setIsAwayFromBottom(false);
-    scrollToEndProgrammatically(true);
+    scrollToEndProgrammatically(true, 'explicit');
     runStickToLatestVerify();
   }, [
     cancelHistoryPrependTransaction,

--- a/apps/mobile/src/session/MessageRenderer.tsx
+++ b/apps/mobile/src/session/MessageRenderer.tsx
@@ -975,6 +975,7 @@ export function MessageRenderer({
   // 可能打断进行中的捏合/拖动手势(rule 7)。
   const closePayload = useCallback(() => setPayload(null), []);
   const markProgrammaticScroll = useCallback((animated: boolean) => {
+    dragStartOffsetYRef.current = null;
     const generation = programmaticScrollGenerationRef.current + 1;
     const settleMs = animated
       ? MOBILE_PROGRAMMATIC_ANIMATED_SCROLL_SETTLE_MS
@@ -2098,7 +2099,14 @@ export function MessageRenderer({
   // 「恢复跟随」走 resolveMobileNearBottomOnScroll:距离 + 明确向下方向。读历史
   // (readingOlderRef)期间禁止方向性恢复——load-earlier prepend 的 mVCP 补偿会产生
   // 程序化向下增量,短会话里会被误判成「用户滑回底部」。
-  const handleScroll = useCallback((event: NativeSyntheticEvent<NativeScrollEvent>) => {
+  const handleScroll = useCallback((
+    event: NativeSyntheticEvent<NativeScrollEvent>,
+    isFinalDragSample = false,
+  ) => {
+    // Cancellation releases ownership immediately. Only endDrag may still consume its final
+    // sample; an ordinary layout/MVCP scroll cannot use the retained origin as user intent.
+    const isDragSample = isDraggingRef.current
+      || (isFinalDragSample && dragStartOffsetYRef.current !== null);
     nativeScrollEventSequenceRef.current += 1;
     const metrics = {
       contentHeight: event.nativeEvent.contentSize.height,
@@ -2109,7 +2117,7 @@ export function MessageRenderer({
     scrollMetricsRef.current = metrics;
     if (readingOlderRef.current) {
       if (
-        isDraggingRef.current
+        isDragSample
         || isMomentumScrollingRef.current
         || historyTouchTriggeredRef.current
       ) {
@@ -2127,7 +2135,7 @@ export function MessageRenderer({
     if (
       nearBottomRef.current
       && shouldUnpinMobileFollowOnDrag({
-        dragging: isDraggingRef.current,
+        dragging: isDragSample,
         dragStartOffsetY: dragStartOffsetYRef.current,
         metrics,
       })
@@ -2139,7 +2147,7 @@ export function MessageRenderer({
         // Only preserve an actual unpin. A dead-zone drag also enables pagination, but its
         // final native event must not turn a temporary follow suspension into an unpin.
         historyBrowseIntent: userScrollForOlderRef.current && !nearBottomRef.current,
-        userControllingScroll: isDraggingRef.current
+        userControllingScroll: isDragSample
           || isMomentumScrollingRef.current
           || historyTouchStartYRef.current !== null,
       });
@@ -2231,7 +2239,6 @@ export function MessageRenderer({
     // An interrupted drag may never emit endDrag. Android's normal native takeover emits
     // touchCancel before beginDrag, so that subsequent beginDrag establishes its own ownership.
     isDraggingRef.current = false;
-    dragStartOffsetYRef.current = null;
     historyTouchStartYRef.current = null;
     historyTouchTriggeredRef.current = false;
     scheduleHistoryPrependUserHandoffSettle();
@@ -2267,7 +2274,7 @@ export function MessageRenderer({
   // 原生 endDrag 自带最终位置，不依赖最后一帧 onScroll 的投递顺序。
   // 先结算本次拖动再清理起点，避免把后续 MVCP 布局校正误判成用户上翻。
   const handleScrollEndDrag = useCallback((event: NativeSyntheticEvent<NativeScrollEvent>) => {
-    handleScroll(event);
+    handleScroll(event, true);
     isDraggingRef.current = false;
     dragStartOffsetYRef.current = null;
     refreshPreviousUserTarget();


### PR DESCRIPTION
## 这次改了什么

### 摘要

手机版流式回复持续长高时，用户刚开始上翻还没有触发解除跟随，自动滚底和延迟补滚仍可能抢占手势。现在触摸、拖动与惯性滚动期间统一暂停自动滚底；真正上翻后保持阅读位置，轻触或死区内拖动结束后补齐期间新增的内容，即使输出已停止也能恢复跟随。点击跳底或发送消息仍保留立即平滑滚到最新内容的原有行为。

### 变更类型

- [ ] `feat` 新功能
- [x] `fix` 缺陷修复
- [ ] `refactor` / `perf` 重构或性能优化
- [ ] `docs` / `test` / `chore` 文档、测试或工程维护
- [ ] 其他：

### 范围

- 关联 Issue / 需求：用户反馈手机版模型输出期间无法向上滚动聊天记录。
- 本 PR 包含：消息列表滚动所有权判断、手势结束后的有界补滚，以及事件交错回归测试。
- 明确不包含：传输协议、流式接收、原生配置和依赖修改。
- 用户可见变化：输出期间可以上翻历史；仅轻触或小幅拖动时，结束手势后继续跟随最新内容。
- 是否存在 breaking change：无。

### UI 变化

- 平台：iOS / Android 共用的消息列表交互；无样式、布局或文案变化。
- 引用的设计规范：`docs/design-rules/DESIGN.md` §14.4，直接拖动应跟手，不用自动滚动抢占手势；§10，沿用现有主题，不增加模式分支。Light / Dark 实机均未目检。
- 无真机截图或录屏；本次以生产回调的事件交错测试验证控制逻辑。

## 怎么验证的

### 自动验证

```text
pnpm --filter mobile exec vitest run src/__tests__/messageFollowGesture.test.ts src/__tests__/messageScroll.test.ts src/__tests__/messageListVirtualization.test.ts --pool=threads
结果：3 个测试文件、111 项测试通过，其中新增 38 项事件交错测试。

pnpm test:unit:related
结果：通过。

pnpm --filter mobile run --if-present typecheck
结果：通过。

pnpm test:unit（经个人工作流 run-unit-gate.sh 执行）
结果：初始提交 10135f0 的全仓单测通过，GATE_EXIT=0；本轮小修重新通过相关单测、111 项定向测试及 Mobile typecheck，未重跑全仓。本轮已无冲突 rebase 到 main 47ef43edd，相关门禁在 rebase 后通过；合并结果由 CI 验证。

pnpm check:dco
结果：8 个提交签名通过。

git diff --cached --check
结果：通过。
```

测试调用实际生产回调，模拟内容长高早于首次滚动事件、释放后尾部事件早于双帧校验、输出结束于按住期间、惯性滚动、旧校验和振荡保护恢复计时器到期、历史分页保护，以及主动跳底。新增回归覆盖跳底点击早于/晚于外层触摸结束、动画尚未落地时内容增长，以及新的上翻手势中断后续自动补滚。累计 8px 边界使用原生 endDrag 的最终位置，覆盖匹配 onScroll 迟到、惯性开始前后、同次拖动往返；布局校正用例验证 1200→1196 的轻微拖动释放后，即使原生锚点校正到 1180/900 也不会误解除。取消矩阵覆盖缺失/迟到 endDrag、已解除跟随、Android 正常接管、独立惯性和第二根手指加入。取消会立即释放拖动占用，但仍允许 endDrag 结算最终位置；覆盖最终样本晚于无操作校验、夹入布局校正、显式跳底接管，以及最终滑回底部。普通 onScroll、自动滚底与 offset 补偿不会消费取消后保留的起点；显式跳底/发送及 index 定位会清理。取消矩阵还覆盖最终样本晚于实际自动补滚，确认超过死区后不再继续跟随。

### 手工验证

已 review 完整 diff，并完成独立静态复核。

### 未执行的验证

未启动手机 App 或 Metro，未连接用户真机，未验证原生事件实际投递顺序及 Light / Dark 目检；回调测试不能替代实机验证。
分支 `dash/mobile-stream-scroll-gesture`，worktree `cindy-mobile-stream-scroll-gesture`；Metro 归属与 `__DEV__` build label 不适用，未运行开发包。

## 风险

### 风险分类

- [ ] 无已知风险
- [ ] SQLite / migration
- [ ] system prompt
- [ ] 协议兼容
- [ ] 权限 / 安全 / 用户数据
- [ ] 存量插件兼容（批准状态 / 指纹 / manifest 校验 / 安装布局 / 包格式）
- [ ] 原生层 / fingerprint / OTA
- [x] 跨平台差异
- [ ] 其他：

### 影响与回滚

- 影响范围：手机版消息列表的自动跟随和手势结束后的恢复；iOS / Android 原生手势事件时序仍需实机验证。
- 回滚 / 降级方式：回退本 PR 的 JS 修改即可；无数据迁移、原生配置或依赖变化。

### 提交前检查

- [x] 已 review 完整 diff
- [x] 每个 commit 都带 DCO 签名（`git commit -s`，见 [DCO](../DCO)）
- [x] UI 改动已在「UI 变化」注明引用的设计规范章节（不涉及 UI 则跳过）
- [x] 未提交凭证、令牌或授权文件
- [x] 已补充必要文档（本次行为与验证说明见 PR，无需新增产品规则）
- [x] 已确认测试结果或说明未执行原因
