### PR TITLE
fix(mobile): 输入框拖拽 worklet 的辅助函数提前声明,修复 Android release 拖拽即闪退

### DIFF
--- a/apps/mobile/src/__tests__/composerResizeWorklet.test.ts
+++ b/apps/mobile/src/__tests__/composerResizeWorklet.test.ts
@@ -1,0 +1,73 @@
+/**
+ * #4039 回归:输入框拖拽的 UI 线程 worklet 在 Android release 包里崩溃
+ * (`undefined is not a function at applyComposerResizeDrag`)。
+ *
+ * 根因不在逻辑而在**声明顺序**:react-native-worklets 的 babel 插件把每个 `'worklet'`
+ * 函数改写成「模块求值时立即执行的工厂」,并在那一刻把它引用的模块内标识符抓进
+ * `__closure`。`applyComposerResizeDrag` 若写在它依赖的 `normalizeBounds` / `clamp`
+ * 之前,抓到的就是两个尚未赋值的 `var`(undefined);UI 线程按 `__closure` 取值调用即崩。
+ * vitest 走 esbuild、不跑该插件,普通单测永远发现不了 —— 本测试用仓库实际的 babel
+ * preset + worklets 插件把源码真转译一遍并求值,断言闭包里拿到的是函数。
+ */
+import { describe, expect, it } from 'vitest';
+import { transformFileSync, type TransformOptions } from '@babel/core';
+import Module, { createRequire } from 'node:module';
+import path from 'node:path';
+
+const require = createRequire(import.meta.url);
+const sourcePath = path.resolve(__dirname, '..', 'session', 'composerResize.ts');
+
+interface WorkletLike {
+  (...args: unknown[]): unknown;
+  __closure?: Record<string, unknown>;
+  __workletHash?: number;
+}
+
+function loadWorkletTransformedModule(): Record<string, unknown> {
+  const out = transformFileSync(sourcePath, {
+    filename: sourcePath,
+    babelrc: false,
+    configFile: false,
+    presets: [[require.resolve('babel-preset-expo'), {}]],
+    plugins: [require.resolve('react-native-worklets/plugin')],
+    // Metro 的 caller 带 platform 字段(babel-preset-expo 据此选平台分支),类型定义里没有。
+    caller: {
+      name: 'metro',
+      supportsStaticESM: false,
+      platform: 'android',
+    } as unknown as TransformOptions['caller'],
+    envName: 'production',
+  });
+  if (!out?.code) throw new Error('babel produced no output');
+  const compiledPath = sourcePath.replace(/\.ts$/, '.js');
+  const mod = new Module(compiledPath);
+  const nodeModulePaths = (
+    Module as unknown as { _nodeModulePaths: (from: string) => string[] }
+  )._nodeModulePaths;
+  mod.paths = nodeModulePaths(path.dirname(sourcePath));
+  (mod as unknown as { _compile: (code: string, filename: string) => void })._compile(
+    out.code,
+    compiledPath,
+  );
+  return mod.exports as Record<string, unknown>;
+}
+
+describe('composerResize worklets(经 react-native-worklets 插件转译后)', () => {
+  it('applyComposerResizeDrag 的 __closure 在模块求值时已拿到辅助函数,UI 线程可调用', () => {
+    const exported = loadWorkletTransformedModule();
+    const worklet = exported.applyComposerResizeDrag as WorkletLike;
+    expect(typeof worklet).toBe('function');
+    expect(typeof worklet.__workletHash).toBe('number');
+    const closure = worklet.__closure ?? {};
+    // 插件抓进闭包的每一个标识符都必须已经是函数,否则 UI 线程求值即 "undefined is not a function"。
+    for (const [name, value] of Object.entries(closure)) {
+      expect(typeof value, `__closure.${name}`).toBe('function');
+    }
+    // 转译后的 JS 线程副本与 UI 线程副本共用同一份闭包捕获:直接调用等价于 UI 线程调用。
+    expect(worklet({
+      startContentHeight: 100,
+      translationY: -20,
+      bounds: { minContentHeight: 20, maxContentHeight: 300 },
+    })).toBe(120);
+  });
+});

