### PR TITLE
fix(mobile): 收起输入框前同步未发送草稿

### DIFF
--- a/apps/mobile/src/__tests__/composerRichInputHtml.test.ts
+++ b/apps/mobile/src/__tests__/composerRichInputHtml.test.ts
@@ -484,6 +484,61 @@ describe('mobile composer rich input HTML', () => {
       },
     });
     expect(legacyHtml).not.toContain('replaceChildren');
+    for (const finish of ['commit', 'replace-document']) {
+      windowStub.cindyComposer?.applyDocument({
+        version: 1,
+        nodes: [{ type: 'text', text: 'hello world' }],
+      }, true);
+      const selectedPasteRange = createRange();
+      selectedPasteRange.setStart(children[0], 5);
+      // Model replacing the selected suffix: Range.deleteContents mutates
+      // the DOM before native returns the asynchronously processed paste.
+      selectedPasteRange.deleteContents = () => { children[0].nodeValue = 'hello'; };
+      selection.addRange(selectedPasteRange);
+      const beforePaste = messages.length;
+      listeners.get('paste')?.({
+        clipboardData: { getData: () => ' replacement', items: [] },
+        preventDefault() {},
+      });
+      const requestId = finish === 'commit' ? '2' : '3';
+      const pasteRequest = { type: 'paste-text-request', requestId, text: ' replacement' };
+      expect(children[0].nodeValue).toBe('hello');
+      listeners.get('blur')?.();
+      expect(messages.slice(beforePaste)).toEqual([pasteRequest, { type: 'blur' }]);
+
+      if (finish === 'commit') {
+        windowStub.cindyComposer?.commitPaste(requestId, [{ type: 'text', text: ' replacement' }]);
+        expect(messages.slice(beforePaste)).toEqual([
+          pasteRequest,
+          { type: 'blur' },
+          {
+            type: 'change',
+            document: { version: 1, nodes: [{ type: 'text', text: 'hello replacement' }] },
+          },
+        ]);
+      } else {
+        // Replacing the document detaches the pending marker. Its late reply
+        // must neither overwrite the new draft nor block a later blur flush.
+        windowStub.cindyComposer?.applyDocument({
+          version: 1,
+          nodes: [{ type: 'text', text: 'new draft' }],
+        }, true);
+        children[0].nodeValue = 'new draft edited';
+        const beforeNewBlur = messages.length;
+        listeners.get('blur')?.();
+        expect(messages.slice(beforeNewBlur)).toEqual([
+          {
+            type: 'change',
+            document: { version: 1, nodes: [{ type: 'text', text: 'new draft edited' }] },
+          },
+          { type: 'blur' },
+        ]);
+        const beforeLatePaste = messages.length;
+        windowStub.cindyComposer?.commitPaste(requestId, [{ type: 'text', text: ' replacement' }]);
+        expect(messages).toHaveLength(beforeLatePaste);
+        expect(children[0].nodeValue).toBe('new draft edited');
+      }
+    }
     windowStub.cindyComposer?.applyDocument({
       version: 1,
       nodes: [

--- a/apps/mobile/src/__tests__/composerRichInputHtml.test.ts
+++ b/apps/mobile/src/__tests__/composerRichInputHtml.test.ts
@@ -387,6 +387,24 @@ describe('mobile composer rich input HTML', () => {
       nodes: [{ type: 'text', text: 'hello world' }],
     }, true);
 
+    // Blur can happen before WebView delivers a final input event (for
+    // example when the resize handle collapses the composer). The blur hook
+    // must flush that DOM value before native receives the blur message.
+    children[0].nodeValue = 'draft flushed on blur';
+    const beforeBlur = messages.length;
+    listeners.get('blur')?.();
+    expect(messages.slice(beforeBlur)).toEqual([
+      {
+        type: 'change',
+        document: { version: 1, nodes: [{ type: 'text', text: 'draft flushed on blur' }] },
+      },
+      { type: 'blur' },
+    ]);
+    windowStub.cindyComposer?.applyDocument({
+      version: 1,
+      nodes: [{ type: 'text', text: 'hello world' }],
+    }, true);
+
     const pasteRange = createRange();
     pasteRange.setStart(children[0], String(children[0].nodeValue).length);
     selection.addRange(pasteRange);

--- a/apps/mobile/src/__tests__/composerRichInputHtml.test.ts
+++ b/apps/mobile/src/__tests__/composerRichInputHtml.test.ts
@@ -400,6 +400,49 @@ describe('mobile composer rich input HTML', () => {
       },
       { type: 'blur' },
     ]);
+
+    // IME completion may arrive on either side of blur. Keep preedit text
+    // private until completion/cancellation, then publish the final DOM once.
+    for (const completion of ['compositionend', 'compositioncancel']) {
+      for (const blurFirst of [false, true]) {
+        windowStub.cindyComposer?.applyDocument({
+          version: 1,
+          nodes: [{ type: 'text', text: '草稿' }],
+        }, true);
+        const beforeComposition = messages.length;
+        listeners.get('compositionstart')?.();
+        children[0].nodeValue = '草稿候选';
+        listeners.get('input')?.();
+        expect(messages.slice(beforeComposition)).toEqual([]);
+        if (blurFirst) {
+          listeners.get('blur')?.();
+          expect(messages.slice(beforeComposition)).toEqual([{ type: 'blur' }]);
+          expect(children[0].nodeValue).toBe('草稿候选');
+        }
+
+        const finalText = completion === 'compositionend' ? '草稿完成' : '草稿';
+        children[0].nodeValue = finalText;
+        listeners.get(completion)?.();
+        listeners.get('input')?.();
+        if (!blurFirst) listeners.get('blur')?.();
+        const changes = completion === 'compositionend' ? [{
+          type: 'change',
+          document: { version: 1, nodes: [{ type: 'text', text: finalText }] },
+        }] : [];
+        expect(messages.slice(beforeComposition)).toEqual(blurFirst
+          ? [{ type: 'blur' }, ...changes]
+          : [...changes, { type: 'blur' }]);
+
+        // Completion must also unlock ordinary editing after refocusing.
+        listeners.get('focus')?.();
+        children[0].nodeValue = `${finalText}继续编辑`;
+        listeners.get('input')?.();
+        expect(messages.at(-1)).toEqual({
+          type: 'change',
+          document: { version: 1, nodes: [{ type: 'text', text: `${finalText}继续编辑` }] },
+        });
+      }
+    }
     windowStub.cindyComposer?.applyDocument({
       version: 1,
       nodes: [{ type: 'text', text: 'hello world' }],

--- a/apps/mobile/src/session/composerRichInputHtml.ts
+++ b/apps/mobile/src/session/composerRichInputHtml.ts
@@ -503,7 +503,9 @@ export function buildComposerRichInputHtml(config: ComposerRichInputConfig): str
   root.addEventListener('compositionend', () => { composing = false; notify(); });
   root.addEventListener('compositioncancel', () => { composing = false; notify(); });
   root.addEventListener('focus', () => post({ type: 'focus' }));
-  root.addEventListener('blur', () => { reportSelection(); post({ type: 'blur' }); });
+  // A resize-to-collapsed gesture blurs the WebView immediately. Flush any
+  // DOM edits that have not crossed the bridge yet before native changes state.
+  root.addEventListener('blur', () => { notify(); post({ type: 'blur' }); });
   root.addEventListener('keydown', (event) => {
     const backward = event.key === 'Backspace';
     if (!backward && event.key !== 'Delete') return;

--- a/apps/mobile/src/session/composerRichInputHtml.ts
+++ b/apps/mobile/src/session/composerRichInputHtml.ts
@@ -504,8 +504,13 @@ export function buildComposerRichInputHtml(config: ComposerRichInputConfig): str
   root.addEventListener('compositioncancel', () => { composing = false; notify(); });
   root.addEventListener('focus', () => post({ type: 'focus' }));
   // A resize-to-collapsed gesture blurs the WebView immediately. Flush any
-  // DOM edits that have not crossed the bridge yet before native changes state.
-  root.addEventListener('blur', () => { notify(); post({ type: 'blur' }); });
+  // settled DOM edits before native changes state. A pending paste has already
+  // deleted its selection; let commitPaste publish the completed replacement.
+  root.addEventListener('blur', () => {
+    const pendingPaste = Array.from(pasteMarkers.values()).some(({ marker }) => root.contains(marker));
+    if (!pendingPaste) notify();
+    post({ type: 'blur' });
+  });
   root.addEventListener('keydown', (event) => {
     const backward = event.key === 'Backspace';
     if (!backward && event.key !== 'Delete') return;


### PR DESCRIPTION
## 这次改了什么

### 摘要

输入框拖到最小高度会让 WebView 失焦，旧失焦处理只上报选区和 blur，未补发尚未同步的 DOM 文本。现在先同步最新草稿，再通知原生侧失焦，避免收起后的状态切换遗漏最新编辑。

### 变更类型

- [x] `fix` 缺陷修复

### 范围

- 关联 Issue：#4177。
- 包含：富文本输入框失焦同步、change 先于 blur 的回归断言。
- 不包含：桌面兼容链路、原生依赖与配置改动。
- 用户可见变化：收起并重新展开输入框时保留未发送草稿。
- breaking change：无。

### UI 变化

- 不涉及视觉、布局、手势或文案变化，仅补齐现有失焦流程中的草稿同步。
- 引用的设计规范：不涉及：未调整视觉样式、输入快捷键或焦点目标。

## 怎么验证的

### 自动验证

- `pnpm test:unit:related`：通过。
- `pnpm --filter mobile run --if-present typecheck`：通过。
- `pnpm check:dco`、`git diff --check origin/main...HEAD`：通过。
- `pnpm test:runner`：505 项通过、8 项跳过、0 失败。
- `node scripts/test-workspaces.mjs --tier unit`：全部适用 workspace 通过（Desktop、Mobile 及共享包）；无测试的 workspace 按仓库配置跳过。

### 手工验证

Windows 上的 CN Android 开发版，AVD `cindy-api36`，应用 `com.xd.cindycn`，连接在线电脑并进入已有任务：

- 单行草稿：拉到最大高度 → 下拉至最小高度 → 键盘消失 → 点击输入框重新展开，文字保留。
- 多行草稿：下拉至最小高度后重新展开，两行文字保留，未发送。
- 测试草稿已清理，临时输入法设置已恢复。
- 工作树 `humble-cohen` / 分支 `cindy/humble-cohen` 的 Metro 监听 8081；页面源码标识为 `cindy/humble-cohen@1590f9659+896dd21158`，对应提交前相同代码；Metro 输出新的 Android bundle。`mobile:sim:whoami` 在此 Windows 环境未正确识别 Android，归属由启动脚本、页面标识和新 bundle 三项确认。

### 未执行的验证

- 未在未修复版本上稳定实机复现原始草稿丢失；自动回归用例验证“DOM 已变化、input 尚未到达时失焦”的同步缺口。
- iOS、中文 IME 组合输入进行中、Dark 模式未实机验证；不将上述安卓普通文本回归视为这些场景已通过。

## 风险

### 风险分类

- [x] 跨平台差异：Android 已验证，iOS 未实机验证。

### 影响与回滚

- 影响范围：移动端富文本编辑器 blur；沿用现有 notify 去重及组合输入处理。
- 冷更分析：仅修改 TypeScript 生成的 WebView 脚本与单测，没有修改原生配置、依赖或 fingerprint 输入，不触发移动端冷更。
- 回滚方式：回退本提交。

### 提交前检查

- [x] 已 review 完整 diff。
- [x] commit 带 DCO 签名。
- [x] UI 变化已说明。
- [x] 未提交凭证、令牌、授权文件或临时文档。
- [x] 无需新增产品文档。
- [x] 已列出验证结果和未覆盖场景。