### PR TITLE
test: 覆盖兼容同源 Codex 会话并行

### DIFF
--- a/packages/maker-core/src/agents/codex/index.test.ts
+++ b/packages/maker-core/src/agents/codex/index.test.ts
@@ -7709,6 +7709,43 @@ describe('CodexAgent MCP thread context hooks', () => {
     await agent.dispose();
   });
 
+  it('reuses an active host for concurrent compatible provider OAuth sessions', async () => {
+    const prepareCodexLocalCredentialModeSwitch = vi.fn(async () => {});
+    const prepareCodexExtraSpawnConfig: NonNullable<AgentDeps['prepareCodexExtraSpawnConfig']> =
+      vi.fn(async () => ({
+        extraArgs: [],
+        extraEnv: {},
+        codexProxyActive: true,
+        codexSubagentRoutingProfile: 'default' as const,
+      }));
+    const agent = new CodexAgent(createDeps({}, {
+      prepareCodexExtraSpawnConfig,
+      prepareCodexLocalCredentialModeSwitch,
+    }));
+
+    const first = await agent.startSession({
+      sessionId: 'session-provider-oauth-concurrent-1',
+      providerId: 'xai',
+      model: 'xai/grok-4.3',
+      workingDir: '/repo-xai-1',
+    });
+    const second = await agent.startSession({
+      sessionId: 'session-provider-oauth-concurrent-2',
+      providerId: 'xai',
+      model: 'xai/grok-4.3',
+      workingDir: '/repo-xai-2',
+    });
+
+    expect(createdTransports).toHaveLength(1);
+    expect(createdTransports[0].closed).toBe(false);
+    expect(prepareCodexLocalCredentialModeSwitch).not.toHaveBeenCalled();
+
+    await second.close();
+    expect(createdTransports[0].closed).toBe(false);
+    await first.close();
+    await agent.dispose();
+  });
+
   it('rebuilds an idle smart host when its routing signature changes', async () => {
     let routingSignature = 'smart:1';
     const prepareCodexExtraSpawnConfig: NonNullable<AgentDeps['prepareCodexExtraSpawnConfig']> =


### PR DESCRIPTION
## 目的
补充回归测试，锁定同一号池且运行配置兼容的多个本地 Codex 会话可以并行复用同一个 host。

## 改动
- 增加两个活跃兼容 provider-oauth 会话的并行回归测试。
- 断言只创建一个 transport。
- 断言不会误调用 credential switch coordinator。
- 断言关闭其中一个会话不会关闭仍在使用的 host。

## 验证
- maker-core：708/708 通过。
- desktop 定向回归：157/157 通过。
- required unit：通过；test:runner 504 passed、0 failed、1 skipped。
- e2e tester worker：PASS。

## 范围
本 PR 不修改 host 生命周期逻辑、不绕过活跃任务保护、不改变用户配置。等待文案的 UI 修改另行处理。