### PR TITLE
fix(models): 预设 Pi 来源按官方目录补齐档位投影

### DIFF
--- a/packages/model-providers/src/__tests__/user-provider.test.ts
+++ b/packages/model-providers/src/__tests__/user-provider.test.ts
@@ -1503,3 +1503,58 @@ describe("live preset defaults and discovery provenance", () => {
     expect(current().supportsImageInput).toBeUndefined();
   });
 });
+
+describe("official Pi catalog defaults for preset-marked sources (#4295)", () => {
+  const kimiRuntime = () => ({
+    piCatalogProviderId: "kimi-coding",
+    baseUrl: "https://api.kimi.com/coding",
+    wireProtocol: "anthropic-messages" as const,
+    models: [
+      // 2026-09-09 之前从预设创建的存量来源:没有 catalogPresetId,模型也没有 reasoning 字段。
+      { id: "k3-256k", name: "Kimi K3-256K", contextWindow: 262144 },
+      { id: "kimi-for-coding", name: "Kimi K2.7 Code", contextWindow: 262144 },
+    ],
+  });
+  const build = (config: CustomProviderConfig) =>
+    buildUserProvider(config, {
+      modelRegistry: { schemaVersion: 4, updatedAt: "2026-09-11T00:00:00.000Z", models: [] },
+    }).models.pi!;
+
+  it("projects reasoning efforts from the official Pi catalog when the stored model lacks them", () => {
+    const models = build({ id: "kimi-code", name: "Kimi Code", runtimes: { pi: kimiRuntime() } });
+    expect(models.find((m) => m.id === "k3-256k")).toMatchObject({
+      efforts: ["low", "high", "max"],
+      defaultEffort: "high",
+      supportsImageInput: true,
+      maxOutput: 131072,
+    });
+    // 官方目录对该模型只声明 reasoning 而无档位表:与 pi-host 运行期同样得到通用四档。
+    expect(models.find((m) => m.id === "kimi-for-coding")).toMatchObject({
+      efforts: ["minimal", "low", "medium", "high"],
+    });
+  });
+
+  it("keeps explicit user reasoning settings ahead of the catalog defaults", () => {
+    const runtime = kimiRuntime();
+    runtime.models[0] = { ...runtime.models[0], reasoning: false } as never;
+    const models = build({ id: "kimi-code", name: "Kimi Code", runtimes: { pi: runtime } });
+    expect(models.find((m) => m.id === "k3-256k")).toMatchObject({ efforts: [], defaultEffort: null });
+  });
+
+  it("does not lend catalog capabilities to a hand-edited endpoint or protocol", () => {
+    const edited = kimiRuntime();
+    edited.baseUrl = "https://proxy.example/coding";
+    expect(
+      build({ id: "kimi-code", name: "Kimi Code", runtimes: { pi: edited } }).find((m) => m.id === "k3-256k"),
+    ).toMatchObject({ efforts: [] });
+    const otherProtocol = { ...kimiRuntime(), wireProtocol: "openai-chat" as const };
+    expect(
+      build({ id: "kimi-code", name: "Kimi Code", runtimes: { pi: otherProtocol } }).find((m) => m.id === "k3-256k"),
+    ).toMatchObject({ efforts: [] });
+    const unmarked = kimiRuntime();
+    delete (unmarked as { piCatalogProviderId?: string }).piCatalogProviderId;
+    expect(
+      build({ id: "kimi-code", name: "Kimi Code", runtimes: { pi: unmarked } }).find((m) => m.id === "k3-256k"),
+    ).toMatchObject({ efforts: [] });
+  });
+});

--- a/packages/model-providers/src/__tests__/user-provider.test.ts
+++ b/packages/model-providers/src/__tests__/user-provider.test.ts
@@ -1534,6 +1534,38 @@ describe("official Pi catalog defaults for preset-marked sources (#4295)", () =>
     });
   });
 
