### PR TITLE
fix(desktop): render automation settings before status probes

### DIFF
--- a/apps/desktop/src/main/__tests__/computerUsePluginIpc.test.ts
+++ b/apps/desktop/src/main/__tests__/computerUsePluginIpc.test.ts
@@ -327,7 +327,7 @@ describe('computer use platform copy invariants', () => {
     );
     expect(sectionSource).toContain("nextStatus.permissionState?.platform === 'macos'");
     const macPermissionBlockStart = sectionSource.indexOf(
-      "{window.electronAPI.platform === 'darwin' ? (",
+      "{window.electronAPI.platform === 'darwin' && computerStatus !== null ? (",
     );
     const permissionTitle = sectionSource.indexOf(
       "t('settings.computerUse.directControl.permissions.title')",

--- a/apps/desktop/src/renderer/components/settings/ComputerUseSection.tsx
+++ b/apps/desktop/src/renderer/components/settings/ComputerUseSection.tsx
@@ -1229,6 +1229,13 @@ export function ComputerUseSection({
     !computerScreenRecordingGranted;
   const computerReady =
     computerStatus?.installed === true && isComputerPermissionReady(computerStatus);
+  // Browser/backend and computer probes can insert rows above the lower cards.
+  // Keep those lower controls inert until that initial geometry is settled so
+  // an async row cannot move an enabled action out from under the pointer.
+  const lowerControlsLayoutPending =
+    browserBackendKind === null
+    || (browserBackendKind === 'external' && availability === null)
+    || computerStatus === null;
   // Persisted opt-in and runtime readiness are separate states. Keeping an
   // unavailable enabled configuration checked lets the user turn it off
   // instead of forcing the only interaction back into onboarding.
@@ -1238,8 +1245,8 @@ export function ComputerUseSection({
     computerEnableIntentRef.current,
   );
   const computerSwitchDisabled =
-    computerEnabled === null
-    || computerStatus === null
+    lowerControlsLayoutPending
+    || computerEnabled === null
     || computerTogglePending
     || computerInstallPending
     || computerPermissionPending;
@@ -1660,7 +1667,7 @@ export function ComputerUseSection({
           </div>
           <Switch
             checked={androidEnabled ?? false}
-            disabled={androidEnabled === null || androidTogglePending}
+            disabled={lowerControlsLayoutPending || androidEnabled === null || androidTogglePending}
             onCheckedChange={handleToggleAndroid}
             aria-label={t('settings.computerUse.android.toggleAria')}
           />
@@ -1679,7 +1686,7 @@ export function ComputerUseSection({
               <DropdownMenuTrigger asChild>
                 <button
                   type="button"
-                  disabled={androidDevicePending || !androidStatus}
+                  disabled={lowerControlsLayoutPending || androidDevicePending || !androidStatus}
                   className={cn(ACTION_BUTTON_CLASS, 'max-w-[260px] px-2.5')}
                   aria-label={t('settings.computerUse.android.device.ariaLabel')}
                   title={configuredDefaultAndroidDevice ?? undefined}
@@ -1768,7 +1775,7 @@ export function ComputerUseSection({
             <button
               type="button"
               onClick={() => void handleRefreshAndroidStatus()}
-              disabled={androidStatusPending}
+              disabled={lowerControlsLayoutPending || androidStatusPending}
               className={ACTION_BUTTON_CLASS}
             >
               <RefreshCw size={12} className="shrink-0" />
@@ -1827,7 +1834,7 @@ export function ComputerUseSection({
                 setAndroidAdbPathDraft(event.target.value);
                 setAndroidAdbPathEdited(true);
               }}
-              disabled={androidAdbPathBusy}
+              disabled={lowerControlsLayoutPending || androidAdbPathBusy}
               placeholder={t('settings.computerUse.android.adb.placeholder')}
               aria-label={t('settings.computerUse.android.adb.pathAria')}
               className={cn(
@@ -1842,7 +1849,7 @@ export function ComputerUseSection({
             <button
               type="button"
               onClick={() => void handleSaveAndroidAdbPath()}
-              disabled={!androidAdbPathCanSave || androidAdbPathBusy}
+              disabled={lowerControlsLayoutPending || !androidAdbPathCanSave || androidAdbPathBusy}
               className={ACTION_BUTTON_CLASS}
             >
               {t('settings.computerUse.android.adb.save')}
@@ -1850,7 +1857,7 @@ export function ComputerUseSection({
             <button
               type="button"
               onClick={() => void handleUseDefaultAndroidAdbPath()}
-              disabled={androidAdbPathBusy}
+              disabled={lowerControlsLayoutPending || androidAdbPathBusy}
               className={ACTION_BUTTON_CLASS}
             >
               {t('settings.computerUse.android.adb.useDefault')}

--- a/apps/desktop/src/renderer/components/settings/ComputerUseSection.tsx
+++ b/apps/desktop/src/renderer/components/settings/ComputerUseSection.tsx
@@ -714,6 +714,11 @@ export function ComputerUseSection({
     }
   }, [computerEnabled, refreshComputerPermissionStatus, t]);
 
+  const joinDriverUpdateRef = useRef(joinDriverUpdate);
+  useEffect(() => {
+    joinDriverUpdateRef.current = joinDriverUpdate;
+  }, [joinDriverUpdate]);
+
   useEffect(() => {
     if (!computerStatus?.installed || driverUpdateCheckedRef.current) return;
     driverUpdateCheckedRef.current = true;
@@ -728,7 +733,7 @@ export function ComputerUseSection({
           // 上次面板关闭前发起的更新还在 main 侧跑:恢复「更新中」态并以
           // join-only 语义重挂结果(安装恰好已完成时只读状态,不起新安装)。
           setDriverUpdatePending(true);
-          void joinDriverUpdate(true);
+          void joinDriverUpdateRef.current(true);
         }
       })
       .catch((err) => {
@@ -737,7 +742,7 @@ export function ComputerUseSection({
     return () => {
       cancelled = true;
     };
-  }, [computerStatus?.installed, joinDriverUpdate]);
+  }, [computerStatus?.installed]);
 
   const handleUpdateDriver = useCallback(() => {
     if (driverUpdatePending) return;

--- a/apps/desktop/src/renderer/components/settings/ComputerUseSection.tsx
+++ b/apps/desktop/src/renderer/components/settings/ComputerUseSection.tsx
@@ -7,11 +7,11 @@
  *   - 未探测到时引导去 Chrome 官方下载页
  * 以及「直接操作电脑」能力 (cindy_computer MCP, machine-wide opt-in).
  *
- * 数据流 (规则 7: 先拉数据再渲染, 无 loading 闪屏):
- *   - mount → 并行拉 plugins.getState('browser', workingDir) (取 browser 开关态)
- *     + browser.status()。注意 browser 是 HOSTED_ELSEWHERE, 不在 plugins.list()
- *     里, 必须按 id 直接读单个状态, 否则 find() 永远 undefined。
- *   - 两者都到位后一次性渲染
+ * 数据流:
+ *   - mount → 立即渲染各卡片的基础 UI，并行拉取插件、浏览器、电脑与 backend 状态。
+ *   - 每项状态只解锁它所属的控件或详情；慢的进程/健康探测不阻塞整页首屏。
+ *   - browser 是 HOSTED_ELSEWHERE，不在 plugins.list() 里，必须按 id
+ *     直接读单个状态，否则 find() 永远 undefined。
  * 浏览器开关读写完全复用 builtin plugin IPC, 不新造持久化通道。
  */
 
@@ -468,58 +468,70 @@ export function ComputerUseSection({
         return { health: null, error };
       }
     })();
-    void (async () => {
-      const [browserState, computerState, avail, computer, backendState] = await Promise.all([
-        // `browser` is hidden from plugins.list() (HOSTED_ELSEWHERE), so read its
-        // enable state directly by id — list().find() would always be undefined
-        // and the toggle would wrongly reset to enabled on every remount.
-        window.electronAPI.maker.plugins.getState(BROWSER_PLUGIN_ID, workingDir).catch((err) => {
-          log.warn('plugins.getState(browser) failed', err);
-          return null;
-        }),
-        window.electronAPI.maker.plugins.getState(COMPUTER_PLUGIN_ID).catch((err) => {
-          log.warn('plugins.getState(computer) failed', err);
-          return null;
-        }),
-        window.electronAPI.maker.browser.status().catch((err) => {
-          log.warn('browser.status failed', err);
-          return { detected: false, browserKind: null, executablePath: null } as BrowserAvailability;
-        }),
-        // Entering Automation is the shared refresh boundary for every card.
-        // CuaDriver 0.12.2+ reports its own TCC state without opening the legacy
-        // grant flow. Bypass our prior-result cache so reopening this page
-        // reflects the latest settings without requiring a manual Recheck.
-        window.electronAPI.maker.computer.status({
-          forcePermissionProbe: true,
-          bypassPermissionProbeCache: true,
-          passivePermissionProbeOnly: true,
-        }).catch((err) => {
-          log.warn('computer.status failed', err);
-          return {
-            installed: false,
+    // Each base read owns its own render stage. A slow browser/process probe
+    // must not hold back already available plugin or backend state.
+    void window.electronAPI.maker.plugins.getState(BROWSER_PLUGIN_ID, workingDir)
+      .then((browserState) => {
+        if (!cancelled) setBrowserEnabled(browserState.effectiveEnabled);
+      })
+      .catch((err) => {
+        log.warn('plugins.getState(browser) failed', err);
+        if (!cancelled) setBrowserEnabled(true);
+      });
+    void window.electronAPI.maker.plugins.getState(COMPUTER_PLUGIN_ID)
+      .then((computerState) => {
+        if (!cancelled) setComputerEnabled(computerState.effectiveEnabled);
+      })
+      .catch((err) => {
+        log.warn('plugins.getState(computer) failed', err);
+        if (!cancelled) setComputerEnabled(false);
+      });
+    void window.electronAPI.maker.browser.status()
+      .then((avail) => {
+        if (!cancelled) setAvailability(avail);
+      })
+      .catch((err) => {
+        log.warn('browser.status failed', err);
+        if (!cancelled) {
+          setAvailability({
+            detected: false,
+            browserKind: null,
             executablePath: null,
-            version: null,
-            daemonRunning: false,
-            installCommand:
-              'cua-driver install instructions: https://cua.ai/docs/cua-driver',
-            docsUrl: 'https://cua.ai/docs/cua-driver',
-            error: String(err),
-          } as ComputerDriverStatus;
-        }),
-        window.electronAPI.browserBackend?.getState?.().catch((err) => {
-          log.warn('browserBackend.getState failed', err);
-          return null;
-        }) ?? Promise.resolve(null),
-      ]);
+          } as BrowserAvailability);
+        }
+      });
+    // Entering Automation is the shared refresh boundary for every card.
+    // CuaDriver 0.12.2+ reports its own TCC state without opening the legacy
+    // grant flow. Bypass our prior-result cache so reopening this page
+    // reflects the latest settings without requiring a manual Recheck.
+    void window.electronAPI.maker.computer.status({
+      forcePermissionProbe: true,
+      bypassPermissionProbeCache: true,
+      passivePermissionProbeOnly: true,
+    }).then((computer) => {
       if (cancelled) return;
-      // Browser keeps the builtin default-on behavior. Direct computer control
-      // reflects the persisted machine-wide opt-in; readiness is shown separately.
-      setBrowserEnabled(browserState ? browserState.effectiveEnabled : true);
-      const effectiveComputerEnabled = computerState ? computerState.effectiveEnabled : false;
-      setComputerEnabled(effectiveComputerEnabled);
-      setAvailability(avail);
       setComputerStatus(computer);
       log.debug('computer initial status loaded', getComputerPermissionLogSummary(computer));
+    }).catch((err) => {
+      log.warn('computer.status failed', err);
+      if (!cancelled) {
+        setComputerStatus({
+          installed: false,
+          executablePath: null,
+          version: null,
+          daemonRunning: false,
+          installCommand:
+            'cua-driver install instructions: https://cua.ai/docs/cua-driver',
+          docsUrl: 'https://cua.ai/docs/cua-driver',
+          error: String(err),
+        } as ComputerDriverStatus);
+      }
+    });
+    void (window.electronAPI.browserBackend?.getState?.().catch((err) => {
+      log.warn('browserBackend.getState failed', err);
+      return null;
+    }) ?? Promise.resolve(null)).then(async (backendState) => {
+      if (cancelled) return;
       // Phase 5: backend kind 拉不到时(老版本 preload / IPC 缺失)安全 fallback
       // 到 'external',保持现有 Chrome 探测 / 登录 UI 可见 — 总比因为 IPC 失败
       // 让卡片整张瘫成内置态强。
@@ -535,7 +547,7 @@ export function ComputerUseSection({
             ? browserBackendHealthFallback(activeBackend)
             : null,
       );
-    })();
+    });
     return () => {
       cancelled = true;
     };
@@ -1201,17 +1213,6 @@ export function ComputerUseSection({
     }
   }, [refreshComputerPermissionStatus, t]);
 
-  const automationViewLoading =
-    browserEnabled === null
-    || computerEnabled === null
-    || availability === null
-    || computerStatus === null;
-
-  // First render: blank until all reads land (no flash, rule 7).
-  if (automationViewLoading) {
-    return null;
-  }
-
   const computerAccessibilityGranted = isComputerAccessibilityPermissionReady(computerStatus);
   const computerScreenRecordingGranted = isComputerScreenRecordingPermissionReady(computerStatus);
   const computerAccessibilityPending = computerPermissionPending && !computerAccessibilityGranted;
@@ -1220,17 +1221,21 @@ export function ComputerUseSection({
     computerAccessibilityGranted &&
     !computerScreenRecordingGranted;
   const computerReady =
-    computerStatus.installed && isComputerPermissionReady(computerStatus);
+    computerStatus?.installed === true && isComputerPermissionReady(computerStatus);
   // Persisted opt-in and runtime readiness are separate states. Keeping an
   // unavailable enabled configuration checked lets the user turn it off
   // instead of forcing the only interaction back into onboarding.
   const computerSwitchChecked = getComputerPermissionSwitchChecked(
-    computerEnabled,
+    computerEnabled ?? false,
     computerTogglePending,
     computerEnableIntentRef.current,
   );
   const computerSwitchDisabled =
-    computerTogglePending || computerInstallPending || computerPermissionPending;
+    computerEnabled === null
+    || computerStatus === null
+    || computerTogglePending
+    || computerInstallPending
+    || computerPermissionPending;
 
   const configuredDefaultAndroidDevice =
     androidConfig?.value.defaultDeviceSerial
@@ -1313,8 +1318,8 @@ export function ComputerUseSection({
             </div>
           </div>
           <Switch
-            checked={browserEnabled}
-            disabled={togglePending}
+            checked={browserEnabled ?? false}
+            disabled={browserEnabled === null || togglePending}
             onCheckedChange={handleToggleBrowser}
             aria-label={t('settings.computerUse.browser.toggleAria')}
           />
@@ -1342,7 +1347,7 @@ export function ComputerUseSection({
         ) : null}
         {/* 只在 backend === 'external' 时展示 Chrome 探测 + 登录入口。内置 webview
             backend 用 Electron 自带 Chromium,这些 UI 对它都没有意义。 */}
-        {browserBackendKind === 'external' ? (
+        {browserBackendKind === 'external' && availability !== null ? (
           <div className="flex flex-wrap items-center justify-between gap-3 border-t border-[var(--settings-theme-card-border)] px-4 py-[14px]">
             <p className="min-w-0 text-12 leading-[1.5] text-[var(--settings-section-desc)]">
               {availability.detected
@@ -1370,7 +1375,7 @@ export function ComputerUseSection({
         ) : null}
       </div>
 
-      {browserBackendKind === 'external' && availability.detected ? (
+      {browserBackendKind === 'external' && availability?.detected ? (
         <p className="text-12 leading-[1.5] text-[var(--settings-section-desc)]">
           {t('settings.computerUse.browser.openForLoginHint')}
         </p>
@@ -1416,7 +1421,7 @@ export function ComputerUseSection({
           />
         </div>
         {/* Windows/Linux 没有 macOS TCC 权限,整块隐藏;安装进度改在下方状态行展示。 */}
-        {window.electronAPI.platform === 'darwin' ? (
+        {window.electronAPI.platform === 'darwin' && computerStatus !== null ? (
           <div className="border-t border-[var(--settings-theme-card-border)] px-4 py-4">
             <div className="flex items-center justify-between gap-3">
               <p className="text-13 font-medium text-[var(--settings-section-title)]">
@@ -1461,7 +1466,7 @@ export function ComputerUseSection({
                 }
                 onAction={() =>
                   void (
-                    computerStatus.installed
+                    computerStatus?.installed
                       ? handleOpenComputerPermission(
                           MAC_ACCESSIBILITY_SETTINGS_URL,
                           computerAccessibilityGranted,
@@ -1484,7 +1489,7 @@ export function ComputerUseSection({
                 }
                 onAction={() =>
                   void (
-                    computerStatus.installed
+                    computerStatus?.installed
                       ? handleOpenComputerPermission(
                           MAC_SCREEN_RECORDING_SETTINGS_URL,
                           computerScreenRecordingGranted,
@@ -1497,6 +1502,7 @@ export function ComputerUseSection({
           </div>
         ) : null}
 
+        {computerStatus !== null ? (
         <div className="relative border-t border-[var(--settings-theme-card-border)] px-4 py-2.5">
           <div className="flex flex-wrap items-center justify-between gap-x-3 gap-y-2">
             <div className="flex min-w-0 flex-wrap items-center gap-x-2 gap-y-1">
@@ -1586,6 +1592,7 @@ export function ComputerUseSection({
             </div>
           ) : null}
         </div>
+        ) : null}
 
         {computerDetailsOpen ? (
           <div className="flex flex-col gap-3 border-t border-[var(--settings-theme-card-border)] px-4 py-3.5">

--- a/apps/desktop/src/renderer/components/settings/ComputerUseSection.tsx
+++ b/apps/desktop/src/renderer/components/settings/ComputerUseSection.tsx
@@ -719,8 +719,10 @@ export function ComputerUseSection({
     joinDriverUpdateRef.current = joinDriverUpdate;
   }, [joinDriverUpdate]);
 
+  const computerEnabledResolved = computerEnabled !== null;
   useEffect(() => {
-    if (!computerStatus?.installed || driverUpdateCheckedRef.current) return;
+    if (!computerStatus?.installed || !computerEnabledResolved || driverUpdateCheckedRef.current)
+      return;
     driverUpdateCheckedRef.current = true;
     let cancelled = false;
     void window.electronAPI.maker.computer
@@ -742,7 +744,7 @@ export function ComputerUseSection({
     return () => {
       cancelled = true;
     };
-  }, [computerStatus?.installed]);
+  }, [computerEnabledResolved, computerStatus?.installed]);
 
   const handleUpdateDriver = useCallback(() => {
     if (driverUpdatePending) return;

--- a/apps/desktop/src/renderer/components/settings/__tests__/ComputerUseSection.browserHealth.test.tsx
+++ b/apps/desktop/src/renderer/components/settings/__tests__/ComputerUseSection.browserHealth.test.tsx
@@ -120,6 +120,47 @@ beforeEach(() => {
 afterEach(cleanup);
 
 describe('ComputerUseSection browser backend health loading', () => {
+  it('renders the base settings before browser status resolves', async () => {
+    const browserStatus = deferred<BrowserAvailability>();
+    api.getBrowserStatus.mockReturnValueOnce(browserStatus.promise);
+    api.getBackendState.mockResolvedValueOnce({ active: 'external' });
+    api.getBackendHealth.mockResolvedValueOnce({
+      active: 'external',
+      status: 'ready',
+      canRecover: false,
+    });
+
+    render(<ComputerUseSection workingDir="/tmp/project" />);
+
+    expect(screen.getByText('settings.computerUse.title')).toBeTruthy();
+    expect(screen.getByText('settings.computerUse.browser.title')).toBeTruthy();
+    expect(screen.getByText('settings.computerUse.directControl.title')).toBeTruthy();
+    expect(screen.getByText('settings.computerUse.android.title')).toBeTruthy();
+    expect(
+      (screen.getByRole('switch', {
+        name: 'settings.computerUse.browser.toggleAria',
+      }) as HTMLButtonElement).disabled,
+    ).toBe(true);
+
+    expect(
+      await screen.findByRole('radio', {
+        name: 'settings.computerUse.browserBackend.external.title',
+      }),
+    ).toBeTruthy();
+    expect(screen.queryByText('settings.computerUse.browser.notDetected')).toBeNull();
+
+    await act(async () => {
+      browserStatus.resolve({
+        detected: false,
+        browserKind: null,
+        executablePath: null,
+      });
+      await browserStatus.promise;
+    });
+
+    expect(await screen.findByText('settings.computerUse.browser.notDetected')).toBeTruthy();
+  });
+
   it('renders the Automation settings while the recoverable health probe is still pending', async () => {
     const initialHealth = deferred<BrowserBackendHealth>();
     api.getBackendHealth.mockReturnValueOnce(initialHealth.promise);

--- a/apps/desktop/src/renderer/components/settings/__tests__/ComputerUseSection.browserHealth.test.tsx
+++ b/apps/desktop/src/renderer/components/settings/__tests__/ComputerUseSection.browserHealth.test.tsx
@@ -11,6 +11,7 @@ const api = vi.hoisted(() => ({
   getBrowserStatus: vi.fn(),
   getComputerStatus: vi.fn(),
   checkComputerUpdate: vi.fn(),
+  updateComputerDriver: vi.fn(),
   getAndroidConfig: vi.fn(),
   getAndroidStatus: vi.fn(),
   getBackendState: vi.fn(),
@@ -63,6 +64,12 @@ beforeEach(() => {
   });
   api.getComputerStatus.mockResolvedValue(computerUnavailable);
   api.checkComputerUpdate.mockResolvedValue({ updateAvailable: false, updating: false });
+  api.updateComputerDriver.mockResolvedValue({
+    ok: true,
+    stdout: '',
+    stderr: '',
+    status: computerUnavailable,
+  });
   api.getAndroidConfig.mockResolvedValue({
     value: { defaultDeviceSerial: null, adbPathOverride: null },
     defaults: { defaultDeviceSerial: null, adbPathOverride: null },
@@ -101,6 +108,7 @@ beforeEach(() => {
           onPermissionGuideCancelled: vi.fn(() => () => undefined),
           onUpdateProgress: vi.fn(() => () => undefined),
           checkUpdate: api.checkComputerUpdate,
+          updateDriver: api.updateComputerDriver,
         },
         android: {
           getConfig: api.getAndroidConfig,
@@ -122,6 +130,63 @@ beforeEach(() => {
 afterEach(cleanup);
 
 describe('ComputerUseSection browser backend health loading', () => {
+  it('waits for computer plugin state before joining an in-flight driver update', async () => {
+    const computerStatus = deferred<ComputerDriverStatus>();
+    const computerPluginState = deferred<{ effectiveEnabled: boolean }>();
+    const driverUpdate = deferred<ComputerDriverInstallResult>();
+    api.getComputerStatus.mockReturnValueOnce(computerStatus.promise);
+    api.getPluginState.mockImplementation((id: string) =>
+      id === 'computer'
+        ? computerPluginState.promise
+        : Promise.resolve({ effectiveEnabled: id === 'browser' }),
+    );
+    api.checkComputerUpdate.mockResolvedValueOnce({
+      updateAvailable: false,
+      updating: true,
+      currentVersion: '0.12.2',
+      latestVersion: '0.12.3',
+    });
+    api.updateComputerDriver.mockReturnValueOnce(driverUpdate.promise);
+
+    render(<ComputerUseSection workingDir="/tmp/project" />);
+
+    await act(async () => {
+      computerStatus.resolve({
+        ...computerUnavailable,
+        installed: true,
+        version: '0.12.2',
+      });
+      await computerStatus.promise;
+    });
+    expect(api.checkComputerUpdate).not.toHaveBeenCalled();
+
+    await act(async () => {
+      computerPluginState.resolve({ effectiveEnabled: true });
+      await computerPluginState.promise;
+    });
+    await waitFor(() => expect(api.updateComputerDriver).toHaveBeenCalledWith({ joinOnly: true }));
+
+    await act(async () => {
+      driverUpdate.resolve({
+        ok: true,
+        stdout: '',
+        stderr: '',
+        status: {
+          ...computerUnavailable,
+          installed: true,
+          permissionState: {
+            platform: 'linux',
+            required: true,
+            status: 'missing',
+            canGrant: false,
+          },
+        },
+      });
+      await driverUpdate.promise;
+    });
+    await waitFor(() => expect(api.setPluginEnabled).toHaveBeenCalledWith('computer', false));
+  });
+
   it('keeps the initial driver update result when plugin state resolves later', async () => {
     const computerPluginState = deferred<{ effectiveEnabled: boolean }>();
     const driverUpdate = deferred<ComputerDriverUpdateCheck>();
@@ -139,11 +204,11 @@ describe('ComputerUseSection browser backend health loading', () => {
 
     render(<ComputerUseSection workingDir="/tmp/project" />);
 
-    await waitFor(() => expect(api.checkComputerUpdate).toHaveBeenCalledTimes(1));
     await act(async () => {
       computerPluginState.resolve({ effectiveEnabled: false });
       await computerPluginState.promise;
     });
+    await waitFor(() => expect(api.checkComputerUpdate).toHaveBeenCalledTimes(1));
     await act(async () => {
       driverUpdate.resolve({
         updateAvailable: true,

--- a/apps/desktop/src/renderer/components/settings/__tests__/ComputerUseSection.browserHealth.test.tsx
+++ b/apps/desktop/src/renderer/components/settings/__tests__/ComputerUseSection.browserHealth.test.tsx
@@ -10,6 +10,7 @@ const api = vi.hoisted(() => ({
   setPluginEnabled: vi.fn(),
   getBrowserStatus: vi.fn(),
   getComputerStatus: vi.fn(),
+  checkComputerUpdate: vi.fn(),
   getAndroidConfig: vi.fn(),
   getAndroidStatus: vi.fn(),
   getBackendState: vi.fn(),
@@ -61,6 +62,7 @@ beforeEach(() => {
     executablePath: null,
   });
   api.getComputerStatus.mockResolvedValue(computerUnavailable);
+  api.checkComputerUpdate.mockResolvedValue({ updateAvailable: false, updating: false });
   api.getAndroidConfig.mockResolvedValue({
     value: { defaultDeviceSerial: null, adbPathOverride: null },
     defaults: { defaultDeviceSerial: null, adbPathOverride: null },
@@ -98,7 +100,7 @@ beforeEach(() => {
           onPermissionGuideStatusChanged: vi.fn(() => () => undefined),
           onPermissionGuideCancelled: vi.fn(() => () => undefined),
           onUpdateProgress: vi.fn(() => () => undefined),
-          checkUpdate: vi.fn(),
+          checkUpdate: api.checkComputerUpdate,
         },
         android: {
           getConfig: api.getAndroidConfig,
@@ -120,6 +122,44 @@ beforeEach(() => {
 afterEach(cleanup);
 
 describe('ComputerUseSection browser backend health loading', () => {
+  it('keeps the initial driver update result when plugin state resolves later', async () => {
+    const computerPluginState = deferred<{ effectiveEnabled: boolean }>();
+    const driverUpdate = deferred<ComputerDriverUpdateCheck>();
+    api.getPluginState.mockImplementation((id: string) =>
+      id === 'computer'
+        ? computerPluginState.promise
+        : Promise.resolve({ effectiveEnabled: id === 'browser' }),
+    );
+    api.getComputerStatus.mockResolvedValueOnce({
+      ...computerUnavailable,
+      installed: true,
+      version: '0.12.2',
+    });
+    api.checkComputerUpdate.mockReturnValueOnce(driverUpdate.promise);
+
+    render(<ComputerUseSection workingDir="/tmp/project" />);
+
+    await waitFor(() => expect(api.checkComputerUpdate).toHaveBeenCalledTimes(1));
+    await act(async () => {
+      computerPluginState.resolve({ effectiveEnabled: false });
+      await computerPluginState.promise;
+    });
+    await act(async () => {
+      driverUpdate.resolve({
+        updateAvailable: true,
+        updating: false,
+        currentVersion: '0.12.2',
+        latestVersion: '0.12.3',
+      });
+      await driverUpdate.promise;
+    });
+
+    expect(
+      await screen.findByText('settings.computerUse.directControl.update.available'),
+    ).toBeTruthy();
+    expect(api.checkComputerUpdate).toHaveBeenCalledTimes(1);
+  });
+
   it('renders the base settings before browser status resolves', async () => {
     const browserStatus = deferred<BrowserAvailability>();
     api.getBrowserStatus.mockReturnValueOnce(browserStatus.promise);

--- a/apps/desktop/src/renderer/components/settings/__tests__/ComputerUseSection.browserHealth.test.tsx
+++ b/apps/desktop/src/renderer/components/settings/__tests__/ComputerUseSection.browserHealth.test.tsx
@@ -227,7 +227,9 @@ describe('ComputerUseSection browser backend health loading', () => {
 
   it('renders the base settings before browser status resolves', async () => {
     const browserStatus = deferred<BrowserAvailability>();
+    const computerStatus = deferred<ComputerDriverStatus>();
     api.getBrowserStatus.mockReturnValueOnce(browserStatus.promise);
+    api.getComputerStatus.mockReturnValueOnce(computerStatus.promise);
     api.getBackendState.mockResolvedValueOnce({ active: 'external' });
     api.getBackendHealth.mockResolvedValueOnce({
       active: 'external',
@@ -253,6 +255,16 @@ describe('ComputerUseSection browser backend health loading', () => {
       }),
     ).toBeTruthy();
     expect(screen.queryByText('settings.computerUse.browser.notDetected')).toBeNull();
+    expect(
+      (screen.getByRole('switch', {
+        name: 'settings.computerUse.directControl.toggleAria',
+      }) as HTMLButtonElement).disabled,
+    ).toBe(true);
+    expect(
+      (screen.getByRole('switch', {
+        name: 'settings.computerUse.android.toggleAria',
+      }) as HTMLButtonElement).disabled,
+    ).toBe(true);
 
     await act(async () => {
       browserStatus.resolve({
@@ -264,6 +276,28 @@ describe('ComputerUseSection browser backend health loading', () => {
     });
 
     expect(await screen.findByText('settings.computerUse.browser.notDetected')).toBeTruthy();
+    expect(
+      (screen.getByRole('switch', {
+        name: 'settings.computerUse.android.toggleAria',
+      }) as HTMLButtonElement).disabled,
+    ).toBe(true);
+
+    await act(async () => {
+      computerStatus.resolve(computerUnavailable);
+      await computerStatus.promise;
+    });
+    await waitFor(() =>
+      expect(
+        (screen.getByRole('switch', {
+          name: 'settings.computerUse.directControl.toggleAria',
+        }) as HTMLButtonElement).disabled,
+      ).toBe(false),
+    );
+    expect(
+      (screen.getByRole('switch', {
+        name: 'settings.computerUse.android.toggleAria',
+      }) as HTMLButtonElement).disabled,
+    ).toBe(false);
   });
 
   it('renders the Automation settings while the recoverable health probe is still pending', async () => {


### PR DESCRIPTION
## 这次改了什么

### 摘要

「设置 → 自动操作」之前用一个 `Promise.all` 等待插件状态、浏览器探测、电脑驱动状态和 backend state，且任一基础状态未完成时整个 `ComputerUseSection` 返回 `null`。`browser.status()` 为了正确区分 CDP 就绪和进程存活，可能需要持续确认进程已消失；这个被动探测因此会把整个设置内容拖成白屏。

本 PR 把首屏渲染和后台状态确认拆成独立阶段：

- 标题与浏览器、电脑、Android 三张基础卡片立即渲染；
- 各项插件、浏览器、电脑和 backend 状态独立回填；会改变上方几何的初始探测落定前，电脑与 Android 下方交互保持禁用；
- backend state 到达后即可显示选择器，health 结果仍按原有序列保护异步回填；
- 不修改 `ExternalChromeBackend` 的进程存活确认，不弱化启动、停止或路由切换的安全边界。

### 变更类型

- [ ] `feat` 新功能
- [x] `fix` 缺陷修复
- [ ] `refactor` / `perf` 重构或性能优化
- [ ] `docs` / `test` / `chore` 文档、测试或工程维护
- [ ] 其他：

### 范围

- 关联 Issue / 需求：Fixes #4292
- 本 PR 包含：`ComputerUseSection` 分阶段渲染；延迟 `browser.status()` / `computer.status()` 时的首屏与下方交互解锁回归测试
- 明确不包含：browser backend 的 status / health / 进程确认算法改动
- 用户可见变化：进入「自动操作」时先看到基础内容，各状态详情随异步探测完成补齐
- 是否存在 breaking change：无

### UI 变化

- Visual explanation：首帧保持原有标题、说明和三张卡片外观；依赖运行状态的开关在结果到达前禁用，browser/backend 详情随各自 Promise 完成后出现。未改样式、颜色、文案或卡片几何，因此没有额外截图。时序由延迟 Promise 的组件测试锁定。
- 引用的设计规范：`docs/design-rules/DESIGN.md` §10 Light / Dark Dual-Mode Delivery Gate。本次仅改渲染时序，保留现有语义 token 与所有已有状态样式，两种模式无分支差异。

## 怎么验证的

### 自动验证

```text
pnpm test:unit:related
结果：通过（apps/desktop related 3）。

pnpm --filter desktop exec vitest run src/renderer/components/settings/__tests__/ComputerUseSection.browserHealth.test.tsx
结果：通过（1 个测试文件，5 个测试）。

pnpm --filter desktop exec eslint src/renderer/components/settings/ComputerUseSection.tsx src/renderer/components/settings/__tests__/ComputerUseSection.browserHealth.test.tsx
结果：通过。

git diff --check origin/main...HEAD
结果：通过。
```

### 手工验证

不涉及；本次未启动打包版 macOS 应用。

### 未执行的验证

未在 macOS arm64 打包版上计时复测；白屏对应的渲染门槛和延迟状态返回由组件回归测试覆盖。

## 风险

### 风险分类

- [x] 无已知风险
- [ ] SQLite / migration
- [ ] system prompt
- [ ] 协议兼容
- [ ] 权限 / 安全 / 用户数据
- [ ] 存量插件兼容（批准状态 / 指纹 / manifest 校验 / 安装布局 / 包格式）
- [ ] 原生层 / fingerprint / OTA
- [ ] 跨平台差异
- [ ] 其他：

### 影响与回滚

- 影响范围：Desktop Renderer 的「自动操作」初始渲染时序
- 回滚 / 降级方式：回退本 PR 的单个提交即可恢复旧行为

### 提交前检查

- [x] 已 review 完整 diff
- [x] 每个 commit 都带 DCO 签名（`git commit -s`，见 [DCO](../DCO)）
- [x] UI 改动已在「UI 变化」注明引用的设计规范章节
- [x] 未提交凭证、令牌或授权文件
- [x] 已核对受影响的文档，本次行为变化与现行规则一致，无需修改文档
- [x] 已确认测试结果并如实说明未执行的打包版复测
