### PR TITLE
fix(mobile): 恢复模型目录加载失败后的自动重试

### DIFF
--- a/apps/mobile/app/sessions/[sessionId].tsx
+++ b/apps/mobile/app/sessions/[sessionId].tsx
@@ -1991,7 +1991,7 @@ export default function SessionScreen() {
     [sessionId, sessions],
   );
   const sessionManagedByHost = isHostManagedSession(currentSession);
-  const composerDeviceProviders = useDeviceProviders(deviceId || undefined);
+  const composerDeviceProviders = useDeviceProviders(deviceId || undefined, modelSheetOpen);
   const accountProvider = composerDeviceProviders.ready
     ? composerDeviceProviders.providers.find((provider) => provider.id === currentSession?.providerId)
     : undefined;

--- a/apps/mobile/app/sessions/new.tsx
+++ b/apps/mobile/app/sessions/new.tsx
@@ -749,7 +749,7 @@ export default function NewRemoteSessionScreen() {
     [capabilities, draft.model],
   );
   // 被控端供应商目录 → provider-aware 模型分段(对齐桌面)。0 供应商 / 旧被控端 → 回退扁平列表。
-  const deviceProviders = useDeviceProviders(selectedDeviceId || undefined);
+  const deviceProviders = useDeviceProviders(selectedDeviceId || undefined, modelSheetOpen);
   // 模型列表元信息(单价 / 折扣版 key presence)+ 草稿 per-(agent,来源,模型) 记忆(对齐桌面)。
   const deviceModelPricing = useDeviceModelPricing(selectedDeviceId || undefined);
   const deviceApiKeyStatus = useDeviceApiKeyStatus(selectedDeviceId || undefined);

--- a/apps/mobile/src/__tests__/deviceProvidersReadiness.test.tsx
+++ b/apps/mobile/src/__tests__/deviceProvidersReadiness.test.tsx
@@ -20,8 +20,14 @@ import { canUseFlatModelFallback } from '@/session/modelPickerSheetModel';
 import { resolveNewSessionAutoDefault } from '@/session/newSession';
 
 const transport = vi.hoisted(() => ({ listProviders: vi.fn(), epoch: 0 }));
-vi.mock('@/device-link/DeviceLinkContext', () => ({ useDeviceLink: () => ({ connectionEpoch: transport.epoch }) }));
+vi.mock('@/device-link/DeviceLinkContext', () => ({ useDeviceLink: () => ({
+  connectionEpoch: transport.epoch, status: 'online', recoveringDeviceIds: new Set(),
+}) }));
 vi.mock('@/device-link/useMobileMakerTransport', () => ({ useMobileMakerTransport: () => transport }));
+vi.mock('react-native', () => ({ AppState: {
+  currentState: 'active',
+  addEventListener: () => ({ remove() {} }),
+} }));
 
 Object.assign(globalThis, { IS_REACT_ACT_ENVIRONMENT: true });
 let root: Root;
@@ -81,7 +87,7 @@ describe('mobile provider visibility readiness', () => {
     expect(allowsFlatFallback()).toBe(false);
   });
 
