### PR TITLE
fix(remote-desktop): 修复首次辅助功能权限检测

### DIFF
--- a/apps/desktop/src/main/remote-desktop/__tests__/inputPermission.test.ts
+++ b/apps/desktop/src/main/remote-desktop/__tests__/inputPermission.test.ts
@@ -40,7 +40,35 @@ describe('desktop input permission detection', () => {
     mocks.access.mockResolvedValue(undefined);
     mocks.exec.mockResolvedValue({ stdout: 'ready\n' });
   });
-  afterEach(() => vi.restoreAllMocks());
+  afterEach(() => {
+    vi.useRealTimers();
+    vi.restoreAllMocks();
+  });
+
+  it('bounds a slow cold build and lets later polls reuse it without prompting', async () => {
+    vi.useFakeTimers();
+    mocks.access.mockRejectedValue(new Error('ENOENT'));
+    let finishBuild!: () => void;
+    mocks.exec.mockImplementationOnce(
+      () =>
+        new Promise<void>((resolve) => {
+          finishBuild = resolve;
+        }),
+    );
+    const first = readDesktopInputPermission();
+    await vi.advanceTimersByTimeAsync(5000);
+    expect(await first).toBe('unknown');
+    expect(mocks.exec).toHaveBeenCalledTimes(1);
+
+    const retry = readDesktopInputPermission();
+    finishBuild();
+    expect(await retry).toBe('granted');
+    expect(mocks.exec.mock.calls.map(([binary, args]) => [binary === 'swiftc', args[0]])).toEqual([
+      [true, '-D'],
+      [false, '--check'],
+    ]);
+    expect(vi.getTimerCount()).toBe(0);
+  });
 
   it('detects an existing grant on a cold dev build without requesting authorization', async () => {
     mocks.access.mockRejectedValue(new Error('ENOENT'));

--- a/apps/desktop/src/main/remote-desktop/__tests__/inputPermission.test.ts
+++ b/apps/desktop/src/main/remote-desktop/__tests__/inputPermission.test.ts
@@ -1,0 +1,79 @@
+import path from 'node:path';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { readDesktopInputPermission } from '../inputHost';
+
+const mocks = vi.hoisted(() => ({
+  exec: vi.fn(),
+  access: vi.fn(),
+  app: {
+    isPackaged: false,
+    getAppPath: () => '/fixture/desktop',
+    getPath: () => '/fixture/profile',
+  },
+}));
+vi.mock('electron', () => ({ app: mocks.app, screen: {} }));
+vi.mock('node:child_process', async (importOriginal) => {
+  const original = await importOriginal<typeof import('node:child_process')>();
+  const { promisify } = await import('node:util');
+  return {
+    ...original,
+    execFile: Object.assign(vi.fn(), { [promisify.custom]: mocks.exec }),
+  };
+});
+vi.mock('node:fs/promises', () => ({
+  default: {
+    readFile: vi.fn(async () => 'fixture source'),
+    access: mocks.access,
+    mkdir: vi.fn(),
+    mkdtemp: vi.fn(async () => '/fixture/compile'),
+    writeFile: vi.fn(),
+    rm: vi.fn(),
+    rename: vi.fn(),
+  },
+}));
+
+describe('desktop input permission detection', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.spyOn(process, 'platform', 'get').mockReturnValue('darwin');
+    mocks.app.isPackaged = false;
+    mocks.access.mockResolvedValue(undefined);
+    mocks.exec.mockResolvedValue({ stdout: 'ready\n' });
+  });
+  afterEach(() => vi.restoreAllMocks());
+
+  it('detects an existing grant on a cold dev build without requesting authorization', async () => {
+    mocks.access.mockRejectedValue(new Error('ENOENT'));
+    expect(await readDesktopInputPermission()).toBe('granted');
+    expect(mocks.exec.mock.calls.map(([binary, args]) => [binary === 'swiftc', args[0]])).toEqual([
+      [true, '-D'],
+      [false, '--check'],
+    ]);
+  });
+
+  it.each([
+    ['ready\n', 'granted'],
+    ['permission\n', 'missing'],
+    ['unexpected\n', 'unknown'],
+  ])('maps helper output %j to %s without prompting', async (stdout, expected) => {
+    mocks.exec.mockResolvedValue({ stdout });
+    expect(await readDesktopInputPermission()).toBe(expected);
+    expect(mocks.exec).toHaveBeenCalledExactlyOnceWith(
+      expect.stringContaining(path.join('remote-desktop', 'native')),
+      ['--check'],
+      { timeout: 5000, maxBuffer: 1024 },
+    );
+  });
+
+  it('does not claim a grant when preparation fails', async () => {
+    mocks.access.mockRejectedValue(new Error('ENOENT'));
+    mocks.exec.mockRejectedValue(new Error('compiler unavailable'));
+    expect(await readDesktopInputPermission()).toBe('unknown');
+  });
+
+  it('does not probe Accessibility on Windows', async () => {
+    vi.spyOn(process, 'platform', 'get').mockReturnValue('win32');
+    expect(await readDesktopInputPermission()).toBe('notRequired');
+    expect(mocks.exec).not.toHaveBeenCalled();
+  });
+});

