### PR TITLE
fix(mobile): 按历史游标继续首屏补齐

### DIFF
--- a/apps/mobile/src/__tests__/messageHistoryAutofillCallbacks.test.ts
+++ b/apps/mobile/src/__tests__/messageHistoryAutofillCallbacks.test.ts
@@ -4,15 +4,20 @@ import ts from 'typescript';
 import { describe, expect, it, vi } from 'vitest';
 import { shouldAutoLoadEarlier } from '@/session/messageScroll';
 
-// Execute the production callback so its early dedupe guard and its helper input are both tested.
+// Execute the production progress-key calculation and callback, including the early dedupe guard.
 const source = ts.createSourceFile('renderer.tsx', readFileSync(
   resolve(process.cwd(), 'src/session/MessageRenderer.tsx'), 'utf8',
 ), ts.ScriptTarget.Latest, true, ts.ScriptKind.TSX);
 let callbackSource = '';
+let progressKeySource = '';
 function visit(node: ts.Node) {
   if (ts.isVariableDeclaration(node) && node.name.getText(source) === 'attemptAutoLoadEarlier'
     && node.initializer && ts.isCallExpression(node.initializer)) {
     callbackSource = node.initializer.arguments[0].getText(source);
+  }
+  if (ts.isVariableDeclaration(node) && node.name.getText(source) === 'historyProgressKey'
+    && node.initializer) {
+    progressKeySource = node.initializer.getText(source);
   }
   ts.forEachChild(node, visit);
 }
