### PR TITLE
fix(voice-input): 词典学习统一使用辅助模型通道

### DIFF
--- a/apps/desktop/src/main/utility-model/__tests__/auxiliaryCustomNoAgentFallback.test.ts
+++ b/apps/desktop/src/main/utility-model/__tests__/auxiliaryCustomNoAgentFallback.test.ts
@@ -42,9 +42,13 @@ describe('custom auxiliary chain does not hit the session agent', () => {
   });
 
   it('dictionary learning uses the same owner and chain dispatch guard', () => {
-    const source = readFileSync(path.join(root, 'voice-input/index.ts'), 'utf8');
-    expect(source).toContain('const advisorAttempts: FallbackTextModelAttempt[] = readyAdvisorProfiles.map');
-    expect(source).toContain('client: guardRefinerClientAgainstUnavailableRoute(');
-    expect(source).toContain('assertVoiceInputOwnerScopeCurrent(ownerScopeKey, auxiliaryChainSnapshot);');
+    const source = readFileSync(path.join(root, 'voice-input/index.ts'), 'utf8').replace(/\r\n/g, '\n');
+    expect(source).toContain(`const advisorClient = new DictionaryLearningTextModelClient(
+      (prompt, requestOptions) => requestUtilityText(getMaker(), prompt, requestOptions),
+      () => assertVoiceInputOwnerScopeCurrent(ownerScopeKey, auxiliaryChainSnapshot),
+    );`);
+    expect(source).toContain(`const result = await advisor.advise(adviceInput);
+    assertVoiceInputOwnerScopeCurrent(ownerScopeKey, auxiliaryChainSnapshot);
+    const recordResult = voiceInputDataStore.recordDictionaryLearningActions(result.actions);`);
   });
 });

--- a/apps/desktop/src/main/utility-model/__tests__/oneShotCandidates.test.ts
+++ b/apps/desktop/src/main/utility-model/__tests__/oneShotCandidates.test.ts
@@ -2488,15 +2488,45 @@ describe('utility one-shot candidates', () => {
       expect(sut.client.servedRoute).toEqual({ providerId: 'anthropic', model: 'claude-haiku-4-5' });
       expect(readCodexCreds).not.toHaveBeenCalled();
       expect(fetchMock).toHaveBeenCalledTimes(1);
+      expect(JSON.parse(String(fetchMock.mock.calls[0]?.[1]?.body)).max_tokens).toBe(4_096);
     });
 
