### PR TITLE
perf(file-browser): 合并文件树刷新请求

### DIFF
--- a/apps/desktop/src/renderer/features/cc-agent/workdir-browse/hooks/__tests__/useFileTree.test.tsx
+++ b/apps/desktop/src/renderer/features/cc-agent/workdir-browse/hooks/__tests__/useFileTree.test.tsx
@@ -1,0 +1,117 @@
+// @vitest-environment jsdom
+
+import { act, renderHook, waitFor } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+type FileTreeEvent = { workdir: string; relPath: string };
+type Deferred<T> = {
+  promise: Promise<T>;
+  resolve: (value: T) => void;
+};
+
+const mocks = vi.hoisted(() => {
+  const eventCallbacks: Array<(event: FileTreeEvent) => void> = [];
+  return {
+    eventCallbacks,
+    fileBrowserApiFor: vi.fn(),
+    isDeviceTooOldError: vi.fn(() => false),
+    listDir: vi.fn(),
+    loadExpandedSet: vi.fn(() => new Set<string>()),
+    onFileTreeEventFor: vi.fn(
+      (_deviceId: string | null | undefined, cb: (event: FileTreeEvent) => void) => {
+        eventCallbacks.push(cb);
+        return () => {
+          const index = eventCallbacks.indexOf(cb);
+          if (index >= 0) eventCallbacks.splice(index, 1);
+        };
+      },
+    ),
+    saveExpandedSet: vi.fn(),
+    startWatchFor: vi.fn(async () => undefined),
+    stopWatchFor: vi.fn(async () => undefined),
+  };
+});
+
+vi.mock('@/lib/fileBrowserTransport', () => ({
+  fileBrowserApiFor: mocks.fileBrowserApiFor,
+  isDeviceTooOldError: mocks.isDeviceTooOldError,
+  onFileTreeEventFor: mocks.onFileTreeEventFor,
+  startWatchFor: mocks.startWatchFor,
+  stopWatchFor: mocks.stopWatchFor,
+}));
+
+vi.mock('@/lib/logger', () => ({
+  createLogger: () => ({ warn: vi.fn() }),
+}));
+
+vi.mock('../../lib/expandedStore', () => ({
+  loadExpandedSet: mocks.loadExpandedSet,
+  saveExpandedSet: mocks.saveExpandedSet,
+}));
+
+import { useFileTree, type DirEntry } from '../useFileTree';
+
+function deferred<T>(): Deferred<T> {
+  let resolve!: (value: T) => void;
+  const promise = new Promise<T>((res) => {
+    resolve = res;
+  });
+  return { promise, resolve };
+}
+
+describe('useFileTree refresh scheduling', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mocks.eventCallbacks.length = 0;
+    mocks.fileBrowserApiFor.mockReturnValue({ listDir: mocks.listDir });
+  });
+
+  it('limits a directory refresh to one trailing scan during a watcher storm', async () => {
+    const entries: readonly DirEntry[] = [
+      { name: 'src', relPath: 'src', type: 'directory', size: 0, mtimeMs: 1 },
+    ];
+    const pending: Array<Deferred<readonly DirEntry[]>> = [];
+    mocks.listDir.mockImplementation(() => {
+      if (mocks.listDir.mock.calls.length === 1) return Promise.resolve(entries);
+      const request = deferred<readonly DirEntry[]>();
+      pending.push(request);
+      return request.promise;
+    });
+
+    const view = renderHook(() => useFileTree({ workdir: '/workdir' }));
+    await waitFor(() => expect(view.result.current.initialLoading).toBe(false));
+    expect(mocks.listDir).toHaveBeenCalledTimes(1);
+    const emitEvent = mocks.eventCallbacks[0];
+    expect(emitEvent).toBeDefined();
+
+    await act(async () => {
+      emitEvent({ workdir: '/workdir', relPath: 'first.md' });
+      await new Promise((resolve) => setTimeout(resolve, 70));
+    });
+    expect(mocks.listDir).toHaveBeenCalledTimes(2);
+
+    await act(async () => {
+      emitEvent({ workdir: '/workdir', relPath: 'second.md' });
+      await new Promise((resolve) => setTimeout(resolve, 70));
+    });
+    pending[0].resolve(entries);
+    await waitFor(() => expect(mocks.listDir).toHaveBeenCalledTimes(3));
+
+    await act(async () => {
+      for (let i = 0; i < 10; i += 1) {
+        emitEvent({ workdir: '/workdir', relPath: `storm-${i}.md` });
+      }
+      await new Promise((resolve) => setTimeout(resolve, 70));
+    });
+    expect(mocks.listDir).toHaveBeenCalledTimes(3);
+
+    await act(async () => {
+      pending[1].resolve(entries);
+      await Promise.resolve();
+    });
+    await waitFor(() => expect(view.result.current.loadingPaths.size).toBe(0));
+    expect(mocks.listDir).toHaveBeenCalledTimes(3);
+
+    view.unmount();
+  });
+});

