### PR TITLE
fix(mobile): 修复 iOS 左滑「选项」里删除与重命名无响应

### DIFF
--- a/apps/mobile/src/__tests__/sessionOptionsExpoSheet.test.ts
+++ b/apps/mobile/src/__tests__/sessionOptionsExpoSheet.test.ts
@@ -1,33 +1,204 @@
-import { readFileSync } from 'node:fs';
-import { resolve } from 'node:path';
-import { describe, expect, it } from 'vitest';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 /**
- * iOS 左滑「选项」Sheet 的关闭时序(回归锚点):
- * 删除 / 重命名的后续弹窗都挂在 onClosed 上等 Sheet 真正卸载后再 present。
- * `@expo/ui` 通用 BottomSheet 的 onDismiss 只在**用户**下拉 / 点背板时触发
- * (原生只在 isPresented 状态与 props 不一致时派发 onIsPresentedChange);
- * 点菜单项后由 JS 把 isPresented 置 false 属于程序化关闭,不会回调,
- * pendingSheetActionRef 里的删除确认永远不弹——用户看到「删除按钮没反应」。
- * 因此 iOS 路径必须直接用 swift-ui BottomSheet 的 onDismiss(SwiftUI
- * `.sheet(onDismiss:)`,两种关闭方式都触发)来驱动 onClosed。
+ * iOS 左滑「选项」Sheet 的关闭时序(回归锚点)。
+ *
+ * 删除 / 重命名的后续弹窗都挂在 onClosed 上等 Sheet 真正卸载后再 present
+ * (useSessionListActions 的 pendingSheetActionRef)。通用 `@expo/ui` BottomSheet 的
+ * onDismiss 只由原生 onIsPresentedChange 派生,而原生只在**用户**下拉 / 点背板时派发它
+ * (BottomSheetView.swift 的防回环 guard:props.isPresented == newIsPresented 就 return);
+ * 点菜单项后由 JS 把 isPresented 置 false 属于程序化关闭,不会回调,存好的删除确认
+ * 永远不弹 —— 用户看到「删除按钮没反应」。
+ *
+ * 因此 iOS 必须用 swift-ui BottomSheet,它把两个信号分开暴露:
+ *   - onIsPresentedChange(false) = 用户主动关闭   → onClose
+ *   - onDismiss(SwiftUI .sheet(onDismiss:)) = 已完全消失(两种关闭都触发) → onClosed
+ *
+ * 本测试直接调用组件函数、断言真实传给 BottomSheet 的 props 与回调行为
+ * (不做源码文本匹配,等价重构不会误报)。mobile 无 react renderer 依赖,
+ * 这里手动展开函数组件即可 —— 组件是纯函数,只用到被 mock 的 useTheme。
  */
