### PR TITLE
feat(helper): 补齐会话操作 MCP 工具(移动/置顶/删除/导出/新窗口/分叉/分支)

### DIFF
--- a/apps/desktop/src/main/__tests__/writableDirectoryGrantWiring.test.ts
+++ b/apps/desktop/src/main/__tests__/writableDirectoryGrantWiring.test.ts
@@ -39,7 +39,13 @@ describe('writable directory grant wiring', () => {
     expect(create.indexOf('consumeWritableDirectoryPickerGrants({')).toBeLessThan(
       create.indexOf('db.insert(sessions)'),
     );
+    // update handler 只做 adapter,业务体在 updateSessionInDb(MCP 会话操作工具共用同一路径)。
     const update = sessions.slice(updateStart, sessions.indexOf("'local-db:sessions:patch-meta'"));
-    expect(update).toContain('p.extraDirs !== undefined || p.writableDirs !== undefined');
+    expect(update).toContain('return updateSessionInDb(sid, p, opts)');
+    const updateBody = sessions.slice(
+      sessions.indexOf('export async function updateSessionInDb('),
+      sessions.indexOf('export async function patchSessionMetaInDb('),
+    );
+    expect(updateBody).toContain('p.extraDirs !== undefined || p.writableDirs !== undefined');
   });
 });

--- a/apps/desktop/src/main/localDb/ipc/sessions.ts
+++ b/apps/desktop/src/main/localDb/ipc/sessions.ts
@@ -1177,10 +1177,17 @@ export async function clearSessionContextInDb(sessionId: string, atMs?: number):
   }
 }
 
