### PR TITLE
fix(desktop): 修复 Skill 详情随列表滚动上移

### DIFF
--- a/apps/desktop/src/renderer/features/skillhub/SkillhubHomeView.tsx
+++ b/apps/desktop/src/renderer/features/skillhub/SkillhubHomeView.tsx
@@ -283,210 +283,211 @@ export function SkillhubHomeView({
         </button>
       )}
     >
-      <main
+      <div
         className={cn(
-          'relative h-full w-full overflow-x-hidden overflow-y-auto [scrollbar-gutter:stable_both-edges]',
+          'relative h-full min-h-0 w-full overflow-hidden',
           embedded ? 'bg-transparent' : 'bg-[var(--surface)]',
         )}
       >
-        <PluginManagementPage className="gap-8">
-          <header className="plugin-motion-page-header flex flex-wrap items-start justify-between gap-4">
-            <div className="min-w-0 pt-1">
-              <h1 className="text-28 font-medium leading-tight text-[var(--text-primary)]">
-                {t('skillhub.home.title')}
-              </h1>
-              <p className="mt-2 max-w-2xl text-14 leading-6 text-[var(--text-secondary)]">
-                {t('skillhub.home.description')}
-              </p>
-            </div>
-            <div
-              className="flex min-w-0 max-w-full flex-wrap items-center justify-end gap-1"
-              role="group"
-              aria-label={t('skillhub.home.catalogFiltersAria')}
-            >
-                {homeCatalogTabs.map((tab) => (
-                  <button
-                    key={tab}
-                    type="button"
-                    aria-pressed={catalogTab === tab}
-                    onClick={() => {
-                      setPreviewSkill(null);
-                      setCatalogTab(tab);
-                    }}
-                    className={cn(
-                      'shrink-0 select-none rounded-full px-3.5 py-2 text-12 transition-colors duration-150',
-                      'focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--focus-ring)]',
-                      catalogTab === tab
-                        ? 'bg-[var(--surface-chip)] font-medium text-[var(--text-primary)]'
-                        : 'text-[var(--text-secondary)] hover:bg-[var(--surface-hover-soft)] hover:text-[var(--text-primary)]',
-                    )}
-                  >
-                    {tab === 'local'
-                      ? t('skillhub.home.local')
-                      : t(`skillhub.home.catalogFilter.${tab}`)}
-                  </button>
-                ))}
-                <button
-                  type="button"
-                  onClick={openMarket}
-                  className={cn(
-                    'inline-flex shrink-0 items-center gap-1 rounded-full px-3.5 py-2 text-12 text-[var(--text-secondary)]',
-                    'transition-colors duration-150 hover:bg-[var(--surface-hover-soft)] hover:text-[var(--text-primary)]',
-                    'focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--focus-ring)]',
-                  )}
-                >
-                  {t('skillhub.home.catalogMore')}
-                  <ChevronRight size={13} strokeWidth={1.8} aria-hidden="true" />
-                </button>
-            </div>
-          </header>
-
-          {/* ① 当前云端目录摘要 */}
-          {catalogTab !== 'local' && (!normalizedQuery || catalogItems.length > 0 || marketLoading) ? (
-            <section className="plugin-motion-page-section min-w-0">
-              {categories.length > 0 ? (
-                <SkillCategoryFilterBar
-                  categories={categories}
-                  selectedCategory={categoryFilter}
-                  allLabel={t('skillhub.market.categoryAll')}
-                  ariaLabel={t('skillhub.home.categoryFiltersAria')}
-                  scrollLeftLabel={t('skillhub.home.scrollCategoriesLeft')}
-                  scrollRightLabel={t('skillhub.home.scrollCategoriesRight')}
-                  scrollStartLabel={t('skillhub.home.categoryScrollAtStart')}
-                  scrollEndLabel={t('skillhub.home.categoryScrollAtEnd')}
-                  onSelectCategory={setCategoryFilter}
-                  className="mb-4"
-                />
-              ) : null}
-
-              {(marketLoading || !marketResponseCurrent) && catalogItems.length === 0 ? (
-                // 占位骨架:与真实卡片同栅格、同行数、同高度,内容到位后原地替换不跳动。
-                <div className={PLUGIN_MANAGEMENT_CARD_GRID_CLASS} aria-hidden>
-                  {Array.from({ length: MARKET_PAGE_SIZE }).map((_, i) => (
-                    <div
-                      key={i}
-                      className="flex min-h-[100px] flex-col gap-2 rounded-[12px] border-[0.5px] border-[var(--border-default)] bg-[var(--surface-elevated)] p-3 shadow-[var(--plugin-card-shadow)]"
-                    >
-                      <div className="flex items-center gap-2">
-                        <div className="size-9 shrink-0 animate-pulse rounded-xl bg-[var(--cmd-palette-item-hover)] opacity-60" />
-                        <div className="h-3.5 w-2/3 animate-pulse rounded bg-[var(--cmd-palette-item-hover)] opacity-60" />
-                      </div>
-                      <div className="h-3 w-full animate-pulse rounded bg-[var(--cmd-palette-item-hover)] opacity-40" />
-                      <div className="h-3 w-4/5 animate-pulse rounded bg-[var(--cmd-palette-item-hover)] opacity-40" />
-                      <div className="mt-auto h-3 w-1/3 animate-pulse rounded bg-[var(--cmd-palette-item-hover)] opacity-40" />
-                    </div>
-                  ))}
-                </div>
-              ) : catalogItems.length === 0 ? (
-                <div className="rounded-[12px] border-[0.5px] border-[var(--border-default)] px-4 py-5 text-13 leading-5 text-[var(--text-secondary)]">
-                  {t('skillhub.home.catalogEmpty')}
-                </div>
-              ) : (
-                <div className={cn('plugin-motion-stagger', PLUGIN_MANAGEMENT_CARD_GRID_CLASS)}>
-                  {catalogItems.map((s) => (
+        <main className="h-full overflow-x-hidden overflow-y-auto [scrollbar-gutter:stable_both-edges]">
+          <PluginManagementPage className="gap-8">
+            <header className="plugin-motion-page-header flex flex-wrap items-start justify-between gap-4">
+              <div className="min-w-0 pt-1">
+                <h1 className="text-28 font-medium leading-tight text-[var(--text-primary)]">
+                  {t('skillhub.home.title')}
+                </h1>
+                <p className="mt-2 max-w-2xl text-14 leading-6 text-[var(--text-secondary)]">
+                  {t('skillhub.home.description')}
+                </p>
+              </div>
+              <div
+                className="flex min-w-0 max-w-full flex-wrap items-center justify-end gap-1"
+                role="group"
+                aria-label={t('skillhub.home.catalogFiltersAria')}
+              >
+                  {homeCatalogTabs.map((tab) => (
                     <button
-                      key={s.name}
+                      key={tab}
                       type="button"
-                      onClick={() => openCatalogSkill(s)}
+                      aria-pressed={catalogTab === tab}
+                      onClick={() => {
+                        setPreviewSkill(null);
+                        setCatalogTab(tab);
+                      }}
                       className={cn(
-                        'group flex min-h-[100px] flex-col gap-1.5 rounded-[12px] border-[0.5px] border-[var(--border-default)]',
-                        'bg-[var(--surface-elevated)] p-3 text-left shadow-[var(--plugin-card-shadow)]',
-                        'transition-[background-color,border-color,transform] duration-150 ease-out',
-                        'hover:-translate-y-0.5 hover:border-[var(--text-tertiary)]',
-                        'active:translate-y-0 active:scale-[0.992]',
+                        'shrink-0 select-none rounded-full px-3.5 py-2 text-12 transition-colors duration-150',
                         'focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--focus-ring)]',
+                        catalogTab === tab
+                          ? 'bg-[var(--surface-chip)] font-medium text-[var(--text-primary)]'
+                          : 'text-[var(--text-secondary)] hover:bg-[var(--surface-hover-soft)] hover:text-[var(--text-primary)]',
                       )}
                     >
-                      <div className="flex items-center gap-2">
-                        <SkillIcon url={s.icon} />
-                        <span className="min-w-0 flex-1 truncate text-sm font-medium text-[var(--msg-assistant-text)]">
-                          {s.displayName || s.name}
-                        </span>
-                        <SkillTagList tags={s.tags} maxVisible={1} className="shrink-0" />
-                        {s.installedLocally && (
-                          <span className="shrink-0 rounded-full bg-[var(--chat-input-chip-bg)] px-1.5 py-0.5 text-10 text-[var(--cmd-palette-item-meta)]">
-                            {t('skillhub.home.installed')}
-                          </span>
-                        )}
-                      </div>
-                      {s.description && (
-                        <p className="line-clamp-2 text-xs text-[var(--cmd-palette-item-meta)]">
-                          {s.description}
-                        </p>
-                      )}
-                      <div className="flex items-center gap-2 text-11 text-[var(--cmd-palette-item-meta)]">
-                        <span className="min-w-0 truncate">{skillPublisherLabel(s)}</span>
-                        <span className="inline-flex shrink-0 items-center gap-0.5">
-                          <Download size={11} />
-                          {s.downloads}
-                        </span>
-                      </div>
+                      {tab === 'local'
+                        ? t('skillhub.home.local')
+                        : t(`skillhub.home.catalogFilter.${tab}`)}
                     </button>
                   ))}
-                  {marketResponseCurrent && marketHasMore ? (
-                    <div className="col-span-full flex justify-center pt-1">
+                  <button
+                    type="button"
+                    onClick={openMarket}
+                    className={cn(
+                      'inline-flex shrink-0 items-center gap-1 rounded-full px-3.5 py-2 text-12 text-[var(--text-secondary)]',
+                      'transition-colors duration-150 hover:bg-[var(--surface-hover-soft)] hover:text-[var(--text-primary)]',
+                      'focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--focus-ring)]',
+                    )}
+                  >
+                    {t('skillhub.home.catalogMore')}
+                    <ChevronRight size={13} strokeWidth={1.8} aria-hidden="true" />
+                  </button>
+              </div>
+            </header>
+
+            {/* ① 当前云端目录摘要 */}
+            {catalogTab !== 'local' && (!normalizedQuery || catalogItems.length > 0 || marketLoading) ? (
+              <section className="plugin-motion-page-section min-w-0">
+                {categories.length > 0 ? (
+                  <SkillCategoryFilterBar
+                    categories={categories}
+                    selectedCategory={categoryFilter}
+                    allLabel={t('skillhub.market.categoryAll')}
+                    ariaLabel={t('skillhub.home.categoryFiltersAria')}
+                    scrollLeftLabel={t('skillhub.home.scrollCategoriesLeft')}
+                    scrollRightLabel={t('skillhub.home.scrollCategoriesRight')}
+                    scrollStartLabel={t('skillhub.home.categoryScrollAtStart')}
+                    scrollEndLabel={t('skillhub.home.categoryScrollAtEnd')}
+                    onSelectCategory={setCategoryFilter}
+                    className="mb-4"
+                  />
+                ) : null}
+
+                {(marketLoading || !marketResponseCurrent) && catalogItems.length === 0 ? (
+                  // 占位骨架:与真实卡片同栅格、同行数、同高度,内容到位后原地替换不跳动。
+                  <div className={PLUGIN_MANAGEMENT_CARD_GRID_CLASS} aria-hidden>
+                    {Array.from({ length: MARKET_PAGE_SIZE }).map((_, i) => (
+                      <div
+                        key={i}
+                        className="flex min-h-[100px] flex-col gap-2 rounded-[12px] border-[0.5px] border-[var(--border-default)] bg-[var(--surface-elevated)] p-3 shadow-[var(--plugin-card-shadow)]"
+                      >
+                        <div className="flex items-center gap-2">
+                          <div className="size-9 shrink-0 animate-pulse rounded-xl bg-[var(--cmd-palette-item-hover)] opacity-60" />
+                          <div className="h-3.5 w-2/3 animate-pulse rounded bg-[var(--cmd-palette-item-hover)] opacity-60" />
+                        </div>
+                        <div className="h-3 w-full animate-pulse rounded bg-[var(--cmd-palette-item-hover)] opacity-40" />
+                        <div className="h-3 w-4/5 animate-pulse rounded bg-[var(--cmd-palette-item-hover)] opacity-40" />
+                        <div className="mt-auto h-3 w-1/3 animate-pulse rounded bg-[var(--cmd-palette-item-hover)] opacity-40" />
+                      </div>
+                    ))}
+                  </div>
+                ) : catalogItems.length === 0 ? (
+                  <div className="rounded-[12px] border-[0.5px] border-[var(--border-default)] px-4 py-5 text-13 leading-5 text-[var(--text-secondary)]">
+                    {t('skillhub.home.catalogEmpty')}
+                  </div>
+                ) : (
+                  <div className={cn('plugin-motion-stagger', PLUGIN_MANAGEMENT_CARD_GRID_CLASS)}>
+                    {catalogItems.map((s) => (
                       <button
+                        key={s.name}
                         type="button"
-                        disabled={marketLoadingMore}
-                        onClick={() => void loadMoreMarket()}
+                        onClick={() => openCatalogSkill(s)}
                         className={cn(
-                          'inline-flex min-h-9 items-center justify-center rounded-full border border-[var(--border-default)]',
-                          'bg-[var(--surface-elevated)] px-5 text-12 font-medium text-[var(--text-secondary)]',
-                          'transition-colors duration-150 hover:bg-[var(--surface-hover)] hover:text-[var(--text-primary)]',
+                          'group flex min-h-[100px] flex-col gap-1.5 rounded-[12px] border-[0.5px] border-[var(--border-default)]',
+                          'bg-[var(--surface-elevated)] p-3 text-left shadow-[var(--plugin-card-shadow)]',
+                          'transition-[background-color,border-color,transform] duration-150 ease-out',
+                          'hover:-translate-y-0.5 hover:border-[var(--text-tertiary)]',
+                          'active:translate-y-0 active:scale-[0.992]',
                           'focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--focus-ring)]',
-                          'disabled:cursor-wait disabled:opacity-60',
                         )}
                       >
-                        {marketLoadingMore
-                          ? t('skillhub.home.loadingMore')
-                          : t('skillhub.home.loadMore')}
+                        <div className="flex items-center gap-2">
+                          <SkillIcon url={s.icon} />
+                          <span className="min-w-0 flex-1 truncate text-sm font-medium text-[var(--msg-assistant-text)]">
+                            {s.displayName || s.name}
+                          </span>
+                          <SkillTagList tags={s.tags} maxVisible={1} className="shrink-0" />
+                          {s.installedLocally && (
+                            <span className="shrink-0 rounded-full bg-[var(--chat-input-chip-bg)] px-1.5 py-0.5 text-10 text-[var(--cmd-palette-item-meta)]">
+                              {t('skillhub.home.installed')}
+                            </span>
+                          )}
+                        </div>
+                        {s.description && (
+                          <p className="line-clamp-2 text-xs text-[var(--cmd-palette-item-meta)]">
+                            {s.description}
+                          </p>
+                        )}
+                        <div className="flex items-center gap-2 text-11 text-[var(--cmd-palette-item-meta)]">
+                          <span className="min-w-0 truncate">{skillPublisherLabel(s)}</span>
+                          <span className="inline-flex shrink-0 items-center gap-0.5">
+                            <Download size={11} />
+                            {s.downloads}
+                          </span>
+                        </div>
                       </button>
-                    </div>
-                  ) : null}
-                </div>
-              )}
-            </section>
-          ) : null}
+                    ))}
+                    {marketResponseCurrent && marketHasMore ? (
+                      <div className="col-span-full flex justify-center pt-1">
+                        <button
+                          type="button"
+                          disabled={marketLoadingMore}
+                          onClick={() => void loadMoreMarket()}
+                          className={cn(
+                            'inline-flex min-h-9 items-center justify-center rounded-full border border-[var(--border-default)]',
+                            'bg-[var(--surface-elevated)] px-5 text-12 font-medium text-[var(--text-secondary)]',
+                            'transition-colors duration-150 hover:bg-[var(--surface-hover)] hover:text-[var(--text-primary)]',
+                            'focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--focus-ring)]',
+                            'disabled:cursor-wait disabled:opacity-60',
+                          )}
+                        >
+                          {marketLoadingMore
+                            ? t('skillhub.home.loadingMore')
+                            : t('skillhub.home.loadMore')}
+                        </button>
+                      </div>
+                    ) : null}
+                  </div>
+                )}
+              </section>
+            ) : null}
 
-          {/* ② 本地技能 */}
-          {catalogTab === 'local' && (!normalizedQuery || visibleLocalCount > 0) ? (
-            <section className="plugin-motion-page-section min-w-0">
-              {visibleLocalCount === 0 ? (
-                <div className="rounded-[12px] border-[0.5px] border-[var(--border-default)] px-4 py-5 text-13 leading-5 text-[var(--text-secondary)]">
-                  {bootstrapped ? t('skillhub.home.localEmpty') : t('skillhub.welcome.scanning')}
-                </div>
-              ) : (
-                <div className="flex flex-col gap-6">
-                  {globalSkills.length > 0 && (
-                    <LocalGroup
-                      skills={globalSkills}
-                      syncResults={syncResults}
-                      onOpen={openLocal}
-                    />
-                  )}
-                  {projectGroups.map((g) => (
-                    <LocalGroup
-                      key={g.root}
-                      label={g.label}
-                      skills={g.skills}
-                      syncResults={syncResults}
-                      onOpen={openLocal}
-                    />
-                  ))}
-                </div>
-              )}
-            </section>
-          ) : null}
+            {/* ② 本地技能 */}
+            {catalogTab === 'local' && (!normalizedQuery || visibleLocalCount > 0) ? (
+              <section className="plugin-motion-page-section min-w-0">
+                {visibleLocalCount === 0 ? (
+                  <div className="rounded-[12px] border-[0.5px] border-[var(--border-default)] px-4 py-5 text-13 leading-5 text-[var(--text-secondary)]">
+                    {bootstrapped ? t('skillhub.home.localEmpty') : t('skillhub.welcome.scanning')}
+                  </div>
+                ) : (
+                  <div className="flex flex-col gap-6">
+                    {globalSkills.length > 0 && (
+                      <LocalGroup
+                        skills={globalSkills}
+                        syncResults={syncResults}
+                        onOpen={openLocal}
+                      />
+                    )}
+                    {projectGroups.map((g) => (
+                      <LocalGroup
+                        key={g.root}
+                        label={g.label}
+                        skills={g.skills}
+                        syncResults={syncResults}
+                        onOpen={openLocal}
+                      />
+                    ))}
+                  </div>
+                )}
+              </section>
+            ) : null}
 
-          {normalizedQuery && (catalogTab === 'local' || !marketLoading) && !hasSearchResults ? (
-            <div className="plugin-motion-page-section rounded-[12px] border-[0.5px] border-[var(--border-default)] px-4 py-8 text-center text-13 leading-5 text-[var(--text-secondary)]">
-              {t('skillhub.home.noSearchResults')}
-            </div>
-          ) : null}
-        </PluginManagementPage>
+            {normalizedQuery && (catalogTab === 'local' || !marketLoading) && !hasSearchResults ? (
+              <div className="plugin-motion-page-section rounded-[12px] border-[0.5px] border-[var(--border-default)] px-4 py-8 text-center text-13 leading-5 text-[var(--text-secondary)]">
+                {t('skillhub.home.noSearchResults')}
+              </div>
+            ) : null}
+          </PluginManagementPage>
+        </main>
 
-        {/* 推荐技能预览浮层(下一步)+ 安装选择器 —— 复用 Market 同款。
-          点推荐卡 = 打开预览;关闭 = 回退到首页。 */}
+        {/* Keep the preview outside the list scroller so it stays anchored to the viewport. */}
         <SkillhubMarketPreviewPanel
           open={previewSkill !== null}
           skill={previewSkill}
@@ -572,7 +573,7 @@ export function SkillhubHomeView({
             });
           }}
         />
-      </main>
+      </div>
     </PluginManagementLayout>
   );
 }

