### PR TITLE
fix(mobile): 修复输入框展开和拖拽时的高度约束残留

### DIFF
--- a/apps/mobile/src/__tests__/composerInteractionBoundary.test.tsx
+++ b/apps/mobile/src/__tests__/composerInteractionBoundary.test.tsx
@@ -68,7 +68,26 @@ Object.assign(globalThis, { IS_REACT_ACT_ENVIRONMENT: true });
 let root: Root;
 const flushJS = () => act(() => { for (const job of runtime.js.splice(0)) job(); });
 const gestureOf = (value: unknown) => value as TestGesture;
-const styleOf = (value: unknown) => (value as { current: { height: number; maxHeight?: number } }).current;
+const styleOf = (value: unknown) => (value as { current: { height: number | 'auto'; maxHeight?: number } }).current;
+
+// Reanimated's native registry merges incremental props. JSI dynamicFromValue
+// omits undefined object fields; returning undefined does not remove an earlier
+// height/maxHeight. Keep the receiver's state to test transitions, not just the
+// worklet's latest return value. This models that boundary, not device rendering.
+function nativeFrameReceiver() {
+  let props: { height?: number | 'auto'; maxHeight?: number } = {};
+  return {
+    apply(style: unknown) {
+      const update = Object.fromEntries(Object.entries(styleOf(style)).filter(([, value]) => value !== undefined));
+      props = { ...props, ...update };
+      return props;
+    },
+    heightForContent(contentHeight: number) {
+      const height = typeof props.height === 'number' ? props.height : contentHeight;
+      return Math.min(height, props.maxHeight ?? Infinity);
+    },
+  };
+}
 
 beforeEach(() => {
   runtime.js = [];
@@ -97,6 +116,50 @@ function mountComposer(input: UseComposerResizeInput) {
 }
 
 describe('composer resize interaction boundary', () => {
+  it('clears a collapsed native height when reopening and lets content grow and shrink', () => {
+    const input = { ...composerInput(), collapsed: true };
+    const harness = mountComposer(input);
+    const frame = nativeFrameReceiver();
+    frame.apply(harness.result.frameStyle);
+    expect(frame.heightForContent(60)).toBeLessThan(60);
+    input.collapsed = false;
+    harness.rerender();
+    frame.apply(harness.result.frameStyle);
+    expect(frame.heightForContent(60)).toBe(60);
+    // Native TextInput can grow before its onContentSizeChange arrives.
+    expect(frame.heightForContent(104)).toBe(104);
+    expect(frame.heightForContent(20)).toBe(20);
+    input.autoMaxContentHeight = 80;
+    harness.rerender();
+    frame.apply(harness.result.frameStyle);
+    expect(frame.heightForContent(104)).toBe(80);
+    expect(harness.result.scrollEnabled).toBe(true);
+  });
+
+  it.each(['cancel', 'reset'] as const)('replaces the auto cap while dragging and restores intrinsic height after %s', (finish) => {
+    const input = composerInput();
+    const harness = mountComposer(input);
+    const frame = nativeFrameReceiver();
+    const gesture = gestureOf(harness.result.gesture);
+    frame.apply(harness.result.frameStyle);
+    expect(frame.heightForContent(500)).toBe(120);
+    gesture.begin({ translationY: 0 });
+    gesture.update({ translationY: -100 });
+    frame.apply(harness.result.frameStyle);
+    expect(frame.heightForContent(500)).toBe(styleOf(harness.result.frameStyle).height);
+    expect(frame.heightForContent(500)).toBeGreaterThan(120);
+    gesture.finalize({ translationY: -100 }, finish === 'reset');
+    flushJS();
+    if (finish === 'reset') {
+      frame.apply(harness.result.frameStyle);
+      expect(frame.heightForContent(500)).toBeGreaterThan(120);
+      act(() => harness.result.reset());
+    }
+    frame.apply(harness.result.frameStyle);
+    expect(frame.heightForContent(20)).toBe(20);
+    expect(frame.heightForContent(500)).toBe(120);
+  });
+
   it('tracks 100 pointer moves with no JS deliveries or React renders, then commits once', () => {
     const input = composerInput();
     const harness = mountComposer(input);
@@ -110,8 +173,8 @@ describe('composer resize interaction boundary', () => {
     for (let index = 1; index <= 100; index++) gesture.update({ translationY: -index });
     expect(harness.result.contentHeight.value).toBe(160);
     expect(styleOf(harness.result.frameStyle).height).toBeGreaterThan(160);
-    expect(styleOf(harness.result.frameStyle).maxHeight).toBeUndefined();
-    expect(innerLimit).toBeGreaterThanOrEqual(styleOf(harness.result.frameStyle).height);
+    expect(styleOf(harness.result.frameStyle).maxHeight).toBe(harness.result.maxFrameHeight);
+    expect(styleOf(harness.result.frameStyle).height).toBeLessThanOrEqual(innerLimit);
     expect(harness.result.inputMaxHeight).toBe(innerLimit);
     expect(harness.renders).toBe(before);
     expect(runtime.js).toHaveLength(1); // only begin, never pointer moves
@@ -159,7 +222,7 @@ describe('composer resize interaction boundary', () => {
     gesture.update({ translationY: -100 });
     gesture.finalize({ translationY: -100 }, true);
     flushJS();
-    expect(styleOf(harness.result.frameStyle).maxHeight).toBeUndefined();
+    expect(styleOf(harness.result.frameStyle).maxHeight).toBe(harness.result.maxFrameHeight);
     act(() => harness.result.reset());
     expect(styleOf(harness.result.frameStyle).maxHeight).toBe(120);
     expect(harness.result.visibleContentHeight).toBe(120);

--- a/apps/mobile/src/session/useComposerResize.ts
+++ b/apps/mobile/src/session/useComposerResize.ts
@@ -150,12 +150,15 @@ export function useComposerResize(input: UseComposerResizeInput) {
     ? Math.max(geometry.value.bounds.minContentHeight, Math.min(dragHeight.value, geometry.value.bounds.maxContentHeight))
     : geometry.value.visibleHeight);
   const frameStyle = useAnimatedStyle(() => ({
-    // Auto growth stays capped, but the grabber removes that cap on UI before
-    // begin can reach JS. Explicit heights are already bounded by the model.
-    maxHeight: active.value || geometry.value.explicit ? undefined : geometry.value.autoMaxHeight,
+    // Native animated updates omit undefined props, retaining the previous
+    // height/cap. Explicitly restore intrinsic sizing with 'auto' and replace
+    // the auto cap with the drag ceiling before begin can reach JS.
+    maxHeight: active.value || geometry.value.explicit
+      ? Math.max(geometry.value.minFrameHeight, geometry.value.bounds.maxContentHeight + COMPOSER_TEXT_VERTICAL_PADDING * 2)
+      : geometry.value.autoMaxHeight,
     height: active.value || geometry.value.explicit
       ? Math.max(geometry.value.minFrameHeight, contentHeight.value + COMPOSER_TEXT_VERTICAL_PADDING * 2)
-      : undefined,
+      : 'auto' as const,
   }));
   const reset = useCallback(() => setUserContentHeight(null), []);
   const adjustByLine = useCallback((direction: 1 | -1) => {


### PR DESCRIPTION
## 这次改了什么

### 摘要

修复 #3948 引入的手机版输入框高度回归：多行草稿重新展开时，文字可能压到模型选择和发送按钮；从自动高度开始拖高时，外框仍被旧上限限制。

原来的 React 样式移除被改成动画更新中的 `undefined`。当前原生 JSI 转换会忽略该字段，而 Reanimated 属性记录采用增量合并，导致旧的 `height` / `maxHeight` 留存。本次用 `height: 'auto'` 明确恢复内容撑高，并在拖拽或手动模式显式替换为已计算的拖拽上限。

### 变更类型

- [x] `fix` 缺陷修复

### 范围

- 关联 Issue / 需求：#3948 的输入框布局回归及同根问题排查。
- 本 PR 包含：共享 `useComposerResize` 高度约束修复，原生增量属性更新语义的回归测试。
- 明确不包含：面板行为重设计、原生依赖升级、草稿或语音生命周期变更。
- 用户可见变化：已有任务和新建任务的输入框恢复正常自动撑高、拖高及取消/清空后的高度恢复。
- 是否存在 breaking change：无。

### UI 变化

- 引用的设计规范：`docs/design-rules/DESIGN.md` §8（自适应布局）、§10（双主题）、§14.4（功能性动效）。仅修复现有输入框的高度约束；保留两种主题的现有语义颜色、文字度量和 UI 线程拖拽路径。
- 无设备截图或录屏；未把布局引擎实验当作实机目检。

## 怎么验证的

### 自动验证

发布前另经统一 `run-unit-gate.sh` 执行完整 `pnpm test:unit`，结果 `GATE_EXIT=0`；Desktop、Mobile、共享 packages 及测试调度脚本均通过。

```text
pnpm test:unit:related
通过：Mobile 相关单测。

pnpm --filter mobile run --if-present typecheck
通过。

Mobile 定向 Vitest：composerInteractionBoundary、composerResize、composerRichInputHtml、
sessionComposerDesktopFirst、newSession、contextSheetExpoGo、composerKeyboard、composerDraftSource
通过：8 个文件、233 项测试。

git diff --check
通过。
```

新增三个用例模拟原生接收端忽略 undefined 并保留旧属性：在修复前分别得到错误的单行高度 26（期望 60），以及受旧上限钳制的 120（期望 166）；修复后全部通过。覆盖展开、内容增长/缩短、上限改变、拖拽、取消与清空重置，保留原生 TextInput 在测量回调前自然增高的能力。这是边界语义模拟，不是设备测试。

另外在临时目录编译当前 React Native 自带 Yoga，按同一容器结构验证：旧定高残留造成 30pt 重叠，旧上限残留造成 32pt 重叠；分别应用显式 auto 和新上限后，重叠均为 0；取消、空草稿与既有 44pt 语音最小高度检查通过。

### 手工验证

进行了 #3948 合并前后的代码对照及独立复核，范围包括输入高度、共享面板和草稿/语音状态迁移；未发现其他已证实的同类回归。未执行手机手工操作验证。

### 未执行的验证

未运行 iOS/Android 设备上的键盘、拖拽、IME 及 Light/Dark 目检。本次验证在分支 `dash/fix-mobile-composer-overlap`、worktree `cindy-fix-mobile-composer-overlap` 完成；未启动 Metro，无设备侧 `__DEV__` build label 证据。

## 风险

### 风险分类

- [x] 跨平台差异
- [x] 其他：原生布局仍需设备目检。

### 影响与回滚

- 影响范围：已有任务和新建任务共用的输入框高度约束。保留现有自动高度与手动高度模型。
- 回滚 / 降级方式：回退本 PR 即恢复原实现；无数据迁移。
- 未改原生配置、依赖或 fingerprint 输入；存量插件影响：无。

### 提交前检查

- [x] 已 review 完整 diff
- [x] 每个 commit 都带 DCO 签名（`git commit -s`）
- [x] UI 改动已在「UI 变化」注明引用的设计规范章节
- [x] 未提交凭证、令牌或授权文件
- [x] 已补充必要文档（代码中的原生属性更新约束注释）
- [x] 已确认测试结果或说明未执行原因
