### PR TITLE
feat(sidebar): 支持按创建时间排序任务

### DIFF
--- a/apps/desktop/src/renderer/__tests__/mainListModel.test.ts
+++ b/apps/desktop/src/renderer/__tests__/mainListModel.test.ts
@@ -945,3 +945,84 @@ describe('splitEntriesByDevice — 拆段后按本段重排', () => {
     expect(labels(sections[0].entries)).toEqual(['s:remote-draft']);
   });
 });
+
+describe('creation-time ordering', () => {
+  it.each(['flat', 'project'] as const)('keeps %s tasks and groups in place after activity changes', (groupBy) => {
+    const older = session({ id: 'older', title: 'older', createdAt: '2026-08-01T00:00:00Z', updatedAt: '2026-08-20T00:00:00Z' });
+    const newer = session({ id: 'newer', title: 'newer', createdAt: '2026-08-10T00:00:00Z', updatedAt: '2026-08-10T00:00:00Z' });
+    const middle = session({ title: 'middle', createdAt: '2026-08-05T00:00:00Z', updatedAt: '2026-08-21T00:00:00Z' });
+    const input = {
+      projects: [project('alpha', [older, newer])],
+      dialogues: [middle],
+      groupBy,
+      groupDialogue: false,
+      sortBy: 'created' as const,
+      manualProjectOrder: [],
+    };
+    const before = buildMainListEntries(input);
+    expect(labels(before)).toEqual(
+      groupBy === 'flat' ? ['s:newer', 's:middle', 's:older'] : ['p:alpha', 's:middle'],
+    );
+    if (before[0].kind === 'project') {
+      expect(before[0].project.sessions.map((s) => s.id)).toEqual(['newer', 'older']);
+    }
+    older.updatedAt = '2026-09-09T00:00:00Z';
+    older.userSendAt = '2026-09-09T00:00:00Z';
+    expect(labels(buildMainListEntries(input))).toEqual(labels(before));
+    expect(labels(buildMainListEntries({ ...input, sortBy: 'recency' }))).toEqual(
+      groupBy === 'flat' ? ['s:older', 's:middle', 's:newer'] : ['p:alpha', 's:middle'],
+    );
+  });
+
+  it('orders dialogue groups and cached remote device sections by creation time', () => {
+    const old = session({
+      title: 'old',
+      createdAt: '2026-08-01T00:00:00Z',
+      updatedAt: '2026-09-09T00:00:00Z',
+      deviceLinkDeviceId: 'old-device',
+    });
+    const recent = session({
+      title: 'recent',
+      createdAt: '2026-08-10T00:00:00Z',
+      updatedAt: '2026-08-10T00:00:00Z',
+      deviceLinkDeviceId: 'new-device',
+    });
+    const entries = buildMainListEntries({
+      projects: [], dialogues: [old, recent], groupBy: 'flat', groupDialogue: true,
+      sortBy: 'created', manualProjectOrder: [],
+    });
+    expect(getMainListEntrySessions(entries[0]).map((s) => s.title)).toEqual(['recent', 'old']);
+    const sections = splitEntriesByDevice(entries, [], { sortBy: 'created' });
+    expect(sections.map((section) => section.deviceId)).toEqual(['new-device', 'old-device']);
+  });
+});
+
+
+it('keeps manual project order while creation-time tasks stay stable inside each project', () => {
+  const old = session({
+    id: 'old', title: 'old',
+    createdAt: '2026-08-01T00:00:00Z', updatedAt: '2026-08-20T00:00:00Z',
+  });
+  const recent = session({
+    id: 'recent', title: 'recent',
+    createdAt: '2026-08-10T00:00:00Z', updatedAt: '2026-08-10T00:00:00Z',
+  });
+  const alpha = project('alpha', [old, recent]);
+  const beta = project('beta', [session({ updatedAt: '2026-07-01T00:00:00Z' })]);
+  const input = {
+    projects: [alpha, beta], dialogues: [], groupBy: 'project' as const,
+    groupDialogue: false, sortBy: 'created' as const,
+    projectOrder: 'custom' as const, manualProjectOrder: ['local:beta', 'local:alpha'],
+  };
+  const before = buildMainListEntries(input);
+  expect(labels(before)).toEqual(['p:beta', 'p:alpha']);
+  expect(getMainListEntrySessions(before[1]).map((s) => s.id)).toEqual(['recent', 'old']);
+  old.userSendAt = '2026-09-09T00:00:00Z';
+  old.updatedAt = '2026-09-09T00:00:00Z';
+  const after = buildMainListEntries(input);
+  expect(labels(after)).toEqual(['p:beta', 'p:alpha']);
+  expect(getMainListEntrySessions(after[1]).map((s) => s.id)).toEqual(['recent', 'old']);
+  const activityOrder = buildMainListEntries({ ...input, sortBy: 'recency' });
+  expect(labels(activityOrder)).toEqual(['p:beta', 'p:alpha']);
+  expect(getMainListEntrySessions(activityOrder[1]).map((s) => s.id)).toEqual(['old', 'recent']);
+});

