### PR TITLE
feat(browser): add current-tab reload without cache

### DIFF
--- a/apps/desktop/src/main/rsb-browser-bridge/__tests__/native-popup-surfaces.test.ts
+++ b/apps/desktop/src/main/rsb-browser-bridge/__tests__/native-popup-surfaces.test.ts
@@ -47,6 +47,7 @@ vi.mock('../../security/trustedAppRenderer', () => ({
 
 import {
   RSB_NATIVE_POPUP_CLAIM_CHANNEL,
+  RSB_NATIVE_POPUP_COMMAND_CHANNEL,
   RSB_NATIVE_POPUP_CLOSE_CHANNEL,
   RSB_NATIVE_POPUP_SET_BOUNDS_CHANNEL,
 } from '../../../shared/rsbNativePopup';
@@ -76,6 +77,8 @@ function makeContents(id: number) {
     canGoForward: () => boolean;
     isCurrentlyAudible: () => boolean;
     getZoomFactor: () => number;
+    reload: ReturnType<typeof vi.fn>;
+    reloadIgnoringCache: ReturnType<typeof vi.fn>;
   };
   contents.id = id;
   contents.destroyed = false;
@@ -94,6 +97,8 @@ function makeContents(id: number) {
   contents.canGoForward = () => false;
   contents.isCurrentlyAudible = () => false;
   contents.getZoomFactor = () => 1;
+  contents.reload = vi.fn();
+  contents.reloadIgnoringCache = vi.fn();
   return contents;
 }
 
@@ -138,6 +143,22 @@ describe('main-owned RSB native popup surfaces', () => {
   afterEach(() => {
     _resetRsbNativePopupSurfacesForTests();
     vi.useRealTimers();
+  });
+
+  it.each([undefined, false, true])('reloads only the owned popup (ignoreCache=%s)', (ignoreCache) => {
+    const host = makeContents(1);
+    const popup = makeContents(42);
+    electronMocks.windows.set(host, makeWindow());
+    const surfaceId = createRsbNativePopupSurface(host as never, popup as never);
+    const command = electronMocks.handlers.get(RSB_NATIVE_POPUP_COMMAND_CHANNEL)!;
+    command({ sender: host }, { surfaceId, command: 'reload', ignoreCache });
+    expect(popup.reload).toHaveBeenCalledTimes(ignoreCache ? 0 : 1);
+    expect(popup.reloadIgnoringCache).toHaveBeenCalledTimes(ignoreCache ? 1 : 0);
+    expect(() => command({ sender: makeContents(2) }, { surfaceId, command: 'reload', ignoreCache: true })).toThrow();
+    expect(() => command({ sender: host }, { surfaceId, command: 'reload', ignoreCache: 'true' })).toThrow();
+    expect(popup.reloadIgnoringCache).toHaveBeenCalledTimes(ignoreCache ? 1 : 0);
+    popup.close();
+    expect(() => command({ sender: host }, { surfaceId, command: 'reload', ignoreCache: true })).toThrow();
   });
 
   it('adopts the exact popup WebContents, claims it, and applies renderer bounds', async () => {

--- a/apps/desktop/src/main/rsb-browser-bridge/native-popup-surfaces.ts
+++ b/apps/desktop/src/main/rsb-browser-bridge/native-popup-surfaces.ts
@@ -340,7 +340,8 @@ function runCommand(record: SurfaceRecord, command: RsbNativePopupCommand): void
   } else if (command.command === 'reload') {
     record.crash = null;
     applyVisibility(record);
-    wc.reload();
+    if (command.ignoreCache) wc.reloadIgnoringCache();
+    else wc.reload();
   } else if (command.command === 'go-back') {
     if (wc.canGoBack()) wc.goBack();
   } else if (command.command === 'go-forward') {
@@ -419,8 +420,15 @@ export function registerRsbNativePopupSurfaceIpc(tabRegistry: TabRegistry): void
       ['navigate', 'reload', 'go-back', 'go-forward', 'stop'] as const,
       'command',
     );
+    if (command === 'reload' && raw.ignoreCache !== undefined && typeof raw.ignoreCache !== 'boolean') {
+      throwIpcError('INVALID_PARAMS', 'ignoreCache must be a boolean');
+    }
     const parsed: RsbNativePopupCommand =
-      command === 'navigate' ? { command, url: requireString(raw.url, 'url') } : { command };
+      command === 'navigate'
+        ? { command, url: requireString(raw.url, 'url') }
+        : command === 'reload'
+          ? { command, ignoreCache: raw.ignoreCache === true }
+          : { command };
     runCommand(record, parsed);
     return { ok: true };
   });

--- a/apps/desktop/src/renderer/features/right-sidebar/hooks/__tests__/useBrowserWebview.test.ts
+++ b/apps/desktop/src/renderer/features/right-sidebar/hooks/__tests__/useBrowserWebview.test.ts
@@ -20,6 +20,7 @@ interface MockWebview {
   canGoBack: ReturnType<typeof vi.fn>;
   canGoForward: ReturnType<typeof vi.fn>;
   reload: ReturnType<typeof vi.fn>;
+  reloadIgnoringCache: ReturnType<typeof vi.fn>;
   goBack: ReturnType<typeof vi.fn>;
   goForward: ReturnType<typeof vi.fn>;
   stop: ReturnType<typeof vi.fn>;
@@ -117,6 +118,7 @@ function makeMockWebview(initialUrl: string): MockWebview {
     canGoBack: vi.fn(() => false),
     canGoForward: vi.fn(() => false),
     reload: vi.fn(),
+    reloadIgnoringCache: vi.fn(),
     goBack: vi.fn(),
     goForward: vi.fn(),
     stop: vi.fn(),
@@ -321,23 +323,25 @@ describe('useBrowserWebview', () => {
     expect(mockWebview.loadURL).toHaveBeenCalledTimes(BROWSER_NAVIGATION_FUSE_LIMIT + 1);
   });
 
-  it('shows loading immediately on reload and resets after stop-loading', () => {
+  it.each([false, true])('shows loading immediately on reload (ignoreCache=%s) and resets after stop-loading', (ignoreCache) => {
     let result: UseBrowserWebviewResult | null = null;
     render(createElement(HookProbe, {
       visible: true,
       onResult: (next) => { result = next; },
     }));
 
-    act(() => result!.reload());
-    expect(mockWebview.reload).toHaveBeenCalledOnce();
+    act(() => result!.reload({ ignoreCache }));
+    expect(mockWebview.reload).toHaveBeenCalledTimes(ignoreCache ? 0 : 1);
+    expect(mockWebview.reloadIgnoringCache).toHaveBeenCalledTimes(ignoreCache ? 1 : 0);
     expect(result!.isLoading).toBe(true);
 
     act(() => mockWebview.dispatch('did-stop-loading'));
     expect(result!.isLoading).toBe(false);
   });
 
-  it('rolls back optimistic loading when reload throws', () => {
-    mockWebview.reload.mockImplementationOnce(() => {
+  it.each([false, true])('rolls back loading when reload (ignoreCache=%s) throws', (ignoreCache) => {
+    const method = ignoreCache ? mockWebview.reloadIgnoringCache : mockWebview.reload;
+    method.mockImplementationOnce(() => {
       throw new Error('detached');
     });
     let result: UseBrowserWebviewResult | null = null;
@@ -346,7 +350,7 @@ describe('useBrowserWebview', () => {
       onResult: (next) => { result = next; },
     }));
 
-    act(() => result!.reload());
+    act(() => result!.reload({ ignoreCache }));
     expect(result!.isLoading).toBe(false);
   });
 

--- a/apps/desktop/src/renderer/features/right-sidebar/hooks/useBrowserWebview.ts
+++ b/apps/desktop/src/renderer/features/right-sidebar/hooks/useBrowserWebview.ts
@@ -93,7 +93,7 @@ export interface UseBrowserWebviewResult {
   /** 加载新 URL(URL bar 输入或外部跳转入口)。 */
   navigate: (url: string) => void;
   /** 重新加载当前页。 */
-  reload: () => void;
+  reload: (options?: { ignoreCache?: boolean }) => void;
   /** 上一页。 */
   goBack: () => void;
   /** 下一页。 */
@@ -482,7 +482,7 @@ export function useBrowserWebview(
       wv.setAttribute('src', nextUrl);
     }
   }, []);
-  const reload = useCallback(() => {
+  const reload = useCallback((options?: { ignoreCache?: boolean }) => {
     navigationAttemptsRef.current = [];
     navigationFuseTrippedRef.current = false;
     setCrash(null);
@@ -493,7 +493,8 @@ export function useBrowserWebview(
     // BrowserChrome 的 loading 动画。调用失败时回滚，避免 UI 永久卡住。
     setIsLoading(true);
     try {
-      wv.reload();
+      if (options?.ignoreCache) wv.reloadIgnoringCache();
+      else wv.reload();
     } catch {
       setIsLoading(false);
     }

--- a/apps/desktop/src/renderer/features/right-sidebar/hooks/useNativePopupSurface.ts
+++ b/apps/desktop/src/renderer/features/right-sidebar/hooks/useNativePopupSurface.ts
@@ -123,7 +123,12 @@ export function useNativePopupSurface(
       if (!surfaceId) return;
       void window.electronAPI.rsbNativePopup
         .command({ ...input, surfaceId })
-        .catch((err) => log.warn('native popup command failed', { surfaceId, err }));
+        .catch((err) => {
+          if (input.command === 'reload') {
+            setSnapshot((current) => ({ ...current, isLoading: false }));
+          }
+          log.warn('native popup command failed', { surfaceId, err });
+        });
     },
     [surfaceId],
   );
@@ -135,9 +140,9 @@ export function useNativePopupSurface(
     },
     [command],
   );
-  const reload = useCallback(() => {
+  const reload = useCallback((options?: { ignoreCache?: boolean }) => {
     setSnapshot((current) => ({ ...current, isLoading: true, crash: null }));
-    command({ command: 'reload' });
+    command(options?.ignoreCache ? { command: 'reload', ignoreCache: true } : { command: 'reload' });
   }, [command]);
   const goBack = useCallback(() => command({ command: 'go-back' }), [command]);
   const goForward = useCallback(() => command({ command: 'go-forward' }), [command]);

--- a/apps/desktop/src/renderer/features/right-sidebar/plugins/web-browser/BrowserChrome.tsx
+++ b/apps/desktop/src/renderer/features/right-sidebar/plugins/web-browser/BrowserChrome.tsx
@@ -65,6 +65,7 @@ export interface BrowserChromeProps {
   canGoForward: boolean;
   onNavigate: (url: string) => void;
   onReload: () => void;
+  onHardReload: () => void;
   onStop: () => void;
   onGoBack: () => void;
   onGoForward: () => void;
@@ -105,6 +106,7 @@ export const BrowserChrome = forwardRef<BrowserChromeHandle, BrowserChromeProps>
       canGoForward,
       onNavigate,
       onReload,
+      onHardReload,
       onStop,
       onGoBack,
       onGoForward,
@@ -321,6 +323,10 @@ export const BrowserChrome = forwardRef<BrowserChromeHandle, BrowserChromeProps>
             </Tip>
           </DropdownMenuTrigger>
           <DropdownMenuContent align="end" className="min-w-[9rem]">
+            <DropdownMenuItem disabled={!hasValidLink} onSelect={onHardReload}>
+              <RotateCw size={14} strokeWidth={2} className="mr-2 shrink-0" />
+              {t('rightSidebar.browser.hardReload')}
+            </DropdownMenuItem>
             <DropdownMenuItem
               disabled={!hasValidLink || !canOpenInSystemBrowser}
               onSelect={onOpenInSystemBrowser}

--- a/apps/desktop/src/renderer/features/right-sidebar/plugins/web-browser/BrowserTabBody.tsx
+++ b/apps/desktop/src/renderer/features/right-sidebar/plugins/web-browser/BrowserTabBody.tsx
@@ -482,6 +482,7 @@ export function BrowserTabBody({ state, ctx, active, shellVisible }: BrowserTabB
         canGoForward={browser.canGoForward}
         onNavigate={handleNavigate}
         onReload={browser.reload}
+        onHardReload={() => browser.reload({ ignoreCache: true })}
         onStop={browser.stop}
         onGoBack={browser.goBack}
         onGoForward={browser.goForward}

--- a/apps/desktop/src/renderer/features/right-sidebar/plugins/web-browser/__tests__/BrowserChrome.test.ts
+++ b/apps/desktop/src/renderer/features/right-sidebar/plugins/web-browser/__tests__/BrowserChrome.test.ts
@@ -53,6 +53,7 @@ function renderChrome(
     canGoForward?: boolean;
     commentActive?: boolean;
     onReload?: () => void;
+    onHardReload?: () => void;
     onStop?: () => void;
   } = {},
 ) {
@@ -69,6 +70,7 @@ function renderChrome(
       canGoForward: extra.canGoForward ?? false,
       onNavigate,
       onReload: extra.onReload ?? vi.fn(),
+      onHardReload: extra.onHardReload ?? vi.fn(),
       onStop: extra.onStop ?? vi.fn(),
       onGoBack: vi.fn(),
       onGoForward: vi.fn(),
@@ -85,6 +87,24 @@ function renderChrome(
 }
 
 describe('BrowserChrome', () => {
+  it('offers a distinct hard reload action while normal reload keeps its meaning', () => {
+    const onReload = vi.fn();
+    const onHardReload = vi.fn();
+    renderChrome('http://localhost:3000/', { onReload, onHardReload });
+    fireEvent.click(screen.getByRole('button', { name: 'rightSidebar.browser.hardReload' }));
+    expect(onHardReload).toHaveBeenCalledOnce();
+    expect(onReload).not.toHaveBeenCalled();
+    fireEvent.click(screen.getByRole('button', { name: 'rightSidebar.browser.reload' }));
+    expect(onReload).toHaveBeenCalledOnce();
+  });
+
+  it('disables hard reload for an empty tab', () => {
+    const onHardReload = vi.fn();
+    renderChrome('about:blank', { onHardReload });
+    fireEvent.click(screen.getByRole('button', { name: 'rightSidebar.browser.hardReload' }));
+    expect(onHardReload).not.toHaveBeenCalled();
+  });
+
   afterEach(() => {
     cleanup();
     vi.clearAllMocks();

--- a/apps/desktop/src/renderer/features/right-sidebar/plugins/web-browser/__tests__/BrowserTabBody.navigation.test.ts
+++ b/apps/desktop/src/renderer/features/right-sidebar/plugins/web-browser/__tests__/BrowserTabBody.navigation.test.ts
@@ -202,6 +202,20 @@ describe('BrowserTabBody navigation', () => {
     browserState = makeBrowserState();
   });
 
+  it.each([false, true])('routes hard reload to the active tab backend (native=%s)', (native) => {
+    const reload = vi.fn();
+    const inactiveReload = vi.fn();
+    browserState = makeBrowserState({ reload: native ? inactiveReload : reload });
+    if (native) {
+      registerNativePopupTab('tab-browser', 'session-a', 'surface-hard-reload');
+      nativePopupHook.mockReturnValue({ ...makeBrowserState({ reload }), closed: false });
+    }
+    render(renderBrowserTab('https://example.com/'));
+    fireEvent.click(screen.getByRole('button', { name: 'rightSidebar.browser.hardReload' }));
+    expect(reload).toHaveBeenCalledExactlyOnceWith({ ignoreCache: true });
+    expect(inactiveReload).not.toHaveBeenCalled();
+  });
+
   it('recovers a live native popup surface after plugin hydration strips its id', () => {
     registerNativePopupTab('tab-browser', 'session-a', 'surface-oauth');
     browserState = makeBrowserState({ wrapper: sharedWrapper, url: 'about:blank' });

--- a/apps/desktop/src/renderer/i18n/locales/en/common.json
+++ b/apps/desktop/src/renderer/i18n/locales/en/common.json
@@ -6581,6 +6581,7 @@
       "goBackUnavailable": "No previous page",
       "goForwardUnavailable": "No next page",
       "reload": "Reload",
+      "hardReload": "Reload Page Without Cache",
       "stop": "Stop loading",
       "screenshot": "Screenshot",
       "screenshotCopied": "Screenshot copied to clipboard",

--- a/apps/desktop/src/renderer/i18n/locales/ja/common.json
+++ b/apps/desktop/src/renderer/i18n/locales/ja/common.json
@@ -6579,6 +6579,7 @@
       "goBackUnavailable": "前のページはありません",
       "goForwardUnavailable": "次のページはありません",
       "reload": "再読み込み",
+      "hardReload": "キャッシュを無視してページを再読み込み",
       "stop": "読み込み停止",
       "screenshot": "スクリーンショット",
       "screenshotCopied": "スクリーンショットをクリップボードにコピーしました",

--- a/apps/desktop/src/renderer/i18n/locales/ko/common.json
+++ b/apps/desktop/src/renderer/i18n/locales/ko/common.json
@@ -6579,6 +6579,7 @@
       "goBackUnavailable": "이전 페이지가 없습니다",
       "goForwardUnavailable": "다음 페이지가 없습니다",
       "reload": "새로 고침",
+      "hardReload": "캐시를 무시하고 페이지 새로고침",
       "stop": "로드 중지",
       "screenshot": "스크린샷",
       "screenshotCopied": "스크린샷을 클립보드에 복사했습니다",

--- a/apps/desktop/src/renderer/i18n/locales/zh-CN/common.json
+++ b/apps/desktop/src/renderer/i18n/locales/zh-CN/common.json
@@ -6579,6 +6579,7 @@
       "goBackUnavailable": "没有可后退的页面",
       "goForwardUnavailable": "没有可前进的页面",
       "reload": "刷新",
+      "hardReload": "强制刷新页面（忽略缓存）",
       "stop": "停止加载",
       "screenshot": "截图",
       "screenshotCopied": "已复制截图到剪贴板",

--- a/apps/desktop/src/renderer/i18n/locales/zh-TW/common.json
+++ b/apps/desktop/src/renderer/i18n/locales/zh-TW/common.json
@@ -6579,6 +6579,7 @@
       "goBackUnavailable": "沒有可後退的頁面",
       "goForwardUnavailable": "沒有可前進的頁面",
       "reload": "重新整理",
+      "hardReload": "強制重新整理頁面（忽略快取）",
       "stop": "停止載入",
       "screenshot": "截圖",
       "screenshotCopied": "已複製截圖到剪貼簿",

--- a/apps/desktop/src/shared/rsbNativePopup.ts
+++ b/apps/desktop/src/shared/rsbNativePopup.ts
@@ -36,7 +36,9 @@ export type RsbNativePopupEvent =
   | { surfaceId: string; type: 'closed' };
 
 export type RsbNativePopupCommand =
-  { command: 'navigate'; url: string } | { command: 'reload' | 'go-back' | 'go-forward' | 'stop' };
+  | { command: 'navigate'; url: string }
+  | { command: 'reload'; ignoreCache?: boolean }
+  | { command: 'go-back' | 'go-forward' | 'stop' };
 
 export interface RsbNativePopupClaimInput {
   surfaceId: string;


### PR DESCRIPTION
## 这次改了什么

### 摘要

浏览器更多菜单增加强制刷新页面（忽略缓存），接入 WebView 与原生 popup 的既有刷新路径。保留普通刷新，补齐五语文案和当前标签归属/非法参数/销毁测试。

### 变更类型

- [x] `feat` 新功能
- [ ] `fix` 缺陷修复
- [ ] `refactor` / `perf` 重构或性能优化
- [ ] `docs` / `test` / `chore` 文档、测试或工程维护
- [ ] 其他：

### 范围

- 关联 Issue / 需求：Closes #3837
- 本 PR 包含：浏览器更多菜单增加强制刷新页面（忽略缓存），接入 WebView 与原生 popup 的既有刷新路径。保留普通刷新，补齐五语文案和当前标签归属/非法参数/销毁测试。
- 明确不包含：全分区清缓存、站点数据清理及新快捷键
- 用户可见变化：更多菜单新增当前页强制刷新入口
- 是否存在 breaking change：无

### UI 变化

- 引用的设计规范：docs/design-rules/DESIGN.md §10 双模式、§11 文案；§4 菜单及 §5 交互目标，复用现有 DropdownMenuItem 和语义 token，无新增硬编码颜色。
- 实机截图：未取得，见未执行的验证。

## 怎么验证的

### 自动验证

- 首轮相关门禁有 installService / worktreeRestore 两个失败文件；定向重跑 121 个测试通过，无并行类型检查时重跑完整相关门禁通过（67.5 秒）。
- `pnpm check:i18n` 与 `pnpm check:i18n-glossary` 通过，保留既有非阻塞告警。

```text
pnpm test:unit:related — PASS
pnpm --filter desktop run --if-present typecheck — PASS
浏览器与 native popup 定向测试：51 tests PASS；追加后端接线测试已进入相关门禁
```

- ESLint 改动文件与基线逐项比较，无新增错误。基线对应的 Desktop 整包 lint 实测 689 errors / 6 warnings，未报告通过；用户已明确接受“相关单测、类型检查通过，lint 无新增错误”的交付条件。

### 手工验证

未完成目标平台实机验收。

### 未执行的验证

实机启动被 Electron Forge 的 pnpm node-linker 检测阻塞；Light/Dark 未目检，Windows 未实测；不清除共享 session 或站点数据，不承诺解决 service worker 缓存。

## 风险

### 风险分类

- [ ] 无已知风险
- [ ] SQLite / migration
- [ ] system prompt
- [ ] 协议兼容
- [ ] 权限 / 安全 / 用户数据
- [ ] 存量插件兼容（批准状态 / 指纹 / manifest 校验 / 安装布局 / 包格式）
- [ ] 原生层 / fingerprint / OTA
- [x] 跨平台差异
- [ ] 其他：

### 影响与回滚

- 影响范围：Desktop 当前浏览器标签刷新，原生 popup 沿用既有 sender/owner 校验。
- 回滚 / 降级方式：回退本 PR 的单一提交；无持久数据迁移。

### 提交前检查

- [x] 已 review 完整 diff
- [x] 每个 commit 都带 DCO 签名；`pnpm check:dco` 通过
- [x] UI 改动已在「UI 变化」注明引用的设计规范章节
- [x] 未提交凭证、令牌或授权文件
- [x] 已核对受影响的文档
- [x] 已确认测试结果或说明未执行原因
