### PR TITLE
fix(desktop): 点击文件名筛选结果后保留当前列表

### DIFF
--- a/apps/desktop/src/renderer/features/cc-agent/workdir-browse/WorkdirBrowseSidebar.tsx
+++ b/apps/desktop/src/renderer/features/cc-agent/workdir-browse/WorkdirBrowseSidebar.tsx
@@ -44,7 +44,6 @@ import { fileBrowserApiFor } from '@/lib/fileBrowserTransport';
 import { useConfirmSwitchAwayIfDirty } from './hooks/useConfirmSwitchAwayIfDirty';
 import { useProjectFileList } from './hooks/useProjectFileList';
 import { FileTreeView, type FileTreeViewHandle, type PendingCreate } from './FileTreeView';
-import { useRevealFileInTree } from './hooks/useRevealFileInTree';
 import { FileFilterInput } from './FileFilterInput';
 import { FilterResultList } from './FilterResultList';
 import { FILTER_RESULT_LIMIT, filterFiles } from './lib/filterFiles';
@@ -348,9 +347,7 @@ export function WorkdirBrowseSidebar({
     projectFiles.refresh();
   }, [tree, projectFiles]);
 
-  // FileTreeView 的 imperative ref —— useRevealFileInTree 通过它调 scrollToPath。
   const fileTreeRef = useRef<FileTreeViewHandle>(null);
-  const revealFileInTree = useRevealFileInTree(tree, fileTreeRef);
 
   // 筛选结果点击 → 走跟 handleSelectFile 同样的 URL + storeAddTab 流程,
   // 但保留 filter query 和结果列表,支持连续打开多个命中项。

