### PR TITLE
fix(desktop): 远程任务顶部仅保留异常提示

### DIFF
--- a/apps/desktop/src/renderer/features/cc-agent/CCAgentSessionView.tsx
+++ b/apps/desktop/src/renderer/features/cc-agent/CCAgentSessionView.tsx
@@ -4624,11 +4624,6 @@ export function CCAgentSessionView({
             issue={remoteLinkIssue}
             onResync={remoteSync.resync}
           />
-        ) : remoteConn === 'connected' ? (
-          <RemoteSessionBanner
-            status={remoteSync.contentState === 'ready' ? 'recovered' : 'syncing'}
-            onResync={remoteSync.resync}
-          />
         ) : null}
 
         {/* 远程会话首屏:等被控端经隧道返回历史/元数据期间的 loading(仅远程、延迟防闪)。 */}
@@ -4712,8 +4707,7 @@ export function CCAgentSessionView({
                     <span>{t('ccAgent.agentStatus.thinking')}</span>
                   </div>
                 ) : null
-              ) : !pendingPlanReview ||
-                (hasControlledBanner && controlledBannerCollapsed) ? (
+              ) : !pendingPlanReview || (hasControlledBanner && controlledBannerCollapsed) ? (
                 <RunningStatusBar
                   key={sessionId}
                   status={composerStatus}
@@ -4819,7 +4813,8 @@ export function CCAgentSessionView({
                 Retry 门控与恢复路径(同步登录态 / fork 剥离),此前的简化红条
                 一律显示重试会把用户带进同样的失败循环。onRetry 忽略 retryText
                 (typed token),发隐藏续跑指令;onCancel = dismiss 持久化。 */}
-            {!readOnly && errorTailMsg &&
+            {!readOnly &&
+              errorTailMsg &&
               !errorTailBannerHidden &&
               !syntheticContinuationPending &&
               !error &&
@@ -4864,7 +4859,8 @@ export function CCAgentSessionView({
 
             {/* interrupted-turn-resume(简化版):session 双时间戳驱动的中断提示。
               历史中断行(上方 errorTailMsg 判定)优先;互斥条件与 error-tail 同款。 */}
-            {!readOnly && !errorTailMsg &&
+            {!readOnly &&
+              !errorTailMsg &&
               interruptedFromSession &&
               !syntheticContinuationPending &&
               !error &&
@@ -5250,16 +5246,16 @@ export function CCAgentSessionView({
                 自动 clear,UI 回到正常显示。设计参考用户反馈"把这部分的体验逻辑放到
                 chatinput 底部 显示 work dir 的地方"——不再在 chat stream 插 SystemCard。 */}
               {!botChatIdentity ? (
-              <div
-                className={cn(
-                  'mt-1.5 flex w-full items-center justify-between gap-3 px-1',
-                  !session?.workingDir && !worktreeCreation && 'invisible',
-                )}
-              >
+                <div
+                  className={cn(
+                    'mt-1.5 flex w-full items-center justify-between gap-3 px-1',
+                    !session?.workingDir && !worktreeCreation && 'invisible',
+                  )}
+                >
                   {/* Left: workingDir — 点击在系统文件管理器中打开;
                   click 区域宽度与文本一致(不拉伸到整行) */}
                   {worktreeCreation?.status === 'creating' ? (
-                  <div className="flex min-w-0 items-center gap-1.5">
+                    <div className="flex min-w-0 items-center gap-1.5">
                       <Spinner size={12} className="text-[var(--workingdir-icon)]" />
                       <span className="block min-w-0 truncate text-12 font-medium leading-none text-[var(--workingdir-text)]">
                         {t('ccAgent.layout.worktreeCreating', '正在创建 worktree')}{' '}
@@ -5269,130 +5265,133 @@ export function CCAgentSessionView({
                         …
                       </span>
                     </div>
-                ) : worktreeCreation?.status === 'failed' ? (
-                  <Tip text={worktreeCreation.error} mono side="top">
+                  ) : worktreeCreation?.status === 'failed' ? (
+                    <Tip text={worktreeCreation.error} mono side="top">
                       <div className="flex min-w-0 items-center gap-1.5">
-                        <AlertCircle size={12} className="shrink-0 text-red-500 dark:text-red-400" />
+                        <AlertCircle
+                          size={12}
+                          className="shrink-0 text-red-500 dark:text-red-400"
+                        />
                         <span className="block min-w-0 truncate text-12 font-medium leading-none text-red-500 dark:text-red-400">
                           {t('ccAgent.layout.worktreeFailed', 'Worktree 创建失败')}
                           {' — '}
                           {worktreeCreation.error}
                         </span>
                         <button
-                        type="button"
-                        onClick={(e) => {
-                          e.stopPropagation();
-                          if (sessionId) worktreeCreationStore.clear(sessionId);
-                        }}
-                        className="shrink-0 rounded p-0.5 transition-colors hover:bg-foreground/10"
-                        aria-label={t('common.dismiss', 'Dismiss')}
-                      >
+                          type="button"
+                          onClick={(e) => {
+                            e.stopPropagation();
+                            if (sessionId) worktreeCreationStore.clear(sessionId);
+                          }}
+                          className="shrink-0 rounded p-0.5 transition-colors hover:bg-foreground/10"
+                          aria-label={t('common.dismiss', 'Dismiss')}
+                        >
                           <X size={10} className="text-red-500/70 dark:text-red-400/70" />
                         </button>
                       </div>
                     </Tip>
-                ) : (
-                  <Tip
-                    text={
-                      composerDir ? (
-                        session?.remoteHostId ? (
-                          // 远端 session: Tip 顶部加一行 "Host: <alias>" 让用户在
-                          // 同 workingDir 跨多 host 撞合场景下也能区分。hostId 即
-                          // SSH alias (HostConfig.id), 不需要额外 lookup。
-                          <>
+                  ) : (
+                    <Tip
+                      text={
+                        composerDir ? (
+                          session?.remoteHostId ? (
+                            // 远端 session: Tip 顶部加一行 "Host: <alias>" 让用户在
+                            // 同 workingDir 跨多 host 撞合场景下也能区分。hostId 即
+                            // SSH alias (HostConfig.id), 不需要额外 lookup。
+                            <>
                               <div>Host: {session.remoteHostId}</div>
                               <div>{composerDir}</div>
                             </>
-                        ) : (
-                          composerDir
-                        )
-                      ) : null
-                    }
-                    mono
-                    side="top"
-                  >
+                          ) : (
+                            composerDir
+                          )
+                        ) : null
+                      }
+                      mono
+                      side="top"
+                    >
                       {isRemoteWorktreeSession ? (
-                      <div className="flex min-w-0 items-center gap-1.5">
+                        <div className="flex min-w-0 items-center gap-1.5">
                           {workingDirChipContent}
                         </div>
-                    ) : (
-                      <button
-                        type="button"
-                        className="flex min-w-0 cursor-pointer items-center gap-1.5 text-left transition-opacity active:opacity-60"
-                        onClick={handleOpenWorkingDir}
-                        aria-label={t('ccAgent.layout.openWorkingDirAria')}
-                      >
+                      ) : (
+                        <button
+                          type="button"
+                          className="flex min-w-0 cursor-pointer items-center gap-1.5 text-left transition-opacity active:opacity-60"
+                          onClick={handleOpenWorkingDir}
+                          aria-label={t('ccAgent.layout.openWorkingDirAria')}
+                        >
                           {workingDirChipContent}
                         </button>
-                    )}
+                      )}
                     </Tip>
-                )}
+                  )}
 
                   {/* Right: Context capacity indicator */}
                   <div className="flex shrink-0 items-center gap-3">
                     {session?.usedProjectContext && (
-                    <Tip text={t('ccAgent.layout.projectContextLoaded')} side="top">
+                      <Tip text={t('ccAgent.layout.projectContextLoaded')} side="top">
                         <Brain
-                        size={14}
-                        strokeWidth={1.75}
-                        className="shrink-0 -translate-y-px text-foreground/70"
-                        aria-label={t('ccAgent.layout.projectContextLoaded')}
-                      />
+                          size={14}
+                          strokeWidth={1.75}
+                          className="shrink-0 -translate-y-px text-foreground/70"
+                          aria-label={t('ccAgent.layout.projectContextLoaded')}
+                        />
                       </Tip>
-                  )}
-                    <TodaySpendChip
-                    vendorKey={normalizeDbAgentKind(displayAgentKind)}
-                    modelId={agentSwitchIntent?.model ?? session?.model ?? null}
-                    providerId={
-                      agentSwitchIntent
-                        ? agentSwitchIntent.providerId
-                        : (session?.providerId ?? null)
-                    }
-                    sessionId={sessionId}
-                    sessionInitialMoney={session?.totalMoney ?? null}
-                    sessionInitialCostUsd={session?.totalCostUsd ?? null}
-                    sessionInitialTokens={session?.totalTokenUsage ?? null}
-                    remoteHostId={session?.remoteHostId ?? null}
-                    deviceLinkDeviceId={remoteDeviceId ?? null}
-                  />
-                    <ContextCapacityRing
-                    isRunning={agentStatus.isRunning}
-                    sessionId={sessionId}
-                    providerId={session?.providerId}
-                    contextTokens={agentStatus.contextTokens}
-                    model={agentSwitchIntent?.model ?? session?.model ?? ''}
-                    vendorKey={normalizeDbAgentKind(displayAgentKind)}
-                    sdkContextWindow={agentStatus.contextWindow}
-                    verifiedContextWindow={resolveSessionContextWindow(
-                      { providers },
-                      {
-                        agentKind: normalizeDbAgentKind(displayAgentKind),
-                        model: agentSwitchIntent?.model ?? session?.model,
-                        providerId: agentSwitchIntent
-                          ? agentSwitchIntent.providerId
-                          : session?.providerId,
-                      },
                     )}
-                    deviceId={remoteDeviceId}
-                    onCompact={
-                      // 按 agent 能力分流(#1927/#1933 review):claude-code 走 inputCoordinator,
-                      // 其余声明 manualCompact.supported(当前仅 pi)走 compact-session 通道;
-                      // codex 无手动 compact(上游自动压缩)保持纯展示。pi 的 SSH 远程会话
-                      // (remoteHostId)无 compact-session 路由 → 不开放(与 SessionContentHeader
-                      // 压缩菜单仅本地/device-link 一致);device-link 远程 pi 走隧道,照常开放。
-                      // pi 回合运行中会拒绝压缩 → compact-session 通道在 running 时禁用
-                      // (与 SessionContentHeader 的 runningSessionIds 一致,codex P1);
-                      // claude-input 保留旧行为(turn 中可走 inputCoordinator)。
-                      !readOnly &&
-                      compactChannel !== null &&
-                      !(realAgentKind === 'pi' && !!session?.remoteHostId) &&
-                      session != null &&
-                      agentStatus.contextTokens > 0 &&
-                      !(compactChannel === 'compact-session' && agentStatus.isRunning)
-                        ? handleCompactRequest
-                        : undefined
-                    }
-                  />
+                    <TodaySpendChip
+                      vendorKey={normalizeDbAgentKind(displayAgentKind)}
+                      modelId={agentSwitchIntent?.model ?? session?.model ?? null}
+                      providerId={
+                        agentSwitchIntent
+                          ? agentSwitchIntent.providerId
+                          : (session?.providerId ?? null)
+                      }
+                      sessionId={sessionId}
+                      sessionInitialMoney={session?.totalMoney ?? null}
+                      sessionInitialCostUsd={session?.totalCostUsd ?? null}
+                      sessionInitialTokens={session?.totalTokenUsage ?? null}
+                      remoteHostId={session?.remoteHostId ?? null}
+                      deviceLinkDeviceId={remoteDeviceId ?? null}
+                    />
+                    <ContextCapacityRing
+                      isRunning={agentStatus.isRunning}
+                      sessionId={sessionId}
+                      providerId={session?.providerId}
+                      contextTokens={agentStatus.contextTokens}
+                      model={agentSwitchIntent?.model ?? session?.model ?? ''}
+                      vendorKey={normalizeDbAgentKind(displayAgentKind)}
+                      sdkContextWindow={agentStatus.contextWindow}
+                      verifiedContextWindow={resolveSessionContextWindow(
+                        { providers },
+                        {
+                          agentKind: normalizeDbAgentKind(displayAgentKind),
+                          model: agentSwitchIntent?.model ?? session?.model,
+                          providerId: agentSwitchIntent
+                            ? agentSwitchIntent.providerId
+                            : session?.providerId,
+                        },
+                      )}
+                      deviceId={remoteDeviceId}
+                      onCompact={
+                        // 按 agent 能力分流(#1927/#1933 review):claude-code 走 inputCoordinator,
+                        // 其余声明 manualCompact.supported(当前仅 pi)走 compact-session 通道;
+                        // codex 无手动 compact(上游自动压缩)保持纯展示。pi 的 SSH 远程会话
+                        // (remoteHostId)无 compact-session 路由 → 不开放(与 SessionContentHeader
+                        // 压缩菜单仅本地/device-link 一致);device-link 远程 pi 走隧道,照常开放。
+                        // pi 回合运行中会拒绝压缩 → compact-session 通道在 running 时禁用
+                        // (与 SessionContentHeader 的 runningSessionIds 一致,codex P1);
+                        // claude-input 保留旧行为(turn 中可走 inputCoordinator)。
+                        !readOnly &&
+                        compactChannel !== null &&
+                        !(realAgentKind === 'pi' && !!session?.remoteHostId) &&
+                        session != null &&
+                        agentStatus.contextTokens > 0 &&
+                        !(compactChannel === 'compact-session' && agentStatus.isRunning)
+                          ? handleCompactRequest
+                          : undefined
+                      }
+                    />
                   </div>
                 </div>
               ) : null}
@@ -5920,7 +5919,10 @@ function ContextCapacityRing({
   const [contextInspection, setContextInspection] = useState(0);
   const codexContext = useCodexContextWindow({
     enabled: vendorKey === 'codex' && !deviceId && Boolean(sessionId),
-    providerId, modelId: model, sessionId, reportedWindow: sdkContextWindow,
+    providerId,
+    modelId: model,
+    sessionId,
+    reportedWindow: sdkContextWindow,
     refreshKey: `${isRunning}:${contextInspection}`,
   });
   const contextWindow = resolveDisplayContextWindow({
@@ -6007,16 +6009,20 @@ function ContextCapacityRing({
         ) : vendorKey === 'codex' ? (
           // Native Codex manages compaction; this control only reads its capacity.
           <>
-            <div>{codexContext?.pendingApply
-              ? t('ccAgent.layout.contextRing.codexPendingHint')
-              : tooltipText}</div>
-            <div>{codexContext
-              ? t('settings.providers.models.advanced.codexContextValues', {
-                  total: codexContext.contextWindow.toLocaleString(),
-                  usable: codexContext.usableContextWindow.toLocaleString(),
-                  compact: codexContext.autoCompactTokenLimit.toLocaleString(),
-                })
-              : t('settings.providers.models.advanced.codexContextUnknown')}</div>
+            <div>
+              {codexContext?.pendingApply
+                ? t('ccAgent.layout.contextRing.codexPendingHint')
+                : tooltipText}
+            </div>
+            <div>
+              {codexContext
+                ? t('settings.providers.models.advanced.codexContextValues', {
+                    total: codexContext.contextWindow.toLocaleString(),
+                    usable: codexContext.usableContextWindow.toLocaleString(),
+                    compact: codexContext.autoCompactTokenLimit.toLocaleString(),
+                  })
+                : t('settings.providers.models.advanced.codexContextUnknown')}
+            </div>
             <div>{t('ccAgent.layout.contextRing.codexAutoHint')}</div>
           </>
         ) : (
@@ -6034,8 +6040,12 @@ function ContextCapacityRing({
           {ringContent}
         </button>
       ) : (
-        <div className="flex shrink-0 items-center gap-1"
-          onMouseEnter={() => { if (vendorKey === 'codex') setContextInspection(n => n + 1); }}>
+        <div
+          className="flex shrink-0 items-center gap-1"
+          onMouseEnter={() => {
+            if (vendorKey === 'codex') setContextInspection((n) => n + 1);
+          }}
+        >
           {ringContent}
         </div>
       )}

--- a/apps/desktop/src/renderer/features/cc-agent/RemoteSessionBanner.tsx
+++ b/apps/desktop/src/renderer/features/cc-agent/RemoteSessionBanner.tsx
@@ -18,11 +18,10 @@
  */
 
 import { useTranslation } from 'react-i18next';
-import { useEffect, useState } from 'react';
 import { RotateCw, Square } from 'lucide-react';
 
 interface Props {
-  status: 'reconnecting' | 'host-offline' | 'degraded' | 'suspect-stall' | 'syncing' | 'recovered';
+  status: 'reconnecting' | 'host-offline' | 'degraded' | 'suspect-stall';
   /**
    * 本机到 relay 的连接问题(鉴权失效/被顶号/超限/版本不符)。仅 reconnecting 态消费:
    * 有明确原因时把笼统的「重连中」替换成具体原因文案,避免无限重连横幅无法行动。
@@ -35,13 +34,6 @@ interface Props {
 
 export function RemoteSessionBanner({ status, issue, onResync, onFinalize }: Props) {
   const { t } = useTranslation();
-  const [hideRecovered, setHideRecovered] = useState(false);
-  useEffect(() => {
-    setHideRecovered(false);
-    if (status !== 'recovered') return;
-    const timer = setTimeout(() => setHideRecovered(true), 2_000);
-    return () => clearTimeout(timer);
-  }, [status]);
   const activeIssue = status === 'reconnecting' ? (issue ?? null) : null;
   const dotColor =
     status === 'host-offline' || activeIssue
@@ -55,16 +47,10 @@ export function RemoteSessionBanner({ status, issue, onResync, onFinalize }: Pro
         ? t('ccAgent.remoteSession.hostOffline')
         : status === 'degraded'
           ? t('ccAgent.remoteSession.degraded')
-          : status === 'syncing'
-            ? t('ccAgent.remoteSession.syncing')
-            : status === 'recovered'
-              ? t('ccAgent.remoteSession.recovered')
-              : t('ccAgent.remoteSession.suspectStall');
+          : t('ccAgent.remoteSession.suspectStall');
   const pulse =
     !activeIssue &&
-    (status === 'reconnecting' || status === 'degraded' || status === 'suspect-stall' || status === 'syncing');
-
-  if (status === 'recovered' && hideRecovered) return null;
+    (status === 'reconnecting' || status === 'degraded' || status === 'suspect-stall');
 
   return (
     <div className="flex select-none items-center gap-2 border-b border-[var(--border-default)] bg-[var(--surface-chip)] px-4 py-1.5">

--- a/apps/desktop/src/renderer/i18n/locales/en/common.json
+++ b/apps/desktop/src/renderer/i18n/locales/en/common.json
@@ -9042,8 +9042,6 @@
       "runningTool": "{{tool}} running…"
     },
     "remoteSession": {
-      "syncing": "Syncing…",
-      "recovered": "Restored",
       "reconnecting": "Connection to the controlled device was lost — reconnecting…",
       "hostOffline": "The controlled device is offline; can't sync right now",
       "degraded": "Connection to the controlled device is unstable — retrying automatically…",

--- a/apps/desktop/src/renderer/i18n/locales/ja/common.json
+++ b/apps/desktop/src/renderer/i18n/locales/ja/common.json
@@ -9027,8 +9027,6 @@
       "runningTool": "{{tool}} を実行中…"
     },
     "remoteSession": {
-      "syncing": "同期中…",
-      "recovered": "復旧しました",
       "reconnecting": "被制御デバイスとの接続が切れました。再接続中…",
       "hostOffline": "被制御デバイスがオフラインのため、現在は同期できません",
       "degraded": "被制御デバイスとの接続が不安定です。自動的に再試行中…",

--- a/apps/desktop/src/renderer/i18n/locales/ko/common.json
+++ b/apps/desktop/src/renderer/i18n/locales/ko/common.json
@@ -9027,8 +9027,6 @@
       "runningTool": "{{tool}} 실행 중…"
     },
     "remoteSession": {
-      "syncing": "동기화 중…",
-      "recovered": "복구됨",
       "reconnecting": "제어 대상 기기와 연결이 끊겼습니다. 다시 연결 중…",
       "hostOffline": "제어 대상 기기가 오프라인이라 지금은 동기화할 수 없습니다",
       "degraded": "제어 대상 기기와 연결이 불안정합니다. 자동으로 다시 시도 중…",

--- a/apps/desktop/src/renderer/i18n/locales/zh-CN/common.json
+++ b/apps/desktop/src/renderer/i18n/locales/zh-CN/common.json
@@ -9027,8 +9027,6 @@
       "runningTool": "{{tool}} 运行中…"
     },
     "remoteSession": {
-      "syncing": "正在同步…",
-      "recovered": "已恢复",
       "reconnecting": "与被控设备的连接中断，正在重连…",
       "hostOffline": "被控设备已离线，暂时无法同步",
       "degraded": "与被控设备的连接不稳定，正在自动重试…",

--- a/apps/desktop/src/renderer/i18n/locales/zh-TW/common.json
+++ b/apps/desktop/src/renderer/i18n/locales/zh-TW/common.json
@@ -9027,8 +9027,6 @@
       "runningTool": "{{tool}} 執行中…"
     },
     "remoteSession": {
-      "syncing": "正在同步…",
-      "recovered": "已恢復",
       "reconnecting": "與被控裝置的連線中斷，正在重連…",
       "hostOffline": "被控裝置已離線，暫時無法同步",
       "degraded": "與被控裝置的連線不穩定，正在自動重試…",


### PR DESCRIPTION
## 这次改了什么

### 摘要

桌面端打开远程任务时，即使消息正常更新，顶部也可能持续显示「正在同步…」，完成后还会短暂显示「已恢复」。这两种状态没有可操作项，容易造成卡住的错觉。

移除这两种正常状态的顶部横幅及恢复提示计时器，同步清理五种语言中对应的废弃翻译。断线重连、设备离线、无响应、疑似断流和具体连接错误继续显示；首屏加载、后台订阅与内容对账照常运行。

### 变更类型

- [x] `fix` 缺陷修复

### 范围

- 关联 Issue / 需求：用户确认去掉正常同步与恢复提示、保留异常提示。
- 本 PR 包含：远程任务顶部横幅显示分支和组件状态精简；同一文件按 Prettier 修正已有格式。
- 明确不包含：连接协议、自动重连、内容恢复机制、移动端。
- 用户可见变化：正常连接时顶部不再出现「正在同步…」「已恢复」。
- 是否存在 breaking change：无。

### UI 变化

- 引用的设计规范：`docs/design-rules/DESIGN.md` §1 Visual Theme & Atmosphere、§5 Layout Principles / Whitespace Philosophy、§9 Iteration Guide、§10 Light / Dark 双模式交付要求。减少低价值提示占用，保留异常反馈和操作入口；两种主题共用同一显示条件，无新增颜色或布局样式。
- 平台：Desktop。未采集实机截图或录屏；Light / Dark 均未实机目检。

## 怎么验证的

### 自动验证

- `corepack pnpm test:unit:related`：通过（Desktop related，52.4 秒；此前等待共享门禁）。
- `corepack pnpm --filter desktop run --if-present typecheck`：通过。
- `corepack pnpm exec prettier --check apps/desktop/src/renderer/features/cc-agent/RemoteSessionBanner.tsx apps/desktop/src/renderer/features/cc-agent/CCAgentSessionView.tsx`：通过。
- `corepack pnpm check:i18n`、`corepack pnpm check:i18n-glossary`：通过（仅存量告警）；五种语言文件 Prettier 检查通过。
- `git diff --check`：通过。

### 手工验证

已 review 完整 diff，核对异常状态优先级、操作按钮和首屏加载显示条件保持一致。

### 未执行的验证

未启动桌面客户端验证真实远程重连；Light / Dark 实机目检均未执行。全量单测 runner 曾因本机未提供裸 `pnpm` 命令而未启动；本次按仓库当前门禁执行 `corepack pnpm test:unit:related`，全量单测交由 CI。

## 风险

### 风险分类

- [x] 其他：低风险 UI 显示调整。

### 影响与回滚

- 影响范围：桌面端远程任务的顶部状态提示；后台同步机制未变。
- 回滚 / 降级方式：回退本 PR 即恢复两种提示。

### 提交前检查

- [x] 已 review 完整 diff
- [x] 每个 commit 都带 DCO 签名（`git commit -s`）
- [x] UI 改动已在「UI 变化」注明引用的设计规范章节
- [x] 未提交凭证、令牌或授权文件
- [x] 已补充必要文档（无需独立文档，行为与验证记于本 PR）
- [x] 已确认测试结果或说明未执行原因