+/**
+ * registerSessionIpc 收到的运行时依赖(closeIdleSessionForMove 等)。MCP 会话操作工具
+ * 不经 IPC 直接调 updateSessionInDb 时沿用同一份,保证与 renderer 路径行为一致。
+ */
+let registeredSessionIpcOpts: RegisterSessionIpcOpts = {};
+
 export function registerSessionIpc(
   readSessionListLogScope: () => string | null = () => null,
   opts: RegisterSessionIpcOpts = {},
 ): void {
+  registeredSessionIpcOpts = opts;
   // interrupted-turn-resume 假阳性修复:每次 last_turn_ended_at 真正落库(正常收尾 /
   // barrier 版收尾 / ack)都广播 lastTurnEndedAt patch —— renderer 的 session 快照可能
   // 是在 turn 飞行中或「done → ended 落库」空窗里取的(startedAt > endedAt),此前
@@ -1660,285 +1667,8 @@ export function registerSessionIpc(
 
   ipcMain.handle('local-db:sessions:update', async (_e, id: unknown, patch: unknown) => {
     const sid = requireString(id, 'id');
-    const ownerScope = captureOwnerScope();
     const p = requireObject(patch, 'patch');
-    if (p.extraDirs !== undefined || p.writableDirs !== undefined) {
-      throwIpcError(
-        'UNSUPPORTED_CAPABILITY',
-        'directory grants must be changed through maker:set-*-dirs',
-      );
-    }
-    const dbClient = getDbClient();
-    const db = dbClient.drizzle;
-    // 工作目录切换必须和发送/懒启动共用同一把路由锁。否则发送可能在
-    // 读取旧目录后、写入新目录前重建 runtime，随后仍在旧目录执行。
-    const update = async () => {
-      if (p.workspaceKind !== undefined) {
-        const value = p.workspaceKind;
-        if (value !== 'project' && value !== 'dialogue') {
-          throwIpcError('INVALID_PARAMS', `invalid workspaceKind: ${String(value)}`);
-        }
-      }
-      const ALLOWED_UPDATE_ORCA_ROLES = new Set<string>(['lead', 'worker']);
-      if (
-        p.orcaRole !== undefined &&
-        p.orcaRole !== null &&
-        !ALLOWED_UPDATE_ORCA_ROLES.has(p.orcaRole as string)
-      ) {
-        throwIpcError('INVALID_PARAMS', `invalid orcaRole: ${String(p.orcaRole)}`);
-      }
-      if (typeof p.workingDir === 'string') {
-        p.workingDir = normalizeWorkingDirForStorage(p.workingDir) ?? null;
-      }
-      const REVIEW_IMMUTABLE_FIELDS = new Set([
-        'workingDir',
-        'workspaceKind',
-        'model',
-        'providerId',
-        'effort',
-        'permissionMode',
-        'fastMode',
-        'planModeEnabled',
-        'orcaRole',
-        'extraDirs',
-        'writableDirs',
-      ]);
-      if (Object.keys(p).some((key) => REVIEW_IMMUTABLE_FIELDS.has(key))) {
-        const [target] = await db
-          .select({ source: sessions.source })
-          .from(sessions)
-          .where(eq(sessions.id, sid))
-          .limit(1);
-        if (target?.source === 'review') {
-          throwIpcError(
-            'UNSUPPORTED_CAPABILITY',
-            'Review task settings are fixed to the source task',
-          );
-        }
-      }
-      // 会话移动转录迁移:patch 带 workingDir 时先留存旧值,update 后对比实际变化。
-      // CLI 转录按 cwd 转码目录存放,workingDir 变了必须跟着搬,否则 resume 报
-      // "No conversation found with session ID"(见 claude-transcript-relocation.ts)。
-      const beforeMove =
-        p.workingDir !== undefined
-          ? (
-              await db
-                .select({
-                  workingDir: sessions.workingDir,
-                  agentKind: sessions.agentKind,
-                  remoteHostId: sessions.remoteHostId,
-                })
-                .from(sessions)
-                .where(eq(sessions.id, sid))
-            )[0]
-          : undefined;
-      const movingLocalNonClaudeSession =
-        beforeMove &&
-        beforeMove.agentKind !== 'cc' &&
-        !beforeMove.remoteHostId &&
-        beforeMove.workingDir &&
-        typeof p.workingDir === 'string' &&
-        p.workingDir &&
-        normalizeWorkingDirForStorage(beforeMove.workingDir) !== p.workingDir;
-      // Pi/Codex keep a live Maker handle whose cwd is fixed at bootstrap. Close it
-      // before persisting the new directory so the next send lazily recreates the
-      // runtime with the moved session's cwd instead of continuing in the old one.
-      if (movingLocalNonClaudeSession) {
-        if (!opts.closeIdleSessionForMove) {
-          throwIpcError('INTERNAL', '会话移动 runtime 操作未配置');
-        }
-        const idle = await opts.closeIdleSessionForMove(sid);
-        if (idle === false) {
-          throwIpcError('PRECONDITION_FAILED', '运行中的任务不能移动');
-        }
-      }
-      // 只有纯设置字段(model/effort 等)才跳过 bump；凡带 activity 字段
-      // (clearedAt / sdkSessionId / status / token 用量等)仍需更新 updatedAt，
-      // 否则本地 /clear 后重启侧栏时间回退旧值。
-      const SETTINGS_ONLY_FIELDS = new Set([
-        'model',
-        'effort',
-        'permissionMode',
-        'fastMode',
-        'planModeEnabled',
-        'providerId',
-        'orcaRole',
-        'extraDirs',
-        'writableDirs',
-        'pinnedAt',
-        'workingDir',
-        'workspaceKind',
-        'title',
-      ]);
-      const isSettingsOnly = Object.keys(p).every((k) => SETTINGS_ONLY_FIELDS.has(k));
-      const setObj = sessionPatchToRow(p as Parameters<typeof sessionPatchToRow>[0], {
-        bumpUpdatedAt: !isSettingsOnly,
-      });
-      if (p.clearedAt !== undefined) {
-        setObj.summary = null;
-        setObj.listPreview = null;
-        setObj.listPreviewRole = null;
-      }
-      // 用户手动改名(重命名框 / 侧边栏)走这条:告诉自动起名收手。同值改名不会让
-      // 条件写落空,不显式说一声的话智能标题会把他刚保存的名字盖掉(review P1)。
-      // **必须先于 UPDATE**:写库是一次 worker RPC 往返,改名提交与这里拿到回执之间
-      // 有真实时间差,在那期间智能标题仍能满足 `WHERE title = 期望值` 把名字盖掉。
-      // 先记号后写库,代价只是写库失败时该会话本进程内不再自动起名 —— 用户毕竟确实
-      // 按下过保存,这个方向的偏差是安全的。
-      if (typeof p.title === 'string') noteUserTitleWritten(sid);
-      await withStatusWriteLock(
-        db,
-        sid,
-        p.status,
-        async () => {
-          if (p.status !== undefined) await assertGenericSessionLifecycleAllowed(db, sid);
-          await writeSessionPatch(db, sid, setObj, p.status);
-          cleanupSessionRuntimeForTerminalStatus(sid, p.status);
-        },
-        p.workingDir !== undefined,
-      );
-      // session-git-pr-context:/clear 经此处写 clearedAt——边界之前的消息对用户
-      // 不可见,PR 引用同步重算(fire-and-forget,内部按 clearedAt/rewindAt 过滤)。
-      if (p.clearedAt !== undefined) {
-        noteSessionClearBoundary(sid, p.clearedAt as string | null);
-        // sidebar-card-mode(codex review):summary 是基于 clear 前内容生成的,clear 后
-        // 已过时;置顶卡片优先用 summary 而非 preview,不清就会继续显示旧任务摘要。
-        // 与 clearedAt 同一句 UPDATE 置空，避免崩溃后非 NULL 缓存绕过 clear 边界。
-        if (isOwnerScopeCurrent(ownerScope)) {
-          broadcastSessionPatched(sid, { summary: null, preview: null }, ownerScope);
-        }
-        void recomputePrRefsForSession(sid).catch(() => undefined);
-      }
-      // workingDir 实际变化的本机 cc 会话:迁移 CLI 转录后再查询返回行/广播,保证
-      // renderer 拿到更新结果时转录已就位(用户可立即续聊),且迁移中持久化的最新
-      // sdkSessionId 能进返回行与广播 patch——否则 renderer 留着旧 resume id,下一次
-      // lazy-create 仍会 resume 到 pre-fork 会话。内部 best-effort 不抛错。
-      // 动态 import 避免 localDb → maker-host 的静态模块环(同下方 sessionTaskSummary)。
-      if (
-        beforeMove &&
-        beforeMove.agentKind === 'cc' &&
-        !beforeMove.remoteHostId &&
-        beforeMove.workingDir &&
-        typeof p.workingDir === 'string' &&
-        p.workingDir &&
-        normalizeWorkingDirForStorage(beforeMove.workingDir) !== p.workingDir
-      ) {
-        const m = await import('../../maker-host/claude-transcript-relocation.js');
-        const reloc = await m.relocateClaudeTranscriptsForSessionMove(
-          sid,
-          beforeMove.workingDir,
-          p.workingDir,
-        );
-        if (reloc.persistedSdkSessionId) {
-          (p as Record<string, unknown>).sdkSessionId = reloc.persistedSdkSessionId;
-        }
-      }
-      const row = await selectSessionWithCount(db, sid);
-      if (!row) throwIpcError('NOT_FOUND', 'Session 不存在');
-      // 取消置顶后摘要不再有展示面,立刻清掉,避免列表/再次置顶前继续吃旧句。
-      if (p.pinnedAt !== undefined && row.pinnedAt == null) {
-        await db.update(sessions).set({ summary: null }).where(eq(sessions.id, sid));
-        row.summary = null;
-      }
-      const updated = sessionToCamel(row);
-      const projectTargetChanged = p.workspaceKind !== undefined || p.workingDir !== undefined;
-      const settingsChanged = Object.keys(p).some((key) => REMOTE_PERSIST_FIELDS.has(key));
-      const titleChanged = p.title !== undefined;
-      // 归档/删除这类纯 status 变化也要广播:本机多窗口收敛靠 sessions:patched,
-      // 否则「在新窗口打开」的副窗口无从得知会话已被移除,仍停留在旧视图(#3175)。
-      const statusChanged = p.status !== undefined;
-      if (
-        (projectTargetChanged || p.status === 'deleted' || p.status === 'archived') &&
-        row.workspaceKind === 'project' &&
-        row.workingDir &&
-        !row.remoteHostId &&
-        isRetainableProjectSessionSource(row.source)
-      ) {
-        const touched = await upsertRecentWorkdir(
-          row.workingDir,
-          Date.now(),
-          process.platform,
-          dbClient,
-        );
-        if (touched) broadcastRecentWorkdirsChanged(row.workingDir, ownerScope);
-      }
-      // status 广播必须用**广播时刻的持久化真值**,不能带请求值 p.status,也不能用
-      // 上方读行的快照:写入(withStatusWriteLock)与广播不在同一串行区间,且读行
-      // 之后、广播之前还有 await(摘要清理 / recent-workdir / 转录迁移),两个窗口
-      // 对同一任务并发操作时,本请求可能在此期间被另一窗口推进到更晚的终态(如
-      // 归档写入后被删除)。用过期值广播会把镜像回滚成旧 UI 状态(已删除任务在
-      // 副窗/控制端复活),且若本广播是最后一条,镜像不会自愈。
-      //
-      // 因此含 status 的 patch 在广播前(所有 await 之后)**重读一次**:重读与广播
-      // 之间无 await,同进程单事件循环下不可能再插入并发写;即便并发删除的广播
-      // 晚于本广播到达,镜像最终也收敛到 deleted。
-      let broadcastStatus = updated.status;
-      if (p.status !== undefined) {
-        const [currentRow] = await db
-          .select({ status: sessions.status })
-          .from(sessions)
-          .where(eq(sessions.id, sid))
-          .limit(1);
-        if (currentRow) broadcastStatus = currentRow.status;
-      }
-      const broadcastPatch =
-        p.pinnedAt === undefined && p.status === undefined
-          ? p
-          : {
-              ...p,
-              ...(p.pinnedAt !== undefined ? { pinnedAt: updated.pinnedAt } : {}),
-              ...(p.status !== undefined ? { status: broadcastStatus } : {}),
-              ...(p.pinnedAt !== undefined && updated.pinnedAt === null ? { summary: null } : {}),
-              ...(p.pinnedAt !== undefined && updated.pinnedAt !== null
-                ? { status: broadcastStatus }
-                : {}),
-            };
-      if (
-        projectTargetChanged ||
-        settingsChanged ||
-        titleChanged ||
-        statusChanged ||
-        p.pinnedAt !== undefined
-      ) {
-        if (isOwnerScopeCurrent(ownerScope)) {
-          broadcastSessionPatched(sid, broadcastPatch, ownerScope);
-        }
-      }
-      // sidebar-card-mode: 会话被置顶那一刻补生成任务摘要(turn-done 路径只覆盖
-      // "置顶后又跑过 turn"的会话)。动态 import 避免 localDb → maker-host 的静态
-      // 模块环;fire-and-forget,模块内部自带置顶/节流守卫。
-      if (p.pinnedAt !== undefined && updated.pinnedAt !== null) {
-        void import('../../sessionTaskSummary.js').then((m) =>
-          m.maybeGenerateSessionTaskSummary(sid, { force: true }),
-        );
-      }
-      notifyAgentIslandSessionPatch(updated.id, {
-        status: updated.status,
-        title: updated.title,
-        workingDir: updated.workingDir,
-        workspaceKind: updated.workspaceKind,
-      });
-      scheduleWorktreeRecycleForStatusChange(sid, p.status, { ownerScope, mediaDb: db });
-      notifyGhostSessionStatusChange(sid, p.status, updated.workingDir);
-      cleanupSessionTerminalArtifacts(sid, p.status);
-      compactTerminalSessionToolResults(dbClient, sid, p.status);
-      return updated;
-    };
-    if (p.workingDir === undefined) return update();
-    return withSessionRouteLock(sid, async () => {
-      const [binding] = await db
-        .select({ remoteHostId: sessions.remoteHostId })
-        .from(sessions)
-        .where(eq(sessions.id, sid))
-        .limit(1);
-      const resource =
-        !binding?.remoteHostId && typeof p.workingDir === 'string'
-          ? managedWorktreeRoot(p.workingDir)
-          : null;
-      const resources = await readSessionWorktreeResources(db, sid);
-      if (resource) resources.push(resource);
-      return withWorktreeMutation(resources, update);
-    });
+    return updateSessionInDb(sid, p, opts);
   });
 
   // 窄口径会话元数据编辑(status / title / pinnedAt)。专为 device-link 控制端**远程**
@@ -1985,6 +1715,297 @@ export function registerSessionIpc(
       m.setPinnedSectionCardMode(enabled);
     },
   );
+}
+
+/**
+ * `local-db:sessions:update` 的业务体。renderer 的 sessionService.update 与 MCP
+ * 会话操作工具(move / pin / delete 等)共用这一条路径:路由锁 + worktree 锁、
+ * review 会话拒改、Pi/Codex 空闲 runtime 关闭、cc 转录目录搬迁、recent-workdir
+ * 维护、sessions:patched 广播与 agent-island 通知都在这里,不得另起平行写入链路。
+ */
+export async function updateSessionInDb(
+  sid: string,
+  p: Record<string, unknown>,
+  opts: RegisterSessionIpcOpts = registeredSessionIpcOpts,
+): Promise<ReturnType<typeof sessionToCamel>> {
+  const ownerScope = captureOwnerScope();
+  if (p.extraDirs !== undefined || p.writableDirs !== undefined) {
+    throwIpcError(
+      'UNSUPPORTED_CAPABILITY',
+      'directory grants must be changed through maker:set-*-dirs',
+    );
+  }
+  const dbClient = getDbClient();
+  const db = dbClient.drizzle;
+  // 工作目录切换必须和发送/懒启动共用同一把路由锁。否则发送可能在
+  // 读取旧目录后、写入新目录前重建 runtime，随后仍在旧目录执行。
+  const update = async () => {
+    if (p.workspaceKind !== undefined) {
+      const value = p.workspaceKind;
+      if (value !== 'project' && value !== 'dialogue') {
+        throwIpcError('INVALID_PARAMS', `invalid workspaceKind: ${String(value)}`);
+      }
+    }
+    const ALLOWED_UPDATE_ORCA_ROLES = new Set<string>(['lead', 'worker']);
+    if (
+      p.orcaRole !== undefined &&
+      p.orcaRole !== null &&
+      !ALLOWED_UPDATE_ORCA_ROLES.has(p.orcaRole as string)
+    ) {
+      throwIpcError('INVALID_PARAMS', `invalid orcaRole: ${String(p.orcaRole)}`);
+    }
+    if (typeof p.workingDir === 'string') {
+      p.workingDir = normalizeWorkingDirForStorage(p.workingDir) ?? null;
+    }
+    const REVIEW_IMMUTABLE_FIELDS = new Set([
+      'workingDir',
+      'workspaceKind',
+      'model',
+      'providerId',
+      'effort',
+      'permissionMode',
+      'fastMode',
+      'planModeEnabled',
+      'orcaRole',
+      'extraDirs',
+      'writableDirs',
+    ]);
+    if (Object.keys(p).some((key) => REVIEW_IMMUTABLE_FIELDS.has(key))) {
+      const [target] = await db
+        .select({ source: sessions.source })
+        .from(sessions)
+        .where(eq(sessions.id, sid))
+        .limit(1);
+      if (target?.source === 'review') {
+        throwIpcError(
+          'UNSUPPORTED_CAPABILITY',
+          'Review task settings are fixed to the source task',
+        );
+      }
+    }
+    // 会话移动转录迁移:patch 带 workingDir 时先留存旧值,update 后对比实际变化。
+    // CLI 转录按 cwd 转码目录存放,workingDir 变了必须跟着搬,否则 resume 报
+    // "No conversation found with session ID"(见 claude-transcript-relocation.ts)。
+    const beforeMove =
+      p.workingDir !== undefined
+        ? (
+            await db
+              .select({
+                workingDir: sessions.workingDir,
+                agentKind: sessions.agentKind,
+                remoteHostId: sessions.remoteHostId,
+              })
+              .from(sessions)
+              .where(eq(sessions.id, sid))
+          )[0]
+        : undefined;
+    const movingLocalNonClaudeSession =
+      beforeMove &&
+      beforeMove.agentKind !== 'cc' &&
+      !beforeMove.remoteHostId &&
+      beforeMove.workingDir &&
+      typeof p.workingDir === 'string' &&
+      p.workingDir &&
+      normalizeWorkingDirForStorage(beforeMove.workingDir) !== p.workingDir;
+    // Pi/Codex keep a live Maker handle whose cwd is fixed at bootstrap. Close it
+    // before persisting the new directory so the next send lazily recreates the
+    // runtime with the moved session's cwd instead of continuing in the old one.
+    if (movingLocalNonClaudeSession) {
+      if (!opts.closeIdleSessionForMove) {
+        throwIpcError('INTERNAL', '会话移动 runtime 操作未配置');
+      }
+      const idle = await opts.closeIdleSessionForMove(sid);
+      if (idle === false) {
+        throwIpcError('PRECONDITION_FAILED', '运行中的任务不能移动');
+      }
+    }
+    // 只有纯设置字段(model/effort 等)才跳过 bump；凡带 activity 字段
+    // (clearedAt / sdkSessionId / status / token 用量等)仍需更新 updatedAt，
+    // 否则本地 /clear 后重启侧栏时间回退旧值。
+    const SETTINGS_ONLY_FIELDS = new Set([
+      'model',
+      'effort',
+      'permissionMode',
+      'fastMode',
+      'planModeEnabled',
+      'providerId',
+      'orcaRole',
+      'extraDirs',
+      'writableDirs',
+      'pinnedAt',
+      'workingDir',
+      'workspaceKind',
+      'title',
+    ]);
+    const isSettingsOnly = Object.keys(p).every((k) => SETTINGS_ONLY_FIELDS.has(k));
+    const setObj = sessionPatchToRow(p as Parameters<typeof sessionPatchToRow>[0], {
+      bumpUpdatedAt: !isSettingsOnly,
+    });
+    if (p.clearedAt !== undefined) {
+      setObj.summary = null;
+      setObj.listPreview = null;
+      setObj.listPreviewRole = null;
+    }
+    // 用户手动改名(重命名框 / 侧边栏)走这条:告诉自动起名收手。同值改名不会让
+    // 条件写落空,不显式说一声的话智能标题会把他刚保存的名字盖掉(review P1)。
+    // **必须先于 UPDATE**:写库是一次 worker RPC 往返,改名提交与这里拿到回执之间
+    // 有真实时间差,在那期间智能标题仍能满足 `WHERE title = 期望值` 把名字盖掉。
+    // 先记号后写库,代价只是写库失败时该会话本进程内不再自动起名 —— 用户毕竟确实
+    // 按下过保存,这个方向的偏差是安全的。
+    if (typeof p.title === 'string') noteUserTitleWritten(sid);
+    await withStatusWriteLock(
+      db,
+      sid,
+      p.status,
+      async () => {
+        if (p.status !== undefined) await assertGenericSessionLifecycleAllowed(db, sid);
+        await writeSessionPatch(db, sid, setObj, p.status);
+        cleanupSessionRuntimeForTerminalStatus(sid, p.status);
+      },
+      p.workingDir !== undefined,
+    );
+    // session-git-pr-context:/clear 经此处写 clearedAt——边界之前的消息对用户
+    // 不可见,PR 引用同步重算(fire-and-forget,内部按 clearedAt/rewindAt 过滤)。
+    if (p.clearedAt !== undefined) {
+      noteSessionClearBoundary(sid, p.clearedAt as string | null);
+      // sidebar-card-mode(codex review):summary 是基于 clear 前内容生成的,clear 后
+      // 已过时;置顶卡片优先用 summary 而非 preview,不清就会继续显示旧任务摘要。
+      // 与 clearedAt 同一句 UPDATE 置空，避免崩溃后非 NULL 缓存绕过 clear 边界。
+      if (isOwnerScopeCurrent(ownerScope)) {
+        broadcastSessionPatched(sid, { summary: null, preview: null }, ownerScope);
+      }
+      void recomputePrRefsForSession(sid).catch(() => undefined);
+    }
+    // workingDir 实际变化的本机 cc 会话:迁移 CLI 转录后再查询返回行/广播,保证
+    // renderer 拿到更新结果时转录已就位(用户可立即续聊),且迁移中持久化的最新
+    // sdkSessionId 能进返回行与广播 patch——否则 renderer 留着旧 resume id,下一次
+    // lazy-create 仍会 resume 到 pre-fork 会话。内部 best-effort 不抛错。
+    // 动态 import 避免 localDb → maker-host 的静态模块环(同下方 sessionTaskSummary)。
+    if (
+      beforeMove &&
+      beforeMove.agentKind === 'cc' &&
+      !beforeMove.remoteHostId &&
+      beforeMove.workingDir &&
+      typeof p.workingDir === 'string' &&
+      p.workingDir &&
+      normalizeWorkingDirForStorage(beforeMove.workingDir) !== p.workingDir
+    ) {
+      const m = await import('../../maker-host/claude-transcript-relocation.js');
+      const reloc = await m.relocateClaudeTranscriptsForSessionMove(
+        sid,
+        beforeMove.workingDir,
+        p.workingDir,
+      );
+      if (reloc.persistedSdkSessionId) {
+        (p as Record<string, unknown>).sdkSessionId = reloc.persistedSdkSessionId;
+      }
+    }
+    const row = await selectSessionWithCount(db, sid);
+    if (!row) throwIpcError('NOT_FOUND', 'Session 不存在');
+    // 取消置顶后摘要不再有展示面,立刻清掉,避免列表/再次置顶前继续吃旧句。
+    if (p.pinnedAt !== undefined && row.pinnedAt == null) {
+      await db.update(sessions).set({ summary: null }).where(eq(sessions.id, sid));
+      row.summary = null;
+    }
+    const updated = sessionToCamel(row);
+    const projectTargetChanged = p.workspaceKind !== undefined || p.workingDir !== undefined;
+    const settingsChanged = Object.keys(p).some((key) => REMOTE_PERSIST_FIELDS.has(key));
+    const titleChanged = p.title !== undefined;
+    // 归档/删除这类纯 status 变化也要广播:本机多窗口收敛靠 sessions:patched,
+    // 否则「在新窗口打开」的副窗口无从得知会话已被移除,仍停留在旧视图(#3175)。
+    const statusChanged = p.status !== undefined;
+    if (
+      (projectTargetChanged || p.status === 'deleted' || p.status === 'archived') &&
+      row.workspaceKind === 'project' &&
+      row.workingDir &&
+      !row.remoteHostId &&
+      isRetainableProjectSessionSource(row.source)
+    ) {
+      const touched = await upsertRecentWorkdir(
+        row.workingDir,
+        Date.now(),
+        process.platform,
+        dbClient,
+      );
+      if (touched) broadcastRecentWorkdirsChanged(row.workingDir, ownerScope);
+    }
+    // status 广播必须用**广播时刻的持久化真值**,不能带请求值 p.status,也不能用
+    // 上方读行的快照:写入(withStatusWriteLock)与广播不在同一串行区间,且读行
+    // 之后、广播之前还有 await(摘要清理 / recent-workdir / 转录迁移),两个窗口
+    // 对同一任务并发操作时,本请求可能在此期间被另一窗口推进到更晚的终态(如
+    // 归档写入后被删除)。用过期值广播会把镜像回滚成旧 UI 状态(已删除任务在
+    // 副窗/控制端复活),且若本广播是最后一条,镜像不会自愈。
+    //
+    // 因此含 status 的 patch 在广播前(所有 await 之后)**重读一次**:重读与广播
+    // 之间无 await,同进程单事件循环下不可能再插入并发写;即便并发删除的广播
+    // 晚于本广播到达,镜像最终也收敛到 deleted。
+    let broadcastStatus = updated.status;
+    if (p.status !== undefined) {
+      const [currentRow] = await db
+        .select({ status: sessions.status })
+        .from(sessions)
+        .where(eq(sessions.id, sid))
+        .limit(1);
+      if (currentRow) broadcastStatus = currentRow.status;
+    }
+    const broadcastPatch =
+      p.pinnedAt === undefined && p.status === undefined
+        ? p
+        : {
+            ...p,
+            ...(p.pinnedAt !== undefined ? { pinnedAt: updated.pinnedAt } : {}),
+            ...(p.status !== undefined ? { status: broadcastStatus } : {}),
+            ...(p.pinnedAt !== undefined && updated.pinnedAt === null ? { summary: null } : {}),
+            ...(p.pinnedAt !== undefined && updated.pinnedAt !== null
+              ? { status: broadcastStatus }
+              : {}),
+          };
+    if (
+      projectTargetChanged ||
+      settingsChanged ||
+      titleChanged ||
+      statusChanged ||
+      p.pinnedAt !== undefined
+    ) {
+      if (isOwnerScopeCurrent(ownerScope)) {
+        broadcastSessionPatched(sid, broadcastPatch, ownerScope);
+      }
+    }
+    // sidebar-card-mode: 会话被置顶那一刻补生成任务摘要(turn-done 路径只覆盖
+    // "置顶后又跑过 turn"的会话)。动态 import 避免 localDb → maker-host 的静态
+    // 模块环;fire-and-forget,模块内部自带置顶/节流守卫。
+    if (p.pinnedAt !== undefined && updated.pinnedAt !== null) {
+      void import('../../sessionTaskSummary.js').then((m) =>
+        m.maybeGenerateSessionTaskSummary(sid, { force: true }),
+      );
+    }
+    notifyAgentIslandSessionPatch(updated.id, {
+      status: updated.status,
+      title: updated.title,
+      workingDir: updated.workingDir,
+      workspaceKind: updated.workspaceKind,
+    });
+    scheduleWorktreeRecycleForStatusChange(sid, p.status, { ownerScope, mediaDb: db });
+    notifyGhostSessionStatusChange(sid, p.status, updated.workingDir);
+    cleanupSessionTerminalArtifacts(sid, p.status);
+    compactTerminalSessionToolResults(dbClient, sid, p.status);
+    return updated;
+  };
+  if (p.workingDir === undefined) return update();
+  return withSessionRouteLock(sid, async () => {
+    const [binding] = await db
+      .select({ remoteHostId: sessions.remoteHostId })
+      .from(sessions)
+      .where(eq(sessions.id, sid))
+      .limit(1);
+    const resource =
+      !binding?.remoteHostId && typeof p.workingDir === 'string'
+        ? managedWorktreeRoot(p.workingDir)
+        : null;
+    const resources = await readSessionWorktreeResources(db, sid);
+    if (resource) resources.push(resource);
+    return withWorktreeMutation(resources, update);
+  });
 }
 
 export async function patchSessionMetaInDb(

--- a/apps/desktop/src/main/maker-host/index.ts
+++ b/apps/desktop/src/main/maker-host/index.ts
@@ -927,6 +927,8 @@ export function getMaker(): Maker {
       pluginRegistry,
       resolveIOSSimulatorAccess,
       invokeRemote: remoteInvoke,
+      isSessionTurnRunning: (sessionId: string) =>
+        _maker?.getSession(sessionId)?.isTurnRunning() === true,
       // 只读活跃 Session 的运行时真相。权限切换是 runtime-first、DB-second，
       // 因此插件过户自动放行不得回退 sessions.permission_mode；会话不再 active
       // 时同样 fail closed。闭包在 MCP tool-call 时执行，此时 _maker 已装配完成。

--- a/apps/desktop/src/main/mcp-integrations/__tests__/sessionOperations.test.ts
+++ b/apps/desktop/src/main/mcp-integrations/__tests__/sessionOperations.test.ts
@@ -1,0 +1,259 @@
+/**
+ * sessionOperations 业务体回归测试:GUI 同口径守卫(远程 / 运行中 / IM 接管 / 已归档 /
+ * 空草稿 / review)、NOT_FOUND 整批不写、逐个应用与中途失败的返回形状、fork 错误码映射、
+ * 分支家族遍历。依赖全部注入,不加载 Electron。
+ */
+
+import { describe, expect, it, vi } from 'vitest';
+
+import {
+  deleteSessions,
+  exportSession,
+  forkSession,
+  getSessionBranches,
+  moveSessions,
+  openSessionInNewWindow,
+  setSessionsPinned,
+  type SessionOperationsDeps,
+  type SessionOpsRow,
+} from '../sessionOperations.js';
+
+function row(id: string, patch: Partial<SessionOpsRow> = {}): SessionOpsRow {
+  return {
+    id,
+    title: `title-${id}`,
+    workingDir: '/tmp/old',
+    workspaceKind: 'project',
+    status: 'active',
+    source: 'user',
+    remoteHostId: null,
+    orcaRole: null,
+    parentSessionId: null,
+    forkedAtMessageId: null,
+    createdAt: 1,
+    messageCount: 3,
+    ...patch,
+  };
+}
+
+function makeDeps(rows: SessionOpsRow[], overrides: Partial<SessionOperationsDeps> = {}) {
+  const byId = new Map(rows.map((r) => [r.id, r]));
+  const updateSession = vi.fn(async (id: string, patch: Record<string, unknown>) => ({
+    ...byId.get(id),
+    ...patch,
+  }));
+  const deps: SessionOperationsDeps = {
+    loadSessions: async (ids) => ids.flatMap((id) => (byId.has(id) ? [byId.get(id) as SessionOpsRow] : [])),
+    loadChildren: async (parentIds) => rows.filter((r) => r.parentSessionId && parentIds.includes(r.parentSessionId)),
+    listWorkerSessionIds: async () => [],
+    isTurnRunning: () => false,
+    isImAttached: () => false,
+    isDirectory: async () => true,
+    updateSession,
+    worktreeRemovalPreview: async () => ({ hasWorktree: false, dirty: false }),
+    exportShare: async ({ targetPath }) => ({ status: 'ok', filePath: targetPath, fidelity: 'full', missingTranscripts: [], mediaMissing: 0, orcaWorkers: 0 }),
+    openInNewWindow: vi.fn(),
+    resolveMessageClientId: async () => 'client-1',
+    forkAtMessage: async () => ({ id: 'forked' }),
+    ...overrides,
+  };
+  return { deps, updateSession };
+}
+
+const toProject = { kind: 'project' as const, workingDir: '/tmp/new' };
+
+describe('moveSessions', () => {
+  it('applies the GUI patch through updateSession for every id', async () => {
+    const { deps, updateSession } = makeDeps([row('a'), row('b')]);
+    const res = await moveSessions(deps, { sessionIds: ['a', 'b'], target: toProject });
+    expect(res.ok).toBe(true);
+    expect(updateSession.mock.calls.map((c) => c[1])).toEqual([
+      { workingDir: '/tmp/new', workspaceKind: 'project' },
+      { workingDir: '/tmp/new', workspaceKind: 'project' },
+    ]);
+    if (res.ok) expect(res.moved.map((m) => m.workingDir)).toEqual(['/tmp/new', '/tmp/new']);
+  });
+
+  it('moves to dialogue with workspaceKind only', async () => {
+    const { deps, updateSession } = makeDeps([row('a')]);
+    await moveSessions(deps, { sessionIds: ['a'], target: { kind: 'dialogue' } });
+    expect(updateSession).toHaveBeenCalledWith('a', { workspaceKind: 'dialogue' });
+  });
+
+  it('NOT_FOUND for any missing id writes nothing', async () => {
+    const { deps, updateSession } = makeDeps([row('a')]);
+    const res = await moveSessions(deps, { sessionIds: ['a', 'ghost'], target: toProject });
+    expect(res).toMatchObject({ ok: false, errorCode: 'NOT_FOUND' });
+    expect(updateSession).not.toHaveBeenCalled();
+  });
+
+  it('INVALID_ARGS when working_dir is not a directory', async () => {
+    const { deps, updateSession } = makeDeps([row('a')], { isDirectory: async () => false });
+    const res = await moveSessions(deps, { sessionIds: ['a'], target: toProject });
+    expect(res).toMatchObject({ ok: false, errorCode: 'INVALID_ARGS' });
+    expect(updateSession).not.toHaveBeenCalled();
+  });
+
+  it.each<[string, Partial<SessionOpsRow>, Partial<SessionOperationsDeps>]>([
+    ['remote', { remoteHostId: 'host' }, {}],
+    ['deleted', { status: 'deleted' }, {}],
+    ['archived', { status: 'archived' }, {}],
+    ['review', { source: 'review' }, {}],
+    ['empty draft', { title: 'New Maker', messageCount: 0 }, {}],
+    ['running', {}, { isTurnRunning: (id) => id === 'b' }],
+    ['lead with running worker', { orcaRole: 'lead' }, { listWorkerSessionIds: async () => ['w'], isTurnRunning: (id) => id === 'w' }],
+    ['IM attached', {}, { isImAttached: (id) => id === 'b' }],
+  ])('PRECONDITION_FAILED (%s) blocks the whole batch', async (_name, patch, overrides) => {
+    const { deps, updateSession } = makeDeps([row('a'), row('b', patch)], overrides);
+    const res = await moveSessions(deps, { sessionIds: ['a', 'b'], target: toProject });
+    expect(res).toMatchObject({ ok: false, errorCode: 'PRECONDITION_FAILED' });
+    if (!res.ok) expect(res.message).toContain('b: ');
+    expect(updateSession).not.toHaveBeenCalled();
+  });
+
+  it('reports partial progress when a later update fails', async () => {
+    const { deps } = makeDeps([row('a'), row('b')], {
+      updateSession: vi.fn(async (id: string) => {
+        if (id === 'b') throw new Error('disk on fire');
+        return {};
+      }),
+    });
+    const res = await moveSessions(deps, { sessionIds: ['a', 'b'], target: toProject });
+    expect(res).toMatchObject({ ok: false, errorCode: 'INTERNAL', moved: [{ sessionId: 'a' }] });
+  });
+});
+
+describe('setSessionsPinned', () => {
+  it('writes pinnedAt ISO / null through updateSession', async () => {
+    const { deps, updateSession } = makeDeps([row('a')]);
+    await setSessionsPinned(deps, { sessionIds: ['a'], pinned: true });
+    expect(typeof updateSession.mock.calls[0][1].pinnedAt).toBe('string');
+    await setSessionsPinned(deps, { sessionIds: ['a'], pinned: false });
+    expect(updateSession.mock.calls[1][1]).toEqual({ pinnedAt: null });
+  });
+
+  it('refuses archived sessions', async () => {
+    const { deps, updateSession } = makeDeps([row('a', { status: 'archived' })]);
+    const res = await setSessionsPinned(deps, { sessionIds: ['a'], pinned: true });
+    expect(res).toMatchObject({ ok: false, errorCode: 'PRECONDITION_FAILED' });
+    expect(updateSession).not.toHaveBeenCalled();
+  });
+});
+
+describe('deleteSessions', () => {
+  it('dry run previews dirty worktrees without writing', async () => {
+    const { deps, updateSession } = makeDeps([row('a'), row('b')], {
+      worktreeRemovalPreview: async (id) => ({ hasWorktree: id === 'b', dirty: true }),
+    });
+    const res = await deleteSessions(deps, { sessionIds: ['a', 'b'], dryRun: true });
+    expect(res).toMatchObject({
+      ok: true,
+      items: [{ sessionId: 'a', dirtyWorktree: false }, { sessionId: 'b', dirtyWorktree: true }],
+    });
+    expect(updateSession).not.toHaveBeenCalled();
+  });
+
+  it('soft-deletes via status=deleted and allows archived sessions', async () => {
+    const { deps, updateSession } = makeDeps([row('a', { status: 'archived' })]);
+    const res = await deleteSessions(deps, { sessionIds: ['a'], dryRun: false });
+    expect(updateSession).toHaveBeenCalledWith('a', { status: 'deleted' });
+    expect(res).toMatchObject({ ok: true, items: [{ sessionId: 'a', status: 'deleted' }] });
+  });
+
+  it('blocks running / remote / attached sessions', async () => {
+    const { deps, updateSession } = makeDeps([row('a'), row('b')], { isImAttached: (id) => id === 'b' });
+    const res = await deleteSessions(deps, { sessionIds: ['a', 'b'], dryRun: false });
+    expect(res).toMatchObject({ ok: false, errorCode: 'PRECONDITION_FAILED' });
+    expect(updateSession).not.toHaveBeenCalled();
+  });
+});
+
+describe('exportSession', () => {
+  it('appends the share extension and validates the parent directory', async () => {
+    const exportShare = vi.fn(async ({ targetPath }: { targetPath: string }) => ({
+      status: 'ok' as const,
+      filePath: targetPath,
+      fidelity: 'full',
+      missingTranscripts: [],
+      mediaMissing: 0,
+      orcaWorkers: 0,
+    }));
+    const { deps } = makeDeps([row('a')], { exportShare });
+    const res = await exportSession(deps, { sessionId: 'a', targetPath: '/tmp/out/x', password: null, excludeMedia: false }, '.cshare');
+    expect(exportShare).toHaveBeenCalledWith(expect.objectContaining({ targetPath: '/tmp/out/x.cshare' }));
+    expect(res).toMatchObject({ ok: true, filePath: '/tmp/out/x.cshare' });
+
+    const { deps: bad } = makeDeps([row('a')], { isDirectory: async () => false });
+    const res2 = await exportSession(bad, { sessionId: 'a', targetPath: '/nope/x', password: null, excludeMedia: false }, '.cshare');
+    expect(res2).toMatchObject({ ok: false, errorCode: 'INVALID_ARGS' });
+  });
+
+  it('maps oversize and coded errors', async () => {
+    const { deps } = makeDeps([row('a')], {
+      exportShare: async () => ({ status: 'oversize', totalBytes: 10, mediaBytes: 8, limitBytes: 5 }),
+    });
+    const res = await exportSession(deps, { sessionId: 'a', targetPath: '/tmp/x.cshare', password: null, excludeMedia: false }, '.cshare');
+    expect(res).toMatchObject({ ok: false, errorCode: 'OVERSIZE', data: { limit_bytes: 5 } });
+
+    const { deps: remote } = makeDeps([row('a')], {
+      exportShare: async () => {
+        throw Object.assign(new Error('remote'), { code: 'PRECONDITION_FAILED' });
+      },
+    });
+    const res2 = await exportSession(remote, { sessionId: 'a', targetPath: '/tmp/x.cshare', password: null, excludeMedia: false }, '.cshare');
+    expect(res2).toMatchObject({ ok: false, errorCode: 'PRECONDITION_FAILED' });
+  });
+});
+
+describe('openSessionInNewWindow', () => {
+  it('opens existing sessions and rejects deleted ones', async () => {
+    const { deps } = makeDeps([row('a'), row('d', { status: 'deleted' })]);
+    expect(await openSessionInNewWindow(deps, { sessionId: 'a' })).toMatchObject({ ok: true, sessionId: 'a' });
+    expect(deps.openInNewWindow).toHaveBeenCalledWith('a');
+    expect(await openSessionInNewWindow(deps, { sessionId: 'd' })).toMatchObject({ ok: false, errorCode: 'PRECONDITION_FAILED' });
+    expect(await openSessionInNewWindow(deps, { sessionId: 'x' })).toMatchObject({ ok: false, errorCode: 'NOT_FOUND' });
+  });
+});
+
+describe('forkSession', () => {
+  it('resolves the message client id and returns the forked session', async () => {
+    const forkAtMessage = vi.fn(async () => ({ id: 'forked' }));
+    const { deps } = makeDeps([row('a'), row('forked', { parentSessionId: 'a' })], { forkAtMessage });
+    const res = await forkSession(deps, { sessionId: 'a', messageId: 'm1' });
+    expect(forkAtMessage).toHaveBeenCalledWith('a', 'client-1');
+    expect(res).toMatchObject({ ok: true, session: { sessionId: 'forked' } });
+  });
+
+  it('maps fork error codes', async () => {
+    const withCode = (code: string) =>
+      makeDeps([row('a')], {
+        forkAtMessage: async () => {
+          throw Object.assign(new Error(code), { code });
+        },
+      }).deps;
+    expect(await forkSession(withCode('NOT_USER_MESSAGE'), { sessionId: 'a', messageId: 'm' })).toMatchObject({ errorCode: 'INVALID_ARGS' });
+    expect(await forkSession(withCode('NO_PRIOR_ASSISTANT'), { sessionId: 'a', messageId: 'm' })).toMatchObject({ errorCode: 'PRECONDITION_FAILED' });
+    expect(await forkSession(withCode('UNSUPPORTED_HISTORY'), { sessionId: 'a', messageId: 'm' })).toMatchObject({ errorCode: 'UNSUPPORTED_CAPABILITY' });
+    const { deps: noMsg } = makeDeps([row('a')], { resolveMessageClientId: async () => null });
+    expect(await forkSession(noMsg, { sessionId: 'a', messageId: 'm' })).toMatchObject({ errorCode: 'NOT_FOUND' });
+  });
+});
+
+describe('getSessionBranches', () => {
+  it('walks up to the root and collects all descendants', async () => {
+    const { deps } = makeDeps([
+      row('root'),
+      row('c1', { parentSessionId: 'root', forkedAtMessageId: 'm1' }),
+      row('c2', { parentSessionId: 'root' }),
+      row('gc', { parentSessionId: 'c1' }),
+      row('other'),
+    ]);
+    const res = await getSessionBranches(deps, { sessionId: 'gc' });
+    expect(res.ok).toBe(true);
+    if (res.ok) {
+      expect(res.rootSessionId).toBe('root');
+      expect(res.family.map((f) => f.sessionId).sort()).toEqual(['c1', 'c2', 'gc', 'root']);
+      expect(res.family.find((f) => f.sessionId === 'c1')).toMatchObject({ parentSessionId: 'root', forkedAtMessageId: 'm1' });
+    }
+  });
+});

--- a/apps/desktop/src/main/mcp-integrations/mcp-providers.ts
+++ b/apps/desktop/src/main/mcp-integrations/mcp-providers.ts
@@ -24,6 +24,7 @@ import {
   type ToolResultImageDescription,
 } from './ghost.js';
 import { createGroupHistoryMcpServer } from './groupHistoryMcpServer.js';
+import { createSessionOpsCallbacks } from './sessionOperationsHost.js';
 import { renderHtmlToPdf } from '../doc-tools/htmlPdfRenderer.js';
 import { writeDocsOutput } from '../doc-tools/docsOutputWriter.js';
 import { inspectPdf } from '../doc-tools/pdfInspector.js';
@@ -95,6 +96,11 @@ export interface DesktopMcpProvidersDeps {
   ) => IOSSimulatorMcpAccessDecision;
   /** Device-link transport stays host-injected so provider tests do not load Electron runtime services. */
   invokeRemote: ChatHistoryReaderDeps['invokeRemote'];
+  /**
+   * 会话操作工具(move / delete 等)的运行中判断。maker-host 注入 `getSession(id)?.isTurnRunning()`;
+   * 缺失时视为全部空闲(仅测试)。
+   */
+  isSessionTurnRunning?: (sessionId: string) => boolean;
   /** 插件文件交接只认活跃 Session 的实时权限；缺失时由 ghost.ts fail closed。 */
   getLiveSessionGrantState?: (
     sessionId: string,
@@ -420,6 +426,7 @@ export function createDesktopMcpProviders(deps: DesktopMcpProvidersDeps): LiziMc
           return { ok: false, errorCode: 'INTERNAL', message };
         }
       },
+      sessionOps: createSessionOpsCallbacks(deps.isSessionTurnRunning ?? (() => false)),
       setSessionsStatus: async ({ sessionIds, status }) => {
         if (!tryGetDbClient()) {
           return { ok: false, errorCode: 'HOST_NOT_READY', message: 'localDb not ready' };

--- a/apps/desktop/src/main/mcp-integrations/sessionOperations.ts
+++ b/apps/desktop/src/main/mcp-integrations/sessionOperations.ts
@@ -1,0 +1,387 @@
+/**
+ * mcp-integrations/sessionOperations.ts —— cindy_helper control 类「会话操作」工具的 host 业务体。
+ *
+ * 对应 GUI 会话菜单的移动到项目/对话、置顶、删除、导出分享包、在新窗口打开、分叉与
+ * 分支家族。所有写操作都走主进程既有路径(`updateSessionInDb` = sessions:update 业务体,
+ * session-share 导出编排,maker-orchestration/fork),不另起绕过广播与副作用的写入链路。
+ *
+ * GUI 侧的守卫(远程会话不支持、运行中拦截、IM 接管中拦截、空草稿 / 已归档不出入口)
+ * 在这里逐条复现;批量操作先对全部 id 校验,任一不过整批不写。
+ *
+ * 依赖全部注入(Electron / maker / im 均不直接 import),便于单测直接驱动业务体
+ * (docs/dev-rules/engineering-conventions.md §3)。
+ */
+
+import { isDefaultDraftSessionTitle } from '@cindy/maker-shared/session-title';
+import type {
+  DeleteSessionPreviewItem,
+  DeleteSessionsResult,
+  ExportSessionResult,
+  ForkSessionResult,
+  GetSessionBranchesResult,
+  MoveSessionsResult,
+  OpenSessionInNewWindowResult,
+  SessionBranchItem,
+  SessionMoveTarget,
+  SessionOpErrorCode,
+  SessionOpItem,
+  SetSessionsPinnedResult,
+} from '@cindy/mcps';
+
+import { isIpcError } from '../../shared/ipc-errors.js';
+
+export interface SessionOpsRow {
+  id: string;
+  title: string | null;
+  workingDir: string | null;
+  workspaceKind: 'project' | 'dialogue';
+  status: 'active' | 'archived' | 'deleted';
+  source: string | null;
+  remoteHostId: string | null;
+  orcaRole: 'lead' | 'worker' | null;
+  parentSessionId: string | null;
+  forkedAtMessageId: string | null;
+  createdAt: number;
+  messageCount: number;
+}
+
+export interface SessionShareExportOutcomeLike {
+  status: 'ok' | 'oversize';
+  filePath?: string;
+  fidelity?: string;
+  missingTranscripts?: string[];
+  mediaMissing?: number;
+  orcaWorkers?: number;
+  totalBytes?: number;
+  mediaBytes?: number;
+  limitBytes?: number;
+}
+
+export interface SessionOperationsDeps {
+  /** 按 id 读会话行(任意 status);缺失的 id 不出现在结果里。 */
+  loadSessions(ids: string[]): Promise<SessionOpsRow[]>;
+  /** 读 parentSessionId ∈ ids 的直接子会话(分支家族遍历用)。 */
+  loadChildren(parentIds: string[]): Promise<SessionOpsRow[]>;
+  /** Orca lead 下的 worker 会话 id。 */
+  listWorkerSessionIds(leadSessionId: string): Promise<string[]>;
+  isTurnRunning(sessionId: string): boolean;
+  isImAttached(sessionId: string): boolean;
+  isDirectory(path: string): Promise<boolean>;
+  /** sessions:update 业务体(updateSessionInDb)。 */
+  updateSession(sessionId: string, patch: Record<string, unknown>): Promise<unknown>;
+  worktreeRemovalPreview(sessionId: string): Promise<{ hasWorktree: boolean; dirty: boolean }>;
+  exportShare(opts: {
+    sessionId: string;
+    targetPath: string;
+    password: string | null;
+    excludeMedia: boolean;
+  }): Promise<SessionShareExportOutcomeLike>;
+  openInNewWindow(sessionId: string): void;
+  resolveMessageClientId(sessionId: string, messageId: string): Promise<string | null>;
+  forkAtMessage(sessionId: string, messageClientId: string): Promise<{ id: string }>;
+}
+
+type Err<E extends string> = { ok: false; errorCode: E; message: string };
+
+function err<E extends string>(errorCode: E, message: string): Err<E> {
+  return { ok: false, errorCode, message };
+}
+
+function toItem(row: SessionOpsRow): SessionOpItem {
+  return {
+    sessionId: row.id,
+    title: row.title,
+    workingDir: row.workingDir,
+    workspaceKind: row.workspaceKind,
+    status: row.status,
+  };
+}
+
+function mapIpcError(e: unknown): Err<SessionOpErrorCode> {
+  const message = e instanceof Error ? e.message : String(e);
+  if (isIpcError(e)) {
+    if (e.code === 'NOT_FOUND' || e.code === 'PRECONDITION_FAILED') return err(e.code, message);
+    if (e.code === 'UNSUPPORTED_CAPABILITY') return err('PRECONDITION_FAILED', message);
+    if (e.code === 'INVALID_PARAMS') return err('INVALID_ARGS', message);
+  }
+  return err('INTERNAL', message);
+}
+
+/** 读全部目标行;任一缺失即 NOT_FOUND(device-link 镜像会话不在本地库,同样落这里)。 */
+async function loadAll(
+  deps: SessionOperationsDeps,
+  ids: string[],
+): Promise<SessionOpsRow[] | Err<'NOT_FOUND'>> {
+  const rows = await deps.loadSessions(ids);
+  const byId = new Map(rows.map((row) => [row.id, row]));
+  const missing = ids.filter((id) => !byId.has(id));
+  if (missing.length > 0) {
+    return err('NOT_FOUND', `session 不存在(或是远程设备上的会话): ${missing.join(', ')}`);
+  }
+  return ids.map((id) => byId.get(id) as SessionOpsRow);
+}
+
+/** 会话本身或(lead 时)任一 worker 正在跑 turn —— 与 sidebar effectiveRunningSessionIds 口径一致。 */
+async function isRunning(deps: SessionOperationsDeps, row: SessionOpsRow): Promise<boolean> {
+  if (deps.isTurnRunning(row.id)) return true;
+  if (row.orcaRole !== 'lead') return false;
+  const workers = await deps.listWorkerSessionIds(row.id).catch(() => []);
+  return workers.some((id) => deps.isTurnRunning(id));
+}
+
+/**
+ * GUI 移动 / 删除共用的前置守卫。返回 null 表示放行,否则是给模型看的原因。
+ * 远程会话与 IM 接管的判断与 CCAgentSidebarUpper.handleMoveSession 同款。
+ */
+async function mutationGuard(
+  deps: SessionOperationsDeps,
+  row: SessionOpsRow,
+): Promise<string | null> {
+  if (row.remoteHostId) return '远程(SSH)会话不支持此操作';
+  if (row.status === 'deleted') return '会话已删除';
+  if (await isRunning(deps, row)) return '会话正在运行中(含协同 worker),请等它结束';
+  if (deps.isImAttached(row.id)) return '会话正被 IM 接管中';
+  return null;
+}
+
+export async function moveSessions(
+  deps: SessionOperationsDeps,
+  params: { sessionIds: string[]; target: SessionMoveTarget },
+): Promise<MoveSessionsResult> {
+  if (params.target.kind === 'project') {
+    if (!(await deps.isDirectory(params.target.workingDir))) {
+      return err('INVALID_ARGS', `working_dir 不是已存在的目录: ${params.target.workingDir}`);
+    }
+  }
+  const loaded = await loadAll(deps, params.sessionIds);
+  if (!Array.isArray(loaded)) return loaded;
+  for (const row of loaded) {
+    const reason =
+      (await mutationGuard(deps, row)) ??
+      (row.status === 'archived'
+        ? '已归档的会话不能移动,请先 unarchive_sessions'
+        : row.source === 'review'
+          ? 'review 会话的工作区固定跟随源任务,不能移动'
+          : isDefaultDraftSessionTitle(row.title) && row.messageCount === 0
+            ? '空草稿会话没有可移动的内容'
+            : null);
+    if (reason) return err('PRECONDITION_FAILED', `${row.id}: ${reason}`);
+  }
+  const patch =
+    params.target.kind === 'dialogue'
+      ? { workspaceKind: 'dialogue' as const }
+      : { workingDir: params.target.workingDir, workspaceKind: 'project' as const };
+  const moved: SessionOpItem[] = [];
+  for (const row of loaded) {
+    try {
+      const updated = (await deps.updateSession(row.id, { ...patch })) as Partial<SessionOpsRow>;
+      moved.push(
+        toItem({
+          ...row,
+          workingDir: updated.workingDir ?? row.workingDir,
+          workspaceKind: updated.workspaceKind ?? patch.workspaceKind,
+        }),
+      );
+    } catch (e) {
+      const mapped = mapIpcError(e);
+      return { ...err('INTERNAL', `${row.id}: ${mapped.message}`), moved } as MoveSessionsResult;
+    }
+  }
+  return { ok: true, moved };
+}
+
+export async function setSessionsPinned(
+  deps: SessionOperationsDeps,
+  params: { sessionIds: string[]; pinned: boolean },
+): Promise<SetSessionsPinnedResult> {
+  const loaded = await loadAll(deps, params.sessionIds);
+  if (!Array.isArray(loaded)) return loaded;
+  for (const row of loaded) {
+    if (row.remoteHostId) return err('PRECONDITION_FAILED', `${row.id}: 远程(SSH)会话不支持置顶`);
+    if (row.status !== 'active') {
+      return err('PRECONDITION_FAILED', `${row.id}: 会话已${row.status === 'deleted' ? '删除' : '归档'},不能置顶`);
+    }
+  }
+  const changed: SessionOpItem[] = [];
+  for (const row of loaded) {
+    try {
+      await deps.updateSession(row.id, {
+        pinnedAt: params.pinned ? new Date().toISOString() : null,
+      });
+      changed.push(toItem(row));
+    } catch (e) {
+      const mapped = mapIpcError(e);
+      return { ...err('INTERNAL', `${row.id}: ${mapped.message}`), changed } as SetSessionsPinnedResult;
+    }
+  }
+  return { ok: true, changed };
+}
+
+export async function deleteSessions(
+  deps: SessionOperationsDeps,
+  params: { sessionIds: string[]; dryRun: boolean },
+): Promise<DeleteSessionsResult> {
+  const loaded = await loadAll(deps, params.sessionIds);
+  if (!Array.isArray(loaded)) return loaded;
+  for (const row of loaded) {
+    const reason = await mutationGuard(deps, row);
+    if (reason) return err('PRECONDITION_FAILED', `${row.id}: ${reason}`);
+  }
+  const previews: DeleteSessionPreviewItem[] = [];
+  for (const row of loaded) {
+    const preview = await deps.worktreeRemovalPreview(row.id).catch(() => ({
+      hasWorktree: false,
+      dirty: false,
+    }));
+    previews.push({ ...toItem(row), dirtyWorktree: preview.hasWorktree && preview.dirty });
+  }
+  if (params.dryRun) return { ok: true, items: previews };
+  const items: DeleteSessionPreviewItem[] = [];
+  for (const preview of previews) {
+    try {
+      await deps.updateSession(preview.sessionId, { status: 'deleted' });
+      items.push({ ...preview, status: 'deleted' });
+    } catch (e) {
+      const mapped = mapIpcError(e);
+      return {
+        ...err('INTERNAL', `${preview.sessionId}: ${mapped.message}`),
+        items,
+      } as DeleteSessionsResult;
+    }
+  }
+  return { ok: true, items };
+}
+
+export async function exportSession(
+  deps: SessionOperationsDeps,
+  params: { sessionId: string; targetPath: string; password: string | null; excludeMedia: boolean },
+  shareFileExt: string,
+): Promise<ExportSessionResult> {
+  const targetPath = params.targetPath.endsWith(shareFileExt)
+    ? params.targetPath
+    : `${params.targetPath}${shareFileExt}`;
+  const parent = targetPath.slice(0, Math.max(targetPath.lastIndexOf('/'), targetPath.lastIndexOf('\\')));
+  if (!parent || !(await deps.isDirectory(parent))) {
+    return err('INVALID_ARGS', `target_path 所在目录不存在: ${parent || params.targetPath}`);
+  }
+  let outcome: SessionShareExportOutcomeLike;
+  try {
+    outcome = await deps.exportShare({ ...params, targetPath });
+  } catch (e) {
+    const code = (e as { code?: string }).code;
+    const message = e instanceof Error ? e.message : String(e);
+    if (code === 'NOT_FOUND' || code === 'PRECONDITION_FAILED') return err(code, message);
+    return err('INTERNAL', message);
+  }
+  if (outcome.status === 'oversize') {
+    return {
+      ...err('OVERSIZE', '分享包体积超过上限,可用 exclude_media=true 只导出文本与转录重试'),
+      data: {
+        total_bytes: outcome.totalBytes,
+        media_bytes: outcome.mediaBytes,
+        limit_bytes: outcome.limitBytes,
+      },
+    };
+  }
+  return {
+    ok: true,
+    filePath: outcome.filePath ?? targetPath,
+    fidelity: outcome.fidelity ?? 'unknown',
+    missingTranscripts: outcome.missingTranscripts ?? [],
+    mediaMissing: outcome.mediaMissing ?? 0,
+    orcaWorkers: outcome.orcaWorkers ?? 0,
+  };
+}
+
+export async function openSessionInNewWindow(
+  deps: SessionOperationsDeps,
+  params: { sessionId: string },
+): Promise<OpenSessionInNewWindowResult> {
+  const loaded = await loadAll(deps, [params.sessionId]);
+  if (!Array.isArray(loaded)) return loaded;
+  const [row] = loaded;
+  if (row.status === 'deleted') return err('PRECONDITION_FAILED', `${row.id}: 会话已删除`);
+  try {
+    deps.openInNewWindow(row.id);
+  } catch (e) {
+    return err('INTERNAL', e instanceof Error ? e.message : String(e));
+  }
+  return { ok: true, sessionId: row.id, title: row.title };
+}
+
+export async function forkSession(
+  deps: SessionOperationsDeps,
+  params: { sessionId: string; messageId: string },
+): Promise<ForkSessionResult> {
+  const loaded = await loadAll(deps, [params.sessionId]);
+  if (!Array.isArray(loaded)) return loaded;
+  const [row] = loaded;
+  if (row.status === 'deleted') return err('PRECONDITION_FAILED', `${row.id}: 会话已删除`);
+  if (row.remoteHostId) return err('PRECONDITION_FAILED', `${row.id}: 远程会话不支持在本地 fork`);
+  const clientId = await deps.resolveMessageClientId(row.id, params.messageId);
+  if (!clientId) return err('NOT_FOUND', `消息 ${params.messageId} 不存在于 ${row.id}`);
+  let forkedId: string;
+  try {
+    forkedId = (await deps.forkAtMessage(row.id, clientId)).id;
+  } catch (e) {
+    const code = (e as { code?: string }).code;
+    const message = e instanceof Error ? e.message : String(e);
+    switch (code) {
+      case 'SOURCE_NOT_FOUND':
+      case 'MESSAGE_NOT_FOUND':
+        return err('NOT_FOUND', message);
+      case 'NOT_USER_MESSAGE':
+        return err('INVALID_ARGS', message);
+      case 'SOURCE_NEVER_RAN':
+      case 'NO_PRIOR_ASSISTANT':
+      case 'REMOTE_NOT_SUPPORTED':
+      case 'CODEX_FORK_STATE_UNAVAILABLE':
+        return err('PRECONDITION_FAILED', message);
+      case 'UNSUPPORTED_HISTORY':
+        return err('UNSUPPORTED_CAPABILITY', message);
+      default:
+        return err('INTERNAL', message);
+    }
+  }
+  const [forked] = await deps.loadSessions([forkedId]);
+  return {
+    ok: true,
+    session: forked
+      ? toItem(forked)
+      : { sessionId: forkedId, title: null, workingDir: row.workingDir, workspaceKind: row.workspaceKind, status: 'active' },
+  };
+}
+
+export async function getSessionBranches(
+  deps: SessionOperationsDeps,
+  params: { sessionId: string },
+): Promise<GetSessionBranchesResult> {
+  const loaded = await loadAll(deps, [params.sessionId]);
+  if (!Array.isArray(loaded)) return loaded;
+  // 向上找根(源被删时 parentSessionId 已 SET NULL,链在此断开即视为根)。
+  let root = loaded[0];
+  const seen = new Set<string>([root.id]);
+  while (root.parentSessionId && !seen.has(root.parentSessionId)) {
+    const [parent] = await deps.loadSessions([root.parentSessionId]);
+    if (!parent) break;
+    seen.add(parent.id);
+    root = parent;
+  }
+  // 向下 BFS 收集全部派生会话。
+  const family: SessionOpsRow[] = [root];
+  let frontier = [root.id];
+  const visited = new Set<string>([root.id]);
+  while (frontier.length > 0) {
+    const children = (await deps.loadChildren(frontier)).filter((row) => !visited.has(row.id));
+    for (const child of children) visited.add(child.id);
+    family.push(...children);
+    frontier = children.map((row) => row.id);
+  }
+  const items: SessionBranchItem[] = family.map((row) => ({
+    ...toItem(row),
+    parentSessionId: row.parentSessionId,
+    forkedAtMessageId: row.forkedAtMessageId,
+    createdAt: row.createdAt,
+  }));
+  return { ok: true, rootSessionId: root.id, family: items };
+}

--- a/apps/desktop/src/main/mcp-integrations/sessionOperationsHost.ts
+++ b/apps/desktop/src/main/mcp-integrations/sessionOperationsHost.ts
@@ -1,0 +1,169 @@
+/**
+ * mcp-integrations/sessionOperationsHost.ts —— sessionOperations 业务体的真实依赖装配。
+ *
+ * 把 Electron 窗口、localDb、worktree、session-share、fork、IM binding 等 main 专属
+ * 依赖收拢在这一个文件里注入给 sessionOperations.ts;运行中判断由 maker-host 注入
+ * (mcp-providers 不能反向 import maker-host/index,会成环)。
+ */
+
+import { stat } from 'node:fs/promises';
+import { BrowserWindow } from 'electron';
+import { and, eq, inArray, sql } from 'drizzle-orm';
+
+import type {
+  DeleteSessionsResult,
+  ExportSessionResult,
+  ForkSessionResult,
+  GetSessionBranchesResult,
+  MoveSessionsResult,
+  OpenSessionInNewWindowResult,
+  SessionMoveTarget,
+  SetSessionsPinnedResult,
+} from '@cindy/mcps';
+
+import { bindingStore } from '../im/binding.js';
+import { getDbClient, tryGetDbClient } from '../localDb/client/current.js';
+import { updateSessionInDb } from '../localDb/ipc/sessions.js';
+import { emitSessionCreated } from '../localDb/ipc/sessionCreatedBroadcast.js';
+import { messages, sessions } from '../localDb/schema.js';
+import { forkSessionAtMessage } from '../maker-orchestration/fork.js';
+import { openSessionInNewWindow as openSecondaryWindow } from '../secondary-windows.js';
+import { exportSessionShare } from '../session-share/sessionShareExport.js';
+import { SHARE_FILE_EXT } from '../session-share/xdtshareFormat.pure.js';
+import { getRemovalPreview } from '../worktree/WorktreeManager.js';
+import {
+  deleteSessions,
+  exportSession,
+  forkSession,
+  getSessionBranches,
+  moveSessions,
+  openSessionInNewWindow,
+  setSessionsPinned,
+  type SessionOperationsDeps,
+  type SessionOpsRow,
+} from './sessionOperations.js';
+
+const ROW_COLUMNS = {
+  id: sessions.id,
+  title: sessions.title,
+  workingDir: sessions.workingDir,
+  workspaceKind: sessions.workspaceKind,
+  status: sessions.status,
+  source: sessions.source,
+  remoteHostId: sessions.remoteHostId,
+  orcaRole: sessions.orcaRole,
+  parentSessionId: sessions.parentSessionId,
+  forkedAtMessageId: sessions.forkedAtMessageId,
+  createdAt: sessions.createdAt,
+  messageCount: sql<number>`(select count(*) from messages where messages.session_id = ${sessions.id})`,
+};
+
+function toRow(row: {
+  id: string;
+  title: string | null;
+  workingDir: string | null;
+  workspaceKind: string | null;
+  status: string;
+  source: string | null;
+  remoteHostId: string | null;
+  orcaRole: string | null;
+  parentSessionId: string | null;
+  forkedAtMessageId: string | null;
+  createdAt: number;
+  messageCount: number;
+}): SessionOpsRow {
+  return {
+    ...row,
+    workspaceKind: row.workspaceKind === 'dialogue' ? 'dialogue' : 'project',
+    status: row.status as SessionOpsRow['status'],
+    orcaRole: row.orcaRole as SessionOpsRow['orcaRole'],
+    messageCount: Number(row.messageCount ?? 0),
+  };
+}
+
+export function createSessionOperationsDeps(
+  isTurnRunning: (sessionId: string) => boolean,
+): SessionOperationsDeps {
+  return {
+    loadSessions: async (ids) => {
+      if (ids.length === 0) return [];
+      const rows = await getDbClient()
+        .drizzle.select(ROW_COLUMNS)
+        .from(sessions)
+        .where(inArray(sessions.id, ids));
+      return rows.map(toRow);
+    },
+    loadChildren: async (parentIds) => {
+      if (parentIds.length === 0) return [];
+      const rows = await getDbClient()
+        .drizzle.select(ROW_COLUMNS)
+        .from(sessions)
+        .where(inArray(sessions.parentSessionId, parentIds));
+      return rows.map(toRow);
+    },
+    listWorkerSessionIds: async (leadSessionId) => {
+      const rows = await getDbClient()
+        .drizzle.select({ id: sessions.id })
+        .from(sessions)
+        .where(and(eq(sessions.parentSessionId, leadSessionId), eq(sessions.orcaRole, 'worker')));
+      return rows.map((row) => row.id);
+    },
+    isTurnRunning,
+    isImAttached: (sessionId) => bindingStore.findByTarget(sessionId) !== null,
+    isDirectory: async (path) => {
+      try {
+        return (await stat(path)).isDirectory();
+      } catch {
+        return false;
+      }
+    },
+    updateSession: (sessionId, patch) => updateSessionInDb(sessionId, patch),
+    worktreeRemovalPreview: (sessionId) => getRemovalPreview(sessionId),
+    exportShare: (opts) => exportSessionShare(opts),
+    openInNewWindow: (sessionId) => {
+      const anchor = BrowserWindow.getFocusedWindow() ?? BrowserWindow.getAllWindows()[0] ?? null;
+      openSecondaryWindow(sessionId, anchor);
+    },
+    resolveMessageClientId: async (sessionId, messageId) => {
+      const [row] = await getDbClient()
+        .drizzle.select({ clientId: messages.clientId })
+        .from(messages)
+        .where(and(eq(messages.sessionId, sessionId), eq(messages.id, messageId)))
+        .limit(1);
+      return row?.clientId ?? null;
+    },
+    forkAtMessage: async (sessionId, messageClientId) => {
+      const session = await forkSessionAtMessage(sessionId, messageClientId);
+      emitSessionCreated(session.id);
+      return { id: session.id };
+    },
+  };
+}
+
+/** cindy_helper `sessionOps` 回调组:localDb 未就绪统一返回 HOST_NOT_READY。 */
+export function createSessionOpsCallbacks(isTurnRunning: (sessionId: string) => boolean) {
+  const deps = createSessionOperationsDeps(isTurnRunning);
+  const notReady = { ok: false as const, errorCode: 'HOST_NOT_READY' as const, message: 'localDb not ready' };
+  const guarded = <T>(run: () => Promise<T>): Promise<T | typeof notReady> =>
+    tryGetDbClient() ? run() : Promise.resolve(notReady);
+  return {
+    moveSessions: (params: { sessionIds: string[]; target: SessionMoveTarget }): Promise<MoveSessionsResult> =>
+      guarded(() => moveSessions(deps, params)),
+    setSessionsPinned: (params: { sessionIds: string[]; pinned: boolean }): Promise<SetSessionsPinnedResult> =>
+      guarded(() => setSessionsPinned(deps, params)),
+    deleteSessions: (params: { sessionIds: string[]; dryRun: boolean }): Promise<DeleteSessionsResult> =>
+      guarded(() => deleteSessions(deps, params)),
+    exportSession: (params: {
+      sessionId: string;
+      targetPath: string;
+      password: string | null;
+      excludeMedia: boolean;
+    }): Promise<ExportSessionResult> => guarded(() => exportSession(deps, params, SHARE_FILE_EXT)),
+    openSessionInNewWindow: (params: { sessionId: string }): Promise<OpenSessionInNewWindowResult> =>
+      guarded(() => openSessionInNewWindow(deps, params)),
+    forkSession: (params: { sessionId: string; messageId: string }): Promise<ForkSessionResult> =>
+      guarded(() => forkSession(deps, params)),
+    getSessionBranches: (params: { sessionId: string }): Promise<GetSessionBranchesResult> =>
+      guarded(() => getSessionBranches(deps, params)),
+  };
+}

--- a/packages/lizi-mcps/src/__tests__/sessionOpsTools.test.ts
+++ b/packages/lizi-mcps/src/__tests__/sessionOpsTools.test.ts
@@ -1,0 +1,281 @@
+/**
+ * GUI 会话菜单对应的 control 工具单测 —— schema 护栏、当前会话保护、dry-run token、
+ * host 失败码透传(move / pin / delete / export / open-in-new-window / fork / branches)。
+ */
+
+import { describe, expect, it, vi } from 'vitest';
+
+import { XdtHelperToolRegistry } from '../lizi_xdtHelperToolRegistry.js';
+import type { XdtHelperToolResult } from '../lizi_xdtHelperToolRegistry.js';
+import { registerDeleteSessionsTool, type DeleteSessionsDeps } from '../xdt-helper/delete_sessions.js';
+import { registerExportSessionTool, type ExportSessionDeps } from '../xdt-helper/export_session.js';
+import { registerForkSessionTool, type ForkSessionDeps } from '../xdt-helper/fork_session.js';
+import {
+  registerGetSessionBranchesTool,
+  type GetSessionBranchesDeps,
+} from '../xdt-helper/get_session_branches.js';
+import { registerMoveSessionsTool, type MoveSessionsDeps } from '../xdt-helper/move_sessions.js';
+import {
+  registerOpenSessionInNewWindowTool,
+  type OpenSessionInNewWindowDeps,
+} from '../xdt-helper/open_session_in_new_window.js';
+import {
+  registerPinSessionsTool,
+  registerUnpinSessionsTool,
+  type PinSessionsDeps,
+} from '../xdt-helper/pin_sessions.js';
+
+function parse(result: XdtHelperToolResult) {
+  const [block] = result.content;
+  if (block?.type !== 'text') throw new Error('Expected first MCP content block to be text');
+  return JSON.parse(block.text);
+}
+
+const CURRENT = 'current-session';
+const getSessionContext = () => ({ sessionId: CURRENT, agentKind: 'claude-code', workingDir: '/tmp/p' });
+const noContext = () => ({ sessionId: '', agentKind: 'claude-code', workingDir: '/tmp/p' });
+
+const item = (id: string) => ({
+  sessionId: id,
+  title: `title-${id}`,
+  workingDir: '/tmp/p',
+  workspaceKind: 'project' as const,
+  status: 'active',
+});
+
+describe('move_sessions', () => {
+  function setup(ctx = getSessionContext) {
+    const moveSessions = vi.fn<MoveSessionsDeps['moveSessions']>(async ({ sessionIds }) => ({
+      ok: true as const,
+      moved: sessionIds.map(item),
+    }));
+    const registry = new XdtHelperToolRegistry();
+    registerMoveSessionsTool(registry, { getSessionContext: ctx, moveSessions });
+    return { registry, moveSessions };
+  }
+
+  it('moves to a project and passes the target to host', async () => {
+    const { registry, moveSessions } = setup();
+    const res = await registry.call('move_sessions', {
+      session_ids: ['s1', 's2'],
+      target_kind: 'project',
+      working_dir: '/tmp/proj',
+    });
+    expect(res.isError).toBeFalsy();
+    expect(moveSessions).toHaveBeenCalledWith({
+      sessionIds: ['s1', 's2'],
+      target: { kind: 'project', workingDir: '/tmp/proj' },
+    });
+    expect(parse(res)).toMatchObject({ ok: true, target_kind: 'project', count: 2 });
+  });
+
+  it('moves to dialogue without working_dir', async () => {
+    const { registry, moveSessions } = setup();
+    const res = await registry.call('move_sessions', { session_ids: ['s1'], target_kind: 'dialogue' });
+    expect(res.isError).toBeFalsy();
+    expect(moveSessions).toHaveBeenCalledWith({ sessionIds: ['s1'], target: { kind: 'dialogue' } });
+  });
+
+  it('rejects project target without working_dir', async () => {
+    const { registry, moveSessions } = setup();
+    const res = await registry.call('move_sessions', { session_ids: ['s1'], target_kind: 'project' });
+    expect(res.isError).toBe(true);
+    expect(parse(res).errorCode).toBe('INVALID_ARGS');
+    expect(moveSessions).not.toHaveBeenCalled();
+  });
+
+  it('rejects moving the current session and duplicates', async () => {
+    const { registry, moveSessions } = setup();
+    const self = await registry.call('move_sessions', { session_ids: [CURRENT], target_kind: 'dialogue' });
+    expect(parse(self).errorCode).toBe('INVALID_ARGS');
+    const dup = await registry.call('move_sessions', { session_ids: ['a', 'a'], target_kind: 'dialogue' });
+    expect(parse(dup).errorCode).toBe('INVALID_ARGS');
+    expect(moveSessions).not.toHaveBeenCalled();
+  });
+
+  it('requires session context', async () => {
+    const { registry } = setup(noContext);
+    const res = await registry.call('move_sessions', { session_ids: ['s1'], target_kind: 'dialogue' });
+    expect(parse(res).errorCode).toBe('NO_SESSION_CONTEXT');
+  });
+
+  it('passes host failure codes through, including partial progress', async () => {
+    const registry = new XdtHelperToolRegistry();
+    registerMoveSessionsTool(registry, {
+      getSessionContext,
+      moveSessions: async () => ({
+        ok: false,
+        errorCode: 'INTERNAL',
+        message: 's2: boom',
+        moved: [item('s1')],
+      }) as never,
+    });
+    const res = await registry.call('move_sessions', { session_ids: ['s1', 's2'], target_kind: 'dialogue' });
+    expect(res.isError).toBe(true);
+    expect(parse(res)).toMatchObject({ ok: false, errorCode: 'INTERNAL' });
+    expect(parse(res).data.moved).toHaveLength(1);
+  });
+
+  it('maps HOST_NOT_READY to a retry hint', async () => {
+    const registry = new XdtHelperToolRegistry();
+    registerMoveSessionsTool(registry, {
+      getSessionContext,
+      moveSessions: async () => ({ ok: false, errorCode: 'HOST_NOT_READY', message: 'x' }),
+    });
+    const res = await registry.call('move_sessions', { session_ids: ['s1'], target_kind: 'dialogue' });
+    expect(parse(res)).toMatchObject({ ok: false, errorCode: 'HOST_NOT_READY' });
+  });
+});
+
+describe('pin_sessions / unpin_sessions', () => {
+  it('passes pinned flag to host', async () => {
+    const setSessionsPinned = vi.fn<PinSessionsDeps['setSessionsPinned']>(async ({ sessionIds }) => ({
+      ok: true as const,
+      changed: sessionIds.map(item),
+    }));
+    const registry = new XdtHelperToolRegistry();
+    registerPinSessionsTool(registry, { getSessionContext, setSessionsPinned });
+    registerUnpinSessionsTool(registry, { getSessionContext, setSessionsPinned });
+    await registry.call('pin_sessions', { session_ids: ['s1'] });
+    expect(setSessionsPinned).toHaveBeenLastCalledWith({ sessionIds: ['s1'], pinned: true });
+    const res = await registry.call('unpin_sessions', { session_ids: ['s1', 's2'] });
+    expect(setSessionsPinned).toHaveBeenLastCalledWith({ sessionIds: ['s1', 's2'], pinned: false });
+    expect(parse(res)).toMatchObject({ ok: true, pinned: false, count: 2 });
+  });
+});
+
+describe('delete_sessions', () => {
+  function setup() {
+    const deleteSessions = vi.fn<DeleteSessionsDeps['deleteSessions']>(async ({ sessionIds }) => ({
+      ok: true as const,
+      items: sessionIds.map((id) => ({ ...item(id), dirtyWorktree: id === 'dirty' })),
+    }));
+    const registry = new XdtHelperToolRegistry();
+    registerDeleteSessionsTool(registry, { getSessionContext, deleteSessions });
+    return { registry, deleteSessions };
+  }
+
+  it('dry-runs by default and returns a confirmation token', async () => {
+    const { registry, deleteSessions } = setup();
+    const res = await registry.call('delete_sessions', { session_ids: ['s1', 'dirty'] });
+    expect(deleteSessions).toHaveBeenCalledWith({ sessionIds: ['s1', 'dirty'], dryRun: true });
+    const body = parse(res);
+    expect(body).toMatchObject({ ok: true, dry_run: true, count: 2, dirty_worktree_count: 1 });
+    expect(typeof body.confirmation_token).toBe('string');
+  });
+
+  it('refuses real deletion without a matching token', async () => {
+    const { registry, deleteSessions } = setup();
+    const preview = parse(await registry.call('delete_sessions', { session_ids: ['s1'] }));
+    deleteSessions.mockClear();
+    const noToken = await registry.call('delete_sessions', { session_ids: ['s1'], dry_run: false });
+    expect(parse(noToken).errorCode).toBe('INVALID_ARGS');
+    const wrongBatch = await registry.call('delete_sessions', {
+      session_ids: ['s1', 's2'],
+      dry_run: false,
+      confirmation_token: preview.confirmation_token,
+    });
+    expect(parse(wrongBatch).errorCode).toBe('INVALID_ARGS');
+    const tampered = await registry.call('delete_sessions', {
+      session_ids: ['s1'],
+      dry_run: false,
+      confirmation_token: `${preview.confirmation_token}x`,
+    });
+    expect(parse(tampered).errorCode).toBe('INVALID_ARGS');
+    expect(deleteSessions).not.toHaveBeenCalled();
+  });
+
+  it('deletes with the token from the same batch', async () => {
+    const { registry, deleteSessions } = setup();
+    const preview = parse(await registry.call('delete_sessions', { session_ids: ['s1', 's2'] }));
+    const res = await registry.call('delete_sessions', {
+      session_ids: ['s1', 's2'],
+      dry_run: false,
+      confirmation_token: preview.confirmation_token,
+    });
+    expect(deleteSessions).toHaveBeenLastCalledWith({ sessionIds: ['s1', 's2'], dryRun: false });
+    expect(parse(res)).toMatchObject({ ok: true, dry_run: false, count: 2 });
+  });
+
+  it('never deletes the current session', async () => {
+    const { registry, deleteSessions } = setup();
+    const res = await registry.call('delete_sessions', { session_ids: ['s1', CURRENT] });
+    expect(parse(res).errorCode).toBe('INVALID_ARGS');
+    expect(deleteSessions).not.toHaveBeenCalled();
+  });
+});
+
+describe('export_session', () => {
+  it('passes args through and surfaces OVERSIZE data', async () => {
+    const exportSession = vi.fn<ExportSessionDeps['exportSession']>(async ({ excludeMedia }) =>
+      excludeMedia
+        ? { ok: true as const, filePath: '/tmp/a.cshare', fidelity: 'full', missingTranscripts: [], mediaMissing: 0, orcaWorkers: 0 }
+        : { ok: false as const, errorCode: 'OVERSIZE' as const, message: 'too big', data: { limit_bytes: 1 } },
+    );
+    const registry = new XdtHelperToolRegistry();
+    registerExportSessionTool(registry, { getSessionContext, exportSession });
+    const big = await registry.call('export_session', { session_id: 's1', target_path: '/tmp/a' });
+    expect(exportSession).toHaveBeenCalledWith({ sessionId: 's1', targetPath: '/tmp/a', password: null, excludeMedia: false });
+    expect(parse(big)).toMatchObject({ ok: false, errorCode: 'OVERSIZE', data: { limit_bytes: 1 } });
+    const ok = await registry.call('export_session', { session_id: 's1', target_path: '/tmp/a', exclude_media: true, password: 'pw' });
+    expect(exportSession).toHaveBeenLastCalledWith({ sessionId: 's1', targetPath: '/tmp/a', password: 'pw', excludeMedia: true });
+    expect(parse(ok)).toMatchObject({ ok: true, file_path: '/tmp/a.cshare', fidelity: 'full' });
+  });
+});
+
+describe('open_session_in_new_window / fork_session / get_session_branches', () => {
+  it('open passes through', async () => {
+    const open = vi.fn<OpenSessionInNewWindowDeps['openSessionInNewWindow']>(async ({ sessionId }) => ({
+      ok: true as const,
+      sessionId,
+      title: 't',
+    }));
+    const registry = new XdtHelperToolRegistry();
+    registerOpenSessionInNewWindowTool(registry, { getSessionContext, openSessionInNewWindow: open });
+    const res = await registry.call('open_session_in_new_window', { session_id: 's1' });
+    expect(open).toHaveBeenCalledWith({ sessionId: 's1' });
+    expect(parse(res)).toMatchObject({ ok: true, session_id: 's1', title: 't' });
+  });
+
+  it('fork passes message id and returns the new session', async () => {
+    const fork = vi.fn<ForkSessionDeps['forkSession']>(async () => ({ ok: true as const, session: item('new') }));
+    const registry = new XdtHelperToolRegistry();
+    registerForkSessionTool(registry, { getSessionContext, forkSession: fork });
+    const res = await registry.call('fork_session', { session_id: 's1', message_id: 'm1' });
+    expect(fork).toHaveBeenCalledWith({ sessionId: 's1', messageId: 'm1' });
+    expect(parse(res)).toMatchObject({ ok: true, source_session_id: 's1', session: { session_id: 'new' } });
+  });
+
+  it('branches returns family with ISO created_at', async () => {
+    const branches = vi.fn<GetSessionBranchesDeps['getSessionBranches']>(async () => ({
+      ok: true as const,
+      rootSessionId: 'root',
+      family: [
+        { ...item('root'), parentSessionId: null, forkedAtMessageId: null, createdAt: 0 },
+        { ...item('child'), parentSessionId: 'root', forkedAtMessageId: 'm1', createdAt: 1000 },
+      ],
+    }));
+    const registry = new XdtHelperToolRegistry();
+    registerGetSessionBranchesTool(registry, { getSessionContext, getSessionBranches: branches });
+    const res = await registry.call('get_session_branches', { session_id: 'child' });
+    expect(parse(res)).toMatchObject({
+      ok: true,
+      root_session_id: 'root',
+      count: 2,
+      family: [
+        { session_id: 'root', parent_session_id: null },
+        { session_id: 'child', parent_session_id: 'root', forked_at_message_id: 'm1', created_at: '1970-01-01T00:00:01.000Z' },
+      ],
+    });
+  });
+
+  it('branches maps NOT_FOUND', async () => {
+    const registry = new XdtHelperToolRegistry();
+    registerGetSessionBranchesTool(registry, {
+      getSessionContext,
+      getSessionBranches: async () => ({ ok: false, errorCode: 'NOT_FOUND', message: 'nope' }),
+    });
+    const res = await registry.call('get_session_branches', { session_id: 'x' });
+    expect(parse(res)).toMatchObject({ ok: false, errorCode: 'NOT_FOUND' });
+  });
+});

--- a/packages/lizi-mcps/src/lizi_xdtHelperMcpServer.ts
+++ b/packages/lizi-mcps/src/lizi_xdtHelperMcpServer.ts
@@ -40,6 +40,14 @@ import {
   registerRenameSessionsTool,
   registerArchiveSessionsTool,
   registerUnarchiveSessionsTool,
+  registerMoveSessionsTool,
+  registerPinSessionsTool,
+  registerUnpinSessionsTool,
+  registerDeleteSessionsTool,
+  registerExportSessionTool,
+  registerOpenSessionInNewWindowTool,
+  registerForkSessionTool,
+  registerGetSessionBranchesTool,
   registerSendToSessionTool,
   registerListWorkdirsTool,
   registerListSessionsTool,
@@ -58,6 +66,13 @@ import type { SubmitGithubIssueDeps } from './xdt-helper/submit_github_issue.js'
 import type { SetCurrentSessionTitleDeps } from './xdt-helper/set_current_session_title.js';
 import type { RenameSessionsDeps } from './xdt-helper/rename_sessions.js';
 import type { ArchiveSessionsDeps } from './xdt-helper/archive_sessions.js';
+import type { MoveSessionsDeps } from './xdt-helper/move_sessions.js';
+import type { PinSessionsDeps } from './xdt-helper/pin_sessions.js';
+import type { DeleteSessionsDeps } from './xdt-helper/delete_sessions.js';
+import type { ExportSessionDeps } from './xdt-helper/export_session.js';
+import type { OpenSessionInNewWindowDeps } from './xdt-helper/open_session_in_new_window.js';
+import type { ForkSessionDeps } from './xdt-helper/fork_session.js';
+import type { GetSessionBranchesDeps } from './xdt-helper/get_session_branches.js';
 import type { SendToSessionCallback } from './xdt-helper/send_to_session.js';
 import {
   registerBotSkillTools,
@@ -625,6 +640,21 @@ export interface XdtHelperMcpDeps {
    * unarchive_sessions 会被注册。host 负责存在性校验(全有才写)、写库并广播 sessions:patched。
    */
   setSessionsStatus?: ArchiveSessionsDeps['setSessionsStatus'];
+  /**
+   * GUI 会话菜单对应的其余会话操作回调(移动到项目/对话、置顶、删除、导出分享包、
+   * 在新窗口打开、分叉、分支家族)。host 注入后对应 control 类工具才会注册;host 侧
+   * 一律复用主进程既有业务路径(sessions:update / session-share / fork),并负责与 GUI
+   * 同口径的守卫(远程 / 运行中 / IM 接管中 / 空草稿等)。
+   */
+  sessionOps?: {
+    moveSessions: MoveSessionsDeps['moveSessions'];
+    setSessionsPinned: PinSessionsDeps['setSessionsPinned'];
+    deleteSessions: DeleteSessionsDeps['deleteSessions'];
+    exportSession: ExportSessionDeps['exportSession'];
+    openSessionInNewWindow: OpenSessionInNewWindowDeps['openSessionInNewWindow'];
+    forkSession: ForkSessionDeps['forkSession'];
+    getSessionBranches: GetSessionBranchesDeps['getSessionBranches'];
+  };
 }
 
 /**
@@ -689,6 +719,25 @@ export function createXdtHelperMcpServer(
     };
     registerArchiveSessionsTool(registry, archiveDeps);
     registerUnarchiveSessionsTool(registry, archiveDeps);
+  }
+  if (deps.sessionOps) {
+    const ops = deps.sessionOps;
+    const getSessionContext = () => resolveLiziMcpSessionContext(sessionCtx);
+    registerMoveSessionsTool(registry, { getSessionContext, moveSessions: ops.moveSessions });
+    const pinDeps = { getSessionContext, setSessionsPinned: ops.setSessionsPinned };
+    registerPinSessionsTool(registry, pinDeps);
+    registerUnpinSessionsTool(registry, pinDeps);
+    registerDeleteSessionsTool(registry, { getSessionContext, deleteSessions: ops.deleteSessions });
+    registerExportSessionTool(registry, { getSessionContext, exportSession: ops.exportSession });
+    registerOpenSessionInNewWindowTool(registry, {
+      getSessionContext,
+      openSessionInNewWindow: ops.openSessionInNewWindow,
+    });
+    registerForkSessionTool(registry, { getSessionContext, forkSession: ops.forkSession });
+    registerGetSessionBranchesTool(registry, {
+      getSessionContext,
+      getSessionBranches: ops.getSessionBranches,
+    });
   }
 
   // History 类工具: 仅 host 注入了 history 回调时注册。

--- a/packages/lizi-mcps/src/xdt-helper/_confirmation_token.ts
+++ b/packages/lizi-mcps/src/xdt-helper/_confirmation_token.ts
@@ -1,0 +1,38 @@
+/**
+ * xdt-helper/_confirmation_token.ts —— dry-run → 确认 两段式写操作共用的 token 编解码。
+ *
+ * 需要用户核对后才能落库的批量写(rename_sessions / delete_sessions)先返回预览与
+ * 一枚 HMAC 签名的 token,真正写入时必须回传同一批变更对应的 token。密钥进程内随机,
+ * token 不跨进程、不落盘,只用于防止模型跳过预览直接写。
+ */
+
+import { createHmac, randomBytes } from 'node:crypto';
+
+const CONFIRMATION_TOKEN_SECRET = randomBytes(32);
+
+function sign(encoded: string): string {
+  return createHmac('sha256', CONFIRMATION_TOKEN_SECRET).update(encoded).digest('hex').slice(0, 24);
+}
+
+export function encodeConfirmationToken(payload: unknown): string {
+  const encoded = Buffer.from(JSON.stringify(payload), 'utf8').toString('base64url');
+  return `v1.${encoded}.${sign(encoded)}`;
+}
+
+/**
+ * 解码并校验签名;`validate` 负责结构校验,任一步失败返回 null。
+ */
+export function decodeConfirmationToken<T>(
+  token: string,
+  validate: (payload: unknown) => payload is T,
+): T | null {
+  const [version, encoded, digest] = token.split('.');
+  if (version !== 'v1' || !encoded || !digest) return null;
+  if (digest !== sign(encoded)) return null;
+  try {
+    const payload: unknown = JSON.parse(Buffer.from(encoded, 'base64url').toString('utf8'));
+    return validate(payload) ? payload : null;
+  } catch {
+    return null;
+  }
+}

--- a/packages/lizi-mcps/src/xdt-helper/_session_ops.ts
+++ b/packages/lizi-mcps/src/xdt-helper/_session_ops.ts
@@ -1,0 +1,67 @@
+/**
+ * xdt-helper/_session_ops.ts —— 会话操作类 control 工具共用的类型与小函数。
+ *
+ * move / pin / delete / export / fork / open-in-new-window / branches 这组工具对应
+ * GUI 会话菜单里的同名操作,host 侧一律复用主进程既有的业务路径(sessions:update /
+ * session-share / fork),这里只放工具层共享的批次护栏与 payload 映射。
+ */
+
+import type { ControlResult } from '../lizi_xdtHelperMcpServer.js';
+import { errorPayload, type ToolPayloadResult } from './_payload.js';
+
+export const SESSION_OPS_MAX_BATCH = 50;
+
+/** host 回传的会话摘要行(与 archive_sessions 的 changed 项同款字段)。 */
+export interface SessionOpItem {
+  sessionId: string;
+  title: string | null;
+  workingDir: string | null;
+  workspaceKind: 'project' | 'dialogue';
+  status: string;
+}
+
+export type SessionOpErrorCode =
+  | 'NOT_FOUND'
+  | 'PRECONDITION_FAILED'
+  | 'INVALID_ARGS'
+  | 'HOST_NOT_READY'
+  | 'INTERNAL';
+
+export type SessionOpResult<T extends object> = ControlResult<T, SessionOpErrorCode>;
+
+export function dedupeSessionIds(ids: string[]): { ids: string[]; duplicate: string | null } {
+  const seen = new Set<string>();
+  const out: string[] = [];
+  for (const id of ids) {
+    if (seen.has(id)) return { ids: out, duplicate: id };
+    seen.add(id);
+    out.push(id);
+  }
+  return { ids: out, duplicate: null };
+}
+
+export function sessionOpItemToPayload(item: SessionOpItem): Record<string, unknown> {
+  return {
+    session_id: item.sessionId,
+    title: item.title,
+    working_dir: item.workingDir,
+    workspace_kind: item.workspaceKind,
+    status: item.status,
+  };
+}
+
+/** host 失败码 → 工具 errorPayload;HOST_NOT_READY 统一换成可转述的提示。 */
+export function hostErrorPayload(
+  result: { errorCode: string; message: string },
+  brandName: string,
+  data: Record<string, unknown> = {},
+): ToolPayloadResult {
+  if (result.errorCode === 'HOST_NOT_READY') {
+    return errorPayload(
+      'HOST_NOT_READY',
+      `${brandName} 主进程会话服务尚未就绪。请告知用户稍等几秒后重试。`,
+      data,
+    );
+  }
+  return errorPayload(result.errorCode, result.message, data);
+}

--- a/packages/lizi-mcps/src/xdt-helper/capabilities.ts
+++ b/packages/lizi-mcps/src/xdt-helper/capabilities.ts
@@ -109,6 +109,8 @@ export const CAPABILITIES: readonly CapabilityEntry[] = [
       'Rewind:在当前会话回到历史点,改写发送内容后重新运行,原分支被替换。',
       'agent 批量整理:control 类工具 rename_sessions(批量改名)、archive_sessions / unarchive_sessions(批量归档/取消归档,把 status 在 active↔archived 间切换)。',
       '归档可逆、不删数据,经统一权威出口写库并广播 sessions:patched,侧栏即时收敛;不能归档当前正在运行的会话。',
+      '侧栏会话菜单的其余操作 agent 同样可代办(都在 cindy_helper control 类,与 GUI 走同一条主进程路径,侧栏即时刷新):move_sessions(移动到项目 / 移回对话)、pin_sessions / unpin_sessions(置顶)、delete_sessions(软删除,必须先 dry_run 预览并经用户确认)、export_session(导出 .cshare 分享包到指定路径)、open_session_in_new_window(在新窗口打开)、fork_session(在某条消息处分叉出新会话)、get_session_branches(查看分叉家族)。远程会话、运行中、被 IM 接管中的会话这些操作都会被拦下。',
+      '「复制任务链接」不需要工具:链接格式固定为 cindy://session/<session_id>,粘贴到对话里会渲染成会话 chip。',
       '以上操作都不破坏原数据,可放心试错。',
     ].join(' '),
   },

--- a/packages/lizi-mcps/src/xdt-helper/delete_sessions.ts
+++ b/packages/lizi-mcps/src/xdt-helper/delete_sessions.ts
@@ -1,0 +1,156 @@
+/**
+ * xdt-helper/delete_sessions.ts —— 批量删除 session(control 类,dry-run 两段式)。
+ *
+ * 对应 GUI 会话菜单的「删除」。GUI 删除前弹确认框并提示「有未提交改动的 worktree」;
+ * 工具侧的对应物是 dry_run 预览(含 dirty_worktree 标记)+ confirmation_token,真正删除
+ * 必须回传同一批 id 对应的 token。host 侧走 sessions:update 业务体写 status=deleted:
+ * 软删除,与 GUI 同一条路径(worktree 回收、运行时清理、sessions:patched 广播)。
+ *
+ * 守卫(host 逐条校验,任一不过整批不写):远程会话、运行中(含协同 worker 运行中)、
+ * 被 IM 接管中不允许;已删除的直接 PRECONDITION_FAILED。工具层不允许删除当前 session 自己。
+ */
+
+import { BRAND_NAME } from '@cindy/maker-shared/branding';
+import { z } from 'zod';
+
+import type { XdtHelperToolRegistry } from '../lizi_xdtHelperToolRegistry.js';
+import type { LiziMcpSessionContext } from '../types.js';
+import { decodeConfirmationToken, encodeConfirmationToken } from './_confirmation_token.js';
+import { errorPayload, okPayload } from './_payload.js';
+import {
+  SESSION_OPS_MAX_BATCH,
+  dedupeSessionIds,
+  hostErrorPayload,
+  sessionOpItemToPayload,
+  type SessionOpItem,
+  type SessionOpResult,
+} from './_session_ops.js';
+
+export interface DeleteSessionPreviewItem extends SessionOpItem {
+  /** 该会话绑定的托管 worktree 有未提交改动(删除会回收 worktree)。 */
+  dirtyWorktree: boolean;
+}
+
+/**
+ * dryRun=true:只做守卫校验并返回预览;dryRun=false:守卫通过后逐个软删除。
+ * 中途失败返回 INTERNAL,items 为已完成部分。
+ */
+export type DeleteSessionsResult = SessionOpResult<{ items: DeleteSessionPreviewItem[] }>;
+
+export interface DeleteSessionsDeps {
+  getSessionContext(): LiziMcpSessionContext;
+  deleteSessions(params: { sessionIds: string[]; dryRun: boolean }): Promise<DeleteSessionsResult>;
+}
+
+interface DeleteConfirmationPayload {
+  v: 1;
+  sessionIds: string[];
+}
+
+function isDeleteConfirmationPayload(payload: unknown): payload is DeleteConfirmationPayload {
+  const p = payload as Partial<DeleteConfirmationPayload> | null;
+  return (
+    !!p &&
+    p.v === 1 &&
+    Array.isArray(p.sessionIds) &&
+    p.sessionIds.every((id) => typeof id === 'string')
+  );
+}
+
+function sameIds(a: string[], b: string[]): boolean {
+  return a.length === b.length && a.every((id, i) => id === b[i]);
+}
+
+const DESCRIPTION =
+  `批量删除 ${BRAND_NAME} 历史对话/session(软删除:从侧栏移除并回收托管 worktree;` +
+  '不同于归档,删除不提供恢复入口)。等价于侧栏菜单的「删除」。' +
+  '必须先 dry_run=true 预览待删列表(含 dirty_worktree 标记:有未提交改动的 worktree 会一并回收),' +
+  '把结果核对给用户并取得同意后,再以 dry_run=false + 同一批 id 对应的 confirmation_token 真正删除。' +
+  '限制:远程会话、运行中(含协同 worker 运行中)、被 IM 接管中不能删除;不能删除当前 session 自己。' +
+  '想只是整理侧栏请优先用 archive_sessions。' +
+  '失败码: NOT_FOUND(某些 id 不存在,整批不写) / PRECONDITION_FAILED(被守卫拦下或已删除,整批不写) / ' +
+  'INVALID_ARGS(含 token 不匹配) / NO_SESSION_CONTEXT / HOST_NOT_READY / INTERNAL(途中失败,data.items 为已删部分)。';
+
+function toPreviewPayload(item: DeleteSessionPreviewItem): Record<string, unknown> {
+  return { ...sessionOpItemToPayload(item), dirty_worktree: item.dirtyWorktree };
+}
+
+export function registerDeleteSessionsTool(
+  registry: XdtHelperToolRegistry,
+  deps: DeleteSessionsDeps,
+): void {
+  registry.register({
+    name: 'delete_sessions',
+    category: 'control',
+    description: DESCRIPTION,
+    inputShape: {
+      session_ids: z
+        .array(z.string().min(1))
+        .min(1)
+        .max(SESSION_OPS_MAX_BATCH)
+        .describe(`要删除的 session id 列表。一次最多 ${SESSION_OPS_MAX_BATCH} 个。`),
+      dry_run: z
+        .boolean()
+        .default(true)
+        .describe('true(默认)只预览并返回 confirmation_token;false 真正删除,必须同时传 token。'),
+      confirmation_token: z
+        .string()
+        .optional()
+        .describe('dry_run=false 时必填:上一次 dry_run 对同一批 session_ids 返回的 token。'),
+    },
+    handler: async ({ session_ids, dry_run, confirmation_token }) => {
+      const { ids, duplicate } = dedupeSessionIds(session_ids);
+      if (duplicate) {
+        return errorPayload('INVALID_ARGS', `同一次调用里 session_id 重复: ${duplicate}。`);
+      }
+      const ctx = deps.getSessionContext();
+      if (!ctx.sessionId) {
+        return errorPayload(
+          'NO_SESSION_CONTEXT',
+          `本次 MCP 调用没有绑定 ${BRAND_NAME} session,无法写库。`,
+        );
+      }
+      if (ids.includes(ctx.sessionId)) {
+        return errorPayload(
+          'INVALID_ARGS',
+          '不能删除当前正在运行的 session 自己。请把它从 session_ids 里去掉。',
+        );
+      }
+      if (!dry_run) {
+        const payload = confirmation_token
+          ? decodeConfirmationToken(confirmation_token, isDeleteConfirmationPayload)
+          : null;
+        if (!payload || !sameIds(payload.sessionIds, ids)) {
+          return errorPayload(
+            'INVALID_ARGS',
+            'dry_run=false 需要携带同一批 session_ids 对应的 confirmation_token。请先 dry_run=true 预览并向用户确认。',
+          );
+        }
+      }
+
+      const result = await deps.deleteSessions({ sessionIds: ids, dryRun: dry_run });
+      if (!result.ok) {
+        return hostErrorPayload(result, BRAND_NAME, {
+          items:
+            (result as { items?: DeleteSessionPreviewItem[] }).items?.map(toPreviewPayload) ?? [],
+        });
+      }
+      if (dry_run) {
+        return okPayload({
+          dry_run: true,
+          count: result.items.length,
+          items: result.items.map(toPreviewPayload),
+          dirty_worktree_count: result.items.filter((item) => item.dirtyWorktree).length,
+          confirmation_token: encodeConfirmationToken({ v: 1, sessionIds: ids }),
+          next_step:
+            '把待删列表核对给用户,取得同意后再以 dry_run=false + 此 confirmation_token 调用。',
+        });
+      }
+      return okPayload({
+        dry_run: false,
+        count: result.items.length,
+        deleted: result.items.map(toPreviewPayload),
+      });
+    },
+  });
+}

--- a/packages/lizi-mcps/src/xdt-helper/export_session.ts
+++ b/packages/lizi-mcps/src/xdt-helper/export_session.ts
@@ -1,0 +1,93 @@
+/**
+ * xdt-helper/export_session.ts —— 把一个 session 导出成 .cshare 分享包(control 类)。
+ *
+ * 对应 GUI 会话菜单的「导出分享包」。GUI 弹系统保存框选路径;工具侧由调用方给出
+ * 目标绝对路径,其余(打包、可选密码、体积上限)复用主进程 session-share 的导出编排。
+ * 远程会话、协同 worker、已删除会话不能导出(与 host 守卫同口径)。
+ */
+
+import { BRAND_NAME } from '@cindy/maker-shared/branding';
+import { z } from 'zod';
+
+import type { XdtHelperToolRegistry } from '../lizi_xdtHelperToolRegistry.js';
+import type { ControlResult } from '../lizi_xdtHelperMcpServer.js';
+import type { LiziMcpSessionContext } from '../types.js';
+import { errorPayload, okPayload } from './_payload.js';
+import { hostErrorPayload } from './_session_ops.js';
+
+export interface ExportSessionOk {
+  filePath: string;
+  fidelity: string;
+  missingTranscripts: string[];
+  mediaMissing: number;
+  orcaWorkers: number;
+}
+
+export type ExportSessionResult = ControlResult<
+  ExportSessionOk,
+  'NOT_FOUND' | 'PRECONDITION_FAILED' | 'INVALID_ARGS' | 'OVERSIZE' | 'HOST_NOT_READY' | 'INTERNAL'
+> & { data?: Record<string, unknown> };
+
+export interface ExportSessionDeps {
+  getSessionContext(): LiziMcpSessionContext;
+  exportSession(params: {
+    sessionId: string;
+    targetPath: string;
+    password: string | null;
+    excludeMedia: boolean;
+  }): Promise<ExportSessionResult>;
+}
+
+const DESCRIPTION =
+  `把一个 ${BRAND_NAME} 历史对话/session 导出为 .cshare 分享包文件(可在另一台 ${BRAND_NAME} 导入)。` +
+  '等价于侧栏菜单的「导出分享包」,但由你指定 target_path(绝对路径,扩展名不是 .cshare 时会自动补上)。' +
+  '可选 password 加密;体积超限时返回 OVERSIZE,可用 exclude_media=true 只导出文本与转录重试。' +
+  '限制:远程会话、协同 worker、已删除会话不能导出。' +
+  '失败码: NOT_FOUND / PRECONDITION_FAILED / OVERSIZE(data 含 total_bytes / limit_bytes) / INVALID_ARGS / HOST_NOT_READY / INTERNAL。';
+
+export function registerExportSessionTool(
+  registry: XdtHelperToolRegistry,
+  deps: ExportSessionDeps,
+): void {
+  registry.register({
+    name: 'export_session',
+    category: 'control',
+    description: DESCRIPTION,
+    inputShape: {
+      session_id: z.string().min(1).describe('要导出的 session id。'),
+      target_path: z
+        .string()
+        .min(1)
+        .describe('导出文件的绝对路径;所在目录须已存在。'),
+      password: z.string().min(1).optional().describe('可选:给分享包加密的密码。'),
+      exclude_media: z
+        .boolean()
+        .default(false)
+        .describe('true 时跳过全部媒体附件,只保留消息文本与转录(超限重试用)。'),
+    },
+    handler: async ({ session_id, target_path, password, exclude_media }) => {
+      const ctx = deps.getSessionContext();
+      if (!ctx.sessionId) {
+        return errorPayload(
+          'NO_SESSION_CONTEXT',
+          `本次 MCP 调用没有绑定 ${BRAND_NAME} session,无法访问会话数据。`,
+        );
+      }
+      const result = await deps.exportSession({
+        sessionId: session_id,
+        targetPath: target_path,
+        password: password ?? null,
+        excludeMedia: exclude_media,
+      });
+      if (!result.ok) return hostErrorPayload(result, BRAND_NAME, result.data ?? {});
+      return okPayload({
+        session_id,
+        file_path: result.filePath,
+        fidelity: result.fidelity,
+        missing_transcripts: result.missingTranscripts,
+        media_missing: result.mediaMissing,
+        orca_workers: result.orcaWorkers,
+      });
+    },
+  });
+}

--- a/packages/lizi-mcps/src/xdt-helper/fork_session.ts
+++ b/packages/lizi-mcps/src/xdt-helper/fork_session.ts
@@ -1,0 +1,73 @@
+/**
+ * xdt-helper/fork_session.ts —— 在某条历史消息处分叉出新 session(control 类)。
+ *
+ * 对应 GUI 的消息级「Fork」。host 侧复用 maker-orchestration/fork 的 forkSessionAtMessage:
+ * 新会话继承到该消息为止的上文,原会话不变。message_id 用 history/get_chat_history
+ * 返回的消息 id(host 内部换算成 fork 所需的 clientId)。
+ */
+
+import { BRAND_NAME } from '@cindy/maker-shared/branding';
+import { z } from 'zod';
+
+import type { XdtHelperToolRegistry } from '../lizi_xdtHelperToolRegistry.js';
+import type { ControlResult } from '../lizi_xdtHelperMcpServer.js';
+import type { LiziMcpSessionContext } from '../types.js';
+import { errorPayload, okPayload } from './_payload.js';
+import { hostErrorPayload, sessionOpItemToPayload, type SessionOpItem } from './_session_ops.js';
+
+export type ForkSessionResult = ControlResult<
+  { session: SessionOpItem },
+  | 'NOT_FOUND'
+  | 'PRECONDITION_FAILED'
+  | 'INVALID_ARGS'
+  | 'UNSUPPORTED_CAPABILITY'
+  | 'HOST_NOT_READY'
+  | 'INTERNAL'
+>;
+
+export interface ForkSessionDeps {
+  getSessionContext(): LiziMcpSessionContext;
+  forkSession(params: { sessionId: string; messageId: string }): Promise<ForkSessionResult>;
+}
+
+const DESCRIPTION =
+  `在 ${BRAND_NAME} 某个历史对话/session 的一条消息处分叉出一个新 session(等价于 GUI 的 Fork):` +
+  '新会话继承到该消息为止的全部上文,原会话保持不变,新会话会出现在侧栏。' +
+  'message_id 取 history/get_chat_history 返回的消息 id;只能在 user 或 assistant 消息上分叉,' +
+  '且必须在至少一条 AI 回复之后。远程会话不支持。' +
+  '失败码: NOT_FOUND(会话或消息不存在) / INVALID_ARGS(消息角色不合法) / ' +
+  'PRECONDITION_FAILED(原会话尚未运行 / 无前置 AI 回复 / 远程会话) / UNSUPPORTED_CAPABILITY(该 agent 或历史格式不支持 fork) / HOST_NOT_READY / INTERNAL。';
+
+export function registerForkSessionTool(
+  registry: XdtHelperToolRegistry,
+  deps: ForkSessionDeps,
+): void {
+  registry.register({
+    name: 'fork_session',
+    category: 'control',
+    description: DESCRIPTION,
+    inputShape: {
+      session_id: z.string().min(1).describe('要分叉的源 session id。'),
+      message_id: z
+        .string()
+        .min(1)
+        .describe('在哪条消息处分叉:history/get_chat_history 返回的消息 id。'),
+    },
+    handler: async ({ session_id, message_id }) => {
+      const ctx = deps.getSessionContext();
+      if (!ctx.sessionId) {
+        return errorPayload(
+          'NO_SESSION_CONTEXT',
+          `本次 MCP 调用没有绑定 ${BRAND_NAME} session,无法写库。`,
+        );
+      }
+      const result = await deps.forkSession({ sessionId: session_id, messageId: message_id });
+      if (!result.ok) return hostErrorPayload(result, BRAND_NAME);
+      return okPayload({
+        source_session_id: session_id,
+        forked_at_message_id: message_id,
+        session: sessionOpItemToPayload(result.session),
+      });
+    },
+  });
+}

--- a/packages/lizi-mcps/src/xdt-helper/get_session_branches.ts
+++ b/packages/lizi-mcps/src/xdt-helper/get_session_branches.ts
@@ -1,0 +1,73 @@
+/**
+ * xdt-helper/get_session_branches.ts —— 查看一个 session 所在的分叉家族(control 类,只读)。
+ *
+ * 对应 GUI 会话头菜单的「会话分支」。家族 = 顺着 parentSessionId 找到根,再收集根下
+ * 全部派生会话;每项带 parent_session_id / forked_at_message_id,足够还原分支树。
+ */
+
+import { BRAND_NAME } from '@cindy/maker-shared/branding';
+import { z } from 'zod';
+
+import type { XdtHelperToolRegistry } from '../lizi_xdtHelperToolRegistry.js';
+import type { ControlResult } from '../lizi_xdtHelperMcpServer.js';
+import type { LiziMcpSessionContext } from '../types.js';
+import { errorPayload, okPayload } from './_payload.js';
+import { hostErrorPayload, sessionOpItemToPayload, type SessionOpItem } from './_session_ops.js';
+
+export interface SessionBranchItem extends SessionOpItem {
+  parentSessionId: string | null;
+  forkedAtMessageId: string | null;
+  createdAt: number;
+}
+
+export type GetSessionBranchesResult = ControlResult<
+  { rootSessionId: string; family: SessionBranchItem[] },
+  'NOT_FOUND' | 'HOST_NOT_READY' | 'INTERNAL'
+>;
+
+export interface GetSessionBranchesDeps {
+  getSessionContext(): LiziMcpSessionContext;
+  getSessionBranches(params: { sessionId: string }): Promise<GetSessionBranchesResult>;
+}
+
+const DESCRIPTION =
+  `查看一个 ${BRAND_NAME} 会话所在的分叉家族(等价于会话菜单的「会话分支」):返回根会话与` +
+  '全部派生会话,每项带 parent_session_id 与 forked_at_message_id,可据此还原分支树。' +
+  '只读。家族里只有它自己时 family 只有一项。' +
+  '失败码: NOT_FOUND / HOST_NOT_READY / INTERNAL。';
+
+export function registerGetSessionBranchesTool(
+  registry: XdtHelperToolRegistry,
+  deps: GetSessionBranchesDeps,
+): void {
+  registry.register({
+    name: 'get_session_branches',
+    category: 'control',
+    description: DESCRIPTION,
+    inputShape: {
+      session_id: z.string().min(1).describe('家族里任意一个 session 的 id。'),
+    },
+    handler: async ({ session_id }) => {
+      const ctx = deps.getSessionContext();
+      if (!ctx.sessionId) {
+        return errorPayload(
+          'NO_SESSION_CONTEXT',
+          `本次 MCP 调用没有绑定 ${BRAND_NAME} session,无法访问会话数据。`,
+        );
+      }
+      const result = await deps.getSessionBranches({ sessionId: session_id });
+      if (!result.ok) return hostErrorPayload(result, BRAND_NAME);
+      return okPayload({
+        session_id,
+        root_session_id: result.rootSessionId,
+        count: result.family.length,
+        family: result.family.map((item) => ({
+          ...sessionOpItemToPayload(item),
+          parent_session_id: item.parentSessionId,
+          forked_at_message_id: item.forkedAtMessageId,
+          created_at: new Date(item.createdAt).toISOString(),
+        })),
+      });
+    },
+  });
+}

--- a/packages/lizi-mcps/src/xdt-helper/index.ts
+++ b/packages/lizi-mcps/src/xdt-helper/index.ts
@@ -38,6 +38,53 @@ export {
   type SessionStatusChangeItem,
   type SetSessionsStatusResult,
 } from './archive_sessions.js';
+// GUI 会话菜单对应的 control 工具(移动 / 置顶 / 删除 / 导出 / 新窗口 / 分叉 / 分支)
+export {
+  SESSION_OPS_MAX_BATCH,
+  type SessionOpErrorCode,
+  type SessionOpItem,
+  type SessionOpResult,
+} from './_session_ops.js';
+export {
+  registerMoveSessionsTool,
+  type MoveSessionsDeps,
+  type MoveSessionsResult,
+  type SessionMoveTarget,
+} from './move_sessions.js';
+export {
+  registerPinSessionsTool,
+  registerUnpinSessionsTool,
+  type PinSessionsDeps,
+  type SetSessionsPinnedResult,
+} from './pin_sessions.js';
+export {
+  registerDeleteSessionsTool,
+  type DeleteSessionPreviewItem,
+  type DeleteSessionsDeps,
+  type DeleteSessionsResult,
+} from './delete_sessions.js';
+export {
+  registerExportSessionTool,
+  type ExportSessionDeps,
+  type ExportSessionOk,
+  type ExportSessionResult,
+} from './export_session.js';
+export {
+  registerOpenSessionInNewWindowTool,
+  type OpenSessionInNewWindowDeps,
+  type OpenSessionInNewWindowResult,
+} from './open_session_in_new_window.js';
+export {
+  registerForkSessionTool,
+  type ForkSessionDeps,
+  type ForkSessionResult,
+} from './fork_session.js';
+export {
+  registerGetSessionBranchesTool,
+  type GetSessionBranchesDeps,
+  type GetSessionBranchesResult,
+  type SessionBranchItem,
+} from './get_session_branches.js';
 // multi-worker Phase 1 control tools
 export {
   registerStartTeamTool,

--- a/packages/lizi-mcps/src/xdt-helper/move_sessions.ts
+++ b/packages/lizi-mcps/src/xdt-helper/move_sessions.ts
@@ -1,0 +1,125 @@
+/**
+ * xdt-helper/move_sessions.ts —— 批量把 session 移动到某个项目 / 移回对话(control 类)。
+ *
+ * 对应 GUI 会话菜单的「移动到项目」「移动到对话」。host 侧走 sessions:update 的业务体
+ * (updateSessionInDb):路由锁、cc 转录目录搬迁、Pi/Codex runtime 关闭、recent-workdir
+ * 维护与 sessions:patched 广播全部复用,侧栏即时收敛。
+ *
+ * 守卫(与 GUI 同口径,由 host 逐条校验,任一不过整批不写):
+ *  - 远程(SSH / device-link)会话不支持;
+ *  - 运行中(含 Orca lead 下任一 worker 运行中)不允许;
+ *  - 被 IM 接管中不允许;
+ *  - 已归档 / 已删除、空草稿、review 会话不允许。
+ * 工具层额外不允许移动当前正在运行的这个 session 自己。
+ */
+
+import { BRAND_NAME } from '@cindy/maker-shared/branding';
+import { z } from 'zod';
+
+import type { XdtHelperToolRegistry } from '../lizi_xdtHelperToolRegistry.js';
+import type { LiziMcpSessionContext } from '../types.js';
+import { errorPayload, okPayload } from './_payload.js';
+import {
+  SESSION_OPS_MAX_BATCH,
+  dedupeSessionIds,
+  hostErrorPayload,
+  sessionOpItemToPayload,
+  type SessionOpItem,
+  type SessionOpResult,
+} from './_session_ops.js';
+
+export type SessionMoveTarget =
+  | { kind: 'project'; workingDir: string }
+  | { kind: 'dialogue' };
+
+/**
+ * host 回调:全部守卫通过后逐个应用。`moved` 为已成功移动的会话;中途失败时 host 返回
+ * INTERNAL 并把已完成部分放进 partial(工具层原样透传给模型,便于如实汇报)。
+ */
+export type MoveSessionsResult = SessionOpResult<{ moved: SessionOpItem[] }>;
+
+export interface MoveSessionsDeps {
+  getSessionContext(): LiziMcpSessionContext;
+  moveSessions(params: {
+    sessionIds: string[];
+    target: SessionMoveTarget;
+  }): Promise<MoveSessionsResult>;
+}
+
+const DESCRIPTION =
+  `批量把 ${BRAND_NAME} 历史对话/session 移动到某个项目目录(target_kind=project + working_dir),` +
+  '或移回不属于任何项目的「对话」(target_kind=dialogue)。等价于侧栏菜单的「移动到项目 / 移动到对话」,' +
+  '主进程会同步搬迁 agent 转录目录并即时刷新侧栏。' +
+  '限制:远程会话、运行中(含协同 worker 运行中)、被 IM 接管中、已归档、空草稿、review 会话都不能移动;' +
+  '不能移动当前正在运行的 session 自己。建议先用 history/list_sessions 找到目标 session_id。' +
+  '失败码: NOT_FOUND(某些 id 不存在,整批不写) / PRECONDITION_FAILED(某个会话被上述守卫拦下,整批不写) / ' +
+  'INVALID_ARGS / NO_SESSION_CONTEXT / HOST_NOT_READY / INTERNAL(逐个应用途中失败,data.moved 为已完成部分)。';
+
+export function registerMoveSessionsTool(
+  registry: XdtHelperToolRegistry,
+  deps: MoveSessionsDeps,
+): void {
+  registry.register({
+    name: 'move_sessions',
+    category: 'control',
+    description: DESCRIPTION,
+    inputShape: {
+      session_ids: z
+        .array(z.string().min(1))
+        .min(1)
+        .max(SESSION_OPS_MAX_BATCH)
+        .describe(`要移动的 session id 列表。一次最多 ${SESSION_OPS_MAX_BATCH} 个。`),
+      target_kind: z
+        .enum(['project', 'dialogue'])
+        .describe('project = 移动到 working_dir 指定的项目;dialogue = 移回对话(不属于任何项目)。'),
+      working_dir: z
+        .string()
+        .min(1)
+        .optional()
+        .describe('target_kind=project 时必填:目标项目目录的绝对路径,须已存在。'),
+    },
+    handler: async ({ session_ids, target_kind, working_dir }) => {
+      const { ids, duplicate } = dedupeSessionIds(session_ids);
+      if (duplicate) {
+        return errorPayload('INVALID_ARGS', `同一次调用里 session_id 重复: ${duplicate}。`);
+      }
+      if (target_kind === 'project' && !working_dir) {
+        return errorPayload('INVALID_ARGS', 'target_kind=project 时必须提供 working_dir。');
+      }
+      if (target_kind === 'dialogue' && working_dir) {
+        return errorPayload('INVALID_ARGS', 'target_kind=dialogue 时不要传 working_dir。');
+      }
+
+      const ctx = deps.getSessionContext();
+      if (!ctx.sessionId) {
+        return errorPayload(
+          'NO_SESSION_CONTEXT',
+          `本次 MCP 调用没有绑定 ${BRAND_NAME} session,无法写库。`,
+        );
+      }
+      if (ids.includes(ctx.sessionId)) {
+        return errorPayload(
+          'INVALID_ARGS',
+          '不能移动当前正在运行的 session 自己。请把它从 session_ids 里去掉,或让用户在侧栏菜单里操作。',
+        );
+      }
+
+      const target: SessionMoveTarget =
+        target_kind === 'project'
+          ? { kind: 'project', workingDir: working_dir as string }
+          : { kind: 'dialogue' };
+      const result = await deps.moveSessions({ sessionIds: ids, target });
+      if (!result.ok) {
+        return hostErrorPayload(result, BRAND_NAME, {
+          moved: (result as { moved?: SessionOpItem[] }).moved?.map(sessionOpItemToPayload) ?? [],
+        });
+      }
+      return okPayload({
+        target_kind,
+        working_dir: target_kind === 'project' ? working_dir : null,
+        count: result.moved.length,
+        moved: result.moved.map(sessionOpItemToPayload),
+      });
+    },
+  });
+}

--- a/packages/lizi-mcps/src/xdt-helper/open_session_in_new_window.ts
+++ b/packages/lizi-mcps/src/xdt-helper/open_session_in_new_window.ts
@@ -1,0 +1,56 @@
+/**
+ * xdt-helper/open_session_in_new_window.ts —— 在新的应用窗口里打开一个 session(control 类)。
+ *
+ * 对应 GUI 会话菜单的「在新窗口打开」。纯本机 UI 动作,复用 main/secondary-windows 的
+ * 窗口生命周期;远程(device-link)会话在本地库里不存在,返回 NOT_FOUND。
+ */
+
+import { BRAND_NAME } from '@cindy/maker-shared/branding';
+import { z } from 'zod';
+
+import type { XdtHelperToolRegistry } from '../lizi_xdtHelperToolRegistry.js';
+import type { ControlResult } from '../lizi_xdtHelperMcpServer.js';
+import type { LiziMcpSessionContext } from '../types.js';
+import { errorPayload, okPayload } from './_payload.js';
+import { hostErrorPayload } from './_session_ops.js';
+
+export type OpenSessionInNewWindowResult = ControlResult<
+  { sessionId: string; title: string | null },
+  'NOT_FOUND' | 'PRECONDITION_FAILED' | 'HOST_NOT_READY' | 'INTERNAL'
+>;
+
+export interface OpenSessionInNewWindowDeps {
+  getSessionContext(): LiziMcpSessionContext;
+  openSessionInNewWindow(params: { sessionId: string }): Promise<OpenSessionInNewWindowResult>;
+}
+
+const DESCRIPTION =
+  `把一个 ${BRAND_NAME} 会话在一个完整的新应用窗口里打开(等价于侧栏菜单的「在新窗口打开」),` +
+  '便于用户同时盯多个会话。只作用于本机桌面端窗口。' +
+  '失败码: NOT_FOUND / PRECONDITION_FAILED(已删除) / HOST_NOT_READY / INTERNAL。';
+
+export function registerOpenSessionInNewWindowTool(
+  registry: XdtHelperToolRegistry,
+  deps: OpenSessionInNewWindowDeps,
+): void {
+  registry.register({
+    name: 'open_session_in_new_window',
+    category: 'control',
+    description: DESCRIPTION,
+    inputShape: {
+      session_id: z.string().min(1).describe('要在新窗口打开的 session id。'),
+    },
+    handler: async ({ session_id }) => {
+      const ctx = deps.getSessionContext();
+      if (!ctx.sessionId) {
+        return errorPayload(
+          'NO_SESSION_CONTEXT',
+          `本次 MCP 调用没有绑定 ${BRAND_NAME} session。`,
+        );
+      }
+      const result = await deps.openSessionInNewWindow({ sessionId: session_id });
+      if (!result.ok) return hostErrorPayload(result, BRAND_NAME);
+      return okPayload({ session_id: result.sessionId, title: result.title });
+    },
+  });
+}

--- a/packages/lizi-mcps/src/xdt-helper/pin_sessions.ts
+++ b/packages/lizi-mcps/src/xdt-helper/pin_sessions.ts
@@ -1,0 +1,105 @@
+/**
+ * xdt-helper/pin_sessions.ts —— 批量置顶 / 取消置顶 session(control 类)。
+ *
+ * 对应 GUI 会话菜单的「置顶」「取消置顶」。host 侧走 sessions:update 业务体
+ * (updateSessionInDb)写 pinnedAt,并广播 sessions:patched。置顶只是侧栏排序偏好,
+ * 可逆、不删数据;已归档 / 已删除的会话不能置顶(GUI 不提供入口)。
+ */
+
+import { BRAND_NAME } from '@cindy/maker-shared/branding';
+import { z } from 'zod';
+
+import type { XdtHelperToolRegistry } from '../lizi_xdtHelperToolRegistry.js';
+import type { LiziMcpSessionContext } from '../types.js';
+import { errorPayload, okPayload } from './_payload.js';
+import {
+  SESSION_OPS_MAX_BATCH,
+  dedupeSessionIds,
+  hostErrorPayload,
+  sessionOpItemToPayload,
+  type SessionOpItem,
+  type SessionOpResult,
+} from './_session_ops.js';
+
+export type SetSessionsPinnedResult = SessionOpResult<{ changed: SessionOpItem[] }>;
+
+export interface PinSessionsDeps {
+  getSessionContext(): LiziMcpSessionContext;
+  setSessionsPinned(params: {
+    sessionIds: string[];
+    pinned: boolean;
+  }): Promise<SetSessionsPinnedResult>;
+}
+
+const PIN_DESCRIPTION =
+  `批量置顶 ${BRAND_NAME} 历史对话/session(侧栏置顶区)。可逆,要取消用 unpin_sessions。` +
+  '已归档 / 已删除的会话不能置顶。建议先用 history/list_sessions 找到目标 session_id。' +
+  '失败码: NOT_FOUND(某些 id 不存在,整批不写) / PRECONDITION_FAILED(已归档或已删除,整批不写) / ' +
+  'INVALID_ARGS / NO_SESSION_CONTEXT / HOST_NOT_READY / INTERNAL。';
+
+const UNPIN_DESCRIPTION =
+  `批量取消置顶 ${BRAND_NAME} 历史对话/session。是 pin_sessions 的逆操作。` +
+  '失败码: NOT_FOUND / PRECONDITION_FAILED / INVALID_ARGS / NO_SESSION_CONTEXT / HOST_NOT_READY / INTERNAL。';
+
+function registerPinnedTool(
+  registry: XdtHelperToolRegistry,
+  deps: PinSessionsDeps,
+  config: { name: 'pin_sessions' | 'unpin_sessions'; description: string; pinned: boolean },
+): void {
+  registry.register({
+    name: config.name,
+    category: 'control',
+    description: config.description,
+    inputShape: {
+      session_ids: z
+        .array(z.string().min(1))
+        .min(1)
+        .max(SESSION_OPS_MAX_BATCH)
+        .describe(
+          `要${config.pinned ? '置顶' : '取消置顶'}的 session id 列表。一次最多 ${SESSION_OPS_MAX_BATCH} 个。`,
+        ),
+    },
+    handler: async ({ session_ids }) => {
+      const { ids, duplicate } = dedupeSessionIds(session_ids);
+      if (duplicate) {
+        return errorPayload('INVALID_ARGS', `同一次调用里 session_id 重复: ${duplicate}。`);
+      }
+      const ctx = deps.getSessionContext();
+      if (!ctx.sessionId) {
+        return errorPayload(
+          'NO_SESSION_CONTEXT',
+          `本次 MCP 调用没有绑定 ${BRAND_NAME} session,无法写库。`,
+        );
+      }
+      const result = await deps.setSessionsPinned({ sessionIds: ids, pinned: config.pinned });
+      if (!result.ok) return hostErrorPayload(result, BRAND_NAME);
+      return okPayload({
+        pinned: config.pinned,
+        count: result.changed.length,
+        changed: result.changed.map(sessionOpItemToPayload),
+      });
+    },
+  });
+}
+
+export function registerPinSessionsTool(
+  registry: XdtHelperToolRegistry,
+  deps: PinSessionsDeps,
+): void {
+  registerPinnedTool(registry, deps, {
+    name: 'pin_sessions',
+    description: PIN_DESCRIPTION,
+    pinned: true,
+  });
+}
+
+export function registerUnpinSessionsTool(
+  registry: XdtHelperToolRegistry,
+  deps: PinSessionsDeps,
+): void {
+  registerPinnedTool(registry, deps, {
+    name: 'unpin_sessions',
+    description: UNPIN_DESCRIPTION,
+    pinned: false,
+  });
+}

--- a/packages/lizi-mcps/src/xdt-helper/rename_sessions.ts
+++ b/packages/lizi-mcps/src/xdt-helper/rename_sessions.ts
@@ -1,16 +1,14 @@
 import { BRAND_NAME } from '@cindy/maker-shared/branding';
-import { createHmac, randomBytes } from 'node:crypto';
-
 import { z } from 'zod';
 
 import type { XdtHelperToolRegistry } from '../lizi_xdtHelperToolRegistry.js';
 import type { ControlResult } from '../lizi_xdtHelperMcpServer.js';
 import type { LiziMcpSessionContext } from '../types.js';
+import { decodeConfirmationToken, encodeConfirmationToken } from './_confirmation_token.js';
 import { errorPayload, okPayload } from './_payload.js';
 
 const MAX_RENAME_BATCH_SIZE = 20;
 const TITLE_MAX_LENGTH = 120;
-const CONFIRMATION_TOKEN_SECRET = randomBytes(32);
 
 export interface RenameSessionChange {
   sessionId: string;
@@ -108,44 +106,23 @@ function createConfirmationPayload(
   };
 }
 
-function encodeConfirmationToken(payload: RenameSessionsConfirmationPayload): string {
-  const encoded = Buffer.from(JSON.stringify(payload), 'utf8').toString('base64url');
-  const digest = createHmac('sha256', CONFIRMATION_TOKEN_SECRET)
-    .update(encoded)
-    .digest('hex')
-    .slice(0, 24);
-  return `v1.${encoded}.${digest}`;
-}
-
-function decodeConfirmationToken(token: string): RenameSessionsConfirmationPayload | null {
-  const [version, encoded, digest] = token.split('.');
-  if (version !== 'v1' || !encoded || !digest) return null;
-  const expectedDigest = createHmac('sha256', CONFIRMATION_TOKEN_SECRET)
-    .update(encoded)
-    .digest('hex')
-    .slice(0, 24);
-  if (digest !== expectedDigest) return null;
-
-  try {
-    const payload = JSON.parse(
-      Buffer.from(encoded, 'base64url').toString('utf8'),
-    ) as RenameSessionsConfirmationPayload;
-    if (payload.v !== 1 || !Array.isArray(payload.changes)) return null;
-    for (const change of payload.changes) {
-      if (
-        typeof change?.sessionId !== 'string' ||
-        typeof change.title !== 'string' ||
-        (change.expectedCurrentTitle !== null && typeof change.expectedCurrentTitle !== 'string') ||
-        (change.expectedUpdatedAt !== null && typeof change.expectedUpdatedAt !== 'string') ||
-        (change.approvedCurrentTitle !== null && typeof change.approvedCurrentTitle !== 'string')
-      ) {
-        return null;
-      }
+function isRenameConfirmationPayload(
+  payload: unknown,
+): payload is RenameSessionsConfirmationPayload {
+  const p = payload as Partial<RenameSessionsConfirmationPayload> | null;
+  if (!p || p.v !== 1 || !Array.isArray(p.changes)) return false;
+  for (const change of p.changes) {
+    if (
+      typeof change?.sessionId !== 'string' ||
+      typeof change.title !== 'string' ||
+      (change.expectedCurrentTitle !== null && typeof change.expectedCurrentTitle !== 'string') ||
+      (change.expectedUpdatedAt !== null && typeof change.expectedUpdatedAt !== 'string') ||
+      (change.approvedCurrentTitle !== null && typeof change.approvedCurrentTitle !== 'string')
+    ) {
+      return false;
     }
-    return payload;
-  } catch {
-    return null;
   }
+  return true;
 }
 
 function matchesConfirmationPayload(
@@ -213,7 +190,9 @@ export function registerRenameSessionsTool(
       }
 
       const confirmationPayload =
-        !dry_run && confirmation_token ? decodeConfirmationToken(confirmation_token) : null;
+        !dry_run && confirmation_token
+          ? decodeConfirmationToken(confirmation_token, isRenameConfirmationPayload)
+          : null;
       if (
         !dry_run &&
         (!confirmationPayload || !matchesConfirmationPayload(normalized, confirmationPayload))


### PR DESCRIPTION
## 这次改了什么

### 摘要

GUI 会话菜单里的操作此前只有「改名」「归档」暴露给了 agent(`cindy_helper` control 类)。真实踩坑:agent 要把一个会话从对话移到项目下,只能绕过 app 直写 SQLite,跳过了 renderer 广播与 `upsertRecentWorkdir` 等副作用,界面要重启才刷新。

本 PR 把 GUI 会话菜单的其余操作补到 `cindy_helper` control 类目,**全部复用主进程既有业务路径**,不另起写入链路:

| 工具 | 对应 GUI 操作 | host 路径 |
|---|---|---|
| `move_sessions` | 移动到项目 / 移动到对话 | `updateSessionInDb`(`sessions:update` 业务体) |
| `pin_sessions` / `unpin_sessions` | 置顶 / 取消置顶 | 同上 |
| `delete_sessions` | 删除(dry-run 预览 + confirmation_token,含 dirty worktree 标记) | 同上,`status=deleted` |
| `export_session` | 导出 .cshare 分享包(调用方给目标路径) | `exportSessionShare` |
| `open_session_in_new_window` | 在新窗口打开 | `secondary-windows.openSessionInNewWindow` |
| `fork_session` | 消息级 Fork | `forkSessionAtMessage` + `emitSessionCreated` |
| `get_session_branches` | 会话分支(只读) | 沿 `parentSessionId` 遍历家族 |

「复制任务链接」不需要工具(固定 `cindy://session/<id>`,已写进 capabilities);Rewind 是作曲器内的交互式改写,未暴露。

GUI 侧守卫在 host 逐条复现,批量先全量校验、任一不过整批不写:远程(SSH)会话不支持、运行中(含 Orca lead 的 worker)拦截、IM 接管中拦截、已归档 / 已删除、空草稿、review 会话;工具层另外拒绝对当前 session 自己做移动 / 删除。失败码与 `archive_sessions` 同风格(`NOT_FOUND` / `PRECONDITION_FAILED` / `INVALID_ARGS` / `HOST_NOT_READY` / `INTERNAL`,导出另有 `OVERSIZE`)。

主要改动点:
- `sessions.ts`:把 `local-db:sessions:update` 的业务体抽成导出的 `updateSessionInDb`,IPC handler 只做 adapter(`git diff -w` 可见是纯搬动);`registerSessionIpc` 记下 opts 供非 IPC 调用沿用 `closeIdleSessionForMove`。
- `mcp-integrations/sessionOperations.ts`:依赖全注入的业务体;`sessionOperationsHost.ts` 装配真实依赖。运行中判断由 maker-host 注入(`DesktopMcpProvidersDeps.isSessionTurnRunning`),避免 mcp-providers 反向 import maker-host 成环。
- `packages/lizi-mcps`:7 个工具文件 + `_session_ops.ts` 共享类型;确认 token 编解码从 `rename_sessions` 抽到 `_confirmation_token.ts` 与 delete 共用(rename 行为不变)。
- `capabilities.ts` session-management 条目补充新工具与链接格式。

### 变更类型

- [x] `feat` 新功能
- [ ] `fix` 缺陷修复
- [ ] `refactor` / `perf` 重构或性能优化
- [ ] `docs` / `test` / `chore` 文档、测试或工程维护
- [ ] 其他:

### 范围

- 关联 Issue / 需求:无(内部踩坑)
- 本 PR 包含:上表 7 个 control 工具、host 业务体与装配、`updateSessionInDb` 抽取、单测
- 明确不包含:GUI 交互改动、control 类目重构、Rewind、新 schema / migration
- 用户可见变化:agent 可代办上述会话操作,侧栏即时刷新;GUI 行为不变
- 是否存在 breaking change:无

### UI 变化

不涉及。

- 引用的设计规范:不涉及

## 怎么验证的

### 自动验证

```text
pnpm test:unit:related(Node 22.23.2,与 .nvmrc 一致)
结果:PASS apps/desktop unit(2617 files / 36761 tests);PASS packages/lizi-mcps unit
pnpm --filter desktop run --if-present typecheck
结果:0 errors
@cindy/mcps 无 typecheck script;直接 tsc --noEmit:本次文件 0 errors(submitGithubIssueTool / sessionControlTools 两个测试文件的既有类型错误与本 PR 无关)
pnpm check:dco
结果:1 commit signed off
新增单测:packages/lizi-mcps sessionOpsTools.test.ts(17)、apps/desktop sessionOperations.test.ts(24)
既有 writableDirectoryGrantWiring.test.ts 的源码文本断言随 handler 抽取更新
```

备注:在 Node 26 下跑同一门禁会出现约 60 个 renderer 测试文件失败(Node 26 全局 `localStorage` 存根导致 `localStorage.clear` 为 undefined),与本 PR 无关;切到 .nvmrc 指定的 Node 22 并重编译 better-sqlite3 后全绿。

### 手工验证

未执行:未在实机 Desktop 里通过 agent 调用新工具走一遍(本会话为远程 worktree 环境)。守卫与写入路径均以单测覆盖,写入路径与 GUI 完全同一函数。

### 未执行的验证

- 实机端到端(agent 调 `move_sessions` 后观察侧栏刷新与 cc 转录搬迁)未执行,原因同上。

## 风险

### 风险分类

- [x] 权限 / 安全 / 用户数据
- [ ] 无已知风险
- [ ] SQLite / migration
- [ ] system prompt
- [ ] 协议兼容
- [ ] 存量插件兼容(批准状态 / 指纹 / manifest 校验 / 安装布局 / 包格式)
- [ ] 原生层 / fingerprint / OTA
- [ ] 跨平台差异
- [x] 其他:`sessions:update` handler 业务体抽取(纯搬动,行为不变)

### 影响与回滚

- 影响范围:agent 新增了删除(软删除,dry-run + token 两段式,工具描述要求先向用户核对)、导出到 agent 指定路径(与 agent 已有的文件系统权限同级)、在新窗口打开等能力;写库仍全部经既有权威路径,无新 schema。运行中 / 远程 / IM 接管中的会话均被拦下。
- 回滚 / 降级方式:revert 本 PR 即可;`updateSessionInDb` 抽取不改变 IPC 契约与行为。

### 提交前检查

- [x] 已 review 完整 diff
- [x] 每个 commit 都带 DCO 签名(`git commit -s`,见 [DCO](../DCO))
- [x] UI 改动已在「UI 变化」注明引用的设计规范章节(不涉及 UI 则跳过)
- [x] 未提交凭证、令牌或授权文件
- [x] 已核对受影响的文档,行为变化涉及的旧结论已同步修订(capabilities.ts 已更新;docs/ 无既有工具清单需改)
- [x] 已确认测试结果或说明未执行原因
