### PR TITLE
fix(codex): Chat bridge 按每个对话附带 x-opencode-session 稳定会话头,修复 OpenCode Go 强制校验后全线 400

### DIFF
--- a/apps/desktop/src/main/maker-host/__tests__/codexProxyHost.test.ts
+++ b/apps/desktop/src/main/maker-host/__tests__/codexProxyHost.test.ts
@@ -991,6 +991,7 @@ describe('chatBridgeCapabilitiesForRoute', () => {
             parsedBody.input[2],
           ],
         },
+        requestHeaders: ctx.headers,
         res,
       });
     } finally {
@@ -1060,6 +1061,7 @@ describe('chatBridgeCapabilitiesForRoute', () => {
           instructions: 'PRODUCT_PROMPT',
           input: [],
         },
+        requestHeaders: ctx.headers,
         res,
       });
     } finally {
@@ -1859,6 +1861,7 @@ describe('chatBridgeCapabilitiesForRoute', () => {
           reasoning: { effort: 'high', summary: 'auto' },
           instructions: 'PRODUCT_PROMPT',
         },
+        requestHeaders: ctx.headers,
         res,
       });
     } finally {
@@ -3399,6 +3402,7 @@ describe('codex proxy host', () => {
         model: 'deepseek-v4',
         tools: [{ type: 'function', name: 'shell' }],
       },
+      requestHeaders: ctx.headers,
       res,
     });
 
@@ -3451,6 +3455,7 @@ describe('codex proxy host', () => {
         instructions: 'PRODUCT_PROMPT',
         tools: [{ type: 'function', name: 'shell' }],
       },
+      requestHeaders: ctx.headers,
       res,
     });
 
@@ -3506,6 +3511,7 @@ describe('codex proxy host', () => {
         tools: [{ type: 'function', name: 'shell' }],
         tool_choice: 'auto',
       },
+      requestHeaders: ctx.headers,
       res,
     });
 

--- a/apps/desktop/src/main/maker-host/codex-proxy-host.ts
+++ b/apps/desktop/src/main/maker-host/codex-proxy-host.ts
@@ -1069,7 +1069,7 @@ function createChatBridgeDecision(
     // 出站代理;显式注入代理感知 fetch(见 outbound-fetch.ts)。
   }, { logger: log, fetchImpl: outboundFetch });
   return {
-    localHandler: ({ rawBody, parsedBody, res }) => {
+    localHandler: ({ rawBody, parsedBody, ctx, res }) => {
       const body = prepareLocalBridgeBody({
         rawBody,
         parsedBody,
@@ -1080,7 +1080,10 @@ function createChatBridgeDecision(
         providerId,
         upstreamBase: route.routing.upstream,
       });
-      return handler.handle({ parsedBody: body, res });
+      // 只把入站头快照交给 bridge 解析稳定会话 ID(→ x-opencode-session,#4073);bridge 不透传
+      // 这些头,凭证与 Codex 账号头仍由 buildLocalHandlerHeaders 的隔离边界管。
+      // ctx 在生产路径恒有;既有测试与旧调用方可能省略,按「无入站头」处理即不附加会话头。
+      return handler.handle({ parsedBody: body, res, requestHeaders: ctx?.headers });
     },
   };
 }

--- a/packages/responses-chat-bridge/src/__tests__/handler.test.ts
+++ b/packages/responses-chat-bridge/src/__tests__/handler.test.ts
@@ -1080,4 +1080,58 @@ describe('createResponsesChatHandler', () => {
     );
     expect(JSON.stringify(warn.mock.calls)).not.toContain('system message must be at the beginning');
   });
