### PR TITLE
fix(bots): 修正备用模型编号与编辑范围

### DIFF
--- a/apps/desktop/src/renderer/features/bots/BotModelChainEditor.tsx
+++ b/apps/desktop/src/renderer/features/bots/BotModelChainEditor.tsx
@@ -71,7 +71,7 @@ export function BotModelChainEditor({
   };
   const move = (index: number, delta: -1 | 1) => {
     const target = index + delta;
-    if (target < 0 || target >= routes.length) return;
+    if (index < 1 || target < 1 || target >= routes.length) return;
     const next = [...routes];
     [next[index], next[target]] = [next[target]!, next[index]!];
     onChange(next);
@@ -139,43 +139,46 @@ export function BotModelChainEditor({
         </summary>
         {expanded ? (
           <div className="space-y-2 pt-2">
-            {routes.map((route, index) => (
-              <div key={index} className="flex min-w-0 items-center gap-2">
-                <span className="w-4 shrink-0 text-11">{index + 1}</span>
-                {picker(route, index)}
-                <div className="flex shrink-0 gap-1">
-                  <button
-                    type="button"
-                    disabled={disabled || index === 0}
-                    onClick={() => move(index, -1)}
-                    aria-label={t('bots.modelChain.moveUp')}
-                    className="rounded-lg p-1.5 hover:bg-[var(--surface-hover)] disabled:opacity-30"
-                  >
-                    <ArrowUp size={14} />
-                  </button>
-                  <button
-                    type="button"
-                    disabled={disabled || index === routes.length - 1}
-                    onClick={() => move(index, 1)}
-                    aria-label={t('bots.modelChain.moveDown')}
-                    className="rounded-lg p-1.5 hover:bg-[var(--surface-hover)] disabled:opacity-30"
-                  >
-                    <ArrowDown size={14} />
-                  </button>
-                  {routes.length > 1 ? (
+            {routes.slice(1).map((route, fallbackIndex) => {
+              const index = fallbackIndex + 1;
+              return (
+                <div key={index} className="flex min-w-0 items-center gap-2">
+                  <span className="w-4 shrink-0 text-11">{index}</span>
+                  {picker(route, index)}
+                  <div className="flex shrink-0 gap-1">
                     <button
                       type="button"
-                      disabled={disabled}
-                      onClick={() => onChange(routes.filter((_, at) => at !== index))}
-                      aria-label={t('bots.modelChain.remove')}
-                      className="rounded-lg p-1.5 hover:bg-[var(--danger-bg-soft)] hover:text-[var(--text-danger)]"
+                      disabled={disabled || index === 1}
+                      onClick={() => move(index, -1)}
+                      aria-label={t('bots.modelChain.moveUp')}
+                      className="rounded-lg p-1.5 hover:bg-[var(--surface-hover)] disabled:opacity-30"
                     >
-                      <Trash2 size={14} />
+                      <ArrowUp size={14} />
                     </button>
-                  ) : null}
+                    <button
+                      type="button"
+                      disabled={disabled || index === routes.length - 1}
+                      onClick={() => move(index, 1)}
+                      aria-label={t('bots.modelChain.moveDown')}
+                      className="rounded-lg p-1.5 hover:bg-[var(--surface-hover)] disabled:opacity-30"
+                    >
+                      <ArrowDown size={14} />
+                    </button>
+                    {routes.length > 1 ? (
+                      <button
+                        type="button"
+                        disabled={disabled}
+                        onClick={() => onChange(routes.filter((_, at) => at !== index))}
+                        aria-label={t('bots.modelChain.remove')}
+                        className="rounded-lg p-1.5 hover:bg-[var(--danger-bg-soft)] hover:text-[var(--text-danger)]"
+                      >
+                        <Trash2 size={14} />
+                      </button>
+                    ) : null}
+                  </div>
                 </div>
-              </div>
-            ))}
+              );
+            })}
             <button
               type="button"
               disabled={disabled || routes.length >= BOT_MODEL_CHAIN_MAX || visibleVendors.length === 0}

--- a/apps/desktop/src/renderer/features/bots/__tests__/botModelChainEditor.test.tsx
+++ b/apps/desktop/src/renderer/features/bots/__tests__/botModelChainEditor.test.tsx
@@ -1,6 +1,6 @@
 // @vitest-environment jsdom
 
-import { cleanup, fireEvent, render, screen } from '@testing-library/react';
+import { cleanup, fireEvent, render, screen, within } from '@testing-library/react';
 import { afterEach, describe, expect, it, vi } from 'vitest';
 
 const { modelSelectorProps, roster } = vi.hoisted(() => ({
@@ -12,6 +12,7 @@ vi.mock('@/hooks/useAvailableAgents', () => ({ useAvailableAgents: () => roster 
 
 vi.mock('@/components/new-chat/ModelSelector', () => ({
   ModelSelector: (props: {
+    modelId: string;
     onEffortChange: (effort: string) => void;
     onFastModeChange: (enabled: boolean) => void;
     onUnifiedSelect: (selection: {
@@ -25,7 +26,7 @@ vi.mock('@/components/new-chat/ModelSelector', () => ({
   }) => {
     modelSelectorProps(props);
     return (
-      <>
+      <div data-testid={`model-selector-${props.modelId}`}>
         <button onClick={() => props.onEffortChange("high")}>set-high-effort</button>
         <button onClick={() => props.onFastModeChange(true)}>enable-fast-mode</button>
         <button
@@ -57,7 +58,7 @@ vi.mock('@/components/new-chat/ModelSelector', () => ({
         >
           choose-official-claude-model
         </button>
-      </>
+      </div>
     );
   },
 }));
@@ -88,6 +89,71 @@ afterEach(() => {
 });
 
 describe('BotModelChainEditor', () => {
+  const primary = { harness: 'codex' as const, model: 'primary-model', providerId: 'openai', effort: 'medium', fastMode: false };
+  const firstFallback = { ...primary, model: 'first-fallback' };
+  const secondFallback = { ...primary, model: 'second-fallback' };
+
+  function expand(container: HTMLElement) {
+    const details = container.querySelector('details')!;
+    details.open = true;
+    fireEvent(details, new Event('toggle'));
+    return within(details);
+  }
+
+  it('lists and numbers only fallbacks, and edits the second route without replacing the primary', () => {
+    const onChange = vi.fn();
+    const view = render(<BotModelChainEditor value={[primary, firstFallback]} onChange={onChange} />);
+    const fallbacks = expand(view.container);
+
+    expect(screen.getAllByTestId('model-selector-primary-model')).toHaveLength(1);
+    expect(fallbacks.queryByTestId('model-selector-primary-model')).toBeNull();
+    expect(fallbacks.getByText('bots.modelChain.options:{"count":1}')).toBeTruthy();
+    expect(fallbacks.getByText('1')).toBeTruthy();
+    expect(fallbacks.queryByText('2')).toBeNull();
+    const picker = within(fallbacks.getByTestId('model-selector-first-fallback'));
+    fireEvent.click(picker.getByText('choose-official-codex-model'));
+    expect(onChange).toHaveBeenLastCalledWith([primary, {
+      harness: 'codex', providerId: 'openai', model: 'gpt-5.6-sol', effort: 'medium', fastMode: true,
+    }]);
+    fireEvent.click(picker.getByText('set-high-effort'));
+    expect(onChange).toHaveBeenLastCalledWith([primary, { ...firstFallback, effort: 'high' }]);
+    fireEvent.click(picker.getByText('enable-fast-mode'));
+    expect(onChange).toHaveBeenLastCalledWith([primary, { ...firstFallback, fastMode: true }]);
+  });
+
+  it('reorders and removes fallbacks while keeping the primary in place', () => {
+    const onChange = vi.fn();
+    const view = render(<BotModelChainEditor value={[primary, firstFallback, secondFallback]} onChange={onChange} />);
+    const fallbacks = expand(view.container);
+    const up = fallbacks.getAllByLabelText('bots.modelChain.moveUp');
+    expect((up[0] as HTMLButtonElement).disabled).toBe(true);
+    fireEvent.click(up[0]!);
+    expect(onChange).not.toHaveBeenCalled();
+    fireEvent.click(up[1]!);
+    expect(onChange).toHaveBeenLastCalledWith([primary, secondFallback, firstFallback]);
+    fireEvent.click(fallbacks.getAllByLabelText('bots.modelChain.moveDown')[0]!);
+    expect(onChange).toHaveBeenLastCalledWith([primary, secondFallback, firstFallback]);
+    fireEvent.click(fallbacks.getAllByLabelText('bots.modelChain.remove')[0]!);
+    expect(onChange).toHaveBeenLastCalledWith([primary, secondFallback]);
+
+    view.rerender(<BotModelChainEditor value={[primary, secondFallback]} onChange={onChange} />);
+    expect(fallbacks.getByText('1')).toBeTruthy();
+    expect(fallbacks.queryByText('2')).toBeNull();
+    fireEvent.click(fallbacks.getByLabelText('bots.modelChain.remove'));
+    expect(onChange).toHaveBeenLastCalledWith([primary]);
+  });
+
+  it('shows no fallback rows for a primary-only chain and appends the first fallback', () => {
+    const onChange = vi.fn();
+    const view = render(<BotModelChainEditor value={[primary]} onChange={onChange} />);
+    const fallbacks = expand(view.container);
+    expect(fallbacks.getByText('bots.modelChain.options:{"count":0}')).toBeTruthy();
+    expect(fallbacks.queryByTestId('model-selector-primary-model')).toBeNull();
+    expect(fallbacks.queryByLabelText('bots.modelChain.remove')).toBeNull();
+    fireEvent.click(fallbacks.getByText('bots.modelChain.add'));
+    expect(onChange).toHaveBeenLastCalledWith([primary, expect.objectContaining({ model: 'default-model' })]);
+  });
+
   it('uses the standard configurable picker for the current harness', () => {
     render(
       <BotModelChainEditor


### PR DESCRIPTION
## 这次改了什么

### 摘要

伙伴模型设置把主模型重复显示为“备用 1”，修改它会覆盖主模型。现在备用列表从候选链第二项开始，编号从 1 起，数量与实际行数一致；编辑、删除和排序备用模型都保留主模型。

### 变更类型

- [x] `fix` 缺陷修复

### 范围

- 关联 Issue / 需求：用户反馈伙伴“备用模型 1”实际修改主模型。
- 本 PR 包含：共用模型编辑器的备用列表范围、编号与排序边界，及行为回归测试。
- 明确不包含：模型目录、持久化格式、运行时自动接替规则和模型上限变更。
- 用户可见变化：主模型只显示一次；备用 1 就是第二个模型，备用排序不再把主模型换掉。
- 是否存在 breaking change：无。

### UI 变化

- 平台：Desktop。展开备用列表不再出现重复的主模型行；已有配色、布局样式和模型选择器保持不变。
- 引用的设计规范：`docs/design-rules/DESIGN.md` §5 留白与信息密度，去除重复主模型行；§10 双模式，保留现有语义 token，不新增模式专属样式。
- 未取得修复后实机截图；Light / Dark 均未实机目检。

<details>
<summary>Light / Dark HTML 结构示意（可另存为 HTML 打开）</summary>

以下为根据改动后列表结构制作的静态示意，**不是运行中应用的截图或组件渲染产物**。仅用于核对：主模型独立显示、备用数量与行数一致、备用 1 为候选链第二项、单个备用的上下移均禁用。模型菜单、品牌图标、说明文字和真实主题色不作为此示意的视觉验收；实际行为由回归测试覆盖。Light / Dark 实机目检仍未执行。

```html
<!doctype html>
<html lang="zh-CN">
<meta charset="utf-8">
<meta name="viewport" content="width=device-width,initial-scale=1">
<title>伙伴备用模型列表 · 结构示意</title>
<style>
*{box-sizing:border-box}body{margin:0;padding:24px;font:14px/1.5 system-ui;background:#ddd}
.preview{max-width:620px;margin:0 auto 24px;padding:24px;background:var(--surface);color:var(--text-primary)}
.light{--surface:#f5f5f4;--text-primary:#262626;--text-secondary:#737373;--surface-hover:#e5e5e5}
.dark{--surface:#242423;--text-primary:#d4d4d4;--text-secondary:#a3a3a3;--surface-hover:#3c3c3a}
.row{display:flex;align-items:center;gap:12px;min-width:0}.label{font-size:12px;color:var(--text-secondary)}
.model{flex:1;min-width:0}button{border:0;background:transparent;color:inherit;font:inherit;cursor:pointer}
button:hover{background:var(--surface-hover)}button:disabled{opacity:.3;cursor:default}
.picker{padding:6px 8px;border-radius:9999px}.controls{display:flex;gap:4px}.controls button{padding:6px;border-radius:8px}
summary{padding:8px 0;cursor:pointer;font-size:12px;color:var(--text-secondary)}
.list{padding-top:8px}.number{width:16px;font-size:11px;color:var(--text-secondary)}
.actions{display:flex;gap:8px;margin-top:8px;color:var(--text-secondary);font-size:12px}
.actions button{height:32px;padding:0 12px;border-radius:9999px}
.note{font-size:12px;color:var(--text-secondary);margin:0 0 16px}
</style>
<section class="preview light" aria-label="浅色结构示意">
<p class="note">浅色 · 静态结构示意；模型菜单与保存行为不在此页面模拟。</p>
<div class="row"><span class="label">模型</span><div class="model"><button class="picker">GPT-6 Astra · 中 ⌄</button></div></div>
<details open><summary>备用模型（1）</summary><div class="list">
<div class="row"><span class="number">1</span><div class="model"><button class="picker">GLM 5.3 Flash · 中 ⌄</button></div><div class="controls"><button disabled aria-label="上移">↑</button><button disabled aria-label="下移">↓</button><button aria-label="删除备用模型">×</button></div></div>
<div class="actions"><button>＋ 添加备用模型</button><button>恢复默认模型</button></div>
</div></details>
</section>
<section class="preview dark" aria-label="深色结构示意">
<p class="note">深色 · 静态结构示意；模型菜单与保存行为不在此页面模拟。</p>
<div class="row"><span class="label">模型</span><div class="model"><button class="picker">GPT-6 Astra · 中 ⌄</button></div></div>
<details open><summary>备用模型（1）</summary><div class="list">
<div class="row"><span class="number">1</span><div class="model"><button class="picker">GLM 5.3 Flash · 中 ⌄</button></div><div class="controls"><button disabled aria-label="上移">↑</button><button disabled aria-label="下移">↓</button><button aria-label="删除备用模型">×</button></div></div>
<div class="actions"><button>＋ 添加备用模型</button><button>恢复默认模型</button></div>
</div></details>
</section>
</html>
```

</details>

## 怎么验证的

### 自动验证

```text
pnpm --filter desktop exec vitest run src/renderer/features/bots/__tests__/botModelChainEditor.test.tsx --maxWorkers=1 --minWorkers=1
结果：13 项通过，覆盖备用编辑、排序、删除与空备用列表。
pnpm test:unit:related -- --no-lock --workspace-concurrency=1
结果：通过。首次运行在共享测试锁连接重置（ECONNRESET）后退出；确认资源余量后使用仓库提供的 no-lock 重跑，未改变测试覆盖。
pnpm --filter desktop run --if-present typecheck
结果：通过。
git diff --check
结果：通过。
```

### 手工验证

已逐文件审阅完整 diff，并沿个人设置、全局设置的保存回调核对主模型仍取候选链第一项。

### 未执行的验证

未启动 Desktop 做 Light / Dark 实机目检；完整跨平台单测交由 CI。

## 风险

### 风险分类

- [x] 无已知风险

### 影响与回滚

- 影响范围：复用 BotModelChainEditor 的伙伴设置与模型选择入口。存量配置保留原有顺序，不涉及 schema、权限或运行时变更。
- 回滚 / 降级方式：回退本提交即可；无数据迁移。

### 提交前检查

- [x] 已 review 完整 diff
- [x] 每个 commit 都带 DCO 签名（git commit -s）
- [x] UI 改动已在「UI 变化」注明引用的设计规范章节
- [x] 未提交凭证、令牌或授权文件
- [x] 已补充必要文档（无需新增产品规则，行为符合现有候选链契约）
- [x] 已确认测试结果或说明未执行原因
