### PR TITLE
fix(scheduler): 换 agentKind 时丢弃上一引擎的模型路由,schedule_update 支持 null 清空

### DIFF
--- a/packages/lizi-mcps/src/__tests__/cindy_schedulerMcpServer.test.ts
+++ b/packages/lizi-mcps/src/__tests__/cindy_schedulerMcpServer.test.ts
@@ -1134,6 +1134,28 @@ describe('schedule_update — partial 语义的 JSON 边界翻译', () => {
     expect(updated.patch?.agentKind).toBe('claude-code');
   });
 
+  it('workingDir: null 且任务仍开 useWorktree → 拒绝;同时关 useWorktree → 清目录并回到 dialogue', async () => {
+    // worktree 需要 workingDir 作为基仓,只清目录会留下一条每次 fire 都失败的任务(codex review)
+    const { updated, registry } = setup({ workingDir: '/repo', useWorktree: true });
+    const rejected = await callUpdate(registry, { workingDir: null });
+    expect(rejected.ok).toBe(false);
+    expect(updated.patch).toBeUndefined();
+
+    const ok = await callUpdate(registry, { workingDir: null, useWorktree: false });
+    expect(ok.ok).toBe(true);
+    expect(Object.prototype.hasOwnProperty.call(updated.patch ?? {}, 'workingDir')).toBe(true);
+    expect(updated.patch?.workingDir).toBeUndefined();
+    expect(updated.patch?.useWorktree).toBe(false);
+    expect(updated.patch?.workspaceKind).toBe('dialogue');
+
+    // 任务本来没开 worktree → 直接清
+    const plain = setup({ workingDir: '/repo', useWorktree: false });
+    const env = await callUpdate(plain.registry, { workingDir: null });
+    expect(env.ok).toBe(true);
+    expect(plain.updated.patch?.workingDir).toBeUndefined();
+    expect(plain.updated.patch?.workspaceKind).toBe('dialogue');
+  });
+
   it('省略 model / providerId → patch 不带 key(真 partial);非法 effort 仍被拒', async () => {
     const { updated, registry } = setup({ model: 'gpt-6-astra', providerId: 'openai' });
     const env = await callUpdate(registry, { prompt: 'only prompt' });

--- a/packages/lizi-mcps/src/__tests__/cindy_schedulerMcpServer.test.ts
+++ b/packages/lizi-mcps/src/__tests__/cindy_schedulerMcpServer.test.ts
@@ -1109,6 +1109,41 @@ describe('schedule_update — partial 语义的 JSON 边界翻译', () => {
     expect(updated.patch?.intervalMs).toBeUndefined();
   });
 
+  it('model / providerId / effort / workingDir: null → 带 key 的 undefined(显式清空路由)', async () => {
+    // 此前四个字段 schema 只收 string,agent 想把伙伴接管期钉上的 Codex 路由清掉
+    // 只能拿到 INVALID_ARGS,陈旧 model 永远摘不下来。
+    const { updated, registry } = setup({
+      agentKind: 'codex',
+      model: 'gpt-6-astra',
+      providerId: 'openai',
+      effort: 'medium',
+      workingDir: '/repo',
+    });
+    const env = await callUpdate(registry, {
+      agentKind: 'claude-code',
+      model: null,
+      providerId: null,
+      effort: null,
+      workingDir: null,
+    });
+    expect(env.ok).toBe(true);
+    for (const key of ['model', 'providerId', 'effort', 'workingDir']) {
+      expect(Object.prototype.hasOwnProperty.call(updated.patch ?? {}, key)).toBe(true);
+      expect(updated.patch?.[key]).toBeUndefined();
+    }
+    expect(updated.patch?.agentKind).toBe('claude-code');
+  });
+
+  it('省略 model / providerId → patch 不带 key(真 partial);非法 effort 仍被拒', async () => {
+    const { updated, registry } = setup({ model: 'gpt-6-astra', providerId: 'openai' });
+    const env = await callUpdate(registry, { prompt: 'only prompt' });
+    expect(env.ok).toBe(true);
+    expect(Object.prototype.hasOwnProperty.call(updated.patch ?? {}, 'model')).toBe(false);
+    expect(Object.prototype.hasOwnProperty.call(updated.patch ?? {}, 'providerId')).toBe(false);
+    const bad = await callUpdate(registry, { effort: 'turbo' });
+    expect(bad.ok).toBe(false);
+  });
+
   it('preRunHook 只改 command → 沿用任务现有 timeoutMs,不再静默清成不限时', async () => {
     const { updated, registry } = setup({
       preRunHook: { command: 'node /abs/old.mjs', timeoutMs: 180_000 },

--- a/packages/lizi-mcps/src/scheduler/update.ts
+++ b/packages/lizi-mcps/src/scheduler/update.ts
@@ -40,10 +40,26 @@ export function registerScheduleUpdateTool(
       recurring: z.boolean().optional(),
       agentKind: z.enum(AGENT_KIND).optional(),
       kind: z.literal('cron').optional(),
-      model: z.string().optional(),
-      providerId: z.string().optional(),
-      effort: z.enum(EFFORT).optional(),
-      workingDir: z.string().optional(),
+      model: z
+        .string()
+        .nullable()
+        .optional()
+        .describe('传 null = 清空,回到所选 agentKind 的默认模型路由;省略 = 不修改。换 agentKind 时上一引擎的 model 会被引擎自动丢弃,无需手动清。'),
+      providerId: z
+        .string()
+        .nullable()
+        .optional()
+        .describe('传 null = 清空(同 model 一起回到默认路由);省略 = 不修改。'),
+      effort: z
+        .enum(EFFORT)
+        .nullable()
+        .optional()
+        .describe('传 null = 清空(按模型默认档);省略 = 不修改。'),
+      workingDir: z
+        .string()
+        .nullable()
+        .optional()
+        .describe('传 null = 清空(回到绑定会话 / 对话工作区语义);省略 = 不修改。'),
       useWorktree: z.boolean().optional(),
       targetSessionId: z
         .string()
@@ -110,6 +126,15 @@ export function registerScheduleUpdateTool(
           // cronExpr 壁钟槽位语义。引擎遵循真 partial 契约(没带 key 就不动),
           // 这是 JSON 边界唯一的清空表达。
           input = { ...input, intervalMs: undefined };
+        }
+        // 同上:model / providerId / effort / workingDir 的 null 也翻成带 key 的
+        // undefined(storage 按 hasOwnProperty 判定 → 清列 NULL)。此前 schema 只收
+        // string,agent 想把任务从一个引擎的模型路由上摘下来(如伙伴接管期用 Codex
+        // 模型跑过、再改回 Claude Code)只能报 INVALID_ARGS,陈旧路由永远清不掉。
+        for (const key of ['model', 'providerId', 'effort', 'workingDir'] as const) {
+          if ((patch as Record<string, unknown>)[key] === null) {
+            input = { ...input, [key]: undefined };
+          }
         }
         // 无条件校验本次 patch 显式带的 cronExpr / timezone(函数对缺省字段是
         // no-op)。不能只在 patch 带 intervalMs 数值时校验:任务已有 intervalMs、

--- a/packages/lizi-mcps/src/scheduler/update.ts
+++ b/packages/lizi-mcps/src/scheduler/update.ts
@@ -136,6 +136,12 @@ export function registerScheduleUpdateTool(
             input = { ...input, [key]: undefined };
           }
         }
+        const clearsWorkingDir = (patch as { workingDir?: string | null }).workingDir === null;
+        if (clearsWorkingDir) {
+          // 清目录 = 回到对话工作区语义(与 create 缺省目录时的推断、引擎「给了真实
+          // 目录翻成 project」对称),否则 workspaceKind 仍是 project 却无目录。
+          input = { ...input, workspaceKind: 'dialogue' };
+        }
         // 无条件校验本次 patch 显式带的 cronExpr / timezone(函数对缺省字段是
         // no-op)。不能只在 patch 带 intervalMs 数值时校验:任务已有 intervalMs、
         // patch 只改 cronExpr 时,真 partial 语义保留原 interval,引擎按
@@ -154,6 +160,17 @@ export function registerScheduleUpdateTool(
           input = { ...input, targetSessionId: sessionId };
         }
         return scheduler.updateFromCurrent(id, async (existing) => {
+          // worktree 模式以 workingDir 为基仓(workdir-resolver 会拒绝无目录的 worktree
+          // 任务,每次 fire 都失败)。清目录时若任务仍开着 useWorktree 且本次没关,
+          // 明确拒绝而不是写出一条跑不动的任务(codex review)。
+          const nextUseWorktree = Object.prototype.hasOwnProperty.call(input, 'useWorktree')
+            ? input.useWorktree
+            : existing.useWorktree;
+          if (clearsWorkingDir && nextUseWorktree) {
+            throw new Error(
+              'invalid request: workingDir 传 null 清空时任务仍开启 useWorktree(worktree 需要 workingDir 作为基仓);请同时传 useWorktree:false,或改传新的 workingDir',
+            );
+          }
           // preRunHook.timeoutMs 的真 partial 表达:只改 command 时沿用任务现有超时
           // (此前整对象替换会把省略的 timeoutMs 静默清成"不限时");传 null 才显式清除。
           // null 在进入引擎前剥掉 —— 引擎/storage 只认 number | undefined。

--- a/packages/maker-scheduler/src/__tests__/scheduler.test.ts
+++ b/packages/maker-scheduler/src/__tests__/scheduler.test.ts
@@ -363,6 +363,51 @@ describe('Scheduler', () => {
     expect(plain.workspaceKind).toBe('project');
   });
 
+  it('update() 换 agentKind 时丢弃上一引擎的 model / providerId / effort(回到默认路由)', async () => {
+    // 伙伴接管期把任务钉在 Codex 的 gpt-6-astra@openai 上,之后改回 Claude Code 却没法
+    // 清模型 → 任务带着 Claude Code 跑不了的路由,每轮 fire 都被上游拒绝。
+    const sch = await h.scheduler.create({
+      ...baseInput,
+      agentKind: 'codex',
+      model: 'gpt-6-astra',
+      providerId: 'openai',
+      effort: 'medium',
+    });
+    const switched = await h.scheduler.update(sch.id, { agentKind: 'claude-code' });
+    expect(switched.agentKind).toBe('claude-code');
+    expect(switched.model).toBeUndefined();
+    expect(switched.providerId).toBeUndefined();
+    expect(switched.effort).toBeUndefined();
+    // 落库 patch 必须带 key(storage 按 hasOwnProperty 清列),不能只是省略
+    const stored = h.storage.schedules.get(sch.id)!;
+    expect(Object.prototype.hasOwnProperty.call(stored, 'model')).toBe(true);
+    expect(stored.model).toBeUndefined();
+    expect(stored.providerId).toBeUndefined();
+
+    // 反证 1:agentKind 没变 → 路由原样保留
+    const sch2 = await h.scheduler.create({
+      ...baseInput,
+      agentKind: 'codex',
+      model: 'gpt-6-astra',
+      providerId: 'openai',
+    });
+    const same = await h.scheduler.update(sch2.id, { agentKind: 'codex', prompt: 'p2' });
+    expect(same.model).toBe('gpt-6-astra');
+    expect(same.providerId).toBe('openai');
+    const untouched = await h.scheduler.update(sch2.id, { prompt: 'p3' });
+    expect(untouched.model).toBe('gpt-6-astra');
+
+    // 反证 2:换引擎同时显式给了新路由 → 按调用方意图
+    const explicit = await h.scheduler.update(sch2.id, {
+      agentKind: 'claude-code',
+      model: 'claude-fable-5-1',
+      providerId: 'anthropic',
+    });
+    expect(explicit.model).toBe('claude-fable-5-1');
+    expect(explicit.providerId).toBe('anthropic');
+    expect(explicit.effort).toBeUndefined();
+  });
+
   it('update() 给了真实 workingDir 时翻成 project(与 create 推断对称)', async () => {
     // 对话任务后来被显式改了项目目录 → 不能仍留 dialogue,否则 fire 时
     // 新目录会被管理工作区分配覆盖,显式设置被静默丢弃

--- a/packages/maker-scheduler/src/__tests__/scheduler.test.ts
+++ b/packages/maker-scheduler/src/__tests__/scheduler.test.ts
@@ -372,12 +372,18 @@ describe('Scheduler', () => {
       model: 'gpt-6-astra',
       providerId: 'openai',
       effort: 'medium',
+      fastMode: true,
     });
     const switched = await h.scheduler.update(sch.id, { agentKind: 'claude-code' });
     expect(switched.agentKind).toBe('claude-code');
     expect(switched.model).toBeUndefined();
     expect(switched.providerId).toBeUndefined();
     expect(switched.effort).toBeUndefined();
+    // 旧引擎的 Fast 开关不能潜伏到下次切回 Codex/Pi 时复活
+    expect(switched.fastMode).toBe(false);
+    const back = await h.scheduler.update(sch.id, { agentKind: 'codex' });
+    expect(back.fastMode).toBe(false);
+    expect(back.model).toBeUndefined();
     // 落库 patch 必须带 key(storage 按 hasOwnProperty 清列),不能只是省略
     const stored = h.storage.schedules.get(sch.id)!;
     expect(Object.prototype.hasOwnProperty.call(stored, 'model')).toBe(true);
@@ -390,10 +396,12 @@ describe('Scheduler', () => {
       agentKind: 'codex',
       model: 'gpt-6-astra',
       providerId: 'openai',
+      fastMode: true,
     });
     const same = await h.scheduler.update(sch2.id, { agentKind: 'codex', prompt: 'p2' });
     expect(same.model).toBe('gpt-6-astra');
     expect(same.providerId).toBe('openai');
+    expect(same.fastMode).toBe(true);
     const untouched = await h.scheduler.update(sch2.id, { prompt: 'p3' });
     expect(untouched.model).toBe('gpt-6-astra');
 
@@ -406,6 +414,10 @@ describe('Scheduler', () => {
     expect(explicit.model).toBe('claude-fable-5-1');
     expect(explicit.providerId).toBe('anthropic');
     expect(explicit.effort).toBeUndefined();
+    expect(explicit.fastMode).toBe(false);
+    // 显式带 fastMode 按调用方意图
+    const keepFast = await h.scheduler.update(sch2.id, { agentKind: 'codex', fastMode: true });
+    expect(keepFast.fastMode).toBe(true);
   });
 
   it('update() 给了真实 workingDir 时翻成 project(与 create 推断对称)', async () => {

--- a/packages/maker-scheduler/src/engine/scheduler.ts
+++ b/packages/maker-scheduler/src/engine/scheduler.ts
@@ -1376,6 +1376,18 @@ export class Scheduler extends EventEmitter {
     }
     const existing = await this.get(id);
     if (!existing) throw new Error(`Schedule not found: ${id}`);
+    // 换引擎(agentKind 变了)时,上一引擎的 model / providerId / effort 是另一套模型
+    // 目录里的路由,对新引擎没有意义,patch 没显式给就丢弃(带 key 的 undefined →
+    // storage 清列 NULL),让任务回到新引擎的默认路由。否则陈旧路由会被原样带过去:
+    // fire 时路由守卫对「没有任何来源提供该模型」的组合放行,runner 再把绑定会话的
+    // 凭证/模型切到这条跑不通的路由上,每轮都以上游拒绝失败,会话 meta 也被写坏
+    // (伙伴接管期用 Codex 模型钉过的任务改回 Claude Code 后即复现)。
+    // 显式给了(含带 key 的 undefined)按调用方意图,不覆盖。
+    if (patch.agentKind !== undefined && patch.agentKind !== existing.agentKind) {
+      for (const key of ['model', 'providerId', 'effort'] as const) {
+        if (!Object.prototype.hasOwnProperty.call(patch, key)) updates[key] = undefined;
+      }
+    }
     const candidate: Schedule = { ...existing, ...updates };
     validateScheduleExecutionShape(
       candidate,

--- a/packages/maker-scheduler/src/engine/scheduler.ts
+++ b/packages/maker-scheduler/src/engine/scheduler.ts
@@ -1382,11 +1382,14 @@ export class Scheduler extends EventEmitter {
     // fire 时路由守卫对「没有任何来源提供该模型」的组合放行,runner 再把绑定会话的
     // 凭证/模型切到这条跑不通的路由上,每轮都以上游拒绝失败,会话 meta 也被写坏
     // (伙伴接管期用 Codex 模型钉过的任务改回 Claude Code 后即复现)。
-    // 显式给了(含带 key 的 undefined)按调用方意图,不覆盖。
+    // 显式给了(含带 key 的 undefined)按调用方意图,不覆盖。fastMode 同属完整运行路由
+    // (harness + provider + model + effort + fastMode),旧引擎的 Fast 开关同样不该
+    // 潜伏到下一次切回 Codex/Pi 时复活(codex review),未显式给则关掉。
     if (patch.agentKind !== undefined && patch.agentKind !== existing.agentKind) {
       for (const key of ['model', 'providerId', 'effort'] as const) {
         if (!Object.prototype.hasOwnProperty.call(patch, key)) updates[key] = undefined;
       }
+      if (!Object.prototype.hasOwnProperty.call(patch, 'fastMode')) updates.fastMode = false;
     }
     const candidate: Schedule = { ...existing, ...updates };
     validateScheduleExecutionShape(


### PR DESCRIPTION
## 这次改了什么

### 摘要

定时任务(schedule)从一个引擎改成另一个引擎(如 Codex → Claude Code)后,上一引擎的 `model / providerId / effort` 会原样留在任务上,而且经 MCP `schedule_update` 也清不掉(四个字段只收 string,传 `null` 报 `INVALID_ARGS`)。带着这条跨引擎的陈旧路由 fire 时,路由守卫对「没有任何来源提供该模型」的组合按既有约定放行,runner 随后把绑定会话的凭证/模型切到这条跑不通的路由上,每轮都以「The upstream account cannot access this model」失败,绑定会话的 meta(model / provider_id)也被写坏。

这是本机真实复现的链路(2026-09-08 ~ 09-09):伙伴(bot)接管我的「刷贡献」任务时用 Codex 会话显式把任务钉在 `gpt-6-astra@openai`;次日我用一个 Claude Code 会话 `schedule_update` 改回 `agentKind=claude-code` 并 `bindToCurrentSession`,想顺手 `model:null / providerId:null` 清路由被 schema 拒绝,只好不传;结果任务变成 `agentKind=claude-code, model=gpt-6-astra, providerId=openai`,13:03 排队心跳日志「queued heartbeat routing needs credential mode switch」,13:15 直发时「closed live session after credential mode switch … claude-code, anthropic→openai, claude-fable-5-1→gpt-6-astra」,run 失败,会话行 model 被改成 `gpt-6-astra`。

两处修复:

- `packages/maker-scheduler` 引擎 `updateUnlocked`:patch 的 `agentKind` 与现有不同、且 patch 没显式带 `model / providerId / effort` 时,以带 key 的 `undefined` 清掉(storage 按 hasOwnProperty 清列 NULL),任务回到新引擎的默认路由;显式给了(含带 key 的 undefined)按调用方意图,不覆盖。agentKind 未变或未传时不动任何字段(真 partial 不变)。
- `packages/lizi-mcps` `schedule_update`:`model / providerId / effort / workingDir` 改为 `.nullable()`,`null` 翻成带 key 的 `undefined`,与 `targetSessionId: null` / `intervalMs: null` 同一约定;描述里写清「null = 清空,省略 = 不修改」。

### 变更类型

- [ ] `feat` 新功能
- [x] `fix` 缺陷修复
- [ ] `refactor` / `perf` 重构或性能优化
- [ ] `docs` / `test` / `chore` 文档、测试或工程维护
- [ ] 其他：

### 范围

- 关联 Issue / 需求：无对应 issue(本机复现,链路见上)
- 本 PR 包含：引擎 update 换引擎时丢弃旧路由三件套;MCP `schedule_update` 四个路由字段接受 `null` 清空;两处单测(含反证:agentKind 未变保留、显式给新路由按意图、省略字段不带 key、非法 effort 仍拒)
- 明确不包含:路由守卫 `checkModelRoute` 对「显式 providerId 存在但不为该 agent 提供该模型」的组合仍按既有约定放行(PR #744 系列的口径),本 PR 不动;runner 在 spawn 失败前已把 schedule.model 落到 sessions 行的时序也不动
- 用户可见变化:换引擎后任务不再带着旧引擎模型;agent 可用 `null` 清空模型/来源/效果档/工作目录
- 是否存在 breaking change:无(engine 层仅在 `agentKind` 实际变化且未显式给路由时生效;UI 表单换引擎时会带新模型,不受影响)

### UI 变化

不涉及

- 引用的设计规范：不涉及:纯 main/包逻辑,无渲染层改动

## 怎么验证的

### 自动验证

```text
packages/maker-scheduler: npx vitest run src/__tests__/scheduler.test.ts
结果:149 passed(新增 1 例;反证:去掉引擎改动后该例按预期失败「expected 'gpt-6-astra' to be undefined」)

packages/lizi-mcps: npx vitest run src/__tests__/cindy_schedulerMcpServer.test.ts
结果:63 passed(新增 2 例)

packages/maker-scheduler: npx tsc --noEmit -p .
结果:通过
packages/lizi-mcps: npx tsc --noEmit -p .
结果:仅 src/__tests__/submitGithubIssueTool.test.ts 的 7 处 zod 类型错误,main 上同样存在,与本 PR 无关

根目录 pnpm test:unit:related
结果:apps/desktop unit PASS(168.6s)、packages/lizi-mcps unit PASS、packages/maker-scheduler unit PASS
```

### 手工验证

不涉及(本机故障任务已手工把 model 改回 claude-fable-5-1 复位;修复行为由单测覆盖)

### 未执行的验证

未在打包后的 app 里回放整条 fire 链路(需要再制造一次跨引擎陈旧路由);引擎与 MCP 两层的行为由单测覆盖。

## 风险

### 风险分类

- [x] 无已知风险
- [ ] SQLite / migration
- [ ] system prompt
- [ ] 协议兼容
- [ ] 权限 / 安全 / 用户数据
- [ ] 存量插件兼容（批准状态 / 指纹 / manifest 校验 / 安装布局 / 包格式）
- [ ] 原生层 / fingerprint / OTA
- [ ] 跨平台差异
- [ ] 其他：

### 影响与回滚

- 影响范围:仅 schedule 的 update 路径(desktop IPC / device-link / MCP 都经引擎 `updateUnlocked`);自定义来源下同一 model id 同时挂在两个引擎列表上的少见情况,换引擎不再自动沿用旧 id,显式传 model 即可保留
- 回滚 / 降级方式:revert 本 PR 即可,无数据迁移
