### PR TITLE
fix(mobile): 修复 Lead 错误恢复按钮被只读规则禁用

### DIFF
--- a/apps/mobile/app/sessions/[sessionId].tsx
+++ b/apps/mobile/app/sessions/[sessionId].tsx
@@ -2331,10 +2331,13 @@ export default function SessionScreen() {
   // 会话参数未就绪(缓存种入 / 新建在途)时队列行仍只读:取消 / 编辑 / 插队都是打到
   // 被控端队列的 RPC,会话在那边可能还不存在。暂时断线则与 Desktop 一致继续允许
   // 尝试,失败由 runQueueAction 报错,不把连接恢复职责转嫁给用户。
-  const queueInlineReadOnlyReason = collaborationReadOnlyReason
-    ?? cacheSeededReason
+  const queueAvailabilityReason = cacheSeededReason
     ?? pendingCreationReason
     ?? (sessionOperationLayout.showQueue ? null : composerDisabledReason);
+  const queueInlineReadOnlyReason = collaborationReadOnlyReason ?? queueAvailabilityReason;
+  // 重试/清错属于输入恢复：Lead 能发消息，也应能恢复失败输入。
+  // 队列编辑和恢复整组队列仍沿用协作编排只读规则。
+  const errorRecoveryReadOnlyReason = composerReadOnlyReason ?? queueAvailabilityReason;
   const showMessageHistory = sessionOperationLayout.messageHistoryMode === 'visible'
     || (sessionOperationLayout.messageHistoryMode === 'collapsed' && pendingHistoryExpanded);
   // 冷开即出壳:session 元信息还没回来,但不是真正不可用(离线/被撤销,看 remoteUnavailableReason)——
@@ -7277,10 +7280,12 @@ export default function SessionScreen() {
   }, [cancelQueueEdit, inputProjection.pendingQueue, queueEditing]);
 
   const retryQueueError = () => {
+    if (errorRecoveryReadOnlyReason || !inputProjection.errorRetryText) return;
     void runQueueAction(() => maker.input.retryLastError(sessionId));
   };
 
   const clearQueueError = () => {
+    if (errorRecoveryReadOnlyReason) return;
     void runQueueAction(() => maker.input.clearError(sessionId));
   };
 
@@ -9316,6 +9321,7 @@ export default function SessionScreen() {
                             不在这里,它们是消息流里的 pending_send 项。 */}
                         <InlineQueueSection
                           busy={queueBusy}
+                          errorRecoveryReadOnlyReason={errorRecoveryReadOnlyReason}
                           onClearError={clearQueueError}
                           onResume={resumeQueue}
                           onRetryError={retryQueueError}

