### PR TITLE
fix(mobile): hide Orca worker sessions from full session list

### DIFF
--- a/apps/mobile/app/devices/[deviceId].tsx
+++ b/apps/mobile/app/devices/[deviceId].tsx
@@ -72,7 +72,7 @@ import {
   shouldReplaceListWithSearchResults,
 } from '@/session/conversationSearch';
 import { useConversationSearch } from '@/session/useConversationSearch';
-import { excludeOrcaWorkerSessions, sessionMatchesProjectDir } from '@/session/mobileHome';
+import { selectVisibleDeviceSessions, sessionMatchesProjectDir } from '@/session/mobileHome';
 import { HomeSessionRow } from './index';
 import { RenameSessionModal } from '@/session/RenameSessionModal';
 import { SessionOptionsPresenter } from '@/session/SessionOptionsExpoSheet';
@@ -178,12 +178,11 @@ function DeviceDetailScreenContent() {
   // 重渲染风暴)。store 层已保证 allSessions 引用在内容未变时稳定,这里不能亲手打破。
   // 列表隐藏 Orca worker 子会话(本期不支持进 worker 聊天);Lead + 普通会话保留。仅 mobile 侧过滤。
   // 与首页卡片口径对齐:首页已 exclude worker,「查看全部 N 条」不能再把它们露出来。
-  const sessions = useMemo(() => excludeOrcaWorkerSessions(allSessions).filter((s) =>
-    // 用展示用 canonicalDeviceId(设备归并结果)匹配,与首页项目卡一致 —— 被认领的 stale 会话也能显示,
-    // 数量与卡片相符。deviceLinkDeviceId 仍是物理路由 key(openSession / patch 用它),不参与此处判断。
-    (s.canonicalDeviceId ?? s.deviceLinkDeviceId) === deviceId
-    && (!projectWorkingDir || sessionMatchesProjectDir(s.workingDir, projectWorkingDir))),
-  [allSessions, deviceId, projectWorkingDir]);
+  // 用展示用 canonicalDeviceId(设备归并结果)匹配 —— 被认领的 stale 会话也能显示,数量与卡片相符。
+  const sessions = useMemo(
+    () => selectVisibleDeviceSessions(allSessions, deviceId, projectWorkingDir),
+    [allSessions, deviceId, projectWorkingDir],
+  );
   const messageVersion = useRemoteMessageVersion();
   const storeVersion = useRemoteSessionStoreVersion();
   const [statusFilter, setStatusFilter] = useState<RemoteSessionStatusFilter>(

--- a/apps/mobile/app/devices/[deviceId].tsx
+++ b/apps/mobile/app/devices/[deviceId].tsx
@@ -72,7 +72,7 @@ import {
   shouldReplaceListWithSearchResults,
 } from '@/session/conversationSearch';
 import { useConversationSearch } from '@/session/useConversationSearch';
-import { sessionMatchesProjectDir } from '@/session/mobileHome';
+import { excludeOrcaWorkerSessions, sessionMatchesProjectDir } from '@/session/mobileHome';
 import { HomeSessionRow } from './index';
 import { RenameSessionModal } from '@/session/RenameSessionModal';
 import { SessionOptionsPresenter } from '@/session/SessionOptionsExpoSheet';
@@ -176,7 +176,9 @@ function DeviceDetailScreenContent() {
   // filter 必须 memo:裸 filter 每次渲染都产新数组,会让下游全部 [sessions, ...] 依赖的
   // useMemo 逐 emit 失效,派生链(索引 → sections → 全列表行)整体重建(2026-07-18
   // 重渲染风暴)。store 层已保证 allSessions 引用在内容未变时稳定,这里不能亲手打破。
-  const sessions = useMemo(() => allSessions.filter((s) =>
+  // 列表隐藏 Orca worker 子会话(本期不支持进 worker 聊天);Lead + 普通会话保留。仅 mobile 侧过滤。
+  // 与首页卡片口径对齐:首页已 exclude worker,「查看全部 N 条」不能再把它们露出来。
+  const sessions = useMemo(() => excludeOrcaWorkerSessions(allSessions).filter((s) =>
     // 用展示用 canonicalDeviceId(设备归并结果)匹配,与首页项目卡一致 —— 被认领的 stale 会话也能显示,
     // 数量与卡片相符。deviceLinkDeviceId 仍是物理路由 key(openSession / patch 用它),不参与此处判断。
     (s.canonicalDeviceId ?? s.deviceLinkDeviceId) === deviceId

--- a/apps/mobile/src/__tests__/orcaCollab.test.ts
+++ b/apps/mobile/src/__tests__/orcaCollab.test.ts
@@ -206,6 +206,15 @@ describe('excludeOrcaWorkerSessions', () => {
     ]);
     expect(kept.map((item) => item.id)).toEqual(['lead', 'normal']);
   });
+
+  it('hides workers on home, the session drawer, and the full device/project list', () => {
+    const home = readFileSync(resolve(process.cwd(), 'app/devices/index.tsx'), 'utf8');
+    const detail = readFileSync(resolve(process.cwd(), 'app/devices/[deviceId].tsx'), 'utf8');
+    const drawer = readFileSync(resolve(process.cwd(), 'src/session/SessionListDrawer.tsx'), 'utf8');
+    expect(home).toContain('excludeOrcaWorkerSessions(sessions)');
+    expect(detail).toContain('excludeOrcaWorkerSessions(allSessions)');
+    expect(drawer).toContain('excludeOrcaWorkerSessions(sessions)');
+  });
 });
 
 describe('MessageRenderer wires the orca card', () => {

--- a/apps/mobile/src/__tests__/orcaCollab.test.ts
+++ b/apps/mobile/src/__tests__/orcaCollab.test.ts
@@ -7,7 +7,7 @@ import {
   classifyOrcaDispatchTool,
   parseOrcaWorkerReport,
 } from '@/session/orcaCollab';
-import { excludeOrcaWorkerSessions } from '@/session/mobileHome';
+import { excludeOrcaWorkerSessions, selectVisibleDeviceSessions } from '@/session/mobileHome';
 import { normalizeRemoteMessages } from '@/session/messageNormalize';
 import type { RemoteMessage, RemoteSession } from '@/session/types';
 
@@ -212,8 +212,57 @@ describe('excludeOrcaWorkerSessions', () => {
     const detail = readFileSync(resolve(process.cwd(), 'app/devices/[deviceId].tsx'), 'utf8');
     const drawer = readFileSync(resolve(process.cwd(), 'src/session/SessionListDrawer.tsx'), 'utf8');
     expect(home).toContain('excludeOrcaWorkerSessions(sessions)');
-    expect(detail).toContain('excludeOrcaWorkerSessions(allSessions)');
     expect(drawer).toContain('excludeOrcaWorkerSessions(sessions)');
+    expect(detail).toContain('selectVisibleDeviceSessions(allSessions, deviceId, projectWorkingDir)');
+    expect(detail).toContain('buildRemoteSessionSections(sessions,');
+  });
+});
+
+describe('selectVisibleDeviceSessions', () => {
+  it('drops workers and keeps lead/normal rows in the same device and project', () => {
+    const rows = selectVisibleDeviceSessions([
+      session({
+        id: 'lead',
+        orcaRole: 'lead',
+        deviceLinkDeviceId: 'dev-a',
+        workingDir: '/repo/cindy',
+      }),
+      session({
+        id: 'worker',
+        orcaRole: 'worker',
+        deviceLinkDeviceId: 'dev-a',
+        workingDir: '/repo/cindy',
+      }),
+      session({
+        id: 'other-device',
+        orcaRole: null,
+        deviceLinkDeviceId: 'dev-b',
+        workingDir: '/repo/cindy',
+      }),
+      session({
+        id: 'other-project',
+        orcaRole: null,
+        deviceLinkDeviceId: 'dev-a',
+        workingDir: '/repo/infra',
+      }),
+      session({
+        id: 'canonical-match',
+        orcaRole: null,
+        canonicalDeviceId: 'dev-a',
+        deviceLinkDeviceId: 'stale-id',
+        workingDir: '/repo/cindy',
+      }),
+    ], 'dev-a', '/repo/cindy');
+    expect(rows.map((item) => item.id)).toEqual(['lead', 'canonical-match']);
+  });
+
+  it('keeps all non-worker rows for a device when no project dir is set', () => {
+    const rows = selectVisibleDeviceSessions([
+      session({ id: 'keep', orcaRole: null, deviceLinkDeviceId: 'dev-a', workingDir: '/repo/one' }),
+      session({ id: 'worker', orcaRole: 'worker', deviceLinkDeviceId: 'dev-a', workingDir: '/repo/one' }),
+      session({ id: 'other', orcaRole: 'lead', deviceLinkDeviceId: 'dev-b', workingDir: '/repo/one' }),
+    ], 'dev-a');
+    expect(rows.map((item) => item.id)).toEqual(['keep']);
   });
 });
 

--- a/apps/mobile/src/__tests__/orcaCollab.test.ts
+++ b/apps/mobile/src/__tests__/orcaCollab.test.ts
@@ -206,16 +206,6 @@ describe('excludeOrcaWorkerSessions', () => {
     ]);
     expect(kept.map((item) => item.id)).toEqual(['lead', 'normal']);
   });
-
-  it('hides workers on home, the session drawer, and the full device/project list', () => {
-    const home = readFileSync(resolve(process.cwd(), 'app/devices/index.tsx'), 'utf8');
-    const detail = readFileSync(resolve(process.cwd(), 'app/devices/[deviceId].tsx'), 'utf8');
-    const drawer = readFileSync(resolve(process.cwd(), 'src/session/SessionListDrawer.tsx'), 'utf8');
-    expect(home).toContain('excludeOrcaWorkerSessions(sessions)');
-    expect(drawer).toContain('excludeOrcaWorkerSessions(sessions)');
-    expect(detail).toContain('selectVisibleDeviceSessions(allSessions, deviceId, projectWorkingDir)');
-    expect(detail).toContain('buildRemoteSessionSections(sessions,');
-  });
 });
 
 describe('selectVisibleDeviceSessions', () => {
@@ -263,6 +253,13 @@ describe('selectVisibleDeviceSessions', () => {
       session({ id: 'other', orcaRole: 'lead', deviceLinkDeviceId: 'dev-b', workingDir: '/repo/one' }),
     ], 'dev-a');
     expect(rows.map((item) => item.id)).toEqual(['keep']);
+  });
+
+  it('feeds the derived rows into the device/project list sections', () => {
+    const detail = readFileSync(resolve(process.cwd(), 'app/devices/[deviceId].tsx'), 'utf8');
+    expect(detail).toContain('selectVisibleDeviceSessions(allSessions, deviceId, projectWorkingDir)');
+    expect(detail).toContain('buildRemoteSessionSections(sessions,');
+    expect(detail).toContain('summarizeRemoteSessionOverview(sessions,');
   });
 });
 