+  describe('outbound headers carry only the stable conversation id (#4073)', () => {
+    function captureHeaders(requestHeaders?: Record<string, string>, providerHeaders: Record<string, string> = { authorization: 'Bearer secret' }) {
+      const fetchImpl = vi.fn(async () => streamResponse([
+        { id: 'chat_1', choices: [{ delta: { content: 'hi' } }] },
+        { id: 'chat_1', choices: [{ delta: {}, finish_reason: 'stop' }] },
+      ]));
+      const handler = createResponsesChatHandler({
+        upstreamBase: 'https://opencode.example/zen/go/v1',
+        buildHeaders: async () => providerHeaders,
+      }, { fetchImpl });
+      const res = new FakeResponse();
+      return handler.handle({
+        parsedBody: { model: 'kimi-k2', input: [{ role: 'user', content: 'hi' }] },
+        res: res as never,
+        ...(requestHeaders ? { requestHeaders } : {}),
+      }).then(() => {
+        expect(res.status).toBe(200);
+        return (fetchImpl.mock.calls[0] as unknown as [string, RequestInit])[1].headers as Record<string, string>;
+      });
+    }
+
+    it('derives x-opencode-session from the Codex thread-id and drops every other inbound header', async () => {
+      const headers = await captureHeaders({
+        'thread-id': 'thr_abc',
+        'x-codex-parent-thread-id': 'thr_parent',
+        authorization: 'Bearer client-token-must-not-leak',
+        'chatgpt-account-id': 'acct-must-not-leak',
+        'x-client-request-id': 'req-1',
+      });
+      expect(headers['x-opencode-session']).toBe('thr_abc');
+      expect(headers.authorization).toBe('Bearer secret');
+      expect(headers).not.toHaveProperty('chatgpt-account-id');
+      expect(headers).not.toHaveProperty('x-codex-parent-thread-id');
+      expect(headers).not.toHaveProperty('x-client-request-id');
+      expect(headers['user-agent']).toBe('Cindy-CodexChatBridge/1');
+    });
+
+    it('lets an explicit inbound x-opencode-session win over thread-id and provider static headers', async () => {
+      const headers = await captureHeaders(
+        { 'x-opencode-session': 'conv-explicit', 'thread-id': 'thr_abc' },
+        { authorization: 'Bearer secret', 'x-opencode-session': 'machine-wide-fixed', 'user-agent': 'custom/1' },
+      );
+      expect(headers['x-opencode-session']).toBe('conv-explicit');
+      expect(headers['user-agent']).toBe('custom/1');
+    });
+
+    it('sends no session header when the request carries no stable conversation id', async () => {
+      const headers = await captureHeaders({ 'x-client-request-id': 'req-only' });
+      expect(headers).not.toHaveProperty('x-opencode-session');
+      const legacy = await captureHeaders(undefined);
+      expect(legacy).not.toHaveProperty('x-opencode-session');
+    });
+  });
+
 });

--- a/packages/responses-chat-bridge/src/__tests__/handler.test.ts
+++ b/packages/responses-chat-bridge/src/__tests__/handler.test.ts
@@ -1126,6 +1126,26 @@ describe('createResponsesChatHandler', () => {
       expect(headers['user-agent']).toBe('custom/1');
     });
 
