### PR TITLE
fix(mobile): 修复分享长图中照片变成文件名占位

### DIFF
--- a/apps/mobile/src/__tests__/remoteMediaDiskCacheExpo.test.ts
+++ b/apps/mobile/src/__tests__/remoteMediaDiskCacheExpo.test.ts
@@ -1,0 +1,68 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import {
+  downloadRemoteMediaAsDataUri,
+  withDownloadedRemoteMediaFile,
+} from '@/session/remoteMediaDiskCacheExpo';
+
+const io = vi.hoisted(() => ({
+  size: 5,
+  download: vi.fn(),
+  remove: vi.fn(),
+}));
+
+vi.mock('expo-file-system', () => ({
+  Paths: { cache: 'file:///app/cache' },
+  Directory: class {
+    uri: string;
+    constructor(parent: string, name: string) { this.uri = `${parent}/${name}`; }
+    create() {}
+  },
+  File: class {
+    uri: string;
+    constructor(parent: { uri: string }, name: string) { this.uri = `${parent.uri}/${name}`; }
+    get size() { return io.size; }
+    async base64() { return 'aGVsbG8='; }
+    delete() { io.remove(this.uri); }
+    static downloadFileAsync = io.download;
+  },
+}));
+
+beforeEach(() => {
+  io.size = 5;
+  io.remove.mockClear();
+  io.download.mockReset().mockImplementation(async (_url, target) => target);
+});
+
+describe('bounded temporary media downloads', () => {
+  it('keeps the file until the asynchronous consumer finishes, then removes it', async () => {
+    let finish!: (value: string) => void;
+    const read = vi.fn(() => new Promise<string>((done) => { finish = done; }));
+    const result = withDownloadedRemoteMediaFile('https://example.com/image', 'image/png', 8, read);
+    await vi.waitFor(() => expect(read).toHaveBeenCalledOnce());
+    expect(io.remove).not.toHaveBeenCalled();
+    finish('dimensions and embedded bytes');
+    expect(await result).toBe('dimensions and embedded bytes');
+    expect(io.remove).toHaveBeenCalledExactlyOnceWith(io.download.mock.calls[0]![1].uri);
+  });
+
+  it.each([0, 9])('removes a %s-byte download without exposing it to the consumer', async (size) => {
+    io.size = size;
+    const read = vi.fn();
+    expect(await withDownloadedRemoteMediaFile('https://example.com/image', 'image/png', 8, read)).toBeNull();
+    expect(read).not.toHaveBeenCalled();
+    expect(io.remove).toHaveBeenCalledOnce();
+  });
+
+  it.each(['download', 'read'])('removes partial files after a %s failure', async (failure) => {
+    const read = vi.fn(async () => { throw new Error('read failed'); });
+    if (failure === 'download') io.download.mockRejectedValueOnce(new Error('interrupted'));
+    expect(await withDownloadedRemoteMediaFile('https://example.com/image', 'image/png', 8, read)).toBeNull();
+    expect(io.remove).toHaveBeenCalledOnce();
+  });
+
+  it('preserves the existing inline-resource download contract', async () => {
+    expect(await downloadRemoteMediaAsDataUri('https://example.com/image', 'image/png', 8))
+      .toBe('data:image/png;base64,aGVsbG8=');
+    expect(io.remove).toHaveBeenCalledOnce();
+  });
+});

--- a/apps/mobile/src/__tests__/useConversationShareImages.test.ts
+++ b/apps/mobile/src/__tests__/useConversationShareImages.test.ts
@@ -1,33 +1,56 @@
 // @vitest-environment jsdom
 import { act, createElement, StrictMode } from "react";
 import { createRoot } from "react-dom/client";
