### PR TITLE
fix(desktop): AI 改名优先读取群聊用户正文

### DIFF
--- a/apps/desktop/src/main/localDb/__tests__/latestMessageText.test.ts
+++ b/apps/desktop/src/main/localDb/__tests__/latestMessageText.test.ts
@@ -219,7 +219,13 @@ describe('regenerateTitleMaterial hook user text', () => {
           index * 2 + 2,
         );
       }
-      const material = await regenerateTitleMaterial('s1', 2);
+      const material = await regenerateTitleMaterial('s1', 2, false, { preferHookUserText: true });
+      const predictionMaterial = await regenerateTitleMaterial('s1', 2);
+      expect(predictionMaterial.opening.text).toBe(background + opening);
+      expect(predictionMaterial.recent.map((m) => m.text)).toEqual([
+        background + latest,
+        '已整理修改',
+      ]);
       expect(material.opening.text).toBe(opening);
       expect(material.recent.map((m) => m.text)).toEqual([latest, '已整理修改']);
       expect(material.recent[0].text.slice(0, 300)).toBe(latest);
@@ -245,7 +251,7 @@ describe('regenerateTitleMaterial hook user text', () => {
       VALUES ('u1', 'cu1', 's1', 'user', ?, ?, 1)`,
       )
       .run(JSON.stringify({ text: '原始用户正文' }), meta);
-    const material = await regenerateTitleMaterial('s1', 8);
+    const material = await regenerateTitleMaterial('s1', 8, false, { preferHookUserText: true });
     expect(material.opening.text).toBe('原始用户正文');
     expect(material.recent.map((m) => m.text)).toEqual(['原始用户正文']);
   });

--- a/apps/desktop/src/main/localDb/__tests__/latestMessageText.test.ts
+++ b/apps/desktop/src/main/localDb/__tests__/latestMessageText.test.ts
@@ -115,9 +115,23 @@ describe('regenerateTitleMaterial pagination', () => {
         id, client_id, session_id, role, content, tool_use_id, agent_meta, created_at, rewind_at
       ) VALUES (?, ?, 's1', ?, ?, NULL, ?, ?, NULL)
     `);
-    insert.run('m1', 'c1', 'user', JSON.stringify({ text: '继续' }), JSON.stringify({ autoResume: true }), 1);
+    insert.run(
+      'm1',
+      'c1',
+      'user',
+      JSON.stringify({ text: '继续' }),
+      JSON.stringify({ autoResume: true }),
+      1,
+    );
     insert.run('m2', 'c2', 'user', JSON.stringify({ text: '真实需求：修复标题' }), null, 2);
-    insert.run('m3', 'c3', 'assistant', JSON.stringify('已完成修复'), JSON.stringify({ turnCompleted: true }), 3);
+    insert.run(
+      'm3',
+      'c3',
+      'assistant',
+      JSON.stringify('已完成修复'),
+      JSON.stringify({ turnCompleted: true }),
+      3,
+    );
 
     const material = await regenerateTitleMaterial('s1', 8);
 
@@ -137,14 +151,28 @@ describe('regenerateTitleMaterial pagination', () => {
       ) VALUES (?, ?, 's1', ?, ?, NULL, ?, ?, NULL)
     `);
     insert.run('m1', 'c1', 'user', JSON.stringify({ text: '原始需求' }), null, 1);
-    insert.run('m2', 'c2', 'assistant', JSON.stringify('历史答复'), JSON.stringify({ turnCompleted: true }), 2);
+    insert.run(
+      'm2',
+      'c2',
+      'assistant',
+      JSON.stringify('历史答复'),
+      JSON.stringify({ turnCompleted: true }),
+      2,
+    );
 
     let stateReads = 0;
     const material = await regenerateTitleMaterial('s1', 8, () => {
       stateReads += 1;
       if (stateReads === 1) {
         insert.run('m3', 'c3', 'user', JSON.stringify({ text: '新一轮需求' }), null, 3);
-        insert.run('m4', 'c4', 'assistant', JSON.stringify('施工播报'), JSON.stringify({ uuid: 'progress' }), 4);
+        insert.run(
+          'm4',
+          'c4',
+          'assistant',
+          JSON.stringify('施工播报'),
+          JSON.stringify({ uuid: 'progress' }),
+          4,
+        );
       }
       return true;
     });
@@ -156,5 +184,69 @@ describe('regenerateTitleMaterial pagination', () => {
       '新一轮需求',
     ]);
     expect(material.recent.some((message) => message.text === '施工播报')).toBe(false);
+  });
+});
+
+describe('regenerateTitleMaterial hook user text', () => {
+  it.each([false, true])(
+    'uses the authored body for opening and recent messages (JSON content: %s)',
+    async (jsonContent) => {
+      const { sqlite } = createHarness();
+      sqlite.prepare('INSERT INTO sessions (id, cleared_at) VALUES (?, NULL)').run('s1');
+      const insert = sqlite.prepare(`
+      INSERT INTO messages (id, client_id, session_id, role, content, agent_meta, created_at)
+      VALUES (?, ?, 's1', ?, ?, ?, ?)
+    `);
+      const background = `<group_chat_context>${'旧群聊背景'.repeat(100)}</group_chat_context>`;
+      const opening = '修复手机滚动卡顿';
+      const latest = '总结本周手机流畅性修改，包括草稿';
+      for (const [index, body] of [opening, latest].entries()) {
+        const text = background + body;
+        insert.run(
+          `u${index}`,
+          `cu${index}`,
+          'user',
+          jsonContent ? JSON.stringify({ text }) : text,
+          JSON.stringify({ hookSource: { im: 'telegram', userText: body } }),
+          index * 2 + 1,
+        );
+        insert.run(
+          `a${index}`,
+          `ca${index}`,
+          'assistant',
+          JSON.stringify('已整理修改'),
+          JSON.stringify({ turnCompleted: true, hookSource: { userText: '不应替换助手回复' } }),
+          index * 2 + 2,
+        );
+      }
+      const material = await regenerateTitleMaterial('s1', 2);
+      expect(material.opening.text).toBe(opening);
+      expect(material.recent.map((m) => m.text)).toEqual([latest, '已整理修改']);
+      expect(material.recent[0].text.slice(0, 300)).toBe(latest);
+    },
+  );
+
+  it.each([
+    null,
+    '{broken',
+    '[]',
+    JSON.stringify({ hookSource: null }),
+    JSON.stringify({ hookSource: [] }),
+    JSON.stringify({ hookSource: { im: 'telegram' } }),
+    JSON.stringify({ hookSource: { userText: 42 } }),
+    JSON.stringify({ hookSource: { userText: '' } }),
+    JSON.stringify({ hookSource: { userText: '   ' } }),
+  ])('preserves legacy and ordinary content for metadata %s', async (meta) => {
+    const { sqlite } = createHarness();
+    sqlite.prepare('INSERT INTO sessions (id, cleared_at) VALUES (?, NULL)').run('s1');
+    sqlite
+      .prepare(
+        `INSERT INTO messages (id, client_id, session_id, role, content, agent_meta, created_at)
+      VALUES ('u1', 'cu1', 's1', 'user', ?, ?, 1)`,
+      )
+      .run(JSON.stringify({ text: '原始用户正文' }), meta);
+    const material = await regenerateTitleMaterial('s1', 8);
+    expect(material.opening.text).toBe('原始用户正文');
+    expect(material.recent.map((m) => m.text)).toEqual(['原始用户正文']);
   });
 });

--- a/apps/desktop/src/main/localDb/latestMessageText.ts
+++ b/apps/desktop/src/main/localDb/latestMessageText.ts
@@ -123,10 +123,9 @@ interface RecentTitleDbRow {
 
 function toTitleMessageCandidate(row: RecentTitleDbRow): TitleMessageCandidate | null {
   const role = row.role === 'user' ? 'user' : 'assistant';
-  const text = extractText(row.content, role);
-  if (!text) return null;
-
   const agentMeta = parseTitleAgentMeta(row.agentMeta);
+  const text = extractTitleMessageText(row.content, role, agentMeta);
+  if (!text) return null;
   return {
     role,
     text,
@@ -135,6 +134,24 @@ function toTitleMessageCandidate(row: RecentTitleDbRow): TitleMessageCandidate |
     toolUseId: row.toolUseId ?? null,
     agentMeta,
   };
+}
+
+/** Use the persisted user-authored body before the caller applies its title budget. */
+function extractTitleMessageText(
+  content: string,
+  role: 'user' | 'assistant',
+  agentMeta: Record<string, unknown> | null,
+): string {
+  const source = agentMeta?.hookSource;
+  if (role === 'user' && source && typeof source === 'object' && !Array.isArray(source)) {
+    const userText = (source as Record<string, unknown>).userText;
+    if (typeof userText === 'string' && userText.trim()) {
+      // Match hook dispatch's empty-body fallback and preserve the existing
+      // synthetic-input filtering for authored text.
+      return extractText(JSON.stringify({ text: userText.trim() }), role);
+    }
+  }
+  return extractText(content, role);
 }
 
 function parseTitleAgentMeta(raw: string | null): Record<string, unknown> | null {
@@ -337,8 +354,9 @@ async function firstUserMessageWithClearedAt(
     .orderBy(asc(messages.createdAt), asc(messageRowid))
     .limit(OPENING_SCAN_LIMIT);
   for (const row of rows) {
-    if (!isVisibleTitleUser(parseTitleAgentMeta(row.agentMeta))) continue;
-    const text = extractText(row.content, 'user');
+    const agentMeta = parseTitleAgentMeta(row.agentMeta);
+    if (!isVisibleTitleUser(agentMeta)) continue;
+    const text = extractTitleMessageText(row.content, 'user', agentMeta);
     if (text) return { text, createdAt: row.createdAt ?? null, rowid: row.rowid };
   }
   return { text: '', createdAt: null, rowid: null };
@@ -367,13 +385,9 @@ export async function regenerateTitleMaterial(
     .where(eq(messages.sessionId, sessionId))
     .get();
   const inFlightAfterSnapshotSubmit = readLatestTurnIsInFlight();
-  const [clearedAt, snapshot] = await Promise.all([
-    sessionClearedAt(sessionId),
-    snapshotPromise,
-  ]);
+  const [clearedAt, snapshot] = await Promise.all([sessionClearedAt(sessionId), snapshotPromise]);
   const snapshotUpperRowid = snapshot?.rowid ?? null;
-  const snapshotLatestTurnIsInFlight =
-    inFlightBeforeSnapshot || inFlightAfterSnapshotSubmit;
+  const snapshotLatestTurnIsInFlight = inFlightBeforeSnapshot || inFlightAfterSnapshotSubmit;
   const [recent, opening] = await Promise.all([
     recentMessagesWithClearedAt(
       sessionId,

--- a/apps/desktop/src/main/localDb/latestMessageText.ts
+++ b/apps/desktop/src/main/localDb/latestMessageText.ts
@@ -121,10 +121,13 @@ interface RecentTitleDbRow {
   rowid: number;
 }
 
-function toTitleMessageCandidate(row: RecentTitleDbRow): TitleMessageCandidate | null {
+function toTitleMessageCandidate(
+  row: RecentTitleDbRow,
+  preferHookUserText: boolean,
+): TitleMessageCandidate | null {
   const role = row.role === 'user' ? 'user' : 'assistant';
   const agentMeta = parseTitleAgentMeta(row.agentMeta);
-  const text = extractTitleMessageText(row.content, role, agentMeta);
+  const text = extractTitleMessageText(row.content, role, agentMeta, preferHookUserText);
   if (!text) return null;
   return {
     role,
@@ -141,9 +144,16 @@ function extractTitleMessageText(
   content: string,
   role: 'user' | 'assistant',
   agentMeta: Record<string, unknown> | null,
+  preferHookUserText: boolean,
 ): string {
   const source = agentMeta?.hookSource;
-  if (role === 'user' && source && typeof source === 'object' && !Array.isArray(source)) {
+  if (
+    preferHookUserText &&
+    role === 'user' &&
+    source &&
+    typeof source === 'object' &&
+    !Array.isArray(source)
+  ) {
     const userText = (source as Record<string, unknown>).userText;
     if (typeof userText === 'string' && userText.trim()) {
       // Match hook dispatch's empty-body fallback and preserve the existing
@@ -229,6 +239,7 @@ async function recentMessagesWithClearedAt(
   clearedAt: number | null,
   snapshotUpperRowid: number | null,
   latestTurnIsInFlight: boolean,
+  preferHookUserText: boolean,
 ): Promise<RecentMessage[]> {
   if (limit <= 0 || snapshotUpperRowid == null) return [];
   const db = getDbClient().drizzle;
@@ -280,7 +291,7 @@ async function recentMessagesWithClearedAt(
     };
 
     const pageCandidates = rows
-      .map(toTitleMessageCandidate)
+      .map((row) => toTitleMessageCandidate(row, preferHookUserText))
       .filter((candidate): candidate is TitleMessageCandidate => candidate !== null);
     candidates.push(...pageCandidates);
     for (const candidate of pageCandidates) {
@@ -332,6 +343,7 @@ async function firstUserMessageWithClearedAt(
   sessionId: string,
   clearedAt: number | null,
   snapshotUpperRowid: number | null,
+  preferHookUserText: boolean,
 ): Promise<OpeningMessage> {
   if (snapshotUpperRowid == null) return { text: '', createdAt: null, rowid: null };
   const db = getDbClient().drizzle;
@@ -356,7 +368,7 @@ async function firstUserMessageWithClearedAt(
   for (const row of rows) {
     const agentMeta = parseTitleAgentMeta(row.agentMeta);
     if (!isVisibleTitleUser(agentMeta)) continue;
-    const text = extractTitleMessageText(row.content, 'user', agentMeta);
+    const text = extractTitleMessageText(row.content, 'user', agentMeta, preferHookUserText);
     if (text) return { text, createdAt: row.createdAt ?? null, rowid: row.rowid };
   }
   return { text: '', createdAt: null, rowid: null };
@@ -370,6 +382,8 @@ export async function regenerateTitleMaterial(
   sessionId: string,
   recentLimit: number,
   latestTurnIsInFlight: boolean | (() => boolean) = false,
+  // Prompt prediction also consumes this material and needs injected context.
+  options: { preferHookUserText?: boolean } = {},
 ): Promise<RegenerateTitleMaterial> {
   const readLatestTurnIsInFlight = (): boolean =>
     typeof latestTurnIsInFlight === 'function'
@@ -395,8 +409,14 @@ export async function regenerateTitleMaterial(
       clearedAt,
       snapshotUpperRowid,
       snapshotLatestTurnIsInFlight,
+      options.preferHookUserText === true,
     ),
-    firstUserMessageWithClearedAt(sessionId, clearedAt, snapshotUpperRowid),
+    firstUserMessageWithClearedAt(
+      sessionId,
+      clearedAt,
+      snapshotUpperRowid,
+      options.preferHookUserText === true,
+    ),
   ]);
   return { recent, opening };
 }

--- a/apps/desktop/src/main/maker-ipc/__tests__/autoTitleIpcBoundary.test.ts
+++ b/apps/desktop/src/main/maker-ipc/__tests__/autoTitleIpcBoundary.test.ts
@@ -171,6 +171,7 @@ describe('maker:regenerate-title — 当前 turn 状态', () => {
       's-running',
       expect.any(Number),
       expect.any(Function),
+      { preferHookUserText: true },
     );
   });
 
@@ -197,6 +198,7 @@ describe('maker:regenerate-title — 当前 turn 状态', () => {
       's-completed',
       expect.any(Number),
       expect.any(Function),
+      { preferHookUserText: true },
     );
   });
 
@@ -227,6 +229,7 @@ describe('maker:regenerate-title — 当前 turn 状态', () => {
       's-new-turn',
       expect.any(Number),
       expect.any(Function),
+      { preferHookUserText: true },
     );
   });
 
@@ -252,6 +255,7 @@ describe('maker:regenerate-title — 当前 turn 状态', () => {
       's-snapshot-race',
       expect.any(Number),
       expect.any(Function),
+      { preferHookUserText: true },
     );
   });
 });

--- a/apps/desktop/src/main/maker-ipc/title.ts
+++ b/apps/desktop/src/main/maker-ipc/title.ts
@@ -155,7 +155,10 @@ async function readSessionAgentKindFromDb(sessionId: string): Promise<AgentKind 
 
 const defaultRegenerateDeps: RegenerateTitleDeps = {
   readSessionAgentKind: readSessionAgentKindFromDb,
-  collectMaterial: regenerateTitleMaterial,
+  collectMaterial: (sessionId, recentLimit, latestTurnIsInFlight) =>
+    regenerateTitleMaterial(sessionId, recentLimit, latestTurnIsInFlight, {
+      preferHookUserText: true,
+    }),
   generateTitle: (sessionId, agentKind, prompt) =>
     generateTitleWithAuxiliaryModelResult(
       { sessionId, agentKind, prompt },


### PR DESCRIPTION
## 这次改了什么

### 摘要

群聊触发的任务消息可能以很长的群聊历史开头。手动 AI 改名此前直接截取消息前 300 字，导致真正的用户要求没有进入标题素材，标题继续围绕旧话题生成。

现在手动 AI 改名显式启用正文投影，开场和最近消息统一优先读取已持久化的 `agentMeta.hookSource.userText`，再使用既有标题预算。共享素材读取默认保留群聊上下文，推荐下一步输入保持原行为。仅处理用户消息；缺字段、空白正文或非法元数据回退现有提取逻辑，助手回复不变。

### 变更类型

- [x] `fix` 缺陷修复

### 范围

- 关联 Issue / 需求：群聊任务的 AI 改名偏向注入历史。
- 本 PR 包含：两条标题素材路径的正文提取与 11 个新增回归用例。
- 明确不包含：标题长度校验与辅助模型 fallback 调整。
- 用户可见变化：改名可读到用户原始要求，避免群历史挤占输入预算。
- 是否存在 breaking change：无。

### UI 变化

- 引用的设计规范：不涉及；无界面、交互、样式或 UI 文案改动。

## 怎么验证的

### 自动验证

- `corepack pnpm test:unit:related`：通过。
- `corepack pnpm --filter desktop run typecheck`：通过。
- 定向 Vitest：`latestMessageText.test.ts` 14 个、`latestMessageText.logic.test.ts` 13 个，以及 `autoTitleIpcBoundary.test.ts` 36 个全部通过（共 63 个），覆盖仅改名启用正文投影及默认上下文保留。
- `corepack pnpm --filter desktop run test:db`：整体未通过；其中 `claudeLocalSessions.test.ts` 的 5 个用例报 `no such column: list_preview`，已在相同基线 `afa8a51b2` 的干净 worktree 定向复现相同 5 个失败。本 PR 不修改该导入逻辑或 schema。
- `git diff --check`：通过。

### 手工验证

已检查完整 diff，确认 SQL、clear/rewind 可见性、快照和完成轮次筛选不变。新增用例使用内存数据库与虚构消息，覆盖长背景、原始/JSON 正文、开场、最近消息、助手回复以及旧数据回退。

### 未执行的验证

未将修复安装到运行中的客户端，未做修复后的实机点按或真实模型复验。

## 风险

### 风险分类

- [x] 其他：标题素材选取变化；不涉及 schema、migration、系统提示词、权限或协议变更。

### 影响与回滚

- 影响范围：Desktop 手动 AI 改名的开场与最近消息素材；自动起名和卡片摘要不变。
- 回滚 / 降级方式：回退本提交；缺失或无效原始正文继续使用原有提取路径，无数据迁移。

### 提交前检查

- [x] 已 review 完整 diff
- [x] 每个 commit 都带 DCO 签名
- [x] UI 改动已在「UI 变化」说明不涉及
- [x] 未提交凭证、令牌或授权文件
- [x] 已补充必要文档（范围及验证说明见本 PR，无新增独立文档需求）
- [x] 已确认测试结果或说明未执行原因
