### PR TITLE
test(desktop): cover new-session model selection regression

### DIFF
--- a/apps/desktop/src/renderer/__tests__/chatInputModelSelectorRouting.test.ts
+++ b/apps/desktop/src/renderer/__tests__/chatInputModelSelectorRouting.test.ts
@@ -503,6 +503,29 @@ describe('ChatInput model source switching wiring', () => {
     expect(selectorBlock).not.toContain('rowModelId');
   });
 
+  it('keeps a new conversation model pick on the draft path', () => {
+    const draftStart = chatInputSource.indexOf('const handleUnifiedDraftSelect = useCallback(');
+    const draftEnd = chatInputSource.indexOf(
+      '[sessionId, settingsLocked, modelMemory, onUnifiedDraftSelect]',
+      draftStart,
+    );
+    const draftHandler = chatInputSource.slice(draftStart, draftEnd);
+
+    expect(draftHandler).toContain('if (sessionId || settingsLocked) return;');
+    expect(draftHandler).toContain('onUnifiedDraftSelect?.({');
+    expect(draftHandler).not.toContain('maker.setModel(');
+    expect(draftHandler).not.toContain('confirmModelSwitchContextGuard(');
+
+    const selectorStart = chatInputSource.lastIndexOf('<ModelSelector');
+    const selectorBlock = chatInputSource.slice(
+      selectorStart,
+      chatInputSource.indexOf('/>', selectorStart) + 2,
+    );
+    expect(selectorBlock).toContain(
+      '!sessionId && unifiedPanelActive && onUnifiedDraftSelect\n                        ? handleUnifiedDraftSelect',
+    );
+  });
+
   it('sends null atomic effort for models with no ranks and keeps row Fast', () => {
     const modelStart = chatInputSource.indexOf('const performModelChange = useCallback(');
     const providerStart = chatInputSource.indexOf('const performProviderChange = useCallback(');


### PR DESCRIPTION
## 这次改了什么

### 摘要

为新建对话时选择模型的路由增加回归测试，锁定草稿态应走 `handleUnifiedDraftSelect`，避免误用已建会话的 `maker.setModel` 和上下文窗口切换守卫。

### 变更类型

- [ ] `feat` 新功能
- [ ] `fix` 缺陷修复
- [ ] `refactor` / `perf` 重构或性能优化
- [x] `docs` / `test` / `chore` 文档、测试或工程维护
- [ ] 其他：

### 范围

- 关联 Issue / 需求：#4003
- 本 PR 包含：新建对话模型选择草稿路径的回归测试。
- 明确不包含：生产代码修改；其他入口（如 Bot / IM）的模型切换行为。
- 用户可见变化：无。
- 是否存在 breaking change：无。

### UI 变化

不涉及 UI 变化，无需截图或录屏。

- 引用的设计规范：不涉及：仅新增模型选择路由的回归测试，未修改任何生产 UI、交互或文案。

## 怎么验证的

### 自动验证

```text
corepack pnpm --filter desktop exec vitest run src/renderer/__tests__/chatInputModelSelectorRouting.test.ts
结果：通过，1 个测试文件、27 个测试通过。

corepack pnpm test:unit:related
结果：通过，apps/desktop 相关单元测试门禁通过。

corepack pnpm --filter desktop run --if-present typecheck
结果：通过。

node scripts/check-pr-design-basis.mjs --body <PR body> --files <changed files>
结果：通过。
```

### 手工验证

不涉及：本 PR 只增加源码契约回归测试，不修改运行时行为。

### 未执行的验证

未执行 Electron 实机验证；本 PR 不修改生产代码或 UI。

## 风险

### 风险分类

- [x] 无已知风险
- [ ] SQLite / migration
- [ ] system prompt
- [ ] 协议兼容
- [ ] 权限 / 安全 / 用户数据
- [ ] 存量插件兼容（批准状态 / 指纹 / manifest 校验 / 安装布局 / 包格式）
- [ ] 原生层 / fingerprint / OTA
- [ ] 跨平台差异
- [ ] 其他：

### 影响与回滚

- 影响范围：仅 Desktop Renderer 的回归测试。
- 回滚 / 降级方式：回滚本测试提交；无运行时影响。

### 提交前检查

- [x] 已 review 完整 diff
- [x] 每个 commit 都带 DCO 签名（`git commit -s`，见 [DCO](../DCO)）
- [x] UI 改动已在「UI 变化」注明引用的设计规范章节（不涉及 UI 则跳过）
- [x] 未提交凭证、令牌或授权文件
- [x] 已补充必要文档
- [x] 已确认测试结果或说明未执行原因
