### PR TITLE
fix(auth): wait for owner transition before login initialization

### DIFF
--- a/apps/desktop/src/main/__tests__/authLoginFlowReset.test.ts
+++ b/apps/desktop/src/main/__tests__/authLoginFlowReset.test.ts
@@ -829,6 +829,9 @@ describe('auth login-flow reset', () => {
     const getLoginStart = source.indexOf('export async function getLoginState(');
     const getLoginEnd = source.indexOf('\n}\n\nasync function completeLogin(', getLoginStart);
     const getLoginBody = source.slice(getLoginStart, getLoginEnd);
+    expect(getLoginBody.indexOf('await ownerChangeShellGate.waitForSettled();')).toBeLessThan(
+      getLoginBody.indexOf('const expectedLoginFlowEpoch = loginFlowEpoch;'),
+    );
     expect(getLoginBody).toContain('await loadLoginProviders(expectedLoginFlowEpoch)');
     expect(getLoginBody).toContain('mapLoginProvidersLoadFailure(error)');
   });

--- a/apps/desktop/src/main/__tests__/authLoginFlowReset.test.ts
+++ b/apps/desktop/src/main/__tests__/authLoginFlowReset.test.ts
@@ -829,9 +829,13 @@ describe('auth login-flow reset', () => {
     const getLoginStart = source.indexOf('export async function getLoginState(');
     const getLoginEnd = source.indexOf('\n}\n\nasync function completeLogin(', getLoginStart);
     const getLoginBody = source.slice(getLoginStart, getLoginEnd);
-    expect(getLoginBody.indexOf('await ownerChangeShellGate.waitForSettled();')).toBeLessThan(
-      getLoginBody.indexOf('const expectedLoginFlowEpoch = loginFlowEpoch;'),
+    const waitForOwnerChange = getLoginBody.indexOf('await ownerChangeShellGate.waitForSettled();');
+    const captureLoginEpoch = getLoginBody.indexOf(
+      'const expectedLoginFlowEpoch = loginFlowEpoch;',
     );
+    expect(waitForOwnerChange).toBeGreaterThan(-1);
+    expect(captureLoginEpoch).toBeGreaterThan(-1);
+    expect(waitForOwnerChange).toBeLessThan(captureLoginEpoch);
     expect(getLoginBody).toContain('await loadLoginProviders(expectedLoginFlowEpoch)');
     expect(getLoginBody).toContain('mapLoginProvidersLoadFailure(error)');
   });

--- a/apps/desktop/src/main/__tests__/authOwnerChangeShellGate.test.ts
+++ b/apps/desktop/src/main/__tests__/authOwnerChangeShellGate.test.ts
@@ -1,0 +1,54 @@
+import { describe, expect, it, vi } from 'vitest';
+
+import { AuthOwnerChangeShellGate } from '../authOwnerChangeShellGate';
+
+describe('AuthOwnerChangeShellGate', () => {
+  it('releases login initialization only after a nested owner change settles', async () => {
+    const gate = new AuthOwnerChangeShellGate();
+    const settled = vi.fn();
+
+    gate.enter();
+    gate.enter();
+    const waiting = gate.waitForSettled();
+    void waiting.then(settled);
+    await Promise.resolve();
+
+    expect(gate.isPending()).toBe(true);
+    expect(settled).not.toHaveBeenCalled();
+
+    gate.leave();
+    await Promise.resolve();
+    expect(settled).not.toHaveBeenCalled();
+
+    gate.leave();
+    await waiting;
+    expect(gate.isPending()).toBe(false);
+    expect(settled).toHaveBeenCalledOnce();
+  });
+
+  it('waits for a replacement transition that starts as the first one releases', async () => {
+    const gate = new AuthOwnerChangeShellGate();
+    const settled = vi.fn();
+
+    gate.enter();
+    void gate.waitForSettled().then(settled);
+    gate.leave();
+    gate.enter();
+    await Promise.resolve();
+
+    expect(settled).not.toHaveBeenCalled();
+
+    gate.leave();
+    await Promise.resolve();
+    await Promise.resolve();
+    expect(settled).toHaveBeenCalledOnce();
+  });
+
+  it('settles immediately when no owner change is active', async () => {
+    const gate = new AuthOwnerChangeShellGate();
+
+    await expect(gate.waitForSettled()).resolves.toBeUndefined();
+    gate.leave();
+    expect(gate.isPending()).toBe(false);
+  });
+});

--- a/apps/desktop/src/main/authManager.ts
+++ b/apps/desktop/src/main/authManager.ts
@@ -92,6 +92,7 @@ import {
 import { resolveLoginScenarioFetch } from '@cindy/auth-client/fixtures';
 
 import { createLogger } from './logger';
+import { AuthOwnerChangeShellGate } from './authOwnerChangeShellGate';
 import {
   isGhostSkillProjectionBoundaryStableForOwner,
   withGhostSkillProjectionOwnerCommit,
@@ -375,18 +376,18 @@ let sessionInvalidationPromise: Promise<void> | null = null;
 // Real owner change / logout: keep the renderer fail-closed even if a late
 // notifyRenderer() races the teardown. Same-owner Ghost repair must not set
 // this — that was the 55-minute /login flash.
-let ownerChangeShellPendingDepth = 0;
+const ownerChangeShellGate = new AuthOwnerChangeShellGate();
 
 function enterOwnerChangeShellPending(): void {
-  ownerChangeShellPendingDepth += 1;
+  ownerChangeShellGate.enter();
 }
 
 function leaveOwnerChangeShellPending(): void {
-  ownerChangeShellPendingDepth = Math.max(0, ownerChangeShellPendingDepth - 1);
+  ownerChangeShellGate.leave();
 }
 
 function isOwnerChangeShellPending(): boolean {
-  return ownerChangeShellPendingDepth > 0;
+  return ownerChangeShellGate.isPending();
 }
 /**
  * 设备标识。默认绑定物理机(machineIdSync)。
@@ -4902,6 +4903,13 @@ async function discoverOrganizationRealm(org: string, expectedLoginFlowEpoch = l
 }
 
 export async function getLoginState(): Promise<DesktopLoginActionResult> {
+  // A logout publishes the signed-out shell before its owner transition has
+  // finished. Start provider discovery only after that transition settles so
+  // this request captures the post-logout login epoch instead of reporting a
+  // recoverable supersession as a terminal login-page error.
+  while (isOwnerChangeShellPending()) {
+    await ownerChangeShellGate.waitForSettled();
+  }
   const expectedLoginFlowEpoch = loginFlowEpoch;
   try {
     if (loginFlowState) return { success: true, state: loginFlowState };

--- a/apps/desktop/src/main/authOwnerChangeShellGate.ts
+++ b/apps/desktop/src/main/authOwnerChangeShellGate.ts
@@ -1,0 +1,43 @@
+/**
+ * Coordinates login-page initialization with real auth owner transitions.
+ * Nested transitions share one settled signal so callers cannot capture an
+ * obsolete login epoch while logout or account replacement is still tearing
+ * down the previous owner.
+ */
+export class AuthOwnerChangeShellGate {
+  private depth = 0;
+  private pending: Promise<void> | null = null;
+  private resolvePending: (() => void) | null = null;
+
+  enter(): void {
+    if (this.depth === 0) {
+      this.pending = new Promise<void>((resolve) => {
+        this.resolvePending = resolve;
+      });
+    }
+    this.depth += 1;
+  }
+
+  leave(): void {
+    if (this.depth === 0) return;
+    this.depth -= 1;
+    if (this.depth !== 0) return;
+
+    const resolve = this.resolvePending;
+    this.pending = null;
+    this.resolvePending = null;
+    resolve?.();
+  }
+
+  isPending(): boolean {
+    return this.depth > 0;
+  }
+
+  async waitForSettled(): Promise<void> {
+    // A second transition can start while a previous wait resumes. Re-read the
+    // active promise until there is no owner-change shell left to observe.
+    while (this.pending) {
+      await this.pending;
+    }
+  }
+}


### PR DESCRIPTION
## 这次改了什么

### 摘要

修复退出登录后，登录页初始化与 owner 切换交错导致的错误页。`getLoginState()` 现在等待 owner-change shell 收敛，再读取登录状态并捕获 login epoch，避免 provider 加载使用已经过期的 epoch。

### 变更类型

- [x] `fix` 缺陷修复

### 范围

- Closes makecindy/cindy#4153
- 将已有 owner-change pending depth 封装为 `AuthOwnerChangeShellGate`，在最外层切换结束时唤醒登录初始化；嵌套切换及紧接着开始的新切换都会继续等待。
- 保留现有 login epoch 校验、supersession 处理和 Main 侧 owner-boundary 安全门。
- 用户可见变化：退出登录后的登录初始化等待 owner 切换完成，避免这条时序路径把可恢复切换呈现为登录失败。
- 无 breaking change。

### UI 变化

- 引用的设计规范：不涉及；改动位于 Main 登录初始化及其测试，没有修改 UI 布局、样式或文案。

## 怎么验证的

### 自动验证

```text
pnpm --filter desktop exec vitest run src/main/__tests__/authOwnerChangeShellGate.test.ts src/main/__tests__/authLoginFlowReset.test.ts
结果：2 个测试文件、34 项测试通过。

pnpm test:unit:related
结果：通过，退出码 0。

pnpm --filter desktop run --if-present typecheck
结果：通过，退出码 0。

git diff --check
结果：通过。
```

新增 gate 测试覆盖嵌套 owner 切换、前一次唤醒时紧接着开始的新切换，以及无 pending 时立即返回；登录流程测试锁定等待发生在捕获 epoch 之前。

## 风险

### 风险分类

- [x] 其他：登录初始化与 owner 切换的异步时序。

### 影响与回滚

- 影响范围：Desktop 的登录初始化与现有 owner-change shell 协调。现有认证失败映射、epoch 校验及权限边界保持不变。
- 回滚方式：revert 本 PR 的单个提交；无数据库、协议或持久数据格式变更。

### 提交前检查

- [x] 已 review 完整 diff
- [x] 每个 commit 都带 DCO 签名
- [x] 未提交凭证、令牌或授权文件
- [x] 已确认上述测试结果
