### PR TITLE
fix(pi): 修正 Anthropic OAuth 请求构造并保留原生 beta 头

### DIFF
--- a/apps/desktop/src/main/maker-host/__tests__/claudeProxyScopeGate.test.ts
+++ b/apps/desktop/src/main/maker-host/__tests__/claudeProxyScopeGate.test.ts
@@ -521,7 +521,6 @@ describe('pi routingTransform — xdt session header selects the Pi provider rou
       upstreamOverride: 'https://api.anthropic.com',
       headerOverride: {
         'anthropic-version': '2023-06-01',
-        'anthropic-beta': 'oauth-2025-04-20',
         authorization: 'Bearer pi-claude-token',
       },
       headerDelete: [
@@ -643,7 +642,6 @@ describe('pi routingTransform — xdt session header selects the Pi provider rou
       upstreamOverride: 'https://api.anthropic.com',
       headerOverride: {
         'anthropic-version': '2023-06-01',
-        'anthropic-beta': 'oauth-2025-04-20',
         authorization: 'Bearer pi-claude-token',
       },
       headerDelete: [

--- a/apps/desktop/src/main/maker-host/__tests__/piNativeProviders.test.ts
+++ b/apps/desktop/src/main/maker-host/__tests__/piNativeProviders.test.ts
@@ -853,8 +853,12 @@ describe('buildPiNativeProvidersFromConfigs', () => {
       sourceProviderId: 'anthropic',
       baseUrl: 'http://127.0.0.1:4567/',
       inheritModels: true,
+      apiKeyEnvVar: 'CINDY_PI_ANTHROPIC_PROXY_KEY',
       models: [{ id: 'claude-opus-5', wireId: 'claude-opus-5' }],
     });
+    // Pi 按 `sk-ant-oat` 前缀识别 OAuth 形态,才会自己拼 claude-code/oauth/server-side-fallback
+    // 等 beta 头与 Claude Code 身份;占位值不能是真 token 形态之外的普通字串。
+    expect(env.CINDY_PI_ANTHROPIC_PROXY_KEY).toContain('sk-ant-oat');
     expect(providers[1]).toMatchObject({
       sourceProviderId: 'openai',
       baseUrl: 'http://127.0.0.1:4567/',

--- a/apps/desktop/src/main/maker-host/__tests__/providerRoute.test.ts
+++ b/apps/desktop/src/main/maker-host/__tests__/providerRoute.test.ts
@@ -317,7 +317,6 @@ describe('pi: provider-aware Anthropic wire routing', () => {
       upstreamOverride: ANTHROPIC_DIRECT_UPSTREAM,
       headerOverride: {
         'anthropic-version': '2023-06-01',
-        'anthropic-beta': 'oauth-2025-04-20',
         authorization: 'Bearer claude-live-token',
       },
       headerDelete: ['x-api-key'],

--- a/apps/desktop/src/main/maker-host/pi-host.ts
+++ b/apps/desktop/src/main/maker-host/pi-host.ts
@@ -121,6 +121,16 @@ const PI_SESSION_ID_ENV = 'CINDY_PI_SESSION_ID';
 const PI_SESSION_TOKEN_ENV = 'CINDY_PI_SESSION_TOKEN';
 const PI_PROVIDER_AUTH_PLACEHOLDER_KEY = 'cindy-pi-provider-auth-placeholder';
 const PI_OPENAI_PROXY_KEY_ENV = 'CINDY_PI_OPENAI_PROXY_KEY';
+const PI_ANTHROPIC_PROXY_KEY_ENV = 'CINDY_PI_ANTHROPIC_PROXY_KEY';
+/**
+ * Claude 订阅占位 token。Pi 的 anthropic 适配器按 `apiKey.includes('sk-ant-oat')` 判定
+ * OAuth 形态,命中后才走原生订阅请求构造:Bearer 鉴权、`claude-code-20250219,oauth-2025-04-20`
+ * 加各 beta(fine-grained tool streaming / server-side fallback 等)、Claude Code 身份 system
+ * 段与 `claude-cli` UA。真 token 由 loopback proxy 按 session 覆盖 `authorization`,
+ * 占位值绝不出本机。用普通字串会让 Pi 按 x-api-key 形态发请求,proxy 再补 beta 头就会
+ * 与 body 里 Pi 已注入的 `fallbacks` 等字段脱节(400 `fallbacks: Extra inputs are not permitted`)。
+ */
+const PI_ANTHROPIC_PROXY_PLACEHOLDER_TOKEN = 'sk-ant-oat01-cindy-pi-proxy-placeholder';
 const PI_PROVIDER_HEADER = 'x-cindy-pi-provider-id';
 
 export interface PiBundledModelInfo {
@@ -544,6 +554,7 @@ export function buildPiSubscriptionNativeProviders(
   const env: Record<string, string> = {
     [PI_OPENAI_PROXY_KEY_ENV]: piOpenaiProxyPlaceholderJwt(),
     [PI_XAI_PROXY_API_KEY_ENV]: PI_PROVIDER_AUTH_PLACEHOLDER_KEY,
+    [PI_ANTHROPIC_PROXY_KEY_ENV]: PI_ANTHROPIC_PROXY_PLACEHOLDER_TOKEN,
   };
   const add = (
     sourceProviderId: 'anthropic' | 'openai' | 'xai',
@@ -606,6 +617,7 @@ export function buildPiSubscriptionNativeProviders(
       name,
       baseUrl,
       inheritModels: true,
+      ...(sourceProviderId === 'anthropic' ? { apiKeyEnvVar: PI_ANTHROPIC_PROXY_KEY_ENV } : {}),
       ...(sourceProviderId === 'openai' ? { apiKeyEnvVar: PI_OPENAI_PROXY_KEY_ENV } : {}),
       ...(sourceProviderId === 'xai' ? { apiKeyEnvVar: PI_XAI_PROXY_API_KEY_ENV } : {}),
       modelIdAliases,

--- a/packages/model-providers/src/__tests__/user-provider.test.ts
+++ b/packages/model-providers/src/__tests__/user-provider.test.ts
@@ -1236,10 +1236,15 @@ describe('custom model defaults with partial registry metadata', () => {
       models: [{
         id: 'sparse-model', name: 'Sparse model',
         efforts: ['low', 'medium', 'high'],
-        ...(declared !== undefined ? { defaultEffort: declared } : {}),
         routes: [{ providerId: 'relay', modelId: 'sparse-model', agents: ['codex'] }],
       }],
     };
+    if (declared === null) {
+      // @ts-expect-error Exercise malformed registry metadata outside the wire contract.
+      modelRegistry.models[0].defaultEffort = declared;
+    } else if (declared !== undefined) {
+      modelRegistry.models[0].defaultEffort = declared;
+    }
     const provider = buildUserProvider({
       id: 'relay', name: 'Custom relay',
       runtimes: { codex: { baseUrl: 'https://relay.example/v1', models: [{ id: 'sparse-model', name: 'My model' }] } },

--- a/packages/model-providers/src/builtin.ts
+++ b/packages/model-providers/src/builtin.ts
@@ -137,10 +137,11 @@ const ANTHROPIC_PROVIDER: Provider = {
       upstream: 'https://api.anthropic.com',
       wireProtocol: 'anthropic-messages',
       authStrategy: 'provider-oauth-header',
-      headerOverride: {
-        'anthropic-version': '2023-06-01',
-        'anthropic-beta': 'oauth-2025-04-20',
-      },
+      // Pi 拿的是 `sk-ant-oat` 形态占位 token(pi-host),自己就按原生订阅方式发请求:
+      // `anthropic-beta` 由 Pi 按模型拼好(oauth / claude-code / server-side-fallback 等),
+      // 这里只换 authorization,不得覆盖 beta 头——覆盖会让 body 里 Pi 注入的 `fallbacks`
+      // 失去 beta 声明,官方端点 400 `fallbacks: Extra inputs are not permitted`。
+      headerOverride: { 'anthropic-version': '2023-06-01' },
       headerDelete: ['x-api-key'],
     },
   },


### PR DESCRIPTION
## 这次改了什么

### 摘要

Cindy 为 Pi 的 Anthropic 订阅 provider 使用普通占位 key，导致 Pi 未进入原生 OAuth 请求构造分支。代理还会覆盖整个 `anthropic-beta`，丢失模型相关 beta 声明，使请求体中的 `fallbacks` 与请求头不匹配。

本 PR 使用 OAuth 形态的无效占位 token，让 Pi 自行构造身份 system 段、鉴权头、UA 和工具名映射；真实 token 仍由本机代理按 session 注入。代理保留 Pi 生成的完整 beta 头及服务端 fallback 配置。

### 变更类型

- [x] `fix` 缺陷修复

### 范围

- 关联 Issue / 需求：Pi 接入 Anthropic 订阅时的请求构造错误。
- 本 PR 包含：OAuth 占位 env、删除 beta 覆盖、更新相关断言，以及修正一个阻塞类型检查的异常输入测试夹具，保留原测试覆盖。
- 明确不包含：订阅计费资格变更、移除 `fallbacks`、服务端修改。
- 用户可见变化：Usage credits 可用时，已实测 Pi 的 Sonnet 5、Opus 5 响应和工具往返成功。
- 是否存在 breaking change：无配置或存储格式变更。

### UI 变化

- 引用的设计规范：不涉及。

## 怎么验证的

### 自动验证

使用 Node 22.22.3，与仓库 `.nvmrc` 一致。Rebase 到上游 `main`（`a7798117`）后，在最终提交 `9b34367e5` 上执行：

```text
mise exec node@22.22.3 -- pnpm test:unit:related
通过。脚本相对 Fork 旧主干检测到上游的依赖/CI 变更，自动扩大为全仓 unit 门禁；
test:runner 与全部适用 workspace 通过，未缩减覆盖。

mise exec node@22.22.3 -- pnpm --filter desktop run --if-present typecheck
通过。

mise exec node@22.22.3 -- pnpm --filter @cindy/model-providers run --if-present typecheck
该包无 typecheck script，按规则跳过；另执行以下类型检查：

mise exec node@22.22.3 -- pnpm --filter @cindy/model-providers exec tsc --noEmit
通过。

git diff a7798117..HEAD --check
通过。

pnpm check:dco --base a7798117e250ce910f7ab7d8e99a0ddfb2d21748
通过：本次 1 个 commit 带有效 Signed-off-by。
```

环境说明：此前 Node 24 的 Desktop threads 池发生 SIGSEGV；切换 Node 22 并通过仓库依赖脚本修复 `better-sqlite3` ABI 后，完整门禁通过。未修改测试调度配置。

### 手工验证

macOS Global 隔离开发版，通过 Computer Use 操作 UI，并核对实例来自本次 checkout。以下实机验证在 rebase 前完成，rebase 后本 PR 的功能 diff 未改变。Usage credits 可用后：

| 验证项 | 结果 |
|---|---|
| Pi / Sonnet 5 文本响应 | 返回 `PI_SONNET5_OK` |
| Sonnet 5 工具调用 | 成功执行 `printf PI_TOOL_ROUNDTRIP_OK` |
| 工具结果续接 | 正确返回 `PI_TOOL_ROUNDTRIP_OK` |
| 同一任务切换 Pi / Opus 5 | 返回 `PI_OPUS5_OK` |

本轮未出现原来的 429 `"Error"`、`fallbacks` 字段错误或 `out of extra usage`。

充值前 Pi 请求返回额外用量错误，同期 Claude Code / Opus 5 对照成功；充值后 Pi 成功。本次验证不证明 Pi 请求可消耗套餐内额度，也未核验账单扣款。

### 未执行的验证

- Opus 4.6：测试时 Pi 模型选择器未找到匹配项。
- 服务端实际触发 fallback：未模拟上游故障。
- Windows / Linux 实机验证：未执行。
- Rebase 后未重复实机 E2E；重新执行自动门禁。

## 风险

### 风险分类

- [x] system prompt
- [x] 协议兼容
- [x] 权限 / 安全 / 用户数据
- [x] 其他：请求能否使用套餐内额度由上游决定。

### 影响与回滚

- 影响范围：Desktop 本机 Pi 的 Anthropic 订阅路径。Pi 原生 OAuth 分支会注入身份 system 段并双向映射工具名，已验证一次 bash 往返。
- 凭证处理：占位 token 无实际授权能力；`models.json` 使用 env 引用，真实 token 仍由本机代理注入。
- 回滚 / 降级方式：撤销本提交并重启 Desktop，无数据迁移；回滚会重新引入原请求构造缺陷。

### 提交前检查

- [x] 已 review 完整 diff
- [x] 每个 commit 都带 DCO 签名（`git commit -s`）；最终由 PR 上的 DCO check 校验，无需 CLA
- [x] 不涉及 UI 改动
- [x] 未提交真实凭证、令牌或授权文件
- [x] 无需新增使用文档
- [x] 已确认测试结果或说明未执行原因
