### PR TITLE
refactor(mcps): 抽出确认 token 编解码供多个工具复用

### DIFF
--- a/packages/lizi-mcps/src/__tests__/_confirmation_token.test.ts
+++ b/packages/lizi-mcps/src/__tests__/_confirmation_token.test.ts
@@ -1,0 +1,46 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  decodeConfirmationToken,
+  encodeConfirmationToken,
+} from "../xdt-helper/_confirmation_token.js";
+
+describe("confirmation token", () => {
+  it("round-trips a payload when validation succeeds", () => {
+    const payload = { v: 1, changes: ["session-1"] };
+    const token = encodeConfirmationToken(payload);
+
+    expect(
+      decodeConfirmationToken(token, (value): value is typeof payload => {
+        return (
+          typeof value === "object" &&
+          value !== null &&
+          "v" in value &&
+          value.v === 1 &&
+          "changes" in value &&
+          Array.isArray(value.changes)
+        );
+      }),
+    ).toEqual(payload);
+  });
+
+  it("returns null when the signature is tampered with", () => {
+    const token = encodeConfirmationToken({ v: 1 });
+    const tampered = `${token.slice(0, -1)}${token.endsWith("0") ? "1" : "0"}`;
+
+    expect(
+      decodeConfirmationToken(
+        tampered,
+        (_value): _value is { v: number } => true,
+      ),
+    ).toBeNull();
+  });
+
+  it("returns null when validation rejects the payload", () => {
+    const token = encodeConfirmationToken({ v: 1 });
+
+    expect(
+      decodeConfirmationToken(token, (_value): _value is { v: 2 } => false),
+    ).toBeNull();
+  });
+});

