### PR TITLE
fix(compat-proxy): 剥离 Pi 注入的 fallbacks,修复 Claude 订阅下 Opus 5 / Fable 5 全量 400

### DIFF
--- a/packages/anthropic-compat-proxy/src/transform.test.ts
+++ b/packages/anthropic-compat-proxy/src/transform.test.ts
@@ -1123,7 +1123,7 @@ describe('stripNonAnthropicFields · glm-5.2 tool_result 图像降级 (#794)', (
 
   it('未登记的 model 不受影响(字节透传)', () => {
     expect(
-      stripNonAnthropicFields(makeBody('claude-opus-5'), ctx),
+      stripNonAnthropicFields(makeBody('claude-sonnet-5'), ctx),
     ).toBeNull();
   });
 
@@ -1133,6 +1133,58 @@ describe('stripNonAnthropicFields · glm-5.2 tool_result 图像降级 (#794)', (
       messages: [{ role: 'user', content: [imageBlock] }],
     };
     expect(stripNonAnthropicFields(body, ctx)).toBeNull();
+  });
+});
+
+describe('stripNonAnthropicFields · Pi Gateway fallbacks 剥离(Claude 订阅直连)', () => {
+  const direct = (upstreamBase: string | undefined): RequestTransformCtx => ({
+    reqId: 1,
+    method: 'POST',
+    url: '/v1/messages',
+    headers: {},
+    ...(upstreamBase === undefined ? {} : { upstreamBase }),
+  });
+  const anthropicCtx = direct('https://api.anthropic.com');
+
+  const makeBody = (model: string, withFallbacks: boolean): Record<string, unknown> => ({
+    model,
+    messages: [{ role: 'user', content: 'hi' }],
+    ...(withFallbacks ? { fallbacks: [{ model: 'claude-opus-4-8' }] } : {}),
+  });
+
+  it.each(['claude-fable-5', 'claude-opus-5'])(
+    '%s:直连 api.anthropic.com 时删掉 fallbacks,其余字段原样保留',
+    (model) => {
+      const out = stripNonAnthropicFields(makeBody(model, true), anthropicCtx) as Record<
+        string,
+        unknown
+      > | null;
+      expect(out).not.toBeNull();
+      expect(out).not.toHaveProperty('fallbacks');
+      expect(out).toMatchObject({ model, messages: [{ role: 'user', content: 'hi' }] });
+    },
+  );
+
+  it.each(['claude-fable-5', 'claude-opus-5'])(
+    '%s:请求本就没有 fallbacks 时返回 null(字节透传,保 cache)',
+    (model) => {
+      expect(stripNonAnthropicFields(makeBody(model, false), anthropicCtx)).toBeNull();
+    },
+  );
+
+  // 网关路由能消费 fallbacks —— 删掉会废掉 Pi 配好的降级链(pi-harness.md §3.1 非退化红线)。
+  it.each([
+    ['网关路由', 'https://gateway.example.com'],
+    ['同后缀的钓鱼域名', 'https://api.anthropic.com.evil.com'],
+    ['路由未解析(undefined)', undefined],
+  ])('%s:保留 fallbacks 不动', (_label, upstreamBase) => {
+    expect(
+      stripNonAnthropicFields(makeBody('claude-opus-5', true), direct(upstreamBase)),
+    ).toBeNull();
+  });
+
+  it('未登记的 claude 模型即使带 fallbacks 也不动(Pi 不会给它们注入)', () => {
+    expect(stripNonAnthropicFields(makeBody('claude-sonnet-5', true), anthropicCtx)).toBeNull();
   });
 });
 

--- a/packages/anthropic-compat-proxy/src/transform.ts
+++ b/packages/anthropic-compat-proxy/src/transform.ts
@@ -24,10 +24,15 @@ export { createVllmResponsesCompatibilityRule } from './vllm-responses-compatibi
  *
  * @param body 已经 parse 好的 plain object,调用前已确认 typeof body === 'object'
  *             且 body.model 命中字典 key。handler 内部不需要再做这些校验。
+ * @param ctx  本请求的 transform 上下文;需要按目标上游区别对待的 handler 读
+ *             `ctx.upstreamBase`(同一 model id 可能走网关也可能直连供应商)。
  * @returns 新的 body 对象 → 代理用它替换原 body 转发上游;
  *          null → 显式表示"虽然命中我但不需要改",代理走透传。
  */
