### PR TITLE
fix(desktop): 不自动重试 OAuth 账号池耗尽错误

### DIFF
--- a/apps/desktop/src/main/maker-ipc/__tests__/interruptedTurnAutoResume.test.ts
+++ b/apps/desktop/src/main/maker-ipc/__tests__/interruptedTurnAutoResume.test.ts
@@ -165,6 +165,39 @@ describe('isInterruptedTurnError', () => {
     );
   });
 
+  it('does not auto-resume when the inference gateway has no available OAuth accounts', () => {
+    const exact =
+      'API Error: 503 {"error":"No available OAuth accounts in pool","detail":"No available OAuth accounts: 12 cooling down."}';
+    expect(isInterruptedTurnError({ message: exact, errorStatus: 503 })).toBe(false);
+    expect(
+      isInterruptedTurnError({
+        message: '503 Service Unavailable: No available OAuth accounts: 12 cooling down.',
+      }),
+    ).toBe(false);
+    // A stable reason must not override this non-retryable provider signal.
+    expect(
+      isInterruptedTurnError({
+        reason: 'upstream-overload',
+        message: 'No available OAuth accounts in pool',
+        errorStatus: 503,
+      }),
+    ).toBe(false);
+  });
+
+  it('does not broaden the OAuth-pool exception to a different HTTP status', () => {
+    expect(
+      isInterruptedTurnError({
+        message: 'No available OAuth accounts in pool',
+        errorStatus: 400,
+      }),
+    ).toBe(false);
+    expect(
+      isInterruptedTurnError({
+        message: 'No available OAuth accounts in pool',
+      }),
+    ).toBe(false);
+  });
+
   // 第三类:上游没容量。与 #844 的分工靠「本 turn 有没有产出」划清(见判定函数注释),
   // 零产出的容量拒绝由 Codex 侧重投,本份只在已有产出时接手,两者互斥。
   it('accepts capacity / overload failures', () => {

--- a/apps/desktop/src/main/maker-ipc/interruptedTurnAutoResume.ts
+++ b/apps/desktop/src/main/maker-ipc/interruptedTurnAutoResume.ts
@@ -59,6 +59,20 @@ const STREAM_TRUNCATION_PATTERN =
   /connection closed mid-response|response above may be incomplete|stream (?:closed|ended|interrupted) (?:unexpectedly|mid-response)/i;
 
 /**
+ * Inference gateways may return 503 while every OAuth account is cooling down.
+ * This is not a transient transport failure: replaying the same turn immediately
+ * only asks the same exhausted account pool again, so it must stay out of the
+ * automatic resume allowlist below.
+ */
+const OAUTH_ACCOUNT_POOL_UNAVAILABLE_PATTERN = /\bno available oauth accounts\b/i;
+
+function isOAuthAccountPoolUnavailableError(signals: InterruptedTurnErrorSignals): boolean {
+  if (signals.errorStatus !== undefined && signals.errorStatus !== 503) return false;
+  return typeof signals.message === 'string' &&
+    OAUTH_ACCOUNT_POOL_UNAVAILABLE_PATTERN.test(signals.message);
+}
+
+/**
  * SSE 流被中途切断（Claude Code 形态）。三层收紧后才看文案：
  *  - 没有 HTTP 状态码：上游给了状态码说明它**应答过**，不是流被切断。
  *  - SDK tag 必须是 `server_error`：把 `authentication_failed` / `rate_limit` /
@@ -105,6 +119,9 @@ function isStreamTruncationError(signals: InterruptedTurnErrorSignals): boolean 
  * 状态码，网络 errno 也没有 SDK tag。收紧只对第 1 类成立。
  */
 export function isInterruptedTurnError(signals: InterruptedTurnErrorSignals): boolean {
+  // This is a deliberate exception to the broad 503/network allowlist. Check it
+  // first so a future stable reason cannot accidentally re-enable auto-resume.
+  if (isOAuthAccountPoolUnavailableError(signals)) return false;
   const reason = typeof signals.reason === 'string' ? signals.reason : '';
   // 例外先行：`upstream-overload` 是**已归类为可重试**的 reason，它本身就是比文案更可靠的
   // 权威判据（结构化优先于文案，与 overload-error.ts 的论证同源），直接放行、不再看文案。


### PR DESCRIPTION
## 这次改了什么

### 摘要

网关返回 `503 No available OAuth accounts` 时，账号池正在冷却，立即续跑仍会命中同一失败状态。现在 Desktop 不会为这类错误自动补发任务。

### 变更类型

- [x] `fix` 缺陷修复

### 范围

- 关联 Issue / 需求：用户反馈的 OAuth 账号池耗尽错误
- 本 PR 包含：Desktop interrupted-turn 自动续跑判定与回归测试
- 明确不包含：Claude/Codex SDK 内部重试循环
- 用户可见变化：该错误会直接保留为错误，等待用户稍后手动处理
- 是否存在 breaking change：无

### UI 变化

不涉及 UI。

## 怎么验证的

### 自动验证

```text
pnpm exec vitest run apps/desktop/src/main/maker-ipc/__tests__/interruptedTurnAutoResume.test.ts
结果：51/51 通过（rebase 到最新 main 后）

pnpm --filter desktop typecheck
结果：受最新 main 的基线依赖/类型错误阻断，缺少 @cindy/model-compat、@earendil-works/pi-ai 等模块；与本 PR 文件无关。

pnpm test:unit:related
结果：目标测试通过；最新 main 的 Desktop plugin-market 测试已有 37 项失败，与本 PR 无关。
```

### 手工验证

不涉及。

### 未执行的验证

无。

## 风险

### 风险分类

- [x] 无已知风险

### 影响与回滚

- 影响范围：仅影响 Desktop interrupted-turn 自动续跑中的 OAuth 账号池耗尽错误；普通 503 网络错误保持原行为。
- 回滚 / 降级方式：回滚本 PR commits 即可。

### 提交前检查

- [x] 已 review 完整 diff
- [x] 每个 commit 都带 DCO 签名
- [x] 未提交凭证、令牌或授权文件
- [x] 已确认测试结果或说明未执行原因
