### PR TITLE
fix(desktop): 修复远程伙伴刷新后模型回退与会话信息丢失

### DIFF
--- a/apps/desktop/src/renderer/__tests__/machineSwitcher.test.ts
+++ b/apps/desktop/src/renderer/__tests__/machineSwitcher.test.ts
@@ -9,6 +9,7 @@ import {
   normalizeSelectedMachineId,
   parseMachineSelection,
   selectVisibleSessions,
+  type MachineSelection,
   serializeMachineSelection,
   toggleMachineSelection,
 } from '@/features/device-link/selectedMachineStore';
@@ -51,8 +52,46 @@ function mkSession(id: string, deviceLinkDeviceId?: string): Session {
 }
 
 describe('selectVisibleSessions', () => {
+  afterEach(() => remoteProjectsStore.clear());
   const local = [mkSession('l1'), mkSession('l2')];
   const remote = [mkSession('r1', 'dev-a'), mkSession('r2', 'dev-a'), mkSession('r3', 'dev-b')];
+
+  it.each<{ selection: MachineSelection; expected: string[] }>([
+    { selection: MACHINE_ALL, expected: ['l1', 'l2', 'r1', 'r2', 'r3'] },
+    { selection: [MACHINE_LOCAL], expected: ['l1', 'l2'] },
+    { selection: ['dev-a'], expected: ['r1', 'r2'] },
+    { selection: [MACHINE_LOCAL, 'dev-a'], expected: ['l1', 'l2', 'r1', 'r2'] },
+  ])(
+    'excludes companion tasks from ordinary sidebar selection $selection',
+    ({ selection, expected }) => {
+      const bots = ['active', 'archived'].map((status) => ({
+        ...mkSession(`bot-${status}`, 'dev-a'),
+        source: 'bot' as const,
+        status: status as Session['status'],
+        model: 'gpt-6-astra',
+      }));
+      remoteProjectsStore.mergeDeviceSessions('dev-a', 'MacBook', [
+        ...remote.slice(0, 2),
+        bots[0]!,
+      ]);
+      remoteProjectsStore.mergeDeviceSessions('dev-a', 'MacBook', [bots[1]!], 'archived');
+      remoteProjectsStore.mergeDeviceSessions('dev-b', 'Other Mac', remote.slice(2));
+      const mirrored = remoteProjectsStore.getMergedRemoteSessions();
+      const locals = [...local, { ...mkSession('local-bot'), source: 'bot' as const }];
+      expect(selectVisibleSessions(locals, mirrored, selection).map((row) => row.id)).toEqual(
+        expected,
+      );
+      expect(
+        remoteProjectsStore.getDeviceSessions('dev-a').filter((row) => row.source === 'bot'),
+      ).toEqual(
+        expect.arrayContaining(
+          bots.map((bot) =>
+            expect.objectContaining({ id: bot.id, status: bot.status, model: 'gpt-6-astra' }),
+          ),
+        ),
+      );
+    },
+  );
 
   it('所有(默认)→ 本机 + 全部远程合并(顺序:本地在前)', () => {
     expect(selectVisibleSessions(local, remote, MACHINE_ALL).map((s) => s.id)).toEqual([

--- a/apps/desktop/src/renderer/__tests__/refreshRemoteSessionsRetry.test.ts
+++ b/apps/desktop/src/renderer/__tests__/refreshRemoteSessionsRetry.test.ts
@@ -115,6 +115,117 @@ describe('isTransientRemoteError', () => {
 
 describe('refreshRemoteDeviceSessions retry', () => {
   it.each(['merge', 'replace'] as const)(
+    '%s archived refresh reconciles companions deleted while disconnected',
+    async (snapshotMode) => {
+      const d = did();
+      const bots = ['deleted', 'missing', 'kept', 'restored', 'timeout'].map((id) =>
+        session(id, { source: 'bot', status: 'archived', model: 'gpt-6-astra' }),
+      );
+      remoteProjectsStore.mergeDeviceSessions(d, 'MacBook', bots, 'archived');
+      remoteProjectsStore.markDeviceDisconnected(d);
+      invoke.mockImplementation(async (_device, channel, args) => {
+        if (channel === 'local-db:sessions:list') return [];
+        if (args[0] === 'missing') throw new Error('[NOT_FOUND] removed');
+        if (args[0] === 'timeout') throw new Error('[DEVICE_LINK_TIMEOUT] unavailable');
+        const bot = bots.find((row) => row.id === args[0])!;
+        return {
+          ...bot,
+          status: bot.id === 'deleted' ? 'deleted' : bot.id === 'restored' ? 'active' : 'archived',
+        };
+      });
+
+      await refreshRemoteDeviceSessions(d, 'MacBook', { status: 'archived', snapshotMode });
+
+      expect(remoteProjectsStore.getDeviceSessions(d, 'archived').map((row) => row.id)).toEqual([
+        'kept',
+        'timeout',
+      ]);
+      expect(remoteProjectsStore.getDeviceSessions(d, 'active').map((row) => row.id)).toEqual([
+        'restored',
+      ]);
+      expect(
+        remoteProjectsStore.getDeviceSessions(d).every((row) => row.model === 'gpt-6-astra'),
+      ).toBe(true);
+      expect(invoke).toHaveBeenCalledTimes(6);
+    },
+  );
+
+  it('keeps independent bounded probe rotation for active and archived companions', async () => {
+    const d = did();
+    const bots = ['active', 'archived'].flatMap((status) =>
+      Array.from({ length: 9 }, (_, i) =>
+        session(`${status}-${i}`, {
+          source: 'bot',
+          status: status as Session['status'],
+        }),
+      ),
+    );
+    for (const status of ['active', 'archived'] as const) {
+      remoteProjectsStore.mergeDeviceSessions(
+        d,
+        'MacBook',
+        bots.filter((row) => row.status === status),
+        status,
+      );
+    }
+    const probed: string[] = [];
+    invoke.mockImplementation(async (_device, channel, args) => {
+      if (channel === 'local-db:sessions:list') return [];
+      probed.push(args[0]);
+      return bots.find((row) => row.id === args[0]);
+    });
+    for (const status of ['active', 'archived', 'active', 'archived'] as const) {
+      const before = probed.length;
+      await refreshRemoteDeviceSessions(d, 'MacBook', { status });
+      expect(probed.length - before).toBe(8);
+    }
+    expect(new Set(probed).size).toBe(18);
+    expect(remoteProjectsStore.getDeviceSessions(d)).toHaveLength(18);
+  });
+
+  it('does not invalidate an archived detail probe when the active bucket refreshes', async () => {
+    const d = did();
+    const bot = session('archived-concurrent', { source: 'bot', status: 'archived' });
+    remoteProjectsStore.mergeDeviceSessions(d, 'MacBook', [bot], 'archived');
+    const detail = deferred<Session>();
+    invoke.mockImplementation(async (_device, channel) =>
+      channel === 'local-db:sessions:list' ? [] : detail.promise,
+    );
+    const refresh = refreshRemoteDeviceSessions(d, 'MacBook', { status: 'archived' });
+    await vi.waitFor(() => expect(invoke).toHaveBeenCalledTimes(2));
+    await refreshRemoteDeviceSessions(d, 'MacBook');
+    await refreshRemoteDeviceSessions(d, 'MacBook');
+    detail.resolve({ ...bot, status: 'deleted' });
+    await expect(refresh).resolves.toBe('ok');
+    expect(remoteProjectsStore.getDeviceSessions(d)).toEqual([]);
+  });
+
+  it('fences archived detail responses against disconnect and newer pushes', async () => {
+    const d = did();
+    const bot = session('archived-late', {
+      source: 'bot',
+      status: 'archived',
+      model: 'gpt-6-astra',
+    });
+    remoteProjectsStore.mergeDeviceSessions(d, 'MacBook', [bot], 'archived');
+    for (const change of ['push', 'disconnect'] as const) {
+      const detail = deferred<Session>();
+      invoke
+        .mockReset()
+        .mockImplementation(async (_device, channel) =>
+          channel === 'local-db:sessions:list' ? [] : detail.promise,
+        );
+      const refresh = refreshRemoteDeviceSessions(d, 'MacBook', { status: 'archived' });
+      await vi.waitFor(() => expect(invoke).toHaveBeenCalledTimes(2));
+      if (change === 'push') remoteProjectsStore.applyPatch(d, bot.id, { model: 'new-model' });
+      else remoteProjectsStore.markDeviceDisconnected(d);
+      detail.resolve({ ...bot, status: 'deleted' });
+      await expect(refresh).resolves.toBe(change === 'push' ? 'ok' : 'superseded');
+      expect(remoteProjectsStore.getDeviceSessions(d)[0]?.model).toBe('new-model');
+    }
+  });
+
+  it.each(['merge', 'replace'] as const)(
     '%s refresh preserves a remote companion omitted by the ordinary task list',
     async (snapshotMode) => {
       const d = did();

--- a/apps/desktop/src/renderer/__tests__/refreshRemoteSessionsRetry.test.ts
+++ b/apps/desktop/src/renderer/__tests__/refreshRemoteSessionsRetry.test.ts
@@ -114,6 +114,173 @@ describe('isTransientRemoteError', () => {
 });
 
 describe('refreshRemoteDeviceSessions retry', () => {
+  it.each(['merge', 'replace'] as const)(
+    '%s refresh preserves a remote companion omitted by the ordinary task list',
+    async (snapshotMode) => {
+      const d = did();
+      const bot = session('remote-lizi', {
+        source: 'bot',
+        model: 'gpt-6-astra',
+        agentKind: 'codex',
+        providerId: 'openai',
+      });
+      remoteProjectsStore.pinSessionOrigin(d, bot.id);
+      remoteProjectsStore.mergeDeviceSessions(d, 'MacBook', [bot, session('old-task')]);
+      invoke.mockImplementation(async (_device, channel, args) => {
+        if (channel === 'local-db:sessions:list') return [session('ordinary-task')];
+        if (channel === 'local-db:sessions:get' && args[0] === bot.id) return bot;
+        throw new Error(`Unexpected channel: ${channel}`);
+      });
+
+      for (let turn = 0; turn < 3; turn++) {
+        await expect(refreshRemoteDeviceSessions(d, 'MacBook', { snapshotMode })).resolves.toBe(
+          'ok',
+        );
+        const mirrored = remoteProjectsStore.getDeviceSessions(d).find((row) => row.id === bot.id);
+        expect(mirrored).toMatchObject({
+          model: 'gpt-6-astra',
+          agentKind: 'codex',
+          providerId: 'openai',
+          source: 'bot',
+          deviceLinkDeviceId: d,
+        });
+        expect(remoteProjectsStore.getSessionDeviceId(bot.id)).toBe(d);
+      }
+      expect(remoteProjectsStore.getDeviceSessions(d).some((row) => row.id === 'old-task')).toBe(
+        false,
+      );
+    },
+  );
+
+  it('preserves a busy companion and applies the host runtime model across an empty list refresh', async () => {
+    const d = did();
+    const bot = session('busy-companion', {
+      source: 'bot',
+      model: 'gpt-6-astra',
+      agentKind: 'codex',
+    });
+    remoteProjectsStore.mergeDeviceSessions(d, 'MacBook', [bot]);
+    applyRemoteSessionActivity(d, {
+      sessionId: bot.id,
+      phase: 'running',
+      compactDetail: 'generating',
+    });
+    const runtimeEffective = {
+      agentKind: 'codex' as const,
+      model: 'gpt-6-astra',
+      providerId: 'openai',
+      effort: 'high' as const,
+      fastMode: false,
+    };
+    invoke.mockImplementation(async (_device, channel) =>
+      channel === 'local-db:sessions:list' ? [] : { ...bot, runtimeEffective },
+    );
+
+    await refreshRemoteDeviceSessions(d);
+
+    expect(getRemoteSessionActivity(bot.id)?.phase).toBe('running');
+    expect(remoteProjectsStore.getDeviceSessions(d)[0]).toMatchObject({ runtimeEffective });
+    remoteProjectsStore.applyPatch(d, bot.id, { effort: 'high', listPreview: 'reply received' });
+    expect(remoteProjectsStore.getDeviceSessions(d)[0]).toMatchObject({
+      model: 'gpt-6-astra',
+      effort: 'high',
+      listPreview: 'reply received',
+    });
+  });
+
+  it('keeps the companion snapshot when its detail request times out, without retrying other peers', async () => {
+    const d = did();
+    const other = did();
+    const bot = session('offline-companion', { source: 'bot', model: 'gpt-6-astra' });
+    remoteProjectsStore.mergeDeviceSessions(d, 'MacBook', [bot]);
+    remoteProjectsStore.setDeviceSessions(other, 'Other Mac', [session('unaffected')]);
+    applyRemoteSessionActivity(d, {
+      sessionId: bot.id,
+      phase: 'running',
+      compactDetail: 'generating',
+    });
+    invoke.mockImplementation(async (device, channel) => {
+      expect(device).toBe(d);
+      if (channel === 'local-db:sessions:list') return [];
+      throw new Error('[DEVICE_LINK_TIMEOUT] detail timed out');
+    });
+
+    await expect(refreshRemoteDeviceSessions(d)).resolves.toBe('ok');
+
+    expect(invoke).toHaveBeenCalledTimes(2);
+    expect(remoteProjectsStore.getDeviceSessions(d)[0]?.model).toBe('gpt-6-astra');
+    expect(getRemoteSessionActivity(bot.id)?.phase).toBe('running');
+    expect(remoteProjectsStore.getDeviceSessions(other)[0]?.deviceLinkConnectionStatus).toBe(
+      'connected',
+    );
+  });
+
+  it.each(['deleted', 'archived', 'missing'] as const)(
+    'reconciles a companion that became %s while disconnected',
+    async (terminal) => {
+      const d = did();
+      const bot = session('retired-companion', { source: 'bot' });
+      remoteProjectsStore.mergeDeviceSessions(d, 'MacBook', [bot]);
+      remoteProjectsStore.markDeviceDisconnected(d);
+      applyRemoteSessionActivity(d, {
+        sessionId: bot.id,
+        phase: 'running',
+        compactDetail: 'generating',
+      });
+      invoke.mockImplementation(async (_device, channel) => {
+        if (channel === 'local-db:sessions:list') return [];
+        if (terminal === 'missing') throw new Error('[NOT_FOUND] session missing');
+        return { ...bot, status: terminal };
+      });
+
+      await refreshRemoteDeviceSessions(d, 'MacBook', { snapshotMode: 'replace' });
+
+      expect(getRemoteSessionActivity(bot.id)).toBeUndefined();
+      expect(remoteProjectsStore.getDeviceSessions(d, 'active')).toHaveLength(0);
+      expect(remoteProjectsStore.getDeviceSessions(d)).toHaveLength(
+        terminal === 'archived' ? 1 : 0,
+      );
+    },
+  );
+
+  it('does not revive or modify a companion from a late detail response after disconnect', async () => {
+    const d = did();
+    const bot = session('late-companion', { source: 'bot', model: 'gpt-6-astra' });
+    const detail = deferred<Session>();
+    remoteProjectsStore.mergeDeviceSessions(d, 'MacBook', [bot]);
+    invoke.mockImplementation(async (_device, channel) =>
+      channel === 'local-db:sessions:list' ? [] : detail.promise,
+    );
+    const refresh = refreshRemoteDeviceSessions(d);
+    await vi.waitFor(() => expect(invoke).toHaveBeenCalledTimes(2));
+    remoteProjectsStore.markDeviceDisconnected(d);
+    detail.resolve({ ...bot, model: 'stale-model' });
+    await expect(refresh).resolves.toBe('superseded');
+    expect(remoteProjectsStore.getDeviceSessions(d)[0]).toMatchObject({
+      model: 'gpt-6-astra',
+      deviceLinkConnectionStatus: 'disconnected',
+    });
+  });
+
+  it('does not overwrite a live model switch with an older companion detail response', async () => {
+    const d = did();
+    const bot = session('switching-companion', { source: 'bot', model: 'old-model' });
+    const detail = deferred<Session>();
+    remoteProjectsStore.mergeDeviceSessions(d, 'MacBook', [bot]);
+    invoke.mockImplementation(async (_device, channel) =>
+      channel === 'local-db:sessions:list' ? [] : detail.promise,
+    );
+    const refresh = refreshRemoteDeviceSessions(d);
+    await vi.waitFor(() => expect(invoke).toHaveBeenCalledTimes(2));
+    remoteProjectsStore.applyPatch(d, bot.id, { model: 'gpt-6-astra', agentKind: 'codex' });
+    detail.resolve(bot);
+    await refresh;
+    expect(remoteProjectsStore.getDeviceSessions(d)[0]).toMatchObject({
+      model: 'gpt-6-astra',
+      agentKind: 'codex',
+    });
+  });
+
   it('被控端 DB 未就绪:重试两次后成功 → 会话出现在控制端', async () => {
     const d = did();
     invoke

--- a/apps/desktop/src/renderer/features/device-link/refreshRemoteSessions.ts
+++ b/apps/desktop/src/renderer/features/device-link/refreshRemoteSessions.ts
@@ -337,6 +337,9 @@ async function probeMissingSessionStatuses(
   if (queue.length === 0) return;
   const count = Math.min(MISSING_STATUS_PROBE_LIMIT, queue.length);
   const candidates = queue.slice(0, count);
+  const snapshots = new Map(
+    remoteProjectsStore.getDeviceSessions(deviceId).map((session) => [session.id, session]),
+  );
   const results = await Promise.all(
     candidates.map(async (sessionId) => {
       try {
@@ -355,6 +358,12 @@ async function probeMissingSessionStatuses(
   if (!remoteProjectsStore.isLatestSnapshotEpoch(deviceId, epoch, 'active')) return;
   const terminalIds = new Set<string>();
   for (const result of results) {
+    // A live push accepted while this GET was in flight is newer than its
+    // snapshot. Do not roll its model/status back; the next tick can reconcile.
+    const current = remoteProjectsStore
+      .getDeviceSessions(deviceId)
+      .find((session) => session.id === result.sessionId);
+    if (current !== snapshots.get(result.sessionId)) continue;
     if (result.errorCode === 'NOT_FOUND') {
       terminalIds.add(result.sessionId);
       remoteProjectsStore.applyPatch(deviceId, result.sessionId, { status: 'deleted' });
@@ -423,22 +432,30 @@ async function runRefreshRemoteDeviceSessions(
         if (!remoteProjectsStore.isLatestSnapshotEpoch(deviceId, epoch, status))
           return 'superseded';
         const sessions = parseRemoteSessionList(value, status);
+        // Companions are fetched by resource:get + sessions:get, not by the
+        // ordinary task list. Keep their live state and reconcile them by id,
+        // even when the ordinary list is empty or is a full replacement.
+        const incomingIds = new Set(sessions.map((session) => session.id));
+        const missingSessions = remoteProjectsStore
+          .getDeviceSessions(deviceId, status)
+          .filter((session) => !incomingIds.has(session.id));
+        const missingCompanionIds = missingSessions
+          .filter((session) => session.source === 'bot')
+          .map((session) => session.id);
         if ((opts.snapshotMode ?? 'merge') === 'merge') {
-          const incomingIds = new Set(sessions.map((session) => session.id));
-          const missingSessionIds = remoteProjectsStore
-            .getDeviceSessions(deviceId, status)
-            .filter((session) => !incomingIds.has(session.id))
-            .map((session) => session.id);
+          const missingSessionIds = missingSessions.map((session) => session.id);
           // archived 使用与本地侧栏一致的 1000 条产品窗口，可直接替换并清掉断线期间的
           // 删除 / 取消归档陈旧行；active 仍保持 200 条轻量窗口，满窗时有界补查缺席缓存。
           if (status === 'archived' || sessions.length < LIST_LIMIT) {
             if (status === 'active') {
-              missingStatusProbeQueues.delete(deviceId);
-              for (const sessionId of missingSessionIds) {
-                removeRemoteSessionActivityEntry(sessionId);
+              for (const session of missingSessions) {
+                if (session.source !== 'bot') removeRemoteSessionActivityEntry(session.id);
               }
             }
             remoteProjectsStore.setDeviceSessions(deviceId, deviceName, sessions, status);
+            if (status === 'active') {
+              await probeMissingSessionStatuses(deviceId, epoch, missingCompanionIds);
+            }
           } else {
             remoteProjectsStore.mergeDeviceSessions(deviceId, deviceName, sessions, status);
             if (status === 'active') {
@@ -447,6 +464,9 @@ async function runRefreshRemoteDeviceSessions(
           }
         } else {
           remoteProjectsStore.setDeviceSessions(deviceId, deviceName, sessions, status);
+          if (status === 'active') {
+            await probeMissingSessionStatuses(deviceId, epoch, missingCompanionIds);
+          }
         }
       }
       if (opts.scope === 'schedule' || opts.scope === 'both') {
@@ -477,7 +497,9 @@ async function runRefreshRemoteDeviceSessions(
           log.debug('remote schedule index unavailable');
         }
       }
-      return 'ok'; // 成功
+      return remoteProjectsStore.isLatestSnapshotEpoch(deviceId, epoch, status)
+        ? 'ok'
+        : 'superseded';
     } catch (err) {
       if (!remoteProjectsStore.isLatestSnapshotEpoch(deviceId, epoch, status)) {
         return 'superseded';

--- a/apps/desktop/src/renderer/features/device-link/refreshRemoteSessions.ts
+++ b/apps/desktop/src/renderer/features/device-link/refreshRemoteSessions.ts
@@ -237,22 +237,22 @@ function refreshTaskKey(deviceId: string, status: RemoteSessionStatus): string {
 }
 
 /**
- * 满窗口缺席行的轮询队列(per-device)。不能用 snapshot epoch 推导数组下标：前一轮
+ * 满窗口缺席行的轮询队列(per-device + status)。不能用 snapshot epoch 推导数组下标：前一轮
  * 确认终态并移除候选后，数组会收缩，重算下标会跳过紧邻项。队列在每轮开始时与当前
  * missing ids 对账，保留旧轮询顺序、移除已不缺席项，并把新缺席项追加到队尾。
  */
 const missingStatusProbeQueues = new Map<string, string[]>();
 
 function reconcileMissingStatusProbeQueue(
-  deviceId: string,
+  queueKey: string,
   missingSessionIds: readonly string[],
 ): string[] {
   if (missingSessionIds.length === 0) {
-    missingStatusProbeQueues.delete(deviceId);
+    missingStatusProbeQueues.delete(queueKey);
     return [];
   }
   const missingIds = new Set(missingSessionIds);
-  const previous = missingStatusProbeQueues.get(deviceId) ?? [];
+  const previous = missingStatusProbeQueues.get(queueKey) ?? [];
   const queuedIds = new Set<string>();
   const queue: string[] = [];
   for (const sessionId of previous) {
@@ -265,7 +265,7 @@ function reconcileMissingStatusProbeQueue(
     queuedIds.add(sessionId);
     queue.push(sessionId);
   }
-  missingStatusProbeQueues.set(deviceId, queue);
+  missingStatusProbeQueues.set(queueKey, queue);
   return queue;
 }
 
@@ -332,8 +332,10 @@ async function probeMissingSessionStatuses(
   deviceId: string,
   epoch: number,
   missingSessionIds: readonly string[],
+  status: RemoteSessionStatus,
 ): Promise<void> {
-  const queue = reconcileMissingStatusProbeQueue(deviceId, missingSessionIds);
+  const queueKey = refreshTaskKey(deviceId, status);
+  const queue = reconcileMissingStatusProbeQueue(queueKey, missingSessionIds);
   if (queue.length === 0) return;
   const count = Math.min(MISSING_STATUS_PROBE_LIMIT, queue.length);
   const candidates = queue.slice(0, count);
@@ -355,7 +357,7 @@ async function probeMissingSessionStatuses(
     }),
   );
   // 更强的 refresh / remove / disconnect 已使本轮失效时，不应用迟到的补查结果。
-  if (!remoteProjectsStore.isLatestSnapshotEpoch(deviceId, epoch, 'active')) return;
+  if (!remoteProjectsStore.isLatestSnapshotEpoch(deviceId, epoch, status)) return;
   const terminalIds = new Set<string>();
   for (const result of results) {
     // A live push accepted while this GET was in flight is newer than its
@@ -373,7 +375,7 @@ async function probeMissingSessionStatuses(
     if (!result.value || typeof result.value !== 'object') continue;
     const session = result.value as Partial<Session>;
     if (session.id !== result.sessionId) continue;
-    if (session.status === 'archived' || session.status === 'deleted') {
+    if (session.status === 'deleted' || (status === 'active' && session.status === 'archived')) {
       terminalIds.add(result.sessionId);
       remoteProjectsStore.applyPatch(deviceId, result.sessionId, {
         status: session.status,
@@ -382,8 +384,9 @@ async function probeMissingSessionStatuses(
       removeRemoteSessionActivityEntry(result.sessionId);
       continue;
     }
-    // sessions:get 返回窗口外 active 行时同样是权威快照，回填 title / pinnedAt / model 等
+    // sessions:get 返回缺席行时同样是权威快照，回填 title / pinnedAt / model 等
     // 元数据；否则丢失 patched push 后会永久保留旧字段。
+    if (session.status !== status) terminalIds.add(result.sessionId);
     remoteProjectsStore.applyPatch(deviceId, result.sessionId, { ...session });
   }
   const nextQueue = [
@@ -391,9 +394,9 @@ async function probeMissingSessionStatuses(
     ...candidates.filter((sessionId) => !terminalIds.has(sessionId)),
   ];
   if (nextQueue.length === 0) {
-    missingStatusProbeQueues.delete(deviceId);
+    missingStatusProbeQueues.delete(queueKey);
   } else {
-    missingStatusProbeQueues.set(deviceId, nextQueue);
+    missingStatusProbeQueues.set(queueKey, nextQueue);
   }
 }
 
@@ -453,20 +456,16 @@ async function runRefreshRemoteDeviceSessions(
               }
             }
             remoteProjectsStore.setDeviceSessions(deviceId, deviceName, sessions, status);
-            if (status === 'active') {
-              await probeMissingSessionStatuses(deviceId, epoch, missingCompanionIds);
-            }
+            await probeMissingSessionStatuses(deviceId, epoch, missingCompanionIds, status);
           } else {
             remoteProjectsStore.mergeDeviceSessions(deviceId, deviceName, sessions, status);
             if (status === 'active') {
-              await probeMissingSessionStatuses(deviceId, epoch, missingSessionIds);
+              await probeMissingSessionStatuses(deviceId, epoch, missingSessionIds, status);
             }
           }
         } else {
           remoteProjectsStore.setDeviceSessions(deviceId, deviceName, sessions, status);
-          if (status === 'active') {
-            await probeMissingSessionStatuses(deviceId, epoch, missingCompanionIds);
-          }
+          await probeMissingSessionStatuses(deviceId, epoch, missingCompanionIds, status);
         }
       }
       if (opts.scope === 'schedule' || opts.scope === 'both') {

--- a/apps/desktop/src/renderer/features/device-link/remoteProjectsStore.ts
+++ b/apps/desktop/src/renderer/features/device-link/remoteProjectsStore.ts
@@ -447,7 +447,13 @@ const actions = {
     const incomingIds = new Set(stamped.map((session) => session.id));
     const preserved =
       existing?.sessions
-        .filter((session) => session.status !== status && !incomingIds.has(session.id))
+        // The ordinary sessions:list excludes companions. Absence from that
+        // snapshot cannot retire a companion loaded through its resource link.
+        // Its own authoritative patch/get still controls status and deletion.
+        .filter(
+          (session) =>
+            (session.status !== status || session.source === 'bot') && !incomingIds.has(session.id),
+        )
         .map((session) =>
           session.deviceLinkDeviceName === deviceName &&
           session.deviceLinkConnectionStatus === connectionStatus

--- a/apps/desktop/src/renderer/features/device-link/selectedMachineStore.ts
+++ b/apps/desktop/src/renderer/features/device-link/selectedMachineStore.ts
@@ -205,10 +205,13 @@ export function selectVisibleSessions(
   remoteSessions: Session[],
   selection: MachineSelection,
 ): Session[] {
-  if (selection === MACHINE_ALL) return [...localSessions, ...remoteSessions];
+  // Companion metadata remains in the mirror for chat, but belongs only to the Bots UI.
+  const visibleLocal = localSessions.filter((session) => session.source !== 'bot');
+  const visibleRemote = remoteSessions.filter((session) => session.source !== 'bot');
+  if (selection === MACHINE_ALL) return [...visibleLocal, ...visibleRemote];
   const set = new Set(selection);
-  const out = set.has(MACHINE_LOCAL) ? [...localSessions] : [];
-  for (const s of remoteSessions) {
+  const out = set.has(MACHINE_LOCAL) ? [...visibleLocal] : [];
+  for (const s of visibleRemote) {
     if (s.deviceLinkDeviceId && set.has(s.deviceLinkDeviceId)) out.push(s);
   }
   return out;

--- a/apps/desktop/src/renderer/lib/__tests__/conversationSearchFanout.test.ts
+++ b/apps/desktop/src/renderer/lib/__tests__/conversationSearchFanout.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it, vi } from 'vitest';
+import { afterEach, describe, expect, it, vi } from 'vitest';
 
 import type { Session } from '@/lib/ccAgent.types';
 import {
@@ -16,12 +16,13 @@ import {
   shouldReleaseConversationSearchLock,
   stampRemoteSearchResponse,
 } from '@/lib/conversationSearchFanout';
-import { searchConversationsAcrossOrigins } from '@/lib/conversationSearchService';
+import { searchConversations, searchConversationsAcrossOrigins } from '@/lib/conversationSearchService';
 import type {
   ConversationSearchRequest,
   ConversationSearchResponse,
   ConversationSearchResultItem,
 } from '../../../shared/conversationSearch';
+import { remoteProjectsStore } from '@/features/device-link/remoteProjectsStore';
 import { MACHINE_ALL, MACHINE_LOCAL } from '@/features/device-link/selectedMachineStore';
 
 function session(partial: Partial<Session> & Pick<Session, 'id' | 'title'>): Session {
@@ -300,6 +301,23 @@ describe('merge and stamp', () => {
 });
 
 describe('searchCachedSessionsByTitle', () => {
+  it('excludes active and archived companions before ranking and limiting title matches', () => {
+    const rows = [
+      session({ id: 'bot-active', title: 'needle', source: 'bot' }),
+      session({ id: 'bot-archived', title: 'needle', source: 'bot', status: 'archived' }),
+      session({ id: 'ordinary', title: 'Needle planning', source: 'desktop' }),
+      session({ id: 'legacy', title: 'Needle notes' }),
+    ];
+    const page = searchCachedSessionsByTitle(rows, { query: 'needle', limit: 2 });
+    expect(page.results.map((item) => item.session.id).sort()).toEqual(['legacy', 'ordinary']);
+    expect(
+      searchCachedSessionsByTitle(rows, {
+        query: 'needle',
+        filters: { sessionIds: ['bot-active', 'bot-archived'] },
+      }).results,
+    ).toEqual([]);
+  });
+
   it('matches visible titles and skips workers', () => {
     const request: ConversationSearchRequest = { query: 'remote', limit: 10 };
     const page = searchCachedSessionsByTitle(
@@ -318,6 +336,79 @@ describe('searchCachedSessionsByTitle', () => {
     expect(page.results.map((item) => item.session.id)).toEqual(['hit']);
     expect(page.results[0]?.matchKind).toBe('title');
   });
+});
+
+describe('ordinary search against a retained remote companion mirror', () => {
+  afterEach(() => {
+    remoteProjectsStore.clear();
+    vi.unstubAllGlobals();
+  });
+
+  it.each(['offline', 'disconnect', 'timeout', 'legacy-list', 'legacy-cache'] as const)(
+    'hides companion titles on %s fallback while preserving their model metadata',
+    async (mode) => {
+      const deviceId = 'companion-search-host';
+      const bot = session({
+        id: 'bot-active',
+        title: 'needle',
+        source: 'bot',
+        model: 'gpt-6-astra',
+        agentKind: 'codex',
+      });
+      const archivedBot = { ...bot, id: 'bot-archived', status: 'archived' as const };
+      const ordinary = session({ id: 'ordinary', title: 'Needle planning', source: 'desktop' });
+      remoteProjectsStore.pinSessionOrigin(deviceId, bot.id);
+      remoteProjectsStore.mergeDeviceSessions(deviceId, 'MacBook', [bot, ordinary]);
+      remoteProjectsStore.mergeDeviceSessions(deviceId, 'MacBook', [archivedBot], 'archived');
+      // An ordinary list excludes companions; their chat metadata survives its refresh.
+      remoteProjectsStore.setDeviceSessions(deviceId, 'MacBook', [ordinary]);
+      remoteProjectsStore.markDeviceDisconnected(deviceId);
+      const snapshot = remoteProjectsStore.getDeviceSessions(deviceId);
+      const invoke = vi.fn(async (_device, channel) => {
+        if (mode === 'disconnect') throw new Error('[DEVICE_LINK_NOT_CONNECTED] closed');
+        if (mode === 'timeout') throw new Error('[DEVICE_LINK_TIMEOUT] unavailable');
+        if (channel === 'local-db:conversations:search')
+          throw new Error('[DEVICE_LINK_CHANNEL_NOT_ALLOWED] unsupported');
+        if (mode === 'legacy-list') return [bot, archivedBot, ordinary];
+        throw new Error('[DEVICE_LINK_TIMEOUT] list unavailable');
+      });
+      vi.stubGlobal('window', { electronAPI: { deviceLink: { invoke } } });
+      const page = await searchConversations(
+        { query: 'needle', limit: 1 },
+        {
+          origins: [
+            {
+              kind: 'remote',
+              deviceId,
+              deviceName: 'MacBook',
+              connected: mode !== 'offline',
+              sessionIds: null,
+            },
+          ],
+        },
+      );
+      expect(page.results.map((item) => item.session.id)).toEqual(['ordinary']);
+      expect(page.remoteResults?.map((item) => item.session.id)).toEqual(['ordinary']);
+      expect(page.results[0]?.session.deviceLinkDeviceId).toBe(deviceId);
+      expect(invoke).toHaveBeenCalledTimes(
+        mode === 'offline' ? 0 : mode.startsWith('legacy') ? 2 : 1,
+      );
+      expect(remoteProjectsStore.getDeviceSessions(deviceId)).toBe(snapshot);
+      expect(snapshot.filter((row) => row.source === 'bot')).toEqual(
+        expect.arrayContaining(
+          [bot, archivedBot].map((row) =>
+            expect.objectContaining({
+              id: row.id,
+              status: row.status,
+              model: 'gpt-6-astra',
+              agentKind: 'codex',
+              deviceLinkDeviceId: deviceId,
+            }),
+          ),
+        ),
+      );
+    },
+  );
 });
 
 describe('searchConversationsAcrossOrigins', () => {

--- a/apps/desktop/src/renderer/lib/conversationSearchFanout.ts
+++ b/apps/desktop/src/renderer/lib/conversationSearchFanout.ts
@@ -320,7 +320,8 @@ export function searchCachedSessionsByTitle(
   }> = [];
 
   sessions.forEach((session, index) => {
-    if (isOrcaWorkerSession(session)) return;
+    // The mirror includes companion chat metadata; ordinary search must not expose it.
+    if (session.source === 'bot' || isOrcaWorkerSession(session)) return;
     if (allowed && !allowed.has(session.id)) return;
     if (!matchesWorkingDirSet(session.workingDir, workingDirs)) return;
     if (!matchesStatus(session.status, filters.status ?? 'all')) return;


### PR DESCRIPTION
## 这次改了什么

### 摘要

远程伙伴的任务由伙伴资源入口单独加载，普通任务列表按设计不返回 `source=bot`。原来的列表刷新会把这些缺席的伙伴任务从远端镜像移除，导致正在打开的对话失去模型、工作目录和运行状态，模型栏回退到控制端默认模型。

现在普通列表刷新保留伙伴任务，并复用已有的有界详情补查来确认远端真实状态。active 与 archived 按设备和状态分别轮询，断线期间删除、永久删除或取消归档仍能收敛；迟到的详情响应不能覆盖较新的模型推送或恢复已断开的设备状态。普通任务侧栏在所有机器筛选方式下排除 source=bot，离线及旧版回退标题搜索也在排序和截断前排除伙伴任务，同时保留伙伴聊天需要的镜像元数据。

### 变更类型

- [x] `fix` 缺陷修复

### 范围

- 关联 Issue / 需求：远程伙伴设置 GPT-6，对话后模型栏变成 Fable，并伴随发送异常的用户反馈。
- 本 PR 包含：远程任务镜像保留、active/archived 伙伴详情状态补查、并发响应保护、普通侧栏伙伴过滤及回归测试。
- 明确不包含：快捷键偏好修改、模型目录变更、服务端协议修改、正式版发布。
- 用户可见变化：普通任务列表刷新后，远程伙伴保留原模型与对话所需信息。
- 是否存在 breaking change：无。

### UI 变化

- 无布局、样式、文案或快捷键规则变化；修复现有模型栏与对话的数据来源。
- 引用的设计规范：不涉及：只修改远程状态存储与刷新逻辑，沿用现有组件和交互。

## 怎么验证的

### 自动验证

```text
修改前：新增 merge/replace 回归用例均失败，伙伴任务被清除。
修改后：
pnpm test:unit:related
PASS apps/desktop unit (116.7s)

pnpm --filter desktop run typecheck
退出码 0

remoteProjectsStore + refreshRemoteSessionsRetry 定向套件
105 tests passed

git diff --check
退出码 0
```

新增用例覆盖连续刷新、空普通列表、生成中状态、详情超时、另一设备不受影响、断线期间删除/归档/NOT_FOUND、断线后的迟到详情和模型切换后的迟到详情。伙伴入口、输入框快捷键、生成中发送的相关定向测试也通过。

本轮审查修复验证：修复前 8 项新增回归失败；修复后 3 个定向套件共 173 项通过。覆盖永久删除/NOT_FOUND、保留有效归档与超时快照、取消归档、状态桶独立轮询与 8 条上限、跨桶并发、断线/新推送防倒灌，以及全部/本机/远程/多选侧栏过滤。本轮最终根 `pnpm test:unit:related` 为 PASS apps/desktop unit (58.6s)，Desktop typecheck 退出码 0；提交 `54ae16f30dcec5a1bd471b2fb3774f8e0198d6ee`，DCO 作者/提交者 ficowang <fico@xd.com>。


离线搜索审查修复（9ce8350c61f92b032aea55acef986283b759984c）：新增 6 项回归修复前全部失败；修复后标题搜索、侧栏筛选/排序与伙伴入口 4 个定向套件共 106 项通过，Desktop typecheck 退出码 0，根 pnpm test:unit:related 为 PASS apps/desktop unit (55.8s)。覆盖离线、断线、超时、旧版列表/缓存回退；伙伴元数据不被修改，普通与缺 source 的历史任务仍可搜索。

### 手工验证

macOS arm64，中国大陆版隔离 Desktop dev，分支 `fix/remote-companion-model-send`。实际 GPT-6-Astra 连续完成两轮回复：Shift+Enter 保留换行，Enter 提交后收到预期回复，第二轮点击发送按钮也收到预期回复，两轮回复后模型栏仍为 GPT-6-Astra。

这是本机真实输入框/模型调用验证；远程刷新场景通过真实 store/refresh 逻辑配合模拟传输回归验证。

### 未执行的验证

未完成两台实体机器间的登录、连接和多轮对话验证：隔离 dev 尚未登录 Cindy 账号，当前没有 MacBook 的可用执行通道。未将本修复替换进用户已安装的正式 App。回车问题尚未在远程实体环境独立复现，不将本机输入框测试表述为远程问题已完全验收。


补充构建验证：执行 `pnpm release:package --platform darwin --arch arm64 --region cn --no-sign`，在 prePackage 的 iOS Simulator helper 构建阶段失败。本机仅安装 CommandLineTools，缺少完整 Xcode 的 SimulatorKit.framework，尚未生成安装包，未运行 packaged smoke。此前源码相关单测、类型检查和隔离开发版真实模型对话验证均通过。

## 风险

### 风险分类

- [x] 其他：普通列表刷新后对缺席伙伴复用每个设备/状态桶每轮最多 8 条的详情补查，增加少量有界远程读取。

### 远程适配与故障范围

- 本次修复的是 Desktop device-link 控制端的内存镜像和普通侧栏投影；SSH 工作目录执行、手机版资源入口及 wire protocol 沿用既有实现。
- 触发条件为单个设备列表缺席或详情读取失败；恢复只补查该设备、该状态桶中最多 8 条任务，不重连 relay，不修改调度或 ACK。
- 现有超时回归验证一台设备的详情失败不会修改另一设备的连接状态。此次没有链路重试/断链/ACK 变更，未新增或宣称完成两个实体控制端共享被控端的实机测试。

### 影响与回滚

- 影响范围：Desktop device-link 任务镜像及缺席任务对账。普通任务仍按原列表窗口清理；伙伴以详情或推送确认删除/归档。
- 回滚 / 降级方式：撤销本 PR，无数据库、凭证、协议和持久化迁移。

### 提交前检查

- [x] 已 review 完整 diff
- [x] 每个 commit 都带 DCO 签名（`git commit -s`）
- [x] UI 改动已在「UI 变化」注明引用的设计规范章节（不涉及 UI 则跳过）
- [x] 未提交凭证、令牌或授权文件
- [x] 已补充必要文档
- [x] 已确认测试结果或说明未执行原因
