### PR TITLE
perf(device-link): 合并重复网络探测并保留前台快速恢复

### DIFF
--- a/apps/mobile/src/__tests__/historyViewProvider.test.tsx
+++ b/apps/mobile/src/__tests__/historyViewProvider.test.tsx
@@ -20,11 +20,23 @@ const auth = vi.hoisted(() => ({
   apiFetch: vi.fn(async () => ({ devices: [] })),
 }));
 vi.mock('@/auth/AuthContext', () => ({ useAuth: () => auth }));
+const networkEvents = vi.hoisted(() => ({
+  state: 'active',
+  app: (_next: string) => {},
+  network: (_next: { type: string; isConnected: boolean; isInternetReachable: boolean }) => {},
+}));
 vi.mock('react-native', () => ({
   Platform: { OS: 'android' },
-  AppState: { currentState: 'active', addEventListener: () => ({ remove() {} }) },
+  AppState: {
+    get currentState() { return networkEvents.state; },
+    addEventListener: (_event: string, listener: typeof networkEvents.app) => {
+      networkEvents.app = listener; return { remove() {} };
+    },
+  },
 }));
-vi.mock('expo-network', () => ({ addNetworkStateListener: () => ({ remove() {} }) }));
+vi.mock('expo-network', () => ({ addNetworkStateListener: (listener: typeof networkEvents.network) => {
+  networkEvents.network = listener; return { remove() {} };
+} }));
 vi.mock('expo-secure-store', () => ({
   getItemAsync: vi.fn(async () => null), setItemAsync: vi.fn(async () => {}), deleteItemAsync: vi.fn(async () => {}),
 }));
