### PR TITLE
fix(models): 迁移老用户模型设置并保留兼容模式入口

### DIFF
--- a/apps/desktop/src/renderer/__tests__/modelVisibilityPrefs.test.ts
+++ b/apps/desktop/src/renderer/__tests__/modelVisibilityPrefs.test.ts
@@ -17,6 +17,7 @@
  */
 
 import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { unifiedModelEntries, type ProviderView } from '@cindy/model-providers';
 
 class MemLocalStorage {
   private store = new Map<string, string>();
@@ -405,4 +406,142 @@ it('restoring model visibility deletes overrides and follows future online defau
   expect(prefs.isModelVisibilityCustomized(target.agent, 'openai', target.modelId)).toBe(false);
   expect(prefs.isModelEnabled(target.agent, 'openai', { id: target.modelId, defaultEnabled: false })).toBe(false);
   expect(prefs.isModelEnabled(target.agent, 'openai', { id: target.modelId, defaultEnabled: true })).toBe(true);
+});
+
+
+describe('compact model defaults upgrade', () => {
+  const scopedKey = 'xdt:modelVisibilityPrefs:v1.owner.owner-a';
+  const markerKey = 'xdt:modelVisibilityPrefs:v1.defaults-migration.v1.owner.owner-a';
+  const provider = {
+    id: 'xd', name: 'Cindy AI', connected: true, source: 'builtin',
+    agents: ['claude-code', 'codex', 'pi'], auth: { method: 'token' },
+    routing: {
+      'claude-code': { modelPrefixes: ['chatgpt/'], wireProtocol: 'anthropic-messages' },
+      codex: { wireProtocol: 'openai-responses' },
+      pi: { wireProtocol: 'openai-responses' },
+    },
+    models: Object.fromEntries(['claude-code', 'codex', 'pi'].map((agent) => [agent,
+      ['fable-5', 'fable-5-1', 'gemini'].map((id) => ({
+        id: agent === 'claude-code' ? `chatgpt/${id}` : id,
+        name: id, contextWindow: 200000, efforts: [], defaultEffort: null,
+        defaultEnabled: agent === 'pi' && id !== 'fable-5',
+        nativeApi: 'google-generative-ai',
+      })),
+    ])),
+  } as unknown as ProviderView;
+
+  async function upgrade(ownerId = 'owner-a', generation = 1) {
+    const memory = await import('@/state/providerModelMemory');
+    const engines = await import('@/state/modelEnginePrefs');
+    const favorites = await import('@/state/modelFavorites');
+    memory.setProviderModelMemoryOwner(ownerId);
+    engines.setModelEnginePrefsOwner(ownerId);
+    favorites.setModelFavoritesOwner(ownerId);
+    const prefs = await loadModuleForOwner(ownerId, generation);
+    prefs.migrateModelVisibilityDefaults(ownerId, generation, [provider]);
+    return prefs;
+  }
+
+  it('keeps new-user defaults and does not manufacture compatibility selections', async () => {
+    const prefs = await upgrade();
+    expect(prefs.isModelEnabled('claude-code', 'xd', provider.models['claude-code']![2]!)).toBe(false);
+    expect(prefs.isModelEnabled('pi', 'xd', provider.models.pi![2]!)).toBe(true);
+    expect(JSON.parse(memStorage.getItem(scopedKey)!)).toEqual({});
+  });
+
+  it('preserves old switches, selected no-effort models, favorites and compatibility engines', async () => {
+    memStorage.setItem('xdt:modelVisibilityPrefs:v1', JSON.stringify({
+      'claude-code:xd:chatgpt/fable-5': true,
+      'claude-code:xd:chatgpt/fable-5-1': false,
+      'codex:xd:gemini': false,
+    }));
+    memStorage.setItem('xdt:providerModelMemory:v2:owner-a', JSON.stringify({
+      'codex:xd': { lastModel: 'fable-5', effortByModel: {}, fastByModel: {}, thinkingByModel: {} },
+    }));
+    memStorage.setItem('xdt:modelEnginePrefs:v1:owner-a', JSON.stringify({
+      'xd:gemini': { agent: 'cc' },
+    }));
+    const favorites = await import('@/state/modelFavorites');
+    favorites.setModelFavoritesOwner('owner-a');
+    favorites.addModelFavorite({ providerId: 'xd', modelId: 'fable-5', agent: 'pi' });
+    const prefs = await upgrade();
+    expect(prefs.isModelEnabled('claude-code', 'xd', { id: 'chatgpt/fable-5', defaultEnabled: false })).toBe(true);
+    expect(prefs.isModelEnabled('codex', 'xd', { id: 'fable-5', defaultEnabled: false })).toBe(true);
+    expect(prefs.isModelEnabled('pi', 'xd', { id: 'fable-5', defaultEnabled: false })).toBe(true);
+    // A row with only explicit off switches remains off even with new default-on routes.
+    expect(prefs.isModelEnabled('pi', 'xd', { id: 'fable-5-1', defaultEnabled: true })).toBe(false);
+    // An explicit engine choice on another route is preserved; this route's off switch still wins.
+    expect(prefs.isModelEnabled('claude-code', 'xd', { id: 'chatgpt/gemini', defaultEnabled: false })).toBe(true);
+    expect(prefs.isModelEnabled('codex', 'xd', { id: 'gemini', defaultEnabled: false })).toBe(false);
+  });
+
+  it('restores a previously chosen compatibility route in the actual unified candidates', async () => {
+    memStorage.setItem('xdt:modelEnginePrefs:v1:owner-a', JSON.stringify({ 'xd:gemini': { agent: 'cc' } }));
+    const prefs = await upgrade();
+    const entries = unifiedModelEntries({ providers: [provider], isVisible: (pid, model, agent) => prefs.isModelEnabled(agent, pid, model) });
+    const model = entries.find((entry) => entry.modelId === 'gemini')!;
+    expect(model.candidates).toContain('claude-code');
+    expect(model.capabilities['claude-code']?.protocolMode).toBe('compatibility');
+    expect(model.candidates).not.toContain('codex');
+    expect(syncModelVisibility).toHaveBeenLastCalledWith('owner-a', 1, expect.objectContaining({
+      'claude-code:xd:chatgpt/gemini': true,
+    }));
+  });
+
+  it('maps only declared same-engine prefixes, without enabling another model version', async () => {
+    memStorage.setItem('xdt:modelVisibilityPrefs:v1', JSON.stringify({ 'claude-code:xd:fable-5': true }));
+    const prefs = await upgrade();
+    expect(prefs.isModelEnabled('claude-code', 'xd', { id: 'chatgpt/fable-5', defaultEnabled: false })).toBe(true);
+    expect(prefs.isModelEnabled('claude-code', 'xd', { id: 'chatgpt/fable-5-1', defaultEnabled: false })).toBe(false);
+  });
+
+  it('does not repeat after restart or undo reset-to-defaults', async () => {
+    memStorage.setItem('xdt:modelEnginePrefs:v1:owner-a', JSON.stringify({ 'xd:gemini': { agent: 'cc' } }));
+    const prefs = await upgrade();
+    prefs.resetModelVisibilities('xd', [{ agent: 'claude-code', modelId: 'chatgpt/gemini' }]);
+    vi.resetModules();
+    const restarted = await upgrade();
+    expect(restarted.isModelVisibilityCustomized('claude-code', 'xd', 'chatgpt/gemini')).toBe(false);
+    expect(restarted.isModelEnabled('claude-code', 'xd', { id: 'chatgpt/gemini', defaultEnabled: false })).toBe(false);
+  });
+
+  it('defers until legacy import is safe, then honors the imported off switch', async () => {
+    memStorage.setItem('xdt:modelVisibilityPrefs:v1', JSON.stringify({ 'claude-code:xd:chatgpt/gemini': false }));
+    setOwnerClaim('owner-a', 1, true, false);
+    const prefs = await upgrade();
+    expect(memStorage.getItem(markerKey)).toBeNull();
+    setOwnerClaim('owner-a', 1);
+    prefs.migrateModelVisibilityDefaults('owner-a', 1, [provider]);
+    expect(prefs.isModelEnabled('pi', 'xd', { id: 'gemini', defaultEnabled: true })).toBe(false);
+    expect(memStorage.getItem(markerKey)).not.toBeNull();
+  });
+
+  it('isolates accounts and rejects stale catalog generations', async () => {
+    memStorage.setItem('xdt:modelEnginePrefs:v1:owner-a', JSON.stringify({ 'xd:gemini': { agent: 'cc' } }));
+    await upgrade();
+    setOwnerClaim('owner-b', 2, false, false, true);
+    const prefs = await upgrade('owner-b', 2);
+    expect(prefs.isModelEnabled('claude-code', 'xd', { id: 'chatgpt/gemini', defaultEnabled: false })).toBe(false);
+    const before = memStorage.getItem('xdt:modelVisibilityPrefs:v1.owner.owner-b');
+    prefs.migrateModelVisibilityDefaults('owner-a', 1, [provider]);
+    prefs.migrateModelVisibilityDefaults('owner-b', 1, [provider]);
+    expect(memStorage.getItem('xdt:modelVisibilityPrefs:v1.owner.owner-b')).toBe(before);
+  });
+
+  it('retries storage failure without claiming completion or losing a newer explicit off', async () => {
+    memStorage.setItem('xdt:modelEnginePrefs:v1:owner-a', JSON.stringify({ 'xd:gemini': { agent: 'cc' } }));
+    const original = memStorage.setItem.bind(memStorage);
+    const spy = vi.spyOn(memStorage, 'setItem').mockImplementation((key, value) => {
+      if (key === scopedKey && value.includes('chatgpt/gemini')) throw new Error('storage full');
+      original(key, value);
+    });
+    const prefs = await upgrade();
+    expect(memStorage.getItem(markerKey)).toBeNull();
+    expect(prefs.isModelEnabled('claude-code', 'xd', { id: 'chatgpt/gemini', defaultEnabled: false })).toBe(false);
+    spy.mockRestore();
+    prefs.setModelVisibility('claude-code', 'xd', 'chatgpt/gemini', false);
+    prefs.migrateModelVisibilityDefaults('owner-a', 1, [provider]);
+    expect(prefs.isModelEnabled('claude-code', 'xd', { id: 'chatgpt/gemini', defaultEnabled: false })).toBe(false);
+    expect(memStorage.getItem(markerKey)).not.toBeNull();
+  });
 });

