### PR TITLE
fix(desktop): 修复远端伙伴私聊顶栏无限更新

### DIFF
--- a/apps/desktop/src/renderer/features/bots/BotDirectMessageView.tsx
+++ b/apps/desktop/src/renderer/features/bots/BotDirectMessageView.tsx
@@ -29,7 +29,6 @@ export function BotDirectMessageView() {
   const { botId, threadId } = useParams();
   const deviceId = new URLSearchParams(location.search).get('deviceId');
   const allProfiles = useBotProfiles();
-  const profiles = deviceId ? [] : allProfiles;
   const [state, setState] = useState<DirectMessageState>({ kind: 'loading' });
 
   useEffect(() => {
@@ -79,14 +78,16 @@ export function BotDirectMessageView() {
   const thread = state.kind === 'ready' ? state.thread : null;
   const profileFor = useCallback(
     (id: string, fallbackName: string) => {
-      const profile = profiles.find((item) => item.id === id);
+      // Keep the callback stable when a remote thread registers its header.
+      // A fresh empty profiles array here would feed each slot update back into render.
+      const profile = deviceId ? undefined : allProfiles.find((item) => item.id === id);
       return {
         name: profile?.name || fallbackName || id,
         avatar: profile?.avatar ?? null,
         avatarColor: profile?.avatarColor ?? null,
       };
     },
-    [profiles],
+    [allProfiles, deviceId],
   );
   const [leftBot, rightBot] = useMemo(() => {
     if (!thread || !botId) return [null, null] as const;

--- a/apps/desktop/src/renderer/features/bots/__tests__/BotDirectMessageView.test.tsx
+++ b/apps/desktop/src/renderer/features/bots/__tests__/BotDirectMessageView.test.tsx
@@ -1,6 +1,7 @@
 // @vitest-environment jsdom
 
 import { act, cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { FeatureSidebarSlotProvider, useFeatureContentHeader } from '../../feature-context';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 import { BotDirectMessageView } from '../BotDirectMessageView';
@@ -8,7 +9,10 @@ import { BotDirectMessageView } from '../BotDirectMessageView';
 const mocks = vi.hoisted(() => ({
   getThread: vi.fn(),
   navigate: vi.fn(),
-  registerHeader: vi.fn(),
+  profiles: [
+    { id: 'bot-a', name: 'Cindy', avatar: '', avatarColor: 'red' },
+    { id: 'bot-b', name: 'Planner', avatar: '', avatarColor: 'blue' },
+  ],
   search: '',
 }));
 
@@ -29,23 +33,27 @@ vi.mock('@/contexts/dataOwnerGeneration', () => ({
   isDataOwnerGenerationCurrent: () => true,
   isDataOwnerPushCurrent: () => true,
 }));
-vi.mock('../../feature-context', () => ({
-  useRegisterContentHeader: (node: unknown) => mocks.registerHeader(node),
-}));
-vi.mock('../botStore', () => ({
-  useBotProfiles: () => [
-    { id: 'bot-a', name: 'Cindy', avatar: '', avatarColor: 'red' },
-    { id: 'bot-b', name: 'Planner', avatar: '', avatarColor: 'blue' },
-  ],
-}));
+vi.mock('../botStore', () => ({ useBotProfiles: () => mocks.profiles }));
 vi.mock('../BotAvatar', () => ({
   BotAvatar: ({ bot }: { bot: { name: string } }) => <span data-avatar={bot.name} />,
 }));
 
+function HeaderSlot() {
+  return <header data-testid="content-header">{useFeatureContentHeader()}</header>;
+}
+
+function TestPage({ showThread = true }: { showThread?: boolean }) {
+  return (
+    <FeatureSidebarSlotProvider isCollapsed={false}>
+      <HeaderSlot />
+      {showThread ? <BotDirectMessageView /> : null}
+    </FeatureSidebarSlotProvider>
+  );
+}
+
 beforeEach(() => {
   mocks.search = '';
   mocks.navigate.mockClear();
-  mocks.registerHeader.mockClear();
   mocks.getThread.mockReset();
   mocks.getThread.mockResolvedValue({
     ok: true,
@@ -101,40 +109,107 @@ afterEach(cleanup);
 
 describe('BotDirectMessageView', () => {
   it('shows both sides read-only, renders the hard-limit ending, and returns to the source timeline', async () => {
-    render(<BotDirectMessageView />);
+    render(<TestPage />, { reactStrictMode: true });
     expect(await screen.findByText('Can you check this?')).toBeTruthy();
     expect(screen.getByText('Checked.')).toBeTruthy();
     expect(screen.queryByRole('textbox')).toBeNull();
     expect(screen.getByText('bots.directMessage.limitReached')).toBeTruthy();
     fireEvent.click(screen.getByRole('button', { name: 'bots.directMessage.close' }));
     expect(mocks.navigate).toHaveBeenCalledWith('/bots/bot-a/session/a-main', { replace: true });
-    expect(mocks.registerHeader).toHaveBeenCalled();
+    expect(screen.getByTestId('content-header').textContent).toContain('Cindy');
   });
 
   it('fails closed when the thread is unavailable', async () => {
-    mocks.getThread.mockResolvedValueOnce({ ok: false, errorCode: 'NOT_FOUND', message: 'missing' });
-    render(<BotDirectMessageView />);
+    mocks.getThread.mockResolvedValue({ ok: false, errorCode: 'NOT_FOUND', message: 'missing' });
+    render(<TestPage />, { reactStrictMode: true });
     expect(await screen.findByText('bots.directMessage.unavailable')).toBeTruthy();
     expect(screen.queryByRole('textbox')).toBeNull();
   });
 });
 
-
 it('loads a remote private thread and refreshes it after reconnect without using local profiles', async () => {
   mocks.search = '?deviceId=home';
   let status!: (state: any) => void;
-  const response = await mocks.getThread(); mocks.getThread.mockClear();
+  const unsubscribePush = vi.fn();
+  const unsubscribeStatus = vi.fn();
+  const response = await mocks.getThread();
+  mocks.getThread.mockClear();
   response.thread.botAName = 'Remote Cindy';
   response.thread.messages[0].senderBotName = 'Remote Cindy';
-  const invoke = vi.fn(async () => response);
+  const invoke = vi.fn(async () => structuredClone(response));
   window.electronAPI.deviceLink = {
-    invoke, onRemotePush: () => () => {}, onStatusChanged: (fn: any) => { status = fn; return () => {}; },
+    invoke,
+    onRemotePush: () => unsubscribePush,
+    onStatusChanged: (fn: any) => {
+      status = fn;
+      return unsubscribeStatus;
+    },
   } as any;
-  render(<BotDirectMessageView />);
+  const view = render(<TestPage />, { reactStrictMode: true });
   await screen.findByText('Can you check this?');
-  expect(invoke).toHaveBeenCalledWith('home', 'maker:bot-direct-message-thread:get', ['dm-1', 'bot-a']);
+  expect(invoke).toHaveBeenCalledWith('home', 'maker:bot-direct-message-thread:get', [
+    'dm-1',
+    'bot-a',
+  ]);
   expect(mocks.getThread).not.toHaveBeenCalled();
-  expect(screen.getAllByText(/Remote Cindy/).length).toBeGreaterThan(0);
+  const header = screen.getByTestId('content-header');
+  expect(header.textContent).toContain('Remote Cindy');
+  const registeredHeader = header.firstElementChild;
+  for (let i = 0; i < 20; i += 1) view.rerender(<TestPage />);
+  expect(header.firstElementChild).toBe(registeredHeader);
+  expect(invoke).toHaveBeenCalledTimes(2); // StrictMode setup / cleanup / setup.
+  response.thread.botAName = 'Updated remote name';
+  response.thread.messages[0].senderBotName = 'Updated remote name';
   act(() => status({ status: 'online' }));
-  await waitFor(() => expect(invoke).toHaveBeenCalledTimes(2));
+  await waitFor(() => expect(invoke).toHaveBeenCalledTimes(3));
+  await waitFor(() => expect(header.textContent).toContain('Updated remote name'));
+  view.rerender(<TestPage showThread={false} />);
+  expect(header.textContent).toBe('');
+  expect(unsubscribePush).toHaveBeenCalledTimes(2);
+  expect(unsubscribeStatus).toHaveBeenCalledTimes(2);
+});
+
+it('clears the local header on navigation and registers fresh profile data when reopened', async () => {
+  const view = render(<TestPage />, { reactStrictMode: true });
+  await screen.findByText('Can you check this?');
+  expect(screen.getByTestId('content-header').textContent).toContain('Planner');
+  view.rerender(<TestPage showThread={false} />);
+  expect(screen.getByTestId('content-header').textContent).toBe('');
+  const previousProfiles = mocks.profiles;
+  try {
+    mocks.profiles = mocks.profiles.map((profile) => ({
+      ...profile,
+      name: `Renamed ${profile.name}`,
+    }));
+    view.rerender(<TestPage />);
+    await waitFor(() =>
+      expect(screen.getByTestId('content-header').textContent).toContain('Renamed Planner'),
+    );
+  } finally {
+    mocks.profiles = previousProfiles;
+  }
+});
+
+it('does not restore a header when a remote read finishes after navigation away', async () => {
+  mocks.search = '?deviceId=home';
+  const response = await mocks.getThread();
+  let finish!: (value: typeof response) => void;
+  const pending = new Promise<typeof response>((resolve) => {
+    finish = resolve;
+  });
+  const unsubscribe = vi.fn();
+  window.electronAPI.deviceLink = {
+    invoke: vi.fn(() => pending),
+    onRemotePush: () => unsubscribe,
+    onStatusChanged: () => unsubscribe,
+  } as any;
+  const view = render(<TestPage />, { reactStrictMode: true });
+  view.rerender(<TestPage showThread={false} />);
+  await act(async () => {
+    finish(response);
+    await pending;
+  });
+  expect(screen.getByTestId('content-header').textContent).toBe('');
+  expect(screen.queryByText('Can you check this?')).toBeNull();
+  expect(unsubscribe).toHaveBeenCalledTimes(4);
 });


### PR DESCRIPTION
## 这次改了什么

### 摘要

打开远端伙伴之间的私聊记录（URL 带 `deviceId`）且记录加载成功时，`BotDirectMessageView` 每次 render 新建空 profiles 数组，导致 profile callback、双方资料和顶栏节点不断变化。顶栏 layout effect 写回 Provider 后再次触发该组件，最终在清理回调触发 React #185。

移除临时空数组，按设备 ID 决定是否查询原始本地资料快照，稳定 callback 的依赖，保留远端名字与本地同 ID 资料的隔离。生产改动仅 4 行增加、3 行删除。

### 变更类型

- [x] `fix` 缺陷修复

### 范围

- 关联 Issue / 需求：伙伴页面 React #185 排查；问题代码引入于 #3912。
- 本 PR 包含：远端私聊顶栏循环修复，真实 Provider 的回归测试。
- 明确不包含：其他顶栏调用方重构、Mobile #4252/#4259、自动归档、宿主配置与安装包变更。
- 用户可见变化：远端伙伴私聊记录加载后可稳定显示与刷新。
- 是否存在 breaking change：无。

### UI 变化

- 引用的设计规范：不涉及：仅修复 memo 依赖身份，无视觉、交互或文案变化。遵循 `docs/design-rules/DESIGN.md` §7 的稳定界面与 §10 的主题约束，沿用现有样式；未进行 Light/Dark 实机目检。

## 怎么验证的

### 自动验证

```text
pnpm --filter desktop exec vitest run src/renderer/features/bots/__tests__/BotDirectMessageView.test.tsx
结果：5 tests passed。

反证：保留回归测试、临时恢复旧生产文件。
结果：1 failed / 4 passed，Maximum update depth exceeded，feature-context.tsx:223 清理回调。
恢复修复文件后跑提交门禁：
pnpm test:unit:related
结果：Desktop related 通过，exit 0。
pnpm --filter desktop run --if-present typecheck
结果：通过，exit 0。
pnpm check:dco
结果：1 commit signed off。
```

测试恢复真实 `FeatureSidebarSlotProvider` 与 header slot，在根开启 StrictMode；覆盖本地/远端展示、不可用记录、20 次重复渲染、重连名称刷新、关闭时清空顶栏并释放监听、本地重开和远端迟到响应。IPC、路由、资料 store、翻译与头像是替身。

### 手工验证

只读核对安装包 0.1.78：业务 chunk 的 419:119737 精确位于顶栏清理回调，与反证位置一致；安装包也包含同一临时空数组逻辑。包内无 renderer source map，且缺少源码提交元数据，未声称确认完整打包 commit。

### 未执行的验证

未启动/重启正式 App，未做完整 Electron 或双设备实机复现。原报告未确认出错前最后操作，不能证明这条已复现路径是该次复发的唯一根因；如果没有进入远端私聊记录，仍需继续定位其他调用方。未将截图或用户原始内容公开。

## 风险

### 风险分类

- [x] 其他：远端记录渲染的 callback 依赖调整。

### 影响与回滚

- 影响范围：Desktop `BotDirectMessageView`；本地资料仍来自原 store，远端仍只使用记录中的身份信息。无协议、数据库、权限或安装包修改。
- 回滚 / 降级方式：revert 本提交；会恢复该远端循环缺陷。

### 提交前检查

- [x] 已 review 完整 diff
- [x] 每个 commit 都带 DCO 签名
- [x] UI 变化已注明理由与设计依据
- [x] 未提交凭证、令牌或授权文件
- [x] 已补充回归测试及故障报告（报告本地交付）
- [x] 已确认测试结果并说明未验证项
