### PR TITLE
fix(pi): 启动确认窗口内的 Stop 叠加进程退出按取消结算

### DIFF
--- a/packages/maker-core/src/agents/pi/__tests__/pi-auto-review-dispatch.test.ts
+++ b/packages/maker-core/src/agents/pi/__tests__/pi-auto-review-dispatch.test.ts
@@ -775,6 +775,32 @@ describe('pi auto-review dispatch & spawn config (mocked pi process)', () => {
     await handle.close();
   });
 
+  // #4354: Stop lands after the prompt RPC was confirmed but before `agent_start`; a
+  // process exit inside that window is the user's cancellation, not a failure. Without a
+  // Stop the same exit stays a terminal failure.
+  it.each([{ code: 0, stopped: true }, { code: 1, stopped: true }, { code: 1, stopped: false }])('settles Pi exit $code before agent_start after Stop=$stopped as the user outcome', async ({ code, stopped }) => {
+    const deps = buildDeps();
+    const agent = new PiAgent(deps);
+    const handle = await agent.startSession({ sessionId: 'exit-before-start', workingDir: cwd, model: 'm' });
+    const session = new Session({ id: 'exit-before-start', agentKind: 'pi', workDir: cwd,
+      handle, capabilities: agent.capabilities, logger: deps.logger, turnStallMs: 0 });
+    const seen: import('../../../types/events.js').AgentEvent[] = [];
+    session.onEvent((event) => seen.push(event));
+    await session.send('perform work');
+    // prompt RPC confirmed, agent_start deliberately never emitted
+    if (stopped) await session.abort();
+    captured.onExit?.({ code, signal: null });
+    await vi.waitFor(() => expect(session.getStatus()).toBe('closed'));
+    expect(seen.filter((event) => event.type === 'error')).toEqual(stopped ? [] : [
+      expect.objectContaining({ data: expect.objectContaining({ isTerminal: true }) }),
+    ]);
+    expect(seen.filter((event) => event.type === 'done')).toEqual(stopped ? [
+      expect.objectContaining({ data: { status: 'cancelled' } }),
+    ] : []);
+    expect(captured.requests.filter((request) => request.type === 'prompt')).toHaveLength(1);
+    await handle.close();
+  });
+
   it.each([0, 1])('preserves a delivered successful reply when Pi subsequently exits with %s', async (code) => {
     const deps = buildDeps();
     const agent = new PiAgent(deps);

--- a/packages/maker-core/src/agents/pi/__tests__/pi-translator.test.ts
+++ b/packages/maker-core/src/agents/pi/__tests__/pi-translator.test.ts
@@ -9,8 +9,12 @@ import { rewriteContextModeDoctorPath } from '../context-mode-doctor-path.js';
 import {
   createPiTranslateContext,
   disposePiTranslateContext,
+  isCurrentTurnHostAbortRequested,
+  isHostAbortRequestedAtExit,
+  isPendingTurnHostAbortRequested,
   markPiHostAbortRequested,
   markPiHostTurnStartPending,
+  rollbackPiHostAbortRequest,
   rollbackPiHostTurnStart,
   translatePiEvent,
   usageSnapshotOf,
@@ -2178,5 +2182,53 @@ describe('pi translator', () => {
       expect(events.some((e) => e.type === 'agent_task_update')).toBe(true);
       expect(usageSnapshotOf(ctx).tokenUsage).toBe(0);
     });
+  });
+});
+
+// #4354: a Stop accepted after the prompt RPC was confirmed but before `agent_start`
+// is booked on the pending generation; exit settlement must see it as the user's
+// cancellation, while a rolled-back prompt or a rejected Stop leaves nothing behind.
+describe('pi translator exit-time host abort classification (#4354)', () => {
+  it('recognises a Stop booked on the confirmed, not yet started turn', () => {
+    const ctx = createPiTranslateContext(noopLogger);
+    expect(isHostAbortRequestedAtExit(ctx)).toBe(false);
+    markPiHostTurnStartPending(ctx);
+    markPiHostAbortRequested(ctx);
+    expect(isCurrentTurnHostAbortRequested(ctx)).toBe(false);
+    expect(isPendingTurnHostAbortRequested(ctx)).toBe(true);
+    expect(isHostAbortRequestedAtExit(ctx)).toBe(true);
+    // The pending Stop is carried into the turn once it actually starts.
+    const { queue } = makeQueue();
+    translatePiEvent(ev({ type: 'agent_start' }), queue, ctx);
+    expect(isPendingTurnHostAbortRequested(ctx)).toBe(false);
+    expect(isCurrentTurnHostAbortRequested(ctx)).toBe(true);
+    expect(isHostAbortRequestedAtExit(ctx)).toBe(true);
+    disposePiTranslateContext(ctx);
+  });
+
+  it('is not fooled by a rejected prompt or a rolled-back Stop', () => {
+    const ctx = createPiTranslateContext(noopLogger);
+    const start = markPiHostTurnStartPending(ctx);
+    const stop = markPiHostAbortRequested(ctx);
+    // Stop RPC rejected: nothing remains for exit settlement.
+    rollbackPiHostAbortRequest(ctx, stop);
+    expect(isHostAbortRequestedAtExit(ctx)).toBe(false);
+    // Stop accepted, then the prompt itself is rejected: the pending generation never
+    // exists, so its Stop must not classify a later exit (or the next turn) as cancelled.
+    markPiHostAbortRequested(ctx);
+    rollbackPiHostTurnStart(ctx, start);
+    expect(isHostAbortRequestedAtExit(ctx)).toBe(false);
+    const { queue } = makeQueue();
+    translatePiEvent(ev({ type: 'agent_start' }), queue, ctx);
+    expect(isCurrentTurnHostAbortRequested(ctx)).toBe(false);
+    disposePiTranslateContext(ctx);
+  });
+
+  it('never reports a pending Stop without a pending turn start', () => {
+    const ctx = createPiTranslateContext(noopLogger);
+    markPiHostAbortRequested(ctx); // no prompt in flight: books the current generation
+    expect(isPendingTurnHostAbortRequested(ctx)).toBe(false);
+    expect(isCurrentTurnHostAbortRequested(ctx)).toBe(true);
+    disposePiTranslateContext(ctx);
   });
 });

