### PR TITLE
fix(desktop): normalize open-path IPC lifecycle failures

### DIFF
--- a/apps/desktop/src/preload/__tests__/openPath.test.ts
+++ b/apps/desktop/src/preload/__tests__/openPath.test.ts
@@ -1,0 +1,46 @@
+import { describe, expect, it, vi } from 'vitest';
+import { invokeOpenPath } from '../openPath';
+import { shouldShowOpenPathError } from '../../shared/openPathResult';
+
+describe('openPath IPC result boundary', () => {
+  it.each([
+    { success: true },
+    { success: false, error: 'Path must be absolute' },
+    { success: false, error: '不允许访问该路径' },
+    { success: false, error: 'No application is associated with this file' },
+    { success: false, error: 'reply was never sent' },
+  ])('preserves main result %j', async (result) => {
+    const invoke = vi.fn().mockResolvedValue(result);
+    // The preload transports an opaque target; it does not resolve filesystem paths.
+    expect(await invokeOpenPath(invoke, 'target')).toBe(result);
+    expect(invoke).toHaveBeenCalledExactlyOnceWith('shell:open-path', 'target');
+    expect(shouldShowOpenPathError(result)).toBe(!result.success);
+  });
+
+  it.each([
+    'reply was never sent',
+    'Render frame was disposed before WebFrameMain could be accessed',
+    "Error invoking remote method 'shell:open-path': reply was never sent",
+    "Error invoking remote method 'shell:open-path': Error: Render frame was disposed before WebFrameMain could be accessed",
+  ])('keeps lifecycle rejection as failure without a toast: %s', async (message) => {
+    const result = await invokeOpenPath(vi.fn().mockRejectedValue(new Error(message)), 'target');
+    expect(result).toEqual({ success: false, error: message, failureKind: 'ipc_lifecycle' });
+    expect(shouldShowOpenPathError(result)).toBe(false);
+  });
+
+  it.each([
+    new Error(
+      "Error invoking remote method 'shell:open-path': No handler registered for 'shell:open-path'",
+    ),
+    new Error('Permission denied'),
+    new Error('Operation failed: reply was never sent'),
+    'non-Error rejection',
+  ])('preserves actionable rejection %s', async (cause) => {
+    const result = await invokeOpenPath(vi.fn().mockRejectedValue(cause), 'target');
+    expect(result).toEqual({
+      success: false,
+      error: cause instanceof Error ? cause.message : cause,
+    });
+    expect(shouldShowOpenPathError(result)).toBe(true);
+  });
+});

