### PR TITLE
fix(desktop): 按需检查当前任务的 worktree

### DIFF
--- a/apps/desktop/scripts/benchmark-worktree-focus.mjs
+++ b/apps/desktop/scripts/benchmark-worktree-focus.mjs
@@ -97,6 +97,7 @@ async function run(version, dirs, scenario) {
     exports: {},
     path,
     gitExec,
+    createCwdProbeScheduler: (probe) => probe,
     GitExecError: Error,
     getManagedWorktreeBasePath: () => null,
     log: {
@@ -139,10 +140,12 @@ async function run(version, dirs, scenario) {
       },
     },
   });
-  vm.runInContext(functionsOnly(version.manager, ['detectCwd']), context);
-  const names = ['isLiveOfficialPath', 'WorktreeProvider'];
-  if (version.label === 'after')
-    names.push('FOREGROUND_REFRESH_INTERVAL_MS', 'VALIDATION_CONCURRENCY');
+  const managerNames = version.label === 'after' ? ['detectCwd', 'detectCwdOnce'] : ['detectCwd'];
+  vm.runInContext(functionsOnly(version.manager, managerNames), context);
+  context.detectCwd = context.exports.detectCwd;
+  const names = version.label === 'after'
+    ? ['WorktreeProvider']
+    : ['isLiveOfficialPath', 'WorktreeProvider', 'FOREGROUND_REFRESH_INTERVAL_MS', 'VALIDATION_CONCURRENCY'];
   vm.runInContext(functionsOnly(version.provider, names, true), context);
   const drain = async () => {
     const deadline = performance.now() + 120_000;
@@ -161,10 +164,10 @@ async function run(version, dirs, scenario) {
     statsReset();
     now = scenario === 'warm-focus' ? 1000 : 20_000;
     start = performance.now();
-    listeners.get('focus')();
+    listeners.get('focus')?.();
     // All ten focus events arrive while the first Git probe is still running.
     await tick();
-    for (let i = 1; i < 10; i++) listeners.get('focus')();
+    for (let i = 1; i < 10; i++) listeners.get('focus')?.();
     await drain();
   }
   const immediate = {

--- a/apps/desktop/scripts/benchmark-worktree-focus.mjs
+++ b/apps/desktop/scripts/benchmark-worktree-focus.mjs
@@ -47,7 +47,27 @@ function functionsOnly(sourceText, names, tsx = false) {
       (ts.isVariableStatement(s) &&
         s.declarationList.declarations.some((d) => names.includes(d.name.getText(ast)))),
   );
-  assert.equal(statements.length, names.length, 'benchmark source extraction drifted');
+  const found = new Set();
+  for (const statement of statements) {
+    if (ts.isFunctionDeclaration(statement) && statement.name) found.add(statement.name.text);
+    if (ts.isVariableStatement(statement)) {
+      for (const declaration of statement.declarationList.declarations) {
+        found.add(declaration.name.getText(ast));
+      }
+    }
+  }
+  assert.deepEqual(
+    [...new Set(names)].filter((name) => found.has(name)),
+    [...new Set(names)],
+    'benchmark source extraction drifted',
+  );
+  // Exported constants can reference a function declared later in the source.
+  // Hoist declarations in the extracted fragment so the VM behaves like a module.
+  statements.sort((a, b) => {
+    const aFunction = ts.isFunctionDeclaration(a) ? 0 : 1;
+    const bFunction = ts.isFunctionDeclaration(b) ? 0 : 1;
+    return aFunction - bFunction;
+  });
   return ts.transpileModule(statements.map((s) => s.getText(ast)).join('\n'), {
     compilerOptions: {
       target: ts.ScriptTarget.ES2022,
@@ -76,6 +96,7 @@ async function run(version, dirs, scenario) {
     probes = 0,
     now = 0;
   let metas = {};
+  let snapshot = { metas: {}, invalid: new Set() };
   const effects = [],
     disposers = [],
     listeners = new Map(),
@@ -110,12 +131,19 @@ async function run(version, dirs, scenario) {
     useRef: (current) => ({ current }),
     useCallback: (fn) => fn,
     useMemo: (fn) => fn(),
-    useState: () => [
-      metas,
-      (value) => {
-        metas = typeof value === 'function' ? value(metas) : value;
-      },
-    ],
+    useState: () => version.label === 'after'
+      ? [
+          snapshot,
+          (value) => {
+            snapshot = typeof value === 'function' ? value(snapshot) : value;
+          },
+        ]
+      : [
+          metas,
+          (value) => {
+            metas = typeof value === 'function' ? value(metas) : value;
+          },
+        ],
     useEffect: (fn) => effects.push(fn),
     Date: { now: () => now },
     setTimeout: (fn, ms) => {
@@ -140,12 +168,26 @@ async function run(version, dirs, scenario) {
       },
     },
   });
-  const managerNames = version.label === 'after' ? ['detectCwd', 'detectCwdOnce'] : ['detectCwd'];
+  const managerNames = ['detectCwd'];
+  if (version.manager.includes('detectCwdOnce')) managerNames.push('detectCwdOnce');
   vm.runInContext(functionsOnly(version.manager, managerNames), context);
   context.detectCwd = context.exports.detectCwd;
   const names = version.label === 'after'
     ? ['WorktreeProvider']
-    : ['isLiveOfficialPath', 'WorktreeProvider', 'FOREGROUND_REFRESH_INTERVAL_MS', 'VALIDATION_CONCURRENCY'];
+    : ['isLiveOfficialPath', 'WorktreeProvider'];
+  // These knobs existed in the pre-snapshot implementation but were removed
+  // from later baselines. Extract them only when the selected ref still has
+  // the declarations, so the benchmark remains usable with either baseline.
+  if (version.label === 'before') {
+    for (const name of [
+      'FOREGROUND_REFRESH_INTERVAL_MS',
+      'VALIDATION_CONCURRENCY',
+      'BACKGROUND_CHECK_INTERVAL_MS',
+      'BACKGROUND_CHECK_CONCURRENCY',
+    ]) {
+      if (version.provider.includes(name)) names.push(name);
+    }
+  }
   vm.runInContext(functionsOnly(version.provider, names, true), context);
   const drain = async () => {
     const deadline = performance.now() + 120_000;
@@ -159,7 +201,10 @@ async function run(version, dirs, scenario) {
   context.WorktreeProvider({ children: null });
   effects.forEach((fn) => disposers.push(fn()));
   await drain();
-  assert.equal(Object.keys(metas).length, dirs.length);
+  assert.equal(
+    Object.keys(version.label === 'after' ? snapshot.metas : metas).length,
+    dirs.length,
+  );
   if (scenario !== 'cold') {
     statsReset();
     now = scenario === 'warm-focus' ? 1000 : 20_000;
@@ -191,7 +236,10 @@ async function run(version, dirs, scenario) {
       elapsedMs: +(performance.now() - start).toFixed(2),
     };
   }
-  assert.equal(Object.keys(metas).length, dirs.length);
+  assert.equal(
+    Object.keys(version.label === 'after' ? snapshot.metas : metas).length,
+    dirs.length,
+  );
   disposers.forEach((dispose) => dispose?.());
   return { version: version.label, worktrees: dirs.length, scenario, ...immediate, trailing };
 }

--- a/apps/desktop/src/main/__tests__/worktreeDetectCwd.test.ts
+++ b/apps/desktop/src/main/__tests__/worktreeDetectCwd.test.ts
@@ -82,6 +82,26 @@ describe('detectCwd → isInsideWorktree (I-1 fix)', () => {
     expect(gitExecMock).toHaveBeenCalledTimes(6);
   });
 
+  it('coalesces concurrent directory probes but reads fresh Git state after completion', async () => {
+    const wtPath = path.resolve('/tmp/feature');
+    const gitState = {
+      toplevel: wtPath,
+      gitDir: path.resolve('/tmp/repo/.git/worktrees/feature'),
+      gitCommonDir: path.resolve('/tmp/repo/.git'),
+      branch: 'before',
+    };
+    setupGitMock(gitState);
+    const first = detectCwd(wtPath);
+    const duplicate = detectCwd(path.join(wtPath, '.'));
+    expect(duplicate).toBe(first);
+    expect((await first).currentBranch).toBe('before');
+    expect(gitExecMock).toHaveBeenCalledTimes(6);
+
+    setupGitMock({ ...gitState, branch: 'after' });
+    expect((await detectCwd(wtPath)).currentBranch).toBe('after');
+    expect(gitExecMock).toHaveBeenCalledTimes(12);
+  });
+
   it('returns isInsideWorktree=true for a Cindy-created worktree', async () => {
     const baseRepo = path.resolve('/tmp/repo');
     const wtPath = path.join(baseRepo, '.cindy-worktrees', 'jolly-turing');

--- a/apps/desktop/src/main/__tests__/worktreeDetectCwd.test.ts
+++ b/apps/desktop/src/main/__tests__/worktreeDetectCwd.test.ts
@@ -8,9 +8,10 @@
  *   2) 外部工具 (CC Desktop / 手工 git worktree add) 创建的 worktree (路径不含)
  */
 
-import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import path from 'node:path';
 import { detectCwd } from '../worktree/WorktreeManager';
+import { GitExecError, type GitExecOpts } from '../worktree/gitExec';
 
 // ── mock gitExec, 控制 detectCwd 看到的 git 输出 ──────────────────────────
 const { gitExecMock } = vi.hoisted(() => ({
@@ -20,13 +21,19 @@ vi.mock('../worktree/gitExec', async () => {
   const actual = await vi.importActual<typeof import('../worktree/gitExec')>('../worktree/gitExec');
   return {
     ...actual,
-    gitExec: (args: readonly string[], cwd?: string) => gitExecMock(args, cwd),
+    gitExec: (args: readonly string[], cwd?: string, opts?: GitExecOpts) => gitExecMock(args, cwd, opts),
   };
 });
 
 beforeEach(() => {
   gitExecMock.mockReset();
 });
+
+afterEach(() => vi.useRealTimers());
+
+function timeoutError() {
+  return new GitExecError({ args: ['rev-parse'], exitCode: null, stderr: 'timed out', stdout: '', timedOut: true });
+}
 
 /**
  * 通用 mock builder: 按 args[0] 分派, 让测试用例只关心两个 rev-parse 输出。
@@ -55,6 +62,59 @@ function setupGitMock(opts: {
 }
 
 describe('detectCwd → isInsideWorktree (I-1 fix)', () => {
+  it('releases all four hung probes after Git timeout and allows queued work and same-path retries', async () => {
+    vi.useFakeTimers();
+    gitExecMock.mockImplementation((_args: readonly string[], _cwd: string, opts: GitExecOpts) => (
+      new Promise((_resolve, reject) => setTimeout(() => reject(timeoutError()), opts.timeoutMs))
+    ));
+    const pending = Array.from({ length: 4 }, (_, i) => detectCwd(path.resolve('/tmp', `hung-${i}`)));
+    const failures = pending.map((p) => expect(p).rejects.toMatchObject({ timedOut: true }));
+    const queued = detectCwd('/tmp/healthy');
+    await vi.advanceTimersByTimeAsync(0);
+    expect(gitExecMock).toHaveBeenCalledTimes(4);
+    expect(gitExecMock.mock.calls.every((call) => call[2]?.timeoutMs === 10_000)).toBe(true);
+    gitExecMock.mockResolvedValue({ stdout: '/tmp/healthy\nmain\n.git\n.git\n' });
+    await vi.advanceTimersByTimeAsync(10_000);
+    await Promise.all(failures);
+    await expect(queued).resolves.toMatchObject({ isGitRepo: true });
+    await expect(detectCwd('/tmp/hung-0')).resolves.toMatchObject({ isGitRepo: true });
+    // 超时不进入 fallback，也不缓存拒绝结果。
+    expect(gitExecMock).toHaveBeenCalledTimes(6);
+  });
+
+  it.each(['--version', '--show-toplevel', '--abbrev-ref', '--git-dir', '--git-common-dir'])(
+    'bounds fallback %s and does not report a timeout as a missing directory',
+    async (command) => {
+      gitExecMock.mockImplementation(async (args: readonly string[], _cwd: string, opts: GitExecOpts) => {
+        expect(opts.timeoutMs).toBe(10_000);
+        if (args.length > 3) return { stdout: 'ambiguous' };
+        if (args.includes(command)) throw timeoutError();
+        return { stdout: args.includes('--show-toplevel') ? '/repo' : '.git' };
+      });
+      await expect(detectCwd('/repo')).rejects.toMatchObject({ timedOut: true });
+    },
+  );
+
+  it('waits for both fallback metadata processes to settle before returning a timeout', async () => {
+    let finishOther!: () => void;
+    gitExecMock.mockImplementation(async (args: readonly string[]) => {
+      if (args.length > 3) return { stdout: 'ambiguous' };
+      if (args.includes('--git-dir')) throw timeoutError();
+      if (args.includes('--git-common-dir')) {
+        await new Promise<void>((resolve) => { finishOther = resolve; });
+      }
+      return { stdout: args.includes('--show-toplevel') ? '/repo' : '.git' };
+    });
+    const pending = detectCwd('/repo');
+    let settled = false;
+    void pending.then(() => { settled = true; }, () => { settled = true; });
+    for (let i = 0; i < 20; i++) await Promise.resolve();
+    expect(finishOther).toBeTypeOf('function');
+    expect(settled).toBe(false);
+    finishOther();
+    await expect(pending).rejects.toMatchObject({ timedOut: true });
+  });
+
   it.each([
     ['linked', '/repo/.git/worktrees/feature', '/repo/.git', 'feature', true],
     ['main', '.git', '.git', 'main', false],

--- a/apps/desktop/src/main/__tests__/worktreeManagerRemove.test.ts
+++ b/apps/desktop/src/main/__tests__/worktreeManagerRemove.test.ts
@@ -854,6 +854,7 @@ describe('removeWorktreeForSession', () => {
       expect(gitExecMock).toHaveBeenCalledWith(
         ['rev-parse', '--show-toplevel', '--abbrev-ref', 'HEAD', '--git-dir', '--git-common-dir'],
         BASE_REPO,
+        { timeoutMs: 10_000 },
       );
     });
 

--- a/apps/desktop/src/main/__tests__/worktreeReveal.test.ts
+++ b/apps/desktop/src/main/__tests__/worktreeReveal.test.ts
@@ -8,10 +8,12 @@
 
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import path from 'node:path';
+import { extractIpcError } from '../../renderer/utils/ipcError';
 
 // ── mock electron 的 ipcMain + shell ──────────────────────────────────────
 const showItemInFolderMock = vi.fn();
 const suggestNameMock = vi.fn();
+const detectCwdMock = vi.fn();
 type Handler = (event: unknown, req: unknown) => unknown | Promise<unknown>;
 const handlers = new Map<string, Handler>();
 const ipcMainMock = {
@@ -40,7 +42,7 @@ vi.mock('../worktree/worktreeStore', () => ({
 // 业务依赖 (避免触达真实 git 调用)
 vi.mock('../worktree/WorktreeManager', () => ({
   createWorktree: vi.fn(),
-  detectCwd: vi.fn(),
+  detectCwd: (...args: unknown[]) => detectCwdMock(...args),
   getForSession: vi.fn(),
   listAll: vi.fn(),
   suggestName: (...args: unknown[]) => suggestNameMock(...args),
@@ -52,6 +54,7 @@ let registerWorktreeIpc: typeof import('../worktree/index').registerWorktreeIpc;
 beforeEach(async () => {
   showItemInFolderMock.mockReset();
   suggestNameMock.mockReset();
+  detectCwdMock.mockReset();
   getAllPathsMock.mockReset();
   handlers.clear();
   if (!registerWorktreeIpc) {
@@ -72,6 +75,46 @@ function callSuggestName(req: unknown): Promise<unknown> {
   if (!handler) throw new Error('worktree:suggest-name handler not registered');
   return Promise.resolve(handler({}, req));
 }
+
+async function callDetectCwd(req: unknown): Promise<unknown> {
+  const handler = handlers.get('worktree:detect-cwd');
+  if (!handler) throw new Error('worktree:detect-cwd handler not registered');
+  return handler({}, req);
+}
+
+describe('worktree:detect-cwd IPC contract', () => {
+  it.each([true, false])('preserves successful probe responses (inside worktree: %s)', async (inside) => {
+    const cwd = path.resolve('/tmp/worktree');
+    const response = { isGitRepo: inside, isInsideWorktree: inside, gitInstalled: true };
+    detectCwdMock.mockResolvedValue(response);
+    await expect(callDetectCwd({ cwd })).resolves.toEqual(response);
+    expect(detectCwdMock).toHaveBeenCalledExactlyOnceWith(cwd);
+  });
+
+  it.each(['timeout', 'unexpected'])('encodes %s failures without leaking raw Git details', async (kind) => {
+    const { GitExecError } = await import('../worktree/gitExec');
+    const cwd = path.resolve('/private/worktree');
+    const rawError = kind === 'timeout'
+      ? new GitExecError({
+          args: ['rev-parse'], exitCode: null, timedOut: true,
+          stdout: 'private output', stderr: `probe stalled in ${cwd}`,
+        })
+      : new Error(`failed in ${cwd}`);
+    detectCwdMock.mockRejectedValue(rawError);
+
+    const error = await callDetectCwd({ cwd }).catch((err: unknown) => err);
+    expect(error).toBeInstanceOf(Error);
+    expect(error).toMatchObject({ code: 'INTERNAL' });
+    // Electron only preserves the message; the renderer must still decode it.
+    const serialized = new Error(`Error invoking remote method 'worktree:detect-cwd': ${(error as Error).toString()}`);
+    expect(extractIpcError(serialized)).toEqual({
+      code: 'INTERNAL', message: 'Worktree directory probe failed',
+    });
+    expect(serialized.message).not.toContain(cwd);
+    expect(serialized.message).not.toContain('rev-parse');
+    expect(serialized.message).not.toContain('private output');
+  });
+});
 
 describe('worktree:suggest-name IPC contract', () => {
   it('wraps the generated name in the declared response shape', async () => {

--- a/apps/desktop/src/main/worktree/WorktreeManager.ts
+++ b/apps/desktop/src/main/worktree/WorktreeManager.ts
@@ -25,6 +25,7 @@ import {
   validateWorktreeName,
 } from './nameGenerator';
 import { readAttachedWorktreeBranch } from './attachedBranch';
+import { createCwdProbeScheduler } from './cwdProbeScheduler';
 import { classifyError, type ClassifyInput } from './errorClassifier';
 import {
   gitExec,
@@ -395,7 +396,9 @@ async function withPrecreatedWorktreeOperationQueue<T>(
 /**
  * 探测 cwd 状态: 是否 git repo / 是否在 worktree 内 / git 是否可用 / 当前分支 / repo root
  */
-export async function detectCwd(cwd: string): Promise<DetectCwdResp> {
+export const detectCwd = createCwdProbeScheduler(detectCwdOnce);
+
+async function detectCwdOnce(cwd: string): Promise<DetectCwdResp> {
   // One Git process returns the same snapshot that previously needed five.
   // Unborn HEADs, older Git versions and newline-containing paths retain the
   // individual-query fallback below rather than changing the IPC contract.

--- a/apps/desktop/src/main/worktree/WorktreeManager.ts
+++ b/apps/desktop/src/main/worktree/WorktreeManager.ts
@@ -398,6 +398,9 @@ async function withPrecreatedWorktreeOperationQueue<T>(
  */
 export const detectCwd = createCwdProbeScheduler(detectCwdOnce);
 
+// 每条探测命令都有界；复用 gitExec 的整树清理后才释放 scheduler slot。
+const CWD_PROBE_GIT_OPTS = { timeoutMs: 10_000 };
+
 async function detectCwdOnce(cwd: string): Promise<DetectCwdResp> {
   // One Git process returns the same snapshot that previously needed five.
   // Unborn HEADs, older Git versions and newline-containing paths retain the
@@ -406,6 +409,7 @@ async function detectCwdOnce(cwd: string): Promise<DetectCwdResp> {
     const { stdout } = await gitExec(
       ['rev-parse', '--show-toplevel', '--abbrev-ref', 'HEAD', '--git-dir', '--git-common-dir'],
       cwd,
+      CWD_PROBE_GIT_OPTS,
     );
     const lines = stdout.trim().split(/\r?\n/);
     if (lines.length === 4 && lines.every((line) => line.trim().length > 0)) {
@@ -419,7 +423,8 @@ async function detectCwdOnce(cwd: string): Promise<DetectCwdResp> {
         ...(branch !== 'HEAD' ? { currentBranch: branch.trim() } : {}),
       };
     }
-  } catch {
+  } catch (err) {
+    if (err instanceof GitExecError && err.timedOut) throw err;
     // Preserve the existing partial results and error classification.
   }
   const out: DetectCwdResp = {
@@ -430,8 +435,9 @@ async function detectCwdOnce(cwd: string): Promise<DetectCwdResp> {
   };
   // 1. git --version 探测安装
   try {
-    await gitExec(['--version']);
+    await gitExec(['--version'], undefined, CWD_PROBE_GIT_OPTS);
   } catch (err) {
+    if (err instanceof GitExecError && err.timedOut) throw err;
     if (err instanceof GitExecError && err.cause?.code === 'ENOENT') {
       out.gitInstalled = false;
       return out;
@@ -443,13 +449,14 @@ async function detectCwdOnce(cwd: string): Promise<DetectCwdResp> {
 
   // 2. rev-parse --show-toplevel: 拿 repo 根
   try {
-    const { stdout } = await gitExec(['rev-parse', '--show-toplevel'], cwd);
+    const { stdout } = await gitExec(['rev-parse', '--show-toplevel'], cwd, CWD_PROBE_GIT_OPTS);
     const toplevel = stdout.trim();
     if (toplevel) {
       out.isGitRepo = true;
       out.repoRoot = path.resolve(toplevel);
     }
-  } catch {
+  } catch (err) {
+    if (err instanceof GitExecError && err.timedOut) throw err;
     out.isGitRepo = false;
   }
 
@@ -457,10 +464,11 @@ async function detectCwdOnce(cwd: string): Promise<DetectCwdResp> {
 
   // 3. 当前分支
   try {
-    const { stdout } = await gitExec(['rev-parse', '--abbrev-ref', 'HEAD'], cwd);
+    const { stdout } = await gitExec(['rev-parse', '--abbrev-ref', 'HEAD'], cwd, CWD_PROBE_GIT_OPTS);
     const branch = stdout.trim();
     if (branch && branch !== 'HEAD') out.currentBranch = branch;
-  } catch {
+  } catch (err) {
+    if (err instanceof GitExecError && err.timedOut) throw err;
     // ignore — 分支信息不影响主流程
   }
 
@@ -470,16 +478,28 @@ async function detectCwdOnce(cwd: string): Promise<DetectCwdResp> {
   // 这种判断是 git 自己用来区分主/linked worktree 的方式, 不依赖目录命名约定 ——
   // 任何工具(CC Desktop / 手工 git worktree add 等) 创建的 worktree 都能被检出。
   try {
-    const [{ stdout: gitDirRaw }, { stdout: gitCommonDirRaw }] = await Promise.all([
-      gitExec(['rev-parse', '--git-dir'], cwd),
-      gitExec(['rev-parse', '--git-common-dir'], cwd),
+    // 任一命令失败后仍等另一条完成清理，不能提前释放目录探测槽位。
+    const results = await Promise.allSettled([
+      gitExec(['rev-parse', '--git-dir'], cwd, CWD_PROBE_GIT_OPTS),
+      gitExec(['rev-parse', '--git-common-dir'], cwd, CWD_PROBE_GIT_OPTS),
     ]);
+    for (const result of results) {
+      if (result.status === 'rejected' && result.reason instanceof GitExecError && result.reason.timedOut) {
+        throw result.reason;
+      }
+    }
+    const [gitDirResult, commonDirResult] = results;
+    if (gitDirResult.status === 'rejected') throw gitDirResult.reason;
+    if (commonDirResult.status === 'rejected') throw commonDirResult.reason;
+    const gitDirRaw = gitDirResult.value.stdout;
+    const gitCommonDirRaw = commonDirResult.value.stdout;
     const gitDir = path.resolve(cwd, gitDirRaw.trim());
     const gitCommonDir = path.resolve(cwd, gitCommonDirRaw.trim());
     if (gitDir && gitCommonDir && gitDir !== gitCommonDir) {
       out.isInsideWorktree = true;
     }
-  } catch {
+  } catch (err) {
+    if (err instanceof GitExecError && err.timedOut) throw err;
     // 解析失败 → 兜底走托管目录名启发式, 至少识别出 Cindy 自己创建的 worktree
     const normalizedRepoRoot = out.repoRoot?.replace(/\\/g, '/');
     if (normalizedRepoRoot && getManagedWorktreeBasePath(normalizedRepoRoot) != null) {

--- a/apps/desktop/src/main/worktree/__tests__/cwdProbeScheduler.test.ts
+++ b/apps/desktop/src/main/worktree/__tests__/cwdProbeScheduler.test.ts
@@ -1,0 +1,70 @@
+import path from 'node:path';
+import { describe, expect, it, vi } from 'vitest';
+
+import { createCwdProbeScheduler } from '../cwdProbeScheduler';
+
+function deferred<T>() {
+  let resolve!: (value: T) => void;
+  let reject!: (reason: unknown) => void;
+  const promise = new Promise<T>((res, rej) => { resolve = res; reject = rej; });
+  return { promise, resolve, reject };
+}
+
+describe('cwd probe scheduling', () => {
+  it('shares normalized paths both in flight and in the queue, with at most four active probes', async () => {
+    const gates = Array.from({ length: 69 }, () => deferred<number>());
+    let active = 0;
+    let peak = 0;
+    const probe = vi.fn(async (cwd: string) => {
+      active++;
+      peak = Math.max(peak, active);
+      try {
+        return await gates[Number(path.basename(cwd))].promise;
+      } finally {
+        active--;
+      }
+    });
+    const detect = createCwdProbeScheduler(probe);
+    const pending = gates.map((_, i) => detect(`/tmp/wt/${i}`));
+    expect(detect('/tmp/wt/0/../0')).toBe(pending[0]);
+    expect(detect('/tmp/wt/68/')).toBe(pending[68]);
+    await Promise.resolve();
+    expect(probe).toHaveBeenCalledTimes(4);
+    for (let i = 0; i < gates.length; i++) gates[i].resolve(i);
+    expect(await Promise.all(pending)).toEqual(gates.map((_, i) => i));
+    expect(peak).toBe(4);
+    expect(active).toBe(0);
+    expect(probe).toHaveBeenCalledTimes(69);
+  });
+
+  it('releases failed probes and does not cache completed or rejected results', async () => {
+    const gates = Array.from({ length: 4 }, () => deferred<string>());
+    const probe = vi.fn((cwd: string) => {
+      const i = Number(path.basename(cwd));
+      return i < 4 ? gates[i].promise : Promise.resolve('queued');
+    });
+    const detect = createCwdProbeScheduler(probe);
+    const pending = gates.map((_, i) => detect(`/tmp/wt/${i}`));
+    const failed = expect(pending[0]).rejects.toThrow('failed');
+    const queued = detect('/tmp/wt/4');
+    gates[0].reject(new Error('failed'));
+    await failed;
+    expect(await queued).toBe('queued');
+    for (let i = 1; i < gates.length; i++) gates[i].resolve('done');
+    await Promise.all(pending.slice(1));
+
+    probe.mockResolvedValue('new branch');
+    expect(await detect('/tmp/wt/0')).toBe('new branch');
+    expect(await detect('/tmp/wt/4')).toBe('new branch');
+    expect(probe).toHaveBeenCalledTimes(7);
+  });
+
+  it('also releases a slot when the probe throws synchronously', async () => {
+    const probe = vi.fn<(_cwd: string) => Promise<string>>()
+      .mockImplementationOnce(() => { throw new Error('spawn failed'); })
+      .mockResolvedValue('ok');
+    const detect = createCwdProbeScheduler(probe);
+    await expect(detect('/tmp/wt/0')).rejects.toThrow('spawn failed');
+    expect(await detect('/tmp/wt/0')).toBe('ok');
+  });
+});

--- a/apps/desktop/src/main/worktree/__tests__/gitExec.test.ts
+++ b/apps/desktop/src/main/worktree/__tests__/gitExec.test.ts
@@ -227,6 +227,7 @@ describe('gitExec timeoutMs', () => {
       name: 'GitExecError',
       exitCode: null,
       stderr: expect.stringContaining('timed out after 1000ms'),
+      timedOut: true,
     });
     vi.advanceTimersByTime(1000);
     await flushMicrotasks();
@@ -618,6 +619,28 @@ describe('gitExec dubious-ownership safe.directory', () => {
   async function flushDeep() {
     for (let i = 0; i < 20; i += 1) await Promise.resolve();
   }
+
+  it.each(['read', 'add', 'retry'])('bounds the safe.directory %s stage with the caller timeout', async (stage) => {
+    setPlatform('linux');
+    const { calls, cbs } = installSequenceMock();
+    const pending = gitExec(['rev-parse'], '/repo', { timeoutMs: 100 });
+    const rejected = expect(pending).rejects.toMatchObject({ timedOut: true });
+    cbs[0](new Error('dubious'), '', "fatal: detected dubious ownership in repository at '/repo'");
+    await flushDeep();
+    if (stage !== 'read') {
+      cbs[1](Object.assign(new Error('absent'), { code: 1 }), '', '');
+      await flushDeep();
+    }
+    if (stage === 'retry') {
+      cbs[2](null, '', '');
+      await flushDeep();
+    }
+    const expectedCalls = stage === 'read' ? 2 : stage === 'add' ? 3 : 4;
+    expect(calls).toHaveLength(expectedCalls);
+    await vi.advanceTimersByTimeAsync(100);
+    await rejected;
+    expect(calls).toHaveLength(expectedCalls);
+  });
 
   it('首次 dubious ownership → 幂等加入 safe.directory 后重试一次', async () => {
     const { calls, cbs } = installSequenceMock();

--- a/apps/desktop/src/main/worktree/cwdProbeScheduler.ts
+++ b/apps/desktop/src/main/worktree/cwdProbeScheduler.ts
@@ -1,0 +1,48 @@
+import path from 'node:path';
+
+/** Bound native process creation and share pending probes; never cache completed Git state. */
+export function createCwdProbeScheduler<T>(probe: (cwd: string) => Promise<T>) {
+  const pending = new Map<string, Promise<T>>();
+  const queue: Array<() => void> = [];
+  let active = 0;
+
+  const drain = () => {
+    while (active < 4 && queue.length > 0) {
+      queue.shift()!();
+    }
+  };
+
+  return (cwd: string): Promise<T> => {
+    const key = path.resolve(cwd);
+    const existing = pending.get(key);
+    if (existing) return existing;
+
+    let resolve!: (value: T) => void;
+    let reject!: (reason: unknown) => void;
+    const result = new Promise<T>((res, rej) => {
+      resolve = res;
+      reject = rej;
+    });
+    pending.set(key, result);
+    queue.push(() => {
+      active++;
+      const finish = () => {
+        pending.delete(key);
+        active--;
+        drain();
+      };
+      void Promise.resolve().then(() => probe(key)).then(
+        (value) => {
+          finish();
+          resolve(value);
+        },
+        (error: unknown) => {
+          finish();
+          reject(error);
+        },
+      );
+    });
+    drain();
+    return result;
+  };
+}

--- a/apps/desktop/src/main/worktree/cwdProbeScheduler.ts
+++ b/apps/desktop/src/main/worktree/cwdProbeScheduler.ts
@@ -1,6 +1,8 @@
 import path from 'node:path';
 
-/** Bound native process creation and share pending probes; never cache completed Git state. */
+/** Bound native process creation and share pending probes; never cache completed Git state.
+ * The probe must bound its Git commands and await cleanup before settling.
+ */
 export function createCwdProbeScheduler<T>(probe: (cwd: string) => Promise<T>) {
   const pending = new Map<string, Promise<T>>();
   const queue: Array<() => void> = [];

--- a/apps/desktop/src/main/worktree/gitExec.ts
+++ b/apps/desktop/src/main/worktree/gitExec.ts
@@ -40,6 +40,8 @@ export class GitExecError extends Error {
   readonly stdout: string;
   /** 原始底层错误对象, spawn ENOENT 等用得上。 */
   readonly cause?: NodeJS.ErrnoException;
+  /** 超时是未知状态，探测调用方不得把它当作「目录不存在」。 */
+  readonly timedOut: boolean;
 
   constructor(opts: {
     args: readonly string[];
@@ -47,6 +49,7 @@ export class GitExecError extends Error {
     stderr: string;
     stdout: string;
     cause?: NodeJS.ErrnoException;
+    timedOut?: boolean;
   }) {
     super(
       `git ${opts.args.join(' ')} failed${
@@ -59,6 +62,7 @@ export class GitExecError extends Error {
     this.stderr = opts.stderr;
     this.stdout = opts.stdout;
     this.cause = opts.cause;
+    this.timedOut = opts.timedOut ?? false;
   }
 }
 
@@ -450,6 +454,7 @@ function execFileOnce(
               ? `timed out after ${timeoutMs}ms; process tree terminated`
               : `timed out after ${timeoutMs}ms; process tree cleanup unconfirmed`,
             stdout: '',
+            timedOut: true,
           }),
         );
       }, timeoutMs);
@@ -515,9 +520,9 @@ export function safeDirectorySpellings(p: string): string[] {
  * 失败)必须向上抛,否则会把「读不到」误判成「未配置」而重复 --add,反而制造出
  * 本条修复要避免的重复条目。
  */
-async function readGlobalSafeDirectories(): Promise<string[]> {
+async function readGlobalSafeDirectories(opts?: Pick<GitExecOpts, 'timeoutMs'>): Promise<string[]> {
   try {
-    const { stdout } = await execFileOnce(['config', '--global', '--get-all', 'safe.directory']);
+    const { stdout } = await execFileOnce(['config', '--global', '--get-all', 'safe.directory'], undefined, opts);
     return stdout
       .split('\n')
       .map((s) => s.trim())
@@ -537,7 +542,7 @@ async function readGlobalSafeDirectories(): Promise<string[]> {
  * dubious-ownership 错误还给调用方,而不是退化成并发写入重复条目。用底层
  * execFileOnce 而非 gitExec, 防止递归进入 dubious-ownership 分支。
  */
-async function ensureGlobalSafeDirectory(targetPath: string): Promise<void> {
+async function ensureGlobalSafeDirectory(targetPath: string, opts?: Pick<GitExecOpts, 'timeoutMs'>): Promise<void> {
   await withCrossProcessLock(
     globalSafeDirectoryLockPath(),
     { label: 'git-safe-directory', waitMs: 1_000 },
@@ -547,8 +552,8 @@ async function ensureGlobalSafeDirectory(targetPath: string): Promise<void> {
       }
       // 统一成 git 的拼写再读写: 让幂等检查与后续清理命中同一个值。
       const normalized = normalizeSafeDirectorySpelling(targetPath);
-      if ((await readGlobalSafeDirectories()).some((p) => p === normalized)) return;
-      await execFileOnce(['config', '--global', '--add', 'safe.directory', normalized]);
+      if ((await readGlobalSafeDirectories(opts)).some((p) => p === normalized)) return;
+      await execFileOnce(['config', '--global', '--add', 'safe.directory', normalized], undefined, opts);
     },
   );
 }
@@ -578,17 +583,19 @@ export async function gitExec(
       const dubiousPath = extractDubiousPath(err.stderr) ?? cwd;
       if (dubiousPath) {
         try {
-          await ensureGlobalSafeDirectory(dubiousPath);
+          await ensureGlobalSafeDirectory(dubiousPath, { timeoutMs: opts?.timeoutMs });
           // 配完 safe.directory 后重试原命令
           return await execFileOnce(args, cwd, opts);
         } catch (cause) {
-          // 对外错误契约不变: 调用方/classifier 仍拿到原始 dubious-ownership 错误。
+          // 普通修复失败仍返回原始 dubious-ownership 错误；超时单独向上传递。
           // 但 ensureGlobalSafeDirectory 的真实失败(--get-all 权限/锁冲突/配置损坏,
           // 或拿不到跨进程锁)不能被静默吞掉 —— 先落日志保住诊断信息, 再抛原始错误。
           log.warn(
             `gitExec auto safe.directory add failed for ${dubiousPath}:`,
             cause instanceof Error ? cause.message : String(cause),
           );
+          // 探测超时不能被误判为目录失效，也不能继续 fallback 启动新的 Git。
+          if (cause instanceof GitExecError && cause.timedOut) throw cause;
           throw err;
         }
       }

--- a/apps/desktop/src/main/worktree/index.ts
+++ b/apps/desktop/src/main/worktree/index.ts
@@ -13,6 +13,7 @@ import * as WorktreeManager from './WorktreeManager';
 import * as worktreeStore from './worktreeStore';
 import { getWorktreeRestoreStatus, restoreWorktreeForSession } from './restore';
 import { createLogger } from '../logger';
+import { throwIpcError } from '../utils/ipcValidate';
 
 const log = createLogger('worktree');
 
@@ -51,9 +52,15 @@ export function registerWorktreeIpc(ipcMain: IpcMain = ipcMainType): void {
     WorktreeManager.createWorktree(req),
   );
 
-  ipcMain.handle('worktree:detect-cwd', (_e, req: DetectCwdReq) =>
-    WorktreeManager.detectCwd(req.cwd),
-  );
+  ipcMain.handle('worktree:detect-cwd', async (_e, req: DetectCwdReq) => {
+    try {
+      return await WorktreeManager.detectCwd(req.cwd);
+    } catch {
+      // Keep probe failure distinct from a missing directory, without sending
+      // raw Git output or internal paths across the IPC boundary.
+      throwIpcError('INTERNAL', 'Worktree directory probe failed');
+    }
+  });
 
   ipcMain.handle('worktree:get-for-session', (_e, sessionId: string) =>
     WorktreeManager.getForSession(sessionId),

--- a/apps/desktop/src/renderer/__tests__/worktreeContextRecycleRefresh.test.tsx
+++ b/apps/desktop/src/renderer/__tests__/worktreeContextRecycleRefresh.test.tsx
@@ -1,6 +1,6 @@
 // @vitest-environment jsdom
 
-/** WorktreeContext 有界后台校验；聚焦读缓存，创建/回收事件按 sessionId 增量更新。 */
+/** WorktreeContext 只共享快照与 active 任务的探测结果；创建/回收按 sessionId 增量更新。 */
 
 import { act, cleanup, render, waitFor } from '@testing-library/react';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
@@ -9,7 +9,10 @@ import {
   WorktreeProvider,
   useWorktrees,
   useRefreshWorktreeForSession,
+  useReportWorktreeLiveness,
+  useWorktreeForSession,
 } from '@/contexts/WorktreeContext';
+import { useTaskInfoWorktree } from '@/features/cc-agent/sidebar/sessionWorktreeInfo';
 import { emitRefresh } from '@/lib/sessionsBus';
 
 vi.mock('@/lib/logger', () => ({
@@ -20,6 +23,7 @@ const mocks = {
   worktreeListAll: vi.fn(),
   worktreeGetForSession: vi.fn(),
   worktreeDetectCwd: vi.fn(),
+  findLinkedWorktree: vi.fn(),
   listeners: new Set<(payload: { sessionId: string }) => void>(),
   sessionCreatedListeners: new Set<
     (payload: { sessionId: string }, ownerStamp?: unknown) => void
@@ -46,10 +50,16 @@ function Probe() {
   );
 }
 
+function ActiveProbe() {
+  const info = useTaskInfoWorktree({ id: 'open', workingDir: '/repo' }, true, { observeTelemetry: true });
+  return <span data-testid="active">{info?.path ?? ''}</span>;
+}
+
 beforeEach(() => {
   mocks.worktreeListAll.mockReset();
   mocks.worktreeGetForSession.mockReset();
   mocks.worktreeDetectCwd.mockReset();
+  mocks.findLinkedWorktree.mockReset().mockResolvedValue(null);
   mocks.worktreeDetectCwd.mockResolvedValue({
     isInsideWorktree: true,
     isGitRepo: true,
@@ -63,6 +73,7 @@ beforeEach(() => {
       worktreeListAll: mocks.worktreeListAll,
       worktreeGetForSession: mocks.worktreeGetForSession,
       worktreeDetectCwd: mocks.worktreeDetectCwd,
+      gitContext: { findLinkedWorktree: mocks.findLinkedWorktree },
       onWorktreeChanged: (cb: (payload: { sessionId: string }) => void) => {
         mocks.listeners.add(cb);
         return () => mocks.listeners.delete(cb);
@@ -86,6 +97,89 @@ afterEach(() => {
 });
 
 describe('WorktreeContext recycle refresh', () => {
+  it('shares external deletion with sidebar badges, retains metadata for reopening and detects external restoration', async () => {
+    const meta = { sessionId: 'open', path: '/tmp/wt/open' };
+    mocks.worktreeListAll.mockResolvedValue([meta, { sessionId: 'idle', path: '/tmp/wt/idle' }]);
+    const content = (active: boolean) => <WorktreeProvider><Probe />{active && <ActiveProbe />}</WorktreeProvider>;
+    const view = render(content(true));
+    await act(async () => {});
+    expect(view.getByTestId('active').textContent).toBe(meta.path);
+
+    mocks.worktreeDetectCwd.mockResolvedValue({ isInsideWorktree: false });
+    await act(async () => { window.dispatchEvent(new Event('focus')); });
+    expect(view.getByTestId('active').textContent).toBe('');
+    expect(view.getByTestId('ids').textContent).toBe('idle:/tmp/wt/idle');
+
+    view.rerender(content(false));
+    mocks.worktreeDetectCwd.mockClear().mockResolvedValue({ isInsideWorktree: true });
+    view.rerender(content(true));
+    await act(async () => {});
+    expect(view.getByTestId('active').textContent).toBe(meta.path);
+    expect(view.getByTestId('ids').textContent).toContain('open:/tmp/wt/open');
+    expect(mocks.worktreeDetectCwd).toHaveBeenCalledExactlyOnceWith({ cwd: meta.path });
+    expect(mocks.worktreeListAll).toHaveBeenCalledOnce();
+    expect(mocks.worktreeGetForSession).not.toHaveBeenCalled();
+  });
+
+  it('rechecks same-path restoration through refreshSession without requiring a changed push or focus', async () => {
+    const meta = { sessionId: 'open', path: '/tmp/wt/open' };
+    mocks.worktreeListAll.mockResolvedValue([meta]);
+    mocks.worktreeDetectCwd.mockResolvedValue({ isInsideWorktree: false });
+    let refresh!: (sessionId: string) => Promise<void>;
+    function Actions() {
+      refresh = useRefreshWorktreeForSession();
+      return <><Probe /><ActiveProbe /></>;
+    }
+    const view = render(<WorktreeProvider><Actions /></WorktreeProvider>);
+    await act(async () => {});
+    expect(view.getByTestId('active').textContent).toBe('');
+    expect(view.getByTestId('ids').textContent).toBe('');
+
+    mocks.worktreeGetForSession.mockResolvedValue({ ...meta });
+    mocks.worktreeDetectCwd.mockClear().mockResolvedValue({ isInsideWorktree: true });
+    await act(async () => { await refresh('open'); });
+    expect(view.getByTestId('active').textContent).toBe(meta.path);
+    expect(view.getByTestId('ids').textContent).toBe(`open:${meta.path}`);
+    expect(mocks.worktreeDetectCwd).toHaveBeenCalledExactlyOnceWith({ cwd: meta.path });
+    expect(mocks.worktreeListAll).toHaveBeenCalledOnce();
+  });
+
+  it('does not hide a live worktree when its probe rejects', async () => {
+    mocks.worktreeListAll.mockResolvedValue([{ sessionId: 'open', path: '/tmp/wt/open' }]);
+    const view = render(<WorktreeProvider><Probe /><ActiveProbe /></WorktreeProvider>);
+    await act(async () => {});
+    mocks.worktreeDetectCwd.mockRejectedValue(new Error('probe timeout'));
+    await act(async () => { window.dispatchEvent(new Event('focus')); });
+    expect(view.getByTestId('active').textContent).toBe('/tmp/wt/open');
+    expect(view.getByTestId('ids').textContent).toBe('open:/tmp/wt/open');
+  });
+
+  it('ignores liveness reports captured before same-path restoration or recycling', async () => {
+    const meta = { sessionId: 'open', path: '/tmp/wt/open' };
+    mocks.worktreeListAll.mockResolvedValue([meta]);
+    let report!: ReturnType<typeof useReportWorktreeLiveness>;
+    let original!: NonNullable<ReturnType<typeof useWorktreeForSession>>;
+    let refresh!: (sessionId: string) => Promise<void>;
+    function Actions() {
+      report = useReportWorktreeLiveness();
+      original = useWorktreeForSession('open') ?? original;
+      refresh = useRefreshWorktreeForSession();
+      return <Probe />;
+    }
+    const view = render(<WorktreeProvider><Actions /></WorktreeProvider>);
+    await act(async () => {});
+    const oldMeta = original;
+    mocks.worktreeGetForSession.mockResolvedValue({ ...meta });
+    await act(async () => { await refresh('open'); });
+    await act(async () => { report(oldMeta, false); });
+    expect(view.getByTestId('ids').textContent).toBe('open:/tmp/wt/open');
+    mocks.worktreeGetForSession.mockResolvedValue(null);
+    await act(async () => { await refresh('open'); });
+    await act(async () => { report(original, true); });
+    expect(view.getByTestId('ids').textContent).toBe('');
+    expect(mocks.worktreeDetectCwd).not.toHaveBeenCalled();
+  });
+
   it('removes only the reported session without reloading the full snapshot', async () => {
     mocks.worktreeListAll.mockResolvedValueOnce([
       { sessionId: 'archived-one', path: '/tmp/wt/archived-one' },

--- a/apps/desktop/src/renderer/__tests__/worktreeContextRecycleRefresh.test.tsx
+++ b/apps/desktop/src/renderer/__tests__/worktreeContextRecycleRefresh.test.tsx
@@ -1,11 +1,15 @@
 // @vitest-environment jsdom
 
-/** WorktreeContext 全量校验只用于启动/聚焦；回收事件按 sessionId 增量更新。 */
+/** WorktreeContext 有界后台校验；聚焦读缓存，创建/回收事件按 sessionId 增量更新。 */
 
 import { act, cleanup, render, waitFor } from '@testing-library/react';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
-import { WorktreeProvider, useWorktrees } from '@/contexts/WorktreeContext';
+import {
+  WorktreeProvider,
+  useWorktrees,
+  useRefreshWorktreeForSession,
+} from '@/contexts/WorktreeContext';
 import { emitRefresh } from '@/lib/sessionsBus';
 
 vi.mock('@/lib/logger', () => ({
@@ -253,6 +257,30 @@ describe('WorktreeContext recycle refresh', () => {
     expect(mocks.worktreeDetectCwd).not.toHaveBeenCalled();
   });
 
+  it('refreshes explicit creation, recycling and restoration repeatedly without a full scan', async () => {
+    mocks.worktreeListAll.mockResolvedValue([]);
+    let refresh!: (sessionId: string) => Promise<void>;
+    function Actions() {
+      refresh = useRefreshWorktreeForSession();
+      return <Probe />;
+    }
+    const view = render(<WorktreeProvider><Actions /></WorktreeProvider>);
+    await act(async () => {});
+    for (let i = 0; i < 3; i++) {
+      mocks.worktreeGetForSession.mockResolvedValueOnce({
+        sessionId: 'restored', path: `/tmp/wt/restored-${i}`,
+      });
+      await act(async () => { await refresh('restored'); });
+      expect(view.getByTestId('ids').textContent).toBe(`restored:/tmp/wt/restored-${i}`);
+      mocks.worktreeGetForSession.mockResolvedValueOnce(null);
+      await act(async () => { emitWorktreeChanged('restored'); });
+      expect(view.getByTestId('ids').textContent).toBe('');
+    }
+    expect(mocks.worktreeListAll).toHaveBeenCalledOnce();
+    expect(mocks.worktreeDetectCwd).toHaveBeenCalledTimes(3);
+    expect(mocks.worktreeGetForSession).toHaveBeenCalledTimes(6);
+  });
+
   it('ignores remote session creation pushes for the local worktree cache', async () => {
     mocks.worktreeListAll.mockResolvedValueOnce([]);
     render(
@@ -273,114 +301,146 @@ describe('WorktreeContext recycle refresh', () => {
     expect(mocks.worktreeListAll).toHaveBeenCalledOnce();
   });
 
-  it('still performs a full validation when the window regains focus after the cooldown', async () => {
-    mocks.worktreeListAll.mockResolvedValue([]);
+  it('does not rescan 69 worktrees during repeated foreground/background switches', async () => {
+    mocks.worktreeListAll.mockResolvedValue(Array.from({ length: 69 }, (_, i) => ({
+      sessionId: `session-${i}`,
+      path: `/tmp/wt/${i}`,
+    })));
     render(
       <WorktreeProvider>
         <Probe />
       </WorktreeProvider>,
     );
-    await waitFor(() => expect(mocks.worktreeListAll).toHaveBeenCalledOnce());
+    await waitFor(() => expect(mocks.worktreeDetectCwd).toHaveBeenCalledTimes(69));
 
-    vi.spyOn(Date, 'now').mockReturnValue(Date.now() + 15_001);
-    act(() => window.dispatchEvent(new Event('focus')));
-
-    await waitFor(() => expect(mocks.worktreeListAll).toHaveBeenCalledTimes(2));
-  });
-
-  it('bounds probes and merges repeated focus while validation is in flight', async () => {
-    mocks.worktreeListAll.mockResolvedValue(
-      Array.from({ length: 6 }, (_, i) => ({
-        sessionId: String(i),
-        path: `/tmp/wt/${i}`,
-      })),
-    );
-    const releases: Array<() => void> = [];
-    let active = 0;
-    let peak = 0;
-    mocks.worktreeDetectCwd.mockImplementation(
-      () =>
-        new Promise((resolve) => {
-          peak = Math.max(peak, ++active);
-          releases.push(() => {
-            active--;
-            resolve({ isInsideWorktree: true });
-          });
-        }),
-    );
-    const view = render(
-      <WorktreeProvider>
-        <Probe />
-      </WorktreeProvider>,
-    );
-    await waitFor(() => expect(releases).toHaveLength(2));
-    act(() => {
-      for (let i = 0; i < 10; i++) window.dispatchEvent(new Event('focus'));
-    });
-    expect(mocks.worktreeListAll).toHaveBeenCalledOnce();
-    for (let i = 0; i < 3; i++) {
+    for (let i = 0; i < 20; i++) {
       await act(async () => {
-        releases.splice(0).forEach((release) => release());
+        window.dispatchEvent(new Event('blur'));
+        window.dispatchEvent(new Event('focus'));
       });
     }
-    expect(peak).toBe(2);
-    expect(mocks.worktreeDetectCwd).toHaveBeenCalledTimes(6);
-    expect(view.getByTestId('ids').textContent).toContain('5:/tmp/wt/5');
+
+    expect(mocks.worktreeListAll).toHaveBeenCalledOnce();
+    expect(mocks.worktreeDetectCwd).toHaveBeenCalledTimes(69);
   });
 
-  it('keeps badges during cooldown, applies recycle immediately, and checks external removal on the trailing refresh', async () => {
-    mocks.worktreeListAll.mockResolvedValue([
-      { sessionId: 'archived', path: '/tmp/wt/archived' },
-      { sessionId: 'external', path: '/tmp/wt/external' },
-    ]);
-    const view = render(
-      <WorktreeProvider>
-        <Probe />
-      </WorktreeProvider>,
-    );
-    await waitFor(() => expect(view.getByTestId('ids').textContent).toContain('external'));
+  it('shows the snapshot immediately and bounds pending scans across focus and timer ticks', async () => {
     vi.useFakeTimers();
-    act(() => {
-      for (let i = 0; i < 10; i++) window.dispatchEvent(new Event('focus'));
+    mocks.worktreeListAll.mockResolvedValue(Array.from({ length: 69 }, (_, i) => ({
+      sessionId: `session-${i}`,
+      path: `/tmp/wt/${i}`,
+    })));
+    const finish: Array<() => void> = [];
+    mocks.worktreeDetectCwd.mockImplementation(() => new Promise((resolve) => {
+      finish.push(() => resolve({ isInsideWorktree: true }));
+    }));
+    const view = render(<WorktreeProvider><Probe /></WorktreeProvider>);
+    await act(async () => {});
+    expect(view.getByTestId('ids').textContent).toContain('session-68:/tmp/wt/68');
+    expect(mocks.worktreeDetectCwd).toHaveBeenCalledTimes(4);
+
+    await act(async () => {
+      for (let i = 0; i < 20; i++) {
+        window.dispatchEvent(new Event('blur'));
+        window.dispatchEvent(new Event('focus'));
+      }
+      await vi.advanceTimersByTimeAsync(15 * 60_000);
     });
     expect(mocks.worktreeListAll).toHaveBeenCalledOnce();
-    expect(view.getByTestId('ids').textContent).toContain('external');
-    mocks.worktreeGetForSession.mockResolvedValue(null);
-    await act(async () => emitWorktreeChanged('archived'));
-    expect(view.getByTestId('ids').textContent).toBe('external:/tmp/wt/external');
-    mocks.worktreeListAll.mockResolvedValue([{ sessionId: 'external', path: '/tmp/wt/external' }]);
-    mocks.worktreeDetectCwd.mockResolvedValue({ isInsideWorktree: false });
-    await act(async () => vi.advanceTimersByTimeAsync(15_000));
-    expect(mocks.worktreeListAll).toHaveBeenCalledTimes(2);
-    expect(view.getByTestId('ids').textContent).toBe('');
+    expect(mocks.worktreeDetectCwd).toHaveBeenCalledTimes(4);
+
+    // 卸载后已有 IPC 可以完成，但余下 65 个目录和下一轮检查都不再启动。
+    view.unmount();
+    await act(async () => {
+      finish.forEach((resolve) => resolve());
+      await vi.advanceTimersByTimeAsync(15 * 60_000);
+    });
+    expect(mocks.worktreeListAll).toHaveBeenCalledOnce();
+    expect(mocks.worktreeDetectCwd).toHaveBeenCalledTimes(4);
   });
 
-  it('rechecks an external removal when focus arrives during an older scan', async () => {
-    mocks.worktreeListAll.mockResolvedValue([{ sessionId: 'external', path: '/tmp/wt/external' }]);
-    let release!: (value: unknown) => void;
-    mocks.worktreeDetectCwd.mockImplementationOnce(
-      () =>
-        new Promise((resolve) => {
-          release = resolve;
-        }),
-    );
-    const view = render(
-      <WorktreeProvider>
-        <Probe />
-      </WorktreeProvider>,
-    );
-    await waitFor(() => expect(mocks.worktreeDetectCwd).toHaveBeenCalledOnce());
+  it('detects external deletion and restoration in the background, preserving badges on IPC failure', async () => {
     vi.useFakeTimers();
-    act(() => window.dispatchEvent(new Event('focus')));
-    // Even a scan longer than the cooldown must not swallow the focus hint.
-    await act(async () => vi.advanceTimersByTimeAsync(15_000));
+    mocks.worktreeListAll.mockResolvedValue([
+      { sessionId: 'external', path: '/tmp/wt/external' },
+      { sessionId: 'live', path: '/tmp/wt/live' },
+    ]);
+    const view = render(<WorktreeProvider><Probe /></WorktreeProvider>);
+    await act(async () => {});
+    expect(view.getByTestId('ids').textContent).toContain('external:/tmp/wt/external');
+
+    mocks.worktreeDetectCwd.mockImplementation(async ({ cwd }: { cwd: string }) => ({
+      isInsideWorktree: cwd !== '/tmp/wt/external',
+    }));
+    await act(async () => { await vi.advanceTimersByTimeAsync(5 * 60_000); });
+    expect(view.getByTestId('ids').textContent).toBe('live:/tmp/wt/live');
+
+    mocks.worktreeDetectCwd.mockResolvedValue({ isInsideWorktree: true });
+    await act(async () => { await vi.advanceTimersByTimeAsync(5 * 60_000); });
+    expect(view.getByTestId('ids').textContent).toContain('external:/tmp/wt/external');
+
+    mocks.worktreeDetectCwd.mockRejectedValue(new Error('IPC unavailable'));
+    await act(async () => { await vi.advanceTimersByTimeAsync(5 * 60_000); });
+    expect(view.getByTestId('ids').textContent).toBe(
+      'external:/tmp/wt/external,live:/tmp/wt/live',
+    );
+    expect(mocks.worktreeListAll).toHaveBeenCalledTimes(4);
+  });
+
+  it('does not revive recycled entries or lose a creation when an older scan completes', async () => {
+    mocks.worktreeListAll.mockResolvedValue(Array.from({ length: 6 }, (_, i) => ({
+      sessionId: `session-${i}`,
+      path: `/tmp/wt/${i}`,
+    })));
+    const finish: Array<() => void> = [];
+    mocks.worktreeDetectCwd.mockImplementation(({ cwd }: { cwd: string }) => {
+      if (cwd === '/tmp/wt/new' || cwd === '/tmp/wt/5') {
+        return Promise.resolve({ isInsideWorktree: true });
+      }
+      return new Promise((resolve) => {
+        finish.push(() => resolve({ isInsideWorktree: true }));
+      });
+    });
+    const view = render(<WorktreeProvider><Probe /></WorktreeProvider>);
+    await act(async () => {});
+    expect(mocks.worktreeDetectCwd).toHaveBeenCalledTimes(4);
+
+    mocks.worktreeGetForSession.mockImplementation(async (sessionId: string) => (
+      sessionId === 'new' ? { sessionId, path: '/tmp/wt/new' } : null
+    ));
+    await act(async () => {
+      emitWorktreeChanged('session-0');
+      emitWorktreeChanged('session-4');
+      emitSessionCreated('new');
+    });
+    await act(async () => { finish.forEach((resolve) => resolve()); });
+
+    expect(view.getByTestId('ids').textContent).toBe(
+      'new:/tmp/wt/new,session-1:/tmp/wt/1,session-2:/tmp/wt/2,session-3:/tmp/wt/3,session-5:/tmp/wt/5',
+    );
+    expect(mocks.worktreeDetectCwd).not.toHaveBeenCalledWith({ cwd: '/tmp/wt/4' });
     expect(mocks.worktreeListAll).toHaveBeenCalledOnce();
-    await act(async () => release({ isInsideWorktree: true }));
-    expect(view.getByTestId('ids').textContent).toContain('external');
-    mocks.worktreeDetectCwd.mockResolvedValue({ isInsideWorktree: false });
-    await act(async () => vi.advanceTimersByTimeAsync(15_000));
-    expect(view.getByTestId('ids').textContent).toBe('');
-    expect(mocks.worktreeListAll).toHaveBeenCalledTimes(2);
+  });
+
+  it('keeps creation and recycling events newer than a pending metadata snapshot', async () => {
+    let finishList!: (value: Array<{ sessionId: string; path: string }>) => void;
+    mocks.worktreeListAll.mockImplementation(() => new Promise((resolve) => {
+      finishList = resolve;
+    }));
+    mocks.worktreeGetForSession.mockImplementation(async (sessionId: string) => (
+      sessionId === 'new' ? { sessionId, path: '/tmp/wt/new' } : null
+    ));
+    const view = render(<WorktreeProvider><Probe /></WorktreeProvider>);
+    await act(async () => {
+      emitSessionCreated('new');
+      emitWorktreeChanged('recycled');
+    });
+    await act(async () => {
+      finishList([{ sessionId: 'recycled', path: '/tmp/wt/recycled' }]);
+    });
+    expect(view.getByTestId('ids').textContent).toBe('new:/tmp/wt/new');
+    expect(mocks.worktreeDetectCwd).toHaveBeenCalledOnce();
+    expect(mocks.worktreeDetectCwd).toHaveBeenCalledWith({ cwd: '/tmp/wt/new' });
   });
 
   it('does not let an in-flight full snapshot resurrect a recycled entry', async () => {

--- a/apps/desktop/src/renderer/__tests__/worktreeContextRecycleRefresh.test.tsx
+++ b/apps/desktop/src/renderer/__tests__/worktreeContextRecycleRefresh.test.tsx
@@ -154,6 +154,51 @@ describe('WorktreeContext recycle refresh', () => {
     expect(view.getByTestId('ids').textContent).toBe('open:/tmp/wt/open');
   });
 
+  it.each(['/tmp/wt/open', '/tmp/wt/restored'])(
+    'uses replacement metadata at %s while its probe is pending or fails, ignoring old results',
+    async (restoredPath) => {
+      const meta = { sessionId: 'open', path: '/tmp/wt/open' };
+      mocks.worktreeListAll.mockResolvedValue([meta]);
+      mocks.worktreeDetectCwd.mockResolvedValue({ isInsideWorktree: false });
+      let refresh!: (sessionId: string) => Promise<void>;
+      function Actions() {
+        refresh = useRefreshWorktreeForSession();
+        return <><Probe /><ActiveProbe /></>;
+      }
+      const view = render(<WorktreeProvider><Actions /></WorktreeProvider>);
+      await act(async () => {});
+      expect(view.getByTestId('active').textContent).toBe('');
+      expect(view.getByTestId('ids').textContent).toBe('');
+
+      let finishOld!: (value: { isInsideWorktree: boolean }) => void;
+      mocks.worktreeDetectCwd.mockImplementationOnce(() => new Promise((resolve) => { finishOld = resolve; }));
+      await act(async () => { window.dispatchEvent(new Event('focus')); });
+
+      let rejectNew!: (reason: Error) => void;
+      mocks.worktreeGetForSession.mockResolvedValue({ ...meta, path: restoredPath });
+      mocks.worktreeDetectCwd.mockImplementationOnce(() => new Promise((_resolve, reject) => { rejectNew = reject; }));
+      await act(async () => { await refresh('open'); });
+      expect(view.getByTestId('ids').textContent).toBe(`open:${restoredPath}`);
+      expect(view.getByTestId('active').textContent).toBe(restoredPath);
+      expect(mocks.worktreeDetectCwd).toHaveBeenLastCalledWith({ cwd: restoredPath });
+
+      await act(async () => { finishOld({ isInsideWorktree: false }); });
+      expect(view.getByTestId('active').textContent).toBe(restoredPath);
+      expect(view.getByTestId('ids').textContent).toBe(`open:${restoredPath}`);
+      await act(async () => { rejectNew(new Error('[INTERNAL] Worktree directory probe failed')); });
+      expect(view.getByTestId('active').textContent).toBe(restoredPath);
+      expect(view.getByTestId('ids').textContent).toBe(`open:${restoredPath}`);
+
+      // A conclusive result for the new metadata must still update both views.
+      await act(async () => { window.dispatchEvent(new Event('focus')); });
+      expect(view.getByTestId('active').textContent).toBe('');
+      expect(view.getByTestId('ids').textContent).toBe('');
+      expect(mocks.worktreeDetectCwd).toHaveBeenCalledTimes(4);
+      expect(mocks.worktreeListAll).toHaveBeenCalledOnce();
+      expect(mocks.worktreeGetForSession).toHaveBeenCalledExactlyOnceWith('open');
+    },
+  );
+
   it('ignores liveness reports captured before same-path restoration or recycling', async () => {
     const meta = { sessionId: 'open', path: '/tmp/wt/open' };
     mocks.worktreeListAll.mockResolvedValue([meta]);

--- a/apps/desktop/src/renderer/__tests__/worktreeContextRecycleRefresh.test.tsx
+++ b/apps/desktop/src/renderer/__tests__/worktreeContextRecycleRefresh.test.tsx
@@ -110,10 +110,9 @@ describe('WorktreeContext recycle refresh', () => {
     });
     expect(mocks.worktreeGetForSession).toHaveBeenCalledWith('archived-one');
     expect(mocks.worktreeListAll).toHaveBeenCalledTimes(1);
-    expect(mocks.worktreeDetectCwd).toHaveBeenCalledTimes(2);
   });
 
-  it('validates and updates only the reported worktree', async () => {
+  it('updates only the reported worktree', async () => {
     mocks.worktreeListAll.mockResolvedValueOnce([
       { sessionId: 'changed', path: '/tmp/wt/old' },
       { sessionId: 'other', path: '/tmp/wt/other' },
@@ -123,8 +122,6 @@ describe('WorktreeContext recycle refresh', () => {
         <Probe />
       </WorktreeProvider>,
     );
-    await waitFor(() => expect(mocks.worktreeDetectCwd).toHaveBeenCalledTimes(2));
-    mocks.worktreeDetectCwd.mockClear();
     mocks.worktreeGetForSession.mockResolvedValueOnce({
       sessionId: 'changed',
       path: '/tmp/wt/new',
@@ -136,8 +133,6 @@ describe('WorktreeContext recycle refresh', () => {
       expect(view.getByTestId('ids').textContent).toContain('changed:/tmp/wt/new');
     });
     expect(mocks.worktreeListAll).toHaveBeenCalledTimes(1);
-    expect(mocks.worktreeDetectCwd).toHaveBeenCalledOnce();
-    expect(mocks.worktreeDetectCwd).toHaveBeenCalledWith({ cwd: '/tmp/wt/new' });
   });
 
   it('keeps the newest response when the same session changes twice', async () => {
@@ -235,7 +230,6 @@ describe('WorktreeContext recycle refresh', () => {
     });
     expect(mocks.worktreeGetForSession).toHaveBeenCalledWith('background');
     expect(mocks.worktreeListAll).toHaveBeenCalledOnce();
-    expect(mocks.worktreeDetectCwd).toHaveBeenCalledOnce();
   });
 
   it('does not run Git validation for a local background session without a worktree', async () => {
@@ -277,7 +271,6 @@ describe('WorktreeContext recycle refresh', () => {
       expect(view.getByTestId('ids').textContent).toBe('');
     }
     expect(mocks.worktreeListAll).toHaveBeenCalledOnce();
-    expect(mocks.worktreeDetectCwd).toHaveBeenCalledTimes(3);
     expect(mocks.worktreeGetForSession).toHaveBeenCalledTimes(6);
   });
 
@@ -301,125 +294,23 @@ describe('WorktreeContext recycle refresh', () => {
     expect(mocks.worktreeListAll).toHaveBeenCalledOnce();
   });
 
-  it('does not rescan 69 worktrees during repeated foreground/background switches', async () => {
-    mocks.worktreeListAll.mockResolvedValue(Array.from({ length: 69 }, (_, i) => ({
-      sessionId: `session-${i}`,
-      path: `/tmp/wt/${i}`,
-    })));
-    render(
-      <WorktreeProvider>
-        <Probe />
-      </WorktreeProvider>,
-    );
-    await waitFor(() => expect(mocks.worktreeDetectCwd).toHaveBeenCalledTimes(69));
-
-    for (let i = 0; i < 20; i++) {
-      await act(async () => {
-        window.dispatchEvent(new Event('blur'));
-        window.dispatchEvent(new Event('focus'));
-      });
-    }
-
-    expect(mocks.worktreeListAll).toHaveBeenCalledOnce();
-    expect(mocks.worktreeDetectCwd).toHaveBeenCalledTimes(69);
-  });
-
-  it('shows the snapshot immediately and bounds pending scans across focus and timer ticks', async () => {
+  it('loads idle worktree metadata without Git probes or a periodic full scan', async () => {
     vi.useFakeTimers();
     mocks.worktreeListAll.mockResolvedValue(Array.from({ length: 69 }, (_, i) => ({
       sessionId: `session-${i}`,
       path: `/tmp/wt/${i}`,
     })));
-    const finish: Array<() => void> = [];
-    mocks.worktreeDetectCwd.mockImplementation(() => new Promise((resolve) => {
-      finish.push(() => resolve({ isInsideWorktree: true }));
-    }));
     const view = render(<WorktreeProvider><Probe /></WorktreeProvider>);
+
     await act(async () => {});
     expect(view.getByTestId('ids').textContent).toContain('session-68:/tmp/wt/68');
-    expect(mocks.worktreeDetectCwd).toHaveBeenCalledTimes(4);
-
     await act(async () => {
-      for (let i = 0; i < 20; i++) {
-        window.dispatchEvent(new Event('blur'));
-        window.dispatchEvent(new Event('focus'));
-      }
+      window.dispatchEvent(new Event('focus'));
       await vi.advanceTimersByTimeAsync(15 * 60_000);
     });
+
     expect(mocks.worktreeListAll).toHaveBeenCalledOnce();
-    expect(mocks.worktreeDetectCwd).toHaveBeenCalledTimes(4);
-
-    // 卸载后已有 IPC 可以完成，但余下 65 个目录和下一轮检查都不再启动。
-    view.unmount();
-    await act(async () => {
-      finish.forEach((resolve) => resolve());
-      await vi.advanceTimersByTimeAsync(15 * 60_000);
-    });
-    expect(mocks.worktreeListAll).toHaveBeenCalledOnce();
-    expect(mocks.worktreeDetectCwd).toHaveBeenCalledTimes(4);
-  });
-
-  it('detects external deletion and restoration in the background, preserving badges on IPC failure', async () => {
-    vi.useFakeTimers();
-    mocks.worktreeListAll.mockResolvedValue([
-      { sessionId: 'external', path: '/tmp/wt/external' },
-      { sessionId: 'live', path: '/tmp/wt/live' },
-    ]);
-    const view = render(<WorktreeProvider><Probe /></WorktreeProvider>);
-    await act(async () => {});
-    expect(view.getByTestId('ids').textContent).toContain('external:/tmp/wt/external');
-
-    mocks.worktreeDetectCwd.mockImplementation(async ({ cwd }: { cwd: string }) => ({
-      isInsideWorktree: cwd !== '/tmp/wt/external',
-    }));
-    await act(async () => { await vi.advanceTimersByTimeAsync(5 * 60_000); });
-    expect(view.getByTestId('ids').textContent).toBe('live:/tmp/wt/live');
-
-    mocks.worktreeDetectCwd.mockResolvedValue({ isInsideWorktree: true });
-    await act(async () => { await vi.advanceTimersByTimeAsync(5 * 60_000); });
-    expect(view.getByTestId('ids').textContent).toContain('external:/tmp/wt/external');
-
-    mocks.worktreeDetectCwd.mockRejectedValue(new Error('IPC unavailable'));
-    await act(async () => { await vi.advanceTimersByTimeAsync(5 * 60_000); });
-    expect(view.getByTestId('ids').textContent).toBe(
-      'external:/tmp/wt/external,live:/tmp/wt/live',
-    );
-    expect(mocks.worktreeListAll).toHaveBeenCalledTimes(4);
-  });
-
-  it('does not revive recycled entries or lose a creation when an older scan completes', async () => {
-    mocks.worktreeListAll.mockResolvedValue(Array.from({ length: 6 }, (_, i) => ({
-      sessionId: `session-${i}`,
-      path: `/tmp/wt/${i}`,
-    })));
-    const finish: Array<() => void> = [];
-    mocks.worktreeDetectCwd.mockImplementation(({ cwd }: { cwd: string }) => {
-      if (cwd === '/tmp/wt/new' || cwd === '/tmp/wt/5') {
-        return Promise.resolve({ isInsideWorktree: true });
-      }
-      return new Promise((resolve) => {
-        finish.push(() => resolve({ isInsideWorktree: true }));
-      });
-    });
-    const view = render(<WorktreeProvider><Probe /></WorktreeProvider>);
-    await act(async () => {});
-    expect(mocks.worktreeDetectCwd).toHaveBeenCalledTimes(4);
-
-    mocks.worktreeGetForSession.mockImplementation(async (sessionId: string) => (
-      sessionId === 'new' ? { sessionId, path: '/tmp/wt/new' } : null
-    ));
-    await act(async () => {
-      emitWorktreeChanged('session-0');
-      emitWorktreeChanged('session-4');
-      emitSessionCreated('new');
-    });
-    await act(async () => { finish.forEach((resolve) => resolve()); });
-
-    expect(view.getByTestId('ids').textContent).toBe(
-      'new:/tmp/wt/new,session-1:/tmp/wt/1,session-2:/tmp/wt/2,session-3:/tmp/wt/3,session-5:/tmp/wt/5',
-    );
-    expect(mocks.worktreeDetectCwd).not.toHaveBeenCalledWith({ cwd: '/tmp/wt/4' });
-    expect(mocks.worktreeListAll).toHaveBeenCalledOnce();
+    expect(mocks.worktreeDetectCwd).not.toHaveBeenCalled();
   });
 
   it('keeps creation and recycling events newer than a pending metadata snapshot', async () => {
@@ -439,29 +330,6 @@ describe('WorktreeContext recycle refresh', () => {
       finishList([{ sessionId: 'recycled', path: '/tmp/wt/recycled' }]);
     });
     expect(view.getByTestId('ids').textContent).toBe('new:/tmp/wt/new');
-    expect(mocks.worktreeDetectCwd).toHaveBeenCalledOnce();
-    expect(mocks.worktreeDetectCwd).toHaveBeenCalledWith({ cwd: '/tmp/wt/new' });
-  });
-
-  it('does not let an in-flight full snapshot resurrect a recycled entry', async () => {
-    mocks.worktreeListAll.mockResolvedValue([{ sessionId: 'gone', path: '/tmp/wt/gone' }]);
-    let release!: (value: unknown) => void;
-    mocks.worktreeDetectCwd.mockImplementation(
-      () =>
-        new Promise((resolve) => {
-          release = resolve;
-        }),
-    );
-    const view = render(
-      <WorktreeProvider>
-        <Probe />
-      </WorktreeProvider>,
-    );
-    await waitFor(() => expect(mocks.worktreeDetectCwd).toHaveBeenCalledOnce());
-    mocks.worktreeGetForSession.mockResolvedValue(null);
-    await act(async () => emitWorktreeChanged('gone'));
-    await act(async () => release({ isInsideWorktree: true }));
-    expect(view.getByTestId('ids').textContent).toBe('');
   });
 
   it('unsubscribes on unmount so a later push cannot refresh a dead tree', async () => {
@@ -501,25 +369,4 @@ describe('WorktreeContext recycle refresh', () => {
     });
   });
 
-  it('drops store entries whose directories are no longer linked worktrees', async () => {
-    mocks.worktreeListAll.mockResolvedValue([
-      { sessionId: 'gone', path: '/tmp/wt/gone' },
-      { sessionId: 'live', path: '/tmp/wt/live' },
-    ]);
-    mocks.worktreeDetectCwd.mockImplementation(async ({ cwd }: { cwd: string }) => ({
-      isInsideWorktree: cwd === '/tmp/wt/live',
-      isGitRepo: true,
-      gitInstalled: true,
-    }));
-
-    const view = render(
-      <WorktreeProvider>
-        <Probe />
-      </WorktreeProvider>,
-    );
-
-    await waitFor(() => {
-      expect(view.getByTestId('ids').textContent).toBe('live:/tmp/wt/live');
-    });
-  });
 });

--- a/apps/desktop/src/renderer/contexts/WorktreeContext.tsx
+++ b/apps/desktop/src/renderer/contexts/WorktreeContext.tsx
@@ -8,7 +8,7 @@
  *   - Scheduler / hook 等 main 侧后台创建完成后，复用 sessions:created 按
  *     sessionId 增量发现 worktree
  *   - 归档/删除的 worktree 回收跑完后，由 main 的 `worktree:changed` 推送按
- *     sessionId 增量更新；启动先显示快照，低频、有界校验兜底外部删除，不随聚焦扫描
+ *     sessionId 增量更新；启动只读取快照，外部删除由打开中的任务按需校验
  *
  * 与项目内 AuthContext / EnvCheckContext 同
  * Provider+hooks 范式，不引入新状态库。
@@ -29,21 +29,6 @@ import type { WorktreeMeta } from '@/lib/worktree.types';
 import { createLogger } from '@/lib/logger';
 
 const log = createLogger('WorktreeContext');
-const BACKGROUND_CHECK_INTERVAL_MS = 5 * 60_000;
-const BACKGROUND_CHECK_CONCURRENCY = 4;
-
-/** store 仍可能留着已被 `git worktree remove` 的路径；探测失败不摘标，避免 IPC 抖动清空侧栏。 */
-async function isLiveOfficialPath(cwd: string): Promise<boolean> {
-  const detect = window.electronAPI?.worktreeDetectCwd;
-  if (!detect) return true;
-  try {
-    const result = await detect({ cwd });
-    return Boolean(result?.isInsideWorktree);
-  } catch {
-    return true;
-  }
-}
-
 interface WorktreeContextValue {
   /** sessionId → meta；非 null 即代表此 session 正绑定一个 worktree。 */
   metas: Record<string, WorktreeMeta>;
@@ -60,7 +45,7 @@ export function WorktreeProvider({ children }: { children: ReactNode }) {
   const fullRefreshGenerationRef = useRef(0);
   const eventGenerationRef = useRef(0);
   const sessionEventGenerationsRef = useRef(new Map<string, number>());
-  const refresh = useCallback(async (showSnapshot: boolean) => {
+  const refresh = useCallback(async () => {
     const myTurn = ++fullRefreshGenerationRef.current;
     const eventGenerationAtStart = eventGenerationRef.current;
     try {
@@ -80,27 +65,7 @@ export function WorktreeProvider({ children }: { children: ReactNode }) {
         }
         return merged;
       });
-      if (showSnapshot) {
-        mergeSnapshot(Object.fromEntries(entries.map((meta) => [meta.sessionId, meta])));
-      }
-      const next: Record<string, WorktreeMeta> = {};
-      let index = 0;
-      const checkNext = async () => {
-        while (myTurn === fullRefreshGenerationRef.current && index < entries.length) {
-          const meta = entries[index++];
-          // 已收到增量事件的条目由 refreshSession 负责；不再启动旧快照里的探测。
-          if ((sessionEventGenerationsRef.current.get(meta.sessionId) ?? 0) > eventGenerationAtStart) {
-            continue;
-          }
-          if (await isLiveOfficialPath(meta.path)) next[meta.sessionId] = meta;
-        }
-      };
-      await Promise.all(Array.from(
-        { length: Math.min(BACKGROUND_CHECK_CONCURRENCY, entries.length) },
-        checkNext,
-      ));
-      if (myTurn !== fullRefreshGenerationRef.current) return;
-      mergeSnapshot(next);
+      mergeSnapshot(Object.fromEntries(entries.map((meta) => [meta.sessionId, meta])));
     } catch (err) {
       log.warn('refresh failed:', err);
     }
@@ -119,9 +84,7 @@ export function WorktreeProvider({ children }: { children: ReactNode }) {
       const meta = await getForSession(sessionId);
       if (!isCurrent()) return;
       const next =
-        meta?.sessionId === sessionId && meta.path && (await isLiveOfficialPath(meta.path))
-          ? meta
-          : null;
+        meta?.sessionId === sessionId && meta.path ? meta : null;
       if (!isCurrent()) return;
       setMetas((current) => {
         if (next) return { ...current, [sessionId]: next };
@@ -136,17 +99,8 @@ export function WorktreeProvider({ children }: { children: ReactNode }) {
   }, []);
 
   useEffect(() => {
-    let cancelled = false;
-    let timer: ReturnType<typeof setTimeout>;
-    const check = async (showSnapshot: boolean) => {
-      await refresh(showSnapshot);
-      // 从本轮完成后计时，慢扫描不会与下一轮重叠或积压。
-      if (!cancelled) timer = setTimeout(() => void check(false), BACKGROUND_CHECK_INTERVAL_MS);
-    };
-    void check(true);
+    void refresh();
     return () => {
-      cancelled = true;
-      clearTimeout(timer);
       fullRefreshGenerationRef.current++;
     };
   }, [refresh]);
@@ -154,7 +108,7 @@ export function WorktreeProvider({ children }: { children: ReactNode }) {
   // 权威时机在这条推送上：main 侧的 worktree 回收是 fire-and-forget 的异步链
   // （关子进程 → git worktree remove → 文件系统清理），store 条目被移除的时刻
   // 远晚于归档/删除的状态 IPC 返回。main 只为实际涉及 worktree 的 session 广播，
-  // 这里也只查询、校验并更新这一条，不再扫描其它 worktree。
+  // 这里也只查询并更新这一条，不再扫描其它 worktree；存活校验由打开中的任务负责。
   useEffect(() => {
     const subscribe = window.electronAPI?.onWorktreeChanged;
     if (!subscribe) return;

--- a/apps/desktop/src/renderer/contexts/WorktreeContext.tsx
+++ b/apps/desktop/src/renderer/contexts/WorktreeContext.tsx
@@ -32,6 +32,9 @@ const log = createLogger('WorktreeContext');
 interface WorktreeContextValue {
   /** sessionId → meta；非 null 即代表此 session 正绑定一个 worktree。 */
   metas: Record<string, WorktreeMeta>;
+  /** 保留失效目录的登记信息，供打开中的任务在聚焦/恢复时重新探测。 */
+  rawMetas: Record<string, WorktreeMeta>;
+  reportLiveness: (meta: WorktreeMeta, live: boolean) => void;
   /** 从 main 查询并更新单个 session 的 worktree 缓存。 */
   refreshSession: (sessionId: string) => Promise<void>;
 }
@@ -39,7 +42,10 @@ interface WorktreeContextValue {
 const WorktreeContext = createContext<WorktreeContextValue | null>(null);
 
 export function WorktreeProvider({ children }: { children: ReactNode }) {
-  const [metas, setMetas] = useState<Record<string, WorktreeMeta>>({});
+  const [snapshot, setSnapshot] = useState<{
+    metas: Record<string, WorktreeMeta>;
+    invalid: Set<string>;
+  }>({ metas: {}, invalid: new Set() });
   // 全量刷新彼此只接收最后一次；单条事件另按 sessionId 记代次，避免连续回收时
   // 一个 session 的迟到响应覆盖另一个 session 的新状态。
   const fullRefreshGenerationRef = useRef(0);
@@ -53,17 +59,17 @@ export function WorktreeProvider({ children }: { children: ReactNode }) {
       // 中间发生了更新的 refresh，丢弃本次结果
       if (myTurn !== fullRefreshGenerationRef.current) return;
       const entries = (list ?? []).filter((meta) => meta?.sessionId && meta.path);
-      const mergeSnapshot = (next: Record<string, WorktreeMeta>) => setMetas((current) => {
+      const mergeSnapshot = (next: Record<string, WorktreeMeta>) => setSnapshot((current) => {
         if (myTurn !== fullRefreshGenerationRef.current) return current;
         const merged = { ...next };
-        // 全量探测期间若某个 session 收到更晚的权威事件，只保留该 session 当前
+        // 快照读取期间若某个 session 收到更晚的权威事件，只保留该 session 当前
         // 的增量结果；未完成的增量请求随后会再落一次，不能让旧全量快照回写。
         for (const [sessionId, generation] of sessionEventGenerationsRef.current) {
           if (generation <= eventGenerationAtStart) continue;
-          if (current[sessionId]) merged[sessionId] = current[sessionId];
+          if (current.metas[sessionId]) merged[sessionId] = current.metas[sessionId];
           else delete merged[sessionId];
         }
-        return merged;
+        return { ...current, metas: merged };
       });
       mergeSnapshot(Object.fromEntries(entries.map((meta) => [meta.sessionId, meta])));
     } catch (err) {
@@ -86,16 +92,30 @@ export function WorktreeProvider({ children }: { children: ReactNode }) {
       const next =
         meta?.sessionId === sessionId && meta.path ? meta : null;
       if (!isCurrent()) return;
-      setMetas((current) => {
-        if (next) return { ...current, [sessionId]: next };
-        if (!current[sessionId]) return current;
-        const updated = { ...current };
-        delete updated[sessionId];
-        return updated;
+      setSnapshot((current) => {
+        if (!isCurrent()) return current;
+        const metas = { ...current.metas };
+        if (next) metas[sessionId] = next;
+        else delete metas[sessionId];
+        const invalid = new Set(current.invalid);
+        invalid.delete(sessionId);
+        return { metas, invalid };
       });
     } catch (err) {
       log.warn('session refresh failed:', { sessionId, err });
     }
+  }, []);
+
+  const reportLiveness = useCallback((meta: WorktreeMeta, live: boolean) => {
+    setSnapshot((current) => {
+      // 同路径恢复也会换一份元数据；旧探测不能覆盖新一代创建/恢复/回收结果。
+      if (current.metas[meta.sessionId] !== meta) return current;
+      if (current.invalid.has(meta.sessionId) === !live) return current;
+      const invalid = new Set(current.invalid);
+      if (live) invalid.delete(meta.sessionId);
+      else invalid.add(meta.sessionId);
+      return { ...current, invalid };
+    });
   }, []);
 
   useEffect(() => {
@@ -132,10 +152,13 @@ export function WorktreeProvider({ children }: { children: ReactNode }) {
     });
   }, [refreshSession]);
 
-  const value = useMemo<WorktreeContextValue>(
-    () => ({ metas, refreshSession }),
-    [metas, refreshSession],
-  );
+  const value = useMemo<WorktreeContextValue>(() => ({
+    metas: Object.fromEntries(Object.entries(snapshot.metas)
+      .filter(([sessionId]) => !snapshot.invalid.has(sessionId))),
+    rawMetas: snapshot.metas,
+    reportLiveness,
+    refreshSession,
+  }), [snapshot, reportLiveness, refreshSession]);
 
   return <WorktreeContext.Provider value={value}>{children}</WorktreeContext.Provider>;
 }
@@ -154,10 +177,18 @@ export function useWorktrees(): Record<string, WorktreeMeta> {
 }
 
 /** 单条快捷查询；徽标 (M4) / 各 session 视图都用它。 */
-export function useWorktreeForSession(sessionId: string | null | undefined): WorktreeMeta | null {
-  const { metas } = useCtx();
+export function useWorktreeForSession(
+  sessionId: string | null | undefined,
+  opts?: { includeInvalid?: boolean },
+): WorktreeMeta | null {
+  const { metas, rawMetas } = useCtx();
   if (!sessionId) return null;
-  return metas[sessionId] ?? null;
+  return (opts?.includeInvalid ? rawMetas : metas)[sessionId] ?? null;
+}
+
+/** 仅同步当前任务已有探测的结果，不额外启动 Git，也不修改 main store。 */
+export function useReportWorktreeLiveness(): WorktreeContextValue['reportLiveness'] {
+  return useCtx().reportLiveness;
 }
 
 /** 让创建/恢复等明确知道 sessionId 的调用方只刷新对应 worktree。 */

--- a/apps/desktop/src/renderer/contexts/WorktreeContext.tsx
+++ b/apps/desktop/src/renderer/contexts/WorktreeContext.tsx
@@ -8,7 +8,7 @@
  *   - Scheduler / hook 等 main 侧后台创建完成后，复用 sessions:created 按
  *     sessionId 增量发现 worktree
  *   - 归档/删除的 worktree 回收跑完后，由 main 的 `worktree:changed` 推送按
- *     sessionId 增量更新；启动和窗口聚焦时才做全量存活校验
+ *     sessionId 增量更新；启动先显示快照，低频、有界校验兜底外部删除，不随聚焦扫描
  *
  * 与项目内 AuthContext / EnvCheckContext 同
  * Provider+hooks 范式，不引入新状态库。
@@ -29,8 +29,8 @@ import type { WorktreeMeta } from '@/lib/worktree.types';
 import { createLogger } from '@/lib/logger';
 
 const log = createLogger('WorktreeContext');
-const FOREGROUND_REFRESH_INTERVAL_MS = 15_000;
-const VALIDATION_CONCURRENCY = 2;
+const BACKGROUND_CHECK_INTERVAL_MS = 5 * 60_000;
+const BACKGROUND_CHECK_CONCURRENCY = 4;
 
 /** store 仍可能留着已被 `git worktree remove` 的路径；探测失败不摘标，避免 IPC 抖动清空侧栏。 */
 async function isLiveOfficialPath(cwd: string): Promise<boolean> {
@@ -60,52 +60,50 @@ export function WorktreeProvider({ children }: { children: ReactNode }) {
   const fullRefreshGenerationRef = useRef(0);
   const eventGenerationRef = useRef(0);
   const sessionEventGenerationsRef = useRef(new Map<string, number>());
-  const refreshInFlightRef = useRef<Promise<void> | null>(null);
-  const lastRefreshAtRef = useRef(-Infinity);
-
-  const refresh = useCallback(() => {
-    if (refreshInFlightRef.current) return refreshInFlightRef.current;
-    const pending = (async () => {
-      const myTurn = ++fullRefreshGenerationRef.current;
-      const eventGenerationAtStart = eventGenerationRef.current;
-      try {
-        const list = await window.electronAPI.worktreeListAll();
-        // 中间发生了更新的 refresh，丢弃本次结果
-        if (myTurn !== fullRefreshGenerationRef.current) return;
-        const next: Record<string, WorktreeMeta> = {};
-        let index = 0;
-        const validateNext = async () => {
-          while (index < (list?.length ?? 0)) {
-            if (myTurn !== fullRefreshGenerationRef.current) return;
-            const meta = list[index++];
-            if (!meta?.sessionId || !meta.path) continue;
-            if (!(await isLiveOfficialPath(meta.path))) continue;
-            next[meta.sessionId] = meta;
-          }
-        };
-        await Promise.all(Array.from({ length: VALIDATION_CONCURRENCY }, validateNext));
-        if (myTurn !== fullRefreshGenerationRef.current) return;
-        setMetas((current) => {
-          const merged = { ...next };
-          // 全量探测期间若某个 session 收到更晚的权威事件，只保留该 session 当前
-          // 的增量结果；未完成的增量请求随后会再落一次，不能让旧全量快照回写。
-          for (const [sessionId, generation] of sessionEventGenerationsRef.current) {
-            if (generation <= eventGenerationAtStart) continue;
-            if (current[sessionId]) merged[sessionId] = current[sessionId];
-            else delete merged[sessionId];
-          }
-          return merged;
-        });
-        lastRefreshAtRef.current = Date.now();
-      } catch (err) {
-        log.warn('refresh failed:', err);
+  const refresh = useCallback(async (showSnapshot: boolean) => {
+    const myTurn = ++fullRefreshGenerationRef.current;
+    const eventGenerationAtStart = eventGenerationRef.current;
+    try {
+      const list = await window.electronAPI.worktreeListAll();
+      // 中间发生了更新的 refresh，丢弃本次结果
+      if (myTurn !== fullRefreshGenerationRef.current) return;
+      const entries = (list ?? []).filter((meta) => meta?.sessionId && meta.path);
+      const mergeSnapshot = (next: Record<string, WorktreeMeta>) => setMetas((current) => {
+        if (myTurn !== fullRefreshGenerationRef.current) return current;
+        const merged = { ...next };
+        // 全量探测期间若某个 session 收到更晚的权威事件，只保留该 session 当前
+        // 的增量结果；未完成的增量请求随后会再落一次，不能让旧全量快照回写。
+        for (const [sessionId, generation] of sessionEventGenerationsRef.current) {
+          if (generation <= eventGenerationAtStart) continue;
+          if (current[sessionId]) merged[sessionId] = current[sessionId];
+          else delete merged[sessionId];
+        }
+        return merged;
+      });
+      if (showSnapshot) {
+        mergeSnapshot(Object.fromEntries(entries.map((meta) => [meta.sessionId, meta])));
       }
-    })();
-    refreshInFlightRef.current = pending;
-    void pending.finally(() => {
-      refreshInFlightRef.current = null;
-    });
-    return pending;
+      const next: Record<string, WorktreeMeta> = {};
+      let index = 0;
+      const checkNext = async () => {
+        while (myTurn === fullRefreshGenerationRef.current && index < entries.length) {
+          const meta = entries[index++];
+          // 已收到增量事件的条目由 refreshSession 负责；不再启动旧快照里的探测。
+          if ((sessionEventGenerationsRef.current.get(meta.sessionId) ?? 0) > eventGenerationAtStart) {
+            continue;
+          }
+          if (await isLiveOfficialPath(meta.path)) next[meta.sessionId] = meta;
+        }
+      };
+      await Promise.all(Array.from(
+        { length: Math.min(BACKGROUND_CHECK_CONCURRENCY, entries.length) },
+        checkNext,
+      ));
+      if (myTurn !== fullRefreshGenerationRef.current) return;
+      mergeSnapshot(next);
+    } catch (err) {
+      log.warn('refresh failed:', err);
+    }
   }, []);
 
   const refreshSession = useCallback(async (sessionId: string) => {
@@ -138,29 +136,18 @@ export function WorktreeProvider({ children }: { children: ReactNode }) {
   }, []);
 
   useEffect(() => {
-    let trailingRefresh: ReturnType<typeof setTimeout> | undefined;
-    void refresh();
-    const onFocus = () => {
-      const remaining = refreshInFlightRef.current
-        ? FOREGROUND_REFRESH_INTERVAL_MS
-        : FOREGROUND_REFRESH_INTERVAL_MS - (Date.now() - lastRefreshAtRef.current);
-      if (remaining <= 0) {
-        if (trailingRefresh !== undefined) clearTimeout(trailingRefresh);
-        trailingRefresh = undefined;
-        void refresh();
-      } else if (trailingRefresh === undefined) {
-        // A final focus within the cooldown still gets a trailing check, even
-        // if the user stays here. External worktree removal cannot stay stale.
-        trailingRefresh = setTimeout(() => {
-          trailingRefresh = undefined;
-          onFocus();
-        }, remaining);
-      }
+    let cancelled = false;
+    let timer: ReturnType<typeof setTimeout>;
+    const check = async (showSnapshot: boolean) => {
+      await refresh(showSnapshot);
+      // 从本轮完成后计时，慢扫描不会与下一轮重叠或积压。
+      if (!cancelled) timer = setTimeout(() => void check(false), BACKGROUND_CHECK_INTERVAL_MS);
     };
-    window.addEventListener('focus', onFocus);
+    void check(true);
     return () => {
-      window.removeEventListener('focus', onFocus);
-      if (trailingRefresh !== undefined) clearTimeout(trailingRefresh);
+      cancelled = true;
+      clearTimeout(timer);
+      fullRefreshGenerationRef.current++;
     };
   }, [refresh]);
 

--- a/apps/desktop/src/renderer/features/cc-agent/sidebar/__tests__/SessionCard.visual.test.ts
+++ b/apps/desktop/src/renderer/features/cc-agent/sidebar/__tests__/SessionCard.visual.test.ts
@@ -97,9 +97,13 @@ vi.mock('@/components/sidebar/WorktreeBadge', () => ({
       : null,
 }));
 
-vi.mock('@/contexts/WorktreeContext', () => ({
-  useWorktreeForSession: () => null,
-}));
+vi.mock('@/contexts/WorktreeContext', () => {
+  const reportLiveness = vi.fn();
+  return {
+    useWorktreeForSession: () => null,
+    useReportWorktreeLiveness: () => reportLiveness,
+  };
+});
 
 vi.mock('@/state/agentIslandActivity', () => ({
   useAgentIslandActivity: (sessionId: string) => {

--- a/apps/desktop/src/renderer/features/cc-agent/sidebar/__tests__/sessionRowRenderIsolation.test.ts
+++ b/apps/desktop/src/renderer/features/cc-agent/sidebar/__tests__/sessionRowRenderIsolation.test.ts
@@ -93,9 +93,13 @@ vi.mock('@/components/sidebar/WorktreeBadge', () => ({
   WorktreeBadge: () => null,
 }));
 
-vi.mock('@/contexts/WorktreeContext', () => ({
-  useWorktreeForSession: () => null,
-}));
+vi.mock('@/contexts/WorktreeContext', () => {
+  const reportLiveness = vi.fn();
+  return {
+    useWorktreeForSession: () => null,
+    useReportWorktreeLiveness: () => reportLiveness,
+  };
+});
 
 vi.mock('@/lib/toast', () => ({
   toast: { success: vi.fn(), warning: vi.fn(), error: vi.fn() },

--- a/apps/desktop/src/renderer/features/cc-agent/sidebar/__tests__/sessionWorktreeInfoRefresh.test.tsx
+++ b/apps/desktop/src/renderer/features/cc-agent/sidebar/__tests__/sessionWorktreeInfoRefresh.test.tsx
@@ -46,6 +46,18 @@ afterEach(() => {
 });
 
 describe('opened worktree refresh', () => {
+  it('checks an active task again when it regains focus and hides an externally deleted worktree', async () => {
+    const { result } = renderHook(() => useTaskInfoWorktree(session, true, { observeTelemetry: true }));
+    await act(async () => {});
+    expect(result.current?.source).toBe('managed');
+
+    mocks.detect.mockResolvedValue({ isInsideWorktree: false });
+    await act(async () => switchFocus());
+
+    expect(mocks.detect).toHaveBeenCalledTimes(2);
+    expect(result.current).toBeNull();
+  });
+
   it('applies recycle and restore events immediately', async () => {
     const { result } = renderHook(() => useTaskInfoWorktree(session, true, { observeTelemetry: true }));
     await act(async () => {});

--- a/apps/desktop/src/renderer/features/cc-agent/sidebar/__tests__/sessionWorktreeInfoRefresh.test.tsx
+++ b/apps/desktop/src/renderer/features/cc-agent/sidebar/__tests__/sessionWorktreeInfoRefresh.test.tsx
@@ -7,12 +7,16 @@ import { useTaskInfoWorktree } from '../sessionWorktreeInfo';
 
 const mocks = vi.hoisted(() => ({
   official: vi.fn(),
+  reportLiveness: vi.fn(),
   detect: vi.fn(),
   findLinked: vi.fn(),
   listeners: new Set<(payload: { sessionId: string }) => void>(),
 }));
 
-vi.mock('@/contexts/WorktreeContext', () => ({ useWorktreeForSession: mocks.official }));
+vi.mock('@/contexts/WorktreeContext', () => ({
+  useWorktreeForSession: mocks.official,
+  useReportWorktreeLiveness: () => mocks.reportLiveness,
+}));
 
 const session = { id: 'open', workingDir: '/repo', worktreePath: '/tmp/wt/open' };
 
@@ -23,6 +27,7 @@ function switchFocus() {
 
 beforeEach(() => {
   vi.useFakeTimers();
+  mocks.reportLiveness.mockReset();
   mocks.official.mockReset().mockReturnValue({ path: '/tmp/wt/open', name: 'open', branch: 'feature' });
   mocks.detect.mockReset().mockResolvedValue({ isInsideWorktree: true });
   mocks.findLinked.mockReset().mockResolvedValue(null);

--- a/apps/desktop/src/renderer/features/cc-agent/sidebar/__tests__/sessionWorktreeInfoRefresh.test.tsx
+++ b/apps/desktop/src/renderer/features/cc-agent/sidebar/__tests__/sessionWorktreeInfoRefresh.test.tsx
@@ -81,9 +81,9 @@ describe('opened worktree refresh', () => {
   it('resets liveness from the new snapshot when switching tasks in place', async () => {
     const metaA = { path: '/tmp/wt/a', name: 'a', branch: 'feature-a' };
     const metaB = { path: '/tmp/wt/b', name: 'b', branch: 'feature-b' };
-    mocks.official.mockImplementation((task: { id: string }, options?: { includeInvalid?: boolean }) => {
-      if (options?.includeInvalid) return task.id === 'a' ? metaA : metaB;
-      return task.id === 'a' ? null : metaB;
+    mocks.official.mockImplementation((sessionId: string, options?: { includeInvalid?: boolean }) => {
+      if (options?.includeInvalid) return sessionId === 'a' ? metaA : metaB;
+      return sessionId === 'a' ? null : metaB;
     });
     mocks.detect.mockResolvedValue({ isInsideWorktree: false });
     const view = renderHook(
@@ -96,6 +96,63 @@ describe('opened worktree refresh', () => {
     mocks.detect.mockResolvedValue({ isInsideWorktree: true });
     await act(async () => view.rerender({ current: { ...session, id: 'b' } }));
     expect(view.result.current?.source).toBe('managed');
+  });
+
+  it('keeps invalid liveness through disable, delayed re-enable, and a failed probe', async () => {
+    mocks.detect.mockResolvedValue({ isInsideWorktree: false });
+    const view = renderHook(
+      ({ enabled }) => useTaskInfoWorktree(session, enabled, { observeTelemetry: true }),
+      { initialProps: { enabled: true } },
+    );
+    await act(async () => {});
+    expect(view.result.current).toBeNull();
+
+    view.rerender({ enabled: false });
+    await act(async () => switchFocus());
+    expect(view.result.current).toBeNull();
+    expect(mocks.detect).toHaveBeenCalledOnce();
+    expect(mocks.listeners.size).toBe(0);
+
+    let reject!: (error: Error) => void;
+    mocks.detect.mockImplementationOnce(() => new Promise((_resolve, fail) => { reject = fail; }));
+    view.rerender({ enabled: true });
+    expect(view.result.current).toBeNull();
+    await act(async () => reject(new Error('[INTERNAL] Worktree directory probe failed')));
+    expect(view.result.current).toBeNull();
+    expect(mocks.reportLiveness).toHaveBeenCalledTimes(1);
+
+    mocks.detect.mockResolvedValue({ isInsideWorktree: true });
+    await act(async () => switchFocus());
+    expect(view.result.current?.source).toBe('managed');
+    expect(mocks.reportLiveness).toHaveBeenLastCalledWith(expect.anything(), true);
+  });
+
+  it('updates liveness after a route switch even when the previous task had the same probe result', async () => {
+    const metaA = { path: '/tmp/wt/a', name: 'a', branch: 'feature-a' };
+    const metaB = { path: '/tmp/wt/b', name: 'b', branch: 'feature-b' };
+    mocks.official.mockImplementation((sessionId: string, options?: { includeInvalid?: boolean }) => {
+      if (options?.includeInvalid) return sessionId === 'a' ? metaA : metaB;
+      return sessionId === 'a' ? metaA : null;
+    });
+    const view = renderHook(
+      ({ id }) => useTaskInfoWorktree({ ...session, id }, true, { observeTelemetry: true }),
+      { initialProps: { id: 'a' } },
+    );
+    await act(async () => {});
+    expect(view.result.current?.path).toBe(metaA.path);
+
+    let finish!: (value: { isInsideWorktree: boolean }) => void;
+    mocks.detect.mockImplementationOnce(() => new Promise((resolve) => { finish = resolve; }));
+    view.rerender({ id: 'b' });
+    expect(view.result.current).toBeNull();
+    await act(async () => finish({ isInsideWorktree: true }));
+    expect(view.result.current?.path).toBe(metaB.path);
+
+    mocks.detect.mockImplementationOnce(() => new Promise((resolve) => { finish = resolve; }));
+    view.rerender({ id: 'a' });
+    expect(view.result.current?.path).toBe(metaA.path);
+    await act(async () => finish({ isInsideWorktree: false }));
+    expect(view.result.current).toBeNull();
   });
 
   it('applies recycle and restore events immediately', async () => {

--- a/apps/desktop/src/renderer/features/cc-agent/sidebar/__tests__/sessionWorktreeInfoRefresh.test.tsx
+++ b/apps/desktop/src/renderer/features/cc-agent/sidebar/__tests__/sessionWorktreeInfoRefresh.test.tsx
@@ -78,6 +78,26 @@ describe('opened worktree refresh', () => {
     expect(result.current?.source).toBe('managed');
   });
 
+  it('resets liveness from the new snapshot when switching tasks in place', async () => {
+    const metaA = { path: '/tmp/wt/a', name: 'a', branch: 'feature-a' };
+    const metaB = { path: '/tmp/wt/b', name: 'b', branch: 'feature-b' };
+    mocks.official.mockImplementation((task: { id: string }, options?: { includeInvalid?: boolean }) => {
+      if (options?.includeInvalid) return task.id === 'a' ? metaA : metaB;
+      return task.id === 'a' ? null : metaB;
+    });
+    mocks.detect.mockResolvedValue({ isInsideWorktree: false });
+    const view = renderHook(
+      ({ current }) => useTaskInfoWorktree(current, true, { observeTelemetry: true }),
+      { initialProps: { current: { ...session, id: 'a' } } },
+    );
+    await act(async () => {});
+    expect(view.result.current).toBeNull();
+
+    mocks.detect.mockResolvedValue({ isInsideWorktree: true });
+    await act(async () => view.rerender({ current: { ...session, id: 'b' } }));
+    expect(view.result.current?.source).toBe('managed');
+  });
+
   it('applies recycle and restore events immediately', async () => {
     const { result } = renderHook(() => useTaskInfoWorktree(session, true, { observeTelemetry: true }));
     await act(async () => {});

--- a/apps/desktop/src/renderer/features/cc-agent/sidebar/__tests__/sessionWorktreeInfoRefresh.test.tsx
+++ b/apps/desktop/src/renderer/features/cc-agent/sidebar/__tests__/sessionWorktreeInfoRefresh.test.tsx
@@ -1,0 +1,102 @@
+// @vitest-environment jsdom
+
+import { act, cleanup, renderHook } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { useTaskInfoWorktree } from '../sessionWorktreeInfo';
+
+const mocks = vi.hoisted(() => ({
+  official: vi.fn(),
+  detect: vi.fn(),
+  findLinked: vi.fn(),
+  listeners: new Set<(payload: { sessionId: string }) => void>(),
+}));
+
+vi.mock('@/contexts/WorktreeContext', () => ({ useWorktreeForSession: mocks.official }));
+
+const session = { id: 'open', workingDir: '/repo', worktreePath: '/tmp/wt/open' };
+
+function switchFocus() {
+  window.dispatchEvent(new Event('blur'));
+  window.dispatchEvent(new Event('focus'));
+}
+
+beforeEach(() => {
+  vi.useFakeTimers();
+  mocks.official.mockReset().mockReturnValue({ path: '/tmp/wt/open', name: 'open', branch: 'feature' });
+  mocks.detect.mockReset().mockResolvedValue({ isInsideWorktree: true });
+  mocks.findLinked.mockReset().mockResolvedValue(null);
+  mocks.listeners.clear();
+  Object.defineProperty(window, 'electronAPI', {
+    configurable: true,
+    value: {
+      worktreeDetectCwd: mocks.detect,
+      gitContext: { findLinkedWorktree: mocks.findLinked },
+      onWorktreeChanged: (cb: (payload: { sessionId: string }) => void) => {
+        mocks.listeners.add(cb);
+        return () => mocks.listeners.delete(cb);
+      },
+    },
+  });
+});
+
+afterEach(() => {
+  cleanup();
+  vi.useRealTimers();
+});
+
+describe('opened worktree refresh', () => {
+  it('applies recycle and restore events immediately', async () => {
+    const { result } = renderHook(() => useTaskInfoWorktree(session, true, { observeTelemetry: true }));
+    await act(async () => {});
+    mocks.detect.mockResolvedValue({ isInsideWorktree: false });
+    await act(async () => { mocks.listeners.forEach((cb) => cb({ sessionId: 'open' })); });
+    expect(result.current).toBeNull();
+
+    mocks.detect.mockResolvedValue({ isInsideWorktree: true });
+    await act(async () => { mocks.listeners.forEach((cb) => cb({ sessionId: 'open' })); });
+    expect(result.current?.source).toBe('managed');
+    expect(mocks.detect).toHaveBeenCalledTimes(3);
+    await act(async () => { mocks.listeners.forEach((cb) => cb({ sessionId: 'other' })); });
+    expect(mocks.detect).toHaveBeenCalledTimes(3);
+  });
+
+  it('coalesces authoritative changes during a pending check and discards its stale result', async () => {
+    let finish!: (value: { isInsideWorktree: boolean }) => void;
+    mocks.detect.mockImplementationOnce(() => new Promise((resolve) => { finish = resolve; }));
+    mocks.detect.mockResolvedValue({ isInsideWorktree: false });
+    const { result } = renderHook(() => useTaskInfoWorktree(session, true, { observeTelemetry: true }));
+    await act(async () => {
+      for (let i = 0; i < 10; i++) mocks.listeners.forEach((cb) => cb({ sessionId: 'open' }));
+      finish({ isInsideWorktree: true });
+    });
+    expect(mocks.detect).toHaveBeenCalledTimes(2);
+    expect(result.current).toBeNull();
+  });
+
+  it('does not start queued work after unmount', async () => {
+    let finish!: (value: { isInsideWorktree: boolean }) => void;
+    mocks.detect.mockImplementationOnce(() => new Promise((resolve) => { finish = resolve; }));
+    const view = renderHook(() => useTaskInfoWorktree(session, true, { observeTelemetry: true }));
+    act(() => { mocks.listeners.forEach((cb) => cb({ sessionId: 'open' })); });
+    view.unmount();
+    await act(async () => {
+      finish({ isInsideWorktree: true });
+      switchFocus();
+    });
+    expect(mocks.detect).toHaveBeenCalledOnce();
+    expect(mocks.listeners.size).toBe(0);
+  });
+
+  it.each([
+    { enabled: false, observeTelemetry: true },
+    { enabled: true, observeTelemetry: false },
+    { enabled: true, observeTelemetry: true, deviceLinkDeviceId: 'remote' },
+    { enabled: true, observeTelemetry: true, remoteHostId: 'ssh' },
+  ])('never probes disabled, sidebar or remote entries: %j', async (opts) => {
+    renderHook(() => useTaskInfoWorktree({ ...session, ...opts }, opts.enabled, opts));
+    await act(async () => { switchFocus(); });
+    expect(mocks.detect).not.toHaveBeenCalled();
+    expect(mocks.findLinked).not.toHaveBeenCalled();
+  });
+});

--- a/apps/desktop/src/renderer/features/cc-agent/sidebar/__tests__/sessionWorktreeInfoRefresh.test.tsx
+++ b/apps/desktop/src/renderer/features/cc-agent/sidebar/__tests__/sessionWorktreeInfoRefresh.test.tsx
@@ -63,6 +63,21 @@ describe('opened worktree refresh', () => {
     expect(result.current).toBeNull();
   });
 
+  it('keeps an invalid official worktree hidden until a remount probe confirms it', async () => {
+    const official = { path: '/tmp/wt/open', name: 'open', branch: 'feature' };
+    mocks.official.mockImplementation((_session, options?: { includeInvalid?: boolean }) =>
+      options?.includeInvalid ? official : null,
+    );
+    let finish!: (value: { isInsideWorktree: boolean }) => void;
+    mocks.detect.mockImplementation(() => new Promise((resolve) => { finish = resolve; }));
+
+    const { result } = renderHook(() => useTaskInfoWorktree(session, true, { observeTelemetry: true }));
+    expect(result.current).toBeNull();
+
+    await act(async () => finish({ isInsideWorktree: true }));
+    expect(result.current?.source).toBe('managed');
+  });
+
   it('applies recycle and restore events immediately', async () => {
     const { result } = renderHook(() => useTaskInfoWorktree(session, true, { observeTelemetry: true }));
     await act(async () => {});

--- a/apps/desktop/src/renderer/features/cc-agent/sidebar/sessionWorktreeInfo.ts
+++ b/apps/desktop/src/renderer/features/cc-agent/sidebar/sessionWorktreeInfo.ts
@@ -13,7 +13,7 @@ import { useEffect, useState } from 'react';
 
 import { groupingWorktreeBaseRepo } from '@cindy/maker-shared/worktree-paths';
 
-import { useWorktreeForSession } from '@/contexts/WorktreeContext';
+import { useReportWorktreeLiveness, useWorktreeForSession } from '@/contexts/WorktreeContext';
 import type { Session } from '@/lib/ccAgent.types';
 import type { GitContextDirSource } from '@/lib/gitContext.types';
 import type { DetectCwdResp, WorktreeMeta } from '@/lib/worktree.types';
@@ -100,7 +100,8 @@ export function useTaskInfoWorktree(
   enabled: boolean,
   opts?: { observeTelemetry?: boolean },
 ): SessionWorktreeInfo | null {
-  const official = useWorktreeForSession(session.id);
+  const official = useWorktreeForSession(session.id, { includeInvalid: opts?.observeTelemetry });
+  const reportLiveness = useReportWorktreeLiveness();
   const managed = resolveManagedWorktree(official);
   const [observed, setObserved] = useState<SessionWorktreeInfo | null>(null);
   const [officialStillLive, setOfficialStillLive] = useState(true);
@@ -124,7 +125,9 @@ export function useTaskInfoWorktree(
       if (officialPath) {
         const live = await probeIsInsideWorktree(officialPath, deviceId);
         if (cancelled || gen !== generation) return;
+        if (live === null) return; // IPC 失败不代表目录已被删除，保留上次状态。
         setOfficialStillLive(live);
+        if (official) reportLiveness(official, live);
         if (live) {
           setObserved(null);
           return;
@@ -167,7 +170,7 @@ export function useTaskInfoWorktree(
       unsubscribe?.();
       window.removeEventListener('focus', onFocus);
     };
-  }, [enabled, officialPath, deviceId, isRemote, observeTelemetry, session.id]);
+  }, [enabled, official, officialPath, deviceId, isRemote, observeTelemetry, session.id, reportLiveness]);
 
   if (isRemote) return null;
   if (!observeTelemetry) {
@@ -186,7 +189,7 @@ export function useTaskInfoWorktree(
   });
 }
 
-async function probeIsInsideWorktree(cwd: string, deviceId: string | null): Promise<boolean> {
+async function probeIsInsideWorktree(cwd: string, deviceId: string | null): Promise<boolean | null> {
   try {
     const detect: DetectCwdResp = deviceId
       ? ((await window.electronAPI.deviceLink.invoke(deviceId, DETECT_CWD_CHANNEL, [
@@ -195,7 +198,7 @@ async function probeIsInsideWorktree(cwd: string, deviceId: string | null): Prom
       : await window.electronAPI.worktreeDetectCwd({ cwd });
     return Boolean(detect?.isInsideWorktree);
   } catch {
-    return false;
+    return null;
   }
 }
 

--- a/apps/desktop/src/renderer/features/cc-agent/sidebar/sessionWorktreeInfo.ts
+++ b/apps/desktop/src/renderer/features/cc-agent/sidebar/sessionWorktreeInfo.ts
@@ -110,14 +110,15 @@ export function useTaskInfoWorktree(
   const managed = resolveManagedWorktree(official);
   const [observed, setObserved] = useState<SessionWorktreeInfo | null>(null);
   const initialOfficialStillLive = !observeTelemetry || liveOfficial !== null;
-  const [liveness, setLiveness] = useState({ sessionId: session.id, live: initialOfficialStillLive });
-  if (liveness.sessionId !== session.id) {
-    // The hook instance is reused when the route changes. Reset synchronously
-    // from the new snapshot so the previous task's state cannot leak for a
-    // render while the effect starts its probe.
-    setLiveness({ sessionId: session.id, live: initialOfficialStillLive });
+  const [liveness, setLiveness] = useState({ sessionId: session.id, official, live: initialOfficialStillLive });
+  const matchesSnapshot = liveness.sessionId === session.id && liveness.official === official;
+  if (!matchesSnapshot) {
+    // Route changes and same-path restoration both replace the snapshot that
+    // owns this result. Match Context's metadata identity guard so an old
+    // invalid result cannot override a new authoritative row while probing.
+    setLiveness({ sessionId: session.id, official, live: initialOfficialStillLive });
   }
-  const displayedOfficialStillLive = liveness.sessionId === session.id
+  const displayedOfficialStillLive = matchesSnapshot
     ? liveness.live
     : initialOfficialStillLive;
   const officialPath = official?.path ?? null;
@@ -141,14 +142,14 @@ export function useTaskInfoWorktree(
         const live = await probeIsInsideWorktree(officialPath, deviceId);
         if (cancelled || gen !== generation) return;
         if (live === null) return; // IPC 失败不代表目录已被删除，保留上次状态。
-        setLiveness({ sessionId: session.id, live });
+        setLiveness({ sessionId: session.id, official, live });
         if (official) reportLiveness(official, live);
         if (live) {
           setObserved(null);
           return;
         }
       } else if (gen === generation) {
-        setLiveness({ sessionId: session.id, live: false });
+        setLiveness({ sessionId: session.id, official, live: false });
       }
       if (isRemote) {
         if (!cancelled && gen === generation) setObserved(null);

--- a/apps/desktop/src/renderer/features/cc-agent/sidebar/sessionWorktreeInfo.ts
+++ b/apps/desktop/src/renderer/features/cc-agent/sidebar/sessionWorktreeInfo.ts
@@ -9,7 +9,7 @@
  * 不写 store、不改变回收。目录没了摘掉徽标。外部 observed 不可 reveal。
  */
 
-import { useEffect, useRef, useState } from 'react';
+import { useEffect, useState } from 'react';
 
 import { groupingWorktreeBaseRepo } from '@cindy/maker-shared/worktree-paths';
 
@@ -110,15 +110,16 @@ export function useTaskInfoWorktree(
   const managed = resolveManagedWorktree(official);
   const [observed, setObserved] = useState<SessionWorktreeInfo | null>(null);
   const initialOfficialStillLive = !observeTelemetry || liveOfficial !== null;
-  const [officialStillLive, setOfficialStillLive] = useState(initialOfficialStillLive);
-  const livenessRef = useRef({ sessionId: session.id, live: initialOfficialStillLive });
-  if (livenessRef.current.sessionId !== session.id) {
+  const [liveness, setLiveness] = useState({ sessionId: session.id, live: initialOfficialStillLive });
+  if (liveness.sessionId !== session.id) {
     // The hook instance is reused when the route changes. Reset synchronously
     // from the new snapshot so the previous task's state cannot leak for a
     // render while the effect starts its probe.
-    livenessRef.current = { sessionId: session.id, live: initialOfficialStillLive };
+    setLiveness({ sessionId: session.id, live: initialOfficialStillLive });
   }
-  const displayedOfficialStillLive = livenessRef.current.live;
+  const displayedOfficialStillLive = liveness.sessionId === session.id
+    ? liveness.live
+    : initialOfficialStillLive;
   const officialPath = official?.path ?? null;
   const deviceId = session.deviceLinkDeviceId ?? null;
   const isRemote = Boolean(deviceId || session.remoteHostId);
@@ -126,8 +127,8 @@ export function useTaskInfoWorktree(
   useEffect(() => {
     setObserved(null);
     if (!enabled || isRemote || !observeTelemetry) {
-      livenessRef.current = { sessionId: session.id, live: !isRemote };
-      setOfficialStillLive(!isRemote);
+      // Pausing probes says nothing about directory liveness. Preserve the last
+      // result until a resumed probe actually confirms deletion or restoration.
       return;
     }
     let cancelled = false;
@@ -140,16 +141,14 @@ export function useTaskInfoWorktree(
         const live = await probeIsInsideWorktree(officialPath, deviceId);
         if (cancelled || gen !== generation) return;
         if (live === null) return; // IPC 失败不代表目录已被删除，保留上次状态。
-        livenessRef.current = { sessionId: session.id, live };
-        setOfficialStillLive(live);
+        setLiveness({ sessionId: session.id, live });
         if (official) reportLiveness(official, live);
         if (live) {
           setObserved(null);
           return;
         }
       } else if (gen === generation) {
-        livenessRef.current = { sessionId: session.id, live: false };
-        setOfficialStillLive(false);
+        setLiveness({ sessionId: session.id, live: false });
       }
       if (isRemote) {
         if (!cancelled && gen === generation) setObserved(null);

--- a/apps/desktop/src/renderer/features/cc-agent/sidebar/sessionWorktreeInfo.ts
+++ b/apps/desktop/src/renderer/features/cc-agent/sidebar/sessionWorktreeInfo.ts
@@ -100,15 +100,21 @@ export function useTaskInfoWorktree(
   enabled: boolean,
   opts?: { observeTelemetry?: boolean },
 ): SessionWorktreeInfo | null {
-  const official = useWorktreeForSession(session.id, { includeInvalid: opts?.observeTelemetry });
+  const observeTelemetry = Boolean(opts?.observeTelemetry);
+  // Keep the raw row so an invalid worktree can be re-probed, but seed the
+  // displayed liveness from the filtered snapshot. This prevents a remounted
+  // task from briefly showing a stale managed badge before its probe settles.
+  const liveOfficial = useWorktreeForSession(session.id);
+  const official = useWorktreeForSession(session.id, { includeInvalid: observeTelemetry });
   const reportLiveness = useReportWorktreeLiveness();
   const managed = resolveManagedWorktree(official);
   const [observed, setObserved] = useState<SessionWorktreeInfo | null>(null);
-  const [officialStillLive, setOfficialStillLive] = useState(true);
+  const [officialStillLive, setOfficialStillLive] = useState(
+    () => !observeTelemetry || liveOfficial !== null,
+  );
   const officialPath = official?.path ?? null;
   const deviceId = session.deviceLinkDeviceId ?? null;
   const isRemote = Boolean(deviceId || session.remoteHostId);
-  const observeTelemetry = Boolean(opts?.observeTelemetry);
 
   useEffect(() => {
     setObserved(null);

--- a/apps/desktop/src/renderer/features/cc-agent/sidebar/sessionWorktreeInfo.ts
+++ b/apps/desktop/src/renderer/features/cc-agent/sidebar/sessionWorktreeInfo.ts
@@ -9,7 +9,7 @@
  * 不写 store、不改变回收。目录没了摘掉徽标。外部 observed 不可 reveal。
  */
 
-import { useEffect, useState } from 'react';
+import { useEffect, useRef, useState } from 'react';
 
 import { groupingWorktreeBaseRepo } from '@cindy/maker-shared/worktree-paths';
 
@@ -109,9 +109,16 @@ export function useTaskInfoWorktree(
   const reportLiveness = useReportWorktreeLiveness();
   const managed = resolveManagedWorktree(official);
   const [observed, setObserved] = useState<SessionWorktreeInfo | null>(null);
-  const [officialStillLive, setOfficialStillLive] = useState(
-    () => !observeTelemetry || liveOfficial !== null,
-  );
+  const initialOfficialStillLive = !observeTelemetry || liveOfficial !== null;
+  const [officialStillLive, setOfficialStillLive] = useState(initialOfficialStillLive);
+  const livenessRef = useRef({ sessionId: session.id, live: initialOfficialStillLive });
+  if (livenessRef.current.sessionId !== session.id) {
+    // The hook instance is reused when the route changes. Reset synchronously
+    // from the new snapshot so the previous task's state cannot leak for a
+    // render while the effect starts its probe.
+    livenessRef.current = { sessionId: session.id, live: initialOfficialStillLive };
+  }
+  const displayedOfficialStillLive = livenessRef.current.live;
   const officialPath = official?.path ?? null;
   const deviceId = session.deviceLinkDeviceId ?? null;
   const isRemote = Boolean(deviceId || session.remoteHostId);
@@ -119,6 +126,7 @@ export function useTaskInfoWorktree(
   useEffect(() => {
     setObserved(null);
     if (!enabled || isRemote || !observeTelemetry) {
+      livenessRef.current = { sessionId: session.id, live: !isRemote };
       setOfficialStillLive(!isRemote);
       return;
     }
@@ -132,6 +140,7 @@ export function useTaskInfoWorktree(
         const live = await probeIsInsideWorktree(officialPath, deviceId);
         if (cancelled || gen !== generation) return;
         if (live === null) return; // IPC 失败不代表目录已被删除，保留上次状态。
+        livenessRef.current = { sessionId: session.id, live };
         setOfficialStillLive(live);
         if (official) reportLiveness(official, live);
         if (live) {
@@ -139,6 +148,7 @@ export function useTaskInfoWorktree(
           return;
         }
       } else if (gen === generation) {
+        livenessRef.current = { sessionId: session.id, live: false };
         setOfficialStillLive(false);
       }
       if (isRemote) {
@@ -190,7 +200,7 @@ export function useTaskInfoWorktree(
   return selectDisplayedWorktree({
     enabled,
     managed,
-    officialStillLive,
+    officialStillLive: displayedOfficialStillLive,
     observed,
   });
 }


### PR DESCRIPTION
## 这次改了什么

### 摘要

移除窗口聚焦和周期性任务对全部登记 worktree 的 Git 扫描，只对当前打开且处于 active 状态的任务按需检查 worktree；创建、回收、恢复继续通过事件增量更新，避免闲置 worktree 带来的进程和主线程开销。

### 变更类型

- [ ] `feat` 新功能
- [x] `fix` 缺陷修复
- [x] `refactor` / `perf` 重构或性能优化
- [ ] `docs` / `test` / `chore` 文档、测试或工程维护
- [ ] 其他：

### 范围

- 关联 Issue / 需求：无
- 本 PR 包含：WorktreeContext 的按需刷新与存活快照同步、当前任务探测、主进程探测并发/同路径合并、Git 命令超时和 IPC 错误封装、生命周期回归测试及 focus benchmark 更新。
- 明确不包含：不扩展 SSH/远程任务的 worktree 徽标和恢复入口，不修改数据库 schema，不改变 worktree 创建与回收接口；Mobile 源码未改，但其既有 detect-cwd 调用纳入本 PR 影响分析和验证。
- 用户可见变化：外部删除的 worktree 在重新打开对应任务时更新状态并显示恢复入口。
- 是否存在 breaking change：无

### UI 变化

不涉及 UI 布局、样式或文案；仅更新已有任务 worktree 状态。

- 引用的设计规范：不涉及：本次改动仅更新已有任务 worktree 状态，无视觉、交互或文案变化。

### SSH / 设备互联 / 手机版适配

- **SSH 远程工作区：本轮新增的当前任务存活检查不涉及 SSH 路径。** `sessionWorktreeInfo.ts` 在 `remoteHostId` 非空时不启动探测；新建任务由 `NewMakerDraftRoute.tsx` 的 `isRemoteProjectDraft` 传入 `worktreeDisabled`，`WorktreeChipsRow.tsx` 向 `useDetectCwd` 传 null，避免本机 Git 探测 SSH 远端路径。本 PR 保持既有 SSH 无该徽标/恢复入口的边界，不把远程文件访问改成本机 fs/Git。
- **设备互联远程控制：已适配，复用既有隧道路由与协议，无需新增通道。** 新建任务的 `useWorktreeQueries.ts` 在存在 deviceId 时通过 `deviceLink.invoke(deviceId, worktree:detect-cwd, [{ cwd }])` 转发，被控端 `dispatchLocalInvoke` 执行本 PR 的 handler/Git；不是在控制端解析被控端路径。`packages/device-link/src/allowlist.ts` 已允许该只读 invoke，本 PR 不新增 push、权限或 wire 字段，成功回包不变。探测失败由 handler 抛出脱敏的 `[INTERNAL] Worktree directory probe failed`，隧道仍使用既有 `{ ok: false, error: { code: IPC_ERROR, message } }`；Desktop 控制端保持探测失败/开关不可用，不误判为确认非 Git。当前任务徽标探测继续排除 `deviceLinkDeviceId`。
- **手机版：已适配，复用已有新建任务入口和失败处理，无需改 Mobile 代码。** `mobileMakerTransport.ts` 已发送同一 detect-cwd 请求，`app/sessions/new.tsx` 按设备/目录/连接代次探测；`MobileWorktreeDetectCwdResult` 与成功响应兼容。`newSessionWorktree.ts` 对老端 `CHANNEL_NOT_ALLOWED` 降级为 unsupported，链路瞬时错误为 recovering，新的 Git INTERNAL 错误归入 detect-failed；保留开关行、禁用资格，已勾选 worktree 时阻止创建，不能把探测失败当作非 Git 后静默创建普通目录任务。Git 探测失败不是 recovering，不会因此进入页面的 1.5 秒自动重试。

故障半径：触发的是被控端单次目录探测中的 Git 命令超时；每条命令期限为 10 秒（不是含排队和回退查询的端到端总期限），完成子进程清理后释放探测槽位并返回该请求错误。本 PR 未修改 device-link 的重试、ACK、peer teardown 或 relay 重连，不因单次 Git 失败断开共享连接。多个控制端仍共享被控端的全局 4 槽探测队列，可能排队；不声称其它请求延迟零影响。本轮未做双控制端实机联调；因未改共享链路恢复路径，不以单请求测试冒充多 peer 恢复验收。

## 怎么验证的

### 自动验证

```text
pnpm test:unit:related
结果：通过，apps/desktop 相关单测通过（60.4s）。

pnpm --filter desktop typecheck
结果：通过。

git diff --check
结果：通过。
```

### 本轮适配核对（代码基线 e07d852db）

```text
pnpm --filter desktop exec vitest run --pool=forks --maxWorkers=1 src/main/__tests__/worktreeReveal.test.ts src/main/__tests__/worktreeDetectCwd.test.ts src/renderer/hooks/__tests__/useWorktreeQueries.test.ts src/renderer/features/cc-agent/sidebar/__tests__/sessionWorktreeInfoRefresh.test.tsx src/renderer/__tests__/newMakerProjectPicker.test.ts
结果：5 个文件、133 项通过。

pnpm --filter mobile exec vitest run --maxWorkers=1 src/__tests__/newSessionWorktree.test.ts src/__tests__/mobileMakerTransport.test.ts
结果：2 个文件、67 项通过。

pnpm --filter @cindy/device-link exec vitest run --maxWorkers=1 src/__tests__/allowlist.test.ts
结果：1 个文件、45 项通过。

git diff --check
结果：通过；工作区干净，本轮仅更新 PR 说明，不修改源码。
```

以上为自动测试与源码核对，合计 8 个文件、245 项通过，不等同于真实 SSH/跨设备/手机端到端验收。另，e07d852db 推送前已运行 `node scripts/test-workspaces.mjs --tier unit`，全仓单测通过；这是前轮验证记录，本轮未重跑全仓。

### 手工验证（此前隔离 Desktop 验证记录，非本轮新增跨端联调）

- 在隔离 client 中创建真实 active 任务并打开：首次打开和连续快速聚焦均完成 worktree 检查，未出现请求堆积。
- 连续快速聚焦 3 轮、每轮 10 次：每轮启动 10 个 Git 进程，未发生全量 worktree 扫描。
- 完整验证创建、回收、恢复和外部删除；外部删除后重新打开任务能显示 worktree 已被回收并提供恢复入口。

### 未执行的验证

- 本轮未做 SSH 实机、桌面控制端到被控端、手机到被控端以及双控制端联调：本轮为适配说明核对，使用现有相关自动测试，没有建立真实远程连接。实际网络、后台休眠和设备组合行为仍未在本轮实测。
- 本轮未重复全仓单测和类型检查：代码无变动；保留此前提交验证记录，追加上述跨端定向测试。

## 风险

### 风险分类

- [ ] 无已知风险
- [ ] SQLite / migration
- [ ] system prompt
- [ ] 协议兼容
- [ ] 权限 / 安全 / 用户数据
- [ ] 存量插件兼容（批准状态 / 指纹 / manifest 校验 / 安装布局 / 包格式）
- [ ] 原生层 / fingerprint / OTA
- [ ] 跨平台差异
- [x] 其他：闲置 worktree 的外部删除不再由周期性全量扫描发现，而是在再次打开任务时检查。

### 影响与回滚

- 影响范围：Desktop Renderer 的 worktree 状态刷新、Main 的共享目录探测/超时与 IPC 错误行为、相关测试 benchmark；设备互联和 Mobile 的既有 detect-cwd 调用也会使用被控端的新实现，适配和降级结论见上文。
- 回滚方式：回滚本 PR commit 即可恢复原刷新逻辑。
- 移动端冷更判断：不会触发；改动仅位于 `apps/desktop`，未触及 `apps/mobile` 原生配置、依赖、插件或 runtime fingerprint。

### 提交前检查

- [x] 已 review 完整 diff
- [x] 每个 commit 带 DCO 签名
- [x] UI 改动已说明（本次不涉及 UI）
- [x] 未提交凭证、令牌或授权文件
- [x] 已确认测试结果