@@ -29,7 +34,7 @@ function fixture() {
     initialHistoryAutofillRemainingRef: { current: 3 },
     regroupedHistoryContinuationRef: { current: false },
     firstItemKey: 'local-notice',
-    historyProgressKey: 'host-80',
+    loadEarlierProgressKey: 'host-80' as string | null,
     lastAutoLoadEarlierKeyRef: { current: null as string | null },
     listRef: { current: { getState: () => ({ isAtEnd: true, isAtStart: true, isNearStart: true }) } },
     loadEarlierAction: { visible: true, disabled: false },
@@ -37,8 +42,9 @@ function fixture() {
     requestLoadEarlier,
   };
   const attempt = () => {
-    if (!callbackSource) throw new Error('Missing production callback');
-    const compiled = ts.transpileModule(`const callback = ${callbackSource};`, {
+    if (!callbackSource || !progressKeySource) throw new Error('Missing production paging code');
+    const compiled = ts.transpileModule(`const historyProgressKey = ${progressKeySource};
+const callback = ${callbackSource};`, {
       compilerOptions: { target: ts.ScriptTarget.ES2022, module: ts.ModuleKind.CommonJS },
     }).outputText;
     new Function(...Object.keys(bindings), `${compiled}\nreturn callback;`)(...Object.values(bindings))();
@@ -51,13 +57,13 @@ describe('history autofill production callback', () => {
     const { bindings, attempt, requestLoadEarlier } = fixture();
     attempt();
     expect(requestLoadEarlier).toHaveBeenCalledTimes(1);
-    bindings.historyProgressKey = 'host-60';
+    bindings.loadEarlierProgressKey = 'host-60';
     attempt();
     expect(requestLoadEarlier).toHaveBeenCalledTimes(2);
-    bindings.historyProgressKey = 'host-40';
+    bindings.loadEarlierProgressKey = 'host-40';
     attempt();
     expect(requestLoadEarlier).toHaveBeenCalledTimes(3);
-    bindings.historyProgressKey = 'host-20';
+    bindings.loadEarlierProgressKey = 'host-20';
     attempt();
     expect(requestLoadEarlier).toHaveBeenCalledTimes(3);
   });
@@ -70,11 +76,22 @@ describe('history autofill production callback', () => {
     expect(requestLoadEarlier).toHaveBeenCalledTimes(1);
   });
 
+  it('falls back to the first rendered row only when no host cursor is available', () => {
+    const { bindings, attempt, requestLoadEarlier } = fixture();
+    bindings.loadEarlierProgressKey = null;
+    attempt();
+    attempt();
+    expect(requestLoadEarlier).toHaveBeenCalledTimes(1);
+    bindings.firstItemKey = 'earlier-render-item';
+    attempt();
+    expect(requestLoadEarlier).toHaveBeenCalledTimes(2);
+  });
+
   it('uses the same cursor progress for user-driven regroup continuation', () => {
     const { bindings, attempt, requestLoadEarlier } = fixture();
     bindings.userScrollForOlderRef.current = true;
     attempt();
-    bindings.historyProgressKey = 'host-60';
+    bindings.loadEarlierProgressKey = 'host-60';
     bindings.regroupedHistoryContinuationRef.current = true;
     attempt();
     expect(requestLoadEarlier).toHaveBeenCalledTimes(2);

--- a/apps/mobile/src/__tests__/messageHistoryAutofillCallbacks.test.ts
+++ b/apps/mobile/src/__tests__/messageHistoryAutofillCallbacks.test.ts
@@ -1,0 +1,83 @@
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+import ts from 'typescript';
+import { describe, expect, it, vi } from 'vitest';
+import { shouldAutoLoadEarlier } from '@/session/messageScroll';
+
+// Execute the production callback so its early dedupe guard and its helper input are both tested.
+const source = ts.createSourceFile('renderer.tsx', readFileSync(
+  resolve(process.cwd(), 'src/session/MessageRenderer.tsx'), 'utf8',
+), ts.ScriptTarget.Latest, true, ts.ScriptKind.TSX);
+let callbackSource = '';
+function visit(node: ts.Node) {
+  if (ts.isVariableDeclaration(node) && node.name.getText(source) === 'attemptAutoLoadEarlier'
+    && node.initializer && ts.isCallExpression(node.initializer)) {
+    callbackSource = node.initializer.arguments[0].getText(source);
+  }
+  ts.forEachChild(node, visit);
+}
+visit(source);
+
+function fixture() {
+  const requestLoadEarlier = vi.fn();
+  const bindings = {
+    onLoadEarlier: () => {},
+    readingOlderRef: { current: false },
+    queuedLoadEarlierRef: { current: false },
+    userScrollForOlderRef: { current: false },
+    listRevealed: true,
+    initialHistoryAutofillRemainingRef: { current: 3 },
+    regroupedHistoryContinuationRef: { current: false },
+    firstItemKey: 'local-notice',
+    historyProgressKey: 'host-80',
+    lastAutoLoadEarlierKeyRef: { current: null as string | null },
+    listRef: { current: { getState: () => ({ isAtEnd: true, isAtStart: true, isNearStart: true }) } },
+    loadEarlierAction: { visible: true, disabled: false },
+    shouldAutoLoadEarlier,
+    requestLoadEarlier,
+  };
+  const attempt = () => {
+    if (!callbackSource) throw new Error('Missing production callback');
+    const compiled = ts.transpileModule(`const callback = ${callbackSource};`, {
+      compilerOptions: { target: ts.ScriptTarget.ES2022, module: ts.ModuleKind.CommonJS },
+    }).outputText;
+    new Function(...Object.keys(bindings), `${compiled}\nreturn callback;`)(...Object.values(bindings))();
+  };
+  return { bindings, attempt, requestLoadEarlier };
+}
+
+describe('history autofill production callback', () => {
+  it('continues through host pages behind an unchanged first rendered row, within the cold-open budget', () => {
+    const { bindings, attempt, requestLoadEarlier } = fixture();
+    attempt();
+    expect(requestLoadEarlier).toHaveBeenCalledTimes(1);
+    bindings.historyProgressKey = 'host-60';
+    attempt();
+    expect(requestLoadEarlier).toHaveBeenCalledTimes(2);
+    bindings.historyProgressKey = 'host-40';
+    attempt();
+    expect(requestLoadEarlier).toHaveBeenCalledTimes(3);
+    bindings.historyProgressKey = 'host-20';
+    attempt();
+    expect(requestLoadEarlier).toHaveBeenCalledTimes(3);
+  });
+
+  it('does not repeat failed/duplicate pages just because streaming changes the first rendered row', () => {
+    const { bindings, attempt, requestLoadEarlier } = fixture();
+    attempt();
+    bindings.firstItemKey = 'changed-render-item';
+    attempt();
+    expect(requestLoadEarlier).toHaveBeenCalledTimes(1);
+  });
+
+  it('uses the same cursor progress for user-driven regroup continuation', () => {
+    const { bindings, attempt, requestLoadEarlier } = fixture();
+    bindings.userScrollForOlderRef.current = true;
+    attempt();
+    bindings.historyProgressKey = 'host-60';
+    bindings.regroupedHistoryContinuationRef.current = true;
+    attempt();
+    expect(requestLoadEarlier).toHaveBeenCalledTimes(2);
+    expect(bindings.initialHistoryAutofillRemainingRef.current).toBe(3);
+  });
+});

--- a/apps/mobile/src/__tests__/messageScroll.test.ts
+++ b/apps/mobile/src/__tests__/messageScroll.test.ts
@@ -253,9 +253,9 @@ describe('shouldAutoLoadEarlier', () => {
     actionVisible: true,
     atEnd: false,
     atStart: true,
-    firstItemKey: 'message-a',
+    progressKey: 'message-a',
     initialAutoFillAllowed: false,
-    lastAttemptedFirstItemKey: null,
+    lastAttemptedProgressKey: null,
     nearStart: true,
     userScrolledForOlder: true,
   };
@@ -328,11 +328,11 @@ describe('shouldAutoLoadEarlier', () => {
 
   it('requires progress between attempts to avoid hammering a host that returns no new rows', () => {
     // 上次尝试后首项没变(加载失败 / host cursor 未命中拉回重复页)→ 不自动重试;
-    expect(shouldAutoLoadEarlier({ ...eligible, lastAttemptedFirstItemKey: 'message-a' })).toBe(false);
+    expect(shouldAutoLoadEarlier({ ...eligible, lastAttemptedProgressKey: 'message-a' })).toBe(false);
     // prepend 真落地(首项变化)→ 允许级联拉下一页(小页填满预取区);
-    expect(shouldAutoLoadEarlier({ ...eligible, lastAttemptedFirstItemKey: 'message-z' })).toBe(true);
+    expect(shouldAutoLoadEarlier({ ...eligible, lastAttemptedProgressKey: 'message-z' })).toBe(true);
     // 空列表无进展信号,不触发。
-    expect(shouldAutoLoadEarlier({ ...eligible, firstItemKey: null })).toBe(false);
+    expect(shouldAutoLoadEarlier({ ...eligible, progressKey: null })).toBe(false);
   });
 });
 

--- a/apps/mobile/src/session/MessageRenderer.tsx
+++ b/apps/mobile/src/session/MessageRenderer.tsx
@@ -1386,8 +1386,8 @@ export function MessageRenderer({
     () => mobileMessageListKeysSignature(itemKeys),
     [itemKeys],
   );
-  // Keep main's rendered-row progress signal for near-start auto paging. The host cursor remains
-  // the stronger transaction commit signal because local synthetic rows can sit before host data.
+  // Use host-cursor progress for both paging and transaction settlement. A history page may
+  // expand a folded group or sit after a local synthetic row without changing the first item.
   const firstItemKey = itemKeys[0] ?? null;
   const historyProgressKey = loadEarlierProgressKey ?? firstItemKey;
   // A successful history page changes the oldest host cursor. Restore the captured visible row
@@ -1891,7 +1891,7 @@ export function MessageRenderer({
     const continueAfterRegroup = userScrolledForOlder
       && regroupedHistoryContinuationRef.current;
     if (!userScrolledForOlder && !initialAutoFillAllowed && !continueAfterRegroup) return;
-    if (firstItemKey !== null && lastAutoLoadEarlierKeyRef.current === firstItemKey) return;
+    if (historyProgressKey !== null && lastAutoLoadEarlierKeyRef.current === historyProgressKey) return;
     if (continueAfterRegroup) {
       if (!loadEarlierAction.visible) {
         regroupedHistoryContinuationRef.current = false;
@@ -1900,9 +1900,9 @@ export function MessageRenderer({
       // A merged page did make host-cursor progress but added no visible top-level history. Do not
       // reapply the near-start gate after app-owned anchor restoration moved the viewport; main
       // immediately continues from the changed first rendered row in the same situation.
-      if (loadEarlierAction.disabled || firstItemKey === null) return;
+      if (loadEarlierAction.disabled || historyProgressKey === null) return;
       regroupedHistoryContinuationRef.current = false;
-      lastAutoLoadEarlierKeyRef.current = firstItemKey;
+      lastAutoLoadEarlierKeyRef.current = historyProgressKey;
       requestLoadEarlier();
       return;
     }
@@ -1961,18 +1961,18 @@ export function MessageRenderer({
       actionVisible: loadEarlierAction.visible,
       atEnd: listState.isAtEnd,
       atStart: listState.isAtStart || nativeAtStart,
-      firstItemKey,
+      progressKey: historyProgressKey,
       initialAutoFillAllowed,
-      lastAttemptedFirstItemKey: lastAutoLoadEarlierKeyRef.current,
+      lastAttemptedProgressKey: lastAutoLoadEarlierKeyRef.current,
       nearStart: listState.isNearStart || nativeNearStart,
       userScrolledForOlder,
     });
     if (!eligible) return;
-    lastAutoLoadEarlierKeyRef.current = firstItemKey;
+    lastAutoLoadEarlierKeyRef.current = historyProgressKey;
     if (initialAutoFillAllowed) initialHistoryAutofillRemainingRef.current -= 1;
     requestLoadEarlier();
   }, [
-    firstItemKey,
+    historyProgressKey,
     loadEarlierAction.disabled,
     loadEarlierAction.visible,
     listRevealed,

--- a/apps/mobile/src/session/messageScroll.ts
+++ b/apps/mobile/src/session/messageScroll.ts
@@ -451,12 +451,12 @@ export interface MobileAutoLoadEarlierDecisionInput {
   atEnd: boolean;
   /** 列表当前也贴在内容开头；与 atEnd 同时成立才说明内容未撑满视口。 */
   atStart: boolean;
-  /** 当前首个渲染项 key(prepend 落地后必变,作为「上次尝试有进展」的信号)。 */
-  firstItemKey: string | null;
+  /** 当前最旧的历史游标；调用方没有游标时退回首个渲染项 key。 */
+  progressKey: string | null;
   /** 冷开补齐预算尚有余额；仍需 atStart + atEnd 确认视口未填满。 */
   initialAutoFillAllowed: boolean;
-  /** 上一次自动触发时的首项 key;相同说明上次尝试无进展(失败/重复页),不再自动重试。 */
-  lastAttemptedFirstItemKey: string | null;
+  /** 上一次自动触发时的历史游标;相同说明上次尝试无进展(失败/重复页),不再自动重试。 */
+  lastAttemptedProgressKey: string | null;
   /** 列表处于近顶预取区(LegendList getState().isNearStart,阈值 = onStartReachedThreshold × 视口)。 */
   nearStart: boolean;
   /** 用户产生过真实上翻意图(拖动 / 上跳导航);冷开初始布局不算。 */
@@ -480,7 +480,7 @@ export interface MobileAutoLoadEarlierDecisionInput {
  * 防失控:
  * - 用户浏览态 atEnd 时不触发:贴底跟流不因自动预取被关掉 end-pin；只有冷开有界补齐
  *   允许短窗口同时 nearStart + atEnd 时拉取；
- * - firstItemKey 去重:一次尝试后必须看到首项变化(真有 prepend)才允许下一次,
+ * - progressKey 去重:一次尝试后必须看到历史游标变化(真有 prepend)才允许下一次,
  *   加载失败或拉回重复页(host cursor 未命中返回最新页)不会无限重试;用户重新拖动时清除,
  *   保证手势永远能重新驱动一次尝试。
  */
@@ -495,8 +495,8 @@ export function shouldAutoLoadEarlier(input: MobileAutoLoadEarlierDecisionInput)
   // request the previous page; only suppress user-driven prefetch when a longer list is still
   // pinned at the latest edge without also being at the history edge.
   if (input.atEnd && input.userScrolledForOlder && !input.atStart) return false;
-  if (!input.firstItemKey) return false;
-  return input.lastAttemptedFirstItemKey !== input.firstItemKey;
+  if (!input.progressKey) return false;
+  return input.lastAttemptedProgressKey !== input.progressKey;
 }
 
 export interface MobilePreviousUserJumpTarget {


### PR DESCRIPTION
## 这次改了什么

### 摘要

手机版补回历史消息后，如果首个渲染项仍是同一张本地提示卡或折叠项，旧逻辑会把它误判为没有分页进展，提前停止首屏补齐。现在统一用最旧历史消息游标判断进展，让成功补页继续驱动加载，同时避免显示条目变化触发对失败或重复页的重复请求。

### 变更类型

- [x] `fix` 缺陷修复

### 范围

- 关联 Issue / 需求：手机版打开已有任务时历史区偶发空白或迟迟未补齐的反馈。
- 本 PR 包含：自动分页去重使用既有历史游标；覆盖首屏补齐与用户上翻后的分组续页；增加执行生产回调的回归测试。
- 明确不包含：增加分页预算、修改远程协议、列表样式或原生配置。
- 用户可见变化：补页成功但首个显示条目不变时，历史加载可继续。
- 是否存在 breaking change：无。

### UI 变化

- 引用的设计规范：`docs/design-rules/DESIGN.md` §2 Color Palette & Roles；沿用既有主题与列表样式，仅修正加载进度判定。保留首屏最多三页的补齐上限、阅读锚点与加载入口。
- 无视觉样式或文案调整；未附真机效果证据。

## 怎么验证的

### 自动验证

```text
corepack pnpm test:unit:related
结果：通过（apps/mobile related 4）
corepack pnpm --filter mobile run --if-present typecheck
结果：通过
corepack pnpm --filter mobile exec vitest run src/__tests__/messageHistoryAutofillCallbacks.test.ts src/__tests__/messageScroll.test.ts src/__tests__/messageListVirtualization.test.ts
结果：3 个文件、77 项测试通过
```

对旧版生产回调的独立复现：历史游标已前移、首项未变时只请求一页，尽管仍有两页预算。新测试覆盖成功续页、失败/重复页不重复请求、用户上翻续页与三页预算。

补充全仓门禁：通过 Git skill 的 `run-unit-gate.sh` 执行 `pnpm test:unit`，Mobile 与其他包通过；Desktop 三个文件共 9 项失败。已在同一基线提交 `760005b4` 的干净 checkout 定向复测，完全相同的 9 项失败（`claudeOrphanReaper` 5 项、`codexAuthIsolatedSandbox` 3 项、`usageHistory` 1 项），属于基线/本机问题，本 PR 未修改对应模块。

### 手工验证

未进行手机实机或模拟器交互验证。

### 未执行的验证

未启动 Metro，无对应 `__DEV__` build label；Light/Dark、iOS/Android 实机均未验证。分支 `dash/fix-mobile-history-autofill`，worktree `cindy-fix-mobile-history-autofill`。本 PR 修复已复现的进度判定缺陷，尚未确认其覆盖反馈截图的全部原因。

## 风险

### 风险分类

- [x] 其他：消息列表自动分页触发时机。

### 影响与回滚

- 影响范围：Mobile 首屏历史补齐和近顶分页。沿用已有请求、预算、事务和锚点机制；无协议、权限、数据库或原生配置变更。
- 回滚 / 降级方式：回退本 PR；手动加载更早消息入口保留。

### 提交前检查

- [x] 已 review 完整 diff
- [x] 每个 commit 都带 DCO 签名（`git commit -s`，见 [DCO](../DCO)）
- [x] UI 改动已在「UI 变化」注明引用的设计规范章节
- [x] 未提交凭证、令牌或授权文件
- [x] 已补充必要文档（代码注释，未引入新配置或用法）
- [x] 已确认测试结果或说明未执行原因
