### PR TITLE
fix(providers): reject credentials embedded in model discovery URLs

### DIFF
--- a/apps/desktop/src/main/maker-host/__tests__/custom-provider-store.test.ts
+++ b/apps/desktop/src/main/maker-host/__tests__/custom-provider-store.test.ts
@@ -72,6 +72,25 @@ afterEach(() => {
 });
 
 describe('validateCustomProviderConfig (per-runtime)', () => {
+  it.each(['user@', ':secret@', 'user:secret@', 'us%65r:s%65cret@'])(
+    'rejects credentials in modelsUrl without exposing them: %s',
+    (userinfo) => {
+      expect(validateCustomProviderConfig({
+        ...valid,
+        runtimes: {
+          codex: {
+            ...valid.runtimes.codex!,
+            modelsUrl: `https://${userinfo}openrouter.ai/api/v1/models`,
+          },
+        },
+      })).toEqual({
+        ok: false,
+        code: 'INVALID_PARAMS',
+        message: "runtime 'codex' modelsUrl must not contain embedded credentials",
+      });
+    },
+  );
+
   it('accepts a valid single-runtime config', () => {
     expect(validateCustomProviderConfig(valid)).toEqual({ ok: true });
   });

--- a/apps/desktop/src/main/maker-host/__tests__/providerModelFetch.test.ts
+++ b/apps/desktop/src/main/maker-host/__tests__/providerModelFetch.test.ts
@@ -21,6 +21,16 @@ function fakeResponse(status: number, body: string): Response {
 }
 
 describe('buildModelsFetchRequest', () => {
+  it.each(
+    (['baseUrl', 'modelsUrl'] as const).flatMap((field) =>
+      ['user@', ':secret@', 'user:secret@', 'us%65r:s%65cret@'].map((userinfo) => ({ field, userinfo })),
+    ),
+  )('rejects credentials in $field before building a request: $userinfo', ({ field, userinfo }) => {
+    expect(() => buildModelsFetchRequest(spec({
+      [field]: `https://${userinfo}api.acme.example/anthropic/v1/models`,
+    }))).toThrow('model discovery requires HTTP(S) URLs without embedded credentials');
+  });
+
   it('derives {base}/v1/models for non-/vN baseUrl; appends /models when baseUrl ends with /vN', () => {
     expect(buildModelsFetchRequest(spec()).url).toBe('https://api.acme.example/anthropic/v1/models');
     expect(
@@ -116,6 +126,24 @@ describe('buildModelsFetchRequest', () => {
 });
 
 describe('fetchProviderModels', () => {
+  it.each(
+    (['baseUrl', 'modelsUrl'] as const).flatMap((field) =>
+      ['user@', ':secret@', 'user:secret@', 'us%65r:s%65cret@'].map((userinfo) => ({ field, userinfo })),
+    ),
+  )('does not dispatch a request with credentials in $field: $userinfo', async ({ field, userinfo }) => {
+    const fetchImpl = vi.fn<typeof fetch>();
+    const result = await fetchProviderModels(spec({
+      [field]: `https://${userinfo}api.acme.example/anthropic/v1/models`,
+      authMethod: 'apiKey',
+    }), fetchImpl);
+    expect(result).toEqual({
+      ok: false,
+      code: 'UNKNOWN',
+      detail: 'model discovery requires HTTP(S) URLs without embedded credentials',
+    });
+    expect(fetchImpl).not.toHaveBeenCalled();
+  });
+
   it.each([
     {
       baseUrl: 'https://remote.example/v1',

--- a/apps/desktop/src/main/maker-host/custom-provider-store.ts
+++ b/apps/desktop/src/main/maker-host/custom-provider-store.ts
@@ -343,6 +343,9 @@ function validateRuntime(agent: string, rt: unknown): ValidationResult {
       if (u.protocol !== 'http:' && u.protocol !== 'https:') {
         return invalid(`runtime '${agent}' modelsUrl must be http(s)`);
       }
+      if (u.username || u.password) {
+        return invalid(`runtime '${agent}' modelsUrl must not contain embedded credentials`);
+      }
     } catch {
       return invalid(`runtime '${agent}' modelsUrl is not a valid URL`);
     }

--- a/apps/desktop/src/main/maker-host/provider-model-fetch.ts
+++ b/apps/desktop/src/main/maker-host/provider-model-fetch.ts
@@ -28,6 +28,7 @@ import { outboundFetch } from './outbound-fetch.js';
 const FETCH_TIMEOUT_MS = 10_000;
 /** 失败响应体最多读取的字节数（分类只看前几 KB）。 */
 const MAX_ERROR_BODY_BYTES = 16 * 1024;
+const INVALID_DISCOVERY_URL = 'model discovery requires HTTP(S) URLs without embedded credentials';
 
 /** 一次「获取模型列表」的完整参数（表单值内存透传，不落盘）。 */
 export interface ProviderModelsFetchSpec {
@@ -64,13 +65,17 @@ export interface ProviderModelsFetchResult {
   detail?: string;
 }
 
-/** 两个 URL 是否同源（scheme + host + 端口）。任一解析失败视为不同源（fail-closed）。 */
-function sameOrigin(a: string, b: string): boolean {
+/** origin 不含 userinfo；先独立验证地址，错误中不带原始 URL 或解析器异常。 */
+function parseModelsFetchUrl(value: string): URL {
   try {
-    return new URL(a).origin === new URL(b).origin;
+    const url = new URL(value);
+    if ((url.protocol === 'http:' || url.protocol === 'https:') && !url.username && !url.password) {
+      return url;
+    }
   } catch {
-    return false;
+    // URL 解析器的异常可能包含凭据，只返回固定的校验说明。
   }
+  throw new Error(INVALID_DISCOVERY_URL);
 }
 
 function withoutCredentialHeaders(
@@ -94,6 +99,9 @@ function normalizedHeaders(headers: Record<string, string> | undefined): Record<
 
 /** 构造列模型请求（纯函数，单测直断言）。鉴权头组合与 buildProbeRequest 同口径。 */
 export function buildModelsFetchRequest(spec: ProviderModelsFetchSpec): { url: string; init: RequestInit } {
+  const baseUrl = parseModelsFetchUrl(spec.baseUrl);
+  const explicit = spec.modelsUrl?.trim();
+  const modelsUrl = explicit ? parseModelsFetchUrl(explicit) : null;
   const mustStripCredentialHeaders =
     !!spec.apiKey || spec.authMethod === 'none' || spec.authMethod === 'oauth';
   const headers: Record<string, string> = mustStripCredentialHeaders
@@ -116,9 +124,8 @@ export function buildModelsFetchRequest(spec: ProviderModelsFetchSpec): { url: s
   }
   // modelsUrl 是用户不可见的隐藏字段（预设/配置快照）。只有与 baseUrl 同源才采用——
   // 防止用户改了 baseUrl 后，key 仍被发往快照里的旧主机 / 被降级成明文（现有预设全部同源）。
-  const explicit = spec.modelsUrl?.trim();
   return {
-    url: explicit && sameOrigin(explicit, spec.baseUrl) ? explicit : deriveModelsDiscoveryUrl(spec.baseUrl),
+    url: explicit && modelsUrl?.origin === baseUrl.origin ? explicit : deriveModelsDiscoveryUrl(spec.baseUrl),
     init: { method: 'GET', headers },
   };
 }
@@ -152,7 +159,13 @@ export async function fetchProviderModels(
       detail: 'no-auth provider model discovery requires loopback URLs',
     };
   }
-  const { url, init } = buildModelsFetchRequest(spec);
+  let request: ReturnType<typeof buildModelsFetchRequest>;
+  try {
+    request = buildModelsFetchRequest(spec);
+  } catch {
+    return { ok: false, code: 'UNKNOWN', detail: INVALID_DISCOVERY_URL };
+  }
+  const { url, init } = request;
   let res: Response;
   try {
     res = await fetchImpl(url, { ...init, signal: AbortSignal.timeout(FETCH_TIMEOUT_MS) });

--- a/apps/desktop/src/main/maker-ipc/__tests__/providerHandlers.test.ts
+++ b/apps/desktop/src/main/maker-ipc/__tests__/providerHandlers.test.ts
@@ -3233,6 +3233,23 @@ describe('provider:models-fetch handler', () => {
     expect(deps.fetchModels).not.toHaveBeenCalled();
   });
 
+  it.each(
+    (['baseUrl', 'modelsUrl'] as const).flatMap((field) =>
+      ['user@', ':secret@', 'user:secret@', 'us%65r:s%65cret@'].map((userinfo) => ({ field, userinfo })),
+    ),
+  )('rejects credentials in model discovery $field at IPC ingress: $userinfo', async ({ field, userinfo }) => {
+    const harness = new IpcHarness();
+    const deps = makeDeps();
+    registerProviderHandlers(harness, deps);
+    await expect(harness.invoke(MAKER_INVOKE.PROVIDER_MODELS_FETCH, {
+      agent: 'codex',
+      authMethod: 'apiKey',
+      baseUrl: 'https://x.example/v1',
+      [field]: `https://${userinfo}x.example/v1/models`,
+    })).rejects.toThrow(/INVALID_PARAMS/);
+    expect(deps.fetchModels).not.toHaveBeenCalled();
+  });
+
   it('rejects malformed input with INVALID_PARAMS (bad agent / bad url / bad modelsUrl / bad headers)', async () => {
     const harness = new IpcHarness();
     const deps = makeDeps();

--- a/apps/desktop/src/main/maker-ipc/providerHandlers.ts
+++ b/apps/desktop/src/main/maker-ipc/providerHandlers.ts
@@ -463,7 +463,7 @@ function parseModelsFetchInput(input: unknown): ProviderModelsFetchSpec | null {
   const httpUrlOk = (v: string): boolean => {
     try {
       const u = new URL(v);
-      return u.protocol === 'http:' || u.protocol === 'https:';
+      return (u.protocol === 'http:' || u.protocol === 'https:') && !u.username && !u.password;
     } catch {
       return false;
     }

--- a/packages/model-providers/src/__tests__/presets.test.ts
+++ b/packages/model-providers/src/__tests__/presets.test.ts
@@ -261,6 +261,52 @@ describe('sanitizePresets', () => {
     }
   });
 
+  it.each(['user@', ':secret@', 'user:secret@', 'us%65r:s%65cret@'])(
+    'strips credential-bearing modelsUrl without dropping the preset: %s',
+    (userinfo) => {
+      const preset = {
+        ...VALID_PRESET,
+        runtimes: {
+          codex: {
+            baseUrl: 'https://x.example/v1',
+            models: [{ id: 'm', name: 'M' }],
+            modelsUrl: `https://${userinfo}x.example/v1/models`,
+          },
+        },
+      };
+      const out = sanitizePresets([preset]);
+      expect(out).toHaveLength(1);
+      expect(out[0]?.runtimes.codex).toEqual({
+        baseUrl: 'https://x.example/v1',
+        models: [{ id: 'm', name: 'M' }],
+      });
+    },
+  );
+
+  it.each(
+    (['baseUrl', 'modelsUrl'] as const).flatMap((field) =>
+      ['user@', ':secret@', 'user:secret@', 'us%65r:s%65cret@'].map((userinfo) => ({ field, userinfo })),
+    ),
+  )('removes only discovery sources with credentials in $field: $userinfo', ({ field, userinfo }) => {
+    const source = {
+      baseUrl: 'https://x.example/v1',
+      modelsUrl: 'https://x.example/v1/models',
+      wireProtocol: 'openai-responses',
+    };
+    const out = sanitizePresets([{
+      ...VALID_PRESET,
+      runtimes: {
+        codex: {
+          baseUrl: 'https://x.example/v1',
+          models: [{ id: 'm', name: 'M' }],
+          modelDiscovery: [source, { ...source, [field]: `https://${userinfo}x.example/v1/models` }],
+        },
+      },
+    }]);
+    expect(out).toHaveLength(1);
+    expect(out[0]?.runtimes.codex?.modelDiscovery).toEqual([source]);
+  });
+
   it('modelDiscovery 只保留同源且协议合法的附加目录', () => {
     const source = {
       baseUrl: 'https://x.example/api/v1',

--- a/packages/model-providers/src/catalog.ts
+++ b/packages/model-providers/src/catalog.ts
@@ -579,12 +579,12 @@ function isValidPreset(v: unknown): v is ProviderPreset {
   return true;
 }
 
-/** 是否合法 http(s) URL（modelsUrl 归一化用）。 */
+/** 是否为不含内嵌凭据的 http(s) URL（模型发现地址归一化用）。 */
 function isHttpUrl(v: unknown): boolean {
   if (typeof v !== 'string' || v.length === 0) return false;
   try {
     const u = new URL(v);
-    return u.protocol === 'https:' || u.protocol === 'http:';
+    return (u.protocol === 'https:' || u.protocol === 'http:') && !u.username && !u.password;
   } catch {
     return false;
   }
@@ -625,7 +625,7 @@ function isLegacyAnthropicPiRuntime(
 }
 
 /**
- * runtime.modelsUrl 非法（非 http(s) URL）时剥掉该字段、保留预设本体——OSS 推错一个
+ * runtime.modelsUrl 非法（非 http(s) URL 或含内嵌凭据）时剥掉该字段、保留预设本体——OSS 推错一个
  * 不可见字段不该让整条预设消失，更不该让用户保存时撞 main 侧 URL 校验无法自助修复。
  */
 function normalizePresetRuntimeOptions(p: ProviderPreset): ProviderPreset {


### PR DESCRIPTION
## 这次改了什么

### 摘要

补齐模型发现地址的无凭据 URL 校验，使目录清洗、配置保存、IPC 入口与实际请求构造遵守一致边界，避免发现结果携带无效地址、直到保存供应商时才失败。

- 清理预设 runtime.modelsUrl 中的无效地址，过滤 modelDiscovery 中的无效来源，同时保留整个预设及其他合法来源。
- 主进程保存与模型发现 IPC 拒绝含用户名或密码的发现 URL。
- 请求构造处再次校验，拒绝时不发网络请求，错误信息不回显原始 URL 或解析器异常。
- 新增 40 项回归用例，覆盖仅用户名、仅密码、用户名与密码、编码后的凭据；保留合法同源地址和原有跨源回退行为。

### 变更类型

- [ ] `feat` 新功能
- [x] `fix` 缺陷修复
- [ ] `refactor` / `perf` 重构或性能优化
- [ ] `docs` / `test` / `chore` 文档、测试或工程维护
- [ ] 其他：

### 范围

- 关联 Issue / 需求：Closes #2790
- 本 PR 包含：共享模型目录清洗、Desktop 自定义供应商校验、模型发现 IPC 与请求层，以及对应测试。
- 明确不包含：UI、模型目录数据、服务端、正常鉴权流程、运行时二进制版本或测试调度配置。
- 用户可见变化：无效的发现地址更早被清理或拒绝；返回安全的校验说明。
- 是否存在 breaking change：不改变公开字段或正常配置行为；收紧 URL 内嵌凭据校验，不再接受这类无效发现地址。

### UI 变化

不涉及。

- 引用的设计规范：不涉及。

## 怎么验证的

### 自动验证

本地 macOS arm64，Node 22.23.1、pnpm 10.33.2；分支 `fix/2790-discovery-url-credentials`，基于 `main@8d6c404f7`。

```text
pnpm test:unit:related
结果：通过：Desktop full（标准 threads/8 workers，227.1 秒）、Mobile full（25.2 秒）、model-providers related（1.4 秒）；未修改调度配置。

pnpm --filter desktop run --if-present typecheck
结果：通过。

pnpm --filter @cindy/model-providers run --if-present typecheck
结果：该包无此 script，按门禁规则跳过。

pnpm --filter @cindy/model-providers build
结果：通过（tsc --noEmit）。

pnpm --filter @cindy/model-providers exec vitest run src/__tests__/presets.test.ts
结果：79 项通过。

pnpm --filter desktop exec vitest run src/main/maker-host/__tests__/custom-provider-store.test.ts src/main/maker-host/__tests__/providerModelFetch.test.ts src/main/maker-ipc/__tests__/providerHandlers.test.ts
结果：217 项通过。

pnpm --filter desktop exec eslint src/main/maker-host/custom-provider-store.ts src/main/maker-host/provider-model-fetch.ts src/main/maker-ipc/providerHandlers.ts src/main/maker-host/__tests__/custom-provider-store.test.ts src/main/maker-host/__tests__/providerModelFetch.test.ts src/main/maker-ipc/__tests__/providerHandlers.test.ts
结果：通过。

pnpm check:i18n-glossary
结果：通过；无新增违规，18 处既有待裁决术语告警不阻断。

git diff --check
结果：通过。

pnpm check:dco
结果：通过，唯一提交 918e5e58c 已签名。
```

前期验证曾遇到 Desktop 默认 threads 进程 SIGSEGV，未将该轮记作通过；依赖安装后还遇到 Electron 未完成安装导致的测试加载失败，补齐锁定版本 Electron 后已消除。另以 `--pool=forks --maxWorkers=4` 重跑 Desktop 与 unit 门禁完全相同的范围（沿用相同排除项，没有新增跳过）：2,323 个测试文件通过、1 个原有跳过；31,759 项测试通过、11 项原有跳过。最终标准门禁结果见上文。

### 手工验证

未进行 GUI 操作或真实供应商联网验证。本次通过纯函数、可注入 fetch 与 IPC 单测验证边界，使用的用户名、密码均为测试数据，没有真实凭据。

### 未执行的验证

- 未进行 Windows 本地实机、真实供应商联网或桌面 GUI 验证。
- Mobile 仅由 related 门禁运行整包 unit；未启动 Metro、模拟器或 __DEV__ build，因此无 Metro 归属或 build label 证据。
- 未运行不属于本次相关门禁的数据库、迁移及 Git integration 专项。

## 风险

### 风险分类

- [ ] 无已知风险
- [ ] SQLite / migration
- [ ] system prompt
- [ ] 协议兼容
- [x] 权限 / 安全 / 用户数据
- [ ] 存量插件兼容（批准状态 / 指纹 / manifest 校验 / 安装布局 / 包格式）
- [ ] 原生层 / fingerprint / OTA
- [ ] 跨平台差异
- [ ] 其他：

### 影响与回滚

- 影响范围：仅收紧带 URL 内嵌用户名/密码的模型发现地址；不改变正常鉴权头、合法同源目录及跨源回退。预设保留容错语义，坏的可选字段/来源不会淘汰整个预设。错误使用固定说明，不回显原始 URL。
- 不迁移、删除或重写用户已有数据；存量无效发现地址再次提交时会被拒绝，需要改用不含内嵌凭据的地址与正常鉴权设置。
- 回滚 / 降级方式：revert 本次修复提交；无 schema 或协议迁移。

### 提交前检查

- [x] 已 review 完整 diff
- [x] 每个 commit 都带 DCO 签名（`git commit -s`）
- [x] UI 改动已在「UI 变化」注明引用的设计规范章节（本次不涉及）
- [x] 未提交凭证、令牌或授权文件
- [x] 已补充必要文档（无文档行为契约变更，细节及验证记录于本 PR）
- [x] 已确认测试结果或说明未执行原因

