### PR TITLE
fix(models): 补齐公共档位参考价并修复 Codex 缓存写入计量

### DIFF
--- a/apps/desktop/src/main/__tests__/makerEventHotPathOrdering.test.ts
+++ b/apps/desktop/src/main/__tests__/makerEventHotPathOrdering.test.ts
@@ -869,7 +869,7 @@ describe('maker:event hot path ordering', () => {
     expect(codexDoneSource).toContain('void recordTurnSpend(money);');
     expect(codexDoneSource).toContain('void recordSessionTurnSpend(session.id, money);');
     expect(codexDoneSource).toMatch(
-      /await recordModelTurnUsage\(\{\s*agentKind: 'codex',\s*model: modelUsageKey,\s*money: isSubscriptionValue \? unpricedSubscriptionValueMarker\(\) : undefined,\s*inputTokensDelta: promptTokens,\s*outputTokensDelta: completionTokens,\s*cacheReadTokensDelta: cachedTokens,\s*cacheCreateTokensDelta: 0,\s*\}\)\.finally\(\(\) => rebroadcastCodexTodayUsage\(\)\);[\s\S]*?const pricing = isSubscriptionValue/,
+      /await recordModelTurnUsage\(\{\s*agentKind: 'codex',\s*model: modelUsageKey,\s*money: isSubscriptionValue \? unpricedSubscriptionValueMarker\(\) : undefined,\s*inputTokensDelta: promptTokens,\s*outputTokensDelta: completionTokens,\s*cacheReadTokensDelta: cachedTokens,\s*cacheCreateTokensDelta: cacheCreationTokens,\s*\}\)\.finally\(\(\) => rebroadcastCodexTodayUsage\(\)\);[\s\S]*?const pricing = isSubscriptionValue/,
     );
     expect(codexDoneSource).toMatch(
       /await recordModelTurnUsage\(\{\s*agentKind: 'codex',\s*model: modelUsageKey,\s*money,\s*inputTokensDelta: 0,\s*outputTokensDelta: 0,\s*cacheReadTokensDelta: 0,\s*cacheCreateTokensDelta: 0,\s*\}\);/,

--- a/apps/desktop/src/main/__tests__/turnCostBroadcaster.test.ts
+++ b/apps/desktop/src/main/__tests__/turnCostBroadcaster.test.ts
@@ -764,8 +764,9 @@ describe('codexUsageToTokens', () => {
         completionTokens: 200,
         reasoningTokens: 300,
         cachedTokens: 4000,
+        cacheCreationTokens: 50,
       }),
-    ).toEqual({ inputTokens: 1000, outputTokens: 200, cacheReadTokens: 4000, cacheCreateTokens: 0 });
+    ).toEqual({ inputTokens: 1000, outputTokens: 200, cacheReadTokens: 4000, cacheCreateTokens: 50 });
   });
 
   it('缺失字段按 0 处理', () => {

--- a/apps/desktop/src/main/__tests__/usageBroadcasterCodexAccount.test.ts
+++ b/apps/desktop/src/main/__tests__/usageBroadcasterCodexAccount.test.ts
@@ -73,6 +73,17 @@ describe('codex account usage source slots', () => {
     mocks.broadcasts.length = 0;
   });
 
+  it('counts cache writes once in today usage and accepts older done events', async () => {
+    const broadcaster = await import('../usageBroadcaster');
+    broadcaster.recordCodexTurnUsage({ promptTokens: 100, completionTokens: 20,
+      reasoningTokens: 5, cachedTokens: 10, cacheCreationTokens: 50 });
+    broadcaster.recordCodexTurnUsage({ promptTokens: 10, completionTokens: 2, cachedTokens: 1 });
+    expect(await broadcaster.readAgentTodayUsage('codex')).toMatchObject({
+      totalTokens: 193, promptTokens: 110, completionTokens: 22,
+      reasoningTokens: 5, cachedTokens: 11, cacheCreationTokens: 50,
+    });
+  });
+
   it('keeps app-server windows when a WHAM snapshot arrives (no cross-source overwrite)', async () => {
     const broadcaster = await import('../usageBroadcaster');
 

--- a/apps/desktop/src/main/maker-host/__tests__/bundledCatalogIntegrity.test.ts
+++ b/apps/desktop/src/main/maker-host/__tests__/bundledCatalogIntegrity.test.ts
@@ -47,13 +47,15 @@ describe('bundled model settings integrity', () => {
     expect(checked).toBeGreaterThan(0);
   });
 
-  it.each(['openai/gpt-6-astra', 'codex/gpt-6-astra', 'gpt-6-astra'])(
+  it.each(['gpt-6-astra', 'gpt-5.6-sol', 'gpt-5.6-terra', 'gpt-5.6-luna'].flatMap(
+    (model) => [`openai/${model}`, `codex/${model}`, model],
+  ))(
     'shows known tiers for Gateway %s without opening them', (id) => {
     setActiveCatalog(BUNDLED_CATALOG);
     setXdGatewayModels([{
-      id, name: 'GPT-6 Astra', mode: 'chat',
+      id, name: id, mode: 'chat',
       agents: ['codex', 'claude-code', 'pi'], contextWindow: 1_050_000,
-      maxOutputTokens: 128_000, efforts: ['medium', 'high', 'xhigh', 'max'],
+      maxOutputTokens: 128_000, efforts: ['medium', 'high', 'xhigh'],
       defaultEffort: 'medium', supportsFastMode: true,
     }], { authoritative: true });
     const gateway = getActiveCatalog().providers.find((provider) => provider.id === 'xd')!;
@@ -61,7 +63,7 @@ describe('bundled model settings integrity', () => {
       expect(gateway.models[agent]).toHaveLength(1);
       expect(gateway.models[agent]![0]).toMatchObject({
         contextWindow: 272_000, contextWindowMax: 1_050_000,
-        efforts: ['medium', 'high', 'xhigh', 'max'], defaultEffort: 'medium',
+        efforts: ['medium', 'high', 'xhigh'], defaultEffort: 'medium',
         displayEfforts: ['low', 'medium', 'high', 'xhigh', 'max'],
       });
     }

--- a/apps/desktop/src/main/maker-host/__tests__/openAiAccountCatalogParity.test.ts
+++ b/apps/desktop/src/main/maker-host/__tests__/openAiAccountCatalogParity.test.ts
@@ -27,7 +27,7 @@ afterEach(() => {
 });
 
 describe('OpenAI account catalog identity', () => {
-  it.each([false, true])('Pro/Cyber keep all Harness routes with old missing metadata (%s)', (oldSnapshot) => {
+  it.each([false, true])('Pro/Cyber keep all Harness routes and inherit available public tiers (old snapshot: %s)', (oldSnapshot) => {
     const catalog = structuredClone(BUNDLED_CATALOG);
     const slugs = ['gpt-5.4-pro', 'gpt-5.5-pro', 'gpt-5.6-cyber'];
     if (oldSnapshot) {
@@ -46,7 +46,9 @@ describe('OpenAI account catalog identity', () => {
       for (const agent of ['codex', 'claude-code', 'pi'] as const) {
         for (const slug of slugs) {
           expect(entry(providerId, agent, agent === 'codex' ? slug : `chatgpt/${slug}`))
-            .toMatchObject({ efforts: [], defaultEffort: null });
+            .toMatchObject(oldSnapshot || slug === 'gpt-5.6-cyber'
+              ? { efforts: [], defaultEffort: null }
+              : { efforts: ['medium', 'high', 'xhigh'], defaultEffort: 'medium' });
         }
       }
     }

--- a/apps/desktop/src/main/maker-ipc/__tests__/sessionEventPipeline.test.ts
+++ b/apps/desktop/src/main/maker-ipc/__tests__/sessionEventPipeline.test.ts
@@ -882,6 +882,47 @@ describe('usage through the production event pipeline', () => {
     effects.fn('consumeLastAssistantPersistId').mockReturnValue('assistant-row');
   }
 
+  it.each(['priced', 'missing-write-price', 'legacy-summary'] as const)(
+    'preserves Codex cache writes without guessing cost (%s)', async (mode) => {
+      const h = harness();
+      pricing(false);
+      const writes = mode === 'legacy-summary' ? 0 : 50;
+      const allTokens = { ...tokens, cacheCreateTokens: writes };
+      effects.fn('codexUsageToTokens').mockReturnValue(allTokens);
+      effects.fn('getModelPriceQuote').mockReturnValue({
+        providerId: 'xd', modelId: 'test-model', currency: 'USD', source: 'gateway',
+        inputPerMtok: 1, outputPerMtok: 2, cacheReadPerMtok: 0.1,
+        ...(mode !== 'missing-write-price' ? { cacheCreatePerMtok: 1.25 } : {}),
+      });
+      h.emit(event('done', { usage: {
+        promptTokens: 100, completionTokens: 20, cachedTokens: 10,
+        ...(mode !== 'legacy-summary' ? { cacheCreationTokens: 50 } : {}),
+        segments: [{ ...segment, cacheCreateTokens: 50 }],
+      } }, { source: 'codex' }));
+      await microtasks();
+      expect(effects.fn('recordSessionTurnTokens')).toHaveBeenCalledWith('task', 130 + writes);
+      expect(effects.fn('recordModelTurnUsage')).toHaveBeenCalledWith(expect.objectContaining({
+        inputTokensDelta: 100, outputTokensDelta: 20, cacheReadTokensDelta: 10,
+        cacheCreateTokensDelta: writes,
+      }));
+      if (mode === 'priced') {
+        expect(effects.fn('recordSchedulerTurnCost')).toHaveBeenCalledWith(expect.objectContaining({
+          money: expect.objectContaining({ amount: 0.0002035 }),
+          turnUsageDetails: expect.objectContaining({ cacheCreateTokens: 50 }),
+        }));
+        expect(effects.fn('recordModelTurnUsage')).toHaveBeenLastCalledWith(expect.objectContaining({
+          inputTokensDelta: 0, outputTokensDelta: 0, cacheReadTokensDelta: 0, cacheCreateTokensDelta: 0,
+        }));
+      } else {
+        expect(effects.fn('recordTurnSpend')).not.toHaveBeenCalled();
+        expect(effects.fn('recordTurnUsageOnMessage')).toHaveBeenCalledWith(expect.objectContaining({
+          turnUsageDetails: expect.objectContaining({ cacheCreateTokens: writes }),
+        }));
+      }
+      await h.dispose();
+    },
+  );
+
   it.each([
     ['codex', false],
     ['codex', true],

--- a/apps/desktop/src/main/maker-ipc/sessionCodexTurnUsage.ts
+++ b/apps/desktop/src/main/maker-ipc/sessionCodexTurnUsage.ts
@@ -70,7 +70,7 @@ export function recordSessionCodexTurnUsage(
     if (usage) recordCodexTurnUsage(usage);
     // 按模型记账: codex done.data.usage 是 **per-turn 增量语义** (maker-core
     // codexDoneUsage 契约: promptTokens=本 turn 未命中输入, completionTokens=完整输出
-    // (reasoningTokens 只是其中的诊断子集), cachedTokens=命中缓存;
+    // (reasoningTokens 只是其中的诊断子集), cachedTokens=命中缓存, cacheCreationTokens=写入缓存;
     // 整 turn 没收到 tokenUsage/updated 时全 0。
     // 直接入库, 不做 delta 化 —— 历史上 promptTokens 曾是 contextTokens 快照、这里
     // 做过 per-session delta 化, 语义改为 per-turn 后那套逻辑会把后小于前的 turn 记 0。
@@ -80,6 +80,7 @@ export function recordSessionCodexTurnUsage(
         completionTokens?: number;
         reasoningTokens?: number;
         cachedTokens?: number;
+        cacheCreationTokens?: number;
         segments?: unknown;
         durationMs?: number;
         turnDurationMs?: number;
@@ -87,14 +88,16 @@ export function recordSessionCodexTurnUsage(
       const promptTokens = Number(u.promptTokens) || 0;
       const completionTokens = Number(u.completionTokens) || 0;
       const cachedTokens = Number(u.cachedTokens) || 0;
+      const cacheCreationTokens = Number(u.cacheCreationTokens) || 0;
       const codexUsageSegments = normalizeTurnUsageSegments(u.segments);
       const codexSegmentTotals = sumTurnUsageSegments(codexUsageSegments);
       const codexSegmentsReliable =
         codexUsageSegments.length > 0 &&
         codexSegmentTotals.inputTokens === promptTokens &&
         codexSegmentTotals.outputTokens === completionTokens &&
-        codexSegmentTotals.cacheReadTokens === cachedTokens;
-      void recordSessionTurnTokens(session.id, promptTokens + completionTokens + cachedTokens);
+        codexSegmentTotals.cacheReadTokens === cachedTokens &&
+        codexSegmentTotals.cacheCreateTokens === cacheCreationTokens;
+      void recordSessionTurnTokens(session.id, promptTokens + completionTokens + cachedTokens + cacheCreationTokens);
       // 先落 daily_model_usage token 行, 再等价格表补 API cost。首页 usage push 会在
       // ~2s 后刷新, 不能让冷价格表 / 离线 fetch 把模型 token 行延后到刷新之后。
       // 后续 cost-only 增量不会重复累计 token。
@@ -155,7 +158,7 @@ export function recordSessionCodexTurnUsage(
           inputTokensDelta: promptTokens,
           outputTokensDelta: completionTokens,
           cacheReadTokensDelta: cachedTokens,
-          cacheCreateTokensDelta: 0,
+          cacheCreateTokensDelta: cacheCreationTokens,
         }).finally(() => rebroadcastCodexTodayUsage());
 
         // Codex SDK 不报 $, 用价格表折算。普通模型 + oauth(订阅)显示为 token 价值;api 模式和 codex/
@@ -171,7 +174,7 @@ export function recordSessionCodexTurnUsage(
           inputTokens: promptTokens,
           outputTokens: completionTokens,
           cacheReadTokens: cachedTokens,
-          cacheCreateTokens: 0,
+          cacheCreateTokens: cacheCreationTokens,
           model: turnModel,
           durationMs: u.durationMs,
           turnDurationMs: u.turnDurationMs,

--- a/apps/desktop/src/main/turnCostBroadcaster.ts
+++ b/apps/desktop/src/main/turnCostBroadcaster.ts
@@ -433,19 +433,20 @@ export async function recordSchedulerTurnCost(
 /**
  * Codex done.data.usage → computeGatewayTurnCost 的 TurnTokenDeltas 入参映射。
  * Provider 的 completionTokens 已包含 reasoning 子集，这里不再重复相加。
- * Codex 无 cache 写入概念, cacheCreateTokens 恒 0。
+ * 写缓存独立传递；旧版 done 未声明时按 0 兼容。
  */
 export function codexUsageToTokens(usage: {
   promptTokens?: number;
   completionTokens?: number;
   reasoningTokens?: number;
   cachedTokens?: number;
+  cacheCreationTokens?: number;
 }): { inputTokens: number; outputTokens: number; cacheReadTokens: number; cacheCreateTokens: number } {
   return {
     inputTokens: usage.promptTokens || 0,
     outputTokens: usage.completionTokens || 0,
     cacheReadTokens: usage.cachedTokens || 0,
-    cacheCreateTokens: 0,
+    cacheCreateTokens: usage.cacheCreationTokens || 0,
   };
 }
 

--- a/apps/desktop/src/main/usageBroadcaster.ts
+++ b/apps/desktop/src/main/usageBroadcaster.ts
@@ -81,6 +81,7 @@ export interface AgentTodayUsage {
   completionTokens?: number;
   reasoningTokens?: number;
   cachedTokens?: number;
+  cacheCreationTokens?: number;
 }
 
 export interface RateLimitWindow {
@@ -197,6 +198,7 @@ interface CodexTokenSnapshot {
   completionTokens: number;
   reasoningTokens: number;
   cachedTokens: number;
+  cacheCreationTokens: number;
   total: number;
 }
 
@@ -209,6 +211,7 @@ function blankCodexSnapshot(): CodexTokenSnapshot {
     completionTokens: 0,
     reasoningTokens: 0,
     cachedTokens: 0,
+    cacheCreationTokens: 0,
     total: 0,
   };
 }
@@ -219,6 +222,7 @@ interface CodexTurnUsage {
   completionTokens?: number;
   reasoningTokens?: number;
   cachedTokens?: number;
+  cacheCreationTokens?: number;
 }
 
 /**
@@ -239,6 +243,7 @@ export function recordCodexTurnUsage(usage: unknown): void {
   const completionDelta = Number(u.completionTokens) || 0;
   const reasoningDelta = Number(u.reasoningTokens) || 0;
   const cachedDelta = Number(u.cachedTokens) || 0;
+  const cacheCreationDelta = Number(u.cacheCreationTokens) || 0;
 
   codexTodaySnapshot = {
     day: today,
@@ -246,7 +251,8 @@ export function recordCodexTurnUsage(usage: unknown): void {
     completionTokens: codexTodaySnapshot.completionTokens + completionDelta,
     reasoningTokens: codexTodaySnapshot.reasoningTokens + reasoningDelta,
     cachedTokens: codexTodaySnapshot.cachedTokens + cachedDelta,
-    total: codexTodaySnapshot.total + promptDelta + completionDelta + cachedDelta,
+    cacheCreationTokens: codexTodaySnapshot.cacheCreationTokens + cacheCreationDelta,
+    total: codexTodaySnapshot.total + promptDelta + completionDelta + cachedDelta + cacheCreationDelta,
   };
 
   broadcastCodexTokens(codexTodaySnapshot);
@@ -288,6 +294,7 @@ export async function readAgentTodayUsage(agentKind: AgentKind): Promise<AgentTo
       completionTokens: s.completionTokens,
       reasoningTokens: s.reasoningTokens,
       cachedTokens: s.cachedTokens,
+      cacheCreationTokens: s.cacheCreationTokens,
     };
   }
   // 未知 agentKind: 返回空 snapshot (TS 完备性, 不抛错让 UI 优雅 fallback)

--- a/apps/desktop/src/renderer/vite-env.d.ts
+++ b/apps/desktop/src/renderer/vite-env.d.ts
@@ -711,7 +711,8 @@ interface CodexUsageSnapshot {
   completionTokens: number;
   reasoningTokens: number;
   cachedTokens: number;
-  /** = prompt + completion + cached; reasoning is a diagnostic subset of completion */
+  cacheCreationTokens?: number;
+  /** = prompt + completion + cached + cacheCreation; reasoning is a diagnostic subset of completion */
   total: number;
 }
 
@@ -6365,6 +6366,7 @@ interface ElectronAPI {
         completionTokens?: number;
         reasoningTokens?: number;
         cachedTokens?: number;
+        cacheCreationTokens?: number;
       }>;
       getAccount: (agentKind: 'claude-code' | 'codex' | 'pi', providerId?: string) => Promise<unknown | null>;
       /** Codex app-server authoritative windows and banked reset-credit metadata. */

--- a/apps/desktop/src/shared/__tests__/modelPriceQuote.test.ts
+++ b/apps/desktop/src/shared/__tests__/modelPriceQuote.test.ts
@@ -115,6 +115,32 @@ describe('gatewayPricingCatalog', () => {
 });
 
 describe('registryPricingCatalog', () => {
+  it('projects the audited public tariffs without backfilling Gateway sale prices', () => {
+    const registry = BUNDLED_CATALOG.modelRegistry!;
+    const luna = providerReferencePriceQuote('openai', 'gpt-5.6-luna', registry, { at: '2026-09-11' });
+    expect(luna).toMatchObject({ inputPerMtok: 0.2, cacheCreatePerMtok: 0.25,
+      priority: { inputPerMtok: 0.4, cacheCreatePerMtok: 0.5,
+        inputTokenPriceBands: expect.arrayContaining([
+          expect.objectContaining({ minInputTokens: 272001, inputPerMtok: 0.8, cacheCreatePerMtok: 1 }),
+        ]),
+      },
+    });
+    expect(providerReferencePriceQuote('openai', 'gpt-5.4-pro', registry, { at: '2026-09-11', inputTokens: 272001 }))
+      .toMatchObject({ inputPerMtok: 60, outputPerMtok: 270 });
+    expect(providerReferencePriceQuote('anthropic', 'claude-fable-5-1', registry, { at: '2026-09-11' }))
+      .toMatchObject({ inputPerMtok: 10, cacheReadPerMtok: 0.25, cacheCreatePerMtok: 12.5 });
+    expect(providerReferencePriceQuote('minimax-cn', 'MiniMax-M2.7', registry, { at: '2026-09-11' }))
+      .toMatchObject({ currency: 'CNY', inputPerMtok: 2.1, cacheCreatePerMtok: 2.625 });
+    expect(providerReferencePriceQuote('minimax-global', 'MiniMax-M2.7', registry, { at: '2026-09-11' }))
+      .toMatchObject({ currency: 'USD', inputPerMtok: 0.3, cacheCreatePerMtok: 0.375 });
+    expect(registryPricingCatalog(registry).xd).toBeUndefined();
+    const gateway = gatewayPricingCatalog([model('openai/gpt-5.6-luna', {
+      currency: 'USD', inputCostPerToken: 0.0000002, outputCostPerToken: 0.0000012,
+      cacheReadInputTokenCost: 0.00000002,
+    })], 'USD');
+    expect(gateway.xd['openai/gpt-5.6-luna'].cacheCreatePerMtok).toBeUndefined();
+  });
+
   it.each(['fast', 'priority'] as const)('projects declared %s prices without inventing unavailable tariffs', (variant) => {
     const entry = structuredClone(BUNDLED_CATALOG.modelRegistry!.models.find((model) => model.id === 'openai/gpt-6-astra')!);
     const prices = entry.routes[0]!.referencePrices!;

--- a/docs/model-catalog-history.md
+++ b/docs/model-catalog-history.md
@@ -3,6 +3,100 @@
 > 参考记录，不是当前配置或部署状态。当前维护规则见 [模型配置与下发](dev-rules/model-catalog-maintenance.md)。
 > 下列文字记录各批次当时的事实，不能相互当作后续状态的证明。引用时须带日期、来源和验证范围。
 
+## 价格与缓存写入计量核对（2026-09-11）
+
+本轮遍历 Registry 及 Pi 目录的价格来源，同时读取 Global / CN 的匿名网关模型目录。
+服务端正本与客户端同步修改 32 个型号的 44 条 route，参考价记录从 69 条增加至 116 条。
+新增记录从 `2026-09-11` 开始采用，表示本目录首次核实并采用该参考快照，
+不宣称厂商当天调价，不倒填未知历史；已知历史区间保留。媒体扩展仍遵守本页下节的
+不同快照 revision 约束。配置和测试结果不表示生产已部署。
+
+| 已修复项                                                   | 依据与边界                                                                                                                                                                                                                                                                                                                                                       |
+| ---------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| GPT-5.4 Pro / 5.5 Pro、Cyber、Fable 5.1 缺参考价           | [5.4 Pro](https://developers.openai.com/api/docs/models/gpt-5.4-pro)、[5.5 Pro](https://developers.openai.com/api/docs/models/gpt-5.5-pro)、[Cyber](https://developers.openai.com/api/docs/models/gpt-5.6-cyber)、[Claude 定价](https://platform.claude.com/docs/en/about-claude/pricing)。Pro 5.5 无缓存读折扣，按普通输入价；不猜写价。                        |
+| Sol / Terra / Luna 缺 Fast 及其长输入档                    | [OpenAI Fast 表](https://developers.openai.com/api/docs/pricing)；覆盖 Sol 旧 1M 路由。标准价和 Fast 分开，保留旧价格。                                                                                                                                                                                                                                          |
+| MiniMax M2 / M2.1 / M2.5 / M2.7 及 highspeed 的 API 参考价 | [中国区](https://platform.minimaxi.com/docs/guides/pricing-paygo)与[国际区](https://platform.minimax.io/docs/guides/pricing-paygo)分别采用 CNY / USD，不用汇率推导，也不将 API 价当成 Coding Plan 扣款。                                                                                                                                                         |
+| Kimi K3 / K2.7 Code / Highspeed 国内国际、K2.6 官方参考    | 官方动态表经浏览器实际读取：[国际 K3](https://platform.kimi.ai/docs/pricing/chat-k3)、[中国 K3](https://platform.kimi.com/docs/pricing/chat-k3)、[国际 Code](https://platform.kimi.ai/docs/pricing/chat-k27-code)、[中国 Code](https://platform.kimi.com/docs/pricing/chat-k27-code)、[K2.6](https://platform.kimi.ai/docs/pricing/chat-k26)。不改 Coding Plan。 |
+| GLM 5.1 / 5.2 / 5.3 / 5.3 Flash、Qwen3.8 Flash 中国区参考  | [Z.AI USD](https://docs.z.ai/guides/overview/pricing)、[阿里云北京 CNY](https://help.aliyun.com/zh/model-studio/model-pricing)。GLM 中国区和 Qwen 国际部署价格不互相套用。                                                                                                                                                                                       |
+| Gemini 3.5 Flash、3.5/3.1 Flash-Lite 缺文本参考价          | [Google 定价](https://ai.google.dev/gemini-api/docs/pricing)。3.1 Lite 音频单价不同；3.6/3.7 的 token·小时存储费原误放入 `cacheWrite1hPerMtok`，已移除，不能按一次写缓存计费。                                                                                                                                                                                   |
+| DeepSeek V4 Flash 的旧别名价已变                           | [当前官方定价](https://api-docs.deepseek.com/quick_start/pricing/)确认旧别名由 V4.1 Flash 服务，采用峰值参考价 input 0.30 / output 1.20 / read 0.006 USD/MTok。原峰值价保存为截止本次核验日的历史区间。                                                                                                                                                          |
+
+xAI 当前文本价的短／长输入边界与[官方表](https://docs.x.ai/developers/pricing)一致；
+现有 OpenAI 标准价、Astra Fast、Claude 已有标准与 Fast 价保持。不能把 OpenAI 页面先出现的
+Batch / Flex 半价表误当 Standard。Pi 固定 xAI cost 与短档相符，其余依赖原生目录的
+缺字段不等于免费，不写静态零值。
+
+Codex 原生 `inputTokens` 包含读缓存和写缓存子集，实时解析已正确拆桶；丢失发生在
+`done` 汇总。现在增加可选 `cacheCreationTokens`，贯通消息明细、模型日账本、今日总量
+与费用映射；旧事件缺字段按零兼容。四个桶都与请求分段一致才允许计价；第二次仅补费用的
+写账保持全零 token，避免重复累计。请求与 system prompt 不变；验证使用真实处理函数的
+模拟事件重放，未用付费模型调用或生产账单作验收。
+
+### 仍需证据或更细合同的价格
+
+- XD 实价来自 Gateway `/models`，Registry 的官方参考价不能回填。Global 当次 30 个模型中
+  有 12 条具备缓存读价但缺写价（Luna / Sol / Terra、Gemini 3.5–3.8 Flash、Muse Spark 1.3、
+  Kimi K3、Grok 4.5 / 4.6、GPT Image 2）；CN 当次 20 个模型中为 Kimi K3，未列 Luna。
+  “有读无写”仅是待核对集合，不证明这些模型都应单独收写入费。
+  Server 已保留标准 `cacheCreationInputTokenCost` 及 tier 同名字段；需拿到上游价表正本或
+  原始 `/model-groups` 响应，才能区分上游缺价与未支持的字段形式。
+- Cyber 型号页说明长输入倍数，但[总价表](https://developers.openai.com/api/docs/pricing)长档为 `-`。
+  暂只提供不超过 272,000 输入的短档，超出范围不计参考金额，不把短价延长或当免费。
+- MiniMax M3 的 512k、Qwen3.6/3.7 的 K 分档，尚未找到足以确认精确整数边界的官方说明。
+  不用上下文容量推断计费单位。Qwen 国际部署地区、GLM 中国区当前收费也尚未确认。
+  GPT-5.5 Auto、Muse、HY、Seed 等 XD-only 型号仍取通道实报，不凭相似型号补官方价。
+- DeepSeek 参考价按峰值口径；当前日历日期合同不能表达每周峰谷时段或官方预告
+  9 月 14 日北京时间 12:00 的 Pro 别名切换，发布时需再次核对，不能当精确账单。
+- 缓存一小时写入与按小时存储不同；Qwen 显式／隐式缓存、媒体按张／秒／字符收费、
+  工具调用等不能塞进通用 token 写价。缺乏用量维度或报价时继续保留未知，不能写零。
+
+## 公共思考档位核对（2026-09-11）
+
+遍历 94 个公共型号，区分分级思考、仅思考开关／预算、媒体以及资料未知。
+本批次同步补全服务端正本和客户端离线 Registry 的 9 个公共条目；生产下发仍需单独验收，
+不能把配置同步或测试通过视为已上线。
+
+服务端保留已发布的 Registry 形状，客户端媒体扩展依照
+[媒体目录发布前提](model-registry-v4-media.md)继续仅存在于离线副本，未随本次同步下发。
+两份完整快照因此采用不同 revision；本批次公共档位和 GLM 路由默认一致。
+
+| 公共型号                                 | 档位                              | Cindy 默认 | 官方依据                                                                                                                                                   |
+| ---------------------------------------- | --------------------------------- | ---------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| GPT-5.6 Sol、Luna                        | low / medium / high / xhigh / max | medium     | [Sol](https://developers.openai.com/api/docs/models/gpt-5.6-sol)、[Luna](https://developers.openai.com/api/docs/models/gpt-5.6-luna)                       |
+| GPT-5.4 Pro、5.5 Pro                     | medium / high / xhigh             | medium     | [5.4 Pro](https://developers.openai.com/api/docs/models/gpt-5.4-pro)、[5.5 Pro](https://developers.openai.com/api/docs/models/gpt-5.5-pro)；原先误填空数组 |
+| Gemini 3.1 Flash-Lite                    | minimal / low / medium / high     | medium     | [Google 型号对应表](https://ai.google.dev/gemini-api/docs/gemini-3?hl=zh-CN)；该旧版指南仍明确列出此型号                                                   |
+| GLM-5.3-Flash（z-ai 与 xd 两条公共定义） | low / high / max                  | high       | [发布者模型卡](https://huggingface.co/zai-org/GLM-5.3-Flash#note)；现有 Coding Plan Pi 预设也已采用这三档                                                  |
+| Qwen3.8 Flash                            | low / medium / xhigh              | medium     | [官方 API](https://www.alibabacloud.com/help/en/model-studio/qwen-api-via-openai-chat-completions)；原先误填空数组                                         |
+| Qwen3.8 Flash-Next                       | low / medium / xhigh              | medium     | [发布者模型卡](https://huggingface.co/Qwen/Qwen3.8-Flash-Next#api-usage)；本地包装是否提供相应参数仍由运行时决定                                           |
+
+默认值沿用 Cindy 的 medium 优先策略；没有 medium 时选 high，不能将官方默认
+minimal / max / xhigh 自动变成 Cindy 默认。GLM 的公共默认采用合法的 high，原先 XD 的
+medium 意图移到 XD route.defaults，保留既有中档裁决；该路由同时保留两区域
+[实时网关](https://model-access.cindy.app/api/model-access/models?schemaVersion=5)已明确支持的
+low / medium / high / max，实际能力仍以实报为准，不把兼容 medium 上提为公共档位。
+此次不扩展 schema 中尚未表达的 none／no_think。
+
+公共档位不取 route／perAgent 的并集：保留 Sol 旧 1M 路由的四档、Codex 特有 ultra，
+以及 Seed／GLM 的引擎差异；不将其上提为公共能力。已配置的兼容映射档位不在本轮删除。
+思考档位这一步不调整模型成员、窗口、价格、协议、本地推荐或用户覆盖；随后授权的价格审计见上节。
+
+两区域公开目录核对时 revision 为 `2026-09-08T07:58:08.918Z`，客户端基线为
+`2026-09-10T06:40:00.000Z`。Global 公开网关的 Luna 实报只有 medium / high / xhigh；
+公共资料补齐后应显示 low / max，但仍不可选。回归覆盖 Astra / Sol / Terra / Luna 的
+三种 wire ID、三个引擎，以及网关显式空数组与未知型号，确保公共展示不解锁通道。
+
+保留缺项或显式空值的理由：
+
+- Anthropic 现有分级与[官方表](https://platform.claude.com/docs/en/build-with-claude/effort)一致；
+  Sonnet / Haiku 4.5 不支持 effort，空数组保留。
+- xAI 现有档位核对[reasoning 文档](https://docs.x.ai/developers/model-capabilities/text/reasoning)；
+  普通 Grok 4.20 的旧别名与 multi-agent 档位语义不能互相推导，未获精确证据不增删。
+- MiniMax M3 / M2 系列、Qwen3.6 Plus API、Qwen3.5 / 3.6 本地模型、Gemma 和 Nemotron
+  当前证据仅支持思考模式／预算开关，不能编造分级档位。
+- GPT-5.5 Auto、GPT-5.6 Cyber、Muse Spark 1.2、DeepSeek V4 Flash Vision Exp 和 Hy4 preview
+  尚无本轮可确认、适用于现有 schema 的完整公共档位。网关实报不替代公共型号证据；
+  DeepSeek 搜索摘要与实际打开的当前 API 型号列表不一致，因此未据摘要补实验型号。
+
 ## 本地模型配置与证据快照（2026-09-05）
 
 本轮由 9 个内置条目收敛到 7 个逻辑模型。正式推荐保留 Qwen3.8 27B；其他
@@ -61,7 +155,6 @@ GLM-4.7-Flash。本轮未证明它们相对上述候选有独立的三维优势�
 Qwen27 的 32GB MLX、64GB MXFP8 选择沿用现有行为，不把更大包装描述成已经证实更优。
 非 Apple 主机的普通 RAM 也不等于 GPU 显存；内存适配不是 GPU 性能认证。
 
-
 ## 2026-09-05 至 09-07：协议与价格迁移
 
 历史 V1–V3 迁移时，先保存并恢复经核实的 `nativeApi` / `nativeApiRules`，
@@ -81,7 +174,6 @@ Cindy 的 Seed 2.1 Pro 默认协议基准补为 `openai-completions`；这表示
 不表示官方只支持这一种协议（同页也有 Responses 示例）。Gateway 出站仍按实际通道比较。
 当时 Server V2 目录可继续在原文件维护价格与窗口，当时本地 V3 只补协议；后续完整快照遗漏
 协议时仍由客户端兜底，显式 null/retired 保持优先。
-
 
 ## 2026-09-07 至 09-08：不同批次的同步记录
 

--- a/packages/maker-core/src/agents/codex/index.test.ts
+++ b/packages/maker-core/src/agents/codex/index.test.ts
@@ -18241,6 +18241,7 @@ describe('CodexAgent MCP thread context hooks', () => {
       completionTokens: 11,
       reasoningTokens: 5,
       cachedTokens: 15_000,
+      cacheCreationTokens: cacheWriteInputTokens ?? 0,
       segments: [
         {
           inputTokens: 50_000 - (cacheWriteInputTokens ?? 0),

--- a/packages/maker-core/src/agents/codex/index.ts
+++ b/packages/maker-core/src/agents/codex/index.ts
@@ -9999,6 +9999,7 @@ export class CodexAgent extends BaseAgent {
           0,
         ),
         cachedTokens: realTurnUsage.cacheRead,
+        cacheCreationTokens: realTurnUsage.cacheCreate,
         segments: realTurnUsageSegments,
         // With usage, exclude post-output finalization. Without usage, retain
         // the measured duration metadata (zero output cannot produce a rate).

--- a/packages/model-providers/catalog/model-registry.json
+++ b/packages/model-providers/catalog/model-registry.json
@@ -1,6 +1,6 @@
 {
   "schemaVersion": 4,
-  "updatedAt": "2026-09-10T06:40:00.000Z",
+  "updatedAt": "2026-09-11T03:36:09.185Z",
   "models": [
     {
       "id": "openai/gpt-5.6-sol",
@@ -83,6 +83,36 @@
                 "url": "https://developers.openai.com/api/docs/models/gpt-5.6-sol",
                 "verifiedAt": "2026-08-28"
               }
+            },
+            {
+              "currency": "USD",
+              "variant": "fast",
+              "inputPerMtok": 8,
+              "outputPerMtok": 40,
+              "effectiveFrom": "2026-09-11",
+              "source": {
+                "kind": "provider-official",
+                "url": "https://developers.openai.com/api/docs/pricing",
+                "verifiedAt": "2026-09-11"
+              },
+              "cacheReadPerMtok": 0.8,
+              "cacheWritePerMtok": 10.0,
+              "maxInputTokens": 272001
+            },
+            {
+              "currency": "USD",
+              "variant": "fast",
+              "inputPerMtok": 16,
+              "outputPerMtok": 60.0,
+              "effectiveFrom": "2026-09-11",
+              "source": {
+                "kind": "provider-official",
+                "url": "https://developers.openai.com/api/docs/pricing",
+                "verifiedAt": "2026-09-11"
+              },
+              "cacheReadPerMtok": 1.6,
+              "cacheWritePerMtok": 20.0,
+              "minInputTokens": 272001
             }
           ],
           "defaults": {
@@ -169,6 +199,36 @@
                 "url": "https://developers.openai.com/api/docs/models/gpt-5.6-sol",
                 "verifiedAt": "2026-08-28"
               }
+            },
+            {
+              "currency": "USD",
+              "variant": "fast",
+              "inputPerMtok": 8,
+              "outputPerMtok": 40,
+              "effectiveFrom": "2026-09-11",
+              "source": {
+                "kind": "provider-official",
+                "url": "https://developers.openai.com/api/docs/pricing",
+                "verifiedAt": "2026-09-11"
+              },
+              "cacheReadPerMtok": 0.8,
+              "cacheWritePerMtok": 10.0,
+              "maxInputTokens": 272001
+            },
+            {
+              "currency": "USD",
+              "variant": "fast",
+              "inputPerMtok": 16,
+              "outputPerMtok": 60.0,
+              "effectiveFrom": "2026-09-11",
+              "source": {
+                "kind": "provider-official",
+                "url": "https://developers.openai.com/api/docs/pricing",
+                "verifiedAt": "2026-09-11"
+              },
+              "cacheReadPerMtok": 1.6,
+              "cacheWritePerMtok": 20.0,
+              "minInputTokens": 272001
             }
           ],
           "defaults": {
@@ -297,6 +357,36 @@
                 "url": "https://developers.openai.com/api/docs/models/gpt-5.6-terra",
                 "verifiedAt": "2026-08-07"
               }
+            },
+            {
+              "currency": "USD",
+              "variant": "fast",
+              "inputPerMtok": 4,
+              "outputPerMtok": 24,
+              "effectiveFrom": "2026-09-11",
+              "source": {
+                "kind": "provider-official",
+                "url": "https://developers.openai.com/api/docs/pricing",
+                "verifiedAt": "2026-09-11"
+              },
+              "cacheReadPerMtok": 0.4,
+              "cacheWritePerMtok": 5.0,
+              "maxInputTokens": 272001
+            },
+            {
+              "currency": "USD",
+              "variant": "fast",
+              "inputPerMtok": 8,
+              "outputPerMtok": 36.0,
+              "effectiveFrom": "2026-09-11",
+              "source": {
+                "kind": "provider-official",
+                "url": "https://developers.openai.com/api/docs/pricing",
+                "verifiedAt": "2026-09-11"
+              },
+              "cacheReadPerMtok": 0.8,
+              "cacheWritePerMtok": 10.0,
+              "minInputTokens": 272001
             }
           ],
           "defaults": {
@@ -410,6 +500,36 @@
                 "url": "https://developers.openai.com/api/docs/models/gpt-5.6-luna",
                 "verifiedAt": "2026-08-07"
               }
+            },
+            {
+              "currency": "USD",
+              "variant": "fast",
+              "inputPerMtok": 0.4,
+              "outputPerMtok": 2.4,
+              "effectiveFrom": "2026-09-11",
+              "source": {
+                "kind": "provider-official",
+                "url": "https://developers.openai.com/api/docs/pricing",
+                "verifiedAt": "2026-09-11"
+              },
+              "cacheReadPerMtok": 0.04,
+              "cacheWritePerMtok": 0.5,
+              "maxInputTokens": 272001
+            },
+            {
+              "currency": "USD",
+              "variant": "fast",
+              "inputPerMtok": 0.8,
+              "outputPerMtok": 3.6,
+              "effectiveFrom": "2026-09-11",
+              "source": {
+                "kind": "provider-official",
+                "url": "https://developers.openai.com/api/docs/pricing",
+                "verifiedAt": "2026-09-11"
+              },
+              "cacheReadPerMtok": 0.08,
+              "cacheWritePerMtok": 1.0,
+              "minInputTokens": 272001
             }
           ],
           "defaults": {
@@ -718,7 +838,35 @@
         {
           "providerId": "openai",
           "modelId": "gpt-5.4-pro",
-          "agents": ["claude-code", "codex"]
+          "agents": ["claude-code", "codex"],
+          "referencePrices": [
+            {
+              "currency": "USD",
+              "variant": "standard",
+              "inputPerMtok": 30,
+              "outputPerMtok": 180,
+              "effectiveFrom": "2026-09-11",
+              "source": {
+                "kind": "provider-official",
+                "url": "https://developers.openai.com/api/docs/models/gpt-5.4-pro",
+                "verifiedAt": "2026-09-11"
+              },
+              "maxInputTokens": 272001
+            },
+            {
+              "currency": "USD",
+              "variant": "standard",
+              "inputPerMtok": 60,
+              "outputPerMtok": 270.0,
+              "effectiveFrom": "2026-09-11",
+              "source": {
+                "kind": "provider-official",
+                "url": "https://developers.openai.com/api/docs/models/gpt-5.4-pro",
+                "verifiedAt": "2026-09-11"
+              },
+              "minInputTokens": 272001
+            }
+          ]
         }
       ],
       "nativeApi": "openai-responses",
@@ -734,7 +882,22 @@
         {
           "providerId": "openai",
           "modelId": "gpt-5.5-pro",
-          "agents": ["claude-code", "codex"]
+          "agents": ["claude-code", "codex"],
+          "referencePrices": [
+            {
+              "currency": "USD",
+              "variant": "standard",
+              "inputPerMtok": 30,
+              "outputPerMtok": 180,
+              "effectiveFrom": "2026-09-11",
+              "source": {
+                "kind": "provider-official",
+                "url": "https://developers.openai.com/api/docs/models/gpt-5.5-pro",
+                "verifiedAt": "2026-09-11"
+              },
+              "cacheReadPerMtok": 30
+            }
+          ]
         }
       ],
       "nativeApi": "openai-responses",
@@ -750,7 +913,24 @@
         {
           "providerId": "openai",
           "modelId": "gpt-5.6-cyber",
-          "agents": ["claude-code", "codex"]
+          "agents": ["claude-code", "codex"],
+          "referencePrices": [
+            {
+              "currency": "USD",
+              "variant": "standard",
+              "inputPerMtok": 12.5,
+              "outputPerMtok": 75,
+              "effectiveFrom": "2026-09-11",
+              "source": {
+                "kind": "provider-official",
+                "url": "https://developers.openai.com/api/docs/models/gpt-5.6-cyber",
+                "verifiedAt": "2026-09-11"
+              },
+              "cacheReadPerMtok": 1.25,
+              "cacheWritePerMtok": 15.625,
+              "maxInputTokens": 272001
+            }
+          ]
         }
       ],
       "nativeApi": "openai-responses",
@@ -884,7 +1064,24 @@
         {
           "providerId": "anthropic",
           "modelId": "claude-fable-5-1",
-          "agents": ["claude-code", "codex"]
+          "agents": ["claude-code", "codex"],
+          "referencePrices": [
+            {
+              "currency": "USD",
+              "variant": "standard",
+              "inputPerMtok": 10,
+              "outputPerMtok": 50,
+              "effectiveFrom": "2026-09-11",
+              "source": {
+                "kind": "provider-official",
+                "url": "https://platform.claude.com/docs/en/about-claude/pricing",
+                "verifiedAt": "2026-09-11"
+              },
+              "cacheReadPerMtok": 0.25,
+              "cacheWritePerMtok": 12.5,
+              "cacheWrite1hPerMtok": 20
+            }
+          ]
         }
       ],
       "nativeApi": "anthropic-messages",
@@ -1947,7 +2144,6 @@
               "inputPerMtok": 0.75,
               "outputPerMtok": 3.75,
               "cacheReadPerMtok": 0.075,
-              "cacheWrite1hPerMtok": 0.5,
               "effectiveFrom": "2026-08-13",
               "effectiveUntil": "2027-01-01",
               "source": {
@@ -1962,7 +2158,6 @@
               "inputPerMtok": 1.5,
               "outputPerMtok": 7.5,
               "cacheReadPerMtok": 0.15,
-              "cacheWrite1hPerMtok": 1,
               "effectiveFrom": "2027-01-01",
               "source": {
                 "kind": "provider-official",
@@ -1996,7 +2191,6 @@
               "inputPerMtok": 0.75,
               "outputPerMtok": 3.75,
               "cacheReadPerMtok": 0.075,
-              "cacheWrite1hPerMtok": 0.5,
               "effectiveFrom": "2026-07-21",
               "effectiveUntil": "2027-01-01",
               "source": {
@@ -2011,7 +2205,6 @@
               "inputPerMtok": 1.5,
               "outputPerMtok": 7.5,
               "cacheReadPerMtok": 0.15,
-              "cacheWrite1hPerMtok": 1,
               "effectiveFrom": "2027-01-01",
               "source": {
                 "kind": "provider-official",
@@ -2039,7 +2232,22 @@
           "agents": ["claude-code"],
           "defaults": {
             "supportsFastMode": false
-          }
+          },
+          "referencePrices": [
+            {
+              "currency": "USD",
+              "variant": "standard",
+              "inputPerMtok": 1.5,
+              "outputPerMtok": 9,
+              "cacheReadPerMtok": 0.15,
+              "effectiveFrom": "2026-09-11",
+              "source": {
+                "kind": "provider-official",
+                "url": "https://ai.google.dev/gemini-api/docs/pricing",
+                "verifiedAt": "2026-09-11"
+              }
+            }
+          ]
         }
       ],
       "nativeApi": "google-generative-ai",
@@ -2093,7 +2301,22 @@
           "agents": ["claude-code"],
           "defaults": {
             "supportsFastMode": false
-          }
+          },
+          "referencePrices": [
+            {
+              "currency": "USD",
+              "variant": "standard",
+              "inputPerMtok": 0.3,
+              "outputPerMtok": 2.5,
+              "cacheReadPerMtok": 0.03,
+              "effectiveFrom": "2026-09-11",
+              "source": {
+                "kind": "provider-official",
+                "url": "https://ai.google.dev/gemini-api/docs/pricing",
+                "verifiedAt": "2026-09-11"
+              }
+            }
+          ]
         }
       ],
       "nativeApi": "google-generative-ai",
@@ -2111,7 +2334,22 @@
           "agents": ["claude-code"],
           "defaults": {
             "supportsFastMode": false
-          }
+          },
+          "referencePrices": [
+            {
+              "currency": "USD",
+              "variant": "standard",
+              "inputPerMtok": 0.25,
+              "outputPerMtok": 1.5,
+              "cacheReadPerMtok": 0.025,
+              "effectiveFrom": "2026-09-11",
+              "source": {
+                "kind": "provider-official",
+                "url": "https://ai.google.dev/gemini-api/docs/pricing",
+                "verifiedAt": "2026-09-11"
+              }
+            }
+          ]
         }
       ],
       "nativeApi": "google-generative-ai",
@@ -2198,12 +2436,42 @@
         {
           "providerId": "moonshot-kimi-cn",
           "modelId": "kimi-k2.7-code",
-          "agents": ["claude-code", "codex"]
+          "agents": ["claude-code", "codex"],
+          "referencePrices": [
+            {
+              "currency": "CNY",
+              "variant": "standard",
+              "inputPerMtok": 6.5,
+              "outputPerMtok": 27,
+              "cacheReadPerMtok": 1.3,
+              "effectiveFrom": "2026-09-11",
+              "source": {
+                "kind": "provider-official",
+                "url": "https://platform.kimi.com/docs/pricing/chat-k27-code",
+                "verifiedAt": "2026-09-11"
+              }
+            }
+          ]
         },
         {
           "providerId": "moonshot-kimi-global",
           "modelId": "kimi-k2.7-code",
-          "agents": ["claude-code", "codex"]
+          "agents": ["claude-code", "codex"],
+          "referencePrices": [
+            {
+              "currency": "USD",
+              "variant": "standard",
+              "inputPerMtok": 0.95,
+              "outputPerMtok": 4,
+              "cacheReadPerMtok": 0.19,
+              "effectiveFrom": "2026-09-11",
+              "source": {
+                "kind": "provider-official",
+                "url": "https://platform.kimi.ai/docs/pricing/chat-k27-code",
+                "verifiedAt": "2026-09-11"
+              }
+            }
+          ]
         }
       ],
       "nativeApi": "openai-completions",
@@ -2219,12 +2487,42 @@
         {
           "providerId": "moonshot-kimi-cn",
           "modelId": "kimi-k2.7-code-highspeed",
-          "agents": ["claude-code", "codex"]
+          "agents": ["claude-code", "codex"],
+          "referencePrices": [
+            {
+              "currency": "CNY",
+              "variant": "standard",
+              "inputPerMtok": 13,
+              "outputPerMtok": 54,
+              "cacheReadPerMtok": 2.6,
+              "effectiveFrom": "2026-09-11",
+              "source": {
+                "kind": "provider-official",
+                "url": "https://platform.kimi.com/docs/pricing/chat-k27-code",
+                "verifiedAt": "2026-09-11"
+              }
+            }
+          ]
         },
         {
           "providerId": "moonshot-kimi-global",
           "modelId": "kimi-k2.7-code-highspeed",
-          "agents": ["claude-code", "codex"]
+          "agents": ["claude-code", "codex"],
+          "referencePrices": [
+            {
+              "currency": "USD",
+              "variant": "standard",
+              "inputPerMtok": 1.9,
+              "outputPerMtok": 8,
+              "cacheReadPerMtok": 0.38,
+              "effectiveFrom": "2026-09-11",
+              "source": {
+                "kind": "provider-official",
+                "url": "https://platform.kimi.ai/docs/pricing/chat-k27-code",
+                "verifiedAt": "2026-09-11"
+              }
+            }
+          ]
         }
       ],
       "nativeApi": "openai-completions",
@@ -2242,7 +2540,22 @@
           "agents": ["claude-code"],
           "defaults": {
             "supportsFastMode": false
-          }
+          },
+          "referencePrices": [
+            {
+              "currency": "USD",
+              "variant": "standard",
+              "inputPerMtok": 0.95,
+              "outputPerMtok": 4,
+              "cacheReadPerMtok": 0.16,
+              "effectiveFrom": "2026-09-11",
+              "source": {
+                "kind": "provider-official",
+                "url": "https://platform.kimi.ai/docs/pricing/chat-k26",
+                "verifiedAt": "2026-09-11"
+              }
+            }
+          ]
         }
       ],
       "nativeApi": "openai-completions",
@@ -2260,7 +2573,22 @@
           "agents": ["claude-code"],
           "defaults": {
             "supportsFastMode": false
-          }
+          },
+          "referencePrices": [
+            {
+              "currency": "USD",
+              "variant": "standard",
+              "inputPerMtok": 1.4,
+              "outputPerMtok": 4.4,
+              "cacheReadPerMtok": 0.26,
+              "effectiveFrom": "2026-09-11",
+              "source": {
+                "kind": "provider-official",
+                "url": "https://docs.z.ai/guides/overview/pricing",
+                "verifiedAt": "2026-09-11"
+              }
+            }
+          ]
         }
       ],
       "nativeApi": "openai-completions",
@@ -2282,7 +2610,22 @@
           "agents": ["claude-code", "codex"],
           "defaults": {
             "supportsFastMode": false
-          }
+          },
+          "referencePrices": [
+            {
+              "currency": "USD",
+              "variant": "standard",
+              "inputPerMtok": 1.4,
+              "outputPerMtok": 4.4,
+              "cacheReadPerMtok": 0.26,
+              "effectiveFrom": "2026-09-11",
+              "source": {
+                "kind": "provider-official",
+                "url": "https://docs.z.ai/guides/overview/pricing",
+                "verifiedAt": "2026-09-11"
+              }
+            }
+          ]
         }
       ],
       "nativeApi": "openai-completions",
@@ -2300,7 +2643,22 @@
           "agents": ["claude-code", "codex"],
           "defaults": {
             "supportsFastMode": false
-          }
+          },
+          "referencePrices": [
+            {
+              "currency": "USD",
+              "variant": "standard",
+              "inputPerMtok": 1.4,
+              "outputPerMtok": 4.4,
+              "cacheReadPerMtok": 0.26,
+              "effectiveFrom": "2026-09-11",
+              "source": {
+                "kind": "provider-official",
+                "url": "https://docs.z.ai/guides/overview/pricing",
+                "verifiedAt": "2026-09-11"
+              }
+            }
+          ]
         }
       ],
       "nativeApi": "openai-completions",
@@ -2319,7 +2677,22 @@
         {
           "providerId": "zhipu-glm-global",
           "modelId": "glm-5.3-flash",
-          "agents": ["claude-code", "codex"]
+          "agents": ["claude-code", "codex"],
+          "referencePrices": [
+            {
+              "currency": "USD",
+              "variant": "standard",
+              "inputPerMtok": 0.15,
+              "outputPerMtok": 0.5,
+              "cacheReadPerMtok": 0.03,
+              "effectiveFrom": "2026-09-11",
+              "source": {
+                "kind": "provider-official",
+                "url": "https://docs.z.ai/guides/overview/pricing",
+                "verifiedAt": "2026-09-11"
+              }
+            }
+          ]
         }
       ],
       "nativeApi": "openai-completions",
@@ -2333,7 +2706,26 @@
         {
           "providerId": "xd",
           "modelId": "z-ai/glm-5.3-flash",
-          "agents": ["claude-code", "codex"]
+          "agents": ["claude-code", "codex"],
+          "defaults": {
+            "efforts": ["low", "medium", "high", "max"],
+            "defaultEffort": "medium"
+          },
+          "referencePrices": [
+            {
+              "currency": "USD",
+              "variant": "standard",
+              "inputPerMtok": 0.15,
+              "outputPerMtok": 0.5,
+              "cacheReadPerMtok": 0.03,
+              "effectiveFrom": "2026-09-11",
+              "source": {
+                "kind": "provider-official",
+                "url": "https://docs.z.ai/guides/overview/pricing",
+                "verifiedAt": "2026-09-11"
+              }
+            }
+          ]
         }
       ],
       "nativeApi": "openai-completions",
@@ -2429,6 +2821,20 @@
                 "kind": "provider-official",
                 "url": "https://api-docs.deepseek.com/quick_start/pricing",
                 "verifiedAt": "2026-08-16"
+              },
+              "effectiveUntil": "2026-09-11"
+            },
+            {
+              "currency": "USD",
+              "variant": "standard",
+              "inputPerMtok": 0.3,
+              "outputPerMtok": 1.2,
+              "cacheReadPerMtok": 0.006,
+              "effectiveFrom": "2026-09-11",
+              "source": {
+                "kind": "provider-official",
+                "url": "https://api-docs.deepseek.com/quick_start/pricing",
+                "verifiedAt": "2026-09-11"
               }
             }
           ],
@@ -2466,6 +2872,20 @@
                 "kind": "provider-official",
                 "url": "https://api-docs.deepseek.com/quick_start/pricing",
                 "verifiedAt": "2026-08-16"
+              },
+              "effectiveUntil": "2026-09-11"
+            },
+            {
+              "currency": "USD",
+              "variant": "standard",
+              "inputPerMtok": 0.3,
+              "outputPerMtok": 1.2,
+              "cacheReadPerMtok": 0.006,
+              "effectiveFrom": "2026-09-11",
+              "source": {
+                "kind": "provider-official",
+                "url": "https://api-docs.deepseek.com/quick_start/pricing",
+                "verifiedAt": "2026-09-11"
               }
             }
           ],
@@ -2563,12 +2983,44 @@
         {
           "providerId": "minimax-cn",
           "modelId": "MiniMax-M2.7",
-          "agents": ["claude-code", "codex"]
+          "agents": ["claude-code", "codex"],
+          "referencePrices": [
+            {
+              "currency": "CNY",
+              "variant": "standard",
+              "inputPerMtok": 2.1,
+              "outputPerMtok": 8.4,
+              "cacheReadPerMtok": 0.42,
+              "cacheWritePerMtok": 2.625,
+              "effectiveFrom": "2026-09-11",
+              "source": {
+                "kind": "provider-official",
+                "url": "https://platform.minimaxi.com/docs/guides/pricing-paygo",
+                "verifiedAt": "2026-09-11"
+              }
+            }
+          ]
         },
         {
           "providerId": "minimax-global",
           "modelId": "MiniMax-M2.7",
-          "agents": ["claude-code", "codex"]
+          "agents": ["claude-code", "codex"],
+          "referencePrices": [
+            {
+              "currency": "USD",
+              "variant": "standard",
+              "inputPerMtok": 0.3,
+              "outputPerMtok": 1.2,
+              "cacheReadPerMtok": 0.06,
+              "cacheWritePerMtok": 0.375,
+              "effectiveFrom": "2026-09-11",
+              "source": {
+                "kind": "provider-official",
+                "url": "https://platform.minimax.io/docs/guides/pricing-paygo",
+                "verifiedAt": "2026-09-11"
+              }
+            }
+          ]
         }
       ],
       "nativeApi": "anthropic-messages",
@@ -2584,12 +3036,44 @@
         {
           "providerId": "minimax-cn",
           "modelId": "MiniMax-M2.7-highspeed",
-          "agents": ["claude-code", "codex"]
+          "agents": ["claude-code", "codex"],
+          "referencePrices": [
+            {
+              "currency": "CNY",
+              "variant": "standard",
+              "inputPerMtok": 4.2,
+              "outputPerMtok": 16.8,
+              "cacheReadPerMtok": 0.42,
+              "cacheWritePerMtok": 2.625,
+              "effectiveFrom": "2026-09-11",
+              "source": {
+                "kind": "provider-official",
+                "url": "https://platform.minimaxi.com/docs/guides/pricing-paygo",
+                "verifiedAt": "2026-09-11"
+              }
+            }
+          ]
         },
         {
           "providerId": "minimax-global",
           "modelId": "MiniMax-M2.7-highspeed",
-          "agents": ["claude-code", "codex"]
+          "agents": ["claude-code", "codex"],
+          "referencePrices": [
+            {
+              "currency": "USD",
+              "variant": "standard",
+              "inputPerMtok": 0.6,
+              "outputPerMtok": 2.4,
+              "cacheReadPerMtok": 0.06,
+              "cacheWritePerMtok": 0.375,
+              "effectiveFrom": "2026-09-11",
+              "source": {
+                "kind": "provider-official",
+                "url": "https://platform.minimax.io/docs/guides/pricing-paygo",
+                "verifiedAt": "2026-09-11"
+              }
+            }
+          ]
         }
       ],
       "nativeApi": "anthropic-messages",
@@ -2605,12 +3089,44 @@
         {
           "providerId": "minimax-cn",
           "modelId": "MiniMax-M2.5",
-          "agents": ["claude-code", "codex"]
+          "agents": ["claude-code", "codex"],
+          "referencePrices": [
+            {
+              "currency": "CNY",
+              "variant": "standard",
+              "inputPerMtok": 2.1,
+              "outputPerMtok": 8.4,
+              "cacheReadPerMtok": 0.21,
+              "cacheWritePerMtok": 2.625,
+              "effectiveFrom": "2026-09-11",
+              "source": {
+                "kind": "provider-official",
+                "url": "https://platform.minimaxi.com/docs/guides/pricing-paygo",
+                "verifiedAt": "2026-09-11"
+              }
+            }
+          ]
         },
         {
           "providerId": "minimax-global",
           "modelId": "MiniMax-M2.5",
-          "agents": ["claude-code", "codex"]
+          "agents": ["claude-code", "codex"],
+          "referencePrices": [
+            {
+              "currency": "USD",
+              "variant": "standard",
+              "inputPerMtok": 0.3,
+              "outputPerMtok": 1.2,
+              "cacheReadPerMtok": 0.03,
+              "cacheWritePerMtok": 0.375,
+              "effectiveFrom": "2026-09-11",
+              "source": {
+                "kind": "provider-official",
+                "url": "https://platform.minimax.io/docs/guides/pricing-paygo",
+                "verifiedAt": "2026-09-11"
+              }
+            }
+          ]
         }
       ],
       "nativeApi": "anthropic-messages",
@@ -2626,12 +3142,44 @@
         {
           "providerId": "minimax-cn",
           "modelId": "MiniMax-M2.5-highspeed",
-          "agents": ["claude-code", "codex"]
+          "agents": ["claude-code", "codex"],
+          "referencePrices": [
+            {
+              "currency": "CNY",
+              "variant": "standard",
+              "inputPerMtok": 4.2,
+              "outputPerMtok": 16.8,
+              "cacheReadPerMtok": 0.21,
+              "cacheWritePerMtok": 2.625,
+              "effectiveFrom": "2026-09-11",
+              "source": {
+                "kind": "provider-official",
+                "url": "https://platform.minimaxi.com/docs/guides/pricing-paygo",
+                "verifiedAt": "2026-09-11"
+              }
+            }
+          ]
         },
         {
           "providerId": "minimax-global",
           "modelId": "MiniMax-M2.5-highspeed",
-          "agents": ["claude-code", "codex"]
+          "agents": ["claude-code", "codex"],
+          "referencePrices": [
+            {
+              "currency": "USD",
+              "variant": "standard",
+              "inputPerMtok": 0.6,
+              "outputPerMtok": 2.4,
+              "cacheReadPerMtok": 0.03,
+              "cacheWritePerMtok": 0.375,
+              "effectiveFrom": "2026-09-11",
+              "source": {
+                "kind": "provider-official",
+                "url": "https://platform.minimax.io/docs/guides/pricing-paygo",
+                "verifiedAt": "2026-09-11"
+              }
+            }
+          ]
         }
       ],
       "nativeApi": "anthropic-messages",
@@ -2647,12 +3195,44 @@
         {
           "providerId": "minimax-cn",
           "modelId": "MiniMax-M2.1",
-          "agents": ["claude-code", "codex"]
+          "agents": ["claude-code", "codex"],
+          "referencePrices": [
+            {
+              "currency": "CNY",
+              "variant": "standard",
+              "inputPerMtok": 2.1,
+              "outputPerMtok": 8.4,
+              "cacheReadPerMtok": 0.21,
+              "cacheWritePerMtok": 2.625,
+              "effectiveFrom": "2026-09-11",
+              "source": {
+                "kind": "provider-official",
+                "url": "https://platform.minimaxi.com/docs/guides/pricing-paygo",
+                "verifiedAt": "2026-09-11"
+              }
+            }
+          ]
         },
         {
           "providerId": "minimax-global",
           "modelId": "MiniMax-M2.1",
-          "agents": ["claude-code", "codex"]
+          "agents": ["claude-code", "codex"],
+          "referencePrices": [
+            {
+              "currency": "USD",
+              "variant": "standard",
+              "inputPerMtok": 0.3,
+              "outputPerMtok": 1.2,
+              "cacheReadPerMtok": 0.03,
+              "cacheWritePerMtok": 0.375,
+              "effectiveFrom": "2026-09-11",
+              "source": {
+                "kind": "provider-official",
+                "url": "https://platform.minimax.io/docs/guides/pricing-paygo",
+                "verifiedAt": "2026-09-11"
+              }
+            }
+          ]
         }
       ],
       "nativeApi": "anthropic-messages",
@@ -2668,12 +3248,44 @@
         {
           "providerId": "minimax-cn",
           "modelId": "MiniMax-M2.1-highspeed",
-          "agents": ["claude-code", "codex"]
+          "agents": ["claude-code", "codex"],
+          "referencePrices": [
+            {
+              "currency": "CNY",
+              "variant": "standard",
+              "inputPerMtok": 4.2,
+              "outputPerMtok": 16.8,
+              "cacheReadPerMtok": 0.21,
+              "cacheWritePerMtok": 2.625,
+              "effectiveFrom": "2026-09-11",
+              "source": {
+                "kind": "provider-official",
+                "url": "https://platform.minimaxi.com/docs/guides/pricing-paygo",
+                "verifiedAt": "2026-09-11"
+              }
+            }
+          ]
         },
         {
           "providerId": "minimax-global",
           "modelId": "MiniMax-M2.1-highspeed",
-          "agents": ["claude-code", "codex"]
+          "agents": ["claude-code", "codex"],
+          "referencePrices": [
+            {
+              "currency": "USD",
+              "variant": "standard",
+              "inputPerMtok": 0.6,
+              "outputPerMtok": 2.4,
+              "cacheReadPerMtok": 0.03,
+              "cacheWritePerMtok": 0.375,
+              "effectiveFrom": "2026-09-11",
+              "source": {
+                "kind": "provider-official",
+                "url": "https://platform.minimax.io/docs/guides/pricing-paygo",
+                "verifiedAt": "2026-09-11"
+              }
+            }
+          ]
         }
       ],
       "nativeApi": "anthropic-messages",
@@ -2689,12 +3301,44 @@
         {
           "providerId": "minimax-cn",
           "modelId": "MiniMax-M2",
-          "agents": ["claude-code", "codex"]
+          "agents": ["claude-code", "codex"],
+          "referencePrices": [
+            {
+              "currency": "CNY",
+              "variant": "standard",
+              "inputPerMtok": 2.1,
+              "outputPerMtok": 8.4,
+              "cacheReadPerMtok": 0.21,
+              "cacheWritePerMtok": 2.625,
+              "effectiveFrom": "2026-09-11",
+              "source": {
+                "kind": "provider-official",
+                "url": "https://platform.minimaxi.com/docs/guides/pricing-paygo",
+                "verifiedAt": "2026-09-11"
+              }
+            }
+          ]
         },
         {
           "providerId": "minimax-global",
           "modelId": "MiniMax-M2",
-          "agents": ["claude-code", "codex"]
+          "agents": ["claude-code", "codex"],
+          "referencePrices": [
+            {
+              "currency": "USD",
+              "variant": "standard",
+              "inputPerMtok": 0.3,
+              "outputPerMtok": 1.2,
+              "cacheReadPerMtok": 0.03,
+              "cacheWritePerMtok": 0.375,
+              "effectiveFrom": "2026-09-11",
+              "source": {
+                "kind": "provider-official",
+                "url": "https://platform.minimax.io/docs/guides/pricing-paygo",
+                "verifiedAt": "2026-09-11"
+              }
+            }
+          ]
         }
       ],
       "nativeApi": "anthropic-messages",
@@ -2711,7 +3355,22 @@
           "agents": ["claude-code", "codex"],
           "defaults": {
             "supportsFastMode": false
-          }
+          },
+          "referencePrices": [
+            {
+              "currency": "CNY",
+              "variant": "standard",
+              "inputPerMtok": 20,
+              "outputPerMtok": 100,
+              "cacheReadPerMtok": 2,
+              "effectiveFrom": "2026-09-11",
+              "source": {
+                "kind": "provider-official",
+                "url": "https://platform.kimi.com/docs/pricing/chat-k3",
+                "verifiedAt": "2026-09-11"
+              }
+            }
+          ]
         },
         {
           "providerId": "moonshot-kimi-global",
@@ -2719,7 +3378,22 @@
           "agents": ["claude-code", "codex"],
           "defaults": {
             "supportsFastMode": false
-          }
+          },
+          "referencePrices": [
+            {
+              "currency": "USD",
+              "variant": "standard",
+              "inputPerMtok": 3,
+              "outputPerMtok": 15,
+              "cacheReadPerMtok": 0.3,
+              "effectiveFrom": "2026-09-11",
+              "source": {
+                "kind": "provider-official",
+                "url": "https://platform.kimi.ai/docs/pricing/chat-k3",
+                "verifiedAt": "2026-09-11"
+              }
+            }
+          ]
         }
       ],
       "nativeApi": "openai-completions",
@@ -2792,7 +3466,21 @@
         {
           "providerId": "aliyun-model-studio-cn",
           "modelId": "qwen3.8-flash",
-          "agents": ["claude-code", "codex"]
+          "agents": ["claude-code", "codex"],
+          "referencePrices": [
+            {
+              "currency": "CNY",
+              "variant": "standard",
+              "inputPerMtok": 0.8,
+              "outputPerMtok": 2.7,
+              "effectiveFrom": "2026-09-11",
+              "source": {
+                "kind": "provider-official",
+                "url": "https://help.aliyun.com/zh/model-studio/model-pricing",
+                "verifiedAt": "2026-09-11"
+              }
+            }
+          ]
         },
         {
           "providerId": "aliyun-model-studio-global",
@@ -2909,7 +3597,22 @@
           "agents": ["claude-code", "codex"],
           "defaults": {
             "supportsFastMode": false
-          }
+          },
+          "referencePrices": [
+            {
+              "currency": "USD",
+              "variant": "standard",
+              "inputPerMtok": 3,
+              "outputPerMtok": 15,
+              "cacheReadPerMtok": 0.3,
+              "effectiveFrom": "2026-09-11",
+              "source": {
+                "kind": "provider-official",
+                "url": "https://platform.kimi.ai/docs/pricing/chat-k3",
+                "verifiedAt": "2026-09-11"
+              }
+            }
+          ]
         },
         {
           "providerId": "xd",
@@ -2917,7 +3620,22 @@
           "agents": ["claude-code", "codex"],
           "defaults": {
             "supportsFastMode": false
-          }
+          },
+          "referencePrices": [
+            {
+              "currency": "USD",
+              "variant": "standard",
+              "inputPerMtok": 3,
+              "outputPerMtok": 15,
+              "cacheReadPerMtok": 0.3,
+              "effectiveFrom": "2026-09-11",
+              "source": {
+                "kind": "provider-official",
+                "url": "https://platform.kimi.ai/docs/pricing/chat-k3",
+                "verifiedAt": "2026-09-11"
+              }
+            }
+          ]
         }
       ],
       "nativeApi": "openai-completions",
