### PR TITLE
fix(chat): 交互边界 flush 后同源 isFinal 不再落第二行

### DIFF
--- a/apps/desktop/src/main/__tests__/messagePersistBroadcaster.test.ts
+++ b/apps/desktop/src/main/__tests__/messagePersistBroadcaster.test.ts
@@ -2406,6 +2406,53 @@ describe('assistant isFinal burst DUP-SKIP(P1:main 对称去重,防重复 isFina
     expect(assistantCreates[0]?.[1]).toEqual(
       expect.objectContaining({ clientId: persistId, content: '选哪个?' }),
     );
+    // message_end 才带来的终态 meta 必须合并回被复用的行,不能因复用而丢失。
+    expect(patchMessageAgentMetaWithResult).toHaveBeenCalledWith(
+      SESSION,
+      persistId,
+      expect.objectContaining({ model: 'pi-test', stopReason: 'toolUse' }),
+    );
+    expect(broadcastMessageAgentMetaUpdate).toHaveBeenCalledWith(
+      SESSION,
+      persistId,
+      expect.anything(),
+    );
+  });
+
+  it('边界后落过别的消息(tool_use)时同文本快照不复用,仍单独落行', async () => {
+    const persistId = onAssistantTextEvent(SESSION, { text: 'Done.', isFinal: false }, null);
+    flushAssistantBlock(SESSION, null);
+    onToolUseEvent(SESSION, { toolUseId: 'tu_between', toolName: 'Edit', input: {} }, null);
+    const lateFinalId = onAssistantTextEvent(
+      SESSION,
+      { text: 'Done.', isFinal: true, isFullText: true },
+      null,
+    );
+    // 上一条已落库消息不是交互行 → 复用窗口已关闭,不能吞这条合法消息。
+    expect(lateFinalId).not.toBe(persistId);
+    await flushWrites();
+    const assistantCreates = vi.mocked(createMessage).mock.calls
+      .filter(([, message]) => message.role === 'assistant');
+    expect(assistantCreates).toHaveLength(2);
+  });
+
+  it('交互被回答后同文本快照不复用(复用窗口随交互结束关闭)', async () => {
+    const persistId = onAssistantTextEvent(SESSION, { text: '同一句话', isFinal: false }, null);
+    flushAssistantBlock(SESSION, null);
+    const request = { kind: 'ask_user_question' as const, requestId: 'req-reuse-window', questions: [{ question: '同一句话' }] };
+    const askId = onInteractionMessage(SESSION, request);
+    expect(askId).toBeTruthy();
+    onInteractionResolved(SESSION, askId, 'ask_user_question', request, { answers: { '同一句话': '答' } });
+    const lateFinalId = onAssistantTextEvent(
+      SESSION,
+      { text: '同一句话', isFinal: true, isFullText: true },
+      null,
+    );
+    expect(lateFinalId).not.toBe(persistId);
+    await flushWrites();
+    const assistantCreates = vi.mocked(createMessage).mock.calls
+      .filter(([, message]) => message.role === 'assistant');
+    expect(assistantCreates).toHaveLength(2);
   });
 
   it('交互边界 flush 后,不同 SDK 消息的同文本快照仍单独落行(身份不同不吞)', async () => {

--- a/apps/desktop/src/main/__tests__/messagePersistBroadcaster.test.ts
+++ b/apps/desktop/src/main/__tests__/messagePersistBroadcaster.test.ts
@@ -2485,6 +2485,27 @@ describe('assistant isFinal burst DUP-SKIP(P1:main 对称去重,防重复 isFina
     );
   });
 
+  it('边界复用窗口内同一份终态快照重复投递两次 → 仍只落一行、复用同一 persistId', async () => {
+    const persistId = onAssistantTextEvent(SESSION, { text: '选哪个?', isFinal: false }, null);
+    flushAssistantBlock(SESSION, null);
+    onInteractionMessage(SESSION, {
+      kind: 'ask_user_question',
+      requestId: 'req-repeat-final',
+      questions: [{ question: '选哪个?' }],
+    });
+    const meta = { model: 'pi-test', stopReason: 'toolUse', usage: {} };
+    const first = onAssistantTextEvent(SESSION, { text: '选哪个?', isFinal: true, isFullText: true }, meta);
+    const second = onAssistantTextEvent(SESSION, { text: '选哪个?', isFinal: true, isFullText: true }, meta);
+    // 上一条已落库消息是交互行 → 相邻 DUP-SKIP 看不到已落库的 assistant 行;
+    // 复用记录不能在第一次命中时就消费掉,否则第二次投递会另起一行。
+    expect(first).toBe(persistId);
+    expect(second).toBe(persistId);
+    await flushWrites();
+    const assistantCreates = vi.mocked(createMessage).mock.calls
+      .filter(([, message]) => message.role === 'assistant');
+    expect(assistantCreates).toHaveLength(1);
+  });
+
   it('交互边界 flush 后,不同 SDK 消息的同文本快照仍单独落行(身份不同不吞)', async () => {
     const firstId = onAssistantTextEvent(SESSION, { text: '选哪个?', isFinal: false }, null);
     flushAssistantBlock(SESSION, null);

--- a/apps/desktop/src/main/__tests__/messagePersistBroadcaster.test.ts
+++ b/apps/desktop/src/main/__tests__/messagePersistBroadcaster.test.ts
@@ -2419,6 +2419,29 @@ describe('assistant isFinal burst DUP-SKIP(P1:main 对称去重,防重复 isFina
     );
   });
 
