### PR TITLE
fix(desktop): 修复 Ollama 下载界面跳动与进度交替

### DIFF
--- a/apps/desktop/src/main/local-model-runtime/__tests__/managedOllamaProvider.test.ts
+++ b/apps/desktop/src/main/local-model-runtime/__tests__/managedOllamaProvider.test.ts
@@ -21,6 +21,7 @@ import {
   syncManagedOllamaAgentProjections,
   upsertManagedOllamaModel,
   upsertManagedOllamaModels,
+  toPlainRuntimeModel,
 } from '../managedOllamaProvider.js';
 
 function providerWith(id: string) {
@@ -158,5 +159,16 @@ describe('managed Ollama model identity', () => {
     });
     expect(wrote).toBe(false);
     expect(updateCustomProvider).not.toHaveBeenCalled();
+  });
+});
+
+describe('local model display names', () => {
+  it.each([
+    ['hf.co/ornith-ai/Ornith-1.5-35B-A3B-GGUF:Q4_K_M', 'Ornith 1.5 35B A3B (Q4_K_M)'],
+    ['hf.co/team/Example-GGUF:Q8_0', 'Example (Q8_0)'],
+    ['hf.co/team/Example-GGUF:latest', 'Example'],
+    ['custom-model:8b', 'custom-model:8b'],
+  ])('formats %s without changing its execution ID', (id, name) => {
+    expect(toPlainRuntimeModel(id)).toMatchObject({ id, name });
   });
 });

--- a/apps/desktop/src/main/local-model-runtime/__tests__/service.list.test.ts
+++ b/apps/desktop/src/main/local-model-runtime/__tests__/service.list.test.ts
@@ -1,0 +1,135 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import type { CustomProviderConfig } from '@cindy/model-providers';
+
+vi.mock('../../maker-host/custom-provider-store.js', () => ({
+  createCustomProvider: vi.fn(),
+  getCustomProvider: vi.fn(),
+  updateCustomProvider: vi.fn(),
+}));
+vi.mock('../localConnectDetect.js', () => ({ detectLocalConnectPresets: async () => [] }));
+
+import { getCustomProvider, updateCustomProvider } from '../../maker-host/custom-provider-store.js';
+import {
+  buildEmptyManagedOllamaProvider,
+  upsertManagedOllamaModels,
+} from '../managedOllamaProvider.js';
+import { createLocalModelService } from '../service.js';
+
+// Real service and projection logic, with only persistence and Ollama I/O replaced.
+describe('Ollama list refresh convergence', () => {
+  let provider: CustomProviderConfig;
+  let toolsSupported: boolean;
+  let tagsFail: boolean;
+  const model = 'test-tools:latest';
+  const pausedPullStore = {
+    read: async () => null,
+    readSync: () => null,
+    readAll: async () => [],
+    readAllSync: () => [],
+    write: async () => undefined,
+    remove: async () => null,
+    clear: async () => undefined,
+  };
+  const makeService = () =>
+    createLocalModelService({
+      platform: 'darwin',
+      arch: 'arm64',
+      totalmem: () => 128 * 1024 ** 3,
+      pausedPullStore,
+      fetchImpl: async (url) => {
+        if (String(url).endsWith('/api/tags')) {
+          if (tagsFail) throw new Error('temporarily unavailable');
+          return new Response(JSON.stringify({ models: [{ name: model, size: 1024 }] }));
+        }
+        if (String(url).endsWith('/api/show')) {
+          return new Response(JSON.stringify({ capabilities: toolsSupported ? ['tools'] : [] }));
+        }
+        return new Response(JSON.stringify({ version: '0.32.14' }));
+      },
+      streamPull: async (_name, _onEvent, signal) =>
+        new Promise<void>((_resolve, reject) => {
+          signal?.addEventListener('abort', () => reject(new Error('aborted')), { once: true });
+        }),
+    });
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    provider = buildEmptyManagedOllamaProvider();
+    toolsSupported = true;
+    tagsFail = false;
+    vi.mocked(getCustomProvider).mockImplementation(async () => provider);
+    vi.mocked(updateCustomProvider).mockImplementation(async (_id, next) => {
+      // Persistence reconstructs objects in its own key order. Compare values,
+      // not the insertion order of JSON keys (including nested model metadata).
+      const reorder = (value: unknown): unknown => {
+        if (Array.isArray(value)) return value.map(reorder);
+        if (value && typeof value === 'object') {
+          return Object.fromEntries(
+            Object.entries(value)
+              .sort(([a], [b]) => a.localeCompare(b))
+              .map(([key, item]) => [key, reorder(item)]),
+          );
+        }
+        return value;
+      };
+      provider = reorder(next) as CustomProviderConfig;
+      return provider;
+    });
+  });
+
+  it('settles after one import instead of broadcasting changes forever', async () => {
+    const service = makeService();
+    expect((await service.list()).catalogDirty).toBe(true);
+    vi.mocked(updateCustomProvider).mockClear();
+    for (let i = 0; i < 3; i++) {
+      const result = await service.list();
+      expect(result.catalogDirty).toBe(false);
+      expect(result.memoryGb).toBe(128);
+      expect(provider.runtimes.codex?.models.map((entry) => entry.id)).toEqual([model]);
+    }
+    expect(updateCustomProvider).not.toHaveBeenCalled();
+  });
+
+  it('keeps coding models and hardware information stable during a pull', async () => {
+    const service = makeService();
+    await service.list();
+    const pull = service.pull('another-model:latest').catch(() => undefined);
+    try {
+      await vi.waitFor(() => expect(service.activePulls()).toHaveLength(1));
+      vi.mocked(updateCustomProvider).mockClear();
+      for (let i = 0; i < 3; i++) {
+        const result = await service.list();
+        expect(result.status.kind).toBe('pulling');
+        expect(result.catalogDirty).toBe(false);
+        expect(result.memoryGb).toBe(128);
+        expect(result.pulls[0]?.name).toBe('another-model:latest');
+      }
+      expect(updateCustomProvider).not.toHaveBeenCalled();
+    } finally {
+      await service.abortPull('pause', 'another-model:latest');
+      await pull;
+    }
+  });
+
+  it('retains projections on tags failure, but applies a real capabilities change once', async () => {
+    const service = makeService();
+    await service.list();
+    vi.mocked(updateCustomProvider).mockClear();
+    tagsFail = true;
+    expect((await service.list()).catalogDirty).toBe(false);
+    expect(updateCustomProvider).not.toHaveBeenCalled();
+    expect(provider.runtimes.codex?.models).toHaveLength(1);
+    tagsFail = false;
+    toolsSupported = false;
+    expect((await service.list()).catalogDirty).toBe(true);
+    expect(provider.runtimes.codex?.models).toHaveLength(0);
+    expect((await service.list()).catalogDirty).toBe(false);
+    expect(updateCustomProvider).toHaveBeenCalledTimes(1);
+  });
+
+  it('reports a legacy migration even if the subsequent upsert is unchanged', async () => {
+    provider.runtimes = { pi: provider.runtimes.pi! };
+    expect(await upsertManagedOllamaModels([])).toMatchObject({ ok: true, changed: true });
+    expect(await upsertManagedOllamaModels([])).toMatchObject({ ok: true, changed: false });
+  });
+});

