### PR TITLE
fix(mobile): 完全断网时新建会话的 worktree 探测进入「连接恢复中」,不再永久停在「检测环境中…」

### DIFF
--- a/apps/mobile/app/sessions/new.tsx
+++ b/apps/mobile/app/sessions/new.tsx
@@ -311,6 +311,7 @@ import {
   isValidWorktreeBranchPreferenceSnapshot,
   isWorktreeChannelNotAllowedError,
   parseWorktreeCreateResult,
+  initialWorktreeProbeEligibility,
   resolveWorktreeEligibility,
   shouldAcceptWorktreeBranchListResult,
   shouldBlockNewSessionCreateForWorktree,
@@ -2286,9 +2287,16 @@ export default function NewRemoteSessionScreen() {
     };
     let cancelled = false;
     let retryTimer: ReturnType<typeof setTimeout> | null = null;
-    const probingEligibility: NewSessionWorktreeEligibility = { status: 'probing' };
-    worktreeEligibilityRef.current = probingEligibility;
-    setWorktreeProbe({ target, eligibility: probingEligibility });
+    // 起始状态由纯函数决定(#4046):设备与目录都已选、但链路不在 online(如完全断网)
+    // 时直接进 recovering 而不是停在 probing —— 下面的提前返回不会进 catch,停在
+    // probing 就是永久的「检测环境中…」。
+    const initialEligibility: NewSessionWorktreeEligibility = initialWorktreeProbeEligibility({
+      hasDevice: Boolean(selectedDeviceId),
+      hasWorkingDir: cwd.length > 0,
+      online: deviceLinkStatus === 'online',
+    });
+    worktreeEligibilityRef.current = initialEligibility;
+    setWorktreeProbe({ target, eligibility: initialEligibility });
     // Relay 离线时不把预期的 NOT_CONNECTED 固化成 detect-failed；online /
     // connectionEpoch / presenceVersion 变化后自动重探，覆盖手机重连和工作端
     // 重新上线两种路径。

--- a/apps/mobile/src/__tests__/newSession.test.ts
+++ b/apps/mobile/src/__tests__/newSession.test.ts
@@ -2574,4 +2574,25 @@ describe('new.tsx worktree 探测 effect 的离线起始态(#4046,源码契约)'
     // 提前返回条件与 fail-closed 语义不变:非 online 不发探测请求。
     expect(source).toContain("if (!selectedDeviceId || !cwd || deviceLinkStatus !== 'online') return undefined;");
   });
+
+  it('离线起始态的恢复依赖 effect 依赖数组:链路 / 连接代次 / presence / 定时重探任一变化即重跑', () => {
+    // recovering 不是终态,靠 effect 重跑回到探测;这几项漏掉任何一个,断网恢复后都会卡在
+    // 「连接恢复中」。锁住依赖数组片段,补上 initialWorktreeProbeEligibility 单测覆盖不到的那一段。
+    const effectStart = source.indexOf('initialWorktreeProbeEligibility({');
+    expect(effectStart).toBeGreaterThan(0);
+    const depsStart = source.indexOf('}, [', effectStart);
+    const depsEnd = source.indexOf(']);', depsStart);
+    const deps = source.slice(depsStart, depsEnd);
+    for (const dep of [
+      'connectionEpoch',
+      'deviceLinkStatus',
+      'presenceVersion',
+      'worktreeDetectRetryNonce',
+      'selectedDeviceId',
+      'draft.workspaceKind',
+      'draft.workingDir',
+    ]) {
+      expect(deps, `effect deps 应包含 ${dep}`).toContain(dep);
+    }
+  });
 });

--- a/apps/mobile/src/__tests__/newSession.test.ts
+++ b/apps/mobile/src/__tests__/newSession.test.ts
@@ -2561,3 +2561,17 @@ describe('resolveStartedDowngradeOrCommit —— started 落账后设备切换�
     expect(restoreStarted).toHaveBeenCalledTimes(1);
   });
 });
+
+describe('new.tsx worktree 探测 effect 的离线起始态(#4046,源码契约)', () => {
+  const source = readTextLf(resolve(__dirname, '..', '..', 'app', 'sessions', 'new.tsx'), 'utf8');
+
+  it('起始 eligibility 经 initialWorktreeProbeEligibility 决定,不再硬编码 probing 后直接提前返回', () => {
+    expect(source).toContain('initialWorktreeProbeEligibility({');
+    expect(source).toContain("online: deviceLinkStatus === 'online',");
+    expect(source).toContain('worktreeEligibilityRef.current = initialEligibility;');
+    expect(source).toContain('setWorktreeProbe({ target, eligibility: initialEligibility });');
+    expect(source).not.toContain("const probingEligibility: NewSessionWorktreeEligibility = { status: 'probing' };");
+    // 提前返回条件与 fail-closed 语义不变:非 online 不发探测请求。
+    expect(source).toContain("if (!selectedDeviceId || !cwd || deviceLinkStatus !== 'online') return undefined;");
+  });
+});

