### PR TITLE
fix(mobile): 修复横屏启动角色图偏移，保持竖屏布局

### DIFF
--- a/apps/mobile/src/auth/__tests__/loginSkinLayout.test.ts
+++ b/apps/mobile/src/auth/__tests__/loginSkinLayout.test.ts
@@ -274,6 +274,49 @@ describe("loginSkin 42s 重发倒计时纯函数(Step 3a 契约)", () => {
 });
 
 describe("loginSkin §3.6 平板/横竖屏 surface 构图(PR4b Step 5b.3;adaptation §3.6 + demo resolveMobileStage/ipadPortrait/ipadLandscape 仲裁)", () => {
+  it.each([
+    [667, 375],
+    [812, 375],
+    [852, 393],
+    [932, 430],
+    [1100, 600],
+    [375, 667],
+    [393, 852],
+  ])("%i×%i 启动立绘按实际视口居中，字标与加载圈不越出屏幕", (width, height) => {
+    const surface = resolveLoginSurface(width, height);
+    const { scale, splashOffset, cindy, word, spinner } = surface;
+    expect(surface.mode).toBe("phone");
+    const heroTop = (cindy.y + splashOffset) * scale;
+    const heroBottom = heroTop + cindy.h * scale;
+    // splashOffset 取整最多产生半个设计像素误差。
+    expect(Math.abs((heroTop + heroBottom) / 2 - height / 2)).toBeLessThanOrEqual(
+      scale / 2,
+    );
+    expect(heroTop).toBeGreaterThanOrEqual(0);
+    expect(heroBottom).toBeLessThanOrEqual(height);
+    expect((word.y + splashOffset) * scale).toBeGreaterThanOrEqual(0);
+    expect((word.y + word.h + splashOffset) * scale).toBeLessThanOrEqual(height);
+    expect(spinner.y * scale).toBeGreaterThanOrEqual(0);
+    expect((spinner.y + spinner.size) * scale).toBeLessThanOrEqual(height);
+    expect(Math.abs(spinner.y - (word.y + word.h + splashOffset + 44))).toBeLessThanOrEqual(0.5);
+  });
+
+  it.each([
+    [375, 667, 247, 893],
+    [393, 852, 256, 1101],
+    [430, 932, 256, 1101],
+    [320, 768, 343, 1188],
+    [320, 1000, 343, 1188],
+    [600, 600, 270, 465],
+    [744, 1133, 158, 804],
+    [820, 1180, 158, 804],
+  ])("%i×%i 竖屏保留修复前的启动落位", (width, height, splashOffset, spinnerY) => {
+    // 修复前基线实值，包含触发 designHeight 上限的超长竖屏与正方形边界。
+    const surface = resolveLoginSurface(width, height);
+    expect(surface.splashOffset).toBe(splashOffset);
+    expect(surface.spinner.y).toBe(spinnerY);
+  });
+
   it("断点三分支:landscape∧w≥1000∧h≥690→pad-landscape;portrait∧w≥700→pad-portrait;其余→phone", () => {
     // 基准画布
     expect(resolveLoginSurfaceMode(1180, 820)).toBe("pad-landscape");

--- a/apps/mobile/src/auth/loginSkinLayout.ts
+++ b/apps/mobile/src/auth/loginSkinLayout.ts
@@ -346,8 +346,8 @@ export const LOGIN_PHONE_SPLASH_SPINNER_SIZE = 64;
 
 /**
  * 纯函数:物理 viewport → 登录 surface 构图(§3.6 断点 + 三构图布局统一出口)。
- * phone 分支复用 resolveLoginStage 两档插值;splash 簇偏移 = demo phoneStage
- * off = round((designHeight - cindy.h)/2 - cindy.y),spinner 居字标下方 44。
+ * phone 分支复用 resolveLoginStage 两档插值;横屏 splash 簇按实际视口高度居中
+ * (先除以 scale 换回 stage 坐标),竖屏沿用设计高,spinner 居字标下方 44。
  */
 export function resolveLoginSurface(
   viewportWidth: number,
@@ -361,8 +361,13 @@ export function resolveLoginSurface(
     return padSurface(mode, LOGIN_PAD_LANDSCAPE_STAGE, viewportWidth, viewportHeight);
   }
   const stage = resolveLoginStage(viewportWidth, viewportHeight);
+  // designHeight 的上下限只约束登录构图。横屏时它可能高于可见视口，
+  // 用它居中会把启动立绘、字标和 spinner 一起推到屏幕下方。
+  const splashHeight = viewportWidth > viewportHeight
+    ? viewportHeight / stage.scale
+    : stage.designHeight;
   const splashOffset = Math.round(
-    (stage.designHeight - stage.cindy.h) / 2 - stage.cindy.y,
+    (splashHeight - stage.cindy.h) / 2 - stage.cindy.y,
   );
   return {
     mode,


### PR DESCRIPTION
## 这次改了什么

### 摘要

手机横屏启动时，启动角色图沿用了被钳制到最小设计高度的画布来居中，导致角色、字标和加载圈整体下偏。852×393 视口下角色框中心偏低约 144 点。本次仅在 phone 构图的横屏分支中使用实际视口高度计算启动偏移，竖屏与平板专属构图保留原行为。

### 变更类型

- [ ] `feat` 新功能
- [x] `fix` 缺陷修复
- [ ] `refactor` / `perf` 重构或性能优化
- [ ] `docs` / `test` / `chore` 文档、测试或工程维护
- [ ] 其他：

### 范围

- 关联 Issue / 需求：用户反馈手机横屏启动时 Cindy 角色图位置异常，并要求竖屏保持不变。
- 本 PR 包含：横屏启动偏移计算修复、横屏可见性回归及竖屏原落位回归测试。
- 明确不包含：登录终态构图、图片查看器、原生配置、依赖与素材修改。
- 用户可见变化：手机横屏启动的角色图恢复在实际视口内居中，字标和加载圈随之上移；竖屏保持不变。
- 是否存在 breaking change：无。

### UI 变化

- 引用的设计规范：`docs/design-rules/DESIGN.md` §16.2 登录品牌构图。复用既有角色／字标几何与统一 stage 缩放，只校正横屏启动居中参考高度；保留手机短长屏 loginY 622/827、平板构图及元素间距。明暗主题共同消费同一布局函数，沿用既有素材与语义颜色。
- 平台：iOS / Android 共享布局；本次未运行设备截图或录屏。

## 怎么验证的

### 自动验证

```text
pnpm test:unit:related
结果：通过。

pnpm --filter mobile run --if-present typecheck
结果：通过。

git diff --check
结果：通过。
```

新增横屏／普通竖屏可见性用例及 8 组竖屏原落位用例。另以 Node 加载修改前基线与修改后模块，对宽 280–1600、高从宽度到 2400、步长 10 的 19,551 组竖屏／正方形视口做完整输出 deepEqual，比对全部通过。

### 手工验证

已审阅完整 diff，并核对 852×393 横屏的修复前偏差。未进行手机 App 操作验证。

### 未执行的验证

未做 iOS / Android 模拟器或真机目检，Light / Dark 均未目检。本次验证位于分支 `dash/fix-mobile-landscape-brand`、worktree `cindy-fix-mobile-landscape-brand`，仅运行纯布局测试与类型检查；未启动 Metro，无 Metro 归属及 __DEV__ build label 证据。完整仓库单测由 CI 执行。

## 风险

### 风险分类

- [ ] 无已知风险
- [ ] SQLite / migration
- [ ] system prompt
- [ ] 协议兼容
- [ ] 权限 / 安全 / 用户数据
- [ ] 存量插件兼容（批准状态 / 指纹 / manifest 校验 / 安装布局 / 包格式）
- [ ] 原生层 / fingerprint / OTA
- [ ] 跨平台差异
- [x] 其他：横屏视觉变化尚未经过设备目检。

### 影响与回滚

- 影响范围：phone 构图横屏启动的角色／字标／加载圈偏移；竖屏、平板专属构图与登录终态不变。不改原生指纹输入。
- 回滚 / 降级方式：回退本 PR 的布局计算改动。

### 提交前检查

- [x] 已 review 完整 diff
- [x] 每个 commit 都带 DCO 签名（`git commit -s`，见 [DCO](../DCO)）
- [x] UI 改动已在「UI 变化」注明引用的设计规范章节（不涉及 UI 则跳过）
- [x] 未提交凭证、令牌或授权文件
- [x] 已补充必要文档（源码注释说明横屏参考高度与竖屏保留行为）
- [x] 已确认测试结果或说明未执行原因