+  it('边界 flush 只攒到部分文本时,终态全文更新既有行而不是另起一行', async () => {
+    const persistId = onAssistantTextEvent(SESSION, { text: '选哪个', isFinal: false }, null);
+    flushAssistantBlock(SESSION, null);
+    onInteractionMessage(SESSION, {
+      kind: 'ask_user_question',
+      requestId: 'req-partial-flush',
+      questions: [{ question: '选哪个?' }],
+    });
+    // message_end 是权威全文,与已 flush 的部分文本不完全相等。
+    const lateFinalId = onAssistantTextEvent(
+      SESSION,
+      { text: '选哪个?', isFinal: true, isFullText: true },
+      { model: 'pi-test', stopReason: 'toolUse', usage: {} },
+    );
+    expect(lateFinalId).toBe(persistId);
+    await flushWrites();
+    expect(updateMessageContent).toHaveBeenCalledWith(SESSION, persistId, '选哪个?');
+    expect(broadcastMessageRow).toHaveBeenCalled();
+    const assistantCreates = vi.mocked(createMessage).mock.calls
+      .filter(([, message]) => message.role === 'assistant');
+    expect(assistantCreates).toHaveLength(1);
+  });
+
   it('边界后落过别的消息(tool_use)时同文本快照不复用,仍单独落行', async () => {
     const persistId = onAssistantTextEvent(SESSION, { text: 'Done.', isFinal: false }, null);
     flushAssistantBlock(SESSION, null);

--- a/apps/desktop/src/main/__tests__/messagePersistBroadcaster.test.ts
+++ b/apps/desktop/src/main/__tests__/messagePersistBroadcaster.test.ts
@@ -2459,6 +2459,32 @@ describe('assistant isFinal burst DUP-SKIP(P1:main 对称去重,防重复 isFina
     expect(assistantCreates).toHaveLength(2);
   });
 
+  it('tool_use 边界留下的记录不会被随后到达的交互行重新激活(陈旧候选不上身)', async () => {
+    // 1) assistant 文本在普通 tool_use 边界 flush(不是交互边界)。
+    const earlyId = onAssistantTextEvent(SESSION, { text: '早些时候的回复', isFinal: false }, null);
+    flushAssistantBlock(SESSION, null);
+    onToolUseEvent(SESSION, { toolUseId: 'tu_early', toolName: 'Edit', input: {} }, null);
+    // 2) 随后到来的 ask_user 前没有新的文本 block:交互行落库,旧记录不得被角色激活。
+    onInteractionMessage(SESSION, {
+      kind: 'ask_user_question',
+      requestId: 'req-stale-candidate',
+      questions: [{ question: '继续吗?' }],
+    });
+    // 3) 当前这条 assistant 消息的权威终态全文(无 agentMessageId,只有 isFullText)。
+    const currentId = onAssistantTextEvent(
+      SESSION,
+      { text: '继续吗?', isFinal: true, isFullText: true },
+      { model: 'pi-test', stopReason: 'toolUse', usage: {} },
+    );
+    // 必须另起一行:不能把当前全文写到更早那条上(内容/meta 都被覆盖)。
+    expect(currentId).not.toBe(earlyId);
+    await flushWrites();
+    expect(updateMessageContent).not.toHaveBeenCalledWith(SESSION, earlyId, '继续吗?');
+    const assistantCreates = vi.mocked(createMessage).mock.calls
+      .filter(([, message]) => message.role === 'assistant');
+    expect(assistantCreates).toHaveLength(2);
+  });
+
   it('交互被回答后迟到的同源终态全文仍复用该行(resolution 不作废复用窗口)', async () => {
     const persistId = onAssistantTextEvent(SESSION, { text: '同一句话', isFinal: false }, null);
     flushAssistantBlock(SESSION, null);

--- a/apps/desktop/src/main/__tests__/messagePersistBroadcaster.test.ts
+++ b/apps/desktop/src/main/__tests__/messagePersistBroadcaster.test.ts
@@ -2382,6 +2382,52 @@ describe('assistant isFinal burst DUP-SKIP(P1:main 对称去重,防重复 isFina
     expect(assistantCreates).toHaveLength(2);
   });
 
+  it('交互边界 flush 后,同源 isFinal 全文快照复用已落库行(ask_user 行打断相邻守卫)', async () => {
+    const persistId = onAssistantTextEvent(SESSION, { text: '选哪个?', isFinal: false }, null);
+    // 交互边界:先 flush 在飞 assistant,再落 ask_user 行(会把 lastPersistedMsgBySession
+    // 刷成非 assistant,使相邻 DUP-SKIP 失效)。
+    flushAssistantBlock(SESSION, null);
+    onInteractionMessage(SESSION, {
+      kind: 'ask_user_question',
+      requestId: 'req-dup-after-flush',
+      questions: [{ question: '选哪个?' }],
+    });
+    // 随后 message_end 的权威全文快照(带 usage meta)到达 —— 必须复用同一行。
+    const lateFinalId = onAssistantTextEvent(
+      SESSION,
+      { text: '选哪个?', isFinal: true, isFullText: true },
+      { model: 'pi-test', stopReason: 'toolUse', usage: {} },
+    );
+    expect(lateFinalId).toBe(persistId);
+    await flushWrites();
+    const assistantCreates = vi.mocked(createMessage).mock.calls
+      .filter(([, message]) => message.role === 'assistant');
+    expect(assistantCreates).toHaveLength(1);
+    expect(assistantCreates[0]?.[1]).toEqual(
+      expect.objectContaining({ clientId: persistId, content: '选哪个?' }),
+    );
+  });
+
+  it('交互边界 flush 后,不同 SDK 消息的同文本快照仍单独落行(身份不同不吞)', async () => {
+    const firstId = onAssistantTextEvent(SESSION, { text: '选哪个?', isFinal: false }, null);
+    flushAssistantBlock(SESSION, null);
+    onInteractionMessage(SESSION, {
+      kind: 'ask_user_question',
+      requestId: 'req-dup-distinct',
+      questions: [{ question: '选哪个?' }],
+    });
+    const secondId = onAssistantTextEvent(
+      SESSION,
+      { text: '选哪个?', isFinal: true, isFullText: true, agentMessageId: 'msg-second' },
+      null,
+    );
+    expect(secondId).not.toBe(firstId);
+    await flushWrites();
+    const assistantCreates = vi.mocked(createMessage).mock.calls
+      .filter(([, message]) => message.role === 'assistant');
+    expect(assistantCreates).toHaveLength(2);
+  });
+
   it('P1b:跨 turn(reset 之后)同内容 burst 不去重 → 两次 create、不丢消息', async () => {
     // turn1 非流式 burst "X";turn 结束 reset(用户消息走 renderer、不更新 main tracker,
     // 故必须靠 reset 清 tracker,否则 turn2 同内容 burst 会被误判重复跳 create → 丢回复)。

--- a/apps/desktop/src/main/__tests__/messagePersistBroadcaster.test.ts
+++ b/apps/desktop/src/main/__tests__/messagePersistBroadcaster.test.ts
@@ -2459,23 +2459,30 @@ describe('assistant isFinal burst DUP-SKIP(P1:main 对称去重,防重复 isFina
     expect(assistantCreates).toHaveLength(2);
   });
 
-  it('交互被回答后同文本快照不复用(复用窗口随交互结束关闭)', async () => {
+  it('交互被回答后迟到的同源终态全文仍复用该行(resolution 不作废复用窗口)', async () => {
     const persistId = onAssistantTextEvent(SESSION, { text: '同一句话', isFinal: false }, null);
     flushAssistantBlock(SESSION, null);
     const request = { kind: 'ask_user_question' as const, requestId: 'req-reuse-window', questions: [{ question: '同一句话' }] };
     const askId = onInteractionMessage(SESSION, request);
     expect(askId).toBeTruthy();
+    // 用户可能在 message_end 的全文快照被消费前就答完(两条路径竞速):回答本身
+    // 不作废复用窗口,否则这块正文会在提问卡之后再落一行。
     onInteractionResolved(SESSION, askId, 'ask_user_question', request, { answers: { '同一句话': '答' } });
     const lateFinalId = onAssistantTextEvent(
       SESSION,
       { text: '同一句话', isFinal: true, isFullText: true },
-      null,
+      { model: 'pi-test', stopReason: 'toolUse', usage: {} },
     );
-    expect(lateFinalId).not.toBe(persistId);
+    expect(lateFinalId).toBe(persistId);
     await flushWrites();
     const assistantCreates = vi.mocked(createMessage).mock.calls
       .filter(([, message]) => message.role === 'assistant');
-    expect(assistantCreates).toHaveLength(2);
+    expect(assistantCreates).toHaveLength(1);
+    expect(patchMessageAgentMetaWithResult).toHaveBeenCalledWith(
+      SESSION,
+      persistId,
+      expect.objectContaining({ model: 'pi-test', stopReason: 'toolUse' }),
+    );
   });
 
   it('交互边界 flush 后,不同 SDK 消息的同文本快照仍单独落行(身份不同不吞)', async () => {

--- a/apps/desktop/src/main/messagePersistBroadcaster.ts
+++ b/apps/desktop/src/main/messagePersistBroadcaster.ts
@@ -2176,7 +2176,10 @@ export function onAssistantTextEvent(
               { ...agentMeta },
             );
             if (patched) {
-              broadcastMessageAgentMetaUpdate(sessionId, boundaryFlushed.persistId, ownerScope);
+              // 与其它 agent-meta 落库路径一致 await:广播内部要回查行,DB worker 正在
+              // 关停/替换时它会 reject;不 await 的话这个 promise 会逃出 enqueueWrite
+              // 的错误处理,变成 main 进程的 unhandled rejection。
+              await broadcastMessageAgentMetaUpdate(sessionId, boundaryFlushed.persistId, ownerScope);
             }
           },
         );

--- a/apps/desktop/src/main/messagePersistBroadcaster.ts
+++ b/apps/desktop/src/main/messagePersistBroadcaster.ts
@@ -264,8 +264,11 @@ const sealedAssistantLateFinalBySession = new Map<string, SealedAssistantLateFin
  *
  * 复用只发生在"交互行仍是最后一条已落库消息"的窗口内(见 onAssistantTextEvent):
  * 窗口内到达的全文快照按构造属于刚 flush 的同一块。新 assistant 行落库、开始新的
- * delta block、交互被回答、turn reset / clear 时都作废记录,避免吞掉合法的同文本
- * 新消息。
+ * delta block、turn reset / clear 时都作废记录,避免吞掉合法的同文本新消息。
+ * 交互被回答(onInteractionResolved)**不**作废记录:message_end 的全文快照与交互
+ * 回答是两条竞速路径,用户可能在快照被消费前就答完,此时记录必须还活着,否则同一块
+ * 正文会再落一行;窗口改由紧随其后的 tool_result 行(ask_user 工具结果)自然关闭 ——
+ * 下一条 assistant 消息只可能在 tool_result 之后产生。
  */
 const lastBoundaryFlushedAssistantBySession = new Map<
   string,
@@ -1874,9 +1877,9 @@ export function onInteractionResolved(
   const requestId = typeof request.requestId === 'string' ? request.requestId : '';
   if (!requestId) return;
   if (!claimInteractionPersistId(sessionId, persistId)) return;
-  // 交互已结束:边界 flush 的复用窗口到此为止。其后到达的全文快照即使文本相同,
-  // 也可能是新一轮 assistant 消息,不能再当作刚 flush 那块的快照。
-  lastBoundaryFlushedAssistantBySession.delete(sessionId);
+  // 刻意不动 lastBoundaryFlushedAssistantBySession:回答完成不等于 message_end 的
+  // 全文快照已被消费(见该 map 的注释)。交互行本身不刷新 lastPersistedMsgBySession,
+  // 复用窗口仍然成立;等 ask_user 的 tool_result 行落库后窗口自然关闭。
   const acceptedAt = Date.now();
 
   if (kind === 'ask_user_question') {
@@ -2108,8 +2111,9 @@ export function onAssistantTextEvent(
     // assistant,相邻 DUP-SKIP 看不到刚落库的行 —— 这里按身份复用,不落第二行。
     //
     // 复用窗口严格限定在"交互行仍是最后一条已落库消息"期间:窗口内到达的全文快照
-    // 按构造属于刚 flush 的同一块;交互被回答(onInteractionResolved)/中间落过其它
-    // 消息/又开始新 delta block 后,记录已失效,合法的同文本新消息不会被吞。
+    // 按构造属于刚 flush 的同一块;中间落过其它消息(如 ask_user 的 tool_result)/
+    // 又开始新 delta block 后,记录已失效,合法的同文本新消息不会被吞。交互被回答
+    // 本身不作废窗口:终态全文可能与回答竞速,迟到的那条仍要更新这一行。
     const boundaryFlushed = lastBoundaryFlushedAssistantBySession.get(sessionId);
     const lastPersisted = lastPersistedMsgBySession.get(sessionId);
     const atInteractionBoundary =

--- a/apps/desktop/src/main/messagePersistBroadcaster.ts
+++ b/apps/desktop/src/main/messagePersistBroadcaster.ts
@@ -2118,10 +2118,26 @@ export function onAssistantTextEvent(
       boundaryFlushed &&
       visible &&
       atInteractionBoundary &&
-      boundaryFlushed.text === visible &&
-      (!agentMessageId || boundaryFlushed.agentMessageId === agentMessageId)
+      (!agentMessageId || boundaryFlushed.agentMessageId === agentMessageId) &&
+      (boundaryFlushed.text === visible || isFullText)
     ) {
       lastBoundaryFlushedAssistantBySession.delete(sessionId);
+      // message_end 的 isFullText 是权威全文:边界 flush 可能只攒到部分文本(尾部
+      // delta 未消费 / 流式纠错),此时用全文更新既有行,而不是要求逐字相等后另起
+      // 一行(否则仍是"部分文本 + 提问卡 + 完整文本"两行)。
+      if (isFullText && boundaryFlushed.text !== visible) {
+        enqueueWrite(
+          `boundary_flushed_content:${sessionId}:${boundaryFlushed.persistId}`,
+          async (ownerScope) => {
+            const updated = await updateDbMessageContent(
+              sessionId,
+              boundaryFlushed.persistId,
+              visible,
+            );
+            if (updated) broadcastMessageRow(sessionId, updated, ownerScope);
+          },
+        );
+      }
       // 交互边界 flush 时 delta 往往还没带 model / usage / stopReason,message_end 的
       // 全文快照才是权威终态 meta;复用旧行时必须把这些字段合并回去,否则 reload 与
       // 费用统计会读到不完整记录。

--- a/apps/desktop/src/main/messagePersistBroadcaster.ts
+++ b/apps/desktop/src/main/messagePersistBroadcaster.ts
@@ -270,8 +270,10 @@ const sealedAssistantLateFinalBySession = new Map<string, SealedAssistantLateFin
  * 正文会再落一行;窗口改由紧随其后的 tool_result 行(ask_user 工具结果)自然关闭 ——
  * 下一条 assistant 消息只可能在 tool_result 之后产生。复用命中后也不消费记录:终态
  * 快照可能重复投递,而交互行还占着 lastPersistedMsgBySession 时相邻 DUP-SKIP 看不到
- * 已落库的 assistant 行,删早了第二次投递就会再落一行。记录只由窗口推进(其它消息
- * 落库 / 新 delta block / turn reset / clear)作废。
+ * 已落库的 assistant 行,删早了第二次投递就会再落一行。
+ * 记录只在"flush 与交互行紧邻"时成立:flush 之后任何非交互消息先落库都会作废它
+ * (见 notePersistedMessage),否则更晚到达的交互行会仅凭角色把陈旧记录重新激活,
+ * 把当前这条 assistant 的终态全文写到更早那一行上。
  */
 const lastBoundaryFlushedAssistantBySession = new Map<
   string,
@@ -491,6 +493,14 @@ function notePersistedMessage(
   text = '',
   agentMessageId?: string,
 ): void {
+  // 边界复用候选只在"交互行紧随 flush 落库"时有效:flushAssistantBlock 与
+  // onInteractionMessage 在同一段同步代码里先后落库,所以 flush 之后第一条落库的不是
+  // 交互行,就说明这次 flush 不是交互边界(或交互行不是紧邻的那条)。立即作废候选,
+  // 防止更晚到达的 ask_user / plan_review 行仅凭角色把陈旧候选重新激活,把当前这条
+  // assistant 的终态全文写到更早那一行上。
+  if (role !== 'ask_user' && role !== 'plan_review') {
+    lastBoundaryFlushedAssistantBySession.delete(sessionId);
+  }
   lastPersistedMsgBySession.set(sessionId, { role, text, persistId, agentMessageId });
 }
 
@@ -2113,11 +2123,12 @@ export function onAssistantTextEvent(
     // assistant 行、再落交互行,交互行把 lastPersistedMsgBySession 刷成非
     // assistant,相邻 DUP-SKIP 看不到刚落库的行 —— 这里按身份复用,不落第二行。
     //
-    // 复用窗口严格限定在"交互行仍是最后一条已落库消息"期间:窗口内到达的全文快照
-    // 按构造属于刚 flush 的同一块;中间落过其它消息(如 ask_user 的 tool_result)/
-    // 又开始新 delta block 后,记录已失效,合法的同文本新消息不会被吞。交互被回答
-    // 本身不作废窗口:终态全文可能与回答竞速,迟到的那条仍要更新这一行;一份快照
-    // 重复投递时也走这里(否则第二次会另起一行)。
+    // 复用窗口严格限定在"交互行紧随本次 flush 落库"期间:flush 之后先落库了任何非
+    // 交互消息(如 tool_use / tool_result)记录即作废(见 notePersistedMessage),所以
+    // 这里看到 lastPersisted 是交互行,就说明它就是紧邻本次 flush 的那条,不会把更早
+    // 的陈旧记录重新激活;又开始新 delta block 后同样失效,合法的同文本新消息不会被
+    // 吞。交互被回答本身不作废窗口:终态全文可能与回答竞速,迟到的那条仍要更新这一
+    // 行;一份快照重复投递时也走这里(否则第二次会另起一行)。
     const boundaryFlushed = lastBoundaryFlushedAssistantBySession.get(sessionId);
     const lastPersisted = lastPersistedMsgBySession.get(sessionId);
     const atInteractionBoundary =

--- a/apps/desktop/src/main/messagePersistBroadcaster.ts
+++ b/apps/desktop/src/main/messagePersistBroadcaster.ts
@@ -268,7 +268,10 @@ const sealedAssistantLateFinalBySession = new Map<string, SealedAssistantLateFin
  * 交互被回答(onInteractionResolved)**不**作废记录:message_end 的全文快照与交互
  * 回答是两条竞速路径,用户可能在快照被消费前就答完,此时记录必须还活着,否则同一块
  * 正文会再落一行;窗口改由紧随其后的 tool_result 行(ask_user 工具结果)自然关闭 ——
- * 下一条 assistant 消息只可能在 tool_result 之后产生。
+ * 下一条 assistant 消息只可能在 tool_result 之后产生。复用命中后也不消费记录:终态
+ * 快照可能重复投递,而交互行还占着 lastPersistedMsgBySession 时相邻 DUP-SKIP 看不到
+ * 已落库的 assistant 行,删早了第二次投递就会再落一行。记录只由窗口推进(其它消息
+ * 落库 / 新 delta block / turn reset / clear)作废。
  */
 const lastBoundaryFlushedAssistantBySession = new Map<
   string,
@@ -2113,7 +2116,8 @@ export function onAssistantTextEvent(
     // 复用窗口严格限定在"交互行仍是最后一条已落库消息"期间:窗口内到达的全文快照
     // 按构造属于刚 flush 的同一块;中间落过其它消息(如 ask_user 的 tool_result)/
     // 又开始新 delta block 后,记录已失效,合法的同文本新消息不会被吞。交互被回答
-    // 本身不作废窗口:终态全文可能与回答竞速,迟到的那条仍要更新这一行。
+    // 本身不作废窗口:终态全文可能与回答竞速,迟到的那条仍要更新这一行;一份快照
+    // 重复投递时也走这里(否则第二次会另起一行)。
     const boundaryFlushed = lastBoundaryFlushedAssistantBySession.get(sessionId);
     const lastPersisted = lastPersistedMsgBySession.get(sessionId);
     const atInteractionBoundary =
@@ -2125,7 +2129,9 @@ export function onAssistantTextEvent(
       (!agentMessageId || boundaryFlushed.agentMessageId === agentMessageId) &&
       (boundaryFlushed.text === visible || isFullText)
     ) {
-      lastBoundaryFlushedAssistantBySession.delete(sessionId);
+      // 命中后不删记录:同一份终态快照可能被重复投递(对齐紧邻 DUP-SKIP 的存在意义),
+      // 而此时上一条已落库消息是交互行,相邻 DUP-SKIP 挡不住第二次 —— 记录留到窗口
+      // 被推进(tool_result 等其它消息落库 / 新 delta block / reset)再失效。
       // message_end 的 isFullText 是权威全文:边界 flush 可能只攒到部分文本(尾部
       // delta 未消费 / 流式纠错),此时用全文更新既有行,而不是要求逐字相等后另起
       // 一行(否则仍是"部分文本 + 提问卡 + 完整文本"两行)。
@@ -2138,7 +2144,11 @@ export function onAssistantTextEvent(
               boundaryFlushed.persistId,
               visible,
             );
-            if (updated) broadcastMessageRow(sessionId, updated, ownerScope);
+            if (updated) {
+              // 缓存已落库的全文:重复投递同一份快照时不再重复 UPDATE。
+              boundaryFlushed.text = visible;
+              broadcastMessageRow(sessionId, updated, ownerScope);
+            }
           },
         );
       }

--- a/apps/desktop/src/main/messagePersistBroadcaster.ts
+++ b/apps/desktop/src/main/messagePersistBroadcaster.ts
@@ -253,6 +253,21 @@ interface SealedAssistantLateFinalCandidate {
  */
 const sealedAssistantLateFinalBySession = new Map<string, SealedAssistantLateFinalCandidate>();
 
+/**
+ * 最近一次边界(tool_use / interaction / done)flush 掉的 assistant block 身份。
+ *
+ * 交互边界会先 flushAssistantBlock 再落 ask_user / plan_review 行,而交互行会把
+ * lastPersistedMsgBySession 刷成非 assistant —— 紧随其后的 message_end 全文快照
+ * (isFinal + isFullText)看到的上一条已是交互行,相邻 DUP-SKIP 失效,于是同一段
+ * 正文落第二行(现象:回复 → 提问卡 → 同一条回复)。这里单独记住这块已落库的身份,
+ * 让同源快照复用它;新 assistant 行落库 / turn reset / clear 时作废,避免吞掉
+ * 新消息。
+ */
+const lastBoundaryFlushedAssistantBySession = new Map<
+  string,
+  { persistId: string; text: string; agentMessageId?: string }
+>();
+
 function matchesSealedAssistantIdentity(
   candidate: SealedAssistantLateFinalCandidate,
   agentMeta: AgentMeta | null,
@@ -290,6 +305,7 @@ export function noteSessionClearBoundary(sessionId: string, clearedAt: string | 
     clearSessionThinkingSnapshots(sessionId);
     clearBoundaryBySession.set(sessionId, parsed);
     sealedAssistantLateFinalBySession.delete(sessionId);
+    lastBoundaryFlushedAssistantBySession.delete(sessionId);
     // A cleared transcript must not be revived by a late terminal update from an
     // older background task. New tool calls repopulate this linkage after the boundary.
     clearAgentTaskPersistState(sessionId);
@@ -742,6 +758,9 @@ function enqueuePersistAssistant(
   createdAt: number,
   agentMessageId?: string,
 ): void {
+  // 有新的 assistant 行要落库:上一条边界 flush 身份作废,防止迟到的全文快照
+  // 误复用到更早的消息上。flushAssistantBlockInternal 在本函数返回后重新登记。
+  lastBoundaryFlushedAssistantBySession.delete(sessionId);
   noteAssistantTranscriptUuid(sessionId, agentMeta);
   enqueueVisibleDbMessage(`assistant:${sessionId}:${clientId}`, sessionId, {
     clientId,
@@ -1987,6 +2006,7 @@ export function resetTurnPersistState(sessionId: string): void {
   // 不经 notePersistedMessage),若跨 turn 保留,turn1 burst "X" → 用户发消息(不更新 main
   // tracker)→ turn2 又 burst "X" 会被误判重复、跳 create → turn2 回复丢失。清在这里堵死。
   lastPersistedMsgBySession.delete(sessionId);
+  lastBoundaryFlushedAssistantBySession.delete(sessionId);
   lastTopLevelAssistantPersistIdBySession.delete(sessionId);
 }
 
@@ -2076,6 +2096,19 @@ export function onAssistantTextEvent(
       if (agentMeta) block.agentMeta = agentMeta;
       return block.persistId;
     }
+    // 边界 flush 后同源的全文快照:交互边界(ask_user / plan_review)会先落
+    // assistant 行、再落交互行,交互行把 lastPersistedMsgBySession 刷成非
+    // assistant,相邻 DUP-SKIP 看不到刚落库的行 —— 这里按身份复用,不落第二行。
+    const boundaryFlushed = lastBoundaryFlushedAssistantBySession.get(sessionId);
+    if (
+      boundaryFlushed &&
+      visible &&
+      boundaryFlushed.text === visible &&
+      (!agentMessageId || boundaryFlushed.agentMessageId === agentMessageId)
+    ) {
+      lastBoundaryFlushedAssistantBySession.delete(sessionId);
+      return boundaryFlushed.persistId;
+    }
     // 非流式 isFinal burst(result 兜底补推也走这):无在飞 block,立即落库。
     if (visible) {
       // DUP-SKIP(对齐 renderer 老 757-762):若紧邻的上一条已落库消息正是内容完全
@@ -2163,6 +2196,13 @@ function flushAssistantBlockInternal(
     block.createdAt,
     block.agentMessageId,
   );
+  // 登记这次边界 flush 的身份,供随后到达的同源 isFinal 全文快照复用(见
+  // onAssistantTextEvent 的 burst 分支)。
+  lastBoundaryFlushedAssistantBySession.set(sessionId, {
+    persistId: block.persistId,
+    text: visible,
+    ...(block.agentMessageId ? { agentMessageId: block.agentMessageId } : {}),
+  });
   return {
     persistId: block.persistId,
     text: visible,
@@ -2589,6 +2629,7 @@ export function clearSessionPersistState(sessionId: string): void {
   pendingFullTextByToolUseId.delete(sessionId);
   toolResultContentByClientId.delete(sessionId);
   lastPersistedMsgBySession.delete(sessionId);
+  lastBoundaryFlushedAssistantBySession.delete(sessionId);
   lastAssistantPersistIdBySession.delete(sessionId);
   lastTopLevelAssistantPersistIdBySession.delete(sessionId);
   lastAssistantTranscriptUuidBySession.delete(sessionId);

--- a/apps/desktop/src/main/messagePersistBroadcaster.ts
+++ b/apps/desktop/src/main/messagePersistBroadcaster.ts
@@ -260,7 +260,11 @@ const sealedAssistantLateFinalBySession = new Map<string, SealedAssistantLateFin
  * lastPersistedMsgBySession 刷成非 assistant —— 紧随其后的 message_end 全文快照
  * (isFinal + isFullText)看到的上一条已是交互行,相邻 DUP-SKIP 失效,于是同一段
  * 正文落第二行(现象:回复 → 提问卡 → 同一条回复)。这里单独记住这块已落库的身份,
- * 让同源快照复用它;新 assistant 行落库 / turn reset / clear 时作废,避免吞掉
+ * 让同源快照复用它。
+ *
+ * 复用只发生在"交互行仍是最后一条已落库消息"的窗口内(见 onAssistantTextEvent):
+ * 窗口内到达的全文快照按构造属于刚 flush 的同一块。新 assistant 行落库、开始新的
+ * delta block、交互被回答、turn reset / clear 时都作废记录,避免吞掉合法的同文本
  * 新消息。
  */
 const lastBoundaryFlushedAssistantBySession = new Map<
@@ -1870,6 +1874,9 @@ export function onInteractionResolved(
   const requestId = typeof request.requestId === 'string' ? request.requestId : '';
   if (!requestId) return;
   if (!claimInteractionPersistId(sessionId, persistId)) return;
+  // 交互已结束:边界 flush 的复用窗口到此为止。其后到达的全文快照即使文本相同,
+  // 也可能是新一轮 assistant 消息,不能再当作刚 flush 那块的快照。
+  lastBoundaryFlushedAssistantBySession.delete(sessionId);
   const acceptedAt = Date.now();
 
   if (kind === 'ask_user_question') {
@@ -2099,14 +2106,40 @@ export function onAssistantTextEvent(
     // 边界 flush 后同源的全文快照:交互边界(ask_user / plan_review)会先落
     // assistant 行、再落交互行,交互行把 lastPersistedMsgBySession 刷成非
     // assistant,相邻 DUP-SKIP 看不到刚落库的行 —— 这里按身份复用,不落第二行。
+    //
+    // 复用窗口严格限定在"交互行仍是最后一条已落库消息"期间:窗口内到达的全文快照
+    // 按构造属于刚 flush 的同一块;交互被回答(onInteractionResolved)/中间落过其它
+    // 消息/又开始新 delta block 后,记录已失效,合法的同文本新消息不会被吞。
     const boundaryFlushed = lastBoundaryFlushedAssistantBySession.get(sessionId);
+    const lastPersisted = lastPersistedMsgBySession.get(sessionId);
+    const atInteractionBoundary =
+      lastPersisted?.role === 'ask_user' || lastPersisted?.role === 'plan_review';
     if (
       boundaryFlushed &&
       visible &&
+      atInteractionBoundary &&
       boundaryFlushed.text === visible &&
       (!agentMessageId || boundaryFlushed.agentMessageId === agentMessageId)
     ) {
       lastBoundaryFlushedAssistantBySession.delete(sessionId);
+      // 交互边界 flush 时 delta 往往还没带 model / usage / stopReason,message_end 的
+      // 全文快照才是权威终态 meta;复用旧行时必须把这些字段合并回去,否则 reload 与
+      // 费用统计会读到不完整记录。
+      if (agentMeta) {
+        enqueueWrite(
+          `boundary_flushed_meta:${sessionId}:${boundaryFlushed.persistId}`,
+          async (ownerScope) => {
+            const patched = await patchMessageAgentMetaWithResult(
+              sessionId,
+              boundaryFlushed.persistId,
+              { ...agentMeta },
+            );
+            if (patched) {
+              broadcastMessageAgentMetaUpdate(sessionId, boundaryFlushed.persistId, ownerScope);
+            }
+          },
+        );
+      }
       return boundaryFlushed.persistId;
     }
     // 非流式 isFinal burst(result 兜底补推也走这):无在飞 block,立即落库。
@@ -2141,6 +2174,9 @@ export function onAssistantTextEvent(
   // delta: accumulate the raw snapshot; strip only the completed block.
   let block = assistantBlocks.get(sessionId);
   if (!block) {
+    // 新的 delta block 已开始:上一条边界 flush 的身份不再可复用(它的全文快照
+    // 已经过去,或会走 block 分支),避免吞掉这条新消息。
+    lastBoundaryFlushedAssistantBySession.delete(sessionId);
     block = {
       persistId: createId(),
       text: rawText,


### PR DESCRIPTION
## 这次改了什么

### 摘要

修复 assistant 文本在「交互边界」后重复落库的问题：回复 + `ask_user_question` / `plan_review` 的回合里，`flushAssistantBlock` 先落了 assistant 行，交互行随后把相邻去重游标（`lastPersistedMsgBySession`）刷成非 assistant，导致紧随其后的 `message_end` 全文快照（`isFinal + isFullText`）绕过 DUP-SKIP，同一段正文落第二行。

用户可见表现：**回复 → 提问卡 → 同一条回复**；会话引用里两条重复相邻（引用只保留 user/assistant，过滤掉中间的提问卡）。

修复：main 侧单独记录最近一次边界 flush 的 assistant 身份（persistId / text / agentMessageId），同源全文快照复用它而不是新建；新 assistant 行落库、turn reset、`/clear` 时作废该记录，避免吞掉真正的新消息。

### 变更类型

- [x] `fix` 缺陷修复

### 范围

- 关联 Issue / 需求：无（真实会话数据复盘：某会话 128 条 assistant 行里 19 组重复，19/19 都发生在 `ask_user` 前置回复；Pi 原始会话文件里同一段文本只出现一次，确认不是模型复读）
- 本 PR 包含：`apps/desktop/src/main/messagePersistBroadcaster.ts` 的边界 flush 身份复用；`messagePersistBroadcaster.test.ts` 两条回归用例
- 明确不包含：已产生的历史重复行清理（属于个人数据修复，不在本 PR）
- 用户可见变化：回复不再在提问卡后重复出现
- 是否存在 breaking change：无

### UI 变化

不涉及：只有消息落库去重逻辑，无视觉/交互/文案变化。

## 怎么验证的

### 自动验证

```text
npx vitest run src/main/__tests__/messagePersistBroadcaster.test.ts
结果：145 passed（含新增 2 条）

去掉修复后重跑新用例：
结果：稳定失败（expected persistId A, received B），确认用例覆盖该缺陷

pnpm test:unit:related
结果：PASS（apps/desktop unit 及相关包全绿）

pnpm --filter desktop run typecheck
结果：通过

pnpm check:dco
结果：passed
```

### 手工验证

用真实会话数据做了根因复盘（Pi 原始 jsonl 无重复、SQLite `messages` 两行、19/19 与 `ask_user` 相关），未在真实 App 中做 UI 回归。

### 未执行的验证

未构建运行桌面端做端到端 UI 回归；改动落在 main 侧落库去重，已由单测覆盖该事件序。

## 风险

### 风险分类

- [x] 无已知风险

### 影响与回滚

- 影响范围：仅 Desktop main 侧「交互边界 flush 后同源 isFinal」这一条落库路径；不涉及 DB schema、协议或权限。
- 回滚 / 降级方式：回滚本 commit 即可，无数据迁移。

### 提交前检查

- [x] 已 review 完整 diff
- [x] 每个 commit 都带 DCO 签名（`git commit -s`）
- [x] UI 改动已在「UI 变化」注明引用的设计规范章节（不涉及 UI，已写明理由）
- [x] 未提交凭证、令牌或授权文件
- [x] 已核对受影响的文档（行为变化不涉及既有文档结论，无需修订）
- [x] 已确认测试结果
