### PR TITLE
fix(file-browser): 无 NUL 字节的 PDF 按二进制识别,进入既有 PdfPreview

### DIFF
--- a/packages/file-browser-core/src/__tests__/fixtures/nul-free.pdf
+++ b/packages/file-browser-core/src/__tests__/fixtures/nul-free.pdf
@@ -1,0 +1,341 @@
+%PDF-1.4
+1 0 obj
+<< /Type /Catalog /Pages 2 0 R >>
+endobj
+2 0 obj
+<< /Type /Pages /Kids [4 0 R 6 0 R 8 0 R 10 0 R 12 0 R 14 0 R 16 0 R 18 0 R 20 0 R 22 0 R 24 0 R 26 0 R 28 0 R 30 0 R 32 0 R 34 0 R] /Count 16 >>
+endobj
+3 0 obj
+<< /Type /Font /Subtype /Type1 /BaseFont /Helvetica >>
+endobj
+4 0 obj
+<< /Type /Page /Parent 2 0 R /MediaBox [0 0 612 792] /Resources << /Font << /F1 3 0 R >> >> /Contents 5 0 R >>
+endobj
+5 0 obj
+<< /Length 504 >>
+stream
+q
+0.95 0.95 0.95 rg 36 714 540 36 re f
+0 0 0 rg
+BT /F1 18 Tf 48 734 Td (BH-003 ASCII PDF reproduction | Page 1) Tj ET
+0.2 0.45 0.8 RG 2 w 36 42 540 660 re S
+BT /F1 12 Tf 52 676 Td (BH-003 PDF reproduction fixture - page 1 of 16) Tj ET
+BT /F1 12 Tf 52 652 Td (This is a valid ASCII-only PDF with no NUL byte in the first 4 KiB.) Tj ET
+BT /F1 12 Tf 52 628 Td (It should be recognized by file extension/signature and rendered as PDF.) Tj ET
+BT /F1 12 Tf 52 604 Td (Unique marker: ASCII-PDF-REPRO-01) Tj ET
+Q
+endstream
+endobj
+6 0 obj
+<< /Type /Page /Parent 2 0 R /MediaBox [0 0 612 792] /Resources << /Font << /F1 3 0 R >> >> /Contents 7 0 R >>
+endobj
+7 0 obj
+<< /Length 504 >>
+stream
+q
+0.95 0.95 0.95 rg 36 714 540 36 re f
+0 0 0 rg
+BT /F1 18 Tf 48 734 Td (BH-003 ASCII PDF reproduction | Page 2) Tj ET
+0.2 0.45 0.8 RG 2 w 36 42 540 660 re S
+BT /F1 12 Tf 52 676 Td (BH-003 PDF reproduction fixture - page 2 of 16) Tj ET
+BT /F1 12 Tf 52 652 Td (This is a valid ASCII-only PDF with no NUL byte in the first 4 KiB.) Tj ET
+BT /F1 12 Tf 52 628 Td (It should be recognized by file extension/signature and rendered as PDF.) Tj ET
+BT /F1 12 Tf 52 604 Td (Unique marker: ASCII-PDF-REPRO-02) Tj ET
+Q
+endstream
+endobj
+8 0 obj
+<< /Type /Page /Parent 2 0 R /MediaBox [0 0 612 792] /Resources << /Font << /F1 3 0 R >> >> /Contents 9 0 R >>
+endobj
+9 0 obj
+<< /Length 504 >>
+stream
+q
+0.95 0.95 0.95 rg 36 714 540 36 re f
+0 0 0 rg
+BT /F1 18 Tf 48 734 Td (BH-003 ASCII PDF reproduction | Page 3) Tj ET
+0.2 0.45 0.8 RG 2 w 36 42 540 660 re S
+BT /F1 12 Tf 52 676 Td (BH-003 PDF reproduction fixture - page 3 of 16) Tj ET
+BT /F1 12 Tf 52 652 Td (This is a valid ASCII-only PDF with no NUL byte in the first 4 KiB.) Tj ET
+BT /F1 12 Tf 52 628 Td (It should be recognized by file extension/signature and rendered as PDF.) Tj ET
+BT /F1 12 Tf 52 604 Td (Unique marker: ASCII-PDF-REPRO-03) Tj ET
+Q
+endstream
+endobj
+10 0 obj
+<< /Type /Page /Parent 2 0 R /MediaBox [0 0 612 792] /Resources << /Font << /F1 3 0 R >> >> /Contents 11 0 R >>
+endobj
+11 0 obj
+<< /Length 504 >>
+stream
+q
+0.95 0.95 0.95 rg 36 714 540 36 re f
+0 0 0 rg
+BT /F1 18 Tf 48 734 Td (BH-003 ASCII PDF reproduction | Page 4) Tj ET
+0.2 0.45 0.8 RG 2 w 36 42 540 660 re S
+BT /F1 12 Tf 52 676 Td (BH-003 PDF reproduction fixture - page 4 of 16) Tj ET
+BT /F1 12 Tf 52 652 Td (This is a valid ASCII-only PDF with no NUL byte in the first 4 KiB.) Tj ET
+BT /F1 12 Tf 52 628 Td (It should be recognized by file extension/signature and rendered as PDF.) Tj ET
+BT /F1 12 Tf 52 604 Td (Unique marker: ASCII-PDF-REPRO-04) Tj ET
+Q
+endstream
+endobj
+12 0 obj
+<< /Type /Page /Parent 2 0 R /MediaBox [0 0 612 792] /Resources << /Font << /F1 3 0 R >> >> /Contents 13 0 R >>
+endobj
+13 0 obj
+<< /Length 504 >>
+stream
+q
+0.95 0.95 0.95 rg 36 714 540 36 re f
+0 0 0 rg
+BT /F1 18 Tf 48 734 Td (BH-003 ASCII PDF reproduction | Page 5) Tj ET
+0.2 0.45 0.8 RG 2 w 36 42 540 660 re S
+BT /F1 12 Tf 52 676 Td (BH-003 PDF reproduction fixture - page 5 of 16) Tj ET
+BT /F1 12 Tf 52 652 Td (This is a valid ASCII-only PDF with no NUL byte in the first 4 KiB.) Tj ET
+BT /F1 12 Tf 52 628 Td (It should be recognized by file extension/signature and rendered as PDF.) Tj ET
+BT /F1 12 Tf 52 604 Td (Unique marker: ASCII-PDF-REPRO-05) Tj ET
+Q
+endstream
+endobj
+14 0 obj
+<< /Type /Page /Parent 2 0 R /MediaBox [0 0 612 792] /Resources << /Font << /F1 3 0 R >> >> /Contents 15 0 R >>
+endobj
+15 0 obj
+<< /Length 504 >>
+stream
+q
+0.95 0.95 0.95 rg 36 714 540 36 re f
+0 0 0 rg
+BT /F1 18 Tf 48 734 Td (BH-003 ASCII PDF reproduction | Page 6) Tj ET
+0.2 0.45 0.8 RG 2 w 36 42 540 660 re S
+BT /F1 12 Tf 52 676 Td (BH-003 PDF reproduction fixture - page 6 of 16) Tj ET
+BT /F1 12 Tf 52 652 Td (This is a valid ASCII-only PDF with no NUL byte in the first 4 KiB.) Tj ET
+BT /F1 12 Tf 52 628 Td (It should be recognized by file extension/signature and rendered as PDF.) Tj ET
+BT /F1 12 Tf 52 604 Td (Unique marker: ASCII-PDF-REPRO-06) Tj ET
+Q
+endstream
+endobj
+16 0 obj
+<< /Type /Page /Parent 2 0 R /MediaBox [0 0 612 792] /Resources << /Font << /F1 3 0 R >> >> /Contents 17 0 R >>
+endobj
+17 0 obj
+<< /Length 504 >>
+stream
+q
+0.95 0.95 0.95 rg 36 714 540 36 re f
+0 0 0 rg
+BT /F1 18 Tf 48 734 Td (BH-003 ASCII PDF reproduction | Page 7) Tj ET
+0.2 0.45 0.8 RG 2 w 36 42 540 660 re S
+BT /F1 12 Tf 52 676 Td (BH-003 PDF reproduction fixture - page 7 of 16) Tj ET
+BT /F1 12 Tf 52 652 Td (This is a valid ASCII-only PDF with no NUL byte in the first 4 KiB.) Tj ET
+BT /F1 12 Tf 52 628 Td (It should be recognized by file extension/signature and rendered as PDF.) Tj ET
+BT /F1 12 Tf 52 604 Td (Unique marker: ASCII-PDF-REPRO-07) Tj ET
+Q
+endstream
+endobj
+18 0 obj
+<< /Type /Page /Parent 2 0 R /MediaBox [0 0 612 792] /Resources << /Font << /F1 3 0 R >> >> /Contents 19 0 R >>
+endobj
+19 0 obj
+<< /Length 504 >>
+stream
+q
+0.95 0.95 0.95 rg 36 714 540 36 re f
+0 0 0 rg
+BT /F1 18 Tf 48 734 Td (BH-003 ASCII PDF reproduction | Page 8) Tj ET
+0.2 0.45 0.8 RG 2 w 36 42 540 660 re S
+BT /F1 12 Tf 52 676 Td (BH-003 PDF reproduction fixture - page 8 of 16) Tj ET
+BT /F1 12 Tf 52 652 Td (This is a valid ASCII-only PDF with no NUL byte in the first 4 KiB.) Tj ET
+BT /F1 12 Tf 52 628 Td (It should be recognized by file extension/signature and rendered as PDF.) Tj ET
+BT /F1 12 Tf 52 604 Td (Unique marker: ASCII-PDF-REPRO-08) Tj ET
+Q
+endstream
+endobj
+20 0 obj
+<< /Type /Page /Parent 2 0 R /MediaBox [0 0 612 792] /Resources << /Font << /F1 3 0 R >> >> /Contents 21 0 R >>
+endobj
+21 0 obj
+<< /Length 504 >>
+stream
+q
+0.95 0.95 0.95 rg 36 714 540 36 re f
+0 0 0 rg
+BT /F1 18 Tf 48 734 Td (BH-003 ASCII PDF reproduction | Page 9) Tj ET
+0.2 0.45 0.8 RG 2 w 36 42 540 660 re S
+BT /F1 12 Tf 52 676 Td (BH-003 PDF reproduction fixture - page 9 of 16) Tj ET
+BT /F1 12 Tf 52 652 Td (This is a valid ASCII-only PDF with no NUL byte in the first 4 KiB.) Tj ET
+BT /F1 12 Tf 52 628 Td (It should be recognized by file extension/signature and rendered as PDF.) Tj ET
+BT /F1 12 Tf 52 604 Td (Unique marker: ASCII-PDF-REPRO-09) Tj ET
+Q
+endstream
+endobj
+22 0 obj
+<< /Type /Page /Parent 2 0 R /MediaBox [0 0 612 792] /Resources << /Font << /F1 3 0 R >> >> /Contents 23 0 R >>
+endobj
+23 0 obj
+<< /Length 506 >>
+stream
+q
+0.95 0.95 0.95 rg 36 714 540 36 re f
+0 0 0 rg
+BT /F1 18 Tf 48 734 Td (BH-003 ASCII PDF reproduction | Page 10) Tj ET
+0.2 0.45 0.8 RG 2 w 36 42 540 660 re S
+BT /F1 12 Tf 52 676 Td (BH-003 PDF reproduction fixture - page 10 of 16) Tj ET
+BT /F1 12 Tf 52 652 Td (This is a valid ASCII-only PDF with no NUL byte in the first 4 KiB.) Tj ET
+BT /F1 12 Tf 52 628 Td (It should be recognized by file extension/signature and rendered as PDF.) Tj ET
+BT /F1 12 Tf 52 604 Td (Unique marker: ASCII-PDF-REPRO-10) Tj ET
+Q
+endstream
+endobj
+24 0 obj
+<< /Type /Page /Parent 2 0 R /MediaBox [0 0 612 792] /Resources << /Font << /F1 3 0 R >> >> /Contents 25 0 R >>
+endobj
+25 0 obj
+<< /Length 506 >>
+stream
+q
+0.95 0.95 0.95 rg 36 714 540 36 re f
+0 0 0 rg
+BT /F1 18 Tf 48 734 Td (BH-003 ASCII PDF reproduction | Page 11) Tj ET
+0.2 0.45 0.8 RG 2 w 36 42 540 660 re S
+BT /F1 12 Tf 52 676 Td (BH-003 PDF reproduction fixture - page 11 of 16) Tj ET
+BT /F1 12 Tf 52 652 Td (This is a valid ASCII-only PDF with no NUL byte in the first 4 KiB.) Tj ET
+BT /F1 12 Tf 52 628 Td (It should be recognized by file extension/signature and rendered as PDF.) Tj ET
+BT /F1 12 Tf 52 604 Td (Unique marker: ASCII-PDF-REPRO-11) Tj ET
+Q
+endstream
+endobj
+26 0 obj
+<< /Type /Page /Parent 2 0 R /MediaBox [0 0 612 792] /Resources << /Font << /F1 3 0 R >> >> /Contents 27 0 R >>
+endobj
+27 0 obj
+<< /Length 506 >>
+stream
+q
+0.95 0.95 0.95 rg 36 714 540 36 re f
+0 0 0 rg
+BT /F1 18 Tf 48 734 Td (BH-003 ASCII PDF reproduction | Page 12) Tj ET
+0.2 0.45 0.8 RG 2 w 36 42 540 660 re S
+BT /F1 12 Tf 52 676 Td (BH-003 PDF reproduction fixture - page 12 of 16) Tj ET
+BT /F1 12 Tf 52 652 Td (This is a valid ASCII-only PDF with no NUL byte in the first 4 KiB.) Tj ET
+BT /F1 12 Tf 52 628 Td (It should be recognized by file extension/signature and rendered as PDF.) Tj ET
+BT /F1 12 Tf 52 604 Td (Unique marker: ASCII-PDF-REPRO-12) Tj ET
+Q
+endstream
+endobj
+28 0 obj
+<< /Type /Page /Parent 2 0 R /MediaBox [0 0 612 792] /Resources << /Font << /F1 3 0 R >> >> /Contents 29 0 R >>
+endobj
+29 0 obj
+<< /Length 506 >>
+stream
+q
+0.95 0.95 0.95 rg 36 714 540 36 re f
+0 0 0 rg
+BT /F1 18 Tf 48 734 Td (BH-003 ASCII PDF reproduction | Page 13) Tj ET
+0.2 0.45 0.8 RG 2 w 36 42 540 660 re S
+BT /F1 12 Tf 52 676 Td (BH-003 PDF reproduction fixture - page 13 of 16) Tj ET
+BT /F1 12 Tf 52 652 Td (This is a valid ASCII-only PDF with no NUL byte in the first 4 KiB.) Tj ET
+BT /F1 12 Tf 52 628 Td (It should be recognized by file extension/signature and rendered as PDF.) Tj ET
+BT /F1 12 Tf 52 604 Td (Unique marker: ASCII-PDF-REPRO-13) Tj ET
+Q
+endstream
+endobj
+30 0 obj
+<< /Type /Page /Parent 2 0 R /MediaBox [0 0 612 792] /Resources << /Font << /F1 3 0 R >> >> /Contents 31 0 R >>
+endobj
+31 0 obj
+<< /Length 506 >>
+stream
+q
+0.95 0.95 0.95 rg 36 714 540 36 re f
+0 0 0 rg
+BT /F1 18 Tf 48 734 Td (BH-003 ASCII PDF reproduction | Page 14) Tj ET
+0.2 0.45 0.8 RG 2 w 36 42 540 660 re S
+BT /F1 12 Tf 52 676 Td (BH-003 PDF reproduction fixture - page 14 of 16) Tj ET
+BT /F1 12 Tf 52 652 Td (This is a valid ASCII-only PDF with no NUL byte in the first 4 KiB.) Tj ET
+BT /F1 12 Tf 52 628 Td (It should be recognized by file extension/signature and rendered as PDF.) Tj ET
+BT /F1 12 Tf 52 604 Td (Unique marker: ASCII-PDF-REPRO-14) Tj ET
+Q
+endstream
+endobj
+32 0 obj
+<< /Type /Page /Parent 2 0 R /MediaBox [0 0 612 792] /Resources << /Font << /F1 3 0 R >> >> /Contents 33 0 R >>
+endobj
+33 0 obj
+<< /Length 506 >>
+stream
+q
+0.95 0.95 0.95 rg 36 714 540 36 re f
+0 0 0 rg
+BT /F1 18 Tf 48 734 Td (BH-003 ASCII PDF reproduction | Page 15) Tj ET
+0.2 0.45 0.8 RG 2 w 36 42 540 660 re S
+BT /F1 12 Tf 52 676 Td (BH-003 PDF reproduction fixture - page 15 of 16) Tj ET
+BT /F1 12 Tf 52 652 Td (This is a valid ASCII-only PDF with no NUL byte in the first 4 KiB.) Tj ET
+BT /F1 12 Tf 52 628 Td (It should be recognized by file extension/signature and rendered as PDF.) Tj ET
+BT /F1 12 Tf 52 604 Td (Unique marker: ASCII-PDF-REPRO-15) Tj ET
+Q
+endstream
+endobj
+34 0 obj
+<< /Type /Page /Parent 2 0 R /MediaBox [0 0 612 792] /Resources << /Font << /F1 3 0 R >> >> /Contents 35 0 R >>
+endobj
+35 0 obj
+<< /Length 506 >>
+stream
+q
+0.95 0.95 0.95 rg 36 714 540 36 re f
+0 0 0 rg
+BT /F1 18 Tf 48 734 Td (BH-003 ASCII PDF reproduction | Page 16) Tj ET
+0.2 0.45 0.8 RG 2 w 36 42 540 660 re S
+BT /F1 12 Tf 52 676 Td (BH-003 PDF reproduction fixture - page 16 of 16) Tj ET
+BT /F1 12 Tf 52 652 Td (This is a valid ASCII-only PDF with no NUL byte in the first 4 KiB.) Tj ET
+BT /F1 12 Tf 52 628 Td (It should be recognized by file extension/signature and rendered as PDF.) Tj ET
+BT /F1 12 Tf 52 604 Td (Unique marker: ASCII-PDF-REPRO-16) Tj ET
+Q
+endstream
+endobj
+xref
+0 36
+0000000000 65535 f 
+0000000009 00000 n 
+0000000058 00000 n 
+0000000219 00000 n 
+0000000289 00000 n 
+0000000415 00000 n 
+0000000970 00000 n 
+0000001096 00000 n 
+0000001651 00000 n 
+0000001777 00000 n 
+0000002332 00000 n 
+0000002460 00000 n 
+0000003016 00000 n 
+0000003144 00000 n 
+0000003700 00000 n 
+0000003828 00000 n 
+0000004384 00000 n 
+0000004512 00000 n 
+0000005068 00000 n 
+0000005196 00000 n 
+0000005752 00000 n 
+0000005880 00000 n 
+0000006436 00000 n 
+0000006564 00000 n 
+0000007122 00000 n 
+0000007250 00000 n 
+0000007808 00000 n 
+0000007936 00000 n 
+0000008494 00000 n 
+0000008622 00000 n 
+0000009180 00000 n 
+0000009308 00000 n 
+0000009866 00000 n 
+0000009994 00000 n 
+0000010552 00000 n 
+0000010680 00000 n 
+trailer
+<< /Size 36 /Root 1 0 R >>
+startxref
+11238
+%%EOF