@@ -3456,7 +4174,8 @@
       "defaults": {
         "maxOutputTokens": 128000,
         "defaultEffort": "medium",
-        "name": "GPT-5.6-Sol"
+        "name": "GPT-5.6-Sol",
+        "efforts": ["low", "medium", "high", "xhigh", "max"]
       }
     },
     {
@@ -3484,7 +4203,9 @@
         "codex/gpt-5.6-luna"
       ],
       "defaults": {
-        "name": "GPT-5.6-Luna"
+        "name": "GPT-5.6-Luna",
+        "efforts": ["low", "medium", "high", "xhigh", "max"],
+        "defaultEffort": "medium"
       }
     },
     {
@@ -3531,8 +4252,8 @@
         "group": "gpt",
         "contextWindow": 1050000,
         "maxOutputTokens": 128000,
-        "efforts": [],
-        "defaultEffort": null
+        "efforts": ["medium", "high", "xhigh"],
+        "defaultEffort": "medium"
       }
     },
     {
@@ -3544,8 +4265,8 @@
         "group": "gpt",
         "contextWindow": 1050000,
         "maxOutputTokens": 128000,
-        "efforts": [],
-        "defaultEffort": null
+        "efforts": ["medium", "high", "xhigh"],
+        "defaultEffort": "medium"
       }
     },
     {
@@ -3917,7 +4638,9 @@
         "description": "Google Gemini 3.1 Flash-Lite — efficient multimodal model for large-scale tasks",
         "group": "google",
         "contextWindow": 1000000,
-        "maxOutputTokens": 65536
+        "maxOutputTokens": 65536,
+        "efforts": ["minimal", "low", "medium", "high"],
+        "defaultEffort": "medium"
       }
     },
     {
@@ -4046,7 +4769,9 @@
         "description": "Zhipu GLM-5.3-Flash native multimodal coding model; 1M context",
         "group": "china",
         "contextWindow": 1000000,
-        "maxOutputTokens": 131072
+        "maxOutputTokens": 131072,
+        "efforts": ["low", "high", "max"],
+        "defaultEffort": "high"
       }
     },
     {
@@ -4058,7 +4783,8 @@
         "group": "china",
         "contextWindow": 1000000,
         "maxOutputTokens": 131072,
-        "defaultEffort": "medium"
+        "defaultEffort": "high",
+        "efforts": ["low", "high", "max"]
       }
     },
     {
@@ -4227,7 +4953,8 @@
         "group": "china",
         "contextWindow": 991808,
         "maxOutputTokens": 131072,
-        "efforts": []
+        "efforts": ["low", "medium", "xhigh"],
+        "defaultEffort": "medium"
       }
     },
     {
@@ -4359,7 +5086,9 @@
       "id": "qwen/qwen3.8-flash-next",
       "aliases": [],
       "defaults": {
-        "name": "Qwen3.8 Flash-Next"
+        "name": "Qwen3.8 Flash-Next",
+        "efforts": ["low", "medium", "xhigh"],
+        "defaultEffort": "medium"
       }
     },
     {

--- a/packages/model-providers/src/__tests__/modelRegistryConsistency.test.ts
+++ b/packages/model-providers/src/__tests__/modelRegistryConsistency.test.ts
@@ -1,4 +1,7 @@
-import { expandedRegistryEntries } from "../modelMetadataLayers.js";
+import {
+  expandedRegistryEntries,
+  resolveModelMetadata,
+} from "../modelMetadataLayers.js";
 import { describe, expect, it } from "vitest";
 
 import modelRegistryJson from "../../catalog/model-registry.json" with { type: "json" };
@@ -54,6 +57,22 @@ function bandGroups(route: ModelRegistryRoute): ModelReferencePrice[][] {
 }
 
 describe("model registry data consistency", () => {
+  it("keeps the XD GLM middle-effort intent separate from public native tiers", () => {
+    expect(
+      resolveModelMetadata(rawRegistry, "new-supplier", "glm-5.3-flash"),
+    ).toMatchObject({ efforts: ["low", "high", "max"], defaultEffort: "high" });
+    expect(
+      resolveModelMetadata(rawRegistry, "xd", "z-ai/glm-5.3-flash", {
+        efforts: ["low", "medium", "high", "max"],
+      }),
+    ).toMatchObject({ defaultEffort: "medium" });
+    expect(
+      resolveModelMetadata(rawRegistry, "xd", "z-ai/glm-5.3-flash", {
+        efforts: [],
+      }),
+    ).toMatchObject({ efforts: [], defaultEffort: null });
+  });
+
   it("window / output declarations are positive and mutually sane", () => {
     for (const entry of registry.models) {
       if (entry.contextWindow !== undefined) {
@@ -170,6 +189,17 @@ describe("model registry data consistency", () => {
         for (const group of bandGroups(route)) {
           const top = group[group.length - 1]!;
           if (top.maxInputTokens === undefined) continue;
+          // Cyber's model page and consolidated pricing table disagree on long-input
+          // charges. Keep only the verified short quote; the calculator rejects
+          // requests outside this bound instead of extending that price silently.
+          if (
+            entry.id === "openai/gpt-5.6-cyber" &&
+            route.providerId === "openai"
+          ) {
+            expect(group).toHaveLength(1);
+            expect(top.maxInputTokens).toBe(272_001);
+            continue;
+          }
           for (const agent of route.agents) {
             const window = effectiveWindow(entry, agent);
             if (window === undefined) continue;


### PR DESCRIPTION
## 这次改了什么

### 摘要

补齐公共模型目录的思考档位与官方参考价，并修复 Codex 完成事件漏传缓存写入用量的问题。此前有缓存写入的轮次会少记 token；现在四类用量完整进入汇总和费用计算，缺少单价时继续保留未知费用。

### 变更类型

- [ ] `feat` 新功能
- [x] `fix` 缺陷修复
- [ ] `refactor` / `perf` 重构或性能优化
- [x] `docs` / `test` / `chore` 文档、测试或工程维护
- [ ] 其他：N/A

### 范围

- 关联 Issue / 需求：完善模型基础信息，与服务端目录同步。
- 本 PR 包含：9 个公共条目的思考档位；32 个型号、44 条路由的参考价更新；Codex 缓存写入用量贯通与回归测试。
- 明确不包含：文件改名、XD 实际售价调整、历史账单重算、用户配置迁移。
- 用户可见变化：基础信息与费用估算更完整；公共档位展示仍受实际渠道能力限制，用户显式覆盖优先。
- 是否存在 breaking change：无。完成事件增加可选字段，旧事件兼容。

### UI 变化

- 引用的设计规范：不涉及：只修改目录、计量及 Renderer 类型声明，没有布局、交互或文案改动。

## 怎么验证的

### 自动验证

- 定向回归：model-providers 873、Codex 773、Desktop 费用链路 192 项通过。
- Desktop、maker-core 类型检查通过；文档检查通过。
- `env -u CINDY_AUTH_REGION -u VITE_CINDY_AUTH_REGION corepack pnpm test:unit:related`：全部选中工作区通过（Desktop、Mobile、maker-core、model-providers、lizi-mcps、orca-workflow）。
- 经 Git skill runner 执行全量单测：只有宿主 CN 区域变量导致的 9 项默认 Global 测试失败；清除变量后两文件 47 项通过，根相关门禁全绿；没有修改测试来规避失败。
- 整合最新 main 后重跑 Codex 773 项、Desktop 费用链 192 项及类型检查。

### 手工验证

核对官方价表与两区域公开目录；服务端和客户端共有路由的参考价一致。没有付费调用。

### 未执行的验证

未部署、未用生产账单或实际客户端运行验收；XD 缓存写入实价缺项及不明确的计费边界保留未知。

## 风险

### 风险分类

- [ ] 无已知风险
- [ ] SQLite / migration
- [ ] system prompt
- [x] 协议兼容
- [ ] 权限 / 安全 / 用户数据
- [ ] 存量插件兼容（批准状态 / 指纹 / manifest 校验 / 安装布局 / 包格式）
- [ ] 原生层 / fingerprint / OTA
- [ ] 跨平台差异
- [x] 其他：官方参考价不等于渠道实际扣款。

### 影响与回滚

- 影响范围：公共目录和后续 Codex 用量汇总。可选 cacheCreationTokens 缺省按零兼容；分段四桶一致才计价，费用补写不重复累计 token。
- 回滚 / 降级方式：撤回客户端改动；目录纠错必须发布更高 revision 的修正快照。保留客户端既有媒体扩展，未把它混入服务端 V4 下发。

### 提交前检查

- [x] 已 review 完整 diff
- [x] 每个 commit 都带 DCO 签名（git commit -s）
- [x] UI 改动已在「UI 变化」注明引用的设计规范章节（N/A：无 UI 改动）
- [x] 未提交凭证、令牌或授权文件
- [x] 已核对受影响的文档，行为变化涉及的旧结论已同步修订（不涉及则无需修改文档）
- [x] 已确认测试结果或说明未执行原因

服务端配套 PR：https://github.com/xindong/cindy-server/pull/634 。两仓共有模型 route 一致，保留已有客户端媒体扩展差异。
