### PR TITLE
fix(pi): persist completed replies before agent settlement

### DIFF
--- a/apps/desktop/src/main/localDb/ipc/__tests__/piReplyDelivery.test.ts
+++ b/apps/desktop/src/main/localDb/ipc/__tests__/piReplyDelivery.test.ts
@@ -1,0 +1,237 @@
+/** Pi RPC → translator → Session → stream persistence → real in-memory SQLite. */
+import { PassThrough } from 'node:stream';
+import Database from 'better-sqlite3';
+import { drizzle } from 'drizzle-orm/better-sqlite3';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { messages, sessions } from '../../schema';
+import { tx } from '../../worker/opHandlers/tx';
+
+import { Session } from '../../../../../../../packages/maker-core/src/session';
+import type { AgentSessionHandle } from '../../../../../../../packages/maker-core/src/agents/base-agent';
+import type { AgentEvent } from '../../../../../../../packages/maker-core/src/types/events';
+import { createAsyncQueue } from '../../../../../../../packages/maker-core/src/agents/shared/async-queue';
+import { PiRpcProcess } from '../../../../../../../packages/maker-core/src/agents/pi/rpc-client';
+import { attachJsonlReader, type PiTransport } from '../../../../../../../packages/maker-core/src/agents/pi/transport';
+import { createPiTranslateContext, disposePiTranslateContext, translatePiEvent } from '../../../../../../../packages/maker-core/src/agents/pi/translator';
+import { piSuccessfulReplyFrames, piReplyText, piReplyThinking } from '../../../../test/fixtures/piSuccessfulReply';
+import { persistSessionStreamEvent } from '../../../maker-ipc/sessionEventStream';
+import type { PreparedSessionEvent } from '../../../maker-ipc/sessionEventPreparation';
+import { clearSessionPersistState, drainPersistQueue, flushAssistantBlock, noteSessionAgentKind } from '../../../messagePersistBroadcaster';
+
+const h = vi.hoisted(() => ({
+  sqlite: null as Database.Database | null,
+  client: null as {
+    drizzle: ReturnType<typeof drizzle>;
+    tx: (name: string, args: unknown) => Promise<unknown>;
+    exec: (sql: string, params?: unknown[]) => Promise<Database.RunResult>;
+    query: (sql: string, params?: unknown[]) => Promise<unknown[]>;
+  } | null,
+  broadcast: vi.fn(),
+  warn: vi.fn(),
+}));
+
+vi.mock('electron', () => ({
+  ipcMain: { handle: vi.fn() },
+  BrowserWindow: { getAllWindows: () => [{ isDestroyed: () => false, webContents: { send: h.broadcast } }] },
+}));
+vi.mock('../../../logger', () => ({
+  createLogger: () => ({ debug: vi.fn(), info: vi.fn(), warn: h.warn, error: vi.fn() }),
+}));
+vi.mock('../../../logger.js', () => ({
+  createLogger: () => ({ debug: vi.fn(), info: vi.fn(), warn: h.warn, error: vi.fn() }),
+}));
+vi.mock('../../../maker-host/codex-local-sessions', () => ({
+  importExternalCodexMessagesForSession: vi.fn(async () => undefined),
+}));
+vi.mock('../../../maker-host/claude-local-sessions', () => ({
+  importExternalClaudeCodeMessagesForSession: vi.fn(async () => undefined),
+}));
+vi.mock('../../../embedders/chat-history-embedder', () => ({
+  onMessageCreated: vi.fn(async () => undefined),
+}));
+vi.mock('../../../git-context/prRefsStore', () => ({
+  recomputePrRefsForSession: vi.fn(async () => undefined),
+  recordPrRefsForMessage: vi.fn(async () => undefined),
+}));
+vi.mock('../../../cindy-media/chatAttachments', () => ({
+  commitMessageMediaRefs: vi.fn(async () => null),
+  collectCindyMediaHashes: vi.fn(() => []),
+}));
+vi.mock('../../../cindy-media/ledger', () => ({
+  removeRefs: vi.fn(async () => undefined),
+  removeSessionAttachmentRefIfUnreferencedByLiveMessage: vi.fn(async () => undefined),
+}));
+vi.mock('../../../device-link/invoke-context', () => ({
+  isDeviceLinkInvoke: vi.fn(() => false),
+}));
+vi.mock('../../../device-link/broadcast-tap', () => ({
+  captureDataOwnerBroadcastScope: vi.fn(() => null),
+  getSafeDataOwnerPushStamp: vi.fn(() => undefined),
+  tapWindowBroadcast: vi.fn(),
+}));
+vi.mock('../../client/current', () => ({
+  getDbClient: () => h.client,
+}));
+
+function setupDb(): void {
+  const sqlite = new Database(':memory:');
+  sqlite.exec(`
+    CREATE TABLE sessions (
+      id TEXT PRIMARY KEY,
+      cleared_at INTEGER,
+      list_preview TEXT,
+      list_preview_role TEXT,
+      list_message_count INTEGER,
+      status TEXT NOT NULL DEFAULT 'active'
+    );
+    CREATE TABLE messages (
+      id TEXT PRIMARY KEY,
+      client_id TEXT NOT NULL,
+      session_id TEXT NOT NULL,
+      role TEXT NOT NULL,
+      content TEXT NOT NULL,
+      tool_use_id TEXT,
+      agent_meta TEXT,
+      agent_kind TEXT,
+      created_at INTEGER NOT NULL,
+      rewind_at INTEGER
+    );
+    CREATE UNIQUE INDEX uniq_messages_session_client ON messages(session_id, client_id);
+  `);
+  sqlite.prepare("INSERT INTO sessions (id, cleared_at, status) VALUES ('s1', NULL, 'active')").run();
+  const db = drizzle(sqlite, {
+    schema: { messages, sessions },
+  });
+  h.sqlite = sqlite;
+  h.client = {
+    drizzle: db,
+    tx: async (name: string, args: unknown) => tx(sqlite, { name, args }),
+    exec: vi.fn(async (sql: string, params: unknown[] = []) => h.sqlite!.prepare(sql).run(...params)),
+    query: vi.fn(async (sql: string, params: unknown[] = []) => h.sqlite!.prepare(sql).all(...params)),
+  };
+}
+
+const logger = {
+  trace: vi.fn(), debug: vi.fn(), info: vi.fn(), warn: h.warn, error: vi.fn(), fatal: vi.fn(),
+  child: () => logger,
+};
+
+function createReplay() {
+  const stdout = new PassThrough();
+  const queue = createAsyncQueue<AgentEvent>();
+  const ctx = createPiTranslateContext(logger);
+  const transport: PiTransport = {
+    pid: undefined,
+    writeLine: vi.fn(async () => undefined),
+    onLine: (listener) => { attachJsonlReader(stdout, listener); return () => undefined; },
+    onClose: () => () => undefined,
+    close: async () => { stdout.destroy(); },
+    isClosed: () => stdout.destroyed,
+  };
+  new PiRpcProcess({
+    transport, logger, onExit: vi.fn(),
+    onEvent: (event) => translatePiEvent(event, queue, ctx),
+  });
+  const handle = {
+    id: 'pi-replay', agentKind: 'pi', model: 'z-ai/glm-5.3-flash',
+    events: () => queue, setInteractionResolver: vi.fn(),
+    isTurnRunning: () => ctx.isStreaming,
+    getUsageSnapshot: () => ({ tokenUsage: 0, contextTokens: 0, contextWindow: 0, costUsd: 0 }),
+    close: async () => { disposePiTranslateContext(ctx); queue.end(); stdout.destroy(); },
+  } as unknown as AgentSessionHandle;
+  const session = new Session({
+    id: 's1', agentKind: 'pi', workDir: process.cwd(), handle,
+    capabilities: {} as never, logger, turnStallMs: 0,
+  });
+  const received: AgentEvent[] = [];
+  const persistIds: string[] = [];
+  session.onEvent((event) => {
+    received.push(event);
+    const result = persistSessionStreamEvent({ log: logger, orcaTeamServiceForEvents: null }, session, {
+      event, eventAgentMeta: event.agentMeta ?? null,
+    } as PreparedSessionEvent);
+    if (result.persistId) persistIds.push(result.persistId);
+    // The existing terminal consumer uses this same helper at done/error.
+    if (event.type === 'done') flushAssistantBlock(session.id);
+  });
+  return {
+    session, received, persistIds, transport,
+    async feed(frames: unknown[], chunkSize = 17) {
+      const bytes = Buffer.from(frames.map((frame) => JSON.stringify(frame)).join('\r\n') + '\r\n');
+      for (let i = 0; i < bytes.length; i += chunkSize) stdout.write(bytes.subarray(i, i + chunkSize));
+      await new Promise<void>((resolve) => setImmediate(resolve));
+      await drainPersistQueue();
+    },
+  };
+}
+
+function rows() {
+  return h.sqlite!.prepare('SELECT role, content, client_id, agent_meta FROM messages ORDER BY rowid').all() as
+    Array<{ role: string; content: string; client_id: string; agent_meta: string | null }>;
+}
+
+describe('Pi successful reply delivery (#3696)', () => {
+  let replay: ReturnType<typeof createReplay>;
+  beforeEach(() => {
+    vi.clearAllMocks();
+    setupDb();
+    clearSessionPersistState('s1');
+    noteSessionAgentKind('s1', 'pi');
+    replay = createReplay();
+  });
+  afterEach(async () => {
+    await replay.session.close();
+    await drainPersistQueue();
+    clearSessionPersistState('s1');
+    h.sqlite?.close();
+  });
+
+  it.each([true, false])('persists thinking and full text before settlement (streamed=%s)', async (streamed) => {
+    const fixture = piSuccessfulReplyFrames({ streamed });
+    await replay.feed(fixture.generation);
+    expect(replay.received.filter((event) => event.type === 'done')).toEqual([]);
+    expect(logger.error.mock.calls).toEqual([]);
+    expect(h.warn.mock.calls).toEqual([]);
+    expect(replay.received.some((event) => event.type === 'text')).toBe(true);
+    expect(rows().map((row) => row.role)).toEqual(['thinking', 'assistant']);
+    expect(rows()[0].content).toContain(piReplyThinking);
+    expect(rows()[1].content).toBe(piReplyText);
+    const assistant = rows().find((row) => row.role === 'assistant')!;
+    expect(JSON.parse(assistant.agent_meta ?? '{}').turnCompleted).toBeUndefined();
+    expect(replay.persistIds.every((id) => id === assistant.client_id)).toBe(true);
+    expect(h.broadcast).toHaveBeenCalledWith('local-db:messages:created', expect.objectContaining({
+      message: expect.objectContaining({ clientId: assistant.client_id, role: 'assistant', content: piReplyText }),
+    }));
+    await replay.feed(fixture.settlement);
+    expect(rows().filter((row) => row.role === 'assistant')).toHaveLength(1);
+    expect(replay.received.filter((event) => event.type === 'done')).toMatchObject([
+      { data: { status: 'completed', result: piReplyText, usage: { outputTokens: 684 } } },
+    ]);
+    expect(replay.received.find((event) => event.type === 'done')?.data).not.toHaveProperty('silentStop');
+    expect(replay.transport.writeLine).not.toHaveBeenCalled();
+    expect(logger.error).not.toHaveBeenCalled();
+  });
+
+  it('retains a completed message when another assistant reply starts before agent_settled', async () => {
+    const first = piSuccessfulReplyFrames();
+    await replay.feed(first.generation);
+    const secondText = '第二条独立回复，不应覆盖上一条正文。';
+    const second = piSuccessfulReplyFrames({ text: secondText });
+    // Queued follow-up: no tool boundary or product settlement between replies.
+    await replay.feed([first.settlement[0], ...second.generation.slice(1)]);
+    await replay.feed(second.settlement);
+    expect(rows().filter((row) => row.role === 'assistant').map((row) => row.content))
+      .toEqual([piReplyText, secondText]);
+  });
+
+  it('does not duplicate an authoritative final snapshot or lose it when the consumer closes', async () => {
+    const fixture = piSuccessfulReplyFrames();
+    await replay.feed(fixture.generation, 1); // UTF-8 characters split across stdout chunks.
+    await replay.feed(fixture.generation.slice(-1));
+    await replay.session.close();
+    clearSessionPersistState('s1');
+    expect(rows().filter((row) => row.role === 'assistant').map((row) => row.content))
+      .toEqual([piReplyText]);
+  });
+});

