### PR TITLE
fix(desktop): prevent accidental account menu switches

### DIFF
--- a/apps/desktop/src/renderer/__tests__/userInfoSectionMobileDownload.test.tsx
+++ b/apps/desktop/src/renderer/__tests__/userInfoSectionMobileDownload.test.tsx
@@ -1,22 +1,33 @@
 // @vitest-environment jsdom
 
-import { cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { act, cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
-const { authState, betaChannelState, listAccounts, navigate, syncAccounts, switchAccount } =
-  vi.hoisted(() => ({
-    authState: {
-      user: { name: 'Cindy user', avatar: null } as { name: string; avatar: string | null } | null,
-      mode: 'cloud' as 'cloud' | 'local',
-      dataOwnerId: 'owner-a' as string | null,
-      isCanary: false,
-    },
-    betaChannelState: { enableBeta: false, isCustomized: false, loading: false },
-    listAccounts: vi.fn(),
-    navigate: vi.fn(),
-    syncAccounts: vi.fn(),
-    switchAccount: vi.fn(),
-  }));
+const {
+  authState,
+  betaChannelState,
+  confirm,
+  runningSnapshot,
+  listAccounts,
+  navigate,
+  syncAccounts,
+  switchAccount,
+} = vi.hoisted(() => ({
+  authState: {
+    user: { name: 'Cindy user', avatar: null } as { name: string; avatar: string | null } | null,
+    mode: 'cloud' as 'cloud' | 'local',
+    dataOwnerId: 'owner-a' as string | null,
+    isCanary: false,
+  },
+  betaChannelState: { enableBeta: false, isCustomized: false, loading: false },
+  confirm: vi.fn(),
+  runningSnapshot: new Map<string, { isRunning: boolean }>(),
+  listAccounts: vi.fn(),
+  navigate: vi.fn(),
+  syncAccounts: vi.fn(),
+  switchAccount: vi.fn(),
+}));
 
 vi.mock('react-i18next', () => ({
   useTranslation: () => ({
@@ -39,11 +50,11 @@ vi.mock('@/contexts/AuthContext', () => ({
 }));
 
 vi.mock('@/components/ui/confirm-dialog-provider', () => ({
-  useOptionalConfirmDialog: () => ({ confirm: vi.fn().mockResolvedValue(true) }),
+  useOptionalConfirmDialog: () => ({ confirm }),
 }));
 
 vi.mock('@/lib/makerChatStore', () => ({
-  makerChatStore: { getRunningSnapshot: () => new Map() },
+  makerChatStore: { getRunningSnapshot: () => runningSnapshot },
 }));
 
 vi.mock('@/hooks/useUpdateStatus', () => ({
@@ -90,6 +101,8 @@ vi.mock('@/components/sidebar/MobileDownloadDialog', () => ({
 import { UserInfoSection } from '@/components/sidebar/UserInfoSection';
 
 beforeEach(() => {
+  confirm.mockReset().mockResolvedValue(true);
+  runningSnapshot.clear();
   navigate.mockClear();
   authState.user = { name: 'Cindy user', avatar: null };
   authState.mode = 'cloud';
@@ -214,9 +227,83 @@ describe('UserInfoSection mobile download entry', () => {
       'true',
     );
 
-    fireEvent.click(screen.getByRole('menuitem', { name: /Other user/ }));
+    await userEvent.click(screen.getByRole('menuitem', { name: /Other user/ }));
     await waitFor(() => expect(switchAccount).toHaveBeenCalledWith('other'));
   });
+
+  it.each([false, true])(
+    'does not switch on a release over an asynchronously loaded account (collapsed=%s)',
+    async (isCollapsed) => {
+      render(<UserInfoSection isCollapsed={isCollapsed} />);
+
+      // The opening press starts on the trigger. Account rows arrive before
+      // release; Radix must not turn that release into an account selection.
+      fireEvent.pointerDown(screen.getByRole('button', { name: 'sidebar.user.moreLabel' }), {
+        button: 0,
+        ctrlKey: false,
+      });
+      const account = await screen.findByRole('menuitem', { name: /Other user/ });
+      await act(async () => {
+        fireEvent.pointerUp(account, { button: 0 });
+        // Flush the asynchronous running-task check used by switchSavedAccount.
+        await new Promise((resolve) => setTimeout(resolve, 0));
+      });
+      expect(switchAccount).not.toHaveBeenCalled();
+      expect(screen.getByRole('menu')).toBeTruthy();
+    },
+  );
+
+  it.each(['Enter', ' '])('still switches with keyboard selection (%s)', async (key) => {
+    render(<UserInfoSection isCollapsed={false} />);
+    fireEvent.keyDown(screen.getByRole('button', { name: 'sidebar.user.moreLabel' }), {
+      key: 'Enter',
+    });
+    const account = await screen.findByRole('menuitem', { name: /Other user/ });
+    act(() => account.focus());
+    fireEvent.keyDown(account, { key });
+    await waitFor(() => expect(switchAccount).toHaveBeenCalledWith('other'));
+  });
+
+  it.each([false, true])('keeps running-task confirmation (confirmed=%s)', async (confirmed) => {
+    runningSnapshot.set('running-session', { isRunning: true });
+    confirm.mockResolvedValue(confirmed);
+    render(<UserInfoSection isCollapsed={false} />);
+    fireEvent.pointerDown(screen.getByRole('button', { name: 'sidebar.user.moreLabel' }), {
+      button: 0,
+      ctrlKey: false,
+    });
+    await userEvent.click(await screen.findByRole('menuitem', { name: /Other user/ }));
+    await waitFor(() => expect(confirm).toHaveBeenCalledOnce());
+    if (confirmed) {
+      await waitFor(() => expect(switchAccount).toHaveBeenCalledWith('other'));
+    } else {
+      expect(switchAccount).not.toHaveBeenCalled();
+    }
+  });
+
+  it.each([false, true])(
+    'does not switch during repeated open/dismiss (collapsed=%s)',
+    async (isCollapsed) => {
+      render(<UserInfoSection isCollapsed={isCollapsed} />);
+      const trigger = screen.getByRole('button', { name: 'sidebar.user.moreLabel' });
+      for (const closeWith of ['trigger', 'outside', 'escape', 'trigger', 'outside']) {
+        fireEvent.pointerDown(trigger, { button: 0, ctrlKey: false });
+        await screen.findByRole('menuitem', { name: /Other user/ });
+        if (closeWith === 'escape') {
+          fireEvent.keyDown(screen.getByRole('menu'), { key: 'Escape' });
+        } else {
+          fireEvent.pointerDown(closeWith === 'trigger' ? trigger : document.body, {
+            button: 0,
+            ctrlKey: false,
+            pointerType: 'mouse',
+          });
+        }
+        await waitFor(() => expect(screen.queryByRole('menu')).toBeNull());
+      }
+      expect(switchAccount).not.toHaveBeenCalled();
+      expect(confirm).not.toHaveBeenCalled();
+    },
+  );
 
   it('drops the previous account menu snapshot as soon as the owner changes', async () => {
     const view = render(<UserInfoSection isCollapsed={false} />);

--- a/apps/desktop/src/renderer/components/sidebar/UserInfoSection.tsx
+++ b/apps/desktop/src/renderer/components/sidebar/UserInfoSection.tsx
@@ -243,6 +243,10 @@ export function UserInfoSection({ isCollapsed, onOpenUpdateNotice }: UserInfoSec
                 account.isCurrent || switchingAccountKey !== null || !accountsMutationAllowed
               }
               onSelect={() => void switchSavedAccount(account)}
+              // Radix synthesizes a click when a press starts outside this item
+              // and releases over it. Async account rows can move under that
+              // release; require a normal click or keyboard selection instead.
+              onPointerUp={(event) => event.preventDefault()}
               className="gap-2.5 py-2"
             >
               <AccountMenuAvatar account={account} />


### PR DESCRIPTION
## 这次改了什么

### 摘要

账号菜单在 pointerdown 时打开，账号行随后异步加载。Radix MenuItem 会把“在别处按下、在账号项上抬起”转换为合成 click，导致没有完整点击账号项也会切换身份。

仅在已保存账号项阻止该 pointerup 默认处理；正常点击和 Enter / 空格仍通过原有 onSelect 切换，并保留运行中任务确认。

### 变更类型

- [x] `fix` 缺陷修复

### 范围

- 关联 Issue：Fixes #4027
- 本 PR 包含：账号菜单事件修复和行为回归测试。
- 明确不包含：账号存储、认证 IPC、后端、全局菜单 primitive 或账号列表加载策略变更。
- 用户可见变化：打开菜单后，仅释放在账号项上不再触发账号切换。
- Breaking change：无。

### UI 变化

- 引用的设计规范：`docs/design-rules/DESIGN.md` §4 Select & Dropdown、§14.2 Focus Management、§10 Light / Dark Dual-Mode Delivery Gate。
- 复用现有菜单、键盘与焦点机制；没有新增布局、颜色或文案，Light / Dark 共用同一事件修复。
- 未进行 Light / Dark 实机目检；无视觉截图。

## 怎么验证的

### 自动验证

```text
pnpm test:unit:related
结果：通过（apps/desktop related 2，122.0s）

pnpm --filter desktop run --if-present typecheck
结果：通过

pnpm --filter desktop exec vitest run src/renderer/__tests__/userInfoSectionMobileDownload.test.tsx
结果：通过（16 tests）

pnpm --filter desktop exec eslint src/renderer/components/sidebar/UserInfoSection.tsx src/renderer/__tests__/userInfoSectionMobileDownload.test.tsx
结果：通过

pnpm check:dco
结果：通过（1 commit signed off）
```

新增回归覆盖展开/折叠侧栏下的 pointerup 误触、明确点击、Enter / 空格、反复点击触发器/空白处/Esc 关闭，以及运行中任务确认与取消。误触用例在修复前会调用 `switchAccount('other')`，修复后不再调用。

### 手工验证

未进行真实账号操作。

### 未执行的验证

- 未在 Windows / macOS 的完整 Electron 客户端复现和目检，未对报告人的录屏路径做实机复测。复现证据来自真实 Radix 组件的 jsdom 事件测试。
- Codex / Pi runtime 下载在安装 postinstall 阶段超时，不影响相关单测和类型检查。

## 风险

### 风险分类

- [x] 其他：账号切换入口的交互行为

### 影响与回滚

- 影响范围：Desktop 已保存账号菜单。账号项不再支持“别处按下后拖入账号项松开”的快捷选择；必须正常点击或键盘选择。其他菜单项不受影响。
- 不改变认证、账号数据、权限、协议或数据库。
- 回滚：revert 本 PR。

### 提交前检查

- [x] 已 review 完整 diff
- [x] 每个 commit 都带 DCO 签名
- [x] UI 改动已注明设计规范
- [x] 未提交凭证、令牌或授权文件
- [x] 已补充必要文档（本 PR 说明）
- [x] 已确认测试结果或说明未执行原因