### PR TITLE
fix(desktop): 修复打开登录页即误报登录失败

### DIFF
--- a/apps/desktop/src/renderer/components/login/LoginPage.tsx
+++ b/apps/desktop/src/renderer/components/login/LoginPage.tsx
@@ -128,6 +128,7 @@ export function LoginPage({
   intent?: 'sign-in' | 'add-account';
   onClose?: () => void;
 }) {
+  // AddAccountLoginPage owns initialization: a second load would race its flow reset.
   const {
     isLoading,
     errorCode,
@@ -140,7 +141,7 @@ export function LoginPage({
     dispatchWithResult,
     clearError,
     enterLocalMode,
-  } = useLogin();
+  } = useLogin({ autoLoad: intent !== 'add-account' });
   const { t } = useTranslation();
   const handoff = useLoginHandoff();
   const isAddAccount = intent === 'add-account';

--- a/apps/desktop/src/renderer/components/login/__tests__/LoginPage.initialization.test.tsx
+++ b/apps/desktop/src/renderer/components/login/__tests__/LoginPage.initialization.test.tsx
@@ -1,0 +1,129 @@
+// @vitest-environment jsdom
+
+import { useState } from 'react';
+import { cleanup, render, screen, waitFor } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { MemoryRouter } from 'react-router-dom';
+import { CindyAuthClient, reduceAuthFlow, type AuthFlowState } from '@cindy/auth-client';
+import { createScenarioFetch } from '@cindy/auth-client/fixtures';
+import type { DesktopLoginActionResult } from '../../../../shared/authIpc';
+
+const auth = vi.hoisted(() => ({
+  value: {} as Record<string, unknown>,
+  loadLoginState: vi.fn<() => Promise<DesktopLoginActionResult>>(),
+  beginAddAccount: vi.fn<() => Promise<DesktopLoginActionResult>>(),
+  cancelAddAccount: vi.fn(async () => undefined),
+}));
+
+vi.mock('@/contexts/AuthContext', () => ({ useAuth: () => auth.value }));
+vi.mock('react-i18next', () => ({
+  useTranslation: () => ({ t: (key: string) => key }),
+}));
+vi.mock('@/components/title-bar/WindowControls', () => ({ WindowControls: () => null }));
+vi.mock('@/components/sidebar/AccountSwitcherDialog', () => ({
+  AccountSwitcherDialog: () => null,
+}));
+
+import { AppShellCoverProvider } from '@/contexts/AppShellCoverContext';
+import { AddAccountLoginPage } from '../AddAccountLoginPage';
+import { LoginPage } from '../LoginPage';
+
+let identifierState: AuthFlowState;
+let publishState: (state: AuthFlowState | null) => void;
+let epoch: number;
+
+function Harness({ addAccount = false }: { addAccount?: boolean }) {
+  const [loginState, setLoginState] = useState<AuthFlowState | null>(null);
+  publishState = setLoginState;
+  auth.value = {
+    loginState,
+    loadLoginState: auth.loadLoginState,
+    beginAddAccount: auth.beginAddAccount,
+    cancelAddAccount: auth.cancelAddAccount,
+  };
+  return (
+    <AppShellCoverProvider>
+      <MemoryRouter>{addAccount ? <AddAccountLoginPage /> : <LoginPage />}</MemoryRouter>
+    </AppShellCoverProvider>
+  );
+}
+
+beforeEach(async () => {
+  epoch = 0;
+  Object.defineProperty(window, 'electronAPI', {
+    configurable: true,
+    value: { platform: 'darwin' },
+  });
+  const providers = await new CindyAuthClient({
+    baseUrl: 'https://auth.scenario.invalid',
+    region: 'global',
+    deviceId: 'login-initialization-test',
+    clientType: 'desktop',
+    fetch: createScenarioFetch('providers:both', { region: 'global' })!,
+  }).getProviders();
+  identifierState = reduceAuthFlow(null, { type: 'providers-loaded', providers });
+
+  // Model main's epoch contract: beginAddAccount invalidates any earlier provider load.
+  auth.loadLoginState.mockImplementation(async () => {
+    const loadEpoch = epoch;
+    await Promise.resolve();
+    publishState(identifierState);
+    return loadEpoch === epoch
+      ? { success: true, state: identifierState }
+      : { success: false, code: 'AUTH_FLOW_SUPERSEDED', state: identifierState };
+  });
+  auth.beginAddAccount.mockImplementation(async () => {
+    epoch += 1;
+    await Promise.resolve();
+    publishState(identifierState);
+    return { success: true, state: identifierState };
+  });
+});
+
+afterEach(() => {
+  cleanup();
+  vi.clearAllMocks();
+});
+
+describe('login initialization ownership', () => {
+  it('opens add-account login without an invalidated load or a false failure', async () => {
+    render(<Harness addAccount />);
+
+    await screen.findByTestId('login-panel-identifier');
+    await waitFor(() => expect(auth.beginAddAccount).toHaveBeenCalledOnce());
+    expect(screen.queryByTestId('login-error-text')).toBeNull();
+    expect(auth.loadLoginState).not.toHaveBeenCalled();
+    expect(screen.getByTestId('login-input').getAttribute('style')).not.toContain(
+      'var(--login-error-fg)',
+    );
+  });
+
+  it('still initializes ordinary sign-in automatically', async () => {
+    render(<Harness />);
+
+    await screen.findByTestId('login-panel-identifier');
+    expect(auth.loadLoginState).toHaveBeenCalledOnce();
+    expect(auth.beginAddAccount).not.toHaveBeenCalled();
+    expect(screen.queryByTestId('login-error-text')).toBeNull();
+  });
+
+  it('preserves the retry screen when add-account initialization actually fails', async () => {
+    auth.beginAddAccount.mockImplementation(async () => {
+      const state: AuthFlowState = {
+        step: 'error',
+        code: 'AUTH_SERVICE_UNAVAILABLE',
+        recoverTo: 'identifier',
+      };
+      publishState(state);
+      return { success: false, code: state.code, state };
+    });
+    render(<Harness addAccount />);
+
+    await screen.findByTestId('login-panel-error');
+    expect(screen.getByTestId('login-error-retry')).toBeTruthy();
+    expect(screen.getByTestId('login-error-text').textContent).toBe(
+      'login.errors.AUTH_SERVICE_UNAVAILABLE',
+    );
+    expect(auth.loadLoginState).not.toHaveBeenCalled();
+  });
+});

--- a/apps/desktop/src/renderer/hooks/useLogin.ts
+++ b/apps/desktop/src/renderer/hooks/useLogin.ts
@@ -31,7 +31,7 @@ interface UseLoginReturn {
 }
 
 /** Coordinates presentation state while all credentials and tickets stay in main. */
-export function useLogin(): UseLoginReturn {
+export function useLogin({ autoLoad = true }: { autoLoad?: boolean } = {}): UseLoginReturn {
   const {
     loginState,
     loadLoginState,
@@ -47,7 +47,7 @@ export function useLogin(): UseLoginReturn {
   const loadingRef = useRef(false);
 
   useEffect(() => {
-    if (loginState || loadingRef.current) return;
+    if (!autoLoad || loginState || loadingRef.current) return;
     loadingRef.current = true;
     setIsLoading(true);
     void loadLoginState()
@@ -59,7 +59,7 @@ export function useLogin(): UseLoginReturn {
         loadingRef.current = false;
         setIsLoading(false);
       });
-  }, [loadLoginState, loginState]);
+  }, [autoLoad, loadLoginState, loginState]);
 
   const dispatchWithResult = useCallback(
     async (action: DesktopLoginAction): Promise<{ success: boolean; code: string | null }> => {


### PR DESCRIPTION
## 这次改了什么

### 摘要

从侧栏点击「登录」打开添加账号页面时，父页面和内层登录表单原先会同时初始化。父页面重置登录流程后，内层的旧请求返回 `AUTH_FLOW_SUPERSEDED`，导致用户尚未输入邮箱便看到「登录失败，请稍后重试」和红色输入框。

添加账号入口现在只由父页面负责初始化，普通登录页保留自动加载。补充组件回归测试，覆盖误报消失、普通登录初始化和真实服务故障的重试入口。

### 变更类型

- [ ] `feat` 新功能
- [x] `fix` 缺陷修复
- [ ] `refactor` / `perf` 重构或性能优化
- [ ] `docs` / `test` / `chore` 文档、测试或工程维护
- [ ] 其他：

### 范围

- 关联 Issue / 需求：用户反馈点击登录后、未操作即提示失败。
- 本 PR 包含：登录页初始化归属与三个组件回归用例。
- 明确不包含：服务端、凭证处理、授权协议或布局调整。
- 用户可见变化：打开登录页时不再误报失败；真实错误仍显示。
- 是否存在 breaking change：无。

### UI 变化

- 引用的设计规范：`docs/design-rules/DESIGN.md` §16.4，初始 identifier 页面与错误页面分离。仅修正错误状态来源，复用现有 Light/Dark 语义 token、输入框和错误提示组件。
- 平台：Desktop。未附实机截图；本次通过组件测试验证空输入框不出现错误文本和错误边框。

## 怎么验证的

### 自动验证

```text
pnpm --filter desktop exec vitest run src/renderer/components/login/__tests__/LoginPage.initialization.test.tsx
结果：3 个用例通过；临时恢复旧初始化调用时，误报与真实错误屏保留用例均失败，普通登录用例通过。

pnpm test:unit:related
结果：通过，覆盖本次三个改动文件的相关测试。

pnpm --filter desktop run --if-present typecheck
结果：通过。

pnpm --filter desktop exec eslint src/renderer/hooks/useLogin.ts src/renderer/components/login/LoginPage.tsx src/renderer/components/login/__tests__/LoginPage.initialization.test.tsx
结果：通过。

pnpm exec prettier --check apps/desktop/src/renderer/hooks/useLogin.ts apps/desktop/src/renderer/components/login/LoginPage.tsx apps/desktop/src/renderer/components/login/__tests__/LoginPage.initialization.test.tsx
git diff --check
结果：通过。
```

### 手工验证

已自审完整 diff，并通过恢复旧调用进行回归测试的反向验证。未启动 Desktop 进行手工操作。

### 未执行的验证

未执行真实账号登录或 Light/Dark 实机目检；本次验证使用 jsdom 组件与内存认证场景，不接触真实凭证。全量单测交由 CI 执行。

## 风险

### 风险分类

- [x] 无已知风险
- [ ] SQLite / migration
- [ ] system prompt
- [ ] 协议兼容
- [ ] 权限 / 安全 / 用户数据
- [ ] 存量插件兼容（批准状态 / 指纹 / manifest 校验 / 安装布局 / 包格式）
- [ ] 原生层 / fingerprint / OTA
- [ ] 跨平台差异
- [ ] 其他：

### 影响与回滚

- 影响范围：Desktop 添加账号页初始化；普通登录、登录动作、取消与服务故障处理继续沿用原有逻辑。无需数据迁移。
- 回滚 / 降级方式：回退本 PR 即可。

### 提交前检查

- [x] 已 review 完整 diff
- [x] 每个 commit 都带 DCO 签名（`git commit -s`，见 [DCO](../DCO)）
- [x] UI 改动已在「UI 变化」注明引用的设计规范章节（不涉及 UI 则跳过）
- [x] 未提交凭证、令牌或授权文件
- [x] 已补充必要文档（初始化归属代码注释；无需额外产品文档）
- [x] 已确认测试结果或说明未执行原因
