### PR TITLE
fix(desktop): 修复引擎切换时选中模型被默认值覆盖

### DIFF
--- a/apps/desktop/src/renderer/__tests__/vendorModelFallback.test.ts
+++ b/apps/desktop/src/renderer/__tests__/vendorModelFallback.test.ts
@@ -60,6 +60,45 @@ const PROVIDERS: ProviderView[] = [
 ];
 
 describe('shouldFallbackVendorModel', () => {
+  const subscriptionRoutes = [
+    provider('openai', 'builtin', {
+      codex: ['gpt-6-astra'],
+      pi: ['chatgpt/gpt-6-astra'],
+    }),
+    provider('xd', 'builtin', { pi: ['glm-5.3'] }),
+  ];
+
+  it('does not repair the old model while a cross-engine intent masks it', () => {
+    // This exact mixed-generation comparison previously selected the Pi seed.
+    expect(shouldFallbackVendorModel(subscriptionRoutes, 'gpt-6-astra', 'pi')).toBe(true);
+    expect(shouldFallbackVendorModel(subscriptionRoutes, 'gpt-6-astra', 'pi', {
+      hasSwitchIntent: true,
+    })).toBe(false);
+    // Persisted fields still belong to Codex until Main commits the switch.
+    expect(shouldFallbackVendorModel(subscriptionRoutes, 'gpt-6-astra', 'codex')).toBe(false);
+  });
+
+  it('preserves a bound route after intent consumption, even with a partial catalog', () => {
+    expect(shouldFallbackVendorModel(subscriptionRoutes, 'chatgpt/gpt-6-astra', 'pi', {
+      providerId: 'openai',
+    })).toBe(false);
+    // A delayed snapshot/other controller must not turn openai + GPT into openai + GLM.
+    expect(shouldFallbackVendorModel(subscriptionRoutes, 'gpt-6-astra', 'pi', {
+      providerId: 'openai',
+    })).toBe(false);
+  });
+
+  it('preserves host-authoritative selection when a phone or remote desktop switches it', () => {
+    // Host Renderer sees an intent registered elsewhere, not a local click flag.
+    expect(shouldFallbackVendorModel(subscriptionRoutes, 'gpt-6-astra', 'pi', {
+      hasSwitchIntent: true,
+    })).toBe(false);
+    // Control-side and SSH catalogs cannot establish that a host route is invalid.
+    expect(shouldFallbackVendorModel(subscriptionRoutes, 'gpt-6-astra', 'pi', {
+      isRemote: true,
+    })).toBe(false);
+  });
+
   it('keeps a custom (mimo) codex model in a codex session (the fixed bug)', () => {
     expect(shouldFallbackVendorModel(PROVIDERS, 'mimo-codex', 'codex')).toBe(false);
   });

--- a/apps/desktop/src/renderer/features/cc-agent/CCAgentSessionView.tsx
+++ b/apps/desktop/src/renderer/features/cc-agent/CCAgentSessionView.tsx
@@ -3942,7 +3942,7 @@ export function CCAgentSessionView({
     t,
   ]);
 
-  // M35: Vendor fallback —— 会话的 model 与它(固定不变的)agent vendor 明确错配时,
+  // M35: Vendor fallback —— 仅修复未绑定 provider、且没有切换意图的历史行。
   // 回退到该 vendor 的默认模型。守的是「绕过模型选择器写入 session.model」的脏数据路径
   // (历史 DB 行 / 上古 model id),选择器主动选择的 happy path 由 provider 逻辑自己保证一致。
   //
@@ -3955,15 +3955,19 @@ export function CCAgentSessionView({
   // (别名 / 脏数据 / 目录未加载的瞬间)一律不动,避免 load race 误杀。cc / codex 统一这一套。
   const sessionAgentKind = session?.agentKind;
   const sessionModel = session?.model;
+  const sessionProviderId = session?.providerId;
   useEffect(() => {
     if (readOnly) return;
     if (!sessionAgentKind || !sessionModel || !sessionId) return;
     // device-link 远程会话:vendor↔model 一致性由被控端权威保证。控制端不能替它"纠正"——
     // 远程模型可能只存在于被控端(本地目录查不到 → 误判跨 vendor),且本地 DB 没有该会话行,
     // sessionService.update 会写错 / refreshServerSession 对远程是 no-op。直接跳过(规则:host 为准)。
-    if (getSessionDeviceId(sessionId)) return;
-    const agent = displayAgentKind;
-    if (!shouldFallbackVendorModel(providers, sessionModel, agent)) return;
+    const agent = dbToMakerAgentKind(sessionAgentKind);
+    if (!shouldFallbackVendorModel(providers, sessionModel, agent, {
+      providerId: sessionProviderId,
+      hasSwitchIntent: agentSwitchIntent != null,
+      isRemote: Boolean(isRemoteSession || remoteDeviceId || getSessionDeviceId(sessionId)),
+    })) return;
     // 用三值化后的 agent 映射选默认模型:Pi 会话必须回退到 Pi 目录默认,而不是被
     // `isCodex ? 'codex' : 'cc'` 误写成 CC 首选(可能是更贵的 Opus)(codex review)。
     const defaultModel = getDefaultModelForVendor(
@@ -3974,12 +3978,15 @@ export function CCAgentSessionView({
       .then(() => refreshServerSession())
       .catch((err) => log.warn('vendor fallback patch failed:', err));
   }, [
-    displayAgentKind,
+    agentSwitchIntent,
+    isRemoteSession,
     providers,
     refreshServerSession,
+    remoteDeviceId,
     sessionAgentKind,
     sessionId,
     sessionModel,
+    sessionProviderId,
     readOnly,
   ]);
 

--- a/apps/desktop/src/renderer/features/cc-agent/lib/vendorModelFallback.ts
+++ b/apps/desktop/src/renderer/features/cc-agent/lib/vendorModelFallback.ts
@@ -26,14 +26,25 @@ import { providerOffersModel, type AgentKind, type ProviderView } from '@cindy/m
  *
  * @param providers   live 供应商视图(useProviders 的结果;含内置 + 自定义,按 agent 挂模型)。
  * @param sessionModel 会话当前存的 model id。
- * @param agent        会话所属 agent(建会话即固定,不可变)。
+ * @param agent        与 sessionModel 同一持久化快照中的 agent，不得传展示意图的 agent。
  * @returns true = 需要回退(model 明确属于另一个 vendor);false = 保持不动。
  */
 export function shouldFallbackVendorModel(
   providers: ProviderView[],
   sessionModel: string,
   agent: AgentKind,
+  context: {
+    providerId?: string | null;
+    hasSwitchIntent?: boolean;
+    isRemote?: boolean;
+  } = {},
 ): boolean {
+  // Only repair unbound legacy rows. A selected route belongs to Main, including
+  // routes selected by mobile/another desktop while this view is open. Catalog
+  // absence is not permission to replace that route with a new-session seed.
+  // Pending intent and persisted model are different generations (and may use
+  // different wire IDs); never compare one generation's model to the other's agent.
+  if (context.providerId || context.hasSwitchIntent || context.isRemote) return false;
   // 本端任一供应商 offer 该模型 → 合法(含自定义供应商、gpt-5.x 等),绝不回退。
   if (providers.some((p) => providerOffersModel(p, sessionModel, agent))) return false;
   // 本端不 offer:仅当对端 agent 明确 offer 它(确定的跨 vendor 错配)才回退;


### PR DESCRIPTION
## 这次改了什么

### 摘要

从 Codex GPT-6 切换至 Pi GPT-6 时，回退校验会将新引擎与旧模型 ID 混用，把默认 GLM 写回已选择 OpenAI 来源的任务。切换意图在首句发送后消失，错误组合随之显示为不可用。

改为比较同一持久化快照中的引擎与模型，并在存在切换意图、已绑定供应商或远程任务时跳过默认回写；仅保留未绑定来源的历史错配修复。

### 变更类型

- [x] `fix` 缺陷修复

### 范围

- 关联 Issue / 需求：用户报告 Codex GPT-6 → Pi GPT-6 后被错误改为 GLM，不可用，要求覆盖手机/远程操作。
- 本 PR 包含：修复 Renderer 回退判定及回归测试。
- 明确不包含：升级后模型默认启用策略、供应商偏好、历史数据迁移、切换协议改造。
- 用户可见变化：明确选择的模型不再被这条回退路径覆盖。
- 是否存在 breaking change：无。
- SSH 远程工作区：已适配，检测 remoteHostId 后跳过本地目录回写，无远端文件/进程操作。
- 设备互联：已适配，控制端跳过回写，被控桌面通过共享切换意图及来源绑定保护手机/另一台桌面的选择。
- 手机版：复用现有切换入口与宿主状态，无需新增手机 UI；未改 IPC、推送、allowlist 或 wire protocol，也未改重试/断链恢复路径。

### UI 变化

- 引用的设计规范：不涉及：仅修复选中模型状态的错误回写，无布局、样式、文案或新交互变化。

## 怎么验证的

### 自动验证

```text
pnpm test:unit:related
结果：通过，退出码 0。
pnpm --filter desktop run --if-present typecheck
结果：通过，退出码 0。
```

附加定向验证：Desktop 的 vendorModelFallback、sessionAgentSwitchRemoteRouting、sessionAgentSwitchHandler 三个测试文件通过（137 tests）；Mobile 的 sessionAgentSwitch、sessionAgentSwitchConfirmation 通过（6 tests）。两端均使用 `vitest run --maxWorkers=1`。

### 手工验证

已逐文件审查完整 diff，核对持久化字段与切换意图的使用，以及远程身份判断。

### 未执行的验证

未做 Desktop、手机及远程实机切换验收；本轮使用代码审查和自动测试，未启动开发实例，也未操作用户原任务。

## 风险

### 风险分类

- [x] 其他：缩小历史模型自动修复范围。

### 影响与回滚

- 影响范围：已绑定来源的无效模型将保留给权威路由层处理，不再由 Renderer 擅自改成默认模型；未绑定来源的历史明确错配仍按原策略回退。无数据库 schema、权限、system prompt 或原生指纹变化。
- 回滚 / 降级方式：回退本提交即可恢复原逻辑；无迁移或外部服务依赖。

### 提交前检查

- [x] 已 review 完整 diff
- [x] 每个 commit 都带 DCO 签名（git commit -s）
- [x] UI 改动已在「UI 变化」注明引用的设计规范章节（不涉及 UI 则跳过）
- [x] 未提交凭证、令牌或授权文件
- [x] 已补充必要文档
- [x] 已确认测试结果或说明未执行原因
