### PR TITLE
fix(desktop): 修复自动任务模型菜单层级

### DIFF
--- a/apps/desktop/src/renderer/components/new-chat/ModelSelector.tsx
+++ b/apps/desktop/src/renderer/components/new-chat/ModelSelector.tsx
@@ -264,7 +264,7 @@ function ModelOptionsFloatingPanel({
     <div
       ref={refs.setFloating}
       data-radix-popper-content-wrapper=""
-      className="z-50 w-[248px]"
+      className={cn('z-50 w-[248px]', className)}
       style={{
         ...floatingStyles,
         visibility: isPositioned ? undefined : 'hidden',

--- a/apps/desktop/src/renderer/components/new-chat/UnifiedFlyoutHost.tsx
+++ b/apps/desktop/src/renderer/components/new-chat/UnifiedFlyoutHost.tsx
@@ -148,7 +148,7 @@ export function UnifiedFlyoutHost({
         // 见上:MorphPopover 的 outside / focusin 判定靠这个属性认「自己人」。
         data-radix-popper-content-wrapper=""
         data-unified-flyout-wrapper=""
-        className="fixed z-50"
+        className={cn('fixed z-50', className)}
         style={{
           width: FLYOUT_WIDTH + UNIFIED_FLYOUT_GAP,
           // 行与浮层之间那条缝隙由**外层包装自己吃掉**:包装比卡片宽 gap 并把这段留白


### PR DESCRIPTION
## 这次改了什么

### 摘要

修复自动任务设置中的模型选择器配置子面板被对话框遮挡的问题：调用方传入的高层级 class 现在会应用到实际定位 wrapper。

### 变更类型

- [x] `fix` 缺陷修复

### 范围

- 本 PR 包含：修正 ModelSelector 浮层 wrapper 的层级 class 传递。
- 明确不包含：其他页面布局或产品行为调整。
- 用户可见变化：自动任务设置中的模型选项菜单始终显示在对话框上层。
- 是否存在 breaking change：无

### UI 变化

- 引用的设计规范：不涉及视觉样式变化；仅修复浮层层级行为。

## 怎么验证的

### 自动验证

```text
git diff --check
结果：通过
```

### 手工验证

未执行。

### 未执行的验证

项目测试未执行：当前环境未安装 pnpm。

## 风险

### 风险分类

- [x] 无已知风险

### 影响与回滚

- 影响范围：ModelSelector 配置子面板的定位 wrapper 层级。
- 回滚 / 降级方式：回滚本 PR commit 即可。

### 提交前检查

- [x] 已 review 完整 diff
- [x] 每个 commit 都带 DCO 签名
- [x] 未提交凭证、令牌或授权文件
