### PR TITLE
fix(mobile): 对齐桌面项目机器标注，区分同名文件夹

### DIFF
--- a/apps/mobile/app/devices/index.tsx
+++ b/apps/mobile/app/devices/index.tsx
@@ -3431,7 +3431,7 @@ function ProjectRow({
   const groupTestID = kind === 'dialogue' ? 'home.dialogueGroup' : 'home.projectGroup';
   const rowTestID = kind === 'dialogue' ? 'home.dialogueRow' : 'home.projectRow';
   const childTestID = kind === 'dialogue' ? 'home.chatRow' : 'home.projectSessionRow';
-  const displayTitle = machineIdentity
+  const displayTitle = machineIdentity && !machineIdentity.hideLabel
     ? `${project.title} (${machineIdentity.displayLabel})`
     : project.title;
   const reorderable = kind === 'project' && !!onDragStart && !!onDragMove && !!onDragEnd;

--- a/apps/mobile/app/devices/index.tsx
+++ b/apps/mobile/app/devices/index.tsx
@@ -3421,6 +3421,8 @@ function ProjectRow({
   const groupTestID = kind === 'dialogue' ? 'home.dialogueGroup' : 'home.projectGroup';
   const rowTestID = kind === 'dialogue' ? 'home.dialogueRow' : 'home.projectRow';
   const childTestID = kind === 'dialogue' ? 'home.chatRow' : 'home.projectSessionRow';
+  const deviceName = kind === 'project' ? project.deviceName.trim() : '';
+  const displayTitle = deviceName ? `${project.title} - ${deviceName}` : project.title;
   const reorderable = kind === 'project' && !!onDragStart && !!onDragMove && !!onDragEnd;
   const dragGesture = useMemo(() => {
     if (!onDragStart || !onDragMove || !onDragEnd || kind !== 'project') return null;
@@ -3434,7 +3436,7 @@ function ProjectRow({
           absoluteY: event.absoluteY,
           count: project.sessionCount,
           key: project.key,
-          title: project.title,
+          title: displayTitle,
         });
       })
       .onUpdate((event) => {
@@ -3443,13 +3445,13 @@ function ProjectRow({
       .onFinalize(() => {
         runOnJS(finish)();
       });
-  }, [kind, onDragEnd, onDragMove, onDragStart, project.key, project.sessionCount, project.title]);
+  }, [displayTitle, kind, onDragEnd, onDragMove, onDragStart, project.key, project.sessionCount]);
   const header = (
     <Pressable
       accessibilityHint={reorderable ? t('devices.list.menu.projectOrderManualTip') : undefined}
       accessibilityLabel={kind === 'dialogue'
         ? t('devices.list.a11y.dialogue')
-        : t('devices.list.a11y.project', { title: project.title })}
+        : t('devices.list.a11y.project', { title: displayTitle })}
       accessibilityRole="button"
       accessibilityState={{ expanded: !collapsed }}
       onLayout={(event) => {
@@ -3481,7 +3483,14 @@ function ProjectRow({
       ) : (
         <FolderOpen color={colors.textSecondary} size={iconSize.xl} strokeWidth={iconStroke.thin} />
       )}
-      <Text style={styles.projectTitle} numberOfLines={1}>{project.title}</Text>
+      <View style={styles.projectLabel}>
+        <Text style={[styles.projectTitle, styles.projectFolderTitle]} numberOfLines={1}>{project.title}</Text>
+        {deviceName ? (
+          <Text style={styles.projectDeviceName} numberOfLines={1} ellipsizeMode="middle">
+            {` - ${deviceName}`}
+          </Text>
+        ) : null}
+      </View>
       <Text style={styles.projectCount} numberOfLines={1}>{project.sessionCount}</Text>
     </Pressable>
   );
@@ -4650,6 +4659,12 @@ const makeStyles = (colors: ThemeColors) => StyleSheet.create({
     paddingRight: spacing.lg,
     paddingVertical: spacing.sm,
   },
+  projectLabel: {
+    alignItems: 'baseline',
+    flex: 1,
+    flexDirection: 'row',
+    minWidth: 0,
+  },
   projectTitle: {
     color: colors.textPrimary,
     flex: 1,
@@ -4657,6 +4672,19 @@ const makeStyles = (colors: ThemeColors) => StyleSheet.create({
     fontWeight: fontWeight.medium,
     lineHeight: lineHeight.listTitle,
     minWidth: 0,
+  },
+  projectFolderTitle: {
+    flex: 0,
+    flexShrink: 1,
+  },
+  projectDeviceName: {
+    color: colors.textTertiary,
+    flexShrink: 0,
+    fontSize: typeScale.footnote,
+    fontWeight: fontWeight.regular,
+    lineHeight: lineHeight.listTitle,
+    // Reserve room for both names; long folders must not push the device away.
+    maxWidth: '50%',
   },
   projectCount: {
     color: colors.textTertiary,

--- a/apps/mobile/app/devices/index.tsx
+++ b/apps/mobile/app/devices/index.tsx
@@ -66,6 +66,8 @@ import { HomeChromeFrost } from '@/session/HomeChromeFrost';
 import { HomeGlassMenuPanel, HomeMenuScrim } from '@/session/HomeGlassMenuPanel';
 import { HomeHeaderGlassButton } from '@/session/HomeHeaderGlassButton';
 import { HomeSearchBar } from '@/session/HomeSearchBar';
+import { HomeProjectMachineLabel } from '@/session/HomeProjectMachineLabel';
+import { buildHomeProjectMachineIdentities, type HomeProjectMachineIdentity } from '@/session/homeProjectMachineIdentity';
 import {
   HomeNativeStackHeader,
   NativePullDownMenu,
@@ -1700,6 +1702,10 @@ function HomeScreenContent() {
     }),
     [deviceModels, liveActivityIndex, messagePreviewIndex, pendingInteractionIndex, scheduleIndex, searchQuery, selectedDeviceId, homeSessions, statusFilter, t],
   );
+  const projectMachineIdentities = useMemo(
+    () => buildHomeProjectMachineIdentities(home, deviceConnectionStates),
+    [home, deviceConnectionStates],
+  );
   const runningSessionIds = useMemo(() => {
     const ids = new Set<string>();
     for (const session of homeSessions) {
@@ -2288,6 +2294,7 @@ function HomeScreenContent() {
       expandedAutomationGroups={expandedAutomationGroups}
       isLastPinnedRow={section.key === 'pinned' && index === section.data.length - 1 && sections.length > 1}
       item={item}
+      machineIdentity={item.kind === 'project' ? projectMachineIdentities.get(item.project.key) : undefined}
       nextIsBlock={isBlockHomeRow(section.data[index + 1])}
       onArchive={archiveSession}
       onOpenAutomationGroup={openAutomationGroup}
@@ -2336,6 +2343,7 @@ function HomeScreenContent() {
     toggleSessionPinned,
     homeScrollY,
     screenHeight,
+    projectMachineIdentities,
   ]);
 
   // 底部边到边:列表填满到物理屏底(内容滚到 home indicator 下方),用 inset 兜底而非靠 SafeAreaView 留白带。
@@ -3311,6 +3319,7 @@ function ProjectRow({
   expandedAutomationGroups,
   headerRefs,
   kind = 'project',
+  machineIdentity,
   onDragEnd,
   onDragMove,
   onDragStart,
@@ -3331,6 +3340,7 @@ function ProjectRow({
   expandedAutomationGroups: readonly string[];
   headerRefs?: MutableRefObject<Map<string, View>>;
   kind?: 'project' | 'dialogue';
+  machineIdentity?: HomeProjectMachineIdentity;
   onDragEnd?: () => void;
   onDragMove?: (absoluteY: number) => void;
   onDragStart?: (input: { absoluteY: number; count: number; key: string; title: string }) => void;
@@ -3421,8 +3431,9 @@ function ProjectRow({
   const groupTestID = kind === 'dialogue' ? 'home.dialogueGroup' : 'home.projectGroup';
   const rowTestID = kind === 'dialogue' ? 'home.dialogueRow' : 'home.projectRow';
   const childTestID = kind === 'dialogue' ? 'home.chatRow' : 'home.projectSessionRow';
-  const deviceName = kind === 'project' ? project.deviceName.trim() : '';
-  const displayTitle = deviceName ? `${project.title} - ${deviceName}` : project.title;
+  const displayTitle = machineIdentity
+    ? `${project.title} (${machineIdentity.displayLabel})`
+    : project.title;
   const reorderable = kind === 'project' && !!onDragStart && !!onDragMove && !!onDragEnd;
   const dragGesture = useMemo(() => {
     if (!onDragStart || !onDragMove || !onDragEnd || kind !== 'project') return null;
@@ -3485,11 +3496,7 @@ function ProjectRow({
       )}
       <View style={styles.projectLabel}>
         <Text style={[styles.projectTitle, styles.projectFolderTitle]} numberOfLines={1}>{project.title}</Text>
-        {deviceName ? (
-          <Text style={styles.projectDeviceName} numberOfLines={1} ellipsizeMode="middle">
-            {` - ${deviceName}`}
-          </Text>
-        ) : null}
+        {machineIdentity ? <HomeProjectMachineLabel identity={machineIdentity} /> : null}
       </View>
       <Text style={styles.projectCount} numberOfLines={1}>{project.sessionCount}</Text>
     </Pressable>
@@ -3638,6 +3645,7 @@ function HomeListRowInner({
   expandedAutomationGroups,
   isLastPinnedRow,
   item,
+  machineIdentity,
   nextIsBlock,
   onArchive,
   onOpenAutomationGroup,
@@ -3665,6 +3673,7 @@ function HomeListRowInner({
   /** 置顶组展开态:行进入置顶卡片内的缩进/描边形态(CINDY list 视觉)。 */
   isLastPinnedRow: boolean;
   item: HomeRow;
+  machineIdentity?: HomeProjectMachineIdentity;
   nextIsBlock: boolean;
   onArchive(session: RemoteSession): void;
   onOpenAutomationGroup(group: RemoteAutomationSessionGroup): void;
@@ -3696,6 +3705,7 @@ function HomeListRowInner({
         expandedAutomationGroups={expandedAutomationGroups}
         headerRefs={projectHeaderRefs}
         kind={item.kind}
+        machineIdentity={machineIdentity}
         onDragEnd={item.kind === 'project' ? onProjectDragEnd : undefined}
         onDragMove={item.kind === 'project' ? onProjectDragMove : undefined}
         onDragStart={item.kind === 'project' ? onProjectDragStart : undefined}
@@ -4660,9 +4670,10 @@ const makeStyles = (colors: ThemeColors) => StyleSheet.create({
     paddingVertical: spacing.sm,
   },
   projectLabel: {
-    alignItems: 'baseline',
+    alignItems: 'center',
     flex: 1,
     flexDirection: 'row',
+    gap: 6, // Desktop ProjectNode name / remote icon / machine label gap-1.5.
     minWidth: 0,
   },
   projectTitle: {
@@ -4676,15 +4687,6 @@ const makeStyles = (colors: ThemeColors) => StyleSheet.create({
   projectFolderTitle: {
     flex: 0,
     flexShrink: 1,
-  },
-  projectDeviceName: {
-    color: colors.textTertiary,
-    flexShrink: 0,
-    fontSize: typeScale.footnote,
-    fontWeight: fontWeight.regular,
-    lineHeight: lineHeight.listTitle,
-    // Reserve room for both names; long folders must not push the device away.
-    maxWidth: '50%',
   },
   projectCount: {
     color: colors.textTertiary,

--- a/apps/mobile/src/__tests__/homeProjectMachineIdentity.test.ts
+++ b/apps/mobile/src/__tests__/homeProjectMachineIdentity.test.ts
@@ -1,0 +1,71 @@
+import { describe, expect, it } from 'vitest';
+import type { MobileHomeDeviceFilterItem, MobileHomeProjectGroup } from '@/session/mobileHome';
+import { buildHomeProjectMachineIdentities } from '@/session/homeProjectMachineIdentity';
+
+function project(key: string, deviceId: string | null, deviceName: string): MobileHomeProjectGroup {
+  return {
+    key, deviceId, deviceName, title: 'folder', workingDir: '/folder',
+    sessions: [], sessionCount: 0, pendingInteractionCount: 0,
+    latestActivityAt: '', subtitle: '',
+  };
+}
+
+function device(deviceId: string, label: string, available = true): MobileHomeDeviceFilterItem {
+  return {
+    id: deviceId, deviceId, label, available, selected: false,
+    sessionCount: 0, waitingCount: 0, state: available ? 'ready' : 'offline', statusLabel: '',
+  };
+}
+
+describe('project machine identity parity with Desktop', () => {
+  it('shows names without IDs for distinct devices and repeated projects on one device', () => {
+    const result = buildHomeProjectMachineIdentities({
+      projects: [project('a', 'win', 'Windows'), project('b', 'mac', 'MacBook'), project('c', 'mac', 'MacBook')],
+      deviceFilters: [device('win', 'Windows'), device('mac', 'MacBook')],
+      selectedDeviceId: null,
+    });
+    expect([...result.values()].map((item) => item.displayLabel)).toEqual(['Windows', 'MacBook', 'MacBook']);
+    expect(result.get('a')).toEqual({ displayLabel: 'Windows', disconnected: false, hideLabel: false });
+  });
+
+  it('only disambiguates visible projects on distinct same-named devices, ignoring case and padding', () => {
+    const deviceFilters = [device('one', ' MacBook '), device('two', 'macbook')];
+    const result = buildHomeProjectMachineIdentities({
+      projects: [project('a', 'one', 'MacBook'), project('b', 'two', 'macbook')],
+      deviceFilters, selectedDeviceId: null,
+    });
+    expect(result.get('a')?.displayLabel).toBe('MacBook · one');
+    expect(result.get('b')?.displayLabel).toBe('macbook · two');
+    const onlyOneVisible = buildHomeProjectMachineIdentities({
+      projects: [project('a', 'one', 'MacBook')], deviceFilters, selectedDeviceId: null,
+    });
+    expect(onlyOneVisible.get('a')?.displayLabel).toBe('MacBook');
+  });
+
+  it('hides redundant labels under a selected device but retains offline identity for the icon', () => {
+    const result = buildHomeProjectMachineIdentities({
+      projects: [project('a', 'mac', 'MacBook')],
+      deviceFilters: [device('mac', 'MacBook', false)], selectedDeviceId: 'mac',
+    });
+    expect(result.get('a')).toEqual({ displayLabel: 'MacBook', disconnected: true, hideLabel: true });
+  });
+
+  it('reflects a failed connection and a later recovery without hiding the machine label', () => {
+    const home = {
+      projects: [project('a', 'mac', 'MacBook')],
+      deviceFilters: [device('mac', 'MacBook')], selectedDeviceId: null,
+    };
+    expect(buildHomeProjectMachineIdentities(home, { mac: 'failed' }).get('a')?.disconnected).toBe(true);
+    expect(buildHomeProjectMachineIdentities(home, { mac: 'idle' }).get('a')?.disconnected).toBe(false);
+  });
+
+  it('uses the current device name, falls back to ID for empty names, and skips unowned folders', () => {
+    const result = buildHomeProjectMachineIdentities({
+      projects: [project('a', 'mac', 'Old name'), project('b', 'win', ''), project('c', null, '')],
+      deviceFilters: [device('mac', 'Renamed Mac'), device('win', '  ')], selectedDeviceId: null,
+    });
+    expect(result.get('a')?.displayLabel).toBe('Renamed Mac');
+    expect(result.get('b')?.displayLabel).toBe('win');
+    expect(result.has('c')).toBe(false);
+  });
+});

--- a/apps/mobile/src/session/HomeProjectMachineLabel.tsx
+++ b/apps/mobile/src/session/HomeProjectMachineLabel.tsx
@@ -1,0 +1,41 @@
+import { StyleSheet } from 'react-native';
+import { MonitorOff, MonitorSmartphone } from 'lucide-react-native';
+import { Text } from '@/components/AppText';
+import { useTheme, useThemedStyles, type ThemeColors } from '@/theme';
+import { fontWeight, iconSize, iconStroke, lineHeight, typeScale } from '@/theme/tokens';
+import type { HomeProjectMachineIdentity } from './homeProjectMachineIdentity';
+
+/** Desktop ProjectNode / RemoteProjectIcon: icon stays even when the heading owns the label. */
+export function HomeProjectMachineLabel({ identity }: { identity: HomeProjectMachineIdentity }) {
+  const { colors } = useTheme();
+  const styles = useThemedStyles(makeStyles);
+  const Icon = identity.disconnected ? MonitorOff : MonitorSmartphone;
+  return (
+    <>
+      <Icon
+        color={colors.textSecondary}
+        size={iconSize.sm}
+        strokeWidth={iconStroke.regular}
+        style={identity.disconnected ? styles.disconnected : styles.icon}
+      />
+      {!identity.hideLabel ? (
+        <Text style={styles.label} numberOfLines={1} ellipsizeMode="tail">
+          {identity.displayLabel}
+        </Text>
+      ) : null}
+    </>
+  );
+}
+
+const makeStyles = (colors: ThemeColors) => StyleSheet.create({
+  icon: { flexShrink: 0 },
+  disconnected: { flexShrink: 0, opacity: 0.75 },
+  label: {
+    color: colors.textSecondary,
+    flexShrink: 1,
+    fontSize: typeScale.micro,
+    fontWeight: fontWeight.regular,
+    lineHeight: lineHeight.caption,
+    maxWidth: '45%',
+  },
+});

--- a/apps/mobile/src/session/homeProjectMachineIdentity.ts
+++ b/apps/mobile/src/session/homeProjectMachineIdentity.ts
@@ -1,0 +1,39 @@
+import type { MobileHomePresentation } from './mobileHome';
+
+export interface HomeProjectMachineIdentity {
+  displayLabel: string;
+  disconnected: boolean;
+  hideLabel: boolean;
+}
+
+/** Mirrors Desktop remoteProjectIdentity: only visible, distinct devices disambiguate names. */
+export function buildHomeProjectMachineIdentities(
+  home: Pick<MobileHomePresentation, 'projects' | 'deviceFilters' | 'selectedDeviceId'>,
+  connectionStates: Readonly<Record<string, string>> = {},
+): ReadonlyMap<string, HomeProjectMachineIdentity> {
+  const filters = new Map(home.deviceFilters.map((device) => [device.deviceId, device]));
+  const deviceName = (project: MobileHomePresentation['projects'][number]) =>
+    (filters.get(project.deviceId)?.label ?? project.deviceName).trim();
+  const idsByName = new Map<string, Set<string>>();
+  for (const project of home.projects) {
+    const name = deviceName(project).toLowerCase();
+    if (!project.deviceId || !name) continue;
+    const ids = idsByName.get(name) ?? new Set<string>();
+    ids.add(project.deviceId);
+    idsByName.set(name, ids);
+  }
+  const identities = new Map<string, HomeProjectMachineIdentity>();
+  for (const project of home.projects) {
+    if (!project.deviceId) continue;
+    const name = deviceName(project);
+    const ambiguous = name && (idsByName.get(name.toLowerCase())?.size ?? 0) > 1;
+    const device = filters.get(project.deviceId);
+    identities.set(project.key, {
+      displayLabel: ambiguous ? `${name} · ${project.deviceId}` : name || project.deviceId,
+      disconnected: !device?.available || connectionStates[project.deviceId] === 'failed',
+      // As on Desktop, an explicit device heading makes the inline label redundant.
+      hideLabel: home.selectedDeviceId === project.deviceId,
+    });
+  }
+  return identities;
+}


### PR DESCRIPTION
## 这次改了什么

### 摘要

手机版「所有任务」中的项目分组只显示文件夹名，多台电脑上的同名文件夹难以区分。现在项目名后显示远程设备图标和机器名，沿用桌面 ProjectNode 的机器标注规则：同名设备才附设备 ID，明确选定单台设备时隐藏重复名称但保留连接图标。

### 变更类型

- [x] `fix` 缺陷修复
- [ ] `feat` 新功能
- [ ] `refactor` / `perf` 重构或性能优化
- [ ] `docs` / `test` / `chore` 文档、测试或工程维护

### 范围

- 关联 Issue / 需求：手机版同名项目的设备归属消歧。
- 本 PR 包含：项目行机器身份投影、在线/断线图标、重名消歧、读屏及拖动标题、规则测试。
- 明确不包含：桌面代码、服务端、远程桌面功能、原生依赖或配置变动。
- 用户可见变化：文件夹名后紧跟设备图标和小号机器名，不加横杠；机器名称取当前设备名，空名回退设备 ID。
- 是否存在 breaking change：无。

### UI 变化

- 平台：Mobile（React Native，iOS / Android）。名称使用 11 号次要文字，最大宽度 45%，尾部省略；图标与桌面 RemoteProjectIcon 一致，断线时使用 MonitorOff。
- 引用的设计规范：`docs/design-rules/DESIGN.md` §3（字重与字号）、§10（语义 token 与双模式）、§15.13（跨端图标和色彩语义）；`apps/mobile/docs/mobile-design-guide.md` §2、§3、§6。新增文字与图标走现有主题 token；名称组间距对齐 Desktop ProjectNode 的 6px。
- 没有实机截图或录屏。HTML 布局示意不作为实机或双模式验证证据。

## 怎么验证的

### 自动验证

```text
pnpm test:unit:related
pnpm --filter mobile run --if-present typecheck
pnpm --filter mobile exec vitest run src/__tests__/homeProjectMachineIdentity.test.ts src/__tests__/homeDesktopFirst.test.ts src/__tests__/homeSections.test.ts src/__tests__/designTokenDiscipline.test.ts
pnpm check:dco
```

结果：同步最新 main 后均通过，定向测试 62 项。身份测试覆盖可见设备重名、同设备多项目、不含项目的同名设备、改名、空名、单设备范围、断线与恢复。

### 手工验证

已对照桌面 `ProjectNode.tsx`、`RemoteProjectIcon.tsx`、`remoteProjectIdentity.ts` 核对行为并自审完整 diff。

### 未执行的验证

未做 iOS / Android 实机或模拟器验证，Light / Dark 均未目检。当前环境没有可用 iOS Simulator；此分支未启动 Metro，没有可报告的 Metro 归属或 `__DEV__` build label。分支 `cindy/silly-einstein`，worktree `.cindy-worktrees/silly-einstein`。全仓单测由 CI 执行。

## 风险

### 风险分类

- [x] 跨平台差异
- [x] 其他：移动端长名称、大字体和窄屏原生布局尚未实机验证。

### 影响与回滚

- 影响范围：手机版首页项目分组标题；不修改设备连接、存储或路由，存量插件影响：无。没有修改原生配置、依赖或其他 fingerprint 输入。
- 回滚 / 降级方式：回退本 PR 即恢复原有文件夹标题，无数据迁移。

### 提交前检查

- [x] 已 review 完整 diff
- [x] 每个 commit 都带 DCO 签名
- [x] UI 改动已在「UI 变化」注明引用的设计规范章节
- [x] 未提交凭证、令牌或授权文件
- [x] 已补充必要文档（行为、设计依据和验证限制见本 PR）
- [x] 已确认测试结果或说明未执行原因
