### PR TITLE
fix(mobile): 避免 Android 解析 iOS WebView 属性崩溃

### DIFF
--- a/apps/mobile/src/remote-desktop/RemoteDesktopScreen.tsx
+++ b/apps/mobile/src/remote-desktop/RemoteDesktopScreen.tsx
@@ -1527,7 +1527,7 @@ export default function RemoteDesktopScreen() {
             hideKeyboardAccessoryView
             textInteractionEnabled={false}
             allowsLinkPreview={false}
-            dataDetectorTypes="none"
+            {...(Platform.OS === "ios" ? { dataDetectorTypes: "none" as const } : {})}
             javaScriptEnabled
             allowsInlineMediaPlayback
             mediaPlaybackRequiresUserAction={false}

--- a/apps/mobile/src/remote-desktop/__tests__/screen.test.tsx
+++ b/apps/mobile/src/remote-desktop/__tests__/screen.test.tsx
@@ -68,6 +68,7 @@ const fixture = vi.hoisted(() => ({
   status: "online",
   appState: null as null | ((state: string) => void),
   crashed: null as null | (() => void),
+  webViewProps: null as null | Record<string, unknown>,
   retryPermissions: null as null | (() => void),
 }));
 vi.mock("react-native", async () => {
@@ -278,6 +279,7 @@ vi.mock("../PermissionGuide", () => ({
 }));
 vi.mock("react-native-webview", () => ({
   WebView: forwardRef((p: any, ref) => {
+    fixture.webViewProps = p;
     fixture.message = p.onMessage;
     fixture.crashed = p.onContentProcessDidTerminate;
     useImperativeHandle(ref, () => ({
@@ -313,6 +315,7 @@ beforeEach(() => {
   fixture.lockSupported = true;
   fixture.views = {};
   fixture.keyboardListeners = {};
+  fixture.webViewProps = null;
   vi.useFakeTimers();
   fixture.focused = true;
   fixture.status = "online";
@@ -377,6 +380,16 @@ const connect = async () => {
 };
 
 describe("remote desktop controls", () => {
+  it("keeps iOS data detection disabled without passing its prop to Android", async () => {
+    await act(async () => {});
+    expect(fixture.webViewProps).toMatchObject({ dataDetectorTypes: "none" });
+
+    fixture.platform = "android";
+    await act(async () => root.render(<RemoteDesktopScreen />));
+
+    expect(fixture.webViewProps).not.toHaveProperty("dataDetectorTypes");
+  });
+
   it("fetches ICE configuration only through native auth and sends sanitized short-term credentials", async () => {
     await connect();
     const iceServers = [


### PR DESCRIPTION
## 这次改了什么

### 摘要

Android 远程桌面页面此前会把仅供 iOS 使用的 `dataDetectorTypes="none"` 传给 WebView。`react-native-webview` 的 Android 包装层会继续透传该字段，而 Fabric 原生属性转换要求字符串数组，导致创建 `RNCWebView` 节点时发生宿主进程 SIGSEGV。

本 PR 将该属性限定为只在 iOS 上提供，并补充平台 props 回归测试，确保 Android 的最终 WebView props 中不存在 `dataDetectorTypes`。

### 变更类型

- [ ] `feat` 新功能
- [x] `fix` 缺陷修复
- [ ] `refactor` / `perf` 重构或性能优化
- [ ] `docs` / `test` / `chore` 文档、测试或工程维护
- [ ] 其他：

### 范围

- 关联 Issue / 需求：Android 远程桌面页面 native 崩溃
- 本 PR 包含：按平台限定 WebView 的 `dataDetectorTypes` 属性；增加 iOS 保留该属性、Android 完全省略该属性的回归测试
- 明确不包含：升级 `react-native-webview`、修改原生依赖或原生配置、调整远程桌面交互
- 用户可见变化：Android 打开远程桌面时不再因该 WebView 属性解析而崩溃；iOS 行为保持不变
- 是否存在 breaking change：无

### UI 变化

不涉及：仅修正平台 props 边界，没有视觉、布局、交互或文案变化。

- 引用的设计规范：不涉及：未改变 UI 呈现或交互

## 怎么验证的

### 自动验证

```text
pnpm --filter mobile run --if-present typecheck
结果：通过

pnpm test:unit:related
结果：通过，apps/mobile 相关单测通过

pnpm check:dco
结果：通过，1 个提交已签署
```

### 手工验证

未执行 Android 模拟器验证。回归测试直接检查传给 WebView 的最终 props：iOS 仍为 `dataDetectorTypes="none"`，Android 不含该字段。

### 未执行的验证

- 未运行 CN Android 模拟器：本次是纯 JS 属性分流，自动化测试已覆盖触发 native 崩溃前的精确属性边界；没有启动 Metro，因此无 branch/worktree、Metro 归属或 `__DEV__` build label 证据
- 未运行全仓 `pnpm test:unit`：按工作流仅执行相关单测门禁，完整单测由 CI 执行

## 风险

### 风险分类

- [ ] 无已知风险
- [ ] SQLite / migration
- [ ] system prompt
- [ ] 协议兼容
- [ ] 权限 / 安全 / 用户数据
- [ ] 存量插件兼容（批准状态 / 指纹 / manifest 校验 / 安装布局 / 包格式）
- [x] 原生层 / fingerprint / OTA
- [x] 跨平台差异
- [ ] 其他：

### 影响与回滚

- 影响范围：仅 `apps/mobile` 远程桌面 WebView 的平台属性。Android 省略 iOS-only 属性；iOS 继续禁用数据检测。未修改 `app.json`、`app.config.js`、`eas.json`、移动端依赖、config plugin 或原生模块，因此 runtime fingerprint 不变，不触发冷更，可通过 OTA 下发。
- 回滚 / 降级方式：回滚本提交即可，但会重新暴露 Android Fabric 解析该属性时的崩溃风险。

### 提交前检查

- [x] 已 review 完整 diff
- [x] 每个 commit 都带 DCO 签名（`git commit -s`，见 [DCO](../DCO)）
- [x] UI 改动已在「UI 变化」注明引用的设计规范章节（不涉及 UI，已说明）
- [x] 未提交凭证、令牌或授权文件
- [x] 已补充必要文档（无需新增文档，已补回归测试）
- [x] 已确认测试结果或说明未执行原因