### PR TITLE
fix(mobile): 仅对更高版本提示整包更新

### DIFF
--- a/apps/mobile/src/update/bundleUpdate.test.ts
+++ b/apps/mobile/src/update/bundleUpdate.test.ts
@@ -15,6 +15,17 @@ const VALID = {
   itmsUrl: 'itms-services://?action=download-manifest&url=https%3A%2F%2Fx%2Fplist%2F42',
 };
 
+const UNSUPPORTED_VERSIONS = [
+  '1.0.0-beta.1',
+  '1.0.0+build.1',
+  'v2.0.0',
+  '1..2',
+  '1.0.-1',
+  '1.0.1e2',
+  '1.0.Infinity',
+  '1.0.9007199254740992',
+];
+
 describe('shouldCheckBundleUpdate', () => {
   it.each([
     ['非自建分发', false, false, false, false],
@@ -45,6 +56,18 @@ describe('parseLatestRelease', () => {
     expect(parseLatestRelease(null)).toBeNull();
     expect(parseLatestRelease('x')).toBeNull();
   });
+
+  it.each(UNSUPPORTED_VERSIONS)('version=%s 不受支持 → 无效记录', (version) => {
+    expect(parseLatestRelease({ ...VALID, version })).toBeNull();
+  });
+
+  it.each(UNSUPPORTED_VERSIONS)('minVersion=%s 不受支持 → 无效记录', (minVersion) => {
+    expect(parseLatestRelease({ ...VALID, minVersion })).toBeNull();
+  });
+
+  it.each(['1', '1.2', '01.002.0003', '1.2.0.0', '1.0.9007199254740991'])('保留纯数字版本 %s 的兼容性', (version) => {
+    expect(parseLatestRelease({ ...VALID, version })?.version).toBe(version);
+  });
 });
 
 describe('compareVersions', () => {
@@ -56,6 +79,44 @@ describe('compareVersions', () => {
 });
 
 describe('evaluateBundleUpdate', () => {
+  it.each(UNSUPPORTED_VERSIONS)('服务端 version=%s 不受支持 → 不提示整包', (version) => {
+    const evaluation = evaluateBundleUpdate({
+      currentRuntimeVersion: 'rtv-old',
+      currentVersion: '1.0.0',
+      latest: { ...VALID, version },
+    });
+    expect(evaluation).toEqual({ needsUpdate: false, forced: false, target: null });
+  });
+
+  it.each(UNSUPPORTED_VERSIONS)('本机 currentVersion=%s 不受支持 → 不提示整包', (currentVersion) => {
+    const evaluation = evaluateBundleUpdate({
+      currentRuntimeVersion: 'rtv-old',
+      currentVersion,
+      latest: { ...VALID, minVersion: '1.2.0' },
+    });
+    expect(evaluation).toEqual({ needsUpdate: false, forced: false, target: null });
+  });
+
+  it.each(UNSUPPORTED_VERSIONS)('服务端 minVersion=%s 不受支持 → 不提示整包', (minVersion) => {
+    const evaluation = evaluateBundleUpdate({
+      currentRuntimeVersion: 'rtv-old',
+      currentVersion: '1.0.0',
+      latest: { ...VALID, minVersion },
+    });
+    expect(evaluation).toEqual({ needsUpdate: false, forced: false, target: null });
+  });
+
+  it('版本周围的空格不影响纯数字版本比较', () => {
+    const evaluation = evaluateBundleUpdate({
+      currentRuntimeVersion: 'rtv-old',
+      currentVersion: ' 1.1.0 ',
+      latest: { ...VALID, version: ' 1.2.0 ', minVersion: ' 1.1.0 ' },
+    });
+    expect(evaluation.needsUpdate).toBe(true);
+    expect(evaluation.forced).toBe(false);
+    expect(evaluation.target?.version).toBe('1.2.0');
+  });
+
   it('runtimeVersion 相同 → 无整包更新(交给 JS OTA)', () => {
     const r = evaluateBundleUpdate({ currentRuntimeVersion: 'rtv-new', currentVersion: '1.1.0', latest: VALID });
     expect(r.needsUpdate).toBe(false);

--- a/apps/mobile/src/update/bundleUpdate.test.ts
+++ b/apps/mobile/src/update/bundleUpdate.test.ts
@@ -69,6 +69,34 @@ describe('evaluateBundleUpdate', () => {
     expect(r.target?.itmsUrl).toBe(VALID.itmsUrl);
   });
 
+  it.each([
+    ['0.1.4', 'rtv-old', undefined],
+    ['0.1.4', 'rtv-new', undefined],
+    ['0.1.5', 'rtv-old', undefined],
+    ['0.1.5', 'rtv-new', undefined],
+    ['0.1.5.0', 'rtv-old', undefined],
+    ['0.1.4', 'rtv-old', '0.1.6'],
+    ['0.1.5', 'rtv-old', '0.1.6'],
+  ])('本机 0.1.5 忽略服务端 version=%s / runtime=%s / minVersion=%s 的整包', (version, runtimeVersion, minVersion) => {
+    const evaluation = evaluateBundleUpdate({
+      currentRuntimeVersion: 'rtv-new',
+      currentVersion: '0.1.5',
+      latest: { ...VALID, version, runtimeVersion, minVersion, buildNumber: 9999999999 },
+    });
+    expect(evaluation).toEqual({ needsUpdate: false, forced: false, target: null });
+  });
+
+  it('更高的多位 patch 版本 → 普通整包更新(按数值而非字符串比较)', () => {
+    const evaluation = evaluateBundleUpdate({
+      currentRuntimeVersion: 'rtv-old',
+      currentVersion: '0.1.9',
+      latest: { ...VALID, version: '0.1.10' },
+    });
+    expect(evaluation.needsUpdate).toBe(true);
+    expect(evaluation.forced).toBe(false);
+    expect(evaluation.target?.version).toBe('0.1.10');
+  });
+
   it('minVersion 高于当前 → 强制', () => {
     const r = evaluateBundleUpdate({
       currentRuntimeVersion: 'rtv-old',
@@ -82,9 +110,10 @@ describe('evaluateBundleUpdate', () => {
   it('minVersion 不高于当前 → 不强制', () => {
     const r = evaluateBundleUpdate({
       currentRuntimeVersion: 'rtv-old',
-      currentVersion: '1.2.0',
-      latest: { ...VALID, minVersion: '1.2.0' },
+      currentVersion: '1.1.0',
+      latest: { ...VALID, minVersion: '1.1.0' },
     });
+    expect(r.needsUpdate).toBe(true);
     expect(r.forced).toBe(false);
   });
 
@@ -105,23 +134,20 @@ describe('evaluateBundleUpdate', () => {
   it('runtimeVersion 相同且不低于 minVersion → 无更新', () => {
     const r = evaluateBundleUpdate({
       currentRuntimeVersion: 'rtv-new',
-      currentVersion: '1.2.0',
-      latest: { ...VALID, minVersion: '1.2.0' },
+      currentVersion: '1.1.0',
+      latest: { ...VALID, minVersion: '1.1.0' },
     });
     expect(r.needsUpdate).toBe(false);
     expect(r.target).toBeNull();
   });
 
-  it('record 缺 version 但带 minVersion → 不强更(退化成普通提示,不造无法自愈的阻断)', () => {
-    // 无目标版本就无法证明"装上它能解除阻断",阻断态的自愈也失去比较基准。
-    // 发布链侧 assertMinVersionUsable 已保证有 minVersion 必有 version,这里是客户端兜底。
-    const r = evaluateBundleUpdate({
+  it.each([undefined, null, '', '   '])('record version=%s → 不提示(无法证明服务端版本更高)', (version) => {
+    const evaluation = evaluateBundleUpdate({
       currentRuntimeVersion: 'rtv-old',
       currentVersion: '1.0.0',
-      latest: { ...VALID, version: '', minVersion: '1.2.0' },
+      latest: { ...VALID, version, minVersion: '1.2.0' },
     });
-    expect(r.forced).toBe(false);
-    expect(r.needsUpdate).toBe(true); // runtimeVersion 不同 → 仍是可跳过的普通更新
+    expect(evaluation).toEqual({ needsUpdate: false, forced: false, target: null });
   });
 
   it('minVersion 高于该记录自己的 version → 不强更(装完仍低于门槛,阻断屏会没有出口)', () => {
@@ -144,14 +170,13 @@ describe('evaluateBundleUpdate', () => {
     expect(r.forced).toBe(true);
   });
 
-  it('缺 currentVersion → 不强更(无法比较,fail-open)', () => {
-    const r = evaluateBundleUpdate({
-      currentRuntimeVersion: 'rtv-new',
-      currentVersion: null,
+  it.each([undefined, null, '', '   '])('currentVersion=%s → 不提示(无法比较,fail-open)', (currentVersion) => {
+    const evaluation = evaluateBundleUpdate({
+      currentRuntimeVersion: 'rtv-old',
+      currentVersion,
       latest: { ...VALID, minVersion: '1.2.0' },
     });
-    expect(r.needsUpdate).toBe(false);
-    expect(r.forced).toBe(false);
+    expect(evaluation).toEqual({ needsUpdate: false, forced: false, target: null });
   });
 
   it('拿不到当前 runtimeVersion(dev / 未启用)→ 无更新', () => {

--- a/apps/mobile/src/update/bundleUpdate.ts
+++ b/apps/mobile/src/update/bundleUpdate.ts
@@ -2,9 +2,9 @@
 //
 // 背景:
 // - expo-updates 只感知"我这个 runtimeVersion 有没有新 JS OTA",不会告知"有更高 runtimeVersion 的整包"。
-// - 所以整包发现靠独立的 `/latest` 通道 + 客户端比对 runtimeVersion:
-//     · latest.runtimeVersion === 当前 runtimeVersion → 无需整包(JS OTA 通道会处理);
-//     · 不同 → 原生层变了,JS OTA 覆盖不到 → 引导用户打开 release record 的正常安装入口。
+// - 所以整包发现靠独立的 `/latest` 通道,先确认服务端 version 高于当前原生版本:
+//     · 服务端版本不高于当前版本 → 不提示整包,不影响独立的 JS OTA 通道;
+//     · 版本更高时比对 runtimeVersion:相同交给 JS OTA,不同则引导打开正常安装入口。
 // - minVersion(可选)用于强制更新:当前 version 低于它则阻断使用、只留"去更新"。
 //   强更判定**不经过 runtimeVersion 门闸**:门槛由服务端按 version 下发,同 runtimeVersion
 //   的旧构建也必须能被强更(否则"发布链写了 minVersion 却对同指纹装机无效")。
@@ -22,7 +22,7 @@ export interface LatestReleaseRecord {
 }
 
 export interface BundleUpdateEvaluation {
-  /** 是否有整包更新(runtimeVersion 与当前不一致)。 */
+  /** 是否有整包更新(服务端版本更高,且 runtimeVersion 不同或命中强更)。 */
   needsUpdate: boolean;
   /** 是否强制(needsUpdate 且当前 version < minVersion)。 */
   forced: boolean;
@@ -100,14 +100,14 @@ export function compareVersions(a: string, b: string): number {
 }
 
 /**
- * 判定是否需要引导整包更新。两条独立信号:
+ * 判定是否需要引导整包更新。服务端 version 必须高于当前原生 version,再检查两条信号:
  * - runtimeVersion 不一致 → 有整包更新(可跳过的普通提示);
  * - 当前 version < minVersion → 强更,**与 runtimeVersion 是否一致无关**。
  *   服务端可以对某个已发布版本事后下发门槛,把同指纹的问题构建也挡住;
  *   反过来说,同 runtimeVersion 命中强更时 target.runtimeVersion 就等于当前值,
  *   消费方不得把它当作"换了指纹"的证据。
- * 拿不到当前 runtimeVersion(dev / expo-updates 未启用)、拿不到当前 version 或
- * `/latest` 无效 → 一律视为无更新(比不出来就不挡人,fail-open)。
+ * 拿不到当前 runtimeVersion(dev / expo-updates 未启用)、本机或服务端 version 缺失、
+ * 服务端版本不高于本机、`/latest` 无效 → 视为无整包更新,不影响独立的 JS OTA 通道。
  */
 export function evaluateBundleUpdate({
   currentRuntimeVersion,
@@ -120,18 +120,18 @@ export function evaluateBundleUpdate({
   const current = String(currentRuntimeVersion ?? '').trim();
   if (!current) return NO_UPDATE;
 
+  const currentAppVersion = String(currentVersion ?? '').trim();
+  if (!currentAppVersion || !record.version) return NO_UPDATE;
+  if (compareVersions(record.version, currentAppVersion) <= 0) return NO_UPDATE;
+
   // 强更要求这条记录本身**能被满足**:
-  // - 带 version:拿不到目标版本就无法证明"装上它就能解除阻断"(阻断态自愈全靠这个
-  //   可比较的版本,见 forcedUpdateRecheck 的新鲜度门);
   // - minVersion ≤ version:否则唯一提供的安装目标仍低于门槛,用户装完照旧被强更,
   //   阻断屏成了没有出口的死屋,只能等运维改指针。
-  // 发布链侧 assertMinVersionUsable 已经保证这两条,这里是客户端兜底(手工改过的 / 历史
+  // 发布链侧 assertMinVersionUsable 已经保证门槛可满足,这里是客户端兜底(手工改过的 / 历史
   // 遗留的指针也不能把人关死):记录不自洽时退化成可跳过的普通更新提示。
   const forced = Boolean(
     record.minVersion &&
-    record.version &&
-    currentVersion &&
-    compareVersions(String(currentVersion), record.minVersion) < 0 &&
+    compareVersions(currentAppVersion, record.minVersion) < 0 &&
     compareVersions(record.version, record.minVersion) >= 0,
   );
 

--- a/apps/mobile/src/update/bundleUpdate.ts
+++ b/apps/mobile/src/update/bundleUpdate.ts
@@ -64,7 +64,12 @@ export function shouldCheckBundleUpdate({
   return isSelfHosted && !isReviewMode && !isTestFlightBuild;
 }
 
-/** 校验并收窄 `/latest` 响应为 LatestReleaseRecord;字段缺失即返回 null(宁可不提示,不误导)。 */
+export function isSupportedBundleVersion(version: string): boolean {
+  return /^\d+(?:\.\d+)*$/.test(version)
+    && version.split('.').every((part) => Number.isSafeInteger(Number(part)));
+}
+
+/** 校验 `/latest` 响应;版本仅支持点分纯数字,字段缺失或格式非法返回 null(不误导)。 */
 export function parseLatestRelease(value: unknown): LatestReleaseRecord | null {
   if (!value || typeof value !== 'object') return null;
   const v = value as Record<string, unknown>;
@@ -72,8 +77,8 @@ export function parseLatestRelease(value: unknown): LatestReleaseRecord | null {
   const version = typeof v.version === 'string' ? v.version.trim() : '';
   const installUrl = typeof v.installUrl === 'string' ? v.installUrl.trim() : '';
   const itmsUrl = typeof v.itmsUrl === 'string' ? v.itmsUrl.trim() : '';
-  // 至少要有 runtimeVersion(判定门闸)+ 一个可跳转的安装地址。
-  if (!runtimeVersion || (!installUrl && !itmsUrl)) return null;
+  // 必须有 runtimeVersion、支持的 version 和一个可跳转的安装地址。
+  if (!runtimeVersion || !isSupportedBundleVersion(version) || (!installUrl && !itmsUrl)) return null;
   const record: LatestReleaseRecord = {
     version,
     buildNumber: (typeof v.buildNumber === 'string' || typeof v.buildNumber === 'number') ? v.buildNumber : '',
@@ -82,11 +87,15 @@ export function parseLatestRelease(value: unknown): LatestReleaseRecord | null {
     itmsUrl,
   };
   if (typeof v.releaseNotes === 'string') record.releaseNotes = v.releaseNotes;
-  if (typeof v.minVersion === 'string' && v.minVersion.trim()) record.minVersion = v.minVersion.trim();
+  if (typeof v.minVersion === 'string' && v.minVersion.trim()) {
+    const minVersion = v.minVersion.trim();
+    if (!isSupportedBundleVersion(minVersion)) return null;
+    record.minVersion = minVersion;
+  }
   return record;
 }
 
-/** 语义化版本比较:a<b → -1,a==b → 0,a>b → 1。非数字段按 0 处理。 */
+/** 比较已校验的点分纯数字版本:a<b → -1,a==b → 0,a>b → 1,缺失段按 0 处理。 */
 export function compareVersions(a: string, b: string): number {
   const pa = String(a).split('.').map((x) => Number(x));
   const pb = String(b).split('.').map((x) => Number(x));
@@ -106,7 +115,7 @@ export function compareVersions(a: string, b: string): number {
  *   服务端可以对某个已发布版本事后下发门槛,把同指纹的问题构建也挡住;
  *   反过来说,同 runtimeVersion 命中强更时 target.runtimeVersion 就等于当前值,
  *   消费方不得把它当作"换了指纹"的证据。
- * 拿不到当前 runtimeVersion(dev / expo-updates 未启用)、本机或服务端 version 缺失、
+ * 拿不到当前 runtimeVersion(dev / expo-updates 未启用)、版本字段缺失或不是点分纯数字、
  * 服务端版本不高于本机、`/latest` 无效 → 视为无整包更新,不影响独立的 JS OTA 通道。
  */
 export function evaluateBundleUpdate({
@@ -121,7 +130,7 @@ export function evaluateBundleUpdate({
   if (!current) return NO_UPDATE;
 
   const currentAppVersion = String(currentVersion ?? '').trim();
-  if (!currentAppVersion || !record.version) return NO_UPDATE;
+  if (!isSupportedBundleVersion(currentAppVersion)) return NO_UPDATE;
   if (compareVersions(record.version, currentAppVersion) <= 0) return NO_UPDATE;
 
   // 强更要求这条记录本身**能被满足**:

--- a/apps/mobile/src/update/forcedUpdateRecheck.test.ts
+++ b/apps/mobile/src/update/forcedUpdateRecheck.test.ts
@@ -241,6 +241,35 @@ describe('createForcedUpdateRechecker 解除判定', () => {
     expect(deps.onCleared).not.toHaveBeenCalled();
   });
 
+  it.each(['3.0.0-beta.1', '3.0.0+build.1', 'v3.0.0', '3..0'])('目标 version=%s 不受支持 → 维持阻断', async (version) => {
+    const deps = makeDeps({
+      fetchLatest: vi.fn(async () => latestRecord({ version, minVersion: undefined })),
+      getHeldTarget: () => ({ version: '2.0.0' }),
+    });
+    await expect(runOnce(deps)).resolves.toBe('error');
+    expect(deps.onCleared).not.toHaveBeenCalled();
+    expect(deps.onStillForced).not.toHaveBeenCalled();
+  });
+
+  it.each(['3.0.0-beta.1', '3.0.0+build.1', 'v3.0.0', '3..0'])('本机 version=%s 不受支持 → 维持阻断', async (version) => {
+    const deps = makeDeps({
+      fetchLatest: vi.fn(async () => latestRecord({ minVersion: undefined })),
+      getCurrentVersion: () => version,
+    });
+    await expect(runOnce(deps)).resolves.toBe('error');
+    expect(deps.onCleared).not.toHaveBeenCalled();
+    expect(deps.onStillForced).not.toHaveBeenCalled();
+  });
+
+  it.each(['2.0.0-beta.1', '2.0.0+build.1', 'v2.0.0'])('minVersion=%s 不受支持 → 维持阻断且不更新目标', async (minVersion) => {
+    const deps = makeDeps({
+      fetchLatest: vi.fn(async () => latestRecord({ minVersion })),
+    });
+    await expect(runOnce(deps)).resolves.toBe('error');
+    expect(deps.onCleared).not.toHaveBeenCalled();
+    expect(deps.onStillForced).not.toHaveBeenCalled();
+  });
+
   it('同版本记录撤回门槛(最常见的撤回形态)→ 正常解除', async () => {
     const deps = makeDeps({
       fetchLatest: vi.fn(async () => latestRecord({ version: '2.0.0', minVersion: undefined })),

--- a/apps/mobile/src/update/forcedUpdateRecheck.ts
+++ b/apps/mobile/src/update/forcedUpdateRecheck.ts
@@ -13,7 +13,7 @@
 // 节流比 resume 通道(5 分钟)短得多:用户此刻正被挡在门外,恢复延迟直接可感;
 // 但仍要节流,避免在阻断屏上反复切前后台把 /latest 打成高频请求。
 
-import { compareVersions, evaluateBundleUpdate, parseLatestRelease } from './bundleUpdate';
+import { compareVersions, evaluateBundleUpdate, isSupportedBundleVersion, parseLatestRelease } from './bundleUpdate';
 import { withTimeout } from './startupOtaUpdate';
 
 export type ForcedUpdateRecheckOutcome = 'still-forced' | 'cleared' | 'error';
@@ -139,9 +139,10 @@ export function createForcedUpdateRechecker(
       const currentRuntimeVersion = String(deps.getCurrentRuntimeVersion() ?? '').trim();
       const currentVersion = String(deps.getCurrentVersion() ?? '').trim();
       if (!record || !currentRuntimeVersion || !currentVersion) return 'error';
+      if (!isSupportedBundleVersion(currentVersion)) return 'error';
       // 新鲜度门:读到的记录不得比正在阻断的目标更旧。可变指针 + 无 cache-buster 的请求
       // 会撞上 CDN 边缘的旧记录,那条记录没有 minVersion → 会把仍需强更的用户放出去。
-      // 记录缺 version(parseLatestRelease 容许空串)同样证明不了新鲜度,一并挡掉。
+      // 记录的 version 格式已在 parseLatestRelease 校验,这里继续挡掉版本更旧的记录。
       // 只有两边都有版本号时才比较。held.version 为空按"无新鲜度约束"处理而不是维持阻断
       // ——否则一条无 version 的记录会把用户永久钉在阻断屏上(定时与回前台核对都过不去)。
       // 这种情况现在不可达:evaluateBundleUpdate 要求 record 带 version 才判 forced,

--- a/apps/mobile/src/update/resumeUpdateCheck.test.ts
+++ b/apps/mobile/src/update/resumeUpdateCheck.test.ts
@@ -240,6 +240,17 @@ describe('createResumeUpdateChecker 整包路径', () => {
     expect(deps.onForcedUpdate).not.toHaveBeenCalled();
   });
 
+  it.each(['0.1.4', '0.1.5'])('整包 version=%s 不高于本机 → 忽略整包,OTA 仍正常下载', async (version) => {
+    const deps = makeDeps({
+      getCurrentVersion: () => '0.1.5',
+      fetchLatest: vi.fn(async () => latestRecord({ version })),
+      checkForUpdateAsync: vi.fn(async () => ({ isAvailable: true })),
+    });
+    await expect(runOnce(deps)).resolves.toEqual({ ota: 'fetched', bundle: 'up-to-date' });
+    expect(deps.fetchUpdateAsync).toHaveBeenCalledOnce();
+    expect(deps.onForcedUpdate).not.toHaveBeenCalled();
+  });
+
   it('强更(minVersion)→ forced 且回调一次', async () => {
     const deps = makeDeps({ fetchLatest: vi.fn(async () => latestRecord({ minVersion: '2.0.0' })) });
     const { bundle } = await runOnce(deps);


### PR DESCRIPTION
## 这次改了什么

### 摘要

审阅补充：仅支持点分纯数字版本，拒绝不支持的 version / minVersion 字符串和不安全整数，避免把非数字片段当作 0 排序；同时保持已有强更状态对坏记录的保护。

自建移动端发现整包更新时，先确认服务端当前通道的版本严格高于本机原生版本，再沿用既有 runtimeVersion / minVersion 判定。修复本机已安装 0.1.5、release / beta 仍指向 0.1.4 时误弹整包更新的问题。

### 变更类型

- [x] `fix` 缺陷修复
- [ ] `feat` 新功能
- [ ] `refactor` / `perf` 重构或性能优化
- [ ] `docs` / `test` / `chore` 文档、测试或工程维护
- [ ] 其他：

### 范围

- 关联 Issue / 需求：用户确认的「先做版本高低门控，再保留现有 OTA / 强更语义」需求。
- 本 PR 包含：统一整包判定函数的版本门控；低版本、同版本、多位 patch、版本缺失、异常门槛与 OTA 独立下载的回归测试；同步更新函数说明。
- 明确不包含：服务端或私有发布流水线、线上 minVersion、通道选择、安装入口、OTA 下载/重启、原生配置与依赖。
- 用户可见变化：服务端 version <= 本机 APP_BINARY_VERSION 时不再提示整包更新；缺少本机或目标版本也不提示。iOS / Android、release / beta / canary 共用同一逻辑。
- 是否存在 breaking change：无协议或原生 ABI 变化。相同 version 但不同 runtime 的整包将不再提示，这是本次明确要求的行为；需要引导安装的新原生包必须提升 version，不能只提高 buildNumber / versionCode。

### UI 变化

不新增或修改界面、布局、样式和文案，只收窄现有整包提示的触发条件。

- 引用的设计规范：不涉及：纯更新判定及单测，复用既有普通更新提示和强更阻断屏，不改视觉组件。

## 怎么验证的

### 自动验证

#### 审阅修复 c3dc8ae38（2026-09-11）

- 新增 57 个版本格式与强更恢复边界用例；修改前复现 47 项失败。
- 定向测试：4 个文件，152 项通过。
- 干净临时验证环境（原工作区与验证副本逐文件一致）：
  - `pnpm test:unit:related` 通过，自动选择 `apps/mobile (related 5)`。
  - `pnpm --filter mobile run --if-present typecheck` 通过。
  - `pnpm --filter mobile test` 通过：428 个文件，5,474 项测试。
- `pnpm check:dco` 通过：本 PR 2 个提交均带匹配身份的 Signed-off-by。
- 再次比较本轮修改前后的 iOS / Android fingerprint：均不变，与首轮记录相同。
- 版本支持范围仅为点分纯数字；不新增预发布、构建元数据或 v 前缀的排序语义。对不支持格式不提示整包，已强更时则保持阻断。该处理与已确认需求无冲突。

#### 首轮实现 00381d4b7

以下提交门禁在用户确认的干净临时验证环境运行：以主仓 `makecindy/cindy` 的 `main` 为比较基线，只带入本次 3 个文件的改动；与原工作区逐文件比对一致。依赖按锁文件安装（`pnpm install --frozen-lockfile --ignore-scripts`，仅用于 JS 验证，不启动客户端或下载原生运行时）。

```text
pnpm test:unit:related
通过：RELATED related: apps/mobile (related 3)

pnpm --filter mobile run --if-present typecheck
通过

pnpm --filter mobile test
通过：428 个测试文件，5,417 项测试

pnpm check:dco
通过：本次 1 个 commit 带匹配 author 的 Signed-off-by

node apps/mobile/scripts/ci-fingerprint.mjs compute --output <临时文件>
在原工作区修改前后分别计算，并用 compareFingerprintReports 对比：changed=false
工具版本：@expo/fingerprint 0.20.10
  iOS：643c2ec10dce31a6218d8fce5e43e0de85e1a24c（前后相同）
  Android：36a233f2aa64a5cafcc2c66dcadb4945de6eefcf（前后相同）

git diff --check
通过
```

定向测试先复现了 15 项失败，加入版本门控后，包含强更恢复、手动检查、启动 OTA 的 8 个定向测试文件 / 168 项全部通过。

**共享工作区的额外验证结果（未隐瞒失败）：** 最初运行根 `pnpm test:unit:related` 时，因默认 `origin/main` 指向落后的 fork，继承的主仓依赖变化使它自动退回全量。Mobile 全量通过，但 Desktop `botSettingsDrawer.test.tsx` 有 4 项 AbortSignal / RequestInit 错误（单文件重跑仍复现），原有未跟踪的 `remoteHostAgentForwarding.test.ts` 有 3 项失败，且旧依赖目录缺少新加入的 `@terrazzo/cli`。这些均未被删改或纳入本 PR。用户随后明确选择隔离验证，提交依据为上面按真实 PR 基线运行并通过的原始门禁。

### 手工验证

- 已 review 完整 diff；只包含 5 个 Mobile 更新判定/测试文件，不包含工作区原有未跟踪文件。
- 检查原生指纹输入路径，无 app.json / app.config.js / package.json / eas.json / fingerprint.config.cjs / plugins / modules / lockfile 改动。

### 未执行的验证

- 未做 iOS / Android 真机安装或 Light / Dark 实机目检；没有修改视觉界面。
- 本地分支 `fix/mobile-update-version-gate`，复用现有工作区；未启动 Metro / App，因此没有 Metro 归属或 __DEV__ build label 验收证据。
- 未跑私有 CN / Global 发布流水线，未发布整包或 OTA；本地 fingerprint 对比使用相同环境的仓库 production guard，不冒充线上 runtime 哈希。

## 风险

### 风险分类

- [ ] 无已知风险
- [ ] SQLite / migration
- [ ] system prompt
- [ ] 协议兼容
- [ ] 权限 / 安全 / 用户数据
- [ ] 存量插件兼容（批准状态 / 指纹 / manifest 校验 / 安装布局 / 包格式）
- [x] 原生层 / fingerprint / OTA
- [ ] 跨平台差异
- [ ] 其他：

### 影响与回滚

- 影响范围：自建移动端整包发现，iOS / Android 一致。只修改 JS 判定，双端本地 fingerprint 前后不变，本 PR 本身不触发冷更。
- 服务端版本更高时保留原行为：runtime 不同且未命中 minVersion → 普通提示；满足 `currentVersion < minVersion <= target.version` → 强更（包括同 runtime）；同 runtime 且无需强更 → 交给 JS OTA。
- JS OTA 检查/下载独立运行，不因整包版本门控停用。已进入强更的旧记录保护、网络失败保持阻断及门槛撤回机制保持不变。
- 发布注意：这不是发布流水线门禁的实现。若要引导用户安装新的原生包，必须递增 version；只增 buildNumber / versionCode 或同 version 换 runtime 不会弹整包提示。
- 回滚 / 降级方式：撤销本提交并通过原有渠道发布兼容 runtime 的 JS OTA；无需新增数据库迁移或整包冷更。旧 runtime 能否收到修复取决于对应 OTA 的维护/发布范围。

### 提交前检查

- [x] 已 review 完整 diff
- [x] 每个 commit 都带 DCO 签名（`git commit -s`）
- [x] UI 改动已在「UI 变化」注明引用的设计规范章节（不涉及 UI 则跳过）
- [x] 未提交凭证、令牌或授权文件
- [x] 已核对受影响的文档，行为变化涉及的旧结论已同步修订（相关说明在判定函数内）
- [x] 已确认测试结果或说明未执行原因
