### PR TITLE
fix(mobile): 修复图片查看器缩放复位与操作交接

### DIFF
--- a/apps/mobile/src/__tests__/imageLightboxInteraction.test.tsx
+++ b/apps/mobile/src/__tests__/imageLightboxInteraction.test.tsx
@@ -21,6 +21,7 @@ const runtime = vi.hoisted(() => ({
   values: [] as Value[],
   immediate: false,
   dimensions: { width: 400, height: 800 },
+  insets: { top: 40, bottom: 20, left: 0, right: 0 },
   gesture: null as GestureNode | null,
 }));
 
@@ -34,7 +35,7 @@ vi.mock("@/session/remoteMedia", () => ({
   isDesktopLocalMediaUrl: (uri: string) => uri.startsWith("cindy-media:"),
 }));
 vi.mock("react-native-safe-area-context", () => ({
-  useSafeAreaInsets: () => ({ top: 40, bottom: 20, left: 0, right: 0 }),
+  useSafeAreaInsets: () => runtime.insets,
 }));
 vi.mock("lucide-react-native", () => ({
   MessageSquarePlus: () => null,
@@ -183,6 +184,7 @@ beforeEach(() => {
   runtime.values = [];
   runtime.immediate = false;
   runtime.dimensions = { width: 400, height: 800 };
+  runtime.insets = { top: 40, bottom: 20, left: 0, right: 0 };
   root = createRoot(document.createElement("div"));
 });
 afterEach(() => act(() => root.unmount()));
@@ -349,14 +351,24 @@ describe("image viewer actions", () => {
     act(() => runtime.nodes.get('Image').onLoad({ nativeEvent: { source: { width: 400, height: 800 } } }));
     doubleTapAtCorner(); finishAnimations();
     runtime.dimensions = { width: 800, height: 400 };
+    runtime.insets = { top: 0, bottom: 20, left: 59, right: 0 };
     // The native dimensions hook schedules its own render; this mock uses a changed prop.
     harness.props.onClose = vi.fn();
     harness.render();
+    const chromeBounds = () => Object.assign({}, ...runtime.nodes.get('message.imageLightboxChrome').style);
+    const closeBounds = Object.assign({}, ...runtime.nodes.get('message.imageLightboxCloseButton').style);
+    expect(chromeBounds().left + closeBounds.left).toBe(75);
+    expect(chromeBounds().right).toBe(0);
     expect(transform().x).toBeCloseTo(0);
     expect(transform().y).toBe(-300);
     expect(transform().scale).toBe(2.5);
     doubleTapAtCorner(); finishAnimations();
     expect(transform()).toEqual({ x: 0, y: 0, scale: 1 });
+    runtime.insets = { top: 0, bottom: 20, left: 0, right: 59 };
+    harness.props.onClose = vi.fn();
+    harness.render();
+    expect(chromeBounds().left).toBe(0);
+    expect(chromeBounds().right).toBe(59);
   });
 
   it('includes the visible unfinished stroke and ignores drawing delivered after submit', async () => {

--- a/apps/mobile/src/__tests__/imageLightboxInteraction.test.tsx
+++ b/apps/mobile/src/__tests__/imageLightboxInteraction.test.tsx
@@ -1,0 +1,509 @@
+// @vitest-environment jsdom
+import { act, type ReactNode } from "react";
+import { createRoot, type Root } from "react-dom/client";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  ImageLightbox,
+  type ImageLightboxProps,
+} from "@/session/ImageLightbox";
+
+type Handler = (...args: any[]) => void;
+type GestureNode = {
+  kind: string;
+  options: Record<string, any>;
+  handlers: Record<string, Handler>;
+  children?: GestureNode[];
+};
+type Animation = { target: number; done?: (finished: boolean) => void };
+type Value = { value: number; animation?: Animation };
+const runtime = vi.hoisted(() => ({
+  nodes: new Map<string, any>(),
+  values: [] as Value[],
+  immediate: false,
+  dimensions: { width: 400, height: 800 },
+  gesture: null as GestureNode | null,
+}));
+
+vi.mock("expo-router", () => ({
+  useNavigation: () => ({ setOptions: () => undefined }),
+}));
+vi.mock("react-i18next", () => ({
+  useTranslation: () => ({ t: (key: string) => key }),
+}));
+vi.mock("@/session/remoteMedia", () => ({
+  isDesktopLocalMediaUrl: (uri: string) => uri.startsWith("cindy-media:"),
+}));
+vi.mock("react-native-safe-area-context", () => ({
+  useSafeAreaInsets: () => ({ top: 40, bottom: 20, left: 0, right: 0 }),
+}));
+vi.mock("lucide-react-native", () => ({
+  MessageSquarePlus: () => null,
+  Pen: () => null,
+  Share: () => null,
+  Undo2: () => null,
+  X: () => null,
+}));
+vi.mock("react-native-svg", () => ({ default: () => null, Path: () => null }));
+vi.mock("@/theme", async () => await import("@/theme/tokens"));
+vi.mock("react-native", async () => {
+  const { createElement, useImperativeHandle } = await import("react");
+  const view = (name: string) => (props: any) => {
+    runtime.nodes.set(props.testID ?? name, props);
+    return createElement("div", null, props.children as ReactNode);
+  };
+  return {
+    View: view("View"),
+    Pressable: view("Pressable"),
+    Modal: view("Modal"),
+    Text: view("Text"),
+    ActivityIndicator: view("ActivityIndicator"),
+    StatusBar: () => null,
+    Image: view("Image"),
+    Platform: { OS: "android" },
+    StyleSheet: {
+      create: (s: unknown) => s,
+      absoluteFill: {},
+      hairlineWidth: 1,
+    },
+    useWindowDimensions: () => runtime.dimensions,
+    FlatList: (props: any) => {
+      runtime.nodes.set("FlatList", props);
+      useImperativeHandle(
+        props.ref,
+        () => ({ scrollToOffset: () => undefined }),
+        [],
+      );
+      return props.renderItem({ item: props.data[0], index: 0 });
+    },
+  };
+});
+vi.mock("@/components/AppText", async () => ({
+  Text: (await import("react-native")).Text,
+}));
+vi.mock("@/platform/gestureHandler", async () => {
+  const { View } = await import("react-native");
+  const make = (kind: string) => {
+    const node: GestureNode = { kind, handlers: {}, options: {} };
+    const chain: any = new Proxy(node, {
+      get(target, key: string) {
+        if (key === "children") return target.children;
+        if (key in target) return target[key as keyof GestureNode];
+        return (value: any) => {
+          if (key.startsWith("on")) node.handlers[key] = value;
+          else node.options[key] = value;
+          return chain;
+        };
+      },
+    });
+    return chain;
+  };
+  return {
+    GestureHandlerRootView: View,
+    GestureDetector: ({
+      gesture,
+      children,
+    }: {
+      gesture: GestureNode;
+      children: ReactNode;
+    }) => {
+      runtime.gesture = gesture;
+      return children;
+    },
+    Gesture: {
+      Pan: () => make("Pan"),
+      Pinch: () => make("Pinch"),
+      Tap: () => make("Tap"),
+      Exclusive: (...children: GestureNode[]) => ({
+        kind: "Exclusive",
+        children,
+      }),
+      Simultaneous: (...children: GestureNode[]) => ({
+        kind: "Simultaneous",
+        children,
+      }),
+    },
+  };
+});
+// Execute the production handlers with real React hooks. Animations stay pending
+// until the test advances a frame, including cancellation callbacks and zero-motion completion.
+vi.mock("react-native-reanimated", async () => {
+  const { useRef } = await import("react");
+  const native = await import("react-native");
+  const cancel = (cell: Pick<Value, "animation">) => {
+    const old = cell.animation;
+    cell.animation = undefined;
+    old?.done?.(false);
+  };
+  const timing = (
+    target: number,
+    _config?: unknown,
+    done?: Animation["done"],
+  ) => ({ target, done });
+  return {
+    default: { View: native.View, Image: native.Image },
+    useSharedValue: (initial: number) => {
+      const ref = useRef<Value | null>(null);
+      if (!ref.current) {
+        let current = initial;
+        const cell = {
+          get value() {
+            return current;
+          },
+          set value(next: number | Animation) {
+            cancel(cell);
+            if (typeof next === "number") current = next;
+            else if (runtime.immediate) {
+              current = next.target;
+              next.done?.(true);
+            } else cell.animation = next;
+          },
+          animation: undefined as Animation | undefined,
+        };
+        ref.current = cell as Value;
+        runtime.values.push(ref.current);
+      }
+      return ref.current;
+    },
+    useAnimatedStyle: (calculate: () => unknown) => ({
+      get current() {
+        return calculate();
+      },
+    }),
+    runOnJS: (fn: Handler) => fn,
+    cancelAnimation: cancel,
+    withTiming: timing,
+    withSpring: timing,
+  };
+});
+
+let root: Root;
+beforeEach(() => {
+  Object.assign(globalThis, { IS_REACT_ACT_ENVIRONMENT: true });
+  runtime.nodes.clear();
+  runtime.values = [];
+  runtime.immediate = false;
+  runtime.dimensions = { width: 400, height: 800 };
+  root = createRoot(document.createElement("div"));
+});
+afterEach(() => act(() => root.unmount()));
+
+function mount(overrides: Partial<ImageLightboxProps> = {}) {
+  const image = {
+    key: "one",
+    url: "https://example.invalid/image.png",
+    title: "Image",
+    subtitle: "",
+    payload: {
+      kind: "media",
+      media: {
+        kind: "image",
+        url: "https://example.invalid/image.png",
+        previewable: true,
+      },
+    },
+  } as ImageLightboxProps["images"][number];
+  const props: ImageLightboxProps = {
+    images: [image, { ...image, key: "two" }],
+    initialUrl: image.url,
+    onClose: vi.fn(),
+    ...overrides,
+  };
+  const render = () => act(() => root.render(<ImageLightbox {...props} />));
+  render();
+  return { props, render };
+}
+function gestures(node = runtime.gesture!): GestureNode[] {
+  return node.children ? node.children.flatMap(gestures) : [node];
+}
+const doubleTap = () =>
+  gestures().find((g) => g.kind === "Tap" && g.options.numberOfTaps === 2)!;
+const pan = () =>
+  gestures().find((g) => g.kind === "Pan" && "minPointers" in g.options)!;
+const pinch = () => gestures().find((g) => g.kind === "Pinch")!;
+function fire(gesture: GestureNode, name: string, event = {}, success = true) {
+  act(() => gesture.handlers[name]?.(event, success));
+}
+function finishAnimations() {
+  act(() => {
+    for (const cell of runtime.values) {
+      const animation = cell.animation;
+      if (!animation) continue;
+      cell.animation = undefined;
+      cell.value = animation.target;
+      animation.done?.(true);
+    }
+  });
+}
+function transform() {
+  const style = runtime.nodes.get("Image").style[1].current;
+  return {
+    x: style.transform[0].translateX,
+    y: style.transform[1].translateY,
+    scale: style.transform[4].scale,
+  };
+}
+const press = (id: string) =>
+  act(() => runtime.nodes.get(id).onPress({ stopPropagation: vi.fn() }));
+const doubleTapAtCorner = () => fire(doubleTap(), "onEnd", { x: 330, y: 650 });
+
+describe("image viewer gesture lifecycle", () => {
+  it.each(["before", "after"])(
+    "recenters when an unactivated pan finalizes %s the second double tap",
+    (order) => {
+      mount();
+      doubleTapAtCorner();
+      finishAnimations();
+      expect(transform()).toEqual({ x: -195, y: -375, scale: 2.5 });
+      if (order === "before") fire(pan(), "onFinalize", {}, false);
+      doubleTapAtCorner();
+      if (order === "after") fire(pan(), "onFinalize", {}, false);
+      expect(runtime.nodes.get("FlatList").scrollEnabled).toBe(false);
+      finishAnimations();
+      expect(transform()).toEqual({ x: 0, y: 0, scale: 1 });
+      expect(runtime.nodes.get("FlatList").scrollEnabled).toBe(true);
+    },
+  );
+
+  it("rapid double taps toggle the animation destination even before the first frame", () => {
+    mount();
+    doubleTapAtCorner();
+    doubleTapAtCorner();
+    finishAnimations();
+    expect(transform()).toEqual({ x: 0, y: 0, scale: 1 });
+  });
+
+  it.each(["pan", "pinch"])(
+    "%s takes over all transform animations at the visible frame",
+    (kind) => {
+      mount();
+      doubleTapAtCorner();
+      finishAnimations();
+      doubleTapAtCorner();
+      // Move halfway through the pending zoom-out without completing its callbacks.
+      const moving = runtime.values.filter((v) => v.animation);
+      for (const cell of moving) {
+        const animation = cell.animation!;
+        cell.animation = undefined;
+        const half = (cell.value + animation.target) / 2;
+        cell.value = half;
+        cell.animation = animation;
+      }
+      const gesture = kind === "pan" ? pan() : pinch();
+      fire(gesture, "onStart", { focalX: 200, focalY: 400 });
+      if (kind === "pan")
+        fire(gesture, "onChange", { changeX: 20, changeY: 10 });
+      else fire(gesture, "onChange", { focalX: 200, focalY: 400, scale: 1.2 });
+      fire(gesture, "onFinalize");
+      const takenOver = transform();
+      finishAnimations();
+      expect(transform()).toEqual(takenOver);
+      expect(transform().scale).toBeGreaterThan(1);
+      expect(runtime.nodes.get("FlatList").scrollEnabled).toBe(false);
+    },
+  );
+
+  it("supports immediate animation completion for reduced motion", () => {
+    runtime.immediate = true;
+    mount();
+    doubleTapAtCorner();
+    expect(transform()).toEqual({ x: -195, y: -375, scale: 2.5 });
+    doubleTapAtCorner();
+    expect(transform()).toEqual({ x: 0, y: 0, scale: 1 });
+  });
+
+  it("reclamps an in-flight zoom when a landscape image finishes loading", () => {
+    mount();
+    doubleTapAtCorner();
+    act(() =>
+      runtime.nodes
+        .get("Image")
+        .onLoad({ nativeEvent: { source: { width: 1600, height: 900 } } }),
+    );
+    finishAnimations();
+    expect(transform().y).toBe(0);
+    expect(transform().x).toBe(-195);
+  });
+
+  it("does not accept dragging as the second tap", () => {
+    mount();
+    expect(doubleTap().options.maxDistance).toBe(12);
+    fire(doubleTap(), "onEnd", { x: 330, y: 650 }, false);
+    finishAnimations();
+    expect(transform()).toEqual({ x: 0, y: 0, scale: 1 });
+  });
+});
+
+describe("image viewer actions", () => {
+  it('keeps gestures stable when a parent replaces only its close callback', () => {
+    const harness = mount();
+    const originalGesture = runtime.gesture;
+    harness.props.onClose = vi.fn();
+    harness.render();
+    expect(runtime.gesture).toBe(originalGesture);
+    press('message.imageLightboxCloseButton');
+    expect(harness.props.onClose).toHaveBeenCalledTimes(1);
+  });
+
+  it('reclamps zoom after rotation and still returns to the centered image', () => {
+    const harness = mount();
+    act(() => runtime.nodes.get('Image').onLoad({ nativeEvent: { source: { width: 400, height: 800 } } }));
+    doubleTapAtCorner(); finishAnimations();
+    runtime.dimensions = { width: 800, height: 400 };
+    // The native dimensions hook schedules its own render; this mock uses a changed prop.
+    harness.props.onClose = vi.fn();
+    harness.render();
+    expect(transform().x).toBeCloseTo(0);
+    expect(transform().y).toBe(-300);
+    expect(transform().scale).toBe(2.5);
+    doubleTapAtCorner(); finishAnimations();
+    expect(transform()).toEqual({ x: 0, y: 0, scale: 1 });
+  });
+
+  it('includes the visible unfinished stroke and ignores drawing delivered after submit', async () => {
+    let complete!: () => void;
+    const onSubmit = vi.fn(() => new Promise<void>((resolve) => { complete = resolve; }));
+    mount({ annotation: { submitLabel: 'Send', onSubmit } });
+    act(() => runtime.nodes.get('Image').onLoad({ nativeEvent: { source: { width: 400, height: 800 } } }));
+    press('message.imageLightboxAnnotateButton');
+    const draw = gestures().find(g => g.kind === 'Pan' && g.options.minDistance === 0)!;
+    fire(draw, 'onStart', { x: 100, y: 200 });
+    press('message.imageLightboxAnnotationSubmit');
+    fire(draw, 'onUpdate', { x: 300, y: 600 });
+    fire(draw, 'onFinalize');
+    await act(async () => { await Promise.resolve(); });
+    expect(onSubmit.mock.calls[0]).toEqual(expect.arrayContaining([
+      [{ points: [{ x: 0.25, y: 0.25 }] }],
+    ]));
+    await act(async () => { complete(); });
+  });
+
+  it('preserves the unfinished stroke when submission fails and drawing resumes', async () => {
+    let reject!: (error: Error) => void;
+    const onSubmit = vi.fn(() => new Promise<void>((_resolve, fail) => { reject = fail; }));
+    mount({ annotation: { submitLabel: 'Send', onSubmit } });
+    act(() => runtime.nodes.get('Image').onLoad({ nativeEvent: { source: { width: 400, height: 800 } } }));
+    press('message.imageLightboxAnnotateButton');
+    const draw = () => gestures().find(g => g.kind === 'Pan' && g.options.minDistance === 0)!;
+    fire(draw(), 'onStart', { x: 100, y: 200 });
+    press('message.imageLightboxAnnotationSubmit');
+    fire(draw(), 'onFinalize');
+    await act(async () => { await Promise.resolve(); });
+    await act(async () => { reject(new Error('offline')); });
+    fire(draw(), 'onStart', { x: 300, y: 600 });
+    fire(draw(), 'onFinalize');
+    press('message.imageLightboxAnnotationSubmit');
+    await act(async () => { await Promise.resolve(); });
+    expect(onSubmit.mock.calls[1]).toEqual(expect.arrayContaining([
+      [{ points: [{ x: 0.25, y: 0.25 }] }, { points: [{ x: 0.75, y: 0.75 }] }],
+    ]));
+    await act(async () => { reject(new Error('offline')); });
+  });
+
+  it("offers an accessible close while zoomed and handles accessibility escape", () => {
+    const { props } = mount();
+    doubleTapAtCorner();
+    finishAnimations();
+    expect(
+      runtime.nodes.get("message.imageLightboxCloseButton").accessibilityRole,
+    ).toBe("button");
+    press("message.imageLightboxCloseButton");
+    act(() =>
+      runtime.nodes.get("message.imageLightbox").onAccessibilityEscape(),
+    );
+    expect(props.onClose).toHaveBeenCalledTimes(2);
+  });
+
+  it("retries a direct image in place after a native load failure", () => {
+    const { props } = mount();
+    act(() => runtime.nodes.get("Image").onError());
+    expect(runtime.nodes.has("message.imageLightboxRetryButton")).toBe(true);
+    press("message.imageLightboxRetryButton");
+    act(() =>
+      runtime.nodes
+        .get("Image")
+        .onLoad({ nativeEvent: { source: { width: 400, height: 800 } } }),
+    );
+    expect(props.onClose).not.toHaveBeenCalled();
+    expect(runtime.nodes.get("Image").source.uri).toBe(props.initialUrl);
+  });
+
+  it("deduplicates sharing and restores its button after rejection", async () => {
+    let reject!: (error: Error) => void;
+    const onShareImage = vi.fn(
+      () =>
+        new Promise<void>((_resolve, fail) => {
+          reject = fail;
+        }),
+    );
+    mount({ onShareImage });
+    press("message.imageLightboxShareButton");
+    press("message.imageLightboxShareButton");
+    await act(async () => {
+      await Promise.resolve();
+    });
+    expect(onShareImage).toHaveBeenCalledTimes(1);
+    expect(runtime.nodes.get("message.imageLightboxShareButton").disabled).toBe(
+      true,
+    );
+    await act(async () => {
+      reject(new Error("offline"));
+    });
+    expect(runtime.nodes.get("message.imageLightboxShareButton").disabled).toBe(
+      false,
+    );
+  });
+
+  it.each([false, true])(
+    "freezes gestures and closing during submission (annotating=%s)",
+    async (annotating) => {
+      let complete!: () => void;
+      const onSubmit = vi.fn(
+        () =>
+          new Promise<void>((resolve) => {
+            complete = resolve;
+          }),
+      );
+      const { props } = mount({
+        annotation: { allowDirectSubmit: true, submitLabel: "Send", onSubmit },
+      });
+      if (annotating) press("message.imageLightboxAnnotateButton");
+      const submitId = annotating
+        ? "message.imageLightboxAnnotationSubmit"
+        : "message.imageLightboxSendToChatButton";
+      press(submitId);
+      press(submitId);
+      await act(async () => {
+        await Promise.resolve();
+      });
+      expect(onSubmit).toHaveBeenCalledTimes(1);
+      expect(gestures().every((g) => g.options.enabled === false)).toBe(true);
+      expect(runtime.nodes.get("FlatList").scrollEnabled).toBe(false);
+      act(() => runtime.nodes.get("Modal").onRequestClose());
+      expect(props.onClose).not.toHaveBeenCalled();
+      await act(async () => {
+        complete();
+      });
+      expect(props.onClose).toHaveBeenCalledTimes(1);
+    },
+  );
+
+  it("recovers from a synchronously throwing submit callback", async () => {
+    mount({
+      annotation: {
+        allowDirectSubmit: true,
+        submitLabel: "Send",
+        onSubmit: () => {
+          throw new Error("offline");
+        },
+      },
+    });
+    press("message.imageLightboxSendToChatButton");
+    await act(async () => {
+      await Promise.resolve();
+    });
+    expect(
+      runtime.nodes.get("message.imageLightboxSendToChatButton").disabled,
+    ).toBe(false);
+    expect(runtime.nodes.get("FlatList").scrollEnabled).toBe(true);
+  });
+});

--- a/apps/mobile/src/session/ImageLightbox.tsx
+++ b/apps/mobile/src/session/ImageLightbox.tsx
@@ -563,7 +563,14 @@ export const ImageLightbox = memo(function ImageLightbox({
         />
         <Animated.View
           pointerEvents={chromeInteractive ? 'box-none' : 'none'}
-          style={[styles.chrome, chromeStyle, { paddingBottom: insets.bottom + 16, paddingTop: insets.top + 8 }]}
+          // 整个操作层避开横屏两侧切口,让关闭、文件标题和所有底栏共用安全边界。
+          style={[styles.chrome, chromeStyle, {
+            left: insets.left,
+            right: insets.right,
+            paddingBottom: insets.bottom + 16,
+            paddingTop: insets.top + 8,
+          }]}
+          testID="message.imageLightboxChrome"
         >
           {!isAnnotating && !showFileHeader ? (
             <Pressable

--- a/apps/mobile/src/session/ImageLightbox.tsx
+++ b/apps/mobile/src/session/ImageLightbox.tsx
@@ -7,7 +7,7 @@
  *   - 1x 下竖直下滑跟手关闭(位移 + 背景渐隐),横滑翻会话内图片集
  *   - 放大后单指只平移;单击不关(双击缩回,或先回到 1x 再单击/下滑)
  *   - 捏合/平移期间 chrome 让位(不抢触摸),结束后恢复
- *   - chrome 极简:右下系统分享、多图时顶部页码;无关闭按钮(单击 / 下滑即关)、无文件名无正文
+ *   - chrome 极简:顶部关闭与多图页码,底部标注/发送/分享;关闭同时支持读屏返回
  * 手势判定全部走 imageLightboxModel.ts 纯函数;取件复用会话屏的队列 + 磁盘缓存
  * (onResolveRemoteMedia),点开时通常已被列表缩略图取过、秒出。
  * 仅图片走本组件;video / audio / 文件仍走 MessagePayloadModal。
@@ -33,6 +33,7 @@ import Svg, { Path } from 'react-native-svg';
 import { fontWeight, iconSize, iconStroke, motionDuration, radius, typeScale } from '@/theme';
 import { Gesture, GestureDetector, GestureHandlerRootView } from '@/platform/gestureHandler';
 import Animated, {
+  cancelAnimation,
   runOnJS,
   useAnimatedStyle,
   useSharedValue,
@@ -201,6 +202,11 @@ export const ImageLightbox = memo(function ImageLightbox({
   // ---- 圈点标注状态(仅活跃页;笔迹归一化存储,显示/烧录共用同一映射)----
   const [isAnnotating, setIsAnnotating] = useState(false);
   const [annotationSubmitting, setAnnotationSubmitting] = useState(false);
+  const submittingRef = useRef(false);
+  const sharingRef = useRef(false);
+  const [sharing, setSharing] = useState(false);
+  const onCloseRef = useRef(onClose);
+  onCloseRef.current = onClose;
   const [strokes, setStrokes] = useState<AnnotationStroke[]>([]);
   const [draftStroke, setDraftStroke] = useState<AnnotationStroke | null>(null);
   /** url → 图片自然尺寸(LightboxPage onLoad 上报;overlay 与坐标换算的基准)。 */
@@ -243,6 +249,7 @@ export const ImageLightbox = memo(function ImageLightbox({
     translateY: number,
     scale: number,
   ) => {
+    if (submittingRef.current) return;
     if (phase === 'end') {
       const draft = draftStrokeRef.current;
       draftStrokeRef.current = null;
@@ -408,11 +415,23 @@ export const ImageLightbox = memo(function ImageLightbox({
   const shareVisible = !!onShareImage && !!activeImage && canShareLightboxImage(activeUri);
 
   const handleShare = useCallback(() => {
-    if (!activeImage || !activeUri || !onShareImage) return;
+    if (!activeImage || !activeUri || !onShareImage || sharingRef.current || submittingRef.current) return;
     const state = resolveMap[activeImage.url];
     const mimeType = state?.status === 'ready' ? state.media.mimeType : undefined;
     const sizeBytes = state?.status === 'ready' ? state.media.size : undefined;
-    void onShareImage(activeImage.payload.media, activeUri, mimeType, sizeBytes);
+    sharingRef.current = true;
+    setSharing(true);
+    void Promise.resolve()
+      .then(() =>
+        onShareImage(activeImage.payload.media, activeUri, mimeType, sizeBytes),
+      )
+      .catch(() => {
+        // 与标注提交一致,宿主负责显示具体分享错误。
+      })
+      .finally(() => {
+        sharingRef.current = false;
+        setSharing(false);
+      });
   }, [activeImage, activeUri, onShareImage, resolveMap]);
 
   // 活跃页 mime(取件结果优先,兜底 uri 后缀):gif / svg 不开放画笔(烧录只留首帧)。
@@ -430,32 +449,42 @@ export const ImageLightbox = memo(function ImageLightbox({
   const directSubmitVisible = !!annotation?.allowDirectSubmit && !!activeImage && !!activeUri;
 
   const handleSubmitAnnotation = useCallback(() => {
-    if (!annotation || !activeImage || !activeUri || annotationSubmitting) return;
+    if (!annotation || !activeImage || !activeUri || submittingRef.current || sharingRef.current) return;
+    submittingRef.current = true;
     setAnnotationSubmitting(true);
-    void Promise.resolve(
-      annotation.onSubmit(activeImage, activeUri, strokes.map((s) => ({ points: [...s.points] })), {
+    // 点击提交时另一根手指可能还在画,把屏幕上最后一笔也纳入同一快照。
+    const visibleStrokes = draftStrokeRef.current ? [...strokes, draftStrokeRef.current] : strokes;
+    // 提交期间会忽略抬手回调,先收存草稿,失败后继续画也不会覆盖这一笔。
+    setStrokes(visibleStrokes);
+    draftStrokeRef.current = null;
+    setDraftStroke(null);
+    const submittedStrokes = visibleStrokes.map((s) => ({ points: [...s.points] }));
+    void Promise.resolve()
+      .then(() => annotation.onSubmit(activeImage, activeUri, submittedStrokes, {
         mimeType: activeMimeType,
-      }),
-    )
-      .then(() => onClose())
+      }))
+      .then(() => onCloseRef.current())
       .catch(() => {
         // 宿主已提示错误;停留在标注模式让用户重试或放弃。
       })
-      .finally(() => setAnnotationSubmitting(false));
-  }, [annotation, activeImage, activeUri, activeMimeType, annotationSubmitting, strokes, onClose]);
+      .finally(() => {
+        submittingRef.current = false;
+        setAnnotationSubmitting(false);
+      });
+  }, [annotation, activeImage, activeUri, activeMimeType, strokes]);
 
   // Android 物理返回键触发 Modal.onRequestClose,不受手势层/按钮层的
   // isAnnotating 禁用覆盖(review 发现:会绕开"标注模式中关闭均禁用"保护
   // 直接整体关闭 lightbox,未保存笔迹丢失)。标注中改为退出标注模式,
   // 提交中忽略返回键,非标注态才走原始关闭。
   const handleRequestClose = useCallback(() => {
-    if (annotationSubmitting) return;
+    if (submittingRef.current) return;
     if (isAnnotating) {
       exitAnnotationMode();
       return;
     }
-    onClose();
-  }, [annotationSubmitting, isAnnotating, exitAnnotationMode, onClose]);
+    onCloseRef.current();
+  }, [isAnnotating, exitAnnotationMode]);
 
   // iOS 沉浸式隐藏状态栏:经宿主屏的 screen option 走 VC-based 通道(iOS 27 起
   // RN StatusBar 全局 API 失效;transparent Modal 不接管状态栏,穿透到宿主屏)。
@@ -480,7 +509,11 @@ export const ImageLightbox = memo(function ImageLightbox({
       visible
     >
       {Platform.OS === 'android' ? <StatusBar hidden /> : null}
-      <GestureHandlerRootView style={styles.root} testID="message.imageLightbox">
+      <GestureHandlerRootView
+        onAccessibilityEscape={handleRequestClose}
+        style={styles.root}
+        testID="message.imageLightbox"
+      >
         <Animated.View pointerEvents="none" style={[styles.backdrop, backdropStyle]} />
         <FlatList
           data={images}
@@ -509,12 +542,13 @@ export const ImageLightbox = memo(function ImageLightbox({
               dismissY={dismissY}
               height={height}
               image={item}
+              interactionDisabled={annotationSubmitting || index !== activeIndex}
               naturalSize={naturalSizes[item.key] ?? null}
               onChromeBusy={handleChromeBusy}
               onDrawPoint={handleDrawPoint}
               onImageError={handleImageLoadError}
               onNaturalSize={handleNaturalSize}
-              onRequestClose={onClose}
+              onRequestClose={handleRequestClose}
               onRetry={handleRetryPage}
               onZoomChange={setZoomed}
               previewUri={previewUriFor(item)}
@@ -523,7 +557,7 @@ export const ImageLightbox = memo(function ImageLightbox({
               width={width}
             />
           )}
-          scrollEnabled={!zoomed && !isAnnotating && images.length > 1}
+          scrollEnabled={!zoomed && !isAnnotating && !annotationSubmitting && images.length > 1}
           showsHorizontalScrollIndicator={false}
           windowSize={3}
         />
@@ -531,6 +565,18 @@ export const ImageLightbox = memo(function ImageLightbox({
           pointerEvents={chromeInteractive ? 'box-none' : 'none'}
           style={[styles.chrome, chromeStyle, { paddingBottom: insets.bottom + 16, paddingTop: insets.top + 8 }]}
         >
+          {!isAnnotating && !showFileHeader ? (
+            <Pressable
+              accessibilityLabel={t('message.lightbox.closeImage')}
+              accessibilityRole="button"
+              disabled={annotationSubmitting}
+              onPress={handleRequestClose}
+              style={[styles.closeButton, { top: insets.top + 8 }]}
+              testID="message.imageLightboxCloseButton"
+            >
+              <X color="#ffffff" size={iconSize.action} strokeWidth={iconStroke.regular} />
+            </Pressable>
+          ) : null}
           {isAnnotating ? (
             // 标注模式 chrome(对齐桌面):底部工具栏切换为 取消 / 撤销 / 提交
             // 三项;翻页/下滑/单击关闭均已在手势层禁用,页码与分享隐藏。
@@ -581,7 +627,10 @@ export const ImageLightbox = memo(function ImageLightbox({
             </View>
           ) : showFileHeader ? (
             <View pointerEvents="box-none" style={styles.fileHeader}>
-              <Pressable accessibilityLabel={t('message.lightbox.done')} hitSlop={10} onPress={onClose} testID="message.imageLightboxDone">
+              <Pressable accessibilityLabel={t('message.lightbox.done')}
+                accessibilityRole="button"
+                disabled={annotationSubmitting}
+                hitSlop={10} onPress={handleRequestClose} testID="message.imageLightboxDone">
                 <Text style={styles.fileHeaderDone}>{t('message.lightbox.done')}</Text>
               </Pressable>
               <View pointerEvents="none" style={styles.fileHeaderTitleCol}>
@@ -595,11 +644,16 @@ export const ImageLightbox = memo(function ImageLightbox({
               {shareVisible ? (
                 <Pressable
                   accessibilityLabel={t('message.lightbox.shareImage')}
+                  accessibilityRole="button"
+                  accessibilityState={{ busy: sharing }}
+                  disabled={sharing || annotationSubmitting}
                   hitSlop={10}
                   onPress={handleShare}
                   testID="message.imageLightboxShareButton"
                 >
-                  <ShareIcon color="#ffffff" size={iconSize.action} strokeWidth={iconStroke.regular} />
+                  {sharing ? (
+                    <ActivityIndicator color="#ffffff" size="small" />
+                  ) : <ShareIcon color="#ffffff" size={iconSize.action} strokeWidth={iconStroke.regular} />}
                 </Pressable>
               ) : (
                 <View style={styles.fileHeaderShareSpacer} />
@@ -614,6 +668,7 @@ export const ImageLightbox = memo(function ImageLightbox({
                 {annotateVisible ? (
                   <Pressable
                     accessibilityLabel={t('message.lightbox.annotateImage')}
+                    disabled={annotationSubmitting || sharing}
                     hitSlop={8}
                     onPress={() => setIsAnnotating(true)}
                     style={styles.actionItem}
@@ -626,6 +681,7 @@ export const ImageLightbox = memo(function ImageLightbox({
                 {extraActions.map((action) => (
                   <Pressable
                     accessibilityLabel={action.label}
+                    disabled={annotationSubmitting || sharing}
                     hitSlop={8}
                     key={action.key}
                     onPress={() => activeImage && action.onPress(activeImage)}
@@ -639,13 +695,22 @@ export const ImageLightbox = memo(function ImageLightbox({
                 {shareVisible && !showFileHeader ? (
                   <Pressable
                     accessibilityLabel={t('message.lightbox.shareImage')}
+                    accessibilityRole="button"
+                    accessibilityState={{ busy: sharing }}
+                    disabled={sharing || annotationSubmitting}
                     hitSlop={8}
                     onPress={handleShare}
                     style={styles.actionItem}
                     testID="message.imageLightboxShareButton"
                   >
-                    <ShareIcon color="#ffffff" size={iconSize.action} strokeWidth={iconStroke.regular} />
-                    <Text style={styles.actionLabel}>{t('message.lightbox.exportShare')}</Text>
+                    {sharing ? (
+                      <ActivityIndicator color="#ffffff" size="small" />
+                    ) : (
+                      <ShareIcon color="#ffffff" size={iconSize.action} strokeWidth={iconStroke.regular} />
+                    )}
+                    <Text style={styles.actionLabel}>
+                      {t('message.lightbox.exportShare')}
+                    </Text>
                   </Pressable>
                 ) : null}
               </View>
@@ -659,19 +724,22 @@ export const ImageLightbox = memo(function ImageLightbox({
                 {annotateVisible ? (
                   <Pressable
                     accessibilityLabel={t('message.lightbox.annotateImage')}
+                    disabled={annotationSubmitting || sharing}
                     hitSlop={8}
                     onPress={() => setIsAnnotating(true)}
                     style={styles.actionItem}
                     testID="message.imageLightboxAnnotateButton"
                   >
                     <Pen color="#ffffff" size={iconSize.action} strokeWidth={iconStroke.regular} />
-                    <Text style={styles.actionLabel}>{t('message.lightbox.annotate')}</Text>
+                    <Text style={styles.actionLabel}>
+                      {t('message.lightbox.annotate')}
+                    </Text>
                   </Pressable>
                 ) : null}
                 {directSubmitVisible ? (
                   <Pressable
                     accessibilityLabel={annotation?.submitLabel ?? t('message.lightbox.sendToChat')}
-                    disabled={annotationSubmitting}
+                    disabled={annotationSubmitting || sharing}
                     hitSlop={8}
                     onPress={handleSubmitAnnotation}
                     style={styles.actionItem}
@@ -682,7 +750,9 @@ export const ImageLightbox = memo(function ImageLightbox({
                     ) : (
                       <MessageSquarePlus color="#ffffff" size={iconSize.action} strokeWidth={iconStroke.regular} />
                     )}
-                    <Text style={styles.actionLabel}>{annotation?.submitLabel ?? t('message.lightbox.sendToChat')}</Text>
+                    <Text style={styles.actionLabel}>
+                      {annotation?.submitLabel ?? t('message.lightbox.sendToChat')}
+                    </Text>
                   </Pressable>
                 ) : null}
                 {shareVisible && (annotateVisible || directSubmitVisible) ? (
@@ -691,13 +761,22 @@ export const ImageLightbox = memo(function ImageLightbox({
                 {shareVisible ? (
                   <Pressable
                     accessibilityLabel={t('message.lightbox.shareImage')}
+                    accessibilityRole="button"
+                    accessibilityState={{ busy: sharing }}
+                    disabled={sharing || annotationSubmitting}
                     hitSlop={8}
                     onPress={handleShare}
                     style={styles.actionItem}
                     testID="message.imageLightboxShareButton"
                   >
-                    <ShareIcon color="#ffffff" size={iconSize.action} strokeWidth={iconStroke.regular} />
-                    <Text style={styles.actionLabel}>{t('message.lightbox.exportShare')}</Text>
+                    {sharing ? (
+                      <ActivityIndicator color="#ffffff" size="small" />
+                    ) : (
+                      <ShareIcon color="#ffffff" size={iconSize.action} strokeWidth={iconStroke.regular} />
+                    )}
+                    <Text style={styles.actionLabel}>
+                      {t('message.lightbox.exportShare')}
+                    </Text>
                   </Pressable>
                 ) : null}
               </View>
@@ -722,6 +801,7 @@ const LightboxPage = memo(function LightboxPage({
   dismissY,
   height,
   image,
+  interactionDisabled,
   naturalSize,
   onChromeBusy,
   onDrawPoint,
@@ -736,6 +816,7 @@ const LightboxPage = memo(function LightboxPage({
   width,
 }: {
   active: boolean;
+  interactionDisabled: boolean;
   /** 标注模式(仅活跃页):单指作画、禁单击/下滑关闭与双击缩放,双指仍可缩放平移。 */
   annotating: boolean;
   /** 进行中的一笔(仅活跃页非空)。 */
@@ -804,11 +885,11 @@ const LightboxPage = memo(function LightboxPage({
   /**
    * 已确证 onError 的原图地址(同样存地址,换图 / 重取换 url 天然失效)。
    * 桌面取件图有 forceRefresh 自愈 + 重试按钮兜底,失败终态由父层的 resolveMap 接管;
-   * 直连 http 图两者都没有,必须在本页给失败终态,否则会永远转圈谎报"还在加载"。
+   * 直连 http 图在本页落失败态,用户重试时清除此标记并重新挂载 Image。
    */
   const [failedFullUri, setFailedFullUri] = useState<string | null>(null);
   const media = image.payload.media;
-  // 可重取 = 桌面取件图:失败有 forceRefresh 自愈与重试按钮。直连 http / data 图两者皆无。
+  // 桌面取件图可 forceRefresh;直连图重试只重新挂载原 URI,不走桌面取件。
   const retryable = !media.previewable && isDesktopLocalMediaUrl(media.url);
   const layers = lightboxImageLayers({
     fullUri: uri,
@@ -888,6 +969,14 @@ const LightboxPage = memo(function LightboxPage({
   }, [active]);
 
   const gesture = useMemo(() => {
+    // 新手势接管当前帧,必须同时停掉缩放与两轴位移,避免旧动画继续推着图片走。
+    const stopTransformAnimation = () => {
+      'worklet';
+      doubleTapBusy.value = 0;
+      cancelAnimation(scale);
+      cancelAnimation(translateX);
+      cancelAnimation(translateY);
+    };
     const hideChrome = () => {
       'worklet';
       chromeHidden.value = withTiming(1, { duration: motionDuration.instant });
@@ -928,9 +1017,10 @@ const LightboxPage = memo(function LightboxPage({
     // 焦点捏合:起点锁定 origin,缩放绕焦点;浏览态跟手质心,标注态只改 scale
     // (平移交给双指 pan,避免 Simultaneous 下位移被加两遍)。
     const pinch = Gesture.Pinch()
+      .enabled(!interactionDisabled)
       .onStart((event) => {
         pinchBusy.value = 1;
-        doubleTapBusy.value = 0;
+        stopTransformAnimation();
         hideChrome();
         // 捏合一开始就锁死翻页,不等 JS zoomed 提交;否则松手后立刻左右拖
         // 会被 pagingEnabled 的 FlatList 抢走,当前页直接滑走。
@@ -977,6 +1067,7 @@ const LightboxPage = memo(function LightboxPage({
     // 浏览:单指平移,未放大时 fail,避免与 pinch 抢 2 指。
     // 标注:恰好双指平移,1x 也可挪视野。
     const panZoomed = Gesture.Pan()
+      .enabled(!interactionDisabled)
       .minPointers(annotating ? 2 : 1)
       .maxPointers(annotating ? 2 : 1)
       .onTouchesDown((_event, state) => {
@@ -984,7 +1075,7 @@ const LightboxPage = memo(function LightboxPage({
       })
       .onStart(() => {
         panBusy.value = 1;
-        doubleTapBusy.value = 0;
+        stopTransformAnimation();
         hideChrome();
         savedTranslateX.value = translateX.value;
         savedTranslateY.value = translateY.value;
@@ -1007,15 +1098,19 @@ const LightboxPage = memo(function LightboxPage({
         translateY.value = next.y;
       })
       .onFinalize(() => {
+        // Tap 也会让未激活的 Pan 走 FAILED → finalize。它不拥有位移,
+        // 不能把双击缩回的 saved=0 覆盖成动画中途的旧偏移。
+        if (!panBusy.value) return;
         savedTranslateX.value = translateX.value;
         savedTranslateY.value = translateY.value;
-        if (!panBusy.value) return;
         panBusy.value = 0;
+        if (!pinchBusy.value)
+          runOnJS(reportZoomed)(isLightboxZoomed(scale.value));
         maybeShowChrome();
       });
 
     const panDismiss = Gesture.Pan()
-      .enabled(!annotating)
+      .enabled(!annotating && !interactionDisabled)
       .maxPointers(1)
       .onTouchesDown((_event, state) => {
         if (isLightboxZoomed(scale.value)) state.fail();
@@ -1054,13 +1149,19 @@ const LightboxPage = memo(function LightboxPage({
       });
 
     const doubleTap = Gesture.Tap()
-      .enabled(!annotating)
+      .enabled(!annotating && !interactionDisabled)
       .numberOfTaps(2)
+      .maxDistance(LIGHTBOX_TAP_MAX_DISTANCE)
       .onEnd((event, success) => {
-        if (!success) return;
-        const next = nextDoubleTapScale(scale.value);
+        if (!success || pinchBusy.value || panBusy.value) return;
+        const next = nextDoubleTapScale(
+          doubleTapBusy.value ? savedScale.value : scale.value,
+        );
+        stopTransformAnimation();
         originX.value = 0;
         originY.value = 0;
+        dragY.value = 0;
+        dismissY.value = 0;
         doubleTapBusy.value = 1;
         const clearDoubleTapBusy = (finished?: boolean) => {
           'worklet';
@@ -1069,15 +1170,16 @@ const LightboxPage = memo(function LightboxPage({
           // 尺寸变化只改过 saved:与 scale 同一拍结束时把 live 收到新 contain 边界。
           translateX.value = savedTranslateX.value;
           translateY.value = savedTranslateY.value;
+          runOnJS(reportZoomed)(isLightboxZoomed(savedScale.value));
         };
         if (!isLightboxZoomed(next)) {
-          scale.value = withTiming(1);
           savedScale.value = 1;
-          translateX.value = withTiming(0);
-          translateY.value = withTiming(0, undefined, clearDoubleTapBusy);
           savedTranslateX.value = 0;
           savedTranslateY.value = 0;
-          runOnJS(reportZoomed)(false);
+          // 动画完成前继续锁住翻页;减少动态效果下回调可同步执行,先写目标。
+          scale.value = withTiming(1);
+          translateX.value = withTiming(0);
+          translateY.value = withTiming(0, undefined, clearDoubleTapBusy);
           return;
         }
         const tx = clampLightboxTranslation(
@@ -1092,17 +1194,17 @@ const LightboxPage = memo(function LightboxPage({
           next,
           displayedH.value,
         );
-        scale.value = withTiming(next);
         savedScale.value = next;
-        translateX.value = withTiming(tx);
-        translateY.value = withTiming(ty, undefined, clearDoubleTapBusy);
         savedTranslateX.value = tx;
         savedTranslateY.value = ty;
         runOnJS(reportZoomed)(true);
+        scale.value = withTiming(next);
+        translateX.value = withTiming(tx);
+        translateY.value = withTiming(ty, undefined, clearDoubleTapBusy);
       });
 
     const singleTap = Gesture.Tap()
-      .enabled(!annotating)
+      .enabled(!annotating && !interactionDisabled)
       .numberOfTaps(1)
       .maxDistance(LIGHTBOX_TAP_MAX_DISTANCE)
       .onEnd((_event, success) => {
@@ -1112,7 +1214,7 @@ const LightboxPage = memo(function LightboxPage({
     // 画笔:单指跟手采点(worklet 只搬运坐标 + transform 快照,归一化在 JS 侧
     // 纯函数完成);第二根手指落下时本手势自然结束,已画的半笔照常落笔。
     const panDraw = Gesture.Pan()
-      .enabled(annotating)
+      .enabled(annotating && !interactionDisabled)
       .maxPointers(1)
       .minDistance(0)
       .onStart((event) => {
@@ -1135,7 +1237,16 @@ const LightboxPage = memo(function LightboxPage({
     // 共享值引用恒定,只有布尔开关与尺寸变化需要重建手势。不再把 zoomed
     // 放进 deps:捏合结束改 React 状态会整图重建手势图,正是卡顿来源。
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [annotating, width, height, onRequestClose, reportZoomed, onDrawPoint, onChromeBusy]);
+  }, [
+    annotating,
+    interactionDisabled,
+    width,
+    height,
+    onRequestClose,
+    reportZoomed,
+    onDrawPoint,
+    onChromeBusy,
+  ]);
 
   const imageStyle = useAnimatedStyle(() => ({
     transform: [
@@ -1170,7 +1281,7 @@ const LightboxPage = memo(function LightboxPage({
 
   return (
     <View style={{ height, width }}>
-      {uri ? (
+      {uri && !layers.showFailure ? (
         <GestureDetector gesture={gesture}>
           <Animated.View collapsable={false} style={styles.pageFill}>
             {/*
@@ -1195,9 +1306,7 @@ const LightboxPage = memo(function LightboxPage({
             ) : null}
             <Animated.Image
               // 两条失败路径都要接:可重取的图交父层做一次 forceRefresh 自愈(再失败
-              // 落父层 error 态给重试按钮);直连图没有任何重取入口,只能在本页记下
-              // "这个地址确证没有像素",由 lightboxImageLayers 给失败终态——否则会
-              // 一直转圈谎报"还在加载"(此前是一直纯黑)。
+              // 落父层 error 态给重试按钮);直连图在本页落失败态,提供原地重试。
               onError={() => {
                 setFailedFullUri(uri);
                 if (onImageError && retryable) onImageError(image);
@@ -1219,12 +1328,6 @@ const LightboxPage = memo(function LightboxPage({
             {layers.showSpinner ? (
               <View pointerEvents="none" style={styles.pageSpinnerLayer}>
                 <ActivityIndicator color="#ffffff" testID="message.imageLightboxLoading" />
-              </View>
-            ) : null}
-            {/* 直连图加载失败:没有重取入口,给失败终态而不是永远转圈。单击关闭仍由手势层接管。 */}
-            {layers.showFailure ? (
-              <View pointerEvents="none" style={styles.pageSpinnerLayer}>
-                <Text style={styles.stateText}>{t('message.lightbox.loadFailed')}</Text>
               </View>
             ) : null}
             {overlayVisible ? (
@@ -1283,17 +1386,33 @@ const LightboxPage = memo(function LightboxPage({
           onPress={onRequestClose}
           style={[styles.pageFill, styles.pageCenter]}
         >
-          {resolveState?.status === 'error' || resolvedUnsupported || (!retryable && !media.previewable) ? (
+          {layers.showFailure ||
+          resolveState?.status === 'error' ||
+          resolvedUnsupported ||
+          (!retryable && !media.previewable) ? (
             <>
-              <Text style={styles.stateText}>{t('message.lightbox.loadFailed')}</Text>
-              {retryable ? (
+              <Text style={styles.stateText}>
+                {t('message.lightbox.loadFailed')}
+              </Text>
+              {retryable || layers.showFailure ? (
                 <Pressable
                   accessibilityLabel={t('message.lightbox.retryLoadImage')}
-                  onPress={() => onRetry(image)}
+                  accessibilityRole="button"
+                  onPress={(event) => {
+                    event.stopPropagation();
+                    if (retryable) onRetry(image);
+                    else {
+                      // 清掉失败态后重新挂载 Image,原 URI 原地重试,不改签名 URL。
+                      setFailedFullUri(null);
+                      setLoadedUri(null);
+                    }
+                  }}
                   style={styles.retryButton}
                   testID="message.imageLightboxRetryButton"
                 >
-                  <Text style={styles.retryText}>{t('message.lightbox.retry')}</Text>
+                  <Text style={styles.retryText}>
+                    {t('message.lightbox.retry')}
+                  </Text>
                 </Pressable>
               ) : null}
             </>
@@ -1329,6 +1448,16 @@ const styles = StyleSheet.create({
   root: { flex: 1 },
   backdrop: { backgroundColor: '#000000', ...absoluteFill },
   chrome: { ...absoluteFill, alignItems: 'center' },
+  closeButton: {
+    alignItems: 'center',
+    backgroundColor: 'rgba(0, 0, 0, 0.6)',
+    borderRadius: radius.pill,
+    height: 48,
+    justifyContent: 'center',
+    left: 16,
+    position: 'absolute',
+    width: 48,
+  },
   pageFill: { flex: 1, height: '100%', width: '100%' },
   pageCenter: { alignItems: 'center', gap: 16, justifyContent: 'center' },
   // 垫底缩略图 / 转圈都脱离 flex 流:与原图同为 flex 子节点会被各分一半高度。
@@ -1353,6 +1482,7 @@ const styles = StyleSheet.create({
   fileHeaderShareSpacer: { width: 20 },
   actionBar: {
     alignItems: 'center',
+    paddingHorizontal: 16,
     left: 0,
     position: 'absolute',
     right: 0,
@@ -1366,12 +1496,26 @@ const styles = StyleSheet.create({
     borderRadius: radius.pill, // 胶囊语义用 pill(RN 截半)
     borderWidth: StyleSheet.hairlineWidth,
     flexDirection: 'row',
-    gap: 24,
-    paddingHorizontal: 22,
+    flexWrap: 'wrap',
+    justifyContent: 'center',
+    maxWidth: '100%',
+    gap: 16,
+    paddingHorizontal: 16,
     paddingVertical: 9,
   },
-  actionItem: { alignItems: 'center', gap: 4, justifyContent: 'flex-start', minWidth: 56 },
-  actionLabel: { color: 'rgba(255,255,255,0.72)', fontSize: typeScale.micro },
+  actionItem: {
+    alignItems: 'center',
+    flexShrink: 1,
+    gap: 4,
+    justifyContent: 'center',
+    minHeight: 48,
+    minWidth: 48,
+  },
+  actionLabel: {
+    color: 'rgba(255,255,255,0.72)',
+    fontSize: typeScale.micro,
+    textAlign: 'center',
+  },
   actionDivider: {
     backgroundColor: 'rgba(255, 255, 255, 0.25)',
     height: 22,


### PR DESCRIPTION
## 这次改了什么

### 摘要

手机版图片双击放大后再次双击，倍率虽然回到 1 倍，图片却可能偏到角落。原因是没有激活的拖动手势也会执行结束回调，把旧偏移覆盖到缩小动画的目标位置；现在只有真正开始的拖动可以保存位移，缩小后恢复居中。

同时补齐同一个查看器中的操作交接：连续双击切换动画目标，拖动和捏合接管时停止旧动画；增加可访问的关闭按钮及读屏返回；发送标注期间冻结绘制、分页与退出，保留提交瞬间可见的最后一笔，发送失败后继续画也不会丢失；分享防重复点击并显示等待状态；直连图片失败后可原地重试，底栏支持窄屏和长文案换行。

### 变更类型

- [x] `fix` 缺陷修复

### 范围

- 关联 Issue / 需求：用户报告手机版图片第二次双击不能正常缩小，并要求检查图片查看体验。
- 本 PR 包含：共用 `ImageLightbox` 及实际执行手势回调的 18 个交互回归用例；覆盖聊天、附件和文件浏览入口。
- 明确不包含：服务端、媒体存储协议、原生依赖或配置改动。
- 用户可见变化：缩小恢复居中；缩放中接续手势更稳定；提供显式关闭、加载失败重试和提交／分享等待反馈。
- 是否存在 breaking change：无。

### UI 变化

- 引用的设计规范：`docs/design-rules/DESIGN.md` §10 Light / Dark Dual-Mode Delivery Gate、§14.4 Motion & Transitions，以及 `apps/mobile/docs/mobile-design-guide.md` 的安全区与触控尺寸约束。沿用查看器既有常黑媒体语境和共享 motion token；新增关闭及底栏按钮至少 48×48；整个操作层统一避开顶部、底部与横屏左右安全区，限制底栏宽度并允许长文案换行。
- iOS / Android 共用实现；截图和录屏尚未采集，未将代码检查视作两种主题的实机验证。

## 怎么验证的

### 自动验证

```text
pnpm --filter mobile exec vitest run src/__tests__/imageLightboxInteraction.test.tsx src/__tests__/imageLightboxModel.test.ts src/__tests__/imageAnnotationModel.test.ts src/__tests__/messageMediaThumbnailWiring.test.ts src/__tests__/filePreviewPagerWiring.test.ts
结果：5 个文件、103 个用例通过。

pnpm test:unit
结果：全仓单测通过（统一 gate runner，exit 0）；最后补充的标注失败恢复改动随后重跑以下相关测试。

pnpm test:unit:related
结果：通过；横屏安全区修复后重新执行，旋转回归覆盖左侧与右侧切口。

pnpm --filter mobile run --if-present typecheck
pnpm check:dco
git diff --check
结果：通过。

node apps/mobile/scripts/ci-fingerprint.mjs compute --output <report>
结果：改动前后 iOS / Android 指纹一致。
iOS: 96e76c9f4cb4fd4c990fb09e631e8ab42d61583e
Android: 20a7dee6fb588f451c59b37deec3faf7e37a8b41
```

已做反向验证：临时恢复原来的 Pan finalize 回写顺序，回归测试失败，得到 `scale=1, x=-195, y=-375`；恢复修复后通过。

### 手工验证

已审查查看器与各入口代码、完整 diff。未启动模拟器或真机进行触摸、VoiceOver、系统分享单及视觉验证。

### 未执行的验证

- iOS / Android 真机及模拟器、Light / Dark 目检和大字体实际布局，仍需设备验收。
- 本地分支 `dash/mobile-image-viewer-gestures`，独立 worktree `cindy-mobile-image-viewer-gestures`；未启动该 worktree 的 Metro，因此没有 Metro 归属或 `__DEV__` build label 运行证据。

## 风险

### 风险分类

- [x] 跨平台差异
- [x] 其他：原生手势识别顺序、屏幕旋转和系统分享单的设备体验尚未实测。

### 影响与回滚

- 影响范围：Mobile 共用图片查看器。仅 JS 改动，原生指纹不变，存量插件影响：无。
- 状态约束：双击动画拥有缩放与位移目标，真实拖动／捏合接管时取消旧动画，未激活手势不写目标；提交与分享分别保持单次在途，同步 ref 防重复，React 状态展示等待，成功／拒绝／同步异常均结束等待。提交期间忽略迟到的绘制与关闭；原地重试由用户显式触发，不新增自动重试循环。
- 回滚 / 降级方式：回退本 PR 的两个文件即可恢复旧查看器；不涉及数据库、持久数据或原生迁移。

### 提交前检查

- [x] 已 review 完整 diff
- [x] 每个 commit 都带 DCO 签名（`git commit -s`，见 [DCO](../DCO)）
- [x] UI 改动已在「UI 变化」注明引用的设计规范章节
- [x] 未提交凭证、令牌或授权文件
- [x] 已补充必要文档（行为约束与回归原因记录在组件注释及本说明）
- [x] 已确认测试结果或说明未执行原因
