### PR TITLE
fix(desktop): Codex live 模型清单对 registry 未收录模型回填 models_cache 明示的上下文窗口(Refs #4087)

### DIFF
--- a/apps/desktop/src/main/maker-host/__tests__/codexModelDiscovery.test.ts
+++ b/apps/desktop/src/main/maker-host/__tests__/codexModelDiscovery.test.ts
@@ -291,86 +291,116 @@ describe('mergeCodexLiveModelsWithCache (#4087)', () => {
     });
     expect(unverifiedCache[0].contextWindowVerified).toBeUndefined();
     expect(mergeCodexLiveModelsWithCache(live, unverifiedCache)).toBe(live);
+    // 有明示窗口但没有任何 slug 命中 → 同一引用(调用方据此跳过二次发布)
+    const unrelated = mapCodexModelsToCatalog({
+      models: [{ slug: 'gpt-unrelated', display_name: 'x', visibility: 'list', supported_in_api: true, context_window: 400000, supported_reasoning_levels: [{ effort: 'high' }] }],
+    });
+    expect(mergeCodexLiveModelsWithCache(live, unrelated)).toBe(live);
   });
 });
 
-describe('createCodexLiveModelsPublisher (#4087 review: 异步读 cache 后的新鲜度与读取上限)', () => {
+describe('createCodexLiveModelsPublisher (#4087 review: 两阶段发布、新鲜度与读取上限)', () => {
   const liveItem = (slug: string): CodexModelListItem =>
     ({
       id: slug, model: slug, displayName: slug, description: '', hidden: false,
       supportedReasoningEfforts: [{ reasoningEffort: 'high', description: '' }],
       defaultReasoningEffort: 'high', additionalSpeedTiers: [], serviceTiers: [], isDefault: false,
     }) as CodexModelListItem;
-  const verifiedCache = mapCodexModelsToCatalog({
-    models: [{ slug: 'gpt-5.6-luna', display_name: 'GPT-5.6-Luna', visibility: 'list', supported_in_api: true, context_window: 1_100_000, supported_reasoning_levels: [{ effort: 'high' }] }],
+  const cacheFor = (...slugs: string[]) => mapCodexModelsToCatalog({
+    models: slugs.map((slug) => ({ slug, display_name: slug, visibility: 'list', supported_in_api: true, context_window: 1_100_000, supported_reasoning_levels: [{ effort: 'high' }] })),
   });
+  const verifiedCache = cacheFor('gpt-5.6-luna');
   const deferred = <T,>() => {
     let resolve!: (value: T) => void;
     const promise = new Promise<T>((r) => { resolve = r; });
     return { promise, resolve };
   };
+  const ids = (call: unknown[]) => (call[0] as { id: string; contextWindow: number }[]).map((m) => `${m.id}:${m.contextWindow}`);
 
-  it('正常路径:读到 cache 即发布回填后的快照', async () => {
+  it('第一阶段同步发布 live 快照,回调返回的 Promise 不等 cache 读取(不占 model/list 的 deadline)', async () => {
     const publish = vi.fn();
-    let epoch = 7;
+    const read = deferred<null>(); // 永不 resolve:模拟 cache 读取卡住
+    const publisher = createCodexLiveModelsPublisher({
+      readCache: () => read.promise,
+      publish,
+      authEpoch: () => 1,
+      cacheReadTimeoutMs: 60_000,
+    });
+    const pending = publisher([liveItem('gpt-5.6-luna')]);
+    // 还没让出事件循环,live 已经发布
+    expect(publish).toHaveBeenCalledOnce();
+    expect(ids(publish.mock.calls[0])).toEqual(['gpt-5.6-luna:272000']);
+    await expect(Promise.race([pending.then(() => 'resolved'), new Promise((r) => setTimeout(() => r('timeout'), 50))]))
+      .resolves.toBe('resolved');
+  });
+
+  it('第二阶段读到 cache 后按 slug 回填真实窗口并二次发布;回填不到任何 slug 时不发二次', async () => {
+    const publish = vi.fn();
     const publisher = createCodexLiveModelsPublisher({
       readCache: async () => verifiedCache,
       publish,
-      authEpoch: () => epoch,
+      authEpoch: () => 7,
     });
     await publisher([liveItem('gpt-5.6-luna'), liveItem('gpt-5.5')]);
-    expect(publish).toHaveBeenCalledOnce();
-    const published = publish.mock.calls[0][0] as ReturnType<typeof mapCodexAppServerModelsToCatalog>;
-    expect(published.map((m) => [m.id, m.contextWindow, m.contextWindowVerified])).toEqual([
-      ['gpt-5.6-luna', 1_100_000, true],
-      ['gpt-5.5', 272_000, undefined],
-    ]);
+    await vi.waitFor(() => expect(publish).toHaveBeenCalledTimes(2));
+    expect(ids(publish.mock.calls[0])).toEqual(['gpt-5.6-luna:272000', 'gpt-5.5:272000']);
+    expect(ids(publish.mock.calls[1])).toEqual(['gpt-5.6-luna:1100000', 'gpt-5.5:272000']);
+    expect((publish.mock.calls[1][0] as { contextWindowVerified?: boolean }[])[0].contextWindowVerified).toBe(true);
+
+    const noHit = vi.fn();
+    const publisher2 = createCodexLiveModelsPublisher({
+      readCache: async () => cacheFor('gpt-unrelated'),
+      publish: noHit,
+      authEpoch: () => 7,
+    });
+    await publisher2([liveItem('gpt-5.5')]);
+    await new Promise((r) => setTimeout(r, 10));
+    expect(noHit).toHaveBeenCalledOnce();
   });
 
-  it('读 cache 期间鉴权代次变化(登出/换号/凭证失效)→ 丢弃本次 live 清单,不发布旧账号模型', async () => {
+  it('读 cache 期间鉴权代次变化(登出/换号/凭证失效/resetMaker)→ 丢弃回填,不发布旧账号清单', async () => {
     const publish = vi.fn();
     const log = { info: vi.fn() };
     let epoch = 1;
-    const read = deferred<null>();
+    const read = deferred<typeof verifiedCache>();
     const publisher = createCodexLiveModelsPublisher({
       readCache: () => read.promise,
       publish,
       authEpoch: () => epoch,
       log,
     });
-    const pending = publisher([liveItem('gpt-5.6-luna')]);
-    epoch = 2; // 账号收口:refreshDiscoveredCodexModels 已清空目录
-    read.resolve(null);
-    await pending;
-    expect(publish).not.toHaveBeenCalled();
-    expect(log.info).toHaveBeenCalledWith(
+    await publisher([liveItem('gpt-5.6-luna')]);
+    expect(publish).toHaveBeenCalledOnce(); // 第一阶段(进入回调时 host 仍有效)
+    epoch = 2; // 账号收口:refreshDiscoveredCodexModels / resetMaker 已推进代次
+    read.resolve(verifiedCache);
+    await vi.waitFor(() => expect(log.info).toHaveBeenCalledWith(
       expect.stringContaining('auth boundary changed'),
       expect.objectContaining({ epoch: 1, current: 2 }),
-    );
+    ));
+    expect(publish).toHaveBeenCalledOnce();
   });
 
-  it('并发回调:只有最后进入的清单会发布,较旧的清单即使后完成也不覆盖', async () => {
+  it('并发回调:只有最后进入的清单会做二次发布,较旧的回填即使后完成也不覆盖', async () => {
     const publish = vi.fn();
-    const first = deferred<null>();
-    const second = deferred<null>();
+    const first = deferred<typeof verifiedCache>();
+    const second = deferred<typeof verifiedCache>();
     const reads = [first.promise, second.promise];
     const publisher = createCodexLiveModelsPublisher({
       readCache: () => reads.shift() ?? Promise.resolve(null),
       publish,
       authEpoch: () => 1,
     });
-    const older = publisher([liveItem('gpt-old')]);
-    const newer = publisher([liveItem('gpt-new')]);
-    // 新的先完成 → 发布;旧的后完成 → 序号已过期,丢弃
-    second.resolve(null);
-    await newer;
-    first.resolve(null);
-    await older;
-    expect(publish).toHaveBeenCalledOnce();
-    expect((publish.mock.calls[0][0] as { id: string }[]).map((m) => m.id)).toEqual(['gpt-new']);
+    await publisher([liveItem('gpt-old')]);
+    await publisher([liveItem('gpt-new')]);
+    expect(publish.mock.calls.map(ids)).toEqual([['gpt-old:272000'], ['gpt-new:272000']]);
+    second.resolve(cacheFor('gpt-new'));
+    await vi.waitFor(() => expect(publish).toHaveBeenCalledTimes(3));
+    first.resolve(cacheFor('gpt-old'));
+    await new Promise((r) => setTimeout(r, 10));
+    expect(publish.mock.calls.map(ids)).toEqual([['gpt-old:272000'], ['gpt-new:272000'], ['gpt-new:1100000']]);
   });
 
-  it('cache 读取超时 → 在独立上限内原样发布 live 快照,不拖累 model/list 的 deadline', async () => {
+  it('cache 读取超时 → 只保留第一阶段的 live 快照,不再二次发布', async () => {
     vi.useFakeTimers();
     try {
       const publish = vi.fn();
@@ -380,11 +410,11 @@ describe('createCodexLiveModelsPublisher (#4087 review: 异步读 cache 后的�
         authEpoch: () => 1,
         cacheReadTimeoutMs: 100,
       });
-      const pending = publisher([liveItem('gpt-5.6-luna')]);
+      await publisher([liveItem('gpt-5.6-luna')]);
       await vi.advanceTimersByTimeAsync(100);
-      await pending;
+      await vi.advanceTimersByTimeAsync(10);
       expect(publish).toHaveBeenCalledOnce();
-      expect((publish.mock.calls[0][0] as { contextWindow: number }[])[0].contextWindow).toBe(272_000);
+      expect(ids(publish.mock.calls[0])).toEqual(['gpt-5.6-luna:272000']);
     } finally {
       vi.useRealTimers();
     }

--- a/apps/desktop/src/main/maker-host/__tests__/codexModelDiscovery.test.ts
+++ b/apps/desktop/src/main/maker-host/__tests__/codexModelDiscovery.test.ts
@@ -14,10 +14,14 @@ vi.mock('electron', () => ({ app: { getPath: () => '/tmp/xdt-codex-model-discove
 vi.mock('node:fs/promises', () => ({ default: { readFile: vi.fn() } }));
 
 import {
+  bumpCodexDiscoveryAuthEpoch,
+  createCodexLiveModelsPublisher,
+  getCodexDiscoveryAuthEpoch,
   mapCodexModelsToCatalog,
   mapCodexAppServerModelsToCatalog,
   mergeCodexLiveModelsWithCache,
   readCodexDiscoveredModels,
+  readCodexDiscoveredModelsBounded,
   readCodexDiscoveredModelsForAuthRefresh,
 } from '../codex-model-discovery.js';
 
@@ -287,6 +291,118 @@ describe('mergeCodexLiveModelsWithCache (#4087)', () => {
     });
     expect(unverifiedCache[0].contextWindowVerified).toBeUndefined();
     expect(mergeCodexLiveModelsWithCache(live, unverifiedCache)).toBe(live);
+  });
+});
+
+describe('createCodexLiveModelsPublisher (#4087 review: 异步读 cache 后的新鲜度与读取上限)', () => {
+  const liveItem = (slug: string): CodexModelListItem =>
+    ({
+      id: slug, model: slug, displayName: slug, description: '', hidden: false,
+      supportedReasoningEfforts: [{ reasoningEffort: 'high', description: '' }],
+      defaultReasoningEffort: 'high', additionalSpeedTiers: [], serviceTiers: [], isDefault: false,
+    }) as CodexModelListItem;
+  const verifiedCache = mapCodexModelsToCatalog({
+    models: [{ slug: 'gpt-5.6-luna', display_name: 'GPT-5.6-Luna', visibility: 'list', supported_in_api: true, context_window: 1_100_000, supported_reasoning_levels: [{ effort: 'high' }] }],
+  });
+  const deferred = <T,>() => {
+    let resolve!: (value: T) => void;
+    const promise = new Promise<T>((r) => { resolve = r; });
+    return { promise, resolve };
+  };
+
+  it('正常路径:读到 cache 即发布回填后的快照', async () => {
+    const publish = vi.fn();
+    let epoch = 7;
+    const publisher = createCodexLiveModelsPublisher({
+      readCache: async () => verifiedCache,
+      publish,
+      authEpoch: () => epoch,
+    });
+    await publisher([liveItem('gpt-5.6-luna'), liveItem('gpt-5.5')]);
+    expect(publish).toHaveBeenCalledOnce();
+    const published = publish.mock.calls[0][0] as ReturnType<typeof mapCodexAppServerModelsToCatalog>;
+    expect(published.map((m) => [m.id, m.contextWindow, m.contextWindowVerified])).toEqual([
+      ['gpt-5.6-luna', 1_100_000, true],
+      ['gpt-5.5', 272_000, undefined],
+    ]);
+  });
+
+  it('读 cache 期间鉴权代次变化(登出/换号/凭证失效)→ 丢弃本次 live 清单,不发布旧账号模型', async () => {
+    const publish = vi.fn();
+    const log = { info: vi.fn() };
+    let epoch = 1;
+    const read = deferred<null>();
+    const publisher = createCodexLiveModelsPublisher({
+      readCache: () => read.promise,
+      publish,
+      authEpoch: () => epoch,
+      log,
+    });
+    const pending = publisher([liveItem('gpt-5.6-luna')]);
+    epoch = 2; // 账号收口:refreshDiscoveredCodexModels 已清空目录
+    read.resolve(null);
+    await pending;
+    expect(publish).not.toHaveBeenCalled();
+    expect(log.info).toHaveBeenCalledWith(
+      expect.stringContaining('auth boundary changed'),
+      expect.objectContaining({ epoch: 1, current: 2 }),
+    );
+  });
+
+  it('并发回调:只有最后进入的清单会发布,较旧的清单即使后完成也不覆盖', async () => {
+    const publish = vi.fn();
+    const first = deferred<null>();
+    const second = deferred<null>();
+    const reads = [first.promise, second.promise];
+    const publisher = createCodexLiveModelsPublisher({
+      readCache: () => reads.shift() ?? Promise.resolve(null),
+      publish,
+      authEpoch: () => 1,
+    });
+    const older = publisher([liveItem('gpt-old')]);
+    const newer = publisher([liveItem('gpt-new')]);
+    // 新的先完成 → 发布;旧的后完成 → 序号已过期,丢弃
+    second.resolve(null);
+    await newer;
+    first.resolve(null);
+    await older;
+    expect(publish).toHaveBeenCalledOnce();
+    expect((publish.mock.calls[0][0] as { id: string }[]).map((m) => m.id)).toEqual(['gpt-new']);
+  });
+
+  it('cache 读取超时 → 在独立上限内原样发布 live 快照,不拖累 model/list 的 deadline', async () => {
+    vi.useFakeTimers();
+    try {
+      const publish = vi.fn();
+      const publisher = createCodexLiveModelsPublisher({
+        readCache: () => new Promise(() => {}), // 永不返回:模拟文件系统卡住
+        publish,
+        authEpoch: () => 1,
+        cacheReadTimeoutMs: 100,
+      });
+      const pending = publisher([liveItem('gpt-5.6-luna')]);
+      await vi.advanceTimersByTimeAsync(100);
+      await pending;
+      expect(publish).toHaveBeenCalledOnce();
+      expect((publish.mock.calls[0][0] as { contextWindow: number }[])[0].contextWindow).toBe(272_000);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it('readCodexDiscoveredModelsBounded:读取抛错也归一为 null,不让回填决定刷新成败', async () => {
+    await expect(
+      readCodexDiscoveredModelsBounded(() => Promise.reject(new Error('EIO')), 50),
+    ).resolves.toBeNull();
+    await expect(
+      readCodexDiscoveredModelsBounded(async () => verifiedCache, 50),
+    ).resolves.toBe(verifiedCache);
+  });
+
+  it('bumpCodexDiscoveryAuthEpoch 单调递增并可读回', () => {
+    const before = getCodexDiscoveryAuthEpoch();
+    expect(bumpCodexDiscoveryAuthEpoch()).toBe(before + 1);
+    expect(getCodexDiscoveryAuthEpoch()).toBe(before + 1);
   });
 });
 

--- a/apps/desktop/src/main/maker-host/__tests__/codexModelDiscovery.test.ts
+++ b/apps/desktop/src/main/maker-host/__tests__/codexModelDiscovery.test.ts
@@ -16,6 +16,7 @@ vi.mock('node:fs/promises', () => ({ default: { readFile: vi.fn() } }));
 import {
   mapCodexModelsToCatalog,
   mapCodexAppServerModelsToCatalog,
+  mergeCodexLiveModelsWithCache,
   readCodexDiscoveredModels,
   readCodexDiscoveredModelsForAuthRefresh,
 } from '../codex-model-discovery.js';
@@ -229,6 +230,63 @@ describe('mapCodexAppServerModelsToCatalog', () => {
     // live 协议不给 context_window,这 272k 是统一兜底 → 一律不得标记为已核实。
     // 标了它就会被拿去收敛运行期上报的窗口,把真实更大的窗口压成 272k。
     expect(out.every((model) => model.contextWindowVerified === undefined)).toBe(true);
+  });
+});
+
+describe('mergeCodexLiveModelsWithCache (#4087)', () => {
+  const liveItem = (slug: string, displayName: string): CodexModelListItem =>
+    ({
+      id: slug, model: slug, displayName, description: '', hidden: false,
+      supportedReasoningEfforts: [{ reasoningEffort: 'high', description: '' }],
+      defaultReasoningEffort: 'high', additionalSpeedTiers: [], serviceTiers: [], isDefault: false,
+    }) as CodexModelListItem;
+
+  it('刷新走 live 清单时按 slug 回填 cache 明示的真实 context_window,不再退回 272k 兜底', () => {
+    // 首次加载:cache 明示 luna 1.1M(verified)。之后「刷新模型信息」走 live,协议不带窗口。
+    const cache = mapCodexModelsToCatalog({
+      models: [
+        { slug: 'gpt-5.6-luna', display_name: 'GPT-5.6-Luna', visibility: 'list', supported_in_api: true, context_window: 1_100_000, priority: 3, supported_reasoning_levels: [{ effort: 'high' }] },
+        { slug: 'gpt-5.5', display_name: 'GPT-5.5', visibility: 'list', supported_in_api: true, context_window: 272000, priority: 7, supported_reasoning_levels: [{ effort: 'high' }] },
+        { slug: 'gpt-5.4-mini', display_name: 'GPT-5.4 Mini', visibility: 'list', supported_in_api: true, context_window: 128000, priority: 23, supported_reasoning_levels: [{ effort: 'high' }] },
+        // cache 里有、live 已下架:不得凭 cache 复活
+        { slug: 'gpt-retired', display_name: 'Retired', visibility: 'list', supported_in_api: true, context_window: 400000, priority: 30, supported_reasoning_levels: [{ effort: 'high' }] },
+      ],
+    });
+    const live = mapCodexAppServerModelsToCatalog([
+      liveItem('gpt-5.6-luna', 'GPT-5.6-Luna'),
+      liveItem('gpt-5.5', 'GPT-5.5'),
+      liveItem('gpt-5.4-mini', 'GPT-5.4 Mini'),
+      // live 新上、cache 还没落盘的模型:保留 272k 兜底且不标 verified
+      liveItem('gpt-5.7', 'GPT-5.7'),
+    ]);
+
+    const merged = mergeCodexLiveModelsWithCache(live, cache);
+
+    // 成员与顺序以 live 为准(含 live 的 sortOrder 锚点),cache 独有的模型不复活
+    expect(merged.map((m) => m.id)).toEqual(['gpt-5.6-luna', 'gpt-5.5', 'gpt-5.4-mini', 'gpt-5.7']);
+    expect(merged.map((m) => m.sortOrder)).toEqual(live.map((m) => m.sortOrder));
+    // 真实窗口回填:1.1M 不再变 272k;更小的 128k 同样照搬(窗口以数据源为准,不做"只升不降")
+    expect(merged[0]).toMatchObject({ contextWindow: 1_100_000, contextWindowVerified: true });
+    expect(merged[1]).toMatchObject({ contextWindow: 272_000, contextWindowVerified: true });
+    expect(merged[2]).toMatchObject({ contextWindow: 128_000, contextWindowVerified: true });
+    // live 独有:仍是兜底值,不得被标成已核实
+    expect(merged[3].contextWindow).toBe(272_000);
+    expect(merged[3].contextWindowVerified).toBeUndefined();
+    // 其余能力字段仍来自 live(effort 白名单等),不被 cache 覆盖
+    expect(merged[0].efforts).toEqual(live[0].efforts);
+    expect(merged[0].defaultEnabled).toBe(true);
+  });
+
+  it('cache 缺失 / 为空 / 没有明示窗口时原样返回 live 快照', () => {
+    const live = mapCodexAppServerModelsToCatalog([liveItem('gpt-5.6-luna', 'GPT-5.6-Luna')]);
+    expect(mergeCodexLiveModelsWithCache(live, null)).toBe(live);
+    expect(mergeCodexLiveModelsWithCache(live, [])).toBe(live);
+    // cache 条目没标 verified(例如 cache 也缺 context_window 只给了 272k 兜底)→ 不回填
+    const unverifiedCache = mapCodexModelsToCatalog({
+      models: [{ slug: 'gpt-5.6-luna', display_name: 'GPT-5.6-Luna', visibility: 'list', supported_in_api: true, supported_reasoning_levels: [{ effort: 'high' }] }],
+    });
+    expect(unverifiedCache[0].contextWindowVerified).toBeUndefined();
+    expect(mergeCodexLiveModelsWithCache(live, unverifiedCache)).toBe(live);
   });
 });
 

--- a/apps/desktop/src/main/maker-host/codex-model-discovery.ts
+++ b/apps/desktop/src/main/maker-host/codex-model-discovery.ts
@@ -246,6 +246,92 @@ export function mergeCodexLiveModelsWithCache(
   });
 }
 
+/**
+ * Codex 目录的「鉴权代次」:每次走鉴权边界重读/清空快照(登录、登出、凭证失效、auth 模式切换)
+ * 时 +1。live `model/list` 回调在异步读 cache 前后比对它,代次变了就丢弃本次结果——
+ * 旧账号的 live 清单绝不能在账号收口之后再被发布回目录(Greptile / Codex review P1)。
+ */
+let codexDiscoveryAuthEpoch = 0;
+
+export function bumpCodexDiscoveryAuthEpoch(): number {
+  codexDiscoveryAuthEpoch += 1;
+  return codexDiscoveryAuthEpoch;
+}
+
+export function getCodexDiscoveryAuthEpoch(): number {
+  return codexDiscoveryAuthEpoch;
+}
+
+/** live 回填时允许等待 cache 读取的上限;超时直接发布 live 快照,不拖累 model/list 的整体 deadline。 */
+export const CODEX_LIVE_CACHE_READ_TIMEOUT_MS = 1_500;
+
+/**
+ * 有上限的 cache 读取:超时 / 抛错都返回 null(= 没读到,原样用 live)。挂起的读取继续跑完
+ * 但结果被丢弃;定时器 unref,不阻塞进程退出。
+ */
+export async function readCodexDiscoveredModelsBounded(
+  read: () => Promise<CatalogModel[] | null>,
+  timeoutMs: number,
+): Promise<CatalogModel[] | null> {
+  let timer: ReturnType<typeof setTimeout> | undefined;
+  const timeout = new Promise<null>((resolve) => {
+    timer = setTimeout(() => resolve(null), timeoutMs);
+    timer.unref?.();
+  });
+  try {
+    return await Promise.race([read().catch(() => null), timeout]);
+  } finally {
+    if (timer !== undefined) clearTimeout(timer);
+  }
+}
+
+export interface CodexLiveModelsPublisherDeps {
+  /** 读 Cindy 自管 models_cache(生产 = readCodexDiscoveredModels);null = 没读到。 */
+  readCache: () => Promise<CatalogModel[] | null>;
+  /** 发布合并后的快照(生产 = setDiscoveredCodexModels)。 */
+  publish: (models: CatalogModel[]) => void;
+  /** 当前鉴权代次(生产 = getCodexDiscoveryAuthEpoch)。 */
+  authEpoch: () => number;
+  cacheReadTimeoutMs?: number;
+  log?: { info?: (msg: string, meta?: Record<string, unknown>) => void };
+}
+
+/**
+ * 构造 `onCodexLocalModelsListed` 的宿主实现(#4087)。
+ *
+ * maker-core 只在**进入**回调前校验来源 host 仍是当前 host;本实现为了回填真实窗口要
+ * 异步读 cache,让出事件循环后账号可能已经收口、也可能有更新的 live 清单进来。因此发布前
+ * 再做两道新鲜度校验,任一不满足就丢弃本次结果:
+ *   1. 序号:本回调仍是最后一次进入的回调(更新的 live 清单永远赢,旧清单不覆盖新清单);
+ *   2. 鉴权代次:读 cache 期间没有发生登录/登出/凭证失效(旧账号清单不复活)。
+ * cache 读取有独立上限(默认 1.5s),超时/失败原样发布 live 快照;回填只是增强,不决定
+ * live 刷新的成败。
+ */
+export function createCodexLiveModelsPublisher(
+  deps: CodexLiveModelsPublisherDeps,
+): (models: readonly CodexModelListItem[]) => Promise<void> {
+  let latestSeq = 0;
+  const timeoutMs = deps.cacheReadTimeoutMs ?? CODEX_LIVE_CACHE_READ_TIMEOUT_MS;
+  return async (models) => {
+    const seq = ++latestSeq;
+    const epoch = deps.authEpoch();
+    const live = mapCodexAppServerModelsToCatalog(models);
+    const cached = await readCodexDiscoveredModelsBounded(deps.readCache, timeoutMs);
+    if (seq !== latestSeq) {
+      deps.log?.info?.('codex live model list superseded by a newer snapshot; discarded', { seq, latestSeq });
+      return;
+    }
+    if (epoch !== deps.authEpoch()) {
+      deps.log?.info?.('codex live model list discarded: auth boundary changed during cache read', {
+        epoch,
+        current: deps.authEpoch(),
+      });
+      return;
+    }
+    deps.publish(mergeCodexLiveModelsWithCache(live, cached));
+  };
+}
+
 /** Cindy 自管的 Codex home；系统 ~/.codex 属于独立登录边界，不能混读其账号缓存。 */
 function desktopCodexHome(): string {
   return path.join(app.getPath('userData'), 'codex-home');

--- a/apps/desktop/src/main/maker-host/codex-model-discovery.ts
+++ b/apps/desktop/src/main/maker-host/codex-model-discovery.ts
@@ -216,6 +216,36 @@ export function mapCodexAppServerModelsToCatalog(
   return out;
 }
 
+/**
+ * live `model/list` 快照 + models_cache 派生快照 → 合并后的规范化目录(#4087)。
+ *
+ * live 决定成员与顺序(它是当前账号的权威清单),但 live 协议不带 `context_window`,
+ * mapper 只能写 272k 兜底;若整份替换 cache 派生快照,首次加载时 cache 明示的真实窗口
+ * (例如 1.1M)会在「刷新模型信息」/ 登录补拉后退回 272k,展示上限与计数器分母一起变。
+ * 这里只回填 cache 里同 slug **明示**的 context_window(带 contextWindowVerified),
+ * 其余字段仍以 live 为准;cache 缺失 / 该 slug 不在 cache 时保留 live 的兜底值。
+ * 不做「刷新不得降低窗口」:cache 明示更小的窗口同样照搬,窗口以数据源为准。
+ */
+export function mergeCodexLiveModelsWithCache(
+  live: CatalogModel[],
+  cache: CatalogModel[] | null,
+): CatalogModel[] {
+  if (!cache || cache.length === 0) return live;
+  const verifiedById = new Map<string, number>();
+  for (const model of cache) {
+    if (model.contextWindowVerified === true && typeof model.contextWindow === 'number') {
+      verifiedById.set(model.id, model.contextWindow);
+    }
+  }
+  if (verifiedById.size === 0) return live;
+  return live.map((model) => {
+    const contextWindow = verifiedById.get(model.id);
+    return contextWindow === undefined
+      ? model
+      : { ...model, contextWindow, contextWindowVerified: true };
+  });
+}
+
 /** Cindy 自管的 Codex home；系统 ~/.codex 属于独立登录边界，不能混读其账号缓存。 */
 function desktopCodexHome(): string {
   return path.join(app.getPath('userData'), 'codex-home');

--- a/apps/desktop/src/main/maker-host/codex-model-discovery.ts
+++ b/apps/desktop/src/main/maker-host/codex-model-discovery.ts
@@ -238,12 +238,15 @@ export function mergeCodexLiveModelsWithCache(
     }
   }
   if (verifiedById.size === 0) return live;
-  return live.map((model) => {
+  let changed = false;
+  const merged = live.map((model) => {
     const contextWindow = verifiedById.get(model.id);
-    return contextWindow === undefined
-      ? model
-      : { ...model, contextWindow, contextWindowVerified: true };
+    if (contextWindow === undefined) return model;
+    changed = true;
+    return { ...model, contextWindow, contextWindowVerified: true };
   });
+  // 没有任何 slug 被回填时返回同一引用,调用方可据此跳过多余的二次发布。
+  return changed ? merged : live;
 }
 
 /**
@@ -297,15 +300,16 @@ export interface CodexLiveModelsPublisherDeps {
 }
 
 /**
- * 构造 `onCodexLocalModelsListed` 的宿主实现(#4087)。
+ * 构造 `onCodexLocalModelsListed` 的宿主实现(#4087)。两阶段发布:
  *
- * maker-core 只在**进入**回调前校验来源 host 仍是当前 host;本实现为了回填真实窗口要
- * 异步读 cache,让出事件循环后账号可能已经收口、也可能有更新的 live 清单进来。因此发布前
- * 再做两道新鲜度校验,任一不满足就丢弃本次结果:
- *   1. 序号:本回调仍是最后一次进入的回调(更新的 live 清单永远赢,旧清单不覆盖新清单);
- *   2. 鉴权代次:读 cache 期间没有发生登录/登出/凭证失效(旧账号清单不复活)。
- * cache 读取有独立上限(默认 1.5s),超时/失败原样发布 live 快照;回填只是增强,不决定
- * live 刷新的成败。
+ *   1. **同步**发布 live 快照(与本修复之前完全一致):maker-core 在 `refreshLocalModels`
+ *      的 20s deadline 内 await 本回调,live 刷新的成败不能被 cache 读取拖累,所以返回的
+ *      Promise 在这一步就 resolve。
+ *   2. **异步**增强:有上限地读 cache(默认 1.5s),按 slug 回填真实窗口后再发布一次;
+ *      回填不到任何 slug 时不发二次。发布前做两道新鲜度校验,任一不满足即丢弃:
+ *      - 序号:本回调仍是最后一次进入的回调(更新的 live 清单永远赢,旧清单不覆盖新清单);
+ *      - 鉴权代次:读 cache 期间没有发生登录/登出/凭证失效/换账号(旧账号清单不复活)。
+ *      maker-core 只在**进入**回调前校验来源 host,让出事件循环后的这两道校验由这里补上。
  */
 export function createCodexLiveModelsPublisher(
   deps: CodexLiveModelsPublisherDeps,
@@ -316,19 +320,30 @@ export function createCodexLiveModelsPublisher(
     const seq = ++latestSeq;
     const epoch = deps.authEpoch();
     const live = mapCodexAppServerModelsToCatalog(models);
-    const cached = await readCodexDiscoveredModelsBounded(deps.readCache, timeoutMs);
-    if (seq !== latestSeq) {
-      deps.log?.info?.('codex live model list superseded by a newer snapshot; discarded', { seq, latestSeq });
-      return;
-    }
-    if (epoch !== deps.authEpoch()) {
-      deps.log?.info?.('codex live model list discarded: auth boundary changed during cache read', {
-        epoch,
-        current: deps.authEpoch(),
+    deps.publish(live);
+    void (async () => {
+      const cached = await readCodexDiscoveredModelsBounded(deps.readCache, timeoutMs);
+      if (seq !== latestSeq) {
+        deps.log?.info?.('codex live model list backfill superseded by a newer snapshot; discarded', {
+          seq,
+          latestSeq,
+        });
+        return;
+      }
+      if (epoch !== deps.authEpoch()) {
+        deps.log?.info?.('codex live model list backfill discarded: auth boundary changed during cache read', {
+          epoch,
+          current: deps.authEpoch(),
+        });
+        return;
+      }
+      const merged = mergeCodexLiveModelsWithCache(live, cached);
+      if (merged !== live) deps.publish(merged);
+    })().catch((error: unknown) => {
+      deps.log?.info?.('codex live model list backfill failed; live snapshot already published', {
+        error: error instanceof Error ? error.message : String(error),
       });
-      return;
-    }
-    deps.publish(mergeCodexLiveModelsWithCache(live, cached));
+    });
   };
 }
 

--- a/apps/desktop/src/main/maker-host/createDesktopProviderService.ts
+++ b/apps/desktop/src/main/maker-host/createDesktopProviderService.ts
@@ -61,6 +61,7 @@ import {
 import { readModelCatalogOverrides } from './model-catalog-override-store.js';
 import {
   readCodexDiscoveredModels,
+  bumpCodexDiscoveryAuthEpoch,
   readCodexDiscoveredModelsForAuthRefresh,
 } from './codex-model-discovery.js';
 import {
@@ -743,6 +744,8 @@ export async function refreshDiscoveredCodexModels(
   authenticated = true,
   shouldApply: () => boolean = () => true,
 ): Promise<void> {
+  // 鉴权边界:让仍在异步读 cache 的 live model/list 回调作废(旧账号清单不得在此之后发布)。
+  bumpCodexDiscoveryAuthEpoch();
   if (!authenticated) {
     if (shouldApply()) setDiscoveredCodexModels([]);
     return;

--- a/apps/desktop/src/main/maker-host/index.ts
+++ b/apps/desktop/src/main/maker-host/index.ts
@@ -314,8 +314,8 @@ import {
   getDesktopMcpToolApprovalPresentation,
 } from './mcp-tool-approval-policy.js';
 import {
-  mapCodexAppServerModelsToCatalog,
-  mergeCodexLiveModelsWithCache,
+  createCodexLiveModelsPublisher,
+  getCodexDiscoveryAuthEpoch,
   readCodexDiscoveredModels,
 } from './codex-model-discovery.js';
 import { prepareSharedProjectSkillLinks } from './shared-global-skills.js';
@@ -1410,15 +1410,15 @@ export function getMaker(): Maker {
           getDesktopSelectableCatalog(), 'codex', source, modelId,
         );
       },
-      onCodexLocalModelsListed: async (models) => {
-        // live 清单定成员与顺序;真实 context_window 只有 models_cache 明示,按 slug 回填,
-        // 否则「刷新模型信息」会把首次加载的 1.1M 退回 272k 兜底(#4087)。cache 读失败
-        // 返回 null → 原样使用 live 快照,不阻塞目录发布。
-        const cached = await readCodexDiscoveredModels();
-        setDiscoveredCodexModels(
-          mergeCodexLiveModelsWithCache(mapCodexAppServerModelsToCatalog(models), cached),
-        );
-      },
+      // live 清单定成员与顺序;真实 context_window 只有 models_cache 明示,按 slug 回填,
+      // 否则「刷新模型信息」会把首次加载的 1.1M 退回 272k 兜底(#4087)。异步读 cache 后
+      // 的新鲜度(序号 + 鉴权代次)与读取上限见 createCodexLiveModelsPublisher。
+      onCodexLocalModelsListed: createCodexLiveModelsPublisher({
+        readCache: readCodexDiscoveredModels,
+        publish: setDiscoveredCodexModels,
+        authEpoch: getCodexDiscoveryAuthEpoch,
+        log: desktopMakerLogger,
+      }),
       // 「后端不可达」终局升级时读一次本次请求的出站路径判定,把通用猜测换成实测事实。
       // 快照的 proxy 字段在 resolver 侧已脱敏,可直接进用户可见的错误消息。
       //

--- a/apps/desktop/src/main/maker-host/index.ts
+++ b/apps/desktop/src/main/maker-host/index.ts
@@ -314,6 +314,7 @@ import {
   getDesktopMcpToolApprovalPresentation,
 } from './mcp-tool-approval-policy.js';
 import {
+  bumpCodexDiscoveryAuthEpoch,
   createCodexLiveModelsPublisher,
   getCodexDiscoveryAuthEpoch,
   readCodexDiscoveredModels,
@@ -1411,8 +1412,8 @@ export function getMaker(): Maker {
         );
       },
       // live 清单定成员与顺序;真实 context_window 只有 models_cache 明示,按 slug 回填,
-      // 否则「刷新模型信息」会把首次加载的 1.1M 退回 272k 兜底(#4087)。异步读 cache 后
-      // 的新鲜度(序号 + 鉴权代次)与读取上限见 createCodexLiveModelsPublisher。
+      // 否则「刷新模型信息」会把首次加载的 1.1M 退回 272k 兜底(#4087)。两阶段发布(同步
+      // 发 live、异步回填)、新鲜度(序号 + 鉴权代次)与读取上限见 createCodexLiveModelsPublisher。
       onCodexLocalModelsListed: createCodexLiveModelsPublisher({
         readCache: readCodexDiscoveredModels,
         publish: setDiscoveredCodexModels,
@@ -2685,6 +2686,9 @@ export async function preflightBotRuntimeResources(
  */
 export function resetMaker(): void {
   cancelCodexAuthModeChange();
+  // 账号边界:让仍在异步回填 cache 的旧 Maker live model/list 回调作废(旧账号清单不得在
+  // 新 Maker 建立后再发布,见 createCodexLiveModelsPublisher 的鉴权代次校验)。
+  bumpCodexDiscoveryAuthEpoch();
   setCodexAppliedCustomProviderRoutes([]);
   _maker = null;
   botRuntimeResourcePreflight = null;

--- a/apps/desktop/src/main/maker-host/index.ts
+++ b/apps/desktop/src/main/maker-host/index.ts
@@ -313,7 +313,11 @@ import {
   getDesktopMcpToolApprovalPolicy,
   getDesktopMcpToolApprovalPresentation,
 } from './mcp-tool-approval-policy.js';
-import { mapCodexAppServerModelsToCatalog } from './codex-model-discovery.js';
+import {
+  mapCodexAppServerModelsToCatalog,
+  mergeCodexLiveModelsWithCache,
+  readCodexDiscoveredModels,
+} from './codex-model-discovery.js';
 import { prepareSharedProjectSkillLinks } from './shared-global-skills.js';
 import {
   buildDesktopCapabilityRoutingPolicy,
@@ -1406,8 +1410,14 @@ export function getMaker(): Maker {
           getDesktopSelectableCatalog(), 'codex', source, modelId,
         );
       },
-      onCodexLocalModelsListed: (models) => {
-        setDiscoveredCodexModels(mapCodexAppServerModelsToCatalog(models));
+      onCodexLocalModelsListed: async (models) => {
+        // live 清单定成员与顺序;真实 context_window 只有 models_cache 明示,按 slug 回填,
+        // 否则「刷新模型信息」会把首次加载的 1.1M 退回 272k 兜底(#4087)。cache 读失败
+        // 返回 null → 原样使用 live 快照,不阻塞目录发布。
+        const cached = await readCodexDiscoveredModels();
+        setDiscoveredCodexModels(
+          mergeCodexLiveModelsWithCache(mapCodexAppServerModelsToCatalog(models), cached),
+        );
       },
       // 「后端不可达」终局升级时读一次本次请求的出站路径判定,把通用猜测换成实测事实。
       // 快照的 proxy 字段在 resolver 侧已脱敏,可直接进用户可见的错误消息。


### PR DESCRIPTION
## 这次改了什么

### 摘要

> **范围更正(09-08 13:20)**:本 PR 最初按「live `model/list` 丢掉 cache 明示窗口」立项并写了 Fixes #4087。review 复核后确认 **#4087 报告的 Luna 场景不是这条路径造成的**,本 PR 已收窄为 Refs #4087,只修一处独立的一致性缺陷;#4087 的真实根因与归属见 issue 评论。

**收窄后的问题**:Codex 模型目录有两条发布路径——首次加载读 Cindy 自管 `models_cache.json`(`mapCodexModelsToCatalog`,cache 明示的 `context_window` 带 `contextWindowVerified`);「刷新模型信息」/ 登录补拉走 app-server `model/list`(`mapCodexAppServerModelsToCatalog`,live 协议不带 `context_window`,一律 272K 且不标 verified),且 `setDiscoveredCodexModels` 整份替换。对于 **registry 尚未收录的模型**(例如刚上线、Server 目录还没跟上的型号),刷新前后目录给出的窗口不一致(cache 真实值 → live 272K 兜底)。对于 registry 已收录的模型,registry overlay 在场即胜出(`modelPlanePolicy.toOverlay`),两条路径结果相同,本 PR 不改变其行为。

改动:
- `codex-model-discovery.ts`:`mergeCodexLiveModelsWithCache(live, cache)` —— live 决定成员与顺序,只按 slug 回填 cache 明示的 `context_window` + `contextWindowVerified`;cache 缺失 / 该 slug 不在 cache / 无 slug 命中时原样返回 live(同一引用)。
- `createCodexLiveModelsPublisher`(`onCodexLocalModelsListed` 的宿主实现)**两阶段发布**:同步发布 live 快照后立即 resolve(不占 maker-core `refreshLocalModels` 的 20s deadline);异步有上限(1.5s)读 cache,命中 slug 才二次发布(active-catalog changed listener 会再广播);二次发布前校验**序号**(最后进入的回调才发布)与**鉴权代次**(读 cache 期间无登录/登出/凭证失效/换账号)。
- `refreshDiscoveredCodexModels`(鉴权边界统一入口)与 `resetMaker()`(账号边界)进入即 `bumpCodexDiscoveryAuthEpoch()`。

### 变更类型

- [ ] `feat` 新功能
- [x] `fix` 缺陷修复
- [ ] `refactor` / `perf` 重构或性能优化
- [ ] `docs` / `test` / `chore` 文档、测试或工程维护
- [ ] 其他：

### 范围

- 关联 Issue / 需求：Refs #4087(不 Fixes;Luna 场景归因见 issue)
- 本 PR 包含：live/cache 合并纯函数、两阶段 publisher、鉴权代次、单测
- 明确不包含:registry overlay 优先级(registry 显式字段 > discovery 显式值,见 active-catalog 装配注释)的任何改动;#4016 的 272K 工作默认;Server 目录中 `openai/gpt-5.6-luna` 的容量声明;「刷新导致窗口变化时提示用户」
- 用户可见变化:仅对 registry 未收录的 Codex 模型,刷新模型信息 / 重新登录后上下文上限与首次加载一致
- 是否存在 breaking change：无

### UI 变化

不涉及。

- 引用的设计规范：不涉及：仅主进程模型目录合并逻辑

## 怎么验证的

### 自动验证

```text
pnpm --dir apps/desktop exec vitest run src/main/maker-host/__tests__/codexModelDiscovery.test.ts
结果:25 passed(合并 3 例 / publisher 7 例)

反证 1:mergeCodexLiveModelsWithCache 改回「整份替换」语义 → 回填用例失败
反证 2:去掉序号 + 鉴权代次校验 → 代次/并发 2 例失败
反证 3:第二阶段改回 await → 「不占 deadline」等 4 例失败

pnpm --dir apps/desktop exec vitest run codexModelDiscovery activeCatalogDiscovery codexModelBackfill codexModelBackfillWiring
结果:56 passed

pnpm --dir apps/desktop run typecheck → 0 错误
pnpm test:unit:related(仓库根)→ PASS apps/desktop unit
```

### 手工验证

不涉及:无 Windows 环境。

### 未执行的验证

未做真实 ChatGPT 账号刷新前后实机对比;未经过完整 active-catalog 装配链的集成测试(registry 已收录模型由 overlay 决定,本 PR 不改变其结果)。

## 风险

### 风险分类

- [x] 无已知风险
- [ ] SQLite / migration
- [ ] system prompt
- [ ] 协议兼容
- [ ] 权限 / 安全 / 用户数据
- [ ] 存量插件兼容（批准状态 / 指纹 / manifest 校验 / 安装布局 / 包格式）
- [ ] 原生层 / fingerprint / OTA
- [ ] 跨平台差异
- [ ] 其他：

### 影响与回滚

- 影响范围：仅 Codex(openai 路由)live 清单发布时 registry 未收录模型的 context_window 取值;成员、顺序、effort、fast tier、registry 已收录模型均不变
- 回滚 / 降级方式：revert 本分支 3 个 commit 即回到「live 整份替换」
