### PR TITLE
fix(codex): 修复 fork 后子任务无法继续发送消息

### DIFF
--- a/packages/maker-core/src/agents/codex/index.test.ts
+++ b/packages/maker-core/src/agents/codex/index.test.ts
@@ -22438,7 +22438,6 @@ describe('CodexAgent.forkSdkSession', () => {
     expect(host.request).toHaveBeenCalledWith(Method.ThreadFork, {
       threadId: 'source-thread-id',
       lastTurnId: 'turn-at-boundary',
-      persistExtendedHistory: true,
       excludeTurns: true,
       cwd: '/repo',
     });
@@ -22476,7 +22475,6 @@ describe('CodexAgent.forkSdkSession', () => {
     expect(host.request).toHaveBeenCalledWith(Method.ThreadFork, {
       threadId: 'imported-source-thread',
       lastTurnId: 'turn-at-boundary',
-      persistExtendedHistory: true,
       excludeTurns: true,
     });
   });

--- a/packages/maker-core/src/agents/codex/index.test.ts
+++ b/packages/maker-core/src/agents/codex/index.test.ts
@@ -7044,7 +7044,10 @@ describe('CodexAgent MCP thread context hooks', () => {
     await agent.dispose();
   });
 
-  it('does not retire an explicit credential host for Codex fork utility calls', async () => {
+  it.each([false, true])('keeps the source host alive while retiring the fork host (native=%s)', async (native) => {
+    MockCodexTransport.onCreate = transport => transport.setMockResponse('initialize', {
+      result: { userAgent: 'mock-codex/0.153.4' },
+    });
     const prepareCodexExtraSpawnConfig = vi.fn(async () => ({
       extraArgs: [],
       extraEnv: {},
@@ -7067,6 +7070,7 @@ describe('CodexAgent MCP thread context hooks', () => {
     const result = await agent.forkSdkSession({
       sourceSdkSessionId: 'thread-1',
       upToMessageId: undefined,
+      ...(native ? { lastTurnId: 'source-turn' } : {}),
       tailTurnsToDrop: 0,
     });
 
@@ -7078,6 +7082,11 @@ describe('CodexAgent MCP thread context hooks', () => {
     expect(createdTransports[0].closed).toBe(false);
     expect(createdTransports[1].closed).toBe(true);
     expect(prepareCodexLocalCredentialModeSwitch).not.toHaveBeenCalled();
+    expect(result.usedNativeForkAnchor).toBe(native ? true : undefined);
+    expect(createdTransports[0].lines.some(line => {
+      const request = JSON.parse(line);
+      return request.method === Method.ThreadFork || request.method === Method.ThreadUnsubscribe;
+    })).toBe(false);
 
     await handle.close();
     await agent.dispose();
@@ -22400,11 +22409,11 @@ describe('CodexAgent.forkSdkSession', () => {
     expect(retire).toHaveBeenCalledOnce();
   });
 
-  it('reuses the shared host and forks directly at a native turn', async () => {
+  it.each(['0.145.0', '0.153.4'])('isolates a native-turn fork on Codex %s', async (version) => {
     const prepareCodexResumeSession = vi.fn(async () => {});
     const agent = new CodexAgent(createDeps({}, { prepareCodexResumeSession }));
     const host = installFakeHost(agent, undefined, {
-      userAgent: 'mock-codex/0.145.0',
+      userAgent: `mock-codex/${version}`,
       activeThreadIds: ['source-thread-id'],
     });
     const retireHostKey = vi.spyOn(
@@ -22421,19 +22430,26 @@ describe('CodexAgent.forkSdkSession', () => {
     });
 
     expect(host.getHost).toHaveBeenCalledWith(undefined, undefined, {
-      ignoreBindingLeases: 1,
+      keyOverride: expect.stringMatching(/^local-fork:/),
+      hostPurpose: 'control-plane',
     });
-    expect(prepareCodexResumeSession).not.toHaveBeenCalled();
+    expect(prepareCodexResumeSession).toHaveBeenCalledWith('source-thread-id');
     expect(host.request).toHaveBeenCalledTimes(1);
     expect(host.request).toHaveBeenCalledWith(Method.ThreadFork, {
       threadId: 'source-thread-id',
       lastTurnId: 'turn-at-boundary',
+      persistExtendedHistory: true,
       excludeTurns: true,
       cwd: '/repo',
     });
     expect(host.request).not.toHaveBeenCalledWith(Method.ThreadRollback, expect.anything());
     expect(host.unsubscribeThread).toHaveBeenCalledWith('fork-thread-id');
-    expect(retireHostKey).not.toHaveBeenCalled();
+    expect(retireHostKey).toHaveBeenCalledExactlyOnceWith(
+      expect.stringMatching(/^local-fork:/),
+      'Codex fork host is single-use',
+      expect.objectContaining({ expectedHost: host, throwOnShutdownFailure: true }),
+    );
+    expect(host.unsubscribeThread).not.toHaveBeenCalledWith('source-thread-id');
     expect(result).toMatchObject({
       newSdkSessionId: 'fork-thread-id',
       usedNativeForkAnchor: true,
@@ -22460,6 +22476,7 @@ describe('CodexAgent.forkSdkSession', () => {
     expect(host.request).toHaveBeenCalledWith(Method.ThreadFork, {
       threadId: 'imported-source-thread',
       lastTurnId: 'turn-at-boundary',
+      persistExtendedHistory: true,
       excludeTurns: true,
     });
   });
@@ -22486,7 +22503,7 @@ describe('CodexAgent.forkSdkSession', () => {
     expect(result.usedNativeForkAnchor).toBeUndefined();
   });
 
-  it('fails a precise fork without retiring the shared host when child unload fails', async () => {
+  it('retires only the isolated native fork host when child unsubscribe fails', async () => {
     const agent = new CodexAgent(createDeps());
     const host = installFakeHost(agent, undefined, {
       userAgent: 'mock-codex/0.145.0',
@@ -22504,8 +22521,73 @@ describe('CodexAgent.forkSdkSession', () => {
       lastTurnId: 'turn-at-boundary',
     })).rejects.toThrow('unsubscribe failed');
 
-    expect(retireHostKey).not.toHaveBeenCalled();
+    expect(retireHostKey).toHaveBeenCalledExactlyOnceWith(
+      expect.stringMatching(/^local-fork:/),
+      'Codex fork host is single-use',
+      expect.objectContaining({ expectedHost: host, throwOnShutdownFailure: true }),
+    );
     expect(host.unsubscribeThread).not.toHaveBeenCalledWith('source-thread-id');
+  });
+
+  it('waits for the native fork writer to exit before the child can resume', async () => {
+    const childId = '123e4567-e89b-12d3-a456-426614174000';
+    const exit = deferred<void>();
+    const retiring = deferred<void>();
+    let writerActive = false;
+    const agent = new CodexAgent(createDeps());
+    const host = installFakeHost(agent, (method) => {
+      if (method === Method.ThreadFork) {
+        writerActive = true;
+        return { thread: { id: childId } };
+      }
+      if (method === Method.ThreadResume && writerActive) {
+        throw new Error(`thread ${childId} already has an active writer`);
+      }
+      return undefined;
+    }, { userAgent: 'mock-codex/0.153.4' });
+    vi.spyOn(agent as any, 'retireHostKey').mockImplementation(async () => {
+      retiring.resolve();
+      await exit.promise;
+      writerActive = false;
+    });
+    let forkPublished = false;
+    const resumed = agent.forkSdkSession({
+      sourceSdkSessionId: 'source-thread-id',
+      upToMessageId: undefined,
+      lastTurnId: 'turn-at-boundary',
+    }).then((fork) => {
+      forkPublished = true;
+      return agent.startSession({
+        sessionId: 'fork-child', model: 'gpt-5.4', workingDir: '/repo',
+        resumeSessionId: fork.newSdkSessionId,
+      });
+    });
+    try {
+      await retiring.promise;
+      expect(host.unsubscribeThread).toHaveBeenCalledWith(childId);
+      // Codex 0.153 acknowledges unsubscribe but retains the live writer.
+      expect(writerActive).toBe(true);
+      expect(forkPublished).toBe(false);
+      expect(host.request.mock.calls.some(([method]) => method === Method.ThreadResume)).toBe(false);
+    } finally {
+      exit.resolve();
+    }
+    const handle = await resumed;
+    expect(forkPublished).toBe(true);
+    expect(host.request.mock.calls.filter(([method]) => method === Method.ThreadResume)).toHaveLength(1);
+    await handle.close();
+  });
+
+  it.each([undefined, 'turn-at-boundary'])('rejects a fork if writer shutdown fails (anchor=%s)', async (lastTurnId) => {
+    const cause = new Error('process exit was not confirmed');
+    const agent = new CodexAgent(createDeps());
+    const host = installFakeHost(agent, undefined, { userAgent: 'mock-codex/0.153.4' });
+    vi.spyOn(agent as any, 'retireHostKey').mockRejectedValue(cause);
+
+    await expect(agent.forkSdkSession({
+      sourceSdkSessionId: 'source-thread-id', upToMessageId: undefined, lastTurnId,
+    })).rejects.toMatchObject({ stage: 'host-retire', cause });
+    expect(host.unsubscribeThread).toHaveBeenCalledWith('fork-thread-id');
   });
 
   it('prepares an imported source thread before thread/fork', async () => {

--- a/packages/maker-core/src/agents/codex/index.ts
+++ b/packages/maker-core/src/agents/codex/index.ts
@@ -13597,7 +13597,7 @@ export class CodexAgent extends BaseAgent {
       );
       const params: ThreadForkParams = {
         threadId: opts.sourceSdkSessionId,
-        persistExtendedHistory: true,
+        ...(!usedNativeForkAnchor ? { persistExtendedHistory: true } : {}),
         ...(usedNativeForkAnchor ? { lastTurnId } : {}),
         // 响应体瘦身:fork 后 Cindy 自己的会话数据负责历史展示,thread.turns 全量
         // 回传只会撑爆单行上限。老 daemon 不认识该字段则保持 legacy 行为 —— 此时

--- a/packages/maker-core/src/agents/codex/index.ts
+++ b/packages/maker-core/src/agents/codex/index.ts
@@ -13485,84 +13485,6 @@ export class CodexAgent extends BaseAgent {
     return bestPath;
   }
 
-  private async tryForkSdkSessionAtNativeTurn(
-    opts: ForkSdkSessionOptions,
-    lastTurnId: string,
-    credentialMode: AgentCredentialMode | undefined,
-  ): Promise<ForkSdkSessionResult | null> {
-    const log = this.deps.logger.child('codex/fork');
-    const sharedHostKey = hostKey();
-    let releaseHostBindingLease: (() => void) | null = null;
-    let nativeForkRequestStarted = false;
-    const startedAt = Date.now();
-    try {
-      await this.waitForHostCredentialModeSwitch(sharedHostKey);
-      releaseHostBindingLease = this.acquireHostSessionBindingLease(sharedHostKey);
-      const hostStartedAt = Date.now();
-      const sharedHost = await this.getHost(undefined, credentialMode, {
-        ignoreBindingLeases: 1,
-      });
-      const initResp = await sharedHost.ensureStarted();
-      const hostReadyMs = Date.now() - hostStartedAt;
-      if (!supportsCodexNativeTurnFork(initResp.userAgent)) {
-        log.info('native-turn fork unavailable; using legacy isolated fallback', {
-          userAgent: initResp.userAgent ?? null,
-        });
-        return null;
-      }
-
-      if (initResp.codexHome) this.codexHome = initResp.codexHome;
-      const prepareStartedAt = Date.now();
-      if (!sharedHost.hasThreadSubscription(opts.sourceSdkSessionId)) {
-        await this.deps.prepareCodexResumeSession?.(opts.sourceSdkSessionId);
-      }
-      const prepareMs = Date.now() - prepareStartedAt;
-      const forkStartedAt = Date.now();
-      nativeForkRequestStarted = true;
-      const resp = await sharedHost.request<ThreadForkResponse>(Method.ThreadFork, {
-        threadId: opts.sourceSdkSessionId,
-        lastTurnId,
-        excludeTurns: true,
-        ...(opts.workingDir ? { cwd: opts.workingDir } : {}),
-      } satisfies ThreadForkParams);
-      const threadForkMs = Date.now() - forkStartedAt;
-      const newSdkSessionId = resp.thread.id;
-      const cleanupStartedAt = Date.now();
-      try {
-        await sharedHost.unsubscribeThread(newSdkSessionId);
-      } catch (error) {
-        log.warn('precise fork child cleanup failed', {
-          threadId: newSdkSessionId,
-          error: error instanceof Error ? error.message : String(error),
-        });
-        throw error;
-      }
-      const cleanupMs = Date.now() - cleanupStartedAt;
-      log.info('forkSdkSession ◀', {
-        newSdkSessionId,
-        mode: 'native-turn',
-        hostReadyMs,
-        prepareMs,
-        threadForkMs,
-        cleanupMs,
-        totalMs: Date.now() - startedAt,
-      });
-      return {
-        newSdkSessionId,
-        uuidMap: new Map(),
-        usedNativeForkAnchor: true,
-      };
-    } catch (error) {
-      if (nativeForkRequestStarted) throw error;
-      log.warn('shared host unavailable before precise fork; using legacy isolated fallback', {
-        error: error instanceof Error ? error.message : String(error),
-      });
-      return null;
-    } finally {
-      releaseHostBindingLease?.();
-    }
-  }
-
   async forkSdkSession(opts: ForkSdkSessionOptions): Promise<ForkSdkSessionResult> {
     const log = this.deps.logger.child('codex/fork');
     const tailTurnsToDrop = normalizeTailTurnsToDrop(opts.tailTurnsToDrop);
@@ -13573,18 +13495,10 @@ export class CodexAgent extends BaseAgent {
       model: opts.model,
     });
 
-    // Keep exact native-turn forks on the regular host so an active source
-    // thread is already hydrated. The helper holds a binding lease across the
-    // control-plane request and returns null only before a fork is attempted.
-    if (lastTurnId && !opts.stripEncryptedReasoning) {
-      const nativeForkResult = await this.tryForkSdkSessionAtNativeTurn(
-        opts,
-        lastTurnId,
-        forkCredentialMode,
-      );
-      if (nativeForkResult) return nativeForkResult;
-    }
-
+    // Codex 0.153 keeps unsubscribed threads loaded for 30 minutes. Even an
+    // exact native-turn fork must own a one-shot host: returning its child ID
+    // before that process exits leaves a writer that blocks a different host
+    // from resuming the child. Never retire the shared host to release it.
     // 故障半径隔离(2026-08-08 实排):thread/fork 的响应体与源 thread 历史成正比、
     // 无上界 —— 47MB rollout 实测产出 31MiB 单行 NDJSON,超过 client 16MiB
     // maxLineBytes 守卫后整条连接被熔断,当时共享 utility host 上挂着的 5 个活跃
@@ -13601,12 +13515,10 @@ export class CodexAgent extends BaseAgent {
       if (!forkHost || createdThreadIds.size === 0) return;
       for (const threadId of createdThreadIds) {
         try {
-          // Codex 0.145 keeps a forked child loaded in the app-server. Unload
-          // it before the new Cindy Session resumes with its own MCP instance
-          // URL; otherwise thread/resume.config is ignored and the child
-          // remains bound to this host's spawn-level URL. The ephemeral host
-          // is retired right after, but graceful unload also flushes the
-          // child's state before the process dies.
+          // Request graceful cleanup before retiring the one-shot host.
+          // Since 0.153 this only schedules unload, so the process shutdown
+          // below is the barrier that releases the writer and allows the new
+          // session to resume with its own MCP instance configuration.
           await forkHost.unsubscribeThread(threadId);
         } catch (error) {
           log.warn('fork child cleanup failed; ephemeral fork host will be retired', {
@@ -13680,9 +13592,13 @@ export class CodexAgent extends BaseAgent {
         // Cindy's handoff recovery, never a file rewrite that invalidates Codex's DB.
         await assertCodexRolloutRewriteSupported(preparedSourcePath || await this.findRolloutPath(opts.sourceSdkSessionId));
       }
+      const usedNativeForkAnchor = Boolean(
+        lastTurnId && !opts.stripEncryptedReasoning && supportsCodexNativeTurnFork(initResp.userAgent),
+      );
       const params: ThreadForkParams = {
         threadId: opts.sourceSdkSessionId,
         persistExtendedHistory: true,
+        ...(usedNativeForkAnchor ? { lastTurnId } : {}),
         // 响应体瘦身:fork 后 Cindy 自己的会话数据负责历史展示,thread.turns 全量
         // 回传只会撑爆单行上限。老 daemon 不认识该字段则保持 legacy 行为 —— 此时
         // 一次性 host 的隔离仍兜住故障半径。
@@ -13694,7 +13610,7 @@ export class CodexAgent extends BaseAgent {
       const resp = await host.request<ThreadForkResponse>(Method.ThreadFork, params);
       let newSdkSessionId = resp.thread.id;
       createdThreadIds.add(newSdkSessionId);
-      if (tailTurnsToDrop > 0) {
+      if (!usedNativeForkAnchor && tailTurnsToDrop > 0) {
         const rollbackParams: ThreadRollbackParams = {
           threadId: newSdkSessionId,
           numTurns: tailTurnsToDrop,
@@ -13729,7 +13645,11 @@ export class CodexAgent extends BaseAgent {
         });
       }
       log.info('forkSdkSession ◀', { newSdkSessionId, tailTurnsToDrop });
-      return { newSdkSessionId, uuidMap: new Map() };
+      return {
+        newSdkSessionId,
+        uuidMap: new Map(),
+        ...(usedNativeForkAnchor ? { usedNativeForkAnchor: true } : {}),
+      };
     } catch (error) {
       operationFailed = true;
       // Recovery and authentication are control signals consumed by callers.
@@ -13746,13 +13666,20 @@ export class CodexAgent extends BaseAgent {
         await cleanupCreatedThreads();
       } catch (error) {
         // A cleanup failure must never replace the primary failure.
-        if (!operationFailed) throw new CodexForkError('child-cleanup', error);
+        if (!operationFailed) {
+          operationFailed = true;
+          forkFailure = new CodexForkError('child-cleanup', error);
+          throw forkFailure;
+        }
         if (forkFailure) forkFailure.cleanupFailed = true;
       } finally {
         // 一次性 host 用完即收,无论成败。key 唯一、无 session 绑定,
         // retire 不会波及任何共享 host 或活跃会话。
         if (forkHost && !forkHostRetired) {
-          await retireForkHost(forkFailure !== undefined).catch((err) => {
+          // Unsubscribe is not a writer-release barrier. Never publish a
+          // successful fork unless physical shutdown has been confirmed.
+          await retireForkHost(true).catch((err) => {
+            if (!operationFailed) throw new CodexForkError('host-retire', err);
             if (forkFailure) forkFailure.cleanupFailed = true;
             log.warn('fork host retire failed', {
               forkHostKey,


### PR DESCRIPTION
## 这次改了什么

### 摘要

Codex 任务 fork 成功打开后，发送消息会在恢复子线程时失败，报 `thread ... already has an active writer`。本次修复确保 fork 返回的子线程能够由新 Host 恢复并继续发送消息。

**根因：** #3864 将带 `lastTurnId` 的 native-turn fork 放到共享 Host 执行，并在 `thread/unsubscribe` 返回后交付子线程 ID。但 Codex 0.153 的 unsubscribe 只安排延迟卸载，成功响应不代表 writer 已退出；共享 Host 继续运行时，子任务的新 Host 执行 `thread/resume` 就会撞上仍存活的 writer。

**改动：**

- 所有 fork 统一使用独立、一次性的 `local-fork:*` control-plane Host，保留 `lastTurnId`、`excludeTurns` 和 `persistExtendedHistory`；原生定位成功时不再额外 rollback。
- 子线程 cleanup 后，在 finally 中等待 Host shutdown 完成，再返回成功结果。无法确认退出时抛出 `CodexForkError('host-retire', ...)`，防止返回尚不可恢复的子线程 ID。
- 只回收本次 fork 的 Host，保留源任务的共享 Host 和订阅。
- 补充 writer 延迟退出、源 Host 保持存活、cleanup/shutdown 失败，以及 0.145/0.153 协议版本的 mock 回归测试。

### 变更类型

- [x] `fix` 缺陷修复

### 范围

- 关联需求：修复 fork 后无法发送消息；回归来源为 PR #3864。
- 本 PR 包含：`packages/maker-core/src/agents/codex/index.ts` 及其单元测试。
- 明确不包含：UI、数据库、system prompt、IPC、跨端 wire protocol 和 SSH 实现变更。
- 用户可见变化：fork 创建的子任务可继续发送消息，源任务保持可用。
- 是否存在 breaking change：无。

### UI 变化

不涉及。
- 引用的设计规范：不涉及。

## 怎么验证的

### 自动验证

- `pnpm test:unit:related`：已执行，整体退出码为 1，**未全绿**。
  - `@cindy/maker-core` 的 2 个相关测试路径通过，包含本次 fork 回归测试；`@cindy/lizi-mcps`、`@cindy/orca-workflow` 的相关测试也通过。
  - Desktop：2,423 个测试文件通过、2 个失败；32,771 项通过、8 项失败、94 项跳过。
  - 失败集中在 `cindy-media/__tests__/blobStore.test.ts`（7 项）和 `ingest.test.ts`（1 项）：Windows `fs.symlinkSync` 返回 `EPERM`，部分后续断言因链接未创建而返回 `ENOENT`。这些失败与本次 fork 改动无关；未修改或跳过这些测试。
- `pnpm --filter @cindy/maker-core run --if-present typecheck`：退出码 0；该包未定义 typecheck script，实际跳过，不能视为完整类型检查通过。
- 另行 TypeScript 检查存在 54 项已有错误，前序与基线对比未发现新增错误。
- `pnpm check:dco` 与 `git diff --check HEAD^ HEAD`：通过。

### 手工验证

Windows 独立 CN Dev 沙盒加载本分支修复，使用隔离数据目录及 Codex 0.153.4 runtime。用户已反馈本次问题的人工测试验收通过。

启动命令：

```text
pnpm restart:desktop:remote -- --region=cn --isolated=fierce-kernighan-blackbox --isolated-auth --wait-ready
```

### 未执行的验证

- 未执行全仓 `pnpm test:unit`；提交前执行的是上述 related 门禁，完整单测交由 CI 验证。
- 未进行 macOS/Linux、SSH 或手机实机回归。
- 0.145/0.153 多版本覆盖来自 mock 单测，不代表这两个版本均完成真实 runtime 黑盒测试。

## 风险

### 风险分类

- [x] 跨平台差异：实机验收仅覆盖 Windows，其他平台尚未验证。
- [x] 其他：native fork 增加一次独立 Host 启停；shutdown 失败会明确返回 fork 失败。

### 影响与回滚

- 影响范围：本地 Codex fork 的 Host 生命周期。保留原生边界定位和精简响应参数；源任务的共享 Host 不会因本次 fork 被关闭。远程控制入口继续复用既有 Desktop 路径。
- 移动端冷更判断：不会触发。本 PR 仅改 maker-core 的 Codex 实现和测试，未修改 mobile 原生配置、原生依赖、config plugin 或 runtime fingerprint 输入。
- 存量插件影响：无，未修改插件基座、批准记录或装配契约。
- 回滚 / 降级方式：可回滚本提交，但会恢复共享 fork Host 的 writer 冲突风险。
- 本地 related 门禁未全绿，具体环境失败已列于自动验证；最终仍需结合 CI 结果评估。

### 提交前检查

- [x] 已 review 完整 diff
- [x] 每个 commit 都带 DCO 签名（`git commit -s`）
- [x] 未提交凭证、令牌或授权文件
- [x] 已确认测试结果或说明未执行原因
- 文档：无须新增持久文档，临时测试材料仅保留本地。