### PR TITLE
fix(codex): allow trusted Nowledge plugin runtime

### DIFF
--- a/apps/desktop/src/main/__tests__/codexGlobalPlugins.test.ts
+++ b/apps/desktop/src/main/__tests__/codexGlobalPlugins.test.ts
@@ -8,6 +8,7 @@ import type { CapabilityRoutingPolicy } from '@cindy/maker-core';
 
 import {
   codexGlobalPluginsPaths,
+  prepareCodexAllowlistedPluginRuntimeConfig,
   prepareCodexGlobalPluginsBridge,
   writeFileAtomicIfUnchanged,
 } from '../maker-host/codex-global-plugins';
@@ -127,6 +128,66 @@ afterEach(async () => {
   const dirs = tmpDirs;
   tmpDirs = [];
   await Promise.all(dirs.map((dir) => fs.rm(dir, { recursive: true, force: true })));
+});
+
+describe('prepareCodexAllowlistedPluginRuntimeConfig', () => {
+  it('enables only an explicitly enabled cached allowlisted plugin', async () => {
+    const { codexHome, paths } = await setup();
+    await writePluginCache(paths.cacheDir, 'nowledge-community', 'nowledge-mem');
+    await writePluginCache(paths.cacheDir, 'personal', 'other-plugin');
+    await fs.writeFile(
+      paths.configFile,
+      [
+        '[plugins."nowledge-mem@nowledge-community"]',
+        'enabled = true',
+        '',
+        '[plugins."other-plugin@personal"]',
+        'enabled = true',
+        '',
+      ].join('\n'),
+      'utf8',
+    );
+
+    const result = await prepareCodexAllowlistedPluginRuntimeConfig(
+      codexHome,
+      ['nowledge-mem@nowledge-community'],
+    );
+
+    expect(result.enabledPluginIds).toEqual(['nowledge-mem@nowledge-community']);
+    expect(result.extraArgs).toEqual(expect.arrayContaining([
+      '--enable',
+      'plugins',
+      '--enable',
+      'hooks',
+      '--disable',
+      'remote_plugin',
+      '-c',
+      'plugins."nowledge-mem@nowledge-community".enabled=true',
+      '-c',
+      'plugins."other-plugin@personal".enabled=false',
+    ]));
+  });
+
+  it('keeps the plugin runtime disabled when the allowlisted plugin is disabled', async () => {
+    const { codexHome, paths } = await setup();
+    await writePluginCache(paths.cacheDir, 'nowledge-community', 'nowledge-mem');
+    await writePluginEnabledState(
+      paths.configFile,
+      'nowledge-mem',
+      'nowledge-community',
+      false,
+    );
+
+    await expect(
+      prepareCodexAllowlistedPluginRuntimeConfig(
+        codexHome,
+        ['nowledge-mem@nowledge-community'],
+      ),
+    ).resolves.toEqual({
+      extraArgs: ['--disable', 'plugins', '--disable', 'remote_plugin'],
+      enabledPluginIds: [],
+    });
+  });
 });
 
 describe('prepareCodexGlobalPluginsBridge', () => {

--- a/apps/desktop/src/main/__tests__/codexGlobalPlugins.test.ts
+++ b/apps/desktop/src/main/__tests__/codexGlobalPlugins.test.ts
@@ -33,6 +33,27 @@ async function writePluginCache(
   await fs.writeFile(path.join(dir, 'plugin.json'), `{"name":"${plugin}"}`, 'utf8');
 }
 
+async function writeLoadablePluginCache(
+  cacheDir: string,
+  marketplace: string,
+  plugin: string,
+  version = '1.0.0',
+): Promise<void> {
+  const dir = path.join(cacheDir, marketplace, plugin, version);
+  await fs.mkdir(path.join(dir, '.codex-plugin'), { recursive: true });
+  await fs.mkdir(path.join(dir, 'skills', 'memory'), { recursive: true });
+  await fs.writeFile(
+    path.join(dir, '.codex-plugin', 'plugin.json'),
+    JSON.stringify({ name: plugin, version, skills: './skills/' }),
+    'utf8',
+  );
+  await fs.writeFile(
+    path.join(dir, 'skills', 'memory', 'SKILL.md'),
+    '---\nname: memory\ndescription: Memory helper\n---\n',
+    'utf8',
+  );
+}
+
 async function writePluginEnabledState(
   configFile: string,
   plugin: string,
@@ -133,7 +154,11 @@ afterEach(async () => {
 describe('prepareCodexAllowlistedPluginRuntimeConfig', () => {
   it('enables only an explicitly enabled cached allowlisted plugin', async () => {
     const { codexHome, paths } = await setup();
-    await writePluginCache(paths.cacheDir, 'nowledge-community', 'nowledge-mem');
+    await writeLoadablePluginCache(
+      paths.cacheDir,
+      'nowledge-community',
+      'nowledge-mem',
+    );
     await writePluginCache(paths.cacheDir, 'personal', 'other-plugin');
     await fs.writeFile(
       paths.configFile,
@@ -187,6 +212,88 @@ describe('prepareCodexAllowlistedPluginRuntimeConfig', () => {
       extraArgs: ['--disable', 'plugins', '--disable', 'remote_plugin'],
       enabledPluginIds: [],
     });
+  });
+
+  it('requires the allowlisted plugin to be explicitly enabled', async () => {
+    const { codexHome, paths } = await setup();
+    await writeLoadablePluginCache(
+      paths.cacheDir,
+      'nowledge-community',
+      'nowledge-mem',
+    );
+    await fs.writeFile(
+      paths.configFile,
+      '[plugins."nowledge-mem@nowledge-community"]\n',
+      'utf8',
+    );
+
+    await expect(
+      prepareCodexAllowlistedPluginRuntimeConfig(
+        codexHome,
+        ['nowledge-mem@nowledge-community'],
+      ),
+    ).resolves.toEqual({
+      extraArgs: ['--disable', 'plugins', '--disable', 'remote_plugin'],
+      enabledPluginIds: [],
+    });
+  });
+
+  it('rejects an empty cache for an enabled allowlisted plugin', async () => {
+    const { codexHome, paths } = await setup();
+    await fs.mkdir(
+      path.join(paths.cacheDir, 'nowledge-community', 'nowledge-mem'),
+      { recursive: true },
+    );
+    await writePluginEnabledState(
+      paths.configFile,
+      'nowledge-mem',
+      'nowledge-community',
+      true,
+    );
+
+    await expect(
+      prepareCodexAllowlistedPluginRuntimeConfig(
+        codexHome,
+        ['nowledge-mem@nowledge-community'],
+      ),
+    ).rejects.toThrow(
+      'allowlisted Codex plugin cache is incomplete: nowledge-mem@nowledge-community',
+    );
+  });
+
+  it('rejects a cache whose manifest points to missing plugin content', async () => {
+    const { codexHome, paths } = await setup();
+    const versionDir = path.join(
+      paths.cacheDir,
+      'nowledge-community',
+      'nowledge-mem',
+      '1.0.0',
+    );
+    await fs.mkdir(path.join(versionDir, '.codex-plugin'), { recursive: true });
+    await fs.writeFile(
+      path.join(versionDir, '.codex-plugin', 'plugin.json'),
+      JSON.stringify({
+        name: 'nowledge-mem',
+        version: '1.0.0',
+        skills: './missing-skills/',
+      }),
+      'utf8',
+    );
+    await writePluginEnabledState(
+      paths.configFile,
+      'nowledge-mem',
+      'nowledge-community',
+      true,
+    );
+
+    await expect(
+      prepareCodexAllowlistedPluginRuntimeConfig(
+        codexHome,
+        ['nowledge-mem@nowledge-community'],
+      ),
+    ).rejects.toThrow(
+      'allowlisted Codex plugin cache is incomplete: nowledge-mem@nowledge-community',
+    );
   });
 });
 

--- a/apps/desktop/src/main/maker-host/codex-global-plugins.ts
+++ b/apps/desktop/src/main/maker-host/codex-global-plugins.ts
@@ -77,6 +77,11 @@ interface PrepareOptions {
   capabilityRouting?: CapabilityRoutingPolicy;
 }
 
+export interface CodexAllowlistedPluginRuntimeConfig {
+  extraArgs: string[];
+  enabledPluginIds: string[];
+}
+
 type PluginEnablementSnapshot =
   | { status: 'known'; enabledPluginKeys: ReadonlySet<string> }
   | { status: 'unknown' };
@@ -976,6 +981,60 @@ async function readPluginsTable(file: string): Promise<{
       plugins && typeof plugins === 'object' && !Array.isArray(plugins)
         ? (plugins as Record<string, unknown>)
         : {},
+  };
+}
+
+/**
+ * Build a complete local Codex plugin policy for one app-server spawn.
+ * Only explicitly enabled, cached entries from the host allowlist survive;
+ * every other configured plugin is disabled and remote installation stays off.
+ */
+export async function prepareCodexAllowlistedPluginRuntimeConfig(
+  codexHome: string,
+  allowedPluginIds: readonly string[],
+): Promise<CodexAllowlistedPluginRuntimeConfig> {
+  const paths = codexGlobalPluginsPaths(codexHome);
+  const { plugins } = await readPluginsTable(paths.configFile);
+  const allowed = new Set(allowedPluginIds);
+  const enabledPluginIds: string[] = [];
+
+  for (const pluginId of [...allowed].sort()) {
+    const config = plugins[pluginId];
+    if (!isRecord(config) || config['enabled'] === false) continue;
+    const marketplace = marketplaceOfPluginKey(pluginId);
+    if (!marketplace) continue;
+    const pluginName = pluginId.slice(0, -(marketplace.length + 1));
+    if (!(await isDirectory(path.join(paths.cacheDir, marketplace, pluginName)))) {
+      throw new Error(`allowlisted Codex plugin cache is missing: ${pluginId}`);
+    }
+    enabledPluginIds.push(pluginId);
+  }
+
+  if (enabledPluginIds.length === 0) {
+    return {
+      extraArgs: ['--disable', 'plugins', '--disable', 'remote_plugin'],
+      enabledPluginIds: [],
+    };
+  }
+
+  const enabled = new Set(enabledPluginIds);
+  const pluginOverrides = Object.keys(plugins)
+    .sort()
+    .flatMap((pluginId) => [
+      '-c',
+      `plugins.${JSON.stringify(pluginId)}.enabled=${enabled.has(pluginId)}`,
+    ]);
+  return {
+    extraArgs: [
+      '--enable',
+      'plugins',
+      '--enable',
+      'hooks',
+      '--disable',
+      'remote_plugin',
+      ...pluginOverrides,
+    ],
+    enabledPluginIds,
   };
 }
 

--- a/apps/desktop/src/main/maker-host/codex-global-plugins.ts
+++ b/apps/desktop/src/main/maker-host/codex-global-plugins.ts
@@ -984,9 +984,115 @@ async function readPluginsTable(file: string): Promise<{
   };
 }
 
+async function isNonEmptyFile(file: string): Promise<boolean> {
+  try {
+    const stat = await fsp.stat(file);
+    return stat.isFile() && stat.size > 0;
+  } catch {
+    return false;
+  }
+}
+
+async function hasLoadableSkillContent(
+  pluginVersionDir: string,
+  declaration: unknown,
+): Promise<boolean> {
+  if (typeof declaration !== 'string') return false;
+  let skillsDir: string;
+  try {
+    skillsDir = resolvePluginOwnedPath(pluginVersionDir, declaration);
+  } catch {
+    return false;
+  }
+  for (const skillName of await listDirectoryNames(skillsDir)) {
+    if (await isNonEmptyFile(path.join(skillsDir, skillName, 'SKILL.md'))) return true;
+  }
+  return false;
+}
+
+async function hasLoadableJsonMap(
+  pluginVersionDir: string,
+  declaration: unknown,
+  mapKey: string,
+): Promise<boolean> {
+  let entries: Record<string, unknown>;
+  if (isRecord(declaration)) {
+    entries = declaration;
+  } else if (typeof declaration === 'string') {
+    let configFile: string;
+    try {
+      configFile = resolvePluginOwnedPath(pluginVersionDir, declaration);
+      const config = await readJsonObject(configFile);
+      entries = isRecord(config[mapKey]) ? config[mapKey] : config;
+    } catch {
+      return false;
+    }
+  } else {
+    return false;
+  }
+  return Object.keys(entries).length > 0;
+}
+
+async function isLoadableCachedPluginVersion(
+  pluginVersionDir: string,
+  pluginName: string,
+  version: string,
+): Promise<boolean> {
+  let manifest: Record<string, unknown> | null = null;
+  try {
+    for (const relativeManifest of DISCOVERABLE_PLUGIN_MANIFEST_PATHS) {
+      const candidate = path.join(pluginVersionDir, relativeManifest);
+      if (!(await isNonEmptyFile(candidate))) continue;
+      manifest = await readJsonObject(candidate);
+      break;
+    }
+  } catch {
+    return false;
+  }
+  if (
+    !manifest ||
+    manifest['name'] !== pluginName ||
+    manifest['version'] !== version
+  ) {
+    return false;
+  }
+
+  const contentChecks: Promise<boolean>[] = [];
+  if ('skills' in manifest) {
+    contentChecks.push(hasLoadableSkillContent(pluginVersionDir, manifest['skills']));
+  }
+  if ('mcpServers' in manifest) {
+    contentChecks.push(
+      hasLoadableJsonMap(pluginVersionDir, manifest['mcpServers'], 'mcpServers'),
+    );
+  }
+  if ('hooks' in manifest) {
+    contentChecks.push(hasLoadableJsonMap(pluginVersionDir, manifest['hooks'], 'hooks'));
+  }
+  return contentChecks.length > 0 && (await Promise.all(contentChecks)).every(Boolean);
+}
+
+async function hasLoadableCachedPlugin(
+  pluginDir: string,
+  pluginName: string,
+): Promise<boolean> {
+  for (const version of await listDirectoryNames(pluginDir)) {
+    if (
+      await isLoadableCachedPluginVersion(
+        path.join(pluginDir, version),
+        pluginName,
+        version,
+      )
+    ) {
+      return true;
+    }
+  }
+  return false;
+}
+
 /**
  * Build a complete local Codex plugin policy for one app-server spawn.
- * Only explicitly enabled, cached entries from the host allowlist survive;
+ * Only explicitly enabled, loadable cached entries from the host allowlist survive;
  * every other configured plugin is disabled and remote installation stays off.
  */
 export async function prepareCodexAllowlistedPluginRuntimeConfig(
@@ -1000,12 +1106,16 @@ export async function prepareCodexAllowlistedPluginRuntimeConfig(
 
   for (const pluginId of [...allowed].sort()) {
     const config = plugins[pluginId];
-    if (!isRecord(config) || config['enabled'] === false) continue;
+    if (!isRecord(config) || config['enabled'] !== true) continue;
     const marketplace = marketplaceOfPluginKey(pluginId);
     if (!marketplace) continue;
     const pluginName = pluginId.slice(0, -(marketplace.length + 1));
-    if (!(await isDirectory(path.join(paths.cacheDir, marketplace, pluginName)))) {
+    const pluginDir = path.join(paths.cacheDir, marketplace, pluginName);
+    if (!(await isDirectory(pluginDir))) {
       throw new Error(`allowlisted Codex plugin cache is missing: ${pluginId}`);
+    }
+    if (!(await hasLoadableCachedPlugin(pluginDir, pluginName))) {
+      throw new Error(`allowlisted Codex plugin cache is incomplete: ${pluginId}`);
     }
     enabledPluginIds.push(pluginId);
   }

--- a/apps/desktop/src/main/maker-host/index.ts
+++ b/apps/desktop/src/main/maker-host/index.ts
@@ -99,6 +99,7 @@ import {
   getCodexHome,
   readClaudeApiKey,
 } from './auth-adapters.js';
+import { prepareCodexAllowlistedPluginRuntimeConfig } from './codex-global-plugins.js';
 import { syncOpenAiMediaAfterCodexAuthChange } from './model-discovery/openai-media.js';
 import {
   desktopSessionStorage,
@@ -1405,6 +1406,11 @@ export function getMaker(): Maker {
       binaryPath: codexPath,
       logger: desktopMakerLogger,
       disableCodexPluginRuntime: true,
+      prepareCodexPluginRuntimeConfig: ({ codexHome }) =>
+        prepareCodexAllowlistedPluginRuntimeConfig(
+          codexHome ?? getCodexHome(),
+          ['nowledge-mem@nowledge-community'],
+        ),
       registerLocalCodexAppServerProcess: ({ pid, role }) => registerCodexProcessRole(pid, role),
       // Codex 也接 Cindy MCP providers (跟 claude 共享同一份 provider instances);
       // codex 子进程没法消费 in-process JS instance, prepareCodexExtraSpawnConfig

--- a/packages/maker-core/src/agents/base-agent.ts
+++ b/packages/maker-core/src/agents/base-agent.ts
@@ -1008,6 +1008,18 @@ export interface AgentDeps {
   disableCodexPluginRuntime?: boolean;
 
   /**
+   * Optional local exception to the host-wide Codex plugin disable policy.
+   * The callback must return a complete, fail-closed spawn policy: when it
+   * throws, maker-core keeps all local Codex plugins disabled.
+   */
+  prepareCodexPluginRuntimeConfig?: (ctx: {
+    codexHome?: string;
+  }) => Promise<{
+    extraArgs: string[];
+    enabledPluginIds: string[];
+  }>;
+
+  /**
    * Codex 专用：登记本机 stdio app-server 的 PID 与职责。
    * 返回 disposer 时会跟随 transport close 调用；远端 SSH transport 不触发。
    */

--- a/packages/maker-core/src/agents/codex/index.test.ts
+++ b/packages/maker-core/src/agents/codex/index.test.ts
@@ -464,6 +464,45 @@ describe('CodexAgent spawn configuration', () => {
     await ordinaryAgain.close();
     await agent.dispose();
   });
+
+  it('keeps an allowlisted plugin runtime policy when dynamic spawn preparation fails', async () => {
+    const prepareCodexExtraSpawnConfig = vi.fn(async () => {
+      throw new Error('bridge unavailable');
+    });
+    const prepareCodexPluginRuntimeConfig = vi.fn(async () => ({
+      extraArgs: [
+        '--enable',
+        'plugins',
+        '--disable',
+        'remote_plugin',
+        '-c',
+        'plugins."nowledge-mem@nowledge-community".enabled=true',
+      ],
+      enabledPluginIds: ['nowledge-mem@nowledge-community'],
+    }));
+    const agent = new CodexAgent(createDeps({}, {
+      disableCodexPluginRuntime: true,
+      prepareCodexPluginRuntimeConfig,
+      prepareCodexExtraSpawnConfig,
+    }));
+
+    const handle = await agent.startSession({
+      sessionId: 'session-allowlisted-plugin-runtime-fallback',
+      model: 'gpt-5.4',
+      workingDir: '/repo',
+    });
+
+    expect(createdStdioOptions[0]?.extraArgs).toEqual([
+      '--enable',
+      'plugins',
+      '--disable',
+      'remote_plugin',
+      '-c',
+      'plugins."nowledge-mem@nowledge-community".enabled=true',
+    ]);
+    await handle.close();
+    await agent.dispose();
+  });
 });
 
 describe('CodexAgent oneShot dispatch guard', () => {

--- a/packages/maker-core/src/agents/codex/index.ts
+++ b/packages/maker-core/src/agents/codex/index.ts
@@ -2725,9 +2725,11 @@ export class CodexAgent extends BaseAgent {
 
     // 超集升格硬依赖 proxy。proxy 不可用时降级回原 gateway-key spawn 重来一轮;
     // 降级后 upgraded=false,循环至多跑两轮必收敛。
-    const baseExtraArgs = !remoteHostId && this.deps.disableCodexPluginRuntime
+    const disabledPluginRuntimeArgs = !remoteHostId && this.deps.disableCodexPluginRuntime
       ? ['--disable', 'plugins', '--disable', 'remote_plugin']
       : [];
+    let baseExtraArgs = [...disabledPluginRuntimeArgs];
+    let enabledPluginIds: string[] = [];
     let effectiveMode: AgentCredentialMode | undefined;
     let env: Record<string, string> = {};
     let extraArgs = [...baseExtraArgs];
@@ -2764,6 +2766,27 @@ export class CodexAgent extends BaseAgent {
       env = await buildCodexEnv(this.deps.auth, this.deps.runtimeConfig, authOptions);
       assertCurrentGeneration('env');
 
+      baseExtraArgs = [...disabledPluginRuntimeArgs];
+      enabledPluginIds = [];
+      if (
+        !remoteHostId
+        && this.deps.disableCodexPluginRuntime
+        && this.deps.prepareCodexPluginRuntimeConfig
+      ) {
+        try {
+          const pluginRuntime = await this.deps.prepareCodexPluginRuntimeConfig({
+            codexHome: env.CODEX_HOME,
+          });
+          assertCurrentGeneration('plugin runtime config');
+          baseExtraArgs = [...pluginRuntime.extraArgs];
+          enabledPluginIds = [...pluginRuntime.enabledPluginIds];
+        } catch (error) {
+          this.deps.logger.error(
+            'Codex allowlisted plugin runtime prep failed; keeping plugins disabled',
+            { message: error instanceof Error ? error.message : String(error) },
+          );
+        }
+      }
       extraArgs = [...baseExtraArgs];
       codexProxyActive = false;
       codexBrowserUseAvailable = false;
@@ -2887,7 +2910,12 @@ export class CodexAgent extends BaseAgent {
       break;
     }
     if (!remoteHostId && sqliteHome) extraArgs.push('-c', `sqlite_home=${JSON.stringify(sqliteHome)}`);
-    if (baseExtraArgs.length > 0) {
+    if (enabledPluginIds.length > 0) {
+      this.deps.logger.info('Codex allowlisted plugin runtime enabled for local app-server', {
+        pluginIds: enabledPluginIds,
+        remotePlugin: false,
+      });
+    } else if (disabledPluginRuntimeArgs.length > 0) {
       this.deps.logger.info('Codex plugin runtime disabled for local app-server', {
         plugins: false,
         remotePlugin: false,


### PR DESCRIPTION
## 这次改了什么

### 摘要

Cindy 当前为本地 Codex app-server 一刀切关闭插件运行时，以规避不兼容插件造成的假可用状态；这也会阻止用户已经明确启用的 Nowledge Mem 官方 Connector。

本 PR 保留默认禁用策略，只对 Cindy 明确允许、用户配置明确启用且本地缓存完整的 `nowledge-mem@nowledge-community` 开放本地插件与 Hook 运行时。其他已配置插件仍通过逐项 CLI override 强制禁用，远程插件安装继续关闭；任何准备失败都回退为全禁用。

### 变更类型

- [ ] `feat` 新功能
- [x] `fix` 缺陷修复
- [ ] `refactor` / `perf` 重构或性能优化
- [ ] `docs` / `test` / `chore` 文档、测试或工程维护
- [ ] 其他：

### 范围

- 关联 Issue / 需求：#1970；延续 #3160 的本地 Codex 插件隔离边界
- 本 PR 包含：本地 Codex spawn 的 fail-closed allowlist 回调、Nowledge Connector 单项放行、单元测试
- 明确不包含：远程 Codex 插件、运行时安装插件、Pi Connector、Cindy 原生 transcript sync
- 用户可见变化：在 Cindy 隔离 Codex Home 中明确启用 Nowledge Mem Connector 后，本地 Codex 会加载其官方插件与 Hook；其他插件不受影响
- 是否存在 breaking change：无

### UI 变化

不涉及。

- 引用的设计规范：不涉及

## 怎么验证的

### 自动验证

```text
pnpm --dir apps/desktop run typecheck
结果：通过

pnpm --dir apps/desktop exec vitest run src/main/__tests__/codexGlobalPlugins.test.ts --pool=threads --maxWorkers=1
结果：30/30 通过

pnpm --dir packages/maker-core exec vitest run src/agents/codex/index.test.ts -t 'CodexAgent spawn configuration' --pool=threads --maxWorkers=1
结果：3/3 通过

pnpm test:unit:related
结果：全部通过；apps/desktop 167.7s、packages/lizi-mcps 14.2s、packages/maker-core 76.4s、packages/orca-workflow 1.7s

git diff --check
结果：通过
```

### 手工验证

在 macOS arm64、Cindy 隔离 Codex Home 中按 Nowledge 官方插件安装脚本配置并通过 Codex Hook 信任审核；新建 Codex 会话发送唯一文本后，`nmem t search --source codex` 返回对应线程与原句，证明官方 Connector 的 Hook 采集链路可工作。

### 未执行的验证

未启动开发版 Cindy 并通过微信新建 Codex Session 做端到端回归；该路径需要可连接到当前移动端绑定的开发版宿主。新增单测已覆盖最终 app-server 参数策略。

## 风险

### 风险分类

- [ ] 无已知风险
- [ ] SQLite / migration
- [ ] system prompt
- [ ] 协议兼容
- [x] 权限 / 安全 / 用户数据
- [x] 存量插件兼容（批准状态 / 指纹 / manifest 校验 / 安装布局 / 包格式）
- [ ] 原生层 / fingerprint / OTA
- [ ] 跨平台差异
- [ ] 其他：

### 影响与回滚

- 影响范围：仅本地 Codex app-server；仅显式启用且缓存存在的 allowlist 插件会运行。远程 host 保持原逻辑。
- 存量插件影响：无。非 allowlist 插件继续被显式禁用；本 PR 不改变安装布局、批准状态、指纹或 manifest。
- 安全边界：读取隔离 Codex Home 的配置与缓存，不记录配置内容；缓存缺失、配置异常或回调抛错均回退到 `--disable plugins --disable remote_plugin`。
- 回滚 / 降级方式：移除 Desktop 注入的 `prepareCodexPluginRuntimeConfig` 回调即可恢复 #3160 的全禁用行为；用户也可在隔离配置中禁用 Nowledge 插件，运行时将保持全禁用。

### 提交前检查

- [x] 已 review 完整 diff
- [x] 每个 commit 都带 DCO 签名（`git commit -s`，见 [DCO](../DCO)）
- [x] UI 改动已在「UI 变化」注明引用的设计规范章节（不涉及 UI 则跳过）
- [x] 未提交凭证、令牌或授权文件
- [x] 已补充必要文档
- [x] 已确认测试结果或说明未执行原因
