### PR TITLE
fix(desktop): 未登录时账户菜单显示登录

### DIFF
--- a/apps/desktop/src/renderer/__tests__/userInfoSectionHover.test.ts
+++ b/apps/desktop/src/renderer/__tests__/userInfoSectionHover.test.ts
@@ -228,7 +228,7 @@ describe('UserInfoSection — inner main button no longer owns hover background'
     expect(source).not.toContain('useLogout');
     expect(source).not.toContain('<LogOut');
     expect(source).toContain("mode === 'local'");
-    expect(source.indexOf("t('sidebar.user.menuAddAccount')")).toBeLessThan(
+    expect(source.indexOf("t('login.signIn')")).toBeLessThan(
       source.indexOf("t('sidebar.user.menuSettings')"),
     );
     expect(source).not.toContain('AccountSwitcherDialog');

--- a/apps/desktop/src/renderer/__tests__/userInfoSectionMobileDownload.test.tsx
+++ b/apps/desktop/src/renderer/__tests__/userInfoSectionMobileDownload.test.tsx
@@ -275,7 +275,7 @@ describe('UserInfoSection mobile download entry', () => {
     expect(screen.queryByRole('menuitem', { name: /Cindy user/ })).toBeNull();
   });
 
-  it('keeps the add-account entry before Settings when the user is not signed in', async () => {
+  it('keeps the sign-in entry before Settings when the user is not signed in', async () => {
     authState.user = null;
     authState.mode = 'local';
 
@@ -285,16 +285,16 @@ describe('UserInfoSection mobile download entry', () => {
       ctrlKey: false,
     });
 
-    const addAccount = await screen.findByRole('menuitem', {
-      name: 'sidebar.user.menuAddAccount',
+    const signIn = await screen.findByRole('menuitem', {
+      name: 'login.signIn',
     });
     const settings = screen.getByRole('menuitem', { name: 'sidebar.user.menuSettings' });
-    expect(addAccount.compareDocumentPosition(settings) & Node.DOCUMENT_POSITION_FOLLOWING).toBe(
+    expect(signIn.compareDocumentPosition(settings) & Node.DOCUMENT_POSITION_FOLLOWING).toBe(
       Node.DOCUMENT_POSITION_FOLLOWING,
     );
     expect(listAccounts).not.toHaveBeenCalled();
 
-    fireEvent.click(addAccount);
+    fireEvent.click(signIn);
     await waitFor(() =>
       expect(navigate).toHaveBeenCalledWith('/add-account', { state: { returnTo: '/' } }),
     );

--- a/apps/desktop/src/renderer/components/sidebar/UserInfoSection.tsx
+++ b/apps/desktop/src/renderer/components/sidebar/UserInfoSection.tsx
@@ -284,7 +284,7 @@ export function UserInfoSection({ isCollapsed, onOpenUpdateNotice }: UserInfoSec
         {mode === 'local' ? (
           <DropdownMenuItem onSelect={() => void openAddAccount()} className="gap-2.5">
             <UserPlus className="h-4 w-4" aria-hidden="true" />
-            {t('sidebar.user.menuAddAccount')}
+            {t('login.signIn')}
           </DropdownMenuItem>
         ) : null}
         <DropdownMenuItem onSelect={openSettings} className="gap-2.5">


### PR DESCRIPTION
## 这次改了什么

### 摘要

未登录时，桌面侧边栏账户菜单误显示“登录更多账号”。改为复用已有五语 `login.signIn` 文案，简体中文显示“登录”。

### 变更类型

- [ ] `feat` 新功能
- [x] `fix` 缺陷修复
- [ ] `refactor` / `perf` 重构或性能优化
- [ ] `docs` / `test` / `chore` 文档、测试或工程维护
- [ ] 其他：

### 范围

- 关联 Issue / 需求：用户反馈未登录账户菜单文案不准确。
- 本 PR 包含：替换未登录菜单项的翻译 key，并同步现有测试断言。
- 明确不包含：登录流程、账号切换逻辑及已登录状态的添加账号入口。
- 用户可见变化：未登录时显示“登录”。
- 是否存在 breaking change：无。

### UI 变化

Desktop 侧边栏账户菜单：“登录更多账号” → “登录”。复用现有五语翻译、菜单与主题样式。

- 引用的设计规范：`docs/design-rules/DESIGN.md` §10 Theme System & Token Reference、§11 Voice & Content；沿用现有 Light/Dark 语义样式，使用与当前登录状态一致的简洁动作文案。

## 怎么验证的

### 自动验证

以下检查均通过，复用本次改动完成后且代码未再变化的结果：

```text
pnpm test:unit:related
pnpm --filter desktop run --if-present typecheck
pnpm --filter desktop exec prettier --check src/renderer/components/sidebar/UserInfoSection.tsx src/renderer/__tests__/userInfoSectionMobileDownload.test.tsx src/renderer/__tests__/userInfoSectionHover.test.ts
pnpm check:i18n
pnpm check:i18n-glossary
git diff --check
pnpm check:dco
```

相关测试覆盖未登录菜单项、菜单顺序及点击后仍进入原登录流程。国际化检查仅有存量非阻断警告。

### 手工验证

已检查完整 diff 和五语 `login.signIn` 翻译。

### 未执行的验证

未启动 Desktop 做 Light/Dark 实机目检或截图；本次只替换已有翻译 key，不改布局或样式。未跑全量单测，由 CI 执行。

## 风险

### 风险分类

- [x] 无已知风险
- [ ] SQLite / migration
- [ ] system prompt
- [ ] 协议兼容
- [ ] 权限 / 安全 / 用户数据
- [ ] 存量插件兼容（批准状态 / 指纹 / manifest 校验 / 安装布局 / 包格式）
- [ ] 原生层 / fingerprint / OTA
- [ ] 跨平台差异
- [ ] 其他：

### 影响与回滚

- 影响范围：Desktop 未登录时的账户菜单文案。
- 回滚 / 降级方式：还原本次翻译 key 与测试断言即可。

### 提交前检查

- [x] 已 review 完整 diff
- [x] 每个 commit 都带 DCO 签名（`git commit -s`，见 [DCO](../DCO)）
- [x] UI 改动已在「UI 变化」注明引用的设计规范章节（不涉及 UI 则跳过）
- [x] 未提交凭证、令牌或授权文件
- [x] 已补充必要文档（本次无需额外文档）
- [x] 已确认测试结果或说明未执行原因
