### PR TITLE
fix(remote-ssh): SSH 认证失败提示带上本次使用的 IdentityFile 与底层原因

### DIFF
--- a/packages/maker-remote-ssh/src/RemoteHost.ts
+++ b/packages/maker-remote-ssh/src/RemoteHost.ts
@@ -23,7 +23,7 @@ import { StringDecoder } from 'node:string_decoder';
 import { Client, type ConnectConfig, type ClientChannel, type TcpConnectionDetails } from 'ssh2';
 
 import type { HostConfig, HostSnapshot, RemoteStatus } from './types.js';
-import { resolveAuth, type ResolvedAuth } from './credentials.js';
+import { resolveAuth, type AgentAuthOutcome, type ResolvedAuth } from './credentials.js';
 import { type HostKeyStore, hostKeyFingerprint, hostKeyId, decideHostKey } from './hostKeys.js';
 
 export interface RemoteHostDeps {
@@ -296,12 +296,13 @@ export interface AuthFailureHintOptions {
   /** Identity files the attempt was limited to (from `ResolvedAuth`). */
   pinnedIdentityFiles?: readonly string[];
   /**
-   * How many pinned identities the agent actually held and offered
-   * (`FilteredAgent.lastOfferedCount`). `0` = nothing was offered (key not
-   * loaded), `> 0` = the remote rejected what was offered, `null`/omitted =
-   * unknown (unfiltered agent or enumeration never happened).
+   * What the filtered agent actually did (`ResolvedAuth.readAgentAuthOutcome`).
+   * `offeredCount === 0` = nothing was offered (key not loaded);
+   * `signFailureCount > 0` = the agent could not sign (local problem);
+   * `offeredCount > 0 && signedCount > 0` with no sign failure = the remote
+   * rejected a signed attempt. Anything else is unknown → neutral wording.
    */
-  offeredIdentityCount?: number | null;
+  agentOutcome?: AgentAuthOutcome | null;
   /** Test seam for home-directory abbreviation. */
   homeDir?: string;
 }
@@ -335,14 +336,20 @@ export function authFailureHint(cfg: HostConfig, options: AuthFailureHintOptions
       || (cfg.sshAuthentication?.allowedAgentFingerprints?.length ?? 0) > 0;
     if (pinned) {
       const identitySet = identities ? ` (IdentityFile: ${identities})` : '';
-      const offered = options.offeredIdentityCount;
-      if (offered === 0) {
+      const outcome = options.agentOutcome;
+      if (outcome?.offeredCount === 0) {
         return withCause(
           `Authentication failed for ${who}: none of the configured identities${identitySet} is currently loaded in ssh-agent, so no key was offered. `
             + 'Load it with `ssh-add`, or re-add this host with the identity that is loaded.',
         );
       }
-      if (typeof offered === 'number' && offered > 0) {
+      if (outcome && outcome.signFailureCount > 0) {
+        return withCause(
+          `Authentication failed for ${who}: ssh-agent could not sign with the configured identity${identitySet} (agent locked, hardware-key confirmation refused, or signer error). `
+            + 'Unlock the agent or retry the key confirmation, then try again.',
+        );
+      }
+      if (outcome && (outcome.offeredCount ?? 0) > 0 && outcome.signedCount > 0) {
         return withCause(
           `Authentication failed for ${who}: the remote rejected every key ssh-agent offered from the configured identity set${identitySet}. `
             + 'Verify that identity\'s public key is installed on the remote, or re-add this host with the right identity.',
@@ -1412,7 +1419,7 @@ export class RemoteHost {
             ? authFailureHint(attemptConfig, {
                 cause: err.message,
                 pinnedIdentityFiles: auth.pinnedIdentityFiles,
-                offeredIdentityCount: auth.readOfferedIdentityCount?.() ?? null,
+                agentOutcome: auth.readAgentAuthOutcome?.() ?? null,
               })
             : err.message;
         this.client = null;

--- a/packages/maker-remote-ssh/src/RemoteHost.ts
+++ b/packages/maker-remote-ssh/src/RemoteHost.ts
@@ -17,6 +17,8 @@
 
 import { EventEmitter } from 'node:events';
 import net from 'node:net';
+import os from 'node:os';
+import path from 'node:path';
 import { StringDecoder } from 'node:string_decoder';
 import { Client, type ConnectConfig, type ClientChannel, type TcpConnectionDetails } from 'ssh2';
 
@@ -226,27 +228,88 @@ export function isAuthFailure(msg: string): boolean {
 }
 
 /**
- * Build a one-line user-facing message for an auth failure. Subtitle in
- * the host row + toast both show this verbatim — keep it under ~120 chars
- * so it doesn't ellipsize. CLI command text stays English (shell commands
- * are English) but a future improvement could split this into structured
- * fields for full i18n.
+ * Render an identity path for a user-facing error without leaking the raw
+ * absolute path: `~/.ssh/x` when it lives under the home directory, otherwise
+ * just the basename. Never touches the file, never guesses a `.pub` sibling.
  */
-export function authFailureHint(cfg: HostConfig): string {
+export function describeIdentityPath(identityPath: string, homeDir: string = os.homedir()): string {
+  const trimmed = identityPath.trim();
+  if (!trimmed) return '';
+  if (trimmed === '~' || trimmed.startsWith('~/') || trimmed.startsWith('~\\')) return trimmed;
+  const home = homeDir.trim();
+  if (home) {
+    const rel = path.relative(home, trimmed);
+    if (rel && !rel.startsWith('..') && !path.isAbsolute(rel)) {
+      return `~/${rel.split(path.sep).join('/')}`;
+    }
+  }
+  return path.basename(trimmed);
+}
+
+/** Effective identities the connect attempt was limited to: explicit marker first, then ssh_config IdentityFile entries. */
+function describeConfiguredIdentities(cfg: HostConfig, homeDir?: string): string {
+  const seen = new Set<string>();
+  const out: string[] = [];
+  for (const raw of [cfg.identityFile, ...(cfg.sshAuthentication?.configuredIdentityFiles ?? [])]) {
+    if (typeof raw !== 'string') continue;
+    const shown = describeIdentityPath(raw, homeDir);
+    if (!shown || seen.has(shown)) continue;
+    seen.add(shown);
+    out.push(shown);
+  }
+  return out.join(', ');
+}
+
+export interface AuthFailureHintOptions {
+  /**
+   * Underlying failure text from ssh2 (e.g. "All configured authentication
+   * methods failed"). Appended as a short summary so the visible error keeps
+   * the real reason instead of only a template (#4201). Never contains key
+   * material; callers must not pass passphrases or agent sockets here.
+   */
+  cause?: string;
+  /** Test seam for home-directory abbreviation. */
+  homeDir?: string;
+}
+
+/**
+ * Build a one-line user-facing message for an auth failure. Subtitle in
+ * the host row + toast both show this verbatim. CLI command text stays
+ * English (shell commands are English) but a future improvement could split
+ * this into structured fields for full i18n.
+ *
+ * #4201: the message is chosen by auth *shape*, but it must not assert a
+ * cause it cannot see. For `agent` + pinned identities the only fact we have
+ * is "the remote rejected every key from the configured identity set", so
+ * say that and name the identity set (a wrong cached IdentityFile is the
+ * common cause) instead of unconditionally sending the user to `ssh-add`.
+ */
+export function authFailureHint(cfg: HostConfig, options: AuthFailureHintOptions = {}): string {
   const portArg = cfg.port && cfg.port !== 22 ? `-p ${cfg.port} ` : '';
+  const withCause = (text: string): string => {
+    const cause = options.cause?.trim();
+    if (!cause || text.toLowerCase().includes(cause.toLowerCase())) return text;
+    return `${text} (ssh: ${cause})`;
+  };
   if (cfg.authMethod === 'agent') {
+    const identities = describeConfiguredIdentities(cfg, options.homeDir);
     const pinned = !!cfg.identityFile
       || (cfg.sshAuthentication?.allowedAgentFingerprints?.length ?? 0) > 0;
     if (pinned) {
-      return 'SSH agent has no key the remote accepts from the configured identity set. '
-        + 'Load the matching private key with `ssh-add`, then try again.';
+      const identitySet = identities ? ` (IdentityFile: ${identities})` : '';
+      return withCause(
+        `Every key ssh-agent offered from the configured identity set${identitySet} was rejected by the remote for ${cfg.user}@${cfg.hostname}. `
+          + 'Verify that identity\'s public key is installed on the remote, re-add this host with the right identity, or load the matching key with `ssh-add` if it is not in the agent.',
+      );
     }
-    return `SSH agent has no key the remote accepts. Run \`ssh-copy-id ${portArg}${cfg.user}@${cfg.hostname}\` from your terminal to install your pubkey, or re-add this host with "Identity file" auth.`;
+    return withCause(`SSH agent has no key the remote accepts. Run \`ssh-copy-id ${portArg}${cfg.user}@${cfg.hostname}\` from your terminal to install your pubkey, or re-add this host with "Identity file" auth.`);
   }
   if (cfg.authMethod === 'key') {
-    return `The configured identity file was rejected by the remote. Verify it is the right key for ${cfg.user}@${cfg.hostname}, or run \`ssh-copy-id ${portArg}-i <public-key-file> ${cfg.user}@${cfg.hostname}\` with its matching public key.`;
+    const identity = cfg.identityFile ? describeIdentityPath(cfg.identityFile, options.homeDir) : '';
+    const which = identity ? `The configured identity file (${identity})` : 'The configured identity file';
+    return withCause(`${which} was rejected by the remote. Verify it is the right key for ${cfg.user}@${cfg.hostname}, or run \`ssh-copy-id ${portArg}-i <public-key-file> ${cfg.user}@${cfg.hostname}\` with its matching public key.`);
   }
-  return `Authentication failed connecting as ${cfg.user}@${cfg.hostname}.`;
+  return withCause(`Authentication failed connecting as ${cfg.user}@${cfg.hostname}.`);
 }
 
 function wrapChannel(channel: ClientChannel): ExecStreamHandle {
@@ -1296,7 +1359,7 @@ export class RemoteHost {
         this.lastError = this.hostKeyError
           ? this.hostKeyError
           : isAuthFailure(err.message)
-            ? authFailureHint(attemptConfig)
+            ? authFailureHint(attemptConfig, { cause: err.message })
             : err.message;
         this.client = null;
         this.setStatus('failed');

--- a/packages/maker-remote-ssh/src/RemoteHost.ts
+++ b/packages/maker-remote-ssh/src/RemoteHost.ts
@@ -23,7 +23,7 @@ import { StringDecoder } from 'node:string_decoder';
 import { Client, type ConnectConfig, type ClientChannel, type TcpConnectionDetails } from 'ssh2';
 
 import type { HostConfig, HostSnapshot, RemoteStatus } from './types.js';
-import { resolveAuth } from './credentials.js';
+import { resolveAuth, type ResolvedAuth } from './credentials.js';
 import { type HostKeyStore, hostKeyFingerprint, hostKeyId, decideHostKey } from './hostKeys.js';
 
 export interface RemoteHostDeps {
@@ -246,18 +246,43 @@ export function describeIdentityPath(identityPath: string, homeDir: string = os.
   return path.basename(trimmed);
 }
 
-/** Effective identities the connect attempt was limited to: explicit marker first, then ssh_config IdentityFile entries. */
-function describeConfiguredIdentities(cfg: HostConfig, homeDir?: string): string {
-  const seen = new Set<string>();
-  const out: string[] = [];
-  for (const raw of [cfg.identityFile, ...(cfg.sshAuthentication?.configuredIdentityFiles ?? [])]) {
-    if (typeof raw !== 'string') continue;
-    const shown = describeIdentityPath(raw, homeDir);
-    if (!shown || seen.has(shown)) continue;
-    seen.add(shown);
-    out.push(shown);
+/**
+ * Identity files the attempt was actually limited to. Prefer the resolved
+ * auth's list (single source of truth); without it, mirror `resolveAuth`:
+ * ssh_config IdentityFile entries only count when they produced
+ * `allowedAgentFingerprints`, otherwise only the explicit Cindy pin does.
+ */
+function pinnedIdentityFilesFor(cfg: HostConfig, explicit?: readonly string[]): string[] {
+  if (explicit) return [...explicit];
+  if (cfg.authMethod === 'agent') {
+    if ((cfg.sshAuthentication?.allowedAgentFingerprints?.length ?? 0) > 0) {
+      return [...(cfg.sshAuthentication?.configuredIdentityFiles ?? [])];
+    }
+    return cfg.identityFile ? [cfg.identityFile] : [];
   }
-  return out.join(', ');
+  return cfg.identityFile ? [cfg.identityFile] : [];
+}
+
+/**
+ * Render the identity set: de-duplicate by raw path (two different files may
+ * share a basename), then disambiguate colliding labels with the parent
+ * directory name so nothing configured is silently dropped.
+ */
+function describeIdentityFiles(files: readonly string[], homeDir?: string): string {
+  const raws: string[] = [];
+  for (const raw of files) {
+    const trimmed = typeof raw === 'string' ? raw.trim() : '';
+    if (trimmed && !raws.includes(trimmed)) raws.push(trimmed);
+  }
+  const labels = raws.map((raw) => describeIdentityPath(raw, homeDir));
+  return labels
+    .map((label, index) => {
+      if (labels.indexOf(label) === labels.lastIndexOf(label)) return label;
+      const parent = path.basename(path.dirname(raws[index]!));
+      return parent && parent !== '.' ? `${parent}/${label}` : label;
+    })
+    .filter((label) => label.length > 0)
+    .join(', ');
 }
 
 export interface AuthFailureHintOptions {
@@ -268,6 +293,15 @@ export interface AuthFailureHintOptions {
    * material; callers must not pass passphrases or agent sockets here.
    */
   cause?: string;
+  /** Identity files the attempt was limited to (from `ResolvedAuth`). */
+  pinnedIdentityFiles?: readonly string[];
+  /**
+   * How many pinned identities the agent actually held and offered
+   * (`FilteredAgent.lastOfferedCount`). `0` = nothing was offered (key not
+   * loaded), `> 0` = the remote rejected what was offered, `null`/omitted =
+   * unknown (unfiltered agent or enumeration never happened).
+   */
+  offeredIdentityCount?: number | null;
   /** Test seam for home-directory abbreviation. */
   homeDir?: string;
 }
@@ -279,37 +313,53 @@ export interface AuthFailureHintOptions {
  * this into structured fields for full i18n.
  *
  * #4201: the message is chosen by auth *shape*, but it must not assert a
- * cause it cannot see. For `agent` + pinned identities the only fact we have
- * is "the remote rejected every key from the configured identity set", so
- * say that and name the identity set (a wrong cached IdentityFile is the
- * common cause) instead of unconditionally sending the user to `ssh-add`.
+ * cause it cannot see. For `agent` + pinned identities we name the identity
+ * set the attempt was actually limited to (a wrong cached IdentityFile is the
+ * common cause) and only claim "nothing was loaded" / "the remote rejected
+ * the offered keys" when the FilteredAgent recorded that fact; otherwise the
+ * wording stays neutral. Every variant keeps a phrase `isAuthFailure()`
+ * recognizes (see the invariant test).
  */
 export function authFailureHint(cfg: HostConfig, options: AuthFailureHintOptions = {}): string {
   const portArg = cfg.port && cfg.port !== 22 ? `-p ${cfg.port} ` : '';
+  const who = `${cfg.user}@${cfg.hostname}`;
   const withCause = (text: string): string => {
     const cause = options.cause?.trim();
     if (!cause || text.toLowerCase().includes(cause.toLowerCase())) return text;
     return `${text} (ssh: ${cause})`;
   };
+  const pinnedFiles = pinnedIdentityFilesFor(cfg, options.pinnedIdentityFiles);
+  const identities = describeIdentityFiles(pinnedFiles, options.homeDir);
   if (cfg.authMethod === 'agent') {
-    const identities = describeConfiguredIdentities(cfg, options.homeDir);
-    const pinned = !!cfg.identityFile
+    const pinned = pinnedFiles.length > 0
       || (cfg.sshAuthentication?.allowedAgentFingerprints?.length ?? 0) > 0;
     if (pinned) {
       const identitySet = identities ? ` (IdentityFile: ${identities})` : '';
+      const offered = options.offeredIdentityCount;
+      if (offered === 0) {
+        return withCause(
+          `Authentication failed for ${who}: none of the configured identities${identitySet} is currently loaded in ssh-agent, so no key was offered. `
+            + 'Load it with `ssh-add`, or re-add this host with the identity that is loaded.',
+        );
+      }
+      if (typeof offered === 'number' && offered > 0) {
+        return withCause(
+          `Authentication failed for ${who}: the remote rejected every key ssh-agent offered from the configured identity set${identitySet}. `
+            + 'Verify that identity\'s public key is installed on the remote, or re-add this host with the right identity.',
+        );
+      }
       return withCause(
-        `Every key ssh-agent offered from the configured identity set${identitySet} was rejected by the remote for ${cfg.user}@${cfg.hostname}. `
+        `Authentication failed for ${who} with the configured identity set${identitySet}. `
           + 'Verify that identity\'s public key is installed on the remote, re-add this host with the right identity, or load the matching key with `ssh-add` if it is not in the agent.',
       );
     }
-    return withCause(`SSH agent has no key the remote accepts. Run \`ssh-copy-id ${portArg}${cfg.user}@${cfg.hostname}\` from your terminal to install your pubkey, or re-add this host with "Identity file" auth.`);
+    return withCause(`SSH agent has no key the remote accepts. Run \`ssh-copy-id ${portArg}${who}\` from your terminal to install your pubkey, or re-add this host with "Identity file" auth.`);
   }
   if (cfg.authMethod === 'key') {
-    const identity = cfg.identityFile ? describeIdentityPath(cfg.identityFile, options.homeDir) : '';
-    const which = identity ? `The configured identity file (${identity})` : 'The configured identity file';
-    return withCause(`${which} was rejected by the remote. Verify it is the right key for ${cfg.user}@${cfg.hostname}, or run \`ssh-copy-id ${portArg}-i <public-key-file> ${cfg.user}@${cfg.hostname}\` with its matching public key.`);
+    const which = identities ? `The configured identity file (${identities})` : 'The configured identity file';
+    return withCause(`${which} was rejected by the remote. Verify it is the right key for ${who}, or run \`ssh-copy-id ${portArg}-i <public-key-file> ${who}\` with its matching public key.`);
   }
-  return withCause(`Authentication failed connecting as ${cfg.user}@${cfg.hostname}.`);
+  return withCause(`Authentication failed connecting as ${who}.`);
 }
 
 function wrapChannel(channel: ClientChannel): ExecStreamHandle {
@@ -1260,7 +1310,7 @@ export class RemoteHost {
     this.hostKeyError = null;
     this.lastAuthError = null;
 
-    let auth;
+    let auth: ResolvedAuth;
     try {
       auth = await resolveAuth(attemptConfig);
     } catch (err) {
@@ -1359,7 +1409,11 @@ export class RemoteHost {
         this.lastError = this.hostKeyError
           ? this.hostKeyError
           : isAuthFailure(err.message)
-            ? authFailureHint(attemptConfig, { cause: err.message })
+            ? authFailureHint(attemptConfig, {
+                cause: err.message,
+                pinnedIdentityFiles: auth.pinnedIdentityFiles,
+                offeredIdentityCount: auth.readOfferedIdentityCount?.() ?? null,
+              })
             : err.message;
         this.client = null;
         this.setStatus('failed');

--- a/packages/maker-remote-ssh/src/RemoteHost.ts
+++ b/packages/maker-remote-ssh/src/RemoteHost.ts
@@ -350,8 +350,14 @@ export function authFailureHint(cfg: HostConfig, options: AuthFailureHintOptions
         );
       }
       if (outcome && (outcome.offeredCount ?? 0) > 0 && outcome.signedCount > 0) {
+        // A signature proves the remote saw that key; it does not prove every
+        // enumerated key was tried (MaxAuthTries can end the session early).
+        const everyKeyTried = outcome.signedCount >= (outcome.offeredCount ?? 0);
+        const rejected = everyKeyTried
+          ? `the remote rejected every key ssh-agent offered from the configured identity set${identitySet}`
+          : `the remote rejected the key(s) ssh-agent offered from the configured identity set${identitySet} before every identity was tried`;
         return withCause(
-          `Authentication failed for ${who}: the remote rejected every key ssh-agent offered from the configured identity set${identitySet}. `
+          `Authentication failed for ${who}: ${rejected}. `
             + 'Verify that identity\'s public key is installed on the remote, or re-add this host with the right identity.',
         );
       }

--- a/packages/maker-remote-ssh/src/__tests__/authFailureClassification.test.ts
+++ b/packages/maker-remote-ssh/src/__tests__/authFailureClassification.test.ts
@@ -14,7 +14,7 @@
 
 import { describe, it, expect } from 'vitest';
 
-import { isAuthFailure, authFailureHint } from '../RemoteHost.js';
+import { isAuthFailure, authFailureHint, describeIdentityPath } from '../RemoteHost.js';
 import type { HostConfig } from '../types.js';
 
 function cfg(partial: Partial<HostConfig>): HostConfig {
@@ -71,6 +71,83 @@ describe('isAuthFailure recognizes every authFailureHint variant', () => {
     expect(
       isAuthFailure(authFailureHint(cfg({ authMethod: 'password' as HostConfig['authMethod'] }))),
     ).toBe(true);
+  });
+});
+
+describe('authFailureHint names the identity set and keeps the real reason (#4201)', () => {
+  const pinnedCfg = cfg({
+    authMethod: 'agent',
+    sshAuthentication: {
+      identitiesOnly: true,
+      configuredIdentityFiles: ['/home/u/.ssh/id_ed25519_github'],
+      identityFileDirectiveSeen: true,
+      identityFileNoneSeen: false,
+      allowedAgentFingerprints: ['SHA256:test'],
+    },
+  });
+
+  it('pinned agent: says the remote rejected the configured identity set, names the IdentityFile, and does not assert the key is missing from the agent', () => {
+    const hint = authFailureHint(pinnedCfg, { homeDir: '/home/u' });
+    expect(hint).toContain('IdentityFile: ~/.ssh/id_ed25519_github');
+    expect(hint).toContain('was rejected by the remote');
+    expect(hint).not.toContain('has no key');
+    // 绝对路径不进用户可见文案(主目录缩写),也不猜 .pub 文件名。
+    expect(hint).not.toContain('/home/u/.ssh');
+    expect(hint).not.toContain('.pub');
+    expect(isAuthFailure(hint)).toBe(true);
+  });
+
+  it('pinned agent: explicit Cindy identity marker is listed first, de-duplicated against ssh_config entries', () => {
+    const hint = authFailureHint(
+      cfg({
+        ...pinnedCfg,
+        identityFile: '/home/u/.ssh/id_ed25519_github',
+        sshAuthentication: {
+          ...pinnedCfg.sshAuthentication!,
+          configuredIdentityFiles: ['/home/u/.ssh/id_ed25519_github', '/home/u/.ssh/id_rsa'],
+        },
+      }),
+      { homeDir: '/home/u' },
+    );
+    expect(hint).toContain('IdentityFile: ~/.ssh/id_ed25519_github, ~/.ssh/id_rsa');
+    expect(hint.split('id_ed25519_github').length - 1).toBe(1);
+  });
+
+  it('appends the underlying ssh2 reason once, and not when the text already says it', () => {
+    const hint = authFailureHint(pinnedCfg, {
+      homeDir: '/home/u',
+      cause: 'All configured authentication methods failed',
+    });
+    expect(hint).toContain('(ssh: All configured authentication methods failed)');
+    expect(hint.split('All configured authentication methods failed').length - 1).toBe(1);
+    expect(isAuthFailure(hint)).toBe(true);
+
+    const plain = authFailureHint(cfg({ authMethod: 'agent' }), { cause: '  ' });
+    expect(plain).not.toContain('(ssh:');
+    const fallback = authFailureHint(
+      cfg({ authMethod: 'password' as HostConfig['authMethod'] }),
+      { cause: 'Authentication failed.' },
+    );
+    expect(fallback).toContain('(ssh: Authentication failed.)');
+    expect(isAuthFailure(fallback)).toBe(true);
+  });
+
+  it('key mode names the identity by basename only when it is outside the home directory', () => {
+    const hint = authFailureHint(
+      cfg({ authMethod: 'key', identityFile: '/srv/keys/deploy.key' }),
+      { homeDir: '/home/u', cause: 'All configured authentication methods failed' },
+    );
+    expect(hint).toContain('The configured identity file (deploy.key) was rejected by the remote');
+    expect(hint).not.toContain('/srv/keys');
+    expect(isAuthFailure(hint)).toBe(true);
+  });
+
+  it('describeIdentityPath abbreviates home, keeps ~ forms, and otherwise falls back to the basename', () => {
+    expect(describeIdentityPath('/home/u/.ssh/id_ed25519', '/home/u')).toBe('~/.ssh/id_ed25519');
+    expect(describeIdentityPath('~/.ssh/id_ed25519', '/home/u')).toBe('~/.ssh/id_ed25519');
+    expect(describeIdentityPath('/srv/keys/deploy.key', '/home/u')).toBe('deploy.key');
+    expect(describeIdentityPath('/home/u2/.ssh/id_rsa', '/home/u')).toBe('id_rsa');
+    expect(describeIdentityPath('   ', '/home/u')).toBe('');
   });
 });
 

--- a/packages/maker-remote-ssh/src/__tests__/authFailureClassification.test.ts
+++ b/packages/maker-remote-ssh/src/__tests__/authFailureClassification.test.ts
@@ -86,31 +86,70 @@ describe('authFailureHint names the identity set and keeps the real reason (#420
     },
   });
 
-  it('pinned agent: says the remote rejected the configured identity set, names the IdentityFile, and does not assert the key is missing from the agent', () => {
+  it('pinned agent, offered count unknown: neutral wording that names the IdentityFile and never asserts a cause', () => {
     const hint = authFailureHint(pinnedCfg, { homeDir: '/home/u' });
     expect(hint).toContain('IdentityFile: ~/.ssh/id_ed25519_github');
-    expect(hint).toContain('was rejected by the remote');
+    expect(hint).toContain('Authentication failed for deploy@10.0.0.5 with the configured identity set');
     expect(hint).not.toContain('has no key');
+    expect(hint).not.toContain('rejected every key');
+    expect(hint).not.toContain('no key was offered');
     // 绝对路径不进用户可见文案(主目录缩写),也不猜 .pub 文件名。
     expect(hint).not.toContain('/home/u/.ssh');
     expect(hint).not.toContain('.pub');
     expect(isAuthFailure(hint)).toBe(true);
   });
 
-  it('pinned agent: explicit Cindy identity marker is listed first, de-duplicated against ssh_config entries', () => {
+  it('pinned agent, nothing offered (key not loaded): says so and points at ssh-add, not at the remote', () => {
+    const hint = authFailureHint(pinnedCfg, { homeDir: '/home/u', offeredIdentityCount: 0 });
+    expect(hint).toContain('none of the configured identities (IdentityFile: ~/.ssh/id_ed25519_github) is currently loaded in ssh-agent');
+    expect(hint).toContain('ssh-add');
+    expect(hint).not.toContain('rejected');
+    expect(isAuthFailure(hint)).toBe(true);
+  });
+
+  it('pinned agent, keys were offered: says the remote rejected them and does not send the user to ssh-add', () => {
+    const hint = authFailureHint(pinnedCfg, { homeDir: '/home/u', offeredIdentityCount: 1 });
+    expect(hint).toContain('the remote rejected every key ssh-agent offered from the configured identity set (IdentityFile: ~/.ssh/id_ed25519_github)');
+    expect(hint).not.toContain('ssh-add');
+    expect(isAuthFailure(hint)).toBe(true);
+  });
+
+  it('names only the identities the attempt was actually limited to (explicit pin beats unrelated ssh_config entries)', () => {
+    // marker auth=agent + explicit Cindy pin, IdentitiesOnly unset: resolveAuth pins
+    // only cfg.identityFile; the other IdentityFile entries never reach the agent.
     const hint = authFailureHint(
       cfg({
-        ...pinnedCfg,
+        authMethod: 'agent',
         identityFile: '/home/u/.ssh/id_ed25519_github',
         sshAuthentication: {
-          ...pinnedCfg.sshAuthentication!,
-          configuredIdentityFiles: ['/home/u/.ssh/id_ed25519_github', '/home/u/.ssh/id_rsa'],
+          identitiesOnly: false,
+          configuredIdentityFiles: ['/home/u/.ssh/id_rsa', '/home/u/.ssh/id_ed25519_github', '/home/u/.ssh/other'],
+          identityFileDirectiveSeen: true,
+          identityFileNoneSeen: false,
         },
       }),
       { homeDir: '/home/u' },
     );
-    expect(hint).toContain('IdentityFile: ~/.ssh/id_ed25519_github, ~/.ssh/id_rsa');
-    expect(hint.split('id_ed25519_github').length - 1).toBe(1);
+    expect(hint).toContain('IdentityFile: ~/.ssh/id_ed25519_github)');
+    expect(hint).not.toContain('id_rsa');
+    expect(hint).not.toContain('other');
+    // The resolved auth's list wins over any derivation from config.
+    const explicit = authFailureHint(pinnedCfg, {
+      homeDir: '/home/u',
+      pinnedIdentityFiles: ['/home/u/.ssh/only_this'],
+    });
+    expect(explicit).toContain('IdentityFile: ~/.ssh/only_this)');
+    expect(explicit).not.toContain('id_ed25519_github');
+  });
+
+  it('keeps distinct files that share a basename instead of merging them', () => {
+    const hint = authFailureHint(pinnedCfg, {
+      homeDir: '/home/u',
+      pinnedIdentityFiles: ['/srv/a/id_rsa', '/opt/b/id_rsa', '/srv/a/id_rsa'],
+    });
+    expect(hint).toContain('IdentityFile: a/id_rsa, b/id_rsa)');
+    expect(hint).not.toContain('/srv/');
+    expect(hint).not.toContain('/opt/');
   });
 
   it('appends the underlying ssh2 reason once, and not when the text already says it', () => {

--- a/packages/maker-remote-ssh/src/__tests__/authFailureClassification.test.ts
+++ b/packages/maker-remote-ssh/src/__tests__/authFailureClassification.test.ts
@@ -120,6 +120,16 @@ describe('authFailureHint names the identity set and keeps the real reason (#420
     expect(isAuthFailure(hint)).toBe(true);
   });
 
+  it('pinned agent, several keys offered but only some signed: does not claim every key was rejected', () => {
+    const hint = authFailureHint(pinnedCfg, {
+      homeDir: '/home/u',
+      agentOutcome: { offeredCount: 3, signedCount: 1, signFailureCount: 0 },
+    });
+    expect(hint).toContain('the remote rejected the key(s) ssh-agent offered from the configured identity set (IdentityFile: ~/.ssh/id_ed25519_github) before every identity was tried');
+    expect(hint).not.toContain('rejected every key');
+    expect(isAuthFailure(hint)).toBe(true);
+  });
+
   it('pinned agent, key offered but the agent could not sign: local problem, never blamed on the remote', () => {
     const hint = authFailureHint(pinnedCfg, {
       homeDir: '/home/u',

--- a/packages/maker-remote-ssh/src/__tests__/authFailureClassification.test.ts
+++ b/packages/maker-remote-ssh/src/__tests__/authFailureClassification.test.ts
@@ -100,18 +100,42 @@ describe('authFailureHint names the identity set and keeps the real reason (#420
   });
 
   it('pinned agent, nothing offered (key not loaded): says so and points at ssh-add, not at the remote', () => {
-    const hint = authFailureHint(pinnedCfg, { homeDir: '/home/u', offeredIdentityCount: 0 });
+    const hint = authFailureHint(pinnedCfg, {
+      homeDir: '/home/u',
+      agentOutcome: { offeredCount: 0, signedCount: 0, signFailureCount: 0 },
+    });
     expect(hint).toContain('none of the configured identities (IdentityFile: ~/.ssh/id_ed25519_github) is currently loaded in ssh-agent');
     expect(hint).toContain('ssh-add');
     expect(hint).not.toContain('rejected');
     expect(isAuthFailure(hint)).toBe(true);
   });
 
-  it('pinned agent, keys were offered: says the remote rejected them and does not send the user to ssh-add', () => {
-    const hint = authFailureHint(pinnedCfg, { homeDir: '/home/u', offeredIdentityCount: 1 });
+  it('pinned agent, key offered AND signed: says the remote rejected it and does not send the user to ssh-add', () => {
+    const hint = authFailureHint(pinnedCfg, {
+      homeDir: '/home/u',
+      agentOutcome: { offeredCount: 1, signedCount: 1, signFailureCount: 0 },
+    });
     expect(hint).toContain('the remote rejected every key ssh-agent offered from the configured identity set (IdentityFile: ~/.ssh/id_ed25519_github)');
     expect(hint).not.toContain('ssh-add');
     expect(isAuthFailure(hint)).toBe(true);
+  });
+
+  it('pinned agent, key offered but the agent could not sign: local problem, never blamed on the remote', () => {
+    const hint = authFailureHint(pinnedCfg, {
+      homeDir: '/home/u',
+      agentOutcome: { offeredCount: 1, signedCount: 0, signFailureCount: 1 },
+    });
+    expect(hint).toContain('ssh-agent could not sign with the configured identity (IdentityFile: ~/.ssh/id_ed25519_github)');
+    expect(hint).not.toContain('rejected');
+    expect(isAuthFailure(hint)).toBe(true);
+    // 枚举到了但一次签名都没发生(ssh2 未走到该 key)→ 不能断言远端拒绝,回到中性措辞
+    const neutral = authFailureHint(pinnedCfg, {
+      homeDir: '/home/u',
+      agentOutcome: { offeredCount: 1, signedCount: 0, signFailureCount: 0 },
+    });
+    expect(neutral).toContain('with the configured identity set');
+    expect(neutral).not.toContain('rejected every key');
+    expect(isAuthFailure(neutral)).toBe(true);
   });
 
   it('names only the identities the attempt was actually limited to (explicit pin beats unrelated ssh_config entries)', () => {

--- a/packages/maker-remote-ssh/src/__tests__/credentials.test.ts
+++ b/packages/maker-remote-ssh/src/__tests__/credentials.test.ts
@@ -14,6 +14,9 @@
  */
 
 import { describe, expect, it } from 'vitest';
+import { promises as fs } from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
 
 import {
   KEY_FILE_NOT_FOUND_CODE,
@@ -24,8 +27,11 @@ import {
   previewAgentEndpoint,
   resolveAgentEndpoint,
   SSH_AGENT_UNAVAILABLE_CODE,
+  resolveIdentityFingerprints,
 } from '../sshAuthentication.js';
 import type { HostConfig } from '../types.js';
+const TEST_PUBLIC_KEY = 'ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIPFqmiBYVCrZsGBJy/djBu4yIr1lYkTuOXI0A9vPN/lD cindy-test\n';
+const TEST_PUBLIC_KEY_2 = 'ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIIkv84ni34F924G7htx9qVI7CcGG5xYDJQoabgKUbMiv cindy-test-2\n';
 
 function keyHost(over: Partial<HostConfig> & Pick<HostConfig, 'identityFile'>): HostConfig {
   return {
@@ -163,6 +169,48 @@ describe('resolveAuth OpenSSH agent metadata', () => {
     } finally {
       if (previous === undefined) delete process.env.SSH_AUTH_SOCK;
       else process.env.SSH_AUTH_SOCK = previous;
+    }
+  });
+
+  it('pins only the configured identity files whose public key is in the fingerprint set (#4201)', async () => {
+    const dir = await fs.mkdtemp(path.join(os.tmpdir(), 'cindy-pin-'));
+    const previous = process.env.SSH_AUTH_SOCK;
+    process.env.SSH_AUTH_SOCK = '/tmp/cindy-test-agent.sock';
+    try {
+      const pinned = path.join(dir, 'id_ed25519');
+      const other = path.join(dir, 'id_ecdsa');
+      const missing = path.join(dir, 'id_rsa');
+      await fs.writeFile(`${pinned}.pub`, TEST_PUBLIC_KEY);
+      await fs.writeFile(`${other}.pub`, TEST_PUBLIC_KEY_2);
+      const { fingerprints } = await resolveIdentityFingerprints(pinned);
+      const resolved = await resolveAuth({
+        id: 'lab',
+        hostname: '192.0.2.10',
+        port: 22,
+        user: 'developer',
+        authMethod: 'agent',
+        source: 'ssh-config',
+        managedByCindy: false,
+        sshAuthentication: {
+          identitiesOnly: true,
+          // sshConfig lists every default path, but only `pinned` produced a fingerprint.
+          configuredIdentityFiles: [missing, pinned, other],
+          identityFileDirectiveSeen: false,
+          identityFileNoneSeen: false,
+          allowedAgentFingerprints: fingerprints,
+        },
+      });
+      expect(resolved.label).toBe('ssh-agent[filtered]');
+      expect(resolved.pinnedIdentityFiles).toEqual([pinned]);
+      expect(resolved.readAgentAuthOutcome?.()).toEqual({
+        offeredCount: null,
+        signedCount: 0,
+        signFailureCount: 0,
+      });
+    } finally {
+      if (previous === undefined) delete process.env.SSH_AUTH_SOCK;
+      else process.env.SSH_AUTH_SOCK = previous;
+      await fs.rm(dir, { recursive: true, force: true });
     }
   });
 

--- a/packages/maker-remote-ssh/src/__tests__/credentials.test.ts
+++ b/packages/maker-remote-ssh/src/__tests__/credentials.test.ts
@@ -156,6 +156,9 @@ describe('resolveAuth OpenSSH agent metadata', () => {
           ? '\\\\.\\pipe\\openssh-ssh-agent'
           : '/tmp/cindy-test-agent.sock',
         label: 'ssh-agent',
+        // #4201: an unfiltered agent pins nothing, so the failure hint must not
+        // name the external IdentityFile entries that never reached the agent.
+        pinnedIdentityFiles: [],
       });
     } finally {
       if (previous === undefined) delete process.env.SSH_AUTH_SOCK;

--- a/packages/maker-remote-ssh/src/__tests__/filteredAgent.test.ts
+++ b/packages/maker-remote-ssh/src/__tests__/filteredAgent.test.ts
@@ -168,6 +168,38 @@ describe('FilteredAgent.getIdentities', () => {
     expect(notLoaded.lastOfferedCount).toBe(0);
   });
 
+  it('tracks sign outcomes after enumeration so a local signer failure is not mistaken for a remote rejection', async () => {
+    const keyA = makeKey(Buffer.from('keyA-pub-bytes'));
+    const upstream = new MockUpstreamAgent([keyA]);
+    const filtered = new FilteredAgent(upstream, [sshFingerprint(keyA)]);
+    await new Promise<void>((resolve, reject) => {
+      filtered.getIdentities((err) => (err ? reject(err) : resolve()));
+    });
+    expect(filtered.signedCount).toBe(0);
+    expect(filtered.signFailureCount).toBe(0);
+
+    upstream.sign = (_k, _d, optsOrCb, cb) => {
+      const done = typeof optsOrCb === 'function' ? optsOrCb : cb!;
+      done(undefined, Buffer.from('sig'));
+    };
+    await new Promise<void>((resolve) => filtered.sign(keyA, Buffer.from('d'), () => resolve()));
+    expect(filtered.signedCount).toBe(1);
+
+    upstream.sign = (_k, _d, optsOrCb, cb) => {
+      const done = typeof optsOrCb === 'function' ? optsOrCb : cb!;
+      done(new Error('agent locked'));
+    };
+    await new Promise<void>((resolve) => filtered.sign(keyA, Buffer.from('d'), {}, () => resolve()));
+    expect(filtered.signFailureCount).toBe(1);
+
+    // 重新枚举即重置计数(新一次 connect attempt)
+    await new Promise<void>((resolve, reject) => {
+      filtered.getIdentities((err) => (err ? reject(err) : resolve()));
+    });
+    expect(filtered.signedCount).toBe(0);
+    expect(filtered.signFailureCount).toBe(0);
+  });
+
   it('propagates upstream errors', async () => {
     const boom = new Error('agent unreachable');
     const upstream = new MockUpstreamAgent([], boom);

--- a/packages/maker-remote-ssh/src/__tests__/filteredAgent.test.ts
+++ b/packages/maker-remote-ssh/src/__tests__/filteredAgent.test.ts
@@ -151,6 +151,23 @@ describe('FilteredAgent.getIdentities', () => {
     expect(keys).toEqual([]);
   });
 
+  it('records how many allowed identities were actually offered (#4201)', async () => {
+    const keyA = makeKey(Buffer.from('keyA-pub-bytes'));
+    const keyB = makeKey(Buffer.from('keyB-pub-bytes'));
+    const loaded = new FilteredAgent(new MockUpstreamAgent([keyA, keyB]), [sshFingerprint(keyB)]);
+    expect(loaded.lastOfferedCount).toBeNull();
+    await new Promise<void>((resolve, reject) => {
+      loaded.getIdentities((err) => (err ? reject(err) : resolve()));
+    });
+    expect(loaded.lastOfferedCount).toBe(1);
+
+    const notLoaded = new FilteredAgent(new MockUpstreamAgent([keyA]), [sshFingerprint(keyB)]);
+    await new Promise<void>((resolve, reject) => {
+      notLoaded.getIdentities((err) => (err ? reject(err) : resolve()));
+    });
+    expect(notLoaded.lastOfferedCount).toBe(0);
+  });
+
   it('propagates upstream errors', async () => {
     const boom = new Error('agent unreachable');
     const upstream = new MockUpstreamAgent([], boom);

--- a/packages/maker-remote-ssh/src/credentials.ts
+++ b/packages/maker-remote-ssh/src/credentials.ts
@@ -101,9 +101,21 @@ export async function resolveAuth(host: HostConfig): Promise<ResolvedAuth> {
 
   if (host.authMethod === 'agent') {
     let allowedFingerprints = host.sshAuthentication?.allowedAgentFingerprints;
-    let pinnedIdentityFiles: string[] = allowedFingerprints && allowedFingerprints.length > 0
-      ? [...(host.sshAuthentication?.configuredIdentityFiles ?? [])]
-      : [];
+    // Only the configured files whose public key actually made it into the pin
+    // set count as "this attempt's identities": with `IdentitiesOnly yes` and
+    // no explicit IdentityFile, sshConfig lists every default path but only
+    // fingerprints the ones that exist (#4201 review). Public-key files only;
+    // private keys are never read here.
+    let pinnedIdentityFiles: string[] = [];
+    if (allowedFingerprints && allowedFingerprints.length > 0) {
+      const allowed = new Set(allowedFingerprints);
+      for (const identityFile of host.sshAuthentication?.configuredIdentityFiles ?? []) {
+        const resolved = await resolveIdentityFingerprints(identityFile);
+        if (resolved.fingerprints.some((fingerprint) => allowed.has(fingerprint))) {
+          pinnedIdentityFiles.push(identityFile);
+        }
+      }
+    }
 
     // A marker-authenticated agent host may carry an explicit Cindy pin even
     // when IdentitiesOnly is no. External IdentityFile metadata never enters

--- a/packages/maker-remote-ssh/src/credentials.ts
+++ b/packages/maker-remote-ssh/src/credentials.ts
@@ -62,6 +62,23 @@ export interface ResolvedAuth {
   passphrase?: string;
   /** Human-readable label used in logs / errors so we don't leak the path. */
   label: string;
+  /**
+   * Identity files this attempt was actually limited to, in the order they
+   * restrict the agent (or the single private key for `authMethod='key'`).
+   * Empty for an unfiltered agent. Mirrors the branch taken above so a
+   * failure hint never names an IdentityFile that was not part of the pin
+   * (#4201): ssh_config entries only count when they produced
+   * `allowedAgentFingerprints`; otherwise only the explicit Cindy pin does.
+   */
+  pinnedIdentityFiles: string[];
+  /**
+   * For a filtered agent: how many pinned identities the agent actually held
+   * on its last enumeration (`FilteredAgent.lastOfferedCount`); `null` before
+   * enumeration or on enumeration failure. Absent for unfiltered agents and
+   * key files. Kept as an accessor so RemoteHost never has to import the ssh2
+   * agent classes (tests mock `ssh2` wholesale).
+   */
+  readOfferedIdentityCount?: () => number | null;
 }
 
 export async function resolveAuth(host: HostConfig): Promise<ResolvedAuth> {
@@ -76,6 +93,9 @@ export async function resolveAuth(host: HostConfig): Promise<ResolvedAuth> {
 
   if (host.authMethod === 'agent') {
     let allowedFingerprints = host.sshAuthentication?.allowedAgentFingerprints;
+    let pinnedIdentityFiles: string[] = allowedFingerprints && allowedFingerprints.length > 0
+      ? [...(host.sshAuthentication?.configuredIdentityFiles ?? [])]
+      : [];
 
     // A marker-authenticated agent host may carry an explicit Cindy pin even
     // when IdentitiesOnly is no. External IdentityFile metadata never enters
@@ -83,6 +103,7 @@ export async function resolveAuth(host: HostConfig): Promise<ResolvedAuth> {
     if (!allowedFingerprints && host.identityFile) {
       const resolved = await resolveIdentityFingerprints(host.identityFile);
       allowedFingerprints = resolved.fingerprints;
+      pinnedIdentityFiles = [host.identityFile];
       if (allowedFingerprints.length === 0) {
         const e = new Error(
           `agent + pinned key failed: ${host.identityFile} is not a readable public key `
@@ -119,12 +140,14 @@ export async function resolveAuth(host: HostConfig): Promise<ResolvedAuth> {
           label: allowedFingerprints.length === 1
             ? 'ssh-agent[filtered]'
             : `ssh-agent[filtered:${allowedFingerprints.length}]`,
+          pinnedIdentityFiles,
+          readOfferedIdentityCount: () => filtered.lastOfferedCount,
         };
       } catch (err) {
         throwUnsupported((err as Error).message);
       }
     }
-    return { agent: endpoint, label: 'ssh-agent' };
+    return { agent: endpoint, label: 'ssh-agent', pinnedIdentityFiles: [] };
   }
 
   if (host.authMethod === 'key') {
@@ -150,7 +173,11 @@ export async function resolveAuth(host: HostConfig): Promise<ResolvedAuth> {
       (e as { code?: string }).code = KEY_FILE_UNREADABLE_CODE;
       throw e;
     }
-    return { privateKey, label: `key:${baseName(host.identityFile)}` };
+    return {
+      privateKey,
+      label: `key:${baseName(host.identityFile)}`,
+      pinnedIdentityFiles: [host.identityFile],
+    };
   }
 
   throw new Error(`unsupported authMethod: ${(host as { authMethod: string }).authMethod}`);

--- a/packages/maker-remote-ssh/src/credentials.ts
+++ b/packages/maker-remote-ssh/src/credentials.ts
@@ -72,13 +72,21 @@ export interface ResolvedAuth {
    */
   pinnedIdentityFiles: string[];
   /**
-   * For a filtered agent: how many pinned identities the agent actually held
-   * on its last enumeration (`FilteredAgent.lastOfferedCount`); `null` before
-   * enumeration or on enumeration failure. Absent for unfiltered agents and
-   * key files. Kept as an accessor so RemoteHost never has to import the ssh2
-   * agent classes (tests mock `ssh2` wholesale).
+   * For a filtered agent: what the agent did on the last attempt —
+   * `offeredCount` pinned identities held (null before enumeration or on
+   * enumeration failure), `signedCount` signatures the agent produced and
+   * `signFailureCount` local sign failures (agent locked, hardware key touch
+   * refused). Absent for unfiltered agents and key files. Kept as an accessor
+   * so RemoteHost never has to import the ssh2 agent classes (tests mock
+   * `ssh2` wholesale).
    */
-  readOfferedIdentityCount?: () => number | null;
+  readAgentAuthOutcome?: () => AgentAuthOutcome;
+}
+
+export interface AgentAuthOutcome {
+  offeredCount: number | null;
+  signedCount: number;
+  signFailureCount: number;
 }
 
 export async function resolveAuth(host: HostConfig): Promise<ResolvedAuth> {
@@ -141,7 +149,11 @@ export async function resolveAuth(host: HostConfig): Promise<ResolvedAuth> {
             ? 'ssh-agent[filtered]'
             : `ssh-agent[filtered:${allowedFingerprints.length}]`,
           pinnedIdentityFiles,
-          readOfferedIdentityCount: () => filtered.lastOfferedCount,
+          readAgentAuthOutcome: () => ({
+            offeredCount: filtered.lastOfferedCount,
+            signedCount: filtered.signedCount,
+            signFailureCount: filtered.signFailureCount,
+          }),
         };
       } catch (err) {
         throwUnsupported((err as Error).message);

--- a/packages/maker-remote-ssh/src/filteredAgent.ts
+++ b/packages/maker-remote-ssh/src/filteredAgent.ts
@@ -87,6 +87,14 @@ export class FilteredAgent extends BaseAgent<ParsedKey> {
    * from "the remote rejected what was offered" (#4201).
    */
   lastOfferedCount: number | null = null;
+  /**
+   * Sign outcomes since the last enumeration. An offered key only proves the
+   * agent held it; the remote has rejected it only if the agent also signed
+   * for it. A sign failure (agent locked, hardware-key touch refused, signer
+   * error) is a local problem, not a remote rejection.
+   */
+  signedCount = 0;
+  signFailureCount = 0;
 
   constructor(upstream: BaseAgent<ParsedKey>, allowedFingerprints: string | readonly string[]) {
     super();
@@ -117,6 +125,8 @@ export class FilteredAgent extends BaseAgent<ParsedKey> {
         .map((fingerprint) => byFingerprint.get(fingerprint))
         .filter((key): key is ParsedKey => key !== undefined);
       this.lastOfferedCount = matches.length;
+      this.signedCount = 0;
+      this.signFailureCount = 0;
       cb(undefined, matches);
     });
   }
@@ -130,10 +140,16 @@ export class FilteredAgent extends BaseAgent<ParsedKey> {
     cb?: SignCallback,
   ): void {
     // Defer to upstream. The signature for sign() varies — handle both arities.
+    const done: SignCallback = typeof optsOrCb === 'function' ? optsOrCb : cb!;
+    const track: SignCallback = (err, signature) => {
+      if (err) this.signFailureCount += 1;
+      else this.signedCount += 1;
+      done(err, signature);
+    };
     if (typeof optsOrCb === 'function') {
-      this.upstream.sign(pubKey, data, optsOrCb);
+      this.upstream.sign(pubKey, data, track);
     } else {
-      this.upstream.sign(pubKey, data, optsOrCb, cb);
+      this.upstream.sign(pubKey, data, optsOrCb, track);
     }
   }
 }

--- a/packages/maker-remote-ssh/src/filteredAgent.ts
+++ b/packages/maker-remote-ssh/src/filteredAgent.ts
@@ -79,6 +79,14 @@ export class FilteredAgent extends BaseAgent<ParsedKey> {
   private readonly upstream: BaseAgent<ParsedKey>;
   /** Full `SHA256:...` forms, de-duplicated in OpenSSH configuration order. */
   private readonly allowedFingerprints: string[];
+  /**
+   * How many allowed identities the upstream agent actually held on the last
+   * `getIdentities` call (= how many keys ssh2 could offer). `null` until the
+   * agent has been enumerated, or when enumeration itself failed. Lets the
+   * connect failure path tell "nothing was offered (key not loaded)" apart
+   * from "the remote rejected what was offered" (#4201).
+   */
+  lastOfferedCount: number | null = null;
 
   constructor(upstream: BaseAgent<ParsedKey>, allowedFingerprints: string | readonly string[]) {
     super();
@@ -94,7 +102,10 @@ export class FilteredAgent extends BaseAgent<ParsedKey> {
 
   getIdentities(cb: (err: Error | undefined, publicKeys?: ParsedKey[]) => void): void {
     this.upstream.getIdentities((err, keys) => {
-      if (err) return cb(err);
+      if (err) {
+        this.lastOfferedCount = null;
+        return cb(err);
+      }
       const byFingerprint = new Map<string, ParsedKey>();
       for (const item of keys ?? []) {
         const key = asParsedKey(item);
@@ -105,6 +116,7 @@ export class FilteredAgent extends BaseAgent<ParsedKey> {
       const matches = this.allowedFingerprints
         .map((fingerprint) => byFingerprint.get(fingerprint))
         .filter((key): key is ParsedKey => key !== undefined);
+      this.lastOfferedCount = matches.length;
       cb(undefined, matches);
     });
   }


### PR DESCRIPTION
## 这次改了什么

### 摘要

SSH 认证失败时 `authFailureHint` 按认证**形态**挑模板文案:只要是 `agent` + 配了 IdentityFile,一律说「SSH agent has no key the remote accepts … Load the matching private key with `ssh-add`」。它不看 key 是否已在 agent 里、是否已装到服务器,也不带底层原因,#4201 里真正的原因(「设置 → 远程连接」缓存的 IdentityFile 选错)完全不可见,ssh2 的 `All configured authentication methods failed` 只留在 main 日志里。

本次让可见错误如实、可行动:

- **agent + 钉死身份集**:改为「Every key ssh-agent offered from the configured identity set (IdentityFile: ~/.ssh/id_ed25519_github) was rejected by the remote for user@host. Verify that identity's public key is installed on the remote, re-add this host with the right identity, or load the matching key with `ssh-add` if it is not in the agent.」——先列本次实际限定的 IdentityFile(显式 Cindy marker 优先,再 ssh_config 的 IdentityFile 条目,去重),不再断言 key 不在 agent 里,`ssh-add` 只作为其中一个可能动作保留。
- **key 模式**同样点名身份文件:「The configured identity file (deploy.key) was rejected by the remote …」。
- **路径脱敏**:新增 `describeIdentityPath`,主目录下的以 `~/.ssh/x` 展示,`~` 形式原样保留,其余只给文件名;不读文件、不猜 `.pub`。
- **底层原因随行**:`doConnect` 把 `err.message` 作为 `cause` 传入,文案末尾附 `(ssh: All configured authentication methods failed)`;文案已包含该原因时不重复。UI toast / 主机行副标题 / `cindy_ssh` 的 `SSH_AUTH_FAILED` hint 都消费同一条 `lastError`,三处一致。
- `isAuthFailure` 的识别短语(`was rejected by the remote` / `has no key the remote accepts` / 原始 ssh2 文案)与 `SSH_AUTH_FAILED` 分类**不变**,既有 invariant 单测继续覆盖每一种输出。

`authFailureHint` 的签名新增可选第二参 `{ cause?, homeDir? }`,既有调用方不受影响。

### 变更类型

- [ ] `feat` 新功能
- [x] `fix` 缺陷修复
- [ ] `refactor` / `perf` 重构或性能优化
- [ ] `docs` / `test` / `chore` 文档、测试或工程维护
- [ ] 其他：

### 范围

- 关联 Issue / 需求：Fixes #4201
- 本 PR 包含:`packages/maker-remote-ssh` 的 `authFailureHint` / `describeIdentityPath` / `doConnect` 失败路径,及回归测试
- 明确不包含:结构化错误字段与 i18n 拆分(dash 分析里的第 2/5 点,属跨 renderer/MCP 的契约改动,留维护者决定);实际提供给服务器的 key 指纹(需要在 ssh2 认证回调里采集,另做);renderer 与 lizi-mcps 文案未动
- 用户可见变化:认证失败的 toast / 主机行副标题 / `ssh_exec` 错误 hint 会带上 IdentityFile 与 ssh 原因摘要,文案变长(不再受原「~120 字符」注释约束,已同步更新注释)
- 是否存在 breaking change:无(`SSH_AUTH_FAILED` 码与 `isAuthFailure` 判定不变;新参数可选)

### UI 变化

不涉及

- 引用的设计规范：不涉及:纯 main 侧包逻辑,无渲染层改动

## 怎么验证的

### 自动验证

```text
packages/maker-remote-ssh: npx vitest run src/__tests__/authFailureClassification.test.ts
结果:16 passed(新增 5 例:钉死 agent 列出 ~/.ssh 缩写身份且不含 has no key / 不含绝对路径与 .pub;显式 marker 与 ssh_config 去重;cause 附加一次且已含时不重复;key 模式只给文件名;describeIdentityPath 四种形态)
反证:stash 掉 RemoteHost.ts 改动后同文件 16 tests | 5 failed

packages/maker-remote-ssh: npx vitest run
结果:15 files / 235 passed

packages/maker-remote-ssh: npx tsc --noEmit -p .
结果:通过

根目录 pnpm test:unit:related
结果:apps/desktop unit PASS(220.8s)、packages/maker-remote-ssh unit PASS
```

### 手工验证

不涉及(本机无可复现的错误 IdentityFile 主机;行为由单测覆盖,文案示例见摘要)

### 未执行的验证

eslint:该包目录下 `npx eslint` 因 ESLint v9 找不到 flat config 无法执行,未单独跑 lint;typecheck 与 vitest 已过。

## 风险

### 风险分类

- [x] 无已知风险
- [ ] SQLite / migration
- [ ] system prompt
- [ ] 协议兼容
- [ ] 权限 / 安全 / 用户数据
- [ ] 存量插件兼容（批准状态 / 指纹 / manifest 校验 / 安装布局 / 包格式）
- [ ] 原生层 / fingerprint / OTA
- [ ] 跨平台差异
- [ ] 其他：

### 影响与回滚

- 影响范围:仅 SSH 认证失败时的用户可见文案;分类码与重连判定不变。路径只以 `~` 缩写或文件名出现,不含私钥内容 / passphrase / agent socket
- 回滚 / 降级方式:revert 本 PR,无数据迁移
