### PR TITLE
fix(orca): 运行时恢复提示不再进入 Worker 兜底结果捕获

### DIFF
--- a/apps/desktop/src/main/maker-ipc/__tests__/sessionEventPipeline.test.ts
+++ b/apps/desktop/src/main/maker-ipc/__tests__/sessionEventPipeline.test.ts
@@ -419,6 +419,22 @@ describe('production Session event pipeline', () => {
     await h.dispose();
   });
 
+  // #4349: the Host recovery notice reaches Desktop through the dedicated
+  // onRuntimeRecovery channel but shares handleSessionEvent with turn text. It is
+  // persisted and broadcast, yet must not be captured as an Orca worker result.
+  it('keeps a Host runtime-recovery notice out of Orca worker capture while still persisting it', async () => {
+    const h = harness();
+    const data = { isFinal: true, text: 'restart-cindy-to-refresh-packages' };
+    h.emit(event('text', data, { source: 'pi', runtimeRecovery: true }));
+    expect(h.deps.orcaTeamServiceForEvents.captureWorkerText).not.toHaveBeenCalled();
+    // Still persisted (with the localized notice text) for the transcript.
+    expect(effects.fn('onAssistantTextEvent')).toHaveBeenCalledOnce();
+    // Ordinary worker text is still captured.
+    h.emit(event('text', { isFinal: true, text: 'real worker reply' }, { source: 'pi' }));
+    expect(h.deps.orcaTeamServiceForEvents.captureWorkerText).toHaveBeenCalledWith('task', 'real worker reply', { isFinal: true });
+    await h.dispose();
+  });
+
   it('preserves ordinary Pi text without the Host recovery marker', async () => {
     const h = harness();
     const data = { isFinal: true, text: 'partial: restart-cindy-to-refresh-packages' };

--- a/apps/desktop/src/main/maker-ipc/sessionEventStream.ts
+++ b/apps/desktop/src/main/maker-ipc/sessionEventStream.ts
@@ -34,7 +34,11 @@ export function persistSessionStreamEvent(
   let resolvedContent: string | undefined;
   if (event.type === 'text') {
     const td = event.data as { text?: unknown; isFinal?: unknown; isFullText?: unknown } | null;
-    if (typeof td?.text === 'string') {
+    // A Host runtime-recovery notice (#4349) is not the worker's reply: it is
+    // persisted and broadcast like any assistant text below, but must never be
+    // captured as an Orca worker result. Otherwise an error terminal that lacks
+    // finalText could fall back to the localized recovery prompt as the "result".
+    if (typeof td?.text === 'string' && event.runtimeRecovery !== true) {
       deps.orcaTeamServiceForEvents?.captureWorkerText(session.id, td.text, {
         isFinal: td.isFinal === true,
       });


### PR DESCRIPTION
## 这次改了什么

### 摘要

Desktop 把 `Session.onRuntimeRecovery` 的恢复通知与普通事件一样送进 `handleSessionEvent`，而 `sessionEventStream.persistSessionStreamEvent` 对所有 `text` 事件都会调用 Orca 的 `captureWorkerText`。当 Pi Orca Worker 在扩展刷新退役失败叠加错误终态、旧运行时 close 失败且终态仍等待 start sequencer 时，Desktop 的本地化恢复提示会被当作 Worker 输出，进入 auto-bridge 的兜底结果（#4349）。

恢复通知事件由 maker-core `Session.closeAfterCurrentTurn` 的 `failureEvent` 生成，带 `runtimeRecovery: true`。本 PR 让该文本**仍照常持久化与广播**（transcript 与 renderer 不变，Pi 的本地化文案替换也不变），但**不再送入 `captureWorkerText`**，因此不会成为 Orca Worker 的兜底结果。

### 变更类型

- [x] `fix` 缺陷修复
- [x] `test` 回归覆盖

### 范围

- 关联 Issue：closes #4349（来源 #4186 discussion_r3995704084）。
- 本 PR 包含：`apps/desktop/src/main/maker-ipc/sessionEventStream.ts` 一处条件（`event.runtimeRecovery !== true`）；`sessionEventPipeline.test.ts` 一条回归用例（恢复通知不进捕获但仍持久化；普通 Worker 文本仍被捕获）。
- 明确不包含：#4186 的扩展刷新与静默停止范围、恢复通知的持久化/广播语义、共享 Session 正文隔离（`onEvent` 路径已隔离，未改）。
- 用户可见变化：仅该极端组合下 Orca Worker 的兜底结果不再显示恢复提示文案；恢复提示本身在会话记录中照常出现。
- breaking change：无。

## 怎么验证的

### 自动验证

- `apps/desktop`：`vitest run src/main/maker-ipc/__tests__/`（152 个文件、2953 个用例，含 `orcaTeamService.test.ts` 与 `sessionEventPipeline.test.ts`）全部通过。
- 反证：撤销 `sessionEventStream.ts` 改动后，新增用例失败（恢复通知被 `captureWorkerText` 捕获）。
- `pnpm run typecheck`（apps/desktop）通过；eslint 两个改动文件通过。

### 人工验证

- 未做真实 Pi Worker 退役失败复现：issue 明确"尚无真实场景复现"，本 PR 按验收口径以生产事件管线用例覆盖该次序。

## 风险

### 风险分类

- [x] 无已知风险
- [ ] SQLite / migration
- [ ] system prompt
- [ ] 协议兼容
- [ ] 权限 / 安全 / 用户数据
- [ ] 存量插件兼容（批准状态 / 指纹 / manifest 校验 / 安装布局 / 包格式）
- [ ] 原生层 / fingerprint / OTA
- [ ] 跨平台差异
- [ ] 其他：

### 影响与回滚

- 影响范围：仅 Desktop 主进程事件持久化路径中 Orca Worker 文本捕获的一个条件；`runtimeRecovery` 事件的持久化、广播、本地化不受影响；非恢复文本的捕获行为不变。不改 wire schema、IPC 或数据库。
- 回滚 / 降级方式：revert 本 PR 单个 commit；无数据、配置或协议迁移。存量插件影响：无。
