### PR TITLE
fix(pi): 提问卡片「自行键入」的答案原样回给 Pi,不再当作取消

### DIFF
--- a/packages/maker-core/src/agents/pi/__tests__/cindyBridgeSource.test.ts
+++ b/packages/maker-core/src/agents/pi/__tests__/cindyBridgeSource.test.ts
@@ -420,6 +420,19 @@ describe('cindy-bridge extension source', () => {
     expect((await run).details).toEqual({ answers: { 'Continue?': 'No' }, cancelled: false });
   });
 
+  it('returns a typed answer outside the options as a real answer, not a cancel (#4273)', async () => {
+    const tool = loadQuestionTool();
+    const result = await tool.execute('q', {
+      questions: [
+        { question: 'Continue?', options: ['Yes', 'No'] },
+        { question: 'Which color?', options: ['Red', 'Blue'] },
+      ],
+    }, undefined, undefined, {
+      ui: { select: async (_title: string, options: string[]) => (options.includes('Yes') ? 'No' : 'teal') },
+    });
+    expect(result.details).toEqual({ answers: { 'Continue?': 'No', 'Which color?': 'teal' }, cancelled: false });
+  });
+
   it('reports cancellation without fabricating a choice and validates all questions before showing UI', async () => {
     const tool = loadQuestionTool();
     const ctx = { ui: { input: async () => undefined } };

--- a/packages/maker-core/src/agents/pi/__tests__/pi-auto-review-dispatch.test.ts
+++ b/packages/maker-core/src/agents/pi/__tests__/pi-auto-review-dispatch.test.ts
@@ -1311,6 +1311,51 @@ describe('pi auto-review dispatch & spawn config (mocked pi process)', () => {
     }
   });
 
+  it('passes a typed custom answer for a select dialog through and keeps an empty answer as cancel (#4273)', async () => {
+    const handle = await start();
+    const answers: Record<string, string> = {
+      'Pick a color': 'teal',
+      'Pick a size': '',
+    };
+    handle.setInteractionResolver(async (request) => {
+      if (request.kind !== 'ask_user_question') throw new Error(`unexpected interaction ${request.kind}`);
+      const question = request.questions[0]?.question ?? '';
+      expect(request.questions[0]?.options).toEqual([{ label: 'Red' }, { label: 'Blue' }]);
+      return { kind: 'ask_user_question', answers: { [question]: answers[question] ?? '' } };
+    });
+    try {
+      // The card's "type your own" entry yields an answer that is not one of `options`.
+      captured.onEvent!({
+        type: 'extension_ui_request',
+        id: 'select-custom',
+        method: 'select',
+        title: 'Pick a color',
+        options: ['Red', 'Blue'],
+      });
+      expect(await waitForResponse('select-custom')).toEqual({
+        type: 'extension_ui_response',
+        id: 'select-custom',
+        value: 'teal',
+      });
+
+      // An empty answer is still a skip/cancel, not a value.
+      captured.onEvent!({
+        type: 'extension_ui_request',
+        id: 'select-empty',
+        method: 'select',
+        title: 'Pick a size',
+        options: ['Red', 'Blue'],
+      });
+      expect(await waitForResponse('select-empty')).toEqual({
+        type: 'extension_ui_response',
+        id: 'select-empty',
+        cancelled: true,
+      });
+    } finally {
+      await handle.close();
+    }
+  });
+
   it('surfaces Pi UI requests that Cindy cannot safely adapt at runtime', async () => {
     const handle = await start();
     const events: Array<Record<string, unknown>> = [];

--- a/packages/maker-core/src/agents/pi/index.ts
+++ b/packages/maker-core/src/agents/pi/index.ts
@@ -8456,10 +8456,10 @@ export class PiAgent extends BaseAgent {
             proc.send({ type: 'extension_ui_response', id, cancelled: true });
             return;
           }
-          if (method === 'select' && !options.includes(answer)) {
-            proc.send({ type: 'extension_ui_response', id, cancelled: true });
-            return;
-          }
+          // Pi's RPC select contract only distinguishes cancelled from value and hands
+          // `value` back to the caller verbatim; Cindy's question card always offers a
+          // "type your own" entry, so a non-empty answer outside `options` is a real
+          // answer, not a cancel (#4273).
           context.recordUserClarification(question, answer);
           proc.send({ type: 'extension_ui_response', id, value: answer });
         })


### PR DESCRIPTION
## 这次改了什么

Pi runtime 的提问卡片:Agent 用带候选项的提问工具提问时,用户点「自行键入」提交的自定义文本不会送达模型,模型拿到的是 `{"answers":{},"cancelled":true}`(#4273)。

根因在宿主把 Pi 扩展对话框(`extension_ui_request` method=select)适配到 Cindy 提问卡片后的回帧分支:`packages/maker-core/src/agents/pi/index.ts` 对 `select` 额外做了 `options.includes(answer)` 归属校验,不在候选项内的答案一律回 `{cancelled:true}`。上游 Pi 的 RPC select 契约只区分 cancelled / value 并把 `value` 原样交回调用方,下游 Cindy 卡片又固定提供「自行键入」入口,这层宿主自加的校验把自定义答案全部丢掉。

本 PR 删除这层校验:非空答案一律回 `{value: answer}`(并照旧记入用户澄清),空答案与取消仍回 `{cancelled:true}`;`confirm` / `input` / `editor` 分支不动。

## 变更类型

fix

## 范围

- `packages/maker-core/src/agents/pi/index.ts`:扩展对话框 select 回帧分支删除 `options.includes(answer)` 校验(8 行)。
- 测试:`pi-auto-review-dispatch.test.ts` 新增宿主回帧用例(候选外非空自定义答案 → `{value}`;空答案 → `{cancelled:true}`);`cindyBridgeSource.test.ts` 新增提问工具端到端用例(多问题中候选项答案与候选外自定义答案同时形成 `answers`,`cancelled:false`)。
- 不涉及 renderer、协议、Pi 运行时或其他对话框类型。

## UI 变化

引用的设计规范:不涉及:仅主进程 Pi 宿主回帧逻辑,无界面改动。

## 怎么验证的

- `packages/maker-core`:`vitest run src/agents/pi/__tests__/pi-auto-review-dispatch.test.ts src/agents/pi/__tests__/cindyBridgeSource.test.ts` 209 passed / 1 skipped(含 2 项新增)。
- 反证:恢复 `options.includes(answer)` 校验后新增宿主用例失败(`{cancelled:true}` 而非 `{value:'teal'}`)。
- `packages/maker-core` `tsc --noEmit` 通过;根 `pnpm test:unit:related` PASS(apps/desktop full、packages/maker-core、packages/lizi-mcps、packages/orca-workflow)。
- 未在真实 Pi 会话实机点击卡片验证;issue 给出的无界面复现链路(extension_ui_request select + resolver 返回候选外字符串)即为新增用例。

## 风险

- 行为放宽仅限 select 的非空答案;真正的取消(resolver 非 ask_user_question 结果、空字符串)语义不变。空白字符串是否算有效答案沿用既有 `answer.length === 0` 判定,未扩大。
- 若某扩展依赖宿主替它过滤候选外的值,现在会收到原样字符串;这与原生 Pi RPC 行为一致,调用方本就需自行校验。

Fixes #4273
