### PR TITLE
fix(desktop): restore cold-session source provider before model window evaluation

### DIFF
--- a/apps/desktop/src/main/__tests__/sessionRuntimeControlWiring.test.ts
+++ b/apps/desktop/src/main/__tests__/sessionRuntimeControlWiring.test.ts
@@ -503,6 +503,37 @@ describe('session runtime control wiring', () => {
     expect(setModel).toContain('wakeSessionInputAfterCredentialSwitch(sessionId);');
   });
 
+  it('restores the cold-session source provider before window evaluation even when the switch names a target provider (#3996)', () => {
+    const setModel = handlerBody(
+      registerSource,
+      'const handleSetModel = async (',
+      'const recoverRemoteRuntimeAxisPersistence',
+    );
+    // 目标 provider(用户要切去的来源)与源会话 provider(窗口评估所需身份)是两个
+    // 独立事实。冷会话内存未 hydrate 时,即使请求显式携带目标 provider,也必须先从
+    // DB 恢复源 provider,否则 currentProviderId 为 null,源模型窗口按全局 modelId
+    // 反查,同名模型跨 provider 时不确定 → fail-closed 误报
+    // MODEL_WINDOW_CURRENT_CONTEXT_UNKNOWN(#3996)。
+    expect(setModel).not.toContain(
+      'if (requestedProviderId === undefined && !hasSessionProvider(sessionId)) {',
+    );
+    const requested = setModel.indexOf('const requestedProviderId = normalizeSessionProviderId(');
+    const restore = setModel.indexOf('if (!hasSessionProvider(sessionId)) {');
+    const hydrate = setModel.indexOf('hydrateSessionProvider(sessionId, persistedProviderId);');
+    const current = setModel.indexOf('const currentProviderId = resolveCurrentSetModelProviderId(');
+    const catalogCurrent = setModel.indexOf('const catalogCurrentWindow =');
+    expect(requested).toBeGreaterThan(-1);
+    expect(restore).toBeGreaterThan(requested);
+    expect(hydrate).toBeGreaterThan(restore);
+    expect(current).toBeGreaterThan(hydrate);
+    // 恢复出的源 provider 必须先于源窗口解析被消费;目标窗口仍由目标 provider 解析。
+    expect(catalogCurrent).toBeGreaterThan(current);
+    expect(setModel).toContain(
+      'lookupVerifiedContextWindow(\n          resolveRouteWindow,\n          model,\n          targetRouteProviderId,',
+    );
+    expect(setModel).toContain('const targetProviderId =');
+  });
+
   it('projects rebuilt zero usage and the verified window after the runtime is closed', () => {
     const commitRebuild = handlerBody(
       registerSource,

--- a/apps/desktop/src/main/__tests__/sessionRuntimeControlWiring.test.ts
+++ b/apps/desktop/src/main/__tests__/sessionRuntimeControlWiring.test.ts
@@ -532,6 +532,13 @@ describe('session runtime control wiring', () => {
       'lookupVerifiedContextWindow(\n          resolveRouteWindow,\n          model,\n          targetRouteProviderId,',
     );
     expect(setModel).toContain('const targetProviderId =');
+    // 停用轴准入只依赖目标路由,源 provider 的 DB 查询失败不能跳过准入
+    // (只能放弃独占 pin 重裁决,#3996 review)。
+    expect(setModel).not.toContain('? await assertModelRouteUsable(');
+    const admission = setModel.indexOf('await assertModelRouteUsable(');
+    const rerouteApply = setModel.indexOf('resolveExclusiveSetModelReroute(');
+    expect(admission).toBeGreaterThan(-1);
+    expect(rerouteApply).toBeGreaterThan(admission);
   });
 
   it('projects rebuilt zero usage and the verified window after the runtime is closed', () => {

--- a/apps/desktop/src/main/maker-ipc/register.ts
+++ b/apps/desktop/src/main/maker-ipc/register.ts
@@ -13870,7 +13870,14 @@ export function registerMakerIpc(maker: Maker, options: RegisterMakerIpcOptions)
       );
       let persistedProviderId: string | null = null;
       let persistedProviderKnown = true;
-      if (requestedProviderId === undefined && !hasSessionProvider(sessionId)) {
+      // 「目标 provider」(requestedProviderId,用户要切去的来源)与「源会话 provider」
+      // (会话当前路由,窗口评估要用)是两个独立事实。冷会话内存未 hydrate 时,即使
+      // 本次请求显式携带了目标 provider,也必须先从 DB 恢复源 provider —— 否则
+      // currentProviderId 为 null,源模型窗口按全局 modelId 反查,同名模型跨
+      // provider 时解析不确定(fail-closed),冷会话带历史切换渠道会误报
+      // MODEL_WINDOW_CURRENT_CONTEXT_UNKNOWN(#3996)。目标 provider 只参与目标
+      // 模型解析与最终提交,不覆盖源窗口解析所需身份。
+      if (!hasSessionProvider(sessionId)) {
         try {
           const db = getDbClient().drizzle;
           const [row] = await db

--- a/apps/desktop/src/main/maker-ipc/register.ts
+++ b/apps/desktop/src/main/maker-ipc/register.ts
@@ -13908,9 +13908,13 @@ export function registerMakerIpc(maker: Maker, options: RegisterMakerIpcOptions)
       if (routeExplicit) {
         const dbAgentKind = getSessionDbAgentKind(sessionId);
         if (dbAgentKind) {
-          const reroute = persistedProviderKnown
-            ? await assertModelRouteUsable(dbToMakerAgentKind(dbAgentKind), model, guardProviderId)
-            : undefined;
+          // 停用轴准入只依赖目标路由(guard = 显式目标 ?? 恢复出的源),与源 provider
+          // 的 DB 查询成败无关 —— 查询失败只能放弃独占 pin 重裁决,不能跳过准入。
+          const reroute = await assertModelRouteUsable(
+            dbToMakerAgentKind(dbAgentKind),
+            model,
+            guardProviderId,
+          );
           effectiveProviderId = resolveExclusiveSetModelReroute(
             requestedProviderId,
             currentProviderId,


### PR DESCRIPTION
## 这次改了什么

### 摘要

修复 #3996:冷会话(内存未 hydrate 路由)在显式指定目标供应商切换模型时,`maker:set-model` 不会从 DB 恢复源会话 provider(原条件 `requestedProviderId === undefined && !hasSessionProvider(...)` 在请求携带目标 provider 时不成立)。`currentProviderId` 因此为 null,源模型窗口按全局 modelId 反查;当同名模型配置在多个自定义供应商下时解析不确定,verified 窗口未知,触发 fail-closed 拦截 `MODEL_WINDOW_CURRENT_CONTEXT_UNKNOWN`,前端报「当前状态下无法执行此操作」。

本 PR 将源 provider 恢复与目标 provider 解耦:只要内存路由未 hydrate,就先从 session route / DB 恢复源 provider(无论请求是否携带目标 provider)。目标 provider 只参与目标模型解析与最终路由提交。

### 变更类型

- [x] `fix` 缺陷修复

### 范围

- 关联 Issue / 需求:#3996
- 本 PR 包含:`register.ts` 中 `handleSetModel` 的源 provider 恢复条件修正(+注释说明「源/目标 provider」两个事实的区分);`sessionRuntimeControlWiring.test.ts` 新增对应源码契约测试。
- 明确不包含:窗口解析算法本身(仍按 `(agentKind, providerId, modelId)`,见 #3488 既有实现)、同名模型冲突的产品策略(按 issue 维护者意见,不强制视为冲突、不放宽 fail-closed)。
- 用户可见变化:冷会话带历史上下文、两个自定义供应商存在同名模型时,切换供应商/模型不再被 `MODEL_WINDOW_CURRENT_CONTEXT_UNKNOWN` 误拦;窗口确实不足时仍走既有的 handoff/rebuild 保护。
- 是否存在 breaking change:无

### UI 变化

不涉及(仅 main 进程 IPC 处理器的路由身份恢复顺序,无 UI 代码路径改动)。

## 怎么验证的

### 自动验证

```text
pnpm --filter desktop exec vitest run src/main/__tests__/sessionRuntimeControlWiring.test.ts
结果:47 passed(含新增契约测试 "restores the cold-session source provider before window evaluation even when the switch names a target provider (#3996)")

pnpm --filter desktop exec vitest run src/main/maker-host/__tests__/model-route-guard.test.ts src/shared/__tests__/sessionContextWindow.test.ts
结果:38 passed
```

新增测试断言:源 provider 恢复(`if (!hasSessionProvider(sessionId))` → DB 查询 → `hydrateSessionProvider`)位于 `currentProviderId` 解析与源/目标窗口解析(`catalogCurrentWindow` / target `lookupVerifiedContextWindow`)之前,且不再以「请求未携带目标 provider」为前提。

### 手工验证

不涉及(需要多自定义供应商同名模型 + 冷会话环境的实机复现;按 issue 维护者建议在发布回归矩阵中覆盖)。

### 未执行的验证

未执行实机打包版验证——本 PR 只恢复已可确定的源路由身份,fail-closed 路径(无持久 provider、DB 查询失败)保持原行为。

## 风险

### 风险分类

- [x] 无已知风险

### 影响与回滚

- 影响范围:仅 `maker:set-model` 冷会话场景的源 provider 恢复时机。已 hydrate 会话(运行中切换)与请求未携带 provider 的场景行为逐字节不变;`resolveSetModelGuardProviderId` / `resolveExclusiveSetModelReroute` / `assertModelRouteUsable` 的裁决输入不变(显式目标 provider 时 guard 仍用目标)。DB 查询失败时 `persistedProviderKnown=false` 的降级路径与原语义一致。
- 回滚 / 降级方式:revert 单 commit 即可,无 schema/协议/持久化变更。

### 提交前检查

- [x] 已 review 完整 diff
- [x] 每个 commit 都带 DCO 签名(`git commit -s`,见 [DCO](../DCO))
- [ ] UI 改动已在「UI 变化」注明引用的设计规范章节(不涉及 UI 则跳过)
- [x] 未提交凭证、令牌或授权文件
- [x] 已补充必要文档(代码注释说明源/目标 provider 区分)
- [x] 已确认测试结果或说明未执行原因

---

Closes #3996
