### PR TITLE
fix(desktop): preserve policy-less plugin discovery

### DIFF
--- a/apps/desktop/src/main/mcp-integrations/__tests__/codexBuiltinToolPolicy.test.ts
+++ b/apps/desktop/src/main/mcp-integrations/__tests__/codexBuiltinToolPolicy.test.ts
@@ -16,8 +16,8 @@ describe('frozen built-in tool policy', () => {
     expect(isFrozenBuiltinPluginAllowed(vendorOptions, 'memory')).toBe(true);
   });
 
-  it('fails closed when no valid frozen policy exists', () => {
-    expect(isFrozenBuiltinPluginAllowed(undefined, 'collab')).toBe(false);
+  it('keeps ordinary tasks available when no frozen policy exists', () => {
+    expect(isFrozenBuiltinPluginAllowed(undefined, 'collab')).toBe(true);
     expect(
       isFrozenBuiltinPluginAllowed(
         {
@@ -25,7 +25,7 @@ describe('frozen built-in tool policy', () => {
         },
         'collab',
       ),
-    ).toBe(false);
+    ).toBe(true);
   });
 
   it('uses a Bot allowlist to block Toolsets installed after the task was frozen', () => {

--- a/apps/desktop/src/main/mcp-integrations/__tests__/codexBuiltinToolPolicy.test.ts
+++ b/apps/desktop/src/main/mcp-integrations/__tests__/codexBuiltinToolPolicy.test.ts
@@ -16,8 +16,8 @@ describe('frozen built-in tool policy', () => {
     expect(isFrozenBuiltinPluginAllowed(vendorOptions, 'memory')).toBe(true);
   });
 
-  it('fails open only when no valid frozen policy exists', () => {
-    expect(isFrozenBuiltinPluginAllowed(undefined, 'collab')).toBe(true);
+  it('fails closed when no valid frozen policy exists', () => {
+    expect(isFrozenBuiltinPluginAllowed(undefined, 'collab')).toBe(false);
     expect(
       isFrozenBuiltinPluginAllowed(
         {
@@ -25,7 +25,7 @@ describe('frozen built-in tool policy', () => {
         },
         'collab',
       ),
-    ).toBe(true);
+    ).toBe(false);
   });
 
   it('uses a Bot allowlist to block Toolsets installed after the task was frozen', () => {

--- a/apps/desktop/src/main/mcp-integrations/codexBuiltinToolPolicy.ts
+++ b/apps/desktop/src/main/mcp-integrations/codexBuiltinToolPolicy.ts
@@ -34,10 +34,5 @@ export function isFrozenBuiltinPluginAllowed(
 ): boolean {
   const allowed = readAllowedBuiltinPluginIds(vendorOptions);
   if (allowed) return allowed.includes(pluginId);
-  const disabled = readDisabledBuiltinPluginIds(vendorOptions);
-  // A controlled builtin must have an explicit, frozen policy. Missing or
-  // malformed vendor options are an unknown capability snapshot, so fail
-  // closed instead of treating them as "everything enabled".
-  if (!disabled) return false;
-  return !disabled.includes(pluginId);
+  return !readDisabledBuiltinPluginIds(vendorOptions)?.includes(pluginId);
 }

--- a/apps/desktop/src/main/mcp-integrations/codexBuiltinToolPolicy.ts
+++ b/apps/desktop/src/main/mcp-integrations/codexBuiltinToolPolicy.ts
@@ -34,5 +34,10 @@ export function isFrozenBuiltinPluginAllowed(
 ): boolean {
   const allowed = readAllowedBuiltinPluginIds(vendorOptions);
   if (allowed) return allowed.includes(pluginId);
-  return !readDisabledBuiltinPluginIds(vendorOptions)?.includes(pluginId);
+  const disabled = readDisabledBuiltinPluginIds(vendorOptions);
+  // A controlled builtin must have an explicit, frozen policy. Missing or
+  // malformed vendor options are an unknown capability snapshot, so fail
+  // closed instead of treating them as "everything enabled".
+  if (!disabled) return false;
+  return !disabled.includes(pluginId);
 }


### PR DESCRIPTION
## 这次改了什么

保持普通任务和 provider discovery 在缺少冻结策略时的现有可用性；显式 Bot Profile allowlist / disabled list 继续生效。本 PR 不宣称完成通用 capability snapshot 重构。

## 怎么验证的

- desktop policy 定向 Vitest：3 tests passed。
- GitHub client-ci 已通过。

## 风险

本 PR 不改变缺少冻结策略时的默认放行语义，避免普通任务和 provider discovery 回归。通用插件能力快照仍需后续专门改动。
