### PR TITLE
fix(desktop): 首页首次发送不再闪现两个空行

### DIFF
--- a/apps/desktop/src/renderer/components/new-chat/ChatInput.tsx
+++ b/apps/desktop/src/renderer/components/new-chat/ChatInput.tsx
@@ -5690,7 +5690,7 @@ export function ChatInput({
         };
         const restoreRemoteComposerAndRelease = () => {
           try {
-            restoreOptimisticallyClearedComposer();
+            if (sourceSessionId) restoreOptimisticallyClearedComposer();
           } finally {
             releaseRemoteComposerTransition();
           }
@@ -5699,15 +5699,21 @@ export function ChatInput({
         // the user bubble. Device-link already did this; local/SSH used to wait
         // until onSend resolved, so the same text sat in both the transcript
         // and the composer while enqueue / effort / slash / auth settled.
-        try {
-          clearSentComposer();
-        } catch (error) {
-          restoreRemoteComposerAndRelease();
-          throw error;
-        }
-        dispatchSendClearedKeysRef.current.add(sendInFlightKey);
-        if (lockCurrentComposer && storageKeyForDraftRef.current === sourceStorageKey) {
-          setAllowTypeDuringSend(true);
+        // Home owns the asynchronous creation handoff: onSend returns false
+        // while it is still creating the session, then clears the draft itself.
+        // Keep that draft intact instead of clearing and restoring it as though
+        // an existing-session send had failed.
+        if (sourceSessionId) {
+          try {
+            clearSentComposer();
+          } catch (error) {
+            restoreRemoteComposerAndRelease();
+            throw error;
+          }
+          dispatchSendClearedKeysRef.current.add(sendInFlightKey);
+          if (lockCurrentComposer && storageKeyForDraftRef.current === sourceStorageKey) {
+            setAllowTypeDuringSend(true);
+          }
         }
         if (
           optimisticallyClearRemoteComposer &&
@@ -5804,6 +5810,7 @@ export function ChatInput({
           restoreRemoteComposerAndRelease();
           return;
         }
+        if (!sourceSessionId) clearSentComposer();
         releaseRemoteComposerTransition();
         markRecentPluginUsage();
       } finally {


### PR DESCRIPTION
## 这次改了什么

### 摘要

修复首页输入文字后按回车，输入框先增加两个空行、随后才创建任务并发送的问题。

#3388 将发送改为先清空、失败再恢复，但首页 `onSend` 返回 `false` 表示由异步创建流程接管草稿，并非发送失败。统一恢复逻辑因此把正文连同两个恢复用空段落重新插回编辑器。

现在首页保留原草稿，由创建流程在成功交接时清空；明确受理的首页同步路径仍清空。已有任务内继续采用发送前清空、失败恢复的行为。

### 变更类型

- [x] `fix` 缺陷修复
- [ ] `feat` 新功能
- [ ] `refactor` / `perf` 重构或性能优化
- [ ] `docs` / `test` / `chore` 文档、测试或工程维护
- [ ] 其他

### 范围

- 关联 Issue / 需求：首页首次发送的空行闪动反馈；回归来源 #3388。
- 本 PR 包含：按是否已有任务区分提前清空、失败恢复与成功清空时机。
- 明确不包含：修改回车快捷键、远程恢复算法、任务创建流程或输入框样式。
- 用户可见变化：首页回车发送时正文保持原样，创建成功后清空并跳转，不额外出现空行。
- 是否存在 breaking change：无。

### UI 变化

- 引用的设计规范：`docs/design-rules/DESIGN.md` §4 Inputs & Forms、§14.3 Keyboard & IME、§10 Theme System。保留既有回车发送与换行语义，消除无意内容和高度变化；未改颜色、主题或布局样式。
- macOS Electron 隔离实例通过 CDP 记录真实编辑器变化：修复前正文后新增两个 paragraph，高度 28 → 72 px；修复后正文保持一段、高度 28 px，交接成功后清空。未上传截图或录屏。

## 怎么验证的

### 自动验证

- `pnpm test:unit:related`：通过。
- `pnpm --filter desktop run typecheck`：通过。
- 定向 Vitest：`chatInputSessionFocus.test.ts`、`voiceInputEnterToSend.test.ts`、`newMakerWorktreeSend.test.ts`，42 项通过。
- 完整 `pnpm test:unit`（经 `run-unit-gate.sh`）：已跑完，Desktop 10 项失败，其余 workspace 通过。9 项是继承 `CINDY_AUTH_REGION=cn` / `VITE_CINDY_AUTH_REGION=cn` 导致的区域假设失配，在未修改的同一主干 `3d0515661` 复现；另外 1 项为 ASR readiness 等待超时，基线定向执行通过。清除两个区域变量后，在修复分支重跑涉及的三个文件（`claudeOrphanReaper`、`codexAuthIsolatedSandbox`、`RealtimeAsrWebSocketProvider`）66 项全部通过。未把首轮全量结果记为全绿，未修改或跳过失败用例。

### 手工验证

macOS Electron，Global 独立测试沙箱，分支 `dash/fix-home-enter-blank-lines`。使用 Playwright/CDP 驱动实际首页：输入单行和多行文字后按 Enter，记录 transaction、DOM 和高度，确认没有额外空段落、原换行保留、成功跳转新任务。属于真实客户端自动操作验证，不是仅运行简化发送函数。

### 未执行的验证

- 未执行 Windows、Linux、语音输入实机回归。
- 未分别目检 Light / Dark；此次没有样式或主题改动。

## 风险

### 风险分类

- [x] 其他：首页发送与草稿交接时序。
- [ ] 无已知风险
- [ ] SQLite / migration
- [ ] system prompt
- [ ] 协议兼容
- [ ] 权限 / 安全 / 用户数据
- [ ] 存量插件兼容（批准状态 / 指纹 / manifest 校验 / 安装布局 / 包格式）
- [ ] 原生层 / fingerprint / OTA
- [ ] 跨平台差异

### 影响与回滚

- 影响范围：Desktop 共用 ChatInput 的首页分支。首页返回 false / 抛错时保留原稿，不触发失败合并；成功返回时按现有归属检查清空；已有任务发送继续保留原有提前清空和恢复路径。
- 回滚 / 降级方式：回退本 PR，恢复原有清空时机。
- 存量插件影响：无。

### 提交前检查

- [x] 已 review 完整 diff
- [x] 每个 commit 都带 DCO 签名（`git commit -s`）
- [x] UI 改动已在「UI 变化」注明引用的设计规范章节
- [x] 未提交凭证、令牌或授权文件
- [x] 已核对受影响的文档，行为变化涉及的旧结论已同步修订（恢复首页既有约定，无需改文档）
- [x] 已确认测试结果或说明未执行原因
