### PR TITLE
fix(codex): preserve compacted turn recovery after disconnect

### DIFF
--- a/apps/desktop/src/main/maker-ipc/__tests__/agent-input-coordinator.test.ts
+++ b/apps/desktop/src/main/maker-ipc/__tests__/agent-input-coordinator.test.ts
@@ -1,4 +1,9 @@
-import { AUTO_REVIEW_SOURCE_CONTENT, AUTO_REVIEW_USER_INTENT, appendAutoReviewUserIntent } from '@cindy/maker-core';
+import {
+  AUTO_REVIEW_SOURCE_CONTENT,
+  AUTO_REVIEW_USER_INTENT,
+  CODEX_COMPACTION_TRANSPORT_INTERRUPTED_REASON,
+  appendAutoReviewUserIntent,
+} from '@cindy/maker-core';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { AgentInputCoordinator } from '../agent-input-coordinator.js';
 import { createOrcaInterAgentDispatcher } from '../orcaInterAgentDispatcher.js';
@@ -10893,11 +10898,12 @@ describe('AgentInputCoordinator 中断自动续跑', () => {
     h: ReturnType<typeof createHarness>,
     sid: string,
     item = makeItem('q-first', 'original long task'),
+    signals: { sdkError?: string; reason?: string } = truncationSignals,
   ) {
     h.coordinator.enqueue(sid, item);
     await flush();
     h.setRunning(false);
-    h.coordinator.onTurnEvent(sid, 'error', truncationMessage, truncationSignals);
+    h.coordinator.onTurnEvent(sid, 'error', truncationMessage, signals);
     await flush();
     return h;
   }
@@ -11352,6 +11358,25 @@ describe('AgentInputCoordinator 中断自动续跑', () => {
     expect(mocks.touchUserSendInDb).toHaveBeenCalledTimes(2);
   });
 
+  it('压缩断流后的人工 Retry 不重放原始任务', async () => {
+    const h = createHarness();
+    const sid = 'manual-retry-after-compaction-transport-interrupt';
+    h.setHasAssistantProgressAfter(async () => false);
+    await failAfterDispatch(h, sid, undefined, {
+      reason: CODEX_COMPACTION_TRANSPORT_INTERRUPTED_REASON,
+    });
+
+    await h.coordinator.retryLastError(sid);
+    await flush();
+
+    expect(h.sendToAgent).toHaveBeenCalledTimes(2);
+    expect(h.sendToAgent.mock.calls[1]?.[1]).toEqual({
+      type: 'user',
+      content: CONTINUE_AFTER_ERROR_PROMPT,
+    });
+    expect(h.sendToAgent.mock.calls[1]?.[3]?.persistUserMessage?.autoResume).toBeUndefined();
+  });
+
   it('自动续跑再次失败后,人工 Retry 会清掉上一轮隐藏标记并重置真人额度', async () => {
     const h = createHarness();
     const sid = 'manual-retry-after-auto-failure';
@@ -11424,6 +11449,7 @@ describe('AgentInputCoordinator 中断自动续跑', () => {
     ['turn_no_event_timeout', false, true],
     ['upstream_response_idle_timeout', false, true],
     ['codex_reconnect_stalled', true, true],
+    [CODEX_COMPACTION_TRANSPORT_INTERRUPTED_REASON, false, true],
     ['turn_no_event_timeout', true, false],
     ['upstream_response_idle_timeout', true, undefined],
     ['empty-response', true, true],

--- a/apps/desktop/src/main/maker-ipc/__tests__/interruptedTurnAutoResume.test.ts
+++ b/apps/desktop/src/main/maker-ipc/__tests__/interruptedTurnAutoResume.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it, vi } from 'vitest';
+import { CODEX_COMPACTION_TRANSPORT_INTERRUPTED_REASON } from '@cindy/maker-core';
 
 import {
   INTERRUPTED_TURN_MAX_CONSECUTIVE_ATTEMPTS,
@@ -96,6 +97,9 @@ describe('isInterruptedTurnError', () => {
     expect(isAcceptedTurnContinuationOnlyReason('turn_no_event_timeout')).toBe(true);
     expect(isAcceptedTurnContinuationOnlyReason('upstream_response_idle_timeout')).toBe(true);
     expect(isAcceptedTurnContinuationOnlyReason('codex_reconnect_stalled')).toBe(true);
+    expect(
+      isAcceptedTurnContinuationOnlyReason(CODEX_COMPACTION_TRANSPORT_INTERRUPTED_REASON),
+    ).toBe(true);
     expect(isAcceptedTurnContinuationOnlyReason('empty-response')).toBe(false);
     expect(isAcceptedTurnContinuationOnlyReason('upstream-overload')).toBe(false);
     expect(isAcceptedTurnContinuationOnlyReason('turn-failed')).toBe(false);

--- a/apps/desktop/src/main/maker-ipc/agent-input-coordinator.ts
+++ b/apps/desktop/src/main/maker-ipc/agent-input-coordinator.ts
@@ -1,4 +1,8 @@
-import { AUTO_REVIEW_SOURCE_CONTENT, AUTO_REVIEW_USER_INTENT } from '@cindy/maker-core';
+import {
+  AUTO_REVIEW_SOURCE_CONTENT,
+  AUTO_REVIEW_USER_INTENT,
+  CODEX_COMPACTION_TRANSPORT_INTERRUPTED_REASON,
+} from '@cindy/maker-core';
 /**
  * AgentInputCoordinator — main 侧排队输入事务协调器。
  *
@@ -2711,9 +2715,9 @@ export class AgentInputCoordinator {
     let progressKnown = false;
     const previousAutoResumeInfo = opts?.auto ? state.autoResumePending : null;
     const attemptToken = opts?.auto ? (opts.attemptToken ?? null) : null;
-    const continuationOnly = Boolean(
-      opts?.auto && isAcceptedTurnContinuationOnlyReason(previousAutoResumeInfo?.reason),
-    );
+    const continuationOnly = opts?.auto
+      ? isAcceptedTurnContinuationOnlyReason(previousAutoResumeInfo?.reason)
+      : state.errorReason === CODEX_COMPACTION_TRANSPORT_INTERRUPTED_REASON;
     let continueText = CONTINUE_AFTER_ERROR_PROMPT;
     let recoveryCheckpoint: RecoveryCheckpoint | undefined;
     if (recovery.kind === 'active-turn') {

--- a/apps/desktop/src/main/maker-ipc/interruptedTurnAutoResume.ts
+++ b/apps/desktop/src/main/maker-ipc/interruptedTurnAutoResume.ts
@@ -28,6 +28,7 @@ import { hasUserVisibleText } from '../../shared/visibleText.js';
 import type { AgentInputToolLoopDetails } from '../../shared/agentInputQueue.js';
 
 import {
+  CODEX_COMPACTION_TRANSPORT_INTERRUPTED_REASON,
   isNetworkishErrorMessage,
   isOverloadErrorMessage,
   UPSTREAM_OVERLOAD_REASON,
@@ -118,7 +119,8 @@ export function isAcceptedTurnContinuationOnlyReason(reason: unknown): boolean {
   return (
     reason === 'turn_no_event_timeout' ||
     reason === 'upstream_response_idle_timeout' ||
-    reason === 'codex_reconnect_stalled'
+    reason === 'codex_reconnect_stalled' ||
+    reason === CODEX_COMPACTION_TRANSPORT_INTERRUPTED_REASON
   );
 }
 
@@ -172,7 +174,8 @@ export function isInterruptedTurnError(signals: InterruptedTurnErrorSignals): bo
   // 续跑——两种形态都有安全动作可执行。连续空响应仍由同一份连续失败上限 / 人工介入周期
   // 硬上限 / 退避止损，预算耗尽后横幅交还用户，不会无界重试。
   //
-  // stall / idle / reconnect-stalled 也放行，但 coordinator 对它们是 **CONTINUE-only**：
+  // stall / idle / reconnect-stalled / compact transport interruption 也放行，但 coordinator
+  // 对它们是 **CONTINUE-only**：
   // 见 `isAcceptedTurnContinuationOnlyReason`。
   if (
     reason === UPSTREAM_OVERLOAD_REASON ||

--- a/docs/dev-rules/maker-core-and-agent-behavior.md
+++ b/docs/dev-rules/maker-core-and-agent-behavior.md
@@ -149,8 +149,10 @@ send 已开始则等真实 outcome——vendor 已 accept 必须 commit、禁止
 （pendingOutcome=failed、丢弃 suppressed、rollback guard）；不得走会补落旧错误、恢复
 recovery 或再入队的 undispatched finalize。确认失败且 attemptToken 仍匹配才重新入队。
 显式关闭 / 停止已清 token 后，sendStarted 且已落库的隐藏 CONTINUE 必须丢弃，不得落成
-可重试 recovery。unexpected close 的 preserve 只认三类 CONTINUE-only reason
-（stall / idle / reconnect-stall）；generic clone-原文 retry fail-closed 不交棒。
+可重试 recovery。unexpected close 的 preserve 只认四类 CONTINUE-only reason
+（stall / idle / reconnect-stall / compact transport interrupted）；generic clone-原文 retry
+fail-closed 不交棒。压缩期间的传输结果不明既不能触发本地摘要 fallback，也不能重放原始
+请求；自动续跑与人工 Retry 都只发 CONTINUE，保留已被上游接受的 turn 边界。
 连续 replacement `unexpected` close 时 WeakMap lease 可能已随旧实例消失，必须按同一
 attemptToken 把 lease 绑到新 Session，或在 coordinator / guard / book 仍一致且队里 /
 live schedule 仍活着时继续 preserve。预算内不能 discard 或只留人工 recovery，也不能清掉

--- a/packages/maker-core/src/agents/codex/compaction-transport-interrupt.ts
+++ b/packages/maker-core/src/agents/codex/compaction-transport-interrupt.ts
@@ -1,0 +1,7 @@
+/**
+ * The native turn was accepted and entered context compaction before its
+ * response stream became indeterminate. Recovery must continue that accepted
+ * turn instead of replaying the original user request and possible effects.
+ */
+export const CODEX_COMPACTION_TRANSPORT_INTERRUPTED_REASON =
+  "codex_compaction_transport_interrupted";

--- a/packages/maker-core/src/agents/codex/index.test.ts
+++ b/packages/maker-core/src/agents/codex/index.test.ts
@@ -9088,6 +9088,26 @@ describe('CodexAgent MCP thread context hooks', () => {
       expect(host.request.mock.calls.filter(([m]) => m === Method.ThreadFork)).toHaveLength(0);
       await handle.close();
     });
+    it('marks a compact response-stream disconnect as accepted-turn continuation-only', async () => {
+      const { host, handle, events } = await start();
+      compact(host);
+      fail(host, 'turn-1', {
+        message: 'stream disconnected before completion: Transport error: network error: error decoding response body',
+        codexErrorInfo: { responseStreamDisconnected: { httpStatusCode: null } },
+      });
+      await waitForExpectation(() => expect(events).toContainEqual(expect.objectContaining({
+        type: 'error',
+        data: expect.objectContaining({
+          reason: 'codex_compaction_transport_interrupted',
+          isTerminal: true,
+        }),
+      })));
+
+      expect(handle.isTurnRunning?.()).toBe(false);
+      expect(host.request.mock.calls.filter(([m]) => m === Method.ThreadFork)).toHaveLength(0);
+      expect(host.request.mock.calls.filter(([m]) => m === Method.TurnStart)).toHaveLength(1);
+      await handle.close();
+    });
     it.each([502, 503])('recovers explicit compact HTTP %s after the native turn has failed', async (status) => {
       const { host, handle } = await start();
       compact(host);

--- a/packages/maker-core/src/agents/codex/index.test.ts
+++ b/packages/maker-core/src/agents/codex/index.test.ts
@@ -9108,6 +9108,30 @@ describe('CodexAgent MCP thread context hooks', () => {
       expect(host.request.mock.calls.filter(([m]) => m === Method.TurnStart)).toHaveLength(1);
       await handle.close();
     });
+    it('marks a completed-only compact disconnect as accepted-turn continuation-only', async () => {
+      const { host, handle, events } = await start();
+      compact(host);
+      const error = {
+        message: 'stream disconnected before completion: Transport error: network error: error decoding response body',
+        codexErrorInfo: { responseStreamDisconnected: { httpStatusCode: null } },
+      };
+      host.getThreadHandlers()!.turnCompleted!({
+        threadId: nativeId,
+        turn: { id: 'turn-1', status: 'failed', error },
+      });
+      await waitForExpectation(() => expect(events).toContainEqual(expect.objectContaining({
+        type: 'error',
+        data: expect.objectContaining({
+          reason: 'codex_compaction_transport_interrupted',
+          isTerminal: true,
+        }),
+      })));
+
+      expect(handle.isTurnRunning?.()).toBe(false);
+      expect(host.request.mock.calls.filter(([m]) => m === Method.ThreadFork)).toHaveLength(0);
+      expect(host.request.mock.calls.filter(([m]) => m === Method.TurnStart)).toHaveLength(1);
+      await handle.close();
+    });
     it.each([502, 503])('recovers explicit compact HTTP %s after the native turn has failed', async (status) => {
       const { host, handle } = await start();
       compact(host);

--- a/packages/maker-core/src/agents/codex/index.ts
+++ b/packages/maker-core/src/agents/codex/index.ts
@@ -161,6 +161,7 @@ import {
   readCodexSubagentSpawnRegistration,
   type CodexRuntimeState,
 } from './translator.js';
+import { CODEX_COMPACTION_TRANSPORT_INTERRUPTED_REASON } from './compaction-transport-interrupt.js';
 import {
   createSubagentLiveCardTracker,
   type SubagentLiveCardUpdate,
@@ -9925,6 +9926,13 @@ export class CodexAgent extends BaseAgent {
      * turn/completed 驱动。这样无论 error / completed / turn-start response
      * 如何乱序，都只有一个执行入口。
      */
+    const isUncertainCompactionTransportFailure = (error: { message?: string; additionalDetails?: unknown; codexErrorInfo?: CodexErrorInfo | null } | null | undefined): boolean => {
+      const text = `${error?.message ?? ''}\n${typeof error?.additionalDetails === 'string' ? error.additionalDetails : ''}`;
+      const tag = codexErrorInfoTag(error?.codexErrorInfo);
+      return tag === 'responseStreamDisconnected' || tag === 'responseStreamConnectionFailed'
+        || /timeout|timed out|ECONNRESET|ECONNREFUSED|ENOTFOUND|connection reset|network error|stream disconnected/i.test(text);
+    };
+
     const canRecoverRemoteCompaction = (deadTurnId: string, error: { message?: string; additionalDetails?: unknown; codexErrorInfo?: CodexErrorInfo | null } | null | undefined): boolean => {
       if (!localSummaryProvider || !threadModelProvider || !hostUsesCodexProxy || threadModelProvider === localSummaryProvider) return false;
       if (threadModelProvider !== host.getCindyRemoteCompactionProviderId?.()
@@ -9952,9 +9960,7 @@ export class CodexAgent extends BaseAgent {
         ? info.httpConnectionFailed.httpStatusCode ?? textStatus
         : textStatus;
       const rejectedRequest = [400, 404, 405, 422, 500, 501, 502, 503].includes(httpStatus ?? 0);
-      const uncertainTransport = tag === 'responseStreamDisconnected' || tag === 'responseStreamConnectionFailed'
-        || /timeout|timed out|ECONNRESET|ECONNREFUSED|ENOTFOUND|connection reset|network error|stream disconnected/i.test(text);
-      return !uncertainTransport
+      return !isUncertainCompactionTransportFailure(error)
         && !isAuthRelatedErrorMessage(text)
         && ((rejectedRequest && !signals.usageLimit) || compactRateLimit)
         && !isRemoteCompactEncryptedContentError(text);
@@ -9966,10 +9972,13 @@ export class CodexAgent extends BaseAgent {
     ): boolean => {
       const state = overloadRetry;
       const summaryRecovery = canRecoverRemoteCompaction(deadTurnId, error);
+      const compactionTransportUnknown =
+        compactingTurnIds.has(deadTurnId) && isUncertainCompactionTransportFailure(error);
       if (
         !deadTurnId
         || !state
         || closed
+        || compactionTransportUnknown
         || state.automaticRecoveryAttempted
         || state.isCancelled()
         || state.timer !== null
@@ -12249,9 +12258,18 @@ export class CodexAgent extends BaseAgent {
         // 服务过载(模型容量不足)时接管重投：translator 命中 capacity 才回调，
         // 拿到进度就把错误透成非终止状态，本函数随后跳过 Done 收口。
         let turnReplayRetryScheduled = false;
+        const terminalTurnId = effectiveParams.turnId || currentTurnId;
+        const compactionTransportInterrupted =
+          isTerminalError &&
+          terminalTurnId !== null &&
+          compactingTurnIds.has(terminalTurnId) &&
+          (isTransportError || isUncertainCompactionTransportFailure(effectiveParams.error));
         translateErrorNotification(effectiveParams, eventQueue, {
           rt: translatorRt,
           log,
+          ...(compactionTransportInterrupted
+            ? { errorReasonOverride: CODEX_COMPACTION_TRANSPORT_INTERRUPTED_REASON }
+            : {}),
           tryTakeOverOverload: () => {
             // 只接管 app-server 本来就不重试的容量拒绝(原始 willRetry !== true)。
             // TurnRetryTracker 把持续 retry 升级成终态的那条路径不接管：那说明
@@ -12288,7 +12306,6 @@ export class CodexAgent extends BaseAgent {
         });
         // 与 translator 的 terminal 判定保持一致：willRetry=false 或缺省都视为终态。
         if (!isTerminalError) return;
-        const terminalTurnId = effectiveParams.turnId || currentTurnId;
         if (turnReplayRetryScheduled) {
           // 死掉的 turn **必须**落墓碑：app-server 随后还会为它发正常的
           // turn/completed(failed)，没有墓碑 handleTurnCompleted 就会 emit terminal

--- a/packages/maker-core/src/agents/codex/index.ts
+++ b/packages/maker-core/src/agents/codex/index.ts
@@ -10181,6 +10181,14 @@ export class CodexAgent extends BaseAgent {
       // 同一个墓碑也负责拦截该 turn 随后迟到的 item / reasoning / started 事件。
       if (completedTurnIds.has(turn.id)) return;
       completedTurnIds.add(turn.id);
+      // Some app-server versions report a failed remote compaction only via
+      // turn/completed. Capture the marker before terminal cleanup so this
+      // path preserves the same accepted-turn/CONTINUE-only classification as
+      // the preceding error-notification path.
+      const completedCompactionTransportInterrupted =
+        turn.status === 'failed'
+        && compactingTurnIds.has(turn.id)
+        && isUncertainCompactionTransportFailure(turn.error);
       compactingTurnIds.delete(turn.id);
       normalModelWorkTurnIds.delete(turn.id);
       completedSummaryRecoveryTurnIds.delete(turn.id);
@@ -10375,6 +10383,9 @@ export class CodexAgent extends BaseAgent {
             type: 'error',
             data: {
               ...classified.data,
+              ...(completedCompactionTransportInterrupted
+                ? { reason: CODEX_COMPACTION_TRANSPORT_INTERRUPTED_REASON }
+                : {}),
               isTerminal: true,
             },
             source: 'codex',

--- a/packages/maker-core/src/agents/codex/translator.ts
+++ b/packages/maker-core/src/agents/codex/translator.ts
@@ -340,6 +340,8 @@ interface TranslatorLog {
 export interface CodexTranslateContext {
   rt: CodexRuntimeState;
   log: TranslatorLog;
+  /** Stable host classification that is known only from surrounding turn state. */
+  errorReasonOverride?: string;
   /**
    * Maker Memory flush 观察器 — codex contextCompaction completed 时调,
    * controller 重置 fired 阈值 (compact 后 context 又有空间, 可重新触发)。
@@ -557,7 +559,10 @@ export function translateErrorNotification(
   const errorStatus = classified.errorStatus;
   const isCapacityError = classified.isCapacityError;
   const errorInfoTag = classified.errorInfoTag;
-  const safeErrorData = classified.data;
+  const safeErrorData = {
+    ...classified.data,
+    ...(ctx.errorReasonOverride ? { reason: ctx.errorReasonOverride } : {}),
+  };
   // willRetry=true 的暂时错误 (transient API blip / 5xx blip), server 自己会重试 — 默认
   // 不 emit error event 给 UI,否则会把瞬时错误暴露成用户可见失败。**但** auth 缺失
   // (401/Unauthorized/Missing bearer) 是 daemon 怎么 retry 也不可能自愈的 —— 必须

--- a/packages/maker-core/src/agents/index.ts
+++ b/packages/maker-core/src/agents/index.ts
@@ -7,6 +7,7 @@ export type {
   ClaudeSubagentModelAccessStatus,
 } from './claude-code/subagent-model-access.js';
 export { CodexAgent } from './codex/index.js';
+export { CODEX_COMPACTION_TRANSPORT_INTERRUPTED_REASON } from './codex/compaction-transport-interrupt.js';
 export { isCodexHistoryRecoveryRequired } from './codex/history-recovery.js';
 export {
   CODEX_HISTORY_OVERSIZED_REASON,


### PR DESCRIPTION
## 这次改了什么

### 摘要

Codex 原生压缩正在进行时，如果响应流断开，压缩请求可能已经被上游接受，客户端却无法确认结果。此前该错误会落入通用恢复：本地摘要 fallback 可能接管，Retry 也可能重放压缩前的原始任务，造成重复工具副作用或丢失已压缩的 turn 边界。

本 PR 为这个结果不明的窗口增加稳定错误分类，并让自动续跑与人工 Retry 都只发送 CONTINUE。明确的远端压缩拒绝仍保留现有本地摘要 fallback，其他普通错误的恢复行为不变。

### 变更类型

- [ ] `feat` 新功能
- [x] `fix` 缺陷修复
- [ ] `refactor` / `perf` 重构或性能优化
- [ ] `docs` / `test` / `chore` 文档、测试或工程维护
- [ ] 其他：

### 范围

- 关联 Issue / 需求：Fixes #4371
- 本 PR 包含：压缩期不确定传输错误分类；阻止该错误触发本地摘要 fallback；自动续跑和人工 Retry 的 CONTINUE-only 恢复；maker-core 与 desktop 回归测试；行为文档更新。
- 明确不包含：更改 Codex 压缩协议、远端压缩实现或通用网络重试策略。
- 用户可见变化：压缩期间断流后，Retry 从已接受 turn 继续，不再重新发送原始任务。
- 是否存在 breaking change：无。

### UI 变化

不涉及：只调整 maker-core 错误分类与 desktop main 进程恢复语义，没有视觉、交互布局或文案变更。

- 引用的设计规范：不涉及。

## 怎么验证的

### 自动验证

```text
pnpm --dir apps/desktop exec vitest run --pool=threads --maxWorkers=1 \
  src/main/maker-ipc/__tests__/agent-input-coordinator.test.ts \
  src/main/maker-ipc/__tests__/interruptedTurnAutoResume.test.ts
结果：436 passed

pnpm --dir packages/maker-core exec vitest run --pool=forks --maxWorkers=1 \
  src/agents/codex/index.test.ts -t compact
结果：52 passed, 755 skipped

pnpm --filter desktop run --if-present typecheck
结果：通过

pnpm check:dco
结果：通过（1 commit signed off）

git diff --check origin/main...HEAD
结果：通过
```

仓库规定的 `pnpm test:unit:related` 已完整运行，但没有全绿：maker-core 969/969、lizi-mcps 781/781、orca-workflow 40/40 均通过；Desktop full 中 2580/2601 个文件通过，21 个未改路径的文件失败（51/36492 tests），主要是 5 秒超时和本机 Swift module cache `Operation not permitted`。本 PR 修改的两个 Desktop 目标文件在该 run 中通过，并在单 worker 定向复跑中 436/436 通过。一个未改的 Agent Island service 用例默认 5 秒门限下约 5.03 秒超时；相对 `origin/main` 的实现与测试无 diff，诊断性 30 秒门限复跑在 5.303 秒通过。

### 手工验证

不涉及：该恢复边界由构造的 Codex 压缩/断流事件与 coordinator 回归测试验证。

### 未执行的验证

- 未在 Windows 实机触发真实 Codex 断流；平台无关的错误分类和恢复路径已由单元测试覆盖。

## 风险

### 风险分类

- [ ] 无已知风险
- [ ] SQLite / migration
- [ ] system prompt
- [x] 协议兼容
- [ ] 权限 / 安全 / 用户数据
- [ ] 存量插件兼容（批准状态 / 指纹 / manifest 校验 / 安装布局 / 包格式）
- [ ] 原生层 / fingerprint / OTA
- [ ] 跨平台差异
- [ ] 其他：

### 影响与回滚

- 影响范围：仅 Codex 原生压缩 active turn 的终态传输不确定窗口；wire protocol 和持久化格式不变。
- 回滚 / 降级方式：回退本提交即可恢复原有通用错误分类和 Retry 行为。

### 提交前检查

- [x] 已 review 完整 diff
- [x] 每个 commit 都带 DCO 签名（`git commit -s`，见 [DCO](../DCO)）
- [x] UI 改动已在「UI 变化」注明引用的设计规范章节（不涉及 UI 则跳过）
- [x] 未提交凭证、令牌或授权文件
- [x] 已核对受影响的文档，行为变化涉及的旧结论已同步修订（不涉及则无需修改文档）
- [x] 已确认测试结果或说明未执行原因
