### PR TITLE
feat(desktop): 支持双击重命名模型供应商

### DIFF
--- a/apps/desktop/src/renderer/__tests__/providersSectionDeepLink.test.tsx
+++ b/apps/desktop/src/renderer/__tests__/providersSectionDeepLink.test.tsx
@@ -297,6 +297,52 @@ describe('ProvidersSection — 深链定位', () => {
     expect(customDialogSpy).not.toHaveBeenCalled();
   });
 
+  it('renames an account when its sidebar row is double-clicked', async () => {
+    providersState.providers = [
+      makeProvider('openai-work', {
+        name: 'Work account',
+        source: 'user',
+        agents: ['codex'],
+        connected: true,
+        auth: { method: 'oauth', native: 'codex' },
+        models: { codex: [] },
+      }),
+    ];
+    renderAt('?tab=providers');
+
+    fireEvent.doubleClick(await screen.findByRole('button', { name: /Work account/ }));
+
+    await waitFor(() => expect(confirmSpy).toHaveBeenCalledWith(
+      expect.objectContaining({ title: 'settings.providers.pill.rename' }),
+    ));
+    await waitFor(() => expect(window.electronAPI.maker.setProviderPresentation).toHaveBeenCalledWith(
+      {
+        providerId: 'openai-work',
+        action: 'rename',
+        name: 'Work account',
+        dataOwnerId: 'owner',
+        ownerGeneration: 1,
+      },
+    ));
+  });
+
+  it('does not offer double-click rename for Cindy AI', async () => {
+    providersState.providers = [makeProvider('xd', {
+      name: 'Cindy AI',
+      auth: { method: 'managed' } as ProviderView['auth'],
+      agents: ['claude-code', 'codex'],
+      models: { 'claude-code': [], codex: [] },
+    })];
+    renderAt('?tab=providers');
+
+    fireEvent.doubleClick(
+      await screen.findByRole('button', { name: 'settings.providers.xd.title' }),
+    );
+
+    expect(confirmSpy).not.toHaveBeenCalled();
+    expect(window.electronAPI.maker.setProviderPresentation).not.toHaveBeenCalled();
+  });
+
   it('API key presence is configured rather than authenticated', async () => {
     providersState.providers = [
       makeProvider('api-work', {

--- a/apps/desktop/src/renderer/components/settings/ProvidersSection.tsx
+++ b/apps/desktop/src/renderer/components/settings/ProvidersSection.tsx
@@ -1800,6 +1800,7 @@ function ListRow({
   sortable: boolean;
 }) {
   const { t } = useTranslation();
+  const management = useProviderManagement(provider);
   const [ollamaLive, setOllamaLive] = useState<boolean | null>(null);
   useEffect(() => {
     if (provider.id !== MANAGED_OLLAMA_PROVIDER_ID) return;
@@ -1853,6 +1854,7 @@ function ListRow({
         <button
           type="button"
           onClick={onSelect}
+          onDoubleClick={provider.id === 'xd' ? undefined : () => void management.rename()}
           aria-current={selected}
           className="flex min-w-0 flex-1 items-center gap-2.5 py-2 pl-3 pr-2.5 text-left"
         >


### PR DESCRIPTION
## 这次改了什么

### 摘要

模型供应商设置列表中的普通供应商支持双击直接进入已有的重命名确认流程；Cindy AI（托管供应商）保持不可重命名。实现复用现有 `useProviderManagement.rename`，不改变已有持久化和 owner 边界。

### 变更类型

- [x] `feat` 新功能
- [ ] `fix` 缺陷修复
- [ ] `refactor` / `perf` 重构或性能优化
- [ ] `docs` / `test` / `chore` 文档、测试或工程维护
- [ ] 其他：

### 范围

- 关联 Issue / 需求：无
- 本 PR 包含：供应商列表行的双击重命名入口，以及普通供应商/Cindy AI 的行为测试。
- 明确不包含：供应商目录、排序、连接状态、重命名持久化协议或已有单击选择行为。
- 用户可见变化：在模型供应商设置中双击普通供应商行，会打开现有重命名确认流程。
- 是否存在 breaking change：无

### UI 变化

- 引用的设计规范：`docs/design-rules/DESIGN.md §5 Layout Principles`（沿用现有列表行的布局与命中区域）；`§14 Interaction Conventions`（把交互挂在现有按钮命中区，不新增视觉层）。本次没有新增颜色、圆角、字号或文案，Light/Dark 样式继续复用现有主题样式。

## 怎么验证的

### 自动验证

```text
corepack pnpm test:unit:related
结果：PASS apps/desktop unit（改动相关测试通过）

corepack pnpm --filter desktop run --if-present typecheck
结果：通过

bash /Users/dash/Code/XD/dash/Skills/git/scripts/run-unit-gate.sh /Users/dash/Code/Cindy/cindy-provider-double-click-rename
结果：统一门禁在 apps/desktop 2573 个测试中有 9 个失败；失败只落在
src/main/__tests__/claudeOrphanReaper.test.ts 与
src/main/maker-host/__tests__/codexAuthIsolatedSandbox.test.ts，且在干净的
origin/main 基线上复现同样的 9 个失败，与本 PR 改动无关。
```

### 手工验证

开发版已使用 `--isolated=@worktree` 启动并确认 `DESKTOP_DEV_VERDICT=ready`。未在本轮执行真实鼠标双击操作；交互路径由现有重命名逻辑测试覆盖。

### 未执行的验证

未执行打包产物和 Windows 实机验证；本 PR 只修改 Desktop Renderer 的现有按钮事件，不涉及原生层、协议或平台专属代码。

## 风险

### 风险分类

- [x] 无已知风险
- [ ] SQLite / migration
- [ ] system prompt
- [ ] 协议兼容
- [ ] 权限 / 安全 / 用户数据
- [ ] 存量插件兼容（批准状态 / 指纹 / manifest 校验 / 安装布局 / 包格式）
- [ ] 原生层 / fingerprint / OTA
- [ ] 跨平台差异
- [ ] 其他：

### 影响与回滚

- 影响范围：仅影响设置页供应商列表中普通供应商行的双击入口；单击选择和 Cindy AI 行为不变。
- 回滚 / 降级方式：回退本 PR commit 即可移除双击入口，不影响已有供应商数据和重命名能力。

### 提交前检查

- [x] 已 review 完整 diff
- [x] 每个 commit 都带 DCO 签名（`git commit -s`，见 [DCO](../DCO)）
- [x] UI 改动已在「UI 变化」注明引用的设计规范章节
- [x] 未提交凭证、令牌或授权文件
- [x] 已核对受影响的文档，行为变化涉及的旧结论已同步修订（不涉及）
- [x] 已确认测试结果或说明未执行原因
