### PR TITLE
fix(desktop): 修复灵动岛加载期间丢跳转与迟到确认不收起

### DIFF
--- a/apps/desktop/src/main/agent-island/__tests__/service.test.ts
+++ b/apps/desktop/src/main/agent-island/__tests__/service.test.ts
@@ -25,6 +25,7 @@ import { AGENT_ISLAND_DISPLAY_CONFIG } from '../displayConfig.js';
 import type { AgentIslandNativeFrame } from '../MacAgentIslandNativeHost.js';
 import { markAppContentWindow } from '../../windowFocusClassifier.js';
 import type { AgentIslandService } from '../service.js';
+import { setDeepLinkMainWindow, takePendingDeepLink } from '../../deepLink.js';
 
 const REMOTE_DAEMON_CLOSED_REASON = 'remote_daemon_closed';
 
@@ -99,6 +100,7 @@ function tccDeniedError(): NodeJS.ErrnoException {
 vi.mock('electron', () => {
   return {
     app: {
+      focus: vi.fn(),
       getPreferredSystemLanguages: mocks.getPreferredSystemLanguages,
       getLocale: mocks.getLocale,
     },
@@ -136,6 +138,8 @@ vi.mock('../../device-link/broadcast-tap.js', () => ({
 import { resetEpermGuidanceForTest } from '../../file-access/permissions.js';
 
 beforeEach(() => {
+  setDeepLinkMainWindow(null);
+  takePendingDeepLink();
   mocks.getSessionRowSnapshot.mockReset();
   mocks.getSessionRowSnapshot.mockResolvedValue(null);
   mocks.displays.splice(0, mocks.displays.length, mocks.primaryDisplay);
@@ -1883,11 +1887,15 @@ describe('AgentIslandService native publishing', () => {
     const mainWindow = {
       isDestroyed: () => false,
       isMinimized: () => false,
+      isVisible: () => true,
       restore: vi.fn(),
       show: vi.fn(),
       focus: vi.fn(),
-      webContents: { send },
+      setAlwaysOnTop: vi.fn(),
+      moveTop: vi.fn(),
+      webContents: { send, isLoading: () => false },
     } as unknown as BrowserWindow;
+    setDeepLinkMainWindow(mainWindow);
     const publish = vi.fn((state: AgentIslandDisplayState, frameOrFrames: AgentIslandNativeFrame | AgentIslandNativeFrame[]) => {
       void state;
       void frameOrFrames;
@@ -1924,11 +1932,58 @@ describe('AgentIslandService native publishing', () => {
       'target-session',
     );
 
-    expect(send).toHaveBeenCalledWith('notification:focus-session', 'target-session');
+    expect(send).toHaveBeenCalledWith('deep-link:navigate', { type: 'session', id: 'target-session' });
     expect(publish.mock.calls.at(-1)?.[0]).toMatchObject({
       mode: 'compact',
       currentSessionId: 'target-session',
     });
+  });
+
+  it('retains a completion click during renderer reload and collapses after the target is shown', async () => {
+    const { AgentIslandService } = await import('../service.js');
+    const send = vi.fn();
+    const mainWindow = {
+      isDestroyed: () => false,
+      isMinimized: () => false,
+      isVisible: () => false,
+      isFocused: () => true,
+      restore: vi.fn(),
+      show: vi.fn(),
+      focus: vi.fn(),
+      setAlwaysOnTop: vi.fn(),
+      moveTop: vi.fn(),
+      webContents: { send, isLoading: () => true },
+    } as unknown as BrowserWindow;
+    setDeepLinkMainWindow(mainWindow);
+    const publish = vi.fn((_state: AgentIslandDisplayState) => true);
+    const service = new AgentIslandService({
+      getMainWindow: () => mainWindow,
+      nativeHost: { failed: false, publish },
+    });
+    syncEnabledForTest(service, publish);
+    service.registerIpc();
+    service.handleUserPrompt({ sessionId: 'completed-session', agentKind: 'codex' }, 'run tests');
+    service.handleAgentEvent({ sessionId: 'completed-session', agentKind: 'codex' }, doneEvent());
+    expect(publish.mock.calls.at(-1)?.[0]).toMatchObject({ mode: 'expanded' });
+    const focusSession = (service as unknown as { focusSession(id: string): void }).focusSession.bind(service);
+
+    focusSession('completed-session');
+
+    // A loading renderer has no notification listener. The existing deep-link
+    // pull-on-mount path must retain the click instead of sending it into the gap.
+    expect(send).not.toHaveBeenCalled();
+    expect(mainWindow.show).toHaveBeenCalled();
+    expect(mainWindow.focus).toHaveBeenCalled();
+    expect(takePendingDeepLink()).toEqual({ type: 'session', id: 'completed-session' });
+    expect(takePendingDeepLink()).toBeNull();
+
+    service.setAppFocused(true);
+    mocks.browserWindowFromWebContents.mockReturnValue(mainWindow);
+    await registeredIpcHandler(AGENT_ISLAND_SET_VISIBLE_SESSION_CHANNEL)(
+      { sender: {} },
+      'completed-session',
+    );
+    expect(publish.mock.calls.at(-1)?.[0]).toMatchObject({ mode: 'compact' });
   });
 
   it('smart-suppresses all visible split sessions', async () => {

--- a/apps/desktop/src/main/agent-island/__tests__/state.test.ts
+++ b/apps/desktop/src/main/agent-island/__tests__/state.test.ts
@@ -1663,6 +1663,28 @@ describe('Agent Island display state', () => {
     expect(buildAgentIslandDisplayState(state, 3_350).mode).toBe('compact');
   });
 
+  it.each([false, true])('expires abandoned navigation before an ordinary visit (timer ran: %s)', (timerRan) => {
+    const state = createAgentIslandState();
+    applyAgentIslandEvent(state, { sessionId: 'a' }, statusEvent(true, 'Running'), 1_000);
+    requestAgentIslandManualExpand(state);
+    buildAgentIslandDisplayState(state, 1_100);
+    requestAgentIslandSessionFocus(state, 'a', 1_200);
+    buildAgentIslandDisplayState(state, 3_200);
+
+    // The grace is over, but the slow-navigation target still has a finite
+    // cleanup deadline. It must expire even if a route ack beats that timer.
+    expect(isAgentIslandPendingFocusAck(state, 'a', 3_200)).toBe(false);
+    expect(getNextAgentIslandTimerAt(state, 3_200)).toBe(61_200);
+    if (timerRan) buildAgentIslandDisplayState(state, 61_200);
+    setAgentIslandAppFocused(state, true, 61_200);
+    setAgentIslandVisibleSession(state, 'a', 61_200);
+
+    expect(buildAgentIslandDisplayState(state, 61_200).mode).toBe('expanded');
+    expect(state.pendingFocusSessionId).toBeNull();
+    expect(state.pendingFocusUntil).toBeNull();
+    expect(getNextAgentIslandTimerAt(state, 61_200)).toBeNull();
+  });
+
   it('dismisses the first permission approval card after the clicked session becomes visible', () => {
     const state = createAgentIslandState();
     applyAgentIslandEvent(state, { sessionId: 'ask', title: 'Ask', agentKind: 'codex' }, statusEvent(true, 'Running'), 1_000);

--- a/apps/desktop/src/main/agent-island/__tests__/state.test.ts
+++ b/apps/desktop/src/main/agent-island/__tests__/state.test.ts
@@ -20,6 +20,7 @@ import {
   createAgentIslandState,
   dismissAgentIslandActiveReveal,
   getNextAgentIslandTimerAt,
+  isAgentIslandPendingFocusAck,
   markAgentIslandSessionAttention,
   requestAgentIslandManualCollapse,
   requestAgentIslandManualExpand,
@@ -1629,6 +1630,37 @@ describe('Agent Island display state', () => {
     expect(collapsed.mode).toBe('compact');
     expect(collapsed.displaySurface).toBe('collapsed');
     expect(getNextAgentIslandTimerAt(state, 1_900)).toBeNull();
+  });
+
+  it('collapses after slow navigation without extending the background-window ack grace', () => {
+    const state = createAgentIslandState();
+    applyAgentIslandEvent(state, { sessionId: 'done' }, doneEvent(), 1_000);
+    requestAgentIslandManualExpand(state);
+    expect(buildAgentIslandDisplayState(state, 1_100).mode).toBe('expanded');
+    requestAgentIslandSessionFocus(state, 'done', 1_200);
+    expect(isAgentIslandPendingFocusAck(state, 'done', 1_250)).toBe(true);
+
+    expect(buildAgentIslandDisplayState(state, 3_200).mode).toBe('expanded');
+    expect(isAgentIslandPendingFocusAck(state, 'done', 3_200)).toBe(false);
+    setAgentIslandAppFocused(state, true, 3_250);
+    setAgentIslandVisibleSession(state, 'done', 3_300);
+    acknowledgeAgentIslandSessionRead(state, 'done', 3_300);
+    expect(buildAgentIslandDisplayState(state, 3_350).mode).toBe('compact');
+  });
+
+  it('keeps the newest click when an earlier navigation finishes late', () => {
+    const state = createAgentIslandState();
+    applyAgentIslandEvent(state, { sessionId: 'a' }, statusEvent(true, 'Running'), 1_000);
+    applyAgentIslandEvent(state, { sessionId: 'b' }, statusEvent(true, 'Running'), 1_000);
+    requestAgentIslandManualExpand(state);
+    requestAgentIslandSessionFocus(state, 'a', 1_200);
+    requestAgentIslandSessionFocus(state, 'b', 1_300);
+    buildAgentIslandDisplayState(state, 3_200);
+
+    setAgentIslandVisibleSession(state, 'a', 3_250);
+    expect(buildAgentIslandDisplayState(state, 3_250).mode).toBe('expanded');
+    setAgentIslandVisibleSession(state, 'b', 3_300);
+    expect(buildAgentIslandDisplayState(state, 3_350).mode).toBe('compact');
   });
 
   it('dismisses the first permission approval card after the clicked session becomes visible', () => {

--- a/apps/desktop/src/main/agent-island/service.ts
+++ b/apps/desktop/src/main/agent-island/service.ts
@@ -23,6 +23,7 @@ import {
 import type { ApplicationMenuCommand } from '../../shared/applicationMenuCommands.js';
 
 import { hasSessionAttention as hasAppBadgeSessionAttention } from '../appBadgeService.js';
+import { openMainWindowSession } from '../deepLink.js';
 import {
   AGENT_ISLAND_MAX_RESIZABLE_WIDTH,
   AGENT_ISLAND_GET_DISPLAY_OPTIONS_CHANNEL,
@@ -2325,13 +2326,11 @@ export class AgentIslandService {
       return;
     }
 
-    const mainWindow = this.deps.getMainWindow();
-    if (!mainWindow || mainWindow.isDestroyed()) return;
     const focusChanged = requestAgentIslandSessionFocus(this.state, nextSessionId, now);
-    if (mainWindow.isMinimized()) mainWindow.restore();
-    mainWindow.show();
-    mainWindow.focus();
-    mainWindow.webContents.send('notification:focus-session', nextSessionId);
+    // Reuse the primary-window handoff: it retains navigation while the
+    // renderer reloads and restores macOS app focus. A one-shot notification
+    // sent during loading is lost before MainLayout can acknowledge the task.
+    openMainWindowSession(nextSessionId);
     if (focusChanged) this.publish();
   }
 

--- a/apps/desktop/src/main/agent-island/state.ts
+++ b/apps/desktop/src/main/agent-island/state.ts
@@ -187,6 +187,8 @@ export interface AgentIslandState {
   activeTransientSessionId: string | null;
   transientRevealQueue: string[];
   pendingFocusSessionId: string | null;
+  // Short grace for a renderer ack before OS focus settles. Navigation itself
+  // may take longer (for example a renderer reload) and retains its target.
   pendingFocusUntil: number | null;
   lastDisplayMode: AgentIslandDisplayState['mode'] | null;
   lastDisplayPolicy: AgentIslandDisplayPolicy | null;
@@ -1089,8 +1091,9 @@ export function requestAgentIslandSessionFocus(
 export function isAgentIslandPendingFocusAck(
   state: AgentIslandState,
   sessionId: string | readonly string[] | null,
+  now = Date.now(),
 ): boolean {
-  if (!state.pendingFocusSessionId) return false;
+  if (!state.pendingFocusSessionId || !state.pendingFocusUntil || state.pendingFocusUntil <= now) return false;
   return normalizeVisibleSessionIds(sessionId).includes(state.pendingFocusSessionId);
 }
 
@@ -1382,7 +1385,8 @@ function completionRevealDwellMs(session: AgentIslandSessionState, now: number):
 
 function updateFocusVerificationLifecycle(state: AgentIslandState, now: number): void {
   if (!state.pendingFocusUntil || state.pendingFocusUntil > now) return;
-  state.pendingFocusSessionId = null;
+  // Expire only the background-window exception. A later focused route report
+  // must still close the island for the user's last navigation request.
   state.pendingFocusUntil = null;
 }
 

--- a/apps/desktop/src/main/agent-island/state.ts
+++ b/apps/desktop/src/main/agent-island/state.ts
@@ -58,6 +58,7 @@ export const AGENT_ISLAND_HOVER_SHORT_COOLDOWN_MS = 300;
 export const AGENT_ISLAND_TOOL_DETAIL_LINGER_MS = 2_000;
 export const AGENT_ISLAND_MESSAGE_PREVIEW_MIN_DWELL_MS = 1_600;
 export const AGENT_ISLAND_FOCUS_VERIFY_TIMEOUT_MS = 1_500;
+const AGENT_ISLAND_FOCUS_NAVIGATION_TIMEOUT_MS = 60_000;
 // 未读的 completed / error 在**灵动岛浮窗**里驻留的上限;超过后即便用户没 ack,
 // 也不再占用展开列表。岛 state 会按 TTL prune;远程绿/红点改订独立的
 // remoteUnreadTerminals 账本,不跟完整会话(含活动文本)一起留下。
@@ -188,7 +189,8 @@ export interface AgentIslandState {
   transientRevealQueue: string[];
   pendingFocusSessionId: string | null;
   // Short grace for a renderer ack before OS focus settles. Navigation itself
-  // may take longer (for example a renderer reload) and retains its target.
+  // may take longer (for example a renderer reload); its bounded deadline is
+  // derived from this timestamp by pendingFocusNavigationExpiresAt.
   pendingFocusUntil: number | null;
   lastDisplayMode: AgentIslandDisplayState['mode'] | null;
   lastDisplayPolicy: AgentIslandDisplayPolicy | null;
@@ -1256,7 +1258,7 @@ export function getNextAgentIslandTimerAt(state: AgentIslandState, now: number):
     state.hoverIntentAt,
     state.collapseAt,
     state.hoverCooldownUntil && isPointerInsideIsland(state) ? state.hoverCooldownUntil : null,
-    state.pendingFocusUntil,
+    pendingFocusNavigationExpiresAt(state),
     state.expandedProtectUntil && state.protectedDismissPending ? state.expandedProtectUntil : null,
   ]) {
     if (value && value > now && (next === null || value < next)) {
@@ -1383,10 +1385,18 @@ function completionRevealDwellMs(session: AgentIslandSessionState, now: number):
   return Math.max(AGENT_ISLAND_COMPLETION_REVEAL_DWELL_MS, remainingPreviewMs + AGENT_ISLAND_REVEAL_DWELL_MS);
 }
 
+function pendingFocusNavigationExpiresAt(state: AgentIslandState): number | null {
+  return state.pendingFocusUntil === null
+    ? null
+    : state.pendingFocusUntil - AGENT_ISLAND_FOCUS_VERIFY_TIMEOUT_MS + AGENT_ISLAND_FOCUS_NAVIGATION_TIMEOUT_MS;
+}
+
 function updateFocusVerificationLifecycle(state: AgentIslandState, now: number): void {
-  if (!state.pendingFocusUntil || state.pendingFocusUntil > now) return;
-  // Expire only the background-window exception. A later focused route report
-  // must still close the island for the user's last navigation request.
+  const expiresAt = pendingFocusNavigationExpiresAt(state);
+  if (expiresAt === null || expiresAt > now) return;
+  // Allow slow renderer loading, but do not let an abandoned navigation turn a
+  // much later ordinary visit into an acknowledgement of the old island click.
+  state.pendingFocusSessionId = null;
   state.pendingFocusUntil = null;
 }
 
@@ -1953,6 +1963,8 @@ function applyVerifiedFocusIfMatched(
   state: AgentIslandState,
   now: number,
 ): boolean {
+  // A route report can arrive before the expiry timer gets a chance to run.
+  updateFocusVerificationLifecycle(state, now);
   const focusedSessionId = state.pendingFocusSessionId;
   if (!focusedSessionId || !state.visibleSessionIds.has(focusedSessionId)) return false;
   state.pendingFocusSessionId = null;


### PR DESCRIPTION
## 这次改了什么

### 摘要

灵动岛点击完成任务时，主窗口若正在加载或重载，原来的单次通知可能在页面监听就绪前丢失，导致没有跳转；导航耗时超过 1.5 秒时，收起所需的目标也会被提前清除，导致跳转后手动展开列表仍不收起。

点击入口改为复用现有主窗口 deep link 交接：加载期间保留请求，页面挂载后消费；焦点稳定的短暂宽限期仍为 1.5 秒，但最后点击的目标可保留至点击后 60 秒，让较慢的前台可见确认仍能收起灵动岛。未完成的旧目标到期失效，避免后续普通访问误触发收起。

### 变更类型

- [x] `fix` 缺陷修复

### 范围

- 关联 Issue / 需求：灵动岛完成提醒偶发点击无跳转、无收起。
- 本 PR 包含：主窗口导航交接复用、迟到可见确认收起、对应回归测试。
- 明确不包含：原生 Swift 手势、窗口样式或新增重试机制。
- 用户可见变化：加载期间点击的任务不会因单次通知丢失而被忽略；慢导航成功后列表正常收起。
- 是否存在 breaking change：无。

### UI 变化

引用 `docs/design-rules/DESIGN.md` §10 双模式交付门槛：Light/Dark 共用同一交互逻辑，没有视觉或文案改动。任务跳转复用既有主窗口焦点处理。

## 怎么验证的

### 自动验证

- 修改前：加载期回归失败，实际仍向未就绪页面发送 `notification:focus-session`；两个慢导航回归均复现 `expanded` 未收起。
- 修改后：定向 `vitest run` 执行 `service.test.ts` 与 `state.test.ts`，254 项通过。覆盖加载期保留请求、单次拉取消费、窗口焦点未稳定时的确认、迟到前台确认、最新点击覆盖旧目标，以及旧目标到期后计时器与路由回报的两种先后顺序。
- `pnpm test:unit:related`：通过。
- `pnpm --filter desktop run --if-present typecheck`：通过。
- `git diff --check`：通过；已独立审查完整 diff。

### 手工验证

未重启正在使用的 Cindy；通过内存状态实验复核超过 1.5 秒后，后台确认例外失效，前台目标确认仍能收起并清空待处理目标。

### 未执行的验证

未执行真实 macOS 原生点击、Light/Dark 实机目检或 Windows 实机验证。用户现场的偶发点击尚未复现；本 PR 修复的是已通过回归确认的加载丢通知和迟到确认问题，不声称已证明所有偶发点击都来自这两条路径。

## 风险

### 风险分类

- [x] 跨平台差异
- [x] 其他：导航与可见确认的异步时序。

### 影响与回滚

- 影响范围：Desktop 灵动岛任务点击。macOS 复用既有应用激活逻辑；Windows 测试 fake 包含对应 `moveTop` 路径。没有新增 IPC 能力，也没有延长非聚焦窗口可报告目标的 1.5 秒宽限期。
- 状态收口：最新点击覆盖旧目标；匹配可见确认、目标移除、状态重置或点击后 60 秒到期均清理目标。到期判据由现有发布计时器和可见确认入口共用；后台确认宽限仍只有 1.5 秒，没有新增状态字段、独立计时器或重试。
- 回滚 / 降级方式：回退本 PR 的四个文件。

### 提交前检查

- [x] 已 review 完整 diff
- [x] 每个 commit 都带 DCO 签名（`git commit -s`）
- [x] UI 改动已在「UI 变化」注明引用的设计规范章节
- [x] 未提交凭证、令牌或授权文件
- [x] 已补充必要文档（无新增配置或操作流程，PR 记录行为与验证边界）
- [x] 已确认测试结果或说明未执行原因