@@ -48,6 +60,8 @@ const transport = vi.hoisted(() => {
     invoke = vi.fn(async () => ({ ok: true, result: 'history page' }));
     start = vi.fn();
     stop = vi.fn();
+    connectNow = vi.fn();
+    notifyNetworkChanged = vi.fn();
     getStatus = () => this.status;
     isOutboundExplicitlyClosed = () => false;
     // No background recovery owner; each test explicitly starts the fresh read.
@@ -89,12 +103,47 @@ async function readHistory() {
 }
 
 beforeEach(async () => {
+  networkEvents.state = 'active';
   auth.accountGeneration = 1;
   transport.clients.length = 0;
   root = createRoot(document.createElement('div'));
   await act(async () => render());
 });
 afterEach(async () => { await act(async () => root.unmount()); });
+
+describe('Provider network recovery priority', () => {
+  const wifi = { type: 'WIFI', isConnected: true, isInternetReachable: true };
+  it('coalesces equal hints but expedites transport changes and offline recovery', async () => {
+    const client = transport.clients[0];
+    await act(async () => {
+      networkEvents.network(wifi);
+      networkEvents.network(wifi);
+      networkEvents.network({ ...wifi, type: 'CELLULAR' });
+      networkEvents.network({ type: 'NONE', isConnected: false, isInternetReachable: false });
+      networkEvents.network(wifi);
+    });
+    expect(client.notifyNetworkChanged.mock.calls).toEqual([
+      [{ urgent: false }], [{ urgent: false }], [{ urgent: true }], [{ urgent: true }],
+    ]);
+  });
+
+  it.each(['online', 'stopped', 'connecting'] as const)('recovers immediately from background with a %s connection', async (status) => {
+    const client = transport.clients[0];
+    client.status = status;
+    await act(async () => {
+      networkEvents.state = 'background'; networkEvents.app('background');
+      networkEvents.network(wifi);
+    });
+    expect(client.notifyNetworkChanged).not.toHaveBeenCalled();
+    await act(async () => {
+      networkEvents.state = 'active'; networkEvents.app('active');
+    });
+    expect(client.connectNow).toHaveBeenCalledWith('appstate-active', { overrideCongestionCooldown: true });
+    if (status === 'online') expect(client.notifyNetworkChanged).toHaveBeenCalledWith({ urgent: true });
+    else expect(client.notifyNetworkChanged).not.toHaveBeenCalled();
+    expect(client.stop).not.toHaveBeenCalled();
+  });
+});
 
 describe('Provider history handshake lifetime', () => {
   it.each(['presence', 'reconnect', 'peer reset', 'account switch'] as const)(

--- a/apps/mobile/src/device-link/DeviceLinkContext.tsx
+++ b/apps/mobile/src/device-link/DeviceLinkContext.tsx
@@ -1198,6 +1198,9 @@ export function DeviceLinkProvider({ children }: { children: ReactNode }) {
         // overrideCongestionCooldown:用户显式回前台是拥塞冷却的合法豁免——
         // 冷却默认只拦请求路径的 un-park(waitUntilOnline),不拦真人操作。
         backgroundConnection.active();
+        // A short background stay can preserve a socket whose route changed.
+        // Probe without the ordinary hint cooldown; never delay content recovery.
+        if (client.getStatus() === 'online') client.notifyNetworkChanged({ urgent: true });
         // 快速切换(连接被宽限保住、始终 online)不会有 online 状态转换,这条显式
         // 补齐就是断档回填的唯一触发点;其余路径下它因 status 未 online 而空转。
         void rehydrateWithClient(client);
@@ -1222,12 +1225,19 @@ export function DeviceLinkProvider({ children }: { children: ReactNode }) {
     // existing heartbeat fallback if the optional runtime module is unavailable.
     let disposed = false;
     let networkSubscription: { remove(): void } | undefined;
+    let previousNetwork: { type?: string; isConnected?: boolean; isInternetReachable?: boolean } | undefined;
     void import('expo-network').then(({ addNetworkStateListener }) => {
       if (disposed) return;
       networkSubscription = addNetworkStateListener((network) => {
-        mobileDebugLog('debug', 'device-link', 'network changed', { type: network.type, connected: network.isConnected, reachable: network.isInternetReachable, appState: AppState.currentState });
+        const urgent = previousNetwork !== undefined && (
+          previousNetwork.type !== network.type
+          || previousNetwork.isConnected !== network.isConnected
+          || previousNetwork.isInternetReachable !== network.isInternetReachable
+        );
+        previousNetwork = network;
+        mobileDebugLog('debug', 'device-link', 'network path notification', { type: network.type, connected: network.isConnected, reachable: network.isInternetReachable, appState: AppState.currentState, urgent });
         if (AppState.currentState !== 'active' || network.isConnected === false) return;
-        client.notifyNetworkChanged();
+        client.notifyNetworkChanged({ urgent });
       });
     }).catch(() => {
       console.warn('[device-link] network listener unavailable; using heartbeat recovery');

--- a/packages/device-link/src/__tests__/client.test.ts
+++ b/packages/device-link/src/__tests__/client.test.ts
@@ -155,7 +155,7 @@ describe('network change probes', () => {
       h.client.notifyNetworkChanged();
       await vi.advanceTimersByTimeAsync(250);
       h.client.notifyNetworkChanged();
-      await vi.advanceTimersByTimeAsync(499);
+      await vi.advanceTimersByTimeAsync(249);
       expect(socket.sent.filter((e) => e.kind === 'ping')).toHaveLength(0);
       await vi.advanceTimersByTimeAsync(1);
       expect(socket.sent.filter((e) => e.kind === 'ping')).toHaveLength(1);
@@ -208,6 +208,121 @@ describe('network change probes', () => {
       h.client.stop();
       await vi.advanceTimersByTimeAsync(10_000);
       expect(h.sockets).toHaveLength(3);
+    } finally { h.client.stop(); vi.useRealTimers(); }
+  });
+
+  it.each([false, true])('bounds repeated hints after a successful probe (post-hint traffic=%s)', async (traffic) => {
+    vi.useFakeTimers();
+    const h = makeHarness({ timing: { pingIntervalMs: 60_000 } });
+    try {
+      h.client.start(); await vi.advanceTimersByTimeAsync(0);
+      const socket = h.current(); socket.ack();
+      h.client.notifyNetworkChanged(); await vi.advanceTimersByTimeAsync(500);
+      socket.push({ v: PROTOCOL_VERSION, kind: 'pong' });
+      // A route can die just after success without changing its Wi-Fi label.
+      for (let i = 0; i < 29; i++) {
+        await vi.advanceTimersByTimeAsync(100);
+        h.client.notifyNetworkChanged();
+      }
+      expect(socket.sent.filter(e => e.kind === 'ping')).toHaveLength(1);
+      if (traffic) {
+        await vi.advanceTimersByTimeAsync(1);
+        socket.push({ v: PROTOCOL_VERSION, kind: 'pong' });
+      }
+      await vi.advanceTimersByTimeAsync(traffic ? 99 : 100);
+      expect(socket.sent.filter(e => e.kind === 'ping')).toHaveLength(traffic ? 1 : 2);
+      if (!traffic) {
+        await vi.advanceTimersByTimeAsync(15_000);
+        expect(h.sockets).toHaveLength(2);
+      } else expect(h.sockets).toHaveLength(1);
+    } finally { h.client.stop(); vi.useRealTimers(); }
+  });
+
+  it('expedites a queued probe on foreground or explicit route change without waiting for cooldown', async () => {
+    vi.useFakeTimers();
+    const h = makeHarness({ timing: { pingIntervalMs: 60_000 } });
+    try {
+      h.client.start(); await vi.advanceTimersByTimeAsync(0);
+      const socket = h.current(); socket.ack();
+      h.client.notifyNetworkChanged(); await vi.advanceTimersByTimeAsync(500);
+      socket.push({ v: PROTOCOL_VERSION, kind: 'pong' });
+      await vi.advanceTimersByTimeAsync(1);
+      h.client.notifyNetworkChanged();
+      h.client.notifyNetworkChanged({ urgent: true });
+      await vi.advanceTimersByTimeAsync(0);
+      expect(socket.sent.filter(e => e.kind === 'ping')).toHaveLength(2);
+      // Even urgent hints must not restart an in-flight probe's failure deadline.
+      await vi.advanceTimersByTimeAsync(14_000);
+      h.client.notifyNetworkChanged({ urgent: true });
+      await vi.advanceTimersByTimeAsync(1_000);
+      expect(h.sockets).toHaveLength(2);
+    } finally { h.client.stop(); vi.useRealTimers(); }
+  });
+
+  it('does not let continuous hints starve the initial probe', async () => {
+    vi.useFakeTimers();
+    const h = makeHarness({ timing: { pingIntervalMs: 60_000 } });
+    try {
+      h.client.start(); await vi.advanceTimersByTimeAsync(0);
+      const socket = h.current(); socket.ack();
+      for (let i = 0; i < 5; i++) {
+        h.client.notifyNetworkChanged();
+        await vi.advanceTimersByTimeAsync(100);
+      }
+      expect(socket.sent.filter(e => e.kind === 'ping')).toHaveLength(1);
+    } finally { h.client.stop(); vi.useRealTimers(); }
+  });
+
+  it('keeps a second peer and its in-flight request alive while the first peer stops ACKing', async () => {
+    vi.useFakeTimers();
+    const h = makeHarness({ timing: {
+      pingIntervalMs: 60_000, requestTimeoutMs: 30_000, transportRetryIntervalMs: 60_000,
+    } });
+    try {
+      h.client.start(); await vi.advanceTimersByTimeAsync(0);
+      const socket = h.current(); socket.ack();
+      for (const peer of ['dev-b', 'dev-c']) {
+        const linked = establishInboundReliableLink(h, `stream-${peer}`, 1, peer);
+        await vi.advanceTimersByTimeAsync(0); await linked;
+      }
+      h.client.sendPush('dev-b', 'maker:event', { waitingForAck: true });
+      const pending = h.client.invoke('dev-c', { channel: 'local-db:sessions:list', args: [] });
+      const request = socket.sent.filter(e => e.kind === 'invoke' && e.dst === 'dev-c').at(-1)!;
+      h.client.notifyNetworkChanged({ urgent: true });
+      await vi.advanceTimersByTimeAsync(14_000);
+      // A peer's valid response proves relay health even without pong or ACKs from dev-b.
+      encodeReliableFrames({
+        v: PROTOCOL_VERSION, kind: 'invoke-result', src: 'dev-c', id: request.id,
+        payload: { ok: true, result: ['healthy'] },
+      }, 'stream-dev-c', 1).forEach(frame => socket.push(frame));
+      await vi.advanceTimersByTimeAsync(0);
+      await expect(pending).resolves.toMatchObject({ result: ['healthy'] });
+      await vi.advanceTimersByTimeAsync(2_000);
+      expect(h.sockets).toHaveLength(1);
+      expect(socket.closed).toBeNull();
+      expect(socket.sent.filter(e => e.kind === 'link-close')).toHaveLength(0);
+      h.client.sendPush('dev-c', 'maker:event', { stillLinked: true });
+      expect(socket.sent.at(-1)).toMatchObject({ kind: 'push', dst: 'dev-c' });
+    } finally { h.client.stop(); vi.useRealTimers(); }
+  });
+
+  it('clears a deferred hint and its cooldown when the connection is stopped', async () => {
+    vi.useFakeTimers();
+    const h = makeHarness({ timing: { pingIntervalMs: 60_000 } });
+    try {
+      h.client.start(); await vi.advanceTimersByTimeAsync(0);
+      const old = h.current(); old.ack();
+      h.client.notifyNetworkChanged(); await vi.advanceTimersByTimeAsync(500);
+      old.push({ v: PROTOCOL_VERSION, kind: 'pong' });
+      h.client.notifyNetworkChanged();
+      h.client.stop();
+      h.client.connectNow('appstate-active'); await vi.advanceTimersByTimeAsync(0);
+      const socket = h.current(); socket.ack();
+      h.client.notifyNetworkChanged(); await vi.advanceTimersByTimeAsync(500);
+      expect(socket.sent.filter(e => e.kind === 'ping')).toHaveLength(1);
+      socket.push({ v: PROTOCOL_VERSION, kind: 'pong' });
+      await vi.advanceTimersByTimeAsync(3_000);
+      expect(socket.sent.filter(e => e.kind === 'ping')).toHaveLength(1);
     } finally { h.client.stop(); vi.useRealTimers(); }
   });
 });

--- a/packages/device-link/src/client.ts
+++ b/packages/device-link/src/client.ts
@@ -693,6 +693,8 @@ export class DeviceLinkClient {
   private networkChangeTimer: ReturnType<typeof setTimeout> | null = null;
   private networkProbeTimer: ReturnType<typeof setTimeout> | null = null;
   private networkProbeStartedAt = 0;
+  private networkChangeHintedAt = 0;
+  private networkProbeNextAllowedAt = 0;
   private connectionStartedAt = 0;
   /** 当前连接的代号,用于丢弃过期 socket 的事件回调 */
   private connEpoch = 0;
@@ -852,11 +854,19 @@ export class DeviceLinkClient {
 
   /** Network changes are hints, not proof of failure. Probe the shared relay,
    * never an individual peer; any valid inbound frame keeps the socket alive.
-   * Repeated hints coalesce and cannot extend an already running probe. */
-  notifyNetworkChanged(): void {
+   * Repeated hints coalesce without postponing detection indefinitely. Foreground
+   * and explicit network transitions bypass the successful-probe cooldown. */
+  notifyNetworkChanged(options?: { urgent?: boolean }): void {
     if (this.stopped || this.networkProbeTimer) return;
-    const hintedAt = this.monotonicNow();
-    if (this.networkChangeTimer) clearTimeout(this.networkChangeTimer);
+    this.networkChangeHintedAt = this.monotonicNow();
+    if (this.networkChangeTimer) {
+      if (!options?.urgent) return;
+      clearTimeout(this.networkChangeTimer);
+    }
+    const delay = options?.urgent ? 0 : Math.max(
+      500,
+      this.networkProbeNextAllowedAt - this.networkChangeHintedAt,
+    );
     this.networkChangeTimer = setTimeout(() => {
       this.networkChangeTimer = null;
       if (this.stopped) return;
@@ -867,7 +877,7 @@ export class DeviceLinkClient {
       }
       // Activity after the latest hint already proves this relay is reachable.
       // Do not compare Wi-Fi labels: switching access points can keep them equal.
-      if (this.lastInboundAt > hintedAt) return;
+      if (this.lastInboundAt > this.networkChangeHintedAt) return;
       const epoch = this.connEpoch;
       const socket = this.ws;
       const startedAt = this.monotonicNow();
@@ -888,7 +898,7 @@ export class DeviceLinkClient {
         // to settle the same bounded probe rather than tearing down immediately.
         this.log.debug('network probe send deferred; waiting for inbound activity');
       }
-    }, 500);
+    }, delay);
   }
 
   private clearNetworkProbe(): void {
@@ -896,6 +906,7 @@ export class DeviceLinkClient {
     if (this.networkProbeTimer) clearTimeout(this.networkProbeTimer);
     this.networkChangeTimer = null;
     this.networkProbeTimer = null;
+    this.networkProbeNextAllowedAt = 0;
   }
 
   /**
@@ -2045,6 +2056,7 @@ export class DeviceLinkClient {
       if (this.networkProbeTimer) {
         clearTimeout(this.networkProbeTimer);
         this.networkProbeTimer = null;
+        this.networkProbeNextAllowedAt = this.lastInboundAt + 3_000;
         this.log.debug(`network probe confirmed relay activity (elapsedMs=${Math.max(0, this.lastInboundAt - this.networkProbeStartedAt)})`);
       }
     }


### PR DESCRIPTION
## 这次改了什么

### 摘要

手机收到重复网络路径通知时，探测成功后仍可能每隔一两秒再次发送 ping。本次合并重复提示并增加成功后 3 秒冷却，同时让回前台和明确的网络切换绕过冷却，不阻塞内容恢复与普通请求。

### 变更类型

- [x] `refactor` / `perf` 重构或性能优化

### 范围

- 关联需求：降低重复网络探测开销，保留手机回前台的快速恢复。
- 本 PR 包含：有界合并通知、成功后冷却、紧急探测入口、手机前台与网络状态转换接入、时序与多 peer 回归测试。
- 明确不包含：桌面处理延迟与回复队列拥堵优化、原生配置或依赖变更。
- 用户可见变化：回前台立即恢复内容，健康连接继续复用；后台超过既有 10 秒阈值仍立即重建连接。标签不变的真实切网不会被丢弃，但普通补探测最多等待 3 秒。
- 是否存在 breaking change：无。只追加客户端方法可选参数，不改变 wire 消息、allowlist、权限或存储。
- 多端适配：Mobile 已接入；Desktop 复用共享连接层的同一判据；SSH 不经过此网络提示入口，不涉及。

### UI 变化

- 引用的设计规范：不涉及：仅修改连接时序和本地诊断事件，未修改界面、样式或用户文案。

## 怎么验证的

### 自动验证

- `env -u VITE_CINDY_AUTH_REGION -u NODE_ENV -u NODE_DEBUG -u CLAUDE_CODE_IDE_SKIP_AUTO_INSTALL pnpm test:unit:related`：通过（Desktop 全量 139.2s、Mobile 全量 19.6s、device-link 相关 9.0s）。
- 完整 `run-unit-gate.sh` 已执行，其余工作区通过；Desktop 有 9 项继承区域变量造成的失败，在同一干净主干复现。仅清除测试环境变量后，47 项定向测试及上述 Desktop 全量测试全部通过。早先一次 Desktop SIGSEGV 在后续执行中未再出现。
- 手机 typecheck、device-link build（tsc --noEmit）通过；device-link 没有独立 typecheck script。
- mobile test:scope 和 test:smoke 通过。
- 新增覆盖：成功后重复提示、提示后的有效流量免探测、持续通知不饿死探测、紧急提示绕过冷却、断连清理旧计时器、多 peer 共享连接、手机前台和明确切网接入。

### 手工验证

已完成 diff 自审；本 PR 未运行新版本 App。

### 未执行的验证

未进行 iPhone 真机切网、后台恢复及耗电对比。验证位于 dash/mobile-network-probe-cooldown worktree，未启动 Metro，无新版 __DEV__ build label 或实机归属证据。

## 风险

### 风险分类

- [x] 其他：连接恢复时序

### 影响与回滚

- 影响范围：手机网络通知驱动的探测，以及共享连接层的通知合并。普通请求不等待冷却；标签不变的路径变化补探测最多等待 3 秒。
- 故障半径：探测针对本机与 relay 的共享连接，不以单个 peer 不回 ACK 判死；任意合法入站数据可结束探测。仅整条连接在既有至少 15 秒容忍期内无响应时重建，不扩大恢复半径。
- 多 peer 证据：两个 peer 共享连接，其中一个停止 ACK；另一 peer 在途请求正常完成，连接不重建、不发送 link-close，后续发送仍可用。
- 取消与迟到：stop/reconnect 清理计时器和冷却；已有探测的期限不受重复提示延长；旧 socket 不得结清新连接探测；明确切网与前台提示可以提前执行待发探测。
- 协议、原生层、用户数据、存量插件：均无契约或持久化变更。
- 回滚 / 降级方式：回退本 PR 的 JS/TS 改动，不需要数据迁移或服务端配合。

### 提交前检查

- [x] 已 review 完整 diff
- [x] 每个 commit 都带 DCO 签名（git commit -s）
- [x] UI 改动已在「UI 变化」说明不涉及
- [x] 未提交凭证、令牌或授权文件
- [x] 已核对受影响的文档，无须同步修改的旧结论
- [x] 已确认测试结果或说明未执行原因
