### PR TITLE
fix(models): decouple guest provider settings from gateway media

### DIFF
--- a/apps/desktop/src/main/cindy-brain/index.ts
+++ b/apps/desktop/src/main/cindy-brain/index.ts
@@ -418,7 +418,7 @@ import {
   markGhostRecentlyUsed,
 } from './ghostRecentUsageStore.js';
 import { createXaiImageChannel } from './xaiImageClient.js';
-import { getCindyProxyMediaService } from '../mcp-integrations/cindyProxyMedia.js';
+import { getCindyProxyMediaService, getCindyVideoProviderRegistry } from '../mcp-integrations/cindyProxyMedia.js';
 import { getCindyProxySearchService } from '../mcp-integrations/cindyProxySearch.js';
 import { ImageChannelRegistry, decodeImageResponse } from './imageChannelRegistry.js';
 import { createGeminiImageChannel } from './geminiImageClient.js';
@@ -3341,7 +3341,7 @@ export function getGhostScheduleSlot(): GhostScheduleSlot {
  * 产物落媒体总仓(blob + 账本,出生=该意识),意识只拿到指纹字符串。
  */
 function getVideoProviderRegistry() {
-  const registry = getCindyProxyMediaService().backend.videoRegistry;
+  const registry = getCindyVideoProviderRegistry();
   if (!registry) return null;
   const xaiCatalogProvider = getActiveCatalog().providers.find(
     (provider) => provider.id === 'xai',

--- a/apps/desktop/src/main/cindy-media/__tests__/mediaRequestLog.test.ts
+++ b/apps/desktop/src/main/cindy-media/__tests__/mediaRequestLog.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from 'vitest';
 
-import { mediaRequestParamsForLog, mediaRequestUrlForLog } from '../mediaRequestLog.js';
+import { mediaErrorForLog, mediaRequestParamsForLog, mediaRequestUrlForLog } from '../mediaRequestLog.js';
 
 describe('media request log redaction', () => {
   it('保留实际 URL 并脱敏 query 凭证', () => {
@@ -37,5 +37,25 @@ describe('media request log redaction', () => {
       image: '[data URL mime=image/png bytes=2]',
       source: 'https://example.test/input.png?token=%5BREDACTED%5D#frame',
     });
+  });
+});
+
+describe('media error log redaction', () => {
+  it('preserves the failure reason while removing URLs, credentials and error payloads', () => {
+    const error = Object.assign(new Error('provider initialization failed: https://user:password@example.test/private?sig=secret; api_key=test-secret'), {
+      response: { body: 'private payload' },
+    });
+    const logged = mediaErrorForLog(error);
+    expect(logged).toContain('provider initialization failed:');
+    expect(logged).toContain('[REDACTED_URL]');
+    expect(logged).toContain('api_key=[REDACTED]');
+    expect(logged).not.toMatch(/password|example\.test|test-secret|private payload|\n +at /);
+    expect(mediaErrorForLog(new Error('art: proxy.baseUrl is required'))).toBe('art: proxy.baseUrl is required');
+  });
+
+  it('bounds diagnostics and does not serialize arbitrary thrown objects', () => {
+    expect(mediaErrorForLog('x'.repeat(2_000))).toHaveLength(1_000);
+    expect(mediaErrorForLog({ token: 'private' })).toBe('Non-Error thrown (object)');
+    expect(mediaErrorForLog('token=private')).toBe('token=[REDACTED]');
   });
 });

--- a/apps/desktop/src/main/cindy-media/mediaRequestLog.ts
+++ b/apps/desktop/src/main/cindy-media/mediaRequestLog.ts
@@ -96,3 +96,11 @@ export function mediaRequestParamsForLog(value: unknown): unknown {
 
   return visit(value, null, 0);
 }
+
+/** Keep diagnostic reasons without logging error payloads, stacks, or credential-bearing URLs. */
+export function mediaErrorForLog(error: unknown): string {
+  const message = error instanceof Error
+    ? error.message
+    : typeof error === 'string' ? error : `Non-Error thrown (${typeof error})`;
+  return redactSensitiveText(message.replace(/\bhttps?:\/\/[^\s"'<>]+/gi, '[REDACTED_URL]')).slice(0, 1_000);
+}

--- a/apps/desktop/src/main/maker-host/__tests__/providerService.test.ts
+++ b/apps/desktop/src/main/maker-host/__tests__/providerService.test.ts
@@ -23,6 +23,24 @@ describe('createProviderService', () => {
     expect((await svc.listProviders()).find((p) => p.id === 'openai')?.availableMediaModelIds).toEqual([]);
   });
 
+  it('keeps guest provider configuration available when optional media discovery fails', async () => {
+    let failed = true;
+    const svc = createProviderService({
+      getCatalog: bundledCatalog,
+      connection: { xd: () => false, anthropic: () => false, openai: () => false, xai: () => false },
+      getAvailableMediaModels: () => {
+        if (failed) throw new Error('art: proxy.baseUrl is required');
+        return [{ providerId: 'openai', id: 'gpt-image-2' }];
+      },
+    });
+    const providers = await svc.listProviders();
+    expect(providers.map((provider) => provider.id)).toEqual(BUNDLED_CATALOG.providers.map((provider) => provider.id));
+    expect(providers.every((provider) => !provider.connected)).toBe(true);
+    expect(providers.every((provider) => provider.availableMediaModelIds?.length === 0)).toBe(true);
+    failed = false;
+    expect((await svc.listProviders()).find((provider) => provider.id === 'openai')?.availableMediaModelIds).toEqual(['gpt-image-2']);
+  });
+
   it('lists providers with injected connection state', async () => {
     const svc = createProviderService({
       getCatalog: bundledCatalog,

--- a/apps/desktop/src/main/maker-host/provider-service.ts
+++ b/apps/desktop/src/main/maker-host/provider-service.ts
@@ -12,6 +12,8 @@
  * active-catalog 统一持有；连接状态每次实时读（凭证变化要立即反映）。
  */
 
+import { createLogger } from '../logger.js';
+
 import {
   buildRegistry,
   type Catalog,
@@ -22,6 +24,8 @@ import {
   type ProviderView,
   type Provider,
 } from '@cindy/model-providers';
+
+const log = createLogger('provider-service');
 
 /**
  * 读取连接态时是否允许附带**本机副作用**（绑定自愈、随之而来的清单拉取）。
@@ -169,7 +173,16 @@ export function createProviderService(deps: ProviderServiceDeps): ProviderServic
         if (failure) discoveryFailures[p.id] = failure;
       }
     }
-    const media = deps.getAvailableMediaModels?.();
+    let media: readonly { providerId: string; id: string }[] | undefined;
+    try {
+      media = deps.getAvailableMediaModels?.();
+    } catch {
+      // Media is optional enrichment; configuration and chat providers remain usable.
+      media = [];
+      log.warn(
+        'Media readiness unavailable; returning provider configuration without media readiness',
+      );
+    }
     return buildRegistry(catalog, connected, discoveryFailures, deps.getModelAccess?.()).map(
       (provider) =>
         media === undefined

--- a/apps/desktop/src/main/maker-host/provider-service.ts
+++ b/apps/desktop/src/main/maker-host/provider-service.ts
@@ -13,6 +13,7 @@
  */
 
 import { createLogger } from '../logger.js';
+import { mediaErrorForLog } from '../cindy-media/mediaRequestLog.js';
 
 import {
   buildRegistry,
@@ -176,11 +177,12 @@ export function createProviderService(deps: ProviderServiceDeps): ProviderServic
     let media: readonly { providerId: string; id: string }[] | undefined;
     try {
       media = deps.getAvailableMediaModels?.();
-    } catch {
+    } catch (error) {
       // Media is optional enrichment; configuration and chat providers remain usable.
       media = [];
       log.warn(
         'Media readiness unavailable; returning provider configuration without media readiness',
+        { error: mediaErrorForLog(error) },
       );
     }
     return buildRegistry(catalog, connected, discoveryFailures, deps.getModelAccess?.()).map(

--- a/apps/desktop/src/main/mcp-integrations/__tests__/cindyVideoProviderRegistry.test.ts
+++ b/apps/desktop/src/main/mcp-integrations/__tests__/cindyVideoProviderRegistry.test.ts
@@ -1,0 +1,43 @@
+import { describe, expect, it, vi } from 'vitest';
+import { createXaiVideoProvider, XAI_VIDEO_CATALOG_MODEL_ID } from '../../cindy-proxy-media/video/providers/xai.js';
+
+const state = vi.hoisted(() => ({ baseUrl: '', createService: vi.fn(), createStorage: vi.fn() }));
+vi.mock('../../model-access/effectiveEndpoint.js', () => ({ effectiveXdGatewayBaseUrl: () => state.baseUrl }));
+vi.mock('../../cindy-proxy-media/service.js', () => ({ createCindyProxyMediaService: state.createService }));
+vi.mock('../../cindy-media/generatedMedia.js', () => ({ createBlobImageStorage: state.createStorage, createBlobVideoStorage: state.createStorage }));
+vi.mock('../../imageCacheStore.js', () => ({ resolveSafe: vi.fn() }));
+vi.mock('../../secrets/providerSecretStore.js', () => ({ getProviderSecretStore: () => { throw new Error('Discovery must not read credentials'); } }));
+vi.mock('../../appCapabilities.js', () => ({ getAppCapabilities: () => ({ canUseCindyGateway: false }) }));
+vi.mock('../../logger.js', () => ({ createLogger: () => ({ warn: vi.fn() }) }));
+
+import { getCindyVideoProviderRegistry } from '../cindyProxyMedia.js';
+
+describe('video registry independent of Gateway image initialization', () => {
+  it('supports guest third-party video and endpoint changes without initializing image clients or storage', () => {
+    state.baseUrl = '';
+    const guest = getCindyVideoProviderRegistry();
+    expect(guest.hasAny()).toBe(false);
+    guest.register(createXaiVideoProvider({
+      hasOAuthLogin: () => true,
+      getAccessToken: async () => 'test-token',
+      getCredentialGeneration: () => 1,
+      getOwnerScopeKey: () => 'guest',
+      isOwnerBoundaryPending: () => false,
+    }), 'xai');
+    expect(getCindyVideoProviderRegistry()).toBe(guest);
+    expect(guest.hasAlias(XAI_VIDEO_CATALOG_MODEL_ID, 'xai')).toBe(true);
+
+    state.baseUrl = 'https://gateway.example.invalid';
+    const configured = getCindyVideoProviderRegistry();
+    expect(configured).not.toBe(guest);
+    expect(configured.hasAlias('seedance-fast', 'xd')).toBe(true);
+    expect(configured.collectAllAliases()[0]?.alias).toBe('seedance-fast');
+
+    state.baseUrl = '';
+    const signedOut = getCindyVideoProviderRegistry();
+    expect(signedOut).not.toBe(configured);
+    expect(signedOut.hasAny()).toBe(false);
+    expect(state.createService).not.toHaveBeenCalled();
+    expect(state.createStorage).not.toHaveBeenCalled();
+  });
+});

--- a/apps/desktop/src/main/mcp-integrations/cindyProxyMedia.ts
+++ b/apps/desktop/src/main/mcp-integrations/cindyProxyMedia.ts
@@ -6,10 +6,8 @@ import {
 } from '../cindy-proxy-media/video/providers/seedance.js';
 import { createHappyhorseProvider } from '../cindy-proxy-media/video/providers/happyhorse.js';
 import { resolveSafe as resolveXdtImage } from '../imageCacheStore.js';
-import {
-  createBlobImageStorage,
-  createBlobVideoStorage,
-} from '../cindy-media/generatedMedia.js';
+import { createBlobImageStorage, createBlobVideoStorage } from '../cindy-media/generatedMedia.js';
+import { VideoProviderRegistry } from '../cindy-proxy-media/video/registry.js';
 import { createLogger } from '../logger.js';
 import { getProviderSecretStore } from '../secrets/providerSecretStore.js';
 import { effectiveXdGatewayBaseUrl } from '../model-access/effectiveEndpoint.js';
@@ -53,32 +51,7 @@ export function getCindyProxyMediaService(): CindyProxyMediaService {
       resolveLegacyImageRef: (ref) => resolveXdtImage(ref),
     });
     const videoStore = createBlobVideoStorage();
-    // 视频 provider 装配点 — 加新模型(kling/luma/wan)就在这个数组追加一行,
-    // cindy 槽 handler / 渲染层 / 协议层零改动。
-    //
-    // 顺序敏感:数组首个 alias 就是出厂默认(GATEWAY_VIDEO_MODELS 首项同源
-    // 守卫锁定),seedance-fast 必须永远排第一个。happyhorse 是 opt-in,
-    // 只有用户显式点名才切。
-    const videoProviders = [
-      createSeedanceProvider({
-        baseUrl: getGatewayBaseUrl(),
-        getApiKey: readApiKey,
-        logger: log,
-      }),
-      // Seedance 2.5 是独立 provider(值域与 2.0 差太远,capabilities 是
-      // per-provider 的,详见 seedance.ts 文件头)。同样是 opt-in:排在
-      // seedance-fast 之后,不抢出厂默认。
-      createSeedance25Provider({
-        baseUrl: getGatewayBaseUrl(),
-        getApiKey: readApiKey,
-        logger: log,
-      }),
-      createHappyhorseProvider({
-        baseUrl: getGatewayBaseUrl(),
-        getApiKey: readApiKey,
-        logger: log,
-      }),
-    ];
+    const videoProviders = createGatewayVideoProviders(artServiceBaseUrl);
     artService = createCindyProxyMediaService({
       imageApi: {
         getApiKey: readApiKey,
@@ -100,4 +73,50 @@ export function getCindyProxyMediaService(): CindyProxyMediaService {
     });
   }
   return artService;
+}
+
+/** Shared factory: execution keeps the same aliases and ordering as discovery. */
+function createGatewayVideoProviders(baseUrl: string) {
+  return [
+    createSeedanceProvider({
+      baseUrl,
+      getApiKey: readApiKey,
+      logger: log,
+    }),
+    // Seedance 2.5 是独立 provider(值域与 2.0 差太远,capabilities 是
+    // per-provider 的,详见 seedance.ts 文件头)。同样是 opt-in:排在
+    // seedance-fast 之后,不抢出厂默认。
+    createSeedance25Provider({
+      baseUrl,
+      getApiKey: readApiKey,
+      logger: log,
+    }),
+    createHappyhorseProvider({
+      baseUrl,
+      getApiKey: readApiKey,
+      logger: log,
+    }),
+  ];
+}
+
+let videoRegistry: VideoProviderRegistry | null = null;
+let videoRegistryBaseUrl: string | null = null;
+
+/** Video discovery must work without constructing the Gateway image client or media storage. */
+export function getCindyVideoProviderRegistry(): VideoProviderRegistry {
+  const baseUrl = getGatewayBaseUrl();
+  if (!videoRegistry || videoRegistryBaseUrl !== baseUrl) {
+    const next = new VideoProviderRegistry();
+    if (baseUrl.trim()) {
+      try {
+        for (const provider of createGatewayVideoProviders(baseUrl)) next.register(provider);
+      } catch {
+        // A broken optional Gateway must not prevent independent providers from registering.
+        log.warn('Gateway video providers unavailable during registry initialization');
+      }
+    }
+    videoRegistry = next;
+    videoRegistryBaseUrl = baseUrl;
+  }
+  return videoRegistry;
 }

--- a/apps/desktop/src/main/mcp-integrations/cindyProxyMedia.ts
+++ b/apps/desktop/src/main/mcp-integrations/cindyProxyMedia.ts
@@ -9,6 +9,7 @@ import { resolveSafe as resolveXdtImage } from '../imageCacheStore.js';
 import { createBlobImageStorage, createBlobVideoStorage } from '../cindy-media/generatedMedia.js';
 import { VideoProviderRegistry } from '../cindy-proxy-media/video/registry.js';
 import { createLogger } from '../logger.js';
+import { mediaErrorForLog } from '../cindy-media/mediaRequestLog.js';
 import { getProviderSecretStore } from '../secrets/providerSecretStore.js';
 import { effectiveXdGatewayBaseUrl } from '../model-access/effectiveEndpoint.js';
 import { getAppCapabilities } from '../appCapabilities.js';
@@ -110,9 +111,11 @@ export function getCindyVideoProviderRegistry(): VideoProviderRegistry {
     if (baseUrl.trim()) {
       try {
         for (const provider of createGatewayVideoProviders(baseUrl)) next.register(provider);
-      } catch {
+      } catch (error) {
         // A broken optional Gateway must not prevent independent providers from registering.
-        log.warn('Gateway video providers unavailable during registry initialization');
+        log.warn('Gateway video providers unavailable during registry initialization', {
+          error: mediaErrorForLog(error),
+        });
       }
     }
     videoRegistry = next;


### PR DESCRIPTION
## 这次改了什么

### 摘要

访客打开模型供应商页面时，媒体可用性查询会初始化 Gateway 图像客户端，缺少 endpoint 导致整个列表失败。本次将视频注册表与图像客户端初始化分离，缺少 Gateway 时仍允许第三方来源注册；可选媒体查询失败不再阻断供应商配置。

### 变更类型

- [x] `fix` 缺陷修复

### 范围

- 关联 Issue / 需求：Fixes #4120；修复 #3987 引入的回归。
- 本 PR 包含：独立视频注册表、endpoint 变化时重建、媒体可用性异常隔离、两条针对性回归。
- 明确不包含：模型配置架构重写、UI 重设计、登录/权限/凭证/数据库/协议变更。
- 用户可见变化：无 Gateway 的访客仍能加载供应商页面，访问现有自定义供应商入口。
- 是否存在 breaking change：无。

### UI 变化

- 引用的设计规范：不涉及；没有 Renderer、布局、样式或文案修改，仅恢复原有页面的数据加载。

## 怎么验证的

### 自动验证

```text
pnpm test:unit:related
结果：通过，Desktop 32.4 秒、Mobile 2.9 秒（脚本自动选择的相关范围）。
pnpm --filter desktop run --if-present typecheck
结果：通过。
git diff --check
结果：通过。
```

### 手工验证

已逐文件 review 完整 diff；核对供应商列表、媒体枚举、视频执行注册表和自定义供应商入口的调用链。

### 未执行的验证

未启动 Desktop 实机、未测试付费图像/视频生成，未验证 Windows 与 Light/Dark 实机。按紧急最小修复要求，不跑全仓测试、不扩展 UI。发版前可用访客模式打开设置 → 模型供应商，添加自定义供应商确认。

## 风险

### 风险分类

- [x] 其他：视频注册表由独立实例持有，Gateway provider 工厂与顺序保持复用；媒体枚举故障时媒体可用列表暂为空，普通供应商配置保留。

### 影响与回滚

- 影响范围：Desktop 供应商列表和视频注册表初始化；未修改生成协议、权限或持久数据。
- 回滚 / 降级方式：回退本 PR，无数据迁移；回退会恢复访客页面回归。

### 提交前检查

- [x] 已 review 完整 diff
- [x] 每个 commit 都带 DCO 签名
- [x] UI 改动已在「UI 变化」注明引用的设计规范章节（不涉及 UI 则跳过）
- [x] 未提交凭证、令牌或授权文件
- [x] 已补充必要文档（不涉及新配置与契约）
- [x] 已确认测试结果或说明未执行原因
