### PR TITLE
fix(desktop): dismiss menu tooltip when menu opens

### DIFF
--- a/apps/desktop/src/renderer/__tests__/iconButtonTooltips.test.ts
+++ b/apps/desktop/src/renderer/__tests__/iconButtonTooltips.test.ts
@@ -289,6 +289,13 @@ describe('icon-only button tooltip coverage', () => {
     expect(chromeActions).toContain('aria-label={sidebarToggleLabel}');
     expect(menuButton).toContain("import { Tip } from '@/components/ui/tooltip';");
     expect(menuButton).toContain("text={t('titleBar.menu')}");
+    expect(menuButton).toContain('const [menuOpen, setMenuOpen] = useState(false)');
+    expect(menuButton).toContain(
+      '<DropdownMenu open={menuOpen} onOpenChange={setMenuOpen}>',
+    );
+    expect(menuButton).toContain(
+      '<Tip text={t(\'titleBar.menu\')} side="bottom" controlledOpen={menuOpen ? false : undefined}>',
+    );
   });
 
   it('keeps Windows system window controls accessible without visible tips', () => {

--- a/apps/desktop/src/renderer/components/title-bar/MenuButton.tsx
+++ b/apps/desktop/src/renderer/components/title-bar/MenuButton.tsx
@@ -1,4 +1,5 @@
 import { Menu } from 'lucide-react';
+import { useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { useLocation, useNavigate } from 'react-router-dom';
 
@@ -19,10 +20,12 @@ export function MenuButton({ onExitFullscreen }: { onExitFullscreen?: () => void
   const { t } = useTranslation();
   const navigate = useNavigate();
   const location = useLocation();
+  const [menuOpen, setMenuOpen] = useState(false);
+
   return (
-    <DropdownMenu>
+    <DropdownMenu open={menuOpen} onOpenChange={setMenuOpen}>
       <DropdownMenuTrigger asChild>
-        <Tip text={t('titleBar.menu')} side="bottom">
+        <Tip text={t('titleBar.menu')} side="bottom" controlledOpen={menuOpen ? false : undefined}>
           {/* 尺寸与 ChromeActions 的折叠按钮同规格(h-7 / 图标 15 / rounded-md),
               与折叠态标题行图标(「…」h-7 / 15)视觉重量一致。 */}
           <button

--- a/apps/desktop/src/renderer/components/title-bar/__tests__/MenuButton.test.tsx
+++ b/apps/desktop/src/renderer/components/title-bar/__tests__/MenuButton.test.tsx
@@ -1,0 +1,44 @@
+// @vitest-environment jsdom
+
+import { cleanup, render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+vi.mock('react-i18next', () => ({
+  useTranslation: () => ({
+    t: (key: string) => key,
+  }),
+}));
+
+vi.mock('react-router-dom', () => ({
+  useLocation: () => ({ pathname: '/', search: '' }),
+  useNavigate: () => vi.fn(),
+}));
+
+vi.mock('@/lib/checkForUpdateWithToast', () => ({
+  checkForUpdateWithToast: vi.fn(),
+}));
+
+import { MenuButton } from '@/components/title-bar/MenuButton';
+
+afterEach(() => {
+  cleanup();
+  vi.clearAllMocks();
+});
+
+describe('MenuButton tooltip and dropdown interaction', () => {
+  it('dismisses the tooltip when the menu opens', async () => {
+    const user = userEvent.setup();
+    render(<MenuButton />);
+
+    const trigger = screen.getByRole('button', { name: 'titleBar.menu' });
+    await user.hover(trigger);
+
+    expect((await screen.findByRole('tooltip')).textContent).toContain('titleBar.menu');
+
+    await user.click(trigger);
+
+    expect(screen.getByRole('menu')).toBeTruthy();
+    await waitFor(() => expect(screen.queryByRole('tooltip')).toBeNull());
+  });
+});


### PR DESCRIPTION
## 这次改了什么

### 摘要

修复标题栏菜单按钮的 Tooltip 在打开下拉菜单后仍然停留的问题。

打开标题栏菜单时，现在会：

- 使用受控状态跟踪下拉菜单是否打开；
- 在下拉菜单打开期间强制关闭菜单按钮 Tooltip；
- 在下拉菜单关闭后恢复正常的悬停和焦点 Tooltip 行为；
- 增加真实的 jsdom 交互测试，验证 Tooltip 出现后打开菜单会自动消失。

### 变更类型

- [x] `fix` 缺陷修复
- [x] `test` 测试补充

### 范围

- 关联 Issue / 需求：Fixes #4160
- 本 PR 包含：
  - 修改 `MenuButton` 的 DropdownMenu 状态管理；
  - 菜单打开时关闭对应 Tooltip；
  - 添加 Tooltip 与 DropdownMenu 的真实交互回归测试。
- 明确不包含：
  - 不修改全局 Tooltip 行为；
  - 不修改其他标题栏按钮；
  - 不涉及后端、账号登录、模型配置或数据存储。
- 用户可见变化：
  - 点击打开标题栏菜单后，黑色“菜单”Tooltip 会立即消失；
  - 菜单关闭后，按钮仍然可以正常显示 Tooltip。
- 是否存在 breaking change：无

### UI 变化

本次涉及标题栏菜单按钮的交互行为，但没有新增视觉样式。

引用的设计规范：`docs/design-rules/DESIGN.md §14.6 Icon-only Controls and Tooltips`。本次改动遵循该章节关于 icon-only control Tooltip 的交互约定，仅修复菜单打开时 Tooltip 与 DropdownMenu 的状态冲突，不新增视觉样式。

## 怎么验证的

### 自动验证

```text
命令：
cd apps/desktop && pnpm exec vitest run src/renderer/__tests__/iconButtonTooltips.test.ts src/renderer/components/title-bar/__tests__/MenuButton.test.tsx

结果：
2 个测试文件通过，10 个测试通过。

命令：
pnpm --filter desktop typecheck

结果：
本地通过。
```

## 风险

### 风险分类

- [x] 无已知风险

### 影响与回滚

- 影响范围：仅影响标题栏 `MenuButton` 的 Tooltip 与 DropdownMenu 状态同步。
- 不影响全局 Tooltip 组件、其他按钮、登录态、后端请求或本地数据。
- 回滚方式：回滚本 PR 中的业务修复和对应测试 commit 即可恢复原行为。