--- a/apps/mobile/src/__tests__/newSessionWorktree.test.ts
+++ b/apps/mobile/src/__tests__/newSessionWorktree.test.ts
@@ -16,6 +16,7 @@ import {
   classifyWorktreePreferenceSeed,
   fallbackWorktreeName,
   formatWorktreeCreateFailure,
+  initialWorktreeProbeEligibility,
   isExactRemoteSessionClaimed,
   isValidWorktreeBranchPreferenceSnapshot,
   isWorktreeChannelNotAllowedError,
@@ -354,6 +355,38 @@ describe('worktreeEligibilityFromError', () => {
     )).toBe(true);
     expect(isWorktreeChannelNotAllowedError(new Error('INVOKE_TIMEOUT'))).toBe(false);
     expect(isWorktreeChannelNotAllowedError(new Error('socket closed'))).toBe(false);
+  });
+});
+
+describe('initialWorktreeProbeEligibility(#4046 完全断网时探测起始态)', () => {
+  it('设备 + 目录都已选但链路不在 online → recovering(自动重试文案,不停在检测中)', () => {
+    expect(initialWorktreeProbeEligibility({ hasDevice: true, hasWorkingDir: true, online: false }))
+      .toEqual({ status: 'recovering' });
+  });
+
+  it('设备或目录未选全 → probing(探测尚未开始,不把输入未完整误报成网络错误)', () => {
+    expect(initialWorktreeProbeEligibility({ hasDevice: false, hasWorkingDir: true, online: false }))
+      .toEqual({ status: 'probing' });
+    expect(initialWorktreeProbeEligibility({ hasDevice: true, hasWorkingDir: false, online: false }))
+      .toEqual({ status: 'probing' });
+    expect(initialWorktreeProbeEligibility({ hasDevice: false, hasWorkingDir: false, online: true }))
+      .toEqual({ status: 'probing' });
+  });
+
+  it('三者齐备 → probing,由后续请求结果 / 抛错归并覆盖', () => {
+    expect(initialWorktreeProbeEligibility({ hasDevice: true, hasWorkingDir: true, online: true }))
+      .toEqual({ status: 'probing' });
+  });
+
+  it('recovering 起始态与探测抛错的 recovering 走同一文案,且创建门禁保持 fail-closed', () => {
+    const offline = initialWorktreeProbeEligibility({ hasDevice: true, hasWorkingDir: true, online: false });
+    expect(worktreeEligibilityCaptionKey(offline)).toBe('session.new.worktreeRecovering');
+    expect(shouldBlockNewSessionCreateForWorktree({
+      applicable: true,
+      enabled: true,
+      eligibility: offline,
+      preferenceSaving: false,
+    })).toBe(true);
   });
 });
 

--- a/apps/mobile/src/session/newSessionWorktree.ts
+++ b/apps/mobile/src/session/newSessionWorktree.ts
@@ -247,6 +247,24 @@ export function worktreeEligibilityFromError(error: unknown): NewSessionWorktree
 }
 
 /**
+ * 探测 effect 的**起始**状态(#4046):
+ *  - 设备或目录还没选全 → probing(探测尚未开始,UI 不暴露该行);
+ *  - 设备与目录都在、但链路不在 online → recovering(「连接恢复中,正在自动重试…」)。
+ *    完全断网时 effect 会在发请求前直接返回,永远进不了 catch,若仍停在 probing 就是
+ *    永久的「检测环境中…」;online / connectionEpoch / presenceVersion 变化即重探。
+ *  - 三者齐备 → probing,随后由请求结果 / 抛错归并覆盖。
+ * 创建门禁不变:probing / recovering 都 fail-closed(shouldBlockNewSessionCreateForWorktree)。
+ */
+export function initialWorktreeProbeEligibility(input: {
+  hasDevice: boolean;
+  hasWorkingDir: boolean;
+  online: boolean;
+}): NewSessionWorktreeEligibility {
+  if (input.hasDevice && input.hasWorkingDir && !input.online) return { status: 'recovering' };
+  return { status: 'probing' };
+}
+
+/**
  * 读取工作端 get-new-maker-defaults 的明确偏好。缺字段/形状异常返回 null，
  * 由控制端保留当前镜像；全新设备的镜像自身默认未勾选。
  */


### PR DESCRIPTION
## 这次改了什么

### 摘要