--- a/apps/desktop/src/renderer/__tests__/sidebarProjectSorting.test.ts
+++ b/apps/desktop/src/renderer/__tests__/sidebarProjectSorting.test.ts
@@ -4,6 +4,7 @@ import {
   sortProjectsForSidebar,
   sortSessionsForSidebar,
 } from '@/features/cc-agent/lib/sidebarProjectSorting';
+import { buildMainListEntries } from '@/features/cc-agent/lib/mainListModel';
 import { sessionActivityMs } from '@/features/cc-agent/lib/dateSessionGrouping';
 import type { ProjectNode } from '@/features/cc-agent/lib/projectGrouping';
 import type { Session } from '@/lib/ccAgent.types';
@@ -127,4 +128,26 @@ it('sorts project-panel tasks by creation time, with stable ties and no activity
   const input = [old, b, invalid, a];
   expect(sortSessionsForSidebar(input, 'created').map((s) => s.id)).toEqual(['a', 'b', 'old', 'invalid']);
   expect(input.map((s) => s.id)).toEqual(['old', 'b', 'invalid', 'a']);
+});
+
+
+it.each(['activity', 'custom'] as const)('keeps collapsed and expanded project ordering consistent for %s order', (projectOrder) => {
+  const older = project({
+    workingDir: '/older', displayName: 'older',
+    sessions: [session({ id: 'older', createdAt: '2026-01-01T00:00:00Z', updatedAt: '2026-09-09T00:00:00Z' })],
+  });
+  const newer = project({
+    workingDir: '/newer', displayName: 'newer',
+    sessions: [session({ id: 'newer', createdAt: '2026-02-01T00:00:00Z', updatedAt: '2026-02-01T00:00:00Z' })],
+  });
+  const projects = [older, newer];
+  const manualOrder = [older.projectKey, newer.projectKey];
+  const collapsed = sortProjectsForSidebar(projects, 'created', manualOrder, projectOrder);
+  const expanded = buildMainListEntries({
+    projects, dialogues: [], groupBy: 'project', groupDialogue: false,
+    sortBy: 'created', projectOrder, manualProjectOrder: manualOrder,
+  });
+  const keys = collapsed.map((item) => item.projectKey);
+  expect(keys).toEqual(projectOrder === 'custom' ? manualOrder : [...manualOrder].reverse());
+  expect(keys).toEqual(expanded.map((entry) => entry.kind === 'project' ? entry.project.projectKey : 'unexpected'));
 });

--- a/apps/desktop/src/renderer/__tests__/sidebarProjectSorting.test.ts
+++ b/apps/desktop/src/renderer/__tests__/sidebarProjectSorting.test.ts
@@ -118,3 +118,13 @@ describe('sidebar project sorting', () => {
     expect(sortSessionsForSidebar([b, a], 'priority').map((s) => s.id)).toEqual(['b', 'a']);
   });
 });