--- a/apps/desktop/src/renderer/features/skillhub/SkillhubMarketPreviewPanel.tsx
+++ b/apps/desktop/src/renderer/features/skillhub/SkillhubMarketPreviewPanel.tsx
@@ -303,7 +303,7 @@ export function SkillhubMarketPreviewPanel({
                 <h3 className="mb-2 shrink-0 text-xs font-medium uppercase tracking-wider text-[var(--cmd-palette-item-meta)]">
                   {t('skillhub.marketDetail.files')}
                 </h3>
-                <div className="min-h-0 flex-1 overflow-y-auto">
+                <div className="min-h-0 flex-1 overflow-y-auto overscroll-contain">
                   {filesLoading ? null : tree.length === 0 ? (
                     <p className="px-1 text-xs text-[var(--cmd-palette-item-meta)]">
                       {t('skillhub.marketDetail.noPreviewFiles')}
@@ -320,7 +320,7 @@ export function SkillhubMarketPreviewPanel({
 
               <main
                 className={cn(
-                  'flex min-w-0 flex-1 flex-col overflow-y-auto bg-[hsl(var(--content-area))]',
+                  'flex min-w-0 flex-1 flex-col overflow-y-auto overscroll-contain bg-[hsl(var(--content-area))]',
                   'text-15 font-normal leading-[1.65] text-[var(--text-primary)]',
                 )}
               >


### PR DESCRIPTION
## 这次改了什么

### 摘要

Skill Tab 的详情预览原本挂在列表滚动容器内：列表已有滚动偏移或继续滚动时，详情浮层会一起向上移动。现在将详情与列表滚动区分开，详情固定在内容区内；正文和文件树独立滚动，关闭详情后保留列表位置。

### 变更类型

- [x] `fix` 缺陷修复

### 范围

- 关联需求：修复 Skill Tab 列表滚动带走详情浮层的问题。
- 本 PR 包含：Skill 首页增加不滚动的定位外层；详情正文和文件树增加 `overscroll-contain`。
- 明确不包含：服务端、端点配置、插件运行时及数据逻辑。
- 用户可见变化：滚动列表、详情正文或文件树时，详情浮层位置保持稳定。
- 是否存在 breaking change：无。

### UI 变化

- 引用的设计规范：`docs/design-rules/DESIGN.md` §8 Window & Adaptive Behavior、§10 Light / Dark Dual-Mode Delivery Gate。浮层仍限定在内容区内，保留现有尺寸、层级和语义颜色 token；Light/Dark 使用同一滚动结构。
- 验证平台：macOS。未附实机截图或录屏；本次以隔离 Chromium 的滚动几何断言验证行为，未完成 Light/Dark 实机目检。
- 首页较大的文本 diff 来自增加列表容器后的 JSX 缩进；可用忽略空白的 diff 查看实际逻辑变化。

## 怎么验证的

### 自动验证

```text
pnpm test:unit:related
结果：通过。

pnpm --filter desktop run --if-present typecheck
结果：通过。

git diff --check
结果：通过。
```

隔离 Chromium 布局验证（临时脚本，非完整应用 E2E）：从改动前后 TSX 提取容器结构与 class，使用 Tailwind 生成样式并填充长列表/正文。原版列表滚动 500px 后详情上移 500px；修复后详情位移为 0。正文和文件树滚到底继续滚动不会改变背景列表位置，移除详情后列表仍保留 500px 偏移，均通过。

### 手工验证

修复 worktree 已通过安全启动入口启动 macOS Desktop remote dev 隔离实例，返回 `DESKTOP_DEV_VERDICT=ready`（region=dev）。这仅证明应用启动就绪，不代表详情页实机交互已验证。

### 未执行的验证

- 未完成 Light/Dark 实机目检及完整应用详情交互回归；滚动行为通过隔离浏览器布局验证。
- 未进行 Windows 实机验证；此次未增加平台分支。

## 风险

### 风险分类

- [x] 其他：低风险 UI 滚动容器调整；完整应用与 Windows 实机回归尚未完成。

### 影响与回滚

- 影响范围：Skill 首页（含设置内嵌入口）的列表与详情定位；共享市场预览组件的正文和文件树滚动边界。
- 回滚方式：回退本提交；无数据迁移。

### 提交前检查

- [x] 已 review 完整 diff
- [x] 每个 commit 都带 DCO 签名（`git commit -s`）
- [x] UI 改动已在「UI 变化」注明引用的设计规范章节
- [x] 未提交凭证、令牌或授权文件
- [x] 已补充必要文档（PR 中记录根因和验证范围，无新增产品规则）
- [x] 已确认测试结果或说明未执行原因
