### PR TITLE
fix(desktop): 点击灵动岛完成任务后立即收起提示

### DIFF
--- a/apps/desktop/src/main/agent-island/__tests__/service.test.ts
+++ b/apps/desktop/src/main/agent-island/__tests__/service.test.ts
@@ -1939,7 +1939,7 @@ describe('AgentIslandService native publishing', () => {
     });
   });
 
-  it('retains a completion click during renderer reload and collapses after the target is shown', async () => {
+  it('collapses a completion before opening a loading window and retains its navigation', async () => {
     const { AgentIslandService } = await import('../service.js');
     const send = vi.fn();
     const mainWindow = {
@@ -1967,7 +1967,11 @@ describe('AgentIslandService native publishing', () => {
     expect(publish.mock.calls.at(-1)?.[0]).toMatchObject({ mode: 'expanded' });
     const focusSession = (service as unknown as { focusSession(id: string): void }).focusSession.bind(service);
 
+    vi.mocked(mainWindow.show).mockImplementation(() => {
+      expect(publish.mock.calls.at(-1)?.[0]).toMatchObject({ mode: 'compact' });
+    });
     focusSession('completed-session');
+    expect(publish.mock.calls.at(-1)?.[0]).toMatchObject({ mode: 'compact' });
 
     // A loading renderer has no notification listener. The existing deep-link
     // pull-on-mount path must retain the click instead of sending it into the gap.

--- a/apps/desktop/src/main/agent-island/__tests__/state.test.ts
+++ b/apps/desktop/src/main/agent-island/__tests__/state.test.ts
@@ -1279,8 +1279,9 @@ describe('Agent Island display state', () => {
     expect(protectedDisplay.mode).toBe('expanded');
     expect(protectedDisplay.displaySurface).toBe('interactionCard');
 
-    expect(dismissAgentIslandActiveReveal(state, 2_200)).toBe(true);
-    const display = buildAgentIslandDisplayState(state, 2_250);
+    expect(dismissAgentIslandActiveReveal(state, 1_399)).toBe(false);
+    expect(dismissAgentIslandActiveReveal(state, 1_400)).toBe(true);
+    const display = buildAgentIslandDisplayState(state, 1_401);
 
     expect(display.mode).toBe('compact');
     expect(display.displayPolicy).toBe('blocking');
@@ -1632,20 +1633,61 @@ describe('Agent Island display state', () => {
     expect(getNextAgentIslandTimerAt(state, 1_900)).toBeNull();
   });
 
-  it('collapses after slow navigation without extending the background-window ack grace', () => {
+  it.each([false, true])('collapses a completion immediately without extending the background-window ack grace (manual: %s)', (manual) => {
     const state = createAgentIslandState();
     applyAgentIslandEvent(state, { sessionId: 'done' }, doneEvent(), 1_000);
-    requestAgentIslandManualExpand(state);
+    if (manual) requestAgentIslandManualExpand(state);
     expect(buildAgentIslandDisplayState(state, 1_100).mode).toBe('expanded');
     requestAgentIslandSessionFocus(state, 'done', 1_200);
+    expect(buildAgentIslandDisplayState(state, 1_201).mode).toBe('compact');
+    expect(state.sessions.get('done')?.unread).toBe(true);
     expect(isAgentIslandPendingFocusAck(state, 'done', 1_250)).toBe(true);
 
-    expect(buildAgentIslandDisplayState(state, 3_200).mode).toBe('expanded');
+    expect(buildAgentIslandDisplayState(state, 3_200).mode).toBe('compact');
     expect(isAgentIslandPendingFocusAck(state, 'done', 3_200)).toBe(false);
     setAgentIslandAppFocused(state, true, 3_250);
     setAgentIslandVisibleSession(state, 'done', 3_300);
     acknowledgeAgentIslandSessionRead(state, 'done', 3_300);
     expect(buildAgentIslandDisplayState(state, 3_350).mode).toBe('compact');
+  });
+
+  it('keeps a clicked completion stack collapsed and unread when navigation never arrives', () => {
+    const state = createAgentIslandState();
+    applyAgentIslandEvent(state, { sessionId: 'first' }, doneEvent(), 1_000);
+    applyAgentIslandEvent(state, { sessionId: 'second' }, doneEvent(), 1_050);
+    expect(buildAgentIslandDisplayState(state, 1_100).displaySurface).toBe('sessionList');
+    setAgentIslandPointerZones(state, { menuBar: false, panel: true }, 1_110);
+
+    requestAgentIslandSessionFocus(state, 'second', 1_120);
+    expect(buildAgentIslandDisplayState(state, 1_121).mode).toBe('compact');
+    // The pointer is still over the collapsed island; its next native report
+    // must not turn the click into another hover expansion.
+    setAgentIslandPointerZones(state, { menuBar: true, panel: false }, 1_130);
+    for (const now of [2_000, 10_000, 62_000]) {
+      const display = buildAgentIslandDisplayState(state, now);
+      expect(display.mode).toBe('compact');
+      expect(display.pillSnapshot.unreadCompletedCount).toBe(2);
+    }
+    expect(state.pendingFocusSessionId).toBeNull();
+  });
+
+  it.each(['manual', 'new-error'] as const)('does not close a newer %s surface on a late completion navigation', (surface) => {
+    const state = createAgentIslandState();
+    applyAgentIslandEvent(state, { sessionId: 'done' }, doneEvent(), 1_000);
+    buildAgentIslandDisplayState(state, 1_100);
+    requestAgentIslandSessionFocus(state, 'done', 1_200);
+    expect(buildAgentIslandDisplayState(state, 1_201).mode).toBe('compact');
+
+    if (surface === 'manual') {
+      requestAgentIslandManualExpand(state);
+    } else {
+      applyAgentIslandEvent(state, { sessionId: 'done' }, statusEvent(true, 'Running'), 2_000);
+      applyAgentIslandEvent(state, { sessionId: 'done' }, terminalErrorEvent('new failure'), 2_100);
+    }
+    expect(buildAgentIslandDisplayState(state, 2_200).mode).toBe('expanded');
+    setAgentIslandVisibleSession(state, 'done', 3_200);
+    expect(buildAgentIslandDisplayState(state, 3_201).mode).toBe('expanded');
+    expect(state.pendingFocusSessionId).toBeNull();
   });
 
   it('keeps the newest click when an earlier navigation finishes late', () => {
@@ -1947,8 +1989,9 @@ describe('Agent Island display state', () => {
     expect(protectedDisplay.mode).toBe('expanded');
     expect(protectedDisplay.displaySurface).toBe('completionCard');
 
-    expect(dismissAgentIslandActiveReveal(state, 3_200)).toBe(true);
-    const display = buildAgentIslandDisplayState(state, 3_250);
+    expect(dismissAgentIslandActiveReveal(state, 2_399)).toBe(false);
+    expect(dismissAgentIslandActiveReveal(state, 2_400)).toBe(true);
+    const display = buildAgentIslandDisplayState(state, 2_401);
 
     expect(display.mode).toBe('compact');
     expect(display.displayPolicy).toBe('transient');

--- a/apps/desktop/src/main/agent-island/service.ts
+++ b/apps/desktop/src/main/agent-island/service.ts
@@ -2327,11 +2327,11 @@ export class AgentIslandService {
     }
 
     const focusChanged = requestAgentIslandSessionFocus(this.state, nextSessionId, now);
+    if (focusChanged) this.publish();
     // Reuse the primary-window handoff: it retains navigation while the
     // renderer reloads and restores macOS app focus. A one-shot notification
     // sent during loading is lost before MainLayout can acknowledge the task.
     openMainWindowSession(nextSessionId);
-    if (focusChanged) this.publish();
   }
 
   private dispatchMainWindowCommand(

--- a/apps/desktop/src/main/agent-island/state.ts
+++ b/apps/desktop/src/main/agent-island/state.ts
@@ -52,6 +52,7 @@ export const AGENT_ISLAND_REVEAL_DWELL_MS = 5_000;
 export const AGENT_ISLAND_COMPLETION_REVEAL_DWELL_MS = 8_000;
 export const AGENT_ISLAND_ERROR_REVEAL_DWELL_MS = 12_000;
 export const AGENT_ISLAND_EXPANDED_MIN_DWELL_MS = 1_000;
+const AGENT_ISLAND_OUTSIDE_CLICK_PROTECTION_MS = 300;
 export const AGENT_ISLAND_HOVER_EXPAND_DELAY_MS = 500;
 export const AGENT_ISLAND_MOUSE_LEAVE_COLLAPSE_DELAY_MS = 150;
 export const AGENT_ISLAND_HOVER_SHORT_COOLDOWN_MS = 300;
@@ -188,6 +189,7 @@ export interface AgentIslandState {
   activeTransientSessionId: string | null;
   transientRevealQueue: string[];
   pendingFocusSessionId: string | null;
+  pendingFocusDismissOnAck: boolean;
   // Short grace for a renderer ack before OS focus settles. Navigation itself
   // may take longer (for example a renderer reload); its bounded deadline is
   // derived from this timestamp by pendingFocusNavigationExpiresAt.
@@ -236,6 +238,7 @@ export function createAgentIslandState(): AgentIslandState {
     activeTransientSessionId: null,
     transientRevealQueue: [],
     pendingFocusSessionId: null,
+    pendingFocusDismissOnAck: false,
     pendingFocusUntil: null,
     lastDisplayMode: null,
     lastDisplayPolicy: null,
@@ -270,6 +273,7 @@ export function resetAgentIslandState(state: AgentIslandState): void {
   state.activeTransientSessionId = fresh.activeTransientSessionId;
   state.transientRevealQueue = fresh.transientRevealQueue;
   state.pendingFocusSessionId = fresh.pendingFocusSessionId;
+  state.pendingFocusDismissOnAck = fresh.pendingFocusDismissOnAck;
   state.pendingFocusUntil = fresh.pendingFocusUntil;
   state.lastDisplayMode = fresh.lastDisplayMode;
   state.lastDisplayPolicy = fresh.lastDisplayPolicy;
@@ -1005,6 +1009,7 @@ function forgetAgentIslandSession(state: AgentIslandState, sessionId: string): v
   removeQueuedTransientReveal(state, sessionId);
   if (state.pendingFocusSessionId === sessionId) {
     state.pendingFocusSessionId = null;
+    state.pendingFocusDismissOnAck = false;
     state.pendingFocusUntil = null;
   }
 }
@@ -1076,18 +1081,28 @@ export function requestAgentIslandSessionFocus(
 ): boolean {
   const nextSessionId = typeof sessionId === 'string' && sessionId.trim() ? sessionId.trim() : null;
   if (!nextSessionId) return false;
+  // Closing a completion notification is immediate feedback, not a read ack.
+  // Keep navigation tracking below so a loading window can still open the task.
+  let completionDismissed = false;
+  const isCompletion = state.sessions.get(nextSessionId)?.phase === 'completed';
+  if (isCompletion) {
+    completionDismissed = dismissTransientReveals(state);
+    completionDismissed = collapseAgentIslandToCompact(state, now) || completionDismissed;
+  }
   if (state.visibleSessionIds.has(nextSessionId)) {
     const dismissed = dismissFocusedSessionReveal(state, nextSessionId, now);
     const collapsed = collapseAgentIslandToCompact(state, now);
     state.pendingFocusSessionId = null;
+    state.pendingFocusDismissOnAck = false;
     state.pendingFocusUntil = null;
-    return dismissed || collapsed;
+    return completionDismissed || dismissed || collapsed;
   }
   const previousSessionId = state.pendingFocusSessionId;
   const previousUntil = state.pendingFocusUntil;
   state.pendingFocusSessionId = nextSessionId;
+  state.pendingFocusDismissOnAck = !isCompletion;
   state.pendingFocusUntil = now + AGENT_ISLAND_FOCUS_VERIFY_TIMEOUT_MS;
-  return previousSessionId !== state.pendingFocusSessionId || previousUntil !== state.pendingFocusUntil;
+  return completionDismissed || previousSessionId !== state.pendingFocusSessionId || previousUntil !== state.pendingFocusUntil;
 }
 
 export function isAgentIslandPendingFocusAck(
@@ -1100,7 +1115,11 @@ export function isAgentIslandPendingFocusAck(
 }
 
 export function dismissAgentIslandActiveReveal(state: AgentIslandState, now: number): boolean {
-  if (isExpandedProtected(state, now) && (hasActiveTransientReveal(state, now) || hasActiveBlockingReveal(state, now))) {
+  // Explicit outside clicks have a shorter guard than automatic mouse-leave collapse.
+  const clickProtectedUntil = state.expandedProtectUntil === null ? null
+    : state.expandedProtectUntil - AGENT_ISLAND_EXPANDED_MIN_DWELL_MS + AGENT_ISLAND_OUTSIDE_CLICK_PROTECTION_MS;
+  if (clickProtectedUntil !== null && clickProtectedUntil > now
+    && (hasActiveTransientReveal(state, now) || hasActiveBlockingReveal(state, now))) {
     return false;
   }
   const dismissedTransientReveal = dismissPublishedTransientReveal(state);
@@ -1397,6 +1416,7 @@ function updateFocusVerificationLifecycle(state: AgentIslandState, now: number):
   // Allow slow renderer loading, but do not let an abandoned navigation turn a
   // much later ordinary visit into an acknowledgement of the old island click.
   state.pendingFocusSessionId = null;
+  state.pendingFocusDismissOnAck = false;
   state.pendingFocusUntil = null;
 }
 
@@ -1584,6 +1604,10 @@ function deferActiveTransientReveal(
 
 function dismissPublishedTransientReveal(state: AgentIslandState): boolean {
   if (state.lastDisplayMode !== 'expanded' || state.lastDisplayPolicy !== 'transient') return false;
+  return dismissTransientReveals(state);
+}
+
+function dismissTransientReveals(state: AgentIslandState): boolean {
   const transientSessionIds = [
     state.activeTransientSessionId,
     ...state.transientRevealQueue,
@@ -1967,8 +1991,13 @@ function applyVerifiedFocusIfMatched(
   updateFocusVerificationLifecycle(state, now);
   const focusedSessionId = state.pendingFocusSessionId;
   if (!focusedSessionId || !state.visibleSessionIds.has(focusedSessionId)) return false;
+  const dismissOnAck = state.pendingFocusDismissOnAck;
   state.pendingFocusSessionId = null;
+  state.pendingFocusDismissOnAck = false;
   state.pendingFocusUntil = null;
+  // Completion clicks already closed their notification. A delayed navigation
+  // must not close a newer reveal or a list the user has since reopened.
+  if (!dismissOnAck) return false;
   const dismissed = dismissFocusedSessionReveal(state, focusedSessionId, now);
   const collapsed = collapseAgentIslandToCompact(state, now);
   return dismissed || collapsed;


### PR DESCRIPTION
## 这次改了什么

### 摘要

点击灵动岛中的完成任务后，先收起提示，再唤起主窗口并跳转；不再等待目标任务可见回报。收起不清除未读，加载期间的导航保留原有交接方式。完成点击的迟到确认不会再次收起用户重新展开的列表或同一任务的新提醒。

自动提醒的外部点击保护由 1 秒缩短至 300 毫秒，鼠标移出时的保护节奏保持原样。

### 变更类型

- [x] `fix` 缺陷修复

### 范围

- 关联 Issue / 需求：完成任务点击后立即收起；延续 #3978 的导航可靠性交接。
- 本 PR 包含：完成通知点击反馈、迟到确认隔离、外部点击 300 毫秒边界及回归测试。
- 明确不包含：运行中任务和权限任务的点击语义变更、原生 helper 改动。
- 用户可见变化：完成提示立即开始收起；自动提醒出现 300 毫秒后可点击岛外收起。
- 是否存在 breaking change：无。

### UI 变化

- 平台：macOS Desktop 灵动岛。仅调整交互时序，沿用既有收起动画与 Light / Dark 样式，未新增颜色或视觉结构。
- 引用的设计规范：`docs/design-rules/DESIGN.md` §14.4（直接、快速的交互反馈）、§10（双模式交付与验证边界）。300 毫秒为点击保护阈值，不是动画时长。
- 未提供截图或录屏：本次尚未启动修改后的客户端进行实机验证。

## 怎么验证的

### 自动验证

- `pnpm --filter desktop exec vitest run src/main/agent-island/__tests__`：8 个文件、313 项测试通过。
- `pnpm --filter desktop run typecheck`：通过。
- `pnpm test:unit:related`：通过（42 秒）。首轮 Vitest 进程 SIGSEGV，清理环境变量后重跑通过。
- `run-unit-gate.sh` → `pnpm test:unit`：已完整执行，Desktop 有 9 项基线失败，其余 workspace 通过。失败位于 `claudeOrphanReaper.test.ts`（5）、`codexAuthIsolatedSandbox.test.ts`（3）、`usageHistory.test.ts`（1）；在未修改的 main 基线 `87994cd4a` 对这三个文件复跑，同样 9 项失败、46 项通过。未把无关修复混入本 PR。
- `git diff --check`：通过。

回归覆盖：自动和手动展开的完成提示在导航确认前收起、堆叠通知不连续重弹、导航未完成时保留未读、迟到确认不关新列表/新错误提醒，以及外部点击 299/300 毫秒边界。

### 手工验证

已 review 完整 diff，并独立复核状态清理路径。

### 未执行的验证

未进行 macOS 实际鼠标操作、Light / Dark 实机目检或 Windows 验证；没有重启当前正在运行的客户端。

## 风险

### 风险分类

- [x] 其他：灵动岛交互时序调整，实际动画和点击体感尚待实机验证。

### 影响与回滚

- 影响范围：Desktop 灵动岛完成通知与自动提醒的外部点击保护；未更改未读清除、权限操作或跨端协议。
- 回滚 / 降级方式：回退本 PR；无数据迁移。

### 提交前检查

- [x] 已 review 完整 diff
- [x] 每个 commit 都带 DCO 签名（`git commit -s`）
- [x] UI 改动已在「UI 变化」注明引用的设计规范章节
- [x] 未提交凭证、令牌或授权文件
- [x] 已补充必要文档（源码注释与测试；无既有产品文档数值需要同步）
- [x] 已确认测试结果或说明未执行原因