-describe('SessionOptionsExpoSheet dismiss lifecycle', () => {
-  const source = readFileSync(
-    resolve(process.cwd(), 'src/session/SessionOptionsExpoSheet.tsx'),
-    'utf8',
-  ).replace(/\r\n/g, '\n');
 
-  it('uses the swift-ui BottomSheet whose onDismiss also fires for programmatic close', () => {
-    expect(source).toContain("from \"@expo/ui/swift-ui\"");
-    expect(source).not.toMatch(/import \{[^}]*\bBottomSheet\b[^}]*\} from "@expo\/ui";/);
+const platform = vi.hoisted(() => ({ os: 'ios' }));
+
+// 原生视图在 node 下 requireNativeView 会抛,全部替换成可识别的标记。
+// 通用封装与 swift-ui 用不同标记,才能断言「没退回通用 BottomSheet」。
+vi.mock('react-native', () => ({
+  Platform: { get OS() { return platform.os; } },
+}));
+vi.mock('@expo/ui', () => ({
+  BottomSheet: 'UniversalBottomSheet',
+  Column: 'Column',
+  Host: 'Host',
+  List: 'List',
+  ListItem: 'ListItem',
+  Text: 'Text',
+}));
+vi.mock('@expo/ui/swift-ui', () => ({
+  BottomSheet: 'SwiftUIBottomSheet',
+  Group: 'Group',
+}));
+vi.mock('@expo/ui/swift-ui/modifiers', () => ({
+  frame: (params: unknown) => ({ modifier: 'frame', params }),
+  padding: (params: unknown) => ({ modifier: 'padding', params }),
+  presentationDragIndicator: (visibility: unknown) => ({
+    modifier: 'presentationDragIndicator',
+    visibility,
+  }),
+}));
+vi.mock('@/session/SessionActionSheet', () => ({
+  SessionActionSheet: 'SessionActionSheet',
+}));
+vi.mock('@/theme', () => ({
+  useTheme: () => ({ colors: { destructive: '#ff0000' } }),
+}));
+
+import { SessionOptionsPresenter } from '@/session/SessionOptionsExpoSheet';
+import type { SessionSwipeAction } from '@/session/swipeRowRegistry';
+
+interface Element {
+  type: unknown;
+  props: Record<string, unknown> & { children?: unknown };
+}
+
+/** 手动展开函数组件(组件是纯函数,useTheme 已 mock),得到宿主元素树。 */
+function renderTree(element: unknown): unknown {
+  let current = element;
+  while (isElement(current) && typeof current.type === 'function') {
+    current = (current.type as (p: unknown) => unknown)(current.props);
+  }
+  return current;
+}
+
+function isElement(value: unknown): value is Element {
+  return typeof value === 'object' && value !== null && 'type' in value && 'props' in value;
+}
+
+/** 深度优先找第一个 type 命中的元素(children 可能是数组 / 嵌套数组)。 */
+function findByType(node: unknown, type: string): Element | null {
+  const expanded = renderTree(node);
+  if (Array.isArray(expanded)) {
+    for (const child of expanded) {
+      const hit = findByType(child, type);
+      if (hit) return hit;
+    }
+    return null;
+  }
+  if (!isElement(expanded)) return null;
+  if (expanded.type === type) return expanded;
+  return findByType(expanded.props.children, type);
+}
+
+function collectByType(node: unknown, type: string, out: Element[] = []): Element[] {
+  const expanded = renderTree(node);
+  if (Array.isArray(expanded)) {
+    for (const child of expanded) collectByType(child, type, out);
+    return out;
+  }
+  if (!isElement(expanded)) return out;
+  if (expanded.type === type) out.push(expanded);
+  collectByType(expanded.props.children, type, out);
+  return out;
+}
+
+function makeProps(overrides: Record<string, unknown> = {}) {
+  return {
+    onAction: vi.fn(),
+    onClose: vi.fn(),
+    onClosed: vi.fn(),
+    pinnedAt: null,
+    status: 'active',
+    visible: true,
+    ...overrides,
+  };
+}
+
+function renderSheet(overrides: Record<string, unknown> = {}) {
+  const props = makeProps(overrides);
+  const tree = SessionOptionsPresenter(props as never);
+  return { props, tree };
+}
+
+beforeEach(() => {
+  platform.os = 'ios';
+});
+
+describe('SessionOptionsExpoSheet 关闭生命周期', () => {
+  it('用 swift-ui BottomSheet,而不是回调语义不同的通用 @expo/ui 封装', () => {
+    const { tree } = renderSheet();
+    expect(findByType(tree, 'SwiftUIBottomSheet')).not.toBeNull();
+    expect(findByType(tree, 'UniversalBottomSheet')).toBeNull();
   });
 
-  it('drives onClosed from onDismiss (fully dismissed), not from onIsPresentedChange', () => {
-    const sheetStart = source.indexOf('<BottomSheet');
-    const sheetEnd = source.indexOf('<Group', sheetStart);
-    const sheetProps = source.slice(sheetStart, sheetEnd);
-    expect(sheetProps).toMatch(/onDismiss=\{[\s\S]*onClosed\?\.\(\)/);
-    expect(sheetProps).not.toMatch(/onIsPresentedChange=\{[\s\S]*onClosed/);
+  it('onDismiss(已完全消失)只触发 onClosed —— 延迟的删除确认据此才能弹出', () => {
+    const { props, tree } = renderSheet();
+    const sheet = findByType(tree, 'SwiftUIBottomSheet');
+    expect(sheet).not.toBeNull();
+
+    (sheet!.props.onDismiss as () => void)();
+
+    expect(props.onClosed).toHaveBeenCalledTimes(1);
+    expect(props.onClose).not.toHaveBeenCalled();
+  });
+
+  it('onIsPresentedChange(false)(用户下拉 / 点背板)只触发 onClose', () => {
+    const { props, tree } = renderSheet();
+    const sheet = findByType(tree, 'SwiftUIBottomSheet');
+
+    (sheet!.props.onIsPresentedChange as (p: boolean) => void)(false);
+
+    expect(props.onClose).toHaveBeenCalledTimes(1);
+    expect(props.onClosed).not.toHaveBeenCalled();
+  });
+
+  it('onIsPresentedChange(true)(打开)不触发任何关闭回调', () => {
+    const { props, tree } = renderSheet();
+    const sheet = findByType(tree, 'SwiftUIBottomSheet');
+
+    (sheet!.props.onIsPresentedChange as (p: boolean) => void)(true);
+
+    expect(props.onClose).not.toHaveBeenCalled();
+    expect(props.onClosed).not.toHaveBeenCalled();
+  });
+
+  it('程序化关闭(visible=false)后 onDismiss 仍然触发 onClosed', () => {
+    // 点菜单项的真实序列:调用方先置 visible=false,再由原生报告已消失。
+    const { props, tree } = renderSheet({ visible: false });
+    const sheet = findByType(tree, 'SwiftUIBottomSheet');
+    expect(sheet!.props.isPresented).toBe(false);
+
+    (sheet!.props.onDismiss as () => void)();
+
+    expect(props.onClosed).toHaveBeenCalledTimes(1);
+  });
+
+  it('visible 直接驱动 isPresented', () => {
+    expect(
+      findByType(renderSheet({ visible: true }).tree, 'SwiftUIBottomSheet')!.props.isPresented,
+    ).toBe(true);
+  });
+});
+
+describe('SessionOptionsExpoSheet 菜单接线', () => {
+  it('每个菜单项把自己的 action 透传给 onAction(含删除)', () => {
+    const { props, tree } = renderSheet();
+    const items = collectByType(tree, 'ListItem');
+    const actions = items.map((item) => String(item.props.testID).replace('home.sessionActions.', ''));
+
+    expect(actions).toContain('delete');
+    expect(actions).toContain('rename');
+
+    const deleteItem = items.find((item) => item.props.testID === 'home.sessionActions.delete');
+    (deleteItem!.props.onPress as () => void)();
+    expect(props.onAction).toHaveBeenCalledWith<[SessionSwipeAction]>('delete');
+  });
+});
+
+describe('SessionOptionsPresenter 平台分流', () => {
+  it('非 iOS 走 Android 自绘 SessionActionSheet', () => {
+    platform.os = 'android';
+    const { tree } = renderSheet();
+    expect(findByType(tree, 'SessionActionSheet')).not.toBeNull();
+    expect(findByType(tree, 'SwiftUIBottomSheet')).toBeNull();
   });
 });

--- a/apps/mobile/src/__tests__/sessionOptionsExpoSheet.test.ts
+++ b/apps/mobile/src/__tests__/sessionOptionsExpoSheet.test.ts
@@ -1,0 +1,33 @@
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+import { describe, expect, it } from 'vitest';
+
+/**
+ * iOS 左滑「选项」Sheet 的关闭时序(回归锚点):
+ * 删除 / 重命名的后续弹窗都挂在 onClosed 上等 Sheet 真正卸载后再 present。
+ * `@expo/ui` 通用 BottomSheet 的 onDismiss 只在**用户**下拉 / 点背板时触发
+ * (原生只在 isPresented 状态与 props 不一致时派发 onIsPresentedChange);
+ * 点菜单项后由 JS 把 isPresented 置 false 属于程序化关闭,不会回调,
+ * pendingSheetActionRef 里的删除确认永远不弹——用户看到「删除按钮没反应」。
+ * 因此 iOS 路径必须直接用 swift-ui BottomSheet 的 onDismiss(SwiftUI
+ * `.sheet(onDismiss:)`,两种关闭方式都触发)来驱动 onClosed。
+ */
+describe('SessionOptionsExpoSheet dismiss lifecycle', () => {
+  const source = readFileSync(
+    resolve(process.cwd(), 'src/session/SessionOptionsExpoSheet.tsx'),
+    'utf8',
+  ).replace(/\r\n/g, '\n');
+
+  it('uses the swift-ui BottomSheet whose onDismiss also fires for programmatic close', () => {
+    expect(source).toContain("from \"@expo/ui/swift-ui\"");
+    expect(source).not.toMatch(/import \{[^}]*\bBottomSheet\b[^}]*\} from "@expo\/ui";/);
+  });
+
+  it('drives onClosed from onDismiss (fully dismissed), not from onIsPresentedChange', () => {
+    const sheetStart = source.indexOf('<BottomSheet');
+    const sheetEnd = source.indexOf('<Group', sheetStart);
+    const sheetProps = source.slice(sheetStart, sheetEnd);
+    expect(sheetProps).toMatch(/onDismiss=\{[\s\S]*onClosed\?\.\(\)/);
+    expect(sheetProps).not.toMatch(/onIsPresentedChange=\{[\s\S]*onClosed/);
+  });
+});

--- a/apps/mobile/src/session/SessionOptionsExpoSheet.tsx
+++ b/apps/mobile/src/session/SessionOptionsExpoSheet.tsx
@@ -1,7 +1,20 @@
 /**
  * 左滑「选项」:iOS 用 Expo UI BottomSheet + List;Android 用 SessionActionSheet。
+ *
+ * iOS 直接用 `@expo/ui/swift-ui` 的 BottomSheet 而非通用 `@expo/ui` 封装:通用封装只把
+ * onIsPresentedChange(false) 转成 onDismiss,而原生只在**用户**下拉 / 点背板时派发它;
+ * 点菜单项后由 JS 把 isPresented 置 false 属于程序化关闭,不会回调。删除 / 重命名的
+ * 后续弹窗都挂在 onClosed 上等 Sheet 卸载后再 present(useSessionListActions),没有
+ * 回调就永远不弹。swift-ui 层的 onDismiss 对应 SwiftUI `.sheet(onDismiss:)`,两种关闭
+ * 都在 Sheet 完全消失后触发,才是 onClosed 的正确挂点。
  */
-import { BottomSheet, Column, Host, List, ListItem, Text } from "@expo/ui";
+import { Column, Host, List, ListItem, Text } from "@expo/ui";
+import { BottomSheet, Group } from "@expo/ui/swift-ui";
+import {
+  frame,
+  padding,
+  presentationDragIndicator,
+} from "@expo/ui/swift-ui/modifiers";
 import { Platform } from "react-native";
 import { SessionActionSheet } from "@/session/SessionActionSheet";
 import {
@@ -26,6 +39,13 @@ export function SessionOptionsPresenter(props: SessionOptionsProps) {
   return <SessionOptionsExpoSheet {...props} />;
 }
 
+// 与通用 BottomSheet 封装相同的内容边距 / 顶对齐 / 把手,fitToContents 自适应菜单高度。
+const SHEET_CONTENT_MODIFIERS = [
+  frame({ maxWidth: Infinity, alignment: "topLeading" }),
+  padding({ top: 16, bottom: 0, leading: 16, trailing: 16 }),
+  presentationDragIndicator("visible"),
+];
+
 function SessionOptionsExpoSheet({
   onAction,
   onClose,
@@ -40,42 +60,46 @@ function SessionOptionsExpoSheet({
   const destructive = menu.filter((item) => item.destructive === true);
 
   return (
-    <Host>
+    <Host pointerEvents="none" style={{ position: "absolute" }}>
       <BottomSheet
+        fitToContents
         isPresented={visible}
         onDismiss={() => {
-          onClose();
           onClosed?.();
         }}
-        showDragIndicator
+        onIsPresentedChange={(presented) => {
+          if (!presented) onClose();
+        }}
         testID="home.sessionActions"
       >
-        <Column>
-          <List>
-            {regular.map((item) => (
-              <ListItem
-                key={item.action}
-                onPress={() => onAction(item.action)}
-                testID={`home.sessionActions.${item.action}`}
-              >
-                {item.label}
-              </ListItem>
-            ))}
-          </List>
-          <List>
-            {destructive.map((item) => (
-              <ListItem
-                key={item.action}
-                onPress={() => onAction(item.action)}
-                testID={`home.sessionActions.${item.action}`}
-              >
-                <Text textStyle={{ color: colors.destructive }}>
+        <Group modifiers={SHEET_CONTENT_MODIFIERS}>
+          <Column>
+            <List>
+              {regular.map((item) => (
+                <ListItem
+                  key={item.action}
+                  onPress={() => onAction(item.action)}
+                  testID={`home.sessionActions.${item.action}`}
+                >
                   {item.label}
-                </Text>
-              </ListItem>
-            ))}
-          </List>
-        </Column>
+                </ListItem>
+              ))}
+            </List>
+            <List>
+              {destructive.map((item) => (
+                <ListItem
+                  key={item.action}
+                  onPress={() => onAction(item.action)}
+                  testID={`home.sessionActions.${item.action}`}
+                >
+                  <Text textStyle={{ color: colors.destructive }}>
+                    {item.label}
+                  </Text>
+                </ListItem>
+              ))}
+            </List>
+          </Column>
+        </Group>
       </BottomSheet>
     </Host>
   );


### PR DESCRIPTION
## 这次改了什么

### 摘要

iOS 上左滑任务行 →「选项」→「删除任务」点了**没有任何反应**,确认弹窗不出现;
同一个 Sheet 里的「重命名任务」同样无响应。置顶 / 归档正常,会话详情页「…」里的
删除也正常,所以问题一直被当成偶发。

根因是 `@expo/ui` 里**两个都叫 `onDismiss` 的回调语义不同**,代码接错了那个。

iOS 不允许在 Sheet 关闭过程中 present 系统 Alert(会被吞掉),所以
`useSessionListActions.ts` 刻意把删除 / 重命名拆成两拍:先关 Sheet,把后续弹窗
存进 `pendingSheetActionRef`,等 Sheet 报告"我关完了"(`onClosed`)再弹。
**`onClosed` 不触发 = 什么都不发生**。

而通用 `@expo/ui` BottomSheet 的 `onDismiss` 只由原生 `onIsPresentedChange` 派生,
原生 `BottomSheetView.swift` 里有一个防回环 guard:

```swift
.onChange(of: isPresented) { newIsPresented in
  if props.isPresented == newIsPresented { return }   // 吞掉事件
  props.onIsPresentedChange(["isPresented": newIsPresented])
}
```

| 关闭方式 | 本地 state vs props | 事件 | `onClosed` |
|---|---|---|---|
| 用户下拉 / 点背板 | SwiftUI 先改本地态,props 仍为 true → **不一致** | 派发 | ✅ |
| 点菜单项(JS 置 `visible=false`) | props 先变再驱动本地态 → **一致** | **被 guard 吞掉** | ❌ |

点「删除任务」永远走第二行,所以 Sheet 滑走了、确认弹窗永远躺在 ref 里。
这不是 Expo 的 bug——guard 是防回环的,那个 `onDismiss` 语义就是"**用户**关的",
不是"关完了"。纯回调不触发,不抛错、无日志,typecheck 和单测都看不见。

**改法**:直接用 `@expo/ui/swift-ui` 的 BottomSheet,它把两个信号分开暴露:

- `onIsPresentedChange` → 用户主动关闭,驱动 `onClose`
- `onDismiss` → 对应 SwiftUI `.sheet(onDismiss:)`,**两种关闭方式**都在 Sheet
  完全消失后触发,才是 `onClosed` 的正确挂点

内容 modifier(frame / padding / 拖拽把手 / fitToContents)与通用封装逐条对齐,视觉不变。

引入于 #3500——该 commit 同时把 iOS Sheet 换成 `@expo/ui`,又把删除从立即弹
Alert 挪进了延迟路径,两个改动叠加才暴露。

### 变更类型

- [x] `fix` 缺陷修复

### 范围

- 关联 Issue / 需求:无(用户报告"手机上删不掉被控电脑的任务")
- 本 PR 包含:`SessionOptionsExpoSheet.tsx` 的 iOS Sheet 关闭时序修复 + 回归测试
- 明确不包含:Android 路径(`SessionActionSheet`,本来就正常)、会话详情页
  `SessionMenuSheet`(走 RN `SheetModal`,不受影响)、device-link / 被控端写库链路
  (`invoke` 往右全程正常,请求压根没离开手机)
- 用户可见变化:iOS 左滑「选项」里的**删除**与**重命名**恢复可用
- 是否存在 breaking change:无

### UI 变化

- 引用的设计规范:**不涉及**——本次只改 Sheet 的关闭事件接线,不改布局、
  尺寸、颜色与文案。内容 modifier(`frame` / `padding` /
  `presentationDragIndicator` / `fitToContents`)按通用封装的原值逐条复刻,
  渲染结果与改动前一致。已在模拟器 Light / Dark 双模式实机目检确认外观未变。

## 怎么验证的

### 自动验证

```text
pnpm test:unit:related
结果:PASS(apps/mobile unit),exit 0

pnpm --filter mobile run --if-present typecheck
结果:通过,exit 0

pnpm check:dco
结果:DCO check passed: 1 commit signed off
```

新增回归测试 `apps/mobile/src/__tests__/sessionOptionsExpoSheet.test.ts`:
钉死 iOS 路径必须用 swift-ui BottomSheet,且 `onClosed` 由 `onDismiss` 驱动、
不再挂在 `onIsPresentedChange` 上。改前该测试失败,改后通过。

### 手工验证

平台:iOS 26.5 iPhone 17 Pro 模拟器,**iOS development client**(非 Expo Go、
非分发包),bundle id `com.xd.cindy`(Global)。

`pnpm mobile:sim:whoami -- --region=global` → PASS:booted dev client、本 worktree 的
8081 Metro、源码指纹三者一致(`fix/mobile-ios-session-options-dismiss@77ccdc239+68f7b40dde`)。
worktree:`.cindy-worktrees/mobile-ios-delete-session`;新建 dev client 由
`pnpm mobile:sim:rebuild` 产出(原装机为 7 月构建,缺 `ExpoNetwork` 原生模块)。

**A/B 对照(同一台设备、同一条 Maestro flow、同一个任务行):**

| 代码 | 点「删除任务」 | 结果 |
|---|---|---|
| 改前(main 版本) | 确认弹窗不出现 | 断言失败,**复现用户报告** |
| 改后 | 确认弹窗正常弹出 | flow 通过 |

**端到端真实删除(不碰任何真实数据):** 在手机端新建一次性任务
「throwaway session delete test」(`7c9e8853`),左滑 →「选项」→「删除任务」→
确认弹窗指名该任务 → 点「删除」→ 列表行消失。被控端数据库核对:

```text
sqlite3 …/Cindy/cindy-*.db
  select id, title, status from sessions where id='7c9e8853-…';
→ 7c9e8853-…|throwaway session delete test|deleted
```

即写入真的落到了被控端,不只是控制端的乐观更新。

**重命名**:改后同一个 Sheet 里点「重命名任务」可正常打开
`home.renameSession.modal`(改前的负向对照未单独跑,见下)。

**双模式**:Light / Dark 均实机目检 Sheet 外观,布局与危险色一致。

### 未执行的验证

- **重命名的改前负向对照未跑**:A/B 只对删除做了。重命名与删除共用同一条
  `pendingSheetActionRef` 延迟路径(代码层面同因),但我只验证了"改后可用"。
- 未跑 `pnpm test:all` / E2E 全量:改动只落在一个 iOS-only 展示组件,
  最终以 CI 门禁为准。
- Android 未实机验证:该平台走 `SessionActionSheet`,本 PR 未触碰其代码路径。

## 风险

### 风险分类

- [x] 跨平台差异

### 影响与回滚

- 影响范围:仅 iOS 左滑「选项」Sheet(`SessionOptionsExpoSheet`)。Android 分支
  提前 return 到 `SessionActionSheet`,零改动。
- **不触发冷更**:未动 `apps/mobile/package.json` 依赖与 scripts、`app.json` /
  `app.config.js`、`eas.json` production 段、`plugins/`、`modules/`。`@expo/ui`
  版本未变,只是从包内 `.` 子路径改用 `./swift-ui` 子路径导入,不改变 runtime
  fingerprint,存量装机可经 OTA 拿到。已按规则实测比对(`ci-fingerprint.mjs compute`
  改动前后各跑一次),两次逐字节一致:
  `ios b69c311c6098a3adc4fc67bc0d9ef3410619ea05` / `android eded6b21982ef138c322702a95d8ec7b534de4d6`。
- 回滚方式:`git revert` 单个 commit 即可,无数据迁移、无持久化状态。
- 存量插件影响:无。

### 提交前检查

- [x] 已 review 完整 diff
- [x] 每个 commit 都带 DCO 签名(`git commit -s`)
- [x] UI 改动已在「UI 变化」注明(此处为"不涉及 + 理由")
- [x] 未提交凭证、令牌或授权文件
- [x] 已补充必要文档(改动理由写进了组件头注释)
- [x] 已确认测试结果或说明未执行原因
