### PR TITLE
fix(skillhub): 浏览技能时隐藏空标签

### DIFF
--- a/apps/desktop/src/main/skillhub/__tests__/marketService.test.ts
+++ b/apps/desktop/src/main/skillhub/__tests__/marketService.test.ts
@@ -380,7 +380,7 @@ describe('SkillhubMarketService', () => {
     }]);
   });
 
-  it.each(['market', 'team'] as const)('excludes empty browse tags from older %s servers, including nested tags', async (scope) => {
+  it.each(['market', 'team'] as const)('delegates %s browse filtering to the server without dropping legacy tags', async (scope) => {
     const { fetch, calls } = makeFetch([[
       { slug: 'empty', name: 'Empty', skillCount: 0, mySkillCount: 2,
         children: [{ slug: 'used', name: 'Used', skillCount: 3, mySkillCount: 1 }] },
@@ -390,11 +390,24 @@ describe('SkillhubMarketService', () => {
 
     await expect(service.listCategories(scope, false)).resolves.toEqual({
       success: true,
-      categories: [{ slug: 'used', name: 'Used', count: 3, myCount: 1 }],
+      categories: [
+        { slug: 'empty', name: 'Empty', count: 0, myCount: 2 },
+        { slug: 'used', name: 'Used', count: 3, myCount: 1 },
+        { slug: 'missing-count', name: 'Missing', count: 0, myCount: 0 },
+      ],
       totalCount: 3,
-      myTotalCount: 1,
+      myTotalCount: 3,
     });
     expect(calls[0]?.path).toBe(`/api/skills-hub/categories?scope=${scope}&includeEmpty=false`);
+  });
+
+  it.each(['market', 'team'] as const)('preserves the filtered category result from updated %s servers', async (scope) => {
+    const { fetch } = makeFetch([[{ slug: 'used', name: 'Used', skillCount: 3 }], []]);
+    const service = new SkillhubMarketService({ fetch });
+    await expect(service.listCategories(scope, false)).resolves.toMatchObject({
+      categories: [{ slug: 'used', count: 3 }],
+    });
+    await expect(service.listCategories(scope, false)).resolves.toMatchObject({ categories: [] });
   });
 
   it('keeps unused tags selectable in explicit full-list mode', async () => {

--- a/apps/desktop/src/main/skillhub/__tests__/marketService.test.ts
+++ b/apps/desktop/src/main/skillhub/__tests__/marketService.test.ts
@@ -379,6 +379,32 @@ describe('SkillhubMarketService', () => {
       opts: undefined,
     }]);
   });
+
+  it.each(['market', 'team'] as const)('excludes empty browse tags from older %s servers, including nested tags', async (scope) => {
+    const { fetch, calls } = makeFetch([[
+      { slug: 'empty', name: 'Empty', skillCount: 0, mySkillCount: 2,
+        children: [{ slug: 'used', name: 'Used', skillCount: 3, mySkillCount: 1 }] },
+      { slug: 'missing-count', name: 'Missing' },
+    ]]);
+    const service = new SkillhubMarketService({ fetch });
+
+    await expect(service.listCategories(scope, false)).resolves.toEqual({
+      success: true,
+      categories: [{ slug: 'used', name: 'Used', count: 3, myCount: 1 }],
+      totalCount: 3,
+      myTotalCount: 1,
+    });
+    expect(calls[0]?.path).toBe(`/api/skills-hub/categories?scope=${scope}&includeEmpty=false`);
+  });
+
+  it('keeps unused tags selectable in explicit full-list mode', async () => {
+    const { fetch, calls } = makeFetch([[{ slug: 'empty', name: 'Empty', skillCount: 0 }]]);
+    const service = new SkillhubMarketService({ fetch });
+    await expect(service.listCategories('market', true)).resolves.toMatchObject({
+      categories: [{ slug: 'empty', count: 0 }],
+    });
+    expect(calls[0]?.path).toBe('/api/skills-hub/categories?scope=market');
+  });
 });
 
 describe('skillhub market helpers', () => {

--- a/apps/desktop/src/main/skillhub/marketService.ts
+++ b/apps/desktop/src/main/skillhub/marketService.ts
@@ -310,8 +310,9 @@ export class SkillhubMarketService {
         mySkillCount?: number;
       }>;
     }>>(`/api/skills-hub/categories?scope=${scope}${includeEmpty ? '' : '&includeEmpty=false'}`);
-    // Older servers may ignore includeEmpty; keep their empty tags out of browse results too.
-    const categories = flattenHubCategories(items ?? []).filter((category) => includeEmpty || category.count > 0);
+    // Filtering belongs to the server: legacy counts may be absent, and older servers'
+    // team responses may contain public-market counts rather than team counts.
+    const categories = flattenHubCategories(items ?? []);
     const totalCount = categories.reduce((s, c) => s + c.count, 0);
     const myTotalCount = categories.reduce((s, c) => s + c.myCount, 0);
     return { success: true as const, categories, totalCount, myTotalCount };

--- a/apps/desktop/src/main/skillhub/marketService.ts
+++ b/apps/desktop/src/main/skillhub/marketService.ts
@@ -296,7 +296,7 @@ export class SkillhubMarketService {
     };
   }
 
-  async listCategories(scope: SkillhubCatalogScope = 'market') {
+  async listCategories(scope: SkillhubCatalogScope = 'market', includeEmpty = true) {
     const items = await this.fetch<Array<{
       slug: string;
       name: string;
@@ -309,8 +309,9 @@ export class SkillhubMarketService {
         skillCount?: number;
         mySkillCount?: number;
       }>;
-    }>>(`/api/skills-hub/categories?scope=${scope}`);
-    const categories = flattenHubCategories(items ?? []);
+    }>>(`/api/skills-hub/categories?scope=${scope}${includeEmpty ? '' : '&includeEmpty=false'}`);
+    // Older servers may ignore includeEmpty; keep their empty tags out of browse results too.
+    const categories = flattenHubCategories(items ?? []).filter((category) => includeEmpty || category.count > 0);
     const totalCount = categories.reduce((s, c) => s + c.count, 0);
     const myTotalCount = categories.reduce((s, c) => s + c.myCount, 0);
     return { success: true as const, categories, totalCount, myTotalCount };

--- a/apps/desktop/src/main/skillhub/registerIpc.ts
+++ b/apps/desktop/src/main/skillhub/registerIpc.ts
@@ -577,12 +577,12 @@ export function registerSkillhubIpc(options: RegisterSkillhubIpcOptions): void {
   // Market 分类列表 — 若 broker / 网络不可用，降级空数组
   ipcMain.handle(
     'skillhub:list-categories',
-    async (_event, params?: { scope?: 'market' | 'team' }) => {
+    async (_event, params?: { scope?: 'market' | 'team'; includeEmpty?: boolean }) => {
       try {
         // Renderer payload is untrusted: only the two catalog scopes are valid,
         // and an absent/invalid value keeps the historical market behavior.
         const scope = params?.scope === 'team' ? 'team' : 'market';
-        return await marketService.listCategories(scope);
+        return await marketService.listCategories(scope, params?.includeEmpty !== false);
       } catch (err) {
         const message = err instanceof Error ? err.message : String(err);
         log.warn('list-categories failed', message);

--- a/apps/desktop/src/preload/preload.ts
+++ b/apps/desktop/src/preload/preload.ts
@@ -3197,6 +3197,8 @@ contextBridge.exposeInMainWorld('electronAPI', {
     // Market 分类列表
     listCategories: (params?: {
       scope?: import('../shared/skillhubCatalog').SkillhubCatalogScope;
+      /** Defaults to true for publish/edit pickers; browse filters pass false. */
+      includeEmpty?: boolean;
     }): Promise<{
       success: boolean;
       categories?: import('../shared/skillhubCategory').MarketCategory[];

--- a/apps/desktop/src/renderer/features/skillhub/hooks/__tests__/useCategoryList.test.tsx
+++ b/apps/desktop/src/renderer/features/skillhub/hooks/__tests__/useCategoryList.test.tsx
@@ -52,6 +52,7 @@ describe('useCategoryList data-owner isolation', () => {
 
     const first = renderHook(() => useCategoryList('team'));
     await waitFor(() => expect(listCategories).toHaveBeenCalledTimes(1));
+    expect(listCategories).toHaveBeenLastCalledWith({ scope: 'team', includeEmpty: false });
     first.unmount();
 
     setDataOwnerGeneration('owner-b', 2);

--- a/apps/desktop/src/renderer/features/skillhub/hooks/useMarketList.ts
+++ b/apps/desktop/src/renderer/features/skillhub/hooks/useMarketList.ts
@@ -699,7 +699,7 @@ export function useCategoryList(scope: SkillhubCatalogScope = 'market'): Categor
       new Map<SkillhubCatalogScope, Promise<CategoryListState>>();
     if (!inflightCategories.has(owner)) inflightCategories.set(owner, ownerInflight);
     const existing = ownerInflight.get(scope);
-    const inflight = existing ?? window.electronAPI.skillhub.listCategories({ scope })
+    const inflight = existing ?? window.electronAPI.skillhub.listCategories({ scope, includeEmpty: false })
       .then((res) => (res.success
         ? { categories: res.categories ?? [], totalCount: res.totalCount ?? 0, myTotalCount: res.myTotalCount ?? 0 }
         : EMPTY_CATEGORY_STATE))

--- a/apps/desktop/src/renderer/vite-env.d.ts
+++ b/apps/desktop/src/renderer/vite-env.d.ts
@@ -3411,6 +3411,8 @@ interface ElectronAPI {
     }>;
     listCategories: (params?: {
       scope?: import('../shared/skillhubCatalog').SkillhubCatalogScope;
+      /** Defaults to true for publish/edit pickers; browse filters pass false. */
+      includeEmpty?: boolean;
     }) => Promise<{
       success: boolean;
       categories?: import('../shared/skillhubCategory').MarketCategory[];

--- a/apps/desktop/src/shared/skillhubCategory.ts
+++ b/apps/desktop/src/shared/skillhubCategory.ts
@@ -1,8 +1,8 @@
 /**
  * SkillHub 分类（main / preload / renderer 共享类型）。
  * slug 是后端稳定标识，name 是展示用本地化字符串。
- * count = 该分类下总 skill 数（Hub skillCount）。
- * myCount = 该分类下当前用户发布的 skill 数（Hub mySkillCount）。
+ * count = 当前目录中该分类下可见的 skill 数（Hub skillCount）。
+ * myCount = 同一目录中当前用户发布的 skill 数（Hub mySkillCount）。
  */
 export interface MarketCategory {
   slug: string;


### PR DESCRIPTION
## 这次改了什么

### 摘要

SkillHub 浏览页目前会显示尚无 Skill 的标签。浏览分类请求改为 `includeEmpty=false`，公开与组织目录只展示有内容的标签；上传和编辑 Skill 继续使用默认全量标签。

### 变更类型

- [ ] `feat` 新功能
- [x] `fix` 缺陷修复
- [ ] `refactor` / `perf` 重构或性能优化
- [ ] `docs` / `test` / `chore` 文档、测试或工程维护
- [ ] 其他：N/A

### 范围

- 关联 Issue / 需求：技能浏览区隐藏空标签，上传时保留全量可选标签。
- 配套服务端 PR：https://github.com/xindong/cindy-server/pull/594。
- 本 PR 包含：分类参数贯穿 Renderer、preload、IPC 和 HTTP；由服务端过滤分类，兼容旧服务端与旧站计数缺失；回归测试。
- 明确不包含：Platform Console、数据库、发布写入流程。
- 用户可见变化：SkillHub 首页与市场筛选移除空标签，上传及编辑仍可选择未使用标签。
- 是否存在 breaking change：无。参数可选，默认全量。

### UI 变化

仅收窄现有标签筛选的数据集合，无布局、样式或文案改动。未进行实机截图验证。

- 引用的设计规范：`docs/design-rules/DESIGN.md` §1 内容克制；沿用现有标签组件和主题 token，仅隐藏无内容标签。

## 怎么验证的

### 自动验证

```text
pnpm test:unit:related — PASS（apps/desktop related 8）
pnpm --filter desktop typecheck — PASS，0 errors
pnpm --filter desktop exec vitest run src/main/skillhub/__tests__/marketService.test.ts src/renderer/features/skillhub/hooks/__tests__/useCategoryList.test.tsx src/renderer/features/skillhub/lib/__tests__/publishForm.test.ts src/renderer/features/skillhub/components/__tests__/PlatformTagSelector.test.tsx
— PASS，4 files / 39 tests
pnpm check:dco — PASS，2 commits
git diff --check — PASS
```

### 手工验证

已核对上传、编辑入口保持默认全量调用，以及公开/组织浏览入口共用过滤 hook；未运行 Desktop 实机验证。

### 未执行的验证

未进行 Light/Dark 实机目检或线上端到端验证；本次不修改视觉样式，两端契约由本地测试覆盖。

## 风险

### 风险分类

- [ ] 无已知风险
- [ ] SQLite / migration
- [ ] system prompt
- [x] 协议兼容
- [ ] 权限 / 安全 / 用户数据
- [ ] 存量插件兼容（批准状态 / 指纹 / manifest 校验 / 安装布局 / 包格式）
- [ ] 原生层 / fingerprint / OTA
- [ ] 跨平台差异
- [ ] 其他：N/A

### 影响与回滚

- 影响范围：SkillHub 分类读取；客户端不再根据旧计数重复过滤。旧服务端忽略参数时保留原有全量展示，避免误删团队标签；精确过滤由升级后的服务端负责。旧站缺少计数时保留未知分类，建议先部署服务端。
- 回滚 / 降级方式：回退此提交即可恢复全量筛选；上传与编辑协议不变。

### 提交前检查

- [x] 已 review 完整 diff
- [x] 每个 commit 都带 DCO 签名
- [x] UI 改动已在「UI 变化」注明引用的设计规范章节
- [x] 未提交凭证、令牌或授权文件
- [x] 已补充必要文档（服务端配套 PR 的接口契约）
- [x] 已确认测试结果或说明未执行原因
