### PR TITLE
fix(codex): recover thread-not-loaded pre-resume read probe for imported sessions

### DIFF
--- a/packages/maker-core/src/agents/codex/index.test.ts
+++ b/packages/maker-core/src/agents/codex/index.test.ts
@@ -8791,6 +8791,82 @@ describe('CodexAgent MCP thread context hooks', () => {
         expect(await fs.readFile(source, 'utf8')).toBe(history);
       } finally { await fs.rm(dir, { recursive: true, force: true }); }
     });
+    it('recovers a thread-not-loaded pre-resume read probe for an imported session without a rollout path', async () => {
+      const threadId = '01a03676-c588-7e63-afbd-56b35ed75338';
+      const agent = new CodexAgent(createDeps({}));
+      const host = installFakeHost(agent, (method) => {
+        if (method === 'thread/read') {
+          throw Object.assign(new Error(`codex app-server thread/read error -32600: thread not loaded: ${threadId}`), { code: -32600 });
+        }
+        if (method === Method.ThreadResume) {
+          return { thread: { id: threadId }, model: 'gpt-5.6-luna', modelProvider: 'openai', cwd: '/repo' };
+        }
+        return undefined;
+      }, { localCompactionProviderId: 'cindy_summary' });
+      const handle = await agent.startSession({ sessionId: 'imported-resume', providerId: 'openai', model: 'gpt-5.6-luna', workingDir: '/repo', resumeSessionId: threadId });
+      expect(host.request.mock.calls.some(([m]) => m === 'thread/read')).toBe(true);
+      expect(host.request.mock.calls.some(([m]) => m === Method.ThreadStart || m === Method.ThreadFork)).toBe(false);
+      expect(handle.id).toBe(threadId);
+      await handle.close();
+    });
+    it('does not recover a non-not-loaded thread/read probe failure', async () => {
+      const threadId = '01a03676-c588-7e63-afbd-56b35ed75338';
+      const agent = new CodexAgent(createDeps({}));
+      const host = installFakeHost(agent, (method) => {
+        if (method === 'thread/read') {
+          throw Object.assign(new Error(`codex app-server thread/read error -32600: connection reset by peer`), { code: -32600 });
+        }
+        if (method === Method.ThreadResume) {
+          return { thread: { id: threadId }, model: 'gpt-5.6-luna', modelProvider: 'openai', cwd: '/repo' };
+        }
+        return undefined;
+      }, { localCompactionProviderId: 'cindy_summary' });
+      await expect(agent.startSession({ sessionId: 'imported-resume-strict', providerId: 'openai', model: 'gpt-5.6-luna', workingDir: '/repo', resumeSessionId: threadId })).rejects.toThrow(`thread/read error -32600: connection reset by peer`);
+      expect(host.request.mock.calls.some(([m]) => m === 'thread/read')).toBe(true);
+      await agent.dispose();
+    });
+    it('does not send the local-summary provider as a resume override when the probe reports thread-not-loaded', async () => {
+      const threadId = '01a03676-c588-7e63-afbd-56b35ed75338';
+      const agent = new CodexAgent(createDeps({}));
+      let resumeParams: { modelProvider?: string } = {};
+      const host = installFakeHost(agent, (method, raw) => {
+        if (method === 'thread/read') {
+          throw Object.assign(new Error(`codex app-server thread/read error -32600: thread not loaded: ${threadId}`), { code: -32600 });
+        }
+        if (method === Method.ThreadResume) {
+          resumeParams = raw as { modelProvider?: string };
+          return { thread: { id: threadId }, model: 'gpt-5.6-luna', modelProvider: (raw as { modelProvider?: string }).modelProvider, cwd: '/repo' };
+        }
+        return undefined;
+      }, { localCompactionProviderId: 'cindy_summary', remoteCompactionProviderId: 'remote-compact' });
+      const handle = await agent.startSession({ sessionId: 'imported-resume-provider', providerId: 'openai', model: 'gpt-5.6-luna', workingDir: '/repo', resumeSessionId: threadId });
+      expect(resumeParams.modelProvider).not.toBe('cindy_summary');
+      await handle.close();
+    });
+    it('restores the saved local-summary provider when the probe reads it successfully', async () => {
+      const threadId = '01a03676-c588-7e63-afbd-56b35ed75338';
+      const agent = new CodexAgent(createDeps({}));
+      let resumeParams: { modelProvider?: string } = {};
+      const host = installFakeHost(agent, (method, raw) => {
+        if (method === 'thread/read') {
+          return { thread: { id: threadId, modelProvider: 'cindy_summary' } };
+        }
+        if (method === Method.ThreadResume) {
+          resumeParams = raw as { modelProvider?: string };
+          return { thread: { id: threadId }, model: 'gpt-5.6-luna', modelProvider: (raw as { modelProvider?: string }).modelProvider, cwd: '/repo' };
+        }
+        return undefined;
+      }, { localCompactionProviderId: 'cindy_summary', remoteCompactionProviderId: 'remote-compact' });
+      const handle = await agent.startSession({ sessionId: 'imported-resume-provider-ok', providerId: 'openai', model: 'gpt-5.6-luna', workingDir: '/repo', resumeSessionId: threadId });
+      expect(resumeParams.modelProvider).toBe('cindy_summary');
+      await handle.close();
+    });
+
+
+
+
+
+
 
     it.each(['wrong-id', 'missing-file', 'resume-failure'])('never replaces existing account history on %s', async (failure) => {
       const dir = await fs.mkdtemp(path.join(os.tmpdir(), 'cindy-account-resume-error-'));

--- a/packages/maker-core/src/agents/codex/index.ts
+++ b/packages/maker-core/src/agents/codex/index.ts
@@ -1088,6 +1088,21 @@ export function isExactNoRolloutThreadResumeError(error: unknown, threadId: stri
     `codex app-server thread/resume error -32600: no rollout found for thread id ${threadId}`;
 }
 
+/**
+ * Pre-resume `thread/read` 探测只用于取回已保存的 modelProvider 身份。当线程未加载、
+ * 或没有 rollout 时，这里读不到任何身份，应视为可恢复：交给后续 resume 路径
+ * （无 rollout → 新开线程）去处理，而不是把这条本应非致命的探测失败当成致命错误上抛。
+ * 与 isExactNoRolloutThreadResumeError 的 fail-closed 精确匹配不同，这里对 read 的
+ * "未加载 / 无 rollout" 文案做宽松匹配（不同 app-server 版本的措辞可能有细微差异）。
+ */
+export function isThreadNotLoadedReadError(error: unknown, threadId: string): boolean {
+  if (typeof error !== 'object' || error === null) return false;
+  const candidate = error as { code?: unknown; message?: unknown };
+  if (candidate.code !== -32600 || typeof candidate.message !== 'string') return false;
+  if (!candidate.message.includes(threadId)) return false;
+  return /codex app-server thread\/read error -32600:[\s\S]*?(thread not loaded|no rollout found for thread id)/.test(candidate.message);
+}
+
 // 插话 (steer) 时 turn/steer RPC 的 ack 有界等待上限。AppServerClient.request
 // 本身没有超时, app-server 卡死时裸 await 会永久挂起 → coordinator steering marker
 // 永久残留 → 后续插话点击被静默吞掉。正常情况下 ack 是毫秒级, 10s 足够宽裕。
@@ -5902,15 +5917,19 @@ export class CodexAgent extends BaseAgent {
             : {}),
       };
     }