--- a/apps/desktop/src/main/remote-desktop/inputHost.ts
+++ b/apps/desktop/src/main/remote-desktop/inputHost.ts
@@ -125,10 +125,19 @@ export async function readDesktopLockState(): Promise<'locked' | 'unlocked' | 'u
 
 export async function readDesktopInputPermission(): Promise<DesktopPermissionStatus> {
   if (process.platform !== 'darwin') return 'notRequired';
+  let timer: ReturnType<typeof setTimeout> | undefined;
   try {
     // A cold dev build must prepare the helper too; preparation does not prompt.
+    // Bound this caller's wait below the remote channel budget. A slow build
+    // stays shared in resolveBinary so later polls reuse it instead of restarting.
+    const binary = await Promise.race([
+      resolveBinary(),
+      new Promise<never>((_, reject) => {
+        timer = setTimeout(() => reject(new Error('DESKTOP_INPUT_PREPARING')), 5000);
+      }),
+    ]);
     // Only --request-permission may open the macOS authorization UI.
-    const { stdout } = await exec(await resolveBinary(), ['--check'], {
+    const { stdout } = await exec(binary, ['--check'], {
       timeout: 5000,
       maxBuffer: 1024,
     });
@@ -139,6 +148,8 @@ export async function readDesktopInputPermission(): Promise<DesktopPermissionSta
         : 'unknown';
   } catch {
     return 'unknown';
+  } finally {
+    if (timer) clearTimeout(timer);
   }
 }
 

--- a/apps/desktop/src/main/remote-desktop/inputHost.ts
+++ b/apps/desktop/src/main/remote-desktop/inputHost.ts
@@ -20,10 +20,10 @@ const exec = promisify(execFile);
 const binaryName =
   process.platform === 'darwin' ? 'cindy-macos-desktop-input' : 'cindy-windows-desktop-input.exe';
 let build: Promise<string> | null = null;
-async function resolveBinary(prepare = true): Promise<string> {
+async function resolveBinary(): Promise<string> {
   if (app.isPackaged)
     return path.join(process.resourcesPath, 'tools', 'remote-desktop', binaryName);
-  if (build && prepare) return build;
+  if (build) return build;
   const resolve = async () => {
     const sourceRoot = path.join(app.getAppPath(), 'native', 'remote-desktop');
     const source =
@@ -34,9 +34,16 @@ async function resolveBinary(prepare = true): Promise<string> {
       .update(await fs.readFile(source))
       .update(process.arch)
       .update('v1-O');
-    const callerSource = process.platform === 'darwin'
-      ? await fs.readFile(path.resolve(app.getAppPath(), '../../packages/remote-credentials-native/Sources/DesktopNativeCaller/DesktopNativeCaller.swift'), 'utf8')
-      : '';
+    const callerSource =
+      process.platform === 'darwin'
+        ? await fs.readFile(
+            path.resolve(
+              app.getAppPath(),
+              '../../packages/remote-credentials-native/Sources/DesktopNativeCaller/DesktopNativeCaller.swift',
+            ),
+            'utf8',
+          )
+        : '';
     digest.update(callerSource);
     if (process.platform === 'darwin') digest.update(process.execPath).update('dev-caller-v1');
     if (process.platform === 'win32') {
@@ -56,7 +63,6 @@ async function resolveBinary(prepare = true): Promise<string> {
     } catch {
       /* build this source version */
     }
-    if (!prepare) throw new Error('DESKTOP_INPUT_NOT_PREPARED');
     await fs.mkdir(directory, { recursive: true });
     const temporary = `${binary}.${process.pid}.tmp`;
     if (process.platform === 'darwin') {
@@ -65,7 +71,7 @@ async function resolveBinary(prepare = true): Promise<string> {
       const buildDirectory = await fs.mkdtemp(path.join(directory, 'compile-'));
       try {
         const main = path.join(buildDirectory, 'main.swift');
-        const program = (callerSource + '\n' + await fs.readFile(source, 'utf8')).replace(
+        const program = (callerSource + '\n' + (await fs.readFile(source, 'utf8'))).replace(
           '"DESKTOP_INPUT_DEVELOPMENT_EXECUTABLE"',
           JSON.stringify(Buffer.from(process.execPath).toString('base64')),
         );
@@ -96,7 +102,6 @@ async function resolveBinary(prepare = true): Promise<string> {
     await fs.rename(temporary, binary);
     return binary;
   };
-  if (!prepare) return resolve();
   build = resolve().finally(() => {
     build = null;
   });
@@ -107,16 +112,23 @@ async function resolveBinary(prepare = true): Promise<string> {
 export async function readDesktopLockState(): Promise<'locked' | 'unlocked' | 'unavailable'> {
   if (process.platform !== 'darwin') return 'unavailable';
   try {
-    const { stdout } = await exec(await resolveBinary(), ['--lock-state'], { timeout: 5000, maxBuffer: 1024 });
+    const { stdout } = await exec(await resolveBinary(), ['--lock-state'], {
+      timeout: 5000,
+      maxBuffer: 1024,
+    });
     const value = stdout.trim();
     return value === 'locked' || value === 'unlocked' ? value : 'unavailable';
-  } catch { return 'unavailable'; }
+  } catch {
+    return 'unavailable';
+  }
 }
 
 export async function readDesktopInputPermission(): Promise<DesktopPermissionStatus> {
   if (process.platform !== 'darwin') return 'notRequired';
   try {
-    const { stdout } = await exec(await resolveBinary(false), ['--check'], {
+    // A cold dev build must prepare the helper too; preparation does not prompt.
+    // Only --request-permission may open the macOS authorization UI.
+    const { stdout } = await exec(await resolveBinary(), ['--check'], {
       timeout: 5000,
       maxBuffer: 1024,
     });
@@ -130,14 +142,23 @@ export async function readDesktopInputPermission(): Promise<DesktopPermissionSta
   }
 }
 
-export async function lockDesktopScreen(isCurrent: () => boolean, signal: AbortSignal): Promise<void> {
+export async function lockDesktopScreen(
+  isCurrent: () => boolean,
+  signal: AbortSignal,
+): Promise<void> {
   if (process.platform !== 'darwin') throw new Error('DESKTOP_LOCK_UNAVAILABLE');
   const binary = await resolveBinary();
   if (signal.aborted || !isCurrent()) throw new Error('DESKTOP_LEASE_EXPIRED');
   try {
-    const { stdout } = await exec(binary, ['--lock-screen'], { timeout: 5000, maxBuffer: 1024, signal });
+    const { stdout } = await exec(binary, ['--lock-screen'], {
+      timeout: 5000,
+      maxBuffer: 1024,
+      signal,
+    });
     if (stdout.trim() !== 'locked') throw new Error('DESKTOP_LOCK_FAILED');
-  } catch { throw new Error('DESKTOP_LOCK_FAILED'); }
+  } catch {
+    throw new Error('DESKTOP_LOCK_FAILED');
+  }
 }
 
 export async function requestDesktopInputPermission(


### PR DESCRIPTION
## 这次改了什么

### 摘要

macOS 开发版的远程桌面权限检测在原生输入程序尚未编译时直接返回“未确认”，而点击“去授权”会准备该程序，导致已经授权的用户也必须先点一次授权。现在普通检测会复用已有的程序准备流程，再执行不弹窗的 `--check`，无需先请求授权。

准备阶段单次最多等待 5 秒，随后原生检查最多 5 秒，低于远程通道 59 秒预算。慢速编译继续在后台完成，本次返回 unknown，后续检测复用同一个编译过程。

### 变更类型

- [x] `fix` 缺陷修复

### 范围

- 关联 Issue / 需求：已授权的辅助功能在远程桌面权限弹窗中仍显示未确认。
- 本 PR 包含：检测前准备原生程序、单次准备等待上限、移除不再使用的禁止准备参数、7 项权限检测回归用例；修改文件按 Prettier 格式化。
- 明确不包含：系统授权流程、原生程序身份验证、远程控制授权边界和 UI 文案调整。
- 用户可见变化：开发版自动准备权限检测程序，不必先点击“去授权”；首次编译较慢时返回未确认，后续轮询自动获取实际授权状态。
- 是否存在 breaking change：无。

### UI 变化

- 引用的设计规范：不涉及。只修正 Main 返回的权限状态，未修改界面、布局或文案。

## 怎么验证的

### 自动验证

- `pnpm test:unit:related`：通过。
- `pnpm --filter desktop run --if-present typecheck`：通过。
- 最终定向运行 `inputPermission.test.ts`、`permissions.test.ts`：15 项通过，包含慢速编译超时、后续轮询共享编译及定时器清理。
- `pnpm check:dco`、Prettier 和 PR preflight：通过。
- 首轮通过 `run-unit-gate.sh` 执行全量 `pnpm test:unit`：Desktop 36443 项通过，9 项失败，其他 workspace 通过。失败集中在 `claudeOrphanReaper.test.ts`（5 项）和 `codexAuthIsolatedSandbox.test.ts`（4 项）。本轮超时修复重跑相关门禁及类型检查。
- 在无本 PR 改动的干净主干 `da7ed2b17` 独立安装依赖，运行上述两个文件：相同 9 项失败、38 项通过。确认是已有基线／本机环境问题，未混入无关修复，交由 CI 继续验证。

### 手工验证

已核对原生 `--check` 使用 `AXIsProcessTrusted()`；请求系统授权仍只在显式 `--request-permission` 路径执行。

### 未执行的验证

未启动开发客户端进行 macOS 实机授权弹窗验证，也未进行 Windows 实机验证。本次使用模拟原生程序和文件系统的测试覆盖冷启动、授权状态、准备失败及 Windows 跳过检测。

## 风险

### 风险分类

- [x] 权限 / 安全 / 用户数据
- [x] 跨平台差异

### 影响与回滚

- 影响范围：macOS 源码开发模式准备超时或编译失败仍返回 unknown，不会误报已授权；后台共享编译保留原有 120 秒上限。正式包继续使用随包原生程序，Windows 继续返回 notRequired。未变更原生源码、协议、授权身份或用户数据布局。
- 远程适配：手机和另一台桌面均复用同一权限接口；只限制单次查询的等待，不重连或重置 peer/relay，不改变其他控制端在途请求。已有共享编译继续复用，超时后的调用不会发起迟到的原生检查。SSH 工作区不涉及此本机桌面权限功能。
- 回滚 / 降级方式：撤回本提交即可恢复旧检测流程，无数据迁移。

### 提交前检查

- [x] 已 review 完整 diff
- [x] 每个 commit 都带 DCO 签名（`git commit -s`）
- [x] UI 改动已在「UI 变化」注明引用的设计规范章节（不涉及 UI）
- [x] 未提交凭证、令牌或授权文件
- [x] 已核对受影响的文档，无需同步修改
- [x] 已确认测试结果或说明未执行原因
