### PR TITLE
fix(desktop): 修复 macOS 远程桌面 helper target

### DIFF
--- a/apps/desktop/forge.config.ts
+++ b/apps/desktop/forge.config.ts
@@ -911,6 +911,7 @@ const MACOS_AGENT_ISLAND_HELPER_DEPLOYMENT_TARGET = 'macos14.0';
 const MACOS_COMPUTER_PERMISSION_GUIDE_HELPER_DEPLOYMENT_TARGET = 'macos13.0';
 const MACOS_SESSION_DRAG_RELEASE_HELPER_DEPLOYMENT_TARGET = 'macos10.15';
 const MACOS_XBOX_GAMEPAD_HELPER_DEPLOYMENT_TARGET = 'macos11.0';
+const MACOS_REMOTE_DESKTOP_INPUT_DEPLOYMENT_TARGET = 'macos10.15';
 
 function swiftTargetTriple(cpuArch: 'arm64' | 'x86_64', deploymentTarget: string): string {
   return `${cpuArch}-apple-${deploymentTarget}`;
@@ -1033,7 +1034,14 @@ function buildRemoteDesktopInput(platform: ForgePlatform, arch: ForgeArch): void
   fs.mkdirSync(destDir, { recursive: true });
   if (process.platform === 'darwin' && isMacForgePlatform(platform)) {
     const dest = path.join(destDir, 'cindy-macos-desktop-input');
-    buildSwiftHelperForForgeArch(path.join(__dirname, 'native', 'remote-desktop', 'macos-input.swift'), dest, arch, '10.15', [], 'remote desktop input');
+    buildSwiftHelperForForgeArch(
+      path.join(__dirname, 'native', 'remote-desktop', 'macos-input.swift'),
+      dest,
+      arch,
+      MACOS_REMOTE_DESKTOP_INPUT_DEPLOYMENT_TARGET,
+      [],
+      'remote desktop input',
+    );
     fs.chmodSync(dest, 0o755);
     const capture = path.join(destDir, 'cindy-macos-desktop-capture');
     const captureArch = arch === 'universal' ? ['-arch', 'arm64', '-arch', 'x86_64'] : ['-arch', arch === 'arm64' ? 'arm64' : 'x86_64'];

--- a/apps/desktop/forge.config.ts
+++ b/apps/desktop/forge.config.ts
@@ -21,6 +21,7 @@ import {
 } from '@cindy/maker-shared/brand-identity';
 import { stageMacIOSSimulatorHelper } from './forge-ios-simulator-helper';
 import { stagePackagedThirdPartyNotices } from './forge-third-party-notices';
+import { swiftTargetTriple, swiftTargetTriplesForForgeArch } from './src/main/remote-desktop/swiftTarget';
 import { READ_SHEET_RUNTIME_PACKAGES } from '../../packages/lizi-mcps/src/cindy-docs/readSheetRuntimeDeps';
 import { reviewPdfRuntimePackages } from './src/main/reviewer/reviewPdfRuntimeDeps';
 import {
@@ -912,26 +913,6 @@ const MACOS_COMPUTER_PERMISSION_GUIDE_HELPER_DEPLOYMENT_TARGET = 'macos13.0';
 const MACOS_SESSION_DRAG_RELEASE_HELPER_DEPLOYMENT_TARGET = 'macos10.15';
 const MACOS_XBOX_GAMEPAD_HELPER_DEPLOYMENT_TARGET = 'macos11.0';
 const MACOS_REMOTE_DESKTOP_INPUT_DEPLOYMENT_TARGET = 'macos10.15';
-
-function swiftTargetTriple(cpuArch: 'arm64' | 'x86_64', deploymentTarget: string): string {
-  return `${cpuArch}-apple-${deploymentTarget}`;
-}
-
-function swiftTargetTriplesForForgeArch(arch: ForgeArch, deploymentTarget: string): string[] {
-  switch (arch) {
-    case 'x64':
-      return [swiftTargetTriple('x86_64', deploymentTarget)];
-    case 'arm64':
-      return [swiftTargetTriple('arm64', deploymentTarget)];
-    case 'universal':
-      return [
-        swiftTargetTriple('x86_64', deploymentTarget),
-        swiftTargetTriple('arm64', deploymentTarget),
-      ];
-    default:
-      throw new Error(`[forge] unsupported macOS Swift helper arch: ${arch}`);
-  }
-}
 
 function swiftArchLabel(arch: ForgeArch, deploymentTarget: string): string {
   return swiftTargetTriplesForForgeArch(arch, deploymentTarget)

--- a/apps/desktop/src/main/__tests__/sessionDragReleaseNativeHost.test.ts
+++ b/apps/desktop/src/main/__tests__/sessionDragReleaseNativeHost.test.ts
@@ -128,20 +128,24 @@ describe('SessionDragReleaseNativeHost', () => {
   });
 
   it('is included in the macOS package helper build', () => {
-    const forgeSource = fs.readFileSync(
-      path.resolve(__dirname, '..', '..', '..', 'forge.config.ts'),
-      'utf8',
-    );
+    const forgeSource = fs
+      .readFileSync(
+        path.resolve(__dirname, '..', '..', '..', 'forge.config.ts'),
+        'utf8',
+      )
+      .replace(/\r\n?/g, '\n');
     expect(forgeSource).toContain('function buildMacSessionDragReleaseHelper(');
     expect(forgeSource).toContain('buildMacSessionDragReleaseHelper(platform, arch);');
     expect(forgeSource).toContain("'xdt-macos-session-drag-release-helper'");
   });
 
   it('uses a complete macOS target triple for the remote desktop input helper', () => {
-    const forgeSource = fs.readFileSync(
-      path.resolve(__dirname, '..', '..', '..', 'forge.config.ts'),
-      'utf8',
-    );
+    const forgeSource = fs
+      .readFileSync(
+        path.resolve(__dirname, '..', '..', '..', 'forge.config.ts'),
+        'utf8',
+      )
+      .replace(/\r\n?/g, '\n');
     expect(forgeSource).toContain(
       "const MACOS_REMOTE_DESKTOP_INPUT_DEPLOYMENT_TARGET = 'macos10.15';",
     );

--- a/apps/desktop/src/main/__tests__/sessionDragReleaseNativeHost.test.ts
+++ b/apps/desktop/src/main/__tests__/sessionDragReleaseNativeHost.test.ts
@@ -5,6 +5,7 @@ import { PassThrough } from 'node:stream';
 import type { ChildProcessByStdio } from 'node:child_process';
 import type { Readable, Writable } from 'node:stream';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { swiftTargetTriple, swiftTargetTriplesForForgeArch } from '../remote-desktop/swiftTarget.js';
 
 const h = vi.hoisted(() => ({
   spawn: vi.fn(),
@@ -148,6 +149,12 @@ describe('SessionDragReleaseNativeHost', () => {
       "MACOS_REMOTE_DESKTOP_INPUT_DEPLOYMENT_TARGET,\n      [],\n      'remote desktop input'",
     );
     expect(forgeSource).not.toContain("dest, arch, '10.15', [], 'remote desktop input'");
+    expect(swiftTargetTriple('arm64', 'macos10.15')).toBe('arm64-apple-macos10.15');
+    expect(swiftTargetTriple('x86_64', 'macos10.15')).toBe('x86_64-apple-macos10.15');
+    expect(swiftTargetTriplesForForgeArch('universal', 'macos10.15')).toEqual([
+      'x86_64-apple-macos10.15',
+      'arm64-apple-macos10.15',
+    ]);
   });
 });
 

--- a/apps/desktop/src/main/__tests__/sessionDragReleaseNativeHost.test.ts
+++ b/apps/desktop/src/main/__tests__/sessionDragReleaseNativeHost.test.ts
@@ -135,6 +135,20 @@ describe('SessionDragReleaseNativeHost', () => {
     expect(forgeSource).toContain('buildMacSessionDragReleaseHelper(platform, arch);');
     expect(forgeSource).toContain("'xdt-macos-session-drag-release-helper'");
   });
+
+  it('uses a complete macOS target triple for the remote desktop input helper', () => {
+    const forgeSource = fs.readFileSync(
+      path.resolve(__dirname, '..', '..', '..', 'forge.config.ts'),
+      'utf8',
+    );
+    expect(forgeSource).toContain(
+      "const MACOS_REMOTE_DESKTOP_INPUT_DEPLOYMENT_TARGET = 'macos10.15';",
+    );
+    expect(forgeSource).toContain(
+      "MACOS_REMOTE_DESKTOP_INPUT_DEPLOYMENT_TARGET,\n      [],\n      'remote desktop input'",
+    );
+    expect(forgeSource).not.toContain("dest, arch, '10.15', [], 'remote desktop input'");
+  });
 });
 
 function createFakeChild(): FakeNativeProcess {

--- a/apps/desktop/src/main/remote-desktop/swiftTarget.ts
+++ b/apps/desktop/src/main/remote-desktop/swiftTarget.ts
@@ -1,0 +1,27 @@
+import type { ForgeArch } from '@electron-forge/shared-types';
+
+export function swiftTargetTriple(
+  cpuArch: 'arm64' | 'x86_64',
+  deploymentTarget: string,
+): string {
+  return `${cpuArch}-apple-${deploymentTarget}`;
+}
+
+export function swiftTargetTriplesForForgeArch(
+  arch: ForgeArch,
+  deploymentTarget: string,
+): string[] {
+  switch (arch) {
+    case 'x64':
+      return [swiftTargetTriple('x86_64', deploymentTarget)];
+    case 'arm64':
+      return [swiftTargetTriple('arm64', deploymentTarget)];
+    case 'universal':
+      return [
+        swiftTargetTriple('x86_64', deploymentTarget),
+        swiftTargetTriple('arm64', deploymentTarget),
+      ];
+    default:
+      throw new Error(`[forge] unsupported macOS Swift helper arch: ${arch}`);
+  }
+}


### PR DESCRIPTION
## 这次改了什么\n\n### 摘要\n\n修复 macOS 远程桌面输入 helper 的 Swift target triple。原实现传入裸版本号 10.15，拼接后生成无效的 arm64-apple-10.15，导致 Mac arm64/x64 打包在 prePackage 阶段失败。\n\n现在使用命名 deployment target macos10.15，生成完整的 <arch>-apple-macos10.15 target，并增加 packaging contract 回归测试。\n\n### 变更类型\n\n- [x] fix\n- [ ] feat\n- [ ] refactor / perf\n- [ ] docs / test / chore\n\n### 范围\n\n- 关联 Issue / 需求：Mac 打包失败：swiftc unknown target arm64-apple-10.15\n- 本 PR 包含：修正远程桌面 macOS Swift helper target；新增 target triple packaging contract 测试。\n- 明确不包含：Windows 打包临时目录隔离、构建脚本并发策略及其他远程桌面功能变更。\n- 用户可见变化：无直接 UI 变化；Mac 正式包可继续进入后续打包阶段。\n- 是否存在 breaking change：无。\n\n### UI 变化\n\n- 引用的设计规范：不涉及：仅修改 macOS 原生 helper 的打包 target 与测试。\n\n## 怎么验证的\n\n### 自动验证\n\n- pnpm --filter desktop exec vitest run src/main/__tests__/sessionDragReleaseNativeHost.test.ts：5/5 通过。\n- pnpm --filter desktop run --if-present typecheck：通过。\n- pnpm test:unit:related：runner 子集通过；packages/maker-remote-ssh 相关测试通过；Desktop workspace 通过 34,742 项，但已有的 src/renderer/__tests__/modelVisibilityPrefs.test.ts 有 51 项 5 秒超时。该失败与本 PR 修改路径无关，单独重跑该文件仍复现。\n\n### 手工验证\n\n未执行：当前环境不是 macOS，未实际运行 swiftc 或完整 Mac Forge 打包。\n\n### 未执行的验证\n\nMac arm64/x64 完整打包：需在 macOS runner 上验证；Windows 打包：不涉及本 PR。\n\n## 风险\n\n### 风险分类\n\n- [x] 原生层 / fingerprint / OTA\n- [x] 跨平台差异\n\n### 影响与回滚\n\n- 影响范围：macOS Desktop 远程桌面输入 helper 的构建 target；Windows/Linux 不进入该分支。\n- 回滚 / 降级方式：回滚本 PR 即恢复原 target，但会重新触发 Mac 打包失败。\n\n### 提交前检查\n\n- [x] 已 review 完整 diff\n- [x] 每个 commit 都带 DCO 签名（git commit -s）\n- [x] UI 改动已在「UI 变化」注明引用的设计规范章节（不涉及 UI）\n- [x] 未提交凭证、令牌或授权文件\n- [x] 已补充必要文档\n- [x] 已确认测试结果或说明未执行原因