-type ModelStripHandler = (body: Record<string, unknown>) => Record<string, unknown> | null;
+type ModelStripHandler = (
+  body: Record<string, unknown>,
+  ctx: RequestTransformCtx,
+) => Record<string, unknown> | null;
 
 function isPlainObject(v: unknown): v is Record<string, unknown> {
   return typeof v === 'object' && v !== null && !Array.isArray(v);
@@ -1383,6 +1388,51 @@ export function compactOversizedImageHistory(
 /** glm-5.2 (智谱,官方仅文本/代码模态) —— 直通与网关两条路由同一 model id。 */
 const stripGlm52: ModelStripHandler = (body) => replaceToolResultImagesWithNotice(body);
 
+/**
+ * Anthropic 官方端点精确判定 —— hostname 全等,不用 substring 包含
+ * (CodeQL js/incomplete-url-substring-sanitization: `includes('api.anthropic.com')`
+ * 会放行 `api.anthropic.com.evil.com`)。
+ */
+function isAnthropicDirectUpstream(upstreamBase: string | undefined): boolean {
+  if (!upstreamBase) return false;
+  try {
+    return new URL(upstreamBase).hostname === 'api.anthropic.com';
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Pi 订阅直连的 `fallbacks` 剥离。
+ *
+ * Pi 构造 anthropic-messages 请求时无条件注入 Pi Gateway 的私有参数
+ * (pi 0.84.4 反编译, 无 baseUrl / OAuth 判断):
+ *   params.fallbacks = model.compat.allowedFallbackModels.map((f) => ({ model: f.model }))
+ * Claude 订阅路由把 Pi 直接接到官方端点, 该参数一律 400:
+ *   fallbacks: Extra inputs are not permitted
+ * → 自带 allowedFallbackModels 的模型每一轮都发不出去, 会话完全不可用。
+ *
+ * **只在直连 api.anthropic.com 时剥**。同一个 model id 也可能走网关路由,那条路
+ * 能消费 `fallbacks`;无条件删会把 Pi 配好的降级链废掉,主模型一抖就是一次失败的
+ * turn —— 正是 pi-harness.md §3.1「不得让同版本 Pi 原本能完成的事情因 Cindy 控制层
+ * 新增判断而失败」禁止的退化。目标上游由 proxy 经 ctx.upstreamBase 给出,host 侧
+ * 不用复刻路由逻辑;拿不到(undefined)时按不剥处理,宁可漏剥也不误伤网关路由。
+ *
+ * 登记范围 = Pi 内置目录里带 allowedFallbackModels 的 anthropic 模型 (0.84.4:
+ * claude-fable-5 / claude-opus-5)。其余 claude-* 保持字节透传 —— 不为一个 Pi 侧
+ * 字段让全部 Claude Code 流量多一次 JSON 解析+序列化。Pi 后续版本给别的模型加了
+ * allowedFallbackModels, 在此补登记即可。
+ *
+ * 无该字段时返回 null(Claude Code 等其它来源的同 id 请求继续字节透传, 保 cache)。
+ */
+const stripPiGatewayFallbacks: ModelStripHandler = (body, ctx) => {
+  if (!('fallbacks' in body)) return null;
+  if (!isAnthropicDirectUpstream(ctx.upstreamBase)) return null;
+  const next: Record<string, unknown> = { ...body };
+  delete next.fallbacks;
+  return next;
+};
+
 // ───────────────────────────────────────────────────────────────────────────
 // 分发表
 // ───────────────────────────────────────────────────────────────────────────
@@ -1404,12 +1454,17 @@ const STRIP_HANDLERS: Readonly<Record<string, ModelStripHandler>> = {
   'z-ai/glm-5.2': stripGlm52,
   'glm-5.2[1m]': stripGlm52,
   'z-ai/glm-5.2[1m]': stripGlm52,
+  // Pi 按 compat.allowedFallbackModels 注入 Gateway 私有参数 `fallbacks`,直连官方
+  // 端点时 400(handler 内按 ctx.upstreamBase 分路由)。Pi 的 anthropic wireId 无前缀
+  // 无后缀,登记裸 id 即可。
+  'claude-fable-5': stripPiGatewayFallbacks,
+  'claude-opus-5': stripPiGatewayFallbacks,
 };
 
 /**
  * 默认 transform —— 按 model 分发到对应 handler;查不到就透传。
  */
-export const stripNonAnthropicFields: RequestTransform = (body) => {
+export const stripNonAnthropicFields: RequestTransform = (body, ctx) => {
   if (!isPlainObject(body)) return null;
 
   const model = body.model;
@@ -1418,7 +1473,7 @@ export const stripNonAnthropicFields: RequestTransform = (body) => {
   const handler = STRIP_HANDLERS[model];
   if (!handler) return null;
 
-  return handler(body);
+  return handler(body, ctx);
 };
 
 /**


### PR DESCRIPTION
## 这次改了什么

### 摘要

Pi engine 接 Claude 订阅时，选 **Opus 5** 或 **Fable 5** 每一轮都失败，会话完全不可用：

```
400 {"type":"error","error":{"type":"invalid_request_error",
     "message":"fallbacks: Extra inputs are not permitted"}}
```

原因是 Pi 构造 anthropic-messages 请求体时，**无条件**注入 Pi Gateway 的私有参数（pi 0.84.4，函数末尾，没有任何 baseUrl / OAuth 判断）：

```js
const allowedFallbackModels = model.compat?.allowedFallbackModels;
if (allowedFallbackModels && allowedFallbackModels.length > 0) {
  params.fallbacks = allowedFallbackModels.map((fallback) => ({ model: fallback.model }));
}
```

Pi 内置目录里带 `allowedFallbackModels` 的 anthropic 模型正好只有两个：

| 模型 | allowedFallbackModels |
|---|---|
| `claude-fable-5` | claude-opus-4-8, claude-opus-5 |
| `claude-opus-5` | claude-opus-4-8 |

Claude 订阅路由把 Pi 直接接到 `api.anthropic.com`，官方端点不认这个字段。代理这层没拦住是因为 `STRIP_HANDLERS` 是按 model id 的精确白名单，此前只登记了 `gpt-5.4` / `glm-5.2` 系列，`claude-*` 一律字节透传（刻意设计，Claude 自家模型延迟 0），于是该字段一路原样打到官方端点。

本 PR 给这两个 id 登记 handler，**在直连 `api.anthropic.com` 时**删掉 `fallbacks`。

### 变更类型

- [x] `fix` 缺陷修复

### 范围

- 关联 Issue / 需求：无（用户实测反馈）
- 本 PR 包含：`stripPiGatewayFallbacks` handler + 分发表登记 + `ModelStripHandler` 签名加 `ctx` 参数 + 5 个新测试用例
- 明确不包含：Pi 侧的修复（`fallbacks` 注入在 Pi 二进制里，不在本仓库）；其它 claude 模型的登记（目前没有别的模型带 `allowedFallbackModels`）
- 用户可见变化：Pi + Claude 订阅下 Opus 5 / Fable 5 从「每轮必失败」恢复为可用；其余路径行为不变
- 是否存在 breaking change：无

### UI 变化

不涉及。

## 怎么验证的

### 自动验证

```text
cd packages/anthropic-compat-proxy

pnpm test
结果：Test Files 13 passed (13) / Tests 446 passed | 1 skipped (447)

pnpm typecheck
结果：通过，无输出

pnpm lint
结果：通过，无输出
```

新增 5 个用例：

- 两个模型各测「直连 Anthropic + 带 fallbacks → 删掉、其余字段不动」
- 两个模型各测「没有 fallbacks → 返回 null」（字节透传 / cache 契约）
- 三种非直连上游（网关域名 / 同后缀钓鱼域名 / `upstreamBase` 未解析）→ 保留 `fallbacks` 不动
- 未登记模型（`claude-sonnet-5`）即使带 `fallbacks` 也不受影响

顺带把原有「未登记的 model 不受影响」用例的样本从 `claude-opus-5` 换成 `claude-sonnet-5` —— 前者现在已登记，需要一个真正未登记的 id 该用例才有意义。

### 手工验证

不涉及。

### 未执行的验证

**未做端到端实跑**：需要一个已登录 Claude 订阅、且模型选到 Opus 5 / Fable 5 的 Pi 会话，提交者当前环境没有可复现该组合的构建。根因来自 Pi 二进制内的请求构造代码与其内置模型表，链路是确定的，但「修复后该会话恢复正常」这一步没有实测过，烦请 reviewer 或有环境的同学确认。

## 风险

### 风险分类

- [x] 协议兼容

### 影响与回滚

- 影响范围：仅 `claude-fable-5` / `claude-opus-5` 两个 model id，且仅当请求体里存在 `fallbacks`、同时目标上游 hostname 全等于 `api.anthropic.com` 时才改写。其余 model / 其余上游 / 不带该字段的请求全部保持原有字节透传，prompt cache 不受影响。
- 按目标上游分路由是刻意的：同一个 model id 也可能走网关，那条路能消费 `fallbacks`，无条件删会废掉 Pi 配好的降级链，主模型一抖就变成一次失败的 turn —— 正是 `docs/dev-rules/pi-harness.md` §3.1 非退化红线禁止的情况。上游从 `ctx.upstreamBase` 读（proxy 已提供，host 侧不用复刻路由逻辑），拿不到时按不剥处理，宁可漏剥也不误伤网关路由。
- hostname 用全等比较而非 substring 包含，避免 CodeQL `js/incomplete-url-substring-sanitization`（`includes('api.anthropic.com')` 会放行 `api.anthropic.com.evil.com`）。
- 回滚 / 降级方式：从 `STRIP_HANDLERS` 移除这两行即可完全恢复原行为，无状态、无迁移。

### 提交前检查

- [x] 已 review 完整 diff
- [x] 每个 commit 都带 DCO 签名
- [x] UI 改动已在「UI 变化」注明引用的设计规范章节（不涉及 UI）
- [x] 未提交凭证、令牌或授权文件
- [x] 已补充必要文档（handler 内注释写明判定依据与后续维护方式）
- [x] 已确认测试结果或说明未执行原因