### PR TITLE
fix(mobile): 幂等化 schedule 镜像失效,修复 Android 冷启动无限更新崩溃

### DIFF
--- a/apps/mobile/app/devices/[deviceId].tsx
+++ b/apps/mobile/app/devices/[deviceId].tsx
@@ -265,8 +265,17 @@ function DeviceDetailScreenContent() {
     swipeRegistry,
   } = useSessionListActions();
 
+  // Mirror 失效标记在权威同步成功前持续存在,所以同一 generation 只消费一次;
+  // 否则每次 sessions 引用变化(离线标记、后台对账)都会把本 effect 重新拉进
+  // 更新链(2026-09-10 Android Maximum update depth 崩溃)。会话列表晚于本次
+  // 消费到达的场景由 syncSessions 的权威索引重载兜底,不在此重复清理。
+  const consumedMirrorGenerationsRef = useRef<Map<string, number>>(new Map());
   useEffect(() => {
-    if (!deviceId || !scheduleMirrorInvalidations.has(deviceId)) return;
+    if (!deviceId) return;
+    const generation = scheduleMirrorInvalidations.get(deviceId);
+    if (generation === undefined) return;
+    if (consumedMirrorGenerationsRef.current.get(deviceId) === generation) return;
+    consumedMirrorGenerationsRef.current.set(deviceId, generation);
     setScheduleIndex((current) => invalidateRunningSessionScheduleEntries(
       current,
       sessions.map((session) => session.id),

--- a/apps/mobile/app/devices/[deviceId].tsx
+++ b/apps/mobile/app/devices/[deviceId].tsx
@@ -267,15 +267,35 @@ function DeviceDetailScreenContent() {
 
   // Mirror 失效标记在权威同步成功前持续存在,所以同一 generation 只消费一次;
   // 否则每次 sessions 引用变化(离线标记、后台对账)都会把本 effect 重新拉进
-  // 更新链(2026-09-10 Android Maximum update depth 崩溃)。会话列表晚于本次
-  // 消费到达的场景由 syncSessions 的权威索引重载兜底,不在此重复清理。
-  const consumedMirrorGenerationsRef = useRef<Map<string, number>>(new Map());
+  // 更新链(2026-09-10 Android Maximum update depth 崩溃)。代次内后进入可见
+  // 列表的会话仍要清 running:按 generation 记录已处理的会话,只处理增量。
+  // 标记被清除时丢弃消费记录——store 代次虽单调,这里同步重置可对账户切换等
+  // 全量重置场景保持正确。
+  const consumedMirrorGenerationsRef = useRef<Map<string, {
+    generation: number;
+    sessionIds: Set<string>;
+  }>>(new Map());
   useEffect(() => {
     if (!deviceId) return;
     const generation = scheduleMirrorInvalidations.get(deviceId);
-    if (generation === undefined) return;
-    if (consumedMirrorGenerationsRef.current.get(deviceId) === generation) return;
-    consumedMirrorGenerationsRef.current.set(deviceId, generation);
+    if (generation === undefined) {
+      consumedMirrorGenerationsRef.current.delete(deviceId);
+      return;
+    }
+    const consumed = consumedMirrorGenerationsRef.current.get(deviceId);
+    if (consumed?.generation === generation) {
+      const freshSessionIds = sessions
+        .filter((session) => !consumed.sessionIds.has(session.id))
+        .map((session) => session.id);
+      if (freshSessionIds.length === 0) return;
+      for (const id of freshSessionIds) consumed.sessionIds.add(id);
+      setScheduleIndex((current) => invalidateRunningSessionScheduleEntries(current, freshSessionIds));
+      return;
+    }
+    consumedMirrorGenerationsRef.current.set(deviceId, {
+      generation,
+      sessionIds: new Set(sessions.map((session) => session.id)),
+    });
     setScheduleIndex((current) => invalidateRunningSessionScheduleEntries(
       current,
       sessions.map((session) => session.id),

--- a/apps/mobile/src/__tests__/deviceScheduleVisibility.test.ts
+++ b/apps/mobile/src/__tests__/deviceScheduleVisibility.test.ts
@@ -3,6 +3,7 @@ import ts from 'typescript';
 import { beforeEach, expect, it, vi } from 'vitest';
 import {
   getScheduleIndexInvalidationVersion,
+  invalidateRunningSessionScheduleEntries,
   loadSharedSessionScheduleIndex,
   resetScheduleIndexThrottleForTesting,
 } from '@/session/scheduleIndex';
@@ -56,4 +57,60 @@ it.each(['blur', 'background'] as const)('reloads a cancelled first index after 
   run();
   await Promise.all(pending);
   expect(list).toHaveBeenCalledTimes(1);
+});
+
+// 2026-09-10 Android Maximum update depth 崩溃回归:mirror 失效标记在权威同步
+// 成功前持续存在,effect 必须对同一 generation 只消费一次,不能随 `sessions`
+// 引用变化(离线标记、后台对账)反复把 setScheduleIndex 拉进更新链。
+let mirrorEffectSource = '';
+let mirrorEffectDependencies: string[] = [];
+function visitMirrorEffect(node: ts.Node) {
+  if (ts.isCallExpression(node) && node.expression.getText(source) === 'useEffect'
+    && node.arguments[0]?.getText(source).includes('invalidateRunningSessionScheduleEntries')) {
+    mirrorEffectSource = node.arguments[0].getText(source);
+    mirrorEffectDependencies = (node.arguments[1] as ts.ArrayLiteralExpression).elements.map((e) => e.getText(source));
+  }
+  ts.forEachChild(node, visitMirrorEffect);
+}
+visitMirrorEffect(source);
+const runMirrorEffect = new Function(
+  'deviceId',
+  'scheduleMirrorInvalidations',
+  'consumedMirrorGenerationsRef',
+  'invalidateRunningSessionScheduleEntries',
+  'sessions',
+  'setScheduleIndex',
+  ts.transpile(`(${mirrorEffectSource})();`),
+);
+
+it('consumes a mirror invalidation generation once even as session identities churn', () => {
+  expect(mirrorEffectDependencies).toEqual(
+    expect.arrayContaining(['deviceId', 'scheduleMirrorInvalidations', 'sessions']),
+  );
+  const consumedMirrorGenerationsRef = { current: new Map<string, number>() };
+  const current = new Map([['s1', { running: true }]]);
+  const setScheduleIndex = vi.fn((updater: (map: typeof current) => typeof current) => updater(current));
+  const sessions = [{ id: 's1' }, { id: 's2' }];
+  const run = (generation: number | undefined, nextSessions: typeof sessions) => runMirrorEffect(
+    'device',
+    generation === undefined ? new Map() : new Map([['device', generation]]),
+    consumedMirrorGenerationsRef,
+    invalidateRunningSessionScheduleEntries,
+    nextSessions,
+    setScheduleIndex,
+  );
+
+  run(1, sessions);
+  // 同一 generation 内 sessions 引用变化(离线标记、对账重渲染)不得再次入链。
+  run(1, [...sessions]);
+  expect(setScheduleIndex).toHaveBeenCalledTimes(1);
+  const cleared = setScheduleIndex.mock.results[0]?.value;
+  expect(cleared?.get('s1')).toMatchObject({ running: false });
+
+  // 新 generation(失效后有新事件快照再被清)才允许消费下一次。
+  run(2, sessions);
+  expect(setScheduleIndex).toHaveBeenCalledTimes(2);
+  // 标记被清除(generation 消失)后回到静止,不得再触发。
+  run(undefined, sessions);
+  expect(setScheduleIndex).toHaveBeenCalledTimes(2);
 });

--- a/apps/mobile/src/__tests__/deviceScheduleVisibility.test.ts
+++ b/apps/mobile/src/__tests__/deviceScheduleVisibility.test.ts
@@ -83,15 +83,18 @@ const runMirrorEffect = new Function(
   ts.transpile(`(${mirrorEffectSource})();`),
 );
 
-it('consumes a mirror invalidation generation once even as session identities churn', () => {
+it('consumes a mirror invalidation generation once, with incremental sessions and reset on clear', () => {
   expect(mirrorEffectDependencies).toEqual(
     expect.arrayContaining(['deviceId', 'scheduleMirrorInvalidations', 'sessions']),
   );
-  const consumedMirrorGenerationsRef = { current: new Map<string, number>() };
-  const current = new Map([['s1', { running: true }]]);
+  const consumedMirrorGenerationsRef = {
+    current: new Map<string, { generation: number; sessionIds: Set<string> }>(),
+  };
+  // s3 在 scheduleIndex 里 running,但尚未进入当前可见会话列表。
+  const current = new Map([['s1', { running: true }], ['s3', { running: true }]]);
   const setScheduleIndex = vi.fn((updater: (map: typeof current) => typeof current) => updater(current));
   const sessions = [{ id: 's1' }, { id: 's2' }];
-  const run = (generation: number | undefined, nextSessions: typeof sessions) => runMirrorEffect(
+  const run = (generation: number | undefined, nextSessions: Array<{ id: string }>) => runMirrorEffect(
     'device',
     generation === undefined ? new Map() : new Map([['device', generation]]),
     consumedMirrorGenerationsRef,
@@ -106,11 +109,19 @@ it('consumes a mirror invalidation generation once even as session identities ch
   expect(setScheduleIndex).toHaveBeenCalledTimes(1);
   const cleared = setScheduleIndex.mock.results[0]?.value;
   expect(cleared?.get('s1')).toMatchObject({ running: false });
+  // 不可见的 s3 本轮不被触碰。
+  expect(cleared?.get('s3')).toMatchObject({ running: true });
 
-  // 新 generation(失效后有新事件快照再被清)才允许消费下一次。
-  run(2, sessions);
+  // 代次内后进入可见列表的会话要增量清理 running(greptile P1:遗漏后到会话)。
+  run(1, [...sessions, { id: 's3' }]);
   expect(setScheduleIndex).toHaveBeenCalledTimes(2);
-  // 标记被清除(generation 消失)后回到静止,不得再触发。
+  const incremental = setScheduleIndex.mock.results[1]?.value;
+  expect(incremental?.get('s3')).toMatchObject({ running: false });
+
+  // 标记被清除时丢弃消费记录;新一轮失效(更高代次)重新消费
+  // (codex P2:代次跨 marker 清除单调,不回绕)。
   run(undefined, sessions);
-  expect(setScheduleIndex).toHaveBeenCalledTimes(2);
+  expect(consumedMirrorGenerationsRef.current.has('device')).toBe(false);
+  run(2, sessions);
+  expect(setScheduleIndex).toHaveBeenCalledTimes(3);
 });

--- a/apps/mobile/src/__tests__/remoteScheduleEvents.test.ts
+++ b/apps/mobile/src/__tests__/remoteScheduleEvents.test.ts
@@ -99,6 +99,19 @@ describe('remote schedule event store', () => {
     expect(remoteScheduleEventStore.getVersion('dev-1')).toBe(0);
     expect(sub).toHaveBeenCalledTimes(3);
 
+    // 清除后再失效:代次跨 marker 清除单调前进,不回绕为 1——消费方据此识别
+    // 「离线 → 恢复 → 再离线」的新一轮失效(codex P2:代次回绕会让已消费
+    // 记录挡住第二次离线的 running 清理)。
+    remoteScheduleEventStore.clearDeviceMirrorInvalidation('dev-1');
+    expect(sub).toHaveBeenCalledTimes(4);
+    remoteScheduleEventStore.invalidateDeviceMirror('dev-1');
+    const afterReinvalidate = remoteScheduleEventStore.getMirrorInvalidationSnapshot();
+    expect(afterReinvalidate.get('dev-1')).toBe(3);
+    expect(sub).toHaveBeenCalledTimes(5);
+    // 幂等依旧:重复标记静默。
+    remoteScheduleEventStore.invalidateDeviceMirror('dev-1');
+    expect(sub).toHaveBeenCalledTimes(5);
+
     off();
   });
 

--- a/apps/mobile/src/__tests__/remoteScheduleEvents.test.ts
+++ b/apps/mobile/src/__tests__/remoteScheduleEvents.test.ts
@@ -70,7 +70,7 @@ describe('remote schedule event store', () => {
     off();
   });
 
-  it('publishes mirror invalidation even without an existing schedule event snapshot', () => {
+  it('publishes mirror invalidation once per generation and re-arms after a fresh event', () => {
     const before = remoteScheduleEventStore.getMirrorInvalidationSnapshot();
     const sub = vi.fn();
     const off = remoteScheduleEventStore.subscribe(sub);
@@ -83,11 +83,21 @@ describe('remote schedule event store', () => {
     expect(remoteScheduleEventStore.getVersion('dev-1')).toBe(0);
     expect(sub).toHaveBeenCalledTimes(1);
 
+    // 已失效且没有新事件快照:重复的离线标记(闪断、两层各标一次)必须静默,
+    // 否则挂载中的屏幕被反复拉进更新链(2026-09-10 Maximum update depth 崩溃)。
     remoteScheduleEventStore.invalidateDeviceMirror('dev-1');
-    const afterSecond = remoteScheduleEventStore.getMirrorInvalidationSnapshot();
-    expect(afterSecond).not.toBe(afterFirst);
-    expect(afterSecond.get('dev-1')).toBe(2);
+    expect(remoteScheduleEventStore.getMirrorInvalidationSnapshot()).toBe(afterFirst);
+    expect(sub).toHaveBeenCalledTimes(1);
+
+    // 失效后有新事件写入快照:快照重新上膛,下一次离线标记要清掉它并广播。
+    remoteScheduleEventStore.apply('dev-1', { type: 'fired', scheduleId: 'sched-1', runId: 'run-1' });
     expect(sub).toHaveBeenCalledTimes(2);
+    remoteScheduleEventStore.invalidateDeviceMirror('dev-1');
+    const afterThird = remoteScheduleEventStore.getMirrorInvalidationSnapshot();
+    expect(afterThird).not.toBe(afterFirst);
+    expect(afterThird.get('dev-1')).toBe(2);
+    expect(remoteScheduleEventStore.getVersion('dev-1')).toBe(0);
+    expect(sub).toHaveBeenCalledTimes(3);
 
     off();
   });

--- a/apps/mobile/src/scheduler/remoteScheduleEvents.ts
+++ b/apps/mobile/src/scheduler/remoteScheduleEvents.ts
@@ -74,6 +74,11 @@ export const remoteScheduleEventStore = {
 
   invalidateDeviceMirror(deviceId: string): void {
     if (!deviceId) return;
+    // 幂等:marker 尚在且没有新事件快照时,重复的离线标记(presence 闪断、首页与
+    // device-link 两层各标一次)不得再次 emit——否则挂载中的所有屏幕被反复拉进
+    // 更新链,最终触发 React Maximum update depth(2026-09-10 Android 冷启动崩溃)。
+    // 失效后有新事件写入快照时,快照重新上膛,这里照常清掉并广播一次。
+    if (!snapshots.has(deviceId) && mirrorInvalidationVersions.has(deviceId)) return;
     snapshots.delete(deviceId);
     mirrorInvalidationVersions.set(
       deviceId,

--- a/apps/mobile/src/scheduler/remoteScheduleEvents.ts
+++ b/apps/mobile/src/scheduler/remoteScheduleEvents.ts
@@ -36,6 +36,10 @@ const snapshots = new Map<string, RemoteScheduleEventSnapshot>();
 // `clearDevice()` so mounted screens can observe a presence-offline cleanup even when
 // that device had not emitted a schedule event in the current process.
 const mirrorInvalidationVersions = new Map<string, number>();
+// 单调代次计数:不随 `clearDeviceMirrorInvalidation` 回绕,消费方(设备详情页)
+// 据此区分「同一轮失效」与「清除后的新一轮失效」,离线 → 恢复 → 再离线时
+// running 徽标不会被已消费的旧代次挡住。
+const mirrorInvalidationGenerationCounter = new Map<string, number>();
 let mirrorInvalidationSnapshot: ReadonlyMap<string, number> = new Map();
 const subs = new Set<() => void>();
 
@@ -80,16 +84,16 @@ export const remoteScheduleEventStore = {
     // 失效后有新事件写入快照时,快照重新上膛,这里照常清掉并广播一次。
     if (!snapshots.has(deviceId) && mirrorInvalidationVersions.has(deviceId)) return;
     snapshots.delete(deviceId);
-    mirrorInvalidationVersions.set(
-      deviceId,
-      (mirrorInvalidationVersions.get(deviceId) ?? 0) + 1,
-    );
+    const generation = (mirrorInvalidationGenerationCounter.get(deviceId) ?? 0) + 1;
+    mirrorInvalidationGenerationCounter.set(deviceId, generation);
+    mirrorInvalidationVersions.set(deviceId, generation);
     mirrorInvalidationSnapshot = new Map(mirrorInvalidationVersions);
     emit();
   },
 
   clearDeviceMirrorInvalidation(deviceId: string): void {
     if (!mirrorInvalidationVersions.delete(deviceId)) return;
+    // 计数器不清:代次跨清除单调,下一轮失效的 generation 继续前进。
     mirrorInvalidationSnapshot = new Map(mirrorInvalidationVersions);
     emit();
   },
@@ -98,6 +102,7 @@ export const remoteScheduleEventStore = {
     if (snapshots.size === 0 && mirrorInvalidationVersions.size === 0) return;
     snapshots.clear();
     mirrorInvalidationVersions.clear();
+    mirrorInvalidationGenerationCounter.clear();
     mirrorInvalidationSnapshot = new Map();
     emit();
   },


### PR DESCRIPTION
## 这次改了什么

### 摘要

**配套硬化 PR**(崩溃主修复在 #4259 批量合并离线镜像通知,两 PR 相互独立、不互相依赖)。

背景:2026-09-10 Android 端 JS 层 `Maximum update depth exceeded` 致命崩溃,隔离复现定位为剂量依赖机制——presence 整批离线时每台设备各触发一轮 store 通知,设备数超过 React 嵌套更新上限(约 50)即致命退出(40 台正常,80 台第 53 次通知崩,同批处理仅 3 次渲染正常)。

本 PR 修掉排查中确认的三个真实缺陷,降低崩溃波里的重复通知与消费错乱(非主修复):

1. `invalidateDeviceMirror` 幂等:marker 已存在且没有新事件快照时不再重复 emit(presence 闪断、首页与 device-link 两层对同一设备重复标记时去重);快照被新事件重新写入后照常清除并广播一次。
2. 详情页 effect 对同一失效代次只消费一次;`sessions` 引用变化不再重复入链;同一代次内后进入可见列表的会话按增量补清 running;标记清除时同步丢弃消费记录。
3. 失效代次跨 marker 清除单调(离线 → 恢复 → 再离线不会被回绕代次挡住)。

### 变更类型

- [x] `fix` 缺陷修复

### 范围

- 关联 Issue / 需求:2026-09-10 Android 冷启动崩溃排查;主修复见 #4259
- 本 PR 包含:store 幂等化 + 代次单调、详情页 consume-once + 增量清理、测试
- 明确不包含:批量合并通知(#4259)
- 用户可见变化:无直接可见变化(硬化)
- 是否存在 breaking change:无

### UI 变化

- 引用的设计规范:不涉及。纯状态机/更新链逻辑修复,无视觉、交互或文案变化(命中 UI 路径的文件为设备详情页 screens,改动仅限 effect 触发语义与 store 幂等)

## 怎么验证的

### 自动验证

```text
pnpm test:unit:related
结果:apps/mobile 全部通过;desktop 与 maker-core 存在与本改动无关的既有本机失败
(已隔离验证,以 CI 为准)。

pnpm --filter mobile run typecheck
结果:通过。

node apps/mobile/scripts/ci-fingerprint.mjs compute(改动前后比对)
结果:iOS 8545caf7c05b591dc81a460f7ed6cd12f3e6f339 / Android 70a051193695c4af3775baa93c0d6db5e2c8bd82
前后完全一致 → 不触发冷更。
```

### 手工验证

不涉及(无实机回归条件)。

### 未执行的验证

Android 实机验证未在本地执行;语义已由 store 层与屏幕 effect 回归测试覆盖。

## 风险

### 风险分类

- [x] 无已知风险
- [x] 原生层 / fingerprint / OTA(仅指 OTA 下发,不触发冷更)

### 影响与回滚

- 影响范围:纯 JS 改动,只影响 `apps/mobile` 的 schedule 镜像失效广播与详情页 effect 消费语义;不改变 runtime fingerprint,不触发冷更。
- 回滚 / 降级方式:revert 本 PR 即可。

### 提交前检查

- [x] 已 review 完整 diff
- [x] 每个 commit 都带 DCO 签名(`git commit -s`,见 [DCO](../DCO))
- [x] UI 改动已在「UI 变化」注明(不涉及,附理由)
- [x] 未提交凭证、令牌或授权文件
- [x] 已确认测试结果或说明未执行原因