### PR TITLE
fix(mobile): 稳定本地空闲发送的乐观气泡位置

### DIFF
--- a/apps/mobile/app/sessions/[sessionId].tsx
+++ b/apps/mobile/app/sessions/[sessionId].tsx
@@ -116,7 +116,7 @@ import { shouldClearOperationErrorAfterSync, type SessionOperationError } from '
 import { createTransientTopicSubscriptionCoordinator } from '@/device-link/transientTopicSubscription';
 import { useMobileMakerTransport } from '@/device-link/useMobileMakerTransport';
 import { findRemoteHistoryView, useRemoteHistoryView } from '@/session/remoteHistoryView';
-import { HistoryViewHandoff, isHistoryViewUnavailable } from '@cindy/maker-shared/message-window';
+import { HistoryViewHandoff, historyViewLeaves, isHistoryViewUnavailable } from '@cindy/maker-shared/message-window';
 import { buildMobileHistoryRenderItems } from '@/session/mobileHistoryRender';
 import { createMobileMakerTransport } from '@/device-link/mobileMakerTransport';
 import { startFocusedTopicSubscription } from '@/device-link/focusedTopicSubscription';
@@ -337,11 +337,15 @@ import {
 } from '@/session/inputProjection';
 import {
   mergePendingSendItems,
-  reconcilePendingSendOrder,
-  type PendingSendOrder,
   buildPendingSendItems,
   type MobilePendingSendActions,
 } from '@/session/pendingSendItems';
