### PR TITLE
chore(windows-input): 失败行带上失败点与 Win32 状态

### DIFF
--- a/apps/desktop/native/remote-desktop/windows-input/src/desktop.rs
+++ b/apps/desktop/native/remote-desktop/windows-input/src/desktop.rs
@@ -1,6 +1,7 @@
 //! Input belongs to the active Windows desktop, not permanently to Default.
 //! This does not grant access: the OS still checks the process token. Secure
 //! desktops require the session worker to be launched by the SYSTEM broker.
+use windows_sys::Win32::Foundation::GetLastError;
 use windows_sys::Win32::System::StationsAndDesktops::*;
 
 pub struct InputDesktop {
@@ -23,8 +24,10 @@ impl InputDesktop {
     /// Call only on the input thread, which must never own windows or hooks.
     /// Returns true after a transition; callers discard the transition batch
     /// so characters intended for the previous screen cannot reach a password
-    /// prompt or another user's desktop.
-    pub fn bind(&mut self) -> Result<bool, ()> {
+    /// prompt or another user's desktop. The error is the Win32 status of the
+    /// call that failed, so a machine that cannot bind can be told apart in the
+    /// field without a debugger.
+    pub fn bind(&mut self) -> Result<bool, u32> {
         unsafe {
             let next = OpenInputDesktop(
                 0,
@@ -32,7 +35,7 @@ impl InputDesktop {
                 DESKTOP_READOBJECTS | DESKTOP_WRITEOBJECTS | DESKTOP_SWITCHDESKTOP,
             );
             if next.is_null() {
-                return Err(());
+                return Err(GetLastError());
             }
             let mut name = vec![0u16; 256];
             let mut needed = 0;
@@ -44,8 +47,10 @@ impl InputDesktop {
                 &mut needed,
             ) == 0
             {
+                // Read the status before closing: closing has its own result.
+                let status = GetLastError();
                 CloseDesktop(next);
-                return Err(());
+                return Err(status);
             }
             name.truncate((needed as usize / 2).min(name.len()));
             if !self.handle.is_null() && name == self.name {
@@ -53,8 +58,9 @@ impl InputDesktop {
                 return Ok(false);
             }
             if SetThreadDesktop(next) == 0 {
+                let status = GetLastError();
                 CloseDesktop(next);
-                return Err(());
+                return Err(status);
             }
             let changed = !self.handle.is_null();
             if changed {

--- a/apps/desktop/native/remote-desktop/windows-input/src/main.rs
+++ b/apps/desktop/native/remote-desktop/windows-input/src/main.rs
@@ -5,6 +5,7 @@ use std::{
     sync::mpsc,
     time::Duration,
 };
+use windows_sys::Win32::Foundation::GetLastError;
 use windows_sys::Win32::UI::{HiDpi::*, Input::KeyboardAndMouse::*, WindowsAndMessaging::*};
 mod desktop;
 mod selection;
@@ -12,9 +13,15 @@ mod selection;
 static FAILED: std::sync::atomic::AtomicBool = std::sync::atomic::AtomicBool::new(false);
 fn send(input: INPUT) -> bool {
     let ok = unsafe { SendInput(1, &input, std::mem::size_of::<INPUT>() as i32) == 1 };
-    if !ok && !FAILED.swap(true, std::sync::atomic::Ordering::SeqCst) {
-        println!("error");
-        io::stdout().flush().ok();
+    if !ok {
+        let status = unsafe { GetLastError() };
+        if !FAILED.swap(true, std::sync::atomic::Ordering::SeqCst) {
+            // The parent treats any output line as "input failed" and stops
+            // reading, so the reason rides on the one line it already prints:
+            // which call failed and the Win32 status. No coordinates, no text.
+            println!("error send_input {status}");
+            io::stdout().flush().ok();
+        }
     }
     ok
 }
@@ -187,8 +194,8 @@ fn main() {
     let mut keys = HashSet::new();
     let mut buttons = HashSet::new();
     let mut desktop = desktop::InputDesktop::new();
-    if desktop.bind().is_err() {
-        println!("error");
+    if let Err(status) = desktop.bind() {
+        println!("error input_desktop {status}");
         return;
     }
     println!("ready");
@@ -205,8 +212,8 @@ fn main() {
                 break;
             }
             Ok(false) => (),
-            Err(_) => {
-                println!("error");
+            Err(status) => {
+                println!("error input_desktop {status}");
                 io::stdout().flush().ok();
                 break;
             }

--- a/docs/remote-desktop.md
+++ b/docs/remote-desktop.md
@@ -198,6 +198,13 @@ Windows secure desktop/UAC and elevated applications can reject input, and
 macOS lock/login screens and protected surfaces are not guaranteed controllable.
 System audio and explicit clipboard transfers are supported when advertised by the host. Virtual displays and remote power-on are not included. The phone keyboard sends committed text directly; the computer keyboard supplies modifiers and special keys.
 
+The Windows input helper reports a failed call on the single output line its host
+already treats as "input failed": `error send_input <status>` when Win32 rejects
+an injection, and `error input_desktop <status>` when the desktop binding fails,
+with the Win32 status of the failing call. The line carries no coordinates and no
+typed text, and both consumers (Main's output watch and the SYSTEM service
+worker's failure watch) still classify it by the same rules as before.
+
 Unit tests cover peer/lease isolation, expiry, revocation during asynchronous
 capture, start/stop races, input replay, human/Agent exclusion, portrait/landscape
 geometry, keyboard resize, inline viewer parsing, two-finger gestures, and reconnect.


### PR DESCRIPTION
## 这次改了什么

### 摘要

Windows 输入 helper 目前失败时只打印一行没有信息量的 `error`：既不知道是哪个调用失败，也拿不到 Win32 状态。本 PR 让这一行带上原因——`error send_input <status>`（`SendInput` 被拒）或 `error input_desktop <status>`（桌面绑定失败），status 是失败那个调用的 `GetLastError`。

动机是正在排查的一个线上问题：iOS/安卓直连 Windows 电脑时点一下画面就重连，手工隔离复现（不启动 Cindy、直接喂一行 JSON 给 `cindy-windows-desktop-input.exe`）已经确认 helper 自己 `ready` 之后立刻 `error` 退出，而同一台机器上 PowerShell 用同样的 `INPUT`/flags 调 `SendInput` 全部 `sent=1`、向日葵/ToDesk 也能正常点。也就是说机器不拦注入，问题在这个进程里，但一行 `error` 无法区分「注入被拒」还是「桌面绑定失败」，更看不到错误码。这条诊断就是把它变成一次复现即可定性。

### 变更类型

- [x] `docs` / `test` / `chore` 文档、测试或工程维护（可观测性）

### 范围

- 关联 Issue / 需求：Windows 远程桌面「点击即重连」排查（失败半径那半已在 #4284 修掉；本条是原生根因定位的前置）。
- 本 PR 包含：
  - `windows-input/src/desktop.rs`：`bind()` 的错误从 `()` 改为失败调用的 Win32 状态（`GetLastError`，在 `CloseDesktop` 之前读取，避免被关闭调用覆盖）。
  - `windows-input/src/main.rs`：`send()` 与两处 `bind()` 失败点打印 `error <call> <status>`。
  - `docs/remote-desktop.md`：「Platform and verification limits」补一句契约说明。
- 明确不包含：
  - 不修注入本身。根因（是不是启动时那步多余的 `SetThreadDesktop`，还是别的）等这份诊断复现一次再定，随后单独提修复。
  - 不动 `capture` 侧（`windows-host` 的采集 worker 复用同一个 `desktop` 模块，但它的错误目前合并成 `PermissionDenied`，没有对外协议可携带错误码）。
  - 不动 Main / 服务 worker 的解析、不动 wire 协议、不动 allowlist。
- 用户可见变化：无（输出行只在失败路径、且解析规则不变）。
- 是否存在 breaking change：无。两个消费方都按原规则分类：Main 的 stdout 监听是「首行 `startsWith('ready')`，之后任一行 `includes('error')` 即视为输入失败」；SYSTEM 服务 worker 是「首行必须等于 ready 那一行，之后任意一行即判定失败」。本改动只改错误行的**内容**，不新增行、不改首行。

### UI 变化

- 引用的设计规范：不涉及（原生 helper 的失败输出，无界面）。

## 怎么验证的

### 自动验证

```text
pnpm test:unit:related（仓库根，worktree 内）→ 见下方结果（本改动只涉及 .rs 与 docs，工作区单测不覆盖）
```

静态核对（本机不能编译，故逐项对照依赖定义）：

```text
windows-sys 0.59（Cargo.lock 锁定）：
  GetLastError() -> WIN32_ERROR，WIN32_TYPE 为 `pub type WIN32_ERROR = u32`（非 newtype）→ 返回 u32 成立
  INPUT / MOUSEINPUT / INPUT_0 字段与顺序与 helper 现有构造一致，SendInput(cinputs: u32, pinputs: *const INPUT, cbsize: i32) -> u32 签名未变
两个 crate 都启用了 Win32_Foundation：windows-input/Cargo.toml 与 windows-host/Cargo.toml（后者经 #[path] 复用 desktop.rs，编译时同属一个 crate）
bind() 的其它调用点：windows-host/src/capture.rs 用 `.map_err(|_| ...)`，忽略错误值 → 新错误类型下仍可编译
其余调用点：main.rs 里两处 `desktop.bind() != Ok(false)` 依赖 Result<bool, u32> 的 PartialEq，成立
```

结果：**本 PR 没有编译验证**（原因见下）。上面是我能做到的静态核对。

### 手工验证

不涉及（没有 Windows 机器；改动是失败路径上的输出内容）。

### 未执行的验证

- **未编译、未在 Windows 上运行**：本开发机没有 Rust 工具链（`cargo`/`rustc` 均不存在），仓库 CI 也没有 cargo——`cargo` 只在 forge 打包时执行。因此这份改动只做了上述静态核对，需要 Windows 侧出 build 时暴露任何编译问题。
- 建议的验证路径（出 build 后 30 秒即可完成）：在被控机 Cindy 安装目录 `resources\tools\remote-desktop\` 下
  `echo [{"kind":"button","button":0,"down":true,"x":100,"y":100},{"kind":"button","button":0,"down":false,"x":100,"y":100}]|cindy-windows-desktop-input.exe`
  预期从现在的 `ready / error` 变成 `ready / error send_input <status>` 或 `ready / error input_desktop <status>`，把这一行发回来即可定性。

## 风险

### 风险分类

- [x] 原生层 / fingerprint / OTA
- [x] 其他：helper 输出行内容（与宿主/服务的隐式契约）

- 原生层：改动落在 Windows 原生 helper（随桌面端打包发布，不走移动端冷更；移动 fingerprint 不变）。
- 输出契约：错误行的内容变了，若将来有人按整行精确匹配解析会受影响；当前两个消费方都是「有没有 error 子串 / 有没有这一行」的判定，因此兼容。诊断内容只有调用名与 Win32 状态，不含坐标、按键、文本。

### 影响与回滚

- 影响范围：只在 Windows 输入 helper 的失败路径上多打印两个词；成功路径与 macOS 完全不变。
- 回滚 / 降级方式：revert 本 commit（无迁移、无持久化、无协议变更）。

### 远程与手机适配三问

1. workdir 文件 / agent 进程 / 会话数据：不涉及。
2. 新增 IPC / 推送白名单：不涉及（helper 的 stdout 不是 device-link channel）。
3. 手机版入口 / UI：不涉及。

### 提交前检查

- [x] 已 review 完整 diff
- [x] 每个 commit 都带 DCO 签名（`git commit -s`）
- [x] UI 改动已在「UI 变化」注明引用的设计规范章节（不涉及 UI 则跳过）
- [x] 未提交凭证、令牌或授权文件
- [x] 已补充必要文档（`docs/remote-desktop.md`）
- [x] 已确认测试结果或说明未执行原因（含未编译的原因）