--- a/apps/mobile/src/__tests__/InlineQueueSection.test.tsx
+++ b/apps/mobile/src/__tests__/InlineQueueSection.test.tsx
@@ -1,0 +1,85 @@
+// @vitest-environment jsdom
+import { act, type ReactNode } from 'react';
+import { createRoot, type Root } from 'react-dom/client';
+import { afterEach, beforeEach, expect, it, vi } from 'vitest';
+import { readFileSync } from 'node:fs';
+import { InlineQueueSection, type InlineQueueSectionProps } from '@/session/InlineQueueSection';
+import { sessionCollaborationComposerReadOnlyReason, sessionCollaborationReadOnlyReason } from '@/session/collaboration';
+import type { InputProjection } from '@/session/types';
+
+vi.mock('react-native', async () => {
+  const { createElement } = await import('react');
+  const view = (tag: string) => ({ children, onPress, disabled, testID, accessibilityHint }: {
+    children?: ReactNode; onPress?: () => void; disabled?: boolean; testID?: string; accessibilityHint?: string;
+  }) => createElement(tag, { onClick: onPress, disabled, 'data-testid': testID, title: accessibilityHint }, children);
+  return { View: view('div'), Text: view('span'), Pressable: view('button'), ActivityIndicator: () => null,
+    StyleSheet: { create: (s: unknown) => s, hairlineWidth: 1 } };
+});
+vi.mock('@/components/AppText', async () => ({ Text: (await import('react-native')).Text }));
+vi.mock('lucide-react-native', () => ({ Pause: () => null, Play: () => null }));
+vi.mock('react-i18next', async (importOriginal) => ({
+  ...await importOriginal<typeof import('react-i18next')>(),
+  useTranslation: () => ({ t: (key: string) => key }),
+}));
+vi.mock('@/theme', async () => {
+  const tokens = await import('@/theme/tokens');
+  return { ...tokens, useTheme: () => ({ colors: tokens.lightColors }),
+    useThemedStyles: (make: (colors: typeof tokens.lightColors) => unknown) => make(tokens.lightColors) };
+});
+
+let root: Root;
+let host: HTMLDivElement;
+const retry = vi.fn();
+const clear = vi.fn();
+const resume = vi.fn();
+beforeEach(() => {
+  Object.assign(globalThis, { IS_REACT_ACT_ENVIRONMENT: true });
+  vi.clearAllMocks();
+  host = document.createElement('div'); root = createRoot(host);
+});
+afterEach(() => act(() => root.unmount()));
+const projection = { error: 'Usage limit', errorRetryText: 'Try again', queuePaused: true } as InputProjection;
+async function show(role: string | null, props: Partial<InlineQueueSectionProps> = {}) {
+  await act(async () => root.render(<InlineQueueSection
+    projection={projection}
+    readOnlyReason={sessionCollaborationReadOnlyReason({ orcaRole: role })}
+    errorRecoveryReadOnlyReason={sessionCollaborationComposerReadOnlyReason({ orcaRole: role })}
+    onRetryError={retry} onClearError={clear} onResume={resume} {...props}
+  />));
+}
+const button = (action: string) => host.querySelector<HTMLButtonElement>(`[data-testid="queue.inline.${action}Button"]`)!;
+
+it.each(['lead', null])('lets %s retry and clear an error', async (role) => {
+  await show(role);
+  expect(button('retry').disabled).toBe(false);
+  expect(button('clearError').disabled).toBe(false);
+  expect(button('resume').disabled).toBe(role === 'lead');
+  await act(async () => { button('retry').click(); button('clearError').click(); });
+  expect(retry).toHaveBeenCalledOnce(); expect(clear).toHaveBeenCalledOnce();
+});
+it.each(['worker', 'reviewer'])('keeps %s read-only and explains why', async (role) => {
+  await show(role);
+  expect(button('retry').disabled).toBe(true);
+  expect(button('clearError').disabled).toBe(true);
+  expect(host.querySelector('[data-testid="queue.inline.errorDisabledReason"]')?.textContent).toBe(button('retry').title);
+  await act(async () => { button('retry').click(); button('clearError').click(); });
+  expect(retry).not.toHaveBeenCalled(); expect(clear).not.toHaveBeenCalled();
+});
+it('keeps readiness and in-flight gates, then re-enables recovery', async () => {
+  await show('lead', { errorRecoveryReadOnlyReason: 'Syncing' });
+  expect(button('retry').disabled).toBe(true); expect(button('clearError').title).toBe('Syncing');
+  await show('lead', { busy: true });
+  expect(button('retry').disabled).toBe(true); expect(button('clearError').disabled).toBe(true);
+  expect(host.textContent).toContain('message.queuePresentation.row.busy');
+  await show('lead'); expect(button('retry').disabled).toBe(false);
+});
+it('allows clearing an error without retry content', async () => {
+  await show('lead', { projection: { ...projection, errorRetryText: null } });
+  expect(button('retry').disabled).toBe(true); expect(button('clearError').disabled).toBe(false);
+});
+it('wires the route recovery gate independently from the orchestration gate', () => {
+  const source = readFileSync('app/sessions/[sessionId].tsx', 'utf8');
+  expect(source).toContain('errorRecoveryReadOnlyReason = composerReadOnlyReason ?? queueAvailabilityReason');
+  expect(source).toContain('errorRecoveryReadOnlyReason={errorRecoveryReadOnlyReason}');
+  expect(source).toContain('queueInlineReadOnlyReason = collaborationReadOnlyReason ?? queueAvailabilityReason');
+});