--- a/packages/file-browser-core/src/__tests__/scanner.test.ts
+++ b/packages/file-browser-core/src/__tests__/scanner.test.ts
@@ -255,13 +255,37 @@ describe('readFile binary detection', () => {
     }
   });
 
-  it('still returns plain text that only mentions %PDF- past the header window', async () => {
+  it('keeps a non-.pdf text file that quotes %PDF- in its first line as text', async () => {
+    const root = await mkdtemp(path.join(os.tmpdir(), 'xdt-file-browser-'));
+    try {
+      const notes = `# PDF header\nEvery PDF starts with %PDF-1.x followed by objects.\n`;
+      await fsWriteFile(path.join(root, 'notes.md'), notes, 'utf8');
+      const result = await readFile(root, 'notes.md');
+      expect(result.content).toBe(notes);
+      await writeFile(root, 'notes.md', `${notes}edited\n`);
+      expect(await fsReadFile(path.join(root, 'notes.md'), 'utf8')).toBe(`${notes}edited\n`);
+    } finally {
+      await rm(root, { recursive: true, force: true });
+    }
+  });
+
+  it('matches the .pdf extension case-insensitively', async () => {
+    const root = await mkdtemp(path.join(os.tmpdir(), 'xdt-file-browser-'));
+    try {
+      await fsWriteFile(path.join(root, 'SCAN.PDF'), MINIMAL_NUL_FREE_PDF, 'latin1');
+      await expectBinaryFileError(readFile(root, 'SCAN.PDF'));
+    } finally {
+      await rm(root, { recursive: true, force: true });
+    }
+  });
+
+  it('still returns a .pdf-named text file when the header lies past the 1 KiB window', async () => {
     const root = await mkdtemp(path.join(os.tmpdir(), 'xdt-file-browser-'));
     try {
       const notes = `${'# PDF notes\n'.repeat(120)}The header is %PDF-1.7 followed by objects.\n`;
       expect(notes.indexOf('%PDF-')).toBeGreaterThan(1024);
-      await fsWriteFile(path.join(root, 'notes.md'), notes, 'utf8');
-      const result = await readFile(root, 'notes.md');
+      await fsWriteFile(path.join(root, 'notes.pdf'), notes, 'utf8');
+      const result = await readFile(root, 'notes.pdf');
       expect(result.content).toBe(notes);
       expect(result.truncated).toBe(false);
     } finally {

--- a/packages/file-browser-core/src/__tests__/scanner.test.ts
+++ b/packages/file-browser-core/src/__tests__/scanner.test.ts
@@ -198,3 +198,85 @@ describe('readFileChunk', () => {
     }
   });
 });
+
+/** 最小合法 PDF:一页、无压缩对象流、整份文件不含 NUL 字节。 */
+const MINIMAL_NUL_FREE_PDF = [
+  '%PDF-1.4',
+  '1 0 obj',
+  '<< /Type /Catalog /Pages 2 0 R >>',
+  'endobj',
+  '2 0 obj',
+  '<< /Type /Pages /Kids [3 0 R] /Count 1 >>',
+  'endobj',
+  '3 0 obj',
+  '<< /Type /Page /Parent 2 0 R /MediaBox [0 0 200 100] >>',
+  'endobj',
+  'trailer',
+  '<< /Root 1 0 R >>',
+  '%%EOF',
+  '',
+].join('\n');
+
+async function expectBinaryFileError(promise: Promise<unknown>): Promise<void> {
+  await expect(promise).rejects.toMatchObject({ code: 'BINARY_FILE' });
+}
+
+describe('readFile binary detection', () => {
+  it('treats a NUL-free PDF as binary so the renderer can route it to PdfPreview', async () => {
+    const root = await mkdtemp(path.join(os.tmpdir(), 'xdt-file-browser-'));
+    try {
+      expect(MINIMAL_NUL_FREE_PDF.includes('\0')).toBe(false);
+      await fsWriteFile(path.join(root, 'doc.pdf'), MINIMAL_NUL_FREE_PDF, 'latin1');
+      await expectBinaryFileError(readFile(root, 'doc.pdf'));
+    } finally {
+      await rm(root, { recursive: true, force: true });
+    }
+  });
+
+  it('classifies the issue #4158 repro PDF (no NUL in the first 4 KiB) as binary', async () => {
+    const root = await mkdtemp(path.join(os.tmpdir(), 'xdt-file-browser-'));
+    try {
+      const fixture = await fsReadFile(path.join(__dirname, 'fixtures', 'nul-free.pdf'));
+      expect(fixture.subarray(0, 4096).includes(0)).toBe(false);
+      await fsWriteFile(path.join(root, 'repro.pdf'), fixture);
+      await expectBinaryFileError(readFile(root, 'repro.pdf'));
+    } finally {
+      await rm(root, { recursive: true, force: true });
+    }
+  });
+
+  it('detects the PDF header when a few junk bytes precede it', async () => {
+    const root = await mkdtemp(path.join(os.tmpdir(), 'xdt-file-browser-'));
+    try {
+      await fsWriteFile(path.join(root, 'junk.pdf'), `ï»¿\n${MINIMAL_NUL_FREE_PDF}`, 'latin1');
+      await expectBinaryFileError(readFile(root, 'junk.pdf'));
+    } finally {
+      await rm(root, { recursive: true, force: true });
+    }
+  });
+
+  it('still returns plain text that only mentions %PDF- past the header window', async () => {
+    const root = await mkdtemp(path.join(os.tmpdir(), 'xdt-file-browser-'));
+    try {
+      const notes = `${'# PDF notes\n'.repeat(120)}The header is %PDF-1.7 followed by objects.\n`;
+      expect(notes.indexOf('%PDF-')).toBeGreaterThan(1024);
+      await fsWriteFile(path.join(root, 'notes.md'), notes, 'utf8');
+      const result = await readFile(root, 'notes.md');
+      expect(result.content).toBe(notes);
+      expect(result.truncated).toBe(false);
+    } finally {
+      await rm(root, { recursive: true, force: true });
+    }
+  });
+
+  it('refuses to overwrite a NUL-free PDF through the text editor path', async () => {
+    const root = await mkdtemp(path.join(os.tmpdir(), 'xdt-file-browser-'));
+    try {
+      await fsWriteFile(path.join(root, 'doc.pdf'), MINIMAL_NUL_FREE_PDF, 'latin1');
+      await expect(writeFile(root, 'doc.pdf', 'not a pdf anymore')).rejects.toThrow(/binary file/);
+      expect(await fsReadFile(path.join(root, 'doc.pdf'), 'latin1')).toBe(MINIMAL_NUL_FREE_PDF);
+    } finally {
+      await rm(root, { recursive: true, force: true });
+    }
+  });
+});

--- a/packages/file-browser-core/src/scanner.ts
+++ b/packages/file-browser-core/src/scanner.ts
@@ -26,6 +26,23 @@ const log = scopedLogger('file-browser/scanner');
  *  banner. 2 MiB is enough for any realistic markdown/code file. */
 const MAX_FILE_BYTES = 2 * 1024 * 1024;
 
+/** PDF 文件头。规范允许其前面有少量垃圾字节,pdf.js 也只在前 1 KiB 内找它,这里同口径。 */
+const PDF_SIGNATURE = Buffer.from('%PDF-', 'latin1');
+const PDF_SIGNATURE_WINDOW = 1024;
+
+/**
+ * 文本读取 / 覆写前的二进制判定,readFile 与 writeFile 共用:
+ *   - 前 4 KiB 含 NUL → PNG/FBX/DLL 等常见二进制;
+ *   - 前 1 KiB 内出现 `%PDF-` → PDF。合法 PDF 不一定含 NUL(对象流未压缩、纯 ASCII 时
+ *     整份文件都可能没有 NUL),只靠 NUL 探测会把它当 UTF-8 文本交给渲染层,显示成
+ *     `%PDF-1.4 ... obj ... stream` 原始语法(issue #4158)。判成二进制后渲染层按扩展名
+ *     走既有 PdfPreview 分支。
+ */
+function isBinaryProbe(probe: Buffer): boolean {
+  if (probe.includes(0)) return true;
+  return probe.subarray(0, PDF_SIGNATURE_WINDOW).includes(PDF_SIGNATURE);
+}
+
 /**
  * 原子写中间产物的后缀。writeFile 把内容先落到 `${target}.xdt-tmp`,fsync 后
  * rename 成正式名。这个临时文件理论上只活一两毫秒,但在边栏 listDir 路径上仍
@@ -325,8 +342,8 @@ export async function listDir(
 
 /**
  * Read one file, capped at MAX_FILE_BYTES. Returns UTF-8 string + truncation
- * flag. Binary files (NULL byte in first 4KB) raise an error so the renderer
- * can render the unrenderable-placeholder card instead.
+ * flag. Binary files (NULL byte in first 4KB, or a PDF header) raise an error
+ * so the renderer can render the placeholder / PDF preview instead.
  */
 export async function readFile(
   workdir: string,
@@ -346,11 +363,12 @@ export async function readFile(
     if (buf.length > 0) {
       await handle.read(buf, 0, buf.length, 0);
     }
-    // Quick binary detection: NULL byte in first 4 KiB. Catches PNG/FBX/DLL
-    // etc. UTF-16 text files contain NULL bytes too but are rare in dev
-    // workflows; renderer can still fall back to "open in OS" if needed.
+    // Quick binary detection: NULL byte in first 4 KiB (PNG/FBX/DLL etc.) or a
+    // PDF header (see isBinaryProbe). UTF-16 text files contain NULL bytes too
+    // but are rare in dev workflows; renderer can still fall back to "open in
+    // OS" if needed.
     const probe = buf.subarray(0, Math.min(buf.length, 4096));
-    if (probe.includes(0)) {
+    if (isBinaryProbe(probe)) {
       const err = new Error(`binary file: ${relPath}`);
       (err as Error & { code?: string }).code = 'BINARY_FILE';
       throw err;
@@ -435,8 +453,8 @@ export async function readFileChunk(
  *   - Refuses files >MAX_FILE_BYTES on disk (the read path truncates large
  *     files; saving back would silently lose data).
  *   - Refuses content >MAX_FILE_BYTES (defense against giant paste).
- *   - Refuses binary files (NULL byte in first 4KB) — same probe as readFile,
- *     so the editor never opens binaries to begin with.
+ *   - Refuses binary files (NULL byte in first 4KB, or a PDF header) — same
+ *     probe as readFile, so the editor never opens binaries to begin with.
  */
 export async function writeFile(
   workdir: string,
@@ -469,7 +487,7 @@ export async function writeFile(
   try {
     const probe = Buffer.alloc(Math.min(st.size, 4096));
     if (probe.length > 0) await probeHandle.read(probe, 0, probe.length, 0);
-    if (probe.includes(0)) {
+    if (isBinaryProbe(probe)) {
       throw new Error(`binary file: ${relPath}`);
     }
   } finally {

--- a/packages/file-browser-core/src/scanner.ts
+++ b/packages/file-browser-core/src/scanner.ts
@@ -33,14 +33,24 @@ const PDF_SIGNATURE_WINDOW = 1024;
 /**
  * 文本读取 / 覆写前的二进制判定,readFile 与 writeFile 共用:
  *   - 前 4 KiB 含 NUL → PNG/FBX/DLL 等常见二进制;
- *   - 前 1 KiB 内出现 `%PDF-` → PDF。合法 PDF 不一定含 NUL(对象流未压缩、纯 ASCII 时
- *     整份文件都可能没有 NUL),只靠 NUL 探测会把它当 UTF-8 文本交给渲染层,显示成
- *     `%PDF-1.4 ... obj ... stream` 原始语法(issue #4158)。判成二进制后渲染层按扩展名
- *     走既有 PdfPreview 分支。
+ *   - `.pdf` 文件前 1 KiB 内出现 `%PDF-` → PDF。合法 PDF 不一定含 NUL(对象流未压缩、
+ *     纯 ASCII 时整份文件都可能没有 NUL),只靠 NUL 探测会把它当 UTF-8 文本交给渲染层,
+ *     显示成 `%PDF-1.4 ... obj ... stream` 原始语法(issue #4158)。判成二进制后渲染层按
+ *     扩展名走既有 PdfPreview 分支。
+ *     文件头判定只对 `.pdf` 扩展名生效:渲染层的 PDF 预览本来就以扩展名为准,其他扩展名
+ *     判成二进制只会得到不可渲染占位、还会让编辑器拒绝保存;而 markdown / 日志 / 源码
+ *     在开头引用 `%PDF-` 很常见,不能误伤。
  */
-function isBinaryProbe(probe: Buffer): boolean {
+function isBinaryProbe(probe: Buffer, relPath: string): boolean {
   if (probe.includes(0)) return true;
+  if (!hasPdfExtension(relPath)) return false;
   return probe.subarray(0, PDF_SIGNATURE_WINDOW).includes(PDF_SIGNATURE);
+}
+
+function hasPdfExtension(relPath: string): boolean {
+  const name = relPath.slice(relPath.lastIndexOf('/') + 1);
+  const dot = name.lastIndexOf('.');
+  return dot > 0 && name.slice(dot).toLowerCase() === '.pdf';
 }
 
 /**
@@ -342,8 +352,8 @@ export async function listDir(
 
 /**
  * Read one file, capped at MAX_FILE_BYTES. Returns UTF-8 string + truncation
- * flag. Binary files (NULL byte in first 4KB, or a PDF header) raise an error
- * so the renderer can render the placeholder / PDF preview instead.
+ * flag. Binary files (NULL byte in first 4KB, or a `.pdf` with a PDF header)
+ * raise an error so the renderer can render the placeholder / PDF preview instead.
  */
 export async function readFile(
   workdir: string,
@@ -364,11 +374,11 @@ export async function readFile(
       await handle.read(buf, 0, buf.length, 0);
     }
     // Quick binary detection: NULL byte in first 4 KiB (PNG/FBX/DLL etc.) or a
-    // PDF header (see isBinaryProbe). UTF-16 text files contain NULL bytes too
-    // but are rare in dev workflows; renderer can still fall back to "open in
-    // OS" if needed.
+    // PDF header in a `.pdf` file (see isBinaryProbe). UTF-16 text files contain
+    // NULL bytes too but are rare in dev workflows; renderer can still fall back
+    // to "open in OS" if needed.
     const probe = buf.subarray(0, Math.min(buf.length, 4096));
-    if (isBinaryProbe(probe)) {
+    if (isBinaryProbe(probe, sub)) {
       const err = new Error(`binary file: ${relPath}`);
       (err as Error & { code?: string }).code = 'BINARY_FILE';
       throw err;
@@ -453,8 +463,8 @@ export async function readFileChunk(
  *   - Refuses files >MAX_FILE_BYTES on disk (the read path truncates large
  *     files; saving back would silently lose data).
  *   - Refuses content >MAX_FILE_BYTES (defense against giant paste).
- *   - Refuses binary files (NULL byte in first 4KB, or a PDF header) — same
- *     probe as readFile, so the editor never opens binaries to begin with.
+ *   - Refuses binary files (NULL byte in first 4KB, or a `.pdf` with a PDF
+ *     header) — same probe as readFile, so the editor never opens binaries.
  */
 export async function writeFile(
   workdir: string,
@@ -487,7 +497,7 @@ export async function writeFile(
   try {
     const probe = Buffer.alloc(Math.min(st.size, 4096));
     if (probe.length > 0) await probeHandle.read(probe, 0, probe.length, 0);
-    if (isBinaryProbe(probe)) {
+    if (isBinaryProbe(probe, sub)) {
       throw new Error(`binary file: ${relPath}`);
     }
   } finally {

--- a/packages/remote-file-service/src/protocol.ts
+++ b/packages/remote-file-service/src/protocol.ts
@@ -36,7 +36,7 @@ import type {
 export const FILE_SERVICE_SCHEMA_VERSION = 2;
 
 /** 人读 bundle 版本(probe / 日志用),行为变化时手动 bump。 */
-export const FILE_SERVICE_BUNDLE_VERSION = '0.2.3';
+export const FILE_SERVICE_BUNDLE_VERSION = '0.2.4';
 
 /* ============================== 帧 ============================== */
 


### PR DESCRIPTION
## 这次改了什么

### 摘要

文件浏览器打开部分合法 PDF 时没有进入 PDF 预览,而是把 `%PDF-1.4 ... obj ... stream` 原始语法当 UTF-8 文本显示(#4158)。根因在 `packages/file-browser-core/src/scanner.ts`:`readFile()` 只用「前 4 KiB 含 NUL 字节」判二进制,而对象流未压缩、纯 ASCII 的合法 PDF(如 issue 附件,12 KB 全程无 NUL)整份文件都没有 NUL,于是被当文本返回;渲染层的 `PdfPreview` 只在 `kind: 'binary'` + `.pdf` 扩展名时才会走到。

本 PR 在 `readFile` / `writeFile` 共用的二进制判定里增加 PDF 文件头识别:`.pdf` 文件(扩展名大小写不敏感)前 1 KiB 内出现 `%PDF-`(PDF 规范允许文件头前有少量垃圾字节,pdf.js 也只在前 1 KiB 内找它)即抛 `BINARY_FILE`;非 `.pdf` 文件只保留原有 NUL 探测,开头引用 `%PDF-` 的 markdown / 日志 / 源码不受影响。这样本地与远程(`remote-file-service` 用的是同一个 `readFile`)都按既有 binary 分支进入 `PdfPreview`,文本编辑器也不会再把 PDF 当文本覆写。渲染层零改动。

### 变更类型

- [x] `fix` 缺陷修复

### 范围

- 关联 Issue / 需求:Fixes #4158
- 本 PR 包含:`scanner.ts` 新增 `isBinaryProbe()`(NUL 探测 + 仅 `.pdf` 的文件头判定),`readFile` / `writeFile` 改用它;`scanner.test.ts` 新增 7 例回归;新增夹具 `__tests__/fixtures/nul-free.pdf`(issue 附件原样,无 NUL 的合法 PDF);`remote-file-service` 的 `FILE_SERVICE_BUNDLE_VERSION` 0.2.3 → 0.2.4(schema 不变,让已装旧 daemon 的 SSH 主机重推 bundle 拿到新判定)
- 明确不包含:按 MIME / 内容的通用类型分派、其他二进制格式(如 UTF-16 文本)的识别、渲染层 `useFileContent` / `FileBodyView` 的任何改动、非 `.pdf` 扩展名但内容是 PDF 的文件(维持原有文本显示)
- 用户可见变化:无 NUL 字节的 `.pdf` 在本地与远程文件浏览器里进入既有 PDF 预览;编辑器拒绝打开这类 PDF(与含 NUL 的 PDF 行为一致)
- 是否存在 breaking change:无

### UI 变化

不涉及:仅改 `packages/file-browser-core` 的文件读取判定,渲染层零改动。

- 引用的设计规范:不涉及

## 怎么验证的

### 自动验证

```text
cd packages/file-browser-core && pnpm exec vitest run src/__tests__/scanner.test.ts
结果:15 passed(含新增 7 例:无 NUL 最小 PDF → BINARY_FILE;issue 附件夹具(前 4 KiB 无 NUL)→ BINARY_FILE;
      文件头前有 BOM/换行等垃圾字节仍识别;`SCAN.PDF` 大小写不敏感;`.pdf` 命名但 `%PDF-` 只出现在前 1 KiB 之外仍按文本返回;
      `notes.md` 首行引用 `%PDF-1.x` 仍按文本读取且可 writeFile 保存;writeFile 拒绝覆写无 NUL 的 PDF 且原文件内容不变)

反证 1:git stash 掉 scanner.ts 的修复后重跑 → 4 failed(无 NUL PDF / 附件夹具 / 垃圾字节 / writeFile 四例精确复现缺陷)
反证 2:scanner.ts 回退到首 commit(无扩展名收窄)→ 1 failed(`notes.md` 首行引用 `%PDF-` 被误判二进制)

cd packages/remote-file-service && pnpm exec vitest run && pnpm exec tsc --noEmit -p tsconfig.json
结果:14 passed,tsc 0 报错

cd packages/file-browser-core && pnpm exec tsc --noEmit -p tsconfig.json
结果:仅 src/__tests__/ripgrep-exit-handling.test.ts 6 处既有报错(与 main 基线逐条一致,stash 本 PR 改动后同样 6 处),本 PR 触及文件 0 报错

cd packages/file-browser-core && pnpm exec eslint src/scanner.ts src/__tests__/scanner.test.ts
结果:通过

pnpm test:unit:related(仓库根)
结果:PASS(两次 commit 各跑一次;related: apps/desktop full、packages/file-browser-core related 2、packages/remote-file-service full;EXIT 0)
```

### 手工验证

不涉及:本机无 Desktop 打包环境;渲染层分派路径(`kind: 'binary'` + `.pdf` → `PdfPreview`,远程走 `startBigFetch` → `cached` → `PdfPreview`)为既有逻辑,本 PR 未改。

### 未执行的验证

Desktop 真机打开 issue 附件 PDF 的端到端预览未执行(原因同上),已请提报人复核。

## 风险

### 风险分类

- [x] 协议兼容
- [x] 其他:文件类型判定范围扩大

### 影响与回滚

- 影响范围:仅 `readFile` / `writeFile` 对「`.pdf` 且前 1 KiB 内含 `%PDF-`」文件的判定;这类文件此前显示为原始 PDF 语法文本,本 PR 后按二进制处理进入 PDF 预览;非 `.pdf` 文件行为逐字节不变;`readFileChunk`、搜索、监听等路径不受影响。远端:bundle 版本 0.2.3 → 0.2.4 会让已装旧 daemon 的 SSH 主机下次 probe 时重推一次 bundle(秒级,既有升级路径),schema 版本不变、协议形状不变。
- 回滚 / 降级方式:revert 本 PR 即恢复纯 NUL 探测,无数据或格式迁移;bundle 版本回退同样会触发一次重推。

### 提交前检查

- [x] 已 review 完整 diff
- [x] 每个 commit 都带 DCO 签名(`git commit -s`,见 [DCO](../DCO))
- [x] UI 改动已在「UI 变化」注明引用的设计规范章节(不涉及 UI 则跳过)
- [x] 未提交凭证、令牌或授权文件
- [x] 已补充必要文档
- [x] 已确认测试结果或说明未执行原因
