### PR TITLE
fix(desktop): 开发启动按地区选择服务器端点

### DIFF
--- a/docs/dev-rules/desktop-development.md
+++ b/docs/dev-rules/desktop-development.md
@@ -56,6 +56,9 @@ checkout 占用而中止，不要换命令绕过，应把 verdict 交给用户�
 
 - `--region=cn|global`（默认 `global`）：切换构建身份与仓内端点清单；中国大陆版
   必须显式传 `--region=cn`，读取 `config/endpoint.json`。
+  remote 开发启动忽略环境里的 `XDT_ENDPOINT_MANIFEST_FILE`，始终按所选区域重设
+  端点文件，避免继承宿主的其它区域或自定义服务器。`--endpoints-cdn` 仍走所选区域的
+  线上 CDN；本地服务调试（local）仍保留本地端点文件配置。
 - `--shared`：显式选择共享 userData（旧默认行为）：dev 与正式版共用当前区域的正式
   profile，数据库、登录态、会话完全共享。仅当用户明确要求「共享登录 / 复用现有数据」
   时使用；禁止与 `--isolated` 或环境里的 `XDT_ISOLATED=1` 组合。

--- a/scripts/__tests__/desktop-dev-region.test.mjs
+++ b/scripts/__tests__/desktop-dev-region.test.mjs
@@ -15,7 +15,10 @@ test("desktop shared userData follows the region identity", () => {
   assert.equal(desktopUserDataDirNameForRegion("global"), "CindyGlobal");
   assert.equal(desktopUserDataDirNameForRegion("cn"), "Cindy");
   assert.equal(desktopUserDataDirNameForRegion("dev"), "CindyDev");
-  assert.throws(() => desktopUserDataDirNameForRegion("us"), /expected cn, global or dev/);
+  assert.throws(
+    () => desktopUserDataDirNameForRegion("us"),
+    /expected cn, global or dev/,
+  );
 });
 
 test("desktop userData path follows platform appData rules and selected region", () => {
@@ -24,7 +27,12 @@ test("desktop userData path follows platform appData rules and selected region",
     "/Users/tester/Library/Application Support/CindyGlobal",
   );
   assert.equal(
-    desktopUserDataDirForRegion("cn", "linux", { XDG_CONFIG_HOME: "/tmp/config" }, "/home/tester"),
+    desktopUserDataDirForRegion(
+      "cn",
+      "linux",
+      { XDG_CONFIG_HOME: "/tmp/config" },
+      "/home/tester",
+    ),
     "/tmp/config/Cindy",
   );
   assert.equal(
@@ -40,10 +48,7 @@ test("desktop userData path follows platform appData rules and selected region",
 
 test("desktop dev region defaults to global and keeps the legacy env fallback", () => {
   assert.equal(resolveDesktopDevRegion([], {}), "global");
-  assert.equal(
-    resolveDesktopDevRegion([], { CINDY_AUTH_REGION: "cn" }),
-    "cn",
-  );
+  assert.equal(resolveDesktopDevRegion([], { CINDY_AUTH_REGION: "cn" }), "cn");
 });
 
 test("desktop dev region accepts both CLI forms and overrides the legacy env", () => {
@@ -175,12 +180,12 @@ test("direct dev consumes the region flag before launching Electron Forge", () =
   ]);
 });
 
-test("an explicit endpoint manifest override remains higher priority than the region default", () => {
+test("local server debugging retains its endpoint manifest", () => {
   assert.deepEqual(
     resolveDesktopDevStartupConfig({
       argv: ["--region=global"],
       env: { XDT_ENDPOINT_MANIFEST_FILE: "config/custom-endpoint.json" },
-      mode: "remote",
+      mode: "local",
     }),
     {
       region: "global",
@@ -188,4 +193,65 @@ test("an explicit endpoint manifest override remains higher priority than the re
       endpointManifestFile: "config/custom-endpoint.json",
     },
   );
+});
+
+test("remote dev replaces inherited manifests for every selected region", () => {
+  const manifests = {
+    cn: "config/endpoint.json",
+    global: "config/endpoint.global.json",
+    dev: "config/endpoint.dev.json",
+  };
+  for (const inherited of [
+    ...Object.values(manifests),
+    "config/custom-endpoint.json",
+  ]) {
+    for (const [region, manifest] of Object.entries(manifests)) {
+      const env = {
+        CINDY_AUTH_REGION: "cn",
+        VITE_CINDY_AUTH_REGION: "cn",
+        XDT_ENDPOINT_MANIFEST_FILE: inherited,
+      };
+      applyDesktopDevStartupConfig({ argv: [`--region=${region}`], env });
+      assert.equal(env.CINDY_AUTH_REGION, region);
+      assert.equal(env.VITE_CINDY_AUTH_REGION, region);
+      assert.equal(env.XDT_ENDPOINT_MANIFEST_FILE, manifest);
+      // The downstream dev wrapper parses the environment again without CLI flags.
+      applyDesktopDevStartupConfig({ argv: [], env });
+      assert.equal(env.XDT_ENDPOINT_MANIFEST_FILE, manifest);
+    }
+  }
+});
+
+test("switching regions in the same environment also switches the endpoint file", () => {
+  const env = {};
+  for (const region of ["cn", "global", "dev", "cn"]) {
+    const config = applyDesktopDevStartupConfig({
+      argv: [`--region=${region}`],
+      env,
+    });
+    assert.equal(config.region, region);
+    assert.equal(
+      env.XDT_ENDPOINT_MANIFEST_FILE,
+      `config/endpoint${region === "cn" ? "" : `.${region}`}.json`,
+    );
+  }
+});
+
+test("remote CDN startup removes inherited files and remains CDN through the child wrapper", () => {
+  for (const argv of [
+    ["--region=global", "--endpoints-cdn"],
+    ["--region=global"],
+  ]) {
+    const env = {
+      XDT_ENDPOINT_MANIFEST_FILE: "config/endpoint.json",
+      XDT_ENDPOINTS_CDN: "1",
+    };
+    applyDesktopDevStartupConfig({ argv, env });
+    assert.equal(env.XDT_ENDPOINT_MANIFEST_FILE, undefined);
+    assert.deepEqual(applyDesktopDevStartupConfig({ argv: [], env }), {
+      region: "global",
+      endpointsCdn: true,
+      endpointManifestFile: undefined,
+    });
+  }
 });

--- a/scripts/shared/desktop-dev-region.mjs
+++ b/scripts/shared/desktop-dev-region.mjs
@@ -17,7 +17,9 @@ export const DESKTOP_USER_DATA_DIR_NAME_BY_REGION = Object.freeze({
 /** 共享 Desktop profile 的区域目录名；省略区域时遵循产品规则默认 Global。 */
 export function desktopUserDataDirNameForRegion(region = "global") {
   if (!DESKTOP_DEV_REGIONS.includes(region)) {
-    throw new Error(`invalid desktop dev region: ${region}; expected cn, global or dev`);
+    throw new Error(
+      `invalid desktop dev region: ${region}; expected cn, global or dev`,
+    );
   }
   return DESKTOP_USER_DATA_DIR_NAME_BY_REGION[region];
 }
@@ -67,7 +69,8 @@ export function resolveDesktopDevRegion(argv, env = process.env) {
       index += 1;
     } else if (arg.startsWith("--region=")) {
       value = arg.slice("--region=".length);
-      if (!value) throw new Error("--region requires a value: cn, global or dev");
+      if (!value)
+        throw new Error("--region requires a value: cn, global or dev");
     } else {
       continue;
     }
@@ -103,7 +106,8 @@ export function stripDesktopDevRegionArgs(argv) {
 }
 
 /**
- * 计算 desktop dev 启动配置。remote dev 默认读取同区域仓内清单；
+ * 计算 desktop dev 启动配置。remote dev 始终读取同区域仓内清单，
+ * 不把父进程继承的端点文件当成用户覆盖；local 模式保留本地服务文件。
  * --endpoints-cdn / XDT_ENDPOINTS_CDN=1 时不注入默认文件，让主进程走区域化 CDN。
  */
 export function resolveDesktopDevStartupConfig({
@@ -114,12 +118,12 @@ export function resolveDesktopDevStartupConfig({
   const region = resolveDesktopDevRegion(argv, env);
   const endpointsCdn =
     argv.includes("--endpoints-cdn") || env.XDT_ENDPOINTS_CDN === "1";
-  const configuredManifestFile = env.XDT_ENDPOINT_MANIFEST_FILE?.trim();
   const endpointManifestFile =
-    configuredManifestFile ||
-    (mode === "remote" && !endpointsCdn
-      ? `config/${{ cn: "endpoint.json", global: "endpoint.global.json", dev: "endpoint.dev.json" }[region]}`
-      : undefined);
+    mode === "remote"
+      ? endpointsCdn
+        ? undefined
+        : `config/${{ cn: "endpoint.json", global: "endpoint.global.json", dev: "endpoint.dev.json" }[region]}`
+      : env.XDT_ENDPOINT_MANIFEST_FILE?.trim() || undefined;
   return { region, endpointsCdn, endpointManifestFile };
 }
 
@@ -132,6 +136,8 @@ export function applyDesktopDevStartupConfig(options) {
   if (config.endpointsCdn) env.XDT_ENDPOINTS_CDN = "1";
   if (config.endpointManifestFile) {
     env.XDT_ENDPOINT_MANIFEST_FILE = config.endpointManifestFile;
+  } else if (options.mode !== "local") {
+    delete env.XDT_ENDPOINT_MANIFEST_FILE;
   }
   return config;
 }


### PR DESCRIPTION
## 这次改了什么

### 摘要

开发版显式选择 Global 时，继承的 CN 端点文件仍可覆盖地区默认值，导致客户端与登录服务器区域不匹配。remote 开发启动现在按所选地区重设端点文件，CDN 模式清除遗留文件覆盖；local 本地服务调试保留现有配置。

### 变更类型

- [x] `fix` 缺陷修复

### 范围

- 关联 Issue / 需求：开发版选择哪个地区，就连接哪个地区服务器。
- 本 PR 包含：启动配置解析、跨地区继承及连续切换回归测试、开发说明。
- 明确不包含：正式包端点策略、登录协议、UI、本地服务调试行为变更。
- 用户可见变化：普通开发启动不再继承其它区域或自定义端点文件。
- 是否存在 breaking change：有，remote 开发入口不再接受 `XDT_ENDPOINT_MANIFEST_FILE` 覆盖；这是本次有意收紧的开发配置行为，正式包不受影响。

### UI 变化

不涉及。
- 引用的设计规范：不涉及。

## 怎么验证的

### 自动验证

- `corepack pnpm test:unit:related`：通过；runner 509 项通过、1 项跳过、0 失败；无关联 workspace 单测。
- `node --test --test-reporter=spec scripts/__tests__/desktop-dev-region.test.mjs scripts/__tests__/restart-desktop-remote.test.mjs scripts/__tests__/dev-docs-contract.test.mjs`：92 项通过。
- 实际调用 `dev-remote-env.mjs` 启动 Node 子进程：注入遗留自定义端点，分别验证 cn/global/dev 子进程收到同区域身份与端点。
- `corepack pnpm run --if-present typecheck`：根包无 typecheck，自动跳过；本次仅修改根 scripts 和文档。
- `git diff --check` 与两个改动脚本的 Prettier 检查通过。

### 手工验证

已 review 完整 diff。

### 未执行的验证

未启动完整 Electron 客户端检查真实登录页面；本次验证止于配置解析与启动包装器子进程。未运行 Windows 实机验证。

## 风险

### 风险分类

- [x] 其他：remote 开发端点覆盖行为调整。

### 影响与回滚

- 影响范围：使用共享开发启动解析器的 remote 启动路径。自定义端点文件覆盖被忽略；local 本地服务调试与区域 CDN 路径保留。
- 回滚 / 降级方式：回退本提交可恢复原有覆盖优先级，但同时会恢复跨区域继承问题。

### 提交前检查

- [x] 已 review 完整 diff
- [x] 每个 commit 都带 DCO 签名（`git commit -s`）
- [x] UI 改动已在「UI 变化」注明引用的设计规范章节（不涉及 UI）
- [x] 未提交凭证、令牌或授权文件
- [x] 已补充必要文档
- [x] 已确认测试结果或说明未执行原因