--- a/apps/desktop/src/main/local-model-runtime/__tests__/service.list.test.ts
+++ b/apps/desktop/src/main/local-model-runtime/__tests__/service.list.test.ts
@@ -20,6 +20,7 @@ describe('Ollama list refresh convergence', () => {
   let provider: CustomProviderConfig;
   let toolsSupported: boolean;
   let tagsFail: boolean;
+  let offline: boolean;
   const model = 'test-tools:latest';
   const pausedPullStore = {
     read: async () => null,
@@ -37,6 +38,7 @@ describe('Ollama list refresh convergence', () => {
       totalmem: () => 128 * 1024 ** 3,
       pausedPullStore,
       fetchImpl: async (url) => {
+        if (offline) throw new TypeError('fetch failed');
         if (String(url).endsWith('/api/tags')) {
           if (tagsFail) throw new Error('temporarily unavailable');
           return new Response(JSON.stringify({ models: [{ name: model, size: 1024 }] }));
@@ -57,6 +59,7 @@ describe('Ollama list refresh convergence', () => {
     provider = buildEmptyManagedOllamaProvider();
     toolsSupported = true;
     tagsFail = false;
+    offline = false;
     vi.mocked(getCustomProvider).mockImplementation(async () => provider);
     vi.mocked(updateCustomProvider).mockImplementation(async (_id, next) => {
       // Persistence reconstructs objects in its own key order. Compare values,
@@ -126,6 +129,38 @@ describe('Ollama list refresh convergence', () => {
     expect((await service.list()).catalogDirty).toBe(false);
     expect(updateCustomProvider).toHaveBeenCalledTimes(1);
   });
+
+  it.each(['offline', 'tags failure'])(
+    'keeps legacy models Pi-only during %s until capabilities are known',
+    async (failure) => {
+      const legacyModel = { id: model, name: 'Existing model', contextWindow: 32_768 };
+      provider.runtimes = {
+        pi: { ...provider.runtimes.pi!, models: [legacyModel] },
+      };
+      offline = failure === 'offline';
+      tagsFail = failure === 'tags failure';
+      const service = makeService();
+      expect((await service.list()).catalogDirty).toBe(true);
+      expect(provider.runtimes.pi?.models).toEqual([legacyModel]);
+      expect(provider.runtimes['claude-code']?.models).toEqual([]);
+      expect(provider.runtimes.codex?.models).toEqual([]);
+      expect((await service.list()).catalogDirty).toBe(false);
+      expect(updateCustomProvider).toHaveBeenCalledTimes(1);
+
+      offline = false;
+      tagsFail = false;
+      toolsSupported = false;
+      await service.list();
+      expect(provider.runtimes.pi?.models.map((entry) => entry.id)).toEqual([model]);
+      expect(provider.runtimes['claude-code']?.models).toEqual([]);
+      expect(provider.runtimes.codex?.models).toEqual([]);
+      toolsSupported = true;
+      expect((await service.list()).catalogDirty).toBe(true);
+      expect(provider.runtimes['claude-code']?.models.map((entry) => entry.id)).toEqual([model]);
+      expect(provider.runtimes.codex?.models.map((entry) => entry.id)).toEqual([model]);
+      expect((await service.list()).catalogDirty).toBe(false);
+    },
+  );
 
   it('reports a legacy migration even if the subsequent upsert is unchanged', async () => {
     provider.runtimes = { pi: provider.runtimes.pi! };

--- a/apps/desktop/src/main/local-model-runtime/__tests__/service.owner.test.ts
+++ b/apps/desktop/src/main/local-model-runtime/__tests__/service.owner.test.ts
@@ -5,8 +5,8 @@ vi.mock('../managedOllamaProvider.js', async (importOriginal) => {
   return {
     ...actual,
     readManagedOllamaProvider: vi.fn(async () => actual.buildEmptyManagedOllamaProvider()),
-    syncManagedOllamaAgentProjections: vi.fn(async (_agents, opts) => {
-      if (opts?.stillActive && !opts.stillActive()) return false;
+    migrateManagedOllamaOnCatalogLoad: vi.fn(async (stillActive) => {
+      if (stillActive && !stillActive()) return false;
       return false;
     }),
     upsertManagedOllamaModel: vi.fn(async (_model, _agents, opts) => {
@@ -31,7 +31,7 @@ vi.mock('../managedOllamaProvider.js', async (importOriginal) => {
 import { createLocalModelService, OwnerChangedError } from '../service.js';
 import {
   readManagedOllamaProvider,
-  syncManagedOllamaAgentProjections,
+  migrateManagedOllamaOnCatalogLoad,
   upsertManagedOllamaModel,
   upsertManagedOllamaModels,
 } from '../managedOllamaProvider.js';
@@ -68,7 +68,7 @@ describe('owner change during pull', () => {
     vi.mocked(upsertManagedOllamaModel).mockClear();
     vi.mocked(upsertManagedOllamaModels).mockClear();
     vi.mocked(readManagedOllamaProvider).mockClear();
-    vi.mocked(syncManagedOllamaAgentProjections).mockClear();
+    vi.mocked(migrateManagedOllamaOnCatalogLoad).mockClear();
   });
 
   it('does not upsert or import a pull finished after the account switched', async () => {
@@ -132,7 +132,7 @@ describe('owner change during pull', () => {
     expect(upsertManagedOllamaModels).not.toHaveBeenCalled();
   });
 
-  it('passes the captured owner into projection sync during list', async () => {
+  it('passes the captured owner into legacy migration during list', async () => {
     const service = createLocalModelService({
       fetchImpl: readyFetch(),
     });
@@ -140,11 +140,8 @@ describe('owner change during pull', () => {
       owner: { dataOwnerId: 'alice', generation: 1 },
       ownerStillActive: () => false,
     });
-    expect(syncManagedOllamaAgentProjections).toHaveBeenCalledWith(
-      expect.anything(),
-      expect.objectContaining({ stillActive: expect.any(Function) }),
-    );
-    const opts = vi.mocked(syncManagedOllamaAgentProjections).mock.calls[0]?.[1];
-    expect(opts?.stillActive?.()).toBe(false);
+    expect(migrateManagedOllamaOnCatalogLoad).toHaveBeenCalledWith(expect.any(Function));
+    const opts = vi.mocked(migrateManagedOllamaOnCatalogLoad).mock.calls[0]?.[0];
+    expect(opts?.()).toBe(false);
   });
 });

--- a/apps/desktop/src/main/local-model-runtime/managedOllamaProvider.ts
+++ b/apps/desktop/src/main/local-model-runtime/managedOllamaProvider.ts
@@ -187,10 +187,10 @@ export function migrateManagedOllamaProvider(
     ...existing,
     runtimes: {
       pi: emptyPiRuntime(piModels),
-      'claude-code': emptyClaudeRuntime(
-        piModels.map((model) => toAgentModel(model, 'claude-code')),
-      ),
-      codex: emptyCodexRuntime(piModels.map((model) => toAgentModel(model, 'codex'))),
+      // Migration has no capability evidence. Imports populate coding runtimes
+      // only after probing each model; offline legacy models remain Pi-only.
+      'claude-code': emptyClaudeRuntime(),
+      codex: emptyCodexRuntime(),
     },
   };
 }

--- a/apps/desktop/src/main/local-model-runtime/managedOllamaProvider.ts
+++ b/apps/desktop/src/main/local-model-runtime/managedOllamaProvider.ts
@@ -1,3 +1,4 @@
+import { isDeepStrictEqual } from 'node:util';
 import type {
   AgentKind,
   CustomProviderConfig,
@@ -23,7 +24,7 @@ import {
 } from '../maker-host/custom-provider-store.js';
 
 export type ManagedEnsureResult =
-  | { ok: true; created: boolean; provider: CustomProviderConfig }
+  | { ok: true; created: boolean; changed?: boolean; provider: CustomProviderConfig }
   | { ok: false; code: 'OWNER_CHANGED' }
   | { ok: false; code: 'MANAGED_ID_CONFLICT'; existing: CustomProviderConfig };
 
@@ -96,13 +97,23 @@ export function buildEmptyManagedOllamaProvider(): CustomProviderConfig {
   };
 }
 
+/** Keep the repository identity and quantization visible without the HF transport prefix. */
+function localModelDisplayName(name: string): string {
+  const curated = curatedOllamaDisplayName(name);
+  if (curated) return curated;
+  const hf = /^hf\.co\/[^/]+\/([^/:]+)(?::([^/]+))?$/.exec(name);
+  if (!hf) return name;
+  const title = hf[1]!.replace(/[-_]GGUF$/i, '').replace(/[-_]+/g, ' ');
+  return hf[2] && hf[2] !== 'latest' ? `${title} (${hf[2]})` : title;
+}
+
 export function toPlainRuntimeModel(
   name: string,
   contextLength?: number,
 ): ProviderRuntimeModelConfig {
   return {
     id: name,
-    name: curatedOllamaDisplayName(name) ?? name,
+    name: localModelDisplayName(name),
     reasoning: false,
     ...(contextLength && contextLength > 0 ? { contextWindow: contextLength } : {}),
   };
@@ -194,7 +205,7 @@ export async function migrateManagedOllamaOnCatalogLoad(
     if (!existing || !fingerprintOf(existing)) return false;
     const migrated = migrateManagedOllamaProvider(existing);
     if (!migrated) return false;
-    if (JSON.stringify(migrated.runtimes) === JSON.stringify(existing.runtimes)) {
+    if (isDeepStrictEqual(migrated.runtimes, existing.runtimes)) {
       return false;
     }
     if (!stillCurrent()) return false;
@@ -219,7 +230,7 @@ export async function syncManagedOllamaAgentProjections(
     for (const model of piModels) {
       next = applyModelToAgents(next, model, agents, 'upsert');
     }
-    if (JSON.stringify(next.runtimes) === JSON.stringify(existing.runtimes)) return false;
+    if (isDeepStrictEqual(next.runtimes, existing.runtimes)) return false;
     if (ownerChanged(opts)) return false;
     const updated = await updateCustomProvider(MANAGED_OLLAMA_PROVIDER_ID, next);
     return updated !== null;
@@ -274,12 +285,17 @@ export async function upsertManagedOllamaModels(
       next = retainCanonicalModels(next, opts.retainCanonicalIds);
     }
     if (opts?.stillActive && !opts.stillActive()) return { ok: false, code: 'OWNER_CHANGED' };
-    if (JSON.stringify(next.runtimes) === JSON.stringify(latest.runtimes)) {
-      return { ok: true, created: false, provider: latest };
+    if (isDeepStrictEqual(next.runtimes, latest.runtimes)) {
+      return {
+        ok: true,
+        created: ensured.created,
+        changed: ensured.changed === true || ensured.created,
+        provider: latest,
+      };
     }
     const updated = await updateCustomProvider(MANAGED_OLLAMA_PROVIDER_ID, next);
     if (!updated) return { ok: false, code: 'MANAGED_ID_CONFLICT', existing: latest };
-    return { ok: true, created: false, provider: updated };
+    return { ok: true, created: false, changed: true, provider: updated };
   });
 }
 
@@ -325,7 +341,7 @@ export async function removeManagedOllamaModel(
     if (ownerChanged(opts)) return { ok: false, code: 'OWNER_CHANGED' };
     const updated = await updateCustomProvider(MANAGED_OLLAMA_PROVIDER_ID, next);
     if (!updated) return { ok: false, code: 'MANAGED_ID_CONFLICT', existing };
-    return { ok: true, created: false, provider: updated };
+    return { ok: true, created: false, changed: true, provider: updated };
   });
 }
 
@@ -366,7 +382,7 @@ async function ensureManagedOllamaProviderUnlocked(
   if (!existing) {
     try {
       const created = await createCustomProvider(buildEmptyManagedOllamaProvider());
-      return { ok: true, created: true, provider: created };
+      return { ok: true, created: true, changed: true, provider: created };
     } catch {
       if (ownerChanged(opts)) return { ok: false, code: 'OWNER_CHANGED' };
       const raced = await getCustomProvider(MANAGED_OLLAMA_PROVIDER_ID);
@@ -376,7 +392,7 @@ async function ensureManagedOllamaProviderUnlocked(
         if (migrated !== raced) {
           if (ownerChanged(opts)) return { ok: false, code: 'OWNER_CHANGED' };
           const updated = await updateCustomProvider(MANAGED_OLLAMA_PROVIDER_ID, migrated);
-          if (updated) return { ok: true, created: false, provider: updated };
+          if (updated) return { ok: true, created: false, changed: true, provider: updated };
         }
         return { ok: true, created: false, provider: raced };
       }
@@ -391,7 +407,7 @@ async function ensureManagedOllamaProviderUnlocked(
     if (ownerChanged(opts)) return { ok: false, code: 'OWNER_CHANGED' };
     const updated = await updateCustomProvider(MANAGED_OLLAMA_PROVIDER_ID, migrated);
     if (!updated) return { ok: false, code: 'MANAGED_ID_CONFLICT', existing };
-    return { ok: true, created: false, provider: updated };
+    return { ok: true, created: false, changed: true, provider: updated };
   }
   return { ok: true, created: false, provider: existing };
 }

--- a/apps/desktop/src/main/local-model-runtime/service.ts
+++ b/apps/desktop/src/main/local-model-runtime/service.ts
@@ -49,7 +49,7 @@ import { probeOllamaStatus, startOfficialOllamaApp } from './ollamaRuntime.js';
 import {
   ensureManagedOllamaProvider,
   managedOllamaRemovalGeneration,
-  syncManagedOllamaAgentProjections,
+  migrateManagedOllamaOnCatalogLoad,
   readManagedOllamaProvider,
   removeManagedOllamaModel,
   toPlainRuntimeModel,
@@ -467,10 +467,11 @@ export function createLocalModelService(deps: LocalModelServiceDeps = {}): Local
     const pulls = visiblePulls(await rememberedPaused());
     const pull = pulls[0] ?? null;
     const pausedPull = pulls.find((item) => item.phase === 'paused') ?? null;
-    const catalogDirty = await syncManagedOllamaAgentProjections(
-      resolveManagedOllamaAgents({ version: current.version }),
-      { stillActive: opts?.ownerStillActive },
-    ).catch(() => false);
+    // Preserve existing agent membership until per-model capabilities are probed.
+    // Version alone has no tools evidence and would remove then re-add coding models.
+    const catalogDirty = await migrateManagedOllamaOnCatalogLoad(opts?.ownerStillActive).catch(
+      () => false,
+    );
     const detectedLocalPresetIds = await detectedLocalPresetIdsPromise;
     if (current.kind !== 'ready' && current.kind !== 'pulling') {
       return {
@@ -855,7 +856,7 @@ export function createLocalModelService(deps: LocalModelServiceDeps = {}): Local
     if (result.ok) {
       for (const tag of named) clearUnclaimed(tag.name);
     }
-    return result.ok;
+    return result.ok && result.changed === true;
   }
 
   function keepPullNames(): string[] {

--- a/apps/desktop/src/renderer/__tests__/ollamaProviderDetail.test.tsx
+++ b/apps/desktop/src/renderer/__tests__/ollamaProviderDetail.test.tsx
@@ -46,10 +46,12 @@ const snapshot = (pulls: LocalModelPullProgress[] = []) => ({
 });
 function deferred<T>() {
   let resolve!: (value: T) => void;
-  const promise = new Promise<T>((r) => {
+  let reject!: (reason: Error) => void;
+  const promise = new Promise<T>((r, fail) => {
     resolve = r;
+    reject = fail;
   });
-  return { promise, resolve };
+  return { promise, resolve, reject };
 }
 let onProgress: (value: LocalModelPullProgress) => void;
 let onCatalog: () => void;
@@ -142,6 +144,31 @@ describe('Ollama download snapshot ordering', () => {
     fireEvent.click(download());
     await act(async () => onCatalog());
     expect(screen.getByTestId('progress').textContent).toBe('starting');
+  });
+
+  it.each([false, true])('keeps the resumed pull guarded after the old refresh (fails=%s)', async (fails) => {
+    await mount();
+    const first = deferred<{ stopped: boolean }>();
+    pull.mockReturnValueOnce(first.promise);
+    fireEvent.click(download());
+    act(() => onProgress({ ...progress(25, 'paused'), done: true }));
+    const old = deferred<ReturnType<typeof snapshot>>();
+    list.mockReturnValueOnce(old.promise);
+    await act(async () => first.resolve({ stopped: true }));
+    // Resume while the old call is still awaiting its post-stop list refresh.
+    const input = document.querySelector('#ollama-manual-download')!;
+    fireEvent.change(input, { target: { value: 'test' } });
+    const manual = screen.getAllByText(downloadLabel).at(-1)!;
+    fireEvent.click(manual);
+    expect(pull).toHaveBeenCalledTimes(2);
+    act(() => onProgress(progress(40)));
+    await act(async () => {
+      if (fails) old.reject(new Error('list unavailable'));
+      else old.resolve(snapshot([progress(25, 'paused')]));
+    });
+    fireEvent.click(manual);
+    expect(pull).toHaveBeenCalledTimes(2);
+    expect(screen.getByTestId('progress').textContent).toBe('40');
   });
 
   it('dispatches once when the same model is submitted twice', async () => {

--- a/apps/desktop/src/renderer/__tests__/ollamaProviderDetail.test.tsx
+++ b/apps/desktop/src/renderer/__tests__/ollamaProviderDetail.test.tsx
@@ -1,0 +1,161 @@
+// @vitest-environment jsdom
+import React from 'react';
+import { act, cleanup, fireEvent, render, screen } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import type { LocalModelPullProgress } from '../../shared/localModelRuntime';
+import { OllamaProviderDetail } from '../components/settings/OllamaProviderDetail';
+
+vi.mock('react-i18next', () => ({
+  useTranslation: () => ({ t: (key: string) => key, i18n: { language: 'en' } }),
+}));
+vi.mock('@/lib/toast', () => ({ toast: { success: vi.fn(), error: vi.fn() } }));
+vi.mock('../components/settings/LocalOllamaInstall', () => ({
+  LocalOllamaInstall: () => null,
+  offersManagedOllamaInstall: () => false,
+}));
+vi.mock('../components/settings/DownloadMeter', () => ({
+  DownloadMeter: ({ progress }: { progress: { percent?: number } }) => (
+    <div data-testid="progress">{progress.percent ?? 'starting'}</div>
+  ),
+}));
+
+const model = {
+  id: 'test',
+  name: 'Test model',
+  libraryName: 'test:latest',
+  minUnifiedMemoryGb: 8,
+  sizeBytes: 1024,
+};
+const progress = (
+  percent: number,
+  phase: LocalModelPullProgress['phase'] = 'downloading',
+): LocalModelPullProgress => ({
+  name: model.libraryName,
+  status: phase!,
+  phase,
+  percent,
+  done: phase === 'success',
+});
+const snapshot = (pulls: LocalModelPullProgress[] = []) => ({
+  status: { kind: 'ready' },
+  models: [],
+  catalog: [model],
+  featured: [model],
+  memoryGb: 128,
+  pulls,
+});
+function deferred<T>() {
+  let resolve!: (value: T) => void;
+  const promise = new Promise<T>((r) => {
+    resolve = r;
+  });
+  return { promise, resolve };
+}
+let onProgress: (value: LocalModelPullProgress) => void;
+let onCatalog: () => void;
+const list = vi.fn();
+const pull = vi.fn();
+const changed = vi.fn();
+const downloadLabel = 'settings.providers.local.downloadAdd';
+const download = () =>
+  screen.getAllByText(downloadLabel).find((el) => !el.hasAttribute('disabled'))!;
+
+beforeEach(() => {
+  list.mockReset().mockResolvedValue(snapshot());
+  pull.mockReset().mockReturnValue(new Promise(() => undefined));
+  changed.mockReset();
+  Object.defineProperty(window, 'electronAPI', {
+    configurable: true,
+    value: {
+      platform: 'darwin',
+      maker: {
+        localModelList: list,
+        localModelPull: pull,
+        onProvidersChanged: (cb: typeof onCatalog) => {
+          onCatalog = cb;
+          return () => undefined;
+        },
+        onLocalModelPullProgress: (cb: typeof onProgress) => {
+          onProgress = cb;
+          return () => undefined;
+        },
+        onLocalModelStatus: () => () => undefined,
+      },
+    },
+  });
+});
+afterEach(cleanup);
+const mount = async () => {
+  await act(async () => {
+    render(<OllamaProviderDetail onChanged={changed} />);
+  });
+};
+
+describe('Ollama download snapshot ordering', () => {
+  it('does not replace a newly started download with a late empty list', async () => {
+    await mount();
+    const old = deferred<ReturnType<typeof snapshot>>();
+    list.mockReturnValueOnce(old.promise);
+    act(() => onCatalog());
+    fireEvent.click(download());
+    expect(screen.getByTestId('progress').textContent).toBe('starting');
+    await act(async () => old.resolve(snapshot()));
+    expect(screen.getByTestId('progress').textContent).toBe('starting');
+  });
+
+  it('keeps newer progress while still restoring unrelated paused downloads', async () => {
+    const old = deferred<ReturnType<typeof snapshot>>();
+    list.mockReturnValueOnce(old.promise);
+    await mount();
+    act(() => onProgress(progress(40)));
+    await act(async () =>
+      old.resolve(
+        snapshot([progress(5), { ...progress(12, 'paused'), name: 'other:latest', done: true }]),
+      ),
+    );
+    expect(screen.getAllByTestId('progress').map((el) => el.textContent)).toEqual(['40', '12']);
+  });
+
+  it('does not resurrect a completed download from a late list', async () => {
+    const old = deferred<ReturnType<typeof snapshot>>();
+    list.mockReturnValueOnce(old.promise);
+    await mount();
+    act(() => {
+      onProgress(progress(40));
+      onProgress(progress(100, 'success'));
+    });
+    await act(async () => old.resolve(snapshot([progress(5)])));
+    expect(screen.queryByTestId('progress')).toBeNull();
+  });
+
+  it('ignores an older list that finishes after a newer refresh', async () => {
+    const old = deferred<ReturnType<typeof snapshot>>();
+    list.mockReturnValueOnce(old.promise).mockResolvedValueOnce(snapshot([progress(60)]));
+    await mount();
+    await act(async () => onCatalog());
+    await act(async () => old.resolve(snapshot([progress(5)])));
+    expect(screen.getByTestId('progress').textContent).toBe('60');
+  });
+
+  it('keeps a local start while the pull IPC has not registered it yet', async () => {
+    await mount();
+    fireEvent.click(download());
+    await act(async () => onCatalog());
+    expect(screen.getByTestId('progress').textContent).toBe('starting');
+  });
+
+  it('dispatches once when the same model is submitted twice', async () => {
+    await mount();
+    const input = document.querySelector('#ollama-manual-download')!;
+    fireEvent.change(input, { target: { value: 'test' } });
+    const buttons = screen.getAllByText(downloadLabel);
+    const manual = buttons[buttons.length - 1]!;
+    fireEvent.click(manual);
+    fireEvent.click(manual);
+    expect(pull).toHaveBeenCalledTimes(1);
+    act(() => onProgress(progress(25)));
+    fireEvent.click(manual);
+    expect(screen.getByTestId('progress').textContent).toBe('25');
+    expect(pull).toHaveBeenCalledTimes(1);
+  });
+});

--- a/apps/desktop/src/renderer/components/settings/OllamaProviderDetail.tsx
+++ b/apps/desktop/src/renderer/components/settings/OllamaProviderDetail.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useMemo, useState, type ReactNode } from 'react';
+import { useCallback, useEffect, useMemo, useRef, useState, type ReactNode } from 'react';
 import { useTranslation } from 'react-i18next';
 import { Pause, Play, X } from 'lucide-react';
 
@@ -14,6 +14,7 @@ import type {
   LocalRuntimeStatus,
 } from '../../../shared/localModelRuntime';
 import {
+  canonicalOllamaModelRef,
   classifyOllamaPullError,
   filterCuratedOllamaModels,
   isHfMlxPullName,
@@ -125,42 +126,64 @@ export function OllamaProviderDetail({ onChanged }: { onChanged: () => void }) {
   const [busy, setBusy] = useState(false);
   const [pulls, setPulls] = useState<Record<string, LocalModelPullProgress>>({});
 
-  const replaceListedPulls = useCallback((items: readonly LocalModelPullProgress[]) => {
-    setPulls((current) => {
-      const next: Record<string, LocalModelPullProgress> = {};
-      for (const item of items) {
-        if (item.phase === 'cancelled' || item.phase === 'success') continue;
-        next[item.name] = item;
-      }
-      for (const [name, item] of Object.entries(current)) {
-        if (!next[name] && item.phase === 'error') next[name] = item;
-      }
-      return next;
-    });
-  }, []);
+  const refreshGeneration = useRef(0);
+  const progressRevision = useRef(0);
+  const statusRevision = useRef(0);
+  const updatedPulls = useRef(new Map<string, number>());
+  const pendingPulls = useRef(new Set<string>());
+
+  const replaceListedPulls = useCallback(
+    (items: readonly LocalModelPullProgress[], since: number) => {
+      setPulls((current) => {
+        const next: Record<string, LocalModelPullProgress> = {};
+        for (const item of items) {
+          if (item.phase === 'cancelled' || item.phase === 'success') continue;
+          next[canonicalOllamaModelRef(item.name)] = item;
+        }
+        for (const [name, item] of Object.entries(current)) {
+          if (!next[name] && item.phase === 'error') next[name] = item;
+        }
+        // A slow list response must not undo progress, start, pause or completion
+        // events received after that request began. Keep terminal deletions too.
+        for (const [name, revision] of updatedPulls.current) {
+          if (revision <= since && !pendingPulls.current.has(name)) continue;
+          if (current[name]) next[name] = current[name];
+          else delete next[name];
+        }
+        return next;
+      });
+    },
+    [],
+  );
 
   const upsertPull = useCallback((item: LocalModelPullProgress) => {
+    const name = canonicalOllamaModelRef(item.name);
+    updatedPulls.current.set(name, ++progressRevision.current);
     setPulls((current) => {
       if (item.phase === 'cancelled' || item.phase === 'success') {
-        if (!(item.name in current)) return current;
+        if (!(name in current)) return current;
         const next = { ...current };
-        delete next[item.name];
+        delete next[name];
         return next;
       }
-      return { ...current, [item.name]: item };
+      return { ...current, [name]: item };
     });
   }, []);
 
   const refresh = useCallback(async () => {
+    const generation = ++refreshGeneration.current;
+    const since = progressRevision.current;
+    const statusSince = statusRevision.current;
     const result = await window.electronAPI.maker.localModelList();
-    setStatus(result.status);
+    if (generation !== refreshGeneration.current) return;
+    if (statusSince === statusRevision.current) setStatus(result.status);
     setModels(result.models);
     setCatalog(result.catalog ?? []);
     setFeatured(result.featured ?? []);
     setMemoryGb(result.memoryGb ?? 0);
     setRecommendReason(result.recommendReason ?? 'unknown');
     setAppleSilicon(result.appleSilicon === true);
-    replaceListedPulls(result.pulls ?? []);
+    replaceListedPulls(result.pulls ?? [], since);
     if (result.catalogDirty) onChanged();
   }, [onChanged, replaceListedPulls]);
 
@@ -170,12 +193,14 @@ export function OllamaProviderDetail({ onChanged }: { onChanged: () => void }) {
       void refresh().catch(() => undefined);
     });
     const offStatus = window.electronAPI.maker.onLocalModelStatus((next) => {
+      statusRevision.current += 1;
       setStatus(next as LocalRuntimeStatus);
     });
     const offPull = window.electronAPI.maker.onLocalModelPullProgress((next) => {
       upsertPull(next as LocalModelPullProgress);
     });
     return () => {
+      refreshGeneration.current += 1;
       offCatalog();
       offStatus();
       offPull();
@@ -206,9 +231,13 @@ export function OllamaProviderDetail({ onChanged }: { onChanged: () => void }) {
       toast.error(t('settings.providers.local.pullError.not-gguf'));
       return;
     }
+    const key = canonicalOllamaModelRef(name);
+    if (pendingPulls.current.has(key)) return;
+    pendingPulls.current.add(key);
     upsertPull({ name, status: 'starting', phase: 'starting', done: false });
     try {
       const result = await window.electronAPI.maker.localModelPull(name);
+      pendingPulls.current.delete(key);
       if (result.stopped) {
         await refresh();
         return;
@@ -235,12 +264,14 @@ export function OllamaProviderDetail({ onChanged }: { onChanged: () => void }) {
           ? t('settings.providers.local.conflict')
           : t(`settings.providers.local.pullError.${kind ?? 'generic'}`),
       );
+    } finally {
+      pendingPulls.current.delete(key);
     }
   };
 
   const handleAbort = async (reason: 'pause' | 'cancel', name: string) => {
     try {
-      const current = pulls[name];
+      const current = pulls[canonicalOllamaModelRef(name)];
       if (reason === 'cancel' && current?.phase === 'paused') {
         await window.electronAPI.maker.localModelDiscardPaused(name);
       } else {
@@ -284,7 +315,7 @@ export function OllamaProviderDetail({ onChanged }: { onChanged: () => void }) {
 
   const renderCatalogCard = (entry: CuratedOllamaModel) => {
     const installed = models.some((model) => ollamaModelRefsEqual(model.name, entry.libraryName));
-    const pull = pulls[entry.libraryName];
+    const pull = pulls[canonicalOllamaModelRef(entry.libraryName)];
     const pulling = Boolean(pull && (!pull.done || pull.phase === 'paused'));
     const failed = pull?.phase === 'error';
     if (!searching && installed && !pulling && !failed) return null;

--- a/apps/desktop/src/renderer/components/settings/OllamaProviderDetail.tsx
+++ b/apps/desktop/src/renderer/components/settings/OllamaProviderDetail.tsx
@@ -236,14 +236,20 @@ export function OllamaProviderDetail({ onChanged }: { onChanged: () => void }) {
     pendingPulls.current.add(key);
     upsertPull({ name, status: 'starting', phase: 'starting', done: false });
     try {
-      const result = await window.electronAPI.maker.localModelPull(name);
-      pendingPulls.current.delete(key);
+      let result;
+      try {
+        result = await window.electronAPI.maker.localModelPull(name);
+      } finally {
+        // Release only this IPC's guard, before awaiting a refresh that may
+        // outlive a resumed download. Never clear another call's guard later.
+        pendingPulls.current.delete(key);
+      }
       if (result.stopped) {
-        await refresh();
+        await refresh().catch(() => undefined);
         return;
       }
       upsertPull({ name, status: 'success', phase: 'success', percent: 100, done: true });
-      await refresh();
+      await refresh().catch(() => undefined);
       onChanged();
       toast.success(t('settings.providers.local.added'));
     } catch (error) {
@@ -264,8 +270,6 @@ export function OllamaProviderDetail({ onChanged }: { onChanged: () => void }) {
           ? t('settings.providers.local.conflict')
           : t(`settings.providers.local.pullError.${kind ?? 'generic'}`),
       );
-    } finally {
-      pendingPulls.current.delete(key);
     }
   };
 


### PR DESCRIPTION
## 这次改了什么

### 摘要

Ollama 下载期间，供应商配置的无效写入不断触发目录刷新，迟到的列表快照又覆盖实时进度，导致界面上下跳动、下载按钮反复出现或两种进度交替显示。

本次消除配置刷新循环，并让下载事件优先于请求发出后已过时的列表内容。同一模型的重复点击只发起一次下载。Hugging Face 已有模型显示可读名称与量化标签，实际模型 ID 保持原样。

### 变更类型

- [x] `fix` 缺陷修复

### 范围

- 关联 Issue / 需求：Ollama 设置页下载期间抖动、重复进度及已有模型名称显示错误。
- 本 PR 包含：配置值比较、实际变更标记、按模型能力维护 Harness 成员、下载状态合并和重复请求防护、名称显示及回归测试。
- 明确不包含：Harness 默认选择（已由 #4318 合并）、下载协议变更、新增持久化结构。
- 用户可见变化：下载卡片稳定呈现当前进度；重复点击不会重置正在进行的下载；例如 `hf.co/org/Example-GGUF:Q8_0` 显示为 `Example (Q8_0)`。
- 是否存在 breaking change：无。

### UI 变化

- 引用的设计规范：`docs/design-rules/DESIGN.md §14.4 Motion & Transitions`、`§10 Theme System & Token Reference`。修复数据反复切换引起的布局跳动，复用现有卡片、进度组件和语义颜色，不增加动效或硬编码颜色。

## 怎么验证的

### 自动验证

- `env -u VITE_CINDY_AUTH_REGION -u NODE_ENV -u NODE_DEBUG -u CLAUDE_CODE_IDE_SKIP_AUTO_INSTALL pnpm test:unit:related`：通过。
- `pnpm --filter desktop run --if-present typecheck`：通过。
- 回归覆盖：持久化调整对象字段顺序仍能收敛；重复列表读取不写配置；真实能力变化只更新一次；网络失败保留原成员；旧快照不覆盖新下载和进度、不复活已完成下载；乱序返回与重复点击；显示名称不改变模型 ID。
- `git diff --check`：通过。

### 手工验证

2026-09-11 在 macOS 的功能工作区隔离开发版实测：Dark 界面连续观察 10 秒，进度从 37% 到 38%，下载卡片高度不变、未回到下载按钮，供应商目录更新通知为 0；已查看模型友好名称。此后仅同步主干，相关修复文件没有改动。

### 未执行的验证

同步最新主干后未重新启动 GUI；未目检 Light，未进行 Windows 实机验证。既有样式同时保留两种主题，不把样式复用视为双主题实测。

## 风险

### 风险分类

- [x] 其他：异步状态合并、托管供应商配置更新判定。

### 影响与回滚

- 影响范围：Desktop Ollama 供应商设置页与本地模型列表刷新。
- 状态约束：列表请求使用请求代次、进度及状态修订号；后来的进度事件和终态删除优先于旧列表，同一规范化模型名在 IPC 未完成期间只允许一个请求；请求成功、失败、停止均释放防重复标记，卸载时废弃旧请求返回。配置仅在值实际变化时写入，保留账户切换保护。
- 回滚 / 降级方式：回退本提交。无数据库 schema、协议或用户文件格式变更，模型执行 ID 不变。

### 提交前检查

- [x] 已 review 完整 diff
- [x] 每个 commit 都带 DCO 签名（`git commit -s`）
- [x] UI 改动已在「UI 变化」注明引用的设计规范章节
- [x] 未提交凭证、令牌或授权文件
- [x] 已核对受影响的文档；恢复原有下载交互，无新增产品规则
- [x] 已确认测试结果或说明未执行原因
