### PR TITLE
fix(maker-host): 会话来源在启动边界冻结进路由 store

### DIFF
--- a/apps/desktop/src/main/maker-host/__tests__/sessionProviderStore.test.ts
+++ b/apps/desktop/src/main/maker-host/__tests__/sessionProviderStore.test.ts
@@ -4,6 +4,9 @@
  * learn-host 等在 createSession 之前自行写好 store 的路径。
  */
 
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+
 import { beforeEach, describe, expect, it } from 'vitest';
 
 import {
@@ -45,5 +48,22 @@ describe('freezeSessionProviderAtStart', () => {
     freezeSessionProviderAtStart('s-blank', '  ');
     expect(hasSessionProvider('s-blank')).toBe(true);
     expect(getSessionProvider('s-blank')).toBeNull();
+  });
+});
+
+/**
+ * 接线本身也要钉住,否则删掉调用点这组三态断言照样全绿。钩子早于
+ * `agent.startSession` 那半由 maker-core 的 order 断言保证,这里不重复。
+ */
+describe('启动边界接线', () => {
+  it('冻结挂在 prepareStartOptions 内,且排在账号就绪门之后', () => {
+    const makerHostSource = readFileSync(resolve(__dirname, '..', 'index.ts'), 'utf8');
+    const hook = makerHostSource.indexOf('prepareStartOptions: async');
+    const gate = makerHostSource.indexOf('!providerReady', hook);
+    const freeze = makerHostSource.indexOf('freezeSessionProviderAtStart(sessionId', hook);
+
+    expect(hook).toBeGreaterThanOrEqual(0);
+    expect(gate).toBeGreaterThan(hook);
+    expect(freeze).toBeGreaterThan(gate);
   });
 });

--- a/apps/desktop/src/main/maker-host/__tests__/sessionProviderStore.test.ts
+++ b/apps/desktop/src/main/maker-host/__tests__/sessionProviderStore.test.ts
@@ -1,0 +1,49 @@
+/**
+ * session-provider-store 启动派发边界单测(Refs #4154)。
+ * 不变量:三态 id / null / undefined —— 把 undefined 折叠成 null 会清掉
+ * learn-host 等在 createSession 之前自行写好 store 的路径。
+ */
+
+import { beforeEach, describe, expect, it } from 'vitest';
+
+import {
+  clearAllSessionProviders,
+  freezeSessionProviderAtStart,
+  getSessionProvider,
+  hasSessionProvider,
+  setSessionProvider,
+} from '../session-provider-store';
+
+describe('freezeSessionProviderAtStart', () => {
+  beforeEach(() => {
+    clearAllSessionProviders();
+  });
+
+  it('显式来源在 spawn 前即可被路由层读到', () => {
+    freezeSessionProviderAtStart('s-custom', 'my-relay');
+    expect(getSessionProvider('s-custom')).toBe('my-relay');
+  });
+
+  it('显式 null 登记为「已知的默认路由」,不是未登记', () => {
+    freezeSessionProviderAtStart('s-default', null);
+    expect(hasSessionProvider('s-default')).toBe(true);
+    expect(getSessionProvider('s-default')).toBeNull();
+  });
+
+  it('undefined 表示调用方未携带选择:不登记,也不清掉已写入的选择', () => {
+    expect(hasSessionProvider('s-untouched')).toBe(false);
+    freezeSessionProviderAtStart('s-untouched', undefined);
+    expect(hasSessionProvider('s-untouched')).toBe(false);
+
+    // learn-host / cardActionHandler 会在 createSession 之前自己写 store。
+    setSessionProvider('s-preset', 'my-relay');
+    freezeSessionProviderAtStart('s-preset', undefined);
+    expect(getSessionProvider('s-preset')).toBe('my-relay');
+  });
+
+  it('空白字符串按清除处理,与 setSessionProvider 同口径', () => {
+    freezeSessionProviderAtStart('s-blank', '  ');
+    expect(hasSessionProvider('s-blank')).toBe(true);
+    expect(getSessionProvider('s-blank')).toBeNull();
+  });
+});

