### PR TITLE
fix(mobile): prevent UI worklet closure crash

### DIFF
--- a/apps/mobile/src/__tests__/workletProductionTransform.test.ts
+++ b/apps/mobile/src/__tests__/workletProductionTransform.test.ts
@@ -1,0 +1,72 @@
+import { createRequire } from 'node:module';
+import { resolve } from 'node:path';
+import { describe, expect, it } from 'vitest';
+
+type BabelTransformResult = { code?: string | null };
+type Babel = {
+  transformFileSync: (filename: string, options: Record<string, unknown>) => BabelTransformResult;
+};
+type WorkletFunction = ((input: unknown) => unknown) & {
+  __closure?: Record<string, unknown>;
+};
+
+const require = createRequire(import.meta.url);
+const babel = require('@babel/core') as Babel;
+const expoPreset = require('babel-preset-expo');
+
+/** Evaluate a pure model module after the same transform used by Android release bundles. */
+function loadProductionModule(relativePath: string): Record<string, unknown> {
+  const filename = resolve(process.cwd(), relativePath);
+  const transformed = babel.transformFileSync(filename, {
+    babelrc: false,
+    configFile: false,
+    envName: 'production',
+    filename,
+    presets: [[expoPreset, { platform: 'android' }]],
+  });
+  if (!transformed.code) throw new Error(`Babel produced no code for ${relativePath}`);
+  const moduleExports: Record<string, unknown> = {};
+  const evaluate = Function('exports', transformed.code) as (exports: Record<string, unknown>) => void;
+  evaluate(moduleExports);
+  return moduleExports;
+}
+
+function worklet(moduleExports: Record<string, unknown>, name: string): WorkletFunction {
+  const value = moduleExports[name];
+  expect(typeof value).toBe('function');
+  return value as WorkletFunction;
+}
+
+describe('Android production worklet transform', () => {
+  it('initializes composer resize helper closures before the UI gesture calls them', () => {
+    const moduleExports = loadProductionModule('src/session/composerResize.ts');
+    const applyComposerResizeDrag = worklet(moduleExports, 'applyComposerResizeDrag');
+
+    expect(typeof applyComposerResizeDrag.__closure?.normalizeBounds).toBe('function');
+    expect(typeof applyComposerResizeDrag.__closure?.clamp).toBe('function');
+    expect(applyComposerResizeDrag({
+      bounds: { minContentHeight: 20, maxContentHeight: 200 },
+      startContentHeight: 40,
+      translationY: -10,
+    })).toBe(50);
+  });
+
+  it('initializes context sheet helper closures before UI drag and settle worklets call them', () => {
+    const moduleExports = loadProductionModule('src/session/contextSheetModel.ts');
+    const applyContextSheetDrag = worklet(moduleExports, 'applyContextSheetDrag');
+    const settleContextSheetDrag = worklet(moduleExports, 'settleContextSheetDrag');
+
+    expect(typeof applyContextSheetDrag.__closure?.normalizeHeights).toBe('function');
+    expect(typeof applyContextSheetDrag.__closure?.clamp).toBe('function');
+    expect(typeof settleContextSheetDrag.__closure?.normalizeHeights).toBe('function');
+    expect(applyContextSheetDrag({
+      heights: { half: 320, full: 700 },
+      startHeight: 320,
+      translationY: -100,
+    })).toBe(420);
+    expect(settleContextSheetDrag({
+      heights: { half: 320, full: 700 },
+      draggedHeight: 600,
+    })).toBe('full');
+  });
+});

--- a/apps/mobile/src/session/composerResize.ts
+++ b/apps/mobile/src/session/composerResize.ts
@@ -47,6 +47,24 @@ export const COMPOSER_RESIZE_AUTO_SNAP_THRESHOLD = 24;
 /** manual 模式上边界之上保留的屏幕空间（顶部导航 + 至少一部分消息内容可见）。 */
 export const COMPOSER_RESIZE_TOP_RESERVED_HEIGHT = 220;
 