--- a/apps/desktop/src/renderer/__tests__/modelVisibilityPrefs.test.ts
+++ b/apps/desktop/src/renderer/__tests__/modelVisibilityPrefs.test.ts
@@ -430,7 +430,7 @@ describe('compact model defaults upgrade', () => {
     ])),
   } as unknown as ProviderView;
 
-  async function upgrade(ownerId = 'owner-a', generation = 1) {
+  async function upgrade(ownerId = 'owner-a', generation = 1, snapshot = provider) {
     const memory = await import('@/state/providerModelMemory');
     const engines = await import('@/state/modelEnginePrefs');
     const favorites = await import('@/state/modelFavorites');
@@ -438,7 +438,7 @@ describe('compact model defaults upgrade', () => {
     engines.setModelEnginePrefsOwner(ownerId);
     favorites.setModelFavoritesOwner(ownerId);
     const prefs = await loadModuleForOwner(ownerId, generation);
-    prefs.migrateModelVisibilityDefaults(ownerId, generation, [provider]);
+    prefs.migrateModelVisibilityDefaults(ownerId, generation, [snapshot]);
     return prefs;
   }
 
@@ -503,6 +503,52 @@ describe('compact model defaults upgrade', () => {
     const restarted = await upgrade();
     expect(restarted.isModelVisibilityCustomized('claude-code', 'xd', 'chatgpt/gemini')).toBe(false);
     expect(restarted.isModelEnabled('claude-code', 'xd', { id: 'chatgpt/gemini', defaultEnabled: false })).toBe(false);
+  });
+
+  it.each(['claude-code', 'codex'] as const)(
+    'migrates late %s models after a Pi-only snapshot and restart without undoing a reset',
+    async (agent) => {
+      const engine = agent === 'claude-code' ? 'cc' : agent;
+      const wireId = agent === 'claude-code' ? 'chatgpt/fable-5' : 'fable-5';
+      memStorage.setItem('xdt:modelEnginePrefs:v1:owner-a', JSON.stringify({
+        'xd:fable-5': { agent: engine },
+        'xd:gemini': { agent: 'pi' },
+      }));
+      const partial = {
+        ...provider,
+        models: { pi: provider.models.pi, 'claude-code': [], codex: [] },
+      };
+      const prefs = await upgrade('owner-a', 1, partial);
+      expect(prefs.isModelVisibilityCustomized('pi', 'xd', 'gemini')).toBe(true);
+      expect(prefs.resetModelVisibilities('xd', [{ agent: 'pi', modelId: 'gemini' }])).toBe(true);
+
+      vi.resetModules();
+      const restarted = await upgrade();
+      expect(restarted.isModelEnabled(agent, 'xd', { id: wireId, defaultEnabled: false })).toBe(true);
+      expect(restarted.isModelVisibilityCustomized('pi', 'xd', 'gemini')).toBe(false);
+      const entries = unifiedModelEntries({
+        providers: [provider],
+        isVisible: (pid, model, kind) => restarted.isModelEnabled(kind, pid, model),
+      });
+      expect(entries.find((entry) => entry.modelId === 'fable-5')?.candidates).toContain(agent);
+    },
+  );
+
+  it('migrates a late model even when its agent already had other models', async () => {
+    memStorage.setItem('xdt:providerModelMemory:v2:owner-a', JSON.stringify({
+      'codex:xd': { lastModel: 'fable-5', effortByModel: {} },
+    }));
+    const partial = {
+      ...provider,
+      models: { ...provider.models, codex: provider.models.codex!.filter((model) => model.id !== 'fable-5') },
+    };
+    const prefs = await upgrade('owner-a', 1, partial);
+    prefs.migrateModelVisibilityDefaults('owner-a', 1, [provider]);
+    expect(prefs.isModelEnabled('codex', 'xd', { id: 'fable-5', defaultEnabled: false })).toBe(true);
+    expect(prefs.setModelVisibility('codex', 'xd', 'fable-5', false)).toBe(true);
+    prefs.migrateModelVisibilityDefaults('owner-a', 1, [partial]);
+    prefs.migrateModelVisibilityDefaults('owner-a', 1, [provider]);
+    expect(prefs.isModelEnabled('codex', 'xd', { id: 'fable-5', defaultEnabled: false })).toBe(false);
   });
 
   it('defers until legacy import is safe, then honors the imported off switch', async () => {

--- a/apps/desktop/src/renderer/__tests__/providerModelMemory.test.ts
+++ b/apps/desktop/src/renderer/__tests__/providerModelMemory.test.ts
@@ -564,7 +564,7 @@ describe('providerModelMemory v2 —— (agent, model) 全局 effort + provider 
     });
   });
 
-  it('v2 脏数据:非法 effort 条目过滤 / effortByModel 空槽丢弃 / 缺 lastModel 仍可查 effort', async () => {
+  it('v2 脏数据:非法 effort 条目过滤 / 保留无深度模型的 lastModel / 缺 lastModel 仍可查 effort', async () => {
     memStorage.setItem(
       'xdt:providerModelMemory:v2',
       JSON.stringify({
@@ -572,7 +572,7 @@ describe('providerModelMemory v2 —— (agent, model) 全局 effort + provider 
           lastModel: 'claude-opus-4-8',
           effortByModel: { 'claude-opus-4-8': 'high', bad: 42 }, // bad 非 string → 过滤
         },
-        'claude-code:xd': { lastModel: 'x', effortByModel: {} }, // 空 effortByModel → 整槽丢弃
+        'claude-code:xd': { lastModel: 'x', effortByModel: {} }, // 无 effort 仍保留 lastModel，choice 仍须有 effort
         'codex:openai': { effortByModel: { 'gpt-5.5': 'medium' } }, // 无 lastModel:effort 可查,choice undefined
       }),
     );
@@ -581,6 +581,8 @@ describe('providerModelMemory v2 —— (agent, model) 全局 effort + provider 
     expect(m.getProviderModelEffort('claude-code', 'anthropic', 'claude-opus-4-8')).toBe('high');
     expect(m.getProviderModelEffort('claude-code', 'anthropic', 'bad')).toBeUndefined();
     expect(m.getProviderModelChoice('claude-code', 'xd')).toBeUndefined();
+    expect(m.getProviderLastModel('claude-code', 'xd')).toBe('x');
+    expect(m.getProviderLastModel('codex', '*')).toBeUndefined();
     expect(m.getProviderModelEffort('codex', 'openai', 'gpt-5.5')).toBe('medium');
     expect(m.getProviderModelChoice('codex', 'openai')).toBeUndefined();
   });

--- a/apps/desktop/src/renderer/components/new-chat/ModelHarnessPicker.tsx
+++ b/apps/desktop/src/renderer/components/new-chat/ModelHarnessPicker.tsx
@@ -100,7 +100,7 @@ export function ModelHarnessPicker({
               </span>
               <span className="min-w-0 text-12 leading-4">{labelOf(engine)}</span>
             </button>
-            {engine === 'codex' && mode === 'compatibility' && (
+            {mode === 'compatibility' && (
               <span className="relative z-10 text-10 leading-4">
                 <ModelCompatibilityNotice />
               </span>

--- a/apps/desktop/src/renderer/components/new-chat/__tests__/ModelHarnessPicker.test.tsx
+++ b/apps/desktop/src/renderer/components/new-chat/__tests__/ModelHarnessPicker.test.tsx
@@ -64,7 +64,7 @@ describe('model harness choices', () => {
     expect(screen.getByRole('button', { name: /Codex · Responses · 兼容模式/ })).toBeTruthy();
     expect(container.querySelectorAll('[data-engine-capsule]')).toHaveLength(3);
     expect(screen.queryByText('原生支持')).toBeNull();
-    expect(screen.getAllByText('兼容模式')).toHaveLength(1);
+    expect(screen.getAllByText('兼容模式')).toHaveLength(2);
     expect(screen.queryByText('推荐 Pi')).toBeNull();
     expect(screen.queryByText('兼容')).toBeNull();
     expect(screen.queryByRole('combobox')).toBeNull();
@@ -90,7 +90,7 @@ describe('model harness choices', () => {
   it('opens the compatibility explanation without selecting its harness', async () => {
     const onChange = vi.fn();
     render(<ModelHarnessPicker entry={entry()} value="pi" onChange={onChange} />);
-    fireEvent.click(screen.getByRole('button', { name: '兼容模式' }));
+    fireEvent.click(screen.getAllByRole('button', { name: '兼容模式' })[0]!);
     expect((await screen.findByRole('tooltip')).textContent).toContain('建议有经验的用户使用');
     expect(onChange).not.toHaveBeenCalled();
   });

--- a/apps/desktop/src/renderer/lib/providersSnapshotStore.ts
+++ b/apps/desktop/src/renderer/lib/providersSnapshotStore.ts
@@ -5,6 +5,7 @@
  * agent capabilities；这样 useProviders.refetch 可以复用联合刷新而不形成循环依赖。
  */
 import type { ProviderView } from '@cindy/model-providers';
+import { migrateModelVisibilityDefaults } from '@/state/modelVisibilityPrefs';
 import {
   getDataOwnerGeneration,
   isDataOwnerGenerationCurrent,
@@ -86,6 +87,7 @@ export function commitProvidersSnapshot(
   next: ProvidersSnapshot,
 ): boolean {
   if (!isProvidersRefreshCurrent(token, next)) return false;
+  migrateModelVisibilityDefaults(next.dataOwnerId, next.ownerGeneration, next.providers);
   cachedProviders = next;
   for (const listener of providerListeners) listener(next);
   return true;

--- a/apps/desktop/src/renderer/state/modelVisibilityPrefs.ts
+++ b/apps/desktop/src/renderer/state/modelVisibilityPrefs.ts
@@ -15,8 +15,8 @@
  *
  * 与系统默认值的关系(对齐 CLAUDE.md 规则 20):
  *   - 本 store 只记 override(布尔),**不**快照系统默认值。
- *   - 未被 override 的模型永远跟随当前版本目录的 defaultEnabled —— 新增模型默认开,
- *     未自定义的用户随版本自然吃到。
+ *   - 未被 override 的模型跟随当前目录默认值。精简默认上线时，一次性把可恢复的历史
+ *     选模/收藏/引擎选择迁为 override；没有历史证据的条目继续跟随目录。
  *   - 「全部开启 / 全部关闭」是显式批量动作 → 为当前 agent 该来源的每个模型写显式 override。
  *
  * 谁读谁写:
@@ -31,7 +31,11 @@
 
 import { useSyncExternalStore } from 'react';
 
-import { isModelVisible } from '@cindy/model-providers';
+import { isModelVisible, type ProviderView } from '@cindy/model-providers';
+
+import { getProviderLastModel } from './providerModelMemory';
+import { getModelEngineOverride } from './modelEnginePrefs';
+import { listModelFavorites } from './modelFavorites';
 
 import type { AgentKind } from '@/hooks/useAgentCapabilities';
 import { createLogger } from '@/lib/logger';
@@ -40,6 +44,7 @@ const log = createLogger('ModelVisibilityPrefs');
 
 const LEGACY_STORAGE_KEY = 'xdt:modelVisibilityPrefs:v1';
 const STORAGE_KEY_PREFIX = `${LEGACY_STORAGE_KEY}.owner`;
+const DEFAULTS_MIGRATION_KEY_PREFIX = `${LEGACY_STORAGE_KEY}.defaults-migration.v1.owner`;
 const MIGRATION_COMPLETE_KEY_PREFIX = `${LEGACY_STORAGE_KEY}.migration-complete.owner`;
 
 /** override 表:key=`${agent}:${providerId}:${modelId}` → 用户显式设定的可见性。 */
@@ -286,6 +291,81 @@ export function setModelVisibilityOwner(
   load();
   version += 1;
   for (const listener of listeners) listener();
+}
+
+/**
+ * Upgrade the compact-defaults rollout once per owner/provider, before publishing the local
+ * catalog. Existing switches win; selected/favorited harnesses remain reachable even when
+ * their new catalog default is off. Never infer a model version replacement from its name.
+ * Other devices' catalogs must not enter this migration.
+ */
+export function migrateModelVisibilityDefaults(
+  ownerId: string | null,
+  ownerGeneration: number,
+  providers: readonly ProviderView[],
+): void {
+  if (!ownerId || ownerId !== activeOwnerId || ownerGeneration !== activeOwnerGeneration) return;
+  if (!ensureActiveOwnerReadyForWrites() || activeOwnerMigrationPending) return;
+  try {
+    const markerKey = `${DEFAULTS_MIGRATION_KEY_PREFIX}.${encodeURIComponent(ownerId)}`;
+    const raw: unknown = JSON.parse(window.localStorage.getItem(markerKey) ?? '[]');
+    const completed = new Set<string>(Array.isArray(raw) ? raw.filter((id) => typeof id === 'string') : []);
+    // Re-read: another renderer may have saved a switch since this window loaded its cache.
+    const previous = readStoredMap(window.localStorage.getItem(ownerStorageKey(ownerId)));
+    const next = { ...previous };
+    const favorites = listModelFavorites();
+    let changed = false;
+    for (const provider of providers) {
+      if (completed.has(provider.id)) continue;
+      const canonical = (agent: AgentKind, id: string) => {
+        for (const prefix of provider.routing[agent]?.modelPrefixes ?? []) {
+          if (id.startsWith(prefix)) return id.slice(prefix.length);
+        }
+        return id;
+      };
+      const rows = new Map<string, { agent: AgentKind; modelId: string }[]>();
+      for (const agent of provider.agents) {
+        for (const model of provider.models[agent] ?? []) {
+          const id = canonical(agent, model.id);
+          const row = rows.get(id) ?? [];
+          row.push({ agent, modelId: model.id });
+          rows.set(id, row);
+        }
+      }
+      // An unavailable/empty provider can be retried after its catalog loads.
+      if (!rows.size) continue;
+      for (const [modelId, routes] of rows) {
+        const oldValues = routes.map(({ agent, modelId: wireId }) =>
+          previous[keyOf(agent, provider.id, wireId)] ?? previous[keyOf(agent, provider.id, modelId)],
+        ).filter((value) => value !== undefined);
+        const explicitlyHidden = oldValues.length > 0 && oldValues.every((value) => value === false);
+        for (const { agent, modelId: wireId } of routes) {
+          const key = keyOf(agent, provider.id, wireId);
+          if (Object.hasOwn(next, key)) continue;
+          const aliasOverride = previous[keyOf(agent, provider.id, modelId)];
+          const engine = agent === 'claude-code' ? 'cc' : agent;
+          const lastModel = getProviderLastModel(agent, provider.id);
+          const wasSelected = (lastModel !== undefined && canonical(agent, lastModel) === modelId)
+            || (getModelEngineOverride(provider.id, modelId) ?? getModelEngineOverride(provider.id, wireId)) === engine
+            || favorites.some((favorite) => favorite.providerId === provider.id
+              && favorite.agent === engine && canonical(agent, favorite.modelId) === modelId);
+          // A hidden row must not reopen solely because a new harness now defaults to enabled.
+          const inherited = aliasOverride ?? (wasSelected ? true : explicitlyHidden ? false : undefined);
+          if (inherited !== undefined) {
+            next[key] = inherited;
+            changed = true;
+          }
+        }
+      }
+      completed.add(provider.id);
+    }
+    // Data first, marker second. A failed write leaves the upgrade retryable; existing values
+    // always win on retry. Keep the old keys, so downgrading does not lose old preferences.
+    if (changed && !persist(next, { operation: 'bulk', providerId: '*', enabled: true })) return;
+    window.localStorage.setItem(markerKey, JSON.stringify([...completed]));
+  } catch (error) {
+    log.warn('model defaults migration deferred', error);
+  }
 }
 
 /**

--- a/apps/desktop/src/renderer/state/modelVisibilityPrefs.ts
+++ b/apps/desktop/src/renderer/state/modelVisibilityPrefs.ts
@@ -294,7 +294,7 @@ export function setModelVisibilityOwner(
 }
 
 /**
- * Upgrade the compact-defaults rollout once per owner/provider, before publishing the local
+ * Upgrade the compact-defaults rollout once per owner/provider/agent/model, before publishing the local
  * catalog. Existing switches win; selected/favorited harnesses remain reachable even when
  * their new catalog default is off. Never infer a model version replacement from its name.
  * Other devices' catalogs must not enter this migration.
@@ -316,7 +316,6 @@ export function migrateModelVisibilityDefaults(
     const favorites = listModelFavorites();
     let changed = false;
     for (const provider of providers) {
-      if (completed.has(provider.id)) continue;
       const canonical = (agent: AgentKind, id: string) => {
         for (const prefix of provider.routing[agent]?.modelPrefixes ?? []) {
           if (id.startsWith(prefix)) return id.slice(prefix.length);
@@ -341,6 +340,11 @@ export function migrateModelVisibilityDefaults(
         const explicitlyHidden = oldValues.length > 0 && oldValues.every((value) => value === false);
         for (const { agent, modelId: wireId } of routes) {
           const key = keyOf(agent, provider.id, wireId);
+          // Pi's static catalog may arrive before other agents, and dynamic discovery can
+          // add models to an already nonempty agent. Complete only this observed route;
+          // retain its marker after reset/removal so later refreshes cannot revive it.
+          if (completed.has(key)) continue;
+          completed.add(key);
           if (Object.hasOwn(next, key)) continue;
           const aliasOverride = previous[keyOf(agent, provider.id, modelId)];
           const engine = agent === 'claude-code' ? 'cc' : agent;
@@ -357,7 +361,6 @@ export function migrateModelVisibilityDefaults(
           }
         }
       }
-      completed.add(provider.id);
     }
     // Data first, marker second. A failed write leaves the upgrade retryable; existing values
     // always win on retry. Keep the old keys, so downgrading does not lose old preferences.

--- a/apps/desktop/src/renderer/state/providerModelMemory.ts
+++ b/apps/desktop/src/renderer/state/providerModelMemory.ts
@@ -61,7 +61,7 @@ function storageKey(): string {
 /**
  * 单个来源槽:真实来源槽记「上次选中的模型」+ 兼容副本;`*` 槽记权威模型级 effort / fast。
  * lastModel 可为空(只记过 effort/fast 没法确定 lastModel 的脏数据);
- * effortByModel / fastByModel 至少一边非空才保留。
+ * lastModel 或任一模型预设非空就保留。
  */
 interface ProviderMemory {
   lastModel: string;
@@ -86,7 +86,7 @@ function presetKeyOf(agent: AgentKind): string {
 
 /**
  * 严格校验 v2:每个槽收敛成 { lastModel, effortByModel },其中 effortByModel 只保留
- * model / effort 都是非空 string 的条目;effortByModel 为空的槽整条丢弃(无可恢复信息)。
+ * model / effort 都是非空 string 的条目;lastModel 和预设都为空才丢弃。
  * 老版本 / 手改 localStorage 损坏时静默回退空表(不抛)。
  */
 function sanitize(raw: unknown): Record<string, ProviderMemory> {
@@ -127,6 +127,7 @@ function sanitize(raw: unknown): Record<string, ProviderMemory> {
       }
     }
     if (
+      !(typeof rec.lastModel === 'string' && rec.lastModel.length > 0) &&
       Object.keys(effortByModel).length === 0 &&
       Object.keys(fastByModel).length === 0 &&
       Object.keys(thinkingByModel).length === 0
@@ -572,6 +573,12 @@ function persist(
     // 只记最小操作；恢复可写后重放到最新共享快照，不能用本窗口旧整表覆盖另一 renderer。
     for (const op of ops) recordPendingOp(key, op, base);
   }
+}
+
+/** Last selected model, including models without an effort control. */
+export function getProviderLastModel(agent: AgentKind, providerId: string): string | undefined {
+  if (!providerId || providerId === MODEL_PRESET_SLOT_ID) return undefined;
+  return load()[keyOf(agent, providerId)]?.lastModel || undefined;
 }
 
 /**


### PR DESCRIPTION
## 这次改了什么

### 摘要

精简模型默认列表上线后，老用户过去选用的旧型号或兼容引擎可能跟着新默认隐藏。本 PR 在本地模型目录交给界面之前，将可恢复的历史选择一次性迁成可见性偏好；保留现有明确开关，给所有兼容引擎显示已有的「兼容模式」说明。

### 变更类型

- [x] `fix` 缺陷修复

### 范围

- 关联 Issue / 需求：发版前补齐老用户模型设置升级兼容。
- 本 PR 包含：按 owner/provider/agent/model 逐条迁移、无思考档位模型的上次选择保留、兼容模式标注、升级回归测试。
- 明确不包含：服务端目录/价格/推荐版本/真实调用协议调整；不同模型版本替换；无任何历史记录的旧默认值推测。
- 用户可见变化：历史选用的模型和兼容引擎恢复可见，明确关闭的路线保持关闭；兼容说明不再只标 Codex。
- 是否存在 breaking change：无。沿用原本的可见性 key 和布尔结构，附加独立完成标记，旧记录不删除。

### 迁移口径（新老用户差异）

| 原配置 | 升级结果 |
| --- | --- |
| 新用户，无历史选择 | 继续跟随当前精简默认，不批量打开兼容引擎 |
| 某引擎/来源/模型已有明确开关 | 原 true/false 最高优先，目录新默认不覆盖 |
| 没有开关，但记录了该来源上次选用、收藏或手动引擎选择 | 对应模型/引擎补 true，包括新默认隐藏的旧型号和兼容路线 |
| 同一模型已有开关全为 false，另一个引擎没有历史选择 | 未配置路线继承关闭，避免新增默认引擎把该行重新点亮；另一路线有明确选择历史则保留该选择 |
| 只有声明的桥接前缀不同 | 同一引擎的旧规范 ID 开关映射到实际 wire ID，不合并不同型号/版本 |
| 迁移后点恢复默认 | 删除可见性 override，后续刷新/重启不重复迁移，继续跟随目录 |
| 切换账号 | 数据和完成标记按账号隔离，过期目录不迁移 |

没有被保存下来的历史默认开启状态无法可靠还原，仍跟随当前目录；本 PR 不承诺凭空恢复全部旧默认。已下架、停用、未连接或需要付费的路线仍受原有可用性检查，开启显示不等于实际服务可调用。

旧全局配置必须先完成 Main 认领与安全导入；并发旧客户端导致导入待定时，本次迁移也等待，目录刷新后重试。完成状态只记录已经出现的来源/引擎/模型路线；Pi 静态目录先出现不会结束 Claude/Codex 动态路线的迁移，同一引擎晚到的模型也会继续处理。空目录不写任何路线完成标记。先保存数据再写完成标记，写入失败保留重试机会，新显式值优先。

### UI 变化

- 复用已有 ModelCompatibilityNotice：所有 compatibility 引擎显示说明，点击说明不切换引擎。未增加开关/弹窗/文案。
- 引用的设计规范：docs/design-rules/DESIGN.md §2 语义颜色、§3 字号、§10 Light/Dark 双模式：沿用原组件与语义 token；两种模式均未实机目检。

## 怎么验证的

### 自动验证

```text
pnpm --filter desktop exec vitest run src/renderer/__tests__/modelVisibilityPrefs.test.ts src/renderer/__tests__/providerModelMemory.test.ts src/renderer/components/new-chat/__tests__/ModelHarnessPicker.test.tsx
结果：69 项通过。覆盖迁移输入、实际 unifiedModelEntries 候选、兼容说明点击、新旧用户、账号隔离、重启/恢复默认、旧导入延迟和写盘失败重试。
pnpm test:unit:related
结果：初版全量通过；本轮修复只涉及 Desktop 状态迁移与测试，使用下列命令复验。
pnpm --filter desktop run --if-present typecheck
结果：通过。
pnpm --filter desktop exec vitest run src/renderer/__tests__/modelVisibilityPrefs.test.ts
结果：33 项通过；新增 3 条动态目录延迟回归在旧实现上均失败，修复后均通过。
pnpm test:unit:related --workspace apps/desktop
结果：通过（test:runner 与 Desktop unit 全部通过）。
git diff --check
结果：通过。
```

### 手工验证

供 QA 发版前执行（本 PR 尚未实机执行）：
1. 在旧版测试档案启用一个旧型号；关闭一个较新型号；选择并收藏一个 Claude Code 或 Codex 兼容模式；记录设置页开关及模型配置浮层。
2. 使用同一测试档案升级，进入「设置 → 模型供应商」：旧显式开关保持，上次选择/收藏的模型仍启用，关闭的模型不会仅因新增引擎重新启用。
3. 打开输入框模型选择器 → 对应模型配置：保留原引擎入口；兼容路线显示「兼容模式」，点击解释不切换选中项。
4. 分别发送一条消息，确认实际模型及引擎符合选择。服务调用失败独立记录原始错误，不能把“显示启用”当作可调用证明。
5. 关闭一个迁移恢复的模型，重启验证不复活；对另一个模型恢复默认，刷新/重启验证不再次补回旧选择。
6. 模拟 Pi 目录先返回、Claude/Codex 动态发现稍后完成，再检查历史兼容路线出现；同一引擎分批返回模型也应补齐，已恢复默认的早到模型不得复活。
7. 新建干净测试档案并切换另一账号：仍为精简默认，不出现前一个账号的迁移结果。检查浅色、深色下兼容标注。

### 未执行的验证

真实旧用户档案升级、真实模型请求、桌面 Light/Dark 目检未执行。本补丁未重新启动 DEV；已有 latest-main DEV 不含本 PR。

## 风险

### 风险分类

- [x] 权限 / 安全 / 用户数据
- [x] 其他：本地偏好的一次性迁移；不涉及数据库 migration、凭证或网络协议变化。

### 影响与回滚

- 影响范围：Desktop 本地账号的模型可见性；沿用原镜像同步到 Main。远程设备目录不进入本次迁移。
- 回滚 / 降级方式：回退代码不会丢旧显式记录；已补的普通可见性 override 仍可由设置页关闭或恢复默认。原全局 key 不删除；额外完成标记旧版忽略。

### 提交前检查

- [x] 已 review 完整 diff
- [x] 每个 commit 都带 DCO 签名（git commit -s）
- [x] UI 改动已在「UI 变化」注明引用的设计规范章节
- [x] 未提交凭证、令牌或授权文件
- [x] 已补充必要文档（迁移口径与 QA 流程在本 PR）
- [x] 已确认测试结果或说明未执行原因