+
+it('sorts project-panel tasks by creation time, with stable ties and no activity fallback', () => {
+  const old = session({ id: 'old', createdAt: '2026-01-01T00:00:00Z', updatedAt: '2026-09-09T00:00:00Z' });
+  const a = session({ id: 'a', createdAt: '2026-02-01T00:00:00Z' });
+  const b = session({ id: 'b', createdAt: a.createdAt });
+  const invalid = session({ id: 'invalid', createdAt: 'invalid', updatedAt: '2026-09-09T00:00:00Z' });
+  const input = [old, b, invalid, a];
+  expect(sortSessionsForSidebar(input, 'created').map((s) => s.id)).toEqual(['a', 'b', 'old', 'invalid']);
+  expect(input.map((s) => s.id)).toEqual(['old', 'b', 'invalid', 'a']);
+});

--- a/apps/desktop/src/renderer/__tests__/useSidebarFilter.test.ts
+++ b/apps/desktop/src/renderer/__tests__/useSidebarFilter.test.ts
@@ -494,6 +494,8 @@ describe('persist round-trip', () => {
   });
 
   it('persistSortBy → loadSortBy returns the same value', () => {
+    persistSortBy('created');
+    expect(loadSortBy()).toBe('created');
     persistSortBy('priority');
     expect(loadSortBy()).toBe('priority');
     persistSortBy('recency');

--- a/apps/desktop/src/renderer/features/cc-agent/hooks/helpers/sidebarFilterCore.ts
+++ b/apps/desktop/src/renderer/features/cc-agent/hooks/helpers/sidebarFilterCore.ts
@@ -64,10 +64,11 @@ export type FilterGroupBy = 'project' | 'flat';
 /** 最近活跃范围筛选。默认 all。 */
 export type FilterLastActivity = 'all' | '1d' | '3d' | '7d' | '30d';
 /** Sidebar 主列表任务排序。默认 recency(菜单文案「按时间排序」= 最近活动在前)。
+ *  created = 创建时间倒序,不随任务活动重排。
  *  priority = 等待处理 > 运行中 > 其余按最近活动。
  *  旧值 'manual' 已从排序里拆出,存量回退 recency,并迁移到 projectOrder=custom。
  *  alphabetic / time(旧「最早优先」)同样回退 recency。 */
-export type FilterSortBy = 'recency' | 'priority';
+export type FilterSortBy = 'recency' | 'created' | 'priority';
 /** 按项目分组时的项目行顺序。activity = 跟任务排序走;custom = 拖拽持久序。 */
 export type FilterProjectOrder = 'activity' | 'custom';
 /**
@@ -456,7 +457,7 @@ export function persistLastActivity(lastActivity: FilterLastActivity): void {
 
 /* ============================== sortBy load/persist ============================== */
 
-const SORT_BY_VALUES: ReadonlySet<string> = new Set<FilterSortBy>(['recency', 'priority']);
+const SORT_BY_VALUES: ReadonlySet<string> = new Set<FilterSortBy>(['recency', 'created', 'priority']);
 const PROJECT_ORDER_VALUES: ReadonlySet<string> = new Set<FilterProjectOrder>([
   'activity',
   'custom',

--- a/apps/desktop/src/renderer/features/cc-agent/hooks/useSidebarFilter.ts
+++ b/apps/desktop/src/renderer/features/cc-agent/hooks/useSidebarFilter.ts
@@ -7,7 +7,7 @@
  *   - vendor   : 'all' | 'cc' | 'codex'           → 客户端 render 阶段过滤
  *   - lastActivity : 'all' | '1d' | ...           → 客户端 render 阶段过滤
  *   - groupBy  : 'project' | 'flat'               → 客户端 render 阶段切换主列表分组
- *   - sortBy   : 'recency' | 'priority'           → 客户端 render 阶段切换任务排序
+ *   - sortBy   : 'recency' | 'created' | 'priority'           → 客户端 render 阶段切换任务排序
  *   - projectOrder : 'activity' | 'custom'        → 按项目分组时的项目行顺序
  *   - manualProjectOrder : string[]               → Project 分组的自定义顺序
  *

--- a/apps/desktop/src/renderer/features/cc-agent/lib/dateSessionGrouping.ts
+++ b/apps/desktop/src/renderer/features/cc-agent/lib/dateSessionGrouping.ts
@@ -21,6 +21,10 @@ function toMs(iso: string | null | undefined): number {
   return Number.isFinite(t) ? t : 0;
 }
 
+export function sessionCreatedMs(session: Session): number {
+  return toMs(session.createdAt);
+}
+
 export function sessionActivityMs(session: Session): number {
   // 以 userSendAt（用户最近一次按下发送）为主键排序：agent 回复 / /clear 等
   // 只 bump updatedAt 的路径不再重排列表。userSendAt == null 时回落到 updatedAt，

--- a/apps/desktop/src/renderer/features/cc-agent/lib/mainListModel.ts
+++ b/apps/desktop/src/renderer/features/cc-agent/lib/mainListModel.ts
@@ -36,7 +36,7 @@ import {
   type AutomationScheduleSessionInfo,
   type SidebarSessionEntry,
 } from './automationSidebarGrouping';
-import { sessionActivityMs } from './dateSessionGrouping';
+import { sessionActivityMs, sessionCreatedMs } from './dateSessionGrouping';
 import type { BotGroupNode, ProjectNode } from './projectGrouping';
 
 export type MainListEntry =
@@ -189,11 +189,11 @@ export function getMainListEntrySessions(entry: MainListEntry): readonly Session
   return [entry.session];
 }
 
-function entryActivityMs(entry: MainListEntry): number {
+function entryTimeMs(entry: MainListEntry, sortBy: FilterSortBy = 'recency'): number {
   const sessions = getMainListEntrySessions(entry);
   let max = 0;
   for (const s of sessions) {
-    const ms = sessionActivityMs(s);
+    const ms = sortBy === 'created' ? sessionCreatedMs(s) : sessionActivityMs(s);
     if (ms > max) max = ms;
   }
   return max;
@@ -224,6 +224,7 @@ function entryPriorityRank(entry: MainListEntry, ctx: MainListPriorityContext): 
  * 组内(项目 / 对话组)会话排序的唯一入口。
  *   - priority:分档 + 同档 recency
  *   - recency:一律按最近活动倒序
+ *   - created:按创建时间倒序,消息和状态更新不改序
  * 自定义项目顺序只影响顶层项目行,组内仍走当前 sortBy。不得沿用 groupSessions 的
  * active-first 入参序——状态=全部时,刚归档的任务必须能排在陈旧活跃任务前面。
  */
@@ -240,6 +241,11 @@ export function sortSessionsForMainList(
           sessionPriorityRank(a, ctx) - sessionPriorityRank(b, ctx) ||
           sessionPriorityRecencyMs(b, ctx) - sessionPriorityRecencyMs(a, ctx),
       );
+  }
+  if (sortBy === 'created') {
+    return sessions.slice().sort((a, b) =>
+      sessionCreatedMs(b) - sessionCreatedMs(a) || a.id.localeCompare(b.id),
+    );
   }
   return sessions.slice().sort((a, b) => sessionActivityMs(b) - sessionActivityMs(a));
 }
@@ -378,7 +384,11 @@ function compareEntriesBySortBy(
       entryPriorityRecencyMs(b, ctx) - entryPriorityRecencyMs(a, ctx)
     );
   }
-  return entryActivityMs(b) - entryActivityMs(a);
+  const timeDifference = entryTimeMs(b, sortBy) - entryTimeMs(a, sortBy);
+  if (timeDifference !== 0 || sortBy !== 'created') return timeDifference;
+  return (getMainListEntrySessions(a)[0]?.id ?? '').localeCompare(
+    getMainListEntrySessions(b)[0]?.id ?? '',
+  );
 }
 
 function sortMainListEntries(
@@ -508,7 +518,8 @@ export function splitEntriesByDevice(
     }))
     .sort(
       (a, b) =>
-        Math.max(...b.entries.map(entryActivityMs)) - Math.max(...a.entries.map(entryActivityMs)),
+        Math.max(...b.entries.map((entry) => entryTimeMs(entry, options.sortBy))) -
+        Math.max(...a.entries.map((entry) => entryTimeMs(entry, options.sortBy))),
     );
   result.push(...rest);
   return result;

--- a/apps/desktop/src/renderer/features/cc-agent/lib/sidebarProjectSorting.ts
+++ b/apps/desktop/src/renderer/features/cc-agent/lib/sidebarProjectSorting.ts
@@ -43,5 +43,13 @@ export function sortProjectsForSidebar(
     );
   }
 
