### PR TITLE
fix(voice-input): 修复跨音频块重采样的异常零值

### DIFF
--- a/apps/desktop/src/renderer/voice-input/WebMicAudioEngine.ts
+++ b/apps/desktop/src/renderer/voice-input/WebMicAudioEngine.ts
@@ -1029,6 +1029,7 @@ export class WebMicAudioEngine {
   private sink?: GainNode;
   private pending: number[] = [];
   private carry = 0;
+  private previousSample = 0;
   private chunkIndex = 0;
   private trackCleanup: Array<() => void> = [];
   private watchdogId?: number;
@@ -1356,6 +1357,7 @@ export class WebMicAudioEngine {
     this.context = undefined;
     this.pending = [];
     this.carry = 0;
+    this.previousSample = 0;
   }
 
   async drainBufferedAudio(): Promise<void> {
@@ -1628,6 +1630,7 @@ export class WebMicAudioEngine {
   }
 
   private resample(input: Float32Array, fromRate: number, toRate: number): number[] {
+    if (input.length === 0) return [];
     if (fromRate === toRate) return Array.from(input);
 
     const ratio = fromRate / toRate;
@@ -1638,11 +1641,14 @@ export class WebMicAudioEngine {
       const left = Math.floor(sourceIndex);
       const right = Math.min(left + 1, input.length - 1);
       const fraction = sourceIndex - left;
-      output.push(input[left] + (input[right] - input[left]) * fraction);
+      // Match the worklet: negative carry refers to the previous block's tail.
+      const leftSample = left < 0 ? this.previousSample : input[left];
+      output.push(leftSample + (input[right] - leftSample) * fraction);
       sourceIndex += ratio;
     }
 
     this.carry = sourceIndex - input.length;
+    this.previousSample = input[input.length - 1];
     return output;
   }
 }

--- a/apps/desktop/src/renderer/voice-input/__tests__/audioResampling.test.ts
+++ b/apps/desktop/src/renderer/voice-input/__tests__/audioResampling.test.ts
@@ -1,0 +1,142 @@
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+import vm from 'node:vm';
+
+import { describe, expect, it, vi } from 'vitest';
+
+import { WebMicAudioEngine } from '../WebMicAudioEngine';
+
+vi.mock('../audioContextPool', () => ({ PCM16K_WORKLET_NAME: 'pcm16k-worklet' }));
+
+type Capture = {
+  output: number[];
+  feed: (input: Float32Array) => void;
+  drain: () => Promise<void>;
+  reset: () => Promise<void>;
+};
+
+function createWorkletCapture(rate: number): Capture {
+  const output: number[] = [];
+  type Processor = {
+    port: { onmessage: (event: { data: Record<string, unknown> }) => void };
+    process: (inputs: Float32Array[][]) => void;
+  };
+  let ProcessorClass: (new () => Processor) | undefined;
+  vm.runInNewContext(
+    readFileSync(join(process.cwd(), 'src/renderer/voice-input/pcm16k-worklet.js'), 'utf8'),
+    {
+      AudioWorkletProcessor: class {
+        port = {
+          onmessage: null,
+          postMessage: (message: { type: string; pcm16k?: ArrayBuffer }) => {
+            if (message.type === 'pcm16k') output.push(...new Int16Array(message.pcm16k!));
+          },
+        };
+      },
+      currentTime: 0,
+      sampleRate: rate,
+      registerProcessor: (_name: string, cls: new () => Processor) => {
+        ProcessorClass = cls;
+      },
+    },
+  );
+  if (!ProcessorClass) throw new Error('Worklet was not registered');
+  const processor = new ProcessorClass();
+  const send = (data: Record<string, unknown>): void => processor.port.onmessage({ data });
+  return {
+    output,
+    feed: (input) => processor.process([[input]]),
+    drain: async () => {
+      send({ type: 'flush', flushId: 1 });
+    },
+    reset: async () => {
+      send({ type: 'setActive', active: true, reset: true });
+    },
+  };
+}
+
+function createFallbackCapture(rate: number): Capture {
+  const output: number[] = [];
+  const engine = new WebMicAudioEngine({ workletUrl: '', chunkMs: 40 });
+  engine.onPcm16k(({ pcm16k }) => output.push(...new Int16Array(pcm16k)));
+  // Feed the same boundary as ScriptProcessorNode. No device or browser is needed.
+  const fallback = engine as unknown as {
+    handleInputFrame: (input: Float32Array, sourceRate: number) => void;
+  };
+  return {
+    output,
+    feed: (input) => fallback.handleInputFrame(input, rate),
+    drain: () => engine.drainBufferedAudio(),
+    reset: () => engine.stop(),
+  };
+}
+
+function feedChunks(capture: Capture, input: Float32Array, sizes: number[]): void {
+  let block = 0;
+  for (let offset = 0; offset < input.length; block++) {
+    const end = Math.min(input.length, offset + sizes[block % sizes.length]);
+    capture.feed(input.subarray(offset, end));
+    offset = end;
+  }
+}
+
+// Offline oracle uses absolute positions, independent of streaming carry/state.
+function expectedPcm(input: Float32Array, rate: number): number[] {
+  const ratio = rate / 16_000;
+  const count = rate === 16_000 ? input.length : Math.ceil((input.length - 1) / ratio);
+  return Array.from({ length: count }, (_, i) => {
+    const position = i * ratio;
+    const left = Math.floor(position);
+    const fraction = position - left;
+    const value =
+      input[left] * (1 - fraction) + input[Math.min(left + 1, input.length - 1)] * fraction;
+    return Math.trunc(value * (value < 0 ? 0x8000 : 0x7fff));
+  });
+}
+
+describe.each([
+  ['AudioWorklet', createWorkletCapture],
+  ['ScriptProcessor fallback', createFallbackCapture],
+] as const)('%s continuous resampling', (_name, createCapture) => {
+  it.each([48_000, 44_100, 32_000, 16_000, 8_000])(
+    'keeps a constant signal intact at %i Hz, including the tail',
+    async (rate) => {
+      const capture = createCapture(rate);
+      const input = new Float32Array(12_800).fill(0.5);
+      feedChunks(capture, input, [128]);
+      await capture.drain();
+      expect(capture.output).toEqual(expectedPcm(input, rate));
+      const count = capture.output.length;
+      await capture.drain();
+      expect(capture.output).toHaveLength(count);
+    },
+  );
+
+  it.each([48_000, 44_100, 8_000])(
+    'preserves the waveform across arbitrary block boundaries at %i Hz',
+    async (rate) => {
+      const input = Float32Array.from({ length: 4097 }, (_, i) => Math.sin(i * 0.13) * 0.7);
+      const expected = expectedPcm(input, rate);
+      for (const sizes of [[128], [1024], [1, 127, 257, 63]]) {
+        const capture = createCapture(rate);
+        feedChunks(capture, input, sizes);
+        await capture.drain();
+        expect(capture.output).toHaveLength(expected.length);
+        // At most one PCM unit of rounding error from fractional-rate accumulation.
+        const error = Math.max(...capture.output.map((value, i) => Math.abs(value - expected[i])));
+        expect(error).toBeLessThanOrEqual(1);
+      }
+    },
+  );
+
+  it('does not carry samples or fractional position into the next recording', async () => {
+    const capture = createCapture(44_100);
+    feedChunks(capture, new Float32Array(256).fill(-0.75), [128]);
+    await capture.reset();
+    capture.output.length = 0;
+    const next = new Float32Array(4097).fill(0.5);
+    feedChunks(capture, next, [128]);
+    await capture.drain();
+    expect(capture.output).toEqual(expectedPcm(next, 44_100));
+  });
+});

--- a/apps/desktop/src/renderer/voice-input/pcm16k-worklet.js
+++ b/apps/desktop/src/renderer/voice-input/pcm16k-worklet.js
@@ -8,6 +8,7 @@ class PCM16kWorklet extends AudioWorkletProcessor {
     this.timeOriginMs = 0;
     this.pending = [];
     this.carry = 0;
+    this.previousSample = 0;
     this.chunkIndex = 0;
     this.active = true;
 
@@ -35,6 +36,7 @@ class PCM16kWorklet extends AudioWorkletProcessor {
       if (event.data.reset) {
         this.pending = [];
         this.carry = 0;
+        this.previousSample = 0;
       }
       this.active = event.data.active;
     };
@@ -90,6 +92,7 @@ class PCM16kWorklet extends AudioWorkletProcessor {
   }
 
   resample(input, fromRate, toRate) {
+    if (input.length === 0) return [];
     if (fromRate === toRate) return Array.from(input);
 
     const ratio = fromRate / toRate;
@@ -100,11 +103,15 @@ class PCM16kWorklet extends AudioWorkletProcessor {
       const left = Math.floor(sourceIndex);
       const right = Math.min(left + 1, input.length - 1);
       const fraction = sourceIndex - left;
-      output.push(input[left] + (input[right] - input[left]) * fraction);
+      // carry can be in [-1, 0): this interpolation straddles two input blocks.
+      // Keep the previous block's last sample instead of reading input[-1].
+      const leftSample = left < 0 ? this.previousSample : input[left];
+      output.push(leftSample + (input[right] - leftSample) * fraction);
       sourceIndex += ratio;
     }
 
     this.carry = sourceIndex - input.length;
+    this.previousSample = input[input.length - 1];
     return output;
   }
 


### PR DESCRIPTION
## 这次改了什么

### 摘要

连续音频块重采样时，跨块插值位置可能落在前一块的最后一个样本。原实现读取当前块的负索引，得到 NaN，转成 PCM16 后产生异常零值。48kHz 恒定输入分成 100 个 128 样本块时，修复前的 4,267 个输出样本中可复现 33 个异常零值。

AudioWorklet 和 ScriptProcessor 回退路径现在都保留上一块末样本供跨块插值，并在录音重置时清除该状态。新增同一套输出回归矩阵覆盖两条路径，确保分块后的波形与离线连续插值一致。

### 变更类型

- [x] `fix` 缺陷修复

### 范围

- 关联 Issue / 需求：修复桌面语音输入跨块重采样的异常零值。
- 本 PR 包含：两条采集路径的插值边界修复，以及连续块、不同采样率、尾包和重置回归测试。
- 明确不包含：采集格式、网络协议、降噪配置、ASR 或润色策略调整。
- 用户可见变化：跨块音频不再因负索引插入异常零值；实际识别准确率改善尚未测量。
- 是否存在 breaking change：无。

### UI 变化

- 引用的设计规范：不涉及：仅修正音频重采样计算，无界面、交互或文案变化。

## 怎么验证的

### 自动验证

```text
pnpm --filter desktop exec vitest run src/renderer/voice-input/__tests__/audioResampling.test.ts src/renderer/voice-input/__tests__/pcm16kWorklet.test.ts
结果：21 项通过，其中新增 18 项；新增测试在修复前有 14 项失败。

pnpm test:unit:related
结果：通过（Desktop 相关单测）。

pnpm --filter desktop run --if-present typecheck
结果：通过。

pnpm --filter desktop exec eslint src/renderer/voice-input/pcm16k-worklet.js src/renderer/voice-input/WebMicAudioEngine.ts src/renderer/voice-input/__tests__/audioResampling.test.ts
结果：通过。

git diff --check
结果：通过。
```

回归包含 48k/44.1k/32k/16k/8kHz 输入、128/1024/混合单样本分块、恒定与变化波形、尾包只发送一次、录音重启状态隔离。波形使用绝对位置的离线插值作为独立基准。

### 手工验证

进程内加载实际 Worklet，以合成输入复现并核对 PCM 输出；另对完整 diff 做独立审查，未发现 P0/P1。

### 未执行的验证

未启动真实麦克风、未运行端到端 ASR 准确率测试，也未进行 Windows 设备实测。本修复为共享的纯计算路径，回归使用内存输入，不访问设备、账号或云服务。全量单测由 CI 执行。

## 风险

### 风险分类

- [x] 跨平台差异

### 影响与回滚

- 影响范围：Desktop AudioWorklet 与 ScriptProcessor 回退路径，均应用相同插值修复；macOS/Windows 的真实设备行为尚未实测。没有原生层、权限、持久数据或协议变更。
- 回滚 / 降级方式：回退本提交即可，不需要数据迁移；但旧版的跨块异常零值会重新出现。

### 提交前检查

- [x] 已 review 完整 diff
- [x] 每个 commit 都带 DCO 签名（`git commit -s`，见 [DCO](../DCO)）
- [x] UI 改动已在「UI 变化」注明引用的设计规范章节（不涉及 UI 则跳过）
- [x] 未提交凭证、令牌或授权文件
- [x] 已补充必要文档（算法边界注释与 PR 复现说明）
- [x] 已确认测试结果或说明未执行原因