+    it('replaces a provider static header written in a different casing instead of sending both (Greptile P1)', async () => {
+      const headers = await captureHeaders(
+        { 'thread-id': 'thr_abc' },
+        { authorization: 'Bearer secret', 'X-OpenCode-Session': 'machine-wide-fixed' },
+      );
+      const sessionKeys = Object.keys(headers).filter((key) => key.toLowerCase() === 'x-opencode-session');
+      expect(sessionKeys).toEqual(['x-opencode-session']);
+      expect(headers['x-opencode-session']).toBe('thr_abc');
+      expect(new Headers(headers).get('x-opencode-session')).toBe('thr_abc');
+    });
+
+    it('keeps a provider static session header as-is when no stable conversation id is available', async () => {
+      const headers = await captureHeaders(
+        { 'x-client-request-id': 'req-only' },
+        { authorization: 'Bearer secret', 'X-OpenCode-Session': 'machine-wide-fixed' },
+      );
+      expect(headers['X-OpenCode-Session']).toBe('machine-wide-fixed');
+      expect(headers).not.toHaveProperty('x-opencode-session');
+    });
+
     it('sends no session header when the request carries no stable conversation id', async () => {
       const headers = await captureHeaders({ 'x-client-request-id': 'req-only' });
       expect(headers).not.toHaveProperty('x-opencode-session');

--- a/packages/responses-chat-bridge/src/__tests__/session-header.test.ts
+++ b/packages/responses-chat-bridge/src/__tests__/session-header.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from 'vitest';
 
 import {
   CHAT_BRIDGE_USER_AGENT,
+  overrideHeadersCaseInsensitive,
   resolveConversationSessionHeaders,
   withChatBridgeUserAgent,
 } from '../session-header.js';
@@ -47,5 +48,23 @@ describe('withChatBridgeUserAgent', () => {
 
   it('keeps an explicit provider User-Agent (any casing) untouched', () => {
     expect(withChatBridgeUserAgent({ 'User-Agent': 'my-ua/2' })).toEqual({ 'User-Agent': 'my-ua/2' });
+  });
+});
+
+describe('overrideHeadersCaseInsensitive', () => {
+  it('drops a provider static header whose name only differs in casing before applying the override', () => {
+    const merged = overrideHeadersCaseInsensitive(
+      { authorization: 'Bearer k', 'X-OpenCode-Session': 'machine-wide-fixed' },
+      { 'x-opencode-session': 'thr_abc' },
+    );
+    expect(merged).toEqual({ authorization: 'Bearer k', 'x-opencode-session': 'thr_abc' });
+    expect(Object.keys(merged).filter((key) => key.toLowerCase() === 'x-opencode-session')).toHaveLength(1);
+  });
+
+  it('keeps the base untouched (and copied) when there is nothing to override', () => {
+    const base = { 'X-OpenCode-Session': 'machine-wide-fixed', 'User-Agent': 'ua/1' };
+    const merged = overrideHeadersCaseInsensitive(base, {});
+    expect(merged).toEqual(base);
+    expect(merged).not.toBe(base);
   });
 });

--- a/packages/responses-chat-bridge/src/__tests__/session-header.test.ts
+++ b/packages/responses-chat-bridge/src/__tests__/session-header.test.ts
@@ -1,0 +1,51 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  CHAT_BRIDGE_USER_AGENT,
+  resolveConversationSessionHeaders,
+  withChatBridgeUserAgent,
+} from '../session-header.js';
+
+describe('resolveConversationSessionHeaders (#4073)', () => {
+  it('maps the Codex thread-id to x-opencode-session', () => {
+    expect(resolveConversationSessionHeaders({ 'thread-id': 'thr_0190abc-1234' }))
+      .toEqual({ 'x-opencode-session': 'thr_0190abc-1234' });
+  });
+
+  it('prefers an explicit inbound x-opencode-session over thread-id (case-insensitive, trimmed)', () => {
+    expect(resolveConversationSessionHeaders({
+      'X-OpenCode-Session': '  conv-explicit ',
+      'Thread-Id': 'thr_ignored',
+    })).toEqual({ 'x-opencode-session': 'conv-explicit' });
+  });
+
+  it('never derives a session from parent-thread, auth or other inbound headers', () => {
+    expect(resolveConversationSessionHeaders({
+      'x-codex-parent-thread-id': 'parent-1',
+      authorization: 'Bearer secret',
+      'chatgpt-account-id': 'acct',
+      'x-client-request-id': 'req-per-request',
+    })).toEqual({});
+    expect(resolveConversationSessionHeaders(undefined)).toEqual({});
+    expect(resolveConversationSessionHeaders({})).toEqual({});
+  });
+
+  it('rejects non-token session values instead of forwarding arbitrary strings', () => {
+    expect(resolveConversationSessionHeaders({ 'thread-id': 'has space' })).toEqual({});
+    expect(resolveConversationSessionHeaders({ 'thread-id': 'a\r\nx-injected: 1' })).toEqual({});
+    expect(resolveConversationSessionHeaders({ 'thread-id': 'x'.repeat(129) })).toEqual({});
+    expect(resolveConversationSessionHeaders({ 'thread-id': 'x'.repeat(128) }))
+      .toEqual({ 'x-opencode-session': 'x'.repeat(128) });
+  });
+});
+
+describe('withChatBridgeUserAgent', () => {
+  it('adds the bridge User-Agent when the provider headers have none', () => {
+    expect(withChatBridgeUserAgent({ authorization: 'Bearer k' }))
+      .toEqual({ authorization: 'Bearer k', 'user-agent': CHAT_BRIDGE_USER_AGENT });
+  });
+
+  it('keeps an explicit provider User-Agent (any casing) untouched', () => {
+    expect(withChatBridgeUserAgent({ 'User-Agent': 'my-ua/2' })).toEqual({ 'User-Agent': 'my-ua/2' });
+  });
+});

--- a/packages/responses-chat-bridge/src/handler.ts
+++ b/packages/responses-chat-bridge/src/handler.ts
@@ -1,6 +1,7 @@
 import type { ServerResponse } from 'node:http';
 
 import { ChatSseTranslator } from './chat-sse-translator.js';
+import { resolveConversationSessionHeaders, withChatBridgeUserAgent } from './session-header.js';
 import { coalesceLeadingSystemMessages, translateResponsesRequestWithContext } from './translate-request.js';
 import {
   UnsupportedResponsesFeatureError,
@@ -185,7 +186,7 @@ export function createResponsesChatHandler(
   const fetchImpl = opts.fetchImpl ?? fetch;
 
   return {
-    async handle({ parsedBody, res }): Promise<void> {
+    async handle({ parsedBody, res, requestHeaders }): Promise<void> {
       if (!isPlainObject(parsedBody) || typeof parsedBody.model !== 'string') {
         writeJson(res, 400, responsesError(400, 'invalid_request', 'invalid Responses request body'));
         return;
@@ -260,10 +261,15 @@ export function createResponsesChatHandler(
       let upstream: Response;
       let upstreamErrorText: string | undefined;
       try {
+        // 出站头 = 供应商凭证/自定义头(缺 UA 时补 bridge 标识)+ 稳定会话头 + 协议头。
+        // 会话头按每个对话从入站 thread-id 映射,优先于供应商静态配置里同名的固定值
+        // (整机共用一个 ID 达不到上游「每个对话稳定」的要求,见 #4073);其余入站头不出网。
+        const sessionHeaders = resolveConversationSessionHeaders(requestHeaders);
         const send = (): Promise<Response> => fetchImpl(upstreamUrl, {
           method: 'POST',
           headers: {
-            ...providerHeaders,
+            ...withChatBridgeUserAgent(providerHeaders),
+            ...sessionHeaders,
             'content-type': 'application/json',
             accept: 'text/event-stream',
           },

--- a/packages/responses-chat-bridge/src/handler.ts
+++ b/packages/responses-chat-bridge/src/handler.ts
@@ -1,7 +1,11 @@
 import type { ServerResponse } from 'node:http';
 
 import { ChatSseTranslator } from './chat-sse-translator.js';
-import { resolveConversationSessionHeaders, withChatBridgeUserAgent } from './session-header.js';
+import {
+  overrideHeadersCaseInsensitive,
+  resolveConversationSessionHeaders,
+  withChatBridgeUserAgent,
+} from './session-header.js';
 import { coalesceLeadingSystemMessages, translateResponsesRequestWithContext } from './translate-request.js';
 import {
   UnsupportedResponsesFeatureError,
@@ -264,12 +268,13 @@ export function createResponsesChatHandler(
         // 出站头 = 供应商凭证/自定义头(缺 UA 时补 bridge 标识)+ 稳定会话头 + 协议头。
         // 会话头按每个对话从入站 thread-id 映射,优先于供应商静态配置里同名的固定值
         // (整机共用一个 ID 达不到上游「每个对话稳定」的要求,见 #4073);其余入站头不出网。
+        // 覆盖按头名大小写不敏感进行,否则 `X-OpenCode-Session` 与 `x-opencode-session`
+        // 会被 fetch 合并成一个非法复合值。
         const sessionHeaders = resolveConversationSessionHeaders(requestHeaders);
         const send = (): Promise<Response> => fetchImpl(upstreamUrl, {
           method: 'POST',
           headers: {
-            ...withChatBridgeUserAgent(providerHeaders),
-            ...sessionHeaders,
+            ...overrideHeadersCaseInsensitive(withChatBridgeUserAgent(providerHeaders), sessionHeaders),
             'content-type': 'application/json',
             accept: 'text/event-stream',
           },

--- a/packages/responses-chat-bridge/src/index.ts
+++ b/packages/responses-chat-bridge/src/index.ts
@@ -1,6 +1,13 @@
 export { ChatSseTranslator, type ChatSseTranslatorOptions } from './chat-sse-translator.js';
 export { createResponsesChatHandler, type ResponsesChatHandlerOptions } from './handler.js';
 export {
+  CHAT_BRIDGE_USER_AGENT,
+  CODEX_THREAD_ID_HEADER,
+  CONVERSATION_SESSION_HEADER,
+  resolveConversationSessionHeaders,
+  withChatBridgeUserAgent,
+} from './session-header.js';
+export {
   translateResponsesRequest,
   translateResponsesRequestWithContext,
   type TranslatedResponsesChatRequest,

--- a/packages/responses-chat-bridge/src/index.ts
+++ b/packages/responses-chat-bridge/src/index.ts
@@ -4,6 +4,7 @@ export {
   CHAT_BRIDGE_USER_AGENT,
   CODEX_THREAD_ID_HEADER,
   CONVERSATION_SESSION_HEADER,
+  overrideHeadersCaseInsensitive,
   resolveConversationSessionHeaders,
   withChatBridgeUserAgent,
 } from './session-header.js';

--- a/packages/responses-chat-bridge/src/session-header.ts
+++ b/packages/responses-chat-bridge/src/session-header.ts
@@ -52,3 +52,21 @@ export function withChatBridgeUserAgent(
   const hasUserAgent = Object.keys(providerHeaders).some((key) => key.toLowerCase() === 'user-agent');
   return hasUserAgent ? { ...providerHeaders } : { ...providerHeaders, 'user-agent': CHAT_BRIDGE_USER_AGENT };
 }
+
+/**
+ * 用 overrides 覆盖 base 中的同名头。HTTP 头名不区分大小写,但对象键区分:供应商静态配置里
+ * 写成 `X-OpenCode-Session` 时,普通展开不会覆盖它,两个键一起交给 fetch 会被合并成
+ * `fixed, thread-id` 这种非法复合值(Greptile P1)。这里先按小写头名剔除 base 里的同名项,
+ * 再写入 overrides;overrides 为空时原样返回 base 的拷贝。
+ */
+export function overrideHeadersCaseInsensitive(
+  base: Readonly<Record<string, string>>,
+  overrides: Readonly<Record<string, string>>,
+): Record<string, string> {
+  const overridden = new Set(Object.keys(overrides).map((key) => key.toLowerCase()));
+  const merged: Record<string, string> = {};
+  for (const [key, value] of Object.entries(base)) {
+    if (!overridden.has(key.toLowerCase())) merged[key] = value;
+  }
+  return { ...merged, ...overrides };
+}

--- a/packages/responses-chat-bridge/src/session-header.ts
+++ b/packages/responses-chat-bridge/src/session-header.ts
@@ -1,0 +1,54 @@
+/**
+ * Chat bridge 的「稳定会话标识」出站头(#4073)。
+ *
+ * OpenCode Go 自 2026-09-06 起强制要求每个对话携带稳定的 `x-opencode-session`(路由 +
+ * prompt cache),缺失直接 400 `MissingSessionID`。Codex app-server 每个 thread 自带稳定的
+ * `thread-id` 入站头,但本 bridge 发往上游的请求头是从零构造的(只有供应商凭证 +
+ * content-type/accept),上游看不到任何会话标识。
+ *
+ * 这里**只**把稳定会话 ID 映射成一个出站头,不做入站 header 透传:Authorization / API key /
+ * Codex 账号与内部元数据头一律不出网(与 codex-proxy-host 的凭证隔离边界一致)。
+ *
+ * 取值优先级:入站已带 `x-opencode-session`(客户端或代理明确给出)> Codex `thread-id`。
+ * `x-codex-parent-thread-id` 是子线程路由信息,不当作普通会话 ID。值必须是 token 形态
+ * (字母数字 . _ : -,≤128 字符),避免把任意字符串塞进请求头。
+ */
+
+export const CONVERSATION_SESSION_HEADER = 'x-opencode-session';
+export const CODEX_THREAD_ID_HEADER = 'thread-id';
+/**
+ * OpenCode Go 要求客户端用自己的 User-Agent 而非通用 SDK / HTTP 库名。供应商 header 已显式
+ * 给出 UA 时尊重之;否则补一个稳定的 Cindy bridge 标识(不伪装成 OpenCode 或 Codex 本身)。
+ */
+export const CHAT_BRIDGE_USER_AGENT = 'Cindy-CodexChatBridge/1';
+
+const SESSION_ID_PATTERN = /^[A-Za-z0-9._:-]{1,128}$/;
+
+function headerValue(headers: Readonly<Record<string, string>>, name: string): string {
+  const direct = headers[name];
+  if (typeof direct === 'string' && direct.trim()) return direct.trim();
+  const lower = name.toLowerCase();
+  for (const [key, value] of Object.entries(headers)) {
+    if (key.toLowerCase() === lower && typeof value === 'string' && value.trim()) return value.trim();
+  }
+  return '';
+}
+
+/** 从已验证的入站请求头解析出站会话头;拿不到稳定 ID 或形态非法时返回空对象。 */
+export function resolveConversationSessionHeaders(
+  requestHeaders: Readonly<Record<string, string>> | undefined,
+): Record<string, string> {
+  if (!requestHeaders) return {};
+  const explicit = headerValue(requestHeaders, CONVERSATION_SESSION_HEADER);
+  const candidate = explicit || headerValue(requestHeaders, CODEX_THREAD_ID_HEADER);
+  if (!candidate || !SESSION_ID_PATTERN.test(candidate)) return {};
+  return { [CONVERSATION_SESSION_HEADER]: candidate };
+}
+
+/** 供应商 header 没有 User-Agent 时补 bridge 自己的标识;已有则原样保留。 */
+export function withChatBridgeUserAgent(
+  providerHeaders: Readonly<Record<string, string>>,
+): Record<string, string> {
+  const hasUserAgent = Object.keys(providerHeaders).some((key) => key.toLowerCase() === 'user-agent');
+  return hasUserAgent ? { ...providerHeaders } : { ...providerHeaders, 'user-agent': CHAT_BRIDGE_USER_AGENT };
+}

--- a/packages/responses-chat-bridge/src/types.ts
+++ b/packages/responses-chat-bridge/src/types.ts
@@ -359,6 +359,11 @@ export interface ChatBridgeProviderConfig {
 export interface ChatBridgeHandleArgs {
   parsedBody: unknown;
   res: ServerResponse;
+  /**
+   * 经本地代理验证过的入站请求头快照(#4073)。bridge **不**透传它们,只从中解析稳定会话
+   * 标识映射为出站 `x-opencode-session`(见 session-header.ts);省略 = 不附加会话头。
+   */
+  requestHeaders?: Readonly<Record<string, string>>;
 }
 
 export interface ResponsesChatBridgeHandler {


### PR DESCRIPTION
## 这次改了什么

### 摘要

用 OpenCode Go 供应商 + Codex runtime 发消息全部被上游 400 拒绝:`MissingSessionID: Request is missing x-opencode-session`。OpenCode Go 自 2026-09-06 起强制要求**每个对话**携带稳定的 `x-opencode-session`(用于路由与 prompt cache),其文档明确点名「Codex 的原生会话头在部分代理设置里会丢,转发时请保留」。

根因(与 issue 及 dash-s-cindy 的定位一致):Codex app-server 每个 thread 自带稳定的 `thread-id` 入站头,但 `packages/responses-chat-bridge` 发往上游 Chat Completions 的请求头是从零构造的(仅供应商凭证 + `content-type` + `accept`),`handle()` 也没有入站请求头入参,上游看不到任何会话标识。

本 PR 做**局部、可回滚的 header 适配,不开放全量入站 header 透传**:

- `ChatBridgeHandleArgs` 新增可选 `requestHeaders`(经本地代理验证的入站头快照)。
- 新增 `session-header.ts`:`resolveConversationSessionHeaders()` 只产出一个出站头——入站已带 `x-opencode-session` 则原样使用(客户端/代理明确给出的优先),否则由 Codex `thread-id` 生成;`x-codex-parent-thread-id` 是子线程路由信息,不当普通会话 ID;值必须是 token 形态(`/^[A-Za-z0-9._:-]{1,128}$/`),防止把任意字符串塞进请求头。`withChatBridgeUserAgent()`:供应商头没有 User-Agent 时补 `Cindy-CodexChatBridge/1`(OpenCode 要求客户端使用自有 UA 而非通用 SDK/HTTP 库名;已显式配置的 UA 原样保留,不伪装成 OpenCode/Codex)。
- `handler.ts` 出站头顺序:供应商头(补 UA)→ 会话头 → 协议头。会话头按每个对话从 `thread-id` 映射,**优先于**供应商静态配置里同名的固定值(issue 中「自定义供应商请求头手工加固定 UUID」的整机共用 ID 达不到上游「每对话稳定」的要求)。
- `codex-proxy-host.ts` 的 chat bridge `localHandler` 把 `ctx.headers` 交给 bridge;`Authorization` / API key / Codex 账号头(`chatgpt-account-id` 等)继续由 `buildLocalHandlerHeaders` 的隔离边界管理,bridge 不透传任何入站头。

对所有走 chat bridge 的供应商统一附加该头(不按上游域名判定):`thread-id` 是本地 Codex 线程的不透明 UUID,不含凭证或账号信息;若维护者希望只对 OpenCode 系 endpoint 发,`resolveConversationSessionHeaders` 已是单一收口点,加一个 provider 级开关即可。

### 变更类型

- [ ] `feat` 新功能
- [x] `fix` 缺陷修复
- [ ] `refactor` / `perf` 重构或性能优化
- [ ] `docs` / `test` / `chore` 文档、测试或工程维护
- [ ] 其他:

### 范围

- 关联 Issue / 需求:Fixes #4073
- 本 PR 包含:`responses-chat-bridge` 的 `session-header.ts`(新)、`handler.ts`、`types.ts`、`index.ts` 与两处测试;`codex-proxy-host.ts` chat bridge 接线一行;`codexProxyHost.test.ts` 六处既有断言补 `requestHeaders`。
- 明确不包含:Anthropic bridge / 透明转发路径(`anthropic-compat-proxy` 本就全量透传,Claude Code 不受影响);pi runtime(issue 标注未验证);按上游域名区分是否发送会话头(留给维护者的产品决策,见上);OpenCode 之外的任何协议改动。
- 用户可见变化:经 Codex chat bridge 直连 OpenCode Go 的会话恢复可用;其他 Chat Completions 供应商多收到一个 `x-opencode-session` 与(缺省时)一个 Cindy UA。
- 是否存在 breaking change:无。`handle()` 新入参可选,既有调用方行为不变(不传即不附加会话头)。

### UI 变化

- 引用的设计规范:不涉及:仅主进程代理与 bridge 包的出站请求头,无界面改动。

## 怎么验证的

### 自动验证

```text
packages/responses-chat-bridge: vitest run src/__tests__/session-header.test.ts src/__tests__/handler.test.ts
结果:76/76。新增:
  - session-header:thread-id → x-opencode-session;显式入站头优先且大小写不敏感/去空白;
    parent-thread / authorization / chatgpt-account-id / x-client-request-id 一律不产出会话头;
    非 token 形态(含空格、CRLF 注入、>128 字符)拒绝;UA 缺省补齐、显式 UA 保留。
  - handler(真发请求,fetch mock):入站 thread-id → 上游收到 x-opencode-session,其余入站头
    (authorization / chatgpt-account-id / x-codex-parent-thread-id / x-client-request-id)一个不出网,
    供应商凭证原样;显式入站 x-opencode-session 覆盖 thread-id 与供应商静态同名头;
    无稳定 ID / 未传 requestHeaders 时不附加会话头。

反证:把 handler.ts 回退到 main、保留测试 → 2 例失败(上游收不到会话头);恢复后通过。

apps/desktop: vitest run src/main/maker-host/__tests__/codexProxyHost.test.ts → 213/213
  (六处 chat bridge 断言现在同时验证 requestHeaders === ctx.headers 的透传)
pnpm --dir apps/desktop run typecheck:0 错误;packages/responses-chat-bridge tsc --noEmit:0 错误
pnpm test:unit:related(仓库根):PASS(apps/desktop unit、packages/responses-chat-bridge unit)
git diff --check:通过
```

eslint 对 `codex-proxy-host.ts` 报 3 处 `no-unused-vars` / `prefer-const`(L772 / L3489 / L3570),均为 main 既有问题、不在本次改动行内,未顺手改。

### 手工验证

未接真实 OpenCode Go 账号做端到端复测(本机无该供应商)。请提报人 @eanz 用含本 PR 的构建复核:去掉自定义供应商里手工加的固定 `x-opencode-session` 后,Codex runtime 会话应恢复可用,且同一对话的多次请求带同一个 `x-opencode-session`。

### 未执行的验证

- OpenCode Go 真实端到端。
- pi runtime 是否也需要同类适配(issue 标注未验证,不在本 PR 范围)。

## 风险

### 风险分类

- [ ] 无已知风险
- [ ] SQLite / migration
- [ ] system prompt
- [x] 协议兼容
- [ ] 权限 / 安全 / 用户数据
- [ ] 存量插件兼容(批准状态 / 指纹 / manifest 校验 / 安装布局 / 包格式)
- [ ] 原生层 / fingerprint / OTA
- [ ] 跨平台差异
- [ ] 其他:

### 影响与回滚

- 影响范围:所有经 Codex chat bridge(`wireProtocol: openai-chat`)出网的请求多带一个 `x-opencode-session`(值 = Codex thread-id),以及缺省 UA。未知头按 HTTP 语义应被上游忽略;若某供应商对未知头敏感,可在 `resolveConversationSessionHeaders` 单一收口点加 provider 级开关。
- 安全边界:bridge 只从入站头解析一个 token 形态的会话 ID,不透传任何其他入站头;凭证隔离逻辑未动,测试断言 authorization / 账号头不出网。
- 回滚 / 降级方式:revert 本 PR 单个 commit;或在 `codex-proxy-host.ts` 不传 `requestHeaders` 即回到原行为。