--- a/packages/maker-core/src/agents/pi/index.ts
+++ b/packages/maker-core/src/agents/pi/index.ts
@@ -197,8 +197,8 @@ import { applyPiBotSkillPolicy } from './bot-skill-policy.js';
 import {
   createPiTranslateContext,
   disposePiTranslateContext,
-  isCurrentTurnHostAbortRequested,
   isFailedOrAbortedPiCompaction,
+  isHostAbortRequestedAtExit,
   markPiHostAbortRequested,
   markPiHostTurnStartPending,
   rollbackPiHostAbortRequest,
@@ -5237,7 +5237,9 @@ export class PiAgent extends BaseAgent {
           }
         },
         onExit: ({ code, signal }) => {
-          const hostAbortRequested = isCurrentTurnHostAbortRequested(ctx);
+          // A Stop booked on the confirmed-but-not-started turn (prompt RPC accepted,
+          // `agent_start` pending) is the user's cancellation of exactly this exit (#4354).
+          const hostAbortRequested = isHostAbortRequestedAtExit(ctx);
           piProcessExited = true;
           clearPiSubagentRefreshTimer();
           void deferProxyDisposalForDetachedRuns();

--- a/packages/maker-core/src/agents/pi/translator.ts
+++ b/packages/maker-core/src/agents/pi/translator.ts
@@ -295,6 +295,27 @@ export function isCurrentTurnHostAbortRequested(ctx: PiTranslateContext): boolea
     && ctx.hostAbortRequestTokens.size > 0;
 }
 