+// Worklets' Babel transform lowers function declarations with a `worklet`
+// directive into initialization expressions. Keep helpers before every
+// worklet that captures them, otherwise the caller's closure is initialized
+// with `undefined` during module evaluation.
+function normalizeBounds(bounds: ComposerResizeBounds): ComposerResizeBounds {
+  'worklet';
+  const minContentHeight = Math.max(1, Math.round(bounds.minContentHeight));
+  return {
+    minContentHeight,
+    maxContentHeight: Math.max(minContentHeight, Math.round(bounds.maxContentHeight)),
+  };
+}
+
+function clamp(value: number, min: number, max: number): number {
+  'worklet';
+  return Math.min(Math.max(value, min), max);
+}
+
 export interface ResolveComposerInputHeightInput {
   /** TextInput 上报的内容高度（页面 state）。 */
   contentHeight: number;
@@ -295,24 +313,10 @@ export function computeComposerResizeBounds(
   };
 }
 
-function normalizeBounds(bounds: ComposerResizeBounds): ComposerResizeBounds {
-  'worklet';
-  const minContentHeight = Math.max(1, Math.round(bounds.minContentHeight));
-  return {
-    minContentHeight,
-    maxContentHeight: Math.max(minContentHeight, Math.round(bounds.maxContentHeight)),
-  };
-}
-
 function normalizePositiveDimension(value: number, fallback: number): number {
   return Number.isFinite(value) && value > 0 ? value : fallback;
 }
 
 function normalizeNonNegativeDimension(value: number, fallback: number): number {
   return Number.isFinite(value) && value >= 0 ? value : fallback;
-}
-
-function clamp(value: number, min: number, max: number): number {
-  'worklet';
-  return Math.min(Math.max(value, min), max);
 }

--- a/apps/mobile/src/session/contextSheetModel.ts
+++ b/apps/mobile/src/session/contextSheetModel.ts
@@ -27,6 +27,20 @@ const FULL_TOP_RESERVED_HEIGHT = 64;
 /** 松手高度低于 half 档的该比例时判定为「想关掉」。 */
 export const CONTEXT_SHEET_DISMISS_RATIO = 0.62;
 
+// Keep worklet helpers before their callers. The Worklets Babel transform
+// materializes worklet function declarations in source order; a later helper
+// would otherwise be captured as `undefined` during module initialization.
+function normalizeHeights(heights: ContextSheetSnapHeights): ContextSheetSnapHeights {
+  'worklet';
+  const half = Math.max(1, Math.round(heights.half));
+  return { half, full: Math.max(half, Math.round(heights.full)) };
+}
+
+function clamp(value: number, min: number, max: number): number {
+  'worklet';
+  return Math.min(Math.max(value, min), max);
+}
+
 export interface ComputeContextSheetSnapHeightsInput {
   /** 窗口高度（useWindowDimensions().height）。 */
   screenHeight: number;
@@ -83,21 +97,10 @@ export function settleContextSheetDrag(input: SettleContextSheetDragInput): Cont
   return 'half';
 }
 
-function normalizeHeights(heights: ContextSheetSnapHeights): ContextSheetSnapHeights {
-  'worklet';
-  const half = Math.max(1, Math.round(heights.half));
-  return { half, full: Math.max(half, Math.round(heights.full)) };
-}
-
 function normalizePositiveDimension(value: number | undefined, fallback: number): number {
   return typeof value === 'number' && Number.isFinite(value) && value > 0 ? value : fallback;
 }
 
 function normalizeNonNegativeDimension(value: number | undefined, fallback: number): number {
   return typeof value === 'number' && Number.isFinite(value) && value >= 0 ? value : fallback;
-}
-
-function clamp(value: number, min: number, max: number): number {
-  'worklet';
-  return Math.min(Math.max(value, min), max);
 }