--- a/apps/desktop/src/main/maker-ipc/__tests__/sessionEventPipeline.test.ts
+++ b/apps/desktop/src/main/maker-ipc/__tests__/sessionEventPipeline.test.ts
@@ -619,6 +619,36 @@ describe('production Session event pipeline', () => {
     },
   );
 
+  it.each([
+    ['pi', true, true, true],
+    ['pi', false, true, false],
+    ['pi', true, false, false],
+    ['claude-code', true, true, false],
+    ['codex', true, true, false],
+  ] as const)('commits only Pi authoritative final text (%s, final=%s, full=%s)', async (source, isFinal, isFullText, flush) => {
+    const h = harness();
+    h.emit(event('status', { isRunning: true }, { source }));
+    effects.calls.length = 0;
+    h.emit(event('text', { text: 'complete reply', isFinal, isFullText }, { source }));
+    expect(effects.fn('flushAssistantBlock')).toHaveBeenCalledTimes(flush ? 1 : 0);
+    if (flush) {
+      expect(effects.fn('onAssistantTextEvent').mock.invocationCallOrder[0])
+        .toBeLessThan(effects.fn('flushAssistantBlock').mock.invocationCallOrder[0]);
+      ordered('flushAssistantBlock', 'broadcast');
+    }
+    expect(effects.fn('markAssistantTurnCompleted')).not.toHaveBeenCalled();
+    expect(effects.fn('resetTurnPersistState')).not.toHaveBeenCalled();
+    expect(h.activity.isSessionInTurn('task')).toBe(true);
+    if (flush) {
+      effects.fn('consumeLastTopLevelAssistantPersistId').mockReturnValueOnce('assistant-row');
+      h.emit(event('done', { status: 'completed', result: 'complete reply' }, { source }));
+      expect(h.activity.isSessionInTurn('task')).toBe(false);
+      expect(effects.fn('markAssistantTurnCompleted')).toHaveBeenCalledWith('task', 'assistant-row', undefined);
+      expect(effects.fn('resetTurnPersistState')).toHaveBeenCalledOnce();
+    }
+    await h.dispose();
+  });
+
   it('flushes assistant before foreground tool use, without flushing the current turn for background tools', async () => {
     const h = harness();
     effects.fn('onToolUseEvent').mockImplementation(() => {

--- a/apps/desktop/src/main/maker-ipc/sessionEventStream.ts
+++ b/apps/desktop/src/main/maker-ipc/sessionEventStream.ts
@@ -33,7 +33,7 @@ export function persistSessionStreamEvent(
   let persistId: string | undefined;
   let resolvedContent: string | undefined;
   if (event.type === 'text') {
-    const td = event.data as { text?: unknown; isFinal?: unknown } | null;
+    const td = event.data as { text?: unknown; isFinal?: unknown; isFullText?: unknown } | null;
     if (typeof td?.text === 'string') {
       deps.orcaTeamServiceForEvents?.captureWorkerText(session.id, td.text, {
         isFinal: td.isFinal === true,
@@ -49,6 +49,13 @@ export function persistSessionStreamEvent(
       },
       eventAgentMeta,
     );
+    // Pi message_end carries the authoritative whole assistant message. Commit
+    // its calibrated block now: agent_settled may arrive much later (or never),
+    // and a subsequent assistant message must not overwrite this one in memory.
+    // This closes only the text block; turn completion/usage still waits for done.
+    if (event.source === 'pi' && td?.isFinal === true && td.isFullText === true) {
+      flushAssistantBlock(session.id, eventAgentMeta);
+    }
   } else if (event.type === 'tool_use') {
     // tool_use 边界:先 flush 在飞 assistant(保证 assistant 行先于其 tool_use 入队
     // 落库),再落 tool_use 本身,拿回 persistId 盖进 payload。两者都只入队、不阻塞。

--- a/apps/desktop/src/renderer/__tests__/makerChatStoreTextDeltaBatching.test.ts
+++ b/apps/desktop/src/renderer/__tests__/makerChatStoreTextDeltaBatching.test.ts
@@ -111,6 +111,7 @@ import {
   setDataOwnerGeneration,
 } from '@/contexts/dataOwnerGeneration';
 import { CONTINUE_AFTER_APP_EXIT_PROMPT } from '../../shared/interruptedTurn';
+import { piReplyText, piReplyThinking } from '../../test/fixtures/piSuccessfulReply';
 
 const SESSION_ID = 'text-delta-batching';
 const MODEL = 'gpt-5';
@@ -541,6 +542,44 @@ describe('makerChatStore text delta batching', () => {
     for (const sessionId of MULTI_SESSION_IDS) makerChatStore.purgeSession(sessionId);
     for (const sessionId of LRU_SESSION_IDS) makerChatStore.purgeSession(sessionId);
     vi.useRealTimers();
+  });
+
+  it.each([true, false])('keeps the Pi reply through early persistence and history reload (DB first=%s)', async (dbFirst) => {
+    const persisted = [
+      serverMessage({
+        id: 'pi-thinking-row', clientId: 'pi-thinking', sessionId: SESSION_ID, role: 'thinking',
+        content: { kind: 'thinking', text: piReplyThinking, durationMs: 20_000, isRedacted: false },
+        createdAt: '2026-08-31T12:34:19.000Z',
+      }),
+      serverMessage({
+        id: 'pi-text-row', clientId: 'pi-text', sessionId: SESSION_ID, role: 'assistant', content: piReplyText,
+        agentMeta: { model: 'z-ai/glm-5.3-flash', stopReason: 'stop' },
+        createdAt: '2026-08-31T12:34:19.001Z',
+      }),
+    ];
+    const echo = () => persisted.forEach((message) => onDbMessageCreated?.({ sessionId: SESSION_ID, message }));
+    if (dbFirst) echo();
+    onEvent?.({ sessionId: SESSION_ID, event: {
+      type: 'thinking', source: 'pi', data: { stage: 'final', blockId: 'pi-thinking', text: piReplyThinking, durationMs: 20_000 },
+    } });
+    onEvent?.({ sessionId: SESSION_ID, persistId: 'pi-text', event: {
+      type: 'text', source: 'pi', data: { text: piReplyText.slice(0, 5), isFinal: false },
+    } });
+    onEvent?.({ sessionId: SESSION_ID, persistId: 'pi-text', event: {
+      type: 'text', source: 'pi', data: { text: piReplyText, isFinal: true, isFullText: true },
+    } });
+    if (!dbFirst) echo();
+    vi.advanceTimersByTime(32);
+    const assertReply = () => expect(makerChatStore.getSnapshot(SESSION_ID).messages.map(({ role, content }) => ({ role, content })))
+      .toEqual([{ role: 'thinking', content: piReplyThinking }, { role: 'assistant', content: piReplyText }]);
+    assertReply();
+    onEvent?.({ sessionId: SESSION_ID, event: { type: 'done', source: 'pi', data: { status: 'completed', result: piReplyText } } });
+    assertReply();
+    makerChatStore.purgeSession(SESSION_ID);
+    vi.mocked(messageService.list).mockResolvedValueOnce(persisted);
+    makerChatStore.ensureInitialMessages(SESSION_ID);
+    await flushPromises();
+    assertReply();
   });
 
   it('coalesces consecutive text deltas into one store notification', () => {

--- a/apps/desktop/src/test/fixtures/piSuccessfulReply.ts
+++ b/apps/desktop/src/test/fixtures/piSuccessfulReply.ts
@@ -1,0 +1,53 @@
+/**
+ * Synthetic, non-user content using Pi v0.84.4's RPC wire shape:
+ * packages/coding-agent/src/modes/json-event.ts removes `partial` only from
+ * message_update; packages/agent/src/agent-loop.ts emits the full message_end.
+ * This is a protocol replay, not a capture of the missing frames in #3696.
+ */
+export const piReplyThinking = '需要先明确用户希望修改的文件。';
+export const piReplyText = '请告诉我需要修改哪个 Markdown 文件，以及希望修改的内容。';
+
+export function piSuccessfulReplyFrames({ streamed = true, text = piReplyText } = {}) {
+  const message = {
+    role: 'assistant',
+    api: 'openai-completions',
+    provider: 'cindy',
+    model: 'z-ai/glm-5.3-flash',
+    timestamp: 1_788_179_640_000,
+    duration: 20_000,
+    stopReason: 'stop',
+    content: [
+      { type: 'thinking', thinking: piReplyThinking },
+      { type: 'text', text },
+    ],
+    usage: {
+      input: 587, output: 684, reasoning: 247, cacheRead: 57_280,
+      cacheWrite: 0, totalTokens: 58_551,
+      cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
+    },
+  };
+  const update = (assistantMessageEvent: Record<string, unknown>) => ({
+    type: 'message_update', usage: message.usage, assistantMessageEvent,
+  });
+  return {
+    generation: [
+      { type: 'agent_start' },
+      { type: 'turn_start' },
+      { type: 'message_start', message: { ...message, content: [] } },
+      update({ type: 'thinking_start', contentIndex: 0 }),
+      update({ type: 'thinking_delta', contentIndex: 0, delta: piReplyThinking }),
+      update({ type: 'thinking_end', contentIndex: 0, content: piReplyThinking }),
+      ...(streamed ? [
+        update({ type: 'text_start', contentIndex: 1 }),
+        // A deliberately incomplete delta tests authoritative final calibration.
+        update({ type: 'text_delta', contentIndex: 1, delta: text.slice(0, 5) }),
+      ] : []),
+      { type: 'message_end', message },
+    ],
+    settlement: [
+      { type: 'turn_end', message, toolResults: [] },
+      { type: 'agent_end', messages: [message] },
+      { type: 'agent_settled' },
+    ],
+  };
+}

--- a/docs/research/pi-successful-reply-delivery-3696.md
+++ b/docs/research/pi-successful-reply-delivery-3696.md
@@ -1,0 +1,77 @@
+# Pi 成功正文交付：#3696 取证与加固
+
+核查日期：2026-09-09；代码基线：`56c0e5002`。
+
+## 已有证据与未定案部分
+
+[#3696](https://github.com/makecindy/cindy/issues/3696) 报告 Windows Global
+`0.1.70-hotfix` / Pi `0.84.4` 的一轮只显示 thinking。用户直读 SQLite 确认故障轮
+只有 thinking 行，Pi JSONL 则有 thinking 与完整正文、`stopReason=stop`；健康轮的
+各类消息均有记录。
+
+这是已产生正文未交付的证据，但不足以证明哪一层丢失。讨论中先后提出的错误 preload、
+RPC 缺 text block、stdout 丢帧、stale 世代过滤均不能直接当成实证根因。尤其“只要
+translator 发出 text 就不可能没有 DB 行”的推论不成立：流式正文有尚未落库的内存阶段。
+`localDb.sessions.update is not a function` 发生在元数据调用面，不能由它推出正文写库
+失败；本次不修改该接口或更新器。
+
+已合并的 [#3742](https://github.com/makecindy/cindy/pull/3742) 只添加 RPC 帧元数据
+诊断，不改变交付行为。合并提交 `ae2945c1f` 在本次基线及公开 `v0.1.72`、`v0.1.73`
+tag 中，晚于报告版本。本次未获取或启动用户的 Windows 安装产物，不能据 Git tag
+证明其实际安装文件组成。代码 pin 仍为 Pi `0.84.4`。
+
+## 可确定复现的缺口
+
+Pi `v0.84.4` 的
+[JSON/RPC 转换](https://github.com/earendil-works/pi/blob/v0.84.4/packages/coding-agent/src/modes/json-event.ts)
+只剥离 `message_update.partial`，`message_end` 完整透传。
+[agent loop](https://github.com/earendil-works/pi/blob/v0.84.4/packages/agent/src/agent-loop.ts)
+发送消息结束后还会执行后续轮次/工具/跟进逻辑；消息完成与产品终态是不同边界。
+
+当前 Cindy 的实际路径为：
+
+1. `attachJsonlReader` 分帧，`PiRpcProcess.handleStdoutLine` 解析并转交事件。
+2. PiAgent 的 `onEvent` 调用 `translatePiEvent`；它在 `message_end` 发出
+   `text { isFinal: true, isFullText: true }`，在 `agent_settled` 发出带 result 的 done。
+3. `Session` 消费异步队列并 fan-out；Desktop 的事件消费进入 `persistSessionStreamEvent`。
+4. `onAssistantTextEvent` 在已有流式 block 时只校准内存全文；没有 block 时立即入队写库。
+   前一种情况依赖随后 done/tool/interaction 等边界才 flush。
+5. `createMessage` 经现有 FIFO 与 `message.insert` 事务写库、广播权威行；Renderer
+   依 persistId 合并流式气泡与 DB 回执，历史读取恢复正文。
+
+因此完整 message_end 已到达时，流式轮次仍可能只有 thinking 行。若在后续边界前清理
+内存，正文丢失；若继续生成下一条 assistant，后者的全文校准还可能覆盖前一条。
+这是本次回放锁定的代码缺口，**不等同于已经复现报告中的那一次事故**。无 text delta
+的对照轮可以直接落库，也说明“thinking 与 text 同消息”本身不是充分触发条件。
+
+## 修改与验证范围
+
+仅在 Pi 的 `isFinal && isFullText` 到达后，通过既有 `flushAssistantBlock` 入队持久化。
+不新增同步数据库访问、协议字段、消息类型或重试；不改变 thinking/text 分离。
+正文落库不标记 turnCompleted，终态和 usage 仍由既有 done 消费负责。
+SSH Pi 也进入同一个消费函数，设备互联继续接收原有消息行广播，无需新客户端协议。
+
+`piReplyDelivery.test.ts` 使用自造正文和 Pi 协议形态，经过真实分帧、RPC client、
+translator、Session、stream consumer、createMessage 和内存 SQLite 事务。
+模拟的是字节来源、Agent handle 装配、DB transport 与非正文副作用，不启动 Pi、Electron
+或 dev，不读取用户数据库。终态测试在此调用现有 flush helper；完整产品终态管线由
+`sessionEventPipeline.test.ts` 独立覆盖。
+
+回归覆盖流式/非流式最终全文、终态前落库、连续回复、重复终帧、逐字节 UTF-8 分帧，
+以及 Renderer 的两种 DB 回执顺序和历史重载。撤去生产修复时，流式终态前落库与清理后
+保留用例失败，非流式对照通过；恢复修复后通过。
+
+仍未验证用户原机/安装产物、原故障轮 RPC 到达情况或真实模型调用。若该轮的 text 与
+message_end 根本未进入消费函数，本次加固无法补回缺失正文；需用 #3742 的帧诊断与
+对应消费/写库错误证据继续定界，不能靠自动续跑成功请求掩盖它。
+
+## 本次本地验证
+
+- 定向 Vitest：`piReplyDelivery.test.ts` 4 项、`sessionEventPipeline.test.ts` 45 项、
+  `makerChatStoreTextDeltaBatching.test.ts` 172 项通过，均用单 worker 执行。
+- `pnpm --filter desktop run --if-present typecheck`：通过。
+- `pnpm test:unit:related -- --workspace-concurrency=1 --no-lock`：通过；设置
+  `VITEST_MAX_THREADS=1 VITEST_MIN_THREADS=1 VITEST_MAX_FORKS=1 VITEST_MIN_FORKS=1`
+  限制 Vitest 池。正常互斥入口先等待约 16 分钟后以 75 退出（未运行测试）；核实机器资源
+  后使用仓库允许的有意并行入口，测试范围未缩减。调度器检查 511 项通过、1 项既有跳过，
+  Desktop 相关单测段通过（约 323 秒）。SQLite 回放不属于根 unit tier，已单独执行如上。


### PR DESCRIPTION
## 这次改了什么

### 摘要

Pi 流式正文在 `message_end` 收到权威全文后，原先仍只保存在内存，直到后续 done/tool 等边界才写库。消费端提前清理会丢失正文，连续 assistant 消息也可能覆盖前一条。

现在仅对 Pi 的 `isFinal && isFullText` 调用既有 FIFO flush，及时保存已完成正文；任务终态和 usage 仍等待 done。新增协议回放、内存 SQLite 与 Renderer 回归，记录证据边界。

### 变更类型

- [x] `fix` 缺陷修复

### 范围

- 关联 Issue / 需求：Related #3696。修复确定性回放发现的持久化缺口，原事故未定因，暂不关闭 issue。
- 本 PR 包含：Pi 权威正文提前入队持久化、跨层回归、取证说明。
- 明确不包含：执行者关闭/接续生命周期改造、成功请求重试、thinking/text 合并、更新器及 localDb.sessions.update 接口修复、历史 migration。
- 用户可见变化：完整回复已到达时，正文及时保存，后续清理或继续回复不会使前文丢失。
- 是否存在 breaking change：无。

### UI 变化

不涉及视觉、组件、交互或文案修改；Renderer 仅新增行为测试。

- 引用的设计规范：不涉及：仅验证既有消息合并与历史恢复。

## 怎么验证的

### 自动验证

```text
单 worker 定向 Vitest：piReplyDelivery.test.ts + sessionEventPipeline.test.ts + makerChatStoreTextDeltaBatching.test.ts
结果：4 + 45 + 172 = 221 项通过。
移除本 PR 生产补丁再运行 SQLite 回放：3 失败、1 非流式对照通过；恢复后全部通过。
pnpm --filter desktop run --if-present typecheck
结果：通过。
VITEST_MAX_THREADS=1 VITEST_MIN_THREADS=1 VITEST_MAX_FORKS=1 VITEST_MIN_FORKS=1 pnpm test:unit:related -- --workspace-concurrency=1 --no-lock
结果：通过；runner 511 项通过、1 项既有跳过，Desktop related 通过。常规互斥入口等待约 16 分钟退出 75、未运行测试；核实资源后使用仓库允许的有意并行入口，未缩减测试范围。
pnpm check:dco
结果：本次提交 DCO 检查通过。
```

SQLite 测试使用合成 Pi 0.84.4 协议形态，经真实分帧、RPC client、translator、Session、持久化消费者与内存 SQLite；模拟字节来源、Agent 装配、DB transport 和无关副作用。完整终态管线另由现有 pipeline 套件覆盖。详细边界见 `docs/research/pi-successful-reply-delivery-3696.md`。

### 手工验证

逐文件 review 当前 diff；对照 Pi 上游源码、issue 回复与 #3742 的实际 diff，确认其仅增加诊断。未读取真实用户数据库。

### 未执行的验证

按用户约束未启动 dev、未重启正式版、未调用真实模型；未验证 Windows 安装产物、原事故 RPC 帧与 Light/Dark 实机。故障若发生在正文到达消费者之前，本 PR 无法补回缺失帧。

## 风险

### 风险分类

- [x] SQLite / migration
- [x] 权限 / 安全 / 用户数据

### 影响与回滚

- 影响范围：仅 Pi 已完成正文写库时机；复用现有 FIFO、persistId 去重与广播。无 schema/migration、协议、权限或日志格式修改。SSH Pi 共用该消费者，设备互联沿用原广播。
- 回滚 / 降级方式：回退本提交恢复原持久化时机，无数据库回滚或迁移；已保存消息保留。

### 提交前检查

- [x] 已 review 完整 diff
- [x] 每个 commit 都带 DCO 签名（git commit -s）
- [x] UI 改动已在「UI 变化」注明引用的设计规范章节（不涉及 UI 则跳过）
- [x] 未提交凭证、令牌或授权文件
- [x] 已补充必要文档
- [x] 已确认测试结果或说明未执行原因
