### PR TITLE
fix(mobile): avoid stale device roster snapshot

### DIFF
--- a/apps/mobile/app/devices/index.tsx
+++ b/apps/mobile/app/devices/index.tsx
@@ -945,7 +945,10 @@ function HomeScreenContent() {
           if (homeAccountGenerationRef.current !== accountGenerationAtStart) {
             throw new Error('Home account generation superseded');
           }
-          return readDeviceList();
+          // Provider connection recovery may already own an older roster request. Home's
+          // presence fence is captured above, so joining that earlier request could let its
+          // stale empty snapshot erase a desktop presence delta that will not be replayed.
+          return readDeviceList({ fresh: true });
         },
         { maxAttempts: 3 },
       );

--- a/apps/mobile/src/__tests__/historyViewProvider.test.tsx
+++ b/apps/mobile/src/__tests__/historyViewProvider.test.tsx
@@ -154,6 +154,38 @@ describe('Provider device roster reads', () => {
     expect(await joined).toEqual({ devices: [] });
     expect(await fresh).toEqual({ devices: [desktop] });
   });
+
+  it('prevents an older roster response from superseding a newer fresh read', async () => {
+    const stale = deferredRoster();
+    const current = deferredRoster();
+    auth.apiFetch.mockReturnValueOnce(stale.promise).mockReturnValueOnce(current.promise);
+    const client = transport.clients[0];
+
+    await act(async () => {
+      client.status = 'online';
+      client.statusChanged('online');
+    });
+    const joined = context.readDeviceList();
+    const fresh = context.readDeviceList({ fresh: true });
+
+    const offlineDesktop: DeviceView = {
+      deviceId: 'desktop', name: 'Desktop', platform: 'darwin', appVersion: 'test',
+      online: false, remoteControlEnabled: true, busy: false, lastSeenAt: new Date(1).toISOString(),
+      isSelf: false,
+    };
+    const onlineDesktop: DeviceView = { ...offlineDesktop, online: true };
+    await act(async () => {
+      stale.resolve({ devices: [offlineDesktop] });
+    });
+    expect(context.getPresenceAvailability('desktop')).toBeNull();
+    await act(async () => {
+      current.resolve({ devices: [onlineDesktop] });
+    });
+
+    expect(await joined).toEqual({ devices: [offlineDesktop] });
+    expect(await fresh).toEqual({ devices: [onlineDesktop] });
+    expect(context.getPresenceAvailability('desktop')).toBe(true);
+  });
 });
 
 describe('Provider network recovery priority', () => {

--- a/apps/mobile/src/__tests__/historyViewProvider.test.tsx
+++ b/apps/mobile/src/__tests__/historyViewProvider.test.tsx
@@ -6,6 +6,7 @@ import {
   DEVICE_LINK_CAPABILITY_HISTORY_VIEW_V1,
   type DeviceLinkClient,
   type DeviceLinkStatus,
+  type DeviceView,
   type LinkAcceptPayload,
   type PresenceSnapshot,
 } from '@cindy/device-link';
@@ -17,7 +18,7 @@ const auth = vi.hoisted(() => ({
   accountGeneration: 1,
   user: { id: 'test-account' },
   getAccessToken: vi.fn(async () => 'test-token'),
-  apiFetch: vi.fn(async () => ({ devices: [] })),
+  apiFetch: vi.fn(async (..._args: unknown[]): Promise<{ devices: DeviceView[] }> => ({ devices: [] })),
 }));
 vi.mock('@/auth/AuthContext', () => ({ useAuth: () => auth }));
 const networkEvents = vi.hoisted(() => ({
@@ -95,6 +96,11 @@ function deferredAccept() {
   const promise = new Promise<LinkAcceptPayload>(done => { resolve = done; });
   return { promise, resolve };
 }
+function deferredRoster() {
+  let resolve!: (value: { devices: DeviceView[] }) => void;
+  const promise = new Promise<{ devices: DeviceView[] }>(done => { resolve = done; });
+  return { promise, resolve };
+}
 async function readHistory() {
   // Attach rejection handling immediately: lifecycle tests intentionally reject.
   let result!: Promise<unknown>;
@@ -105,11 +111,50 @@ async function readHistory() {
 beforeEach(async () => {
   networkEvents.state = 'active';
   auth.accountGeneration = 1;
+  auth.apiFetch.mockReset();
+  auth.apiFetch.mockResolvedValue({ devices: [] });
   transport.clients.length = 0;
   root = createRoot(document.createElement('div'));
   await act(async () => render());
 });
 afterEach(async () => { await act(async () => root.unmount()); });
+
+describe('Provider device roster reads', () => {
+  it('starts a fresh snapshot when Home joins a recovery read that predates its presence fence', async () => {
+    const stale = deferredRoster();
+    const current = deferredRoster();
+    auth.apiFetch.mockReturnValueOnce(stale.promise).mockReturnValueOnce(current.promise);
+    const client = transport.clients[0];
+
+    await act(async () => {
+      client.status = 'online';
+      client.statusChanged('online');
+    });
+    expect(auth.apiFetch).toHaveBeenCalledTimes(1);
+
+    await act(async () => client.presenceChanged({
+      deviceId: 'desktop', deviceName: 'Desktop', platform: 'darwin', appVersion: 'test',
+      online: true, remoteControlEnabled: true, busy: false, lastSeenAt: 1,
+    }));
+    const joined = context.readDeviceList();
+    expect(auth.apiFetch).toHaveBeenCalledTimes(1);
+    const fresh = context.readDeviceList({ fresh: true });
+    expect(auth.apiFetch).toHaveBeenCalledTimes(2);
+
+    const desktop: DeviceView = {
+      deviceId: 'desktop', name: 'Desktop', platform: 'darwin', appVersion: 'test',
+      online: true, remoteControlEnabled: true, busy: false, lastSeenAt: new Date(1).toISOString(),
+      isSelf: false,
+    };
+    await act(async () => {
+      stale.resolve({ devices: [] });
+      current.resolve({ devices: [desktop] });
+    });
+
+    expect(await joined).toEqual({ devices: [] });
+    expect(await fresh).toEqual({ devices: [desktop] });
+  });
+});
 
 describe('Provider network recovery priority', () => {
   const wifi = { type: 'WIFI', isConnected: true, isInternetReachable: true };

--- a/apps/mobile/src/__tests__/homeDesktopFirst.test.ts
+++ b/apps/mobile/src/__tests__/homeDesktopFirst.test.ts
@@ -672,7 +672,7 @@ describe('mobile home desktop-first surface', () => {
     // Home remains mounted across saved-account activation, so clearing the shared DeviceLink
     // stores is insufficient: page-local refs/state must disappear before the next paint too.
     expect(source).toContain('const { accountGeneration, deviceId: selfDeviceId, user } = auth;');
-    expect(source).toContain('return readDeviceList();');
+    expect(source).toContain('return readDeviceList({ fresh: true });');
     expect(source).toContain('const homeAccountGenerationRef = useRef(accountGeneration);');
     expect(source).toContain('useLayoutEffect(() => {');
     expect(source).toContain('syncInFlightRef.current = null;');

--- a/apps/mobile/src/device-link/DeviceLinkContext.tsx
+++ b/apps/mobile/src/device-link/DeviceLinkContext.tsx
@@ -376,6 +376,7 @@ export function DeviceLinkProvider({ children }: { children: ReactNode }) {
   const presenceAvailableByDeviceRef = useRef(new Map<string, boolean>());
   const rosterConsumerRef = useRef<(() => (devices: DeviceView[]) => void) | null>(null);
   const rosterRequestRef = useRef<{ client: DeviceLinkClient | null; epoch: number; promise: Promise<{ devices: DeviceView[] }> } | null>(null);
+  const rosterRequestGenerationRef = useRef(0);
   const presenceAvailabilityEpochsRef = useRef(createPresenceAvailabilityEpochs());
   const presencePendingRecoveryDeviceIdsRef = useRef(new Set<string>());
   const presenceUnavailableVerdictsRef = useRef(
@@ -404,10 +405,16 @@ export function DeviceLinkProvider({ children }: { children: ReactNode }) {
     const epoch = connectionEpochRef.current;
     const pending = rosterRequestRef.current;
     if (!options.fresh && pending?.client === client && pending.epoch === epoch) return pending.promise;
+    const generation = ++rosterRequestGenerationRef.current;
     const apply = rosterConsumerRef.current?.();
     const promise = auth.apiFetch<{ devices: DeviceView[] }>('/api/device-link/devices', {
       baseUrl: DEVICE_LINK_API_BASE_URL, timeoutMs: 12_000,
-    }).then((result) => { apply?.(result.devices); return result; });
+    }).then((result) => {
+      // A fresh read supersedes every older roster consumer, even when the older
+      // response arrives first and would otherwise outrank the new snapshot.
+      if (rosterRequestGenerationRef.current === generation) apply?.(result.devices);
+      return result;
+    });
     rosterRequestRef.current = { client, epoch, promise };
     void promise.finally(() => {
       if (rosterRequestRef.current?.promise === promise) rosterRequestRef.current = null;

--- a/apps/mobile/src/device-link/DeviceLinkContext.tsx
+++ b/apps/mobile/src/device-link/DeviceLinkContext.tsx
@@ -163,7 +163,11 @@ export interface DeviceLinkContextValue {
   lastPresenceSnapshot: PresenceSnapshot | null;
   /** 当前 relay 连接代内的逐设备 availability；null = 本代尚无权威 verdict。 */
   getPresenceAvailability(deviceId: string): boolean | null;
-  readDeviceList(): Promise<{ devices: DeviceView[] }>;
+  /**
+   * Read the account device roster. `fresh` starts a new REST snapshot instead of
+   * joining a request that may have started before the caller's reconciliation fence.
+   */
+  readDeviceList(options?: { fresh?: boolean }): Promise<{ devices: DeviceView[] }>;
   openLink(deviceId: string): Promise<LinkAcceptPayload>;
   /** 丢弃已结算的开链缓存并真正重开；并发重开仍按设备单飞。 */
   reopenLink(deviceId: string): Promise<LinkAcceptPayload>;
@@ -395,11 +399,11 @@ export function DeviceLinkProvider({ children }: { children: ReactNode }) {
 
   // Home and direct task entry share the same in-flight roster read. Evidence
   // belongs to the connection that started it, not whichever one finishes it.
-  const readDeviceList = useCallback((): Promise<{ devices: DeviceView[] }> => {
+  const readDeviceList = useCallback((options: { fresh?: boolean } = {}): Promise<{ devices: DeviceView[] }> => {
     const client = clientRef.current;
     const epoch = connectionEpochRef.current;
     const pending = rosterRequestRef.current;
-    if (pending?.client === client && pending.epoch === epoch) return pending.promise;
+    if (!options.fresh && pending?.client === client && pending.epoch === epoch) return pending.promise;
     const apply = rosterConsumerRef.current?.();
     const promise = auth.apiFetch<{ devices: DeviceView[] }>('/api/device-link/devices', {
       baseUrl: DEVICE_LINK_API_BASE_URL, timeoutMs: 12_000,


### PR DESCRIPTION
## 这次改了什么

### 摘要

修复移动端 Home 在 device-link 重连期间复用更早发起的设备目录请求时，迟到的空目录快照覆盖新 presence 更新、导致桌面设备持续不可见的问题。Home 的目录同步现在会在其 presence reconciliation fence 之后启动独立的新快照读取，同时保留已有的 connection epoch 与 client fencing。

### 变更类型

- [x] `fix` 缺陷修复
- [ ] `feat` 新功能
- [ ] `refactor` / `perf` 重构或性能优化
- [ ] `docs` / `test` / `chore` 文档、测试或工程维护
- [ ] 其他：

### 范围

- 关联 Issue / 需求：Fixes https://github.com/makecindy/cindy/issues/4358
- 本 PR 包含：为 Home 设备目录同步增加 fresh-read 模式；覆盖旧恢复请求仍在进行、presence 先到、旧空快照迟到的确定性回归。
- 明确不包含：服务端 relay/lease 修改、任务执行或远程控制协议变化。
- 用户可见变化：网络恢复后，移动端不会再因旧空目录响应覆盖新的桌面在线状态而停留在连接引导页。
- 是否存在 breaking change：无。

### UI 变化

不涉及：没有修改布局、样式、交互或文案；仅修正现有设备列表的数据同步顺序。

- 引用的设计规范：不涉及：纯数据同步顺序修复，无视觉、交互或文案变化。

## 怎么验证的

### 自动验证

```text
pnpm --filter mobile run --if-present typecheck
结果：通过

pnpm --filter mobile exec vitest run src/__tests__/historyViewProvider.test.tsx src/__tests__/homeDesktopFirst.test.ts
结果：通过（48 tests）

pnpm test:unit:related
结果：通过（apps/mobile 相关测试）
```


2026-09-18：同步 `main` `8db75b10af` 后，根 `pnpm test:unit:related`（本次自动选择全量 unit）、mobile 与 desktop typecheck 均通过；macOS 上 Windows barrier 定向测试 3 passed / 1 Windows-only skipped。同步包含上游 #4208 已合并的 probe 阶段预算修复，未另写 desktop 补丁；原 Windows CI 超时是否消失由新 head CI 验证。

### 手工验证

不涉及；本次使用确定性的请求时序夹具验证竞态，没有宣称真机复现。

### 未执行的验证

未执行 iOS 真机弱网/代理切换验证；修复针对客户端可确定复现的迟到目录快照竞态，不把模拟测试表述为真机测试。

## 风险

### 风险分类

- [x] 无已知风险
- [ ] SQLite / migration
- [ ] system prompt
- [ ] 协议兼容
- [ ] 权限 / 安全 / 用户数据
- [ ] 存量插件兼容（批准状态 / 指纹 / manifest 校验 / 安装布局 / 包格式）
- [ ] 原生层 / fingerprint / OTA
- [ ] 跨平台差异
- [ ] 其他：

### 影响与回滚

- 影响范围：移动端 Home 的设备目录读取时序；不改变 wire protocol、原生配置或 runtime fingerprint。
- 回滚 / 降级方式：回退本 PR，恢复同一连接代次共享已有目录请求的行为。

### 提交前检查

- [x] 已 review 完整 diff
- [x] 每个 commit 都带 DCO 签名（`git commit -s`，见 [DCO](../DCO)）
- [x] UI 改动已在「UI 变化」注明引用的设计规范（不涉及 UI）
- [x] 未提交凭证、令牌或授权文件
- [x] 已核对受影响的文档，行为变化无需修改现有文档
- [x] 已确认测试结果或说明未执行原因
