### PR TITLE
fix(mobile): 退出远程桌面时隐藏连接状态提示

### DIFF
--- a/apps/mobile/src/i18n/locales/en/remoteDesktop.json
+++ b/apps/mobile/src/i18n/locales/en/remoteDesktop.json
@@ -56,6 +56,7 @@
   "connect": "Connect",
   "connecting": "Connecting…",
   "reconnecting": "Reconnecting…",
+  "lockingOnExit": "Locking computer…",
   "disconnected": "Disconnected",
   "compatibility": "Compatibility mode · lower frame rate",
   "live": "Live",

--- a/apps/mobile/src/i18n/locales/ja/remoteDesktop.json
+++ b/apps/mobile/src/i18n/locales/ja/remoteDesktop.json
@@ -56,6 +56,7 @@
   "connect": "接続",
   "connecting": "接続中…",
   "reconnecting": "再接続中…",
+  "lockingOnExit": "コンピューターをロック中…",
   "disconnected": "切断済み",
   "compatibility": "互換モード · 低フレームレート",
   "live": "ライブ映像",

--- a/apps/mobile/src/i18n/locales/ko/remoteDesktop.json
+++ b/apps/mobile/src/i18n/locales/ko/remoteDesktop.json
@@ -56,6 +56,7 @@
   "connect": "연결",
   "connecting": "연결 중…",
   "reconnecting": "다시 연결 중…",
+  "lockingOnExit": "컴퓨터를 잠그는 중…",
   "disconnected": "연결 끊김",
   "compatibility": "호환 모드 · 낮은 프레임 속도",
   "live": "실시간 화면",

--- a/apps/mobile/src/i18n/locales/zh-CN/remoteDesktop.json
+++ b/apps/mobile/src/i18n/locales/zh-CN/remoteDesktop.json
@@ -56,6 +56,7 @@
   "connect": "连接",
   "connecting": "连接中…",
   "reconnecting": "正在重新连接…",
+  "lockingOnExit": "正在锁定电脑…",
   "disconnected": "已断开",
   "compatibility": "兼容模式 · 帧率较低",
   "live": "实时画面",

--- a/apps/mobile/src/i18n/locales/zh-TW/remoteDesktop.json
+++ b/apps/mobile/src/i18n/locales/zh-TW/remoteDesktop.json
@@ -56,6 +56,7 @@
   "connect": "連線",
   "connecting": "連線中…",
   "reconnecting": "正在重新連線…",
+  "lockingOnExit": "正在鎖定電腦…",
   "disconnected": "已中斷",
   "compatibility": "相容模式 · 畫格率較低",
   "live": "即時畫面",