--- a/apps/desktop/src/preload/openPath.ts
+++ b/apps/desktop/src/preload/openPath.ts
@@ -1,0 +1,26 @@
+import type { OpenPathResult } from '../shared/openPathResult';
+
+/** Keep invoke transport failures inside the existing openPath result boundary. */
+export async function invokeOpenPath(
+  invoke: (channel: string, target: string) => Promise<OpenPathResult>,
+  target: string,
+): Promise<OpenPathResult> {
+  try {
+    return await invoke('shell:open-path', target);
+  } catch (cause) {
+    const error = cause instanceof Error ? cause.message : String(cause);
+    const message = error.replace(
+      /^Error invoking remote method ['"]shell:open-path['"]: (?:Error: )?/,
+      '',
+    );
+    // Classify only rejected IPC calls; main's path/OS errors pass through unchanged.
+    // No handler registered can mean version skew or broken initialization.
+    const lifecycle =
+      /^(?:reply was never sent[.!]?|Render frame was disposed(?: before WebFrameMain could be accessed)?[.!]?)$/.test(
+        message,
+      );
+    return lifecycle
+      ? { success: false, error, failureKind: 'ipc_lifecycle' }
+      : { success: false, error };
+  }
+}

--- a/apps/desktop/src/preload/preload.ts
+++ b/apps/desktop/src/preload/preload.ts
@@ -1,3 +1,4 @@
+import { invokeOpenPath } from './openPath';
 import { REMOTE_VIEWER } from '../shared/remoteDesktopViewer';
 import type { RoutineInput } from '@cindy/maker-scheduler';
 import type { BotToolsetContext } from '../shared/botRemoteCapabilities';
@@ -3757,8 +3758,7 @@ contextBridge.exposeInMainWorld('electronAPI', {
 
   // Open a local absolute path or a main-resolved cindy-media reference with
   // the OS default application (the renderer never receives the blob path).
-  openPath: (filePathOrUrl: string): Promise<{ success: boolean; error?: string }> =>
-    ipcRenderer.invoke('shell:open-path', filePathOrUrl),
+  openPath: (filePathOrUrl: string) => invokeOpenPath(ipcRenderer.invoke.bind(ipcRenderer), filePathOrUrl),
 
   // 文件 chip 右键「打开方式」。appId 只能是 listOpenWithApps 返回的 id,
   // main 侧反查可执行体;renderer 无法让 main 执行任意路径。

--- a/apps/desktop/src/preload/sidebarWindowPreload.ts
+++ b/apps/desktop/src/preload/sidebarWindowPreload.ts
@@ -1,3 +1,4 @@
+import { invokeOpenPath } from './openPath';
 /**
  * 鍙充晶鏍忓瓙绐楀彛涓撶敤 preload锛氬彧鏆撮湶 RSB 绐楀彛鎵€闇€鐨勬渶灏忚兘鍔涖€?
  *
@@ -236,7 +237,7 @@ contextBridge.exposeInMainWorld('electronAPI', {
   },
   openExternal: (url: string): Promise<unknown> => ipcRenderer.invoke('shell:open-external', url),
   openFileInBrowser: (pathOrUrl: string): Promise<unknown> => ipcRenderer.invoke('shell:open-file-in-browser', pathOrUrl),
-  openPath: (pathOrUrl: string): Promise<unknown> => ipcRenderer.invoke('shell:open-path', pathOrUrl),
+  openPath: (pathOrUrl: string) => invokeOpenPath(ipcRenderer.invoke.bind(ipcRenderer), pathOrUrl),
   showItemInFolder: (params: unknown): Promise<unknown> => ipcRenderer.invoke('shell:show-item-in-folder', params),
   copyMediaToClipboard: (params: unknown): Promise<unknown> =>
     ipcRenderer.invoke('media:copy-to-clipboard', params),

--- a/apps/desktop/src/renderer/__tests__/openPathFeedback.test.ts
+++ b/apps/desktop/src/renderer/__tests__/openPathFeedback.test.ts
@@ -1,0 +1,40 @@
+// @vitest-environment jsdom
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { invokeOpenPath } from '../../preload/openPath';
+import { shouldOpenTextLightbox } from '../lib/filePreview';
+import { toast } from '../lib/toast';
+
+vi.mock('../lib/toast', () => ({ toast: { error: vi.fn() } }));
+vi.mock('@/i18n', () => ({ i18n: { t: (key: string) => key } }));
+vi.mock('../lib/remoteFileOpen', () => ({ openRemoteChatFile: vi.fn() }));
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+  vi.clearAllMocks();
+});
+
+describe('opening a non-text file from chat', () => {
+  it.each([
+    ['reply was never sent', false],
+    ['Render frame was disposed before WebFrameMain could be accessed', false],
+    ["No handler registered for 'shell:open-path'", true],
+    ['Permission denied', true],
+  ])('handles invoke rejection %s', async (message, visible) => {
+    const invoke = vi.fn().mockRejectedValue(new Error(message));
+    vi.stubGlobal('electronAPI', undefined);
+    window.electronAPI = {
+      openPath: (target: string) => invokeOpenPath(invoke, target),
+    } as typeof window.electronAPI;
+    expect(await shouldOpenTextLightbox('report.pdf')).toBe(false);
+    expect(toast.error).toHaveBeenCalledTimes(visible ? 1 : 0);
+    if (visible) expect(toast.error).toHaveBeenCalledWith(message);
+  });
+
+  it('still shows an ordinary system error returned by main', async () => {
+    vi.stubGlobal('electronAPI', {
+      openPath: vi.fn().mockResolvedValue({ success: false, error: 'No application associated' }),
+    });
+    await shouldOpenTextLightbox('report.pdf');
+    expect(toast.error).toHaveBeenCalledWith('No application associated');
+  });
+});

--- a/apps/desktop/src/renderer/components/chat/ModelLightbox.tsx
+++ b/apps/desktop/src/renderer/components/chat/ModelLightbox.tsx
@@ -1,3 +1,4 @@
+import { shouldShowOpenPathError } from '../../../shared/openPathResult';
 /**
  * ModelLightbox
  * ---------------------------------------------------------------------------
@@ -166,7 +167,7 @@ export function ModelLightbox({ source, onClose }: ModelLightboxProps) {
           action === 'open'
             ? await window.electronAPI.openPath(source.absPath)
             : await window.electronAPI.showItemInFolder({ filePath: source.absPath });
-        if (!res.success) {
+        if (shouldShowOpenPathError(res)) {
           toast.error(
             res.error ??
               (action === 'open'

--- a/apps/desktop/src/renderer/components/chat/TextLightbox.tsx
+++ b/apps/desktop/src/renderer/components/chat/TextLightbox.tsx
@@ -1,3 +1,4 @@
+import { shouldShowOpenPathError } from '../../../shared/openPathResult';
 /**
  * TextLightbox
  * ---------------------------------------------------------------------------
@@ -343,7 +344,7 @@ export function TextLightbox({ filePath, fileName, initialLine, triggerRef, onCl
     const target = remoteOrigin ? remoteCopy?.cachePath : filePath;
     if (!target) return;
     const res = await window.electronAPI.openPath(target);
-    if (!res.success) {
+    if (shouldShowOpenPathError(res)) {
       toast.error(res.error || t('chat.textLightbox.openSystemFailed'));
     }
   }

--- a/apps/desktop/src/renderer/components/chat/useFileChipContextMenu.tsx
+++ b/apps/desktop/src/renderer/components/chat/useFileChipContextMenu.tsx
@@ -1,3 +1,4 @@
+import { shouldShowOpenPathError } from '../../../shared/openPathResult';
 /**
  * useFileChipContextMenu
  * ---------------------------------------------------------------------------
@@ -261,7 +262,7 @@ export function useFileChipContextMenu({
     setMenuPos(null);
     const abs = await getAbsPath();
     const res = await window.electronAPI.openPath(abs);
-    if (!res.success) toast.error(res.error ?? t('chat.markdownRenderer.openWithAppFailed'));
+    if (shouldShowOpenPathError(res)) toast.error(res.error ?? t('chat.markdownRenderer.openWithAppFailed'));
   }
 
   async function handleOpenWithApp(appId: string): Promise<void> {

--- a/apps/desktop/src/renderer/features/bots/BotsHomeView.tsx
+++ b/apps/desktop/src/renderer/features/bots/BotsHomeView.tsx
@@ -1,3 +1,4 @@
+import { shouldShowOpenPathError } from '../../../shared/openPathResult';
 import { ConnectProviderCard } from '@/components/onboarding/ConnectProviderCard';
 import { useProviderOnboarding } from '@/hooks/useProviderOnboarding';
 import { useCallback, useEffect, useMemo, useRef, useState, useSyncExternalStore } from 'react';
@@ -579,7 +580,7 @@ export function BotSettings({
                     if (!bot.homeDir) return;
                     setFolderError(null);
                     void window.electronAPI.openPath(bot.homeDir).then((result) => {
-                      if (!result.success)
+                      if (shouldShowOpenPathError(result))
                         setFolderError(result.error ?? t('bots.homeFolder.openFailed'));
                     });
                   }}

--- a/apps/desktop/src/renderer/features/cc-agent/CCAgentSessionView.tsx
+++ b/apps/desktop/src/renderer/features/cc-agent/CCAgentSessionView.tsx
@@ -1,3 +1,4 @@
+import { shouldShowOpenPathError } from '../../../shared/openPathResult';
 import { shouldShowFailedScheduleNotice } from '@cindy/maker-shared/schedule-model';
 /**
  * CCAgentSessionView
@@ -1503,7 +1504,7 @@ export function CCAgentSessionView({
     if (isRemoteWorktreeSession) return;
     try {
       const result = await window.electronAPI.openPath(wd);
-      if (!result.success) toast.error(result.error || t('ccAgent.common.openFolderFailed'));
+      if (shouldShowOpenPathError(result)) toast.error(result.error || t('ccAgent.common.openFolderFailed'));
     } catch (err) {
       log.error('[open workingDir]', err);
       toast.error(t('ccAgent.common.openFolderFailed'));

--- a/apps/desktop/src/renderer/features/cc-agent/CCAgentSidebarUpper.tsx
+++ b/apps/desktop/src/renderer/features/cc-agent/CCAgentSidebarUpper.tsx
@@ -1,3 +1,4 @@
+import { shouldShowOpenPathError } from '../../../shared/openPathResult';
 /**
  * CCAgentFeature 的 Sidebar 上半内容。
  * ---------------------------------------------------------------------------
@@ -2495,7 +2496,7 @@ function ExpandedView({
     async (workingDir: string) => {
       try {
         const result = await window.electronAPI.openPath(workingDir);
-        if (!result.success) {
+        if (shouldShowOpenPathError(result)) {
           toast.error(result.error || t('ccAgent.common.openFolderFailed'));
         }
       } catch (err) {

--- a/apps/desktop/src/renderer/features/cc-agent/workdir-browse/OpenInSystemActions.tsx
+++ b/apps/desktop/src/renderer/features/cc-agent/workdir-browse/OpenInSystemActions.tsx
@@ -1,3 +1,4 @@
+import { shouldShowOpenPathError } from '../../../../shared/openPathResult';
 import { ExternalLink, FolderOpen } from 'lucide-react';
 import { useTranslation } from 'react-i18next';
 
@@ -23,7 +24,7 @@ export function OpenInSystemActions({
   const onOpenFile = async () => {
     try {
       const r = await window.electronAPI.openPath(absPath);
-      if (!r.success) toast.error(r.error || t('ccAgent.common.openFailed'));
+      if (shouldShowOpenPathError(r)) toast.error(r.error || t('ccAgent.common.openFailed'));
     } catch (err) {
       toast.error(
         t('ccAgent.common.openFailedWith', {
@@ -36,7 +37,7 @@ export function OpenInSystemActions({
   const onOpenFolder = async () => {
     try {
       const r = await window.electronAPI.openPath(folderPath);
-      if (!r.success) toast.error(r.error || t('ccAgent.common.openFolderFailed'));
+      if (shouldShowOpenPathError(r)) toast.error(r.error || t('ccAgent.common.openFolderFailed'));
     } catch (err) {
       toast.error(
         t('ccAgent.common.openFolderFailedWith', {

--- a/apps/desktop/src/renderer/features/plugin/GhostPluginDetailView.tsx
+++ b/apps/desktop/src/renderer/features/plugin/GhostPluginDetailView.tsx
@@ -1,3 +1,4 @@
+import { shouldShowOpenPathError } from '../../../shared/openPathResult';
 /**
  * Plugin detail presentation for configuration, Tools, permissions, and factual metadata.
  *
@@ -944,7 +945,7 @@ export function DetailsSection({
                     if (!installDir) return;
                     void window.electronAPI.openPath(installDir).then(
                       (result) => {
-                        if (!result.success) toast.error(t('settings.ghosts.errors.generic'));
+                        if (shouldShowOpenPathError(result)) toast.error(t('settings.ghosts.errors.generic'));
                       },
                       () => toast.error(t('settings.ghosts.errors.generic')),
                     );

--- a/apps/desktop/src/renderer/features/scheduler/SchedulerPage.tsx
+++ b/apps/desktop/src/renderer/features/scheduler/SchedulerPage.tsx
@@ -1,3 +1,4 @@
+import { shouldShowOpenPathError } from '../../../shared/openPathResult';
 /**
  * SchedulerPage — /schedules 主路由（master-detail 改版）
  * ---------------------------------------------------------------------------
@@ -456,7 +457,7 @@ export function SchedulerPage() {
       const filePath = projectAutomationConfigPath(workingDir);
       try {
         const result = await window.electronAPI.openPath(filePath);
-        if (!result.success)
+        if (shouldShowOpenPathError(result))
           toast.error(result.error || t('scheduler.list.section.openConfigFailed'));
       } catch (e) {
         toast.error(e instanceof Error ? e.message : String(e));

--- a/apps/desktop/src/renderer/features/scheduler/components/RunHistoryPane.tsx
+++ b/apps/desktop/src/renderer/features/scheduler/components/RunHistoryPane.tsx
@@ -1,3 +1,4 @@
+import { shouldShowOpenPathError } from '../../../../shared/openPathResult';
 /**
  * RunHistoryPane — 右侧执行历史面板
  * ---------------------------------------------------------------------------
@@ -219,7 +220,7 @@ export function RunHistoryPane({
     if (!dest.workingDir) return;
     try {
       const result = await window.electronAPI.openPath(dest.workingDir);
-      if (!result.success) toast.error(result.error || t('scheduler.detail.openWorkdirFailed'));
+      if (shouldShowOpenPathError(result)) toast.error(result.error || t('scheduler.detail.openWorkdirFailed'));
     } catch {
       toast.error(t('scheduler.detail.openWorkdirFailed'));
     }

--- a/apps/desktop/src/renderer/lib/filePreview.ts
+++ b/apps/desktop/src/renderer/lib/filePreview.ts
@@ -1,3 +1,4 @@
+import { shouldShowOpenPathError } from '../../shared/openPathResult';
 import { toast } from './toast';
 import { isTextPreviewSupported } from './textPreview';
 import { i18n } from '@/i18n';
@@ -14,7 +15,7 @@ export async function shouldOpenTextLightbox(filePath: string): Promise<boolean>
 
   try {
     const res = await window.electronAPI.openPath(filePath);
-    if (!res.success) {
+    if (shouldShowOpenPathError(res)) {
       toast.error(res.error || i18n.t('logic.errors.openFileFailed'));
     }
   } catch (err) {

--- a/apps/desktop/src/renderer/lib/remoteFileOpen.ts
+++ b/apps/desktop/src/renderer/lib/remoteFileOpen.ts
@@ -1,3 +1,4 @@
+import { shouldShowOpenPathError } from '../../shared/openPathResult';
 /**
  * remoteFileOpen — 聊天流文件类交互的远程分流入口(renderer 侧)。
  * ---------------------------------------------------------------------------
@@ -88,7 +89,7 @@ export async function openRemoteChatFile(
   const cachePath = await fetchChatFileWithToasts(origin, workdir, absPath);
   if (!cachePath) return;
   const res = await window.electronAPI.openPath(cachePath);
-  if (!res.success) toast.error(res.error || i18n.t('logic.errors.openFileFailed'));
+  if (shouldShowOpenPathError(res)) toast.error(res.error || i18n.t('logic.errors.openFileFailed'));
 }
 
 /** 远程会话「定位文件」:取回缓存副本后在文件管理器中定位本地副本。 */

--- a/apps/desktop/src/renderer/vite-env.d.ts
+++ b/apps/desktop/src/renderer/vite-env.d.ts
@@ -2934,7 +2934,7 @@ interface ElectronAPI {
    * Open a local file path with the OS default application. Used by the
    * TextLightbox toolbar Open-in-System button and the Oversize main button.
    */
-  openPath: (filePath: string) => Promise<{ success: boolean; error?: string }>;
+  openPath: (filePath: string) => Promise<import('../shared/openPathResult').OpenPathResult>;
 
   /**
    * 文件 chip 右键「打开方式」:枚举可打开该文件的应用(Windows 注册表;

--- a/apps/desktop/src/shared/openPathResult.ts
+++ b/apps/desktop/src/shared/openPathResult.ts
@@ -1,0 +1,10 @@
+/** An IPC lifecycle failure does not establish whether the OS opened the path. */
+export interface OpenPathResult {
+  success: boolean;
+  error?: string;
+  failureKind?: 'ipc_lifecycle';
+}
+
+export function shouldShowOpenPathError(result: OpenPathResult): boolean {
+  return !result.success && result.failureKind !== 'ipc_lifecycle';
+}


### PR DESCRIPTION
## 这次改了什么

### 摘要

主窗口与独立侧栏 preload 捕获 openPath invoke reject，归一成既有失败结果。明确的生命周期失败以可选 failureKind 标记，打开文件相关调用方不再将其弹为错误提示。普通系统错误、路径拒绝与 No handler registered 保留提示。

### 变更类型

- [ ] `feat` 新功能
- [x] `fix` 缺陷修复
- [ ] `refactor` / `perf` 重构或性能优化
- [ ] `docs` / `test` / `chore` 文档、测试或工程维护
- [ ] 其他：

### 范围

- 关联 Issue / 需求：Closes #4068
- 本 PR 包含：主窗口与独立侧栏 preload 捕获 openPath invoke reject，归一成既有失败结果。明确的生命周期失败以可选 failureKind 标记，打开文件相关调用方不再将其弹为错误提示。普通系统错误、路径拒绝与 No handler registered 保留提示。
- 明确不包含：主进程路径安全策略或自动重试
- 用户可见变化：生命周期类打开失败不再弹错误提示，普通错误继续显示
- 是否存在 breaking change：无

### UI 变化

- 引用的设计规范：docs/design-rules/DESIGN.md §10 双模式、§11 文案；沿用现有错误提示样式，只调整展示条件。
- 实机截图：未取得，见未执行的验证。

## 怎么验证的

### 自动验证

```text
pnpm test:unit:related — PASS
pnpm --filter desktop run --if-present typecheck — PASS
定向 openPath 测试：18 tests PASS
```

- ESLint 改动文件与基线逐项比较，无新增错误。基线对应的 Desktop 整包 lint 实测 689 errors / 6 warnings，未报告通过；用户已明确接受“相关单测、类型检查通过，lint 无新增错误”的交付条件。

### 手工验证

未完成目标平台实机验收。

### 未执行的验证

未复现 Linux Electron 41.10.3 原始生命周期竞态；不宣称文件已打开或竞态根因已修复。

## 风险

### 风险分类

- [ ] 无已知风险
- [ ] SQLite / migration
- [ ] system prompt
- [ ] 协议兼容
- [ ] 权限 / 安全 / 用户数据
- [ ] 存量插件兼容（批准状态 / 指纹 / manifest 校验 / 安装布局 / 包格式）
- [ ] 原生层 / fingerprint / OTA
- [x] 跨平台差异
- [ ] 其他：

### 影响与回滚

- 影响范围：Desktop 打开文件的 IPC 失败展示。
- 回滚 / 降级方式：回退本 PR 的单一提交；无持久数据迁移。

### 提交前检查

- [x] 已 review 完整 diff
- [x] 每个 commit 都带 DCO 签名；`pnpm check:dco` 通过
- [x] UI 改动已在「UI 变化」注明引用的设计规范章节
- [x] 未提交凭证、令牌或授权文件
- [x] 已核对受影响的文档
- [x] 已确认测试结果或说明未执行原因