-import { afterEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { Image } from "react-native";
+import { File } from "expo-file-system";
 import { useConversationShareImages } from "@/session/useConversationShareImages";
 import type { ConversationShareMessage } from "@/session/conversationShareWebViewHtml";
 import type { ResolveRemoteMediaFn } from "@/session/remoteMedia";
-import { downloadRemoteMediaAsDataUri } from "@/session/remoteMediaDiskCacheExpo";
+import { withDownloadedRemoteMediaFile } from "@/session/remoteMediaDiskCacheExpo";
 import { createRemoteMediaResolveQueue } from "@/session/remoteMediaResolveQueue";
 
 vi.mock("react-native", () => ({
-  Image: { getSize: vi.fn(async () => ({ width: 40, height: 20 })) },
+  Image: { getSize: vi.fn() },
 }));
 const thumbs = vi.hoisted(() => ({
   entries: new Map<string, string>(),
   reads: vi.fn(async () => "aGVsbG8="),
+  writes: vi.fn(async () => undefined),
+  deletes: vi.fn(),
+  size: 5,
 }));
 vi.mock("expo-file-system", () => ({
-  File: class {
-    exists = true;
-    size = 5;
-    base64 = thumbs.reads;
+  Paths: { cache: "file:///app/cache" },
+  Directory: class {
+    uri: string;
+    constructor(parent: string, name: string) {
+      this.uri = `${parent}/${name}`;
+    }
+    create() {}
   },
+  File: class {
+    uri: string;
+    constructor(parent: string | { uri: string }, name?: string) {
+      this.uri = typeof parent === "string" ? parent : parent.uri;
+      if (name) this.uri += `/${name}`;
+    }
+    exists = true;
+    get size() { return thumbs.size; }
+    base64 = thumbs.reads;
+    delete() { thumbs.deletes(this.uri); }
+  },
+}));
+vi.mock("expo-file-system/legacy", () => ({
+  writeAsStringAsync: thumbs.writes,
+  EncodingType: { Base64: "base64" },
 }));
 vi.mock("@/session/sentAttachmentThumbStore", () => ({
   ensureSentAttachmentThumbsHydrated: vi.fn(async () => undefined),
   getSentAttachmentThumbUri: (uri: string) => thumbs.entries.get(uri) ?? null,
 }));
 vi.mock("@/session/remoteMediaDiskCacheExpo", () => ({
-  downloadRemoteMediaAsDataUri: vi.fn(),
+  withDownloadedRemoteMediaFile: vi.fn(),
 }));
 
 Object.assign(globalThis, { IS_REACT_ACT_ENVIRONMENT: true });
@@ -68,16 +91,100 @@ const media = {
   expiresAt: "",
   previewable: true,
 };
+beforeEach(() => {
+  vi.mocked(Image.getSize).mockReset().mockImplementation(async (uri) => {
+    if (!uri.startsWith("file://")) {
+      throw new Error("Unsupported uri scheme for encoded image fetch!");
+    }
+    return { width: 40, height: 20 };
+  });
+  thumbs.size = 5;
+});
 afterEach(async () => {
   await act(async () => root.unmount());
   vi.useRealTimers();
   thumbs.entries.clear();
   thumbs.reads.mockClear();
-  vi.mocked(downloadRemoteMediaAsDataUri).mockReset();
+  thumbs.writes.mockReset();
+  thumbs.deletes.mockClear();
+  vi.mocked(withDownloadedRemoteMediaFile).mockReset();
   root = createRoot(container);
 });
 
 describe("share image readiness", () => {
+  it("sizes a controlled local file before embedding its bytes", async () => {
+    const uri = "file:///app/cache/remote.png";
+    const resolve = vi.fn<ResolveRemoteMediaFn>(async () => ({ ...media, url: uri }));
+    await act(async () => root.render(createElement(Probe, { messages: [source], resolve })));
+    await startShare();
+    expect((await ready)[0]?.images?.get("cindy-media://paste")).toEqual({
+      uri: media.url, width: 40, height: 20,
+    });
+    expect(Image.getSize).toHaveBeenCalledWith(uri);
+    expect(vi.mocked(Image.getSize).mock.invocationCallOrder[0]).toBeLessThan(
+      thumbs.reads.mock.invocationCallOrder[0]!,
+    );
+    expect(thumbs.writes).not.toHaveBeenCalled();
+    expect(thumbs.deletes).not.toHaveBeenCalled();
+  });
+
+  it("sizes inline bytes via a temporary file and keeps the original data URI", async () => {
+    const resolve = vi.fn<ResolveRemoteMediaFn>(async () => media);
+    await act(async () => root.render(createElement(Probe, { messages: [source], resolve })));
+    await startShare();
+    expect((await ready)[0]?.images?.get("cindy-media://paste")).toEqual({
+      uri: media.url, width: 40, height: 20,
+    });
+    const tempUri = vi.mocked(Image.getSize).mock.calls[0]![0];
+    expect(tempUri).toMatch(/^file:\/\/\/app\/cache\/conversation-share-images\/image-.*\.png$/);
+    expect(thumbs.writes).toHaveBeenCalledWith(tempUri, "aGVsbG8=", { encoding: "base64" });
+    expect(thumbs.deletes).toHaveBeenCalledExactlyOnceWith(tempUri);
+    expect(thumbs.reads).not.toHaveBeenCalled();
+  });
+
+  it.each(["error", "cancel", "timeout"])("cleans inline sizing files on %s", async (event) => {
+    vi.useFakeTimers({ toFake: ["setTimeout", "clearTimeout"] });
+    let finish!: (size: { width: number; height: number }) => void;
+    if (event === "error") {
+      vi.mocked(Image.getSize).mockRejectedValueOnce(new Error("invalid image"));
+    } else {
+      vi.mocked(Image.getSize).mockImplementationOnce(() => new Promise<{ width: number; height: number }>((done) => { finish = done; }));
+    }
+    const resolve = vi.fn<ResolveRemoteMediaFn>(async () => media);
+    await act(async () => root.render(createElement(Probe, { messages: [source], resolve })));
+    await startShare();
+    const tempUri = vi.mocked(Image.getSize).mock.calls[0]![0];
+    await act(async () => {
+      if (event === "cancel") current.cancel();
+      if (event === "timeout") await vi.advanceTimersByTimeAsync(20_000);
+    });
+    const result = await ready;
+    expect(event === "cancel" ? result.length : result[0]?.images?.size).toBe(0);
+    expect(thumbs.deletes).toHaveBeenCalledExactlyOnceWith(tempUri);
+    if (finish) await act(async () => finish({ width: 40, height: 20 }));
+    expect(event === "cancel" ? current.messages.length : current.messages[0]?.images?.size).toBe(0);
+  });
+
+  it("cleans a partial inline write without trying to size it", async () => {
+    thumbs.writes.mockRejectedValueOnce(new Error("disk full"));
+    const resolve = vi.fn<ResolveRemoteMediaFn>(async () => media);
+    await act(async () => root.render(createElement(Probe, { messages: [source], resolve })));
+    await startShare();
+    expect((await ready)[0]?.images?.size).toBe(0);
+    expect(Image.getSize).not.toHaveBeenCalled();
+    expect(thumbs.deletes).toHaveBeenCalledOnce();
+  });
+
+  it.each([0, 8 * 1024 * 1024 + 1])("rejects an inline file of %s bytes before native sizing", async (size) => {
+    thumbs.size = size;
+    const resolve = vi.fn<ResolveRemoteMediaFn>(async () => media);
+    await act(async () => root.render(createElement(Probe, { messages: [source], resolve })));
+    await startShare();
+    expect((await ready)[0]?.images?.size).toBe(0);
+    expect(Image.getSize).not.toHaveBeenCalled();
+    expect(thumbs.deletes).toHaveBeenCalledOnce();
+  });
+
   it.each(["timeout", "cancel", "selection", "session", "unmount"])(
     "removes queued media work on %s before a free slot can start it",
     async (event) => {
@@ -183,7 +290,7 @@ describe("share image readiness", () => {
     await startShare();
     expect((await ready)[0]?.images?.size).toBe(0);
     expect(resolve).not.toHaveBeenCalled();
-    expect(downloadRemoteMediaAsDataUri).not.toHaveBeenCalled();
+    expect(withDownloadedRemoteMediaFile).not.toHaveBeenCalled();
   });
 
   it.each([5, 0, -1, NaN, Infinity, 8 * 1024 * 1024 + 1])(
@@ -195,13 +302,13 @@ describe("share image readiness", () => {
         size,
         url,
       }));
-      vi.mocked(downloadRemoteMediaAsDataUri).mockResolvedValue(media.url);
+      vi.mocked(withDownloadedRemoteMediaFile).mockImplementation(async (_url, _mime, _maxBytes, read) => read(new File("file:///app/cache/download.png")));
       await act(async () =>
         root.render(createElement(Probe, { messages: [source], resolve })),
       );
       await startShare();
       expect((await ready)[0]?.images?.size).toBe(size === 5 ? 1 : 0);
-      expect(downloadRemoteMediaAsDataUri).toHaveBeenCalledTimes(
+      expect(withDownloadedRemoteMediaFile).toHaveBeenCalledTimes(
         size === 5 ? 1 : 0,
       );
     },
@@ -248,6 +355,9 @@ describe("share image readiness", () => {
       expect(result[0]?.images?.size).toBe(1);
       expect(result[0]?.attachments?.[0]?.uri).toBe(uri);
       expect(thumbs.reads).toHaveBeenCalledTimes(1);
+      expect(Image.getSize).toHaveBeenCalledWith("file:///app/sent-attachment-thumbs/paste.png");
+      expect(thumbs.writes).not.toHaveBeenCalled();
+      expect(thumbs.deletes).not.toHaveBeenCalled();
       expect(resolve).not.toHaveBeenCalled();
     },
   );
@@ -358,7 +468,7 @@ describe("share image readiness", () => {
       );
       expect(current.messages).toBe(result);
       expect(result[0]?.images?.size).toBe(2);
-      expect(downloadRemoteMediaAsDataUri).not.toHaveBeenCalled();
+      expect(withDownloadedRemoteMediaFile).not.toHaveBeenCalled();
     },
   );
 
@@ -417,7 +527,7 @@ describe("share image readiness", () => {
     await act(async () =>
       finish({ ...media, url: "https://example.com/cancelled.png" }),
     );
-    expect(downloadRemoteMediaAsDataUri).not.toHaveBeenCalled();
+    expect(withDownloadedRemoteMediaFile).not.toHaveBeenCalled();
     await startShare();
     expect((await ready).map((message) => message.clientId)).toEqual(["next"]);
     expect(current.messages[0]?.images?.size).toBe(0);

--- a/apps/mobile/src/__tests__/useConversationShareImages.test.ts
+++ b/apps/mobile/src/__tests__/useConversationShareImages.test.ts
@@ -106,7 +106,7 @@ afterEach(async () => {
   thumbs.entries.clear();
   thumbs.reads.mockClear();
   thumbs.writes.mockReset();
-  thumbs.deletes.mockClear();
+  thumbs.deletes.mockReset();
   vi.mocked(withDownloadedRemoteMediaFile).mockReset();
   root = createRoot(container);
 });
@@ -139,6 +139,78 @@ describe("share image readiness", () => {
     expect(tempUri).toMatch(/^file:\/\/\/app\/cache\/conversation-share-images\/image-.*\.png$/);
     expect(thumbs.writes).toHaveBeenCalledWith(tempUri, "aGVsbG8=", { encoding: "base64" });
     expect(thumbs.deletes).toHaveBeenCalledExactlyOnceWith(tempUri);
+    expect(thumbs.reads).not.toHaveBeenCalled();
+  });
+
+  it.each([
+    "data:image/png;charset=utf-8;base64,aGVsbG8=",
+    "data:image/png;charset=utf-8;name=photo;BASE64,aGVsbG8%3D",
+  ])("preserves MIME parameters and escaped Base64 in %s", async (uri) => {
+    const resolve = vi.fn<ResolveRemoteMediaFn>(async () => ({ ...media, url: uri }));
+    await act(async () => root.render(createElement(Probe, { messages: [source], resolve })));
+    await startShare();
+    expect((await ready)[0]?.images?.get("cindy-media://paste")).toEqual({
+      uri, width: 40, height: 20,
+    });
+    const tempUri = vi.mocked(Image.getSize).mock.calls[0]![0];
+    expect(tempUri).toMatch(/^file:\/\/\/app\/cache\/conversation-share-images\/image-.*\.png$/);
+    expect(thumbs.writes).toHaveBeenCalledWith(tempUri, "aGVsbG8=", { encoding: "base64" });
+    expect(thumbs.deletes).toHaveBeenCalledExactlyOnceWith(tempUri);
+  });
+
+  it.each([true, false])("preserves non-Base64 data images when native sizing supports them: %s", async (supported) => {
+    const png = "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mP8/x8AAwMCAO+jBvkAAAAASUVORK5CYII=";
+    const encoded = Array.from(atob(png), (byte) => `%${byte.charCodeAt(0).toString(16).padStart(2, "0")}`).join("");
+    const uri = `data:image/png,${encoded}`;
+    if (supported) vi.mocked(Image.getSize).mockImplementationOnce(async () => ({ width: 1, height: 1 }));
+    const message = { ...source, attachments: [{ kind: "image" as const, name: "pixel", uri }] };
+    const resolve = vi.fn<ResolveRemoteMediaFn>();
+    await act(async () => root.render(createElement(Probe, { messages: [message], resolve })));
+    await startShare();
+    expect((await ready)[0]?.images?.get(uri)).toEqual(supported ? { uri, width: 1, height: 1 } : undefined);
+    expect(Image.getSize).toHaveBeenCalledWith(uri);
+    expect(thumbs.writes).not.toHaveBeenCalled();
+    expect(thumbs.deletes).not.toHaveBeenCalled();
+    expect(resolve).not.toHaveBeenCalled();
+  });
+
+  it.each([
+    ["cancel", "resolve"], ["cancel", "reject"],
+    ["timeout", "resolve"], ["timeout", "reject"],
+  ])("cleans a pending write on %s and again after its late %s", async (event, outcome) => {
+    vi.useFakeTimers({ toFake: ["setTimeout", "clearTimeout"] });
+    const files = new Set<string>();
+    let finish!: () => void;
+    let tempUri!: string;
+    thumbs.deletes.mockImplementation((uri: string) => { files.delete(uri); });
+    thumbs.writes.mockImplementationOnce((...args: unknown[]) => {
+      tempUri = args[0] as string;
+      files.add(tempUri);
+      return new Promise<undefined>((resolve, reject) => {
+        finish = () => {
+          // The native writer can create or finish a partial file after cancellation.
+          files.add(tempUri);
+          if (outcome === "resolve") resolve(undefined);
+          else reject(new Error("late write failed"));
+        };
+      });
+    });
+    const resolve = vi.fn<ResolveRemoteMediaFn>(async () => media);
+    await act(async () => root.render(createElement(Probe, { messages: [source], resolve })));
+    await startShare();
+    expect(files.has(tempUri)).toBe(true);
+    await act(async () => {
+      if (event === "cancel") current.cancel();
+      else await vi.advanceTimersByTimeAsync(20_000);
+    });
+    const result = await ready;
+    expect(event === "cancel" ? result.length : result[0]?.images?.size).toBe(0);
+    expect(files.size).toBe(0);
+    expect(thumbs.deletes).toHaveBeenCalledExactlyOnceWith(tempUri);
+    await act(async () => finish());
+    expect(files.size).toBe(0);
+    expect(thumbs.deletes).toHaveBeenCalledTimes(2);
+    expect(Image.getSize).not.toHaveBeenCalled();
     expect(thumbs.reads).not.toHaveBeenCalled();
   });
 

--- a/apps/mobile/src/session/remoteMediaDiskCacheExpo.ts
+++ b/apps/mobile/src/session/remoteMediaDiskCacheExpo.ts
@@ -63,6 +63,19 @@ export async function downloadRemoteMediaAsDataUri(
   mimeType: string,
   maxBytes: number,
 ): Promise<string | null> {
+  return withDownloadedRemoteMediaFile(url, mimeType, maxBytes, async (file) => {
+    const base64 = await file.base64();
+    return base64 ? `data:${mimeType};base64,${base64}` : null;
+  });
+}
+
+/** Consume a size-bounded download before deleting its private temporary file. */
+export async function withDownloadedRemoteMediaFile<T>(
+  url: string,
+  mimeType: string,
+  maxBytes: number,
+  read: (file: File) => Promise<T | null>,
+): Promise<T | null> {
   const dir = new Directory(Paths.cache, SHARE_TMP_DIR_NAME);
   let target: File | null = null;
   try {
@@ -72,8 +85,7 @@ export async function downloadRemoteMediaAsDataUri(
     const file = await File.downloadFileAsync(url, target, { idempotent: true });
     const size = file.size ?? 0;
     if (size <= 0 || size > maxBytes) return null;
-    const base64 = await file.base64();
-    return base64 ? `data:${mimeType};base64,${base64}` : null;
+    return await read(file);
   } catch {
     return null;
   } finally {

--- a/apps/mobile/src/session/useConversationShareImages.ts
+++ b/apps/mobile/src/session/useConversationShareImages.ts
@@ -22,7 +22,10 @@ import {
 
 const MAX_IMAGE_BYTES = 8 * 1024 * 1024;
 
-async function readShareImageSize(uri: string, signal: AbortSignal) {
+async function readWithShareImageCancellation<T>(
+  read: () => Promise<T>,
+  signal: AbortSignal,
+) {
   if (signal.aborted) throw new Error("conversation share image cancelled");
   let onAbort!: () => void;
   const cancelled = new Promise<never>((_, reject) => {
@@ -30,9 +33,8 @@ async function readShareImageSize(uri: string, signal: AbortSignal) {
     signal.addEventListener("abort", onAbort, { once: true });
   });
   try {
-    // Android's encoded-image size reader accepts file:// but rejects data:.
-    // Racing cancellation also releases temporary files if native IO stalls.
-    return await Promise.race([Image.getSize(uri), cancelled]);
+    // Native IO may outlive this export; let its owner clean up on cancellation.
+    return await Promise.race([read(), cancelled]);
   } finally {
     signal.removeEventListener("abort", onAbort);
   }
@@ -49,38 +51,59 @@ async function readShareImageFile(
   const file = new File(uri);
   if (!file.exists || file.size <= 0 || file.size > MAX_IMAGE_BYTES)
     return null;
-  const size = await readShareImageSize(uri, signal);
+  // Android's encoded-image size reader accepts file:// but rejects data:.
+  const size = await readWithShareImageCancellation(() => Image.getSize(uri), signal);
   if (!canRead()) return null;
   const dataUri = embeddedUri ?? `data:${mimeType};base64,${await file.base64()}`;
   return canRead() ? { uri: dataUri, ...size } : null;
 }
 
-/** Inline sources need a file only for sizing; exports keep their embedded bytes. */
+/** Stage Base64 only for sizing; retain other inline formats supported natively. */
 async function readShareImageDataUri(
   uri: string,
   canRead: () => boolean,
   signal: AbortSignal,
 ): Promise<ConversationShareImage | null> {
-  const header = /^data:(image\/[^;,]+);base64,/.exec(uri);
-  if (!header || uri.length === header[0].length || !canRead()) return null;
+  if (!canRead()) return null;
+  const header = /^data:(image\/[^;,]+)(?:;[^,]*)?;base64,/i.exec(uri);
+  if (!header) {
+    // iOS can size other data-image encodings. Preserve that existing support;
+    // an unsupported native format still follows the usual placeholder path.
+    const size = await readWithShareImageCancellation(() => Image.getSize(uri), signal);
+    return canRead() ? { uri, ...size } : null;
+  }
+  if (uri.length === header[0].length) return null;
+  const mimeType = header[1]!.toLowerCase();
+  const base64 = decodeURIComponent(uri.slice(header[0].length));
   const directory = new Directory(Paths.cache, "conversation-share-images");
   let file: File | null = null;
-  try {
-    directory.create({ intermediates: true, idempotent: true });
-    const unique = `${Date.now().toString(36)}-${Math.random().toString(36).slice(2, 8)}`;
-    file = new File(directory, `image-${unique}.${extOfMime(header[1]!)}`);
-    const FileSystem = await import("expo-file-system/legacy");
-    if (!canRead()) return null;
-    await FileSystem.writeAsStringAsync(file.uri, uri.slice(header[0].length), {
-      encoding: FileSystem.EncodingType.Base64,
-    });
-    return await readShareImageFile(file.uri, header[1]!, canRead, signal, uri);
-  } finally {
+  const cleanup = () => {
     try {
       file?.delete();
     } catch {
       // Best-effort cleanup within the OS cache, including partial writes.
     }
+  };
+  try {
+    directory.create({ intermediates: true, idempotent: true });
+    const unique = `${Date.now().toString(36)}-${Math.random().toString(36).slice(2, 8)}`;
+    file = new File(directory, `image-${unique}.${extOfMime(mimeType)}`);
+    const FileSystem = await import("expo-file-system/legacy");
+    if (!canRead()) return null;
+    const targetUri = file.uri;
+    await readWithShareImageCancellation(() => {
+      const write = FileSystem.writeAsStringAsync(targetUri, base64, {
+        encoding: FileSystem.EncodingType.Base64,
+      });
+      // Cancellation cannot stop this native write. Clean up again if a late
+      // completion recreates the file after the immediate finally cleanup.
+      const cleanupLateWrite = () => { if (signal.aborted) cleanup(); };
+      void write.then(cleanupLateWrite, cleanupLateWrite);
+      return write;
+    }, signal);
+    return await readShareImageFile(file.uri, mimeType, canRead, signal, uri);
+  } finally {
+    cleanup();
   }
 }
 

--- a/apps/mobile/src/session/useConversationShareImages.ts
+++ b/apps/mobile/src/session/useConversationShareImages.ts
@@ -1,6 +1,6 @@
 import { useCallback, useEffect, useRef, useState } from "react";
 import { Image } from "react-native";
-import { File } from "expo-file-system";
+import { Directory, File, Paths } from "expo-file-system";
 import {
   prepareConversationShareImages,
   type ConversationShareImageContext,
@@ -13,8 +13,8 @@ import {
   isDesktopLocalMediaUrl,
   type ResolveRemoteMediaFn,
 } from "@/session/remoteMedia";
-import { downloadRemoteMediaAsDataUri } from "@/session/remoteMediaDiskCacheExpo";
-import { imageMimeFromUrl } from "@/session/remoteMediaDiskCache";
+import { withDownloadedRemoteMediaFile } from "@/session/remoteMediaDiskCacheExpo";
+import { extOfMime, imageMimeFromUrl } from "@/session/remoteMediaDiskCache";
 import {
   getSentAttachmentThumbUri,
   ensureSentAttachmentThumbsHydrated,
@@ -22,14 +22,66 @@ import {
 
 const MAX_IMAGE_BYTES = 8 * 1024 * 1024;
 
+async function readShareImageSize(uri: string, signal: AbortSignal) {
+  if (signal.aborted) throw new Error("conversation share image cancelled");
+  let onAbort!: () => void;
+  const cancelled = new Promise<never>((_, reject) => {
+    onAbort = () => reject(new Error("conversation share image cancelled"));
+    signal.addEventListener("abort", onAbort, { once: true });
+  });
+  try {
+    // Android's encoded-image size reader accepts file:// but rejects data:.
+    // Racing cancellation also releases temporary files if native IO stalls.
+    return await Promise.race([Image.getSize(uri), cancelled]);
+  } finally {
+    signal.removeEventListener("abort", onAbort);
+  }
+}
+
 async function readShareImageFile(
   uri: string,
   mimeType: string,
-): Promise<string | null> {
+  canRead: () => boolean,
+  signal: AbortSignal,
+  embeddedUri?: string,
+): Promise<ConversationShareImage | null> {
+  if (!canRead()) return null;
   const file = new File(uri);
   if (!file.exists || file.size <= 0 || file.size > MAX_IMAGE_BYTES)
     return null;
-  return `data:${mimeType};base64,${await file.base64()}`;
+  const size = await readShareImageSize(uri, signal);
+  if (!canRead()) return null;
+  const dataUri = embeddedUri ?? `data:${mimeType};base64,${await file.base64()}`;
+  return canRead() ? { uri: dataUri, ...size } : null;
+}
+
+/** Inline sources need a file only for sizing; exports keep their embedded bytes. */
+async function readShareImageDataUri(
+  uri: string,
+  canRead: () => boolean,
+  signal: AbortSignal,
+): Promise<ConversationShareImage | null> {
+  const header = /^data:(image\/[^;,]+);base64,/.exec(uri);
+  if (!header || uri.length === header[0].length || !canRead()) return null;
+  const directory = new Directory(Paths.cache, "conversation-share-images");
+  let file: File | null = null;
+  try {
+    directory.create({ intermediates: true, idempotent: true });
+    const unique = `${Date.now().toString(36)}-${Math.random().toString(36).slice(2, 8)}`;
+    file = new File(directory, `image-${unique}.${extOfMime(header[1]!)}`);
+    const FileSystem = await import("expo-file-system/legacy");
+    if (!canRead()) return null;
+    await FileSystem.writeAsStringAsync(file.uri, uri.slice(header[0].length), {
+      encoding: FileSystem.EncodingType.Base64,
+    });
+    return await readShareImageFile(file.uri, header[1]!, canRead, signal, uri);
+  } finally {
+    try {
+      file?.delete();
+    } catch {
+      // Best-effort cleanup within the OS cache, including partial writes.
+    }
+  }
 }
 
 async function loadShareImage(
@@ -42,13 +94,17 @@ async function loadShareImage(
   await ensureSentAttachmentThumbsHydrated();
   if (!canRead()) return null;
   const localThumb = getSentAttachmentThumbUri(url);
-  let uri = localThumb
-    ? ((await readShareImageFile(
-        localThumb,
-        imageMimeFromUrl(localThumb) ?? "image/jpeg",
-      ).catch(() => null)) ?? url)
-    : url;
+  if (localThumb) {
+    const image = await readShareImageFile(
+      localThumb,
+      imageMimeFromUrl(localThumb) ?? "image/jpeg",
+      canRead,
+      signal,
+    ).catch(() => null);
+    if (image) return image;
+  }
   if (!canRead()) return null;
+  let uri = url;
   let mimeType = imageMimeFromUrl(uri) ?? "image/jpeg";
   if (uri === url && isDesktopLocalMediaUrl(url)) {
     const media = await resolve(
@@ -73,14 +129,14 @@ async function loadShareImage(
     // Only download objects whose size the controlled desktop resolver knows.
     // Arbitrary HTTP sources have no trusted pre-transfer bound: keep alt text.
     if (/^https?:\/\//i.test(uri)) {
-      uri =
-        (await downloadRemoteMediaAsDataUri(uri, mimeType, MAX_IMAGE_BYTES)) ??
-        "";
+      return withDownloadedRemoteMediaFile(uri, mimeType, MAX_IMAGE_BYTES, (file) =>
+        readShareImageFile(file.uri, mimeType, canRead, signal),
+      );
     }
   }
   if (uri.startsWith("file://") && isDesktopLocalMediaUrl(url)) {
     // Other local files must come from the controlled media resolver.
-    uri = (await readShareImageFile(uri, mimeType)) ?? "";
+    return readShareImageFile(uri, mimeType, canRead, signal);
   }
   if (
     !canRead() ||
@@ -88,8 +144,7 @@ async function loadShareImage(
     uri.length > (MAX_IMAGE_BYTES * 4) / 3 + 128
   )
     return null;
-  const size = await Image.getSize(uri);
-  return { uri, width: size.width, height: size.height };
+  return readShareImageDataUri(uri, canRead, signal);
 }
 
 interface ShareImageJob {


### PR DESCRIPTION
## 这次改了什么

### 摘要

Android 发送照片后，消息气泡能显示照片，分享长图却退回文件名占位。原因是图片先转为 data URI，再交给 Android 不支持该 scheme 的尺寸读取接口。

改为先从本地文件读取尺寸，再嵌入 Base64；已有文件直接复用，受控下载在文件删除前完成读取，直接 Base64 来源仅为读取尺寸创建临时文件，并在成功、失败、取消后清理。

### 变更类型

- [x] `fix` 缺陷修复

### 范围

- 关联 Issue / 需求：#4118
- 本 PR 包含：分享图片读取、受限下载文件消费接口及回归测试。
- 明确不包含：附件上传、分享布局、输入框行为及原生配置变更。
- 用户可见变化：发送照片后分享长图，照片正常保留。
- 是否存在 breaking change：无。

### UI 变化

- 引用的设计规范：不涉及：未改布局、交互、样式或文案，仅修复导出图片的数据准备过程。

## 怎么验证的

### 自动验证

- `pnpm --filter mobile exec vitest run src/__tests__/useConversationShareImages.test.ts src/__tests__/remoteMediaDiskCacheExpo.test.ts src/__tests__/conversationShareImages.test.ts`：3 个测试文件、47 个测试通过。
- `pnpm test:unit:related`：通过。
- `pnpm --filter mobile run --if-present typecheck`：通过。
- `pnpm test:runner`：499 项通过，8 项按原配置跳过。
- `node scripts/test-workspaces.mjs --tier unit`：全仓配置的单测全部通过；无测试包按既有清单跳过。
- `git diff --check`、`pnpm check:dco`：通过。
- 独立子 Agent 审查完整 diff，未发现 P0/P1。

### 手工验证

Android 16 / API 36 模拟器，已登录的中国大陆版开发包 `com.xd.cindycn`，深色模式：

1. 修复前通过相册选图、发送、分享长图，实际 PNG 中照片为文件名占位。
2. 加载修复后源码，重新分享旧照片，系统分享预览和实际 PNG 均正常。
3. 重新从相册选择测试照片，发送并收到回复，再选中新消息分享长图，照片正常保留；实际 PNG 为 2158×2804、265235 字节。

验证分支 / worktree：`cindy/noble-cohen` / `noble-cohen`。Metro 属于该 worktree，使用 `10.0.2.2:8082`；已核对应用源码标记 `cindy/noble-cohen@3fe2a5f19+dcdd549d2a`，验证后的代码提交为 `e17ca01f6`。原生开发包标签为 `v0.1.0 (2026072301)`，不是发行包。截图及原始导出 PNG 保存在本地，未加入仓库。

### 未执行的验证

- iOS、浅色模式及发行包未实测；本机使用 Windows Android 模拟器。

## 风险

### 风险分类

- [x] 跨平台差异

### 影响与回滚

- 影响范围：Mobile 分享长图的图片准备；保留现有 8 MB、像素预算、20 秒超时以及任意 HTTP 图片不下载的限制。原 HTML 内联资源下载接口的返回值保持兼容。
- 冷更判断：只修改 JS/TS 源码和测试，未修改依赖、原生模块、Expo 配置或其它 runtime fingerprint 输入，预计不触发冷更；以 CI fingerprint guard 为准。
- 验证时输入文字曾出现输入框循环更新 LogBox，关闭提示后正常发送并完成分享；已单独留图，该路径不在本次变更范围内。
- 回滚 / 降级方式：回滚本提交；单张图片准备失败仍保留原有占位降级，不影响消息文字。

### 提交前检查

- [x] 已 review 完整 diff
- [x] 每个 commit 都带 DCO 签名
- [x] 已说明 UI 变化范围
- [x] 未提交凭证、令牌或授权文件
- [x] 已确认无需新增项目文档
- [x] 已确认测试结果或说明未执行原因