### PR TITLE
fix(auto-review): 第一方 Art 作图不再弹手动授权

### DIFF
--- a/apps/desktop/src/main/maker-host/__tests__/mcpToolApprovalPolicy.test.ts
+++ b/apps/desktop/src/main/maker-host/__tests__/mcpToolApprovalPolicy.test.ts
@@ -358,6 +358,61 @@ describe('desktop MCP approval policy', () => {
     );
   });
 
+  it('auto-approves first-party Cindy Art media ghost_call tools without prompting', () => {
+    for (const tool of ['gen_image', 'edit_image', 'gen_video', 'edit_video']) {
+      expect(
+        getDesktopMcpToolApprovalPolicy({
+          serverName: 'cindy',
+          toolName: 'ghost_call',
+          toolParams: { ghost_id: 'cindy-art', tool, args: { prompt: 'a cat' } },
+        }),
+        `${tool} should be auto-approved`,
+      ).toBe('auto-approve');
+    }
+
+    // Codex elicitation 可能省略外层 toolName，仍按内层 ghost_id / tool 判定。
+    expect(
+      getDesktopMcpToolApprovalPolicy({
+        serverName: 'cindy',
+        toolParams: { ghost_id: 'cindy-art', tool: 'gen_image', args: { prompt: 'a cat' } },
+      }),
+    ).toBe('auto-approve');
+    expect(
+      getDesktopMcpToolApprovalPolicy({
+        serverName: 'cindy',
+        toolName: 'ghost_call',
+        toolParams: JSON.stringify({
+          ghost_id: 'cindy-art',
+          tool: 'gen_image',
+          args: { prompt: 'a cat' },
+        }),
+      }),
+    ).toBe('auto-approve');
+
+    // 其它插件、未知工具、缺内层身份仍 fail closed。
+    expect(
+      getDesktopMcpToolApprovalPolicy({
+        serverName: 'cindy',
+        toolName: 'ghost_call',
+        toolParams: { ghost_id: 'google-gmail', tool: 'gmail', args: { action: 'send' } },
+      }),
+    ).toBe('prompt');
+    expect(
+      getDesktopMcpToolApprovalPolicy({
+        serverName: 'cindy',
+        toolName: 'ghost_call',
+        toolParams: { ghost_id: 'cindy-art', tool: 'unknown_tool' },
+      }),
+    ).toBe('prompt');
+    expect(
+      getDesktopMcpToolApprovalPolicy({
+        serverName: 'cindy',
+        toolName: 'ghost_call',
+        toolParams: { tool: 'gen_image' },
+      }),
+    ).toBe('prompt');
+  });
+
   it('auto-approves the browser call_tool entry that Claude used to prompt for every time', () => {
     // 回归锚点: cindy_browser 的真实动作全部走 call_tool。Claude 侧过去只静态放行
     // list_tools, 于是每次 navigate / snapshot / click 都弹一次窗。

--- a/apps/desktop/src/main/maker-host/mcp-tool-approval-policy.ts
+++ b/apps/desktop/src/main/maker-host/mcp-tool-approval-policy.ts
@@ -13,8 +13,9 @@
  * 判定顺序（从最窄到最宽）：
  *   1. READ_ONLY_MCP_TOOLS —— 精确到工具的只读发现入口，server 未整体可信也放行
  *   2. cindy_contacts     —— 按内层 action 细粒度判定（见 contacts/approval.ts）
- *   3. TRUSTED_MCP_SERVERS —— 已 review 的第一方 server，整体静默
- *   4. 其余                —— 逐次弹窗（第三方 server、cindy_ssh、插件 ghost_call…）
+ *   3. cindy-art ghost_call —— 第一方作图/视频内层工具静默；其它插件仍逐次确认
+ *   4. TRUSTED_MCP_SERVERS —— 已 review 的第一方 server，整体静默
+ *   5. 其余                —— 逐次弹窗（第三方 server、cindy_ssh、其它 ghost_call…）
  */
 
 import type {
@@ -173,6 +174,29 @@ function skipsRoutelessDeviceApproval(args: unknown): boolean {
   return !hasIOSSimulatorInstanceRoute(parsed);
 }
 
+/** 第一方 Cindy Art 的媒体生成工具。风险是额度而非越权，用户点名作图即授权。 */
+const CINDY_ART_MEDIA_TOOLS: ReadonlySet<string> = new Set([
+  'gen_image',
+  'edit_image',
+  'gen_video',
+  'edit_video',
+]);
+
+/**
+ * ghost_call 是聚合入口，默认逐次确认。Cindy Art 的作图/改图/视频是第一方媒体
+ * 能力，用户发「画一张」即构成授权；Auto-review 下再弹卡会把常规作图变成手动授权。
+ * 读不出 ghost_id / tool 时 fail closed，其它插件不受影响。
+ */
+function canAutoApproveCindyArtGhostCall(context: McpToolApprovalContext): boolean {
+  if (context.serverName !== 'cindy') return false;
+  if (context.toolName !== 'ghost_call' && context.toolName !== undefined) return false;
+  const params = readJsonObject(context.toolParams);
+  if (!params) return false;
+  const ghostId = typeof params.ghost_id === 'string' ? params.ghost_id.trim() : '';
+  const tool = typeof params.tool === 'string' ? params.tool.trim() : '';
+  return ghostId === 'cindy-art' && CINDY_ART_MEDIA_TOOLS.has(tool);
+}
+
 /** Claude SDK 工具名格式固定为 `mcp__<server>__<tool>`。 */
 function toClaudeToolName(key: string): string {
   const [serverName, toolName] = key.split('::');
@@ -202,6 +226,9 @@ export function getDesktopMcpToolApprovalPolicy(
     return canAutoApproveContactsMcpTool({ toolName, toolParams })
       ? 'auto-approve'
       : 'prompt-each-time';
+  }
+  if (canAutoApproveCindyArtGhostCall(context)) {
+    return 'auto-approve';
   }
   const iosSimulatorCall = readIOSSimulatorInnerCall(context);
   if (iosSimulatorCall) {


### PR DESCRIPTION
## 这次改了什么

### 摘要

Pi Auto-review 下调用第一方 Cindy Art 作图时会弹出手动授权卡。`ghost_call` 是聚合入口，默认逐次确认；Pi 没有原生 reviewer，灰区审阅在 GLM 等路径上失败或过于保守就会打扰用户。本 PR 按内层工具静默放行 `cindy-art` 的 `gen_image` / `edit_image` / `gen_video` / `edit_video`，其它插件仍走原确认链。

### 变更类型

- [x] `fix` 缺陷修复

### 范围

- 关联 Issue / 需求：Pi GLM + Auto-review 下 Cindy Art 作图弹出手动授权
- 本 PR 包含：Desktop MCP 审批策略对第一方 Art 媒体 `ghost_call` 的内层放行，以及对应单测
- 明确不包含：GLM 专用 Auto-review 模型链、当前会话模型兜底、其它插件 `ghost_call`、Ask/Full Access 档位语义重做、Art 插件/cindySlot/附件过户
- 用户可见变化：Pi Auto-review 下用 Cindy Art 作图/改图/视频不再弹出工具授权卡
- 是否存在 breaking change：无

### UI 变化

- 引用的设计规范：不涉及：只改 Host MCP 审批策略，无界面、交互或文案改动

## 怎么验证的

### 自动验证

```text
pnpm --filter desktop exec vitest run src/main/maker-host/__tests__/mcpToolApprovalPolicy.test.ts
结果：15 tests passed

pnpm --filter desktop run typecheck
结果：通过

pnpm test:unit:related
结果：desktop / mobile / lizi-mcps / maker-shared / model-providers / orca-workflow 通过。
maker-core 有 1 条既有环境失败（cindyBridgeSource.test.ts 缺少 worktree 内 apps/ripgrep-bin/darwin-arm64/rg），与本 diff 无关。
```

### 手工验证

未做正式版实机点选。用户可在 Pi + GLM + Auto-review 下发「画一张…」，确认不再出授权卡。工作区外附件过户确认应仍在。

### 未执行的验证

正式版 Desktop 实机：Pi GLM Auto-review 作图路径。原因：worktree 改动不能热更到宿主 app。

## 风险

### 风险分类

- [x] 权限 / 安全 / 用户数据

### 影响与回滚

- 影响范围：仅 `cindy-art` 的四个媒体工具。Gmail / GitHub / 第三方插件 `ghost_call` 仍确认。工作区外附件过户确认不变。该策略在 Ask 档也会静默放行这些 Art 工具（与第一方 browser 同类）。
- 回滚 / 降级方式：revert 本 PR 即可恢复对 Art `ghost_call` 的逐次确认。

### 提交前检查

- [x] 已 review 完整 diff
- [x] 每个 commit 都带 DCO 签名（`git commit -s`，见 [DCO](../DCO)）
- [x] UI 改动已在「UI 变化」注明引用的设计规范章节（不涉及 UI 则跳过）
- [x] 未提交凭证、令牌或授权文件
- [x] 已补充必要文档
- [x] 已确认测试结果或说明未执行原因