--- a/apps/desktop/src/renderer/features/cc-agent/workdir-browse/hooks/useFileTree.ts
+++ b/apps/desktop/src/renderer/features/cc-agent/workdir-browse/hooks/useFileTree.ts
@@ -193,6 +193,8 @@ interface FileTreeStore {
 interface DirectoryRefresh {
   promise: Promise<void>;
   trailing: boolean;
+  /** At most one trailing scan may be queued for this refresh lifecycle. */
+  trailingScheduled: boolean;
 }
 
 /** 全局 stores 表。key 由 storeKey() 算,同 (workdir, options) 共享同一份。 */
@@ -292,17 +294,24 @@ function setDirectoryLoading(store: FileTreeStore, relPath: string, loading: boo
 /**
  * Fetch one directory at a time. Calls made while the request is running set
  * one trailing bit; the request loop consumes that bit after the current
- * result is applied. This keeps watcher storms from producing a request per
- * event while still observing a change that arrived during the first scan.
+ * result is applied. The trailing budget is capped at one scan per lifecycle,
+ * so a watcher storm cannot keep the loop alive indefinitely.
  */
 function fetchDir(store: FileTreeStore, relPath: string): Promise<void> {
   const current = store.inFlight.get(relPath);
   if (current) {
-    current.trailing = true;
+    if (!current.trailingScheduled) {
+      current.trailingScheduled = true;
+      current.trailing = true;
+    }
     return current.promise;
   }
 
-  const refresh: DirectoryRefresh = { promise: Promise.resolve(), trailing: false };
+  const refresh: DirectoryRefresh = {
+    promise: Promise.resolve(),
+    trailing: false,
+    trailingScheduled: false,
+  };
   refresh.promise = (async () => {
     do {
       refresh.trailing = false;

--- a/apps/desktop/src/renderer/features/cc-agent/workdir-browse/hooks/useFileTree.ts
+++ b/apps/desktop/src/renderer/features/cc-agent/workdir-browse/hooks/useFileTree.ts
@@ -117,6 +117,7 @@ export interface UseFileTreeReturn {
 }
 
 const ROOT_KEY = '';
+const EVENT_COALESCE_MS = 50;
 
 /**
  * 结构等价判定 —— name/type/relPath 完全相同(顺序也相同, listDir 是稳定排序),
@@ -177,11 +178,21 @@ interface FileTreeStore {
   /** 同一 relPath 的并发 listDir,latest 赢:每次开 listDir 前 bump,resolve
    *  时比对 —— 不一致就丢结果。 */
   tokens: Map<string, number>;
+  /** Single-flight directory requests plus one dirty bit for a trailing scan. */
+  inFlight: Map<string, DirectoryRefresh>;
+  /** Parent directories observed by the IPC listener in the current turn. */
+  pendingEventParents: Set<string>;
+  eventFlushTimer: ReturnType<typeof setTimeout> | null;
   /** chokidar listener 取消函数。首个挂载时挂、refCount 归 0 时调。 */
   watcherOff: (() => void) | null;
   /** ref count + listeners 用来驱动 lifecycle 和重渲订阅。 */
   refCount: number;
   listeners: Set<() => void>;
+}
+
+interface DirectoryRefresh {
+  promise: Promise<void>;
+  trailing: boolean;
 }
 
 /** 全局 stores 表。key 由 storeKey() 算,同 (workdir, options) 共享同一份。 */
@@ -216,6 +227,9 @@ function getOrCreateStore(opts: Required<UseFileTreeOptions>): FileTreeStore {
       loadError: null,
     },
     tokens: new Map(),
+    inFlight: new Map(),
+    pendingEventParents: new Set(),
+    eventFlushTimer: null,
     watcherOff: null,
     refCount: 0,
     listeners: new Set(),
@@ -226,18 +240,11 @@ function getOrCreateStore(opts: Required<UseFileTreeOptions>): FileTreeStore {
 
 /** 把 fetchDir 抽成 store 方法 —— 所有订阅者(无论挂在哪个 hook 实例)共享同
  *  一份 entries / loadingPaths 状态。 */
-async function fetchDir(store: FileTreeStore, relPath: string): Promise<void> {
+async function fetchDirOnce(store: FileTreeStore, relPath: string): Promise<void> {
   const myToken = (store.tokens.get(relPath) ?? 0) + 1;
   store.tokens.set(relPath, myToken);
 
   // loadingPaths 设置
-  {
-    const nextLoading = new Set(store.snapshot.loadingPaths);
-    nextLoading.add(relPath);
-    store.snapshot = { ...store.snapshot, loadingPaths: nextLoading };
-    emit(store);
-  }
-
   try {
     const list = await fileBrowserApiFor(store.deviceId).listDir({
       workdir: store.workdir,
@@ -269,14 +276,98 @@ async function fetchDir(store: FileTreeStore, relPath: string): Promise<void> {
       emit(store);
     }
     // Keep prior state; user can refresh manually.
-  } finally {
-    if (store.tokens.get(relPath) === myToken) {
-      const nextLoading = new Set(store.snapshot.loadingPaths);
-      nextLoading.delete(relPath);
-      store.snapshot = { ...store.snapshot, loadingPaths: nextLoading };
-      emit(store);
-    }
   }
+}
+
+function setDirectoryLoading(store: FileTreeStore, relPath: string, loading: boolean): void {
+  const alreadyLoading = store.snapshot.loadingPaths.has(relPath);
+  if (alreadyLoading === loading) return;
+  const nextLoading = new Set(store.snapshot.loadingPaths);
+  if (loading) nextLoading.add(relPath);
+  else nextLoading.delete(relPath);
+  store.snapshot = { ...store.snapshot, loadingPaths: nextLoading };
+  emit(store);
+}
+
+/**
+ * Fetch one directory at a time. Calls made while the request is running set
+ * one trailing bit; the request loop consumes that bit after the current
+ * result is applied. This keeps watcher storms from producing a request per
+ * event while still observing a change that arrived during the first scan.
+ */
+function fetchDir(store: FileTreeStore, relPath: string): Promise<void> {
+  const current = store.inFlight.get(relPath);
+  if (current) {
+    current.trailing = true;
+    return current.promise;
+  }
+
+  const refresh: DirectoryRefresh = { promise: Promise.resolve(), trailing: false };
+  refresh.promise = (async () => {
+    do {
+      refresh.trailing = false;
+      await fetchDirOnce(store, relPath);
+    } while (refresh.trailing);
+  })().finally(() => {
+    if (store.inFlight.get(relPath) === refresh) {
+      store.inFlight.delete(relPath);
+    }
+    setDirectoryLoading(store, relPath, false);
+  });
+  store.inFlight.set(relPath, refresh);
+  setDirectoryLoading(store, relPath, true);
+  return refresh.promise;
+}
+
+function parentPath(relPath: string): string {
+  const slashIdx = relPath.lastIndexOf('/');
+  return slashIdx < 0 ? ROOT_KEY : relPath.slice(0, slashIdx);
+}
+
+function addDocModeAncestors(
+  store: FileTreeStore,
+  parent: string,
+  targets: Set<string>,
+): void {
+  let cursor: string | null = parent;
+  while (cursor !== null) {
+    // An ancestor can still be warming during initial restore. Include an
+    // in-flight directory as a target so a watcher event arriving in that
+    // window gets a trailing refresh instead of being lost before the first
+    // result is committed.
+    if (store.snapshot.entries.has(cursor) || store.inFlight.has(cursor)) {
+      targets.add(cursor);
+    }
+    if (cursor === ROOT_KEY) break;
+    cursor = parentPath(cursor);
+  }
+}
+
+/**
+ * Coalesce synchronous IPC deliveries by parent directory. The IPC contract
+ * intentionally remains one event per changed path; only tree refresh work is
+ * merged here. In doc mode every cached ancestor is retained because a
+ * directory can disappear when its last visible descendant is removed.
+ */
+function queueEventRefresh(store: FileTreeStore, eventRelPath: string): void {
+  store.pendingEventParents.add(parentPath(eventRelPath));
+  if (store.eventFlushTimer) return;
+  store.eventFlushTimer = setTimeout(() => {
+    store.eventFlushTimer = null;
+    const parents = [...store.pendingEventParents];
+    store.pendingEventParents.clear();
+    if (store.refCount === 0) return;
+
+    const targets = new Set<string>();
+    for (const parent of parents) {
+      if (store.docMode) {
+        addDocModeAncestors(store, parent, targets);
+      } else if (store.snapshot.entries.has(parent) || store.inFlight.has(parent)) {
+        targets.add(parent);
+      }
+    }
+    for (const target of targets) void fetchDir(store, target);
+  }, EVENT_COALESCE_MS);
 }
 
 /** 首次挂载触发:initial fetch + 恢复 localStorage expanded + 启动 watcher。
@@ -301,22 +392,7 @@ async function initStore(store: FileTreeStore): Promise<void> {
 
     store.watcherOff = onFileTreeEventFor(store.deviceId, (event) => {
       if (event.workdir !== store.workdir) return;
-      const slashIdx = event.relPath.lastIndexOf('/');
-      const parent = slashIdx < 0 ? ROOT_KEY : event.relPath.slice(0, slashIdx);
-      const currentEntries = store.snapshot.entries;
-      if (store.docMode) {
-        // Doc mode wrinkle (见函数顶部大注释):一条 doc 文件 add/unlink 会改变整条
-        // 祖先链的可见性,需要 refetch 所有已 cache 的祖先。
-        let cursor: string | null = parent;
-        while (cursor !== null) {
-          if (currentEntries.has(cursor)) void fetchDir(store, cursor);
-          if (cursor === ROOT_KEY) break;
-          const idx = cursor.lastIndexOf('/');
-          cursor = idx < 0 ? ROOT_KEY : cursor.slice(0, idx);
-        }
-      } else if (currentEntries.has(parent)) {
-        void fetchDir(store, parent);
-      }
+      queueEventRefresh(store, event.relPath);
     });
   }
 
@@ -332,6 +408,10 @@ async function initStore(store: FileTreeStore): Promise<void> {
 
 /** 最后一个订阅者离开:停 watcher、从 stores 表移除。store 对象被回收。 */
 function disposeStore(store: FileTreeStore): void {
+  if (store.eventFlushTimer) clearTimeout(store.eventFlushTimer);
+  store.eventFlushTimer = null;
+  store.pendingEventParents.clear();
+  store.inFlight.clear();
   if (store.watcherOff) {
     store.watcherOff();
     store.watcherOff = null;

--- a/packages/file-browser-core/src/scanner.ts
+++ b/packages/file-browser-core/src/scanner.ts
@@ -170,14 +170,37 @@ function isDocModeFile(name: string): boolean {
  * Implementation:
  *   - Sibling subdirs are walked in parallel (Promise.all over the level)
  *     so a top-level dir like apps/desktop/ doesn't serialize 50 subwalks.
- *   - A shared `Found` cell short-circuits: any walk that's about to start
- *     bails if some other branch has already returned true.
+ *   - Overlapping probes share only the in-flight `readdir` for each absolute
+ *     directory. Traversals keep their own `Found` cell, preserving sibling
+ *     short-circuiting without allowing one probe's result to contaminate
+ *     another; completed directory reads are never cached.
  *
  * Worst case (deep subtree with no matching file): walks the whole subtree
  * once, but in parallel. BUILTIN_IGNORE prunes node_modules / Library /
  * etc., which are the only realistic huge subtrees.
  */
 type Found = { v: boolean };
+
+/** In-flight-only sharing for overlapping doc-mode directory reads. */
+const docDirentsInFlight = new Map<string, Promise<Dirent[]>>();
+
+function readDocDirents(abs: string): Promise<Dirent[]> {
+  const key = path.resolve(abs);
+  const current = docDirentsInFlight.get(key);
+  if (current) return current;
+
+  const read = fs.readdir(abs, { withFileTypes: true });
+  docDirentsInFlight.set(key, read);
+  void read.then(
+    () => {
+      if (docDirentsInFlight.get(key) === read) docDirentsInFlight.delete(key);
+    },
+    () => {
+      if (docDirentsInFlight.get(key) === read) docDirentsInFlight.delete(key);
+    },
+  );
+  return read;
+}
 
 async function hasDocDescendantInner(
   abs: string,
@@ -188,7 +211,7 @@ async function hasDocDescendantInner(
   if (found.v) return true;
   let dirents: Dirent[];
   try {
-    dirents = await fs.readdir(abs, { withFileTypes: true });
+    dirents = await readDocDirents(abs);
   } catch {
     return false;
   }
@@ -208,8 +231,8 @@ async function hasDocDescendantInner(
     }
   }
   if (subdirs.length === 0 || found.v) return found.v;
-  // Pass 2: recurse all subdirs in parallel. Each child re-checks `found`
-  // at entry, so a fast hit anywhere in the tree stops new work cheaply.
+  // Pass 2: recurse all subdirs in parallel. Each traversal keeps the same
+  // `Found` cell, so a fast hit stops deeper work in sibling branches.
   const results = await Promise.all(
     subdirs.map((s) =>
       hasDocDescendantInner(path.join(abs, s.name), s.childRel, matcher, found),
@@ -240,7 +263,13 @@ export async function listDir(
 ): Promise<DirEntry[]> {
   const sub = assertInsideWorkdir(workdir, relPath);
   const abs = sub === '' ? workdir : path.join(workdir, sub);
-  const dirents = await fs.readdir(abs, { withFileTypes: true });
+  // In doc mode this top-level read participates in the same in-flight map as
+  // recursive descendant probes. An overlapping `listDir('src')` can thus
+  // reuse the read already started while listing the root, without retaining
+  // a completed snapshot.
+  const dirents = opts.docMode
+    ? await readDocDirents(abs)
+    : await fs.readdir(abs, { withFileTypes: true });
 
   // Process all entries in parallel. With docMode on, each surviving subdir
   // triggers a recursive hasDocDescendant probe — running siblings in


### PR DESCRIPTION
## 这次改了什么

### 摘要

按目录合并文件树 watcher 刷新事件，为同一目录提供单飞请求和最多一次尾随刷新；doc mode 只共享在途目录读取，避免重复扫描并保持最新可见性。

### 变更类型

- [ ] `feat` 新功能
- [ ] `fix` 缺陷修复
- [x] `refactor` / `perf` 重构或性能优化
- [ ] `docs` / `test` / `chore` 文档、测试或工程维护
- [ ] 其他：

### 范围

- 关联 Issue / 需求：无
- 本 PR 包含：renderer 文件树刷新调度、file-browser-core doc mode 扫描去重。
- 明确不包含：watcher IPC 事件格式和逐文件事件语义未改变。
- 用户可见变化：文件树在文件变更集中发生时减少重复刷新和重复扫描。
- 是否存在 breaking change：无。

### UI 变化

不涉及：仅调整文件树数据刷新调度，不改变界面布局、样式、交互或文案。

- 引用的设计规范：不涉及：纯逻辑重构，无视觉/交互/文案变化。

## 怎么验证的

### 自动验证

`pnpm --filter @cindy/file-browser-core test`：24 个测试通过。

`pnpm --filter desktop exec vitest run src/main/file-browser/__tests__/watcher.test.ts`：10 个测试通过。

`pnpm --filter desktop exec vitest run src/renderer/features/cc-agent/workdir-browse/__tests__/FileTreeView.imagePreview.test.tsx`：4 个测试通过。

`pnpm --filter desktop typecheck`：通过。

`pnpm test:unit:related`：file-browser-core 与 remote-file-service 通过；Desktop 2421 个测试通过，8 个既有 Windows symlink 用例失败。

### 手工验证

未执行：无专门的实机文件树手动验证。

### 未执行的验证

未执行：`pnpm test:unit`，按任务要求未运行。

## 风险

### 风险分类

- [x] 无已知风险
- [ ] SQLite / migration
- [ ] system prompt
- [ ] 协议兼容
- [ ] 权限 / 安全 / 用户数据
- [ ] 存量插件兼容（批准状态 / 指纹 / manifest 校验 / 安装布局 / 包格式）
- [ ] 原生层 / fingerprint / OTA
- [ ] 跨平台差异
- [ ] 其他：

### 影响与回滚

不涉及移动端 runtime fingerprint、原生配置或原生依赖，不触发移动端冷更。若需回滚，回退本 PR commit 即可。related 门禁中的 Windows symlink 失败来自现有 cindy-media 测试环境权限，不是本 PR 引入。

### 提交前检查

- [x] 已 review 完整 diff
- [x] 每个 commit 都带 DCO 签名（`git commit -s`）
- [x] UI 变更已在“UI 变化”注明（本 PR 不涉及 UI）
- [x] 未提交凭证、令牌或授权文件
- [x] 已确认测试结果并说明未执行项