--- a/apps/mobile/src/__tests__/optimisticSessionComposer.test.ts
+++ b/apps/mobile/src/__tests__/optimisticSessionComposer.test.ts
@@ -31,7 +31,9 @@ describe('mobile optimistic composer while session is not ready', () => {
     expect(source).toContain('remoteUnavailableReason: composerRemoteUnavailableReason,');
     expect(source).toContain('describeRemoteComposerBlockingError(connectionError)');
     // 会话尚未在被控端建成时,队列行(取消 / 编辑 / 插队)仍然只读。
-    expect(source).toContain('const queueInlineReadOnlyReason = collaborationReadOnlyReason\n    ?? cacheSeededReason\n    ?? pendingCreationReason');
+    expect(source).toContain('const queueAvailabilityReason = cacheSeededReason\n    ?? pendingCreationReason');
+    expect(source).toContain('const queueInlineReadOnlyReason = collaborationReadOnlyReason ?? queueAvailabilityReason');
+    expect(source).toContain('const errorRecoveryReadOnlyReason = composerReadOnlyReason ?? queueAvailabilityReason');
   });
 
   it('matches Desktop control behavior during a transient disconnect', () => {

--- a/apps/mobile/src/__tests__/sessionMainLayerDesktopFirst.test.ts
+++ b/apps/mobile/src/__tests__/sessionMainLayerDesktopFirst.test.ts
@@ -88,7 +88,9 @@ describe('mobile session main layer desktop-first noise budget', () => {
     // 输入框换成只读卡片,而它们只表示还不能 enqueue。composer 保持可用,发送改走 outbox
     // 排队(见 optimisticSessionComposer.test.ts),这两条理由只留给队列行操作。
     expect(source).toContain('      readOnlyReason: composerReadOnlyReason,\n');
-    expect(source).toContain('const queueInlineReadOnlyReason = collaborationReadOnlyReason\n    ?? cacheSeededReason\n    ?? pendingCreationReason');
+    expect(source).toContain('const queueAvailabilityReason = cacheSeededReason\n    ?? pendingCreationReason');
+    expect(source).toContain('const queueInlineReadOnlyReason = collaborationReadOnlyReason ?? queueAvailabilityReason');
+    expect(source).toContain('const errorRecoveryReadOnlyReason = composerReadOnlyReason ?? queueAvailabilityReason');
     expect(source).toContain('readOnlyReason={composerReadOnlyReason}');
     // header notice:协作会话(可聊天的 Lead)显示协作标签而非"只读模式"。
     expect(source).toContain('const collaborationLabel = sessionCollaborationLabel(session);');

--- a/apps/mobile/src/i18n/locales/en/message.json
+++ b/apps/mobile/src/i18n/locales/en/message.json
@@ -153,6 +153,7 @@
     "systemInstruction": "System instruction",
     "retrySend": "Retry Send",
     "clearError": "Clear Error",
+    "noRetryContent": "No content is available to resend. Clear the error and enter your input again.",
     "piImageInputUnsupported": "Image input is not enabled for the current Pi model. Switch to a model that supports images. For a custom model, enable “Supports image input” in provider settings, then start a new Pi task.",
     "codexResumeNotReady": "Codex can't resume this task right now. Try again in a little while.",
     "credentialSwitchWait": "Waiting for another Codex task to finish; it will send automatically once done",

--- a/apps/mobile/src/i18n/locales/ja/message.json
+++ b/apps/mobile/src/i18n/locales/ja/message.json
@@ -153,6 +153,7 @@
     "systemInstruction": "システム指令",
     "retrySend": "送信を再試行",
     "clearError": "エラーをクリア",
+    "noRetryContent": "再送信できる内容がありません。エラーをクリアして、もう一度入力してください。",
     "piImageInputUnsupported": "現在の Pi モデルでは画像入力が有効になっていません。画像に対応するモデルへ切り替えてください。カスタムモデルの場合は、プロバイダー設定で「画像入力に対応」を有効にしてから、新しい Pi タスクを開始してください。",
     "codexResumeNotReady": "Codex は現在このタスクを再開できません。しばらくしてからもう一度お試しください。",
     "credentialSwitchWait": "他の Codex タスクの終了を待っています。終了後に自動で送信します",

--- a/apps/mobile/src/i18n/locales/ko/message.json
+++ b/apps/mobile/src/i18n/locales/ko/message.json
@@ -153,6 +153,7 @@
     "systemInstruction": "시스템 지시",
     "retrySend": "전송 재시도",
     "clearError": "오류 지우기",
+    "noRetryContent": "다시 보낼 내용이 없습니다. 오류를 지운 후 다시 입력해 주세요.",
     "piImageInputUnsupported": "현재 Pi 모델에는 이미지 입력이 활성화되어 있지 않습니다. 이미지를 지원하는 모델로 전환하세요. 사용자 지정 모델이라면 제공자 설정에서 ‘이미지 입력 지원’을 켠 다음 새 Pi 작업을 시작하세요.",
     "codexResumeNotReady": "Codex에서 현재 이 작업을 재개할 수 없습니다. 잠시 후 다시 시도해 주세요.",
     "credentialSwitchWait": "다른 Codex 작업이 끝나기를 기다리는 중입니다. 끝나면 자동으로 전송합니다",

--- a/apps/mobile/src/i18n/locales/zh-CN/message.json
+++ b/apps/mobile/src/i18n/locales/zh-CN/message.json
@@ -153,6 +153,7 @@
     "systemInstruction": "系统指令",
     "retrySend": "重试发送",
     "clearError": "清除错误",
+    "noRetryContent": "没有可重发的内容，请清除错误后重新输入。",
     "piImageInputUnsupported": "当前 Pi 模型未启用图片输入。请切换到支持图片的模型；如果这是自定义模型，请在供应商设置中开启“支持图片输入”，然后新建 Pi 任务。",
     "codexResumeNotReady": "Codex 暂时无法恢复这个任务，请稍后重试",
     "credentialSwitchWait": "正在等待其它 Codex 任务结束，结束后自动发送",

--- a/apps/mobile/src/i18n/locales/zh-TW/message.json
+++ b/apps/mobile/src/i18n/locales/zh-TW/message.json
@@ -153,6 +153,7 @@
     "systemInstruction": "系統指令",
     "retrySend": "重試傳送",
     "clearError": "清除錯誤",
+    "noRetryContent": "沒有可重新傳送的內容，請清除錯誤後重新輸入。",
     "piImageInputUnsupported": "當前 Pi 模型未啟用圖片輸入。請切換到支援圖片的模型；如果這是自定義模型，請在供應商設定中開啟“支援圖片輸入”，然後新建 Pi 任務。",
     "codexResumeNotReady": "Codex 暫時無法恢復這個任務，請稍後重試",
     "credentialSwitchWait": "正在等待其它 Codex 任務結束，結束後自動傳送",

--- a/apps/mobile/src/session/InlineQueueSection.tsx
+++ b/apps/mobile/src/session/InlineQueueSection.tsx
@@ -41,6 +41,7 @@ export interface InlineQueueSectionProps {
   projection: InputProjection;
   busy?: boolean;
   readOnlyReason?: string | null;
+  errorRecoveryReadOnlyReason: string | null;
   onResume(): void;
   onRetryError(): void;
   onClearError(): void;
@@ -50,6 +51,7 @@ export function InlineQueueSection({
   projection,
   busy,
   readOnlyReason,
+  errorRecoveryReadOnlyReason,
   onResume,
   onRetryError,
   onClearError,
@@ -65,6 +67,10 @@ export function InlineQueueSection({
   if (!hasBanner) return null;
 
   const controlsDisabled = busy || !!readOnlyReason;
+  const errorDisabledReason = errorRecoveryReadOnlyReason
+    || (busy ? t('message.queuePresentation.row.busy') : null);
+  const retryDisabledReason = errorDisabledReason
+    || (!projection.errorRetryText ? t('message.queue.noRetryContent') : null);
   const localizedAgentError = localizeAgentError(
     projection.errorReason,
     projection.toolLoop ?? null,
@@ -88,19 +94,26 @@ export function InlineQueueSection({
           <View style={styles.errorActions}>
             <ActionPill
               busy={busy}
-              disabled={controlsDisabled || !projection.errorRetryText}
+              disabled={!!retryDisabledReason}
+              disabledReason={retryDisabledReason}
               label={t('message.queue.retrySend')}
               onPress={onRetryError}
               testID="queue.inline.retryButton"
             />
             <ActionPill
               busy={busy}
-              disabled={controlsDisabled}
+              disabled={!!errorDisabledReason}
+              disabledReason={errorDisabledReason}
               label={t('message.queue.clearError')}
               onPress={onClearError}
               testID="queue.inline.clearErrorButton"
             />
           </View>
+          {retryDisabledReason ? (
+            <Text style={styles.disabledHint} testID="queue.inline.errorDisabledReason">
+              {retryDisabledReason}
+            </Text>
+          ) : null}
         </View>
       ) : null}
 
@@ -250,6 +263,7 @@ const makeStyles = (colors: ThemeColors) => StyleSheet.create({
     padding: spacing.md,
   },
   errorText: { color: colors.errorText, fontSize: typeScale.caption, lineHeight: lineHeight.caption },
+  disabledHint: { color: colors.textSecondary, fontSize: typeScale.caption, lineHeight: lineHeight.caption },
   errorActions: { flexDirection: 'row', flexWrap: 'wrap', gap: spacing.sm },
   actionPill: {
     alignItems: 'center',


### PR DESCRIPTION
## 这次改了什么

### 摘要

手机端允许给协作 Lead 发消息，但发送失败后的「重试发送」「清除错误」却复用了协作编排只读规则，导致两个按钮同时不可用。本次将错误恢复与队列编排的可用性分开，让 Lead 的错误恢复与发消息权限一致。

### 变更类型

- [x] `fix` 缺陷修复

### 范围

- 关联 Issue / 需求：手机端 Lead 发送失败后无法重试。
- 本 PR 包含：拆分错误恢复权限、回调守卫、禁用原因提示及五种语言文案、回归测试。
- 明确不包含：队列编辑及整组队列恢复放行、Worker 写操作、额度恢复、后端协议调整。
- 用户可见变化：Lead 可重试或清错；只读、同步中、操作进行中、缺少可重发内容时显示原因。
- 是否存在 breaking change：无。
- 多端适配：手机复用现有 Device Link 重试与清错接口，SSH 任务仍由被控桌面处理；不新增 IPC，不改变重连或超时机制。

### UI 变化

- 引用的设计规范：`docs/design-rules/DESIGN.md` §2、§10：提示使用 `textSecondary` 语义颜色，支持 Light/Dark；沿用错误卡片布局与 caption 字号，不新增硬编码颜色。
- 平台：Mobile。尚无修复版本的实机截图。

## 怎么验证的

### 自动验证

- `pnpm test:unit:related`：通过。
- `pnpm --filter mobile typecheck`：通过。
- `pnpm --filter mobile exec vitest run src/__tests__/InlineQueueSection.test.tsx src/__tests__/collaboration.test.ts`：10 个测试通过。
- `pnpm check:i18n-glossary`：通过，无新增违规。
- `git diff --check`：通过。
- 更新旧权限表达式断言后，手机端全量 `vitest run --pool=threads --maxWorkers=4`：429 个文件、5496 个用例通过。
- 通过统一 runner 执行全仓 `pnpm test:unit`：Desktop 的 `claudeOrphanReaper.test.ts`、`codexAuthIsolatedSandbox.test.ts` 共 9 个断言失败。在同一基准提交 `4fad02bc1` 的干净 main 上定向复跑，两文件相同 9 个失败（其余 38 个通过），属于本机/基线问题，未混入无关修复。

### 手工验证

修复前结合手机与桌面日志、任务角色和代码禁用条件定位问题。组件回归覆盖 Lead/普通任务、Worker/其它角色、忙碌、未就绪、缺少重试内容与路由接线。

### 未执行的验证

未启动修复版本的 Metro，未做 iOS/Android 真机操作和 Light/Dark 目检，无 Metro 或 build label 验收证据。分支为 `dash/fix-mobile-lead-error-retry`，worktree 为 `cindy-fix-mobile-lead-error-retry`。

## 风险

### 风险分类

- [x] 其他：手机端操作可用性调整。

### 影响与回滚

- 影响范围：错误横幅的重试、清错与禁用提示；Worker 及队列编排限制保留。只改 JS/TS 与文案，不修改原生配置或依赖。
- 回滚 / 降级方式：回退本 PR 恢复原可用性规则，无数据迁移。

### 提交前检查

- [x] 已 review 完整 diff
- [x] 每个 commit 都带 DCO 签名（`git commit -s`）
- [x] UI 改动已在「UI 变化」注明引用的设计规范章节
- [x] 未提交凭证、令牌或授权文件
- [x] 已核对受影响的文档，队列编排只读边界保持不变
- [x] 已确认测试结果或说明未执行原因