--- a/apps/mobile/src/remote-desktop/RemoteDesktopScreen.tsx
+++ b/apps/mobile/src/remote-desktop/RemoteDesktopScreen.tsx
@@ -184,6 +184,7 @@ export default function RemoteDesktopScreen() {
   const exitLock = useRef(false);
   const leaving = useRef(false);
   const [isLeaving, setIsLeaving] = useState(false);
+  const [exitLockPending, setExitLockPending] = useState(false);
   const linkRef = useRef(link);
   linkRef.current = link;
   const { t } = useTranslation();
@@ -238,7 +239,7 @@ export default function RemoteDesktopScreen() {
   const connectionPending = !error && (!lease || !frameReady || !controlReady);
   const showConnectionStatus =
     !isLeaving && (connectionPending || (!error && status === "reconnecting"));
-  const showExitLockStatus = isLeaving && exitLock.current;
+  const showExitLockStatus = isLeaving && exitLockPending;
   const connectionLabel = t(
     showExitLockStatus
       ? "remoteDesktop.lockingOnExit"
@@ -405,6 +406,7 @@ export default function RemoteDesktopScreen() {
       void remotePresentation?.playback(false).catch(() => {});
       connecting.current = false;
       const previous = active.current;
+      setExitLockPending(Boolean(previous && exiting && exitLock.current));
       active.current = null;
       pendingVideoSettings.current = null;
       if (previous) pendingMediaOffers.current.delete(previous);
@@ -866,6 +868,7 @@ export default function RemoteDesktopScreen() {
     } else if (focused) {
       leaving.current = false;
       setIsLeaving(false);
+      setExitLockPending(false);
       if (!active.current) void connectRef.current();
     }
   }, [focused, pause, videoPreferencesLoaded]);

--- a/apps/mobile/src/remote-desktop/RemoteDesktopScreen.tsx
+++ b/apps/mobile/src/remote-desktop/RemoteDesktopScreen.tsx
@@ -859,8 +859,15 @@ export default function RemoteDesktopScreen() {
   useEffect(() => {
     // Route blur means leaving this desktop (including a native back swipe).
     // App background/inactive events use pause() without the exit flag.
-    if (!focused && !presentation.current) pause(true);
-    else if (!active.current) void connectRef.current();
+    if (!focused && !presentation.current) {
+      leaving.current = true;
+      setIsLeaving(true);
+      pause(true);
+    } else if (focused) {
+      leaving.current = false;
+      setIsLeaving(false);
+      if (!active.current) void connectRef.current();
+    }
   }, [focused, pause, videoPreferencesLoaded]);
   useEffect(() => {
     send({

--- a/apps/mobile/src/remote-desktop/RemoteDesktopScreen.tsx
+++ b/apps/mobile/src/remote-desktop/RemoteDesktopScreen.tsx
@@ -183,6 +183,7 @@ export default function RemoteDesktopScreen() {
     useLockOnExitPreference(deviceId);
   const exitLock = useRef(false);
   const leaving = useRef(false);
+  const [isLeaving, setIsLeaving] = useState(false);
   const linkRef = useRef(link);
   linkRef.current = link;
   const { t } = useTranslation();
@@ -236,11 +237,14 @@ export default function RemoteDesktopScreen() {
   const [controlReady, setControlReady] = useState(false);
   const connectionPending = !error && (!lease || !frameReady || !controlReady);
   const showConnectionStatus =
-    connectionPending || (!error && status === "reconnecting");
+    !isLeaving && (connectionPending || (!error && status === "reconnecting"));
+  const showExitLockStatus = isLeaving && exitLock.current;
   const connectionLabel = t(
-    recovery.current.at || status === "reconnecting"
-      ? "remoteDesktop.reconnecting"
-      : "remoteDesktop.connecting",
+    showExitLockStatus
+      ? "remoteDesktop.lockingOnExit"
+      : recovery.current.at || status === "reconnecting"
+        ? "remoteDesktop.reconnecting"
+        : "remoteDesktop.connecting",
   );
   const [busy, setBusy] = useState(false);
   const [inputMode, setInputMode] = useInputModePreference();
@@ -670,6 +674,7 @@ export default function RemoteDesktopScreen() {
   const leave = async () => {
     if (leaving.current) return;
     leaving.current = true;
+    setIsLeaving(true);
     recovery.current.enabled = false;
     Keyboard.dismiss();
     const ending = stop(false, true);
@@ -1580,7 +1585,9 @@ export default function RemoteDesktopScreen() {
             style={styles.webview}
             testID="remoteDesktop.viewer"
           />
-          {(showConnectionStatus || (!lease && error)) && (
+          {(showConnectionStatus ||
+            showExitLockStatus ||
+            (!lease && error)) && (
             <View
               pointerEvents="box-none"
               style={[
@@ -1588,7 +1595,7 @@ export default function RemoteDesktopScreen() {
                 { top: edgePadding.paddingTop + spacing.xs + 44 + spacing.lg },
               ]}
             >
-              {showConnectionStatus ? (
+              {showConnectionStatus || showExitLockStatus ? (
                 <View
                   style={styles.connectionBadge}
                   accessibilityRole="progressbar"


### PR DESCRIPTION
## 这次改了什么

### 摘要

主动退出远程桌面时隐藏连接中/重新连接中提示；启用退出锁屏且确实发送锁屏请求时显示正在锁定电脑。

### 变更类型

- [x] `fix` 缺陷修复

### 范围

- 关联 Issue / 需求：无
- 本 PR 包含：Mobile JS 退出状态分流和五种语言文案。
- 明确不包含：原生层、fingerprint、协议和连接流程。
- 用户可见变化：主动退出不再显示误导性的连接状态；锁屏请求等待期间显示准确进度。
- 是否存在 breaking change：无。

### UI 变化

- 引用的设计规范：`docs/design-rules/DESIGN.md` §11.1/§11.2：进行中状态使用持续时态和省略号；五种语言遵循各自标点。沿用现有连接徽标和主题 token，仅改变退出状态可见性与文案。

## 怎么验证的

### 自动验证

```text
corepack pnpm check:i18n-glossary
corepack pnpm exec prettier --check ...
git diff --check
结果：通过；CI 的 Mobile、Linux、Windows、CodeQL、DCO 和设计依据检查通过。
```

### 手工验证

用户已在 iPhone 确认远程桌面退出时的视觉行为符合预期。

### 未执行的验证

本地新 worktree 未安装完整依赖，未重复运行 Mobile Vitest/typecheck；Windows 初次失败为与本 PR 无关的 Desktop 测试超时/瞬态问题，重跑后通过。

## 风险

### 风险分类

- [x] 无已知风险

### 影响与回滚

- 影响范围：Mobile 远程桌面退出期间的状态提示。
- 回滚 / 降级方式：回退本 PR 提交。

### 提交前检查

- [x] 已 review 完整 diff
- [x] 每个 commit 都带 DCO 签名
- [x] UI 改动已注明设计规范章节
- [x] 未提交凭证、令牌或授权文件
- [x] 已确认测试结果或说明未执行原因