--- a/apps/mobile/src/session/mobileHome.ts
+++ b/apps/mobile/src/session/mobileHome.ts
@@ -4,6 +4,7 @@ import { mobilePresentationLocalizer } from '@/i18n/presentationLocalizer';
 import { localizeRemoteSessionListItem } from '@/session/sessionList';
 import {
   buildMobileHomePresentation as buildMobileHomePresentationShared,
+  sessionMatchesProjectDir,
   type MobileHomeSessionLike,
   type MobileHomeNoDeviceContext,
   type MobileHomeOptions,
@@ -98,4 +99,20 @@ export function excludeOrcaWorkerSessions<T extends Pick<RemoteSession, 'orcaRol
   sessions: readonly T[],
 ): T[] {
   return sessions.filter((session) => session.orcaRole !== 'worker');
+}
+
+/**
+ * 设备/项目「查看全部」列表的会话派生:先丢掉 Orca worker,再按规范设备 id 与项目目录收口。
+ * 结果必须直接喂给该页的 sections / 计数,不能只在别处调用 helper。
+ */
+export function selectVisibleDeviceSessions<
+  T extends Pick<RemoteSession, 'orcaRole' | 'canonicalDeviceId' | 'deviceLinkDeviceId' | 'workingDir'>,
+>(
+  sessions: readonly T[],
+  deviceId: string,
+  projectWorkingDir?: string | null,
+): T[] {
+  return excludeOrcaWorkerSessions(sessions).filter((session) =>
+    (session.canonicalDeviceId ?? session.deviceLinkDeviceId) === deviceId
+    && (!projectWorkingDir || sessionMatchesProjectDir(session.workingDir, projectWorkingDir)));
 }


