### PR TITLE
fix(dev): 防止普通启动继承 Terminal 的 smoke 开关

### DIFF
--- a/scripts/__tests__/restart-desktop-remote.test.mjs
+++ b/scripts/__tests__/restart-desktop-remote.test.mjs
@@ -909,7 +909,7 @@ test("devEnvPrefix passes XDT_LOGIN_SCENARIO and VITE_SPLASH_PHASE_FIXTURE throu
 	);
 	assert.equal(
 		prefix,
-		"XDT_LOGIN_SCENARIO='error:verify-code:INVALID_CODE' VITE_SPLASH_PHASE_FIXTURE='spawn_failed' ",
+		"XDT_LOGIN_SCENARIO='error:verify-code:INVALID_CODE' VITE_SPLASH_PHASE_FIXTURE='spawn_failed' CINDY_CUA_SMOKE='0' ",
 	);
 });
 
@@ -930,12 +930,30 @@ test("devEnvPrefix passes harness envs through on Windows cmd with quote strippi
 	);
 	assert.equal(
 		prefix,
-		'set "XDT_LOGIN_SCENARIO=providers:both" && set "VITE_SPLASH_PHASE_FIXTURE=updating" && ',
+		'set "XDT_LOGIN_SCENARIO=providers:both" && set "VITE_SPLASH_PHASE_FIXTURE=updating" && set "CINDY_CUA_SMOKE=0" && ',
 	);
 });
 
+test("devEnvPrefix overrides a stale Computer Use smoke flag in the target shell", () => {
+	for (const value of [undefined, "", "0", "1"]) {
+		const env = value === undefined ? {} : { CINDY_CUA_SMOKE: value };
+		const node = process.platform === "win32" ? "%CINDY_TEST_NODE%" : "$CINDY_TEST_NODE";
+		const result = spawnSync(
+			`${devEnvPrefix(env)}"${node}" -p "process.env.CINDY_CUA_SMOKE"`,
+			{
+				shell: true,
+				env: { ...process.env, CINDY_CUA_SMOKE: "1", CINDY_TEST_NODE: process.execPath },
+				encoding: "utf8",
+				timeout: 5000,
+			},
+		);
+		assert.equal(result.status, 0, result.stderr);
+		assert.equal(result.stdout.trim(), value === "1" ? "1" : "0", `caller value: ${value}`);
+	}
+});
+
 test("devEnvPrefix omits harness envs when unset (whitelist stays opt-in)", () => {
-	assert.equal(devEnvPrefix({}, "darwin"), "");
+	assert.equal(devEnvPrefix({}, "darwin"), "CINDY_CUA_SMOKE='0' ");
 });
 
 test("devEnvPrefix passes the explicit isolated OAuth write escape hatch", () => {
@@ -949,7 +967,7 @@ test("devEnvPrefix passes the explicit isolated OAuth write escape hatch", () =>
 			"darwin",
 		),
 		"XDT_ISOLATED_AUTH='1' XDT_ALLOW_DEV_OAUTH_WRITE='1' " +
-			"XDT_ISOLATED_AUTH_PROOF='proof-nonce' ",
+			"XDT_ISOLATED_AUTH_PROOF='proof-nonce' CINDY_CUA_SMOKE='0' ",
 	);
 });
 
@@ -964,7 +982,7 @@ test("devEnvPrefix passes explicit model catalog test controls to Desktop", () =
 	);
 	assert.equal(
 		prefix,
-		"XDT_MODELS_URL='http://127.0.0.1:43181/api/model-catalog/catalog' " +
+		"CINDY_CUA_SMOKE='0' XDT_MODELS_URL='http://127.0.0.1:43181/api/model-catalog/catalog' " +
 			"XDT_MODELS_PATH='/tmp/model catalog.json' XDT_DISABLE_MODELS_FETCH='1' ",
 	);
 });
@@ -978,7 +996,7 @@ test("devEnvPrefix passes native iOS dev switches to Electron", () => {
 			},
 			"darwin",
 		),
-		"CINDY_IOS_SIMULATOR_NATIVE_H264='1' CINDY_IOS_SIMULATOR_NATIVE_HID='1' ",
+		"CINDY_CUA_SMOKE='0' CINDY_IOS_SIMULATOR_NATIVE_H264='1' CINDY_IOS_SIMULATOR_NATIVE_HID='1' ",
 	);
 });
 

