### PR TITLE
fix(mobile): 自动恢复连接时显示加载动画

### DIFF
--- a/apps/mobile/src/components/ConnectionBanner.tsx
+++ b/apps/mobile/src/components/ConnectionBanner.tsx
@@ -1,6 +1,8 @@
 import { useEffect, useState } from 'react';
 import { ActivityIndicator, StyleSheet, View } from 'react-native';
 import { useTranslation } from 'react-i18next';
+import { LoaderCircle } from 'lucide-react-native';
+import { useReduceMotionEnabled } from '@/hooks/useReduceMotion';
 import { Text } from '@/components/AppText';
 import type { DeviceLinkConnectionIssue, DeviceLinkStatus } from '@cindy/device-link';
 import {
@@ -93,6 +95,7 @@ export function ConnectionBanner({
 }) {
   const styles = useThemedStyles(makeStyles);
   const { colors } = useTheme();
+  const reduceMotion = useReduceMotionEnabled();
   const { t } = useTranslation();
   // 链路已 online 说明普通 issue 已过期;unstable 描述跨连接抖动,online 时仍展示。
   // issue 优先于请求级 error:链路断因明确时,invoke 失败都是它的下游症状(NOT_CONNECTED)。
@@ -168,19 +171,26 @@ export function ConnectionBanner({
           </Text>
         ) : null}
       </View>
-      {showRecoveryProgress ? (
+      {showSyncAction ? (
+        <ConnectionSyncButton
+          compact={compact}
+          loading={loading}
+          onPress={onSync}
+          testID="connection.syncButton"
+        />
+      ) : showRecoveryProgress ? reduceMotion === false ? (
         <ActivityIndicator
           accessibilityLabel={`${title} · ${copy}`}
           color={colors.textSecondary}
           size="small"
           testID="connection.recoveryProgress"
         />
-      ) : showSyncAction ? (
-        <ConnectionSyncButton
-          compact={compact}
-          loading={loading}
-          onPress={onSync}
-          testID="connection.syncButton"
+      ) : (
+        <LoaderCircle
+          accessibilityLabel={`${title} · ${copy}`}
+          color={colors.textSecondary}
+          size={20}
+          testID="connection.recoveryProgressStatic"
         />
       ) : null}
     </View>

--- a/apps/mobile/src/components/ConnectionBanner.tsx
+++ b/apps/mobile/src/components/ConnectionBanner.tsx
@@ -20,7 +20,7 @@ import {
   resolveEffectiveConnectionError,
 } from '@/components/connectionBannerVisibility';
 import { fontWeight, useTheme, useThemedStyles, type ThemeColors } from '@/theme';
-import { lineHeight, radius, spacing, typeScale } from '@/theme/tokens';
+import { iconSize, lineHeight, radius, spacing, typeScale } from '@/theme/tokens';
 
 /** 普通断线(无分类 issue)转为可见提示前的静默窗口:健康重连通常 <1s 完成,不闪 banner。 */
 const OFFLINE_BANNER_DELAY_MS = 1_200;
@@ -109,7 +109,7 @@ export function ConnectionBanner({
   const friendlyError = activeIssue || showUnresponsive ? null : describeRemoteError(effectiveError);
   const autoRecoveringRequest = requestErrorAutoRecovering ?? isAutoRecoveringRemoteError(effectiveError);
   const showRecoveryProgress = (!activeIssue || activeIssue.kind === 'unstable' || activeIssue.kind === 'replaced')
-    && (status === 'connecting' || showUnresponsive || recovery === 'syncing'
+    && (status === 'connecting' || deviceUnresponsive || recovery === 'syncing'
       || (friendlyError !== null && autoRecoveringRequest));
   const showSyncAction = resolveConnectionBannerSyncActionVisibility({
     online: status === 'online',
@@ -189,7 +189,7 @@ export function ConnectionBanner({
         <LoaderCircle
           accessibilityLabel={`${title} · ${copy}`}
           color={colors.textSecondary}
-          size={20}
+          size={iconSize.action}
           testID="connection.recoveryProgressStatic"
         />
       ) : null}

--- a/apps/mobile/src/components/ConnectionBanner.tsx
+++ b/apps/mobile/src/components/ConnectionBanner.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useState } from 'react';
-import { StyleSheet, View } from 'react-native';
+import { ActivityIndicator, StyleSheet, View } from 'react-native';
 import { useTranslation } from 'react-i18next';
 import { Text } from '@/components/AppText';
 import type { DeviceLinkConnectionIssue, DeviceLinkStatus } from '@cindy/device-link';
@@ -17,7 +17,7 @@ import {
   resolveConnectionBannerVisibility,
   resolveEffectiveConnectionError,
 } from '@/components/connectionBannerVisibility';
-import { fontWeight, useThemedStyles, type ThemeColors } from '@/theme';
+import { fontWeight, useTheme, useThemedStyles, type ThemeColors } from '@/theme';
 import { lineHeight, radius, spacing, typeScale } from '@/theme/tokens';
 
 /** 普通断线(无分类 issue)转为可见提示前的静默窗口:健康重连通常 <1s 完成,不闪 banner。 */
@@ -92,6 +92,7 @@ export function ConnectionBanner({
   recovery?: 'syncing' | 'recovered';
 }) {
   const styles = useThemedStyles(makeStyles);
+  const { colors } = useTheme();
   const { t } = useTranslation();
   // 链路已 online 说明普通 issue 已过期;unstable 描述跨连接抖动,online 时仍展示。
   // issue 优先于请求级 error:链路断因明确时,invoke 失败都是它的下游症状(NOT_CONNECTED)。
@@ -103,12 +104,16 @@ export function ConnectionBanner({
   // useShowConnectionBanner 同一判定,否则会出现可见但无内容的空壳 banner)。
   const effectiveError = resolveEffectiveConnectionError(error, deviceUnresponsive);
   const friendlyError = activeIssue || showUnresponsive ? null : describeRemoteError(effectiveError);
+  const autoRecoveringRequest = requestErrorAutoRecovering ?? isAutoRecoveringRemoteError(effectiveError);
+  const showRecoveryProgress = (!activeIssue || activeIssue.kind === 'unstable' || activeIssue.kind === 'replaced')
+    && (status === 'connecting' || showUnresponsive || recovery === 'syncing'
+      || (friendlyError !== null && autoRecoveringRequest));
   const showSyncAction = resolveConnectionBannerSyncActionVisibility({
     online: status === 'online',
     hasActiveIssue: activeIssue !== null,
     deviceUnresponsive: showUnresponsive,
     hasRequestError: friendlyError !== null,
-    requestErrorAutoRecovering: requestErrorAutoRecovering ?? isAutoRecoveringRemoteError(effectiveError),
+    requestErrorAutoRecovering: autoRecoveringRequest,
   });
   const tone = activeIssue
     ? 'off'
@@ -163,7 +168,14 @@ export function ConnectionBanner({
           </Text>
         ) : null}
       </View>
-      {showSyncAction ? (
+      {showRecoveryProgress ? (
+        <ActivityIndicator
+          accessibilityLabel={`${title} · ${copy}`}
+          color={colors.textSecondary}
+          size="small"
+          testID="connection.recoveryProgress"
+        />
+      ) : showSyncAction ? (
         <ConnectionSyncButton
           compact={compact}
           loading={loading}


### PR DESCRIPTION
## 这次改了什么

### 摘要

Mobile 连接横幅在自动重连、电脑未响应或自动恢复同步期间显示不可点击的小型加载动画，让用户能看出恢复仍在进行。沿用现有手动同步按钮的可见性规则；需要重新登录或升级等人工处理的连接错误不会显示持续加载。

### 变更类型

- [x] `fix` 缺陷修复

### 范围

- 关联 Issue / 需求：用户反馈自动重试时右侧图标看起来像按钮，希望改成重新连接动画。
- 本 PR 包含：ConnectionBanner 的恢复进度展示。
- 明确不包含：重连机制、网络请求、原生依赖或配置变更。
- 用户可见变化：自动恢复期间右侧显示原生 ActivityIndicator。
- 是否存在 breaking change：无。

### UI 变化

- 平台：Mobile；本次没有实机截图或录屏。
- 引用的设计规范：`docs/design-rules/DESIGN.md` §2 Color Palette & Roles、§10 Theme System & Token Reference；加载动画使用现有 `textSecondary` 语义 token，随 Light/Dark 切换，保留横幅布局与文案。

## 怎么验证的

### 自动验证

- `pnpm test:unit:related`：通过。
- `pnpm --filter mobile run --if-present typecheck`：通过。
- `pnpm --filter mobile exec vitest run src/__tests__/connectionBannerVisibility.test.ts`：12 项通过。
- `git diff --check`：通过。

### 手工验证

已 review 完整 diff，核对自动恢复、人工处理错误与手动同步入口的显示分支。

### 未执行的验证

未启动模拟器或实机，Light/Dark 均未目检；本次仅完成代码与自动检查。分支 `dash/mobile-reconnect-indicator`，worktree `cindy-mobile-reconnect-indicator`；未运行 Metro，无 Metro 归属或 __DEV__ build label 证据。

## 风险

### 风险分类

- [x] 其他：UI 动画实际尺寸和表现尚未实机验证。

### 影响与回滚

- 影响范围：Mobile 连接状态横幅；无原生配置或 fingerprint 输入变更。
- 回滚 / 降级方式：回退本提交，恢复原有横幅显示。

### 提交前检查

- [x] 已 review 完整 diff
- [x] 每个 commit 都带 DCO 签名（`git commit -s`）
- [x] UI 改动已在「UI 变化」注明引用的设计规范章节
- [x] 未提交凭证、令牌或授权文件
- [x] 已补充必要文档（本次无独立文档变更需要）
- [x] 已确认测试结果或说明未执行原因
