### PR TITLE
fix(mobile): 减少远程桌面横屏键盘开合时的横移

### DIFF
--- a/apps/mobile/src/remote-desktop/__tests__/viewer.test.ts
+++ b/apps/mobile/src/remote-desktop/__tests__/viewer.test.ts
@@ -306,7 +306,9 @@ describe("remote desktop viewport", () => {
     expect(v.elements.image.style.width).toBe("400px");
     expect(parseFloat(v.elements.image.style.top)).toBeGreaterThan(0);
   });
-  it.each([1, 2])("keeps landscape scale %sx and centers the cursor above keyboard overlays", (scale) => {
+  it.each([
+    [1, .1], [1, .5], [1, .9], [2, .1], [2, .5], [2, .9],
+  ])("keeps landscape scale %sx with minimal horizontal movement for cursor %s", (scale, cursorX) => {
     const v = viewer();
     v.elements.stage.clientWidth = 800;
     v.elements.stage.clientHeight = 400;
@@ -322,20 +324,31 @@ describe("remote desktop viewport", () => {
       v.pointer("pointerup", 2, 500, 200);
     }
     v.send({ type: "frame", jpeg: "", cursor: {
-      x: .9, y: .85, width: 18, height: 18, hotX: 9, hotY: 9,
+      x: cursorX, y: .85, width: 18, height: 18, hotX: 9, hotY: 9,
       visible: true, png: "iVBORw0KGgo=",
     } });
+    v.send({ type: "mouseButtons", keyboardOpen: false, bottomInset: 0, leftInset: 50, rightInset: 80 });
+    for (let i = 0; i < 30; i++) v.frame();
     const width = v.elements.image.style.width;
     expect(parseFloat(v.elements.image.style.height)).toBeCloseTo(400 * scale);
+    // Removing the toolbar before the keyboard has a measured height must not shift the image.
+    const originalLeft = v.elements.image.style.left;
+    v.send({ type: "mouseButtons", keyboardOpen: true, bottomInset: 0, leftInset: 50, rightInset: 0 });
+    expect(parseFloat(v.elements.image.style.left)).toBeCloseTo(parseFloat(originalLeft));
     // Header, computer keyboard, phone keyboard, and closing the keyboard.
     for (const bottomInset of [60, 260, 300, 0]) {
-      v.send({ type: "mouseButtons", keyboardOpen: bottomInset > 0, bottomInset, leftInset: 50, rightInset: 0 });
+      const previousLeft = parseFloat(v.elements.image.style.left);
+      const previousCursorX = previousLeft + cursorX * parseFloat(width);
+      const rightInset = bottomInset > 0 ? 0 : 80;
+      const expectedCursorX = Math.max(67, Math.min(800 - rightInset - 17, previousCursorX));
+      v.send({ type: "mouseButtons", keyboardOpen: bottomInset > 0, bottomInset, leftInset: 50, rightInset });
       v.blur();
       for (let i = 0; i < 30; i++) v.frame();
       const image = v.elements.image.style;
       expect(image.width).toBe(width);
       expect(parseFloat(image.height)).toBeCloseTo(400 * scale);
-      expect(parseFloat(image.left) + .9 * parseFloat(image.width)).toBeCloseTo(425);
+      expect(parseFloat(image.left) + cursorX * parseFloat(image.width)).toBeCloseTo(expectedCursorX);
+      expect(parseFloat(image.left)).toBeCloseTo(previousLeft + expectedCursorX - previousCursorX);
       expect(parseFloat(image.top) + .85 * parseFloat(image.height)).toBeCloseTo((400 - bottomInset) / 2);
     }
   });

--- a/apps/mobile/src/remote-desktop/__tests__/viewer.test.ts
+++ b/apps/mobile/src/remote-desktop/__tests__/viewer.test.ts
@@ -358,6 +358,22 @@ describe("remote desktop viewport", () => {
     v.send({ type: "mouseButtons", keyboardOpen: true, bottomInset: 260 });
     expect(v.elements.image.style).toEqual(before);
   });
+  it("preserves horizontal position when the keyboard closes before measurement", () => {
+    const v = viewer();
+    v.elements.stage.clientWidth = 800;
+    v.elements.stage.clientHeight = 400;
+    v.send({ type: "init", epoch: "quick-keyboard", width: 1920, height: 1080, fillHeight: true });
+    v.send({ type: "mouseButtons", keyboardOpen: false, bottomInset: 0, leftInset: 50, rightInset: 80 });
+    const before = { ...v.elements.image.style };
+    for (let i = 0; i < 2; i++) {
+      v.send({ type: "mouseButtons", keyboardOpen: true, bottomInset: 0, leftInset: 50, rightInset: 0 });
+      v.send({ type: "mouseButtons", keyboardOpen: false, bottomInset: 0, leftInset: 50, rightInset: 80 });
+      expect(v.elements.image.style).toEqual(before);
+      v.blur();
+      for (let j = 0; j < 30; j++) v.frame();
+      expect(v.elements.image.style).toEqual(before);
+    }
+  });
   it("initializes when the native engine cannot serialize function source", () => {
     const stringify = vi
       .spyOn(Function.prototype, "toString")

--- a/apps/mobile/src/remote-desktop/viewerHtml.ts
+++ b/apps/mobile/src/remote-desktop/viewerHtml.ts
@@ -86,6 +86,7 @@ const VIEWER_SCRIPT = String.raw`
   const clamp=(v)=>Math.max(0,Math.min(1,v));
   let fillHeight=false;
   let panAnimation=null,viewportRightInset=0,viewportLeftInset=0,viewportBottomInset=0,keyboardViewportInset=0;
+  let keyboardViewportOpen=false;
   let cursorNeedsEntry=true,manualViewMoved=false,followRest=null;
   // Insets guide centering and pan limits without clipping the full-screen
   // video surface or adding an opaque strip beside the Dynamic Island.
@@ -313,25 +314,31 @@ const VIEWER_SCRIPT = String.raw`
       case 'releaseInput':release();break;
       case 'theme':if(/^#[0-9a-f]{3,8}$/i.test(message.surface)){document.body.style.background=message.surface;document.documentElement.style.background=message.surface;document.documentElement.style.setProperty('--surface',message.surface);}if(/^#[0-9a-f]{3,8}$/i.test(message.foreground)){cursor.style.borderColor=message.foreground;document.documentElement.style.setProperty('--foreground',message.foreground);}break;
       case 'mouseButtons':{
-        const before=layout(),keepHorizontal=fillHeight&&(message.keyboardOpen===true||keyboardViewportInset>0);
+        const before=layout(),keyboardOpen=fillHeight&&message.keyboardOpen===true;
+        const keepHorizontal=fillHeight&&(keyboardOpen||keyboardViewportOpen);
+        // Opening is observable before the native keyboard has a measured height.
+        keyboardViewportOpen=keyboardOpen;
         let sideInsetsChanged=false;
         if(Number.isFinite(message.bottomInset))viewportBottomInset=Math.max(0,Math.min(stage.clientHeight-1,message.bottomInset));
         if(Number.isFinite(message.leftInset)){const inset=Math.max(0,Math.min(stage.clientWidth-1,message.leftInset));sideInsetsChanged=sideInsetsChanged||inset!==viewportLeftInset;viewportLeftInset=inset;}
         if(Number.isFinite(message.rightInset)){const inset=Math.max(0,Math.min(stage.clientWidth-1,message.rightInset));sideInsetsChanged=sideInsetsChanged||inset!==viewportRightInset;viewportRightInset=inset;}
         // Hiding the side toolbar changes the viewport center. Keep the image's
         // actual horizontal position instead of following that center sideways.
-        if(keepHorizontal){const r=layout();place(before.x,r.y,r);}
-        const keyboardInset=fillHeight&&message.keyboardOpen===true?viewportBottomInset:0;
+        if(keepHorizontal){stopPanAnimation();const r=layout();place(before.x,r.y,r);}
+        const keyboardInset=keyboardOpen?viewportBottomInset:0;
         if(keyboardInset!==keyboardViewportInset){
           const wasOpen=keyboardViewportInset>0;keyboardViewportInset=keyboardInset;
           if(fillHeight&&(keyboardInset>0||wasOpen)){
-            stopPanAnimation();const r=layout(),v=cursorViewport(),x=r.x+cx*r.width;
-            // Center vertically; move sideways only enough to expose the cursor.
-            place(r.x+bounded(x,v.minX,v.maxX)-x,(v.minY+v.maxY)/2-cy*r.height,r);
+            const r=layout(),v=cursorViewport();
+            place(r.x,(v.minY+v.maxY)/2-cy*r.height,r);
             cursorNeedsEntry=false;manualViewMoved=false;
           }
         }
-        if(keepHorizontal){followRest={fx,fy,zoom};render();}
+        if(keepHorizontal){
+          // Restoring the toolbar can cover the cursor even after a zero-height opening.
+          if(!keyboardOpen||keyboardInset>0){const r=layout(),v=cursorViewport(),x=r.x+cx*r.width;place(r.x+bounded(x,v.minX,v.maxX)-x,r.y,r);}
+          followRest={fx,fy,zoom};render();
+        }
         else if(sideInsetsChanged){settlePan();render();}
         if(!message.enabled){for(const button of heldMouse.keys())queue({kind:'button',button,down:false,x:cx,y:cy});heldMouse.clear();resetWheel();flush();}for(const [edge,value] of [['bottom',message.bottomInset],['right',message.rightInset]])if(Number.isFinite(value)&&value>=0&&value<=4096)mouseButtons.style[edge]=value+'px';showMouseButtons=message.enabled===true;for(const name of ['left','right','wheel'])if(typeof message.labels?.[name]==='string')document.getElementById('mouse-'+name).setAttribute('aria-label',message.labels[name]);updateMouseButtons();break;
       }

--- a/apps/mobile/src/remote-desktop/viewerHtml.ts
+++ b/apps/mobile/src/remote-desktop/viewerHtml.ts
@@ -312,16 +312,29 @@ const VIEWER_SCRIPT = String.raw`
       case 'resume':if(video.srcObject)video.play().catch(()=>{});break;
       case 'releaseInput':release();break;
       case 'theme':if(/^#[0-9a-f]{3,8}$/i.test(message.surface)){document.body.style.background=message.surface;document.documentElement.style.background=message.surface;document.documentElement.style.setProperty('--surface',message.surface);}if(/^#[0-9a-f]{3,8}$/i.test(message.foreground)){cursor.style.borderColor=message.foreground;document.documentElement.style.setProperty('--foreground',message.foreground);}break;
-      case 'mouseButtons':if(Number.isFinite(message.bottomInset))viewportBottomInset=Math.max(0,Math.min(stage.clientHeight-1,message.bottomInset));if(Number.isFinite(message.leftInset)){const left=Math.max(0,Math.min(stage.clientWidth-1,message.leftInset));if(left!==viewportLeftInset){viewportLeftInset=left;settlePan();render();}}if(Number.isFinite(message.rightInset)){const inset=Math.max(0,Math.min(stage.clientWidth-1,message.rightInset));if(inset!==viewportRightInset){viewportRightInset=inset;settlePan();render();}}const keyboardInset=fillHeight&&message.keyboardOpen===true?viewportBottomInset:0;
+      case 'mouseButtons':{
+        const before=layout(),keepHorizontal=fillHeight&&(message.keyboardOpen===true||keyboardViewportInset>0);
+        let sideInsetsChanged=false;
+        if(Number.isFinite(message.bottomInset))viewportBottomInset=Math.max(0,Math.min(stage.clientHeight-1,message.bottomInset));
+        if(Number.isFinite(message.leftInset)){const inset=Math.max(0,Math.min(stage.clientWidth-1,message.leftInset));sideInsetsChanged=sideInsetsChanged||inset!==viewportLeftInset;viewportLeftInset=inset;}
+        if(Number.isFinite(message.rightInset)){const inset=Math.max(0,Math.min(stage.clientWidth-1,message.rightInset));sideInsetsChanged=sideInsetsChanged||inset!==viewportRightInset;viewportRightInset=inset;}
+        // Hiding the side toolbar changes the viewport center. Keep the image's
+        // actual horizontal position instead of following that center sideways.
+        if(keepHorizontal){const r=layout();place(before.x,r.y,r);}
+        const keyboardInset=fillHeight&&message.keyboardOpen===true?viewportBottomInset:0;
         if(keyboardInset!==keyboardViewportInset){
           const wasOpen=keyboardViewportInset>0;keyboardViewportInset=keyboardInset;
           if(fillHeight&&(keyboardInset>0||wasOpen)){
-            stopPanAnimation();const r=layout(),v=cursorViewport();
-            place((v.minX+v.maxX)/2-cx*r.width,(v.minY+v.maxY)/2-cy*r.height,r);
-            followRest={fx,fy,zoom};cursorNeedsEntry=false;manualViewMoved=false;render();
+            stopPanAnimation();const r=layout(),v=cursorViewport(),x=r.x+cx*r.width;
+            // Center vertically; move sideways only enough to expose the cursor.
+            place(r.x+bounded(x,v.minX,v.maxX)-x,(v.minY+v.maxY)/2-cy*r.height,r);
+            cursorNeedsEntry=false;manualViewMoved=false;
           }
         }
+        if(keepHorizontal){followRest={fx,fy,zoom};render();}
+        else if(sideInsetsChanged){settlePan();render();}
         if(!message.enabled){for(const button of heldMouse.keys())queue({kind:'button',button,down:false,x:cx,y:cy});heldMouse.clear();resetWheel();flush();}for(const [edge,value] of [['bottom',message.bottomInset],['right',message.rightInset]])if(Number.isFinite(value)&&value>=0&&value<=4096)mouseButtons.style[edge]=value+'px';showMouseButtons=message.enabled===true;for(const name of ['left','right','wheel'])if(typeof message.labels?.[name]==='string')document.getElementById('mouse-'+name).setAttribute('aria-label',message.labels[name]);updateMouseButtons();break;
+      }
       case 'init':followRest=null;cursorNeedsEntry=true;stopPanAnimation();resetCursor();control=false;release();pending=[];sending=false;seq=0;epoch=message.epoch;dw=message.width;dh=message.height;fillHeight=message.fillHeight===true;video.muted=!message.audio;trickleIce=message.trickleIce===true;retries=0;render();connect();break;
       case 'viewport':fillHeight=message.fillHeight===true;release();render();break;
       case 'answer':if(message.epoch===epoch)void receiveAnswer(message);break;


### PR DESCRIPTION
## 这次改了什么

### 摘要

手机横屏展开或收起远程桌面键盘时，原逻辑会把鼠标水平居中，侧边工具栏宽度变化还会带动画面横移。现在保留画面横向位置，只有鼠标被边缘遮挡时才最小幅度平移；鼠标继续在剩余可视高度内居中，桌面缩放保持不变。

### 变更类型

- [x] `fix` 缺陷修复

### 范围

- 关联需求：补齐 #4065 后续的横屏键盘最小横移要求。
- 本 PR 包含：viewer 布局调整及回归测试，共两个文件。
- 明确不包含：远程协议、连接恢复、权限及原生配置变更。
- 用户可见变化：键盘开合时减少画面左右跳动，鼠标仍保持可见。
- 是否存在 breaking change：无。

### UI 变化

- 引用的设计规范：`docs/design-rules/DESIGN.md` §14.4 Motion & Transitions（避免无意义位移）；§8 Mobile；§10 Light / Dark Dual-Mode Delivery Gate。
- 保留已有缩放、竖屏布局、主题和控件样式；同一位置算法适用于 Light/Dark。未添加动画或颜色。
- 未提供实机截图或录屏，本轮未启动客户端。

## 怎么验证的

### 自动验证

```text
pnpm test:unit:related
pnpm --filter mobile run --if-present typecheck
pnpm --filter mobile exec vitest run src/remote-desktop/__tests__/viewer.test.ts
```

覆盖 1x/2x 缩放、鼠标左/中/右位置、工具栏先隐藏但键盘高度仍为零、不同键盘高度、测量前立即关闭并连续开合两轮、收起键盘和失焦后回弹。定向 viewer 测试 30 项通过，根相关测试门禁与 Mobile 类型检查均通过。

### 手工验证

已 review 完整 diff，并经独立只读审查，未发现提交阻塞。

### 未执行的验证

未做 iOS/Android 实机和 Light/Dark 目检，尤其尚未验证 WKWebView 的快速键盘开合、缩放后键盘动画事件时序。未启动 Metro，因此无 Metro 归属或 __DEV__ build label 运行证据。

本地验证工作区：`/Users/dash/Code/Cindy/cindy-mobile-remote-desktop`，分支：`dash/mobile-desktop-keyboard-pan`。测试清除了宿主注入的四项区域/profile 环境变量。

## 风险

### 风险分类

- [x] 其他：键盘与侧边工具栏切换时的布局行为。

### 影响与回滚

- 影响范围：Mobile 横屏远程桌面键盘避让；无原生/fingerprint 输入改动。
- 回滚方式：回退本提交，恢复原来的水平居中行为。

### 提交前检查

- [x] 已 review 完整 diff
- [x] 每个 commit 都带 DCO 签名
- [x] UI 变化已注明设计规范章节
- [x] 未提交凭证、令牌或授权文件
- [x] 已核对受影响文档，无需同步改写
- [x] 已说明验证范围与未执行项目
