### PR TITLE
fix(desktop): 撤销语音纠正时清除待学习证据

### DIFF
--- a/apps/desktop/src/renderer/voice-input/__tests__/useVoiceInput.dictionaryUndo.test.ts
+++ b/apps/desktop/src/renderer/voice-input/__tests__/useVoiceInput.dictionaryUndo.test.ts
@@ -118,6 +118,9 @@ function mountDictation() {
     clear() {
       act(() => dispatch(state.tr.delete(1, state.doc.content.size - 1)));
     },
+    type(text: string) {
+      act(() => dispatch(state.tr.insertText(text)));
+    },
   };
 }
 
@@ -133,6 +136,24 @@ afterEach(() => {
 });
 
 describe('in-app dictionary learning after undo', () => {
+  describe.each(['unchanged', 'undone correction'] as const)('clearing %s dictation', (source) => {
+    it.each(['clear', 'unmount', 'timeout'] as const)(
+      'does not learn unrelated new input on %s',
+      (finish) => {
+        const dictation = mountDictation();
+        if (source === 'undone correction') dictation.correct()();
+        dictation.clear();
+        dictation.type('明天再讨论这个问题。');
+        if (finish === 'timeout') act(() => vi.advanceTimersByTime(15_000));
+        else dictation[finish]();
+        expect(mocks.advise).not.toHaveBeenCalled();
+        dictation.unmount();
+        act(() => vi.advanceTimersByTime(15_000));
+        expect(mocks.advise).not.toHaveBeenCalled();
+      },
+    );
+  });
+
   it.each(['clear', 'unmount'] as const)('discards an undone correction before %s', (finish) => {
     const dictation = mountDictation();
     const undo = dictation.correct();

--- a/apps/desktop/src/renderer/voice-input/__tests__/useVoiceInput.dictionaryUndo.test.ts
+++ b/apps/desktop/src/renderer/voice-input/__tests__/useVoiceInput.dictionaryUndo.test.ts
@@ -1,0 +1,177 @@
+// @vitest-environment jsdom
+import { act, cleanup, renderHook } from '@testing-library/react';
+import type { Editor } from '@tiptap/core';
+import { Schema } from '@tiptap/pm/model';
+import { EditorState, type Transaction } from '@tiptap/pm/state';
+import type { VoiceInputRendererEvent } from '@cindy/voice-input-core';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+const mocks = vi.hoisted(() => ({
+  advise: vi.fn(),
+  promptExpired: vi.fn(),
+  translate: (key: string) => key,
+  settings: { language: 'auto', refinementEnabled: true, autoDictionaryEnabled: true },
+}));
+
+vi.mock('react-i18next', () => ({ useTranslation: () => ({ t: mocks.translate }) }));
+vi.mock('@/lib/logger', () => ({
+  createLogger: () => ({ debug: vi.fn(), info: vi.fn(), warn: vi.fn() }),
+}));
+vi.mock('@/lib/toast', () => ({ toast: { warning: vi.fn(), error: vi.fn() } }));
+vi.mock('@/hooks/useCodexSessionExpiredPrompt', () => ({
+  useCodexSessionExpiredPrompt: () => mocks.promptExpired,
+  isCodexSessionExpiredError: () => false,
+}));
+vi.mock('@/hooks/useVoiceInputSettings', () => ({
+  useVoiceInputSettings: () => ({ settings: mocks.settings }),
+  adviseAndRecordVoiceInputDictionaryLearning: mocks.advise,
+}));
+vi.mock('@/hooks/useVoiceInputHistory', () => ({
+  recordVoiceInputHistory: () => null,
+  updateVoiceInputHistoryEntry: vi.fn(),
+}));
+vi.mock('@/hooks/useVoiceInputUsageStats', () => ({
+  recordVoiceInputUsage: vi.fn(),
+  recordVoiceInputRefinementUsage: vi.fn(),
+}));
+vi.mock('../workletUrl', () => ({ getVoiceInputWorkletUrl: () => '' }));
+// Deliver an already accepted transcript without opening a microphone/ASR session.
+vi.mock('../eventScope', () => ({
+  shouldHandleVoiceInputEvent: () => true,
+  isVoiceInputEventScopeActive: () => false,
+}));
+
+import { useVoiceInput } from '../useVoiceInput';
+
+const baseline = '使用 Cloud Code。';
+const schema = new Schema({
+  nodes: {
+    doc: { content: 'paragraph+' },
+    paragraph: { content: 'text*' },
+    text: {},
+  },
+});
+
+function mountDictation() {
+  let onEvent!: (event: VoiceInputRendererEvent) => void;
+  vi.stubGlobal('electronAPI', {
+    voiceInput: {
+      onEvent: (listener: typeof onEvent) => {
+        onEvent = listener;
+        return vi.fn();
+      },
+      cancel: vi.fn().mockResolvedValue({ ok: true }),
+    },
+  });
+  let state = EditorState.create({ doc: schema.node('doc', null, [schema.node('paragraph')]) });
+  const listeners = new Set<(payload: { transaction: Transaction }) => void>();
+  const dispatch = (transaction: Transaction) => {
+    state = state.apply(transaction);
+    listeners.forEach((listener) => listener({ transaction }));
+  };
+  // Real ProseMirror documents, steps and mappings; only the editor view is stubbed.
+  const editor = {
+    get state() {
+      return state;
+    },
+    view: {
+      get state() {
+        return state;
+      },
+      dispatch,
+    },
+    isDestroyed: false,
+    commands: { focus: vi.fn() },
+    on: (_event: string, listener: (payload: { transaction: Transaction }) => void) =>
+      listeners.add(listener),
+    off: (_event: string, listener: (payload: { transaction: Transaction }) => void) =>
+      listeners.delete(listener),
+  } as unknown as Editor;
+  const hook = renderHook(() => useVoiceInput(editor, true));
+  act(() =>
+    onEvent({
+      type: 'submitted',
+      runId: 'run',
+      text: baseline,
+      segment: {
+        id: 'segment',
+        source: 'mic',
+        status: 'submitted',
+        text: baseline,
+        updatedAt: Date.now(),
+      },
+    }),
+  );
+  expect(state.doc.textContent).toBe(baseline);
+
+  return {
+    unmount: hook.unmount,
+    correct(replacement = 'Claude') {
+      const transaction = state.tr.insertText(replacement, 4, 9);
+      const undo = transaction.steps[0].invert(transaction.docs[0]);
+      act(() => dispatch(transaction));
+      return () => {
+        act(() => dispatch(state.tr.step(undo)));
+        expect(state.doc.textContent).toBe(baseline);
+      };
+    },
+    clear() {
+      act(() => dispatch(state.tr.delete(1, state.doc.content.size - 1)));
+    },
+  };
+}
+
+beforeEach(() => {
+  vi.useFakeTimers();
+  mocks.advise.mockReset();
+});
+
+afterEach(() => {
+  cleanup();
+  vi.useRealTimers();
+  vi.unstubAllGlobals();
+});
+
+describe('in-app dictionary learning after undo', () => {
+  it.each(['clear', 'unmount'] as const)('discards an undone correction before %s', (finish) => {
+    const dictation = mountDictation();
+    const undo = dictation.correct();
+    expect(mocks.advise).not.toHaveBeenCalled();
+    undo();
+    dictation[finish]();
+    act(() => vi.advanceTimersByTime(15_000));
+    expect(mocks.advise).not.toHaveBeenCalled();
+  });
+
+  it('does not learn an undone correction when its old timeout elapses', () => {
+    const dictation = mountDictation();
+    const undo = dictation.correct();
+    undo();
+    act(() => vi.advanceTimersByTime(15_000));
+    expect(mocks.advise).not.toHaveBeenCalled();
+    dictation.unmount();
+    expect(mocks.advise).not.toHaveBeenCalled();
+  });
+
+  it.each(['clear', 'unmount', 'timeout'] as const)(
+    'learns a fresh correction after undo on %s',
+    (finish) => {
+      const dictation = mountDictation();
+      const undo = dictation.correct();
+      undo();
+      dictation.correct('Codex');
+      if (finish === 'timeout') act(() => vi.advanceTimersByTime(15_000));
+      else dictation[finish]();
+      expect(mocks.advise).toHaveBeenCalledExactlyOnceWith(
+        expect.objectContaining({
+          beforeText: baseline,
+          rawTranscriptText: baseline,
+          afterText: '使用 Codex Code。',
+        }),
+      );
+      dictation.unmount();
+      act(() => vi.advanceTimersByTime(15_000));
+      expect(mocks.advise).toHaveBeenCalledTimes(1);
+    },
+  );
+});

--- a/apps/desktop/src/renderer/voice-input/useVoiceInput.ts
+++ b/apps/desktop/src/renderer/voice-input/useVoiceInput.ts
@@ -718,6 +718,8 @@ export function useVoiceInput(
             start: range.from,
             end: range.to,
             pendingAdviceTimer: undefined,
+            // A later clear/unmount must not publish a correction the user undid.
+            pendingEvidence: undefined,
           });
           return [];
         }

--- a/apps/desktop/src/renderer/voice-input/useVoiceInput.ts
+++ b/apps/desktop/src/renderer/voice-input/useVoiceInput.ts
@@ -589,9 +589,11 @@ export function useVoiceInput(
     triggerReason: string,
   ): boolean => {
     const watch = dictionaryLearningWatchesRef.current.get(segmentId);
-    if (!watch?.pendingEvidence) return false;
+    if (!watch) return false;
+    // Clearing the tracked text ends its lifetime even without a correction.
     clearDictionaryLearningWatchTimer(watch);
     dictionaryLearningWatchesRef.current.delete(segmentId);
+    if (!watch.pendingEvidence) return false;
     publishDictionaryLearningEvidence(watch.pendingEvidence, triggerReason);
     return true;
   }, [clearDictionaryLearningWatchTimer, publishDictionaryLearningEvidence]);


### PR DESCRIPTION
## 这次改了什么

### 摘要

应用内语音输入后，用户手动纠正文字再撤销回原文，旧的待学习证据仍被保留；随后清空输入框或离开编辑器时，系统会将已经撤销的纠正提交给词典学习。

恢复原文时清空待学习证据与计时器，保留跟踪范围，让用户之后的新纠正仍能正常学习。清空语音文本时，无论是否存在待学习证据都结束跟踪，避免后续无关输入被当成旧语音的纠正。

生命周期约束（唯一状态 owner 为 useVoiceInput 内的 watch 集合）：
- 撤销回原文：取消证据及计时器，保留跟踪范围。
- 清空跟踪文本：始终取消计时器并移除 watch；仅在有有效证据时提交一次。
- 有效修改超时或编辑器卸载：提交最新证据并结束跟踪；移除后的计时器回调不再提交。
- 新输入只有属于仍有效的语音跟踪范围时才能生成学习证据。

### 变更类型

- [ ] `feat` 新功能
- [x] `fix` 缺陷修复
- [ ] `refactor` / `perf` 重构或性能优化
- [ ] `docs` / `test` / `chore` 文档、测试或工程维护
- [ ] 其他：

### 范围

- 关联 Issue / 需求：修复语音输入撤销后仍提交旧词典学习证据的问题。
- 本 PR 包含：恢复原文时清空 pendingEvidence、清空文本时无条件移除 watch；12 个 hook 回归用例，使用真实 ProseMirror transaction、反向 step 和映射。
- 明确不包含：已入库词条回滚、学习模型或门槛调整、外部应用及 Mobile 跟踪逻辑。
- 用户可见变化：撤销掉的纠正不会在后续清空输入框或离开时被学习；再次修改仍学习最新内容。
- 是否存在 breaking change：无。

### UI 变化

不涉及视觉、布局或文案变化。

- 引用的设计规范：不涉及：仅修复 Renderer 内待学习证据的取消状态，无新增界面或交互入口。

## 怎么验证的

### 自动验证

```text
pnpm --filter desktop exec vitest run src/renderer/voice-input/__tests__/useVoiceInput.dictionaryUndo.test.ts --pool=threads
结果：12 个用例通过。撤销证据修复前复现 3 个失败用例；清空跟踪修复前新增的 6 个用例均失败。

pnpm test:unit:related
结果：通过。

pnpm --filter desktop run --if-present typecheck
结果：通过。

pnpm --filter desktop exec eslint src/renderer/voice-input/__tests__/useVoiceInput.dictionaryUndo.test.ts src/renderer/voice-input/useVoiceInput.ts
结果：通过。

git diff --check
结果：通过。
```

覆盖撤销后的清空、卸载、超时，撤销后再次修改的三种提交方式，以及未修改／已撤销语音被清空后输入无关文字的三种结束方式；断言不提交旧证据或无关新输入，只提交一次最新有效纠正。

### 手工验证

完成整体 diff 自审；未启动桌面客户端进行人工操作。

### 未执行的验证

未执行真实麦克风、模型请求或实机回归。本次验证聚焦 Renderer 状态与 ProseMirror 编辑事务，测试不访问真实账号或词典。

## 风险

### 风险分类

- [x] 无已知风险
- [ ] SQLite / migration
- [ ] system prompt
- [ ] 协议兼容
- [ ] 权限 / 安全 / 用户数据
- [ ] 存量插件兼容（批准状态 / 指纹 / manifest 校验 / 安装布局 / 包格式）
- [ ] 原生层 / fingerprint / OTA
- [ ] 跨平台差异
- [ ] 其他：

### 影响与回滚

- 影响范围：应用内语音输入尚未提交的学习证据；不修改已入库词典或存储格式。
- 回滚 / 降级方式：回退本提交即可，无数据迁移。

### 提交前检查

- [x] 已 review 完整 diff
- [x] 每个 commit 都带 DCO 签名（`git commit -s`，见 [DCO](../DCO)）
- [x] UI 改动已在「UI 变化」注明引用的设计规范章节（不涉及 UI 则跳过）
- [x] 未提交凭证、令牌或授权文件
- [x] 已补充必要文档（取消语义已在代码注释与回归用例说明，无需额外文档）
- [x] 已确认测试结果或说明未执行原因


