### PR TITLE
fix(desktop): 对齐供应商提示中的账号名称展示

### DIFF
--- a/apps/desktop/src/main/maker-host/__tests__/nativeProviderConnectionClaim.test.ts
+++ b/apps/desktop/src/main/maker-host/__tests__/nativeProviderConnectionClaim.test.ts
@@ -55,10 +55,15 @@ vi.mock('../../appSessionState.js', () => ({
 // 本机凭证库:*Unbound 是「blob 里有凭证吗」,无绑定语义;带绑定的读取叠加 owner 校验,
 // 与真实实现(readClaudeAiOAuth / hasGrokOAuthLogin)的分层一致。
 vi.mock('../claude-credentials-store.js', () => ({
+  readClaudeAiOAuth: () =>
+    h.claudeCredentialPresent && isBoundToCurrentOwner('anthropic')
+      ? { accessToken: 'fake-token', identity: 'claude@example.test' }
+      : null,
   hasClaudeAiOAuthUnbound: () => h.claudeCredentialPresent,
   hasClaudeAiOAuth: () => h.claudeCredentialPresent && isBoundToCurrentOwner('anthropic'),
 }));
 vi.mock('../grok-oauth-login.js', () => ({
+  grokAccountIdentity: () => 'grok@example.test',
   hasGrokOAuthLoginUnbound: () => h.grokCredentialPresent,
   hasGrokOAuthLogin: () => h.grokCredentialPresent && isBoundToCurrentOwner('xai'),
   getGrokAccessToken: () => null,
@@ -172,6 +177,27 @@ afterEach(() => {
 });
 
 describe('native provider connection claim on read', () => {
+  it('projects only bound native account identities without exposing credentials', async () => {
+    const before = await listProviders(false);
+    for (const id of ['anthropic', 'xai']) {
+      expect(before.find((p) => p.id === id)?.subscriptionAccount?.identity).toBeUndefined();
+    }
+    bindNativeProviderAuth('anthropic', { sharedSystem: true });
+    bindNativeProviderAuth('xai');
+    const after = await listProviders(false);
+    expect(after.find((p) => p.id === 'anthropic')?.subscriptionAccount).toEqual({
+      source: 'local', identity: 'claude@example.test',
+    });
+    expect(after.find((p) => p.id === 'xai')?.subscriptionAccount).toEqual({
+      source: 'oauth', identity: 'grok@example.test',
+    });
+    h.dataOwnerId = 'owner-b';
+    h.generation += 1;
+    const switched = await listProviders(false);
+    for (const id of ['anthropic', 'xai']) {
+      expect(switched.find((p) => p.id === id)?.subscriptionAccount?.identity).toBeUndefined();
+    }
+  });
   it('认领本机 anthropic 凭证并补拉一次清单(修「已连接 + 零模型」)', async () => {
     expect(isNativeProviderAuthBound('anthropic')).toBe(false);
 

--- a/apps/desktop/src/main/maker-host/createDesktopProviderService.ts
+++ b/apps/desktop/src/main/maker-host/createDesktopProviderService.ts
@@ -109,11 +109,16 @@ import {
   readCustomProviderHeaders,
   readCustomProviderKey,
 } from '../secrets/providerSecretStore.js';
-import { hasClaudeAiOAuth, hasClaudeAiOAuthUnbound } from './claude-credentials-store.js';
+import {
+  hasClaudeAiOAuth,
+  hasClaudeAiOAuthUnbound,
+  readClaudeAiOAuth,
+} from './claude-credentials-store.js';
 import { getValidClaudeAiOAuth } from './claude-oauth-refresh.js';
 import {
   getGrokAccessToken,
   hasGrokOAuthLogin,
+  grokAccountIdentity,
   recoverGrokAuthAfterRejection,
   resetGrokOAuthMemoryCache,
 } from './grok-oauth-login.js';
@@ -128,6 +133,7 @@ import { filterProviderCatalogForAccount } from './provider-access-policy.js';
 import { getAppCapabilities } from '../appCapabilities.js';
 import {
   claimDetectedNativeProviderAuth,
+  getNativeProviderAuthSource,
   migrateLegacyNativeProviderAuthBindings,
 } from './nativeProviderAuthBinding.js';
 import { hasLegacyOwnerNamespaceClaim } from '../ownerNamespaceMigration.js';
@@ -1042,7 +1048,24 @@ export function getDesktopProviderService(): ProviderService {
     genericOAuthConnected: (providerId) => hasGenericOAuthLogin(storedCustomProviderId(providerId)),
     codexAccountConnected: (providerId) => codexAccountState(providerId).authenticated,
     subscriptionAccountConnected: (providerId) => subscriptionAccountState(providerId).authenticated,
-    subscriptionAccountInfo: async (providerId) => ({ source: 'oauth', identity: subscriptionAccountState(providerId).identity }),
+    subscriptionAccountInfo: async (providerId) => {
+      if (providerId === 'anthropic') {
+        const oauth = readClaudeAiOAuth();
+        const source = getNativeProviderAuthSource('anthropic');
+        return {
+          source: source === 'native-harness-inherited' ? 'local'
+            : source === 'explicit-provider-oauth' ? 'oauth' : 'unknown',
+          identity: typeof oauth?.identity === 'string' ? oauth.identity : undefined,
+        };
+      }
+      if (providerId === 'xai') {
+        return {
+          source: 'oauth',
+          identity: hasGrokOAuthLogin() ? grokAccountIdentity('xai') : undefined,
+        };
+      }
+      return { source: 'oauth', identity: subscriptionAccountState(providerId).identity };
+    },
     openAiAccountInfo: async (providerId) => {
       const state = providerId === 'openai' ? await desktopCodexAuthAdapter.readAccountPresentationState() : codexAccountState(providerId);
       return {

--- a/apps/desktop/src/main/maker-host/provider-service.ts
+++ b/apps/desktop/src/main/maker-host/provider-service.ts
@@ -202,7 +202,7 @@ export function createProviderService(deps: ProviderServiceDeps): ProviderServic
     }
     const subscriptionInfo = new Map<string, ProviderView['subscriptionAccount']>();
     if (deps.subscriptionAccountInfo) await Promise.all(catalog.providers
-      .filter(p => p.auth.native === 'claude' || p.auth.native === 'xai')
+      .filter(p => p.id === 'anthropic' || p.id === 'xai' || p.auth.native === 'claude' || p.auth.native === 'xai')
       .map(async p => subscriptionInfo.set(p.id, await deps.subscriptionAccountInfo!(p.id))));
     return buildRegistry(catalog, connected, discoveryFailures, deps.getModelAccess?.()).map((provider) => ({
       ...(subscriptionInfo.get(provider.id) ? { subscriptionAccount: subscriptionInfo.get(provider.id) } : {}),

--- a/apps/desktop/src/renderer/__tests__/providerRailWeeklyQuota.test.tsx
+++ b/apps/desktop/src/renderer/__tests__/providerRailWeeklyQuota.test.tsx
@@ -98,6 +98,73 @@ describe('provider weekly quota identity and windows', () => {
 });
 
 describe('provider rail weekly remaining bars', () => {
+  it.each(['openai', 'anthropic', 'xai', 'independent'])(
+    'shows %s account identity without quota and updates it with the directory',
+    async (id) => {
+      const account = { source: 'local' as const, identity: 'first@example.test' };
+      const providers = [
+        provider(
+          id,
+          id === 'openai' ? { openAiAccount: account } : { subscriptionAccount: account },
+        ),
+      ];
+      const props = {
+        items: [{ kind: 'provider' as const, providerId: id }],
+        active: { kind: 'all' as const },
+        providers,
+        providerLabel: () => 'My provider',
+        onSelect: () => {},
+        localProviderUsage: false,
+      };
+      const { rerender } = render(<UnifiedModelRail {...props} />);
+      const button = screen.getByRole('button', { name: 'My provider · first@example.test' });
+      fireEvent.focus(button);
+      expect((await screen.findByRole('tooltip')).textContent).toBe(
+        'My provider · first@example.test',
+      );
+      account.identity = 'second@example.test';
+      rerender(<UnifiedModelRail {...props} />);
+      expect(screen.queryByRole('button', { name: /first@example/ })).toBeNull();
+      expect(
+        screen.getByRole('button', { name: 'My provider · second@example.test' }),
+      ).toBeTruthy();
+      expect(reads.codex).not.toHaveBeenCalled();
+      expect(reads.claude).not.toHaveBeenCalled();
+      expect(reads.xai).not.toHaveBeenCalled();
+    },
+  );
+  it.each([
+    ['OpenAI · user@example.test', 'user@example.test'],
+    ['OpenAI · user@example.test (2)', 'user@example.test'],
+    ['Anthropic · user@example.test', 'user@example.test'],
+    ['xAI · user@example.test', 'user@example.test'],
+    ['user@example.test', 'user@example.test'],
+    [
+      'OpenAI · very-long-account-name-for-display@example.test'.slice(0, 50),
+      'very-long-account-name-for-display@example.test',
+    ],
+    [
+      'OpenAI · very-long-account-name-for-display@example.test'.slice(0, 50) + ' (2)',
+      'very-long-account-name-for-display@example.test',
+    ],
+  ])(
+    'preserves existing account connection name %s without repeating identity',
+    async (name, identity) => {
+      render(
+        <UnifiedModelRail
+          items={[{ kind: 'provider', providerId: 'independent' }]}
+          active={{ kind: 'all' }}
+          providers={[
+            provider('independent', { name, openAiAccount: { source: 'oauth', identity } }),
+          ]}
+          providerLabel={() => name}
+          onSelect={() => {}}
+        />,
+      );
+      fireEvent.focus(screen.getByRole('button', { name }));
+      expect((await screen.findByRole('tooltip')).textContent).toBe(name);
+    },
+  );
   it('keeps two OpenAI accounts separate, preserves selection and updates remaining including zero', () => {
     let usedB = 79;
     reads.codex.mockImplementation((enabled, id) => ({

--- a/apps/desktop/src/renderer/components/new-chat/UnifiedModelRail.tsx
+++ b/apps/desktop/src/renderer/components/new-chat/UnifiedModelRail.tsx
@@ -57,6 +57,13 @@ export function UnifiedModelRail({
         const separatorBefore = item.kind === 'all';
         const engineOption =
           item.kind === 'engine' ? agentOptionOf(engineOfAgentKind(item.agent)) : null;
+        const provider =
+          item.kind === 'provider'
+            ? providers.find((entry) => entry.id === item.providerId)
+            : undefined;
+        const accountIdentity =
+          provider?.openAiAccount?.identity?.trim() ||
+          provider?.subscriptionAccount?.identity?.trim();
         const label =
           item.kind === 'favorites'
             ? t('newChat.modelSelector.unified.railFavorites')
@@ -77,15 +84,12 @@ export function UnifiedModelRail({
             )}
             <RailButton
               label={label}
+              accountIdentity={accountIdentity}
               isActive={isActive}
               itemKey={key}
               onClick={() => onSelect(item)}
               disabled={interactionDisabled}
-              provider={
-                localProviderUsage && item.kind === 'provider'
-                  ? providers.find((provider) => provider.id === item.providerId)
-                  : undefined
-              }
+              provider={localProviderUsage ? provider : undefined}
             >
               {item.kind === 'favorites' ? (
                 // ☆ 未激活与其它格同灰(hover 提亮)—— 常亮金色会在没进收藏视图时也
@@ -110,6 +114,7 @@ export function UnifiedModelRail({
 
 interface RailButtonProps {
   label: string;
+  accountIdentity?: string;
   isActive: boolean;
   itemKey: string;
   onClick: () => void;
@@ -132,8 +137,25 @@ function ProviderQuotaButton(props: RailButtonProps & { provider: ProviderView }
   return <RailButtonView {...props} quota={quota} />;
 }
 
+function accountLabel(label: string, identity?: string): string {
+  if (!identity || label === identity) return label;
+  // Independent logins already name the connection "Provider · identity".
+  // OpenAI also truncates that generated name to 50 characters and may add (2).
+  const baseLabel = label.replace(/ \(\d+\)$/, '');
+  if (baseLabel.endsWith(` · ${identity}`)) return label;
+  const separator = baseLabel.indexOf(' · ');
+  if (
+    separator >= 0 &&
+    baseLabel.length === 50 &&
+    `${baseLabel.slice(0, separator)} · ${identity}`.slice(0, 50) === baseLabel
+  )
+    return label;
+  return `${label} · ${identity}`;
+}
+
 function RailButtonView({
   label,
+  accountIdentity,
   isActive,
   itemKey,
   onClick,
@@ -150,14 +172,15 @@ function RailButtonView({
       ? null
       : `${t('quotaCard.weeklyLabel')} · ${t('quotaCard.remainingPercent', { percent: remaining })}`;
   const reset = formatQuotaResetCountdown(quota?.resetsAt, Date.now(), t);
+  const displayLabel = accountLabel(label, accountIdentity);
   const tooltip = quotaLabel ? (
     <>
-      <div>{label}</div>
-      <div>{quotaLabel}</div>
+      <div>{displayLabel}</div>
+      {quotaLabel && <div>{quotaLabel}</div>}
       {reset && <div>{reset}</div>}
     </>
   ) : (
-    label
+    displayLabel
   );
   return (
     <Tip
@@ -170,7 +193,7 @@ function RailButtonView({
         type="button"
         disabled={disabled}
         onClick={onClick}
-        aria-label={label}
+        aria-label={displayLabel}
         aria-description={quotaLabel ?? undefined}
         aria-pressed={isActive}
         data-rail-item={itemKey}


### PR DESCRIPTION
## 这次改了什么

### 摘要

模型选择器左侧供应商提示补齐本机 Codex、Claude 和 Grok 的账号名称，标题沿用独立登录账号已有的 `供应商 · 账号名称` 格式。已有名称包含账号时不重复追加，包括自动截短的长名称和 OpenAI 的数字后缀；额度和重置时间保持原有展示。

### 变更类型

- [x] `fix` 缺陷修复

### 范围

- 关联 Issue / 需求：本机绑定的供应商 Tips 缺少账号名称，需要与独立登录账号一致。
- 本 PR 包含：供应商提示标题和无障碍名称；本机 Claude、Grok 的公开账号身份投影；回归测试。
- 明确不包含：登录、凭证刷新、持久化名称和模型路由的变更。
- 用户可见变化：例如 `OpenAI` 变为 `OpenAI · user@example.test`；没有额度时仍显示账号名称。示例邮箱为虚构数据。
- 是否存在 breaking change：无，复用现有可选身份字段。

### UI 变化

Desktop 模型选择器左栏 Tips 第一行补充账号，复用原有 Tip 和排版，不另加账号行。未附实机截图。

- 引用的设计规范：`docs/design-rules/DESIGN.md §14.6`，复用共享 Tip，图标按钮的 aria-label 与显示标题一致；`§10`，保留已有语义主题样式，Light / Dark 均使用原有样式。

## 怎么验证的

### 自动验证

```text
corepack pnpm test:unit:related
corepack pnpm --filter desktop run --if-present typecheck
corepack pnpm --filter desktop exec vitest run src/renderer/__tests__/providerRailWeeklyQuota.test.tsx
git diff --check
结果：全部通过；选择器定向测试 17 项通过。
```

回归覆盖同一行标题、独立账号名称去重、长名称和数字后缀、目录账号切换、远端目录不读取本机额度，以及未绑定/切换所有者时不投影本机身份。

### 手工验证

已对照独立账号首次登录命名逻辑和最终 diff，完成独立代码复查。

### 未执行的验证

未启动实际客户端进行真实账号验证；未完成 Light / Dark 实机目检。HTML 对比图仅为示意，不作为运行验收证据。

## 风险

### 风险分类

- [x] 权限 / 安全 / 用户数据
- [x] 其他：账号名称缺失时的展示回退。

### 影响与回滚

- 影响范围：Desktop 供应商提示，以及已有 ProviderView 中本机 Claude/Grok 的公开身份字段。只传账号名称，保留原有所有者绑定检查，不传令牌或凭证对象，也不增加网络请求。
- 旧账号未提供身份时继续显示供应商名称；本次不补拉缺失身份，不覆盖用户命名。
- 回滚 / 降级方式：回退本 PR 即恢复原展示，无存储迁移。

### 提交前检查

- [x] 已 review 完整 diff
- [x] 每个 commit 都带 DCO 签名（`git commit -s`）
- [x] UI 改动已在「UI 变化」注明引用的设计规范章节
- [x] 未提交凭证、令牌或授权文件
- [x] 已补充必要文档：无新功能或配置入口，沿用现有供应商规则
- [x] 已确认测试结果或说明未执行原因