--- a/apps/desktop/src/main/maker-host/index.ts
+++ b/apps/desktop/src/main/maker-host/index.ts
@@ -303,7 +303,11 @@ import {
   rehydrateCloseSuppression,
   withRehydrateCloseSuppressed,
 } from './rehydrateCloseSuppression.js';
-import { getSessionProvider, hydrateSessionProvider } from './session-provider-store.js';
+import {
+  freezeSessionProviderAtStart,
+  getSessionProvider,
+  hydrateSessionProvider,
+} from './session-provider-store.js';
 import { prepareLocalCodexCredentialModeSwitch } from './codex-credential-switch.js';
 import { createDesktopOrcaTeamStoreAdapter } from './orcaTeamStoreAdapter.js';
 import { broadcastOrcaWorkerChanged } from './orcaWorkerBroadcast.js';
@@ -2392,6 +2396,8 @@ export function getMaker(): Maker {
               { code: ACCOUNT_PROVIDER_NOT_READY_CODE },
             );
           }
+          // 所有创建路径共用的派发边界,opts.providerId 此刻已是本次启动的终值。
+          freezeSessionProviderAtStart(sessionId, opts.providerId);
           await preparePersistedOrcaSessionStart(sessionId, opts as MakerSessionCreateOpts);
           if (opts.agentKind === 'pi' && opts.thinkingEnabled === undefined) {
             const thinkingEnabled = getThinkingEnabledFromMemory(

--- a/apps/desktop/src/main/maker-host/session-provider-store.ts
+++ b/apps/desktop/src/main/maker-host/session-provider-store.ts
@@ -30,6 +30,20 @@ export function setSessionProvider(sessionId: string, providerId: string | null)
   bySession.set(sessionId, normalizeSessionProviderId(providerId) ?? null);
 }
 
+/**
+ * 启动派发边界(`prepareStartOptions` 钩子)冻结调用方携带的来源:登记须早于第一次
+ * send 且不经 DB 往返 —— renderer 那份排在 createSession 之后、落库失败只记日志,
+ * 会让会话永久未登记而恒走默认路由。`undefined` = 调用方未携带选择,不写入:
+ * learn-host 等路径自己在 createSession 前写好 store,写 null 会清掉它们的选择。
+ * proxy 在 createSession 返回前反解不到 sessionId,首 turn 误路由(#4154)不在此闭合。
+ */
+export function freezeSessionProviderAtStart(
+  sessionId: string,
+  providerId: string | null | undefined,
+): void {
+  if (providerId !== undefined) setSessionProvider(sessionId, providerId);
+}
+
 /** 读取某会话的供应商;未设置或已清除返回 null(调用方据此走默认路由)。 */
 export function getSessionProvider(sessionId: string): string | null {
   return bySession.get(sessionId) ?? null;

--- a/apps/desktop/src/main/maker-ipc/register.ts
+++ b/apps/desktop/src/main/maker-ipc/register.ts
@@ -6150,7 +6150,8 @@ export function registerMakerIpc(maker: Maker, options: RegisterMakerIpcOptions)
         o.providerId = row.providerId?.trim() || null;
       }
     } catch (err) {
-      log.debug('pre-hydrate session provider failed (non-fatal)', {
+      // 读不到只能按「调用方未指定」继续 → 整个会话跑在非用户所选的上游上。
+      log.warn('pre-hydrate session provider failed (non-fatal)', {
         sessionId: o.id,
         error: err instanceof Error ? err.message : String(err),
       });
@@ -6364,7 +6365,8 @@ export function registerMakerIpc(maker: Maker, options: RegisterMakerIpcOptions)
         setSessionFastMode(session.id, !!efRow?.fastMode);
       }
     } catch (err) {
-      log.debug('hydrate session provider failed (non-fatal)', {
+      // 来源没能落库 → 所选来源在下次冷启动后消失(本次路由已在启动边界冻结)。
+      log.warn('hydrate session provider failed (non-fatal)', {
         sessionId: session.id,
         error: err instanceof Error ? err.message : String(err),
       });


### PR DESCRIPTION
## 这次改了什么

### 摘要

会话显式选定的来源（provider）原先由每条创建路径各自登记进 `session-provider-store`，renderer 那份排在 `maker.createSession()` **之后**、夹在一次 DB 往返里，外层 `catch` 只 `log.debug`。于是 DB 偶发失败会让该会话**永久**未登记 —— 之后每个 turn 都按默认路由发往 Cindy 网关、用网关钥匙请求用户自定义 Provider 的模型，且不会自愈；新增创建路径漏写 store 同样静默落默认路由。

改为在 Maker 的 `prepareStartOptions` 钩子里统一冻结：带着已解析的 sessionId、在 `agent.startSession` 之前、对所有创建路径各跑一次，只读内存里的 `opts.providerId`，不经 DB 往返，renderer / scheduler / hook / device-link 一处覆盖。保留 `id / null / undefined` 三态 —— `undefined` 表示调用方未携带选择，不写入，以免清掉 learn-host 等在 `createSession` 之前自行写好 store 的路径。

顺带把来源登记链路上两处静默失败提到 `warn`。

### 变更类型

- [x] `fix` 缺陷修复

### 范围

- **关联 Issue**：Refs #4154（不 Fixes）
- **本 PR 包含**：启动派发边界统一登记会话来源；两处静默失败日志提级；三态语义单测
- **明确不包含**：#4154 复现步骤所走的链路。从 spawn 到 `createSession()` 返回这段，proxy 靠 `x-claude-code-session-id` 经 `listActiveSessions()` 反解会话（`register.ts:5549`），而 `activeSessions` 要到 `createSession` 末尾才 set（`maker.ts:983`）、新建会话的 `sdkSessionId` 要等 SDK 首条带 `session_id` 的消息才学到（`claude-code/index.ts:2620`、`:4892`）。那段时间路由拿不到 sessionId，`getSessionProvider` 不会被调用 —— 本 PR 不改变该路径行为，它需 #3279 / #3289 闭合。
- **与 #3289 的关系**：无代码冲突。文件交集仅 `maker-host/index.ts`，两者 hunk 相距 170 行以上；`git merge-tree` 试算显示本 PR 引入 0 处新冲突。两个改动正交，可独立合并。
- **也未改动**路由层对「未登记」返回 `null` 的契约：`hasSessionProvider` 无法区分「尚未登记」与「合法的默认路由会话」（learn-host 未继承到来源时永不登记），一律 fail-closed 会让这些会话恒 503。
- **用户可见变化**：DB 写失败时会话不再静默落默认网关；两条诊断日志由 debug 提到 warn。无 UI 变化。
- **breaking change**：无

### UI 变化

不涉及。

- 引用的设计规范：不涉及

## 怎么验证的

### 自动验证

```text
pnpm test:unit:related                              → exit 0（PASS apps/desktop unit，含新增 4 tests）
pnpm --filter desktop run --if-present typecheck    → exit 0
pnpm check:dco                                      → passed, 1 commit signed off
```

### 手工验证

不涉及 —— 本 PR 不改变已知可复现路径的运行时行为。

### 未执行的验证

未注入 DB 写失败实测，靠单测覆盖登记边界。

## 风险

### 风险分类

- [x] 权限 / 安全 / 用户数据 —— 改动落在「请求发往哪个上游、用谁的钥匙」这条边界上

### 影响与回滚

- **影响范围**：`session-provider-store` 的写入时机（提前到 `prepareStartOptions`），以及两条日志级别。读侧、路由决策、持久化格式均未改动。
- **回滚**：单 commit，`git revert` 即可。无 migration、无 schema、无协议字段。

### 提交前检查

- [x] 已 review 完整 diff
- [x] 每个 commit 都带 DCO 签名
- [x] UI 改动已注明设计规范章节（不涉及 UI，跳过）
- [x] 未提交凭证、令牌或授权文件
- [x] 已补充必要文档（契约在 `session-provider-store.ts` 的 JSDoc）
- [x] 已确认测试结果
