### PR TITLE
fix(desktop): 消除菜单和图标栏的横向滚动占位

### DIFF
--- a/apps/desktop/src/renderer/__tests__/machineSwitcherMenu.test.ts
+++ b/apps/desktop/src/renderer/__tests__/machineSwitcherMenu.test.ts
@@ -665,7 +665,7 @@ describe('远程机器切换入口并入 SidebarTopNav(置顶段上方,固定不
     // 渲染进程画不到窗口外:菜单高度按 Radix 可用高度收口 + 纵向滚动,
     // 否则 content 的 overflow-hidden 会把超出部分静默切掉(实机丢过「分组」整段)。
     expect(filterSource).toContain(
-      'max-h-[calc(var(--radix-dropdown-menu-content-available-height)-0.75rem)] overflow-y-auto',
+      'max-h-[calc(var(--radix-dropdown-menu-content-available-height)-0.75rem)] overflow-x-hidden overflow-y-auto',
     );
     expect(filterSource).toContain('collisionPadding={8}');
   });

--- a/apps/desktop/src/renderer/components/new-chat/UnifiedModelRail.tsx
+++ b/apps/desktop/src/renderer/components/new-chat/UnifiedModelRail.tsx
@@ -49,7 +49,8 @@ export function UnifiedModelRail({
   const activeKey = railItemKey(active);
   return (
     // 设计稿 .rail:宽 48(含 6px 侧距 + 1px 右分隔线)、纵向 8px、格间 2px。
-    <div className="flex min-h-0 w-12 shrink-0 flex-col items-center gap-0.5 overflow-y-auto border-r border-[var(--model-dropdown-border)] px-1.5 py-2">
+    // 与侧栏窄图标栏一致：滚动条不占宽度，避免挤压按钮并触发横向溢出。
+    <div className="flex min-h-0 w-12 shrink-0 flex-col items-center gap-0.5 overflow-x-hidden overflow-y-auto scrollbar-hide border-r border-[var(--model-dropdown-border)] px-1.5 py-2">
       {items.map((item) => {
         const key = railItemKey(item);
         const isActive = activeKey === key;

--- a/apps/desktop/src/renderer/features/cc-agent/sidebar/SidebarFilterPopover.tsx
+++ b/apps/desktop/src/renderer/features/cc-agent/sidebar/SidebarFilterPopover.tsx
@@ -603,9 +603,10 @@ export function SidebarFilterPopover({
             而 DropdownMenuContent 基础样式带 overflow-hidden 且无 max-height,
             超出部分会被**静默切掉**(实机:最上面的「分组」整段不见)。渲染进程
             画不到 BrowserWindow 外面,所以这里按 Radix 给出的可用高度收口并允许
-            纵向滚动——滚动容器放内层(与下方项目列表同款做法),不与 content 的
+            纵向滚动；禁止横向滚动，避免分隔线的负边距撑出底部滚动条占位。
+            滚动容器放内层(与下方项目列表同款做法),不与 content 的
             overflow-hidden 抢同一属性。减 0.75rem 让出 content 的 p-1 与边框。 */}
-        <div className="max-h-[calc(var(--radix-dropdown-menu-content-available-height)-0.75rem)] overflow-y-auto">
+        <div className="max-h-[calc(var(--radix-dropdown-menu-content-available-height)-0.75rem)] overflow-x-hidden overflow-y-auto">
           <MenuSubRow
             label={t('ccAgent.sidebar.filterGroupByHeading')}
             value={groupByValue}


### PR DESCRIPTION
## 这次改了什么

### 摘要

侧栏整理菜单的分隔线负边距触发横向滚动，导致最后一项下方多出 16px 空白。限制这个内层容器的横向溢出，同时保留纵向滚动。排查同类布局时发现模型选择器的窄供应商栏也会被原生滚动条挤宽，复用现有 `scrollbar-hide` 样式避免按钮横向溢出。

### 变更类型

- [ ] `feat` 新功能
- [x] `fix` 缺陷修复
- [ ] `refactor` / `perf` 重构或性能优化
- [ ] `docs` / `test` / `chore` 文档、测试或工程维护
- [ ] 其他：

### 范围

- 关联 Issue / 需求：#4343 合并后的菜单底部空白反馈。
- 本 PR 包含：SidebarFilterPopover 的内层滚动容器、UnifiedModelRail 的窄图标栏，以及对应的菜单样式断言。
- 明确不包含：全局滚动条规则、代码块、Diff、表格及 tabs 的正常横向滚动。
- 用户可见变化：菜单底部多余占位消失；供应商较多时图标栏不被滚动条挤压，仍可上下滚动。
- 是否存在 breaking change：无。

### UI 变化

- 引用的设计规范：`docs/design-rules/DESIGN.md` §4、§5、§8、§10；保留原菜单尺寸、圆角及 Light/Dark 语义 token，按 §8 保留代码等内容的正常横向滚动。图标栏沿用现有窄侧栏隐藏滚动条的做法。
- 仅调整滚动轴与滚动条占位；未上传本地窗口截图。

## 怎么验证的

### 自动验证

```text
pnpm --filter desktop exec vitest run src/renderer/features/cc-agent/sidebar/__tests__/SidebarFilterPopover.test.tsx src/renderer/__tests__/diffHorizontalScroll.test.tsx src/renderer/__tests__/providerRailWeeklyQuota.test.tsx
结果：分两次运行，共 30 项通过。
pnpm --filter desktop run --if-present typecheck
结果：通过。
pnpm test:unit:related
结果：通过。
完整单测：git skill run-unit-gate.sh
结果：显式设置 VITE_CINDY_AUTH_REGION=global 后完整通过（GATE_EXIT=0）。Linux / Windows 单测及其余 CI 检查全部通过。
prettier --check（三个修改文件）及 git diff --check：通过。
```

首轮完整单测发现菜单源码断言需要同步，已更新；另有 9 项因会话继承 CN 区域变量失败，在同 SHA 的干净基线复现。显式使用 Global 环境后，这两个测试文件、更新器测试文件和菜单源码断言共 152 项通过。更新器首轮出现过一次临时文件缺失，基线及定点复测均通过。

### 手工验证

macOS 运行中窗口的临时 CSS 对照：菜单宽度 248px，容器 scrollWidth=242/clientWidth=238；禁用横向滚动后菜单高度由 236px 变为 220px，验证底部 16px 为横向滚动条占位，检查后恢复临时样式。

Chrome 布局复现：用供应商栏的实际宽度、padding、按钮尺寸及 12px 滚动条，模拟占宽滚动条；修复前 clientWidth=35/scrollWidth=41，修复后两者均为47，按钮保持34px，scrollTop 可设为100，纵向滚动保留。

### 未执行的验证

未启动此 worktree 的完整客户端做 Light/Dark、Windows 实机回归。上述浏览器尺寸对照不等同于全量实机验收。

## 风险

### 风险分类

- [ ] 无已知风险
- [ ] SQLite / migration
- [ ] system prompt
- [ ] 协议兼容
- [ ] 权限 / 安全 / 用户数据
- [ ] 存量插件兼容（批准状态 / 指纹 / manifest 校验 / 安装布局 / 包格式）
- [ ] 原生层 / fingerprint / OTA
- [x] 跨平台差异
- [ ] 其他：

### 影响与回滚

- 影响范围：Desktop 两处局部布局；原生滚动条占宽依平台设置而异。供应商栏隐藏原生滚动条但保留滚动能力，与既有窄侧栏一致。
- 回滚 / 降级方式：回退两个组件的样式改动即可，无迁移。

### 提交前检查

- [x] 已 review 完整 diff
- [x] 每个 commit 都带 DCO 签名（git commit -s）
- [x] UI 改动已在「UI 变化」注明引用的设计规范章节
- [x] 未提交凭证、令牌或授权文件
- [x] 已核对受影响的文档，保持既有内部纵向滚动合同
- [x] 已确认测试结果或说明未执行原因
