### PR TITLE
fix(desktop): 修复同名模型 pill 的来源解析

### DIFF
--- a/apps/desktop/src/renderer/__tests__/modelSelectorTriggerVariant.test.ts
+++ b/apps/desktop/src/renderer/__tests__/modelSelectorTriggerVariant.test.ts
@@ -3037,4 +3037,75 @@ describe('ModelSelector trigger variants', () => {
       providersRef.providers = providersRef.DEFAULT_PROVIDERS;
     }
   });
+
+  it('does not borrow same-id trigger metadata from another provider', () => {
+    providersRef.providers = [
+      {
+        id: 'kimi-cn',
+        name: 'China source',
+        connected: true,
+        agents: ['claude-code'],
+        routing: { 'claude-code': {} },
+        models: {
+          'claude-code': [
+            {
+              id: 'kimi-k3',
+              name: 'China Kimi K3',
+              contextWindow: 262144,
+              efforts: ['high'],
+              defaultEffort: 'high',
+            },
+          ],
+        },
+      },
+      {
+        id: 'kimi-global',
+        name: 'Global source',
+        connected: true,
+        agents: ['claude-code'],
+        routing: { 'claude-code': {} },
+        models: {
+          'claude-code': [
+            {
+              id: 'kimi-k3',
+              name: 'Global Kimi K3',
+              contextWindow: 262144,
+              efforts: ['high'],
+              defaultEffort: 'high',
+            },
+          ],
+        },
+      },
+    ];
+    visibleModelsRef.models = [
+      {
+        id: 'kimi-k3',
+        displayName: 'Global Kimi K3',
+        contextWindow: 262144,
+        efforts: ['high'],
+        defaultEffort: 'high',
+      },
+    ];
+
+    try {
+      render(
+        React.createElement(ModelSelector, {
+          modelId: 'kimi-k3',
+          effort: 'high',
+          onModelChange: vi.fn(),
+          onEffortChange: vi.fn(),
+          vendorKey: 'cc',
+          currentProviderId: 'kimi-selected-account',
+          actualRoute: true,
+        }),
+      );
+
+      const trigger = screen.getByRole('button', { name: /Current: kimi-k3/ });
+      expect(trigger.textContent).toContain('kimi-k3');
+      expect(trigger.textContent).not.toContain('Global Kimi K3');
+    } finally {
+      providersRef.providers = providersRef.DEFAULT_PROVIDERS;
+      visibleModelsRef.models = null;
+    }
+  });
 });

