### PR TITLE
fix(mobile): 新建任务按设备记住上次显式选择的项目目录,重进不再回退到最近首项

### DIFF
--- a/apps/mobile/app/sessions/new.tsx
+++ b/apps/mobile/app/sessions/new.tsx
@@ -2148,6 +2148,16 @@ export default function NewRemoteSessionScreen() {
     setShowHiddenDirectories(false);
   }, [patchDraft]);
 
+  // 用户显式选定目录(快捷选择 / 目录浏览器确认):按设备记住,下次空白新建先恢复它(#4103)。
+  // 自动取最近项目首项走上面的 selectWorkingDir,不算显式选择,不写记忆。
+  const chooseWorkingDir = useCallback((workingDir: string) => {
+    const trimmed = workingDir.trim();
+    if (selectedDeviceId && trimmed) {
+      void saveNewSessionPreferences({ workingDirForDevice: { deviceId: selectedDeviceId, workingDir: trimmed } });
+    }
+    selectWorkingDir(workingDir);
+  }, [selectWorkingDir, selectedDeviceId]);
+
   const selectDialogueWorkspace = useCallback(() => {
     userTouchedWorkspaceRef.current = true;
     void saveNewSessionPreferences({ workspaceKind: 'dialogue' });
@@ -2159,12 +2169,19 @@ export default function NewRemoteSessionScreen() {
 
   const selectRecentProject = useCallback((workingDir: string) => {
     userTouchedWorkspaceRef.current = true;
-    void saveNewSessionPreferences({ workspaceKind: 'project' });
+    const trimmed = workingDir.trim();
+    void saveNewSessionPreferences({
+      workspaceKind: 'project',
+      // 显式点选最近项目 = 该设备的目录记忆(#4103);设备未定时只记模式。
+      ...(selectedDeviceId && trimmed
+        ? { workingDirForDevice: { deviceId: selectedDeviceId, workingDir: trimmed } }
+        : {}),
+    });
     patchDraft({ workspaceKind: 'project', workingDir });
     setWorkspacePickerOpen(false);
     setBrowseOpen(false);
     setShowHiddenDirectories(false);
-  }, [patchDraft]);
+  }, [patchDraft, selectedDeviceId]);
 
   const openProjectBrowse = useCallback(() => {
     userTouchedWorkspaceRef.current = true;
@@ -3697,7 +3714,12 @@ export default function NewRemoteSessionScreen() {
     if (initialWorkspaceKeyRef.current === key) return;
     initialWorkspaceKeyRef.current = key;
 
-    const initialWorkspace = pickInitialNewSessionWorkspace(draft.workingDir, recentWorkspaces);
+    // 先用该设备记住的上次显式选择(#4103),没有再取最近项目首项。
+    const initialWorkspace = pickInitialNewSessionWorkspace(
+      draft.workingDir,
+      recentWorkspaces,
+      newSessionPreferences?.workingDirByDevice?.[selectedDeviceId] ?? null,
+    );
     if (initialWorkspace) {
       selectWorkingDir(initialWorkspace);
       return;
@@ -3714,6 +3736,7 @@ export default function NewRemoteSessionScreen() {
     recentWorkspaces,
     selectWorkingDir,
     newSessionPreferencesLoaded,
+    newSessionPreferences?.workingDirByDevice,
     preferredDefaultDevice?.deviceId,
   ]);
 
@@ -5640,7 +5663,7 @@ export default function NewRemoteSessionScreen() {
                         accessibilityRole="button"
                         disabled={creating}
                         key={workspace.workingDir}
-                        onPress={() => selectWorkingDir(workspace.workingDir)}
+                        onPress={() => chooseWorkingDir(workspace.workingDir)}
                         style={({ pressed }) => [styles.workspaceQuickPick, pressed && styles.pressed]}
                         testID="newSession.workspaceQuickPick"
                       >
@@ -5668,7 +5691,7 @@ export default function NewRemoteSessionScreen() {
                     accessibilityLabel={t('session.new.useCurrentRemoteDir')}
                     accessibilityRole="button"
                     disabled={!browsePath || browseLoading}
-                    onPress={() => browsePath && selectWorkingDir(browsePath)}
+                    onPress={() => browsePath && chooseWorkingDir(browsePath)}
                     style={({ pressed }) => [
                       styles.browseActionButton,
                       (!browsePath || browseLoading) && styles.disabled,
@@ -5715,7 +5738,7 @@ export default function NewRemoteSessionScreen() {
                       disabled={creating || browseLoading}
                       entry={item}
                       onEnter={() => void loadBrowsePath(item.path)}
-                      onSelect={() => selectWorkingDir(item.path)}
+                      onSelect={() => chooseWorkingDir(item.path)}
                     />
                   )}
                   nestedScrollEnabled

--- a/apps/mobile/app/sessions/new.tsx
+++ b/apps/mobile/app/sessions/new.tsx
@@ -2148,15 +2148,24 @@ export default function NewRemoteSessionScreen() {
     setShowHiddenDirectories(false);
   }, [patchDraft]);
 
+  // 用户显式选定目录 → 该设备的目录记忆(#4103):同步进本地 state(本页内切走再切回
+  // 也拿最新值,落盘不回写 state,对齐 selectPermissionMode)并返回落盘 patch 片段。
+  // 路径原样保存,只用 trim 判空(首尾空格可能是路径的一部分)。设备未定时不记。
+  const rememberWorkingDirForDevice = useCallback((workingDir: string) => {
+    if (!selectedDeviceId || !workingDir.trim()) return undefined;
+    setNewSessionPreferences((prev) => prev
+      ? { ...prev, workingDirByDevice: { ...prev.workingDirByDevice, [selectedDeviceId]: workingDir } }
+      : prev);
+    return { deviceId: selectedDeviceId, workingDir };
+  }, [selectedDeviceId]);
+
   // 用户显式选定目录(快捷选择 / 目录浏览器确认):按设备记住,下次空白新建先恢复它(#4103)。
   // 自动取最近项目首项走上面的 selectWorkingDir,不算显式选择,不写记忆。
   const chooseWorkingDir = useCallback((workingDir: string) => {
-    const trimmed = workingDir.trim();
-    if (selectedDeviceId && trimmed) {
-      void saveNewSessionPreferences({ workingDirForDevice: { deviceId: selectedDeviceId, workingDir: trimmed } });
-    }
+    const remembered = rememberWorkingDirForDevice(workingDir);
+    if (remembered) void saveNewSessionPreferences({ workingDirForDevice: remembered });
     selectWorkingDir(workingDir);
-  }, [selectWorkingDir, selectedDeviceId]);
+  }, [rememberWorkingDirForDevice, selectWorkingDir]);
 
   const selectDialogueWorkspace = useCallback(() => {
     userTouchedWorkspaceRef.current = true;
@@ -2169,19 +2178,17 @@ export default function NewRemoteSessionScreen() {
 
   const selectRecentProject = useCallback((workingDir: string) => {
     userTouchedWorkspaceRef.current = true;
-    const trimmed = workingDir.trim();
+    // 显式点选最近项目 = 该设备的目录记忆(#4103);设备未定时只记模式。
+    const remembered = rememberWorkingDirForDevice(workingDir);
     void saveNewSessionPreferences({
       workspaceKind: 'project',
-      // 显式点选最近项目 = 该设备的目录记忆(#4103);设备未定时只记模式。
-      ...(selectedDeviceId && trimmed
-        ? { workingDirForDevice: { deviceId: selectedDeviceId, workingDir: trimmed } }
-        : {}),
+      ...(remembered ? { workingDirForDevice: remembered } : {}),
     });
     patchDraft({ workspaceKind: 'project', workingDir });
     setWorkspacePickerOpen(false);
     setBrowseOpen(false);
     setShowHiddenDirectories(false);
-  }, [patchDraft, selectedDeviceId]);
+  }, [patchDraft, rememberWorkingDirForDevice]);
 
   const openProjectBrowse = useCallback(() => {
     userTouchedWorkspaceRef.current = true;

--- a/apps/mobile/app/sessions/new.tsx
+++ b/apps/mobile/app/sessions/new.tsx
@@ -453,6 +453,7 @@ export default function NewRemoteSessionScreen() {
   const [selectedDeviceId, setSelectedDeviceId] = useState(routeDeviceId);
   const [selectedDeviceName, setSelectedDeviceName] = useState(routeDeviceName);
   const [newSessionPreferences, setNewSessionPreferences] = useState<NewSessionStoredPreferences | null>(null);
+  const workingDirPreferenceOverridesRef = useRef<Record<string, string>>({});
   const [newSessionPreferencesLoaded, setNewSessionPreferencesLoaded] = useState(false);
   const [devicePickerOpen, setDevicePickerOpen] = useState(false);
   const preferredDefaultDevice = useMemo(
@@ -838,7 +839,11 @@ export default function NewRemoteSessionScreen() {
     void readNewSessionPreferences()
       .then((preferences) => {
         if (cancelled) return;
-        setNewSessionPreferences(preferences);
+        // A late initial read must not replace directories explicitly chosen while it was pending.
+        setNewSessionPreferences({
+          ...preferences,
+          workingDirByDevice: { ...preferences.workingDirByDevice, ...workingDirPreferenceOverridesRef.current },
+        });
         const workspaceKind = preferences.workspaceKind;
         if (!initialWorkingDir && workspaceKind) {
           setDraft((current) => userTouchedWorkspaceRef.current
@@ -2153,6 +2158,7 @@ export default function NewRemoteSessionScreen() {
   // 路径原样保存,只用 trim 判空(首尾空格可能是路径的一部分)。设备未定时不记。
   const rememberWorkingDirForDevice = useCallback((workingDir: string) => {
     if (!selectedDeviceId || !workingDir.trim()) return undefined;
+    workingDirPreferenceOverridesRef.current[selectedDeviceId] = workingDir;
     setNewSessionPreferences((prev) => prev
       ? { ...prev, workingDirByDevice: { ...prev.workingDirByDevice, [selectedDeviceId]: workingDir } }
       : prev);

--- a/apps/mobile/src/__tests__/authWeakNetworkBootstrap.test.ts
+++ b/apps/mobile/src/__tests__/authWeakNetworkBootstrap.test.ts
@@ -36,7 +36,7 @@ describe('auth weak-network bootstrap', () => {
       'activateMobileSessionRealm(storedSession.realm);',
     );
     const publishUserAt = restoreBody.indexOf('setUser(cachedUser);');
-    const publishOwnerAt = restoreBody.indexOf('setMobileAuthOwner(cachedUser.id);');
+    const publishOwnerAt = restoreBody.indexOf('setMobileAuthOwner(cachedUser.id, storedSession.realm);');
     expect(loadRealmAt).toBeGreaterThanOrEqual(0);
     expect(activateRealmAt).toBeGreaterThan(loadRealmAt);
     expect(publishOwnerAt).toBeGreaterThan(activateRealmAt);
@@ -63,7 +63,7 @@ describe('auth weak-network bootstrap', () => {
     const applyUserStart = authSource.indexOf('const applyUser = useCallback');
     const applyUserEnd = authSource.indexOf('\n  );', applyUserStart);
     const applyUserBody = authSource.slice(applyUserStart, applyUserEnd);
-    expect(applyUserBody.indexOf('setMobileAuthOwner(next?.id);'))
+    expect(applyUserBody.indexOf('setMobileAuthOwner(next?.id, activeAuthRealmRef.current);'))
       .toBeLessThan(applyUserBody.indexOf('setUser(next);'));
     expect(applyUserBody).toContain(
       'accountVaultKey(activeAuthRealmRef.current, next.id)',

--- a/apps/mobile/src/__tests__/newSession.test.ts
+++ b/apps/mobile/src/__tests__/newSession.test.ts
@@ -1448,7 +1448,8 @@ describe('new session model', () => {
     ]);
     // 记忆的目录优先;不要求它仍在最近列表里(列表只保留 6 项,用户本就可从浏览器选任意目录)
     expect(pickInitialNewSessionWorkspace('', recentWorkspaces, '/repo/third')).toBe('/repo/third');
-    expect(pickInitialNewSessionWorkspace('', recentWorkspaces, ' /elsewhere/app ')).toBe('/elsewhere/app');
+    // 路径原样返回:首尾空格可能是目录名的一部分(review:Greptile P1)
+    expect(pickInitialNewSessionWorkspace('', recentWorkspaces, ' /elsewhere/app ')).toBe(' /elsewhere/app ');
     expect(pickInitialNewSessionWorkspace('', [], '/repo/third')).toBe('/repo/third');
     // 草稿已有目录时仍然不动;没有记忆时回落最近项目首项
     expect(pickInitialNewSessionWorkspace('/explicit', recentWorkspaces, '/repo/third')).toBeNull();

--- a/apps/mobile/src/__tests__/newSession.test.ts
+++ b/apps/mobile/src/__tests__/newSession.test.ts
@@ -1441,6 +1441,21 @@ describe('new session model', () => {
     expect(pickInitialNewSessionWorkspace('', [])).toBeNull();
   });
 
+  it('prefers the directory the user last explicitly chose on this device over the most recent workspace (#4103)', () => {
+    const recentWorkspaces = buildRecentWorkspaceOptions([
+      remoteSession('latest', { workingDir: '/repo/latest', userSendAt: '2026-01-01T00:10:00.000Z' }),
+      remoteSession('third', { workingDir: '/repo/third', userSendAt: '2026-01-01T00:01:00.000Z' }),
+    ]);
+    // 记忆的目录优先;不要求它仍在最近列表里(列表只保留 6 项,用户本就可从浏览器选任意目录)
+    expect(pickInitialNewSessionWorkspace('', recentWorkspaces, '/repo/third')).toBe('/repo/third');
+    expect(pickInitialNewSessionWorkspace('', recentWorkspaces, ' /elsewhere/app ')).toBe('/elsewhere/app');
+    expect(pickInitialNewSessionWorkspace('', [], '/repo/third')).toBe('/repo/third');
+    // 草稿已有目录时仍然不动;没有记忆时回落最近项目首项
+    expect(pickInitialNewSessionWorkspace('/explicit', recentWorkspaces, '/repo/third')).toBeNull();
+    expect(pickInitialNewSessionWorkspace('', recentWorkspaces, null)).toBe('/repo/latest');
+    expect(pickInitialNewSessionWorkspace('', recentWorkspaces, '   ')).toBe('/repo/latest');
+  });
+
   it('normalizes create results and can synthesize a fallback session row', () => {
     const result = normalizeCreateSessionResult({
       sessionId: 's-new',

--- a/apps/mobile/src/__tests__/newSessionPreferenceStore.test.ts
+++ b/apps/mobile/src/__tests__/newSessionPreferenceStore.test.ts
@@ -1,4 +1,5 @@
-import { setMobileAuthOwner } from '@/auth/authOwnerGeneration';
+import { accountVaultKey } from '@cindy/auth-client';
+import { getMobileAuthOwner, isMobileAuthOwnerCurrent, setMobileAuthOwner } from '@/auth/authOwnerGeneration';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 const store = vi.hoisted(() => new Map<string, string>());
@@ -55,6 +56,30 @@ describe('newSessionPreferenceStore', () => {
     await saving;
     expect((await reading).workingDirByDevice).toEqual({});
     expect((await readNewSessionPreferences()).workingDirByDevice).toEqual({});
+  });
+
+  it('isolates equal membership IDs across realms and invalidates pending work', async () => {
+    const { __testing, readNewSessionPreferences, saveNewSessionPreferences } =
+      await import('@/session/newSessionPreferenceStore');
+    store.set(__testing.workingDirStorageKey('shared-member'), JSON.stringify({
+      'shared-device': '/unqualified/private',
+    }));
+    setMobileAuthOwner('shared-member', 'cn');
+    expect((await readNewSessionPreferences()).workingDirByDevice).toEqual({});
+    await saveNewSessionPreferences({ workingDirForDevice: { deviceId: 'shared-device', workingDir: '/cn/private' } });
+    const cnOwner = getMobileAuthOwner();
+    const saving = saveNewSessionPreferences({ workingDirForDevice: { deviceId: 'shared-device', workingDir: '/cn/pending' } });
+    const reading = readNewSessionPreferences();
+    setMobileAuthOwner('shared-member', 'global');
+    expect(isMobileAuthOwnerCurrent(cnOwner)).toBe(false);
+    await saving;
+    expect((await reading).workingDirByDevice).toEqual({});
+    expect((await readNewSessionPreferences()).workingDirByDevice).toEqual({});
+    await saveNewSessionPreferences({ workingDirForDevice: { deviceId: 'shared-device', workingDir: '/global/private' } });
+    setMobileAuthOwner('shared-member', 'cn');
+    expect((await readNewSessionPreferences()).workingDirByDevice).toEqual({ 'shared-device': '/cn/private' });
+    setMobileAuthOwner('shared-member', 'global');
+    expect((await readNewSessionPreferences()).workingDirByDevice).toEqual({ 'shared-device': '/global/private' });
   });
 
   it('stores the last selected device and agent for new sessions', async () => {
@@ -190,14 +215,14 @@ describe('newSessionPreferenceStore', () => {
     expect(JSON.parse(store.get(__testing.storageKey) ?? '{}')).toEqual({
       workspaceKind: 'dialogue',
     });
-    expect(JSON.parse(store.get(__testing.workingDirStorageKey('account-a')) ?? '{}')).toEqual({ devA: '/repo/fourth', devB: ' /other/app ' });
+    expect(JSON.parse(store.get(__testing.workingDirStorageKey(accountVaultKey('global', 'account-a'))) ?? '{}')).toEqual({ devA: '/repo/fourth', devB: ' /other/app ' });
 
     // 落盘里的非法条目(非字符串 / 空)在读取时被清洗,旧存储没有该字段也不报错。
-    store.set(__testing.workingDirStorageKey('account-a'), JSON.stringify({ devA: '/repo/ok', devB: 42, ' ': '/x', devC: '', devD: ' /keep me ' }));
+    store.set(__testing.workingDirStorageKey(accountVaultKey('global', 'account-a')), JSON.stringify({ devA: '/repo/ok', devB: 42, ' ': '/x', devC: '', devD: ' /keep me ' }));
     await expect(readNewSessionPreferences()).resolves.toMatchObject({
       workingDirByDevice: { devA: '/repo/ok', devD: ' /keep me ' },
     });
-    store.set(__testing.workingDirStorageKey('account-a'), JSON.stringify('bad'));
+    store.set(__testing.workingDirStorageKey(accountVaultKey('global', 'account-a')), JSON.stringify('bad'));
     await expect(readNewSessionPreferences()).resolves.toMatchObject({ workingDirByDevice: {} });
   });
 

--- a/apps/mobile/src/__tests__/newSessionPreferenceStore.test.ts
+++ b/apps/mobile/src/__tests__/newSessionPreferenceStore.test.ts
@@ -40,6 +40,7 @@ describe('newSessionPreferenceStore', () => {
       device: { deviceId: 'devA', name: 'Mac A' },
       workspaceKind: null,
       permissionModeByAgent: {},
+      workingDirByDevice: {},
     });
     expect(JSON.parse(store.get(__testing.storageKey) ?? '{}')).toEqual({
       agentKind: 'codex',
@@ -66,6 +67,7 @@ describe('newSessionPreferenceStore', () => {
       device: { deviceId: 'devB', name: 'devB' },
       workspaceKind: null,
       permissionModeByAgent: {},
+      workingDirByDevice: {},
     });
 
     store.set(__testing.storageKey, '{broken');
@@ -74,6 +76,7 @@ describe('newSessionPreferenceStore', () => {
       device: null,
       workspaceKind: null,
       permissionModeByAgent: {},
+      workingDirByDevice: {},
     });
 
     await saveNewSessionPreferences({
@@ -84,6 +87,7 @@ describe('newSessionPreferenceStore', () => {
       device: { deviceId: 'devC', name: 'devC' },
       workspaceKind: null,
       permissionModeByAgent: {},
+      workingDirByDevice: {},
     });
   });
 
@@ -110,6 +114,7 @@ describe('newSessionPreferenceStore', () => {
       device: null,
       workspaceKind: null,
       permissionModeByAgent: { 'claude-code': 'bypassPermissions', codex: 'ask' },
+      workingDirByDevice: {},
     });
 
     // 落盘的 plan / 非法 agent 键在读取时被清洗。
@@ -121,7 +126,46 @@ describe('newSessionPreferenceStore', () => {
       device: null,
       workspaceKind: null,
       permissionModeByAgent: { codex: 'auto' },
+      workingDirByDevice: {},
     });
+  });
+
+  it('remembers the last explicitly chosen project directory per device (#4103)', async () => {
+    const {
+      __testing,
+      readNewSessionPreferences,
+      saveNewSessionPreferences,
+    } = await import('@/session/newSessionPreferenceStore');
+
+    await saveNewSessionPreferences({ workingDirForDevice: { deviceId: 'devA', workingDir: '/repo/third' } });
+    await saveNewSessionPreferences({ workingDirForDevice: { deviceId: 'devB', workingDir: ' /other/app ' } });
+    // 同设备再次选择覆盖上次;空值 / 空设备被忽略,不清掉已有记忆。
+    await saveNewSessionPreferences({ workingDirForDevice: { deviceId: 'devA', workingDir: '/repo/fourth' } });
+    await saveNewSessionPreferences({ workingDirForDevice: { deviceId: 'devA', workingDir: '   ' } });
+    await saveNewSessionPreferences({ workingDirForDevice: { deviceId: '', workingDir: '/nope' } });
+    await saveNewSessionPreferences({ workspaceKind: 'dialogue' });
+
+    await expect(readNewSessionPreferences()).resolves.toEqual({
+      agentKind: null,
+      device: null,
+      workspaceKind: 'dialogue',
+      permissionModeByAgent: {},
+      workingDirByDevice: { devA: '/repo/fourth', devB: '/other/app' },
+    });
+    expect(JSON.parse(store.get(__testing.storageKey) ?? '{}')).toEqual({
+      workspaceKind: 'dialogue',
+      workingDirByDevice: { devA: '/repo/fourth', devB: '/other/app' },
+    });
+
+    // 落盘里的非法条目(非字符串 / 空)在读取时被清洗,旧存储没有该字段也不报错。
+    store.set(__testing.storageKey, JSON.stringify({
+      workingDirByDevice: { devA: '/repo/ok', devB: 42, ' ': '/x', devC: '' },
+    }));
+    await expect(readNewSessionPreferences()).resolves.toMatchObject({
+      workingDirByDevice: { devA: '/repo/ok' },
+    });
+    store.set(__testing.storageKey, JSON.stringify({ workingDirByDevice: 'bad' }));
+    await expect(readNewSessionPreferences()).resolves.toMatchObject({ workingDirByDevice: {} });
   });
 
   it('remembers either workspace mode across reloads without losing other preferences', async () => {
@@ -148,6 +192,7 @@ describe('newSessionPreferenceStore', () => {
       workspaceKind: 'dialogue',
       agentKind: 'codex',
       permissionModeByAgent: { codex: 'ask' },
+      workingDirByDevice: {},
     });
   });
 

--- a/apps/mobile/src/__tests__/newSessionPreferenceStore.test.ts
+++ b/apps/mobile/src/__tests__/newSessionPreferenceStore.test.ts
@@ -138,6 +138,7 @@ describe('newSessionPreferenceStore', () => {
     } = await import('@/session/newSessionPreferenceStore');
 
     await saveNewSessionPreferences({ workingDirForDevice: { deviceId: 'devA', workingDir: '/repo/third' } });
+    // 路径原样保存:首尾空格可能是目录名的一部分(review:Greptile P1)
     await saveNewSessionPreferences({ workingDirForDevice: { deviceId: 'devB', workingDir: ' /other/app ' } });
     // 同设备再次选择覆盖上次;空值 / 空设备被忽略,不清掉已有记忆。
     await saveNewSessionPreferences({ workingDirForDevice: { deviceId: 'devA', workingDir: '/repo/fourth' } });
@@ -150,19 +151,19 @@ describe('newSessionPreferenceStore', () => {
       device: null,
       workspaceKind: 'dialogue',
       permissionModeByAgent: {},
-      workingDirByDevice: { devA: '/repo/fourth', devB: '/other/app' },
+      workingDirByDevice: { devA: '/repo/fourth', devB: ' /other/app ' },
     });
     expect(JSON.parse(store.get(__testing.storageKey) ?? '{}')).toEqual({
       workspaceKind: 'dialogue',
-      workingDirByDevice: { devA: '/repo/fourth', devB: '/other/app' },
+      workingDirByDevice: { devA: '/repo/fourth', devB: ' /other/app ' },
     });
 
     // 落盘里的非法条目(非字符串 / 空)在读取时被清洗,旧存储没有该字段也不报错。
     store.set(__testing.storageKey, JSON.stringify({
-      workingDirByDevice: { devA: '/repo/ok', devB: 42, ' ': '/x', devC: '' },
+      workingDirByDevice: { devA: '/repo/ok', devB: 42, ' ': '/x', devC: '', devD: ' /keep me ' },
     }));
     await expect(readNewSessionPreferences()).resolves.toMatchObject({
-      workingDirByDevice: { devA: '/repo/ok' },
+      workingDirByDevice: { devA: '/repo/ok', devD: ' /keep me ' },
     });
     store.set(__testing.storageKey, JSON.stringify({ workingDirByDevice: 'bad' }));
     await expect(readNewSessionPreferences()).resolves.toMatchObject({ workingDirByDevice: {} });

--- a/apps/mobile/src/__tests__/newSessionPreferenceStore.test.ts
+++ b/apps/mobile/src/__tests__/newSessionPreferenceStore.test.ts
@@ -1,3 +1,4 @@
+import { setMobileAuthOwner } from '@/auth/authOwnerGeneration';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 const store = vi.hoisted(() => new Map<string, string>());
@@ -21,6 +22,39 @@ describe('newSessionPreferenceStore', () => {
     const { clearNewSessionPreferences } = await import('@/session/newSessionPreferenceStore');
     await clearNewSessionPreferences();
     store.clear();
+    setMobileAuthOwner('account-a');
+  });
+
+  it('isolates directories on the same device across accounts and signed-out reads', async () => {
+    const { readNewSessionPreferences, saveNewSessionPreferences } =
+      await import('@/session/newSessionPreferenceStore');
+    await saveNewSessionPreferences({ workingDirForDevice: { deviceId: 'shared-device', workingDir: '/account-a/private' } });
+    setMobileAuthOwner('account-b');
+    expect((await readNewSessionPreferences()).workingDirByDevice).toEqual({});
+    await saveNewSessionPreferences({ workingDirForDevice: { deviceId: 'shared-device', workingDir: '/account-b/private' } });
+    setMobileAuthOwner(null);
+    expect((await readNewSessionPreferences()).workingDirByDevice).toEqual({});
+    setMobileAuthOwner('account-a');
+    expect((await readNewSessionPreferences()).workingDirByDevice).toEqual({ 'shared-device': '/account-a/private' });
+    setMobileAuthOwner('account-b');
+    expect((await readNewSessionPreferences()).workingDirByDevice).toEqual({ 'shared-device': '/account-b/private' });
+  });
+
+  it('does not adopt the unowned legacy directory map into a logged-in account', async () => {
+    const { __testing, readNewSessionPreferences } = await import('@/session/newSessionPreferenceStore');
+    store.set(__testing.storageKey, JSON.stringify({ agentKind: 'codex', workingDirByDevice: { devA: '/previous-owner/private' } }));
+    expect(await readNewSessionPreferences()).toMatchObject({ agentKind: 'codex', workingDirByDevice: {} });
+  });
+
+  it('does not attribute a queued directory save or late read to the next account', async () => {
+    const { readNewSessionPreferences, saveNewSessionPreferences } =
+      await import('@/session/newSessionPreferenceStore');
+    const saving = saveNewSessionPreferences({ workingDirForDevice: { deviceId: 'shared-device', workingDir: '/account-a/private' } });
+    const reading = readNewSessionPreferences();
+    setMobileAuthOwner('account-b');
+    await saving;
+    expect((await reading).workingDirByDevice).toEqual({});
+    expect((await readNewSessionPreferences()).workingDirByDevice).toEqual({});
   });
 
   it('stores the last selected device and agent for new sessions', async () => {
@@ -155,17 +189,15 @@ describe('newSessionPreferenceStore', () => {
     });
     expect(JSON.parse(store.get(__testing.storageKey) ?? '{}')).toEqual({
       workspaceKind: 'dialogue',
-      workingDirByDevice: { devA: '/repo/fourth', devB: ' /other/app ' },
     });
+    expect(JSON.parse(store.get(__testing.workingDirStorageKey('account-a')) ?? '{}')).toEqual({ devA: '/repo/fourth', devB: ' /other/app ' });
 
     // 落盘里的非法条目(非字符串 / 空)在读取时被清洗,旧存储没有该字段也不报错。
-    store.set(__testing.storageKey, JSON.stringify({
-      workingDirByDevice: { devA: '/repo/ok', devB: 42, ' ': '/x', devC: '', devD: ' /keep me ' },
-    }));
+    store.set(__testing.workingDirStorageKey('account-a'), JSON.stringify({ devA: '/repo/ok', devB: 42, ' ': '/x', devC: '', devD: ' /keep me ' }));
     await expect(readNewSessionPreferences()).resolves.toMatchObject({
       workingDirByDevice: { devA: '/repo/ok', devD: ' /keep me ' },
     });
-    store.set(__testing.storageKey, JSON.stringify({ workingDirByDevice: 'bad' }));
+    store.set(__testing.workingDirStorageKey('account-a'), JSON.stringify('bad'));
     await expect(readNewSessionPreferences()).resolves.toMatchObject({ workingDirByDevice: {} });
   });
 

--- a/apps/mobile/src/__tests__/newSessionPreferenceStore.test.ts
+++ b/apps/mobile/src/__tests__/newSessionPreferenceStore.test.ts
@@ -1,3 +1,5 @@
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
 import { accountVaultKey } from '@cindy/auth-client';
 import { getMobileAuthOwner, isMobileAuthOwnerCurrent, setMobileAuthOwner } from '@/auth/authOwnerGeneration';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
@@ -80,6 +82,25 @@ describe('newSessionPreferenceStore', () => {
     expect((await readNewSessionPreferences()).workingDirByDevice).toEqual({ 'shared-device': '/cn/private' });
     setMobileAuthOwner('shared-member', 'global');
     expect((await readNewSessionPreferences()).workingDirByDevice).toEqual({ 'shared-device': '/global/private' });
+  });
+
+  it('keeps the bare owner ID accepted by both live creation guards and recovery namespaces', () => {
+    setMobileAuthOwner('shared-member', 'cn');
+    // These are the actual normal/goal creation predicates, not a copied guard.
+    const source = readFileSync(resolve(process.cwd(), 'app/sessions/new.tsx'), 'utf8');
+    const guards = [...source.matchAll(/const isCurrentOwner = \(\) => \(([\s\S]*?)\n    \);/g)];
+    expect(guards).toHaveLength(2);
+    for (const [, predicate] of guards) {
+      const accepts = new Function('authOwnerAtCreate', 'accountIdAtCreate', 'isMobileAuthOwnerCurrent', `return (${predicate});`);
+      const currentOwner = getMobileAuthOwner();
+      expect(accepts(currentOwner, 'shared-member', isMobileAuthOwnerCurrent)).toBe(true);
+      setMobileAuthOwner('shared-member', 'global');
+      expect(accepts(currentOwner, 'shared-member', isMobileAuthOwnerCurrent)).toBe(false);
+      setMobileAuthOwner('shared-member', 'cn');
+    }
+    // Existing recovery entries are namespaced by the bare membership ID.
+    expect(getMobileAuthOwner().accountId).toBe('shared-member');
+    expect(source.match(/const worktreeAccountId = authOwnerAtCreate.accountId;/g)).toHaveLength(2);
   });
 
   it('stores the last selected device and agent for new sessions', async () => {

--- a/apps/mobile/src/__tests__/newSessionWorkspaceEffects.test.tsx
+++ b/apps/mobile/src/__tests__/newSessionWorkspaceEffects.test.tsx
@@ -27,7 +27,8 @@ const declarations = new Set([
   'selectedDeviceId', 'selectedDeviceName', 'newSessionPreferences', 'newSessionPreferencesLoaded',
   'preferredDefaultDevice', 'recentWorkspaces', 'draft', 'initialWorkspaceKeyRef',
   'appliedDefaultDeviceKeyRef', 'userTouchedDeviceRef', 'userTouchedWorkspaceRef',
-  'patchDraft', 'selectWorkingDir', 'selectDialogueWorkspace', 'selectRecentProject', 'openProjectBrowse',
+  'patchDraft', 'selectWorkingDir', 'rememberWorkingDirForDevice', 'selectDialogueWorkspace',
+  'selectRecentProject', 'openProjectBrowse',
 ]);
 const effectMarkers = new Set([
   'drainStashedNewSessionDraft', 'readNewSessionPreferences',
@@ -67,6 +68,8 @@ interface WorkspaceState {
   selectDialogueWorkspace(): void;
   selectRecentProject(path: string): void;
   openProjectBrowse(): void;
+  /** 模拟页面 selectDevice 里与工作区相关的部分:标记用户动过设备、重置初始工作区决策、清空项目目录。 */
+  switchDevice(deviceId: string): void;
 }
 const bindingNames = [
   'useState', 'useRef', 'useMemo', 'useEffect', 'useCallback', 'DEFAULT_NEW_SESSION_DRAFT',
@@ -80,8 +83,14 @@ const bindingNames = [
 const compiled = ts.transpileModule(`function usePageWorkspace(bindings) {
   const { ${bindingNames.join(', ')} } = bindings;
   ${selected.map((statement) => statement.getText(source)).join('\n')}
+  const switchDevice = (deviceId) => {
+    userTouchedDeviceRef.current = true;
+    initialWorkspaceKeyRef.current = null;
+    setSelectedDeviceId(deviceId);
+    setDraft((current) => current.workspaceKind === 'project' ? { ...current, workingDir: '' } : current);
+  };
   return { draft, selectedDeviceId, newSessionPreferencesLoaded,
-    selectDialogueWorkspace, selectRecentProject, openProjectBrowse };
+    selectDialogueWorkspace, selectRecentProject, openProjectBrowse, switchDevice };
 }`, { compilerOptions: { target: ts.ScriptTarget.ES2022 } }).outputText;
 const usePageWorkspace = new Function(`${compiled}; return usePageWorkspace;`)() as
   (bindings: Record<string, unknown>) => WorkspaceState;
@@ -211,6 +220,20 @@ describe('new session workspace page effects', () => {
       expect.objectContaining({ workingDirForDevice: expect.anything() }),
     );
     expect(page.bindings.loadBrowsePath).not.toHaveBeenCalled();
+  });
+
+  it('uses the directory chosen in this session after switching devices and back, not the stale stored one (#4103 Codex P2)', async () => {
+    const page = mountWorkspace();
+    await page.resolvePreferences('project', 'a', { a: '/projects/old-a' });
+    expect(page.current.draft.workingDir).toBe('/projects/old-a');
+    // 本页内显式换成新目录 → 内存里的设备记忆同步更新(落盘不回写 state)
+    act(() => page.current.selectRecentProject('/projects/new-a'));
+    expect(page.current.draft.workingDir).toBe('/projects/new-a');
+    // 切到 b(无记忆 → 最近首项),再切回 a:应恢复本页刚选的 new-a,而不是读取时的 old-a
+    act(() => page.current.switchDevice('b'));
+    expect(page.current.draft.workingDir).toBe('/projects/b');
+    act(() => page.current.switchDevice('a'));
+    expect(page.current.draft.workingDir).toBe('/projects/new-a');
   });
 
   it('falls back to the most recent workspace when only another device has a remembered directory', async () => {

--- a/apps/mobile/src/__tests__/newSessionWorkspaceEffects.test.tsx
+++ b/apps/mobile/src/__tests__/newSessionWorkspaceEffects.test.tsx
@@ -25,6 +25,7 @@ const page = source.statements.find((node): node is ts.FunctionDeclaration =>
 if (!page?.body) throw new Error('NewRemoteSessionScreen not found');
 const declarations = new Set([
   'selectedDeviceId', 'selectedDeviceName', 'newSessionPreferences', 'newSessionPreferencesLoaded',
+  'workingDirPreferenceOverridesRef',
   'preferredDefaultDevice', 'recentWorkspaces', 'draft', 'initialWorkspaceKeyRef',
   'appliedDefaultDeviceKeyRef', 'userTouchedDeviceRef', 'userTouchedWorkspaceRef',
   'patchDraft', 'selectWorkingDir', 'rememberWorkingDirForDevice', 'selectDialogueWorkspace',
@@ -154,6 +155,19 @@ function mountWorkspace(options: { initialWorkingDir?: string; restoredKind?: Ne
 }
 
 describe('new session workspace page effects', () => {
+  it('keeps choices for both devices made before the stored preferences arrive', async () => {
+    const page = mountWorkspace();
+    act(() => page.current.selectRecentProject(' /manual/a '));
+    act(() => page.current.switchDevice('b'));
+    act(() => page.current.selectRecentProject('/manual/b'));
+    await page.resolvePreferences('project', 'a', { a: '/old/a', b: '/old/b' });
+    act(() => page.current.switchDevice('a'));
+    expect(page.current.draft.workingDir).toBe(' /manual/a ');
+    act(() => page.current.switchDevice('b'));
+    expect(page.current.draft.workingDir).toBe('/manual/b');
+    expect(page.bindings.saveNewSessionPreferences).toHaveBeenCalledTimes(2);
+  });
+
   it('keeps an explicit project entry when a different preference arrives late', async () => {
     const page = mountWorkspace({ initialWorkingDir: '/explicit/project' });
     await page.resolvePreferences('dialogue', 'b');

--- a/apps/mobile/src/__tests__/newSessionWorkspaceEffects.test.tsx
+++ b/apps/mobile/src/__tests__/newSessionWorkspaceEffects.test.tsx
@@ -130,10 +130,14 @@ function mountWorkspace(options: { initialWorkingDir?: string; restoredKind?: Ne
   act(() => root!.render(createElement(Harness)));
   return {
     bindings, commits, get current() { return current; },
-    async resolvePreferences(kind: NewSessionWorkspaceKind | null, deviceId = 'a') {
+    async resolvePreferences(
+      kind: NewSessionWorkspaceKind | null,
+      deviceId = 'a',
+      workingDirByDevice: Record<string, string> = {},
+    ) {
       await act(async () => {
         resolveRead({ workspaceKind: kind, device: { deviceId, name: deviceId },
-          agentKind: null, permissionModeByAgent: {} });
+          agentKind: null, permissionModeByAgent: {}, workingDirByDevice });
         await pendingRead;
       });
     },
@@ -166,7 +170,10 @@ describe('new session workspace page effects', () => {
     await page.resolvePreferences(kind === 'project' ? 'dialogue' : 'project');
     expect(page.current.draft).toMatchObject({ workspaceKind: kind,
       workingDir: kind === 'project' ? '/manual/project' : '' });
-    expect(page.bindings.saveNewSessionPreferences).toHaveBeenCalledWith({ workspaceKind: kind });
+    expect(page.bindings.saveNewSessionPreferences).toHaveBeenCalledWith(kind === 'project'
+      // 显式点选最近项目同时按设备记住目录(#4103)
+      ? { workspaceKind: 'project', workingDirForDevice: { deviceId: 'a', workingDir: '/manual/project' } }
+      : { workspaceKind: 'dialogue' });
   });
 
   it('keeps an explicitly opened project browser open after a late dialogue preference', async () => {
@@ -190,6 +197,26 @@ describe('new session workspace page effects', () => {
       { device: 'b', kind: 'project', path: '/projects/b' },
     ]);
     expect(page.bindings.loadBrowsePath).not.toHaveBeenCalled();
+  });
+
+  it('restores the directory last explicitly chosen on the remembered device instead of the most recent one (#4103)', async () => {
+    const page = mountWorkspace();
+    // 用户上次在设备 b 显式选了第三个目录(它甚至不在最近列表里);重进后应恢复它而不是最近首项 /projects/b
+    await page.resolvePreferences('project', 'b', { b: '/projects/third', a: '/projects/other' });
+    expect(page.current.selectedDeviceId).toBe('b');
+    expect(page.current.draft).toMatchObject({ workspaceKind: 'project', workingDir: '/projects/third' });
+    expect(page.bindings.pickInitialNewSessionWorkspace).toHaveBeenCalledTimes(1);
+    // 自动恢复不算显式选择:不得把它再写回目录记忆
+    expect(page.bindings.saveNewSessionPreferences).not.toHaveBeenCalledWith(
+      expect.objectContaining({ workingDirForDevice: expect.anything() }),
+    );
+    expect(page.bindings.loadBrowsePath).not.toHaveBeenCalled();
+  });
+
+  it('falls back to the most recent workspace when only another device has a remembered directory', async () => {
+    const page = mountWorkspace();
+    await page.resolvePreferences('project', 'b', { a: '/projects/other' });
+    expect(page.current.draft).toMatchObject({ workspaceKind: 'project', workingDir: '/projects/b' });
   });
 
   it('keeps the existing default when storage has no remembered mode', async () => {

--- a/apps/mobile/src/auth/AuthContext.tsx
+++ b/apps/mobile/src/auth/AuthContext.tsx
@@ -817,7 +817,7 @@ export function AuthProvider({ children }: { children: ReactNode }) {
         ? accountVaultKey(activeAuthRealmRef.current, next.id)
         : null;
       setDeferredSessionRecovery(false);
-      setMobileAuthOwner(next?.id);
+      setMobileAuthOwner(next?.id, activeAuthRealmRef.current);
       userRef.current = next;
       setUser(next);
       void serializeUserProfileMutation(() =>
@@ -1072,7 +1072,7 @@ export function AuthProvider({ children }: { children: ReactNode }) {
             // old owner and advance its generation after cleanup settles so
             // account-scoped effects reconnect from the restored session.
             activateMobileSessionRealm(previousRealm);
-            setMobileAuthOwner(userRef.current?.id ?? null);
+            setMobileAuthOwner(userRef.current?.id ?? null, previousRealm);
             setAccountGeneration((value) => value + 1);
           }
           throw error;
@@ -1436,7 +1436,7 @@ export function AuthProvider({ children }: { children: ReactNode }) {
             activateMobileSessionRealm(storedSession.realm);
             activeAuthRealmRef.current = storedSession.realm;
             userRef.current = cachedUser;
-            setMobileAuthOwner(cachedUser.id);
+            setMobileAuthOwner(cachedUser.id, storedSession.realm);
             setUser(cachedUser);
             if (cachedProfile.accountKey === null) {
               void serializeUserProfileMutation(() =>
@@ -2472,14 +2472,14 @@ export function AuthProvider({ children }: { children: ReactNode }) {
                 authGenerationRef.current === generation
               ) {
                 activateMobileSessionRealm(previousRealm);
-                setMobileAuthOwner(userRef.current?.id ?? null);
+                setMobileAuthOwner(userRef.current?.id ?? null, previousRealm);
                 setAccountGeneration((value) => value + 1);
               }
               throw error;
             }
           });
         } catch (error) {
-          setMobileAuthOwner(userRef.current?.id ?? null);
+          setMobileAuthOwner(userRef.current?.id ?? null, activeAuthRealmRef.current);
           throw error;
         }
 
@@ -2535,7 +2535,7 @@ export function AuthProvider({ children }: { children: ReactNode }) {
     sessionRecoverySuspendedRef.current = false;
     await deleteSecureItem(PENDING_OAUTH_KEY).catch(() => undefined);
     activateMobileSessionRealm(activeAuthRealmRef.current);
-    setMobileAuthOwner(userRef.current?.id ?? null);
+    setMobileAuthOwner(userRef.current?.id ?? null, activeAuthRealmRef.current);
     updateLoginState(null);
     setAuthError(null);
   }, [updateLoginState]);

--- a/apps/mobile/src/auth/authOwnerGeneration.ts
+++ b/apps/mobile/src/auth/authOwnerGeneration.ts
@@ -1,13 +1,16 @@
 import { accountVaultKey, type AuthRegion } from '@cindy/auth-client';
 
 export interface MobileAuthOwnerGeneration {
-  /** Canonical realm-qualified account key, not a bare membership ID. */
+  /** Bare membership ID retained for creation guards and recovery ledgers. */
   readonly accountId: string;
+  /** Canonical realm-qualified key for new account-scoped storage. */
+  readonly accountKey: string;
   readonly generation: number;
 }
 
 let current: MobileAuthOwnerGeneration = {
   accountId: '',
+  accountKey: '',
   generation: 0,
 };
 
@@ -16,10 +19,12 @@ export function setMobileAuthOwner(
   accountId: string | null | undefined,
   realm: AuthRegion = 'global',
 ): void {
-  const normalized = accountId ? accountVaultKey(realm, accountId) : '';
-  if (current.accountId === normalized) return;
+  const normalized = accountId?.trim() ?? '';
+  const accountKey = normalized ? accountVaultKey(realm, normalized) : '';
+  if (current.accountKey === accountKey) return;
   current = {
     accountId: normalized,
+    accountKey,
     generation: current.generation + 1,
   };
 }
@@ -32,13 +37,13 @@ export function isMobileAuthOwnerCurrent(
   owner: MobileAuthOwnerGeneration,
 ): boolean {
   return (
-    current.accountId === owner.accountId
+    current.accountKey === owner.accountKey
     && current.generation === owner.generation
   );
 }
 
 export const __testing = {
   reset(): void {
-    current = { accountId: '', generation: 0 };
+    current = { accountId: '', accountKey: '', generation: 0 };
   },
 };

--- a/apps/mobile/src/auth/authOwnerGeneration.ts
+++ b/apps/mobile/src/auth/authOwnerGeneration.ts
@@ -1,4 +1,7 @@
+import { accountVaultKey, type AuthRegion } from '@cindy/auth-client';
+
 export interface MobileAuthOwnerGeneration {
+  /** Canonical realm-qualified account key, not a bare membership ID. */
   readonly accountId: string;
   readonly generation: number;
 }
@@ -9,8 +12,11 @@ let current: MobileAuthOwnerGeneration = {
 };
 
 /** Publish the account owner synchronously, before React state updates settle. */
-export function setMobileAuthOwner(accountId: string | null | undefined): void {
-  const normalized = accountId?.trim() ?? '';
+export function setMobileAuthOwner(
+  accountId: string | null | undefined,
+  realm: AuthRegion = 'global',
+): void {
+  const normalized = accountId ? accountVaultKey(realm, accountId) : '';
   if (current.accountId === normalized) return;
   current = {
     accountId: normalized,

--- a/apps/mobile/src/session/newSession.ts
+++ b/apps/mobile/src/session/newSession.ts
@@ -841,8 +841,8 @@ export function pickInitialNewSessionWorkspace(
   rememberedWorkingDir?: string | null,
 ): string | null {
   if (currentWorkingDir.trim()) return null;
-  const remembered = rememberedWorkingDir?.trim();
-  if (remembered) return remembered;
+  // 记忆目录原样返回(首尾空格可能是路径的一部分),只用 trim 判空。
+  if (rememberedWorkingDir?.trim()) return rememberedWorkingDir;
   return recentWorkspaces[0]?.workingDir ?? null;
 }
 

--- a/apps/mobile/src/session/newSession.ts
+++ b/apps/mobile/src/session/newSession.ts
@@ -83,6 +83,12 @@ export interface NewSessionStoredPreferences {
    * 没选过 = 缺失,回落该 agent 的安全种子默认。'plan' 不入记忆(计划模式是独立开关)。
    */
   permissionModeByAgent: Partial<Record<NewSessionAgentKind, string>>;
+  /**
+   * 每台被控电脑上次在新建页**显式选择**的项目目录(deviceId → 绝对路径,#4103)。
+   * 只在用户点选最近项目 / 在目录浏览器里确认时写入;自动取最近项目首项不算显式选择。
+   * 按设备归属,避免把一台电脑的路径套到另一台;没有记忆的设备沿用最近项目默认逻辑。
+   */
+  workingDirByDevice: Record<string, string>;
 }
 
 export interface NewSessionDraftSummary {
@@ -824,11 +830,19 @@ export function resolveNewSessionAutoDefault(input: {
   };
 }
 
+/**
+ * 空白新建的初始项目目录:草稿已有目录 → 不动;否则先用该设备记住的上次显式选择
+ * (#4103,不要求它仍在最近列表里——列表只保留 6 项,且用户本就有目录浏览入口),
+ * 没有记忆再取最近项目首项。
+ */
 export function pickInitialNewSessionWorkspace(
   currentWorkingDir: string,
   recentWorkspaces: readonly RecentWorkspaceOption[],
+  rememberedWorkingDir?: string | null,
 ): string | null {
   if (currentWorkingDir.trim()) return null;
+  const remembered = rememberedWorkingDir?.trim();
+  if (remembered) return remembered;
   return recentWorkspaces[0]?.workingDir ?? null;
 }
 

--- a/apps/mobile/src/session/newSessionPreferenceStore.ts
+++ b/apps/mobile/src/session/newSessionPreferenceStore.ts
@@ -15,6 +15,8 @@ export interface NewSessionPreferencePatch {
   workspaceKind?: NewSessionWorkspaceKind;
   /** 记住某 agent 在新建页选的权限档(单键合并进 permissionModeByAgent;'plan' 被忽略)。 */
   permissionModeForAgent?: { agentKind: NewSessionAgentKind; mode: string };
+  /** 记住某台被控电脑上次显式选择的项目目录(单键合并进 workingDirByDevice;空值被忽略,#4103)。 */
+  workingDirForDevice?: { deviceId: string; workingDir: string };
 }
 
 export async function readNewSessionPreferences(): Promise<NewSessionStoredPreferences> {
@@ -45,6 +47,9 @@ export function saveNewSessionPreferences(patch: NewSessionPreferencePatch): Pro
 async function writeNewSessionPreferences(patch: NewSessionPreferencePatch): Promise<void> {
   const current = await loadNewSessionPreferences();
   const permissionPatch = patch.permissionModeForAgent;
+  const workingDirPatch = patch.workingDirForDevice;
+  const workingDirDeviceId = workingDirPatch?.deviceId.trim() ?? '';
+  const workingDirValue = workingDirPatch?.workingDir.trim() ?? '';
   const next: NewSessionStoredPreferences = {
     agentKind: patch.agentKind ?? current.agentKind,
     workspaceKind: patch.workspaceKind ?? current.workspaceKind,
@@ -55,6 +60,10 @@ async function writeNewSessionPreferences(patch: NewSessionPreferencePatch): Pro
       permissionPatch && isRememberablePermissionMode(permissionPatch.mode)
         ? { ...current.permissionModeByAgent, [permissionPatch.agentKind]: permissionPatch.mode }
         : current.permissionModeByAgent,
+    workingDirByDevice:
+      workingDirDeviceId && workingDirValue
+        ? { ...current.workingDirByDevice, [workingDirDeviceId]: workingDirValue }
+        : current.workingDirByDevice,
   };
   await AsyncStorage.setItem(STORAGE_KEY, JSON.stringify(serializePreferences(next))).catch(() => undefined);
 }
@@ -71,7 +80,20 @@ function emptyPreferences(): NewSessionStoredPreferences {
     workspaceKind: null,
     device: null,
     permissionModeByAgent: {},
+    workingDirByDevice: {},
   };
+}
+
+function normalizeWorkingDirByDevice(value: unknown): Record<string, string> {
+  const record = readRecord(value);
+  if (!record) return {};
+  const out: Record<string, string> = {};
+  for (const [deviceId, workingDir] of Object.entries(record)) {
+    const id = deviceId.trim();
+    const dir = readString(workingDir);
+    if (id && dir) out[id] = dir;
+  }
+  return out;
 }
 
 // 'plan' 是计划模式的实现细节(老被控端兼容路径),不是用户可记忆的权限档。
@@ -106,6 +128,7 @@ function normalizeStoredPreferences(value: unknown): NewSessionStoredPreferences
       ? { deviceId, name: deviceName || deviceId }
       : null,
     permissionModeByAgent: normalizePermissionModeByAgent(record.permissionModeByAgent),
+    workingDirByDevice: normalizeWorkingDirByDevice(record.workingDirByDevice),
   };
 }
 
@@ -135,6 +158,9 @@ function serializePreferences(
       : {}),
     ...(permissionEntries.length > 0
       ? { permissionModeByAgent: Object.fromEntries(permissionEntries) }
+      : {}),
+    ...(Object.keys(preferences.workingDirByDevice).length > 0
+      ? { workingDirByDevice: { ...preferences.workingDirByDevice } }
       : {}),
   };
 }

--- a/apps/mobile/src/session/newSessionPreferenceStore.ts
+++ b/apps/mobile/src/session/newSessionPreferenceStore.ts
@@ -49,7 +49,8 @@ async function writeNewSessionPreferences(patch: NewSessionPreferencePatch): Pro
   const permissionPatch = patch.permissionModeForAgent;
   const workingDirPatch = patch.workingDirForDevice;
   const workingDirDeviceId = workingDirPatch?.deviceId.trim() ?? '';
-  const workingDirValue = workingDirPatch?.workingDir.trim() ?? '';
+  // 路径原样保存(macOS / Linux 允许目录名首尾带空格,浏览器也原样返回);只用 trim 判空。
+  const workingDirValue = workingDirPatch && workingDirPatch.workingDir.trim() ? workingDirPatch.workingDir : '';
   const next: NewSessionStoredPreferences = {
     agentKind: patch.agentKind ?? current.agentKind,
     workspaceKind: patch.workspaceKind ?? current.workspaceKind,
@@ -90,8 +91,8 @@ function normalizeWorkingDirByDevice(value: unknown): Record<string, string> {
   const out: Record<string, string> = {};
   for (const [deviceId, workingDir] of Object.entries(record)) {
     const id = deviceId.trim();
-    const dir = readString(workingDir);
-    if (id && dir) out[id] = dir;
+    // 目录原样保留(首尾空格可能是路径的一部分),只剔除非字符串 / 纯空白。
+    if (id && typeof workingDir === 'string' && workingDir.trim()) out[id] = workingDir;
   }
   return out;
 }

--- a/apps/mobile/src/session/newSessionPreferenceStore.ts
+++ b/apps/mobile/src/session/newSessionPreferenceStore.ts
@@ -1,3 +1,8 @@
+import {
+  getMobileAuthOwner,
+  isMobileAuthOwnerCurrent,
+  type MobileAuthOwnerGeneration,
+} from '@/auth/authOwnerGeneration';
 import AsyncStorage from '@react-native-async-storage/async-storage';
 import {
   normalizeNewSessionAgentKind,
@@ -21,31 +26,51 @@ export interface NewSessionPreferencePatch {
 
 export async function readNewSessionPreferences(): Promise<NewSessionStoredPreferences> {
   // 刚选完就重新打开新建页时，也要看到已提交但尚未落盘的选择。
+  const owner = getMobileAuthOwner();
   await writeChain;
-  return loadNewSessionPreferences();
+  const preferences = await loadNewSessionPreferences(owner.accountId);
+  return isMobileAuthOwnerCurrent(owner) ? preferences : { ...preferences, workingDirByDevice: {} };
 }
 
-async function loadNewSessionPreferences(): Promise<NewSessionStoredPreferences> {
-  const raw = await AsyncStorage.getItem(STORAGE_KEY).catch(() => null);
-  if (!raw) return emptyPreferences();
+function workingDirStorageKey(accountId: string): string {
+  return `${STORAGE_KEY}.working-directories.${encodeURIComponent(accountId)}`;
+}
+
+async function loadNewSessionPreferences(accountId: string): Promise<NewSessionStoredPreferences> {
+  const [raw, directories] = await Promise.all([
+    AsyncStorage.getItem(STORAGE_KEY).catch(() => null),
+    accountId ? AsyncStorage.getItem(workingDirStorageKey(accountId)).catch(() => null) : null,
+  ]);
+  let preferences = emptyPreferences();
   try {
-    return normalizeStoredPreferences(JSON.parse(raw));
+    if (raw) preferences = normalizeStoredPreferences(JSON.parse(raw));
   } catch {
-    return emptyPreferences();
+    // Malformed preferences fall back to defaults.
   }
+  // The old global map has no provable owner; never assign it to the next account.
+  try {
+    if (directories) preferences.workingDirByDevice = normalizeWorkingDirByDevice(JSON.parse(directories));
+  } catch {
+    // A malformed directory map must not prevent loading the other preferences.
+  }
+  return preferences;
 }
 
 // 与首页偏好存储一致：连续选择不同字段时，读改写必须按操作顺序执行。
 let writeChain: Promise<void> = Promise.resolve();
 
 export function saveNewSessionPreferences(patch: NewSessionPreferencePatch): Promise<void> {
-  const next = writeChain.then(() => writeNewSessionPreferences(patch));
+  const owner = getMobileAuthOwner();
+  const next = writeChain.then(() => writeNewSessionPreferences(patch, owner));
   writeChain = next.catch(() => undefined);
   return next;
 }
 
-async function writeNewSessionPreferences(patch: NewSessionPreferencePatch): Promise<void> {
-  const current = await loadNewSessionPreferences();
+async function writeNewSessionPreferences(
+  patch: NewSessionPreferencePatch,
+  owner: MobileAuthOwnerGeneration,
+): Promise<void> {
+  const current = await loadNewSessionPreferences(owner.accountId);
   const permissionPatch = patch.permissionModeForAgent;
   const workingDirPatch = patch.workingDirForDevice;
   const workingDirDeviceId = workingDirPatch?.deviceId.trim() ?? '';
@@ -67,10 +92,17 @@ async function writeNewSessionPreferences(patch: NewSessionPreferencePatch): Pro
         : current.workingDirByDevice,
   };
   await AsyncStorage.setItem(STORAGE_KEY, JSON.stringify(serializePreferences(next))).catch(() => undefined);
+  if (workingDirDeviceId && workingDirValue && owner.accountId && isMobileAuthOwnerCurrent(owner)) {
+    await AsyncStorage.setItem(workingDirStorageKey(owner.accountId), JSON.stringify(next.workingDirByDevice)).catch(() => undefined);
+  }
 }
 
 export function clearNewSessionPreferences(): Promise<void> {
-  const next = writeChain.then(() => AsyncStorage.removeItem(STORAGE_KEY));
+  const owner = getMobileAuthOwner();
+  const next = writeChain.then(async () => {
+    await AsyncStorage.removeItem(STORAGE_KEY);
+    if (owner.accountId) await AsyncStorage.removeItem(workingDirStorageKey(owner.accountId));
+  });
   writeChain = next.catch(() => undefined);
   return writeChain;
 }
@@ -129,7 +161,7 @@ function normalizeStoredPreferences(value: unknown): NewSessionStoredPreferences
       ? { deviceId, name: deviceName || deviceId }
       : null,
     permissionModeByAgent: normalizePermissionModeByAgent(record.permissionModeByAgent),
-    workingDirByDevice: normalizeWorkingDirByDevice(record.workingDirByDevice),
+    workingDirByDevice: {},
   };
 }
 
@@ -160,9 +192,6 @@ function serializePreferences(
     ...(permissionEntries.length > 0
       ? { permissionModeByAgent: Object.fromEntries(permissionEntries) }
       : {}),
-    ...(Object.keys(preferences.workingDirByDevice).length > 0
-      ? { workingDirByDevice: { ...preferences.workingDirByDevice } }
-      : {}),
   };
 }
 
@@ -178,4 +207,5 @@ function readString(value: unknown): string | null {
 
 export const __testing = {
   storageKey: STORAGE_KEY,
+  workingDirStorageKey,
 };

--- a/apps/mobile/src/session/newSessionPreferenceStore.ts
+++ b/apps/mobile/src/session/newSessionPreferenceStore.ts
@@ -28,7 +28,7 @@ export async function readNewSessionPreferences(): Promise<NewSessionStoredPrefe
   // 刚选完就重新打开新建页时，也要看到已提交但尚未落盘的选择。
   const owner = getMobileAuthOwner();
   await writeChain;
-  const preferences = await loadNewSessionPreferences(owner.accountId);
+  const preferences = await loadNewSessionPreferences(owner.accountKey);
   return isMobileAuthOwnerCurrent(owner) ? preferences : { ...preferences, workingDirByDevice: {} };
 }
 
@@ -70,7 +70,7 @@ async function writeNewSessionPreferences(
   patch: NewSessionPreferencePatch,
   owner: MobileAuthOwnerGeneration,
 ): Promise<void> {
-  const current = await loadNewSessionPreferences(owner.accountId);
+  const current = await loadNewSessionPreferences(owner.accountKey);
   const permissionPatch = patch.permissionModeForAgent;
   const workingDirPatch = patch.workingDirForDevice;
   const workingDirDeviceId = workingDirPatch?.deviceId.trim() ?? '';
@@ -92,8 +92,8 @@ async function writeNewSessionPreferences(
         : current.workingDirByDevice,
   };
   await AsyncStorage.setItem(STORAGE_KEY, JSON.stringify(serializePreferences(next))).catch(() => undefined);
-  if (workingDirDeviceId && workingDirValue && owner.accountId && isMobileAuthOwnerCurrent(owner)) {
-    await AsyncStorage.setItem(workingDirStorageKey(owner.accountId), JSON.stringify(next.workingDirByDevice)).catch(() => undefined);
+  if (workingDirDeviceId && workingDirValue && owner.accountKey && isMobileAuthOwnerCurrent(owner)) {
+    await AsyncStorage.setItem(workingDirStorageKey(owner.accountKey), JSON.stringify(next.workingDirByDevice)).catch(() => undefined);
   }
 }
 
@@ -101,7 +101,7 @@ export function clearNewSessionPreferences(): Promise<void> {
   const owner = getMobileAuthOwner();
   const next = writeChain.then(async () => {
     await AsyncStorage.removeItem(STORAGE_KEY);
-    if (owner.accountId) await AsyncStorage.removeItem(workingDirStorageKey(owner.accountId));
+    if (owner.accountKey) await AsyncStorage.removeItem(workingDirStorageKey(owner.accountKey));
   });
   writeChain = next.catch(() => undefined);
   return writeChain;

--- a/packages/device-link/src/__tests__/client.test.ts
+++ b/packages/device-link/src/__tests__/client.test.ts
@@ -1168,6 +1168,7 @@ describe('DeviceLinkClient', () => {
   });
 
   it('入站 link 的可靠重试耗尽只重置该 peer link:relay 连接不拆,发 transport-timeout link-close,重开后 live 帧按原 seq 重放', async () => {
+    vi.useFakeTimers();
     const warn = vi.fn();
     const h = makeHarness({
       timing: {
@@ -1179,72 +1180,77 @@ describe('DeviceLinkClient', () => {
       },
       logger: { debug: vi.fn(), info: vi.fn(), warn, error: vi.fn() },
     });
-    h.client.start();
-    await tick();
-    h.current().ack();
-    await establishInboundReliableLink(h, 'inbound-timeout-stream');
+    try {
+      h.client.start();
+      await vi.advanceTimersByTimeAsync(0);
+      h.current().ack();
+      const initialOpen = establishInboundReliableLink(h, 'inbound-timeout-stream');
+      await vi.advanceTimersByTimeAsync(0);
+      await initialOpen;
 
-    const firstSocket = h.current();
-    // 可丢弃前缀(陈旧实时镜像) + 不可丢弃的 live invoke-result
-    h.client.sendPush('dev-b', 'maker:event', { drop: 'me' });
-    h.client.sendInvokeResult('dev-b', 'keep-me', { ok: true, result: [] });
-    const firstReliable = firstSocket.sent.find((env) => (
-      env.kind === 'invoke-result' && parseTransportPayload(env.payload)
-    ))!;
-    const firstMeta = parseTransportPayload(firstReliable.payload)!.meta;
+      const firstSocket = h.current();
+      // 可丢弃前缀(陈旧实时镜像) + 不可丢弃的 live invoke-result
+      h.client.sendPush('dev-b', 'maker:event', { drop: 'me' });
+      h.client.sendInvokeResult('dev-b', 'keep-me', { ok: true, result: [] });
+      const firstReliable = firstSocket.sent.find((env) => (
+        env.kind === 'invoke-result' && parseTransportPayload(env.payload)
+      ))!;
+      const firstMeta = parseTransportPayload(firstReliable.payload)!.meta;
 
-    // 对端永不 ACK → 重试耗尽 → 只重置该 peer 的 link 并通知对端
-    await vi.waitFor(() => {
+      // 对端永不 ACK → 重试耗尽 → 只重置该 peer 的 link 并通知对端
+      await vi.advanceTimersByTimeAsync(50);
       expect(firstSocket.sent.some((env) => (
         env.kind === 'link-close'
         && env.dst === 'dev-b'
         && (env.payload as { reason?: string } | undefined)?.reason === 'transport-timeout'
       ))).toBe(true);
-    });
-    // relay 连接毫发无损:既没 terminate,也没新建 socket(其它 peer 零感知)
-    expect(firstSocket.terminated).toBe(false);
-    expect(firstSocket.closed).toBeNull();
-    expect(h.sockets).toHaveLength(1);
-    expect(warn).toHaveBeenCalledWith(expect.stringMatching(
-      /ACK timeout; resetting peer link .*dst=dev-b seq=1 kind=push attempts=2 sent=true ageMs=\d+ pending=2\/\d+ ack=0 next=3 send=ready receive=true stream=.{8} remoteStream=inbound-/,
-    ));
+      // relay 连接毫发无损:既没 terminate,也没新建 socket(其它 peer 零感知)
+      expect(firstSocket.terminated).toBe(false);
+      expect(firstSocket.closed).toBeNull();
+      expect(h.sockets).toHaveLength(1);
+      expect(warn).toHaveBeenCalledWith(expect.stringMatching(
+        /ACK timeout; resetting peer link .*dst=dev-b seq=1 kind=push attempts=2 sent=true ageMs=\d+ pending=2\/\d+ ack=0 next=3 send=ready receive=true stream=.{8} remoteStream=inbound-/,
+      ));
 
-    // 对端重开链路 → 陈旧 push 前缀被清扫,live invoke-result 按原 seq 重放
-    const sentBefore = firstSocket.sent.length;
-    await establishInboundReliableLink(h, 'inbound-timeout-stream');
-    // 模拟真实接收端:重放帧已写入 socket FIFO 后立即回 ACK(见 client.ts
-    // sendTransportAck 的交付即确认语义)。不 ACK 的话,重放后 retryTimer
-    // 会在 Windows 低精度计时器(≈12ms>配置 5ms)下把同一帧再发一遍,慢 CI
-    // runner 上断言窗口跨过该周期时会把「重试重发」误判成「重放两次」。
-    const justReplayed = firstSocket.sent.slice(sentBefore).filter((env) => (
-      env.kind === 'invoke-result' && parseTransportPayload(env.payload)
-    ));
-    if (justReplayed.length > 0) {
-      const meta = parseTransportPayload(justReplayed[0].payload)!.meta;
-      h.current().push({
-        v: PROTOCOL_VERSION,
-        kind: 'push',
-        src: 'dev-b',
-        payload: {
-          channel: DEVICE_LINK_TRANSPORT_ACK_CHANNEL,
-          payload: { streamId: meta.streamId, ackSeq: meta.seq },
-        },
+      // 对端重开链路 → 陈旧 push 前缀被清扫,live invoke-result 按原 seq 重放
+      const sentBefore = firstSocket.sent.length;
+      const reopened = establishInboundReliableLink(h, 'inbound-timeout-stream');
+      await vi.advanceTimersByTimeAsync(0);
+      await reopened;
+      // 受控时钟保持在重开时刻:真实计时器可能在 tick 等待期间已跨过 5ms
+      // 重试窗口,此时再 ACK 也来不及阻止第二帧。确认重放后再 ACK,不放宽数量断言。
+      const justReplayed = firstSocket.sent.slice(sentBefore).filter((env) => (
+        env.kind === 'invoke-result' && parseTransportPayload(env.payload)
+      ));
+      if (justReplayed.length > 0) {
+        const meta = parseTransportPayload(justReplayed[0].payload)!.meta;
+        h.current().push({
+          v: PROTOCOL_VERSION,
+          kind: 'push',
+          src: 'dev-b',
+          payload: {
+            channel: DEVICE_LINK_TRANSPORT_ACK_CHANNEL,
+            payload: { streamId: meta.streamId, ackSeq: meta.seq },
+          },
+        });
+      }
+      const replayed = firstSocket.sent.slice(sentBefore);
+      const replays = replayed.filter((env) => (
+        env.kind === 'invoke-result' && parseTransportPayload(env.payload)
+      ));
+      expect(replays).toHaveLength(1);
+      expect(parseTransportPayload(replays[0].payload)?.meta).toMatchObject({
+        streamId: firstMeta.streamId,
+        seq: firstMeta.seq,
       });
+      expect(replayed.filter((env) => (
+        env.kind === 'push'
+        && parseTransportPayload(env.payload)
+      ))).toHaveLength(0);
+    } finally {
+      h.client.stop();
+      vi.useRealTimers();
     }
-    const replayed = firstSocket.sent.slice(sentBefore);
-    const replays = replayed.filter((env) => (
-      env.kind === 'invoke-result' && parseTransportPayload(env.payload)
-    ));
-    expect(replays).toHaveLength(1);
-    expect(parseTransportPayload(replays[0].payload)?.meta).toMatchObject({
-      streamId: firstMeta.streamId,
-      seq: firstMeta.seq,
-    });
-    expect(replayed.filter((env) => (
-      env.kind === 'push'
-      && parseTransportPayload(env.payload)
-    ))).toHaveLength(0);
-    h.client.stop();
   });
 
   it('互控:出站 link-accept 不覆盖入站标记,重试耗尽仍走 peer 级重置不拆共享 relay', async () => {

--- a/packages/maker-core/src/agents/claude-code/__tests__/mcp-approval-policy.test.ts
+++ b/packages/maker-core/src/agents/claude-code/__tests__/mcp-approval-policy.test.ts
@@ -244,7 +244,7 @@ async function startSession(
         canUseTool?: CanUseToolFn;
       hooks?: Record<
           string,
-          Array<{ hooks: Array<(input: unknown) => Promise<unknown>> }>
+          Array<{ matcher?: string; hooks: Array<(input: unknown) => Promise<unknown>> }>
         >;
         env?: Record<string, string>;
       }

--- a/packages/maker-core/src/agents/claude-code/generation-timing.test.ts
+++ b/packages/maker-core/src/agents/claude-code/generation-timing.test.ts
@@ -601,7 +601,9 @@ describe('claude generation pause boundaries', () => {
     queue.end();
     const events: AgentEvent[] = [];
     for await (const event of queue) events.push(event);
-    const statuses = events.filter((event) => event.type === 'status');
+    const statuses = events.filter((event) => event.type === 'status').map((event) => ({
+      ...event, data: event.data as { outputTokens?: number; generationDurationMs?: number },
+    }));
     expect(statuses.filter((event) => event.data.outputTokens === 100)).toHaveLength(5);
     for (const event of statuses.filter((event) => event.data.outputTokens === 100)) {
       expect(event.data.generationDurationMs).toBe(1_000);

--- a/packages/maker-core/src/agents/codex/index.test.ts
+++ b/packages/maker-core/src/agents/codex/index.test.ts
@@ -3768,7 +3768,7 @@ describe('CodexAgent reference directories', () => {
       expect(events.filter((event) => event.type === 'done')).toHaveLength(2),
     );
 
-    const doneEvents = events.filter((event): event is Extract<AgentEvent, { type: 'done' }> =>
+    const doneEvents = events.filter((event) =>
       event.type === 'done',
     );
     expect((doneEvents[0]?.data as { usage?: { segments?: unknown[] } }).usage?.segments).toHaveLength(1);
@@ -5525,7 +5525,7 @@ describe('CodexAgent fast mode service tier', () => {
     await sendPromise;
     await waitForExpectation(() => expect(events.some((event) => event.type === 'done')).toBe(true));
 
-    const done = events.find((event): event is Extract<AgentEvent, { type: 'done' }> => event.type === 'done');
+    const done = events.find((event) => event.type === 'done');
     expect((done?.data as { usage?: { segments?: unknown[] } }).usage?.segments).toEqual([
       expect.objectContaining({ inputTokens: 20, outputTokens: 10, priceVariant: 'standard' }),
     ]);
@@ -13633,7 +13633,7 @@ describe('CodexAgent MCP thread context hooks', () => {
     if (!handlers?.mcpServerElicitation) {
       throw new Error('expected mcpServerElicitation handler');
     }
-    handlers.itemStarted({
+    handlers.itemStarted!({
       threadId: 'start-thread-id',
       turnId: 'turn-wechat-mcp',
       item: {
@@ -13668,7 +13668,7 @@ describe('CodexAgent MCP thread context hooks', () => {
       toolName: 'mcp:cindy_contacts',
       suggestions: undefined,
     });
-    handlers.itemStarted({
+    handlers.itemStarted!({
       threadId: 'start-thread-id',
       turnId: 'turn-wechat-mcp',
       item: {
@@ -13695,7 +13695,7 @@ describe('CodexAgent MCP thread context hooks', () => {
     });
     expect(resolver.mock.calls[1]?.[0]).not.toHaveProperty('toolUseId');
     for (const itemId of ['contacts-call-1', 'contacts-call-2']) {
-      handlers.itemCompleted({
+      handlers.itemCompleted!({
         threadId: 'start-thread-id',
         turnId: 'turn-wechat-mcp',
         item: {
@@ -13707,7 +13707,7 @@ describe('CodexAgent MCP thread context hooks', () => {
         },
       } as never);
     }
-    handlers.itemUpdated({
+    handlers.itemUpdated!({
       threadId: 'start-thread-id',
       turnId: 'turn-wechat-mcp',
       item: {
@@ -23029,7 +23029,7 @@ describe('CodexAgent turn lifecycle', () => {
           turnStartResponse.resolve({ turn: { id: 'turn-retry-state' } });
           await sendPromise;
         } else {
-          handlers.turnStarted({
+          handlers.turnStarted!({
             threadId: 'start-thread-id',
             turn: { id: 'turn-retry-state' },
           });
@@ -30283,7 +30283,7 @@ describe('CodexAgent context window reporting', () => {
           currentTurnResponse.resolve({ turn: { id: 'turn-current-diff' } });
           await sendPromise;
         } else {
-          handlers.turnStarted({
+          handlers.turnStarted!({
             threadId: 'start-thread-id',
             turn: { id: 'turn-current-diff' },
           });

--- a/packages/maker-core/src/agents/pi/__tests__/cindyBridgeSource.test.ts
+++ b/packages/maker-core/src/agents/pi/__tests__/cindyBridgeSource.test.ts
@@ -158,7 +158,7 @@ function loadBashPackageHomeHelper(): {
       target: ts.ScriptTarget.ES2022,
     },
   }).outputText;
-  const context: Record<string, unknown> = {
+  const context: Record<string, unknown> & { process: { env: Record<string, string | undefined> } } = {
     process: { env: {} },
     path,
   };

--- a/packages/maker-core/src/agents/pi/__tests__/cindySubagentForeground.test.ts
+++ b/packages/maker-core/src/agents/pi/__tests__/cindySubagentForeground.test.ts
@@ -398,6 +398,7 @@ const timer = setInterval(() => {
   let files = [];
   try { files = fs.readdirSync(path.join(config.runDir, 'controls')); } catch {}
   for (const file of files) {
+    if (!file.endsWith('.json')) continue;
     const control = JSON.parse(fs.readFileSync(path.join(config.runDir, 'controls', file), 'utf8'));
     if (control.action !== 'stop') continue;
     clearInterval(timer);
@@ -407,6 +408,10 @@ const timer = setInterval(() => {
 // Publish readiness only after the stop-control poller is installed. Writing
 // this before setInterval leaves a small CI race where the parent aborts while
 // this fixture is still initializing and observes only the process exit.
+// The writer publishes controls by renaming temporary files. Keep one incomplete
+// temporary file present to exercise the reader during that publication window.
+fs.mkdirSync(path.join(config.runDir, 'controls'), { recursive: true });
+fs.writeFileSync(path.join(config.runDir, 'controls', 'pending.json.tmp-placeholder'), '{');
 fs.writeFileSync(path.join(config.runDir, 'started'), '1');
 setTimeout(() => process.exit(2), 5000).unref();
 `, { mode: 0o700 });

--- a/packages/maker-core/src/agents/pi/__tests__/pi-auto-review-dispatch.test.ts
+++ b/packages/maker-core/src/agents/pi/__tests__/pi-auto-review-dispatch.test.ts
@@ -101,7 +101,7 @@ vi.mock('../rpc-client.js', () => ({
     }
     async request(
       cmd: Record<string, unknown> & { type: string },
-    ): Promise<{ success: boolean; command?: string; data?: unknown }> {
+    ): Promise<{ success: boolean; command?: string; data?: unknown; error?: string }> {
       captured.requests.push(cmd);
       if (cmd.type === 'set_model' && captured.holdSetModel) {
         await captured.holdSetModel;
@@ -733,8 +733,9 @@ describe('pi auto-review dispatch & spawn config (mocked pi process)', () => {
       for (let attempt = 0; attempt < 10; attempt += 1) {
         const event = await events.next();
         if (event.done) break;
-        if (event.value.type === 'text' && event.value.data.text.includes('Pi extension installed')) {
-          visibleReceipt = event.value.data.text;
+        const data = event.value.data as { text?: unknown };
+        if (event.value.type === 'text' && typeof data?.text === 'string' && data.text.includes('Pi extension installed')) {
+          visibleReceipt = data.text;
           break;
         }
       }
@@ -879,8 +880,9 @@ describe('pi auto-review dispatch & spawn config (mocked pi process)', () => {
       for (let attempt = 0; attempt < 10; attempt += 1) {
         const event = await events.next();
         if (event.done) break;
-        if (event.value.type === 'text' && event.value.data.text.includes('Installed')) {
-          visibleReceipt = event.value.data.text;
+        const data = event.value.data as { text?: unknown };
+        if (event.value.type === 'text' && typeof data?.text === 'string' && data.text.includes('Installed')) {
+          visibleReceipt = data.text;
           break;
         }
       }
@@ -1585,7 +1587,8 @@ describe('pi auto-review dispatch & spawn config (mocked pi process)', () => {
         { type: 'user', content: 'pi install npm:context-mode' },
         desktopCommandOptions('pi install npm:context-mode'),
       );
-      const prompt = captured.requests.find((request) => request.type === 'prompt')?.message ?? '';
+      const prompt = captured.requests.find((request) => request.type === 'prompt')?.message;
+      if (typeof prompt !== 'string') throw new Error('expected prompt message');
       expect(prompt).toContain('"ok":true');
       expect(prompt).toContain('do not claim every task has already stopped');
       expect(prompt).toContain('this task remains active');
@@ -1699,8 +1702,9 @@ describe('pi auto-review dispatch & spawn config (mocked pi process)', () => {
       for (let attempt = 0; attempt < 10; attempt += 1) {
         const event = await events.next();
         if (event.done) break;
-        if (event.value.type === 'text' && event.value.data.text.includes('context-mode')) {
-          visibleReceipt = event.value.data.text;
+        const data = event.value.data as { text?: unknown };
+        if (event.value.type === 'text' && typeof data?.text === 'string' && data.text.includes('context-mode')) {
+          visibleReceipt = data.text;
           break;
         }
       }
@@ -1767,8 +1771,9 @@ describe('pi auto-review dispatch & spawn config (mocked pi process)', () => {
       for (let attempt = 0; attempt < 10; attempt += 1) {
         const event = await events.next();
         if (event.done) break;
-        if (event.value.type === 'text' && event.value.data.text.includes('"name":"extension"')) {
-          visibleReceipt = event.value.data.text;
+        const data = event.value.data as { text?: unknown };
+        if (event.value.type === 'text' && typeof data?.text === 'string' && data.text.includes('"name":"extension"')) {
+          visibleReceipt = data.text;
           break;
         }
       }
@@ -1832,8 +1837,9 @@ describe('pi auto-review dispatch & spawn config (mocked pi process)', () => {
       for (let attempt = 0; attempt < 10; attempt += 1) {
         const event = await events.next();
         if (event.done) break;
-        if (event.value.type === 'text' && event.value.data.text.includes('Pi 扩展操作失败。')) {
-          visibleReceipt = event.value.data.text;
+        const data = event.value.data as { text?: unknown };
+        if (event.value.type === 'text' && typeof data?.text === 'string' && data.text.includes('Pi 扩展操作失败。')) {
+          visibleReceipt = data.text;
           break;
         }
       }
@@ -2084,8 +2090,9 @@ describe('pi auto-review dispatch & spawn config (mocked pi process)', () => {
       for (let attempt = 0; attempt < 10; attempt += 1) {
         const event = await events.next();
         if (event.done) break;
-        if (event.value.type === 'text' && event.value.data.text.includes('Pi 扩展操作失败。')) {
-          visibleReceipt = event.value.data.text;
+        const data = event.value.data as { text?: unknown };
+        if (event.value.type === 'text' && typeof data?.text === 'string' && data.text.includes('Pi 扩展操作失败。')) {
+          visibleReceipt = data.text;
           break;
         }
       }
@@ -2262,8 +2269,9 @@ describe('pi auto-review dispatch & spawn config (mocked pi process)', () => {
       for (let attempt = 0; attempt < 10; attempt += 1) {
         const event = await events.next();
         if (event.done) break;
-        if (event.value.type === 'text' && event.value.data.text.includes('Pi 扩展已安装')) {
-          visibleReceipt = event.value.data.text;
+        const data = event.value.data as { text?: unknown };
+        if (event.value.type === 'text' && typeof data?.text === 'string' && data.text.includes('Pi 扩展已安装')) {
+          visibleReceipt = data.text;
           break;
         }
       }
@@ -2432,7 +2440,8 @@ describe('pi auto-review dispatch & spawn config (mocked pi process)', () => {
         { type: 'user', content: 'pi install npm:oversized-extension' },
         desktopCommandOptions('pi install npm:oversized-extension'),
       );
-      const prompt = captured.requests.find((request) => request.type === 'prompt')?.message ?? '';
+      const prompt = captured.requests.find((request) => request.type === 'prompt')?.message;
+      if (typeof prompt !== 'string') throw new Error('expected prompt message');
       expect(prompt.length).toBeLessThanOrEqual(16_384);
       expect(prompt).toContain('"name":"oversized-extension"');
       expect(prompt).toContain('"version":"9.8.7"');

--- a/packages/maker-core/src/agents/pi/__tests__/pi-native-auto-compact.test.ts
+++ b/packages/maker-core/src/agents/pi/__tests__/pi-native-auto-compact.test.ts
@@ -363,16 +363,16 @@ describe("PiAgent native auto-compaction ownership", () => {
       "prompt",
       (handle: AgentSessionHandle) =>
         handle.send({
-          role: "user",
-          content: [{ type: "text", text: "hi" }],
+          type: "user",
+          content: "hi",
         }),
     ],
     [
       "steer",
       (handle: AgentSessionHandle) =>
         handle.steer!({
-          role: "user",
-          content: [{ type: "text", text: "steer now" }],
+          type: "user",
+          content: "steer now",
         }),
     ],
   ] as const)(
@@ -488,7 +488,7 @@ describe("PiAgent native auto-compaction ownership", () => {
       piAutoCompactThresholdPct: 90,
     };
     deps.capabilityAdditions = {
-      availableModels: deps.capabilityAdditions!.availableModels.map((model) =>
+      availableModels: deps.capabilityAdditions!.availableModels!.map((model) =>
         model.id === "n" ? { ...model, contextWindow: 200_000 } : model,
       ),
     };

--- a/packages/maker-core/src/agents/pi/__tests__/pi-subagent-runs.test.ts
+++ b/packages/maker-core/src/agents/pi/__tests__/pi-subagent-runs.test.ts
@@ -1021,9 +1021,9 @@ describe('PI durable subagent run store', () => {
      * until a real signal reaches it, then ESRCH like any reaped process. The
      * default (never reaped) is the zombie/stubborn case.
      */
-    let sentSignals: Array<NodeJS.Signals | number> = [];
+    let sentSignals: Array<NodeJS.Signals | number | 'unknown'> = [];
     let sentKillPids: number[] = [];
-    const killSignals = (): Array<NodeJS.Signals | number> => sentSignals;
+    const killSignals = (): Array<NodeJS.Signals | number | 'unknown'> => sentSignals;
 
     function stubKill(options: { reapedByKill?: boolean } = {}): void {
       const real = process.kill.bind(process);

--- a/packages/maker-core/src/agents/pi/__tests__/rpc-client.test.ts
+++ b/packages/maker-core/src/agents/pi/__tests__/rpc-client.test.ts
@@ -32,7 +32,7 @@ function makeFakeTransport() {
     close: vi.fn(async () => { closeHandler?.({ code: 0, signal: null, reason: 'test close' }); }),
     isClosed: vi.fn(() => false),
     get pid() { return 1234; },
-  } as unknown as PiTransport;
+  } satisfies PiTransport;
   const emitLine = (line: string) => lineHandler?.(line);
   const drain = () => {
     for (const w of written.splice(0)) w.resolve();
@@ -42,7 +42,7 @@ function makeFakeTransport() {
 
 function makeProc(overrides: Partial<PiRpcSpawnOptions> = {}) {
   const logger = {
-    debug: vi.fn(), info: vi.fn(), warn: vi.fn(), error: vi.fn(),
+    trace: vi.fn(), debug: vi.fn(), info: vi.fn(), warn: vi.fn(), error: vi.fn(), fatal: vi.fn(),
     child: () => logger,
   };
   const onEvent = vi.fn();
@@ -72,7 +72,7 @@ describe('PiRpcProcess response envelope validation', () => {
 
     const resp = await p;
     expect(resp.success).toBe(true);
-    expect(resp.data?.sessionFile).toBe('/sessions/abc.jsonl');
+    expect(resp.data).toMatchObject({ sessionFile: '/sessions/abc.jsonl' });
   });
 
   it('rejects when success is not a boolean (round 40-w4-t4 CRITICAL)', async () => {

--- a/packages/maker-core/src/agents/pi/__tests__/transport.test.ts
+++ b/packages/maker-core/src/agents/pi/__tests__/transport.test.ts
@@ -9,6 +9,7 @@
  */
 
 import { EventEmitter } from 'node:events';
+import { PassThrough } from 'node:stream';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 const mocks = vi.hoisted(() => ({ spawn: vi.fn() }));
@@ -204,7 +205,7 @@ describe('createPiStdioTransport', () => {
 
 describe('attachJsonlReader', () => {
   function makeStream() {
-    return new EventEmitter() as EventEmitter & { pipe(): void };
+    return new PassThrough();
   }
 
   it('splits lines across chunk boundaries (UTF-8 safe)', () => {

--- a/packages/maker-core/src/maker.test.ts
+++ b/packages/maker-core/src/maker.test.ts
@@ -441,7 +441,7 @@ describe('Maker local Pi package generation fence', () => {
 
   it.each([
     ['remote', { remoteHostId: 'ssh-host' }],
-    ['Review', { reviewMode: true }],
+    ['Review', { reviewMode: true as const }],
   ])('does not fence an in-flight %s Pi startup', async (_label, boundary) => {
     const started = createDeferred<AgentSessionHandle>();
     const handle = createHandle({ id: 'pi-thread', agentKind: 'pi' });

--- a/packages/maker-core/src/session.origin.test.ts
+++ b/packages/maker-core/src/session.origin.test.ts
@@ -16,7 +16,7 @@ import {
   type TurnContinuationState,
 } from './agents/base-agent.js';
 import type { AgentEvent, InteractionDecision, InteractionRequest, SendOrigin } from './types/events.js';
-import type { AgentKind } from './types/common.js';
+import type { AgentKind, UserMessage } from './types/common.js';
 
 function createLogger() {
   const logger = {
@@ -62,7 +62,7 @@ function createControllableHandle(opts?: {
     id: 'thread-1',
     agentKind: opts?.agentKind ?? 'codex',
     model: 'gpt-5.4',
-    async send(_message, sendOptions) {
+    async send(_message: UserMessage, sendOptions?: SendOptions) {
       lastSendOptions = sendOptions;
       sendCount += 1;
       if (opts?.sendError && (opts.sendErrorOnSend ?? 1) === sendCount) {


### PR DESCRIPTION
## 这次改了什么

### 摘要

移动端选好项目目录后，即使没有创建任务就退出，重新进入仍恢复该设备上次显式选择的目录。首次偏好读取期间或同页切换设备时，也保留用户刚做的选择。

沿用既有串行写链：workingDirByDevice 单独按 realm + membershipId 的 accountKey 分区存储；accountId 仍保持裸用户 ID，兼容创建守卫与已有清理账本，账号切换后的排队写入和迟到读取不会把目录交给下一账号；无 owner 的旧全局目录 map 及未限定 realm 的旧目录键不自动归入任何账号，其余旧偏好仍兼容。显式选择时同步内存并持久化，自动恢复不回写；读取旧快照时合并本页选择。合法路径的首尾空格原样保留。没有记忆的设备沿用最近项目首项。

### 变更类型

- [ ] `feat` 新功能
- [x] `fix` 缺陷修复
- [ ] `refactor` / `perf` 重构或性能优化
- [x] `docs` / `test` / `chore` 文档、测试或工程维护
- [ ] 其他：

### 范围

- 关联 Issue：Fixes #4103
- 本 PR 包含：按账号及设备存储目录、显式入口接线、读取/切设备恢复及回归；本 PR CI 中两处测试夹具竞态及 maker-core 测试类型修正（不改对应生产代码）。
- 明确不包含：失效目录回退策略、切到对话模式清除记忆、原生配置或依赖变更。
- 用户可见变化：恢复上次显式选择，迟到的偏好快照不覆盖本页选择。
- breaking change：无；旧存储缺字段时仍使用原有默认。
- 远程/Mobile：仅改变手机对设备目录的本地偏好；不读取本机工作目录，不新增 IPC 或修改 device-link 重试/恢复。SSH 与 Desktop 不新增行为。

### UI 变化

- 引用的设计规范：不涉及：修改偏好存储、读取竞态及选择逻辑，没有组件结构、样式或 UI 文案变更。
- 没有新增颜色/主题分支；Light/Dark 实机表现均未验证。

## 怎么验证的

### 自动验证

- 10a59157c：修复前实际普通/目标创建谓词拒绝当前账号；修复后40/40定向测试、Mobile类型检查、根相关单测和DCO通过。保留裸accountId供原创建/清理消费者使用，区域accountKey仅用于目录存储及代次；真机创建与清理恢复端到端未验证。
- fbe309110：同 membershipId 跨 cn/global 目录隔离及迟到读写回归；修复前反证读取到未限定区域的私有目录，修复后定向 39/39、Mobile typecheck、根 `pnpm test:unit:related`（Mobile/device-link/maker-core）及 DCO 全部通过。登录、缓存启动、取消与失败恢复的 owner 发布均包含对应 realm。
- 续接修复 c1defab73：`pnpm test:unit:related` 覆盖 Mobile、device-link、maker-core，全部通过；`pnpm --filter mobile run --if-present typecheck` 通过。两个共享包无 typecheck script，`--if-present` 跳过后另跑 `pnpm --filter @cindy/device-link build` 和 `pnpm --filter @cindy/maker-core build`（tsc --noEmit），均通过。
- 账号隔离和页面恢复定向回归 23/23 通过：同设备跨账号、退出、切回、排队保存、迟到读取、旧无 owner map；修复前两个隔离反证失败。
- Linux shard 1：给重连 ACK 前注入 7ms 等待可复现重放数 2≠1；测试改用可控时钟，保留重试耗尽、重连和单次重放断言。
- Linux shard 2：保留半写 `.json.tmp-placeholder` 控制文件复现 runner exit 1；测试 runner 只读取已原子发布的 `.json` 后 4/4 通过。CI 未保留子进程 stderr，反证验证了该机制，不能还原当时每一步竞态。
- 同时修正 maker-core 测试桩与既有事件/transport/用户消息类型不一致的问题，保留原行为断言。

- 前次 777a18529：实际页面 hook 定向回归 12/12 通过。新增“读取完成前分别在 A/B 选择目录，旧快照到达后切回仍恢复新选择”；修复前此用例得到旧目录而失败。
- 前次 777a18529：`pnpm --filter mobile run --if-present typecheck`、根 `pnpm test:unit:related`、`pnpm check:dco`、`git diff --check` 通过。
- 前两次提交：三文件 151 项初版回归、记忆优先反证 2 项失败、内存同步反证 1 项失败；相关当前变更继续由根 related 门禁覆盖。
- 未对已有格式不符合 Prettier 的文件执行整文件格式化。

### 手工验证

完成 diff 和读写时序 review；未做 Android/iOS 真机操作。

### 未执行的验证

- 未启动 Metro/模拟器，无 Metro 归属或 __DEV__ build label；没有 Light/Dark 目检。
- 当前验证 worktree 分支 fix/4113-preferences-read-race；新提交的远端 CI 仍需完成。
- 未运行原生 fingerprint 前后比较；没有修改原生配置、依赖、config plugin 或模块。

## 风险

### 风险分类

- [ ] 无已知风险
- [ ] SQLite / migration
- [ ] system prompt
- [ ] 协议兼容
- [x] 权限 / 安全 / 用户数据
- [ ] 存量插件兼容（批准状态 / 指纹 / manifest 校验 / 安装布局 / 包格式）
- [ ] 原生层 / fingerprint / OTA
- [x] 跨平台差异
- [x] 其他：偏好异步读取与本页显式操作的优先级

### 影响与回滚

- 影响范围：手机新建任务的本地目录偏好；不改变权限、设备边界或创建协议。原生路径保持原文，其余旧偏好继续兼容；目录只恢复当前账号的数据，未登录不恢复。无可验证 owner/realm 的旧目录不自动迁入，原键保留（需重新显式选择），避免跨账号泄漏。
- 显式选择按设备归属，自动默认不存为 override；失效目录仍沿用既有创建失败路径。恢复默认/设置 UI 未增加。
- 回滚本 PR 后账号目录分区不再读取，其余旧偏好不受影响；无数据库迁移。存量插件影响：无。
- 真机慢存储、跨设备实际切换与双主题表现仍待复核。

### 提交前检查

- [x] 已 review 完整 diff
- [x] 每个 commit 都带 DCO 签名
- [x] UI 路径已说明设计规范适用范围
- [x] 未提交凭证、令牌或授权文件
- [x] 已补充必要的行为与兼容说明
- [x] 已确认测试结果并说明未执行验证
