### PR TITLE
feat(desktop): preserve tree structure in file search results

### DIFF
--- a/apps/desktop/src/renderer/features/cc-agent/workdir-browse/FilterResultList.test.tsx
+++ b/apps/desktop/src/renderer/features/cc-agent/workdir-browse/FilterResultList.test.tsx
@@ -1,0 +1,43 @@
+// @vitest-environment jsdom
+
+import { cleanup, fireEvent, render, screen } from '@testing-library/react';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+vi.mock('react-i18next', () => ({
+  useTranslation: () => ({ t: (key: string) => key }),
+}));
+
+import { FilterResultList } from './FilterResultList';
+
+afterEach(() => cleanup());
+
+describe('FilterResultList', () => {
+  it('expands and collapses matching directories without changing the results', () => {
+    render(
+      <FilterResultList
+        files={['src/index.ts', 'src/lib/readme.md']}
+        truncated={false}
+        isLoading={false}
+        selectedPath={null}
+        onSelectFile={vi.fn()}
+      />,
+    );
+
+    const src = screen.getByRole('button', { name: 'src' });
+    expect(src.getAttribute('aria-expanded')).toBe('true');
+    expect(screen.getByRole('button', { name: 'lib' })).not.toBeNull();
+    expect(screen.getByRole('button', { name: 'readme.md' })).not.toBeNull();
+
+    fireEvent.click(src);
+
+    expect(src.getAttribute('aria-expanded')).toBe('false');
+    expect(screen.queryByRole('button', { name: 'lib' })).toBeNull();
+    expect(screen.queryByRole('button', { name: 'readme.md' })).toBeNull();
+
+    fireEvent.click(src);
+
+    expect(src.getAttribute('aria-expanded')).toBe('true');
+    expect(screen.getByRole('button', { name: 'lib' })).not.toBeNull();
+    expect(screen.getByRole('button', { name: 'readme.md' })).not.toBeNull();
+  });
+});

--- a/apps/desktop/src/renderer/features/cc-agent/workdir-browse/FilterResultList.tsx
+++ b/apps/desktop/src/renderer/features/cc-agent/workdir-browse/FilterResultList.tsx
@@ -1,18 +1,17 @@
 /**
- * FilterResultList —— 文件名筛选结果列表。
+ * FilterResultList —— 文件名筛选结果树。
  *
- * 每行 basename(主) + dirname(副,小一号),点击选中文件触发 onSelectFile。
- * 跟 FileTreeView 同视觉风格(h-28px / rounded-md / hover bg-sidebar-item-hover /
- * selected bg-sidebar-item-active)。
+ * 从扁平索引结果重建最小树，只显示命中文件所需的目录；没有分叉的目录链
+ * 合并为一行路径。这样搜索不会把工作区压成失去层级的文件列表。
  *
  * 抽到 workdir-browse/ 下,RSB plugin 和 doc 模式 sidebar 共用。
  */
 
-import { File as FileIcon } from 'lucide-react';
+import { ChevronDown, File as FileIcon, Folder } from 'lucide-react';
 import { useTranslation } from 'react-i18next';
 
 import { cn } from '@/lib/utils';