-    let threadModelProvider = opts.remoteHostId
-      ? undefined
-      : customProviderModelProvider
-        ? customProviderModelProvider
-        : cindyProviderRemoteCompaction
-          ? host.getCindyRemoteCompactionProviderId?.() ?? undefined
-          : threadCredentialFamily === 'oauth-bearer'
-            ? host.getRemoteCompactionProviderId?.() ?? undefined
-            : undefined;
+    // 默认 thread model provider（未确认保存身份时 resume 使用的值）。抽成函数，
+    // 便于探测失败跳过时复位，避免把远端压缩 provider 当成显式 override 发出去。
+    const defaultThreadModelProvider = (): string | undefined =>
+      opts.remoteHostId
+        ? undefined
+        : customProviderModelProvider
+          ? customProviderModelProvider
+          : cindyProviderRemoteCompaction
+            ? host.getCindyRemoteCompactionProviderId?.() ?? undefined
+            : threadCredentialFamily === 'oauth-bearer'
+              ? host.getRemoteCompactionProviderId?.() ?? undefined
+              : undefined;
+    let threadModelProvider = defaultThreadModelProvider();
 
     const isLikelyValidThreadId = (id: string | undefined): id is string =>
       typeof id === 'string' && id.length > 0 && !id.startsWith('<') && /^[0-9a-fA-F-]+$/.test(id);
@@ -5949,10 +5968,13 @@ export class CodexAgent extends BaseAgent {
       } catch (error) {
         // Let the existing resume path recover an unused thread without a rollout.
         // Other read failures must not silently reset a saved summary identity.
-        if (preparedResumePath || !isExactNoRolloutThreadResumeError(error, opts.resumeSessionId)) {
+        if (preparedResumePath || (!isExactNoRolloutThreadResumeError(error, opts.resumeSessionId) && !isThreadNotLoadedReadError(error, opts.resumeSessionId))) {
           releaseHostBindingLeaseIfNeeded();
           throw error;
         }
+        // 探测因“未加载 / 无 rollout”跳过时，保存身份未知：复位到默认值，避免把远端压缩
+        // provider 当成显式 override 发进 thread/resume，把历史线程悄悄切离其持久化的本地摘要兜底。
+        threadModelProvider = defaultThreadModelProvider();
       }
     }
 


### PR DESCRIPTION
## 背景

导入的 Codex 会话无法继续对话：每次发送新消息都报
`LAZY_CREATE_FAILED: codex app-server thread/read error -32600: thread not loaded: <threadId>`。
所有导入的 Codex 会话均复现（#4260）。

## 根因

Codex agent 续会话时，在真正 `thread/resume` 之前会先做一次 `thread/read` 探测
（`packages/maker-core/src/agents/codex/index.ts`），用于取回已保存的摘要 provider 身份。
这个探测本应是**非致命**的，但其兜底 `isExactNoRolloutThreadResumeError` 只精确匹配
`thread/resume error -32600: no rollout found for thread id ...` 一条文案。

导入会话的原生线程在本机 app-server 里没有已加载 / 无 rollout，`thread/read` 返回的是
`thread/read error -32600: thread not loaded: ...`——RPC 动词与文案都不同，判定不命中，
于是探测失败被当成致命错误上抛，最终包成 `LAZY_CREATE_FAILED`。

## 修复

新增 `isThreadNotLoadedReadError`，把 `thread/read` 探测的「未加载 / 无 rollout」失败
识别为可恢复，交给既有 resume 路径处理（无 rollout → 新开线程），不再上抛为致命错误。
改动仅限这一条导入续聊路径。

## 验证

- 新增回归测试：`thread/read` 返回 `thread not loaded` 时，续会话能正常恢复、不误开新线程。
- 负向验证：回退修复后该测试失败，且报错正是 #4260 的那条 `thread not loaded`。
- 全量 `codex/index.test.ts`：774 通过。
- `pnpm --filter @cindy/maker-core build`（tsc --noEmit）通过。

Fixes #4260