--- a/apps/mobile/src/__tests__/composerResizeWorklet.test.ts
+++ b/apps/mobile/src/__tests__/composerResizeWorklet.test.ts
@@ -59,9 +59,13 @@ describe('composerResize worklets(经 react-native-worklets 插件转译后)', (
     expect(typeof worklet).toBe('function');
     expect(typeof worklet.__workletHash).toBe('number');
     const closure = worklet.__closure ?? {};
-    // 插件抓进闭包的每一个标识符都必须已经是函数,否则 UI 线程求值即 "undefined is not a function"。
+    // 本次回归只关乎两个辅助函数的声明顺序:它们必须以函数身份进入闭包。
+    expect(typeof closure.normalizeBounds, '__closure.normalizeBounds').toBe('function');
+    expect(typeof closure.clamp, '__closure.clamp').toBe('function');
+    // 更一般的约束是「抓进闭包的标识符不能是尚未赋值的 var」;worklet 合法捕获常量 /
+    // 对象在仓库里有先例,所以只拒绝 undefined,不限定类型。
     for (const [name, value] of Object.entries(closure)) {
-      expect(typeof value, `__closure.${name}`).toBe('function');
+      expect(value, `__closure.${name}`).not.toBeUndefined();
     }
     // 转译后的 JS 线程副本与 UI 线程副本共用同一份闭包捕获:直接调用等价于 UI 线程调用。
     expect(worklet({

--- a/apps/mobile/src/session/composerResize.ts
+++ b/apps/mobile/src/session/composerResize.ts
@@ -47,6 +47,25 @@ export const COMPOSER_RESIZE_AUTO_SNAP_THRESHOLD = 24;
 /** manual 模式上边界之上保留的屏幕空间（顶部导航 + 至少一部分消息内容可见）。 */
 export const COMPOSER_RESIZE_TOP_RESERVED_HEIGHT = 220;
 
+// ⚠️ 声明顺序即正确性(#4039):react-native-worklets 插件把每个 `'worklet'` 函数改写成
+// 模块求值时立即执行的工厂,并在那一刻把它引用的模块内标识符抓进 `__closure`。
+// 被其它 worklet 引用的辅助函数必须写在引用者**之前**,否则抓到的是尚未赋值的 `var`
+// (undefined),UI 线程一调用就是 `undefined is not a function`(Android release 崩溃)。
+// vitest 不跑该插件,靠 composerResizeWorklet.test.ts 用真实转译守住这条约束。
+function normalizeBounds(bounds: ComposerResizeBounds): ComposerResizeBounds {
+  'worklet';
+  const minContentHeight = Math.max(1, Math.round(bounds.minContentHeight));
+  return {
+    minContentHeight,
+    maxContentHeight: Math.max(minContentHeight, Math.round(bounds.maxContentHeight)),
+  };
+}
+
+function clamp(value: number, min: number, max: number): number {
+  'worklet';
+  return Math.min(Math.max(value, min), max);
+}
+
 export interface ResolveComposerInputHeightInput {
   /** TextInput 上报的内容高度（页面 state）。 */
   contentHeight: number;
@@ -295,14 +314,6 @@ export function computeComposerResizeBounds(
   };
 }
 
-function normalizeBounds(bounds: ComposerResizeBounds): ComposerResizeBounds {
-  'worklet';
-  const minContentHeight = Math.max(1, Math.round(bounds.minContentHeight));
-  return {
-    minContentHeight,
-    maxContentHeight: Math.max(minContentHeight, Math.round(bounds.maxContentHeight)),
-  };
-}
 
 function normalizePositiveDimension(value: number, fallback: number): number {
   return Number.isFinite(value) && value > 0 ? value : fallback;
@@ -310,9 +321,4 @@ function normalizePositiveDimension(value: number, fallback: number): number {
 
 function normalizeNonNegativeDimension(value: number, fallback: number): number {
   return Number.isFinite(value) && value >= 0 ? value : fallback;
-}
-
-function clamp(value: number, min: number, max: number): number {
-  'worklet';
-  return Math.min(Math.max(value, min), max);
 }


### PR DESCRIPTION
## 这次改了什么

### 摘要

Android 上从输入框顶部向上拖拽调整高度时应用立即闪退(0.1.74;0.1.73 正常),崩溃栈:`com.facebook.jni.CppException: undefined is not a function … at applyComposerResizeDrag_composerResizeTs1 … runWorklet_reactNativeGestureHandler`。

**根因是声明顺序,不是逻辑。** #3948 把拖拽迁到 UI 线程后,`applyComposerResizeDrag` 成为 `'worklet'`。react-native-worklets 的 babel 插件会把每个 worklet 函数改写成「模块求值时立即执行的工厂」,并在那一刻把它引用的模块内标识符抓进 `__closure`;它依赖的两个辅助函数 `normalizeBounds` / `clamp`(同样是 worklet)写在文件**更靠后**的位置,也被改写成 `var` 工厂,于是 `applyComposerResizeDrag` 的工厂执行时抓到的是两个尚未赋值的 `var`(undefined)。UI 线程按 `__closure` 取值调用 → `undefined is not a function`。

用仓库实际的 `babel-preset-expo` + `react-native-worklets/plugin` 转译并求值 `composerResize.ts` 可直接复现:`applyComposerResizeDrag.__closure === { normalizeBounds: undefined, clamp: undefined }`,调用即抛 `normalizeBounds is not a function`。vitest 走 esbuild、不经过该插件,所以既有单测(34 例)全绿却发现不了。

修法:把 `normalizeBounds` / `clamp` 提到第一个引用者之前,并在源码加注释说明「被其它 worklet 引用的辅助函数必须先于引用者声明」;新增回归测试真跑一遍转译守住这条约束。

### 变更类型

- [ ] `feat` 新功能
- [x] `fix` 缺陷修复
- [ ] `refactor` / `perf` 重构或性能优化
- [ ] `docs` / `test` / `chore` 文档、测试或工程维护
- [ ] 其他:

### 范围

- 关联 Issue / 需求:Fixes #4039
- 本 PR 包含:`apps/mobile/src/session/composerResize.ts` 两个辅助函数的位置调整 + 约束注释(函数体、导出、行为零变化);新增 `apps/mobile/src/__tests__/composerResizeWorklet.test.ts`。
- 明确不包含:拖拽逻辑、手势配置、`useComposerResize.ts`(其 worklet 只捕获在它之前声明的 shared value 与模块导入,不受此约束影响)、原生层。纯 JS 改动,可走热更新。
- 用户可见变化:Android 上拖拽输入框不再闪退。
- 是否存在 breaking change:无。

### UI 变化

- 引用的设计规范:不涉及:仅调整模块内函数声明顺序与新增转译回归测试,无界面、布局、样式或交互改动。

## 怎么验证的

### 自动验证

```text
apps/mobile: vitest run src/__tests__/composerResizeWorklet.test.ts src/__tests__/composerResize.test.ts
结果:35/35(新测试 1 例 + 既有 34 例)

反证:新测试对改动前的 composerResize.ts 运行 → 失败
  AssertionError: __closure.normalizeBounds: expected 'undefined' to be 'function'
改动后通过;转译后的函数直接调用返回 120(startContentHeight 100,translationY -20)。

pnpm --dir apps/mobile run typecheck:0 错误
pnpm test:unit:related(仓库根):PASS(apps/mobile unit)
prettier / git diff --check:通过(apps/mobile 无 eslint 配置)
```

新测试的做法:用 `@babel/core` + 仓库自带的 `babel-preset-expo` + `react-native-worklets/plugin`(caller 模拟 Metro android、production)真转译 `composerResize.ts`,在 Node 里求值该模块,断言 `applyComposerResizeDrag.__closure` 中每个被捕获的标识符都是函数,并直接调用转译后的函数得到正确结果——这与 UI 线程按 `__closure` 求值等价。

### 手工验证

无 Android 真机,未做 release 包实机复现。根因链条以插件真实转译输出为证据(改前 `__closure` 两项为 undefined、调用即抛与 issue 同名错误),请 @mp55 有条件时用含本 PR 的构建在 Mi 10 / Civi 4 复核一次拖拽。

### 未执行的验证

- Android release 真机拖拽实测(无设备)。
- iOS 未单独验证(同一 JS 路径,预期同样受益;改动前 iOS 是否同样崩溃未知)。

## 风险

### 风险分类

- [x] 无已知风险
- [ ] SQLite / migration
- [ ] system prompt
- [ ] 协议兼容
- [ ] 权限 / 安全 / 用户数据
- [ ] 存量插件兼容(批准状态 / 指纹 / manifest 校验 / 安装布局 / 包格式)
- [ ] 原生层 / fingerprint / OTA
- [ ] 跨平台差异
- [ ] 其他:

### 影响与回滚

- 影响范围:仅 `composerResize.ts` 的声明顺序;所有导出函数签名与行为不变。
- 新测试会在 CI 里真跑一次 babel 转译(本机约 130ms),依赖仓库已有的 `babel-preset-expo` / `react-native-worklets`(apps/mobile 直接依赖),不新增依赖。
- 回滚 / 降级方式:revert 本 PR 单个 commit。