-import { FILTER_RESULT_LIMIT } from './lib/filterFiles';
+import { buildFilterTreeRows, FILTER_RESULT_LIMIT } from './lib/filterFiles';
 
 export interface FilterResultListProps {
   files: readonly string[];
@@ -39,6 +38,7 @@ export function FilterResultList({
   onSelectFile,
 }: FilterResultListProps) {
   const { t } = useTranslation();
+  const rows = buildFilterTreeRows(files);
 
   if (isLoading && files.length === 0) {
     return (
@@ -66,31 +66,40 @@ export function FilterResultList({
   return (
     <div className="rsb-fbody-tree-scroll min-h-0 flex-1">
       <div className="flex h-full w-full flex-col gap-px overflow-y-auto py-2">
-        {files.map((relPath) => {
-          const slash = relPath.lastIndexOf('/');
-          const basename = slash < 0 ? relPath : relPath.slice(slash + 1);
-          const dirname = slash < 0 ? '' : relPath.slice(0, slash);
-          const selected = relPath === selectedPath;
+        {rows.map((row) => {
+          const paddingLeft = row.depth * 16 + 8;
+          if (row.kind === 'directory') {
+            return (
+              <div
+                key={`directory:${row.relPath}`}
+                title={row.relPath}
+                className="flex min-w-0 items-center gap-1.5 rounded-md py-1 pr-2 text-left text-sm text-foreground"
+                style={{ paddingLeft }}
+              >
+                <ChevronDown size={14} strokeWidth={1.8} className="shrink-0 text-sidebar-muted" />
+                <Folder size={14} strokeWidth={1.5} className="shrink-0 text-sidebar-muted" />
+                <span className="truncate">{row.label}</span>
+              </div>
+            );
+          }
+
+          const selected = row.relPath === selectedPath;
           return (
             <button
               type="button"
-              key={relPath}
-              onClick={() => onSelectFile(relPath)}
-              title={relPath}
+              key={`file:${row.relPath}`}
+              onClick={() => onSelectFile(row.relPath)}
+              title={row.relPath}
               className={cn(
-                'flex w-full items-center gap-1.5 rounded-md px-2 py-1 text-left text-sm',
+                'flex w-full min-w-0 items-center gap-1.5 rounded-md py-1 pr-2 text-left text-sm',
                 selected
                   ? 'bg-sidebar-item-active font-medium text-sidebar-item-active-foreground'
                   : 'text-foreground hover:bg-sidebar-item-hover',
               )}
+              style={{ paddingLeft }}
             >
               <FileIcon size={14} strokeWidth={1.5} className="shrink-0 text-sidebar-muted" />
-              <span className="flex min-w-0 flex-1 flex-col leading-tight">
-                <span className="truncate">{basename}</span>
-                {dirname && (
-                  <span className="truncate text-10 text-sidebar-muted">{dirname}</span>
-                )}
-              </span>
+              <span className="truncate">{row.label}</span>
             </button>
           );
         })}

--- a/apps/desktop/src/renderer/features/cc-agent/workdir-browse/FilterResultList.tsx
+++ b/apps/desktop/src/renderer/features/cc-agent/workdir-browse/FilterResultList.tsx
@@ -7,7 +7,8 @@
  * 抽到 workdir-browse/ 下,RSB plugin 和 doc 模式 sidebar 共用。
  */
 
-import { ChevronDown, File as FileIcon, Folder } from 'lucide-react';
+import { ChevronDown, ChevronRight, File as FileIcon, Folder } from 'lucide-react';
+import { useState } from 'react';
 import { useTranslation } from 'react-i18next';
 
 import { cn } from '@/lib/utils';
@@ -15,7 +16,7 @@ import { buildFilterTreeRows, FILTER_RESULT_LIMIT } from './lib/filterFiles';
 
 export interface FilterResultListProps {
   files: readonly string[];
-  /** ripgrep cap 截断或前端展示上限截断 —— 显示"结果过多"提示行。 */
+  /** 当前关键词命中超过展示上限 —— 显示"结果过多"提示行。 */
   truncated: boolean;
   /** 首次索引加载中(no cached files yet)。 */
   isLoading: boolean;
@@ -39,6 +40,30 @@ export function FilterResultList({
 }: FilterResultListProps) {
   const { t } = useTranslation();
   const rows = buildFilterTreeRows(files);
+  const [directoryExpansionOverrides, setDirectoryExpansionOverrides] = useState<
+    ReadonlyMap<string, boolean>
+  >(new Map());
+
+  const toggleDirectory = (relPath: string) => {
+    setDirectoryExpansionOverrides((current) => {
+      const next = new Map(current);
+      const expanded = current.get(relPath) ?? true;
+      next.set(relPath, !expanded);
+      return next;
+    });
+  };
+
+  const isDirectoryExpanded = (relPath: string) => directoryExpansionOverrides.get(relPath) ?? true;
+
+  const isHiddenByCollapsedDirectory = (relPath: string) => {
+    return rows.some(
+      (row) =>
+        row.kind === 'directory' &&
+        row.relPath !== relPath &&
+        relPath.startsWith(`${row.relPath}/`) &&
+        !isDirectoryExpanded(row.relPath),
+    );
+  };
 
   if (isLoading && files.length === 0) {
     return (
@@ -67,19 +92,36 @@ export function FilterResultList({
     <div className="rsb-fbody-tree-scroll min-h-0 flex-1">
       <div className="flex h-full w-full flex-col gap-px overflow-y-auto py-2">
         {rows.map((row) => {
+          if (isHiddenByCollapsedDirectory(row.relPath)) return null;
           const paddingLeft = row.depth * 16 + 8;
           if (row.kind === 'directory') {
+            const expanded = isDirectoryExpanded(row.relPath);
             return (
-              <div
+              <button
+                type="button"
                 key={`directory:${row.relPath}`}
+                onClick={() => toggleDirectory(row.relPath)}
+                aria-expanded={expanded}
                 title={row.relPath}
-                className="flex min-w-0 items-center gap-1.5 rounded-md py-1 pr-2 text-left text-sm text-foreground"
+                className="flex w-full min-w-0 items-center gap-1.5 rounded-md py-1 pr-2 text-left text-sm text-foreground hover:bg-sidebar-item-hover"
                 style={{ paddingLeft }}
               >
-                <ChevronDown size={14} strokeWidth={1.8} className="shrink-0 text-sidebar-muted" />
+                {expanded ? (
+                  <ChevronDown
+                    size={14}
+                    strokeWidth={1.8}
+                    className="shrink-0 text-sidebar-muted"
+                  />
+                ) : (
+                  <ChevronRight
+                    size={14}
+                    strokeWidth={1.8}
+                    className="shrink-0 text-sidebar-muted"
+                  />
+                )}
                 <Folder size={14} strokeWidth={1.5} className="shrink-0 text-sidebar-muted" />
                 <span className="truncate">{row.label}</span>
-              </div>
+              </button>
             );
           }
 
@@ -98,6 +140,7 @@ export function FilterResultList({
               )}
               style={{ paddingLeft }}
             >
+              <span aria-hidden="true" className="h-3.5 w-3.5 shrink-0" />
               <FileIcon size={14} strokeWidth={1.5} className="shrink-0 text-sidebar-muted" />
               <span className="truncate">{row.label}</span>
             </button>

--- a/apps/desktop/src/renderer/features/cc-agent/workdir-browse/WorkdirBrowseSidebar.tsx
+++ b/apps/desktop/src/renderer/features/cc-agent/workdir-browse/WorkdirBrowseSidebar.tsx
@@ -23,7 +23,15 @@
 
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { useNavigate, useSearchParams } from 'react-router-dom';
-import { ArrowLeft, Check, ChevronDown, ChevronsDownUp, RefreshCw, Search, X as XIcon } from 'lucide-react';
+import {
+  ArrowLeft,
+  Check,
+  ChevronDown,
+  ChevronsDownUp,
+  RefreshCw,
+  Search,
+  X as XIcon,
+} from 'lucide-react';
 import { useTranslation } from 'react-i18next';
 
 import { cn } from '@/lib/utils';
@@ -47,7 +55,7 @@ import { FileTreeView, type FileTreeViewHandle, type PendingCreate } from './Fil
 import { useRevealFileInTree } from './hooks/useRevealFileInTree';
 import { FileFilterInput } from './FileFilterInput';
 import { FilterResultList } from './FilterResultList';
-import { FILTER_RESULT_LIMIT, filterFiles } from './lib/filterFiles';
+import { filterFilesWithMeta } from './lib/filterFiles';
 import { loadSelectedFile, saveSelectedFile } from './lib/selectedFileStore';
 import { loadExpandedSet, saveExpandedSet } from './lib/expandedStore';
 import { clearFileScroll } from './lib/fileScrollStore';
@@ -181,9 +189,7 @@ export function WorkdirBrowseSidebar({
     const onOpen = () => {
       setMode('search');
       setTimeout(() => {
-        const input = document.querySelector<HTMLInputElement>(
-          'input[data-workdir-search-input]',
-        );
+        const input = document.querySelector<HTMLInputElement>('input[data-workdir-search-input]');
         input?.focus();
         input?.select();
       }, 0);
@@ -217,7 +223,13 @@ export function WorkdirBrowseSidebar({
   // 要递归扫一遍判断 "有没有 doc 文件"(即使 sibling 已经并行,顶层走完一轮
   // 仍然有感知)。先放开让用户看全部文件,等 hasDocDescendant 加缓存或换成
   // 流式增量返回再启用。scanner.ts 的过滤逻辑保留,改回 true 即可恢复。
-  const tree = useFileTree({ workdir, remoteHostId, deviceId, hideMetaFiles: true, docMode: false });
+  const tree = useFileTree({
+    workdir,
+    remoteHostId,
+    deviceId,
+    hideMetaFiles: true,
+    docMode: false,
+  });
 
   // 文件名筛选 query —— tree 模式下用,独立于内容搜索。空 query 显示文件树,有
   // 内容显示筛选结果列表。workdir 切换时自动清空(下方 useEffect)。
@@ -230,8 +242,8 @@ export function WorkdirBrowseSidebar({
   const projectFiles = useProjectFileList(workdir, remoteHostId, deviceId, {
     enabled: filterQuery.trim() !== '',
   });
-  const filteredFiles = useMemo(
-    () => filterFiles(filterQuery, projectFiles.files),
+  const filteredFileResults = useMemo(
+    () => filterFilesWithMeta(filterQuery, projectFiles.files),
     [filterQuery, projectFiles.files],
   );
 
@@ -260,11 +272,7 @@ export function WorkdirBrowseSidebar({
 
   const confirmSwitchAway = useConfirmSwitchAwayIfDirty();
   const currentSelectedFile = searchParams.get('file');
-  const canSwitchProject = hasSwitchableDocModeProject(
-    switchProjects,
-    projectKey,
-    sessionId,
-  );
+  const canSwitchProject = hasSwitchableDocModeProject(switchProjects, projectKey, sessionId);
 
   const handleBack = useCallback(async () => {
     // 离开整个 doc 模式回到 chat 视图。如果当前文件处于 dirty 编辑状态,
@@ -297,10 +305,7 @@ export function WorkdirBrowseSidebar({
       // setSearchParams(updater) form keeps unrelated params if any exist;
       // 但 search/line 是 search panel 跳转专用,从文件树切文件时要清掉,否则
       // 上次跳转过的 highlight 会黏在新文件上。
-      setSearchParams(
-        (prev) => buildNormalFileSelectionParams(prev, relPath),
-        { replace: true },
-      );
+      setSearchParams((prev) => buildNormalFileSelectionParams(prev, relPath), { replace: true });
       // 同步落地到 localStorage,下次切回该 workdir 时自动恢复。
       saveSelectedFile(workdir, relPath);
       // 同步加到 tab 列表。已存在 = 切换已打开文档,保留阅读位置;
@@ -359,10 +364,7 @@ export function WorkdirBrowseSidebar({
     async (relPath: string) => {
       const ok = await confirmSwitchAway(currentSelectedFile, relPath);
       if (!ok) return;
-      setSearchParams(
-        (prev) => buildNormalFileSelectionParams(prev, relPath),
-        { replace: true },
-      );
+      setSearchParams((prev) => buildNormalFileSelectionParams(prev, relPath), { replace: true });
       saveSelectedFile(workdir, relPath);
       const openedNow = storeAddTab(workdir, relPath);
       if (openedNow) clearFileScroll(workdir, relPath);
@@ -413,9 +415,10 @@ export function WorkdirBrowseSidebar({
       const newRel = parentRel === '' ? name : `${parentRel}/${name}`;
       setPendingCreate(null);
       const api = fileBrowserApiFor(deviceId);
-      const res = kind === 'file'
-        ? await api.createFile({ workdir, remoteHostId, relPath: newRel })
-        : await api.createFolder({ workdir, remoteHostId, relPath: newRel });
+      const res =
+        kind === 'file'
+          ? await api.createFile({ workdir, remoteHostId, relPath: newRel })
+          : await api.createFolder({ workdir, remoteHostId, relPath: newRel });
       if (!res.ok) {
         log.warn(`create ${kind} failed`, { newRel, message: res.message });
         toast.error(t('ccAgent.workdirBrowse.createFailed', { message: res.message }));
@@ -481,7 +484,11 @@ export function WorkdirBrowseSidebar({
       const res = await window.electronAPI.showItemInFolder({ filePath: abs });
       if (!res.success) {
         log.warn('reveal in folder failed', { relPath: entry.relPath, error: res.error });
-        toast.error(t('ccAgent.workdirBrowse.revealFailed', { error: res.error ?? t('ccAgent.common.unknownError') }));
+        toast.error(
+          t('ccAgent.workdirBrowse.revealFailed', {
+            error: res.error ?? t('ccAgent.common.unknownError'),
+          }),
+        );
       }
     },
     [workdir, t],
@@ -545,9 +552,7 @@ export function WorkdirBrowseSidebar({
   //     v1 接受;chokidar add/unlink 会自然刷父目录 listing。
   const handleRenameSubmit = useCallback(
     async (newName: string) => {
-      const entry = renamingPath
-        ? findEntryByRelPath(tree.entries, renamingPath)
-        : null;
+      const entry = renamingPath ? findEntryByRelPath(tree.entries, renamingPath) : null;
       if (!renamingPath || !entry) {
         setRenamingPath(null);
         return;
@@ -585,13 +590,10 @@ export function WorkdirBrowseSidebar({
 
       // 当前 active 文件命中 → 重新指向新路径。
       const isActiveHit =
-        selectedPath !== null &&
-        (selectedPath === oldRel || selectedPath.startsWith(`${oldRel}/`));
+        selectedPath !== null && (selectedPath === oldRel || selectedPath.startsWith(`${oldRel}/`));
       if (isActiveHit) {
         const newSelected =
-          selectedPath === oldRel
-            ? newRel
-            : `${newRel}/${selectedPath.slice(oldRel.length + 1)}`;
+          selectedPath === oldRel ? newRel : `${newRel}/${selectedPath.slice(oldRel.length + 1)}`;
         saveSelectedFile(workdir, newSelected);
         setSearchParams(
           (prev) => {
@@ -674,10 +676,10 @@ export function WorkdirBrowseSidebar({
       <div className="flex items-center justify-between pt-2 pb-1 pl-6 pr-3">
         {mode === 'search' ? (
           <div className="flex min-w-0 items-center gap-2">
-            <span className="text-sm font-semibold text-foreground">{t('ccAgent.workdirBrowse.searchPanel.headingSearch')}</span>
-            <span className="min-w-0 truncate text-11 text-sidebar-muted">
-              {displayName}
+            <span className="text-sm font-semibold text-foreground">
+              {t('ccAgent.workdirBrowse.searchPanel.headingSearch')}
             </span>
+            <span className="min-w-0 truncate text-11 text-sidebar-muted">{displayName}</span>
           </div>
         ) : canSwitchProject ? (
           <DropdownMenu>
@@ -694,7 +696,11 @@ export function WorkdirBrowseSidebar({
                   )}
                 >
                   <span className="min-w-0 truncate">{displayName}</span>
-                  <ChevronDown size={14} strokeWidth={2} className="shrink-0 text-sidebar-action-icon" />
+                  <ChevronDown
+                    size={14}
+                    strokeWidth={2}
+                    className="shrink-0 text-sidebar-action-icon"
+                  />
                 </button>
               </Tip>
             </DropdownMenuTrigger>
@@ -722,16 +728,16 @@ export function WorkdirBrowseSidebar({
                         count: project.activeSessionCount,
                       })}
                     </span>
-                    {active && <Check size={14} strokeWidth={2} className="ml-2 shrink-0 text-foreground" />}
+                    {active && (
+                      <Check size={14} strokeWidth={2} className="ml-2 shrink-0 text-foreground" />
+                    )}
                   </DropdownMenuItem>
                 );
               })}
             </DropdownMenuContent>
           </DropdownMenu>
         ) : (
-          <span className="truncate text-sm font-semibold text-foreground">
-            {displayName}
-          </span>
+          <span className="truncate text-sm font-semibold text-foreground">{displayName}</span>
         )}
         <div className="flex shrink-0 items-center gap-1.5">
           {mode === 'search' ? (
@@ -795,10 +801,8 @@ export function WorkdirBrowseSidebar({
           <FileFilterInput value={filterQuery} onChange={setFilterQuery} />
           {filterQuery ? (
             <FilterResultList
-              files={filteredFiles}
-              truncated={
-                projectFiles.truncated || filteredFiles.length >= FILTER_RESULT_LIMIT
-              }
+              files={filteredFileResults.files}
+              truncated={filteredFileResults.truncated}
               isLoading={projectFiles.isLoading}
               indexError={projectFiles.error}
               selectedPath={selectedPath}
@@ -815,7 +819,9 @@ export function WorkdirBrowseSidebar({
               onDeleteFile={handleDeleteFile}
               onCopyFilePath={handleCopyFilePath}
               onRevealInFolder={remoteHostId || deviceId ? undefined : handleRevealInFolder}
-              onOpenInSidebarBrowser={remoteHostId || deviceId ? undefined : handleOpenInSidebarBrowser}
+              onOpenInSidebarBrowser={
+                remoteHostId || deviceId ? undefined : handleOpenInSidebarBrowser
+              }
               onOpenInBrowser={remoteHostId || deviceId ? undefined : handleOpenInBrowser}
               onRename={handleRename}
               pendingCreate={pendingCreate}

--- a/apps/desktop/src/renderer/features/cc-agent/workdir-browse/lib/filterFiles.test.ts
+++ b/apps/desktop/src/renderer/features/cc-agent/workdir-browse/lib/filterFiles.test.ts
@@ -1,0 +1,37 @@
+import { describe, expect, it } from 'vitest';
+
+import { buildFilterTreeRows } from './filterFiles';
+
+describe('buildFilterTreeRows', () => {
+  it('keeps matching folders and files in tree order', () => {
+    expect(buildFilterTreeRows([
+      'benchmarks/README.md',
+      'desktop/frontend/src/components/ReadOnlyBatch.tsx',
+      'desktop/README.md',
+      'internal/acp/readiness_gate_test.go',
+      'internal/agent/read_delivery.go',
+    ])).toEqual([
+      { kind: 'directory', relPath: 'benchmarks', label: 'benchmarks', depth: 0 },
+      { kind: 'file', relPath: 'benchmarks/README.md', label: 'README.md', depth: 1 },
+      { kind: 'directory', relPath: 'desktop', label: 'desktop', depth: 0 },
+      { kind: 'directory', relPath: 'desktop/frontend/src/components', label: 'frontend / src / components', depth: 1 },
+      { kind: 'file', relPath: 'desktop/frontend/src/components/ReadOnlyBatch.tsx', label: 'ReadOnlyBatch.tsx', depth: 2 },
+      { kind: 'file', relPath: 'desktop/README.md', label: 'README.md', depth: 1 },
+      { kind: 'directory', relPath: 'internal', label: 'internal', depth: 0 },
+      { kind: 'directory', relPath: 'internal/acp', label: 'acp', depth: 1 },
+      { kind: 'file', relPath: 'internal/acp/readiness_gate_test.go', label: 'readiness_gate_test.go', depth: 2 },
+      { kind: 'directory', relPath: 'internal/agent', label: 'agent', depth: 1 },
+      { kind: 'file', relPath: 'internal/agent/read_delivery.go', label: 'read_delivery.go', depth: 2 },
+    ]);
+  });
+
+  it('does not lose root files or direct files beside a directory chain', () => {
+    expect(buildFilterTreeRows(['README.md', 'src/index.ts', 'src/lib/readme.md'])).toEqual([
+      { kind: 'directory', relPath: 'src', label: 'src', depth: 0 },
+      { kind: 'directory', relPath: 'src/lib', label: 'lib', depth: 1 },
+      { kind: 'file', relPath: 'src/lib/readme.md', label: 'readme.md', depth: 2 },
+      { kind: 'file', relPath: 'src/index.ts', label: 'index.ts', depth: 1 },
+      { kind: 'file', relPath: 'README.md', label: 'README.md', depth: 0 },
+    ]);
+  });
+});

--- a/apps/desktop/src/renderer/features/cc-agent/workdir-browse/lib/filterFiles.test.ts
+++ b/apps/desktop/src/renderer/features/cc-agent/workdir-browse/lib/filterFiles.test.ts
@@ -1,27 +1,61 @@
 import { describe, expect, it } from 'vitest';
 
-import { buildFilterTreeRows } from './filterFiles';
+import { buildFilterTreeRows, filterFilesWithMeta } from './filterFiles';
+
+describe('filterFilesWithMeta', () => {
+  it('only marks results as truncated when there is a match beyond the limit', () => {
+    const files = Array.from({ length: 200 }, (_, index) => `src/file-${index}.ts`);
+
+    expect(filterFilesWithMeta('file', files)).toEqual({ files, truncated: false });
+    expect(filterFilesWithMeta('file', [...files, 'src/file-200.ts'])).toEqual({
+      files,
+      truncated: true,
+    });
+  });
+});
 
 describe('buildFilterTreeRows', () => {
   it('keeps matching folders and files in tree order', () => {
-    expect(buildFilterTreeRows([
-      'benchmarks/README.md',
-      'desktop/frontend/src/components/ReadOnlyBatch.tsx',
-      'desktop/README.md',
-      'internal/acp/readiness_gate_test.go',
-      'internal/agent/read_delivery.go',
-    ])).toEqual([
+    expect(
+      buildFilterTreeRows([
+        'benchmarks/README.md',
+        'desktop/frontend/src/components/ReadOnlyBatch.tsx',
+        'desktop/README.md',
+        'internal/acp/readiness_gate_test.go',
+        'internal/agent/read_delivery.go',
+      ]),
+    ).toEqual([
       { kind: 'directory', relPath: 'benchmarks', label: 'benchmarks', depth: 0 },
       { kind: 'file', relPath: 'benchmarks/README.md', label: 'README.md', depth: 1 },
       { kind: 'directory', relPath: 'desktop', label: 'desktop', depth: 0 },
-      { kind: 'directory', relPath: 'desktop/frontend/src/components', label: 'frontend / src / components', depth: 1 },
-      { kind: 'file', relPath: 'desktop/frontend/src/components/ReadOnlyBatch.tsx', label: 'ReadOnlyBatch.tsx', depth: 2 },
+      {
+        kind: 'directory',
+        relPath: 'desktop/frontend/src/components',
+        label: 'frontend / src / components',
+        depth: 1,
+      },
+      {
+        kind: 'file',
+        relPath: 'desktop/frontend/src/components/ReadOnlyBatch.tsx',
+        label: 'ReadOnlyBatch.tsx',
+        depth: 2,
+      },
       { kind: 'file', relPath: 'desktop/README.md', label: 'README.md', depth: 1 },
       { kind: 'directory', relPath: 'internal', label: 'internal', depth: 0 },
       { kind: 'directory', relPath: 'internal/acp', label: 'acp', depth: 1 },
-      { kind: 'file', relPath: 'internal/acp/readiness_gate_test.go', label: 'readiness_gate_test.go', depth: 2 },
+      {
+        kind: 'file',
+        relPath: 'internal/acp/readiness_gate_test.go',
+        label: 'readiness_gate_test.go',
+        depth: 2,
+      },
       { kind: 'directory', relPath: 'internal/agent', label: 'agent', depth: 1 },
-      { kind: 'file', relPath: 'internal/agent/read_delivery.go', label: 'read_delivery.go', depth: 2 },
+      {
+        kind: 'file',
+        relPath: 'internal/agent/read_delivery.go',
+        label: 'read_delivery.go',
+        depth: 2,
+      },
     ]);
   });
 

--- a/apps/desktop/src/renderer/features/cc-agent/workdir-browse/lib/filterFiles.ts
+++ b/apps/desktop/src/renderer/features/cc-agent/workdir-browse/lib/filterFiles.ts
@@ -16,6 +16,11 @@
 /** 文件名筛选结果展示上限。匹配再多也只渲染前 N 条,避免列表爆 + 用户分不清重点。 */
 export const FILTER_RESULT_LIMIT = 200;
 
+export interface FilterFileResults {
+  files: string[];
+  truncated: boolean;
+}
+
 export interface FilterTreeRow {
   kind: 'directory' | 'file';
   /** The complete workdir-relative POSIX path represented by this row. */
@@ -30,20 +35,33 @@ export function filterFiles(
   files: readonly string[],
   limit = FILTER_RESULT_LIMIT,
 ): string[] {
+  return filterFilesWithMeta(query, files, limit).files;
+}
+
+export function filterFilesWithMeta(
+  query: string,
+  files: readonly string[],
+  limit = FILTER_RESULT_LIMIT,
+): FilterFileResults {
   const q = query.trim().toLowerCase();
-  if (!q) return [];
+  if (!q) return { files: [], truncated: false };
   const basenameMatches: string[] = [];
   const pathMatches: string[] = [];
+  let matchCount = 0;
   for (const f of files) {
     const lower = f.toLowerCase();
     if (!lower.includes(q)) continue;
+    matchCount += 1;
+    if (matchCount > limit) break;
     const slash = lower.lastIndexOf('/');
     const basename = slash < 0 ? lower : lower.slice(slash + 1);
     if (basename.includes(q)) basenameMatches.push(f);
     else pathMatches.push(f);
-    if (basenameMatches.length + pathMatches.length >= limit) break;
   }
-  return [...basenameMatches, ...pathMatches];
+  return {
+    files: [...basenameMatches, ...pathMatches],
+    truncated: matchCount > limit,
+  };
 }
 
 interface FilterTreeNode {
@@ -88,7 +106,12 @@ export function buildFilterTreeRows(files: readonly string[]): FilterTreeRow[] {
         compacted = onlyChild;
         labels.push(compacted.name);
       }
-      rows.push({ kind: 'directory', relPath: compacted.relPath, label: labels.join(' / '), depth });
+      rows.push({
+        kind: 'directory',
+        relPath: compacted.relPath,
+        label: labels.join(' / '),
+        depth,
+      });
       visit(compacted, depth + 1);
     }
     for (const file of node.files) {

--- a/apps/desktop/src/renderer/features/cc-agent/workdir-browse/lib/filterFiles.ts
+++ b/apps/desktop/src/renderer/features/cc-agent/workdir-browse/lib/filterFiles.ts
@@ -16,6 +16,15 @@
 /** 文件名筛选结果展示上限。匹配再多也只渲染前 N 条,避免列表爆 + 用户分不清重点。 */
 export const FILTER_RESULT_LIMIT = 200;
 
+export interface FilterTreeRow {
+  kind: 'directory' | 'file';
+  /** The complete workdir-relative POSIX path represented by this row. */
+  relPath: string;
+  /** The visible path segment(s); directory chains may be compacted here. */
+  label: string;
+  depth: number;
+}
+
 export function filterFiles(
   query: string,
   files: readonly string[],
@@ -35,4 +44,63 @@ export function filterFiles(
     if (basenameMatches.length + pathMatches.length >= limit) break;
   }
   return [...basenameMatches, ...pathMatches];
+}
+
+interface FilterTreeNode {
+  name: string;
+  relPath: string;
+  directories: Map<string, FilterTreeNode>;
+  files: string[];
+}
+
+/**
+ * Turn flat filename matches into the smallest useful tree for search.
+ * A directory chain is compacted only while it has one directory child and no
+ * direct matching files, preserving both hierarchy and useful path context.
+ */
+export function buildFilterTreeRows(files: readonly string[]): FilterTreeRow[] {
+  const root: FilterTreeNode = { name: '', relPath: '', directories: new Map(), files: [] };
+
+  for (const file of files) {
+    const segments = file.split('/').filter(Boolean);
+    if (segments.length === 0) continue;
+    let node = root;
+    for (const segment of segments.slice(0, -1)) {
+      const relPath = node.relPath ? `${node.relPath}/${segment}` : segment;
+      let child = node.directories.get(segment);
+      if (!child) {
+        child = { name: segment, relPath, directories: new Map(), files: [] };
+        node.directories.set(segment, child);
+      }
+      node = child;
+    }
+    node.files.push(segments[segments.length - 1]);
+  }
+
+  const rows: FilterTreeRow[] = [];
+  const visit = (node: FilterTreeNode, depth: number) => {
+    for (const directory of node.directories.values()) {
+      let compacted = directory;
+      const labels = [directory.name];
+      while (compacted.files.length === 0 && compacted.directories.size === 1) {
+        const onlyChild = compacted.directories.values().next().value as FilterTreeNode | undefined;
+        if (!onlyChild) break;
+        compacted = onlyChild;
+        labels.push(compacted.name);
+      }
+      rows.push({ kind: 'directory', relPath: compacted.relPath, label: labels.join(' / '), depth });
+      visit(compacted, depth + 1);
+    }
+    for (const file of node.files) {
+      rows.push({
+        kind: 'file',
+        relPath: node.relPath ? `${node.relPath}/${file}` : file,
+        label: file,
+        depth,
+      });
+    }
+  };
+
+  visit(root, 0);
+  return rows;
 }

--- a/apps/desktop/src/renderer/features/right-sidebar/plugins/file-browser/FileBrowserBody.tsx
+++ b/apps/desktop/src/renderer/features/right-sidebar/plugins/file-browser/FileBrowserBody.tsx
@@ -28,7 +28,15 @@
  * singleton 拿当前 dirty 状态,跟 doc 模式行为一致。
  */
 
-import { useCallback, useEffect, useMemo, useRef, useState, useSyncExternalStore, type DragEvent } from 'react';
+import {
+  useCallback,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+  useSyncExternalStore,
+  type DragEvent,
+} from 'react';
 import { useTranslation } from 'react-i18next';
 import { ChevronsDownUp, FolderX, RefreshCw, Search, X as XIcon } from 'lucide-react';
 
@@ -48,10 +56,7 @@ import {
   type FileTreeViewHandle,
 } from '@/features/cc-agent/workdir-browse/FileTreeView';
 import { FileBodyView } from '@/features/cc-agent/workdir-browse/FileBodyView';
-import {
-  useFileTree,
-  type DirEntry,
-} from '@/features/cc-agent/workdir-browse/hooks/useFileTree';
+import { useFileTree, type DirEntry } from '@/features/cc-agent/workdir-browse/hooks/useFileTree';
 import { useFileContent } from '@/features/cc-agent/workdir-browse/hooks/useFileContent';
 import { useConfirmSwitchAwayIfDirty } from '@/features/cc-agent/workdir-browse/hooks/useConfirmSwitchAwayIfDirty';
 import { useProjectFileList } from '@/features/cc-agent/workdir-browse/hooks/useProjectFileList';
@@ -60,10 +65,7 @@ import { SearchPanel } from '@/features/cc-agent/workdir-browse/search/SearchPan
 import { useProjectSearch } from '@/features/cc-agent/workdir-browse/search/hooks/useProjectSearch';
 import { FileFilterInput } from '@/features/cc-agent/workdir-browse/FileFilterInput';
 import { FilterResultList } from '@/features/cc-agent/workdir-browse/FilterResultList';
-import {
-  FILTER_RESULT_LIMIT,
-  filterFiles,
-} from '@/features/cc-agent/workdir-browse/lib/filterFiles';
+import { filterFilesWithMeta } from '@/features/cc-agent/workdir-browse/lib/filterFiles';
 import { toOsAbsolutePath } from '@/features/cc-agent/workdir-browse/lib/fileMeta';
 import {
   openUrlInSidebarBrowser,
@@ -133,7 +135,7 @@ function FileBrowserBodyWithWorkdir({
   // remoteHostId)时 deviceId 优先——SSH 二跳由被控端 device-op 处理,控制端
   // 不能把被控端的 hostId 发给自己的 main。
   const deviceId = useSyncExternalStore(remoteProjectsStore.subscribe, () =>
-    ctx.sessionId ? getSessionDeviceId(ctx.sessionId) ?? null : null,
+    ctx.sessionId ? (getSessionDeviceId(ctx.sessionId) ?? null) : null,
   );
   const remoteHostId = deviceId ? null : ctx.remoteHostId;
   const isRemote = Boolean(remoteHostId) || Boolean(deviceId);
@@ -141,7 +143,10 @@ function FileBrowserBodyWithWorkdir({
   const fileContent = useFileContent(workdir, state.selectedFilePath, remoteHostId, deviceId);
   const [externalFile, setExternalFile] = useState<ExternalFileSelection | null>(null);
   const [imageLightboxSrc, setImageLightboxSrc] = useState<string | null>(null);
-  const externalFileContent = useFileContent(externalFile?.workdir ?? workdir, externalFile?.relPath ?? null);
+  const externalFileContent = useFileContent(
+    externalFile?.workdir ?? workdir,
+    externalFile?.relPath ?? null,
+  );
   const fileDragDepthRef = useRef(0);
   const [isDraggingFile, setIsDraggingFile] = useState(false);
   const confirmSwitchAway = useConfirmSwitchAwayIfDirty();
@@ -163,8 +168,8 @@ function FileBrowserBodyWithWorkdir({
   const projectFiles = useProjectFileList(workdir, remoteHostId, deviceId, {
     enabled: filterQuery.trim() !== '',
   });
-  const filteredFiles = useMemo(
-    () => filterFiles(filterQuery, projectFiles.files),
+  const filteredFileResults = useMemo(
+    () => filterFilesWithMeta(filterQuery, projectFiles.files),
     [filterQuery, projectFiles.files],
   );
   const search = useProjectSearch({
@@ -356,7 +361,11 @@ function FileBrowserBodyWithWorkdir({
       const abs = toOsAbsolutePath(workdir, entry.relPath);
       const res = await window.electronAPI.showItemInFolder({ filePath: abs });
       if (!res.success) {
-        toast.error(t('ccAgent.workdirBrowse.revealFailed', { error: res.error ?? t('ccAgent.common.unknownError') }));
+        toast.error(
+          t('ccAgent.workdirBrowse.revealFailed', {
+            error: res.error ?? t('ccAgent.common.unknownError'),
+          }),
+        );
       }
     },
     [workdir, t],
@@ -654,11 +663,8 @@ function FileBrowserBodyWithWorkdir({
           <FileFilterInput value={filterQuery} onChange={setFilterQuery} />
           {filterQuery ? (
             <FilterResultList
-              files={filteredFiles}
-              truncated={
-                // ripgrep cap 截断,或者前端展示上限截断(命中超过 FILTER_RESULT_LIMIT)
-                projectFiles.truncated || filteredFiles.length >= FILTER_RESULT_LIMIT
-              }
+              files={filteredFileResults.files}
+              truncated={filteredFileResults.truncated}
               isLoading={projectFiles.isLoading}
               indexError={projectFiles.error}
               selectedPath={state.selectedFilePath}
@@ -677,7 +683,9 @@ function FileBrowserBodyWithWorkdir({
                 onCopyFilePath={!isRemote ? handleCopyFilePath : undefined}
                 onRevealInFolder={!isRemote ? handleRevealInFolder : undefined}
                 onOpenInFileBrowser={ctx.sessionId ? handleOpenInFileBrowser : undefined}
-                onOpenInSidebarBrowser={!isRemote && ctx.sessionId ? handleOpenInSidebarBrowser : undefined}
+                onOpenInSidebarBrowser={
+                  !isRemote && ctx.sessionId ? handleOpenInSidebarBrowser : undefined
+                }
                 onOpenInBrowser={!isRemote ? handleOpenInBrowser : undefined}
               />
             </div>


### PR DESCRIPTION
## 这次改了什么

### 摘要

搜索文件时保留目录层级，以最小树形结构展示命中的文件；单链目录自动合并为一行路径，避免搜索结果被拍平成列表。同时修正文件筛选截断状态提示。

### 变更类型

- [x] `feat` 新功能
- [x] `fix` 缺陷修复
- [ ] `refactor` / `perf`
- [ ] `docs` / `test` / `chore`

### 范围

- 关联 PR：暂无
- 本 PR 包含：搜索结果树形展示、目录链压缩、相关单元测试及文件筛选截断状态的准确提示。
- 明确不包含：点击文件后保留搜索结果并继续查看其他文件（见独立 PR）。
- 用户可见变化：搜索结果按目录层级展示，点击文件可打开文件。
- 是否存在 breaking change：无

## UI 变化

- 引用的设计规范：`docs/design-rules/DESIGN.md` §5（层级、间距、语义颜色）；复用现有 sidebar 语义 token 与文件树视觉约束，目录行与文件行保持一致的缩进体系。
- 截图/录屏：已在原 PR 中说明。

## 怎么验证的

### 自动验证

```text
pnpm test:unit:related
结果：已执行；当前工作区存在一个与本 PR 无关的既有 DCO hook 测试失败。

pnpm --filter desktop run --if-present typecheck
结果：当前仓库存在与本 PR 无关的 DSH AgentKind 类型错误。

git diff --check
结果：通过。
```

### 手工验证

已在 macOS Desktop 开发环境中验证搜索结果展示和文件点击行为。

### 未执行的验证

无。

## 风险

### 风险分类

- [x] 无已知风险

### 影响与回滚

- 影响范围：Desktop 文件浏览器搜索结果展示。
- 回滚 / 降级方式：回退本 PR commits 即可恢复原有扁平搜索结果展示。

### 提交前检查

- [x] 已 review 完整 diff
- [x] 每个 commit 都带 DCO 签名
- [x] UI 改动已注明设计规范章节
- [x] 未提交凭证、令牌或授权文件
- [x] 已确认测试结果或说明未执行原因