--- a/scripts/restart-desktop-remote.mjs
+++ b/scripts/restart-desktop-remote.mjs
@@ -877,7 +877,9 @@ export function devEnvPrefix(env = process.env, platform = process.platform) {
     ['XDT_ISOLATED_AUTH_PROOF', env.XDT_ISOLATED_AUTH_PROOF],
     // CDP 端口覆写(bootstrap-electron 消费): 并行多开沙箱时给后起实例换端口。
     ['XDT_CDP_PORT', env.XDT_CDP_PORT],
-    ['CINDY_CUA_SMOKE', env.CINDY_CUA_SMOKE],
+    // A long-lived Terminal can retain a previous smoke run's environment.
+    // Override its value even when this invocation did not request the smoke.
+    ['CINDY_CUA_SMOKE', env.CINDY_CUA_SMOKE === '1' ? '1' : '0'],
     // 一次性 Grok wire 归因探针(dev-only;正常环境不设置,不产生额外日志)。
     ['XDT_WIRE_DIAGNOSTICS', env.XDT_WIRE_DIAGNOSTICS],
     // 一次性 Grok strict tool spike(dev-only;必须与 wire probe 一起显式开启)。
@@ -902,7 +904,6 @@ export function devEnvPrefix(env = process.env, platform = process.platform) {
     // 插件存储启动边界的 dev 黑盒验收：仅显式临时结果路径时启用。
     ['XDT_PLUGIN_STORAGE_SMOKE_RESULT_FILE', env.XDT_PLUGIN_STORAGE_SMOKE_RESULT_FILE],
   ].filter(([, value]) => value);
-  if (envEntries.length === 0) return '';
 
   if (platform === 'win32') {
     return envEntries


### PR DESCRIPTION
## 这次改了什么

### 摘要

普通开发启动没有设置 `CINDY_CUA_SMOKE` 时，长期运行的 Terminal 仍可能保留先前测试留下的 `1`，导致再次弹出 Computer Use 回归窗口。启动命令现在总是覆盖该变量：调用方明确传 `1` 才开启，其余情况传 `0`。

### 变更类型

- [x] `fix` 缺陷修复

### 范围

- 关联 Issue / 需求：开发版普通启动意外弹出 Computer Use smoke 窗口。
- 本 PR 包含：修正系统终端启动命令的变量传递；增加一条实际 shell 环境污染回归，覆盖未设置、空值、`0`、`1`。
- 明确不包含：远程桌面功能、其他启动变量及 Terminal 全局配置。
- 用户可见变化：普通启动不再受 Terminal 残留测试开关影响；显式测试命令继续可用。
- 是否存在 breaking change：无。

### UI 变化

不涉及 UI 代码、布局或文案修改。

- 引用的设计规范：不涉及。

## 怎么验证的

### 自动验证

```text
node --test --test-name-pattern='stale Computer Use smoke' scripts/__tests__/restart-desktop-remote.test.mjs
结果：修复前回归失败（未设置时实际仍为 1），修复后随下列测试集通过。

node --test scripts/__tests__/restart-desktop-remote.test.mjs
结果：69 项通过。

pnpm test:unit:related
结果：通过；test:runner 504 项通过、1 项既有跳过，无受影响 workspace 单测。

pnpm --filter cindy run --if-present typecheck
结果：成功；根 package 没有 typecheck 脚本，自动跳过。

pnpm check:dco
结果：1 个提交签名通过。

git diff --check
结果：通过。
```

### 手工验证

macOS 查因时核对了实际启动命令、进程环境与新建临时 Terminal tab：命令未传测试开关，子进程仍收到 `1`。修复后的实际 shell 传值由回归测试验证，测试不启动 Electron 或 Computer Use 驱动。

### 未执行的验证

未重新启动完整 Desktop，以免打断正在使用的开发实例；未在 Windows 实机运行。Windows 命令生成断言已通过，回归用例按宿主平台选择 shell。

## 风险

### 风险分类

- [x] 跨平台差异

### 影响与回滚

- 影响范围：系统终端启动命令中的 Computer Use smoke 标记；不改变正式包、已保存偏好或其他环境变量。
- 回滚 / 降级方式：回退本提交；临时需要明确关闭测试时可在启动命令中传 `CINDY_CUA_SMOKE=0`。

### 提交前检查

- [x] 已 review 完整 diff
- [x] 每个 commit 都带 DCO 签名（`git commit -s`）
- [x] UI 改动已注明设计规范（不涉及 UI）
- [x] 未提交凭证、令牌或授权文件
- [x] 已补充必要文档（现有显式 smoke 启动说明仍有效，无需改动）
- [x] 已确认测试结果或说明未执行原因
