### PR TITLE
fix(desktop): 将任务简介中的 Markdown 转为可读纯文本

### DIFF
--- a/apps/desktop/src/main/localDb/__tests__/mapperMarkdownPreview.test.ts
+++ b/apps/desktop/src/main/localDb/__tests__/mapperMarkdownPreview.test.ts
@@ -51,6 +51,14 @@ describe('sidebar Markdown preview', () => {
     ],
     ['尚未写完 **结果', '尚未写完 **结果'],
     ['<script>alert(1)</script>\n\n正文', '正文'],
+    ['<img src="https://example.com/image.png" alt="效果图">', '效果图'],
+    [
+      '完成 <img src="cindy-media://blobs/image" alt="Light &amp; Dark"> 通过',
+      '完成 Light & Dark 通过',
+    ],
+    ['<img src="javascript:alert(1)" alt="不支持的图片">', null],
+    ['<img src="https://example.com/image.png">', null],
+    ['<script><img src="https://example.com/image.png" alt="隐藏内容"></script>', null],
     ['---', null],
   ])('extracts readable content from %s', (text, expected) => {
     expect(finalizePlainPreview(text, 'assistant')).toBe(expected);

--- a/apps/desktop/src/main/localDb/__tests__/mapperMarkdownPreview.test.ts
+++ b/apps/desktop/src/main/localDb/__tests__/mapperMarkdownPreview.test.ts
@@ -1,0 +1,58 @@
+import { describe, expect, it } from 'vitest';
+
+import { extractMessagePreview, finalizePlainPreview, sessionToCamel } from '../mapper';
+import type { SessionRowWithCount } from '../mapper';
+
+describe('sidebar Markdown preview', () => {
+  const markdown =
+    '[PR #3943](https://github.com/makecindy/cindy/pull/3943) 已合并，CI 无失败、review 已通过。';
+  const plain = 'PR #3943 已合并，CI 无失败、review 已通过。';
+
+  it('keeps link labels and the conclusion in live and serialized previews', () => {
+    expect(finalizePlainPreview(markdown, 'assistant')).toBe(plain);
+    expect(extractMessagePreview(JSON.stringify(markdown), 'assistant')).toBe(plain);
+    expect(extractMessagePreview(JSON.stringify({ text: markdown }), 'user')).toBe(plain);
+  });
+
+  it('normalizes existing raw cached previews on read', () => {
+    const session = sessionToCamel({
+      createdAt: 1,
+      updatedAt: 1,
+      totalCostUsd: 0,
+      listPreview: markdown,
+      listPreviewRole: 'assistant',
+    } as SessionRowWithCount);
+    expect(session.preview).toBe(plain);
+  });
+
+  it('counts readable characters rather than a long link destination', () => {
+    const text = `看过了，[PR #4069](https://example.com/${'a'.repeat(250)}) 已修复。`;
+    expect(finalizePlainPreview(text, 'assistant')).toBe('看过了，PR #4069 已修复。');
+    expect(finalizePlainPreview(`**${'字'.repeat(160)}**`, 'assistant')).toBe('字'.repeat(140));
+  });
+
+  it.each([
+    [
+      '## 结果\n\n> **已完成**，`APPROVED / CLEAN`。\n- [x] 检查通过',
+      '结果 已完成，APPROVED / CLEAN。 检查通过',
+    ],
+    [
+      '[**PR**](https://example.com/a_(b)) 和 [文档][doc]\n\n[doc]: https://example.com',
+      'PR 和 文档',
+    ],
+    [
+      '![效果图](https://example.com/image.png)\n\n```ts\nconst ok = true;\n```',
+      '效果图 const ok = true;',
+    ],
+    ['| 项目 | 状态 |\n| --- | --- |\n| CI | **通过** |', '项目 状态 CI 通过'],
+    [
+      'src/my_file.ts、foo_bar_baz、2 * 3、[普通括号]',
+      'src/my_file.ts、foo_bar_baz、2 * 3、[普通括号]',
+    ],
+    ['尚未写完 **结果', '尚未写完 **结果'],
+    ['<script>alert(1)</script>\n\n正文', '正文'],
+    ['---', null],
+  ])('extracts readable content from %s', (text, expected) => {
+    expect(finalizePlainPreview(text, 'assistant')).toBe(expected);
+  });
+});

--- a/apps/desktop/src/main/localDb/__tests__/sessionListProjection.test.ts
+++ b/apps/desktop/src/main/localDb/__tests__/sessionListProjection.test.ts
@@ -43,6 +43,41 @@ const extractSql = `SELECT ${LIST_PREVIEW_EXTRACT_SQL} AS preview, m.role AS rol
   LIMIT 1`;
 
 describe('session list SQL preview extract', () => {
+  it.each(['```\n# foo\n```', '`---`', '\\*literal\\*'])(
+    'keeps raw Markdown through cache backfill: %s',
+    (markdown) => {
+      const db = openPreviewDb();
+      try {
+        db.prepare('INSERT INTO sessions (id) VALUES (?)').run('s1');
+        db.prepare(
+          'INSERT INTO messages (id, session_id, role, content, created_at) VALUES (?, ?, ?, ?, ?)',
+        ).run('m1', 's1', 'assistant', JSON.stringify(markdown), 1);
+        const cold = db.prepare(extractSql).get('s1') as { preview: string; role: string };
+        const display = finalizePlainPreview(cold.preview, cold.role);
+        db.prepare(SESSION_LIST_PROJECTION_BACKFILL_SQL).run(
+          JSON.stringify([{ id: 's1', preview: display }]),
+        );
+        const warm = db
+          .prepare(
+            'SELECT list_preview AS preview, list_preview_role AS role FROM sessions WHERE id = ?',
+          )
+          .get('s1') as { preview: string; role: string };
+        expect(warm.preview).toBe(markdown);
+        expect(finalizePlainPreview(warm.preview, warm.role)).toBe(display);
+        db.prepare(
+          'UPDATE sessions SET list_preview = NULL, list_preview_role = NULL WHERE id = ?',
+        ).run('s1');
+        db.prepare(SESSION_LIST_PROJECTION_BACKFILL_SQL).run(JSON.stringify([{ id: 's1' }]));
+        const refreshed = db
+          .prepare('SELECT list_preview FROM sessions WHERE id = ?')
+          .get('s1') as { list_preview: string };
+        expect(refreshed.list_preview).toBe(markdown);
+      } finally {
+        db.close();
+      }
+    },
+  );
+
   it('extracts user .text and assistant JSON strings without slicing JSON', () => {
     const db = openPreviewDb();
     db.prepare('INSERT INTO sessions (id, cleared_at) VALUES (?, NULL)').run('s1');
@@ -224,12 +259,26 @@ describe('session list projection backfill SQL', () => {
     db.prepare(
       `INSERT INTO messages (id, session_id, role, content, created_at)
        VALUES (?, 's1', 'assistant', ?, 2), (?, 's1', 'user', ?, 1), (?, 's2', 'assistant', ?, 1)`,
-    ).run('m1', JSON.stringify('hello'), 'm0', JSON.stringify({ text: 'older' }), 'm2', JSON.stringify('stale'));
+    ).run(
+      'm1',
+      JSON.stringify('hello'),
+      'm0',
+      JSON.stringify({ text: 'older' }),
+      'm2',
+      JSON.stringify('stale'),
+    );
 
     db.prepare(SESSION_LIST_PROJECTION_BACKFILL_SQL).run(
       JSON.stringify([
         { id: 's1', preview: 'stale payload', role: 'user', count: 99, hasPreview: 1, hasCount: 1 },
-        { id: 's2', preview: 'overwrite?', role: 'assistant', count: 9, hasPreview: 1, hasCount: 1 },
+        {
+          id: 's2',
+          preview: 'overwrite?',
+          role: 'assistant',
+          count: 9,
+          hasPreview: 1,
+          hasCount: 1,
+        },
         { id: 's3', preview: 'new preview', role: 'user', count: 99, hasPreview: 1, hasCount: 1 },
       ]),
     );

--- a/apps/desktop/src/main/localDb/ipc/messages.ts
+++ b/apps/desktop/src/main/localDb/ipc/messages.ts
@@ -7,14 +7,27 @@
  */
 
 import { ipcMain, BrowserWindow } from 'electron';
-import { and, asc, eq, inArray, lt, lte, gt, gte, desc, isNull, or, sql, type SQL } from 'drizzle-orm';
+import {
+  and,
+  asc,
+  eq,
+  inArray,
+  lt,
+  lte,
+  gt,
+  gte,
+  desc,
+  isNull,
+  or,
+  sql,
+  type SQL,
+} from 'drizzle-orm';
 import { createId } from '@paralleldrive/cuid2';
 
 import { getDbClient } from '../client/current';
 import type { ContextRebuildArgs } from '../client/tx/types';
 import { latestVisiblePreviewRow } from '../latestMessageText';
 import { messages, sessions } from '../schema';
-import { persistSessionListPreview } from '../sessionListProjection';
 import {
   messageToCamel,
   messageCreateToRow,
@@ -177,11 +190,7 @@ async function maybeBroadcastSessionListPreview(
   // 不在这里落库。insert/update 事务已经把 list_preview 置空；事后 persist 无法
   // 校验同一 clientId 的内容版本，交错改写会把旧正文写回非 NULL 缓存。
   // 侧栏即时刷新靠广播；下次 list/回填从 messages 现算。
-  broadcastOwnedPayload(
-    'local-db:sessions:patched',
-    { sessionId, patch: { preview } },
-    ownerScope,
-  );
+  broadcastOwnedPayload('local-db:sessions:patched', { sessionId, patch: { preview } }, ownerScope);
 }
 
 function isAutoResumeUserRow(agentMetaJson: string | null): boolean {
@@ -190,9 +199,9 @@ function isAutoResumeUserRow(agentMetaJson: string | null): boolean {
     const parsed: unknown = JSON.parse(agentMetaJson);
     return Boolean(
       parsed &&
-        typeof parsed === 'object' &&
-        !Array.isArray(parsed) &&
-        (parsed as { autoResume?: unknown }).autoResume === true,
+      typeof parsed === 'object' &&
+      !Array.isArray(parsed) &&
+      (parsed as { autoResume?: unknown }).autoResume === true,
     );
   } catch {
     return false;
@@ -979,13 +988,9 @@ export async function commitMessageDeletion(
   try {
     const latest = await latestVisiblePreviewRow(sessionId);
     preview = extractMessagePreview(latest?.content, latest?.role);
-    await persistSessionListPreview(
-      sessionId,
-      preview,
-      latest?.role ?? null,
-      latest?.createdAt,
-      latest?.clientId,
-    );
+    // Keep the transaction's invalidation. Only SQL backfill may populate the
+    // raw Markdown cache; persisting this display text would parse code literals
+    // a second time on the next list read (and could overwrite a newer edit).
   } catch (error) {
     // 删除已经原子提交；message.delete 事务已把 list_preview / role / count 置 NULL，
     // 投影刷新失败不能把成功操作伪装成失败。广播保守空值，list 回落子查询。
@@ -1008,7 +1013,8 @@ export async function commitContextRebuild(
   sessionId: string,
   handoff: string,
   meta: {
-    reason: 'context-overflow' | 'model-window-switch' | 'pi-prompt-timeout' | 'native-session-recovery';
+    reason:
+      'context-overflow' | 'model-window-switch' | 'pi-prompt-timeout' | 'native-session-recovery';
     sourceUserClientId: string | null;
     sourceAgentKind?: 'cc' | 'codex' | 'pi';
     sourceModel?: string | null;
@@ -1027,7 +1033,9 @@ export async function commitContextRebuild(
       consumed: false,
       reason: meta.reason,
       sourceUserClientId: meta.sourceUserClientId,
-      ...(meta.replacementRoute ? { sourceSdkSessionId: meta.replacementRoute.expectedSdkSessionId } : {}),
+      ...(meta.replacementRoute
+        ? { sourceSdkSessionId: meta.replacementRoute.expectedSdkSessionId }
+        : {}),
       ...(meta.sourceAgentKind ? { sourceAgentKind: meta.sourceAgentKind } : {}),
       ...(meta.sourceModel !== undefined ? { sourceModel: meta.sourceModel } : {}),
       ...(meta.sourceProviderId !== undefined ? { sourceProviderId: meta.sourceProviderId } : {}),
@@ -1505,35 +1513,35 @@ export async function createMessage(
       expectedClearBoundaryMs: guarded ? (expected ?? null) : undefined,
     });
     if (guarded && inserted.changes === 0) {
-        const [existingAfterGuard] = await db
-          .select()
-          .from(messages)
-          .where(and(eq(messages.sessionId, sessionId), eq(messages.clientId, body.clientId)))
-          .limit(1);
-        const [sessionAfterGuard] = await db
-          .select({ clearedAt: sessions.clearedAt })
-          .from(sessions)
-          .where(eq(sessions.id, sessionId))
-          .limit(1);
-        const actual = sessionAfterGuard?.clearedAt ?? null;
-        if (
-          existingAfterGuard &&
-          actual === expected &&
-          existingAfterGuard.rewindAt === null &&
-          (expected === null || existingAfterGuard.createdAt > expected)
-        ) {
-          return messageToCamel(existingAfterGuard);
-        }
-        if (actual !== expected) {
-          throw Object.assign(
-            new Error(
-              `REMOTE_OPTIMISTIC_INPUT_CLEARED: expectedClearBoundaryMs=${expected ?? 'null'}; currentClearBoundaryMs=${actual ?? 'null'}`,
-            ),
-            { code: 'REMOTE_OPTIMISTIC_INPUT_CLEARED' },
-          );
-        }
-        throw new Error('Message insert skipped without a clear-boundary change');
+      const [existingAfterGuard] = await db
+        .select()
+        .from(messages)
+        .where(and(eq(messages.sessionId, sessionId), eq(messages.clientId, body.clientId)))
+        .limit(1);
+      const [sessionAfterGuard] = await db
+        .select({ clearedAt: sessions.clearedAt })
+        .from(sessions)
+        .where(eq(sessions.id, sessionId))
+        .limit(1);
+      const actual = sessionAfterGuard?.clearedAt ?? null;
+      if (
+        existingAfterGuard &&
+        actual === expected &&
+        existingAfterGuard.rewindAt === null &&
+        (expected === null || existingAfterGuard.createdAt > expected)
+      ) {
+        return messageToCamel(existingAfterGuard);
       }
+      if (actual !== expected) {
+        throw Object.assign(
+          new Error(
+            `REMOTE_OPTIMISTIC_INPUT_CLEARED: expectedClearBoundaryMs=${expected ?? 'null'}; currentClearBoundaryMs=${actual ?? 'null'}`,
+          ),
+          { code: 'REMOTE_OPTIMISTIC_INPUT_CLEARED' },
+        );
+      }
+      throw new Error('Message insert skipped without a clear-boundary change');
+    }
   } catch (err) {
     const after = await db
       .select()

--- a/apps/desktop/src/main/localDb/mapper.ts
+++ b/apps/desktop/src/main/localDb/mapper.ts
@@ -9,6 +9,7 @@
 
 import { DEFAULT_DRAFT_SESSION_TITLE } from '@cindy/maker-shared/session-title';
 import { stripInternalWebCitations } from '@cindy/maker-shared/internal-citation';
+import { markdownPreviewText } from '../../shared/markdownPreviewText.js';
 
 import type {
   sessions,
@@ -73,9 +74,7 @@ type SessionUsageRow = Pick<
  * 运行时固定 effort 模型用 `null`；`sessions.effort` 是 NOT NULL 枚举。
  * 空白 / null 表示不落库，UPDATE 保留该行已有的合法档位。
  */
-export function persistableSessionEffort(
-  effort: unknown,
-): SessionInsert['effort'] | undefined {
+export function persistableSessionEffort(effort: unknown): SessionInsert['effort'] | undefined {
   if (typeof effort !== 'string') return undefined;
   const trimmed = effort.trim();
   return trimmed ? (trimmed as SessionInsert['effort']) : undefined;
@@ -125,7 +124,7 @@ const PREVIEW_CONTENT_BOUND_CHARS = 4096;
 /**
  * 从消息 content（DB 存的 JSON string）提炼 sidebar 卡片预览纯文本。
  *  - user 消息：content 是 `{"text":"...","images":[],"files":[]}` → 取 .text
- *  - assistant 消息：content 是 JSON.stringify 后的 markdown 字符串 → 解析后原样用
+ *  - assistant 消息：content 是 JSON.stringify 后的 markdown 字符串 → 提取可读正文
  *  - 解析失败 / 空文本 → null（渲染端隐藏预览行）
  * 换行折叠成空格——卡片预览是流式 3 行 clamp，不保留消息内排版。
  */
@@ -140,7 +139,8 @@ export function finalizePlainPreview(
   // 实现细节。返回 null 与"无预览"同渲染语义。
   if (isSyntheticTriggerText(next)) return null;
   if (role === 'assistant') next = stripInternalWebCitations(next);
-  const collapsed = next.replace(/\s+/g, ' ').trim();
+  // Strip formatting before the display limit: URLs must not consume the preview budget.
+  const collapsed = markdownPreviewText(next);
   if (!collapsed) return null;
   return collapsed.length > PREVIEW_MAX_CHARS ? collapsed.slice(0, PREVIEW_MAX_CHARS) : collapsed;
 }
@@ -203,8 +203,7 @@ export function boundSerializedMessageContent(
  * 出口处补一个空字符串 `userId: ''`，避免类型缺失；上层消费如果需要用户 id 应该读 AuthContext。
  */
 export function sessionToCamel(row: SessionRowWithCount): Session {
-  const legacyMoney =
-    row.totalCostUsd > 0 ? legacyUsdMoney(row.totalCostUsd) : undefined;
+  const legacyMoney = row.totalCostUsd > 0 ? legacyUsdMoney(row.totalCostUsd) : undefined;
   const currentMoney =
     row.totalCostCurrency && row.totalCostAmount > 0
       ? normalizeRegionalMoney({
@@ -224,8 +223,7 @@ export function sessionToCamel(row: SessionRowWithCount): Session {
   // 否则(CNY 无法表达进 USD 字段)保持冻结历史值。只消费 totalCostUsd 的读方
   // (device-link v1 / 手机端)在全量 reseed 后才不会丢本构建新增的 USD 花费。
   const legacyUsdProjection =
-    row.totalCostUsd +
-    (row.totalCostCurrency === 'USD' ? row.totalCostAmount : 0);
+    row.totalCostUsd + (row.totalCostCurrency === 'USD' ? row.totalCostAmount : 0);
   const base: Session = {
     id: row.id,
     userId: '', // 本地 db 已按 user 隔离，无需冗余存储
@@ -824,8 +822,7 @@ export function projectAutomationConsentToRow(
 
 /** ScheduleRun 行 → 内存对象。 */
 export function scheduleRunToCamel(row: ScheduleRunRow): ScheduleRun {
-  const legacyCost =
-    row.costUsd > 0 ? legacyUsdMoney(row.costUsd) : undefined;
+  const legacyCost = row.costUsd > 0 ? legacyUsdMoney(row.costUsd) : undefined;
   const currentCost =
     row.costCurrency && row.costAmount > 0
       ? normalizeRegionalMoney({
@@ -860,9 +857,7 @@ export function scheduleRunToCamel(row: ScheduleRunRow): ScheduleRun {
       ? legacyEstimate.currency === currentEstimate.currency
         ? addRegionalMoney([legacyEstimate, currentEstimate])
         : currentEstimate
-      : (currentEstimate ??
-        legacyEstimate ??
-        zeroUsageMoney('value-estimate'));
+      : (currentEstimate ?? legacyEstimate ?? zeroUsageMoney('value-estimate'));
   return {
     id: row.id,
     scheduleId: row.scheduleId,

--- a/apps/desktop/src/main/maker-ipc/__tests__/messageDeleteHandler.test.ts
+++ b/apps/desktop/src/main/maker-ipc/__tests__/messageDeleteHandler.test.ts
@@ -48,8 +48,7 @@ describe('performMessageDeletion', () => {
     expect(deletionBlock).toContain(
       'preview = extractMessagePreview(latest?.content, latest?.role);',
     );
-    expect(deletionBlock).toContain('await persistSessionListPreview(');
-    expect(deletionBlock).toContain('latest?.createdAt');
+    expect(deletionBlock).not.toContain('persistSessionListPreview(');
     expect(deletionBlock).not.toContain('.where(eq(messages.sessionId, sessionId))');
   });
 

--- a/apps/desktop/src/renderer/components/chat/remarkHtmlImages.ts
+++ b/apps/desktop/src/renderer/components/chat/remarkHtmlImages.ts
@@ -8,88 +8,10 @@
  */
 
 import type { Plugin } from 'unified';
-import type { Root, Html, Image } from 'mdast';
+import type { Root, Html } from 'mdast';
 import { visit, SKIP } from 'unist-util-visit';
 
-const IMG_TAG_RE = /^\s*<img\b([^>]*)\/?>\s*$/i;
-const ATTR_RE = /([A-Za-z_:][A-Za-z0-9:._-]*)\s*=\s*(?:"([^"]*)"|'([^']*)'|([^\s"'=<>`]+))/g;
-const SAFE_DIMENSION_RE = /^\d{1,4}$/;
-const SAFE_HTML_IMAGE_SRC_RE = /^https?:\/\//i;
-
-function decodeHtmlAttribute(value: string): string {
-  return value.replace(/&(amp|quot|#39|apos|lt|gt);/g, (entity, name: string) => {
-    switch (name) {
-      case 'amp':
-        return '&';
-      case 'quot':
-        return '"';
-      case '#39':
-      case 'apos':
-        return "'";
-      case 'lt':
-        return '<';
-      case 'gt':
-        return '>';
-      default:
-        return entity;
-    }
-  });
-}
-
-function parseAttributes(raw: string): Map<string, string> {
-  const attrs = new Map<string, string>();
-  ATTR_RE.lastIndex = 0;
-  let match: RegExpExecArray | null;
-  while ((match = ATTR_RE.exec(raw)) !== null) {
-    const key = match[1].toLowerCase();
-    const value = match[2] ?? match[3] ?? match[4] ?? '';
-    attrs.set(key, decodeHtmlAttribute(value));
-  }
-  return attrs;
-}
-
-function hPropertiesFromAttrs(attrs: Map<string, string>): Record<string, string> | undefined {
-  const hProperties: Record<string, string> = {};
-  for (const key of ['width', 'height'] as const) {
-    const value = attrs.get(key);
-    if (value && SAFE_DIMENSION_RE.test(value)) {
-      hProperties[key] = value;
-    }
-  }
-  return Object.keys(hProperties).length > 0 ? hProperties : undefined;
-}
-
-function isSafeHtmlImageSrc(src: string): boolean {
-  return (
-    SAFE_HTML_IMAGE_SRC_RE.test(src) ||
-    src.startsWith('xdt-image://') ||
-    src.startsWith('cindy-media://') ||
-    src.startsWith('xdt-file://') ||
-    src.startsWith('cindy-remote-media://')
-  );
-}
-
-function htmlImgToImageNode(node: Html): Image | null {
-  const match = node.value.match(IMG_TAG_RE);
-  if (!match) return null;
-
-  const attrs = parseAttributes(match[1]);
-  const src = attrs.get('src')?.trim();
-  if (!src || !isSafeHtmlImageSrc(src)) return null;
-
-  const image: Image = {
-    type: 'image',
-    url: src,
-    alt: attrs.get('alt') ?? '',
-    title: attrs.get('title') || null,
-    position: node.position,
-  };
-  const hProperties = hPropertiesFromAttrs(attrs);
-  if (hProperties) {
-    image.data = { hProperties };
-  }
-  return image;
-}
+import { htmlImgToImageNode } from '../../../shared/htmlImage';
 
 const remarkHtmlImages: Plugin<[], Root> = () => {
   return (tree) => {

--- a/apps/desktop/src/shared/htmlImage.ts
+++ b/apps/desktop/src/shared/htmlImage.ts
@@ -1,0 +1,81 @@
+import type { Html, Image } from 'mdast';
+
+const IMG_TAG_RE = /^\s*<img\b([^>]*)\/?>\s*$/i;
+const ATTR_RE = /([A-Za-z_:][A-Za-z0-9:._-]*)\s*=\s*(?:"([^"]*)"|'([^']*)'|([^\s"'=<>`]+))/g;
+const SAFE_DIMENSION_RE = /^\d{1,4}$/;
+const SAFE_HTML_IMAGE_SRC_RE = /^https?:\/\//i;
+
+function decodeHtmlAttribute(value: string): string {
+  return value.replace(/&(amp|quot|#39|apos|lt|gt);/g, (entity, name: string) => {
+    switch (name) {
+      case 'amp':
+        return '&';
+      case 'quot':
+        return '"';
+      case '#39':
+      case 'apos':
+        return "'";
+      case 'lt':
+        return '<';
+      case 'gt':
+        return '>';
+      default:
+        return entity;
+    }
+  });
+}
+
+function parseAttributes(raw: string): Map<string, string> {
+  const attrs = new Map<string, string>();
+  ATTR_RE.lastIndex = 0;
+  let match: RegExpExecArray | null;
+  while ((match = ATTR_RE.exec(raw)) !== null) {
+    const key = match[1].toLowerCase();
+    const value = match[2] ?? match[3] ?? match[4] ?? '';
+    attrs.set(key, decodeHtmlAttribute(value));
+  }
+  return attrs;
+}
+
+function hPropertiesFromAttrs(attrs: Map<string, string>): Record<string, string> | undefined {
+  const hProperties: Record<string, string> = {};
+  for (const key of ['width', 'height'] as const) {
+    const value = attrs.get(key);
+    if (value && SAFE_DIMENSION_RE.test(value)) {
+      hProperties[key] = value;
+    }
+  }
+  return Object.keys(hProperties).length > 0 ? hProperties : undefined;
+}
+
+function isSafeHtmlImageSrc(src: string): boolean {
+  return (
+    SAFE_HTML_IMAGE_SRC_RE.test(src) ||
+    src.startsWith('xdt-image://') ||
+    src.startsWith('cindy-media://') ||
+    src.startsWith('xdt-file://') ||
+    src.startsWith('cindy-remote-media://')
+  );
+}
+
+export function htmlImgToImageNode(node: Html): Image | null {
+  const match = node.value.match(IMG_TAG_RE);
+  if (!match) return null;
+
+  const attrs = parseAttributes(match[1]);
+  const src = attrs.get('src')?.trim();
+  if (!src || !isSafeHtmlImageSrc(src)) return null;
+
+  const image: Image = {
+    type: 'image',
+    url: src,
+    alt: attrs.get('alt') ?? '',
+    title: attrs.get('title') || null,
+    position: node.position,
+  };
+  const hProperties = hPropertiesFromAttrs(attrs);
+  if (hProperties) {
+    image.data = { hProperties };
+  }
+  return image;
+}

--- a/apps/desktop/src/shared/markdownPreviewText.ts
+++ b/apps/desktop/src/shared/markdownPreviewText.ts
@@ -1,0 +1,42 @@
+import { Lexer, type Token, type Tokens } from 'marked';
+
+/** Extract display text without generating HTML or counting link destinations. */
+export function markdownPreviewText(markdown: string): string {
+  return previewTokens(Lexer.lex(markdown, { gfm: true }))
+    .replace(/\s+/g, ' ')
+    .trim();
+}
+
+function previewTokens(tokens: Token[]): string {
+  return tokens
+    .map((token): string => {
+      switch (token.type) {
+        case 'space':
+        case 'br':
+        case 'hr':
+        case 'html':
+        case 'def':
+          return ' ';
+        case 'list':
+          return `${token.items.map((item: Tokens.ListItem) => previewTokens(item.tokens)).join(' ')} `;
+        case 'table':
+          return (
+            [token.header, ...token.rows]
+              .map((row: { tokens: Token[] }[]) =>
+                row.map((cell) => previewTokens(cell.tokens)).join(' '),
+              )
+              .join(' ') + ' '
+          );
+        case 'heading':
+        case 'paragraph':
+        case 'blockquote':
+          return `${previewTokens(token.tokens ?? [])} `;
+        case 'code':
+          return `${token.text} `;
+        default:
+          if ('tokens' in token && token.tokens) return previewTokens(token.tokens);
+          return 'text' in token ? token.text : '';
+      }
+    })
+    .join('');
+}

--- a/apps/desktop/src/shared/markdownPreviewText.ts
+++ b/apps/desktop/src/shared/markdownPreviewText.ts
@@ -1,5 +1,7 @@
 import { Lexer, type Token, type Tokens } from 'marked';
 
+import { htmlImgToImageNode } from './htmlImage';
+
 /** Extract display text without generating HTML or counting link destinations. */
 export function markdownPreviewText(markdown: string): string {
   return previewTokens(Lexer.lex(markdown, { gfm: true }))
@@ -14,9 +16,10 @@ function previewTokens(tokens: Token[]): string {
         case 'space':
         case 'br':
         case 'hr':
-        case 'html':
         case 'def':
           return ' ';
+        case 'html':
+          return `${htmlImgToImageNode({ type: 'html', value: token.text })?.alt ?? ''} `;
         case 'list':
           return `${token.items.map((item: Tokens.ListItem) => previewTokens(item.tokens)).join(' ')} `;
         case 'table':


### PR DESCRIPTION
## 这次改了什么

### 摘要

任务列表直接显示 Markdown 原文时，长链接会挤掉后面的结论，单行简介可能只剩 `[PR #3943]…`。现在先提取可读正文，再应用 140 字符上限：链接保留标题，去掉格式标记，显示为「PR #3943 已合并，CI 无失败、review 已通过。」

### 变更类型

- [x] `fix` 缺陷修复

### 范围

- 关联 Issue / 需求：用户反馈任务列表简介被 Markdown 链接挤占。
- 本 PR 包含：复用已有 marked 依赖提取纯文本；统一处理历史缓存读取和新消息预览；补充回归用例。
- 明确不包含：开发版区域选择、数据库迁移、消息正文渲染和远程查看端的兼容兜底。
- 用户可见变化：简介保留链接标题、标题/列表正文、代码内容和图片说明，清理格式及地址。
- 是否存在 breaking change：无。

### UI 变化

- 引用的设计规范：`docs/design-rules/DESIGN.md` §§1、3、10、14.1。仅改变预览文字，沿用既有字体、行高、截断及语义颜色，Light/Dark 样式均保留。
- 示例：`[PR #3943](https://github.com/makecindy/cindy/pull/3943) 已合并` → `PR #3943 已合并`。
- 平台：macOS Desktop；用户在共享开发版确认效果。未上传含私人任务内容的截图。

## 怎么验证的

### 自动验证

```text
corepack pnpm test:unit:related
结果：通过。

corepack pnpm --filter desktop run --if-present typecheck
结果：通过。

corepack pnpm --filter desktop exec vitest run src/main/localDb/__tests__/mapperMarkdownPreview.test.ts src/main/localDb/__tests__/mapperCitation.test.ts --reporter=dot
结果：2 个文件、17 个用例通过。
```

### 手工验证

macOS，中国大陆版共享开发实例启动就绪，用户确认效果可提交。

### 未执行的验证

- 未分别记录 Light/Dark 目检证据；本次没有修改主题或布局。
- 未在远程被控端安装验证；远程简介由被控端生成，需要被控端更新后生效。
- 未执行 Windows 实机验证和本地全量单测，完整单测由 CI 执行。

## 风险

### 风险分类

- [x] 其他：预览文本转换。

### 影响与回滚

- 影响范围：Desktop 生成的最近消息简介。仅转换派生显示内容，不改写消息正文或数据库结构。旧端已经截断丢失的内容无法在查看端恢复；通用 HTML 实体解码不在此次范围内（HTML 图片属性沿用正文已有解码规则）。
- 已接受的边界：保留列表查询现有 512 字符原文提取上限；极长链接可能在解析前被截断，导致简介仍含部分链接或缺失后续结论。Dash 已确认本次接受这一显示限制，不扩展数据库 worker 或缓存机制。
- 回滚 / 降级方式：回退本 PR，即恢复原来的空白合并和截断逻辑，无需数据迁移。

### 提交前检查

- [x] 已 review 完整 diff
- [x] 每个 commit 都带 DCO 签名（`git commit -s`）
- [x] UI 改动已注明引用的设计规范章节
- [x] 未提交凭证、令牌或授权文件
- [x] 已补充必要说明及回归用例
- [x] 已确认测试结果或说明未执行原因