Android 完全断网时进入「新建会话」并选择项目目录,页面永久显示「检测环境中…」,超过 60 秒也不会进入失败态、无提示、无重试入口(#4046)。

根因:`apps/mobile/app/sessions/new.tsx` 的 worktree 探测 effect 先写入 `{ status: 'probing' }`,然后在 `deviceLinkStatus !== 'online'` 时**提前返回**;完全断网时不会发出探测请求、永远进不了 `catch`,`probing` 没有任何机会转成既有的 `recovering` / `detect-failed`。既有状态契约、文案(`session.new.worktreeRecovering`「连接恢复中,正在自动重试…」)与创建门禁都已存在,缺的只是这一处状态收敛(与 dash-s-cindy 在 issue 中的分析一致)。

修法:新增纯函数 `initialWorktreeProbeEligibility({ hasDevice, hasWorkingDir, online })` 决定探测起始态——设备与目录都已选、链路不在 online → `recovering`;设备或目录未选全 → 仍为 `probing`(探测尚未开始,不把输入未完整误报成网络错误);三者齐备 → `probing`,由后续结果覆盖。effect 用它替换硬编码的 `probing`。online / `connectionEpoch` / `presenceVersion` 变化时沿用既有依赖自动重探;`recovering` 与 `probing` 对创建门禁同样 fail-closed,不会因断网把 worktree 意图降级成普通目录会话。

### 变更类型

- [ ] `feat` 新功能
- [x] `fix` 缺陷修复
- [ ] `refactor` / `perf` 重构或性能优化
- [ ] `docs` / `test` / `chore` 文档、测试或工程维护
- [ ] 其他:

### 范围

- 关联 Issue / 需求:Fixes #4046
- 本 PR 包含:`newSessionWorktree.ts` 新增 `initialWorktreeProbeEligibility`;`new.tsx` 探测 effect 起始态改用该函数(提前返回条件与后续请求/归并逻辑不变);`newSessionWorktree.test.ts` 新增 4 例;`newSession.test.ts` 新增源码契约测试。
- 明确不包含:新的错误类型或「固定时长后进入终态 + 显式重试按钮」的产品变更(issue 中 dash-s-cindy 明确留作后续产品决策);探测请求、重试节奏、创建门禁语义;原生层。纯 TS 改动,可走热更新。
- 用户可见变化:完全断网时显示「连接恢复中,正在自动重试…」而非永久「检测环境中…」;恢复网络后自动重探。
- 是否存在 breaking change:无。

### UI 变化

- 引用的设计规范:不涉及:仅改变探测状态机的起始态,复用既有 `recovering` 文案与样式,无新增界面元素、布局或交互。

## 怎么验证的

### 自动验证

```text
apps/mobile: vitest run src/__tests__/newSessionWorktree.test.ts src/__tests__/newSession.test.ts
结果:176/176(新增 helper 4 例:offline→recovering;设备/目录未选全→probing;齐备→probing;
recovering 起始态的文案 key 与创建门禁 fail-closed 与探测抛错的 recovering 一致;
新增 new.tsx 源码契约 1 例)

反证:把 new.tsx 回退到 main、保留测试 → 契约测试失败(仍硬编码 probing);恢复后通过。

pnpm --dir apps/mobile run typecheck:0 错误
pnpm test:unit:related(仓库根):PASS(apps/mobile unit)
git diff --check:通过(apps/mobile 无 eslint 配置;未对既有文件跑 prettier,保持原有格式)
```

### 手工验证

无 Android 真机,未做断网实机复测。逻辑改动为一处起始态判定,由纯函数单测覆盖;请 @sakiko-toyokawa 有条件时用含本 PR 的构建按 issue 步骤(断开 Wi‑Fi 与移动网络 → 新建会话 → 选目录)复核:应显示「连接恢复中,正在自动重试…」,恢复网络后自动进入可用/不可用判定。

### 未执行的验证

- Android / iOS 真机断网复测(无设备)。
- 「超时后进入终态 + 显式重试按钮」未实现(产品决策待定,见 issue)。

## 风险

### 风险分类

- [x] 无已知风险
- [ ] SQLite / migration
- [ ] system prompt
- [ ] 协议兼容
- [ ] 权限 / 安全 / 用户数据
- [ ] 存量插件兼容(批准状态 / 指纹 / manifest 校验 / 安装布局 / 包格式)
- [ ] 原生层 / fingerprint / OTA
- [ ] 跨平台差异
- [ ] 其他:

### 影响与回滚

- 影响范围:仅新建会话页 worktree 探测的起始状态;设备/目录未选全的路径行为不变;探测请求、错误归并、重试与创建门禁不变。
- 回滚 / 降级方式:revert 本 PR 单个 commit。
