### PR TITLE
fix(pi): 统一过滤扩展不兼容的 UI 请求

### DIFF
--- a/apps/desktop/src/main/maker-host/__tests__/pi-package-compatibility.test.ts
+++ b/apps/desktop/src/main/maker-host/__tests__/pi-package-compatibility.test.ts
@@ -72,6 +72,63 @@ describe('Pi extension compatibility parser', () => {
     expect(result.compatibilityIssues).toEqual([]);
   });
 
+  it('allows native theme access while reporting theme switching and ignored RPC display methods', async () => {
+    const pkg = await makePackage({
+      'index.ts': `
+        export default function setup(pi: any) {
+          pi.on('session_start', (_event, ctx) => {
+            ctx.ui.notify(ctx.ui.theme.fg('accent', 'Ready'));
+          });
+        }
+      `,
+    });
+    await expect(analyzePiExtensionCompatibility(pkg.entry, pkg.root)).resolves.toMatchObject({
+      compatibility: 'supported', compatibilityIssues: [], detectedApis: ['notify', 'theme'],
+    });
+    await fs.writeFile(pkg.entry, `
+      export default function setup(pi: any) {
+        pi.on('session_start', (_event, ctx) => {
+          ctx.ui.setStatus('key', 'status');
+          ctx.ui.setWidget('key', ['line']);
+          ctx.ui.setTitle('title');
+          ctx.ui.setEditorText('text');
+          ctx.ui.pasteToEditor('text');
+          ctx.ui.setTheme('light');
+        });
+      }
+    `);
+    await expect(analyzePiExtensionCompatibility(pkg.entry, pkg.root)).resolves.toMatchObject({
+      compatibility: 'partial',
+      compatibilityIssues: ['editor-integration', 'status-display', 'terminal-title', 'theme-control', 'widgets'],
+      detectedApis: ['pasteToEditor', 'setEditorText', 'setStatus', 'setTheme', 'setTitle', 'setWidget'],
+    });
+  });
+
+  it('reports explicit timed dialogs in Settings but not TUI-only timers', async () => {
+    const pkg = await makePackage({
+      'index.ts': `
+        export default function setup(pi: any) {
+          pi.on('session_start', async (_event, ctx) => {
+            if (ctx.mode === 'tui') await ctx.ui.confirm('TUI', '', { timeout: 1000 });
+            await ctx.ui.select('Choose', ['a']);
+          });
+        }
+      `,
+    });
+    expect((await analyzePiExtensionCompatibility(pkg.entry, pkg.root)).compatibilityIssues).toEqual([]);
+    await fs.writeFile(pkg.entry, `
+      export default function setup(pi: any) {
+        pi.on('session_start', async (_event, ctx) => {
+          const confirm = ctx.ui.confirm;
+          await confirm('Confirm', '', { timeout: 1000 });
+        });
+      }
+    `);
+    await expect(analyzePiExtensionCompatibility(pkg.entry, pkg.root)).resolves.toMatchObject({
+      compatibility: 'partial', compatibilityIssues: ['interactive-dialogs'], detectedApis: ['confirm'],
+    });
+  });
+
   it('ignores comments and string literals that only mention Pi UI APIs', async () => {
     const pkg = await makePackage({
       'index.ts': `
@@ -137,7 +194,6 @@ describe('Pi extension compatibility parser', () => {
         'editor-integration',
         'status-display',
         'terminal-input',
-        'theme-control',
         'tui-rendering',
       ],
       detectedApis: [

--- a/apps/desktop/src/main/maker-host/pi-package-compatibility.ts
+++ b/apps/desktop/src/main/maker-host/pi-package-compatibility.ts
@@ -7,6 +7,7 @@
  * that arbitrary third-party code is fully compatible or safe.
  */
 
+import { PI_EXTENSION_UI_CAPABILITIES } from '@cindy/maker-core/pi-extension-ui';
 import { parse } from '@babel/parser';
 import { createRequire } from 'node:module';
 import path from 'node:path';
@@ -54,48 +55,9 @@ interface SemverApi {
 
 const semver = createRequire(import.meta.url)('semver') as SemverApi;
 
-const ISSUE_BY_API: Partial<Record<PiExtensionUiApi, PiPackageCompatibilityIssue>> = {
-  setStatus: 'status-display',
-  setWorkingMessage: 'status-display',
-  setWorkingVisible: 'status-display',
-  setWorkingIndicator: 'status-display',
-  setHiddenThinkingLabel: 'status-display',
-  setWidget: 'widgets',
-  setTitle: 'terminal-title',
-  setEditorText: 'editor-integration',
-  getEditorText: 'editor-integration',
-  pasteToEditor: 'editor-integration',
-  getEditorComponent: 'editor-integration',
-  addAutocompleteProvider: 'editor-integration',
-  setEditorComponent: 'editor-integration',
-  setFooter: 'tui-layout',
-  setHeader: 'tui-layout',
-  setToolsExpanded: 'tui-layout',
-  getToolsExpanded: 'tui-layout',
-  custom: 'custom-ui',
-  getAllThemes: 'theme-control',
-  getTheme: 'theme-control',
-  setTheme: 'theme-control',
-  theme: 'theme-control',
-  onTerminalInput: 'terminal-input',
-  registerShortcut: 'tui-rendering',
-  registerFlag: 'cli-flags',
-  registerMessageRenderer: 'tui-rendering',
-  registerMarkdownTransformer: 'tui-rendering',
-  registerEntryRenderer: 'tui-rendering',
-};
-
-const KNOWN_UI_APIS = new Set<PiExtensionUiApi>([
-  ...(Object.keys(ISSUE_BY_API) as PiExtensionUiApi[]),
-  // RPC exposes these through extension_ui_request. Cindy maps dialogs onto
-  // its cross-device question card and presents notifications in the task
-  // transcript, so they are adapted instead of merely tolerated.
-  'select',
-  'confirm',
-  'input',
-  'editor',
-  'notify',
-]);
+const KNOWN_UI_APIS = new Set<PiExtensionUiApi>(
+  Object.keys(PI_EXTENSION_UI_CAPABILITIES) as PiExtensionUiApi[],
+);
 
 type AstNode = {
   type: string;
@@ -385,10 +347,11 @@ function modeComparison(node: unknown, contextBindings: Set<string>): 'true' | '
   return trueInTui ? 'true' : 'false';
 }
 
-function collectDetectedApis(root: AstNode): Set<PiExtensionUiApi> {
+function collectDetectedApis(root: AstNode): { apis: Set<PiExtensionUiApi>; timedDialog: boolean } {
   const { contextBindings, extensionApiBindings, uiBindings, methodBindings } =
     collectBindings(root);
   const detected = new Set<PiExtensionUiApi>();
+  let timedDialog = false;
 
   const visit = (node: AstNode, tuiOnly: boolean): void => {
     if (node.type === 'IfStatement' && isNode(node.test) && isNode(node.consequent)) {
@@ -434,6 +397,22 @@ function collectDetectedApis(root: AstNode): Set<PiExtensionUiApi> {
         const method = member.property as PiExtensionUiApi;
         if (KNOWN_UI_APIS.has(method)) detected.add(method);
       }
+      const calledUiApi = boundMethod ?? (
+        member && isUiExpression(member.object, contextBindings, uiBindings)
+          ? member.property as PiExtensionUiApi : undefined
+      );
+      // Pi's editor(title, prefill) has no timeout options argument.
+      if (calledUiApi && calledUiApi !== 'editor' && KNOWN_UI_APIS.has(calledUiApi)
+        && PI_EXTENSION_UI_CAPABILITIES[calledUiApi].handling === 'dialog') {
+        const options = Array.isArray(node.arguments) ? node.arguments[2] : undefined;
+        if (isNode(options) && options.type === 'ObjectExpression' && Array.isArray(options.properties)) {
+          timedDialog ||= options.properties.some((property) =>
+            isNode(property) && propertyName(property.key) === 'timeout'
+            && isNode(property.value) && property.value.type === 'NumericLiteral'
+            && typeof property.value.value === 'number' && Number.isFinite(property.value.value),
+          );
+        }
+      }
     }
     if (!tuiOnly) {
       const member = memberParts(node);
@@ -449,7 +428,7 @@ function collectDetectedApis(root: AstNode): Set<PiExtensionUiApi> {
   };
 
   visit(root, false);
-  return detected;
+  return { apis: detected, timedDialog };
 }
 
 function collectImports(root: AstNode): string[] {
@@ -575,6 +554,7 @@ export async function analyzePiExtensionCompatibility(
   const detectedApis = new Set<PiExtensionUiApi>();
   let totalBytes = 0;
   let incomplete = false;
+  let timedDialog = false;
   const startedAt = Date.now();
 
   while (queue.length > 0) {
@@ -602,7 +582,9 @@ export async function analyzePiExtensionCompatibility(
       totalBytes += sourceFile.bytes;
       const parsed = parseModule(sourceFile.source);
       if (parsed.recoveredErrors) incomplete = true;
-      for (const api of collectDetectedApis(parsed.root)) detectedApis.add(api);
+      const detected = collectDetectedApis(parsed.root);
+      for (const api of detected.apis) detectedApis.add(api);
+      timedDialog ||= detected.timedDialog;
       for (const specifier of parsed.imports) {
         const resolved = await resolveLocalModule(file, specifier, canonicalRoot);
         if (resolved && !visited.has(resolved)) queue.push(resolved);
@@ -614,14 +596,15 @@ export async function analyzePiExtensionCompatibility(
   }
 
   const apis = [...detectedApis].sort();
-  const issues = [
+  const issues: PiPackageCompatibilityIssue[] = [
     ...new Set(
       apis.flatMap((api) => {
-        const issue = ISSUE_BY_API[api];
+        const issue = PI_EXTENSION_UI_CAPABILITIES[api].issue;
         return issue ? [issue] : [];
       }),
     ),
   ].sort();
+  if (timedDialog) issues.push('interactive-dialogs');
   if (incomplete) issues.push('analysis-incomplete');
   return {
     compatibility: issues.some((issue) => issue !== 'analysis-incomplete')

--- a/apps/desktop/src/renderer/components/settings/__tests__/PiPackagesSection.interactions.test.tsx
+++ b/apps/desktop/src/renderer/components/settings/__tests__/PiPackagesSection.interactions.test.tsx
@@ -198,7 +198,7 @@ describe('PiPackagesSection interaction state machine', () => {
     await waitFor(() => expect((updateButtons[1] as HTMLButtonElement).disabled).toBe(false));
   });
 
-  it('routes install directly into the Main-owned confirmation flow and keeps retry state on failure', async () => {
+  it('installs an extension with compatibility limits without a confirmation dialog and keeps retry state on failure', async () => {
     const firstMutation = deferred<{ available: boolean; packages: PiPackageView[] }>();
     const enabledPackage: PiPackageView = {
       ...packageView(1),

--- a/apps/desktop/src/shared/piPackages.ts
+++ b/apps/desktop/src/shared/piPackages.ts
@@ -1,4 +1,6 @@
 import type { PiPackageCommandDiagnostic } from '@cindy/maker-core';
+import type { PiExtensionUiApi } from '@cindy/maker-core/pi-extension-ui';
+export type { PiExtensionUiApi } from '@cindy/maker-core/pi-extension-ui';
 
 export type PiPackageResourceKind = 'extension' | 'skill' | 'prompt' | 'theme';
 
@@ -18,41 +20,6 @@ export type PiPackageCompatibilityIssue =
   | 'tui-rendering'
   | 'cli-flags'
   | 'analysis-incomplete';
-
-export type PiExtensionUiApi =
-  | 'select'
-  | 'confirm'
-  | 'input'
-  | 'editor'
-  | 'notify'
-  | 'setStatus'
-  | 'setWorkingMessage'
-  | 'setWorkingVisible'
-  | 'setWorkingIndicator'
-  | 'setHiddenThinkingLabel'
-  | 'setWidget'
-  | 'setTitle'
-  | 'setEditorText'
-  | 'getEditorText'
-  | 'pasteToEditor'
-  | 'getEditorComponent'
-  | 'addAutocompleteProvider'
-  | 'setEditorComponent'
-  | 'setFooter'
-  | 'setHeader'
-  | 'setToolsExpanded'
-  | 'getToolsExpanded'
-  | 'custom'
-  | 'getAllThemes'
-  | 'getTheme'
-  | 'setTheme'
-  | 'theme'
-  | 'onTerminalInput'
-  | 'registerShortcut'
-  | 'registerFlag'
-  | 'registerMessageRenderer'
-  | 'registerMarkdownTransformer'
-  | 'registerEntryRenderer';
 
 export interface PiPackageResourceView {
   kind: PiPackageResourceKind;

--- a/docs/dev-rules/pi-extension-ui.md
+++ b/docs/dev-rules/pi-extension-ui.md
@@ -1,0 +1,45 @@
+# Pi 扩展 UI 兼容与安装
+
+2026-09-11：Chris 确认，不兼容的展示能力在 Cindy 中间层统一过滤，兼容信息只放在设置中；
+扩展安装沿用 Pi CLI 体验，显式操作直接执行，不追加扩展专属确认。
+
+## 能力真源
+
+按 Pi v0.84.4 的 [RPC 实现](https://github.com/earendil-works/pi/blob/v0.84.4/packages/coding-agent/src/modes/rpc/rpc-mode.ts)
+及随包 `docs/rpc.md`、`docs/extensions.md` 核对。代码正本为
+`packages/maker-core/src/agents/pi/extension-ui-capabilities.ts`；Desktop 静态兼容分析与
+Pi 运行时分发共用它。更新 Pi 后按整张表核对，不为单一扩展添加例外。
+
+| 能力 | Cindy 行为 |
+| --- | --- |
+| `select` / `confirm` / `input` / `editor` | 保留现有选择卡适配和响应；带有限 `timeout` 的请求取消并回传，避免扩展等待，不输出兼容警告 |
+| `notify` | 保留扩展实际通知、命令结果和错误输出 |
+| `setStatus` / `setWidget` / `setTitle` | RPC 单向展示请求，Cindy 静默忽略，不回传、不写聊天正文 |
+| `setEditorText` / `pasteToEditor` | 上游发出 `set_editor_text`，Cindy 静默忽略，不改写输入框 |
+| `setWorkingMessage` / `setWorkingVisible` / `setWorkingIndicator` / `setHiddenThinkingLabel` | Pi RPC 已不执行；保留原生行为 |
+| `setFooter` / `setHeader` / `setToolsExpanded` / `setEditorComponent` / `addAutocompleteProvider` | Pi RPC 已不执行；保留原生行为 |
+| `getEditorText` / `getToolsExpanded` / `getEditorComponent` | Pi RPC 分别返回空字符串、`false`、`undefined` |
+| `custom` / `onTerminalInput` | Pi RPC 分别返回 `undefined`、空取消函数，不提供终端组件或按键 |
+| `getAllThemes` / `getTheme` / `setTheme` | Pi RPC 分别返回空列表、`undefined`、失败结果；不伪造成功 |
+| `theme` | Pi RPC 提供真实 theme 对象，读取和文字格式化可用，不应判成主题切换不兼容 |
+| `registerShortcut` / `registerMessageRenderer` / `registerMarkdownTransformer` / `registerEntryRenderer` | 保留原生注册，Cindy 不承接终端快捷键和自定义渲染 |
+| `registerFlag` | 保留注册及默认值，Cindy 固定启动参数没有扩展 flag 配置入口 |
+
+Cindy 不修改第三方扩展源码、不将 `ctx.hasUI` 改成 false、不替换 Pi 原生空值或失败结果，
+不因兼容分析停用整个扩展。未知 UI 请求同样不进入聊天正文；私有权限、包管理、子代理
+控制请求仍先经现有处理链，不能被 UI 过滤吞掉。工具执行、命令、事件及消息能力继续交给 Pi。
+
+设置页仍展示按源码发现的 API 限制。显式数字 `timeout` 的对话框列入交互限制；静态扫描
+不能保证发现动态生成的参数或调用，不将“没有发现”视为完整兼容证明。
+
+## 安装与授权
+
+- 设置页点击安装或输入完整 `pi install <source>` 即授权，直接进入已有 Host 安装服务。
+- 安装后默认启用；不因 TUI 限制、分析未知或分析失败再弹确认或要求批准扩展。
+- Agent 自主工具调用沿用通用 Ask / Auto / Full Access；通过后没有第二层 Pi 包审批。
+- Pi 原生命令失败正常反馈，Cindy 分析失败不能改判安装失败。用户已有停用偏好按现有
+  安装／更新语义保留，不借 UI 过滤改动数据或原生资源发现。
+
+现有入口与边界见 [`pi-managed-commands.md`](pi-managed-commands.md) 和
+[`pi-harness.md`](pi-harness.md) §3.1。兼容提醒不得再作为 `text` 事件写回模型对话；
+设置的兼容详情与扩展自己主动调用 `notify` 是不同来源，后者不能按文案删掉。

--- a/docs/dev-rules/pi-harness.md
+++ b/docs/dev-rules/pi-harness.md
@@ -160,6 +160,9 @@ Full access 读/搜/bash 与原生对齐的需求正本见 [`pi-full-access-nati
 Pi CLI 管理入口、内核自更新与旧工具兼容的执行边界见
 [`pi-managed-commands.md`](pi-managed-commands.md)。
 
+扩展 UI 能力清单、RPC 静默过滤与设置兼容提示的统一合同见
+[`pi-extension-ui.md`](pi-extension-ui.md)。
+
 ## 4. 维护不变量(改动时不得破坏)
 
 1. **权限档从严到宽**:`capabilities.permissionModes` 必须 `[ask, auto, bypassPermissions]`

--- a/packages/maker-core/package.json
+++ b/packages/maker-core/package.json
@@ -9,6 +9,7 @@
   "exports": {
     ".": "./src/index.ts",
     "./contacts-sync-worker": "./src/contacts/sync/worker-api.ts",
+    "./pi-extension-ui": "./src/agents/pi/extension-ui-capabilities.ts",
     "./pi-subagent-runs": "./src/agents/pi/pi-subagent-runs.ts"
   },
   "scripts": {

--- a/packages/maker-core/src/agents/pi/__tests__/pi-auto-review-dispatch.test.ts
+++ b/packages/maker-core/src/agents/pi/__tests__/pi-auto-review-dispatch.test.ts
@@ -1356,38 +1356,72 @@ describe('pi auto-review dispatch & spawn config (mocked pi process)', () => {
     }
   });
 
-  it('surfaces Pi UI requests that Cindy cannot safely adapt at runtime', async () => {
+  it('filters unsupported extension UI across runtimes while preserving real notifications', async () => {
+    // Actual RPC wire methods plus defensive TUI/unknown frames. Reopening a
+    // runtime must stay silent too, not merely reset a per-process warning Set.
+    const methods = [
+      'setStatus', 'setWidget', 'setTitle', 'set_editor_text',
+      'setWorkingMessage', 'setWorkingVisible', 'setWorkingIndicator',
+      'setHiddenThinkingLabel', 'setFooter', 'setHeader', 'setToolsExpanded',
+      'getToolsExpanded', 'setEditorText', 'getEditorText', 'pasteToEditor',
+      'setEditorComponent', 'getEditorComponent', 'addAutocompleteProvider',
+      'custom', 'getAllThemes', 'getTheme', 'setTheme', 'theme',
+      'onTerminalInput', 'registerShortcut', 'registerFlag',
+      'registerMessageRenderer', 'registerMarkdownTransformer', 'registerEntryRenderer',
+      'future_display_feature', '__proto__', 'constructor',
+    ];
+    for (let run = 0; run < 2; run += 1) {
+      const handle = await start();
+      const events: Array<Record<string, unknown>> = [];
+      const resolver = vi.fn();
+      handle.setInteractionResolver(resolver);
+      void (async () => {
+        for await (const event of handle.events()) events.push(event as unknown as Record<string, unknown>);
+      })();
+      try {
+        const sentBefore = captured.sent.length;
+        for (const method of methods) {
+          for (let repeat = 0; repeat < 2; repeat += 1) {
+            captured.onEvent!({
+              type: 'extension_ui_request', id: `${run}-${method}-${repeat}`, method,
+              statusText: 'background status', widgetLines: ['background widget'], text: 'editor text',
+            });
+          }
+        }
+        captured.onEvent!({
+          type: 'extension_ui_request', id: `notify-${run}`, method: 'notify', message: 'Extension command result',
+        });
+        await flush();
+        expect(resolver).not.toHaveBeenCalled();
+        expect(captured.sent).toHaveLength(sentBefore);
+        expect(events.filter((event) => event.type === 'text')).toEqual([
+          { type: 'text', data: { text: 'Extension command result', isFinal: false }, source: 'pi' },
+        ]);
+      } finally {
+        await handle.close();
+      }
+    }
+  });
+
+  it('settles timed extension dialogs silently so the extension does not hang', async () => {
     const handle = await start();
     const events: Array<Record<string, unknown>> = [];
+    const resolver = vi.fn();
+    handle.setInteractionResolver(resolver);
     void (async () => {
       for await (const event of handle.events()) events.push(event as unknown as Record<string, unknown>);
     })();
     try {
-      captured.onEvent!({
-        type: 'extension_ui_request',
-        id: 'timed-select',
-        method: 'select',
-        title: 'Pick quickly',
-        options: ['A', 'B'],
-        timeout: 1_000,
-      });
-      expect(await waitForResponse('timed-select')).toMatchObject({
-        cancelled: true,
-      });
-      captured.onEvent!({
-        type: 'extension_ui_request',
-        id: 'status-1',
-        method: 'setStatus',
-      });
-      captured.onEvent!({
-        type: 'extension_ui_request',
-        id: 'status-2',
-        method: 'setStatus',
-      });
+      for (const method of ['select', 'confirm', 'input', 'editor']) {
+        captured.onEvent!({
+          type: 'extension_ui_request', id: `timed-${method}`, method,
+          title: 'Pick quickly', options: ['A', 'B'], timeout: 1_000,
+        });
+        expect(await waitForResponse(`timed-${method}`)).toMatchObject({ cancelled: true });
+      }
       await flush();
-      const notices = events.filter((event) => event.type === 'text');
-      expect(notices.some((event) => JSON.stringify(event).includes('timed select dialog'))).toBe(true);
-      expect(notices.filter((event) => JSON.stringify(event).includes('setStatus'))).toHaveLength(1);
+      expect(resolver).not.toHaveBeenCalled();
+      expect(events.filter((event) => event.type === 'text')).toEqual([]);
     } finally {
       await handle.close();
     }
@@ -1726,7 +1760,7 @@ describe('pi auto-review dispatch & spawn config (mocked pi process)', () => {
     }
   });
 
-  it('deterministically handles an exact pi install user command before prompting the model', async () => {
+  it.each(['ask', 'auto', 'bypassPermissions'] as const)('installs an exact user command without additional confirmation in %s', async (permissionMode) => {
     const mutatePiManagedPackage = vi.fn(async () => ({
       changed: true,
       affectedPackage: {
@@ -1751,16 +1785,20 @@ describe('pi auto-review dispatch & spawn config (mocked pi process)', () => {
     deps.mutatePiManagedPackage = mutatePiManagedPackage;
     deps.onPiManagedPackageMutationSettled = onPiManagedPackageMutationSettled;
     const handle = await new PiAgent(deps).startSession({
+      permissionMode,
       sessionId: 'managed-package-command-session',
       workingDir: cwd,
       model: 'm',
     });
+    const resolver = vi.fn(async () => ({ kind: 'permission' as const, behavior: 'deny' as const }));
+    handle.setInteractionResolver(resolver);
     try {
       captured.requests = [];
       await handle.send(
         { type: 'user', content: 'pi install npm:context-mode' },
         desktopCommandOptions('pi install npm:context-mode'),
       );
+      expect(resolver).not.toHaveBeenCalled();
       expect(mutatePiManagedPackage).toHaveBeenCalledWith({
         action: 'install',
         source: 'npm:context-mode',

--- a/packages/maker-core/src/agents/pi/extension-ui-capabilities.ts
+++ b/packages/maker-core/src/agents/pi/extension-ui-capabilities.ts
@@ -1,0 +1,52 @@
+/**
+ * Pi 0.84.4 RPC UI contract, shared by dispatch and Settings inspection.
+ * Pure display requests are intentionally silent. Native RPC stubs retain
+ * Pi's own return values; we do not rewrite extensions or disable packages.
+ * See docs/dev-rules/pi-extension-ui.md for the upstream capability audit.
+ */
+export const PI_EXTENSION_UI_CAPABILITIES = {
+  select: { handling: 'dialog', issue: null },
+  confirm: { handling: 'dialog', issue: null },
+  input: { handling: 'dialog', issue: null },
+  editor: { handling: 'dialog', issue: null },
+  notify: { handling: 'notification', issue: null },
+  setStatus: { handling: 'ignore', issue: 'status-display' },
+  setWidget: { handling: 'ignore', issue: 'widgets' },
+  setTitle: { handling: 'ignore', issue: 'terminal-title' },
+  setEditorText: { handling: 'ignore', issue: 'editor-integration' },
+  pasteToEditor: { handling: 'ignore', issue: 'editor-integration' },
+  setWorkingMessage: { handling: 'native', issue: 'status-display' },
+  setWorkingVisible: { handling: 'native', issue: 'status-display' },
+  setWorkingIndicator: { handling: 'native', issue: 'status-display' },
+  setHiddenThinkingLabel: { handling: 'native', issue: 'status-display' },
+  getEditorText: { handling: 'native', issue: 'editor-integration' },
+  getEditorComponent: { handling: 'native', issue: 'editor-integration' },
+  addAutocompleteProvider: { handling: 'native', issue: 'editor-integration' },
+  setEditorComponent: { handling: 'native', issue: 'editor-integration' },
+  setFooter: { handling: 'native', issue: 'tui-layout' },
+  setHeader: { handling: 'native', issue: 'tui-layout' },
+  setToolsExpanded: { handling: 'native', issue: 'tui-layout' },
+  getToolsExpanded: { handling: 'native', issue: 'tui-layout' },
+  custom: { handling: 'native', issue: 'custom-ui' },
+  getAllThemes: { handling: 'native', issue: 'theme-control' },
+  getTheme: { handling: 'native', issue: 'theme-control' },
+  setTheme: { handling: 'native', issue: 'theme-control' },
+  // RPC exposes the real theme object; reading/formatting is not switching.
+  theme: { handling: 'native', issue: null },
+  onTerminalInput: { handling: 'native', issue: 'terminal-input' },
+  registerShortcut: { handling: 'native', issue: 'tui-rendering' },
+  registerFlag: { handling: 'native', issue: 'cli-flags' },
+  registerMessageRenderer: { handling: 'native', issue: 'tui-rendering' },
+  registerMarkdownTransformer: { handling: 'native', issue: 'tui-rendering' },
+  registerEntryRenderer: { handling: 'native', issue: 'tui-rendering' },
+} as const;
+
+export type PiExtensionUiApi = keyof typeof PI_EXTENSION_UI_CAPABILITIES;
+
+/** SDK camelCase and RPC wire names differ for editor writes. */
+export function getPiExtensionUiCapability(method: string) {
+  const api = method === 'set_editor_text' ? 'setEditorText' : method;
+  return Object.hasOwn(PI_EXTENSION_UI_CAPABILITIES, api)
+    ? PI_EXTENSION_UI_CAPABILITIES[api as PiExtensionUiApi]
+    : undefined;
+}

--- a/packages/maker-core/src/agents/pi/index.ts
+++ b/packages/maker-core/src/agents/pi/index.ts
@@ -1,3 +1,4 @@
+import { getPiExtensionUiCapability } from './extension-ui-capabilities.js';
 import { parsePiManagementArgs, parsePiManagementText } from './managed-command.js';
 import { snapshotDisabledSkillLaunch, currentDisabledSkillLaunchPaths, extendDisabledSkillLaunchPaths, type DisabledSkillLaunchSnapshot } from '../shared/skill-activation.js';
 /**
@@ -4639,7 +4640,6 @@ export class PiAgent extends BaseAgent {
     let piAgentLifecycleSequence = 0;
     let activeExtensionCommandNotifications: string[] | null = null;
     const doctorCommandActivity = new DoctorCommandActivity();
-    const unsupportedExtensionUiMethods = new Set<string>();
     const runtimeCapabilityListeners = new Set<(manifest: PiRuntimeCapabilityManifest | undefined) => void>();
     const notifyRuntimeCapabilityListener = (
       listener: (manifest: PiRuntimeCapabilityManifest | undefined) => void,
@@ -5180,22 +5180,6 @@ export class PiAgent extends BaseAgent {
                 queue.push({
                   type: 'text',
                   data: { text, isFinal: false },
-                  source: 'pi',
-                });
-              },
-              notifyUnsupportedExtensionUi: (method, reason) => {
-                const key = `${method}:${reason}`;
-                if (unsupportedExtensionUiMethods.has(key)) return;
-                unsupportedExtensionUiMethods.add(key);
-                queue.push({
-                  type: 'text',
-                  data: {
-                    text:
-                      reason === 'timed-dialog'
-                        ? `This Pi extension requested a timed ${method} dialog, which Cindy cannot keep synchronized. The dialog was cancelled.`
-                        : `This Pi extension requested the Pi UI feature “${method}”, which Cindy cannot display. That UI request was ignored.`,
-                    isFinal: false,
-                  },
                   source: 'pi',
                 });
               },
@@ -7609,7 +7593,6 @@ export class PiAgent extends BaseAgent {
         runId: string,
       ) => Promise<boolean>;
       emitExtensionNotification: (message: string, event?: PiRpcEvent) => void;
-      notifyUnsupportedExtensionUi: (method: string, reason: 'unsupported-ui' | 'timed-dialog') => void;
       /**
        * 把一张挂起的权限卡登记进会话级表,返回注销函数。档位切换 / 关闭会话时由
        * `dismissAllPendingPrompts` 强制 settle,避免放宽档位后调用仍卡在失效的卡上。
@@ -7634,7 +7617,7 @@ export class PiAgent extends BaseAgent {
     const id = typeof event.id === 'string' ? event.id : undefined;
     if (!id) return;
 
-    if (method === 'notify') {
+    if (getPiExtensionUiCapability(method)?.handling === 'notification') {
       const message = typeof event.message === 'string' ? event.message.trim() : '';
       if (!message) return;
       // Pi RPC has no toast surface. Preserve the extension's only visible
@@ -8371,8 +8354,7 @@ export class PiAgent extends BaseAgent {
       return;
     }
 
-    const isDialog = method === 'select' || method === 'confirm' || method === 'input' || method === 'editor';
-    if (isDialog) {
+    if (getPiExtensionUiCapability(method)?.handling === 'dialog') {
       const context = getPermissionCtx();
       const timeout = typeof event.timeout === 'number' && Number.isFinite(event.timeout) ? event.timeout : undefined;
       if (timeout !== undefined) {
@@ -8380,13 +8362,11 @@ export class PiAgent extends BaseAgent {
           method,
           timeout,
         });
-        context.notifyUnsupportedExtensionUi(method, 'timed-dialog');
         proc.send({ type: 'extension_ui_response', id, cancelled: true });
         return;
       }
       if (!context.resolver) {
         this.deps.logger.warn('pi extension dialog has no interaction resolver', { method });
-        context.notifyUnsupportedExtensionUi(method, 'unsupported-ui');
         proc.send({ type: 'extension_ui_response', id, cancelled: true });
         return;
       }
@@ -8402,7 +8382,6 @@ export class PiAgent extends BaseAgent {
           })
         : [];
       if (method === 'select' && options.length === 0) {
-        context.notifyUnsupportedExtensionUi(method, 'unsupported-ui');
         proc.send({ type: 'extension_ui_response', id, cancelled: true });
         return;
       }
@@ -8473,6 +8452,8 @@ export class PiAgent extends BaseAgent {
       return;
     }
 
-    getPermissionCtx().notifyUnsupportedExtensionUi(method || 'unknown', 'unsupported-ui');
+    // Unsupported display requests (including future RPC UI methods) are
+    // intentionally ignored. Compatibility belongs in Settings, never in the
+    // transcript. Pi already handles native TUI-only stubs inside its process.
   }
 }


### PR DESCRIPTION
## 这次改了什么

### 摘要

Pi 扩展调用 setStatus、setWidget 等终端展示接口时，Cindy 会反复把兼容警告写入聊天。现在由一份共享能力清单统一静默过滤不兼容的展示请求，兼容信息留在设置中，保留真实通知和已支持的交互卡。

### 变更类型

- [x] `fix` 缺陷修复

### 范围

- 关联 Issue / 需求：维护者要求统一过滤 Pi 不兼容 UI，安装沿用 Pi CLI，不追加扩展确认。
- 本 PR 包含：共享 RPC 能力表、运行时过滤、设置静态分析与回归测试；纠正 theme 读取误报，标识显式超时对话框限制。
- 明确不包含：不修改第三方扩展源码或安装权限实现；主干已有直接安装行为，本次补三种权限档位与设置安装的回归保证。
- 用户可见变化：不再出现被忽略 UI 的聊天警告；真实 notify、交互卡和原生扩展行为保留。
- 是否存在 breaking change：无。

### UI 变化

无布局、样式或组件交互变动；移除运行时兼容警告，现有设置详情继续展示兼容信息。

- 引用的设计规范：不涉及：Renderer 文件只更新已有安装交互测试名称，无视觉、交互或 UI 文案变更。

## 怎么验证的

### 自动验证

```text
Pi pi-auto-review-dispatch.test.ts --maxWorkers=1：173 项通过
Desktop compatibility + managed mutation + Settings interactions --maxWorkers=1：63 项通过
Desktop package-store-security + compatibility --maxWorkers=1：207 项通过
pnpm --filter desktop run --if-present typecheck：通过
pnpm --filter @cindy/maker-core run --if-present typecheck：无此脚本，自动跳过
pnpm --filter @cindy/maker-core run build：tsc --noEmit 通过
pnpm test:unit:related --workspace-concurrency 1：因 package 导出改动扩至全量，其余 workspace 全部通过；Desktop 首轮语音超时 fixture 波动并发生 Vitest SIGSEGV
pnpm test:unit:related --workspace apps/desktop --workspace-concurrency 1：失败 workspace 完整重跑通过，exit 0
ElevenLabsScribeProvider.test.ts --pool=forks --maxWorkers=1：7 项通过
pnpm check:dco：通过（1 个提交）
```

### 手工验证

macOS arm64 使用仓库固定的真实 Pi 0.84.4 做隔离 RPC 探针，无模型调用：核实 setStatus/setWidget/setTitle/set_editor_text/notify 的实际事件，及 editor、theme、custom、terminal input 等原生返回值。临时扩展和进程已清理，未改正式版用户配置。当前 head 完整 diff 已逐文件自查，上游新增提交仅涉及 Bot，与本次文件无重叠。

### 未执行的验证

未在正式版 GUI、Windows 实机或 Light/Dark 实机目检；本次不改变界面样式。静态分析不能穷举动态参数和调用，结果仅作提示，不用于停用或阻止安装。

## 风险

### 风险分类

- [x] 其他：Pi RPC UI 分发与静态兼容分析。

### 影响与回滚

- 影响范围：Pi 扩展展示请求及设置兼容详情；私有权限、包管理、子代理控制链保持原路径。存量插件影响：无，不改变批准记录、安装布局或启停状态。
- 回滚 / 降级方式：回退本提交恢复旧提示行为，无数据迁移。

### 提交前检查

- [x] 已 review 完整 diff
- [x] 每个 commit 都带 DCO 签名
- [x] UI 改动已在「UI 变化」注明引用的设计规范章节（不涉及 UI 则跳过）
- [x] 未提交凭证、令牌或授权文件
- [x] 已核对受影响的文档，行为变化涉及的旧结论已同步修订
- [x] 已确认测试结果或说明未执行原因
