### PR TITLE
fix(desktop): 周限卡片改为显示剩余额度

### DIFF
--- a/apps/desktop/src/renderer/__tests__/todaySpendChip.test.ts
+++ b/apps/desktop/src/renderer/__tests__/todaySpendChip.test.ts
@@ -361,8 +361,14 @@ describe('shared usage-card provider projections', () => {
     );
     expect(card.windows.map((window) => window.window.utilization)).toEqual([9]);
     expect(card.windows[0].breakdown).toEqual([
-      { label: 'quotaCard.includedLabel:{"name":"Grok Build"}', value: '2%' },
-      { label: 'quotaCard.includedLabel:{"name":"Other Product"}', value: '7%' },
+      {
+        label: 'quotaCard.includedLabel:{"name":"Grok Build"}',
+        value: 'quotaCard.usedPercent:{"percent":2}',
+      },
+      {
+        label: 'quotaCard.includedLabel:{"name":"Other Product"}',
+        value: 'quotaCard.usedPercent:{"percent":7}',
+      },
     ]);
     expect(card.windows[0].detail).toBe('todaySpend.xai.accountWeeklyHint');
     expect(card.details).toEqual(

--- a/apps/desktop/src/renderer/components/status/QuotaBar.tsx
+++ b/apps/desktop/src/renderer/components/status/QuotaBar.tsx
@@ -10,6 +10,9 @@ export type QuotaSeverity = 'normal' | 'warn' | 'crit';
 
 export interface QuotaBarProps {
   usedPercent: number;
+  /** Invert only the displayed value; warnings still follow usage. */
+  showRemaining?: boolean;
+  'aria-valuetext'?: string;
   size?: 'regular' | 'mini';
   /** 调用方已合并本地阈值与上游信号后的展示级别。 */
   severity?: QuotaSeverity;
@@ -40,6 +43,8 @@ const FILL_COLOR_CLASSES: Record<QuotaSeverity, string> = {
 
 export function QuotaBar({
   usedPercent,
+  showRemaining = false,
+  'aria-valuetext': ariaValueText,
   size = 'regular',
   severity: severityOverride,
   ariaLabel,
@@ -47,6 +52,7 @@ export function QuotaBar({
   className,
 }: QuotaBarProps) {
   const clampedPercent = clampPercent(usedPercent);
+  const displayedPercent = showRemaining ? 100 - clampedPercent : clampedPercent;
   const severity = severityOverride ?? quotaSeverity(clampedPercent);
   const isMini = size === 'mini';
 
@@ -55,7 +61,8 @@ export function QuotaBar({
       role="progressbar"
       aria-valuemin={0}
       aria-valuemax={100}
-      aria-valuenow={Math.round(clampedPercent)}
+      aria-valuenow={Math.round(displayedPercent)}
+      aria-valuetext={ariaValueText}
       aria-label={ariaLabel}
       aria-labelledby={ariaLabelledBy}
       data-severity={severity}
@@ -68,10 +75,10 @@ export function QuotaBar({
       <div
         className={cn(
           'h-full rounded-full transition-[width] duration-[var(--motion-base)] ease-[var(--motion-ease-move)] motion-reduce:transition-none',
-          clampedPercent > 0 && (isMini ? 'min-w-[4px]' : 'min-w-[7px]'),
+          displayedPercent > 0 && (isMini ? 'min-w-[4px]' : 'min-w-[7px]'),
           FILL_COLOR_CLASSES[severity],
         )}
-        style={{ width: `${clampedPercent}%` }}
+        style={{ width: `${displayedPercent}%` }}
       />
     </div>
   );

--- a/apps/desktop/src/renderer/components/status/QuotaHoverCard.tsx
+++ b/apps/desktop/src/renderer/components/status/QuotaHoverCard.tsx
@@ -106,6 +106,7 @@ function formatPaceLine(pace: QuotaPace, t: TFunction): string {
 function WindowBlock({
   title,
   window,
+  showRemaining = false,
   paceWindowMinutes,
   detail,
   breakdown,
@@ -116,6 +117,7 @@ function WindowBlock({
 }: {
   title: string;
   window: UsageCardWindow['window'];
+  showRemaining?: boolean;
   paceWindowMinutes?: number;
   detail?: string;
   breakdown?: UsageCardWindow['breakdown'];
@@ -126,6 +128,9 @@ function WindowBlock({
 }) {
   const titleId = React.useId();
   const usedPercent = clampPercent(window.utilization);
+  const percentText = t(showRemaining ? 'quotaCard.remainingPercent' : 'quotaCard.usedPercent', {
+    percent: Math.round(showRemaining ? 100 - usedPercent : usedPercent),
+  });
   const severity = effectiveQuotaSeverity(window);
   const severityAnnouncement =
     severity === 'crit'
@@ -166,11 +171,15 @@ function WindowBlock({
           <span className="sr-only">，{severityAnnouncement}</span>
         ) : null}
       </div>
-      <QuotaBar usedPercent={window.utilization} severity={severity} aria-labelledby={titleId} />
+      <QuotaBar
+        usedPercent={window.utilization}
+        showRemaining={showRemaining}
+        severity={severity}
+        aria-labelledby={titleId}
+        aria-valuetext={percentText}
+      />
       <div className="mt-[7px] flex items-baseline justify-between gap-3 tabular-nums">
-        <span className="font-medium text-[var(--text-primary)]">
-          {t('quotaCard.usedPercent', { percent: Math.round(usedPercent) })}
-        </span>
+        <span className="font-medium text-[var(--text-primary)]">{percentText}</span>
         {resetAt !== null ? (
           <span className="text-12 text-[var(--text-secondary)]">
             {t('quotaCard.resetAt', { at: resetAt })}

--- a/apps/desktop/src/renderer/components/status/__tests__/QuotaHoverCard.test.tsx
+++ b/apps/desktop/src/renderer/components/status/__tests__/QuotaHoverCard.test.tsx
@@ -14,6 +14,7 @@ vi.mock('react-i18next', () => ({
       if (key === 'quotaCard.modelWeeklyLabel') return `${options.model} 周限`;
       if (key === 'quotaCard.windowsRegionLabel') return '配额窗口列表';
       if (key === 'quotaCard.usedPercent') return `已用 ${options.percent}%`;
+      if (key === 'quotaCard.remainingPercent') return `剩余 ${options.percent}%`;
       if (key === 'quotaCard.usageCritical') return '用量较高';
       if (key === 'quotaCard.usageWarning') return '用量偏高';
       if (key === 'quotaCard.limitRejected') return '已触发套餐限额，请求可能被拒绝';
@@ -139,9 +140,9 @@ describe('QuotaHoverCard', () => {
     expect(screen.getByText('Fable 周限')).toBeTruthy();
     expect(screen.getByText('Opus 周限')).toBeTruthy();
     expect(screen.getByText('已用 1%')).toBeTruthy();
-    expect(screen.getByText('已用 4%')).toBeTruthy();
-    expect(screen.getByText('已用 0%')).toBeTruthy();
-    expect(screen.getByText('已用 76%')).toBeTruthy();
+    expect(screen.getByText('剩余 96%')).toBeTruthy();
+    expect(screen.getByText('剩余 100%')).toBeTruthy();
+    expect(screen.getByText('剩余 24%')).toBeTruthy();
     expect(screen.getByText('17:05 重置')).toBeTruthy();
     expect(screen.getByText('8月7日 00:00 重置')).toBeTruthy();
     expect(screen.getByText('8月6日 23:59 重置')).toBeTruthy();
@@ -229,7 +230,7 @@ describe('QuotaHoverCard', () => {
       />,
     );
 
-    expect(screen.getByText('已用 30%')).toBeTruthy();
+    expect(screen.getByText('剩余 70%')).toBeTruthy();
     expect(screen.queryByText(/重置$/)).toBeNull();
   });
 
@@ -243,6 +244,27 @@ describe('QuotaHoverCard', () => {
     expect((bar.firstElementChild as HTMLElement | null)?.style.width).toBe('100%');
     expect(screen.getByText('已用 100%')).toBeTruthy();
   });
+
+  it.each([
+    { utilization: 94, remaining: 6, severity: 'crit' },
+    { utilization: 100, remaining: 0, severity: 'crit' },
+    { utilization: 250, remaining: 0, severity: 'crit' },
+    { utilization: 0, remaining: 100, severity: 'normal' },
+    { utilization: -5, remaining: 100, severity: 'normal' },
+  ])(
+    'shows $remaining% remaining for weekly usage $utilization without reversing warnings',
+    ({ utilization, remaining, severity }) => {
+      render(
+        <QuotaHoverCard nowMs={NOW_MS} snapshot={makeSnapshot({ sevenDay: { utilization } })} />,
+      );
+      const bar = screen.getByRole('progressbar');
+      expect(screen.getByText(`剩余 ${remaining}%`)).toBeTruthy();
+      expect(bar.getAttribute('aria-valuenow')).toBe(String(remaining));
+      expect(bar.getAttribute('aria-valuetext')).toBe(`剩余 ${remaining}%`);
+      expect((bar.firstElementChild as HTMLElement).style.width).toBe(`${remaining}%`);
+      expect(bar.getAttribute('data-severity')).toBe(severity);
+    },
+  );
 
   it('omits a null subscription badge and maps max to Max', () => {
     const { rerender } = render(

--- a/apps/desktop/src/renderer/components/status/__tests__/TodaySpendChip.popover.test.tsx
+++ b/apps/desktop/src/renderer/components/status/__tests__/TodaySpendChip.popover.test.tsx
@@ -60,6 +60,7 @@ vi.mock('react-i18next', () => ({
         'quotaCard.includedLabel': '其中 {{name}}',
         'quotaCard.modelWeeklyLabel': '{{model}} 周限',
         'quotaCard.usedPercent': '已用 {{percent}}%',
+        'quotaCard.remainingPercent': '剩余 {{percent}}%',
         'quotaCard.resetAt': '{{at}} 重置',
         'quotaCard.turnCostUnavailable': '本轮费用暂无法估算',
         'quotaCard.tokenLabel': 'Token',
@@ -808,7 +809,8 @@ describe('TodaySpendChip Claude subscription popover', () => {
       within(card)
         .getAllByRole('progressbar')
         .map((bar) => bar.getAttribute('aria-valuenow')),
-    ).toEqual(['22', '48']);
+    ).toEqual(['22', '52']);
+    expect(within(card).getByText('剩余 52%')).toBeTruthy();
   });
 
   it('Grok 产品用量属于周限明细，不重复进度条或重置时间，过期后移除旧百分比', () => {
@@ -826,7 +828,9 @@ describe('TodaySpendChip Claude subscription popover', () => {
     expect(screen.getAllByRole('progressbar')).toHaveLength(1);
     const breakdown = screen.getByTestId('quota-window-breakdown');
     expect(within(breakdown).getByText('其中 Grok Build')).toBeTruthy();
-    expect(within(breakdown).getByText('8%')).toBeTruthy();
+    expect(within(breakdown).getByText('已用 8%')).toBeTruthy();
+    expect(screen.getByRole('progressbar').getAttribute('aria-valuenow')).toBe('92');
+    expect(screen.getByText('剩余 92%')).toBeTruthy();
     expect(screen.getAllByText(/重置$/)).toHaveLength(1);
     mocks.xaiSnapshot = { ...mocks.xaiSnapshot, updatedAt: Date.now() - 31 * 60_000 };
     view.rerender(

--- a/apps/desktop/src/renderer/components/status/usageCardModel.ts
+++ b/apps/desktop/src/renderer/components/status/usageCardModel.ts
@@ -18,6 +18,8 @@ import {
 export interface UsageCardWindow {
   key: string;
   title: string;
+  /** Weekly quotas show the available percentage; other windows retain used percentage. */
+  showRemaining?: boolean;
   window: {
     utilization: number;
     /** Epoch seconds, matching provider reset timestamps. */
@@ -77,7 +79,7 @@ export function buildClaudeUsageCard(
     paceWindowMinutes?: number,
   ) => {
     if (window && Number.isFinite(window.utilization))
-      windows.push({ key, title, window, paceWindowMinutes });
+      windows.push({ key, title, window, paceWindowMinutes, showRemaining: key !== 'five-hour' });
   };
   add('five-hour', t('quotaCard.fiveHourLabel'), snapshot.fiveHour);
   add('seven-day', t('quotaCard.weeklyLabel'), snapshot.sevenDay, 10_080);
@@ -132,6 +134,7 @@ export function buildCodexUsageCard(
     windows.push({
       key,
       title: quotaWindowLabel(window.windowMinutes, t),
+      showRemaining: window.windowMinutes === 10_080,
       window: { utilization: window.usedPercent, resetsAt: window.resetsAt },
       paceWindowMinutes: window.windowMinutes === 10_080 ? 10_080 : undefined,
     });
@@ -199,6 +202,7 @@ export function buildXaiUsageCard(
     windows.push({
       key: 'weekly',
       title: t('quotaCard.weeklyLabel'),
+      showRemaining: true,
       window: { utilization: weekly.creditUsagePercent, resetsAt: weekly.resetsAt },
       paceWindowMinutes: 10_080,
       detail: t('todaySpend.xai.accountWeeklyHint'),
@@ -206,7 +210,9 @@ export function buildXaiUsageCard(
         .filter((product) => Number.isFinite(product.usagePercent))
         .map((product) => ({
           label: t('quotaCard.includedLabel', { name: formatXaiProductLabel(product.product) }),
-          value: `${Math.round(Math.min(100, Math.max(0, product.usagePercent)))}%`,
+          value: t('quotaCard.usedPercent', {
+            percent: Math.round(Math.min(100, Math.max(0, product.usagePercent))),
+          }),
         })),
     });
     if (

--- a/apps/desktop/src/renderer/i18n/locales/en/common.json
+++ b/apps/desktop/src/renderer/i18n/locales/en/common.json
@@ -5873,6 +5873,7 @@
     "weeklyLabel": "Weekly",
     "modelWeeklyLabel": "{{model}} weekly",
     "usedPercent": "Used {{percent}}%",
+    "remainingPercent": "Remaining {{percent}}%",
     "resetAt": "Resets {{at}}",
     "noWindows": "No quota window data available",
     "limitRejected": "Plan limit reached; requests may be rejected",

--- a/apps/desktop/src/renderer/i18n/locales/ja/common.json
+++ b/apps/desktop/src/renderer/i18n/locales/ja/common.json
@@ -5871,6 +5871,7 @@
     "weeklyLabel": "週間",
     "modelWeeklyLabel": "{{model}} 週間",
     "usedPercent": "使用済み {{percent}}%",
+    "remainingPercent": "残り {{percent}}%",
     "resetAt": "{{at}} にリセット",
     "noWindows": "クォータ期間のデータはありません",
     "limitRejected": "プランの上限に到達しました。リクエストが拒否される可能性があります",

--- a/apps/desktop/src/renderer/i18n/locales/ko/common.json
+++ b/apps/desktop/src/renderer/i18n/locales/ko/common.json
@@ -5871,6 +5871,7 @@
     "weeklyLabel": "주간",
     "modelWeeklyLabel": "{{model}} 주간",
     "usedPercent": "사용 {{percent}}%",
+    "remainingPercent": "남은 {{percent}}%",
     "resetAt": "{{at}} 재설정",
     "noWindows": "할당량 구간 데이터가 없습니다",
     "limitRejected": "플랜 한도에 도달하여 요청이 거부될 수 있습니다",

--- a/apps/desktop/src/renderer/i18n/locales/zh-CN/common.json
+++ b/apps/desktop/src/renderer/i18n/locales/zh-CN/common.json
@@ -5871,6 +5871,7 @@
     "weeklyLabel": "周限",
     "modelWeeklyLabel": "{{model}} 周限",
     "usedPercent": "已用 {{percent}}%",
+    "remainingPercent": "剩余 {{percent}}%",
     "resetAt": "{{at}} 重置",
     "noWindows": "暂无配额窗口数据",
     "limitRejected": "已触发套餐限额，请求可能被拒绝",

--- a/apps/desktop/src/renderer/i18n/locales/zh-TW/common.json
+++ b/apps/desktop/src/renderer/i18n/locales/zh-TW/common.json
@@ -5871,6 +5871,7 @@
     "weeklyLabel": "週限",
     "modelWeeklyLabel": "{{model}} 週限",
     "usedPercent": "已用 {{percent}}%",
+    "remainingPercent": "剩餘 {{percent}}%",
     "resetAt": "{{at}} 重置",
     "noWindows": "暫無配額視窗資料",
     "limitRejected": "已觸發套餐限額，請求可能被拒絕",


### PR DESCRIPTION
## 这次改了什么

### 摘要

周限已用 94% 时，卡片现在显示「剩余 6%」，条形长度和无障碍读数也表示剩余量；低剩余额度仍保留原有告警色。Claude、ChatGPT、Grok 继续复用同一张卡片。

### 变更类型

- [ ] `feat` 新功能
- [x] `fix` 缺陷修复
- [ ] `refactor` / `perf` 重构或性能优化
- [ ] `docs` / `test` / `chore` 文档、测试或工程维护
- [ ] 其他：

### 范围

- 关联 Issue / 需求：#3972 合并后的周限展示调整。
- 本 PR 包含：三家供应商的账号周限、Claude 模型周限、共享进度条的剩余展示、五种语言文案及回归测试。
- 明确不包含：5 小时及其他非周限窗口、网关预算、配额采集、限流和节奏算法的变更。
- 用户可见变化：周限显示剩余百分比；Grok 产品构成明细明确标注「已用」，避免被误认为独立剩余额度。独立窗口仍分别保留。
- 是否存在 breaking change：无。

### UI 变化

- 引用的设计规范：`docs/design-rules/DESIGN.md` §4、§5：沿用共享卡片的 340px 宽、16px 内边距及 12px 圆角；§10：沿用语义 token，同时支持 Light / Dark；§11：剩余文案同步五种语言。进度条的数值、宽度、可见文案及 `aria-valuetext` 保持同一含义，告警级别仍取原始使用率与供应商状态。
- Desktop HTML 效果预览已在本地提供，并获用户确认。以下为改动部位的可独立打开 HTML 示意，非客户端实机截图；未上传用户截图或账号明细。

<details>
<summary>周限剩余 6%：浅色 / 深色 HTML 示意</summary>

```html
<!doctype html>
<html lang="zh-CN"><meta charset="utf-8"><meta name="viewport" content="width=device-width,initial-scale=1">
<title>周限剩余额度</title>
<style>
body{margin:24px;display:flex;flex-wrap:wrap;gap:24px;font:13px/20px system-ui;background:#888}
.card{--card:#fff;--text:#262626;--muted:#737373;--line:#d7d7d4;--track:#e5e5e5;width:340px;box-sizing:border-box;padding:16px;border:1px solid var(--line);border-radius:12px;background:var(--card);color:var(--text)}
.dark{--card:#1f1f1f;--text:#d4d4d4;--line:#333;--track:#252525}
header,.summary{display:flex;align-items:baseline;justify-content:space-between;gap:12px}
header{font-size:12px;color:var(--muted);padding-bottom:12px;border-bottom:1px solid var(--line)}
.badge{border:1px solid var(--line);border-radius:9999px;padding:1px 7px}
h2{font-size:14px;font-weight:500;color:#ef4444;margin:14px 0 8px}
.bar{height:7px;background:var(--track);border-radius:9999px;overflow:hidden}
.fill{width:6%;height:100%;background:#ef4444;border-radius:9999px}
.summary{margin-top:7px}.muted{font-size:12px;color:var(--muted)}p{margin:3px 0 0}
</style>
<article class="card"><header>ChatGPT<span class="badge">Pro</span></header><h2>周限</h2><div class="bar" role="progressbar" aria-label="周限" aria-valuemin="0" aria-valuemax="100" aria-valuenow="6" aria-valuetext="剩余 6%"><div class="fill"></div></div><div class="summary"><span>剩余 6%</span><span class="muted">9月12日 23:50 重置</span></div><p class="muted">按当前平均速度偏快（粗略趋势）</p></article>
<article class="card dark"><header>ChatGPT<span class="badge">Pro</span></header><h2>周限</h2><div class="bar" role="progressbar" aria-label="周限" aria-valuemin="0" aria-valuemax="100" aria-valuenow="6" aria-valuetext="剩余 6%"><div class="fill"></div></div><div class="summary"><span>剩余 6%</span><span class="muted">9月12日 23:50 重置</span></div><p class="muted">按当前平均速度偏快（粗略趋势）</p></article>
</html>
```

</details>

## 怎么验证的

### 自动验证

使用 Corepack 调用仓库指定的 pnpm 10.33.2：

- `pnpm test:unit:related`：提交前相关单测通过。
- `pnpm --filter desktop typecheck`：通过。
- 定向 Vitest（QuotaBar、QuotaHoverCard、TodaySpendChip.popover、todaySpendChip）：4 个文件、132 项测试通过，覆盖三家供应商、超额与零剩余边界、告警方向、非周限窗口及 Grok 次级明细。
- 改动文件 ESLint、Prettier、`git diff --check`：通过。
- `pnpm check:i18n`、`pnpm check:i18n-glossary`：通过，无新增术语违规；存在原有翻译及待裁决术语告警。
- 独立 HTML 的四档剩余量与双主题切换：jsdom 检查通过。

### 手工验证

用户查看本地 HTML 效果预览后确认提交。预览使用示例数据，不连接真实账号。

### 未执行的验证

本次未做 macOS / Windows 客户端实机目检（Light / Dark 均未实机验证）。HTML 示意不作为客户端运行验证。未操作其他 worktree 的开发版。

## 风险

### 风险分类

- [x] 无已知风险
- [ ] SQLite / migration
- [ ] system prompt
- [ ] 协议兼容
- [ ] 权限 / 安全 / 用户数据
- [ ] 存量插件兼容（批准状态 / 指纹 / manifest 校验 / 安装布局 / 包格式）
- [ ] 原生层 / fingerprint / OTA
- [ ] 跨平台差异
- [ ] 其他：

### 影响与回滚

- 影响范围：Desktop 用量卡片的周限展示。共享 QuotaBar 新增可选展示参数，默认保持已有消费者行为；原始使用率、告警与限流语义不变。存量插件影响：无。
- 回滚 / 降级方式：回退本 PR，无数据迁移或持久化变化。

### 提交前检查

- [x] 已 review 完整 diff
- [x] 每个 commit 都带 DCO 签名（`git commit -s`，见 [DCO](../DCO)）
- [x] UI 改动已在「UI 变化」注明引用的设计规范章节（不涉及 UI 则跳过）
- [x] 未提交凭证、令牌或授权文件
- [x] 已补充必要文档
- [x] 已确认测试结果或说明未执行原因