-    it('continues after invalid catalog JSON and a failed second model to use the third selection', async () => {
+    const invalidOutputs = ['not JSON', '{}', '{"actions":null}', '{"actions":{}}'];
+
+    it.each(invalidOutputs)('falls back after user-provider output %s and accepts empty actions', async (invalidText) => {
+      chainState.source = 'custom';
+      chainState.refs = ['cat:dictionary-custom:codex:first', 'cat:dictionary-custom:codex:second'];
+      activeCatalog.mockReturnValue({ providers: [{
+        id: 'dictionary-custom', name: 'Dictionary Custom', source: 'user', agents: ['codex'],
+        auth: { method: 'apiKey' },
+        routing: { codex: {
+          upstream: 'https://dictionary.example/v1', wireProtocol: 'openai-chat', authStrategy: 'api-key-header',
+        } },
+        models: { codex: ['first', 'second'].map((id) => ({ id, name: id, contextWindow: 100_000 })) },
+      }] } as never);
+      readCustomKey.mockReturnValue('fake-custom-key');
+      for (const content of [invalidText, '{"actions":[]}']) {
+        fetchMock.mockResolvedValueOnce({
+          ok: true, text: async () => JSON.stringify({ choices: [{ message: { content } }] }),
+        } as never);
+      }
+      const sut = advisor();
+
+      expect((await sut.advisor.advise(evidence)).actions).toEqual([]);
+      expect(sut.client.servedRoute).toEqual({ providerId: 'dictionary-custom', model: 'second' });
+      expect(fetchMock.mock.calls.map(([, opts]) => JSON.parse(String(opts?.body)))).toEqual([
+        expect.objectContaining({ model: 'first', max_tokens: 4_096 }),
+        expect.objectContaining({ model: 'second', max_tokens: 4_096 }),
+      ]);
+    });
+
+    it.each(invalidOutputs)('falls back to the third custom selection after %s and HTTP failure', async (invalidText) => {
       selectClaude();
       chainState.refs.push('litellm-kimi-k2.6', 'litellm-deepseek-v4-flash');
       readKey.mockReturnValue('fake-proxy-key');
       fetchMock
         .mockResolvedValueOnce({
-          ok: true, text: async () => JSON.stringify({ content: [{ type: 'text', text: 'not JSON' }] }),
+          ok: true, text: async () => JSON.stringify({ content: [{ type: 'text', text: invalidText }] }),
         } as never)
         .mockResolvedValueOnce({ ok: false, status: 503, body: { cancel: vi.fn() } } as never)
         .mockResolvedValueOnce({
@@ -2511,9 +2541,9 @@ describe('utility one-shot candidates', () => {
       ]);
     });
 
-    it('continues after invalid profile JSON and accepts an empty actions verdict', async () => {
+    it.each(invalidOutputs)('falls back after profile output %s and accepts empty actions', async (invalidText) => {
       const maker = makerMock(true);
-      vi.mocked(maker.oneShot).mockResolvedValue('not JSON');
+      vi.mocked(maker.oneShot).mockResolvedValue(invalidText);
       readKey.mockReturnValue('fake-proxy-key');
       fetchMock.mockResolvedValueOnce({
         ok: true, json: async () => ({ choices: [{ message: { content: '{"actions":[]}' } }] }),
@@ -2551,19 +2581,21 @@ describe('utility one-shot candidates', () => {
       expect(fetchMock).toHaveBeenCalledTimes(1);
     });
 
-    it('rejects invalid output on an explicit route without using the auxiliary defaults', async () => {
+    it.each(invalidOutputs)('rejects explicit builtin output %s without using defaults', async (invalidText) => {
       selectClaude();
       fetchMock.mockResolvedValueOnce({
-        ok: true, text: async () => JSON.stringify({ content: [{ type: 'text', text: 'invalid' }] }),
+        ok: true, text: async () => JSON.stringify({ content: [{ type: 'text', text: invalidText }] }),
       } as never);
       const maker = makerMock(true);
+      const client = new DictionaryLearningTextModelClient(
+        (prompt, opts) => requestUtilityText(maker, prompt, {
+          ...opts, providerId: 'anthropic', agentKind: 'claude-code', model: 'claude-haiku-4-5',
+        }),
+        () => {},
+      );
 
-      const result = await requestUtilityText(maker, 'classify', {
-        providerId: 'anthropic', agentKind: 'claude-code', model: 'claude-haiku-4-5',
-        validateResponse: () => false,
-      });
-
-      expect(result).toMatchObject({ ok: false, reason: 'all_candidates_failed' });
+      await expect(new DictationDictionaryAdvisor({ client, model: 'auxiliary' }).advise(evidence))
+        .rejects.toThrow('Dictionary learning failed: all_candidates_failed');
       expect(fetchMock).toHaveBeenCalledTimes(1);
       expect(maker.oneShot).not.toHaveBeenCalled();
     });

--- a/apps/desktop/src/main/utility-model/__tests__/oneShotCandidates.test.ts
+++ b/apps/desktop/src/main/utility-model/__tests__/oneShotCandidates.test.ts
@@ -95,6 +95,8 @@ vi.mock('../../model-access/effectiveEndpoint.js', async () => {
 });
 
 import type { Maker } from '@cindy/maker-core';
+import { DictationDictionaryAdvisor } from '@cindy/voice-input-core';
+import { DictionaryLearningTextModelClient } from '../../voice-input/DictionaryLearningTextModelClient.js';
 import { fetch as undiciFetch } from 'undici';
 
 import { getAppCapabilities } from '../../appCapabilities.js';
@@ -2444,6 +2446,128 @@ describe('utility one-shot candidates', () => {
       expect(body).not.toHaveProperty('reasoning');
     },
   );
+
+  describe('dictionary learning through the auxiliary chain', () => {
+    const action = {
+      action: 'add_entry', term: 'Vibe Coding', aliases: ['web coding'],
+      type: 'technical_term', confidence: 'high',
+    };
+    const responseText = JSON.stringify({ actions: [action] });
+
+    function advisor(maker = makerMock(false)) {
+      const client = new DictionaryLearningTextModelClient(
+        (prompt, opts) => requestUtilityText(maker, prompt, opts),
+        () => {},
+      );
+      return { client, advisor: new DictationDictionaryAdvisor({ client, model: 'auxiliary' }) };
+    }
+
+    function selectClaude() {
+      chainState.source = 'custom';
+      chainState.refs = ['cat:anthropic:claude-code:claude-haiku-4-5'];
+      activeCatalog.mockReturnValue({ providers: [{
+        id: 'anthropic', name: 'Anthropic', source: 'builtin', agents: ['claude-code'],
+        auth: { method: 'oauth' },
+        routing: { 'claude-code': { upstream: 'https://anthropic.example/v1', authStrategy: 'oauth-passthrough' } },
+        models: { 'claude-code': [{ id: 'claude-haiku-4-5', name: 'Haiku', contextWindow: 200_000 }] },
+      }] } as never);
+      readClaudeOAuth.mockResolvedValue({ accessToken: 'fake-anthropic-token' });
+    }
+
+    const evidence = { beforeText: '继续试一下 web coding。', afterText: '继续试一下 Vibe Coding。' };
+
+    it('learns through a selected Claude model without any Codex credentials', async () => {
+      selectClaude();
+      fetchMock.mockResolvedValueOnce({
+        ok: true,
+        text: async () => JSON.stringify({ content: [{ type: 'text', text: responseText }] }),
+      } as never);
+      const sut = advisor();
+
+      expect((await sut.advisor.advise(evidence)).actions).toEqual([action]);
+      expect(sut.client.servedRoute).toEqual({ providerId: 'anthropic', model: 'claude-haiku-4-5' });
+      expect(readCodexCreds).not.toHaveBeenCalled();
+      expect(fetchMock).toHaveBeenCalledTimes(1);
+    });
+
+    it('continues after invalid catalog JSON and a failed second model to use the third selection', async () => {
+      selectClaude();
+      chainState.refs.push('litellm-kimi-k2.6', 'litellm-deepseek-v4-flash');
+      readKey.mockReturnValue('fake-proxy-key');
+      fetchMock
+        .mockResolvedValueOnce({
+          ok: true, text: async () => JSON.stringify({ content: [{ type: 'text', text: 'not JSON' }] }),
+        } as never)
+        .mockResolvedValueOnce({ ok: false, status: 503, body: { cancel: vi.fn() } } as never)
+        .mockResolvedValueOnce({
+          ok: true, json: async () => ({ choices: [{ message: { content: responseText } }] }),
+        } as never);
+      const sut = advisor();
+
+      expect((await sut.advisor.advise(evidence)).actions).toEqual([action]);
+      expect(sut.client.servedRoute?.model).toBe('deepseek/deepseek-v4-flash');
+      expect(fetchMock.mock.calls.map(([, opts]) => JSON.parse(String(opts?.body)).model)).toEqual([
+        'claude-haiku-4-5', 'moonshotai/kimi-k2.6', 'deepseek/deepseek-v4-flash',
+      ]);
+    });
+
+    it('continues after invalid profile JSON and accepts an empty actions verdict', async () => {
+      const maker = makerMock(true);
+      vi.mocked(maker.oneShot).mockResolvedValue('not JSON');
+      readKey.mockReturnValue('fake-proxy-key');
+      fetchMock.mockResolvedValueOnce({
+        ok: true, json: async () => ({ choices: [{ message: { content: '{"actions":[]}' } }] }),
+      } as never);
+
+      expect((await advisor(maker).advisor.advise(evidence)).actions).toEqual([]);
+      expect(maker.oneShot).toHaveBeenCalledTimes(1);
+      expect(fetchMock).toHaveBeenCalledTimes(1);
+    });
+
+    it('fails safely after invalid custom-chain output without trying unrelated defaults', async () => {
+      selectClaude();
+      fetchMock.mockResolvedValueOnce({
+        ok: true, text: async () => JSON.stringify({ content: [{ type: 'text', text: 'private response body' }] }),
+      } as never);
+      const maker = makerMock(true);
+
+      await expect(advisor(maker).advisor.advise(evidence))
+        .rejects.toThrow('Dictionary learning failed: all_candidates_failed');
+      expect(fetchMock).toHaveBeenCalledTimes(1);
+      expect(maker.oneShot).not.toHaveBeenCalled();
+    });
+
+    it.each(['owner', 'chain'] as const)('does not dispatch a fallback after the %s changes', async (changed) => {
+      chainState.source = 'custom';
+      chainState.refs = ['litellm-kimi-k2.6', 'litellm-deepseek-v4-flash'];
+      readKey.mockReturnValue('fake-proxy-key');
+      fetchMock.mockImplementationOnce(async () => {
+        if (changed === 'owner') ownerState.key = 'owner-b';
+        else chainState.refs = ['litellm-gpt-5.4-mini'];
+        return { ok: true, json: async () => ({ choices: [{ message: { content: 'invalid' } }] }) } as never;
+      });
+
+      await expect(advisor().advisor.advise(evidence)).rejects.toThrow('Dictionary learning failed:');
+      expect(fetchMock).toHaveBeenCalledTimes(1);
+    });
+
+    it('rejects invalid output on an explicit route without using the auxiliary defaults', async () => {
+      selectClaude();
+      fetchMock.mockResolvedValueOnce({
+        ok: true, text: async () => JSON.stringify({ content: [{ type: 'text', text: 'invalid' }] }),
+      } as never);
+      const maker = makerMock(true);
+
+      const result = await requestUtilityText(maker, 'classify', {
+        providerId: 'anthropic', agentKind: 'claude-code', model: 'claude-haiku-4-5',
+        validateResponse: () => false,
+      });
+
+      expect(result).toMatchObject({ ok: false, reason: 'all_candidates_failed' });
+      expect(fetchMock).toHaveBeenCalledTimes(1);
+      expect(maker.oneShot).not.toHaveBeenCalled();
+    });
+  });
 
   it('tries a one-item custom chain in order and never expands to AUTO', async () => {
     chainState.source = 'custom';

--- a/apps/desktop/src/main/utility-model/oneShotCandidates.ts
+++ b/apps/desktop/src/main/utility-model/oneShotCandidates.ts
@@ -115,6 +115,8 @@ export type UtilityTextRequestOptions = {
   systemPrompt?: string;
   /** Additional output-shape instruction (mainly for Responses-compatible routes). */
   responseInstructions?: string;
+  /** Reject unusable output before selecting a winner, so the configured chain can continue. */
+  validateResponse?: (text: string) => boolean;
   /** Final ownership/config guard immediately before an explicit HTTP dispatch. */
   beforeDispatch?: (route: UtilityTextDispatchRoute) => Promise<boolean>;
   /** 显式任务来源；存在时禁止跨来源 fallback。 */
@@ -592,7 +594,7 @@ async function runDefaultProfileCandidates(
     };
     try {
       const text = (await candidate.execute(prompt, candidateOpts)).trim();
-      if (!text) throw new UtilityTextExecutionError({ reason: 'empty_response' });
+      validateUtilityResponse(text, opts);
       return {
         ok: true,
         text,
@@ -624,6 +626,13 @@ function failedChainResult(attempts: UtilityTextAttempt[]): UtilityTextResult {
       : 'all_candidates_failed';
   log.warn('all utility text candidates failed', { reason, attempts: attempts.length });
   return { ok: false, reason, attempts };
+}
+
+function validateUtilityResponse(text: string, opts?: UtilityTextRequestOptions): void {
+  if (!text) throw new UtilityTextExecutionError({ reason: 'empty_response' });
+  if (opts?.validateResponse && !opts.validateResponse(text)) {
+    throw new UtilityTextExecutionError({ reason: 'request_failed' });
+  }
 }
 
 async function requestDefaultUtilityText(
@@ -855,6 +864,7 @@ async function requestExplicitProviderText(
       signal: opts.signal,
       systemPrompt: opts.systemPrompt,
       responseInstructions: opts.responseInstructions,
+      validateResponse: opts.validateResponse,
       beforeDispatch: opts.beforeDispatch,
       routeStillCurrent,
     });
@@ -1029,6 +1039,7 @@ async function requestBuiltinProviderText(
     signal?: AbortSignal;
     systemPrompt?: string;
     responseInstructions?: string;
+    validateResponse?: (text: string) => boolean;
     beforeDispatch?: (route: UtilityTextDispatchRoute) => Promise<boolean>;
     routeStillCurrent?: () => boolean;
   },
@@ -1285,7 +1296,7 @@ async function executeCandidates(
       }
     try {
       const text = (await candidate.execute(prompt, opts)).trim();
-      if (!text) throw new UtilityTextExecutionError({ reason: 'empty_response' });
+      validateUtilityResponse(text, opts);
       log.info('explicit utility text provider succeeded', {
         providerId: candidate.providerId,
         model: candidate.model,

--- a/apps/desktop/src/main/voice-input/DictionaryLearningTextModelClient.ts
+++ b/apps/desktop/src/main/voice-input/DictionaryLearningTextModelClient.ts
@@ -22,6 +22,8 @@ export class DictionaryLearningTextModelClient implements TextModelClient {
     const result = await this.requestText(JSON.stringify(input.user), {
       systemPrompt: input.system,
       timeoutMs: 8_000,
+      // The advisor returns at most three actions, not a general text response.
+      maxTokens: 4_096,
       disableReasoning: true,
       beforeDispatch: async () => {
         this.assertRequestCurrent();
@@ -59,7 +61,8 @@ function parseDictionaryResponse(text: string): unknown {
   } catch {
     throw new Error('Invalid dictionary response');
   }
-  if (!parsed || typeof parsed !== 'object' || Array.isArray(parsed)) {
+  if (!parsed || typeof parsed !== 'object' || Array.isArray(parsed)
+    || !('actions' in parsed) || !Array.isArray(parsed.actions)) {
     throw new Error('Invalid dictionary response');
   }
   return parsed;

--- a/apps/desktop/src/main/voice-input/DictionaryLearningTextModelClient.ts
+++ b/apps/desktop/src/main/voice-input/DictionaryLearningTextModelClient.ts
@@ -1,0 +1,66 @@
+import type { TextModelClient } from '@cindy/voice-input-core';
+
+import type { UtilityTextResult } from '../../shared/utilityTextResult.js';
+import type { UtilityTextRequestOptions } from '../utility-model/oneShotCandidates.js';
+
+type RequestText = (prompt: string, opts: UtilityTextRequestOptions) => Promise<UtilityTextResult>;
+
+/** Adapt dictionary JSON requests to the full auxiliary chain, without voice transport filtering. */
+export class DictionaryLearningTextModelClient implements TextModelClient {
+  servedRoute?: { providerId: string; model: string };
+
+  constructor(
+    private readonly requestText: RequestText,
+    private readonly assertRequestCurrent: () => void,
+  ) {}
+
+  async requestJson<T>(input: Parameters<TextModelClient['requestJson']>[0]): Promise<T> {
+    this.assertRequestCurrent();
+    this.servedRoute = undefined;
+    // Model selection and fallback belong to requestUtilityText. The advisor's
+    // model/cache labels must not pin a provider or reintroduce the voice chain.
+    const result = await this.requestText(JSON.stringify(input.user), {
+      systemPrompt: input.system,
+      timeoutMs: 8_000,
+      disableReasoning: true,
+      beforeDispatch: async () => {
+        this.assertRequestCurrent();
+        return true;
+      },
+      validateResponse: (text) => {
+        try {
+          parseDictionaryResponse(text);
+          return true;
+        } catch {
+          return false;
+        }
+      },
+    });
+    this.assertRequestCurrent();
+    if (!result.ok) throw new Error(`Dictionary learning failed: ${result.reason}`);
+    const parsed = parseDictionaryResponse(result.text);
+    this.servedRoute = { providerId: result.providerId, model: result.model };
+    return parsed as T;
+  }
+}
+
+function parseDictionaryResponse(text: string): unknown {
+  // Preserve the previous clients' fenced/wrapped JSON compatibility, but
+  // never include model output in an exception sent to logs or the renderer.
+  let parsed: unknown;
+  try {
+    try {
+      parsed = JSON.parse(text.trim());
+    } catch {
+      const match = text.match(/\{[\s\S]*\}/);
+      if (!match) throw new Error('Invalid dictionary response');
+      parsed = JSON.parse(match[0]);
+    }
+  } catch {
+    throw new Error('Invalid dictionary response');
+  }
+  if (!parsed || typeof parsed !== 'object' || Array.isArray(parsed)) {
+    throw new Error('Invalid dictionary response');
+  }
+  return parsed;
+}

--- a/apps/desktop/src/main/voice-input/__tests__/DictionaryLearningTextModelClient.test.ts
+++ b/apps/desktop/src/main/voice-input/__tests__/DictionaryLearningTextModelClient.test.ts
@@ -1,0 +1,93 @@
+import { describe, expect, it, vi } from 'vitest';
+
+import type { UtilityTextResult } from '../../../shared/utilityTextResult.js';
+import type { UtilityTextRequestOptions } from '../../utility-model/oneShotCandidates.js';
+import { DictionaryLearningTextModelClient } from '../DictionaryLearningTextModelClient.js';
+
+const input = {
+  model: 'auxiliary',
+  schemaName: 'dictation_dictionary_learning',
+  system: 'Existing dictionary learning instructions',
+  user: { beforeText: 'web coding', afterText: 'Vibe Coding' },
+};
+const success: UtilityTextResult = {
+  ok: true,
+  text: '```json\n{"actions":[]}\n```',
+  providerId: 'anthropic',
+  model: 'fixture-model',
+  transport: 'litellm-chat-completions',
+};
+
+describe('DictionaryLearningTextModelClient', () => {
+  it('keeps system and evidence separate, accepts wrapped JSON, and leaves routing to the auxiliary chain', async () => {
+    const requestText = vi.fn<(prompt: string, opts: UtilityTextRequestOptions) => Promise<UtilityTextResult>>()
+      .mockResolvedValue(success);
+    const guard = vi.fn();
+    const client = new DictionaryLearningTextModelClient(requestText, guard);
+
+    await expect(client.requestJson(input)).resolves.toEqual({ actions: [] });
+
+    const [prompt, opts] = requestText.mock.calls[0];
+    expect(JSON.parse(prompt)).toEqual(input.user);
+    expect(opts.systemPrompt).toBe(input.system);
+    expect(opts).not.toHaveProperty('providerId');
+    expect(opts).not.toHaveProperty('model');
+    expect(opts).not.toHaveProperty('pinnedProfileId');
+    expect(opts.validateResponse?.(success.text)).toBe(true);
+    expect(opts.validateResponse?.('{"actions":[]}')).toBe(true);
+    for (const text of ['private response body', '{"actions":', 'null', '[]']) {
+      expect(opts.validateResponse?.(text)).toBe(false);
+    }
+    expect(client.servedRoute).toEqual({ providerId: 'anthropic', model: 'fixture-model' });
+    expect(guard).toHaveBeenCalledTimes(2);
+  });
+
+  it('checks the original request scope immediately before dispatch', async () => {
+    let current = true;
+    const guard = () => {
+      if (!current) throw new Error('request scope changed');
+    };
+    const requestText = vi.fn(async (_prompt: string, opts: UtilityTextRequestOptions) => {
+      current = false;
+      await opts.beforeDispatch?.({ providerId: 'anthropic', agentKind: 'claude-code', model: 'fixture' });
+      return success;
+    });
+
+    await expect(new DictionaryLearningTextModelClient(requestText, guard).requestJson(input))
+      .rejects.toThrow('request scope changed');
+  });
+
+  it('rejects a late success after the owner or auxiliary configuration changes', async () => {
+    let current = true;
+    const requestText = vi.fn(async () => {
+      current = false;
+      return success;
+    });
+    const client = new DictionaryLearningTextModelClient(requestText, () => {
+      if (!current) throw new Error('request scope changed');
+    });
+
+    await expect(client.requestJson(input)).rejects.toThrow('request scope changed');
+    expect(client.servedRoute).toBeUndefined();
+  });
+
+  it('reports exhausted auxiliary routes without exposing response bodies', async () => {
+    const requestText = vi.fn(async (): Promise<UtilityTextResult> => ({
+      ok: false, reason: 'all_candidates_failed', attempts: [],
+    }));
+    const client = new DictionaryLearningTextModelClient(requestText, () => {});
+
+    await expect(client.requestJson(input)).rejects.toThrow('Dictionary learning failed: all_candidates_failed');
+    expect(requestText).toHaveBeenCalledTimes(1);
+  });
+
+  it('does not return malformed JSON even if a requester ignores the validation hook', async () => {
+    const client = new DictionaryLearningTextModelClient(
+      async () => ({ ...success, text: 'private response body' }),
+      () => {},
+    );
+
+    await expect(client.requestJson(input)).rejects.toThrow(/^Invalid dictionary response$/);
+    expect(client.servedRoute).toBeUndefined();
+  });
+});

--- a/apps/desktop/src/main/voice-input/__tests__/DictionaryLearningTextModelClient.test.ts
+++ b/apps/desktop/src/main/voice-input/__tests__/DictionaryLearningTextModelClient.test.ts
@@ -30,12 +30,16 @@ describe('DictionaryLearningTextModelClient', () => {
     const [prompt, opts] = requestText.mock.calls[0];
     expect(JSON.parse(prompt)).toEqual(input.user);
     expect(opts.systemPrompt).toBe(input.system);
+    expect(opts.maxTokens).toBe(4_096);
     expect(opts).not.toHaveProperty('providerId');
     expect(opts).not.toHaveProperty('model');
     expect(opts).not.toHaveProperty('pinnedProfileId');
     expect(opts.validateResponse?.(success.text)).toBe(true);
     expect(opts.validateResponse?.('{"actions":[]}')).toBe(true);
-    for (const text of ['private response body', '{"actions":', 'null', '[]']) {
+    for (const text of [
+      'private response body', '{"actions":', 'null', '[]',
+      '{}', '{"action":"add_entry"}', '{"actions":null}', '{"actions":{}}',
+    ]) {
       expect(opts.validateResponse?.(text)).toBe(false);
     }
     expect(client.servedRoute).toEqual({ providerId: 'anthropic', model: 'fixture-model' });

--- a/apps/desktop/src/main/voice-input/index.ts
+++ b/apps/desktop/src/main/voice-input/index.ts
@@ -23,7 +23,9 @@ import {
   isProviderModelRouteDisabled,
   isUtilityRouteDisabled,
   isUtilityRoutePaymentRequired,
+  requestUtilityText,
 } from '../utility-model/oneShotCandidates.js';
+import { getMaker } from '../maker-host/index.js';
 import { getEffectiveAuxiliaryModelChainSnapshot } from '../utility-model/resolveAuxiliaryModelChain.js';
 import { getAppCapabilities } from '../appCapabilities.js';
 import { getProviderSecretStore } from '../secrets/providerSecretStore.js';
@@ -44,6 +46,7 @@ import {
   prewarmCodexResponsesEndpoint,
 } from './CodexResponsesTextModelClient.js';
 import { ElevenLabsScribeProvider } from './ElevenLabsScribeProvider.js';
+import { DictionaryLearningTextModelClient } from './DictionaryLearningTextModelClient.js';
 import { FallbackAsrProvider } from './FallbackAsrProvider.js';
 import {
   FallbackTextModelClient,
@@ -373,41 +376,15 @@ export async function adviseAndRecordVoiceInputDictionaryLearning(
     };
   }
 
-  // Same fallback chain as dictation refinement: the advisor is a background
-  // task, but a primary refiner outage should degrade to a backup model
-  // instead of silently dropping dictionary learning.
-  const {
-    refinerReadinessList: advisorReadinessList,
-    readyRefinerProfiles: readyAdvisorProfiles,
-  } = await resolveVoiceInputRefinerChainForRuntime();
-  const advisorHeadProfile = readyAdvisorProfiles[0];
-  if (!advisorHeadProfile) {
-    return {
-      ok: false,
-      error: advisorReadinessList[0]?.error ?? 'Dictionary learning advisor requires a configured refiner.',
-    };
-  }
-
   try {
-    const senderId = options.senderId ?? 'device-link';
-    const advisorAttempts: FallbackTextModelAttempt[] = readyAdvisorProfiles.map((profile) => ({
-      profileId: profile.id as VoiceInputRefinerProviderKind,
-      model: profile.model,
-      client: guardRefinerClientAgainstUnavailableRoute(
-        profile,
-        createVoiceInputTextModelClient(profile, {
-          beforeDispatch: () => {
-            assertVoiceInputOwnerScopeCurrent(ownerScopeKey, auxiliaryChainSnapshot);
-            assertRefinerRouteAvailable(profile);
-          },
-        }),
-      ),
-      promptCacheScope: `dictionaryLearning:${profile.id}:${senderId}`,
-    }));
+    const advisorClient = new DictionaryLearningTextModelClient(
+      (prompt, requestOptions) => requestUtilityText(getMaker(), prompt, requestOptions),
+      () => assertVoiceInputOwnerScopeCurrent(ownerScopeKey, auxiliaryChainSnapshot),
+    );
     const advisor = new DictationDictionaryAdvisor({
-      client: new FallbackTextModelClient(advisorAttempts),
-      model: advisorHeadProfile.model,
-      promptCacheScope: `dictionaryLearning:${advisorHeadProfile.id}:${senderId}`,
+      client: advisorClient,
+      // The adapter resolves the shared auxiliary chain; this is not a route pin.
+      model: 'auxiliary',
       debug: DICTIONARY_LEARNING_TEXT_DEBUG,
     });
     const settings = voiceInputDataStore.getSettings();
@@ -444,9 +421,8 @@ export async function adviseAndRecordVoiceInputDictionaryLearning(
         confidence: action.confidence,
         reason: action.reason,
       })),
-      refinerProvider: advisorHeadProfile.id,
-      refinerModel: advisorHeadProfile.model,
-      refinerChain: readyAdvisorProfiles.map((profile) => profile.id),
+      auxiliaryProvider: advisorClient.servedRoute?.providerId,
+      auxiliaryModel: advisorClient.servedRoute?.model,
       ignoreReason: result.ignoreReason,
       elapsedMs: Math.round(result.elapsedMs),
       debugText: DICTIONARY_LEARNING_TEXT_DEBUG


### PR DESCRIPTION
## 这次改了什么

### 摘要

词典学习原先虽然读取统一辅助模型配置，执行时仍经过语音润色的模型映射和两次尝试上限，导致选择 Claude 时无法使用、配置第三个备选时可能不会尝试。本 PR 让词典学习直接通过通用辅助模型入口执行，沿用用户选择的完整候选链。

为保留原有无效 JSON 回退行为，通用入口增加可选的响应校验回调，在候选成功前检查输出；词典适配器继续兼容包裹在代码块中的 JSON，并保留账号及配置切换后的请求隔离。日志记录实际成功的供应商和模型。词典请求显式传入 4096 token 输出预算，并要求响应包含 actions 数组；错误对象沿原候选链回退，合法空数组正常结束。

### 变更类型

- [x] `fix` 缺陷修复
- [ ] `feat` 新功能
- [ ] `refactor` / `perf` 重构或性能优化
- [ ] `docs` / `test` / `chore` 文档、测试或工程维护
- [ ] 其他：

### 范围

- 关联 Issue / 需求：词典学习统一使用辅助模型通道。
- 本 PR 包含：词典学习模型适配器、辅助模型候选输出校验、回归测试。
- 明确不包含：词典学习提示词、纠错判定、触发时机、存储、重试队列、ASR 与语音润色路径。
- 用户可见变化：词典学习遵守统一辅助模型选择，支持 Claude 和完整备选链；全部失败仍报告学习失败，不改用链外模型。
- 是否存在 breaking change：无。辅助模型默认值及 override、词典数据和 IPC 形状均不变。

### UI 变化

不涉及。

- 引用的设计规范：不涉及。

## 怎么验证的

### 自动验证

- 定向 Vitest：`DictionaryLearningTextModelClient.test.ts`、`oneShotCandidates.test.ts`、`auxiliaryCustomNoAgentFallback.test.ts`，106 个测试通过。
- `pnpm test:unit:related`：通过。
- 改动文件 ESLint：通过。
- `pnpm --filter desktop run --if-present typecheck`：通过。
- `pnpm check:dco`：通过，3 个签名提交。

新增用例覆盖 Claude 无 Codex 凭证调用、无效 JSON 与网络故障后尝试第三候选、合法空 actions 不重试、自定义链耗尽不越界、账号或配置切换中止、迟到结果丢弃，以及 system 与用户证据分离。profile、内置供应商和用户自建供应商三条执行路径均覆盖无效 actions 检查。

### 手工验证

已检查完整 diff。测试使用内存 fake 和模拟 HTTP 响应，没有读取真实账号或调用云模型。

### 未执行的验证

未启动 Desktop 做真实听写，也未实测 Windows、手机设备和真实供应商网络。
本地按仓库现行提交门禁执行相关单测；全仓单测由 CI 执行。

## 风险

### 风险分类

- [ ] 无已知风险
- [ ] SQLite / migration
- [ ] system prompt
- [ ] 协议兼容
- [x] 权限 / 安全 / 用户数据
- [ ] 存量插件兼容（批准状态 / 指纹 / manifest 校验 / 安装布局 / 包格式）
- [ ] 原生层 / fingerprint / OTA
- [ ] 跨平台差异
- [ ] 其他：

### 影响与回滚

- 影响范围：Desktop 词典学习的模型执行路径。沿用辅助模型现有凭证、供应商可用性和用户配置边界；保留派发前及写入前的 owner/config 检查，异常不带模型响应正文。通用响应校验为可选项，未启用的消费者行为不变。
- 多端：设备互联和手机继续调用原有被控 Desktop 学习入口，无新增协议或白名单；SSH 无新执行路径。
- 词典提示词和持久化格式不变，不新增授权要求、凭证存储或服务端接口。适配器使用通用通道的 8 秒请求超时；不再使用语音客户端的流式闲置计时。输出预算沿通道现有协议兼容策略传递；不支持此参数的路由仍遵循原处理，不承诺所有供应商的硬上限。
- 回滚 / 降级方式：回退本 PR 即恢复原执行路径，无数据迁移。

### 提交前检查

- [x] 已 review 完整 diff
- [x] 每个 commit 都带 DCO 签名（`git commit -s`）
- [x] UI 改动已在「UI 变化」注明引用的设计规范章节（不涉及 UI 则跳过）
- [x] 未提交凭证、令牌或授权文件
- [x] 已补充必要文档（适配器职责和校验回调以代码注释说明）
- [x] 已确认测试结果或说明未执行原因
