### PR TITLE
fix(mobile): 校验区域清单构建配置并隔离转换缓存

### DIFF
--- a/apps/mobile/metro.config.js
+++ b/apps/mobile/metro.config.js
@@ -1,11 +1,39 @@
 const path = require('path');
 const { getDefaultConfig } = require('expo/metro-config');
+const {
+  assertMobileManifestBuildEnv,
+  createMobileManifestBuildSnapshot,
+} = require('../../scripts/shared/mobile-manifest-build-guard.cjs');
 
 const config = getDefaultConfig(__dirname);
 const workspaceRoot = path.resolve(__dirname, '../..');
 const workspaceNodeModules = path.join(workspaceRoot, 'node_modules');
 const appNodeModules = path.join(__dirname, 'node_modules');
 const sharedArrayBufferPolyfill = path.join(__dirname, 'src/polyfills/sharedArrayBuffer.js');
+
+// 必须早于 Transformer 缓存键及 WorkerFarm 环境快照：仅在 transform 时校验 env
+// 不能阻止已缓存的 Babel 结果内联旧地址。保留 Expo 既有 cacheVersion 并追加区域身份。
+const manifestBuildSnapshot = createMobileManifestBuildSnapshot(process.env);
+config.cacheVersion = `${config.cacheVersion}:${manifestBuildSnapshot.cacheKey}`;
+
+const defaultGetTransformOptions = config.transformer.getTransformOptions;
+config.transformer.getTransformOptions = async (entryPoints, options, getDependencies) => {
+  // dev 来自实际 bundle 请求，不能用 runner 的 NODE_ENV 代替：export:embed
+  // 可能保留 NODE_ENV=development，仍在生成生产 bundle。开发 Metro / CindyDev
+  // 保留端点覆盖；正式 bundle 的最终 env 必须与仓内两区清单一致。
+  const authRegion = process.env.EXPO_PUBLIC_CINDY_AUTH_REGION?.trim();
+  if (options.dev === false && authRegion !== 'dev') {
+    if (authRegion !== 'cn' && authRegion !== 'global') {
+      throw new Error('Mobile 构建配置错误：EXPO_PUBLIC_CINDY_AUTH_REGION 必须指定为 cn 或 global');
+    }
+    const { mobileClientBundleEnv } = await import('../../scripts/shared/client-endpoint-build-env.mjs');
+    assertMobileManifestBuildEnv(process.env, mobileClientBundleEnv({
+      authRegion,
+    }));
+  }
+  if (options.dev === false) manifestBuildSnapshot.assertUnchanged(process.env);
+  return defaultGetTransformOptions(entryPoints, options, getDependencies);
+};
 
 // mobile 直接吃 TS 源码的 workspace 包(见下方 .js→.ts resolveRequest 分流)。
 const workspaceTsSourcePackages = [

--- a/apps/mobile/src/__tests__/mobileManifestBuildGuard.test.ts
+++ b/apps/mobile/src/__tests__/mobileManifestBuildGuard.test.ts
@@ -1,0 +1,165 @@
+import { createRequire } from 'node:module';
+import { dirname, join } from 'node:path';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { mobileClientBundleEnv } from '../../../../scripts/shared/client-endpoint-build-env.mjs';
+
+const require = createRequire(import.meta.url);
+const baseKey = 'EXPO_PUBLIC_ENDPOINT_MANIFEST_BASE_URL';
+const peerKey = 'EXPO_PUBLIC_ENDPOINT_MANIFEST_PEER_BASE_URL';
+const regionKey = 'EXPO_PUBLIC_CINDY_AUTH_REGION';
+const managedKeys = [baseKey, peerKey, regionKey, 'NODE_ENV',
+  'EXPO_PUBLIC_CINDY_DEV_RELEASE_ENDPOINT_MANIFEST_BASE_URL'];
+let previousEnv: Record<string, string | undefined>;
+let metro: ReturnType<typeof require>;
+
+function loadMetroConfig() {
+  const filename = require.resolve('../../metro.config.js');
+  delete require.cache[filename];
+  return require(filename);
+}
+
+beforeEach(() => {
+  previousEnv = Object.fromEntries(managedKeys.map((key) => [key, process.env[key]]));
+  Object.assign(process.env, mobileClientBundleEnv({ authRegion: 'global' }));
+  // 故意与实际生产 bundle 模式不同：export:embed 会保留 runner 的 NODE_ENV。
+  process.env.NODE_ENV = 'development';
+  metro = loadMetroConfig();
+});
+
+afterEach(() => {
+  for (const key of managedKeys) {
+    if (previousEnv[key] === undefined) delete process.env[key];
+    else process.env[key] = previousEnv[key];
+  }
+});
+
+function transform(dev = false, platform = 'android') {
+  return metro.transformer.getTransformOptions([], { dev, hot: false, platform }, async () => []);
+}
+
+describe('Metro production manifest build guard', () => {
+  it('preserves the default Metro cache version and app.config default CN bootstrap', async () => {
+    const { getDefaultConfig } = require('expo/metro-config');
+    const defaultVersion = getDefaultConfig(process.cwd()).cacheVersion;
+    expect(metro.cacheVersion.startsWith(`${defaultVersion}:`)).toBe(true);
+    expect(metro.cacheVersion).toMatch(/:cindy-mobile-manifest-v1:[a-f0-9]{64}$/);
+    for (const key of [regionKey, baseKey, peerKey]) delete process.env[key];
+    require('../../app.config.js')();
+    metro = loadMetroConfig();
+    expect(process.env[regionKey]).toBe('cn');
+    await expect(transform()).resolves.toBeDefined();
+  });
+
+  it.each(['cn', 'global'])('preserves Expo transform options for valid %s bundles on both platforms', async (authRegion) => {
+    Object.assign(process.env, mobileClientBundleEnv({ authRegion }));
+    metro = loadMetroConfig();
+    for (const platform of ['ios', 'android']) {
+      await expect(transform(false, platform)).resolves.toMatchObject({
+        transform: { experimentalImportSupport: true, inlineRequires: false },
+      });
+    }
+  });
+
+  it.each(['cn', 'global'])('rejects identical and swapped %s addresses at the actual bundle boundary', async (authRegion) => {
+    const expected = mobileClientBundleEnv({ authRegion });
+    Object.assign(process.env, expected);
+    metro = loadMetroConfig();
+    process.env[peerKey] = `${expected[baseKey]}/`;
+    await expect(transform()).rejects.toThrow('规范化后不能相同');
+
+    process.env[baseKey] = expected[peerKey];
+    process.env[peerKey] = expected[baseKey];
+    await expect(transform()).rejects.toThrow('仓内清单不一致');
+  });
+
+  it.each([baseKey, peerKey])('checks final %s rather than the initial config or expected values', async (key) => {
+    await expect(transform()).resolves.toBeDefined();
+    // 模拟 config 已求值后，外部发布入口又覆盖环境；每次 bundle 都要重新校验。
+    delete process.env[key];
+    await expect(transform()).rejects.toThrow(key);
+    process.env[key] = ' ';
+    await expect(transform()).rejects.toThrow(key);
+    process.env[key] = 'https://wrong.example.invalid/app';
+    await expect(transform()).rejects.toThrow('仓内清单不一致');
+    process.env[key] = 'https://fake-user:fake-secret@example.invalid/app';
+    await expect(transform()).rejects.toThrow(key);
+    await expect(transform()).rejects.not.toThrow('fake-secret');
+  });
+
+  it('rejects a missing final region instead of silently choosing another build', async () => {
+    delete process.env[regionKey];
+    await expect(transform()).rejects.toThrow(regionKey);
+    process.env[regionKey] = 'fake-secret-not-a-region';
+    await expect(transform()).rejects.toThrow(regionKey);
+    await expect(transform()).rejects.not.toThrow('fake-secret');
+  });
+
+  it('keeps development Metro overrides even if NODE_ENV says production', async () => {
+    process.env.NODE_ENV = 'production';
+    process.env[baseKey] = 'http://localhost:1234';
+    process.env[peerKey] = 'http://localhost:5678';
+    await expect(transform(true)).resolves.toBeDefined();
+    expect(process.env[baseKey]).toBe('http://localhost:1234');
+    expect(process.env[peerKey]).toBe('http://localhost:5678');
+  });
+
+  it('does not let a running production build bypass the snapshot guard by changing to CindyDev', async () => {
+    process.env[regionKey] = 'dev';
+    process.env[baseKey] = 'http://localhost:1234';
+    process.env[peerKey] = 'http://localhost:5678';
+    await expect(transform()).rejects.toThrow('重启 Metro');
+  });
+
+  it('rejects valid but changed production env after Metro and its worker snapshot have loaded', async () => {
+    Object.assign(process.env, mobileClientBundleEnv({ authRegion: 'cn' }));
+    await expect(transform()).rejects.toThrow('重启 Metro');
+    Object.assign(process.env, mobileClientBundleEnv({ authRegion: 'global' }));
+    process.env[peerKey] += '/';
+    await expect(transform()).rejects.toThrow('重启 Metro');
+  });
+
+  it('isolates real cached production transforms across regions while retaining same-env cache hits', async () => {
+    const Transformer = require(join(
+      dirname(require.resolve('metro/package.json')), 'src/DeltaBundler/Transformer.js',
+    )).default;
+    const entries = new Map<string, unknown>();
+    let cacheHits = 0;
+    const cacheStore = {
+      async get(key: Buffer) {
+        const value = entries.get(key.toString('hex'));
+        if (value) cacheHits += 1;
+        return value ?? null;
+      },
+      async set(key: Buffer, value: unknown) { entries.set(key.toString('hex'), value); },
+      async clear() { entries.clear(); },
+    };
+    // 直接给真实 Metro / Expo Babel 传 Buffer，既不写文件，也不使用开发者的磁盘缓存。
+    const source = Buffer.from(
+      'module.exports = process.env.EXPO_PUBLIC_ENDPOINT_MANIFEST_PEER_BASE_URL;',
+    );
+    process.env.NODE_ENV = 'production';
+    for (const [authRegion, suffix] of [
+      ['cn', ''], ['global', ''], ['global', ''], ['cn', ''], ['global', '/'],
+    ]) {
+      const expected = mobileClientBundleEnv({ authRegion });
+      expected[peerKey] += suffix;
+      Object.assign(process.env, expected);
+      metro = loadMetroConfig();
+      const { transform: options } = await transform();
+      const transformer = new Transformer({ ...metro, maxWorkers: 1, cacheStores: [cacheStore] }, {
+        getOrComputeSha1: async () => { throw new Error('Unexpected filesystem read'); },
+      });
+      try {
+        const result = await transformer.transformFile(join(metro.projectRoot, 'manifest-memory-probe.js'), {
+          ...options, customTransformOptions: { engine: 'hermes' },
+          dev: false, minify: false, platform: 'android', type: 'module', inlinePlatform: true,
+          unstable_transformProfile: 'hermes-stable',
+        }, source);
+        expect(result.output[0].data.code).toContain(JSON.stringify(expected[peerKey]));
+      } finally {
+        await transformer.end();
+      }
+    }
+    expect(cacheHits).toBe(2);
+  });
+});

--- a/docs/dev-rules/mobile-development.md
+++ b/docs/dev-rules/mobile-development.md
@@ -40,6 +40,23 @@ pnpm mobile:sim:start -- --region=cn
 不要用临时 Metro、端口探测或手工修改 `.env` 代替这些脚本。多 worktree、原生构建、
 登录态和日志排查见 `apps/mobile/docs/simulator-debugging.md`。
 
+### 打包时的区域清单校验
+
+CN / Global 的生产 bundle 使用 `config/endpoint*.json` 派生本区与对端清单地址。
+本地 Android / iOS 构建在生成子进程环境后校验；Expo export / export:embed
+（包括 EAS / OTA 的 bundle 生成）在 Metro 的生产转换入口再次校验最终环境。
+该入口按实际 bundle 请求的 `dev: false` 判定，不受 runner 残留 `NODE_ENV` 影响：
+两个地址必须是非空、无凭据的 HTTPS URL，规范化后不同，且与所选区域的仓内清单一致。
+发现错配会中止，不将 runner 的残留地址静默打进正式 bundle。
+
+Metro 转换缓存按构建区域和两个清单地址的原始值摘要隔离，切换区域或修正地址后不复用
+旧的内联结果；同配置仍可复用缓存。生产打包进程初始化后若这些值又变化，会要求重启
+Metro，避免主进程校验的是新值、缓存或工作进程却仍使用旧值。摘要不会回显地址原文。
+
+开发 Metro 与 CindyDev 保留已有的自定义端点行为。正式构建需要自建清单时，应修改
+仓内区域配置，不用 shell / `.env` 覆盖；校验错误只提示变量名，不回显环境变量值。
+这些检查不增加 Expo `extra` 字段，也不改变原生身份；它们不能替代最终产物与真机验收。
+
 ## 分层验证
 
 ```bash

--- a/scripts/__tests__/client-endpoint-build-env.test.mjs
+++ b/scripts/__tests__/client-endpoint-build-env.test.mjs
@@ -14,6 +14,10 @@ import {
   mobileClientBuildEnv,
 } from '../shared/client-endpoint-build-env.mjs';
 import { resolveReleaseCdnBaseUrl } from '../shared/release-env.mjs';
+import {
+  assertMobileManifestBuildEnv,
+  createMobileManifestBuildSnapshot,
+} from '../shared/mobile-manifest-build-guard.cjs';
 
 const tempDirs = [];
 const originalReleaseCdn = process.env.XDT_CDN_BASE_URL;
@@ -93,6 +97,105 @@ test('Mobile bundling 进程环境只在 CindyDev 保留 Release 清单基址', 
     dev.EXPO_PUBLIC_CINDY_DEV_RELEASE_ENDPOINT_MANIFEST_BASE_URL,
     'https://hotfix-cn.example.invalid/app',
   );
+});
+
+test('Mobile 生产清单校验接受两区正本及等价 URL，且不修改传入环境', () => {
+  const repoRoot = writeRepoFixtures();
+  for (const authRegion of ['cn', 'global']) {
+    const expected = mobileClientBundleEnv({ authRegion, repoRoot });
+    const env = Object.freeze({
+      ...expected,
+      EXPO_PUBLIC_ENDPOINT_MANIFEST_BASE_URL:
+        `  ${expected.EXPO_PUBLIC_ENDPOINT_MANIFEST_BASE_URL.replace('https://hotfix-', 'https://HOTFIX-')}///  `,
+    });
+    assert.doesNotThrow(() => assertMobileManifestBuildEnv(env, expected));
+  }
+});
+
+test('Mobile 生产清单校验拒绝缺失、重复、对调及不匹配的最终值', () => {
+  const repoRoot = writeRepoFixtures();
+  const baseKey = 'EXPO_PUBLIC_ENDPOINT_MANIFEST_BASE_URL';
+  const peerKey = 'EXPO_PUBLIC_ENDPOINT_MANIFEST_PEER_BASE_URL';
+  for (const authRegion of ['cn', 'global']) {
+    const expected = mobileClientBundleEnv({ authRegion, repoRoot });
+    for (const key of [baseKey, peerKey]) {
+      for (const value of [undefined, '', ' ', 'not-a-url', 'http://example.invalid/app',
+        'https://fake-user:fake-secret@example.invalid/app']) {
+        assert.throws(() => assertMobileManifestBuildEnv({ ...expected, [key]: value }, expected),
+          (error) => error.message.includes(key) && !error.message.includes('fake-secret'));
+      }
+      assert.throws(() => assertMobileManifestBuildEnv({
+        ...expected, [key]: 'https://wrong.example.invalid/app',
+      }, expected), /仓内清单不一致/);
+    }
+    assert.throws(() => assertMobileManifestBuildEnv({
+      ...expected,
+      [peerKey]: `${expected[baseKey].replace('/app', ':443/app')}/`,
+    }, expected), /规范化后不能相同/);
+    assert.throws(() => assertMobileManifestBuildEnv({
+      ...expected, [baseKey]: expected[peerKey], [peerKey]: expected[baseKey],
+    }, expected), /仓内清单不一致/);
+    assert.throws(() => assertMobileManifestBuildEnv({
+      ...expected, EXPO_PUBLIC_CINDY_AUTH_REGION: 'dev',
+    }, expected), /构建区域不一致/);
+  }
+});
+
+test('Mobile bundling 覆盖 runner 的两区残留值并拦截仓内重复 CDN', () => {
+  const repoRoot = writeRepoFixtures();
+  const baseEnv = Object.freeze({
+    EXPO_PUBLIC_CINDY_AUTH_REGION: 'cn',
+    EXPO_PUBLIC_ENDPOINT_MANIFEST_BASE_URL: 'https://stale.example.invalid/app',
+    EXPO_PUBLIC_ENDPOINT_MANIFEST_PEER_BASE_URL: 'https://stale.example.invalid/app',
+  });
+  const expected = mobileClientBundleEnv({ authRegion: 'global', repoRoot });
+  assert.deepEqual(mobileClientBundleProcessEnv({ authRegion: 'global', repoRoot, baseEnv }), expected);
+
+  fs.writeFileSync(path.join(repoRoot, 'config', 'endpoint.global.json'), JSON.stringify({
+    schemaVersion: 1, cdnBaseUrl: 'https://HOTFIX-CN.example.invalid:443/app///',
+  }));
+  for (const authRegion of ['cn', 'global']) {
+    assert.throws(() => mobileClientBundleProcessEnv({ authRegion, repoRoot, baseEnv }), /不能相同/);
+  }
+  assert.doesNotThrow(() => assertMobileManifestBuildEnv({
+    EXPO_PUBLIC_CINDY_AUTH_REGION: 'dev',
+  }, { EXPO_PUBLIC_CINDY_AUTH_REGION: 'dev' }));
+});
+
+test('Mobile 转换缓存按三个原始构建值隔离，且不回显值或受无关 env 影响', () => {
+  const env = Object.freeze(mobileClientBundleEnv({ authRegion: 'global', repoRoot: writeRepoFixtures() }));
+  const snapshot = createMobileManifestBuildSnapshot(env);
+  assert.match(snapshot.cacheKey, /^cindy-mobile-manifest-v1:[a-f0-9]{64}$/);
+  assert.equal(createMobileManifestBuildSnapshot({ ...env }).cacheKey, snapshot.cacheKey);
+  assert.doesNotThrow(() => snapshot.assertUnchanged({ ...env, UNRELATED_ENV: '1' }));
+  assert.equal(createMobileManifestBuildSnapshot({ ...env, UNRELATED_ENV: '1' }).cacheKey, snapshot.cacheKey);
+  for (const key of Object.keys(env)) {
+    for (const value of [undefined, '', `${env[key]} `, 'fake-secret']) {
+      const changed = { ...env, [key]: value };
+      const next = createMobileManifestBuildSnapshot(changed);
+      assert.notEqual(next.cacheKey, snapshot.cacheKey);
+      assert.doesNotMatch(next.cacheKey, /fake-secret/);
+      assert.throws(() => snapshot.assertUnchanged(changed),
+        (error) => error.message.includes('重启 Metro') && !error.message.includes('fake-secret'));
+    }
+  }
+});
+
+test('Mobile 构建快照仅保留稳定 CindyDev 的开发覆盖，跨构建身份必须重启', () => {
+  const dev = {
+    EXPO_PUBLIC_CINDY_AUTH_REGION: 'dev',
+    EXPO_PUBLIC_ENDPOINT_MANIFEST_BASE_URL: 'http://localhost:1234',
+    EXPO_PUBLIC_ENDPOINT_MANIFEST_PEER_BASE_URL: 'http://localhost:5678',
+  };
+  const snapshot = createMobileManifestBuildSnapshot(dev);
+  const changedDev = { ...dev, EXPO_PUBLIC_ENDPOINT_MANIFEST_BASE_URL: 'http://localhost:9999' };
+  assert.doesNotThrow(() => snapshot.assertUnchanged(changedDev));
+  assert.doesNotThrow(() => assertMobileManifestBuildEnv(changedDev, dev));
+  for (const authRegion of ['cn', 'global']) {
+    const release = mobileClientBundleEnv({ authRegion, repoRoot: writeRepoFixtures() });
+    assert.throws(() => snapshot.assertUnchanged(release), /重启 Metro/);
+    assert.throws(() => createMobileManifestBuildSnapshot(release).assertUnchanged(dev), /重启 Metro/);
+  }
 });
 
 test('Mobile 构建入口不把动态异常或环境变量值写入失败日志', () => {

--- a/scripts/shared/client-endpoint-build-env.mjs
+++ b/scripts/shared/client-endpoint-build-env.mjs
@@ -8,6 +8,7 @@
 import fs from 'node:fs';
 import path from 'node:path';
 import { fileURLToPath } from 'node:url';
+import { assertMobileManifestBuildEnv } from './mobile-manifest-build-guard.cjs';
 
 const REPO_ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..', '..');
 export const CLIENT_BUILD_REGIONS = Object.freeze(['cn', 'global', 'dev']);
@@ -160,5 +161,6 @@ export function mobileClientBundleProcessEnv({
   if (bundleEnv.EXPO_PUBLIC_CINDY_AUTH_REGION !== 'dev') {
     delete env.EXPO_PUBLIC_CINDY_DEV_RELEASE_ENDPOINT_MANIFEST_BASE_URL;
   }
+  assertMobileManifestBuildEnv(env, bundleEnv);
   return env;
 }

--- a/scripts/shared/mobile-manifest-build-guard.cjs
+++ b/scripts/shared/mobile-manifest-build-guard.cjs
@@ -1,0 +1,74 @@
+/**
+ * 校验最终传给 Metro 的区域清单地址。CommonJS 供 Metro config 与 ESM 构建
+ * 脚本共用；预期值由调用方从仓内清单派生，不维护另一份端点表。
+ */
+const { createHash } = require('node:crypto');
+
+const REGION_KEY = 'EXPO_PUBLIC_CINDY_AUTH_REGION';
+const BASE_KEY = 'EXPO_PUBLIC_ENDPOINT_MANIFEST_BASE_URL';
+const PEER_KEY = 'EXPO_PUBLIC_ENDPOINT_MANIFEST_PEER_BASE_URL';
+
+function hashManifestEnv(env) {
+  // Babel 内联原字节：即使 URL 规范化后等价，原值变化也必须换转换缓存。
+  return createHash('sha256')
+    .update(JSON.stringify([REGION_KEY, BASE_KEY, PEER_KEY].map((key) => env[key] ?? null)))
+    .digest('hex');
+}
+
+/** 在 Metro / WorkerFarm 初始化前固定缓存身份；不保存或回显原始地址。 */
+function createMobileManifestBuildSnapshot(env) {
+  const region = env[REGION_KEY]?.trim();
+  const hash = hashManifestEnv(env);
+  return Object.freeze({
+    cacheKey: `cindy-mobile-manifest-v1:${hash}`,
+    assertUnchanged(nextEnv) {
+      // 只有一直处于 CindyDev 的构建保留开发覆盖；切换成 dev 不能绕过正式区守卫。
+      if (region === 'dev' && nextEnv[REGION_KEY]?.trim() === 'dev') return;
+      if (hashManifestEnv(nextEnv) !== hash) {
+        throw new Error('Mobile 构建区域或清单配置在初始化后发生变化：请重启 Metro 后重新打包');
+      }
+    },
+  });
+}
+
+function normalizeManifestBaseUrl(value, key) {
+  // 不附带原值或 URL parser 的异常，防止 runner 误填的凭据进入构建日志。
+  const invalid = () => new Error(`Mobile 构建配置错误：${key} 必须是非空、无凭据的 HTTPS URL`);
+  if (typeof value !== 'string' || !value.trim()) throw invalid();
+  let url;
+  try {
+    url = new URL(value.trim());
+  } catch {
+    throw invalid();
+  }
+  if (url.protocol !== 'https:' || url.username || url.password) throw invalid();
+  return url.href.replace(/\/+$/, '');
+}
+
+/**
+ * @param {Record<string, string | undefined>} env 最终 bundling 环境
+ * @param {Record<string, string | undefined>} expectedEnv 仓内派生值
+ */
+function assertMobileManifestBuildEnv(env, expectedEnv) {
+  const region = expectedEnv[REGION_KEY];
+  if (!['cn', 'global', 'dev'].includes(region) || env[REGION_KEY]?.trim() !== region) {
+    throw new Error(`Mobile 构建配置错误：${REGION_KEY} 与所选构建区域不一致`);
+  }
+  // CindyDev 是独立开发身份，保留既有开发端点覆盖契约。
+  if (region === 'dev') return;
+
+  const base = normalizeManifestBaseUrl(env[BASE_KEY], BASE_KEY);
+  const peer = normalizeManifestBaseUrl(env[PEER_KEY], PEER_KEY);
+  if (base === peer) {
+    throw new Error(`Mobile 构建配置错误：${BASE_KEY} 与 ${PEER_KEY} 规范化后不能相同`);
+  }
+  for (const [key, value] of [[BASE_KEY, base], [PEER_KEY, peer]]) {
+    if (value !== normalizeManifestBaseUrl(expectedEnv[key], key)) {
+      throw new Error(
+        `Mobile 构建配置错误：${key} 与所选区域的仓内清单不一致；请清理 shell / .env 残留，或修正 config/endpoint*.json`,
+      );
+    }
+  }
+}
+
+module.exports = { assertMobileManifestBuildEnv, createMobileManifestBuildSnapshot };


### PR DESCRIPTION
## 这次改了什么

### 摘要

为移动端 CN / Global 的清单自举配置增加构建期防错检查，防止“本区和对端都指向同一区域”或残留环境变量被打进生产 bundle。

同时补上转换缓存边界：仅检查最终环境仍可能复用旧的 Babel 内联结果，因此 Metro 缓存按构建区域及两个清单地址的原始值摘要隔离。相同配置仍可复用缓存；生产构建初始化后配置发生变化则要求重启 Metro，避免主进程、缓存与工作进程使用不同值。

### 变更类型

- [x] `fix` 缺陷修复
- [x] `docs` / `test` / `chore` 文档、测试或工程维护

### 范围

- 关联 Issue：Refs #3861。**仅覆盖建议独立提交的构建门禁，不自动关闭原 Issue。**
- 本 PR 包含：
  - 共享校验器：非空、无凭据 HTTPS URL，规范化后本区与对端不能相同，并须匹配所选区域的仓内清单。
  - Android / iOS 构建使用的 `mobileClientBundleProcessEnv` 在生成子进程环境后校验；Metro 在实际生产转换请求（`dev: false`）处再次校验，不依赖 runner 的 `NODE_ENV`。
  - 保留原 Metro `cacheVersion`，追加区域/两区原始地址的 SHA-256 摘要；检查初始化后的环境漂移，且不能通过切为 CindyDev 绕过。
  - 回归测试与开发文档；错误消息不回显环境变量值。
- 明确不包含：运行期登录/区域路由修改、生产发布环境清理、重发安装包/OTA、线上及真机 SSO 修复验收。
- 用户可见变化：无 UI 变化。构建者会在错配时提前收到错误；开发 Metro 与稳定 CindyDev 的覆盖行为保留。
- 是否存在 breaking change：无运行期或协议变更。**构建契约收紧**：CN / Global 生产包不再接受与仓内清单不一致的 shell / `.env` 地址覆盖；自建地址应调整 `config/endpoint*.json` 正本。

### UI 变化

不涉及。引用的设计规范：不涉及。

## 怎么验证的

环境：macOS arm64，Node 22.23.1；本地 checkout 分支 `fix/3861-mobile-manifest-build-guard`，基线 `e9c3729a1`。未启动开发 Metro 实例或安装运行客户端；以下 Metro 验证为测试进程/一次性 CLI 导出，故无真机 `__DEV__` build label。

### 自动验证

| 命令 | 结果 |
| --- | --- |
| `pnpm test:unit:related` | 通过；runner 509 passed / 1 skipped，mobile 相关测试通过 |
| `pnpm --filter mobile exec vitest run --pool=threads --maxWorkers=4` | 373 个测试文件、4,676 项测试全部通过 |
| `pnpm --filter mobile run --if-present typecheck` | 通过 |
| `pnpm check:i18n-glossary` | 通过；18 处已有 proposed 术语告警，不阻断 |
| `node --test scripts/__tests__/client-endpoint-build-env.test.mjs` | 12 项通过 |
| `pnpm check:dco` / `git diff --check` | 通过 |

缓存回归不是只检查 hash：测试使用真实 Metro Transformer / Expo Babel 与共享内存缓存，检查 CN → Global → Global → CN → Global（等价 URL 增加尾斜杠）的实际内联代码，并确认同配置有 2 次缓存命中。修复前可复现旧区域地址被复用，修复后测试通过。测试仅传 Buffer，不写探针源文件、不使用开发者磁盘缓存。

指纹：改动前后运行 `node apps/mobile/scripts/ci-fingerprint.mjs compute --output <report>`，再用 `compare --base <before> --current <after>` 比对，两平台均不变：

- iOS：`96e76c9f4cb4fd4c990fb09e631e8ab42d61583e`
- Android：`20a7dee6fb588f451c59b37deec3faf7e37a8b41`

### 手工验证

- 在 Global 环境故意令本区/对端地址相同，运行 `pnpm --filter mobile exec expo export --platform android --max-workers 1 --output-dir <temp-dir>`：实际 Android bundling 立即被新校验器阻止。
- 正确地址配置通过新检查并进入正常转换；但完整导出随后因本地缺少 `config/endpoint.dev.json` 失败。用基线 Metro 配置的内存加载对照运行同一导出，也得到相同缺文件错误；未修改开发者配置来掩盖此限制。

### 未执行的验证

- 完整成功的安装包 / bundle 产物验收：本地缺少上述开发清单，正常导出未完成。
- Android / iOS 真机同区及跨区 SSO、实际 EAS 云构建、生产 release/beta OTA 发布。
- 全仓完整 unit 未重跑；已跑仓库要求的 related 门禁及额外 mobile 全量。GitHub CI 仍需独立完成。

## 风险

### 风险分类

- [x] 原生层 / fingerprint / OTA：涉及 bundle 构建边界，**未改变原生指纹**
- [x] 其他：构建环境校验 / Metro 转换缓存

### 影响与回滚

- 影响范围：经过本地构建 helper 或 Metro 生成的 CN / Global 生产 bundle。第一次使用新缓存命名空间会重新转换；同配置后续仍可命中缓存。生产进程中途修改区域/清单值时需要重启 Metro。
- `app.config.js`、其 CJS loader、Expo `extra`、原生身份与依赖均未改；本地指纹对比一致，不引入冷更要求。最终仍以 PR CI 的 base/head 指纹比较为准。
- 开发模式与稳定 CindyDev 的显式覆盖不被生产校验收紧。没有 UI、数据库迁移、运行期协议或用户持久数据变化。
- 本补丁不会修复已经发布或直接复制复用的成品 bundle；#3861 仍需发布链路及最终产物/真机证据，不能仅凭本 PR 认定线上恢复。
- 回滚：回退本 PR 即撤销新增门禁及缓存命名空间扩展，无数据迁移；旧转换缓存无需手动删除。

### 提交前检查

- [x] 已 review 完整 diff
- [x] 每个 commit 都带 DCO 签名（`git commit -s`）
- [x] UI 变化与设计依据已注明不涉及
- [x] 未提交凭证、令牌或授权文件
- [x] 已补充必要文档
- [x] 已确认测试结果或说明未执行原因