--- a/apps/desktop/src/renderer/features/cc-agent/workdir-browse/WorkdirBrowseSidebar.tsx
+++ b/apps/desktop/src/renderer/features/cc-agent/workdir-browse/WorkdirBrowseSidebar.tsx
@@ -352,9 +352,8 @@ export function WorkdirBrowseSidebar({
   const fileTreeRef = useRef<FileTreeViewHandle>(null);
   const revealFileInTree = useRevealFileInTree(tree, fileTreeRef);
 
-  // 筛选结果点击 → 走跟 handleSelectFile 同样的 URL + storeAddTab 流程,然后清掉
-  // filter query(用户找到目标文件 = 想看它,而不是接着筛选)。
-  // 选完再调 revealFileInTree:展开父目录链 + 滚动到该行,跟 RSB 版同一份逻辑。
+  // 筛选结果点击 → 走跟 handleSelectFile 同样的 URL + storeAddTab 流程,
+  // 但保留 filter query 和结果列表,支持连续打开多个命中项。
   const handleSelectFromFilter = useCallback(
     async (relPath: string) => {
       const ok = await confirmSwitchAway(currentSelectedFile, relPath);
@@ -366,10 +365,8 @@ export function WorkdirBrowseSidebar({
       saveSelectedFile(workdir, relPath);
       const openedNow = storeAddTab(workdir, relPath);
       if (openedNow) clearFileScroll(workdir, relPath);
-      setFilterQuery('');
-      void revealFileInTree(relPath);
     },
-    [confirmSwitchAway, currentSelectedFile, revealFileInTree, setSearchParams, workdir],
+    [confirmSwitchAway, currentSelectedFile, setSearchParams, workdir],
   );
 
   // 右键 文件夹 → New File / New Folder:开 VSCode 风格内联输入行。

--- a/apps/desktop/src/renderer/features/right-sidebar/plugins/file-browser/FileBrowserBody.tsx
+++ b/apps/desktop/src/renderer/features/right-sidebar/plugins/file-browser/FileBrowserBody.tsx
@@ -297,22 +297,15 @@ function FileBrowserBodyWithWorkdir({
     // state/ctx/tree 引用变化不该重放已消费的请求。
   }, [revealFilePath, revealFileNonce]);
 
-  // 文件名筛选结果点击 → 选中文件 + 清空 query + 展开父目录 + 滚动到该行
-  // (回到正常文件树视图,跟用户直觉一致:"我找到这个文件了,接下来就在看它")。
-  // 展开 + 滚动逻辑封在 useRevealFileInTree,doc 模式 sidebar 共用同一份(以后
-  // 优化 reveal 行为只改 hook 一处)。
+  // 文件名筛选结果点击 → 只选中文件,保留筛选 query 和结果列表。
   const handleSelectFromFilter = useCallback(
     async (relPath: string) => {
       const ok = await confirmSwitchAway(state.selectedFilePath, relPath);
       if (!ok) return;
       setExternalFile(null);
       ctx.patchState({ selectedFilePath: relPath });
-      setFilterQuery('');
-      // 等 filterQuery 清空 → tree 视图重新可见,然后 reveal 内部再两次 rAF
-      // 等 React commit / layout 稳定 → scroll。
-      void revealFileInTree(relPath);
     },
-    [confirmSwitchAway, ctx, revealFileInTree, state.selectedFilePath],
+    [confirmSwitchAway, ctx, state.selectedFilePath],
   );
 
   // refresh 按钮:文件树 + 项目文件索引一起 invalidate。


### PR DESCRIPTION
## 这次改了什么

### 摘要

修复 Desktop 文件浏览器的文件名筛选结果点击行为：点击命中文件后，仅更新当前选中文件，不再清空筛选条件，也不再切回文件树或自动滚动。这样可以保留当前结果列表，连续打开多个匹配文件。

### 变更类型

- [x] `fix` 缺陷修复
- [ ] `feat` 新功能
- [ ] `refactor` / `perf` 重构或性能优化
- [ ] `docs` / `test` / `chore` 文档或工程维护

### 范围

- 关联 PR：Related to #4373（搜索结果目录层级展示）
- 本 PR 包含：右侧栏文件浏览器及 Workdir Browse 文件筛选结果点击后的状态保持。
- 明确不包含：搜索结果树形展示、缓存、历史记录、持久化状态及服务端改动。
- 用户可见变化：搜索后点击一个文件，当前筛选结果仍保留，可继续点击其他命中项。
- 是否存在 breaking change：无

## UI 变化

- 引用的设计规范：不涉及视觉样式、布局、颜色、文案或组件结构变化；仅调整已有文件名筛选结果的交互状态保持行为。
- 截图/录屏：未执行实际 UI 录屏，待维护者本地复核。

## 怎么验证的

### 自动验证

```text
pnpm test:unit:related
结果：529 个测试中 527 通过、1 跳过、1 失败。唯一失败为既有 DCO hook 测试 `installer refuses to clobber an edited hook without --force`，与本 PR 文件无关。

pnpm --filter desktop run --if-present typecheck
结果：失败。现有 DSH AgentKind 类型改动导致大量既有类型错误，与本 PR 文件无关。

git diff --check
结果：通过。
```

### 手工验证

未执行：Desktop 因 Electron 下载失败（`TypeError: fetch failed`）及本地数据库版本不匹配问题，暂未完成实机验证。预期路径：右侧栏 → 文件浏览器 → 搜索一个匹配多个文件的关键词 → 依次点击多个结果，确认结果列表保持可见。

### 未执行的验证

Desktop 实机交互验证未执行，需在可启动的本地环境补充验证。

## 风险

### 风险分类

- [x] 无已知风险
- [ ] SQLite / migration
- [ ] system prompt
- [ ] 协议兼容
- [ ] 权限 / 安全 / 用户数据
- [ ] 跨平台差异

### 影响与回滚

- 影响范围：仅影响文件名筛选结果点击后的 UI 状态；不改变搜索索引、文件读取或持久化逻辑。
- 回滚 / 降级方式：回滚本 PR commit 即可恢复原有点击后清空筛选并回到文件树的行为。

### 提交前检查

- [x] 已 review 完整 diff
- [x] commit 带 DCO 签名（`git commit -s`）
- [x] UI 改动已注明设计规范情况
- [x] 未提交凭证、令牌或授权文件
- [x] 已确认测试结果或说明未执行原因