### PR TITLE
fix(mobile): open managed Markdown video links

### DIFF
--- a/apps/mobile/src/__tests__/messageMarkdown.test.ts
+++ b/apps/mobile/src/__tests__/messageMarkdown.test.ts
@@ -349,6 +349,44 @@ describe('messageMarkdown', () => {
     ]);
   });
 
+  it('classifies managed video Markdown links for the mobile media viewer', () => {
+    const hash = 'a'.repeat(64);
+    expect(parseMobileMarkdownInlines(
+      `播放 [海洋视频](cindy-media://blobs/${hash}.mp4) 继续`,
+    )).toEqual([
+      { type: 'text', text: '播放 ' },
+      {
+        type: 'link',
+        text: '海洋视频',
+        url: `cindy-media://blobs/${hash}.mp4`,
+        managedMediaKind: 'video',
+      },
+      { type: 'text', text: ' 继续' },
+    ]);
+
+    for (const extension of ['webm', 'mov']) {
+      expect(parseMobileMarkdownInlines(
+        `[video](cindy-media://blobs/${hash}.${extension})`,
+      )).toEqual([{
+        type: 'link',
+        text: 'video',
+        url: `cindy-media://blobs/${hash}.${extension}`,
+        managedMediaKind: 'video',
+      }]);
+    }
+  });
+
+  it('keeps unsupported or malformed cindy-media links as literal text', () => {
+    const hash = 'a'.repeat(64);
+    for (const input of [
+      `[image](cindy-media://blobs/${hash}.png)`,
+      '[video](cindy-media://blobs/not-a-sha.mp4)',
+      `[video](cindy-media://other/${hash}.mp4)`,
+    ]) {
+      expect(parseMobileMarkdownInlines(input)).toEqual([{ type: 'text', text: input }]);
+    }
+  });
+
   it('does not swallow fullwidth parentheses or CJK punctuation after a bare URL', () => {
     expect(parseMobileMarkdownInlines(
       '诊断已写在 https://github.com/example/app/issues/3561#issuecomment-5391602790（无 @）。',

--- a/apps/mobile/src/__tests__/messageMediaThumbnailWiring.test.ts
+++ b/apps/mobile/src/__tests__/messageMediaThumbnailWiring.test.ts
@@ -88,10 +88,25 @@ describe('mobile message media thumbnail wiring', () => {
     expect(pendingImage).not.toContain('Image.getSize');
     expect(pendingBranch).toContain('<FileChip');
     expect(pendingBranch).toContain('<MarkdownBody');
+    expect(pendingBranch).not.toContain('onOpenPayload=');
     expect(pending.indexOf('<AttachmentThumbStrip')).toBeLessThan(pending.indexOf('{hasBody ?'));
     expect(pending).toContain('item.fileNames.map(renderFile)');
     expect(pending).not.toContain('height: 72');
     expect(pending).not.toContain('contentFit="cover"');
+  });
+
+  it('does not expose a managed-media press handler without a payload viewer', () => {
+    const markdownBody = rendererSource.slice(
+      rendererSource.indexOf('function MarkdownBody'),
+      rendererSource.indexOf('function renderInline'),
+    );
+    expect(markdownBody).toContain('const openMarkdownMedia = useMemo(() => onOpenPayload');
+    expect(markdownBody).toContain(': undefined, [onOpenPayload]);');
+    const mediaCallback = markdownBody.slice(
+      markdownBody.indexOf('const openMarkdownMedia'),
+      markdownBody.indexOf('// Preserve the inline renderer'),
+    );
+    expect(mediaCallback).not.toContain('if (!onOpenPayload) return;');
   });
 
   it('exempts images from close-time release in the payload viewer', () => {

--- a/apps/mobile/src/session/MessageRenderer.tsx
+++ b/apps/mobile/src/session/MessageRenderer.tsx
@@ -5015,10 +5015,11 @@ function MarkdownBody({
     markdownImageCacheKey,
     onOpenPayload,
   ]);
-  const openMarkdownMedia = useCallback((url: string, title: string, kind: 'video') => {
-    if (!onOpenPayload) return;
-    onOpenPayload(buildMediaPayload({ kind, url, title, previewable: false }, title));
-  }, [onOpenPayload]);
+  const openMarkdownMedia = useMemo(() => onOpenPayload
+    ? (url: string, title: string, kind: 'video') => {
+      onOpenPayload(buildMediaPayload({ kind, url, title, previewable: false }, title));
+    }
+    : undefined, [onOpenPayload]);
   // Preserve the inline renderer while streaming or unrelated task metadata
   // changes; referenced task title changes still refresh every affected chip.
   const remoteSessions = useRemoteSessions();

--- a/apps/mobile/src/session/MessageRenderer.tsx
+++ b/apps/mobile/src/session/MessageRenderer.tsx
@@ -5015,6 +5015,10 @@ function MarkdownBody({
     markdownImageCacheKey,
     onOpenPayload,
   ]);
+  const openMarkdownMedia = useCallback((url: string, title: string, kind: 'video') => {
+    if (!onOpenPayload) return;
+    onOpenPayload(buildMediaPayload({ kind, url, title, previewable: false }, title));
+  }, [onOpenPayload]);
   // Preserve the inline renderer while streaming or unrelated task metadata
   // changes; referenced task title changes still refresh every affected chip.
   const remoteSessions = useRemoteSessions();
@@ -5039,6 +5043,7 @@ function MarkdownBody({
         baseStyle,
         keyPrefix,
         onOpenImage: openMarkdownImage,
+        onOpenMedia: openMarkdownMedia,
         onOpenSessionLink,
         sessionReferenceDetails,
         sessionLinkTitles,
@@ -5048,7 +5053,7 @@ function MarkdownBody({
     ),
     // renderInline also reads translated fallback labels. Invalidate completed
     // memoized text blocks when useTranslation refreshes its bound translator.
-    [onOpenSessionLink, openMarkdownImage, sessionLinkTitles, sessionReferenceDetails, streaming, styles, t],
+    [onOpenSessionLink, openMarkdownImage, openMarkdownMedia, sessionLinkTitles, sessionReferenceDetails, streaming, styles, t],
   );
   const textRunGroupingOptions = Platform.OS === 'android'
     ? ANDROID_SELECTABLE_TEXT_RUN_GROUPING_OPTIONS
@@ -5566,6 +5571,7 @@ function renderInline(
     /** text_run 合并树里多个块共父,key 需要块级前缀防冲突。 */
     keyPrefix?: string;
     onOpenImage?: (url: string, alt?: string) => void;
+    onOpenMedia?: (url: string, title: string, kind: 'video') => void;
     onOpenPayload?: (payload: MessagePayload) => void;
     onOpenSessionLink?: (url: string) => void;
     sessionReferenceDetails?: Readonly<Record<string, string>>;
@@ -5591,6 +5597,21 @@ function renderInline(
     case 'text':
       return <SpanText key={spanKey(`text:${index}`)} style={ctx.baseStyle}>{inline.text}</SpanText>;
     case 'link': {
+      if (inline.managedMediaKind) {
+        const mediaKind = inline.managedMediaKind;
+        const openManagedMedia = ctx.onOpenMedia
+          ? () => ctx.onOpenMedia?.(inline.url, inline.text, mediaKind)
+          : undefined;
+        return (
+          <SpanText
+            key={spanKey(`media-link:${index}:${inline.url}`)}
+            onPress={openManagedMedia}
+            style={clickableInlineStyle(styles, openManagedMedia, ctx.baseStyle)}
+          >
+            {inline.text}
+          </SpanText>
+        );
+      }
       const session = parseSessionDeepLinkUrl(inline.url);
       if (session) {
         return (

--- a/apps/mobile/src/session/messageMarkdown.ts
+++ b/apps/mobile/src/session/messageMarkdown.ts
@@ -19,7 +19,7 @@ export type MobileMarkdownInline =
   // 普通正文,套等宽会让同一句里点亮/未点亮的路径在字体、底色、下划线三处齐变;作者
   // 手写且 label 像文件名的仍保留 chip(那是作者的排版意图)。见 DESIGN.md §14.5。
   // 与桌面 remarkLocalPathLinks 打的 data-bare-path 标记是同一件事的两端实现。
-  | { type: 'link'; text: string; url: string; bare?: true }
+  | { type: 'link'; text: string; url: string; bare?: true; managedMediaKind?: 'video' }
   | { type: 'strong'; text: string }
   | { type: 'emphasis'; text: string }
   | { type: 'code'; text: string }
@@ -1082,19 +1082,25 @@ function findNextInlineToken(
     // 兼容存量消息)session|project/(session 渲染成会话 chip;project 在
     // renderInline 里显示 label 纯文本,不落 Linking.openURL——桌面端粘贴
     // chip 化后会按 [标题](深链) 发送,不 tokenize 会把整段渲染成原始
-    // markdown 源码,review P1)。
+    // markdown 源码,review P1)。cindy-media 只收字节仓严格地址中的视频
+    // 后缀;由 managedMediaKind 让渲染层走既有媒体查看器/远端取件,绝不把
+    // 私有 scheme 交给 Linking.openURL。
     matchRegex(
       input,
       from,
       new RegExp(
-        `\\[([^\\]]+)\\]\\(((?:https?://|(?:${DEEP_LINK_SCHEME_GROUP})://(?:session|project)/)[^)\\s]+)\\)`,
+        `\\[([^\\]]+)\\]\\(((?:https?://|(?:${DEEP_LINK_SCHEME_GROUP})://(?:session|project)/)[^)\\s]+|cindy-media://blobs/[0-9a-f]{64}\\.(?:mp4|webm|mov))\\)`,
         'g',
       ),
-      (match) => ({
-        type: 'link' as const,
-        text: match[1],
-        url: trimUrlPunctuation(match[2]),
-      }),
+      (match) => {
+        const url = trimUrlPunctuation(match[2]);
+        return {
+          type: 'link' as const,
+          text: match[1],
+          url,
+          ...(url.startsWith('cindy-media://') ? { managedMediaKind: 'video' as const } : {}),
+        };
+      },
     ),
     // 本地路径链接:[README.md](/abs/path/README.md:17) 这类模型高频输出形态。
     // URL 经 classifyChatPathLinkTarget 判形状(http/session 之外的路径形态才收),


### PR DESCRIPTION
## 这次改了什么

### 摘要

Mobile now recognizes canonical `cindy-media://blobs/<sha256>.(mp4|webm|mov)` destinations in explicit Markdown links and opens them through the existing media payload viewer. This lets the viewer use the established device-link fetch, MIME validation, and video player path instead of leaving the Markdown literal or passing a private scheme to the OS.

### 变更类型

- [ ] `feat` 新功能
- [x] `fix` 缺陷修复
- [ ] `refactor` / `perf` 重构或性能优化
- [ ] `docs` / `test` / `chore` 文档、测试或工程维护
- [ ] 其他：

### 范围

- 关联 Issue / 需求：Closes #4171
- 本 PR 包含：mobile Markdown managed-video link classification, media-viewer tap routing, and parser regression coverage.
- 明确不包含：bare private-URL autolinking or direct OS handling of private schemes.
- 用户可见变化：On mobile, tapping a labeled managed-video Markdown link opens the existing video viewer.
- 是否存在 breaking change：无。

### UI 变化

No layout or copy changes. This adds the missing tap behavior to an existing Markdown label and reuses the existing media viewer.

- 引用的设计规范：`docs/design-rules/DESIGN.md` §14.5; the label receives link styling only when an `onPress` handler exists, preserving the existing clickable-signal rule.

## 怎么验证的

### 自动验证

```text
pnpm --filter mobile exec vitest run src/__tests__/messageMarkdown.test.ts
结果：115 tests passed

pnpm test:unit:related
结果：apps/mobile related unit gate passed

pnpm --filter mobile run --if-present typecheck
结果：passed

pnpm check:dco
结果：1 commit signed off; 1 merge commit exempt

git diff --check origin/main...HEAD
结果：passed
```

## 风险

### 风险分类

- [ ] 无已知风险
- [ ] SQLite / migration
- [ ] system prompt
- [ ] 协议兼容
- [ ] 权限 / 安全 / 用户数据
- [ ] 存量插件兼容（批准状态 / 指纹 / manifest 校验 / 安装布局 / 包格式）
- [ ] 原生层 / fingerprint / OTA
- [x] 跨平台差异
- [ ] 其他：

### 影响与回滚

- 影响范围：Android and iOS native Markdown text rendering for explicit canonical managed-video links. The parser accepts only the same SHA-256 blob shape and video-extension allowlist as the desktop media store.
- 回滚 / 降级方式：Revert this PR; affected links return to literal text on mobile. No persisted data or wire protocol changes are involved.

### 提交前检查

- [x] 已 review 完整 diff
- [x] 每个 commit 都带 DCO 签名（`git commit -s`，见 [DCO](../DCO)）
- [x] UI 改动已在「UI 变化」注明引用的设计规范章节（不涉及 UI 则跳过）
- [x] 未提交凭证、令牌或授权文件
- [x] 已补充必要文档（不需要额外文档；行为由回归测试覆盖）
- [x] 已确认上述测试结果