+import {
+  appendOptimisticUserMessage,
+  projectOptimisticUserMessages,
+  reconcileOptimisticUserMessages,
+  type OptimisticUserMessage,
+} from '@/session/optimisticUserMessages';
 import type { PendingSendBubbleActions } from '@/session/PendingSendBubble';
 import {
   acquireQueueEditLock,
@@ -1507,19 +1511,25 @@ export default function SessionScreen() {
   // 还没有答案(弱网可达数秒,且失败会回滚摘除气泡),徽标必须是转圈而不是「排入
   // 队尾」——后者是已确认入队的语义。成功 / 回滚 / 转失败任一落定即移除。
   const [sendingQueueClientIds, setSendingQueueClientIds] = useState<ReadonlySet<string>>(new Set());
-  // Ordering evidence stays through the settling phase, after the sending badge
-  // clears. Scope it to the page's session; never compare the phone clock to the host.
-  const [sendBaselineState, setSendBaselineState] = useState<{
+  const [optimisticUserState, setOptimisticUserState] = useState<{
     sessionId: string;
-    byClientId: ReadonlyMap<string, PendingSendOrder>;
-  }>(() => ({ sessionId, byClientId: new Map() }));
-  if (sendBaselineState.sessionId !== sessionId) {
-    setSendBaselineState({ sessionId, byClientId: new Map() });
+    items: readonly OptimisticUserMessage[];
+  }>(() => ({ sessionId, items: [] }));
+  if (optimisticUserState.sessionId !== sessionId) {
+    setOptimisticUserState({ sessionId, items: [] });
   }
-  const markQueueItemSending = useCallback((clientId: string) => {
-    const userSendAt = remoteSessionStore.getSessions().find((item) => item.id === sessionId)?.userSendAt ?? null;
-    setSendBaselineState((current) => current.sessionId !== sessionId ? current : {
-      sessionId, byClientId: new Map([...current.byClientId, [clientId, { baseline: userSendAt }]]),
+  const markQueueItemSending = useCallback((queued: QueuedRemoteMessage) => {
+    const clientId = queued.clientId;
+    const projection = remoteSessionStore.getInputProjection(sessionId);
+    const source = remoteSessionStore.getMessages(sessionId);
+    // Match Desktop's idle-send placement. A busy turn's follow-up remains in
+    // the queue until the existing dispatch/settling projection promotes it.
+    const busy = projection.pendingQueue.length > 0 || projection.steeringQueueClientIds.length > 0
+      || projection.queueAbortPending || remoteSessionStore.isSessionRunning(sessionId)
+      || remoteSessionStore.getPendingInteractions(sessionId).length > 0
+      || currentTurnHasStreamingAssistant(source);
+    if (!busy) setOptimisticUserState((current) => current.sessionId !== sessionId ? current : {
+      sessionId, items: appendOptimisticUserMessage(current.items, source, queued, sessionId),
     });
     setSendingQueueClientIds((current) => {
       if (current.has(clientId)) return current;
@@ -4213,8 +4223,40 @@ export default function SessionScreen() {
     projectedMessageWindowRef.current = { projection, sessionId };
     return projection;
   }, [messageStructureChangedIndexes, messageStructureToken, messages, sessionId]);
-  const projectedMessages = projectedMessageWindow.projected;
-  const projectedMessageStructureChangedIndexes = projectedMessageWindow.changedIndexes;
+  const confirmedUserClientIds = useMemo(() => new Set(
+    (historyView.snapshot.ready
+      ? historyViewLeaves(historyView.snapshot.items).flatMap((item) => item.type === 'messages' ? item.messages : [])
+      : messages).filter((message) => message.role === 'user').map((message) => message.clientId),
+  ), [historyView.snapshot, messages]);
+  const optimisticUsers = useMemo(() => {
+    const activeIds = new Set([
+      ...inputProjection.pendingQueue.filter((item) => sendingQueueClientIds.has(item.clientId)).map((item) => item.clientId),
+      ...settlingItemsForRender.map((item) => item.clientId),
+    ]);
+    let items = reconcileOptimisticUserMessages(
+      optimisticUserState.sessionId === sessionId ? optimisticUserState.items : [],
+      messages, activeIds, confirmedUserClientIds,
+    );
+    for (const item of settlingItemsForRender) {
+      if (!confirmedUserClientIds.has(item.clientId)) {
+        items = appendOptimisticUserMessage(items, messages, item, sessionId);
+      }
+    }
+    return items;
+  }, [optimisticUserState, sessionId, messages, inputProjection.pendingQueue,
+    sendingQueueClientIds, settlingItemsForRender, confirmedUserClientIds]);
+  if (optimisticUserState.sessionId === sessionId && optimisticUsers !== optimisticUserState.items) {
+    setOptimisticUserState({ sessionId, items: optimisticUsers });
+  }
+  const localUserClientIds = useMemo(() => new Set(optimisticUsers.map((entry) => entry.message.clientId)), [optimisticUsers]);
+  const optimisticClientIds = useMemo(() => new Set([...localUserClientIds].filter((id) => !queueHiddenClientIds.has(id))),
+    [localUserClientIds, queueHiddenClientIds]);
+  const projectedMessages = useMemo(() => projectOptimisticUserMessages(projectedMessageWindow.projected, optimisticUsers),
+    [projectedMessageWindow.projected, optimisticUsers]);
+  // Adding/removing a user boundary invalidates prefix grouping, even if no host
+  // message changed. Do not reuse source indexes after inserting local rows.
+  const renderMessageStructureToken = useMemo(() => ({}), [messageStructureToken, optimisticUsers]);
+  const projectedMessageStructureChangedIndexes = optimisticUsers.length > 0 ? undefined : projectedMessageWindow.changedIndexes;
   const oldestLoadedMessageCursor = useMemo(
     () => historyView.snapshot.ready ? historyView.snapshot.nextCursor : oldestMessageCursor(latestMessagesRef.current),
     [messageStructureToken, historyView.snapshot],
@@ -4231,9 +4273,10 @@ export default function SessionScreen() {
         cacheKey: i18nInstance.language,
         messages: projectedMessages,
         messageStructureChangedIndexes: projectedMessageStructureChangedIndexes,
-        messageStructureToken,
+        messageStructureToken: renderMessageStructureToken,
         options: {
           autoResumePending: inputProjection.autoResumePending,
+          preserveSourceOrder: optimisticUsers.length > 0,
           isSessionStreaming: isMessageListStreaming,
           renderOrphanTaskUpdates: makerTurnRunning,
           sessionId,
@@ -4244,7 +4287,7 @@ export default function SessionScreen() {
       const historyItems = historyView.snapshot.ready ? buildMobileHistoryRenderItems({
         view: historyView.view, snapshot: historyView.snapshot, messages: projectedMessages,
         streaming: isMessageListStreaming, sessionId, taskUpdates,
-        pendingHandoff: handoff.pending,
+        pendingHandoff: handoff.pending, localUserClientIds,
       }) : builtWindow.items;
       let items = insertMobileForkOriginItem(
         // 孤儿 agent_task 兜底用 maker status 驱动的权威 turn 边界 gate,与 store 的
@@ -4286,12 +4329,16 @@ export default function SessionScreen() {
         stablePrefixItemCount,
       };
     },
-    [historyView.snapshot, historyView.view, handoff.pending, errorTailClientId, forkOrigin, i18nInstance.language, inputProjection.autoResumePending, isMessageListStreaming, makerTurnRunning, messageStructureToken, projectedMessages, projectedMessageStructureChangedIndexes, sessionId, taskUpdates],
+    [optimisticUsers, localUserClientIds, renderMessageStructureToken, historyView.snapshot, historyView.view, handoff.pending, errorTailClientId, forkOrigin, i18nInstance.language, inputProjection.autoResumePending, isMessageListStreaming, makerTurnRunning, messageStructureToken, projectedMessages, projectedMessageStructureChangedIndexes, sessionId, taskUpdates],
   );
-  const renderItems = renderWindow.items;
+  // Search, media and sharing only see durable user rows. Local user boundaries
+  // still participate in grouping and in the message list below.
+  const renderItems = useMemo(() => optimisticClientIds.size === 0 ? renderWindow.items : renderWindow.items.filter((item) =>
+    !(item.type === 'message' && optimisticClientIds.has(item.message.source.clientId))),
+  [renderWindow.items, optimisticClientIds]);
   const renderItemsStructureKey = useMemo(
     () => ({}),
-    [historyView.snapshot, errorTailClientId, forkOrigin, i18nInstance.language, inputProjection.autoResumePending, isMessageListStreaming, makerTurnRunning, messageStructureToken, sessionId, taskUpdates],
+    [optimisticUsers, historyView.snapshot, errorTailClientId, forkOrigin, i18nInstance.language, inputProjection.autoResumePending, isMessageListStreaming, makerTurnRunning, messageStructureToken, sessionId, taskUpdates],
   );
   // Reconciliation must only use committed rows. Unlike the prefix cache above, a speculative
   // render-item baseline could leak rows from an abandoned render and destabilize tail memoization.
@@ -4301,14 +4348,14 @@ export default function SessionScreen() {
       && previousRenderItemsRef.current?.prefix !== renderWindow.prefix
       && streamingRenderPrefixRef.current === renderWindow.prefix
     ) {
-      commitMobileStreamingPrefixItems(renderWindow.prefix, renderItems);
+      commitMobileStreamingPrefixItems(renderWindow.prefix, renderWindow.items);
     }
     previousRenderItemsRef.current = {
       sessionId,
-      items: renderItems,
+      items: renderWindow.items,
       prefix: renderWindow.prefix,
     };
-  }, [renderItems, renderWindow.prefix, sessionId]);
+  }, [renderWindow.items, renderWindow.prefix, sessionId]);
   // Known stale entry content bypasses the quiet delay; routine sync stays subtle.
   const showSyncingIndicator = !showConnectionBanner && !showCachedHistoryNotice
     && (loading || historyView.snapshot.loading || status === 'connecting' || contentRecoveryState === 'syncing');
@@ -5483,6 +5530,7 @@ export default function SessionScreen() {
     // 乐观交接:进本地 pendingQueue 的同一同步段把条目移出 outbox,气泡原位从
     // 「发送中」变「排队中」不闪断;enqueue 成功后用权威 projection 覆盖 reconcile。
     const projectionBeforeSend = remoteSessionStore.getInputProjection(item.sessionId);
+    markQueueItemSending(queued);
     remoteSessionStore.setInputProjectionOptimistically(item.sessionId, {
       ...projectionBeforeSend,
       sessionId: projectionBeforeSend.sessionId || item.sessionId,
@@ -5500,7 +5548,6 @@ export default function SessionScreen() {
     );
     // outbox 气泡本来就在转圈:交接进 pendingQueue 后 enqueue 仍在途,徽标继续转圈,
     // 不要在这一帧闪成排队 icon 再回来(也不能谎报「已入队」)。
-    markQueueItemSending(queued.clientId);
     const projectionRemoteEpochAtRequestStart =
       remoteSessionStore.captureInputProjectionRemoteEpoch(item.sessionId);
     const projectionEpochAtRequestStart =
@@ -5733,26 +5780,13 @@ export default function SessionScreen() {
       settlingItemsForRender,
     ],
   );
-  const sendOrder = useMemo(() => reconcilePendingSendOrder(
-    sendBaselineState.sessionId === sessionId ? sendBaselineState.byClientId : new Map(),
-    pendingSendItems, currentSession?.userSendAt,
-  ), [sendBaselineState, sessionId, pendingSendItems, currentSession?.userSendAt]);
   const messageListItems = useMemo(
-    () => mergePendingSendItems(
-      renderItems, pendingSendItems, currentSession?.userSendAt,
-      sendOrder,
-    ),
-    [currentSession?.userSendAt, pendingSendItems, renderItems, sendOrder],
+    () => mergePendingSendItems(renderWindow.items, pendingSendItems, optimisticClientIds),
+    [pendingSendItems, renderWindow.items, optimisticClientIds],
   );
-  useEffect(() => {
-    setSendBaselineState((current) => {
-      if (current !== sendBaselineState || current.sessionId !== sessionId) return current;
-      return sendOrder === current.byClientId ? current : { sessionId, byClientId: sendOrder };
-    });
-  }, [sendOrder, sendBaselineState, sessionId]);
   const messageListStructureKey = useMemo(
     () => ({}),
-    [currentSession?.userSendAt, pendingSendItems, renderItemsStructureKey, sendBaselineState],
+    [pendingSendItems, renderItemsStructureKey, optimisticClientIds],
   );
   const shareExpandableBlockIds = useMemo(
     () => (shareSelectionActive ? collectConversationShareBlockIds(messageListItems) : []),
@@ -6491,6 +6525,7 @@ export default function SessionScreen() {
       // previews / mediaAssetAttachments 映射保留到成功后再清:它们不入消息体,失败
       // 恢复 attachments 时缩略图能原样回来。
       const projectionBeforeSend = remoteSessionStore.getInputProjection(sessionId);
+      markQueueItemSending(queued);
       remoteSessionStore.setInputProjectionOptimistically(sessionId, {
         ...projectionBeforeSend,
         sessionId: projectionBeforeSend.sessionId || sessionId,
@@ -6504,7 +6539,6 @@ export default function SessionScreen() {
       );
       // 乐观气泡此刻还没有「已入队」这个事实:徽标先给转圈,enqueue 落定后才交给
       // 排队 icon(或随回滚一起消失)。
-      markQueueItemSending(queued.clientId);
       const projectionRemoteEpochAtRequestStart =
         remoteSessionStore.captureInputProjectionRemoteEpoch(sessionId);
       setAttachments([]);

--- a/apps/mobile/app/sessions/[sessionId].tsx
+++ b/apps/mobile/app/sessions/[sessionId].tsx
@@ -4223,6 +4223,12 @@ export default function SessionScreen() {
     projectedMessageWindowRef.current = { projection, sessionId };
     return projection;
   }, [messageStructureChangedIndexes, messageStructureToken, messages, sessionId]);
+  const previousRenderItemsRef = useRef<{
+    sessionId: string;
+    messages: readonly RemoteMessage[];
+    items: readonly MobileMessageRenderItem[];
+    prefix: MobileStreamingRenderPrefixCache | null;
+  } | null>(null);
   const confirmedUserClientIds = useMemo(() => new Set(
     (historyView.snapshot.ready
       ? historyViewLeaves(historyView.snapshot.items).flatMap((item) => item.type === 'messages' ? item.messages : [])
@@ -4239,7 +4245,11 @@ export default function SessionScreen() {
     );
     for (const item of settlingItemsForRender) {
       if (!confirmedUserClientIds.has(item.clientId)) {
-        items = appendOptimisticUserMessage(items, messages, item, sessionId);
+        // On reconnect the first render can contain both the reply and the
+        // vanished queue. Anchor to the last committed frame, not that reply.
+        const beforeDispatch = previousRenderItemsRef.current?.sessionId === sessionId
+          ? previousRenderItemsRef.current.messages : [];
+        items = appendOptimisticUserMessage(items, beforeDispatch, item, sessionId);
       }
     }
     return items;
@@ -4261,11 +4271,6 @@ export default function SessionScreen() {
     () => historyView.snapshot.ready ? historyView.snapshot.nextCursor : oldestMessageCursor(latestMessagesRef.current),
     [messageStructureToken, historyView.snapshot],
   );
-  const previousRenderItemsRef = useRef<{
-    sessionId: string;
-    items: readonly MobileMessageRenderItem[];
-    prefix: MobileStreamingRenderPrefixCache | null;
-  } | null>(null);
   const streamingRenderPrefixRef = useRef<MobileStreamingRenderPrefixCache | null>(null);
   const renderWindow = useMemo(
     () => {
@@ -4352,10 +4357,11 @@ export default function SessionScreen() {
     }
     previousRenderItemsRef.current = {
       sessionId,
+      messages,
       items: renderWindow.items,
       prefix: renderWindow.prefix,
     };
-  }, [renderWindow.items, renderWindow.prefix, sessionId]);
+  }, [messages, renderWindow.items, renderWindow.prefix, sessionId]);
   // Known stale entry content bypasses the quiet delay; routine sync stays subtle.
   const showSyncingIndicator = !showConnectionBanner && !showCachedHistoryNotice
     && (loading || historyView.snapshot.loading || status === 'connecting' || contentRecoveryState === 'syncing');

--- a/apps/mobile/app/sessions/[sessionId].tsx
+++ b/apps/mobile/app/sessions/[sessionId].tsx
@@ -336,7 +336,7 @@ import {
   type QueueEditTextState,
 } from '@/session/inputProjection';
 import {
-  appendPendingSendItems,
+  mergePendingSendItems,
   buildPendingSendItems,
   type MobilePendingSendActions,
 } from '@/session/pendingSendItems';
@@ -1505,14 +1505,27 @@ export default function SessionScreen() {
   // 还没有答案(弱网可达数秒,且失败会回滚摘除气泡),徽标必须是转圈而不是「排入
   // 队尾」——后者是已确认入队的语义。成功 / 回滚 / 转失败任一落定即移除。
   const [sendingQueueClientIds, setSendingQueueClientIds] = useState<ReadonlySet<string>>(new Set());
+  // Ordering evidence stays through the settling phase, after the sending badge
+  // clears. Scope it to the page's session; never compare the phone clock to the host.
+  const [sendBaselineState, setSendBaselineState] = useState<{
+    sessionId: string;
+    byClientId: ReadonlyMap<string, string | null>;
+  }>(() => ({ sessionId, byClientId: new Map() }));
+  if (sendBaselineState.sessionId !== sessionId) {
+    setSendBaselineState({ sessionId, byClientId: new Map() });
+  }
   const markQueueItemSending = useCallback((clientId: string) => {
+    const userSendAt = remoteSessionStore.getSessions().find((item) => item.id === sessionId)?.userSendAt ?? null;
+    setSendBaselineState((current) => current.sessionId !== sessionId ? current : {
+      sessionId, byClientId: new Map([...current.byClientId, [clientId, userSendAt]]),
+    });
     setSendingQueueClientIds((current) => {
       if (current.has(clientId)) return current;
       const next = new Set(current);
       next.add(clientId);
       return next;
     });
-  }, []);
+  }, [sessionId]);
   const clearQueueItemSending = useCallback((clientId: string) => {
     setSendingQueueClientIds((current) => {
       if (!current.has(clientId)) return current;
@@ -5719,12 +5732,23 @@ export default function SessionScreen() {
     ],
   );
   const messageListItems = useMemo(
-    () => appendPendingSendItems(renderItems, pendingSendItems),
-    [pendingSendItems, renderItems],
+    () => mergePendingSendItems(
+      renderItems, pendingSendItems, currentSession?.userSendAt,
+      sendBaselineState.sessionId === sessionId ? sendBaselineState.byClientId : new Map(),
+    ),
+    [currentSession?.userSendAt, pendingSendItems, renderItems, sendBaselineState, sessionId],
   );
+  useEffect(() => {
+    const pendingIds = new Set(pendingSendItems.map((item) => item.clientId));
+    setSendBaselineState((current) => {
+      if (current !== sendBaselineState || current.sessionId !== sessionId) return current;
+      const kept = new Map([...current.byClientId].filter(([id]) => pendingIds.has(id)));
+      return kept.size === current.byClientId.size ? current : { sessionId, byClientId: kept };
+    });
+  }, [pendingSendItems, sendBaselineState, sessionId]);
   const messageListStructureKey = useMemo(
     () => ({}),
-    [pendingSendItems, renderItemsStructureKey],
+    [currentSession?.userSendAt, pendingSendItems, renderItemsStructureKey, sendBaselineState],
   );
   const shareExpandableBlockIds = useMemo(
     () => (shareSelectionActive ? collectConversationShareBlockIds(messageListItems) : []),

--- a/apps/mobile/app/sessions/[sessionId].tsx
+++ b/apps/mobile/app/sessions/[sessionId].tsx
@@ -337,6 +337,8 @@ import {
 } from '@/session/inputProjection';
 import {
   mergePendingSendItems,
+  reconcilePendingSendOrder,
+  type PendingSendOrder,
   buildPendingSendItems,
   type MobilePendingSendActions,
 } from '@/session/pendingSendItems';
@@ -1509,7 +1511,7 @@ export default function SessionScreen() {
   // clears. Scope it to the page's session; never compare the phone clock to the host.
   const [sendBaselineState, setSendBaselineState] = useState<{
     sessionId: string;
-    byClientId: ReadonlyMap<string, string | null>;
+    byClientId: ReadonlyMap<string, PendingSendOrder>;
   }>(() => ({ sessionId, byClientId: new Map() }));
   if (sendBaselineState.sessionId !== sessionId) {
     setSendBaselineState({ sessionId, byClientId: new Map() });
@@ -1517,7 +1519,7 @@ export default function SessionScreen() {
   const markQueueItemSending = useCallback((clientId: string) => {
     const userSendAt = remoteSessionStore.getSessions().find((item) => item.id === sessionId)?.userSendAt ?? null;
     setSendBaselineState((current) => current.sessionId !== sessionId ? current : {
-      sessionId, byClientId: new Map([...current.byClientId, [clientId, userSendAt]]),
+      sessionId, byClientId: new Map([...current.byClientId, [clientId, { baseline: userSendAt }]]),
     });
     setSendingQueueClientIds((current) => {
       if (current.has(clientId)) return current;
@@ -5731,21 +5733,23 @@ export default function SessionScreen() {
       settlingItemsForRender,
     ],
   );
+  const sendOrder = useMemo(() => reconcilePendingSendOrder(
+    sendBaselineState.sessionId === sessionId ? sendBaselineState.byClientId : new Map(),
+    pendingSendItems, currentSession?.userSendAt,
+  ), [sendBaselineState, sessionId, pendingSendItems, currentSession?.userSendAt]);
   const messageListItems = useMemo(
     () => mergePendingSendItems(
       renderItems, pendingSendItems, currentSession?.userSendAt,
-      sendBaselineState.sessionId === sessionId ? sendBaselineState.byClientId : new Map(),
+      sendOrder,
     ),
-    [currentSession?.userSendAt, pendingSendItems, renderItems, sendBaselineState, sessionId],
+    [currentSession?.userSendAt, pendingSendItems, renderItems, sendOrder],
   );
   useEffect(() => {
-    const pendingIds = new Set(pendingSendItems.map((item) => item.clientId));
     setSendBaselineState((current) => {
       if (current !== sendBaselineState || current.sessionId !== sessionId) return current;
-      const kept = new Map([...current.byClientId].filter(([id]) => pendingIds.has(id)));
-      return kept.size === current.byClientId.size ? current : { sessionId, byClientId: kept };
+      return sendOrder === current.byClientId ? current : { sessionId, byClientId: sendOrder };
     });
-  }, [pendingSendItems, sendBaselineState, sessionId]);
+  }, [sendOrder, sendBaselineState, sessionId]);
   const messageListStructureKey = useMemo(
     () => ({}),
     [currentSession?.userSendAt, pendingSendItems, renderItemsStructureKey, sendBaselineState],

--- a/apps/mobile/app/sessions/[sessionId].tsx
+++ b/apps/mobile/app/sessions/[sessionId].tsx
@@ -1522,8 +1522,8 @@ export default function SessionScreen() {
     const clientId = queued.clientId;
     const projection = remoteSessionStore.getInputProjection(sessionId);
     const source = remoteSessionStore.getMessages(sessionId);
-    // Match Desktop's idle-send placement. A busy turn's follow-up remains in
-    // the queue until the existing dispatch/settling projection promotes it.
+    // Match Desktop's idle-send placement. Busy follow-ups retain the existing
+    // pending tail until authoritative history supplies their transcript row.
     const busy = projection.pendingQueue.length > 0 || projection.steeringQueueClientIds.length > 0
       || projection.queueAbortPending || remoteSessionStore.isSessionRunning(sessionId)
       || remoteSessionStore.getPendingInteractions(sessionId).length > 0
@@ -4225,7 +4225,6 @@ export default function SessionScreen() {
   }, [messageStructureChangedIndexes, messageStructureToken, messages, sessionId]);
   const previousRenderItemsRef = useRef<{
     sessionId: string;
-    messages: readonly RemoteMessage[];
     items: readonly MobileMessageRenderItem[];
     prefix: MobileStreamingRenderPrefixCache | null;
   } | null>(null);
@@ -4239,20 +4238,13 @@ export default function SessionScreen() {
       ...inputProjection.pendingQueue.filter((item) => sendingQueueClientIds.has(item.clientId)).map((item) => item.clientId),
       ...settlingItemsForRender.map((item) => item.clientId),
     ]);
-    let items = reconcileOptimisticUserMessages(
+    // Only the enqueue path can reserve a transcript position. A vanished
+    // busy queue has no reliable local turn boundary: history and projection
+    // can arrive in either order, across any number of committed renders.
+    return reconcileOptimisticUserMessages(
       optimisticUserState.sessionId === sessionId ? optimisticUserState.items : [],
       messages, activeIds, confirmedUserClientIds,
     );
-    for (const item of settlingItemsForRender) {
-      if (!confirmedUserClientIds.has(item.clientId)) {
-        // On reconnect the first render can contain both the reply and the
-        // vanished queue. Anchor to the last committed frame, not that reply.
-        const beforeDispatch = previousRenderItemsRef.current?.sessionId === sessionId
-          ? previousRenderItemsRef.current.messages : [];
-        items = appendOptimisticUserMessage(items, beforeDispatch, item, sessionId);
-      }
-    }
-    return items;
   }, [optimisticUserState, sessionId, messages, inputProjection.pendingQueue,
     sendingQueueClientIds, settlingItemsForRender, confirmedUserClientIds]);
   if (optimisticUserState.sessionId === sessionId && optimisticUsers !== optimisticUserState.items) {
@@ -4357,11 +4349,10 @@ export default function SessionScreen() {
     }
     previousRenderItemsRef.current = {
       sessionId,
-      messages,
       items: renderWindow.items,
       prefix: renderWindow.prefix,
     };
-  }, [messages, renderWindow.items, renderWindow.prefix, sessionId]);
+  }, [renderWindow.items, renderWindow.prefix, sessionId]);
   // Known stale entry content bypasses the quiet delay; routine sync stays subtle.
   const showSyncingIndicator = !showConnectionBanner && !showCachedHistoryNotice
     && (loading || historyView.snapshot.loading || status === 'connecting' || contentRecoveryState === 'syncing');

--- a/apps/mobile/src/__tests__/mobileHistoryRender.test.ts
+++ b/apps/mobile/src/__tests__/mobileHistoryRender.test.ts
@@ -31,6 +31,28 @@ function harness(rows: RemoteMessage[], streaming = false) {
 }
 
 describe('remote history preserves original folding', () => {
+  it.each([0, 2_000_000_000_000])('keeps a local send before an early reply with phone time %s', async (phoneTime) => {
+    const rows = [row(0, 'user', 'Earlier'), row(1, 'assistant', 'Done')];
+    const { view } = harness(rows);
+    await view.refresh();
+    const sent = { ...row(2, 'user', 'Continue'), createdAt: new Date(phoneTime).toISOString() };
+    const reply = { ...row(3, 'assistant', 'Reply'), agentMeta: { isStreaming: true } };
+    const render = (user: RemoteMessage) => buildMobileHistoryRenderItems({
+      view, snapshot: view.getSnapshot(), messages: [...rows.slice(0, 2), user, reply],
+      streaming: true, sessionId: 'session', localUserClientIds: new Set([sent.clientId]),
+    });
+    const expected = ['message-client-0', 'message-client-1', 'message-client-2', 'message-client-3'];
+    expect(render(sent).map((item) => item.key)).toEqual(expected);
+    // Durable push before the history refresh must replace the local body, not
+    // drop the row or append it after its response.
+    const echo = row(2, 'user', 'Confirmed');
+    expect(render(echo).map((item) => item.key)).toEqual(expected);
+    rows.push(echo, row(3, 'assistant', 'Reply'));
+    await view.refresh();
+    expect(render(echo).map((item) => item.key)).toEqual(expected);
+    view.setActive(false);
+  });
+
   it('clips retained detail bodies when a visible media tool splits the old range', async () => {
     const rows = [row(0, 'user', 'Work'), call(1), row(2, 'tool_result', 'ok', 'tool-1'), thought(3),
       call(4), row(5, 'tool_result', 'pending', 'tool-4'), thought(6), call(7), row(8, 'tool_result', 'ok', 'tool-7'), row(9, 'assistant', 'Done')];

--- a/apps/mobile/src/__tests__/pendingSendItems.test.ts
+++ b/apps/mobile/src/__tests__/pendingSendItems.test.ts
@@ -14,8 +14,6 @@ import {
   buildPendingSendItems,
   isPendingSendItemSelected,
   mergePendingSendItems,
-  reconcilePendingSendOrder,
-  type PendingSendOrder,
   pendingSendItemKey,
   pendingSendSpins,
   type MobilePendingSendActions,
@@ -24,6 +22,8 @@ import type { MobileOutboxDisplayItem } from '@/session/sessionOutbox';
 import type { QueuedRemoteMessage, RemoteMessage } from '@/session/types';
 import { remoteSessionStore } from '@/session/remoteSessionStore';
 import { buildMobileMessageRenderItems } from '@/session/messageRenderModel';
+import { buildMobileStreamingRenderWindow } from '@/session/messageRenderStreamingCache';
+import { appendOptimisticUserMessage, projectOptimisticUserMessages, reconcileOptimisticUserMessages, type OptimisticUserMessage } from '@/session/optimisticUserMessages';
 
 const NO_IDS: ReadonlySet<string> = new Set();
 const NO_PRESENTATION: ReadonlyMap<string, { actions: MobilePendingSendActions; hint: string | null }> = new Map();
@@ -102,179 +102,147 @@ describe('appendPendingSendItems', () => {
 
 describe('reply before user echo', () => {
   const sessionId = 'reply-order';
-  const userSendAt = '2026-07-30T00:00:02.000Z';
-  function row(clientId: string, role: RemoteMessage['role'], createdAt: string): RemoteMessage {
-    return { id: clientId, clientId, sessionId, role, createdAt,
+  function row(clientId: string, role: RemoteMessage['role'], seconds: number): RemoteMessage {
+    return { id: clientId, clientId, sessionId, role,
+      createdAt: new Date(Date.UTC(2026, 6, 30, 0, 0, seconds)).toISOString(),
       content: role === 'user' ? { text: 'Continue' } : 'Reply', toolUseId: null, agentMeta: null };
   }
   function push(message: RemoteMessage) {
     remoteSessionStore.applyRemotePush('dev', 'local-db:messages:created', { sessionId, message });
   }
-  function render(
-    pending: ReturnType<typeof build>,
-    boundary: string | null = userSendAt,
-    baselines: ReadonlyMap<string, string | null> = new Map([['sent', '2026-07-30T00:00:00.000Z']]),
-  ) {
+  function reserve(current: readonly OptimisticUserMessage[] = [], clientId = 'sent') {
+    return appendOptimisticUserMessage(current, remoteSessionStore.getMessages(sessionId), queued(clientId), sessionId);
+  }
+  function render(pending: ReturnType<typeof build>, slots: readonly OptimisticUserMessage[]) {
+    const messages = remoteSessionStore.getMessages(sessionId);
+    const echoed = new Set(messages.map((message) => message.clientId));
     return mergePendingSendItems(buildMobileMessageRenderItems(
-      remoteSessionStore.getMessages(sessionId), { isSessionStreaming: true },
-    ), pending, boundary, new Map([...baselines].map(([id, baseline]) => [id, { baseline }])));
+      projectOptimisticUserMessages(messages, slots), { isSessionStreaming: true, preserveSourceOrder: true },
+    ), pending, new Set(slots.map((entry) => entry.message.clientId).filter((id) => !echoed.has(id))));
   }
   afterEach(() => { remoteSessionStore.clear(); vi.useRealTimers(); });
 
+  it('invalidates the streaming prefix when a local user introduces a new turn boundary', () => {
+    const old = [row('old-user', 'user', 0), { ...row('old-thinking', 'thinking', 1), content: { text: 'Old thought' } }];
+    const previous = buildMobileStreamingRenderWindow({
+      cacheKey: 'en', messages: old, messageStructureToken: {},
+      options: { isSessionStreaming: true, sessionId },
+    });
+    const slots = appendOptimisticUserMessage([], old, queued('sent'), sessionId);
+    const current = [...old, { ...row('new-thinking', 'thinking', 3), content: { text: 'New thought' } }];
+    const next = buildMobileStreamingRenderWindow({
+      cacheKey: 'en', messages: projectOptimisticUserMessages(current, slots),
+      messageStructureToken: {}, previousPrefix: previous.prefix,
+      options: { isSessionStreaming: true, preserveSourceOrder: true, sessionId },
+    });
+    expect(next.items.map((item) => item.key)).toEqual([
+      'message-old-user', 'work-old-thinking', 'message-sent', 'work-new-thinking',
+    ]);
+  });
+
   it.each(['settling', 'sending'])('keeps the %s bubble before an early reply and replaces it in place', (phase) => {
-    push(row('old-user', 'user', '2026-07-30T00:00:00.000Z'));
-    push(row('old-reply', 'assistant', '2026-07-30T00:00:01.000Z'));
+    push(row('old-user', 'user', 0));
+    push(row('old-reply', 'assistant', 1));
+    const slots = reserve(); // The production send path reserves BEFORE enqueue.
     const pending = build({
       settling: phase === 'settling' ? [queued('sent')] : [],
       queue: phase === 'sending' ? [queued('sent'), queued('next')] : [queued('next')],
       sendingClientIds: new Set(phase === 'sending' ? ['sent'] : []),
       outbox: [outboxItem('upload', { attachmentCount: 1, uploadedCount: 0 })],
     });
-    push(row('reply', 'assistant', '2026-07-30T00:00:03.000Z'));
-    const before = render(pending);
+    push(row('reply', 'assistant', 3));
+    const before = render(pending, slots);
     expect(before.map((item) => item.key)).toEqual([
       'message-old-user', 'message-old-reply', 'message-sent', 'message-reply', 'message-next', 'message-upload',
     ]);
     expect(before[2]).toBe(pending[0]);
-    push(row('sent', 'user', userSendAt));
-    // Deliberately keep the stale pending snapshot: no duplicate or position change.
-    expect(render(pending).map((item) => item.key)).toEqual(before.map((item) => item.key));
-    expect(render(pending)[2].type).toBe('message');
-    push(row('reply', 'assistant', '2026-07-30T00:00:03.000Z'));
-    expect(render(pending).map((item) => item.key)).toEqual(before.map((item) => item.key));
+    push(row('sent', 'user', 2));
+    expect(render(pending, slots).map((item) => item.key)).toEqual(before.map((item) => item.key));
+    expect(render(pending, slots)[2].type).toBe('message');
   });
 
-  it('keeps streaming deltas behind the pending user without consulting the phone clock', () => {
+  it.each(['2020-01-01', '2030-01-01'])('ignores a phone clock set to %s', (clock) => {
     vi.useFakeTimers();
-    vi.setSystemTime(new Date('2030-01-01'));
-    const pending = build({ settling: [queued('sent')] });
+    vi.setSystemTime(new Date(clock));
+    const source = queued('sent');
+    source.chatMessage.createdAt = new Date().toISOString();
+    const slots = appendOptimisticUserMessage([], [], source, sessionId);
+    const pending = build({ settling: [source] });
     remoteSessionStore.applyRemotePush('dev', 'maker:event', {
       sessionId, persistId: 'reply', event: { type: 'text', data: { text: 'Reply', isFinal: false } },
     });
     vi.advanceTimersByTime(100);
-    expect(render(pending).map((item) => item.key)).toEqual(['message-sent', 'message-reply']);
-    push(row('sent', 'user', userSendAt));
-    expect(render(pending).map((item) => item.key)).toEqual(['message-sent', 'message-reply']);
+    expect(render(pending, slots).map((item) => item.key)).toEqual(['message-sent', 'message-reply']);
+    push(row('sent', 'user', 2));
+    expect(render(pending, slots).map((item) => item.key)).toEqual(['message-sent', 'message-reply']);
   });
 
-  it('places the boundary before folded work, not just before reply text', () => {
-    push(row('old-user', 'user', '2026-07-30T00:00:00.000Z'));
-    push(row('old-reply', 'assistant', '2026-07-30T00:00:01.000Z'));
-    push({ ...row('thinking', 'thinking', userSendAt), content: { text: 'Thinking' } });
-    push(row('reply', 'assistant', '2026-07-30T00:00:03.000Z'));
-    const items = render(build({ settling: [queued('sent')] }));
-    const work = items.find((item) => item.type === 'work_group');
-    expect(work?.startedAtMs).toBeLessThan(Date.parse(userSendAt));
-    expect(items[2].key).toBe('message-sent');
-    expect(items[3]).toBe(work);
-    expect(items.at(-1)?.key).toBe('message-reply');
+  it('separates new folded work from the previous turn before grouping', () => {
+    push(row('old-user', 'user', 0));
+    push({ ...row('old-thinking', 'thinking', 1), content: { text: 'Old thought' } });
+    const slots = reserve();
+    push({ ...row('thinking', 'thinking', 3), content: { text: 'New thought' } });
+    const items = render(build({ settling: [queued('sent')] }), slots);
+    expect(items.map((item) => item.key)).toEqual([
+      'message-old-user', 'work-old-thinking', 'message-sent', 'work-thinking',
+    ]);
   });
 
-  it('skips a foreign settling item without blocking the matching local send', () => {
-    push(row('reply', 'assistant', '2026-07-30T00:00:03.000Z'));
-    const pending = build({ settling: [queued('foreign'), queued('sent')] });
-    expect(render(pending).map((item) => item.key))
-      .toEqual(['message-sent', 'message-reply', 'message-foreign']);
+  it.each(['image', 'synthetic'])('retains the reserved %s bubble before reply grouping', (kind) => {
+    const source = queued('sent', kind === 'synthetic' ? '[UI_ACTION_TRIGGER] hidden action' : '');
+    if (kind === 'image') source.chatMessage.images = [{ url: 'https://example.com/image.png', name: 'image.png' }];
+    const slots = appendOptimisticUserMessage([], [], source, sessionId);
+    push(row('reply', 'assistant', 3));
+    const pending = build({ settling: [source] });
+    const items = render(pending, slots);
+    expect(items.map((item) => item.key)).toEqual(['message-sent', 'message-reply']);
+    expect(items[0]).toBe(pending[0]);
+    expect(JSON.stringify(items[0])).not.toContain('hidden action');
   });
 
-  it.each(['first', 'second'])('keeps both turn positions when the %s echo arrives first', (firstEcho) => {
-    const secondBoundary = '2026-07-30T00:00:04.000Z';
+  it.each(['sent', 'second'])('keeps two reserved positions when %s echoes first', (firstEcho) => {
+    let slots = reserve();
+    push(row('reply', 'assistant', 3));
+    slots = reserve(slots, 'second');
+    push(row('second-reply', 'assistant', 5));
     let pending = build({ settling: [queued('sent'), queued('second')] });
-    let order: ReadonlyMap<string, PendingSendOrder> = new Map([
-      ['sent', { baseline: '2026-07-30T00:00:00.000Z' }],
-      ['second', { baseline: userSendAt }],
-    ]);
-    const draw = (boundary = secondBoundary) => {
-      order = reconcilePendingSendOrder(order, pending, boundary);
-      return mergePendingSendItems(buildMobileMessageRenderItems(
-        remoteSessionStore.getMessages(sessionId), { isSessionStreaming: true },
-      ), pending, boundary, order).map((item) => item.key);
-    };
-    push(row('reply', 'assistant', '2026-07-30T00:00:03.000Z'));
-    push(row('second-reply', 'assistant', '2026-07-30T00:00:05.000Z'));
     const expected = ['message-sent', 'message-reply', 'message-second', 'message-second-reply'];
-    expect(draw()).toEqual(expected);
-    const echoedId = firstEcho === 'first' ? 'sent' : 'second';
-    push(row(echoedId, 'user', echoedId === 'sent' ? userSendAt : secondBoundary));
-    expect(draw()).toEqual(expected); // stale pending snapshot still deduplicates
-    pending = pending.filter((item) => item.clientId !== echoedId);
-    expect(draw()).toEqual(expected); // pruning the later baseline must not move the older bubble
-    expect(order.has(echoedId)).toBe(false);
-    expect(draw('2026-07-30T00:00:06.000Z')).toEqual(expected);
-    const remaining = echoedId === 'sent' ? 'second' : 'sent';
-    push(row(remaining, 'user', remaining === 'sent' ? userSendAt : secondBoundary));
-    expect(draw()).toEqual(expected);
-    expect(reconcilePendingSendOrder(order, [], secondBoundary).size).toBe(0);
+    expect(render(pending, slots).map((item) => item.key)).toEqual(expected);
+    push(row(firstEcho, 'user', firstEcho === 'sent' ? 2 : 4));
+    expect(render(pending, slots).map((item) => item.key)).toEqual(expected);
+    pending = pending.filter((item) => item.clientId !== firstEcho);
+    slots = reconcileOptimisticUserMessages(slots, remoteSessionStore.getMessages(sessionId),
+      new Set(pending.map((item) => item.clientId)), new Set([firstEcho]));
+    expect(render(pending, slots).map((item) => item.key)).toEqual(expected);
   });
 
-  it('pins an observed turn before a later send starts and never assigns queued work early', () => {
-    let order: ReadonlyMap<string, PendingSendOrder> = new Map([['sent', { baseline: null }]]);
-    let pending = build({ settling: [queued('sent')] });
-    order = reconcilePendingSendOrder(order, pending, userSendAt);
-    expect(order.get('sent')?.boundary).toBe(Date.parse(userSendAt));
-    order = new Map([...order, ['next', { baseline: userSendAt }]]);
-    pending = build({ settling: [queued('sent')], queue: [queued('next')] });
-    const nextBoundary = '2026-07-30T00:00:04.000Z';
-    order = reconcilePendingSendOrder(order, pending, nextBoundary);
-    expect(order.get('sent')?.boundary).toBe(Date.parse(userSendAt));
-    expect(order.get('next')?.boundary).toBeUndefined();
-    pending = build({ settling: [queued('sent'), queued('next')] });
-    order = reconcilePendingSendOrder(order, pending, nextBoundary);
-    expect(order.get('next')?.boundary).toBe(Date.parse(nextBoundary));
-    expect(reconcilePendingSendOrder(order, pending, nextBoundary)).toBe(order);
+  it('keeps a busy follow-up and unsent outbox at the tail until dispatch', () => {
+    push(row('current', 'user', 0));
+    const pending = build({ queue: [queued('next')], sendingClientIds: new Set(['next']), outbox: [outboxItem('upload')] });
+    push(row('reply', 'assistant', 3));
+    expect(render(pending, []).map((item) => item.key))
+      .toEqual(['message-current', 'message-reply', 'message-next', 'message-upload']);
+    const slots = reserve([], 'next');
+    push(row('next-reply', 'assistant', 5));
+    expect(render(build({ settling: [queued('next')] }), slots).map((item) => item.key))
+      .toEqual(['message-current', 'message-reply', 'message-next', 'message-next-reply']);
   });
 
-  it('leaves a follow-up behind the current response when the current user is already visible', () => {
-    push(row('current', 'user', userSendAt));
-    push(row('reply', 'assistant', '2026-07-30T00:00:03.000Z'));
-    const pending = build({ queue: [queued('next')], sendingClientIds: new Set(['next']) });
-    expect(render(pending).map((item) => item.key)).toEqual(['message-current', 'message-reply', 'message-next']);
+  it('drops failed, cancelled, and rolled-back queue reservations', () => {
+    const slots = reserve();
+    expect(reconcileOptimisticUserMessages(slots, [], NO_IDS, NO_IDS)).toEqual([]);
+    expect(reconcileOptimisticUserMessages(slots, [], new Set(['sent']), NO_IDS)).toBe(slots);
+    expect(reconcileOptimisticUserMessages(slots, [row('sent', 'user', 2)], NO_IDS, NO_IDS)).toBe(slots);
+    expect(reconcileOptimisticUserMessages(slots, [row('sent', 'user', 2)], NO_IDS, new Set(['sent']))).toEqual([]);
   });
 
-  it('does not assign the same observed turn to two sends with the same baseline', () => {
-    let order: ReadonlyMap<string, PendingSendOrder> = new Map([
-      ['sent', { baseline: null }], ['next', { baseline: null }],
-    ]);
-    let pending = build({ settling: [queued('sent'), queued('next')] });
-    order = reconcilePendingSendOrder(order, pending, userSendAt);
-    expect(order.get('sent')?.boundary).toBe(Date.parse(userSendAt));
-    expect(order.get('next')?.boundary).toBeUndefined();
-    push(row('sent', 'user', userSendAt));
-    pending = pending.filter((item) => item.clientId !== 'sent');
-    order = reconcilePendingSendOrder(order, pending, userSendAt);
-    order = reconcilePendingSendOrder(order, pending, userSendAt);
-    expect(order.get('next')?.boundary).toBeUndefined();
-    const secondBoundary = '2026-07-30T00:00:04.000Z';
-    order = reconcilePendingSendOrder(order, pending, secondBoundary);
-    push(row('reply', 'assistant', '2026-07-30T00:00:03.000Z'));
-    push(row('next-reply', 'assistant', '2026-07-30T00:00:05.000Z'));
-    expect(mergePendingSendItems(buildMobileMessageRenderItems(
-      remoteSessionStore.getMessages(sessionId), { isSessionStreaming: true },
-    ), pending, secondBoundary, order).map((item) => item.key))
-      .toEqual(['message-sent', 'message-reply', 'message-next', 'message-next-reply']);
-  });
-
-  it('does not promote a queued follow-up or an unsent outbox entry into the current turn', () => {
-    push(row('reply', 'assistant', '2026-07-30T00:00:03.000Z'));
-    const pending = build({ queue: [queued('next')], outbox: [outboxItem('local')] });
-    expect(render(pending).map((item) => item.key)).toEqual(['message-reply', 'message-next', 'message-local']);
-  });
-
-  it('does not invent a boundary from missing or invalid host metadata', () => {
-    push(row('reply', 'assistant', '2026-07-30T00:00:03.000Z'));
-    const pending = build({ settling: [queued('sent')] });
-    for (const boundary of [null, 'invalid']) {
-      expect(render(pending, boundary).map((item) => item.key)).toEqual(['message-reply', 'message-sent']);
-    }
-  });
-
-  it('does not mistake an unloaded old user row for the message just sent', () => {
-    push(row('reply', 'assistant', '2026-07-30T00:00:03.000Z'));
-    const pending = build({ queue: [queued('sent')], sendingClientIds: new Set(['sent']) });
-    for (const baselines of [new Map<string, string | null>(), new Map([['sent', userSendAt]])]) {
-      expect(render(pending, userSendAt, baselines).map((item) => item.key))
-        .toEqual(['message-reply', 'message-sent']);
-    }
+  it('preserves prepended history and does not use timestamps to reanchor the send', () => {
+    push(row('old-reply', 'assistant', 1));
+    const slots = reserve();
+    push(row('older-user', 'user', 0));
+    push(row('reply', 'assistant', 3));
+    expect(render(build({ settling: [queued('sent')] }), slots).map((item) => item.key))
+      .toEqual(['message-older-user', 'message-old-reply', 'message-sent', 'message-reply']);
   });
 });
 

--- a/apps/mobile/src/__tests__/pendingSendItems.test.ts
+++ b/apps/mobile/src/__tests__/pendingSendItems.test.ts
@@ -6,19 +6,22 @@
  * 重新出现」。改成消息流项后靠两点保证连续:key 与正式消息一致(`message-${clientId}`)、
  * 已回流的 clientId 立刻不再产出气泡(避免同一句话双显)。
  */
-import { describe, expect, it } from 'vitest';
+import { afterEach, describe, expect, it, vi } from 'vitest';
 import { formatQuoteForSend } from '@cindy/maker-shared/chat-quotes';
 import {
   appendPendingSendItems,
   buildMobileMessageListExtraData,
   buildPendingSendItems,
   isPendingSendItemSelected,
+  mergePendingSendItems,
   pendingSendItemKey,
   pendingSendSpins,
   type MobilePendingSendActions,
 } from '@/session/pendingSendItems';
 import type { MobileOutboxDisplayItem } from '@/session/sessionOutbox';
-import type { QueuedRemoteMessage } from '@/session/types';
+import type { QueuedRemoteMessage, RemoteMessage } from '@/session/types';
+import { remoteSessionStore } from '@/session/remoteSessionStore';
+import { buildMobileMessageRenderItems } from '@/session/messageRenderModel';
 
 const NO_IDS: ReadonlySet<string> = new Set();
 const NO_PRESENTATION: ReadonlyMap<string, { actions: MobilePendingSendActions; hint: string | null }> = new Map();
@@ -92,6 +95,102 @@ describe('appendPendingSendItems', () => {
     const rendered = [{ key: pendingSendItemKey('sent') }];
     expect(appendPendingSendItems(rendered, [])).toBe(rendered);
     expect(appendPendingSendItems(rendered, build({ queue: [queued('sent')] }))).toBe(rendered);
+  });
+});
+
+describe('reply before user echo', () => {
+  const sessionId = 'reply-order';
+  const userSendAt = '2026-07-30T00:00:02.000Z';
+  function row(clientId: string, role: RemoteMessage['role'], createdAt: string): RemoteMessage {
+    return { id: clientId, clientId, sessionId, role, createdAt,
+      content: role === 'user' ? { text: 'Continue' } : 'Reply', toolUseId: null, agentMeta: null };
+  }
+  function push(message: RemoteMessage) {
+    remoteSessionStore.applyRemotePush('dev', 'local-db:messages:created', { sessionId, message });
+  }
+  function render(
+    pending: ReturnType<typeof build>,
+    boundary: string | null = userSendAt,
+    baselines: ReadonlyMap<string, string | null> = new Map([['sent', '2026-07-30T00:00:00.000Z']]),
+  ) {
+    return mergePendingSendItems(buildMobileMessageRenderItems(
+      remoteSessionStore.getMessages(sessionId), { isSessionStreaming: true },
+    ), pending, boundary, baselines);
+  }
+  afterEach(() => { remoteSessionStore.clear(); vi.useRealTimers(); });
+
+  it.each(['settling', 'sending'])('keeps the %s bubble before an early reply and replaces it in place', (phase) => {
+    push(row('old-user', 'user', '2026-07-30T00:00:00.000Z'));
+    push(row('old-reply', 'assistant', '2026-07-30T00:00:01.000Z'));
+    const pending = build({
+      settling: phase === 'settling' ? [queued('sent')] : [],
+      queue: phase === 'sending' ? [queued('sent'), queued('next')] : [queued('next')],
+      sendingClientIds: new Set(phase === 'sending' ? ['sent'] : []),
+      outbox: [outboxItem('upload', { attachmentCount: 1, uploadedCount: 0 })],
+    });
+    push(row('reply', 'assistant', '2026-07-30T00:00:03.000Z'));
+    const before = render(pending);
+    expect(before.map((item) => item.key)).toEqual([
+      'message-old-user', 'message-old-reply', 'message-sent', 'message-reply', 'message-next', 'message-upload',
+    ]);
+    expect(before[2]).toBe(pending[0]);
+    push(row('sent', 'user', userSendAt));
+    // Deliberately keep the stale pending snapshot: no duplicate or position change.
+    expect(render(pending).map((item) => item.key)).toEqual(before.map((item) => item.key));
+    expect(render(pending)[2].type).toBe('message');
+    push(row('reply', 'assistant', '2026-07-30T00:00:03.000Z'));
+    expect(render(pending).map((item) => item.key)).toEqual(before.map((item) => item.key));
+  });
+
+  it('keeps streaming deltas behind the pending user without consulting the phone clock', () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date('2030-01-01'));
+    const pending = build({ settling: [queued('sent')] });
+    remoteSessionStore.applyRemotePush('dev', 'maker:event', {
+      sessionId, persistId: 'reply', event: { type: 'text', data: { text: 'Reply', isFinal: false } },
+    });
+    vi.advanceTimersByTime(100);
+    expect(render(pending).map((item) => item.key)).toEqual(['message-sent', 'message-reply']);
+    push(row('sent', 'user', userSendAt));
+    expect(render(pending).map((item) => item.key)).toEqual(['message-sent', 'message-reply']);
+  });
+
+  it('places the boundary before folded work, not just before reply text', () => {
+    push({ ...row('thinking', 'thinking', userSendAt), content: { thinking: 'Thinking' } });
+    push(row('reply', 'assistant', '2026-07-30T00:00:03.000Z'));
+    const items = render(build({ settling: [queued('sent')] }));
+    expect(items[0].key).toBe('message-sent');
+    expect(items.at(-1)?.key).toBe('message-reply');
+  });
+
+  it('leaves a follow-up behind the current response when the current user is already visible', () => {
+    push(row('current', 'user', userSendAt));
+    push(row('reply', 'assistant', '2026-07-30T00:00:03.000Z'));
+    const pending = build({ queue: [queued('next')], sendingClientIds: new Set(['next']) });
+    expect(render(pending).map((item) => item.key)).toEqual(['message-current', 'message-reply', 'message-next']);
+  });
+
+  it('does not promote a queued follow-up or an unsent outbox entry into the current turn', () => {
+    push(row('reply', 'assistant', '2026-07-30T00:00:03.000Z'));
+    const pending = build({ queue: [queued('next')], outbox: [outboxItem('local')] });
+    expect(render(pending).map((item) => item.key)).toEqual(['message-reply', 'message-next', 'message-local']);
+  });
+
+  it('does not invent a boundary from missing or invalid host metadata', () => {
+    push(row('reply', 'assistant', '2026-07-30T00:00:03.000Z'));
+    const pending = build({ settling: [queued('sent')] });
+    for (const boundary of [null, 'invalid']) {
+      expect(render(pending, boundary).map((item) => item.key)).toEqual(['message-reply', 'message-sent']);
+    }
+  });
+
+  it('does not mistake an unloaded old user row for the message just sent', () => {
+    push(row('reply', 'assistant', '2026-07-30T00:00:03.000Z'));
+    const pending = build({ queue: [queued('sent')], sendingClientIds: new Set(['sent']) });
+    for (const baselines of [new Map<string, string | null>(), new Map([['sent', userSendAt]])]) {
+      expect(render(pending, userSendAt, baselines).map((item) => item.key))
+        .toEqual(['message-reply', 'message-sent']);
+    }
   });
 });
 

--- a/apps/mobile/src/__tests__/pendingSendItems.test.ts
+++ b/apps/mobile/src/__tests__/pendingSendItems.test.ts
@@ -123,24 +123,29 @@ describe('reply before user echo', () => {
   }
   afterEach(() => { remoteSessionStore.clear(); vi.useRealTimers(); });
 
-  it('promotes a busy send when reconnect delivers its reply and empty queue together', () => {
+  it.each([false, true])('leaves unreserved busy sends to authoritative history (separate renders: %s)', (separateRenders) => {
     push(row('current', 'user', 0));
     push(row('current-reply', 'assistant', 1));
     const previousQueue = [queued('sent')];
-    const committedMessages = remoteSessionStore.getMessages(sessionId);
-    // No reservation while busy. Both events arrive before the next UI commit.
+    // Busy sends keep the existing pending tail, without claiming a turn slot.
     expect(render(build({ queue: previousQueue }), []).at(-1)?.key).toBe('message-sent');
     push(row('next-reply', 'assistant', 3));
+    if (separateRenders) {
+      expect(render(build({ queue: previousQueue }), []).map((item) => item.key)).toEqual([
+        'message-current', 'message-current-reply', 'message-next-reply', 'message-sent',
+      ]);
+    }
     const settling = computeVanishedQueueItems({
       previous: previousQueue, current: [], previousSteeringClientIds: NO_IDS,
       currentSteeringClientIds: NO_IDS, hiddenClientIds: NO_IDS, locallyRemovedClientIds: NO_IDS,
     });
-    const slots = settling.reduce<readonly OptimisticUserMessage[]>((items, item) =>
-      appendOptimisticUserMessage(items, committedMessages, item, sessionId), []);
-    const expected = ['message-current', 'message-current-reply', 'message-sent', 'message-next-reply'];
-    expect(render(build({ settling }), slots).map((item) => item.key)).toEqual(expected);
+    expect(render(build({ settling }), []).map((item) => item.key)).toEqual([
+      'message-current', 'message-current-reply', 'message-next-reply', 'message-sent',
+    ]);
     push(row('sent', 'user', 2));
-    expect(render(build({ settling }), slots).map((item) => item.key)).toEqual(expected);
+    expect(render(build({ settling }), []).map((item) => item.key)).toEqual([
+      'message-current', 'message-current-reply', 'message-sent', 'message-next-reply',
+    ]);
   });
 
   it('invalidates the streaming prefix when a local user introduces a new turn boundary', () => {

--- a/apps/mobile/src/__tests__/pendingSendItems.test.ts
+++ b/apps/mobile/src/__tests__/pendingSendItems.test.ts
@@ -14,6 +14,8 @@ import {
   buildPendingSendItems,
   isPendingSendItemSelected,
   mergePendingSendItems,
+  reconcilePendingSendOrder,
+  type PendingSendOrder,
   pendingSendItemKey,
   pendingSendSpins,
   type MobilePendingSendActions,
@@ -115,7 +117,7 @@ describe('reply before user echo', () => {
   ) {
     return mergePendingSendItems(buildMobileMessageRenderItems(
       remoteSessionStore.getMessages(sessionId), { isSessionStreaming: true },
-    ), pending, boundary, baselines);
+    ), pending, boundary, new Map([...baselines].map(([id, baseline]) => [id, { baseline }])));
   }
   afterEach(() => { remoteSessionStore.clear(); vi.useRealTimers(); });
 
@@ -156,11 +158,70 @@ describe('reply before user echo', () => {
   });
 
   it('places the boundary before folded work, not just before reply text', () => {
-    push({ ...row('thinking', 'thinking', userSendAt), content: { thinking: 'Thinking' } });
+    push(row('old-user', 'user', '2026-07-30T00:00:00.000Z'));
+    push(row('old-reply', 'assistant', '2026-07-30T00:00:01.000Z'));
+    push({ ...row('thinking', 'thinking', userSendAt), content: { text: 'Thinking' } });
     push(row('reply', 'assistant', '2026-07-30T00:00:03.000Z'));
     const items = render(build({ settling: [queued('sent')] }));
-    expect(items[0].key).toBe('message-sent');
+    const work = items.find((item) => item.type === 'work_group');
+    expect(work?.startedAtMs).toBeLessThan(Date.parse(userSendAt));
+    expect(items[2].key).toBe('message-sent');
+    expect(items[3]).toBe(work);
     expect(items.at(-1)?.key).toBe('message-reply');
+  });
+
+  it('skips a foreign settling item without blocking the matching local send', () => {
+    push(row('reply', 'assistant', '2026-07-30T00:00:03.000Z'));
+    const pending = build({ settling: [queued('foreign'), queued('sent')] });
+    expect(render(pending).map((item) => item.key))
+      .toEqual(['message-sent', 'message-reply', 'message-foreign']);
+  });
+
+  it.each(['first', 'second'])('keeps both turn positions when the %s echo arrives first', (firstEcho) => {
+    const secondBoundary = '2026-07-30T00:00:04.000Z';
+    let pending = build({ settling: [queued('sent'), queued('second')] });
+    let order: ReadonlyMap<string, PendingSendOrder> = new Map([
+      ['sent', { baseline: '2026-07-30T00:00:00.000Z' }],
+      ['second', { baseline: userSendAt }],
+    ]);
+    const draw = (boundary = secondBoundary) => {
+      order = reconcilePendingSendOrder(order, pending, boundary);
+      return mergePendingSendItems(buildMobileMessageRenderItems(
+        remoteSessionStore.getMessages(sessionId), { isSessionStreaming: true },
+      ), pending, boundary, order).map((item) => item.key);
+    };
+    push(row('reply', 'assistant', '2026-07-30T00:00:03.000Z'));
+    push(row('second-reply', 'assistant', '2026-07-30T00:00:05.000Z'));
+    const expected = ['message-sent', 'message-reply', 'message-second', 'message-second-reply'];
+    expect(draw()).toEqual(expected);
+    const echoedId = firstEcho === 'first' ? 'sent' : 'second';
+    push(row(echoedId, 'user', echoedId === 'sent' ? userSendAt : secondBoundary));
+    expect(draw()).toEqual(expected); // stale pending snapshot still deduplicates
+    pending = pending.filter((item) => item.clientId !== echoedId);
+    expect(draw()).toEqual(expected); // pruning the later baseline must not move the older bubble
+    expect(order.has(echoedId)).toBe(false);
+    expect(draw('2026-07-30T00:00:06.000Z')).toEqual(expected);
+    const remaining = echoedId === 'sent' ? 'second' : 'sent';
+    push(row(remaining, 'user', remaining === 'sent' ? userSendAt : secondBoundary));
+    expect(draw()).toEqual(expected);
+    expect(reconcilePendingSendOrder(order, [], secondBoundary).size).toBe(0);
+  });
+
+  it('pins an observed turn before a later send starts and never assigns queued work early', () => {
+    let order: ReadonlyMap<string, PendingSendOrder> = new Map([['sent', { baseline: null }]]);
+    let pending = build({ settling: [queued('sent')] });
+    order = reconcilePendingSendOrder(order, pending, userSendAt);
+    expect(order.get('sent')?.boundary).toBe(Date.parse(userSendAt));
+    order = new Map([...order, ['next', { baseline: userSendAt }]]);
+    pending = build({ settling: [queued('sent')], queue: [queued('next')] });
+    const nextBoundary = '2026-07-30T00:00:04.000Z';
+    order = reconcilePendingSendOrder(order, pending, nextBoundary);
+    expect(order.get('sent')?.boundary).toBe(Date.parse(userSendAt));
+    expect(order.get('next')?.boundary).toBeUndefined();
+    pending = build({ settling: [queued('sent'), queued('next')] });
+    order = reconcilePendingSendOrder(order, pending, nextBoundary);
+    expect(order.get('next')?.boundary).toBe(Date.parse(nextBoundary));
+    expect(reconcilePendingSendOrder(order, pending, nextBoundary)).toBe(order);
   });
 
   it('leaves a follow-up behind the current response when the current user is already visible', () => {
@@ -168,6 +229,29 @@ describe('reply before user echo', () => {
     push(row('reply', 'assistant', '2026-07-30T00:00:03.000Z'));
     const pending = build({ queue: [queued('next')], sendingClientIds: new Set(['next']) });
     expect(render(pending).map((item) => item.key)).toEqual(['message-current', 'message-reply', 'message-next']);
+  });
+
+  it('does not assign the same observed turn to two sends with the same baseline', () => {
+    let order: ReadonlyMap<string, PendingSendOrder> = new Map([
+      ['sent', { baseline: null }], ['next', { baseline: null }],
+    ]);
+    let pending = build({ settling: [queued('sent'), queued('next')] });
+    order = reconcilePendingSendOrder(order, pending, userSendAt);
+    expect(order.get('sent')?.boundary).toBe(Date.parse(userSendAt));
+    expect(order.get('next')?.boundary).toBeUndefined();
+    push(row('sent', 'user', userSendAt));
+    pending = pending.filter((item) => item.clientId !== 'sent');
+    order = reconcilePendingSendOrder(order, pending, userSendAt);
+    order = reconcilePendingSendOrder(order, pending, userSendAt);
+    expect(order.get('next')?.boundary).toBeUndefined();
+    const secondBoundary = '2026-07-30T00:00:04.000Z';
+    order = reconcilePendingSendOrder(order, pending, secondBoundary);
+    push(row('reply', 'assistant', '2026-07-30T00:00:03.000Z'));
+    push(row('next-reply', 'assistant', '2026-07-30T00:00:05.000Z'));
+    expect(mergePendingSendItems(buildMobileMessageRenderItems(
+      remoteSessionStore.getMessages(sessionId), { isSessionStreaming: true },
+    ), pending, secondBoundary, order).map((item) => item.key))
+      .toEqual(['message-sent', 'message-reply', 'message-next', 'message-next-reply']);
   });
 
   it('does not promote a queued follow-up or an unsent outbox entry into the current turn', () => {

--- a/apps/mobile/src/__tests__/pendingSendItems.test.ts
+++ b/apps/mobile/src/__tests__/pendingSendItems.test.ts
@@ -23,6 +23,7 @@ import type { QueuedRemoteMessage, RemoteMessage } from '@/session/types';
 import { remoteSessionStore } from '@/session/remoteSessionStore';
 import { buildMobileMessageRenderItems } from '@/session/messageRenderModel';
 import { buildMobileStreamingRenderWindow } from '@/session/messageRenderStreamingCache';
+import { computeVanishedQueueItems } from '@/session/queueSettling';
 import { appendOptimisticUserMessage, projectOptimisticUserMessages, reconcileOptimisticUserMessages, type OptimisticUserMessage } from '@/session/optimisticUserMessages';
 
 const NO_IDS: ReadonlySet<string> = new Set();
@@ -121,6 +122,26 @@ describe('reply before user echo', () => {
     ), pending, new Set(slots.map((entry) => entry.message.clientId).filter((id) => !echoed.has(id))));
   }
   afterEach(() => { remoteSessionStore.clear(); vi.useRealTimers(); });
+
+  it('promotes a busy send when reconnect delivers its reply and empty queue together', () => {
+    push(row('current', 'user', 0));
+    push(row('current-reply', 'assistant', 1));
+    const previousQueue = [queued('sent')];
+    const committedMessages = remoteSessionStore.getMessages(sessionId);
+    // No reservation while busy. Both events arrive before the next UI commit.
+    expect(render(build({ queue: previousQueue }), []).at(-1)?.key).toBe('message-sent');
+    push(row('next-reply', 'assistant', 3));
+    const settling = computeVanishedQueueItems({
+      previous: previousQueue, current: [], previousSteeringClientIds: NO_IDS,
+      currentSteeringClientIds: NO_IDS, hiddenClientIds: NO_IDS, locallyRemovedClientIds: NO_IDS,
+    });
+    const slots = settling.reduce<readonly OptimisticUserMessage[]>((items, item) =>
+      appendOptimisticUserMessage(items, committedMessages, item, sessionId), []);
+    const expected = ['message-current', 'message-current-reply', 'message-sent', 'message-next-reply'];
+    expect(render(build({ settling }), slots).map((item) => item.key)).toEqual(expected);
+    push(row('sent', 'user', 2));
+    expect(render(build({ settling }), slots).map((item) => item.key)).toEqual(expected);
+  });
 
   it('invalidates the streaming prefix when a local user introduces a new turn boundary', () => {
     const old = [row('old-user', 'user', 0), { ...row('old-thinking', 'thinking', 1), content: { text: 'Old thought' } }];

--- a/apps/mobile/src/__tests__/sendingQueueBadge.test.ts
+++ b/apps/mobile/src/__tests__/sendingQueueBadge.test.ts
@@ -41,6 +41,10 @@ describe('mobile sending queue badge', () => {
     // Both send entries reserve the user slot before publishing the optimistic
     // queue (and before enqueue can deliver an assistant event).
     expect(source.match(/markQueueItemSending\(queued\);\s+remoteSessionStore\.setInputProjectionOptimistically/g)).toHaveLength(2);
+    // A coalesced reply/queue update must not supply its own predecessor set.
+    expect(source).toContain('appendOptimisticUserMessage(items, beforeDispatch, item, sessionId)');
+    expect(source).toContain('? previousRenderItemsRef.current.messages : []');
+    expect(source).toContain('messages,\n      items: renderWindow.items,');
     expect(source.match(/clearQueueItemSending\(queued\.clientId\);/g)).toHaveLength(2);
     expect(source).toContain('} finally {\n        // 成功、对账认定已入队、回滚 throw 三条路径都算「不再在途」');
     // 新建会话乐观管线在跑时,首条消息同样是「已上屏未确认」。

--- a/apps/mobile/src/__tests__/sendingQueueBadge.test.ts
+++ b/apps/mobile/src/__tests__/sendingQueueBadge.test.ts
@@ -37,7 +37,10 @@ describe('mobile sending queue badge', () => {
 
     expect(source).toContain('sendingClientIds: sendingQueueBadgeClientIds,');
     // 直发路径与 outbox 交接路径各 mark 一次,各自在 finally 收掉。
-    expect(source.match(/markQueueItemSending\(queued\.clientId\);/g)).toHaveLength(2);
+    expect(source.match(/markQueueItemSending\(queued\);/g)).toHaveLength(2);
+    // Both send entries reserve the user slot before publishing the optimistic
+    // queue (and before enqueue can deliver an assistant event).
+    expect(source.match(/markQueueItemSending\(queued\);\s+remoteSessionStore\.setInputProjectionOptimistically/g)).toHaveLength(2);
     expect(source.match(/clearQueueItemSending\(queued\.clientId\);/g)).toHaveLength(2);
     expect(source).toContain('} finally {\n        // 成功、对账认定已入队、回滚 throw 三条路径都算「不再在途」');
     // 新建会话乐观管线在跑时,首条消息同样是「已上屏未确认」。

--- a/apps/mobile/src/__tests__/sendingQueueBadge.test.ts
+++ b/apps/mobile/src/__tests__/sendingQueueBadge.test.ts
@@ -41,10 +41,9 @@ describe('mobile sending queue badge', () => {
     // Both send entries reserve the user slot before publishing the optimistic
     // queue (and before enqueue can deliver an assistant event).
     expect(source.match(/markQueueItemSending\(queued\);\s+remoteSessionStore\.setInputProjectionOptimistically/g)).toHaveLength(2);
-    // A coalesced reply/queue update must not supply its own predecessor set.
-    expect(source).toContain('appendOptimisticUserMessage(items, beforeDispatch, item, sessionId)');
-    expect(source).toContain('? previousRenderItemsRef.current.messages : []');
-    expect(source).toContain('messages,\n      items: renderWindow.items,');
+    // Only enqueue reserves a slot; queue recovery must not infer a boundary
+    // from either current messages or a previous committed render.
+    expect(source.match(/appendOptimisticUserMessage\(/g)).toHaveLength(1);
     expect(source.match(/clearQueueItemSending\(queued\.clientId\);/g)).toHaveLength(2);
     expect(source).toContain('} finally {\n        // 成功、对账认定已入队、回滚 throw 三条路径都算「不再在途」');
     // 新建会话乐观管线在跑时,首条消息同样是「已上屏未确认」。

--- a/apps/mobile/src/session/messageRenderStreamingCache.ts
+++ b/apps/mobile/src/session/messageRenderStreamingCache.ts
@@ -50,6 +50,7 @@ interface BuildMobileStreamingRenderWindowInput {
   messageStructureToken?: object;
   options: MessageRenderOptions & {
     autoResumePending?: Record<string, unknown> | null;
+    preserveSourceOrder?: boolean;
     sessionId?: string;
   };
   prefixCache?: MobileStreamingRenderPrefixCacheRef;

--- a/apps/mobile/src/session/mobileHistoryRender.ts
+++ b/apps/mobile/src/session/mobileHistoryRender.ts
@@ -10,12 +10,14 @@ export function buildMobileHistoryRenderItems(options: {
   streaming: boolean;
   sessionId: string;
   pendingHandoff?: ReadonlySet<string>;
+  localUserClientIds?: ReadonlySet<string>;
   taskUpdates?: ReadonlyMap<string, AgentTaskUpdate>;
 }): MobileMessageRenderItem[] {
   return renderHistoryView<RemoteMessage, MobileMessageRenderItem>({
     view: options.view, snapshot: options.snapshot, liveMessages: options.messages,
     isLive: (row) => row.agentMeta?.isStreaming === true,
     pendingHandoff: options.pendingHandoff,
+    isLocalUser: (row) => options.localUserClientIds?.has(row.clientId) === true,
     streaming: options.streaming,
     build: (rows, streaming) => buildMobileMessageRenderItems(rows, {
       isSessionStreaming: streaming, sessionId: options.sessionId, preserveSourceOrder: true,

--- a/apps/mobile/src/session/optimisticUserMessages.ts
+++ b/apps/mobile/src/session/optimisticUserMessages.ts
@@ -1,0 +1,66 @@
+import type { QueuedRemoteMessage, RemoteMessage } from './types';
+import { pendingSendBubbleText } from './pendingSendItems';
+
+/** Page-local transcript slots, never persisted or sent over device-link. */
+export interface OptimisticUserMessage {
+  message: RemoteMessage;
+  precedingClientIds: ReadonlySet<string>;
+}
+
+/** Reserve a user row synchronously before enqueue, as Desktop does. */
+export function appendOptimisticUserMessage(
+  current: readonly OptimisticUserMessage[],
+  messages: readonly RemoteMessage[],
+  queued: QueuedRemoteMessage,
+  sessionId: string,
+): readonly OptimisticUserMessage[] {
+  if (current.some((entry) => entry.message.clientId === queued.clientId)
+    || messages.some((message) => message.clientId === queued.clientId)) return current;
+  const source = queued.chatMessage;
+  return [...current, {
+    message: {
+      id: queued.clientId, clientId: queued.clientId, sessionId, role: 'user',
+      createdAt: source.createdAt, toolUseId: null, agentMeta: null,
+      // This is the pending bubble's visible label, including synthetic-action
+      // masking. Its authoritative body replaces it on echo.
+      content: { ...source, text: pendingSendBubbleText(queued) },
+    },
+    precedingClientIds: new Set([
+      ...messages.map((message) => message.clientId),
+      ...current.map((entry) => entry.message.clientId),
+    ]),
+  }];
+}
+
+/** Preserve observation order; device clocks are not ordering evidence. */
+export function projectOptimisticUserMessages(
+  messages: readonly RemoteMessage[],
+  optimistic: readonly OptimisticUserMessage[],
+): readonly RemoteMessage[] {
+  if (optimistic.length === 0) return messages;
+  const result = [...messages];
+  for (const entry of optimistic) {
+    const echo = result.findIndex((message) => message.clientId === entry.message.clientId);
+    const message = echo < 0 ? entry.message : result.splice(echo, 1)[0];
+    let after = -1;
+    for (let index = 0; index < result.length; index++) {
+      if (entry.precedingClientIds.has(result[index].clientId)) after = index;
+    }
+    result.splice(after + 1, 0, message);
+  }
+  return result;
+}
+
+/** Queue rollback/failure removes the slot; a durable echo hands it to history. */
+export function reconcileOptimisticUserMessages(
+  current: readonly OptimisticUserMessage[],
+  messages: readonly RemoteMessage[],
+  activeClientIds: ReadonlySet<string>,
+  confirmedClientIds: ReadonlySet<string>,
+): readonly OptimisticUserMessage[] {
+  if (current.length === 0) return current;
+  const echoed = new Set(messages.map((message) => message.clientId));
+  const remaining = current.filter(({ message }) => !confirmedClientIds.has(message.clientId)
+    && (activeClientIds.has(message.clientId) || echoed.has(message.clientId)));
+  return remaining.length === current.length ? current : remaining;
+}

--- a/apps/mobile/src/session/pendingSendItems.ts
+++ b/apps/mobile/src/session/pendingSendItems.ts
@@ -12,8 +12,8 @@
  * 进了 data 之后:与正式消息同容器、同 key(`message-${clientId}`)、同一处位置,回流就是
  * 同一个列表位置上的内容替换 —— 原地变实,零跳动;listData 也不再为空,居中占位自然不出现。
  *
- * 顺序契约(与原 footer 一致):落定中(已出队、等回流)在前,排队中居中,本地 outbox 在后
- * —— outbox 是最晚发出的。
+ * 未派发条目保持队列 / outbox 顺序。已派发但缺少正式回流的气泡，按主机本轮
+ * userSendAt 放在回复之前，不能简单追加到回复后面。
  */
 import { syntheticTriggerKind } from '@cindy/maker-shared/synthetic-trigger';
 import {
@@ -28,6 +28,7 @@ import {
 } from '@/session/sentMessageAtoms';
 import type { QueuedRemoteMessage } from '@/session/types';
 import type { GetSentMessageImagePreview } from '@/session/sentMessageImagePreviews';
+import type { MobileMessageRenderItem, MobileWorkChildItem } from '@/session/messageRenderModel';
 
 export type MobilePendingSendPhase =
   /** 已确认入队,等被控端派发。 */
@@ -117,6 +118,60 @@ export function appendPendingSendItems<T extends { key: string }>(
   const renderedKeys = new Set(rendered.map((item) => item.key));
   const remaining = pending.filter((item) => !renderedKeys.has(item.key));
   return remaining.length === 0 ? rendered : [...rendered, ...remaining];
+}
+
+/**
+ * The host's current user boundary can arrive before its persisted user row. Keep
+ * that row's settling bubble before the reply, including folded work, until the
+ * echo replaces it. Queued follow-ups and local uploads still belong at the tail.
+ * Compare only host timestamps: a phone's enqueue time is not a host ordering fact.
+ */
+export function mergePendingSendItems(
+  rendered: readonly MobileMessageRenderItem[],
+  pending: readonly MobilePendingSendItem[],
+  userSendAt: string | null | undefined,
+  sendBaselines: ReadonlyMap<string, string | null>,
+): readonly MobileMessageRenderItem[] {
+  const appended = appendPendingSendItems(rendered, pending);
+  if (appended === rendered || !userSendAt) return appended;
+  const boundary = Date.parse(userSendAt);
+  if (!Number.isFinite(boundary)) return appended;
+  // A visible current user already supplies the turn boundary. Never move a new
+  // send in front of the response to an earlier, already displayed message.
+  if (rendered.some((item) => item.type === 'message'
+    && item.message.source.role === 'user'
+    && Date.parse(item.message.source.createdAt) >= boundary)) return appended;
+  const waiting = appended.slice(rendered.length) as MobilePendingSendItem[];
+  const candidate = waiting.find((item) => item.phase === 'settling')
+    ?? waiting.find((item) => item.phase === 'sending' && item.queueIndex === 1);
+  if (!candidate) return appended;
+  // The current user may simply be outside the loaded history window. A local
+  // send must have observed an older host turn before we associate it with this
+  // boundary; otherwise we'd move a follow-up in front of the ongoing reply.
+  if (!sendBaselines.has(candidate.clientId)) return appended;
+  const baseline = sendBaselines.get(candidate.clientId);
+  if (baseline && !(Date.parse(baseline) < boundary)) return appended;
+  const replyIndex = rendered.findIndex((item) => renderItemStartsAt(item) >= boundary);
+  if (replyIndex < 0) return appended;
+  return [
+    ...rendered.slice(0, replyIndex), candidate, ...rendered.slice(replyIndex),
+    ...waiting.filter((item) => item !== candidate),
+  ];
+}
+
+function renderItemStartsAt(item: MobileMessageRenderItem | MobileWorkChildItem): number {
+  switch (item.type) {
+    case 'message':
+    case 'thinking': return Date.parse(item.message.source.createdAt);
+    case 'tool_group':
+    case 'tool_media': return Date.parse(item.tools[0]?.source.createdAt ?? '');
+    case 'todo':
+    case 'agent_task': return Date.parse(item.createdAt);
+    case 'work_group': return item.startedAtMs
+      ?? (item.children.length > 0 ? renderItemStartsAt(item.children[0]) : NaN);
+    case 'subagent_group': return item.childItems.length > 0 ? renderItemStartsAt(item.childItems[0]) : NaN;
+    default: return NaN;
+  }
 }
 
 /**

--- a/apps/mobile/src/session/pendingSendItems.ts
+++ b/apps/mobile/src/session/pendingSendItems.ts
@@ -126,37 +126,71 @@ export function appendPendingSendItems<T extends { key: string }>(
  * echo replaces it. Queued follow-ups and local uploads still belong at the tail.
  * Compare only host timestamps: a phone's enqueue time is not a host ordering fact.
  */
+export interface PendingSendOrder {
+  baseline: string | null;
+  /** Once observed, this send's host boundary must not follow later turns. */
+  boundary?: number;
+}
+
+/** Resolve all sends before pruning: a later send's baseline identifies the
+ * preceding turn even when both user echoes are still missing. */
+export function reconcilePendingSendOrder(
+  order: ReadonlyMap<string, PendingSendOrder>,
+  pending: readonly MobilePendingSendItem[],
+  userSendAt: string | null | undefined,
+): ReadonlyMap<string, PendingSendOrder> {
+  const boundaries = [...new Set([
+    Date.parse(userSendAt ?? ''),
+    ...[...order.values()].flatMap((entry) => [Date.parse(entry.baseline ?? ''), entry.boundary ?? NaN]),
+  ].filter(Number.isFinite))].sort((a, b) => a - b);
+  const assigned = new Set([...order.values()].map((entry) => entry.boundary));
+  const next = new Map<string, PendingSendOrder>();
+  for (const item of pending) {
+    const entry = order.get(item.clientId);
+    if (!entry) continue;
+    const baseline = entry.baseline === null ? -Infinity : Date.parse(entry.baseline);
+    const boundary = entry.boundary ?? (isDispatchedPending(item)
+      ? boundaries.find((value) => value > baseline && !assigned.has(value)) : undefined);
+    if (boundary !== undefined) assigned.add(boundary);
+    // Preserve the lower bound when an earlier echo is pruned. Otherwise a
+    // waiting send could claim that same turn on the next render.
+    const claimed = boundary === undefined ? boundaries.filter((value) => assigned.has(value) && value > baseline).at(-1) : undefined;
+    const nextBaseline = claimed === undefined ? entry.baseline : new Date(claimed).toISOString();
+    next.set(item.clientId, boundary === entry.boundary && nextBaseline === entry.baseline
+      ? entry : { baseline: nextBaseline, boundary });
+  }
+  return next.size === order.size && [...next].every(([id, entry]) => order.get(id) === entry)
+    ? order : next;
+}
+
+function isDispatchedPending(item: MobilePendingSendItem): boolean {
+  return item.phase === 'settling' || (item.phase === 'sending' && item.queueIndex === 1);
+}
+
 export function mergePendingSendItems(
   rendered: readonly MobileMessageRenderItem[],
   pending: readonly MobilePendingSendItem[],
   userSendAt: string | null | undefined,
-  sendBaselines: ReadonlyMap<string, string | null>,
+  sendOrder: ReadonlyMap<string, PendingSendOrder>,
 ): readonly MobileMessageRenderItem[] {
   const appended = appendPendingSendItems(rendered, pending);
-  if (appended === rendered || !userSendAt) return appended;
-  const boundary = Date.parse(userSendAt);
-  if (!Number.isFinite(boundary)) return appended;
-  // A visible current user already supplies the turn boundary. Never move a new
-  // send in front of the response to an earlier, already displayed message.
-  if (rendered.some((item) => item.type === 'message'
-    && item.message.source.role === 'user'
-    && Date.parse(item.message.source.createdAt) >= boundary)) return appended;
+  if (appended === rendered) return appended;
+  const order = reconcilePendingSendOrder(sendOrder, pending, userSendAt);
   const waiting = appended.slice(rendered.length) as MobilePendingSendItem[];
-  const candidate = waiting.find((item) => item.phase === 'settling')
-    ?? waiting.find((item) => item.phase === 'sending' && item.queueIndex === 1);
-  if (!candidate) return appended;
-  // The current user may simply be outside the loaded history window. A local
-  // send must have observed an older host turn before we associate it with this
-  // boundary; otherwise we'd move a follow-up in front of the ongoing reply.
-  if (!sendBaselines.has(candidate.clientId)) return appended;
-  const baseline = sendBaselines.get(candidate.clientId);
-  if (baseline && !(Date.parse(baseline) < boundary)) return appended;
-  const replyIndex = rendered.findIndex((item) => renderItemStartsAt(item) >= boundary);
-  if (replyIndex < 0) return appended;
-  return [
-    ...rendered.slice(0, replyIndex), candidate, ...rendered.slice(replyIndex),
-    ...waiting.filter((item) => item !== candidate),
-  ];
+  const insertions = new Map<number, MobilePendingSendItem[]>();
+  const tail: MobilePendingSendItem[] = [];
+  for (const item of waiting) {
+    const boundary = order.get(item.clientId)?.boundary;
+    const replyIndex = boundary !== undefined && isDispatchedPending(item)
+      ? rendered.findIndex((row) => renderItemStartsAt(row) >= boundary) : -1;
+    const firstRow = rendered[replyIndex];
+    // An existing user boundary needs no placeholder. A later user must not
+    // suppress an earlier bubble when its own response is already visible.
+    if (replyIndex < 0 || (firstRow.type === 'message' && firstRow.message.source.role === 'user')) tail.push(item);
+    else insertions.set(replyIndex, [...(insertions.get(replyIndex) ?? []), item]);
+  }
+  return insertions.size === 0 ? appended
+    : [...rendered.flatMap((item, index) => [...(insertions.get(index) ?? []), item]), ...tail];
 }
 
 function renderItemStartsAt(item: MobileMessageRenderItem | MobileWorkChildItem): number {
@@ -167,8 +201,7 @@ function renderItemStartsAt(item: MobileMessageRenderItem | MobileWorkChildItem)
     case 'tool_media': return Date.parse(item.tools[0]?.source.createdAt ?? '');
     case 'todo':
     case 'agent_task': return Date.parse(item.createdAt);
-    case 'work_group': return item.startedAtMs
-      ?? (item.children.length > 0 ? renderItemStartsAt(item.children[0]) : NaN);
+    case 'work_group': return item.children.length > 0 ? renderItemStartsAt(item.children[0]) : NaN;
     case 'subagent_group': return item.childItems.length > 0 ? renderItemStartsAt(item.childItems[0]) : NaN;
     default: return NaN;
   }

--- a/apps/mobile/src/session/pendingSendItems.ts
+++ b/apps/mobile/src/session/pendingSendItems.ts
@@ -12,8 +12,8 @@
  * 进了 data 之后:与正式消息同容器、同 key(`message-${clientId}`)、同一处位置,回流就是
  * 同一个列表位置上的内容替换 —— 原地变实,零跳动;listData 也不再为空,居中占位自然不出现。
  *
- * 未派发条目保持队列 / outbox 顺序。已派发但缺少正式回流的气泡，按主机本轮
- * userSendAt 放在回复之前，不能简单追加到回复后面。
+ * 未派发条目保持队列 / outbox 顺序。已派发气泡在分组前占据本地用户消息的位置，
+ * 正式回流以同一个 clientId 原位替换，不比较控制端与主机的时钟。
  */
 import { syntheticTriggerKind } from '@cindy/maker-shared/synthetic-trigger';
 import {
@@ -28,7 +28,7 @@ import {
 } from '@/session/sentMessageAtoms';
 import type { QueuedRemoteMessage } from '@/session/types';
 import type { GetSentMessageImagePreview } from '@/session/sentMessageImagePreviews';
-import type { MobileMessageRenderItem, MobileWorkChildItem } from '@/session/messageRenderModel';
+import type { MobileMessageRenderItem } from '@/session/messageRenderModel';
 
 export type MobilePendingSendPhase =
   /** 已确认入队,等被控端派发。 */
@@ -120,91 +120,17 @@ export function appendPendingSendItems<T extends { key: string }>(
   return remaining.length === 0 ? rendered : [...rendered, ...remaining];
 }
 
-/**
- * The host's current user boundary can arrive before its persisted user row. Keep
- * that row's settling bubble before the reply, including folded work, until the
- * echo replaces it. Queued follow-ups and local uploads still belong at the tail.
- * Compare only host timestamps: a phone's enqueue time is not a host ordering fact.
- */
-export interface PendingSendOrder {
-  baseline: string | null;
-  /** Once observed, this send's host boundary must not follow later turns. */
-  boundary?: number;
-}
-
-/** Resolve all sends before pruning: a later send's baseline identifies the
- * preceding turn even when both user echoes are still missing. */
-export function reconcilePendingSendOrder(
-  order: ReadonlyMap<string, PendingSendOrder>,
-  pending: readonly MobilePendingSendItem[],
-  userSendAt: string | null | undefined,
-): ReadonlyMap<string, PendingSendOrder> {
-  const boundaries = [...new Set([
-    Date.parse(userSendAt ?? ''),
-    ...[...order.values()].flatMap((entry) => [Date.parse(entry.baseline ?? ''), entry.boundary ?? NaN]),
-  ].filter(Number.isFinite))].sort((a, b) => a - b);
-  const assigned = new Set([...order.values()].map((entry) => entry.boundary));
-  const next = new Map<string, PendingSendOrder>();
-  for (const item of pending) {
-    const entry = order.get(item.clientId);
-    if (!entry) continue;
-    const baseline = entry.baseline === null ? -Infinity : Date.parse(entry.baseline);
-    const boundary = entry.boundary ?? (isDispatchedPending(item)
-      ? boundaries.find((value) => value > baseline && !assigned.has(value)) : undefined);
-    if (boundary !== undefined) assigned.add(boundary);
-    // Preserve the lower bound when an earlier echo is pruned. Otherwise a
-    // waiting send could claim that same turn on the next render.
-    const claimed = boundary === undefined ? boundaries.filter((value) => assigned.has(value) && value > baseline).at(-1) : undefined;
-    const nextBaseline = claimed === undefined ? entry.baseline : new Date(claimed).toISOString();
-    next.set(item.clientId, boundary === entry.boundary && nextBaseline === entry.baseline
-      ? entry : { baseline: nextBaseline, boundary });
-  }
-  return next.size === order.size && [...next].every(([id, entry]) => order.get(id) === entry)
-    ? order : next;
-}
-
-function isDispatchedPending(item: MobilePendingSendItem): boolean {
-  return item.phase === 'settling' || (item.phase === 'sending' && item.queueIndex === 1);
-}
-
+/** Replace only local placeholders; durable echoes win even with stale queue state. */
 export function mergePendingSendItems(
   rendered: readonly MobileMessageRenderItem[],
   pending: readonly MobilePendingSendItem[],
-  userSendAt: string | null | undefined,
-  sendOrder: ReadonlyMap<string, PendingSendOrder>,
+  optimisticClientIds: ReadonlySet<string>,
 ): readonly MobileMessageRenderItem[] {
-  const appended = appendPendingSendItems(rendered, pending);
-  if (appended === rendered) return appended;
-  const order = reconcilePendingSendOrder(sendOrder, pending, userSendAt);
-  const waiting = appended.slice(rendered.length) as MobilePendingSendItem[];
-  const insertions = new Map<number, MobilePendingSendItem[]>();
-  const tail: MobilePendingSendItem[] = [];
-  for (const item of waiting) {
-    const boundary = order.get(item.clientId)?.boundary;
-    const replyIndex = boundary !== undefined && isDispatchedPending(item)
-      ? rendered.findIndex((row) => renderItemStartsAt(row) >= boundary) : -1;
-    const firstRow = rendered[replyIndex];
-    // An existing user boundary needs no placeholder. A later user must not
-    // suppress an earlier bubble when its own response is already visible.
-    if (replyIndex < 0 || (firstRow.type === 'message' && firstRow.message.source.role === 'user')) tail.push(item);
-    else insertions.set(replyIndex, [...(insertions.get(replyIndex) ?? []), item]);
-  }
-  return insertions.size === 0 ? appended
-    : [...rendered.flatMap((item, index) => [...(insertions.get(index) ?? []), item]), ...tail];
-}
-
-function renderItemStartsAt(item: MobileMessageRenderItem | MobileWorkChildItem): number {
-  switch (item.type) {
-    case 'message':
-    case 'thinking': return Date.parse(item.message.source.createdAt);
-    case 'tool_group':
-    case 'tool_media': return Date.parse(item.tools[0]?.source.createdAt ?? '');
-    case 'todo':
-    case 'agent_task': return Date.parse(item.createdAt);
-    case 'work_group': return item.children.length > 0 ? renderItemStartsAt(item.children[0]) : NaN;
-    case 'subagent_group': return item.childItems.length > 0 ? renderItemStartsAt(item.childItems[0]) : NaN;
-    default: return NaN;
-  }
+  const byId = new Map(pending.map((item) => [item.clientId, item]));
+  const replaced = optimisticClientIds.size === 0 ? rendered : rendered.map((item) =>
+    item.type === 'message' && optimisticClientIds.has(item.message.source.clientId)
+      ? byId.get(item.message.source.clientId) ?? item : item);
+  return appendPendingSendItems(replaced, pending);
 }
 
 /**


### PR DESCRIPTION
## 这次改了什么

### 摘要

手机在用户消息正式回流前收到 AI 回复时，原先每帧把待发送气泡追加到列表末尾，导致回复短暂显示在用户消息上方。

现在对齐 Desktop 的乐观显示方式：手机本地状态显示空闲时，发送先在本地消息序列占据用户行的位置，再开始 enqueue；回复在其后分组，正式用户消息按已有 clientId 接管。同样使用共享 `renderHistoryView` 的本地用户行接管逻辑。撤掉此前 PR 中的 `userSendAt` 时间推断，不增加跨端关联字段、数据库列或 migration。

### 变更类型

- [x] `fix` 缺陷修复

### 范围

- 关联需求：手机发送后，AI 回复先到导致气泡短暂错序。
- 本 PR 包含：Mobile 本地观察为空闲的直发／outbox 交接时预留用户位置；历史接管与同 key 去重；乱序回归。
- 明确不包含：繁忙排队派发或断线恢复期间的轮次推断（这些条目保持原有尾部展示，直到正式用户消息回流）；服务端、Desktop 发送流程、device-link 协议、数据库、原生配置改动。
- 用户可见变化：手机本地观察为空闲时，发送气泡保持在随后到达的回复前，正式消息替换时不因尾部追加而换位；排队、上传、失败操作保留原有行为。
- 是否存在 breaking change：无。

已知限制：这里的“空闲”指 Mobile 的当前快照，不是主机权威派发状态。若手机仍缓存 running／pending interaction／queue 等忙碌状态，而主机已空闲，会跳过占位，回复先到时仍可能短暂错序。该情况与繁忙排队恢复一起保留原有行为，本 PR 不保证覆盖；不能把当前修复视为所有主机空闲发送的保证。

### UI 变化

- 引用的设计规范：`docs/design-rules/DESIGN.md` §14.4（功能状态转换）、§2／§10（语义颜色及主题）。保留既有气泡、操作区与 Light/Dark 样式，仅修正列表顺序；未新增动效、颜色或控件。
- 尚未取得实机／模拟器画面证据，详见未执行的验证。

## 怎么验证的

### 自动验证

```text
pnpm test:unit:related
结果：通过。

pnpm --filter mobile typecheck
结果：通过。

pnpm --filter mobile exec vitest run src/__tests__/pendingSendItems.test.ts src/__tests__/mobileHistoryRender.test.ts src/__tests__/messagePerformance.test.ts
结果：3 文件、65 用例通过。

node scripts/test-workspaces.mjs --tier unit --workspace apps/mobile
结果：Mobile 全包通过。

pnpm check:dco
结果：5 个提交签名通过。
```

收敛不变量：只有 enqueue 前观察到空闲的本地发送能创建用户占位；直接发送与 outbox 交接共用一个入口。回复、历史同步、queue 消失、重连和 steering 不创建新占位，只维护已有占位或使用主机历史。正式 echo 按 clientId 接管；失败、取消、超时与 session 切换沿用现有回收逻辑。

本轮撤回出队后使用上一帧消息推断位置的实现：history 与 projection 分帧到达时，该快照也可能包含新回复。没有继续扩展派发边界缓存。回归覆盖同帧／分帧恢复中未占位的繁忙队列保持原有尾部行为，正式消息回流后采用主机排序；空闲发送的回复先到回归仍保留。相关单测、Mobile 全包、typecheck 再次通过。上列 65 用例为此前定向结果。

回归覆盖：回复先于用户 echo、手机时钟超前／落后、两次发送及两种 echo 顺序、历史页晚于 durable push、分组前的用户边界与流式前缀缓存、失败／取消／队列回退、图片及合成指令遮蔽、历史页前插。

另外通过统一 unit-gate runner 跑完整仓库：Desktop 仍有 `claudeOrphanReaper.test.ts` 5 项、`codexAuthIsolatedSandbox.test.ts` 4 项失败。在本轮门禁基线 `0568ff4d6ce64586da1afa110bf6d7b8d6106b0a` 的独立干净 checkout 重现完全相同 9 项（其余 38 项通过），本地证据 `/tmp/cindy-4328-align-baseline.log`。首次整仓中的 Mobile 旧函数签名接线断言已同步更新，随后 Mobile 全包重跑通过；其他工作区通过。未把无关 Desktop 失败混入此 PR。

### 手工验证

已核对 Desktop 的空闲发送占位、排队派发及共享历史渲染接管代码；这属于代码核验，不是 Desktop 实机验证。

### 未执行的验证

手机实机与 iOS Simulator 画面（含 Light/Dark）尚未验证。目标为 `dash/fix-mobile-reply-order`／`cindy-fix-mobile-reply-order`；本地 whoami 报告没有启动的 Simulator、没有 Metro，内嵌 iOS Simulator 插件为 disabled，因此没有当前 bundle／`__DEV__` build label 验收证据。

## 风险

### 风险分类

- [x] 其他：手机端异步列表的本地占位与历史接管顺序。

### 影响与回滚

- 影响范围：Mobile 本地显示投影，不修改持久消息、搜索数据源或跨端 wire 字段。SSH／Desktop 无新增行为；设备互联继续使用原有 enqueue、clientId 和消息推送。
- 回滚／降级方式：回退本 PR 全部改动即可恢复原列表策略，无需数据迁移。原生配置、依赖与 runtime fingerprint 输入未改动。

### 提交前检查

- [x] 已 review 完整 diff
- [x] 每个 commit 都带 DCO 签名
- [x] UI 变化注明设计规范
- [x] 未提交凭证、令牌或授权文件
- [x] 已核对相关文档，原 PR 的时间推断说明已替换
- [x] 已记录测试结果及未执行的验证


