### PR TITLE
fix(mobile): 协商历史投影能力并兼容旧桌面消息读取

### DIFF
--- a/apps/desktop/src/main/device-link/__tests__/dispatchWeakNetwork.test.ts
+++ b/apps/desktop/src/main/device-link/__tests__/dispatchWeakNetwork.test.ts
@@ -14,6 +14,7 @@ import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import {
   DeviceLinkClient,
   DeviceLinkError,
+  DEVICE_LINK_CAPABILITY_HISTORY_VIEW_V1,
   DL_SUBSCRIBE_CHANNEL,
   INVOKE_TIMEOUT_OVERRIDES_MS,
   PROTOCOL_VERSION,
@@ -234,6 +235,15 @@ afterEach(() => {
 });
 
 describe('[1] link-accept 发送失败的有限重试', () => {
+  it('declares history projection support in the host accept, including for legacy controllers', () => {
+    const client = mkClient();
+    __testing.setActiveClient(client as never);
+    __testing.handleLinkOpen(client as never, 'ctrl-a', 'open-1', undefined);
+    expect(client.sendLinkAccept).toHaveBeenCalledWith('ctrl-a', 'open-1', expect.objectContaining({
+      capabilities: expect.arrayContaining([DEVICE_LINK_CAPABILITY_HISTORY_VIEW_V1]),
+    }));
+  });
+
   it('背压首发失败 → 不提交订阅;500ms 重试成功后才提交', () => {
     const sendLinkAccept = vi.fn().mockImplementationOnce(() => {
       throw backpressure();

--- a/apps/desktop/src/main/device-link/dispatch.ts
+++ b/apps/desktop/src/main/device-link/dispatch.ts
@@ -43,6 +43,7 @@ import {
   CONTROLLER_CAPABILITY_MAKER_EVENT_BATCH_V1,
   CONTROLLER_CAPABILITY_SESSION_TEXT_SNAPSHOT_V1,
   DEVICE_LINK_CAPABILITY_COMPACT_MESSAGE_HISTORY_V1,
+  DEVICE_LINK_CAPABILITY_HISTORY_VIEW_V1,
   byteLength,
   DeviceLinkError,
   parseFsWatchTopic,
@@ -2275,6 +2276,7 @@ function handleLinkOpen(
     client.sendLinkAccept(src, requestId, {
       appVersion: app.getVersion(),
       allowlistHash: computeAllowlistHash(),
+      capabilities: [DEVICE_LINK_CAPABILITY_HISTORY_VIEW_V1],
     });
   } catch (err) {
     // 背压等瞬时失败:短退避重试(见 LINK_ACCEPT_RETRY_DELAYS_MS 注释),

--- a/apps/desktop/src/renderer/__tests__/modelVisibilityPrefs.test.ts
+++ b/apps/desktop/src/renderer/__tests__/modelVisibilityPrefs.test.ts
@@ -35,6 +35,29 @@ class MemLocalStorage {
   }
 }
 
+// Model Chromium's Web Locks explicitly. The Node test runner may also expose
+// navigator.locks; that native implementation is not the renderer environment.
+class Locks {
+  chains = new Map<string, Promise<unknown>>();
+  request<T>(key: string, run: () => T | Promise<T>): Promise<T> {
+    const next = (this.chains.get(key) ?? Promise.resolve()).then(run);
+    this.chains.set(key, next.catch(() => undefined));
+    return next;
+  }
+  hold(key = 'xdt:modelVisibilityPrefs:v1.initialization.owner.owner-a'): () => void {
+    let release!: () => void;
+    const held = new Promise<void>((resolve) => { release = resolve; });
+    void this.request(key, () => held);
+    return release;
+  }
+  async settle(): Promise<void> {
+    for (let i = 0; i < 5; i += 1) {
+      await Promise.all([...this.chains.values()]);
+      await Promise.resolve();
+    }
+  }
+}
+
 let memStorage: MemLocalStorage;
 const syncModelVisibility = vi.fn(async () => undefined);
 const logToMain = vi.fn();
@@ -69,6 +92,7 @@ function setOwnerClaim(
 
 beforeEach(() => {
   memStorage = new MemLocalStorage();
+  vi.stubGlobal('navigator', { locks: new Locks() });
   syncModelVisibility.mockClear();
   logToMain.mockClear();
   setOwnerClaim('owner-a', 1);
@@ -250,26 +274,6 @@ describe('model visibility across renderer windows', () => {
 
   // Shared queue models Chromium's cross-renderer Web Locks. Separate module instances
   // share storage and the lock manager, but each retains its own owner/cache state.
-  class Locks {
-    chains = new Map<string, Promise<unknown>>();
-    request<T>(key: string, run: () => T | Promise<T>): Promise<T> {
-      const next = (this.chains.get(key) ?? Promise.resolve()).then(run);
-      this.chains.set(key, next.catch(() => undefined));
-      return next;
-    }
-    hold(key = initKey): () => void {
-      let release!: () => void;
-      const held = new Promise<void>((resolve) => { release = resolve; });
-      void this.request(key, () => held);
-      return release;
-    }
-    async settle(): Promise<void> {
-      for (let i = 0; i < 5; i += 1) {
-        await Promise.all([...this.chains.values()]);
-        await Promise.resolve();
-      }
-    }
-  }
   let locks: Locks;
   let handlers: Array<(event: StorageEvent) => void>;
 

--- a/apps/mobile/src/__tests__/historyViewCapability.test.ts
+++ b/apps/mobile/src/__tests__/historyViewCapability.test.ts
@@ -1,0 +1,79 @@
+import { describe, expect, it, vi } from 'vitest';
+import { DeviceLinkError, DEVICE_LINK_CAPABILITY_HISTORY_VIEW_V1, type LinkAcceptPayload } from '@cindy/device-link';
+import { HistoryViewController, isHistoryViewUnavailable, projectHistoryView } from '@cindy/maker-shared/message-window';
+import { invokeWithHistoryViewCapability } from '../device-link/historyViewCapability';
+import { createMobileMakerTransport, type RemoteInvoke } from '../device-link/mobileMakerTransport';
+import type { RemoteMessage } from '../session/types';
+
+const message: RemoteMessage = { id: 'm', clientId: 'm', sessionId: 's', role: 'assistant',
+  content: 'saved answer', createdAt: '2026-09-10T00:00:00Z', toolUseId: null, agentMeta: null };
+const page = { version: 1 as const, items: projectHistoryView([message], false), hasMore: false, nextCursor: null };
+const accepted = (capabilities?: string[]): LinkAcceptPayload => ({ appVersion: 'test', allowlistHash: 'test', capabilities });
+
+describe('history capability negotiation', () => {
+  it.each([undefined, [], ['unrelated-capability']])('falls back on old hosts with capabilities %j and still loads older messages', async (capabilities) => {
+    const open = vi.fn(async () => accepted(capabilities));
+    const wire = vi.fn<RemoteInvoke>(async (_device, channel) => {
+      if (channel === 'local-db:messages:list') return [message] as never;
+      throw new Error('unsupported channel reached old host');
+    });
+    const maker = createMobileMakerTransport({ deviceId: 'd',
+      invoke: <T,>(device: string, channel: string, args?: unknown[]) =>
+        invokeWithHistoryViewCapability(channel, open, () => wire(device, channel, args) as Promise<T>),
+    });
+    const view = new HistoryViewController<RemoteMessage>({
+      page: before => maker.readHistoryView('s', before),
+      details: (ref, after) => maker.readWorkDetails('s', ref, after),
+      expanded: refs => maker.setHistoryExpanded('s', refs),
+    });
+    await view.refresh();
+    expect(isHistoryViewUnavailable(view.getSnapshot().error)).toBe(true);
+    expect(view.getSnapshot()).toMatchObject({ ready: false, loading: false });
+    expect(wire).not.toHaveBeenCalled();
+    expect(await maker.listMessages('s', { limit: 20 })).toEqual([message]);
+    expect(await maker.listMessages('s', { limit: 20, before: 'older' })).toEqual([message]);
+    expect(open).toHaveBeenCalledTimes(1);
+    await expect(maker.setHistoryExpanded('s', [])).rejects.toThrow('CHANNEL_NOT_ALLOWED');
+    view.setNetworkAvailable(false);
+    view.setActive(false);
+  });
+
+  it.each(['local-db:messages:view', 'local-db:messages:work-details', 'local-db:messages:view-intent'])(
+    'waits for the host handshake before sending %s', async (channel) => {
+      let resolve!: (value: LinkAcceptPayload) => void;
+      const open = vi.fn(() => new Promise<LinkAcceptPayload>(done => { resolve = done; }));
+      const wire = vi.fn(async () => page);
+      const pending = invokeWithHistoryViewCapability(channel, open, wire);
+      expect(wire).not.toHaveBeenCalled();
+      resolve(accepted([DEVICE_LINK_CAPABILITY_HISTORY_VIEW_V1]));
+      expect(await pending).toBe(page);
+      expect(wire).toHaveBeenCalledTimes(1);
+    },
+  );
+
+  it('retires cached projection on downgrade, preserves it on transient failure, and recovers on upgrade', async () => {
+    const open = vi.fn(async () => accepted([DEVICE_LINK_CAPABILITY_HISTORY_VIEW_V1]));
+    const wire = vi.fn(async () => page);
+    const view = new HistoryViewController<RemoteMessage>({
+      page: () => invokeWithHistoryViewCapability('local-db:messages:view', open, wire),
+      details: async () => ({ version: 1, messages: [], hasMore: false, nextCursor: null }),
+      expanded: async () => {},
+    });
+    await view.refresh();
+    expect(view.getSnapshot().ready).toBe(true);
+    const offline = new DeviceLinkError('NOT_CONNECTED', 'offline');
+    open.mockRejectedValueOnce(offline);
+    await view.refresh();
+    expect(view.getSnapshot()).toMatchObject({ ready: true, error: offline });
+    expect(isHistoryViewUnavailable(view.getSnapshot().error)).toBe(false);
+    open.mockResolvedValueOnce(accepted());
+    await view.refresh();
+    expect(view.getSnapshot()).toMatchObject({ ready: false, items: [] });
+    expect(isHistoryViewUnavailable(view.getSnapshot().error)).toBe(true);
+    await view.refresh();
+    expect(view.getSnapshot()).toMatchObject({ ready: true, error: null });
+    expect(wire).toHaveBeenCalledTimes(2);
+    view.setNetworkAvailable(false);
+    view.setActive(false);
+  });
+});

--- a/apps/mobile/src/__tests__/historyViewProvider.test.tsx
+++ b/apps/mobile/src/__tests__/historyViewProvider.test.tsx
@@ -1,0 +1,175 @@
+// @vitest-environment jsdom
+import { act, createElement } from 'react';
+import { createRoot, type Root } from 'react-dom/client';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import {
+  DEVICE_LINK_CAPABILITY_HISTORY_VIEW_V1,
+  type DeviceLinkClient,
+  type DeviceLinkStatus,
+  type LinkAcceptPayload,
+  type PresenceSnapshot,
+} from '@cindy/device-link';
+import { isHistoryViewUnavailable } from '@cindy/maker-shared/message-window';
+import { DeviceLinkProvider, useDeviceLink, type DeviceLinkContextValue } from '../device-link/DeviceLinkContext';
+
+const auth = vi.hoisted(() => ({
+  isAuthenticated: true,
+  accountGeneration: 1,
+  user: { id: 'test-account' },
+  getAccessToken: vi.fn(async () => 'test-token'),
+  apiFetch: vi.fn(async () => ({ devices: [] })),
+}));
+vi.mock('@/auth/AuthContext', () => ({ useAuth: () => auth }));
+vi.mock('react-native', () => ({
+  Platform: { OS: 'android' },
+  AppState: { currentState: 'active', addEventListener: () => ({ remove() {} }) },
+}));
+vi.mock('expo-network', () => ({ addNetworkStateListener: () => ({ remove() {} }) }));
+vi.mock('expo-secure-store', () => ({
+  getItemAsync: vi.fn(async () => null), setItemAsync: vi.fn(async () => {}), deleteItemAsync: vi.fn(async () => {}),
+}));
+vi.mock('@react-native-async-storage/async-storage', () => ({ default: {
+  getItem: vi.fn(async () => null), setItem: vi.fn(async () => {}), removeItem: vi.fn(async () => {}),
+  getAllKeys: vi.fn(async () => []), multiRemove: vi.fn(async () => {}),
+} }));
+vi.mock('@/device-link/rnWebSocket', () => ({ createRnWebSocket: vi.fn() }));
+vi.mock('@/debug/mobileDebugLog', () => ({ mobileDebugLog: vi.fn() }));
+vi.mock('@/debug/visualMock', () => ({ createVisualMockDeviceLinkContext: vi.fn(), seedVisualMockStore: vi.fn() }));
+
+// Only the transport boundary is fake. Mount the real Provider, including its
+// handshake single-flight cache, invalidation callbacks and invoke send path.
+const transport = vi.hoisted(() => {
+  class Client {
+    status: DeviceLinkStatus = 'online';
+    statusChanged: (status: DeviceLinkStatus) => void = () => {};
+    presenceChanged: (snapshot: PresenceSnapshot) => void = () => {};
+    peerReset: Parameters<DeviceLinkClient['onPeerTransportReset']>[0] = () => {};
+    openLink = vi.fn<(deviceId: string) => Promise<LinkAcceptPayload>>();
+    invoke = vi.fn(async () => ({ ok: true, result: 'history page' }));
+    start = vi.fn();
+    stop = vi.fn();
+    getStatus = () => this.status;
+    isOutboundExplicitlyClosed = () => false;
+    // No background recovery owner; each test explicitly starts the fresh read.
+    hasPendingRequestsTo = () => false;
+    onStatusChange(listener: Client['statusChanged']) { this.statusChanged = listener; return () => {}; }
+    onPresenceChanged(listener: Client['presenceChanged']) { this.presenceChanged = listener; return () => {}; }
+    onPeerTransportReset(listener: Client['peerReset']) { this.peerReset = listener; return () => {}; }
+    onConnectionIssue = () => () => {};
+    onFrame = () => () => {};
+    onReliableFrameBeforeLink = () => () => {};
+  }
+  return { Client, clients: [] as Client[] };
+});
+vi.mock('@cindy/device-link', async (importOriginal) => ({
+  ...await importOriginal<typeof import('@cindy/device-link')>(),
+  DeviceLinkClient: class extends transport.Client {
+    constructor() { super(); transport.clients.push(this); }
+  },
+}));
+
+Object.assign(globalThis, { IS_REACT_ACT_ENVIRONMENT: true });
+const supported = [DEVICE_LINK_CAPABILITY_HISTORY_VIEW_V1];
+const accepted = (capabilities?: string[]): LinkAcceptPayload => ({ appVersion: 'test', allowlistHash: 'test', capabilities });
+const historyChannel = 'local-db:messages:view';
+let root: Root;
+let context: DeviceLinkContextValue;
+function Probe() { context = useDeviceLink(); return null; }
+function render() { root.render(createElement(DeviceLinkProvider, null, createElement(Probe))); }
+function deferredAccept() {
+  let resolve!: (value: LinkAcceptPayload) => void;
+  const promise = new Promise<LinkAcceptPayload>(done => { resolve = done; });
+  return { promise, resolve };
+}
+async function readHistory() {
+  // Attach rejection handling immediately: lifecycle tests intentionally reject.
+  let result!: Promise<unknown>;
+  await act(async () => { result = context.invoke('host', historyChannel).catch(error => error); });
+  return { result };
+}
+
+beforeEach(async () => {
+  auth.accountGeneration = 1;
+  transport.clients.length = 0;
+  root = createRoot(document.createElement('div'));
+  await act(async () => render());
+});
+afterEach(async () => { await act(async () => root.unmount()); });
+
+describe('Provider history handshake lifetime', () => {
+  it.each(['presence', 'reconnect', 'peer reset', 'account switch'] as const)(
+    'rejects a late accept after %s and lets the current handshake read history', async (event) => {
+      const client = transport.clients[0];
+      const old = deferredAccept();
+      const current = deferredAccept();
+      client.openLink.mockReturnValueOnce(old.promise).mockReturnValueOnce(current.promise);
+      const pending = await readHistory();
+      expect(client.openLink).toHaveBeenCalledTimes(1);
+      expect(client.invoke).not.toHaveBeenCalled();
+
+      await act(async () => {
+        if (event === 'presence') {
+          client.presenceChanged({ deviceId: 'host', deviceName: 'Host', platform: 'win32',
+            appVersion: 'test', online: true, remoteControlEnabled: true, busy: false, lastSeenAt: 0 });
+        } else if (event === 'reconnect') {
+          client.status = 'stopped'; client.statusChanged('stopped');
+          client.status = 'online'; client.statusChanged('online');
+        } else if (event === 'peer reset') {
+          client.peerReset({ deviceId: 'host', reason: 'ack-timeout', connectionEpoch: 1, linkGeneration: 1, seq: 1 });
+        } else {
+          auth.accountGeneration++;
+          render();
+        }
+      });
+      const currentClient = transport.clients.at(-1)!;
+      if (currentClient !== client) currentClient.openLink.mockReturnValueOnce(current.promise);
+      const fresh = await readHistory();
+
+      // An obsolete legacy accept must not permanently downgrade the controller.
+      await act(async () => old.resolve(accepted()));
+      const error = await pending.result;
+      expect(error).toMatchObject({ code: 'NOT_CONNECTED' });
+      expect(isHistoryViewUnavailable(error)).toBe(false);
+      expect(client.invoke).not.toHaveBeenCalled();
+      expect(currentClient.invoke).not.toHaveBeenCalled();
+
+      await act(async () => current.resolve(accepted(supported)));
+      expect(await fresh.result).toBe('history page');
+      expect(currentClient.invoke).toHaveBeenCalledTimes(1);
+      expect(currentClient.invoke).toHaveBeenCalledWith('host', { channel: historyChannel, args: [] }, undefined);
+      // A late old completion must not evict the new successful single-flight.
+      await act(async () => { expect(await context.invoke('host', historyChannel)).toBe('history page'); });
+      expect(currentClient.openLink).toHaveBeenCalledTimes(currentClient === client ? 2 : 1);
+    },
+  );
+
+  it('does not send a stale supported invocation or invalidate another peer', async () => {
+    const client = transport.clients[0];
+    const old = deferredAccept();
+    client.openLink.mockReturnValueOnce(old.promise).mockResolvedValue(accepted(supported));
+    const pending = await readHistory();
+    await act(async () => { await context.invoke('other-host', historyChannel); });
+    await act(async () => client.peerReset({ deviceId: 'host', reason: 'ack-timeout', connectionEpoch: 1, linkGeneration: 1, seq: 1 }));
+    await act(async () => old.resolve(accepted(supported)));
+    expect(await pending.result).toMatchObject({ code: 'NOT_CONNECTED' });
+    expect(client.invoke).toHaveBeenCalledTimes(1);
+    await act(async () => { await context.invoke('other-host', historyChannel); });
+    expect(client.openLink.mock.calls.map(([deviceId]) => deviceId)).toEqual(['host', 'other-host']);
+  });
+
+  it('shares the current handshake across all projection channels without blocking legacy reads', async () => {
+    const client = transport.clients[0];
+    const open = deferredAccept();
+    client.openLink.mockReturnValue(open.promise);
+    const channels = [historyChannel, 'local-db:messages:work-details', 'local-db:messages:view-intent'];
+    let pending!: Promise<unknown>[];
+    await act(async () => { pending = channels.map(channel => context.invoke('host', channel)); });
+    expect(client.openLink).toHaveBeenCalledTimes(1);
+    expect(client.invoke).not.toHaveBeenCalled();
+    await act(async () => { await context.invoke('host', 'local-db:messages:list'); });
+    expect(client.invoke).toHaveBeenCalledTimes(1);
+    await act(async () => { open.resolve(accepted(supported)); await Promise.all(pending); });
+    expect(client.invoke).toHaveBeenCalledTimes(4);
+    expect(client.openLink).toHaveBeenCalledTimes(1);
+  });
+});

--- a/apps/mobile/src/device-link/DeviceLinkContext.tsx
+++ b/apps/mobile/src/device-link/DeviceLinkContext.tsx
@@ -2,6 +2,7 @@ import Constants from 'expo-constants';
 import { isHistoryViewUnavailable } from '@cindy/maker-shared/message-window';
 import { findRemoteHistoryView } from '@/session/remoteHistoryView';
 import { createBackgroundConnection } from './backgroundConnection';
+import { invokeWithHistoryViewCapability } from './historyViewCapability';
 import { createRecoveryDiagnostics, settleMeasuredSnapshot, type RecoveryPhase } from './recoveryDiagnostics';
 import { confirmTrackedSubscription, SubscriptionAcknowledgements } from './subscriptionAcknowledgements';
 import { AppState, Platform } from 'react-native';
@@ -1315,8 +1316,23 @@ export function DeviceLinkProvider({ children }: { children: ReactNode }) {
       opts?.preSend?.();
     };
     preSend();
-    return sendInvokeWithAccessHandling<T>(requireClient(clientRef.current), deviceId, channel, args, { preSend });
-  }, []);
+    const client = requireClient(clientRef.current);
+    return invokeWithHistoryViewCapability(
+      channel,
+      async () => {
+        // Reuse the existing peer-scoped handshake cache and its invalidation.
+        // A late accept from an obsolete link must not declare a downgrade.
+        const tracked = sendOpenLinkOnce(client, deviceId);
+        const accepted = await tracked.request;
+        if (clientRef.current !== client || openLinkInFlightRef.current.get(deviceId) !== tracked) {
+          throw new DeviceLinkError('NOT_CONNECTED', 'history link was superseded');
+        }
+        preSend();
+        return accepted;
+      },
+      () => sendInvokeWithAccessHandling<T>(client, deviceId, channel, args, { preSend }),
+    );
+  }, [sendOpenLinkOnce]);
 
   const subscribe = useCallback(async (owner: string, deviceId: string, topics: string[]) => {
     // `owner` is the stable id of the mounted consumer (e.g. `session:<id>`). Tracking is

--- a/apps/mobile/src/device-link/historyViewCapability.ts
+++ b/apps/mobile/src/device-link/historyViewCapability.ts
@@ -1,0 +1,24 @@
+import { DeviceLinkError, DEVICE_LINK_CAPABILITY_HISTORY_VIEW_V1, type LinkAcceptPayload } from '@cindy/device-link';
+
+const HISTORY_VIEW_CHANNELS = new Set([
+  'local-db:messages:view',
+  'local-db:messages:work-details',
+  'local-db:messages:view-intent',
+]);
+
+/** Negotiate before sending projection requests; legacy reads and reachability stay independent. */
+export async function invokeWithHistoryViewCapability<T>(
+  channel: string,
+  openLink: () => Promise<LinkAcceptPayload>,
+  invoke: () => Promise<T>,
+): Promise<T> {
+  if (HISTORY_VIEW_CHANNELS.has(channel)) {
+    const accepted = await openLink();
+    if (!accepted.capabilities?.includes(DEVICE_LINK_CAPABILITY_HISTORY_VIEW_V1)) {
+      // Use the existing unavailable path to retire memory/disk projections and
+      // read the raw message window. Do not turn connection failures into fallback.
+      throw new DeviceLinkError('CHANNEL_NOT_ALLOWED', '[CHANNEL_NOT_ALLOWED] History view is unavailable');
+    }
+  }
+  return invoke();
+}

--- a/packages/device-link/src/transport.ts
+++ b/packages/device-link/src/transport.ts
@@ -31,6 +31,9 @@ export const DEVICE_LINK_CAPABILITY_RELIABLE_LINK_CONFIRM = 'reliable-link-confi
  * list/created/maker:event. Around reads retain full detail; old peers stay unchanged. */
 export const DEVICE_LINK_CAPABILITY_COMPACT_MESSAGE_HISTORY_V1 = 'compact-message-history-v1';
 
+/** Desktop declares support for the structured history projection channels. */
+export const DEVICE_LINK_CAPABILITY_HISTORY_VIEW_V1 = 'history-view-v1';
+
 /** transport ACK 使用普通 push 承载，且 ACK 本身永不再包 transport。 */
 export const DEVICE_LINK_TRANSPORT_ACK_CHANNEL = '__cindy/device-link/transport-ack';
 


### PR DESCRIPTION
## 这次改了什么

### 摘要

手机读取任务历史时，旧桌面没有结构化历史投影通道，可能同步失败；正在运行的任务仍能通过实时推送收到新消息，因此表现为部分任务正常、部分任务出错。

现在手机在发送历史投影请求前等待当前设备的握手结果。桌面未声明能力时，本地返回既有的不可用错误，复用已有消息列表、分页与投影缓存清理路径。新版桌面在被控端握手响应中声明能力，继续使用结构化历史。

### 变更类型

- [x] fix 缺陷修复

### 范围

- 关联 Issue / 需求：手机连接旧桌面的任务历史同步兼容问题。
- rebase 后的门禁修复：modelVisibilityPrefs 测试统一复用原有 Chromium Web Locks 替身，防止误用 Node 原生 navigator.locks 后连续超时；61 项原有断言全部通过，未改模型配置逻辑或测试超时。
- 本 PR 包含：被控端能力声明、手机三个历史通道的协商与旧握手失效检查、回归测试。
- 明确不包含：模拟器系统修复、登录、服务端与原生配置改动。
- 用户可见变化：旧桌面的历史消息能够同步并继续加载更早消息；在线状态保持原有判断。
- 是否存在 breaking change：无；沿用握手的可选 capabilities 字段，旧端缺省时使用旧消息协议。

### UI 变化

- 引用的设计规范：不涉及：未修改布局、样式、文案或组件，修复数据读取链路。

## 怎么验证的

### 自动验证

- pnpm test:unit:related：通过，包含 Desktop 全量单测、Mobile 全量单测及 device-link 相关单测。
- pnpm --filter desktop run --if-present typecheck：通过。
- pnpm --filter mobile run --if-present typecheck：通过。
- pnpm --filter @cindy/device-link run --if-present typecheck：包内无该脚本，按约定跳过。
- pnpm --filter mobile test:scope、pnpm --filter mobile test:smoke：通过。
- 2026-09-10 rebase 到 main 040978878 后重新通过上述门禁。新增真实挂载 DeviceLinkProvider 的 6 个用例，覆盖 presence、重连、peer reset、账号切换、过期能力不降级、不发送过期请求、另一 peer 不受影响，以及三个历史通道共享握手；和原有能力测试合计 13 项通过。
- 定向测试覆盖能力缺省/空列表/未知能力、三个通道等待握手、新桌面透传、旧列表首屏与分页、降级清缓存、瞬时错误保留缓存、升级后恢复。
- 提 PR 前的独立子代理复审：未发现 P0/P1；另跑能力、presence、重入与磁盘缓存四组共 70 项测试通过。

### 手工验证

Windows Android AVD cindy-api36 / emulator-5554，CN Debug com.xd.cindycn，连接现有 XD-PC。

- 修复前：历史任务无法正常取正文；正在运行的任务可收到实时新消息，但历史读取异常。
- 修复后：原报错历史任务恢复同步并显示正文；加载更早触发旧消息分页且历史聚合内容增加；运行中的任务可阅读并显示运行状态；重启手机应用后原任务仍可重新加载。
- branch/worktree：cindy/clever-panini；Metro 8081 从本 worktree 的 mobile:sim:start:cn 启动。最终验证页面的 __DEV__ 源码标识为 cindy/clever-panini@36bd8a21e+1639e1c02c，对应本轮 rebase 后、补测试后的提交前最终内容；Metro 有新 Android bundling 完成记录。
- 未向测试任务发送消息，未重启用户正在使用的桌面端。

### 未执行的验证

- 新桌面端到端连接、iOS 与 Dark 模式未实测；新版握手及投影请求由自动测试覆盖。
- 仓库 mobile:sim:whoami 当前只调用 iOS/macOS 工具，在 Windows 无法给出有效判断；以 Android 安装信息、adb reverse、实际 Metro 进程与页面源码标识核对。
- 本轮长历史分页仍出现既有滚动锚点未稳定警告；旧消息分页与内容合并成功，滚动位置连续性未判定全面通过。本轮操作未见 ANR 或 JS 崩溃。

## 风险

### 风险分类

- [x] 协议兼容

### 影响与回滚

- 影响范围：手机的历史投影请求与桌面的能力响应；可选能力追加，relay 沿用既有 capabilities 透传，无需服务端发布。
- 已支持投影但尚未声明新能力的桌面也会使用旧消息列表，升级桌面后恢复投影。
- 回滚 / 降级方式：可回退本提交；不修改消息存储、数据库 schema、认证或权限边界。缓存沿用已有不可用错误清理机制，原始消息保留。
- 移动端冷更分析：仅 TypeScript 逻辑与测试；未变更 package.json、依赖、锁文件、Expo 配置或原生输入，不触发 runtime fingerprint 冷更。
- 多端适配：Mobile 已适配；Desktop 被控端声明能力；SSH 消息仍由被控桌面既有通道读取，无新增本机文件访问。未新增 IPC 或 push。
- 故障半径：仅本次历史请求/当前 peer 的握手有效性检查；不新增重试、超时或 relay 重连动作。多 peer 故障恢复策略未改变；新增 Provider 测试验证单 peer 失效不影响另一 peer 的握手缓存和读取，未做多 peer 实机故障注入。

### 提交前检查

- [x] 已 review 完整 diff
- [x] 每个 commit 都带 DCO 签名
- [x] UI 变化已说明不涉及
- [x] 未提交凭证、令牌或授权文件
- [x] 已补充必要测试与兼容说明
- [x] 已确认测试结果并说明未执行范围