### PR TITLE
fix(mobile): worktree 默认值同步不再阻挡创建任务

### DIFF
--- a/apps/mobile/app/sessions/new.tsx
+++ b/apps/mobile/app/sessions/new.tsx
@@ -1235,6 +1235,7 @@ export default function NewRemoteSessionScreen() {
   })
     || (worktreeEnabled && (
       worktreeBranchPreferenceSaving
+      || (worktreeEligibility.status === 'eligible' && !worktreeBranchPreferenceReady)
       || (worktreeBranchPreferenceTransactionRef.current?.key === worktreeBranchPreferenceKey
         && worktreeBranchPreferenceTransactionRef.current.status === 'unknown')
     ));
@@ -1244,8 +1245,10 @@ export default function NewRemoteSessionScreen() {
     ?? (worktreeBranchPreferenceError ? 'session.new.worktreeBranchSyncFailed' : null);
   const resolveWorktreeCreateErrorKey = useCallback(() => (
     worktreeEligibilityCaptionKey(worktreeEligibilityRef.current)
-      ?? 'session.new.worktreeBranchSaving'
-  ), []);
+      ?? (worktreeBranchPreferenceError
+        ? 'session.new.worktreeBranchSyncFailed'
+        : 'session.new.worktreeBranchSaving')
+  ), [worktreeBranchPreferenceError]);
 
   useLayoutEffect(() => {
     worktreePreferenceRenderedRef.current = {
@@ -1389,7 +1392,10 @@ export default function NewRemoteSessionScreen() {
       || currentEligibility.baseRepo !== intent.eligibility.baseRepo
     ) return false;
     const branchTransaction = worktreeBranchPreferenceTransactionRef.current;
-    return worktreeBranchPreferenceSyncKeyRef.current === intent.branchPreferenceSyncKey
+    // A missing branch snapshot may only be a pending read, not host consent
+    // to use the detected branch. Checkbox defaults remain independent.
+    return worktreeBranchPreferenceReadyKeyRef.current === intent.branchPreferenceSyncKey
+      && worktreeBranchPreferenceSyncKeyRef.current === intent.branchPreferenceSyncKey
       && worktreeBranchPreferenceWriteTargetRef.current !== intent.branchPreferenceKey
       && !(
         branchTransaction?.key === intent.branchPreferenceKey

--- a/apps/mobile/app/sessions/new.tsx
+++ b/apps/mobile/app/sessions/new.tsx
@@ -2928,6 +2928,16 @@ export default function NewRemoteSessionScreen() {
       revisionAtStart: preferenceRevisionAtStart,
       status: 'writing',
     };
+    // Switching devices may replace a write that is still awaiting ACK/echo.
+    // Preserve its uncertainty in the existing per-device reconciliation map.
+    const previousTransaction = worktreePreferenceTransactionRef.current;
+    if (previousTransaction && previousTransaction.deviceId !== targetDeviceId) {
+      worktreePreferenceAuthorityUnknownByDeviceRef.current.set(previousTransaction.deviceId, {
+        enabled: previousTransaction.enabled,
+        revisionAtStart: previousTransaction.revisionAtStart,
+      });
+      setWorktreePreferenceAuthorityVersion((value) => value + 1);
+    }
     worktreePreferenceTransactionRef.current = transaction;
     // Serialize preference writes; Create/Goal use the synchronous draft choice above.
     worktreePreferenceWriteTargetRef.current = targetDeviceId;

--- a/apps/mobile/app/sessions/new.tsx
+++ b/apps/mobile/app/sessions/new.tsx
@@ -389,7 +389,6 @@ interface WorktreeCreateIntentSnapshot {
   target: { deviceId: string; workingDir: string };
   eligibility: NewSessionWorktreeEligibility;
   sourceBranch: string;
-  preferenceSyncKey: string;
   branchPreferenceKey: string;
   branchPreferenceSyncKey: string;
 }
@@ -472,7 +471,14 @@ export default function NewRemoteSessionScreen() {
   const selectedDeviceLabel = selectedDeviceOption?.name || selectedDeviceName || selectedDeviceId || t('session.new.selectDevice');
   const maker = useMobileMakerTransport(selectedDeviceId);
   const worktreePreference = useRemoteNewMakerWorktreePreference(selectedDeviceId);
-  const worktreeEnabled = worktreePreference.enabled;
+  // Defaults are advisory. A choice made in this draft wins over later host pushes.
+  const worktreeChoicesRef = useRef(new Map<string, boolean>());
+  const [, setWorktreeChoiceVersion] = useState(0);
+  const worktreeEnabled = (selectedDeviceId
+    ? worktreeChoicesRef.current.get(selectedDeviceId)
+    : undefined) ?? worktreePreference.enabled;
+  const worktreeEnabledRef = useRef(worktreeEnabled);
+  worktreeEnabledRef.current = worktreeEnabled;
   const sessions = useRemoteSessions();
   const recentWorkspaces = useMemo(
     () => buildRecentWorkspaceOptions(
@@ -570,15 +576,9 @@ export default function NewRemoteSessionScreen() {
   const worktreeSourceBranchRef = useRef('HEAD');
   const worktreeSeedSeqRef = useRef(0);
   const [worktreeSeedRetryNonce, setWorktreeSeedRetryNonce] = useState(0);
-  const [worktreePreferenceReadyKey, setWorktreePreferenceReadyKey] = useState<string | null>(null);
-  const worktreePreferenceReadyKeyRef = useRef<string | null>(null);
   const worktreePreferenceSyncKeyRef = useRef('');
-  const worktreePreferenceAuthorityReadRef = useRef<{ syncKey: string; revision: number } | null>(
-    null,
-  );
   const worktreePreferenceWriteSeqRef = useRef(0);
-  // State updates are batched; this synchronous target fence closes the
-  // OFF→ON/ON→OFF then immediate Create gap before React renders the spinner.
+  // Serialize writes of the next default independently of the current draft.
   const worktreePreferenceWriteTargetRef = useRef<string | null>(null);
   const [worktreePreferenceSavingDeviceId, setWorktreePreferenceSavingDeviceId] =
     useState<string | null>(null);
@@ -1183,27 +1183,16 @@ export default function NewRemoteSessionScreen() {
       worktreePreferenceSavingDeviceId === selectedDeviceId
       || worktreePreferenceWriteTargetRef.current === selectedDeviceId
     );
+  const worktreePreferenceAwaitingEcho =
+    worktreePreferenceTransactionRef.current?.status === 'reconciling';
   const worktreePreferenceSyncKey = selectedDeviceId
     ? `${selectedDeviceId}\u0000${connectionEpoch}\u0000${presenceVersion}`
     : '';
   worktreePreferenceSyncKeyRef.current = worktreePreferenceSyncKey;
-  const worktreePreferenceReady = worktreePreferenceSyncKey.length > 0
-    && worktreePreferenceReadyKey === worktreePreferenceSyncKey
-    && worktreePreferenceReadyKeyRef.current === worktreePreferenceSyncKey;
   const worktreePreferenceAuthorityUnknown = selectedDeviceId != null
     && worktreePreferenceAuthorityUnknownByDeviceRef.current.has(selectedDeviceId);
   const worktreeApplicable = draft.workspaceKind === 'project'
     && draft.workingDir.trim().length > 0;
-  // ineligible(2026-08-07 裁决):确认目录不合格时无需等偏好就绪——反正不会
-  // 创建 worktree,GET 在途不应卡住普通会话创建。
-  const worktreePreferenceCreateBlocked = worktreeApplicable
-    && selectedDeviceId != null
-    && worktreeEligibility.status !== 'ineligible'
-    && (
-      worktreePreferenceSaving
-      || worktreePreferenceAuthorityUnknown
-      || !worktreePreferenceReady
-    );
   // host preference 虽然持久化，连接代次仍属于权威读取 identity：桌面重启/重连后
   // 即使 deviceId/repo 没变，也重新 GET，不能只相信手机内存里的旧快照。
   const worktreeBranchPreferenceSyncKey = worktreeBranchPreferenceKey
@@ -1223,7 +1212,6 @@ export default function NewRemoteSessionScreen() {
   const worktreeToggleDisabled =
     creating
     || worktreePreferenceSaving
-    || (!worktreePreferenceReady && !worktreePreferenceAuthorityUnknown)
     || (worktreeEligibility.status !== 'eligible' && !worktreeEnabled);
   // 分支区与 checkbox 是两条独立轴：OFF 时也可先选源分支；保存 checkbox 偏好在途
   // 同样不影响只读的分支枚举。只有目标尚不具备 worktree 资格或创建在途时禁用。
@@ -1234,31 +1222,30 @@ export default function NewRemoteSessionScreen() {
   const worktreeBranchSheetVisible = worktreeBranchSheetOpen
     && worktreeEligibility.status === 'eligible'
     && worktreeBranchListMatchesTarget;
-  // 勾选展示 = 工作端记忆**原样直出**(2026-07-29 用户裁决:状态只属于用户,系统不做
-  // 视觉折叠);项目目标资格不满足时显示 caption 并阻止创建，不能静默降级普通目录。
+  // 2026-09-11: show this draft's explicit choice, otherwise the last host mirror.
+  // Eligibility failures still cannot silently downgrade an enabled worktree.
   const worktreeChecked = worktreeEnabled;
   const worktreeCaptionKey = worktreeEligibilityCaptionKey(worktreeEligibility);
   const worktreeCreateBlocked = shouldBlockNewSessionCreateForWorktree({
     applicable: worktreeApplicable,
     enabled: worktreeEnabled,
     eligibility: worktreeEligibility,
-    preferenceSaving: worktreePreferenceSaving,
+    // Saving a default does not change the explicit parameters of this request.
+    preferenceSaving: false,
   })
-    || worktreePreferenceCreateBlocked
-    || (worktreeEnabled && worktreeBranchPreferenceSaving)
-    || (worktreeEnabled
-      && worktreeEligibility.status === 'eligible'
-      && (!worktreeBranchPreferenceReady || worktreeBranchPreferenceError));
+    || (worktreeEnabled && (
+      worktreeBranchPreferenceSaving
+      || (worktreeBranchPreferenceTransactionRef.current?.key === worktreeBranchPreferenceKey
+        && worktreeBranchPreferenceTransactionRef.current.status === 'unknown')
+    ));
   const worktreeControlCaptionKey = worktreeCaptionKey
     ?? (worktreePreferenceAuthorityUnknown ? 'session.new.worktreeSettingsSyncFailed' : null)
-    ?? (worktreePreferenceCreateBlocked ? 'session.new.worktreeSettingsSaving' : null)
+    ?? (worktreePreferenceSaving ? 'session.new.worktreeSettingsSaving' : null)
     ?? (worktreeBranchPreferenceError ? 'session.new.worktreeBranchSyncFailed' : null);
-  const resolveWorktreePreferenceGateErrorKey = useCallback(() => (
-    selectedDeviceId != null
-      && worktreePreferenceAuthorityUnknownByDeviceRef.current.has(selectedDeviceId)
-      ? 'session.new.worktreeSettingsSyncFailed'
-      : 'session.new.worktreeSettingsSaving'
-  ), [selectedDeviceId]);
+  const resolveWorktreeCreateErrorKey = useCallback(() => (
+    worktreeEligibilityCaptionKey(worktreeEligibilityRef.current)
+      ?? 'session.new.worktreeBranchSaving'
+  ), []);
 
   useLayoutEffect(() => {
     worktreePreferenceRenderedRef.current = {
@@ -1279,7 +1266,7 @@ export default function NewRemoteSessionScreen() {
       worktreePreferenceWriteTargetRef.current = null;
     }
     setWorktreePreferenceSavingDeviceId(null);
-  }, [selectedDeviceId, worktreePreference.enabled, worktreePreference.revision]);
+  }, [selectedDeviceId, worktreePreference.enabled, worktreePreference.revision, worktreePreferenceAwaitingEcho]);
 
   useEffect(() => {
     if (!selectedDeviceId) return;
@@ -1312,7 +1299,7 @@ export default function NewRemoteSessionScreen() {
     ) return;
     worktreePreferenceAuthorityUnknownByDeviceRef.current.delete(selectedDeviceId);
     setWorktreePreferenceAuthorityVersion((value) => value + 1);
-  }, [selectedDeviceId, worktreePreference.enabled, worktreePreference.revision]);
+  }, [selectedDeviceId, worktreePreference.enabled, worktreePreference.revision, worktreePreferenceAwaitingEcho]);
 
   const settleRenderedWorktreeBranchTransaction = useCallback((
     key: string,
@@ -1362,13 +1349,10 @@ export default function NewRemoteSessionScreen() {
       : '';
     return {
       applicable: target.deviceId.length > 0 && target.workingDir.trim().length > 0,
-      enabled: target.deviceId
-        ? remoteSessionStore.getNewMakerWorktreePreference(target.deviceId).enabled
-        : false,
+      enabled: worktreeEnabledRef.current,
       target,
       eligibility,
       sourceBranch: worktreeSourceBranchRef.current,
-      preferenceSyncKey: worktreePreferenceSyncKeyRef.current,
       branchPreferenceKey,
       branchPreferenceSyncKey: worktreeBranchPreferenceSyncKeyRef.current,
     };
@@ -1389,19 +1373,12 @@ export default function NewRemoteSessionScreen() {
     // 但快照不能替代实时状态:await 期间同目标可能被重探回 probing/eligible/
     // detect-failed,旧 ineligible 快照必须复核 live ref 仍为 ineligible 才放行,
     // 否则回到 fail closed(探测未定不等于确认不合格)。
+    if (!intent.enabled) return true;
     if (intent.eligibility.status === 'ineligible') {
       return worktreeEligibilityRef.current.status === 'ineligible';
     }
-    if (
-      worktreePreferenceSyncKeyRef.current !== intent.preferenceSyncKey
-      || worktreePreferenceReadyKeyRef.current !== intent.preferenceSyncKey
-      || worktreePreferenceWriteTargetRef.current === intent.target.deviceId
-      || worktreePreferenceAuthorityUnknownByDeviceRef.current.has(intent.target.deviceId)
-    ) return false;
-    const currentEnabled = remoteSessionStore
-      .getNewMakerWorktreePreference(intent.target.deviceId).enabled;
-    if (currentEnabled !== intent.enabled) return false;
-    if (!intent.enabled) return true;
+    // The click captures the displayed choice. Background defaults and persistence
+    // ACKs cannot invalidate an already submitted request.
     // ineligible 已在前面提前返回,此处只可能是 eligible(2026-08-07 裁决)。
     if (intent.eligibility.status !== 'eligible') return false;
     // 与 ineligible 快照同理:eligible 快照也必须复核 live 资格仍是同一 repo 的
@@ -1411,20 +1388,8 @@ export default function NewRemoteSessionScreen() {
       currentEligibility.status !== 'eligible'
       || currentEligibility.baseRepo !== intent.eligibility.baseRepo
     ) return false;
-    const currentStoredBranch = remoteSessionStore.getNewMakerWorktreeBranchPreference(
-      intent.target.deviceId,
-      currentEligibility.baseRepo,
-    );
-    const currentSourceBranch = isValidWorktreeBranchPreferenceSnapshot(
-      currentStoredBranch,
-      currentEligibility.baseRepo,
-    )
-      ? currentStoredBranch.sourceBranch
-      : worktreeSourceBranchRef.current;
-    if (currentSourceBranch !== intent.sourceBranch) return false;
     const branchTransaction = worktreeBranchPreferenceTransactionRef.current;
     return worktreeBranchPreferenceSyncKeyRef.current === intent.branchPreferenceSyncKey
-      && worktreeBranchPreferenceReadyKeyRef.current === intent.branchPreferenceSyncKey
       && worktreeBranchPreferenceWriteTargetRef.current !== intent.branchPreferenceKey
       && !(
         branchTransaction?.key === intent.branchPreferenceKey
@@ -2825,32 +2790,18 @@ export default function NewRemoteSessionScreen() {
   // 全新设备在 store 中没有镜像时本来就是默认未勾选,无需失败路径代替宿主写值。
   const worktreeSeedAgentKindRef = useRef(draft.agentKind);
   worktreeSeedAgentKindRef.current = draft.agentKind;
-  // 资格探测完成后才有这个标记。它只用于「缺字段时能不能把老被控端当 ready」,
-  // 不能进本 effect 依赖:选目录会让探测结果换代,cleanup 会把还在飞的 GET 取消掉,
-  // 合格目录上偏好门一直不放行,发送按钮就灰着还没提示。
+  // Read the host capability through a ref: probing a different directory must
+  // not cancel a device-wide defaults request. Old hosts need no missing-field retry.
   const worktreeHostSupportsRecoveryKeyDiscardRef = useRef(worktreeHostSupportsRecoveryKeyDiscard);
   worktreeHostSupportsRecoveryKeyDiscardRef.current = worktreeHostSupportsRecoveryKeyDiscard;
   useEffect(() => {
     const seq = ++worktreeSeedSeqRef.current;
     const syncKey = worktreePreferenceSyncKey;
-    const previousRead = worktreePreferenceAuthorityReadRef.current;
-    if (previousRead?.syncKey !== syncKey) {
-      worktreePreferenceReadyKeyRef.current = null;
-      setWorktreePreferenceReadyKey(null);
-    }
     if (!selectedDeviceId || !syncKey || deviceLinkStatus !== 'online') return undefined;
     const preferenceRevisionAtStart =
       remoteSessionStore.getNewMakerWorktreePreference(selectedDeviceId).revision;
-    worktreePreferenceAuthorityReadRef.current = {
-      syncKey,
-      revision: preferenceRevisionAtStart,
-    };
     let cancelled = false;
     let retryTimer: ReturnType<typeof setTimeout> | null = null;
-    const markReady = () => {
-      worktreePreferenceReadyKeyRef.current = syncKey;
-      setWorktreePreferenceReadyKey(syncKey);
-    };
     const scheduleRetry = () => {
       if (retryTimer) return;
       retryTimer = setTimeout(() => {
@@ -2876,8 +2827,7 @@ export default function NewRemoteSessionScreen() {
         ) return;
         const classification = classifyWorktreePreferenceSeed(defaults);
         if (classification.status === 'ready') {
-          // Store revision + committed render jointly release the ready gate via
-          // the observer below; do not expose the old checkbox value in-between.
+          // Update only the host mirror. Explicit draft choices remain separate.
           remoteSessionStore.setNewMakerWorktreePreference(
             selectedDeviceId,
             classification.enabled,
@@ -2890,8 +2840,7 @@ export default function NewRemoteSessionScreen() {
         ) {
           // Old hosts cannot persist this preference and also lack the recovery
           // capability marker. A new host can transiently return `{}` before its
-          // renderer cache arrives, so missing alone must never authorize OFF.
-          markReady();
+          // renderer cache arrives; keep the last mirror and retry in that case.
           return;
         }
         scheduleRetry();
@@ -2903,11 +2852,9 @@ export default function NewRemoteSessionScreen() {
           || worktreePreferenceSyncKeyRef.current !== syncKey
         ) return;
         if (isWorktreeChannelNotAllowedError(error)) {
-          markReady();
           return;
         }
-        // Timeout/offline/unknown failures cannot authorize the default OFF.
-        // Keep both Create and Goal fail-closed and retry on this same link.
+        // A failed defaults read leaves the displayed value usable for creation.
         scheduleRetry();
       });
     return () => {
@@ -2925,41 +2872,40 @@ export default function NewRemoteSessionScreen() {
     openLink,
   ]);
 
-  // A same-value push is still authoritative: the store deliberately advances
-  // revision for it. Only an observation newer than this connection/read start
-  // may release the initial checkbox authority gate.
+  // Saving the next default is independent of using this draft's explicit choice.
+  // An accepted write may never echo back; release the control after 10 seconds.
   useEffect(() => {
-    const read = worktreePreferenceAuthorityReadRef.current;
-    if (
-      !read
-      || !worktreePreferenceSyncKey
-      || read.syncKey !== worktreePreferenceSyncKey
-      || worktreePreference.revision <= read.revision
-    ) return;
-    worktreePreferenceReadyKeyRef.current = worktreePreferenceSyncKey;
-    setWorktreePreferenceReadyKey(worktreePreferenceSyncKey);
-  }, [worktreePreference.revision, worktreePreferenceSyncKey]);
+    if (!worktreePreferenceSavingDeviceId || !worktreePreferenceAwaitingEcho) return;
+    const transaction = worktreePreferenceTransactionRef.current;
+    const timer = setTimeout(() => {
+      if (!transaction || worktreePreferenceTransactionRef.current !== transaction) return;
+      worktreePreferenceAuthorityUnknownByDeviceRef.current.set(transaction.deviceId, {
+        enabled: transaction.enabled,
+        revisionAtStart: transaction.revisionAtStart,
+      });
+      worktreePreferenceTransactionRef.current = null;
+      worktreePreferenceWriteTargetRef.current = null;
+      setWorktreePreferenceSavingDeviceId(null);
+      setWorktreePreferenceAuthorityVersion((value) => value + 1);
+    }, 10_000);
+    return () => clearTimeout(timer);
+  }, [worktreePreferenceSavingDeviceId, worktreePreferenceAwaitingEcho]);
 
   // 用户显式点击开关:先写工作端,工作端接受后才更新手机内存镜像。
   // 资格不满足导致的禁用不会走到这里 —— 环境因素不抹掉用户偏好;
   // 写入失败也不在手机上制造一份假的持久状态。
   const toggleWorktree = useCallback(() => {
-    const pendingAuthority = selectedDeviceId
-      ? worktreePreferenceAuthorityUnknownByDeviceRef.current.get(selectedDeviceId)
-      : undefined;
     if (
       creatingRef.current
       || !selectedDeviceId
       || worktreePreferenceSaving
       || worktreePreferenceWriteTargetRef.current === selectedDeviceId
-      || (
-        worktreePreferenceReadyKeyRef.current !== worktreePreferenceSyncKeyRef.current
-        && !pendingAuthority
-      )
     ) return;
     const targetDeviceId = selectedDeviceId;
-    const next = pendingAuthority?.enabled
-      ?? !remoteSessionStore.getNewMakerWorktreePreference(targetDeviceId).enabled;
+    const next = !worktreeEnabledRef.current;
+    worktreeChoicesRef.current.set(targetDeviceId, next);
+    worktreeEnabledRef.current = next;
+    setWorktreeChoiceVersion((value) => value + 1);
     // 播种在途回包不得覆盖用户显式选择(seq 作废旧回包)。
     worktreeSeedSeqRef.current += 1;
     const preferenceRevisionAtStart =
@@ -2977,8 +2923,7 @@ export default function NewRemoteSessionScreen() {
       status: 'writing',
     };
     worktreePreferenceTransactionRef.current = transaction;
-    // Set before the first await so an immediate Create/Goal press cannot read
-    // the previous checkbox state from a stale render closure.
+    // Serialize preference writes; Create/Goal use the synchronous draft choice above.
     worktreePreferenceWriteTargetRef.current = targetDeviceId;
     setWorktreePreferenceSavingDeviceId(targetDeviceId);
     const releaseWrite = () => {
@@ -3040,8 +2985,7 @@ export default function NewRemoteSessionScreen() {
         });
         if (worktreePreferenceWriteSeqRef.current !== writeSeq) return;
         if (outcome === 'accepted') {
-          // Main only acknowledged the broadcast. Keep both Create paths
-          // closed until renderer persistence returns through push or GET.
+          // Main acknowledged the broadcast; track persistence separately from creation.
           transaction.status = 'reconciling';
           setWorktreeSeedRetryNonce((value) => value + 1);
         }
@@ -3053,9 +2997,8 @@ export default function NewRemoteSessionScreen() {
           releaseWrite();
           return;
         }
-        // Lost ACK / disconnect may have committed remotely. Reconcile via
-        // push/GET; both Create and Goal remain blocked, while checkbox retry
-        // stays available once the active write spinner is released.
+        // Lost ACK / disconnect may have committed remotely. Reconcile the default
+        // via push/GET, while the explicit draft choice remains usable.
         markAuthorityUnknown();
       }
     })();
@@ -3487,9 +3430,7 @@ export default function NewRemoteSessionScreen() {
     <Pressable
       accessibilityLabel={creating ? t('session.new.creatingSession') : t('session.new.createAndSend')}
       accessibilityHint={createValidation
-        ?? (worktreePreferenceSaving
-          ? t('session.new.worktreeSettingsSaving')
-          : worktreeBranchPreferenceSaving
+        ?? (worktreeBranchPreferenceSaving
             ? t('session.new.worktreeBranchSaving')
             : worktreeCreateBlocked && worktreeControlCaptionKey
               ? t(worktreeControlCaptionKey)
@@ -3498,7 +3439,6 @@ export default function NewRemoteSessionScreen() {
       accessibilityState={{
         busy: creating
           || voiceIsProcessing
-          || worktreePreferenceSaving
           || worktreeBranchPreferenceSaving
           || undefined,
         disabled: !canCreate || undefined,
@@ -4082,40 +4022,9 @@ export default function NewRemoteSessionScreen() {
       setError(t('session.menu.aiRenameOffline'));
       return;
     }
-    if (
-      worktreeApplicable
-      && worktreeEligibility.status !== 'ineligible'
-      && (
-        worktreePreferenceWriteTargetRef.current === selectedDeviceId
-        || worktreePreferenceAuthorityUnknownByDeviceRef.current.has(selectedDeviceId)
-        || worktreePreferenceReadyKeyRef.current !== worktreePreferenceSyncKeyRef.current
-      )
-    ) {
-      setError(t(resolveWorktreePreferenceGateErrorKey()));
-      return;
-    }
-    if (
-      worktreeEnabled
-      && (
-        worktreeBranchPreferenceWriteTargetRef.current === worktreeBranchPreferenceKey
-        || (
-          worktreeEligibility.status === 'eligible'
-          && worktreeBranchPreferenceReadyKeyRef.current !== worktreeBranchPreferenceSyncKey
-        )
-      )
-    ) {
-      setError(t('session.new.worktreeBranchSaving'));
-      return;
-    }
-    if (worktreeCreateBlocked) {
-      setError(worktreeCaptionKey
-        ? t(worktreeCaptionKey)
-        : t(resolveWorktreePreferenceGateErrorKey()));
-      return;
-    }
     const worktreeIntent = captureWorktreeCreateIntent();
     if (!isWorktreeCreateIntentCurrent(worktreeIntent)) {
-      setError(t(resolveWorktreePreferenceGateErrorKey()));
+      setError(t(resolveWorktreeCreateErrorKey()));
       return;
     }
     creatingRef.current = true;
@@ -4228,7 +4137,7 @@ export default function NewRemoteSessionScreen() {
           return;
         }
         if (!isWorktreeCreateIntentCurrent(worktreeIntent)) {
-          setError(t(resolveWorktreePreferenceGateErrorKey()));
+          setError(t(resolveWorktreeCreateErrorKey()));
           return;
         }
       }
@@ -4295,7 +4204,7 @@ export default function NewRemoteSessionScreen() {
           if (!isCurrentOwner()) return;
           if (!ensureDeviceAlive()) return;
           if (!isWorktreeCreateIntentCurrent(worktreeIntent)) {
-            setError(t(resolveWorktreePreferenceGateErrorKey()));
+            setError(t(resolveWorktreeCreateErrorKey()));
             return;
           }
           const recoveryKey = createNewSessionId();
@@ -4336,7 +4245,7 @@ export default function NewRemoteSessionScreen() {
               recoveryKey,
               createdAt,
             });
-            setError(t(resolveWorktreePreferenceGateErrorKey()));
+            setError(t(resolveWorktreeCreateErrorKey()));
             return;
           }
           const createRequest = buildWorktreeCreateRequest({
@@ -4624,7 +4533,7 @@ export default function NewRemoteSessionScreen() {
     worktreeEnabled,
     captureWorktreeCreateIntent,
     isWorktreeCreateIntentCurrent,
-    resolveWorktreePreferenceGateErrorKey,
+    resolveWorktreeCreateErrorKey,
   ]);
 
   // 目标模式建会话(对齐桌面 handleCreateGoal):createSession → goal.set(被控端落
@@ -4645,42 +4554,9 @@ export default function NewRemoteSessionScreen() {
       setGoalError(t('session.new.enterModel'));
       return;
     }
-    if (
-      worktreeApplicable
-      && worktreeEligibility.status !== 'ineligible'
-      && (
-        worktreePreferenceWriteTargetRef.current === selectedDeviceId
-        || worktreePreferenceAuthorityUnknownByDeviceRef.current.has(selectedDeviceId)
-        || worktreePreferenceReadyKeyRef.current !== worktreePreferenceSyncKeyRef.current
-      )
-    ) {
-      setGoalError(t(resolveWorktreePreferenceGateErrorKey()));
-      return;
-    }
-    if (
-      worktreeEnabled
-      && (
-        worktreeBranchPreferenceWriteTargetRef.current === worktreeBranchPreferenceKey
-        || (
-          worktreeEligibility.status === 'eligible'
-          && worktreeBranchPreferenceReadyKeyRef.current !== worktreeBranchPreferenceSyncKey
-        )
-      )
-    ) {
-      setGoalError(t('session.new.worktreeBranchSaving'));
-      return;
-    }
-    // Goal 与普通创建共享同一 Worktree 门禁。分支偏好和 checkbox 仍是
-    // 独立轴：OFF 时直接走 base repo，ON 时必须等偏好/资格确认完成。
-    if (worktreeCreateBlocked) {
-      setGoalError(worktreeCaptionKey
-        ? t(worktreeCaptionKey)
-        : t(resolveWorktreePreferenceGateErrorKey()));
-      return;
-    }
     const worktreeIntent = captureWorktreeCreateIntent();
     if (!isWorktreeCreateIntentCurrent(worktreeIntent)) {
-      setGoalError(t(resolveWorktreePreferenceGateErrorKey()));
+      setGoalError(t(resolveWorktreeCreateErrorKey()));
       return;
     }
     // ㉙ 设备守卫入口(独立 review P1-1 + busy 泄漏):快照取自闭包 selectedDeviceId,
@@ -4814,7 +4690,7 @@ export default function NewRemoteSessionScreen() {
           return;
         }
         if (!isWorktreeCreateIntentCurrent(worktreeIntent)) {
-          setGoalError(t(resolveWorktreePreferenceGateErrorKey()));
+          setGoalError(t(resolveWorktreeCreateErrorKey()));
           return;
         }
       }
@@ -4839,7 +4715,7 @@ export default function NewRemoteSessionScreen() {
           if (!isCurrentOwner()) return;
           if (!ensureDeviceAlive()) return;
           if (!isWorktreeCreateIntentCurrent(worktreeIntent)) {
-            setGoalError(t(resolveWorktreePreferenceGateErrorKey()));
+            setGoalError(t(resolveWorktreeCreateErrorKey()));
             return;
           }
           const recoveryKey = createNewSessionId();
@@ -4875,7 +4751,7 @@ export default function NewRemoteSessionScreen() {
               recoveryKey,
               createdAt,
             });
-            setGoalError(t(resolveWorktreePreferenceGateErrorKey()));
+            setGoalError(t(resolveWorktreeCreateErrorKey()));
             return;
           }
           const createRequest = buildWorktreeCreateRequest({
@@ -5398,7 +5274,7 @@ export default function NewRemoteSessionScreen() {
     worktreeEnabled,
     captureWorktreeCreateIntent,
     isWorktreeCreateIntentCurrent,
-    resolveWorktreePreferenceGateErrorKey,
+    resolveWorktreeCreateErrorKey,
   ]);
 
   return (
@@ -6091,16 +5967,9 @@ export default function NewRemoteSessionScreen() {
           <ContextSheetGoalCreateForm
             busy={goalBusy}
             disabled={worktreeCreateBlocked}
-            disabledHint={worktreePreferenceSaving
-              ? t('session.new.worktreeSettingsSaving')
-              : worktreeBranchPreferenceSaving
-                || (worktreeEnabled
-                  && worktreeEligibility.status === 'eligible'
-                  && !worktreeBranchPreferenceReady)
-                ? t('session.new.worktreeBranchSaving')
-                : worktreeControlCaptionKey
-                  ? t(worktreeControlCaptionKey)
-                  : undefined}
+            disabledHint={worktreeCreateBlocked && worktreeControlCaptionKey
+              ? t(worktreeControlCaptionKey)
+              : undefined}
             error={goalError}
             initial={draft.firstMessage.trim() ? { objective: draft.firstMessage.trim() } : undefined}
             onSetGoal={(input) => void createGoalSession(input)}

--- a/apps/mobile/src/__tests__/newSession.test.ts
+++ b/apps/mobile/src/__tests__/newSession.test.ts
@@ -1839,7 +1839,6 @@ describe('new session composer surface', () => {
     expect(createSource).toContain('effectiveDraft = { ...draft, firstMessage: latestDraftText };');
     expect(createSource).toContain('creatingRef.current = false;');
     expect(createButtonSource).toContain('busy: creating');
-    expect(createButtonSource).toContain('|| worktreePreferenceSaving');
     expect(createButtonSource).toContain('|| worktreeBranchPreferenceSaving');
     expect(newSource).toContain('disabled: !canCreate || undefined,');
     // No start cue on mobile: playing a cue via expo-audio during capture stalls
@@ -1908,69 +1907,6 @@ describe('new session worktree wiring (source locks)', () => {
     expect(newSource).toContain('worktreeIntent.applicable');
     expect(newSource).toContain('&& worktreeIntent.enabled');
     expect(newSource).toContain("&& worktreeIntent.eligibility.status === 'eligible'");
-  });
-
-  it('keeps the workstation-owned preference semantics (seed + explicit write-through)', () => {
-    // 播种:openLink + 瞬态重试(app 后台恢复的重连窗口不得把工作端偏好静默播成未勾)。
-    expect(newSource).toContain(
-      "if (!selectedDeviceId || !syncKey || deviceLinkStatus !== 'online') return undefined;",
-    );
-    expect(newSource).toContain('return maker.getNewMakerDefaults(worktreeSeedAgentKindRef.current);');
-    expect(newSource).toContain(
-      'remoteSessionStore.getNewMakerWorktreePreference(selectedDeviceId).revision',
-    );
-    expect(newSource).toContain(
-      'remoteSessionStore.setNewMakerWorktreePreference(',
-    );
-    expect(newSource).toContain(
-      'useRemoteNewMakerWorktreePreference(selectedDeviceId)',
-    );
-    expect(newSource).toContain("classification.status === 'missing'");
-    expect(newSource).toContain('worktreeHostSupportsRecoveryKeyDiscardRef.current === false');
-    const seedEffect = newSource.indexOf('const worktreeSeedAgentKindRef = useRef(draft.agentKind);');
-    const seedDeps = newSource.slice(
-      newSource.indexOf('}, [', seedEffect),
-      newSource.indexOf(']);', seedEffect) + 3,
-    );
-    expect(seedDeps).toContain('worktreePreferenceSyncKey,');
-    expect(seedDeps).not.toContain('worktreeHostSupportsRecoveryKeyDiscard,');
-    expect(newSource).not.toContain(
-      'remoteSessionStore.setNewMakerWorktreePreference(selectedDeviceId, false);',
-    );
-    expect(newSource).toContain('worktreePreferenceSyncKey,');
-    expect(newSource).toContain('worktreeSeedRetryNonce,');
-    // 显式点击才写穿工作端记忆;工作端接受后才更新手机镜像。
-    expect(newSource).toContain('applyWorktreePreferenceOnHost({');
-    expect(newSource).toContain('apply: maker.applyNewMakerWorktreePref,');
-    expect(newSource).toContain(
-      "!next && worktreeEligibility.status === 'unsupported',",
-    );
-    expect(newSource).toContain('enabled: worktreeEnabled,');
-    expect(newSource).not.toContain(
-      'void maker.applyNewMakerWorktreePref(next).catch(() => undefined);',
-    );
-    // host-first 写入期间，适用 worktree 的项目由按钮和 create() 二次门禁阻止读取旧镜像；
-    // 对话工作区不应被一份与当前创建无关的偏好写入卡住。
-    expect(newSource).toContain('&& !worktreeCreateBlocked;');
-    expect(newSource).toContain(
-      'applicable: worktreeApplicable,',
-    );
-    const createEntry = newSource.indexOf('const create = useCallback(async () => {');
-    // ineligible 豁免守卫使 create 函数体略长,窗口扩至 1600 确保覆盖 worktreeCreateBlocked。
-    const createBody = newSource.slice(createEntry, createEntry + 1_600);
-    expect(createBody).not.toContain('|| worktreePreferenceSaving');
-    expect(createBody).toContain('if (worktreeCreateBlocked) {');
-    expect(newSource).toContain('worktreeBranchPreferenceSaving');
-    expect(newSource).toContain('worktreeCreateBlocked && worktreeControlCaptionKey');
-    expect(newSource).toContain(
-      "worktreePreferenceAuthorityUnknown ? 'session.new.worktreeSettingsSyncFailed' : null",
-    );
-    expect(newSource).toContain("worktreePreferenceCreateBlocked ? 'session.new.worktreeSettingsSaving' : null");
-    expect(newSource).toContain('const resolveWorktreePreferenceGateErrorKey = useCallback(() => (');
-    expect(newSource).toContain("? 'session.new.worktreeSettingsSyncFailed'");
-    expect(newSource).toContain(": 'session.new.worktreeSettingsSaving'");
-    expect(newSource).toContain('setError(t(resolveWorktreePreferenceGateErrorKey()));');
-    expect(newSource).toContain('setGoalError(t(resolveWorktreePreferenceGateErrorKey()));');
   });
 
   it('re-probes worktree eligibility when the relay or workstation reconnects', () => {
@@ -2116,7 +2052,7 @@ describe('new session worktree wiring (source locks)', () => {
     const goalStart = newSource.indexOf('const createGoalSession = useCallback(');
     const goalEnd = newSource.indexOf('\n\n  return (', goalStart);
     const goalBody = newSource.slice(goalStart, goalEnd);
-    const gate = goalBody.indexOf('if (worktreeCreateBlocked) {');
+    const gate = goalBody.indexOf('if (!isWorktreeCreateIntentCurrent(worktreeIntent)) {');
     const worktreeCreate = goalBody.indexOf(
       'await maker.worktree.create(createRequest)',
     );
@@ -2130,27 +2066,6 @@ describe('new session worktree wiring (source locks)', () => {
     expect(goalBody).toContain('effectiveDraft = { ...draft, workingDir: response.meta.path };');
     expect(goalBody).toContain('sessionId: precreatedWorktree!.sessionId');
     expect(goalBody).toContain('sessionId: precreatedWorktree.sessionId');
-  });
-
-  it('does not couple OFF creation to branch writes, while closing checkbox and branch same-tick races', () => {
-    expect(newSource).toContain('|| (worktreeEnabled && worktreeBranchPreferenceSaving)');
-    expect(newSource).toContain('worktreePreferenceWriteTargetRef.current = targetDeviceId;');
-    expect(newSource).toContain('worktreeBranchPreferenceWriteTargetRef.current = key;');
-    const createStart = newSource.indexOf('const create = useCallback(async () => {');
-    const goalStart = newSource.indexOf('const createGoalSession = useCallback(');
-    expect(newSource.slice(createStart, goalStart)).toContain(
-      'worktreePreferenceWriteTargetRef.current === selectedDeviceId',
-    );
-    expect(newSource.slice(goalStart, goalStart + 2_000)).toContain(
-      'worktreePreferenceWriteTargetRef.current === selectedDeviceId',
-    );
-    expect(newSource.slice(createStart, goalStart)).toContain(
-      'worktreeBranchPreferenceWriteTargetRef.current === worktreeBranchPreferenceKey',
-    );
-    expect(newSource.slice(goalStart, goalStart + 2_500)).toContain(
-      'worktreeBranchPreferenceWriteTargetRef.current === worktreeBranchPreferenceKey',
-    );
-    expect(newSource).toContain('disabled={worktreeCreateBlocked}');
   });
 
   it('keeps branch preference GET fail-closed except for explicit old-channel compatibility', () => {

--- a/apps/mobile/src/__tests__/newSessionWorktreeSync.test.tsx
+++ b/apps/mobile/src/__tests__/newSessionWorktreeSync.test.tsx
@@ -1,0 +1,270 @@
+// @vitest-environment jsdom
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+import { act, createElement, useCallback, useEffect, useLayoutEffect, useRef, useState } from 'react';
+import { createRoot, type Root } from 'react-dom/client';
+import ts from 'typescript';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { remoteSessionStore, useRemoteNewMakerWorktreePreference } from '@/session/remoteSessionStore';
+import {
+  applyWorktreePreferenceOnHost, classifyWorktreePreferenceSeed, isWorktreeChannelNotAllowedError,
+  shouldBlockNewSessionCreateForWorktree, worktreeEligibilityCaptionKey,
+  type NewSessionWorktreeEligibility,
+} from '@/session/newSessionWorktree';
+import { withTransientRemoteRetry } from '@/device-link/remoteRetry';
+
+// Exercise the page's actual hooks and both entry guards. Extract AST statements
+// (as in newSessionWorkspaceEffects), avoiding a parallel implementation of the gates.
+const source = ts.createSourceFile('new.tsx', readFileSync(
+  resolve(process.cwd(), 'app/sessions/new.tsx'), 'utf8',
+), ts.ScriptTarget.Latest, true, ts.ScriptKind.TSX);
+const page = source.statements.find((node): node is ts.FunctionDeclaration =>
+  ts.isFunctionDeclaration(node) && node.name?.text === 'NewRemoteSessionScreen');
+if (!page?.body) throw new Error('NewRemoteSessionScreen not found');
+function names(node: ts.Node): Set<string> {
+  const found = new Set<string>();
+  function visit(child: ts.Node) {
+    if (ts.isIdentifier(child)) found.add(child.text);
+    ts.forEachChild(child, visit);
+  }
+  visit(node);
+  return found;
+}
+const declarations = new Set([
+  'worktreePreference', 'worktreeChoicesRef', 'setWorktreeChoiceVersion', 'worktreeEnabled',
+  'worktreeEnabledRef', 'worktreeSeedSeqRef', 'worktreeSeedRetryNonce',
+  'worktreePreferenceSyncKeyRef', 'worktreePreferenceWriteSeqRef',
+  'worktreePreferenceWriteTargetRef', 'worktreePreferenceSavingDeviceId',
+  'worktreePreferenceTransactionRef', 'worktreePreferenceRenderedRef',
+  'worktreePreferenceAuthorityUnknownByDeviceRef', 'setWorktreePreferenceAuthorityVersion',
+  'worktreePreferenceSaving', 'worktreePreferenceSyncKey', 'worktreePreferenceAuthorityUnknown',
+  'worktreeApplicable', 'worktreeToggleDisabled', 'worktreeCreateBlocked', 'worktreeCaptionKey',
+  'worktreeControlCaptionKey', 'resolveWorktreeCreateErrorKey',
+  'captureWorktreeCreateIntent', 'isWorktreeCreateIntentCurrent', 'worktreeSeedAgentKindRef',
+  'worktreeHostSupportsRecoveryKeyDiscardRef', 'worktreePreferenceAwaitingEcho', 'toggleWorktree',
+]);
+const hooks = page.body.statements.filter((statement) => {
+  if (ts.isVariableStatement(statement)) return statement.declarationList.declarations.some(
+    (declaration) => [...names(declaration.name)].some((name) => declarations.has(name)),
+  );
+  if (!ts.isExpressionStatement(statement)) return false;
+  const expr = statement.expression;
+  if (ts.isBinaryExpression(expr)) return [
+    'worktreeEnabledRef.current', 'worktreePreferenceSyncKeyRef.current',
+    'worktreeSeedAgentKindRef.current', 'worktreeHostSupportsRecoveryKeyDiscardRef.current',
+  ].includes(expr.left.getText(source));
+  if (!ts.isCallExpression(expr) || !['useEffect', 'useLayoutEffect'].includes(expr.expression.getText(source))) return false;
+  const ids = names(statement);
+  return ids.has('worktreeSeedSeqRef') || ids.has('worktreePreferenceAuthorityUnknownByDeviceRef')
+    || ids.has('worktreePreferenceRenderedRef');
+});
+for (const name of declarations) {
+  if (!hooks.some((node) => ts.isVariableStatement(node) && node.declarationList.declarations.some(
+    (declaration) => names(declaration.name).has(name),
+  ))) throw new Error(`Missing page worktree declaration: ${name}`);
+}
+function entryGuards(name: string): string {
+  const statement = page!.body!.statements.find((node) => ts.isVariableStatement(node)
+    && node.declarationList.declarations.some((decl) => decl.name.getText(source) === name)) as ts.VariableStatement;
+  const call = statement.declarationList.declarations[0].initializer as ts.CallExpression;
+  const callback = call.arguments[0] as ts.ArrowFunction;
+  const body = callback.body as ts.Block;
+  const end = body.statements.findIndex((node) => ts.isExpressionStatement(node)
+    && node.expression.getText(source) === 'creatingRef.current = true');
+  if (end < 0) throw new Error(`Missing create boundary: ${name}`);
+  const guards = body.statements.slice(0, end).filter((node) =>
+    [...names(node)].some((id) => /^(worktree|captureWorktree|isWorktree)/.test(id)));
+  if (!guards.some((node) => names(node).has('worktreeIntent'))) throw new Error(`Missing intent: ${name}`);
+  return `function ${name}() { ${guards.map((node) => node.getText(source)).join('\n')} return worktreeIntent; }`;
+}
+const bindingsNames = [
+  'useState', 'useRef', 'useEffect', 'useLayoutEffect', 'useCallback',
+  'remoteSessionStore', 'useRemoteNewMakerWorktreePreference', 'applyWorktreePreferenceOnHost',
+  'classifyWorktreePreferenceSeed', 'isWorktreeChannelNotAllowedError', 'withTransientRemoteRetry',
+  'shouldBlockNewSessionCreateForWorktree', 'worktreeEligibilityCaptionKey',
+  'selectedDeviceId', 'connectionEpoch', 'presenceVersion', 'deviceLinkStatus', 'deviceLinkStatusRef',
+  'creating', 'creatingRef', 'draft', 'maker', 'openLink', 'worktreeEligibility',
+  'worktreeHostSupportsRecoveryKeyDiscard', 'worktreeBranchPreferenceSaving',
+  'worktreeBranchPreferenceError', 'worktreeBranchPreferenceKey', 'worktreeBranchPreferenceSyncKey',
+  'worktreeBranchPreferenceSyncKeyRef', 'worktreeBranchPreferenceWriteTargetRef',
+  'worktreeBranchPreferenceTransactionRef', 'worktreeBranchTargetRef',
+  'worktreeEligibilityRef', 'worktreeSourceBranchRef', 't', 'setError', 'setGoalError',
+];
+const compiled = ts.transpileModule(`function usePageWorktree(bindings) {
+  const { ${bindingsNames.join(', ')} } = bindings;
+  ${hooks.map((node) => node.getText(source)).join('\n')}
+  ${entryGuards('create')}
+  ${entryGuards('createGoalSession')}
+  return { worktreeEnabled, worktreeCreateBlocked, worktreeToggleDisabled,
+    worktreePreferenceSaving, worktreePreferenceAuthorityUnknown,
+    toggleWorktree, create, createGoalSession, isWorktreeCreateIntentCurrent };
+}`, { compilerOptions: { target: ts.ScriptTarget.ES2022 } }).outputText;
+interface Intent { enabled: boolean; sourceBranch: string; target: { deviceId: string } }
+interface State {
+  worktreeEnabled: boolean;
+  worktreeCreateBlocked: boolean;
+  worktreeToggleDisabled: boolean;
+  worktreePreferenceSaving: boolean;
+  worktreePreferenceAuthorityUnknown: boolean;
+  toggleWorktree(): void;
+  create(): Intent | undefined;
+  createGoalSession(): Intent | undefined;
+  isWorktreeCreateIntentCurrent(intent: Intent): boolean;
+}
+const usePageWorktree = new Function(`${compiled}; return usePageWorktree;`)() as
+  (bindings: Record<string, unknown>) => State;
+Object.assign(globalThis, { IS_REACT_ACT_ENVIRONMENT: true });
+let root: Root | undefined;
+afterEach(() => { act(() => root?.unmount()); root = undefined; vi.useRealTimers(); });
+let deviceSequence = 0;
+function deferred<T>() {
+  let resolve!: (value: T) => void;
+  let reject!: (error: Error) => void;
+  const promise = new Promise<T>((yes, no) => { resolve = yes; reject = no; });
+  return { promise, resolve, reject };
+}
+function mount(remembered?: boolean) {
+  const deviceId = `worktree-sync-${++deviceSequence}`;
+  if (remembered !== undefined) remoteSessionStore.setNewMakerWorktreePreference(deviceId, remembered);
+  const read = deferred<{ worktreeEnabled?: boolean }>();
+  const write = deferred<void>();
+  const eligibility: NewSessionWorktreeEligibility = { status: 'eligible', baseRepo: '/repo', sourceBranch: 'main' };
+  const bindings = {
+    useState, useRef, useEffect, useLayoutEffect, useCallback,
+    remoteSessionStore, useRemoteNewMakerWorktreePreference, applyWorktreePreferenceOnHost,
+    classifyWorktreePreferenceSeed, isWorktreeChannelNotAllowedError, withTransientRemoteRetry,
+    shouldBlockNewSessionCreateForWorktree, worktreeEligibilityCaptionKey,
+    selectedDeviceId: deviceId, connectionEpoch: 1, presenceVersion: 1,
+    deviceLinkStatus: 'online', deviceLinkStatusRef: { current: 'online' },
+    creating: false, creatingRef: { current: false },
+    draft: { workspaceKind: 'project', workingDir: '/repo', agentKind: 'codex' },
+    maker: { getNewMakerDefaults: vi.fn(() => read.promise), applyNewMakerWorktreePref: vi.fn(() => write.promise) },
+    openLink: vi.fn(async () => {}), worktreeEligibility: eligibility as NewSessionWorktreeEligibility,
+    worktreeHostSupportsRecoveryKeyDiscard: true,
+    worktreeBranchPreferenceSaving: false, worktreeBranchPreferenceError: false,
+    worktreeBranchPreferenceKey: `${deviceId}\0/repo`, worktreeBranchPreferenceSyncKey: 'branch-generation',
+    worktreeBranchPreferenceSyncKeyRef: { current: 'branch-generation' },
+    worktreeBranchPreferenceWriteTargetRef: { current: null as string | null },
+    worktreeBranchPreferenceTransactionRef: { current: null },
+    worktreeBranchTargetRef: { current: { deviceId, workingDir: '/repo' } },
+    worktreeEligibilityRef: { current: eligibility as NewSessionWorktreeEligibility }, worktreeSourceBranchRef: { current: 'main' },
+    t: (key: string) => key, setError: vi.fn(), setGoalError: vi.fn(),
+  };
+  let state!: State;
+  function Harness() { state = usePageWorktree(bindings); return null; }
+  root = createRoot(document.createElement('div'));
+  const render = () => act(() => root!.render(createElement(Harness)));
+  render();
+  return { bindings, read, write, render, deviceId, get state() { return state; } };
+}
+
+for (const entry of ['create', 'createGoalSession'] as const) {
+  describe(entry, () => {
+    it.each([undefined, false, true])('uses displayed value %s without waiting for defaults', async (remembered) => {
+      const h = mount(remembered);
+      await act(async () => {});
+      expect(h.bindings.maker.getNewMakerDefaults).toHaveBeenCalledWith('codex');
+      expect(h.state.worktreeCreateBlocked).toBe(false);
+      expect(h.state.worktreeToggleDisabled).toBe(false);
+      expect(h.state[entry]()).toMatchObject({ enabled: remembered ?? false, sourceBranch: 'main' });
+      await act(async () => { h.read.resolve({}); });
+      expect(h.state[entry]()).toMatchObject({ enabled: remembered ?? false });
+    });
+
+    it('uses a same-tick explicit toggle while saving, and ignores a late opposite default', async () => {
+      const h = mount(false);
+      let intent!: Intent;
+      act(() => { h.state.toggleWorktree(); intent = h.state[entry]()!; });
+      expect(intent.enabled).toBe(true);
+      expect(h.bindings.maker.applyNewMakerWorktreePref).toHaveBeenCalledWith(true);
+      expect(h.state.worktreePreferenceSaving).toBe(true);
+      expect(h.state.worktreeCreateBlocked).toBe(false);
+      await act(async () => {
+        h.read.resolve({ worktreeEnabled: false });
+        remoteSessionStore.setNewMakerWorktreePreference(h.deviceId, false);
+      });
+      expect(h.state.worktreeEnabled).toBe(true);
+      expect(h.state.isWorktreeCreateIntentCurrent(intent)).toBe(true);
+      expect(h.state[entry]()?.enabled).toBe(true);
+      await act(async () => { h.write.reject(new Error('timeout')); });
+      expect(h.state.worktreePreferenceAuthorityUnknown).toBe(true);
+      expect(h.state[entry]()?.enabled).toBe(true);
+      expect(h.state.worktreeToggleDisabled).toBe(false);
+    });
+
+    it('can turn a remembered ON value off and immediately send despite failed detection', () => {
+      const h = mount(true);
+      h.bindings.worktreeEligibility = { status: 'detect-failed' };
+      h.bindings.worktreeEligibilityRef.current = h.bindings.worktreeEligibility;
+      h.render();
+      expect(h.state.worktreeCreateBlocked).toBe(true);
+      let intent: Intent | undefined;
+      act(() => { h.state.toggleWorktree(); intent = h.state[entry](); });
+      expect(intent?.enabled).toBe(false);
+    });
+
+    it('freezes submission while allowing untouched defaults to refresh for the next attempt', async () => {
+      const h = mount(false);
+      const intent = h.state[entry]()!;
+      await act(async () => { h.read.resolve({ worktreeEnabled: true }); });
+      expect(h.state.worktreeEnabled).toBe(true);
+      expect(intent.enabled).toBe(false);
+      expect(h.state.isWorktreeCreateIntentCurrent(intent)).toBe(true);
+      expect(h.state[entry]()?.enabled).toBe(true);
+    });
+
+    it('keeps genuine eligibility and explicit branch-write failures blocking an enabled worktree', () => {
+      const h = mount(true);
+      h.bindings.worktreeEligibility = { status: 'detect-failed' };
+      h.bindings.worktreeEligibilityRef.current = h.bindings.worktreeEligibility;
+      h.render();
+      expect(h.state[entry]()).toBeUndefined();
+      h.bindings.worktreeEligibility = { status: 'eligible', baseRepo: '/repo', sourceBranch: 'main' };
+      h.bindings.worktreeEligibilityRef.current = h.bindings.worktreeEligibility;
+      h.bindings.worktreeBranchPreferenceWriteTargetRef.current = h.bindings.worktreeBranchPreferenceKey;
+      h.render();
+      expect(h.state[entry]()).toBeUndefined();
+    });
+  });
+}
+
+it('bounds an accepted write with no persistence echo, without ever blocking send', async () => {
+  vi.useFakeTimers();
+  const h = mount(false);
+  await act(async () => { h.state.toggleWorktree(); h.write.resolve(); });
+  expect(h.state.worktreePreferenceSaving).toBe(true);
+  expect(h.state.create()?.enabled).toBe(true);
+  await act(async () => { await vi.advanceTimersByTimeAsync(10_000); });
+  expect(h.state.worktreePreferenceSaving).toBe(false);
+  expect(h.state.worktreePreferenceAuthorityUnknown).toBe(true);
+  expect(h.state.worktreeEnabled).toBe(true);
+});
+
+it('keeps remembered values usable after a read failure and reconnection', async () => {
+  const h = mount(true);
+  await act(async () => { h.read.reject(new Error('invalid defaults response')); });
+  expect(h.state.create()?.enabled).toBe(true);
+  h.bindings.connectionEpoch += 1;
+  h.render();
+  expect(h.state.createGoalSession()?.enabled).toBe(true);
+});
+
+it('does not leak an explicit choice to another device, or accept a changed creation target', async () => {
+  const h = mount(false);
+  act(() => h.state.toggleWorktree());
+  const intent = h.state.create()!;
+  h.bindings.selectedDeviceId = `other-${h.deviceId}`;
+  h.bindings.worktreeBranchTargetRef.current = { deviceId: h.bindings.selectedDeviceId, workingDir: '/other' };
+  h.render();
+  expect(h.state.worktreeEnabled).toBe(false);
+  expect(h.state.isWorktreeCreateIntentCurrent(intent)).toBe(false);
+});
+
+it('settles an authoritative echo that arrives before the apply response', async () => {
+  const h = mount(false);
+  act(() => h.state.toggleWorktree());
+  await act(async () => { remoteSessionStore.setNewMakerWorktreePreference(h.deviceId, true); });
+  await act(async () => { h.write.resolve(); });
+  expect(h.state.worktreePreferenceSaving).toBe(false);
+  expect(h.state.worktreePreferenceAuthorityUnknown).toBe(false);
+});

--- a/apps/mobile/src/__tests__/newSessionWorktreeSync.test.tsx
+++ b/apps/mobile/src/__tests__/newSessionWorktreeSync.test.tsx
@@ -85,6 +85,7 @@ const bindingsNames = [
   'selectedDeviceId', 'connectionEpoch', 'presenceVersion', 'deviceLinkStatus', 'deviceLinkStatusRef',
   'creating', 'creatingRef', 'draft', 'maker', 'openLink', 'worktreeEligibility',
   'worktreeHostSupportsRecoveryKeyDiscard', 'worktreeBranchPreferenceSaving',
+  'worktreeBranchPreferenceReady', 'worktreeBranchPreferenceReadyKeyRef',
   'worktreeBranchPreferenceError', 'worktreeBranchPreferenceKey', 'worktreeBranchPreferenceSyncKey',
   'worktreeBranchPreferenceSyncKeyRef', 'worktreeBranchPreferenceWriteTargetRef',
   'worktreeBranchPreferenceTransactionRef', 'worktreeBranchTargetRef',
@@ -142,6 +143,8 @@ function mount(remembered?: boolean) {
     openLink: vi.fn(async () => {}), worktreeEligibility: eligibility as NewSessionWorktreeEligibility,
     worktreeHostSupportsRecoveryKeyDiscard: true,
     worktreeBranchPreferenceSaving: false, worktreeBranchPreferenceError: false,
+    worktreeBranchPreferenceReady: true,
+    worktreeBranchPreferenceReadyKeyRef: { current: 'branch-generation' as string | null },
     worktreeBranchPreferenceKey: `${deviceId}\0/repo`, worktreeBranchPreferenceSyncKey: 'branch-generation',
     worktreeBranchPreferenceSyncKeyRef: { current: 'branch-generation' },
     worktreeBranchPreferenceWriteTargetRef: { current: null as string | null },
@@ -211,6 +214,36 @@ for (const entry of ['create', 'createGoalSession'] as const) {
       expect(intent.enabled).toBe(false);
       expect(h.state.isWorktreeCreateIntentCurrent(intent)).toBe(true);
       expect(h.state[entry]()?.enabled).toBe(true);
+    });
+
+    it('waits for the source branch after project selection or reconnect, but OFF remains usable', () => {
+      const h = mount(true);
+      h.bindings.worktreeBranchPreferenceReady = false;
+      h.bindings.worktreeBranchPreferenceReadyKeyRef.current = null;
+      h.render();
+      expect(h.state.worktreeCreateBlocked).toBe(true);
+      expect(h.state[entry]()).toBeUndefined();
+      h.bindings.worktreeBranchPreferenceError = true;
+      h.render();
+      expect(h.state[entry]()).toBeUndefined();
+      expect(entry === 'create' ? h.bindings.setError : h.bindings.setGoalError)
+        .toHaveBeenLastCalledWith('session.new.worktreeBranchSyncFailed');
+      let intent: Intent | undefined;
+      act(() => { h.state.toggleWorktree(); intent = h.state[entry](); });
+      expect(intent?.enabled).toBe(false);
+    });
+
+    it('captures the confirmed host branch instead of the temporary detected branch', () => {
+      const h = mount(true);
+      h.bindings.worktreeBranchPreferenceReady = false;
+      h.bindings.worktreeBranchPreferenceReadyKeyRef.current = null;
+      h.render();
+      expect(h.state[entry]()).toBeUndefined();
+      h.bindings.worktreeSourceBranchRef.current = 'release';
+      h.bindings.worktreeBranchPreferenceReady = true;
+      h.bindings.worktreeBranchPreferenceReadyKeyRef.current = 'branch-generation';
+      h.render();
+      expect(h.state[entry]()?.sourceBranch).toBe('release');
     });
 
     it('keeps genuine eligibility and explicit branch-write failures blocking an enabled worktree', () => {

--- a/apps/mobile/src/__tests__/newSessionWorktreeSync.test.tsx
+++ b/apps/mobile/src/__tests__/newSessionWorktreeSync.test.tsx
@@ -301,3 +301,25 @@ it('settles an authoritative echo that arrives before the apply response', async
   expect(h.state.worktreePreferenceSaving).toBe(false);
   expect(h.state.worktreePreferenceAuthorityUnknown).toBe(false);
 });
+
+it.each(['writing', 'reconciling'])('retains device A uncertainty when device B replaces a %s write', async (phase) => {
+  const h = mount(false);
+  act(() => h.state.toggleWorktree());
+  if (phase === 'reconciling') await act(async () => { h.write.resolve(); });
+  const secondWrite = deferred<void>();
+  h.bindings.maker.applyNewMakerWorktreePref = vi.fn(() => secondWrite.promise);
+  h.bindings.selectedDeviceId = `other-${h.deviceId}`;
+  h.render();
+  act(() => h.state.toggleWorktree());
+  h.bindings.selectedDeviceId = h.deviceId;
+  h.render();
+  expect(h.state.worktreeEnabled).toBe(true);
+  expect(h.state.worktreePreferenceAuthorityUnknown).toBe(true);
+  expect(h.state.create()?.enabled).toBe(true);
+  expect(h.state.createGoalSession()?.enabled).toBe(true);
+  await act(async () => { h.write.resolve(); });
+  expect(h.state.worktreePreferenceAuthorityUnknown).toBe(true);
+  await act(async () => { remoteSessionStore.setNewMakerWorktreePreference(h.deviceId, true); });
+  expect(h.state.worktreePreferenceAuthorityUnknown).toBe(false);
+  expect(h.state.worktreeEnabled).toBe(true);
+});

--- a/apps/mobile/src/i18n/locales/en/session.json
+++ b/apps/mobile/src/i18n/locales/en/session.json
@@ -344,7 +344,7 @@
     "worktreeBranchSaving": "Syncing the selected branch…",
     "worktreeBranchSyncFailed": "Could not confirm the saved source branch — retry the branch selection",
     "worktreeSettingsSaving": "Syncing the worktree setting…",
-    "worktreeSettingsSyncFailed": "Could not confirm the saved worktree setting — retry the toggle",
+    "worktreeSettingsSyncFailed": "Could not save the worktree default. You can still use this selection.",
     "worktreeBranchesRetry": "Could not load branches. Tap to retry",
     "worktreeDetecting": "Detecting environment…",
     "worktreeRecovering": "Reconnecting and retrying automatically…",

--- a/apps/mobile/src/i18n/locales/ja/session.json
+++ b/apps/mobile/src/i18n/locales/ja/session.json
@@ -344,7 +344,7 @@
     "worktreeBranchSaving": "選択したブランチを同期中…",
     "worktreeBranchSyncFailed": "保存済みのソースブランチを確認できません。ブランチを再選択してください",
     "worktreeSettingsSaving": "worktree 設定を同期中…",
-    "worktreeSettingsSyncFailed": "保存済みの worktree 設定を確認できません。スイッチを再度操作してください",
+    "worktreeSettingsSyncFailed": "worktree の既定設定を保存できませんでした。現在の選択で続行できます。",
     "worktreeBranchesRetry": "ブランチを読み込めません。タップして再試行",
     "worktreeDetecting": "環境を検出中…",
     "worktreeRecovering": "接続を復旧中です。自動的に再試行しています…",

--- a/apps/mobile/src/i18n/locales/ko/session.json
+++ b/apps/mobile/src/i18n/locales/ko/session.json
@@ -340,7 +340,7 @@
     "worktreeBranchSaving": "선택한 브랜치 동기화 중…",
     "worktreeBranchSyncFailed": "저장된 소스 브랜치를 확인할 수 없습니다. 브랜치를 다시 선택해 주세요",
     "worktreeSettingsSaving": "worktree 설정 동기화 중…",
-    "worktreeSettingsSyncFailed": "저장된 worktree 설정을 확인할 수 없습니다. 스위치를 다시 눌러 주세요",
+    "worktreeSettingsSyncFailed": "worktree 기본 설정을 저장하지 못했습니다. 현재 선택으로 계속할 수 있습니다.",
     "worktreeBranchesRetry": "브랜치를 불러오지 못했습니다. 탭하여 다시 시도",
     "worktreeDetecting": "환경 감지 중…",
     "worktreeRecovering": "연결을 복구하는 중이며 자동으로 다시 시도하고 있습니다…",

--- a/apps/mobile/src/i18n/locales/zh-CN/session.json
+++ b/apps/mobile/src/i18n/locales/zh-CN/session.json
@@ -340,7 +340,7 @@
     "worktreeBranchSaving": "正在同步所选分支…",
     "worktreeBranchSyncFailed": "无法确认已保存的源分支，请重新选择分支",
     "worktreeSettingsSaving": "正在同步 worktree 设置…",
-    "worktreeSettingsSyncFailed": "无法确认已保存的 worktree 设置，请重试开关",
+    "worktreeSettingsSyncFailed": "未能保存 worktree 默认设置，仍可按当前选择继续",
     "worktreeBranchesRetry": "无法读取分支，点按重试",
     "worktreeDetecting": "检测环境中…",
     "worktreeRecovering": "连接恢复中，正在自动重试…",

--- a/apps/mobile/src/i18n/locales/zh-TW/session.json
+++ b/apps/mobile/src/i18n/locales/zh-TW/session.json
@@ -344,7 +344,7 @@
     "worktreeBranchSaving": "正在同步所選分支…",
     "worktreeBranchSyncFailed": "無法確認已儲存的源分支，請重新選擇分支",
     "worktreeSettingsSaving": "正在同步 worktree 設定…",
-    "worktreeSettingsSyncFailed": "無法確認已儲存的 worktree 設定，請重試開關",
+    "worktreeSettingsSyncFailed": "無法儲存 worktree 預設設定，仍可依目前選擇繼續",
     "worktreeBranchesRetry": "無法讀取分支，點按重試",
     "worktreeDetecting": "檢測環境中…",
     "worktreeRecovering": "連線恢復中，正在自動重試…",


### PR DESCRIPTION
## 这次改了什么

### 摘要

移动端选中项目后，worktree 默认值读取缺字段、超时或因重连失效，会一直显示“Syncing the worktree setting…”并禁用发送。现在后台读取默认值与创建分离：未手动修改时使用界面当前的主机记忆值（没有记忆则未勾选）；手动选择立即对本次草稿生效，发送冻结当时的选择，迟到的默认值不会改变本次创建。

### 变更类型

- [x] `fix` 缺陷修复

### 范围

- 关联 Issue / 需求：2026-09-11 用户反馈移动端无法发送，并要求默认设置同步尽量不干扰创建主线。
- 本 PR 包含：移动端普通发送和 Goal 创建共用的 worktree 门禁；启用 worktree 时确认来源分支，关闭时不等待分支读取；后台保存开关默认值不阻止发送，已接受的保存最多等 10 秒回显后释放控件；跨设备替换保存时保留旧设备未确认状态；更新五语言失败提示；24 个实际页面 hooks/入口行为回归替换旧同步阻塞的源码锁断言。
- 明确不包含：ACK、relay、服务端及原生层修改。实际 worktree 创建、恢复账本、回收与资格检查沿用现有流程。
- 用户可见变化：开关默认值同步的发送等待为 0 秒；开关可在默认值读取期间操作。本次选择与下次默认值保存分开，保存失败仍可按当前选择发送。来源分支读取与显式分支写入的保护保留，避免把临时探测到的 main 当成主机所选分支。
- 是否存在 breaking change：无，沿用既有 worktree:create/createSession 参数。
- 多端：iOS/Android 共用该新建页，两种创建入口均覆盖。桌面本地直接读本地 draft，无该默认值网络门禁；桌面远控读取的是完整运行配置（模型/来源/权限等），不属于本次手机单一 worktree 默认值卡住的路径，未修改。手机使用既有 Device Link 调用主机，不新增本地文件访问；SSH 不经过该手机 worktree 创建入口。

### UI 变化

- 引用的设计规范：`docs/design-rules/DESIGN.md` §1（减少阻碍工作流的附加状态）、§10（沿用现有 Light/Dark 语义样式）、§11（失败提示说明可继续的动作）。复用现有开关与提示行，不新增弹窗或选择步骤。
- 本次未启动 Metro/模拟器，没有新增真机截图，未声称完成双模式目检。

## 怎么验证的

### 自动验证

```text
pnpm test:unit:related
结果：PASS。初次提交选中的 9 个 workspace 全部通过；本轮分支竞态修复重新运行，相关 mobile 单测通过。
pnpm --filter mobile run typecheck
结果：PASS。
pnpm --filter mobile exec vitest run src/__tests__/newSessionWorktreeSync.test.tsx src/__tests__/newSession.test.ts
结果：PASS，156 tests（含新增 24 个行为回归；本轮通过相关单测门禁重跑）。
pnpm --filter mobile test:scope
结果：PASS。
pnpm --filter mobile test:smoke
结果：PASS，2 tests。
pnpm check:i18n
结果：PASS，仅既有非阻断告警。
pnpm check:i18n-glossary
结果：PASS，无新增违规。
node apps/mobile/scripts/ci-fingerprint.mjs compute --output <before/after report>
结果：两次 iOS/Android hash 一致。
git diff --check
结果：PASS。
```

### 手工验证

已自审全部 8 个文件，沿普通发送/Goal → 点击快照 → worktree:create → createSession 核对参数流及失败出口。测试直接执行页面 hooks 与两个创建入口的实际 worktree 守卫，验证缺字段、失败、重连、即时开关、保存超时、迟到回包、切设备与实际资格保护。

### 未执行的验证

未进行双设备真机、iOS/Android 实机及 Light/Dark 视觉验收。本轮没有启动开发服务或模拟器的授权；仅执行不启动这些服务的检查。worktree 为 `cindy-fix-mobile-worktree-sync-send`，分支 `fix-mobile-worktree-sync-send`；未运行 Metro，故无 Metro 归属或 __DEV__ build label。

## 风险

### 风险分类

- [x] 其他：默认值同步语义调整。

### 影响与回滚

- 影响范围：移动端新建项目任务。界面记忆可能比主机最新默认值旧，按用户明确选择以可见值继续；用户手动选择优先。只在显式操作开关时尝试保存主机默认值，不把未知默认值写成 false。真实开启 worktree 后仍必须完成资格检查与创建，业务失败不静默降级。
- 不修改 wire 协议、数据库、权限、system prompt、原生配置或 fingerprint；iOS/Android 指纹一致，不引入冷更。
- 回滚 / 降级方式：回退本提交即可恢复旧门禁，无数据迁移。

### 提交前检查

- [x] 已 review 完整 diff
- [x] 每个 commit 都带 DCO 签名
- [x] UI 改动已注明设计规范
- [x] 未提交凭证、令牌或授权文件
- [x] 已补充必要说明
- [x] 已确认测试结果并说明未执行项