+/**
+ * Host Stop that was accepted while a prompt RPC had been confirmed but its
+ * `agent_start` had not yet arrived: `markPiHostAbortRequested` books it on the
+ * *pending* generation (turnGeneration + 1). A process exit inside that window
+ * ends the turn the user just cancelled, so exit settlement must recognise it
+ * exactly like a Stop on the streaming turn (#4354). A rolled-back prompt clears
+ * the pending token (and the booked Stop) first, so a rejected prompt never
+ * turns a later unrelated exit into "cancelled".
+ */
+export function isPendingTurnHostAbortRequested(ctx: PiTranslateContext): boolean {
+  return !ctx.isStreaming
+    && ctx.pendingHostTurnStartToken !== null
+    && ctx.hostAbortRequestGeneration === ctx.turnGeneration + 1
+    && ctx.hostAbortRequestTokens.size > 0;
+}
+
+/** Exit-time classification: a Stop on the streaming turn or on the confirmed, not yet started one. */
+export function isHostAbortRequestedAtExit(ctx: PiTranslateContext): boolean {
+  return isCurrentTurnHostAbortRequested(ctx) || isPendingTurnHostAbortRequested(ctx);
+}
+
 function clearPiHostAbortRequests(ctx: PiTranslateContext): void {
   ctx.hostAbortRequestTokens.clear();
   ctx.hostAbortRequestGeneration = null;


### PR DESCRIPTION
## 这次改了什么

### 摘要

Pi 的 prompt RPC 已确认、`agent_start` 尚未到达时，Host Stop 会被 `markPiHostAbortRequested` 登记在 **pending generation**（`turnGeneration + 1`）。若进程恰在这个窗口退出，#4186 引入的 `onExit` 结算只按当前 generation 判断（`isCurrentTurnHostAbortRequested`），会把用户的主动取消显示为终态失败（#4354）。

本 PR 新增 `isPendingTurnHostAbortRequested` / `isHostAbortRequestedAtExit`：退出结算同时识别登记在"已确认、尚未开始"那一代上的 Stop，按 `cancelled` 收口。被拒绝的 Stop（`rollbackPiHostAbortRequest`）与被拒绝的 prompt（`rollbackPiHostTurnStart`）都会先清掉该登记，因此不会把后续无关退出或下一代真实 turn 误判为取消。

### 变更类型

- [x] `fix` 缺陷修复
- [x] `test` 回归覆盖

### 范围

- 关联 Issue：closes #4354（来源 #4186 discussion_r3995814597）。
- 本 PR 包含：`packages/maker-core/src/agents/pi/translator.ts` 两个导出判定；`index.ts` `onExit` 改用 `isHostAbortRequestedAtExit`；translator 单测 3 条；`pi-auto-review-dispatch` 故障注入用例 3 条（Stop 后退出 code 0/1 → `cancelled`，未 Stop 的同类退出仍为 terminal error）。
- 明确不包含：#4186 的扩展刷新与静默停止范围、协议级 executionHandle、真实 Pi 进程复现（该时序在真实场景尚未复现，本 PR 按 issue 验收口径以确定性故障注入覆盖）。
- 用户可见变化：仅该窄时序下 Stop 后的进程退出从"失败"改为"已取消"。
- breaking change：无。

## 怎么验证的

### 自动验证

- `packages/maker-core`：`vitest run pi-translator.test.ts pi-auto-review-dispatch.test.ts` → 268 passed。
- 反证：撤销 `index.ts` 改动后，新增的两个 `Stop=true` 退出用例失败（显示为 terminal error），`Stop=false` 用例仍通过。
- `tsc --noEmit`（maker-core）通过；root `pnpm test:unit:related` 全部 PASS（desktop / maker-core / lizi-mcps / orca-workflow / test:runner）。
- `eslint src/`（maker-core）在基线 main 上本就存在既有错误（34 个文件）；本次触及的两个文件中所有报错行均未被本 PR 修改。

### 人工验证

- 未做真实 Pi 进程复现：issue 明确"当前无真实场景复现"，验收口径为故障注入。

## 风险

### 风险分类

- [x] 无已知风险
- [ ] SQLite / migration
- [ ] system prompt
- [ ] 协议兼容
- [ ] 权限 / 安全 / 用户数据
- [ ] 存量插件兼容（批准状态 / 指纹 / manifest 校验 / 安装布局 / 包格式）
- [ ] 原生层 / fingerprint / OTA
- [ ] 跨平台差异
- [ ] 其他：

### 影响与回滚

- 影响范围：仅 Pi adapter 的进程退出结算（`packages/maker-core/src/agents/pi/{translator,index}.ts`）。只在「prompt RPC 已确认、`agent_start` 未到、Host Stop 已被接受、进程随即退出」这一窄时序下，终态由 `error(isTerminal)` 改为 `done(cancelled)`；不改 wire schema、不新增 IPC、不触碰 Pi 进程生命周期、清理顺序（`onExit` 仍在 `disposePiTranslateContext` 之前读取判定）与 #4186 一致。未 Stop 的退出、Stop/prompt 被拒绝的回滚路径行为不变（有反例用例覆盖）。
- 回滚 / 降级方式：revert 本 PR 单个 commit 即可恢复 #4186 的原判定（仅当前 generation）；无数据、配置或协议迁移，无需降级步骤。存量插件影响：无。

## 限制（补充说明）

- `isPendingTurnHostAbortRequested` 依赖 `pendingHostTurnStartToken` 非空且 `!isStreaming`；`disposePiTranslateContext` 会清空这些字段，因此 `onExit` 在 dispose 之前读取判定（与 #4186 现有顺序一致）。