### PR DESCRIPTION
## 这次改了什么

### 摘要

修复 [#4039](https://github.com/makecindy/cindy/issues/4039) 中 Android 输入框上拉拖拽导致应用闪退的问题。

根因来自 [#3948](https://github.com/makecindy/cindy/pull/3948)：输入框拖拽迁移到 UI worklet 后，生产 Worklets Babel 转换会把带 `worklet` 指令的函数声明按源码顺序初始化。调用者位于 helper 之前，导致 `normalizeBounds` / `clamp` 在 worklet 闭包创建时仍为 `undefined`。

### 变更类型

- [x] `fix` 缺陷修复
- [ ] `feat` 新功能
- [ ] `refactor` / `perf` 重构或性能优化
- [ ] `docs` / `test` / `chore` 文档、测试或工程维护
- [ ] 其他：

### 范围

- 关联 Issue / 需求：Closes #4039
- 本 PR 包含：
  - 将 `composerResize` 的 worklet helper 放到调用者之前，确保生产闭包捕获真实函数；
  - 对 `contextSheetModel` 应用同一修复，避免同一根因造成内容面板拖拽闪退；
  - 新增 Android production Babel 转换回归测试，检查闭包依赖和实际拖拽结果。
- 明确不包含：原生依赖、Expo 配置、手势架构、输入框高度模型或视觉样式调整。
- 用户可见变化：Android 安装版拖拽输入框不再因 worklet helper 缺失而闪退；现有 UI 线程拖拽行为保持不变。
- 是否存在 breaking change：无。

### UI 变化

- 引用的设计规范：`docs/design-rules/DESIGN.md` §7（渲染性能与视觉连续性）、§10（Light / Dark 双模式交付门槛）、§14.4（功能性动效）。
- 不改变颜色、布局、文案或主题状态；保留现有 Light / Dark 样式和 UI 线程手势路径。

## 怎么验证的

### 自动验证

```text
pnpm test:unit:related
结果：通过；以 upstream/main 为基线，仅运行 apps/mobile 相关测试。

pnpm --filter mobile test
结果：通过；374 个测试文件、4,674 项测试。

pnpm --filter mobile run --if-present typecheck
结果：通过。

pnpm --filter mobile exec vitest run src/__tests__/workletProductionTransform.test.ts src/__tests__/composerResize.test.ts src/__tests__/contextSheet.test.ts
结果：通过；44 项测试。

pnpm check:dco
结果：通过。

git diff --check
结果：通过。
```

### 手工验证

未执行 Android / iOS 真机或模拟器上的实际拖拽操作；当前环境没有可用的设备验证链路。

### 未执行的验证

未执行真机键盘、IME、Light / Dark 目检和 OTA 安装验证。

## 风险

### 风险分类

- [ ] SQLite / migration
- [ ] system prompt
- [ ] 协议兼容
- [ ] 权限 / 安全 / 用户数据
- [ ] 存量插件兼容（批准状态 / 指纹 / manifest 校验 / 安装布局 / 包格式）
- [ ] 原生层 / fingerprint / OTA
- [x] 跨平台差异
- [x] 其他：生产 Babel worklet 闭包初始化顺序

### 影响与回滚

- 影响范围：Mobile 输入框和内容面板的 UI worklet helper 初始化；Expo Go 的 JS fallback 和现有手势结算语义保持不变。
- 回滚 / 降级方式：回退本 PR 提交即可恢复原代码；未涉及数据库、协议、原生配置或 runtime fingerprint，JS-only 修复可按现有 OTA 流程评估发布。

### 提交前检查

- [x] 已 review 完整 diff
- [x] 每个 commit 都带 DCO 签名（`git commit -s`，见 [DCO](../DCO)）
- [x] UI 改动已在「UI 变化」注明引用的设计规范章节
- [x] 未提交凭证、令牌或授权文件
- [x] 已补充必要文档
- [x] 已确认测试结果或说明未执行原因
