### PR TITLE
fix(desktop): 修复伙伴控制提示重复显示及折叠后消失

### DIFF
--- a/apps/desktop/src/renderer/__tests__/controlledBannerPlacement.test.ts
+++ b/apps/desktop/src/renderer/__tests__/controlledBannerPlacement.test.ts
@@ -20,7 +20,7 @@ describe('controlled banner placement', () => {
     expect(sessionViewSource).toContain('showControlledBanner?: boolean;');
     expect(sessionViewSource).toContain('showControlledBanner = false');
     expect(sessionViewSource).toContain(
-      'const showComposerControlledBanner = ownsRoute || showControlledBanner;',
+      'const showComposerControlledBanner = viewVisible && (ownsRoute || showControlledBanner);',
     );
     expect(sessionViewSource).toContain(
       'const hasControlledBanner = showComposerControlledBanner && controlledBy.length > 0;',
@@ -29,7 +29,7 @@ describe('controlled banner placement', () => {
       'const controlledBannerCollapsed = useComposerCollapsed(sessionId ?? null);',
     );
     expect(sessionViewSource).toContain(
-      'const showExpandedControlledBanner = hasControlledBanner && !controlledBannerCollapsed;',
+      'hasControlledBanner && (!controlledBannerCollapsed || Boolean(botChatIdentity));',
     );
     expect(sessionViewSource).toContain('placement="composer"');
     expect(sessionViewSource).toContain('sessionId={sessionId ?? null}');
@@ -42,7 +42,7 @@ describe('controlled banner placement', () => {
     expect(sessionViewSource).toContain(
       'const isHidden = suppressContent || (!showContent && !visible);',
     );
-    expect(sessionViewSource).toContain('{showExpandedControlledBanner && (');
+    expect(sessionViewSource).toContain('{showCenteredControlledBanner && (');
     expect(sessionViewSource).toContain('rightLeadingSlot?: ReactNode;');
     expect(sessionViewSource).toContain('{rightLeadingSlot}');
     expect(sessionViewSource).toContain('data-running-status-meta="true"');
@@ -128,7 +128,7 @@ describe('controlled banner placement', () => {
 
   it('opts in only route-owned chat views, not Worker panes or embedded doc rails', () => {
     expect(sessionViewSource).toContain(
-      'const showComposerControlledBanner = ownsRoute || showControlledBanner;',
+      'const showComposerControlledBanner = viewVisible && (ownsRoute || showControlledBanner);',
     );
     expect(routeSource).not.toContain('<CCAgentSessionView');
     expect(routeSource).not.toContain('showControlledBanner');
@@ -139,13 +139,8 @@ describe('controlled banner placement', () => {
     expect(workerPanelSource).not.toContain('showControlledBanner');
   });
 
-  it('suppresses the global floating fallback on legacy Orca redirect pages', () => {
-    expect(mainLayoutSource).toContain(
-      'function hasInlineControlledBannerPath(pathname: string): boolean',
-    );
-    expect(mainLayoutSource).toContain(
-      "return parts.length === 3 && parts[1] === 'orca' && parts[2] !== 'new';",
-    );
-    expect(mainLayoutSource).toContain('{!hasInlineControlledBanner && <ControlledBanner />}');
+  it('always mounts the global fallback so loading and unavailable routes retain a control notice', () => {
+    expect(mainLayoutSource).toContain('<ControlledBanner />');
+    expect(mainLayoutSource).not.toContain('hasInlineControlledBannerPath');
   });
 });

--- a/apps/desktop/src/renderer/components/layout/MainLayout.tsx
+++ b/apps/desktop/src/renderer/components/layout/MainLayout.tsx
@@ -141,8 +141,6 @@ interface RightSidebarSessionDeclarationOptions {
 
 const applicationMenuLog = createLogger('ApplicationMenu');
 const log = createLogger('MainLayout');
-// Keep in sync with single-segment static routes under /cc-agent in router.tsx.
-const CC_AGENT_STATIC_SEGMENTS = ['boot', 'files', 'new', 'new-dialogue', 'orca', 'scheduled'];
 
 function getInitialCollapsed(): boolean {
   // 「在新窗口打开」的副窗口默认折叠侧栏 —— 多开盯多个会话时,每个窗口都铺一条
@@ -189,13 +187,6 @@ function isZoomShortcutBlockedTarget(target: EventTarget | null): boolean {
       '[contenteditable="true"], .ProseMirror, .cm-editor, .cm-content, .cm-scroller, [role="textbox"]',
     ),
   );
-}
-
-function hasInlineControlledBannerPath(pathname: string): boolean {
-  const parts = pathname.split('/').filter(Boolean);
-  if (parts[0] !== 'cc-agent') return false;
-  if (parts.length === 2) return !CC_AGENT_STATIC_SEGMENTS.includes(parts[1]);
-  return parts.length === 3 && parts[1] === 'orca' && parts[2] !== 'new';
 }
 
 /**
@@ -398,7 +389,6 @@ export function MainLayout() {
   }, []);
 
   const isSettingsRoute = location.pathname === '/settings';
-  const hasInlineControlledBanner = hasInlineControlledBannerPath(location.pathname);
 
   // 完全隐藏态 hover 临时浮出(peek)状态机 —— hover 折叠按钮抽屉滑出预览,
   // 点击/⌘B 固定展开(pin)。rail 态(isCollapsed=false)不触发。见 useSidebarPeek。
@@ -1637,8 +1627,8 @@ export function MainLayout() {
           单例 + vanilla DOM,这里只挂一个空 React 节点,Phase 6 maximize 时
           会在这里加 layout 控制。 */}
       <BrowserWebviewPool />
-      {/* 被控端可见性:主聊天页在输入区内联渲染;其它页面保留全局兜底。 */}
-      {!hasInlineControlledBanner && <ControlledBanner />}
+      {/* 实际存在内联提示（含伙伴 / 折叠态）时组件自行退让，其余页面保留兜底。 */}
+      <ControlledBanner />
     </FeatureSidebarSlotProvider>
   );
 }

--- a/apps/desktop/src/renderer/features/cc-agent/CCAgentSessionView.tsx
+++ b/apps/desktop/src/renderer/features/cc-agent/CCAgentSessionView.tsx
@@ -856,11 +856,10 @@ export function CCAgentSessionView({
       viewVisible &&
       navigationMode !== 'sidebar-embedded' &&
       navigationMode !== 'split-pane');
-  const showComposerControlledBanner = ownsRoute || showControlledBanner;
+  const showComposerControlledBanner = viewVisible && (ownsRoute || showControlledBanner);
   const controlledBy = useControlledBy();
   const hasControlledBanner = showComposerControlledBanner && controlledBy.length > 0;
   const controlledBannerCollapsed = useComposerCollapsed(sessionId ?? null);
-  const showExpandedControlledBanner = hasControlledBanner && !controlledBannerCollapsed;
   const isMac = window.electronAPI?.platform === 'darwin';
   // messageWidth：消息流容器宽度（视觉边距 50px / compact 20px）
   // inputWidth：ChatInput / 状态栏 / workingDir 行的宽度（视觉边距 40px / compact 10px）
@@ -936,6 +935,9 @@ export function CCAgentSessionView({
   // 只有 URL 说了不算 —— 那是导航投影,不是身份。
   const botChatIdentity: BotChatIdentity | null =
     botIdentity && session?.source === 'bot' ? botIdentity : null;
+  // 伙伴没有 RunningStatusBar，折叠呼吸灯继续留在输入框上方，不能随状态行一起消失。
+  const showCenteredControlledBanner =
+    hasControlledBanner && (!controlledBannerCollapsed || Boolean(botChatIdentity));
   // assistant 气泡左侧的伙伴头像。节点在整场对话里是同一个,memo 住让 MessageItem
   // 的 memo 比较仍然成立(否则每帧新节点 = 全流重渲染)。
   const botAssistantAvatar = useMemo(
@@ -4783,7 +4785,7 @@ export function CCAgentSessionView({
                   }
                   className="mb-0"
                 />
-                {showExpandedControlledBanner && (
+                {showCenteredControlledBanner && (
                   <ControlledBanner
                     placement="composer"
                     maxWidth={controlledBannerMaxWidth}

--- a/apps/desktop/src/renderer/features/remote-device/ControlledBanner.tsx
+++ b/apps/desktop/src/renderer/features/remote-device/ControlledBanner.tsx
@@ -14,7 +14,14 @@
  * 完整设备名 + 远程控制逻辑说明。
  */
 
-import { useCallback, useEffect, useState, useSyncExternalStore, type CSSProperties } from 'react';
+import {
+  useCallback,
+  useEffect,
+  useLayoutEffect,
+  useState,
+  useSyncExternalStore,
+  type CSSProperties,
+} from 'react';
 import { useTranslation } from 'react-i18next';
 import { useNavigate } from 'react-router-dom';
 import { Eye, MonitorOff, X } from 'lucide-react';
@@ -42,6 +49,37 @@ interface Controller {
 let cachedControllers: Controller[] = [];
 let pushSubscribed = false;
 const controllerListeners = new Set<(c: Controller[]) => void>();
+
+// 按实际挂载的内联提示让全局浮条退让，不猜路由（伙伴也复用聊天视图）。
+// 多个 pane / 路由过渡可短暂共存，必须等最后一个内联提示卸载才恢复兜底。
+const inlineBannerOwners = new Set<symbol>();
+const inlineBannerListeners = new Set<() => void>();
+const getInlineBannerSnapshot = () => inlineBannerOwners.size > 0;
+function subscribeInlineBanners(listener: () => void) {
+  inlineBannerListeners.add(listener);
+  return () => {
+    inlineBannerListeners.delete(listener);
+  };
+}
+
+function useInlineBannerPresence(inline: boolean): boolean {
+  const hasInlineBanner = useSyncExternalStore(
+    subscribeInlineBanners,
+    getInlineBannerSnapshot,
+    getInlineBannerSnapshot,
+  );
+  useLayoutEffect(() => {
+    if (!inline) return;
+    const owner = Symbol();
+    inlineBannerOwners.add(owner);
+    for (const listener of inlineBannerListeners) listener();
+    return () => {
+      inlineBannerOwners.delete(owner);
+      for (const listener of inlineBannerListeners) listener();
+    };
+  }, [inline]);
+  return hasInlineBanner;
+}
 
 // composer 被控提示的折叠状态只在当前 renderer 生命周期内保存,并严格按 sessionId
 // 分桶。它不是全局偏好,不写 localStorage / DB / 服务端;切换任务时直接读取对应桶,
@@ -75,6 +113,8 @@ export function __resetControlledBannerForTests(): void {
   controllerListeners.clear();
   collapsedComposerSessionIds.clear();
   collapsedComposerListeners.clear();
+  inlineBannerOwners.clear();
+  inlineBannerListeners.clear();
 }
 
 function emitControllers(next: Controller[]) {
@@ -138,8 +178,11 @@ export function ControlledBanner({
   const controllers = useControlledBy();
   const composerSessionId = placement === 'composer' ? sessionId : null;
   const composerCollapsed = useComposerCollapsed(composerSessionId);
+  const hasInlineBanner = useInlineBannerPresence(
+    placement !== 'floating' && controllers.length > 0,
+  );
 
-  if (controllers.length === 0) return null;
+  if (controllers.length === 0 || (placement === 'floating' && hasInlineBanner)) return null;
 
   const label =
     controllers.length === 1

--- a/apps/desktop/src/renderer/features/remote-device/__tests__/ControlledBanner.test.tsx
+++ b/apps/desktop/src/renderer/features/remote-device/__tests__/ControlledBanner.test.tsx
@@ -1,7 +1,7 @@
 // @vitest-environment jsdom
 
-import type { ReactElement } from 'react';
-import { cleanup, fireEvent, render, screen } from '@testing-library/react';
+import { StrictMode, type ReactElement } from 'react';
+import { act, cleanup, fireEvent, render, screen } from '@testing-library/react';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 import { ControlledBanner, __resetControlledBannerForTests } from '../ControlledBanner';
@@ -102,5 +102,68 @@ describe('ControlledBanner composer collapse state', () => {
     expect(
       screen.getByRole('button', { name: 'remoteDevice.collapseControlledNotice' }),
     ).toBeTruthy();
+  });
+});
+
+describe('ControlledBanner floating fallback', () => {
+  it('yields to a mounted composer, including its collapsed indicator, and returns after unmount', async () => {
+    const fallback = render(<ControlledBanner />);
+    await screen.findByText('Controlled by iPhone');
+
+    const composer = render(<ControlledBanner placement="composer" sessionId="bot-session" />);
+    expect(screen.getAllByText('Controlled by iPhone')).toHaveLength(1);
+    expect(fallback.container.childElementCount).toBe(0);
+
+    fireEvent.click(screen.getByRole('button', { name: 'remoteDevice.collapseControlledNotice' }));
+    expect(screen.queryByText('Controlled by iPhone')).toBeNull();
+    expect(screen.getByRole('button', { name: 'Expand: Controlled by iPhone' })).toBeTruthy();
+    expect(fallback.container.childElementCount).toBe(0);
+
+    composer.unmount();
+    expect(screen.getAllByText('Controlled by iPhone')).toHaveLength(1);
+    expect(fallback.container.childElementCount).toBe(1);
+  });
+
+  it('waits for the last inline owner and survives StrictMode effect replay', async () => {
+    const fallback = render(<ControlledBanner />);
+    await screen.findByText('Controlled by iPhone');
+    const first = render(
+      <StrictMode>
+        <ControlledBanner placement="composer" sessionId="first" />
+      </StrictMode>,
+    );
+    const second = render(<ControlledBanner placement="inline" />);
+    expect(fallback.container.childElementCount).toBe(0);
+
+    first.unmount();
+    expect(fallback.container.childElementCount).toBe(0);
+    second.unmount();
+    expect(fallback.container.childElementCount).toBe(1);
+  });
+
+  it('handles placement changes without retaining a stale owner', async () => {
+    const view = render(<ControlledBanner placement="composer" sessionId="session" />);
+    await screen.findByText('Controlled by iPhone');
+    view.rerender(<ControlledBanner />);
+    expect(screen.getAllByText('Controlled by iPhone')).toHaveLength(1);
+    view.rerender(<ControlledBanner placement="inline" />);
+    expect(screen.getAllByText('Controlled by iPhone')).toHaveLength(1);
+    view.unmount();
+    render(<ControlledBanner />);
+    expect(screen.getAllByText('Controlled by iPhone')).toHaveLength(1);
+  });
+
+  it('shows neither surface after disconnect and restores only the composer on reconnect', async () => {
+    const fallback = render(<ControlledBanner />);
+    render(<ControlledBanner placement="composer" sessionId="session" />);
+    await screen.findByText('Controlled by iPhone');
+    const onControlledState = vi.mocked(window.electronAPI.deviceLink.onControlledState);
+    expect(onControlledState).toHaveBeenCalledTimes(1);
+    const push = onControlledState.mock.calls[0][0];
+    act(() => push({ controllers: [] }));
+    expect(document.querySelector('[data-controlled-banner-chip]')).toBeNull();
+    act(() => push({ controllers: [{ deviceId: 'iphone', name: 'iPhone' }] }));
+    expect(screen.getAllByText('Controlled by iPhone')).toHaveLength(1);
+    expect(fallback.container.childElementCount).toBe(0);
   });
 });


### PR DESCRIPTION
## 这次改了什么

### 摘要

伙伴聊天同时出现输入框上方和右下角两条「正在被控制」提示，右下角浮条遮挡输入区。原因是全局兜底按 `/cc-agent` 路由白名单判断，伙伴页复用聊天组件后两处同时渲染。

改为按实际挂载的内联提示登记与释放：存在完整提示或折叠呼吸灯时，全局浮条退让；最后一个内联提示卸载后恢复兜底。伙伴页没有普通任务状态栏，折叠呼吸灯保留在输入框上方；不可见聊天视图不占用提示位置。

### 变更类型

- [ ] `feat` 新功能
- [x] `fix` 缺陷修复
- [ ] `refactor` / `perf` 重构或性能优化
- [ ] `docs` / `test` / `chore` 文档、测试或工程维护
- [ ] 其他：

### 范围

- 关联 Issue / 需求：用户本机 macOS Cindy CN 0.1.76 伙伴页重复提示反馈，已直接观察运行窗口确认。
- 本 PR 包含：提示挂载互斥、伙伴折叠态可恢复、相关回归测试。
- 明确不包含：远程连接、授权撤销、协议、数据库及模型行为修改。
- 用户可见变化：同一页面只保留一处控制提示，伙伴折叠后仍能点呼吸灯展开。
- 是否存在 breaking change：无。

### UI 变化

- 引用的设计规范：`docs/design-rules/DESIGN.md` §1 内容克制、§5 Layout Principles、§10 Light / Dark Dual-Mode Delivery Gate。保留既有胶囊、语义颜色与输入框布局，仅修正重复挂载和折叠位置；亮暗模式均已实机目检。
- 平台：macOS，独立 Electron 开发版；截图仅含演示伙伴及回归任务。控制状态由本地测试夹具注入，实际 UI、路由与点击均使用应用源码；测试注入未提交。普通任务截图裁去底部账号用量信息。

| 伙伴展开（暗色） | 伙伴折叠（亮色） |
| --- | --- |
| ![伙伴展开](https://raw.githubusercontent.com/FicoHub/cindy/2dd3107b74f6f51053b4679e13b9527b2c7e6a33/bot-dark-expanded.png) | ![伙伴折叠](https://raw.githubusercontent.com/FicoHub/cindy/2dd3107b74f6f51053b4679e13b9527b2c7e6a33/bot-light-collapsed.png) |

<details>
<summary>其他主题、窄窗口与侧栏四形态回归截图</summary>

![伙伴亮色展开](https://raw.githubusercontent.com/FicoHub/cindy/2dd3107b74f6f51053b4679e13b9527b2c7e6a33/bot-light-expanded.png)
![伙伴暗色折叠](https://raw.githubusercontent.com/FicoHub/cindy/2dd3107b74f6f51053b4679e13b9527b2c7e6a33/bot-dark-collapsed.png)
![800px 窄窗口](https://raw.githubusercontent.com/FicoHub/cindy/2dd3107b74f6f51053b4679e13b9527b2c7e6a33/bot-narrow-expanded.png)
![折叠 rail 与悬浮面板](https://raw.githubusercontent.com/FicoHub/cindy/2dd3107b74f6f51053b4679e13b9527b2c7e6a33/task-rail-popup.png)
![一列卡片](https://raw.githubusercontent.com/FicoHub/cindy/2dd3107b74f6f51053b4679e13b9527b2c7e6a33/task-one-column.png)
![两列卡片](https://raw.githubusercontent.com/FicoHub/cindy/2dd3107b74f6f51053b4679e13b9527b2c7e6a33/task-two-columns.png)
![三列置顶卡片](https://raw.githubusercontent.com/FicoHub/cindy/2dd3107b74f6f51053b4679e13b9527b2c7e6a33/task-three-columns.png)

折叠 rail 按当前实现为 78px；本 PR 不修改侧栏尺寸或布局。

</details>

## 怎么验证的

### 自动验证

```text
pnpm test:unit:related
pnpm --filter desktop run --if-present typecheck
pnpm --filter desktop exec vitest run src/renderer/features/remote-device/__tests__/ControlledBanner.test.tsx
pnpm check:dco
git diff --check
结果：全部通过；5 个修改文件的定向 ESLint 通过。
```

新增回归测试在修复前有 3 项失败，修复后 5 项全部通过。覆盖完整/折叠提示互斥、多个内联实例、StrictMode 重挂、placement 切换、卸载恢复与断线重连；同步维护布局接线测试。

### 手工验证

自行通过原生 CDP 操作独立 Electron 开发版，12 项伙伴场景及 6 项普通任务/侧栏场景断言通过：展开、折叠、再次展开、设置页兜底、伙伴入口重定向、不可用伙伴页兜底、切回伙伴、断开/恢复模拟控制状态、亮暗主题、800px 窄窗口，以及普通任务折叠和四种侧栏形态。截图均已目检。

### 未执行的验证

Windows/Linux UI 及真实双机断线重连未实测；本次仅修改 Renderer 呈现，跨设备状态通过测试夹具复现。原始正式版现场仅观察，未替换正式 App。开发版在 Playwright 路由拦截验证期间曾出现 renderer crash（exitCode=11），改用原生 CDP 后上述流程完成；不将该工具路径记为通过。

## 风险

### 风险分类

- [x] 无已知风险
- [ ] SQLite / migration
- [ ] system prompt
- [ ] 协议兼容
- [ ] 权限 / 安全 / 用户数据
- [ ] 存量插件兼容（批准状态 / 指纹 / manifest 校验 / 安装布局 / 包格式）
- [ ] 原生层 / fingerprint / OTA
- [ ] 跨平台差异
- [ ] 其他：

### 影响与回滚

- 影响范围：Desktop 控制提示的显示归属；多个实例按独立登记项释放，防止提前恢复或永久隐藏兜底。
- 回滚 / 降级方式：回滚本提交；无持久化格式变化。

### 提交前检查

- [x] 已 review 完整 diff
- [x] 每个 commit 都带 DCO 签名（`git commit -s`）
- [x] UI 改动已在「UI 变化」注明引用的设计规范章节
- [x] 未提交凭证、令牌或授权文件
- [x] 已补充必要文档（实现注释与 PR 验证说明）
- [x] 已确认测试结果或说明未执行原因
