### PR TITLE
fix(codex): 等待退出完成并恢复损坏历史的 fork

### DIFF
--- a/apps/desktop/src/main/__tests__/fork.test.ts
+++ b/apps/desktop/src/main/__tests__/fork.test.ts
@@ -18,6 +18,7 @@ import path from 'node:path';
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { CodexResumePreparationBlockedError } from '@cindy/maker-core';
 import { CODEX_RESUME_NOT_READY_WIRE_MESSAGE } from '@cindy/maker-shared/agent-input-projection';
+import { computeForkSourceMessagesDigest } from '../localDb/forkRecoverySnapshot.js';
 
 const UUID_V4_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/;
 
@@ -672,7 +673,7 @@ describe('forkSessionAtMessage', () => {
       const args = txCalls[0]!.args as {
         sourceClearedAt: number; targetCreatedAt: number; targetRowid: number;
         newSession: Record<string, unknown>; nativeForkAnchorSessionMap?: unknown;
-        newMessageIds: Array<{ clientId: string }>; recoveryMarker: { createdAt: number; content: string };
+        newMessageIds: Array<{ clientId: string }>; recoveryMarker: { createdAt: number; content: string; sourceMessagesDigest: string };
       };
       expect(args.sourceClearedAt).toBe(500);
       expect(args.targetCreatedAt).toBe(futureTime);
@@ -680,6 +681,10 @@ describe('forkSessionAtMessage', () => {
       expect(args.newSession).toMatchObject({ sdkSessionId: null, contextTokens: 0, contextWindow: 0,
         totalTokenUsage: 0, totalCostUsd: 0, parentSessionId: 'src-session', forkedAtMessageId: 'target' });
       expect(args.nativeForkAnchorSessionMap).toBeUndefined();
+      expect(args.recoveryMarker.sourceMessagesDigest).toBe(computeForkSourceMessagesDigest(rows.map((row) => ({
+        client_id: row.clientId, role: row.role, content: row.content, tool_use_id: row.toolUseId,
+        agent_meta: row.agentMeta, agent_kind: row.agentKind, created_at: row.createdAt,
+      }))));
       const marker = JSON.parse(args.recoveryMarker.content);
       expect(marker).toMatchObject({ reason: 'native-session-recovery', consumed: false,
         sourceAgentKind: 'codex', sourceModel: 'gpt-5.5', sourceProviderId: 'xd',
@@ -773,7 +778,7 @@ describe('forkSessionAtMessage', () => {
     const txCall = txCalls.find((c) => c.name === 'fork.session');
     expect(txCall).toBeDefined();
     const txArgs = txCall!.args as {
-      recoveryMarker?: { content: string };
+      recoveryMarker?: { content: string; sourceMessagesDigest: string };
       targetCreatedAt: number;
       newSession: Record<string, unknown>;
       newMessageIds: Array<{ id: string; clientId: string }>;
@@ -787,6 +792,10 @@ describe('forkSessionAtMessage', () => {
     expect(txArgs.newMessageIds).toHaveLength(2);
     expect(txArgs.newSession.sdkSessionId).toBe(recover ? null : 'codex-thread-new');
     if (recover) {
+      expect(txArgs.recoveryMarker!.sourceMessagesDigest).toBe(computeForkSourceMessagesDigest([first, second].map((row) => ({
+        client_id: row.clientId, role: row.role, content: row.content, tool_use_id: row.toolUseId,
+        agent_meta: row.agentMeta, agent_kind: row.agentKind, created_at: row.createdAt,
+      }))));
       expect(JSON.parse(txArgs.recoveryMarker!.content)).toMatchObject({
         reason: 'native-session-recovery', consumed: false, sourceSdkSessionId: 'codex-thread-source',
         handoff: expect.stringContaining('[User]\nhello'),

--- a/apps/desktop/src/main/__tests__/fork.test.ts
+++ b/apps/desktop/src/main/__tests__/fork.test.ts
@@ -650,6 +650,63 @@ describe('forkSessionAtMessage', () => {
     expect(txCalls).toHaveLength(0);
   });
 
+  it.each(['user', 'assistant', 'first-user', 'recovered'] as const)(
+    'codex history recovery forks only the selected prefix atomically: %s', async (kind) => {
+      const futureTime = Date.now() + 60_000;
+      const source = makeSourceRow({ agentKind: 'codex', model: 'gpt-5.5', sdkSessionId: 'damaged-thread', clearedAt: 500 });
+      const target = makeMessageRow({ clientId: 'target', role: kind === 'assistant' || kind === 'recovered' ? 'assistant' : 'user', createdAt: futureTime, rowid: 20, content: '"target content"' });
+      const prior = makeMessageRow({ clientId: 'source-user', role: 'user', createdAt: futureTime - 1, content: '"keep prefix"' });
+      const rows = kind === 'first-user' ? [] : target.role === 'assistant' ? [prior, target] : [prior];
+      selectQueue.push([source], [target]);
+      if (target.role === 'assistant') selectQueue.push([makeMessageRow({ role: 'user', createdAt: futureTime, rowid: 30, content: '"future content"' })]);
+      selectQueue.push(rows, [makeSourceRow({ agentKind: 'codex', sdkSessionId: null })]);
+      if (kind === 'recovered') {
+        queryOneMock.mockResolvedValueOnce({ id: 'recovery', created_at: futureTime + 1, rowid: 40,
+          content: JSON.stringify({ reason: 'native-session-recovery', consumed: true, sourceAgentKind: 'codex', sourceModel: 'gpt-5.5', sourceProviderId: 'xd', handoff: 'old handoff with future content' }) });
+      } else {
+        forkSdkSessionMock.mockRejectedValueOnce(new Error('failed to prepare paginated fork: thread-store internal error: thread history projection for damaged-thread expected ordinal 259, got 258'));
+      }
+
+      const result = await forkSessionAtMessage('src-session', 'target');
+      expect(txCalls).toHaveLength(1);
+      const args = txCalls[0]!.args as {
+        sourceClearedAt: number; targetCreatedAt: number; targetRowid: number;
+        newSession: Record<string, unknown>; nativeForkAnchorSessionMap?: unknown;
+        newMessageIds: Array<{ clientId: string }>; recoveryMarker: { createdAt: number; content: string };
+      };
+      expect(args.sourceClearedAt).toBe(500);
+      expect(args.targetCreatedAt).toBe(futureTime);
+      expect(args.targetRowid).toBe(target.role === 'assistant' ? 30 : 20);
+      expect(args.newSession).toMatchObject({ sdkSessionId: null, contextTokens: 0, contextWindow: 0,
+        totalTokenUsage: 0, totalCostUsd: 0, parentSessionId: 'src-session', forkedAtMessageId: 'target' });
+      expect(args.nativeForkAnchorSessionMap).toBeUndefined();
+      const marker = JSON.parse(args.recoveryMarker.content);
+      expect(marker).toMatchObject({ reason: 'native-session-recovery', consumed: false,
+        sourceAgentKind: 'codex', sourceModel: 'gpt-5.5', sourceProviderId: 'xd',
+        sourceUserClientId: args.newMessageIds[0]?.clientId ?? null });
+      expect(args.recoveryMarker.createdAt).toBeGreaterThanOrEqual(rows.at(-1)?.createdAt ?? 0);
+      expect(marker.handoff).not.toContain('future content');
+      if (rows.length) expect(marker.handoff).toContain('keep prefix');
+      if (target.role === 'user') expect(marker.handoff).not.toContain('target content');
+      else expect(marker.handoff).toContain('target content');
+      expect(result._count?.messages).toBe(rows.length + 1);
+      expect(commitContextRebuildMock).not.toHaveBeenCalled();
+      expect(createMessageMock).not.toHaveBeenCalled();
+      if (kind === 'recovered') expect(forkSdkSessionMock).not.toHaveBeenCalled();
+      expect(source.sdkSessionId).toBe('damaged-thread');
+    },
+  );
+
+  it.each(['401 Unauthorized', 'thread/fork timed out after 30000ms', 'cancelled', 'ENOSPC: no space left on device'])(
+    'does not recover unrelated fork errors: %s', async (message) => {
+      selectQueue.push([makeSourceRow({ agentKind: 'codex' })], [makeMessageRow({ clientId: 'target' })],
+        [makeMessageRow({ role: 'assistant', content: '"history"' })]);
+      forkSdkSessionMock.mockRejectedValueOnce(new Error(message));
+      await expect(forkSessionAtMessage('src-session', 'target')).rejects.toMatchObject({ code: 'CODEX_FORK_STATE_UNAVAILABLE' });
+      expect(txCalls).toHaveLength(0);
+    },
+  );
+
   it('codex path: projects a blocked resume preparation without exposing diagnostics', async () => {
     const target = makeMessageRow({ id: 'target-user', role: 'user', createdAt: 3000 });
     selectQueue.push([
@@ -1186,7 +1243,7 @@ describe('forkSessionAtMessage', () => {
     expect(txArgs.newSession.providerId).toBeNull();
   });
 
-  it('restores the provider snapshot from a new historical switch boundary', async () => {
+  it.each([false, true])('restores the provider snapshot from a new historical switch boundary (recovery=%s)', async (recovery) => {
     const target = makeMessageRow({
       id: 'historical-codex-assistant',
       clientId: 'historical-codex-assistant-client',
@@ -1234,6 +1291,7 @@ describe('forkSessionAtMessage', () => {
       newSdkSessionId: 'forked-codex-session',
       uuidMap: new Map<string, string>(),
     });
+    if (recovery) forkSdkSessionMock.mockRejectedValueOnce(new Error('thread history projection for parked-codex-session expected ordinal 259, got 258'));
 
     await forkSessionAtMessage('src-session', 'historical-codex-assistant-client');
 
@@ -1246,6 +1304,13 @@ describe('forkSessionAtMessage', () => {
       }),
     );
     expect(inferProviderIdForModelMock).not.toHaveBeenCalled();
+    if (recovery) {
+      const args = txCalls[0]!.args as { recoveryMarker: { content: string }; newSession: Record<string, unknown> };
+      expect(JSON.parse(args.recoveryMarker.content)).toMatchObject({
+        sourceAgentKind: 'codex', sourceModel: 'google/gemini-3.7-flash', sourceProviderId: 'xd', sourceSdkSessionId: 'parked-codex-session',
+      });
+      expect(args.newSession).toMatchObject({ agentKind: 'codex', model: 'google/gemini-3.7-flash', providerId: 'xd', sdkSessionId: null });
+    }
   });
 
   it('restores provider from the nearest new entry boundary when the exit boundary is old', async () => {

--- a/apps/desktop/src/main/__tests__/lifecycle.test.ts
+++ b/apps/desktop/src/main/__tests__/lifecycle.test.ts
@@ -14,6 +14,7 @@ import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import ts from 'typescript';
 
 // lifecycle.ts 里 import { app } from 'electron' —— 用最小 stub 喂给它。
 // 真实退出路径 (信号 / before-quit) 不在本文件覆盖。
@@ -164,6 +165,42 @@ describe('runQuitDisposers', () => {
     await runQuitDisposers(1000);
 
     expect(log).toEqual(['a-sync', 'b-async', 'c-post']);
+  });
+
+  it.each([false, true])('keeps real bootstrap Codex and DB dependencies until Maker settles or times out (timeout=%s)', async (timesOut) => {
+    vi.useFakeTimers();
+    const { onQuit, runQuitDisposers } = await freshLifecycle();
+    // 读取真实注册顺序和 phase，避免测试中的手写编排与 bootstrap 漂移。
+    const source = ts.createSourceFile('bootstrap-electron.ts', readFileSync(join(__dirname, '../bootstrap-electron.ts'), 'utf8'), ts.ScriptTarget.Latest, true);
+    const names = new Set(['shutdown-maker', 'lsp-pool', 'pi-subagent-final-sweep', 'codex-env', 'codex-proxy', 'remote-ssh-pool', 'db-client', 'local-db-close']);
+    const registrations: Array<{ name: string; phase: 'sync' | 'async' | 'post-async' }> = [];
+    for (const node of source.statements) {
+      if (!ts.isExpressionStatement(node) || !ts.isCallExpression(node.expression)) continue;
+      const call = node.expression;
+      if (!ts.isIdentifier(call.expression) || call.expression.text !== 'onQuit') continue;
+      const [name, , phase] = call.arguments;
+      if (!name || !phase || !ts.isStringLiteral(name) || !ts.isStringLiteral(phase) || !names.has(name.text)) continue;
+      if (phase.text !== 'sync' && phase.text !== 'async' && phase.text !== 'post-async') throw new Error('invalid quit phase');
+      registrations.push({ name: name.text, phase: phase.text });
+    }
+    expect(registrations).toHaveLength(names.size);
+    const events: string[] = [];
+    let finish!: () => void;
+    const maker = new Promise<void>((resolve) => { finish = resolve; });
+    for (const { name, phase } of registrations) {
+      onQuit(name, name === 'shutdown-maker' ? async () => { await maker; events.push(name); } : () => { events.push(name); }, phase);
+    }
+    const quit = runQuitDisposers(100);
+    await vi.advanceTimersByTimeAsync(10);
+    expect(events).toEqual(['lsp-pool']);
+    if (timesOut) await vi.advanceTimersByTimeAsync(100);
+    else finish();
+    await quit;
+    expect(events).toEqual([
+      'lsp-pool', ...(timesOut ? [] : ['shutdown-maker']), 'pi-subagent-final-sweep',
+      'codex-env', 'codex-proxy', 'remote-ssh-pool', 'db-client', 'local-db-close',
+    ]);
+    finish();
   });
 
   it('sync disposer that throws does not block subsequent disposers', async () => {

--- a/apps/desktop/src/main/bootstrap-electron.ts
+++ b/apps/desktop/src/main/bootstrap-electron.ts
@@ -121,12 +121,9 @@ if (
 app.commandLine.appendSwitch('enable-features', 'SharedArrayBuffer');
 
 // agentManager 已在 vendor 大扫除时退役。app 退出 / 崩溃路径走 maker.shutdown()
-// 一刀切 — 它内部按 (Layer 1) 关所有 session → (Layer 2) dispose 所有 agent (Codex
-// shared app-server 子进程 SIGTERM, Claude no-op) 的固定顺序跑, 调用方不需要分两步。
-//
-// **必须 await**: m.shutdown() 内部的 kill 是异步串行的 — Layer 1 先 await 所有
-// session.close(), Layer 2 才在串行 dispose 里调 AppServerClient.close() 发 SIGTERM。
-// 如果在 sync 阶段 fire-and-forget, app.exit(0) 会在 kill 之前就把 Node 主进程掐掉,
+// 一刀切 — session detach 与 agent dispose 并发，避免某个 session 卡住其它进程收尾。
+// **必须 await**: Codex 会先通过 stdin EOF 保存并退出，超时才发信号。
+// 如果在 sync 阶段 fire-and-forget, app.exit(0) 会在收尾前把 Node 主进程掐掉,
 // Windows 上 codex app-server 子进程不会随父死 → 残留孤儿, 持有 binary 文件锁,
 // 用户下次启动时撞 EBUSY / 端口占用 (anthropic-compat-proxy 等)。
 async function shutdownMaker(): Promise<{ piSessionFailures: number }> {
@@ -138,11 +135,6 @@ async function shutdownMaker(): Promise<{ piSessionFailures: number }> {
   // 任何回收,worktree 原样留在磁盘,下次启动 recoverPool 对账(clean ephemeral 重新
   // 入池,dirty / 交互式的保留,session 重开可无缝续用)。
   rehydrateCloseSuppression.suppressAllForShutdown();
-  try {
-    await shutdownLspServerPool();
-  } catch (err) {
-    console.error('[main] lspPool.shutdown failed:', err);
-  }
   let piSessionFailures = 0;
   try {
     // splash 失败时 maker 未 init / getMakerCore() 抛错 —— 静默兜底, 没东西要清。
@@ -8954,14 +8946,11 @@ onQuit(
   'sync',
 );
 // Async 阶段: 并发跑, 6s 超时兜底。
-//   - shutdown-maker:       Layer 1 关 sessions → Layer 2 dispose agents (Codex
-//                           shared app-server 子进程 SIGTERM)。**必须 await** —
-//                           kill 是 Layer 2 才发出, fire-and-forget 会让 app.exit
-//                           在 kill 之前就掐掉 Node, Windows 上子进程会变孤儿。
+//   - shutdown-maker:       并发 detach sessions 与 dispose agents，等待进程退出。
+//                           fire-and-forget 会让 app.exit 抢先结束 Node。
 //   - im.dispose:           wsClient.stop() 内部先发 announce offline (quit path waits 4.5s)
 //                           再 close WS。**整个改造的核心目标——必须 await。**
-//   - codex env shutdown:   关 MCP HTTP bridge。语义上要在 maker.shutdown() 杀完
-//                           codex 子进程之后, 这里并发跑最坏是 log noise。
+//   - Codex 环境、proxy 和 DB 在 post-async 收尾，正常退出时保留到 Maker 完成。
 // (clean-exit-snapshot 已移除 — 退出时不再做 db.backup, 容灾改由 SQLite WAL crash
 //  recovery 兜底, 详见 localDb/index.ts 文件头 ADR-FE7 修订说明。)
 /**
@@ -9106,9 +9095,10 @@ onQuit(
   'async',
 );
 onQuit('review-artifact-snapshots', cleanupActiveReviewArtifactSnapshots, 'async');
+// LSP 不占用 Agent 正常保存和退出的时间窗口。
+onQuit('lsp-pool', shutdownLspServerPool, 'async');
 onQuit('orca-idle-watcher', () => stopOrcaIdleWatcher(), 'sync');
 onQuit('im', () => stopImConnection('quit'), 'async');
-onQuit('codex-env', () => shutdownCodexEnvironment(), 'async');
 // 轮 27 MEDIUM-3:pi-env 挪到 post-async —— 若与 shutdown-maker 同 async 并发,
 // bridge 可能在 session close 的 disposeSessionRegistrations(unregisterSessionCtx/
 // Token)之前关闭, 产生「pi dispose session registration failed (non-fatal)」
@@ -9243,6 +9233,9 @@ onQuit(
   'post-async',
 );
 onQuit('pi-env', () => shutdownPiEnvironment(), 'post-async');
+// 正常退出时保留到 Agent 和 Session 收尾完成；async 超时后仍按退出预算尽力清理。
+onQuit('codex-env', () => shutdownCodexEnvironment(), 'post-async');
+onQuit('codex-proxy', () => disposeCodexProxy(), 'post-async');
 // embedding-host: abort 语义 —— 立刻让出 SQLite 写连接, 不等当前 tick (那批 job 保持
 // pending 下次续跑, 写事务同步原子无中断)。
 onQuit('embedding-host', () => stopEmbeddingHost(), 'async');
@@ -9255,7 +9248,6 @@ onQuit('anthropic-compat-proxy', () => disposeAnthropicCompatProxy(), 'async');
 // browser + locked user-data-dir would otherwise survive quit and force a stale
 // SingletonLock recovery next launch). `stop` is idempotent / no-op if never started.
 onQuit('browser-runtime', () => disposeBrowserRuntime(), 'async');
-onQuit('codex-proxy', () => disposeCodexProxy(), 'async');
 // Remote file-service clients: 先于 pool 关闭, 挂断远端 daemon 的 exec channel。
 onQuit('remote-file-browser', () => disposeRemoteFileBrowser(), 'async');
 // Remote SSH pool: 主动断开所有活动连接, 防止 ssh2 子句柄阻塞 Node 进程退出。
@@ -9272,11 +9264,11 @@ onQuit('ios-simulator-exit-abort', abortIOSSimulatorOperationsForExit, 'sync');
 onQuit('hook-control', () => disposeHookControl(), 'sync');
 // session-git-pr-context: 取消 .git HEAD 的 parcel watcher 订阅, 防原生句柄阻塞退出。
 onQuit('git-context', () => disposeGitContext(), 'async');
-onQuit('db-client', () => lifecycleDbClientManager.dispose('quit'), 'async');
 onQuit('ios-simulator-host', disposeIOSSimulatorHost, 'async');
 onQuit('ios-simulator-ownership-registry', flushIOSSimulatorOwnershipRegistry, 'async');
 
 // Post-async 阶段: 串行跑, 确保依赖 async 阶段产物的清理 (WAL checkpoint by close)。
+onQuit('db-client', () => lifecycleDbClientManager.dispose('quit'), 'post-async');
 onQuit('local-db-close', () => localDbCloseDb(), 'post-async');
 
 installQuitHandler(6000);

--- a/apps/desktop/src/main/localDb/client/WorkerThreadTransport.ts
+++ b/apps/desktop/src/main/localDb/client/WorkerThreadTransport.ts
@@ -1773,6 +1773,11 @@ function forkSession(readyDb, args) {
     'INSERT INTO messages (id, client_id, session_id, role, content, tool_use_id, agent_meta, agent_kind, created_at, rewind_at) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, NULL)',
   );
   readyDb.transaction(() => {
+    if (payload.recoveryMarker != null && !readyDb.prepare(
+      'SELECT 1 FROM sessions WHERE id = ? AND cleared_at IS ?',
+    ).get(sourceSessionId, sourceClearedAt)) {
+      throw invalidArgs('Source history changed while preparing recovery fork');
+    }
     readyDb.prepare(
       'INSERT INTO sessions (id, title, working_dir, model, provider_id, effort, permission_mode, status, sdk_session_id, total_token_usage, total_cost_usd, context_tokens, context_window, fast_mode, cleared_at, pinned_at, user_send_at, agent_kind, workspace_kind, codex_history_has_product_prompt, parent_session_id, forked_at_message_id, created_at, updated_at) VALUES (?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?)',
     ).run(

--- a/apps/desktop/src/main/localDb/client/WorkerThreadTransport.ts
+++ b/apps/desktop/src/main/localDb/client/WorkerThreadTransport.ts
@@ -1749,6 +1749,18 @@ function parseAgentMeta(raw) {
   }
 }
 
+// Keep the inline fallback aligned with localDb/forkRecoverySnapshot.ts.
+function computeForkSourceMessagesDigest(rows) {
+  const hash = crypto.createHash('sha256');
+  for (const row of rows) {
+    hash.update(JSON.stringify([
+      row.client_id, row.role, row.content, row.tool_use_id ?? null,
+      row.agent_meta ?? null, row.agent_kind ?? null, row.created_at,
+    ])).update('\\n');
+  }
+  return hash.digest('hex');
+}
+
 function forkSession(readyDb, args) {
   const payload = asRecord(args, 'fork.session args');
   const sourceSessionId = expectString(payload.sourceSessionId, 'sourceSessionId');
@@ -1763,20 +1775,26 @@ function forkSession(readyDb, args) {
   const detachAgentSwitchSessions = payload.detachAgentSwitchSessions === true;
   const resetHandoffBoundaryClientId = nullableString(payload.resetHandoffBoundaryClientId);
   const newMessageIds = normalizeNewMessageIds(payload.newMessageIds);
-  const sourceMessages = readyDb.prepare(
-    'SELECT client_id, role, content, tool_use_id, agent_meta, agent_kind, created_at FROM messages WHERE session_id = ? AND (? IS NULL OR created_at > ?) AND (created_at < ? OR (? IS NOT NULL AND created_at = ? AND rowid < ?)) AND rewind_at IS NULL ORDER BY created_at ASC, rowid ASC',
-  ).all(sourceSessionId, sourceClearedAt, sourceClearedAt, targetCreatedAt, targetRowid, targetCreatedAt, targetRowid);
-  if (newMessageIds.length !== sourceMessages.length) {
-    throw invalidArgs('newMessageIds length mismatch: expected ' + sourceMessages.length + ', got ' + newMessageIds.length);
-  }
   const insertMessage = readyDb.prepare(
     'INSERT INTO messages (id, client_id, session_id, role, content, tool_use_id, agent_meta, agent_kind, created_at, rewind_at) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, NULL)',
   );
-  readyDb.transaction(() => {
+  return readyDb.transaction(() => {
     if (payload.recoveryMarker != null && !readyDb.prepare(
       'SELECT 1 FROM sessions WHERE id = ? AND cleared_at IS ?',
     ).get(sourceSessionId, sourceClearedAt)) {
       throw invalidArgs('Source history changed while preparing recovery fork');
+    }
+    const sourceMessages = readyDb.prepare(
+      'SELECT client_id, role, content, tool_use_id, agent_meta, agent_kind, created_at FROM messages WHERE session_id = ? AND (? IS NULL OR created_at > ?) AND (created_at < ? OR (? IS NOT NULL AND created_at = ? AND rowid < ?)) AND rewind_at IS NULL ORDER BY created_at ASC, rowid ASC',
+    ).all(sourceSessionId, sourceClearedAt, sourceClearedAt, targetCreatedAt, targetRowid, targetCreatedAt, targetRowid);
+    if (payload.recoveryMarker != null) {
+      const marker = asRecord(payload.recoveryMarker, 'recoveryMarker');
+      if (computeForkSourceMessagesDigest(sourceMessages) !== expectString(marker.sourceMessagesDigest, 'recoveryMarker.sourceMessagesDigest')) {
+        throw invalidArgs('Source history changed while preparing recovery fork');
+      }
+    }
+    if (newMessageIds.length !== sourceMessages.length) {
+      throw invalidArgs('newMessageIds length mismatch: expected ' + sourceMessages.length + ', got ' + newMessageIds.length);
     }
     readyDb.prepare(
       'INSERT INTO sessions (id, title, working_dir, model, provider_id, effort, permission_mode, status, sdk_session_id, total_token_usage, total_cost_usd, context_tokens, context_window, fast_mode, cleared_at, pinned_at, user_send_at, agent_kind, workspace_kind, codex_history_has_product_prompt, parent_session_id, forked_at_message_id, created_at, updated_at) VALUES (?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?)',
@@ -1835,8 +1853,8 @@ function forkSession(readyDb, args) {
         expectNumber(marker.createdAt, 'recoveryMarker.createdAt'),
       );
     }
+    return { messageCount: sourceMessages.length };
   })();
-  return { messageCount: sourceMessages.length };
 }
 
 function sanitizeForkedMessageContent(message, opts) {

--- a/apps/desktop/src/main/localDb/client/__tests__/tx.test.ts
+++ b/apps/desktop/src/main/localDb/client/__tests__/tx.test.ts
@@ -1803,6 +1803,25 @@ describe('db worker tx handlers', () => {
     });
   });
 
+  it.each([false, true])('recovery fork rejects a concurrent clear without reviving history (inline=%s)', async (useInlineWorker) => {
+    await withClient(async (client) => {
+      await seedSession(client, 'src');
+      await client.exec('INSERT INTO messages (id, client_id, session_id, role, content, created_at) VALUES (?, ?, ?, ?, ?, ?)',
+        ['m1', 'c1', 'src', 'user', 'cleared content', 100]);
+      await client.exec('UPDATE sessions SET cleared_at = 500 WHERE id = ?', ['src']);
+      await expect(client.tx('fork.session', {
+        sourceSessionId: 'src', sourceClearedAt: null, targetCreatedAt: 200,
+        newSession: sessionRow('forked', { sdkSessionId: null, parentSessionId: 'src' }),
+        uuidMap: [], newMessageIds: [{ id: 'copy1', clientId: 'copy-client1' }],
+        recoveryMarker: { id: 'recovery', clientId: 'handoff', createdAt: 300,
+          content: JSON.stringify({ reason: 'native-session-recovery', consumed: false, handoff: 'cleared content' }) },
+      })).rejects.toThrow('Source history changed');
+      expect(await client.queryOne('SELECT id FROM sessions WHERE id = ?', ['forked'])).toBeUndefined();
+      expect(await client.query('SELECT id FROM messages ORDER BY id')).toEqual([{ id: 'm1' }]);
+      expect(await client.queryOne('SELECT cleared_at FROM sessions WHERE id = ?', ['src'])).toEqual({ cleared_at: 500 });
+    }, { useInlineWorker });
+  });
+
   it('fork.session filters pre-clear/same-ms tail rows and detaches copied parked sessions', async () => {
     await withClient(async (client) => {
       await seedSession(client, 'src');

--- a/apps/desktop/src/main/localDb/client/__tests__/tx.test.ts
+++ b/apps/desktop/src/main/localDb/client/__tests__/tx.test.ts
@@ -7,6 +7,7 @@ import { afterAll, beforeAll, describe, expect, it } from 'vitest';
 
 import { SESSION_SOURCES } from '../../../../shared/sessionSource.js';
 import { buildDbWorkerBundle } from '../../__tests__/dbWorkerTestUtils.js';
+import { computeForkSourceMessagesDigest, type ForkSourceMessage } from '../../forkRecoverySnapshot.js';
 import type { DbClient } from '../DbClient.js';
 import { createDbClient } from '../DbClient.js';
 import type { SkillUsageApplyMutationArgs } from '../tx/types.js';
@@ -1737,7 +1738,9 @@ describe('db worker tx handlers', () => {
         sourceSessionId: 'src', targetCreatedAt: 200,
         newSession: sessionRow('forked', { sdkSessionId: null, parentSessionId: 'src' }),
         uuidMap: [], newMessageIds: [{ id: 'copy1', clientId: 'copy-client1' }],
-        recoveryMarker: { id: 'm1', clientId: 'handoff', createdAt: 300, content: JSON.stringify({ reason: 'native-session-recovery', consumed: false, handoff: 'keep my history' }) },
+        recoveryMarker: { id: 'm1', clientId: 'handoff', createdAt: 300,
+          sourceMessagesDigest: computeForkSourceMessagesDigest([{ client_id: 'c1', role: 'user', content: 'keep my history', tool_use_id: null, agent_meta: null, agent_kind: null, created_at: 100 }]),
+          content: JSON.stringify({ reason: 'native-session-recovery', consumed: false, handoff: 'keep my history' }) },
       };
       await expect(client.tx('fork.session', args)).rejects.toThrow();
       expect(await client.queryOne('SELECT id FROM sessions WHERE id = ?', ['forked'])).toBeUndefined();
@@ -1750,6 +1753,68 @@ describe('db worker tx handlers', () => {
       const card = await client.queryOne<{ agent_meta: string }>('SELECT agent_meta FROM messages WHERE id = ?', ['recovery:card']);
       expect(JSON.parse(card!.agent_meta)).toEqual({ contextRebuild: { reason: 'native-session-recovery', handoff: 'keep my history' } });
       expect(await client.queryOne('SELECT content FROM messages WHERE id = ?', ['m1'])).toEqual({ content: 'keep my history' });
+    }, { useInlineWorker });
+  });
+
+  it.each([false, true])('recovery fork validates the full ordered prefix despite unchanged count (inline=%s)', async (useInlineWorker) => {
+    await withClient(async (client) => {
+      await seedSession(client, 'src');
+      const originalContent = 'prefix\n'.repeat(5_000);
+      await client.exec(
+        'INSERT INTO messages (id, client_id, session_id, role, content, created_at) VALUES (?, ?, ?, ?, ?, ?), (?, ?, ?, ?, ?, ?)',
+        ['m1', 'c1', 'src', 'user', originalContent, 100, 'm2', 'c2', 'src', 'assistant', 'answer', 100],
+      );
+      const readPrefix = () => client.query<ForkSourceMessage>(
+        'SELECT client_id, role, content, tool_use_id, agent_meta, agent_kind, created_at FROM messages WHERE session_id = ? AND created_at < 200 ORDER BY created_at, rowid', ['src'],
+      );
+      const originalRows = await readPrefix();
+      const args = {
+        sourceSessionId: 'src', targetCreatedAt: 200,
+        newSession: sessionRow('forked', { sdkSessionId: null, parentSessionId: 'src' }),
+        uuidMap: [], newMessageIds: [{ id: 'copy1', clientId: 'copy-client1' }, { id: 'copy2', clientId: 'copy-client2' }],
+        recoveryMarker: { id: 'recovery', clientId: 'handoff', createdAt: 300,
+          sourceMessagesDigest: computeForkSourceMessagesDigest(originalRows),
+          content: JSON.stringify({ reason: 'native-session-recovery', consumed: false, handoff: 'bounded handoff from original prefix' }) },
+      };
+      const edits: Array<[string, unknown[]]> = [
+        ["UPDATE messages SET content = ? WHERE id = 'm1'", [originalContent + 'edited beyond the handoff limit']],
+        ["UPDATE messages SET client_id = ? WHERE id = 'm1'", ['replacement-client']],
+        ["UPDATE messages SET role = ? WHERE id = 'm1'", ['assistant']],
+        ["UPDATE messages SET tool_use_id = ? WHERE id = 'm1'", ['different-tool']],
+        ["UPDATE messages SET agent_meta = ? WHERE id = 'm1'", ['{"nativeForkAnchor":{"id":"changed"}}']],
+        ["UPDATE messages SET agent_kind = ? WHERE id = 'm1'", ['codex']],
+        ["UPDATE messages SET created_at = ? WHERE id = 'm1'", [101]],
+      ];
+      for (const [sql, params] of edits) {
+        await client.exec(sql, params);
+        const changedRows = await readPrefix();
+        expect(changedRows).toHaveLength(originalRows.length);
+        await expect(client.tx('fork.session', args)).rejects.toThrow('Source history changed');
+        expect(await client.queryOne('SELECT id FROM sessions WHERE id = ?', ['forked'])).toBeUndefined();
+        expect(await client.query('SELECT id FROM messages WHERE session_id = ?', ['forked'])).toEqual([]);
+        expect(await readPrefix()).toEqual(changedRows);
+        await client.exec("UPDATE messages SET client_id = 'c1', role = 'user', content = ?, tool_use_id = NULL, agent_meta = NULL, agent_kind = NULL, created_at = 100 WHERE id = 'm1'", [originalContent]);
+      }
+      // Edits outside the selected prefix do not invalidate this fork.
+      await client.exec("INSERT INTO messages (id, client_id, session_id, role, content, created_at) VALUES ('tail', 'tail-client', 'src', 'user', 'new tail', 200)");
+      await expect(client.tx('fork.session', args)).resolves.toEqual({ messageCount: 2 });
+      expect(await client.query('SELECT content FROM messages WHERE id IN (?, ?) ORDER BY id', ['copy1', 'copy2']))
+        .toEqual([{ content: originalContent }, { content: 'answer' }]);
+    }, { useInlineWorker });
+  });
+
+  it.each([false, true])('recovery fork accepts an unchanged empty prefix (inline=%s)', async (useInlineWorker) => {
+    await withClient(async (client) => {
+      await seedSession(client, 'src');
+      await expect(client.tx('fork.session', {
+        sourceSessionId: 'src', targetCreatedAt: 100,
+        newSession: sessionRow('forked', { sdkSessionId: null, parentSessionId: 'src' }),
+        uuidMap: [], newMessageIds: [],
+        recoveryMarker: { id: 'recovery', clientId: 'handoff', createdAt: 300,
+          sourceMessagesDigest: computeForkSourceMessagesDigest([]),
+          content: JSON.stringify({ reason: 'native-session-recovery', consumed: false, handoff: '' }) },
+      })).resolves.toEqual({ messageCount: 0 });
+      expect(await client.queryOne('SELECT id FROM sessions WHERE id = ?', ['forked'])).toEqual({ id: 'forked' });
     }, { useInlineWorker });
   });
 
@@ -1814,6 +1879,7 @@ describe('db worker tx handlers', () => {
         newSession: sessionRow('forked', { sdkSessionId: null, parentSessionId: 'src' }),
         uuidMap: [], newMessageIds: [{ id: 'copy1', clientId: 'copy-client1' }],
         recoveryMarker: { id: 'recovery', clientId: 'handoff', createdAt: 300,
+          sourceMessagesDigest: computeForkSourceMessagesDigest([{ client_id: 'c1', role: 'user', content: 'cleared content', tool_use_id: null, agent_meta: null, agent_kind: null, created_at: 100 }]),
           content: JSON.stringify({ reason: 'native-session-recovery', consumed: false, handoff: 'cleared content' }) },
       })).rejects.toThrow('Source history changed');
       expect(await client.queryOne('SELECT id FROM sessions WHERE id = ?', ['forked'])).toBeUndefined();

--- a/apps/desktop/src/main/localDb/client/tx/types.ts
+++ b/apps/desktop/src/main/localDb/client/tx/types.ts
@@ -169,7 +169,14 @@ export interface ForkSessionArgs {
    */
   newMessageIds: Array<{ id: string; clientId: string }>;
   /** Persist a native-history recovery handoff atomically with the child and copied history. */
-  recoveryMarker?: { id: string; clientId: string; content: string; createdAt: number };
+  recoveryMarker?: {
+    id: string;
+    clientId: string;
+    content: string;
+    createdAt: number;
+    /** Digest of the raw ordered prefix used to prepare content; checked inside the transaction. */
+    sourceMessagesDigest: string;
+  };
 }
 
 export interface EmbeddingMarkDoneArgs {

--- a/apps/desktop/src/main/localDb/forkRecoverySnapshot.ts
+++ b/apps/desktop/src/main/localDb/forkRecoverySnapshot.ts
@@ -1,0 +1,24 @@
+import { createHash } from 'node:crypto';
+
+/** Raw ordered prefix used for both the recovery handoff and the copied history. */
+export interface ForkSourceMessage {
+  client_id: string;
+  role: string;
+  content: string;
+  tool_use_id: string | null;
+  agent_meta: string | null;
+  agent_kind: string | null;
+  created_at: number;
+}
+
+/** Transaction precondition only; never persisted or derived from the truncated handoff. */
+export function computeForkSourceMessagesDigest(rows: readonly ForkSourceMessage[]): string {
+  const hash = createHash('sha256');
+  for (const row of rows) {
+    hash.update(JSON.stringify([
+      row.client_id, row.role, row.content, row.tool_use_id ?? null,
+      row.agent_meta ?? null, row.agent_kind ?? null, row.created_at,
+    ])).update('\n');
+  }
+  return hash.digest('hex');
+}

--- a/apps/desktop/src/main/localDb/worker/opHandlers/tx.ts
+++ b/apps/desktop/src/main/localDb/worker/opHandlers/tx.ts
@@ -4,6 +4,7 @@
 import type Database from 'better-sqlite3';
 
 import type { DbTxName } from '../../client/tx/types.js';
+import { computeForkSourceMessagesDigest, type ForkSourceMessage } from '../../forkRecoverySnapshot.js';
 import { normalizeWorkingDirForStorage } from '../../../../shared/workingDir.js';
 import { capImportedToolResultContent } from '../../../../shared/toolResultPersistCap.js';
 import {
@@ -1599,40 +1600,6 @@ function forkSession(db: Database.Database, args: unknown): { messageCount: numb
   const detachAgentSwitchSessions = payload.detachAgentSwitchSessions === true;
   const resetHandoffBoundaryClientId = nullableString(payload.resetHandoffBoundaryClientId);
   const newMessageIds = normalizeNewMessageIds(payload.newMessageIds);
-  const sourceMessages = db
-    .prepare(
-      `SELECT client_id, role, content, tool_use_id, agent_meta, agent_kind, created_at
-       FROM messages
-      WHERE session_id = ?
-        AND (? IS NULL OR created_at > ?)
-        AND (
-          created_at < ?
-          OR (? IS NOT NULL AND created_at = ? AND rowid < ?)
-        )
-        AND rewind_at IS NULL
-      ORDER BY created_at ASC, rowid ASC`,
-  ).all(
-    sourceSessionId,
-    sourceClearedAt,
-    sourceClearedAt,
-    targetCreatedAt,
-    targetRowid,
-    targetCreatedAt,
-    targetRowid,
-  ) as Array<{
-    client_id: string;
-    role: string;
-    content: string;
-    tool_use_id: string | null;
-    agent_meta: string | null;
-    agent_kind: string | null;
-    created_at: number;
-  }>;
-  if (newMessageIds.length !== sourceMessages.length) {
-    throw invalidArgs(
-      `newMessageIds length mismatch: expected ${sourceMessages.length}, got ${newMessageIds.length}`,
-    );
-  }
   const insertMessage = db.prepare(
     `INSERT INTO messages
       (id, client_id, session_id, role, content, tool_use_id, agent_meta, agent_kind, created_at, rewind_at)
@@ -1643,6 +1610,28 @@ function forkSession(db: Database.Database, args: unknown): { messageCount: numb
       'SELECT 1 FROM sessions WHERE id = ? AND cleared_at IS ?',
     ).get(sourceSessionId, sourceClearedAt)) {
       throw invalidArgs('Source history changed while preparing recovery fork');
+    }
+    const sourceMessages = db.prepare(
+      `SELECT client_id, role, content, tool_use_id, agent_meta, agent_kind, created_at
+       FROM messages
+       WHERE session_id = ?
+         AND (? IS NULL OR created_at > ?)
+         AND (created_at < ? OR (? IS NOT NULL AND created_at = ? AND rowid < ?))
+         AND rewind_at IS NULL
+       ORDER BY created_at ASC, rowid ASC`,
+    ).all(sourceSessionId, sourceClearedAt, sourceClearedAt, targetCreatedAt,
+      targetRowid, targetCreatedAt, targetRowid) as ForkSourceMessage[];
+    if (payload.recoveryMarker != null) {
+      const marker = asRecord(payload.recoveryMarker, 'recoveryMarker');
+      if (computeForkSourceMessagesDigest(sourceMessages)
+        !== expectString(marker.sourceMessagesDigest, 'recoveryMarker.sourceMessagesDigest')) {
+        throw invalidArgs('Source history changed while preparing recovery fork');
+      }
+    }
+    if (newMessageIds.length !== sourceMessages.length) {
+      throw invalidArgs(
+        `newMessageIds length mismatch: expected ${sourceMessages.length}, got ${newMessageIds.length}`,
+      );
     }
     db.prepare(
       `INSERT INTO sessions (
@@ -1731,9 +1720,9 @@ function forkSession(db: Database.Database, args: unknown): { messageCount: numb
         expectNumber(marker.createdAt, 'recoveryMarker.createdAt'),
       );
     }
+    return { messageCount: sourceMessages.length };
   });
-  transaction();
-  return { messageCount: sourceMessages.length };
+  return transaction();
 }
 
 /** 复制边界只保留可见语义；vendor session 绑定必须属于父分支。 */

--- a/apps/desktop/src/main/localDb/worker/opHandlers/tx.ts
+++ b/apps/desktop/src/main/localDb/worker/opHandlers/tx.ts
@@ -1639,6 +1639,11 @@ function forkSession(db: Database.Database, args: unknown): { messageCount: numb
      VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, NULL)`,
   );
   const transaction = db.transaction(() => {
+    if (payload.recoveryMarker != null && !db.prepare(
+      'SELECT 1 FROM sessions WHERE id = ? AND cleared_at IS ?',
+    ).get(sourceSessionId, sourceClearedAt)) {
+      throw invalidArgs('Source history changed while preparing recovery fork');
+    }
     db.prepare(
       `INSERT INTO sessions (
         id, title, working_dir, model, provider_id, effort, permission_mode, status,

--- a/apps/desktop/src/main/maker-orchestration/fork.ts
+++ b/apps/desktop/src/main/maker-orchestration/fork.ts
@@ -17,6 +17,7 @@ import { CODEX_RESUME_NOT_READY_WIRE_MESSAGE } from '@cindy/maker-shared/agent-i
 import { getDbClient } from '../localDb/client/current';
 import { sessions, messages } from '../localDb/schema';
 import { sessionToCamel } from '../localDb/mapper';
+import { computeForkSourceMessagesDigest } from '../localDb/forkRecoverySnapshot.js';
 import { commitContextRebuild, createMessage } from '../localDb/ipc/messages.js';
 import { getMaker } from '../maker-host/index.js';
 import { inferProviderIdForModel } from '../maker-host/provider-route.js';
@@ -116,7 +117,7 @@ function parseJsonContent(content: string): unknown {
 /** 用实际复制的前缀建立交接，和子任务、恢复卡一起原子保存。 */
 function buildCodexForkRecoveryMarker(opts: {
   source: { model: string; providerId: string | null; sdkSessionId: string | null };
-  rows: Array<Pick<ForkTimelineMessage, 'role' | 'content' | 'createdAt' | 'toolUseId'>>;
+  rows: Array<Pick<ForkTimelineMessage, 'clientId' | 'role' | 'content' | 'createdAt' | 'toolUseId' | 'agentMeta' | 'agentKind'>>;
   newMessageIds: Array<{ clientId: string }>;
   sessionId: string;
   now: number;
@@ -124,6 +125,11 @@ function buildCodexForkRecoveryMarker(opts: {
   return {
     id: createId(),
     clientId: createId(),
+    sourceMessagesDigest: computeForkSourceMessagesDigest(opts.rows.map((row) => ({
+      client_id: row.clientId, role: row.role, content: row.content,
+      tool_use_id: row.toolUseId, agent_meta: row.agentMeta, agent_kind: row.agentKind,
+      created_at: row.createdAt,
+    }))),
     // 导入历史可能有晚于墙钟的合成时间；恢复边界必须排在复制内容之后。
     createdAt: opts.rows.reduce((latest, row) => Math.max(latest, row.createdAt), opts.now),
     content: JSON.stringify({

--- a/apps/desktop/src/main/maker-orchestration/fork.ts
+++ b/apps/desktop/src/main/maker-orchestration/fork.ts
@@ -4,7 +4,8 @@
  * 流程：读 source → 校验 target message (user / assistant) → 计算复制边界与
  *      agent 侧截断信息 → 调 SDK fork → SQLite 事务 insert + bulk copy messages。
  *
- * SDK 调用必须在事务外——SDK 失败时 DB 完全没动；DB 失败时 SDK jsonl 已落盘
+ * SDK 调用必须在事务外——确定性历史损坏可从 Cindy 消息恢复；其它失败不写 DB。
+ * DB 失败时 SDK jsonl 已落盘
  * 变成"孤儿 jsonl"，可接受（数量极少，留给后续清理脚本）。
  */
 
@@ -110,6 +111,42 @@ function parseJsonContent(content: string): unknown {
   } catch {
     return content;
   }
+}
+
+/** 用实际复制的前缀建立交接，和子任务、恢复卡一起原子保存。 */
+function buildCodexForkRecoveryMarker(opts: {
+  source: { model: string; providerId: string | null; sdkSessionId: string | null };
+  rows: Array<Pick<ForkTimelineMessage, 'role' | 'content' | 'createdAt' | 'toolUseId'>>;
+  newMessageIds: Array<{ clientId: string }>;
+  sessionId: string;
+  now: number;
+}) {
+  return {
+    id: createId(),
+    clientId: createId(),
+    // 导入历史可能有晚于墙钟的合成时间；恢复边界必须排在复制内容之后。
+    createdAt: opts.rows.reduce((latest, row) => Math.max(latest, row.createdAt), opts.now),
+    content: JSON.stringify({
+      reason: 'native-session-recovery',
+      consumed: false,
+      sourceAgentKind: 'codex',
+      sourceModel: opts.source.model,
+      sourceProviderId: opts.source.providerId,
+      sourceSdkSessionId: opts.source.sdkSessionId,
+      sourceUserClientId: opts.newMessageIds[opts.rows.findLastIndex((row) => row.role === 'user')]?.clientId ?? null,
+      handoff: buildHandoffText(opts.rows.filter((row) => row.role !== 'error').map((row) => ({
+        role: row.role,
+        content: parseJsonContent(row.content),
+        createdAt: row.createdAt,
+        toolUseId: row.toolUseId,
+      })), {
+        fromLabel: 'Codex',
+        toLabel: 'Codex',
+        sessionId: opts.sessionId,
+        reason: 'native-session-recovery',
+      }),
+    }),
+  };
 }
 
 async function seedForkHandoffAfterSameEngineRebuild(opts: {
@@ -832,6 +869,9 @@ export async function forkSessionAtMessage(
   let uuidMap = new Map<string, string>();
   let initialContextTokens: number | undefined;
   let usedNativeForkAnchor = false;
+  let needsHistoryRecovery = isCodex
+    && !forkSource.reuseVendorSession
+    && forkSource.rebuildReason === 'native-session-recovery';
   if (
     forkSource.reuseVendorSession &&
     forkSource.sdkSessionId &&
@@ -856,19 +896,32 @@ export async function forkSessionAtMessage(
         // 错误码 + 文案,只有真 codex 失败才包装。pi 与 cc 一样裸抛原始错误(不会拿到指名道姓
         // 错对象的 "Codex 状态不可用" 提示)。改成 usesTailTurnFork 会让 pi 误报成 codex 错误。
         if (!isCodex) throw err;
+        if (isCodexHistoryRecoveryRequired(err) && (sourceMessages.length > 0 || target.role === 'user')) {
+          // 首条 user 之前的空前缀也是合法 fork；其它错误不得变成丢上下文的新任务。
+          needsHistoryRecovery = true;
+          return {
+            newSdkSessionId: null,
+            uuidMap: new Map<string, string>(),
+            initialContextTokens: undefined,
+            usedNativeForkAnchor: false,
+          };
+        }
         const detail = codexForkFailureDetail(err);
         throw forkError('CODEX_FORK_STATE_UNAVAILABLE', detail);
       });
     ({ newSdkSessionId, uuidMap, initialContextTokens, usedNativeForkAnchor = false } = forkResult);
   }
   const forkContextTokens = normalizePositiveInt(initialContextTokens);
-  const forkContextWindow = normalizePositiveInt(source.contextWindow);
+  const forkContextWindow = needsHistoryRecovery ? 0 : normalizePositiveInt(source.contextWindow);
 
   // 5. SQLite 事务：insert 新 session + bulk copy messages
   const now = Date.now();
   const newSessionId = createBusinessSessionId();
 
   const newMessageIds = sourceMessages.map(() => ({ id: createId(), clientId: createId() }));
+  const recoveryMarker = needsHistoryRecovery ? buildCodexForkRecoveryMarker({
+    source: forkSource, rows: sourceMessages, newMessageIds, sessionId: newSessionId, now,
+  }) : undefined;
   // pi 与 codex 一样:uuidMap 空、无 Claude transcript 锚点,跳过 Claude 专用的
   // synthetic uuid 补全 / parentUuid 采集(只有 Claude cc 需要)。
   const txUuidMap = usesTailTurnFork
@@ -926,6 +979,7 @@ export async function forkSessionAtMessage(
       detachAgentSwitchSessions: true,
       resetHandoffBoundaryClientId,
       newMessageIds,
+      recoveryMarker,
     });
   } catch (err) {
     // 轮 40-w4-t13 HIGH:SDK 侧已创建新 session file(forkSdkSession), DB 事务
@@ -945,7 +999,7 @@ export async function forkSessionAtMessage(
   if (!row) {
     throw new Error('Fork session 创建后查询失败');
   }
-  if (!forkSource.reuseVendorSession && forkSource.rebuildReason) {
+  if (!needsHistoryRecovery && !forkSource.reuseVendorSession && forkSource.rebuildReason) {
     await seedForkHandoffAfterSameEngineRebuild({
       sessionId: newSessionId,
       rows: sourceMessages,
@@ -955,7 +1009,7 @@ export async function forkSessionAtMessage(
       reason: forkSource.rebuildReason,
     });
   }
-  return sessionToCamel({ ...row, messageCount: sourceMessages.length });
+  return sessionToCamel({ ...row, messageCount: sourceMessages.length + (recoveryMarker ? 1 : 0) });
 }
 
 export async function forkSessionStripEncrypted(sourceSessionId: string): Promise<Session> {
@@ -1067,31 +1121,9 @@ export async function forkSessionStripEncrypted(sourceSessionId: string): Promis
   const now = Date.now();
   const newSessionId = createBusinessSessionId();
   const newMessageIds = sourceMessages.map(() => ({ id: createId(), clientId: createId() }));
-  const recoveryMarker = newSdkSessionId === null ? {
-    id: createId(),
-    clientId: createId(),
-    createdAt: now,
-    content: JSON.stringify({
-      reason: 'native-session-recovery',
-      consumed: false,
-      sourceAgentKind: 'codex',
-      sourceModel: source.model,
-      sourceProviderId: source.providerId,
-      sourceSdkSessionId: source.sdkSessionId,
-      sourceUserClientId: newMessageIds[sourceMessages.findLastIndex((row) => row.role === 'user')]?.clientId ?? null,
-      handoff: buildHandoffText(sourceMessages.filter((row) => row.role !== 'error').map((row) => ({
-        role: row.role,
-        content: parseJsonContent(row.content),
-        createdAt: row.createdAt,
-        toolUseId: row.toolUseId,
-      })), {
-        fromLabel: 'Codex',
-        toLabel: 'Codex',
-        sessionId: newSessionId,
-        reason: 'native-session-recovery',
-      }),
-    }),
-  } : undefined;
+  const recoveryMarker = newSdkSessionId === null ? buildCodexForkRecoveryMarker({
+    source, rows: sourceMessages, newMessageIds, sessionId: newSessionId, now,
+  }) : undefined;
   await getDbClient().tx('fork.session', {
     sourceSessionId,
     sourceClearedAt: source.clearedAt,

--- a/packages/maker-core/src/agents/codex/app-server/client.test.ts
+++ b/packages/maker-core/src/agents/codex/app-server/client.test.ts
@@ -363,8 +363,18 @@ describe('AppServerClient close completion', () => {
     if (fails) fail(new Error('exit not confirmed'));
     else finish();
     await Promise.all([first, strictResult]);
-    if (fails) await expect(client.close({ throwOnTransportError: true })).rejects.toThrow('exit not confirmed');
     expect(close).toHaveBeenCalledOnce();
+    if (fails) {
+      await expect(client.close({ throwOnTransportError: true })).rejects.toThrow('exit not confirmed');
+      expect(close).toHaveBeenCalledTimes(2);
+      close.mockResolvedValue(undefined);
+      await Promise.all([client.close(), client.close({ throwOnTransportError: true })]);
+      expect(close).toHaveBeenCalledTimes(3);
+      await expect(strict).rejects.toThrow('exit not confirmed');
+    }
+    await expect(client.close({ throwOnTransportError: true })).resolves.toBeUndefined();
+    expect(close).toHaveBeenCalledTimes(fails ? 3 : 1);
+    await expect(client.request('initialize')).rejects.toThrow('after close');
   });
 });
 

--- a/packages/maker-core/src/agents/codex/app-server/client.test.ts
+++ b/packages/maker-core/src/agents/codex/app-server/client.test.ts
@@ -341,6 +341,33 @@ describe('AppServerClient auth invalidation', () => {
   });
 });
 
+describe('AppServerClient close completion', () => {
+  it.each([false, true])('shares one close result without losing per-call error policy (failure=%s)', async (fails) => {
+    const transport = new FakeTransport();
+    let finish!: () => void;
+    let fail!: (error: Error) => void;
+    const completion = new Promise<void>((resolve, reject) => { finish = resolve; fail = reject; });
+    const close = vi.spyOn(transport, 'close').mockImplementation(() => completion);
+    const client = new AppServerClient({ createTransport: () => transport, logger });
+    client.start();
+    const requestFailure = expect(client.request('initialize')).rejects.toThrow('closed');
+    const settled = vi.fn();
+    const first = client.close().then(settled);
+    const strict = client.close({ throwOnTransportError: true });
+    const strictResult = fails
+      ? expect(strict).rejects.toThrow('exit not confirmed')
+      : expect(strict).resolves.toBeUndefined();
+    await requestFailure;
+    expect(settled).not.toHaveBeenCalled();
+    expect(close).toHaveBeenCalledOnce();
+    if (fails) fail(new Error('exit not confirmed'));
+    else finish();
+    await Promise.all([first, strictResult]);
+    if (fails) await expect(client.close({ throwOnTransportError: true })).rejects.toThrow('exit not confirmed');
+    expect(close).toHaveBeenCalledOnce();
+  });
+});
+
 describe('AppServerClient request timeout', () => {
   it('rejects and removes a pending request when the server stays connected without responding', async () => {
     vi.useFakeTimers();

--- a/packages/maker-core/src/agents/codex/app-server/client.ts
+++ b/packages/maker-core/src/agents/codex/app-server/client.ts
@@ -246,6 +246,7 @@ export class AppServerClient {
   private initialized = false;
   /** close() 调用后置 true, 阻止后续 request / 重复 close 的副作用。 */
   private closed = false;
+  private closePromise: Promise<void> | null = null;
 
   constructor(opts: AppServerClientOptions) {
     if (typeof opts.createTransport !== 'function') {
@@ -318,26 +319,28 @@ export class AppServerClient {
    * - 关闭 transport (杀子进程 / 关 ssh channel)
    */
   async close(opts?: { reason?: string; throwOnTransportError?: boolean }): Promise<void> {
-    if (this.closed) return;
-    this.closed = true;
-    const reason = opts?.reason ?? 'AppServerClient.close()';
+    if (!this.closePromise) {
+      this.closed = true;
+      const reason = opts?.reason ?? 'AppServerClient.close()';
+      // 缓存未吞错的完成结果，各调用方独立选择是否传播失败。
+      this.closePromise = Promise.resolve().then(() => this.transport?.close(reason)).catch((error) => {
+        this.logger.warn('transport.close threw', { message: (error as Error).message });
+        throw error;
+      });
 
-    // reject 所有挂起 request — 上层 await 不会无限等。
-    const err = new Error(`codex app-server closed: ${reason}`);
-    for (const [, pending] of this.pending) {
-      if (pending.timeoutId) clearTimeout(pending.timeoutId);
-      pending.reject(err);
-    }
-    this.pending.clear();
-    this.writeFailureTombstones.clear();
-
-    if (this.transport) {
-      try {
-        await this.transport.close(reason);
-      } catch (e) {
-        this.logger.warn('transport.close threw', { message: (e as Error).message });
-        if (opts?.throwOnTransportError) throw e;
+      // reject 所有挂起 request — 包括正在 initialize 的调用。
+      const err = new Error(`codex app-server closed: ${reason}`);
+      for (const [, pending] of this.pending) {
+        if (pending.timeoutId) clearTimeout(pending.timeoutId);
+        pending.reject(err);
       }
+      this.pending.clear();
+      this.writeFailureTombstones.clear();
+    }
+    try {
+      await this.closePromise;
+    } catch (error) {
+      if (opts?.throwOnTransportError) throw error;
     }
   }
 

--- a/packages/maker-core/src/agents/codex/app-server/client.ts
+++ b/packages/maker-core/src/agents/codex/app-server/client.ts
@@ -323,10 +323,13 @@ export class AppServerClient {
       this.closed = true;
       const reason = opts?.reason ?? 'AppServerClient.close()';
       // 缓存未吞错的完成结果，各调用方独立选择是否传播失败。
-      this.closePromise = Promise.resolve().then(() => this.transport?.close(reason)).catch((error) => {
+      const closePromise = Promise.resolve().then(() => this.transport?.close(reason)).catch((error) => {
+        // 保留 closed，后续调用仅重查幂等关闭，不重新开放协议。
+        if (this.closePromise === closePromise) this.closePromise = null;
         this.logger.warn('transport.close threw', { message: (error as Error).message });
         throw error;
       });
+      this.closePromise = closePromise;
 
       // reject 所有挂起 request — 包括正在 initialize 的调用。
       const err = new Error(`codex app-server closed: ${reason}`);

--- a/packages/maker-core/src/agents/codex/app-server/host.test.ts
+++ b/packages/maker-core/src/agents/codex/app-server/host.test.ts
@@ -258,6 +258,70 @@ describe('AppServerHost custom Provider subagent policy', () => {
   });
 });
 
+describe('AppServerHost shutdown completion', () => {
+  it.each([false, true])('shutdown and retire wait for the same process (failure=%s)', async (fails) => {
+    const transport = new NotificationTransport();
+    let finish!: () => void;
+    let fail!: (error: Error) => void;
+    const completion = new Promise<void>((resolve, reject) => { finish = resolve; fail = reject; });
+    const close = vi.spyOn(transport, 'close').mockImplementation(() => completion);
+    const onRetired = vi.fn();
+    const host = new AppServerHost({ createTransport: () => transport, logger,
+      clientInfo: { name: 'cindy-test', version: '0.0.0' }, onRetired });
+    await host.ensureStarted();
+    const settled = vi.fn();
+    const shutdown = host.shutdown().then(settled);
+    const retire = host.retire('retire', { throwOnTransportError: true });
+    const retirement = fails
+      ? expect(retire).rejects.toThrow('exit not confirmed')
+      : expect(retire).resolves.toBeUndefined();
+    await Promise.resolve();
+    await expect(host.ensureStarted()).rejects.toThrow('after retirement');
+    expect(onRetired).not.toHaveBeenCalled();
+    expect(settled).not.toHaveBeenCalled();
+    if (fails) fail(new Error('exit not confirmed'));
+    else finish();
+    await Promise.all([shutdown, retirement]);
+    expect(close).toHaveBeenCalledOnce();
+    expect(onRetired).toHaveBeenCalledTimes(fails ? 0 : 1);
+    if (fails) await expect(host.shutdown('retry', { throwOnTransportError: true })).rejects.toThrow('exit not confirmed');
+  });
+
+  it('blocks bootstrap retry until the failed process has exited', async () => {
+    const failed = new RejectedInitializeTransport();
+    let finish!: () => void;
+    vi.spyOn(failed, 'close').mockImplementation(() => new Promise<void>((resolve) => { finish = resolve; }));
+    const createTransport = vi.fn().mockReturnValueOnce(failed).mockReturnValue(new NotificationTransport());
+    const host = new AppServerHost({ createTransport, logger, clientInfo: { name: 'cindy-test', version: '0.0.0' } });
+    const failure = expect(host.ensureStarted()).rejects.toThrow('initialize boom');
+    await vi.waitFor(() => expect(failed.close).toHaveBeenCalledOnce());
+    await expect(host.ensureStarted()).rejects.toThrow('during shutdown');
+    expect(createTransport).toHaveBeenCalledOnce();
+    finish();
+    await failure;
+    await host.ensureStarted();
+    expect(createTransport).toHaveBeenCalledTimes(2);
+    await host.shutdown();
+  });
+
+  it('recovers when subscribing synchronously reports a closed startup transport', async () => {
+    const failed = new NotificationTransport();
+    let finish!: () => void;
+    vi.spyOn(failed, 'onClose').mockImplementation((handler) => { handler({ reason: 'closed on subscribe' }); return () => {}; });
+    vi.spyOn(failed, 'close').mockImplementation(() => new Promise<void>((resolve) => { finish = resolve; }));
+    const createTransport = vi.fn().mockReturnValueOnce(failed).mockReturnValue(new NotificationTransport());
+    const host = new AppServerHost({ createTransport, logger, clientInfo: { name: 'cindy-test', version: '0.0.0' } });
+    const failure = expect(host.ensureStarted()).rejects.toThrow();
+    await vi.waitFor(() => expect(failed.close).toHaveBeenCalledOnce());
+    await expect(host.ensureStarted()).rejects.toThrow('during shutdown');
+    finish();
+    await failure;
+    await host.ensureStarted();
+    expect(createTransport).toHaveBeenCalledTimes(2);
+    await host.shutdown();
+  });
+});
+
 describe('AppServerHost MCP readiness', () => {
   it('releases Host-owned resources only on terminal retire and only once', async () => {
     const onRetired = vi.fn(async () => undefined);

--- a/packages/maker-core/src/agents/codex/app-server/host.test.ts
+++ b/packages/maker-core/src/agents/codex/app-server/host.test.ts
@@ -284,7 +284,47 @@ describe('AppServerHost shutdown completion', () => {
     await Promise.all([shutdown, retirement]);
     expect(close).toHaveBeenCalledOnce();
     expect(onRetired).toHaveBeenCalledTimes(fails ? 0 : 1);
-    if (fails) await expect(host.shutdown('retry', { throwOnTransportError: true })).rejects.toThrow('exit not confirmed');
+    if (fails) {
+      await expect(host.shutdown('retry', { throwOnTransportError: true })).rejects.toThrow('exit not confirmed');
+      expect(onRetired).not.toHaveBeenCalled();
+      close.mockResolvedValue(undefined);
+      await Promise.all([host.retire(), host.retire('late exit', { throwOnTransportError: true })]);
+      expect(onRetired).toHaveBeenCalledOnce();
+      await expect(retire).rejects.toThrow('exit not confirmed');
+    }
+    await host.retire();
+    expect(close).toHaveBeenCalledTimes(fails ? 3 : 1);
+    expect(onRetired).toHaveBeenCalledOnce();
+    await expect(host.ensureStarted()).rejects.toThrow('after retirement');
+  });
+
+  it('rechecks failed shutdown before restarting and respects retirement during that recheck', async () => {
+    const transport = new NotificationTransport();
+    const close = vi.spyOn(transport, 'close').mockRejectedValue(new Error('exit not confirmed'));
+    const createTransport = vi.fn().mockReturnValueOnce(transport).mockReturnValue(new NotificationTransport());
+    const onRetired = vi.fn();
+    const host = new AppServerHost({ createTransport, logger,
+      clientInfo: { name: 'cindy-test', version: '0.0.0' }, onRetired });
+    await host.ensureStarted();
+    await expect(host.shutdown('failed', { throwOnTransportError: true })).rejects.toThrow('exit not confirmed');
+    await expect(host.ensureStarted()).rejects.toThrow('exit not confirmed');
+    expect(createTransport).toHaveBeenCalledOnce();
+    close.mockResolvedValue(undefined);
+    await host.ensureStarted();
+    expect(createTransport).toHaveBeenCalledTimes(2);
+
+    const nextTransport = createTransport.mock.results[1]!.value as NotificationTransport;
+    const nextClose = vi.spyOn(nextTransport, 'close').mockRejectedValue(new Error('exit not confirmed'));
+    await host.shutdown();
+    let finish!: () => void;
+    nextClose.mockImplementation(() => new Promise<void>((resolve) => { finish = resolve; }));
+    const restart = expect(host.ensureStarted()).rejects.toThrow('after retirement');
+    const retiring = host.retire('retire during recheck', { throwOnTransportError: true });
+    await vi.waitFor(() => expect(nextClose).toHaveBeenCalledTimes(2));
+    finish();
+    await Promise.all([restart, retiring]);
+    expect(createTransport).toHaveBeenCalledTimes(2);
+    expect(onRetired).toHaveBeenCalledOnce();
   });
 
   it('blocks bootstrap retry until the failed process has exited', async () => {

--- a/packages/maker-core/src/agents/codex/app-server/host.ts
+++ b/packages/maker-core/src/agents/codex/app-server/host.ts
@@ -563,6 +563,10 @@ export class AppServerHost {
       return Promise.reject(new Error('AppServerHost: cannot ensureStarted() after retirement'));
     }
     if (this.shuttingDown) {
+      if (!this.shutdownPromise) {
+        return this.shutdown('recheck failed shutdown before restart', { throwOnTransportError: true })
+          .then(() => this.ensureStarted(capabilities));
+      }
       return Promise.reject(new Error('AppServerHost: cannot ensureStarted() during shutdown'));
     }
     if (this.startPromise) return this.startPromise;
@@ -885,15 +889,20 @@ export class AppServerHost {
     if (!this.shutdownPromise) {
       this.shuttingDown = true;
       const client = this.client;
-      this.shutdownPromise = Promise.resolve().then(async () => {
+      const shutdownPromise = Promise.resolve().then(async () => {
         await client?.close({ reason, throwOnTransportError: true });
+        if (this.client === client) this.client = null;
         // start() 的同步 transport 回调可能在 ensureStarted 赋值前触发关闭。
         this.startPromise = null;
         // 只在关闭成功后开放重启；失败保留 barrier，避免新旧 writer 并存。
         this.shutdownPromise = null;
         this.shuttingDown = false;
+      }).catch((error) => {
+        // 本次结果可以重查，但 client 与 shuttingDown 保留到真实关闭成功。
+        if (this.shutdownPromise === shutdownPromise) this.shutdownPromise = null;
+        throw error;
       });
-      this.client = null;
+      this.shutdownPromise = shutdownPromise;
       this.startPromise = null;
       // MCP readiness belongs to the concrete app-server process.
       this.mcpToolAvailability.clear();
@@ -921,16 +930,22 @@ export class AppServerHost {
     opts?: { throwOnTransportError?: boolean },
   ): Promise<void> {
     this.retired = true;
-    this.retirementPromise ??= Promise.resolve().then(async () => {
-      await this.shutdown(reason, { throwOnTransportError: true });
-      await Promise.resolve()
-        .then(() => this.opts.onRetired?.())
-        .catch((error) => {
-          this.logger.warn('app-server Host retirement cleanup failed', {
-            error: error instanceof Error ? error.message : String(error),
+    if (!this.retirementPromise) {
+      const retirementPromise = Promise.resolve().then(async () => {
+        await this.shutdown(reason, { throwOnTransportError: true });
+        await Promise.resolve()
+          .then(() => this.opts.onRetired?.())
+          .catch((error) => {
+            this.logger.warn('app-server Host retirement cleanup failed', {
+              error: error instanceof Error ? error.message : String(error),
+            });
           });
-        });
-    });
+      }).catch((error) => {
+        if (this.retirementPromise === retirementPromise) this.retirementPromise = null;
+        throw error;
+      });
+      this.retirementPromise = retirementPromise;
+    }
     try {
       await this.retirementPromise;
     } catch (error) {

--- a/packages/maker-core/src/agents/codex/app-server/host.ts
+++ b/packages/maker-core/src/agents/codex/app-server/host.ts
@@ -358,6 +358,7 @@ export class AppServerHost {
   private lastAccountRateLimits: AccountRateLimitsUpdatedNotification['params'] | null = null;
 
   private shuttingDown = false;
+  private shutdownPromise: Promise<void> | null = null;
   private retired = false;
   private retirementPromise: Promise<void> | null = null;
 
@@ -565,14 +566,11 @@ export class AppServerHost {
       return Promise.reject(new Error('AppServerHost: cannot ensureStarted() during shutdown'));
     }
     if (this.startPromise) return this.startPromise;
-    this.startPromise = this.bootstrap(capabilities).catch(async (err) => {
-      // bootstrap 失败 → 清掉 startPromise 让下次调用能重试
-      const failedClient = this.client;
-      this.startPromise = null;
-      this.client = null;
-      if (failedClient) {
+    const startPromise = this.bootstrap(capabilities).catch(async (err) => {
+      // 旧启动的迟到失败不能关闭新 client；重试必须等旧进程真正退出。
+      if (this.startPromise === startPromise) {
         try {
-          await failedClient.close({ reason: 'AppServerHost bootstrap failed' });
+          await this.shutdown('AppServerHost bootstrap failed', { throwOnTransportError: true });
         } catch (closeError) {
           this.logger.warn('failed to close app-server client after bootstrap failure', {
             error: closeError instanceof Error ? closeError.message : String(closeError),
@@ -581,7 +579,8 @@ export class AppServerHost {
       }
       throw err;
     });
-    return this.startPromise;
+    this.startPromise = startPromise;
+    return startPromise;
   }
 
   /**
@@ -883,27 +882,33 @@ export class AppServerHost {
     reason = 'AppServerHost.shutdown()',
     opts?: { throwOnTransportError?: boolean },
   ): Promise<void> {
-    if (this.shuttingDown) return;
-    this.shuttingDown = true;
-    // MCP readiness is scoped to the concrete app-server process. A normal
-    // transport recovery reuses this host object, so never carry a positive
-    // probe result into the replacement process.
-    this.mcpToolAvailability.clear();
-    this.subscribers.clear();
-    this.lineageRoots.clear();
-    this.pendingLineage.clear();
-    this.buffered.clear();
-    for (const threadId of this.threadHandlerWaiters.keys()) {
-      this.notifyThreadHandlerWaiters(threadId);
+    if (!this.shutdownPromise) {
+      this.shuttingDown = true;
+      const client = this.client;
+      this.shutdownPromise = Promise.resolve().then(async () => {
+        await client?.close({ reason, throwOnTransportError: true });
+        // start() 的同步 transport 回调可能在 ensureStarted 赋值前触发关闭。
+        this.startPromise = null;
+        // 只在关闭成功后开放重启；失败保留 barrier，避免新旧 writer 并存。
+        this.shutdownPromise = null;
+        this.shuttingDown = false;
+      });
+      this.client = null;
+      this.startPromise = null;
+      // MCP readiness belongs to the concrete app-server process.
+      this.mcpToolAvailability.clear();
+      this.subscribers.clear();
+      this.lineageRoots.clear();
+      this.pendingLineage.clear();
+      this.buffered.clear();
+      for (const threadId of this.threadHandlerWaiters.keys()) {
+        this.notifyThreadHandlerWaiters(threadId);
+      }
     }
-    const c = this.client;
-    this.client = null;
-    this.startPromise = null;
     try {
-      if (c) await c.close({ reason, throwOnTransportError: opts?.throwOnTransportError });
-    } finally {
-      // 重置, 允许之后的 ensureStarted 重新 spawn (transport error 恢复路径)
-      this.shuttingDown = false;
+      await this.shutdownPromise;
+    } catch (error) {
+      if (opts?.throwOnTransportError) throw error;
     }
   }
 
@@ -916,20 +921,21 @@ export class AppServerHost {
     opts?: { throwOnTransportError?: boolean },
   ): Promise<void> {
     this.retired = true;
-    this.retirementPromise ??= (async () => {
-      try {
-        await this.shutdown(reason, opts);
-      } finally {
-        await Promise.resolve()
-          .then(() => this.opts.onRetired?.())
-          .catch((error) => {
-            this.logger.warn('app-server Host retirement cleanup failed', {
-              error: error instanceof Error ? error.message : String(error),
-            });
+    this.retirementPromise ??= Promise.resolve().then(async () => {
+      await this.shutdown(reason, { throwOnTransportError: true });
+      await Promise.resolve()
+        .then(() => this.opts.onRetired?.())
+        .catch((error) => {
+          this.logger.warn('app-server Host retirement cleanup failed', {
+            error: error instanceof Error ? error.message : String(error),
           });
-      }
-    })();
-    await this.retirementPromise;
+        });
+    });
+    try {
+      await this.retirementPromise;
+    } catch (error) {
+      if (opts?.throwOnTransportError) throw error;
+    }
   }
 
   /**

--- a/packages/maker-core/src/agents/codex/app-server/stdioTransport.test.ts
+++ b/packages/maker-core/src/agents/codex/app-server/stdioTransport.test.ts
@@ -1,5 +1,5 @@
 import { EventEmitter } from 'node:events';
-import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 const mocks = vi.hoisted(() => ({
   spawn: vi.fn(),
@@ -22,7 +22,7 @@ function makeChild(pid = 4321) {
     pid: number;
     stdout: ReturnType<typeof makeEmitterStream>;
     stderr: ReturnType<typeof makeEmitterStream>;
-    stdin: {
+    stdin: EventEmitter & {
       writable: boolean;
       write: ReturnType<typeof vi.fn>;
       end: ReturnType<typeof vi.fn>;
@@ -34,14 +34,14 @@ function makeChild(pid = 4321) {
   child.pid = pid;
   child.stdout = makeEmitterStream();
   child.stderr = makeEmitterStream();
-  child.stdin = {
+  child.stdin = Object.assign(new EventEmitter(), {
     writable: true,
     write: vi.fn((_line, _encoding, callback: (error?: Error) => void) => {
       callback();
       return true;
     }),
     end: vi.fn(),
-  };
+  });
   child.exitCode = null;
   child.signalCode = null;
   child.kill = vi.fn();
@@ -49,10 +49,16 @@ function makeChild(pid = 4321) {
 }
 
 beforeEach(() => {
+  vi.useFakeTimers();
   const readline = new EventEmitter() as EventEmitter & { close: ReturnType<typeof vi.fn> };
   readline.close = vi.fn();
   mocks.createInterface.mockReset().mockReturnValue(readline);
   mocks.spawn.mockReset();
+});
+
+afterEach(() => {
+  vi.clearAllTimers();
+  vi.useRealTimers();
 });
 
 describe('createStdioTransport process observer', () => {
@@ -72,7 +78,7 @@ describe('createStdioTransport process observer', () => {
     );
   });
 
-  it('spawn 时登记一次，主动 close 时只清理一次', async () => {
+  it('close 先 EOF，真正退出前保持进程登记和 stdout 排空，并发调用共享完成', async () => {
     const child = makeChild();
     mocks.spawn.mockReturnValue(child);
     const dispose = vi.fn();
@@ -80,9 +86,30 @@ describe('createStdioTransport process observer', () => {
     const transport = createStdioTransport({ binaryPath: '/codex', onProcessSpawned });
 
     expect(onProcessSpawned).toHaveBeenCalledWith(4321);
-    await transport.close();
-    await transport.close();
+    const onClose = vi.fn();
+    const onLine = vi.fn();
+    transport.onClose(onClose);
+    transport.onLine(onLine);
+    const closing = transport.close();
+    expect(transport.close()).toBe(closing);
+    const settled = vi.fn();
+    void closing.then(settled);
+    await vi.advanceTimersByTimeAsync(100);
+    expect(child.stdin.end).toHaveBeenCalledOnce();
+    expect(child.kill).not.toHaveBeenCalled();
+    expect(dispose).not.toHaveBeenCalled();
+    expect(settled).not.toHaveBeenCalled();
+    const readline = mocks.createInterface.mock.results[0]!.value;
+    expect(readline.close).not.toHaveBeenCalled();
+    readline.emit('line', 'late response');
+    expect(onLine).not.toHaveBeenCalled();
+    await expect(transport.writeLine('new request')).rejects.toThrow('after close');
+    child.emit('exit', 0, null);
+    await closing;
+    expect(onClose).toHaveBeenCalledOnce();
     expect(dispose).toHaveBeenCalledOnce();
+    expect(readline.close).toHaveBeenCalledOnce();
+    expect(vi.getTimerCount()).toBe(0);
   });
 
   it('自然退出时清理；随后 close 不重复清理', async () => {
@@ -118,13 +145,17 @@ describe('close() 强杀兜底 (#3699)', () => {
       mocks.spawn.mockReturnValue(child);
       const transport = createStdioTransport({ binaryPath: '/codex' });
 
-      await transport.close();
+      const closing = transport.close();
+      await vi.advanceTimersByTimeAsync(1_500);
       expect(child.kill).toHaveBeenCalledWith('SIGTERM');
       expect(child.kill).not.toHaveBeenCalledWith('SIGKILL');
 
       // 进程无视 SIGTERM(exitCode/signalCode 保持 null)→ 宽限期后强杀。
-      vi.advanceTimersByTime(5_000);
+      await vi.advanceTimersByTimeAsync(1_000);
       expect(child.kill).toHaveBeenCalledWith('SIGKILL');
+      child.emit('exit', null, 'SIGKILL');
+      await closing;
+      expect(vi.getTimerCount()).toBe(0);
     } finally {
       vi.useRealTimers();
     }
@@ -137,10 +168,12 @@ describe('close() 强杀兜底 (#3699)', () => {
       mocks.spawn.mockReturnValue(child);
       const transport = createStdioTransport({ binaryPath: '/codex' });
 
-      await transport.close();
+      const closing = transport.close();
+      await vi.advanceTimersByTimeAsync(1_500);
       child.signalCode = 'SIGTERM';
       child.emit('exit', null, 'SIGTERM');
-      vi.advanceTimersByTime(5_000);
+      await closing;
+      await vi.advanceTimersByTimeAsync(5_000);
       expect(child.kill).toHaveBeenCalledTimes(1); // 仅 SIGTERM
       expect(child.kill).not.toHaveBeenCalledWith('SIGKILL');
     } finally {
@@ -163,5 +196,59 @@ describe('close() 强杀兜底 (#3699)', () => {
     } finally {
       vi.useRealTimers();
     }
+  });
+
+  it('发送信号失败且无法确认退出时拒绝关闭，不冒充已释放进程', async () => {
+    const child = makeChild();
+    child.kill.mockImplementation(() => { throw new Error('kill denied'); });
+    mocks.spawn.mockReturnValue(child);
+    const dispose = vi.fn();
+    const transport = createStdioTransport({ binaryPath: '/codex', onProcessSpawned: () => dispose });
+    const closing = transport.close();
+    const failure = expect(closing).rejects.toThrow('did not exit after SIGKILL');
+    await vi.advanceTimersByTimeAsync(3_000);
+    await failure;
+    await expect(transport.close()).rejects.toThrow('did not exit after SIGKILL');
+    expect(dispose).not.toHaveBeenCalled();
+    expect(vi.getTimerCount()).toBe(0);
+    child.emit('exit', null, 'SIGKILL');
+    expect(dispose).toHaveBeenCalledOnce();
+  });
+
+  it('stdin 错误不冒充进程退出，仍执行 EOF 和强杀收尾', async () => {
+    const child = makeChild();
+    mocks.spawn.mockReturnValue(child);
+    const transport = createStdioTransport({ binaryPath: '/codex' });
+    child.stdin.emit('error', new Error('EPIPE'));
+    const closing = transport.close();
+    await vi.advanceTimersByTimeAsync(2_500);
+    expect(child.kill).toHaveBeenCalledWith('SIGKILL');
+    child.emit('exit', null, 'SIGKILL');
+    await closing;
+  });
+
+  it('spawn 失败没有子进程，不等待或发送信号', async () => {
+    const child = makeChild();
+    Object.assign(child, { pid: undefined });
+    mocks.spawn.mockReturnValue(child);
+    const transport = createStdioTransport({ binaryPath: '/missing-codex' });
+    child.emit('error', new Error('ENOENT'));
+    await transport.close();
+    expect(child.kill).not.toHaveBeenCalled();
+    expect(vi.getTimerCount()).toBe(0);
+  });
+
+  it('onClose 同步重入也不会提前完成或重复关闭', async () => {
+    const child = makeChild();
+    mocks.spawn.mockReturnValue(child);
+    const transport = createStdioTransport({ binaryPath: '/codex' });
+    let reentered: Promise<void> | undefined;
+    transport.onClose(() => { reentered = transport.close(); });
+    const closing = transport.close();
+    expect(reentered).toBe(closing);
+    await vi.advanceTimersByTimeAsync(1);
+    child.emit('exit', 0, null);
+    await closing;
+    expect(child.stdin.end).toHaveBeenCalledOnce();
   });
 });

--- a/packages/maker-core/src/agents/codex/app-server/stdioTransport.test.ts
+++ b/packages/maker-core/src/agents/codex/app-server/stdioTransport.test.ts
@@ -213,6 +213,13 @@ describe('close() 强杀兜底 (#3699)', () => {
     expect(vi.getTimerCount()).toBe(0);
     child.emit('exit', null, 'SIGKILL');
     expect(dispose).toHaveBeenCalledOnce();
+    await expect(transport.close()).resolves.toBeUndefined();
+    await expect(transport.close()).resolves.toBeUndefined();
+    // 迟到退出只改变后续检查，不能把原调用的严格失败变成成功。
+    await expect(closing).rejects.toThrow('did not exit after SIGKILL');
+    expect(child.stdin.end).toHaveBeenCalledOnce();
+    expect(child.kill).toHaveBeenCalledTimes(2);
+    expect(vi.getTimerCount()).toBe(0);
   });
 
   it('stdin 错误不冒充进程退出，仍执行 EOF 和强杀收尾', async () => {

--- a/packages/maker-core/src/agents/codex/app-server/stdioTransport.ts
+++ b/packages/maker-core/src/agents/codex/app-server/stdioTransport.ts
@@ -1,10 +1,6 @@
 /**
  * StdioTransport — 本地 spawn `codex app-server`, 接 stdin/stdout NDJSON 流。
  *
- * 历史行为搬迁: 这文件里的 spawn/readline/stderr/exit/kill 逻辑跟原本
- * AppServerClient.spawnProcess + close 一字不差, 只是从 client 内部搬到了
- * transport 层。purpose: 让 client 只关心 NDJSON 流, transport 切换无感。
- *
  * Lifecycle:
  *   - 构造时同步 spawn 子进程 (跟原版 spawnProcess 一致)
  *   - readline on('line') → fan-out 给 onLine handlers
@@ -32,16 +28,18 @@ export interface StdioTransportOptions {
   extraArgs?: string[];
   /** 本地进程生命周期观察器；仅用于宿主诊断，不得影响 transport 启动。 */
   onProcessSpawned?: (pid: number) => void | (() => void);
+  /** stdin EOF 后等待正常保存和退出的时间；仅测试注入。 */
+  gracefulCloseMs?: number;
   /** SIGTERM 后强杀宽限毫秒数;仅测试注入,生产走默认值。 */
   forceKillGraceMs?: number;
+  /** SIGKILL 后确认退出的时间；仅测试注入。 */
+  killConfirmationMs?: number;
 }
 
-/**
- * close() 发出 SIGTERM 后等待进程自行退出的宽限期。健康的 app-server 在毫秒级
- * 退出;卡死的(见 close() 内注释)永远不退,5s 已足够区分两者且不拖慢关闭方
- * (close() 本身不等待,timer 在后台收尸)。
- */
-const FORCE_KILL_GRACE_MS = 5_000;
+// 合计 3s，给 Desktop 6s 退出预算中的其它收尾留出时间。
+const GRACEFUL_CLOSE_MS = 1_500;
+const FORCE_KILL_GRACE_MS = 1_000;
+const KILL_CONFIRMATION_MS = 500;
 
 export function createStdioTransport(opts: StdioTransportOptions): Transport {
   if (!opts.binaryPath) {
@@ -60,6 +58,10 @@ export function createStdioTransport(opts: StdioTransportOptions): Transport {
   const lineBuffer: string[] = [];
   let lineHandlerArmed = false;
   let closed = false;
+  let closePromise: Promise<void> | null = null;
+  let exited = false;
+  let resolveExit!: () => void;
+  const exitPromise = new Promise<void>((resolve) => { resolveExit = resolve; });
 
   const args = ['app-server', ...(opts.extraArgs ?? [])];
   const child: ChildProcessWithoutNullStreams = spawn(opts.binaryPath, args, {
@@ -72,7 +74,7 @@ export function createStdioTransport(opts: StdioTransportOptions): Transport {
     shell: false,
     // Windows 上 app-server 及其控制台句柄不应打断桌面端 UI。
     windowsHide: true,
-    // Linux/macOS: 跟父进程同 process group, 父进程退出时一并被收割。
+    // 不创建独立进程组；close() 仍必须显式等待并确认子进程退出。
     detached: false,
   });
   let disposeProcessRegistration: (() => void) | undefined;
@@ -92,6 +94,8 @@ export function createStdioTransport(opts: StdioTransportOptions): Transport {
     crlfDelay: Infinity,
   });
   rl.on('line', (line) => {
+    // 关闭协议后继续排空 stdout，避免退出收尾写满 pipe。
+    if (closed) return;
     if (!lineHandlerArmed) {
       lineBuffer.push(line);
       return;
@@ -118,21 +122,47 @@ export function createStdioTransport(opts: StdioTransportOptions): Transport {
   const fireClose = (reason: string): void => {
     if (closed) return;
     closed = true;
-    try { rl.close(); } catch { /* already closed */ }
-    try { disposeProcessRegistration?.(); } catch { /* best-effort diagnostic cleanup */ }
-    disposeProcessRegistration = undefined;
+    lineBuffer.length = 0;
     for (const cb of closeHandlers) {
       try { cb({ reason }); } catch { /* handler should not throw */ }
     }
   };
 
+  const finishProcess = (reason: string): void => {
+    if (exited) return;
+    exited = true;
+    try { rl.close(); } catch { /* already closed */ }
+    try { disposeProcessRegistration?.(); } catch { /* best-effort diagnostic cleanup */ }
+    disposeProcessRegistration = undefined;
+    resolveExit();
+    fireClose(reason);
+  };
+
   child.on('error', (err) => {
-    fireClose(`child error: ${err.message}`);
+    const reason = `child error: ${err.message}`;
+    // spawn 失败没有进程；运行中的 error（例如 kill 失败）不是退出证据。
+    if (child.pid == null) finishProcess(reason);
+    else fireClose(reason);
   });
+  child.stdin.on('error', (err) => fireClose(`child stdin error: ${err.message}`));
   child.on('exit', (code, signal) => {
     const reason = signal ? `signal=${signal}` : `exit code=${code ?? 'null'}`;
-    fireClose(`child exited (${reason})`);
+    finishProcess(`child exited (${reason})`);
   });
+
+  const waitForExit = async (timeoutMs: number): Promise<boolean> => {
+    if (exited) return true;
+    let timer: ReturnType<typeof setTimeout> | undefined;
+    try {
+      await Promise.race([
+        exitPromise,
+        new Promise<void>((resolve) => { timer = setTimeout(resolve, timeoutMs); }),
+      ]);
+      return exited;
+    } finally {
+      if (timer) clearTimeout(timer);
+    }
+  };
 
   return {
     writeLine(line: string): Promise<void> {
@@ -177,29 +207,24 @@ export function createStdioTransport(opts: StdioTransportOptions): Transport {
       return () => { closeHandlers.delete(handler); };
     },
 
-    async close(reason = 'StdioTransport.close()'): Promise<void> {
-      if (closed) return;
-      // 优雅关: 先 stdin EOF (Rust app-server 看到会自己退), 再 SIGTERM 兜底。
-      try { child.stdin.end(); } catch { /* swallow */ }
-      if (child.exitCode === null && child.signalCode === null) {
-        try { child.kill('SIGTERM'); } catch { /* swallow */ }
-        // #3699: SIGTERM 只对健康的 app-server 有效。当它的主循环卡死(实测
-        // 场景:内部模型刷新子进程 wedged,manager 反复报 "timeout waiting for
-        // child process to exit")时,进程可能既不响应 stdin EOF 也不处理
-        // SIGTERM —— 而调用方(retireHostKey / 切换凭证 / 关闭会话)在 close()
-        // 后即视其为已弃用,不再持有引用。此前没有任何强杀兜底,弃用的
-        // app-server 会以活体泄漏:继续周期性模型刷新、打错误日志、占用
-        // 网络与文件句柄。宽限期后仍未退出则 SIGKILL 收尸;timer unref,
-        // 不阻塞父进程退出(父进程退出时同进程组的子进程本就会被收割)。
-        const killTimer = setTimeout(() => {
-          if (child.exitCode === null && child.signalCode === null) {
-            try { child.kill('SIGKILL'); } catch { /* swallow */ }
-          }
-        }, opts.forceKillGraceMs ?? FORCE_KILL_GRACE_MS);
-        killTimer.unref?.();
-        child.once('exit', () => clearTimeout(killTimer));
+    close(reason = 'StdioTransport.close()'): Promise<void> {
+      if (!closePromise) {
+        // 先发布 Promise，再调用可能同步重入 close() 的监听器。
+        closePromise = Promise.resolve().then(async () => {
+          if (exited) return;
+          // EOF 让 app-server 中止在飞 turn 并保存历史；不能紧跟 SIGTERM。
+          try { child.stdin.end(); } catch { /* signal fallback below */ }
+          if (await waitForExit(opts.gracefulCloseMs ?? GRACEFUL_CLOSE_MS)) return;
+          try { child.kill('SIGTERM'); } catch { /* still confirm exit */ }
+          if (await waitForExit(opts.forceKillGraceMs ?? FORCE_KILL_GRACE_MS)) return;
+          // #3699: 卡死进程仍需强杀，且不能在确认退出前释放 Host。
+          try { child.kill('SIGKILL'); } catch { /* still confirm exit */ }
+          if (await waitForExit(opts.killConfirmationMs ?? KILL_CONFIRMATION_MS)) return;
+          throw new Error('Codex app-server did not exit after SIGKILL');
+        });
+        fireClose(reason);
       }
-      fireClose(reason);
+      return closePromise;
     },
   };
 }

--- a/packages/maker-core/src/agents/codex/app-server/stdioTransport.ts
+++ b/packages/maker-core/src/agents/codex/app-server/stdioTransport.ts
@@ -208,6 +208,8 @@ export function createStdioTransport(opts: StdioTransportOptions): Transport {
     },
 
     close(reason = 'StdioTransport.close()'): Promise<void> {
+      // 首次严格关闭可以超时；迟到的真实 exit 使后续幂等检查成功。
+      if (exited) return exitPromise;
       if (!closePromise) {
         // 先发布 Promise，再调用可能同步重入 close() 的监听器。
         closePromise = Promise.resolve().then(async () => {

--- a/packages/maker-core/src/agents/codex/index.test.ts
+++ b/packages/maker-core/src/agents/codex/index.test.ts
@@ -6173,6 +6173,73 @@ describe('CodexAgent MCP thread context hooks', () => {
     await agent.dispose();
   });
 
+  it('waits for the retiring local writer before session and utility reuse, without blocking remote work', async () => {
+    const getRemoteCodexTransport = vi.fn(() => {
+      const transport = new MockCodexTransport();
+      createdTransports.push(transport);
+      return transport;
+    });
+    const agent = new CodexAgent(createDeps({}, { getRemoteCodexTransport }));
+    const local = await agent.startSession({ sessionId: 'old-local', model: 'gpt-5.4', workingDir: '/repo' });
+    const remote = await agent.startSession({ sessionId: 'remote', model: 'gpt-5.4', workingDir: '/remote', remoteHostId: 'remote-1' });
+    const transport = createdTransports[0]!;
+    const originalClose = transport.close.bind(transport);
+    let finish!: () => void;
+    const gate = new Promise<void>((resolve) => { finish = resolve; });
+    const close = vi.spyOn(transport, 'close').mockImplementation(async (reason) => { await gate; await originalClose(reason); });
+    const retiring = agent.forceDisposeLocalHostForAuthChange('test retirement');
+    await waitForExpectation(() => expect(close).toHaveBeenCalledOnce());
+    const settled = vi.fn();
+    const next = agent.startSession({ sessionId: 'next-local', model: 'gpt-5.4', workingDir: '/repo' }).then((handle) => { settled(); return handle; });
+    const utility = agent.getMemoryStatus().then(settled);
+    await remote.send({ type: 'user', content: 'remote still works' });
+    expect(settled).not.toHaveBeenCalled();
+    expect(createdTransports).toHaveLength(2);
+    finish();
+    await retiring;
+    const newHandle = await next;
+    await utility;
+    expect(createdTransports).toHaveLength(3);
+    expect(close).toHaveBeenCalledOnce();
+    await Promise.all([local.close(), remote.close(), newHandle.close()]);
+    await agent.dispose();
+  });
+
+  it('does not replace a writer whose exit could not be confirmed', async () => {
+    const agent = new CodexAgent(createDeps());
+    const handle = await agent.startSession({ sessionId: 'failed-exit', model: 'gpt-5.4', workingDir: '/repo' });
+    MockCodexTransport.closeError = new Error('exit not confirmed');
+    await agent.forceDisposeLocalHostForAuthChange('failed retirement');
+    await expect(agent.startSession({ sessionId: 'replacement', model: 'gpt-5.4', workingDir: '/repo' })).rejects.toThrow('exit not confirmed');
+    await expect(agent.getMemoryStatus()).rejects.toThrow('exit not confirmed');
+    const guard = await agent.beginLocalHostCredentialChange('strict retry');
+    await expect(guard.retireActiveHost()).rejects.toThrow('exit not confirmed');
+    guard.release();
+    expect(createdTransports).toHaveLength(1);
+    await handle.close();
+    await agent.dispose();
+  });
+
+  it('concurrent dispose calls both wait for registered retirements', async () => {
+    const agent = new CodexAgent(createDeps());
+    const handle = await agent.startSession({ sessionId: 'dispose-twice', model: 'gpt-5.4', workingDir: '/repo' });
+    const transport = createdTransports[0]!;
+    const originalClose = transport.close.bind(transport);
+    let finish!: () => void;
+    const gate = new Promise<void>((resolve) => { finish = resolve; });
+    const close = vi.spyOn(transport, 'close').mockImplementation(async (reason) => { await gate; await originalClose(reason); });
+    const first = agent.dispose();
+    await waitForExpectation(() => expect(close).toHaveBeenCalledOnce());
+    const settled = vi.fn();
+    const second = agent.dispose().then(settled);
+    await Promise.resolve();
+    expect(settled).not.toHaveBeenCalled();
+    finish();
+    await Promise.all([first, second]);
+    expect(close).toHaveBeenCalledOnce();
+    await handle.close();
+  });
+
   it('force-retires one shared local Host under the credential guard and blocks its lazy replacement', async () => {
     const getRemoteCodexTransport = vi.fn(() => {
       const transport = new MockCodexTransport();

--- a/packages/maker-core/src/agents/codex/index.test.ts
+++ b/packages/maker-core/src/agents/codex/index.test.ts
@@ -215,11 +215,13 @@ const { MockCodexTransport, createdTransports, createdStdioOptions } = vi.hoiste
     }
 
     async close(reason = 'MockCodexTransport.close()'): Promise<void> {
-      if (this.closed) return;
-      this.closed = true;
-      for (const handler of this.closeHandlers) {
-        handler({ reason });
+      if (!this.closed) {
+        this.closed = true;
+        for (const handler of this.closeHandlers) {
+          handler({ reason });
+        }
       }
+      // Logical closure can precede confirmed physical exit; rechecks still fail until cleared.
       if (MockCodexTransport.closeError) throw MockCodexTransport.closeError;
     }
 
@@ -6205,7 +6207,7 @@ describe('CodexAgent MCP thread context hooks', () => {
     await agent.dispose();
   });
 
-  it('does not replace a writer whose exit could not be confirmed', async () => {
+  it('does not replace an unconfirmed writer but recovers after its late exit', async () => {
     const agent = new CodexAgent(createDeps());
     const handle = await agent.startSession({ sessionId: 'failed-exit', model: 'gpt-5.4', workingDir: '/repo' });
     MockCodexTransport.closeError = new Error('exit not confirmed');
@@ -6215,6 +6217,34 @@ describe('CodexAgent MCP thread context hooks', () => {
     const guard = await agent.beginLocalHostCredentialChange('strict retry');
     await expect(guard.retireActiveHost()).rejects.toThrow('exit not confirmed');
     guard.release();
+    expect(createdTransports).toHaveLength(1);
+    MockCodexTransport.closeError = null;
+    const [replacement] = await Promise.all([
+      agent.startSession({ sessionId: 'replacement-after-exit', model: 'gpt-5.4', workingDir: '/repo' }),
+      agent.getMemoryStatus(),
+    ]);
+    expect(createdTransports).toHaveLength(2);
+    await replacement.close();
+    await handle.close();
+    await agent.dispose();
+  });
+
+  it.each(['guard', 'dispose'] as const)('rechecks a failed retirement from %s after late exit', async (retryPath) => {
+    const agent = new CodexAgent(createDeps());
+    const handle = await agent.startSession({ sessionId: 'late-exit-recheck', model: 'gpt-5.4', workingDir: '/repo' });
+    const close = vi.spyOn(createdTransports[0]!, 'close');
+    MockCodexTransport.closeError = new Error('exit not confirmed');
+    await agent.forceDisposeLocalHostForAuthChange('failed retirement');
+    expect(close).toHaveBeenCalledOnce();
+    MockCodexTransport.closeError = null;
+    if (retryPath === 'guard') {
+      const guard = await agent.beginLocalHostCredentialChange('late exit');
+      await guard.retireActiveHost();
+      guard.release();
+    } else {
+      await agent.dispose();
+    }
+    expect(close).toHaveBeenCalledTimes(2);
     expect(createdTransports).toHaveLength(1);
     await handle.close();
     await agent.dispose();

--- a/packages/maker-core/src/agents/codex/index.ts
+++ b/packages/maker-core/src/agents/codex/index.ts
@@ -1851,11 +1851,11 @@ export class CodexAgent extends BaseAgent {
    */
   private hostCredentialModeSwitches = new Map<string, Promise<void>>();
 
-  /** 同 key 的替代进程必须等待旧 writer 退出；失败保留原始结果供严格调用方检查。 */
+  /** 同 key 必须等旧 writer 退出；失败仅清本次 Promise，保留 Host 供下次重查。 */
   private retiringHosts = new Map<string, {
     host: AppServerHost;
     generation: number;
-    promise: Promise<void>;
+    promise: Promise<void> | null;
   }>();
 
   /**
@@ -2321,7 +2321,7 @@ export class CodexAgent extends BaseAgent {
       if (!remoteHostId) await this.waitForHostCredentialModeSwitch(key);
       const retiring = this.retiringHosts.get(key);
       if (retiring) {
-        await retiring.promise;
+        await this.beginHostRetirement(key, retiring.host, 'recheck retirement before Host reuse');
         continue;
       }
 
@@ -2486,7 +2486,7 @@ export class CodexAgent extends BaseAgent {
       await this.waitForHostCredentialModeSwitch(key);
       const retiring = this.retiringHosts.get(key);
       if (retiring) {
-        await retiring.promise;
+        await this.beginHostRetirement(key, retiring.host, 'recheck retirement before utility use');
         continue;
       }
       const existing = this.hosts.get(key);
@@ -13405,7 +13405,8 @@ export class CodexAgent extends BaseAgent {
     for (const [key, host] of this.hosts) {
       this.beginHostRetirement(key, host, 'CodexAgent.dispose()');
     }
-    const retirements = Array.from(this.retiringHosts.values(), (entry) => entry.promise);
+    const retirements = Array.from(this.retiringHosts, ([key, entry]) =>
+      this.beginHostRetirement(key, entry.host, 'CodexAgent.dispose()'));
     for (const key of this.hosts.keys()) {
       this.hostGenerations.set(key, (this.hostGenerations.get(key) ?? 0) + 1);
     }
@@ -13479,18 +13480,22 @@ export class CodexAgent extends BaseAgent {
 
   private beginHostRetirement(key: string, host: AppServerHost, reason: string): Promise<void> {
     const existing = this.retiringHosts.get(key);
-    if (existing?.host === host) return existing.promise;
-    const entry = {
+    if (existing?.host === host && existing.promise) return existing.promise;
+    const entry = existing?.host === host ? existing : {
       host,
       generation: this.hostGenerations.get(key) ?? 0,
-      promise: Promise.resolve().then(() => host.retire(reason, { throwOnTransportError: true })),
+      promise: null as Promise<void> | null,
     };
+    const promise = Promise.resolve().then(() => host.retire(reason, { throwOnTransportError: true }));
+    entry.promise = promise;
     this.retiringHosts.set(key, entry);
-    // 只清成功的当前 entry。关闭失败时不能误把旧 writer 当作已经退出。
-    void entry.promise.then(() => {
+    // 失败保留 key/Host 屏障；下次请求可重查迟到的 exit，不自动重试或另启 writer。
+    void promise.then(() => {
       if (this.retiringHosts.get(key) === entry) this.retiringHosts.delete(key);
-    }, () => undefined);
-    return entry.promise;
+    }, () => {
+      if (entry.promise === promise) entry.promise = null;
+    });
+    return promise;
   }
 
   private async retireHostKey(
@@ -13511,7 +13516,7 @@ export class CodexAgent extends BaseAgent {
       && (!opts.expectedHost || opts.expectedHost === retiring.host)
       && (opts.expectedGeneration === undefined || opts.expectedGeneration === retiring.generation)) {
       try {
-        await retiring.promise;
+        await this.beginHostRetirement(key, retiring.host, reason);
       } catch (error) {
         if (opts.throwOnShutdownFailure) throw error;
       }

--- a/packages/maker-core/src/agents/codex/index.ts
+++ b/packages/maker-core/src/agents/codex/index.ts
@@ -1851,6 +1851,13 @@ export class CodexAgent extends BaseAgent {
    */
   private hostCredentialModeSwitches = new Map<string, Promise<void>>();
 
+  /** 同 key 的替代进程必须等待旧 writer 退出；失败保留原始结果供严格调用方检查。 */
+  private retiringHosts = new Map<string, {
+    host: AppServerHost;
+    generation: number;
+    promise: Promise<void>;
+  }>();
+
   /**
    * app-server 启动时返回的 $CODEX_HOME 绝对路径 (InitializeResponse.codexHome)。
    * 用来推 codex 自家 memory 数据目录 (<CODEX_HOME>/memories/), 进而把它加进 turn/start
@@ -2227,6 +2234,7 @@ export class CodexAgent extends BaseAgent {
       toMode: toMode ?? 'fallback',
       forcedBySubagentRoutingProfile: opts.forceRestart === true,
     });
+    const retirement = this.beginHostRetirement(key, host, 'CodexAgent credential mode changed');
     this.hosts.delete(key);
     this.hostCredentialModes.delete(key);
     this.hostEffectiveCredentialModes.delete(key);
@@ -2235,7 +2243,7 @@ export class CodexAgent extends BaseAgent {
     if (key === hostKey()) this.codexHome = null;
     this.createHostSeqByKey.delete(key);
     try {
-      await host.retire('CodexAgent credential mode changed');
+      await retirement;
     } catch (error) {
       this.deps.logger.warn('codex host shutdown after credential mode change failed', {
         key,
@@ -2311,6 +2319,11 @@ export class CodexAgent extends BaseAgent {
     };
     while (true) {
       if (!remoteHostId) await this.waitForHostCredentialModeSwitch(key);
+      const retiring = this.retiringHosts.get(key);
+      if (retiring) {
+        await retiring.promise;
+        continue;
+      }
 
       const existing = this.hosts.get(key);
       if (existing) {
@@ -2326,6 +2339,7 @@ export class CodexAgent extends BaseAgent {
           || (subagentRoutingProfileCompatible
             && await canReuseRegistered(existing, currentMode, currentEffective))
         ) {
+          if (this.hosts.get(key) !== existing || this.retiringHosts.has(key)) continue;
           return existing;
         }
         await this.shutdownHostForCredentialModeChange(
@@ -2360,7 +2374,11 @@ export class CodexAgent extends BaseAgent {
           inflight.credentialMode === spawnMode ||
           this.canReuseHostCredentialMode(inflight.credentialMode, await resolveRequestedEffective())
         ))) {
-          if (remoteHostId) return inflight.promise;
+          if (remoteHostId) {
+            const host = await inflight.promise;
+            if (this.hosts.get(key) !== host || this.retiringHosts.has(key)) continue;
+            return host;
+          }
           let inflightHost: AppServerHost;
           try {
             inflightHost = await inflight.promise;
@@ -2384,6 +2402,7 @@ export class CodexAgent extends BaseAgent {
             )
             && await canReuseRegistered(inflightHost, registeredRaw, registeredEffective)
           ) {
+            if (this.hosts.get(key) !== inflightHost || this.retiringHosts.has(key)) continue;
             return inflightHost;
           }
           continue;
@@ -2419,6 +2438,7 @@ export class CodexAgent extends BaseAgent {
         ).catch(() => undefined);
       }
 
+      if (this.retiringHosts.has(key) || this.hosts.has(key) || this.hostPromises.has(key)) continue;
       const generation = this.bumpHostGeneration(key);
       // 超集归一化发生在 createHost 内(gateway-key → oauth-bearer);通过回调同步
       // in-flight 登记,让并发的 oauth-bearer 诉求命中复用而不是 supersede 重建。
@@ -2454,19 +2474,29 @@ export class CodexAgent extends BaseAgent {
         generation,
       };
       this.hostPromises.set(key, inflightEntry);
-      return promise;
+      const host = await promise;
+      if (this.hosts.get(key) !== host || this.retiringHosts.has(key)) continue;
+      return host;
     }
   }
 
   private async getUtilityHost(): Promise<{ key: string; host: AppServerHost }> {
     const key = hostKey();
-    await this.waitForHostCredentialModeSwitch(key);
-    const existing = this.hosts.get(key);
-    if (existing) return { key, host: existing };
-    const inflight = this.hostPromises.get(key);
-    if (inflight) return { key, host: await inflight.promise };
-    const host = await this.getHost();
-    return { key, host };
+    while (true) {
+      await this.waitForHostCredentialModeSwitch(key);
+      const retiring = this.retiringHosts.get(key);
+      if (retiring) {
+        await retiring.promise;
+        continue;
+      }
+      const existing = this.hosts.get(key);
+      if (existing) return { key, host: existing };
+      const inflight = this.hostPromises.get(key);
+      if (!inflight) return { key, host: await this.getHost() };
+      const host = await inflight.promise;
+      if (this.hosts.get(key) !== host || this.retiringHosts.has(key)) continue;
+      return { key, host };
+    }
   }
 
   /** Start the local OAuth host used by non-model account control-plane RPCs. */
@@ -13372,7 +13402,10 @@ export class CodexAgent extends BaseAgent {
         });
       }
     }
-    const hostsSnapshot = Array.from(this.hosts.values());
+    for (const [key, host] of this.hosts) {
+      this.beginHostRetirement(key, host, 'CodexAgent.dispose()');
+    }
+    const retirements = Array.from(this.retiringHosts.values(), (entry) => entry.promise);
     for (const key of this.hosts.keys()) {
       this.hostGenerations.set(key, (this.hostGenerations.get(key) ?? 0) + 1);
     }
@@ -13387,11 +13420,9 @@ export class CodexAgent extends BaseAgent {
     // codexHome 也跟着 host 走: 下次 ensureStarted() 会用新 server 的返回值重新填,
     // 防止用户中途切 CODEX_HOME (改 auth / 重登) 后这边还拿着老路径。
     this.codexHome = null;
-    if (hostsSnapshot.length > 0) {
+    if (retirements.length > 0) {
       // 并发 shutdown — 互不依赖, 一起更快收完。失败不阻断其他。
-      await Promise.allSettled(
-        hostsSnapshot.map((h) => h.retire('CodexAgent.dispose()')),
-      );
+      await Promise.allSettled(retirements);
     }
     // dispose 完毕 → 重置 seq, 下次 createHost 重新从 1 开始计数 (logout/切账号场景)
     this.createHostSeqByKey.clear();
@@ -13446,6 +13477,22 @@ export class CodexAgent extends BaseAgent {
     });
   }
 
+  private beginHostRetirement(key: string, host: AppServerHost, reason: string): Promise<void> {
+    const existing = this.retiringHosts.get(key);
+    if (existing?.host === host) return existing.promise;
+    const entry = {
+      host,
+      generation: this.hostGenerations.get(key) ?? 0,
+      promise: Promise.resolve().then(() => host.retire(reason, { throwOnTransportError: true })),
+    };
+    this.retiringHosts.set(key, entry);
+    // 只清成功的当前 entry。关闭失败时不能误把旧 writer 当作已经退出。
+    void entry.promise.then(() => {
+      if (this.retiringHosts.get(key) === entry) this.retiringHosts.delete(key);
+    }, () => undefined);
+    return entry.promise;
+  }
+
   private async retireHostKey(
     key: string,
     reason: string,
@@ -13459,6 +13506,17 @@ export class CodexAgent extends BaseAgent {
       throwOnShutdownFailure?: boolean;
     },
   ): Promise<void> {
+    const retiring = this.retiringHosts.get(key);
+    if (retiring
+      && (!opts.expectedHost || opts.expectedHost === retiring.host)
+      && (opts.expectedGeneration === undefined || opts.expectedGeneration === retiring.generation)) {
+      try {
+        await retiring.promise;
+      } catch (error) {
+        if (opts.throwOnShutdownFailure) throw error;
+      }
+      return;
+    }
     let expectedGeneration = opts.expectedGeneration;
     const matchesExpectedHost = (): boolean => {
       if (opts.expectedHost && this.hosts.get(key) !== opts.expectedHost) return false;
@@ -13526,6 +13584,7 @@ export class CodexAgent extends BaseAgent {
       host?.notifySubscribersOfForcedRetire(reason);
     }
 
+    const retirement = host ? this.beginHostRetirement(key, host, reason) : undefined;
     this.hosts.delete(key);
     this.hostPromises.delete(key);
     this.hostCredentialModes.delete(key);
@@ -13537,9 +13596,7 @@ export class CodexAgent extends BaseAgent {
     this.bumpHostGeneration(key);
     if (!host) return;
     try {
-      await host.retire(reason, {
-        throwOnTransportError: opts.throwOnShutdownFailure,
-      });
+      await retirement;
     } catch (error) {
       this.deps.logger.warn(`${opts.logPrefix}: host shutdown failed`, {
         key,


### PR DESCRIPTION
## 这次改了什么

### 摘要

Codex 原生历史出现重复序号时，`thread/fork` 会报 `expected ordinal …, got …`，导致 Cindy 无法创建 fork。退出路径此前在 stdin EOF 后立即发送 SIGTERM，并在子进程实际退出前把关闭视为完成，可能打断保存，也允许同一 Host 的替代进程过早启动。

本次让正常退出先等待 Codex 保存并结束；如果原生历史已经损坏，fork 会通过 Cindy 已保存的选定消息前缀建立新的上下文交接。新任务、复制消息和恢复标记在一个事务内保存，保留原任务。

### 变更类型

- [ ] `feat` 新功能
- [x] `fix` 缺陷修复
- [ ] `refactor` / `perf` 重构或性能优化
- [ ] `docs` / `test` / `chore` 文档、测试或工程维护
- [ ] 其他：

### 范围

- 关联 Issue / 需求：修复退出后的 Codex 历史序号不同步风险，并为损坏历史的 fork 提供恢复路径。
- 本 PR 包含：Codex transport、Client、Host 与 Agent 的退出完成传递；Desktop 退出依赖顺序；普通、strip 和恢复历史再次 fork 的原子交接；两种 DB worker 的源历史一致性检查；回归测试。
- 明确不包含：修改 Codex 原生历史格式、重排 ordinal、覆盖源任务或数据库 schema migration。
- 用户可见变化：正常退出先给 Codex 保存时间；原生历史损坏时仍可从所选位置创建 fork，并显示现有恢复提示。认证、超时、取消和磁盘故障仍保留错误，不会静默改为新任务。
- 是否存在 breaking change：无。

维护不变量：

- 物理退出由 transport 的真实 exit 事件确认。EOF 等待 1.5 秒，超时后 SIGTERM 等待 1 秒，再以 SIGKILL 和 0.5 秒退出确认兜底。并发关闭共享当前等待，各调用方独立保留严格错误传播策略。
- 确认超时后保留旧 client 和同 key Host 屏障，原调用仍失败。若真实 exit 随后到达，下一次关闭或使用请求可重新检查并释放屏障；重查不重发信号、不新增后台重试。普通 shutdown 成功后可重启，retired Host 永不重启，终态清理只执行一次。其他 key 不受影响。
- 启动失败、同步重入、迟到回调、凭据切换及并发 dispose 复用以上规则。正常退出时 Codex 环境、proxy 和 DB 保留到 Maker 收尾；应用整体超时仍按既有尽力清理策略结束。
- 恢复交接与复制消息必须来自同一份有序原始前缀。main 为完整原始行计算 SHA-256，两个 worker 在写事务内重新读取并核对摘要和清空边界，随后才写子任务、消息和恢复记录。内容编辑、身份替换、元数据或顺序变化均使整笔操作失败；选定前缀之外的追加消息不影响 fork。摘要仅作为本次事务前提，不持久化，不使用截短后的 handoff 计算。

### UI 变化

不涉及新增界面、样式或文案；恢复路径复用现有恢复卡片。

- 引用的设计规范：不涉及。

## 怎么验证的

### 自动验证

```text
pnpm test:unit:related
结果：通过；Desktop、lizi-mcps、maker-core、orca-workflow 四个受影响 workspace 全部通过。

pnpm --filter desktop run --if-present typecheck
结果：通过。

pnpm --filter @cindy/maker-core run --if-present typecheck
结果：通过；该包没有 typecheck script，按仓库规则跳过。

pnpm --filter @cindy/maker-core exec vitest run src/agents/codex/app-server/stdioTransport.test.ts src/agents/codex/app-server/client.test.ts src/agents/codex/app-server/host.test.ts src/agents/codex/index.test.ts --pool=threads --maxWorkers=4
结果：690 项通过。

pnpm --filter desktop exec vitest run src/main/__tests__/fork.test.ts src/main/localDb/client/__tests__/tx.test.ts --pool=threads --maxWorkers=2
结果：123 项通过；含 file / inline worker 的真实临时数据库事务验证。

git diff --check
结果：通过。

pnpm check:dco
结果：全部 commit 签名通过。
```

覆盖正常退出、超时强杀、退出确认失败及迟到退出后的恢复、EPIPE、启动失败、重复关闭、重查途中 retire、同 key 重建等待和远程 key 不受影响；fork 覆盖用户/助手消息边界、空前缀、已恢复历史再次 fork、合成时间戳、历史模型/provider、并发清空，以及条数不变时的内容/身份/角色/tool/元数据/顺序变化与事务回滚。

首轮 Desktop 整包有两项首次动态加载模块的用例超过原有 5 秒超时（Agent Island service、Codex OAuth binding claim）。两文件定向复验 137 项通过，保持代码及测试配置不变后，同一套根目录门禁完整复跑通过。

### 手工验证

在 macOS arm64 用当前 Codex CLI 0.153.0 和修改后的 transport 做独立子进程探针：临时 CODEX_HOME、loopback 模拟 Responses、合成工具调用，不使用真实凭证或用户历史。原生 turn 等待工具结果时关闭，26ms 后确认子进程退出，保存了 `turn_aborted`，历史序号连续；重启后 resume 和 fork 均成功。随后仅在临时历史注入重复 ordinal，确认真实 Codex 错误被恢复分类器识别。该探针由脚本执行，未做完整 Desktop UI 手工操作。

### 未执行的验证

- 未在 Windows 实机验证退出；未替换正在运行的 Cindy 客户端。
- 完整仓库单测交由 CI；本地提交门禁按当前仓库要求执行相关单测。
- 首次提交时额外比对过 maker-core `build` 类型检查和改动生产文件 ESLint：相同依赖及工具下，基线 `47ef43ed` 与实现后分别为 59 项、17 项既有问题，无新增。这两项不替代上述提交门禁。

## 风险

### 风险分类

- [ ] 无已知风险
- [x] SQLite / migration
- [ ] system prompt
- [ ] 协议兼容
- [x] 权限 / 安全 / 用户数据
- [ ] 存量插件兼容（批准状态 / 指纹 / manifest 校验 / 安装布局 / 包格式）
- [ ] 原生层 / fingerprint / OTA
- [x] 跨平台差异
- [x] 其他：异步退出和并发 Host 生命周期。

### 影响与回滚

- 影响范围：Codex 进程退出、Desktop 退出依赖与 Codex fork 的历史恢复。SQLite 仅调整既有事务检查，无 schema 或 migration 变更；恢复基于 Cindy 已保存的消息，不承诺还原 Codex 隐藏状态。系统强杀、进程卡死或整体退出超时仍可能留下原生损坏历史，因此保留 fork 恢复路径。
- 回滚 / 降级方式：回退本 PR 即可恢复旧代码，无数据库回滚；已保存的恢复记录使用既有 `native-session-recovery` 格式。源任务与原生历史未被修写。恢复事务发现源历史已被清空或选定前缀被编辑时拒绝创建，避免带回已清除内容或注入过时交接。

### 提交前检查

- [x] 已 review 完整 diff
- [x] 每个 commit 都带 DCO 签名（`git commit -s`，见 [DCO](../DCO)）
- [x] UI 改动已在「UI 变化」注明引用的设计规范章节（不涉及 UI 则跳过）
- [x] 未提交凭证、令牌或授权文件
- [x] 已补充必要文档（无独立文档变更；维护不变量以代码注释和回归测试说明）
- [x] 已确认测试结果或说明未执行原因
