### PR TITLE
fix(desktop): 返回任务时不再默认选中自动化

### DIFF
--- a/apps/desktop/src/renderer/components/sidebar/__tests__/SidebarTopNav.bots.test.tsx
+++ b/apps/desktop/src/renderer/components/sidebar/__tests__/SidebarTopNav.bots.test.tsx
@@ -49,6 +49,28 @@ function Harness({ initialPath, owner = 'one' }: { initialPath: string; owner?: 
 }
 
 describe('Sidebar teammate return action', () => {
+  it('keeps the previous task when visiting automations before teammates', () => {
+    const sessionPath = '/cc-agent/session-1?remoteHostId=host-1#message-2';
+    render(<Harness initialPath={sessionPath} />);
+    fireEvent.click(screen.getByRole('button', { name: 'ccAgent.layout.automations' }));
+    expect(screen.getByRole('button', { name: 'ccAgent.layout.automations' }).getAttribute('aria-current')).toBe('page');
+    fireEvent.click(screen.getByRole('button', { name: '伙伴' }));
+    fireEvent.click(screen.getByRole('button', { name: '返回任务' }));
+    expect(screen.getByTestId('location').textContent).toBe(sessionPath);
+    expect(screen.getByRole('button', { name: 'ccAgent.layout.automations' }).hasAttribute('aria-current')).toBe(false);
+  });
+
+  it.each(['/cc-agent/scheduled', '/cc-agent/scheduled/?filter=enabled#schedule-1'])(
+    'returns to the task index after entering teammates from %s without a previous task',
+    (initialPath) => {
+      render(<Harness initialPath={initialPath} />);
+      fireEvent.click(screen.getByRole('button', { name: '伙伴' }));
+      fireEvent.click(screen.getByRole('button', { name: '返回任务' }));
+      expect(screen.getByTestId('location').textContent).toBe('/cc-agent');
+      expect(screen.getByRole('button', { name: 'ccAgent.layout.automations' }).hasAttribute('aria-current')).toBe(false);
+    },
+  );
+
   it('does not seed a new owner from the unchanged router entry', () => {
     const oldPath = '/cc-agent/old-owner-session?remoteHostId=old-host#message-2';
     function OwnerRouter({ owner }: { owner: string }) {

--- a/apps/desktop/src/renderer/hooks/useActiveMainView.ts
+++ b/apps/desktop/src/renderer/hooks/useActiveMainView.ts
@@ -13,6 +13,7 @@
  *
  * URL 派生由本 hook 维护；各视图最后位置由账号级 MainViewHistoryProvider 共享，
  * 避免侧栏滚动段卸载后丢失返回位置。未提供 Provider 时使用实例内记忆。
+ * 自动化页保留当前视图归属，但不覆盖任务返回位置。
  * [PROTOCOL]: 变更时更新此头部，然后检查 CLAUDE.md
  */
 
@@ -69,7 +70,14 @@ export function useActiveMainView() {
     ) return;
     if (matchedKey) {
       history.current.lastMatchedKey = matchedKey;
-      history.current.paths[matchedKey] = location.pathname + location.search + location.hash;
+      // Automations share the task layout, but are not a task destination.
+      // Keep the previous task (or the index fallback) for return navigation.
+      const isAutomations =
+        location.pathname === '/cc-agent/scheduled' ||
+        location.pathname.startsWith('/cc-agent/scheduled/');
+      if (!isAutomations) {
+        history.current.paths[matchedKey] = location.pathname + location.search + location.hash;
+      }
     }
   }, [history, matchedKey, location.key, location.pathname, location.search, location.hash]);
 


### PR DESCRIPTION
## 这次改了什么

### 摘要

从自动化页进入伙伴后，点击“返回任务”原先会恢复自动化页并选中自动化入口。现在自动化页不再覆盖任务返回位置：有历史任务时恢复原任务及其查询参数、消息锚点；没有记录时进入现有任务默认入口。

### 变更类型

- [x] `fix` 缺陷修复
- [x] `docs` / `test` / `chore` 文档、测试或工程维护

### 范围

- 关联 Issue / 需求：用户反馈“返回任务”不应默认选中自动化。
- 本 PR 包含：调整共享主视图位置记忆，补充自动化与伙伴间返回的回归测试。
- 明确不包含：自动化功能、消息滚动算法、移动端及服务端改动。
- 用户可见变化：展开和收起侧栏的返回操作恢复任务；主动点击自动化仍正常打开和选中。
- 是否存在 breaking change：无。

### UI 变化

- Desktop：只调整返回目标，沿用既有组件外观与选中态。
- 引用的设计规范：`docs/design-rules/DESIGN.md` §2、§10，继续使用既有主题语义样式，未新增颜色或单模式补丁。
- 本轮未附截图或录屏；未进行 Light / Dark 实机目检。

## 怎么验证的

### 自动验证

```text
pnpm test:unit:related
结果：通过，Desktop 相关单测通过。

pnpm --filter desktop run --if-present typecheck
结果：通过。

git diff --check
pnpm check:dco
结果：通过。
```

回归覆盖“原任务 → 自动化 → 伙伴 → 返回任务”、无历史任务时的默认入口，以及自动化主动选中和返回后的取消选中。原有账号隔离与任务位置恢复测试保持通过。

### 手工验证

已检查完整 diff 和路由调用链，未启动 Desktop 做手工点击验证。

### 未执行的验证

未进行 Light / Dark 实机目检及 macOS / Linux 运行验证；本次为共享 Renderer 导航逻辑的小范围修复，执行相关单测和类型检查，未跑全仓测试。

## 风险

### 风险分类

- [x] 其他：任务主视图的返回记忆统一跳过自动化页，因此从其它主视图返回任务时也恢复原任务。
- 移动端冷更判断：不会触发。仅改 Desktop Renderer hook 和测试，未修改 Mobile 原生配置、依赖或 runtime fingerprint 输入。
- 不涉及数据库迁移、系统提示词、协议、权限、持久化数据或插件基座。

### 影响与回滚

- 影响范围：Desktop 主视图切回任务时的目标选择；自动化入口仍可显式访问。
- 回滚 / 降级方式：撤销本次提交即可，无数据迁移。

### 提交前检查

- [x] 已 review 完整 diff
- [x] 每个 commit 都带 DCO 签名
- [x] UI 改动已在“UI 变化”注明引用的设计规范章节
- [x] 未提交凭证、令牌或授权文件
- [x] 已补充必要文档（更新 hook 头部说明）
- [x] 已确认测试结果或说明未执行原因