### PR TITLE
fix(codex): sanitize Grok tools for xai/ and bare grok- namespaces (Grok 4.6)

### DIFF
--- a/apps/desktop/src/main/maker-host/__tests__/codexProxyHost.test.ts
+++ b/apps/desktop/src/main/maker-host/__tests__/codexProxyHost.test.ts
@@ -5226,6 +5226,106 @@ describe('codex proxy host', () => {
     }
   });
 
+  it('sanitizes Grok 4.6 (xai/ namespace) tools for explicit XD Gateway sessions', async () => {
+    // Grok 4.6 reaches the gateway as `xai/grok-4.6`, not the legacy
+    // `x-ai/grok-*` namespace. The cleanup is keyed on the Grok model family,
+    // so the namespace tool and the `external_web_access` extension are still
+    // stripped instead of reaching the upstream and triggering the 400
+    // "Argument not supported: external_web_access" (issue #4336).
+    const host = await freshCodexProxyHost();
+    const { setXdGatewayModels } = await import('../active-catalog.js');
+    const { setSessionProvider, clearSessionProvider } = await import('../session-provider-store.js');
+    setXdGatewayModels([{ id: 'xai/grok-4.6', agents: ['codex'] }]);
+    mockState.createAnthropicCompatProxy.mockResolvedValueOnce({
+      url: 'http://127.0.0.1:43210',
+      dispose: vi.fn(async () => undefined),
+    });
+    await host.ensureCodexProxyReady();
+    host.registerComposed('session-xd-grok-46', 'thread-xd-grok-46', 'PRODUCT_PROMPT');
+    setSessionProvider('session-xd-grok-46', 'xd');
+
+    try {
+      const transforms = mockState.createAnthropicCompatProxy.mock.calls[0]?.[0]?.transformRequest ?? [];
+      let current: unknown = {
+        model: 'xai/grok-4.6',
+        tools: [
+          { type: 'function', name: 'exec_command' },
+          { type: 'namespace', name: 'multi_agent_v1', tools: [] },
+          { type: 'web_search', external_web_access: true },
+        ],
+        tool_choice: { type: 'namespace', name: 'multi_agent_v1' },
+        parallel_tool_calls: false,
+      };
+      const ctx = {
+        method: 'POST',
+        url: '/responses',
+        headers: { 'thread-id': 'thread-xd-grok-46' },
+      };
+      for (const transform of transforms) {
+        const next = transform(current, ctx);
+        if (next !== null && next !== undefined) current = next;
+      }
+
+      expect(current).toEqual({
+        model: 'xai/grok-4.6',
+        tools: [
+          { type: 'function', name: 'exec_command' },
+          { type: 'web_search' },
+        ],
+        tool_choice: 'none',
+        parallel_tool_calls: false,
+      });
+    } finally {
+      clearSessionProvider('session-xd-grok-46');
+      setXdGatewayModels([]);
+    }
+  });
+
+  it('sanitizes bare grok-4.6 tools for implicit sessions on the authoritative gateway catalog', async () => {
+    const host = await freshCodexProxyHost();
+    const { setXdGatewayModels } = await import('../active-catalog.js');
+    const { clearSessionProvider } = await import('../session-provider-store.js');
+    setXdGatewayModels([{ id: 'grok-4.6', agents: ['codex'] }]);
+    mockState.createAnthropicCompatProxy.mockResolvedValueOnce({
+      url: 'http://127.0.0.1:43210',
+      dispose: vi.fn(async () => undefined),
+    });
+    await host.ensureCodexProxyReady();
+    host.registerComposed('session-xd-grok-46-bare', 'thread-xd-grok-46-bare', 'PRODUCT_PROMPT');
+    clearSessionProvider('session-xd-grok-46-bare');
+
+    try {
+      const transforms = mockState.createAnthropicCompatProxy.mock.calls[0]?.[0]?.transformRequest ?? [];
+      let current: unknown = {
+        model: 'grok-4.6',
+        tools: [
+          { type: 'function', name: 'exec_command' },
+          { type: 'web_search', external_web_access: true, search_context_size: 'medium' },
+        ],
+      };
+      const ctx = {
+        method: 'POST',
+        url: '/responses',
+        headers: { 'thread-id': 'thread-xd-grok-46-bare' },
+      };
+      for (const transform of transforms) {
+        const next = transform(current, ctx);
+        if (next !== null && next !== undefined) current = next;
+      }
+
+      expect(current).toMatchObject({
+        model: 'grok-4.6',
+        tools: [
+          { type: 'function', name: 'exec_command' },
+          { type: 'web_search' },
+        ],
+      });
+    } finally {
+      clearSessionProvider('session-xd-grok-46-bare');
+      setXdGatewayModels([], { authoritative: false });
+    }
+  });
+
   it('sanitizes out-of-scope x-ai/grok tools even when the session belongs to a non-xd provider', async () => {
     // A provider-oauth xAI session that sends an `x-ai/grok*` request falls
     // through the xAI scope gate (xAI modelPrefixes cover `xai/`, not the

--- a/apps/desktop/src/main/maker-host/codex-proxy-host.ts
+++ b/apps/desktop/src/main/maker-host/codex-proxy-host.ts
@@ -2227,8 +2227,28 @@ function needsExecFunctionAdapter(
  * this transform exists to prevent. In that state clean unconditionally for
  * implicit routes (PR #2444 Codex P1).
  */
+/**
+ * Grok wire-model ids reach the proxy under several namespaces: the gateway's
+ * legacy `x-ai/grok-*`, the newer shared `xai/grok-*` (the Grok 4.6 ladder is
+ * exposed as `xai/grok-4.6` / bare `grok-4.6` — see `isOfficialGrok46Id`),
+ * and bare `grok-*` ids. The tool-shape cleanup must key on the model family,
+ * not on a single namespace, or requests like `xai/grok-4.6` skip
+ * sanitization entirely and leak Codex's `external_web_access` extension to
+ * the upstream, which rejects it with 400 "Argument not supported:
+ * external_web_access" (issue #4336).
+ */
+function isGrokResponsesWireModel(model: string): boolean {
+  const id = model.toLowerCase();
+  return (
+    id.startsWith('x-ai/grok')
+    || id.startsWith('xai/grok')
+    || id.startsWith('grok-')
+    || id === 'grok'
+  );
+}
+
 function xdProviderClaimsWireModel(wireModel: string): boolean {
-  if (!wireModel.startsWith('x-ai/grok')) return false;
+  if (!isGrokResponsesWireModel(wireModel)) return false;
   const { authoritative, models } = getXdGatewayModelAccessSnapshot();
   if (!authoritative) {
     // Negative evidence is unavailable. The env-key default route and the
@@ -2244,11 +2264,12 @@ function xdProviderClaimsWireModel(wireModel: string): boolean {
 }
 
 /**
- * The XD Gateway also exposes Grok models under the `x-ai/` namespace. They
- * stay on the gateway route (unlike the first-party `xai/` OAuth provider),
- * but the upstream Grok Responses schema still rejects Codex namespace tools.
- * Keep this transform deliberately narrow: gateway routing and the model
- * namespace must both match before applying the same tool-shape cleanup.
+ * The XD Gateway also exposes Grok models, historically under the `x-ai/`
+ * namespace and now also as `xai/grok-4.6` / bare `grok-4.6`. They stay on
+ * the gateway route (unlike the first-party `xai/` OAuth provider), but the
+ * upstream Grok Responses schema still rejects Codex namespace tools and the
+ * `external_web_access` extension. The cleanup keys on the Grok model family
+ * (see `isGrokResponsesWireModel`) while routing stays provider-attributed.
  */
 /**
  * Whether the request's session provider route is actually adopted by the
@@ -2280,7 +2301,7 @@ function createGatewayGrokResponsesCompatTransform(
   return (body, ctx) => {
     if (!isPlainObject(body)) return null;
     const requestModel = typeof body.model === 'string' ? body.model : '';
-    if (!requestModel.startsWith('x-ai/grok')) return null;
+    if (!isGrokResponsesWireModel(requestModel)) return null;
     // Use providerContextForRequest so subagent-frozen routes resolve to xd
     // even when the parent session belongs to a different provider. Only
     // clean tools when the effective provider for THIS request is xd.


### PR DESCRIPTION
## 这次改了什么

### 摘要

Gateway Grok Responses 兼容 transform 此前只对 `x-ai/grok*` 前缀做工具形状清理。Grok 4.6 以 `xai/grok-4.6`（及裸 `grok-4.6`）的 wire id 到达网关，完全绕过了 `sanitizeXaiTools`：Codex 的 namespace 工具与 `web_search` 上的 `external_web_access` 扩展原样到达上游，Grok 4.6 返回 400 `"Argument not supported: external_web_access"`，会话彻底不可用。本 PR 把该 transform 与 `xdProviderClaimsWireModel` 的入口判断改为按 Grok 模型家族（`x-ai/grok*`、`xai/grok*`、`grok-*`）匹配。

### 变更类型

- [ ] `feat` 新功能
- [x] `fix` 缺陷修复
- [ ] `refactor` / `perf` 重构或性能优化
- [ ] `docs` / `test` / `chore` 文档、测试或工程维护
- [ ] 其他：

### 范围

- 关联 Issue / 需求：Fixes #4336
- 本 PR 包含：新增 `isGrokResponsesWireModel` 共享判定；`createGatewayGrokResponsesCompatTransform` 与 `xdProviderClaimsWireModel` 的入口 gate 改用该判定；两条回归测试（显式 XD 会话 + `xai/grok-4.6`、隐式会话 + 裸 `grok-4.6`）。
- 明确不包含：`createXaiResponsesCompatTransform`（first-party `xai/` 订阅直连路由）的行为变更——该路径本就按 provider 归属清理；网关路由 / provider 归属判定逻辑不变，仅模型家族 gate 放宽。
- 用户可见变化：选择 Grok 4.6（`xai/grok-4.6` / `grok-4.6`）的 Codex 会话不再因 400 `"Argument not supported: external_web_access"` 全程不可用。
- 是否存在 breaking change：无

### UI 变化

不涉及：仅改主进程请求 transform 链的匹配条件，无 renderer / 视觉 / 交互 / 文案变化。

## 怎么验证的

### 自动验证

```text
pnpm --filter desktop exec vitest run src/main/maker-host/__tests__/codexProxyHost.test.ts
Result: passed (231 tests, 含 2 条新增回归)。

pnpm --filter desktop run --if-present typecheck
Result: passed.
```

### 手工验证

复现环境（macOS 26.5.1 arm64, 客户端 0.1.79）: Codex 会话选择 `xai/grok-4.6`（model_provider `cindy_gateway`）发送任意消息 → 稳定复现 400 `"Argument not supported: external_web_access"`（上游响应见会话日志 `codex-proxy ◀ upstream response (non-2xx) status 400`）。修复分支按同一请求形状（`tools: [{type:'web_search', external_web_access:true}, namespace 工具]`）在单测中验证清理后不再携带该扩展。

### 未执行的验证

本机未跑完整 `pnpm test:unit`（已跑受影响的 codexProxyHost 全量 231 用例与 desktop typecheck），真实网关冒烟未执行，交由 CI 覆盖。

## 风险

### 风险分类

- [ ] 无已知风险
- [ ] SQLite / migration
- [ ] system prompt
- [x] 协议兼容
- [ ] 权限 / 安全 / 用户数据
- [ ] 存量插件兼容（批准状态 / 指纹 / manifest 校验 / 安装布局 / 包格式）
- [ ] 原生层 / fingerprint / OTA
- [ ] 跨平台差异
- [ ] 其他：

### 影响与回滚

- 影响范围：仅 wire model 命中 Grok 家族（`x-ai/grok*` / `xai/grok*` / `grok-*`）且实际路由归属网关（或隐式回落网关）的请求会额外经过既有的 `sanitizeXaiTools` 清理；显式被采纳的非网关 provider 早退分支保持原样，非 Grok 模型请求不经过任何新逻辑。
- 回滚 / 降级方式：revert 单个 commit 即可，无数据迁移。

### 提交前检查

- [x] 已 review 完整 diff
- [x] 每个 commit 都带 DCO 签名（`git commit -s`，见 [DCO](../DCO)）
- [x] UI 改动已在「UI 变化」注明引用的设计规范章节（不涉及 UI 则跳过）
- [x] 未提交凭证、令牌或授权文件
- [x] 已补充必要文档
- [x] 已确认测试结果或说明未执行原因
