### PR TITLE
fix(remote-desktop): 输入失败只收回控制，不再拆掉整个会话

### DIFF
--- a/apps/desktop/src/main/remote-desktop/__tests__/captureBoundary.test.ts
+++ b/apps/desktop/src/main/remote-desktop/__tests__/captureBoundary.test.ts
@@ -18,6 +18,7 @@ const h = vi.hoisted(() => ({
   viewHeartbeat: vi.fn(),
   inputFailure: null as null | (() => void),
   releaseControl: vi.fn(),
+  hostInput: vi.fn(),
   iceConfig: vi.fn(async (): Promise<any[]> => [
     { urls: ['turn:relay.example.test:3478'], username: 'temporary', credential: 'test-only' },
   ]),
@@ -115,7 +116,7 @@ vi.mock('../inputHost', () => ({
       h.inputFailure = onFailure;
     }
     stop = vi.fn();
-    input = vi.fn();
+    input = h.hostInput;
   },
   readDesktopDisplayModes: vi.fn(),
   setDesktopDisplayMode: vi.fn(),
@@ -172,6 +173,7 @@ beforeEach(() => {
   h.viewHeartbeat.mockClear();
   // The host is constructed once at module load; keep its captured callback.
   h.releaseControl.mockClear();
+  h.hostInput.mockReset();
   h.iceConfig.mockClear();
   registerRemoteDesktopIpc();
 });
@@ -317,6 +319,17 @@ it('turns an input-helper failure into a control release instead of a session st
   expect(h.releaseControl).toHaveBeenCalledTimes(1);
   expect(h.stop).not.toHaveBeenCalled();
   expect(h.owner.dead).toBe(false);
+});
+
+it('releases control when the input host refuses a batch before injecting it', () => {
+  h.hostInput.mockImplementationOnce(() => {
+    throw new Error('DESKTOP_INPUT_UNAVAILABLE');
+  });
+  // The refusal still reaches its caller, but control no longer stays set: a
+  // later take-control must actually restart the helper.
+  expect(() => h.deps.input([{ kind: 'release' }])).toThrow('DESKTOP_INPUT_UNAVAILABLE');
+  expect(h.releaseControl).toHaveBeenCalledTimes(1);
+  expect(h.stop).not.toHaveBeenCalled();
 });
 
 it('retains the capture owner on ICE timeout and rejects old-owner replies after replacement', async () => {

--- a/apps/desktop/src/main/remote-desktop/__tests__/captureBoundary.test.ts
+++ b/apps/desktop/src/main/remote-desktop/__tests__/captureBoundary.test.ts
@@ -16,6 +16,8 @@ const h = vi.hoisted(() => ({
   nativeFrame: vi.fn(async () => 'frame'),
   input: vi.fn(),
   viewHeartbeat: vi.fn(),
+  inputFailure: null as null | (() => void),
+  releaseControl: vi.fn(),
   iceConfig: vi.fn(async (): Promise<any[]> => [
     { urls: ['turn:relay.example.test:3478'], username: 'temporary', credential: 'test-only' },
   ]),
@@ -93,6 +95,9 @@ vi.mock('../controller', () => ({
     stopByUser() {
       this.stop();
     }
+    releaseControl() {
+      h.releaseControl();
+    }
     tick() {}
     input = h.input;
     viewHeartbeat = h.viewHeartbeat;
@@ -106,6 +111,9 @@ vi.mock('../nativeCapture', () => ({
 }));
 vi.mock('../inputHost', () => ({
   DesktopInputHost: class {
+    constructor(onFailure: () => void) {
+      h.inputFailure = onFailure;
+    }
     stop = vi.fn();
     input = vi.fn();
   },
@@ -162,6 +170,8 @@ beforeEach(() => {
   h.nativeFrame.mockClear();
   h.input.mockReset();
   h.viewHeartbeat.mockClear();
+  // The host is constructed once at module load; keep its captured callback.
+  h.releaseControl.mockClear();
   h.iceConfig.mockClear();
   registerRemoteDesktopIpc();
 });
@@ -292,6 +302,21 @@ it('drops view-only input without breaking heartbeats, but still rejects invalid
     h.input.mockImplementation(() => { throw new Error(reason); });
     expect(() => input(event(), 'lease', 2, [])).toThrow('PERMISSION_DENIED');
   }
+});
+
+it('turns an input-helper failure into a control release instead of a session stop', async () => {
+  const pending = offer();
+  h.handlers.get(DESKTOP_LOCAL.REGISTER)(event());
+  await flush();
+  h.handlers.get(DESKTOP_LOCAL.REPLY)(event(), h.owner.send.mock.calls[0][1].id, 'answer');
+  await pending;
+  expect(h.inputFailure).toBeTypeOf('function');
+  h.inputFailure?.();
+  // Input is a lease-scoped capability: the desktop session keeps its lease,
+  // its capture owner and its media when the helper dies.
+  expect(h.releaseControl).toHaveBeenCalledTimes(1);
+  expect(h.stop).not.toHaveBeenCalled();
+  expect(h.owner.dead).toBe(false);
 });
 
 it('retains the capture owner on ICE timeout and rejects old-owner replies after replacement', async () => {

--- a/apps/desktop/src/main/remote-desktop/__tests__/controller.test.ts
+++ b/apps/desktop/src/main/remote-desktop/__tests__/controller.test.ts
@@ -537,6 +537,62 @@ describe('remote desktop authority and lifecycle', () => {
       expect(h.deps.stopVideo).not.toHaveBeenCalled();
     }
   });
+  it('releases control after an input failure without ending the lease or its media', async () => {
+    const h = harness();
+    const lease = await h.start();
+    await h.controller.request('phone', { op: 'control', lease: lease.lease, enabled: true });
+    h.controller.input(lease.lease, 1, [{ kind: 'release' }]);
+    expect(h.deps.input).toHaveBeenCalledTimes(1);
+    // The helper died: control goes, the picture and the lease stay.
+    h.controller.releaseControl();
+    expect(h.controller.state).toEqual({ peer: 'phone', controlling: false });
+    expect(h.controller.hasLease(lease.lease)).toBe(true);
+    expect(h.deps.stopInput).toHaveBeenCalledTimes(1);
+    expect(h.deps.stopVideo).not.toHaveBeenCalled();
+    expect(h.deps.changed).toHaveBeenCalled();
+    // The viewer learns the truth from its own heartbeat.
+    await expect(
+      h.controller.request('phone', { op: 'heartbeat', lease: lease.lease }),
+    ).resolves.toEqual({ controlling: false });
+    // Later input is an input problem, not a lease problem.
+    await expect(
+      h.controller.request('phone', {
+        op: 'input',
+        lease: lease.lease,
+        sequence: 2,
+        events: [{ kind: 'release' }],
+      }),
+    ).rejects.toThrow('VIEW_ONLY');
+    expect(h.deps.input).toHaveBeenCalledTimes(1);
+    await expect(h.controller.request('phone', { op: 'frame', lease: lease.lease })).resolves.toEqual(
+      { jpeg: 'jpeg' },
+    );
+  });
+  it('lets the same viewer take control again after a release without touching the media', async () => {
+    const h = harness();
+    const lease = await h.start();
+    await h.controller.request('phone', { op: 'control', lease: lease.lease, enabled: true });
+    h.controller.releaseControl();
+    await h.controller.request('phone', { op: 'control', lease: lease.lease, enabled: true });
+    expect(h.controller.state).toEqual({ peer: 'phone', controlling: true });
+    // Taking control again restarts the input helper on the same lease.
+    expect(h.deps.startInput).toHaveBeenCalledTimes(2);
+    // A second viewer is still arbitrated by the same single-viewer rules.
+    await expect(h.controller.request('other', { op: 'start', displayId: '1' })).rejects.toThrow(
+      'BUSY',
+    );
+    expect(h.deps.stopVideo).not.toHaveBeenCalled();
+    expect(h.deps.stopInput).toHaveBeenCalledTimes(1);
+  });
+  it('ignores a release when no viewer controls anything', async () => {
+    const h = harness();
+    const lease = await h.start();
+    h.controller.releaseControl();
+    expect(h.controller.state).toEqual({ peer: 'phone', controlling: false });
+    expect(h.deps.stopInput).not.toHaveBeenCalled();
+    expect(h.deps.stopVideo).not.toHaveBeenCalled();
+    expect(h.controller.hasLease(lease.lease)).toBe(true);
+  });
 });
 describe('human / Agent input ownership', () => {
   it('excludes simultaneous input in both directions and releases on error', async () => {

--- a/apps/desktop/src/main/remote-desktop/controller.ts
+++ b/apps/desktop/src/main/remote-desktop/controller.ts
@@ -133,6 +133,22 @@ export class RemoteDesktopController {
     this.deps.stopVideo();
     this.deps.changed();
   }
+  /**
+   * Input injection failed while the lease is still valid. Input belongs to the
+   * control bit, so release control and keep everything else: ending the lease
+   * here would tear down capture and media, and every phone tap would surface as
+   * a reconnect even though the desktop session itself is healthy. The viewer
+   * observes the new state on its next heartbeat or input attempt.
+   */
+  releaseControl(): void {
+    const active = this.active;
+    if (!active?.controlling) return;
+    active.controlling = false;
+    this.controlGeneration++;
+    this.clipboardTransfer.reset();
+    this.deps.stopInput();
+    this.deps.changed();
+  }
   /** Explicit local disconnect must not be undone by the phone's recovery. */
   stopByUser(): void {
     const target = this.active ?? this.lastEnded;

--- a/apps/desktop/src/main/remote-desktop/index.ts
+++ b/apps/desktop/src/main/remote-desktop/index.ts
@@ -370,7 +370,18 @@ export const remoteDesktop = new RemoteDesktopController({
   displayModes: readDesktopDisplayModes,
   resolution: setDesktopDisplayMode,
   startInput: (displayId) => input.start(displayId),
-  input: (events) => input.input(events),
+  input: (events) => {
+    try {
+      input.input(events);
+    } catch (error) {
+      // The input host refused before injecting anything (helper gone, or this
+      // lease's display is unavailable). Release control so the host and the
+      // viewer agree, and so taking control again genuinely restarts the
+      // helper instead of being skipped as "already controlling".
+      remoteDesktop.releaseControl();
+      throw error;
+    }
+  },
   stopInput: () => input.stop(),
   ...(process.platform === 'darwin' ? {
     lockScreen: async (isCurrent: () => boolean, signal: AbortSignal) => {

--- a/apps/desktop/src/main/remote-desktop/index.ts
+++ b/apps/desktop/src/main/remote-desktop/index.ts
@@ -121,7 +121,9 @@ let pending: {
   reject(error: Error): void;
   timer: ReturnType<typeof setTimeout>;
 } | null = null;
-const input = new DesktopInputHost(() => remoteDesktop.stop());
+// A dead input helper or a refused injection is an input failure, not a session
+// failure: release control and keep the lease, capture and media running.
+const input = new DesktopInputHost(() => remoteDesktop.releaseControl());
 function stopVideo(): void {
   offerGeneration++;
   videoAttempt = undefined;

--- a/apps/mobile/src/remote-desktop/RemoteDesktopScreen.tsx
+++ b/apps/mobile/src/remote-desktop/RemoteDesktopScreen.tsx
@@ -30,7 +30,7 @@ import {
 import { useSafeAreaInsets } from "react-native-safe-area-context";
 import { WebView, type WebViewMessageEvent } from "react-native-webview";
 import { connectionDiagnostics } from "./connectionDiagnostics";
-import { isControlLossError, remoteDesktopErrorCode } from "./controlFailure";
+import { controlFailureAction, remoteDesktopErrorCode } from "./controlFailure";
 import { transferClipboardContent } from "./clipboardTransfer";
 import * as Clipboard from "expo-clipboard";
 import { RemoteDesktopClipboardButton } from "./RemoteDesktopClipboardButton";
@@ -510,6 +510,23 @@ export default function RemoteDesktopScreen() {
       setLease({ ...current });
     }
   }, [send]);
+  /**
+   * Route a failed input or control request by its blast radius: a control-only
+   * fault drops to view only, an unknown outcome keeps everything as it is, and
+   * anything else rebuilds the session. Sitting next to the two actions it
+   * chooses between keeps the three call sites from drifting apart.
+   */
+  const resolveControlFailure = (cause: unknown) => {
+    switch (controlFailureAction(cause)) {
+      case "release":
+        releaseControl();
+        break;
+      case "ignore":
+        break;
+      default:
+        fail(cause);
+    }
+  };
   const connect = useCallback(
     async (displayId?: string, takeover = false) => {
       if (
@@ -1229,10 +1246,7 @@ export default function RemoteDesktopScreen() {
         })
           .catch((cause) => {
             if (active.current !== current) return;
-            // A rejected batch means this viewer lost control, not that the
-            // desktop session ended: view only, keep the picture, no reconnect.
-            if (isControlLossError(cause)) releaseControl();
-            else fail(cause);
+            resolveControlFailure(cause);
           })
           .finally(() => {
             if (inputBusy.current === current.lease) inputBusy.current = null;
@@ -1269,12 +1283,10 @@ export default function RemoteDesktopScreen() {
         setKeyboard(false);
       }
     } catch (cause) {
-      if (active.current !== current) return;
       // Taking control can fail because this computer cannot inject input right
       // now. Stay in view only and let the user retry; a session rebuild would
       // cost the picture and the lease for a control-only fault.
-      if (isControlLossError(cause)) releaseControl();
-      else fail(cause);
+      if (active.current === current) resolveControlFailure(cause);
     } finally {
       if (alive.current) setBusy(false);
     }

--- a/apps/mobile/src/remote-desktop/RemoteDesktopScreen.tsx
+++ b/apps/mobile/src/remote-desktop/RemoteDesktopScreen.tsx
@@ -204,6 +204,11 @@ export default function RemoteDesktopScreen() {
   ).current;
   const active = useRef<RemoteDesktopLease | null>(null);
   const wantsControl = useRef(true);
+  // Last control bit we asked the host for but have not confirmed. Overflow and
+  // take-control can time out after the local bit already moved; heartbeats use
+  // this to retry a release or restore local control instead of ignoring host-true.
+  const pendingHostControl = useRef<boolean | null>(null);
+  const controlInFlight = useRef(false);
   const recovery = useRef({
     enabled: true,
     at: 0,
@@ -401,6 +406,8 @@ export default function RemoteDesktopScreen() {
       presentationTimer.current = null;
       void remotePresentation?.playback(false).catch(() => {});
       connecting.current = false;
+      pendingHostControl.current = null;
+      controlInFlight.current = false;
       const previous = active.current;
       active.current = null;
       pendingVideoSettings.current = null;
@@ -527,6 +534,51 @@ export default function RemoteDesktopScreen() {
         fail(cause);
     }
   };
+  const applyConfirmedControl = (
+    current: RemoteDesktopLease,
+    controlling: boolean,
+  ) => {
+    pendingHostControl.current = null;
+    wantsControl.current = controlling;
+    if (current.controlling !== controlling) {
+      current.controlling = controlling;
+      if (!controlling) {
+        heldKeys.current.clear();
+        if (alive.current) {
+          setModifiers([]);
+          setKeyboard(false);
+        }
+      }
+      if (alive.current) setLease({ ...current });
+    }
+    send({ type: "control", enabled: controlling });
+  };
+  const requestHostControl = (
+    current: RemoteDesktopLease,
+    enabled: boolean,
+  ) => {
+    if (controlInFlight.current) return;
+    controlInFlight.current = true;
+    pendingHostControl.current = enabled;
+    void request<{ controlling: boolean }>({
+      op: "control",
+      lease: current.lease,
+      enabled,
+    })
+      .then((result) => {
+        if (active.current !== current) return;
+        applyConfirmedControl(current, result.controlling);
+      })
+      .catch((cause) => {
+        if (active.current !== current) return;
+        resolveControlFailure(cause);
+      })
+      .finally(() => {
+        if (active.current === current) controlInFlight.current = false;
+      });
+  };
+  const requestHostControlRef = useRef(requestHostControl);
+  requestHostControlRef.current = requestHostControl;
   const connect = useCallback(
     async (displayId?: string, takeover = false) => {
       if (
@@ -784,12 +836,21 @@ export default function RemoteDesktopScreen() {
         lease: current.lease,
       })
         .then((result) => {
-          // The host owns the control bit. When it no longer counts this viewer
-          // as controlling — input injection failed, or control was retracted —
-          // follow it to view only instead of waiting for the next rejected tap.
+          // The host owns the control bit. Follow it when it retracts control;
+          // when a local transition timed out, retry a release or restore the
+          // local bit so a held key cannot stay down behind a view-only phone.
           if (active.current !== current || presentation.current) return;
-          if (current.controlling && result.controlling === false)
-            releaseControl();
+          if (result.controlling === false) {
+            pendingHostControl.current = null;
+            if (current.controlling) releaseControl();
+            return;
+          }
+          if (pendingHostControl.current === false) {
+            requestHostControlRef.current(current, false);
+            return;
+          }
+          if (!current.controlling && pendingHostControl.current === true)
+            applyConfirmedControl(current, true);
         })
         .catch((cause) => {
           // A missing reply does not prove renewal failed; the next interval
@@ -1221,14 +1282,7 @@ export default function RemoteDesktopScreen() {
         // Tell the host to drop control (stopInput still injects a native
         // release) so a held key/button cannot stay down while we view only.
         releaseControl();
-        void request({
-          op: "control",
-          lease: current.lease,
-          enabled: false,
-        }).catch((cause) => {
-          if (active.current !== current) return;
-          resolveControlFailure(cause);
-        });
+        requestHostControl(current, false);
         break;
       }
       case "input": {
@@ -1269,36 +1323,32 @@ export default function RemoteDesktopScreen() {
   };
   const toggleControl = async () => {
     const current = active.current;
-    if (!current || busy) return;
+    if (!current || busy || controlInFlight.current) return;
     setBusy(true);
     setError(null);
+    controlInFlight.current = true;
     try {
       if (presentation.current) {
         presentation.current = false;
         send({ type: "presentation", enabled: false });
       }
       send({ type: "control", enabled: false });
+      const enabled = !current.controlling;
+      pendingHostControl.current = enabled;
       const result = await request<{ controlling: boolean }>({
         op: "control",
         lease: current.lease,
-        enabled: !current.controlling,
+        enabled,
       });
       if (active.current !== current) return;
-      wantsControl.current = result.controlling;
-      current.controlling = result.controlling;
-      setLease({ ...current });
-      send({ type: "control", enabled: result.controlling });
-      if (!result.controlling) {
-        heldKeys.current.clear();
-        setModifiers([]);
-        setKeyboard(false);
-      }
+      applyConfirmedControl(current, result.controlling);
     } catch (cause) {
       // Taking control can fail because this computer cannot inject input right
       // now. Stay in view only and let the user retry; a session rebuild would
       // cost the picture and the lease for a control-only fault.
       if (active.current === current) resolveControlFailure(cause);
     } finally {
+      controlInFlight.current = false;
       if (alive.current) setBusy(false);
     }
   };

--- a/apps/mobile/src/remote-desktop/RemoteDesktopScreen.tsx
+++ b/apps/mobile/src/remote-desktop/RemoteDesktopScreen.tsx
@@ -30,6 +30,7 @@ import {
 import { useSafeAreaInsets } from "react-native-safe-area-context";
 import { WebView, type WebViewMessageEvent } from "react-native-webview";
 import { connectionDiagnostics } from "./connectionDiagnostics";
+import { isControlLossError, remoteDesktopErrorCode } from "./controlFailure";
 import { transferClipboardContent } from "./clipboardTransfer";
 import * as Clipboard from "expo-clipboard";
 import { RemoteDesktopClipboardButton } from "./RemoteDesktopClipboardButton";
@@ -457,18 +458,10 @@ export default function RemoteDesktopScreen() {
     (cause: unknown) => {
       if (!alive.current) return;
       const message = cause instanceof Error ? cause.message : String(cause);
-      const code =
-        cause &&
-        typeof cause === "object" &&
-        "code" in cause &&
-        typeof cause.code === "string"
-          ? cause.code
-          : message.match(
-              /\b(?:DESKTOP|CHANNEL|DEVICE|INVOKE|REMOTE|ACCESS)_[A-Z_]+\b/,
-            )?.[0];
+      const code = remoteDesktopErrorCode(cause);
       // Keep diagnostics free of device names, input and signaling payloads.
       console.debug("[remote-desktop] connection failed", {
-        code: code && /^[A-Z_]+$/.test(code) ? code : "UNKNOWN",
+        code: code ?? "UNKNOWN",
       });
       const blocked =
         code === "ACCESS_REVOKED"
@@ -498,6 +491,25 @@ export default function RemoteDesktopScreen() {
     },
     [stop],
   );
+  /**
+   * The host owns the control bit. When it reports that this viewer no longer
+   * controls — input injection failed, the input helper went away, or control
+   * was retracted — drop to view only instead of rebuilding the session: the
+   * lease, the picture and the existing view-only hint all survive, and taking
+   * control again retries from where the user is.
+   */
+  const releaseControl = useCallback(() => {
+    const current = active.current;
+    if (!current?.controlling) return;
+    current.controlling = false;
+    heldKeys.current.clear();
+    send({ type: "control", enabled: false });
+    if (alive.current) {
+      setModifiers([]);
+      setKeyboard(false);
+      setLease({ ...current });
+    }
+  }, [send]);
   const connect = useCallback(
     async (displayId?: string, takeover = false) => {
       if (
@@ -750,7 +762,18 @@ export default function RemoteDesktopScreen() {
       )
         return;
       heartbeatBusy = current.lease;
-      void request({ op: "heartbeat", lease: current.lease })
+      void request<{ controlling: boolean }>({
+        op: "heartbeat",
+        lease: current.lease,
+      })
+        .then((result) => {
+          // The host owns the control bit. When it no longer counts this viewer
+          // as controlling — input injection failed, or control was retracted —
+          // follow it to view only instead of waiting for the next rejected tap.
+          if (active.current !== current || presentation.current) return;
+          if (current.controlling && result.controlling === false)
+            releaseControl();
+        })
         .catch((cause) => {
           // A missing reply does not prove renewal failed; the next interval
           // retries within the lease. Explicit host revocation still stops us.
@@ -850,7 +873,7 @@ export default function RemoteDesktopScreen() {
       clearInterval(metrics);
       stop();
     };
-  }, [request, fail, send, stop, pause]);
+  }, [request, fail, send, stop, pause, releaseControl]);
   useEffect(() => {
     // Route blur means leaving this desktop (including a native back swipe).
     // App background/inactive events use pause() without the exit flag.
@@ -1176,7 +1199,9 @@ export default function RemoteDesktopScreen() {
         break;
       }
       case "inputOverflow":
-        fail(new Error("DESKTOP_INPUT_UNAVAILABLE"));
+        // The viewer dropped a stalled batch. Input was already released there;
+        // mirror it here instead of tearing the session down for a lost tap.
+        releaseControl();
         break;
       case "input": {
         const ack = {
@@ -1203,7 +1228,11 @@ export default function RemoteDesktopScreen() {
           events: message.events,
         })
           .catch((cause) => {
-            if (active.current === current) fail(cause);
+            if (active.current !== current) return;
+            // A rejected batch means this viewer lost control, not that the
+            // desktop session ended: view only, keep the picture, no reconnect.
+            if (isControlLossError(cause)) releaseControl();
+            else fail(cause);
           })
           .finally(() => {
             if (inputBusy.current === current.lease) inputBusy.current = null;
@@ -1240,7 +1269,12 @@ export default function RemoteDesktopScreen() {
         setKeyboard(false);
       }
     } catch (cause) {
-      if (active.current === current) fail(cause);
+      if (active.current !== current) return;
+      // Taking control can fail because this computer cannot inject input right
+      // now. Stay in view only and let the user retry; a session rebuild would
+      // cost the picture and the lease for a control-only fault.
+      if (isControlLossError(cause)) releaseControl();
+      else fail(cause);
     } finally {
       if (alive.current) setBusy(false);
     }

--- a/apps/mobile/src/remote-desktop/RemoteDesktopScreen.tsx
+++ b/apps/mobile/src/remote-desktop/RemoteDesktopScreen.tsx
@@ -1215,11 +1215,22 @@ export default function RemoteDesktopScreen() {
         });
         break;
       }
-      case "inputOverflow":
-        // The viewer dropped a stalled batch. Input was already released there;
-        // mirror it here instead of tearing the session down for a lost tap.
+      case "inputOverflow": {
+        // The viewer replaced a stalled queue with a release, then this handler
+        // posts control:false, which clears that release without flushing it.
+        // Tell the host to drop control (stopInput still injects a native
+        // release) so a held key/button cannot stay down while we view only.
         releaseControl();
+        void request({
+          op: "control",
+          lease: current.lease,
+          enabled: false,
+        }).catch((cause) => {
+          if (active.current !== current) return;
+          resolveControlFailure(cause);
+        });
         break;
+      }
       case "input": {
         const ack = {
           type: "ack",

--- a/apps/mobile/src/remote-desktop/RemoteDesktopScreen.tsx
+++ b/apps/mobile/src/remote-desktop/RemoteDesktopScreen.tsx
@@ -1338,6 +1338,18 @@ export default function RemoteDesktopScreen() {
       }
       send({ type: "control", enabled: false });
       const enabled = !current.controlling;
+      if (pendingHostControl.current === false && enabled) {
+        // Overflow timed out with an unconfirmed host release. Taking control
+        // first would skip stopInput while a key/button may still be held.
+        const released = await request<{ controlling: boolean }>({
+          op: "control",
+          lease: current.lease,
+          enabled: false,
+        });
+        if (active.current !== current) return;
+        applyConfirmedControl(current, released.controlling);
+        if (released.controlling) return;
+      }
       pendingHostControl.current = enabled;
       const result = await request<{ controlling: boolean }>({
         op: "control",

--- a/apps/mobile/src/remote-desktop/RemoteDesktopScreen.tsx
+++ b/apps/mobile/src/remote-desktop/RemoteDesktopScreen.tsx
@@ -841,6 +841,10 @@ export default function RemoteDesktopScreen() {
           // local bit so a held key cannot stay down behind a view-only phone.
           if (active.current !== current || presentation.current) return;
           if (result.controlling === false) {
+            // startInput can still be settling while this heartbeat was in
+            // flight. Clearing a pending take-control here would leave later
+            // host-true beats with nothing to restore after a lost reply.
+            if (pendingHostControl.current === true) return;
             pendingHostControl.current = null;
             if (current.controlling) releaseControl();
             return;

--- a/apps/mobile/src/remote-desktop/__tests__/controlFailure.test.ts
+++ b/apps/mobile/src/remote-desktop/__tests__/controlFailure.test.ts
@@ -1,0 +1,35 @@
+import { describe, expect, it } from "vitest";
+import { isControlLossError, remoteDesktopErrorCode } from "../controlFailure";
+
+describe("remote desktop control failure classification", () => {
+  it("reads the code from the error field before falling back to the message", () => {
+    expect(
+      remoteDesktopErrorCode(
+        Object.assign(new Error("boom"), { code: "DESKTOP_VIEW_ONLY" }),
+      ),
+    ).toBe("DESKTOP_VIEW_ONLY");
+    expect(
+      remoteDesktopErrorCode(new Error("[DESKTOP_LEASE_EXPIRED] gone")),
+    ).toBe("DESKTOP_LEASE_EXPIRED");
+    expect(remoteDesktopErrorCode(new Error("network down"))).toBeUndefined();
+    expect(remoteDesktopErrorCode(undefined)).toBeUndefined();
+  });
+  it.each([
+    "DESKTOP_VIEW_ONLY",
+    "DESKTOP_INPUT_UNAVAILABLE",
+    "DESKTOP_INPUT_BUSY",
+    "INVOKE_TIMEOUT",
+  ])("treats %s as lost control rather than a dead session", (code) => {
+    expect(isControlLossError(new Error(code))).toBe(true);
+  });
+  it.each([
+    "DESKTOP_LEASE_EXPIRED",
+    "DESKTOP_STOPPED",
+    "DESKTOP_DISABLED",
+    "ACCESS_REVOKED",
+    "CHANNEL_NOT_ALLOWED",
+    "DESKTOP_VIDEO_UNAVAILABLE",
+  ])("still rebuilds the session for %s", (code) => {
+    expect(isControlLossError(new Error(code))).toBe(false);
+  });
+});

--- a/apps/mobile/src/remote-desktop/__tests__/controlFailure.test.ts
+++ b/apps/mobile/src/remote-desktop/__tests__/controlFailure.test.ts
@@ -1,5 +1,8 @@
 import { describe, expect, it } from "vitest";
-import { isControlLossError, remoteDesktopErrorCode } from "../controlFailure";
+import {
+  controlFailureAction,
+  remoteDesktopErrorCode,
+} from "../controlFailure";
 
 describe("remote desktop control failure classification", () => {
   it("reads the code from the error field before falling back to the message", () => {
@@ -14,14 +17,20 @@ describe("remote desktop control failure classification", () => {
     expect(remoteDesktopErrorCode(new Error("network down"))).toBeUndefined();
     expect(remoteDesktopErrorCode(undefined)).toBeUndefined();
   });
-  it.each([
-    "DESKTOP_VIEW_ONLY",
-    "DESKTOP_INPUT_UNAVAILABLE",
-    "DESKTOP_INPUT_BUSY",
-    "INVOKE_TIMEOUT",
-  ])("treats %s as lost control rather than a dead session", (code) => {
-    expect(isControlLossError(new Error(code))).toBe(true);
-  });
+  it.each(["DESKTOP_VIEW_ONLY", "DESKTOP_INPUT_UNAVAILABLE"])(
+    "releases control for %s without rebuilding the session",
+    (code) => {
+      expect(controlFailureAction(new Error(code))).toBe("release");
+    },
+  );
+  it.each(["INVOKE_TIMEOUT", "DESKTOP_INPUT_BUSY"])(
+    "keeps the current state for the unknown outcome %s",
+    (code) => {
+      // A lost reply does not prove the host released control, and a batch that
+      // was injected must not be answered with a release that drops its key-up.
+      expect(controlFailureAction(new Error(code))).toBe("ignore");
+    },
+  );
   it.each([
     "DESKTOP_LEASE_EXPIRED",
     "DESKTOP_STOPPED",
@@ -30,6 +39,10 @@ describe("remote desktop control failure classification", () => {
     "CHANNEL_NOT_ALLOWED",
     "DESKTOP_VIDEO_UNAVAILABLE",
   ])("still rebuilds the session for %s", (code) => {
-    expect(isControlLossError(new Error(code))).toBe(false);
+    expect(controlFailureAction(new Error(code))).toBe("rebuild");
+  });
+  it("rebuilds when there is no usable code at all", () => {
+    expect(controlFailureAction(new Error("network down"))).toBe("rebuild");
+    expect(controlFailureAction(undefined)).toBe("rebuild");
   });
 });

--- a/apps/mobile/src/remote-desktop/__tests__/screen.test.tsx
+++ b/apps/mobile/src/remote-desktop/__tests__/screen.test.tsx
@@ -1634,6 +1634,61 @@ describe("remote desktop controls", () => {
     expect(sent().at(-1)).toEqual({ type: "mode", mode: "touch" });
     expect(requests().filter((r) => r.op === "start")).toHaveLength(1);
   });
+  it("keeps the session and the picture when the host refuses an input batch", async () => {
+    await connect();
+    const original = fixture.invoke.getMockImplementation()!;
+    fixture.invoke.mockImplementation((...args) =>
+      args[2][0].op === "input"
+        ? Promise.reject(new Error("DESKTOP_VIEW_ONLY"))
+        : original(...args),
+    );
+    await act(async () => {
+      fixture.message!({
+        nativeEvent: {
+          data: JSON.stringify({
+            type: "input",
+            epoch: "lease",
+            sequence: 1,
+            events: [{ kind: "button", button: 0, down: true, x: 0.5, y: 0.5 }],
+          }),
+        },
+      });
+    });
+    // The host retracted control: view only, no session rebuild.
+    expect(requests().filter((r) => r.op === "stop")).toHaveLength(0);
+    expect(host.textContent).not.toContain("remoteDesktop.reconnecting");
+    expect(sent()).toContainEqual({ type: "control", enabled: false });
+    act(() => button("operations").click());
+    expect(visibleInputHint()).toBe("remoteDesktop.viewOnlyHint");
+  });
+  it("follows the host to view only when its heartbeat stops counting this viewer as controlling", async () => {
+    await connect();
+    const original = fixture.invoke.getMockImplementation()!;
+    fixture.invoke.mockImplementation((...args) =>
+      args[2][0].op === "heartbeat"
+        ? Promise.resolve({ controlling: false })
+        : original(...args),
+    );
+    await act(async () => vi.advanceTimersByTimeAsync(3000));
+    expect(sent()).toContainEqual({ type: "control", enabled: false });
+    expect(requests().filter((r) => r.op === "stop")).toHaveLength(0);
+    expect(host.textContent).not.toContain("remoteDesktop.reconnecting");
+    act(() => button("operations").click());
+    expect(visibleInputHint()).toBe("remoteDesktop.viewOnlyHint");
+  });
+  it("releases a stalled input batch instead of rebuilding the session", async () => {
+    await connect();
+    act(() => {
+      fixture.message!({
+        nativeEvent: {
+          data: JSON.stringify({ type: "inputOverflow", epoch: "lease" }),
+        },
+      });
+    });
+    expect(sent()).toContainEqual({ type: "control", enabled: false });
+    expect(requests().filter((r) => r.op === "stop")).toHaveLength(0);
+    expect(host.textContent).not.toContain("remoteDesktop.reconnecting");
+  });
   it("shows virtual mouse buttons outside the panel and hides them while viewing only", async () => {
     await connect();
     act(() => button("operations").click());

--- a/apps/mobile/src/remote-desktop/__tests__/screen.test.tsx
+++ b/apps/mobile/src/remote-desktop/__tests__/screen.test.tsx
@@ -1784,6 +1784,45 @@ describe("remote desktop controls", () => {
     expect(requests().filter((r) => r.op === "stop")).toHaveLength(0);
     expect(host.textContent).not.toContain("remoteDesktop.reconnecting");
   });
+  it("keeps a take-control intent when a settling heartbeat still reports view-only", async () => {
+    await connect();
+    act(() => button("operations").click());
+    await act(async () => button("viewOnly").click());
+    const original = fixture.invoke.getMockImplementation()!;
+    let rejectTakeControl: ((cause: unknown) => void) | undefined;
+    let heartbeats = 0;
+    fixture.invoke.mockImplementation((...args) => {
+      const req = args[2][0];
+      if (req.op === "control" && req.enabled === true) {
+        return new Promise((_, reject) => {
+          rejectTakeControl = reject;
+        });
+      }
+      if (req.op === "heartbeat") {
+        heartbeats += 1;
+        // startInput is still settling on the first beat; the host only
+        // reports control after the lost take-control reply.
+        return Promise.resolve({ controlling: heartbeats > 1 });
+      }
+      return original(...args);
+    });
+    act(() => button("viewOnly").click());
+    await act(async () => vi.advanceTimersByTimeAsync(3000));
+    await act(async () => {
+      rejectTakeControl!(
+        Object.assign(new Error("timeout"), { code: "INVOKE_TIMEOUT" }),
+      );
+    });
+    await act(async () => vi.advanceTimersByTimeAsync(3000));
+    // A heartbeat issued while startInput was settling must not consume the
+    // pending take-control; after the reply is lost, host-true still restores.
+    expect(sent().filter((m) => m.type === "control").at(-1)).toEqual({
+      type: "control",
+      enabled: true,
+    });
+    expect(requests().filter((r) => r.op === "stop")).toHaveLength(0);
+    expect(host.textContent).not.toContain("remoteDesktop.reconnecting");
+  });
   it("shows virtual mouse buttons outside the panel and hides them while viewing only", async () => {
     await connect();
     act(() => button("operations").click());

--- a/apps/mobile/src/remote-desktop/__tests__/screen.test.tsx
+++ b/apps/mobile/src/remote-desktop/__tests__/screen.test.tsx
@@ -1703,7 +1703,7 @@ describe("remote desktop controls", () => {
   });
   it("releases a stalled input batch instead of rebuilding the session", async () => {
     await connect();
-    act(() => {
+    await act(async () => {
       fixture.message!({
         nativeEvent: {
           data: JSON.stringify({ type: "inputOverflow", epoch: "lease" }),
@@ -1711,6 +1711,14 @@ describe("remote desktop controls", () => {
       });
     });
     expect(sent()).toContainEqual({ type: "control", enabled: false });
+    // The WebView overflow replaces pending with a release, then this handler
+    // posts control:false which clears that release without flushing it. The
+    // host must still drop control so a held key/button cannot stay down.
+    expect(requests()).toContainEqual({
+      op: "control",
+      lease: "lease",
+      enabled: false,
+    });
     expect(requests().filter((r) => r.op === "stop")).toHaveLength(0);
     expect(host.textContent).not.toContain("remoteDesktop.reconnecting");
   });

--- a/apps/mobile/src/remote-desktop/__tests__/screen.test.tsx
+++ b/apps/mobile/src/remote-desktop/__tests__/screen.test.tsx
@@ -1722,6 +1722,68 @@ describe("remote desktop controls", () => {
     expect(requests().filter((r) => r.op === "stop")).toHaveLength(0);
     expect(host.textContent).not.toContain("remoteDesktop.reconnecting");
   });
+  it("retries a timed-out overflow release when the host still reports control", async () => {
+    await connect();
+    const original = fixture.invoke.getMockImplementation()!;
+    fixture.invoke.mockImplementation((...args) => {
+      const req = args[2][0];
+      if (req.op === "control" && req.enabled === false)
+        return Promise.reject(
+          Object.assign(new Error("timeout"), { code: "INVOKE_TIMEOUT" }),
+        );
+      if (req.op === "heartbeat")
+        return Promise.resolve({ controlling: true });
+      return original(...args);
+    });
+    await act(async () => {
+      fixture.message!({
+        nativeEvent: {
+          data: JSON.stringify({ type: "inputOverflow", epoch: "lease" }),
+        },
+      });
+    });
+    const released = requests().filter(
+      (r) => r.op === "control" && r.enabled === false,
+    );
+    expect(released).toHaveLength(1);
+    expect(sent()).toContainEqual({ type: "control", enabled: false });
+    await act(async () => vi.advanceTimersByTimeAsync(3000));
+    // Local view-only is not proof the host dropped control; retry the release
+    // so a held key cannot stay down behind a view-only phone.
+    expect(
+      requests().filter((r) => r.op === "control" && r.enabled === false),
+    ).toHaveLength(2);
+    expect(requests().filter((r) => r.op === "stop")).toHaveLength(0);
+    expect(host.textContent).not.toContain("remoteDesktop.reconnecting");
+  });
+  it("restores control when a take-control reply is lost but the host still holds it", async () => {
+    await connect();
+    act(() => button("operations").click());
+    await act(async () => button("viewOnly").click());
+    const original = fixture.invoke.getMockImplementation()!;
+    fixture.invoke.mockImplementation((...args) => {
+      const req = args[2][0];
+      if (req.op === "control" && req.enabled === true)
+        return Promise.reject(
+          Object.assign(new Error("timeout"), { code: "INVOKE_TIMEOUT" }),
+        );
+      if (req.op === "heartbeat")
+        return Promise.resolve({ controlling: true });
+      return original(...args);
+    });
+    await act(async () => button("viewOnly").click());
+    expect(sent().filter((m) => m.type === "control").at(-1)).toEqual({
+      type: "control",
+      enabled: false,
+    });
+    await act(async () => vi.advanceTimersByTimeAsync(3000));
+    expect(sent().filter((m) => m.type === "control").at(-1)).toEqual({
+      type: "control",
+      enabled: true,
+    });
+    expect(requests().filter((r) => r.op === "stop")).toHaveLength(0);
+    expect(host.textContent).not.toContain("remoteDesktop.reconnecting");
+  });
   it("shows virtual mouse buttons outside the panel and hides them while viewing only", async () => {
     await connect();
     act(() => button("operations").click());

--- a/apps/mobile/src/remote-desktop/__tests__/screen.test.tsx
+++ b/apps/mobile/src/remote-desktop/__tests__/screen.test.tsx
@@ -1661,6 +1661,31 @@ describe("remote desktop controls", () => {
     act(() => button("operations").click());
     expect(visibleInputHint()).toBe("remoteDesktop.viewOnlyHint");
   });
+  it("keeps control and the session when an input reply is lost", async () => {
+    await connect();
+    const original = fixture.invoke.getMockImplementation()!;
+    fixture.invoke.mockImplementation((...args) =>
+      args[2][0].op === "input"
+        ? Promise.reject(Object.assign(new Error("timeout"), { code: "INVOKE_TIMEOUT" }))
+        : original(...args),
+    );
+    await act(async () => {
+      fixture.message!({
+        nativeEvent: {
+          data: JSON.stringify({
+            type: "input",
+            epoch: "lease",
+            sequence: 1,
+            events: [{ kind: "key", code: "KeyA", down: true }],
+          }),
+        },
+      });
+    });
+    // The batch may have been injected: releasing here would drop its key-up.
+    expect(sent()).not.toContainEqual({ type: "control", enabled: false });
+    expect(requests().filter((r) => r.op === "stop")).toHaveLength(0);
+    expect(host.textContent).not.toContain("remoteDesktop.reconnecting");
+  });
   it("follows the host to view only when its heartbeat stops counting this viewer as controlling", async () => {
     await connect();
     const original = fixture.invoke.getMockImplementation()!;

--- a/apps/mobile/src/remote-desktop/__tests__/screen.test.tsx
+++ b/apps/mobile/src/remote-desktop/__tests__/screen.test.tsx
@@ -1756,6 +1756,49 @@ describe("remote desktop controls", () => {
     expect(requests().filter((r) => r.op === "stop")).toHaveLength(0);
     expect(host.textContent).not.toContain("remoteDesktop.reconnecting");
   });
+  it("finishes a timed-out overflow release before taking control again", async () => {
+    await connect();
+    const original = fixture.invoke.getMockImplementation()!;
+    let falseAttempts = 0;
+    fixture.invoke.mockImplementation((...args) => {
+      const req = args[2][0];
+      if (req.op === "control" && req.enabled === false) {
+        falseAttempts += 1;
+        if (falseAttempts === 1)
+          return Promise.reject(
+            Object.assign(new Error("timeout"), { code: "INVOKE_TIMEOUT" }),
+          );
+        return Promise.resolve({ controlling: false });
+      }
+      if (req.op === "heartbeat")
+        return Promise.resolve({ controlling: true });
+      return original(...args);
+    });
+    await act(async () => {
+      fixture.message!({
+        nativeEvent: {
+          data: JSON.stringify({ type: "inputOverflow", epoch: "lease" }),
+        },
+      });
+    });
+    expect(
+      requests().filter((r) => r.op === "control" && r.enabled === false),
+    ).toHaveLength(1);
+    act(() => button("operations").click());
+    await act(async () => button("viewOnly").click());
+    const controlOps = requests()
+      .filter((r) => r.op === "control")
+      .map((r) => r.enabled);
+    // Overflow timed out with pending release. Take control must finish that
+    // release (host stopInput) before asking to enable, so the helper restarts.
+    expect(controlOps).toEqual([true, false, false, true]);
+    expect(sent().filter((m) => m.type === "control").at(-1)).toEqual({
+      type: "control",
+      enabled: true,
+    });
+    expect(requests().filter((r) => r.op === "stop")).toHaveLength(0);
+    expect(host.textContent).not.toContain("remoteDesktop.reconnecting");
+  });
   it("restores control when a take-control reply is lost but the host still holds it", async () => {
     await connect();
     act(() => button("operations").click());

--- a/apps/mobile/src/remote-desktop/controlFailure.ts
+++ b/apps/mobile/src/remote-desktop/controlFailure.ts
@@ -1,0 +1,40 @@
+/** Failure classification for mobile remote desktop.
+ *
+ * Control is a lease-scoped capability, not a session: the host can refuse,
+ * fail or retract input while the viewer keeps its lease, its video and its
+ * picture. Errors in this class must therefore never rebuild the whole remote
+ * desktop — they release control and leave the session running.
+ */
+
+/** Error codes that mean "this viewer lost control", not "the session died". */
+const CONTROL_LOSS_CODES = new Set([
+  // Host released control, typically because input injection failed.
+  "DESKTOP_VIEW_ONLY",
+  // Host has no usable input helper or display for this lease.
+  "DESKTOP_INPUT_UNAVAILABLE",
+  // Another control request for this lease is still settling.
+  "DESKTOP_INPUT_BUSY",
+  // The reply is unknown, not the lease: the heartbeat still owns liveness.
+  "INVOKE_TIMEOUT",
+]);
+
+/** Stable error code of a remote-desktop failure, or undefined when unknown. */
+export function remoteDesktopErrorCode(cause: unknown): string | undefined {
+  const message = cause instanceof Error ? cause.message : String(cause);
+  const code =
+    cause &&
+    typeof cause === "object" &&
+    "code" in cause &&
+    typeof cause.code === "string"
+      ? cause.code
+      : message.match(
+          /\b(?:DESKTOP|CHANNEL|DEVICE|INVOKE|REMOTE|ACCESS)_[A-Z_]+\b/,
+        )?.[0];
+  return code && /^[A-Z_]+$/.test(code) ? code : undefined;
+}
+
+/** True when the failure only costs control and must not restart the session. */
+export function isControlLossError(cause: unknown): boolean {
+  const code = remoteDesktopErrorCode(cause);
+  return code !== undefined && CONTROL_LOSS_CODES.has(code);
+}

--- a/apps/mobile/src/remote-desktop/controlFailure.ts
+++ b/apps/mobile/src/remote-desktop/controlFailure.ts
@@ -2,20 +2,34 @@
  *
  * Control is a lease-scoped capability, not a session: the host can refuse,
  * fail or retract input while the viewer keeps its lease, its video and its
- * picture. Errors in this class must therefore never rebuild the whole remote
- * desktop — they release control and leave the session running.
+ * picture. Errors in that class must never rebuild the whole remote desktop —
+ * they release control and leave the session running. Failures whose outcome is
+ * unknown (a lost reply) are neither: guessing either way would either strand
+ * input or needlessly drop the picture.
  */
 
-/** Error codes that mean "this viewer lost control", not "the session died". */
+export type ControlFailureAction =
+  // The host no longer counts this viewer as controlling: drop to view only.
+  | "release"
+  // Unknown or transient: keep control and let the next attempt decide.
+  | "ignore"
+  // The lease itself is unusable: rebuild the session with the existing path.
+  | "rebuild";
+
+/** Failure codes that mean "this viewer lost control", not "the session died". */
 const CONTROL_LOSS_CODES = new Set([
   // Host released control, typically because input injection failed.
   "DESKTOP_VIEW_ONLY",
   // Host has no usable input helper or display for this lease.
   "DESKTOP_INPUT_UNAVAILABLE",
+]);
+
+/** Failure codes whose outcome is unknown: neither release nor rebuild. */
+const UNKNOWN_OUTCOME_CODES = new Set([
+  // The batch may or may not have been injected; the heartbeat owns liveness.
+  "INVOKE_TIMEOUT",
   // Another control request for this lease is still settling.
   "DESKTOP_INPUT_BUSY",
-  // The reply is unknown, not the lease: the heartbeat still owns liveness.
-  "INVOKE_TIMEOUT",
 ]);
 
 /** Stable error code of a remote-desktop failure, or undefined when unknown. */
@@ -33,8 +47,11 @@ export function remoteDesktopErrorCode(cause: unknown): string | undefined {
   return code && /^[A-Z_]+$/.test(code) ? code : undefined;
 }
 
-/** True when the failure only costs control and must not restart the session. */
-export function isControlLossError(cause: unknown): boolean {
+/** What a failed input or control request should do to this viewer. */
+export function controlFailureAction(cause: unknown): ControlFailureAction {
   const code = remoteDesktopErrorCode(cause);
-  return code !== undefined && CONTROL_LOSS_CODES.has(code);
+  if (code === undefined) return "rebuild";
+  if (CONTROL_LOSS_CODES.has(code)) return "release";
+  if (UNKNOWN_OUTCOME_CODES.has(code)) return "ignore";
+  return "rebuild";
 }

--- a/docs/remote-desktop.md
+++ b/docs/remote-desktop.md
@@ -137,6 +137,35 @@ This harness does not validate WKWebView, Android WebView, carrier NAT, regional
 STUN availability, TURN relay performance or Windows native capture. Those need
 device/network verification before claiming a measured connection-success gain.
 
+## Input failure releases control (2026-09-11)
+
+Control is a lease-scoped capability, not the session itself. When the host can
+no longer inject input — the native helper died, it reported a failed injection,
+or its write path failed — it releases control and keeps everything else: the
+lease, the capture owner, the video track and the last picture. It does not call
+`stop()`, so an input fault can never surface as an ended desktop session.
+
+The viewer follows the host's control bit instead of rebuilding the session. A
+rejected input batch, a dropped stalled batch, a failed control request or a
+heartbeat that reports `controlling: false` all drop the phone to view only with
+the existing view-only hint and take-control action; media and lease identity are
+untouched. Taking control again restarts the native input helper on the same
+lease. Errors that do mean the lease is gone (`DESKTOP_LEASE_EXPIRED`,
+`DESKTOP_STOPPED`, revocation, an unsupported channel) still recover the session
+as before.
+
+This matters most on Windows, where the SendInput helper reports a failed
+injection as a helper failure whereas the macOS helper posts events without a
+result path. On Windows the helper now costs control only; whether a specific
+machine can inject at all (elevated foreground window, secure desktop, a session
+worker outside the interactive window station) is a separate, still unverified
+question, and the helper's `error` line does not yet carry a reason.
+
+Deterministic tests cover the controller release (lease, media and single-viewer
+arbitration retained; later input refused as view-only; control can be taken
+again), the desktop wiring that turns an input-host failure into a release rather
+than a stop, and the viewer paths that drop to view only without reconnecting.
+
 ## Authority and lifetime
 
 On macOS, enabling remote desktop automatically checks screen recording in the

--- a/docs/remote-desktop.md
+++ b/docs/remote-desktop.md
@@ -161,7 +161,9 @@ injects a native release) can let go of a held key or button. If that host
 request times out, the viewer keeps the intended control bit and the next
 heartbeat retries the release (or restores local control after a lost
 take-control reply) instead of ignoring a host-`true` while the phone stays
-view-only. Errors whose outcome is unknown — a lost reply (`INVOKE_TIMEOUT`) or
+view-only. A heartbeat that still reports view-only while `startInput()` is
+settling does not consume that pending take-control: only a later beat, after
+the transition, may reconcile. Errors whose outcome is unknown — a lost reply (`INVOKE_TIMEOUT`) or
 a control request that collides with one still settling — do not rebuild the
 session: a batch that may have been injected must not be answered with a
 release that discards its key-up, and the heartbeat still owns liveness. Errors

--- a/docs/remote-desktop.md
+++ b/docs/remote-desktop.md
@@ -157,13 +157,16 @@ hint and take-control action; media and lease identity are untouched. A dropped
 stalled batch (WebView overflow) also asks the host to drop control: posting
 `control:false` to the WebView clears its queued release without flushing it, so
 only an explicit host `control enabled:false` (which stops the input helper and
-injects a native release) can let go of a held key or button. Errors whose
-outcome is unknown — a lost reply (`INVOKE_TIMEOUT`) or a control request that
-collides with one still settling — change nothing: a batch
-that may have been injected must not be answered with a release that discards its
-key-up, and the heartbeat still owns liveness. Errors that do mean the lease is
-gone (`DESKTOP_LEASE_EXPIRED`, `DESKTOP_STOPPED`, revocation, an unsupported
-channel) still recover the session as before.
+injects a native release) can let go of a held key or button. If that host
+request times out, the viewer keeps the intended control bit and the next
+heartbeat retries the release (or restores local control after a lost
+take-control reply) instead of ignoring a host-`true` while the phone stays
+view-only. Errors whose outcome is unknown — a lost reply (`INVOKE_TIMEOUT`) or
+a control request that collides with one still settling — do not rebuild the
+session: a batch that may have been injected must not be answered with a
+release that discards its key-up, and the heartbeat still owns liveness. Errors
+that do mean the lease is gone (`DESKTOP_LEASE_EXPIRED`, `DESKTOP_STOPPED`,
+revocation, an unsupported channel) still recover the session as before.
 
 This matters most on Windows, where the SendInput helper reports a failed
 injection as a helper failure whereas the macOS helper posts events without a

--- a/docs/remote-desktop.md
+++ b/docs/remote-desktop.md
@@ -145,14 +145,21 @@ or its write path failed — it releases control and keeps everything else: the
 lease, the capture owner, the video track and the last picture. It does not call
 `stop()`, so an input fault can never surface as an ended desktop session.
 
+The host also releases control when its own input path refuses a batch before
+injecting anything, so the two sides cannot disagree about who controls: a later
+take-control genuinely restarts the helper instead of being skipped as "already
+controlling".
+
 The viewer follows the host's control bit instead of rebuilding the session. A
 rejected input batch, a dropped stalled batch, a failed control request or a
 heartbeat that reports `controlling: false` all drop the phone to view only with
 the existing view-only hint and take-control action; media and lease identity are
-untouched. Taking control again restarts the native input helper on the same
-lease. Errors that do mean the lease is gone (`DESKTOP_LEASE_EXPIRED`,
-`DESKTOP_STOPPED`, revocation, an unsupported channel) still recover the session
-as before.
+untouched. Errors whose outcome is unknown — a lost reply (`INVOKE_TIMEOUT`) or a
+control request that collides with one still settling — change nothing: a batch
+that may have been injected must not be answered with a release that discards its
+key-up, and the heartbeat still owns liveness. Errors that do mean the lease is
+gone (`DESKTOP_LEASE_EXPIRED`, `DESKTOP_STOPPED`, revocation, an unsupported
+channel) still recover the session as before.
 
 This matters most on Windows, where the SendInput helper reports a failed
 injection as a helper failure whereas the macOS helper posts events without a
@@ -163,8 +170,9 @@ question, and the helper's `error` line does not yet carry a reason.
 
 Deterministic tests cover the controller release (lease, media and single-viewer
 arbitration retained; later input refused as view-only; control can be taken
-again), the desktop wiring that turns an input-host failure into a release rather
-than a stop, and the viewer paths that drop to view only without reconnecting.
+again), the desktop wiring that turns a refused or failed input batch into a
+release rather than a stop, the failure classification (release, unknown outcome,
+rebuild), and the viewer paths that drop to view only without reconnecting.
 
 ## Authority and lifetime
 

--- a/docs/remote-desktop.md
+++ b/docs/remote-desktop.md
@@ -151,11 +151,15 @@ take-control genuinely restarts the helper instead of being skipped as "already
 controlling".
 
 The viewer follows the host's control bit instead of rebuilding the session. A
-rejected input batch, a dropped stalled batch, a failed control request or a
-heartbeat that reports `controlling: false` all drop the phone to view only with
-the existing view-only hint and take-control action; media and lease identity are
-untouched. Errors whose outcome is unknown — a lost reply (`INVOKE_TIMEOUT`) or a
-control request that collides with one still settling — change nothing: a batch
+rejected input batch, a failed control request or a heartbeat that reports
+`controlling: false` all drop the phone to view only with the existing view-only
+hint and take-control action; media and lease identity are untouched. A dropped
+stalled batch (WebView overflow) also asks the host to drop control: posting
+`control:false` to the WebView clears its queued release without flushing it, so
+only an explicit host `control enabled:false` (which stops the input helper and
+injects a native release) can let go of a held key or button. Errors whose
+outcome is unknown — a lost reply (`INVOKE_TIMEOUT`) or a control request that
+collides with one still settling — change nothing: a batch
 that may have been injected must not be answered with a release that discards its
 key-up, and the heartbeat still owns liveness. Errors that do mean the lease is
 gone (`DESKTOP_LEASE_EXPIRED`, `DESKTOP_STOPPED`, revocation, an unsupported

--- a/docs/remote-desktop.md
+++ b/docs/remote-desktop.md
@@ -163,7 +163,9 @@ heartbeat retries the release (or restores local control after a lost
 take-control reply) instead of ignoring a host-`true` while the phone stays
 view-only. A heartbeat that still reports view-only while `startInput()` is
 settling does not consume that pending take-control: only a later beat, after
-the transition, may reconcile. Errors whose outcome is unknown — a lost reply (`INVOKE_TIMEOUT`) or
+the transition, may reconcile. An unconfirmed overflow release stays
+authoritative until the host is view-only: taking control finishes that
+release (`stopInput`) before asking to enable, so the helper restarts. Errors whose outcome is unknown — a lost reply (`INVOKE_TIMEOUT`) or
 a control request that collides with one still settling — do not rebuild the
 session: a batch that may have been injected must not be answered with a
 release that discards its key-up, and the heartbeat still owns liveness. Errors


### PR DESCRIPTION
## 这次改了什么

### 摘要

手机远程桌面里，输入（鼠标/触摸）注入失败原来被当成整段会话失败：主机会 `stop()` 掉租约、采集窗口和媒体，手机于是看到「一点画面就重连」。本 PR 把这条失败半径收窄到它本来的范围——输入属于**控制位**，不属于会话：注入失败只收回控制（`controlling=false` + 停输入助手），租约、采集、视频与画面全部保留；手机侧跟随主机的控制位退回既有的「仅查看」，可再次「接管操作」在同一租约上重启输入助手，不再整页重连。

触发场景（群内反馈）：iOS/安卓直连 Windows 电脑，画面流畅，点一下画面就重连；不操作不触发。这条放大只在 Windows 上成立——macOS 输入助手不上报注入失败（`macos-input.swift` 的 `CGEvent.post` 没有返回判定），Windows 的 `SendInput` 会把失败报出来。

### 变更类型

- [x] `fix` 缺陷修复

### 范围

- 关联 Issue / 需求：群内反馈（v0.1.79）：iOS/安卓远程桌面 Windows 机器，直连点击画面即重连。
- 本 PR 包含：
  - Desktop：新增 `RemoteDesktopController.releaseControl()`，并把 `DesktopInputHost` 的失败回调从 `remoteDesktop.stop()` 改为它。
  - Mobile：输入批被拒、输入批被丢弃（overflow）、心跳报告 `controlling:false`、接管操作失败这四条路径同步为「仅查看」，不再整页重连；新增 `controlFailure.ts` 作为失败分类唯一入口，按故障半径分三类：`release`（DESKTOP_VIEW_ONLY / DESKTOP_INPUT_UNAVAILABLE，丢控制保留会话）、`ignore`（INVOKE_TIMEOUT / DESKTOP_INPUT_BUSY，结果未知，什么都不动，避免丢掉已注入批次的 key-up）、其余按原样重建会话。
  - Desktop：主机侧 `deps.input` 同步拒绝时（helper 不在 / 该租约显示器取不到）先 `releaseControl()` 再抛出，保证两侧对控制位的认知一致，重新「接管操作」会真正重启 helper。
  - 文档：`docs/remote-desktop.md` 新增「Input failure releases control (2026-09-11)」。
  - 测试：控制器释放语义 + 桌面装配回归 + 手机分类函数与三条界面路径。
- 明确不包含：
  - Windows 原生注入**为什么**失败。helper 只打一行 `error`，不带原因，也没有 `GetLastError`；定位它需要在 Windows 上复现与诊断（见「未执行的验证」）。
  - 锁屏/解锁时释放输入的失败路径（`index.ts` 的 `sessionChanged`）仍按原样停会话：那是 OS 会话切换触发，不是注入失败。
  - 不改 wire 协议、不改 allowlist、不动 device-link 的重试与 relay。
- 用户可见变化：点画面不再导致整页重连；若该电脑当时无法注入输入，手机退回「仅查看」（操作面板显示既有的仅查看提示），可再次「接管操作」重试。
- 是否存在 breaking change：无。协议、allowlist、旧客户端行为都不变（旧桌面端仍回 `DESKTOP_VIEW_ONLY` / `DESKTOP_LEASE_EXPIRED`，新手机按新分类处理）。

### UI 变化

- 引用的设计规范：不涉及：本次不新增界面、控件或文案，只把主机收回控制后的状态同步为既有的「仅查看」态——提示沿用既有 `remoteDesktop.viewOnlyHint`，重试沿用既有「接管操作」按钮，移动端未新增视觉元素或字符串。

## 怎么验证的

### 自动验证

```text
pnpm --filter desktop typecheck                     → 通过
pnpm --filter mobile typecheck                      → 通过
pnpm test:unit:related（仓库根，worktree 内）        → 通过：test:runner PASS、apps/desktop unit PASS、apps/mobile unit PASS
pnpm --filter mobile test:scope                     → mobile-scope-guard passed
pnpm check:dco                                      → DCO check passed（1 commit signed off）
npx vitest run src/main/remote-desktop/__tests__/controller.test.ts src/main/remote-desktop/__tests__/captureBoundary.test.ts（apps/desktop 内）→ 56 passed
npx vitest run src/remote-desktop/__tests__/controlFailure.test.ts src/remote-desktop/__tests__/screen.test.tsx（apps/mobile 内）→ 87 passed
```

### 手工验证

不涉及：行为层由上述单测覆盖（桌面装配、控制器语义、手机三条路径）；本机没有 Windows 实机，也没有 Rust 工具链，无法做端到端复现。

### 未执行的验证

- **Windows 实机端到端未验证**：没有 Windows 环境，无法确认「点击不再重连」在真机上的表现，也无法确认这台机器的原生注入失败是什么。本 PR 只改失败半径，不改原生注入。
- **原生代码未编译**：本机没有 Rust 工具链，因此本 PR 刻意不改 `windows-input` / `windows-host`，避免提交无法编译的原生改动。
- 下一步定位原生原因建议（任选，均可独立于本 PR）：
  1. 在被控机 Cindy 安装目录 `resources\tools\remote-desktop\` 下手动运行 `cindy-windows-desktop-input.exe`，喂一行 `[{"kind":"button","button":0,"down":true,"x":100,"y":100},{"kind":"button","button":0,"down":false,"x":100,"y":100}]`，看它是否打印 `ready`、系统光标是否移动并点击；
  2. 给 helper 的失败行补上失败点与 `GetLastError`，让下次复现能直接定性（需要 Windows 侧出 build）。
- macOS 输入路径未做真机回归（本 PR 不改变 macOS 行为，但装配改动两端生效）。
- 移动端未做真机验证（模拟器/实机手势、浅色深色）——改动只涉及控制状态同步，未改视觉。

## 风险

### 风险分类

- [x] 权限 / 安全 / 用户数据
- [x] 跨平台差异
- [x] 其他：故障半径（控制位 vs 会话）

- 权限/安全：本改动**收窄**而不放宽——输入仍然要求有效租约 + `controlling` + 授权；收回控制后所有输入一律按 `DESKTOP_VIEW_ONLY` 拒绝（`captureHost.ts` 静默丢弃、invoke 路径明确报错），没有新增任何可执行能力。原先「注入失败就停整个会话」并不会带来安全收益（helper 已死，按键释放同样无法注入），把它降级为收回控制不改变安全边界。
- 跨平台差异：Windows 是触发平台（`SendInput` 有失败返回路径）；macOS 的 helper 不上报注入失败，因此行为不变但装配同样生效，需要回归时留意。

### 影响与回滚

- 影响范围：只影响远程桌面的输入/控制路径；不动 relay、不动其它 peer 的 device-link 会话、不动协议与持久化数据。
- 回滚 / 降级方式：revert 本 commit 即可（无 migration、无数据格式变化、无原生改动）。

### 故障半径三问（device-link 共享链路的恢复动作）

1. **触发条件是哪一层的故障**：最小半径——单个 peer 的控制位 / 单条输入批次。不是 relay 连接级，更不是聚合背压层；空闲时每 2 秒的输入心跳走同一条管道、同样经过每个批次前的桌面检查且不触发故障，说明通道与 helper 本身是健康的。
2. **恢复动作作用在哪一层**：原实现把「单条输入失败」放大成「整段远程桌面租约 + 采集 + 媒体停止」（动作半径 > 故障半径），这正是上报现象「一点就重连」的成因；本 PR 收窄为与故障同半径的「只收回控制位」（`stopInput()` + `controlling=false`），保留租约与媒体。没有任何路径扩大到 relay 或其它 peer；重连成功后的重放问题不存在（本改动不产生重连）。
3. **多 peer 拓扑下测过吗**：远程桌面是单租约模型，第二台设备走既有的 BUSY / takeover 仲裁。用例 `controller.test.ts` 断言：收回控制后同一租约仍然有效、媒体未被停止、第二台设备的 `start` 仍按既有规则拿到 `DESKTOP_BUSY`，且 `stopVideo` 从未被调用。

### 远程与手机适配三问

1. workdir 文件 / agent 进程 / 会话数据：不涉及（远程桌面不读写 workdir）。
2. 新增 IPC / 推送白名单：不新增 channel 或 push，复用既有 `DESKTOP_LOCAL.INPUT` 与 `device-link:remote-desktop:v1` invoke，topic 路由不变。
3. 手机版入口 / UI：本 PR 已一并适配（手机同步为仅查看，可再次接管；未新增入口）。

### 提交前检查

- [x] 已 review 完整 diff
- [x] 每个 commit 都带 DCO 签名（`git commit -s`，`pnpm check:dco` 通过）
- [x] UI 改动已在「UI 变化」注明引用的设计规范章节（不涉及 UI 时跳过）
- [x] 未提交凭证、令牌或授权文件
- [x] 已补充必要文档（`docs/remote-desktop.md`）
- [x] 已确认测试结果或说明未执行原因
