### PR TITLE
fix(model-providers): 智谱 / Z.ai Coding Plan 预设补 Claude Code 的 GLM-5.3 1M 入口

### DIFF
--- a/packages/model-providers/catalog/providers.json
+++ b/packages/model-providers/catalog/providers.json
@@ -1944,6 +1944,11 @@
           "baseUrl": "https://open.bigmodel.cn/api/anthropic",
           "models": [
             {
+              "id": "glm-5.3[1m]",
+              "name": "GLM-5.3 (1M)",
+              "contextWindow": 1000000
+            },
+            {
               "id": "glm-5.2[1m]",
               "name": "GLM-5.2 (1M)",
               "contextWindow": 1000000
@@ -2083,6 +2088,11 @@
         "claude-code": {
           "baseUrl": "https://api.z.ai/api/anthropic",
           "models": [
+            {
+              "id": "glm-5.3[1m]",
+              "name": "GLM-5.3 (1M)",
+              "contextWindow": 1000000
+            },
             {
               "id": "glm-5.2[1m]",
               "name": "GLM-5.2 (1M)",

--- a/packages/model-providers/src/__tests__/presets.test.ts
+++ b/packages/model-providers/src/__tests__/presets.test.ts
@@ -1173,6 +1173,25 @@ describe('官方渠道预设契约', () => {
     },
   );
 
+  it.each(['zhipu-coding-plan-cn', 'zai-coding-plan-global'])(
+    '%s 的 Claude Code 提供 GLM-5.3 1M 独立入口,与 Pi 列表的 glm-5.3 窗口一致 (#3883)',
+    (id) => {
+      const claudeModels = preset(id)?.runtimes['claude-code']?.models ?? [];
+      expect(claudeModels.find((model) => model.id === 'glm-5.3[1m]')).toEqual({
+        id: 'glm-5.3[1m]',
+        name: 'GLM-5.3 (1M)',
+        contextWindow: 1_000_000,
+      });
+      // 窗口来源:同一端点族的 Pi 列表已声明 glm-5.3 为 1M,Claude Code 的 [1m] 形态不得比它小。
+      expect(
+        preset(id)?.runtimes.pi?.models.find((model) => model.id === 'glm-5.3')?.contextWindow,
+      ).toBe(1_000_000);
+      // 只补独立 1M 条目:既有裸条目保持原样(留空仍按 200K 保守默认),不静默抬窗。
+      expect(claudeModels.find((model) => model.id === 'glm-5.2')).toEqual({ id: 'glm-5.2', name: 'GLM-5.2' });
+      expect(claudeModels.find((model) => model.id === 'glm-5.3')).toBeUndefined();
+    },
+  );
+
   it('小米按量与 Token Plan 凭证不会混用端点', () => {
     expect(preset('xiaomi-mimo-api-cn')?.runtimes.codex?.baseUrl)
       .toBe('https://api.xiaomimimo.com/v1');


### PR DESCRIPTION
## 这次改了什么

### 摘要

修 #3883:「智谱 GLM Coding Plan(中国大陆)」与「Z.ai Coding Plan(Global)」两个预设的 Claude Code 模型列表没有 GLM-5.3 条目,用户手填裸 `glm-5.3` 且「上下文(tokens)」留空时按 200K 保守默认运行,与 CLI 直连(`glm-5.3[1m]` 1M)不一致。

改动只有目录数据:在 `packages/model-providers/catalog/providers.json` 两个 Coding Plan 预设的 `claude-code` 列表前置补 `glm-5.3[1m]`(名称 `GLM-5.3 (1M)`,`contextWindow: 1000000`),与既有 `glm-5.2[1m]` 完全同形态。既有裸条目(`glm-5.2` / `glm-5.1`)原样保留,不静默抬窗;不做「GLM-5.x 全局 1M」规则(目录里阿里云 Token Plan 的 GLM-5/5.1 是 202,752,窗口必须按供应商 × 模型区分)。

窗口依据:
- 同一份目录中,这两个 Coding Plan 预设的 Pi 列表已声明 `glm-5.3` / `glm-5.3-flash` / `glm-5.3-highspeed` 为 1M(同一端点族);
- 提报人实测:把该行「上下文(tokens)」填 1000000 后新建会话即按 1M 运行,与直连一致;
- `[1m]` wire 形态由 #3848 按目录窗口生成/移除,本条目给出 1M 窗口后后缀自洽。

按 dash-s-cindy 分析的第 1 项落地;第 2 项「留空即 200K」的表单提示属 renderer,本 PR 不涉及,留给维护者。

### 变更类型

- [ ] `feat` 新功能
- [x] `fix` 缺陷修复
- [ ] `refactor` / `perf` 重构或性能优化
- [ ] `docs` / `test` / `chore` 文档、测试或工程维护
- [ ] 其他：

### 范围

- 关联 Issue / 需求：Fixes #3883
- 本 PR 包含：两个 Coding Plan 预设 Claude Code 列表各补 1 条 `glm-5.3[1m]`;presets 契约测试(锁 1M 入口、Pi 侧窗口来源、裸条目不变)
- 明确不包含:Codex / Pi 列表改动;Kimi 等其它供应商;裸 `glm-5.3` 条目;renderer 表单提示;目录 `version` 不变(近三次目录改动均未 bump)
- 用户可见变化:添加/编辑这两个 Coding Plan 预设时,Claude Code 模型列表多一条「GLM-5.3 (1M)」;已保存的自定义供应商不受影响(预设只在导入时展开)
- 是否存在 breaking change：无

### UI 变化

不涉及。

- 引用的设计规范：不涉及

## 怎么验证的

### 自动验证

```text
pnpm --filter @cindy/model-providers exec vitest run
结果:25 files, 757 passed(新增 2 例 it.each:cn / global)

反证:stash 掉 providers.json 改动只留测试
结果:2 failed | 79 passed —— 新增用例在旧目录上失败

pnpm test:unit:related(仓库根)
结果:PASS model-providers / maker-core / desktop / mobile / lizi-mcps / orca-workflow

tsc --noEmit(packages/model-providers)
结果:仅 1 个 main 既有错误(src/__tests__/user-provider.test.ts:1236 TS2322,与本 PR 无关,origin/main 同样报)
```

### 手工验证

不涉及:无智谱 Coding Plan 账号,未做端点实测;窗口值以目录内 Pi 列表与提报人实测为准。

### 未执行的验证

未对 open.bigmodel.cn / api.z.ai 的 Anthropic 兼容端点做 GLM-5.3 1M 实请求;若供应商资料表明 Claude Code 端点下 glm-5.3 非 1M,请 Request Changes,我改数值或撤条目。

## 风险

### 风险分类

- [x] 无已知风险
- [ ] SQLite / migration
- [ ] system prompt
- [ ] 协议兼容
- [ ] 权限 / 安全 / 用户数据
- [ ] 存量插件兼容（批准状态 / 指纹 / manifest 校验 / 安装布局 / 包格式）
- [ ] 原生层 / fingerprint / OTA
- [ ] 跨平台差异
- [ ] 其他：

### 影响与回滚

- 影响范围：仅两个预设导入时的 Claude Code 模型候选列表;不改路由、不改既有条目
- 回滚 / 降级方式：revert 本 commit