### PR DESCRIPTION
## 这次改了什么

### 摘要

手机首页和任务抽屉已经会隐藏 Orca Worker 子会话，但从项目卡点「查看全部」进入设备/项目全量列表时没有过滤。Worker 往往比 Lead 更新，会被顶到列表最前面，看起来像普通任务。全量列表改用同一套 `excludeOrcaWorkerSessions`，与首页卡片数量对齐。桌面侧栏不受影响。

### 变更类型

- [x] `fix` 缺陷修复
- [ ] `feat` 新功能
- [ ] `refactor` / `perf` 重构或性能优化
- [ ] `docs` / `test` / `chore` 文档、测试或工程维护
- [ ] 其他：

### 范围

- 关联 Issue / 需求：无
- 本 PR 包含：mobile 设备/项目全量会话列表过滤 `orcaRole=worker`；源码门禁锁住首页、抽屉、全量列表三处都调用同一 helper
- 明确不包含：桌面侧栏 Worker 展示、Worker 详情页只读打开路径
- 用户可见变化：手机「查看全部」不再出现 `Worker · …` 行
- 是否存在 breaking change：无

### UI 变化

- 引用的设计规范：不涉及：只从已有列表过滤 Worker 子会话，不改布局、样式、动效或文案。产品口径沿用现有 mobile 隐藏 Worker 的约定（`excludeOrcaWorkerSessions`）。