-  it('host timeout survives message-only IPC serialization; retries stop and neither picker nor defaults fail open', async () => {
+  it('host timeout survives serialization; exhausted short retries keep defaults closed until recovery', async () => {
     transport.listProviders.mockImplementation(async () => {
       try {
         await waitForModelVisibilityMirror(100);
@@ -93,7 +99,7 @@ describe('mobile provider visibility readiness', () => {
     });
     await act(async () => { root.render(createElement(Probe)); });
     expect(allowsFlatFallback()).toBe(false);
-    await act(async () => { await vi.runAllTimersAsync(); });
+    await act(async () => { await vi.advanceTimersByTimeAsync(1050); });
     expect(transport.listProviders).toHaveBeenCalledTimes(3);
     expect(state).toMatchObject({ ready: false, loading: false, unsupported: false });
     expect(state.error).toContain('[MODEL_VISIBILITY_NOT_READY]');
@@ -106,6 +112,10 @@ describe('mobile provider visibility readiness', () => {
         effortDisplayNames: {}, defaultEffort: 'medium', supportsFastMode: false,
         newSessionDefault: ['codex'] }],
     })).toBeNull();
+    setModelVisibilityMirror({ 'codex:xd:hidden': false }, { fallback: false });
+    await act(async () => { await vi.advanceTimersByTimeAsync(900); });
+    expect(state).toMatchObject({ ready: true, error: null, modelVisibilityOverrides: { 'codex:xd:hidden': false } });
+    expect(allowsFlatFallback()).toBe(false);
   });
 
   it('accepts synchronized switches on retry without an intermediate error or flat fallback', async () => {

--- a/apps/mobile/src/__tests__/useDeviceProvidersRecovery.test.tsx
+++ b/apps/mobile/src/__tests__/useDeviceProvidersRecovery.test.tsx
@@ -1,0 +1,218 @@
+// @vitest-environment jsdom
+import { act, createElement } from 'react';
+import { createRoot, type Root } from 'react-dom/client';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import type { ProviderView } from '@cindy/model-providers/registry';
+import { useDeviceProviders, type UseDeviceProvidersResult } from '@/device-link/useDeviceProviders';
+import { clearAllDeviceProviders, fetchDeviceProvidersFresh } from '@/device-link/deviceProvidersCache';
+
+const state = vi.hoisted(() => ({
+  context: { connectionEpoch: 1, status: 'online', recoveringDeviceIds: new Set<string>() },
+  appState: 'active',
+  listeners: new Set<(next: string) => void>(),
+  makers: new Map<string, { listProviders: ReturnType<typeof vi.fn> }>(),
+}));
+vi.mock('@/device-link/DeviceLinkContext', () => ({ useDeviceLink: () => state.context }));
+vi.mock('@/device-link/useMobileMakerTransport', () => ({
+  useMobileMakerTransport: (id: string) => state.makers.get(id),
+}));
+vi.mock('@/i18n', () => ({ i18n: {} }));
+vi.mock('react-native', () => ({ AppState: {
+  get currentState() { return state.appState; },
+  addEventListener: (_: string, listener: (next: string) => void) => {
+    state.listeners.add(listener);
+    return { remove: () => state.listeners.delete(listener) };
+  },
+} }));
+Object.assign(globalThis, { IS_REACT_ACT_ENVIRONMENT: true });
+let root: Root;
+let values: Record<string, UseDeviceProvidersResult>;
+const catalog = (id: string) => ({ providers: [{ id } as ProviderView] });
+const timeout = () => new Error('[DEVICE_LINK_TIMEOUT] no invoke-result');
+function Probe({ deviceId, open }: { deviceId: string; open: boolean }) {
+  values[deviceId] = useDeviceProviders(deviceId, open);
+  return null;
+}
+async function render(deviceId = 'a', open = false, other = false) {
+  await act(async () => root.render(createElement('div', null,
+    createElement(Probe, { deviceId, open }),
+    other ? createElement(Probe, { deviceId: 'b', open: false }) : null,
+  )));
+}
+async function advance(ms: number) {
+  await act(async () => { await vi.advanceTimersByTimeAsync(ms); });
+}
+async function foreground(next: string) {
+  await act(async () => {
+    state.appState = next;
+    for (const listener of state.listeners) listener(next);
+  });
+}
+beforeEach(() => {
+  vi.useFakeTimers();
+  state.context = { connectionEpoch: 1, status: 'online', recoveringDeviceIds: new Set() };
+  state.appState = 'active';
+  state.makers.clear();
+  state.makers.set('a', { listProviders: vi.fn().mockRejectedValue(timeout()) });
+  state.makers.set('b', { listProviders: vi.fn().mockResolvedValue(catalog('b')) });
+  values = {};
+  root = createRoot(document.createElement('div'));
+});
+afterEach(async () => {
+  await act(async () => root.unmount());
+  clearAllDeviceProviders();
+  expect(state.listeners.size).toBe(0);
+  vi.useRealTimers();
+});
+
+describe('model catalog failure recovery', () => {
+  it('recovers without a new relay epoch and leaves another device untouched', async () => {
+    const read = state.makers.get('a')!.listProviders;
+    await render('a', false, true);
+    expect(values.a.ready).toBe(false);
+    expect(values.a.error).toContain('TIMEOUT');
+    read.mockResolvedValue(catalog('recovered'));
+    await advance(900);
+    expect(values.a.ready).toBe(true);
+    expect(values.a.error).toBeNull();
+    expect(values.a.providers[0].id).toBe('recovered');
+    expect(state.makers.get('b')!.listProviders).toHaveBeenCalledTimes(1);
+    expect(values.b.ready).toBe(true);
+    expect(state.context.connectionEpoch).toBe(1);
+    await advance(60_000);
+    expect(read).toHaveBeenCalledTimes(2);
+  });
+
+  it('reopening a failed picker retries immediately, including a retained stale cache', async () => {
+    const read = state.makers.get('a')!.listProviders;
+    read.mockResolvedValue(catalog('old'));
+    await render();
+    await act(async () => {
+      await fetchDeviceProvidersFresh('a', async () => { throw timeout(); }).catch(() => undefined);
+    });
+    expect(values.a.ready).toBe(false);
+    read.mockResolvedValue(catalog('new'));
+    await render('a', true);
+    await advance(0);
+    expect(values.a.providers[0].id).toBe('new');
+    expect(values.a.error).toBeNull();
+  });
+
+  it('backs off repeated failures and pauses in background', async () => {
+    const read = state.makers.get('a')!.listProviders;
+    await render();
+    await advance(900);
+    expect(read).toHaveBeenCalledTimes(2);
+    await advance(1799);
+    expect(read).toHaveBeenCalledTimes(2);
+    await advance(1);
+    expect(read).toHaveBeenCalledTimes(3);
+    await foreground('background');
+    await advance(60_000);
+    expect(read).toHaveBeenCalledTimes(3);
+    read.mockResolvedValue(catalog('back'));
+    await foreground('active');
+    await advance(0);
+    expect(values.a.ready).toBe(true);
+  });
+
+  it('waits for peer recovery, then retries without waiting for relay reconnect', async () => {
+    state.context.recoveringDeviceIds.add('a');
+    const read = state.makers.get('a')!.listProviders;
+    await render();
+    await advance(60_000);
+    expect(read).toHaveBeenCalledTimes(1);
+    state.context.recoveringDeviceIds.delete('a');
+    read.mockResolvedValue(catalog('back'));
+    await render();
+    await advance(900);
+    expect(values.a.ready).toBe(true);
+  });
+
+  it.each(['ACCESS_REVOKED', 'CHANNEL_NOT_ALLOWED', 'PERMISSION_DENIED'])('does not retry %s', async (code) => {
+    const read = state.makers.get('a')!.listProviders;
+    read.mockRejectedValue(new Error(`[${code}] denied`));
+    await render('a', true);
+    await advance(60_000);
+    expect(read).toHaveBeenCalledTimes(1);
+    expect(values.a.ready).toBe(false);
+  });
+
+  it('continues recovery after model preference readiness exhausts its short retries', async () => {
+    const read = state.makers.get('a')!.listProviders;
+    read.mockRejectedValue(new Error('[MODEL_VISIBILITY_NOT_READY] pending'));
+    await render();
+    await advance(750);
+    expect(values.a.error).toContain('MODEL_VISIBILITY_NOT_READY');
+    read.mockResolvedValue(catalog('ready'));
+    await advance(900);
+    expect(values.a.ready).toBe(true);
+  });
+
+  it('keeps backoff when transient error details change, even with the picker open', async () => {
+    const read = state.makers.get('a')!.listProviders;
+    let sequence = 0;
+    read.mockImplementation(async () => { throw new Error(`[DEVICE_LINK_TIMEOUT] request ${++sequence}`); });
+    await render('a', true);
+    await advance(0);
+    expect(read).toHaveBeenCalledTimes(2);
+    await advance(899);
+    expect(read).toHaveBeenCalledTimes(2);
+    await advance(1);
+    expect(read).toHaveBeenCalledTimes(3);
+    await advance(1799);
+    expect(read).toHaveBeenCalledTimes(3);
+  });
+
+  it('recovers a previously unresponsive device through the same delayed read', async () => {
+    const read = state.makers.get('a')!.listProviders;
+    read.mockRejectedValue(new Error('[DEVICE_UNRESPONSIVE] probe pending'));
+    await render();
+    read.mockResolvedValue(catalog('responsive'));
+    await advance(900);
+    expect(values.a.ready).toBe(true);
+  });
+
+  it('shares the retry with another consumer and stops scheduling after unmount', async () => {
+    const read = state.makers.get('a')!.listProviders;
+    await act(async () => root.render(createElement('div', null,
+      createElement(Probe, { deviceId: 'a', open: false }),
+      createElement(Probe, { deviceId: 'a', open: false }),
+    )));
+    let reject!: (error: Error) => void;
+    read.mockImplementation(() => new Promise((_, fail) => { reject = fail; }));
+    await advance(900);
+    expect(read).toHaveBeenCalledTimes(2);
+    await act(async () => root.render(null));
+    await act(async () => reject(timeout()));
+    await advance(60_000);
+    expect(read).toHaveBeenCalledTimes(2);
+  });
+
+  it('does not schedule catalog retries while the relay is offline', async () => {
+    const read = state.makers.get('a')!.listProviders;
+    state.context.status = 'connecting';
+    await render('a', true);
+    await advance(60_000);
+    expect(read).toHaveBeenCalledTimes(1);
+    state.context.status = 'online';
+    state.context.connectionEpoch++;
+    read.mockResolvedValue(catalog('online'));
+    await render('a', true);
+    await advance(900);
+    expect(values.a.ready).toBe(true);
+  });
+
+  it('cancels scheduled retries on device change and ignores late results in the new device UI', async () => {
+    const read = state.makers.get('a')!.listProviders;
+    await render();
+    let resolve!: (value: ReturnType<typeof catalog>) => void;
+    read.mockImplementation(() => new Promise((done) => { resolve = done; }));
+    await advance(900);
+    await render('b');
+    await act(async () => resolve(catalog('late-a')));
+    await advance(60_000);
+    expect(values.b.providers[0].id).toBe('b');
+    expect(read).toHaveBeenCalledTimes(2);
+  });
+});

--- a/apps/mobile/src/__tests__/useDeviceProvidersRecovery.test.tsx
+++ b/apps/mobile/src/__tests__/useDeviceProvidersRecovery.test.tsx
@@ -2,6 +2,9 @@
 import { act, createElement } from 'react';
 import { createRoot, type Root } from 'react-dom/client';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { EventEmitter } from 'node:events';
+import { DeviceLinkClient, PROTOCOL_VERSION, DEVICE_LINK_CAPABILITY_RELIABLE_TRANSPORT,
+  type Envelope, type WsLike } from '@cindy/device-link';
 import type { ProviderView } from '@cindy/model-providers/registry';
 import { useDeviceProviders, type UseDeviceProvidersResult } from '@/device-link/useDeviceProviders';
 import { clearAllDeviceProviders, fetchDeviceProvidersFresh } from '@/device-link/deviceProvidersCache';
@@ -66,6 +69,96 @@ afterEach(async () => {
 });
 
 describe('model catalog failure recovery', () => {
+  it('keeps a second controller link and pending request intact when the first controller goes silent', async () => {
+    // Three real clients behind an in-memory relay: A and B both control host.
+    const sockets = new Map<string, Socket>();
+    let silentA = false;
+    class Socket extends EventEmitter implements WsLike {
+      constructor(readonly id: string) { super(); }
+      close = vi.fn(() => { this.emit('close', 1000); });
+      deliver(frame: Envelope) { this.emit('message', { toString: () => JSON.stringify(frame) }); }
+      send(data: string) {
+        const frame = JSON.parse(data) as Envelope;
+        void Promise.resolve().then(() => {
+          if (frame.kind === 'hello') {
+            this.deliver({ v: PROTOCOL_VERSION, kind: 'hello-ack', payload: {
+              serverProtocolVersion: PROTOCOL_VERSION, deviceId: this.id, userId: 'test-user',
+            } });
+          } else if (frame.dst && !(silentA && (this.id === 'a' || frame.dst === 'a'))) {
+            sockets.get(frame.dst)?.deliver({ ...frame, src: this.id });
+          }
+        });
+      }
+    }
+    const client = (id: string) => new DeviceLinkClient({
+      getWsUrl: () => 'ws://test-relay', getToken: async () => 'fake-token',
+      getHello: () => ({ deviceName: id, platform: 'darwin', appVersion: 'test', remoteControlEnabled: true, busy: false }),
+      createWebSocket: () => {
+        const socket = new Socket(id); sockets.set(id, socket);
+        return socket;
+      },
+      timing: { pingIntervalMs: 1_000_000, requestTimeoutMs: 50 },
+    });
+    const host = client('host'), a = client('a'), b = client('b');
+    let heldRequest: Envelope | undefined;
+    host.onFrame((frame) => {
+      if (frame.kind === 'link-open') host.sendLinkAccept(frame.src!, frame.id!, {
+        appVersion: 'test', allowlistHash: 'test', capabilities: [DEVICE_LINK_CAPABILITY_RELIABLE_TRANSPORT],
+      });
+      if (frame.kind === 'invoke') {
+        if (frame.src === 'b') heldRequest = frame;
+        else {
+          // First request reaches host, but A then stops receiving/ACKing.
+          if (!values.host?.error) silentA = true;
+          host.sendInvokeResult('a', frame.id!, { ok: true, result: catalog('recovered') });
+        }
+      }
+    });
+    try {
+      host.start(); a.start(); b.start();
+      await advance(0);
+      for (const socket of sockets.values()) socket.emit('open');
+      await advance(0);
+      const opening = Promise.all([a, b].map((controller) => controller.openLink('host', {
+        controllerName: 'test-controller', protocolVersion: PROTOCOL_VERSION, appVersion: 'test',
+      })));
+      await advance(0); await opening;
+      const bGeneration = b.getPeerLinkGeneration('host');
+      const hostGeneration = host.getPeerLinkGeneration('b');
+      const pending = b.invoke('host', { channel: 'local-db:sessions:list', args: [] }, 10_000);
+      void pending.catch(() => undefined);
+      const settled = vi.fn(); void pending.then(settled, settled);
+      const read = vi.fn(async () => {
+        const result = await a.invoke('host', { channel: 'maker:provider:list', args: [] }, values.host?.error ? 5_000 : 50);
+        if (!result.ok) throw new Error(result.error?.message);
+        return result.result;
+      });
+      state.makers.set('host', { listProviders: read });
+      await render('host');
+      await advance(50);
+      expect(values.host.ready).toBe(false);
+      expect(values.host.error).toContain('TIMEOUT');
+      silentA = false;
+      await advance(900);
+      // Allow the reliable stream to replay the lost earlier response first.
+      await advance(3_000);
+      expect(values.host.ready).toBe(true);
+      expect(read).toHaveBeenCalledTimes(2);
+      expect(settled).not.toHaveBeenCalled();
+      expect(b.isLinkReady('host')).toBe(true);
+      expect(host.isLinkReady('b')).toBe(true);
+      expect(b.getPeerLinkGeneration('host')).toBe(bGeneration);
+      expect(host.getPeerLinkGeneration('b')).toBe(hostGeneration);
+      for (const socket of sockets.values()) expect(socket.close).not.toHaveBeenCalled();
+      host.sendInvokeResult('b', heldRequest!.id!, { ok: true, result: ['uninterrupted'] });
+      await advance(0);
+      expect(await pending).toEqual({ ok: true, result: ['uninterrupted'] });
+    } finally {
+      await act(async () => root.render(null));
+      a.stop(); b.stop(); host.stop();
+    }
+  });
+
   it('recovers without a new relay epoch and leaves another device untouched', async () => {
     const read = state.makers.get('a')!.listProviders;
     await render('a', false, true);
@@ -138,9 +231,12 @@ describe('model catalog failure recovery', () => {
     expect(values.a.ready).toBe(false);
   });
 
-  it('continues recovery after model preference readiness exhausts its short retries', async () => {
+  it.each([
+    '[MODEL_VISIBILITY_NOT_READY] pending',
+    "Error invoking remote method 'maker:provider:list': Error: [MODEL_VISIBILITY_NOT_READY] pending",
+  ])('continues recovery after preference readiness exhausts short retries: %s', async (message) => {
     const read = state.makers.get('a')!.listProviders;
-    read.mockRejectedValue(new Error('[MODEL_VISIBILITY_NOT_READY] pending'));
+    read.mockRejectedValue(new Error(message));
     await render();
     await advance(750);
     expect(values.a.error).toContain('MODEL_VISIBILITY_NOT_READY');

--- a/apps/mobile/src/__tests__/useDeviceProvidersRecovery.test.tsx
+++ b/apps/mobile/src/__tests__/useDeviceProvidersRecovery.test.tsx
@@ -7,7 +7,7 @@ import { DeviceLinkClient, PROTOCOL_VERSION, DEVICE_LINK_CAPABILITY_RELIABLE_TRA
   type Envelope, type WsLike } from '@cindy/device-link';
 import type { ProviderView } from '@cindy/model-providers/registry';
 import { useDeviceProviders, type UseDeviceProvidersResult } from '@/device-link/useDeviceProviders';
-import { clearAllDeviceProviders, fetchDeviceProvidersFresh } from '@/device-link/deviceProvidersCache';
+import { clearAllDeviceProviders, evictDeviceProviders, fetchDeviceProviders, fetchDeviceProvidersFresh } from '@/device-link/deviceProvidersCache';
 
 const state = vi.hoisted(() => ({
   context: { connectionEpoch: 1, status: 'online', recoveringDeviceIds: new Set<string>() },
@@ -69,6 +69,42 @@ afterEach(async () => {
 });
 
 describe('model catalog failure recovery', () => {
+  it('continues recovery when an external fresh read invalidates an ordinary in-flight read', async () => {
+    const read = state.makers.get('a')!.listProviders;
+    await render();
+    let finish!: (value: ReturnType<typeof catalog>) => void;
+    await act(async () => {
+      const old = fetchDeviceProviders('a', () => new Promise((resolve) => { finish = resolve; }));
+      await fetchDeviceProvidersFresh('a', () => read()).catch(() => undefined);
+      finish(catalog('obsolete'));
+      await old;
+    });
+    expect(values.a.ready).toBe(false);
+    read.mockResolvedValue(catalog('current'));
+    await advance(900);
+    expect(values.a.ready).toBe(true);
+    expect(values.a.providers[0].id).toBe('current');
+  });
+
+  it.each(['evict', 'clearAll'] as const)('continues recovery after %s and an identical immediate failure', async (operation) => {
+    const read = state.makers.get('a')!.listProviders;
+    read.mockRejectedValue(new Error('[DEVICE_UNRESPONSIVE] probe pending'));
+    await render();
+    await advance(400);
+    await act(async () => {
+      if (operation === 'evict') evictDeviceProviders('a');
+      else clearAllDeviceProviders();
+    });
+    expect(read).toHaveBeenCalledTimes(2);
+    expect(values.a.ready).toBe(false);
+    read.mockResolvedValue(catalog('new-generation'));
+    await advance(900);
+    expect(read).toHaveBeenCalledTimes(3);
+    expect(values.a.ready).toBe(true);
+    await advance(60_000);
+    expect(read).toHaveBeenCalledTimes(3);
+  });
+
   it('keeps a second controller link and pending request intact when the first controller goes silent', async () => {
     // Three real clients behind an in-memory relay: A and B both control host.
     const sockets = new Map<string, Socket>();

--- a/apps/mobile/src/device-link/deviceProvidersCache.ts
+++ b/apps/mobile/src/device-link/deviceProvidersCache.ts
@@ -27,6 +27,11 @@ function providerErrorCode(error: unknown): string | undefined {
   return /^(?:Error invoking remote method '[^']+': Error: )?\[([A-Z0-9_]+)\]/.exec(message)?.[1];
 }
 
+/** Short retries and mounted-picker recovery must recognize the same IPC forms. */
+export function isDeviceProvidersVisibilityNotReadyError(error: unknown): boolean {
+  return providerErrorCode(error) === 'MODEL_VISIBILITY_NOT_READY';
+}
+
 /** Only an explicitly unsupported channel permits the legacy capabilities fallback. */
 export function isDeviceProvidersUnsupportedError(error: unknown): boolean {
   const code = providerErrorCode(error);
@@ -41,7 +46,7 @@ async function requestDeviceProviders(
     try {
       return await fetcher();
     } catch (error) {
-      if (providerErrorCode(error) !== 'MODEL_VISIBILITY_NOT_READY' || attempt >= 2 || !isCurrent()) throw error;
+      if (!isDeviceProvidersVisibilityNotReadyError(error) || attempt >= 2 || !isCurrent()) throw error;
       await new Promise((resolve) => setTimeout(resolve, 250 * 2 ** attempt));
       if (!isCurrent()) throw error;
     }

--- a/apps/mobile/src/device-link/useDeviceProviders.ts
+++ b/apps/mobile/src/device-link/useDeviceProviders.ts
@@ -23,6 +23,7 @@ import {
   getDeviceProvidersGen,
   markDeviceFetchEpoch,
   isDeviceProvidersUnsupportedError,
+  isDeviceProvidersVisibilityNotReadyError,
   subscribeDeviceProviders,
   subscribeDeviceProvidersGen,
   subscribeDeviceProvidersError,
@@ -54,7 +55,7 @@ const EMPTY_PAYLOAD: DeviceProvidersPayload = { providers: [] };
 
 function canRecoverProviderRead(error: unknown): boolean {
   return isAutoRecoveringRemoteError(error)
-    || formatRemoteError(error).startsWith('[MODEL_VISIBILITY_NOT_READY]');
+    || isDeviceProvidersVisibilityNotReadyError(error);
 }
 
 /** 取被控设备的供应商目录;deviceId 省略 = 不拉取(返回空,调用方回退扁平列表)。 */

--- a/apps/mobile/src/device-link/useDeviceProviders.ts
+++ b/apps/mobile/src/device-link/useDeviceProviders.ts
@@ -9,10 +9,11 @@
  * reject → 暴露 unsupported,调用方才回退到基于 capabilities 的扁平模型列表。
  */
 import { useEffect, useState } from 'react';
+import { AppState } from 'react-native';
 
 import type { ProviderView } from '@cindy/model-providers/registry';
 
-import { formatRemoteError } from './remoteStatus';
+import { connectionRecoverySyncRetryDelayMs, formatRemoteError, isAutoRecoveringRemoteError } from './remoteStatus';
 import { useDeviceLink } from './DeviceLinkContext';
 import {
   fetchDeviceProviders,
@@ -51,15 +52,21 @@ export interface UseDeviceProvidersResult {
 
 const EMPTY_PAYLOAD: DeviceProvidersPayload = { providers: [] };
 
+function canRecoverProviderRead(error: unknown): boolean {
+  return isAutoRecoveringRemoteError(error)
+    || formatRemoteError(error).startsWith('[MODEL_VISIBILITY_NOT_READY]');
+}
+
 /** 取被控设备的供应商目录;deviceId 省略 = 不拉取(返回空,调用方回退扁平列表)。 */
-export function useDeviceProviders(deviceId?: string): UseDeviceProvidersResult {
+export function useDeviceProviders(deviceId?: string, pickerOpen = false): UseDeviceProvidersResult {
   // hooks 规则:无条件取 transport(deviceId 空时其 call 会 reject,但本 hook 不会在空时调用)。
   const maker = useMobileMakerTransport(deviceId ?? '');
   // 连接代际:重连/恢复时 +1。离线驱逐(evict)后重拉失败时,依赖 [deviceId, maker]
   // 的 effect 不会因连接恢复重跑(maker.invoke 跨重连稳定,codex review P2)——把
   // connectionEpoch 纳入 effect 依赖,连接恢复即重跑 effect、经 cache-miss 重新
   // 拉取,不再永久停在 ready=false 的空目录。
-  const { connectionEpoch } = useDeviceLink();
+  const { connectionEpoch, status, recoveringDeviceIds } = useDeviceLink();
+  const recovering = !!deviceId && recoveringDeviceIds.has(deviceId);
   const [payload, setPayload] = useState<DeviceProvidersPayload>(
     deviceId ? getCachedDeviceProviders(deviceId) ?? EMPTY_PAYLOAD : EMPTY_PAYLOAD,
   );
@@ -213,6 +220,50 @@ export function useDeviceProviders(deviceId?: string): UseDeviceProvidersResult 
       unsubscribeError();
     };
   }, [connectionEpoch, deviceId, maker]);
+
+  // A peer link can recover without a new relay epoch. Retry only this failed
+  // catalog read; never reset the transport or turn cached rows into ready data.
+  const needsRecovery = errorDeviceId === deviceId && error !== null && canRecoverProviderRead(error);
+  useEffect(() => {
+    if (!deviceId || !needsRecovery || status !== 'online' || recovering) return;
+    let cancelled = false;
+    let inFlight = false;
+    let attempt = 0;
+    let timer: ReturnType<typeof setTimeout> | undefined;
+    let generation = getDeviceProvidersGen(deviceId);
+    const current = () => !cancelled && generation === getDeviceProvidersGen(deviceId);
+    const schedule = (delay: number) => {
+      clearTimeout(timer);
+      if (!current() || inFlight || AppState.currentState !== 'active') return;
+      timer = setTimeout(() => { void retry(); }, delay);
+    };
+    const retry = async () => {
+      if (!current() || inFlight || AppState.currentState !== 'active') return;
+      inFlight = true;
+      // Fresh bypasses a retained pre-failure cache and shares its in-flight read
+      // with other consumers. Existing generation guards reject late responses.
+      const request = fetchDeviceProvidersFresh(deviceId, () => maker.listProviders());
+      generation = getDeviceProvidersGen(deviceId);
+      try {
+        await request;
+      } catch (failure) {
+        inFlight = false;
+        if (canRecoverProviderRead(failure)) schedule(connectionRecoverySyncRetryDelayMs(attempt++));
+      } finally {
+        inFlight = false;
+      }
+    };
+    const subscription = AppState.addEventListener('change', (next) => {
+      clearTimeout(timer);
+      if (next === 'active') schedule(0);
+    });
+    schedule(pickerOpen ? 0 : connectionRecoverySyncRetryDelayMs(attempt++));
+    return () => {
+      cancelled = true;
+      clearTimeout(timer);
+      subscription.remove();
+    };
+  }, [connectionEpoch, deviceId, needsRecovery, maker, pickerOpen, recovering, status]);
 
   return {
     providers: payload.providers,

--- a/apps/mobile/src/device-link/useDeviceProviders.ts
+++ b/apps/mobile/src/device-link/useDeviceProviders.ts
@@ -74,6 +74,7 @@ export function useDeviceProviders(deviceId?: string, pickerOpen = false): UseDe
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const [errorDeviceId, setErrorDeviceId] = useState<string | null>(null);
+  const [catalogGeneration, setCatalogGeneration] = useState(() => deviceId ? getDeviceProvidersGen(deviceId) : 0);
   // ready 的判定载体:payload 已确认属于哪个设备 + 置位时的缓存代际。仅在缓存命中 /
   // 拉取完成(订阅回调)时置位;切设备 cache-miss 立即清 null。首渲染即按
   // `readyFor === deviceId` 计算,不依赖 effect 先跑,故无「loading 初值 false」窗口;
@@ -102,6 +103,7 @@ export function useDeviceProviders(deviceId?: string, pickerOpen = false): UseDe
   // 该设备首次标记(正常缓存命中快路径,与原 null 语义一致)。
 
   useEffect(() => {
+    setCatalogGeneration(deviceId ? getDeviceProvidersGen(deviceId) : 0);
     if (!deviceId) {
       setPayload(EMPTY_PAYLOAD);
       setError(null);
@@ -143,6 +145,8 @@ export function useDeviceProviders(deviceId?: string, pickerOpen = false): UseDe
     //   响应较晚返回仍通过 isCurrent() 把 fresh 的新目录覆盖回旧目录。
     const unsubscribeGen = subscribeDeviceProvidersGen(deviceId, (reason) => {
       if (cancelled) return;
+      // Restart recovery even when React batches invalidation and an identical error.
+      setCatalogGeneration(getDeviceProvidersGen(deviceId));
       setReadyFor(null);
       if (reason === 'fresh-invalidate') return;
       setPayload(EMPTY_PAYLOAD);
@@ -264,7 +268,7 @@ export function useDeviceProviders(deviceId?: string, pickerOpen = false): UseDe
       clearTimeout(timer);
       subscription.remove();
     };
-  }, [connectionEpoch, deviceId, needsRecovery, maker, pickerOpen, recovering, status]);
+  }, [catalogGeneration, connectionEpoch, deviceId, needsRecovery, maker, pickerOpen, recovering, status]);
 
   return {
     providers: payload.providers,


### PR DESCRIPTION
## 这次改了什么

### 摘要

手机版模型目录请求失败后，打开模型选择器或恢复单台设备的控制连接不一定重新拉取，界面可能一直保留旧错误。为可恢复错误补充带退避的目录刷新；重新打开选择器或回到前台时尽快恢复，复用现有目录请求去重和代际保护。

### 变更类型

- [x] `fix` 缺陷修复

### 范围

- 关联 Issue / 需求：手机远程使用电脑时模型选择器加载失败后的恢复。
- 本 PR 包含：新建页和已有任务页的模型选择器恢复；后台、离线及 peer 恢复中暂停新一轮重试；权限拒绝和不支持通道保留原行为。
- 明确不包含：首次模型请求失败的根因定位、原始错误日志补充、手机掉线修复。尚未证明此改动能解决用户主动重连后仍无法取得模型列表的原始问题。
- 用户可见变化：暂时失败后自动恢复列表，不必依赖整条 relay 连接重建。
- 是否存在 breaking change：无；不改协议、原生依赖或配置。

### UI 变化

- 引用的设计规范：`docs/design-rules/DESIGN.md` §1 内容克制、§10 Light / Dark 双模式。仅调整既有选择器的加载行为，无新增组件、颜色、布局或文案；两种模式均未进行实机目检。

## 怎么验证的

### 自动验证

```text
pnpm test:unit:related — 通过
pnpm --filter mobile run --if-present typecheck — 通过
pnpm --filter mobile exec vitest run src/__tests__/useDeviceProvidersRecovery.test.tsx src/__tests__/useDeviceProviders.test.ts — 48 个用例通过
pnpm --filter mobile test:scope — 通过
pnpm --filter mobile test:smoke — 2 个用例通过
pnpm check:dco — 通过
 git diff --check — 通过
```

新增 18 个恢复用例覆盖无 relay 换代恢复、打开选择器、旧缓存刷新、退避、前后台、权限拒绝、偏好未就绪、错误详情变化、设备切换、请求去重和卸载后的迟到结果；既有偏好就绪测试继续验证恢复前不会开放默认模型。

补充缓存代次变化用例：evict、clearAll 与外部 fresh 作废普通在途请求后仍继续恢复；fresh 用例已验证在修复前失败、修复后通过。恢复循环跟随当前缓存代次，旧代迟到结果不能回写；成功停止，永久错误不重试，卸载取消调度。

### 手工验证

已自审完整 diff 和异步完成路径。未在安装版运行本分支，不将现场连接握手日志视为模型请求成功或修复生效的证据。

### 未执行的验证

iOS / Android 真机和 Light / Dark 目检未执行；本次采用单测与类型检查验证。分支 `fix/mobile-model-picker-recovery`，worktree `cindy-mobile-model-picker-recovery`；未启动 Metro，没有本分支的 Metro 归属或 `__DEV__` build label 证据。全量单测交由 CI；本地按仓库要求执行相关单测。

## 风险

### 风险分类

- [x] 其他：模型目录异步重试与恢复生命周期

### 影响与回滚

- 影响范围：仅 Mobile 的两个模型选择器入口及共享 hook。无 SQLite、system prompt、存量插件、凭证、wire protocol、原生或 fingerprint 输入改动。
- 回滚 / 降级方式：回退本 PR，恢复原有目录加载行为；无数据迁移。
- 三端适配：Mobile 已覆盖新建及已有任务页；设备互联使用原有只读 `maker:provider:list`；SSH 工作区及 Desktop 本机选择器不涉及，本次不改变执行端。
- 故障半径：触发为单个设备的目录读失败，恢复仅重试该设备的读请求，不拆 peer link 或 relay。复用现有 in-flight 去重及退避（上限 30 秒），后台不安排新轮次。
- 隔离证据：hook 测试覆盖两个设备之间互不影响，以及同设备多个消费者共用在途请求。新增三个真实 DeviceLinkClient 与内存 relay 的拓扑测试：A 静默丢帧、不 ACK 后目录超时并恢复，B 的连接代次与在途请求保持不变，所有 socket 均未关闭。未运行真机网络拓扑测试；本 PR 不修改底层 transport / ACK / teardown。

### 提交前检查

- [x] 已 review 完整 diff
- [x] 每个 commit 都带 DCO 签名
- [x] UI 改动已在「UI 变化」注明引用的设计规范章节
- [x] 未提交凭证、令牌或授权文件
- [x] 已核对受影响的文档，无需修订权威产品规则；更新了旧测试对重试终止的断言
- [x] 已确认测试结果或说明未执行原因