+  it("merges the catalog under a preset that only declares context/image metadata", () => {
+    const presets = [
+      {
+        id: "moonshot-kimi-code",
+        name: "Kimi Code",
+        runtimes: {
+          pi: {
+            baseUrl: "https://api.kimi.com/coding",
+            wireProtocol: "anthropic-messages" as const,
+            piCatalogProviderId: "kimi-coding",
+            models: [
+              // 预设显式声明档位:预设优先于官方目录。
+              { id: "k3-256k", name: "Kimi K3-256K", contextWindow: 262144, reasoning: true, reasoningEfforts: ["low", "high"], reasoningDefaultEffort: "low" },
+              // 预设只声明 context/image:reasoning 由官方目录补齐,不被短路。
+              { id: "kimi-for-coding", name: "Kimi K2.7 Code", contextWindow: 262144, supportsImageInput: true },
+            ],
+          },
+        },
+      },
+    ];
+    const runtime = { ...kimiRuntime(), catalogPresetId: "moonshot-kimi-code" };
+    const models = buildUserProvider(
+      { id: "kimi-code", name: "Kimi Code", runtimes: { pi: runtime } },
+      { presets: presets as never, modelRegistry: { schemaVersion: 4, updatedAt: "2026-09-11T00:00:00.000Z", models: [] } },
+    ).models.pi!;
+    expect(models.find((m) => m.id === "k3-256k")).toMatchObject({ efforts: ["low", "high"], defaultEffort: "low" });
+    expect(models.find((m) => m.id === "kimi-for-coding")).toMatchObject({
+      efforts: ["minimal", "low", "medium", "high"],
+      supportsImageInput: true,
+    });
+  });
+
   it("keeps explicit user reasoning settings ahead of the catalog defaults", () => {
     const runtime = kimiRuntime();
     runtime.models[0] = { ...runtime.models[0], reasoning: false } as never;

--- a/packages/model-providers/src/piNativeCatalog.ts
+++ b/packages/model-providers/src/piNativeCatalog.ts
@@ -2,13 +2,20 @@ import piModelCatalogJson from "../catalog/pi-model-catalog.json" with { type: "
 
 import { defaultEffortForCapabilities } from "./effortResolution.js";
 import { piSupportedEfforts } from "./piThinkingLevels.mjs";
-import type { CatalogModel, ModelCost, PiModelApi } from "./types.js";
+import type { ModelMetadata } from "./modelMetadataLayers.js";
+import type {
+  CatalogModel,
+  ModelCost,
+  PiModelApi,
+  ProviderWireProtocol,
+} from "./types.js";
 
 interface PiCatalogRow {
   id: string;
   name?: string;
   api?: string;
   provider: string;
+  baseUrl?: string;
   contextWindow: number;
   maxTokens?: number;
   input?: string[];
@@ -94,4 +101,66 @@ export function piNativeCatalogModels(
       ...(piApi ? { piApi } : {}),
     };
   });
+}
+
+function wireProtocolToPiCatalogApi(protocol: ProviderWireProtocol): string {
+  switch (protocol) {
+    case "anthropic-messages":
+      return "anthropic-messages";
+    case "openai-responses":
+      return "openai-responses";
+    case "openai-chat":
+      return "openai-completions";
+  }
+}
+
+/**
+ * Whether a user runtime still points at the official Pi route of `piProviderId`
+ * (single catalog baseUrl and API family, same as pi-host's official-model overlay gate).
+ * A hand-edited endpoint or protocol must not borrow the official capability table.
+ */
+export function piNativeCatalogRouteMatches(
+  piProviderId: string,
+  baseUrl: string,
+  wireProtocol: ProviderWireProtocol | undefined,
+): boolean {
+  const rows = PI_CATALOG.providers[piProviderId];
+  if (!rows?.length) return false;
+  const baseUrls = new Set(
+    rows.map((row) => (row.baseUrl ?? "").trim().replace(/\/+$/, "")),
+  );
+  const apis = new Set(rows.map((row) => row.api));
+  return (
+    baseUrls.size === 1 &&
+    baseUrls.has(baseUrl.trim().replace(/\/+$/, "")) &&
+    apis.size === 1 &&
+    (wireProtocol === undefined ||
+      apis.has(wireProtocolToPiCatalogApi(wireProtocol)))
+  );
+}
+
+/**
+ * Capability defaults of one official Pi catalog model, for user sources that are marked
+ * with `piCatalogProviderId` but whose stored model lacks reasoning metadata (sources created
+ * before `catalogPresetId` existed). Keeps the Orca/route projection on the same capability
+ * table pi-host materializes at runtime; explicit user settings still override these defaults.
+ */
+export function piNativeCatalogModelDefaults(
+  piProviderId: string,
+  modelId: string,
+): ModelMetadata | undefined {
+  const row = PI_CATALOG.providers[piProviderId]?.find(
+    (candidate) => candidate.id === modelId,
+  );
+  if (!row) return undefined;
+  const efforts = piSupportedEfforts(row);
+  return {
+    contextWindow: row.contextWindow,
+    ...(Number.isFinite(row.maxTokens) && row.maxTokens! > 0
+      ? { maxOutputTokens: row.maxTokens }
+      : {}),
+    efforts,
+    defaultEffort: defaultEffortForCapabilities(efforts),
+    ...(row.input ? { supportsImageInput: row.input.includes("image") } : {}),
+  };
 }

--- a/packages/model-providers/src/user-provider.ts
+++ b/packages/model-providers/src/user-provider.ts
@@ -4,6 +4,7 @@ import {
   expandedRegistryEntries,
   resolveModelMetadata,
   applyModelMetadata,
+  mergeModelMetadata,
   pickModelMetadata,
   runtimeUserModelMetadata,
   type ModelMetadata,
@@ -491,13 +492,17 @@ export function buildUserProvider(
       // Pi 来源带 piCatalogProviderId 且仍走官方路由时,pi-host 运行期会整条套用官方 Pi
       // 目录;没有 catalogPresetId(#4108 之前创建)的存量来源在这里没有预设默认,存储
       // 模型又缺 reasoning 字段,目录投影就成了空档位,Orca 创建 Worker 时把合法的
-      // max 拒成「valid: none」(#4295)。按同一份官方目录补默认,用户显式配置仍优先。
-      const defaults =
-        presetDefaults ??
-        (agent === "pi" && rt.piCatalogProviderId && !m.route &&
+      // max 拒成「valid: none」(#4295)。按同一份官方目录补默认:预设按字段覆盖官方
+      // 目录(预设只声明 context/image 时 reasoning 仍由目录补),用户显式配置仍优先。
+      const catalogDefaults =
+        agent === "pi" && rt.piCatalogProviderId && !m.route &&
         piNativeCatalogRouteMatches(rt.piCatalogProviderId, rt.baseUrl, rt.wireProtocol)
           ? piNativeCatalogModelDefaults(rt.piCatalogProviderId, m.id)
-          : undefined);
+          : undefined;
+      const defaults =
+        catalogDefaults || presetDefaults
+          ? mergeModelMetadata(catalogDefaults, presetDefaults)
+          : undefined;
       return {
         ...toCatalogModel(
           m,

--- a/packages/model-providers/src/user-provider.ts
+++ b/packages/model-providers/src/user-provider.ts
@@ -8,6 +8,10 @@ import {
   runtimeUserModelMetadata,
   type ModelMetadata,
 } from "./modelMetadataLayers.js";
+import {
+  piNativeCatalogModelDefaults,
+  piNativeCatalogRouteMatches,
+} from "./piNativeCatalog.js";
 /**
  * 用户自定义供应商：把 `CustomProviderConfig` 展开成标准 `Provider`（纯逻辑，零依赖）。
  *
@@ -473,7 +477,7 @@ export function buildUserProvider(
         m.route?.baseUrl === presetModel?.route?.baseUrl &&
         m.route?.wireProtocol === presetModel?.route?.wireProtocol &&
         m.route?.requestPath === presetModel?.route?.requestPath;
-      const defaults =
+      const presetDefaults =
         presetModel && sameRoute
           ? pickModelMetadata({
               ...presetModel,
@@ -484,6 +488,16 @@ export function buildUserProvider(
               defaultEffort: presetModel.reasoningDefaultEffort,
             })
           : undefined;
+      // Pi 来源带 piCatalogProviderId 且仍走官方路由时,pi-host 运行期会整条套用官方 Pi
+      // 目录;没有 catalogPresetId(#4108 之前创建)的存量来源在这里没有预设默认,存储
+      // 模型又缺 reasoning 字段,目录投影就成了空档位,Orca 创建 Worker 时把合法的
+      // max 拒成「valid: none」(#4295)。按同一份官方目录补默认,用户显式配置仍优先。
+      const defaults =
+        presetDefaults ??
+        (agent === "pi" && rt.piCatalogProviderId && !m.route &&
+        piNativeCatalogRouteMatches(rt.piCatalogProviderId, rt.baseUrl, rt.wireProtocol)
+          ? piNativeCatalogModelDefaults(rt.piCatalogProviderId, m.id)
+          : undefined);
       return {
         ...toCatalogModel(
           m,


### PR DESCRIPTION
## 这次改了什么

### 摘要

Orca 创建 Pi Worker 时的档位校验用的是模型目录投影（`buildUserProvider`）。对 Pi 来源，只有带 `catalogPresetId` 且仍跟随预设路由时才从预设补 `reasoningEfforts`；`catalogPresetId` 是 #4108 才引入的，之前从预设创建的存量来源（如 Kimi Code 的 `kimi-code`）存储模型没有 reasoning 字段，`toCatalogModel` 对 Pi 投影成空档位，于是显式 `effort=max` 被拒成 `valid: none`。而 pi-host 运行期按 `piCatalogProviderId` 整条套用官方 Pi 目录（k3-256k 为 low/high/max），两边不一致。

本 PR 让目录投影与运行期用同一份官方 Pi 目录：

- `piNativeCatalog.ts` 新增 `piNativeCatalogRouteMatches`（与 pi-host 的官方路由闸口同语义：目录 baseUrl 与 API 族唯一且与来源一致）和 `piNativeCatalogModelDefaults`（efforts / defaultEffort / contextWindow / maxOutput / supportsImageInput）。
- `buildUserProvider` 对带 `piCatalogProviderId`、无 per-model route、仍走官方路由的 Pi 来源，在没有预设默认时用官方目录条目作为 `providerDefaults`。合并优先级不变：用户显式配置（含 `reasoning: false`）> 发现结果 > 这些默认。
- 手改端点/协议、未标记 `piCatalogProviderId` 的来源不借用官方能力表。

### 变更类型

- [x] `fix` 缺陷修复

### 范围

- 关联 Issue / 需求：Fixes #4295
- 本 PR 包含：model-providers 目录投影的官方 Pi 目录默认回填与回归用例
- 明确不包含：pi-host 运行期逻辑、Orca 校验逻辑、renderer、存量配置迁移（不改用户持久化数据）
- 用户可见变化：存量预设 Pi 来源在模型选择/Orca Worker 创建时的档位与运行期一致，K3 系列可选 max
- 是否存在 breaking change：无

### UI 变化

- 不涉及。

## 怎么验证的

### 自动验证

```text
pnpm --filter @cindy/model-providers exec vitest run src/__tests__/user-provider.test.ts
结果：59 通过（新增 3 项：官方目录回填、用户显式 reasoning:false 优先、手改端点/协议/未标记不借用）。
反证：把回填分支短路后，「官方目录回填」用例失败（k3-256k efforts 为空），恢复后通过。

pnpm --filter @cindy/model-providers test
结果：31 文件 876 通过。

pnpm --filter @cindy/model-providers run --if-present typecheck
pnpm --filter desktop run --if-present typecheck
结果：均通过。

pnpm test:unit:related
结果：通过（desktop、mobile、lizi-mcps、maker-core、orca-workflow 全量,model-providers related 3,全部 PASS）。
```

### 手工验证

不涉及；未用真实 Kimi 账号复现（依据 issue 中的 `list_available_models` / `create_worker` 实际调用记录与源码链路）。

### 未执行的验证

未在 0.1.79 打包版复现；未验证 `kimi-code-2` 同名来源（同一投影路径，预期一致）。

## 风险

- 只影响带 `piCatalogProviderId` 且仍走官方路由的 Pi 来源的目录投影；回填值即 pi-host 运行期已在使用的官方目录，不引入新的能力声明。
- 官方目录里 reasoning=true 但无档位表的模型（如 kimi-for-coding）会投影为通用四档，这与运行期 `piSupportedEfforts` 的既有语义一致。