+  if (sortBy === 'created') {
+    return withSortedSessions.sort((a, b) =>
+      Math.max(0, ...b.sessions.map(sessionCreatedMs)) -
+        Math.max(0, ...a.sessions.map(sessionCreatedMs)) ||
+      (a.sessions[0]?.id ?? '').localeCompare(b.sessions[0]?.id ?? ''),
+    );
+  }
+
   return withSortedSessions;
 }

--- a/apps/desktop/src/renderer/features/cc-agent/lib/sidebarProjectSorting.ts
+++ b/apps/desktop/src/renderer/features/cc-agent/lib/sidebarProjectSorting.ts
@@ -2,24 +2,21 @@ import type { Session } from '@/lib/ccAgent.types';
 
 import type { FilterProjectOrder, FilterSortBy } from '../hooks/helpers/sidebarFilterCore';
 import { normalizeManualProjectOrder } from '../hooks/helpers/sidebarFilterCore';
-import { sessionActivityMs } from './dateSessionGrouping';
+import { sessionCreatedMs } from './dateSessionGrouping';
 import type { ProjectNode } from './projectGrouping';
 
-function toMs(iso: string | null | undefined): number {
-  if (!iso) return 0;
-  const t = new Date(iso).getTime();
-  return Number.isFinite(t) ? t : 0;
-}
-
 /**
- * 会话排序。旧 'time'(最早优先)2026-08-12 用户裁决删除,时间排序只保留最近活动
- * 在前一档(recency,由调用方的既有顺序承载),这里对所有档位都保持入参序。
+ * 创建时间排序独立于活动变化;其它档位保留调用方已排好的顺序。
  */
 export function sortSessionsForSidebar(
   sessions: readonly Session[],
-  _sortBy: FilterSortBy,
+  sortBy: FilterSortBy,
 ): Session[] {
-  return sessions.slice();
+  return sortBy === 'created'
+    ? sessions.slice().sort((a, b) =>
+        sessionCreatedMs(b) - sessionCreatedMs(a) || a.id.localeCompare(b.id),
+      )
+    : sessions.slice();
 }
 
 export function sortProjectsForSidebar(

--- a/apps/desktop/src/renderer/features/cc-agent/sidebar/SidebarFilterPopover.tsx
+++ b/apps/desktop/src/renderer/features/cc-agent/sidebar/SidebarFilterPopover.tsx
@@ -126,7 +126,7 @@ const LAST_ACTIVITY_OPTIONS: ReadonlyArray<Option<FilterLastActivity>> = [
 
 /** 「最早优先」(旧 time)与旧「手动排序」都已从任务排序里拿掉。 */
 const SORT_BY_OPTIONS: ReadonlyArray<Option<FilterSortBy>> = [
-  { value: 'recency', labelKey: 'ccAgent.sidebar.filterSortBy.updated' },
+  { value: 'recency', labelKey: 'ccAgent.sidebar.filterSortBy.activity' },
   { value: 'created', labelKey: 'ccAgent.sidebar.filterSortBy.created' },
   {
     value: 'priority',

--- a/apps/desktop/src/renderer/features/cc-agent/sidebar/SidebarFilterPopover.tsx
+++ b/apps/desktop/src/renderer/features/cc-agent/sidebar/SidebarFilterPopover.tsx
@@ -3,7 +3,7 @@
  * ---------------------------------------------------------------------------
  * 菜单分四段语义（侧边栏重设计,docs/product-rules/sidebar-redesign-plan.md §3）：
  *   - 分组：独立复选——按项目分组 / 按设备分组(仅远程连接时出现)/ 对话归为一组
- *   - 排序：任务排序（recency / priority）+ 按项目分组时的项目顺序
+ *   - 排序：任务排序（recency / created / priority）+ 按项目分组时的项目顺序
  *     （activity / custom）
  *   - 筛选：一级只占一行，右侧显示摘要（「无」/「N 项生效」），展开二级子菜单
  *     承载 Status / Project / Agent / Last activity 四维度 + 重置筛选
@@ -126,7 +126,8 @@ const LAST_ACTIVITY_OPTIONS: ReadonlyArray<Option<FilterLastActivity>> = [
 
 /** 「最早优先」(旧 time)与旧「手动排序」都已从任务排序里拿掉。 */
 const SORT_BY_OPTIONS: ReadonlyArray<Option<FilterSortBy>> = [
-  { value: 'recency', labelKey: 'ccAgent.sidebar.filterSortBy.recency' },
+  { value: 'recency', labelKey: 'ccAgent.sidebar.filterSortBy.updated' },
+  { value: 'created', labelKey: 'ccAgent.sidebar.filterSortBy.created' },
   {
     value: 'priority',
     labelKey: 'ccAgent.sidebar.filterSortBy.priority',
@@ -602,7 +603,21 @@ export function SidebarFilterPopover({
           <div className="px-2 py-1.5 text-xs font-medium text-[var(--cmd-palette-item-meta)]">
             {t('ccAgent.sidebar.filterTaskSortHeading')}
           </div>
-          {SORT_BY_OPTIONS.map((option) => (
+          <MenuSubRow
+            label={t('ccAgent.sidebar.filterSortBy.recency')}
+            value={sortBy === 'priority' ? '' : sortByValue}
+            valueEmphasized={sortBy !== 'priority'}
+          >
+            {SORT_BY_OPTIONS.filter((option) => option.value !== 'priority').map((option) => (
+              <SelectMenuItem
+                key={option.value}
+                label={t(option.labelKey)}
+                selected={sortBy === option.value}
+                onSelect={() => setSortBy(option.value)}
+              />
+            ))}
+          </MenuSubRow>
+          {SORT_BY_OPTIONS.filter((option) => option.value === 'priority').map((option) => (
             <SelectMenuItem
               key={option.value}
               label={t(option.labelKey)}

--- a/apps/desktop/src/renderer/i18n/locales/en/common.json
+++ b/apps/desktop/src/renderer/i18n/locales/en/common.json
@@ -9336,6 +9336,8 @@
         "all": "All"
       },
       "filterSortBy": {
+        "created": "Created Time",
+        "updated": "Updated Time",
         "recency": "By time",
         "manual": "Manual",
         "priority": "Priority"

--- a/apps/desktop/src/renderer/i18n/locales/en/common.json
+++ b/apps/desktop/src/renderer/i18n/locales/en/common.json
@@ -9353,7 +9353,7 @@
       "filterTaskSortHeading": "Session sort",
       "filterProjectOrderHeading": "Project order",
       "filterProjectOrder": {
-        "activity": "By recent activity",
+        "activity": "Follow Session Sorting",
         "custom": "Manual"
       },
       "filterProjectOrderTip": {

--- a/apps/desktop/src/renderer/i18n/locales/en/common.json
+++ b/apps/desktop/src/renderer/i18n/locales/en/common.json
@@ -9337,7 +9337,7 @@
       },
       "filterSortBy": {
         "created": "Created Time",
-        "updated": "Updated Time",
+        "activity": "Recent Activity",
         "recency": "By time",
         "manual": "Manual",
         "priority": "Priority"

--- a/apps/desktop/src/renderer/i18n/locales/ja/common.json
+++ b/apps/desktop/src/renderer/i18n/locales/ja/common.json
@@ -9322,7 +9322,7 @@
       },
       "filterSortBy": {
         "created": "作成日時",
-        "updated": "更新日時",
+        "activity": "最近のアクティビティ",
         "recency": "時間順",
         "manual": "手動",
         "priority": "優先度"

--- a/apps/desktop/src/renderer/i18n/locales/ja/common.json
+++ b/apps/desktop/src/renderer/i18n/locales/ja/common.json
@@ -9321,6 +9321,8 @@
         "all": "すべて"
       },
       "filterSortBy": {
+        "created": "作成日時",
+        "updated": "更新日時",
         "recency": "時間順",
         "manual": "手動",
         "priority": "優先度"

--- a/apps/desktop/src/renderer/i18n/locales/ja/common.json
+++ b/apps/desktop/src/renderer/i18n/locales/ja/common.json
@@ -9338,7 +9338,7 @@
       "filterTaskSortHeading": "セッション順",
       "filterProjectOrderHeading": "プロジェクト順",
       "filterProjectOrder": {
-        "activity": "最近のアクティビティ順",
+        "activity": "セッションの並び順に従う",
         "custom": "手動"
       },
       "filterProjectOrderTip": {

--- a/apps/desktop/src/renderer/i18n/locales/ko/common.json
+++ b/apps/desktop/src/renderer/i18n/locales/ko/common.json
@@ -9338,7 +9338,7 @@
       "filterTaskSortHeading": "세션 정렬",
       "filterProjectOrderHeading": "프로젝트 순서",
       "filterProjectOrder": {
-        "activity": "최근 활동순",
+        "activity": "세션 정렬 따르기",
         "custom": "수동"
       },
       "filterProjectOrderTip": {

--- a/apps/desktop/src/renderer/i18n/locales/ko/common.json
+++ b/apps/desktop/src/renderer/i18n/locales/ko/common.json
@@ -9321,6 +9321,8 @@
         "all": "전체"
       },
       "filterSortBy": {
+        "created": "생성 시간",
+        "updated": "업데이트 시간",
         "recency": "시간순",
         "manual": "수동",
         "priority": "우선순위"

--- a/apps/desktop/src/renderer/i18n/locales/ko/common.json
+++ b/apps/desktop/src/renderer/i18n/locales/ko/common.json
@@ -9322,7 +9322,7 @@
       },
       "filterSortBy": {
         "created": "생성 시간",
-        "updated": "업데이트 시간",
+        "activity": "최근 활동",
         "recency": "시간순",
         "manual": "수동",
         "priority": "우선순위"

--- a/apps/desktop/src/renderer/i18n/locales/zh-CN/common.json
+++ b/apps/desktop/src/renderer/i18n/locales/zh-CN/common.json
@@ -9321,6 +9321,8 @@
         "all": "全部"
       },
       "filterSortBy": {
+        "created": "创建时间",
+        "updated": "更新时间",
         "recency": "按时间排序",
         "manual": "手动排序",
         "priority": "优先级"

--- a/apps/desktop/src/renderer/i18n/locales/zh-CN/common.json
+++ b/apps/desktop/src/renderer/i18n/locales/zh-CN/common.json
@@ -9338,7 +9338,7 @@
       "filterTaskSortHeading": "任务排序",
       "filterProjectOrderHeading": "项目顺序",
       "filterProjectOrder": {
-        "activity": "按最近活动",
+        "activity": "跟随任务排序",
         "custom": "手动"
       },
       "filterProjectOrderTip": {

--- a/apps/desktop/src/renderer/i18n/locales/zh-CN/common.json
+++ b/apps/desktop/src/renderer/i18n/locales/zh-CN/common.json
@@ -9322,7 +9322,7 @@
       },
       "filterSortBy": {
         "created": "创建时间",
-        "updated": "更新时间",
+        "activity": "最近活动",
         "recency": "按时间排序",
         "manual": "手动排序",
         "priority": "优先级"

--- a/apps/desktop/src/renderer/i18n/locales/zh-TW/common.json
+++ b/apps/desktop/src/renderer/i18n/locales/zh-TW/common.json
@@ -9321,6 +9321,8 @@
         "all": "全部"
       },
       "filterSortBy": {
+        "created": "建立時間",
+        "updated": "更新時間",
         "recency": "按時間排序",
         "manual": "手動排序",
         "priority": "優先級"

--- a/apps/desktop/src/renderer/i18n/locales/zh-TW/common.json
+++ b/apps/desktop/src/renderer/i18n/locales/zh-TW/common.json
@@ -9338,7 +9338,7 @@
       "filterTaskSortHeading": "任務排序",
       "filterProjectOrderHeading": "專案順序",
       "filterProjectOrder": {
-        "activity": "依最近活動",
+        "activity": "跟隨任務排序",
         "custom": "手動"
       },
       "filterProjectOrderTip": {

--- a/apps/desktop/src/renderer/i18n/locales/zh-TW/common.json
+++ b/apps/desktop/src/renderer/i18n/locales/zh-TW/common.json
@@ -9322,7 +9322,7 @@
       },
       "filterSortBy": {
         "created": "建立時間",
-        "updated": "更新時間",
+        "activity": "最近活動",
         "recency": "按時間排序",
         "manual": "手動排序",
         "priority": "優先級"


### PR DESCRIPTION
## 这次改了什么

### 摘要

侧栏任务可以按创建时间排序，旧任务继续交流后保持位置。原「按时间排序」扩展为「创建时间 / 最近活动」子菜单，选择会保存。

### 变更类型

- [x] `feat` 新功能
- [ ] `fix` 缺陷修复
- [ ] `refactor` / `perf` 重构或性能优化
- [ ] `docs` / `test` / `chore` 文档、测试或工程维护
- [ ] 其他：

### 范围

- 关联 Issue / 需求：维护者要求项目内任务可按创建时间固定顺序。
- 本 PR 包含：时间排序子菜单、本地偏好持久化、组内与平铺任务排序、折叠和展开侧栏项目排序一致性、五种语言文案和回归测试。
- 明确不包含：修改手动项目顺序、置顶或优先级策略、手机独立列表、服务端。
- 既有范围外缺口：优先级模式下折叠项目面板与展开侧栏的顺序差异在基线已存在，由 #4189 单独跟踪；本 PR 不宣称修复该优先级路径。
- 用户可见变化：任务排序选择「创建时间」后按创建时间倒序排列。外层项目仍可独立使用手动顺序；选择「最近活动」保留原最近用户发送时间、缺失时回退 updatedAt 的行为。默认仍是原有最近活动模式，不覆盖存量选择。
- 是否存在 breaking change：无。

### UI 变化

- 「侧边栏显示设置 → 任务排序 → 按时间排序」增加两项子菜单，主菜单展示当前时间依据。
- 引用的设计规范：docs/design-rules/DESIGN.md §4 Select & Dropdown、§5 内层菜单行、§10 Light/Dark、§11 文案；复用现有 MenuSubRow / SelectMenuItem 及语义 token，不新增颜色、圆角或独立控件。五种语言同步补齐。
- 无实机截图；Light/Dark 均未目检，未将 token 复用视为双模式验收。

## 怎么验证的

### 自动验证

```text
pnpm test:unit:related
结果：通过。
pnpm --filter desktop run --if-present typecheck
结果：通过。
pnpm --filter desktop exec vitest run src/renderer/__tests__/mainListModel.test.ts --maxWorkers=1
结果：29 tests 通过，含手动项目顺序 + 创建时间组内排序回归。
pnpm check:i18n
结果：通过，现存警告未增加。
pnpm check:i18n-glossary
结果：通过，无新增术语违规。
git diff --check
结果：通过。
```

### 手工验证

已逐文件审阅完整 diff，核对手动项目顺序走独立 projectOrder 路径，任务排序不会写入或覆盖项目顺序。

### 未执行的验证

未启动 Desktop 实机验证 Light/Dark 或 Windows。建议验收：保持项目手动排序，选择创建时间，继续旧任务并确认项目顺序和组内任务位置不变，重启后确认选择保留。

## 风险

### 风险分类

- [x] 无已知风险
- [ ] SQLite / migration
- [ ] system prompt
- [ ] 协议兼容
- [ ] 权限 / 安全 / 用户数据
- [ ] 存量插件兼容（批准状态 / 指纹 / manifest 校验 / 安装布局 / 包格式）
- [ ] 原生层 / fingerprint / OTA
- [ ] 跨平台差异
- [ ] 其他：

### 影响与回滚

- 影响范围：Desktop 侧栏本地展示偏好；现有 localStorage sortBy 增加 created 枚举，不涉及数据库、协议或权限。
- 回滚 / 降级方式：选择最近活动即恢复旧排序；回退旧版时未知 created 值按既有逻辑回退 recency。手动项目顺序保留。

### 提交前检查

- [x] 已 review 完整 diff
- [x] 每个 commit 都带 DCO 签名（git commit -s）
- [x] UI 改动已在「UI 变化」注明引用的设计规范章节
- [x] 未提交凭证、令牌或授权文件
- [x] 已补充必要文档（PR 中记录配置兼容与验收）
- [x] 已确认测试结果或说明未执行原因
