### PR TITLE
fix(mobile): 修复 Android 听写输入文字重影

### DIFF
--- a/apps/mobile/app/sessions/new.tsx
+++ b/apps/mobile/app/sessions/new.tsx
@@ -6812,6 +6812,9 @@ const makeStyles = (colors: ThemeColors) => StyleSheet.create({
   },
   inputVoiceHidden: {
     color: 'transparent',
+    // Android Fabric can treat transparent text as an unset color and draw it black.
+    // Keep layout/presses; iOS needs nonzero view opacity for native hit testing.
+    ...(Platform.OS === 'android' ? { opacity: 0 } : {}),
   },
   sendButton: {
     alignItems: 'center',

--- a/apps/mobile/src/__tests__/newSessionVoiceInput.test.tsx
+++ b/apps/mobile/src/__tests__/newSessionVoiceInput.test.tsx
@@ -1,0 +1,157 @@
+// @vitest-environment jsdom
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+import { act, createElement, createRef, type ReactNode } from 'react';
+import { createRoot, type Root } from 'react-dom/client';
+import type { TextInputProps, TextStyle } from 'react-native';
+import ts from 'typescript';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { MobileComposerInputRow, type MobileComposerInputRowProps } from '@/session/MobileComposerInputRow';
+import { palettes } from '@/theme/tokens';
+
+const native = vi.hoisted(() => ({
+  platform: 'android',
+  mode: 'light' as 'light' | 'dark',
+  props: {} as TextInputProps,
+}));
+vi.mock('react-native', () => ({
+  Platform: { get OS() { return native.platform; } },
+  StyleSheet: { hairlineWidth: 1 },
+  View: ({ children }: { children: ReactNode }) => createElement('div', null, children),
+}));
+vi.mock('@/components/AppText', async () => {
+  const { forwardRef } = await import('react');
+  return { TextInput: forwardRef<HTMLTextAreaElement, TextInputProps>((props, ref) => {
+    native.props = props;
+    return createElement('textarea', {
+      ref, value: props.value, readOnly: true,
+      onMouseDown: () => props.onPressIn?.({} as never),
+    });
+  }) };
+});
+vi.mock('react-native-reanimated', () => ({
+  default: { View: ({ children }: { children: ReactNode }) => createElement('div', null, children) },
+}));
+vi.mock('@/platform/gestureHandler', () => ({}));
+vi.mock('lucide-react-native', () => ({}));
+vi.mock('expo-constants', () => ({
+  default: { executionEnvironment: 'bare' }, ExecutionEnvironment: { StoreClient: 'storeClient' },
+}));
+vi.mock('expo-paste-input', () => ({
+  TextInputWrapper: ({ children }: { children: ReactNode }) => createElement('div', null, children),
+}));
+vi.mock('@/theme', () => ({
+  useThemedStyles: (make: (colors: typeof palettes.light) => unknown) => make(palettes[native.mode]),
+}));
+
+// Exercise the page's actual visibility/event expressions and the real input row.
+// Extract only this boundary so unrelated screen/network/native dependencies are not loaded.
+// Native drawing and hit testing still require the Android emulator regression.
+const source = ts.createSourceFile('new.tsx', readFileSync(
+  resolve(process.cwd(), 'app/sessions/new.tsx'), 'utf8',
+), ts.ScriptTarget.Latest, true, ts.ScriptKind.TSX);
+function findOne<T extends ts.Node>(guard: (node: ts.Node) => node is T): T {
+  const found: T[] = [];
+  function visit(node: ts.Node) {
+    if (guard(node)) found.push(node);
+    ts.forEachChild(node, visit);
+  }
+  visit(source);
+  if (found.length !== 1) throw new Error(`Expected one source boundary, found ${found.length}`);
+  return found[0];
+}
+const hiddenStyle = findOne((node): node is ts.PropertyAssignment =>
+  ts.isPropertyAssignment(node) && node.name.getText(source) === 'inputVoiceHidden');
+const composer = findOne((node): node is ts.JsxSelfClosingElement =>
+  ts.isJsxSelfClosingElement(node) && node.tagName.getText(source) === 'MobileComposerInputRow');
+const propNames = ['inputStyle', 'caretHidden', 'value', 'placeholder', 'onPressIn'];
+const expressions = propNames.map((name) => {
+  const prop = composer.attributes.properties.find((node) =>
+    ts.isJsxAttribute(node) && node.name.getText(source) === name);
+  if (!prop || !ts.isJsxAttribute(prop) || !prop.initializer
+    || !ts.isJsxExpression(prop.initializer) || !prop.initializer.expression) {
+    throw new Error(`Missing composer expression: ${name}`);
+  }
+  return `${name}: ${prop.initializer.expression.getText(source)}`;
+});
+const compiled = ts.transpileModule(`function pageProps(bindings) {
+  const { Platform, voiceIsListening, draft, finishVoiceRecording, composerPlaceholder } = bindings;
+  const styles = { inputVoiceHidden: ${hiddenStyle.initializer.getText(source)} };
+  return { ${expressions.join(',\n')} };
+}`, { compilerOptions: { target: ts.ScriptTarget.ES2022 } }).outputText;
+const pageProps = new Function(`${compiled}; return pageProps;`)() as
+  (bindings: Record<string, unknown>) => Partial<MobileComposerInputRowProps>;
+
+Object.assign(globalThis, { IS_REACT_ACT_ENVIRONMENT: true });
+let root: Root | undefined;
+afterEach(() => { act(() => root?.unmount()); root = undefined; });
+
+function mountInput() {
+  const container = document.createElement('div');
+  const ref = createRef<HTMLTextAreaElement>();
+  const finishVoiceRecording = vi.fn();
+  root = createRoot(container);
+  function render(listening: boolean, draft: string) {
+    const colors = palettes[native.mode];
+    act(() => root!.render(createElement(MobileComposerInputRow, {
+      accessibilityLabel: 'Draft', inputTestID: 'draft', inputRef: ref,
+      placeholder: 'Draft', placeholderTextColor: colors.textTertiary,
+      value: draft, onChangeText: vi.fn(), onPasteImages: vi.fn(),
+      ...pageProps({ Platform: { OS: native.platform }, voiceIsListening: listening,
+        draft: { firstMessage: draft }, finishVoiceRecording, composerPlaceholder: 'Draft' }),
+      inputOverlay: listening ? createElement('span', { 'data-testid': 'preview' }, draft) : null,
+    })));
+  }
+  const inputStyle = () => {
+    const styles: unknown[] = [native.props.style];
+    return Object.assign({}, ...styles.flat(Infinity).filter(Boolean)) as TextStyle;
+  };
+  return { container, ref, render, inputStyle, finishVoiceRecording };
+}
+
+describe.each(['light', 'dark'] as const)('new-session dictation input (%s)', (mode) => {
+  it('hides Android native drawing while keeping streamed drafts and the same mounted input', () => {
+    native.platform = 'android';
+    native.mode = mode;
+    const input = mountInput();
+    input.render(false, 'before suffix');
+    const original = input.ref.current;
+    expect(original).not.toBeNull();
+    expect(input.inputStyle().opacity ?? 1).toBe(1);
+    expect(input.inputStyle().color).toBe(palettes[mode].textPrimary);
+
+    for (const draft of ['before hello suffix', 'before hello\nworld suffix']) {
+      input.render(true, draft);
+      expect(input.ref.current).toBe(original);
+      expect(original?.value).toBe(draft);
+      expect(input.inputStyle().opacity).toBe(0);
+      expect(input.inputStyle().display).not.toBe('none');
+      expect(native.props.caretHidden).toBe(true);
+      expect(native.props.placeholder).toBe('');
+      expect(input.container.querySelector('[data-testid="preview"]')?.textContent).toBe(draft);
+    }
+    act(() => original!.dispatchEvent(new MouseEvent('mousedown', { bubbles: true })));
+    expect(input.finishVoiceRecording).toHaveBeenCalledOnce();
+
+    input.render(false, 'before hello\nworld suffix');
+    expect(input.ref.current).toBe(original);
+    expect(original?.value).toBe('before hello\nworld suffix');
+    expect(input.inputStyle().opacity ?? 1).toBe(1);
+    expect(input.inputStyle().color).toBe(palettes[mode].textPrimary);
+    expect(native.props.caretHidden).toBe(false);
+    expect(input.container.querySelector('[data-testid="preview"]')).toBeNull();
+    act(() => original!.dispatchEvent(new MouseEvent('mousedown', { bubbles: true })));
+    expect(input.finishVoiceRecording).toHaveBeenCalledOnce();
+  });
+
+  it('retains transparent text on iOS without hiding the view from native hit testing', () => {
+    native.platform = 'ios';
+    native.mode = mode;
+    const input = mountInput();
+    input.render(true, 'dictation');
+    expect(input.inputStyle().color).toBe('transparent');
+    expect(input.inputStyle().opacity ?? 1).toBe(1);
+    input.render(false, 'dictation');
+    expect(input.inputStyle().color).toBe(palettes[mode].textPrimary);
+  });
+});


### PR DESCRIPTION
## 这次改了什么

### 摘要

修复 #4111：Android 新建任务页听写期间，原生输入框文字未被透明色隐藏，与语音预览叠加产生错位重影。录音态在 Android 上额外使用 `opacity: 0` 隐藏原生输入层，保留挂载、布局和草稿更新；停止后恢复正常文字。iOS 保留原来的透明文字策略。

### 变更类型

- [ ] `feat` 新功能
- [x] `fix` 缺陷修复
- [ ] `refactor` / `perf` 重构或性能优化
- [ ] `docs` / `test` / `chore` 文档、测试或工程维护
- [ ] 其他：

### 范围

- 关联 Issue / 需求：#4111。
- 本 PR 包含：Android 录音态显示修复，以及 4 项亮色/深色回归测试，覆盖平台差异、录音前后样式恢复、隐藏期间草稿更新、输入实例保持和既有回调连接。
- 明确不包含：点击输入区停止听写、停止后光标恢复的交互修复；语音识别服务及原生依赖调整。
- 用户可见变化：听写期间只显示语音预览的一层文字，停止后恢复原生输入框文字。
- 是否存在 breaking change：无。

### UI 变化

- 引用的设计规范：`docs/design-rules/DESIGN.md` §4「Inputs & Forms」、§10「Light / Dark Dual-Mode Delivery Gate」及 `apps/mobile/docs/mobile-design-guide.md` §2。保留现有排版与语义色，仅调整 Android 录音态输入层的可见性；亮色和深色均已在 Android 模拟器目检。
- 修复前：原生文字和带麦克风标记的预览同时绘制；修复后：只绘制预览，停止后恢复原生文字。单行、多行、空草稿均已查看。
- 截图：已保存本地模拟器裁剪对照图，未上传或提交到仓库。

## 怎么验证的

### 自动验证

```text
pnpm --filter mobile exec vitest run src/__tests__/newSessionVoiceInput.test.tsx src/__tests__/mobileVoiceController.test.ts src/__tests__/composerRichInputLifecycle.test.tsx src/__tests__/composerVoiceDraftMetrics.test.ts
结果：4 个文件、49 项测试通过。新增 4 项测试；修复前 Android 亮色/深色用例均失败，修复后通过。

pnpm test:unit:related
结果：通过。

pnpm --filter mobile run --if-present typecheck
结果：通过。

node scripts/test-workspaces.mjs --tier unit
结果：PASS

pnpm check:dco
结果：通过，1 个提交已签名。

git diff --check
结果：通过。
```

### 手工验证

- Android 16 / API 36 模拟器 `cindy-api36`，Global 开发包 `com.xd.cindy`，React Native 0.86.3。验证的是开发包与当前源码，不是 Issue 中的 v0.1.75 发布包。
- 分支 `cindy/silent-hopper`，worktree `silent-hopper`。通过 `pnpm mobile:sim:start` 启动该工作区 Metro `:8081`，启动日志源码标识为 `cindy/silent-hopper@3fe2a5f19+fe4047ac55`；修改后出现 `Android Bundled ... (4510 modules)`，CDP 连接目标为 `com.xd.cindy`。该已验证源码随后提交为 `d0a302153`。
- 开发包未登录，因此使用临时组件测试页挂载真实 `MobileComposerInputRow`、实际页面的样式/预览/停止回调及真实语音控制器，音频和转写输入均模拟；未修改登录态或接入真实凭证。
- 原始 `color: transparent` 状态能复现重影；加入 Android `opacity: 0` 后，亮色/深色的空草稿、单行、多行、连续转写和选区替换均不再重影。点击停止按钮后，原生文字恢复正常显示。

### 未执行的验证

- 未进行完整新建任务页面端到端录音、在线语音识别、小米真机、Android 发布包和 iOS 实机验证。组件单测中的鼠标事件仅验证回调连接，不作为 Android 原生命中测试通过的证据。
- 组件验证中的点击输入区停止、停止后光标位置在修复前后表现相同，本 PR 不修复这两项，也不将它们记录为验证通过。
- Windows 的 `pnpm mobile:sim:whoami` 因 `spawnSync pnpm ENOENT` 未通过，未取得完整新建页的 `__DEV__` build label 截图；源码归属以上述启动日志、新 bundle 和 CDP 实际输入样式为依据。

## 风险

### 风险分类

- [ ] 无已知风险
- [ ] SQLite / migration
- [ ] system prompt
- [ ] 协议兼容
- [ ] 权限 / 安全 / 用户数据
- [ ] 存量插件兼容（批准状态 / 指纹 / manifest 校验 / 安装布局 / 包格式）
- [ ] 原生层 / fingerprint / OTA
- [x] 跨平台差异
- [ ] 其他：

### 影响与回滚

- 影响范围：Android 新建任务页的录音态原生输入层。iOS 继续使用透明文字，避免改变其原生视图命中行为。
- 冷更分析：不触发冷更。本次仅修改 TSX 样式与测试，未改动 `app.json`、`app.config.js`、`eas.json`、Mobile 依赖/scripts、lockfile、config plugin 或原生模块等 fingerprint 输入；未新增依赖。
- 回滚 / 降级方式：回退本提交，无协议或数据迁移。

### 提交前检查

- [x] 已 review 完整 diff
- [x] 每个 commit 都带 DCO 签名（`git commit -s`，见 [DCO](../DCO)）
- [x] UI 改动已在「UI 变化」注明引用的设计规范章节（不涉及 UI 则跳过）
- [x] 未提交凭证、令牌或授权文件
- [x] 已补充必要文档（无产品文档变更，原因已在代码注释说明）
- [x] 已确认测试结果或说明未执行原因