### PR TITLE
fix(mobile): 修复听写停止后的输入光标位置

### DIFF
--- a/apps/desktop/src/renderer/__tests__/diffHorizontalScroll.test.tsx
+++ b/apps/desktop/src/renderer/__tests__/diffHorizontalScroll.test.tsx
@@ -21,7 +21,7 @@
 import { readFileSync } from 'node:fs';
 import { resolve } from 'node:path';
 import { act, cleanup, fireEvent, render } from '@testing-library/react';
-import { afterEach, describe, expect, it } from 'vitest';
+import { afterEach, describe, expect, it, vi } from 'vitest';
 
 import { DiffView } from '@/components/chat/DiffView';
 import { MarkdownDiffBlock } from '@/components/chat/MarkdownDiffBlock';
@@ -146,6 +146,7 @@ describe('DiffView 虚拟化分支', () => {
         };
       },
     });
+    vi.useFakeTimers();
     try {
       const { container } = render(
         <DiffView oldString={oldString} newString={newString} analysis={analysis} />,
@@ -170,6 +171,9 @@ describe('DiffView 虚拟化分支', () => {
       });
       await act(async () => {
         fireEvent.scroll(scroller!);
+        // Finish the virtualizer's debounced scroll-end update while jsdom is
+        // still alive; its observer cleanup only removes the scroll listener.
+        await vi.runOnlyPendingTimersAsync();
       });
       const afterScrollIndexes = Array.from(
         scroller?.querySelectorAll<HTMLElement>('[data-index]') ?? [],
@@ -177,7 +181,10 @@ describe('DiffView 虚拟化分支', () => {
       );
       expect(afterScrollIndexes.length).toBeGreaterThan(0);
       expect(afterScrollIndexes).not.toEqual(initialIndexes);
+      expect(vi.getTimerCount()).toBe(0);
     } finally {
+      cleanup();
+      vi.useRealTimers();
       if (clientHeightDescriptor) {
         Object.defineProperty(HTMLElement.prototype, 'clientHeight', clientHeightDescriptor);
       }

--- a/apps/mobile/app/sessions/new.tsx
+++ b/apps/mobile/app/sessions/new.tsx
@@ -5888,7 +5888,9 @@ export default function NewRemoteSessionScreen() {
                   }}
                   onChangeText={setFirstMessageDraft}
                   onSelectionChange={(event) => {
-                    if (!voiceRecordingActiveRef.current && !voiceStopInFlightRef.current) {
+                    // finishVoiceRecording marks recording inactive before awaiting
+                    // ASR/refinement teardown, so native cursor edits remain user-owned.
+                    if (!voiceRecordingActiveRef.current) {
                       const selection = event.nativeEvent.selection;
                       firstMessageSelectionRef.current = selection;
                       setFirstMessageSelection(selection);

--- a/apps/mobile/app/sessions/new.tsx
+++ b/apps/mobile/app/sessions/new.tsx
@@ -3228,11 +3228,23 @@ export default function NewRemoteSessionScreen() {
         },
         localVoiceInputHistory,
         readCurrentDraft: () => firstMessageRef.current,
-        onDraftChanged: (text, selection) => {
-          // Follow final ASR/refinement until a native edit claims the caret.
-          if (selection && !voiceSelectionUserOwnedRef.current) {
-            firstMessageSelectionRef.current = selection;
-            setFirstMessageSelection(selection);
+        onDraftChanged: (text, selection, replacement) => {
+          // Follow ASR until a native edit claims the caret; then preserve its
+          // position in the surrounding text as the voice range changes length.
+          let nextSelection = voiceSelectionUserOwnedRef.current ? undefined : selection;
+          if (voiceSelectionUserOwnedRef.current && replacement) {
+            const replacementEnd = replacement.start + replacement.text.length;
+            const rebaseOffset = (offset: number) => {
+              if (offset <= replacement.start) return offset;
+              if (offset >= replacement.end) return offset + replacementEnd - replacement.end;
+              return Math.min(offset, replacementEnd);
+            };
+            const current = firstMessageSelectionRef.current;
+            nextSelection = { start: rebaseOffset(current.start), end: rebaseOffset(current.end) };
+          }
+          if (nextSelection) {
+            firstMessageSelectionRef.current = nextSelection;
+            setFirstMessageSelection(nextSelection);
           }
           setFirstMessageDraft(text);
         },

--- a/apps/mobile/app/sessions/new.tsx
+++ b/apps/mobile/app/sessions/new.tsx
@@ -698,6 +698,7 @@ export default function NewRemoteSessionScreen() {
   const userTouchedWorkspaceRef = useRef(false);
   const firstMessageRef = useRef(draft.firstMessage);
   const firstMessageSelectionRef = useRef({ start: draft.firstMessage.length, end: draft.firstMessage.length });
+  const [firstMessageSelection, setFirstMessageSelection] = useState(firstMessageSelectionRef.current);
   const firstMessageInputRef = useRef<NativeTextInput>(null);
   const voiceDraftScrollRef = useRef<ScrollView>(null);
   const voiceRecordingActiveRef = useRef(false);
@@ -3219,7 +3220,10 @@ export default function NewRemoteSessionScreen() {
         localVoiceInputHistory,
         readCurrentDraft: () => firstMessageRef.current,
         onDraftChanged: (text, selection) => {
-          if (selection) firstMessageSelectionRef.current = selection;
+          if (selection) {
+            firstMessageSelectionRef.current = selection;
+            setFirstMessageSelection(selection);
+          }
           setFirstMessageDraft(text);
         },
         onStateChanged: setVoiceState,
@@ -5866,7 +5870,9 @@ export default function NewRemoteSessionScreen() {
                   onChangeText={setFirstMessageDraft}
                   onSelectionChange={(event) => {
                     if (!voiceRecordingActiveRef.current && !voiceStopInFlightRef.current) {
-                      firstMessageSelectionRef.current = event.nativeEvent.selection;
+                      const selection = event.nativeEvent.selection;
+                      firstMessageSelectionRef.current = selection;
+                      setFirstMessageSelection(selection);
                     }
                   }}
                   onContentSizeChange={handleFirstMessageInputContentSizeChange}
@@ -5881,6 +5887,7 @@ export default function NewRemoteSessionScreen() {
                   placeholderTextColor={colors.textTertiary}
                   resizeHandle={composerCardActive ? renderComposerResizeHandle() : null}
                   scrollEnabled={composerInputScrollEnabled}
+                  selection={firstMessageSelection}
                   selectionColor={colors.inputCaret}
                   testID="newSession.actions"
                   toolbar={renderComposerToolbar()}

--- a/apps/mobile/app/sessions/new.tsx
+++ b/apps/mobile/app/sessions/new.tsx
@@ -715,6 +715,9 @@ export default function NewRemoteSessionScreen() {
   const voiceStartupInFlightRef = useRef(false);
   const voiceStopInFlightRef = useRef(false);
   const voiceSelectionUserOwnedRef = useRef(false);
+  // The press that stops dictation can emit one native selection event of its
+  // own. Consume that event before allowing a real user move to claim control.
+  const voiceStopGestureSelectionGuardRef = useRef(false);
   const voiceStartupSeqRef = useRef(0);
   const voiceControllerSessionRef = useRef<MobileVoiceControllerSession | null>(null);
   const voiceDictionaryLearningTrackerRef = useRef<MobileVoiceDictionaryLearningTracker | null>(null);
@@ -3210,6 +3213,7 @@ export default function NewRemoteSessionScreen() {
       }
       const selectionBefore = takeRefinementContextTail(currentDraft.slice(0, initialSelection.start));
       const selectionAfter = currentDraft.slice(initialSelection.end, initialSelection.end + 1200);
+      voiceStopGestureSelectionGuardRef.current = false;
       voiceSelectionUserOwnedRef.current = false;
       const controller = createMobileVoiceControllerSession({
         credential,
@@ -5912,6 +5916,10 @@ export default function NewRemoteSessionScreen() {
                     // ASR/refinement teardown, so native cursor edits remain user-owned.
                     if (!voiceRecordingActiveRef.current) {
                       const selection = event.nativeEvent.selection;
+                      if (voiceStopGestureSelectionGuardRef.current) {
+                        voiceStopGestureSelectionGuardRef.current = false;
+                        return;
+                      }
                       const previous = firstMessageSelectionRef.current;
                       // A matching native echo of a controlled selection is not a user move.
                       if (voiceStopInFlightRef.current
@@ -5928,7 +5936,13 @@ export default function NewRemoteSessionScreen() {
                   onPasteImagesLoading={beginPastePlaceholders}
                   onPasteImagesLoadFailed={failPastePlaceholders}
                   onPressIn={() => {
-                    if (voiceIsListening) void finishVoiceRecording();
+                    if (voiceIsListening) {
+                      voiceStopGestureSelectionGuardRef.current = true;
+                      setTimeout(() => {
+                        voiceStopGestureSelectionGuardRef.current = false;
+                      }, 0);
+                      void finishVoiceRecording();
+                    }
                   }}
                   placeholder={voiceIsListening ? '' : composerPlaceholder}
                   placeholderTextColor={colors.textTertiary}

--- a/apps/mobile/app/sessions/new.tsx
+++ b/apps/mobile/app/sessions/new.tsx
@@ -714,6 +714,7 @@ export default function NewRemoteSessionScreen() {
   const voicePermissionRequestAbortRef = useRef<AbortController | null>(null);
   const voiceStartupInFlightRef = useRef(false);
   const voiceStopInFlightRef = useRef(false);
+  const voiceSelectionUserOwnedRef = useRef(false);
   const voiceStartupSeqRef = useRef(0);
   const voiceControllerSessionRef = useRef<MobileVoiceControllerSession | null>(null);
   const voiceDictionaryLearningTrackerRef = useRef<MobileVoiceDictionaryLearningTracker | null>(null);
@@ -3209,6 +3210,7 @@ export default function NewRemoteSessionScreen() {
       }
       const selectionBefore = takeRefinementContextTail(currentDraft.slice(0, initialSelection.start));
       const selectionAfter = currentDraft.slice(initialSelection.end, initialSelection.end + 1200);
+      voiceSelectionUserOwnedRef.current = false;
       const controller = createMobileVoiceControllerSession({
         credential,
         ...(prewarmedVoice ? { asr: prewarmedVoice.asr } : {}),
@@ -3227,10 +3229,8 @@ export default function NewRemoteSessionScreen() {
         localVoiceInputHistory,
         readCurrentDraft: () => firstMessageRef.current,
         onDraftChanged: (text, selection) => {
-          // Once stopping starts, the user owns the native selection. The
-          // final ASR/refinement callback must not move it back to the
-          // dictation insertion point after the user has edited the draft.
-          if (selection && !voiceStopInFlightRef.current) {
+          // Follow final ASR/refinement until a native edit claims the caret.
+          if (selection && !voiceSelectionUserOwnedRef.current) {
             firstMessageSelectionRef.current = selection;
             setFirstMessageSelection(selection);
           }
@@ -5889,12 +5889,23 @@ export default function NewRemoteSessionScreen() {
                     // 失焦收起与「点别处收键盘」同语义:语音结束 hold 一并解除。
                     setComposerVoiceHoldArmed(false);
                   }}
-                  onChangeText={setFirstMessageDraft}
+                  onChangeText={(text) => {
+                    if (voiceStopInFlightRef.current && text !== firstMessageRef.current) {
+                      voiceSelectionUserOwnedRef.current = true;
+                    }
+                    setFirstMessageDraft(text);
+                  }}
                   onSelectionChange={(event) => {
                     // finishVoiceRecording marks recording inactive before awaiting
                     // ASR/refinement teardown, so native cursor edits remain user-owned.
                     if (!voiceRecordingActiveRef.current) {
                       const selection = event.nativeEvent.selection;
+                      const previous = firstMessageSelectionRef.current;
+                      // A matching native echo of a controlled selection is not a user move.
+                      if (voiceStopInFlightRef.current
+                        && (selection.start !== previous.start || selection.end !== previous.end)) {
+                        voiceSelectionUserOwnedRef.current = true;
+                      }
                       firstMessageSelectionRef.current = selection;
                       setFirstMessageSelection(selection);
                     }

--- a/apps/mobile/app/sessions/new.tsx
+++ b/apps/mobile/app/sessions/new.tsx
@@ -3227,7 +3227,10 @@ export default function NewRemoteSessionScreen() {
         localVoiceInputHistory,
         readCurrentDraft: () => firstMessageRef.current,
         onDraftChanged: (text, selection) => {
-          if (selection) {
+          // Once stopping starts, the user owns the native selection. The
+          // final ASR/refinement callback must not move it back to the
+          // dictation insertion point after the user has edited the draft.
+          if (selection && !voiceStopInFlightRef.current) {
             firstMessageSelectionRef.current = selection;
             setFirstMessageSelection(selection);
           }

--- a/apps/mobile/app/sessions/new.tsx
+++ b/apps/mobile/app/sessions/new.tsx
@@ -488,6 +488,9 @@ export default function NewRemoteSessionScreen() {
     workspaceKind: initialWorkingDir ? 'project' : 'dialogue',
     workingDir: initialWorkingDir ?? '',
   });
+  const firstMessageRef = useRef(draft.firstMessage);
+  const firstMessageSelectionRef = useRef({ start: draft.firstMessage.length, end: draft.firstMessage.length });
+  const [firstMessageSelection, setFirstMessageSelection] = useState(firstMessageSelectionRef.current);
   const [creating, setCreating] = useState(false);
   const [createStartedAt, setCreateStartedAt] = useState<number | null>(null);
   const [createPhase, setCreatePhase] = useState<SlowSendPhase>('preparing');
@@ -611,6 +614,13 @@ export default function NewRemoteSessionScreen() {
     if (!stashed) return;
     // 返回编辑沿用草稿的工作区，不能被随后加载的全局默认覆盖。
     userTouchedWorkspaceRef.current = true;
+    firstMessageRef.current = stashed.draft.firstMessage;
+    const restoredSelection = {
+      start: stashed.draft.firstMessage.length,
+      end: stashed.draft.firstMessage.length,
+    };
+    firstMessageSelectionRef.current = restoredSelection;
+    setFirstMessageSelection(restoredSelection);
     setDraft(stashed.draft);
     setAttachments([...stashed.attachments]);
     if (stashed.notice) setAttachmentError(stashed.notice);
@@ -696,9 +706,6 @@ export default function NewRemoteSessionScreen() {
   const appliedPermissionMemoryRef = useRef(false);
   const userTouchedDeviceRef = useRef(false);
   const userTouchedWorkspaceRef = useRef(false);
-  const firstMessageRef = useRef(draft.firstMessage);
-  const firstMessageSelectionRef = useRef({ start: draft.firstMessage.length, end: draft.firstMessage.length });
-  const [firstMessageSelection, setFirstMessageSelection] = useState(firstMessageSelectionRef.current);
   const firstMessageInputRef = useRef<NativeTextInput>(null);
   const voiceDraftScrollRef = useRef<ScrollView>(null);
   const voiceRecordingActiveRef = useRef(false);
@@ -3758,11 +3765,23 @@ export default function NewRemoteSessionScreen() {
   ]);
 
   const selectSlashCommand = useCallback((command: MobileSlashCommand) => {
-    setFirstMessageDraft((current) => insertSlashCommand(current, detectComposerTrigger(current), command));
+    const current = firstMessageRef.current;
+    const next = insertSlashCommand(current, detectComposerTrigger(current), command);
+    if (next === current) return;
+    setFirstMessageDraft(next);
+    const selection = { start: next.length, end: next.length };
+    firstMessageSelectionRef.current = selection;
+    setFirstMessageSelection(selection);
   }, [setFirstMessageDraft]);
 
   const selectAtResource = useCallback((item: MobileAtResourceItem) => {
-    setFirstMessageDraft((current) => insertAtResource(current, detectComposerTrigger(current), item));
+    const current = firstMessageRef.current;
+    const next = insertAtResource(current, detectComposerTrigger(current), item);
+    if (next === current) return;
+    setFirstMessageDraft(next);
+    const selection = { start: next.length, end: next.length };
+    firstMessageSelectionRef.current = selection;
+    setFirstMessageSelection(selection);
   }, [setFirstMessageDraft]);
 
   const removeAttachment = useCallback((id: string) => {

--- a/apps/mobile/app/sessions/new.tsx
+++ b/apps/mobile/app/sessions/new.tsx
@@ -715,6 +715,7 @@ export default function NewRemoteSessionScreen() {
   const voiceStartupInFlightRef = useRef(false);
   const voiceStopInFlightRef = useRef(false);
   const voiceSelectionUserOwnedRef = useRef(false);
+  const voicePendingSelectionEchoesRef = useRef<Array<{ start: number; end: number }>>([]);
   // The press that stops dictation can emit one native selection event of its
   // own. Consume that event before allowing a real user move to claim control.
   const voiceStopGestureSelectionGuardRef = useRef(false);
@@ -3215,6 +3216,7 @@ export default function NewRemoteSessionScreen() {
       const selectionAfter = currentDraft.slice(initialSelection.end, initialSelection.end + 1200);
       voiceStopGestureSelectionGuardRef.current = false;
       voiceSelectionUserOwnedRef.current = false;
+      voicePendingSelectionEchoesRef.current = [];
       const controller = createMobileVoiceControllerSession({
         credential,
         ...(prewarmedVoice ? { asr: prewarmedVoice.asr } : {}),
@@ -3247,6 +3249,10 @@ export default function NewRemoteSessionScreen() {
             nextSelection = { start: rebaseOffset(current.start), end: rebaseOffset(current.end) };
           }
           if (nextSelection) {
+            const previous = firstMessageSelectionRef.current;
+            if (nextSelection.start !== previous.start || nextSelection.end !== previous.end) {
+              voicePendingSelectionEchoesRef.current.push(nextSelection);
+            }
             firstMessageSelectionRef.current = nextSelection;
             setFirstMessageSelection(nextSelection);
           }
@@ -5906,20 +5912,34 @@ export default function NewRemoteSessionScreen() {
                     setComposerVoiceHoldArmed(false);
                   }}
                   onChangeText={(text) => {
-                    if (voiceStopInFlightRef.current && text !== firstMessageRef.current) {
-                      voiceSelectionUserOwnedRef.current = true;
+                    if (text !== firstMessageRef.current) {
+                      voicePendingSelectionEchoesRef.current = [];
+                      if (voiceStopInFlightRef.current) voiceSelectionUserOwnedRef.current = true;
                     }
                     setFirstMessageDraft(text);
                   }}
+                  onKeyPress={() => { voicePendingSelectionEchoesRef.current = []; }}
                   onSelectionChange={(event) => {
+                    const selection = event.nativeEvent.selection;
+                    if (!voiceRecordingActiveRef.current && voiceStopGestureSelectionGuardRef.current) {
+                      voiceStopGestureSelectionGuardRef.current = false;
+                      return;
+                    }
+                    // Native may echo an earlier ASR/refinement update after JS has
+                    // already published the next one, even after stop() resolves.
+                    const pending = voicePendingSelectionEchoesRef.current;
+                    const echoIndex = pending.findIndex((value) =>
+                      value.start === selection.start && value.end === selection.end);
+                    if (echoIndex >= 0) {
+                      // Selection events can coalesce: acknowledging a newer write
+                      // also retires older writes that never emitted an event.
+                      pending.splice(0, echoIndex + 1);
+                      return;
+                    }
                     // finishVoiceRecording marks recording inactive before awaiting
                     // ASR/refinement teardown, so native cursor edits remain user-owned.
                     if (!voiceRecordingActiveRef.current) {
-                      const selection = event.nativeEvent.selection;
-                      if (voiceStopGestureSelectionGuardRef.current) {
-                        voiceStopGestureSelectionGuardRef.current = false;
-                        return;
-                      }
+                      voicePendingSelectionEchoesRef.current = [];
                       const previous = firstMessageSelectionRef.current;
                       // A matching native echo of a controlled selection is not a user move.
                       if (voiceStopInFlightRef.current
@@ -5942,6 +5962,10 @@ export default function NewRemoteSessionScreen() {
                         voiceStopGestureSelectionGuardRef.current = false;
                       }, 0);
                       void finishVoiceRecording();
+                    } else {
+                      // A new editing gesture can intentionally return to any old
+                      // controlled value; it must not be mistaken for its echo.
+                      voicePendingSelectionEchoesRef.current = [];
                     }
                   }}
                   placeholder={voiceIsListening ? '' : composerPlaceholder}

--- a/apps/mobile/scripts/java-runtime-env.mjs
+++ b/apps/mobile/scripts/java-runtime-env.mjs
@@ -34,11 +34,22 @@ export function javaRuntimeDetail(env = resolveJavaRuntimeEnv()) {
 function javaHomeCandidates(env) {
   return [
     env.JAVA_HOME,
+    env.ANDROID_STUDIO_JDK,
+    ...(process.platform === 'win32' ? windowsAndroidStudioJavaHomes(env) : []),
     macJavaHome('17'),
     homebrewOpenJdk17Home('/opt/homebrew/opt/openjdk@17'),
     homebrewOpenJdk17Home('/usr/local/opt/openjdk@17'),
     brewPrefixOpenJdk17Home(),
   ].filter(uniqueTruthy);
+}
+
+function windowsAndroidStudioJavaHomes(env) {
+  return [
+    env.ANDROID_STUDIO_HOME ? join(env.ANDROID_STUDIO_HOME, 'jbr') : null,
+    env.ProgramFiles ? join(env.ProgramFiles, 'Android', 'Android Studio', 'jbr') : null,
+    env['ProgramFiles(x86)'] ? join(env['ProgramFiles(x86)'], 'Android', 'Android Studio', 'jbr') : null,
+    env.LOCALAPPDATA ? join(env.LOCALAPPDATA, 'Programs', 'Android Studio', 'jbr') : null,
+  ];
 }
 
 function macJavaHome(version) {

--- a/apps/mobile/scripts/java-runtime-env.mjs
+++ b/apps/mobile/scripts/java-runtime-env.mjs
@@ -6,7 +6,17 @@ const MIN_JAVA_MAJOR = 17;
 
 export function resolveJavaRuntimeEnv(baseEnv = process.env) {
   const current = javaMajor(versionForJavaCommand('java', baseEnv));
-  if (current >= MIN_JAVA_MAJOR) return { ...baseEnv };
+  if (current >= MIN_JAVA_MAJOR) {
+    const env = { ...baseEnv };
+    if (baseEnv.JAVA_HOME) {
+      const javaBin = join(baseEnv.JAVA_HOME, 'bin', process.platform === 'win32' ? 'java.exe' : 'java');
+      const homeMajor = javaMajor(versionForJavaCommand(javaBin, baseEnv));
+      // Gradle prefers JAVA_HOME over PATH. Drop an unusable override so it uses
+      // the supported PATH Java we just checked, without changing the parent env.
+      if (!(homeMajor >= MIN_JAVA_MAJOR)) delete env.JAVA_HOME;
+    }
+    return env;
+  }
 
   for (const javaHome of javaHomeCandidates(baseEnv)) {
     if (!javaHome) continue;

--- a/apps/mobile/scripts/lib/android-simulator.mjs
+++ b/apps/mobile/scripts/lib/android-simulator.mjs
@@ -61,11 +61,15 @@ export function resolveAndroidSdkTools({
   for (const sdkRoot of [...new Set(candidates)]) {
     const adb = win32Path.join(sdkRoot, 'platform-tools', 'adb.exe');
     const emulator = win32Path.join(sdkRoot, 'emulator', 'emulator.exe');
-    if (!requireTools || (exists(adb) && exists(emulator))) return { sdkRoot, adb, emulator };
+    if (requireTools ? (exists(adb) && exists(emulator)) : exists(sdkRoot)) {
+      return { sdkRoot, adb, emulator };
+    }
   }
 
   throw new Error(
-    '未找到完整 Android SDK。请设置 ANDROID_SDK_ROOT / ANDROID_HOME，或通过 Android Studio 安装 Platform Tools 与 Emulator。',
+    requireTools
+      ? '未找到完整 Android SDK。请设置 ANDROID_SDK_ROOT / ANDROID_HOME，或通过 Android Studio 安装 Platform Tools 与 Emulator。'
+      : '未找到 Android SDK 目录。请设置有效的 ANDROID_SDK_ROOT / ANDROID_HOME，或通过 Android Studio 安装 SDK。',
   );
 }
 

--- a/apps/mobile/scripts/lib/android-simulator.mjs
+++ b/apps/mobile/scripts/lib/android-simulator.mjs
@@ -1,5 +1,5 @@
 import { execFileSync, spawn } from 'node:child_process';
-import { existsSync } from 'node:fs';
+import { existsSync, readdirSync } from 'node:fs';
 import { win32 as win32Path } from 'node:path';
 
 export const DEFAULT_ANDROID_AVD = 'cindy-api36';
@@ -48,6 +48,7 @@ export function resolveAndroidSdkTools({
   env = process.env,
   platform = process.platform,
   exists = existsSync,
+  readDir = readdirSync,
   requireTools = true,
 } = {}) {
   if (platform !== 'win32') return null;
@@ -61,7 +62,20 @@ export function resolveAndroidSdkTools({
   for (const sdkRoot of [...new Set(candidates)]) {
     const adb = win32Path.join(sdkRoot, 'platform-tools', 'adb.exe');
     const emulator = win32Path.join(sdkRoot, 'emulator', 'emulator.exe');
-    if (requireTools ? (exists(adb) && exists(emulator)) : exists(sdkRoot)) {
+    const platforms = win32Path.join(sdkRoot, 'platforms');
+    const buildTools = win32Path.join(sdkRoot, 'build-tools');
+    let hasBuildPackages = false;
+    if (!requireTools && exists(platforms) && exists(buildTools)) {
+      try {
+        const platformPackages = readDir(platforms);
+        const buildToolPackages = readDir(buildTools);
+        hasBuildPackages = platformPackages.some((entry) => /^android-\d+$/.test(String(entry.name ?? entry)))
+          && buildToolPackages.some((entry) => /^\d+\.\d+\.\d+$/.test(String(entry.name ?? entry)));
+      } catch {
+        hasBuildPackages = false;
+      }
+    }
+    if (requireTools ? (exists(adb) && exists(emulator)) : hasBuildPackages) {
       return { sdkRoot, adb, emulator };
     }
   }

--- a/apps/mobile/scripts/lib/android-simulator.mjs
+++ b/apps/mobile/scripts/lib/android-simulator.mjs
@@ -48,6 +48,7 @@ export function resolveAndroidSdkTools({
   env = process.env,
   platform = process.platform,
   exists = existsSync,
+  requireTools = true,
 } = {}) {
   if (platform !== 'win32') return null;
 
@@ -60,7 +61,7 @@ export function resolveAndroidSdkTools({
   for (const sdkRoot of [...new Set(candidates)]) {
     const adb = win32Path.join(sdkRoot, 'platform-tools', 'adb.exe');
     const emulator = win32Path.join(sdkRoot, 'emulator', 'emulator.exe');
-    if (exists(adb) && exists(emulator)) return { sdkRoot, adb, emulator };
+    if (!requireTools || (exists(adb) && exists(emulator))) return { sdkRoot, adb, emulator };
   }
 
   throw new Error(

--- a/apps/mobile/scripts/lib/sim-whoami.mjs
+++ b/apps/mobile/scripts/lib/sim-whoami.mjs
@@ -141,6 +141,8 @@ export function resolveSimMetroHandoff({
   runningSource,
   currentRegion,
   runningRegion,
+  currentEnvFingerprint,
+  runningEnvFingerprint,
   listener,
   listenerWorktreeExists = false,
 } = {}) {
@@ -161,7 +163,9 @@ export function resolveSimMetroHandoff({
   if (listener.isTarget) {
     if (runningSource === currentSource) {
       const regionChanged = currentRegion !== undefined && runningRegion !== currentRegion;
-      if ((envChanged || regionChanged) && !takeover) {
+      const environmentChanged = currentEnvFingerprint !== undefined
+        && runningEnvFingerprint !== currentEnvFingerprint;
+      if ((envChanged || regionChanged || environmentChanged) && !takeover) {
         return {
           action: 'refuse',
           code: regionChanged ? 'target-region-stale' : 'target-env-stale',
@@ -171,7 +175,7 @@ export function resolveSimMetroHandoff({
           ],
         };
       }
-      if ((envChanged || regionChanged) && takeover) {
+      if ((envChanged || regionChanged || environmentChanged) && takeover) {
         return { action: 'restart', code: regionChanged ? 'target-region' : 'target-env', lines: [] };
       }
       return {

--- a/apps/mobile/scripts/lib/sim-whoami.mjs
+++ b/apps/mobile/scripts/lib/sim-whoami.mjs
@@ -139,6 +139,8 @@ export function resolveSimMetroHandoff({
   envChanged = false,
   currentSource,
   runningSource,
+  currentRegion,
+  runningRegion,
   listener,
   listenerWorktreeExists = false,
 } = {}) {
@@ -158,18 +160,19 @@ export function resolveSimMetroHandoff({
 
   if (listener.isTarget) {
     if (runningSource === currentSource) {
-      if (envChanged && !takeover) {
+      const regionChanged = currentRegion !== undefined && runningRegion !== currentRegion;
+      if ((envChanged || regionChanged) && !takeover) {
         return {
           action: 'refuse',
-          code: 'target-env-stale',
+          code: regionChanged ? 'target-region-stale' : 'target-env-stale',
           lines: [
             `✗ 已补/改 apps/mobile/.env,但 ${port} 上的 Metro 是用旧 env 启动的(env 在 bundle 时注入)。`,
             '  需要刷新 env 时传 `--takeover` 重起,新 env 才会生效。',
           ],
         };
       }
-      if (envChanged && takeover) {
-        return { action: 'restart', code: 'target-env', lines: [] };
+      if ((envChanged || regionChanged) && takeover) {
+        return { action: 'restart', code: regionChanged ? 'target-region' : 'target-env', lines: [] };
       }
       return {
         action: 'reuse',

--- a/apps/mobile/scripts/lib/sim-whoami.mjs
+++ b/apps/mobile/scripts/lib/sim-whoami.mjs
@@ -102,7 +102,7 @@ export function extractSimTakeoverArgs(args) {
 }
 
 /** Decide whether a listener has enough Cindy-specific identity for an explicit handoff. */
-export function classifySimMetroListener({ cwd, source, targetWorktree }) {
+export function classifySimMetroListener({ cwd, source, targetWorktree, platform = process.platform }) {
   if (!cwd) return { confirmed: false, worktree: null };
 
   const normalizedCwd = normalize(cwd).replaceAll('\\', '/').replace(/\/+$/, '');
@@ -113,10 +113,13 @@ export function classifySimMetroListener({ cwd, source, targetWorktree }) {
   }
 
   const worktree = normalizedCwd.slice(0, -suffix.length);
+  const isTarget = platform === 'win32'
+    ? worktree.toLowerCase() === normalizedTarget.toLowerCase()
+    : worktree === normalizedTarget;
   return {
     confirmed: true,
     worktree,
-    isTarget: worktree === normalizedTarget,
+    isTarget,
   };
 }
 

--- a/apps/mobile/scripts/sim-metro.mjs
+++ b/apps/mobile/scripts/sim-metro.mjs
@@ -3,9 +3,10 @@
 
 import { execFileSync } from 'node:child_process';
 import { createHash } from 'node:crypto';
-import { readFileSync, statSync } from 'node:fs';
+import { mkdirSync, readFileSync, statSync, unlinkSync, writeFileSync } from 'node:fs';
 import net from 'node:net';
 import { join, relative, resolve } from 'node:path';
+import { tmpdir } from 'node:os';
 
 // 连接探测:连得上 = 有进程在监听。比 listen(127.0.0.1) 可靠 —— Metro 监听 *:port(可能带
 // SO_REUSEADDR),用 listen 探测会误判成空闲。
@@ -20,13 +21,89 @@ export function portInUse(port) {
 }
 
 // 监听该端口的第一个进程 pid(LISTEN)。
+export function parseWindowsNetstatListener(output, port) {
+  for (const line of String(output).split(/\r?\n/)) {
+    const columns = line.trim().split(/\s+/);
+    if (columns[0] !== 'TCP' || columns[3] !== 'LISTENING') continue;
+    if (!columns[1]?.endsWith(`:${port}`)) continue;
+    return columns[4] || null;
+  }
+  return null;
+}
+
 export function listenerPid(port) {
+  if (process.platform === 'win32') {
+    try {
+      const output = execFileSync('netstat', ['-ano', '-p', 'tcp'], { encoding: 'utf8' });
+      return parseWindowsNetstatListener(output, port);
+    } catch {
+      // Fall through to the platform-neutral unknown-owner result.
+    }
+    return null;
+  }
   try {
     return execFileSync('lsof', ['-nP', `-iTCP:${port}`, '-sTCP:LISTEN', '-t'], { encoding: 'utf8' })
       .trim().split('\n')[0] || null;
   } catch {
     return null;
   }
+}
+
+const metroOwnerDir = join(tmpdir(), 'cindy-metro-owners');
+
+function metroOwnerPath(port) {
+  return join(metroOwnerDir, `port-${port}.json`);
+}
+
+export function writeMetroOwner(port, owner) {
+  mkdirSync(metroOwnerDir, { recursive: true });
+  writeFileSync(metroOwnerPath(port), `${JSON.stringify(owner)}\n`, 'utf8');
+}
+
+export function clearMetroOwner(port, pid) {
+  const path = metroOwnerPath(port);
+  try {
+    const owner = JSON.parse(readFileSync(path, 'utf8'));
+    if (owner.pid !== pid) return;
+    unlinkSync(path);
+  } catch {
+    // A missing or malformed owner file is already fail-closed to callers.
+  }
+}
+
+function readMetroOwner(port) {
+  try {
+    return JSON.parse(readFileSync(metroOwnerPath(port), 'utf8'));
+  } catch {
+    return null;
+  }
+}
+
+function processAlive(pid) {
+  try {
+    process.kill(pid, 0);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+/** Probe a Metro listener with a worktree/source identity on every host OS. */
+export function probeMetroOwnership(port) {
+  const pid = listenerPid(port);
+  if (!pid) return null;
+  if (process.platform !== 'win32') {
+    return { pid, cwd: cwdOfPid(pid), source: gitSourceOfPid(pid) };
+  }
+  const owner = readMetroOwner(port);
+  const listenerMatchesOwner = Number(owner?.pid) === Number(pid);
+  const ownerProcessAlive = Number.isInteger(owner?.launcherPid)
+    ? processAlive(owner.launcherPid)
+    : listenerMatchesOwner && processAlive(owner.pid);
+  if (!owner || !Number.isInteger(owner.pid) || !ownerProcessAlive) {
+    return { pid, cwd: null, source: null };
+  }
+  return { pid, cwd: owner.worktreeRoot ?? null, source: owner.source ?? null };
 }
 
 // 进程工作目录(用 cwd 判 worktree,而非解析命令行 —— 命令行常是 `pnpm exec expo`、取不到

--- a/apps/mobile/scripts/sim-metro.mjs
+++ b/apps/mobile/scripts/sim-metro.mjs
@@ -103,7 +103,12 @@ export function probeMetroOwnership(port) {
   if (!owner || !Number.isInteger(owner.pid) || !ownerProcessAlive) {
     return { pid, cwd: null, source: null };
   }
-  return { pid, cwd: owner.worktreeRoot ?? null, source: owner.source ?? null };
+  return {
+    pid,
+    launcherPid: Number.isInteger(owner.launcherPid) ? owner.launcherPid : owner.pid,
+    cwd: owner.worktreeRoot ?? null,
+    source: owner.source ?? null,
+  };
 }
 
 // 进程工作目录(用 cwd 判 worktree,而非解析命令行 —— 命令行常是 `pnpm exec expo`、取不到
@@ -182,11 +187,28 @@ export function isDedicatedMetroProcessGroup(entries, expectedWorktree) {
 export async function terminateMetro(pid, options = {}) {
   const run = options.execFile ?? execFileSync;
   const wait = options.wait ?? ((ms) => new Promise((resolve) => setTimeout(resolve, ms)));
-  const isAlive = options.isAlive ?? (() => Boolean(commandOfPid(pid)));
+  const platform = options.platform ?? process.platform;
+  const isAlive = options.isAlive ?? (() => (
+    platform === 'win32' ? processAlive(pid) : Boolean(commandOfPid(pid))
+  ));
   const signal = options.signal ?? 'TERM';
   const timeoutMs = options.timeoutMs ?? 5000;
   const pollMs = options.pollMs ?? 100;
   if (!Number.isFinite(pollMs) || pollMs <= 0) throw new Error('Metro 终止轮询间隔必须大于 0');
+
+  if (platform === 'win32') {
+    try {
+      run('taskkill', ['/PID', String(pid), '/T', '/F'], { stdio: 'ignore', windowsHide: true });
+    } catch {
+      if (!isAlive()) return true;
+      return false;
+    }
+    for (let waitedMs = 0; waitedMs < timeoutMs; waitedMs += pollMs) {
+      if (!isAlive()) return true;
+      await wait(pollMs);
+    }
+    return !isAlive();
+  }
 
   const groupId = options.groupId !== undefined ? options.groupId : processGroupOfPid(pid);
   const currentGroupId = options.currentGroupId !== undefined

--- a/apps/mobile/scripts/sim-metro.mjs
+++ b/apps/mobile/scripts/sim-metro.mjs
@@ -5,7 +5,7 @@ import { execFileSync } from 'node:child_process';
 import { createHash } from 'node:crypto';
 import { mkdirSync, readFileSync, statSync, unlinkSync, writeFileSync } from 'node:fs';
 import net from 'node:net';
-import { join, relative, resolve } from 'node:path';
+import path, { join } from 'node:path';
 import { tmpdir } from 'node:os';
 
 // 连接探测:连得上 = 有进程在监听。比 listen(127.0.0.1) 可靠 —— Metro 监听 *:port(可能带
@@ -292,7 +292,7 @@ export function gitSourceIdentity(worktreeRoot, options = {}) {
 }
 
 // 真正的路径边界判断:避免 /workspace/XDMaker 与 /workspace/XDMaker-old 这种字符串前缀误判。
-export function isInside(root, child) {
-  const rel = relative(root, child);
-  return rel === '' || !rel.startsWith('..');
+export function isInside(root, child, paths = path) {
+  const rel = paths.relative(root, child);
+  return !paths.isAbsolute(rel) && rel !== '..' && !rel.startsWith(`..${paths.sep}`);
 }

--- a/apps/mobile/scripts/sim-metro.mjs
+++ b/apps/mobile/scripts/sim-metro.mjs
@@ -155,6 +155,7 @@ export function probeMetroOwnership(port, options = {}) {
     launcherPid: Number.isInteger(owner.launcherPid) ? owner.launcherPid : owner.pid,
     cwd: owner.worktreeRoot ? join(owner.worktreeRoot, 'apps/mobile') : null,
     source: owner.source ?? null,
+    region: owner.region ?? null,
   };
 }
 

--- a/apps/mobile/scripts/sim-metro.mjs
+++ b/apps/mobile/scripts/sim-metro.mjs
@@ -51,6 +51,21 @@ export function listenerPid(port) {
 
 const metroOwnerDir = join(tmpdir(), 'cindy-metro-owners');
 
+/**
+ * Hash the public bundle environment and local config inputs without persisting
+ * their values in the owner file. The owner only needs to answer whether the
+ * running Metro was started with the same inputs as the next invocation.
+ */
+export function metroEnvironmentFingerprint({ env = {}, files = {} } = {}) {
+  const ordered = (value) => Object.fromEntries(
+    Object.entries(value).sort(([left], [right]) => left.localeCompare(right)),
+  );
+  return createHash('sha256')
+    .update(JSON.stringify({ env: ordered(env), files: ordered(files) }))
+    .digest('hex')
+    .slice(0, 16);
+}
+
 function metroOwnerPath(port) {
   return join(metroOwnerDir, `port-${port}.json`);
 }
@@ -143,7 +158,19 @@ export function probeMetroOwnership(port, options = {}) {
   const pid = (options.listenerPid ?? listenerPid)(port);
   if (!pid) return null;
   if ((options.platform ?? process.platform) !== 'win32') {
-    return { pid, cwd: cwdOfPid(pid), source: gitSourceOfPid(pid) };
+    const cwd = cwdOfPid(pid);
+    const source = gitSourceOfPid(pid);
+    const owner = (options.readOwner ?? readMetroOwner)(port);
+    const worktreeRoot = cwd ? path.resolve(cwd, '../..') : null;
+    const ownerRoot = owner?.worktreeRoot ? path.resolve(owner.worktreeRoot) : null;
+    return {
+      pid,
+      cwd,
+      source,
+      envFingerprint: ownerRoot && ownerRoot === worktreeRoot && owner?.source === source
+        ? owner.envFingerprint ?? null
+        : null,
+    };
   }
   const owner = (options.readOwner ?? readMetroOwner)(port);
   if (!owner || !windowsOwnerOwnsListener(owner, pid,
@@ -156,6 +183,7 @@ export function probeMetroOwnership(port, options = {}) {
     cwd: owner.worktreeRoot ? join(owner.worktreeRoot, 'apps/mobile') : null,
     source: owner.source ?? null,
     region: owner.region ?? null,
+    envFingerprint: owner.envFingerprint ?? null,
   };
 }
 

--- a/apps/mobile/scripts/sim-metro.mjs
+++ b/apps/mobile/scripts/sim-metro.mjs
@@ -1,5 +1,5 @@
 // 模拟器 / Metro 端口归属与 git env 的共享判断,供 sim-start.mjs / sim-rebuild.mjs 复用,
-// 避免两边各自重复一套(以及"一个脚本加了校验、另一个忘了"的不一致)。macOS 专用(lsof/ps -E)。
+// 避免两边各自重复一套(以及"一个脚本加了校验、另一个忘了"的不一致)。
 
 import { execFileSync } from 'node:child_process';
 import { createHash } from 'node:crypto';
@@ -73,7 +73,8 @@ export function clearMetroOwner(port, pid) {
 
 function readMetroOwner(port) {
   try {
-    return JSON.parse(readFileSync(metroOwnerPath(port), 'utf8'));
+    const file = metroOwnerPath(port);
+    return { ...JSON.parse(readFileSync(file, 'utf8')), recordedAtMs: statSync(file).mtimeMs };
   } catch {
     return null;
   }
@@ -88,19 +89,65 @@ function processAlive(pid) {
   }
 }
 
+/**
+ * Snapshot only process identity, avoiding command lines and environment data.
+ * @param {(file: string, args: string[], options: import('node:child_process').ExecFileSyncOptionsWithStringEncoding) => string} [run]
+ */
+export function windowsProcessSnapshot(run = execFileSync) {
+  try {
+    const output = run('powershell.exe', ['-NoProfile', '-NonInteractive', '-Command',
+      "$ErrorActionPreference = 'Stop'; Get-CimInstance Win32_Process | Select-Object ProcessId, ParentProcessId, @{Name='StartedAtMs';Expression={([DateTimeOffset]$_.CreationDate).ToUnixTimeMilliseconds()}} | ConvertTo-Json -Compress",
+    ], { encoding: 'utf8', windowsHide: true, timeout: 5000, maxBuffer: 4 * 1024 * 1024 });
+    const entries = JSON.parse(String(output));
+    return (Array.isArray(entries) ? entries : [entries]).filter(Boolean).map((entry) => ({
+      pid: entry.ProcessId,
+      parentPid: entry.ParentProcessId,
+      startedAtMs: entry.StartedAtMs,
+    }));
+  } catch {
+    return [];
+  }
+}
+
+function windowsOwnerOwnsListener(owner, listener, processes) {
+  const launcherPid = owner?.launcherPid ?? owner?.pid;
+  if (!Number.isSafeInteger(owner?.pid) || owner.pid <= 0
+    || !Number.isSafeInteger(launcherPid) || launcherPid <= 0
+    || !Number.isFinite(owner.recordedAtMs)) return false;
+
+  const byPid = new Map(processes.map((entry) => [entry.pid, entry]));
+  const launcher = byPid.get(launcherPid);
+  // A process created after the owner file was written cannot be its launcher,
+  // even if Windows has reused that PID. File time also covers existing owners.
+  if (!launcher || !Number.isFinite(launcher.startedAtMs)
+    || launcher.startedAtMs > owner.recordedAtMs) return false;
+
+  let current = byPid.get(Number(listener));
+  const seen = new Set();
+  while (current && !seen.has(current.pid)) {
+    if (!Number.isFinite(current.startedAtMs)) return false;
+    if (current.pid === launcherPid) return true;
+    seen.add(current.pid);
+    const parent = byPid.get(current.parentPid);
+    // Windows retains ParentProcessId after a parent exits. A newer process with
+    // that PID is not the parent, so do not follow that link during takeover.
+    if (!parent || !Number.isFinite(parent.startedAtMs)
+      || parent.startedAtMs > current.startedAtMs) return false;
+    current = parent;
+  }
+  return false;
+}
+
 /** Probe a Metro listener with a worktree/source identity on every host OS. */
-export function probeMetroOwnership(port) {
-  const pid = listenerPid(port);
+export function probeMetroOwnership(port, options = {}) {
+  const pid = (options.listenerPid ?? listenerPid)(port);
   if (!pid) return null;
-  if (process.platform !== 'win32') {
+  if ((options.platform ?? process.platform) !== 'win32') {
     return { pid, cwd: cwdOfPid(pid), source: gitSourceOfPid(pid) };
   }
-  const owner = readMetroOwner(port);
-  const listenerMatchesOwner = Number(owner?.pid) === Number(pid);
-  const ownerProcessAlive = Number.isInteger(owner?.launcherPid)
-    ? processAlive(owner.launcherPid)
-    : listenerMatchesOwner && processAlive(owner.pid);
-  if (!owner || !Number.isInteger(owner.pid) || !ownerProcessAlive) {
+  const owner = (options.readOwner ?? readMetroOwner)(port);
+  if (!owner || !windowsOwnerOwnsListener(owner, pid,
+    (options.processSnapshot ?? windowsProcessSnapshot)())) {
     return { pid, cwd: null, source: null };
   }
   return {

--- a/apps/mobile/scripts/sim-metro.mjs
+++ b/apps/mobile/scripts/sim-metro.mjs
@@ -106,7 +106,7 @@ export function probeMetroOwnership(port) {
   return {
     pid,
     launcherPid: Number.isInteger(owner.launcherPid) ? owner.launcherPid : owner.pid,
-    cwd: owner.worktreeRoot ?? null,
+    cwd: owner.worktreeRoot ? join(owner.worktreeRoot, 'apps/mobile') : null,
     source: owner.source ?? null,
   };
 }

--- a/apps/mobile/scripts/sim-rebuild.mjs
+++ b/apps/mobile/scripts/sim-rebuild.mjs
@@ -55,6 +55,10 @@ import { homedir } from 'node:os';
 import { dirname, join, resolve } from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { mobileClientBundleEnv } from '../../../scripts/shared/client-endpoint-build-env.mjs';
+import {
+  resolvePnpmInvocation,
+  usablePnpmExecPath,
+} from '../../../scripts/shared/pnpm-invocation.mjs';
 import { ensureMobileEnv, formatMobileEnvStatus } from './ensure-mobile-env.mjs';
 import { computeFingerprintReport, parseFingerprintCliOutput } from './ci-fingerprint.mjs';
 import {
@@ -66,6 +70,8 @@ import {
   formatMobileLocalConfigStatus,
 } from './lib/mobile-local-config.mjs';
 import { podInstallBounded } from './sim-pod-install.mjs';
+import { ensureWindowsAndroidEmulator } from './lib/android-simulator.mjs';
+import { resolveJavaRuntimeEnv } from './java-runtime-env.mjs';
 import {
   cwdOfPid,
   gitSourceIdentity,
@@ -119,6 +125,39 @@ const run = (cmd, args, opts = {}) =>
   execFileSync(cmd, args, { stdio: 'inherit', cwd: mobileDir, env: devProcessEnv, ...opts });
 const capture = (cmd, args) =>
   execFileSync(cmd, args, { cwd: mobileDir, env: devProcessEnv, encoding: 'utf8' }).trim();
+function pnpmInvocation(args) {
+  return resolvePnpmInvocation(args, {
+    npmExecPath: usablePnpmExecPath(process.env.npm_execpath, existsSync),
+  });
+}
+
+function runPnpm(args, opts = {}) {
+  const invocation = pnpmInvocation(args);
+  return run(invocation.command, invocation.args, {
+    ...opts,
+    shell: invocation.shell,
+    windowsVerbatimArguments: invocation.windowsVerbatimArguments,
+    env: { ...devProcessEnv, ...(invocation.env ?? {}), ...(opts.env ?? {}) },
+  });
+}
+
+function capturePnpm(args) {
+  const invocation = pnpmInvocation(args);
+  return execFileSync(invocation.command, invocation.args, {
+    cwd: mobileDir,
+    env: { ...devProcessEnv, ...(invocation.env ?? {}) },
+    encoding: 'utf8',
+    shell: invocation.shell,
+    windowsVerbatimArguments: invocation.windowsVerbatimArguments,
+  }).trim();
+}
+
+// Windows 开发机没有 xcrun/Xcode。这里走 Android debug dev client，避免在任何
+// Windows 路径上触发 iOS 的 xcrun、pod 或 xcodebuild。
+if (process.platform === 'win32') {
+  await rebuildAndroidSimulator();
+  process.exit(0);
+}
 
 // 必须有一台 booted 模拟器(--build-only 不装机,无此要求)。
 if (!buildOnly) {
@@ -127,6 +166,56 @@ if (!buildOnly) {
     console.error('✗ 没有 booted 的模拟器。先打开 Simulator.app 并启动一台 iPhone,再重试。');
     process.exit(1);
   }
+}
+
+async function rebuildAndroidSimulator() {
+  const emulator = buildOnly
+    ? { serial: null, adb: null }
+    : await ensureWindowsAndroidEmulator({ port: 8081 });
+  const androidDir = join(mobileDir, 'android');
+  const javaEnv = resolveJavaRuntimeEnv(devProcessEnv);
+  console.log('› Android expo prebuild (debug development client)');
+  runPnpm(['exec', 'expo', 'prebuild', '--platform', 'android', '--no-install']);
+
+  const gradle = process.platform === 'win32' ? 'gradlew.bat' : './gradlew';
+  console.log('› Android gradle assembleDebug');
+  if (process.platform === 'win32') {
+    run(process.env.ComSpec || 'cmd.exe', ['/d', '/s', '/c', `"${gradle} assembleDebug"`], {
+      cwd: androidDir,
+      env: javaEnv,
+      windowsVerbatimArguments: true,
+    });
+  } else {
+    run(gradle, ['assembleDebug'], { cwd: androidDir, env: javaEnv });
+  }
+
+  const apk = join(androidDir, 'app/build/outputs/apk/debug/app-debug.apk');
+  if (!existsSync(apk)) {
+    throw new Error(`prebuild/gradle 后未找到 Android debug APK: ${apk}`);
+  }
+  const config = JSON.parse(capturePnpm(['exec', 'expo', 'config', '--type', 'public', '--json']));
+  const packageName = config?.android?.package;
+  if (typeof packageName !== 'string' || !packageName.trim()) {
+    throw new Error(`Expo config 缺少 android.package(region=${region})`);
+  }
+  if (buildOnly) {
+    console.log(`✓ Android --build-only 完成: ${apk}`);
+    return;
+  }
+  const { adb, serial } = emulator;
+  const target = ['-s', serial];
+  if (clean) {
+    try {
+      run(adb, [...target, 'uninstall', packageName]);
+    } catch {
+      console.log('  (没有可卸载的旧 Android 包,跳过)');
+    }
+  }
+  console.log(`› 安装 Android debug 包到 ${serial}`);
+  run(adb, [...target, 'install', '-r', apk]);
+  run(adb, [...target, 'shell', 'am', 'force-stop', packageName]);
+  run(adb, [...target, 'shell', 'monkey', '-p', packageName, '1']);
+  console.log(`\n✓ 完成: ${packageName} 已重装并启动。JS 改动直接由 Metro Fast Refresh 提供。`);
 }
 
 // 宿主机架构只参与缓存隔离；真实构建架构由 Xcode 与各 Pod 的支持矩阵决定。

--- a/apps/mobile/scripts/sim-rebuild.mjs
+++ b/apps/mobile/scripts/sim-rebuild.mjs
@@ -199,6 +199,12 @@ async function ensureMetroOwnershipBeforeLaunch(packageName) {
     console.error('Restart Metro with pnpm mobile:sim:start before launching the app.');
     return false;
   }
+  if (ownership.region !== region) {
+    console.log(`\nNative package installed (${packageName}).`);
+    console.error(`Metro on 8081 uses region ${ownership.region || '(unknown)'}, but this build requested ${region}.`);
+    console.error('Restart Metro with the matching --region before launching the app.');
+    return false;
+  }
   return true;
 }
 

--- a/apps/mobile/scripts/sim-rebuild.mjs
+++ b/apps/mobile/scripts/sim-rebuild.mjs
@@ -197,7 +197,11 @@ function ensureMetroOwnershipBeforeLaunch(packageName) {
 
 async function rebuildAndroidSimulator() {
   const androidTools = process.platform === 'win32'
-    ? resolveAndroidSdkTools({ env: devProcessEnv, platform: process.platform })
+    ? resolveAndroidSdkTools({
+      env: devProcessEnv,
+      platform: process.platform,
+      requireTools: !buildOnly,
+    })
     : null;
   const emulator = buildOnly
     ? { serial: null, adb: null, sdkRoot: androidTools?.sdkRoot }

--- a/apps/mobile/scripts/sim-rebuild.mjs
+++ b/apps/mobile/scripts/sim-rebuild.mjs
@@ -120,6 +120,7 @@ const envResult = ensureMobileEnv({ mobileDir, authRegion: region, endpointEnv: 
 console.log(formatMobileEnvStatus(envResult, worktreeRoot));
 console.log(`==> Mobile dev region: ${region}`);
 const envChanged = envResult.created || envResult.addedKeys.length > 0;
+const currentSource = gitSourceIdentity(worktreeRoot);
 
 const run = (cmd, args, opts = {}) =>
   execFileSync(cmd, args, { stdio: 'inherit', cwd: mobileDir, env: devProcessEnv, ...opts });
@@ -168,6 +169,30 @@ if (!buildOnly) {
   }
 }
 
+function ensureMetroOwnershipBeforeLaunch(packageName) {
+  const metroPid = listenerPid(8081);
+  if (!metroPid) return true;
+  const metroCwd = cwdOfPid(metroPid);
+  const foreign = !metroCwd || !isInside(worktreeRoot, metroCwd);
+  const runningSource = gitSourceOfPid(metroPid);
+  if (foreign || runningSource !== currentSource) {
+    const why = foreign
+      ? `foreign worktree (${metroCwd || 'unknown'})`
+      : `stale source (${runningSource || 'unknown'}; current=${currentSource})`;
+    console.log(`\\nNative package installed (${packageName}).`);
+    console.error(`Metro on 8081 is not owned by the current source: ${why}.`);
+    console.error('Stop it, start this worktree with pnpm mobile:sim:start, then launch the app.');
+    return false;
+  }
+  if (envChanged) {
+    console.log(`\\nNative package installed (${packageName}).`);
+    console.error('Metro on 8081 was started with an older apps/mobile/.env.');
+    console.error('Restart Metro with pnpm mobile:sim:start before launching the app.');
+    return false;
+  }
+  return true;
+}
+
 async function rebuildAndroidSimulator() {
   const emulator = buildOnly
     ? { serial: null, adb: null }
@@ -180,7 +205,7 @@ async function rebuildAndroidSimulator() {
   const gradle = process.platform === 'win32' ? 'gradlew.bat' : './gradlew';
   console.log('› Android gradle assembleDebug');
   if (process.platform === 'win32') {
-    run(process.env.ComSpec || 'cmd.exe', ['/d', '/s', '/c', `"${gradle} assembleDebug"`], {
+    run('cmd.exe', ['/d', '/s', '/c', 'gradlew.bat assembleDebug'], {
       cwd: androidDir,
       env: javaEnv,
       windowsVerbatimArguments: true,
@@ -214,6 +239,7 @@ async function rebuildAndroidSimulator() {
   console.log(`› 安装 Android debug 包到 ${serial}`);
   run(adb, [...target, 'install', '-r', apk]);
   run(adb, [...target, 'shell', 'am', 'force-stop', packageName]);
+  if (!ensureMetroOwnershipBeforeLaunch(packageName)) return;
   run(adb, [...target, 'shell', 'monkey', '-p', packageName, '1']);
   console.log(`\n✓ 完成: ${packageName} 已重装并启动。JS 改动直接由 Metro Fast Refresh 提供。`);
 }
@@ -329,7 +355,6 @@ const metroPid = listenerPid(8081);
 if (metroPid) {
   const metroCwd = cwdOfPid(metroPid);
   const foreign = !metroCwd || !isInside(worktreeRoot, metroCwd);
-  const currentSource = gitSourceIdentity(worktreeRoot);
   const runningSource = gitSourceOfPid(metroPid);
   if (foreign || runningSource !== currentSource) {
     const why = foreign

--- a/apps/mobile/scripts/sim-rebuild.mjs
+++ b/apps/mobile/scripts/sim-rebuild.mjs
@@ -78,6 +78,7 @@ import {
   gitSourceOfPid,
   isInside,
   listenerPid,
+  portInUse,
   probeMetroOwnership,
 } from './sim-metro.mjs';
 
@@ -170,10 +171,16 @@ if (!buildOnly) {
   }
 }
 
-function ensureMetroOwnershipBeforeLaunch(packageName) {
+async function ensureMetroOwnershipBeforeLaunch(packageName) {
+  if (!await portInUse(8081)) return true;
   const ownership = probeMetroOwnership(8081);
   const metroPid = ownership?.pid ?? null;
-  if (!metroPid) return true;
+  if (!metroPid) {
+    console.log(`\nNative package installed (${packageName}).`);
+    console.error('Metro on 8081 is occupied, but its listener PID could not be verified.');
+    console.error('Refusing to launch until the port owner can be identified.');
+    return false;
+  }
   const metroCwd = ownership.cwd;
   const foreign = !metroCwd || !isInside(worktreeRoot, metroCwd);
   const runningSource = ownership.source;
@@ -252,7 +259,7 @@ async function rebuildAndroidSimulator() {
   console.log(`› 安装 Android debug 包到 ${serial}`);
   run(adb, [...target, 'install', '-r', apk]);
   run(adb, [...target, 'shell', 'am', 'force-stop', packageName]);
-  if (!ensureMetroOwnershipBeforeLaunch(packageName)) return;
+  if (!await ensureMetroOwnershipBeforeLaunch(packageName)) return;
   run(adb, [...target, 'shell', 'monkey', '-p', packageName, '1']);
   console.log(`\n✓ 完成: ${packageName} 已重装并启动。JS 改动直接由 Metro Fast Refresh 提供。`);
 }

--- a/apps/mobile/scripts/sim-rebuild.mjs
+++ b/apps/mobile/scripts/sim-rebuild.mjs
@@ -78,6 +78,7 @@ import {
   gitSourceOfPid,
   isInside,
   listenerPid,
+  probeMetroOwnership,
 } from './sim-metro.mjs';
 
 const mobileDir = resolve(dirname(fileURLToPath(import.meta.url)), '..');
@@ -170,11 +171,12 @@ if (!buildOnly) {
 }
 
 function ensureMetroOwnershipBeforeLaunch(packageName) {
-  const metroPid = listenerPid(8081);
+  const ownership = probeMetroOwnership(8081);
+  const metroPid = ownership?.pid ?? null;
   if (!metroPid) return true;
-  const metroCwd = cwdOfPid(metroPid);
+  const metroCwd = ownership.cwd;
   const foreign = !metroCwd || !isInside(worktreeRoot, metroCwd);
-  const runningSource = gitSourceOfPid(metroPid);
+  const runningSource = ownership.source;
   if (foreign || runningSource !== currentSource) {
     const why = foreign
       ? `foreign worktree (${metroCwd || 'unknown'})`

--- a/apps/mobile/scripts/sim-rebuild.mjs
+++ b/apps/mobile/scripts/sim-rebuild.mjs
@@ -70,7 +70,7 @@ import {
   formatMobileLocalConfigStatus,
 } from './lib/mobile-local-config.mjs';
 import { podInstallBounded } from './sim-pod-install.mjs';
-import { ensureWindowsAndroidEmulator } from './lib/android-simulator.mjs';
+import { ensureWindowsAndroidEmulator, resolveAndroidSdkTools } from './lib/android-simulator.mjs';
 import { resolveJavaRuntimeEnv } from './java-runtime-env.mjs';
 import {
   cwdOfPid,
@@ -196,11 +196,18 @@ function ensureMetroOwnershipBeforeLaunch(packageName) {
 }
 
 async function rebuildAndroidSimulator() {
+  const androidTools = process.platform === 'win32'
+    ? resolveAndroidSdkTools({ env: devProcessEnv, platform: process.platform })
+    : null;
   const emulator = buildOnly
-    ? { serial: null, adb: null }
+    ? { serial: null, adb: null, sdkRoot: androidTools?.sdkRoot }
     : await ensureWindowsAndroidEmulator({ port: 8081 });
+  const sdkRoot = emulator.sdkRoot ?? androidTools?.sdkRoot;
   const androidDir = join(mobileDir, 'android');
-  const javaEnv = resolveJavaRuntimeEnv(devProcessEnv);
+  const javaEnv = resolveJavaRuntimeEnv({
+    ...devProcessEnv,
+    ...(sdkRoot ? { ANDROID_SDK_ROOT: sdkRoot, ANDROID_HOME: sdkRoot } : {}),
+  });
   console.log('› Android expo prebuild (debug development client)');
   runPnpm(['exec', 'expo', 'prebuild', '--platform', 'android', '--no-install']);
 

--- a/apps/mobile/scripts/sim-start.mjs
+++ b/apps/mobile/scripts/sim-start.mjs
@@ -26,7 +26,7 @@
 //   pnpm mobile:sim:start -- --no-emulator # Windows 只启动 Metro
 
 import { execFileSync, spawn } from 'node:child_process';
-import { existsSync } from 'node:fs';
+import { existsSync, readFileSync } from 'node:fs';
 import { dirname, resolve } from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { mobileClientBundleEnv } from '../../../scripts/shared/client-endpoint-build-env.mjs';
@@ -57,6 +57,7 @@ import {
   clearMetroOwner,
   gitSourceIdentity,
   isMetroPid,
+  metroEnvironmentFingerprint,
   portInUse,
   probeMetroOwnership,
   terminateMetro,
@@ -84,6 +85,13 @@ const buildEnv = withLocalMobileRegionConfig(
 const envResult = ensureMobileEnv({ mobileDir, authRegion: region, endpointEnv: buildEnv });
 console.log(formatMobileEnvStatus(envResult, worktreeRoot));
 const envChanged = envResult.created || envResult.addedKeys.length > 0;
+const envFingerprint = metroEnvironmentFingerprint({
+  env: buildEnv,
+  files: {
+    '.env': readFileSync(envResult.envPath, 'utf8'),
+    'scripts/self-host-regions.json': readFileSync(localConfigResult.configPath, 'utf8'),
+  },
+});
 
 function git(args) {
   try {
@@ -125,6 +133,8 @@ if (portArgs.port === DEFAULT_PORT) {
       runningSource,
       currentRegion: process.platform === 'win32' ? region : undefined,
       runningRegion: process.platform === 'win32' ? ownership?.region : undefined,
+      currentEnvFingerprint: envFingerprint,
+      runningEnvFingerprint: ownership?.envFingerprint,
       listener,
       listenerWorktreeExists,
     });
@@ -195,6 +205,7 @@ if (portArgs.port === DEFAULT_PORT && Number.isInteger(child.pid)) {
     launcherPid: child.pid,
     source: sourceIdentity,
     region,
+    envFingerprint,
     worktreeRoot,
   });
   child.once('exit', () => clearMetroOwner(DEFAULT_PORT, child.pid));

--- a/apps/mobile/scripts/sim-start.mjs
+++ b/apps/mobile/scripts/sim-start.mjs
@@ -54,13 +54,13 @@ import {
   formatMobileLocalConfigStatus,
 } from './lib/mobile-local-config.mjs';
 import {
-  cwdOfPid,
+  clearMetroOwner,
   gitSourceIdentity,
-  gitSourceOfPid,
   isMetroPid,
-  listenerPid,
   portInUse,
+  probeMetroOwnership,
   terminateMetro,
+  writeMetroOwner,
 } from './sim-metro.mjs';
 
 const mobileDir = resolve(dirname(fileURLToPath(import.meta.url)), '..');
@@ -106,9 +106,10 @@ async function ensureAndroidTarget() {
 const args = ['exec', 'expo', 'start', '--dev-client', ...portArgs.passthrough];
 if (portArgs.port === DEFAULT_PORT) {
   if (await portInUse(DEFAULT_PORT)) {
-    const pid = listenerPid(DEFAULT_PORT);
-    const cwd = pid ? cwdOfPid(pid) : null;
-    const runningSource = pid ? gitSourceOfPid(pid) : null;
+    const ownership = probeMetroOwnership(DEFAULT_PORT);
+    const pid = ownership?.pid ?? null;
+    const cwd = ownership?.cwd ?? null;
+    const runningSource = ownership?.source ?? null;
     const listener = classifySimMetroListener({
       cwd,
       source: runningSource,
@@ -182,6 +183,16 @@ const child = spawn(invocation.command, invocation.args, {
   shell: invocation.shell,
   windowsVerbatimArguments: invocation.windowsVerbatimArguments,
 });
+
+if (portArgs.port === DEFAULT_PORT && Number.isInteger(child.pid)) {
+  writeMetroOwner(DEFAULT_PORT, {
+    pid: child.pid,
+    launcherPid: child.pid,
+    source: sourceIdentity,
+    worktreeRoot,
+  });
+  child.once('exit', () => clearMetroOwner(DEFAULT_PORT, child.pid));
+}
 
 child.once('error', (error) => {
   console.error(`✗ 无法启动 Metro: ${error.message}`);

--- a/apps/mobile/scripts/sim-start.mjs
+++ b/apps/mobile/scripts/sim-start.mjs
@@ -123,6 +123,8 @@ if (portArgs.port === DEFAULT_PORT) {
       envChanged,
       currentSource: sourceIdentity,
       runningSource,
+      currentRegion: process.platform === 'win32' ? region : undefined,
+      runningRegion: process.platform === 'win32' ? ownership?.region : undefined,
       listener,
       listenerWorktreeExists,
     });
@@ -192,6 +194,7 @@ if (portArgs.port === DEFAULT_PORT && Number.isInteger(child.pid)) {
     pid: child.pid,
     launcherPid: child.pid,
     source: sourceIdentity,
+    region,
     worktreeRoot,
   });
   child.once('exit', () => clearMetroOwner(DEFAULT_PORT, child.pid));

--- a/apps/mobile/scripts/sim-start.mjs
+++ b/apps/mobile/scripts/sim-start.mjs
@@ -136,11 +136,14 @@ if (portArgs.port === DEFAULT_PORT) {
       process.exit(1);
     }
 
-    if (!pid || !isMetroPid(pid)) {
+    const confirmedMetro = process.platform === 'win32'
+      ? Boolean(ownership?.cwd && ownership?.source)
+      : Boolean(pid && isMetroPid(pid));
+    if (!pid || !confirmedMetro) {
       console.error(`✗ ${DEFAULT_PORT} 上的进程不是可确认的 Metro,拒绝接管。`);
       process.exit(1);
     }
-    const stopped = await terminateMetro(pid, { worktreeRoot: listener.worktree });
+    const stopped = await terminateMetro(ownership?.launcherPid ?? pid, { worktreeRoot: listener.worktree });
     if (!stopped) {
       console.error(`✗ 无法在限定时间内停止旧 Metro(pid=${pid}),拒绝继续。`);
       process.exit(1);

--- a/apps/mobile/src/__tests__/javaRuntimeEnv.test.ts
+++ b/apps/mobile/src/__tests__/javaRuntimeEnv.test.ts
@@ -1,0 +1,98 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { delimiter, join } from 'node:path';
+import { resolveJavaRuntimeEnv } from '../../scripts/java-runtime-env.mjs';
+
+const { spawnSync, existsSync } = vi.hoisted(() => ({
+  spawnSync: vi.fn(),
+  existsSync: vi.fn(),
+}));
+
+vi.mock('node:child_process', () => ({ spawnSync }));
+vi.mock('node:fs', () => ({ existsSync }));
+
+const javaBin = (home: string) => join(home, 'bin', process.platform === 'win32' ? 'java.exe' : 'java');
+const configuredHome = join('/toolchains', 'configured-jdk');
+const studioHome = join('/toolchains', 'android-studio-jdk');
+const path = join('/toolchains', 'path-jdk', 'bin');
+const testEnv = { NODE_ENV: 'test' as const, PATH: path };
+let versions: Map<string, number>;
+
+beforeEach(() => {
+  versions = new Map();
+  spawnSync.mockReset().mockImplementation((command: string) => {
+    const major = versions.get(command);
+    return {
+      status: major ? 0 : 1,
+      stdout: '',
+      stderr: major ? `openjdk version "${major}.0.1"` : '',
+    };
+  });
+  existsSync.mockReset().mockImplementation((file: string) => versions.has(file));
+});
+
+describe('Java runtime environment for Gradle', () => {
+  it.each([undefined, 11])('discards unusable JAVA_HOME (version %s) when PATH has Java 17', (major) => {
+    versions.set('java', 17);
+    if (major) versions.set(javaBin(configuredHome), major);
+    const baseEnv = { ...testEnv, JAVA_HOME: configuredHome, KEEP: 'unchanged' };
+
+    const result = resolveJavaRuntimeEnv(baseEnv);
+
+    expect(result).toEqual({ ...testEnv, KEEP: 'unchanged' });
+    // gradlew.bat must fall back to the already validated PATH Java.
+    expect(result).not.toHaveProperty('JAVA_HOME');
+    expect(baseEnv.JAVA_HOME).toBe(configuredHome);
+  });
+
+  it('keeps a supported JAVA_HOME when PATH also has supported Java', () => {
+    versions.set('java', 17);
+    versions.set(javaBin(configuredHome), 21);
+    const baseEnv = { ...testEnv, JAVA_HOME: configuredHome };
+
+    expect(resolveJavaRuntimeEnv(baseEnv)).toEqual(baseEnv);
+  });
+
+  it('keeps a working PATH without requiring JAVA_HOME or a fallback JDK', () => {
+    versions.set('java', 21);
+    const baseEnv = { ...testEnv };
+
+    const result = resolveJavaRuntimeEnv(baseEnv);
+
+    expect(result).toEqual(baseEnv);
+    expect(result).not.toBe(baseEnv);
+    expect(spawnSync).toHaveBeenCalledTimes(1);
+  });
+
+  it('uses a supported JAVA_HOME when PATH Java is too old', () => {
+    versions.set('java', 11);
+    versions.set(javaBin(configuredHome), 17);
+    const baseEnv = { ...testEnv, JAVA_HOME: configuredHome };
+
+    expect(resolveJavaRuntimeEnv(baseEnv)).toEqual({
+      ...baseEnv,
+      PATH: [join(configuredHome, 'bin'), path].join(delimiter),
+    });
+  });
+
+  it.each([undefined, 11])('uses the Studio JDK when PATH and JAVA_HOME (version %s) are unusable', (major) => {
+    versions.set('java', 11);
+    if (major) versions.set(javaBin(configuredHome), major);
+    versions.set(javaBin(studioHome), 21);
+    const baseEnv = { ...testEnv, JAVA_HOME: configuredHome, ANDROID_STUDIO_JDK: studioHome };
+
+    expect(resolveJavaRuntimeEnv(baseEnv)).toEqual({
+      ...baseEnv,
+      JAVA_HOME: studioHome,
+      PATH: [join(studioHome, 'bin'), path].join(delimiter),
+    });
+    expect(baseEnv.JAVA_HOME).toBe(configuredHome);
+  });
+
+  it('preserves the original environment when no supported Java is available', () => {
+    versions.set('java', 11);
+    versions.set(javaBin(configuredHome), 11);
+    const baseEnv = { ...testEnv, JAVA_HOME: configuredHome };
+
+    expect(resolveJavaRuntimeEnv(baseEnv)).toEqual(baseEnv);
+  });
+});

--- a/apps/mobile/src/__tests__/mobileAndroidSimulator.test.ts
+++ b/apps/mobile/src/__tests__/mobileAndroidSimulator.test.ts
@@ -67,6 +67,15 @@ describe('Android SDK 与 adb 输出解析', () => {
     });
   });
 
+  it('build-only 可在缺少 emulator 时仍解析 SDK 根目录', () => {
+    expect(resolveAndroidSdkTools({
+      platform: 'win32',
+      requireTools: false,
+      env: { ANDROID_SDK_ROOT: 'D:\\Android\\Sdk' },
+      exists: () => false,
+    })).toMatchObject({ sdkRoot: 'D:\\Android\\Sdk' });
+  });
+
   it('只接受在线 emulator，并去掉 avd name 的 OK 尾行', () => {
     expect(parseAdbEmulatorSerials([
       'List of devices attached',

--- a/apps/mobile/src/__tests__/mobileAndroidSimulator.test.ts
+++ b/apps/mobile/src/__tests__/mobileAndroidSimulator.test.ts
@@ -1,6 +1,6 @@
 // @ts-nocheck —— 被测对象是 .mjs 开发工具模块，vitest 跑其纯函数与注入式流程。
 import { readFileSync } from 'node:fs';
-import { resolve } from 'node:path';
+import { resolve, win32 } from 'node:path';
 import { describe, expect, it, vi } from 'vitest';
 import {
   DEFAULT_ANDROID_AVD,
@@ -68,12 +68,36 @@ describe('Android SDK 与 adb 输出解析', () => {
   });
 
   it('build-only 可在缺少 emulator 时仍解析 SDK 根目录', () => {
+    const sdkRoot = win32.join('D:\\', 'Android', 'Sdk');
     expect(resolveAndroidSdkTools({
       platform: 'win32',
       requireTools: false,
-      env: { ANDROID_SDK_ROOT: 'D:\\Android\\Sdk' },
+      env: { ANDROID_SDK_ROOT: sdkRoot },
+      exists: (target) => target === sdkRoot,
+    })).toMatchObject({ sdkRoot });
+  });
+
+  it('build-only 跳过失效的环境变量路径，回退到标准 SDK 目录', () => {
+    const localAppData = win32.join('C:\\', 'Users', 'dev', 'AppData', 'Local');
+    const sdkRoot = win32.join(localAppData, 'Android', 'Sdk');
+    expect(resolveAndroidSdkTools({
+      platform: 'win32',
+      requireTools: false,
+      env: {
+        ANDROID_SDK_ROOT: win32.join('D:\\', 'missing-sdk'),
+        ANDROID_HOME: win32.join('D:\\', 'old-sdk'),
+        LOCALAPPDATA: localAppData,
+      },
+      exists: (target) => target === sdkRoot,
+    })).toMatchObject({ sdkRoot });
+  });
+
+  it('build-only 没有有效 SDK 候选时明确失败', () => {
+    expect(() => resolveAndroidSdkTools({
+      platform: 'win32', requireTools: false,
+      env: { ANDROID_SDK_ROOT: win32.join('D:\\', 'missing-sdk') },
       exists: () => false,
-    })).toMatchObject({ sdkRoot: 'D:\\Android\\Sdk' });
+    })).toThrow('未找到 Android SDK 目录');
   });
 
   it('只接受在线 emulator，并去掉 avd name 的 OK 尾行', () => {

--- a/apps/mobile/src/__tests__/mobileAndroidSimulator.test.ts
+++ b/apps/mobile/src/__tests__/mobileAndroidSimulator.test.ts
@@ -69,11 +69,14 @@ describe('Android SDK 与 adb 输出解析', () => {
 
   it('build-only 可在缺少 emulator 时仍解析 SDK 根目录', () => {
     const sdkRoot = win32.join('D:\\', 'Android', 'Sdk');
+    const platforms = win32.join(sdkRoot, 'platforms');
+    const buildTools = win32.join(sdkRoot, 'build-tools');
     expect(resolveAndroidSdkTools({
       platform: 'win32',
       requireTools: false,
       env: { ANDROID_SDK_ROOT: sdkRoot },
-      exists: (target) => target === sdkRoot,
+      exists: (target) => target === platforms || target === buildTools,
+      readDir: (target) => target === platforms ? ['android-36'] : ['35.0.0'],
     })).toMatchObject({ sdkRoot });
   });
 
@@ -88,8 +91,27 @@ describe('Android SDK 与 adb 输出解析', () => {
         ANDROID_HOME: win32.join('D:\\', 'old-sdk'),
         LOCALAPPDATA: localAppData,
       },
-      exists: (target) => target === sdkRoot,
+      exists: (target) => target === win32.join(sdkRoot, 'platforms')
+        || target === win32.join(sdkRoot, 'build-tools'),
+      readDir: (target) => target.endsWith('platforms') ? ['android-36'] : ['35.0.0'],
     })).toMatchObject({ sdkRoot });
+  });
+
+  it('build-only skips an existing but incomplete SDK candidate', () => {
+    const stale = win32.join('D:\\', 'stale-sdk');
+    const valid = win32.join('C:\\', 'Users', 'dev', 'AppData', 'Local', 'Android', 'Sdk');
+    const existing = new Set([
+      stale,
+      win32.join(valid, 'platforms'),
+      win32.join(valid, 'build-tools'),
+    ]);
+    expect(resolveAndroidSdkTools({
+      platform: 'win32',
+      requireTools: false,
+      env: { ANDROID_SDK_ROOT: stale, LOCALAPPDATA: win32.join('C:\\', 'Users', 'dev', 'AppData', 'Local') },
+      exists: (target) => existing.has(target),
+      readDir: (target) => target.endsWith('platforms') ? ['android-36'] : ['35.0.0'],
+    })).toMatchObject({ sdkRoot: valid });
   });
 
   it('build-only 没有有效 SDK 候选时明确失败', () => {

--- a/apps/mobile/src/__tests__/mobileMetroOwnership.test.ts
+++ b/apps/mobile/src/__tests__/mobileMetroOwnership.test.ts
@@ -1,10 +1,11 @@
 import { join } from 'node:path';
 import { describe, expect, it, vi } from 'vitest';
-import { probeMetroOwnership, windowsProcessSnapshot } from '../../scripts/sim-metro.mjs';
+import { metroEnvironmentFingerprint, probeMetroOwnership, windowsProcessSnapshot } from '../../scripts/sim-metro.mjs';
 import { classifySimMetroListener, resolveSimMetroHandoff } from '../../scripts/lib/sim-whoami.mjs';
 
 const worktreeRoot = join('/worktrees', 'metro-owner');
-const owner = { pid: 100, launcherPid: 100, worktreeRoot, source: 'branch@commit', recordedAtMs: 1500 };
+const owner = { pid: 100, launcherPid: 100, worktreeRoot, source: 'branch@commit', recordedAtMs: 1500,
+  envFingerprint: 'env-1' };
 type ProcessEntry = { pid: number; parentPid: number; startedAtMs: number };
 const launcher = { pid: 100, parentPid: 1, startedAtMs: 1000 };
 const wrapper = { pid: 200, parentPid: 100, startedAtMs: 1100 };
@@ -22,7 +23,8 @@ function probe(processes: ProcessEntry[], metadata: object | null = owner, liste
 describe('Windows Metro owner and listener association', () => {
   it('recognizes a listener beneath the pnpm and shell wrappers', () => {
     expect(probe([launcher, wrapper, listener])).toEqual({
-      pid: '300', launcherPid: 100, cwd: join(worktreeRoot, 'apps/mobile'), source: owner.source, region: null,
+      pid: '300', launcherPid: 100, cwd: join(worktreeRoot, 'apps/mobile'), source: owner.source,
+      region: null, envFingerprint: owner.envFingerprint,
     });
   });
 
@@ -84,6 +86,32 @@ describe('Windows Metro owner and listener association', () => {
 
   it('preserves the recorded Metro region for rebuild gates', () => {
     expect(probe([launcher, wrapper, listener], { ...owner, region: 'cn' })?.region).toBe('cn');
+  });
+
+  it('preserves the recorded environment fingerprint for reuse gates', () => {
+    expect(probe([launcher, wrapper, listener], { ...owner, envFingerprint: 'env-2' })?.envFingerprint)
+      .toBe('env-2');
+  });
+});
+
+describe('Metro environment fingerprint', () => {
+  it('is stable for reordered inputs and changes when local config changes', () => {
+    const first = metroEnvironmentFingerprint({
+      env: { REGION: 'cn', MANIFEST: 'https://one.invalid' },
+      files: { '.env': 'REGION=cn\n', 'scripts/self-host-regions.json': '{"cn":1}' },
+    });
+    expect(metroEnvironmentFingerprint({
+      env: { MANIFEST: 'https://one.invalid', REGION: 'cn' },
+      files: { 'scripts/self-host-regions.json': '{"cn":1}', '.env': 'REGION=cn\n' },
+    })).toBe(first);
+    expect(metroEnvironmentFingerprint({
+      env: { REGION: 'cn', MANIFEST: 'https://two.invalid' },
+      files: { '.env': 'REGION=cn\n', 'scripts/self-host-regions.json': '{"cn":1}' },
+    })).not.toBe(first);
+    expect(metroEnvironmentFingerprint({
+      env: { REGION: 'cn', MANIFEST: 'https://one.invalid' },
+      files: { '.env': 'REGION=cn\n', 'scripts/self-host-regions.json': '{"cn":2}' },
+    })).not.toBe(first);
   });
 });
 

--- a/apps/mobile/src/__tests__/mobileMetroOwnership.test.ts
+++ b/apps/mobile/src/__tests__/mobileMetroOwnership.test.ts
@@ -1,0 +1,101 @@
+import { join } from 'node:path';
+import { describe, expect, it, vi } from 'vitest';
+import { probeMetroOwnership, windowsProcessSnapshot } from '../../scripts/sim-metro.mjs';
+import { classifySimMetroListener, resolveSimMetroHandoff } from '../../scripts/lib/sim-whoami.mjs';
+
+const worktreeRoot = join('/worktrees', 'metro-owner');
+const owner = { pid: 100, launcherPid: 100, worktreeRoot, source: 'branch@commit', recordedAtMs: 1500 };
+type ProcessEntry = { pid: number; parentPid: number; startedAtMs: number };
+const launcher = { pid: 100, parentPid: 1, startedAtMs: 1000 };
+const wrapper = { pid: 200, parentPid: 100, startedAtMs: 1100 };
+const listener = { pid: 300, parentPid: 200, startedAtMs: 1200 };
+
+function probe(processes: ProcessEntry[], metadata: object | null = owner, listenerPid = '300') {
+  return probeMetroOwnership(8081, {
+    platform: 'win32',
+    listenerPid: () => listenerPid,
+    readOwner: () => metadata,
+    processSnapshot: () => processes,
+  });
+}
+
+describe('Windows Metro owner and listener association', () => {
+  it('recognizes a listener beneath the pnpm and shell wrappers', () => {
+    expect(probe([launcher, wrapper, listener])).toEqual({
+      pid: '300', launcherPid: 100, cwd: join(worktreeRoot, 'apps/mobile'), source: owner.source,
+    });
+  });
+
+  it('recognizes a launcher that directly owns the listening socket', () => {
+    expect(probe([launcher], owner, '100')?.launcherPid).toBe(100);
+  });
+
+  it('supports older owner metadata without a separate launcherPid', () => {
+    const { launcherPid: _launcherPid, ...legacyOwner } = owner;
+    expect(probe([launcher, wrapper, listener], legacyOwner)?.source).toBe(owner.source);
+  });
+
+  it.each([
+    ['unrelated live launcher', [launcher, wrapper, { ...listener, parentPid: 1 }]],
+    ['missing launcher', [wrapper, listener]],
+    ['missing listener', [launcher, wrapper]],
+    ['missing wrapper', [launcher, listener]],
+    ['launcher PID reused after owner was written', [{ ...launcher, startedAtMs: 1600 }, wrapper, listener]],
+    ['reused parent PID newer than its child', [launcher, { ...wrapper, startedAtMs: 1300 }, listener]],
+    ['ancestry cycle', [launcher, { ...wrapper, parentPid: 300, startedAtMs: 1200 }, listener]],
+    ['missing process creation time', [{ ...launcher, startedAtMs: Number.NaN }, wrapper, listener]],
+    ['unavailable process snapshot', []],
+  ] satisfies [string, ProcessEntry[]][])('rejects %s without allowing takeover', (_name, processes) => {
+    const ownership = probe(processes);
+    expect(ownership).toEqual({ pid: '300', cwd: null, source: null });
+    const classified = classifySimMetroListener({
+      cwd: ownership?.cwd, source: ownership?.source, targetWorktree: worktreeRoot,
+    });
+    const handoff = {
+      takeover: true, currentSource: owner.source, runningSource: ownership?.source, listener: classified,
+    };
+    expect(resolveSimMetroHandoff(handoff).action).toBe('refuse');
+  });
+
+  it('rejects direct listener PID reuse even when it matches the saved owner PID', () => {
+    expect(probe([{ ...launcher, startedAtMs: 1600 }], owner, '100')).toEqual({
+      pid: '100', cwd: null, source: null,
+    });
+  });
+
+  it.each([
+    null,
+    { ...owner, pid: 0 },
+    { ...owner, launcherPid: -1 },
+    { ...owner, recordedAtMs: undefined },
+  ])('rejects missing or malformed owner identity: %j', (metadata) => {
+    expect(probe([launcher, wrapper, listener], metadata)?.source).toBeNull();
+  });
+
+  it('does not read owner metadata or process identity for a free port', () => {
+    const readOwner = vi.fn();
+    const processSnapshot = vi.fn();
+    expect(probeMetroOwnership(8081, {
+      platform: 'win32', listenerPid: () => null, readOwner, processSnapshot,
+    })).toBeNull();
+    expect(readOwner).not.toHaveBeenCalled();
+    expect(processSnapshot).not.toHaveBeenCalled();
+  });
+});
+
+describe('Windows process snapshot', () => {
+  it.each([false, true])('parses CIM identity output (array=%s)', (array) => {
+    const process = { ProcessId: 100, ParentProcessId: 1, StartedAtMs: 1000 };
+    const run = vi.fn(() => JSON.stringify(array ? [process] : process));
+    expect(windowsProcessSnapshot(run)).toEqual([launcher]);
+    expect(run).toHaveBeenCalledWith('powershell.exe', expect.any(Array), expect.objectContaining({
+      timeout: 5000, windowsHide: true,
+    }));
+  });
+
+  it('fails closed when process inspection fails or returns malformed output', () => {
+    expect(windowsProcessSnapshot(() => { throw new Error('timeout'); })).toEqual([]);
+    expect(windowsProcessSnapshot(() => 'invalid json')).toEqual([]);
+    expect(windowsProcessSnapshot(() => 'null')).toEqual([]);
+  });
+});

--- a/apps/mobile/src/__tests__/mobileMetroOwnership.test.ts
+++ b/apps/mobile/src/__tests__/mobileMetroOwnership.test.ts
@@ -22,7 +22,7 @@ function probe(processes: ProcessEntry[], metadata: object | null = owner, liste
 describe('Windows Metro owner and listener association', () => {
   it('recognizes a listener beneath the pnpm and shell wrappers', () => {
     expect(probe([launcher, wrapper, listener])).toEqual({
-      pid: '300', launcherPid: 100, cwd: join(worktreeRoot, 'apps/mobile'), source: owner.source,
+      pid: '300', launcherPid: 100, cwd: join(worktreeRoot, 'apps/mobile'), source: owner.source, region: null,
     });
   });
 
@@ -80,6 +80,10 @@ describe('Windows Metro owner and listener association', () => {
     })).toBeNull();
     expect(readOwner).not.toHaveBeenCalled();
     expect(processSnapshot).not.toHaveBeenCalled();
+  });
+
+  it('preserves the recorded Metro region for rebuild gates', () => {
+    expect(probe([launcher, wrapper, listener], { ...owner, region: 'cn' })?.region).toBe('cn');
   });
 });
 

--- a/apps/mobile/src/__tests__/mobileSimSource.test.ts
+++ b/apps/mobile/src/__tests__/mobileSimSource.test.ts
@@ -5,6 +5,7 @@ import { join } from 'node:path';
 import {
   gitSourceIdentity,
   isDedicatedMetroProcessGroup,
+  parseWindowsNetstatListener,
   terminateMetro,
 } from '../../scripts/sim-metro.mjs';
 
@@ -48,6 +49,15 @@ describe('mobile simulator source identity', () => {
 });
 
 describe('mobile simulator Metro takeover', () => {
+  it('parses a Windows netstat listener without accepting another port', () => {
+    const output = [
+      '  TCP    0.0.0.0:8081    0.0.0.0:0    LISTENING    4242',
+      '  TCP    0.0.0.0:8082    0.0.0.0:0    LISTENING    4343',
+    ].join('\r\n');
+    expect(parseWindowsNetstatListener(output, 8081)).toBe('4242');
+    expect(parseWindowsNetstatListener(output, 8083)).toBeNull();
+  });
+
   it('recognizes only dedicated Metro process groups', () => {
     expect(isDedicatedMetroProcessGroup([
       'pnpm mobile:sim:start',

--- a/apps/mobile/src/__tests__/mobileSimSource.test.ts
+++ b/apps/mobile/src/__tests__/mobileSimSource.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it, vi } from 'vitest';
-import { mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import {
@@ -124,6 +124,11 @@ describe('mobile simulator Metro takeover', () => {
       ['/PID', '123', '/T', '/F'],
       { stdio: 'ignore', windowsHide: true },
     );
+  });
+
+  it('normalizes the Windows owner metadata cwd to the mobile directory', () => {
+    const source = readFileSync(join(process.cwd(), 'scripts/sim-metro.mjs'), 'utf8');
+    expect(source).toContain("cwd: owner.worktreeRoot ? join(owner.worktreeRoot, 'apps/mobile') : null");
   });
 
   it('falls back to the listener PID when the group is unavailable', async () => {

--- a/apps/mobile/src/__tests__/mobileSimSource.test.ts
+++ b/apps/mobile/src/__tests__/mobileSimSource.test.ts
@@ -88,6 +88,7 @@ describe('mobile simulator Metro takeover', () => {
     const run = vi.fn();
     let alive = true;
     const stopped = await terminateMetro(123, {
+      platform: 'darwin',
       execFile: run,
       groupId: '456',
       currentGroupId: '789',
@@ -105,9 +106,30 @@ describe('mobile simulator Metro takeover', () => {
     expect(run).toHaveBeenCalledWith('kill', ['-TERM', '-456']);
   });
 
+  it('uses taskkill tree termination for a confirmed Windows launcher', async () => {
+    const run = vi.fn();
+    let alive = true;
+    const stopped = await terminateMetro(123, {
+      platform: 'win32',
+      execFile: run,
+      isAlive: () => alive,
+      wait: async () => { alive = false; },
+      timeoutMs: 100,
+      pollMs: 10,
+    });
+
+    expect(stopped).toBe(true);
+    expect(run).toHaveBeenCalledWith(
+      'taskkill',
+      ['/PID', '123', '/T', '/F'],
+      { stdio: 'ignore', windowsHide: true },
+    );
+  });
+
   it('falls back to the listener PID when the group is unavailable', async () => {
     const run = vi.fn();
     const stopped = await terminateMetro(123, {
+      platform: 'darwin',
       execFile: run,
       groupId: null,
       currentGroupId: '789',
@@ -121,6 +143,7 @@ describe('mobile simulator Metro takeover', () => {
   it('falls back to the listener PID when the current process group is unknown', async () => {
     const run = vi.fn();
     const stopped = await terminateMetro(123, {
+      platform: 'darwin',
       execFile: run,
       groupId: '456',
       currentGroupId: null,
@@ -135,6 +158,7 @@ describe('mobile simulator Metro takeover', () => {
   it('falls back to the listener PID for a process group with unrelated members', async () => {
     const run = vi.fn();
     const stopped = await terminateMetro(123, {
+      platform: 'darwin',
       execFile: run,
       groupId: '456',
       currentGroupId: '789',
@@ -149,6 +173,7 @@ describe('mobile simulator Metro takeover', () => {
   it('returns success when the listener exits before kill', async () => {
     const run = vi.fn(() => { throw new Error('ESRCH'); });
     const stopped = await terminateMetro(123, {
+      platform: 'darwin',
       execFile: run,
       groupId: null,
       isAlive: () => false,
@@ -163,6 +188,7 @@ describe('mobile simulator Metro takeover', () => {
 
   it('times out instead of claiming a process was stopped', async () => {
     const stopped = await terminateMetro(123, {
+      platform: 'darwin',
       execFile: vi.fn(),
       groupId: null,
       isAlive: () => true,

--- a/apps/mobile/src/__tests__/mobileSimSource.test.ts
+++ b/apps/mobile/src/__tests__/mobileSimSource.test.ts
@@ -1,10 +1,11 @@
 import { describe, expect, it, vi } from 'vitest';
 import { mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
-import { join } from 'node:path';
+import { join, posix, win32 } from 'node:path';
 import {
   gitSourceIdentity,
   isDedicatedMetroProcessGroup,
+  isInside,
   parseWindowsNetstatListener,
   terminateMetro,
 } from '../../scripts/sim-metro.mjs';
@@ -49,6 +50,32 @@ describe('mobile simulator source identity', () => {
 });
 
 describe('mobile simulator Metro takeover', () => {
+  it.each([
+    ['C:\\repo', 'C:\\repo', true],
+    ['C:\\repo', 'c:\\repo\\apps\\mobile', true],
+    ['C:\\repo', 'C:\\repo\\..notes', true],
+    ['C:\\repo', 'D:\\repo\\apps\\mobile', false],
+    ['C:\\repo', 'C:\\repo-other\\apps\\mobile', false],
+    ['C:\\repo', 'C:\\repo\\..\\other\\apps\\mobile', false],
+    ['C:\\repo', 'C:\\', false],
+    ['\\\\server\\repo', '\\\\server\\other\\apps\\mobile', false],
+    ['\\\\server\\repo', '\\\\other\\repo\\apps\\mobile', false],
+    ['\\\\server\\repo', '\\\\server\\repo\\apps\\mobile', true],
+  ])('checks Windows Metro worktree boundaries: %s -> %s', (root, cwd, expected) => {
+    expect(isInside(root, cwd, win32)).toBe(expected);
+  });
+
+  it.each([
+    ['/repo', '/repo', true],
+    ['/repo', '/repo/apps/mobile', true],
+    ['/repo', '/repo/..notes', true],
+    ['/repo', '/repo-other/apps/mobile', false],
+    ['/repo', '/repo/../other/apps/mobile', false],
+    ['/repo', '/', false],
+  ])('checks POSIX Metro worktree boundaries: %s -> %s', (root, cwd, expected) => {
+    expect(isInside(root, cwd, posix)).toBe(expected);
+  });
+
   it('parses a Windows netstat listener without accepting another port', () => {
     const output = [
       '  TCP    0.0.0.0:8081    0.0.0.0:0    LISTENING    4242',

--- a/apps/mobile/src/__tests__/mobileSimWhoami.test.ts
+++ b/apps/mobile/src/__tests__/mobileSimWhoami.test.ts
@@ -118,6 +118,19 @@ describe('mobile:sim takeover and JSON arguments', () => {
       listener: { confirmed: true, isTarget: true }, listenerWorktreeExists: true,
     })).toMatchObject({ action: 'restart', code: 'target-region' });
   });
+
+  it('restarts a target Metro when its persisted environment fingerprint differs', () => {
+    expect(resolveSimMetroHandoff({
+      currentSource: 'branch@commit', runningSource: 'branch@commit',
+      currentEnvFingerprint: 'env-new', runningEnvFingerprint: 'env-old',
+      listener: { confirmed: true, isTarget: true }, listenerWorktreeExists: true,
+    })).toMatchObject({ action: 'refuse', code: 'target-env-stale' });
+    expect(resolveSimMetroHandoff({
+      takeover: true, currentSource: 'branch@commit', runningSource: 'branch@commit',
+      currentEnvFingerprint: 'env-new', runningEnvFingerprint: 'env-old',
+      listener: { confirmed: true, isTarget: true }, listenerWorktreeExists: true,
+    })).toMatchObject({ action: 'restart', code: 'target-env' });
+  });
 });
 
 describe('mobile:sim Metro handoff', () => {

--- a/apps/mobile/src/__tests__/mobileSimWhoami.test.ts
+++ b/apps/mobile/src/__tests__/mobileSimWhoami.test.ts
@@ -105,6 +105,19 @@ describe('mobile:sim takeover and JSON arguments', () => {
       platform: 'linux',
     })).toEqual({ confirmed: true, worktree: '/Repo', isTarget: false });
   });
+
+  it('restarts a target Metro when its persisted region differs', () => {
+    expect(resolveSimMetroHandoff({
+      currentSource: 'branch@commit', runningSource: 'branch@commit',
+      currentRegion: 'global', runningRegion: 'cn',
+      listener: { confirmed: true, isTarget: true }, listenerWorktreeExists: true,
+    })).toMatchObject({ action: 'refuse', code: 'target-region-stale' });
+    expect(resolveSimMetroHandoff({
+      takeover: true, currentSource: 'branch@commit', runningSource: 'branch@commit',
+      currentRegion: 'global', runningRegion: 'cn',
+      listener: { confirmed: true, isTarget: true }, listenerWorktreeExists: true,
+    })).toMatchObject({ action: 'restart', code: 'target-region' });
+  });
 });
 
 describe('mobile:sim Metro handoff', () => {

--- a/apps/mobile/src/__tests__/mobileSimWhoami.test.ts
+++ b/apps/mobile/src/__tests__/mobileSimWhoami.test.ts
@@ -78,6 +78,33 @@ describe('mobile:sim takeover and JSON arguments', () => {
       targetWorktree: '/repo/',
     })).toEqual({ confirmed: true, worktree: '/repo', isTarget: true });
   });
+
+  it('compares Windows worktree paths case-insensitively', () => {
+    expect(classifySimMetroListener({
+      cwd: 'C:\\Repo\\apps\\mobile',
+      source: 'branch@commit',
+      targetWorktree: 'c:\\repo',
+      platform: 'win32',
+    })).toEqual({ confirmed: true, worktree: 'C:/Repo', isTarget: true });
+    expect(classifySimMetroListener({
+      cwd: 'C:\\RepoOther\\apps\\mobile',
+      source: 'branch@commit',
+      targetWorktree: 'c:\\repo',
+      platform: 'win32',
+    })).toEqual({ confirmed: true, worktree: 'C:/RepoOther', isTarget: false });
+    expect(classifySimMetroListener({
+      cwd: 'C:\\Repo\\apps\\mobile',
+      source: 'branch@commit',
+      targetWorktree: 'D:\\repo',
+      platform: 'win32',
+    })).toEqual({ confirmed: true, worktree: 'C:/Repo', isTarget: false });
+    expect(classifySimMetroListener({
+      cwd: '/Repo/apps/mobile',
+      source: 'branch@commit',
+      targetWorktree: '/repo',
+      platform: 'linux',
+    })).toEqual({ confirmed: true, worktree: '/Repo', isTarget: false });
+  });
 });
 
 describe('mobile:sim Metro handoff', () => {

--- a/apps/mobile/src/__tests__/mobileVoiceController.test.ts
+++ b/apps/mobile/src/__tests__/mobileVoiceController.test.ts
@@ -228,6 +228,24 @@ describe('mobileVoiceController', () => {
     expect(await session.stop()).toBe('用户刚修改\nraw final');
   });
 
+  it('reports the original range when the first transcript is published after a user move', async () => {
+    let draft = '前后';
+    let firstReplacement: { start: number; end: number; text: string } | undefined;
+    const session = createMobileVoiceControllerSession({
+      credential: credential(), initialDraft: draft, initialSelection: { start: 1, end: 1 },
+      asr: new FakeAsrProvider(), refiner: null,
+      startAudio: async () => async () => undefined,
+      readCurrentDraft: () => draft,
+      onDraftChanged: (text, _selection, replacement) => {
+        draft = text;
+        firstReplacement ??= replacement;
+      },
+    });
+    await session.start();
+    expect(await session.stop()).toBe('前raw final后');
+    expect(firstReplacement).toEqual({ start: 1, end: 1, text: 'raw final' });
+  });
+
   it('propagates and localizes empty-transcript failures from stop()', async () => {
     const errors: string[] = [];
     const states: string[] = [];

--- a/apps/mobile/src/__tests__/nativeE2eEnvironment.test.ts
+++ b/apps/mobile/src/__tests__/nativeE2eEnvironment.test.ts
@@ -10,6 +10,8 @@ describe('native e2e environment', () => {
     const runner = readFileSync(resolve(process.cwd(), 'scripts/maestro-e2e.mjs'), 'utf8');
 
     expect(helper).toContain('const MIN_JAVA_MAJOR = 17');
+    expect(helper).toContain('env.ANDROID_STUDIO_JDK');
+    expect(helper).toContain("env.ProgramFiles, 'Android', 'Android Studio', 'jbr'");
     expect(helper).toContain("brew', ['--prefix', 'openjdk@17']");
     expect(helper).toContain("'/usr/libexec/java_home', ['-v', version]");
     expect(helper).toContain('JAVA_HOME: javaHome');

--- a/apps/mobile/src/__tests__/newSession.test.ts
+++ b/apps/mobile/src/__tests__/newSession.test.ts
@@ -1821,7 +1821,7 @@ describe('new session composer surface', () => {
     expect(newSource).not.toContain('voiceDraftListeningText: {\n    color: colors.statusReady,');
     expect(newSource).toContain('const voiceDraftShowsListeningPrompt = voiceIsListening && draft.firstMessage.length === 0;');
     expect(newSource).toContain('firstMessageInputRef.current?.setNativeProps({ selection: firstMessageSelectionRef.current });');
-    expect(newSource).toContain('voiceSelectionUserOwnedRef.current = false;\n      const controller = createMobileVoiceControllerSession({');
+    expect(newSource).toContain('voiceSelectionUserOwnedRef.current = false;\n      voicePendingSelectionEchoesRef.current = [];\n      const controller = createMobileVoiceControllerSession({');
     expect(newSource).toContain('voiceDraftScrollRef.current?.scrollTo({ y: voiceDraftCaretFrame.top, animated: false });');
     expect(newSource).toContain('draft.firstMessage.slice(0, firstMessageSelectionRef.current.end)');
     expect(newSource).toContain('draft.firstMessage.slice(firstMessageSelectionRef.current.end)');

--- a/apps/mobile/src/__tests__/newSession.test.ts
+++ b/apps/mobile/src/__tests__/newSession.test.ts
@@ -1821,6 +1821,7 @@ describe('new session composer surface', () => {
     expect(newSource).not.toContain('voiceDraftListeningText: {\n    color: colors.statusReady,');
     expect(newSource).toContain('const voiceDraftShowsListeningPrompt = voiceIsListening && draft.firstMessage.length === 0;');
     expect(newSource).toContain('firstMessageInputRef.current?.setNativeProps({ selection: firstMessageSelectionRef.current });');
+    expect(newSource).toContain('if (selection && !voiceStopInFlightRef.current) {');
     expect(newSource).toContain('voiceDraftScrollRef.current?.scrollTo({ y: voiceDraftCaretFrame.top, animated: false });');
     expect(newSource).toContain('draft.firstMessage.slice(0, firstMessageSelectionRef.current.end)');
     expect(newSource).toContain('draft.firstMessage.slice(firstMessageSelectionRef.current.end)');

--- a/apps/mobile/src/__tests__/newSession.test.ts
+++ b/apps/mobile/src/__tests__/newSession.test.ts
@@ -1537,6 +1537,30 @@ describe('new session model', () => {
 });
 
 describe('new session composer surface', () => {
+  it('keeps the controlled caret at the end after palette insertion and draft restore', () => {
+    const newSource = readTextLf(resolve(process.cwd(), 'app/sessions/new.tsx'), 'utf8');
+    const slashStart = newSource.indexOf('const selectSlashCommand = useCallback');
+    const slashEnd = newSource.indexOf('const selectAtResource = useCallback', slashStart);
+    const slashSource = newSource.slice(slashStart, slashEnd);
+    const atStart = slashEnd;
+    const atEnd = newSource.indexOf('const removeAttachment = useCallback', atStart);
+    const atSource = newSource.slice(atStart, atEnd);
+    const restoreStart = newSource.indexOf('firstMessageRef.current = stashed.draft.firstMessage;');
+    const restoreEnd = newSource.indexOf('setDraft(stashed.draft);', restoreStart);
+    const restoreSource = newSource.slice(restoreStart, restoreEnd);
+
+    for (const source of [slashSource, atSource]) {
+      expect(source).toContain('const current = firstMessageRef.current;');
+      expect(source).toContain('const selection = { start: next.length, end: next.length };');
+      expect(source.indexOf('setFirstMessageDraft(next)')).toBeLessThan(
+        source.indexOf('setFirstMessageSelection(selection)'),
+      );
+    }
+    expect(restoreSource).toContain('firstMessageRef.current = stashed.draft.firstMessage;');
+    expect(restoreSource).toContain('firstMessageSelectionRef.current = restoredSelection;');
+    expect(restoreSource).toContain('setFirstMessageSelection(restoredSelection);');
+  });
+
   it('does not double-apply the Android safe-area inset to the top navigation', () => {
     const newSource = readTextLf(resolve(process.cwd(), 'app/sessions/new.tsx'), 'utf8');
 

--- a/apps/mobile/src/__tests__/newSession.test.ts
+++ b/apps/mobile/src/__tests__/newSession.test.ts
@@ -1656,7 +1656,7 @@ describe('new session composer surface', () => {
     expect(newComposerSource).toContain('inputRef={firstMessageInputRef}');
     expect(newComposerSource).toContain('inputOverlay={renderComposerInputOverlay()}');
     expect(newComposerSource).toContain('inputStyle={voiceIsListening ? styles.inputVoiceHidden : undefined}');
-    expect(newComposerSource).toContain('onChangeText={setFirstMessageDraft}');
+    expect(newComposerSource).toContain('setFirstMessageDraft(text);');
     expect(newComposerSource).toContain('onContentSizeChange={handleFirstMessageInputContentSizeChange}');
     expect(newComposerSource).toContain("placeholder={voiceIsListening ? '' : composerPlaceholder}");
     expect(newComposerSource).toContain('scrollEnabled={composerInputScrollEnabled}');
@@ -1821,7 +1821,7 @@ describe('new session composer surface', () => {
     expect(newSource).not.toContain('voiceDraftListeningText: {\n    color: colors.statusReady,');
     expect(newSource).toContain('const voiceDraftShowsListeningPrompt = voiceIsListening && draft.firstMessage.length === 0;');
     expect(newSource).toContain('firstMessageInputRef.current?.setNativeProps({ selection: firstMessageSelectionRef.current });');
-    expect(newSource).toContain('if (selection && !voiceStopInFlightRef.current) {');
+    expect(newSource).toContain('voiceSelectionUserOwnedRef.current = false;\n      const controller = createMobileVoiceControllerSession({');
     expect(newSource).toContain('voiceDraftScrollRef.current?.scrollTo({ y: voiceDraftCaretFrame.top, animated: false });');
     expect(newSource).toContain('draft.firstMessage.slice(0, firstMessageSelectionRef.current.end)');
     expect(newSource).toContain('draft.firstMessage.slice(firstMessageSelectionRef.current.end)');

--- a/apps/mobile/src/__tests__/newSession.test.ts
+++ b/apps/mobile/src/__tests__/newSession.test.ts
@@ -1758,6 +1758,8 @@ describe('new session composer surface', () => {
     expect(newSource).toContain('const voiceStartupInFlightRef = useRef(false);');
     expect(newSource).toContain('const voicePermissionRequestInFlightRef = useRef(false);');
     expect(newSource).toContain('const voiceStopInFlightRef = useRef(false);');
+    expect(newSource).toContain('if (!voiceRecordingActiveRef.current) {');
+    expect(newSource).not.toContain('if (!voiceRecordingActiveRef.current && !voiceStopInFlightRef.current) {');
     expect(newSource).toContain('const voiceStartupSeqRef = useRef(0);');
     expect(newSource).toContain('|| voiceStopInFlightRef.current');
     expect(newSource).toContain('resolveMobileVoiceRecordingPermission({');

--- a/apps/mobile/src/__tests__/newSessionVoiceInput.test.tsx
+++ b/apps/mobile/src/__tests__/newSessionVoiceInput.test.tsx
@@ -108,14 +108,14 @@ const compiledVoice = ts.transpileModule(`function voiceCallbacks(bindings) {
 }`, { compilerOptions: { target: ts.ScriptTarget.ES2022 } }).outputText;
 const voiceCallbacks = new Function(`${compiledVoice}; return voiceCallbacks;`)() as
   (bindings: Record<string, unknown>) => {
-    publish: (text: string, selection?: Selection) => void;
+    publish: (text: string, selection?: Selection, replacement?: Selection & { text: string }) => void;
     select: (event: { nativeEvent: { selection: Selection } }) => void;
     type: (text: string) => void;
     stop: () => Promise<string | null>;
   };
 
-function pendingVoiceStop() {
-  const firstMessageRef = { current: '前后' };
+function pendingVoiceStop(initialDraft = '前后') {
+  const firstMessageRef = { current: initialDraft };
   const firstMessageSelectionRef = { current: { start: 1, end: 1 } };
   let controlledSelection = firstMessageSelectionRef.current;
   let completeStop!: (draft: string) => void;
@@ -145,6 +145,43 @@ function pendingVoiceStop() {
 }
 
 describe('new-session selection during dictation stop', () => {
+  it.each([
+    ['caret in suffix', [4, 4], [6, 6], [3, 3], '前词后!缀'],
+    ['selected suffix', [3, 5], [5, 7], [2, 4], '前词!'],
+    ['selected prefix', [0, 1], [0, 1], [0, 1], '!词后缀'],
+    ['selection across insertion', [0, 5], [0, 7], [0, 4], '!'],
+    ['caret inside replacement', [2, 2], [2, 2], [2, 2], '前词!后缀'],
+  ] as const)('rebases %s through longer ASR and shorter refinement', async (_name, initial, longer, shorter, inserted) => {
+    const voice = pendingVoiceStop('前后缀');
+    voice.publish('前识别后缀', { start: 3, end: 3 });
+    const stop = voice.stop();
+    voice.move(initial[0], initial[1]);
+    voice.publish('前原始转写后缀', { start: 5, end: 5 }, { start: 1, end: 3, text: '原始转写' });
+    expect(voice.selection()).toEqual({ start: longer[0], end: longer[1] });
+    voice.publish('前词后缀', { start: 2, end: 2 }, { start: 1, end: 5, text: '词' });
+    expect(voice.selection()).toEqual({ start: shorter[0], end: shorter[1] });
+    voice.complete();
+    expect(await stop).toBe('前词后缀');
+    expect(voice.setNativeProps).toHaveBeenCalledWith({ selection: { start: shorter[0], end: shorter[1] } });
+    expect(voice.insert('!')).toBe(inserted);
+  });
+
+  it('preserves the position after manually typed suffix text when final voice text changes length', async () => {
+    const voice = pendingVoiceStop();
+    voice.publish('前识别后', { start: 3, end: 3 });
+    const stop = voice.stop();
+    voice.move(4);
+    voice.type(voice.insert('!'));
+    voice.move(5);
+    voice.publish('前原始转写后!', { start: 5, end: 5 }, { start: 1, end: 3, text: '原始转写' });
+    expect(voice.selection()).toEqual({ start: 7, end: 7 });
+    voice.publish('前词后!', { start: 2, end: 2 }, { start: 1, end: 5, text: '词' });
+    voice.complete();
+    await stop;
+    expect(voice.selection()).toEqual({ start: 4, end: 4 });
+    expect(voice.insert('?')).toBe('前词后!?');
+  });
+
   it.each([false, true])('follows final ASR and refinement without a user move (partial=%s)', async (partial) => {
     const voice = pendingVoiceStop();
     if (partial) voice.publish('前识别后', { start: 3, end: 3 });

--- a/apps/mobile/src/__tests__/newSessionVoiceInput.test.tsx
+++ b/apps/mobile/src/__tests__/newSessionVoiceInput.test.tsx
@@ -64,7 +64,7 @@ const hiddenStyle = findOne((node): node is ts.PropertyAssignment =>
   ts.isPropertyAssignment(node) && node.name.getText(source) === 'inputVoiceHidden');
 const composer = findOne((node): node is ts.JsxSelfClosingElement =>
   ts.isJsxSelfClosingElement(node) && node.tagName.getText(source) === 'MobileComposerInputRow');
-const propNames = ['inputStyle', 'caretHidden', 'value', 'placeholder', 'selection', 'onPressIn'];
+const propNames = ['inputStyle', 'caretHidden', 'value', 'placeholder', 'selection', 'onPressIn', 'onKeyPress'];
 function composerExpression(name: string) {
   const prop = composer.attributes.properties.find((node) =>
     ts.isJsxAttribute(node) && node.name.getText(source) === name);
@@ -77,7 +77,7 @@ function composerExpression(name: string) {
 const expressions = propNames.map((name) => `${name}: ${composerExpression(name)}`);
 const compiled = ts.transpileModule(`function pageProps(bindings) {
   const { Platform, voiceIsListening, draft, finishVoiceRecording, composerPlaceholder, firstMessageSelection,
-    voiceStopGestureSelectionGuardRef } = bindings;
+    voiceStopGestureSelectionGuardRef, voicePendingSelectionEchoesRef } = bindings;
   const styles = { inputVoiceHidden: ${hiddenStyle.initializer.getText(source)} };
   return { ${expressions.join(',\n')} };
 }`, { compilerOptions: { target: ts.ScriptTarget.ES2022 } }).outputText;
@@ -96,7 +96,7 @@ if (!stopCallback.initializer || !ts.isCallExpression(stopCallback.initializer))
 type Selection = { start: number; end: number };
 const compiledVoice = ts.transpileModule(`function voiceCallbacks(bindings) {
   const { voiceSelectionUserOwnedRef, voiceRecordingActiveRef, voiceStopInFlightRef,
-    voiceStopGestureSelectionGuardRef,
+    voiceStopGestureSelectionGuardRef, voicePendingSelectionEchoesRef,
     firstMessageRef, firstMessageSelectionRef, setFirstMessageSelection, setFirstMessageDraft,
     voiceControllerSessionRef, voiceStartupSeqRef, voiceStartupInFlightRef, voiceState,
     setVoiceState, setVoiceError, setAudioModeAsync, requestAnimationFrame,
@@ -106,6 +106,7 @@ const compiledVoice = ts.transpileModule(`function voiceCallbacks(bindings) {
     select: ${composerExpression('onSelectionChange')},
     type: ${composerExpression('onChangeText')},
     press: ${composerExpression('onPressIn')},
+    key: ${composerExpression('onKeyPress')},
     stop: ${stopCallback.initializer.arguments[0].getText(source)},
   };
 }`, { compilerOptions: { target: ts.ScriptTarget.ES2022 } }).outputText;
@@ -115,6 +116,7 @@ const voiceCallbacks = new Function(`${compiledVoice}; return voiceCallbacks;`)(
     select: (event: { nativeEvent: { selection: Selection } }) => void;
     type: (text: string) => void;
     press: () => void;
+    key: () => void;
     stop: () => Promise<string | null>;
   };
 
@@ -127,10 +129,11 @@ function pendingVoiceStop(initialDraft = '前后') {
   let activeStop: Promise<string | null> | undefined;
   const stopGate = new Promise<string>((resolve) => { completeStop = resolve; });
   const setNativeProps = vi.fn();
-  const callbacks = voiceCallbacks({
+  const bindings = {
     firstMessageRef, firstMessageSelectionRef,
     voiceSelectionUserOwnedRef: { current: false },
     voiceStopGestureSelectionGuardRef: { current: false },
+    voicePendingSelectionEchoesRef: { current: [] },
     voiceRecordingActiveRef: { current: true }, voiceStopInFlightRef: { current: false },
     voiceStartupSeqRef: { current: 1 }, voiceStartupInFlightRef: { current: false },
     voiceControllerSessionRef: { current: { stop: () => stopGate } },
@@ -144,19 +147,85 @@ function pendingVoiceStop(initialDraft = '前后') {
       activeStop = callbacks.stop();
       return activeStop;
     },
-  });
+  };
+  const callbacks = voiceCallbacks(bindings);
   return {
     ...callbacks,
     selection: () => controlledSelection,
     move: (start: number, end = start) => callbacks.select({ nativeEvent: { selection: { start, end } } }),
     complete: () => completeStop(firstMessageRef.current), setNativeProps,
     press: () => { callbacks.press(); return activeStop; },
+    pressToEdit: () => voiceCallbacks({ ...bindings, voiceIsListening: false }).press(),
     insert: (text: string) => firstMessageRef.current.slice(0, controlledSelection.start)
       + text + firstMessageRef.current.slice(controlledSelection.end),
   };
 }
 
 describe('new-session selection during dictation stop', () => {
+  it.each([false, true])('ignores a delayed ASR selection echo (stop completed=%s)', async (completed) => {
+    const voice = pendingVoiceStop();
+    const stop = voice.stop();
+    voice.publish('前原始转写后', { start: 5, end: 5 });
+    voice.publish('前润色后', { start: 3, end: 3 });
+    if (completed) {
+      voice.complete();
+      await stop;
+    }
+    voice.move(5); // the first controlled update arrives after the second JS update
+    expect(voice.selection()).toEqual({ start: 3, end: 3 });
+    if (!completed) {
+      voice.publish('前最终润色后', { start: 5, end: 5 });
+      voice.complete();
+      await stop;
+      expect(voice.selection()).toEqual({ start: 5, end: 5 });
+      expect(voice.insert('!')).toBe('前最终润色!后');
+    } else {
+      expect(voice.insert('!')).toBe('前润色!后');
+    }
+  });
+
+  it('ignores delayed echoes of a rebased user selection', async () => {
+    const voice = pendingVoiceStop('前后缀');
+    voice.publish('前识别后缀', { start: 3, end: 3 });
+    const stop = voice.stop();
+    voice.move(4);
+    voice.publish('前原始转写后缀', { start: 5, end: 5 }, { start: 1, end: 3, text: '原始转写' });
+    voice.publish('前词后缀', { start: 2, end: 2 }, { start: 1, end: 5, text: '词' });
+    voice.move(6); // echo of the first rebase, not another user move
+    expect(voice.selection()).toEqual({ start: 3, end: 3 });
+    voice.complete();
+    await stop;
+    expect(voice.insert('!')).toBe('前词后!缀');
+  });
+
+  it('retires skipped echoes when native acknowledges the latest controlled selection', async () => {
+    const voice = pendingVoiceStop();
+    const stop = voice.stop();
+    voice.publish('前原始转写后', { start: 5, end: 5 });
+    voice.publish('前润色后', { start: 3, end: 3 });
+    voice.move(3); // native coalesced the first event
+    voice.move(5); // now a genuine movement back to an old controlled value
+    voice.publish('前润色后', { start: 3, end: 3 });
+    voice.complete();
+    await stop;
+    expect(voice.selection()).toEqual({ start: 5, end: 5 });
+  });
+
+  it.each(['touch', 'key', 'typing'] as const)('accepts a user returning to a pending value via %s', async (action) => {
+    const voice = pendingVoiceStop();
+    const stop = voice.stop();
+    voice.publish('前原始转写后', { start: 5, end: 5 });
+    voice.publish('前润色后', { start: 3, end: 3 });
+    if (action === 'touch') voice.pressToEdit();
+    if (action === 'key') voice.key();
+    if (action === 'typing') voice.type('前润色!?后');
+    voice.move(5);
+    voice.publish(action === 'typing' ? '前润色!?后' : '前润色后', { start: 3, end: 3 });
+    voice.complete();
+    await stop;
+    expect(voice.selection()).toEqual({ start: 5, end: 5 });
+  });
+
   it.each([
     ['caret in suffix', [4, 4], [6, 6], [3, 3], '前词后!缀'],
     ['selected suffix', [3, 5], [5, 7], [2, 4], '前词!'],
@@ -282,7 +351,8 @@ function mountInput() {
       ...pageProps({ Platform: { OS: native.platform }, voiceIsListening: listening,
         draft: { firstMessage: draft }, firstMessageSelection: selection,
         finishVoiceRecording, composerPlaceholder: 'Draft',
-        voiceStopGestureSelectionGuardRef: { current: false } }),
+        voiceStopGestureSelectionGuardRef: { current: false },
+        voicePendingSelectionEchoesRef: { current: [] } }),
       inputOverlay: listening ? createElement('span', { 'data-testid': 'preview' }, draft) : null,
     })));
   }

--- a/apps/mobile/src/__tests__/newSessionVoiceInput.test.tsx
+++ b/apps/mobile/src/__tests__/newSessionVoiceInput.test.tsx
@@ -64,7 +64,7 @@ const hiddenStyle = findOne((node): node is ts.PropertyAssignment =>
   ts.isPropertyAssignment(node) && node.name.getText(source) === 'inputVoiceHidden');
 const composer = findOne((node): node is ts.JsxSelfClosingElement =>
   ts.isJsxSelfClosingElement(node) && node.tagName.getText(source) === 'MobileComposerInputRow');
-const propNames = ['inputStyle', 'caretHidden', 'value', 'placeholder', 'onPressIn'];
+const propNames = ['inputStyle', 'caretHidden', 'value', 'placeholder', 'selection', 'onPressIn'];
 const expressions = propNames.map((name) => {
   const prop = composer.attributes.properties.find((node) =>
     ts.isJsxAttribute(node) && node.name.getText(source) === name);
@@ -75,7 +75,7 @@ const expressions = propNames.map((name) => {
   return `${name}: ${prop.initializer.expression.getText(source)}`;
 });
 const compiled = ts.transpileModule(`function pageProps(bindings) {
-  const { Platform, voiceIsListening, draft, finishVoiceRecording, composerPlaceholder } = bindings;
+  const { Platform, voiceIsListening, draft, finishVoiceRecording, composerPlaceholder, firstMessageSelection } = bindings;
   const styles = { inputVoiceHidden: ${hiddenStyle.initializer.getText(source)} };
   return { ${expressions.join(',\n')} };
 }`, { compilerOptions: { target: ts.ScriptTarget.ES2022 } }).outputText;
@@ -91,14 +91,15 @@ function mountInput() {
   const ref = createRef<HTMLTextAreaElement>();
   const finishVoiceRecording = vi.fn();
   root = createRoot(container);
-  function render(listening: boolean, draft: string) {
+  function render(listening: boolean, draft: string, selection = { start: draft.length, end: draft.length }) {
     const colors = palettes[native.mode];
     act(() => root!.render(createElement(MobileComposerInputRow, {
       accessibilityLabel: 'Draft', inputTestID: 'draft', inputRef: ref,
       placeholder: 'Draft', placeholderTextColor: colors.textTertiary,
       value: draft, onChangeText: vi.fn(), onPasteImages: vi.fn(),
       ...pageProps({ Platform: { OS: native.platform }, voiceIsListening: listening,
-        draft: { firstMessage: draft }, finishVoiceRecording, composerPlaceholder: 'Draft' }),
+        draft: { firstMessage: draft }, firstMessageSelection: selection,
+        finishVoiceRecording, composerPlaceholder: 'Draft' }),
       inputOverlay: listening ? createElement('span', { 'data-testid': 'preview' }, draft) : null,
     })));
   }
@@ -128,6 +129,7 @@ describe.each(['light', 'dark'] as const)('new-session dictation input (%s)', (m
       expect(input.inputStyle().display).not.toBe('none');
       expect(native.props.caretHidden).toBe(true);
       expect(native.props.placeholder).toBe('');
+      expect(native.props.selection).toEqual({ start: draft.length, end: draft.length });
       expect(input.container.querySelector('[data-testid="preview"]')?.textContent).toBe(draft);
     }
     act(() => original!.dispatchEvent(new MouseEvent('mousedown', { bubbles: true })));
@@ -139,6 +141,7 @@ describe.each(['light', 'dark'] as const)('new-session dictation input (%s)', (m
     expect(input.inputStyle().opacity ?? 1).toBe(1);
     expect(input.inputStyle().color).toBe(palettes[mode].textPrimary);
     expect(native.props.caretHidden).toBe(false);
+    expect(native.props.selection).toEqual({ start: 'before hello\nworld suffix'.length, end: 'before hello\nworld suffix'.length });
     expect(input.container.querySelector('[data-testid="preview"]')).toBeNull();
     act(() => original!.dispatchEvent(new MouseEvent('mousedown', { bubbles: true })));
     expect(input.finishVoiceRecording).toHaveBeenCalledOnce();
@@ -153,5 +156,15 @@ describe.each(['light', 'dark'] as const)('new-session dictation input (%s)', (m
     expect(input.inputStyle().opacity ?? 1).toBe(1);
     input.render(false, 'dictation');
     expect(input.inputStyle().color).toBe(palettes[mode].textPrimary);
+  });
+
+  it('keeps the post-dictation insertion point when Android returns to typing', () => {
+    native.platform = 'android';
+    native.mode = mode;
+    const input = mountInput();
+    input.render(true, '甲新词乙', { start: 4, end: 4 });
+    expect(native.props.selection).toEqual({ start: 4, end: 4 });
+    input.render(false, '甲新词乙', { start: 4, end: 4 });
+    expect(native.props.selection).toEqual({ start: 4, end: 4 });
   });
 });

--- a/apps/mobile/src/__tests__/newSessionVoiceInput.test.tsx
+++ b/apps/mobile/src/__tests__/newSessionVoiceInput.test.tsx
@@ -65,15 +65,16 @@ const hiddenStyle = findOne((node): node is ts.PropertyAssignment =>
 const composer = findOne((node): node is ts.JsxSelfClosingElement =>
   ts.isJsxSelfClosingElement(node) && node.tagName.getText(source) === 'MobileComposerInputRow');
 const propNames = ['inputStyle', 'caretHidden', 'value', 'placeholder', 'selection', 'onPressIn'];
-const expressions = propNames.map((name) => {
+function composerExpression(name: string) {
   const prop = composer.attributes.properties.find((node) =>
     ts.isJsxAttribute(node) && node.name.getText(source) === name);
   if (!prop || !ts.isJsxAttribute(prop) || !prop.initializer
     || !ts.isJsxExpression(prop.initializer) || !prop.initializer.expression) {
     throw new Error(`Missing composer expression: ${name}`);
   }
-  return `${name}: ${prop.initializer.expression.getText(source)}`;
-});
+  return prop.initializer.expression.getText(source);
+}
+const expressions = propNames.map((name) => `${name}: ${composerExpression(name)}`);
 const compiled = ts.transpileModule(`function pageProps(bindings) {
   const { Platform, voiceIsListening, draft, finishVoiceRecording, composerPlaceholder, firstMessageSelection } = bindings;
   const styles = { inputVoiceHidden: ${hiddenStyle.initializer.getText(source)} };
@@ -81,6 +82,124 @@ const compiled = ts.transpileModule(`function pageProps(bindings) {
 }`, { compilerOptions: { target: ts.ScriptTarget.ES2022 } }).outputText;
 const pageProps = new Function(`${compiled}; return pageProps;`)() as
   (bindings: Record<string, unknown>) => Partial<MobileComposerInputRowProps>;
+
+// Run the actual page callbacks across a deferred stop(), including native
+// selection echoes and typing, instead of asserting the source of a guard.
+const draftCallback = findOne((node): node is ts.PropertyAssignment =>
+  ts.isPropertyAssignment(node) && node.name.getText(source) === 'onDraftChanged');
+const stopCallback = findOne((node): node is ts.VariableDeclaration =>
+  ts.isVariableDeclaration(node) && node.name.getText(source) === 'finishVoiceRecording');
+if (!stopCallback.initializer || !ts.isCallExpression(stopCallback.initializer)) {
+  throw new Error('Missing finishVoiceRecording callback');
+}
+type Selection = { start: number; end: number };
+const compiledVoice = ts.transpileModule(`function voiceCallbacks(bindings) {
+  const { voiceSelectionUserOwnedRef, voiceRecordingActiveRef, voiceStopInFlightRef,
+    firstMessageRef, firstMessageSelectionRef, setFirstMessageSelection, setFirstMessageDraft,
+    voiceControllerSessionRef, voiceStartupSeqRef, voiceStartupInFlightRef, voiceState,
+    setVoiceState, setVoiceError, setAudioModeAsync, requestAnimationFrame,
+    firstMessageInputRef, formatRemoteError } = bindings;
+  return {
+    publish: ${draftCallback.initializer.getText(source)},
+    select: ${composerExpression('onSelectionChange')},
+    type: ${composerExpression('onChangeText')},
+    stop: ${stopCallback.initializer.arguments[0].getText(source)},
+  };
+}`, { compilerOptions: { target: ts.ScriptTarget.ES2022 } }).outputText;
+const voiceCallbacks = new Function(`${compiledVoice}; return voiceCallbacks;`)() as
+  (bindings: Record<string, unknown>) => {
+    publish: (text: string, selection?: Selection) => void;
+    select: (event: { nativeEvent: { selection: Selection } }) => void;
+    type: (text: string) => void;
+    stop: () => Promise<string | null>;
+  };
+
+function pendingVoiceStop() {
+  const firstMessageRef = { current: '前后' };
+  const firstMessageSelectionRef = { current: { start: 1, end: 1 } };
+  let controlledSelection = firstMessageSelectionRef.current;
+  let completeStop!: (draft: string) => void;
+  const stopGate = new Promise<string>((resolve) => { completeStop = resolve; });
+  const setNativeProps = vi.fn();
+  const callbacks = voiceCallbacks({
+    firstMessageRef, firstMessageSelectionRef,
+    voiceSelectionUserOwnedRef: { current: false },
+    voiceRecordingActiveRef: { current: true }, voiceStopInFlightRef: { current: false },
+    voiceStartupSeqRef: { current: 1 }, voiceStartupInFlightRef: { current: false },
+    voiceControllerSessionRef: { current: { stop: () => stopGate } },
+    voiceState: 'listening', setVoiceState: vi.fn(), setVoiceError: vi.fn(),
+    setFirstMessageSelection: (next: Selection) => { controlledSelection = next; },
+    setFirstMessageDraft: (text: string) => { firstMessageRef.current = text; },
+    setAudioModeAsync: async () => undefined,
+    requestAnimationFrame: (callback: () => void) => callback(),
+    firstMessageInputRef: { current: { setNativeProps } }, formatRemoteError: String,
+  });
+  return {
+    ...callbacks,
+    selection: () => controlledSelection,
+    move: (start: number, end = start) => callbacks.select({ nativeEvent: { selection: { start, end } } }),
+    complete: () => completeStop(firstMessageRef.current), setNativeProps,
+    insert: (text: string) => firstMessageRef.current.slice(0, controlledSelection.start)
+      + text + firstMessageRef.current.slice(controlledSelection.end),
+  };
+}
+
+describe('new-session selection during dictation stop', () => {
+  it.each([false, true])('follows final ASR and refinement without a user move (partial=%s)', async (partial) => {
+    const voice = pendingVoiceStop();
+    if (partial) voice.publish('前识别后', { start: 3, end: 3 });
+    const stop = voice.stop();
+    voice.move(partial ? 3 : 1); // unchanged native echo must not claim the caret
+    voice.publish('前原始转写后', { start: 5, end: 5 });
+    expect(voice.selection()).toEqual({ start: 5, end: 5 });
+    voice.move(5); // echo of the controlled final ASR selection
+    voice.publish('前润色后', { start: 3, end: 3 });
+    expect(voice.selection()).toEqual({ start: 3, end: 3 });
+    voice.complete();
+    expect(await stop).toBe('前润色后');
+    expect(voice.setNativeProps).toHaveBeenCalledWith({ selection: { start: 3, end: 3 } });
+    expect(voice.insert('!')).toBe('前润色!后');
+  });
+
+  it('preserves a user range across final ASR and refinement', async () => {
+    const voice = pendingVoiceStop();
+    voice.publish('前识别后', { start: 3, end: 3 });
+    const stop = voice.stop();
+    voice.move(0, 1);
+    voice.publish('前原始转写后', { start: 5, end: 5 });
+    voice.publish('前润色后', { start: 3, end: 3 });
+    voice.complete();
+    await stop;
+    expect(voice.selection()).toEqual({ start: 0, end: 1 });
+    expect(voice.insert('!')).toBe('!润色后');
+  });
+
+  it('keeps user ownership after moving away and back to the old insertion point', async () => {
+    const voice = pendingVoiceStop();
+    voice.publish('前识别后', { start: 3, end: 3 });
+    const stop = voice.stop();
+    voice.move(0);
+    voice.move(3);
+    voice.publish('前更长转写后', { start: 5, end: 5 });
+    voice.complete();
+    await stop;
+    expect(voice.selection()).toEqual({ start: 3, end: 3 });
+  });
+
+  it('claims the caret on native typing before its selection event arrives', async () => {
+    const voice = pendingVoiceStop();
+    const stop = voice.stop();
+    voice.type('前!后');
+    voice.publish('前!转写后', { start: 4, end: 4 });
+    expect(voice.selection()).toEqual({ start: 1, end: 1 });
+    voice.move(2);
+    voice.publish('前!润色结果后', { start: 6, end: 6 });
+    voice.complete();
+    await stop;
+    expect(voice.selection()).toEqual({ start: 2, end: 2 });
+    expect(voice.insert('?')).toBe('前!?润色结果后');
+  });
+});
 
 Object.assign(globalThis, { IS_REACT_ACT_ENVIRONMENT: true });
 let root: Root | undefined;

--- a/apps/mobile/src/__tests__/newSessionVoiceInput.test.tsx
+++ b/apps/mobile/src/__tests__/newSessionVoiceInput.test.tsx
@@ -76,7 +76,8 @@ function composerExpression(name: string) {
 }
 const expressions = propNames.map((name) => `${name}: ${composerExpression(name)}`);
 const compiled = ts.transpileModule(`function pageProps(bindings) {
-  const { Platform, voiceIsListening, draft, finishVoiceRecording, composerPlaceholder, firstMessageSelection } = bindings;
+  const { Platform, voiceIsListening, draft, finishVoiceRecording, composerPlaceholder, firstMessageSelection,
+    voiceStopGestureSelectionGuardRef } = bindings;
   const styles = { inputVoiceHidden: ${hiddenStyle.initializer.getText(source)} };
   return { ${expressions.join(',\n')} };
 }`, { compilerOptions: { target: ts.ScriptTarget.ES2022 } }).outputText;
@@ -95,14 +96,16 @@ if (!stopCallback.initializer || !ts.isCallExpression(stopCallback.initializer))
 type Selection = { start: number; end: number };
 const compiledVoice = ts.transpileModule(`function voiceCallbacks(bindings) {
   const { voiceSelectionUserOwnedRef, voiceRecordingActiveRef, voiceStopInFlightRef,
+    voiceStopGestureSelectionGuardRef,
     firstMessageRef, firstMessageSelectionRef, setFirstMessageSelection, setFirstMessageDraft,
     voiceControllerSessionRef, voiceStartupSeqRef, voiceStartupInFlightRef, voiceState,
     setVoiceState, setVoiceError, setAudioModeAsync, requestAnimationFrame,
-    firstMessageInputRef, formatRemoteError } = bindings;
+    firstMessageInputRef, formatRemoteError, voiceIsListening, finishVoiceRecording } = bindings;
   return {
     publish: ${draftCallback.initializer.getText(source)},
     select: ${composerExpression('onSelectionChange')},
     type: ${composerExpression('onChangeText')},
+    press: ${composerExpression('onPressIn')},
     stop: ${stopCallback.initializer.arguments[0].getText(source)},
   };
 }`, { compilerOptions: { target: ts.ScriptTarget.ES2022 } }).outputText;
@@ -111,6 +114,7 @@ const voiceCallbacks = new Function(`${compiledVoice}; return voiceCallbacks;`)(
     publish: (text: string, selection?: Selection, replacement?: Selection & { text: string }) => void;
     select: (event: { nativeEvent: { selection: Selection } }) => void;
     type: (text: string) => void;
+    press: () => void;
     stop: () => Promise<string | null>;
   };
 
@@ -119,11 +123,14 @@ function pendingVoiceStop(initialDraft = '前后') {
   const firstMessageSelectionRef = { current: { start: 1, end: 1 } };
   let controlledSelection = firstMessageSelectionRef.current;
   let completeStop!: (draft: string) => void;
+  let finishVoiceRecording!: () => Promise<string | null>;
+  let activeStop: Promise<string | null> | undefined;
   const stopGate = new Promise<string>((resolve) => { completeStop = resolve; });
   const setNativeProps = vi.fn();
   const callbacks = voiceCallbacks({
     firstMessageRef, firstMessageSelectionRef,
     voiceSelectionUserOwnedRef: { current: false },
+    voiceStopGestureSelectionGuardRef: { current: false },
     voiceRecordingActiveRef: { current: true }, voiceStopInFlightRef: { current: false },
     voiceStartupSeqRef: { current: 1 }, voiceStartupInFlightRef: { current: false },
     voiceControllerSessionRef: { current: { stop: () => stopGate } },
@@ -133,12 +140,17 @@ function pendingVoiceStop(initialDraft = '前后') {
     setAudioModeAsync: async () => undefined,
     requestAnimationFrame: (callback: () => void) => callback(),
     firstMessageInputRef: { current: { setNativeProps } }, formatRemoteError: String,
+    voiceIsListening: true, finishVoiceRecording: () => {
+      activeStop = callbacks.stop();
+      return activeStop;
+    },
   });
   return {
     ...callbacks,
     selection: () => controlledSelection,
     move: (start: number, end = start) => callbacks.select({ nativeEvent: { selection: { start, end } } }),
     complete: () => completeStop(firstMessageRef.current), setNativeProps,
+    press: () => { callbacks.press(); return activeStop; },
     insert: (text: string) => firstMessageRef.current.slice(0, controlledSelection.start)
       + text + firstMessageRef.current.slice(controlledSelection.end),
   };
@@ -180,6 +192,20 @@ describe('new-session selection during dictation stop', () => {
     await stop;
     expect(voice.selection()).toEqual({ start: 4, end: 4 });
     expect(voice.insert('?')).toBe('前词后!?');
+  });
+
+  it('ignores the selection event caused by the stop gesture, then accepts a later user move', async () => {
+    const voice = pendingVoiceStop();
+    voice.publish('前识别后', { start: 3, end: 3 });
+    const stop = voice.press();
+    voice.move(5); // native selection change caused by the same stop press
+    voice.publish('前原始转写后', { start: 5, end: 5 });
+    expect(voice.selection()).toEqual({ start: 5, end: 5 });
+    voice.move(0); // a real user move during stop owns the selection
+    voice.publish('前润色后', { start: 3, end: 3 });
+    voice.complete();
+    expect(await stop).toBe('前润色后');
+    expect(voice.selection()).toEqual({ start: 0, end: 0 });
   });
 
   it.each([false, true])('follows final ASR and refinement without a user move (partial=%s)', async (partial) => {
@@ -255,7 +281,8 @@ function mountInput() {
       value: draft, onChangeText: vi.fn(), onPasteImages: vi.fn(),
       ...pageProps({ Platform: { OS: native.platform }, voiceIsListening: listening,
         draft: { firstMessage: draft }, firstMessageSelection: selection,
-        finishVoiceRecording, composerPlaceholder: 'Draft' }),
+        finishVoiceRecording, composerPlaceholder: 'Draft',
+        voiceStopGestureSelectionGuardRef: { current: false } }),
       inputOverlay: listening ? createElement('span', { 'data-testid': 'preview' }, draft) : null,
     })));
   }

--- a/apps/mobile/src/__tests__/newSessionWorkspaceEffects.test.tsx
+++ b/apps/mobile/src/__tests__/newSessionWorkspaceEffects.test.tsx
@@ -30,6 +30,7 @@ const declarations = new Set([
   'appliedDefaultDeviceKeyRef', 'userTouchedDeviceRef', 'userTouchedWorkspaceRef',
   'patchDraft', 'selectWorkingDir', 'rememberWorkingDirForDevice', 'selectDialogueWorkspace',
   'selectRecentProject', 'openProjectBrowse',
+  'firstMessageRef', 'firstMessageSelectionRef', 'firstMessageSelection',
 ]);
 const effectMarkers = new Set([
   'drainStashedNewSessionDraft', 'readNewSessionPreferences',
@@ -64,6 +65,7 @@ for (const name of [...declarations, ...effectMarkers]) {
 
 interface WorkspaceState {
   draft: NewSessionDraft;
+  firstMessageSelection: { start: number; end: number };
   selectedDeviceId: string;
   newSessionPreferencesLoaded: boolean;
   selectDialogueWorkspace(): void;
@@ -91,7 +93,7 @@ const compiled = ts.transpileModule(`function usePageWorkspace(bindings) {
     setDraft((current) => current.workspaceKind === 'project' ? { ...current, workingDir: '' } : current);
   };
   return { draft, selectedDeviceId, newSessionPreferencesLoaded,
-    selectDialogueWorkspace, selectRecentProject, openProjectBrowse, switchDevice };
+    firstMessageSelection, selectDialogueWorkspace, selectRecentProject, openProjectBrowse, switchDevice };
 }`, { compilerOptions: { target: ts.ScriptTarget.ES2022 } }).outputText;
 const usePageWorkspace = new Function(`${compiled}; return usePageWorkspace;`)() as
   (bindings: Record<string, unknown>) => WorkspaceState;
@@ -119,7 +121,8 @@ function mountWorkspace(options: { initialWorkingDir?: string; restoredKind?: Ne
     saveNewSessionPreferences: vi.fn(async () => {}),
     drainStashedNewSessionDraft: vi.fn(() => options.restoredKind ? {
       draft: { ...DEFAULT_NEW_SESSION_DRAFT, workspaceKind: options.restoredKind,
-        workingDir: options.restoredKind === 'project' ? '/restored/project' : '' },
+        workingDir: options.restoredKind === 'project' ? '/restored/project' : '',
+        firstMessage: 'restored draft' },
       attachments: [], deviceId: 'a', deviceName: 'A',
     } : null),
     loadBrowsePath: vi.fn(async () => {}), setDevicePickerOpen: vi.fn(),
@@ -182,6 +185,7 @@ describe('new session workspace page effects', () => {
     expect(page.current.draft).toMatchObject({ workspaceKind: kind,
       workingDir: kind === 'project' ? '/restored/project' : '' });
     expect(page.current.selectedDeviceId).toBe('a');
+    expect(page.current.firstMessageSelection).toEqual({ start: 'restored draft'.length, end: 'restored draft'.length });
     expect(page.bindings.pickInitialNewSessionWorkspace).not.toHaveBeenCalled();
   });
 

--- a/apps/mobile/src/__tests__/simRebuildScript.test.ts
+++ b/apps/mobile/src/__tests__/simRebuildScript.test.ts
@@ -58,4 +58,24 @@ describe('sim-rebuild script invariants', () => {
     expect(source).toContain('`platform=iOS Simulator,id=${simulatorUdid}`');
     expect(source).toContain("'-destination', simulatorDestination");
   });
+
+  it('uses the Android debug client on Windows without invoking xcrun', () => {
+    expect(source).toContain("import { ensureWindowsAndroidEmulator } from './lib/android-simulator.mjs';");
+    expect(source).toContain("import { resolveJavaRuntimeEnv } from './java-runtime-env.mjs';");
+    expect(source).toContain("if (process.platform === 'win32') {");
+    expect(source).toContain('await rebuildAndroidSimulator();');
+    expect(source).toContain("'--platform', 'android', '--no-install'");
+    expect(source).toContain("const gradle = process.platform === 'win32' ? 'gradlew.bat' : './gradlew';");
+    expect(source).toContain("process.env.ComSpec || 'cmd.exe'");
+    expect(source).toContain('resolvePnpmInvocation');
+    expect(source).toContain('function runPnpm(args, opts = {})');
+    expect(source).toContain("run(gradle, ['assembleDebug']");
+    expect(source).toContain("'install', '-r', apk");
+    expect(source).toContain("'shell', 'monkey', '-p', packageName, '1'");
+
+    const windowsBranch = source.indexOf("if (process.platform === 'win32') {");
+    const iosXcrunProbe = source.indexOf("capture('xcrun', ['simctl', 'list', 'devices', 'booted'])");
+    expect(windowsBranch).toBeGreaterThanOrEqual(0);
+    expect(iosXcrunProbe).toBeGreaterThan(windowsBranch);
+  });
 });

--- a/apps/mobile/src/__tests__/simRebuildScript.test.ts
+++ b/apps/mobile/src/__tests__/simRebuildScript.test.ts
@@ -66,12 +66,18 @@ describe('sim-rebuild script invariants', () => {
     expect(source).toContain('await rebuildAndroidSimulator();');
     expect(source).toContain("'--platform', 'android', '--no-install'");
     expect(source).toContain("const gradle = process.platform === 'win32' ? 'gradlew.bat' : './gradlew';");
-    expect(source).toContain("process.env.ComSpec || 'cmd.exe'");
+    expect(source).toContain("run('cmd.exe', ['/d', '/s', '/c', 'gradlew.bat assembleDebug']");
+    expect(source).not.toContain('process.env.ComSpec');
     expect(source).toContain('resolvePnpmInvocation');
     expect(source).toContain('function runPnpm(args, opts = {})');
     expect(source).toContain("run(gradle, ['assembleDebug']");
     expect(source).toContain("'install', '-r', apk");
     expect(source).toContain("'shell', 'monkey', '-p', packageName, '1'");
+    expect(source).toContain('function ensureMetroOwnershipBeforeLaunch(packageName)');
+    const metroGate = source.indexOf('if (!ensureMetroOwnershipBeforeLaunch(packageName)) return;');
+    const androidLaunch = source.indexOf("'shell', 'monkey', '-p', packageName, '1'");
+    expect(metroGate).toBeGreaterThanOrEqual(0);
+    expect(metroGate).toBeLessThan(androidLaunch);
 
     const windowsBranch = source.indexOf("if (process.platform === 'win32') {");
     const iosXcrunProbe = source.indexOf("capture('xcrun', ['simctl', 'list', 'devices', 'booted'])");

--- a/apps/mobile/src/__tests__/simRebuildScript.test.ts
+++ b/apps/mobile/src/__tests__/simRebuildScript.test.ts
@@ -65,6 +65,8 @@ describe('sim-rebuild script invariants', () => {
     expect(source).toContain('const ownership = probeMetroOwnership(8081);');
     expect(source).toContain('if (!await portInUse(8081)) return true;');
     expect(source).toContain('Metro on 8081 is occupied, but its listener PID could not be verified.');
+    expect(source).toContain('Metro on 8081 uses region');
+    expect(source).toContain('ownership.region');
     expect(source).toContain("import { resolveJavaRuntimeEnv } from './java-runtime-env.mjs';");
     expect(source).toContain('const androidTools = process.platform === \'win32\'');
     expect(source).toContain('requireTools: !buildOnly');

--- a/apps/mobile/src/__tests__/simRebuildScript.test.ts
+++ b/apps/mobile/src/__tests__/simRebuildScript.test.ts
@@ -65,6 +65,7 @@ describe('sim-rebuild script invariants', () => {
     expect(source).toContain('const ownership = probeMetroOwnership(8081);');
     expect(source).toContain("import { resolveJavaRuntimeEnv } from './java-runtime-env.mjs';");
     expect(source).toContain('const androidTools = process.platform === \'win32\'');
+    expect(source).toContain('requireTools: !buildOnly');
     expect(source).toContain('ANDROID_SDK_ROOT: sdkRoot, ANDROID_HOME: sdkRoot');
     expect(source).toContain("if (process.platform === 'win32') {");
     expect(source).toContain('await rebuildAndroidSimulator();');

--- a/apps/mobile/src/__tests__/simRebuildScript.test.ts
+++ b/apps/mobile/src/__tests__/simRebuildScript.test.ts
@@ -60,10 +60,12 @@ describe('sim-rebuild script invariants', () => {
   });
 
   it('uses the Android debug client on Windows without invoking xcrun', () => {
-    expect(source).toContain("import { ensureWindowsAndroidEmulator } from './lib/android-simulator.mjs';");
+    expect(source).toContain("import { ensureWindowsAndroidEmulator, resolveAndroidSdkTools } from './lib/android-simulator.mjs';");
     expect(source).toContain("probeMetroOwnership");
     expect(source).toContain('const ownership = probeMetroOwnership(8081);');
     expect(source).toContain("import { resolveJavaRuntimeEnv } from './java-runtime-env.mjs';");
+    expect(source).toContain('const androidTools = process.platform === \'win32\'');
+    expect(source).toContain('ANDROID_SDK_ROOT: sdkRoot, ANDROID_HOME: sdkRoot');
     expect(source).toContain("if (process.platform === 'win32') {");
     expect(source).toContain('await rebuildAndroidSimulator();');
     expect(source).toContain("'--platform', 'android', '--no-install'");

--- a/apps/mobile/src/__tests__/simRebuildScript.test.ts
+++ b/apps/mobile/src/__tests__/simRebuildScript.test.ts
@@ -63,6 +63,8 @@ describe('sim-rebuild script invariants', () => {
     expect(source).toContain("import { ensureWindowsAndroidEmulator, resolveAndroidSdkTools } from './lib/android-simulator.mjs';");
     expect(source).toContain("probeMetroOwnership");
     expect(source).toContain('const ownership = probeMetroOwnership(8081);');
+    expect(source).toContain('if (!await portInUse(8081)) return true;');
+    expect(source).toContain('Metro on 8081 is occupied, but its listener PID could not be verified.');
     expect(source).toContain("import { resolveJavaRuntimeEnv } from './java-runtime-env.mjs';");
     expect(source).toContain('const androidTools = process.platform === \'win32\'');
     expect(source).toContain('requireTools: !buildOnly');
@@ -79,7 +81,7 @@ describe('sim-rebuild script invariants', () => {
     expect(source).toContain("'install', '-r', apk");
     expect(source).toContain("'shell', 'monkey', '-p', packageName, '1'");
     expect(source).toContain('function ensureMetroOwnershipBeforeLaunch(packageName)');
-    const metroGate = source.indexOf('if (!ensureMetroOwnershipBeforeLaunch(packageName)) return;');
+    const metroGate = source.indexOf('if (!await ensureMetroOwnershipBeforeLaunch(packageName)) return;');
     const androidLaunch = source.indexOf("'shell', 'monkey', '-p', packageName, '1'");
     expect(metroGate).toBeGreaterThanOrEqual(0);
     expect(metroGate).toBeLessThan(androidLaunch);

--- a/apps/mobile/src/__tests__/simRebuildScript.test.ts
+++ b/apps/mobile/src/__tests__/simRebuildScript.test.ts
@@ -61,6 +61,8 @@ describe('sim-rebuild script invariants', () => {
 
   it('uses the Android debug client on Windows without invoking xcrun', () => {
     expect(source).toContain("import { ensureWindowsAndroidEmulator } from './lib/android-simulator.mjs';");
+    expect(source).toContain("probeMetroOwnership");
+    expect(source).toContain('const ownership = probeMetroOwnership(8081);');
     expect(source).toContain("import { resolveJavaRuntimeEnv } from './java-runtime-env.mjs';");
     expect(source).toContain("if (process.platform === 'win32') {");
     expect(source).toContain('await rebuildAndroidSimulator();');

--- a/apps/mobile/src/session/MobileComposerInputRow.tsx
+++ b/apps/mobile/src/session/MobileComposerInputRow.tsx
@@ -131,6 +131,7 @@ export interface MobileComposerInputRowProps {
   multilineShape?: boolean;
   onBlur?: TextInputProps['onBlur'];
   onChangeText: (value: string) => void;
+  onKeyPress?: TextInputProps['onKeyPress'];
   onSelectionChange?: TextInputProps['onSelectionChange'];
   onContentSizeChange?: TextInputProps['onContentSizeChange'];
   onFocus?: TextInputProps['onFocus'];
@@ -207,6 +208,7 @@ export function MobileComposerInputRow({
   multilineShape,
   onBlur,
   onChangeText,
+  onKeyPress,
   onSelectionChange,
   onContentSizeChange,
   onFocus,
@@ -267,6 +269,7 @@ export function MobileComposerInputRow({
       onBlur={onBlur}
       onChangeText={onChangeText}
       onSelectionChange={onSelectionChange}
+      onKeyPress={onKeyPress}
       onContentSizeChange={onContentSizeChange}
       onFocus={onFocus}
       onPressIn={onPressIn}

--- a/apps/mobile/src/session/MobileComposerInputRow.tsx
+++ b/apps/mobile/src/session/MobileComposerInputRow.tsx
@@ -154,6 +154,7 @@ export interface MobileComposerInputRowProps {
   onPressIn?: TextInputProps['onPressIn'];
   placeholder: string;
   placeholderTextColor: string;
+  selection?: TextInputProps['selection'];
   /** 顶部居中的拖拽调高 grabber（ComposerResizeGrabber），absolute 定位不占布局空间。 */
   resizeHandle?: ReactNode;
   rowStyle?: StyleProp<ViewStyle>;
@@ -215,6 +216,7 @@ export function MobileComposerInputRow({
   onPressIn,
   placeholder,
   placeholderTextColor,
+  selection,
   resizeHandle,
   rowStyle,
   scrollEnabled,
@@ -271,6 +273,7 @@ export function MobileComposerInputRow({
       placeholder={placeholder}
       placeholderTextColor={placeholderTextColor}
       scrollEnabled={scrollEnabled}
+      selection={selection}
       selectionColor={selectionColor}
       style={[
         styles.input,

--- a/apps/mobile/src/session/mobileVoiceController.ts
+++ b/apps/mobile/src/session/mobileVoiceController.ts
@@ -200,6 +200,7 @@ export function createMobileVoiceControllerSession(
   let asrStartError: unknown = null;
   let audioFailureError: Error | null = null;
   let voiceInsertion: MobileVoiceDraftInsertion | null = null;
+  let voiceInsertionReplacementRange: { start: number; end: number } | null = null;
   let publishedVoiceInsertion: MobileVoiceDraftInsertion | null = null;
   let voiceInsertionSegmentIds: string[] = [];
   let voiceInsertionTouched = false;
@@ -232,8 +233,12 @@ export function createMobileVoiceControllerSession(
     pendingDraftToPublish = null;
     // The first insertion can change selected atoms even when its text is identical.
     if (lastPublishedDraft === draft && (!voiceInsertion || publishedVoiceInsertion)) return;
-    const replacement = publishedVoiceInsertion && voiceInsertion
-      ? { ...publishedVoiceInsertion, text: voiceInsertion.text }
+    const replacement = voiceInsertion
+      ? publishedVoiceInsertion
+        ? { ...publishedVoiceInsertion, text: voiceInsertion.text }
+        : voiceInsertionReplacementRange
+          ? { ...voiceInsertionReplacementRange, text: voiceInsertion.text }
+          : undefined
       : undefined;
     lastPublishedDraft = draft;
     publishedVoiceInsertion = voiceInsertion ? { ...voiceInsertion } : null;
@@ -344,6 +349,11 @@ export function createMobileVoiceControllerSession(
       : appendVoiceTranscriptDraftWithRange(currentDraft, normalized);
     if (!result.insertion) return undefined;
     voiceInsertion = result.insertion;
+    voiceInsertionReplacementRange = options.initialSelection && currentDraft === baseDraft
+      ? 'atomRange' in options.initialSelection
+        ? null
+        : { start: options.initialSelection.start, end: options.initialSelection.end }
+      : { start: result.insertion.start, end: result.insertion.start };
     voiceInsertionSegmentIds = segmentIds;
     latestDraft = result.draft;
     publishDraftChange(latestDraft, mode);


### PR DESCRIPTION
## 这次改了什么

### 摘要

修复 Android 听写停止后继续输入时光标位置错误，并补齐 Windows CN Android 模拟器的开发构建路径。

### 变更类型

- [ ] feat 新功能
- [x] fix 缺陷修复
- [ ] refactor / perf 重构或性能优化
- [ ] docs / test / chore 文档、测试或工程维护
- [ ] 其他：

### 范围

- 关联 Issue / 需求：跟进已合并的 PR #4119，修复听写停止后继续输入的位置问题。
- 本 PR 包含：移动端听写停止后的受控选区同步、补全选择和暂存草稿恢复的选区同步、Windows CN Android 模拟器重建脚本及相关测试。
- 明确不包含：语音识别服务和原生依赖变更。
- 用户可见变化：听写停止后、选择 / 补全后以及返回编辑恢复草稿后，继续输入会从正确的光标位置开始。
- 是否存在 breaking change：无。

### UI 变化

- 引用的设计规范：docs/design-rules/DESIGN.md §4（输入控件）与 §10（主题 Token）；本次只同步 TextInput 的受控选区和草稿 ref，不改变布局、颜色、圆角或交互视觉，沿用现有 Light / Dark themed 样式。
- 平台：Android CN 开发包；iOS 保持原有逻辑。

## 怎么验证的

### 自动验证

pnpm --filter mobile exec vitest run src/__tests__/newSession.test.ts src/__tests__/newSessionWorkspaceEffects.test.tsx src/__tests__/composerPalette.test.ts

结果：通过（146 项测试）。

pnpm test:unit:related

结果：通过，仅运行 apps/mobile 相关单测；未执行全仓 unit。

pnpm --filter mobile run --if-present typecheck

结果：通过。

pnpm check:dco

结果：通过。

### 手工验证

- Windows CN Android 开发包构建成功，APK 安装并启动 com.xd.cindycn。
- Metro bundle 确认使用 CN 配置和 cindy/silent-hopper 分支源码。

### 未执行的验证

- 未完成真实在线 ASR 手工回归：模拟器没有可用登录凭据，无法进入听写页面；相关停止后输入行为由定向测试覆盖。
- 未执行全仓 unit：按用户要求不运行。

## 风险

### 风险分类

- [ ] 无已知风险
- [ ] SQLite / migration
- [ ] system prompt
- [ ] 协议兼容
- [ ] 权限 / 安全 / 用户数据
- [ ] 存量插件兼容（批准状态 / 指纹 / manifest 校验 / 安装布局 / 包格式）
- [ ] 原生层 / fingerprint / OTA
- [x] 跨平台差异
- [ ] 其他：

### 影响与回滚

- 影响范围：移动端输入选区状态和 Windows 本地 Android 模拟器重建脚本；iOS 原生分支保持原逻辑。
- 冷更分析：不触发 mobile runtime fingerprint；未修改 app.json、app.config.js、eas.json、依赖、lockfile 或 apps/mobile/package.json。
- 回滚 / 降级方式：回退本 PR 提交即可恢复原有行为。

### 提交前检查

- [x] 已 review 完整 diff
- [x] 每个 commit 都带 DCO 签名
- [x] UI 改动已在「UI 变化」注明引用的设计规范章节
- [x] 未提交凭证、令牌或授权文件
- [x] 已确认测试结果或说明未执行原因