## 怎么验证的

### 自动验证

```text
pnpm test:unit:related
结果：PASS apps/mobile unit (3.1s)，related 2 个文件

pnpm --filter mobile run --if-present typecheck
结果：tsc --noEmit 通过
```

### 手工验证

未在真机重跑。截图复现路径：手机首页 cindy 项目卡 → View all → 顶部出现 Worker · developer · t5/t4/t3…；修复后该页应与首页卡片同一批任务。

### 未执行的验证

mobile 真机/模拟器目检：当前会话无法重启 Metro / 宿主 app，改动只影响列表过滤，由单测源码门禁覆盖三处调用点。

## 风险

### 风险分类

- [x] 无已知风险
- [ ] SQLite / migration
- [ ] system prompt
- [ ] 协议兼容
- [ ] 权限 / 安全 / 用户数据
- [ ] 存量插件兼容（批准状态 / 指纹 / manifest 校验 / 安装布局 / 包格式）
- [ ] 原生层 / fingerprint / OTA
- [ ] 跨平台差异
- [ ] 其他：

### 影响与回滚

- 影响范围：仅 mobile 设备/项目全量列表与搜索所用的同一 `sessions` 派生数组
- 回滚 / 降级方式：revert 本 PR

### 提交前检查

- [x] 已 review 完整 diff
- [x] 每个 commit 都带 DCO 签名（`git commit -s`，见 [DCO](../DCO)）
- [x] UI 改动已在「UI 变化」注明引用的设计规范章节（不涉及 UI 则跳过）
- [x] 未提交凭证、令牌或授权文件
- [x] 已核对受影响的文档，行为变化涉及的旧结论已同步修订（不涉及则无需修改文档）
- [x] 已确认测试结果或说明未执行原因