### PR TITLE
fix(desktop): preserve Ask input across turn completion

### DIFF
--- a/apps/desktop/src/renderer/__tests__/askUserDoneRace.test.ts
+++ b/apps/desktop/src/renderer/__tests__/askUserDoneRace.test.ts
@@ -63,9 +63,10 @@ vi.mock('@/lib/composerDraftStore', () => ({
 }));
 
 import { updateContent as updateMessageContent } from '@/lib/messageService';
-import { makerChatStore } from '@/lib/makerChatStore';
+import { makerChatStore, type AskUserQuestionItem } from '@/lib/makerChatStore';
 
 const SESSION_ID = 'ask-user-done-race';
+const getPendingInteractions = vi.fn<() => Promise<unknown[]>>(async () => []);
 
 function emptyProjection(sessionId: string) {
   return {
@@ -115,7 +116,7 @@ function installElectronBridge(): void {
         },
         send: vi.fn(async () => ({ accepted: true })),
         generateTitle: vi.fn(async () => ({ title: 't' })),
-        getPendingInteractions: vi.fn(async () => []),
+        getPendingInteractions,
         setPlanMode: vi.fn(async () => {}),
         resolveInteraction: vi.fn(async () => ({ accepted: true })),
         abortSession: vi.fn(async () => {}),
@@ -131,13 +132,16 @@ function installElectronBridge(): void {
   };
 }
 
-function emitAskUserRequest(requestId: string): void {
+function emitAskUserRequest(
+  requestId: string,
+  questions: AskUserQuestionItem[] = [{ question: '桌面版这次要采用哪种范围？', header: '词典编辑' }],
+): void {
   onInteractionRequest?.({
     sessionId: SESSION_ID,
     request: {
       kind: 'ask_user_question',
       requestId,
-      questions: [{ question: '桌面版这次要采用哪种范围？', header: '词典编辑' }],
+      questions,
     },
     persistId: `persist-${requestId}`,
   });
@@ -164,6 +168,7 @@ function pendingAskStatuses(): string[] {
 describe('ask_user 与 done 的时序', () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    getPendingInteractions.mockReset().mockResolvedValue([]);
     installElectronBridge();
     makerChatStore.__teardownGlobalListeners();
     makerChatStore.purgeSession(SESSION_ID);
@@ -186,6 +191,71 @@ describe('ask_user 与 done 的时序', () => {
     const snap = makerChatStore.getSnapshot(SESSION_ID);
     expect(snap.pendingAskUser?.requestId).toBe('ask-1');
     expect(pendingAskStatuses()).toEqual(['pending']);
+  });
+
+  it('codex:done 的 Host 快照重放保留答题状态及 questions 引用', async () => {
+    makerChatStore.setSessionRuntime(SESSION_ID, { agentKind: 'codex' });
+    emitAskUserRequest('ask-replay', [{
+      question: 'Pick details',
+      header: 'Details',
+      multiSelect: true,
+      options: [{ label: 'A', description: 'First option' }],
+    }]);
+    makerChatStore.setAskUserDraft(SESSION_ID, {
+      requestId: 'ask-replay', currentIndex: 0, answers: {},
+    });
+    makerChatStore.setAskUserViewerState(SESSION_ID, 'minimized');
+    const before = makerChatStore.getSnapshot(SESSION_ID);
+    // A fresh IPC payload, including different object key order, is still the same question.
+    const questions: AskUserQuestionItem[] = [{
+      options: [{ description: 'First option', label: 'A' }],
+      multiSelect: true,
+      header: 'Details',
+      question: 'Pick details',
+    }];
+    getPendingInteractions.mockResolvedValue([{
+      request: { kind: 'ask_user_question', requestId: 'ask-replay', questions },
+      persistId: 'persist-ask-replay',
+    }]);
+
+    emitDone('codex');
+
+    // Wait for the actual async snapshot replay, not just the synchronous done reducer.
+    await vi.waitFor(() => {
+      expect(makerChatStore.getSnapshot(SESSION_ID).messages.find(
+        (m) => m.askUserRequestId === 'ask-replay',
+      )?.askUserQuestions).toBe(questions);
+    });
+    const after = makerChatStore.getSnapshot(SESSION_ID);
+    // The prompt restores local unsubmitted text/checkboxes whenever questions changes identity.
+    expect(after.pendingAskUser).toBe(before.pendingAskUser);
+    expect(after.askUserDraft).toBe(before.askUserDraft);
+    expect(after.askUserViewerState).toBe('minimized');
+    expect(pendingAskStatuses()).toEqual(['pending']);
+  });
+
+  it.each([
+    ['new request', 'ask-new', [{ question: 'Pick', options: [{ label: 'A' }] }]],
+    ['changed question', 'ask-edit', [{ question: 'Different', options: [{ label: 'A' }] }]],
+    ['changed option', 'ask-edit', [{ question: 'Pick', options: [{ label: 'B' }] }]],
+    ['changed mode', 'ask-edit', [{ question: 'Pick', options: [{ label: 'A' }], multiSelect: true }]],
+  ] as const)('%s still initializes a fresh question', (_name, requestId, questions) => {
+    emitAskUserRequest('ask-edit', [{ question: 'Pick', options: [{ label: 'A' }] }]);
+    makerChatStore.setAskUserDraft(SESSION_ID, {
+      requestId: 'ask-edit', currentIndex: 0, answers: {},
+    });
+    makerChatStore.setAskUserViewerState(SESSION_ID, 'minimized');
+    const before = makerChatStore.getSnapshot(SESSION_ID);
+
+    emitAskUserRequest(requestId, questions.map((q) => ({
+      ...q, options: q.options.map((option) => ({ ...option })),
+    })));
+
+    const after = makerChatStore.getSnapshot(SESSION_ID);
+    expect(after.pendingAskUser).not.toBe(before.pendingAskUser);
+    expect(after.pendingAskUser?.questions).toEqual(questions);
+    expect(after.askUserDraft).toBeNull();
+    expect(after.askUserViewerState).toBe('expanded');
   });
 
   it('claude:turn 结束仍将 pending 提问卡标过期', () => {

--- a/apps/desktop/src/renderer/__tests__/askUserQuestionActionLabels.test.tsx
+++ b/apps/desktop/src/renderer/__tests__/askUserQuestionActionLabels.test.tsx
@@ -22,6 +22,7 @@ function renderAskUser(
 ) {
   return render(
     createElement(AskUserQuestionPrompt, {
+      sessionId: 'ask-actions',
       pending,
       onAnswer,
       viewerState: 'expanded',

--- a/apps/desktop/src/renderer/__tests__/askUserQuestionIdentity.test.tsx
+++ b/apps/desktop/src/renderer/__tests__/askUserQuestionIdentity.test.tsx
@@ -5,7 +5,7 @@ import { cleanup, fireEvent, render, waitFor } from '@testing-library/react';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 import i18n from '@/i18n';
-import type { PendingAskUser } from '@/lib/makerChatStore';
+import type { AskUserQuestionItem, PendingAskUser } from '@/lib/makerChatStore';
 import { AskUserQuestionPrompt } from '../components/new-chat/AskUserQuestionPrompt';
 
 beforeEach(async () => {
@@ -74,6 +74,49 @@ describe('AskUserQuestionPrompt identity', () => {
       'First question': 'First draft answer',
       'Second question': JSON.stringify(['A', 'Unsubmitted detail']),
     });
+  });
+
+  it.each([
+    { label: 'question text', update: { question: 'Updated second question' } },
+    { label: 'options', update: { options: [{ label: 'C' }] } },
+    { label: 'selection mode', update: { multiSelect: false } },
+    { label: 'header', update: { header: 'Updated header' } },
+    { label: 'option description', update: { options: [{ label: 'A', description: 'Updated meaning' }, { label: 'B' }] } },
+    { label: 'question count', update: null },
+  ])('resets answers when $label changes within the same request', async ({ update }) => {
+    const props = makeProps();
+    const view = render(createElement(AskUserQuestionPrompt, props));
+    const oldInput = await fillBothQuestions(view);
+    props.onDraftChange.mockClear();
+    const questions: AskUserQuestionItem[] = update
+      ? [props.pending.questions[0], { ...props.pending.questions[1], ...update }]
+      : [props.pending.questions[0]];
+
+    // The store clears the draft for changed content, even with the same requestId.
+    view.rerender(createElement(AskUserQuestionPrompt, {
+      ...props,
+      pending: { ...props.pending, questions },
+    }));
+
+    expect(oldInput.isConnected).toBe(false);
+    expect(view.queryByText('First question')).not.toBeNull();
+    expect(view.queryByPlaceholderText('Type your answer…')).toBeNull();
+    expect(props.onDraftChange).toHaveBeenLastCalledWith({
+      requestId: 'request-1', currentIndex: 0, answers: {},
+    });
+
+    fireEvent.click(view.getByText('First option'));
+    const expectedAnswers: Record<string, string> = { 'First question': 'First option' };
+    if (questions.length > 1) {
+      const second = questions[1];
+      await waitFor(() => expect(view.queryByText(second.question)).not.toBeNull());
+      await waitFor(() => expect(view.queryByRole('button', { name: /Back/ })).not.toBeNull());
+      const label = second.options![0].label;
+      fireEvent.click(view.getByText(label));
+      if (second.multiSelect) fireEvent.click(view.getByRole('button', { name: 'Submit' }));
+      expectedAnswers[second.question] = second.multiSelect ? JSON.stringify([label]) : label;
+    }
+    expect(props.onAnswer).toHaveBeenCalledWith('request-1', expectedAnswers);
   });
 
   it.each([

--- a/apps/desktop/src/renderer/__tests__/askUserQuestionIdentity.test.tsx
+++ b/apps/desktop/src/renderer/__tests__/askUserQuestionIdentity.test.tsx
@@ -1,0 +1,114 @@
+// @vitest-environment jsdom
+
+import { createElement } from 'react';
+import { cleanup, fireEvent, render, waitFor } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import i18n from '@/i18n';
+import type { PendingAskUser } from '@/lib/makerChatStore';
+import { AskUserQuestionPrompt } from '../components/new-chat/AskUserQuestionPrompt';
+
+beforeEach(async () => {
+  await i18n.changeLanguage('en');
+});
+
+afterEach(() => cleanup());
+
+function makeProps() {
+  const pending: PendingAskUser = {
+    requestId: 'request-1',
+    questions: [
+      { question: 'First question', options: [{ label: 'First option' }] },
+      {
+        question: 'Second question',
+        multiSelect: true,
+        options: [{ label: 'A' }, { label: 'B' }],
+      },
+    ],
+  };
+  return {
+    sessionId: 'session-1',
+    pending,
+    onAnswer: vi.fn(),
+    viewerState: 'expanded' as const,
+    onViewerStateChange: vi.fn(),
+    draft: null,
+    onDraftChange: vi.fn(),
+  };
+}
+
+async function fillBothQuestions(view: ReturnType<typeof render>) {
+  fireEvent.click(view.getByText('Type something else…'));
+  fireEvent.change(view.getByPlaceholderText('Type your answer…'), {
+    target: { value: 'First draft answer' },
+  });
+  fireEvent.click(view.getByTestId('ask-user-custom-next'));
+  await waitFor(() => expect(view.queryByText('Second question')).not.toBeNull());
+  await waitFor(() => expect(view.queryByRole('button', { name: /Back/ })).not.toBeNull());
+  fireEvent.click(view.getByText('A'));
+  fireEvent.click(view.getByText('Type something else…'));
+  const input = view.getByPlaceholderText('Type your answer…') as HTMLTextAreaElement;
+  fireEvent.change(input, { target: { value: 'Unsubmitted detail' } });
+  return input;
+}
+
+describe('AskUserQuestionPrompt identity', () => {
+  it('keeps text, selections and question progress when the same card is synchronized', async () => {
+    const props = makeProps();
+    const view = render(createElement(AskUserQuestionPrompt, props));
+    const input = await fillBothQuestions(view);
+
+    // The store keeps questions stable for an unchanged Host snapshot. Render
+    // the real exported component; the test deliberately supplies no React key.
+    view.rerender(createElement(AskUserQuestionPrompt, {
+      ...props,
+      pending: { ...props.pending },
+    }));
+
+    expect(view.getByPlaceholderText('Type your answer…')).toBe(input);
+    expect(input.value).toBe('Unsubmitted detail');
+    expect(view.queryByText('Second question')).not.toBeNull();
+    expect(view.queryByText('2/2')).not.toBeNull();
+    fireEvent.click(view.getByRole('button', { name: 'Submit' }));
+    expect(props.onAnswer).toHaveBeenCalledWith('request-1', {
+      'First question': 'First draft answer',
+      'Second question': JSON.stringify(['A', 'Unsubmitted detail']),
+    });
+  });
+
+  it.each([
+    { label: 'request', sessionId: 'session-1', requestId: 'request-2' },
+    { label: 'session', sessionId: 'session-2', requestId: 'request-1' },
+  ])('resets old answers when the $label changes without closing the card', async ({ sessionId, requestId }) => {
+    const props = makeProps();
+    const view = render(createElement(AskUserQuestionPrompt, props));
+    const oldInput = await fillBothQuestions(view);
+    props.onDraftChange.mockClear();
+
+    // Even identical question text and array identity must not carry answers
+    // into another request/session. A normal close/reopen is not involved.
+    view.rerender(createElement(AskUserQuestionPrompt, {
+      ...props,
+      sessionId,
+      pending: { ...props.pending, requestId },
+    }));
+
+    expect(oldInput.isConnected).toBe(false);
+    expect(view.queryByText('First question')).not.toBeNull();
+    expect(view.queryByText('1/2')).not.toBeNull();
+    expect(view.queryByPlaceholderText('Type your answer…')).toBeNull();
+    expect(props.onDraftChange).toHaveBeenCalledWith({ requestId, currentIndex: 0, answers: {} });
+
+    fireEvent.click(view.getByText('First option'));
+    await waitFor(() => expect(view.queryByText('Second question')).not.toBeNull());
+    await waitFor(() => expect(view.queryByRole('button', { name: /Back/ })).not.toBeNull());
+    expect(view.queryByPlaceholderText('Type your answer…')).toBeNull();
+    expect((view.getByRole('button', { name: 'Submit' }) as HTMLButtonElement).disabled).toBe(true);
+    fireEvent.click(view.getByText('B'));
+    fireEvent.click(view.getByRole('button', { name: 'Submit' }));
+    expect(props.onAnswer).toHaveBeenCalledWith(requestId, {
+      'First question': 'First option',
+      'Second question': JSON.stringify(['B']),
+    });
+  });
+});

--- a/apps/desktop/src/renderer/__tests__/askUserQuestionLongAnswer.test.tsx
+++ b/apps/desktop/src/renderer/__tests__/askUserQuestionLongAnswer.test.tsx
@@ -18,6 +18,7 @@ function renderAskUser(
 ) {
   return render(
     createElement(AskUserQuestionPrompt, {
+      sessionId: 'ask-long-answer',
       pending,
       onAnswer,
       viewerState: 'expanded',

--- a/apps/desktop/src/renderer/__tests__/imeEnterCompositionGuard.test.ts
+++ b/apps/desktop/src/renderer/__tests__/imeEnterCompositionGuard.test.ts
@@ -31,6 +31,7 @@ afterEach(() => {
 
 function renderAskUser(pending: PendingAskUser, onAnswer: (requestId: string, answers: Record<string, string>) => void) {
   return render(createElement(AskUserQuestionPrompt, {
+    sessionId: 'ask-ime',
     pending,
     onAnswer,
     viewerState: 'expanded',

--- a/apps/desktop/src/renderer/components/new-chat/AskUserQuestionPrompt.tsx
+++ b/apps/desktop/src/renderer/components/new-chat/AskUserQuestionPrompt.tsx
@@ -104,9 +104,19 @@ export function AskUserQuestionPrompt({
   sessionId,
   ...props
 }: AskUserQuestionPromptProps & { sessionId: string | undefined }) {
-  // Repeated snapshots keep this form mounted; another session or request
-  // starts from its own draft instead of inheriting the previous form's state.
-  return <AskUserQuestionForm key={`${sessionId}:${props.pending.requestId}`} {...props} />;
+  // Match the store's content comparison, including option order and metadata.
+  // Fixed field order avoids treating JSON property order as a new question;
+  // absent and empty options are equivalent, as in the reducer.
+  const questionsIdentity = props.pending.questions.map((question) => [
+    question.question,
+    question.header,
+    question.multiSelect,
+    (question.options ?? []).map((option) => [option.label, option.description]),
+  ]);
+  const formKey = JSON.stringify([sessionId, props.pending.requestId, questionsIdentity]);
+  // Repeated snapshots keep this form mounted. A changed session, request or
+  // question starts from its own draft (cleared by the store on content changes).
+  return <AskUserQuestionForm key={formKey} {...props} />;
 }
 
 function AskUserQuestionForm({
@@ -130,8 +140,8 @@ function AskUserQuestionForm({
   // Note: `requestId` is captured in the lazy initializer closure on first
   // render; subsequent prop updates do NOT re-run the initializer (that is
   // useState's documented behavior). The public wrapper remounts this form
-  // when the session or request changes. For a brand-new question batch the
-  // store has cleared `askUserDraft`, so the new form starts from defaults.
+  // when the session, request or question content changes. For a new or changed
+  // question batch the store clears `askUserDraft`, so the form starts fresh.
   const [currentIndex, setCurrentIndex] = useState<number>(() =>
     draft && draft.requestId === requestId ? draft.currentIndex : 0,
   );

--- a/apps/desktop/src/renderer/components/new-chat/AskUserQuestionPrompt.tsx
+++ b/apps/desktop/src/renderer/components/new-chat/AskUserQuestionPrompt.tsx
@@ -101,6 +101,15 @@ interface AskUserQuestionPromptProps {
 // ---------------------------------------------------------------------------
 
 export function AskUserQuestionPrompt({
+  sessionId,
+  ...props
+}: AskUserQuestionPromptProps & { sessionId: string | undefined }) {
+  // Repeated snapshots keep this form mounted; another session or request
+  // starts from its own draft instead of inheriting the previous form's state.
+  return <AskUserQuestionForm key={`${sessionId}:${props.pending.requestId}`} {...props} />;
+}
+
+function AskUserQuestionForm({
   pending,
   onAnswer,
   viewerState,
@@ -120,10 +129,9 @@ export function AskUserQuestionPrompt({
   // batch — a stale draft from a previous question batch must be ignored.
   // Note: `requestId` is captured in the lazy initializer closure on first
   // render; subsequent prop updates do NOT re-run the initializer (that is
-  // useState's documented behavior). For a brand-new question batch the
-  // store has already cleared `askUserDraft` to null on the
-  // `ask_user_question` reducer path, so the lazy init falls through to
-  // defaults — no stale leak across batches.
+  // useState's documented behavior). The public wrapper remounts this form
+  // when the session or request changes. For a brand-new question batch the
+  // store has cleared `askUserDraft`, so the new form starts from defaults.
   const [currentIndex, setCurrentIndex] = useState<number>(() =>
     draft && draft.requestId === requestId ? draft.currentIndex : 0,
   );

--- a/apps/desktop/src/renderer/features/cc-agent/CCAgentSessionView.tsx
+++ b/apps/desktop/src/renderer/features/cc-agent/CCAgentSessionView.tsx
@@ -5025,6 +5025,7 @@ export function CCAgentSessionView({
                   />
                 ) : pendingAskUser ? (
                   <AskUserQuestionPrompt
+                    sessionId={sessionId}
                     pending={pendingAskUser}
                     onAnswer={answerUserQuestion}
                     viewerState={askUserViewerState}

--- a/apps/desktop/src/renderer/lib/makerChatStore.ts
+++ b/apps/desktop/src/renderer/lib/makerChatStore.ts
@@ -6009,6 +6009,25 @@ export function handleStreamEvent(
         requestId: string;
         questions: AskUserQuestionItem[];
       };
+      // Codex done reconciles pending interactions with fresh IPC objects. Keep
+      // the same question's identity: AskUserQuestionPrompt restores selections
+      // when questions changes, which would erase locally typed, unsubmitted text.
+      // Compare fields rather than JSON object key order; changed questions must
+      // still take the normal initialization path.
+      const previousAsk = state.pendingAskUser;
+      const keepAskProgress = previousAsk?.requestId === data.requestId &&
+        previousAsk.questions.length === data.questions.length &&
+        previousAsk.questions.every((question, index) => {
+          const next = data.questions[index];
+          return question.question === next.question &&
+            question.header === next.header &&
+            question.multiSelect === next.multiSelect &&
+            (question.options?.length ?? 0) === (next.options?.length ?? 0) &&
+            (question.options ?? []).every((option, optionIndex) =>
+              option.label === next.options?.[optionIndex]?.label &&
+              option.description === next.options?.[optionIndex]?.description,
+            );
+        });
       // F1-a: ask_user 消息的落库(+ 在飞 assistant flush)已收口 main
       // (messagePersistBroadcaster.onInteractionMessage,在 setInteractionListener 里),
       // renderer 只做 UI:finalize 在飞气泡 + 用 main 下发的 persistId 建 ask_user 气泡
@@ -6056,19 +6075,17 @@ export function handleStreamEvent(
 
       return {
         ...finalized,
-        pendingAskUser: {
+        pendingAskUser: keepAskProgress ? previousAsk : {
           requestId: data.requestId,
           questions: data.questions,
         },
         // F-AUQ-MIN-1: Every new pendingAskUser starts expanded — even if the
         // previous question in this same session was minimized. Folding never
         // carries across questions.
-        askUserViewerState: 'expanded',
-        // F-AUQ-DRAFT: Same logic — a new question batch must never inherit a
-        // stale draft, even if for some reason the previous draft happened to
-        // share the same requestId. The component additionally guards via
-        // `draft.requestId === pending.requestId` before hydrating.
-        askUserDraft: null,
+        askUserViewerState: keepAskProgress ? state.askUserViewerState : 'expanded',
+        // Only an unchanged pending request may retain its draft. A new batch
+        // or changed question content starts clean, even with the same requestId.
+        askUserDraft: keepAskProgress ? state.askUserDraft : null,
         messages: askMessages,
       };
     }


### PR DESCRIPTION
## 这次改了什么

### 摘要

用户在 Ask「其他」选项里输入文字时，Codex 当前轮运行结束会重新同步待回答问题。此前，同一道题的快照重放会替换问题对象并清空草稿，触发输入组件恢复逻辑，导致未提交文字被重置。另一个边界是旧卡尚未关闭就直接换到新提问请求，组件内部的旧答案和题号可能残留。

本次补齐两条生命周期规则：同一请求、题目内容未变时保留答题状态；任务 ID 或提问请求 ID 改变时重新挂载内部表单，从目标请求自己的草稿初始化，不继承旧卡状态。

### 变更类型

- [ ] `feat` 新功能
- [x] `fix` 缺陷修复
- [ ] `refactor` / `perf` 重构或性能优化
- [ ] `docs` / `test` / `chore` 文档、测试或工程维护
- [ ] 其他：

### 范围

- 关联 Issue / 需求：用户反馈运行结束时 Ask 未提交输入被重置，以及直接切卡可能残留上一张卡的答题状态。
- 本 PR 包含：Desktop Renderer 的 Ask 重复请求守卫；以“任务 ID＋请求 ID”标识内部表单；生产调用接线；异步快照回放和 DOM 界面回归测试。
- 同一未结束请求且题目内容不变时，保留 pending 对象、草稿和折叠状态，组件继续保留输入、选项和题号。新请求清理旧草稿并重新初始化表单；切换任务从目标任务自己的草稿初始化。
- 明确不包含：切走任务或组件卸载后，尚未提交文字的草稿保存与恢复；这是现有独立缺口。
- 用户可见变化：同卡同步不再清空输入，直接切换提问请求或任务不再继承上一张卡的答案和题号。
- 是否存在 breaking change：无。

### UI 变化

本次修复 Ask 提问卡的输入状态保持与切卡初始化行为，未调整布局、样式或文案。

补充 Windows 环境录屏，展示以下修复效果：

https://github.com/user-attachments/assets/0c607621-8b5d-4fc3-82b3-f89375b38fc0

同一张提问卡重复同步或任务结束后，保留正在输入的文字、已选选项和当前题号。
直接切换到新的提问请求时，清空上一张卡的答题状态并回到第一题。
同一请求的题目内容变化时，重新初始化答题状态。
引用的设计规范：docs/design-rules/DESIGN.md 的 Light / Dark 双模式交付门槛；沿用现有主题样式，本录屏仅作为实际展示主题下的验证，不代表双主题均已实测。

## 怎么验证的

### 自动验证

```text
pnpm.cmd test:unit:related
结果：通过，覆盖分支全部 8 个变更文件所影响的 Desktop 相关单测。

pnpm.cmd --filter desktop run --if-present typecheck
结果：通过。

pnpm.cmd --filter desktop exec vitest run src/renderer/__tests__/askUserQuestionIdentity.test.tsx src/renderer/__tests__/askUserQuestionActionLabels.test.tsx src/renderer/__tests__/askUserQuestionLongAnswer.test.tsx src/renderer/__tests__/imeEnterCompositionGuard.test.ts src/renderer/__tests__/askUserDoneRace.test.ts
结果：5 个文件、26 项测试通过。

pnpm.cmd check:dco
结果：通过，2 个提交均包含匹配作者身份的 Signed-off-by。

git diff --check
结果：通过。
```

新增回归覆盖：

- Codex done 后真实异步 Host 快照回放，保留问题对象引用、草稿和折叠状态。
- 新请求或题目、选项、多选模式变化，仍走原有 store 初始化流程。
- DOM 中完成第一题，在第二题勾选选项并输入文字后，同卡重新渲染保留输入框节点、文字、选项及题号；最终提交包含完整答案。
- 不关闭旧卡就直接换请求，以及换任务但请求 ID 不变，均回到目标卡的初始状态，最终答案不包含旧卡内容。

界面测试直接渲染生产导出组件，没有由测试自行添加 key。两项直接切卡测试在身份修复前失败，修复后通过。

### 手工验证

未进行 Electron 实机操作。完整分支 diff 和新增生命周期改动经两位独立 reviewer 检查，未发现 P0/P1。

### 未执行的验证

- Electron 实机操作及 Light / Dark 目检未执行；本次以自动测试与事件链路核对验证。
- 异步 Host 回放和 DOM 输入保留分别由 store 测试与界面测试覆盖，未进行完整 Electron 端到端复现。
- 未运行完整 `pnpm test:unit`；本地运行仓库要求的相关单测门禁，完整单测留给 CI。

## 风险

### 风险分类

- [ ] 无已知风险
- [ ] SQLite / migration
- [ ] system prompt
- [ ] 协议兼容
- [ ] 权限 / 安全 / 用户数据
- [ ] 存量插件兼容（批准状态 / 指纹 / manifest 校验 / 安装布局 / 包格式）
- [ ] 原生层 / fingerprint / OTA
- [ ] 跨平台差异
- [x] 其他：Ask 同步与切卡时的答题状态生命周期。

### 影响与回滚

- 影响范围：Desktop Renderer 的 Ask 请求处理与内部表单生命周期，包括复用该 reducer 和组件的远端 Desktop。正常回答、取消和结束清理路径沿用原有逻辑。
- SSH 远程工作区：复用现有交互事件，不涉及本地或远程文件访问。
- 设备互联：不新增或修改 IPC、推送事件、协议及连接恢复逻辑。
- Mobile：使用独立界面和状态实现，本次不涉及其入口或代码。
- 存量插件影响：无。
- 回滚 / 降级方式：revert 本 PR 提交即可，无存储格式变更或数据迁移。

### 提交前检查

- [x] 已 review 完整 diff
- [x] 每个 commit 都带 DCO 签名（`git commit -s`，见 [DCO](../DCO)）
- [x] UI 改动已在「UI 变化」注明引用的设计规范章节
- [x] 未提交凭证、令牌或授权文件
- [x] 已补充必要文档（代码注释已说明重复请求守卫及表单身份边界，无需新增产品文档）
- [x] 已确认测试结果或说明未执行原因
