### PR TITLE
fix(desktop): 工作目录缺失时恢复目录并继续对话

### DIFF
--- a/apps/desktop/src/main/__tests__/mobileClientPromptNote.test.ts
+++ b/apps/desktop/src/main/__tests__/mobileClientPromptNote.test.ts
@@ -218,7 +218,7 @@ describe('shouldPrependMobileClientPromptNote(内置命令旁路)', () => {
       },
       'claude-code',
     )).toBe(true);
-    expect(shouldPrependMobileClientPromptNote('/compact', 'pi')).toBe(true);
+    expect(shouldPrependMobileClientPromptNote('/compact', 'pi')).toBe(false);
     expect(shouldPrependMobileClientPromptNote('/compact', 'codex')).toBe(true);
   });
 });

--- a/apps/desktop/src/main/bootstrap-electron.ts
+++ b/apps/desktop/src/main/bootstrap-electron.ts
@@ -618,6 +618,7 @@ import {
   anySessionInTurn,
   applyCodexSpawnConfigChangeWithRestart,
   clearDeferredCodexRestartForOwnerBoundary,
+  clearWorkingDirectoryRecoveryForOwnerBoundary,
   collectAgentInputQueueScanTexts,
   createAutomationUserTurnGitBaselineHooks,
   registerModelVisibilitySyncIpc,
@@ -1748,6 +1749,7 @@ async function teardownAuthAccountBoundary(reason: string): Promise<void> {
     // 的 Maker 上兑现旧 owner 的记忆设置重启(shutdown 触发的会话关闭事件也会
     // 撞上它,先清再关)。
     clearDeferredCodexRestartForOwnerBoundary();
+    clearWorkingDirectoryRecoveryForOwnerBoundary();
     // interrupted-turn-resume:shutdown 批量 close 会话会触发 close teardown 的
     // markSessionTurnEnded,把"边界时还在飞的 turn"伪装成正常收尾 —— 被切换打断的
     // 任务从此既无中断横幅也无红点,呈现为"卡住且无报错"(与 ⌘Q 的 quit freeze 同款

--- a/apps/desktop/src/main/maker-ipc/__tests__/bootstrapDirectoryGrants.test.ts
+++ b/apps/desktop/src/main/maker-ipc/__tests__/bootstrapDirectoryGrants.test.ts
@@ -43,6 +43,49 @@ function createOpts(
 }
 
 describe('prepareDirectoryGrantsForBootstrap', () => {
+  it.each(['readonly', 'writable'])('does not grant writes when %s canonicalization times out during fallback', async (failed) => {
+    const { workspace, specs, output } = makeGrantTree();
+    const opts = createOpts(workspace, [specs], [output]);
+    const persistExistingSession = vi.fn(async () => {});
+    await prepareDirectoryGrantsForBootstrap(opts, {
+      preservePersistedGrants: true,
+      readPersistedWritableDirs: async () => [output],
+      realpathDirectory: async (dir) => {
+        if (dir === (failed === 'readonly' ? specs : output)) {
+          throw Object.assign(new Error('timeout'), { code: 'WORKDIR_PROBE_TIMEOUT' });
+        }
+        return dir;
+      },
+      persistExistingSession,
+    });
+    expect(opts).toMatchObject({ extraDirs: [specs], writableDirs: [] });
+    expect(persistExistingSession).not.toHaveBeenCalled();
+  });
+
+  it('keeps saved grants through fallback bootstrap while filtering unavailable runtime roots', async () => {
+    const { workspace, specs, output, root } = makeGrantTree();
+    const stored = { extraDirs: [specs], writableDirs: [output] };
+    const persistExistingSession = vi.fn(async () => {});
+    const statDirectory = vi.fn(async () => {
+      throw Object.assign(new Error('share unavailable'), { code: 'WORKDIR_PROBE_TIMEOUT' });
+    });
+    const temporary = createOpts(workspace, stored.extraDirs, [root]);
+    await prepareDirectoryGrantsForBootstrap(temporary, {
+      preservePersistedGrants: true, statDirectory,
+      readPersistedWritableDirs: async () => stored.writableDirs,
+      persistExistingSession,
+    });
+    expect(temporary).toMatchObject({ extraDirs: [], writableDirs: [] });
+    expect(statDirectory.mock.calls.flat()).not.toContain(root);
+    expect(persistExistingSession).not.toHaveBeenCalled();
+    const reconnected = createOpts(workspace, stored.extraDirs, [root]);
+    await prepareDirectoryGrantsForBootstrap(reconnected, {
+      readPersistedWritableDirs: async () => stored.writableDirs, persistExistingSession,
+    });
+    expect(reconnected).toMatchObject(stored);
+    expect(persistExistingSession).not.toHaveBeenCalled();
+  });
+
   it('persists the complete applied subset when lazy bootstrap removes a nested writable grant', async () => {
     const { workspace, shared, specs, output } = makeGrantTree();
     const opts = createOpts(workspace, [specs], [shared, output]);

--- a/apps/desktop/src/main/maker-ipc/__tests__/makerSendTransaction.test.ts
+++ b/apps/desktop/src/main/maker-ipc/__tests__/makerSendTransaction.test.ts
@@ -1159,7 +1159,7 @@ describe('maker SEND transaction', () => {
   });
 
   it.each(['claude-code', 'pi'] as const)('refreshes a live %s process after same-path recovery and preserves its note', async (agentKind) => {
-    const oldSession = createSession({ agentKind });
+    const oldSession = createSession({ agentKind, hostUserPrompt: 'Keep the caller preference' });
     const recovered = createSession({ agentKind });
     const { deps } = createDeps({
       getSession: () => oldSession,
@@ -1179,7 +1179,7 @@ describe('maker SEND transaction', () => {
     expect(deps.closeSession).toHaveBeenCalledOnce();
     expect(deps.bootstrapSession).toHaveBeenCalledWith(expect.objectContaining({
       workingDir: oldSession.workDir, resumeSessionId: 'native-history',
-      permissionMode: 'ask', planMode: true,
+      permissionMode: 'ask', planMode: true, userPrompt: 'Keep the caller preference',
     }));
     expect(oldSession.send).not.toHaveBeenCalled();
     expect(recovered.send).toHaveBeenCalledWith(expect.stringContaining('original files remain missing'), expect.anything());
@@ -2011,8 +2011,8 @@ describe('mobile client prompt note', () => {
     expect(session.send).toHaveBeenCalledWith('/compact focus on decisions', expect.anything());
   });
 
-  it('keeps the mobile note for /compact text sent to a non-Claude agent', async () => {
-    const session = createSession({ agentKind: 'pi' });
+  it('keeps the mobile note for /compact text sent to Codex', async () => {
+    const session = createSession({ agentKind: 'codex' });
     const { deps } = createDeps({
       getSession: vi.fn(() => session),
       isMobileClientInvoke: vi.fn(() => true),
@@ -2048,6 +2048,27 @@ describe('mobile client prompt note', () => {
 });
 
 describe('session-agent-switch handoff injection', () => {
+  it.each([
+    '/skill:git',
+    ' /extension-command argument',
+    { type: 'user' as const, content: [{ type: 'text' as const, text: '/skill:git' }, { type: 'image' as const, url: 'https://example.invalid/image.png' }] },
+  ])('keeps Pi command intact and retains recovery note: %j', async (command) => {
+    const session = createSession({ agentKind: 'pi' });
+    const consumeWorkingDirectoryRecoveryNote = vi.fn();
+    const { deps } = createDeps({
+      getSession: () => session,
+      peekWorkingDirectoryRecoveryNote: () => 'Directory recreated',
+      consumeWorkingDirectoryRecoveryNote,
+      bootstrapSession: vi.fn(async () => ({ session, didInjectOrcaInstructions: false, didInjectProjectContext: false })),
+    });
+    const transaction = createMakerSendTransaction(deps);
+    await transaction.sendToAgentAccepted('session-1', command);
+    expect(session.send).toHaveBeenLastCalledWith(command, expect.anything());
+    expect(consumeWorkingDirectoryRecoveryNote).not.toHaveBeenCalled();
+    await transaction.sendToAgentAccepted('session-1', 'continue');
+    expect(session.send).toHaveBeenLastCalledWith(expect.stringContaining('Directory recreated'), expect.anything());
+    expect(consumeWorkingDirectoryRecoveryNote).toHaveBeenCalledOnce();
+  });
   it.each([
     '/compact',
     { type: 'user' as const, content: '/compact focus on the bug' },

--- a/apps/desktop/src/main/maker-ipc/__tests__/makerSendTransaction.test.ts
+++ b/apps/desktop/src/main/maker-ipc/__tests__/makerSendTransaction.test.ts
@@ -1107,6 +1107,82 @@ describe('maker SEND transaction', () => {
     expect(session.send).not.toHaveBeenCalled();
   });
 
+  it('recovers a live session from the repaired DB directory and resumes its native history', async () => {
+    const recoveredSession = createSession({ workDir: '/repaired/project' });
+    const { deps, session } = createDeps({
+      readSessionWorkingDirFromDb: vi.fn(async () => '/repaired/project'),
+      checkWorkDirExists: vi.fn(async (_id, dir) => dir === '/repaired/project'),
+      reconcileCreateOptsWithDb: vi.fn(async (_id, opts) => {
+        expect(deps.closeSession).not.toHaveBeenCalled();
+        opts.resumeSessionId = 'native-history';
+        opts.model = 'persisted-model';
+      }),
+      bootstrapSession: vi.fn(async () => ({
+        session: recoveredSession,
+        didInjectOrcaInstructions: false,
+        didInjectProjectContext: false,
+      })),
+    });
+    const transaction = createMakerSendTransaction(deps);
+
+    await expect(transaction.sendToAgentAccepted('session-1', 'hello', {
+      agentKind: 'codex', workingDir: '/stale/caller', model: 'stale-model',
+    })).resolves.toMatchObject({ accepted: true });
+
+    expect(deps.checkWorkDirExists).toHaveBeenNthCalledWith(
+      1, 'session-1', session.workDir, 'codex', null, { suppressMissingBroadcast: true },
+    );
+    expect(deps.bootstrapSession).toHaveBeenCalledWith(expect.objectContaining({
+      id: 'session-1', workingDir: '/repaired/project', remoteHostId: undefined,
+      resumeSessionId: 'native-history', model: 'persisted-model',
+    }));
+    expect(deps.closeSession).toHaveBeenCalledTimes(1);
+    expect(session.send).not.toHaveBeenCalled();
+    expect(recoveredSession.send).toHaveBeenCalledTimes(1);
+  });
+
+  it('keeps the live runtime when both its directory and the DB replacement are missing', async () => {
+    const { deps, session } = createDeps({
+      readSessionWorkingDirFromDb: vi.fn(async () => '/also/missing'),
+      checkWorkDirExists: vi.fn(async () => false),
+      reconcileCreateOptsWithDb: vi.fn(async () => {}),
+    });
+    await expect(createMakerSendTransaction(deps).sendToAgentAccepted('session-1', 'hello', {
+      agentKind: 'codex', workingDir: '/stale/caller',
+    })).resolves.toMatchObject({ accepted: false, reason: 'WORKDIR_MISSING' });
+    expect(deps.closeSession).not.toHaveBeenCalled();
+    expect(deps.bootstrapSession).not.toHaveBeenCalled();
+    expect(session.send).not.toHaveBeenCalled();
+  });
+
+  it('does not close the live runtime if native history reconciliation fails during directory recovery', async () => {
+    const { deps, session } = createDeps({
+      readSessionWorkingDirFromDb: vi.fn(async () => '/repaired/project'),
+      checkWorkDirExists: vi.fn(async (_id, dir) => dir === '/repaired/project'),
+      reconcileCreateOptsWithDb: vi.fn(async () => { throw new Error('DB unavailable'); }),
+    });
+    await expect(createMakerSendTransaction(deps).sendToAgentAccepted('session-1', 'hello', {
+      agentKind: 'codex', workingDir: '/stale/caller',
+    })).resolves.toMatchObject({ accepted: false, reason: 'REHYDRATE_FAILED' });
+    expect(deps.closeSession).not.toHaveBeenCalled();
+    expect(deps.bootstrapSession).not.toHaveBeenCalled();
+    expect(session.send).not.toHaveBeenCalled();
+  });
+
+  it('does not use local DB directory recovery for a live SSH session', async () => {
+    const session = createSession({ remoteHostId: 'ssh-host' });
+    const { deps } = createDeps({
+      getSession: vi.fn(() => session),
+      readSessionWorkingDirFromDb: vi.fn(async () => '/local/project'),
+      reconcileCreateOptsWithDb: vi.fn(async () => {}),
+    });
+    await expect(createMakerSendTransaction(deps).sendToAgentAccepted('session-1', 'hello', {
+      agentKind: 'codex', workingDir: '/remote/project', remoteHostId: 'ssh-host',
+    })).resolves.toMatchObject({ accepted: true });
+    expect(deps.readSessionWorkingDirFromDb).not.toHaveBeenCalled();
+    expect(deps.closeSession).not.toHaveBeenCalled();
+  });
+
   it('rebuilds an error session through lazy bootstrap before dispatch', async () => {
     const failedSession = createSession({
       getStatus: vi.fn(() => 'error' as const),
@@ -1921,6 +1997,38 @@ describe('mobile client prompt note', () => {
 });
 
 describe('session-agent-switch handoff injection', () => {
+  it('tells the agent about recreated cwd without changing the displayed user message', async () => {
+    const consumeWorkingDirectoryRecoveryNote = vi.fn();
+    const { deps, session } = createDeps({
+      peekWorkingDirectoryRecoveryNote: () => 'The directory was recreated; files are missing.',
+      consumeWorkingDirectoryRecoveryNote,
+    });
+    await createMakerSendTransaction(deps).sendToAgentAccepted('session-1', 'hello', undefined, {
+      persistUserMessage: { clientId: 'input', content: 'hello' },
+    });
+    expect(session.send).toHaveBeenCalledWith(
+      expect.stringContaining('The directory was recreated; files are missing.'), expect.anything(),
+    );
+    expect(vi.mocked(deps.createDbMessage).mock.calls[0]?.[1].content).toBe('hello');
+    expect(consumeWorkingDirectoryRecoveryNote).toHaveBeenCalledWith(
+      'session-1', 'The directory was recreated; files are missing.',
+    );
+  });
+
+  it('keeps the recovery notice when the provider has not accepted the message', async () => {
+    const consumeWorkingDirectoryRecoveryNote = vi.fn();
+    const session = createSession({
+      send: vi.fn(async () => ({ accepted: false, reason: 'cancelled-before-dispatch' } satisfies SessionSendResult)),
+    });
+    const { deps } = createDeps({
+      getSession: () => session,
+      peekWorkingDirectoryRecoveryNote: () => 'Directory recreated',
+      consumeWorkingDirectoryRecoveryNote,
+    });
+    await createMakerSendTransaction(deps).sendToAgentAccepted('session-1', 'hello');
+    expect(consumeWorkingDirectoryRecoveryNote).not.toHaveBeenCalled();
+  });
+
   it('pending 命中时 wire payload 前置交接段,落库内容保持用户原文,accepted 后 consume', async () => {
     const consumePendingHandoff = vi.fn();
     const { deps, session } = createDeps({

--- a/apps/desktop/src/main/maker-ipc/__tests__/makerSendTransaction.test.ts
+++ b/apps/desktop/src/main/maker-ipc/__tests__/makerSendTransaction.test.ts
@@ -55,6 +55,9 @@ function createDeps(overrides: Partial<MakerSendTransactionDeps> = {}) {
     synthesizeOrcaVendorOptionsFromDb: vi.fn(async () => false),
     readSessionExtraDirsFromDb: vi.fn(async () => []),
     readSessionWorkingDirFromDb: vi.fn(async () => null),
+    readWorkingDirectoryRecoveryCreateOpts: vi.fn(async (): Promise<MakerSessionCreateOpts> => ({
+      agentKind: 'codex', workingDir: 'C:\\repo', model: 'gpt-5.4',
+    })),
     withRehydrateCloseSuppressed: vi.fn(async (_sessionId, fn) => await fn()),
     bootstrapSession: vi.fn(async (opts: MakerSessionCreateOpts) => ({
       session: createSession({
@@ -1155,6 +1158,26 @@ describe('maker SEND transaction', () => {
     expect(session.send).not.toHaveBeenCalled();
   });
 
+  it('uses persisted settings to recover a live session when send has no createOpts', async () => {
+    const persisted: MakerSessionCreateOpts = {
+      agentKind: 'codex', workingDir: '/repaired/project',
+      model: 'persisted-model', resumeSessionId: 'native-history',
+      permissionMode: 'ask', planMode: true, providerId: 'provider', fastMode: true,
+    };
+    const { deps, session } = createDeps({
+      readSessionWorkingDirFromDb: vi.fn(async () => persisted.workingDir),
+      readWorkingDirectoryRecoveryCreateOpts: vi.fn(async () => ({ ...persisted })),
+      checkWorkDirExists: vi.fn(async (_id, dir) => dir === persisted.workingDir),
+    });
+    await expect(createMakerSendTransaction(deps).sendToAgentAccepted('session-1', 'hello'))
+      .resolves.toMatchObject({ accepted: true });
+    expect(deps.checkWorkDirExists).toHaveBeenNthCalledWith(
+      1, 'session-1', session.workDir, 'codex', null, { suppressMissingBroadcast: true },
+    );
+    expect(deps.bootstrapSession).toHaveBeenCalledWith(expect.objectContaining(persisted));
+    expect(session.send).not.toHaveBeenCalled();
+  });
+
   it('does not close the live runtime if native history reconciliation fails during directory recovery', async () => {
     const { deps, session } = createDeps({
       readSessionWorkingDirFromDb: vi.fn(async () => '/repaired/project'),
@@ -1997,6 +2020,27 @@ describe('mobile client prompt note', () => {
 });
 
 describe('session-agent-switch handoff injection', () => {
+  it.each([
+    '/compact',
+    { type: 'user' as const, content: '/compact focus on the bug' },
+    { type: 'user' as const, content: [{ type: 'text' as const, text: '/compact' }] },
+  ])('retains the recovery notice across a native compact command: %j', async (command) => {
+    const session = createSession({ agentKind: 'claude-code' });
+    const consumeWorkingDirectoryRecoveryNote = vi.fn();
+    const { deps } = createDeps({
+      getSession: () => session,
+      peekWorkingDirectoryRecoveryNote: () => 'Directory recreated',
+      consumeWorkingDirectoryRecoveryNote,
+    });
+    const transaction = createMakerSendTransaction(deps);
+    await transaction.sendToAgentAccepted('session-1', command);
+    expect(session.send).toHaveBeenLastCalledWith(command, expect.anything());
+    expect(consumeWorkingDirectoryRecoveryNote).not.toHaveBeenCalled();
+    await transaction.sendToAgentAccepted('session-1', 'continue');
+    expect(session.send).toHaveBeenLastCalledWith(expect.stringContaining('Directory recreated'), expect.anything());
+    expect(consumeWorkingDirectoryRecoveryNote).toHaveBeenCalledOnce();
+  });
+
   it('tells the agent about recreated cwd without changing the displayed user message', async () => {
     const consumeWorkingDirectoryRecoveryNote = vi.fn();
     const { deps, session } = createDeps({

--- a/apps/desktop/src/main/maker-ipc/__tests__/makerSendTransaction.test.ts
+++ b/apps/desktop/src/main/maker-ipc/__tests__/makerSendTransaction.test.ts
@@ -1158,6 +1158,34 @@ describe('maker SEND transaction', () => {
     expect(session.send).not.toHaveBeenCalled();
   });
 
+  it.each(['claude-code', 'pi'] as const)('refreshes a live %s process after same-path recovery and preserves its note', async (agentKind) => {
+    const oldSession = createSession({ agentKind });
+    const recovered = createSession({ agentKind });
+    const { deps } = createDeps({
+      getSession: () => oldSession,
+      readSessionWorkingDirFromDb: async () => oldSession.workDir,
+      readWorkingDirectoryRecoveryCreateOpts: async () => ({
+        agentKind, workingDir: oldSession.workDir, model: 'persisted-model',
+        resumeSessionId: 'native-history', permissionMode: 'ask', planMode: true,
+      }),
+      peekWorkingDirectoryRecoveryNote: () => 'Directory recreated; original files remain missing',
+      consumeWorkingDirectoryRecoveryNote: vi.fn(),
+      bootstrapSession: vi.fn(async () => ({
+        session: recovered, didInjectOrcaInstructions: false, didInjectProjectContext: false,
+      })),
+    });
+    await expect(createMakerSendTransaction(deps).sendToAgentAccepted('session-1', 'continue'))
+      .resolves.toMatchObject({ accepted: true });
+    expect(deps.closeSession).toHaveBeenCalledOnce();
+    expect(deps.bootstrapSession).toHaveBeenCalledWith(expect.objectContaining({
+      workingDir: oldSession.workDir, resumeSessionId: 'native-history',
+      permissionMode: 'ask', planMode: true,
+    }));
+    expect(oldSession.send).not.toHaveBeenCalled();
+    expect(recovered.send).toHaveBeenCalledWith(expect.stringContaining('original files remain missing'), expect.anything());
+    expect(deps.consumeWorkingDirectoryRecoveryNote).toHaveBeenCalledOnce();
+  });
+
   it('uses persisted settings to recover a live session when send has no createOpts', async () => {
     const persisted: MakerSessionCreateOpts = {
       agentKind: 'codex', workingDir: '/repaired/project',
@@ -2031,6 +2059,9 @@ describe('session-agent-switch handoff injection', () => {
       getSession: () => session,
       peekWorkingDirectoryRecoveryNote: () => 'Directory recreated',
       consumeWorkingDirectoryRecoveryNote,
+      bootstrapSession: vi.fn(async () => ({
+        session, didInjectOrcaInstructions: false, didInjectProjectContext: false,
+      })),
     });
     const transaction = createMakerSendTransaction(deps);
     await transaction.sendToAgentAccepted('session-1', command);

--- a/apps/desktop/src/main/maker-ipc/__tests__/makerSendTransaction.test.ts
+++ b/apps/desktop/src/main/maker-ipc/__tests__/makerSendTransaction.test.ts
@@ -1207,6 +1207,21 @@ describe('maker SEND transaction', () => {
     }));
   });
 
+  it.each(['codex', 'claude-code', 'pi'] as const)('restarts %s in the fallback workspace before dispatch', async (agentKind) => {
+    const session = createSession({ agentKind });
+    const recovered = createSession({ agentKind, workDir: '/conversation' });
+    const { deps } = createDeps({
+      getSession: () => session,
+      resolveRecoveredWorkingDir: () => '/conversation',
+      peekWorkingDirectoryRecoveryNote: () => 'Original filesystem unavailable; temporary conversation workspace',
+      bootstrapSession: vi.fn(async () => ({ session: recovered, didInjectOrcaInstructions: false, didInjectProjectContext: false })),
+    });
+    await expect(createMakerSendTransaction(deps).sendToAgentAccepted('session-1', 'continue')).resolves.toMatchObject({ accepted: true });
+    expect(deps.bootstrapSession).toHaveBeenCalledWith(expect.objectContaining({ workingDir: '/conversation' }));
+    expect(session.send).not.toHaveBeenCalled();
+    expect(recovered.send).toHaveBeenCalledWith(expect.stringContaining('Original filesystem unavailable'), expect.anything());
+  });
+
   it('keeps the old runtime when Bot resource preflight fails, then resumes normally after repair', async () => {
     const session = createSession({ agentKind: 'pi' });
     const { deps } = createDeps({

--- a/apps/desktop/src/main/maker-ipc/__tests__/makerSendTransaction.test.ts
+++ b/apps/desktop/src/main/maker-ipc/__tests__/makerSendTransaction.test.ts
@@ -47,6 +47,7 @@ function createDeps(overrides: Partial<MakerSendTransactionDeps> = {}) {
   const deps: MakerSendTransactionDeps = {
     getSession: vi.fn((sessionId: string) => (sessionId === session.id ? session : undefined)),
     closeSession: vi.fn(async () => {}),
+    preflightBotRuntimeResources: vi.fn(async () => {}),
     getSessionMeta: vi.fn(async () => ({ title: '现有会话' })),
     ensureRemoteReadyForSessionStart: vi.fn(async () => {}),
     checkWorkDirExists: vi.fn(async () => true),
@@ -1159,7 +1160,9 @@ describe('maker SEND transaction', () => {
   });
 
   it.each(['claude-code', 'pi'] as const)('refreshes a live %s process after same-path recovery and preserves its note', async (agentKind) => {
-    const oldSession = createSession({ agentKind, hostUserPrompt: 'Keep the caller preference' });
+    const oldSession = createSession({ agentKind, hostStartupPreferences: {
+      userPrompt: 'Keep the caller preference', makerMemoryEnabled: true,
+    } });
     const recovered = createSession({ agentKind });
     const { deps } = createDeps({
       getSession: () => oldSession,
@@ -1180,10 +1183,45 @@ describe('maker SEND transaction', () => {
     expect(deps.bootstrapSession).toHaveBeenCalledWith(expect.objectContaining({
       workingDir: oldSession.workDir, resumeSessionId: 'native-history',
       permissionMode: 'ask', planMode: true, userPrompt: 'Keep the caller preference',
+      makerMemoryEnabled: true,
     }));
     expect(oldSession.send).not.toHaveBeenCalled();
     expect(recovered.send).toHaveBeenCalledWith(expect.stringContaining('original files remain missing'), expect.anything());
     expect(deps.consumeWorkingDirectoryRecoveryNote).toHaveBeenCalledOnce();
+  });
+
+  it.each([undefined, false, true])('preserves omitted startup preferences and respects an explicit memory setting of %s', async (makerMemoryEnabled) => {
+    const session = createSession({ agentKind: 'pi', hostStartupPreferences: {
+      userPrompt: 'Original preference', makerMemoryEnabled: true, displayReasoning: 'off',
+    } });
+    const { deps } = createDeps({
+      getSession: () => session,
+      peekWorkingDirectoryRecoveryNote: () => 'Directory recreated',
+    });
+    await expect(createMakerSendTransaction(deps).sendToAgentAccepted('session-1', 'hello', {
+      agentKind: 'pi', makerMemoryEnabled,
+    })).resolves.toMatchObject({ accepted: true });
+    expect(deps.bootstrapSession).toHaveBeenCalledWith(expect.objectContaining({
+      userPrompt: 'Original preference', displayReasoning: 'off',
+      makerMemoryEnabled: makerMemoryEnabled ?? true,
+    }));
+  });
+
+  it('keeps the old runtime when Bot resource preflight fails, then resumes normally after repair', async () => {
+    const session = createSession({ agentKind: 'pi' });
+    const { deps } = createDeps({
+      getSession: () => session,
+      peekWorkingDirectoryRecoveryNote: () => 'Directory recreated',
+      preflightBotRuntimeResources: vi.fn().mockRejectedValueOnce(new Error('Bot resource unavailable')).mockResolvedValue(undefined),
+    });
+    const transaction = createMakerSendTransaction(deps);
+    await expect(transaction.sendToAgentAccepted('session-1', 'hello')).resolves.toMatchObject({ accepted: false });
+    expect(deps.closeSession).not.toHaveBeenCalled();
+    expect(deps.bootstrapSession).not.toHaveBeenCalled();
+    await transaction.sendToAgentAccepted('session-1', 'hello');
+    expect(deps.closeSession).toHaveBeenCalledOnce();
+    expect(vi.mocked(deps.preflightBotRuntimeResources).mock.invocationCallOrder[1])
+      .toBeLessThan(vi.mocked(deps.closeSession).mock.invocationCallOrder[0]!);
   });
 
   it('uses persisted settings to recover a live session when send has no createOpts', async () => {

--- a/apps/desktop/src/main/maker-ipc/__tests__/workingDirectoryRecovery.test.ts
+++ b/apps/desktop/src/main/maker-ipc/__tests__/workingDirectoryRecovery.test.ts
@@ -10,6 +10,41 @@ afterEach(async () => {
 });
 
 describe('working directory conversation recovery', () => {
+  it('keeps shared-directory notices independent and drops a notice after moving away', async () => {
+    const recovery = createWorkingDirectoryRecovery({
+      stat: vi.fn(async () => { throw Object.assign(new Error('missing'), { code: 'ENOENT' }); }),
+      mkdir: vi.fn(async () => {}),
+    });
+    await recovery.recover('first', '/project', null, ['second', 'third']);
+    const note = recovery.peek('first', '/project')!;
+    recovery.consume('first', note);
+    expect(recovery.peek('first', '/project')).toBeNull();
+    expect(recovery.peek('second', '/project')).toBe(note);
+    expect(recovery.peek('third', '/elsewhere')).toBeNull();
+    expect(recovery.peek('third', '/project')).toBeNull();
+    recovery.consume('second', note);
+    expect(recovery.peek('second', '/project')).toBeNull();
+  });
+
+  it('does not revive sibling notices cleared or moved during shared-directory IO', async () => {
+    let finish!: () => void;
+    const mkdir = vi.fn(() => new Promise<void>((resolve) => { finish = resolve; }));
+    const recovery = createWorkingDirectoryRecovery({
+      stat: vi.fn(async () => { throw Object.assign(new Error('missing'), { code: 'ENOENT' }); }),
+      mkdir,
+    });
+    const recovering = recovery.recover('first', '/project', null, ['cleared', 'moved', 'remaining']);
+    await vi.waitFor(() => expect(mkdir).toHaveBeenCalled());
+    recovery.discard('cleared');
+    expect(recovery.peek('moved', '/elsewhere')).toBeNull();
+    finish();
+    expect(await recovering).toBe(true);
+    expect(recovery.peek('cleared', '/project')).toBeNull();
+    expect(recovery.peek('moved', '/project')).toBeNull();
+    expect(recovery.peek('remaining', '/project')).toBe(recovery.peek('first', '/project'));
+    expect(recovery.peek('remaining', '/project')).toContain('previous files have not been recovered');
+  });
+
   it('passes the similar-path diagnostic to the agent while keeping the conversation available', async () => {
     const mkdir = vi.fn(async () => {});
     const recovery = createWorkingDirectoryRecovery({

--- a/apps/desktop/src/main/maker-ipc/__tests__/workingDirectoryRecovery.test.ts
+++ b/apps/desktop/src/main/maker-ipc/__tests__/workingDirectoryRecovery.test.ts
@@ -1,0 +1,61 @@
+import fsp from 'node:fs/promises';
+import os from 'node:os';
+import path from 'node:path';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { createWorkingDirectoryRecovery } from '../workingDirectoryRecovery';
+
+const roots: string[] = [];
+afterEach(async () => {
+  await Promise.all(roots.splice(0).map((root) => fsp.rm(root, { recursive: true, force: true })));
+});
+
+describe('working directory conversation recovery', () => {
+  it('recreates the original directory and keeps its notice through repeated probes until acknowledged', async () => {
+    const root = await fsp.mkdtemp(path.join(os.tmpdir(), 'cindy-cwd-recovery-'));
+    roots.push(root);
+    const dir = path.join(root, 'removed-parent', 'project');
+    const recovery = createWorkingDirectoryRecovery();
+    expect(await recovery.recover('task', dir)).toBe(true);
+    expect((await fsp.stat(dir)).isDirectory()).toBe(true);
+    const note = recovery.peek('task');
+    expect(note).toContain(JSON.stringify(dir));
+    expect(note).toContain('previous files have not been recovered');
+    expect(await recovery.recover('task', dir)).toBe(true);
+    expect(recovery.peek('task')).toBe(note);
+    recovery.consume('task', 'stale note');
+    expect(recovery.peek('task')).toBe(note);
+    recovery.consume('task', note!);
+    expect(recovery.peek('task')).toBeNull();
+  });
+
+  it('does not replace an existing file or invent a recovery notice for an existing directory', async () => {
+    const root = await fsp.mkdtemp(path.join(os.tmpdir(), 'cindy-cwd-recovery-'));
+    roots.push(root);
+    const file = path.join(root, 'project');
+    await fsp.writeFile(file, 'keep');
+    const recovery = createWorkingDirectoryRecovery();
+    expect(await recovery.recover('task', file)).toBe(false);
+    expect(await fsp.readFile(file, 'utf8')).toBe('keep');
+    expect(await recovery.recover('task', root)).toBe(true);
+    expect(recovery.peek('task')).toBeNull();
+  });
+
+  it.each(['EACCES', 'ENOTDIR', 'EIO'])('does not recreate a path after %s', async (code) => {
+    const mkdir = vi.fn();
+    const recovery = createWorkingDirectoryRecovery({
+      stat: vi.fn(async () => { throw Object.assign(new Error(code), { code }); }), mkdir,
+    });
+    expect(await recovery.recover('task', '/unavailable')).toBe(false);
+    expect(mkdir).not.toHaveBeenCalled();
+    expect(recovery.peek('task')).toBeNull();
+  });
+
+  it('does not claim recovery if directory creation fails', async () => {
+    const recovery = createWorkingDirectoryRecovery({
+      stat: vi.fn(async () => { throw Object.assign(new Error('missing'), { code: 'ENOENT' }); }),
+      mkdir: vi.fn(async () => { throw new Error('read-only volume'); }),
+    });
+    expect(await recovery.recover('task', '/unavailable')).toBe(false);
+    expect(recovery.peek('task')).toBeNull();
+  });
+});

--- a/apps/desktop/src/main/maker-ipc/__tests__/workingDirectoryRecovery.test.ts
+++ b/apps/desktop/src/main/maker-ipc/__tests__/workingDirectoryRecovery.test.ts
@@ -10,6 +10,106 @@ afterEach(async () => {
 });
 
 describe('working directory conversation recovery', () => {
+  it.runIf(process.platform === 'darwin')('distinguishes a bare /Volumes mount point from an alias to the system disk', async () => {
+    const allocate = vi.fn(async () => '/conversation');
+    const recovery = createWorkingDirectoryRecovery({
+      stat: async () => ({ isDirectory: () => true, dev: 1 }), mkdir: vi.fn(),
+      realpath: async (dir) => dir === '/Volumes/System' ? '/' : dir,
+    }, allocate);
+    expect(await recovery.recover('system', '/Volumes/System/project')).toBe(true);
+    expect(allocate).not.toHaveBeenCalled();
+    const diagnostic = vi.fn(async () => null);
+    expect(await recovery.recover('external', '/Volumes/External/project', diagnostic)).toBe(true);
+    expect(allocate).toHaveBeenCalledOnce();
+    expect(diagnostic).not.toHaveBeenCalled();
+  });
+
+  it.each([false, true])('uses a conversation workspace after the observed volume disappears (shadow exists: %s)', async (shadowExists) => {
+    const dir = path.resolve('/mounted/project');
+    const fallback = path.resolve('/conversation');
+    let mounted = true;
+    const mkdir = vi.fn();
+    const recovery = createWorkingDirectoryRecovery({
+      stat: vi.fn(async (target) => {
+        if (!mounted && target === dir && !shadowExists) throw Object.assign(new Error('missing'), { code: 'ENOENT' });
+        return { isDirectory: () => true, dev: mounted ? 2 : 1 };
+      }),
+      mkdir,
+      realpath: async (target) => target,
+    }, async () => fallback);
+    await recovery.observe('task', dir);
+    mounted = false;
+    expect(await recovery.recover('task', dir)).toBe(true);
+    expect(mkdir).not.toHaveBeenCalled();
+    expect(recovery.resolve('task', dir)).toBe(fallback);
+    const note = recovery.peek('task', fallback)!;
+    expect(note).toContain('not been restored or copied');
+    expect(note).toContain(JSON.stringify(dir));
+    recovery.consume('task', note);
+    mounted = true;
+    expect(await recovery.recover('task', dir)).toBe(true);
+    expect(recovery.resolve('task', dir)).toBe(fallback);
+    expect(recovery.peek('task', fallback)).toBeNull();
+    expect(recovery.resolve('task', '/chosen-project')).toBe('/chosen-project');
+    expect(recovery.resolve('task', dir)).toBe(dir);
+  });
+
+  it('recreates a deleted child on the same observed volume', async () => {
+    const dir = path.resolve('/mounted/project');
+    let missing = false;
+    const mkdir = vi.fn();
+    const allocate = vi.fn(async () => '/conversation');
+    const recovery = createWorkingDirectoryRecovery({
+      stat: async (target) => {
+        if (missing && target === dir) throw Object.assign(new Error('missing'), { code: 'ENOENT' });
+        return { isDirectory: () => true, dev: 2 };
+      }, mkdir,
+    }, allocate);
+    await recovery.observe('task', dir);
+    missing = true;
+    expect(await recovery.recover('task', dir)).toBe(true);
+    expect(mkdir).toHaveBeenCalledWith(dir, { recursive: true });
+    expect(allocate).not.toHaveBeenCalled();
+  });
+
+  it('recreates a deleted fallback without returning to the original mount', async () => {
+    const mkdir = vi.fn();
+    const recovery = createWorkingDirectoryRecovery({
+      stat: async () => { throw Object.assign(new Error('missing'), { code: 'ENOENT' }); }, mkdir,
+    }, async () => '/conversation');
+    expect(await recovery.recover('task', '/offline/project')).toBe(true);
+    recovery.consume('task', recovery.peek('task')!);
+    expect(await recovery.recover('task', '/conversation')).toBe(true);
+    expect(mkdir).toHaveBeenCalledWith(path.resolve('/conversation'), { recursive: true });
+    expect(recovery.resolve('task', '/offline/project')).toBe(path.resolve('/conversation'));
+    expect(recovery.peek('task')).toContain('previous files have not been recovered');
+  });
+
+  it.each(['EIO', 'ENOTCONN', 'ENODEV', 'WORKDIR_PROBE_TIMEOUT'])('uses fallback for an unavailable filesystem probe: %s', async (code) => {
+    const mkdir = vi.fn();
+    const recovery = createWorkingDirectoryRecovery({
+      stat: async () => { throw Object.assign(new Error('unavailable'), { code }); }, mkdir,
+    }, async () => '/conversation');
+    expect(await recovery.recover('task', '/network/project')).toBe(true);
+    expect(mkdir).not.toHaveBeenCalled();
+    expect(recovery.resolve('task', '/network/project')).toBe(path.resolve('/conversation'));
+  });
+
+  it('does not revive a fallback after cleanup during allocation', async () => {
+    let finish!: (dir: string) => void;
+    const allocate = vi.fn(() => new Promise<string>((resolve) => { finish = resolve; }));
+    const recovery = createWorkingDirectoryRecovery({
+      stat: async () => { throw Object.assign(new Error('missing drive'), { code: 'ENOENT' }); }, mkdir: vi.fn(),
+    }, allocate);
+    const recovering = recovery.recover('task', '/unavailable/project');
+    await vi.waitFor(() => expect(allocate).toHaveBeenCalled());
+    recovery.discard('task');
+    finish('/conversation');
+    expect(await recovering).toBe(false);
+    expect(recovery.resolve('task', '/unavailable/project')).toBe('/unavailable/project');
+    expect(recovery.peek('task')).toBeNull();
+  });
+
   it('notifies physical aliases while preserving unrelated pending recovery', async () => {
     const root = await fsp.mkdtemp(path.join(os.tmpdir(), 'cindy-cwd-alias-'));
     roots.push(root);

--- a/apps/desktop/src/main/maker-ipc/__tests__/workingDirectoryRecovery.test.ts
+++ b/apps/desktop/src/main/maker-ipc/__tests__/workingDirectoryRecovery.test.ts
@@ -10,6 +10,19 @@ afterEach(async () => {
 });
 
 describe('working directory conversation recovery', () => {
+  it('passes the similar-path diagnostic to the agent while keeping the conversation available', async () => {
+    const mkdir = vi.fn(async () => {});
+    const recovery = createWorkingDirectoryRecovery({
+      stat: vi.fn(async () => { throw Object.assign(new Error('missing'), { code: 'ENOENT' }); }),
+      mkdir,
+    });
+    expect(await recovery.recover('task', '/project', '/project ')).toBe(true);
+    expect(mkdir).toHaveBeenCalledWith('/project', { recursive: true });
+    expect(recovery.peek('task')).toContain(JSON.stringify('/project '));
+    expect(recovery.peek('task')).toContain('Inspect this candidate before reading or creating project files');
+    expect(recovery.peek('task')).toContain('previous files have not been recovered');
+  });
+
   it('keeps the recovery note when another probe sees the directory before mkdir settles', async () => {
     let finish!: () => void;
     const mkdir = vi.fn(() => new Promise<void>((resolve) => { finish = resolve; }));

--- a/apps/desktop/src/main/maker-ipc/__tests__/workingDirectoryRecovery.test.ts
+++ b/apps/desktop/src/main/maker-ipc/__tests__/workingDirectoryRecovery.test.ts
@@ -10,12 +10,52 @@ afterEach(async () => {
 });
 
 describe('working directory conversation recovery', () => {
+  it('notifies physical aliases while preserving unrelated pending recovery', async () => {
+    const root = await fsp.mkdtemp(path.join(os.tmpdir(), 'cindy-cwd-alias-'));
+    roots.push(root);
+    const parent = path.join(root, 'parent');
+    const alias = path.join(root, 'alias');
+    await fsp.mkdir(parent);
+    await fsp.symlink(parent, alias, process.platform === 'win32' ? 'junction' : 'dir');
+    const dir = path.join(parent, 'project');
+    const aliasDir = path.join(alias, 'project');
+    const other = path.join(root, 'other');
+    const recovery = createWorkingDirectoryRecovery();
+    await recovery.recover('other', other);
+    const otherNote = recovery.peek('other', other);
+    await recovery.recover('first', dir, null, [
+      { id: 'alias', workingDir: aliasDir }, { id: 'other', workingDir: other },
+    ]);
+    expect(recovery.peek('alias', aliasDir)).toContain('previous files have not been recovered');
+    expect(recovery.peek('other', other)).toBe(otherNote);
+    recovery.consume('first', recovery.peek('first', dir)!);
+    expect(recovery.peek('alias', aliasDir)).not.toBeNull();
+  });
+
+  it('does not revive an alias cleared while physical identity is being resolved', async () => {
+    let finish!: (dir: string) => void;
+    const realpath = vi.fn(() => new Promise<string>((resolve) => { finish = resolve; }));
+    const recovery = createWorkingDirectoryRecovery({
+      stat: vi.fn(async () => { throw Object.assign(new Error('missing'), { code: 'ENOENT' }); }),
+      mkdir: vi.fn(async () => {}),
+      realpath,
+    });
+    const recovering = recovery.recover('first', '/project', null, [{ id: 'alias', workingDir: '/alias' }]);
+    await vi.waitFor(() => expect(realpath).toHaveBeenCalledOnce());
+    recovery.discard('alias');
+    realpath.mockResolvedValue('/physical');
+    finish('/physical');
+    expect(await recovering).toBe(true);
+    expect(recovery.peek('alias', '/alias')).toBeNull();
+    expect(recovery.peek('first', '/project')).not.toBeNull();
+  });
+
   it('keeps shared-directory notices independent and drops a notice after moving away', async () => {
     const recovery = createWorkingDirectoryRecovery({
       stat: vi.fn(async () => { throw Object.assign(new Error('missing'), { code: 'ENOENT' }); }),
       mkdir: vi.fn(async () => {}),
     });
-    await recovery.recover('first', '/project', null, ['second', 'third']);
+    await recovery.recover('first', '/project', null, ['second', 'third'].map((id) => ({ id, workingDir: '/project' })));
     const note = recovery.peek('first', '/project')!;
     recovery.consume('first', note);
     expect(recovery.peek('first', '/project')).toBeNull();
@@ -33,7 +73,7 @@ describe('working directory conversation recovery', () => {
       stat: vi.fn(async () => { throw Object.assign(new Error('missing'), { code: 'ENOENT' }); }),
       mkdir,
     });
-    const recovering = recovery.recover('first', '/project', null, ['cleared', 'moved', 'remaining']);
+    const recovering = recovery.recover('first', '/project', null, ['cleared', 'moved', 'remaining'].map((id) => ({ id, workingDir: '/project' })));
     await vi.waitFor(() => expect(mkdir).toHaveBeenCalled());
     recovery.discard('cleared');
     expect(recovery.peek('moved', '/elsewhere')).toBeNull();

--- a/apps/desktop/src/main/maker-ipc/__tests__/workingDirectoryRecovery.test.ts
+++ b/apps/desktop/src/main/maker-ipc/__tests__/workingDirectoryRecovery.test.ts
@@ -10,6 +10,30 @@ afterEach(async () => {
 });
 
 describe('working directory conversation recovery', () => {
+  it.each(['WORKDIR_PROBE_TIMEOUT', 'EIO', 'EACCES'])('handles a share failing during mkdir: %s', async (code) => {
+    const dir = path.resolve('/share/project');
+    const fallback = path.resolve('/conversation');
+    const allocate = vi.fn(async () => fallback);
+    const mkdir = vi.fn(async () => { throw Object.assign(new Error('write failed'), { code }); });
+    const recovery = createWorkingDirectoryRecovery({
+      stat: async (target) => {
+        if (target === dir) throw Object.assign(new Error('missing'), { code: 'ENOENT' });
+        return { isDirectory: () => true, dev: 1 };
+      }, mkdir,
+    }, allocate);
+    const unavailable = code !== 'EACCES';
+    expect(await recovery.recover('task', dir)).toBe(unavailable);
+    expect(mkdir).toHaveBeenCalledOnce();
+    expect(allocate).toHaveBeenCalledTimes(unavailable ? 1 : 0);
+    expect(recovery.isFallback('task', dir)).toBe(unavailable);
+    if (unavailable) {
+      recovery.consume('task', recovery.peek('task')!);
+      expect(recovery.isFallback('task', fallback)).toBe(true);
+      expect(recovery.resolve('task', dir)).toBe(fallback);
+      expect(recovery.isFallback('task', '/explicit-new-project')).toBe(false);
+    }
+  });
+
   it.runIf(process.platform === 'darwin')('distinguishes a bare /Volumes mount point from an alias to the system disk', async () => {
     const allocate = vi.fn(async () => '/conversation');
     const recovery = createWorkingDirectoryRecovery({

--- a/apps/desktop/src/main/maker-ipc/__tests__/workingDirectoryRecovery.test.ts
+++ b/apps/desktop/src/main/maker-ipc/__tests__/workingDirectoryRecovery.test.ts
@@ -10,6 +10,53 @@ afterEach(async () => {
 });
 
 describe('working directory conversation recovery', () => {
+  it('keeps the recovery note when another probe sees the directory before mkdir settles', async () => {
+    let finish!: () => void;
+    const mkdir = vi.fn(() => new Promise<void>((resolve) => { finish = resolve; }));
+    const recovery = createWorkingDirectoryRecovery({
+      stat: vi.fn().mockRejectedValueOnce(Object.assign(new Error('missing'), { code: 'ENOENT' }))
+        .mockResolvedValue({ isDirectory: () => true }),
+      mkdir,
+    });
+    const first = recovery.recover('task', '/project');
+    await vi.waitFor(() => expect(mkdir).toHaveBeenCalled());
+    expect(await recovery.recover('task', '/project')).toBe(true);
+    finish();
+    expect(await first).toBe(true);
+    expect(recovery.peek('task')).toContain('previous files have not been recovered');
+  });
+
+  it.each(['discard', 'clear'] as const)('does not restore a discarded note after late IO: %s', async (operation) => {
+    let finish!: () => void;
+    const mkdirDone = new Promise<void>((resolve) => { finish = resolve; });
+    const mkdir = vi.fn(() => mkdirDone);
+    const recovery = createWorkingDirectoryRecovery({
+      stat: vi.fn(async () => { throw Object.assign(new Error('missing'), { code: 'ENOENT' }); }),
+      mkdir,
+    });
+    const recovering = recovery.recover('task', '/project');
+    await vi.waitFor(() => expect(mkdir).toHaveBeenCalled());
+    if (operation === 'discard') recovery.discard('task');
+    else recovery.clear();
+    finish();
+    expect(await recovering).toBe(true);
+    expect(recovery.peek('task')).toBeNull();
+  });
+
+  it('discards closed or cleared tasks and clears all notes at an owner boundary', async () => {
+    const recovery = createWorkingDirectoryRecovery({
+      stat: vi.fn(async () => { throw Object.assign(new Error('missing'), { code: 'ENOENT' }); }),
+      mkdir: vi.fn(async () => {}),
+    });
+    await recovery.recover('first', '/first');
+    await recovery.recover('second', '/second');
+    recovery.discard('first');
+    expect(recovery.peek('first')).toBeNull();
+    expect(recovery.peek('second')).not.toBeNull();
+    recovery.clear();
+    expect(recovery.peek('second')).toBeNull();
+  });
+
   it('recreates the original directory and keeps its notice through repeated probes until acknowledged', async () => {
     const root = await fsp.mkdtemp(path.join(os.tmpdir(), 'cindy-cwd-recovery-'));
     roots.push(root);

--- a/apps/desktop/src/main/maker-ipc/extraDirsValidator.ts
+++ b/apps/desktop/src/main/maker-ipc/extraDirsValidator.ts
@@ -107,6 +107,7 @@ function isSelfOrSubdir(candidate: string, base: string): boolean {
 export async function validateExtraDirs(
   rawDirs: string[] | undefined | null,
   workingDir: string | undefined | null,
+  statDirectory: (dir: string) => Promise<{ isDirectory(): boolean }> = fs.stat,
 ): Promise<ValidateResult> {
   const valid: string[] = [];
   const rejected: ValidateResult['rejected'] = [];
@@ -142,7 +143,7 @@ export async function validateExtraDirs(
 
     let stat;
     try {
-      stat = await fs.stat(root);
+      stat = await statDirectory(root);
     } catch {
       rejected.push({ path: dir, reason: 'not-exist' });
       continue;
@@ -192,15 +193,22 @@ async function canonicalDirectoryKey(dir: string): Promise<string> {
 export async function excludeDirectoryGrantConflicts(
   candidates: readonly string[],
   blocked: readonly string[],
+  resolvePath?: (dir: string) => Promise<string>,
 ): Promise<string[]> {
   if (candidates.length === 0) return [];
-  const blockedKeys = await Promise.all(blocked.map(canonicalDirectoryKey));
+  // Bounded recovery probes must not treat a timed-out alias as a disjoint tree.
+  const canonical = (dir: string) => resolvePath
+    ? resolvePath(dir).catch(() => null)
+    : canonicalDirectoryKey(dir);
+  const blockedKeys = await Promise.all(blocked.map(canonical));
+  if (blockedKeys.some((key) => key === null)) return [];
   const result: string[] = [];
   const acceptedKeys: string[] = [];
   for (const candidate of candidates) {
-    const candidateKey = await canonicalDirectoryKey(candidate);
+    const candidateKey = await canonical(candidate);
+    if (candidateKey === null) continue;
     const overlapsBlockedTree = blockedKeys.some((blockedKey) =>
-      isSelfOrSubdir(candidateKey, blockedKey) || isSelfOrSubdir(blockedKey, candidateKey));
+      isSelfOrSubdir(candidateKey, blockedKey!) || isSelfOrSubdir(blockedKey!, candidateKey));
     const overlapsAcceptedTree = acceptedKeys.some((acceptedKey) =>
       isSelfOrSubdir(candidateKey, acceptedKey) || isSelfOrSubdir(acceptedKey, candidateKey));
     if (!overlapsBlockedTree && !overlapsAcceptedTree) {

--- a/apps/desktop/src/main/maker-ipc/makerSendTransaction.ts
+++ b/apps/desktop/src/main/maker-ipc/makerSendTransaction.ts
@@ -277,7 +277,7 @@ function extractIpcUserMessageText(message: IpcUserMessage): string {
 }
 
 export interface MakerSendTransactionSession {
-  hostUserPrompt?: string;
+  hostStartupPreferences?: CreateOpts['hostStartupPreferences'];
   id: string;
   agentKind: AgentKind;
   workDir: string;
@@ -298,6 +298,7 @@ export interface MakerSendTransactionLog {
 export interface MakerSendTransactionDeps {
   getSession(sessionId: string): MakerSendTransactionSession | undefined | null;
   closeSession(sessionId: string): Promise<void>;
+  preflightBotRuntimeResources(opts: CreateOpts): Promise<void>;
   getSessionMeta(sessionId: string): Promise<{ title?: string } | null>;
   ensureRemoteReadyForSessionStart(params: {
     session?: { agentKind: AgentKind; remoteHostId: string | null } | null;
@@ -675,6 +676,7 @@ export function createMakerSendTransaction(deps: MakerSendTransactionDeps): Make
       // 中途 start_team 后丢失全部对话历史)。DB 读失败时 reconcile 抛错 → 落入下方
       // REHYDRATE_FAILED,此时尚未 closeSession,旧 runtime 不受损。
       await deps.reconcileCreateOptsWithDb?.(sessionId, createOpts);
+      if (reason === 'workdir') await deps.preflightBotRuntimeResources(createOpts);
       // A newly created device-link Codex Lead has a real sdk_session_id as soon as
       // thread/start returns, but that id is not resumable until a provider turn
       // is accepted. The live Session is the only trustworthy local evidence at
@@ -882,11 +884,14 @@ export function createMakerSendTransaction(deps: MakerSendTransactionDeps): Make
           (sess.agentKind === 'claude-code' || sess.agentKind === 'pi') &&
           !!deps.peekWorkingDirectoryRecoveryNote?.(sessionId, sess.workDir);
         if ((!ok && fallbackDir) || needsCwdRefresh) {
+          const supplied = (createOpts as CreateOpts | undefined) ??
+            await deps.readWorkingDirectoryRecoveryCreateOpts(sessionId);
+          const startupPreferences = sess.hostStartupPreferences ?? {};
+          const preferences = Object.fromEntries(Object.entries(startupPreferences)
+            .filter(([key]) => supplied[key as keyof typeof startupPreferences] === undefined));
           const co = deps.buildCreateOptsWithStderr({
-            ...((createOpts as CreateOpts | undefined) ?? {
-              ...await deps.readWorkingDirectoryRecoveryCreateOpts(sessionId),
-              userPrompt: sess.hostUserPrompt,
-            }),
+            ...supplied,
+            ...preferences,
             id: sessionId,
             workingDir: needsCwdRefresh ? sess.workDir : fallbackDir!,
             agentKind: sess.agentKind,

--- a/apps/desktop/src/main/maker-ipc/makerSendTransaction.ts
+++ b/apps/desktop/src/main/maker-ipc/makerSendTransaction.ts
@@ -311,6 +311,7 @@ export interface MakerSendTransactionDeps {
     remoteHostId?: string | null,
     opts?: { suppressMissingBroadcast?: boolean },
   ): Promise<boolean>;
+  resolveRecoveredWorkingDir?(sessionId: string, workingDir: string): string;
   /**
    * 读 DB 里既有会话的权威 working_dir(行不存在 → null)。lazy-create /
    * rehydrate 在 caller 传入的 workingDir 校验失败时用它兜底——输入队列崩溃
@@ -629,7 +630,12 @@ export function createMakerSendTransaction(deps: MakerSendTransactionDeps): Make
           createOpts.agentKind,
           createOpts.remoteHostId,
         );
-    if (ok) return true;
+    if (ok) {
+      if (!createOpts.remoteHostId && createOpts.workingDir) {
+        createOpts.workingDir = deps.resolveRecoveredWorkingDir?.(sessionId, createOpts.workingDir) ?? createOpts.workingDir;
+      }
+      return true;
+    }
     if (!fallbackDir) return false;
     const okDb = await deps.checkWorkDirExists(
       sessionId,
@@ -643,7 +649,8 @@ export function createMakerSendTransaction(deps: MakerSendTransactionDeps): Make
       staleWorkingDir: createOpts.workingDir,
       workingDir: fallbackDir,
     });
-    createOpts.workingDir = fallbackDir;
+    createOpts.workingDir = createOpts.remoteHostId ? fallbackDir :
+      deps.resolveRecoveredWorkingDir?.(sessionId, fallbackDir) ?? fallbackDir;
     return true;
   }
 
@@ -880,9 +887,13 @@ export function createMakerSendTransaction(deps: MakerSendTransactionDeps): Make
         );
         // Claude/Pi keep a process whose cwd can still reference the deleted inode.
         // The pending note also covers recovery performed by an earlier preflight.
-        const needsCwdRefresh = ok && !sess.remoteHostId &&
-          (sess.agentKind === 'claude-code' || sess.agentKind === 'pi') &&
-          !!deps.peekWorkingDirectoryRecoveryNote?.(sessionId, sess.workDir);
+        const recoveredDir = !sess.remoteHostId
+          ? deps.resolveRecoveredWorkingDir?.(sessionId, sess.workDir) ?? sess.workDir
+          : sess.workDir;
+        const needsCwdRefresh = ok && !sess.remoteHostId && (
+          recoveredDir !== sess.workDir ||
+          ((sess.agentKind === 'claude-code' || sess.agentKind === 'pi') &&
+          !!deps.peekWorkingDirectoryRecoveryNote?.(sessionId, sess.workDir)));
         if ((!ok && fallbackDir) || needsCwdRefresh) {
           const supplied = (createOpts as CreateOpts | undefined) ??
             await deps.readWorkingDirectoryRecoveryCreateOpts(sessionId);
@@ -893,7 +904,7 @@ export function createMakerSendTransaction(deps: MakerSendTransactionDeps): Make
             ...supplied,
             ...preferences,
             id: sessionId,
-            workingDir: needsCwdRefresh ? sess.workDir : fallbackDir!,
+            workingDir: needsCwdRefresh ? recoveredDir : fallbackDir!,
             agentKind: sess.agentKind,
             remoteHostId: sess.remoteHostId ?? undefined,
           });

--- a/apps/desktop/src/main/maker-ipc/makerSendTransaction.ts
+++ b/apps/desktop/src/main/maker-ipc/makerSendTransaction.ts
@@ -38,6 +38,10 @@ import type { MakerSessionCreateOpts } from './sessionRequest.js';
 type CreateOpts = MakerSessionCreateOpts;
 
 export interface BootstrapDirectoryGrantDeps {
+  /** Host-only: a temporary workspace must not turn unavailable grants into revocations. */
+  preservePersistedGrants?: boolean;
+  statDirectory?: (dir: string) => Promise<{ isDirectory(): boolean }>;
+  realpathDirectory?: (dir: string) => Promise<string>;
   readPersistedWritableDirs(sessionId: string): Promise<string[]>;
   persistExistingSession(
     sessionId: string,
@@ -65,10 +69,10 @@ export async function prepareDirectoryGrantsForBootstrap(
     typeof opts.id === 'string' && opts.id
       ? await deps.readPersistedWritableDirs(opts.id)
       : [];
-  const extraValidation = await validateExtraDirs(requestedExtraDirs, opts.workingDir);
-  const writableValidation = await validateExtraDirs(requestedWritableDirs, opts.workingDir);
+  const extraValidation = await validateExtraDirs(requestedExtraDirs, opts.workingDir, deps.statDirectory);
+  const writableValidation = await validateExtraDirs(requestedWritableDirs, opts.workingDir, deps.statDirectory);
   const extraDirs = extraValidation.valid;
-  const writableDirs = await excludeDirectoryGrantConflicts(writableValidation.valid, extraDirs);
+  const writableDirs = await excludeDirectoryGrantConflicts(writableValidation.valid, extraDirs, deps.realpathDirectory);
 
   if (opts.extraDirs !== undefined || extraDirs.length > 0) opts.extraDirs = extraDirs;
   if (opts.writableDirs !== undefined || writableDirs.length > 0) opts.writableDirs = writableDirs;
@@ -76,7 +80,7 @@ export async function prepareDirectoryGrantsForBootstrap(
   const changed =
     !sameDirectoryList(requestedExtraDirs, extraDirs) ||
     !sameDirectoryList(requestedWritableDirs, writableDirs);
-  if (!changed || opts.remoteHostId || typeof opts.id !== 'string' || !opts.id) return;
+  if (!changed || deps.preservePersistedGrants || opts.remoteHostId || typeof opts.id !== 'string' || !opts.id) return;
 
   await deps.persistExistingSession(opts.id, { extraDirs, writableDirs });
 }

--- a/apps/desktop/src/main/maker-ipc/makerSendTransaction.ts
+++ b/apps/desktop/src/main/maker-ipc/makerSendTransaction.ts
@@ -277,6 +277,7 @@ function extractIpcUserMessageText(message: IpcUserMessage): string {
 }
 
 export interface MakerSendTransactionSession {
+  hostUserPrompt?: string;
   id: string;
   agentKind: AgentKind;
   workDir: string;
@@ -882,7 +883,10 @@ export function createMakerSendTransaction(deps: MakerSendTransactionDeps): Make
           !!deps.peekWorkingDirectoryRecoveryNote?.(sessionId, sess.workDir);
         if ((!ok && fallbackDir) || needsCwdRefresh) {
           const co = deps.buildCreateOptsWithStderr({
-            ...((createOpts as CreateOpts | undefined) ?? await deps.readWorkingDirectoryRecoveryCreateOpts(sessionId)),
+            ...((createOpts as CreateOpts | undefined) ?? {
+              ...await deps.readWorkingDirectoryRecoveryCreateOpts(sessionId),
+              userPrompt: sess.hostUserPrompt,
+            }),
             id: sessionId,
             workingDir: needsCwdRefresh ? sess.workDir : fallbackDir!,
             agentKind: sess.agentKind,

--- a/apps/desktop/src/main/maker-ipc/makerSendTransaction.ts
+++ b/apps/desktop/src/main/maker-ipc/makerSendTransaction.ts
@@ -413,6 +413,7 @@ export interface MakerSendTransactionDeps {
   peekPendingHandoff?(sessionId: string): Promise<string | null>;
   consumePendingHandoff?(sessionId: string): void;
   peekWorkingDirectoryRecoveryNote?(sessionId: string): string | null;
+  readWorkingDirectoryRecoveryCreateOpts(sessionId: string): Promise<CreateOpts>;
   consumeWorkingDirectoryRecoveryNote?(sessionId: string, note: string): void;
   /**
    * 计划对账:会话里若有待处理计划,返回一段只进 wire payload 的指示文本。
@@ -863,7 +864,7 @@ export function createMakerSendTransaction(deps: MakerSendTransactionDeps): Make
         // Startup migration or a directory relocation may repair SQLite while a
         // live SDK still owns the old cwd. Only use that persisted replacement;
         // recreating an arbitrary project as an empty folder would lose its context.
-        const dbDir = createOpts && deps.reconcileCreateOptsWithDb && !sess.remoteHostId
+        const dbDir = !sess.remoteHostId
           ? await deps.readSessionWorkingDirFromDb(sessionId).catch(() => null)
           : null;
         const fallbackDir = dbDir && dbDir !== sess.workDir ? dbDir : null;
@@ -876,7 +877,7 @@ export function createMakerSendTransaction(deps: MakerSendTransactionDeps): Make
         );
         if (!ok && fallbackDir) {
           const co = deps.buildCreateOptsWithStderr({
-            ...(createOpts as CreateOpts),
+            ...((createOpts as CreateOpts | undefined) ?? await deps.readWorkingDirectoryRecoveryCreateOpts(sessionId)),
             id: sessionId,
             workingDir: fallbackDir,
             agentKind: sess.agentKind,
@@ -1019,7 +1020,9 @@ export function createMakerSendTransaction(deps: MakerSendTransactionDeps): Make
       }
       // session-agent-switch:切换后的首条消息把交接前缀拼进 wire payload。
       // 落库/显示内容(persistUserMessage.content)不含交接段——display 与 sent 分离。
-      const workdirRecoveryNote = deps.peekWorkingDirectoryRecoveryNote?.(sessionId) ?? null;
+      const workdirRecoveryNote = shouldPrependMobileClientPromptNote(normalized, sess.agentKind)
+        ? deps.peekWorkingDirectoryRecoveryNote?.(sessionId) ?? null
+        : null;
       if (workdirRecoveryNote) {
         normalized = prependNoteToWireUserMessage(normalized as HandoffWireMessage, workdirRecoveryNote);
       }

--- a/apps/desktop/src/main/maker-ipc/makerSendTransaction.ts
+++ b/apps/desktop/src/main/maker-ipc/makerSendTransaction.ts
@@ -412,6 +412,8 @@ export interface MakerSendTransactionDeps {
    */
   peekPendingHandoff?(sessionId: string): Promise<string | null>;
   consumePendingHandoff?(sessionId: string): void;
+  peekWorkingDirectoryRecoveryNote?(sessionId: string): string | null;
+  consumeWorkingDirectoryRecoveryNote?(sessionId: string, note: string): void;
   /**
    * 计划对账:会话里若有待处理计划,返回一段只进 wire payload 的指示文本。
    * sealedTurnId 只用于已完成计划的一次性保护,跨过 accepted 后才消费。
@@ -569,7 +571,7 @@ export function createMakerSendTransaction(deps: MakerSendTransactionDeps): Make
   async function loadExtraDirsIfNeeded(
     sessionId: string,
     opts: CreateOpts,
-    source: 'lazy-create' | 'active-orca-rehydrate',
+    source: 'lazy-create' | 'active-session-rehydrate',
   ): Promise<void> {
     if (opts.extraDirs === undefined) {
       try {
@@ -642,10 +644,11 @@ export function createMakerSendTransaction(deps: MakerSendTransactionDeps): Make
     return true;
   }
 
-  async function rehydrateActiveOrcaSession(
+  async function rehydrateActiveSession(
     sessionId: string,
     createOpts: CreateOpts,
     fromDeviceLinkClient: boolean,
+    reason: 'orca' | 'workdir' = 'orca',
   ): Promise<ResolveSessionResult> {
     const okRehydrate = await ensureWorkDirWithDbFallback(sessionId, createOpts);
     if (!okRehydrate) {
@@ -659,8 +662,11 @@ export function createMakerSendTransaction(deps: MakerSendTransactionDeps): Make
         ),
       };
     }
-    await loadExtraDirsIfNeeded(sessionId, createOpts, 'active-orca-rehydrate');
+    await loadExtraDirsIfNeeded(sessionId, createOpts, 'active-session-rehydrate');
     try {
+      if (reason === 'workdir') {
+        await deps.synthesizeOrcaVendorOptionsFromDb(sessionId, createOpts);
+      }
       // 关旧 runtime 前先按 DB 权威口径对账执行字段(与 lazy-create 同源):caller /
       // 队列的 createOpts 快照常不带 resumeSessionId(或带旧引擎的陈旧值),直接
       // close+bootstrap 会启动一个没有旧 transcript 的全新原生会话(#2882:Pi 会话
@@ -687,15 +693,16 @@ export function createMakerSendTransaction(deps: MakerSendTransactionDeps): Make
       }
       const session = await deps.withRehydrateCloseSuppressed(sessionId, async () => {
         await deps.closeSession(sessionId);
-        // close 后重新 bootstrap，避免旧 SDK handle 缺 Orca MCP vendorOptions。
+        // Rebuild the SDK handle with the repaired cwd and current MCP options.
         const {
           session: newSess,
           didInjectOrcaInstructions,
           didInjectProjectContext,
         } = await deps.bootstrapSession(createOpts);
         await deps.markOrcaRoleIfNeeded(newSess.id, createOpts.orcaRole);
-        deps.log.info('send: rehydrate active Orca session with MCP vendorOptions', {
+        deps.log.info('send: rehydrate active session', {
           sessionId,
+          reason,
           agentKind: createOpts.agentKind,
           usedOrcaInstructions: didInjectOrcaInstructions,
           usedProjectContext: didInjectProjectContext,
@@ -853,13 +860,37 @@ export function createMakerSendTransaction(deps: MakerSendTransactionDeps): Make
       await deps.ensureRemoteReadyForSessionStart({ session: sess, createOpts });
 
       if (sess) {
+        // Startup migration or a directory relocation may repair SQLite while a
+        // live SDK still owns the old cwd. Only use that persisted replacement;
+        // recreating an arbitrary project as an empty folder would lose its context.
+        const dbDir = createOpts && deps.reconcileCreateOptsWithDb && !sess.remoteHostId
+          ? await deps.readSessionWorkingDirFromDb(sessionId).catch(() => null)
+          : null;
+        const fallbackDir = dbDir && dbDir !== sess.workDir ? dbDir : null;
         const ok = await deps.checkWorkDirExists(
           sessionId,
           sess.workDir,
           sess.agentKind,
           sess.remoteHostId,
+          ...(fallbackDir ? [{ suppressMissingBroadcast: true }] : []),
         );
-        if (!ok) {
+        if (!ok && fallbackDir) {
+          const co = deps.buildCreateOptsWithStderr({
+            ...(createOpts as CreateOpts),
+            id: sessionId,
+            workingDir: fallbackDir,
+            agentKind: sess.agentKind,
+            remoteHostId: sess.remoteHostId ?? undefined,
+          });
+          const recovered = await rehydrateActiveSession(
+            sessionId,
+            co,
+            requestedSendOpts.fromDeviceLinkClient === true,
+            'workdir',
+          );
+          if (recovered.kind === 'failure') return recovered.result;
+          sess = recovered.session;
+        } else if (!ok) {
           return toCompatibleMakerSendResult(
             createHostSendFailure(
               'WORKDIR_MISSING',
@@ -880,7 +911,7 @@ export function createMakerSendTransaction(deps: MakerSendTransactionDeps): Make
                 sessionId,
               });
             } else {
-              const rehydrated = await rehydrateActiveOrcaSession(
+              const rehydrated = await rehydrateActiveSession(
                 sessionId,
                 co,
                 requestedSendOpts.fromDeviceLinkClient === true,
@@ -988,6 +1019,10 @@ export function createMakerSendTransaction(deps: MakerSendTransactionDeps): Make
       }
       // session-agent-switch:切换后的首条消息把交接前缀拼进 wire payload。
       // 落库/显示内容(persistUserMessage.content)不含交接段——display 与 sent 分离。
+      const workdirRecoveryNote = deps.peekWorkingDirectoryRecoveryNote?.(sessionId) ?? null;
+      if (workdirRecoveryNote) {
+        normalized = prependNoteToWireUserMessage(normalized as HandoffWireMessage, workdirRecoveryNote);
+      }
       const pendingHandoff = (await deps.peekPendingHandoff?.(sessionId)) ?? null;
       const withHandoff = pendingHandoff
         ? prependHandoffToUserMessage(normalized as HandoffWireMessage, pendingHandoff)
@@ -1344,6 +1379,9 @@ export function createMakerSendTransaction(deps: MakerSendTransactionDeps): Make
         if (pendingHandoff && sendResult.accepted) {
           // 只有跨过不可逆 dispatch 边界才消费;未派发保留 pending 下次重试。
           deps.consumePendingHandoff?.(sessionId);
+        }
+        if (workdirRecoveryNote && sendResult.accepted) {
+          deps.consumeWorkingDirectoryRecoveryNote?.(sessionId, workdirRecoveryNote);
         }
         if (planReconcile?.sealedTurnId && sendResult.accepted) {
           try {

--- a/apps/desktop/src/main/maker-ipc/makerSendTransaction.ts
+++ b/apps/desktop/src/main/maker-ipc/makerSendTransaction.ts
@@ -412,7 +412,7 @@ export interface MakerSendTransactionDeps {
    */
   peekPendingHandoff?(sessionId: string): Promise<string | null>;
   consumePendingHandoff?(sessionId: string): void;
-  peekWorkingDirectoryRecoveryNote?(sessionId: string): string | null;
+  peekWorkingDirectoryRecoveryNote?(sessionId: string, workingDir: string): string | null;
   readWorkingDirectoryRecoveryCreateOpts(sessionId: string): Promise<CreateOpts>;
   consumeWorkingDirectoryRecoveryNote?(sessionId: string, note: string): void;
   /**
@@ -879,7 +879,7 @@ export function createMakerSendTransaction(deps: MakerSendTransactionDeps): Make
         // The pending note also covers recovery performed by an earlier preflight.
         const needsCwdRefresh = ok && !sess.remoteHostId &&
           (sess.agentKind === 'claude-code' || sess.agentKind === 'pi') &&
-          !!deps.peekWorkingDirectoryRecoveryNote?.(sessionId);
+          !!deps.peekWorkingDirectoryRecoveryNote?.(sessionId, sess.workDir);
         if ((!ok && fallbackDir) || needsCwdRefresh) {
           const co = deps.buildCreateOptsWithStderr({
             ...((createOpts as CreateOpts | undefined) ?? await deps.readWorkingDirectoryRecoveryCreateOpts(sessionId)),
@@ -1026,7 +1026,7 @@ export function createMakerSendTransaction(deps: MakerSendTransactionDeps): Make
       // session-agent-switch:切换后的首条消息把交接前缀拼进 wire payload。
       // 落库/显示内容(persistUserMessage.content)不含交接段——display 与 sent 分离。
       const workdirRecoveryNote = shouldPrependMobileClientPromptNote(normalized, sess.agentKind)
-        ? deps.peekWorkingDirectoryRecoveryNote?.(sessionId) ?? null
+        ? deps.peekWorkingDirectoryRecoveryNote?.(sessionId, sess.workDir) ?? null
         : null;
       if (workdirRecoveryNote) {
         normalized = prependNoteToWireUserMessage(normalized as HandoffWireMessage, workdirRecoveryNote);

--- a/apps/desktop/src/main/maker-ipc/makerSendTransaction.ts
+++ b/apps/desktop/src/main/maker-ipc/makerSendTransaction.ts
@@ -875,11 +875,16 @@ export function createMakerSendTransaction(deps: MakerSendTransactionDeps): Make
           sess.remoteHostId,
           ...(fallbackDir ? [{ suppressMissingBroadcast: true }] : []),
         );
-        if (!ok && fallbackDir) {
+        // Claude/Pi keep a process whose cwd can still reference the deleted inode.
+        // The pending note also covers recovery performed by an earlier preflight.
+        const needsCwdRefresh = ok && !sess.remoteHostId &&
+          (sess.agentKind === 'claude-code' || sess.agentKind === 'pi') &&
+          !!deps.peekWorkingDirectoryRecoveryNote?.(sessionId);
+        if ((!ok && fallbackDir) || needsCwdRefresh) {
           const co = deps.buildCreateOptsWithStderr({
             ...((createOpts as CreateOpts | undefined) ?? await deps.readWorkingDirectoryRecoveryCreateOpts(sessionId)),
             id: sessionId,
-            workingDir: fallbackDir,
+            workingDir: needsCwdRefresh ? sess.workDir : fallbackDir!,
             agentKind: sess.agentKind,
             remoteHostId: sess.remoteHostId ?? undefined,
           });

--- a/apps/desktop/src/main/maker-ipc/mobileClientPromptNote.ts
+++ b/apps/desktop/src/main/maker-ipc/mobileClientPromptNote.ts
@@ -57,15 +57,24 @@ function singleTextContent(message: unknown): string | null {
 }
 
 /**
- * Claude Code 内置命令必须位于消息开头；手机客户端说明不能抢占这个位置。
- * 只放行已由 palette 明确暴露的 `/compact`，其它 slash 文本继续保留来源说明。
+ * 原生命令必须位于消息开头；环境说明不能抢占这个位置。
+ * Claude 旁路 /compact；Pi 的 slash 输入交由运行时自己的命令发现处理。
  */
 export function shouldPrependMobileClientPromptNote(
   message: unknown,
   agentKind: string,
 ): boolean {
-  if (agentKind !== 'claude-code') return true;
   const text = singleTextContent(message);
+  // Pi owns command discovery. Leave slash inputs intact so its runtime can
+  // execute installed commands (or treat unknown ones as literal text).
+  if (agentKind === 'pi') {
+    const content = message && typeof message === 'object'
+      ? (message as { content?: unknown }).content : null;
+    const parts = Array.isArray(content) ? content : [];
+    const firstText = parts.find((part) => part?.type === 'text' && typeof part.text === 'string')?.text;
+    return !(text ?? firstText ?? '').trimStart().startsWith('/');
+  }
+  if (agentKind !== 'claude-code') return true;
   return text === null || !/^\/compact(?:\s|$)/.test(text);
 }
 

--- a/apps/desktop/src/main/maker-ipc/register.ts
+++ b/apps/desktop/src/main/maker-ipc/register.ts
@@ -209,6 +209,7 @@ import {
   isDbClientNotReadyError,
 } from '../localDb/client/current.js';
 import { createBotRuntimeRestoreCoordinator } from './botRuntimeRestore.js';
+import { createWorkingDirectoryRecovery } from './workingDirectoryRecovery.js';
 import { getMessagesForHistory } from '../localDb/chatHistoryReader.js';
 import {
   awaitAgentInputQueueSnapshotPersistence,
@@ -220,10 +221,7 @@ import {
   ensureDialogueWorkspaceDir,
   dialogueWorkspaceRootDir,
 } from '../localDb/dialogueWorkspace.js';
-import {
-  healMissingDialogueWorkdir,
-  matchDialogueWorkspacePath,
-} from '../localDb/dialogueWorkdirSelfHeal.js';
+import { matchDialogueWorkspacePath } from '../localDb/dialogueWorkdirSelfHeal.js';
 import {
   broadcastMessageRow,
   broadcastMessageAgentMetaUpdate,
@@ -1053,6 +1051,7 @@ import { handleSessionEvent, type SessionEventDependencies } from './sessionEven
 import { installSessionTurnObserver } from './sessionTurnObserver.js';
 
 const log = createLogger('maker-ipc');
+const workingDirectoryRecovery = createWorkingDirectoryRecovery();
 
 function localModelWindowSwitchErrorCode(code: IpcErrorCode): IpcErrorCode {
   return isDeviceLinkInvoke() ? 'PRECONDITION_FAILED' : code;
@@ -11498,6 +11497,9 @@ export function registerMakerIpc(maker: Maker, options: RegisterMakerIpcOptions)
       await ensureRemoteReadyForSessionStart(params);
     },
     checkWorkDirExists,
+    peekWorkingDirectoryRecoveryNote: (sessionId) => workingDirectoryRecovery.peek(sessionId),
+    consumeWorkingDirectoryRecoveryNote: (sessionId, note) =>
+      workingDirectoryRecovery.consume(sessionId, note),
     isOrcaMcpHydrated,
     buildCreateOptsWithStderr,
     synthesizeOrcaVendorOptionsFromDb,
@@ -17282,21 +17284,24 @@ async function checkWorkDirExists(
       }
     }
     return true;
-  } catch {
-    // app 托管的 dialogue 工作目录(<userData>/dialogues/<日期>/<id>)本来就是
-    // 空的一次性目录:丢了直接 mkdir 重建放行,不打扰用户(自愈详见
-    // dialogueWorkdirSelfHeal.ts;legacy userData 前缀由启动 sweep 先行改写)。
-    const healed = await healMissingDialogueWorkdir(workingDir, dialogueWorkspaceRootDir());
-    if (healed) {
-      log.info('send: recreated missing dialogue workdir', { sessionId, workingDir });
-      return true;
-    }
+  } catch (error) {
     // Cindy 托管 worktree 被外部 PR cleanup / 手动 git 命令移除时，先按 DB 中
-    // 的精确 worktree_path 从本地或 origin tracking 分支重建。普通用户目录绝不
-    // 猜测 fallback；快照冲突也保持阻断，交给恢复横幅显式处理。
+    // 的精确 worktree_path 从本地或 origin tracking 分支重建，保留原代码与快照。
     const restored = await restoreMissingManagedWorktreeForSession(sessionId, workingDir);
     if (restored) {
       log.info('send: restored missing managed worktree', { sessionId, workingDir });
+      return true;
+    }
+    // A missing ordinary/dialogue cwd must not stop the conversation. Prefer a repaired
+    // DB path when the caller has one; never turn a managed Git recovery into
+    // an empty project, or treat permission/non-directory failures as ENOENT.
+    if (
+      !suppress &&
+      (error as NodeJS.ErrnoException).code === 'ENOENT' &&
+      getManagedWorktreeBasePath(path.resolve(workingDir).replace(/\\/g, '/')) === null &&
+      await workingDirectoryRecovery.recover(sessionId, workingDir)
+    ) {
+      log.info('send: recreated missing working directory for conversation', { sessionId, workingDir });
       return true;
     }
     if (suppress) {

--- a/apps/desktop/src/main/maker-ipc/register.ts
+++ b/apps/desktop/src/main/maker-ipc/register.ts
@@ -3315,6 +3315,10 @@ export function clearDeferredCodexRestartForOwnerBoundary(): void {
   deferredCodexRestartHolder?.clear();
 }
 
+export function clearWorkingDirectoryRecoveryForOwnerBoundary(): void {
+  workingDirectoryRecovery.clear();
+}
+
 /**
  * Goal / IM / scheduler 直发 `Session.send()` 的 deferred agent-switch 锁桥。
  *
@@ -4590,6 +4594,7 @@ export function registerMakerIpc(maker: Maker, options: RegisterMakerIpcOptions)
     }),
   );
   setSessionRuntimeCleanup((sessionId) => {
+    workingDirectoryRecovery.discard(sessionId);
     clearSessionRuntimeControlState(sessionId);
     clearSessionProvider(sessionId);
     setSessionEffort(sessionId, null);
@@ -11497,6 +11502,28 @@ export function registerMakerIpc(maker: Maker, options: RegisterMakerIpcOptions)
       await ensureRemoteReadyForSessionStart(params);
     },
     checkWorkDirExists,
+    readWorkingDirectoryRecoveryCreateOpts: async (sessionId) => {
+      const [row] = await getDbClient().drizzle.select().from(sessions)
+        .where(eq(sessions.id, sessionId)).limit(1);
+      if (!row?.workingDir) throw new Error(`Session ${sessionId} has no working directory`);
+      return {
+        id: sessionId,
+        agentKind: dbToMakerAgentKind(row.agentKind),
+        workingDir: row.workingDir,
+        workspaceKind: row.workspaceKind,
+        model: row.model ?? undefined,
+        providerId: row.providerId,
+        effort: (row.effort ?? undefined) as CreateOpts['effort'],
+        fastMode: !!row.fastMode,
+        permissionMode: permissionModeOrAsk(row.permissionMode),
+        planMode: !!row.planModeEnabled,
+        title: row.title ?? undefined,
+        resumeSessionId: row.sdkSessionId ?? undefined,
+        remoteHostId: row.remoteHostId ?? undefined,
+        orcaRole: row.orcaRole as CreateOpts['orcaRole'],
+        codexHistoryHasProductPrompt: row.codexHistoryHasProductPrompt ?? undefined,
+      };
+    },
     peekWorkingDirectoryRecoveryNote: (sessionId) => workingDirectoryRecovery.peek(sessionId),
     consumeWorkingDirectoryRecoveryNote: (sessionId, note) =>
       workingDirectoryRecovery.consume(sessionId, note),
@@ -14580,6 +14607,7 @@ export function registerMakerIpc(maker: Maker, options: RegisterMakerIpcOptions)
           isRemoteInvoke: remoteInvoke,
         });
         const projection = inputCoordinator.clearSession(sid, clearBoundary);
+        workingDirectoryRecovery.discard(sid);
         resetAutomaticRecoveryForExplicitStop(sid);
         // 丢弃缓存的待注入交接 / fork 来源标记:它们是按 clear 之前的历史算出来的,
         // DB 侧的 cleared_at 抑制拦不住已经落进 registry 内存的那一份(首发被拒后

--- a/apps/desktop/src/main/maker-ipc/register.ts
+++ b/apps/desktop/src/main/maker-ipc/register.ts
@@ -11524,7 +11524,7 @@ export function registerMakerIpc(maker: Maker, options: RegisterMakerIpcOptions)
         codexHistoryHasProductPrompt: row.codexHistoryHasProductPrompt ?? undefined,
       };
     },
-    peekWorkingDirectoryRecoveryNote: (sessionId) => workingDirectoryRecovery.peek(sessionId),
+    peekWorkingDirectoryRecoveryNote: (sessionId, workingDir) => workingDirectoryRecovery.peek(sessionId, workingDir),
     consumeWorkingDirectoryRecoveryNote: (sessionId, note) =>
       workingDirectoryRecovery.consume(sessionId, note),
     isOrcaMcpHydrated,
@@ -17330,7 +17330,10 @@ async function checkWorkDirExists(
       !suppress &&
       (error as NodeJS.ErrnoException).code === 'ENOENT' &&
       getManagedWorktreeBasePath(path.resolve(workingDir).replace(/\\/g, '/')) === null &&
-      await workingDirectoryRecovery.recover(sessionId, workingDir, similar)
+      await workingDirectoryRecovery.recover(sessionId, workingDir, similar,
+        getMaker().listActiveSessions()
+          .filter((session) => !session.remoteHostId && path.resolve(session.workDir) === path.resolve(workingDir))
+          .map((session) => session.id))
     ) {
       log.info('send: recreated missing working directory for conversation', { sessionId, workingDir });
       return true;

--- a/apps/desktop/src/main/maker-ipc/register.ts
+++ b/apps/desktop/src/main/maker-ipc/register.ts
@@ -17320,6 +17320,9 @@ async function checkWorkDirExists(
       log.info('send: restored missing managed worktree', { sessionId, workingDir });
       return true;
     }
+    // Preserve the existing sibling-path diagnostic before mkdir makes the probe pass.
+    // A fuzzy match is a lead for the agent, not authority to switch project identity.
+    const similar = suppress ? null : await findSimilarDirOnDisk(workingDir);
     // A missing ordinary/dialogue cwd must not stop the conversation. Prefer a repaired
     // DB path when the caller has one; never turn a managed Git recovery into
     // an empty project, or treat permission/non-directory failures as ENOENT.
@@ -17327,7 +17330,7 @@ async function checkWorkDirExists(
       !suppress &&
       (error as NodeJS.ErrnoException).code === 'ENOENT' &&
       getManagedWorktreeBasePath(path.resolve(workingDir).replace(/\\/g, '/')) === null &&
-      await workingDirectoryRecovery.recover(sessionId, workingDir)
+      await workingDirectoryRecovery.recover(sessionId, workingDir, similar)
     ) {
       log.info('send: recreated missing working directory for conversation', { sessionId, workingDir });
       return true;
@@ -17339,7 +17342,6 @@ async function checkWorkDirExists(
       });
       return false;
     }
-    const similar = await findSimilarDirOnDisk(workingDir);
     emitWorkDirMissingError(sessionId, workingDir, source, 'not-exist', similar);
     return false;
   }

--- a/apps/desktop/src/main/maker-ipc/register.ts
+++ b/apps/desktop/src/main/maker-ipc/register.ts
@@ -210,7 +210,7 @@ import {
 } from '../localDb/client/current.js';
 import { createBotRuntimeRestoreCoordinator } from './botRuntimeRestore.js';
 import { createWorkingDirectoryRecovery, isUnavailableFilesystemError } from './workingDirectoryRecovery.js';
-import { statWorkingDirectory } from '../workdir-probe-host/index.js';
+import { statWorkingDirectory, mkdirWorkingDirectory, realpathWorkingDirectory, findSimilarWorkingDirectory } from '../workdir-probe-host/index.js';
 import { getMessagesForHistory } from '../localDb/chatHistoryReader.js';
 import {
   awaitAgentInputQueueSnapshotPersistence,
@@ -1052,7 +1052,7 @@ import { handleSessionEvent, type SessionEventDependencies } from './sessionEven
 import { installSessionTurnObserver } from './sessionTurnObserver.js';
 
 const log = createLogger('maker-ipc');
-const workingDirectoryRecovery = createWorkingDirectoryRecovery({ stat: statWorkingDirectory, mkdir: fsp.mkdir, realpath: fsp.realpath }, async (sessionId) =>
+const workingDirectoryRecovery = createWorkingDirectoryRecovery({ stat: statWorkingDirectory, mkdir: mkdirWorkingDirectory, realpath: realpathWorkingDirectory }, async (sessionId) =>
   ensureDialogueWorkspaceDir(sessionId, Date.now()));
 
 function localModelWindowSwitchErrorCode(code: IpcErrorCode): IpcErrorCode {
@@ -6267,7 +6267,12 @@ export function registerMakerIpc(maker: Maker, options: RegisterMakerIpcOptions)
     const didInjectProjectContext =
       o.reviewMode === true ? false : await applyProjectContextInjection(o);
 
+    const usingFallback = !!o.id && !!o.workingDir && !o.remoteHostId &&
+      workingDirectoryRecovery.isFallback(o.id, o.workingDir);
     await prepareDirectoryGrantsForBootstrap(o, {
+      statDirectory: usingFallback ? statWorkingDirectory : undefined,
+      realpathDirectory: usingFallback ? realpathWorkingDirectory : undefined,
+      preservePersistedGrants: usingFallback,
       readPersistedWritableDirs: readSessionWritableDirsFromDb,
       persistExistingSession: async (sessionId, patch) => {
         const [existing] = await getDbClient()
@@ -17376,22 +17381,13 @@ async function checkWorkDirExists(
  * ENOENT 兜底:扫一下 parent 目录,找一个 trim/大小写 后等于目标 basename 的真实条目。
  * 命中的最典型场景是 macOS Finder 里目录名末尾带了不可见空格,而 sessions.ts 写库时
  * 做了 .trim() 把空格砍了 —— DB 里存的路径在磁盘上不存在,但同名带空格的目录是存在的。
- * 失败一律返回 null,不要在错误兜底里再抛新错。
+ * 普通诊断失败返回 null；文件系统不可用交给 recovery 的统一 fallback。
  */
 async function findSimilarDirOnDisk(workingDir: string): Promise<string | null> {
-  try {
-    const parent = path.dirname(workingDir);
-    const target = path.basename(workingDir);
-    if (!parent || parent === workingDir || !target) return null;
-    const entries = await fsp.readdir(parent);
-    const trimMatch = entries.find((n) => n !== target && n.trim() === target.trim());
-    if (trimMatch) return path.join(parent, trimMatch);
-    const ciMatch = entries.find((n) => n !== target && n.toLowerCase() === target.toLowerCase());
-    if (ciMatch) return path.join(parent, ciMatch);
+  return findSimilarWorkingDirectory(workingDir).catch((error) => {
+    if (isUnavailableFilesystemError(error)) throw error;
     return null;
-  } catch {
-    return null;
-  }
+  });
 }
 
 function emitWorkDirMissingError(

--- a/apps/desktop/src/main/maker-ipc/register.ts
+++ b/apps/desktop/src/main/maker-ipc/register.ts
@@ -6242,6 +6242,7 @@ export function registerMakerIpc(maker: Maker, options: RegisterMakerIpcOptions)
     didInjectOrcaInstructions: boolean;
     didInjectProjectContext: boolean;
   }> {
+    o.hostUserPrompt = o.userPrompt;
     await options.waitForAccountProviderModelsReady();
     const runtimeOverride =
       typeof o.id === 'string' ? getSessionRuntimeControlSnapshot(o.id).effectiveOverride : null;
@@ -17332,8 +17333,8 @@ async function checkWorkDirExists(
       getManagedWorktreeBasePath(path.resolve(workingDir).replace(/\\/g, '/')) === null &&
       await workingDirectoryRecovery.recover(sessionId, workingDir, similar,
         getMaker().listActiveSessions()
-          .filter((session) => !session.remoteHostId && path.resolve(session.workDir) === path.resolve(workingDir))
-          .map((session) => session.id))
+          .filter((session) => !session.remoteHostId)
+          .map((session) => ({ id: session.id, workingDir: session.workDir })))
     ) {
       log.info('send: recreated missing working directory for conversation', { sessionId, workingDir });
       return true;

--- a/apps/desktop/src/main/maker-ipc/register.ts
+++ b/apps/desktop/src/main/maker-ipc/register.ts
@@ -6242,7 +6242,11 @@ export function registerMakerIpc(maker: Maker, options: RegisterMakerIpcOptions)
     didInjectOrcaInstructions: boolean;
     didInjectProjectContext: boolean;
   }> {
-    o.hostUserPrompt = o.userPrompt;
+    o.hostStartupPreferences = {
+      userPrompt: o.userPrompt,
+      makerMemoryEnabled: o.makerMemoryEnabled,
+      displayReasoning: o.displayReasoning,
+    };
     await options.waitForAccountProviderModelsReady();
     const runtimeOverride =
       typeof o.id === 'string' ? getSessionRuntimeControlSnapshot(o.id).effectiveOverride : null;
@@ -11503,6 +11507,7 @@ export function registerMakerIpc(maker: Maker, options: RegisterMakerIpcOptions)
       await ensureRemoteReadyForSessionStart(params);
     },
     checkWorkDirExists,
+    preflightBotRuntimeResources: async (opts) => { await preflightBotRuntimeResources(opts); },
     readWorkingDirectoryRecoveryCreateOpts: async (sessionId) => {
       const [row] = await getDbClient().drizzle.select().from(sessions)
         .where(eq(sessions.id, sessionId)).limit(1);

--- a/apps/desktop/src/main/maker-ipc/register.ts
+++ b/apps/desktop/src/main/maker-ipc/register.ts
@@ -209,7 +209,8 @@ import {
   isDbClientNotReadyError,
 } from '../localDb/client/current.js';
 import { createBotRuntimeRestoreCoordinator } from './botRuntimeRestore.js';
-import { createWorkingDirectoryRecovery } from './workingDirectoryRecovery.js';
+import { createWorkingDirectoryRecovery, isUnavailableFilesystemError } from './workingDirectoryRecovery.js';
+import { statWorkingDirectory } from '../workdir-probe-host/index.js';
 import { getMessagesForHistory } from '../localDb/chatHistoryReader.js';
 import {
   awaitAgentInputQueueSnapshotPersistence,
@@ -1051,7 +1052,8 @@ import { handleSessionEvent, type SessionEventDependencies } from './sessionEven
 import { installSessionTurnObserver } from './sessionTurnObserver.js';
 
 const log = createLogger('maker-ipc');
-const workingDirectoryRecovery = createWorkingDirectoryRecovery();
+const workingDirectoryRecovery = createWorkingDirectoryRecovery({ stat: statWorkingDirectory, mkdir: fsp.mkdir, realpath: fsp.realpath }, async (sessionId) =>
+  ensureDialogueWorkspaceDir(sessionId, Date.now()));
 
 function localModelWindowSwitchErrorCode(code: IpcErrorCode): IpcErrorCode {
   return isDeviceLinkInvoke() ? 'PRECONDITION_FAILED' : code;
@@ -6242,6 +6244,10 @@ export function registerMakerIpc(maker: Maker, options: RegisterMakerIpcOptions)
     didInjectOrcaInstructions: boolean;
     didInjectProjectContext: boolean;
   }> {
+    if (o.id && o.workingDir && !o.remoteHostId) {
+      o.workingDir = workingDirectoryRecovery.resolve(o.id, o.workingDir);
+      await workingDirectoryRecovery.observe(o.id, o.workingDir).catch(() => undefined);
+    }
     o.hostStartupPreferences = {
       userPrompt: o.userPrompt,
       makerMemoryEnabled: o.makerMemoryEnabled,
@@ -11507,6 +11513,7 @@ export function registerMakerIpc(maker: Maker, options: RegisterMakerIpcOptions)
       await ensureRemoteReadyForSessionStart(params);
     },
     checkWorkDirExists,
+    resolveRecoveredWorkingDir: (sessionId, dir) => workingDirectoryRecovery.resolve(sessionId, dir),
     preflightBotRuntimeResources: async (opts) => { await preflightBotRuntimeResources(opts); },
     readWorkingDirectoryRecoveryCreateOpts: async (sessionId) => {
       const [row] = await getDbClient().drizzle.select().from(sessions)
@@ -17282,12 +17289,13 @@ async function checkWorkDirExists(
   // 或者 agent 真跑起来时由远端 codex 自己报 ENOENT)。这里直接放行。
   if (remoteHostId) return true;
   if (!workingDir?.trim()) return true;
+  workingDir = workingDirectoryRecovery.resolve(sessionId, workingDir);
   const source: AgentKind = agentKind === 'codex' || agentKind === 'pi' ? agentKind : 'claude-code';
   // suppressMissingBroadcast: 调用方(SEND 事务)手里还有 DB 权威值可兜底时,
   // 首检失败只记日志不广播错误横幅——兜底成功的话用户不该看到假错误。
   const suppress = opts?.suppressMissingBroadcast === true;
   try {
-    const stat = await fsp.stat(workingDir);
+    const stat = await statWorkingDirectory(workingDir);
     if (!stat.isDirectory()) {
       if (suppress) {
         log.warn('send: workdir not a directory (broadcast suppressed, caller has fallback)', {
@@ -17317,6 +17325,10 @@ async function checkWorkDirExists(
         return false;
       }
     }
+    if (getManagedWorktreeBasePath(normalizedWorkingDir) === null) {
+      if (!await workingDirectoryRecovery.recover(sessionId, workingDir)) return false;
+      await workingDirectoryRecovery.observe(sessionId, workingDir);
+    }
     return true;
   } catch (error) {
     // Cindy 托管 worktree 被外部 PR cleanup / 手动 git 命令移除时，先按 DB 中
@@ -17328,15 +17340,19 @@ async function checkWorkDirExists(
     }
     // Preserve the existing sibling-path diagnostic before mkdir makes the probe pass.
     // A fuzzy match is a lead for the agent, not authority to switch project identity.
-    const similar = suppress ? null : await findSimilarDirOnDisk(workingDir);
+    const unavailable = isUnavailableFilesystemError(error);
+    let similar: string | null = null;
     // A missing ordinary/dialogue cwd must not stop the conversation. Prefer a repaired
     // DB path when the caller has one; never turn a managed Git recovery into
     // an empty project, or treat permission/non-directory failures as ENOENT.
     if (
       !suppress &&
-      (error as NodeJS.ErrnoException).code === 'ENOENT' &&
+      ((error as NodeJS.ErrnoException).code === 'ENOENT' || unavailable) &&
       getManagedWorktreeBasePath(path.resolve(workingDir).replace(/\\/g, '/')) === null &&
-      await workingDirectoryRecovery.recover(sessionId, workingDir, similar,
+      await workingDirectoryRecovery.recover(sessionId, workingDir, async () => {
+        similar = await findSimilarDirOnDisk(workingDir);
+        return similar;
+      },
         getMaker().listActiveSessions()
           .filter((session) => !session.remoteHostId)
           .map((session) => ({ id: session.id, workingDir: session.workDir })))

--- a/apps/desktop/src/main/maker-ipc/workingDirectoryRecovery.ts
+++ b/apps/desktop/src/main/maker-ipc/workingDirectoryRecovery.ts
@@ -5,35 +5,45 @@ export function createWorkingDirectoryRecovery(io: {
   stat(dir: string): Promise<{ isDirectory(): boolean }>;
   mkdir(dir: string, opts: { recursive: true }): Promise<unknown>;
 } = fsp) {
-  const pending = new Map<string, string>();
+  const pending = new Map<string, { note: string | null }>();
   return {
     async recover(sessionId: string, workingDir: string): Promise<boolean> {
+      const entry = pending.get(sessionId) ?? { note: null };
+      pending.set(sessionId, entry);
       try {
         // A stale probe must not mistake a file, permission error, or a directory
         // restored by someone else for a missing directory.
-        const stat = await io.stat(workingDir);
-        return stat.isDirectory();
-      } catch (error) {
-        if ((error as NodeJS.ErrnoException).code !== 'ENOENT') return false;
-      }
-      try {
+        try {
+          const stat = await io.stat(workingDir);
+          return stat.isDirectory();
+        } catch (error) {
+          if ((error as NodeJS.ErrnoException).code !== 'ENOENT') return false;
+        }
         await io.mkdir(workingDir, { recursive: true });
-        pending.set(sessionId, [
+        // Cleanup may have removed this entry while filesystem IO was pending.
+        // Do not repopulate it after a clear, archive, delete, or owner change.
+        if (pending.get(sessionId) === entry) entry.note = [
           '[Working directory recovery]',
           `The working directory was missing. Cindy recreated the directory at ${JSON.stringify(workingDir)} so this conversation can continue.`,
           'Only the directory was recreated; its previous files have not been recovered. Do not assume the original project contents are available.',
           'Continue responding to the user. If their task needs the missing files, investigate the location or recovery options, or ask the user through the conversation. Do not require a folder-selection interface just to continue chatting.',
-        ].join('\n'));
+        ].join('\n');
         return true;
       } catch {
         return false;
       }
     },
     peek(sessionId: string): string | null {
-      return pending.get(sessionId) ?? null;
+      return pending.get(sessionId)?.note ?? null;
     },
     consume(sessionId: string, expectedNote: string): void {
-      if (pending.get(sessionId) === expectedNote) pending.delete(sessionId);
+      if (pending.get(sessionId)?.note === expectedNote) pending.delete(sessionId);
+    },
+    discard(sessionId: string): void {
+      pending.delete(sessionId);
+    },
+    clear(): void {
+      pending.clear();
     },
   };
 }

--- a/apps/desktop/src/main/maker-ipc/workingDirectoryRecovery.ts
+++ b/apps/desktop/src/main/maker-ipc/workingDirectoryRecovery.ts
@@ -5,16 +5,19 @@ import path from 'node:path';
 export function createWorkingDirectoryRecovery(io: {
   stat(dir: string): Promise<{ isDirectory(): boolean }>;
   mkdir(dir: string, opts: { recursive: true }): Promise<unknown>;
+  realpath?(dir: string): Promise<string>;
 } = fsp) {
   const pending = new Map<string, { workingDir: string; note: string | null }>();
   return {
-    async recover(sessionId: string, workingDir: string, similarPath?: string | null, affectedSessionIds: string[] = []): Promise<boolean> {
-      const normalizedDir = path.resolve(workingDir);
-      const entries = [...new Set([sessionId, ...affectedSessionIds])].map((id) => {
+    async recover(sessionId: string, workingDir: string, similarPath?: string | null, candidates: { id: string; workingDir: string }[] = []): Promise<boolean> {
+      const sessions = new Map(candidates.map((session) => [session.id, session.workingDir]));
+      sessions.set(sessionId, workingDir);
+      const entries = [...sessions].map(([id, dir]) => {
         const previous = pending.get(id);
-        const entry = previous?.workingDir === normalizedDir ? previous : { workingDir: normalizedDir, note: null };
+        // Preserve unrelated recovery notes until physical identity is known.
+        const entry = previous ?? { workingDir: path.resolve(dir), note: null };
         pending.set(id, entry);
-        return { id, entry };
+        return { id, dir, entry };
       });
       try {
         // A stale probe must not mistake a file, permission error, or a directory
@@ -26,6 +29,7 @@ export function createWorkingDirectoryRecovery(io: {
           if ((error as NodeJS.ErrnoException).code !== 'ENOENT') return false;
         }
         await io.mkdir(workingDir, { recursive: true });
+        const canonical = await io.realpath?.(workingDir).catch(() => null);
         // Cleanup may have removed this entry while filesystem IO was pending.
         // Do not repopulate it after a clear, archive, delete, or owner change.
         const note = [
@@ -37,9 +41,13 @@ export function createWorkingDirectoryRecovery(io: {
           ] : []),
           'Continue responding to the user. If their task needs the missing files, investigate the location or recovery options, or ask the user through the conversation. Do not require a folder-selection interface just to continue chatting.',
         ].join('\n');
-        for (const { id, entry } of entries) {
-          if (pending.get(id) === entry) entry.note = note;
-        }
+        await Promise.all(entries.map(async ({ id, dir, entry }) => {
+          const matches = path.resolve(dir) === path.resolve(workingDir) ||
+            (canonical != null && await io.realpath?.(dir).catch(() => null) === canonical);
+          if (matches && pending.get(id) === entry) {
+            pending.set(id, { workingDir: path.resolve(dir), note });
+          }
+        }));
         return true;
       } catch {
         return false;

--- a/apps/desktop/src/main/maker-ipc/workingDirectoryRecovery.ts
+++ b/apps/desktop/src/main/maker-ipc/workingDirectoryRecovery.ts
@@ -1,15 +1,21 @@
 import fsp from 'node:fs/promises';
+import path from 'node:path';
 
 /** Ordinary local directories only; managed Git worktrees keep their own restore path. */
 export function createWorkingDirectoryRecovery(io: {
   stat(dir: string): Promise<{ isDirectory(): boolean }>;
   mkdir(dir: string, opts: { recursive: true }): Promise<unknown>;
 } = fsp) {
-  const pending = new Map<string, { note: string | null }>();
+  const pending = new Map<string, { workingDir: string; note: string | null }>();
   return {
-    async recover(sessionId: string, workingDir: string, similarPath?: string | null): Promise<boolean> {
-      const entry = pending.get(sessionId) ?? { note: null };
-      pending.set(sessionId, entry);
+    async recover(sessionId: string, workingDir: string, similarPath?: string | null, affectedSessionIds: string[] = []): Promise<boolean> {
+      const normalizedDir = path.resolve(workingDir);
+      const entries = [...new Set([sessionId, ...affectedSessionIds])].map((id) => {
+        const previous = pending.get(id);
+        const entry = previous?.workingDir === normalizedDir ? previous : { workingDir: normalizedDir, note: null };
+        pending.set(id, entry);
+        return { id, entry };
+      });
       try {
         // A stale probe must not mistake a file, permission error, or a directory
         // restored by someone else for a missing directory.
@@ -22,7 +28,7 @@ export function createWorkingDirectoryRecovery(io: {
         await io.mkdir(workingDir, { recursive: true });
         // Cleanup may have removed this entry while filesystem IO was pending.
         // Do not repopulate it after a clear, archive, delete, or owner change.
-        if (pending.get(sessionId) === entry) entry.note = [
+        const note = [
           '[Working directory recovery]',
           `The working directory was missing. Cindy recreated the directory at ${JSON.stringify(workingDir)} so this conversation can continue.`,
           'Only the directory was recreated; its previous files have not been recovered. Do not assume the original project contents are available.',
@@ -31,13 +37,21 @@ export function createWorkingDirectoryRecovery(io: {
           ] : []),
           'Continue responding to the user. If their task needs the missing files, investigate the location or recovery options, or ask the user through the conversation. Do not require a folder-selection interface just to continue chatting.',
         ].join('\n');
+        for (const { id, entry } of entries) {
+          if (pending.get(id) === entry) entry.note = note;
+        }
         return true;
       } catch {
         return false;
       }
     },
-    peek(sessionId: string): string | null {
-      return pending.get(sessionId)?.note ?? null;
+    peek(sessionId: string, workingDir?: string): string | null {
+      const entry = pending.get(sessionId);
+      if (entry && workingDir !== undefined && entry.workingDir !== path.resolve(workingDir)) {
+        pending.delete(sessionId);
+        return null;
+      }
+      return entry?.note ?? null;
     },
     consume(sessionId: string, expectedNote: string): void {
       if (pending.get(sessionId)?.note === expectedNote) pending.delete(sessionId);

--- a/apps/desktop/src/main/maker-ipc/workingDirectoryRecovery.ts
+++ b/apps/desktop/src/main/maker-ipc/workingDirectoryRecovery.ts
@@ -1,0 +1,39 @@
+import fsp from 'node:fs/promises';
+
+/** Ordinary local directories only; managed Git worktrees keep their own restore path. */
+export function createWorkingDirectoryRecovery(io: {
+  stat(dir: string): Promise<{ isDirectory(): boolean }>;
+  mkdir(dir: string, opts: { recursive: true }): Promise<unknown>;
+} = fsp) {
+  const pending = new Map<string, string>();
+  return {
+    async recover(sessionId: string, workingDir: string): Promise<boolean> {
+      try {
+        // A stale probe must not mistake a file, permission error, or a directory
+        // restored by someone else for a missing directory.
+        const stat = await io.stat(workingDir);
+        return stat.isDirectory();
+      } catch (error) {
+        if ((error as NodeJS.ErrnoException).code !== 'ENOENT') return false;
+      }
+      try {
+        await io.mkdir(workingDir, { recursive: true });
+        pending.set(sessionId, [
+          '[Working directory recovery]',
+          `The working directory was missing. Cindy recreated the directory at ${JSON.stringify(workingDir)} so this conversation can continue.`,
+          'Only the directory was recreated; its previous files have not been recovered. Do not assume the original project contents are available.',
+          'Continue responding to the user. If their task needs the missing files, investigate the location or recovery options, or ask the user through the conversation. Do not require a folder-selection interface just to continue chatting.',
+        ].join('\n'));
+        return true;
+      } catch {
+        return false;
+      }
+    },
+    peek(sessionId: string): string | null {
+      return pending.get(sessionId) ?? null;
+    },
+    consume(sessionId: string, expectedNote: string): void {
+      if (pending.get(sessionId) === expectedNote) pending.delete(sessionId);
+    },
+  };
+}

--- a/apps/desktop/src/main/maker-ipc/workingDirectoryRecovery.ts
+++ b/apps/desktop/src/main/maker-ipc/workingDirectoryRecovery.ts
@@ -1,15 +1,71 @@
 import fsp from 'node:fs/promises';
 import path from 'node:path';
 
+export function isUnavailableFilesystemError(error: unknown): boolean {
+  return ['EIO', 'ENOTCONN', 'ENODEV', 'ESTALE', 'ETIMEDOUT', 'EHOSTUNREACH', 'ENETUNREACH', 'WORKDIR_PROBE_TIMEOUT']
+    .includes((error as NodeJS.ErrnoException | null)?.code ?? '');
+}
+
 /** Ordinary local directories only; managed Git worktrees keep their own restore path. */
 export function createWorkingDirectoryRecovery(io: {
-  stat(dir: string): Promise<{ isDirectory(): boolean }>;
+  stat(dir: string): Promise<{ isDirectory(): boolean; dev?: number }>;
   mkdir(dir: string, opts: { recursive: true }): Promise<unknown>;
   realpath?(dir: string): Promise<string>;
-} = fsp) {
-  const pending = new Map<string, { workingDir: string; note: string | null }>();
+} = fsp, allocateFallback?: (sessionId: string) => Promise<string>) {
+  const pending = new Map<string, { workingDir: string; note: string | null; device?: number; fallback?: string }>();
+  function entryFor(sessionId: string, dir: string) {
+    const entry = pending.get(sessionId);
+    if (entry && entry.workingDir !== path.resolve(dir) && entry.fallback !== path.resolve(dir)) {
+      pending.delete(sessionId);
+      return undefined;
+    }
+    return entry;
+  }
+  async function mountUnavailable(dir: string, entry: { device?: number }) {
+    const canonical = path.resolve(dir);
+    if (process.platform === 'darwin' && canonical.startsWith('/Volumes/')) {
+      const volume = canonical.split('/').slice(0, 3).join('/');
+      try {
+        const [mounted, parent] = await Promise.all([io.stat(volume), io.stat('/Volumes')]);
+        // A bare mount-point directory is on the parent filesystem. Exclude
+        // aliases such as /Volumes/Macintosh HD -> / before classifying it.
+        if (mounted.dev !== undefined && mounted.dev === parent.dev &&
+          await io.realpath?.(volume).catch(() => null) === volume) return true;
+      } catch (error) {
+        if ((error as NodeJS.ErrnoException).code === 'ENOENT' || isUnavailableFilesystemError(error)) return true;
+        throw error;
+      }
+    }
+    let ancestor = path.resolve(dir);
+    while (true) {
+      try {
+        const current = await io.stat(ancestor);
+        return entry.device !== undefined && current.dev !== undefined && current.dev !== entry.device;
+      } catch (error) {
+        if (isUnavailableFilesystemError(error)) return true;
+        if ((error as NodeJS.ErrnoException).code !== 'ENOENT') throw error;
+      }
+      const parent = path.dirname(ancestor);
+      if (parent === ancestor) return true; // An unavailable drive/share root cannot be recreated.
+      ancestor = parent;
+    }
+  }
   return {
-    async recover(sessionId: string, workingDir: string, similarPath?: string | null, candidates: { id: string; workingDir: string }[] = []): Promise<boolean> {
+    async observe(sessionId: string, workingDir: string): Promise<void> {
+      const existing = entryFor(sessionId, workingDir);
+      if (existing?.device !== undefined || existing?.fallback) return;
+      const entry = existing ?? { workingDir: path.resolve(workingDir), note: null };
+      pending.set(sessionId, entry);
+      const stat = await io.stat(workingDir);
+      // Do not revive a record cleared while observing the filesystem.
+      if (pending.get(sessionId) !== entry) return;
+      pending.set(sessionId, { workingDir: path.resolve(workingDir), note: existing?.note ?? null, device: stat.dev });
+    },
+    resolve(sessionId: string, workingDir: string): string {
+      return entryFor(sessionId, workingDir)?.fallback ?? workingDir;
+    },
+    async recover(sessionId: string, workingDir: string, similarPath?: string | null | (() => Promise<string | null>), candidates: { id: string; workingDir: string }[] = []): Promise<boolean> {
+      entryFor(sessionId, workingDir);
       const sessions = new Map(candidates.map((session) => [session.id, session.workingDir]));
       sessions.set(sessionId, workingDir);
       const entries = [...sessions].map(([id, dir]) => {
@@ -20,6 +76,30 @@ export function createWorkingDirectoryRecovery(io: {
         return { id, dir, entry };
       });
       try {
+        const own = entryFor(sessionId, workingDir);
+        if (own?.fallback) {
+          try { return (await io.stat(own.fallback)).isDirectory(); } catch (error) {
+            if ((error as NodeJS.ErrnoException).code !== 'ENOENT') return false;
+          }
+          await io.mkdir(own.fallback, { recursive: true });
+          if (pending.get(sessionId) !== own) return false;
+          pending.set(sessionId, { ...own, note: [
+            own.note ?? '[Working directory recovery]',
+            `The temporary conversation directory ${JSON.stringify(own.fallback)} was also missing and has been recreated. Its previous files have not been recovered. The original workspace remains ${JSON.stringify(own.workingDir)}; do not create a substitute at that location.`,
+          ].join('\n') });
+          return true;
+        }
+        if (own && allocateFallback && await mountUnavailable(workingDir, own)) {
+          const fallback = path.resolve(await allocateFallback(sessionId));
+          if (pending.get(sessionId) !== own) return false;
+          pending.set(sessionId, { ...own, fallback, note: [
+            '[Working directory recovery]',
+            `The filesystem for ${JSON.stringify(workingDir)} is unavailable or has changed. Cindy is using ${JSON.stringify(fallback)} as a temporary conversation workspace.`,
+            'The original directory and files have not been restored or copied. Do not create a substitute directory at the original mount location. Files written here stay here when the disk reconnects; do not move them or switch back without discussing it with the user.',
+            'Continue responding. If the task needs the original files, investigate the disconnected disk or network share, or ask the user in this conversation. No folder-selection interface is required.',
+          ].join('\n') });
+          return true;
+        }
         // A stale probe must not mistake a file, permission error, or a directory
         // restored by someone else for a missing directory.
         try {
@@ -28,6 +108,7 @@ export function createWorkingDirectoryRecovery(io: {
         } catch (error) {
           if ((error as NodeJS.ErrnoException).code !== 'ENOENT') return false;
         }
+        const similar = typeof similarPath === 'function' ? await similarPath() : similarPath;
         await io.mkdir(workingDir, { recursive: true });
         const canonical = await io.realpath?.(workingDir).catch(() => null);
         // Cleanup may have removed this entry while filesystem IO was pending.
@@ -36,8 +117,8 @@ export function createWorkingDirectoryRecovery(io: {
           '[Working directory recovery]',
           `The working directory was missing. Cindy recreated the directory at ${JSON.stringify(workingDir)} so this conversation can continue.`,
           'Only the directory was recreated; its previous files have not been recovered. Do not assume the original project contents are available.',
-          ...(similarPath ? [
-            `A similarly named filesystem entry exists at ${JSON.stringify(similarPath)} (possibly differing only in whitespace or case). Inspect this candidate before reading or creating project files in the recreated directory. It may contain the original project; verify its identity or ask the user before treating it as their workspace.`,
+          ...(similar ? [
+            `A similarly named filesystem entry exists at ${JSON.stringify(similar)} (possibly differing only in whitespace or case). Inspect this candidate before reading or creating project files in the recreated directory. It may contain the original project; verify its identity or ask the user before treating it as their workspace.`,
           ] : []),
           'Continue responding to the user. If their task needs the missing files, investigate the location or recovery options, or ask the user through the conversation. Do not require a folder-selection interface just to continue chatting.',
         ].join('\n');
@@ -45,7 +126,7 @@ export function createWorkingDirectoryRecovery(io: {
           const matches = path.resolve(dir) === path.resolve(workingDir) ||
             (canonical != null && await io.realpath?.(dir).catch(() => null) === canonical);
           if (matches && pending.get(id) === entry) {
-            pending.set(id, { workingDir: path.resolve(dir), note });
+            pending.set(id, { ...entry, workingDir: path.resolve(dir), note });
           }
         }));
         return true;
@@ -54,15 +135,12 @@ export function createWorkingDirectoryRecovery(io: {
       }
     },
     peek(sessionId: string, workingDir?: string): string | null {
-      const entry = pending.get(sessionId);
-      if (entry && workingDir !== undefined && entry.workingDir !== path.resolve(workingDir)) {
-        pending.delete(sessionId);
-        return null;
-      }
+      const entry = workingDir === undefined ? pending.get(sessionId) : entryFor(sessionId, workingDir);
       return entry?.note ?? null;
     },
     consume(sessionId: string, expectedNote: string): void {
-      if (pending.get(sessionId)?.note === expectedNote) pending.delete(sessionId);
+      const entry = pending.get(sessionId);
+      if (entry?.note === expectedNote) pending.set(sessionId, { ...entry, note: null });
     },
     discard(sessionId: string): void {
       pending.delete(sessionId);

--- a/apps/desktop/src/main/maker-ipc/workingDirectoryRecovery.ts
+++ b/apps/desktop/src/main/maker-ipc/workingDirectoryRecovery.ts
@@ -64,6 +64,9 @@ export function createWorkingDirectoryRecovery(io: {
     resolve(sessionId: string, workingDir: string): string {
       return entryFor(sessionId, workingDir)?.fallback ?? workingDir;
     },
+    isFallback(sessionId: string, workingDir: string): boolean {
+      return !!entryFor(sessionId, workingDir)?.fallback;
+    },
     async recover(sessionId: string, workingDir: string, similarPath?: string | null | (() => Promise<string | null>), candidates: { id: string; workingDir: string }[] = []): Promise<boolean> {
       entryFor(sessionId, workingDir);
       const sessions = new Map(candidates.map((session) => [session.id, session.workingDir]));
@@ -75,8 +78,20 @@ export function createWorkingDirectoryRecovery(io: {
         pending.set(id, entry);
         return { id, dir, entry };
       });
+      const own = entryFor(sessionId, workingDir);
+      const useFallback = async (): Promise<boolean> => {
+        if (!own || !allocateFallback || pending.get(sessionId) !== own) return false;
+        const fallback = path.resolve(await allocateFallback(sessionId));
+        if (pending.get(sessionId) !== own) return false;
+        pending.set(sessionId, { ...own, fallback, note: [
+          '[Working directory recovery]',
+          `The filesystem for ${JSON.stringify(workingDir)} is unavailable or has changed. Cindy is using ${JSON.stringify(fallback)} as a temporary conversation workspace.`,
+          'The original directory and files have not been restored or copied. Do not create a substitute directory at the original mount location. Files written here stay here when the disk reconnects; do not move them or switch back without discussing it with the user.',
+          'Continue responding. If the task needs the original files, investigate the disconnected disk or network share, or ask the user in this conversation. No folder-selection interface is required.',
+        ].join('\n') });
+        return true;
+      };
       try {
-        const own = entryFor(sessionId, workingDir);
         if (own?.fallback) {
           try { return (await io.stat(own.fallback)).isDirectory(); } catch (error) {
             if ((error as NodeJS.ErrnoException).code !== 'ENOENT') return false;
@@ -90,15 +105,7 @@ export function createWorkingDirectoryRecovery(io: {
           return true;
         }
         if (own && allocateFallback && await mountUnavailable(workingDir, own)) {
-          const fallback = path.resolve(await allocateFallback(sessionId));
-          if (pending.get(sessionId) !== own) return false;
-          pending.set(sessionId, { ...own, fallback, note: [
-            '[Working directory recovery]',
-            `The filesystem for ${JSON.stringify(workingDir)} is unavailable or has changed. Cindy is using ${JSON.stringify(fallback)} as a temporary conversation workspace.`,
-            'The original directory and files have not been restored or copied. Do not create a substitute directory at the original mount location. Files written here stay here when the disk reconnects; do not move them or switch back without discussing it with the user.',
-            'Continue responding. If the task needs the original files, investigate the disconnected disk or network share, or ask the user in this conversation. No folder-selection interface is required.',
-          ].join('\n') });
-          return true;
+          return await useFallback();
         }
         // A stale probe must not mistake a file, permission error, or a directory
         // restored by someone else for a missing directory.
@@ -106,7 +113,7 @@ export function createWorkingDirectoryRecovery(io: {
           const stat = await io.stat(workingDir);
           return stat.isDirectory();
         } catch (error) {
-          if ((error as NodeJS.ErrnoException).code !== 'ENOENT') return false;
+          if ((error as NodeJS.ErrnoException).code !== 'ENOENT') throw error;
         }
         const similar = typeof similarPath === 'function' ? await similarPath() : similarPath;
         await io.mkdir(workingDir, { recursive: true });
@@ -130,7 +137,12 @@ export function createWorkingDirectoryRecovery(io: {
           }
         }));
         return true;
-      } catch {
+      } catch (error) {
+        // The share may disappear after stat, including during mkdir. Reuse the
+        // same fallback transition; never retry a timed-out write on the share.
+        if (!own?.fallback && isUnavailableFilesystemError(error)) {
+          return useFallback().catch(() => false);
+        }
         return false;
       }
     },

--- a/apps/desktop/src/main/maker-ipc/workingDirectoryRecovery.ts
+++ b/apps/desktop/src/main/maker-ipc/workingDirectoryRecovery.ts
@@ -7,7 +7,7 @@ export function createWorkingDirectoryRecovery(io: {
 } = fsp) {
   const pending = new Map<string, { note: string | null }>();
   return {
-    async recover(sessionId: string, workingDir: string): Promise<boolean> {
+    async recover(sessionId: string, workingDir: string, similarPath?: string | null): Promise<boolean> {
       const entry = pending.get(sessionId) ?? { note: null };
       pending.set(sessionId, entry);
       try {
@@ -26,6 +26,9 @@ export function createWorkingDirectoryRecovery(io: {
           '[Working directory recovery]',
           `The working directory was missing. Cindy recreated the directory at ${JSON.stringify(workingDir)} so this conversation can continue.`,
           'Only the directory was recreated; its previous files have not been recovered. Do not assume the original project contents are available.',
+          ...(similarPath ? [
+            `A similarly named filesystem entry exists at ${JSON.stringify(similarPath)} (possibly differing only in whitespace or case). Inspect this candidate before reading or creating project files in the recreated directory. It may contain the original project; verify its identity or ask the user before treating it as their workspace.`,
+          ] : []),
           'Continue responding to the user. If their task needs the missing files, investigate the location or recovery options, or ask the user through the conversation. Do not require a folder-selection interface just to continue chatting.',
         ].join('\n');
         return true;

--- a/apps/desktop/src/main/workdir-probe-host/WorkdirProbeHostClient.ts
+++ b/apps/desktop/src/main/workdir-probe-host/WorkdirProbeHostClient.ts
@@ -51,6 +51,7 @@ export class WorkdirProbeClientError extends Error {
 }
 
 interface ProbeEntry {
+  kind: WorkdirProbeRequest['kind'];
   id: number;
   dir: string;
   key: string;
@@ -84,7 +85,8 @@ export class WorkdirProbeHostClient {
     this.maxQueued = deps.maxQueued ?? DEFAULT_MAX_QUEUED;
   }
 
-  probe(dir: string, key: string, timeoutMs: number): Promise<WorkdirProbeResult> {
+  probe(dir: string, key: string, timeoutMs: number, kind: WorkdirProbeRequest['kind'] = 'probe'): Promise<WorkdirProbeResult> {
+    key = `${kind}:${key}`;
     if (this.disposed) {
       return Promise.reject(
         new WorkdirProbeClientError('WORKDIR_PROBE_UNAVAILABLE', 'probe host is disposed'),
@@ -101,6 +103,7 @@ export class WorkdirProbeHostClient {
     let entry!: ProbeEntry;
     const probe = new Promise<WorkdirProbeResult>((resolve, reject) => {
       entry = {
+        kind,
         id: this.nextId++,
         dir,
         key,
@@ -221,7 +224,7 @@ export class WorkdirProbeHostClient {
     entry.probeTimer.unref?.();
 
     const request: WorkdirProbeRequest = {
-      kind: 'probe',
+      kind: entry.kind,
       id: entry.id,
       dir: entry.dir,
     };

--- a/apps/desktop/src/main/workdir-probe-host/__tests__/WorkdirProbeHostClient.test.ts
+++ b/apps/desktop/src/main/workdir-probe-host/__tests__/WorkdirProbeHostClient.test.ts
@@ -47,6 +47,25 @@ afterEach(() => {
 });
 
 describe('WorkdirProbeHostClient', () => {
+  it.each(['mkdir', 'realpath', 'similar'] as const)('isolates %s from stat and ignores its late timeout response', async (kind) => {
+    vi.useFakeTimers();
+    const { client, children } = createHarness({ maxWorkers: 1 });
+    const operation = client.probe('/share/a', '/share/a', 50, kind);
+    const failure = operation.catch((error) => error);
+    const stat = client.probe('/share/a', '/share/a', 150);
+    expect(children[0].posted[0].kind).toBe(kind);
+    await vi.advanceTimersByTimeAsync(50);
+    await expect(failure).resolves.toMatchObject({ code: 'WORKDIR_PROBE_TIMEOUT' });
+    expect(children[0].kill).toHaveBeenCalledOnce();
+    children[0].respond();
+    expect(children).toHaveLength(1);
+    children[0].emit('exit', 0);
+    expect(children[1].posted[0].kind).toBe('probe');
+    children[1].respond();
+    await expect(stat).resolves.toEqual({ ok: true, isDirectory: true });
+    client.dispose();
+  });
+
   it('single-flights equivalent paths', async () => {
     const { client, children } = createHarness();
 

--- a/apps/desktop/src/main/workdir-probe-host/__tests__/directoryOperations.test.ts
+++ b/apps/desktop/src/main/workdir-probe-host/__tests__/directoryOperations.test.ts
@@ -1,0 +1,22 @@
+import fsp from 'node:fs/promises';
+import os from 'node:os';
+import path from 'node:path';
+import { expect, it } from 'vitest';
+import { runDirectoryOperation } from '../workdirProbeHostProcess.js';
+
+it('creates only directories, resolves aliases and retains similar-path diagnostics inside the worker', async () => {
+  const root = await fsp.mkdtemp(path.join(os.tmpdir(), 'cindy-directory-worker-'));
+  try {
+    const dir = path.join(root, 'nested', 'project');
+    expect(await runDirectoryOperation({ kind: 'mkdir', id: 1, dir })).toEqual({ ok: true, isDirectory: true });
+    expect(await runDirectoryOperation({ kind: 'realpath', id: 2, dir })).toMatchObject({ ok: true, path: await fsp.realpath(dir) });
+    expect(await runDirectoryOperation({ kind: 'probe', id: 3, dir })).toMatchObject({ ok: true, isDirectory: true });
+    expect(await runDirectoryOperation({ kind: 'similar', id: 4, dir: `${dir} ` })).toMatchObject({ ok: true, path: dir });
+    const file = path.join(root, 'file');
+    await fsp.writeFile(file, 'keep');
+    expect(await runDirectoryOperation({ kind: 'mkdir', id: 5, dir: file })).toMatchObject({ ok: false, code: 'EEXIST' });
+    expect(await fsp.readFile(file, 'utf8')).toBe('keep');
+  } finally {
+    await fsp.rm(root, { recursive: true, force: true });
+  }
+});

--- a/apps/desktop/src/main/workdir-probe-host/index.ts
+++ b/apps/desktop/src/main/workdir-probe-host/index.ts
@@ -39,6 +39,13 @@ export const workdirProbeHostClient = new WorkdirProbeHostClient({
   log,
 });
 
+/** Bounded filesystem identity probe for local cwd recovery; never expose paths to a controller. */
+export async function statWorkingDirectory(dir: string): Promise<{ isDirectory(): boolean; dev?: number }> {
+  const result = await workdirProbeHostClient.probe(dir, path.resolve(dir), 5_000);
+  if (!result.ok) throw Object.assign(new Error('Working directory probe failed'), { code: result.code });
+  return { isDirectory: () => result.isDirectory, dev: result.device };
+}
+
 // 真实 Electron app 一定有 once；条件注册让引用 guard 的纯 Node 单测仍可使用
 // 只覆盖自身所需字段的窄 electron stub，而不必为未执行的生命周期补整套假实现。
 if (typeof app.once === 'function') {

--- a/apps/desktop/src/main/workdir-probe-host/index.ts
+++ b/apps/desktop/src/main/workdir-probe-host/index.ts
@@ -8,6 +8,7 @@ import { app, utilityProcess } from 'electron';
 
 import { createLogger } from '../logger.js';
 import { WorkdirProbeHostClient } from './WorkdirProbeHostClient.js';
+import type { WorkdirProbeRequest } from './protocol.js';
 
 const log = createLogger('workdir-probe-host');
 
@@ -40,10 +41,29 @@ export const workdirProbeHostClient = new WorkdirProbeHostClient({
 });
 
 /** Bounded filesystem identity probe for local cwd recovery; never expose paths to a controller. */
-export async function statWorkingDirectory(dir: string): Promise<{ isDirectory(): boolean; dev?: number }> {
-  const result = await workdirProbeHostClient.probe(dir, path.resolve(dir), 5_000);
+async function directoryOperation(dir: string, kind: WorkdirProbeRequest['kind']) {
+  const result = await workdirProbeHostClient.probe(dir, path.resolve(dir), 5_000, kind);
   if (!result.ok) throw Object.assign(new Error('Working directory probe failed'), { code: result.code });
+  return result;
+}
+
+export async function statWorkingDirectory(dir: string): Promise<{ isDirectory(): boolean; dev?: number }> {
+  const result = await directoryOperation(dir, 'probe');
   return { isDirectory: () => result.isDirectory, dev: result.device };
+}
+
+export async function mkdirWorkingDirectory(dir: string): Promise<void> {
+  await directoryOperation(dir, 'mkdir');
+}
+
+export async function realpathWorkingDirectory(dir: string): Promise<string> {
+  const result = await directoryOperation(dir, 'realpath');
+  if (typeof result.path !== 'string') throw new Error('Invalid resolved directory');
+  return result.path;
+}
+
+export async function findSimilarWorkingDirectory(dir: string): Promise<string | null> {
+  return (await directoryOperation(dir, 'similar')).path ?? null;
 }
 
 // 真实 Electron app 一定有 once；条件注册让引用 guard 的纯 Node 单测仍可使用

--- a/apps/desktop/src/main/workdir-probe-host/protocol.ts
+++ b/apps/desktop/src/main/workdir-probe-host/protocol.ts
@@ -2,18 +2,18 @@
  * workdir probe host wire format.
  *
  * The utility process returns directory status/device identity or a stable filesystem error code.
- * It never returns the probed path or the host error message to avoid leaking
- * local filesystem details across the process boundary.
+ * Resolved paths are internal Main/utility data, never controller responses.
+ * Host error messages are not returned.
  */
 
 export interface WorkdirProbeRequest {
-  kind: 'probe';
+  kind: 'probe' | 'mkdir' | 'realpath' | 'similar';
   id: number;
   dir: string;
 }
 
 export type WorkdirProbeResult =
-  | { ok: true; isDirectory: boolean; device?: number }
+  | { ok: true; isDirectory: boolean; device?: number; path?: string | null }
   | { ok: false; code: string };
 
 export interface WorkdirProbeResponse {

--- a/apps/desktop/src/main/workdir-probe-host/protocol.ts
+++ b/apps/desktop/src/main/workdir-probe-host/protocol.ts
@@ -1,7 +1,7 @@
 /**
  * workdir probe host wire format.
  *
- * The utility process only returns a boolean or a stable filesystem error code.
+ * The utility process returns directory status/device identity or a stable filesystem error code.
  * It never returns the probed path or the host error message to avoid leaking
  * local filesystem details across the process boundary.
  */
@@ -13,7 +13,7 @@ export interface WorkdirProbeRequest {
 }
 
 export type WorkdirProbeResult =
-  | { ok: true; isDirectory: boolean }
+  | { ok: true; isDirectory: boolean; device?: number }
   | { ok: false; code: string };
 
 export interface WorkdirProbeResponse {

--- a/apps/desktop/src/main/workdir-probe-host/workdirProbeHostProcess.ts
+++ b/apps/desktop/src/main/workdir-probe-host/workdirProbeHostProcess.ts
@@ -6,7 +6,8 @@
  * uncancellable libuv work in Electron's main process.
  */
 
-import { stat } from 'node:fs/promises';
+import { stat, mkdir, realpath, readdir } from 'node:fs/promises';
+import path from 'node:path';
 
 import type {
   WorkdirProbeRequest,
@@ -27,22 +28,43 @@ function filesystemErrorCode(error: unknown): string {
     : 'UNKNOWN';
 }
 
+export async function runDirectoryOperation(request: WorkdirProbeRequest): Promise<WorkdirProbeResult> {
+  try {
+    if (request.kind === 'mkdir') {
+      await mkdir(request.dir, { recursive: true });
+      return { ok: true, isDirectory: true };
+    }
+    if (request.kind === 'realpath') {
+      return { ok: true, isDirectory: true, path: await realpath(request.dir) };
+    }
+    if (request.kind === 'similar') {
+      const parent = path.dirname(request.dir);
+      const target = path.basename(request.dir);
+      if (!target || parent === request.dir) return { ok: true, isDirectory: false, path: null };
+      const entries = await readdir(parent);
+      const match = entries.find((n) => n !== target && n.trim() === target.trim()) ??
+        entries.find((n) => n !== target && n.toLowerCase() === target.toLowerCase());
+      return { ok: true, isDirectory: false, path: match ? path.join(parent, match) : null };
+    }
+    const entry = await stat(request.dir);
+    return { ok: true, isDirectory: entry.isDirectory(), device: entry.dev };
+  } catch (error) {
+    return { ok: false, code: filesystemErrorCode(error) };
+  }
+}
+
 if (parentPort) {
   parentPort.on('message', (event) => {
     const request = event.data as Partial<WorkdirProbeRequest>;
     if (
-      request.kind !== 'probe' ||
+      !['probe', 'mkdir', 'realpath', 'similar'].includes(request.kind ?? '') ||
       typeof request.id !== 'number' ||
       typeof request.dir !== 'string' ||
       request.dir.length === 0
     ) {
       return;
     }
-    void stat(request.dir)
-      .then<WorkdirProbeResult, WorkdirProbeResult>(
-        (entry) => ({ ok: true, isDirectory: entry.isDirectory(), device: entry.dev }),
-        (error) => ({ ok: false, code: filesystemErrorCode(error) }),
-      )
+    void runDirectoryOperation(request as WorkdirProbeRequest)
       .then((result) => {
         const response: WorkdirProbeResponse = {
           kind: 'result',

--- a/apps/desktop/src/main/workdir-probe-host/workdirProbeHostProcess.ts
+++ b/apps/desktop/src/main/workdir-probe-host/workdirProbeHostProcess.ts
@@ -40,7 +40,7 @@ if (parentPort) {
     }
     void stat(request.dir)
       .then<WorkdirProbeResult, WorkdirProbeResult>(
-        (entry) => ({ ok: true, isDirectory: entry.isDirectory() }),
+        (entry) => ({ ok: true, isDirectory: entry.isDirectory(), device: entry.dev }),
         (error) => ({ ok: false, code: filesystemErrorCode(error) }),
       )
       .then((result) => {

--- a/packages/maker-core/src/maker.test.ts
+++ b/packages/maker-core/src/maker.test.ts
@@ -471,6 +471,17 @@ describe('Maker local Pi package generation fence', () => {
 });
 
 describe('Maker session creation singleflight', () => {
+  it('reports the effective runtime cwd when recovering an existing task elsewhere', async () => {
+    const storage = createStorage();
+    await storage.create({ id: 'recovered-cwd', agentKind: 'codex', workDir: '/original', title: 'Existing task', model: 'test-model' });
+    const startSession = vi.fn(async () => createHandle({ id: 'recovered-native' }));
+    const maker = new Maker({ agents: { codex: createAgent(startSession) }, storage, logger: createLogger() });
+    const session = await maker.createSession({ id: 'recovered-cwd', agentKind: 'codex', workingDir: '/conversation', model: 'test-model' });
+    expect(startSession).toHaveBeenCalledWith(expect.objectContaining({ workingDir: '/conversation' }));
+    expect(session.workDir).toBe('/conversation');
+    expect((await storage.get('recovered-cwd'))?.workDir).toBe('/original');
+  });
+
   it('binds each rebuilt business session to a fresh runtime instance id', async () => {
     const seenInstanceIds: string[] = [];
     const startSession = vi.fn(async (opts: CreateSessionOptions) => {

--- a/packages/maker-core/src/maker.test.ts
+++ b/packages/maker-core/src/maker.test.ts
@@ -524,13 +524,16 @@ describe('Maker session creation singleflight', () => {
       resumeSessionId: 'thread-1',
     };
 
-    const first = maker.createSession(options);
-    const second = maker.createSession({ ...options });
+    const first = maker.createSession({ ...options, hostUserPrompt: 'Original caller prompt' });
+    const second = maker.createSession({ ...options, hostUserPrompt: 'Unused caller prompt' });
 
     expect(startSession).toHaveBeenCalledTimes(1);
     resolveStart(createHandle({ id: 'thread-1' }));
     const [firstSession, secondSession] = await Promise.all([first, second]);
 
+    expect(firstSession.hostUserPrompt).toBe('Original caller prompt');
+    const existingSession = await maker.createSession({ ...options, hostUserPrompt: undefined });
+    expect(existingSession.hostUserPrompt).toBe('Original caller prompt');
     expect(secondSession).toBe(firstSession);
     expect(maker.listActiveSessions()).toEqual([firstSession]);
     expect(created).toHaveBeenCalledTimes(1);

--- a/packages/maker-core/src/maker.test.ts
+++ b/packages/maker-core/src/maker.test.ts
@@ -524,16 +524,18 @@ describe('Maker session creation singleflight', () => {
       resumeSessionId: 'thread-1',
     };
 
-    const first = maker.createSession({ ...options, hostUserPrompt: 'Original caller prompt' });
-    const second = maker.createSession({ ...options, hostUserPrompt: 'Unused caller prompt' });
+    const preferences = { userPrompt: 'Original caller prompt', makerMemoryEnabled: true };
+    const first = maker.createSession({ ...options, hostStartupPreferences: preferences });
+    const second = maker.createSession({ ...options, hostStartupPreferences: { makerMemoryEnabled: false } });
 
     expect(startSession).toHaveBeenCalledTimes(1);
     resolveStart(createHandle({ id: 'thread-1' }));
     const [firstSession, secondSession] = await Promise.all([first, second]);
 
-    expect(firstSession.hostUserPrompt).toBe('Original caller prompt');
-    const existingSession = await maker.createSession({ ...options, hostUserPrompt: undefined });
-    expect(existingSession.hostUserPrompt).toBe('Original caller prompt');
+    expect(firstSession.hostStartupPreferences).toEqual(preferences);
+    preferences.makerMemoryEnabled = false;
+    const existingSession = await maker.createSession(options);
+    expect(existingSession.hostStartupPreferences).toMatchObject({ userPrompt: 'Original caller prompt', makerMemoryEnabled: true });
     expect(secondSession).toBe(firstSession);
     expect(maker.listActiveSessions()).toEqual([firstSession]);
     expect(created).toHaveBeenCalledTimes(1);

--- a/packages/maker-core/src/maker.ts
+++ b/packages/maker-core/src/maker.ts
@@ -37,7 +37,7 @@ import type {
 import type { PiRuntimeCapabilityManifest } from './types/pi-runtime-capabilities.js';
 import { piExplicitSkillRuntimePath } from './agents/pi/skill-runtime-provenance.js';
 import { fingerprintPiProjectSkillEntrypoint } from './agents/pi/project-resource-assembly.js';
-import { Session, generateSessionId } from './session.js';
+import { Session, generateSessionId, type SessionStartupPreferences } from './session.js';
 import type {
   AgentSessionHandle,
   AgentSessionTeardownOptions,
@@ -130,8 +130,8 @@ export interface MakerDeps {
 }
 
 export interface CreateSessionOptions extends StartSessionOptions {
-  /** Host prompt before generated context; retained only by the live Session. */
-  hostUserPrompt?: string;
+  /** Host caller preferences before generated context; retained only by the live Session. */
+  hostStartupPreferences?: SessionStartupPreferences;
   agentKind: AgentKind;
   /** 可选：UI 显示用 */
   title?: string;
@@ -916,7 +916,7 @@ export class Maker {
       agentKind: meta.agentKind,
       workDir: meta.workDir,
       handle,
-      hostUserPrompt: opts.hostUserPrompt,
+      hostStartupPreferences: opts.hostStartupPreferences,
       capabilities: capabilitiesForSession(meta.agentKind, agent.capabilities, meta.remoteHostId),
       logger: this.logger,
       permissionMode: startOpts.permissionMode,

--- a/packages/maker-core/src/maker.ts
+++ b/packages/maker-core/src/maker.ts
@@ -914,7 +914,7 @@ export class Maker {
       id: meta.id,
       sessionInstanceId,
       agentKind: meta.agentKind,
-      workDir: meta.workDir,
+      workDir: startOpts.workingDir,
       handle,
       hostStartupPreferences: opts.hostStartupPreferences,
       capabilities: capabilitiesForSession(meta.agentKind, agent.capabilities, meta.remoteHostId),

--- a/packages/maker-core/src/maker.ts
+++ b/packages/maker-core/src/maker.ts
@@ -130,6 +130,8 @@ export interface MakerDeps {
 }
 
 export interface CreateSessionOptions extends StartSessionOptions {
+  /** Host prompt before generated context; retained only by the live Session. */
+  hostUserPrompt?: string;
   agentKind: AgentKind;
   /** 可选：UI 显示用 */
   title?: string;
@@ -914,6 +916,7 @@ export class Maker {
       agentKind: meta.agentKind,
       workDir: meta.workDir,
       handle,
+      hostUserPrompt: opts.hostUserPrompt,
       capabilities: capabilitiesForSession(meta.agentKind, agent.capabilities, meta.remoteHostId),
       logger: this.logger,
       permissionMode: startOpts.permissionMode,

--- a/packages/maker-core/src/session.ts
+++ b/packages/maker-core/src/session.ts
@@ -53,6 +53,7 @@ import type {
   AgentSessionTeardownOptions,
   BackgroundTaskSnapshot,
   SendOptions,
+  StartSessionOptions,
   TurnContinuationState,
 } from './agents/base-agent.js';
 import {
@@ -143,8 +144,12 @@ function parseTurnStallMs(raw: string | undefined): number {
   return Math.floor(n);
 }
 
+/** Launch-only caller preferences. Live controls and grants have separate authorities. */
+export type SessionStartupPreferences = Readonly<Pick<StartSessionOptions,
+  'userPrompt' | 'makerMemoryEnabled' | 'displayReasoning'>>;
+
 export interface SessionOptions {
-  hostUserPrompt?: string;
+  hostStartupPreferences?: SessionStartupPreferences;
   id: string;
   /** 与 Agent MCP context 同源的本次内存实例代号；省略时由 Session 自铸。 */
   sessionInstanceId?: string;
@@ -390,8 +395,8 @@ function createSendReservation(generation: number): SendReservation {
 }
 
 export class Session {
-  /** Host caller prompt before generated project/Orca context; memory-only recovery input. */
-  readonly hostUserPrompt?: string;
+  /** Caller preferences before generated context; memory-only recovery input. */
+  readonly hostStartupPreferences?: SessionStartupPreferences;
   readonly id: string;
   /** business id 可复用；instanceId 精确标识本次内存 Session incarnation。 */
   readonly instanceId: string;
@@ -519,7 +524,8 @@ export class Session {
   private turnControlState: TurnControlState | null = null;
 
   constructor(opts: SessionOptions) {
-    this.hostUserPrompt = opts.hostUserPrompt;
+    this.hostStartupPreferences = opts.hostStartupPreferences
+      ? Object.freeze({ ...opts.hostStartupPreferences }) : undefined;
     this.id = opts.id;
     this.instanceId = opts.sessionInstanceId ?? generateSessionId();
     this.agentKind = opts.agentKind;

--- a/packages/maker-core/src/session.ts
+++ b/packages/maker-core/src/session.ts
@@ -144,6 +144,7 @@ function parseTurnStallMs(raw: string | undefined): number {
 }
 
 export interface SessionOptions {
+  hostUserPrompt?: string;
   id: string;
   /** 与 Agent MCP context 同源的本次内存实例代号；省略时由 Session 自铸。 */
   sessionInstanceId?: string;
@@ -389,6 +390,8 @@ function createSendReservation(generation: number): SendReservation {
 }
 
 export class Session {
+  /** Host caller prompt before generated project/Orca context; memory-only recovery input. */
+  readonly hostUserPrompt?: string;
   readonly id: string;
   /** business id 可复用；instanceId 精确标识本次内存 Session incarnation。 */
   readonly instanceId: string;
@@ -516,6 +519,7 @@ export class Session {
   private turnControlState: TurnControlState | null = null;
 
   constructor(opts: SessionOptions) {
+    this.hostUserPrompt = opts.hostUserPrompt;
     this.id = opts.id;
     this.instanceId = opts.sessionInstanceId ?? generateSessionId();
     this.agentKind = opts.agentKind;


### PR DESCRIPTION
## 这次改了什么

### 摘要

普通本地工作目录被删除后，发送消息会被 `WORKDIR_MISSING` 拦住。现在在原位置重建缺失目录，让原任务继续接收消息，无需先选择文件夹。发给 AI 的消息会附带一次环境说明：仅重建了目录，原文件尚未恢复；是否查找文件、恢复项目或询问用户由 AI 根据当前请求决定。

同时补齐存活任务的旧目录兜底：数据库已保存有效的新目录时，按该目录恢复原生会话，保留原生历史后再发送。

同路径重建后，Claude Code / Pi 也沿现有恢复路径刷新原生进程，避免继续使用指向已删除目录的 cwd。发现相似名称的路径时，把候选位置交给 AI 核实，不自动切换项目。

检测到文件系统不可用或已观测的设备身份改变时，使用 Cindy 现有对话工作目录继续交流，不在断开的挂载点下创建替身目录。AI 收到原目录、临时工作位置及文件未恢复的说明；磁盘重连后不自动切回或迁移产物。该例外已获需求方确认。

恢复时保留调用方原始 userPrompt、Maker Memory 与 reasoning 显示偏好，项目/Orca 内容仍由原启动流程生成。关闭旧实例前复用 Bot 资源预检，实际启动继续统一装配 Bot 身份与资源。Pi 的 slash 输入保留在开头，由 Pi 决定是否执行；恢复说明留给后续普通消息。

### 变更类型

- [ ] `feat` 新功能
- [x] `fix` 缺陷修复
- [ ] `refactor` / `perf` 重构或性能优化
- [ ] `docs` / `test` / `chore` 文档、测试或工程维护
- [ ] 其他：

### 范围

- 关联 Issue / 需求：工作目录缺失不应阻断对话，恢复操作由 AI 与用户在对话中处理。
- 本 PR 包含：普通目录原址重建、不可用文件系统的对话目录兜底、旧目录的 DB 兜底、发给 AI 的恢复说明及回归测试。
- 明确不包含：恢复已删除文件、SSH 远端目录重建、新增目录选择界面、改变托管 Git worktree 的快照恢复规则。
- 用户可见变化：普通本地目录缺失且可重建时，消息直接继续发送；聊天中的用户原文不变。
- 是否存在 breaking change：无。

### UI 变化

不涉及。

- 引用的设计规范：不涉及，无 Renderer、组件或本地化文案改动。

## 怎么验证的

### 自动验证

```text
env -u VITE_CINDY_AUTH_REGION -u NODE_ENV -u NODE_DEBUG pnpm test:unit:related
结果：通过，覆盖 Desktop、maker-core related、lizi-mcps 与 orca-workflow；包括设备消失/替身目录、同卷目录删除、不可用错误/超时、fallback 清理与重建、三种引擎恢复发送，以及真实 Maker 的有效 cwd。

pnpm --filter desktop run --if-present typecheck
结果：通过。

pnpm --filter @cindy/maker-core run --if-present typecheck
结果：正常退出；该包未定义独立 typecheck script。

git diff --check
结果：通过。
```

### 手工验证

未运行客户端手工交互。

### 未执行的验证

未运行 macOS/Windows 客户端实机端到端验证、手机或 SSH 实机验证；本次为后端恢复改动，使用文件系统与发送事务测试验证。完整单测由 CI 执行。

## 风险

### 风险分类

- [ ] 无已知风险
- [ ] SQLite / migration
- [ ] system prompt
- [ ] 协议兼容
- [x] 权限 / 安全 / 用户数据
- [ ] 存量插件兼容（批准状态 / 指纹 / manifest 校验 / 安装布局 / 包格式）
- [ ] 原生层 / fingerprint / OTA
- [x] 跨平台差异
- [x] 其他：恢复说明暂存在进程内存中。

### 影响与回滚

- 仅在确认 `ENOENT` 后原址重建普通目录，不覆盖已存在的文件；权限错误、非目录路径和托管 Git worktree 恢复失败仍保留原处理。
- 初始及恢复探测、mkdir、realpath、相似目录读取复用既有有界 utility-process 池，单次操作上限 5 秒；mkdir 超时或挂载不可用时沿同一个 fallback 继续，不重试原址写入。超时前可能已创建部分父目录，不承诺文件系统回滚。支持不可用 I/O/网络错误、缺失的 Windows drive/share root、macOS /Volumes 根及已观测的文件系统设备变化。文件系统身份在 bootstrap 与成功探测时记录到现有内存条目，不新增落盘记录。**识别限制**：进程启动前已断开的任意自定义挂载点（包括隐藏在悬空符号链接后的挂载）、同设备 bind mount，无法只凭 ENOENT 与设备号可靠识别；不声称完整覆盖这些情况。
- fallback bootstrap 用有界探测过滤运行时目录授权，但不将临时不可用造成的子集写回持久授权。可写授权仍以 SQLite 为准，路径解析无法确认时保守排除可写根；正常 bootstrap 仍保留原有持久收窄规则。内部 Main–utility 消息不向 Renderer/Device Link 开放文件操作。
- 临时工作位置复用 owner-scoped dialogue workspace，避免系统 temp 回收导致新产物丢失；未自动删除或迁移其中生成的文件。运行实例报告实际启动 cwd，原 DB 项目目录保持不变。目录路由与说明仅在进程内存中保留；显式切换/清空/归档/删除/切账号沿既有清理，发送成功仅消费说明，不使运行实例切回原目录。
- 恢复说明只进入模型消息，不修改系统提示词或用户显示内容；发送被接受后才消费，未接受则保留供重试。应用在发送成功前退出会丢失这条尚未发送的说明，此限制已与需求方确认。
- DB 目录兜底在关闭旧运行实例前核对原生恢复信息，避免用新会话替代历史；验证失败不会提前关闭旧实例。
- 启动偏好仅由当前 Session 持有不可变副本，替代原 userPrompt 单字段；恢复只补充发送参数缺省的启动偏好。权限、目录授权、plan/thinking 等可变控制继续从当前权威状态读取，不缓存整份历史启动参数。Bot 资源预检失败发生在关闭旧实例前，重试仍走同一入口，无新增缓存、持久化或重试机制。
- Claude Code / Pi 的同路径恢复复用待发送说明作为刷新依据；说明在 /compact 或拒绝发送后仍保留，因此下一次发送可能再次刷新运行时。没有新增持久状态或重试机制。
- 同一目录的其他存活本地任务也保留恢复说明，重建后用 realpath 识别别名，各自在下次发送时刷新 Claude Code / Pi 运行时，不中断其他任务正在执行的消息。说明绑定各任务自身的目录路径，切换目录后丢弃；每个任务独立消费或清理。Device Link / 手机由执行端共用发送事务受益；SSH 不使用本机文件系统重建远端目录。
- 回滚 / 降级方式：回退本 PR，恢复原目录缺失错误处理。已重建目录不自动删除。
- 存量插件影响：无。
- 远程适配：SSH 保持远端路径规则；Device Link/手机复用被控端发送事务，无新界面或对外 IPC。恢复只影响当前任务的原生实例，不重连 relay、不影响其他控制端链路；因此不涉及连接级多 peer 恢复。

### 提交前检查

- [x] 已 review 完整 diff
- [x] 每个 commit 都带 DCO 签名（`git commit -s`，见 [DCO](../DCO)）
- [x] UI 改动已在「UI 变化」注明引用的设计规范章节（不涉及 UI 则跳过）
- [x] 未提交凭证、令牌或授权文件
- [x] 已补充必要文档（行为、边界及回滚说明见本 PR）
- [x] 已确认测试结果或说明未执行原因