--- a/packages/lizi-mcps/src/__tests__/_confirmation_token.test.ts
+++ b/packages/lizi-mcps/src/__tests__/_confirmation_token.test.ts
@@ -8,10 +8,10 @@ import {
 describe("confirmation token", () => {
   it("round-trips a payload when validation succeeds", () => {
     const payload = { v: 1, changes: ["session-1"] };
-    const token = encodeConfirmationToken(payload);
+    const token = encodeConfirmationToken('unit_test', payload);
 
     expect(
-      decodeConfirmationToken(token, (value): value is typeof payload => {
+      decodeConfirmationToken('unit_test', token, (value): value is typeof payload => {
         return (
           typeof value === "object" &&
           value !== null &&
@@ -25,11 +25,11 @@ describe("confirmation token", () => {
   });
 
   it("returns null when the signature is tampered with", () => {
-    const token = encodeConfirmationToken({ v: 1 });
+    const token = encodeConfirmationToken('unit_test', { v: 1 });
     const tampered = `${token.slice(0, -1)}${token.endsWith("0") ? "1" : "0"}`;
 
     expect(
-      decodeConfirmationToken(
+      decodeConfirmationToken('unit_test', 
         tampered,
         (_value): _value is { v: number } => true,
       ),
@@ -37,10 +37,24 @@ describe("confirmation token", () => {
   });
 
   it("returns null when validation rejects the payload", () => {
-    const token = encodeConfirmationToken({ v: 1 });
+    const token = encodeConfirmationToken('unit_test', { v: 1 });
 
     expect(
-      decodeConfirmationToken(token, (_value): _value is { v: 2 } => false),
+      decodeConfirmationToken('unit_test', token, (_value): _value is { v: 2 } => false),
     ).toBeNull();
+  });
+});
+
+describe('confirmation token purpose binding', () => {
+  it('rejects a token issued for another tool even with an identical payload', () => {
+    const token = encodeConfirmationToken('rename_sessions', { v: 1, ids: ['a'] });
+    const isPayload = (p: unknown): p is { v: 1; ids: string[] } =>
+      !!p && typeof p === 'object' && (p as { v?: unknown }).v === 1;
+    expect(decodeConfirmationToken('rename_sessions', token, isPayload)).toEqual({ v: 1, ids: ['a'] });
+    expect(decodeConfirmationToken('delete_sessions', token, isPayload)).toBeNull();
+  });
+
+  it('refuses malformed purposes', () => {
+    expect(() => encodeConfirmationToken('bad purpose', {})).toThrow();
   });
 });

--- a/packages/lizi-mcps/src/xdt-helper/_confirmation_token.ts
+++ b/packages/lizi-mcps/src/xdt-helper/_confirmation_token.ts
@@ -4,36 +4,53 @@
  * 需要用户核对后才能落库的批量写(rename_sessions / delete_sessions)先返回预览与
  * 一枚 HMAC 签名的 token,真正写入时必须回传同一批变更对应的 token。密钥进程内随机,
  * token 不跨进程、不落盘,只用于防止模型跳过预览直接写。
+ *
+ * 签名内容绑定签发工具的 `purpose`(工具名):多个工具共用同一把进程内密钥时,
+ * 一个工具签发的 token 不能被另一个工具接受,即使二者 payload 形状恰好重叠。
  */
 
 import { createHmac, randomBytes } from "node:crypto";
 
 const CONFIRMATION_TOKEN_SECRET = randomBytes(32);
 
-function sign(encoded: string): string {
+const PURPOSE_PATTERN = /^[a-z0-9_]+$/;
+
+function sign(purpose: string, encoded: string): string {
   return createHmac("sha256", CONFIRMATION_TOKEN_SECRET)
-    .update(encoded)
+    .update(`${purpose}.${encoded}`)
     .digest("hex")
     .slice(0, 24);
 }
 
-export function encodeConfirmationToken(payload: unknown): string {
-  const encoded = Buffer.from(JSON.stringify(payload), "utf8").toString(
-    "base64url",
-  );
-  return `v1.${encoded}.${sign(encoded)}`;
+function assertPurpose(purpose: string): void {
+  if (!PURPOSE_PATTERN.test(purpose)) {
+    throw new Error(`invalid confirmation token purpose: ${purpose}`);
+  }
 }
 
 /**
- * 解码并校验签名;`validate` 负责结构校验,任一步失败返回 null。
+ * `purpose` 是签发工具名(如 `rename_sessions`),进入 token 正文与签名内容。
+ */
+export function encodeConfirmationToken(purpose: string, payload: unknown): string {
+  assertPurpose(purpose);
+  const encoded = Buffer.from(JSON.stringify(payload), "utf8").toString(
+    "base64url",
+  );
+  return `v1.${purpose}.${encoded}.${sign(purpose, encoded)}`;
+}
+
+/**
+ * 解码并校验用途与签名;`validate` 负责结构校验,任一步失败返回 null。
  */
 export function decodeConfirmationToken<T>(
+  purpose: string,
   token: string,
   validate: (payload: unknown) => payload is T,
 ): T | null {
-  const [version, encoded, digest] = token.split(".");
-  if (version !== "v1" || !encoded || !digest) return null;
-  if (digest !== sign(encoded)) return null;
+  assertPurpose(purpose);
+  const [version, tokenPurpose, encoded, digest] = token.split(".");
+  if (version !== "v1" || tokenPurpose !== purpose || !encoded || !digest) return null;
+  if (digest !== sign(purpose, encoded)) return null;
   try {
     const payload: unknown = JSON.parse(
       Buffer.from(encoded, "base64url").toString("utf8"),

--- a/packages/lizi-mcps/src/xdt-helper/_confirmation_token.ts
+++ b/packages/lizi-mcps/src/xdt-helper/_confirmation_token.ts
@@ -1,0 +1,45 @@
+/**
+ * xdt-helper/_confirmation_token.ts —— dry-run → 确认 两段式写操作共用的 token 编解码。
+ *
+ * 需要用户核对后才能落库的批量写(rename_sessions / delete_sessions)先返回预览与
+ * 一枚 HMAC 签名的 token,真正写入时必须回传同一批变更对应的 token。密钥进程内随机,
+ * token 不跨进程、不落盘,只用于防止模型跳过预览直接写。
+ */
+
+import { createHmac, randomBytes } from "node:crypto";
+
+const CONFIRMATION_TOKEN_SECRET = randomBytes(32);
+
+function sign(encoded: string): string {
+  return createHmac("sha256", CONFIRMATION_TOKEN_SECRET)
+    .update(encoded)
+    .digest("hex")
+    .slice(0, 24);
+}
+
+export function encodeConfirmationToken(payload: unknown): string {
+  const encoded = Buffer.from(JSON.stringify(payload), "utf8").toString(
+    "base64url",
+  );
+  return `v1.${encoded}.${sign(encoded)}`;
+}
+
+/**
+ * 解码并校验签名;`validate` 负责结构校验,任一步失败返回 null。
+ */
+export function decodeConfirmationToken<T>(
+  token: string,
+  validate: (payload: unknown) => payload is T,
+): T | null {
+  const [version, encoded, digest] = token.split(".");
+  if (version !== "v1" || !encoded || !digest) return null;
+  if (digest !== sign(encoded)) return null;
+  try {
+    const payload: unknown = JSON.parse(
+      Buffer.from(encoded, "base64url").toString("utf8"),
+    );
+    return validate(payload) ? payload : null;
+  } catch {
+    return null;
+  }
+}

--- a/packages/lizi-mcps/src/xdt-helper/rename_sessions.ts
+++ b/packages/lizi-mcps/src/xdt-helper/rename_sessions.ts
@@ -1,16 +1,14 @@
 import { BRAND_NAME } from '@cindy/maker-shared/branding';
-import { createHmac, randomBytes } from 'node:crypto';
-
 import { z } from 'zod';
 
 import type { XdtHelperToolRegistry } from '../lizi_xdtHelperToolRegistry.js';
 import type { ControlResult } from '../lizi_xdtHelperMcpServer.js';
 import type { LiziMcpSessionContext } from '../types.js';
+import { decodeConfirmationToken, encodeConfirmationToken } from './_confirmation_token.js';
 import { errorPayload, okPayload } from './_payload.js';
 
 const MAX_RENAME_BATCH_SIZE = 20;
 const TITLE_MAX_LENGTH = 120;
-const CONFIRMATION_TOKEN_SECRET = randomBytes(32);
 
 export interface RenameSessionChange {
   sessionId: string;
@@ -108,44 +106,23 @@ function createConfirmationPayload(
   };
 }
 
-function encodeConfirmationToken(payload: RenameSessionsConfirmationPayload): string {
-  const encoded = Buffer.from(JSON.stringify(payload), 'utf8').toString('base64url');
-  const digest = createHmac('sha256', CONFIRMATION_TOKEN_SECRET)
-    .update(encoded)
-    .digest('hex')
-    .slice(0, 24);
-  return `v1.${encoded}.${digest}`;
-}
-
-function decodeConfirmationToken(token: string): RenameSessionsConfirmationPayload | null {
-  const [version, encoded, digest] = token.split('.');
-  if (version !== 'v1' || !encoded || !digest) return null;
-  const expectedDigest = createHmac('sha256', CONFIRMATION_TOKEN_SECRET)
-    .update(encoded)
-    .digest('hex')
-    .slice(0, 24);
-  if (digest !== expectedDigest) return null;
-
-  try {
-    const payload = JSON.parse(
-      Buffer.from(encoded, 'base64url').toString('utf8'),
-    ) as RenameSessionsConfirmationPayload;
-    if (payload.v !== 1 || !Array.isArray(payload.changes)) return null;
-    for (const change of payload.changes) {
-      if (
-        typeof change?.sessionId !== 'string' ||
-        typeof change.title !== 'string' ||
-        (change.expectedCurrentTitle !== null && typeof change.expectedCurrentTitle !== 'string') ||
-        (change.expectedUpdatedAt !== null && typeof change.expectedUpdatedAt !== 'string') ||
-        (change.approvedCurrentTitle !== null && typeof change.approvedCurrentTitle !== 'string')
-      ) {
-        return null;
-      }
+function isRenameConfirmationPayload(
+  payload: unknown,
+): payload is RenameSessionsConfirmationPayload {
+  const p = payload as Partial<RenameSessionsConfirmationPayload> | null;
+  if (!p || p.v !== 1 || !Array.isArray(p.changes)) return false;
+  for (const change of p.changes) {
+    if (
+      typeof change?.sessionId !== 'string' ||
+      typeof change.title !== 'string' ||
+      (change.expectedCurrentTitle !== null && typeof change.expectedCurrentTitle !== 'string') ||
+      (change.expectedUpdatedAt !== null && typeof change.expectedUpdatedAt !== 'string') ||
+      (change.approvedCurrentTitle !== null && typeof change.approvedCurrentTitle !== 'string')
+    ) {
+      return false;
     }
-    return payload;
-  } catch {
-    return null;
   }
+  return true;
 }
 
 function matchesConfirmationPayload(
@@ -213,7 +190,9 @@ export function registerRenameSessionsTool(
       }
 
       const confirmationPayload =
-        !dry_run && confirmation_token ? decodeConfirmationToken(confirmation_token) : null;
+        !dry_run && confirmation_token
+          ? decodeConfirmationToken(confirmation_token, isRenameConfirmationPayload)
+          : null;
       if (
         !dry_run &&
         (!confirmationPayload || !matchesConfirmationPayload(normalized, confirmationPayload))

--- a/packages/lizi-mcps/src/xdt-helper/rename_sessions.ts
+++ b/packages/lizi-mcps/src/xdt-helper/rename_sessions.ts
@@ -191,7 +191,7 @@ export function registerRenameSessionsTool(
 
       const confirmationPayload =
         !dry_run && confirmation_token
-          ? decodeConfirmationToken(confirmation_token, isRenameConfirmationPayload)
+          ? decodeConfirmationToken('rename_sessions', confirmation_token, isRenameConfirmationPayload)
           : null;
       if (
         !dry_run &&
@@ -212,7 +212,7 @@ export function registerRenameSessionsTool(
         if (!result.ok) {
           return mapRenameSessionsError(result);
         }
-        const token = encodeConfirmationToken(
+        const token = encodeConfirmationToken('rename_sessions',
           createConfirmationPayload(normalized, result.changes),
         );
 


### PR DESCRIPTION
## 这次改了什么

### 摘要

抽出 xdt-helper 共用的 HMAC 确认 token 编解码，并让 rename_sessions 通过本地 type guard 校验 payload。补充编码/解码、签名篡改和 validate 拒绝单测。

### 变更类型

- [ ] `feat` 新功能
- [ ] `fix` 缺陷修复
- [x] `refactor` / `perf` 重构或性能优化
- [x] `docs` / `test` / `chore` 文档、测试或工程维护
- [ ] 其他：

### 范围

- 关联 Issue / 需求：Part of #4385 (T2)
- 本 PR 包含：`_confirmation_token.ts`、`rename_sessions` 重构及对应单测
- 明确不包含：其他工具接入确认 token
- 用户可见变化：无，rename 行为不变
- 是否存在 breaking change：无

### UI 变化

不涉及。

- 引用的设计规范：不涉及。

## 怎么验证的

### 自动验证

```text
pnpm test:unit:related
结果：通过（apps/desktop、packages/lizi-mcps）
pnpm --filter @cindy/mcps test -- _confirmation_token.test.ts
结果：通过（57 files / 784 tests）
npx tsc --noEmit -p packages/lizi-mcps/tsconfig.json
结果：仅存在既有 submitGithubIssueTool / sessionControlTools 测试类型错误
```

### 手工验证

不涉及。

### 未执行的验证

无。

## 风险

### 风险分类

- [x] 无已知风险
- [ ] SQLite / migration
- [ ] system prompt
- [ ] 协议兼容
- [ ] 权限 / 安全 / 用户数据
- [ ] 存量插件兼容（批准状态 / 指纹 / manifest 校验 / 安装布局 / 包格式）
- [ ] 原生层 / fingerprint / OTA
- [ ] 跨平台差异
- [ ] 其他：

### 影响与回滚

- 影响范围：内部 token 编解码复用；行为保持不变。
- 回滚 / 降级方式：回滚本 PR 即可。

### 提交前检查

- [x] 已 review 完整 diff
- [x] 每个 commit 都带 DCO 签名（`git commit -s`，见 [DCO](../DCO)）
- [x] UI 改动已在「UI 变化」注明引用的设计规范章节（不涉及 UI 则跳过）
- [x] 未提交凭证、令牌或授权文件
- [x] 已核对受影响的文档，行为变化涉及的旧结论已同步修订（不涉及则无需修改文档）
- [x] 已确认测试结果或说明未执行原因