--- a/apps/desktop/src/renderer/components/new-chat/ModelSelector.tsx
+++ b/apps/desktop/src/renderer/components/new-chat/ModelSelector.tsx
@@ -104,6 +104,7 @@ import {
   chatEligibleSourcesForModel,
   actualSourceIdForModel,
   effectiveSourceIdForModel,
+  findCatalogModel,
   getModel,
   modelSupportsFastMode,
   providerOffersModel,
@@ -3395,10 +3396,18 @@ export function ModelSelector({
   );
 
   const routeProvider = currentProviderId ? providers.find((p) => p.id === currentProviderId) : undefined;
-  const routeModel = routeProvider && agentKind ? getModel(routeProvider, modelId, agentKind) : undefined;
+  const routeModel =
+    routeProvider && agentKind ? findCatalogModel(routeProvider, modelId, agentKind) : undefined;
+  const sameIdProviderCount = agentKind
+    ? providers.filter((provider) => providerOffersModel(provider, modelId, agentKind)).length
+    : 0;
+  // 显式来源暂时不在目录里时，只允许无歧义的兼容兜底；同 ID 跨来源若继续取拍平列表，
+  // pill 会稳定借到首个来源的名称/能力，和用户实际选中的路由相矛盾（#4123）。
   const currentModel = routeModel
     ? { ...routeModel, displayName: routeModel.name, id: modelId }
-    : visibleModels.find((m) => m.id === modelId);
+    : currentProviderId && sameIdProviderCount > 1
+      ? undefined
+      : visibleModels.find((m) => m.id === modelId);
   // 已保存模型即使隐藏、断开或下架，实际任务仍保留模型 ID；偏好字段可通过
   // unknownModelLabel 提供诊断文案。没有保存选择的入口才显示选择模型占位符。
   // unknown label 空串/全空白按缺省处理(否则 ?? 不回落,trigger 渲染成空白)。
@@ -3498,7 +3507,7 @@ export function ModelSelector({
   const activeThinkingToggle =
     currentAgentKind === 'pi' &&
     !!triggerProvider &&
-    getModel(triggerProvider, modelId, currentAgentKind)?.thinkingToggle === true;
+    findCatalogModel(triggerProvider, modelId, currentAgentKind)?.thinkingToggle === true;
   const showEffort =
     !fallbackOption?.active &&
     efforts.length > 0 &&
@@ -3526,14 +3535,14 @@ export function ModelSelector({
   // 缺省回落来源供应商标 —— 与列表行、手机版同一套口径(ModelIconMark)。
   const triggerModelIcon =
     triggerActiveProvider && currentAgentKind
-      ? getModel(triggerActiveProvider, modelId, currentAgentKind)?.icon
+      ? findCatalogModel(triggerActiveProvider, modelId, currentAgentKind)?.icon
       : undefined;
   const disconnectedProvider = currentProviderId
     ? providers.find((p) => p.id === currentProviderId)
     : undefined;
   const disconnectedModelIcon =
     disconnectedProvider && currentAgentKind
-      ? getModel(disconnectedProvider, modelId, currentAgentKind)?.icon
+      ? findCatalogModel(disconnectedProvider, modelId, currentAgentKind)?.icon
       : undefined;
   const triggerFastSupported =
     triggerActiveProvider && currentAgentKind


### PR DESCRIPTION
## 这次改了什么

### 摘要

聊天输入框的模型 pill 现在优先按显式选中的供应商解析模型元数据，并在同一模型 ID 同时存在于多个供应商时拒绝使用有歧义的拍平列表兜底，避免名称、图标和能力信息借用到另一来源。目录元数据查询统一复用 canonical/wire ID 兼容查找。

### 变更类型

- [x] ix 缺陷修复

### 范围

- 关联 Issue / 需求：Closes #4123
- 本 PR 包含：Desktop ModelSelector pill 元数据解析与回归测试
- 明确不包含：模型路由、供应商配置、持久化和服务端改动
- 用户可见变化：跨供应商存在同 ID 模型时，pill 不再展示另一来源的模型元数据
- 是否存在 breaking change：无

### UI 变化

- 引用的设计规范：不涉及：仅修正既有模型 pill 的数据来源，不改变布局、样式、交互或文案；现有 Light/Dark 语义 token 与组件结构保持不变。

## 怎么验证的

### 自动验证

`	ext
pnpm --filter desktop exec vitest run src/renderer/__tests__/modelSelectorTriggerVariant.test.ts src/renderer/__tests__/modelSelectorProviderGroups.test.tsx --pool=forks --maxWorkers=2
结果：2 files / 84 tests passed

pnpm test:unit:related
结果：apps/desktop related tests passed（44 files，803 tests）

pnpm --filter desktop run --if-present typecheck
结果：通过

pnpm check:dco -- --base origin/main
结果：1 commit signed off，检查通过

git diff --check
结果：通过
`

### 手工验证

未执行；本次以 jsdom 回归用例覆盖同 ID 跨来源的 pill 解析分支。

### 未执行的验证

未启动 Desktop 实机验证；未改变视觉样式、路由或持久化。

## 风险

### 风险分类

- [x] 无已知风险

### 影响与回滚

- 影响范围：Desktop 聊天输入框 ModelSelector 的当前模型名称、图标及能力元数据解析
- 回滚 / 降级方式：回滚本提交即可恢复旧解析逻辑；不涉及数据迁移或协议变化

### 提交前检查

- [x] 已 review 完整 diff
- [x] 每个 commit 都带 DCO 签名
- [x] UI 改动已在「UI 变化」注明引用的设计规范章节（不涉及 UI 则跳过）
- [x] 未提交凭证、令牌或授权文件
- [x] 已补充必要文档（不涉及，无需新增文档）
- [x] 已确认测试结果或说明未执行原因